### PR TITLE
feat(approvals): detail view for pending + decided approvals

### DIFF
--- a/dashboard/src/app/approvals/[callId]/page.tsx
+++ b/dashboard/src/app/approvals/[callId]/page.tsx
@@ -1,0 +1,360 @@
+"use client";
+import Link from "next/link";
+import { useParams, useRouter } from "next/navigation";
+import { useState } from "react";
+import { relTime } from "@/components/time";
+import { useBridgeFetch } from "@/hooks/useBridgeFetch";
+
+interface RiskSignal {
+  kind: string;
+  label: string;
+  severity: "low" | "medium" | "high";
+}
+
+interface PendingRecord {
+  callId: string;
+  toolName: string;
+  tier: "low" | "medium" | "high";
+  requestedAt: number;
+  summary?: string;
+  params?: Record<string, unknown>;
+  sessionId?: string;
+  expiresAt?: number;
+  riskSignals?: RiskSignal[];
+}
+
+interface DecisionRecord {
+  id: number;
+  timestamp: string;
+  event: string;
+  metadata?: {
+    callId?: string;
+    toolName?: string;
+    specifier?: string;
+    decision?: string;
+    reason?: string;
+    permissionMode?: string;
+    sessionId?: string;
+    summary?: string;
+    riskSignals?: RiskSignal[];
+  };
+}
+
+interface NearbyTool {
+  kind: "tool";
+  id: number;
+  timestamp: string;
+  tool: string;
+  durationMs: number;
+  status: "success" | "error";
+  errorMessage?: string;
+}
+
+interface NearbyLifecycle {
+  kind: "lifecycle";
+  id: number;
+  timestamp: string;
+  event: string;
+  metadata?: Record<string, unknown>;
+}
+
+type NearbyEntry = NearbyTool | NearbyLifecycle;
+
+interface DetailResponse {
+  pending: PendingRecord | null;
+  decision: DecisionRecord | null;
+  nearby: NearbyEntry[];
+}
+
+export default function ApprovalDetailPage() {
+  const params = useParams<{ callId: string }>();
+  const router = useRouter();
+  const callId = params.callId;
+  const [decideErr, setDecideErr] = useState<string | null>(null);
+
+  const { data, error, loading, status } = useBridgeFetch<DetailResponse>(
+    `/api/bridge/approvals/${callId}`,
+    { intervalMs: 2000 },
+  );
+
+  async function decide(choice: "approve" | "reject") {
+    setDecideErr(null);
+    try {
+      const res = await fetch(`/api/bridge/${choice}/${callId}`, {
+        method: "POST",
+      });
+      if (!res.ok) {
+        setDecideErr(`${choice} failed: ${res.status}`);
+        return;
+      }
+      router.push("/approvals");
+    } catch (e) {
+      setDecideErr(e instanceof Error ? e.message : String(e));
+    }
+  }
+
+  const pending = data?.pending ?? null;
+  const decision = data?.decision ?? null;
+  const meta = decision?.metadata ?? {};
+
+  // Header state — prefer pending, then decision, then fall back.
+  const toolName = pending?.toolName ?? meta.toolName ?? "Unknown";
+  const tier = pending?.tier;
+  const decisionKind = meta.decision;
+  const sessionId = pending?.sessionId ?? meta.sessionId;
+
+  return (
+    <section>
+      <div className="page-head">
+        <div>
+          <div style={{ fontSize: 12, marginBottom: 4 }}>
+            <Link href="/approvals" style={{ color: "var(--fg-2)" }}>
+              ← Approvals
+            </Link>
+          </div>
+          <h1>{toolName}</h1>
+          <div className="page-head-sub">
+            <code style={{ fontFamily: "var(--font-mono)", fontSize: 12 }}>
+              {callId}
+            </code>
+          </div>
+        </div>
+        <div style={{ display: "flex", gap: 6, alignItems: "center" }}>
+          {pending && (
+            <span className="pill warn" title="Awaiting human decision">
+              pending
+            </span>
+          )}
+          {tier && (
+            <span className={`pill ${tierClass(tier)}`}>{tier} risk</span>
+          )}
+          {decisionKind && (
+            <span
+              className={`pill ${decisionKind === "allow" ? "ok" : "err"}`}
+            >
+              {decisionKind}
+            </span>
+          )}
+        </div>
+      </div>
+
+      {decideErr && <div className="alert-err">{decideErr}</div>}
+      {error && !data && (
+        <div className="alert-err">Unreachable: {error}</div>
+      )}
+      {!loading && !data && status === 404 && (
+        <div className="empty-state">
+          <h3>Unknown callId</h3>
+          <p>
+            This approval isn&apos;t pending and hasn&apos;t been decided yet.
+            It may have expired, or the ID is wrong.
+          </p>
+        </div>
+      )}
+
+      {pending && (
+        <div className="card" style={{ marginTop: "var(--s-4)" }}>
+          <div className="card-head">
+            <h2>Decide</h2>
+          </div>
+          <p style={{ fontSize: 13, color: "var(--fg-2)" }}>
+            Still in the queue. Approve or reject to unblock the caller.
+          </p>
+          <div
+            style={{
+              display: "flex",
+              gap: "var(--s-2)",
+              marginTop: "var(--s-3)",
+            }}
+          >
+            <button
+              type="button"
+              className="btn success"
+              onClick={() => decide("approve")}
+            >
+              Approve
+            </button>
+            <button
+              type="button"
+              className="btn danger"
+              onClick={() => decide("reject")}
+            >
+              Reject
+            </button>
+          </div>
+        </div>
+      )}
+
+      {decision && (
+        <div className="card" style={{ marginTop: "var(--s-4)" }}>
+          <div className="card-head">
+            <h2>Decision</h2>
+            <span className="pill muted" title={decision.timestamp}>
+              {relTime(Date.parse(decision.timestamp))}
+            </span>
+          </div>
+          <Row label="Decision" value={meta.decision ?? "—"} />
+          <Row label="Reason" value={meta.reason ?? "—"} mono />
+          {meta.specifier && (
+            <Row label="Specifier" value={meta.specifier} mono />
+          )}
+          {meta.permissionMode && (
+            <Row label="Permission mode" value={meta.permissionMode} mono />
+          )}
+          {meta.summary && <Row label="Summary" value={meta.summary} />}
+        </div>
+      )}
+
+      {(pending?.riskSignals?.length || meta.riskSignals?.length) && (
+        <div className="card" style={{ marginTop: "var(--s-4)" }}>
+          <div className="card-head">
+            <h2>Risk signals</h2>
+          </div>
+          <div
+            style={{
+              display: "flex",
+              gap: 6,
+              flexWrap: "wrap",
+              marginTop: 6,
+            }}
+          >
+            {(pending?.riskSignals ?? meta.riskSignals ?? []).map((s) => (
+              <span
+                key={`${s.kind}-${s.label}`}
+                className={`pill ${s.severity === "high" ? "err" : s.severity === "medium" ? "warn" : "muted"}`}
+                title={s.kind}
+              >
+                {s.label}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {sessionId && (
+        <div className="card" style={{ marginTop: "var(--s-4)" }}>
+          <div className="card-head">
+            <h2>Session</h2>
+          </div>
+          <div style={{ display: "flex", gap: "var(--s-3)", flexWrap: "wrap" }}>
+            <code style={{ fontFamily: "var(--font-mono)", fontSize: 12 }}>
+              {sessionId}
+            </code>
+            <Link
+              href={`/approvals?session=${sessionId}`}
+              style={{ fontSize: 13, color: "var(--accent)" }}
+            >
+              All approvals for this session →
+            </Link>
+          </div>
+        </div>
+      )}
+
+      {pending?.params && Object.keys(pending.params).length > 0 && (
+        <div className="card" style={{ marginTop: "var(--s-4)" }}>
+          <div className="card-head">
+            <h2>Parameters</h2>
+          </div>
+          <pre className="approval-params-json">
+            {JSON.stringify(pending.params, null, 2)}
+          </pre>
+        </div>
+      )}
+
+      {data?.nearby && data.nearby.length > 0 && (
+        <div className="card" style={{ marginTop: "var(--s-4)" }}>
+          <div className="card-head">
+            <h2>Nearby activity</h2>
+            <span className="pill muted">±60s · {data.nearby.length}</span>
+          </div>
+          <div className="table-wrap">
+            <table className="table">
+              <thead>
+                <tr>
+                  <th style={{ width: 140 }}>Time</th>
+                  <th style={{ width: 110 }}>Kind</th>
+                  <th>Tool / Event</th>
+                  <th style={{ width: 110 }}>Duration</th>
+                  <th style={{ width: 110 }}>Status</th>
+                </tr>
+              </thead>
+              <tbody>
+                {data.nearby.map((e) => (
+                  <tr key={`${e.kind}-${e.id}`}>
+                    <td className="muted" title={e.timestamp}>
+                      {relTime(Date.parse(e.timestamp))}
+                    </td>
+                    <td>
+                      <span
+                        className={`pill ${
+                          e.kind === "tool" && e.status === "error"
+                            ? "err"
+                            : "muted"
+                        }`}
+                      >
+                        {e.kind === "tool" ? "tool" : e.event}
+                      </span>
+                    </td>
+                    <td className="mono">
+                      {e.kind === "tool" ? e.tool : "—"}
+                    </td>
+                    <td className="mono muted">
+                      {e.kind === "tool" ? `${e.durationMs}ms` : "—"}
+                    </td>
+                    <td>
+                      {e.kind === "tool" ? (
+                        <span
+                          className={`status-cell ${e.status === "error" ? "err" : "ok"}`}
+                        >
+                          <span className="pill-dot" />
+                          {e.status}
+                        </span>
+                      ) : (
+                        <span className="muted">—</span>
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}
+
+function Row({
+  label,
+  value,
+  mono,
+}: {
+  label: string;
+  value: string;
+  mono?: boolean;
+}) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        justifyContent: "space-between",
+        gap: 16,
+        padding: "10px 0",
+        borderBottom: "1px solid var(--border-subtle)",
+        fontSize: 13,
+      }}
+    >
+      <span style={{ color: "var(--fg-2)" }}>{label}</span>
+      <span
+        className={mono ? "mono" : undefined}
+        style={{ color: "var(--fg-0)", textAlign: "right" }}
+      >
+        {value}
+      </span>
+    </div>
+  );
+}
+
+function tierClass(t: string): string {
+  return t === "high" ? "err" : t === "medium" ? "warn" : "ok";
+}

--- a/dashboard/src/app/approvals/page.tsx
+++ b/dashboard/src/app/approvals/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { Suspense, useCallback, useEffect, useState } from "react";
 import { useApprovalPatterns } from "../../hooks/useApprovalPatterns";
@@ -325,6 +326,13 @@ function ApprovalsContent() {
                   >
                     Reject
                   </button>
+                  <Link
+                    href={`/approvals/${p.callId}`}
+                    className="btn sm ghost"
+                    style={{ textDecoration: "none" }}
+                  >
+                    Details →
+                  </Link>
                   <span className="approval-spacer" />
                   <span className="pill muted" title={p.callId}>
                     {p.callId.slice(0, 8)}

--- a/src/__tests__/activityLog.test.ts
+++ b/src/__tests__/activityLog.test.ts
@@ -564,3 +564,56 @@ describe("ActivityLog.recordRateLimitRejection", () => {
     expect(log.getRateLimitRejections()).toBe(2);
   });
 });
+
+describe("ActivityLog.findApprovalByCallId", () => {
+  it("returns null decision when callId is not logged", async () => {
+    const { ActivityLog } = await import("../activityLog.js");
+    const log = new ActivityLog();
+    const out = log.findApprovalByCallId("missing");
+    expect(out.decision).toBeNull();
+    expect(out.nearby).toEqual([]);
+  });
+
+  it("finds the decision and same-session lifecycle events in window", async () => {
+    const { ActivityLog } = await import("../activityLog.js");
+    const log = new ActivityLog();
+    log.recordEvent("approval_decision", {
+      callId: "call-1",
+      toolName: "Bash",
+      decision: "allow",
+      sessionId: "sess-a",
+    });
+    // Same session, within ±60s.
+    log.recordEvent("session_resumed", { sessionId: "sess-a" });
+    // Different session — must be excluded.
+    log.recordEvent("claude_connected", { sessionId: "sess-other" });
+
+    const out = log.findApprovalByCallId("call-1");
+    expect(out.decision?.metadata?.callId).toBe("call-1");
+    expect(out.nearby).toHaveLength(1);
+    expect(out.nearby[0]).toMatchObject({
+      kind: "lifecycle",
+      event: "session_resumed",
+    });
+  });
+
+  it("excludes the decision itself from nearby list", async () => {
+    const { ActivityLog } = await import("../activityLog.js");
+    const log = new ActivityLog();
+    log.recordEvent("approval_decision", {
+      callId: "call-2",
+      sessionId: "sess-b",
+    });
+    const out = log.findApprovalByCallId("call-2");
+    expect(out.nearby.every((e) => e.id !== out.decision?.id)).toBe(true);
+  });
+
+  it("returns empty nearby when decision has no sessionId", async () => {
+    const { ActivityLog } = await import("../activityLog.js");
+    const log = new ActivityLog();
+    log.recordEvent("approval_decision", { callId: "call-3" });
+    const out = log.findApprovalByCallId("call-3");
+    expect(out.decision).not.toBeNull();
+    expect(out.nearby).toEqual([]);
+  });
+});

--- a/src/__tests__/server-approval-detail.test.ts
+++ b/src/__tests__/server-approval-detail.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Integration tests for GET /approvals/:callId — single-approval detail lookup
+ * backing the dashboard approval detail view. Uses a stub approvalDetailFn so
+ * we test the server routing + serialization independently of ActivityLog +
+ * ApprovalQueue wiring (covered by unit tests).
+ */
+import http from "node:http";
+import { afterEach, describe, expect, it } from "vitest";
+import { Logger } from "../logger.js";
+import { Server } from "../server.js";
+
+const logger = new Logger(false);
+const TOKEN = "test-approval-detail-token-000000";
+
+let server: Server | null = null;
+let port = 0;
+
+async function startServer(
+  detailFn?: (callId: string) => {
+    pending: Record<string, unknown> | null;
+    decision: Record<string, unknown> | null;
+    nearby: Record<string, unknown>[];
+  },
+): Promise<void> {
+  server = new Server(TOKEN, logger);
+  if (detailFn) server.approvalDetailFn = detailFn;
+  port = await server.findAndListen(null);
+}
+
+afterEach(async () => {
+  await server?.close();
+  server = null;
+  port = 0;
+});
+
+function get(
+  path: string,
+  auth = true,
+): Promise<{ status: number; body: string }> {
+  return new Promise((resolve, reject) => {
+    const headers: Record<string, string> = {};
+    if (auth) headers.Authorization = `Bearer ${TOKEN}`;
+    const req = http.request(
+      { hostname: "127.0.0.1", port, method: "GET", path, headers },
+      (res) => {
+        let data = "";
+        res.on("data", (c) => (data += c));
+        res.on("end", () =>
+          resolve({ status: res.statusCode ?? 0, body: data }),
+        );
+      },
+    );
+    req.on("error", reject);
+    req.end();
+  });
+}
+
+describe("GET /approvals/:callId", () => {
+  it("404s when detailFn is not wired", async () => {
+    await startServer();
+    const { status } = await get("/approvals/abc-123");
+    expect(status).toBe(404);
+  });
+
+  it("404s when callId is unknown (both pending + decision null)", async () => {
+    await startServer(() => ({ pending: null, decision: null, nearby: [] }));
+    const { status, body } = await get("/approvals/unknown-id");
+    expect(status).toBe(404);
+    expect(JSON.parse(body).error).toBe("unknown callId");
+  });
+
+  it("returns pending record when approval is in-flight", async () => {
+    await startServer((callId) => ({
+      pending: {
+        callId,
+        toolName: "Bash",
+        tier: "high",
+        requestedAt: 1_700_000_000_000,
+        params: { command: "rm -rf /tmp/x" },
+      },
+      decision: null,
+      nearby: [],
+    }));
+    const { status, body } = await get("/approvals/pending-1");
+    expect(status).toBe(200);
+    const parsed = JSON.parse(body);
+    expect(parsed.pending.callId).toBe("pending-1");
+    expect(parsed.pending.toolName).toBe("Bash");
+    expect(parsed.decision).toBeNull();
+  });
+
+  it("returns decided record with nearby activity", async () => {
+    await startServer((callId) => ({
+      pending: null,
+      decision: {
+        id: 42,
+        timestamp: "2026-04-18T12:00:00Z",
+        event: "approval_decision",
+        metadata: {
+          callId,
+          toolName: "Bash",
+          decision: "allow",
+          reason: "user_approved",
+          sessionId: "sess-abc",
+        },
+      },
+      nearby: [
+        {
+          kind: "tool",
+          id: 43,
+          timestamp: "2026-04-18T12:00:05Z",
+          tool: "Bash",
+          durationMs: 120,
+          status: "success",
+        },
+      ],
+    }));
+    const { status, body } = await get("/approvals/decided-1");
+    expect(status).toBe(200);
+    const parsed = JSON.parse(body);
+    expect(parsed.pending).toBeNull();
+    expect(parsed.decision.metadata.decision).toBe("allow");
+    expect(parsed.nearby).toHaveLength(1);
+    expect(parsed.nearby[0].tool).toBe("Bash");
+  });
+
+  it("returns 500 when detailFn throws", async () => {
+    await startServer(() => {
+      throw new Error("log on fire");
+    });
+    const { status, body } = await get("/approvals/boom");
+    expect(status).toBe(500);
+    expect(JSON.parse(body).error).toContain("log on fire");
+  });
+
+  it("requires auth", async () => {
+    await startServer(() => ({
+      pending: null,
+      decision: null,
+      nearby: [],
+    }));
+    const { status } = await get("/approvals/any", false);
+    expect(status).toBe(401);
+  });
+
+  it("does not collide with /approvals list endpoint", async () => {
+    // /approvals (no trailing id) must still hit the list handler, which
+    // doesn't use approvalDetailFn. Stub detailFn to fail loudly if hit.
+    await startServer(() => {
+      throw new Error("detailFn must not be called for /approvals");
+    });
+    const { status } = await get("/approvals");
+    expect(status).toBe(200);
+  });
+});

--- a/src/activityLog.ts
+++ b/src/activityLog.ts
@@ -256,6 +256,58 @@ export class ActivityLog {
     return Math.max(0, this.nextId - 1);
   }
 
+  /**
+   * Look up a single approval_decision lifecycle entry by callId. Returns
+   * the decision entry plus tool entries + lifecycle events for the same
+   * session in the ±60s window around the decision (for context).
+   *
+   * The dashboard approval detail view is the only caller; keep the window
+   * tight so we don't walk unbounded history for each lookup.
+   */
+  findApprovalByCallId(callId: string): {
+    decision: LifecycleEntry | null;
+    nearby: TimelineEntry[];
+  } {
+    const decision =
+      this.lifecycleEntries.find(
+        (e) =>
+          e.event === "approval_decision" &&
+          typeof e.metadata?.callId === "string" &&
+          e.metadata.callId === callId,
+      ) ?? null;
+    if (!decision) return { decision: null, nearby: [] };
+
+    const sessionId =
+      typeof decision.metadata?.sessionId === "string"
+        ? decision.metadata.sessionId
+        : undefined;
+    if (!sessionId) return { decision, nearby: [] };
+
+    const tDecision = Date.parse(decision.timestamp);
+    const windowMs = 60_000;
+    const lo = tDecision - windowMs;
+    const hi = tDecision + windowMs;
+
+    const tools: TimelineEntry[] = this.entries
+      .filter((e) => {
+        const t = Date.parse(e.timestamp);
+        return t >= lo && t <= hi;
+      })
+      .map((e) => ({ kind: "tool" as const, ...e }));
+
+    const lifecycle: TimelineEntry[] = this.lifecycleEntries
+      .filter((e) => {
+        if (e.id === decision.id) return false;
+        if (e.metadata?.sessionId !== sessionId) return false;
+        const t = Date.parse(e.timestamp);
+        return t >= lo && t <= hi;
+      })
+      .map((e) => ({ kind: "lifecycle" as const, ...e }));
+
+    const nearby = [...tools, ...lifecycle].sort((a, b) => a.id - b.id);
+    return { decision, nearby };
+  }
+
   queryTimeline(opts?: { last?: number }): TimelineEntry[] {
     const tools: TimelineEntry[] = this.entries.map((e) => ({
       kind: "tool" as const,

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -1084,6 +1084,17 @@ export class Bridge {
         unknown
       >[];
     };
+    this.server.approvalDetailFn = (callId: string) => {
+      const queue = getApprovalQueue();
+      const pending = queue.list().find((p) => p.callId === callId) ?? null;
+      const { decision, nearby } =
+        this.activityLog.findApprovalByCallId(callId);
+      return {
+        pending: pending as unknown as Record<string, unknown> | null,
+        decision: decision as unknown as Record<string, unknown> | null,
+        nearby: nearby as unknown as Record<string, unknown>[],
+      };
+    };
     this.server.tracesFn = async (query) => {
       const tool = createCtxQueryTracesTool({
         activityLog: this.activityLog,

--- a/src/server.ts
+++ b/src/server.ts
@@ -188,6 +188,14 @@ export class Server extends EventEmitter<ServerEvents> {
   /** Set by bridge to answer GET /activity — history of recent tool calls + lifecycle events. */
   public activityFn: ((last: number) => Record<string, unknown>[]) | null =
     null;
+  /** Set by bridge to answer GET /approvals/:callId — decision record + nearby session activity. */
+  public approvalDetailFn:
+    | ((callId: string) => {
+        pending: Record<string, unknown> | null;
+        decision: Record<string, unknown> | null;
+        nearby: Record<string, unknown>[];
+      })
+    | null = null;
   /** Set by bridge to answer GET /traces via ctxQueryTraces over persistent logs. */
   public tracesFn:
     | ((query: {
@@ -1036,6 +1044,32 @@ export class Server extends EventEmitter<ServerEvents> {
         });
         return;
       }
+      // Single-approval detail lookup for the dashboard detail page.
+      const detailMatch = /^\/approvals\/([A-Za-z0-9-]+)$/.exec(
+        parsedUrl.pathname,
+      );
+      if (detailMatch && req.method === "GET") {
+        const callId = detailMatch[1] as string;
+        try {
+          const data = this.approvalDetailFn?.(callId);
+          if (!data || (!data.pending && !data.decision)) {
+            res.writeHead(404, { "Content-Type": "application/json" });
+            res.end(JSON.stringify({ error: "unknown callId" }));
+            return;
+          }
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(JSON.stringify(data));
+        } catch (err) {
+          res.writeHead(500, { "Content-Type": "application/json" });
+          res.end(
+            JSON.stringify({
+              error: err instanceof Error ? err.message : String(err),
+            }),
+          );
+        }
+        return;
+      }
+
       // Patchwork approval surface — PreToolUse hook + dashboard approve/reject.
       // Bearer auth already checked above.
       if (


### PR DESCRIPTION
## Summary
- New route \`/approvals/[callId]\` shows full decision record, risk signals, session context, params, and ±60s nearby activity
- Bridge exposes \`GET /approvals/:callId\` via new \`Server.approvalDetailFn\`; \`ActivityLog.findApprovalByCallId()\` does the lookup
- Approval list rows gain a "Details →" link; still-pending rows show approve/reject on the detail page too

## Why
From roadmap #4 (approval detail view). Previously approval rows were dead-ends — no way to see the full decision record, correlate with session activity, or inspect why a rule matched. Now surfacing everything that's already persisted.

## Test plan
- [x] Unit tests for \`ActivityLog.findApprovalByCallId\` (4 cases: missing, same-session nearby, decision self-exclusion, no-sessionId)
- [x] Integration tests for \`GET /approvals/:callId\` (7 cases: unwired, unknown, pending, decided+nearby, error, auth, no-collision-with-list)
- [x] Full test suite passes (3190 tests)
- [x] Dashboard tsc clean
- [ ] Dogfood: click an approval row, confirm detail page renders