### PR TITLE
test(phase-2): fix approval-gate + installer tests; add ADR-0006 + docs

### DIFF
--- a/docs/adr/0006-approval-gate-design.md
+++ b/docs/adr/0006-approval-gate-design.md
@@ -1,0 +1,111 @@
+# ADR-0006: Approval Gate — Dashboard as Claude Code Permission UI
+
+**Status:** Accepted
+**Date:** 2026-04-18
+
+## Context
+
+Claude Code (CC) enforces tool permissions through `settings.json` rules (`allow` / `ask` / `deny` arrays) and a `permission_mode` (`default` / `auto` / `plan` / `dontAsk`). Rules are static — edited by hand, reloaded on session start. There is no interactive UI for "ask" rules; CC prompts the user in the terminal, which blocks the agent until the human is in front of the terminal.
+
+Patchwork needs a runtime, UI-driven approval surface:
+
+- Humans can be on a phone / away from the terminal when CC asks for permission.
+- Security-sensitive operations (`gitPush`, `Bash(rm -rf …)`, write to paths outside workspace) deserve a dashboard with context — risk signals, recent activity, current session — not a terse y/N prompt.
+- Teams running shared deployments need managed policy: admin-controlled deny rules that override user settings.
+- The same approval surface must work whether CC invoked the tool natively or through the bridge's MCP transport.
+
+The naive approach — reimplement CC's permission system inside Patchwork — drifts from CC's semantics, confuses users, and duplicates audit trails. We need to **align with CC's model, not replace it.**
+
+## Decision
+
+Treat the Patchwork dashboard as **the UI for CC's existing "ask" rules**, not a parallel permission system. The gate runs at two layers:
+
+### 1. CC `PreToolUse` hook path (primary)
+
+CC's `PreToolUse` hook fires before every tool invocation and can block by emitting `decision: "deny"` on stdout. We register a hook script that:
+
+1. Parses the tool call from stdin JSON.
+2. POSTs `{ toolName, specifier, params, summary, permissionMode, sessionId }` to `POST /approvals` on the local bridge.
+3. Blocks until the bridge responds, then exits 0/2 accordingly.
+
+Bridge handler ([src/approvalHttp.ts](../../src/approvalHttp.ts)) resolves the decision in strict precedence order:
+
+```
+CC deny rule        →  deny immediately        (reason: cc_deny_rule)
+CC allow rule       →  allow immediately       (reason: cc_allow_rule)
+permissionMode:
+  dontAsk           →  deny (no UI to prompt)  (reason: dontAsk_mode)
+  auto              →  allow (CC owns it)      (reason: auto_mode)
+  plan + read tool  →  allow                   (reason: plan_mode_read)
+  plan + write tool →  deny                    (reason: plan_mode_write)
+approvalGate:
+  off               →  allow                   (reason: gate_off)
+  high + low-tier   →  allow                   (reason: gate_below_threshold)
+  all / high+hi-tier → queue for dashboard → await resolve/reject
+```
+
+Only the final branch blocks on a human. Every other path short-circuits deterministically.
+
+### 2. MCP transport path (secondary)
+
+When Patchwork is the MCP server, the same `routeApprovalRequest` handler runs in the tool-dispatch middleware before executing any tool. Same precedence, same rules, same queue.
+
+### Rule loader
+
+CC settings are read live from disk ([src/ccPermissions.ts](../../src/ccPermissions.ts)), merged in the documented CC precedence:
+
+```
+managed (admin, highest) > project > user (lowest)
+```
+
+`loadCcPermissionsAttributed` returns the same rules but tagged with origin (`managed` / `project` / `user`) so the dashboard can show **why** a rule matched. This is exposed via `GET /cc-permissions` for the settings UI.
+
+### Glob matching
+
+Specifiers (e.g. `Bash(npm run *)`) are matched with glob semantics via `evaluateRules`. Exact tool-name matches (`Read`, `gitPush`) always take precedence over specifier patterns to avoid surprising overrides.
+
+### Managed settings
+
+`managedSettingsPath` points at an admin-writable JSON file with the same shape as user settings. It is merged at the top of the precedence chain and cannot be overridden from project or user scope. This is how an org enforces "never allow `gitPush` to main" across all developers.
+
+### Gate tiers
+
+`approvalGate` is a runtime knob surfaced in the settings dashboard:
+
+- `off` — dev mode; bypass all queueing, approve everything.
+- `high` — only queue high-tier tools (`classifyTool` returns `"high"` for writes, network, exec).
+- `all` — queue every tool below the allow/deny short-circuits.
+
+Changeable at runtime — no reconnect, no hook reinstall — because the gate is consulted on every request.
+
+### Risk signals
+
+High-tier tools are tagged with `riskSignals` ([src/approvalHttp.ts](../../src/approvalHttp.ts) `computeRiskSignals`) that the dashboard surfaces as badges:
+
+- Destructive flags: `rm -rf`, `--force`, `sudo`, `DROP TABLE`, `TRUNCATE`, shell chaining.
+- Domain reputation: non-HTTPS, raw IP hostname.
+- Path escape: `file_path` outside workspace.
+
+Signals are advisory — they don't change the decision, they help the human decide.
+
+## Consequences
+
+**Positive:**
+
+- **One source of truth.** CC's `settings.json` is the permission config; the dashboard is the UI. Edit either, the other stays in sync.
+- **Predictable short-circuits.** Static rules resolve without a human. Only true "ask" calls block, and they always surface in the UI.
+- **Runtime-adjustable gate.** Flip `approvalGate` from the settings page — takes effect on the next request, no CC restart.
+- **Managed settings give orgs real enforcement** without forking CC.
+- **MCP and native paths share one handler** — no duplicate logic, same audit trail.
+
+**Negative:**
+
+- **Hook script must be installed** per workspace. Failure to install = no approval gate on the native CC path. Mitigated by onboarding check surfaced in `getBridgeStatus`.
+- **Polling model for the hook** — hook script blocks on HTTP until the bridge responds. If the bridge dies mid-request, the hook hangs until CC times it out. Acceptable; bridge crashes are rare and CC's timeout is bounded.
+- **`dontAsk` maps to deny, not allow.** Some users expect `dontAsk` to mean "trust me, allow everything silently." We intentionally invert that: if there's no UI to prompt and no explicit allow rule, we deny — safer default. Documented in [documents/platform-docs.md](../../documents/platform-docs.md).
+
+**Audit rules:**
+
+- Every new permission-mode branch must emit via `onDecision` with a stable `reason` string. Dashboard filters and analytics depend on these.
+- Every response body on `/approvals` POST must include `{ decision, reason }`. New branches without `reason` break the audit log.
+- Glob rules must be evaluated through `evaluateRules` — never re-implement matching inline.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,3 +1,12 @@
 # Architecture Decision Records
 
 This directory contains Architecture Decision Records (ADRs) for claude-ide-bridge. Each ADR documents a non-obvious design decision — the context, the choice made, and its consequences.
