### PR TITLE
fix(schema): point schema $id and $schema header at live host

### DIFF
--- a/src/__tests__/server-schemas.test.ts
+++ b/src/__tests__/server-schemas.test.ts
@@ -55,7 +55,9 @@ describe("GET /schemas/*", () => {
     expect(status).toBe(200);
     expect(contentType).toContain("application/schema+json");
     const parsed = JSON.parse(body);
-    expect(parsed.$id).toBe("https://patchworkos.com/schema/recipe.v1.json");
+    expect(parsed.$id).toBe(
+      "https://raw.githubusercontent.com/patchworkos/recipes/main/schema/recipe.v1.json",
+    );
   });
 
   it("serves the dry-run plan schema", async () => {
@@ -64,7 +66,7 @@ describe("GET /schemas/*", () => {
     expect(status).toBe(200);
     const parsed = JSON.parse(body);
     expect(parsed.$id).toBe(
-      "https://patchworkos.com/schema/dry-run-plan.v1.json",
+      "https://raw.githubusercontent.com/patchworkos/recipes/main/schema/dry-run-plan.v1.json",
     );
     expect(parsed.properties.schemaVersion.const).toBe(1);
   });
@@ -74,7 +76,9 @@ describe("GET /schemas/*", () => {
     const { status, body } = await get("/schemas/tools/file.json");
     expect(status).toBe(200);
     const parsed = JSON.parse(body);
-    expect(parsed.$id).toBe("https://patchworkos.com/schema/tools/file.json");
+    expect(parsed.$id).toBe(
+      "https://raw.githubusercontent.com/patchworkos/recipes/main/schema/tools/file.json",
+    );
   });
 
   it("returns an index at /schemas/", async () => {

--- a/src/commands/recipe.ts
+++ b/src/commands/recipe.ts
@@ -51,7 +51,7 @@ import { findYamlRecipePath } from "../recipesHttp.js";
 const RECIPES_DIR = join(os.homedir(), ".patchwork", "recipes");
 const FIXTURES_DIR = join(os.homedir(), ".patchwork", "fixtures");
 const RECIPE_SCHEMA_HEADER =
-  "# yaml-language-server: $schema=https://patchworkos.com/schema/recipe.v1.json";
+  "# yaml-language-server: $schema=https://raw.githubusercontent.com/patchworkos/recipes/main/schema/recipe.v1.json";
 const RECIPE_API_VERSION = "patchwork.sh/v1";
 
 // ============================================================================

--- a/src/recipes/__tests__/schemaGenerator.test.ts
+++ b/src/recipes/__tests__/schemaGenerator.test.ts
@@ -34,7 +34,7 @@ describe("schemaGenerator", () => {
     // Check recipe schema
     expect(schemas.recipe).toMatchObject({
       $schema: "http://json-schema.org/draft-07/schema#",
-      $id: "https://patchworkos.com/schema/recipe.v1.json",
+      $id: "https://raw.githubusercontent.com/patchworkos/recipes/main/schema/recipe.v1.json",
       title: "Patchwork Recipe",
       type: "object",
     });
@@ -296,7 +296,7 @@ describe("schemaGenerator", () => {
       const schema = schemas.dryRunPlan as Record<string, unknown>;
 
       expect(schema.$id).toBe(
-        "https://patchworkos.com/schema/dry-run-plan.v1.json",
+        "https://raw.githubusercontent.com/patchworkos/recipes/main/schema/dry-run-plan.v1.json",
       );
       const properties = schema.properties as Record<string, unknown>;
       expect(properties.schemaVersion).toMatchObject({ const: 1 });

--- a/src/recipes/schemaGenerator.ts
+++ b/src/recipes/schemaGenerator.ts
@@ -67,7 +67,7 @@ export function generateDryRunPlanSchema(): unknown {
 
   return {
     $schema: "http://json-schema.org/draft-07/schema#",
-    $id: "https://patchworkos.com/schema/dry-run-plan.v1.json",
+    $id: "https://raw.githubusercontent.com/patchworkos/recipes/main/schema/dry-run-plan.v1.json",
     title: "Patchwork Recipe Dry-Run Plan",
     description:
       "Stable machine-readable output of `patchwork recipe run --dry-run`. Pin consumers on schemaVersion.",
@@ -267,7 +267,7 @@ function generateRecipeSchema(
 
   return {
     $schema: "http://json-schema.org/draft-07/schema#",
-    $id: "https://patchworkos.com/schema/recipe.v1.json",
+    $id: "https://raw.githubusercontent.com/patchworkos/recipes/main/schema/recipe.v1.json",
     title: "Patchwork Recipe",
     description: "YAML recipe schema for Patchwork automation",
     // taplo formatter: auto-associates *.patchwork.yaml files
@@ -549,7 +549,7 @@ function generateNamespaceSchema(namespace: string): unknown {
 
   return {
     $schema: "http://json-schema.org/draft-07/schema#",
-    $id: `https://patchworkos.com/schema/tools/${namespace}.json`,
+    $id: `https://raw.githubusercontent.com/patchworkos/recipes/main/schema/tools/${namespace}.json`,
     title: `${capitalize(namespace)} Tools`,
     description: `Tool parameters for ${namespace} namespace`,
     definitions,


### PR DESCRIPTION
## Summary

`patchworkos.com/schema/*` returns **HTTP 401**. Two consequences:

- `patchwork recipe new` emitted `# yaml-language-server: \$schema=https://patchworkos.com/...` — editors couldn't fetch, no autocomplete from the explicit header.
- Bridge-served schemas (\`GET /schemas/recipe.v1.json\` etc.) had \`\$id\` fields pointing at the dead URL.

Both now point at the SchemaStore catalog target (#5608):
\`\`\`
https://raw.githubusercontent.com/patchworkos/recipes/main/schema/
\`\`\`

HTTP 200 verified.

## Files

- [src/commands/recipe.ts](src/commands/recipe.ts) — \`RECIPE_SCHEMA_HEADER\`
- [src/recipes/schemaGenerator.ts](src/recipes/schemaGenerator.ts) — three \`\$id\` fields
- 2 test files updated

## Test plan

- [x] \`npx vitest run src/recipes/__tests__/schemaGenerator.test.ts src/__tests__/server-schemas.test.ts\` → 14/14 passing
- [x] \`getDiagnostics\` clean

## Note

Committed \`schemas/*.json\` artifacts predate this change and still have the old \`\$id\`. They regenerate on \`prepublishOnly\` — next release picks them up.