### PR TITLE
feat(enrichment): persist commit→issue links + getCommitsForIssue reverse lookup

### DIFF
--- a/src/__tests__/commitIssueLinkLog.test.ts
+++ b/src/__tests__/commitIssueLinkLog.test.ts
@@ -1,0 +1,146 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { CommitIssueLinkLog } from "../commitIssueLinkLog.js";
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(path.join(os.tmpdir(), "link-log-"));
+});
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+function base() {
+  return {
+    sha: "abc1234",
+    ref: "#42",
+    linkType: "closes" as const,
+    resolved: true,
+    workspace: "/ws/a",
+    subject: "fix: x",
+    issueState: "OPEN",
+  };
+}
+
+describe("CommitIssueLinkLog", () => {
+  it("records and assigns monotonic seq", () => {
+    const log = new CommitIssueLinkLog({ dir, now: () => 1000 });
+    expect(log.record(base())?.seq).toBe(1);
+    expect(log.record({ ...base(), ref: "#43" })?.seq).toBe(2);
+    expect(log.size()).toBe(2);
+  });
+
+  it("dedupes identical repeat calls (same workspace/sha/ref/state)", () => {
+    const log = new CommitIssueLinkLog({ dir });
+    expect(log.record(base())?.seq).toBe(1);
+    expect(log.record(base())).toBeNull();
+    expect(log.size()).toBe(1);
+  });
+
+  it("records a new row when issue state changes", () => {
+    const log = new CommitIssueLinkLog({ dir });
+    log.record(base());
+    const next = log.record({ ...base(), issueState: "CLOSED" });
+    expect(next?.seq).toBe(2);
+    expect(log.size()).toBe(2);
+  });
+
+  it("records a new row when resolved flips true→false", () => {
+    const log = new CommitIssueLinkLog({ dir });
+    log.record(base());
+    const next = log.record({
+      ...base(),
+      resolved: false,
+      issueState: undefined,
+      reason: "not_found",
+    });
+    expect(next?.seq).toBe(2);
+  });
+
+  it("query by ref returns matching rows newest-first", () => {
+    const log = new CommitIssueLinkLog({ dir });
+    log.record({ ...base(), sha: "aaa" });
+    log.record({ ...base(), sha: "bbb" });
+    log.record({ ...base(), sha: "ccc", ref: "#99" });
+    const rows = log.query({ ref: "#42" });
+    expect(rows.map((r) => r.sha)).toEqual(["bbb", "aaa"]);
+  });
+
+  it("query by sha prefix (≥7 chars) matches full SHAs", () => {
+    const log = new CommitIssueLinkLog({ dir });
+    log.record({ ...base(), sha: "abcdef1234567890" });
+    expect(log.query({ sha: "abcdef1" })).toHaveLength(1);
+    expect(log.query({ sha: "abcd" })).toHaveLength(0);
+    expect(log.query({ sha: "abcdef1234567890" })).toHaveLength(1);
+  });
+
+  it("filters by workspace, linkType, and resolved", () => {
+    const log = new CommitIssueLinkLog({ dir });
+    log.record({ ...base(), sha: "a", workspace: "/ws/a" });
+    log.record({
+      ...base(),
+      sha: "b",
+      workspace: "/ws/b",
+      linkType: "references",
+    });
+    log.record({
+      ...base(),
+      sha: "c",
+      workspace: "/ws/a",
+      resolved: false,
+      issueState: undefined,
+      reason: "gh_unavailable",
+    });
+    expect(log.query({ workspace: "/ws/a" })).toHaveLength(2);
+    expect(log.query({ linkType: "references" })).toHaveLength(1);
+    expect(log.query({ resolved: false })).toHaveLength(1);
+  });
+
+  it("persists to JSONL and reloads into a fresh instance", () => {
+    const log1 = new CommitIssueLinkLog({ dir });
+    log1.record(base());
+    log1.record({ ...base(), ref: "#43" });
+    const raw = readFileSync(
+      path.join(dir, "commit_issue_links.jsonl"),
+      "utf-8",
+    );
+    expect(raw.trim().split("\n")).toHaveLength(2);
+
+    const log2 = new CommitIssueLinkLog({ dir });
+    expect(log2.size()).toBe(2);
+    const again = log2.record(base());
+    expect(again).toBeNull();
+  });
+
+  it("skips malformed JSONL lines on load", () => {
+    const log1 = new CommitIssueLinkLog({ dir });
+    log1.record(base());
+    const file = path.join(dir, "commit_issue_links.jsonl");
+    const good = readFileSync(file, "utf-8");
+    const fs = require("node:fs");
+    fs.writeFileSync(file, `not json\n${good}{"no-seq":true}\n`);
+    const log2 = new CommitIssueLinkLog({ dir });
+    expect(log2.size()).toBe(1);
+  });
+
+  it("enforces memoryCap by trimming oldest", () => {
+    const log = new CommitIssueLinkLog({ dir, memoryCap: 3 });
+    for (let i = 0; i < 5; i += 1) {
+      log.record({ ...base(), sha: `sha${i}` });
+    }
+    expect(log.size()).toBe(3);
+    expect(log.query({}).map((r) => r.sha)).toEqual(["sha4", "sha3", "sha2"]);
+  });
+
+  it("respects query limit (1..1000)", () => {
+    const log = new CommitIssueLinkLog({ dir });
+    for (let i = 0; i < 10; i += 1) {
+      log.record({ ...base(), sha: `sha${i}` });
+    }
+    expect(log.query({ limit: 3 })).toHaveLength(3);
+    expect(log.query({ limit: 0 })).toHaveLength(1); // clamped to min 1
+  });
+});

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -13,6 +13,7 @@ import { loadOrCreateBridgeToken } from "./bridgeToken.js";
 import { repairBridgeToolsRulesIfStale } from "./bridgeToolsRules.js";
 import { createDriver } from "./claudeDriver.js";
 import { ClaudeOrchestrator } from "./claudeOrchestrator.js";
