### PR TITLE
feat(scheduler): scan install dirs and honor .disabled marker

### DIFF
--- a/src/recipes/__tests__/scheduler.test.ts
+++ b/src/recipes/__tests__/scheduler.test.ts
@@ -209,4 +209,135 @@ describe("RecipeScheduler", () => {
     scheduler.fireForTest("scheduled-yaml");
     expect(ran).toEqual(["scheduled-yaml"]);
   });
+
+  // ─── install-dir recipes (recipeInstall) + `.disabled` marker ────────────
+  // PR #42 added the marker file but only `recipe enable/disable` checked it.
+  // The scheduler now also honors it for recipes installed into subdirs.
+
+  function installDirRecipe(
+    dirName: string,
+    yaml: string,
+    opts: { disabled?: boolean; manifestMain?: string } = {},
+  ) {
+    const dir = path.join(tmp, dirName);
+    mkdirSync(dir, { recursive: true });
+    const yamlFile = opts.manifestMain ?? "main.yaml";
+    writeFileSync(path.join(dir, yamlFile), yaml);
+    if (opts.manifestMain) {
+      writeFileSync(
+        path.join(dir, "recipe.json"),
+        JSON.stringify(
+          { name: dirName, version: "1", recipes: { main: opts.manifestMain } },
+          null,
+          2,
+        ),
+      );
+    }
+    if (opts.disabled) {
+      writeFileSync(path.join(dir, ".disabled"), "");
+    }
+    return dir;
+  }
+
+  it("schedules a cron-triggered recipe installed into a subdirectory", () => {
+    installDirRecipe(
+      "morning-brief",
+      [
+        "name: morning-brief",
+        "trigger:",
+        "  type: cron",
+        "  at: '@every 5m'",
+        "steps:",
+        "  - id: main",
+        "    agent: true",
+        "    prompt: brief me",
+      ].join("\n"),
+    );
+
+    const scheduler = new RecipeScheduler({
+      recipesDir: tmp,
+      enqueue: () => "tid",
+      runYaml: async () => {},
+    });
+
+    const scheduled = scheduler.start();
+    expect(scheduled.map((s) => s.name).sort()).toContain("morning-brief");
+    scheduler.stop();
+  });
+
+  it("skips a recipe whose install dir contains a .disabled marker", () => {
+    installDirRecipe(
+      "standup-digest",
+      [
+        "name: standup-digest",
+        "trigger:",
+        "  type: cron",
+        "  at: '@every 1h'",
+        "steps:",
+        "  - id: main",
+        "    agent: true",
+        "    prompt: digest",
+      ].join("\n"),
+      { disabled: true },
+    );
+
+    const scheduler = new RecipeScheduler({
+      recipesDir: tmp,
+      enqueue: () => "tid",
+      runYaml: async () => {},
+    });
+
+    const scheduled = scheduler.start();
+    expect(scheduled.map((s) => s.name)).not.toContain("standup-digest");
+  });
+
+  it("uses recipe.json manifest's `recipes.main` when present", () => {
+    installDirRecipe(
+      "weekly-roundup",
+      [
+        "name: weekly-roundup",
+        "trigger:",
+        "  type: cron",
+        "  at: '@every 7h'",
+        "steps:",
+        "  - id: main",
+        "    agent: true",
+        "    prompt: roll up",
+      ].join("\n"),
+      { manifestMain: "recipe.yaml" },
+    );
+
+    const scheduler = new RecipeScheduler({
+      recipesDir: tmp,
+      enqueue: () => "tid",
+      runYaml: async () => {},
+    });
+
+    const scheduled = scheduler.start();
+    expect(scheduled.map((s) => s.name)).toContain("weekly-roundup");
+  });
+
+  it("does not schedule a manual-trigger recipe in an install dir", () => {
+    installDirRecipe(
+      "manual-only",
+      [
+        "name: manual-only",
+        "trigger:",
+        "  type: manual",
+        "steps:",
+        "  - id: main",
+        "    agent: true",
+        "    prompt: hi",
+      ].join("\n"),
+    );
+
+    const scheduler = new RecipeScheduler({
+      recipesDir: tmp,
+      enqueue: () => "tid",
+      runYaml: async () => {},
+    });
+
+    const scheduled = scheduler.start();
+    expect(scheduled.map((s) => s.name)).not.toContain("manual-only");
+  });
 });

