### PR TITLE
fix(recipes): unify dashboard ↔ CLI disabled-state systems (Bug #2 — re-open)

### DIFF
--- a/src/__tests__/dashboard-cli-state-unification.test.ts
+++ b/src/__tests__/dashboard-cli-state-unification.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Tests for dashboard ↔ CLI disabled-state unification (Bug #2 from the
+ * 2026-04-28 audit).
+ *
+ * Two systems coexisted:
+ *   - **Legacy config**: `cfg.recipes.disabled` array — written by the
+ *     dashboard "Disable" button (`setRecipeEnabledFn` in
+ *     `recipeOrchestration.ts`), read by `listInstalledRecipes`.
+ *   - **Per-install marker**: `.disabled` file inside each install dir —
+ *     written by CLI `recipe enable/disable`, read by scheduler + (PR #49)
+ *     webhook + manual-fire paths.
+ *
+ * Neither read the other. So clicking "Disable" in the dashboard for an
+ * install-dir recipe wrote a name to the config that nothing checked.
+ *
+ * After the fix, the routing is:
+ *   - `setRecipeEnabled(name)` finds the install dir if any and writes
+ *     the marker; falls back to legacy config for top-level files.
+ *   - `listInstalledRecipes` reports `enabled` from whichever system
+ *     applies to that recipe (or AND for safety — disabled in either =
+ *     disabled).
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { listInstalledRecipes, setRecipeEnabled } from "../recipesHttp.js";
+
+let tmp: string;
+
+beforeEach(() => {
+  tmp = mkdtempSync(path.join(os.tmpdir(), "patchwork-state-unify-"));
+});
+
+afterEach(() => {
+  if (tmp && existsSync(tmp)) {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+function writeInstallDirRecipe(
+  dirName: string,
+  name: string,
+  opts: { disabled?: boolean } = {},
+) {
+  const dir = path.join(tmp, dirName);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    path.join(dir, "main.yaml"),
+    [
+      `name: ${name}`,
+      "trigger:",
+      "  type: manual",
+      "steps:",
+      "  - id: main",
+      "    agent: true",
+      "    prompt: x",
+    ].join("\n"),
+  );
+  if (opts.disabled) {
+    writeFileSync(path.join(dir, ".disabled"), "");
+  }
+}
+
+function writeTopLevelRecipe(filename: string, name: string) {
+  writeFileSync(
+    path.join(tmp, filename),
+    JSON.stringify({
+      name,
+      version: "1",
+      trigger: { type: "manual" },
+      steps: [{ id: "main", agent: true, prompt: "x" }],
+    }),
+  );
+}
+
+describe("setRecipeEnabled — install-dir recipe writes marker", () => {
+  it("disabling an install-dir recipe writes the .disabled marker", () => {
+    writeInstallDirRecipe("morning-pkg", "morning-brief");
+
+    const result = setRecipeEnabled("morning-brief", false, {
+      recipesDir: tmp,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(existsSync(path.join(tmp, "morning-pkg", ".disabled"))).toBe(true);
+  });
+
+  it("enabling an install-dir recipe removes the .disabled marker", () => {
+    writeInstallDirRecipe("morning-pkg", "morning-brief", { disabled: true });
+
+    const result = setRecipeEnabled("morning-brief", true, {
+      recipesDir: tmp,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(existsSync(path.join(tmp, "morning-pkg", ".disabled"))).toBe(false);
+  });
+
+  it("disabling an install-dir recipe is idempotent", () => {
+    writeInstallDirRecipe("morning-pkg", "morning-brief", { disabled: true });
+
+    const result = setRecipeEnabled("morning-brief", false, {
+      recipesDir: tmp,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(existsSync(path.join(tmp, "morning-pkg", ".disabled"))).toBe(true);
+  });
+});
+
+describe("listInstalledRecipes — install-dir recipes report enabled state from marker", () => {
+  it("reports enabled=true for an install-dir recipe with no marker", () => {
+    writeInstallDirRecipe("morning-pkg", "morning-brief");
+    const list = listInstalledRecipes(tmp);
+    const entry = list.recipes.find((r) => r.name === "morning-brief");
+    expect(entry).toBeDefined();
+    expect(entry?.enabled).toBe(true);
+  });
+
+  it("reports enabled=false for an install-dir recipe with .disabled marker", () => {
+    writeInstallDirRecipe("morning-pkg", "morning-brief", { disabled: true });
+    const list = listInstalledRecipes(tmp);
+    const entry = list.recipes.find((r) => r.name === "morning-brief");
+    expect(entry).toBeDefined();
+    expect(entry?.enabled).toBe(false);
+  });
+
+  it("install-dir recipes still appear in the list (visibility regression check)", () => {
+    writeInstallDirRecipe("standup-pkg", "standup-digest");
+    const list = listInstalledRecipes(tmp);
+    expect(list.recipes.some((r) => r.name === "standup-digest")).toBe(true);
+  });
+
+  it("top-level legacy recipes still report enabled=true by default", () => {
+    writeTopLevelRecipe("legacy.json", "legacy-recipe");
+    const list = listInstalledRecipes(tmp);
+    const entry = list.recipes.find((r) => r.name === "legacy-recipe");
+    expect(entry?.enabled).toBe(true);
+  });
+});

--- a/src/recipeOrchestration.ts
+++ b/src/recipeOrchestration.ts
@@ -9,10 +9,6 @@ import path from "node:path";
 import { parse as parseYaml } from "yaml";
 import { recordRecipeRun } from "./activationMetrics.js";
 import type { ClaudeOrchestrator } from "./claudeOrchestrator.js";
-import {
-  loadConfig as loadPatchworkConfig,
-  saveConfig as savePatchworkConfig,
-} from "./patchworkConfig.js";
 import type { RecipeOrchestrator } from "./recipes/RecipeOrchestrator.js";
 import type {
   SchedulerEnqueue,
@@ -30,6 +26,7 @@ import {
   renderWebhookPrompt,
   saveRecipe,
   saveRecipeContent,
+  setRecipeEnabled,
 } from "./recipesHttp.js";
 import type { RecipeRunLog } from "./runLog.js";
 import type { Server } from "./server.js";
@@ -122,28 +119,14 @@ export class RecipeOrchestration {
     };
 
     server.setRecipeEnabledFn = (name: string, enabled: boolean) => {
-      try {
-        const cfg = loadPatchworkConfig();
-        const disabled = new Set<string>(
-          (cfg as { recipes?: { disabled?: string[] } }).recipes?.disabled ??
-            [],
-        );
-        if (enabled) disabled.delete(name);
-        else disabled.add(name);
-        savePatchworkConfig({
-          ...cfg,
-          recipes: {
-            ...(cfg as { recipes?: Record<string, unknown> }).recipes,
-            disabled: [...disabled],
-          },
-        } as Parameters<typeof savePatchworkConfig>[0]);
-        return { ok: true };
-      } catch (err) {
-        return {
-          ok: false,
-          error: err instanceof Error ? err.message : String(err),
-        };
-      }
+      // Routes through `setRecipeEnabled` (recipesHttp.ts) which writes the
+      // per-install `.disabled` marker for marketplace-installed recipes
+      // and falls back to the legacy `cfg.recipes.disabled` config list
+      // for top-level legacy files. Both surfaces (CLI + dashboard) now
+      // converge on the same enable/disable semantics — fixes Bug #2 from
+      // the 2026-04-28 audit where the dashboard "Disable" button silently
+      // did nothing for install-dir recipes.
+      return setRecipeEnabled(name, enabled);
     };
 
     server.runsFn = (q: {

--- a/src/recipesHttp.ts
+++ b/src/recipesHttp.ts
@@ -7,6 +7,7 @@ import {
   statSync,
   writeFileSync,
 } from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { parse as parseYaml } from "yaml";
 import { loadConfig } from "./patchworkConfig.js";
@@ -60,7 +61,9 @@ export function isRecipeFileEnabled(
  */
 function* iterateInstallDirs(
   recipesDir: string,
-): Generator<{ installDir: string; entrypointPath: string }> {
+  options: { includeDisabled?: boolean } = {},
+): Generator<{ installDir: string; entrypointPath: string; enabled: boolean }> {
+  const includeDisabled = options.includeDisabled === true;
   let entries: string[];
   try {
     entries = readdirSync(recipesDir);
@@ -76,7 +79,8 @@ function* iterateInstallDirs(
       continue;
     }
     if (!isDir) continue;
-    if (existsSync(path.join(fullPath, DISABLED_MARKER))) continue;
+    const enabled = !existsSync(path.join(fullPath, DISABLED_MARKER));
+    if (!enabled && !includeDisabled) continue;
 
     let entrypoint: string | null = null;
     const manifestPath = path.join(fullPath, "recipe.json");
@@ -102,8 +106,106 @@ function* iterateInstallDirs(
       }
     }
     if (entrypoint) {
-      yield { installDir: fullPath, entrypointPath: entrypoint };
+      yield { installDir: fullPath, entrypointPath: entrypoint, enabled };
     }
+  }
+}
+
+/**
+ * Locate an install dir by the *recipe name* declared inside its entrypoint
+ * (not the directory name). The dashboard reports recipes by the parsed
+ * `name` field, while `runRecipeEnable` looks them up by dir name —
+ * the two are usually different (`morning-pkg` vs `morning-brief`). Includes
+ * disabled dirs so re-enabling actually finds them.
+ */
+function findInstallDirByRecipeName(
+  recipesDir: string,
+  name: string,
+): string | null {
+  for (const { installDir, entrypointPath } of iterateInstallDirs(recipesDir, {
+    includeDisabled: true,
+  })) {
+    try {
+      const ext = path.extname(entrypointPath).toLowerCase();
+      const raw = readFileSync(entrypointPath, "utf-8");
+      const parsed = (ext === ".json" ? JSON.parse(raw) : parseYaml(raw)) as {
+        name?: string;
+      };
+      if (parsed.name === name) return installDir;
+    } catch {
+      // skip malformed
+    }
+  }
+  return null;
+}
+
+/**
+ * Unified enable/disable for install-dir AND legacy top-level recipes.
+ *
+ * Routing:
+ *   1. Try to find an install dir whose entrypoint declares this `name`.
+ *      If found, write/remove the `.disabled` marker on that dir. This
+ *      matches CLI `recipe enable/disable` and the trigger-side
+ *      enforcement landed in PRs #43 / #49.
+ *   2. Otherwise the recipe is a top-level legacy file — fall back to
+ *      the legacy `cfg.recipes.disabled` config-file array, which the
+ *      scheduler already honors as a parallel mechanism (it checks both).
+ *
+ * Replaces the old dashboard-only `setRecipeEnabledFn` that wrote ONLY to
+ * the legacy config — which silently did nothing for install-dir recipes.
+ */
+export function setRecipeEnabled(
+  name: string,
+  enabled: boolean,
+  options: {
+    recipesDir?: string;
+    loadConfigFn?: typeof loadConfig;
+    saveConfigFn?: (cfg: unknown) => void;
+  } = {},
+): { ok: boolean; error?: string } {
+  const recipesDir =
+    options.recipesDir ?? path.join(os.homedir(), ".patchwork", "recipes");
+
+  try {
+    const installDir = findInstallDirByRecipeName(recipesDir, name);
+    if (installDir) {
+      const markerPath = path.join(installDir, DISABLED_MARKER);
+      if (enabled) {
+        if (existsSync(markerPath)) rmSync(markerPath);
+      } else {
+        writeFileSync(markerPath, "");
+      }
+      return { ok: true };
+    }
+
+    // Legacy top-level path — fall back to config-file disabled list
+    const cfg = (options.loadConfigFn ?? loadConfig)();
+    const disabled = new Set<string>(
+      (cfg as { recipes?: { disabled?: string[] } }).recipes?.disabled ?? [],
+    );
+    if (enabled) disabled.delete(name);
+    else disabled.add(name);
+    const next = {
+      ...(cfg as object),
+      recipes: {
+        ...((cfg as { recipes?: Record<string, unknown> }).recipes ?? {}),
+        disabled: [...disabled],
+      },
+    };
+    if (options.saveConfigFn) options.saveConfigFn(next);
+    else {
+      // Dynamic import to avoid coupling at module-load time and to keep
+      // tests able to swap the saver via options.saveConfigFn.
+      // biome-ignore lint/suspicious/noExplicitAny: dynamic require shape
+      const mod = require("./patchworkConfig.js");
+      mod.savePatchworkConfig(next);
+    }
+    return { ok: true };
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
   }
 }
 
@@ -651,6 +753,8 @@ export function listInstalledRecipes(recipesDir: string): ListRecipesResult {
         installedAt: stat.mtimeMs,
         hasPermissions,
         source,
+        // Top-level legacy recipes don't have install dirs to put a marker
+        // in, so the `enabled` field still comes from the legacy config list.
         enabled: !disabledSet.has(parsedName),
         ...(Array.isArray(parsed.vars) && parsed.vars.length > 0
           ? { vars: parsed.vars }
@@ -664,6 +768,87 @@ export function listInstalledRecipes(recipesDir: string): ListRecipesResult {
       });
     } catch {
       // skip malformed recipe file
+    }
+  }
+
+  // Second pass — recipes installed via `runRecipeInstall` into subdirs.
+  // `enabled` reflects the per-install `.disabled` marker; the legacy
+  // config disabled list is a top-level concern (we still apply it as a
+  // safety belt in case a name collides).
+  for (const {
+    installDir,
+    entrypointPath,
+    enabled: installEnabled,
+  } of iterateInstallDirs(recipesDir, { includeDisabled: true })) {
+    try {
+      const ext = path.extname(entrypointPath).toLowerCase();
+      const isYaml = ext === ".yaml" || ext === ".yml";
+      const isJson = ext === ".json";
+      if (!isYaml && !isJson) continue;
+
+      const raw = readFileSync(entrypointPath, "utf-8");
+      const parsed = (isYaml ? parseYaml(raw) : JSON.parse(raw)) as {
+        name?: string;
+        description?: string;
+        trigger?: { type?: string; path?: string };
+        steps?: unknown[];
+        vars?: Array<{
+          name: string;
+          description?: string;
+          required?: boolean;
+          default?: string;
+        }>;
+      };
+      const stat = statSync(entrypointPath);
+      const parsedName =
+        parsed.name ??
+        path.basename(entrypointPath, path.extname(entrypointPath));
+      const lintRes = validateRecipeDefinition(parsed);
+      let errCount = 0;
+      let warnCount = 0;
+      let firstError: string | undefined;
+      for (const issue of lintRes.issues) {
+        if (issue.level === "error") {
+          errCount++;
+          if (!firstError) firstError = issue.message;
+        } else {
+          warnCount++;
+        }
+      }
+      const webhookPath =
+        parsed.trigger?.type === "webhook" &&
+        typeof parsed.trigger?.path === "string"
+          ? parsed.trigger.path
+          : undefined;
+      recipes.push({
+        name: parsedName,
+        description: parsed.description,
+        trigger: parsed.trigger?.type,
+        ...(webhookPath ? { webhookPath } : {}),
+        stepCount: Array.isArray(parsed.steps) ? parsed.steps.length : 0,
+        path: entrypointPath,
+        installedAt: stat.mtimeMs,
+        hasPermissions: false,
+        source: "user",
+        // Disabled if EITHER the install marker is set OR the legacy config
+        // names this recipe — defence-in-depth so a stale config entry can't
+        // accidentally re-enable a recipe the user explicitly disabled, and
+        // the dashboard can't accidentally enable one disabled by an admin
+        // through the legacy file.
+        enabled: installEnabled && !disabledSet.has(parsedName),
+        ...(Array.isArray(parsed.vars) && parsed.vars.length > 0
+          ? { vars: parsed.vars }
+          : {}),
+        lint: {
+          ok: errCount === 0,
+          errorCount: errCount,
+          warningCount: warnCount,
+          ...(firstError ? { firstError } : {}),
+        },
+      });
+      void installDir;
+    } catch {
+      // skip malformed install dir
     }
   }
 


### PR DESCRIPTION
## Summary

Re-opens PR #50, whose diff was dropped on main when PR #49 squash-merged. Same content as #50 — cherry-picked onto current main.

The squash-merge of #49 collapsed both #49's and #50's commits into a single squash commit on main, and that squash commit only contained #49's diff. The PR API still reports #50 as "merged" (it merged into the now-deleted stacked branch), but the dashboard ↔ CLI unification was never actually applied to main.

## What this PR adds (same as #50)

| Layer | Change |
|---|---|
| Dashboard "Disable" button | Routes through marker for install-dir recipes (was: silently wrote to legacy config that nothing read) |
| \`listInstalledRecipes\` | Second pass over install dirs; reports correct \`enabled\` state |
| \`recipeOrchestration\` | \`setRecipeEnabledFn\` delegates to new helper |

7 tests in [src/__tests__/dashboard-cli-state-unification.test.ts](src/__tests__/dashboard-cli-state-unification.test.ts), all passing.

## Test plan

- [x] \`npx vitest run src/__tests__/dashboard-cli-state-unification.test.ts\` → 7/7 passing
- [x] Full sweep — 4194 passing, 0 failed
- [x] Cherry-picked cleanly from \`a62704a\` (the original #50 commit)

## Lesson

For future stacked PRs: merge the bottom of the stack first, then *rebase* (not just retarget) the upper PR onto main before merging. GitHub's auto-retargeting alone isn't enough — squash-merging the base PR drops the upper PR's diff.