### PR TITLE
fix(connectors): preserve refresh tokens on transient failures

### DIFF
--- a/docs/recipe-authoring-wave2-plan.md
+++ b/docs/recipe-authoring-wave2-plan.md
@@ -72,9 +72,11 @@ Produced as companion to [`recipe-chaining-wave1-plan.md`](./recipe-chaining-wav
    - Next: finish moving remaining dry-run, authoring, and documentation consumers onto the same source of truth.
    - Target state: tool metadata lives in one place and drives runner dispatch, schema generation, dry-run mocking, and dashboard docs.
 
-2. **OAuth 2.0 refresh primitives in `BaseConnector`**
-   - Add standard refresh-token lifecycle handling before Wave 2 agents start.
-   - Store refresh/access tokens in OS keychain via `keytar`, not plain JSON files.
+2. **OAuth 2.0 refresh primitives in `BaseConnector`** ✅ *Shipped*
+   - `BaseConnector.refreshToken()` (`src/connectors/baseConnector.ts:127-175`) implements the RFC 6749 refresh_token grant; `apiCall<T>` (`:198-278`) refreshes preemptively when expired and again on `auth_expired` mid-call before falling back to full re-auth.
+   - Tokens persisted via `src/connectors/tokenStorage.ts` to OS keychain — native CLIs (`security` on macOS, DPAPI/PowerShell on Windows, `secret-tool` on Linux) with AES-256-GCM encrypted-file fallback. **No `keytar` dependency** (avoids unmaintained native module + Electron rebuild pain).
+   - All Wave 2 candidates (Zendesk, Stripe, Datadog, Intercom, HubSpot, Confluence, Notion, Jira) extend `BaseConnector` and implement `getOAuthConfig()`.
+   - **Remaining gap (test coverage, ~1 day):** only `gmailRefresh.test.ts` exercises the refresh path today; per-Wave-2-connector refresh tests + a direct `BaseConnector.refreshToken()` unit test are needed before merging Wave 2 connectors. See "Testing" section below.
 
 3. **Feature flags + rollback hooks**
    - Every new surface ships behind `bridge.config.features.<featureName>`.

--- a/docs/recipe-schemastore-pr.md
+++ b/docs/recipe-schemastore-pr.md
@@ -1,20 +1,22 @@
 # SchemaStore PR — Patchwork Recipe Schema
 
-**Status:** Draft — not yet submitted  
-**Target repo:** https://github.com/SchemaStore/schemastore  
-**File to add:** `src/schemas/json/patchwork-recipe.json`  
-**Companion catalog entry:** `src/api/json/catalog.json`
+**Status:** Submitted — [SchemaStore/schemastore#5608](https://github.com/SchemaStore/schemastore/pull/5608) (open, awaiting LGTM from @madskristensen / @hyperupcall as of 2026-04-28)
+**Target repo:** https://github.com/SchemaStore/schemastore
+**Catalog entry:** `src/api/json/catalog.json` (only — schema served externally)
+**External schema URL:** `https://raw.githubusercontent.com/patchworkos/recipes/main/schema/recipe.v1.json`
+
+**Note (2026-04-28):** Per maintainer feedback, the in-repo `src/schemas/json/patchwork-recipe.json` and `src/test/patchwork-recipe/` fixtures were dropped — when the catalog points at an external URL, SchemaStore does not need a mirrored copy. PR diff is now a single `catalog.json` entry.
 
 ---
 
 ## Pre-submission checklist
 
 - [x] Add `x-taplo` file-patterns to generated schema (`schemaGenerator.ts` — shipped alpha.22)
-- [ ] Wire upload endpoint + set `PATCHWORK_SCHEMA_UPLOAD_URL` / `PATCHWORK_SCHEMA_UPLOAD_TOKEN` so `prepublishOnly` pushes to `https://patchwork.sh/schema/` (script is written: `scripts/publish-schemas.mjs`; needs the hosting endpoint provisioned)
-- [ ] Confirm `https://patchwork.sh/schema/recipe.v1.json` resolves publicly (SchemaStore validates the URL on PR submission)
-- [ ] Run SchemaStore's local validation: `npm run build` in the schemastore fork passes
-- [ ] Add at least one positive + one negative test fixture under `src/test/`
-- [ ] Confirm `$schema` header in all `examples/recipes/*.yaml` matches the published URL exactly
+- [x] Public schema URL resolves: `raw.githubusercontent.com/patchworkos/recipes/main/schema/recipe.v1.json` HTTP 200 (used as catalog `url` instead of needing `patchwork.sh` hosting)
+- [x] SchemaStore CI passes — `validate`, `triage`, pre-commit, codeowners-merge all green on commit a85eab5
+- [N/A] Test fixtures — dropped per maintainer guidance (external-URL catalog entries don't need them)
+- [ ] Confirm `$schema` header in all `examples/recipes/*.yaml` matches the catalog URL exactly (only matters once PR merges and `https://www.schemastore.org/json/` redirect resolves)
+- [ ] Decide long-term: keep hosting on `patchworkos/recipes` repo, or migrate to `Oolab-labs/patchwork-os/main/schemas/` (also live, HTTP 200) — currently both work, the former is canonical because catalog points there and `$id` matches
 
 ---
 

--- a/src/connectors/__tests__/baseConnector.test.ts
+++ b/src/connectors/__tests__/baseConnector.test.ts
@@ -1,0 +1,361 @@
+/**
+ * Direct unit tests for BaseConnector.refreshToken() and the auto-refresh
+ * paths inside apiCall(). Subclassed via TestConnector so we can drive the
+ * abstract surface without dragging in a real provider.
+ *
+ * Why: gmailRefresh.test.ts only exercises Gmail's overridden refresh path;
+ * none of the Wave-2 connectors (zendesk, stripe, intercom, hubspot, datadog)
+ * have refresh-flow tests. Cover the base class so the contract that all of
+ * them inherit is locked in before more connectors ship.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  type AuthContext,
+  BaseConnector,
+  type ConnectorError,
+  type ConnectorStatus,
+  type OAuthConfig,
+} from "../baseConnector.js";
+
+const storeTokens = vi.fn().mockResolvedValue(undefined);
+const getTokens = vi.fn().mockResolvedValue(null);
+const deleteTokens = vi.fn().mockResolvedValue(undefined);
+
+vi.mock("../tokenStorage.js", () => ({
+  storeTokens: (...args: unknown[]) => storeTokens(...args),
+  getTokens: (...args: unknown[]) => getTokens(...args),
+  deleteTokens: (...args: unknown[]) => deleteTokens(...args),
+}));
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+class TestConnector extends BaseConnector {
+  readonly providerName = "test-provider";
+
+  authenticateImpl: () => Promise<AuthContext> = async () => {
+    throw new Error("authenticate not configured by test");
+  };
+
+  protected getOAuthConfig(): OAuthConfig | null {
+    return {
+      clientId: "test-client",
+      clientSecret: "test-secret",
+      tokenEndpoint: "https://oauth.example.com/token",
+    };
+  }
+
+  async authenticate(): Promise<AuthContext> {
+    return this.authenticateImpl();
+  }
+
+  async healthCheck() {
+    return { ok: true };
+  }
+
+  normalizeError(err: unknown): ConnectorError {
+    if (err instanceof Error && err.message === "EXPIRED") {
+      return {
+        code: "auth_expired",
+        message: "expired",
+        retryable: true,
+      };
+    }
+    if (err instanceof Error && err.message === "RETRYABLE") {
+      return {
+        code: "provider_error",
+        message: "retryable",
+        retryable: true,
+      };
+    }
+    return {
+      code: "provider_error",
+      message: err instanceof Error ? err.message : "unknown",
+      retryable: false,
+    };
+  }
+
+  getStatus(): ConnectorStatus {
+    return { id: this.providerName, status: "connected" };
+  }
+
+  // Test seam — populate auth without going through authenticate()
+  setAuth(auth: AuthContext | null) {
+    this.auth = auth;
+  }
+
+  callRefresh() {
+    return this.refreshToken();
+  }
+
+  callApi<T>(fn: (token: string) => Promise<T>, retries?: number) {
+    return this.apiCall(fn, { retries, retryDelayMs: 1 });
+  }
+}
+
+class NoConfigConnector extends TestConnector {
+  protected getOAuthConfig(): OAuthConfig | null {
+    return null;
+  }
+}
+
+beforeEach(() => {
+  storeTokens.mockClear();
+  getTokens.mockClear();
+  deleteTokens.mockClear();
+  mockFetch.mockReset();
+});
+
+afterEach(() => {
+  vi.clearAllTimers();
+});
+
+describe("BaseConnector.refreshToken()", () => {
+  it("returns null when no refresh token is present", async () => {
+    const c = new TestConnector();
+    c.setAuth({ token: "at_old" });
+
+    const result = await c.callRefresh();
+
+    expect(result).toBeNull();
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(deleteTokens).not.toHaveBeenCalled();
+  });
+
+  it("returns null when no OAuth config is available", async () => {
+    const c = new NoConfigConnector();
+    c.setAuth({ token: "at_old", refreshToken: "rt_test" });
+
+    const result = await c.callRefresh();
+
+    expect(result).toBeNull();
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("posts refresh_token grant and persists new tokens on success", async () => {
+    const c = new TestConnector();
+    c.setAuth({ token: "at_old", refreshToken: "rt_old" });
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        access_token: "at_new",
+        refresh_token: "rt_new",
+        expires_in: 3600,
+        scope: "read write",
+      }),
+    });
+
+    const result = await c.callRefresh();
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const [url, init] = mockFetch.mock.calls[0]!;
+    expect(url).toBe("https://oauth.example.com/token");
+    expect(init.method).toBe("POST");
+    expect(init.headers["Content-Type"]).toBe(
+      "application/x-www-form-urlencoded",
+    );
+    const body = new URLSearchParams(init.body as string);
+    expect(body.get("grant_type")).toBe("refresh_token");
+    expect(body.get("refresh_token")).toBe("rt_old");
+    expect(body.get("client_id")).toBe("test-client");
+    expect(body.get("client_secret")).toBe("test-secret");
+
+    expect(result?.token).toBe("at_new");
+    expect(result?.refreshToken).toBe("rt_new");
+    expect(result?.scopes).toEqual(["read", "write"]);
+    expect(result?.expiresAt).toBeInstanceOf(Date);
+    // expiresAt should be ~3600s in the future (allow 5s skew)
+    const driftMs = result!.expiresAt!.getTime() - Date.now() - 3600_000;
+    expect(Math.abs(driftMs)).toBeLessThan(5_000);
+
+    expect(storeTokens).toHaveBeenCalledTimes(1);
+    expect(storeTokens).toHaveBeenCalledWith("test-provider", {
+      accessToken: "at_new",
+      refreshToken: "rt_new",
+      expiresAt: result!.expiresAt!.toISOString(),
+      scopes: ["read", "write"],
+    });
+  });
+
+  it("preserves the existing refresh token when the response omits one", async () => {
+    const c = new TestConnector();
+    c.setAuth({ token: "at_old", refreshToken: "rt_keep" });
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ access_token: "at_new", expires_in: 60 }),
+    });
+
+    const result = await c.callRefresh();
+
+    expect(result?.token).toBe("at_new");
+    expect(result?.refreshToken).toBe("rt_keep");
+  });
+
+  it("clears stored tokens on 401 (refresh token revoked)", async () => {
+    const c = new TestConnector();
+    c.setAuth({ token: "at_old", refreshToken: "rt_revoked" });
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+      json: async () => ({ error: "invalid_token" }),
+    });
+
+    const result = await c.callRefresh();
+
+    expect(result).toBeNull();
+    expect(deleteTokens).toHaveBeenCalledWith("test-provider");
+    expect(storeTokens).not.toHaveBeenCalled();
+  });
+
+  it("clears stored tokens on 400 invalid_grant (refresh token expired/revoked)", async () => {
+    const c = new TestConnector();
+    c.setAuth({ token: "at_old", refreshToken: "rt_expired" });
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 400,
+      json: async () => ({ error: "invalid_grant" }),
+    });
+
+    const result = await c.callRefresh();
+
+    expect(result).toBeNull();
+    expect(deleteTokens).toHaveBeenCalledWith("test-provider");
+  });
+
+  it("preserves stored tokens on transient 5xx (server error)", async () => {
+    const c = new TestConnector();
+    c.setAuth({ token: "at_old", refreshToken: "rt_test" });
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 503,
+      json: async () => ({ error: "service_unavailable" }),
+    });
+
+    const result = await c.callRefresh();
+
+    expect(result).toBeNull();
+    expect(deleteTokens).not.toHaveBeenCalled();
+  });
+
+  it("preserves stored tokens on network error (transient)", async () => {
+    const c = new TestConnector();
+    c.setAuth({ token: "at_old", refreshToken: "rt_test" });
+    mockFetch.mockRejectedValueOnce(new Error("ECONNRESET"));
+
+    const result = await c.callRefresh();
+
+    expect(result).toBeNull();
+    expect(deleteTokens).not.toHaveBeenCalled();
+  });
+
+  it("preserves stored tokens on 400 without invalid_grant (likely misconfig)", async () => {
+    const c = new TestConnector();
+    c.setAuth({ token: "at_old", refreshToken: "rt_test" });
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 400,
+      json: async () => ({ error: "invalid_request" }),
+    });
+
+    const result = await c.callRefresh();
+
+    expect(result).toBeNull();
+    expect(deleteTokens).not.toHaveBeenCalled();
+  });
+
+  it("omits client_secret when not configured (public client)", async () => {
+    class PublicClient extends TestConnector {
+      protected getOAuthConfig(): OAuthConfig | null {
+        return {
+          clientId: "public-cid",
+          tokenEndpoint: "https://oauth.example.com/token",
+        };
+      }
+    }
+    const c = new PublicClient();
+    c.setAuth({ token: "at_old", refreshToken: "rt_old" });
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ access_token: "at_new" }),
+    });
+
+    await c.callRefresh();
+
+    const body = new URLSearchParams(
+      mockFetch.mock.calls[0]![1].body as string,
+    );
+    expect(body.has("client_secret")).toBe(false);
+    expect(body.get("client_id")).toBe("public-cid");
+  });
+});
+
+describe("BaseConnector.apiCall() refresh integration", () => {
+  it("refreshes preemptively when token is expired before the call", async () => {
+    const c = new TestConnector();
+    c.setAuth({
+      token: "at_expired",
+      refreshToken: "rt_test",
+      expiresAt: new Date(Date.now() - 1000),
+    });
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ access_token: "at_fresh", expires_in: 3600 }),
+    });
+
+    const fnSpy = vi.fn(async (token: string) => `ok:${token}`);
+    const result = await c.callApi(fnSpy);
+
+    expect(mockFetch).toHaveBeenCalledTimes(1); // refresh
+    expect(fnSpy).toHaveBeenCalledTimes(1);
+    expect(fnSpy).toHaveBeenCalledWith("at_fresh");
+    expect(result).toEqual({ data: "ok:at_fresh" });
+  });
+
+  it("falls back to full re-auth when refresh fails", async () => {
+    const c = new TestConnector();
+    c.setAuth({
+      token: "at_expired",
+      refreshToken: "rt_revoked",
+      expiresAt: new Date(Date.now() - 1000),
+    });
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 401 });
+    c.authenticateImpl = vi
+      .fn()
+      .mockResolvedValue({ token: "at_reauth" } satisfies AuthContext);
+
+    const fnSpy = vi.fn(async (token: string) => `ok:${token}`);
+    const result = await c.callApi(fnSpy);
+
+    expect(c.authenticateImpl).toHaveBeenCalledTimes(1);
+    expect(fnSpy).toHaveBeenCalledWith("at_reauth");
+    expect(result).toEqual({ data: "ok:at_reauth" });
+  });
+
+  it("retries with fresh token when call fails mid-flight with auth_expired", async () => {
+    const c = new TestConnector();
+    // expiresAt > 5min in the future so the *preemptive* refresh path is skipped;
+    // we want to exercise the mid-call refresh that runs from the catch block.
+    c.setAuth({
+      token: "at_old",
+      refreshToken: "rt_test",
+      expiresAt: new Date(Date.now() + 600_000),
+    });
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ access_token: "at_new", expires_in: 3600 }),
+    });
+
+    let calls = 0;
+    const fn = async (token: string) => {
+      calls++;
+      if (calls === 1) throw new Error("EXPIRED");
+      return `ok:${token}`;
+    };
+
+    const result = await c.callApi(fn, 2);
+
+    expect(calls).toBe(2);
+    expect(result).toEqual({ data: "ok:at_new" });
+  });
+});

--- a/src/connectors/baseConnector.ts
+++ b/src/connectors/baseConnector.ts
@@ -123,6 +123,13 @@ export abstract class BaseConnector {
   /**
    * Perform OAuth 2.0 token refresh.
    * Subclasses can override for provider-specific refresh flows.
+   *
+   * Failure handling distinguishes permanent from transient failures:
+   *   - Permanent (401, or 400 with `error: invalid_grant`) → clear stored
+   *     tokens so the next call drives a fresh authenticate() flow.
+   *   - Transient (network error, 5xx, 4xx without `invalid_grant`) → keep
+   *     tokens; next call will retry. Avoids forcing a full re-OAuth on
+   *     flaky wifi or temporary IdP outages.
    */
   protected async refreshToken(): Promise<AuthContext | null> {
     if (!this.auth?.refreshToken) return null;
@@ -130,48 +137,66 @@ export abstract class BaseConnector {
     const config = this.getOAuthConfig();
     if (!config) return null;
 
-    try {
-      const params = new URLSearchParams({
-        grant_type: "refresh_token",
-        refresh_token: this.auth.refreshToken,
-        client_id: config.clientId,
-        ...(config.clientSecret ? { client_secret: config.clientSecret } : {}),
-      });
+    const params = new URLSearchParams({
+      grant_type: "refresh_token",
+      refresh_token: this.auth.refreshToken,
+      client_id: config.clientId,
+      ...(config.clientSecret ? { client_secret: config.clientSecret } : {}),
+    });
 
-      const response = await fetch(config.tokenEndpoint, {
+    let response: Response;
+    try {
+      response = await fetch(config.tokenEndpoint, {
         method: "POST",
         headers: { "Content-Type": "application/x-www-form-urlencoded" },
         body: params.toString(),
       });
-
-      if (!response.ok) {
-        throw new Error(`Token refresh failed: ${response.status}`);
-      }
-
-      const data = (await response.json()) as {
-        access_token: string;
-        refresh_token?: string;
-        expires_in?: number;
-        scope?: string;
-      };
-
-      const newAuth: AuthContext = {
-        token: data.access_token,
-        refreshToken: data.refresh_token ?? this.auth.refreshToken,
-        expiresAt: data.expires_in
-          ? new Date(Date.now() + data.expires_in * 1000)
-          : undefined,
-        scopes: data.scope?.split(" ") ?? this.auth.scopes,
-      };
-
-      this.auth = newAuth;
-      await this.saveTokens();
-      return newAuth;
     } catch {
-      // Refresh failed - clear tokens to force re-auth
-      await this.clearTokens();
+      // Network error / DNS failure / timeout — transient, keep tokens
       return null;
     }
+
+    if (!response.ok) {
+      let errorBody: { error?: string } = {};
+      try {
+        errorBody = (await response.json()) as { error?: string };
+      } catch {
+        // Some IdPs return non-JSON error bodies; fall through with empty
+      }
+      const refreshTokenIsInvalid =
+        response.status === 401 ||
+        (response.status === 400 && errorBody.error === "invalid_grant");
+      if (refreshTokenIsInvalid) {
+        await this.clearTokens();
+      }
+      return null;
+    }
+
+    let data: {
+      access_token: string;
+      refresh_token?: string;
+      expires_in?: number;
+      scope?: string;
+    };
+    try {
+      data = (await response.json()) as typeof data;
+    } catch {
+      // Malformed success response — treat as transient
+      return null;
+    }
+
+    const newAuth: AuthContext = {
+      token: data.access_token,
+      refreshToken: data.refresh_token ?? this.auth.refreshToken,
+      expiresAt: data.expires_in
+        ? new Date(Date.now() + data.expires_in * 1000)
+        : undefined,
+      scopes: data.scope?.split(" ") ?? this.auth.scopes,
+    };
+
+    this.auth = newAuth;
+    await this.saveTokens();
+    return newAuth;
   }
 
   /**


### PR DESCRIPTION
## Summary

`BaseConnector.refreshToken()` previously called `clearTokens()` on **any** exception during the refresh flow — including 5xx server errors and network failures. A flaky wifi or temporary IdP outage was enough to wipe a user's stored credentials and force a full re-OAuth.

This change distinguishes **permanent** from **transient** failures:

| HTTP / error | Action |
|---|---|
| `401 Unauthorized` | clear (refresh token revoked) |
| `400 Bad Request` + `error: invalid_grant` | clear (refresh token expired / revoked) |
| `5xx`, network error, timeout | **keep** (transient — let next call retry) |
| `4xx` without `invalid_grant` (likely misconfig) | **keep** |

## Why now

While auditing the OAuth refresh story for the upcoming Wave 2 connectors (Zendesk, Stripe, Intercom, HubSpot, Datadog), we discovered the work item the roadmap doc said was *not started* (`docs/recipe-authoring-wave2-plan.md`) was actually 90% shipped — but the base contract had no direct test coverage and this latent bug was sitting in it.

## What's in the PR

- **`src/connectors/baseConnector.ts`** — refactored `refreshToken()` to differentiate permanent vs transient failures.
- **`src/connectors/__tests__/baseConnector.test.ts`** — new file (13 tests, all passing). Covers `refreshToken()` directly and the `apiCall()` auto-refresh integration path. Fills the gap left by `gmailRefresh.test.ts` only exercising one provider.
- **`docs/recipe-authoring-wave2-plan.md`** — marks OAuth refresh as ✅ shipped; documents the native-keychain-CLI choice (no `keytar` dependency).
- **`docs/recipe-schemastore-pr.md`** — updates status to reflect PR #5608 is now open + single-file diff.

## Test plan

- [x] `npx vitest run src/connectors/__tests__/baseConnector.test.ts` → 13/13 passing
- [x] `npx vitest run src/connectors/__tests__/` → 19 files, 171 tests passing
- [x] Full project test sweep → 4127 passed, 0 failed
- [x] `getDiagnostics` clean on both modified files
- [ ] Reviewer: confirm the `invalid_grant`/`401` clear behaviour matches expectations for any provider with a non-standard refresh-token revocation signal

## Follow-ups (separate PRs)

- Per-Wave-2-connector refresh-flow integration tests (~3-4 h of work)
- Address `apiCall()` line 237 latent typing — `fn(this.auth?.token)` passes `string | undefined` to a `string`-typed callback