### PR TITLE
chore(featureFlags): remove 5 unused feature flags

### DIFF
--- a/src/featureFlags.ts
+++ b/src/featureFlags.ts
@@ -157,23 +157,8 @@ function persistFlags(): void {
 /** Kill switch for ALL write-tier operations */
 export const KILL_SWITCH_WRITES = "kill-switch.writes";
 
-/** Enable visual recipe debugger (A3) */
-export const FLAG_DEBUGGER = "ui.recipe-debugger";
-
-/** Enable CLI test/watch commands (A2) */
-export const FLAG_CLI_UX = "ui.cli-ux-commands";
-
-/** Enable mock connector harness (A4) */
-export const FLAG_MOCK_HARNESS = "experimental.mock-harness";
-
-/** Enable Wave 2 connectors (A5) */
-export const FLAG_WAVE2_CONNECTORS = "connector.wave2";
-
 /** Enable recipe lint with schema validation (A1) */
 export const FLAG_SCHEMA_LINT = "ui.schema-lint";
-
-/** Enable community recipe gallery (M5) */
-export const FLAG_COMMUNITY_GALLERY = "experimental.community-gallery";
 
 // Register built-in flags
 registerFlag({
@@ -187,51 +172,10 @@ registerFlag({
 });
 
 registerFlag({
-  id: FLAG_DEBUGGER,
-  description: "Visual recipe debugger at /runs/[seq] with step timeline",
-  defaultValue: false,
-  category: "ui",
-  requiresOptIn: true,
-});
-
-registerFlag({
-  id: FLAG_CLI_UX,
-  description: "Enhanced CLI commands: new, lint, test, watch, record, fmt",
-  defaultValue: false,
-  category: "ui",
-  requiresOptIn: true,
-});
-
-registerFlag({
-  id: FLAG_MOCK_HARNESS,
-  description: "Mock connector harness with fixture recording and VCR replay",
-  defaultValue: false,
-  category: "experimental",
-  requiresOptIn: true,
-});
-
-registerFlag({
-  id: FLAG_WAVE2_CONNECTORS,
-  description:
-    "Wave 2 connectors: Confluence, Zendesk, Intercom, HubSpot, Datadog, Stripe",
-  defaultValue: false,
-  category: "connector",
-  requiresOptIn: true,
-});
-
-registerFlag({
   id: FLAG_SCHEMA_LINT,
   description: "Recipe linting with JSON Schema validation",
   defaultValue: false,
   category: "ui",
-  requiresOptIn: true,
-});
-
-registerFlag({
-  id: FLAG_COMMUNITY_GALLERY,
-  description: "Community recipe gallery and GitHub-backed install",
-  defaultValue: false,
-  category: "experimental",
   requiresOptIn: true,
 });
 


### PR DESCRIPTION
## Summary

Removes five `FLAG_*` exports + their `registerFlag()` calls from [src/featureFlags.ts](src/featureFlags.ts). Each describes a feature that's already shipped, and grep confirms **zero call sites** for any of them outside `featureFlags.ts` itself.

| Flag id | Status today |
|---|---|
| `ui.recipe-debugger` | Debugger `/runs/[seq]` shipped (alpha.22) |
| `ui.cli-ux-commands` | `new` / `lint` / `test` / `watch` / `record` / `fmt` all live |
| `experimental.mock-harness` | `MockConnector` + `fixtureRecorder` shipped (`src/connectors/mockConnector.ts`) |
| `connector.wave2` | Notion, Confluence, Zendesk, Stripe etc. all in `src/connectors/` |
| `experimental.community-gallery` | `recipe install` shipped (#39), gallery is a separate UX concern that wouldn't gate via this flag |

Wiring these now would gate live features behind opt-in for every existing user — actively harmful. Removing them prevents future "why doesn't this flag do anything?" confusion.

`KILL_SWITCH_WRITES` (wired in #38) and `FLAG_SCHEMA_LINT` (wired in `src/recipes/validation.ts:122`) are kept — both have real call sites.

## Backwards compatibility

`loadFlags()` already ignores unknown keys (`if (FLAG_REGISTRY.has(key))`), so any user with these flags persisted in `~/.patchwork/config/flags.json` degrades gracefully — no read errors, just a no-op.

## Test plan

- [x] `npx vitest run src/__tests__/featureFlags.test.ts src/recipes/__tests__/toolRegistry.killSwitch.test.ts` → 13/13 passing
- [x] Full project sweep — 4139 passed, 0 failed
- [x] `getDiagnostics` clean

## Surfaced by

2026-04-28 roadmap-vs-reality audit (the same one that surfaced #37, #38, #39).