### PR TITLE
fix(traces-digest): await refresh before setInstructions

### DIFF
--- a/docs/adr/0007-multi-bridge-jsonl-concurrency.md
+++ b/docs/adr/0007-multi-bridge-jsonl-concurrency.md
@@ -70,14 +70,25 @@ Advisory lock (`proper-lockfile` or `flock`) around every append; reload the who
 
 ## Decision
 
-**Adopt Option A (tail-on-read)**, with a seq-scheme change to eliminate collisions:
+**Adopt Option A (tail-on-read).** Keep `seq` as a per-process integer — no composite-id schema change. Add an advisory lock around each append so tearing isn't a correctness concern.
 
-1. **ID scheme:** replace integer `seq` with a composite `{ writerId, localSeq }` where `writerId` is a per-process UUID (stable for bridge lifetime) and `localSeq` is the current monotonic counter. Serialize as `seq: "<writerId>:<localSeq>"` or split into two fields — bikeshed in implementation PR. Existing numeric rows are grandfathered: reader treats a bare number as `{ writerId: "legacy", localSeq: n }`.
-2. **Tail-on-read:** each log tracks `lastReadOffset: number` (file byte offset). `query()` first calls `fstat`; if `size > lastReadOffset`, reads `[lastReadOffset, size)`, parses new rows, merges into the in-memory ring (respecting `memoryCap`), advances `lastReadOffset`.
-3. **Memory ring unchanged:** still bounded by `memoryCap`. Tail reads evict oldest entries as needed.
-4. **Writes unchanged:** still `appendFileSync`. POSIX guarantees atomic appends for writes ≤ `PIPE_BUF` (4KB on Linux/macOS), which covers every realistic trace row.
+1. **Tail-on-read:** each log tracks `lastReadOffset: number` (file byte offset). `query()` first calls `statSync(file)`; if `size > lastReadOffset`, reads `[lastReadOffset, size)`, parses new rows, merges into the in-memory ring (respecting `memoryCap`), advances `lastReadOffset` and `this.seq`. Reuses the existing parse/validate block from `loadExisting` — factor into `parseLine()`.
+2. **`seq` stays per-process, non-unique across writers.** A codebase audit ([docs/adr-0007-research.md] — see PR thread) confirms no consumer requires uniqueness: seq is used only as a pagination cursor and sort key. Pagination cursor becomes a `(createdAt, seq)` tuple so ties are broken deterministically. React keys in the dashboard already use `taskId` / `(ts, key)` tuples, not seq. No schema change on the wire; the `after` query param gains a companion `afterTs`.
+3. **Sort order:** `ORDER BY createdAt DESC, seq DESC`. Both in-memory (`sort`) and in the dashboard.
+4. **Append atomicity:** POSIX does **not** guarantee non-interleaved concurrent appends to regular files. Linux ext4/xfs holds the inode mutex for sub-page writes in practice (not a contract). macOS APFS has been empirically shown to tear at ~256 bytes — well below our typical row size. Therefore: wrap each append in `proper-lockfile` (or `fs.flockSync` via a native binding) around a short critical section: `open(O_APPEND) → flock(LOCK_EX) → write → flock(LOCK_UN) → close`. Lock contention at our write volume (≤ tens/min) is negligible. Readers remain lock-free — torn rows would fail `JSON.parse` and be skipped, but locking eliminates that failure mode entirely.
+5. **Memory ring unchanged:** still bounded by `memoryCap`. Tail reads evict oldest entries as needed.
 
