### PR TITLE
test(dashboard): pin DB-2 regression + sidebar smoke walk (DB-7)

### DIFF
--- a/dashboard/src/app/recipes/[name]/edit/page.tsx
+++ b/dashboard/src/app/recipes/[name]/edit/page.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { useEffect, useRef, useState } from "react";
+import { apiPath } from "@/lib/api";
 
 interface Toast {
   id: number;
@@ -50,7 +51,7 @@ export default function RecipeEditPage({
       setLoading(true);
       try {
         const res = await fetch(
-          `/api/bridge/recipes/${encodeURIComponent(name)}`,
+          apiPath(`/api/bridge/recipes/${encodeURIComponent(name)}`),
         );
         if (res.ok) {
           const data = (await res.json()) as { content?: string } | string;
@@ -96,7 +97,7 @@ export default function RecipeEditPage({
     lintTimerRef.current = setTimeout(() => {
       const reqId = ++lintReqIdRef.current;
       setLinting(true);
-      void fetch("/api/bridge/recipes/lint", {
+      void fetch(apiPath("/api/bridge/recipes/lint"), {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ content }),
@@ -134,7 +135,7 @@ export default function RecipeEditPage({
     setSaveError(null);
     try {
       const res = await fetch(
-        `/api/bridge/recipes/${encodeURIComponent(name)}`,
+        apiPath(`/api/bridge/recipes/${encodeURIComponent(name)}`),
         {
           method: "PUT",
           headers: { "Content-Type": "application/json" },
@@ -176,7 +177,7 @@ export default function RecipeEditPage({
     setRunning(true);
     try {
       const res = await fetch(
-        `/api/bridge/recipes/${encodeURIComponent(name)}/run`,
+        apiPath(`/api/bridge/recipes/${encodeURIComponent(name)}/run`),
         { method: "POST" },
       );
       if (res.ok) {

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "start": "node dist/index.js",
     "test": "vitest run",
     "test:smoke": "bash scripts/smoke/run-all.sh",
+    "test:smoke:dashboard": "node scripts/smoke/dashboard-walk.mjs",
     "schema:generate": "node scripts/generate-schemas.mjs",
     "schema:check": "node scripts/audit-schema-changes.mjs",
     "schema:update": "node scripts/audit-schema-changes.mjs --update",

--- a/scripts/smoke/dashboard-walk.mjs
+++ b/scripts/smoke/dashboard-walk.mjs
@@ -1,0 +1,139 @@
+#!/usr/bin/env node
+/**
+ * dashboard-walk.mjs — sidebar walk + bridge-proxy regression smoke for the
+ * Next.js dashboard. Pings every sidebar route + the /api/bridge/status proxy
+ * and asserts each returns a non-404 response (HTML page or JSON).
+ *
+ * Catches the class of regression DB-2 fixed: a misconfigured basePath /
+ * NEXT_PUBLIC_BASE_PATH wiring that makes every API proxy 404.
+ *
+ * Usage:
+ *   # against local dev server (npm run dev in dashboard/)
+ *   node scripts/smoke/dashboard-walk.mjs
+ *
+ *   # against a deployed dashboard
+ *   node scripts/smoke/dashboard-walk.mjs --url https://patchwork.example.com/dashboard
+ *
+ *   # bridge proxy on a different bridge port
+ *   BRIDGE_URL=http://127.0.0.1:37210 node scripts/smoke/dashboard-walk.mjs
+ *
+ * Exits 0 on full pass, 1 on any failure.
+ */
+
+import { argv, env, exit } from "node:process";
+
+// ── args ──────────────────────────────────────────────────────────────────────
+function flag(name, fallback) {
+  const i = argv.indexOf(name);
+  return i >= 0 && i + 1 < argv.length ? argv[i + 1] : fallback;
+}
+
+const DEFAULT_BASE = "http://localhost:3200/dashboard";
+const BASE = flag("--url", env.DASHBOARD_URL ?? DEFAULT_BASE).replace(
+  /\/$/,
+  "",
+);
+const TIMEOUT_MS = Number(flag("--timeout", env.SMOKE_TIMEOUT_MS ?? "5000"));
+
+// Sidebar routes (mirror dashboard/src/components/Shell.tsx NAV_SECTIONS).
+// The walk asserts each route returns a non-404 — content correctness is
+// covered by per-page tests.
+const SIDEBAR_ROUTES = [
+  "/",
+  "/inbox",
+  "/approvals",
+  "/activity",
+  "/recipes",
+  "/marketplace",
+  "/tasks",
+  "/runs",
+  "/sessions",
+  "/metrics",
+  "/analytics",
+  "/traces",
+  "/decisions",
+  "/connections",
+  "/settings",
+  "/recipes/new",
+];
+
+// API proxy routes that must reach the bridge (DB-2 regression surface).
+const API_ROUTES = ["/api/bridge/status"];
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+const RED = "\x1b[31m",
+  GREEN = "\x1b[32m",
+  DIM = "\x1b[2m",
+  RESET = "\x1b[0m";
+
+async function probe(path, expect = "html") {
+  const url = `${BASE}${path}`;
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), TIMEOUT_MS);
+  try {
+    const res = await fetch(url, { signal: ctrl.signal, redirect: "manual" });
+    clearTimeout(timer);
+    // Allow 2xx and 3xx (redirects to /dashboard from bare /). 404 is fail.
+    if (res.status >= 400) {
+      return { ok: false, status: res.status, reason: `HTTP ${res.status}` };
+    }
+    if (expect === "json" && res.status >= 200 && res.status < 300) {
+      const ct = res.headers.get("content-type") ?? "";
+      if (!ct.includes("application/json")) {
+        return {
+          ok: false,
+          status: res.status,
+          reason: `expected JSON, got ${ct}`,
+        };
+      }
+    }
+    return { ok: true, status: res.status };
+  } catch (e) {
+    clearTimeout(timer);
+    const reason = e instanceof Error ? e.message : String(e);
+    return { ok: false, status: 0, reason };
+  }
+}
+
+// ── main ──────────────────────────────────────────────────────────────────────
+console.log(`${DIM}Dashboard smoke walk against ${BASE}${RESET}\n`);
+
+let pass = 0,
+  fail = 0;
+const failures = [];
+
+for (const route of SIDEBAR_ROUTES) {
+  const r = await probe(route, "html");
+  if (r.ok) {
+    pass++;
+    console.log(`  ${GREEN}✓${RESET} ${route}  ${DIM}${r.status}${RESET}`);
+  } else {
+    fail++;
+    failures.push({ route, ...r });
+    console.log(`  ${RED}✗${RESET} ${route}  ${RED}${r.reason}${RESET}`);
+  }
+}
+
+console.log("");
+for (const route of API_ROUTES) {
+  const r = await probe(route, "json");
+  if (r.ok) {
+    pass++;
+    console.log(`  ${GREEN}✓${RESET} ${route}  ${DIM}${r.status}${RESET}`);
+  } else {
+    fail++;
+    failures.push({ route, ...r });
+    console.log(`  ${RED}✗${RESET} ${route}  ${RED}${r.reason}${RESET}`);
+  }
+}
+
+console.log("\n═══════════════════════════════════");
+const total = pass + fail;
+if (fail === 0) {
+  console.log(`${GREEN}ALL PASS${RESET} (${pass}/${total} routes)`);
+  exit(0);
+} else {
+  console.log(`${RED}FAILURES: ${fail}/${total}${RESET}`);
+  for (const f of failures) console.log(`  ✗ ${f.route} → ${f.reason}`);
+  exit(1);
+}

--- a/src/__tests__/dashboardConfig.test.ts
+++ b/src/__tests__/dashboardConfig.test.ts
@@ -1,0 +1,129 @@
+// DB-7: regression tests pinning DB-2 (apiPath helper / NEXT_PUBLIC_BASE_PATH wiring).
+//
+// Background: dashboard's Next.js app is mounted at basePath="/dashboard". A
+// client-side `apiPath(path)` helper prepends basePath to fetch URLs so the
+// bridge-proxy routes (`/api/bridge/*`) resolve. Without basePath, requests
+// hit bare `/api/bridge/*` which 404s.
+//
+// DB-2 fix: inject `NEXT_PUBLIC_BASE_PATH` via `next.config.js`'s `env` block
+// so the static replacement at build time matches `basePath`. If anyone drops
+// the env block, removes the helper, or starts using bare fetches, these
+// tests fail.
+
+import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, test } from "vitest";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, "..", "..");
+const DASHBOARD = join(REPO_ROOT, "dashboard");
+
+const require_ = createRequire(import.meta.url);
+
+describe("dashboard next.config.js — DB-2 regression", () => {
+  test("basePath is /dashboard", () => {
+    const cfg = require_(join(DASHBOARD, "next.config.js"));
+    expect(cfg.basePath).toBe("/dashboard");
+  });
+
+  test("env.NEXT_PUBLIC_BASE_PATH matches basePath", () => {
+    const cfg = require_(join(DASHBOARD, "next.config.js"));
+    expect(cfg.env).toBeDefined();
+    expect(cfg.env.NEXT_PUBLIC_BASE_PATH).toBe(cfg.basePath);
+  });
+});
+
+describe("dashboard apiPath helper — DB-2 regression", () => {
+  const apiSrc = readFileSync(join(DASHBOARD, "src/lib/api.ts"), "utf8");
+
+  test("reads from NEXT_PUBLIC_BASE_PATH", () => {
+    expect(apiSrc).toMatch(/process\.env\.NEXT_PUBLIC_BASE_PATH/);
+  });
+
+  test("falls back to empty string (so dev without env still works)", () => {
+    expect(apiSrc).toMatch(/\?\?\s*""/);
+  });
+
+  test("exports apiPath function that prepends BASE", () => {
+    expect(apiSrc).toMatch(/export function apiPath/);
+    expect(apiSrc).toMatch(/\$\{BASE\}\$\{path\}/);
+  });
+});
+
+describe("dashboard pages — no bare /api/bridge fetches", () => {
+  // Walk dashboard/src/app + components/hooks. Anything fetching the bridge
+  // proxy MUST go through `apiPath()`. Bare `fetch("/api/bridge/x")` was the
+  // exact regression DB-2 fixed.
+  const candidateDirs = [
+    join(DASHBOARD, "src", "app"),
+    join(DASHBOARD, "src", "components"),
+    join(DASHBOARD, "src", "hooks"),
+    join(DASHBOARD, "src", "lib"),
+  ];
+
+  function walk(dir: string): string[] {
+    const fs = require_("node:fs") as typeof import("node:fs");
+    const out: string[] = [];
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const p = join(dir, entry.name);
+      if (entry.isDirectory()) out.push(...walk(p));
+      else if (/\.(tsx?|mts|cts)$/.test(entry.name)) out.push(p);
+    }
+    return out;
+  }
+
+  const files = candidateDirs.flatMap((d) => walk(d));
+
+  // Rule: every `fetch(...)` or `new EventSource(...)` argument that is a
+  // proxy URL literal must be wrapped in `apiPath(...)`. Catches the exact
+  // class of regression DB-2 fixed: `fetch("/api/bridge/x")` 404s in prod
+  // because basePath is `/dashboard` and the route is mounted at
+  // `/dashboard/api/bridge/x`.
+  //
+  // Implementation: locate every `fetch(` / `new EventSource(` opener; read
+  // the argument range up to the matching close paren or 5 lines (whichever
+  // is shorter); if a proxy literal appears in that window without
+  // `apiPath(`, flag it.
+  //
+  // Server-side route handlers under app/api/** legitimately reference these
+  // paths as strings — we exclude any file that lives under `src/app/api/`.
+  const offenders: { file: string; line: number; text: string }[] = [];
+  const PROXY_LITERAL = /["`']\/api\/(?:bridge|inbox|push)\b/;
+  const NETWORK_OPENER = /\b(?:await\s+fetch|fetch|new\s+EventSource)\s*\(/;
+
+  for (const file of files) {
+    if (file.includes(`${join("src", "app", "api")}`)) continue;
+    const text = readFileSync(file, "utf8");
+    const lines = text.split("\n");
+    lines.forEach((line, idx) => {
+      if (!NETWORK_OPENER.test(line)) return;
+      // Window: opener line + up to 4 continuation lines (covers multi-line
+      // fetch(`...`, { ... }) calls where the URL is on its own line).
+      const window = lines
+        .slice(idx, Math.min(idx + 5, lines.length))
+        .join("\n");
+      if (!PROXY_LITERAL.test(window)) return;
+      if (window.includes("apiPath(")) return;
+      offenders.push({
+        file: relative(REPO_ROOT, file),
+        line: idx + 1,
+        text: line.trim(),
+      });
+    });
+  }
+
+  test("no client-side fetch hits bare /api/bridge|/api/inbox|/api/push", () => {
+    expect(offenders).toEqual([]);
+  });
+
+  test("at least one apiPath caller exists (sanity)", () => {
+    let count = 0;
+    for (const file of files) {
+      const text = readFileSync(file, "utf8");
+      count += (text.match(/\bapiPath\(/g) ?? []).length;
+    }
+    expect(count).toBeGreaterThan(20);
+  });
+});


### PR DESCRIPTION
## Summary

Closes the DB cluster — adds two layers of regression protection for the basePath / apiPath wiring fixed in DB-2 (#56), and fixes 4 live DB-2 regressions found by the new test.

### 1. Vitest regression test — `src/__tests__/dashboardConfig.test.ts`
Three groups of assertions:

- **`next.config.js`** — asserts `basePath === "/dashboard"` AND `env.NEXT_PUBLIC_BASE_PATH === basePath` (the exact pivot DB-2 fixed).
- **`apiPath` helper** — asserts `dashboard/src/lib/api.ts` still reads from `NEXT_PUBLIC_BASE_PATH` and prepends correctly.
- **Source walk** — scans `dashboard/src/{app,components,hooks,lib}/**/*.{ts,tsx}` for any client-side `fetch(...)` / `new EventSource(...)` call whose URL literal starts with `/api/(bridge|inbox|push)` without an `apiPath()` wrapper. The hooks `useBridgeFetch` / `useBridgeStream` wrap internally, so callers passing bare paths to them are correctly exempted.

### Live regressions caught by the new test

`dashboard/src/app/recipes/[name]/edit/page.tsx` had **four** bare fetches that would 404 in production once basePath kicks in:

| Line | Call |
|---|---|
| 52 | `await fetch(\`/api/bridge/recipes/${name}\`)` (load) |
| 99 | `void fetch("/api/bridge/recipes/lint", …)` (live lint) |
| 136 | `await fetch(\`/api/bridge/recipes/${name}\`, {PUT})` (save) |
| 178 | `await fetch(\`/api/bridge/recipes/${name}/run\`)` (run) |

All four wrapped with `apiPath()`.

### 2. Live smoke script — `scripts/smoke/dashboard-walk.mjs`

HTTP-pings every sidebar route + `/api/bridge/status` proxy, asserts non-404. Use after `npm run dev` or as a deploy gate.

```bash
# default: http://localhost:3200/dashboard
npm run test:smoke:dashboard

# against a deployed dashboard
node scripts/smoke/dashboard-walk.mjs --url https://patchwork.example.com/dashboard
```

Reports per-route pass/fail and exits non-zero on any failure.

### DB cluster status

| Item | Status | PR |
|---|---|---|
| DB-1 → DB-3 | ✅ merged | #55, #56, #57 |
| DB-4 | ✅ merged | #59 |
| DB-5 | ✅ merged | #58 |
| DB-6a | ✅ merged | #60 |
| DB-6b | 🟡 open | #61 |
| **DB-7** | 🟡 this PR | — |

## Test plan

- [x] `npm test` — 4222 passing (was 4215; +7 new)
- [x] `npx tsc --noEmit` — clean
- [x] `cd dashboard && npx tsc --noEmit` — clean
- [x] Smoke script reports clean pass/fail against an unbound port (sanity)
- [ ] Reviewer: spot-check that hook-wrapped paths are correctly exempted (e.g. `useBridgeFetch("/api/bridge/health", …)` should not be flagged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)