+
+## Index
+
+- [ADR-0001: Dual Version Numbers](0001-dual-version-numbers.md) — `BRIDGE_PROTOCOL_VERSION` vs npm package version
+- [ADR-0002: Generation Guards on Reconnect](0002-generation-guards-on-reconnect.md) — stale-callback prevention across socket resets
+- [ADR-0003: `isBridge` Lock File Flag](0003-isbridge-lock-file-flag.md) — distinguish bridge-owned locks from IDE-owned locks
+- [ADR-0004: Tool Errors as Content Blocks](0004-tool-errors-as-content.md) — `isError: true` for tool failures, JSON-RPC for protocol issues
+- [ADR-0005: HTTP Session Eviction](0005-http-session-eviction.md) — 5-concurrent cap, idle-oldest eviction, 2-hour TTL
+- [ADR-0006: Approval Gate Design](0006-approval-gate-design.md) — dashboard as CC permission UI, not parallel permission system

--- a/documents/platform-docs.md
+++ b/documents/platform-docs.md
@@ -593,3 +593,83 @@ For use without VS Code — see `documents/headless-quickstart.md` for the full 
 - Terminal tools (`createTerminal`, `runInTerminal`, etc.) — these use VS Code shell integration.
 
 **CI pattern:** run the bridge with `--headless` (no extension), configure `typescript-language-server` and `ctags` in the Docker image, and use `getToolCapabilities` in the first step to confirm which fallback paths are active. Full mode is the default; pass `--slim` if you want only IDE-exclusive tools. See `documents/headless-quickstart.md` for Docker and GitHub Actions examples.
