### PR TITLE
feat(enrichment): enrichCommit tool — commit → linked issues

### DIFF
--- a/src/tools/__tests__/enrichCommit.test.ts
+++ b/src/tools/__tests__/enrichCommit.test.ts
@@ -1,0 +1,207 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../utils.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../utils.js")>();
+  return { ...actual, execSafe: vi.fn() };
+});
+
+import { createEnrichCommitTool } from "../enrichCommit.js";
+import { classifyIssueLink, extractIssueRefs } from "../issueRefs.js";
+import { execSafe } from "../utils.js";
+
+const mockExec = vi.mocked(execSafe);
+
+function parse(r: { content: Array<{ type: string; text: string }> }) {
+  return JSON.parse(r.content[0]?.text ?? "{}");
+}
+function ok(stdout: string) {
+  return { stdout, stderr: "", exitCode: 0, timedOut: false, durationMs: 1 };
+}
+function fail(stderr: string, exitCode = 1) {
+  return {
+    stdout: "",
+    stderr,
+    exitCode,
+    timedOut: false,
+    durationMs: 1,
+  };
+}
+
+const WS = "/tmp/ws";
+
+describe("extractIssueRefs", () => {
+  it("extracts #N and GH-N, dedupes, preserves order", () => {
+    expect(extractIssueRefs("fix #12 and #34 then GH-34 refs #12")).toEqual([
+      "#12",
+      "#34",
+    ]);
+  });
+
+  it("returns empty array when no refs", () => {
+    expect(extractIssueRefs("just a message")).toEqual([]);
+  });
+
+  it("handles mixed case GH- prefix", () => {
+    expect(extractIssueRefs("closes gh-7")).toEqual(["#7"]);
+  });
+});
+
+describe("classifyIssueLink", () => {
+  it("identifies closing verbs", () => {
+    expect(classifyIssueLink("fixes #12", "#12")).toBe("closes");
+    expect(classifyIssueLink("closes #12", "#12")).toBe("closes");
+    expect(classifyIssueLink("resolves GH-12", "#12")).toBe("closes");
+    expect(classifyIssueLink("closed #12 earlier", "#12")).toBe("closes");
+  });
+
+  it("treats bare refs as references", () => {
+    expect(classifyIssueLink("see #12 for context", "#12")).toBe("references");
+    expect(classifyIssueLink("#12", "#12")).toBe("references");
+  });
+
+  it("close verb only applies to the following ref", () => {
+    expect(classifyIssueLink("fixes #1\nsee also #2", "#2")).toBe("references");
+  });
+});
+
+describe("enrichCommit tool", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns error when not a git repo", async () => {
+    mockExec.mockResolvedValueOnce(fail("not a git repo"));
+    const tool = createEnrichCommitTool(WS);
+    const res = await tool.handler({});
+    expect(res.content[0]?.text).toContain("Not a git repository");
+  });
+
+  it("enriches commit with validated issue metadata", async () => {
+    mockExec
+      .mockResolvedValueOnce(ok(".git")) // rev-parse
+      .mockResolvedValueOnce(
+        ok(
+          "abc123sha\nJane <j@x>\n2026-04-18T10:00:00Z\nfix: resolve bug\n---BODY---\nfix: resolve bug\n\nFixes #42 and references #99",
+        ),
+      ) // git show
+      .mockResolvedValueOnce(ok("gh version 2.0")) // gh --version
+      .mockResolvedValueOnce(
+        ok(
+          JSON.stringify({
+            number: 42,
+            title: "Bug",
+            state: "OPEN",
+            url: "https://x/42",
+          }),
+        ),
+      ) // issue #42
+      .mockResolvedValueOnce(
+        ok(
+          JSON.stringify({
+            number: 99,
+            title: "Other",
+            state: "OPEN",
+            url: "https://x/99",
+          }),
+        ),
+      ); // issue #99
+
+    const res = parse(await createEnrichCommitTool(WS).handler({}));
+    expect(res.sha).toBe("abc123sha");
+    expect(res.issueRefs).toEqual(["#42", "#99"]);
+    expect(res.unresolved).toBe(0);
+    expect(res.ghAvailable).toBe(true);
+    expect(res.links).toHaveLength(2);
+    expect(res.links[0]).toMatchObject({
+      ref: "#42",
+      linkType: "closes",
+      resolved: true,
+    });
+    expect(res.links[1]).toMatchObject({
+      ref: "#99",
+      linkType: "references",
+      resolved: true,
+    });
+  });
+
+  it("flags missing issues as unresolved without failing", async () => {
+    mockExec
+      .mockResolvedValueOnce(ok(".git"))
+      .mockResolvedValueOnce(
+        ok("sha\nA <a@x>\n2026-01-01\nref #404\n---BODY---\nref #404"),
+      )
+      .mockResolvedValueOnce(ok("gh v")) // gh available
+      .mockResolvedValueOnce(fail("could not resolve to Issue")); // not found
+
+    const res = parse(await createEnrichCommitTool(WS).handler({}));
+    expect(res.issueRefs).toEqual(["#404"]);
+    expect(res.unresolved).toBe(1);
+    expect(res.links[0]).toMatchObject({
+      resolved: false,
+      reason: "not_found",
+    });
+  });
+
+  it("flags all refs unresolved when gh CLI is unavailable", async () => {
+    mockExec
+      .mockResolvedValueOnce(ok(".git"))
+      .mockResolvedValueOnce(
+        ok("sha\nA <a@x>\n2026-01-01\ncloses #1\n---BODY---\ncloses #1"),
+      )
+      .mockResolvedValueOnce(fail("gh: command not found", 127)); // gh probe fails
+
+    const res = parse(await createEnrichCommitTool(WS).handler({}));
+    expect(res.ghAvailable).toBe(false);
+    expect(res.unresolved).toBe(1);
+    expect(res.links[0]).toMatchObject({
+      resolved: false,
+      reason: "gh_unavailable",
+    });
+  });
+
+  it("dedupes repeated references to same issue", async () => {
+    mockExec
+      .mockResolvedValueOnce(ok(".git"))
+      .mockResolvedValueOnce(
+        ok(
+          "sha\nA <a@x>\n2026-01-01\nsubject\n---BODY---\nfix #7\nalso #7 and GH-7",
+        ),
+      )
+      .mockResolvedValueOnce(ok("gh v"))
+      .mockResolvedValueOnce(
+        ok(
+          JSON.stringify({
+            number: 7,
+            title: "T",
+            state: "CLOSED",
+            url: "https://x/7",
+          }),
+        ),
+      );
+
+    const res = parse(await createEnrichCommitTool(WS).handler({}));
+    expect(res.issueRefs).toEqual(["#7"]);
+    expect(res.links).toHaveLength(1);
+  });
+
+  it("returns empty links when no refs in message", async () => {
+    mockExec
+      .mockResolvedValueOnce(ok(".git"))
+      .mockResolvedValueOnce(
+        ok("sha\nA <a@x>\n2026-01-01\nno refs here\n---BODY---\nno refs here"),
+      )
+      .mockResolvedValueOnce(ok("gh v"));
+
+    const res = parse(await createEnrichCommitTool(WS).handler({}));
+    expect(res.issueRefs).toEqual([]);
+    expect(res.links).toEqual([]);
+    expect(res.unresolved).toBe(0);
+  });
+
+  it("surfaces git-show failure with the supplied ref", async () => {
+    mockExec
+      .mockResolvedValueOnce(ok(".git"))
+      .mockRejectedValueOnce(new Error("bad revision 'nope'"));
+
+    const res = await createEnrichCommitTool(WS).handler({ ref: "nope" });
+    expect(res.content[0]?.text).toContain("Failed to read commit 'nope'");
+  });
+});