--- a/src/recipes/scheduler.ts
+++ b/src/recipes/scheduler.ts
@@ -1,10 +1,17 @@
-import { readdirSync, readFileSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import path from "node:path";
 import cron from "node-cron";
 import { parse as parseYaml } from "yaml";
 import type { Logger } from "../logger.js";
 import { loadConfig } from "../patchworkConfig.js";
 import { findYamlRecipePath, loadRecipePrompt } from "../recipesHttp.js";
+
+/**
+ * Per-recipe disabled marker — must match the constant in
+ * src/commands/recipeInstall.ts (kept inline here to avoid a circular
+ * import via commands → recipes back to commands).
+ */
+const DISABLED_MARKER = ".disabled";
 
 /**
  * RecipeScheduler — runs cron-triggered recipes on a simple interval or
@@ -77,18 +84,88 @@ export class RecipeScheduler {
       return [];
     }
 
+    // Build the list of (path, isInstalledDir) pairs to consider:
+    //   - top-level *.json / *.yaml files (legacy, recipes-as-files)
+    //   - subdirectories from `patchwork recipe install` (each with a
+    //     `.disabled` marker that gates this scheduler — see PR #42)
+    type Candidate = {
+      filePath: string;
+      kind: "json" | "yaml";
+      installDir: string | null;
+    };
+    const candidates: Candidate[] = [];
+
     for (const f of entries) {
+      const fullPath = path.join(this.opts.recipesDir, f);
+      let isDir = false;
+      try {
+        isDir = statSync(fullPath).isDirectory();
+      } catch {
+        continue;
+      }
+
+      if (isDir) {
+        // Honor the per-recipe `.disabled` marker written by recipeInstall.
+        if (existsSync(path.join(fullPath, DISABLED_MARKER))) {
+          this.opts.logger?.info?.(
+            `[scheduler] skipping recipe in "${f}" — .disabled marker present`,
+          );
+          continue;
+        }
+        // Locate the recipe entrypoint inside the install dir.
+        // Prefer recipe.json's `recipes.main`, then fall back to first YAML.
+        const manifestPath = path.join(fullPath, "recipe.json");
+        let entrypoint: string | null = null;
+        if (existsSync(manifestPath)) {
+          try {
+            const m = JSON.parse(readFileSync(manifestPath, "utf-8")) as {
+              recipes?: { main?: string };
+            };
+            if (m.recipes?.main) {
+              const candidate = path.join(fullPath, m.recipes.main);
+              if (existsSync(candidate)) entrypoint = candidate;
+            }
+          } catch {
+            // malformed manifest — fall through to first-yaml fallback
+          }
+        }
+        if (!entrypoint) {
+          try {
+            const yaml = readdirSync(fullPath).find((x) => /\.ya?ml$/i.test(x));
+            if (yaml) entrypoint = path.join(fullPath, yaml);
+          } catch {
+            // unreadable — skip
+          }
+        }
+        if (entrypoint) {
+          const ext = path.extname(entrypoint).toLowerCase();
+          candidates.push({
+            filePath: entrypoint,
+            kind: ext === ".json" ? "json" : "yaml",
+            installDir: fullPath,
+          });
+        }
+        continue;
+      }
+
       const isJson = f.endsWith(".json") && !f.endsWith(".permissions.json");
       const isYaml = f.endsWith(".yaml") || f.endsWith(".yml");
       if (!isJson && !isYaml) continue;
+      candidates.push({
+        filePath: fullPath,
+        kind: isJson ? "json" : "yaml",
+        installDir: null,
+      });
+    }
 
-      const fullPath = path.join(this.opts.recipesDir, f);
+    for (const cand of candidates) {
+      const f = path.basename(cand.filePath);
       try {
         let name: string;
         let schedule: string | undefined;
 
-        if (isJson) {
-          const raw = readFileSync(fullPath, "utf-8");
+        if (cand.kind === "json") {
+          const raw = readFileSync(cand.filePath, "utf-8");
           const parsed = JSON.parse(raw) as {
             name?: string;
             trigger?: { type?: string; schedule?: string };
@@ -103,7 +180,7 @@ export class RecipeScheduler {
           name = parsed.name ?? path.basename(f, ".json");
         } else {
           // YAML
-          const raw = readFileSync(fullPath, "utf-8");
+          const raw = readFileSync(cand.filePath, "utf-8");
           const parsed = parseYaml(raw) as {
             name?: string;
             trigger?: { type?: string; at?: string; schedule?: string };
@@ -111,11 +188,10 @@ export class RecipeScheduler {
           if (parsed.trigger?.type !== "cron") continue;
           schedule = parsed.trigger.at ?? parsed.trigger.schedule;
           if (!schedule || typeof schedule !== "string") continue;
-          name =
-            parsed.name ?? path.basename(f, isYaml ? path.extname(f) : ".yaml");
+          name = parsed.name ?? path.basename(f, path.extname(f));
         }
 
-        // Apply disabled filter
+        // Apply config-file disabled list (legacy mechanism)
         if (disabled.has(name)) {
           this.opts.logger?.info?.(
             `[scheduler] skipping disabled recipe "${name}"`,


### PR DESCRIPTION
## Summary

Closes the trigger-side enforcement gap explicitly noted as out-of-scope in PR #42. Two related gaps fixed in one pass:

1. **Scheduler couldn't see install-dir recipes.** It scanned only top-level `*.json` / `*.yaml` files in `~/.patchwork/recipes/`, while `runRecipeInstall` puts each recipe in its own subdirectory (`~/.patchwork/recipes/<name>/`). Scheduled triggers from installed recipes therefore never fired — there was no path from `recipe install foo` → cron firing.

2. **`.disabled` marker had no enforcement.** Even if a user ran `recipe disable foo`, scheduled triggers (had they been wired) would have fired anyway. The marker was informational only.

## What changes

`scheduler.start()` now also iterates one level of subdirectories. Per subdir:

- `.disabled` present → log + skip (honors `recipe enable/disable` from #42)
- Otherwise → use `recipe.json`'s `recipes.main` (or first `*.yaml`) as the entrypoint, parse trigger as before
- The existing config-file `disabled` list (`cfg.recipes.disabled`) still applies as a parallel mechanism

Top-level file scanning is preserved unchanged so legacy installs keep working.

## Files

- [src/recipes/scheduler.ts](src/recipes/scheduler.ts) — extended `start()` with subdir scan and per-recipe marker check
- [src/recipes/__tests__/scheduler.test.ts](src/recipes/__tests__/scheduler.test.ts) — 4 new tests

## Test plan

- [x] `npx vitest run src/recipes/__tests__/scheduler.test.ts` → 25/25 passing (21 existing + 4 new)
- [x] Full project sweep — 4143 passed, 0 failed
- [x] `getDiagnostics` clean

## Note on duplication

`DISABLED_MARKER = ".disabled"` is duplicated as a const in both `scheduler.ts` and `recipeInstall.ts`. A first attempt to import the helper from `commands/recipeInstall.js` triggered a circular import (`commands` → `recipes` → `commands`). The duplication is intentional and cheap — comments in both files cross-reference. A future cleanup could extract a tiny `recipes/sharedMarkers.ts` if more markers accrete.