### PR TITLE
feat(sessions): per-session drill-down view

### DIFF
--- a/dashboard/src/app/sessions/[id]/page.tsx
+++ b/dashboard/src/app/sessions/[id]/page.tsx
@@ -1,0 +1,240 @@
+"use client";
+import Link from "next/link";
+import { useParams } from "next/navigation";
+import { relTime } from "@/components/time";
+import { useBridgeFetch } from "@/hooks/useBridgeFetch";
+
+interface SessionSummary {
+  id: string;
+  connectedAt: string;
+  openedFileCount: number;
+  pendingApprovals: number;
+}
+
+interface LifecycleEntry {
+  id: number;
+  timestamp: string;
+  event: string;
+  metadata?: Record<string, unknown>;
+}
+
+interface PendingApproval {
+  callId: string;
+  toolName: string;
+  tier: "low" | "medium" | "high";
+  requestedAt: number;
+  summary?: string;
+}
+
+interface DetailResponse {
+  summary: SessionSummary | null;
+  lifecycle: LifecycleEntry[];
+  approvals: PendingApproval[];
+}
+
+const NOISE_EVENTS = new Set([
+  "claude_connected",
+  "claude_disconnected",
+  "extension_connected",
+  "extension_disconnected",
+  "grace_started",
+  "grace_expired",
+]);
+
+export default function SessionDetailPage() {
+  const params = useParams<{ id: string }>();
+  const id = params.id;
+
+  const { data, error, loading, status } = useBridgeFetch<DetailResponse>(
+    `/api/bridge/sessions/${id}`,
+    { intervalMs: 3000 },
+  );
+
+  const summary = data?.summary ?? null;
+  const approvals = data?.approvals ?? [];
+  const lifecycle = (data?.lifecycle ?? []).slice().reverse(); // newest first
+
+  return (
+    <section>
+      <div className="page-head">
+        <div>
+          <div style={{ fontSize: 12, marginBottom: 4 }}>
+            <Link href="/sessions" style={{ color: "var(--fg-2)" }}>
+              ← Sessions
+            </Link>
+          </div>
+          <h1>
+            <code style={{ fontFamily: "var(--font-mono)", fontSize: 20 }}>
+              {id.slice(0, 8)}
+            </code>
+          </h1>
+          <div
+            className="page-head-sub"
+            title={id}
+            style={{ fontFamily: "var(--font-mono)", fontSize: 12 }}
+          >
+            {id}
+          </div>
+        </div>
+        {summary && (
+          <div style={{ display: "flex", gap: 6 }}>
+            <span className="pill muted">
+              {summary.openedFileCount} open
+            </span>
+            {summary.pendingApprovals > 0 && (
+              <Link
+                href={`/approvals?session=${id}`}
+                className="pill err"
+                title="Pending approvals"
+              >
+                {summary.pendingApprovals} pending
+              </Link>
+            )}
+          </div>
+        )}
+      </div>
+
+      {error && !data && <div className="alert-err">Unreachable: {error}</div>}
+      {!loading && !data && status === 404 && (
+        <div className="empty-state">
+          <h3>Session not found</h3>
+          <p>
+            No active session with this id. It may have disconnected, or the
+            id is wrong.
+          </p>
+        </div>
+      )}
+
+      {summary && (
+        <div className="card" style={{ marginTop: "var(--s-4)" }}>
+          <div className="card-head">
+            <h2>Summary</h2>
+            <span
+              className="pill muted"
+              title={new Date(summary.connectedAt).toLocaleString()}
+            >
+              connected {relTime(new Date(summary.connectedAt).getTime())}
+            </span>
+          </div>
+        </div>
+      )}
+
+      {approvals.length > 0 && (
+        <div className="card" style={{ marginTop: "var(--s-4)" }}>
+          <div className="card-head">
+            <h2>Pending approvals</h2>
+            <span className="pill warn">{approvals.length}</span>
+          </div>
+          <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+            {approvals.map((a) => (
+              <Link
+                key={a.callId}
+                href={`/approvals/${a.callId}`}
+                style={{
+                  display: "flex",
+                  gap: "var(--s-3)",
+                  alignItems: "center",
+                  padding: "8px 10px",
+                  background: "var(--bg-0)",
+                  border: "1px solid var(--border-subtle)",
+                  borderRadius: "var(--r-2)",
+                  textDecoration: "none",
+                  color: "inherit",
+                }}
+              >
+                <span
+                  className={`pill ${a.tier === "high" ? "err" : a.tier === "medium" ? "warn" : "ok"}`}
+                >
+                  {a.tier}
+                </span>
+                <span className="mono" style={{ fontSize: 13 }}>
+                  {a.toolName}
+                </span>
+                <span
+                  style={{
+                    flex: 1,
+                    color: "var(--fg-2)",
+                    fontSize: 13,
+                    whiteSpace: "nowrap",
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                  }}
+                >
+                  {a.summary ?? "—"}
+                </span>
+                <span style={{ color: "var(--fg-3)", fontSize: 12 }}>
+                  {relTime(a.requestedAt)}
+                </span>
+              </Link>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {lifecycle.length > 0 && (
+        <div className="card" style={{ marginTop: "var(--s-4)" }}>
+          <div className="card-head">
+            <h2>Event stream</h2>
+            <span className="pill muted">{lifecycle.length}</span>
+          </div>
+          <div className="table-wrap">
+            <table className="table">
+              <thead>
+                <tr>
+                  <th style={{ width: 140 }}>Time</th>
+                  <th style={{ width: 160 }}>Event</th>
+                  <th>Detail</th>
+                </tr>
+              </thead>
+              <tbody>
+                {lifecycle.map((e) => {
+                  const isNoise = NOISE_EVENTS.has(e.event);
+                  const isApproval = e.event === "approval_decision";
+                  const meta = e.metadata ?? {};
+                  const detail = isApproval
+                    ? `${meta.decision ?? "?"} ${meta.toolName ?? ""}${meta.reason ? ` — ${meta.reason}` : ""}`
+                    : typeof meta.summary === "string"
+                      ? meta.summary
+                      : "—";
+                  return (
+                    <tr key={e.id}>
+                      <td className="muted" title={e.timestamp}>
+                        {relTime(Date.parse(e.timestamp))}
+                      </td>
+                      <td>
+                        <span
+                          className={`pill ${
+                            isApproval
+                              ? meta.decision === "allow"
+                                ? "ok"
+                                : "err"
+                              : isNoise
+                                ? "muted"
+                                : "ok"
+                          }`}
+                        >
+                          {e.event}
+                        </span>
+                      </td>
+                      <td style={{ fontSize: 13 }}>{detail}</td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+
+      {summary && lifecycle.length === 0 && approvals.length === 0 && (
+        <div className="empty-state" style={{ marginTop: "var(--s-4)" }}>
+          <h3>No recorded activity</h3>
+          <p>
+            This session has connected but hasn&apos;t produced any lifecycle
+            events or approvals yet.
+          </p>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/dashboard/src/app/sessions/page.tsx
+++ b/dashboard/src/app/sessions/page.tsx
@@ -48,7 +48,12 @@ export default function SessionsPage() {
           }}
         >
           {sessions.map((s) => (
-            <div key={s.id} className="card">
+            <Link
+              key={s.id}
+              href={`/sessions/${s.id}`}
+              className="card"
+              style={{ textDecoration: "none", color: "inherit" }}
+            >
               <div className="card-head">
                 <h2>
                   <code
@@ -96,18 +101,13 @@ export default function SessionsPage() {
                 >
                   <span>Pending approvals</span>
                   {s.pendingApprovals > 0 ? (
-                    <Link
-                      href={`/approvals?session=${s.id}`}
-                      className="pill err"
-                    >
-                      {s.pendingApprovals}
-                    </Link>
+                    <span className="pill err">{s.pendingApprovals}</span>
                   ) : (
                     <span style={{ color: "var(--fg-3)" }}>none</span>
                   )}
                 </div>
               </div>
-            </div>
+            </Link>
           ))}
         </div>
       )}

--- a/src/__tests__/activityLog.test.ts
+++ b/src/__tests__/activityLog.test.ts
@@ -617,3 +617,39 @@ describe("ActivityLog.findApprovalByCallId", () => {
     expect(out.nearby).toEqual([]);
   });
 });
+
+describe("ActivityLog.querySessionLifecycle", () => {
+  it("returns only entries matching sessionId", async () => {
+    const { ActivityLog } = await import("../activityLog.js");
+    const log = new ActivityLog();
+    log.recordEvent("claude_connected", { sessionId: "a" });
+    log.recordEvent("session_resumed", { sessionId: "b" });
+    log.recordEvent("approval_decision", {
+      sessionId: "a",
+      toolName: "Bash",
+      decision: "allow",
+    });
+    const out = log.querySessionLifecycle("a");
+    expect(out).toHaveLength(2);
+    for (const e of out) expect(e.metadata?.sessionId).toBe("a");
+  });
+
+  it("returns empty when no match", async () => {
+    const { ActivityLog } = await import("../activityLog.js");
+    const log = new ActivityLog();
+    log.recordEvent("claude_connected", { sessionId: "a" });
+    expect(log.querySessionLifecycle("not-there")).toEqual([]);
+  });
+
+  it("respects limit — keeps newest", async () => {
+    const { ActivityLog } = await import("../activityLog.js");
+    const log = new ActivityLog();
+    for (let i = 0; i < 5; i++) {
+      log.recordEvent(`ev-${i}`, { sessionId: "s", i });
+    }
+    const out = log.querySessionLifecycle("s", 2);
+    expect(out).toHaveLength(2);
+    expect(out[0]?.metadata?.i).toBe(3);
+    expect(out[1]?.metadata?.i).toBe(4);
+  });
+});

--- a/src/__tests__/server-session-detail.test.ts
+++ b/src/__tests__/server-session-detail.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Integration tests for GET /sessions/:id — per-session detail view
+ * backing the dashboard session drill-down. Uses a stub sessionDetailFn
+ * so server routing is tested independently of bridge state.
+ */
+import http from "node:http";
+import { afterEach, describe, expect, it } from "vitest";
+import { Logger } from "../logger.js";
+import { Server, type SessionSummary } from "../server.js";
+
+const logger = new Logger(false);
+const TOKEN = "test-session-detail-token-0000000";
+
+let server: Server | null = null;
+let port = 0;
+
+async function startServer(
+  detailFn?: (id: string) => {
+    summary: SessionSummary | null;
+    lifecycle: Record<string, unknown>[];
+    approvals: Record<string, unknown>[];
+  },
+): Promise<void> {
+  server = new Server(TOKEN, logger);
+  if (detailFn) server.sessionDetailFn = detailFn;
+  port = await server.findAndListen(null);
+}
+
+afterEach(async () => {
+  await server?.close();
+  server = null;
+  port = 0;
+});
+
+function get(
+  path: string,
+  auth = true,
+): Promise<{ status: number; body: string }> {
+  return new Promise((resolve, reject) => {
+    const headers: Record<string, string> = {};
+    if (auth) headers.Authorization = `Bearer ${TOKEN}`;
+    const req = http.request(
+      { hostname: "127.0.0.1", port, method: "GET", path, headers },
+      (res) => {
+        let data = "";
+        res.on("data", (c) => (data += c));
+        res.on("end", () =>
+          resolve({ status: res.statusCode ?? 0, body: data }),
+        );
+      },
+    );
+    req.on("error", reject);
+    req.end();
+  });
+}
+
+describe("GET /sessions/:id", () => {
+  it("404s when detailFn is not wired", async () => {
+    await startServer();
+    const { status } = await get("/sessions/abc");
+    expect(status).toBe(404);
+  });
+
+  it("404s when session is unknown (summary null)", async () => {
+    await startServer(() => ({
+      summary: null,
+      lifecycle: [],
+      approvals: [],
+    }));
+    const { status, body } = await get("/sessions/unknown");
+    expect(status).toBe(404);
+    expect(JSON.parse(body).error).toBe("unknown sessionId");
+  });
+
+  it("returns full detail when session exists", async () => {
+    await startServer((id) => ({
+      summary: {
+        id,
+        connectedAt: "2026-04-18T12:00:00Z",
+        openedFileCount: 3,
+        pendingApprovals: 1,
+      },
+      lifecycle: [
+        {
+          id: 1,
+          timestamp: "2026-04-18T12:00:00Z",
+          event: "claude_connected",
+          metadata: { sessionId: id },
+        },
+      ],
+      approvals: [
+        {
+          callId: "call-1",
+          toolName: "Bash",
+          tier: "high",
+          requestedAt: 1700000000000,
+        },
+      ],
+    }));
+    const { status, body } = await get("/sessions/sess-a");
+    expect(status).toBe(200);
+    const parsed = JSON.parse(body);
+    expect(parsed.summary.id).toBe("sess-a");
+    expect(parsed.lifecycle).toHaveLength(1);
+    expect(parsed.approvals[0].callId).toBe("call-1");
+  });
+
+  it("returns 500 when detailFn throws", async () => {
+    await startServer(() => {
+      throw new Error("oh no");
+    });
+    const { status, body } = await get("/sessions/boom");
+    expect(status).toBe(500);
+    expect(JSON.parse(body).error).toContain("oh no");
+  });
+
+  it("requires auth", async () => {
+    await startServer(() => ({
+      summary: null,
+      lifecycle: [],
+      approvals: [],
+    }));
+    const { status } = await get("/sessions/any", false);
+    expect(status).toBe(401);
+  });
+
+  it("does not shadow the /sessions list endpoint", async () => {
+    // Detail handler must only match /sessions/:id, not /sessions.
+    // Stub detailFn to fail loudly if /sessions hits it.
+    await startServer(() => {
+      throw new Error("detailFn must not be called for /sessions");
+    });
+    const { status } = await get("/sessions");
+    // sessionsFn isn't wired in this test → returns 404 from list handler,
+    // not from detail handler. The throw above would have produced 500.
+    expect([200, 404]).toContain(status);
+  });
+});

--- a/src/activityLog.ts
+++ b/src/activityLog.ts
@@ -308,6 +308,24 @@ export class ActivityLog {
     return { decision, nearby };
   }
 
+  /**
+   * Return all lifecycle entries whose metadata.sessionId matches. Sorted
+   * by id ascending (oldest first). Used by the dashboard session detail
+   * view to render a per-session event stream.
+   *
+   * Tool entries aren't returned because they don't carry a sessionId —
+   * correlation would require a time-window heuristic, which is best-effort
+   * at best. Callers who need tool activity for a session can cross-reference
+   * by time bounds themselves.
+   */
+  querySessionLifecycle(sessionId: string, limit = 100): LifecycleEntry[] {
+    const matches: LifecycleEntry[] = [];
+    for (const e of this.lifecycleEntries) {
+      if (e.metadata?.sessionId === sessionId) matches.push(e);
+    }
+    return matches.slice(-limit);
+  }
+
   queryTimeline(opts?: { last?: number }): TimelineEntry[] {
     const tools: TimelineEntry[] = this.entries.map((e) => ({
       kind: "tool" as const,

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -1240,6 +1240,28 @@ export class Bridge {
           .list()
           .filter((a) => a.sessionId === s.id).length,
       }));
+    this.server.sessionDetailFn = (id: string) => {
+      const s = this.sessions.get(id);
+      const summary = s
+        ? {
+            id: s.id,
+            connectedAt: new Date(s.connectedAt).toISOString(),
+            openedFileCount: s.openedFiles.size,
+            pendingApprovals: getApprovalQueue()
+              .list()
+              .filter((a) => a.sessionId === s.id).length,
+          }
+        : null;
+      const lifecycle = this.activityLog.querySessionLifecycle(id, 100);
+      const approvals = getApprovalQueue()
+        .list()
+        .filter((a) => a.sessionId === id);
+      return {
+        summary,
+        lifecycle: lifecycle as unknown as Record<string, unknown>[],
+        approvals: approvals as unknown as Record<string, unknown>[],
+      };
+    };
     this.server.webhookFn = async (hookPath: string, payload: unknown) => {
       if (!this.orchestrator) {
         return {

--- a/src/server.ts
+++ b/src/server.ts
@@ -215,6 +215,14 @@ export class Server extends EventEmitter<ServerEvents> {
     | null = null;
   /** Patchwork: set by bridge to list active agent sessions for the dashboard. */
   public sessionsFn: (() => SessionSummary[]) | null = null;
+  /** Patchwork: set by bridge to answer GET /sessions/:id with per-session event stream + approvals. */
+  public sessionDetailFn:
+    | ((id: string) => {
+        summary: SessionSummary | null;
+        lifecycle: Record<string, unknown>[];
+        approvals: Record<string, unknown>[];
+      })
+    | null = null;
   /** Set by bridge to handle POST /launch-quick-task — invokes launchQuickTask tool in-process. */
   public launchQuickTaskFn:
     | ((
@@ -935,7 +943,31 @@ export class Server extends EventEmitter<ServerEvents> {
         }
         return;
       }
-      if (req.url === "/sessions" && req.method === "GET") {
+      const sessionDetailMatch = /^\/sessions\/([A-Za-z0-9-]+)$/.exec(
+        parsedUrl.pathname,
+      );
+      if (sessionDetailMatch && req.method === "GET") {
+        const id = sessionDetailMatch[1] as string;
+        try {
+          const data = this.sessionDetailFn?.(id);
+          if (!data || !data.summary) {
+            res.writeHead(404, { "Content-Type": "application/json" });
+            res.end(JSON.stringify({ error: "unknown sessionId" }));
+            return;
+          }
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(JSON.stringify(data));
+        } catch (err) {
+          res.writeHead(500, { "Content-Type": "application/json" });
+          res.end(
+            JSON.stringify({
+              error: err instanceof Error ? err.message : String(err),
+            }),
+          );
+        }
+        return;
+      }
+      if (parsedUrl.pathname === "/sessions" && req.method === "GET") {
         try {
           if (!this.sessionsFn) {
             res.writeHead(404, { "Content-Type": "application/json" });


### PR DESCRIPTION
## Summary
- New dashboard route \`/sessions/[id]\` shows summary, pending approvals, and session-scoped lifecycle event stream
- Bridge exposes \`GET /sessions/:id\` via \`Server.sessionDetailFn\`; \`ActivityLog.querySessionLifecycle()\` does the lookup
- Session cards on \`/sessions\` are now clickable

## Why
Roadmap #5. Session list was a dead-end — no way to see per-session activity or jump to linked approvals. Now each session has a page showing what it's doing.

Tool entries don't carry a \`sessionId\` today so they're excluded; time-window correlation would be guesswork. Filing as a follow-up once tool entries gain session attribution.

## Test plan
- [x] 3 new unit tests for \`ActivityLog.querySessionLifecycle\` (match, empty, limit)
- [x] 6 integration tests for \`GET /sessions/:id\` (404s, happy path, error, auth, list non-shadowing)
- [x] Full test suite passes (3203 tests)
- [x] Dashboard tsc clean
- [ ] Dogfood: click a session card, confirm detail renders