### PR TITLE
fix(dashboard): inject basePath into NEXT_PUBLIC_BASE_PATH (DB-2)

### DIFF
--- a/dashboard/next.config.js
+++ b/dashboard/next.config.js
@@ -1,11 +1,20 @@
+const BASE_PATH = '/dashboard';
+
 const nextConfig = {
-  basePath: '/dashboard',
+  basePath: BASE_PATH,
   output: 'standalone',
+  // Surface basePath at runtime so client-side helpers (e.g. apiPath in
+  // src/lib/api.ts) can prefix bridge-API URLs correctly. Without this,
+  // every fetch goes to bare `/api/bridge/*` which 404s — the routes are
+  // mounted under basePath. Single source of truth: this file.
+  env: {
+    NEXT_PUBLIC_BASE_PATH: BASE_PATH,
+  },
   async redirects() {
     return [
       {
         source: '/',
-        destination: '/dashboard',
+        destination: BASE_PATH,
         permanent: false,
         basePath: false,
       },


### PR DESCRIPTION
## Summary

Closes DB-2 from the [dashboard fix plan](docs/plans/dashboard-fix-plan.md). Single-line fix to a multi-page bug.

## Diagnosis (followed v2.1 hypothesis ladder)

| Step | Finding |
|---|---|
| 0 | \`ps aux \| grep next\` → \`next dev -p 3200\`. Stale-build hypothesis from v1 was moot (\`next dev\` auto-recompiles). |
| 1 | \`curl /dashboard/api/bridge/runs\` → 200. \`curl /api/bridge/runs\` → 404. API IS at basePath. Frontend was calling without prefix. |
| 2 | [\`dashboard/src/lib/api.ts\`](dashboard/src/lib/api.ts) reads \`process.env.NEXT_PUBLIC_BASE_PATH ?? ""\`. Env var was unset → \`apiPath()\` returned bare paths. |

## Fix

Declared the env var in [\`dashboard/next.config.js\`](dashboard/next.config.js) as a single source of truth alongside the existing \`basePath\`:

\`\`\`js
const BASE_PATH = '/dashboard';

const nextConfig = {
  basePath: BASE_PATH,
  env: {
    NEXT_PUBLIC_BASE_PATH: BASE_PATH,  // ← new
  },
  // ...
};
\`\`\`

Next.js inlines the env var at build time, so all 26 \`apiPath()\` callers across the dashboard get the correct prefix without further changes.

## Verified by Playwright

- \`/dashboard/runs/2801\` (the visual-debugger surface) now loads the full step timeline. **CRIT-B from the dogfood pass is unblocked.**

## What this also unblocks

Per [docs/plans/punch-list.md](docs/plans/punch-list.md), DB-2 was the foundation for:
- VD-1 (visual-debugger live-tail) — the surface now exists to attach to
- IMM-1 (production deploy) — proxy needs to work for any non-trivial dashboard usage
- AI-1 (AI Recipe Builder) — calls dashboard API routes

## Out of scope (follow-up)

- **\`/dashboard/connections\`** still shows "Loading…" after this fix. \`/dashboard/api/connections\` returns valid JSON 200 but the page \`loading\` state doesn't transition. Different surface — render-side bug rather than network. Track as separate item.
- Browser PWA-detector still requests bare \`/manifest.json\` (no basePath) and 404s. Cosmetic, unrelated.

## Test plan

- [x] Dev server picked up next.config.js change automatically
- [x] \`curl /dashboard/api/bridge/runs\` → 200 + JSON
- [x] \`/dashboard/runs/2801\` loads with steps + execution plan tabs
- [x] 16 sidebar pages all reachable via Link navigation (basePath rewriting works)
- [x] Full project test sweep — 4213 passing, 0 failed (no backend changes; tests unchanged)