### PR TITLE
feat(phase-2): persistent recipe run audit log + dashboard

### DIFF
--- a/dashboard/src/app/runs/page.tsx
+++ b/dashboard/src/app/runs/page.tsx
@@ -1,0 +1,224 @@
+"use client";
+import { useEffect, useState } from "react";
+
+interface Run {
+  seq: number;
+  taskId: string;
+  recipeName: string;
+  trigger: "cron" | "webhook" | "recipe";
+  status: "done" | "error" | "cancelled" | "interrupted";
+  createdAt: number;
+  startedAt?: number;
+  doneAt: number;
+  durationMs: number;
+  model?: string;
+  outputTail?: string;
+  errorMessage?: string;
+}
+
+type TriggerFilter = "all" | "cron" | "webhook" | "recipe";
+type StatusFilter = "all" | "done" | "error" | "cancelled" | "interrupted";
+
+function fmtWhen(ms: number): string {
+  const d = new Date(ms);
+  const diff = Date.now() - ms;
+  if (diff < 60_000) return "just now";
+  if (diff < 3_600_000) return `${Math.floor(diff / 60_000)}m ago`;
+  if (diff < 86_400_000) return `${Math.floor(diff / 3_600_000)}h ago`;
+  return d.toLocaleString();
+}
+
+function fmtDur(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`;
+  return `${(ms / 60_000).toFixed(1)}m`;
+}
+
+export default function RunsPage() {
+  const [runs, setRuns] = useState<Run[] | null>(null);
+  const [err, setErr] = useState<string>();
+  const [trigger, setTrigger] = useState<TriggerFilter>("all");
+  const [status, setStatus] = useState<StatusFilter>("all");
+  const [expanded, setExpanded] = useState<string | null>(null);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const params = new URLSearchParams({ limit: "100" });
+        if (trigger !== "all") params.set("trigger", trigger);
+        if (status !== "all") params.set("status", status);
+        const res = await fetch(`/api/bridge/runs?${params}`);
+        if (!res.ok) throw new Error(`/runs ${res.status}`);
+        const data = (await res.json()) as { runs?: Run[] };
+        setRuns(data.runs ?? []);
+      } catch (e) {
+        setErr(e instanceof Error ? e.message : String(e));
+      }
+    };
+    load();
+    const id = setInterval(load, 5000);
+    return () => clearInterval(id);
+  }, [trigger, status]);
+
+  return (
+    <section>
+      <div className="page-head">
+        <div>
+          <h1>Runs</h1>
+          <div className="page-head-sub">
+            Audit trail of every recipe execution — cron, webhook, and manual.
+          </div>
+        </div>
+        {runs && <span className="pill muted">{runs.length} shown</span>}
+      </div>
+
+      <div
+        style={{
+          display: "flex",
+          gap: 12,
+          marginBottom: 16,
+          alignItems: "center",
+        }}
+      >
+        <label style={{ fontSize: 12 }}>
+          Trigger:&nbsp;
+          <select
+            value={trigger}
+            onChange={(e) => setTrigger(e.target.value as TriggerFilter)}
+          >
+            <option value="all">all</option>
+            <option value="cron">cron</option>
+            <option value="webhook">webhook</option>
+            <option value="recipe">recipe (manual)</option>
+          </select>
+        </label>
+        <label style={{ fontSize: 12 }}>
+          Status:&nbsp;
+          <select
+            value={status}
+            onChange={(e) => setStatus(e.target.value as StatusFilter)}
+          >
+            <option value="all">all</option>
+            <option value="done">done</option>
+            <option value="error">error</option>
+            <option value="cancelled">cancelled</option>
+            <option value="interrupted">interrupted</option>
+          </select>
+        </label>
+      </div>
+
+      {err && <div className="alert-err">Unreachable: {err}</div>}
+
+      {runs === null && !err ? (
+        <div className="empty-state">
+          <p>Loading…</p>
+        </div>
+      ) : !runs || runs.length === 0 ? (
+        <div className="empty-state">
+          <h3>No runs yet</h3>
+          <p>
+            Recipe executions (cron, webhook, or{" "}
+            <code>patchwork recipe run</code>) will appear here once they
+            complete.
+          </p>
+        </div>
+      ) : (
+        <div className="table-wrap">
+          <table className="table">
+            <thead>
+              <tr>
+                <th style={{ width: 140 }}>When</th>
+                <th>Recipe</th>
+                <th style={{ width: 90 }}>Trigger</th>
+                <th style={{ width: 90 }}>Status</th>
+                <th style={{ width: 80 }}>Duration</th>
+                <th style={{ width: 80 }}>Task</th>
+              </tr>
+            </thead>
+            <tbody>
+              {runs.map((r) => {
+                const isExpanded = expanded === r.taskId;
+                const key = r.taskId;
+                return (
+                  <>
+                    <tr
+                      key={key}
+                      onClick={() => setExpanded(isExpanded ? null : r.taskId)}
+                      style={{ cursor: "pointer" }}
+                    >
+                      <td className="mono muted">{fmtWhen(r.doneAt)}</td>
+                      <td className="mono">{r.recipeName}</td>
+                      <td>
+                        <span className="pill muted">{r.trigger}</span>
+                      </td>
+                      <td>
+                        <span
+                          className={`status-cell ${r.status === "done" ? "ok" : "err"}`}
+                        >
+                          {r.status}
+                        </span>
+                      </td>
+                      <td className="mono muted">{fmtDur(r.durationMs)}</td>
+                      <td className="mono muted">{r.taskId.slice(0, 8)}</td>
+                    </tr>
+                    {isExpanded && (
+                      <tr key={`${key}-detail`}>
+                        <td
+                          colSpan={6}
+                          style={{ background: "rgba(0,0,0,0.02)" }}
+                        >
+                          <div style={{ padding: 12, fontSize: 12 }}>
+                            {r.model && (
+                              <div>
+                                <strong>Model:</strong>{" "}
+                                <span className="mono">{r.model}</span>
+                              </div>
+                            )}
+                            <div>
+                              <strong>Created:</strong>{" "}
+                              <span className="mono">
+                                {new Date(r.createdAt).toISOString()}
+                              </span>
+                            </div>
+                            {r.errorMessage && (
+                              <div style={{ marginTop: 8 }}>
+                                <strong>Error:</strong>
+                                <pre
+                                  style={{
+                                    whiteSpace: "pre-wrap",
+                                    margin: "4px 0 0",
+                                  }}
+                                >
+                                  {r.errorMessage}
+                                </pre>
+                              </div>
+                            )}
+                            {r.outputTail && (
+                              <div style={{ marginTop: 8 }}>
+                                <strong>Output (tail):</strong>
+                                <pre
+                                  style={{
+                                    whiteSpace: "pre-wrap",
+                                    margin: "4px 0 0",
+                                    maxHeight: 240,
+                                    overflow: "auto",
+                                  }}
+                                >
+                                  {r.outputTail}
+                                </pre>
+                              </div>
+                            )}
+                          </div>
+                        </td>
+                      </tr>
+                    )}
+                  </>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/dashboard/src/components/Shell.tsx
+++ b/dashboard/src/components/Shell.tsx
@@ -11,6 +11,7 @@ const NAV: { href: string; label: string; icon: string }[] = [
   { href: "/tasks", label: "Tasks", icon: "\u25B8" },
   { href: "/metrics", label: "Metrics", icon: "\u25B4" },
   { href: "/recipes", label: "Recipes", icon: "\u25C9" },
+  { href: "/runs", label: "Runs", icon: "\u29D6" },
   { href: "/settings", label: "Settings", icon: "\u2699" },
 ];
 
@@ -37,8 +38,7 @@ function useBridgeStatus(): BridgeStatus {
         // fallback: hit approvals as a liveness ping
         try {
           const res = await fetch("/api/bridge/approvals");
-          if (alive)
-            setStatus({ ok: res.ok, ...(res.ok ? {} : {}) });
+          if (alive) setStatus({ ok: res.ok, ...(res.ok ? {} : {}) });
         } catch {
           if (alive) setStatus({ ok: false });
         }
@@ -86,16 +86,12 @@ export function Shell({ children }: { children: ReactNode }) {
             );
           })}
         </nav>
-        <div className="app-sidebar-footer">
-          Patchwork OS · oversight v0.1
-        </div>
+        <div className="app-sidebar-footer">Patchwork OS · oversight v0.1</div>
       </aside>
 
       <div className="app-main">
         <header className="app-header" role="banner">
-          <div className="app-header-title">
-            {pageTitle(pathname ?? "/")}
-          </div>
+          <div className="app-header-title">{pageTitle(pathname ?? "/")}</div>
           <BridgePill status={status} />
         </header>
         <main className="app-content" role="main">

--- a/src/__tests__/runLog.test.ts
+++ b/src/__tests__/runLog.test.ts
@@ -1,0 +1,194 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { RecipeRunLog } from "../runLog.js";
+
+describe("RecipeRunLog.parseTrigger", () => {
+  it("parses cron/webhook/recipe prefixes", () => {
+    expect(RecipeRunLog.parseTrigger("cron:nightly")).toEqual({
+      trigger: "cron",
+      recipeName: "nightly",
+    });
+    expect(RecipeRunLog.parseTrigger("webhook:deploy")).toEqual({
+      trigger: "webhook",
+      recipeName: "deploy",
+    });
+    expect(RecipeRunLog.parseTrigger("recipe:review")).toEqual({
+      trigger: "recipe",
+      recipeName: "review",
+    });
+  });
+
+  it("ignores non-recipe trigger sources", () => {
+    expect(RecipeRunLog.parseTrigger("onFileSave")).toBeNull();
+    expect(RecipeRunLog.parseTrigger(undefined)).toBeNull();
+    expect(RecipeRunLog.parseTrigger("")).toBeNull();
+    expect(RecipeRunLog.parseTrigger("cron:")).toBeNull();
+  });
+
+  it("preserves colons inside recipe names", () => {
+    expect(RecipeRunLog.parseTrigger("recipe:foo:bar")).toEqual({
+      trigger: "recipe",
+      recipeName: "foo:bar",
+    });
+  });
+});
+
+describe("RecipeRunLog.record", () => {
+  let tmp: string;
+  beforeEach(() => {
+    tmp = mkdtempSync(path.join(os.tmpdir(), "patchwork-runlog-"));
+  });
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("records recipe-triggered terminal tasks and skips others", () => {
+    const log = new RecipeRunLog({ dir: tmp });
+    const rec = log.record({
+      id: "task-1",
+      triggerSource: "cron:nightly",
+      status: "done",
+      createdAt: 1_000,
+      startedAt: 1_100,
+      doneAt: 1_500,
+      model: "sonnet-4-6",
+      output: "RECIPE DONE: ok",
+    });
+    expect(rec).not.toBeNull();
+    expect(rec!.trigger).toBe("cron");
+    expect(rec!.recipeName).toBe("nightly");
+    expect(rec!.durationMs).toBe(400);
+    expect(rec!.outputTail).toContain("RECIPE DONE");
+    expect(log.size()).toBe(1);
+
+    // Non-recipe trigger is skipped.
+    const skip = log.record({
+      id: "task-2",
+      triggerSource: "onFileSave",
+      status: "done",
+      createdAt: 2_000,
+      doneAt: 2_100,
+    });
+    expect(skip).toBeNull();
+    expect(log.size()).toBe(1);
+
+    // Non-terminal status is skipped.
+    const skip2 = log.record({
+      id: "task-3",
+      triggerSource: "recipe:review",
+      status: "running",
+      createdAt: 3_000,
+    });
+    expect(skip2).toBeNull();
+  });
+
+  it("persists to JSONL and reloads on construction", () => {
+    const log1 = new RecipeRunLog({ dir: tmp });
+    log1.record({
+      id: "a",
+      triggerSource: "webhook:deploy",
+      status: "done",
+      createdAt: 100,
+      startedAt: 150,
+      doneAt: 200,
+    });
+    log1.record({
+      id: "b",
+      triggerSource: "recipe:review",
+      status: "error",
+      createdAt: 300,
+      doneAt: 400,
+      errorMessage: "boom",
+    });
+    const file = path.join(tmp, "runs.jsonl");
+    const lines = readFileSync(file, "utf-8").trim().split("\n");
+    expect(lines).toHaveLength(2);
+    expect(JSON.parse(lines[0]!).taskId).toBe("a");
+
+    // New instance should see the history.
+    const log2 = new RecipeRunLog({ dir: tmp });
+    expect(log2.size()).toBe(2);
+    const q = log2.query({ status: "error" });
+    expect(q).toHaveLength(1);
+    expect(q[0]!.taskId).toBe("b");
+  });
+
+  it("filters by trigger, status, recipe, and after-seq", () => {
+    const log = new RecipeRunLog({ dir: tmp });
+    log.record({
+      id: "a",
+      triggerSource: "cron:nightly",
+      status: "done",
+      createdAt: 100,
+      doneAt: 200,
+    });
+    log.record({
+      id: "b",
+      triggerSource: "webhook:deploy",
+      status: "done",
+      createdAt: 300,
+      doneAt: 400,
+    });
+    log.record({
+      id: "c",
+      triggerSource: "cron:nightly",
+      status: "error",
+      createdAt: 500,
+      doneAt: 600,
+      errorMessage: "x",
+    });
+
+    expect(log.query({ trigger: "cron" }).map((r) => r.taskId)).toEqual([
+      "c",
+      "a",
+    ]);
+    expect(log.query({ status: "error" }).map((r) => r.taskId)).toEqual(["c"]);
+    expect(log.query({ recipe: "nightly" })).toHaveLength(2);
+    expect(log.query({ after: 2 }).map((r) => r.taskId)).toEqual(["c"]);
+    // Newest first by default.
+    expect(log.query().map((r) => r.taskId)).toEqual(["c", "b", "a"]);
+  });
+
+  it("caps in-memory ring but keeps file intact", () => {
+    const log = new RecipeRunLog({ dir: tmp, memoryCap: 2 });
+    for (let i = 0; i < 5; i++) {
+      log.record({
+        id: `t${i}`,
+        triggerSource: "recipe:x",
+        status: "done",
+        createdAt: i * 100,
+        doneAt: i * 100 + 50,
+      });
+    }
+    expect(log.size()).toBe(2);
+    const lines = readFileSync(path.join(tmp, "runs.jsonl"), "utf-8")
+      .trim()
+      .split("\n");
+    expect(lines).toHaveLength(5);
+  });
+
+  it("tolerates malformed JSONL lines on reload", () => {
+    const file = path.join(tmp, "runs.jsonl");
+    // Seed with one bad line and one good.
+    const good = {
+      seq: 1,
+      taskId: "x",
+      recipeName: "r",
+      trigger: "recipe",
+      status: "done",
+      createdAt: 1,
+      doneAt: 2,
+      durationMs: 1,
+    };
+    // biome-ignore lint/suspicious/noExplicitAny: test fixture
+    require("node:fs").writeFileSync(
+      file,
+      `not-json\n${JSON.stringify(good)}\n`,
+    );
+    const log = new RecipeRunLog({ dir: tmp });
+    expect(log.size()).toBe(1);
+    expect(log.query()[0]!.taskId).toBe("x");
+  });
+});

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -33,6 +33,7 @@ import {
   renderWebhookPrompt,
 } from "./recipesHttp.js";
 import { classifyTool } from "./riskTier.js";
+import { RecipeRunLog } from "./runLog.js";
 import { Server } from "./server.js";
 import { type CheckpointData, SessionCheckpoint } from "./sessionCheckpoint.js";
 import { StreamableHttpHandler } from "./streamableHttp.js";
@@ -133,6 +134,7 @@ export class Bridge {
   private pluginWatcher: PluginWatcher | null = null;
   private automationHooks: AutomationHooks | undefined = undefined;
   private recipeScheduler: RecipeScheduler | null = null;
+  private recipeRunLog: RecipeRunLog | null = null;
   private httpMcpHandler: StreamableHttpHandler | null = null;
   private oauthServer: OAuthServerImpl | null = null;
   /** Incremented each time the VS Code extension (re)connects — guards stale async callbacks. */
@@ -848,6 +850,12 @@ export class Bridge {
         (msg) => this.logger.info(msg),
       );
       if (driver) {
+        // Patchwork: persistent audit trail of recipe-triggered runs.
+        const patchworkDir = path.join(os.homedir(), ".patchwork");
+        this.recipeRunLog = new RecipeRunLog({
+          dir: patchworkDir,
+          logger: this.logger,
+        });
         this.orchestrator = new ClaudeOrchestrator(
           driver,
           this.config.workspace,
@@ -856,8 +864,25 @@ export class Bridge {
             this.extensionClient.notifyTaskOutput(taskId, chunk),
           (taskId, status) => {
             this.extensionClient.notifyTaskDone(taskId, status);
+            const task = this.orchestrator?.getTask(taskId);
+            if (task && this.recipeRunLog) {
+              this.recipeRunLog.record({
+                id: task.id,
+                triggerSource: task.triggerSource,
+                status: task.status,
+                createdAt: task.createdAt,
+                ...(task.startedAt !== undefined && {
+                  startedAt: task.startedAt,
+                }),
+                ...(task.doneAt !== undefined && { doneAt: task.doneAt }),
+                ...(task.model !== undefined && { model: task.model }),
+                ...(task.output !== undefined && { output: task.output }),
+                ...(task.errorMessage !== undefined && {
+                  errorMessage: task.errorMessage,
+                }),
+              });
+            }
             if (status === "done" && this.automationHooks) {
-              const task = this.orchestrator?.getTask(taskId);
               // Loop guard: skip automation-spawned tasks to prevent infinite chains
               if (!task?.isAutomationTask) {
                 this.automationHooks.handleTaskSuccess({
@@ -1086,6 +1111,20 @@ export class Bridge {
         string,
         unknown
       >;
+    };
+    this.server.runsFn = (q) => {
+      if (!this.recipeRunLog) return [];
+      return this.recipeRunLog.query({
+        ...(q.limit !== undefined && { limit: q.limit }),
+        ...(q.trigger !== undefined && {
+          trigger: q.trigger as "cron" | "webhook" | "recipe",
+        }),
+        ...(q.status !== undefined && {
+          status: q.status as "done" | "error" | "cancelled" | "interrupted",
+        }),
+        ...(q.recipe !== undefined && { recipe: q.recipe }),
+        ...(q.after !== undefined && { after: q.after }),
+      }) as unknown as Record<string, unknown>[];
     };
     this.server.webhookFn = async (hookPath: string, payload: unknown) => {
       if (!this.orchestrator) {

--- a/src/runLog.ts
+++ b/src/runLog.ts
@@ -1,0 +1,217 @@
+import { appendFileSync, mkdirSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+import type { Logger } from "./logger.js";
+
+/**
+ * RecipeRunLog — persistent audit trail of every recipe execution.
+ *
+ * A "run" is any orchestrator task whose triggerSource identifies it as recipe-
+ * derived (prefix `cron:`, `webhook:`, or `recipe:`). Runs are appended to a
+ * JSONL file so overnight/background activity survives bridge restarts, and
+ * mirrored into a bounded in-memory ring for quick dashboard reads.
+ *
+ * Schema is deliberately minimal + additive: extra fields go in without a
+ * migration. Consumers must tolerate unknown keys.
+ */
+
+export type RunTrigger = "cron" | "webhook" | "recipe";
+export type RunStatus = "done" | "error" | "cancelled" | "interrupted";
+
+export interface RecipeRun {
+  /** Monotonic sequence id within the process — stable for pagination. */
+  seq: number;
+  /** Orchestrator task id — useful for cross-referencing /tasks. */
+  taskId: string;
+  /** Recipe name extracted from triggerSource. */
+  recipeName: string;
+  /** Trigger kind: how the recipe fired. */
+  trigger: RunTrigger;
+  /** Terminal task status. */
+  status: RunStatus;
+  /** Task creation time (ms epoch). */
+  createdAt: number;
+  /** Task start time (ms epoch) — undefined if cancelled before spawn. */
+  startedAt?: number;
+  /** Task completion time (ms epoch). */
+  doneAt: number;
+  /** Model used, if known. */
+  model?: string;
+  /** Truncated output tail — first 2KB, enough for a "RECIPE DONE:" line. */
+  outputTail?: string;
+  /** Error message for failed runs. */
+  errorMessage?: string;
+  /** Duration ms = doneAt - (startedAt ?? createdAt). */
+  durationMs: number;
+}
+
+const MAX_OUTPUT_TAIL = 2_000;
+const DEFAULT_MEMORY_CAP = 500;
+
+export interface RunLogOptions {
+  /** Directory holding runs.jsonl. Created if missing. */
+  dir: string;
+  logger?: Logger;
+  /** Cap on in-memory ring. File is not truncated. */
+  memoryCap?: number;
+  /** Test hook — default Date.now. */
+  now?: () => number;
+}
+
+export interface RunQuery {
+  limit?: number;
+  trigger?: RunTrigger;
+  status?: RunStatus;
+  recipe?: string;
+  /** Runs with seq > after. */
+  after?: number;
+}
+
+export class RecipeRunLog {
+  private runs: RecipeRun[] = [];
+  private seq = 0;
+  private readonly file: string;
+  private readonly memoryCap: number;
+  private readonly now: () => number;
+
+  constructor(private readonly opts: RunLogOptions) {
+    this.file = path.join(opts.dir, "runs.jsonl");
+    this.memoryCap = opts.memoryCap ?? DEFAULT_MEMORY_CAP;
+    this.now = opts.now ?? Date.now;
+    try {
+      mkdirSync(opts.dir, { recursive: true });
+    } catch (err) {
+      opts.logger?.warn?.(
+        `[runlog] could not create ${opts.dir}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+    this.loadExisting();
+  }
+
+  /**
+   * Parse triggerSource into `{trigger, recipeName}`. Returns null for non-recipe
+   * triggers (e.g. automation hooks like "onFileSave") so the caller can ignore them.
+   */
+  static parseTrigger(
+    triggerSource: string | undefined,
+  ): { trigger: RunTrigger; recipeName: string } | null {
+    if (!triggerSource) return null;
+    const m = /^(cron|webhook|recipe):(.+)$/.exec(triggerSource);
+    if (!m || !m[1] || !m[2]) return null;
+    return { trigger: m[1] as RunTrigger, recipeName: m[2] };
+  }
+
+  record(task: {
+    id: string;
+    triggerSource?: string;
+    status: string;
+    createdAt: number;
+    startedAt?: number;
+    doneAt?: number;
+    model?: string;
+    output?: string;
+    errorMessage?: string;
+  }): RecipeRun | null {
+    const parsed = RecipeRunLog.parseTrigger(task.triggerSource);
+    if (!parsed) return null;
+    const status = task.status as RunStatus;
+    if (
+      status !== "done" &&
+      status !== "error" &&
+      status !== "cancelled" &&
+      status !== "interrupted"
+    ) {
+      return null;
+    }
+    const doneAt = task.doneAt ?? this.now();
+    const startedAt = task.startedAt;
+    const durationMs = doneAt - (startedAt ?? task.createdAt);
+    this.seq += 1;
+    const run: RecipeRun = {
+      seq: this.seq,
+      taskId: task.id,
+      recipeName: parsed.recipeName,
+      trigger: parsed.trigger,
+      status,
+      createdAt: task.createdAt,
+      ...(startedAt !== undefined && { startedAt }),
+      doneAt,
+      ...(task.model !== undefined && { model: task.model }),
+      ...(task.output !== undefined && {
+        outputTail: task.output.slice(-MAX_OUTPUT_TAIL),
+      }),
+      ...(task.errorMessage !== undefined && {
+        errorMessage: task.errorMessage,
+      }),
+      durationMs,
+    };
+    this.runs.push(run);
+    if (this.runs.length > this.memoryCap) {
+      this.runs.splice(0, this.runs.length - this.memoryCap);
+    }
+    this.append(run);
+    return run;
+  }
+
+  query(q: RunQuery = {}): RecipeRun[] {
+    let out = this.runs;
+    if (q.trigger) out = out.filter((r) => r.trigger === q.trigger);
+    if (q.status) out = out.filter((r) => r.status === q.status);
+    if (q.recipe) out = out.filter((r) => r.recipeName === q.recipe);
+    if (q.after !== undefined) {
+      const after = q.after;
+      out = out.filter((r) => r.seq > after);
+    }
+    // Newest first.
+    out = [...out].sort((a, b) => b.seq - a.seq);
+    const limit = Math.min(Math.max(q.limit ?? 100, 1), 500);
+    return out.slice(0, limit);
+  }
+
+  /** Test/inspection helper — current in-memory size. */
+  size(): number {
+    return this.runs.length;
+  }
+
+  private append(run: RecipeRun): void {
+    try {
+      appendFileSync(this.file, `${JSON.stringify(run)}\n`, { mode: 0o600 });
+    } catch (err) {
+      this.opts.logger?.warn?.(
+        `[runlog] append failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  private loadExisting(): void {
+    try {
+      statSync(this.file);
+    } catch {
+      return;
+    }
+    let raw: string;
+    try {
+      raw = readFileSync(this.file, "utf-8");
+    } catch (err) {
+      this.opts.logger?.warn?.(
+        `[runlog] read failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      return;
+    }
+    const lines = raw.split("\n");
+    for (const line of lines) {
+      if (!line) continue;
+      try {
+        const parsed = JSON.parse(line) as RecipeRun;
+        if (typeof parsed.seq !== "number") continue;
+        // Seed in-memory ring from tail so dashboard has immediate history.
+        this.runs.push(parsed);
+        if (parsed.seq > this.seq) this.seq = parsed.seq;
+      } catch {
+        // skip malformed line — never let one bad row break startup
+      }
+    }
+    if (this.runs.length > this.memoryCap) {
+      this.runs.splice(0, this.runs.length - this.memoryCap);
+    }
+  }
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -118,6 +118,16 @@ export class Server extends EventEmitter<ServerEvents> {
   public tasksFn: (() => { tasks: Record<string, unknown>[] }) | null = null;
   /** Patchwork: set by bridge to list installed recipes for the dashboard. */
   public recipesFn: (() => Record<string, unknown>) | null = null;
+  /** Patchwork: set by bridge to query the recipe run audit log. */
+  public runsFn:
+    | ((q: {
+        limit?: number;
+        trigger?: string;
+        status?: string;
+        recipe?: string;
+        after?: number;
+      }) => Record<string, unknown>[])
+    | null = null;
   /** Patchwork: set by bridge to launch a named recipe via the orchestrator. */
   public runRecipeFn:
     | ((
@@ -733,6 +743,36 @@ export class Server extends EventEmitter<ServerEvents> {
             }
           })();
         });
