### PR TITLE
docs: update roadmap + platform-docs + CLAUDE.md for Phase 3 moat

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -361,6 +361,23 @@ Bridge tool substitution rules in `.claude/rules/bridge-tools.md` (loaded above)
 | Change-heavy files | `getGitHotspots` | **[full]** |
 | Scaffold tests | `generateTests` | **[full]** |
 | PR description | `getPRTemplate` | **[full]** |
+| Unified task context (issue/PR/commit) | `ctxGetTaskContext` | **[full]** |
+| Query past decisions (approval/enrichment/recipe/agent) | `ctxQueryTraces` | **[full]** |
+| Record a fix for future sessions | `ctxSaveTrace` | **[full]** |
+| Enrich commit with linked issues | `enrichCommit` | **[full]** |
+| Reverse: commits that touched an issue | `getCommitsForIssue` | **[full]** |
+| Stack frame → introducing commit | `enrichStackTrace` | **[full]** |
+
+### Patchwork context platform — when to call what
+
+The bridge has a built-in cross-session memory layer. **Prefer these over raw `gh` / `git` tools** for task-context lookups:
+
+- **Starting a task?** Call `ctxGetTaskContext(ref)` first. Accepts any ref shape (`#42`, `PR-42`, commit SHA). Returns issue/PR/commit + linked commits + reverse issue links in one call. Fail-soft — missing `gh` / git shows up in `warnings`, never throws.
+- **Fixing a bug?** Pair with `enrichStackTrace(stackTrace)` on the failing trace — maps frames to the commit that likely introduced the bug.
+- **Done resolving?** Call `ctxSaveTrace(ref, problem, solution, tags?)` with a one-line problem + one-line solution. Future sessions see it via the session-start digest and `ctxQueryTraces`.
+- **Debugging oversight?** `ctxQueryTraces({traceType, key, since, limit})` reads across all four stores (approvals, enrichment links, recipe runs, decision traces). The dashboard `/traces` page is the human UI over the same data.
+
+On every session connect, the bridge prepends a digest of the last 12h of decisions to its MCP instructions block (top 5, ≤2 KB). If you see a `RECENT DECISIONS` section in your system prompt, that's live context — use it before re-running `gh`.
 
 ### Dispatch prompts (mobile)
 

--- a/documents/platform-docs.md
+++ b/documents/platform-docs.md
@@ -655,14 +655,14 @@ Signals never change the decision — they help the human decide.
 
 ### Recipe triggers
 
-Recipes live in `~/.claude-ide-bridge/recipes/` (JSON or YAML). Supported triggers:
+Recipes live in `~/.patchwork/recipes/` (JSON or YAML). Supported triggers:
 
 - **manual** — run via `patchwork recipe run <name>` CLI.
 - **cron** — `@every 5m` syntax; runs via the recipe scheduler.
 - **webhook** — `POST /hooks/<name>` dispatches matching recipes.
 - **file_watch** — minimatch patterns on workspace files.
 
-Install with `patchwork recipe install <path-to-recipe.yaml>`. Run history persists to SQLite; surfaced in the dashboard `/recipes` page.
+Install with `patchwork recipe install <path-to-recipe.yaml>`. Run history persists as JSONL at `~/.patchwork/runs.jsonl` via `RecipeRunLog` (append-only file + bounded in-memory ring); surfaced in the dashboard `/recipes` and `/runs` pages.
 
 ### Webhook SSRF defenses
 
@@ -673,3 +673,60 @@ Install with `patchwork recipe install <path-to-recipe.yaml>`. Run history persi
 - DNS-resolved IP checked against loopback / RFC-1918 / link-local blocklist.
 - 5s timeout via `AbortController`.
 - Failures logged, never thrown — webhook errors must not block approval flow.
