### PR TITLE
feat(decisions): dedicated dashboard tab with tag search

### DIFF
--- a/dashboard/src/app/decisions/page.tsx
+++ b/dashboard/src/app/decisions/page.tsx
@@ -1,0 +1,288 @@
+"use client";
+import { useMemo, useState } from "react";
+import { relTime } from "@/components/time";
+import { useBridgeFetch } from "@/hooks/useBridgeFetch";
+
+interface DecisionTrace {
+  traceType: "decision";
+  ts: number;
+  key: string;
+  summary: string;
+  body: {
+    ref?: string;
+    problem?: string;
+    solution?: string;
+    workspace?: string;
+    sessionId?: string;
+    tags?: string[];
+    [k: string]: unknown;
+  };
+}
+
+interface TracesResponse {
+  traces: DecisionTrace[];
+  count: number;
+  sources: { decision: boolean };
+}
+
+export default function DecisionsPage() {
+  const [tag, setTag] = useState("");
+  const [keyQuery, setKeyQuery] = useState("");
+  const [textQuery, setTextQuery] = useState("");
+
+  const qs = useMemo(() => {
+    const params = new URLSearchParams();
+    params.set("traceType", "decision");
+    if (tag.trim()) params.set("tag", tag.trim());
+    if (keyQuery.trim()) params.set("key", keyQuery.trim());
+    if (textQuery.trim()) params.set("q", textQuery.trim());
+    params.set("limit", "200");
+    return `?${params.toString()}`;
+  }, [tag, keyQuery, textQuery]);
+
+  const { data, error, loading } = useBridgeFetch<TracesResponse>(
+    `/api/bridge/traces${qs}`,
+    { intervalMs: 5000 },
+  );
+
+  const traces = data?.traces ?? [];
+
+  // Collect tag universe from the current result set for click-to-filter pills.
+  const allTags = useMemo(() => {
+    const set = new Set<string>();
+    for (const t of traces) {
+      if (Array.isArray(t.body.tags)) {
+        for (const tag of t.body.tags) {
+          if (typeof tag === "string") set.add(tag);
+        }
+      }
+    }
+    return [...set].sort();
+  }, [traces]);
+
+  return (
+    <section>
+      <div className="page-head">
+        <div>
+          <h1>Decisions</h1>
+          <div className="page-head-sub">
+            Agent-authored knowledge base. Saved via <code>ctxSaveTrace</code>;
+            surfaced here and in the session-start digest.
+          </div>
+        </div>
+        <span className="pill muted">
+          {traces.length} decision{traces.length !== 1 ? "s" : ""}
+        </span>
+      </div>
+
+      <div
+        style={{
+          display: "flex",
+          gap: "var(--s-3)",
+          marginBottom: "var(--s-3)",
+          flexWrap: "wrap",
+          alignItems: "center",
+        }}
+      >
+        <input
+          type="text"
+          value={tag}
+          onChange={(e) => setTag(e.target.value)}
+          placeholder="filter by tag (exact match)"
+          style={{
+            minWidth: 200,
+            padding: "6px 10px",
+            fontSize: 13,
+            fontFamily: "var(--font-mono)",
+            background: "var(--bg-2)",
+            border: "1px solid var(--bg-3)",
+            borderRadius: 4,
+            color: "var(--fg-0)",
+          }}
+        />
+        <input
+          type="text"
+          value={keyQuery}
+          onChange={(e) => setKeyQuery(e.target.value)}
+          placeholder="filter by ref (#42, sha, etc.)"
+          style={{
+            flex: 1,
+            minWidth: 200,
+            padding: "6px 10px",
+            fontSize: 13,
+            fontFamily: "var(--font-mono)",
+            background: "var(--bg-2)",
+            border: "1px solid var(--bg-3)",
+            borderRadius: 4,
+            color: "var(--fg-0)",
+          }}
+        />
+        <input
+          type="text"
+          value={textQuery}
+          onChange={(e) => setTextQuery(e.target.value)}
+          placeholder="search problem + solution"
+          style={{
+            flex: 1,
+            minWidth: 200,
+            padding: "6px 10px",
+            fontSize: 13,
+            background: "var(--bg-2)",
+            border: "1px solid var(--bg-3)",
+            borderRadius: 4,
+            color: "var(--fg-0)",
+          }}
+        />
+      </div>
+
+      {allTags.length > 0 && !tag && (
+        <div
+          style={{
+            display: "flex",
+            gap: 6,
+            flexWrap: "wrap",
+            marginBottom: "var(--s-3)",
+            fontSize: 12,
+            color: "var(--fg-3)",
+            alignItems: "center",
+          }}
+        >
+          <span>tags:</span>
+          {allTags.map((t) => (
+            <button
+              key={t}
+              type="button"
+              onClick={() => setTag(t)}
+              className="pill muted"
+              style={{ cursor: "pointer", fontFamily: "var(--font-mono)" }}
+            >
+              {t}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {error && <div className="alert-err">Unreachable: {error}</div>}
+
+      {!loading && traces.length === 0 && !error ? (
+        <div className="empty-state">
+          <h3>
+            {!tag && !keyQuery && !textQuery
+              ? "No decisions yet"
+              : "No matching decisions"}
+          </h3>
+          <p>
+            {!tag && !keyQuery && !textQuery
+              ? "Agents save decisions via ctxSaveTrace when they resolve a task. Those entries will appear here and in the session-start digest."
+              : `No decisions${tag ? ` tagged "${tag}"` : ""}${keyQuery ? ` with ref matching "${keyQuery}"` : ""}${textQuery ? ` containing "${textQuery}"` : ""}.`}
+          </p>
+          {(tag || keyQuery || textQuery) && (
+            <button
+              type="button"
+              onClick={() => {
+                setTag("");
+                setKeyQuery("");
+                setTextQuery("");
+              }}
+              className="pill muted"
+              style={{ cursor: "pointer", marginTop: "var(--s-3)" }}
+            >
+              Clear filters
+            </button>
+          )}
+        </div>
+      ) : (
+        <div
+          style={{ display: "flex", flexDirection: "column", gap: "var(--s-2)" }}
+        >
+          {traces.map((t) => {
+            const b = t.body;
+            const tags = Array.isArray(b.tags) ? b.tags : [];
+            const rowKey = `${t.ts}:${t.key}`;
+            return (
+              <div
+                key={rowKey}
+                className="card"
+                style={{ padding: "var(--s-3)" }}
+              >
+                <div
+                  style={{
+                    display: "flex",
+                    alignItems: "baseline",
+                    gap: "var(--s-3)",
+                    marginBottom: b.problem || b.solution ? 8 : 0,
+                  }}
+                >
+                  <span
+                    style={{
+                      fontFamily: "var(--font-mono)",
+                      fontSize: 13,
+                      color: "#a78bfa",
+                      flexShrink: 0,
+                    }}
+                  >
+                    {b.ref ?? t.key}
+                  </span>
+                  <span
+                    style={{
+                      flex: 1,
+                      color: "var(--fg-3)",
+                      fontSize: 12,
+                      textAlign: "right",
+                    }}
+                  >
+                    {relTime(t.ts)}
+                  </span>
+                </div>
+                {b.problem && (
+                  <div
+                    style={{
+                      fontSize: 13,
+                      color: "var(--fg-2)",
+                      marginBottom: 4,
+                    }}
+                  >
+                    <span style={{ color: "var(--fg-3)" }}>Problem:</span>{" "}
+                    {b.problem}
+                  </div>
+                )}
+                {b.solution && (
+                  <div style={{ fontSize: 13, color: "var(--fg-1)" }}>
+                    <span style={{ color: "var(--fg-3)" }}>Solution:</span>{" "}
+                    {b.solution}
+                  </div>
+                )}
+                {tags.length > 0 && (
+                  <div
+                    style={{
+                      display: "flex",
+                      gap: 6,
+                      flexWrap: "wrap",
+                      marginTop: 8,
+                    }}
+                  >
+                    {tags.map((t) => (
+                      <button
+                        key={t}
+                        type="button"
+                        onClick={() => setTag(t)}
+                        className="pill muted"
+                        style={{
+                          cursor: "pointer",
+                          fontFamily: "var(--font-mono)",
+                          fontSize: 11,
+                        }}
+                      >
+                        {t}
+                      </button>
+                    ))}
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/dashboard/src/components/Shell.tsx
+++ b/dashboard/src/components/Shell.tsx
@@ -15,6 +15,7 @@ const NAV: { href: string; label: string; icon: string }[] = [
   { href: "/recipes", label: "Recipes", icon: "\u25C9" },
   { href: "/runs", label: "Runs", icon: "\u29D6" },
   { href: "/traces", label: "Traces", icon: "\u25C7" },
+  { href: "/decisions", label: "Decisions", icon: "\u2726" },
   { href: "/settings", label: "Settings", icon: "\u2699" },
 ];
 

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -1106,6 +1106,7 @@ export class Bridge {
         ...(query.traceType && { traceType: query.traceType }),
         ...(query.key && { key: query.key }),
         ...(query.q && { q: query.q }),
+        ...(query.tag && { tag: query.tag }),
         ...(query.since !== undefined && { since: query.since }),
         ...(query.limit !== undefined && { limit: query.limit }),
       });

--- a/src/server.ts
+++ b/src/server.ts
@@ -202,6 +202,7 @@ export class Server extends EventEmitter<ServerEvents> {
         traceType?: string;
         key?: string;
         q?: string;
+        tag?: string;
         since?: number;
         limit?: number;
       }) => Promise<Record<string, unknown>>)
@@ -613,6 +614,7 @@ export class Server extends EventEmitter<ServerEvents> {
                 traceType: q.get("traceType") ?? undefined,
                 key: q.get("key") ?? undefined,
                 q: q.get("q") ?? undefined,
+                tag: q.get("tag") ?? undefined,
                 since:
                   sinceStr !== null && /^\d+$/.test(sinceStr)
                     ? Number(sinceStr)

--- a/src/tools/__tests__/ctxQueryTraces.test.ts
+++ b/src/tools/__tests__/ctxQueryTraces.test.ts
@@ -332,3 +332,98 @@ describe("ctxQueryTraces — q (text search)", () => {
     expect(res.traces[0].body.subject).toBe("pineapple");
   });
 });
+
+describe("ctxQueryTraces — tag filter", () => {
+  it("restricts to decision traces carrying the tag", async () => {
+    const decisionLog = new DecisionTraceLog({ dir });
+    decisionLog.record({
+      ref: "#1",
+      problem: "p1",
+      solution: "s1",
+      workspace: "/ws",
+      tags: ["perf", "db"],
+    });
+    decisionLog.record({
+      ref: "#2",
+      problem: "p2",
+      solution: "s2",
+      workspace: "/ws",
+      tags: ["ui"],
+    });
+    const tool = createCtxQueryTracesTool({
+      activityLog: null,
+      commitIssueLinkLog: null,
+      recipeRunLog: null,
+      decisionTraceLog: decisionLog,
+    });
+    const res = parse(await tool.handler({ tag: "perf" }));
+    expect(res.count).toBe(1);
+    expect(res.traces[0].body.ref).toBe("#1");
+  });
+
+  it("excludes non-decision trace types when tag is set", async () => {
+    const decisionLog = new DecisionTraceLog({ dir });
+    decisionLog.record({
+      ref: "#1",
+      problem: "p",
+      solution: "s",
+      workspace: "/ws",
+      tags: ["perf"],
+    });
+    // Enrichment row with no tags — should be filtered out entirely.
+    linkLog.record({
+      sha: "aaa",
+      ref: "#99",
+      linkType: "closes",
+      resolved: true,
+      workspace: "/ws",
+    });
+    const tool = createCtxQueryTracesTool({
+      activityLog: null,
+      commitIssueLinkLog: linkLog,
+      recipeRunLog: null,
+      decisionTraceLog: decisionLog,
+    });
+    const res = parse(await tool.handler({ tag: "perf" }));
+    expect(res.count).toBe(1);
+    expect(res.traces[0].traceType).toBe("decision");
+  });
+
+  it("returns nothing when no decision carries the tag", async () => {
+    const decisionLog = new DecisionTraceLog({ dir });
+    decisionLog.record({
+      ref: "#1",
+      problem: "p",
+      solution: "s",
+      workspace: "/ws",
+      tags: ["ui"],
+    });
+    const tool = createCtxQueryTracesTool({
+      activityLog: null,
+      commitIssueLinkLog: null,
+      recipeRunLog: null,
+      decisionTraceLog: decisionLog,
+    });
+    const res = parse(await tool.handler({ tag: "missing" }));
+    expect(res.count).toBe(0);
+  });
+
+  it("tag is exact-match, case-sensitive", async () => {
+    const decisionLog = new DecisionTraceLog({ dir });
+    decisionLog.record({
+      ref: "#1",
+      problem: "p",
+      solution: "s",
+      workspace: "/ws",
+      tags: ["Perf"],
+    });
+    const tool = createCtxQueryTracesTool({
+      activityLog: null,
+      commitIssueLinkLog: null,
+      recipeRunLog: null,
+      decisionTraceLog: decisionLog,
+    });
+    expect(parse(await tool.handler({ tag: "perf" })).count).toBe(0);
+    expect(parse(await tool.handler({ tag: "Perf" })).count).toBe(1);
+  });
+});

--- a/src/tools/ctxQueryTraces.ts
+++ b/src/tools/ctxQueryTraces.ts
@@ -131,6 +131,11 @@ export function createCtxQueryTracesTool(deps: CtxQueryTracesDeps) {
             description:
               "Case-insensitive substring search across the trace summary and serialized body. Use for free-form lookup when the key schema doesn't fit.",
           },
+          tag: {
+            type: "string",
+            description:
+              "Restrict to decision traces carrying this tag (exact match, case-sensitive). Other trace types don't have tags and will be excluded when this filter is set.",
+          },
           since: {
             type: "integer",
             description: "Only return traces with ts > this ms-epoch value.",
@@ -186,6 +191,7 @@ export function createCtxQueryTracesTool(deps: CtxQueryTracesDeps) {
         | "";
       const keyFilter = optionalString(args, "key");
       const qFilter = optionalString(args, "q");
+      const tagFilter = optionalString(args, "tag");
       const since = optionalInt(args, "since", 0, Number.MAX_SAFE_INTEGER);
       const limit = optionalInt(args, "limit", 1, 500) ?? 100;
 
@@ -215,6 +221,13 @@ export function createCtxQueryTracesTool(deps: CtxQueryTracesDeps) {
 
       let filtered = pools;
       if (since !== undefined) filtered = filtered.filter((t) => t.ts > since);
+      if (tagFilter) {
+        filtered = filtered.filter((t) => {
+          if (t.traceType !== "decision") return false;
+          const tags = t.body.tags;
+          return Array.isArray(tags) && tags.includes(tagFilter);
+        });
+      }
       if (keyFilter) {
         const needle = keyFilter;
         filtered = filtered.filter((t) => t.key.includes(needle));


### PR DESCRIPTION
## Summary
Roadmap item #2 from `documents/roadmap.md` — decisions (the agent-authored knowledge base) get a dedicated tab, since they get lost in the flat `/traces` stream once approval + enrichment + recipe rows pile up. Also adds tag filtering, which agents already set via `ctxSaveTrace({tags})` but previously had no read path.

## Changes
- **`ctxQueryTraces`** — new optional `tag` input. Filters to decision traces whose `body.tags` contains the value (exact match, case-sensitive); excludes all non-decision trace types when set.
- **`GET /traces`** — new `?tag=` query param, threaded through `Server.tracesFn` → `bridge.ts` handler.
- **Dashboard** — new `/decisions` route wired into the sidebar. Cards show `ref` / `problem` / `solution` (not JSON blobs), clickable tag pills, and a "tag universe" row showing every tag present in the current result set for one-click discovery.

## Test plan
- [x] 3212/3212 tests pass (4 new tag-filter tests)
- [x] Biome clean
- [ ] Manual: visit `/decisions`, save a trace via `ctxSaveTrace({ref: '#foo', problem: 'p', solution: 's', tags: ['test']})`, filter by tag

## Backwards compatibility
- `tag` is optional everywhere. Pre-existing `/traces` calls are unchanged.
- The existing `/traces` page is untouched; `/decisions` is additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)