### PR TITLE
fix(security): close SSRF / URL-injection in recipe install (CRIT-1)

### DIFF
--- a/src/__tests__/security-install-ssrf.test.ts
+++ b/src/__tests__/security-install-ssrf.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Security tests for SSRF / URL-injection in `recipe install` (CRIT-1 from
+ * the 2026-04-28 audit).
+ *
+ * Two categories:
+ *   1. `parseInstallSource` should reject sources whose owner/repo/ref/subdir
+ *      contain characters that would change URL semantics (path traversal,
+ *      query injection, control chars, ref injection like leading `-`).
+ *   2. The HTTP redirect follower in `httpsGet` should refuse redirects whose
+ *      `Location` host isn't in a small GitHub-only allowlist.
+ *
+ * Tests are intentionally failing-first against current `main`.
+ */
+
+import { describe, expect, it } from "vitest";
+import { parseInstallSource } from "../commands/recipeInstall.js";
+
+describe("CRIT-1: parseInstallSource — owner/repo/ref/subdir validation", () => {
+  // owner / repo
+  it("rejects owner containing query-string injection", () => {
+    expect(() => parseInstallSource("github:owner&token=evil/repo")).toThrow();
+  });
+
+  it("rejects owner containing whitespace", () => {
+    expect(() => parseInstallSource("github:bad owner/repo")).toThrow();
+  });
+
+  it("rejects repo with non-safe characters", () => {
+    expect(() => parseInstallSource("github:owner/r..epo")).toThrow();
+  });
+
+  it("rejects owner starting with a dash (would be confusable in tooling)", () => {
+    expect(() => parseInstallSource("github:-owner/repo")).toThrow();
+  });
+
+  it("accepts a normal owner/repo", () => {
+    expect(() =>
+      parseInstallSource("github:patchworkos/recipes"),
+    ).not.toThrow();
+  });
+
+  // ref
+  it("rejects ref starting with a dash (git flag injection)", () => {
+    expect(() => parseInstallSource("github:o/r@-rf-the-world")).toThrow();
+  });
+
+  it("rejects ref containing `..` (range syntax / traversal hint)", () => {
+    expect(() => parseInstallSource("github:o/r@v1..v2")).toThrow();
+  });
+
+  it("rejects ref containing `&` or other URL-meaningful chars", () => {
+    expect(() => parseInstallSource("github:o/r@main&inject")).toThrow();
+  });
+
+  it("rejects ref containing whitespace", () => {
+    expect(() => parseInstallSource("github:o/r@bad ref")).toThrow();
+  });
+
+  it("accepts a normal git tag/branch/sha", () => {
+    expect(() => parseInstallSource("github:o/r@v1.0.0")).not.toThrow();
+    expect(() => parseInstallSource("github:o/r@main")).not.toThrow();
+    expect(() => parseInstallSource("github:o/r@a1b2c3d4")).not.toThrow();
+    expect(() => parseInstallSource("github:o/r@feature/xyz")).not.toThrow();
+  });
+
+  // subdir
+  it("rejects subdir containing `..` segments", () => {
+    expect(() => parseInstallSource("github:o/r/foo/../etc")).toThrow();
+  });
+
+  it("rejects subdir containing whitespace", () => {
+    expect(() => parseInstallSource("github:o/r/bad path")).toThrow();
+  });
+
+  it("rejects subdir containing query-string injection", () => {
+    expect(() => parseInstallSource("github:o/r/foo&inject")).toThrow();
+  });
+
+  it("accepts subdir with normal nested path", () => {
+    expect(() =>
+      parseInstallSource("github:o/r/morning-brief/v1"),
+    ).not.toThrow();
+  });
+});
+
+describe("CRIT-1: httpsGet — redirect host allowlist", () => {
+  // We exercise the helper indirectly by exporting an `isAllowedRedirectHost`
+  // predicate the install path uses to validate `res.headers.location`.
+  it("isAllowedRedirectHost helper accepts api.github.com", async () => {
+    const mod = await import("../commands/recipeInstall.js");
+    const fn = (
+      mod as unknown as { isAllowedRedirectHost?: (u: string) => boolean }
+    ).isAllowedRedirectHost;
+    expect(typeof fn).toBe("function");
+    expect(fn!("https://api.github.com/repos/foo/bar/contents/")).toBe(true);
+  });
+
+  it("isAllowedRedirectHost accepts raw.githubusercontent.com and codeload.github.com", async () => {
+    const { isAllowedRedirectHost } = (await import(
+      "../commands/recipeInstall.js"
+    )) as unknown as { isAllowedRedirectHost: (u: string) => boolean };
+    expect(
+      isAllowedRedirectHost(
+        "https://raw.githubusercontent.com/foo/bar/main/file.yaml",
+      ),
+    ).toBe(true);
+    expect(
+      isAllowedRedirectHost(
+        "https://codeload.github.com/foo/bar/zip/refs/heads/main",
+      ),
+    ).toBe(true);
+  });
+
+  it("isAllowedRedirectHost rejects an attacker-controlled host", async () => {
+    const { isAllowedRedirectHost } = (await import(
+      "../commands/recipeInstall.js"
+    )) as unknown as { isAllowedRedirectHost: (u: string) => boolean };
+    expect(isAllowedRedirectHost("https://evil.example.com/steal")).toBe(false);
+    expect(isAllowedRedirectHost("http://api.github.com.evil.com/x")).toBe(
+      false,
+    );
+    expect(isAllowedRedirectHost("https://attacker.com/api.github.com")).toBe(
+      false,
+    );
+  });
+
+  it("isAllowedRedirectHost rejects http (no TLS) even on a github.com host", async () => {
+    const { isAllowedRedirectHost } = (await import(
+      "../commands/recipeInstall.js"
+    )) as unknown as { isAllowedRedirectHost: (u: string) => boolean };
+    expect(isAllowedRedirectHost("http://api.github.com/foo")).toBe(false);
+  });
+
+  it("isAllowedRedirectHost rejects malformed URLs", async () => {
+    const { isAllowedRedirectHost } = (await import(
+      "../commands/recipeInstall.js"
+    )) as unknown as { isAllowedRedirectHost: (u: string) => boolean };
+    expect(isAllowedRedirectHost("not a url")).toBe(false);
+    expect(isAllowedRedirectHost("")).toBe(false);
+  });
+});

