### PR TITLE
feat(ctx): ctxSaveTrace — agent-writable decision trace store

### DIFF
--- a/src/__tests__/decisionTraceLog.test.ts
+++ b/src/__tests__/decisionTraceLog.test.ts
@@ -1,0 +1,135 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { DecisionTraceLog } from "../decisionTraceLog.js";
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(path.join(os.tmpdir(), "decision-trace-log-"));
+});
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+function base() {
+  return {
+    ref: "#42",
+    problem: "auth times out on cold start",
+    solution: "lazy-init the token cache",
+    workspace: "/ws",
+  };
+}
+
+describe("DecisionTraceLog", () => {
+  it("records and assigns monotonic seq", () => {
+    const log = new DecisionTraceLog({ dir });
+    expect(log.record(base()).seq).toBe(1);
+    expect(log.record({ ...base(), ref: "#43" }).seq).toBe(2);
+    expect(log.size()).toBe(2);
+  });
+
+  it("rejects missing required fields", () => {
+    const log = new DecisionTraceLog({ dir });
+    expect(() => log.record({ ...base(), ref: "" })).toThrow(/ref/);
+    expect(() => log.record({ ...base(), problem: "" })).toThrow(/problem/);
+    expect(() => log.record({ ...base(), solution: "" })).toThrow(/solution/);
+  });
+
+  it("clips over-length problem and solution", () => {
+    const log = new DecisionTraceLog({ dir });
+    expect(() => log.record({ ...base(), problem: "x".repeat(600) })).toThrow(
+      /problem exceeds/,
+    );
+    expect(() => log.record({ ...base(), solution: "y".repeat(600) })).toThrow(
+      /solution exceeds/,
+    );
+  });
+
+  it("caps tags at 10 entries, each ≤32 chars", () => {
+    const log = new DecisionTraceLog({ dir });
+    const tags = Array.from({ length: 20 }, (_, i) => `tag${i}`);
+    const result = log.record({ ...base(), tags });
+    expect(result.tags).toHaveLength(10);
+    const longTag = "x".repeat(33);
+    const result2 = log.record({ ...base(), ref: "#2", tags: [longTag] });
+    expect(result2.tags).toBeUndefined();
+  });
+
+  it("filters by ref (substring + exact)", () => {
+    const log = new DecisionTraceLog({ dir });
+    log.record({ ...base(), ref: "#42" });
+    log.record({ ...base(), ref: "PR-42" });
+    log.record({ ...base(), ref: "abc123" });
+    expect(log.query({ ref: "42" })).toHaveLength(2);
+    expect(log.query({ ref: "#42" })).toHaveLength(1);
+    expect(log.query({ ref: "abc" })).toHaveLength(1);
+  });
+
+  it("filters by tag", () => {
+    const log = new DecisionTraceLog({ dir });
+    log.record({ ...base(), ref: "#1", tags: ["perf"] });
+    log.record({ ...base(), ref: "#2", tags: ["security"] });
+    log.record({ ...base(), ref: "#3", tags: ["perf", "db"] });
+    expect(log.query({ tag: "perf" })).toHaveLength(2);
+    expect(log.query({ tag: "db" })).toHaveLength(1);
+  });
+
+  it("filters by workspace, sessionId, since", () => {
+    let t = 1_000;
+    const log = new DecisionTraceLog({ dir, now: () => t });
+    log.record({ ...base(), ref: "#1", workspace: "/a" });
+    t = 2_000;
+    log.record({ ...base(), ref: "#2", workspace: "/b", sessionId: "s1" });
+    t = 3_000;
+    log.record({ ...base(), ref: "#3", workspace: "/a", sessionId: "s2" });
+    expect(log.query({ workspace: "/a" })).toHaveLength(2);
+    expect(log.query({ sessionId: "s1" })).toHaveLength(1);
+    expect(log.query({ since: 2_500 })).toHaveLength(1);
+  });
+
+  it("returns newest-first", () => {
+    let t = 1_000;
+    const log = new DecisionTraceLog({ dir, now: () => t });
+    log.record({ ...base(), ref: "#1" });
+    t = 2_000;
+    log.record({ ...base(), ref: "#2" });
+    const rows = log.query();
+    expect(rows[0]?.ref).toBe("#2");
+    expect(rows[1]?.ref).toBe("#1");
+  });
+
+  it("persists to JSONL + reloads into fresh instance", () => {
+    const log1 = new DecisionTraceLog({ dir });
+    log1.record(base());
+    log1.record({ ...base(), ref: "#43" });
+    const raw = readFileSync(path.join(dir, "decision_traces.jsonl"), "utf-8");
+    expect(raw.trim().split("\n")).toHaveLength(2);
+    const log2 = new DecisionTraceLog({ dir });
+    expect(log2.size()).toBe(2);
+    // seq must continue, not restart
+    const next = log2.record({ ...base(), ref: "#44" });
+    expect(next.seq).toBe(3);
+  });
+
+  it("skips malformed JSONL lines on load", () => {
+    const log1 = new DecisionTraceLog({ dir });
+    log1.record(base());
+    const file = path.join(dir, "decision_traces.jsonl");
+    const good = readFileSync(file, "utf-8");
+    const fs = require("node:fs");
+    fs.writeFileSync(file, `not json\n${good}{"no-required":true}\n`);
+    const log2 = new DecisionTraceLog({ dir });
+    expect(log2.size()).toBe(1);
+  });
+
+  it("enforces memoryCap by trimming oldest", () => {
+    const log = new DecisionTraceLog({ dir, memoryCap: 3 });
+    for (let i = 0; i < 5; i += 1) {
+      log.record({ ...base(), ref: `#${i}` });
+    }
+    expect(log.size()).toBe(3);
+    expect(log.query({}).map((r) => r.ref)).toEqual(["#4", "#3", "#2"]);
+  });
+});

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -15,6 +15,7 @@ import { createDriver } from "./claudeDriver.js";
 import { ClaudeOrchestrator } from "./claudeOrchestrator.js";
 import { CommitIssueLinkLog } from "./commitIssueLinkLog.js";
 import type { Config } from "./config.js";