+
+## Patchwork Approval Gate
+
+Dashboard-backed UI for Claude Code's `ask` permission rules. Runs at two layers: CC's `PreToolUse` hook (native CC tool calls) and the bridge's MCP transport middleware. Design rationale in [ADR-0006](../docs/adr/0006-approval-gate-design.md).
+
+### HTTP surface
+
+| Route | Purpose |
+|---|---|
+| `POST /approvals` | Request approval. Body: `{ toolName, specifier?, params?, summary?, permissionMode?, sessionId? }`. Returns `{ decision: "allow"|"deny", reason, callId? }`. |
+| `GET /approvals?session=<id>` | List pending approvals, optionally filtered by session. |
+| `POST /approve/:callId` | Human approves a queued call. |
+| `POST /reject/:callId` | Human rejects a queued call. |
+| `GET /cc-permissions` | Returns merged rules (`allow` / `ask` / `deny`) + `workspace` + `attributed` (origin-tagged: `managed` / `project` / `user`). |
+| `POST /hooks/<name>` | Recipe webhook trigger. Dispatches matching recipe. |
+
+### Decision precedence
+
+Every `POST /approvals` resolves via:
+
+1. CC `deny` rule → deny (`reason: cc_deny_rule`).
+2. CC `allow` rule → allow (`reason: cc_allow_rule`).
+3. `permissionMode` short-circuits:
+   - `dontAsk` → deny (`reason: dontAsk_mode`) — no UI to prompt, safer to deny.
+   - `auto` → allow (`reason: auto_mode`) — CC owns escalation.
+   - `plan` + read-only tool → allow (`reason: plan_mode_read`).
+   - `plan` + write tool → deny (`reason: plan_mode_write`).
+4. `approvalGate` setting:
+   - `off` → allow (`reason: gate_off`).
+   - `high` + low-tier tool → allow (`reason: gate_below_threshold`).
+   - otherwise → queue for dashboard, await resolve/reject.
+
+`reason` strings are stable — dashboard filters and analytics depend on them.
+
+### Rule merge (ccPermissions)
+
+Loaded from disk live, merged in CC's documented precedence: **managed > project > user**. `managedSettingsPath` is an admin-writable JSON file; rules there cannot be overridden by lower scopes. This is how an org enforces "never allow `gitPush` to main" across all developers without forking CC.
+
+Glob specifiers (`Bash(npm run *)`) are matched via `evaluateRules` — never reimplement matching inline. Exact tool-name matches (`Read`, `gitPush`) always win over specifier patterns.
+
+### Gate tiers
+
+`approvalGate` is runtime-adjustable from the settings UI; no reconnect required.
+
+| Value | Behavior |
+|---|---|
+| `off` | Dev mode. Bypass queueing; allow everything after rule precedence. |
+| `high` | Queue only high-tier tools (`classifyTool` = `"high"`: writes, network, exec). |
+| `all` | Queue every tool that survives allow/deny short-circuits. |
+
+### Risk signals
+
+High-tier queued items carry `riskSignals` — advisory badges surfaced in the dashboard. Detected patterns:
+
+- **Destructive flags** (Bash/runCommand): `rm -rf`, `--force`, `sudo`, `DROP TABLE`, `TRUNCATE`, shell chaining (`` ` `` / `$()` / `&&` / `||`).
+- **Domain reputation** (WebFetch/sendHttpRequest): non-HTTPS URLs, raw IP hostnames.
+- **Path escape** (Write/Edit/Read): `file_path` resolves outside workspace.
+
+Signals never change the decision — they help the human decide.
+
+### Recipe triggers
+
+Recipes live in `~/.claude-ide-bridge/recipes/` (JSON or YAML). Supported triggers:
+
+- **manual** — run via `patchwork recipe run <name>` CLI.
+- **cron** — `@every 5m` syntax; runs via the recipe scheduler.
+- **webhook** — `POST /hooks/<name>` dispatches matching recipes.
+- **file_watch** — minimatch patterns on workspace files.
+
+Install with `patchwork recipe install <path-to-recipe.yaml>`. Run history persists to SQLite; surfaced in the dashboard `/recipes` page.
+
+### Webhook SSRF defenses
+
+`webhookUrl` (approval-queued notification) enforces:
+
+- HTTPS-only.
+- Bare `localhost` blocked.
+- DNS-resolved IP checked against loopback / RFC-1918 / link-local blocklist.
+- 5s timeout via `AbortController`.
+- Failures logged, never thrown — webhook errors must not block approval flow.

--- a/documents/roadmap.md
+++ b/documents/roadmap.md
@@ -4,6 +4,27 @@ Development direction and exploration guidance. Living document — update as pr
 
 ---
 
+## Patchwork Phase 2 — Runtime Approval Gate + Recipes (branch `phase-2-restore`, 2026-04-18)
+
+**Shipped on branch, awaiting PR → main:**
+
+- **Runtime approval gate** ([src/approvalHttp.ts](../src/approvalHttp.ts)) — dashboard is the UI for CC's "ask" rules. `approvalGate` runtime knob (`off` / `high` / `all`) flipped from settings page, takes effect next request. Risk signals (destructive flags, non-HTTPS URLs, path escape) surfaced as badges. Managed settings file enforces admin policy above user/project. Precedence + design rationale: [ADR-0006](../docs/adr/0006-approval-gate-design.md).
+- **CC PreToolUse hook wiring** — `scripts/patchwork-approval-hook.sh` reads stdin JSON, POSTs to `/approvals`, blocks on bridge decision. Works for native CC tool calls (not just MCP transport).
+- **Recipe system** — YAML/JSON recipes installable via `patchwork recipe install <path>`. Manual, cron (`@every`), webhook (`POST /hooks/<name>`), and file-watch triggers. Persistent run-history audit log (SQLite). Dashboard `/recipes` + `/recipes/new` composer.
+- **Dashboard surfaces** — `/analytics` (decisions over time, per-session), `/sessions` (live session state), `/approvals` with pattern learning hooks + live streaming via `useBridgeFetch` / `useBridgeStream`.
+- **`GET /cc-permissions`** — returns merged rules tagged with origin (`managed` / `project` / `user`) so the UI can explain why a rule matched.
+
+**Remaining to land Phase 2:**
+
+1. PR `phase-2-restore` → `main`.
+2. Enrichment Engine (commit → issue linker) — the original strategy-doc Phase 2 item. Current branch is oversight infrastructure; enrichment is still unstarted.
+3. Freshness scoring + dedup across context sources.
+4. Generalize the recipe run-log SQLite schema to a persistent decision-trace store (feeds Phase 3 moat).
+
+**Coverage/test state on branch:** 3061 bridge tests passing (was 3052). `src/approvalHttp.ts` coverage: 76.6% lines, 78.3% branches, 83.3% funcs — above the 75/70/75 gate.
+
+---
+
 ## Current State (v2.25.34 / ext v1.3.2 — 2026-04-14)
 
 **v2.25.34 + ext v1.3.2 shipped (2026-04-14) — outputSchema + extension version debugging:**

--- a/src/__tests__/approvalHttp.test.ts
+++ b/src/__tests__/approvalHttp.test.ts
@@ -62,7 +62,12 @@ describe("routeApprovalRequest", () => {
         path: "/approvals",
         body: { toolName: "sendHttpRequest", params: { url: "x" } },
       },
-      { queue, workspace: "/tmp", ccLoader: emptyRules() },
+      {
+        queue,
+        workspace: "/tmp",
+        ccLoader: emptyRules(),
+        approvalGate: "all",
+      },
     );
     // Wait for the request to hit the queue
     await new Promise((r) => setTimeout(r, 10));
@@ -258,7 +263,7 @@ describe("routeApprovalRequest", () => {
       },
     );
     expect(res.status).toBe(200);
-    expect(res.body).toEqual({
+    expect(res.body).toMatchObject({
       allow: ["Read"],
       ask: ["Bash(npm run *)"],
       deny: ["gitPush"],
@@ -327,5 +332,225 @@ describe("routeApprovalRequest", () => {
       },
     );
     expect(res.status).toBe(404);
+  });
+
+  describe("approvalGate modes", () => {
+    it("gate=off → allow without queueing", async () => {
+      const queue = new ApprovalQueue();
+      const res = await routeApprovalRequest(
+        { method: "POST", path: "/approvals", body: { toolName: "gitPush" } },
+        {
+          queue,
+          workspace: "/tmp",
+          ccLoader: emptyRules(),
+          approvalGate: "off",
+        },
+      );
+      expect(res.body).toMatchObject({ decision: "allow", reason: "gate_off" });
+      expect(queue.size()).toBe(0);
+    });
+
+    it("gate=high → low-tier tool allowed without queue", async () => {
+      const queue = new ApprovalQueue();
+      const res = await routeApprovalRequest(
+        { method: "POST", path: "/approvals", body: { toolName: "Read" } },
+        {
+          queue,
+          workspace: "/tmp",
+          ccLoader: emptyRules(),
+          approvalGate: "high",
+        },
+      );
+      expect(res.body).toMatchObject({
+        decision: "allow",
+        reason: "gate_below_threshold",
+      });
+      expect(queue.size()).toBe(0);
+    });
+
+    it("gate=all → queues even low-tier tools", async () => {
+      const queue = new ApprovalQueue();
+      const pending = routeApprovalRequest(
+        { method: "POST", path: "/approvals", body: { toolName: "Read" } },
+        {
+          queue,
+          workspace: "/tmp",
+          ccLoader: emptyRules(),
+          approvalGate: "all",
+        },
+      );
+      await new Promise((r) => setTimeout(r, 10));
+      expect(queue.list()).toHaveLength(1);
+      const first = queue.list()[0];
+      if (!first) throw new Error("missing queued item");
+      queue.reject(first.callId);
+      const res = await pending;
+      expect(res.body).toMatchObject({ decision: "deny", reason: "rejected" });
+    });
+  });
+
+  describe("permission-mode: auto", () => {
+    it("auto mode → allow without queueing", async () => {
+      const queue = new ApprovalQueue();
+      const res = await routeApprovalRequest(
+        {
+          method: "POST",
+          path: "/approvals",
+          body: { toolName: "gitPush", permissionMode: "auto" },
+        },
+        { queue, workspace: "/tmp", ccLoader: emptyRules() },
+      );
+      expect(res.body).toMatchObject({
+        decision: "allow",
+        reason: "auto_mode",
+      });
+      expect(queue.size()).toBe(0);
+    });
+  });
+
+  describe("risk signals", () => {
+    it("Bash with rm -rf → destructive_flag high signal queued", async () => {
+      const queue = new ApprovalQueue();
+      const pending = routeApprovalRequest(
+        {
+          method: "POST",
+          path: "/approvals",
+          body: {
+            toolName: "Bash",
+            params: { command: "rm -rf /tmp/foo" },
+          },
+        },
+        {
+          queue,
+          workspace: "/tmp",
+          ccLoader: emptyRules(),
+          approvalGate: "all",
+        },
+      );
+      await new Promise((r) => setTimeout(r, 10));
+      const item = queue.list()[0];
+      if (!item) throw new Error("missing queued item");
+      const signals = item.riskSignals ?? [];
+      expect(signals.some((s) => s.label.includes("rm with -rf"))).toBe(true);
+      queue.approve(item.callId);
+      await pending;
+    });
+
+    it("sendHttpRequest with non-HTTPS + raw IP → two domain_reputation signals", async () => {
+      const queue = new ApprovalQueue();
+      const pending = routeApprovalRequest(
+        {
+          method: "POST",
+          path: "/approvals",
+          body: {
+            toolName: "sendHttpRequest",
+            params: { url: "http://10.0.0.1/x" },
+          },
+        },
+        {
+          queue,
+          workspace: "/tmp",
+          ccLoader: emptyRules(),
+          approvalGate: "all",
+        },
+      );
+      await new Promise((r) => setTimeout(r, 10));
+      const item = queue.list()[0];
+      if (!item) throw new Error("missing queued item");
+      const kinds = (item.riskSignals ?? []).map((s) => s.kind);
+      expect(kinds).toContain("domain_reputation");
+      queue.approve(item.callId);
+      await pending;
+    });
+
+    it("Write to path outside workspace → path_escape signal", async () => {
+      const queue = new ApprovalQueue();
+      const pending = routeApprovalRequest(
+        {
+          method: "POST",
+          path: "/approvals",
+          body: {
+            toolName: "Write",
+            params: { file_path: "/etc/passwd" },
+          },
+        },
+        {
+          queue,
+          workspace: "/tmp/ws",
+          ccLoader: emptyRules(),
+          approvalGate: "all",
+        },
+      );
+      await new Promise((r) => setTimeout(r, 10));
+      const item = queue.list()[0];
+      if (!item) throw new Error("missing queued item");
+      expect(
+        (item.riskSignals ?? []).some((s) => s.kind === "path_escape"),
+      ).toBe(true);
+      queue.approve(item.callId);
+      await pending;
+    });
+  });
+
+  describe("webhook dispatch", () => {
+    it("non-HTTPS webhook URL is rejected (no fetch call)", async () => {
+      const originalFetch = globalThis.fetch;
+      const calls: string[] = [];
+      globalThis.fetch = (async (url: string) => {
+        calls.push(url);
+        return new Response("{}", { status: 200 });
+      }) as typeof globalThis.fetch;
+      try {
+        const queue = new ApprovalQueue();
+        const pending = routeApprovalRequest(
+          { method: "POST", path: "/approvals", body: { toolName: "gitPush" } },
+          {
+            queue,
+            workspace: "/tmp",
+            ccLoader: emptyRules(),
+            approvalGate: "all",
+            webhookUrl: "http://example.com/hook",
+          },
+        );
+        await new Promise((r) => setTimeout(r, 10));
+        const item = queue.list()[0];
+        if (!item) throw new Error("missing queued item");
+        queue.approve(item.callId);
+        await pending;
+        expect(calls).toHaveLength(0);
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    });
+
+    it("localhost webhook hostname is blocked", async () => {
+      const originalFetch = globalThis.fetch;
+      const calls: string[] = [];
+      globalThis.fetch = (async (url: string) => {
+        calls.push(url);
+        return new Response("{}", { status: 200 });
+      }) as typeof globalThis.fetch;
+      try {
+        const queue = new ApprovalQueue();
+        const pending = routeApprovalRequest(
+          { method: "POST", path: "/approvals", body: { toolName: "gitPush" } },
+          {
+            queue,
+            workspace: "/tmp",
+            ccLoader: emptyRules(),
+            approvalGate: "all",
+            webhookUrl: "https://localhost/hook",
+          },
+        );
+        await new Promise((r) => setTimeout(r, 10));
+        const item = queue.list()[0];
+        if (!item) throw new Error("missing queued item");
+        queue.approve(item.callId);
+        await pending;
+        expect(calls).toHaveLength(0);
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    });
   });
 });

--- a/src/recipes/__tests__/installer.test.ts
+++ b/src/recipes/__tests__/installer.test.ts
@@ -102,10 +102,10 @@ steps:
     params: { text: hi }
 `,
     );