--- a/src/commands/recipeInstall.ts
+++ b/src/commands/recipeInstall.ts
@@ -63,6 +63,66 @@ export function isSafeBasename(name: unknown): boolean {
   return true;
 }
 
+/**
+ * GitHub repo and owner names. Lenient enough for real-world usage but
+ * strict enough that the value can be string-interpolated into a URL path
+ * without changing semantics. Rejects: empty, leading dash, leading dot,
+ * `..`, anything outside [A-Za-z0-9_.-], length > 100.
+ */
+function isValidGitHubName(name: string): boolean {
+  if (!name || name.length > 100) return false;
+  if (name.startsWith("-") || name.startsWith(".")) return false;
+  if (name.includes("..")) return false;
+  return /^[A-Za-z0-9_.-]+$/.test(name);
+}
+
+/**
+ * Subdir segment (one piece of a `/`-joined path). Must be non-empty,
+ * not `.`/`..`, and contain only chars safe for URL path interpolation.
+ */
+function isValidSubdirSegment(segment: string): boolean {
+  if (!segment || segment === "." || segment === "..") return false;
+  return /^[A-Za-z0-9_.-]+$/.test(segment);
+}
+
+/**
+ * Git ref (branch / tag / SHA / `feature/foo`). Mirrors `isValidRef` from
+ * `src/tools/git-utils.ts` (we don't import it to avoid pulling tools-layer
+ * deps into commands).
+ *
+ * Rejects: leading dash (CLI-flag injection territory), `..` (range syntax /
+ * traversal), shell/URL metacharacters. Allows `/` for `feature/xyz`-style refs.
+ */
+function isValidGitRef(ref: string): boolean {
+  if (!ref || ref.startsWith("-") || ref.includes("..")) return false;
+  return /^[\w./\-^~@{}]+$/.test(ref);
+}
+
+/**
+ * Allowlist for `httpsGet` redirect targets. The recipe-install fetch path
+ * resolves user-supplied identifiers into GitHub API URLs and follows
+ * redirects, so a malicious source could otherwise cause a server-side
+ * fetch against an attacker host. Restrict redirects to the small set of
+ * GitHub-owned hosts the installer actually needs, over HTTPS only.
+ *
+ * Exported for testing.
+ */
+export function isAllowedRedirectHost(url: string): boolean {
+  if (typeof url !== "string" || !url) return false;
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return false;
+  }
+  if (parsed.protocol !== "https:") return false;
+  return (
+    parsed.hostname === "api.github.com" ||
+    parsed.hostname === "raw.githubusercontent.com" ||
+    parsed.hostname === "codeload.github.com"
+  );
+}
+
 // ============================================================================
 // Source parsing
 // ============================================================================
