### PR TITLE
test(lint): widen sessionId truncation guard to all src/ files

### DIFF
--- a/src/__tests__/bridge-sessionid-persistence.test.ts
+++ b/src/__tests__/bridge-sessionid-persistence.test.ts
@@ -7,38 +7,125 @@
  * metadata, making correlation impossible (truncated "31f13def" never matches
  * the full UUID known to /sessions).
  *
- * This test lints the source to ensure every `activityLog.recordEvent` call
- * that includes a `sessionId` passes the *full* identifier, not `.slice(0, 8)`.
+ * This test lints every production source file under src/ to ensure every
+ * `activityLog.recordEvent(...)` call with a `sessionId` field passes the
+ * *full* identifier, not a truncated slice/substring/substr.
+ *
+ * Scope widened from just bridge.ts (PR #23's original guard) so that any
+ * future file gaining a recordEvent call site is covered automatically.
+ * Test files and fixtures are excluded — they may deliberately record
+ * truncated values for unit-test coverage of edge cases.
+ *
  * Human-readable log strings (logger.info/warn/error) are allowed to keep the
  * short form — readability there outweighs correlation, and logs aren't a
  * structured correlation surface.
  */
-import { readFileSync } from "node:fs";
+import { readdirSync, readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
-describe("bridge activity log metadata preserves full sessionId", () => {
-  it("never truncates sessionId inside activityLog.recordEvent", () => {
-    const path = join(__dirname, "..", "bridge.ts");
-    const src = readFileSync(path, "utf8");
+const SRC_DIR = join(__dirname, "..");
 
-    // Find every `activityLog.recordEvent(...)` block and assert the
-    // metadata object (second arg) doesn't contain `sessionId: <var>.slice(0, 8)`.
-    const re = /activityLog\.recordEvent\([^)]*?\{([^}]*)\}/gs;
-    const bad: string[] = [];
-    for (const m of src.matchAll(re)) {
-      const body = m[1] ?? "";
-      if (
-        /sessionId\s*:\s*[A-Za-z_][A-Za-z0-9_]*\.slice\(\s*0\s*,\s*8\s*\)/.test(
-          body,
-        )
-      ) {
-        bad.push(body.trim().replace(/\s+/g, " "));
+/** Recursively enumerate .ts files under src/, skipping tests and node_modules. */
+function collectSources(root: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(root)) {
+    const full = join(root, entry);
+    const st = statSync(full);
+    if (st.isDirectory()) {
+      if (entry === "node_modules" || entry === "__tests__") continue;
+      out.push(...collectSources(full));
+    } else if (
+      st.isFile() &&
+      entry.endsWith(".ts") &&
+      !entry.endsWith(".d.ts")
+    ) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+/**
+ * Extract the argument body (balanced parens) of every
+ * `activityLog.recordEvent(...)` call in `src`.
+ */
+function findRecordEventCalls(src: string): string[] {
+  const starter = /activityLog\??\.recordEvent\(/g;
+  const bodies: string[] = [];
+  let m: RegExpExecArray | null;
+  // biome-ignore lint/suspicious/noAssignInExpressions: canonical regex loop
+  while ((m = starter.exec(src)) !== null) {
+    let depth = 1;
+    let i = m.index + m[0].length;
+    const start = i;
+    while (i < src.length && depth > 0) {
+      const ch = src[i];
+      if (ch === "(") depth += 1;
+      else if (ch === ")") depth -= 1;
+      i += 1;
+    }
+    if (depth === 0) bodies.push(src.slice(start, i - 1));
+  }
+  return bodies;
+}
+
+// Matches any `sessionId: <ident>.slice/substring/substr(0, N)` or template-
+// literal truncations inside the metadata object. Accepts `sessionId` or
+// `sessionID` (defensive against a rename typo). Uses /s flag so multi-line
+// argument objects are covered.
+const TRUNCATED_SESSIONID = new RegExp(
+  [
+    // Plain truncation: sessionId: foo.slice(0, 8) / .substring(...) / .substr(...)
+    "sessionI[dD]\\s*:\\s*[A-Za-z_][A-Za-z0-9_]*\\.",
+    "(?:slice|substring|substr)\\(",
+  ].join(""),
+  "s",
+);
+
+// Template-literal truncation: sessionId: `${foo.slice(0,8)}...`
+const TRUNCATED_SESSIONID_TEMPLATE = new RegExp(
+  [
+    "sessionI[dD]\\s*:\\s*`[^`]*\\$\\{[^}]*\\.",
+    "(?:slice|substring|substr)\\(",
+  ].join(""),
+  "s",
+);
+
+describe("activity log metadata preserves full sessionId", () => {
+  it("enumerates at least one production recordEvent call site", () => {
+    // Sanity: the lint is meaningless if no call sites are found.
+    const files = collectSources(SRC_DIR);
+    let totalCalls = 0;
+    for (const f of files) {
+      const src = readFileSync(f, "utf8");
+      totalCalls += findRecordEventCalls(src).length;
+    }
+    expect(totalCalls).toBeGreaterThan(0);
+  });
+
+  it("never truncates sessionId in activityLog.recordEvent metadata (all src files)", () => {
+    const files = collectSources(SRC_DIR);
+    const offenders: string[] = [];
+    for (const file of files) {
+      const src = readFileSync(file, "utf8");
+      const calls = findRecordEventCalls(src);
+      for (const body of calls) {
+        if (
+          TRUNCATED_SESSIONID.test(body) ||
+          TRUNCATED_SESSIONID_TEMPLATE.test(body)
+        ) {
+          const rel = file.slice(SRC_DIR.length + 1);
+          offenders.push(`${rel}: ${body.trim().replace(/\s+/g, " ")}`);
+        }
       }
     }
     expect(
-      bad,
-      `truncated sessionId in recordEvent metadata: ${bad.join(" | ")}`,
+      offenders,
+      "sessionId inside activityLog.recordEvent metadata must be the full " +
+        "UUID — truncation breaks /sessions/:id correlation. Human-readable " +
+        "log strings (logger.info/warn) are free to use short forms.\n\n" +
+        `Offenders:\n${offenders.join("\n")}`,
     ).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary
Hardens PR #23's regression guard. The original lint only scanned `bridge.ts` and only caught `.slice(0, 8)` literally. Three structurally-equivalent bugs would slip past, and a new `recordEvent` call site added to any other file would be unchecked.

## Bugs now caught
| Variant | Old lint | New lint |
|---|---|---|
| `sessionId: id.slice(0, 8)` | ✓ | ✓ |
| `sessionId: id.substring(0, 8)` | ✗ | ✓ |
| `sessionId: id.substr(0, 8)` | ✗ | ✓ |
| `` sessionId: `${id.slice(0,8)}...` `` | ✗ | ✓ |
| Same bug but in `server.ts` / any new file | ✗ | ✓ |

## Implementation
- Recursively walks `src/` (skipping `__tests__/` and `node_modules/`)
- Extracts balanced-paren argument bodies for every `activityLog?.recordEvent(...)` call — handles multi-line calls with nested parens (`Date.now()` etc.)
- Two regexes: plain `.slice|substring|substr` and template-literal wrapping
- Sanity test asserts at least one production call site exists — prevents the lint silently becoming a no-op if every `recordEvent` is removed

## Verification
Flipped each of 4 variants into `bridge.ts` via `sed`; all fail cleanly. Reverted; all pass. Full suite: 3219/3219.

🤖 Generated with [Claude Code](https://claude.com/claude-code)