### PR TITLE
fix(recipe): `recipe run <name>` resolves install-dir entrypoints (DB-4)

### DIFF
--- a/src/commands/recipe.ts
+++ b/src/commands/recipe.ts
@@ -47,6 +47,7 @@ import {
   type YamlStep,
 } from "../recipes/yamlRunner.js";
 import { findYamlRecipePath } from "../recipesHttp.js";
+import { findInstalledRecipeEntrypoint } from "./recipeInstall.js";
 
 const RECIPES_DIR = join(os.homedir(), ".patchwork", "recipes");
 const FIXTURES_DIR = join(os.homedir(), ".patchwork", "fixtures");
@@ -1098,6 +1099,21 @@ function resolveRecipePath(recipeRef: string): string {
     if (existsSync(candidate) && statSync(candidate).isFile()) {
       return candidate;
     }
+  }
+
+  // Install-dir resolution (DB-4): `recipe install` puts each recipe in
+  // its own subdir at `<RECIPES_DIR>/<install-name>/<entrypoint>.yaml`.
+  // Without this fallback, `recipe run <install-name>` errors with
+  // "not found" even though `recipe list` displays the recipe — observed
+  // in the 2026-04-29 dogfood pass.
+  try {
+    const entrypoint = findInstalledRecipeEntrypoint(normalizedRef);
+    if (entrypoint) return entrypoint;
+  } catch {
+    // findInstalledRecipeEntrypoint throws on path-traversal `name`
+    // values via its underlying validator. That's a security boundary,
+    // not a UX one — fall through to the standard "not found" error
+    // rather than leaking the validator message to a normal user typo.
   }
 
   throw new Error(

--- a/src/commands/recipeInstall.ts
+++ b/src/commands/recipeInstall.ts
@@ -542,6 +542,59 @@ function findInstalledRecipeDir(
 }
 
 /**
+ * Resolve an install-dir-name (the directory `runRecipeInstall` created) to
+ * the YAML entrypoint inside it. Used by `recipe run <name>` so the user can
+ * pass the name they see in `recipe list` rather than having to dig into the
+ * install directory layout.
+ *
+ * Resolution order:
+ *   1. `recipe.json` manifest's `recipes.main`, if the manifest exists and
+ *      the file it points at exists on disk.
+ *   2. First `*.yaml` / `*.yml` in the install dir.
+ *
+ * Returns null if `name` doesn't correspond to an install dir, or the dir
+ * exists but contains no resolvable entrypoint. Path-traversal `name` values
+ * (e.g. `../../etc`) throw via the underlying `findInstalledRecipeDir` —
+ * same defence as enable/disable/uninstall.
+ */
+export function findInstalledRecipeEntrypoint(
+  name: string,
+  options: { recipesDir?: string } = {},
+): string | null {
+  const recipesDir = options.recipesDir ?? INSTALL_RECIPES_DIR;
+  const installDir = findInstalledRecipeDir(name, recipesDir);
+  if (!installDir) return null;
+
+  const manifestPath = path.join(installDir, "recipe.json");
+  if (existsSync(manifestPath)) {
+    try {
+      const m = JSON.parse(readFileSync(manifestPath, "utf-8")) as {
+        recipes?: { main?: string };
+      };
+      if (m.recipes?.main && isSafeBasename(m.recipes.main)) {
+        const candidate = path.join(installDir, m.recipes.main);
+        if (existsSync(candidate)) return candidate;
+      }
+    } catch {
+      // Malformed manifest → fall through to first-yaml lookup. The
+      // scheduler does the same; surfacing the parse error here would
+      // shadow the top-level "recipe not found" error from the CLI.
+    }
+  }
+
+  try {
+    for (const entry of readdirSync(installDir)) {
+      if (/\.ya?ml$/i.test(entry)) {
+        return path.join(installDir, entry);
+      }
+    }
+  } catch {
+    // unreadable
+  }
+  return null;
+}
+
+/**
  * Enable a recipe — removes the .disabled marker so triggers can fire.
  * Idempotent: enabling an already-enabled recipe is a no-op.
  */


### PR DESCRIPTION
## Summary

Closes DB-4 from the [dashboard fix plan](docs/plans/dashboard-fix-plan.md).

## What's broken (verified by 2026-04-29 dogfood)

Recipes installed via \`recipe install\` land at \`~/.patchwork/recipes/<install-name>/<entrypoint>.yaml\` — a subdir per install. The CLI's \`resolveRecipeRef\` only checked flat candidates \`<name>.yaml\`, \`<name>.yml\`, \`<name>.json\` directly under recipesDir.

\`\`\`
$ patchwork recipe install /tmp/dbg-recipe
✓ Installed dbg-recipe
$ patchwork recipe enable dbg-recipe
✓ enabled dbg-recipe
$ patchwork recipe run dbg-recipe
Error: recipe "dbg-recipe" not found in /Users/wesh/.patchwork/recipes
\`\`\`

## Bridge handler isn't broken — only the CLI fallback

\`recipeOrchestration.ts:270\` calls \`findYamlRecipePath\` which PR #49 made install-dir-aware (matches by recipe \`name:\` field). So when a bridge is reachable, recipe-run works. The bug only fires on the CLI fallback path triggered by \`--local\`, no-bridge-running, or bridge returning "not found".

## Fix

- New \`findInstalledRecipeEntrypoint(name)\` exported from [src/commands/recipeInstall.ts](src/commands/recipeInstall.ts). Resolves install-dir name → YAML entrypoint via \`recipe.json\` \`recipes.main\` if present, else the first \`*.yaml\` in the dir. Same path-traversal validator as enable/disable/uninstall.
- [src/commands/recipe.ts](src/commands/recipe.ts) \`resolveRecipeRef\` consults the helper after flat candidates fail and before the "not found" throw.

## Why CLI helper not bridge helper

The bridge's \`findYamlRecipePath\` matches by the recipe's \`name:\` field. If the install dir name differs from the YAML \`name:\` (e.g. dir is \`dbg-recipe\` but recipe declares \`name: dbg-test\`), bridge resolution still works. CLI now ALSO works regardless of name/dir alignment.

## Smoke verified

\`\`\`
$ patchwork recipe install /tmp/dbg-recipe
$ patchwork recipe enable dbg-recipe
$ patchwork recipe run dbg-recipe --dry-run --local
{ "recipe": "dbg-test", "mode": "dry-run", ... }
\`\`\`

## Test plan

- [x] Smoke (above)
- [x] Full project sweep — 4215 passing, 0 failed
- [x] Path-traversal \`name\` values still bounce via underlying validator
- [x] \`getDiagnostics\` clean

## Punch list status after this lands

| ID | Status |
|---|---|
| DB-1 → DB-5 | ✅ merged |
| **DB-4** | 🟡 PR #59 |
| DB-6a, DB-6b, DB-7 | ⏭️ later |

Plus follow-up open from DB-2 verification: Connections page render bug.