### PR TITLE
fix(dashboard): coalesce NaN percentiles + clamp recipe descriptions (DB-6a)

### DIFF
--- a/dashboard/src/app/analytics/page.tsx
+++ b/dashboard/src/app/analytics/page.tsx
@@ -38,6 +38,10 @@ function relTime(ms: number): string {
 }
 
 function fmtDuration(ms: number): string {
+  // Coalesce NaN / Infinity to em-dash so the percentile cells don't render
+  // the literal "NaNs" string. Single-sample tools (one observation, no
+  // percentile defined) are the realistic source of NaN here.
+  if (!Number.isFinite(ms)) return "—";
   if (ms < 1000) return `${ms}ms`;
   return `${(ms / 1000).toFixed(1)}s`;
 }

--- a/dashboard/src/app/recipes/page.tsx
+++ b/dashboard/src/app/recipes/page.tsx
@@ -616,7 +616,20 @@ export default function RecipesPage() {
                         </div>
                       </td>
                       <td className="mono muted">{r.stepCount ?? "—"}</td>
-                      <td>
+                      <td
+                        style={{
+                          // Clamp long descriptions to two lines so a single
+                          // verbose recipe (e.g. ctx-loop-test) doesn't push
+                          // every other row into a vertical pile. Hover/focus
+                          // the row to read the full text via the title attr.
+                          maxWidth: 480,
+                          display: "-webkit-box",
+                          WebkitLineClamp: 2,
+                          WebkitBoxOrient: "vertical" as const,
+                          overflow: "hidden",
+                        }}
+                        title={r.description ?? ""}
+                      >
                         {r.description ?? <span className="muted">—</span>}
                       </td>
                       <td className="muted" style={{ fontSize: 12 }}>


### PR DESCRIPTION
## Summary

Render-polish items from [DB-6a](docs/plans/dashboard-fix-plan.md). Two real bugs + two false alarms cleared.

## Real bugs fixed

### 1. Analytics percentiles render "NaNs" literal
[\`dashboard/src/app/analytics/page.tsx:40-43\`](dashboard/src/app/analytics/page.tsx) — \`fmtDuration(NaN)\` evaluates \`NaN < 1000\` as false (NaN comparisons always false), then falls to \`\${(NaN/1000).toFixed(1)}s\` → literal \`"NaNs"\`. Single-sample tools (one observation, no valid percentile) hit this.

Fix: explicit \`Number.isFinite\` guard returning \`"—"\`.

Verified: \`getDiagnostics\` row now shows \`—\` for p50/p95 when no percentile data exists. No \`"NaN"\` substring anywhere on the analytics page.

### 2. Recipes list row overflow
[\`dashboard/src/app/recipes/page.tsx:619\`](dashboard/src/app/recipes/page.tsx) — long descriptions (e.g. \`ctx-loop-test\` with 6 lines) pushed neighbouring rows out of alignment.

Fix: clamp the description \`<td>\` to 2 lines via \`-webkit-line-clamp: 2\` + \`display: -webkit-box\`, \`max-width: 480px\`. \`title\` attribute reveals the full text on hover.

## False alarms cleared

| DB-6a item | Status | Reason |
|---|---|---|
| Connections "Loading…" stuck | ✅ verified working | Transient state during dev-server restart after PR #56 basePath fix. Page renders 15 connectors correctly when allowed to finish. |
| Marketplace empty cards | ✅ verified working | Slow-loading skeleton placeholders; registry fetch completes in ~2s, 5 cards render with full content. Skeleton was intentional. |

## Test plan

- [x] Browser smoke: analytics p50/p95 → no \`NaN\` text; recipe rows aligned
- [x] Full project sweep — 4215 passing, 0 failed
- [x] \`tsc --noEmit\` on dashboard → clean

## Punch list

- ✅ DB-1 → DB-5 merged
- ✅ DB-4 PR #59 — pending merge or merged
- 🟡 **DB-6a** (this PR)
- ⏭️ DB-6b (formatDuration helper, stat-window labels, sessions counter, recipe new --out)
- ⏭️ DB-7 (Playwright sidebar walk + bridge proxy smoke test)