### PR TITLE
fix(security): harden BaseConnector.refreshToken (HIGH-3 + MED-1)

### DIFF
--- a/src/connectors/__tests__/baseConnector.security.test.ts
+++ b/src/connectors/__tests__/baseConnector.security.test.ts
@@ -1,0 +1,244 @@
+/**
+ * Security tests for OAuth refresh edge cases (HIGH-3 + MED-1 from the
+ * 2026-04-28 audit).
+ *
+ * HIGH-3: `config.tokenEndpoint` was fetched without TLS validation. A
+ *         connector subclass populating this from user-modifiable config
+ *         could trick the bridge into POSTing the refresh_token to an
+ *         attacker host. Refresh now refuses non-HTTPS endpoints.
+ *
+ * MED-1:  Successful refresh response was trusted blindly. `{}` or
+ *         `{access_token: null}` would result in `Bearer undefined`
+ *         persisted to the OS keychain. Refresh now validates that
+ *         `access_token` is a non-empty string and `expires_in` (when
+ *         present) is a sane positive number.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  type AuthContext,
+  BaseConnector,
+  type ConnectorError,
+  type ConnectorStatus,
+  type OAuthConfig,
+} from "../baseConnector.js";
+
+const storeTokens = vi.fn().mockResolvedValue(undefined);
+const getTokens = vi.fn().mockResolvedValue(null);
+const deleteTokens = vi.fn().mockResolvedValue(undefined);
+
+vi.mock("../tokenStorage.js", () => ({
+  storeTokens: (...args: unknown[]) => storeTokens(...args),
+  getTokens: (...args: unknown[]) => getTokens(...args),
+  deleteTokens: (...args: unknown[]) => deleteTokens(...args),
+}));
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+class TestConnector extends BaseConnector {
+  readonly providerName = "test-security";
+  oauthConfigOverride: OAuthConfig | null = {
+    clientId: "id",
+    clientSecret: "secret",
+    tokenEndpoint: "https://oauth.example.com/token",
+  };
+
+  protected getOAuthConfig(): OAuthConfig | null {
+    return this.oauthConfigOverride;
+  }
+
+  async authenticate(): Promise<AuthContext> {
+    throw new Error("authenticate not configured");
+  }
+
+  async healthCheck() {
+    return { ok: true };
+  }
+
+  normalizeError(): ConnectorError {
+    return { code: "provider_error", message: "x", retryable: false };
+  }
+
+  getStatus(): ConnectorStatus {
+    return { id: this.providerName, status: "connected" };
+  }
+
+  setAuth(auth: AuthContext | null) {
+    this.auth = auth;
+  }
+  callRefresh() {
+    return this.refreshToken();
+  }
+}
+
+beforeEach(() => {
+  storeTokens.mockClear();
+  getTokens.mockClear();
+  deleteTokens.mockClear();
+  mockFetch.mockReset();
+});
+
+afterEach(() => {
+  vi.clearAllTimers();
+});
+
+describe("HIGH-3: refreshToken refuses non-HTTPS tokenEndpoint", () => {
+  it("rejects http:// endpoint without sending the refresh token", async () => {
+    const c = new TestConnector();
+    c.oauthConfigOverride = {
+      clientId: "id",
+      tokenEndpoint: "http://oauth.example.com/token", // ← plain HTTP
+    };
+    c.setAuth({ token: "at", refreshToken: "rt-secret" });
+
+    const result = await c.callRefresh();
+
+    expect(result).toBeNull();
+    // CRITICAL: must not have made the request
+    expect(mockFetch).not.toHaveBeenCalled();
+    // and must not have wiped the user's tokens for a misconfig
+    expect(deleteTokens).not.toHaveBeenCalled();
+    expect(storeTokens).not.toHaveBeenCalled();
+  });
+
+  it("rejects ftp:// or other non-https schemes", async () => {
+    const c = new TestConnector();
+    c.oauthConfigOverride = {
+      clientId: "id",
+      tokenEndpoint: "ftp://attacker.example.com/grab",
+    };
+    c.setAuth({ token: "at", refreshToken: "rt-secret" });
+
+    await c.callRefresh();
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("rejects an obviously malformed endpoint", async () => {
+    const c = new TestConnector();
+    c.oauthConfigOverride = {
+      clientId: "id",
+      tokenEndpoint: "not a url",
+    };
+    c.setAuth({ token: "at", refreshToken: "rt-secret" });
+
+    await c.callRefresh();
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("accepts an https:// endpoint", async () => {
+    const c = new TestConnector();
+    c.setAuth({ token: "at", refreshToken: "rt" });
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ access_token: "new-at", expires_in: 3600 }),
+    });
+
+    const result = await c.callRefresh();
+    expect(result?.token).toBe("new-at");
+  });
+});
+
+describe("MED-1: refreshToken validates the response body before adopting tokens", () => {
+  it("returns null without persisting if access_token is missing", async () => {
+    const c = new TestConnector();
+    c.setAuth({ token: "old", refreshToken: "rt" });
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({}), // no access_token
+    });
+
+    const result = await c.callRefresh();
+
+    expect(result).toBeNull();
+    expect(storeTokens).not.toHaveBeenCalled();
+    // Transient → keep existing tokens
+    expect(deleteTokens).not.toHaveBeenCalled();
+  });
+
+  it("returns null if access_token is null", async () => {
+    const c = new TestConnector();
+    c.setAuth({ token: "old", refreshToken: "rt" });
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ access_token: null }),
+    });
+
+    const result = await c.callRefresh();
+    expect(result).toBeNull();
+    expect(storeTokens).not.toHaveBeenCalled();
+  });
+
+  it("returns null if access_token is not a string", async () => {
+    const c = new TestConnector();
+    c.setAuth({ token: "old", refreshToken: "rt" });
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ access_token: 12345 }),
+    });
+
+    const result = await c.callRefresh();
+    expect(result).toBeNull();
+    expect(storeTokens).not.toHaveBeenCalled();
+  });
+
+  it("returns null if access_token is an empty string", async () => {
+    const c = new TestConnector();
+    c.setAuth({ token: "old", refreshToken: "rt" });
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ access_token: "" }),
+    });
+
+    const result = await c.callRefresh();
+    expect(result).toBeNull();
+    expect(storeTokens).not.toHaveBeenCalled();
+  });
+
+  it("clamps absurd expires_in values rather than persisting them", async () => {
+    const c = new TestConnector();
+    c.setAuth({ token: "old", refreshToken: "rt" });
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        access_token: "new",
+        expires_in: -3600, // negative — likely clock skew or buggy IdP
+      }),
+    });
+
+    const result = await c.callRefresh();
+    // Should NOT adopt a token whose expires_in is negative — implies
+    // already-expired or junk IdP response. Treat as transient.
+    expect(result).toBeNull();
+    expect(storeTokens).not.toHaveBeenCalled();
+  });
+
+  it("rejects implausibly long expires_in (> 1 year)", async () => {
+    const c = new TestConnector();
+    c.setAuth({ token: "old", refreshToken: "rt" });
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        access_token: "new",
+        expires_in: 60 * 60 * 24 * 365 * 10, // 10 years
+      }),
+    });
+
+    const result = await c.callRefresh();
+    expect(result).toBeNull();
+    expect(storeTokens).not.toHaveBeenCalled();
+  });
+
+  it("accepts a valid response with no expires_in (some IdPs omit it)", async () => {
+    const c = new TestConnector();
+    c.setAuth({ token: "old", refreshToken: "rt" });
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ access_token: "new-token" }),
+    });
+
+    const result = await c.callRefresh();
+    expect(result?.token).toBe("new-token");
+    expect(storeTokens).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/connectors/baseConnector.ts
+++ b/src/connectors/baseConnector.ts
@@ -127,15 +127,37 @@ export abstract class BaseConnector {
    * Failure handling distinguishes permanent from transient failures:
    *   - Permanent (401, or 400 with `error: invalid_grant`) → clear stored
    *     tokens so the next call drives a fresh authenticate() flow.
-   *   - Transient (network error, 5xx, 4xx without `invalid_grant`) → keep
+   *   - Transient (network error, 5xx, 4xx without `invalid_grant`,
+   *     misconfigured tokenEndpoint, malformed response body) → keep
    *     tokens; next call will retry. Avoids forcing a full re-OAuth on
    *     flaky wifi or temporary IdP outages.
+   *
+   * Security guarantees:
+   *   - `tokenEndpoint` MUST be HTTPS — refresh tokens are never sent over
+   *     plain HTTP, even if a buggy/hostile config supplies one.
+   *   - The response is validated before adoption: `access_token` must be a
+   *     non-empty string and `expires_in` (when present) must fall within
+   *     [1s, 1 year]. Otherwise the existing tokens are kept and the result
+   *     is treated as transient.
    */
   protected async refreshToken(): Promise<AuthContext | null> {
     if (!this.auth?.refreshToken) return null;
 
     const config = this.getOAuthConfig();
     if (!config) return null;
+
+    // Refuse to send the refresh token to a non-HTTPS endpoint. A connector
+    // subclass that derives `tokenEndpoint` from user-modifiable config
+    // could otherwise be tricked into POSTing the secret to an attacker.
+    let endpointUrl: URL;
+    try {
+      endpointUrl = new URL(config.tokenEndpoint);
+    } catch {
+      return null;
+    }
+    if (endpointUrl.protocol !== "https:") {
+      return null;
+    }
 
     const params = new URLSearchParams({
       grant_type: "refresh_token",
@@ -173,10 +195,10 @@ export abstract class BaseConnector {
     }
 
     let data: {
-      access_token: string;
-      refresh_token?: string;
-      expires_in?: number;
-      scope?: string;
+      access_token?: unknown;
+      refresh_token?: unknown;
+      expires_in?: unknown;
+      scope?: unknown;
     };
     try {
       data = (await response.json()) as typeof data;
@@ -185,13 +207,42 @@ export abstract class BaseConnector {
       return null;
     }
 
+    // Validate the success body before adopting any of it. A 200 with
+    // `{}` or `{access_token: null}` would otherwise persist `Bearer
+    // undefined` to the OS keychain.
+    if (
+      typeof data.access_token !== "string" ||
+      data.access_token.length === 0
+    ) {
+      return null;
+    }
+    let expiresAt: Date | undefined;
+    if (data.expires_in !== undefined) {
+      // Reject negative, zero, NaN, or absurdly long lifetimes (> 1 year).
+      const ONE_YEAR_S = 60 * 60 * 24 * 365;
+      const seconds = data.expires_in;
+      if (
+        typeof seconds !== "number" ||
+        !Number.isFinite(seconds) ||
+        seconds <= 0 ||
+        seconds > ONE_YEAR_S
+      ) {
+        return null;
+      }
+      expiresAt = new Date(Date.now() + seconds * 1000);
+    }
+
     const newAuth: AuthContext = {
       token: data.access_token,
-      refreshToken: data.refresh_token ?? this.auth.refreshToken,
-      expiresAt: data.expires_in
-        ? new Date(Date.now() + data.expires_in * 1000)
-        : undefined,
-      scopes: data.scope?.split(" ") ?? this.auth.scopes,
+      refreshToken:
+        typeof data.refresh_token === "string" && data.refresh_token.length > 0
+          ? data.refresh_token
+          : this.auth.refreshToken,
+      expiresAt,
+      scopes:
+        typeof data.scope === "string"
+          ? data.scope.split(" ")
+          : (this.auth.scopes ?? undefined),
     };
 
     this.auth = newAuth;


### PR DESCRIPTION
## Summary

Closes the two BaseConnector findings from the 2026-04-28 audit. Both in [src/connectors/baseConnector.ts](src/connectors/baseConnector.ts), both small but real attack vectors.

| ID | Issue | Fix |
|---|---|---|
| **HIGH-3** | \`tokenEndpoint\` was fetched as-is, no scheme check. A subclass deriving the endpoint from user-modifiable config could POST refresh_token to attacker host. | Refuse to fetch unless URL parses cleanly AND \`protocol === "https:"\`. |
| **MED-1** | 200 OK with \`{}\` / \`{access_token: null}\` / \`{access_token: 12345}\` would persist \`Bearer undefined\` to the OS keychain. Negative \`expires_in\` would set expiry in the past. | Validate \`access_token\` is non-empty string; \`expires_in\` is finite positive number ≤ 1 year. Otherwise return null (transient — keep existing tokens). |

## Independent of #46/#47

Different file, no overlap. Base = main; can merge before, after, or in any order with the install-side security PRs.

## Tests

11 new tests in [src/connectors/__tests__/baseConnector.security.test.ts](src/connectors/__tests__/baseConnector.security.test.ts) — all written failing-first. Coverage:

- http:// / ftp:// / malformed \`tokenEndpoint\` rejected without sending refresh_token
- https:// happy path still works
- access_token missing / null / numeric / empty string → null + no persist
- expires_in negative / > 1 year → null + no persist
- expires_in absent (some IdPs omit) → still accepts the token

Existing 13 baseConnector.test.ts cases untouched.

## Test plan

- [x] \`npx vitest run src/connectors/__tests__/baseConnector.security.test.ts\` → 11/11 passing
- [x] \`npx vitest run src/connectors/__tests__/baseConnector.test.ts\` → 13/13 passing
- [x] Full sweep — 4166 passing, 0 failed
- [x] \`getDiagnostics\` clean

## What's done after this lands

The full security cluster from the audit:

| ID | PR |
|---|---|
| CRIT-1 SSRF/URL injection | [#47](https://github.com/Oolab-labs/patchwork-os/pull/47) (stacked on #46) |
| CRIT-2 GitHub item.name traversal | [#46](https://github.com/Oolab-labs/patchwork-os/pull/46) |
| HIGH-1 manifest path traversal | [#46](https://github.com/Oolab-labs/patchwork-os/pull/46) |
| HIGH-2 enable/disable name traversal | [#46](https://github.com/Oolab-labs/patchwork-os/pull/46) |
| HIGH-3 tokenEndpoint not pinned | this PR |
| MED-1 access_token not validated | this PR |

Remaining (next PRs): two-systems disabled-state semantic gap, kill-switch env-var precedence (MED-2).