--- a/src/tools/enrichCommit.ts
+++ b/src/tools/enrichCommit.ts
@@ -1,0 +1,200 @@
+import { runGitStdout } from "./git-utils.js";
+import { GH_NOT_AUTHED, isNotAuthed, isNotFound } from "./github/shared.js";
+import { classifyIssueLink, extractIssueRefs } from "./issueRefs.js";
+import { error, execSafe, optionalString, successStructured } from "./utils.js";
+
+/**
+ * Fetch a single issue via `gh issue view --json`. Returns `null` if the
+ * issue doesn't exist (not an auth error) — callers treat missing issues
+ * as unresolved, not fatal.
+ */
+async function fetchIssue(
+  workspace: string,
+  number: string,
+  signal?: AbortSignal,
+): Promise<
+  | { ok: true; issue: Record<string, unknown> }
+  | { ok: false; reason: "not_found" | "not_authed" | "error"; detail: string }
+> {
+  const result = await execSafe(
+    "gh",
+    [
+      "issue",
+      "view",
+      number,
+      "--json",
+      "number,title,state,url,labels,assignees",
+    ],
+    { cwd: workspace, signal, timeout: 30_000 },
+  );
+  if (result.exitCode === 0) {
+    try {
+      return { ok: true, issue: JSON.parse(result.stdout.trim()) };
+    } catch {
+      return {
+        ok: false,
+        reason: "error",
+        detail: `parse failed: ${result.stdout.trim().slice(0, 200)}`,
+      };
+    }
+  }
+  const msg = result.stderr.trim() || result.stdout.trim();
+  if (isNotAuthed(msg)) return { ok: false, reason: "not_authed", detail: msg };
+  if (isNotFound(msg) || /not found|could not resolve/i.test(msg)) {
+    return { ok: false, reason: "not_found", detail: msg };
+  }
+  return { ok: false, reason: "error", detail: msg };
+}
+
+export function createEnrichCommitTool(workspace: string) {
+  return {
+    schema: {
+      name: "enrichCommit",
+      description:
+        "Enrich commit w/ linked issues. Parses #N / GH-N refs from message, fetches issue state via gh, classifies close vs ref. Missing issues flagged unresolved — not errors.",
+      annotations: { readOnlyHint: true },
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          ref: {
+            type: "string",
+            description:
+              "Commit SHA or ref. Defaults to HEAD. Passed through to `git show`.",
+          },
+        },
+        additionalProperties: false as const,
+      },
+      outputSchema: {
+        type: "object" as const,
+        properties: {
+          sha: { type: "string" },
+          subject: { type: "string" },
+          author: { type: "string" },
+          date: { type: "string" },
+          issueRefs: { type: "array", items: { type: "string" } },
+          links: {
+            type: "array",
+            items: {
+              type: "object",
+              properties: {
+                ref: { type: "string" },
+                linkType: { type: "string", enum: ["closes", "references"] },
+                resolved: { type: "boolean" },
+                issue: { type: ["object", "null"] },
+                reason: { type: ["string", "null"] },
+              },
+              required: ["ref", "linkType", "resolved"],
+            },
+          },
+          unresolved: { type: "integer" },
+          ghAvailable: { type: "boolean" },
+        },
+        required: [
+          "sha",
+          "subject",
+          "issueRefs",
+          "links",
+          "unresolved",
+          "ghAvailable",
+        ],
+      },
+    },
+    timeoutMs: 45_000,
+    async handler(args: Record<string, unknown>, signal?: AbortSignal) {
+      const ref = optionalString(args, "ref") ?? "HEAD";
+
+      // Verify git repo
+      const check = await execSafe("git", ["rev-parse", "--git-dir"], {
+        cwd: workspace,
+        signal,
+        timeout: 5_000,
+      });
+      if (check.exitCode !== 0) return error("Not a git repository");
+
+      let showOut: string;
+      try {
+        showOut = await runGitStdout(
+          [
+            "show",
+            "--no-patch",
+            "--format=%H%n%an <%ae>%n%aI%n%s%n---BODY---%n%B",
+            ref,
+          ],
+          workspace,
+          { signal, timeout: 10_000 },
+        );
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        return error(`Failed to read commit '${ref}': ${msg}`);
+      }
+
+      const [metaPart, bodyPart = ""] = showOut.split("\n---BODY---\n", 2);
+      const metaLines = (metaPart ?? "").split("\n");
+      const sha = metaLines[0] ?? "";
+      const author = metaLines[1] ?? "";
+      const date = metaLines[2] ?? "";
+      const subject = metaLines[3] ?? "";
+      const fullMessage = bodyPart.trim() || subject;
+
+      const issueRefs = extractIssueRefs(fullMessage);
+
+      // Probe gh availability once — if the tool is missing, skip all fetches.
+      const probe = await execSafe("gh", ["--version"], {
+        cwd: workspace,
+        signal,
+        timeout: 5_000,
+      });
+      const ghAvailable = probe.exitCode === 0;
+
+      const links: Array<Record<string, unknown>> = [];
+      let unresolved = 0;
+
+      for (const r of issueRefs) {
+        const linkType = classifyIssueLink(fullMessage, r);
+        if (!ghAvailable) {
+          links.push({
+            ref: r,
+            linkType,
+            resolved: false,
+            issue: null,
+            reason: "gh_unavailable",
+          });
+          unresolved += 1;
+          continue;
+        }
+        const num = r.replace(/^#/, "");
+        const fetched = await fetchIssue(workspace, num, signal);
+        if (fetched.ok) {
+          links.push({
+            ref: r,
+            linkType,
+            resolved: true,
+            issue: fetched.issue,
+            reason: null,
+          });
+        } else {
+          links.push({
+            ref: r,
+            linkType,
+            resolved: false,
+            issue: null,
+            reason:
+              fetched.reason === "not_authed" ? GH_NOT_AUTHED : fetched.reason,
+          });
+          unresolved += 1;
+        }
+      }
+
+      return successStructured({
+        sha,
+        subject,
+        author,
+        date,
+        issueRefs,
+        links,
+        unresolved,
+        ghAvailable,
+      });
+    },
+  };
+}

