### PR TITLE
fix(security): lock kill-switch env reads at bridge startup (MED-2)

### DIFF
--- a/src/__tests__/featureFlags.envLock.test.ts
+++ b/src/__tests__/featureFlags.envLock.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Tests for the kill-switch env-lock fix (MED-2 from the 2026-04-28 audit).
+ *
+ * The kill switch was readable from `process.env` on every `isEnabled` call,
+ * letting any code running in the bridge process — including a malicious
+ * plugin or recipe step — flip
+ *   process.env.PATCHWORK_FLAG_KILL_SWITCH_WRITES = "0"
+ * to disable an active emergency stop.
+ *
+ * After the fix, the bridge calls `lockKillSwitchEnv()` at start. From that
+ * point on, `process.env` mutations for kill-switch flags are ignored —
+ * value is read from the snapshot taken at lock time.
+ *
+ * Tests use `_resetEnvLockForTesting()` to keep the existing dynamic-read
+ * test ergonomics intact for non-locked code paths.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  _resetEnvLockForTesting,
+  isEnabled,
+  KILL_SWITCH_WRITES,
+  lockKillSwitchEnv,
+  setFlag,
+} from "../featureFlags.js";
+
+const KILL_SWITCH_ENV = "PATCHWORK_FLAG_KILL_SWITCH_WRITES";
+
+beforeEach(() => {
+  delete process.env[KILL_SWITCH_ENV];
+  _resetEnvLockForTesting();
+});
+
+afterEach(() => {
+  delete process.env[KILL_SWITCH_ENV];
+  _resetEnvLockForTesting();
+});
+
+describe("MED-2: kill-switch env lock", () => {
+  it("without lock, env mutation flips kill switch dynamically (legacy behaviour)", () => {
+    expect(isEnabled(KILL_SWITCH_WRITES)).toBe(false);
+    process.env[KILL_SWITCH_ENV] = "1";
+    expect(isEnabled(KILL_SWITCH_WRITES)).toBe(true);
+    process.env[KILL_SWITCH_ENV] = "0";
+    expect(isEnabled(KILL_SWITCH_WRITES)).toBe(false);
+  });
+
+  it("after lock, the kill switch state is frozen at lock time", () => {
+    process.env[KILL_SWITCH_ENV] = "1";
+    lockKillSwitchEnv();
+
+    expect(isEnabled(KILL_SWITCH_WRITES)).toBe(true);
+
+    // attacker mutation attempt — ignored
+    process.env[KILL_SWITCH_ENV] = "0";
+    expect(isEnabled(KILL_SWITCH_WRITES)).toBe(true);
+
+    delete process.env[KILL_SWITCH_ENV];
+    expect(isEnabled(KILL_SWITCH_WRITES)).toBe(true);
+  });
+
+  it("after lock, env mutation cannot flip kill switch from off → on either", () => {
+    lockKillSwitchEnv();
+    expect(isEnabled(KILL_SWITCH_WRITES)).toBe(false);
+
+    // Plugin mutation: kill switch should stay off (env-locked).
+    process.env[KILL_SWITCH_ENV] = "1";
+    expect(isEnabled(KILL_SWITCH_WRITES)).toBe(false);
+  });
+
+  it("non-kill-switch flags are still dynamic post-lock (test-friendly)", () => {
+    lockKillSwitchEnv();
+    process.env.PATCHWORK_FLAG_UI_SCHEMA_LINT = "true";
+    expect(isEnabled("ui.schema-lint")).toBe(true);
+    process.env.PATCHWORK_FLAG_UI_SCHEMA_LINT = "false";
+    expect(isEnabled("ui.schema-lint")).toBe(false);
+    delete process.env.PATCHWORK_FLAG_UI_SCHEMA_LINT;
+  });
+
+  it("calling lockKillSwitchEnv twice is idempotent (second call doesn't re-snapshot)", () => {
+    process.env[KILL_SWITCH_ENV] = "1";
+    lockKillSwitchEnv();
+    expect(isEnabled(KILL_SWITCH_WRITES)).toBe(true);
+    process.env[KILL_SWITCH_ENV] = "0";
+    lockKillSwitchEnv();
+    expect(isEnabled(KILL_SWITCH_WRITES)).toBe(true);
+  });
+
+  it("setFlag still works post-lock (legitimate dashboard panic-button path)", () => {
+    lockKillSwitchEnv();
+    expect(isEnabled(KILL_SWITCH_WRITES)).toBe(false);
+
+    // Programmatic toggle (e.g., dashboard panic button) — must still work
+    // since it goes through the explicit setFlag API, not env mutation.
+    setFlag(KILL_SWITCH_WRITES, true);
+    expect(isEnabled(KILL_SWITCH_WRITES)).toBe(true);
+  });
+});

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -17,6 +17,7 @@ import type { Config } from "./config.js";
 import { DecisionTraceLog } from "./decisionTraceLog.js";
 import { createDriver } from "./drivers/index.js";
 import { ExtensionClient } from "./extensionClient.js";
