### PR TITLE
feat(dashboard): /traces page — unified decision trail UI

### DIFF
--- a/dashboard/src/app/traces/page.tsx
+++ b/dashboard/src/app/traces/page.tsx
@@ -90,17 +90,31 @@ export default function TracesPage() {
         }}
       >
         <div style={{ display: "flex", gap: "var(--s-2)" }}>
-          {(["all", "approval", "enrichment", "recipe_run"] as const).map((f) => (
-            <button
-              type="button"
-              key={f}
-              onClick={() => setFilter(f)}
-              className={filter === f ? "pill" : "pill muted"}
-              style={{ cursor: "pointer", textTransform: "capitalize" }}
-            >
-              {f === "all" ? "All" : TYPE_LABELS[f as TraceType]}
-            </button>
-          ))}
+          {(["all", "approval", "enrichment", "recipe_run"] as const).map(
+            (f) => {
+              const active = filter === f;
+              return (
+                <button
+                  type="button"
+                  key={f}
+                  onClick={() => setFilter(f)}
+                  className={active ? "pill" : "pill muted"}
+                  style={{
+                    cursor: "pointer",
+                    textTransform: "capitalize",
+                    ...(active && {
+                      background: "var(--accent, #8b5cf6)",
+                      color: "var(--bg-0, #0a0a0a)",
+                      borderColor: "var(--accent, #8b5cf6)",
+                      fontWeight: 600,
+                    }),
+                  }}
+                >
+                  {f === "all" ? "All" : TYPE_LABELS[f as TraceType]}
+                </button>
+              );
+            },
+          )}
         </div>
         <input
           type="text"
