### PR TITLE
feat(traces): full-text search across summary + body

### DIFF
--- a/dashboard/src/app/traces/page.tsx
+++ b/dashboard/src/app/traces/page.tsx
@@ -41,16 +41,18 @@ const TYPE_COLORS: Record<TraceType, string> = {
 export default function TracesPage() {
   const [filter, setFilter] = useState<TraceType | "all">("all");
   const [keyQuery, setKeyQuery] = useState("");
+  const [textQuery, setTextQuery] = useState("");
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
 
   const qs = useMemo(() => {
     const params = new URLSearchParams();
     if (filter !== "all") params.set("traceType", filter);
     if (keyQuery.trim()) params.set("key", keyQuery.trim());
+    if (textQuery.trim()) params.set("q", textQuery.trim());
     params.set("limit", "200");
     const s = params.toString();
     return s ? `?${s}` : "";
-  }, [filter, keyQuery]);
+  }, [filter, keyQuery, textQuery]);
 
   const { data, error, loading } = useBridgeFetch<TracesResponse>(
     `/api/bridge/traces${qs}`,
@@ -138,6 +140,22 @@ export default function TracesPage() {
             color: "var(--fg-0)",
           }}
         />
+        <input
+          type="text"
+          value={textQuery}
+          onChange={(e) => setTextQuery(e.target.value)}
+          placeholder="search summary + body (case-insensitive)"
+          style={{
+            flex: 1,
+            minWidth: 240,
+            padding: "6px 10px",
+            fontSize: 13,
+            background: "var(--bg-2)",
+            border: "1px solid var(--bg-3)",
+            borderRadius: 4,
+            color: "var(--fg-0)",
+          }}
+        />
       </div>
 
       {sources && (
@@ -161,14 +179,14 @@ export default function TracesPage() {
       {!loading && traces.length === 0 && !error ? (
         <div className="empty-state">
           <h3>
-            {filter === "all" && !keyQuery
+            {filter === "all" && !keyQuery && !textQuery
               ? "No traces yet"
               : "No matching traces"}
           </h3>
           <p>
-            {filter === "all" && !keyQuery
+            {filter === "all" && !keyQuery && !textQuery
               ? "Traces will appear once the bridge records approval decisions, enrichment links, or recipe runs."
-              : `No ${filter === "all" ? "traces" : TYPE_LABELS[filter as TraceType].toLowerCase()} traces${keyQuery ? ` matching "${keyQuery}"` : ""}.`}
+              : `No ${filter === "all" ? "traces" : TYPE_LABELS[filter as TraceType].toLowerCase()} traces${keyQuery ? ` with key matching "${keyQuery}"` : ""}${textQuery ? ` containing "${textQuery}"` : ""}.`}
           </p>
         </div>
       ) : (

--- a/src/__tests__/server-traces.test.ts
+++ b/src/__tests__/server-traces.test.ts
@@ -19,6 +19,7 @@ async function startServer(
   tracesFn?: (q: {
     traceType?: string;
     key?: string;
+    q?: string;
     since?: number;
     limit?: number;
   }) => Promise<Record<string, unknown>>,
@@ -101,11 +102,12 @@ describe("GET /traces", () => {
       return { traces: [], count: 0, sources: {} };
     });
     await get(
-      "/traces?traceType=enrichment&key=abc&since=1700000000000&limit=25",
+      "/traces?traceType=enrichment&key=abc&q=needle&since=1700000000000&limit=25",
     );
     expect(received[0]).toEqual({
       traceType: "enrichment",
       key: "abc",
+      q: "needle",
       since: 1_700_000_000_000,
       limit: 25,
     });

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -1105,6 +1105,7 @@ export class Bridge {
       const result = await tool.handler({
         ...(query.traceType && { traceType: query.traceType }),
         ...(query.key && { key: query.key }),
+        ...(query.q && { q: query.q }),
         ...(query.since !== undefined && { since: query.since }),
         ...(query.limit !== undefined && { limit: query.limit }),
       });

--- a/src/server.ts
+++ b/src/server.ts
@@ -201,6 +201,7 @@ export class Server extends EventEmitter<ServerEvents> {
     | ((query: {
         traceType?: string;
         key?: string;
+        q?: string;
         since?: number;
         limit?: number;
       }) => Promise<Record<string, unknown>>)
@@ -602,6 +603,7 @@ export class Server extends EventEmitter<ServerEvents> {
             ? await this.tracesFn({
                 traceType: q.get("traceType") ?? undefined,
                 key: q.get("key") ?? undefined,
+                q: q.get("q") ?? undefined,
                 since:
                   sinceStr !== null && /^\d+$/.test(sinceStr)
                     ? Number(sinceStr)

--- a/src/tools/__tests__/ctxQueryTraces.test.ts
+++ b/src/tools/__tests__/ctxQueryTraces.test.ts
@@ -252,3 +252,83 @@ describe("ctxQueryTraces", () => {
     expect(res.traces[0].traceType).toBe("decision");
   });
 });
+
+describe("ctxQueryTraces — q (text search)", () => {
+  it("matches on summary (case-insensitive)", async () => {
+    seed();
+    const tool = createCtxQueryTracesTool({
+      activityLog,
+      commitIssueLinkLog: linkLog,
+      recipeRunLog: runLog,
+    });
+    const res = parse(await tool.handler({ q: "DENY" }));
+    expect(res.count).toBeGreaterThan(0);
+    for (const t of res.traces) {
+      const hay = JSON.stringify(t).toLowerCase();
+      expect(hay).toContain("deny");
+    }
+  });
+
+  it("matches inside body (serialized JSON)", async () => {
+    linkLog.record({
+      sha: "zzz",
+      ref: "#99",
+      linkType: "closes",
+      resolved: true,
+      workspace: "/ws",
+      subject: "needle-in-body-field",
+      issueState: "OPEN",
+    });
+    const tool = createCtxQueryTracesTool({
+      activityLog: null,
+      commitIssueLinkLog: linkLog,
+      recipeRunLog: null,
+    });
+    const res = parse(await tool.handler({ q: "needle-in-body-field" }));
+    expect(res.count).toBe(1);
+    expect(res.traces[0].key).toBe("zzz:#99");
+  });
+
+  it("returns empty when q matches nothing", async () => {
+    seed();
+    const tool = createCtxQueryTracesTool({
+      activityLog,
+      commitIssueLinkLog: linkLog,
+      recipeRunLog: runLog,
+    });
+    const res = parse(await tool.handler({ q: "xyzzy-not-present" }));
+    expect(res.count).toBe(0);
+    expect(res.traces).toEqual([]);
+  });
+
+  it("combines with traceType and key filters (AND semantics)", async () => {
+    linkLog.record({
+      sha: "match",
+      ref: "#1",
+      linkType: "closes",
+      resolved: true,
+      workspace: "/ws",
+      subject: "pineapple",
+      issueState: "OPEN",
+    });
+    linkLog.record({
+      sha: "nope",
+      ref: "#2",
+      linkType: "closes",
+      resolved: true,
+      workspace: "/ws",
+      subject: "apricot",
+      issueState: "OPEN",
+    });
+    const tool = createCtxQueryTracesTool({
+      activityLog: null,
+      commitIssueLinkLog: linkLog,
+      recipeRunLog: null,
+    });
+    const res = parse(
+      await tool.handler({ traceType: "enrichment", q: "pineapple" }),
+    );
+    expect(res.count).toBe(1);
+    expect(res.traces[0].body.subject).toBe("pineapple");
+  });
+});

--- a/src/tools/ctxQueryTraces.ts
+++ b/src/tools/ctxQueryTraces.ts
@@ -126,6 +126,11 @@ export function createCtxQueryTracesTool(deps: CtxQueryTracesDeps) {
             description:
               "Exact key match (sessionId:toolName / sha:ref / taskId). Substring match on the key; case-sensitive.",
           },
+          q: {
+            type: "string",
+            description:
+              "Case-insensitive substring search across the trace summary and serialized body. Use for free-form lookup when the key schema doesn't fit.",
+          },
           since: {
             type: "integer",
             description: "Only return traces with ts > this ms-epoch value.",
@@ -180,6 +185,7 @@ export function createCtxQueryTracesTool(deps: CtxQueryTracesDeps) {
         | undefined
         | "";
       const keyFilter = optionalString(args, "key");
+      const qFilter = optionalString(args, "q");
       const since = optionalInt(args, "since", 0, Number.MAX_SAFE_INTEGER);
       const limit = optionalInt(args, "limit", 1, 500) ?? 100;
 
@@ -212,6 +218,17 @@ export function createCtxQueryTracesTool(deps: CtxQueryTracesDeps) {
       if (keyFilter) {
         const needle = keyFilter;
         filtered = filtered.filter((t) => t.key.includes(needle));
+      }
+      if (qFilter) {
+        const needle = qFilter.toLowerCase();
+        filtered = filtered.filter((t) => {
+          if (t.summary.toLowerCase().includes(needle)) return true;
+          try {
+            return JSON.stringify(t.body).toLowerCase().includes(needle);
+          } catch {
+            return false;
+          }
+        });
       }
 
       filtered.sort((a, b) => b.ts - a.ts);


### PR DESCRIPTION
## Summary
- \`ctxQueryTraces\` gains a \`q\` param — case-insensitive substring search over \`summary\` + stringified \`body\`
- Plumbed through \`GET /traces?q=...\` and the dashboard Traces page (new text input next to the key filter)
- Combines with \`traceType\`, \`key\`, \`since\`, \`limit\` via AND semantics

## Why
Roadmap #2. Traces can be filtered by type + natural key today, but operators searching for a file name, error message, or reason code had to scan JSON manually. This closes that gap with a free-text fallback; natural-key lookup stays fast for the common case.

## Test plan
- [x] 4 new unit tests for \`ctxQueryTraces\` \`q\` (summary match, body match, no match, combined with type+key)
- [x] Integration test updated to assert \`q\` propagates through server → tracesFn
- [x] Full suite + dashboard tsc clean
- [ ] Dogfood: type text on /traces, confirm results filter