### PR TITLE
feat(sessions): show decisions saved during a session on the detail page

### DIFF
--- a/dashboard/src/app/sessions/[id]/page.tsx
+++ b/dashboard/src/app/sessions/[id]/page.tsx
@@ -39,10 +39,20 @@ interface PendingApproval {
   summary?: string;
 }
 
+interface DecisionEntry {
+  seq: number;
+  createdAt: number;
+  ref: string;
+  problem: string;
+  solution: string;
+  tags?: string[];
+}
+
 interface DetailResponse {
   summary: SessionSummary | null;
   lifecycle: LifecycleEntry[];
   tools?: ToolEntry[];
+  decisions?: DecisionEntry[];
   approvals: PendingApproval[];
 }
 
@@ -68,6 +78,7 @@ export default function SessionDetailPage() {
   const approvals = data?.approvals ?? [];
   const lifecycle = data?.lifecycle ?? [];
   const tools = data?.tools ?? [];
+  const decisions = data?.decisions ?? [];
   const stream: StreamRow[] = [
     ...lifecycle.map((entry) => ({ kind: "lifecycle" as const, entry })),
     ...tools.map((entry) => ({ kind: "tool" as const, entry })),
@@ -192,6 +203,81 @@ export default function SessionDetailPage() {
         </div>
       )}
 
+      {decisions.length > 0 && (
+        <div className="card" style={{ marginTop: "var(--s-4)" }}>
+          <div className="card-head">
+            <h2>Decisions saved</h2>
+            <span className="pill muted">{decisions.length}</span>
+          </div>
+          <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+            {decisions.map((d) => {
+              const tags = Array.isArray(d.tags) ? d.tags.slice(0, 3) : [];
+              return (
+                <Link
+                  key={d.seq}
+                  href="/decisions"
+                  style={{
+                    display: "flex",
+                    gap: "var(--s-3)",
+                    alignItems: "baseline",
+                    padding: "8px 10px",
+                    background: "var(--bg-0)",
+                    border: "1px solid var(--border-subtle)",
+                    borderRadius: "var(--r-2)",
+                    textDecoration: "none",
+                    color: "inherit",
+                  }}
+                >
+                  <span
+                    style={{
+                      fontFamily: "var(--font-mono)",
+                      fontSize: 12,
+                      color: "#a78bfa",
+                      flexShrink: 0,
+                    }}
+                  >
+                    {d.ref}
+                  </span>
+                  <span
+                    style={{
+                      flex: 1,
+                      fontSize: 13,
+                      color: "var(--fg-1)",
+                      whiteSpace: "nowrap",
+                      overflow: "hidden",
+                      textOverflow: "ellipsis",
+                    }}
+                  >
+                    {d.solution}
+                  </span>
+                  {tags.length > 0 && (
+                    <span
+                      style={{
+                        fontSize: 11,
+                        fontFamily: "var(--font-mono)",
+                        color: "var(--fg-3)",
+                        flexShrink: 0,
+                      }}
+                    >
+                      {tags.join(",")}
+                    </span>
+                  )}
+                  <span
+                    style={{
+                      fontSize: 12,
+                      color: "var(--fg-3)",
+                      flexShrink: 0,
+                    }}
+                  >
+                    {relTime(d.createdAt)}
+                  </span>
+                </Link>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
       {stream.length > 0 && (
         <div className="card" style={{ marginTop: "var(--s-4)" }}>
           <div className="card-head">
@@ -270,7 +356,10 @@ export default function SessionDetailPage() {
         </div>
       )}
 
-      {summary && stream.length === 0 && approvals.length === 0 && (
+      {summary &&
+        stream.length === 0 &&
+        approvals.length === 0 &&
+        decisions.length === 0 && (
         <div className="empty-state" style={{ marginTop: "var(--s-4)" }}>
           <h3>No recorded activity</h3>
           <p>

--- a/src/__tests__/server-session-detail.test.ts
+++ b/src/__tests__/server-session-detail.test.ts
@@ -19,6 +19,7 @@ async function startServer(
     summary: SessionSummary | null;
     lifecycle: Record<string, unknown>[];
     tools: Record<string, unknown>[];
+    decisions: Record<string, unknown>[];
     approvals: Record<string, unknown>[];
   },
 ): Promise<void> {
@@ -67,6 +68,7 @@ describe("GET /sessions/:id", () => {
       summary: null,
       lifecycle: [],
       tools: [],
+      decisions: [],
       approvals: [],
     }));
     const { status, body } = await get("/sessions/unknown");
@@ -100,6 +102,18 @@ describe("GET /sessions/:id", () => {
           sessionId: id,
         },
       ],
+      decisions: [
+        {
+          seq: 7,
+          createdAt: 1700000002000,
+          ref: "PR-99",
+          problem: "stale cache",
+          solution: "invalidate on write",
+          workspace: "/ws",
+          sessionId: id,
+          tags: ["cache"],
+        },
+      ],
       approvals: [
         {
           callId: "call-1",
@@ -117,6 +131,9 @@ describe("GET /sessions/:id", () => {
     expect(parsed.tools).toHaveLength(1);
     expect(parsed.tools[0].tool).toBe("getBridgeStatus");
     expect(parsed.tools[0].sessionId).toBe("sess-a");
+    expect(parsed.decisions).toHaveLength(1);
+    expect(parsed.decisions[0].ref).toBe("PR-99");
+    expect(parsed.decisions[0].sessionId).toBe("sess-a");
     expect(parsed.approvals[0].callId).toBe("call-1");
   });
 
@@ -134,6 +151,7 @@ describe("GET /sessions/:id", () => {
       summary: null,
       lifecycle: [],
       tools: [],
+      decisions: [],
       approvals: [],
     }));
     const { status } = await get("/sessions/any", false);

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -1255,6 +1255,8 @@ export class Bridge {
         : null;
       const lifecycle = this.activityLog.querySessionLifecycle(id, 100);
       const tools = this.activityLog.querySessionTools(id, 100);
+      const decisions =
+        this.decisionTraceLog?.query({ sessionId: id, limit: 50 }) ?? [];
       const approvals = getApprovalQueue()
         .list()
         .filter((a) => a.sessionId === id);
@@ -1262,6 +1264,7 @@ export class Bridge {
         summary,
         lifecycle: lifecycle as unknown as Record<string, unknown>[],
         tools: tools as unknown as Record<string, unknown>[],
+        decisions: decisions as unknown as Record<string, unknown>[],
         approvals: approvals as unknown as Record<string, unknown>[],
       };
     };

--- a/src/server.ts
+++ b/src/server.ts
@@ -222,6 +222,7 @@ export class Server extends EventEmitter<ServerEvents> {
         summary: SessionSummary | null;
         lifecycle: Record<string, unknown>[];
         tools: Record<string, unknown>[];
+        decisions: Record<string, unknown>[];
         approvals: Record<string, unknown>[];
       })
     | null = null;


### PR DESCRIPTION
## Summary
Completes the session drill-down. `/sessions/:id` showed lifecycle events (#22) and tool calls (#24) but hid the one artefact agents produce that carries lasting value: the decisions they save via `ctxSaveTrace`.

New **Decisions saved** card on the session detail page lists every decision whose `sessionId` matches, showing ref + solution + tags + relative time. Each row links to `/decisions` for full context.

## Why this works cleanly
- `ctxSaveTrace` already persists `sessionId` on each decision trace — the tool accepts `getSessionId` and threads it through (see `ctxSaveTrace.ts:99`)
- `DecisionTraceLog.query({sessionId})` already exists (`decisionTraceLog.ts:148`)
- Only gap was wiring those two into `sessionDetailFn`

Net result: 4-line bridge change, additive `decisions[]` field on the response, new dashboard card.

## Test plan
- [x] 3216/3216 tests pass (updated `server-session-detail.test.ts` stub + assertions)
- [x] Dashboard `next build` clean
- [x] Bridge build clean; biome clean
- [ ] Manual: save a decision via `ctxSaveTrace` from a CC session, open `/sessions/<that-session-id>`, confirm the row appears

## Backwards compatibility
- `decisions[]` added to `/sessions/:id` response; dashboard already guards with `data?.decisions ?? []`
- Empty-state guard extended to include `decisions.length === 0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)