### PR TITLE
feat(enrichment): ctxQueryTraces — unified query + approval metadata …

### DIFF
--- a/src/approvalHttp.ts
+++ b/src/approvalHttp.ts
@@ -341,7 +341,17 @@ async function handleApprovalRequest(
   const sessionId =
     typeof body.sessionId === "string" ? body.sessionId : undefined;
 
-  const emit = (decision: string, reason: string) =>
+  // riskSignals are computed lazily — most short-circuit branches skip the
+  // cost by never calling computeRiskSignals. The queue-awaiting branch
+  // passes the already-computed signals via the optional arg.
+  const emit = (
+    decision: string,
+    reason: string,
+    extras?: {
+      riskSignals?: RiskSignal[];
+      callId?: string;
+    },
+  ) =>
     deps.onDecision?.("approval_decision", {
       toolName,
       specifier,
@@ -349,6 +359,12 @@ async function handleApprovalRequest(
       reason,
       permissionMode,
       sessionId,
+      ...(summary !== undefined && { summary }),
+      ...(extras?.riskSignals &&
+        extras.riskSignals.length > 0 && {
+          riskSignals: extras.riskSignals,
+        }),
+      ...(extras?.callId && { callId: extras.callId }),
     });
 
   if (!toolName) {
@@ -451,7 +467,10 @@ async function handleApprovalRequest(
   }
 
   const outcome = await promise;
-  emit(outcome === "approved" ? "allow" : "deny", outcome);
+  emit(outcome === "approved" ? "allow" : "deny", outcome, {
+    riskSignals,
+    callId,
+  });
   return {
     status: 200,
     body: {

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -392,6 +392,7 @@ export class Bridge {
         },
         () => this.extensionDisconnectCount,
         this.commitIssueLinkLog ?? undefined,
+        this.recipeRunLog ?? undefined,
       );
 
       transport.attach(ws);

--- a/src/tools/__tests__/ctxQueryTraces.test.ts
+++ b/src/tools/__tests__/ctxQueryTraces.test.ts
@@ -1,0 +1,203 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { ActivityLog } from "../../activityLog.js";
+import { CommitIssueLinkLog } from "../../commitIssueLinkLog.js";
+import { RecipeRunLog } from "../../runLog.js";
+import { createCtxQueryTracesTool } from "../ctxQueryTraces.js";
+
+let dir: string;
+let linkLog: CommitIssueLinkLog;
+let runLog: RecipeRunLog;
+let activityLog: ActivityLog;
+
+beforeEach(() => {
+  dir = mkdtempSync(path.join(os.tmpdir(), "ctx-query-traces-"));
+  linkLog = new CommitIssueLinkLog({ dir });
+  runLog = new RecipeRunLog({ dir });
+  activityLog = new ActivityLog({ logDir: dir, maxEntries: 100 });
+});
+afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+function parse(r: { content: Array<{ type: string; text: string }> }) {
+  return JSON.parse(r.content[0]?.text ?? "{}");
+}
+
+function seed() {
+  linkLog.record({
+    sha: "abc",
+    ref: "#42",
+    linkType: "closes",
+    resolved: true,
+    workspace: "/ws",
+    subject: "fix thing",
+    issueState: "OPEN",
+  });
+  runLog.record({
+    id: "task-1",
+    triggerSource: "cron:nightly",
+    status: "done",
+    createdAt: 1000,
+    startedAt: 1000,
+    doneAt: 1100,
+  });
+  activityLog.recordEvent("approval_decision", {
+    toolName: "gitPush",
+    decision: "deny",
+    reason: "cc_deny_rule",
+    sessionId: "s1",
+    summary: "push to main",
+  });
+}
+
+describe("ctxQueryTraces", () => {
+  it("returns traces from all three sources when no filter", async () => {
+    seed();
+    const tool = createCtxQueryTracesTool({
+      activityLog,
+      commitIssueLinkLog: linkLog,
+      recipeRunLog: runLog,
+    });
+    const res = parse(await tool.handler({}));
+    expect(res.count).toBe(3);
+    const types = res.traces.map((t: { traceType: string }) => t.traceType);
+    expect(types).toContain("approval");
+    expect(types).toContain("enrichment");
+    expect(types).toContain("recipe_run");
+  });
+
+  it("filters by traceType", async () => {
+    seed();
+    const tool = createCtxQueryTracesTool({
+      activityLog,
+      commitIssueLinkLog: linkLog,
+      recipeRunLog: runLog,
+    });
+    const res = parse(await tool.handler({ traceType: "approval" }));
+    expect(res.count).toBe(1);
+    expect(res.traces[0].traceType).toBe("approval");
+    expect(res.traces[0].key).toBe("s1:gitPush");
+    expect(res.traces[0].summary).toContain("deny");
+    expect(res.traces[0].body.summary).toBe("push to main");
+  });
+
+  it("filters by key substring", async () => {
+    linkLog.record({
+      sha: "aaa",
+      ref: "#1",
+      linkType: "closes",
+      resolved: true,
+      workspace: "/ws",
+    });
+    linkLog.record({
+      sha: "bbb",
+      ref: "#2",
+      linkType: "closes",
+      resolved: true,
+      workspace: "/ws",
+    });
+    const tool = createCtxQueryTracesTool({
+      activityLog: null,
+      commitIssueLinkLog: linkLog,
+      recipeRunLog: null,
+    });
+    const res = parse(await tool.handler({ key: "aaa:#1" }));
+    expect(res.count).toBe(1);
+    expect(res.traces[0].body.sha).toBe("aaa");
+  });
+
+  it("filters by since (ms epoch)", async () => {
+    seed();
+    // Recipe run has doneAt=1100. Approval + enrichment use Date.now / createdAt.
+    const tool = createCtxQueryTracesTool({
+      activityLog,
+      commitIssueLinkLog: linkLog,
+      recipeRunLog: runLog,
+    });
+    // Exclude recipe run (ts=1100) by filtering since=10000.
+    const res = parse(await tool.handler({ since: 10_000 }));
+    const types = res.traces.map((t: { traceType: string }) => t.traceType);
+    expect(types).not.toContain("recipe_run");
+  });
+
+  it("returns results newest-first", async () => {
+    seed();
+    const tool = createCtxQueryTracesTool({
+      activityLog,
+      commitIssueLinkLog: linkLog,
+      recipeRunLog: runLog,
+    });
+    const res = parse(await tool.handler({}));
+    for (let i = 1; i < res.traces.length; i += 1) {
+      expect(res.traces[i - 1].ts).toBeGreaterThanOrEqual(res.traces[i].ts);
+    }
+  });
+
+  it("reports source availability", async () => {
+    const tool = createCtxQueryTracesTool({
+      activityLog: null,
+      commitIssueLinkLog: linkLog,
+      recipeRunLog: null,
+    });
+    const res = parse(await tool.handler({}));
+    expect(res.sources).toEqual({
+      approval: false,
+      enrichment: true,
+      recipe_run: false,
+    });
+  });
+
+  it("respects limit", async () => {
+    for (let i = 0; i < 5; i += 1) {
+      linkLog.record({
+        sha: `sha${i}`,
+        ref: "#1",
+        linkType: "closes",
+        resolved: true,
+        workspace: "/ws",
+      });
+    }
+    const tool = createCtxQueryTracesTool({
+      activityLog: null,
+      commitIssueLinkLog: linkLog,
+      recipeRunLog: null,
+    });
+    const res = parse(await tool.handler({ limit: 2 }));
+    expect(res.count).toBe(2);
+  });
+
+  it("returns empty when no deps provided", async () => {
+    const tool = createCtxQueryTracesTool({
+      activityLog: null,
+      commitIssueLinkLog: null,
+      recipeRunLog: null,
+    });
+    const res = parse(await tool.handler({}));
+    expect(res.count).toBe(0);
+    expect(res.traces).toEqual([]);
+  });
+
+  it("captures riskSignals and callId from approval events", async () => {
+    activityLog.recordEvent("approval_decision", {
+      toolName: "Bash",
+      decision: "allow",
+      reason: "approved",
+      sessionId: "s2",
+      callId: "call-xyz",
+      summary: "rm tmpfile",
+      riskSignals: [
+        { kind: "destructive_flag", label: "rm flag", severity: "medium" },
+      ],
+    });
+    const tool = createCtxQueryTracesTool({
+      activityLog,
+      commitIssueLinkLog: null,
+      recipeRunLog: null,
+    });
+    const res = parse(await tool.handler({ traceType: "approval" }));
+    expect(res.traces[0].body.callId).toBe("call-xyz");
+    expect(res.traces[0].body.summary).toBe("rm tmpfile");
+    expect(res.traces[0].body.riskSignals).toHaveLength(1);
+  });
+});

--- a/src/tools/ctxQueryTraces.ts
+++ b/src/tools/ctxQueryTraces.ts
@@ -1,0 +1,210 @@
+import type { ActivityLog } from "../activityLog.js";
+import type { CommitIssueLinkLog } from "../commitIssueLinkLog.js";
+import type { RecipeRunLog } from "../runLog.js";
+import { optionalInt, optionalString, successStructured } from "./utils.js";
+
+/**
+ * Unified view over the persistent decision trails that already exist:
+ *   - approval decisions    (activityLog lifecycle rows, event = "approval_decision")
+ *   - enrichment links      (CommitIssueLinkLog)
+ *   - recipe runs           (RecipeRunLog)
+ *
+ * The three logs each have their own dedup / retention semantics, so we
+ * keep them as separate writers. This tool is the read layer — a single
+ * place to answer "why did X happen last Tuesday?" across trace types.
+ *
+ * Schema is intentionally narrow: `traceType` + universal fields
+ * (`ts`, `key`, `summary`) + the raw source row as `body`. Consumers that
+ * need richer per-type shapes can key on `traceType` and unwrap `body`.
+ */
+
+export type TraceType = "approval" | "enrichment" | "recipe_run";
+
+export interface DecisionTrace {
+  traceType: TraceType;
+  /** ms epoch when the trace was recorded. */
+  ts: number;
+  /**
+   * Natural key for dedup / join:
+   *   approval  → `<sessionId>:<toolName>` (or `anon:<toolName>` if no session)
+   *   enrichment → `<sha>:<ref>`
+   *   recipe_run → `<taskId>`
+   */
+  key: string;
+  /** Short human-readable summary for the dashboard / CLI. */
+  summary: string;
+  /** The original row as-persisted. */
+  body: Record<string, unknown>;
+}
+
+export interface CtxQueryTracesDeps {
+  recipeRunLog?: RecipeRunLog | null;
+  commitIssueLinkLog?: CommitIssueLinkLog | null;
+  activityLog?: ActivityLog | null;
+}
+
+function approvalTraces(activityLog: ActivityLog): DecisionTrace[] {
+  const out: DecisionTrace[] = [];
+  // queryTimeline returns combined tool+lifecycle; filter to approval rows.
+  // Use a generous `last` — the tool's own `limit` arg is applied after
+  // cross-source merge.
+  const timeline = activityLog.queryTimeline({ last: 500 });
+  for (const entry of timeline) {
+    if (entry.kind !== "lifecycle") continue;
+    const meta = (entry.metadata ?? {}) as Record<string, unknown>;
+    if (entry.event !== "approval_decision") continue;
+    const tool = typeof meta.toolName === "string" ? meta.toolName : "";
+    const decision = typeof meta.decision === "string" ? meta.decision : "";
+    const reason = typeof meta.reason === "string" ? meta.reason : "";
+    const sessionId =
+      typeof meta.sessionId === "string" ? meta.sessionId : "anon";
+    out.push({
+      traceType: "approval",
+      ts: Date.parse(entry.timestamp),
+      key: `${sessionId}:${tool || "unknown"}`,
+      summary: `${decision || "?"} ${tool || "?"}${reason ? ` (${reason})` : ""}`,
+      body: { ...meta, timestamp: entry.timestamp, id: entry.id },
+    });
+  }
+  return out;
+}
+
+function enrichmentTraces(log: CommitIssueLinkLog): DecisionTrace[] {
+  return log.query({ limit: 500 }).map((l) => ({
+    traceType: "enrichment",
+    ts: l.createdAt,
+    key: `${l.sha}:${l.ref}`,
+    summary: `${l.linkType} ${l.ref} ${
+      l.resolved ? "(resolved)" : `(unresolved: ${l.reason ?? "?"})`
+    }${l.subject ? ` — ${l.subject}` : ""}`,
+    body: l as unknown as Record<string, unknown>,
+  }));
+}
+
+function recipeRunTraces(log: RecipeRunLog): DecisionTrace[] {
+  return log.query({ limit: 500 }).map((r) => ({
+    traceType: "recipe_run",
+    ts: r.doneAt,
+    key: r.taskId,
+    summary: `${r.recipeName} (${r.trigger}) → ${r.status}${
+      r.errorMessage ? `: ${r.errorMessage}` : ""
+    }`,
+    body: r as unknown as Record<string, unknown>,
+  }));
+}
+
+export function createCtxQueryTracesTool(deps: CtxQueryTracesDeps) {
+  return {
+    schema: {
+      name: "ctxQueryTraces",
+      description:
+        "Unified query over approval / enrichment / recipe-run trails. Filter by traceType, time window, or natural key. Answers 'why did X happen' across sources.",
+      annotations: { readOnlyHint: true },
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          traceType: {
+            type: "string",
+            enum: ["approval", "enrichment", "recipe_run"],
+            description:
+              "Optional filter — restrict to one source. Omit to get all.",
+          },
+          key: {
+            type: "string",
+            description:
+              "Exact key match (sessionId:toolName / sha:ref / taskId). Substring match on the key; case-sensitive.",
+          },
+          since: {
+            type: "integer",
+            description: "Only return traces with ts > this ms-epoch value.",
+          },
+          limit: {
+            type: "integer",
+            minimum: 1,
+            maximum: 500,
+            description: "Max results after filtering. Default 100.",
+          },
+        },
+        additionalProperties: false as const,
+      },
+      outputSchema: {
+        type: "object" as const,
+        properties: {
+          traces: {
+            type: "array",
+            items: {
+              type: "object",
+              properties: {
+                traceType: {
+                  type: "string",
+                  enum: ["approval", "enrichment", "recipe_run"],
+                },
+                ts: { type: "integer" },
+                key: { type: "string" },
+                summary: { type: "string" },
+                body: { type: "object" },
+              },
+              required: ["traceType", "ts", "key", "summary", "body"],
+            },
+          },
+          count: { type: "integer" },
+          sources: {
+            type: "object",
+            properties: {
+              approval: { type: "boolean" },
+              enrichment: { type: "boolean" },
+              recipe_run: { type: "boolean" },
+            },
+          },
+        },
+        required: ["traces", "count", "sources"],
+      },
+    },
+    timeoutMs: 5_000,
+    async handler(args: Record<string, unknown>) {
+      const traceType = optionalString(args, "traceType") as
+        | TraceType
+        | undefined
+        | "";
+      const keyFilter = optionalString(args, "key");
+      const since = optionalInt(args, "since", 0, Number.MAX_SAFE_INTEGER);
+      const limit = optionalInt(args, "limit", 1, 500) ?? 100;
+
+      const sources = {
+        approval: Boolean(deps.activityLog),
+        enrichment: Boolean(deps.commitIssueLinkLog),
+        recipe_run: Boolean(deps.recipeRunLog),
+      };
+
+      const pools: DecisionTrace[] = [];
+      if ((!traceType || traceType === "approval") && deps.activityLog) {
+        pools.push(...approvalTraces(deps.activityLog));
+      }
+      if (
+        (!traceType || traceType === "enrichment") &&
+        deps.commitIssueLinkLog
+      ) {
+        pools.push(...enrichmentTraces(deps.commitIssueLinkLog));
+      }
+      if ((!traceType || traceType === "recipe_run") && deps.recipeRunLog) {
+        pools.push(...recipeRunTraces(deps.recipeRunLog));
+      }
+
+      let filtered = pools;
+      if (since !== undefined) filtered = filtered.filter((t) => t.ts > since);
+      if (keyFilter) {
+        const needle = keyFilter;
+        filtered = filtered.filter((t) => t.key.includes(needle));
+      }
+
+      filtered.sort((a, b) => b.ts - a.ts);
+      const traces = filtered.slice(0, limit);
+
+      return successStructured({
+        traces,
+        count: traces.length,
+        sources,
+      });
+    },
+  };
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -29,6 +29,7 @@ import { createCloseAllDiffTabsTool, createCloseTabTool } from "./closeTabs.js";
 import { createGetCodeLensTool } from "./codeLens.js";
 import { createContextBundleTool } from "./contextBundle.js";
 import { createCreateIssueFromAICommentTool } from "./createIssueFromAIComment.js";
+import { createCtxQueryTracesTool } from "./ctxQueryTraces.js";
 import {
   createEvaluateInDebuggerTool,
   createSetDebugBreakpointsTool,
@@ -324,6 +325,7 @@ export function registerAllTools(
   onContextCacheUpdated?: (generatedAt: string) => void,
   getExtensionDisconnectCount?: () => number,
   commitIssueLinkLog?: import("../commitIssueLinkLog.js").CommitIssueLinkLog,
+  recipeRunLog?: import("../runLog.js").RecipeRunLog,
 ): void {
   const workspace = config.workspace;
   const workspaceFolders = config.workspaceFolders;
@@ -650,6 +652,11 @@ export function registerAllTools(
     createGetPRTemplateTool(workspace),
     createEnrichCommitTool(workspace, commitIssueLinkLog),
     createEnrichStackTraceTool(workspace),
+    createCtxQueryTracesTool({
+      activityLog: activityLog ?? null,
+      commitIssueLinkLog: commitIssueLinkLog ?? null,
+      recipeRunLog: recipeRunLog ?? null,
+    }),
     ...(commitIssueLinkLog
       ? [createGetCommitsForIssueTool(workspace, commitIssueLinkLog)]
       : []),


### PR DESCRIPTION
…capture

Decision-trace query layer (Phase 3 moat step). One tool that reads all three existing persistent trails:
- approval decisions  (activityLog lifecycle rows)
- enrichment links    (CommitIssueLinkLog)
- recipe runs         (RecipeRunLog)

Schema: traceType discriminator + universal {ts, key, summary} + raw body. Filter by traceType, key substring, since (ms epoch), limit. Sorted newest-first.

Also fixes a metadata-drop bug: approvalHttp.emit previously recorded approval_decision events without summary / riskSignals / callId — those were computed but never persisted, so the activity log couldn't answer "why did we approve this, and what was the user-visible summary". Now captured on the queue-path decision.

No new log. No SQLite. Reuses the three JSONL / in-memory writers (each with its own dedup + retention). Per research report, this is the right MVP shape — defer unified write-layer until query volume proves need.

10 new tests. 3128/3128 total.