### PR TITLE
feat(recipe): add `recipe uninstall` and fix reinstall correctness

### DIFF
--- a/src/commands/__tests__/recipeUninstallReinstall.test.ts
+++ b/src/commands/__tests__/recipeUninstallReinstall.test.ts
@@ -1,0 +1,226 @@
+/**
+ * Tests for `recipe uninstall` (missing-feature follow-up to PR #42) and
+ * reinstall correctness (Bug #3 from the 2026-04-28 audit).
+ *
+ * Reinstall correctness fixes:
+ *   - Files from a previous version that the new manifest no longer declares
+ *     are LEFT BEHIND today. They should be cleared.
+ *   - `.disabled` marker is rewritten unconditionally on reinstall, which
+ *     re-disables a recipe the user had explicitly enabled. Reinstall should
+ *     preserve the existing enabled state.
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  isRecipeEnabled,
+  runRecipeInstall,
+  runRecipeUninstall,
+} from "../recipeInstall.js";
+
+let recipesRoot: string;
+let srcRoot: string;
+
+beforeEach(() => {
+  recipesRoot = mkdtempSync(path.join(os.tmpdir(), "patchwork-uninstall-"));
+  srcRoot = mkdtempSync(path.join(os.tmpdir(), "patchwork-uninstall-src-"));
+});
+
+afterEach(() => {
+  for (const d of [recipesRoot, srcRoot]) {
+    if (d && existsSync(d)) rmSync(d, { recursive: true, force: true });
+  }
+});
+
+function writeSrcRecipe(
+  files: Record<string, string>,
+  manifest?: {
+    name: string;
+    version: string;
+    description: string;
+    recipes: { main: string; children?: string[] };
+  },
+) {
+  const dir = mkdtempSync(path.join(srcRoot, "pkg-"));
+  for (const [name, content] of Object.entries(files)) {
+    writeFileSync(path.join(dir, name), content);
+  }
+  if (manifest) {
+    writeFileSync(path.join(dir, "recipe.json"), JSON.stringify(manifest));
+  }
+  return dir;
+}
+
+describe("runRecipeUninstall", () => {
+  it("removes the install dir and all its files", async () => {
+    const src = writeSrcRecipe({ "main.yaml": "name: x\nsteps: []\n" });
+    const result = await runRecipeInstall(src, { recipesDir: recipesRoot });
+    expect(existsSync(result.installDir)).toBe(true);
+
+    const r = runRecipeUninstall(result.name, { recipesDir: recipesRoot });
+    expect(r.ok).toBe(true);
+    expect(existsSync(result.installDir)).toBe(false);
+  });
+
+  it("returns ok:false with a clear error when the recipe is not installed", () => {
+    const r = runRecipeUninstall("nonexistent-recipe", {
+      recipesDir: recipesRoot,
+    });
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/No installed recipe/);
+  });
+
+  it("rejects path-traversal in name", () => {
+    expect(() =>
+      runRecipeUninstall("../../../etc", { recipesDir: recipesRoot }),
+    ).toThrow();
+  });
+
+  it("returns the removed install dir path", async () => {
+    const src = writeSrcRecipe({ "main.yaml": "name: x\nsteps: []\n" });
+    const inst = await runRecipeInstall(src, { recipesDir: recipesRoot });
+
+    const r = runRecipeUninstall(inst.name, { recipesDir: recipesRoot });
+    expect(r.ok).toBe(true);
+    expect(r.installDir).toBe(inst.installDir);
+  });
+});
+
+describe("runRecipeInstall — reinstall correctness", () => {
+  it("removes files from the prior version that the new manifest doesn't declare", async () => {
+    // First install: declares main.yaml + extra-old.yaml
+    const v1 = writeSrcRecipe(
+      {
+        "main.yaml": "name: x\nsteps: []\n",
+        "extra-old.yaml": "name: x-old\nsteps: []\n",
+      },
+      {
+        name: "evolving-pkg",
+        version: "1.0.0",
+        description: "v1",
+        recipes: { main: "main.yaml", children: ["extra-old.yaml"] },
+      },
+    );
+    const inst1 = await runRecipeInstall(v1, { recipesDir: recipesRoot });
+    expect(existsSync(path.join(inst1.installDir, "extra-old.yaml"))).toBe(
+      true,
+    );
+
+    // Second install: declares main.yaml + extra-new.yaml (NOT extra-old)
+    const v2 = writeSrcRecipe(
+      {
+        "main.yaml": "name: x\nsteps: []\n",
+        "extra-new.yaml": "name: x-new\nsteps: []\n",
+      },
+      {
+        name: "evolving-pkg",
+        version: "2.0.0",
+        description: "v2",
+        recipes: { main: "main.yaml", children: ["extra-new.yaml"] },
+      },
+    );
+    const inst2 = await runRecipeInstall(v2, { recipesDir: recipesRoot });
+
+    expect(inst2.installDir).toBe(inst1.installDir);
+    expect(existsSync(path.join(inst2.installDir, "extra-new.yaml"))).toBe(
+      true,
+    );
+    expect(existsSync(path.join(inst2.installDir, "extra-old.yaml"))).toBe(
+      false,
+    );
+  });
+
+  it("preserves the enabled state on reinstall (was: re-disables every time)", async () => {
+    // Manifest gives both versions the same install-dir name so it's a true reinstall.
+    const stableManifest = (version: string) => ({
+      name: "stable-pkg",
+      version,
+      description: "stable",
+      recipes: { main: "main.yaml" },
+    });
+
+    const v1 = writeSrcRecipe(
+      { "main.yaml": "name: x\nsteps: []\n" },
+      stableManifest("1.0.0"),
+    );
+    const inst1 = await runRecipeInstall(v1, { recipesDir: recipesRoot });
+    expect(isRecipeEnabled(inst1.installDir)).toBe(false); // fresh install starts disabled
+
+    // User enables it
+    rmSync(path.join(inst1.installDir, ".disabled"));
+    expect(isRecipeEnabled(inst1.installDir)).toBe(true);
+
+    // Reinstall (upgrade)
+    const v2 = writeSrcRecipe(
+      { "main.yaml": "name: x\nsteps: []\nversion: 2\n" },
+      stableManifest("2.0.0"),
+    );
+    const inst2 = await runRecipeInstall(v2, { recipesDir: recipesRoot });
+
+    // Same install dir, enabled state preserved — user opted in and upgrade
+    // shouldn't silently revoke that.
+    expect(inst2.installDir).toBe(inst1.installDir);
+    expect(isRecipeEnabled(inst2.installDir)).toBe(true);
+  });
+
+  it("preserves the disabled state on reinstall (idempotent)", async () => {
+    const stableManifest = (version: string) => ({
+      name: "stable-pkg-2",
+      version,
+      description: "stable2",
+      recipes: { main: "main.yaml" },
+    });
+
+    const v1 = writeSrcRecipe(
+      { "main.yaml": "name: x\nsteps: []\n" },
+      stableManifest("1.0.0"),
+    );
+    const inst1 = await runRecipeInstall(v1, { recipesDir: recipesRoot });
+    expect(isRecipeEnabled(inst1.installDir)).toBe(false);
+
+    const v2 = writeSrcRecipe(
+      { "main.yaml": "name: x\nsteps: []\n" },
+      stableManifest("2.0.0"),
+    );
+    const inst2 = await runRecipeInstall(v2, { recipesDir: recipesRoot });
+    expect(inst2.installDir).toBe(inst1.installDir);
+    expect(isRecipeEnabled(inst2.installDir)).toBe(false);
+  });
+
+  it("a fresh install (different name) still defaults to disabled", async () => {
+    const src = writeSrcRecipe({ "main.yaml": "name: x\nsteps: []\n" });
+    const inst = await runRecipeInstall(src, { recipesDir: recipesRoot });
+    expect(isRecipeEnabled(inst.installDir)).toBe(false);
+  });
+
+  it("reinstall doesn't leave .disabled-like residue files unrelated to the marker", async () => {
+    // Edge case: recipe declares a file literally named ".disabled" as a child.
+    // We only treat the marker file as state; declared files should be copied
+    // and survive uninstall→reinstall.
+    const v1 = writeSrcRecipe(
+      { "main.yaml": "name: x\nsteps: []\n" },
+      {
+        name: "edge-pkg",
+        version: "1.0.0",
+        description: "edge",
+        recipes: { main: "main.yaml" },
+      },
+    );
+    const inst = await runRecipeInstall(v1, { recipesDir: recipesRoot });
+    // After install, the .disabled marker is from runRecipeInstall, not the
+    // package — good.
+    const before = readdirSync(inst.installDir).sort();
+    expect(before).toContain(".disabled");
+    expect(before).toContain("recipe.json");
+    expect(before).toContain("main.yaml");
+  });
+});

--- a/src/commands/recipeInstall.ts
+++ b/src/commands/recipeInstall.ts
@@ -383,9 +383,25 @@ export async function runRecipeInstall(
     const installName = determineInstallName(manifest, source);
     const installDir = path.join(recipesDir, installName);
 
-    if (!existsSync(installDir)) {
-      mkdirSync(installDir, { recursive: true });
+    // Reinstall correctness: detect whether this is an upgrade in place,
+    // and snapshot the existing enabled state so the upgrade doesn't
+    // silently re-disable a recipe the user explicitly opted into.
+    const isReinstall = existsSync(installDir);
+    const wasEnabled = isReinstall
+      ? !existsSync(path.join(installDir, DISABLED_MARKER))
+      : false;
+
+    if (isReinstall) {
+      // Clear stale files from the previous version so files dropped from
+      // the new manifest don't linger. We rebuild the install dir wholesale
+      // rather than overlay the new files on top of the old.
+      try {
+        rmSync(installDir, { recursive: true, force: true });
+      } catch {
+        // best-effort; mkdirSync below will throw with a clearer error
+      }
     }
+    mkdirSync(installDir, { recursive: true });
 
     // Copy files
     for (const file of filesToCopy) {
@@ -399,11 +415,14 @@ export async function runRecipeInstall(
       cpSync(src, dest);
     }
 
-    // New installs start disabled — user must run `recipe enable <name>`
-    // before scheduled triggers (cron/file-watch) take effect. Manual
-    // `recipe run <name>` still works regardless, since that's an explicit
-    // user invocation.
-    writeFileSync(path.join(installDir, DISABLED_MARKER), "");
+    // Write the disabled-marker policy:
+    //   - Fresh install: start disabled (per the wave2 plan's safety story).
+    //   - Reinstall (upgrade in place): preserve whatever the user had set.
+    //     If the recipe was enabled before, leave it enabled; if disabled,
+    //     leave it disabled. Don't silently revoke an explicit user opt-in.
+    if (!isReinstall || !wasEnabled) {
+      writeFileSync(path.join(installDir, DISABLED_MARKER), "");
+    }
 
     return {
       name: installName,
@@ -566,6 +585,30 @@ export function runRecipeDisable(
   }
   writeFileSync(markerPath, "");
   return { name, installDir, alreadyDisabled: false };
+}
+
+/**
+ * Uninstall a recipe — removes its install directory entirely.
+ *
+ * Returns `{ ok: false, error }` when the recipe isn't found rather than
+ * throwing, so the CLI can surface a clean error message instead of a
+ * stack trace. Path-traversal attempts in `name` still throw via
+ * `findInstalledRecipeDir`'s validator (HIGH-2 hardening from #46).
+ */
+export function runRecipeUninstall(
+  name: string,
+  options: { recipesDir?: string } = {},
+): { ok: boolean; installDir?: string; error?: string } {
+  const recipesDir = options.recipesDir ?? INSTALL_RECIPES_DIR;
+  const installDir = findInstalledRecipeDir(name, recipesDir);
+  if (!installDir) {
+    return {
+      ok: false,
+      error: `No installed recipe named "${name}". Run \`patchwork recipe list\` to see installed recipes.`,
+    };
+  }
+  rmSync(installDir, { recursive: true, force: true });
+  return { ok: true, installDir };
 }
 
 export function listInstalledRecipes(

--- a/src/index.ts
+++ b/src/index.ts
@@ -828,6 +828,39 @@ if (
   })();
 }
 
