### PR TITLE
feat(recipe-install): @<ref> version pinning + gh: alias

### DIFF
--- a/src/commands/__tests__/recipeInstall.test.ts
+++ b/src/commands/__tests__/recipeInstall.test.ts
@@ -64,7 +64,7 @@ describe("parseInstallSource", () => {
       });
     });
 
-    it("parses URL with tree/branch/subdir", () => {
+    it("parses URL with tree/branch/subdir and captures ref", () => {
       const result = parseInstallSource(
         "https://github.com/user/repo/tree/main/subdir",
       );
@@ -73,11 +73,82 @@ describe("parseInstallSource", () => {
         owner: "user",
         repo: "repo",
         subdir: "subdir",
+        ref: "main",
+      });
+    });
+
+    it("captures ref from tree/<tag> URL with no subdir", () => {
+      const result = parseInstallSource(
+        "https://github.com/user/repo/tree/v1.2.3",
+      );
+      expect(result).toEqual({
+        type: "github",
+        owner: "user",
+        repo: "repo",
+        ref: "v1.2.3",
       });
     });
 
     it("handles .git suffix", () => {
       const result = parseInstallSource("https://github.com/user/repo.git");
+      expect(result).toEqual({
+        type: "github",
+        owner: "user",
+        repo: "repo",
+      });
+    });
+  });
+
+  describe("@<ref> version pinning", () => {
+    it("pins to a tag via github:owner/repo@v1.0.0", () => {
+      const result = parseInstallSource("github:user/repo@v1.0.0");
+      expect(result).toEqual({
+        type: "github",
+        owner: "user",
+        repo: "repo",
+        ref: "v1.0.0",
+      });
+    });
+
+    it("pins to a commit SHA", () => {
+      const result = parseInstallSource("github:user/repo@a1b2c3d4");
+      expect(result).toEqual({
+        type: "github",
+        owner: "user",
+        repo: "repo",
+        ref: "a1b2c3d4",
+      });
+    });
+
+    it("supports @<ref> after subdir: github:owner/repo/subdir@v1", () => {
+      const result = parseInstallSource("github:user/repo/subdir@v1");
+      expect(result).toEqual({
+        type: "github",
+        owner: "user",
+        repo: "repo",
+        subdir: "subdir",
+        ref: "v1",
+      });
+    });
+
+    it("rejects empty ref after @", () => {
+      expect(() => parseInstallSource("github:user/repo@")).toThrow(
+        /empty ref/,
+      );
+    });
+
+    it("supports the gh: alias", () => {
+      const result = parseInstallSource("gh:user/repo@v2.0.0");
+      expect(result).toEqual({
+        type: "github",
+        owner: "user",
+        repo: "repo",
+        ref: "v2.0.0",
+      });
+    });
+
+    it("gh: without ref still works", () => {
+      const result = parseInstallSource("gh:user/repo");
       expect(result).toEqual({
         type: "github",
         owner: "user",

--- a/src/commands/recipeInstall.ts
+++ b/src/commands/recipeInstall.ts
@@ -62,11 +62,17 @@ export type InstallSource = GitHubInstallSource | LocalInstallSource;
  *
  * Supported forms:
  *   github:owner/repo
+ *   github:owner/repo@<ref>           — pin to branch, tag, or commit SHA
  *   github:owner/repo/subdir
+ *   github:owner/repo/subdir@<ref>
+ *   gh:owner/repo[@<ref>]             — short alias for github:
  *   https://github.com/owner/repo
- *   https://github.com/owner/repo/tree/branch/subdir
+ *   https://github.com/owner/repo/tree/<ref>/subdir   — ref captured from URL
  *   ./relative/path
  *   /absolute/path
+ *
+ * `@<ref>` accepts any value that's valid as a git ref (branch, tag, SHA).
+ * Empty ref (`...@`) is rejected.
  */
 export function parseInstallSource(source: string): InstallSource {
   // Local path: starts with . or /
@@ -78,35 +84,54 @@ export function parseInstallSource(source: string): InstallSource {
     return { type: "local", path: source };
   }
 
-  // github: prefix
+  // github:/gh: prefix
   if (source.startsWith("github:")) {
     return parseGithubShorthand(source.slice("github:".length));
   }
+  if (source.startsWith("gh:")) {
+    return parseGithubShorthand(source.slice("gh:".length));
+  }
 
-  // Full GitHub URL
+  // Full GitHub URL — captures owner, repo, optional ref (tree/<ref>), optional subdir
   const githubUrlMatch = source.match(
-    /^https?:\/\/github\.com\/([^/]+)\/([^/]+)(?:\/tree\/[^/]+\/(.+))?(?:\.git)?$/,
+    /^https?:\/\/github\.com\/([^/]+)\/([^/]+?)(?:\.git)?(?:\/tree\/([^/]+)(?:\/(.+))?)?\/?$/,
   );
   if (githubUrlMatch) {
-    const [, owner, repo, subdir] = githubUrlMatch;
+    const [, owner, repo, ref, subdir] = githubUrlMatch;
     if (!owner || !repo) {
       throw new Error(`Invalid GitHub URL: ${source}`);
     }
     return {
       type: "github",
       owner,
-      repo: repo.replace(/\.git$/, ""),
+      repo,
       ...(subdir ? { subdir } : {}),
+      ...(ref ? { ref } : {}),
     };
   }
 
   throw new Error(
     `Unrecognized install source: "${source}"\n` +
-      `Supported: github:owner/repo, github:owner/repo/subdir, https://github.com/owner/repo, ./local/path`,
+      `Supported: github:owner/repo[@ref], github:owner/repo/subdir[@ref], gh:owner/repo[@ref], https://github.com/owner/repo, ./local/path`,
   );
 }
 
 function parseGithubShorthand(shorthand: string): GitHubInstallSource {
+  // Extract trailing @<ref> if present. The ref is opaque to us — git accepts
+  // branches, tags, and commit SHAs in the same slot, and the GitHub API
+  // (which is what we ultimately call with this value) does too.
+  let ref: string | undefined;
+  const atIdx = shorthand.lastIndexOf("@");
+  if (atIdx !== -1) {
+    ref = shorthand.slice(atIdx + 1);
+    shorthand = shorthand.slice(0, atIdx);
+    if (!ref) {
+      throw new Error(
+        `Invalid github shorthand: empty ref after "@" in "${shorthand}@"`,
+      );
+    }
+  }
+
   // owner/repo or owner/repo/subdir (may have multiple path segments)
   const parts = shorthand.split("/");
   if (parts.length < 2) {
@@ -123,6 +148,7 @@ function parseGithubShorthand(shorthand: string): GitHubInstallSource {
     owner,
     repo,
     ...(subdirParts.length > 0 ? { subdir: subdirParts.join("/") } : {}),
+    ...(ref ? { ref } : {}),
   };
 }
 


### PR DESCRIPTION
## Summary

Closes the recipe-install version-pinning gap surfaced by the wave2-plan reality check. The doc-spec'd `gh:acme/pr-triage@v1.0.0` syntax was previously unrecognized — every install resolved against the default branch.

## Now supported

| Syntax | Resolves to |
|---|---|
| `github:owner/repo@v1.0.0` | tag `v1.0.0` |
| `github:owner/repo@a1b2c3d` | commit SHA |
| `github:owner/repo/subdir@main` | branch `main`, subdir scoped |
| `gh:owner/repo[@<ref>]` | short alias for `github:` |
| `https://github.com/owner/repo/tree/<ref>/subdir` | ref now captured (was silently dropped before) |
| `github:owner/repo` (unchanged) | default branch (main, then master fallback) |

The ref is opaque: branches, tags, and commit SHAs all work because GitHub's Contents API accepts any of them in the same slot.

## What's in the PR

- [src/commands/recipeInstall.ts](src/commands/recipeInstall.ts) — `parseGithubShorthand` extracts trailing `@<ref>`; full-URL regex captures `tree/<ref>`; `gh:` prefix added.
- [src/commands/__tests__/recipeInstall.test.ts](src/commands/__tests__/recipeInstall.test.ts) — 7 new tests + 1 flipped (the existing "tree/branch/subdir" test asserted ref was *missing* — masking the bug).

## Test plan

- [x] `npx vitest run src/commands/__tests__/recipeInstall.test.ts` → 25/25 passing
- [x] Full project sweep — 4121 passed, 0 failed
- [x] `getDiagnostics` clean

## Out of scope (separate PR)

- `patchwork recipe enable` subcommand (the doc spec'd "install + enable" two-step flow)
- Manifest-pinned dependencies (a recipe declaring `requires: { other-recipe: "^1.2" }`)
- Lockfile / reproducible installs