-    // manual trigger fails compile, but parse works — asserts .yml is accepted
-    expect(() => installRecipeFromFile(src, { recipesDir: dir })).toThrow(
-      /manual trigger/,
-    );
+    // Manual triggers bypass compile by design — install succeeds; asserts .yml is accepted
+    const result = installRecipeFromFile(src, { recipesDir: dir });
+    expect(result.action).toBe("created");
+    expect(result.installedPath.endsWith("short-ext.json")).toBe(true);
   });
 
   it("rejects unknown extensions", () => {


### PR DESCRIPTION
Repair three tests that drifted when the runtime approval gate shipped in d60de47:
- approvalHttp: queue path needs approvalGate: "all" (default is "off")
- /cc-permissions: additive `attributed` field → toMatchObject
- installer: manual-trigger recipes install by design, don't throw

Add 9 coverage tests for approvalHttp (gate modes, auto mode, risk signals, webhook SSRF defenses). approvalHttp.ts coverage now 76.6% L / 78.3% B / 83.3% F — above the 75/70/75 gate.

Document the design: ADR-0006 (dashboard as CC permission UI, decision precedence, managed settings, gate tiers, risk signals). Roadmap gains a Patchwork Phase 2 section. platform-docs gains an Approval Gate section with HTTP routes, precedence table, recipe triggers.