@@ -141,10 +155,15 @@ export default function TracesPage() {
 
       {!loading && traces.length === 0 && !error ? (
         <div className="empty-state">
-          <h3>No traces yet</h3>
+          <h3>
+            {filter === "all" && !keyQuery
+              ? "No traces yet"
+              : "No matching traces"}
+          </h3>
           <p>
-            Traces will appear once the bridge records approval decisions,
-            enrichment links, or recipe runs.
+            {filter === "all" && !keyQuery
+              ? "Traces will appear once the bridge records approval decisions, enrichment links, or recipe runs."
+              : `No ${filter === "all" ? "traces" : TYPE_LABELS[filter as TraceType].toLowerCase()} traces${keyQuery ? ` matching "${keyQuery}"` : ""}.`}
           </p>
         </div>
       ) : (

--- a/dashboard/src/app/traces/page.tsx
+++ b/dashboard/src/app/traces/page.tsx
@@ -1,0 +1,247 @@
+"use client";
+import { useMemo, useState } from "react";
+import { relTime } from "@/components/time";
+import { useBridgeFetch } from "@/hooks/useBridgeFetch";
+
+type TraceType = "approval" | "enrichment" | "recipe_run";
+
+interface DecisionTrace {
+  traceType: TraceType;
+  ts: number;
+  key: string;
+  summary: string;
+  body: Record<string, unknown>;
+}
+
+interface TracesResponse {
+  traces: DecisionTrace[];
+  count: number;
+  sources: {
+    approval: boolean;
+    enrichment: boolean;
+    recipe_run: boolean;
+  };
+}
+
+const TYPE_LABELS: Record<TraceType, string> = {
+  approval: "Approval",
+  enrichment: "Enrichment",
+  recipe_run: "Recipe run",
+};
+
+const TYPE_COLORS: Record<TraceType, string> = {
+  approval: "var(--warn, #d97706)",
+  enrichment: "var(--ok, #059669)",
+  recipe_run: "var(--fg-2)",
+};
+
+export default function TracesPage() {
+  const [filter, setFilter] = useState<TraceType | "all">("all");
+  const [keyQuery, setKeyQuery] = useState("");
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+
+  const qs = useMemo(() => {
+    const params = new URLSearchParams();
+    if (filter !== "all") params.set("traceType", filter);
+    if (keyQuery.trim()) params.set("key", keyQuery.trim());
+    params.set("limit", "200");
+    const s = params.toString();
+    return s ? `?${s}` : "";
+  }, [filter, keyQuery]);
+
+  const { data, error, loading } = useBridgeFetch<TracesResponse>(
+    `/api/bridge/traces${qs}`,
+    { intervalMs: 3000 },
+  );
+
+  const traces = data?.traces ?? [];
+  const sources = data?.sources;
+
+  const toggle = (rowKey: string) => {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(rowKey)) next.delete(rowKey);
+      else next.add(rowKey);
+      return next;
+    });
+  };
+
+  return (
+    <section>
+      <div className="page-head">
+        <div>
+          <h1>Traces</h1>
+          <div className="page-head-sub">
+            Unified decision trail — approvals, enrichment links, recipe runs.
+          </div>
+        </div>
+        <span className="pill muted">
+          {traces.length} trace{traces.length !== 1 ? "s" : ""}
+        </span>
+      </div>
+
+      <div
+        style={{
+          display: "flex",
+          gap: "var(--s-3)",
+          marginBottom: "var(--s-4)",
+          flexWrap: "wrap",
+          alignItems: "center",
+        }}
+      >
+        <div style={{ display: "flex", gap: "var(--s-2)" }}>
+          {(["all", "approval", "enrichment", "recipe_run"] as const).map((f) => (
+            <button
+              type="button"
+              key={f}
+              onClick={() => setFilter(f)}
+              className={filter === f ? "pill" : "pill muted"}
+              style={{ cursor: "pointer", textTransform: "capitalize" }}
+            >
+              {f === "all" ? "All" : TYPE_LABELS[f as TraceType]}
+            </button>
+          ))}
+        </div>
+        <input
+          type="text"
+          value={keyQuery}
+          onChange={(e) => setKeyQuery(e.target.value)}
+          placeholder="filter by key (sessionId, sha, taskId…)"
+          style={{
+            flex: 1,
+            minWidth: 240,
+            padding: "6px 10px",
+            fontSize: 13,
+            fontFamily: "var(--font-mono)",
+            background: "var(--bg-2)",
+            border: "1px solid var(--bg-3)",
+            borderRadius: 4,
+            color: "var(--fg-0)",
+          }}
+        />
+      </div>
+
+      {sources && (
+        <div
+          style={{
+            fontSize: 12,
+            color: "var(--fg-3)",
+            marginBottom: "var(--s-3)",
+          }}
+        >
+          Sources:{" "}
+          {(Object.entries(sources) as [TraceType, boolean][])
+            .filter(([, avail]) => avail)
+            .map(([t]) => TYPE_LABELS[t])
+            .join(" · ") || "none available"}
+        </div>
+      )}
+
+      {error && <div className="alert-err">Unreachable: {error}</div>}
+
+      {!loading && traces.length === 0 && !error ? (
+        <div className="empty-state">
+          <h3>No traces yet</h3>
+          <p>
+            Traces will appear once the bridge records approval decisions,
+            enrichment links, or recipe runs.
+          </p>
+        </div>
+      ) : (
+        <div style={{ display: "flex", flexDirection: "column", gap: "var(--s-2)" }}>
+          {traces.map((t) => {
+            const rowKey = `${t.traceType}:${t.ts}:${t.key}`;
+            const isOpen = expanded.has(rowKey);
+            return (
+              <div
+                key={rowKey}
+                className="card"
+                style={{ padding: "var(--s-3)" }}
+              >
+                <button
+                  type="button"
+                  onClick={() => toggle(rowKey)}
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: "var(--s-3)",
+                    width: "100%",
+                    background: "transparent",
+                    border: "none",
+                    padding: 0,
+                    cursor: "pointer",
+                    textAlign: "left",
+                    color: "inherit",
+                  }}
+                >
+                  <span
+                    style={{
+                      fontSize: 11,
+                      padding: "2px 6px",
+                      borderRadius: 3,
+                      color: TYPE_COLORS[t.traceType],
+                      border: `1px solid ${TYPE_COLORS[t.traceType]}`,
+                      textTransform: "uppercase",
+                      letterSpacing: 0.5,
+                      flexShrink: 0,
+                    }}
+                  >
+                    {TYPE_LABELS[t.traceType]}
+                  </span>
+                  <span
+                    style={{
+                      fontFamily: "var(--font-mono)",
+                      fontSize: 12,
+                      color: "var(--fg-2)",
+                      flexShrink: 0,
+                    }}
+                  >
+                    {t.key}
+                  </span>
+                  <span
+                    style={{
+                      flex: 1,
+                      fontSize: 13,
+                      color: "var(--fg-1)",
+                      whiteSpace: "nowrap",
+                      overflow: "hidden",
+                      textOverflow: "ellipsis",
+                    }}
+                  >
+                    {t.summary}
+                  </span>
+                  <span
+                    style={{
+                      fontSize: 12,
+                      color: "var(--fg-3)",
+                      flexShrink: 0,
+                    }}
+                  >
+                    {relTime(t.ts)}
+                  </span>
+                </button>
+                {isOpen && (
+                  <pre
+                    style={{
+                      marginTop: "var(--s-3)",
+                      padding: "var(--s-3)",
+                      background: "var(--bg-2)",
+                      borderRadius: 4,
+                      fontSize: 12,
+                      fontFamily: "var(--font-mono)",
+                      overflow: "auto",
+                      whiteSpace: "pre-wrap",
+                      wordBreak: "break-word",
+                    }}
+                  >
+                    {JSON.stringify(t.body, null, 2)}
+                  </pre>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/dashboard/src/components/Shell.tsx
+++ b/dashboard/src/components/Shell.tsx
@@ -14,6 +14,7 @@ const NAV: { href: string; label: string; icon: string }[] = [
   { href: "/analytics", label: "Analytics", icon: "\u25CE" },
   { href: "/recipes", label: "Recipes", icon: "\u25C9" },
   { href: "/runs", label: "Runs", icon: "\u29D6" },
+  { href: "/traces", label: "Traces", icon: "\u25C7" },
   { href: "/settings", label: "Settings", icon: "\u2699" },
 ];
 

--- a/src/__tests__/server-traces.test.ts
+++ b/src/__tests__/server-traces.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Integration tests for GET /traces — the HTTP surface that backs the
+ * dashboard Traces page. Uses a stub tracesFn so the server logic is
+ * tested independently of ctxQueryTraces internals (those have their
+ * own unit tests).
+ */
+import http from "node:http";
+import { afterEach, describe, expect, it } from "vitest";
+import { Logger } from "../logger.js";
+import { Server } from "../server.js";
+
+const logger = new Logger(false);
+const TOKEN = "test-traces-token-00000000000000";
+
+let server: Server | null = null;
+let port = 0;
+
+async function startServer(
+  tracesFn?: (q: {
+    traceType?: string;
+    key?: string;
+    since?: number;
+    limit?: number;
+  }) => Promise<Record<string, unknown>>,
+): Promise<void> {
+  server = new Server(TOKEN, logger);
+  if (tracesFn) server.tracesFn = tracesFn;
+  port = await server.findAndListen(null);
+}
+
+afterEach(async () => {
+  await server?.close();
+  server = null;
+  port = 0;
+});
+
+function get(path: string): Promise<{ status: number; body: string }> {
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      {
+        hostname: "127.0.0.1",
+        port,
+        method: "GET",
+        path,
+        headers: { Authorization: `Bearer ${TOKEN}` },
+      },
+      (res) => {
+        let data = "";
+        res.on("data", (c) => (data += c));
+        res.on("end", () =>
+          resolve({ status: res.statusCode ?? 0, body: data }),
+        );
+      },
+    );
+    req.on("error", reject);
+    req.end();
+  });
+}
+
+describe("GET /traces", () => {
+  it("returns empty default when tracesFn is not wired", async () => {
+    await startServer();
+    const { status, body } = await get("/traces");
+    expect(status).toBe(200);
+    const parsed = JSON.parse(body);
+    expect(parsed.traces).toEqual([]);
+    expect(parsed.count).toBe(0);
+    expect(parsed.sources).toEqual({
+      approval: false,
+      enrichment: false,
+      recipe_run: false,
+    });
+    expect(parsed.hint).toMatch(/not wired/i);
+  });
+
+  it("passes through query results from tracesFn", async () => {
+    await startServer(async () => ({
+      traces: [
+        {
+          traceType: "approval",
+          ts: 1000,
+          key: "s1:Bash",
+          summary: "allow Bash",
+          body: { toolName: "Bash" },
+        },
+      ],
+      count: 1,
+      sources: { approval: true, enrichment: false, recipe_run: false },
+    }));
+    const { status, body } = await get("/traces");
+    expect(status).toBe(200);
+    const parsed = JSON.parse(body);
+    expect(parsed.count).toBe(1);
+    expect(parsed.traces[0].key).toBe("s1:Bash");
+  });
+
+  it("parses query string into tracesFn args", async () => {
+    const received: Array<Record<string, unknown>> = [];
+    await startServer(async (q) => {
+      received.push(q);
+      return { traces: [], count: 0, sources: {} };
+    });
+    await get(
+      "/traces?traceType=enrichment&key=abc&since=1700000000000&limit=25",
+    );
+    expect(received[0]).toEqual({
+      traceType: "enrichment",
+      key: "abc",
+      since: 1_700_000_000_000,
+      limit: 25,
+    });
+  });
+
+  it("ignores non-numeric since / limit values", async () => {
+    const received: Array<Record<string, unknown>> = [];
+    await startServer(async (q) => {
+      received.push(q);
+      return { traces: [], count: 0, sources: {} };
+    });
+    await get("/traces?since=abc&limit=xyz");
+    expect(received[0]?.since).toBeUndefined();
+    expect(received[0]?.limit).toBeUndefined();
+  });
+
+  it("returns 500 when tracesFn throws", async () => {
+    await startServer(async () => {
+      throw new Error("backend on fire");
+    });
+    const { status, body } = await get("/traces");
+    expect(status).toBe(500);
+    const parsed = JSON.parse(body);
+    expect(parsed.error).toContain("backend on fire");
+  });
+
+  it("requires auth", async () => {
+    await startServer(async () => ({ traces: [], count: 0, sources: {} }));
+    const req = new Promise<number>((resolve, reject) => {
+      const r = http.request(
+        {
+          hostname: "127.0.0.1",
+          port,
+          method: "GET",
+          path: "/traces",
+        },
+        (res) => resolve(res.statusCode ?? 0),
+      );
+      r.on("error", reject);
+      r.end();
+    });
+    expect(await req).toBe(401);
+  });
+});

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -40,6 +40,7 @@ import { Server } from "./server.js";
 import { type CheckpointData, SessionCheckpoint } from "./sessionCheckpoint.js";
 import { StreamableHttpHandler } from "./streamableHttp.js";
 import { initTelemetry, shutdownTelemetry } from "./telemetry.js";
+import { createCtxQueryTracesTool } from "./tools/ctxQueryTraces.js";
 import { readNote, writeNote } from "./tools/handoffNote.js";
 import { registerAllTools } from "./tools/index.js";
 import { cleanupTempDirs } from "./tools/openDiff.js";
@@ -1041,6 +1042,33 @@ export class Bridge {
         latency: { perTool, overallP95Ms },
         health: { score, signals },
       };
+    };
+    this.server.tracesFn = async (query) => {
+      const tool = createCtxQueryTracesTool({
+        activityLog: this.activityLog,
+        commitIssueLinkLog: this.commitIssueLinkLog,
+        recipeRunLog: this.recipeRunLog,
+      });
+      const result = await tool.handler({
+        ...(query.traceType && { traceType: query.traceType }),
+        ...(query.key && { key: query.key }),
+        ...(query.since !== undefined && { since: query.since }),
+        ...(query.limit !== undefined && { limit: query.limit }),
+      });
+      const structured = (result as { structuredContent?: unknown })
+        .structuredContent;
+      if (structured && typeof structured === "object") {
+        return structured as Record<string, unknown>;
+      }
+      const text = result.content[0]?.text;
+      if (typeof text === "string") {
+        try {
+          return JSON.parse(text);
+        } catch {
+          return { traces: [], count: 0 };
+        }
+      }
+      return { traces: [], count: 0 };
     };
     this.server.analyticsFn = async (windowHours?: number) => {
       const wh =

--- a/src/server.ts
+++ b/src/server.ts
@@ -185,6 +185,15 @@ export class Server extends EventEmitter<ServerEvents> {
   public analyticsFn:
     | ((windowHours?: number) => Promise<Record<string, unknown>>)
     | null = null;
+  /** Set by bridge to answer GET /traces via ctxQueryTraces over persistent logs. */
+  public tracesFn:
+    | ((query: {
+        traceType?: string;
+        key?: string;
+        since?: number;
+        limit?: number;
+      }) => Promise<Record<string, unknown>>)
+    | null = null;
   /** Set by bridge to handle CC hook notify events via POST /notify */
   public notifyFn:
     | ((
@@ -541,6 +550,46 @@ export class Server extends EventEmitter<ServerEvents> {
             connections: this.wss.clients.size,
             ...(this.healthDataFn?.() ?? {}),
           };
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(JSON.stringify(data));
+        } catch (err) {
+          res.writeHead(500, { "Content-Type": "application/json" });
+          res.end(
+            JSON.stringify({
+              error: err instanceof Error ? err.message : String(err),
+            }),
+          );
+        }
+        return;
+      }
+      if (parsedUrl.pathname === "/traces" && req.method === "GET") {
+        try {
+          const q = parsedUrl.searchParams;
+          const sinceStr = q.get("since");
+          const limitStr = q.get("limit");
+          const data = this.tracesFn
+            ? await this.tracesFn({
+                traceType: q.get("traceType") ?? undefined,
+                key: q.get("key") ?? undefined,
+                since:
+                  sinceStr !== null && /^\d+$/.test(sinceStr)
+                    ? Number(sinceStr)
+                    : undefined,
+                limit:
+                  limitStr !== null && /^\d+$/.test(limitStr)
+                    ? Number(limitStr)
+                    : undefined,
+              })
+            : {
+                traces: [],
+                count: 0,
+                sources: {
+                  approval: false,
+                  enrichment: false,
+                  recipe_run: false,
+                },
+                hint: "Trace sources not wired yet.",
+              };
           res.writeHead(200, { "Content-Type": "application/json" });
           res.end(JSON.stringify(data));
         } catch (err) {


### PR DESCRIPTION
## Summary

Surface \`ctxQueryTraces\` in the dashboard. The query layer shipped in #11, but without a UI only MCP-tool callers could see the decision trail. Now the human-facing surface:

- **GET /traces HTTP endpoint** (\`src/server.ts\`) — parses \`traceType\` / \`key\` / \`since\` / \`limit\` query params, forwards to an injected \`tracesFn\`, returns \`{traces, count, sources}\`. 500 on throw; auth-gated like every other endpoint; empty default when \`tracesFn\` is not wired (headless / early-init states).
- **Bridge wiring** (\`src/bridge.ts\`) — \`tracesFn\` calls \`createCtxQueryTracesTool\` with activityLog / commitIssueLinkLog / recipeRunLog deps, unwraps \`structuredContent\`.
- **Dashboard /traces page** — filter tabs (all / approval / enrichment / recipe_run), key substring search, click-to-expand body JSON. Polls every 3s via \`useBridgeFetch\`. New Shell nav entry.

Follows the \`/analytics\` and \`/sessions\` patterns — no new hooks, no new infra, no MCP client in the dashboard.

## Test plan

- [x] 6 new server integration tests — empty default, pass-through, query parsing, numeric-validation guards, 500-on-throw, auth required
- [x] Full bridge suite: 3134/3134 passing (was 3128)
- [x] Lint clean
- [ ] Manual: run the bridge + dashboard, trigger an approval / recipe / enrichment, confirm they appear in \`/traces\` with filters working

🤖 Generated with [Claude Code](https://claude.com/claude-code)