### PR TITLE
fix(traces): wire 'decision' traceType into dashboard page

### DIFF
--- a/dashboard/src/app/traces/page.tsx
+++ b/dashboard/src/app/traces/page.tsx
@@ -3,7 +3,7 @@ import { useMemo, useState } from "react";
 import { relTime } from "@/components/time";
 import { useBridgeFetch } from "@/hooks/useBridgeFetch";
 
-type TraceType = "approval" | "enrichment" | "recipe_run";
+type TraceType = "approval" | "enrichment" | "recipe_run" | "decision";
 
 interface DecisionTrace {
   traceType: TraceType;
@@ -20,6 +20,7 @@ interface TracesResponse {
     approval: boolean;
     enrichment: boolean;
     recipe_run: boolean;
+    decision: boolean;
   };
 }
 
@@ -27,12 +28,14 @@ const TYPE_LABELS: Record<TraceType, string> = {
   approval: "Approval",
   enrichment: "Enrichment",
   recipe_run: "Recipe run",
+  decision: "Decision",
 };
 
 const TYPE_COLORS: Record<TraceType, string> = {
   approval: "var(--warn, #d97706)",
   enrichment: "var(--ok, #059669)",
   recipe_run: "var(--fg-2)",
+  decision: "#a78bfa",
 };
 
 export default function TracesPage() {
@@ -90,7 +93,9 @@ export default function TracesPage() {
         }}
       >
         <div style={{ display: "flex", gap: "var(--s-2)" }}>
-          {(["all", "approval", "enrichment", "recipe_run"] as const).map(
+          {(
+            ["all", "approval", "enrichment", "recipe_run", "decision"] as const
+          ).map(
             (f) => {
               const active = filter === f;
               return (


### PR DESCRIPTION
## Summary

**Found via live dogfood** — thanks to Wesley clicking through \`/traces\` with real data, three symptoms from one bug surfaced:

1. Decision rows rendered **without a type badge** (TYPE_COLORS lookup undefined)
2. Sources footer showed \`Sources: Approval · Enrichment · Recipe run ·\` (trailing orphan \`·\` because \`TYPE_LABELS[decision]\` was undefined → joined as empty string)
3. Filter bar had **no \"Decision\" tab** — agent-authored traces couldn't be isolated

One underlying cause: the dashboard page hardcoded 3 trace types but the backend has emitted 4 since PR #15 (\`ctxSaveTrace\`). I shipped the backend and the query layer but missed the dashboard.

Fix: add \`\"decision\"\` to the \`TraceType\` union, \`TYPE_LABELS\`, \`TYPE_COLORS\` (purple \`#a78bfa\` — matches the digest's ★ icon), filter-tab array, and sources response shape.

No backend change — pure dashboard drift. Validated by: reloading the page and observing the 4th tab appear, the orphan \`·\` disappear, and the \`#1 — base case changed...\` row now has a visible \`DECISION\` badge.

## Test plan

- [x] Dashboard reload shows all three symptoms resolved
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)