+import { CommitIssueLinkLog } from "./commitIssueLinkLog.js";
 import type { Config } from "./config.js";
 import { ExtensionClient } from "./extensionClient.js";
 import { FileLock } from "./fileLock.js";
@@ -136,6 +137,7 @@ export class Bridge {
   private automationHooks: AutomationHooks | undefined = undefined;
   private recipeScheduler: RecipeScheduler | null = null;
   private recipeRunLog: RecipeRunLog | null = null;
+  private commitIssueLinkLog: CommitIssueLinkLog | null = null;
   private httpMcpHandler: StreamableHttpHandler | null = null;
   private oauthServer: OAuthServerImpl | null = null;
   /** Incremented each time the VS Code extension (re)connects — guards stale async callbacks. */
@@ -389,6 +391,7 @@ export class Bridge {
           this._emitLiveState();
         },
         () => this.extensionDisconnectCount,
+        this.commitIssueLinkLog ?? undefined,
       );
 
       transport.attach(ws);
@@ -852,9 +855,14 @@ export class Bridge {
         this.config.antBinary,
         (msg) => this.logger.info(msg),
       );
+      // Patchwork: enrichment link log is useful regardless of orchestrator.
+      const patchworkDir = path.join(os.homedir(), ".patchwork");
+      this.commitIssueLinkLog = new CommitIssueLinkLog({
+        dir: patchworkDir,
+        logger: this.logger,
+      });
       if (driver) {
-        // Patchwork: persistent audit trail of recipe-triggered runs.
-        const patchworkDir = path.join(os.homedir(), ".patchwork");
+        // Recipe run-history needs the orchestrator to produce anything.
         this.recipeRunLog = new RecipeRunLog({
           dir: patchworkDir,
           logger: this.logger,

--- a/src/commitIssueLinkLog.ts
+++ b/src/commitIssueLinkLog.ts
@@ -1,0 +1,218 @@
+import { appendFileSync, mkdirSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+import type { Logger } from "./logger.js";
+
+/**
+ * CommitIssueLinkLog — persistent audit trail of every commit→issue link
+ * extracted by the `enrichCommit` tool.
+ *
+ * Mirrors RecipeRunLog: JSONL append-only file + bounded in-memory ring.
+ * Schema is additive; consumers must tolerate unknown keys. Enables reverse
+ * queries ("which commits touch issue #42?") without re-running enrichment.
+ */
+
+export type LinkType = "closes" | "references";
+
+export interface CommitIssueLink {
+  /** Monotonic sequence id within the process — stable for pagination. */
+  seq: number;
+  /** Commit SHA (full). */
+  sha: string;
+  /** Normalized issue ref, e.g. `#42`. */
+  ref: string;
+  /** Classification from commit-message verb proximity. */
+  linkType: LinkType;
+  /** Whether the issue was successfully fetched from the issue tracker. */
+  resolved: boolean;
+  /** Workspace that produced the link — lets one log span many repos. */
+  workspace: string;
+  /** Commit subject (first line of message), for display. */
+  subject?: string;
+  /** Issue state at the time the link was recorded (`OPEN`/`CLOSED`/…). */
+  issueState?: string;
+  /** Issue title at the time the link was recorded. */
+  issueTitle?: string;
+  /** Reason the link is unresolved (not_found / gh_unavailable / error / auth). */
+  reason?: string;
+  /** ms epoch when the link was recorded. */
+  createdAt: number;
+}
+
+const DEFAULT_MEMORY_CAP = 2_000;
+
+export interface LinkLogOptions {
+  /** Directory holding commit_issue_links.jsonl. Created if missing. */
+  dir: string;
+  logger?: Logger;
+  /** Cap on in-memory ring. File is not truncated. */
+  memoryCap?: number;
+  /** Test hook — default Date.now. */
+  now?: () => number;
+}
+
+export interface LinkQuery {
+  /** Filter by commit SHA (exact or prefix ≥7 chars). */
+  sha?: string;
+  /** Filter by issue ref (`#42`). */
+  ref?: string;
+  /** Filter by workspace path. */
+  workspace?: string;
+  linkType?: LinkType;
+  resolved?: boolean;
+  /** Links with seq > after. */
+  after?: number;
+  limit?: number;
+}
+
+export class CommitIssueLinkLog {
+  private links: CommitIssueLink[] = [];
+  private seq = 0;
+  private readonly file: string;
+  private readonly memoryCap: number;
+  private readonly now: () => number;
+
+  constructor(private readonly opts: LinkLogOptions) {
+    this.file = path.join(opts.dir, "commit_issue_links.jsonl");
+    this.memoryCap = opts.memoryCap ?? DEFAULT_MEMORY_CAP;
+    this.now = opts.now ?? Date.now;
+    try {
+      mkdirSync(opts.dir, { recursive: true });
+    } catch (err) {
+      opts.logger?.warn?.(
+        `[linklog] could not create ${opts.dir}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+    this.loadExisting();
+  }
+
+  /**
+   * Record one link. De-duplicates against the most recent existing row for
+   * the same (workspace, sha, ref) — identical repeat calls don't grow the
+   * log. A row whose `resolved` flag or `issueState` changes IS appended, so
+   * the history of an issue's state across commits stays visible.
+   */
+  record(
+    input: Omit<CommitIssueLink, "seq" | "createdAt">,
+  ): CommitIssueLink | null {
+    const prev = this.findMostRecent(input.workspace, input.sha, input.ref);
+    if (
+      prev &&
+      prev.linkType === input.linkType &&
+      prev.resolved === input.resolved &&
+      prev.issueState === input.issueState &&
+      prev.reason === input.reason
+    ) {
+      return null;
+    }
+    this.seq += 1;
+    const link: CommitIssueLink = {
+      seq: this.seq,
+      sha: input.sha,
+      ref: input.ref,
+      linkType: input.linkType,
+      resolved: input.resolved,
+      workspace: input.workspace,
+      ...(input.subject !== undefined && { subject: input.subject }),
+      ...(input.issueState !== undefined && { issueState: input.issueState }),
+      ...(input.issueTitle !== undefined && { issueTitle: input.issueTitle }),
+      ...(input.reason !== undefined && { reason: input.reason }),
+      createdAt: this.now(),
+    };
+    this.links.push(link);
+    if (this.links.length > this.memoryCap) {
+      this.links.splice(0, this.links.length - this.memoryCap);
+    }
+    this.append(link);
+    return link;
+  }
+
+  query(q: LinkQuery = {}): CommitIssueLink[] {
+    let out = this.links;
+    if (q.sha) {
+      const needle = q.sha;
+      out = out.filter(
+        (l) =>
+          l.sha === needle || (needle.length >= 7 && l.sha.startsWith(needle)),
+      );
+    }
+    if (q.ref) out = out.filter((l) => l.ref === q.ref);
+    if (q.workspace) out = out.filter((l) => l.workspace === q.workspace);
+    if (q.linkType) out = out.filter((l) => l.linkType === q.linkType);
+    if (q.resolved !== undefined) {
+      const wanted = q.resolved;
+      out = out.filter((l) => l.resolved === wanted);
+    }
+    if (q.after !== undefined) {
+      const after = q.after;
+      out = out.filter((l) => l.seq > after);
+    }
+    out = [...out].sort((a, b) => b.seq - a.seq);
+    const limit = Math.min(Math.max(q.limit ?? 100, 1), 1_000);
+    return out.slice(0, limit);
+  }
+
+  size(): number {
+    return this.links.length;
+  }
+
+  private findMostRecent(
+    workspace: string,
+    sha: string,
+    ref: string,
+  ): CommitIssueLink | undefined {
+    for (let i = this.links.length - 1; i >= 0; i -= 1) {
+      const l = this.links[i];
+      if (l && l.workspace === workspace && l.sha === sha && l.ref === ref) {
+        return l;
+      }
+    }
+    return undefined;
+  }
+
+  private append(link: CommitIssueLink): void {
+    try {
+      appendFileSync(this.file, `${JSON.stringify(link)}\n`, { mode: 0o600 });
+    } catch (err) {
+      this.opts.logger?.warn?.(
+        `[linklog] append failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  private loadExisting(): void {
+    try {
+      statSync(this.file);
+    } catch {
+      return;
+    }
+    let raw: string;
+    try {
+      raw = readFileSync(this.file, "utf-8");
+    } catch (err) {
+      this.opts.logger?.warn?.(
+        `[linklog] read failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      return;
+    }
+    for (const line of raw.split("\n")) {
+      if (!line) continue;
+      try {
+        const parsed = JSON.parse(line) as CommitIssueLink;
+        if (
+          typeof parsed.seq !== "number" ||
+          typeof parsed.sha !== "string" ||
+          typeof parsed.ref !== "string"
+        ) {
+          continue;
+        }
+        this.links.push(parsed);
+        if (parsed.seq > this.seq) this.seq = parsed.seq;
+      } catch {
+        // skip malformed line
+      }
+    }
+    if (this.links.length > this.memoryCap) {
+      this.links.splice(0, this.links.length - this.memoryCap);
+    }
+  }
+}

--- a/src/tools/__tests__/getCommitsForIssue.test.ts
+++ b/src/tools/__tests__/getCommitsForIssue.test.ts
@@ -1,0 +1,126 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { CommitIssueLinkLog } from "../../commitIssueLinkLog.js";
+import { createGetCommitsForIssueTool } from "../getCommitsForIssue.js";
+
+let dir: string;
+let log: CommitIssueLinkLog;
+
+beforeEach(() => {
+  dir = mkdtempSync(path.join(os.tmpdir(), "get-commits-for-issue-"));
+  log = new CommitIssueLinkLog({ dir });
+});
+afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+function parse(r: { content: Array<{ type: string; text: string }> }) {
+  return JSON.parse(r.content[0]?.text ?? "{}");
+}
+
+const WS = "/ws/a";
+
+describe("getCommitsForIssue", () => {
+  it("returns commits that reference the issue (newest first)", async () => {
+    log.record({
+      sha: "aaa",
+      ref: "#42",
+      linkType: "closes",
+      resolved: true,
+      workspace: WS,
+      subject: "fix: a",
+      issueState: "OPEN",
+    });
+    log.record({
+      sha: "bbb",
+      ref: "#42",
+      linkType: "references",
+      resolved: true,
+      workspace: WS,
+      subject: "note: b",
+    });
+
+    const tool = createGetCommitsForIssueTool(WS, log);
+    const res = parse(await tool.handler({ issue: "#42" }));
+    expect(res.ref).toBe("#42");
+    expect(res.count).toBe(2);
+    expect(res.commits.map((c: { sha: string }) => c.sha)).toEqual([
+      "bbb",
+      "aaa",
+    ]);
+  });
+
+  it("normalizes bare number and GH- prefix to #N", async () => {
+    log.record({
+      sha: "aaa",
+      ref: "#7",
+      linkType: "closes",
+      resolved: true,
+      workspace: WS,
+    });
+    const tool = createGetCommitsForIssueTool(WS, log);
+    expect(parse(await tool.handler({ issue: "7" })).ref).toBe("#7");
+    expect(parse(await tool.handler({ issue: "GH-7" })).ref).toBe("#7");
+    expect(parse(await tool.handler({ issue: "#7" })).count).toBe(1);
+  });
+
+  it("filters by linkType when requested", async () => {
+    log.record({
+      sha: "aaa",
+      ref: "#9",
+      linkType: "closes",
+      resolved: true,
+      workspace: WS,
+    });
+    log.record({
+      sha: "bbb",
+      ref: "#9",
+      linkType: "references",
+      resolved: true,
+      workspace: WS,
+    });
+    const tool = createGetCommitsForIssueTool(WS, log);
+    const res = parse(await tool.handler({ issue: "#9", linkType: "closes" }));
+    expect(res.count).toBe(1);
+    expect(res.commits[0].sha).toBe("aaa");
+  });
+
+  it("defaults to current workspace; workspaceScope:any returns all", async () => {
+    log.record({
+      sha: "x",
+      ref: "#1",
+      linkType: "closes",
+      resolved: true,
+      workspace: "/ws/a",
+    });
+    log.record({
+      sha: "y",
+      ref: "#1",
+      linkType: "closes",
+      resolved: true,
+      workspace: "/ws/other",
+    });
+    const tool = createGetCommitsForIssueTool("/ws/a", log);
+    expect(parse(await tool.handler({ issue: "#1" })).count).toBe(1);
+    expect(
+      parse(await tool.handler({ issue: "#1", workspaceScope: "any" })).count,
+    ).toBe(2);
+  });
+
+  it("errors on missing or malformed issue", async () => {
+    const tool = createGetCommitsForIssueTool(WS, log);
+    expect((await tool.handler({})).content[0]?.text).toContain(
+      "issue is required",
+    );
+    expect(
+      (await tool.handler({ issue: "not-a-ref" })).content[0]?.text,
+    ).toContain("invalid issue ref");
+  });
+
+  it("returns empty result when issue has no links", async () => {
+    const tool = createGetCommitsForIssueTool(WS, log);
+    const res = parse(await tool.handler({ issue: "#999" }));
+    expect(res.count).toBe(0);
+    expect(res.commits).toEqual([]);
+  });
+});

--- a/src/tools/enrichCommit.ts
+++ b/src/tools/enrichCommit.ts
@@ -1,3 +1,4 @@
+import type { CommitIssueLinkLog } from "../commitIssueLinkLog.js";
 import { runGitStdout } from "./git-utils.js";
 import { GH_NOT_AUTHED, isNotAuthed, isNotFound } from "./github/shared.js";
 import { classifyIssueLink, extractIssueRefs } from "./issueRefs.js";
@@ -46,7 +47,10 @@ async function fetchIssue(
   return { ok: false, reason: "error", detail: msg };
 }
 
-export function createEnrichCommitTool(workspace: string) {
+export function createEnrichCommitTool(
+  workspace: string,
+  linkLog?: CommitIssueLinkLog,
+) {
   return {
     schema: {
       name: "enrichCommit",
@@ -151,6 +155,29 @@ export function createEnrichCommitTool(workspace: string) {
 
       for (const r of issueRefs) {
         const linkType = classifyIssueLink(fullMessage, r);
+        const recordLink = (
+          resolved: boolean,
+          issue: Record<string, unknown> | null,
+          reason: string | null,
+        ) => {
+          if (!linkLog || !sha) return;
+          linkLog.record({
+            sha,
+            ref: r,
+            linkType,
+            resolved,
+            workspace,
+            ...(subject && { subject }),
+            ...(typeof issue?.state === "string" && {
+              issueState: issue.state,
+            }),
+            ...(typeof issue?.title === "string" && {
+              issueTitle: issue.title,
+            }),
+            ...(reason !== null && { reason }),
+          });
+        };
+
         if (!ghAvailable) {
           links.push({
             ref: r,
@@ -160,6 +187,7 @@ export function createEnrichCommitTool(workspace: string) {
             reason: "gh_unavailable",
           });
           unresolved += 1;
+          recordLink(false, null, "gh_unavailable");
           continue;
         }
         const num = r.replace(/^#/, "");
@@ -172,16 +200,19 @@ export function createEnrichCommitTool(workspace: string) {
             issue: fetched.issue,
             reason: null,
           });
+          recordLink(true, fetched.issue, null);
         } else {
+          const reason =
+            fetched.reason === "not_authed" ? GH_NOT_AUTHED : fetched.reason;
           links.push({
             ref: r,
             linkType,
             resolved: false,
             issue: null,
-            reason:
-              fetched.reason === "not_authed" ? GH_NOT_AUTHED : fetched.reason,
+            reason,
           });
           unresolved += 1;
+          recordLink(false, null, reason);
         }
       }
 

--- a/src/tools/getCommitsForIssue.ts
+++ b/src/tools/getCommitsForIssue.ts
@@ -1,0 +1,123 @@
+import type { CommitIssueLinkLog, LinkType } from "../commitIssueLinkLog.js";
+import {
+  error,
+  optionalInt,
+  optionalString,
+  successStructured,
+} from "./utils.js";
+
+/**
+ * Reverse lookup over the persisted commit→issue link log.
+ * Answers: "which commits touch issue #N?" without re-running enrichment.
+ */
+export function createGetCommitsForIssueTool(
+  workspace: string,
+  linkLog: CommitIssueLinkLog,
+) {
+  return {
+    schema: {
+      name: "getCommitsForIssue",
+      description:
+        "Reverse commit→issue lookup from the persisted enrichment log. Returns commits that referenced the given issue, newest first.",
+      annotations: { readOnlyHint: true },
+      inputSchema: {
+        type: "object" as const,
+        required: ["issue"],
+        properties: {
+          issue: {
+            type: "string",
+            description:
+              "Issue ref: `#42`, `42`, or `GH-42`. Normalized to `#N` internally.",
+          },
+          linkType: {
+            type: "string",
+            enum: ["closes", "references"],
+            description:
+              "Optional filter — only `closes` or only `references`.",
+          },
+          workspaceScope: {
+            type: "string",
+            enum: ["current", "any"],
+            description:
+              "`current` (default) filters to this workspace; `any` returns matches from every workspace the log has seen.",
+          },
+          limit: {
+            type: "integer",
+            minimum: 1,
+            maximum: 500,
+            description: "Max results (default 100).",
+          },
+        },
+        additionalProperties: false as const,
+      },
+      outputSchema: {
+        type: "object" as const,
+        properties: {
+          ref: { type: "string" },
+          count: { type: "integer" },
+          commits: {
+            type: "array",
+            items: {
+              type: "object",
+              properties: {
+                sha: { type: "string" },
+                subject: { type: ["string", "null"] },
+                linkType: { type: "string", enum: ["closes", "references"] },
+                resolved: { type: "boolean" },
+                issueState: { type: ["string", "null"] },
+                workspace: { type: "string" },
+                recordedAt: { type: "integer" },
+              },
+              required: [
+                "sha",
+                "linkType",
+                "resolved",
+                "workspace",
+                "recordedAt",
+              ],
+            },
+          },
+        },
+        required: ["ref", "count", "commits"],
+      },
+    },
+    timeoutMs: 5_000,
+    async handler(args: Record<string, unknown>) {
+      const raw = optionalString(args, "issue");
+      if (!raw) return error("issue is required");
+      const numMatch = raw.match(/(\d+)/);
+      if (!numMatch) return error(`invalid issue ref: '${raw}'`);
+      const ref = `#${numMatch[1]}`;
+
+      const linkType = optionalString(args, "linkType") as
+        | LinkType
+        | undefined
+        | "";
+      const scope = optionalString(args, "workspaceScope") ?? "current";
+      const limit = optionalInt(args, "limit", 1, 500) ?? 100;
+
+      const links = linkLog.query({
+        ref,
+        ...(linkType === "closes" || linkType === "references"
+          ? { linkType }
+          : {}),
+        ...(scope === "current" ? { workspace } : {}),
+        limit,
+      });
+
+      return successStructured({
+        ref,
+        count: links.length,
+        commits: links.map((l) => ({
+          sha: l.sha,
+          subject: l.subject ?? null,
+          linkType: l.linkType,
+          resolved: l.resolved,
+          issueState: l.issueState ?? null,
+          workspace: l.workspace,
+          recordedAt: l.createdAt,
+        })),
+      });
+    },
+  };
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -66,6 +66,7 @@ import { createGetBufferContentTool } from "./getBufferContent.js";
 import { createGetChangeImpactTool } from "./getChangeImpact.js";
 import { createGetClaudeTaskStatusTool } from "./getClaudeTaskStatus.js";
 import { createGetCodeCoverageTool } from "./getCodeCoverage.js";
+import { createGetCommitsForIssueTool } from "./getCommitsForIssue.js";
 import {
   createGetCurrentSelectionTool,
   createGetLatestSelectionTool,
@@ -321,6 +322,7 @@ export function registerAllTools(
   getDisconnectInfo?: () => DisconnectInfo,
   onContextCacheUpdated?: (generatedAt: string) => void,
   getExtensionDisconnectCount?: () => number,
+  commitIssueLinkLog?: import("../commitIssueLinkLog.js").CommitIssueLinkLog,
 ): void {
   const workspace = config.workspace;
   const workspaceFolders = config.workspaceFolders;
@@ -645,7 +647,10 @@ export function registerAllTools(
     createTestTraceToSourceTool(workspace),
     createScreenshotAndAnnotateTool(workspace, extensionClient),
     createGetPRTemplateTool(workspace),
-    createEnrichCommitTool(workspace),
+    createEnrichCommitTool(workspace, commitIssueLinkLog),
+    ...(commitIssueLinkLog
+      ? [createGetCommitsForIssueTool(workspace, commitIssueLinkLog)]
+      : []),
     createGetCodeCoverageTool(workspace),
     createGenerateTestsTool(workspace),
     ...(probes.gh
@@ -839,6 +844,7 @@ export const TOOL_CATEGORIES: Record<string, string[]> = {
   githubPostPRReview: ["github"],
   getPRTemplate: ["github"],
   enrichCommit: ["github"],
+  getCommitsForIssue: ["github"],
   getAIComments: ["github"],
   createGithubIssueFromAIComment: ["github"],
   // Bridge / orchestration


### PR DESCRIPTION
## Summary

Second step of the Enrichment Engine. `enrichCommit` now writes each parsed link to a JSONL audit log so cross-session queries don't re-run `gh`.

- **`CommitIssueLinkLog`** (`~/.patchwork/commit_issue_links.jsonl`) — mirrors the `RecipeRunLog` pattern: append-only file + bounded in-memory ring (cap 2000). No SQLite dep.
- **Dedup:** identical repeat enrichments of the same `(workspace, sha, ref)` don't grow the log, but `linkType` / `resolved` / `issueState` / `reason` changes DO append — state history stays visible.
- **New tool `getCommitsForIssue`** — reverse query "which commits touch #42" without re-running enrichment. Normalizes `#42` / `42` / `GH-42` → `#N`, filters by `linkType`, defaults to current workspace with `workspaceScope: "any"` opt-in.
- Wired in `bridge.ts` — link log instantiates regardless of orchestrator driver, so enrichment works without Claude subprocess mode.

## Test plan

- [x] 17 new tests (11 for log, 6 for tool) — dedup, persistence+reload, malformed-line tolerance, memoryCap trim, prefix-sha matching, workspace scope
- [x] Full bridge suite: 3091/3091 passing (was 3074)
- [x] Biome check clean (2 pre-existing unrelated warnings)
- [ ] Manual: run `enrichCommit` on two commits referencing same issue → `getCommitsForIssue` returns both newest-first
- [ ] Manual: restart bridge → `getCommitsForIssue` still returns prior results

🤖 Generated with [Claude Code](https://claude.com/claude-code)