### PR TITLE
fix(runLog): read-on-miss for older seqs evicted from ring (DB-3)

### DIFF
--- a/src/__tests__/runLog.test.ts
+++ b/src/__tests__/runLog.test.ts
@@ -203,6 +203,63 @@ describe("RecipeRunLog.record", () => {
     expect(parsed.stepResults).toHaveLength(3);
   });
 
+  it("getBySeq finds runs evicted from the in-memory ring (DB-3 read-on-miss)", () => {
+    // Append more runs than the ring cap can hold. The first ones get
+    // evicted from memory but stay on disk in runs.jsonl. getBySeq must
+    // still find them — without this, the dashboard's run-detail page
+    // 404s every recipe older than the latest 500.
+    const log = new RecipeRunLog({ dir: tmp, memoryCap: 3 });
+    for (let i = 0; i < 8; i++) {
+      log.record({
+        id: `t${i}`,
+        triggerSource: "recipe:foo",
+        status: "done",
+        createdAt: i * 100,
+        doneAt: i * 100 + 10,
+      });
+    }
+    expect(log.size()).toBe(3); // ring evicted 5 older runs
+
+    // Latest seqs (still in memory) — fast path
+    expect(log.getBySeq(8)?.taskId).toBe("t7");
+    expect(log.getBySeq(7)?.taskId).toBe("t6");
+
+    // Older seqs (evicted from ring, must come from disk)
+    expect(log.getBySeq(1)?.taskId).toBe("t0");
+    expect(log.getBySeq(2)?.taskId).toBe("t1");
+    expect(log.getBySeq(3)?.taskId).toBe("t2");
+
+    // Unknown seqs still return null
+    expect(log.getBySeq(99)).toBeNull();
+    expect(log.getBySeq(0)).toBeNull();
+  });
+
+  it("getBySeq read-on-miss handles malformed lines without throwing", () => {
+    // Seed a file with one valid run (seq=1) plus a malformed line, then
+    // ask for a seq that's not in the in-memory ring (we'll use a fresh
+    // log that won't load from disk by default — but constructor's
+    // loadExisting reads everything anyway). Use a non-existent seq to
+    // force the on-miss disk scan to run, prove it doesn't blow up on
+    // the malformed line.
+    const file = path.join(tmp, "runs.jsonl");
+    const valid = {
+      seq: 1,
+      taskId: "v",
+      recipeName: "r",
+      trigger: "recipe",
+      status: "done",
+      createdAt: 1,
+      doneAt: 2,
+      durationMs: 1,
+    };
+    require("node:fs").writeFileSync(
+      file,
+      `${JSON.stringify(valid)}\nnot-json\n`,
+    );
+    const log = new RecipeRunLog({ dir: tmp });
+    expect(log.getBySeq(99)).toBeNull(); // non-existent seq, must not throw
+  });
+
   it("tolerates malformed JSONL lines on reload", () => {
     const file = path.join(tmp, "runs.jsonl");
     // Seed with one bad line and one good.

--- a/src/runLog.ts
+++ b/src/runLog.ts
@@ -191,10 +191,45 @@ export class RecipeRunLog {
     return out.slice(0, limit);
   }
 
-  /** Return a single run by its monotonic seq, or null if not found. */
+  /**
+   * Return a single run by its monotonic seq, or null if not found.
+   *
+   * Fast path: in-memory ring lookup (the latest `memoryCap` runs).
+   * Slow path: scan `runs.jsonl` once when the seq isn't in memory —
+   * this is what makes older runs (evicted from the ring buffer)
+   * accessible. The dashboard's `/runs/<seq>` page would otherwise
+   * 404 for any recipe older than the last `memoryCap` (default 500).
+   *
+   * The on-disk scan reads the whole file but doesn't allocate the
+   * full set in memory: we parse line-by-line and short-circuit on
+   * the first match. Malformed lines are skipped silently, matching
+   * `loadExisting` / `syncFromDisk` behaviour.
+   */
   getBySeq(seq: number): RecipeRun | null {
     this.syncFromDisk();
-    return this.runs.find((r) => r.seq === seq) ?? null;
+    const inMem = this.runs.find((r) => r.seq === seq);
+    if (inMem) return inMem;
+    return this.readFromDiskBySeq(seq);
+  }
+
+  private readFromDiskBySeq(seq: number): RecipeRun | null {
+    let raw: string;
+    try {
+      raw = readFileSync(this.file, "utf-8");
+    } catch {
+      return null;
+    }
+    const lines = raw.split("\n");
+    for (const line of lines) {
+      if (!line) continue;
+      try {
+        const parsed = JSON.parse(line) as RecipeRun;
+        if (parsed.seq === seq) return parsed;
+      } catch {
+        // skip malformed line — never let one bad row break lookup
+      }
+    }
+    return null;
   }
 
   /** Test/inspection helper — current in-memory size. */


### PR DESCRIPTION
## Summary

Closes DB-3 from the [dashboard fix plan](docs/plans/dashboard-fix-plan.md).

\`RecipeRunLog\` (`src/runLog.ts`) keeps an in-memory ring of the last 500 runs. `runs.jsonl` retains everything ever recorded. \`getBySeq(seq)\` only consulted the ring, so any older seq returned \`null\` even when the run was still on disk.

**User-visible effect:** `/dashboard/runs/<seq>` 404'd every recipe older than the last ~500 entries. My dogfood pass had 1133 entries on disk — the first 633 were inaccessible.

## Fix

Cache-miss fall-through: when a seq isn't in the ring, scan `runs.jsonl` once for that seq. Bounded cost (one file read per miss); short-circuits on first match. Malformed lines tolerated, matching `loadExisting`/`syncFromDisk` behaviour.

## Bug-fix protocol

1 failing test written first to reproduce the bug. After fix, all 11 runLog tests pass.

| Test | Coverage |
|---|---|
| getBySeq finds runs evicted from the in-memory ring | hot path (in-memory) + cold path (disk fall-through) |
| getBySeq read-on-miss handles malformed lines | regression — bad rows in jsonl don't break lookup |

## Test plan

- [x] `npx vitest run src/__tests__/runLog.test.ts` → 11/11 passing (9 existing + 2 new)
- [x] Full sweep — 4215 passing, 0 failed
- [x] `getDiagnostics` clean

## Punch list status

- ✅ DB-1 (PR #55) — `$schema` URLs + manifest
- ✅ DB-2 (PR #56) — basePath fix
- ✅ DB-3 (this PR) — read-on-miss
- ⏭️ DB-5 → DB-4 — CLI/bridge dispatch + recipe-run install-dir (same-file pair)