### PR TITLE
feat(dashboard): runtime shape validation for bridge responses

### DIFF
--- a/dashboard/src/app/decisions/page.tsx
+++ b/dashboard/src/app/decisions/page.tsx
@@ -2,6 +2,7 @@
 import { useMemo, useState } from "react";
 import { relTime } from "@/components/time";
 import { useBridgeFetch } from "@/hooks/useBridgeFetch";
+import { arr, isRecord, shape, type ShapeCheck } from "@/lib/validate";
 
 interface DecisionTrace {
   traceType: "decision";
@@ -25,6 +26,19 @@ interface TracesResponse {
   sources: { decision: boolean };
 }
 
+const validateTraces: ShapeCheck<TracesResponse> = shape(
+  "/traces?traceType=decision",
+  (raw, errors) => {
+    if (!isRecord(raw)) {
+      errors.push({ path: "$", reason: "expected object" });
+      return null;
+    }
+    arr(raw, "traces", errors);
+    if (errors.length > 0) return null;
+    return raw as unknown as TracesResponse;
+  },
+);
+
 export default function DecisionsPage() {
   const [tag, setTag] = useState("");
   const [keyQuery, setKeyQuery] = useState("");
@@ -42,7 +56,7 @@ export default function DecisionsPage() {
 
   const { data, error, loading } = useBridgeFetch<TracesResponse>(
     `/api/bridge/traces${qs}`,
-    { intervalMs: 5000 },
+    { intervalMs: 5000, transform: validateTraces },
   );
 
   const traces = data?.traces ?? [];
@@ -162,7 +176,13 @@ export default function DecisionsPage() {
         </div>
       )}
 
-      {error && <div className="alert-err">Unreachable: {error}</div>}
+      {error && (
+        <div className="alert-err">
+          {error.startsWith("/traces")
+            ? `Response shape unexpected (bridge version mismatch?): ${error}`
+            : `Unreachable: ${error}`}
+        </div>
+      )}
 
       {!loading && traces.length === 0 && !error ? (
         <div className="empty-state">

--- a/dashboard/src/app/sessions/[id]/page.tsx
+++ b/dashboard/src/app/sessions/[id]/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { useParams } from "next/navigation";
 import { relTime } from "@/components/time";
 import { useBridgeFetch } from "@/hooks/useBridgeFetch";
+import { arr, isRecord, shape, type ShapeCheck } from "@/lib/validate";
 
 interface SessionSummary {
   id: string;
@@ -56,6 +57,32 @@ interface DetailResponse {
   approvals: PendingApproval[];
 }
 
+/**
+ * Minimal runtime validation — catches bridge/dashboard version drift
+ * (e.g. an older bridge that predates tools[] / decisions[]) and turns
+ * silent blank sections into a loud error. Intentionally permissive on
+ * optional arrays: missing is fine (older bridge), wrong type is not.
+ */
+const validateDetail: ShapeCheck<DetailResponse> = shape(
+  "/sessions/:id",
+  (raw, errors) => {
+    if (!isRecord(raw)) {
+      errors.push({ path: "$", reason: "expected object" });
+      return null;
+    }
+    // summary may be null (unknown session) — only fail on unexpected shapes.
+    if (raw.summary !== null && !isRecord(raw.summary)) {
+      errors.push({ path: "summary", reason: "expected object or null" });
+    }
+    arr(raw, "lifecycle", errors);
+    arr(raw, "approvals", errors);
+    arr(raw, "tools", errors, { optional: true });
+    arr(raw, "decisions", errors, { optional: true });
+    if (errors.length > 0) return null;
+    return raw as unknown as DetailResponse;
+  },
+);
+
 const NOISE_EVENTS = new Set([
   "claude_connected",
   "claude_disconnected",
@@ -71,7 +98,7 @@ export default function SessionDetailPage() {
 
   const { data, error, loading, status } = useBridgeFetch<DetailResponse>(
     `/api/bridge/sessions/${id}`,
-    { intervalMs: 3000 },
+    { intervalMs: 3000, transform: validateDetail },
   );
 
   const summary = data?.summary ?? null;
@@ -126,7 +153,13 @@ export default function SessionDetailPage() {
         )}
       </div>
 
-      {error && !data && <div className="alert-err">Unreachable: {error}</div>}
+      {error && !data && (
+        <div className="alert-err">
+          {error.startsWith("/sessions/:id")
+            ? `Response shape unexpected (bridge version mismatch?): ${error}`
+            : `Unreachable: ${error}`}
+        </div>
+      )}
       {!loading && !data && status === 404 && (
         <div className="empty-state">
           <h3>Session not found</h3>

--- a/dashboard/src/app/traces/page.tsx
+++ b/dashboard/src/app/traces/page.tsx
@@ -2,6 +2,7 @@
 import { useMemo, useState } from "react";
 import { relTime } from "@/components/time";
 import { useBridgeFetch } from "@/hooks/useBridgeFetch";
+import { arr, isRecord, shape, type ShapeCheck } from "@/lib/validate";
 
 type TraceType = "approval" | "enrichment" | "recipe_run" | "decision";
 
@@ -23,6 +24,25 @@ interface TracesResponse {
     decision: boolean;
   };
 }
+
+const validateTraces: ShapeCheck<TracesResponse> = shape(
+  "/traces",
+  (raw, errors) => {
+    if (!isRecord(raw)) {
+      errors.push({ path: "$", reason: "expected object" });
+      return null;
+    }
+    arr(raw, "traces", errors);
+    if (typeof raw.count !== "number") {
+      errors.push({ path: "count", reason: "expected number" });
+    }
+    if (!isRecord(raw.sources)) {
+      errors.push({ path: "sources", reason: "expected object" });
+    }
+    if (errors.length > 0) return null;
+    return raw as unknown as TracesResponse;
+  },
+);
 
 const TYPE_LABELS: Record<TraceType, string> = {
   approval: "Approval",
@@ -56,7 +76,7 @@ export default function TracesPage() {
 
   const { data, error, loading } = useBridgeFetch<TracesResponse>(
     `/api/bridge/traces${qs}`,
-    { intervalMs: 3000 },
+    { intervalMs: 3000, transform: validateTraces },
   );
 
   const traces = data?.traces ?? [];
@@ -174,7 +194,13 @@ export default function TracesPage() {
         </div>
       )}
 
-      {error && <div className="alert-err">Unreachable: {error}</div>}
+      {error && (
+        <div className="alert-err">
+          {error.startsWith("/traces")
+            ? `Response shape unexpected (bridge version mismatch?): ${error}`
+            : `Unreachable: ${error}`}
+        </div>
+      )}
 
       {!loading && traces.length === 0 && !error ? (
         <div className="empty-state">

--- a/dashboard/src/lib/validate.ts
+++ b/dashboard/src/lib/validate.ts
@@ -1,0 +1,112 @@
+/**
+ * Tiny runtime shape validators for bridge responses.
+ *
+ * TypeScript interfaces are erased at compile time, so a bridge/dashboard
+ * version mismatch (e.g. missing `tools` on /sessions/:id from an older
+ * bridge that predates PR #24) silently renders `undefined` in the UI.
+ * These helpers turn silent drift into a loud error we can show to users.
+ *
+ * Keep this dependency-free (no zod/ajv) — the schemas are tiny and the
+ * cost of a runtime dep outweighs writing 5-line validators.
+ */
+
+export type ShapeError = { path: string; reason: string };
+
+export class ShapeValidationError extends Error {
+  constructor(
+    public readonly errors: ShapeError[],
+    public readonly label: string,
+  ) {
+    super(
+      `${label}: ${errors.map((e) => `${e.path} ${e.reason}`).join("; ")}`,
+    );
+    this.name = "ShapeValidationError";
+  }
+}
+
+export type ShapeCheck<T> = (raw: unknown) => T;
+
+/**
+ * Assert that a value is a plain object. Useful as the first line of every
+ * validator.
+ */
+export function isRecord(x: unknown): x is Record<string, unknown> {
+  return typeof x === "object" && x !== null && !Array.isArray(x);
+}
+
+/** Build a validator from a label + a pure check function. */
+export function shape<T>(
+  label: string,
+  check: (raw: unknown, errors: ShapeError[]) => T | null,
+): ShapeCheck<T> {
+  return (raw: unknown): T => {
+    const errors: ShapeError[] = [];
+    const out = check(raw, errors);
+    if (errors.length > 0 || out === null) {
+      throw new ShapeValidationError(
+        errors.length > 0
+          ? errors
+          : [{ path: "$", reason: "validator returned null" }],
+        label,
+      );
+    }
+    return out;
+  };
+}
+
+/** Assert a field exists and is a non-empty string. */
+export function str(
+  obj: Record<string, unknown>,
+  field: string,
+  errors: ShapeError[],
+  opts: { optional?: boolean } = {},
+): string | undefined {
+  const v = obj[field];
+  if (v === undefined) {
+    if (!opts.optional) errors.push({ path: field, reason: "missing" });
+    return undefined;
+  }
+  if (typeof v !== "string") {
+    errors.push({ path: field, reason: `expected string, got ${typeof v}` });
+    return undefined;
+  }
+  return v;
+}
+
+/** Assert a field is a number. */
+export function num(
+  obj: Record<string, unknown>,
+  field: string,
+  errors: ShapeError[],
+  opts: { optional?: boolean } = {},
+): number | undefined {
+  const v = obj[field];
+  if (v === undefined) {
+    if (!opts.optional) errors.push({ path: field, reason: "missing" });
+    return undefined;
+  }
+  if (typeof v !== "number") {
+    errors.push({ path: field, reason: `expected number, got ${typeof v}` });
+    return undefined;
+  }
+  return v;
+}
+
+/** Assert a field is an array (of anything — caller validates items). */
+export function arr<U = unknown>(
+  obj: Record<string, unknown>,
+  field: string,
+  errors: ShapeError[],
+  opts: { optional?: boolean } = {},
+): U[] | undefined {
+  const v = obj[field];
+  if (v === undefined) {
+    if (!opts.optional) errors.push({ path: field, reason: "missing" });
+    return undefined;
+  }
+  if (!Array.isArray(v)) {
+    errors.push({ path: field, reason: `expected array, got ${typeof v}` });
+    return undefined;
+  }
+  return v as U[];
+}


### PR DESCRIPTION
## Summary
TypeScript interfaces are erased at compile time — a bridge/dashboard version mismatch renders silently: missing fields become `undefined`, wrong types blow up deep in render code with opaque React errors. After today's new response shapes (`tools[]`, `decisions[]` on `/sessions/:id`; `tag` param on `/traces`), the drift surface grew.

This adds a tiny dependency-free validator and wires it into the three pages whose response shapes changed today.

## Implementation
**New**: `dashboard/src/lib/validate.ts` — 4 primitives (`isRecord`, `str`, `num`, `arr`) + a `shape()` wrapper that builds a `ShapeCheck<T>` from a label + check function. Throws `ShapeValidationError` with a label-prefixed message the UI can match on.

**Wired in**:
- `/sessions/:id` — `lifecycle`/`approvals` required, `tools`/`decisions` optional (lets older bridges work)
- `/traces` — `traces` + `count` + `sources` required
- `/decisions` — minimal `traces[]` check

Each page's error banner now distinguishes "Response shape unexpected (bridge version mismatch?)" from "Unreachable" by matching on the label prefix.

## Verification
Live smoke test against the running bridge:
```
real response:           VALID  []
tampered (traces=string): INVALID [{ path: 'traces', reason: 'expected array, got string' }]
tampered (no traces):     INVALID [{ path: 'traces', reason: 'missing' }]
```
Plus: `next build` succeeds, bridge vitest suite unchanged at 232 files pass.

## Why no unit tests
Dashboard has no test framework (intentionally kept minimal per CLAUDE.md). Adding one just for this would be scope creep. The validator is 100 lines of pure code with no cleverness, and the smoke test above covers the three interesting shapes (valid / wrong type / missing). If this proves too thin, follow-up PR can add vitest to the dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)