+import { lockKillSwitchEnv } from "./featureFlags.js";
 import { FileLock } from "./fileLock.js";
 import { buildEnforcementReminder } from "./instructionsUtils.js";
 import { LockFileManager } from "./lockfile.js";
@@ -833,7 +834,12 @@ export class Bridge {
     // 0. Initialize OpenTelemetry (no-op when OTEL_EXPORTER_OTLP_ENDPOINT is unset)
     initTelemetry();
 
-    // 0a. Auto-repair .claude/rules/bridge-tools.md if stale (present but missing the
+    // 0a. Snapshot env-derived kill-switch flags. After this, plugins or
+    // recipe steps mutating `process.env.PATCHWORK_FLAG_*` cannot disable an
+    // active emergency stop. Closes MED-2 from the 2026-04-28 audit.
+    lockKillSwitchEnv();
+
+    // 0b. Auto-repair .claude/rules/bridge-tools.md if stale (present but missing the
     // current version sentinel). Older package versions write stale files that may
     // lack new tool substitution rules. Repair is silent on success; falls back to
     // warn-only if the template is missing or the write fails.

--- a/src/featureFlags.ts
+++ b/src/featureFlags.ts
@@ -57,16 +57,69 @@ export function registerFlag(flag: FeatureFlag): void {
 }
 
 /**
+ * Snapshot of env-derived kill-switch values, populated by `lockKillSwitchEnv()`
+ * at bridge startup. Once locked, kill-switch flags ignore live `process.env`
+ * mutations — defends against a plugin / recipe step trying to disable an
+ * active emergency stop by writing `process.env.PATCHWORK_FLAG_*`.
+ */
+const FROZEN_KILL_SWITCH_ENV: Map<string, boolean | undefined> = new Map();
+let envLocked = false;
+
+/**
+ * Snapshot the current `process.env` values for every registered kill-switch
+ * flag. Called once by `Bridge.start()` after `loadFlags()` so subsequent
+ * env mutations are ignored for kill-switch reads. Idempotent — second call
+ * is a no-op (would otherwise let an attacker re-snapshot a tampered env).
+ *
+ * Non-kill-switch flags remain dynamic so test infrastructure that mutates
+ * env per case continues to work.
+ */
+export function lockKillSwitchEnv(): void {
+  if (envLocked) return;
+  for (const [id, flag] of FLAG_REGISTRY.entries()) {
+    if (!flag.isKillSwitch) continue;
+    const envKey = `PATCHWORK_FLAG_${id.replace(/[.-]/g, "_").toUpperCase()}`;
+    const envVal = process.env[envKey];
+    FROZEN_KILL_SWITCH_ENV.set(
+      id,
+      envVal === undefined
+        ? undefined
+        : envVal === "1" || envVal.toLowerCase() === "true",
+    );
+  }
+  envLocked = true;
+}
+
+/**
+ * TEST ONLY — resets the env lock so tests can exercise both locked and
+ * unlocked paths without process restart. Do not call from production code.
+ */
+export function _resetEnvLockForTesting(): void {
+  envLocked = false;
+  FROZEN_KILL_SWITCH_ENV.clear();
+}
+
+/**
  * Check if a feature flag is enabled.
  * Resolution order (highest to lowest priority):
- *   1. Environment variable (PATCHWORK_FLAG_<ID>)
+ *   1. Environment variable (PATCHWORK_FLAG_<ID>) — frozen at `lockKillSwitchEnv()`
+ *      time for kill-switch flags so post-lock mutations are ignored
  *   2. User config file (~/.patchwork/config/flags.json)
  *   3. Default value from registration
  */
 export function isEnabled(flagId: string): boolean {
   // Check cache first
   if (FLAG_VALUES.has(flagId)) {
-    // Check environment override
+    const flag = FLAG_REGISTRY.get(flagId);
+    // Kill-switch flags read from the frozen snapshot once locked. This
+    // closes the gap where a plugin / recipe step could `process.env[...] = "0"`
+    // to disable an active emergency stop.
+    if (envLocked && flag?.isKillSwitch) {
+      const frozen = FROZEN_KILL_SWITCH_ENV.get(flagId);
+      if (frozen !== undefined) return frozen;
+      return FLAG_VALUES.get(flagId)!;
+    }
+    // Dynamic env read for non-kill-switch flags (test-friendly).
     const envKey = `PATCHWORK_FLAG_${flagId.replace(/[.-]/g, "_").toUpperCase()}`;
     const envVal = process.env[envKey];
     if (envVal !== undefined) {


### PR DESCRIPTION
## Summary

Closes MED-2 from the 2026-04-28 audit. \`isEnabled\` read \`process.env\` on every call, letting any code in the bridge process disable an active kill switch via simple JS assignment:

\`\`\`js
process.env.PATCHWORK_FLAG_KILL_SWITCH_WRITES = "0"; // no syscall, no privilege check
\`\`\`

## Fix

[\`Bridge.start()\`](src/bridge.ts) calls new \`lockKillSwitchEnv()\` once at startup. From that point:

- Kill-switch flags read from a frozen env snapshot taken at lock time
- Subsequent \`process.env.PATCHWORK_FLAG_*\` mutations are ignored for kill switches
- Legitimate panic-button path through \`setFlag()\` still works (explicit API, not env)
- Non-kill-switch flags remain env-dynamic (preserves test ergonomics)

## Why one-way

Lock is idempotent — a malicious second call can't re-snapshot a tampered env. Combined with the bridge's startup-only invocation, attackers post-init have no path to flip the lock.

## Files

- [src/featureFlags.ts](src/featureFlags.ts) — \`lockKillSwitchEnv()\` + \`_resetEnvLockForTesting()\` helper
- [src/bridge.ts](src/bridge.ts) — call \`lockKillSwitchEnv()\` at top of \`Bridge.start()\`
- [src/__tests__/featureFlags.envLock.test.ts](src/__tests__/featureFlags.envLock.test.ts) — 6 new tests

## Test plan

- [x] \`npx vitest run src/__tests__/featureFlags.envLock.test.ts\` → 6/6 passing
- [x] Existing 8 featureFlags + 5 toolRegistry kill-switch tests untouched
- [x] Full sweep — 4209 passing, 0 failed
- [x] \`getDiagnostics\` clean

## Audit progress after this lands

| Severity | Open | Closed |
|---|---|---|
| CRIT | 0 | 2 |
| HIGH | 0 | 7 |
| MED | 2 | 2 |

Remaining MED: scheduler silently swallows YAML parse errors; TOCTOU between scheduler scan and fire (just-disabled recipe still scheduled this cycle). Both small follow-ups in src/recipes/scheduler.ts.