### PR TITLE
feat(traces): inject recent-decisions digest into session instructions

### DIFF
--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -44,6 +44,7 @@ import { createCtxQueryTracesTool } from "./tools/ctxQueryTraces.js";
 import { readNote, writeNote } from "./tools/handoffNote.js";
 import { registerAllTools } from "./tools/index.js";
 import { cleanupTempDirs } from "./tools/openDiff.js";
+import { buildRecentTracesDigest } from "./tools/recentTracesDigest.js";
 import { resolveFilePath } from "./tools/utils.js";
 import { McpTransport } from "./transport.js";
 import { PACKAGE_VERSION } from "./version.js";
@@ -139,6 +140,8 @@ export class Bridge {
   private recipeScheduler: RecipeScheduler | null = null;
   private recipeRunLog: RecipeRunLog | null = null;
   private commitIssueLinkLog: CommitIssueLinkLog | null = null;
+  /** Pre-computed digest of recent decisions, refreshed on each session connect. */
+  private recentTracesDigest: string[] = [];
   private httpMcpHandler: StreamableHttpHandler | null = null;
   private oauthServer: OAuthServerImpl | null = null;
   /** Incremented each time the VS Code extension (re)connects — guards stale async callbacks. */
@@ -301,6 +304,10 @@ export class Bridge {
       transport.setExtensionConnectedFn(() =>
         this.extensionClient.isConnected(),
       );
+      // Refresh trace digest before every session's first instruction read.
+      // Fire-and-forget — if it's slow (shouldn't be; local file + memory),
+      // the session just sees the previous digest. Never blocks connect.
+      this.refreshRecentTracesDigest();
       transport.setInstructions(this.buildInstructions());
       transport.onInitialized = () => {
         if (this.pendingListChanged && ws.readyState === WebSocket.OPEN) {
@@ -731,6 +738,10 @@ export class Bridge {
   private buildInstructions(): string {
     const lines = [`claude-ide-bridge v${PACKAGE_VERSION}`];
     lines.push("");
+    if (this.recentTracesDigest.length > 0) {
+      lines.push(...this.recentTracesDigest);
+      lines.push("");
+    }
     lines.push("CONTEXT PLATFORM:");
     lines.push(
       "  Use ctx tools for issue/PR/error context — not gh or githubViewPR.",
@@ -745,6 +756,22 @@ export class Bridge {
     lines.push("");
     lines.push(...buildEnforcementReminder());
     return lines.join("\n");
+  }
+
+  private refreshRecentTracesDigest(): void {
+    buildRecentTracesDigest({
+      activityLog: this.activityLog,
+      commitIssueLinkLog: this.commitIssueLinkLog,
+      recipeRunLog: this.recipeRunLog,
+    })
+      .then((lines) => {
+        this.recentTracesDigest = lines;
+      })
+      .catch((err) => {
+        this.logger.warn?.(
+          `[traces-digest] refresh failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      });
   }
 
   private cleanupSession(id: string): void {

--- a/src/tools/__tests__/recentTracesDigest.test.ts
+++ b/src/tools/__tests__/recentTracesDigest.test.ts
@@ -1,0 +1,211 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { ActivityLog } from "../../activityLog.js";
+import { CommitIssueLinkLog } from "../../commitIssueLinkLog.js";
+import { RecipeRunLog } from "../../runLog.js";
+import { buildRecentTracesDigest } from "../recentTracesDigest.js";
+
+let dir: string;
+let linkLog: CommitIssueLinkLog;
+let runLog: RecipeRunLog;
+let activityLog: ActivityLog;
+
+beforeEach(() => {
+  dir = mkdtempSync(path.join(os.tmpdir(), "recent-traces-digest-"));
+  linkLog = new CommitIssueLinkLog({ dir });
+  runLog = new RecipeRunLog({ dir });
+  activityLog = new ActivityLog({ logDir: dir, maxEntries: 100 });
+});
+afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+describe("buildRecentTracesDigest", () => {
+  it("returns empty array when no sources are wired", async () => {
+    const lines = await buildRecentTracesDigest({});
+    expect(lines).toEqual([]);
+  });
+
+  it("returns empty array when sources are empty", async () => {
+    const lines = await buildRecentTracesDigest({
+      activityLog,
+      commitIssueLinkLog: linkLog,
+      recipeRunLog: runLog,
+    });
+    expect(lines).toEqual([]);
+  });
+
+  it("emits heading + bullet for a single approval trace", async () => {
+    activityLog.recordEvent("approval_decision", {
+      toolName: "gitPush",
+      decision: "deny",
+      reason: "cc_deny_rule",
+      sessionId: "s1",
+    });
+    // activityLog uses Date.now() via recordEvent; use the real clock as `now`.
+    const lines = await buildRecentTracesDigest({ activityLog });
+    expect(lines[0]).toBe("RECENT DECISIONS (last 12h):");
+    expect(lines.length).toBe(2);
+    expect(lines[1]).toMatch(/deny gitPush.*cc_deny_rule.*ago/);
+  });
+
+  it("renders different icons per traceType", async () => {
+    const now = Date.now();
+    activityLog.recordEvent("approval_decision", {
+      toolName: "A",
+      decision: "allow",
+      reason: "ok",
+      sessionId: "s1",
+    });
+    linkLog.record({
+      sha: "aaa",
+      ref: "#1",
+      linkType: "closes",
+      resolved: true,
+      workspace: "/ws",
+    });
+    runLog.record({
+      id: "task-1",
+      triggerSource: "cron:nightly",
+      status: "done",
+      createdAt: now - 1_000,
+      doneAt: now,
+    });
+
+    const lines = await buildRecentTracesDigest({
+      activityLog,
+      commitIssueLinkLog: linkLog,
+      recipeRunLog: runLog,
+    });
+    const joined = lines.join("\n");
+    expect(joined).toContain("•"); // approval icon
+    expect(joined).toContain("⇄"); // enrichment icon
+    expect(joined).toContain("▸"); // recipe_run icon
+  });
+
+  it("honors windowMs — traces older than window are excluded", async () => {
+    const now = 10 * 60 * 60 * 1000; // 10h in epoch
+    // Record a trace that will appear at "now - 15h" — outside 12h window
+    linkLog.record({
+      sha: "old",
+      ref: "#1",
+      linkType: "closes",
+      resolved: true,
+      workspace: "/ws",
+    });
+    // Simulate the link being 15h old by overriding the recorded `createdAt`
+    // via in-memory mutation (simplest route; query uses the field directly).
+    // biome-ignore lint/suspicious/noExplicitAny: internal test access
+    (linkLog as any).links[0].createdAt = now - 15 * 60 * 60 * 1000;
+
+    const lines = await buildRecentTracesDigest(
+      { commitIssueLinkLog: linkLog },
+      { now },
+    );
+    expect(lines).toEqual([]);
+  });
+
+  it("caps at topN entries", async () => {
+    for (let i = 0; i < 10; i += 1) {
+      linkLog.record({
+        sha: `sha${i}`,
+        ref: "#1",
+        linkType: "closes",
+        resolved: true,
+        workspace: "/ws",
+      });
+    }
+    const lines = await buildRecentTracesDigest(
+      { commitIssueLinkLog: linkLog },
+      { topN: 3 },
+    );
+    // 1 heading + 3 bullets
+    expect(lines.length).toBe(4);
+  });
+
+  it("truncates summaries over 80 chars", async () => {
+    const now = Date.now();
+    runLog.record({
+      id: "task-long",
+      triggerSource: "recipe:very-long-recipe-name-that-exceeds-expectations",
+      status: "error",
+      createdAt: now - 1_000,
+      doneAt: now,
+      errorMessage: "x".repeat(200),
+    });
+    const lines = await buildRecentTracesDigest({ recipeRunLog: runLog });
+    const bullet = lines[1] ?? "";
+    expect(bullet).toContain("…"); // truncation marker present
+    // The rendered summary (between icon and "— Ns ago") must be ≤80 chars.
+    const summaryMatch = bullet.match(/^ {2}. (.+) — \d+[smhd] ago$/);
+    expect(summaryMatch).not.toBeNull();
+    expect((summaryMatch?.[1] ?? "").length).toBeLessThanOrEqual(80);
+  });
+
+  it("formats relative times correctly", async () => {
+    const now = 1_000_000_000_000;
+    linkLog.record({
+      sha: "a",
+      ref: "#1",
+      linkType: "closes",
+      resolved: true,
+      workspace: "/ws",
+    });
+    // biome-ignore lint/suspicious/noExplicitAny: internal test access
+    (linkLog as any).links[0].createdAt = now - 2 * 60 * 60 * 1000;
+
+    const lines = await buildRecentTracesDigest(
+      { commitIssueLinkLog: linkLog },
+      { now },
+    );
+    expect(lines[1]).toContain("2h ago");
+  });
+
+  it("orders newest-first", async () => {
+    const now = 1_000_000_000_000;
+    linkLog.record({
+      sha: "older",
+      ref: "#1",
+      linkType: "closes",
+      resolved: true,
+      workspace: "/ws",
+    });
+    linkLog.record({
+      sha: "newer",
+      ref: "#2",
+      linkType: "closes",
+      resolved: true,
+      workspace: "/ws",
+    });
+    // biome-ignore lint/suspicious/noExplicitAny: internal test access
+    (linkLog as any).links[0].createdAt = now - 3 * 60 * 60 * 1000;
+    // biome-ignore lint/suspicious/noExplicitAny: internal test access
+    (linkLog as any).links[1].createdAt = now - 1 * 60 * 60 * 1000;
+
+    const lines = await buildRecentTracesDigest(
+      { commitIssueLinkLog: linkLog },
+      { now },
+    );
+    expect(lines[1]).toContain("#2");
+    expect(lines[2]).toContain("#1");
+  });
+
+  it("enforces hard byte cap", async () => {
+    // Record enough traces to exceed 2KB when formatted
+    for (let i = 0; i < 50; i += 1) {
+      linkLog.record({
+        sha: `sha${i.toString().padStart(40, "0")}`,
+        ref: `#${i}`,
+        linkType: "closes",
+        resolved: true,
+        workspace: "/ws",
+        subject: "x".repeat(70),
+      });
+    }
+    const lines = await buildRecentTracesDigest(
+      { commitIssueLinkLog: linkLog },
+      { topN: 50 },
+    );
+    expect(lines.join("\n").length).toBeLessThanOrEqual(2_048);
+  });
+});

--- a/src/tools/recentTracesDigest.ts
+++ b/src/tools/recentTracesDigest.ts
@@ -1,0 +1,106 @@
+import type { ActivityLog } from "../activityLog.js";
+import type { CommitIssueLinkLog } from "../commitIssueLinkLog.js";
+import type { RecipeRunLog } from "../runLog.js";
+import { createCtxQueryTracesTool } from "./ctxQueryTraces.js";
+
+/**
+ * Cold-start trace digest injected into session instructions.
+ *
+ * Agents reading the instructions see recent cross-session decisions
+ * (approvals / enrichment links / recipe runs) without having to query
+ * ctxQueryTraces first. Strictly read-only, strictly bounded.
+ *
+ * Budget: ≤2 KB total. Top 5 traces, summary + relative time only.
+ * No bodies, no full keys — just enough signal to answer
+ * "has something like this happened recently?"
+ */
+
+export interface RecentTracesDigestDeps {
+  activityLog?: ActivityLog | null;
+  commitIssueLinkLog?: CommitIssueLinkLog | null;
+  recipeRunLog?: RecipeRunLog | null;
+}
+
+const DEFAULT_WINDOW_MS = 12 * 60 * 60 * 1000; // 12 hours
+const DEFAULT_TOP_N = 5;
+const MAX_BYTES = 2_048;
+const MAX_SUMMARY_CHARS = 80;
+
+const TYPE_ICON: Record<string, string> = {
+  approval: "•",
+  enrichment: "⇄",
+  recipe_run: "▸",
+};
+
+function relTime(ms: number, now: number): string {
+  const diff = Math.max(0, now - ms);
+  const s = Math.floor(diff / 1000);
+  if (s < 60) return `${s}s ago`;
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m ago`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h ago`;
+  const d = Math.floor(h / 24);
+  return `${d}d ago`;
+}
+
+function truncate(s: string, max: number): string {
+  return s.length <= max ? s : `${s.slice(0, max - 1)}…`;
+}
+
+interface FormatOptions {
+  windowMs?: number;
+  topN?: number;
+  now?: number;
+}
+
+/**
+ * Build the digest as an array of lines (including the heading and
+ * indentation). Returns empty array if there's nothing to show.
+ *
+ * The caller decides how to join/embed these — buildInstructions() pushes
+ * them into its `lines` array alongside the other sections.
+ */
+export async function buildRecentTracesDigest(
+  deps: RecentTracesDigestDeps,
+  options: FormatOptions = {},
+): Promise<string[]> {
+  const windowMs = options.windowMs ?? DEFAULT_WINDOW_MS;
+  const topN = options.topN ?? DEFAULT_TOP_N;
+  const now = options.now ?? Date.now();
+
+  // If no sources are available, skip the section entirely.
+  if (!deps.activityLog && !deps.commitIssueLinkLog && !deps.recipeRunLog) {
+    return [];
+  }
+
+  const tool = createCtxQueryTracesTool(deps);
+  const result = await tool.handler({
+    since: Math.max(0, now - windowMs),
+    limit: Math.max(topN * 2, 20),
+  });
+
+  const structured = (result as { structuredContent?: unknown })
+    .structuredContent as
+    | { traces?: Array<{ traceType: string; ts: number; summary: string }> }
+    | undefined;
+  const traces = structured?.traces ?? [];
+  if (traces.length === 0) return [];
+
+  const top = traces.slice(0, topN);
+  const lines: string[] = ["RECENT DECISIONS (last 12h):"];
+  for (const t of top) {
+    const icon = TYPE_ICON[t.traceType] ?? "·";
+    const summary = truncate(t.summary, MAX_SUMMARY_CHARS);
+    const line = `  ${icon} ${summary} — ${relTime(t.ts, now)}`;
+    lines.push(line);
+  }
+
+  // Hard byte cap — keep dropping oldest entries until under budget.
+  while (lines.join("\n").length > MAX_BYTES && lines.length > 1) {
+    lines.pop();
+  }
+  // If only the heading survived, drop it too (nothing useful to say).
+  if (lines.length <= 1) return [];
+  return lines;
+}


### PR DESCRIPTION
## Summary

Phase 3 moat, cross-session memory step. Every Claude Code session connect now refreshes a compact digest of the last 12h of decisions (top 5, summary + relative time only, ≤2 KB) and prepends it to the MCP instructions block.

Agents joining a fresh session see something like:

```
RECENT DECISIONS (last 12h):
  • deny gitPush (cc_deny_rule) — 4h ago
  ⇄ closes #42 (resolved) — fix auth timeout — 2h ago
  ▸ nightly (cron) → done — 30m ago
```

\"Has something like this happened recently?\" becomes free context — no tool call required.

## Design

- **No new tool, no new hook.** Reuses \`ctxQueryTraces\` internally (single source of truth for the unified trail).
- **Refresh is fire-and-forget on session connect** — never blocks setup. If refresh is slow or fails, the session sees the previous digest (or an empty heading). Always recovers on the next connect.
- **Bounded aggressively.** 12h window → top 5 → 80 chars/summary → 2 KB total. Hard byte cap pops oldest bullets if exceeded.
- **Per-type icons** for skim-ability: \`•\` approval, \`⇄\` enrichment, \`▸\` recipe_run.

## What this is not

- Not a handoff-note rewrite (those remain user-controlled; these are system-generated).
- Not session-scoped — the digest is global decision history; every agent sees the same.
- Not configurable yet (window/limit are constants). If real usage shows need, expose flags later.
- No per-agent filtering / relevance scoring. MVP is chronological.

## Test plan

- [x] 10 new unit tests (empty sources / empty state / icons / window exclusion / topN cap / truncation / relative time / ordering / byte cap)
- [x] Full bridge suite: 3144/3144 passing (was 3134)
- [x] Lint clean
- [ ] Manual: start bridge, trigger an approval, restart bridge, confirm new session instructions include the digest

🤖 Generated with [Claude Code](https://claude.com/claude-code)