### PR TITLE
feat(activity): seed dashboard page with history before live stream

### DIFF
--- a/dashboard/src/app/activity/page.tsx
+++ b/dashboard/src/app/activity/page.tsx
@@ -7,7 +7,11 @@ interface ActivityEvent {
   tool?: string;
   status?: "success" | "error";
   durationMs?: number;
+  /** ISO 8601 timestamp from the bridge (both history + live stream). */
+  timestamp?: string;
+  /** Derived ms epoch, set by parse. */
   at?: number;
+  id?: number;
   // approval_decision fields (from metadata spread)
   toolName?: string;
   decision?: string;
@@ -19,13 +23,47 @@ interface ActivityEvent {
 
 const MAX_EVENTS = 200;
 
+function withAt(e: ActivityEvent): ActivityEvent {
+  if (typeof e.at === "number") return e;
+  if (e.timestamp) {
+    const ms = Date.parse(e.timestamp);
+    if (Number.isFinite(ms)) return { ...e, at: ms };
+  }
+  return e;
+}
+
 export default function ActivityPage() {
   const [events, setEvents] = useState<ActivityEvent[]>([]);
+  const [seeded, setSeeded] = useState(false);
   const [connected, setConnected] = useState(false);
   const [err, setErr] = useState<string>();
   const [filter, setFilter] = useState("");
   const [, setTick] = useState(0);
   const esRef = useRef<EventSource | null>(null);
+
+  // Seed with recent history on mount, then open the live stream.
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch("/api/bridge/activity?last=100");
+        if (res.ok) {
+          const data = (await res.json()) as { events?: ActivityEvent[] };
+          if (!cancelled) {
+            // Bridge returns oldest-first; dashboard renders newest-first.
+            const hist = (data.events ?? []).map(withAt).reverse();
+            setEvents(hist.slice(0, MAX_EVENTS));
+          }
+        }
+      } catch {
+        // history fetch failed — live stream still opens below
+      }
+      if (!cancelled) setSeeded(true);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   useEffect(() => {
     const es = new EventSource("/api/bridge/stream");
@@ -40,8 +78,18 @@ export default function ActivityPage() {
     };
     es.onmessage = (msg) => {
       try {
-        const entry = JSON.parse(msg.data) as ActivityEvent;
-        setEvents((prev) => [entry, ...prev].slice(0, MAX_EVENTS));
+        const entry = withAt(JSON.parse(msg.data) as ActivityEvent);
+        setEvents((prev) => {
+          // Dedup by (id, kind) so the first live event doesn't duplicate
+          // the most recent history row.
+          if (
+            entry.id !== undefined &&
+            prev.some((p) => p.id === entry.id && p.kind === entry.kind)
+          ) {
+            return prev;
+          }
+          return [entry, ...prev].slice(0, MAX_EVENTS);
+        });
       } catch {
         // ignore
       }
@@ -97,8 +145,12 @@ export default function ActivityPage() {
 
       {events.length === 0 ? (
         <div className="empty-state">
-          <h3>Waiting for events…</h3>
-          <p>Tool calls will appear here as they happen.</p>
+          <h3>{seeded ? "No activity yet" : "Loading history…"}</h3>
+          <p>
+            {seeded
+              ? "Tool calls and bridge events will appear here — most recent first."
+              : "Fetching recent events from the bridge."}
+          </p>
         </div>
       ) : (
         <div className="table-wrap">

--- a/src/__tests__/server-activity.test.ts
+++ b/src/__tests__/server-activity.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Integration tests for GET /activity — the HTTP surface that seeds the
+ * dashboard Activity page with history before the SSE stream takes over.
+ * Uses a stub activityFn so server logic is tested independently of the
+ * activityLog implementation.
+ */
+import http from "node:http";
+import { afterEach, describe, expect, it } from "vitest";
+import { Logger } from "../logger.js";
+import { Server } from "../server.js";
+
+const logger = new Logger(false);
+const TOKEN = "test-activity-token-00000000000000";
+
+let server: Server | null = null;
+let port = 0;
+
+async function startServer(
+  activityFn?: (last: number) => Record<string, unknown>[],
+): Promise<void> {
+  server = new Server(TOKEN, logger);
+  if (activityFn) server.activityFn = activityFn;
+  port = await server.findAndListen(null);
+}
+
+afterEach(async () => {
+  await server?.close();
+  server = null;
+  port = 0;
+});
+
+function get(path: string): Promise<{ status: number; body: string }> {
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      {
+        hostname: "127.0.0.1",
+        port,
+        method: "GET",
+        path,
+        headers: { Authorization: `Bearer ${TOKEN}` },
+      },
+      (res) => {
+        let data = "";
+        res.on("data", (c) => (data += c));
+        res.on("end", () =>
+          resolve({ status: res.statusCode ?? 0, body: data }),
+        );
+      },
+    );
+    req.on("error", reject);
+    req.end();
+  });
+}
+
+describe("GET /activity", () => {
+  it("returns empty when activityFn is not wired", async () => {
+    await startServer();
+    const { status, body } = await get("/activity");
+    expect(status).toBe(200);
+    const parsed = JSON.parse(body);
+    expect(parsed.events).toEqual([]);
+    expect(parsed.count).toBe(0);
+  });
+
+  it("passes through events from activityFn", async () => {
+    await startServer(() => [
+      {
+        kind: "tool",
+        id: 1,
+        timestamp: "2026-04-18T12:00:00Z",
+        tool: "Read",
+        durationMs: 5,
+        status: "success",
+      },
+      {
+        kind: "lifecycle",
+        id: 2,
+        timestamp: "2026-04-18T12:00:01Z",
+        event: "approval_decision",
+        metadata: { toolName: "Bash", decision: "allow" },
+      },
+    ]);
+    const { status, body } = await get("/activity");
+    expect(status).toBe(200);
+    const parsed = JSON.parse(body);
+    expect(parsed.count).toBe(2);
+    expect(parsed.events[0].tool).toBe("Read");
+    expect(parsed.events[1].event).toBe("approval_decision");
+  });
+
+  it("parses and caps `last` query param", async () => {
+    const received: number[] = [];
+    await startServer((last) => {
+      received.push(last);
+      return [];
+    });
+    await get("/activity?last=50");
+    await get("/activity?last=9999"); // should clamp to 500
+    await get("/activity"); // default 100
+    await get("/activity?last=abc"); // non-numeric → default
+    expect(received).toEqual([50, 500, 100, 100]);
+  });
+
+  it("returns 500 when activityFn throws", async () => {
+    await startServer(() => {
+      throw new Error("log on fire");
+    });
+    const { status, body } = await get("/activity");
+    expect(status).toBe(500);
+    const parsed = JSON.parse(body);
+    expect(parsed.error).toContain("log on fire");
+  });
+
+  it("requires auth", async () => {
+    await startServer(() => []);
+    const req = new Promise<number>((resolve, reject) => {
+      const r = http.request(
+        { hostname: "127.0.0.1", port, method: "GET", path: "/activity" },
+        (res) => resolve(res.statusCode ?? 0),
+      );
+      r.on("error", reject);
+      r.end();
+    });
+    expect(await req).toBe(401);
+  });
+});

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -1078,6 +1078,12 @@ export class Bridge {
         health: { score, signals },
       };
     };
+    this.server.activityFn = (last: number) => {
+      return this.activityLog.queryTimeline({ last }) as unknown as Record<
+        string,
+        unknown
+      >[];
+    };
     this.server.tracesFn = async (query) => {
       const tool = createCtxQueryTracesTool({
         activityLog: this.activityLog,

--- a/src/server.ts
+++ b/src/server.ts
@@ -185,6 +185,9 @@ export class Server extends EventEmitter<ServerEvents> {
   public analyticsFn:
     | ((windowHours?: number) => Promise<Record<string, unknown>>)
     | null = null;
+  /** Set by bridge to answer GET /activity — history of recent tool calls + lifecycle events. */
+  public activityFn: ((last: number) => Record<string, unknown>[]) | null =
+    null;
   /** Set by bridge to answer GET /traces via ctxQueryTraces over persistent logs. */
   public tracesFn:
     | ((query: {
@@ -552,6 +555,26 @@ export class Server extends EventEmitter<ServerEvents> {
           };
           res.writeHead(200, { "Content-Type": "application/json" });
           res.end(JSON.stringify(data));
+        } catch (err) {
+          res.writeHead(500, { "Content-Type": "application/json" });
+          res.end(
+            JSON.stringify({
+              error: err instanceof Error ? err.message : String(err),
+            }),
+          );
+        }
+        return;
+      }
+      if (parsedUrl.pathname === "/activity" && req.method === "GET") {
+        try {
+          const lastStr = parsedUrl.searchParams.get("last");
+          const last =
+            lastStr !== null && /^\d+$/.test(lastStr)
+              ? Math.min(Number(lastStr), 500)
+              : 100;
+          const data = this.activityFn?.(last) ?? [];
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ events: data, count: data.length }));
         } catch (err) {
           res.writeHead(500, { "Content-Type": "application/json" });
           res.end(


### PR DESCRIPTION
## Summary

**Dogfood bug** — opening \`/activity\` with nothing currently firing showed \`Waiting for events…\` forever. Every other dashboard treats \"activity\" as history; ours was stream-only, making the page feel broken.

### Backend

- \`GET /activity?last=N\` (default 100, max 500) returns \`activityLog.queryTimeline()\` as JSON \`{events, count}\`.
- Wired \`activityFn\` closure in \`bridge.ts\`.

### Dashboard

- Fetch \`/activity\` on mount, seed events (reversed to newest-first), then open SSE stream.
- Dedup by \`(id, kind)\` so the first live event doesn't duplicate the most recent history row.
- Parse ISO \`timestamp\` (from both history + stream) into ms \`at\` — fixes an **existing bug** where \`relTime\` always rendered \`—\` because the page read \`at\` but the stream only ever sent \`timestamp\`.
- Empty-state copy now distinguishes \"loading history\" from \"truly empty\".

### Why this over the lipstick fix

An earlier draft of this PR was copy-only polish on the empty state. That missed the point: the page is semantically called \"Activity\" — users expect history. Reviewed with Wesley, agreed to ditch the cosmetic patch and fix it properly.

## Test plan

- [x] 5 new integration tests — empty default, passthrough, query parsing, clamping, 500 on throw, auth
- [x] Full bridge suite: 3179/3179 passing
- [x] Lint clean
- [ ] Manual: restart bridge, reload \`/activity\`, confirm history populates before any new events fire

🤖 Generated with [Claude Code](https://claude.com/claude-code)