### PR TITLE
fix(connectors): tighten apiCall token typing

### DIFF
--- a/src/connectors/baseConnector.ts
+++ b/src/connectors/baseConnector.ts
@@ -251,6 +251,19 @@ export abstract class BaseConnector {
       }
     }
 
+    // After auth resolution above, this.auth is guaranteed non-null —
+    // every "auth still null" branch returned an error and exited.
+    // Narrow the type so `fn` gets a `string` instead of `string | undefined`.
+    if (!this.auth) {
+      return {
+        error: {
+          code: "provider_error",
+          message: "auth resolution did not populate this.auth",
+          retryable: false,
+        },
+      };
+    }
+
     // Apply rate limit backoff
     if (this.rateLimit.backoffMs > 0) {
       await sleep(this.rateLimit.backoffMs);
@@ -259,7 +272,7 @@ export abstract class BaseConnector {
     // Execute with retry
     for (let attempt = 0; attempt <= retries; attempt++) {
       try {
-        const result = await fn(this.auth?.token);
+        const result = await fn(this.auth.token);
         return { data: result };
       } catch (err) {
         const normalized = this.normalizeError(err);


### PR DESCRIPTION
## Summary

Closes the latent typing hole at `BaseConnector.apiCall<T>` flagged in #37: the callback signature is `(token: string) => Promise<T>` but the call site passed `this.auth?.token` — `string | undefined` flowing into a `string`-typed param.

## What changes

- Added an early-return guard that narrows `this.auth` from `AuthContext | null` to `AuthContext` before the retry loop. The guard returns a `provider_error` if it ever fires — but it shouldn't, since every preceding "auth not yet resolved" branch either populates auth or returns.
- Call site is now `fn(this.auth.token)` — no optional chain, type-correct.

## Test plan

- [x] `npx vitest run src/connectors/__tests__/baseConnector.test.ts` → 13/13 passing (unchanged)
- [x] Full project sweep clean
- [x] `getDiagnostics` clean