### PR TITLE
fix(bridge): persist full sessionId in activity-log metadata

### DIFF
--- a/src/__tests__/bridge-sessionid-persistence.test.ts
+++ b/src/__tests__/bridge-sessionid-persistence.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Regression guard for sessionId truncation in activity-log metadata.
+ *
+ * Background: bridge.ts writes lifecycle events to activityLog so downstream
+ * consumers (e.g. dashboard session detail) can correlate by sessionId. A
+ * long-standing bug truncated sessionId to 8 chars inside recordEvent
+ * metadata, making correlation impossible (truncated "31f13def" never matches
+ * the full UUID known to /sessions).
+ *
+ * This test lints the source to ensure every `activityLog.recordEvent` call
+ * that includes a `sessionId` passes the *full* identifier, not `.slice(0, 8)`.
+ * Human-readable log strings (logger.info/warn/error) are allowed to keep the
+ * short form — readability there outweighs correlation, and logs aren't a
+ * structured correlation surface.
+ */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("bridge activity log metadata preserves full sessionId", () => {
+  it("never truncates sessionId inside activityLog.recordEvent", () => {
+    const path = join(__dirname, "..", "bridge.ts");
+    const src = readFileSync(path, "utf8");
+
+    // Find every `activityLog.recordEvent(...)` block and assert the
+    // metadata object (second arg) doesn't contain `sessionId: <var>.slice(0, 8)`.
+    const re = /activityLog\.recordEvent\([^)]*?\{([^}]*)\}/gs;
+    const bad: string[] = [];
+    for (const m of src.matchAll(re)) {
+      const body = m[1] ?? "";
+      if (
+        /sessionId\s*:\s*[A-Za-z_][A-Za-z0-9_]*\.slice\(\s*0\s*,\s*8\s*\)/.test(
+          body,
+        )
+      ) {
+        bad.push(body.trim().replace(/\s+/g, " "));
+      }
+    }
+    expect(
+      bad,
+      `truncated sessionId in recordEvent metadata: ${bad.join(" | ")}`,
+    ).toEqual([]);
+  });
+});

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -219,7 +219,7 @@ export class Bridge {
             `Session ${clientSessionId.slice(0, 8)} resumed — grace period cancelled`,
           );
           this.activityLog.recordEvent("session_resumed", {
-            sessionId: clientSessionId.slice(0, 8),
+            sessionId: clientSessionId,
           });
           this.logger.event("session_resumed", { sessionId: clientSessionId });
           // Re-attach close/error handlers to the new WebSocket
@@ -231,7 +231,7 @@ export class Bridge {
               `Claude Code disconnected (session ${clientSessionId.slice(0, 8)}) code=${code} reason=${reason.toString() || "(none)"}`,
             );
             this.activityLog.recordEvent("claude_disconnected", {
-              sessionId: clientSessionId.slice(0, 8),
+              sessionId: clientSessionId,
             });
             this.logger.event("claude_disconnected", {
               sessionId: clientSessionId,
@@ -242,7 +242,7 @@ export class Bridge {
                 this.cleanupSession(clientSessionId);
               }, this.config.gracePeriodMs);
               this.activityLog.recordEvent("grace_started", {
-                sessionId: clientSessionId.slice(0, 8),
+                sessionId: clientSessionId,
                 gracePeriodMs: this.config.gracePeriodMs,
               });
               this.logger.info(
@@ -413,7 +413,7 @@ export class Bridge {
       );
       this.lastConnectAt = new Date().toISOString();
       this.activityLog.recordEvent("claude_connected", {
-        sessionId: sessionId.slice(0, 8),
+        sessionId,
         activeSessions: this.sessions.size,
       });
       this.logger.event("claude_connected", {
@@ -433,7 +433,7 @@ export class Bridge {
           `Claude Code disconnected (session ${sessionId.slice(0, 8)}) code=${code} reason=${reason.toString() || "(none)"}`,
         );
         this.activityLog.recordEvent("claude_disconnected", {
-          sessionId: sessionId.slice(0, 8),
+          sessionId,
         });
         this.logger.event("claude_disconnected", { sessionId });
         const s = this.sessions.get(sessionId);
@@ -442,7 +442,7 @@ export class Bridge {
             this.cleanupSession(sessionId);
           }, this.config.gracePeriodMs);
           this.activityLog.recordEvent("grace_started", {
-            sessionId: sessionId.slice(0, 8),
+            sessionId,
             gracePeriodMs: this.config.gracePeriodMs,
           });
           this.logger.info(
@@ -784,7 +784,7 @@ export class Bridge {
     if (session.graceTimer) {
       clearTimeout(session.graceTimer);
       this.activityLog.recordEvent("grace_expired", {
-        sessionId: id.slice(0, 8),
+        sessionId: id,
       });
     }
     // Read stats before detach() — counters survive detach


### PR DESCRIPTION
## Summary
- 7 \`activityLog.recordEvent\` sites in bridge.ts were writing \`sessionId.slice(0, 8)\` into metadata — now use the full UUID
- Log strings (logger.info/warn/error) still use the short form for readability
- Adds a lint-style regression test to prevent the truncation pattern coming back

## Why — dogfood finding from PR #22
Session detail page (\`/sessions/:id\`) showed "No recorded activity" for a session clearly connected 3 minutes with 100+ lifecycle events. Root cause: \`/sessions\` returns the full UUID, but activityLog stored only the 8-char prefix. Correlation never matched.

This bug also affected any other consumer that correlates by sessionId — including \`ctxQueryTraces\` filtering.

## Test plan
- [x] Regression test scans bridge.ts for \`activityLog.recordEvent(..., { sessionId: <var>.slice(0, 8) })\` and fails if any match
- [x] Full test suite passes (3204 tests)
- [x] Typecheck clean
- [ ] Dogfood after merge: restart bridge, click a session card — expect full event stream