### PR TITLE
feat(recipes): live-tail step events via SSE (VD-1B)

### DIFF
--- a/dashboard/src/app/runs/[seq]/page.tsx
+++ b/dashboard/src/app/runs/[seq]/page.tsx
@@ -1,15 +1,16 @@
 "use client";
 import Link from "next/link";
 import { useParams } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { apiPath } from '@/lib/api';
+import { useBridgeStream } from "@/hooks/useBridgeStream";
 
 // ------------------------------------------------------------------ types
 
 interface StepResult {
   id: string;
   tool?: string;
-  status: "ok" | "skipped" | "error";
+  status: "running" | "ok" | "skipped" | "error";
   error?: string;
   durationMs: number;
 }
@@ -134,9 +135,17 @@ function AssertionFailuresPanel({ failures }: { failures: AssertionFailure[] }) 
 // ------------------------------------------------------------------ step-result row
 
 function stepStatusClass(status: StepResult["status"]): string {
+  if (status === "running") return "running";
   if (status === "ok") return "ok";
   if (status === "error") return "err";
   return "muted";
+}
+
+function stepStatusLabel(status: StepResult["status"]): string {
+  if (status === "running") return "running";
+  if (status === "ok") return "ok";
+  if (status === "error") return "error";
+  return "skipped";
 }
 
 function StepRow({
@@ -223,7 +232,7 @@ function StepRow({
             className={`pill ${stepStatusClass(step.status)}`}
             style={{ fontSize: 10 }}
           >
-            {step.status === "ok" ? "ok" : step.status === "error" ? "error" : "skipped"}
+            {stepStatusLabel(step.status)}
           </span>
         </div>
         <span className="mono muted" style={{ fontSize: 11, minWidth: 40, textAlign: "right" }}>
@@ -403,6 +412,9 @@ export default function RunDetailPage() {
 
     doFetch().then((initialRun) => {
       if (!initialRun || initialRun.status !== "running") return;
+      // Slower polling now that SSE delivers the live step deltas — polling
+      // is just a backstop to canonicalize when the run transitions to
+      // terminal (no `recipe_run_done` event yet; keep this until VD-1C).
       intervalId = setInterval(() => {
         doFetch().then((r) => {
           if (!r || r.status !== "running") {
@@ -410,13 +422,84 @@ export default function RunDetailPage() {
             intervalId = undefined;
           }
         });
-      }, 3000);
+      }, 5000);
     });
 
     return () => {
       if (intervalId !== undefined) clearInterval(intervalId);
     };
   }, [seq]);
+
+  // VD-1B live-tail: subscribe to ActivityLog SSE while the run is in flight
+  // and merge `recipe_step_start` / `recipe_step_done` events into the local
+  // step state. The bridge tags every event with `runSeq` so we filter to
+  // events for this page's run only.
+  const onStreamEvent = useCallback(
+    (type: string, raw: unknown) => {
+      if (type !== "lifecycle") return;
+      const data = raw as
+        | {
+            event?: string;
+            metadata?: {
+              runSeq?: number;
+              stepId?: string;
+              tool?: string;
+              status?: "ok" | "error";
+              error?: string;
+              durationMs?: number;
+            };
+          }
+        | undefined;
+      const md = data?.metadata;
+      if (!md || md.runSeq !== Number(seq)) return;
+      const stepId = md.stepId;
+      if (!stepId) return;
+
+      if (data.event === "recipe_step_start") {
+        setRun((prev) => {
+          if (!prev) return prev;
+          const existing = prev.stepResults ?? [];
+          if (existing.some((s) => s.id === stepId)) return prev;
+          return {
+            ...prev,
+            stepResults: [
+              ...existing,
+              {
+                id: stepId,
+                tool: md.tool,
+                status: "running",
+                durationMs: 0,
+              },
+            ],
+          };
+        });
+      } else if (data.event === "recipe_step_done") {
+        setRun((prev) => {
+          if (!prev) return prev;
+          const existing = prev.stepResults ?? [];
+          const idx = existing.findIndex((s) => s.id === stepId);
+          const updated: StepResult = {
+            id: stepId,
+            tool: md.tool,
+            status: md.status === "error" ? "error" : "ok",
+            ...(md.error !== undefined && { error: md.error }),
+            durationMs: md.durationMs ?? 0,
+          };
+          if (idx === -1) {
+            return { ...prev, stepResults: [...existing, updated] };
+          }
+          const next = existing.slice();
+          next[idx] = updated;
+          return { ...prev, stepResults: next };
+        });
+      }
+    },
+    [seq],
+  );
+
+  useBridgeStream("/api/bridge/stream", onStreamEvent, {
+    enabled: run?.status === "running",
+  });
 
   // Load plan lazily when tab is switched to "plan"
   useEffect(() => {

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -986,6 +986,7 @@ export class Bridge {
           getOrchestrator: () => this.orchestrator,
           recipeOrchestrator: this.recipeOrchestrator,
           recipeRunLog: this.recipeRunLog,
+          activityLog: this.activityLog,
           workdir: this.config.workspace,
           logger: this.logger,
         });

--- a/src/recipeOrchestration.ts
+++ b/src/recipeOrchestration.ts
@@ -41,6 +41,13 @@ export interface RecipeOrchestrationDeps {
   getOrchestrator: () => ClaudeOrchestrator | null;
   recipeOrchestrator: RecipeOrchestrator;
   recipeRunLog: RecipeRunLog | null;
+  /**
+   * Bridge ActivityLog used to broadcast `recipe_step_start` /
+   * `recipe_step_done` events for live-tail SSE consumers (dashboard
+   * `/runs/[seq]` page). Optional — when absent, recipes still run, just
+   * without live-tail.
+   */
+  activityLog?: import("./activityLog.js").ActivityLog;
   workdir: string;
   logger: { info?: (s: string) => void; warn?: (s: string) => void };
 }
@@ -329,9 +336,15 @@ export class RecipeOrchestration {
     // dashboard reads the same instance, so /runs surfaces the live entry
     // immediately. CLI invocations don't go through here — they fall back to
     // `runLogDir` + `appendDirect` (pre-VD-1 behavior, no live-tail).
+    //
+    // The `activityLog` enables VD-1B live-tail: when set, chainedRunner
+    // broadcasts `recipe_step_start` / `recipe_step_done` events tagged with
+    // `runSeq` so the dashboard's `/runs/[seq]` SSE subscription receives
+    // them in real time.
     const chainedOptions = {
       sourcePath: opts.filePath,
       runLog: this.deps.recipeRunLog ?? undefined,
+      activityLog: this.deps.activityLog,
     };
     const fireResult = await this.deps.recipeOrchestrator
       .fire({

--- a/src/recipes/__tests__/chainedRunner.runLog.test.ts
+++ b/src/recipes/__tests__/chainedRunner.runLog.test.ts
@@ -208,3 +208,149 @@ describe("runChainedRecipe — runLog (singleton) path", () => {
     expect(readRunLog()).toHaveLength(1);
   });
 });
+
+// ── VD-1B: live-tail step events via ActivityLog ───────────────────────────
+
+describe("runChainedRecipe — ActivityLog step event broadcast", () => {
+  it("emits recipe_step_start + recipe_step_done with runSeq when activityLog provided", async () => {
+    const { RecipeRunLog } = await import("../../runLog.js");
+    const { ActivityLog } = await import("../../activityLog.js");
+    const log = new RecipeRunLog({ dir: tmpDir });
+    const activityLog = new ActivityLog();
+
+    const events: Array<{ event: string; metadata: Record<string, unknown> }> =
+      [];
+    activityLog.subscribe((kind, entry) => {
+      if (kind !== "lifecycle") return;
+      const e = entry as { event: string; metadata?: Record<string, unknown> };
+      if (e.event.startsWith("recipe_step_")) {
+        events.push({ event: e.event, metadata: e.metadata ?? {} });
+      }
+    });
+
+    const twoStepRecipe: ChainedRecipe & { trigger: { type: string } } = {
+      name: "two-step",
+      trigger: { type: "chained" },
+      steps: [
+        { id: "s1", tool: "noop.tool" },
+        { id: "s2", tool: "noop.tool", awaits: ["s1"] },
+      ],
+    };
+
+    const result = await runChainedRecipe(
+      twoStepRecipe,
+      optsWithLog({ runLog: log, runLogDir: undefined, activityLog }),
+      okDeps,
+    );
+    expect(result.success).toBe(true);
+
+    // Should have emitted: s1.start, s1.done, s2.start, s2.done.
+    expect(events).toHaveLength(4);
+    expect(events.map((e) => e.event)).toEqual([
+      "recipe_step_start",
+      "recipe_step_done",
+      "recipe_step_start",
+      "recipe_step_done",
+    ]);
+
+    const seqs = new Set(events.map((e) => e.metadata.runSeq));
+    expect(seqs.size).toBe(1);
+    const allRuns = log.query();
+    expect([...seqs][0]).toBe(allRuns[0]?.seq);
+
+    expect(events[0]?.metadata.stepId).toBe("s1");
+    expect(events[1]?.metadata.stepId).toBe("s1");
+    expect(events[1]?.metadata.status).toBe("ok");
+    expect(typeof events[1]?.metadata.durationMs).toBe("number");
+  });
+
+  it("emits recipe_step_done with status:'error' when a step fails", async () => {
+    const { RecipeRunLog } = await import("../../runLog.js");
+    const { ActivityLog } = await import("../../activityLog.js");
+    const log = new RecipeRunLog({ dir: tmpDir });
+    const activityLog = new ActivityLog();
+
+    const events: Array<{ event: string; metadata: Record<string, unknown> }> =
+      [];
+    activityLog.subscribe((kind, entry) => {
+      if (kind !== "lifecycle") return;
+      const e = entry as { event: string; metadata?: Record<string, unknown> };
+      if (e.event.startsWith("recipe_step_")) {
+        events.push({ event: e.event, metadata: e.metadata ?? {} });
+      }
+    });
+
+    const failingDeps: ExecutionDeps = {
+      executeTool: vi.fn().mockRejectedValue(new Error("boom")),
+      executeAgent: vi.fn(),
+      loadNestedRecipe: vi.fn().mockResolvedValue(null),
+    };
+
+    await runChainedRecipe(
+      chainedRecipe(),
+      optsWithLog({ runLog: log, runLogDir: undefined, activityLog }),
+      failingDeps,
+    );
+
+    const done = events.find((e) => e.event === "recipe_step_done");
+    expect(done).toBeDefined();
+    expect(done?.metadata.status).toBe("error");
+    expect(done?.metadata.error).toBe("boom");
+  });
+
+  it("does NOT emit step events when activityLog is omitted", async () => {
+    const { RecipeRunLog } = await import("../../runLog.js");
+    const log = new RecipeRunLog({ dir: tmpDir });
+    await runChainedRecipe(
+      chainedRecipe(),
+      optsWithLog({ runLog: log, runLogDir: undefined }),
+      okDeps,
+    );
+    expect(log.query()).toHaveLength(1);
+    expect(log.query()[0]?.status).toBe("done");
+  });
+
+  it("only broadcasts step events for the depth-0 run (nested runs are silent)", async () => {
+    const { RecipeRunLog } = await import("../../runLog.js");
+    const { ActivityLog } = await import("../../activityLog.js");
+    const log = new RecipeRunLog({ dir: tmpDir });
+    const activityLog = new ActivityLog();
+
+    const events: Array<{ event: string; metadata: Record<string, unknown> }> =
+      [];
+    activityLog.subscribe((kind, entry) => {
+      if (kind !== "lifecycle") return;
+      const e = entry as { event: string; metadata?: Record<string, unknown> };
+      if (e.event.startsWith("recipe_step_")) {
+        events.push({ event: e.event, metadata: e.metadata ?? {} });
+      }
+    });
+
+    const nestedRecipe: ChainedRecipe = {
+      name: "nested",
+      trigger: { type: "chained" } as never,
+      steps: [{ id: "inner", tool: "noop.tool" }],
+    };
+    const depsWithNested: ExecutionDeps = {
+      executeTool: vi.fn().mockResolvedValue("ok"),
+      executeAgent: vi.fn(),
+      loadNestedRecipe: vi.fn().mockResolvedValue(nestedRecipe),
+    };
+    const outer: ChainedRecipe & { trigger: { type: string } } = {
+      name: "outer",
+      trigger: { type: "chained" },
+      steps: [{ id: "call-nested", recipe: "nested" }],
+    };
+    await runChainedRecipe(
+      outer,
+      optsWithLog({ runLog: log, runLogDir: undefined, activityLog }),
+      depsWithNested,
+    );
+    expect(events.length).toBeGreaterThan(0);
+    const outerSeq = log.query()[0]?.seq;
+    for (const e of events) {
+      expect(e.metadata.runSeq).toBe(outerSeq);
+      expect(e.metadata.recipeName).toBe("outer");
+    }
+  });
+});

--- a/src/recipes/chainedRunner.ts
+++ b/src/recipes/chainedRunner.ts
@@ -81,6 +81,13 @@ export interface RunOptions {
    * Takes precedence over `runLogDir`.
    */
   runLog?: import("../runLog.js").RecipeRunLog;
+  /**
+   * Bridge `ActivityLog` for VD-1 live-tail. When set together with
+   * `runLog`, the runner broadcasts `recipe_step_start` and
+   * `recipe_step_done` lifecycle events tagged with `runSeq` so the
+   * dashboard `/runs/[seq]` page can subscribe via SSE instead of polling.
+   */
+  activityLog?: import("../activityLog.js").ActivityLog;
 }
 
 export interface StepExecutionContext {
@@ -614,11 +621,65 @@ export async function runChainedRecipe(
     { durationMs: number; skipped?: boolean }
   >();
 
+  // VD-1 live-tail: when an `activityLog` is provided AND we have a `runSeq`
+  // (depth 0, runLog supplied), broadcast `recipe_step_start` /
+  // `recipe_step_done` events so the dashboard `/runs/[seq]` page can
+  // subscribe to step changes via SSE instead of 3s polling.
+  const broadcastActivity = options.activityLog;
+  const broadcastSeq = runSeq;
+  const broadcastName = recipe.name;
+  const stepStartTimes = new Map<string, number>();
+
+  const wrappedOnStepStart =
+    broadcastActivity && broadcastSeq !== undefined
+      ? (stepId: string) => {
+          const ts = Date.now();
+          stepStartTimes.set(stepId, ts);
+          try {
+            broadcastActivity.recordEvent("recipe_step_start", {
+              runSeq: broadcastSeq,
+              recipeName: broadcastName,
+              stepId,
+              tool: stepMap.get(stepId)?.tool,
+              ts,
+            });
+          } catch {
+            // never let live-tail failure break the run
+          }
+          options.onStepStart?.(stepId);
+        }
+      : options.onStepStart;
+
+  const wrappedOnStepComplete =
+    broadcastActivity && broadcastSeq !== undefined
+      ? (stepId: string, error?: Error) => {
+          const ts = Date.now();
+          const startedAt = stepStartTimes.get(stepId);
+          try {
+            broadcastActivity.recordEvent("recipe_step_done", {
+              runSeq: broadcastSeq,
+              recipeName: broadcastName,
+              stepId,
+              tool: stepMap.get(stepId)?.tool,
+              status: error ? "error" : "ok",
+              ...(error?.message !== undefined && { error: error.message }),
+              ...(startedAt !== undefined && {
+                durationMs: ts - startedAt,
+              }),
+              ts,
+            });
+          } catch {
+            // never let live-tail failure break the run
+          }
+          options.onStepComplete?.(stepId, error);
+        }
+      : options.onStepComplete;
+
   // Execute with dependency tracking
   const execOptions: ExecutionOptions = {
     maxConcurrency: options.maxConcurrency,
-    onStepStart: options.onStepStart,
-    onStepComplete: options.onStepComplete,
+    onStepStart: wrappedOnStepStart,
+    onStepComplete: wrappedOnStepComplete,
   };
 
   const stepExecutor: StepExecutor = async (stepId: string) => {

--- a/src/recipes/yamlRunner.ts
+++ b/src/recipes/yamlRunner.ts
@@ -1270,6 +1270,7 @@ export async function dispatchRecipe(
       onStepComplete: deps.chainedOptions?.onStepComplete,
       runLogDir: deps.chainedOptions?.runLogDir,
       runLog: deps.chainedOptions?.runLog,
+      activityLog: deps.chainedOptions?.activityLog,
     };
     if (!deps.chainedDeps) {
       throw new Error(


### PR DESCRIPTION
## Summary

Builds on **#63** (VD-1A foundation). The dashboard `/runs/[seq]` page now updates step rows the moment each step starts and completes — no more 3s polling stutter.

> **Depends on #63.** Open this PR's diff after #63 lands; if the foundation isn't merged yet, the merge-base diff will show both PRs' changes together.

## Bridge

`chainedRunner` learns a new `activityLog?: ActivityLog` option. When set together with `runLog`, the runner broadcasts two new lifecycle events on `ActivityLog`:

| Event | Payload |
|---|---|
| `recipe_step_start` | `{runSeq, recipeName, stepId, tool, ts}` |
| `recipe_step_done` | `{runSeq, recipeName, stepId, tool, status, error?, durationMs, ts}` |

The wiring wraps the existing `onStepStart`/`onStepComplete` callbacks (so any user-supplied hooks still fire) — broadcast happens at depth 0 only, since nested recipes are part of their parent's timeline.

`recipeOrchestration` passes `this.deps.activityLog` through automatically. `bridge.ts` wires the singleton.

## Dashboard

`/runs/[seq]` page subscribes via the existing `useBridgeStream` hook when `run.status === "running"`. Filters on `metadata.runSeq === Number(seq)` so concurrent runs don't bleed into each other's pages.

- `recipe_step_start` → append step with `status: "running"` if not already present
- `recipe_step_done` → upgrade to terminal status with duration

`StepResult.status` extends to include `"running"`. New `.pill.running` style renders the in-flight pill (reuses the animation added in #63).

Polling drops from 3s → 5s as a backstop for the final-status transition (VD-1C will replace with a `recipe_run_done` event).

## Test plan

- [x] `npm test` — 4235 passing (was 4231; +4 new)
  - `chainedRunner.runLog.test.ts`:
    - 2-step happy path emits 4 events with same `runSeq` ✅
    - Error finalization tags `status: "error"` + carries `error: "boom"` ✅
    - No broadcast when `activityLog` omitted (back-compat) ✅
    - Nested recipes don't bleed step events to parent's broadcast ✅
- [x] `npx tsc --noEmit` — clean (root + dashboard)
- [x] DB-7 dashboardConfig regression test still passes (`useBridgeStream` correctly exempted from the bare-fetch detector)
- [ ] Reviewer: spot-check that the `runSeq` filter in `[seq]/page.tsx` correctly handles the case where two recipes run concurrently (only one page open per recipe, but events for both arrive on `/api/bridge/stream`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)