+import { DecisionTraceLog } from "./decisionTraceLog.js";
 import { ExtensionClient } from "./extensionClient.js";
 import { FileLock } from "./fileLock.js";
 import { buildEnforcementReminder } from "./instructionsUtils.js";
@@ -140,6 +141,7 @@ export class Bridge {
   private recipeScheduler: RecipeScheduler | null = null;
   private recipeRunLog: RecipeRunLog | null = null;
   private commitIssueLinkLog: CommitIssueLinkLog | null = null;
+  private decisionTraceLog: DecisionTraceLog | null = null;
   /** Pre-computed digest of recent decisions, refreshed on each session connect. */
   private recentTracesDigest: string[] = [];
   private httpMcpHandler: StreamableHttpHandler | null = null;
@@ -401,6 +403,7 @@ export class Bridge {
         () => this.extensionDisconnectCount,
         this.commitIssueLinkLog ?? undefined,
         this.recipeRunLog ?? undefined,
+        this.decisionTraceLog ?? undefined,
       );
 
       transport.attach(ws);
@@ -763,6 +766,7 @@ export class Bridge {
       activityLog: this.activityLog,
       commitIssueLinkLog: this.commitIssueLinkLog,
       recipeRunLog: this.recipeRunLog,
+      decisionTraceLog: this.decisionTraceLog,
     })
       .then((lines) => {
         this.recentTracesDigest = lines;
@@ -887,6 +891,10 @@ export class Bridge {
       // Patchwork: enrichment link log is useful regardless of orchestrator.
       const patchworkDir = path.join(os.homedir(), ".patchwork");
       this.commitIssueLinkLog = new CommitIssueLinkLog({
+        dir: patchworkDir,
+        logger: this.logger,
+      });
+      this.decisionTraceLog = new DecisionTraceLog({
         dir: patchworkDir,
         logger: this.logger,
       });
@@ -1075,6 +1083,7 @@ export class Bridge {
         activityLog: this.activityLog,
         commitIssueLinkLog: this.commitIssueLinkLog,
         recipeRunLog: this.recipeRunLog,
+        decisionTraceLog: this.decisionTraceLog,
       });
       const result = await tool.handler({
         ...(query.traceType && { traceType: query.traceType }),

--- a/src/decisionTraceLog.ts
+++ b/src/decisionTraceLog.ts
@@ -1,0 +1,213 @@
+import { appendFileSync, mkdirSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+import type { Logger } from "./logger.js";
+
+/**
+ * DecisionTraceLog — agent-authored trace of "I fixed X by doing Y".
+ *
+ * Writers call `ctxSaveTrace(ref, problem, solution)` after resolving a
+ * task; readers call `ctxQueryTraces(traceType: "decision")` or see a
+ * digest on session start. Complements CommitIssueLinkLog (system-
+ * generated links) and RecipeRunLog (orchestrator runs) with durable
+ * problem/solution knowledge — the Phase 3 moat material.
+ *
+ * JSONL append + bounded in-memory ring. Same pattern as the two other
+ * logs; schema is additive. Tags are free-form short labels (max 10 per
+ * trace, 32 chars each) so agents can search by "flaky-test" / "perf" /
+ * "security" without a taxonomy commitment.
+ */
+
+export interface DecisionTrace {
+  /** Monotonic sequence id within the process — stable for pagination. */
+  seq: number;
+  /** ms epoch when the trace was recorded. */
+  createdAt: number;
+  /** The thing the trace is about: issue ref, PR ref, commit SHA, or free text. */
+  ref: string;
+  /** One-line description of the problem (max 500 chars). */
+  problem: string;
+  /** One-line description of the resolution (max 500 chars). */
+  solution: string;
+  /** Workspace where the trace was recorded. */
+  workspace: string;
+  /** Optional free-form tags (max 10, each ≤32 chars). */
+  tags?: string[];
+  /** Optional session id so we can attribute traces back to a run. */
+  sessionId?: string;
+}
+
+const DEFAULT_MEMORY_CAP = 2_000;
+const MAX_PROBLEM_LEN = 500;
+const MAX_SOLUTION_LEN = 500;
+const MAX_TAGS = 10;
+const MAX_TAG_LEN = 32;
+
+export interface DecisionTraceLogOptions {
+  dir: string;
+  logger?: Logger;
+  memoryCap?: number;
+  now?: () => number;
+}
+
+export interface DecisionQuery {
+  ref?: string;
+  tag?: string;
+  workspace?: string;
+  sessionId?: string;
+  /** Only return rows with seq > after. */
+  after?: number;
+  /** Only return rows with createdAt >= since. */
+  since?: number;
+  limit?: number;
+}
+
+export interface RecordDecisionInput {
+  ref: string;
+  problem: string;
+  solution: string;
+  workspace: string;
+  tags?: string[];
+  sessionId?: string;
+}
+
+export class DecisionTraceLog {
+  private traces: DecisionTrace[] = [];
+  private seq = 0;
+  private readonly file: string;
+  private readonly memoryCap: number;
+  private readonly now: () => number;
+
+  constructor(private readonly opts: DecisionTraceLogOptions) {
+    this.file = path.join(opts.dir, "decision_traces.jsonl");
+    this.memoryCap = opts.memoryCap ?? DEFAULT_MEMORY_CAP;
+    this.now = opts.now ?? Date.now;
+    try {
+      mkdirSync(opts.dir, { recursive: true });
+    } catch (err) {
+      opts.logger?.warn?.(
+        `[dtrace-log] could not create ${opts.dir}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+    this.loadExisting();
+  }
+
+  /**
+   * Record a new decision trace. Validates required fields + clips the
+   * free-form text to avoid the agent writing a whole transcript.
+   * Returns the stored trace or throws on invalid input.
+   */
+  record(input: RecordDecisionInput): DecisionTrace {
+    const ref = input.ref.trim();
+    const problem = input.problem.trim();
+    const solution = input.solution.trim();
+    if (!ref) throw new Error("ref is required");
+    if (!problem) throw new Error("problem is required");
+    if (!solution) throw new Error("solution is required");
+    if (problem.length > MAX_PROBLEM_LEN) {
+      throw new Error(`problem exceeds ${MAX_PROBLEM_LEN} chars`);
+    }
+    if (solution.length > MAX_SOLUTION_LEN) {
+      throw new Error(`solution exceeds ${MAX_SOLUTION_LEN} chars`);
+    }
+
+    const tags = (input.tags ?? [])
+      .map((t) => t.trim())
+      .filter((t) => t.length > 0 && t.length <= MAX_TAG_LEN)
+      .slice(0, MAX_TAGS);
+
+    this.seq += 1;
+    const trace: DecisionTrace = {
+      seq: this.seq,
+      createdAt: this.now(),
+      ref,
+      problem,
+      solution,
+      workspace: input.workspace,
+      ...(tags.length > 0 && { tags }),
+      ...(input.sessionId && { sessionId: input.sessionId }),
+    };
+    this.traces.push(trace);
+    if (this.traces.length > this.memoryCap) {
+      this.traces.splice(0, this.traces.length - this.memoryCap);
+    }
+    this.append(trace);
+    return trace;
+  }
+
+  query(q: DecisionQuery = {}): DecisionTrace[] {
+    let out = this.traces;
+    if (q.ref) {
+      const needle = q.ref;
+      out = out.filter((t) => t.ref === needle || t.ref.includes(needle));
+    }
+    if (q.tag) {
+      const needle = q.tag;
+      out = out.filter((t) => t.tags?.includes(needle) ?? false);
+    }
+    if (q.workspace) out = out.filter((t) => t.workspace === q.workspace);
+    if (q.sessionId) out = out.filter((t) => t.sessionId === q.sessionId);
+    if (q.after !== undefined) {
+      const after = q.after;
+      out = out.filter((t) => t.seq > after);
+    }
+    if (q.since !== undefined) {
+      const since = q.since;
+      out = out.filter((t) => t.createdAt >= since);
+    }
+    out = [...out].sort((a, b) => b.seq - a.seq);
+    const limit = Math.min(Math.max(q.limit ?? 100, 1), 1_000);
+    return out.slice(0, limit);
+  }
+
+  size(): number {
+    return this.traces.length;
+  }
+
+  private append(trace: DecisionTrace): void {
+    try {
+      appendFileSync(this.file, `${JSON.stringify(trace)}\n`, { mode: 0o600 });
+    } catch (err) {
+      this.opts.logger?.warn?.(
+        `[dtrace-log] append failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  private loadExisting(): void {
+    try {
+      statSync(this.file);
+    } catch {
+      return;
+    }
+    let raw: string;
+    try {
+      raw = readFileSync(this.file, "utf-8");
+    } catch (err) {
+      this.opts.logger?.warn?.(
+        `[dtrace-log] read failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      return;
+    }
+    for (const line of raw.split("\n")) {
+      if (!line) continue;
+      try {
+        const parsed = JSON.parse(line) as DecisionTrace;
+        if (
+          typeof parsed.seq !== "number" ||
+          typeof parsed.ref !== "string" ||
+          typeof parsed.problem !== "string" ||
+          typeof parsed.solution !== "string"
+        ) {
+          continue;
+        }
+        this.traces.push(parsed);
+        if (parsed.seq > this.seq) this.seq = parsed.seq;
+      } catch {
+        // skip malformed row
+      }
+    }
+    if (this.traces.length > this.memoryCap) {
+      this.traces.splice(0, this.traces.length - this.memoryCap);
+    }
+  }
+}

--- a/src/tools/__tests__/ctxQueryTraces.test.ts
+++ b/src/tools/__tests__/ctxQueryTraces.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { ActivityLog } from "../../activityLog.js";
 import { CommitIssueLinkLog } from "../../commitIssueLinkLog.js";
+import { DecisionTraceLog } from "../../decisionTraceLog.js";
 import { RecipeRunLog } from "../../runLog.js";
 import { createCtxQueryTracesTool } from "../ctxQueryTraces.js";
 
@@ -145,6 +146,7 @@ describe("ctxQueryTraces", () => {
       approval: false,
       enrichment: true,
       recipe_run: false,
+      decision: false,
     });
   });
 
@@ -199,5 +201,54 @@ describe("ctxQueryTraces", () => {
     expect(res.traces[0].body.callId).toBe("call-xyz");
     expect(res.traces[0].body.summary).toBe("rm tmpfile");
     expect(res.traces[0].body.riskSignals).toHaveLength(1);
+  });
+
+  it("includes decision traces when decisionTraceLog is provided", async () => {
+    const decisionLog = new DecisionTraceLog({ dir });
+    decisionLog.record({
+      ref: "#42",
+      problem: "auth timeout",
+      solution: "lazy cache init",
+      workspace: "/ws",
+      tags: ["perf"],
+    });
+    const tool = createCtxQueryTracesTool({
+      activityLog: null,
+      commitIssueLinkLog: null,
+      recipeRunLog: null,
+      decisionTraceLog: decisionLog,
+    });
+    const res = parse(await tool.handler({}));
+    expect(res.sources.decision).toBe(true);
+    expect(res.count).toBe(1);
+    expect(res.traces[0].traceType).toBe("decision");
+    expect(res.traces[0].key).toBe("#42");
+    expect(res.traces[0].summary).toContain("lazy cache init");
+  });
+
+  it("filters by traceType=decision", async () => {
+    const decisionLog = new DecisionTraceLog({ dir });
+    decisionLog.record({
+      ref: "#1",
+      problem: "p",
+      solution: "s",
+      workspace: "/ws",
+    });
+    linkLog.record({
+      sha: "aaa",
+      ref: "#1",
+      linkType: "closes",
+      resolved: true,
+      workspace: "/ws",
+    });
+    const tool = createCtxQueryTracesTool({
+      activityLog: null,
+      commitIssueLinkLog: linkLog,
+      recipeRunLog: null,
+      decisionTraceLog: decisionLog,
+    });
+    const res = parse(await tool.handler({ traceType: "decision" }));
+    expect(res.count).toBe(1);
+    expect(res.traces[0].traceType).toBe("decision");
   });
 });

--- a/src/tools/__tests__/ctxSaveTrace.test.ts
+++ b/src/tools/__tests__/ctxSaveTrace.test.ts
@@ -1,0 +1,87 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { DecisionTraceLog } from "../../decisionTraceLog.js";
+import { createCtxSaveTraceTool } from "../ctxSaveTrace.js";
+
+let dir: string;
+let log: DecisionTraceLog;
+
+beforeEach(() => {
+  dir = mkdtempSync(path.join(os.tmpdir(), "ctx-save-trace-"));
+  log = new DecisionTraceLog({ dir });
+});
+afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+function parse(r: { content: Array<{ type: string; text: string }> }) {
+  return JSON.parse(r.content[0]?.text ?? "{}");
+}
+
+const WS = "/tmp/ws";
+
+describe("ctxSaveTrace", () => {
+  it("records a trace and returns seq + ref", async () => {
+    const tool = createCtxSaveTraceTool(WS, log);
+    const res = parse(
+      await tool.handler({
+        ref: "#42",
+        problem: "auth times out",
+        solution: "lazy-init token cache",
+      }),
+    );
+    expect(res.seq).toBe(1);
+    expect(res.ref).toBe("#42");
+    expect(typeof res.createdAt).toBe("number");
+    expect(log.size()).toBe(1);
+  });
+
+  it("persists tags when provided", async () => {
+    const tool = createCtxSaveTraceTool(WS, log);
+    const res = parse(
+      await tool.handler({
+        ref: "#1",
+        problem: "p",
+        solution: "s",
+        tags: ["perf", "db"],
+      }),
+    );
+    expect(res.tags).toEqual(["perf", "db"]);
+  });
+
+  it("attaches sessionId from the getter callback", async () => {
+    const tool = createCtxSaveTraceTool(WS, log, () => "session-abc");
+    await tool.handler({ ref: "#1", problem: "p", solution: "s" });
+    const stored = log.query()[0];
+    expect(stored?.sessionId).toBe("session-abc");
+  });
+
+  it("returns an error payload on invalid input", async () => {
+    const tool = createCtxSaveTraceTool(WS, log);
+    const res = await tool.handler({
+      ref: "#1",
+      problem: "p",
+      solution: "x".repeat(600),
+    });
+    expect(res.content[0]?.text).toContain("exceeds");
+  });
+
+  it("trims whitespace from ref / problem / solution via log", async () => {
+    const tool = createCtxSaveTraceTool(WS, log);
+    const res = parse(
+      await tool.handler({
+        ref: "  #42  ",
+        problem: "  trimmed  ",
+        solution: "  also trimmed  ",
+      }),
+    );
+    expect(res.ref).toBe("#42");
+    expect(log.query()[0]?.problem).toBe("trimmed");
+  });
+
+  it("writes workspace through to the log", async () => {
+    const tool = createCtxSaveTraceTool("/my/workspace", log);
+    await tool.handler({ ref: "#1", problem: "p", solution: "s" });
+    expect(log.query()[0]?.workspace).toBe("/my/workspace");
+  });
+});

--- a/src/tools/ctxQueryTraces.ts
+++ b/src/tools/ctxQueryTraces.ts
@@ -1,5 +1,6 @@
 import type { ActivityLog } from "../activityLog.js";
 import type { CommitIssueLinkLog } from "../commitIssueLinkLog.js";
+import type { DecisionTraceLog } from "../decisionTraceLog.js";
 import type { RecipeRunLog } from "../runLog.js";
 import { optionalInt, optionalString, successStructured } from "./utils.js";
 
@@ -18,7 +19,7 @@ import { optionalInt, optionalString, successStructured } from "./utils.js";
  * need richer per-type shapes can key on `traceType` and unwrap `body`.
  */
 
-export type TraceType = "approval" | "enrichment" | "recipe_run";
+export type TraceType = "approval" | "enrichment" | "recipe_run" | "decision";
 
 export interface DecisionTrace {
   traceType: TraceType;
@@ -41,6 +42,7 @@ export interface CtxQueryTracesDeps {
   recipeRunLog?: RecipeRunLog | null;
   commitIssueLinkLog?: CommitIssueLinkLog | null;
   activityLog?: ActivityLog | null;
+  decisionTraceLog?: DecisionTraceLog | null;
 }
 
 function approvalTraces(activityLog: ActivityLog): DecisionTrace[] {
@@ -93,6 +95,16 @@ function recipeRunTraces(log: RecipeRunLog): DecisionTrace[] {
   }));
 }
 
+function decisionTraces(log: DecisionTraceLog): DecisionTrace[] {
+  return log.query({ limit: 500 }).map((d) => ({
+    traceType: "decision",
+    ts: d.createdAt,
+    key: d.ref,
+    summary: `${d.ref} — ${d.solution}`,
+    body: d as unknown as Record<string, unknown>,
+  }));
+}
+
 export function createCtxQueryTracesTool(deps: CtxQueryTracesDeps) {
   return {
     schema: {
@@ -105,7 +117,7 @@ export function createCtxQueryTracesTool(deps: CtxQueryTracesDeps) {
         properties: {
           traceType: {
             type: "string",
-            enum: ["approval", "enrichment", "recipe_run"],
+            enum: ["approval", "enrichment", "recipe_run", "decision"],
             description:
               "Optional filter — restrict to one source. Omit to get all.",
           },
@@ -137,7 +149,7 @@ export function createCtxQueryTracesTool(deps: CtxQueryTracesDeps) {
               properties: {
                 traceType: {
                   type: "string",
-                  enum: ["approval", "enrichment", "recipe_run"],
+                  enum: ["approval", "enrichment", "recipe_run", "decision"],
                 },
                 ts: { type: "integer" },
                 key: { type: "string" },
@@ -154,6 +166,7 @@ export function createCtxQueryTracesTool(deps: CtxQueryTracesDeps) {
               approval: { type: "boolean" },
               enrichment: { type: "boolean" },
               recipe_run: { type: "boolean" },
+              decision: { type: "boolean" },
             },
           },
         },
@@ -174,6 +187,7 @@ export function createCtxQueryTracesTool(deps: CtxQueryTracesDeps) {
         approval: Boolean(deps.activityLog),
         enrichment: Boolean(deps.commitIssueLinkLog),
         recipe_run: Boolean(deps.recipeRunLog),
+        decision: Boolean(deps.decisionTraceLog),
       };
 
       const pools: DecisionTrace[] = [];
@@ -188,6 +202,9 @@ export function createCtxQueryTracesTool(deps: CtxQueryTracesDeps) {
       }
       if ((!traceType || traceType === "recipe_run") && deps.recipeRunLog) {
         pools.push(...recipeRunTraces(deps.recipeRunLog));
+      }
+      if ((!traceType || traceType === "decision") && deps.decisionTraceLog) {
+        pools.push(...decisionTraces(deps.decisionTraceLog));
       }
 
       let filtered = pools;

--- a/src/tools/ctxSaveTrace.ts
+++ b/src/tools/ctxSaveTrace.ts
@@ -1,0 +1,112 @@
+import type { DecisionTraceLog } from "../decisionTraceLog.js";
+import {
+  error,
+  optionalString,
+  requireString,
+  successStructured,
+} from "./utils.js";
+
+/**
+ * Agent writer advertised in the MCP handshake as
+ * `ctxSaveTrace(ref, problem, solution)`. Records a durable decision
+ * trace after resolving a task so future sessions can find it via
+ * `ctxQueryTraces(traceType: "decision")` or the injected digest.
+ *
+ * This is the writer half of the Phase 3 moat — `ctxGetTaskContext`
+ * gives agents cross-session *read*, `ctxSaveTrace` gives them
+ * cross-session *write*.
+ */
+
+export function createCtxSaveTraceTool(
+  workspace: string,
+  log: DecisionTraceLog,
+  getSessionId?: () => string | undefined,
+) {
+  return {
+    schema: {
+      name: "ctxSaveTrace",
+      description:
+        "Record a problem+solution trace after resolving a task. Future sessions see it via ctxQueryTraces and the session-start digest. Keep problem + solution to one line each.",
+      annotations: { readOnlyHint: false, destructiveHint: false },
+      inputSchema: {
+        type: "object" as const,
+        required: ["ref", "problem", "solution"],
+        properties: {
+          ref: {
+            type: "string",
+            description:
+              "What the trace is about: issue ref (#42), PR ref (PR-42), commit SHA, or short free text.",
+            maxLength: 256,
+          },
+          problem: {
+            type: "string",
+            description:
+              "One-line summary of the problem. What was broken or unclear?",
+            maxLength: 500,
+          },
+          solution: {
+            type: "string",
+            description:
+              "One-line summary of the fix. What was the root cause and what resolved it?",
+            maxLength: 500,
+          },
+          tags: {
+            type: "array",
+            description:
+              "Up to 10 short labels for search (`flaky-test`, `perf`, `security`, `migration`). Each ≤32 chars.",
+            items: { type: "string", maxLength: 32 },
+            maxItems: 10,
+          },
+        },
+        additionalProperties: false as const,
+      },
+      outputSchema: {
+        type: "object" as const,
+        properties: {
+          seq: { type: "integer" },
+          ref: { type: "string" },
+          createdAt: { type: "integer" },
+          tags: { type: "array", items: { type: "string" } },
+        },
+        required: ["seq", "ref", "createdAt"],
+      },
+    },
+    timeoutMs: 5_000,
+    async handler(args: Record<string, unknown>) {
+      try {
+        const ref = requireString(args, "ref", 256);
+        const problem = requireString(args, "problem", 500);
+        const solution = requireString(args, "solution", 500);
+
+        const tagsInput = args.tags;
+        let tags: string[] | undefined;
+        if (Array.isArray(tagsInput)) {
+          tags = tagsInput
+            .filter((t): t is string => typeof t === "string")
+            .map((t) => t.trim())
+            .filter((t) => t.length > 0);
+        }
+
+        // Validate optional fields — throws on wrong type.
+        void optionalString(args, "sessionId");
+
+        const trace = log.record({
+          ref,
+          problem,
+          solution,
+          workspace,
+          ...(tags && tags.length > 0 && { tags }),
+          ...(getSessionId?.() && { sessionId: getSessionId() }),
+        });
+        return successStructured({
+          seq: trace.seq,
+          ref: trace.ref,
+          createdAt: trace.createdAt,
+          ...(trace.tags && { tags: trace.tags }),
+        });
+      } catch (err) {
+        return error(err instanceof Error ? err.message : String(err));
+      }
+    },
+  };
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -31,6 +31,7 @@ import { createContextBundleTool } from "./contextBundle.js";
 import { createCreateIssueFromAICommentTool } from "./createIssueFromAIComment.js";
 import { createCtxGetTaskContextTool } from "./ctxGetTaskContext.js";
 import { createCtxQueryTracesTool } from "./ctxQueryTraces.js";
+import { createCtxSaveTraceTool } from "./ctxSaveTrace.js";
 import {
   createEvaluateInDebuggerTool,
   createSetDebugBreakpointsTool,
@@ -327,6 +328,7 @@ export function registerAllTools(
   getExtensionDisconnectCount?: () => number,
   commitIssueLinkLog?: import("../commitIssueLinkLog.js").CommitIssueLinkLog,
   recipeRunLog?: import("../runLog.js").RecipeRunLog,
+  decisionTraceLog?: import("../decisionTraceLog.js").DecisionTraceLog,
 ): void {
   const workspace = config.workspace;
   const workspaceFolders = config.workspaceFolders;
@@ -657,11 +659,21 @@ export function registerAllTools(
       activityLog: activityLog ?? null,
       commitIssueLinkLog: commitIssueLinkLog ?? null,
       recipeRunLog: recipeRunLog ?? null,
+      decisionTraceLog: decisionTraceLog ?? null,
     }),
     createCtxGetTaskContextTool({
       workspace,
       commitIssueLinkLog: commitIssueLinkLog ?? null,
     }),
+    ...(decisionTraceLog
+      ? [
+          createCtxSaveTraceTool(
+            workspace,
+            decisionTraceLog,
+            sessionId ? () => sessionId : undefined,
+          ),
+        ]
+      : []),
     ...(commitIssueLinkLog
       ? [createGetCommitsForIssueTool(workspace, commitIssueLinkLog)]
       : []),

--- a/src/tools/recentTracesDigest.ts
+++ b/src/tools/recentTracesDigest.ts
@@ -1,5 +1,6 @@
 import type { ActivityLog } from "../activityLog.js";
 import type { CommitIssueLinkLog } from "../commitIssueLinkLog.js";
+import type { DecisionTraceLog } from "../decisionTraceLog.js";
 import type { RecipeRunLog } from "../runLog.js";
 import { createCtxQueryTracesTool } from "./ctxQueryTraces.js";
 
@@ -19,6 +20,7 @@ export interface RecentTracesDigestDeps {
   activityLog?: ActivityLog | null;
   commitIssueLinkLog?: CommitIssueLinkLog | null;
   recipeRunLog?: RecipeRunLog | null;
+  decisionTraceLog?: DecisionTraceLog | null;
 }
 
 const DEFAULT_WINDOW_MS = 12 * 60 * 60 * 1000; // 12 hours
@@ -30,6 +32,7 @@ const TYPE_ICON: Record<string, string> = {
   approval: "•",
   enrichment: "⇄",
   recipe_run: "▸",
+  decision: "★",
 };
 
 function relTime(ms: number, now: number): string {
@@ -70,7 +73,12 @@ export async function buildRecentTracesDigest(
   const now = options.now ?? Date.now();
 
   // If no sources are available, skip the section entirely.
-  if (!deps.activityLog && !deps.commitIssueLinkLog && !deps.recipeRunLog) {
+  if (
+    !deps.activityLog &&
+    !deps.commitIssueLinkLog &&
+    !deps.recipeRunLog &&
+    !deps.decisionTraceLog
+  ) {
     return [];
   }
 


### PR DESCRIPTION
## Summary

Closes the Phase 3 moat read-write loop. \`ctxGetTaskContext\` (PR #14) gave agents cross-session **read**. This adds the **write** half:

\`\`\`
ctxSaveTrace(ref, problem, solution, tags?)
\`\`\`

Persists to \`~/.patchwork/decision_traces.jsonl\` via new \`DecisionTraceLog\` (JSONL + bounded in-memory ring, 2000 cap — same pattern as \`CommitIssueLinkLog\` / \`RecipeRunLog\`). Validates required fields + clips problem/solution at 500 chars, tags ≤10 × ≤32 chars (so agents can't dump a whole transcript into a single trace).

Extends \`ctxQueryTraces\` with a 4th traceType \`\"decision\"\` so future sessions see saved fixes via the same unified query layer the dashboard \`/traces\` page and the session-start digest already use. **No dashboard change needed** — decision rows render with the generic ★ icon + \`ref: solution\` summary automatically.

Also fixes the last phantom MCP tool — \`ctxSaveTrace\` was advertised in bridge.ts instructions but had no handler. Companion fix to #14 (\`ctxGetTaskContext\`).

## What the full moat looks like now

| Layer | Tool / surface | Lands in |
|---|---|---|
| **Write** | enrichCommit, enrichStackTrace, getCommitsForIssue, recipes, approval gate | CommitIssueLinkLog / RecipeRunLog / activityLog |
| **Write** (agent-authored) | **ctxSaveTrace** | **DecisionTraceLog** ← new |
| **Read (query)** | ctxQueryTraces, ctxGetTaskContext | all four logs |
| **Read (injected)** | session-start digest (recentTracesDigest) | instructions block |
| **Read (UI)** | /traces page | /traces HTTP endpoint |

## Test plan

- [x] 19 new unit tests: log (11) + tool (6) + ctxQueryTraces integration (2)
- [x] Full bridge suite: 3174/3174 passing (was 3155)
- [x] Lint clean
- [ ] Manual: call \`ctxSaveTrace\`, restart bridge, confirm trace persists + appears in /traces page + session digest

🤖 Generated with [Claude Code](https://claude.com/claude-code)