+// Patchwork: `patchwork recipe uninstall <name>` — remove an installed recipe
+// directory and all its files. Sister to `recipe install`. Idempotent on
+// success (subsequent uninstalls error with "no installed recipe").
+if (process.argv[2] === "recipe" && process.argv[3] === "uninstall") {
+  const name = process.argv[4];
+  if (!name) {
+    process.stderr.write(
+      "Usage: patchwork recipe uninstall <name>\n" +
+        "  See `patchwork recipe list` for installed recipe names.\n",
+    );
+    process.exit(1);
+  }
+  (async () => {
+    try {
+      const { runRecipeUninstall } = await import(
+        "./commands/recipeInstall.js"
+      );
+      const r = runRecipeUninstall(name);
+      if (!r.ok) {
+        process.stderr.write(`Error: ${r.error}\n`);
+        process.exit(1);
+      }
+      process.stdout.write(`  ✓ Uninstalled ${name} (${r.installDir})\n`);
+      process.exit(0);
+    } catch (err) {
+      process.stderr.write(
+        `Error: ${err instanceof Error ? err.message : String(err)}\n`,
+      );
+      process.exit(1);
+    }
+  })();
+}
+
 // Patchwork: `patchwork recipe run <name>` — runs a recipe locally or via
 // a running bridge's /recipes/run endpoint if one is available.
 if (process.argv[2] === "recipe" && process.argv[3] === "run") {


### PR DESCRIPTION
## Summary

Two HIGH-severity items from the 2026-04-28 audit, both in the recipe install lifecycle.

| ID | Issue | Fix |
|---|---|---|
| Missing \`recipe uninstall\` | No way to remove an installed recipe — users \`rm -rf\`'d manually | New \`runRecipeUninstall(name)\` + CLI \`patchwork recipe uninstall <name>\` |
| Bug #3 stale files on reinstall | \`runRecipeInstall\` on existing dir overlaid new files; old ones lingered | Wipe install dir wholesale, then copy new files |
| Bug #3 marker overwrite on reinstall | Reinstall always wrote \`.disabled\` marker, silently re-disabling a previously-enabled recipe | Snapshot enabled state pre-teardown; restore marker only if was disabled |

## Behaviour matrix

| Pre-state | After reinstall |
|---|---|
| Fresh install (no prior) | starts disabled (per the wave2 spec) |
| Was enabled (no marker) | stays enabled — user opted in, upgrade doesn't revoke |
| Was disabled (marker present) | stays disabled |

## Files

- [src/commands/recipeInstall.ts](src/commands/recipeInstall.ts) — \`runRecipeUninstall\` + reinstall snapshot/restore
- [src/index.ts](src/index.ts) — CLI dispatch for \`recipe uninstall <name>\`
- [src/commands/__tests__/recipeUninstallReinstall.test.ts](src/commands/__tests__/recipeUninstallReinstall.test.ts) — 9 new tests

## Bug-fix protocol

5 of 9 new tests failed on \`main\` before the fix (the reinstall + uninstall behaviours). After fix, all 9 pass.

## Test plan

- [x] \`npx vitest run src/commands/__tests__/recipeUninstallReinstall.test.ts\` → 9/9 passing
- [x] Existing install + enable/disable tests untouched
- [x] Full sweep — 4196 passing, 0 failed
- [x] \`getDiagnostics\` clean

## Audit progress after this lands

| Severity | Open | Closed |
|---|---|---|
| CRIT | 0 | 2 |
| HIGH | 1 (Bug #1 + #2 still open as #51) | 6 |
| MED | 3 | 1 |