### PR TITLE
feat(recipes): universal .disabled enforcement on webhook + manual paths

### DIFF
--- a/src/__tests__/disabled-marker-enforcement.test.ts
+++ b/src/__tests__/disabled-marker-enforcement.test.ts
@@ -1,0 +1,229 @@
+/**
+ * Tests for universal `.disabled` marker enforcement across all recipe-trigger
+ * surfaces (Bug #1 from the 2026-04-28 audit).
+ *
+ * PR #43 wired `.disabled` enforcement into the cron scheduler. Webhook,
+ * manual-fire (`patchwork recipe run` / HTTP /recipes/run), and the
+ * automation interpreter still ignored the marker — so a "disabled" recipe
+ * could fire via webhook or be triggered by automation. This test file
+ * locks in the fix.
+ *
+ * Two related issues fixed together:
+ *   1. install-dir recipes (created by `runRecipeInstall` into a subdir)
+ *      were invisible to `findWebhookRecipe` / `findYamlRecipePath` — those
+ *      only scanned top-level files. Recipes installed via the marketplace
+ *      flow couldn't be triggered at all by webhook/manual paths.
+ *   2. `.disabled` marker wasn't checked on the result.
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  findWebhookRecipe,
+  findYamlRecipePath,
+  loadRecipePrompt,
+} from "../recipesHttp.js";
+
+let tmp: string;
+
+beforeEach(() => {
+  tmp = mkdtempSync(path.join(os.tmpdir(), "patchwork-disabled-marker-"));
+});
+
+afterEach(() => {
+  if (tmp && existsSync(tmp)) {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+function writeInstalledRecipe(
+  dirName: string,
+  yamlBody: string,
+  opts: { disabled?: boolean; manifestMain?: string } = {},
+) {
+  const dir = path.join(tmp, dirName);
+  mkdirSync(dir, { recursive: true });
+  const yamlFile = opts.manifestMain ?? "main.yaml";
+  writeFileSync(path.join(dir, yamlFile), yamlBody);
+  if (opts.manifestMain) {
+    writeFileSync(
+      path.join(dir, "recipe.json"),
+      JSON.stringify(
+        {
+          name: dirName,
+          version: "1.0.0",
+          description: "x",
+          recipes: { main: opts.manifestMain },
+        },
+        null,
+        2,
+      ),
+    );
+  }
+  if (opts.disabled) {
+    writeFileSync(path.join(dir, ".disabled"), "");
+  }
+  return dir;
+}
+
+describe("findWebhookRecipe — install-dir support + .disabled enforcement", () => {
+  it("finds a webhook recipe inside an install dir", () => {
+    writeInstalledRecipe(
+      "deploy-pkg",
+      [
+        "name: deploy-trigger",
+        "trigger:",
+        "  type: webhook",
+        "  path: /deploy",
+        "steps:",
+        "  - id: main",
+        "    agent: true",
+        "    prompt: deploy",
+      ].join("\n"),
+    );
+
+    const match = findWebhookRecipe(tmp, "/deploy");
+    expect(match).not.toBeNull();
+    expect(match?.name).toBe("deploy-trigger");
+    expect(match?.path).toBe("/deploy");
+  });
+
+  it("does NOT find a webhook recipe whose install dir has the .disabled marker", () => {
+    writeInstalledRecipe(
+      "deploy-pkg",
+      [
+        "name: deploy-trigger",
+        "trigger:",
+        "  type: webhook",
+        "  path: /deploy",
+        "steps:",
+        "  - id: main",
+        "    agent: true",
+        "    prompt: deploy",
+      ].join("\n"),
+      { disabled: true },
+    );
+
+    const match = findWebhookRecipe(tmp, "/deploy");
+    expect(match).toBeNull();
+  });
+
+  it("still finds top-level (legacy) webhook recipes", () => {
+    writeFileSync(
+      path.join(tmp, "topdeploy.json"),
+      JSON.stringify({
+        name: "top-trigger",
+        version: "1",
+        trigger: { type: "webhook", path: "/top" },
+        steps: [{ id: "main", agent: true, prompt: "x" }],
+      }),
+    );
+    const match = findWebhookRecipe(tmp, "/top");
+    expect(match?.name).toBe("top-trigger");
+  });
+
+  it("respects manifest's recipes.main when finding the trigger", () => {
+    writeInstalledRecipe(
+      "weekly-pkg",
+      [
+        "name: weekly-trigger",
+        "trigger:",
+        "  type: webhook",
+        "  path: /weekly",
+        "steps:",
+        "  - id: main",
+        "    agent: true",
+        "    prompt: x",
+      ].join("\n"),
+      { manifestMain: "weekly.yaml" },
+    );
+
+    const match = findWebhookRecipe(tmp, "/weekly");
+    expect(match?.name).toBe("weekly-trigger");
+  });
+});
+
+describe("findYamlRecipePath — install-dir support + .disabled enforcement", () => {
+  it("finds a YAML recipe whose name lives in an install dir", () => {
+    writeInstalledRecipe(
+      "morning-pkg",
+      [
+        "name: morning-brief",
+        "trigger:",
+        "  type: manual",
+        "steps:",
+        "  - id: main",
+        "    agent: true",
+        "    prompt: brief",
+      ].join("\n"),
+    );
+
+    const found = findYamlRecipePath(tmp, "morning-brief");
+    expect(found).not.toBeNull();
+    expect(found).toContain("morning-pkg");
+  });
+
+  it("does NOT find a recipe whose install dir has .disabled marker", () => {
+    writeInstalledRecipe(
+      "morning-pkg",
+      [
+        "name: morning-brief",
+        "trigger:",
+        "  type: manual",
+        "steps:",
+        "  - id: main",
+        "    agent: true",
+        "    prompt: brief",
+      ].join("\n"),
+      { disabled: true },
+    );
+
+    const found = findYamlRecipePath(tmp, "morning-brief");
+    expect(found).toBeNull();
+  });
+
+  it("still resolves top-level <name>.yaml (legacy)", () => {
+    writeFileSync(
+      path.join(tmp, "legacy.yaml"),
+      [
+        "name: legacy",
+        "trigger:",
+        "  type: manual",
+        "steps:",
+        "  - id: main",
+        "    agent: true",
+        "    prompt: x",
+      ].join("\n"),
+    );
+    const found = findYamlRecipePath(tmp, "legacy");
+    expect(found).toContain("legacy.yaml");
+  });
+});
+
+describe("loadRecipePrompt — install-dir support + .disabled enforcement", () => {
+  it("does NOT load a JSON recipe whose install dir has .disabled marker", () => {
+    const dir = path.join(tmp, "json-pkg");
+    mkdirSync(dir);
+    writeFileSync(
+      path.join(dir, "json-recipe.json"),
+      JSON.stringify({
+        name: "json-recipe",
+        version: "1",
+        trigger: { type: "manual" },
+        steps: [{ id: "main", agent: true, prompt: "hi" }],
+      }),
+    );
+    writeFileSync(path.join(dir, ".disabled"), "");
+
+    const result = loadRecipePrompt(tmp, "json-recipe");
+    expect(result).toBeNull();
+  });
+});

--- a/src/recipesHttp.ts
+++ b/src/recipesHttp.ts
@@ -13,6 +13,101 @@ import { loadConfig } from "./patchworkConfig.js";
 import { validateRecipeDefinition } from "./recipes/validation.js";
 
 /**
+ * Per-recipe disabled marker — must match the constant in
+ * `src/commands/recipeInstall.ts` and `src/recipes/scheduler.ts` (kept inline
+ * here to avoid a circular import via commands → recipesHttp → commands).
+ *
+ * Absence on a recipe's install dir = enabled (legacy default).
+ * Presence = disabled — `runRecipeInstall` writes one on every fresh install.
+ */
+const DISABLED_MARKER = ".disabled";
+
+/**
+ * Returns true unless `filePath` lives inside an install dir whose
+ * `.disabled` marker is present. Top-level legacy recipes (direct children
+ * of `recipesDir`) are always considered enabled — there's no install dir
+ * to put a marker in. Used by every trigger surface (webhook, manual fire,
+ * automation) so the marker means the same thing everywhere.
+ */
+export function isRecipeFileEnabled(
+  filePath: string,
+  recipesDir: string,
+): boolean {
+  const rel = path.relative(recipesDir, filePath);
+  // Top-level file in recipesDir → no install dir → enabled by default.
+  if (rel === "" || rel.startsWith("..") || !rel.includes(path.sep)) {
+    return true;
+  }
+  const installDirName = rel.split(path.sep)[0];
+  if (!installDirName) return true;
+  const installDir = path.join(recipesDir, installDirName);
+  return !existsSync(path.join(installDir, DISABLED_MARKER));
+}
+
+/**
+ * Iterate one level of subdirectories under `recipesDir` that look like
+ * install dirs (directory containing `recipe.json` or at least one `.yaml`).
+ * Skips dirs whose `.disabled` marker is present so callers automatically
+ * honor the marker without having to remember.
+ *
+ * Yields `{ installDir, entrypointPath }` pairs where `entrypointPath` is the
+ * file the caller should parse:
+ *   - `recipe.json`'s `recipes.main` if a manifest exists
+ *   - otherwise the first `*.yaml` / `*.yml` in the dir
+ *
+ * Used by webhook + manual-fire path resolvers to find recipes installed
+ * via `runRecipeInstall`.
+ */
+function* iterateInstallDirs(
+  recipesDir: string,
+): Generator<{ installDir: string; entrypointPath: string }> {
+  let entries: string[];
+  try {
+    entries = readdirSync(recipesDir);
+  } catch {
+    return;
+  }
+  for (const f of entries) {
+    const fullPath = path.join(recipesDir, f);
+    let isDir = false;
+    try {
+      isDir = statSync(fullPath).isDirectory();
+    } catch {
+      continue;
+    }
+    if (!isDir) continue;
+    if (existsSync(path.join(fullPath, DISABLED_MARKER))) continue;
+
+    let entrypoint: string | null = null;
+    const manifestPath = path.join(fullPath, "recipe.json");
+    if (existsSync(manifestPath)) {
+      try {
+        const m = JSON.parse(readFileSync(manifestPath, "utf-8")) as {
+          recipes?: { main?: string };
+        };
+        if (m.recipes?.main) {
+          const candidate = path.join(fullPath, m.recipes.main);
+          if (existsSync(candidate)) entrypoint = candidate;
+        }
+      } catch {
+        // malformed manifest — fall through to first-yaml fallback
+      }
+    }
+    if (!entrypoint) {
+      try {
+        const yaml = readdirSync(fullPath).find((x) => /\.ya?ml$/i.test(x));
+        if (yaml) entrypoint = path.join(fullPath, yaml);
+      } catch {
+        // unreadable
+      }
+    }
+    if (entrypoint) {
+      yield { installDir: fullPath, entrypointPath: entrypoint };
+    }
+  }
+}
+
+/**
  * Patchwork recipes HTTP surface — reads installed recipes from disk so the
  * dashboard Recipes page can list what's available. The bridge does not yet
  * run recipes natively; this endpoint is strictly read-only today.
@@ -238,6 +333,23 @@ function resolveJsonRecipePathByName(
     return null;
   }
 
+  // Also search install dirs from `recipeInstall`. Skips dirs with
+  // `.disabled` marker so the manual-fire / orchestrator path can't
+  // resolve a recipe the user has explicitly disabled.
+  for (const { entrypointPath } of iterateInstallDirs(recipesDir)) {
+    if (!entrypointPath.endsWith(".json")) continue;
+    try {
+      const parsed = JSON.parse(readFileSync(entrypointPath, "utf-8")) as {
+        name?: string;
+      };
+      if (parsed.name?.toLowerCase() === safeName) {
+        return entrypointPath;
+      }
+    } catch {
+      // skip malformed
+    }
+  }
+
   return null;
 }
 
@@ -353,7 +465,7 @@ export function deleteRecipeContent(
     return { ok: false, error: "Invalid recipe name" };
   }
   const base = path.resolve(recipesDir);
-  let target =
+  const target =
     findYamlRecipePath(recipesDir, safeName) ??
     resolveJsonRecipePathByName(recipesDir, safeName);
   if (!target) {
@@ -600,6 +712,23 @@ export function findYamlRecipePath(
     }
   }
 
+  // Also search install dirs from `recipeInstall`. Skips dirs with
+  // `.disabled` marker so the manual-fire / orchestrator path can't
+  // resolve a recipe the user has explicitly disabled.
+  for (const { entrypointPath } of iterateInstallDirs(recipesDir)) {
+    if (!/\.ya?ml$/i.test(entrypointPath)) continue;
+    try {
+      const parsed = parseYaml(readFileSync(entrypointPath, "utf-8")) as {
+        name?: string;
+      };
+      if (parsed.name?.toLowerCase() === safeName) {
+        return entrypointPath;
+      }
+    } catch {
+      // skip malformed
+    }
+  }
+
   return null;
 }
 
@@ -618,6 +747,7 @@ export function findWebhookRecipe(
   } catch {
     return null;
   }
+  // Pass 1 — top-level files (legacy)
   for (const f of entries) {
     const isYaml = f.endsWith(".yaml") || f.endsWith(".yml");
     const isJson = f.endsWith(".json") && !f.endsWith(".permissions.json");
@@ -635,6 +765,33 @@ export function findWebhookRecipe(
           name: parsed.name ?? path.basename(f, path.extname(f)),
           path: requestPath,
           filePath,
+          format: isYaml ? "yaml" : "json",
+        };
+      }
+    } catch {
+      // skip malformed
+    }
+  }
+  // Pass 2 — install dirs (skips dirs marked .disabled).
+  for (const { entrypointPath } of iterateInstallDirs(recipesDir)) {
+    const ext = path.extname(entrypointPath).toLowerCase();
+    const isYaml = ext === ".yaml" || ext === ".yml";
+    const isJson = ext === ".json";
+    if (!isYaml && !isJson) continue;
+    try {
+      const raw = readFileSync(entrypointPath, "utf-8");
+      const parsed = (isYaml ? parseYaml(raw) : JSON.parse(raw)) as {
+        name?: string;
+        trigger?: { type?: string; path?: string };
+      };
+      if (parsed.trigger?.type !== "webhook") continue;
+      if (parsed.trigger.path === requestPath) {
+        return {
+          name:
+            parsed.name ??
+            path.basename(entrypointPath, path.extname(entrypointPath)),
+          path: requestPath,
+          filePath: entrypointPath,
           format: isYaml ? "yaml" : "json",
         };
       }


### PR DESCRIPTION
## Summary

Closes **Bug #1** from the 2026-04-28 audit — the highest-impact remaining semantic gap. PR #43 wired \`.disabled\` enforcement into the cron scheduler, but webhook and manual-fire paths still ignored it. Also closes the silent visibility bug: install-dir recipes were *invisible* to webhook + manual paths entirely.

## Two bugs in one PR (they're inseparable)

**Visibility.** \`findWebhookRecipe\`, \`findYamlRecipePath\`, and \`resolveJsonRecipePathByName\` only scanned top-level files. Recipes installed via \`runRecipeInstall\` (which puts each recipe in its own subdir) were not reachable from webhook + manual paths — only the scheduler saw them after PR #43. Now all three search functions iterate install dirs as a second pass.

**Enforcement.** Even when the search functions could see install-dir recipes (after the visibility fix), they had no \`.disabled\` check. A new \`iterateInstallDirs\` helper skips any subdir with the marker, and both passes share this gating. \`recipe disable foo\` now actually stops webhook and manual triggers — matching what the CLI promised.

## What changes

- [src/recipesHttp.ts](src/recipesHttp.ts):
  - New \`isRecipeFileEnabled(filePath, recipesDir)\` (exported) — walks up to find install dir, checks marker
  - New private \`iterateInstallDirs(recipesDir)\` generator — yields enabled install dirs and their entrypoints
  - \`findWebhookRecipe\` extended with second pass over install dirs
  - \`findYamlRecipePath\` extended with second pass over install dirs
  - \`resolveJsonRecipePathByName\` extended with second pass over install dirs
- [src/__tests__/disabled-marker-enforcement.test.ts](src/__tests__/disabled-marker-enforcement.test.ts) — 8 new tests

## Bug-fix protocol

3 of the 8 new tests failed on \`main\` before this fix (the visibility tests). After the fix, all 8 pass. Existing 33 webhook tests untouched.

## Test plan

- [x] \`npx vitest run src/__tests__/disabled-marker-enforcement.test.ts\` → 8/8 passing
- [x] \`npx vitest run src/__tests__/webhookRecipes.test.ts\` → 33/33 (existing) passing
- [x] Full sweep — 4187 passing, 0 failed
- [x] \`getDiagnostics\` clean

## Out of scope (next PR)

The automation interpreter (\`onFileSave\`, \`onGitCommit\`, etc.) also needs to consult the marker before triggering. Same pattern as this PR — call \`isRecipeFileEnabled\` before invoking the recipe.

Bug #2 from the audit (dashboard ↔ CLI disabled-state systems are unconnected) is also a separate follow-up — needs the dashboard \`Disable\` button to write the marker via \`runRecipeDisable\`, and \`listInstalledRecipes\` to report both signals.