+        return;
+      }
+      if (parsedUrl.pathname === "/runs" && req.method === "GET") {
+        try {
+          const sp = parsedUrl.searchParams;
+          const limitRaw = sp.get("limit");
+          const afterRaw = sp.get("after");
+          const trigger = sp.get("trigger");
+          const status = sp.get("status");
+          const recipe = sp.get("recipe");
+          const limit = limitRaw ? Number.parseInt(limitRaw, 10) : Number.NaN;
+          const after = afterRaw ? Number.parseInt(afterRaw, 10) : Number.NaN;
+          const runs =
+            this.runsFn?.({
+              ...(Number.isFinite(limit) && { limit }),
+              ...(trigger && { trigger }),
+              ...(status && { status }),
+              ...(recipe && { recipe }),
+              ...(Number.isFinite(after) && { after }),
+            }) ?? [];
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ runs }));
+        } catch (err) {
+          res.writeHead(500, { "Content-Type": "application/json" });
+          res.end(
+            JSON.stringify({
+              error: err instanceof Error ? err.message : String(err),
+            }),
+          );
+        }
         return;
       }
       if (req.url === "/recipes" && req.method === "GET") {


### PR DESCRIPTION
Every recipe-triggered task (cron:/webhook:/recipe:) now records a run to ~/.patchwork/runs.jsonl at terminal state. Dashboard /runs page shows newest-first history with trigger/status filters and expandable output tail — so overnight cron + incoming webhook activity is inspectable instead of vanishing into orchestrator history.

- src/runLog.ts — RecipeRunLog w/ bounded in-memory ring + JSONL persistence, reloads tail on restart, tolerates malformed rows
- src/bridge.ts — wires RunLog into orchestrator notifyDone callback
- src/server.ts — GET /runs?limit&trigger&status&recipe&after
- dashboard /runs page + nav entry
- 8 new unit tests (parseTrigger, filtering, persistence, ring cap, corrupt rows)