--- a/src/tools/getPRTemplate.ts
+++ b/src/tools/getPRTemplate.ts
@@ -1,4 +1,5 @@
 import { runGitStdout } from "./git-utils.js";
+import { extractIssueRefs } from "./issueRefs.js";
 import { error, execSafe, optionalString, successStructured } from "./utils.js";
 
 function runGit(
@@ -37,14 +38,6 @@ async function detectBaseBranch(
     if (b === "main" || b === "master") return b;
   }
   return "main";
-}
-
-function extractIssueRefs(text: string): string[] {
-  const refs = new Set<string>();
-  for (const match of text.matchAll(/#(\d+)/g)) {
-    refs.add(`#${match[1]}`);
-  }
-  return Array.from(refs);
 }
 
 function formatBullet(

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -42,6 +42,7 @@ import {
 import { createDetectUnusedCodeTool } from "./detectUnusedCode.js";
 import { createGetDocumentLinksTool } from "./documentLinks.js";
 import { createEditTextTool } from "./editText.js";
+import { createEnrichCommitTool } from "./enrichCommit.js";
 import { createExplainDiagnosticTool } from "./explainDiagnostic.js";
 import { createExplainSymbolTool } from "./explainSymbol.js";
 import {
@@ -644,6 +645,7 @@ export function registerAllTools(
     createTestTraceToSourceTool(workspace),
     createScreenshotAndAnnotateTool(workspace, extensionClient),
     createGetPRTemplateTool(workspace),
+    createEnrichCommitTool(workspace),
     createGetCodeCoverageTool(workspace),
     createGenerateTestsTool(workspace),
     ...(probes.gh
@@ -836,6 +838,7 @@ export const TOOL_CATEGORIES: Record<string, string[]> = {
   githubGetPRDiff: ["github"],
   githubPostPRReview: ["github"],
   getPRTemplate: ["github"],
+  enrichCommit: ["github"],
   getAIComments: ["github"],
   createGithubIssueFromAIComment: ["github"],
   // Bridge / orchestration

--- a/src/tools/issueRefs.ts
+++ b/src/tools/issueRefs.ts
@@ -1,0 +1,33 @@
+/**
+ * Parse issue references from commit messages or free text.
+ *
+ * Matches `#123`, `GH-123`, and verbs like `fixes #123` / `closes GH-123`.
+ * Returns deduplicated refs as `#<n>` strings, lowest number first, then
+ * insertion order.
+ */
+export function extractIssueRefs(text: string): string[] {
+  const refs = new Set<string>();
+  for (const match of text.matchAll(/(?:GH-|#)(\d+)/gi)) {
+    refs.add(`#${match[1]}`);
+  }
+  return Array.from(refs);
+}
+
+/**
+ * Classify commit→issue link verb. `fixes #12` / `closes #12` / `resolves #12`
+ * indicate the commit resolves the issue; `refs #12` / bare `#12` are
+ * references only. Useful for enrichment output.
+ */
+export function classifyIssueLink(
+  text: string,
+  ref: string,
+): "closes" | "references" {
+  const num = ref.replace(/^#/, "");
+  // Verb directly precedes the target ref (no other #N or GH-N between them).
+  // Keeps "Fixes #42 and references #99" → #42 closes, #99 references.
+  const closeRe = new RegExp(
+    `\\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\\s+(?:GH-|#)${num}\\b`,
+    "i",
+  );
+  return closeRe.test(text) ? "closes" : "references";
+}


### PR DESCRIPTION
First piece of the Phase-2 Enrichment Engine (platform-strategy.md Phase 2). Parses `#N` / `GH-N` refs from a commit message, fetches each issue via `gh issue view --json`, classifies close vs reference by verb proximity, and flags unresolved refs without failing.

Output: { sha, subject, author, date, issueRefs, links:[{ref, linkType, resolved, issue, reason}], unresolved, ghAvailable }. `gh` missing or issues not found are reflected in `reason`, never thrown — callers treat this as enrichment, not validation.

Shared `extractIssueRefs` moved to src/tools/issueRefs.ts and reused by getPRTemplate. New `classifyIssueLink` handles verb-proximity so "Fixes #42 and references #99" tags #42=closes, #99=references.

13 new unit tests. Registered as github-probe-gated tool.