### PR TITLE
feat(recipe): explicit enable/disable flow after install

### DIFF
--- a/src/commands/__tests__/recipeEnable.test.ts
+++ b/src/commands/__tests__/recipeEnable.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Tests for the recipe enable/disable flow.
+ *
+ * The wave2 plan (`docs/recipe-authoring-wave2-plan.md:242`) requires
+ * recipes installed from third parties to start *disabled* — scheduled
+ * triggers (cron/file-watch) only fire after the user explicitly opts
+ * in via `patchwork recipe enable <name>`.
+ *
+ * The state lives as a `.disabled` marker file inside the install dir.
+ * Absence = enabled (so legacy installs predating this PR keep working).
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  isRecipeEnabled,
+  listInstalledRecipes,
+  runRecipeDisable,
+  runRecipeEnable,
+  runRecipeInstall,
+} from "../recipeInstall.js";
+
+let tmpRoot: string;
+
+beforeEach(() => {
+  tmpRoot = mkdtempSync(path.join(os.tmpdir(), "patchwork-enable-test-"));
+});
+
+afterEach(() => {
+  if (tmpRoot && existsSync(tmpRoot)) {
+    rmSync(tmpRoot, { recursive: true, force: true });
+  }
+});
+
+function makeInstalledRecipe(name: string, withDisabledMarker: boolean) {
+  const dir = path.join(tmpRoot, name);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(path.join(dir, "main.yaml"), "name: test\nsteps: []\n");
+  if (withDisabledMarker) {
+    writeFileSync(path.join(dir, ".disabled"), "");
+  }
+  return dir;
+}
+
+describe("isRecipeEnabled", () => {
+  it("returns true when the install dir has no disabled marker", () => {
+    const dir = makeInstalledRecipe("legacy", false);
+    expect(isRecipeEnabled(dir)).toBe(true);
+  });
+
+  it("returns false when the disabled marker is present", () => {
+    const dir = makeInstalledRecipe("fresh", true);
+    expect(isRecipeEnabled(dir)).toBe(false);
+  });
+});
+
+describe("runRecipeEnable", () => {
+  it("removes the disabled marker on a freshly-installed recipe", () => {
+    makeInstalledRecipe("morning-brief", true);
+
+    const result = runRecipeEnable("morning-brief", { recipesDir: tmpRoot });
+
+    expect(result.alreadyEnabled).toBe(false);
+    expect(existsSync(path.join(tmpRoot, "morning-brief", ".disabled"))).toBe(
+      false,
+    );
+  });
+
+  it("is idempotent on an already-enabled recipe", () => {
+    makeInstalledRecipe("legacy", false);
+
+    const result = runRecipeEnable("legacy", { recipesDir: tmpRoot });
+
+    expect(result.alreadyEnabled).toBe(true);
+    expect(existsSync(path.join(tmpRoot, "legacy", ".disabled"))).toBe(false);
+  });
+
+  it("throws a clear error when the recipe is not installed", () => {
+    expect(() =>
+      runRecipeEnable("nonexistent", { recipesDir: tmpRoot }),
+    ).toThrow(/No installed recipe named "nonexistent"/);
+  });
+});
+
+describe("runRecipeDisable", () => {
+  it("writes the disabled marker on an enabled recipe", () => {
+    makeInstalledRecipe("legacy", false);
+
+    const result = runRecipeDisable("legacy", { recipesDir: tmpRoot });
+
+    expect(result.alreadyDisabled).toBe(false);
+    expect(existsSync(path.join(tmpRoot, "legacy", ".disabled"))).toBe(true);
+  });
+
+  it("is idempotent on an already-disabled recipe", () => {
+    makeInstalledRecipe("fresh", true);
+
+    const result = runRecipeDisable("fresh", { recipesDir: tmpRoot });
+
+    expect(result.alreadyDisabled).toBe(true);
+    expect(existsSync(path.join(tmpRoot, "fresh", ".disabled"))).toBe(true);
+  });
+
+  it("throws a clear error when the recipe is not installed", () => {
+    expect(() =>
+      runRecipeDisable("nonexistent", { recipesDir: tmpRoot }),
+    ).toThrow(/No installed recipe named "nonexistent"/);
+  });
+});
+
+describe("runRecipeInstall — disabled-by-default", () => {
+  it("writes a .disabled marker on a fresh local install", async () => {
+    // Stage a local "source" dir to install from
+    const srcDir = mkdtempSync(path.join(os.tmpdir(), "patchwork-src-"));
+    writeFileSync(path.join(srcDir, "main.yaml"), "name: t\nsteps: []\n");
+
+    try {
+      const result = await runRecipeInstall(srcDir, { recipesDir: tmpRoot });
+      expect(existsSync(path.join(result.installDir, ".disabled"))).toBe(true);
+      expect(isRecipeEnabled(result.installDir)).toBe(false);
+    } finally {
+      rmSync(srcDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("listInstalledRecipes — enabled state in entries", () => {
+  it("reports enabled: true for a recipe without the marker", () => {
+    makeInstalledRecipe("legacy", false);
+    const entries = listInstalledRecipes({ recipesDir: tmpRoot });
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.enabled).toBe(true);
+  });
+
+  it("reports enabled: false for a recipe with the marker", () => {
+    makeInstalledRecipe("fresh", true);
+    const entries = listInstalledRecipes({ recipesDir: tmpRoot });
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.enabled).toBe(false);
+  });
+
+  it("reports the correct state per-recipe across a mix", () => {
+    makeInstalledRecipe("morning-brief", true);
+    makeInstalledRecipe("standup-digest", false);
+    const entries = listInstalledRecipes({ recipesDir: tmpRoot });
+    const byName = Object.fromEntries(entries.map((e) => [e.name, e.enabled]));
+    expect(byName["morning-brief"]).toBe(false);
+    expect(byName["standup-digest"]).toBe(true);
+  });
+});

--- a/src/commands/recipeInstall.ts
+++ b/src/commands/recipeInstall.ts
@@ -18,6 +18,7 @@ import {
   readFileSync,
   rmSync,
   statSync,
+  unlinkSync,
   writeFileSync,
 } from "node:fs";
 import https from "node:https";
@@ -35,6 +36,15 @@ export const INSTALL_RECIPES_DIR = path.join(
   ".patchwork",
   "recipes",
 );
+
+/**
+ * Marker file written into a recipe install dir to mark it as disabled.
+ * Absence = enabled (the default for legacy installs predating this marker).
+ * `runRecipeInstall` writes one on every fresh install so new recipes start
+ * disabled per the wave2 plan's safety story; user runs `patchwork recipe
+ * enable <name>` to remove it.
+ */
+const DISABLED_MARKER = ".disabled";
 
 // ============================================================================
 // Source parsing
@@ -358,6 +368,12 @@ export async function runRecipeInstall(
       cpSync(src, dest);
     }
 
+    // New installs start disabled — user must run `recipe enable <name>`
+    // before scheduled triggers (cron/file-watch) take effect. Manual
+    // `recipe run <name>` still works regardless, since that's an explicit
+    // user invocation.
+    writeFileSync(path.join(installDir, DISABLED_MARKER), "");
+
     return {
       name: installName,
       version: manifest?.version,
@@ -429,6 +445,76 @@ export interface InstalledRecipeEntry {
   mainRecipe?: string;
   yamlFiles?: string[];
   hasManifest: boolean;
+  enabled: boolean;
+}
+
+/**
+ * Returns true if the install dir does not contain the disabled marker.
+ * Recipes installed before this marker existed have no marker and are
+ * therefore considered enabled — preserves backwards compatibility.
+ */
+export function isRecipeEnabled(installDir: string): boolean {
+  return !existsSync(path.join(installDir, DISABLED_MARKER));
+}
+
+/**
+ * Locate an installed recipe directory by name. Returns null if not found.
+ */
+function findInstalledRecipeDir(
+  name: string,
+  recipesDir: string,
+): string | null {
+  const direct = path.join(recipesDir, name);
+  if (existsSync(direct) && statSync(direct).isDirectory()) {
+    return direct;
+  }
+  return null;
+}
+
+/**
+ * Enable a recipe — removes the .disabled marker so triggers can fire.
+ * Idempotent: enabling an already-enabled recipe is a no-op.
+ */
+export function runRecipeEnable(
+  name: string,
+  options: { recipesDir?: string } = {},
+): { name: string; installDir: string; alreadyEnabled: boolean } {
+  const recipesDir = options.recipesDir ?? INSTALL_RECIPES_DIR;
+  const installDir = findInstalledRecipeDir(name, recipesDir);
+  if (!installDir) {
+    throw new Error(
+      `No installed recipe named "${name}". Run \`patchwork recipe list\` to see installed recipes.`,
+    );
+  }
+  const markerPath = path.join(installDir, DISABLED_MARKER);
+  if (!existsSync(markerPath)) {
+    return { name, installDir, alreadyEnabled: true };
+  }
+  unlinkSync(markerPath);
+  return { name, installDir, alreadyEnabled: false };
+}
+
+/**
+ * Disable a recipe — writes the .disabled marker so triggers stop firing.
+ * Idempotent: disabling an already-disabled recipe is a no-op.
+ */
+export function runRecipeDisable(
+  name: string,
+  options: { recipesDir?: string } = {},
+): { name: string; installDir: string; alreadyDisabled: boolean } {
+  const recipesDir = options.recipesDir ?? INSTALL_RECIPES_DIR;
+  const installDir = findInstalledRecipeDir(name, recipesDir);
+  if (!installDir) {
+    throw new Error(
+      `No installed recipe named "${name}". Run \`patchwork recipe list\` to see installed recipes.`,
+    );
+  }
+  const markerPath = path.join(installDir, DISABLED_MARKER);
+  if (existsSync(markerPath)) {
+    return { name, installDir, alreadyDisabled: true };
+  }
+  writeFileSync(markerPath, "");
+  return { name, installDir, alreadyDisabled: false };
 }
 
 export function listInstalledRecipes(
@@ -459,6 +545,7 @@ export function listInstalledRecipes(
           connectors: manifest.connectors,
           mainRecipe: manifest.recipes.main,
           hasManifest: true,
+          enabled: isRecipeEnabled(itemPath),
         });
       } else {
         const yamlFiles = readdirSync(itemPath).filter((f) =>
@@ -469,6 +556,7 @@ export function listInstalledRecipes(
             name: entryName,
             yamlFiles,
             hasManifest: false,
+            enabled: isRecipeEnabled(itemPath),
           });
         } else {
           // Recurse one level for namespaced dirs like "owner/repo"
@@ -500,6 +588,10 @@ export function printInstallResult(result: InstallResult): void {
     );
   }
 
+  console.log(
+    `  Status: disabled (run \`patchwork recipe enable ${result.name}\` to activate scheduled triggers)`,
+  );
+
   const mainRecipe = result.manifest?.recipes.main ?? result.filesInstalled[0];
   if (mainRecipe) {
     console.log(
@@ -522,20 +614,23 @@ export function printInstalledList(entries: InstalledRecipeEntry[]): void {
     7,
   );
 
-  const header = `${"Name".padEnd(maxName)}  ${"Version".padEnd(maxVersion)}  Description / Files`;
+  const header = `${"Name".padEnd(maxName)}  ${"Version".padEnd(maxVersion)}  Status    Description / Files`;
   console.log(header);
   console.log("-".repeat(Math.min(header.length, 100)));
 
   for (const entry of entries) {
     const version = (entry.version ?? "—").padEnd(maxVersion);
+    const status = (entry.enabled ? "enabled" : "disabled").padEnd(8);
     const detail = entry.hasManifest
       ? (entry.description ?? "")
       : `[${(entry.yamlFiles ?? []).join(", ")}]`;
-    console.log(`${entry.name.padEnd(maxName)}  ${version}  ${detail}`);
+    console.log(
+      `${entry.name.padEnd(maxName)}  ${version}  ${status}  ${detail}`,
+    );
 
     if (entry.connectors && entry.connectors.length > 0) {
       console.log(
-        `${"".padEnd(maxName)}  ${"".padEnd(maxVersion)}  connectors: ${entry.connectors.join(", ")}`,
+        `${"".padEnd(maxName)}  ${"".padEnd(maxVersion)}  ${"".padEnd(8)}  connectors: ${entry.connectors.join(", ")}`,
       );
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -782,6 +782,52 @@ if (process.argv[2] === "recipe" && process.argv[3] === "list") {
   })();
 }
 
+// Patchwork: `patchwork recipe enable <name>` / `recipe disable <name>` —
+// flip the disabled marker so scheduled triggers (cron/file-watch) take
+// effect (or stop). Manual `recipe run` is unaffected.
+if (
+  process.argv[2] === "recipe" &&
+  (process.argv[3] === "enable" || process.argv[3] === "disable")
+) {
+  const subcommand = process.argv[3];
+  const name = process.argv[4];
+  if (!name) {
+    process.stderr.write(
+      `Usage: patchwork recipe ${subcommand} <name>\n` +
+        `  See \`patchwork recipe list\` for installed recipe names.\n`,
+    );
+    process.exit(1);
+  }
+  (async () => {
+    try {
+      const { runRecipeEnable, runRecipeDisable } = await import(
+        "./commands/recipeInstall.js"
+      );
+      if (subcommand === "enable") {
+        const r = runRecipeEnable(name);
+        process.stdout.write(
+          r.alreadyEnabled
+            ? `  ℹ ${r.name} is already enabled\n`
+            : `  ✓ enabled ${r.name}\n`,
+        );
+      } else {
+        const r = runRecipeDisable(name);
+        process.stdout.write(
+          r.alreadyDisabled
+            ? `  ℹ ${r.name} is already disabled\n`
+            : `  ✓ disabled ${r.name}\n`,
+        );
+      }
+      process.exit(0);
+    } catch (err) {
+      process.stderr.write(
+        `Error: ${err instanceof Error ? err.message : String(err)}\n`,
+      );
+      process.exit(1);
+    }
+  })();
+}
+
 // Patchwork: `patchwork recipe run <name>` — runs a recipe locally or via
 // a running bridge's /recipes/run endpoint if one is available.
 if (process.argv[2] === "recipe" && process.argv[3] === "run") {


### PR DESCRIPTION
## Summary

Closes the second half of the install flow surfaced in the wave2 plan reality check (`docs/recipe-authoring-wave2-plan.md:242`): **recipes installed from third-party sources should not have their scheduled triggers fire automatically** — the user has to explicitly opt in.

## Design

Marker file: `~/.patchwork/recipes/<name>/.disabled`

| Marker | Meaning |
|---|---|
| **absent** | enabled — pre-existing installs keep working unchanged |
| **present** | disabled — fresh installs get one written by `runRecipeInstall` |

Manual `patchwork recipe run <name>` is intentionally **not** gated — that's an explicit user invocation, distinct from automatic triggers the spec is concerned with.

## API

```ts
runRecipeEnable(name)    // removes marker (idempotent)
runRecipeDisable(name)   // writes marker (idempotent)
isRecipeEnabled(installDir)
```

`InstalledRecipeEntry` now has `enabled: boolean`. CLI:

```sh
patchwork recipe enable morning-brief
patchwork recipe disable morning-brief
patchwork recipe list   # now shows a Status column
```

Post-install output hints at the next step:
```
✓ Installed morning-brief@1.0.0 to /Users/.../.patchwork/recipes/morning-brief
  Requires connectors: gmail, slack
  Status: disabled (run `patchwork recipe enable morning-brief` to activate scheduled triggers)
  Run with: patchwork recipe run /Users/.../.patchwork/recipes/morning-brief/main.yaml
```

## What's in the PR

- [src/commands/recipeInstall.ts](src/commands/recipeInstall.ts) — marker constant, helpers, `enabled` field on entries, status column on `recipe list`, install-side marker write.
- [src/commands/__tests__/recipeEnable.test.ts](src/commands/__tests__/recipeEnable.test.ts) — new file, 12 tests.
- [src/index.ts](src/index.ts) — CLI dispatch for `recipe enable` / `disable`.

## Test plan

- [x] `npx vitest run src/commands/__tests__/recipeEnable.test.ts` → 12/12 passing
- [x] Existing `recipeInstall.test.ts` unchanged (25/25 passing — `enabled` field doesn't break anything)
- [x] Full project sweep — 4151 passed, 0 failed
- [x] `getDiagnostics` clean

## Out of scope (separate PR)

**Trigger-side enforcement.** The cron scheduler and file-watch hook should consult `isRecipeEnabled()` before firing scheduled runs of a recipe. That's a separate plumbing change with its own test surface — for this PR, the marker is the single source of truth those will read once wired.