+
+## Patchwork Context Platform — Phase 3 Moat
+
+Cross-session memory for agents. Every decision (approval verdict, enrichment link, recipe run, agent-authored fix) is persisted to JSONL and queryable through a single surface. New sessions see a digest of recent decisions automatically in their MCP instructions block — no tool call required.
+
+### Tools
+
+| Tool | Purpose |
+|---|---|
+| `ctxSaveTrace(ref, problem, solution, tags?)` | Agent writes a durable trace after resolving a task. Persists to `DecisionTraceLog`. Required: `ref` (issue/PR/commit/free-text, ≤256 chars), `problem` (≤500 chars), `solution` (≤500 chars). Optional: up to 10 tags × 32 chars each. |
+| `ctxGetTaskContext(ref)` | Unified context for an issue, PR, commit, or error ref. Auto-detects ref type. Composes `gh issue view` / `gh pr view` / `git show` + `CommitIssueLinkLog` reverse lookup. Fail-soft: partial context on missing `gh` / git / log rather than throw. |
+| `ctxQueryTraces({traceType?, key?, since?, limit?})` | Unified query over all four trace stores. `traceType: "approval" \| "enrichment" \| "recipe_run" \| "decision"` (omit for all). Key substring match. Returns `{traces:[{traceType, ts, key, summary, body}], count, sources}`. |
+
+### Persistence
+
+All four stores are JSONL with bounded in-memory rings (no SQLite). Located under `~/.patchwork/`:
+
+| File | Writer | Dedup |
+|---|---|---|
+| `runs.jsonl` | `RecipeRunLog` — recipe/cron/webhook runs | none (every run is a new row) |
+| `commit_issue_links.jsonl` | `CommitIssueLinkLog` — `enrichCommit` output | on `(workspace, sha, ref)` unless `linkType` / `resolved` / `issueState` / `reason` changes |
+| `decision_traces.jsonl` | `DecisionTraceLog` — `ctxSaveTrace` output | none (every agent write is a new trace) |
+| (activityLog lifecycle rows) | approval gate `onDecision` | by seq |
+
+### Session-start digest
+
+On every Claude Code session connect, the bridge refreshes a compact digest of the last 12h of decisions and prepends it to the MCP instructions block:
+
+```
+RECENT DECISIONS (last 12h):
+  • deny gitPush (cc_deny_rule) — 4h ago
+  ⇄ closes #42 (resolved) — fix auth timeout — 2h ago
+  ▸ nightly (cron) → done — 30m ago
+  ★ #42 — base case changed to return 1 when n<=1 — 10m ago
+```
+
+Strictly bounded: 12h window, top 5, 80 chars per summary, 2 KB total byte cap. Refresh is fire-and-forget on connect — if slow or failed, session sees the previous digest (or empty heading). Never blocks session setup.
+
+### HTTP surface
+
+| Route | Purpose |
+|---|---|
+| `GET /traces?traceType=&key=&since=&limit=` | Query wrapper over `ctxQueryTraces` — backs the dashboard `/traces` page. |
+| dashboard `/traces` | Filter tabs (All / Approval / Enrichment / Recipe Run / Decision), key substring search, click-to-expand body JSON. Polls every 3s. |
+
+### Ref-detection heuristics
+
+`ctxGetTaskContext` parses refs with these rules (first match wins):
+
+| Pattern | Type | Examples |
+|---|---|---|
+| `(GH-\|#)?N` (1–5 digits) | `issue` | `#42`, `GH-42`, `42` |
+| `PR-N`, `pull/N`, `pr/N`, `#PRN` | `pull_request` | `PR-7`, `pull/7` |
+| 7–40 hex chars | `commit` | `abc1234`, full SHA |
+| else | `unknown` (warning) | |
+
+Failure modes never throw — the returned `{sources, warnings}` tells the caller what was and wasn't available.

--- a/documents/roadmap.md
+++ b/documents/roadmap.md
@@ -4,24 +4,46 @@ Development direction and exploration guidance. Living document — update as pr
 
 ---
 
-## Patchwork Phase 2 — Runtime Approval Gate + Recipes (branch `phase-2-restore`, 2026-04-18)
+## Patchwork Phase 2 — shipped (as of 2026-04-18)
 
