### PR TITLE
feat(enrichment): enrichStackTrace — stack frame → introducing commit

### DIFF
--- a/src/tools/__tests__/blame-utils.test.ts
+++ b/src/tools/__tests__/blame-utils.test.ts
@@ -1,0 +1,85 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createBlameResolver } from "../blame-utils.js";
+
+let repo: string;
+
+function git(...args: string[]): string {
+  return execFileSync("git", args, { cwd: repo, encoding: "utf-8" });
+}
+
+beforeEach(() => {
+  repo = mkdtempSync(path.join(os.tmpdir(), "blame-utils-"));
+  git("init", "-q");
+  git("config", "user.email", "t@t");
+  git("config", "user.name", "Tester");
+  git("config", "commit.gpgsign", "false");
+  writeFileSync(path.join(repo, "a.ts"), "line1\nline2\nline3\n");
+  git("add", "a.ts");
+  git("commit", "-q", "-m", "init");
+});
+afterEach(() => rmSync(repo, { recursive: true, force: true }));
+
+describe("createBlameResolver", () => {
+  it("returns the introducing commit for a line", async () => {
+    const resolver = createBlameResolver(repo);
+    const sha = await resolver.getIntroducedByCommit(
+      path.join(repo, "a.ts"),
+      2,
+    );
+    expect(sha).toMatch(/^[0-9a-f]{40}$/);
+  });
+
+  it("returns undefined for files that don't exist on disk", async () => {
+    const resolver = createBlameResolver(repo);
+    expect(
+      await resolver.getIntroducedByCommit("/nope/missing.ts", 1),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined for untracked files", async () => {
+    writeFileSync(path.join(repo, "untracked.ts"), "x\n");
+    const resolver = createBlameResolver(repo);
+    expect(
+      await resolver.getIntroducedByCommit(path.join(repo, "untracked.ts"), 1),
+    ).toBeUndefined();
+  });
+
+  it("caches results (second call does not re-blame)", async () => {
+    const resolver = createBlameResolver(repo);
+    const file = path.join(repo, "a.ts");
+    const sha1 = await resolver.getIntroducedByCommit(file, 1);
+    expect(resolver.cacheSize()).toBe(1);
+    const sha2 = await resolver.getIntroducedByCommit(file, 1);
+    expect(sha2).toBe(sha1);
+    expect(resolver.cacheSize()).toBe(1);
+  });
+
+  it("expires cached entries after ttlMs", async () => {
+    let time = 0;
+    const resolver = createBlameResolver(repo, {
+      ttlMs: 1_000,
+      now: () => time,
+    });
+    const file = path.join(repo, "a.ts");
+    await resolver.getIntroducedByCommit(file, 1);
+    time = 2_000;
+    // Cache entry is stale — getIntroducedByCommit will re-blame.
+    // We can't observe the subprocess directly, but the freshness path
+    // exercises the cache check; assert it still returns the same sha.
+    const sha = await resolver.getIntroducedByCommit(file, 1);
+    expect(sha).toMatch(/^[0-9a-f]{40}$/);
+  });
+
+  it("evicts FIFO when cache exceeds maxSize", async () => {
+    const resolver = createBlameResolver(repo, { maxSize: 2 });
+    const file = path.join(repo, "a.ts");
+    await resolver.getIntroducedByCommit(file, 1);
+    await resolver.getIntroducedByCommit(file, 2);
+    await resolver.getIntroducedByCommit(file, 3);
+    expect(resolver.cacheSize()).toBe(2);
+  });
+});

--- a/src/tools/__tests__/enrichStackTrace.test.ts
+++ b/src/tools/__tests__/enrichStackTrace.test.ts
@@ -1,0 +1,150 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createEnrichStackTraceTool } from "../enrichStackTrace.js";
+
+let repo: string;
+
+function git(...args: string[]): string {
+  return execFileSync("git", args, { cwd: repo, encoding: "utf-8" });
+}
+
+beforeEach(() => {
+  repo = mkdtempSync(path.join(os.tmpdir(), "enrich-stacktrace-"));
+  git("init", "-q");
+  git("config", "user.email", "t@t");
+  git("config", "user.name", "Tester");
+  git("config", "commit.gpgsign", "false");
+});
+afterEach(() => rmSync(repo, { recursive: true, force: true }));
+
+function parse(r: { content: Array<{ type: string; text: string }> }) {
+  return JSON.parse(r.content[0]?.text ?? "{}");
+}
+
+async function commit(
+  file: string,
+  contents: string,
+  message: string,
+): Promise<string> {
+  writeFileSync(path.join(repo, file), contents);
+  git("add", file);
+  git("commit", "-q", "-m", message);
+  return git("rev-parse", "HEAD").trim();
+}
+
+describe("enrichStackTrace tool", () => {
+  it("maps a Node stack frame to the introducing commit", async () => {
+    const sha = await commit(
+      "a.ts",
+      "export function doThing() {\n  throw new Error('bang');\n}\n",
+      "feat: add doThing",
+    );
+    const trace = `Error: bang
+    at doThing (${path.join(repo, "a.ts")}:2:9)`;
+    const res = parse(
+      await createEnrichStackTraceTool(repo).handler({ stackTrace: trace }),
+    );
+    expect(res.gitAvailable).toBe(true);
+    expect(res.framesParsed).toBe(1);
+    expect(res.framesBlamed).toBe(1);
+    expect(res.frames[0].inWorkspace).toBe(true);
+    expect(res.frames[0].commit.sha).toBe(sha);
+    expect(res.frames[0].commit.subject).toBe("feat: add doThing");
+    expect(res.topSuspect.sha).toBe(sha);
+  });
+
+  it("confidence=high when multiple frames agree on the same commit", async () => {
+    const sha = await commit("a.ts", "line1\nline2\nline3\nline4\n", "init a");
+    const trace = `Error
+    at t (${path.join(repo, "a.ts")}:2:1)
+    at t (${path.join(repo, "a.ts")}:3:1)`;
+    const res = parse(
+      await createEnrichStackTraceTool(repo).handler({ stackTrace: trace }),
+    );
+    expect(res.confidence).toBe("high");
+    expect(res.topSuspect.sha).toBe(sha);
+    expect(res.topSuspect.frameCount).toBe(2);
+  });
+
+  it("confidence=medium when top frame blamed but other frames disagree", async () => {
+    const shaA = await commit("a.ts", "a content\n", "init a");
+    const shaB = await commit("b.ts", "b content\n", "init b");
+    const trace = `Error
+    at t (${path.join(repo, "a.ts")}:1:1)
+    at t (${path.join(repo, "b.ts")}:1:1)`;
+    const res = parse(
+      await createEnrichStackTraceTool(repo).handler({ stackTrace: trace }),
+    );
+    expect(res.confidence).toBe("medium");
+    expect(res.topSuspect.sha).toBe(shaA);
+    expect(shaB).not.toBe(shaA);
+  });
+
+  it("confidence=low when top frame is outside the workspace", async () => {
+    await commit("a.ts", "a\n", "init");
+    const trace = `Error
+    at node:internal/modules/cjs/loader (node:internal/cjs/loader:123:9)
+    at fn (/tmp/not-in-repo/x.ts:1:1)`;
+    const res = parse(
+      await createEnrichStackTraceTool(repo).handler({ stackTrace: trace }),
+    );
+    expect(res.confidence).toBe("low");
+    expect(res.topSuspect).toBeNull();
+  });
+
+  it("flags frames outside the workspace as inWorkspace:false", async () => {
+    await commit("a.ts", "a\n", "init");
+    const trace = `Error
+    at fn (${path.join(repo, "a.ts")}:1:1)
+    at ext (/usr/lib/foo/bar.ts:1:1)`;
+    const res = parse(
+      await createEnrichStackTraceTool(repo).handler({ stackTrace: trace }),
+    );
+    expect(res.frames[0].inWorkspace).toBe(true);
+    expect(res.frames[1].inWorkspace).toBe(false);
+    expect(res.frames[1].commit).toBeNull();
+  });
+
+  it("respects maxFrames cap", async () => {
+    await commit("a.ts", "l1\nl2\nl3\nl4\nl5\n", "init");
+    const f = (n: number) => `    at x (${path.join(repo, "a.ts")}:${n}:1)`;
+    const trace = `Error\n${[1, 2, 3, 4, 5].map(f).join("\n")}`;
+    const res = parse(
+      await createEnrichStackTraceTool(repo).handler({
+        stackTrace: trace,
+        maxFrames: 2,
+      }),
+    );
+    expect(res.framesParsed).toBe(5);
+    expect(res.frames).toHaveLength(2);
+  });
+
+  it("returns empty frames on unparseable input", async () => {
+    const res = parse(
+      await createEnrichStackTraceTool(repo).handler({
+        stackTrace: "no frames here, just prose",
+      }),
+    );
+    expect(res.framesParsed).toBe(0);
+    expect(res.frames).toHaveLength(0);
+    expect(res.confidence).toBe("low");
+  });
+
+  it("reports gitAvailable=false when workspace is not a git repo", async () => {
+    const nonRepo = mkdtempSync(path.join(os.tmpdir(), "not-a-repo-"));
+    try {
+      const res = parse(
+        await createEnrichStackTraceTool(nonRepo).handler({
+          stackTrace: `at fn (${path.join(nonRepo, "x.ts")}:1:1)`,
+        }),
+      );
+      expect(res.gitAvailable).toBe(false);
+      expect(res.framesBlamed).toBe(0);
+    } finally {
+      rmSync(nonRepo, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/tools/__tests__/stackTraceParser.test.ts
+++ b/src/tools/__tests__/stackTraceParser.test.ts
@@ -1,0 +1,128 @@
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { parseStackTrace, resolveFrameFile } from "../stackTraceParser.js";
+
+describe("parseStackTrace", () => {
+  it("parses Node V8 `at fn (path:L:C)`", () => {
+    const trace = `Error: bang
+    at Object.doThing (/abs/repo/src/a.ts:42:13)
+    at doOther (/abs/repo/src/b.ts:7:3)`;
+    const frames = parseStackTrace(trace);
+    expect(frames).toHaveLength(2);
+    expect(frames[0]).toMatchObject({
+      function: "Object.doThing",
+      file: "/abs/repo/src/a.ts",
+      line: 42,
+      column: 13,
+      language: "node",
+    });
+    expect(frames[1]?.function).toBe("doOther");
+  });
+
+  it("parses Node bare `at path:L:C`", () => {
+    const trace = `    at /abs/repo/src/x.ts:99:2`;
+    const frames = parseStackTrace(trace);
+    expect(frames[0]).toMatchObject({
+      file: "/abs/repo/src/x.ts",
+      line: 99,
+      column: 2,
+      function: null,
+      language: "node",
+    });
+  });
+
+  it("parses Python tracebacks", () => {
+    const trace = `Traceback (most recent call last):
+  File "/abs/repo/app.py", line 123, in handler
+    raise ValueError("x")
+ValueError: x`;
+    const frames = parseStackTrace(trace);
+    expect(frames).toHaveLength(1);
+    expect(frames[0]).toMatchObject({
+      file: "/abs/repo/app.py",
+      line: 123,
+      function: "handler",
+      language: "python",
+    });
+  });
+
+  it("parses Firefox/Safari `fn@url:L:C`", () => {
+    const trace = `handler@http://localhost:3000/bundle.js:500:17
+render@http://localhost:3000/bundle.js:210:5`;
+    const frames = parseStackTrace(trace);
+    expect(frames).toHaveLength(2);
+    expect(frames[0]).toMatchObject({
+      function: "handler",
+      file: "http://localhost:3000/bundle.js",
+      line: 500,
+      column: 17,
+      language: "browser",
+    });
+  });
+
+  it("dedupes identical frames", () => {
+    const trace = `at fn (/a.ts:1:1)\nat fn (/a.ts:1:1)`;
+    expect(parseStackTrace(trace)).toHaveLength(1);
+  });
+
+  it("preserves top-of-stack order", () => {
+    const trace = `Error
+    at top (/a.ts:1:1)
+    at middle (/b.ts:2:2)
+    at bottom (/c.ts:3:3)`;
+    const frames = parseStackTrace(trace);
+    expect(frames.map((f) => f.function)).toEqual(["top", "middle", "bottom"]);
+  });
+
+  it("falls back to generic file:line:col when no known format matches", () => {
+    const trace = `some random output\n/repo/file.ts:55:10 something happened`;
+    const frames = parseStackTrace(trace);
+    expect(frames).toHaveLength(1);
+    expect(frames[0]).toMatchObject({
+      file: "/repo/file.ts",
+      line: 55,
+      column: 10,
+      language: "generic",
+    });
+  });
+
+  it("returns empty array on input with no frames", () => {
+    expect(parseStackTrace("just a plain log line")).toEqual([]);
+    expect(parseStackTrace("")).toEqual([]);
+  });
+});
+
+describe("resolveFrameFile", () => {
+  const ws = "/repo";
+
+  it("passes through absolute paths inside workspace", () => {
+    expect(resolveFrameFile(ws, "/repo/src/a.ts")).toBe("/repo/src/a.ts");
+  });
+
+  it("joins relative paths with workspace", () => {
+    expect(resolveFrameFile(ws, "src/a.ts")).toBe(
+      path.resolve("/repo/src/a.ts"),
+    );
+  });
+
+  it("rejects paths outside the workspace", () => {
+    expect(resolveFrameFile(ws, "/etc/passwd")).toBeNull();
+    expect(resolveFrameFile(ws, "../outside.ts")).toBeNull();
+  });
+
+  it("strips URL scheme+host and tries as relative", () => {
+    expect(resolveFrameFile(ws, "http://localhost:3000/src/app.js")).toBe(
+      path.resolve("/repo/src/app.js"),
+    );
+  });
+
+  it("strips webpack:// prefix", () => {
+    expect(resolveFrameFile(ws, "webpack://app/./src/index.ts")).toBe(
+      path.resolve("/repo/src/index.ts"),
+    );
+  });
+
+  it("returns null for empty input", () => {
+    expect(resolveFrameFile(ws, "")).toBeNull();
+  });
+});

--- a/src/tools/blame-utils.ts
+++ b/src/tools/blame-utils.ts
@@ -1,0 +1,89 @@
+import { execFile } from "node:child_process";
+import { existsSync } from "node:fs";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+const DEFAULT_TTL_MS = 30_000;
+const DEFAULT_TIMEOUT_MS = 2_000;
+const DEFAULT_CACHE_MAX = 1_000;
+
+export interface BlameEntry {
+  commitHash: string;
+  cachedAt: number;
+}
+
+export interface BlameCacheOptions {
+  /** Cache TTL in ms. Default 30s. */
+  ttlMs?: number;
+  /** Git blame subprocess timeout in ms. Default 2s. */
+  timeoutMs?: number;
+  /** FIFO cache size cap. Default 1000. */
+  maxSize?: number;
+  /** Test hook — default Date.now. */
+  now?: () => number;
+}
+
+/**
+ * Factory for a per-instance git-blame resolver with LRU cache, subprocess
+ * timeout, and stale-file guard. Used by watchDiagnostics (enriches
+ * diagnostics with introducing commit) and enrichStackTrace (maps stack
+ * frames to commits).
+ *
+ * Returns `undefined` for untracked files, deleted files, blame misses, and
+ * the all-zeros "uncommitted" sentinel — callers treat those as "unknown"
+ * rather than error.
+ */
+export function createBlameResolver(
+  workspace: string,
+  options: BlameCacheOptions = {},
+) {
+  const ttlMs = options.ttlMs ?? DEFAULT_TTL_MS;
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const maxSize = options.maxSize ?? DEFAULT_CACHE_MAX;
+  const now = options.now ?? Date.now;
+  const cache = new Map<string, BlameEntry>();
+
+  function evict(): void {
+    if (cache.size <= maxSize) return;
+    const firstKey = cache.keys().next().value;
+    if (firstKey !== undefined) cache.delete(firstKey);
+  }
+
+  async function getIntroducedByCommit(
+    file: string,
+    line: number,
+  ): Promise<string | undefined> {
+    const key = `${file}:${line}`;
+    const cached = cache.get(key);
+    if (cached && now() - cached.cachedAt < ttlMs) {
+      return cached.commitHash;
+    }
+    // Skip subprocess for files that no longer exist on disk.
+    if (!existsSync(file)) return undefined;
+    try {
+      const { stdout } = await execFileAsync(
+        "git",
+        ["blame", "-L", `${line},${line}`, "--porcelain", "--", file],
+        { cwd: workspace, timeout: timeoutMs },
+      );
+      const hash = stdout.slice(0, 40).trim();
+      if (/^[0-9a-f]{40}$/.test(hash) && !hash.startsWith("0000000")) {
+        cache.set(key, { commitHash: hash, cachedAt: now() });
+        evict();
+        return hash;
+      }
+    } catch {
+      // git not available, file not tracked, timeout — silently omit
+    }
+    return undefined;
+  }
+
+  return {
+    getIntroducedByCommit,
+    cacheSize: () => cache.size,
+    clearCache: () => cache.clear(),
+  };
+}
+
+export type BlameResolver = ReturnType<typeof createBlameResolver>;

--- a/src/tools/enrichStackTrace.ts
+++ b/src/tools/enrichStackTrace.ts
@@ -1,0 +1,243 @@
+import { createBlameResolver } from "./blame-utils.js";
+import { runGitStdout } from "./git-utils.js";
+import {
+  parseStackTrace,
+  resolveFrameFile,
+  type StackFrame,
+} from "./stackTraceParser.js";
+import {
+  execSafe,
+  optionalInt,
+  requireString,
+  successStructured,
+} from "./utils.js";
+
+interface CommitMeta {
+  sha: string;
+  author: string;
+  date: string;
+  subject: string;
+}
+
+/**
+ * Fetch minimal commit metadata for display. Returns `null` if the commit
+ * can't be read (unknown sha, shallow clone, git missing).
+ */
+async function fetchCommitMeta(
+  workspace: string,
+  sha: string,
+  signal?: AbortSignal,
+): Promise<CommitMeta | null> {
+  try {
+    const out = await runGitStdout(
+      ["show", "--no-patch", "--format=%H%n%an <%ae>%n%aI%n%s", sha],
+      workspace,
+      { signal, timeout: 5_000 },
+    );
+    const [fullSha, author, date, subject] = out.split("\n");
+    if (!fullSha) return null;
+    return {
+      sha: fullSha,
+      author: author ?? "",
+      date: date ?? "",
+      subject: subject ?? "",
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Classify overall confidence in the top suspect:
+ *   high   — top frame blamed, >=2 frames agree on the same commit
+ *   medium — top frame blamed, other frames blamed to different commits
+ *   low    — top frame not blamed (outside workspace / uncommitted)
+ */
+function scoreConfidence(
+  topShaResolved: boolean,
+  uniqueShas: string[],
+  topSha: string | null,
+): "high" | "medium" | "low" {
+  if (!topShaResolved || !topSha) return "low";
+  const topAgreements = uniqueShas.filter((s) => s === topSha).length;
+  if (topAgreements >= 2) return "high";
+  return "medium";
+}
+
+export function createEnrichStackTraceTool(workspace: string) {
+  return {
+    schema: {
+      name: "enrichStackTrace",
+      description:
+        "Map stack-trace frames to introducing commits via git blame. Parses Node/Python/browser traces, filters to in-workspace files, returns per-frame commit + overall top suspect.",
+      annotations: { readOnlyHint: true },
+      inputSchema: {
+        type: "object" as const,
+        required: ["stackTrace"],
+        properties: {
+          stackTrace: {
+            type: "string",
+            description: "Full stack trace text. Multi-line; any language.",
+            maxLength: 64_000,
+          },
+          maxFrames: {
+            type: "integer",
+            minimum: 1,
+            maximum: 50,
+            description: "Max frames to blame. Default 10. Top-of-stack first.",
+          },
+        },
+        additionalProperties: false as const,
+      },
+      outputSchema: {
+        type: "object" as const,
+        properties: {
+          frames: {
+            type: "array",
+            items: {
+              type: "object",
+              properties: {
+                file: { type: "string" },
+                line: { type: "integer" },
+                column: { type: ["integer", "null"] },
+                function: { type: ["string", "null"] },
+                language: { type: "string" },
+                inWorkspace: { type: "boolean" },
+                resolvedPath: { type: ["string", "null"] },
+                commit: {
+                  type: ["object", "null"],
+                  properties: {
+                    sha: { type: "string" },
+                    author: { type: "string" },
+                    date: { type: "string" },
+                    subject: { type: "string" },
+                  },
+                },
+              },
+              required: ["file", "line", "language", "inWorkspace"],
+            },
+          },
+          topSuspect: {
+            type: ["object", "null"],
+            properties: {
+              sha: { type: "string" },
+              author: { type: "string" },
+              date: { type: "string" },
+              subject: { type: "string" },
+              frameCount: { type: "integer" },
+            },
+          },
+          confidence: {
+            type: "string",
+            enum: ["high", "medium", "low"],
+          },
+          framesParsed: { type: "integer" },
+          framesBlamed: { type: "integer" },
+          gitAvailable: { type: "boolean" },
+        },
+        required: [
+          "frames",
+          "confidence",
+          "framesParsed",
+          "framesBlamed",
+          "gitAvailable",
+        ],
+      },
+    },
+    timeoutMs: 30_000,
+    async handler(args: Record<string, unknown>, signal?: AbortSignal) {
+      const stackTrace = requireString(args, "stackTrace", 64_000);
+      const maxFrames = optionalInt(args, "maxFrames", 1, 50) ?? 10;
+
+      // Verify git repo up front so we return a meaningful `gitAvailable`.
+      const check = await execSafe("git", ["rev-parse", "--git-dir"], {
+        cwd: workspace,
+        signal,
+        timeout: 5_000,
+      });
+      const gitAvailable = check.exitCode === 0;
+
+      const parsed = parseStackTrace(stackTrace);
+      const framesParsed = parsed.length;
+      const toConsider = parsed.slice(0, maxFrames);
+
+      const resolver = createBlameResolver(workspace);
+      const blameShaByIndex: Array<string | undefined> = new Array(
+        toConsider.length,
+      );
+
+      if (gitAvailable) {
+        // Blame sequentially — top-of-stack first. The cache inside
+        // createBlameResolver makes repeat frames on the same file+line
+        // free, so this is already cheap for the typical case.
+        for (let i = 0; i < toConsider.length; i += 1) {
+          const frame = toConsider[i] as StackFrame;
+          const resolved = resolveFrameFile(workspace, frame.file);
+          if (!resolved) continue;
+          const sha = await resolver.getIntroducedByCommit(
+            resolved,
+            frame.line,
+          );
+          if (sha) blameShaByIndex[i] = sha;
+        }
+      }
+
+      const uniqueShas = Array.from(
+        new Set(
+          blameShaByIndex.filter((s): s is string => typeof s === "string"),
+        ),
+      );
+      const commitMetaCache = new Map<string, CommitMeta | null>();
+      for (const sha of uniqueShas) {
+        commitMetaCache.set(sha, await fetchCommitMeta(workspace, sha, signal));
+      }
+
+      const frames = toConsider.map((frame, i) => {
+        const resolved = resolveFrameFile(workspace, frame.file);
+        const sha = blameShaByIndex[i];
+        const commit = sha ? (commitMetaCache.get(sha) ?? null) : null;
+        return {
+          file: frame.file,
+          line: frame.line,
+          column: frame.column,
+          function: frame.function,
+          language: frame.language,
+          inWorkspace: resolved !== null,
+          resolvedPath: resolved,
+          commit,
+        };
+      });
+
+      const allBlamedShas = blameShaByIndex.filter(
+        (s): s is string => typeof s === "string",
+      );
+      const framesBlamed = allBlamedShas.length;
+      const topSha = blameShaByIndex[0] ?? null;
+      const confidence = scoreConfidence(
+        Boolean(topSha),
+        allBlamedShas,
+        topSha,
+      );
+
+      let topSuspect: (CommitMeta & { frameCount: number }) | null = null;
+      if (topSha) {
+        const meta = commitMetaCache.get(topSha);
+        if (meta) {
+          topSuspect = {
+            ...meta,
+            frameCount: allBlamedShas.filter((s) => s === topSha).length,
+          };
+        }
+      }
+
+      return successStructured({
+        frames,
+        topSuspect,
+        confidence,
+        framesParsed,
+        framesBlamed,
+        gitAvailable,
+      });
+    },
+  };
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -43,6 +43,7 @@ import { createDetectUnusedCodeTool } from "./detectUnusedCode.js";
 import { createGetDocumentLinksTool } from "./documentLinks.js";
 import { createEditTextTool } from "./editText.js";
 import { createEnrichCommitTool } from "./enrichCommit.js";
+import { createEnrichStackTraceTool } from "./enrichStackTrace.js";
 import { createExplainDiagnosticTool } from "./explainDiagnostic.js";
 import { createExplainSymbolTool } from "./explainSymbol.js";
 import {
@@ -648,6 +649,7 @@ export function registerAllTools(
     createScreenshotAndAnnotateTool(workspace, extensionClient),
     createGetPRTemplateTool(workspace),
     createEnrichCommitTool(workspace, commitIssueLinkLog),
+    createEnrichStackTraceTool(workspace),
     ...(commitIssueLinkLog
       ? [createGetCommitsForIssueTool(workspace, commitIssueLinkLog)]
       : []),

--- a/src/tools/stackTraceParser.ts
+++ b/src/tools/stackTraceParser.ts
@@ -1,0 +1,175 @@
+import path from "node:path";
+
+/**
+ * One frame pulled out of a stack trace. `file` is raw from the trace —
+ * may be absolute, workspace-relative, or a webpack/source-map ref.
+ * Resolution to an absolute workspace path is the caller's job.
+ */
+export interface StackFrame {
+  /** Original frame text (trimmed). */
+  raw: string;
+  /** Function / method / symbol name if identifiable, else null. */
+  function: string | null;
+  /** File path as it appeared in the trace. */
+  file: string;
+  /** 1-indexed line number. */
+  line: number;
+  /** 1-indexed column, if present. */
+  column: number | null;
+  /** Detected language family that produced the frame. */
+  language: "node" | "python" | "browser" | "generic";
+}
+
+/**
+ * Heuristic stack-trace parser. Recognises:
+ *   Node/V8: `    at fn (/abs/path/file.ts:123:45)`
+ *            `    at /abs/path/file.ts:123:45`
+ *   Browser: `fn@http://host/path/file.js:123:45`
+ *            `http://host/path/file.js:123:45`
+ *   Python:  `  File "/path/file.py", line 123, in fn`
+ *   Generic: any `file:line:column` or `file:line` inside the text.
+ *
+ * Frames are returned in the order they appear — the first frame is the
+ * top of the stack (where the error was thrown / re-raised last).
+ */
+export function parseStackTrace(text: string): StackFrame[] {
+  const frames: StackFrame[] = [];
+  const seen = new Set<string>();
+
+  const push = (f: StackFrame) => {
+    const key = `${f.file}:${f.line}:${f.column ?? ""}`;
+    if (seen.has(key)) return;
+    seen.add(key);
+    frames.push(f);
+  };
+
+  // Iterate line-by-line so we preserve stack order and keep per-frame regexes
+  // anchored (no cross-line bleed).
+  for (const line of text.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+
+    // Node/V8: `at fn (path:L:C)` or `at path:L:C`
+    const nodeParen = /^at\s+(.+?)\s+\((.+?):(\d+)(?::(\d+))?\)$/.exec(trimmed);
+    if (nodeParen) {
+      push({
+        raw: trimmed,
+        function: nodeParen[1] ?? null,
+        file: nodeParen[2] ?? "",
+        line: Number.parseInt(nodeParen[3] ?? "0", 10),
+        column: nodeParen[4] ? Number.parseInt(nodeParen[4], 10) : null,
+        language: "node",
+      });
+      continue;
+    }
+    const nodeBare = /^at\s+(.+?):(\d+)(?::(\d+))?$/.exec(trimmed);
+    if (nodeBare) {
+      push({
+        raw: trimmed,
+        function: null,
+        file: nodeBare[1] ?? "",
+        line: Number.parseInt(nodeBare[2] ?? "0", 10),
+        column: nodeBare[3] ? Number.parseInt(nodeBare[3], 10) : null,
+        language: "node",
+      });
+      continue;
+    }
+
+    // Python: `File "path", line N, in fn`
+    const py = /^File\s+"([^"]+)",\s+line\s+(\d+)(?:,\s+in\s+(.+))?$/.exec(
+      trimmed,
+    );
+    if (py) {
+      push({
+        raw: trimmed,
+        function: py[3] ?? null,
+        file: py[1] ?? "",
+        line: Number.parseInt(py[2] ?? "0", 10),
+        column: null,
+        language: "python",
+      });
+      continue;
+    }
+
+    // Browser: `fn@url:L:C` (Firefox/Safari format)
+    const browserAt = /^(.+?)@(.+?):(\d+)(?::(\d+))?$/.exec(trimmed);
+    if (browserAt && !browserAt[2]?.includes(" ")) {
+      push({
+        raw: trimmed,
+        function: browserAt[1] ?? null,
+        file: browserAt[2] ?? "",
+        line: Number.parseInt(browserAt[3] ?? "0", 10),
+        column: browserAt[4] ? Number.parseInt(browserAt[4], 10) : null,
+        language: "browser",
+      });
+      continue;
+    }
+
+    // Generic fallback: first `file:line:col` or `file:line` in the text.
+    const generic = /([^\s:()]+):(\d+)(?::(\d+))?/.exec(trimmed);
+    if (generic) {
+      const file = generic[1] ?? "";
+      // Skip bare numbers, URLs without paths, and obviously-non-code (e.g. timestamps).
+      if (file.length < 2 || /^\d+$/.test(file)) continue;
+      push({
+        raw: trimmed,
+        function: null,
+        file,
+        line: Number.parseInt(generic[2] ?? "0", 10),
+        column: generic[3] ? Number.parseInt(generic[3], 10) : null,
+        language: "generic",
+      });
+    }
+  }
+
+  return frames;
+}
+
+/**
+ * Resolve a parsed frame's `file` to an absolute path inside `workspace`.
+ * Handles:
+ *   - absolute paths inside the workspace → pass through
+ *   - workspace-relative paths → joined with workspace
+ *   - URL-form paths (http://host/a/b/file.ts) → strip scheme+host, try as relative
+ *
+ * Returns `null` for paths that resolve outside the workspace (security
+ * guard — we don't want to blame files outside the project root).
+ */
+export function resolveFrameFile(
+  workspace: string,
+  file: string,
+): string | null {
+  if (!file) return null;
+
+  // Strip URL scheme + host → treat as workspace-relative path (leading `/`
+  // from the URL path is stripped so it doesn't become root-absolute).
+  let candidate = file;
+  let wasUrl = false;
+  const urlMatch = /^[a-z]+:\/\/[^/]+\/(.*)$/i.exec(candidate);
+  if (urlMatch?.[1] !== undefined) {
+    candidate = urlMatch[1];
+    wasUrl = true;
+  }
+
+  // Strip webpack-style prefixes: "webpack://app/./src/..." → "src/..."
+  const webpack = /^webpack:\/\/[^/]*\/\.?\/?(.+)$/.exec(candidate);
+  if (webpack?.[1]) {
+    candidate = webpack[1];
+    wasUrl = true;
+  }
+
+  const absolute =
+    !wasUrl && path.isAbsolute(candidate)
+      ? candidate
+      : path.resolve(workspace, candidate);
+  const normalizedWorkspace = path.resolve(workspace) + path.sep;
+  const normalized = path.resolve(absolute);
+
+  if (
+    normalized !== path.resolve(workspace) &&
+    !normalized.startsWith(normalizedWorkspace)
+  ) {
+    return null;
+  }
+  return normalized;
+}

--- a/src/tools/watchDiagnostics.ts
+++ b/src/tools/watchDiagnostics.ts
@@ -1,25 +1,12 @@
-import { execFile } from "node:child_process";
-import { existsSync } from "node:fs";
-import { promisify } from "node:util";
 import type { ExtensionClient } from "../extensionClient.js";
 import { type FileUri, uriToAbsPath } from "../fp/brandedTypes.js";
 import type { ProbeResults } from "../probe.js";
 import type { ToolHandler } from "../transport.js";
+import { createBlameResolver } from "./blame-utils.js";
 import { biomeLinter } from "./linters/biome.js";
 
-const execFileAsync = promisify(execFile);
-
-const BLAME_CACHE_TTL_MS = 30_000;
-const BLAME_TIMEOUT_MS = 2_000;
 /** Maximum concurrent git-blame subprocesses per enrichDiagnostics call. */
 const BLAME_CONCURRENCY = 8;
-/** Maximum blame cache entries per tool instance before FIFO eviction. */
-const BLAME_CACHE_MAX_SIZE = 1_000;
-
-interface BlameEntry {
-  commitHash: string;
-  cachedAt: number;
-}
 
 interface DiagnosticHistory {
   firstSeenAt: number;
@@ -58,47 +45,8 @@ export function createWatchDiagnosticsTool(
   linterFilter?: string[],
 ) {
   // Per-instance blame cache — scoped to this tool instance to prevent
-  // cross-test pollution and allow independent TTL/size management.
-  const blameCache = new Map<string, BlameEntry>();
-
-  function evictBlameCache(): void {
-    if (blameCache.size <= BLAME_CACHE_MAX_SIZE) return;
-    // FIFO eviction: delete the oldest inserted key
-    const firstKey = blameCache.keys().next().value;
-    if (firstKey !== undefined) blameCache.delete(firstKey);
-  }
-
-  async function getIntroducedByCommit(
-    file: string,
-    line: number,
-  ): Promise<string | undefined> {
-    const key = `${file}:${line}`;
-    const cached = blameCache.get(key);
-    if (cached && Date.now() - cached.cachedAt < BLAME_CACHE_TTL_MS) {
-      return cached.commitHash;
-    }
-    // Skip subprocess for files that no longer exist on disk. Diagnostics can
-    // outlive their source file (rename, delete); spawning git blame for each
-    // is wasteful (one fork per stale diagnostic) and dominates cost when the
-    // cache is hot with dead files.
-    if (!existsSync(file)) return undefined;
-    try {
-      const { stdout } = await execFileAsync(
-        "git",
-        ["blame", "-L", `${line},${line}`, "--porcelain", "--", file],
-        { cwd: workspace, timeout: BLAME_TIMEOUT_MS },
-      );
-      const hash = stdout.slice(0, 40).trim();
-      if (/^[0-9a-f]{40}$/.test(hash) && !hash.startsWith("0000000")) {
-        blameCache.set(key, { commitHash: hash, cachedAt: Date.now() });
-        evictBlameCache();
-        return hash;
-      }
-    } catch {
-      // git not available, file not tracked, or timeout — silently omit
-    }
-    return undefined;
-  }
+  // cross-test pollution. Backed by the shared blame-utils helper.
+  const { getIntroducedByCommit } = createBlameResolver(workspace);
 
   // Per-instance diagnostic history: "file:line:message_prefix" → { firstSeenAt, recurrenceCount }
   // Capped to prevent unbounded growth in long-running sessions.


### PR DESCRIPTION
## Summary

Third piece of the Enrichment Engine. Given a stack trace (Node/V8, Python, Firefox/Safari, or generic `file:line:col` text), parses each frame, filters to files inside the workspace, and uses `git blame` to identify the commit that likely introduced each frame's code.

- **Output:** per-frame `{ file, line, commit }` + overall `topSuspect` + `confidence` (`high`/`medium`/`low`). Top frame = highest weight; confidence is `high` when ≥2 frames agree on the same commit, `medium` when only the top frame resolves, `low` when nothing in-workspace is blamed.
- **Fail-soft:** `gh` absence / non-git workspace / non-matching frames are reflected in output flags (`gitAvailable`, `framesBlamed`), never thrown.
- **Refactor:** shared `createBlameResolver` in `src/tools/blame-utils.ts` replaces the inline blame helper in `watchDiagnostics`. Same behavior (30s TTL, 2s subprocess timeout, 1k FIFO cache, stale-file guard) — watchDiagnostics tests still pass.
- **Parsers handled:** Node V8 `at fn (path:L:C)` / `at path:L:C`, Python `File "path", line N, in fn`, Firefox/Safari `fn@url:L:C`, generic `path:L:C` fallback.
- **Security:** frames resolving outside the workspace are flagged `inWorkspace: false` and skipped from blame (reuses the path-traversal guard pattern from existing tools).

## Test plan

- [x] 28 new tests (14 parser, 8 tool with tmp git repo, 6 blame-utils)
- [x] Full bridge suite: 3119/3119 passing (was 3091)
- [x] Biome/lint clean
- [x] `watchDiagnostics` tests unchanged — refactor didn't regress behavior
- [ ] Manual: paste a Sentry stack trace → tool points at introducing commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)