@@ -128,13 +188,13 @@ export function parseInstallSource(source: string): InstallSource {
     if (!owner || !repo) {
       throw new Error(`Invalid GitHub URL: ${source}`);
     }
-    return {
+    return validateGitHubSource({
       type: "github",
       owner,
       repo,
       ...(subdir ? { subdir } : {}),
       ...(ref ? { ref } : {}),
-    };
+    });
   }
 
   throw new Error(
@@ -170,13 +230,48 @@ function parseGithubShorthand(shorthand: string): GitHubInstallSource {
   if (!owner || !repo) {
     throw new Error(`Invalid github shorthand: "${shorthand}"`);
   }
-  return {
+  return validateGitHubSource({
     type: "github",
     owner,
     repo,
     ...(subdirParts.length > 0 ? { subdir: subdirParts.join("/") } : {}),
     ...(ref ? { ref } : {}),
-  };
+  });
+}
+
+/**
+ * Validate a parsed GitHubInstallSource — every field that flows into a URL
+ * must be safe for path interpolation. Throws with a descriptive message
+ * naming the offending field. Returns the same source on success so callers
+ * can chain.
+ */
+function validateGitHubSource(s: GitHubInstallSource): GitHubInstallSource {
+  if (!isValidGitHubName(s.owner)) {
+    throw new Error(
+      `Invalid GitHub owner "${s.owner}": must be [A-Za-z0-9_.-], no leading dash/dot, no "..", ≤ 100 chars`,
+    );
+  }
+  if (!isValidGitHubName(s.repo)) {
+    throw new Error(
+      `Invalid GitHub repo "${s.repo}": must be [A-Za-z0-9_.-], no leading dash/dot, no "..", ≤ 100 chars`,
+    );
+  }
+  if (s.ref !== undefined && !isValidGitRef(s.ref)) {
+    throw new Error(
+      `Invalid git ref "${s.ref}": must be a valid branch/tag/SHA without shell or URL metacharacters`,
+    );
+  }
+  if (s.subdir !== undefined) {
+    const segments = s.subdir.split("/");
+    for (const seg of segments) {
+      if (!isValidSubdirSegment(seg)) {
+        throw new Error(
+          `Invalid subdir segment "${seg}" in "${s.subdir}": must be [A-Za-z0-9_.-], not "." or ".."`,
+        );
+      }
+    }
+  }
+  return s;
 }
 
 // ============================================================================
@@ -211,6 +306,11 @@ export function determineInstallName(
 // ============================================================================
 
 async function httpsGet(url: string): Promise<Buffer> {
+  // Reject the initial URL too — defense in depth in case a caller bypasses
+  // parseInstallSource validation (e.g., raw download_url from API responses).
+  if (!isAllowedRedirectHost(url)) {
+    throw new Error(`Refused fetch: host not in GitHub allowlist (${url})`);
+  }
   return new Promise((resolve, reject) => {
     const req = https.get(
       url,
@@ -221,13 +321,23 @@ async function httpsGet(url: string): Promise<Buffer> {
         },
       },
       (res) => {
-        // Follow redirects
+        // Follow redirects — but only to other GitHub-owned hosts over HTTPS.
+        // A 30x to an attacker-controlled URL would otherwise be silently
+        // followed and the body parsed/written to disk.
         if (
           res.statusCode &&
           res.statusCode >= 300 &&
           res.statusCode < 400 &&
           res.headers.location
         ) {
+          if (!isAllowedRedirectHost(res.headers.location)) {
+            reject(
+              new Error(
+                `Refused redirect to non-allowlisted host: ${res.headers.location}`,
+              ),
+            );
+            return;
+          }
           httpsGet(res.headers.location).then(resolve).catch(reject);
           return;
         }
@@ -261,7 +371,15 @@ async function listGitHubContents(
   dirPath: string,
   ref: string,
 ): Promise<GitHubContentItem[]> {
-  const url = `https://api.github.com/repos/${owner}/${repo}/contents/${dirPath}?ref=${ref}`;
+  // URL-encode every interpolated component so user-controlled values can't
+  // change URL semantics (extra query params, path traversal, fragment).
+  // Note: `dirPath` is encoded per-segment so legitimate `/` separators
+  // survive while reserved chars inside segments get encoded.
+  const encodedOwner = encodeURIComponent(owner);
+  const encodedRepo = encodeURIComponent(repo);
+  const encodedPath = dirPath.split("/").map(encodeURIComponent).join("/");
+  const encodedRef = encodeURIComponent(ref);
+  const url = `https://api.github.com/repos/${encodedOwner}/${encodedRepo}/contents/${encodedPath}?ref=${encodedRef}`;
   const body = await httpsGet(url);
   const parsed = JSON.parse(body.toString("utf-8")) as unknown;
   if (!Array.isArray(parsed)) {


### PR DESCRIPTION
## Summary

Closes the highest-severity finding from the 2026-04-28 security audit (CRIT-1). \`parseInstallSource\` accepted arbitrary \`owner\`/\`repo\`/\`ref\`/\`subdir\` and interpolated them into the GitHub Contents API URL with no validation and no \`encodeURIComponent\`. \`httpsGet\` followed redirects with no host check.

## Stacked on #46

This PR's base is [\`fix/security-path-traversal-hardening\`](https://github.com/Oolab-labs/patchwork-os/pull/46) — once #46 merges, GitHub auto-retargets this PR to \`main\` and the diff narrows to just the SSRF/URL-injection changes.

## Attack scenarios closed

| Attempt | Now |
|---|---|
| \`gh:owner/repo@main&token=evil\` | rejected — \`&\` in ref |
| \`gh:owner/repo@-rf-flag-injection\` | rejected — leading dash |
| \`gh:owner/repo/foo/../etc\` | rejected — \`..\` segment |
| \`gh:bad owner/repo\` | rejected — whitespace |
| api.github.com → evil.com 30x redirect | refused — host not in allowlist |
| Plain HTTP redirect (downgrade) | refused — protocol not https |

## Fixes

- **Validators** (private, in [src/commands/recipeInstall.ts](src/commands/recipeInstall.ts)):
  - \`isValidGitHubName\`, \`isValidSubdirSegment\`, \`isValidGitRef\`
- **\`isAllowedRedirectHost(url)\`** (exported) — allowlist: \`api.github.com\`, \`raw.githubusercontent.com\`, \`codeload.github.com\`. HTTPS only.
- **\`validateGitHubSource()\`** funnel — every parsed \`GitHubInstallSource\` goes through the same validation regardless of input syntax (\`github:\`, \`gh:\`, full URL).
- **URL encoding** — \`listGitHubContents\` now \`encodeURIComponent\`s every interpolated component (owner, repo, per-segment of dirPath, ref). Defense-in-depth even though validators reject the dangerous characters.
- **\`httpsGet\` redirect handling** — rejects initial URL AND each \`Location\` header against the allowlist. Redirect-to-attacker is no longer silent — it throws.

## Bug-fix protocol

19 new tests in [src/__tests__/security-install-ssrf.test.ts](src/__tests__/security-install-ssrf.test.ts) written failing-first. Covers owner/repo/ref/subdir validation in \`parseInstallSource\`, plus redirect-host allowlist (positive cases + attacker-host + http-downgrade + malformed URL).

## Test plan

- [x] \`npx vitest run src/__tests__/security-install-ssrf.test.ts\` → 19/19 passing
- [x] \`npx vitest run src/__tests__/security-path-traversal.test.ts\` → 13/13 passing (PR #46)
- [x] \`npx vitest run src/commands/__tests__/recipeInstall.test.ts\` → 25/25 (existing) — every legacy parse case still works
- [x] Full sweep — **4187 passing, 0 failed**
- [x] \`getDiagnostics\` clean

## Out of scope (next PR)

- HIGH-3: \`tokenEndpoint\` not pinned to https + per-connector host allowlist
- MED-1: \`data.access_token\` not validated post-parse