### PR TITLE
feat(recipes): wire write kill switch into executeTool

### DIFF
--- a/src/recipes/__tests__/toolRegistry.killSwitch.test.ts
+++ b/src/recipes/__tests__/toolRegistry.killSwitch.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Verifies the global write-tier kill switch wiring at the executeTool
+ * dispatch boundary. The kill switch (`PATCHWORK_FLAG_KILL_SWITCH_WRITES`,
+ * registered as `kill-switch.writes` in `src/featureFlags.ts`) had its
+ * helpers in place but no call sites enforcing it; this exercises the
+ * wiring so a regression that drops the check is caught immediately.
+ */
+
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  type MockInstance,
+  vi,
+} from "vitest";
+import { clearRegistry, executeTool, registerTool } from "../toolRegistry.js";
+import type { RunContext, StepDeps } from "../yamlRunner.js";
+
+const KILL_SWITCH_ENV = "PATCHWORK_FLAG_KILL_SWITCH_WRITES";
+
+const dummyContext = {
+  params: {},
+  step: {},
+  ctx: { env: {}, steps: {} } as unknown as RunContext,
+  deps: {} as StepDeps,
+};
+
+describe("executeTool — kill switch enforcement", () => {
+  let writeExec: MockInstance;
+  let readExec: MockInstance;
+
+  beforeEach(() => {
+    clearRegistry();
+    delete process.env[KILL_SWITCH_ENV];
+    writeExec = vi.fn().mockResolvedValue("wrote");
+    readExec = vi.fn().mockResolvedValue("read");
+    registerTool({
+      id: "test.write",
+      namespace: "test",
+      description: "test write tool",
+      paramsSchema: { type: "object" },
+      outputSchema: { type: "string" },
+      riskDefault: "high",
+      isWrite: true,
+      execute: writeExec as unknown as RegisteredToolExecute,
+    });
+    registerTool({
+      id: "test.read",
+      namespace: "test",
+      description: "test read tool",
+      paramsSchema: { type: "object" },
+      outputSchema: { type: "string" },
+      riskDefault: "low",
+      isWrite: false,
+      execute: readExec as unknown as RegisteredToolExecute,
+    });
+  });
+
+  afterEach(() => {
+    delete process.env[KILL_SWITCH_ENV];
+    clearRegistry();
+  });
+
+  it("executes write tools normally when kill switch is off", async () => {
+    const result = await executeTool("test.write", dummyContext);
+    expect(result).toBe("wrote");
+    expect(writeExec).toHaveBeenCalledTimes(1);
+  });
+
+  it("blocks write tools when kill switch is active", async () => {
+    process.env[KILL_SWITCH_ENV] = "1";
+    await expect(executeTool("test.write", dummyContext)).rejects.toThrow(
+      /Write operation blocked by kill switch: test\.write/,
+    );
+    expect(writeExec).not.toHaveBeenCalled();
+  });
+
+  it("still executes read tools when kill switch is active", async () => {
+    process.env[KILL_SWITCH_ENV] = "1";
+    const result = await executeTool("test.read", dummyContext);
+    expect(result).toBe("read");
+    expect(readExec).toHaveBeenCalledTimes(1);
+  });
+
+  it("error message includes the recovery instruction", async () => {
+    process.env[KILL_SWITCH_ENV] = "true";
+    await expect(executeTool("test.write", dummyContext)).rejects.toThrow(
+      /Unset PATCHWORK_FLAG_KILL_SWITCH_WRITES/,
+    );
+  });
+
+  it("Unknown tool error fires before kill-switch check", async () => {
+    process.env[KILL_SWITCH_ENV] = "1";
+    // Even with kill switch on, an unknown tool should report "Unknown tool"
+    // — tells the caller the right thing rather than a misleading kill-switch
+    // message about a tool that doesn't exist.
+    await expect(executeTool("test.nope", dummyContext)).rejects.toThrow(
+      /Unknown tool: "test\.nope"/,
+    );
+  });
+});
+
+// Local type alias so the cast above doesn't drift if the registry's signature
+// gets a new optional field — keeps the test failure surface narrow.
+type RegisteredToolExecute = Parameters<typeof registerTool>[0]["execute"];

--- a/src/recipes/toolRegistry.ts
+++ b/src/recipes/toolRegistry.ts
@@ -9,6 +9,7 @@
  *   - Namespace isolation for connectors
  */
 
+import { assertWriteAllowed } from "../featureFlags.js";
 import type { RunContext, StepDeps } from "./yamlRunner.js";
 
 export interface ToolMetadata {
@@ -99,6 +100,11 @@ export function getNamespaces(): string[] {
 
 /**
  * Execute a tool by ID. Throws if tool not found.
+ *
+ * Refuses to execute write-tier tools when the global write kill switch is
+ * active (`kill-switch.writes` flag — set via `PATCHWORK_FLAG_KILL_SWITCH_WRITES=1`
+ * env var or persisted flag). Read-tier tools are always allowed; the kill
+ * switch is a one-way emergency brake on mutating operations.
  */
 export async function executeTool(
   id: string,
@@ -107,6 +113,9 @@ export async function executeTool(
   const tool = getTool(id);
   if (!tool) {
     throw new Error(`Unknown tool: "${id}"`);
+  }
+  if (tool.isWrite) {
+    assertWriteAllowed(id);
   }
   return tool.execute(context);
 }


### PR DESCRIPTION
## Summary

Wires the long-existing `KILL_SWITCH_WRITES` feature flag (`src/featureFlags.ts:158`) and `assertWriteAllowed()` helper (`:255`) into the central tool dispatch boundary at `toolRegistry.executeTool`. Until now the kill switch was a registered flag with helpers but **zero enforcement** — flipping it during an incident would do nothing.

## What changes

| File | Change |
|---|---|
| [src/recipes/toolRegistry.ts](src/recipes/toolRegistry.ts) | Import `assertWriteAllowed`; call it in `executeTool` when `tool.isWrite` is true. |
| [src/recipes/__tests__/toolRegistry.killSwitch.test.ts](src/recipes/__tests__/toolRegistry.killSwitch.test.ts) | New file. 5 tests covering wiring + ordering. |

## Behaviour

| Kill switch | Tool | Result |
|---|---|---|
| off (default) | write | runs normally |
| off (default) | read | runs normally |
| **on** | **write** | **throws** with recovery instructions |
| on | read | runs normally (kill switch never affects reads) |

## Activation

```sh
PATCHWORK_FLAG_KILL_SWITCH_WRITES=1   # env, ad-hoc
```
or programmatically:
```ts
setFlag("kill-switch.writes", true, true);  // persist=true
```

## Test plan

- [x] `npx vitest run src/recipes/__tests__/toolRegistry.killSwitch.test.ts` → 5/5 passing
- [x] Full project sweep — 4119 passed, 0 failed
- [x] `getDiagnostics` clean on both modified files

## Context

This is one of three "PARTIAL" items surfaced by a roadmap-vs-reality audit (`docs/recipe-authoring-wave2-plan.md`). The other two — feature-flag wiring for the other 6 flags, and `recipe install @version` pinning — are separately scoped follow-ups.

## Follow-ups

- Wire the other 6 registered feature flags to their intended call sites (`FLAG_DEBUGGER`, `FLAG_CLI_UX`, `FLAG_MOCK_HARNESS`, `FLAG_WAVE2_CONNECTORS`, `FLAG_SCHEMA_LINT`, `FLAG_COMMUNITY_GALLERY` — currently declared but unused).
- Add a CLI surface (e.g. `patchwork flags list / set kill-switch.writes on`) and a dashboard indicator. Today the kill switch is env-var/file-only.