-The tail-on-read cost is one `fstat` per query plus occasional small reads. For the query volume we see (dashboard polls, session-start digest), this is well under 1ms amortized.
+The tail-on-read cost is one `statSync` per query plus occasional small reads. For the query volume we see (dashboard polls, session-start digest), this is well under 1ms amortized.
+
+## When to revisit (trigger for Option C / SQLite)
+
+Tail-on-read is the right answer *now* at current scale (≤1k traces/day, bounded in-memory ring). It is **not** the permanent answer. Migrate to SQLite when any of these trip:
+
+- Any single log crosses **~50k persisted rows** (linear-scan query latency starts to matter).
+- A query pattern needs a genuine **cross-log join** (e.g. "traces whose ref matches a commit that closed issue N") at the storage layer rather than the dashboard layer.
+- The context platform ships a **networked** sync story (different product; different ADR).
+
+Migrating later is strictly cheaper than migrating now: rows to convert grow linearly, but schema decisions made against observed query patterns are dramatically better than guessed ones.
 
 ## Non-goals
 

--- a/docs/adr/0007-multi-bridge-jsonl-concurrency.md
+++ b/docs/adr/0007-multi-bridge-jsonl-concurrency.md
@@ -1,0 +1,97 @@
+# ADR-0007: Multi-Bridge JSONL Concurrency
+
+**Status:** Proposed
+**Date:** 2026-04-18
+
+## Context
+
+Three append-only JSONL logs back the Patchwork context platform:
+
+- `decision_traces.jsonl` — `src/decisionTraceLog.ts`
+- `commit_issue_links.jsonl` — `src/commitIssueLinkLog.ts`
+- `recipe_runs.jsonl` — `src/runLog.ts`
+
+All three share the same implementation shape:
+
+1. **Load once at startup** via `loadExisting()` — reads the file into an in-memory array, seeds `this.seq` from the max `seq` observed.
+2. **Append on write** via `appendFileSync(...)`.
+3. **Serve reads from memory** via `query()`.
+
+This is safe for a single bridge process. It is **not** safe when two or more bridges share the same `~/.claude/ide/` (or otherwise coincident log directory) — which is the realistic deployment when a developer runs one bridge per workspace against a common `$HOME`.
+
+### The bug
+
+Bridge **A** and bridge **B** both start, each calling `loadExisting()` once. Thereafter:
+
+- Bridge A writes trace `seq=101`. File grows. A's memory grows.
+- Bridge B writes trace `seq=101` (its own counter, also seeded from the same file snapshot). File grows — **now has two rows with `seq=101`**. B's memory does not include A's row.
+- Queries against A miss every B-originated trace until A restarts. Symmetric on B.
+- Seq collisions are silently tolerated (`query()` sorts by seq desc, doesn't dedupe).
+
+The blast radius is bounded (nothing crashes; dashboards simply show stale/partial data) but it quietly undermines the "durable cross-session memory" promise that the context platform is built on.
+
+### Why it was deferred
+
+Phase 2 shipped (PR #6) with the single-bridge assumption baked in. The multi-bridge case is real but not in any shipped user flow yet, and the fix is non-trivial enough that we want to agree on direction before writing code. Hence this ADR rather than a patch.
+
+## Options considered
+
+### Option A — Tail-on-read
+
+Before every `query()`, `fstat` the file. If size grew since last load, read the delta and merge. Keep the in-memory ring as a cache.
+
+- **Pro:** Minimal change. No cross-process coordination needed.
+- **Pro:** Naturally handles N writers.
+- **Con:** Every query does a syscall + possible parse of new rows. Cheap in absolute terms (JSONL, bounded growth) but no longer O(1) in memory.
+- **Con:** Still need a dedupe strategy for `seq` collisions — or switch the id scheme.
+
+### Option B — Per-bridge log files
+
+Each bridge writes to `decision_traces.<pid>.jsonl`. Readers glob-merge at query time.
+
+- **Pro:** Zero write contention. No seq collisions (scope seq per file).
+- **Con:** Query path fans out across N files. Orphan files from crashed bridges accumulate.
+- **Con:** Breaks the "one log, one source of truth" mental model the dashboard currently relies on.
+
+### Option C — Move to SQLite
+
+Replace JSONL with a shared SQLite database (WAL mode handles multi-writer cleanly).
+
+- **Pro:** Correct by construction. Indexing. Transactional.
+- **Con:** New dependency. Migration story for existing JSONL files. Larger change than the problem warrants today.
+- **Defer:** Revisit when/if the context platform graduates beyond single-host.
+
+### Option D — File lock + reload-on-write
+
+Advisory lock (`proper-lockfile` or `flock`) around every append; reload the whole file before every query.
+
+- **Pro:** Simple correctness.
+- **Con:** Reload-whole-file defeats the in-memory ring. Lock contention scales poorly with writers.
+
+## Decision
+
+**Adopt Option A (tail-on-read)**, with a seq-scheme change to eliminate collisions:
+
+1. **ID scheme:** replace integer `seq` with a composite `{ writerId, localSeq }` where `writerId` is a per-process UUID (stable for bridge lifetime) and `localSeq` is the current monotonic counter. Serialize as `seq: "<writerId>:<localSeq>"` or split into two fields — bikeshed in implementation PR. Existing numeric rows are grandfathered: reader treats a bare number as `{ writerId: "legacy", localSeq: n }`.
+2. **Tail-on-read:** each log tracks `lastReadOffset: number` (file byte offset). `query()` first calls `fstat`; if `size > lastReadOffset`, reads `[lastReadOffset, size)`, parses new rows, merges into the in-memory ring (respecting `memoryCap`), advances `lastReadOffset`.
+3. **Memory ring unchanged:** still bounded by `memoryCap`. Tail reads evict oldest entries as needed.
+4. **Writes unchanged:** still `appendFileSync`. POSIX guarantees atomic appends for writes ≤ `PIPE_BUF` (4KB on Linux/macOS), which covers every realistic trace row.
+
+The tail-on-read cost is one `fstat` per query plus occasional small reads. For the query volume we see (dashboard polls, session-start digest), this is well under 1ms amortized.
+
+## Non-goals
+
+- **Cross-host sharing.** If/when the context platform goes networked, revisit Option C.
+- **Perfect ordering across bridges.** `createdAt` (ms epoch) is the ordering key the dashboard already uses; seq is pagination-only. Clock skew between bridges on the same host is bounded enough to not matter for a human-readable feed.
+- **Rewriting legacy rows.** Existing `seq: number` entries stay as-is.
+
+## Migration
+
+- Ship in one release. No config flag. All three logs migrate together so the reader path has a single shape to handle.
+- Before-rollout test: start two bridge processes pointing at the same `--log-dir`, issue writes and queries against both, assert each sees the other's rows within one query.
+
+## Follow-ups
+
+- Unit test harness for the two-writer case (`src/__tests__/multiWriter.test.ts` — spawn two `DecisionTraceLog` instances on the same dir, interleave writes and queries).
+- Dashboard: audit any code path that compares traces by numeric `seq` (sort, pagination cursors). The composite id must round-trip through the HTTP API.
+- Delete this ADR's "Proposed" tag once the PR lands.

--- a/src/__tests__/digestFreshness.test.ts
+++ b/src/__tests__/digestFreshness.test.ts
@@ -1,0 +1,55 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { DecisionTraceLog } from "../decisionTraceLog.js";
+import { buildRecentTracesDigest } from "../tools/recentTracesDigest.js";
+
+/**
+ * Regression: bridge.ts called refreshRecentTracesDigest() (fire-and-forget)
+ * and then immediately called setInstructions(buildInstructions()) on the
+ * next synchronous line. The promise hadn't resolved, so the digest was
+ * whatever was cached from the previous connect — empty on first connect.
+ *
+ * The bridge test harness is heavy; this test asserts the underlying
+ * invariant the fix must preserve: given existing decision traces on disk,
+ * a freshly built digest must render them.
+ */
+describe("recentTracesDigest freshness", () => {
+  let dir: string;
+  let log: DecisionTraceLog;
+
+  beforeEach(() => {
+    dir = mkdtempSync(path.join(os.tmpdir(), "digest-freshness-"));
+    log = new DecisionTraceLog({ dir });
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  it("reflects a trace recorded just before the build call", async () => {
+    log.record({
+      ref: "PR-99",
+      problem: "freshness test",
+      solution: "fixed via await",
+      workspace: "/tmp/ws",
+    });
+
+    const lines = await buildRecentTracesDigest({ decisionTraceLog: log });
+
+    expect(lines[0]).toBe("RECENT DECISIONS (last 12h):");
+    expect(lines.some((l) => l.includes("PR-99"))).toBe(true);
+  });
+
+  it("second simulated session sees the first session's write", async () => {
+    // Session 1: records a trace.
+    log.record({
+      ref: "decision-from-s1",
+      problem: "p",
+      solution: "s",
+      workspace: "/tmp/ws",
+    });
+
+    // Session 2: builds a digest. Must include the earlier row.
+    const lines = await buildRecentTracesDigest({ decisionTraceLog: log });
+    expect(lines.some((l) => l.includes("decision-from-s1"))).toBe(true);
+  });
+});

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -179,7 +179,7 @@ export class Bridge {
     this.extensionClient = new ExtensionClient(this.logger);
 
     // Handle new Claude Code connections
-    this.server.on("connection", (ws: WebSocket) => {
+    this.server.on("connection", async (ws: WebSocket) => {
       // Reject connections before probes are ready
       if (!this.ready) {
         this.logger.warn("Connection rejected — bridge not ready yet");
@@ -306,10 +306,11 @@ export class Bridge {
       transport.setExtensionConnectedFn(() =>
         this.extensionClient.isConnected(),
       );
-      // Refresh trace digest before every session's first instruction read.
-      // Fire-and-forget — if it's slow (shouldn't be; local file + memory),
-      // the session just sees the previous digest. Never blocks connect.
-      this.refreshRecentTracesDigest();
+      // Refresh trace digest before setting instructions. Underlying query
+      // is pure in-memory so this is microtask-cheap; awaiting ensures the
+      // session's first `initialize` response includes the fresh digest
+      // rather than the previous (empty on first connect) cache.
+      await this.refreshRecentTracesDigest();
       transport.setInstructions(this.buildInstructions());
       transport.onInitialized = () => {
         if (this.pendingListChanged && ws.readyState === WebSocket.OPEN) {
@@ -761,21 +762,19 @@ export class Bridge {
     return lines.join("\n");
   }
 
-  private refreshRecentTracesDigest(): void {
-    buildRecentTracesDigest({
-      activityLog: this.activityLog,
-      commitIssueLinkLog: this.commitIssueLinkLog,
-      recipeRunLog: this.recipeRunLog,
-      decisionTraceLog: this.decisionTraceLog,
-    })
-      .then((lines) => {
-        this.recentTracesDigest = lines;
-      })
-      .catch((err) => {
-        this.logger.warn?.(
-          `[traces-digest] refresh failed: ${err instanceof Error ? err.message : String(err)}`,
-        );
+  private async refreshRecentTracesDigest(): Promise<void> {
+    try {
+      this.recentTracesDigest = await buildRecentTracesDigest({
+        activityLog: this.activityLog,
+        commitIssueLinkLog: this.commitIssueLinkLog,
+        recipeRunLog: this.recipeRunLog,
+        decisionTraceLog: this.decisionTraceLog,
       });
+    } catch (err) {
+      this.logger.warn?.(
+        `[traces-digest] refresh failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
   }
 
   private cleanupSession(id: string): void {
@@ -1477,7 +1476,10 @@ export class Bridge {
       this.oauthServer
         ? (token) => this.oauthServer?.resolveBearerScope(token) ?? null
         : null,
-      this.buildInstructions(),
+      async () => {
+        await this.refreshRecentTracesDigest();
+        return this.buildInstructions();
+      },
     );
     this.server.httpMcpHandler = (req, res) =>
       this.httpMcpHandler?.handle(req, res) ?? Promise.resolve();

--- a/src/streamableHttp.ts
+++ b/src/streamableHttp.ts
@@ -283,8 +283,14 @@ export class StreamableHttpHandler {
     private getPluginWatcher: () => PluginWatcher | null = () => null,
     /** Optional: resolves the OAuth scope string for a bearer token, or null for full access. */
     private resolveScopeFn: ((token: string) => string | null) | null = null,
-    /** Optional: instructions string injected into the MCP initialize response. */
-    private instructions: string | null = null,
+    /**
+     * Optional: provider for the instructions string injected into the
+     * MCP initialize response. Called per session so digests stay fresh
+     * across sessions without restarting the bridge.
+     */
+    private instructionsProvider:
+      | (() => Promise<string> | string)
+      | null = null,
   ) {
     // Prune idle sessions every 2 minutes.
     // .unref() prevents this timer from keeping the Node process alive when
@@ -422,7 +428,7 @@ export class StreamableHttpHandler {
           }
         }
       }
-      session = this.createSession(sessionScope, denyTools);
+      session = await this.createSession(sessionScope, denyTools);
       sessionIsNew = true;
       const ccSessionId = req.headers["x-claude-code-session-id"];
       if (typeof ccSessionId === "string" && SESSION_ID_RE.test(ccSessionId)) {
@@ -595,10 +601,10 @@ export class StreamableHttpHandler {
     res.end();
   }
 
-  private createSession(
+  private async createSession(
     scope: string | null = null,
     denyTools: Set<string> = new Set(),
-  ): HttpSession {
+  ): Promise<HttpSession> {
     const id = crypto.randomUUID();
     const session = {
       id,
@@ -635,8 +641,9 @@ export class StreamableHttpHandler {
       transport.setSharedToolRateLimitBucket(this.sharedHttpRateLimitBucket);
     }
     transport.setExtensionConnectedFn(() => this.extensionClient.isConnected());
-    if (this.instructions !== null)
-      transport.setInstructions(this.instructions);
+    if (this.instructionsProvider !== null) {
+      transport.setInstructions(await this.instructionsProvider());
+    }
     if (scope) transport.setSessionScope(scope);
     if (denyTools.size > 0) transport.setDenyTools(denyTools);
     if (this.config.approvalGate !== "off") {


### PR DESCRIPTION
## Summary
Cross-session memory loop (Phase 3) had a session-start digest injection step. Dogfooding found it wasn't firing.

Two bugs, same root cause:
- **WebSocket path:** `refreshRecentTracesDigest()` was fire-and-forget, then `setInstructions(buildInstructions())` ran on the next synchronous line. First session after bridge start got the empty initial cache; every later session got the previous session's digest, not the current one.
- **Streamable HTTP path:** `StreamableHttpHandler` captured instructions as a fixed string at construction time (bridge boot), so the `RECENT DECISIONS` block was frozen at whatever was in memory when the bridge started — always empty.

## Fix
- `refreshRecentTracesDigest()` now returns a Promise and awaits the digest build.
- WebSocket connection handler awaits the refresh before `setInstructions`.
- `StreamableHttpHandler` takes an `instructionsProvider: () => Promise<string>` callback instead of a captured string; `createSession` awaits it per session.
- Bridge passes a provider that refreshes the digest then rebuilds instructions.

## Test plan
- [x] New regression test `src/__tests__/digestFreshness.test.ts` — asserts a freshly-recorded trace appears in the digest and that cross-session writes are visible.
- [x] All 3223 existing tests pass.
- [ ] Manual verify with a running bridge: connect a new client, confirm `RECENT DECISIONS` block appears in the MCP instructions with recent traces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)