-**Shipped on branch, awaiting PR → main:**
+**Oversight infrastructure** (merged to main in PRs #2–#9):
+- **Runtime approval gate** ([src/approvalHttp.ts](../src/approvalHttp.ts)) — dashboard is the UI for CC's "ask" rules. `approvalGate` runtime knob (`off` / `high` / `all`) flipped live from settings. Risk signals (destructive flags, non-HTTPS URLs, path escape) surfaced as badges. Managed settings file enforces admin policy above user/project. Precedence + design: [ADR-0006](../docs/adr/0006-approval-gate-design.md).
+- **CC PreToolUse hook** — `scripts/patchwork-approval-hook.sh` routes native CC tool calls through the bridge gate, not just MCP transport calls.
+- **Recipe system** — YAML/JSON recipes with manual / cron (`@every`) / webhook (`POST /hooks/<name>`) / file-watch triggers. Persistent run-history via `RecipeRunLog` (JSONL at `~/.patchwork/runs.jsonl`, not SQLite). Dashboard `/recipes` + `/recipes/new` composer.
+- **Dashboard surfaces** — `/approvals` with pattern-learning hooks + live streaming, `/analytics`, `/sessions`, `/recipes`, `/runs`, `/metrics`.
+- **`GET /cc-permissions`** — merged rules tagged with origin (`managed` / `project` / `user`) so the UI explains *why* a rule matched.
 
-- **Runtime approval gate** ([src/approvalHttp.ts](../src/approvalHttp.ts)) — dashboard is the UI for CC's "ask" rules. `approvalGate` runtime knob (`off` / `high` / `all`) flipped from settings page, takes effect next request. Risk signals (destructive flags, non-HTTPS URLs, path escape) surfaced as badges. Managed settings file enforces admin policy above user/project. Precedence + design rationale: [ADR-0006](../docs/adr/0006-approval-gate-design.md).
-- **CC PreToolUse hook wiring** — `scripts/patchwork-approval-hook.sh` reads stdin JSON, POSTs to `/approvals`, blocks on bridge decision. Works for native CC tool calls (not just MCP transport).
-- **Recipe system** — YAML/JSON recipes installable via `patchwork recipe install <path>`. Manual, cron (`@every`), webhook (`POST /hooks/<name>`), and file-watch triggers. Persistent run-history audit log (SQLite). Dashboard `/recipes` + `/recipes/new` composer.
-- **Dashboard surfaces** — `/analytics` (decisions over time, per-session), `/sessions` (live session state), `/approvals` with pattern learning hooks + live streaming via `useBridgeFetch` / `useBridgeStream`.
-- **`GET /cc-permissions`** — returns merged rules tagged with origin (`managed` / `project` / `user`) so the UI can explain why a rule matched.
+**Enrichment Engine** (merged in PRs #10–#11):
+- **`enrichCommit`** ([src/tools/enrichCommit.ts](../src/tools/enrichCommit.ts)) — parses `#N` / `GH-N` refs from commit message, fetches each issue via `gh`, classifies close-vs-reference by verb proximity.
+- **`CommitIssueLinkLog`** ([src/commitIssueLinkLog.ts](../src/commitIssueLinkLog.ts)) — JSONL persistence for enrichment results (`~/.patchwork/commit_issue_links.jsonl`); dedup on `(workspace, sha, ref)` unless state changes.
+- **`getCommitsForIssue`** — reverse lookup without re-running `gh`.
+- **`enrichStackTrace`** ([src/tools/enrichStackTrace.ts](../src/tools/enrichStackTrace.ts)) — maps stack frames (Node/Python/browser/generic) to introducing commits via shared `createBlameResolver`.
+- Shared helpers: [src/tools/issueRefs.ts](../src/tools/issueRefs.ts) (`extractIssueRefs`, `classifyIssueLink`), [src/tools/blame-utils.ts](../src/tools/blame-utils.ts).
 
-**Remaining to land Phase 2:**
+## Patchwork Phase 3 moat — shipped (2026-04-18)
 
-1. PR `phase-2-restore` → `main`.
-2. Enrichment Engine (commit → issue linker) — the original strategy-doc Phase 2 item. Current branch is oversight infrastructure; enrichment is still unstarted.
-3. Freshness scoring + dedup across context sources.
-4. Generalize the recipe run-log SQLite schema to a persistent decision-trace store (feeds Phase 3 moat).
+Cross-session memory loop, end-to-end. Merged in PRs #11–#15:
 
-**Coverage/test state on branch:** 3061 bridge tests passing (was 3052). `src/approvalHttp.ts` coverage: 76.6% lines, 78.3% branches, 83.3% funcs — above the 75/70/75 gate.
+| Direction | Surface | Lands in |
+|---|---|---|
+| **Agents write** decisions | `ctxSaveTrace` | `DecisionTraceLog` → `~/.patchwork/decision_traces.jsonl` |
+| System writes decisions | approval gate, `enrichCommit`, recipe runs | activityLog, `CommitIssueLinkLog`, `RecipeRunLog` |
+| **Agents read** (query) | `ctxQueryTraces` (4 traceTypes), `ctxGetTaskContext` | all four logs |
+| **Agents read** (injected) | session-start digest ([recentTracesDigest.ts](../src/tools/recentTracesDigest.ts)) | MCP instructions block on connect |
+| **Humans read** | `/traces` dashboard page | `GET /traces` + dashboard `[...]/page.tsx` |
+
+All four "phantom tools" previously advertised in the MCP handshake (`ctxGetTaskContext`, `ctxQueryTraces`, `ctxSaveTrace`, plus the digest) are now real handlers. Zero drift between what agents are told and what they can actually call.
+
+**Persistence model:** JSONL across all three logs (not SQLite). Each log has its own dedup / retention semantics; `ctxQueryTraces` is the unified reader. Adding SQLite would be a migration, not a rewrite — deferred until query volume demands it.
+
+**Test state (on main):** 3174 bridge tests passing. Lint 0 errors, 55 warnings (all pre-existing in src/vscode-extension). Dashboard excluded from bridge biome config (own toolchain).
+
+## Remaining Patchwork work
+
+1. **Dogfood the agent-read loop.** Instrumentation already emits `bridge_tool_calls_total{tool="ctxSaveTrace"}` etc. via Prometheus. Need real agent sessions to produce usage data; then decide whether instructions need strengthening to nudge agents toward the ctx tools.
+2. **Decision-trace dashboard view.** `/traces` bundles all 4 types; decisions (the agent-authored knowledge base) could use a dedicated tab with search-by-tag. Speculative until usage data warrants.
+3. **Freshness scoring + dedup across context sources.** Deferred research; wait until real duplication pain appears in `contextBundle` / `getCommitsForIssue` output.
+4. **Upstream connectors** (Sentry, Linear) — Phase 1 federation per `docs/platform-strategy.md`. `enrichStackTrace` already composes with *pasted* stacks; Sentry-as-connector is the next natural extension.
 
 ---
 


### PR DESCRIPTION
## Summary

Docs had drifted badly from the code. Three fixes:

**\`roadmap.md\`** — was still describing Phase 2 as \"awaiting PR → main\" with a list of \"remaining\" items, most of which have since shipped. Also referenced SQLite for recipe run-history (it's JSONL).

Replaced with:
- **Phase 2 shipped** — oversight infrastructure (approval gate, recipes, dashboards) + enrichment engine (enrichCommit, getCommitsForIssue, enrichStackTrace, CommitIssueLinkLog).
- **Phase 3 moat shipped** — ctxSaveTrace / ctxQueryTraces / ctxGetTaskContext + session-start digest + /traces dashboard.
- **Remaining work** — dogfood the agent-read loop, decision-trace dashboard view, freshness scoring (deferred pending real dedup pain), Sentry connector.

**\`platform-docs.md\`** — new \"Phase 3 Moat\" section documenting the three ctx tools, persistence model (JSONL, not SQLite), session-start digest, HTTP surface, and ref-detection heuristics. Also fixed stale pointers to \`~/.claude-ide-bridge/recipes/\` (actual path: \`~/.patchwork/recipes/\`).

**\`CLAUDE.md\`** — adds context-platform tools to the Quick Reference table and a new \"when to call what\" block telling agents to prefer \`ctxGetTaskContext\` over raw \`gh\` / \`git\` for task-context lookups, and to call \`ctxSaveTrace\` after resolving a task.

## Test plan

No code changes. Markdown only. Links verified to point at real files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)