### PR TITLE
fix(dashboard,recipes): VD follow-up — hover clip, truncation, replay audit

### DIFF
--- a/dashboard/src/app/globals.css
+++ b/dashboard/src/app/globals.css
@@ -913,13 +913,12 @@ button { font-family: inherit; }
 .pill.info { background: var(--blue-soft);  color: var(--blue);  border-color: transparent; }
 .pill.muted { color: var(--ink-3); background: var(--recess); border-color: transparent; }
 /* ── VD-3: per-step hover diff panel ─────────────────────────────── */
+/* Position is set inline (fixed coordinates from the anchor row's
+ * getBoundingClientRect) — the panel renders into a React Portal at
+ * document.body so it escapes the steps card's overflow:hidden clip
+ * (BUG-1 from the post-merge dogfood). */
 .step-diff-hover {
-  position: absolute;
   z-index: 50;
-  top: 100%;
-  left: 56px;
-  right: 16px;
-  margin-top: 4px;
   background: var(--bg-1, #1a1a1a);
   border: 1px solid var(--line-2, #333);
   border-radius: var(--r-2, 6px);

--- a/dashboard/src/app/runs/[seq]/page.tsx
+++ b/dashboard/src/app/runs/[seq]/page.tsx
@@ -5,7 +5,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { apiPath } from "@/lib/api";
 import { StepDiffHover } from "@/components/StepDiffHover";
 import { useBridgeStream } from "@/hooks/useBridgeStream";
-import { diffForStep } from "@/lib/registryDiff";
+import { diffForStep, previewMockedReplay } from "@/lib/registryDiff";
 
 // ------------------------------------------------------------------ types
 
@@ -168,13 +168,22 @@ function StepRow({
 }) {
   const [open, setOpen] = useState(false);
   const [hover, setHover] = useState(false);
+  const [anchorRect, setAnchorRect] = useState<DOMRect | null>(null);
   const hoverTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const wrapperRef = useRef<HTMLDivElement>(null);
 
   // Hover-on with 200ms grace so quick mouse passes don't flicker the
   // panel. Hover-off clears the panel and any pending timer immediately.
+  // Captures the wrapper's bounding rect at hover-fire time so the
+  // portal-mounted panel can position relative to it.
   const onEnter = () => {
     if (hoverTimerRef.current) clearTimeout(hoverTimerRef.current);
-    hoverTimerRef.current = setTimeout(() => setHover(true), 200);
+    hoverTimerRef.current = setTimeout(() => {
+      if (wrapperRef.current) {
+        setAnchorRect(wrapperRef.current.getBoundingClientRect());
+      }
+      setHover(true);
+    }, 200);
   };
   const onLeave = () => {
     if (hoverTimerRef.current) {
@@ -182,6 +191,7 @@ function StepRow({
       hoverTimerRef.current = null;
     }
     setHover(false);
+    setAnchorRect(null);
   };
   useEffect(() => {
     return () => {
@@ -193,9 +203,10 @@ function StepRow({
   // show the unavailable empty state for older runs. For now: skip the
   // panel entirely on `running` steps (capture isn't there yet) and on
   // skipped steps (no semantically meaningful diff).
-  const hoverEligible =
-    step.status === "ok" || step.status === "error";
-  const diff = hoverEligible ? diffForStep(allSteps, index) : null;
+  const hoverEligible = step.status === "ok" || step.status === "error";
+  const diffResult = hoverEligible
+    ? diffForStep(allSteps, index)
+    : { kind: "unavailable" as const };
   const showPanel = hover && hoverEligible;
 
   const barWidth =
@@ -205,6 +216,7 @@ function StepRow({
 
   return (
     <div
+      ref={wrapperRef}
       style={{
         position: "relative",
         borderBottom: "1px solid var(--border-subtle)",
@@ -291,9 +303,10 @@ function StepRow({
       )}
       {showPanel && (
         <StepDiffHover
-          diff={diff}
+          result={diffResult}
           resolvedParams={step.resolvedParams}
           output={step.output}
+          anchorRect={anchorRect}
           onClose={() => setHover(false)}
         />
       )}
@@ -728,13 +741,69 @@ export default function RunDetailPage() {
           >
             <h3 style={{ marginTop: 0, marginBottom: 8 }}>Replay this run?</h3>
             <p style={{ fontSize: 13, color: "var(--ink-2)", margin: "0 0 12px" }}>
-              All tool and agent steps will return the captured output from
-              this run. No external API calls, no write side effects. Useful
-              for verifying template/transform changes without re-hitting
-              connected services.
+              Re-runs the recipe with each step's tool / agent call replaced
+              by its captured output from this run. Templates, transforms, and
+              <code className="mono"> when:</code> conditions re-evaluate against
+              the new state — useful for verifying recipe edits without
+              re-hitting connected services.
             </p>
+            {(() => {
+              const preflight = previewMockedReplay(run?.stepResults ?? []);
+              if (preflight.unmocked.length === 0) {
+                return (
+                  <p style={{ fontSize: 12, color: "var(--ink-3)", margin: "0 0 16px" }}>
+                    All {preflight.mocked.length} step
+                    {preflight.mocked.length === 1 ? "" : "s"} will be mocked
+                    from captures. No external API calls.
+                  </p>
+                );
+              }
+              return (
+                <div
+                  style={{
+                    fontSize: 12,
+                    margin: "0 0 16px",
+                    padding: "8px 10px",
+                    borderRadius: "var(--r-1, 4px)",
+                    border: "1px solid var(--amber, #fbbf24)",
+                    background: "rgba(251,191,36,0.08)",
+                    color: "var(--amber, #fbbf24)",
+                  }}
+                >
+                  <div style={{ fontWeight: 600, marginBottom: 4 }}>
+                    {preflight.unmocked.length} step
+                    {preflight.unmocked.length === 1 ? "" : "s"} will run for
+                    real (no usable capture)
+                  </div>
+                  <ul
+                    style={{
+                      margin: "4px 0 0",
+                      paddingLeft: 20,
+                      color: "var(--ink-2)",
+                    }}
+                  >
+                    {preflight.unmocked.slice(0, 8).map((u) => (
+                      <li key={u.id} className="mono" style={{ fontSize: 11 }}>
+                        {u.tool ? `${u.tool} ` : ""}
+                        <span style={{ color: "var(--ink-3)" }}>({u.id})</span>
+                        {" — "}
+                        {u.reason === "truncated"
+                          ? "output >8 KB, will fire real tool"
+                          : "no capture"}
+                      </li>
+                    ))}
+                    {preflight.unmocked.length > 8 && (
+                      <li style={{ fontSize: 11, color: "var(--ink-3)" }}>
+                        …and {preflight.unmocked.length - 8} more
+                      </li>
+                    )}
+                  </ul>
+                </div>
+              );
+            })()}
             <p style={{ fontSize: 12, color: "var(--ink-3)", margin: "0 0 16px" }}>
-              A new run will be created with <code className="mono">triggerSource:replay:{seq}</code>.
+              A new run will be created with{" "}
+              <code className="mono">replay:{seq}</code> in its taskId.
             </p>
             <div style={{ display: "flex", justifyContent: "flex-end", gap: 8 }}>
               <button

--- a/dashboard/src/components/StepDiffHover.tsx
+++ b/dashboard/src/components/StepDiffHover.tsx
@@ -3,28 +3,36 @@
  * StepDiffHover — popover that shows a step's registry-diff plus its
  * resolvedParams + output. Used by `/runs/[seq]` page on row hover.
  *
- * Anchors to the parent row (caller positions via wrapping div). Closes
- * on Escape, click-outside, or `mouseleave` from the wrapper.
+ * Renders into a React Portal anchored to `document.body` so it escapes
+ * the parent steps card's `overflow: hidden` clip. Position is
+ * fixed-coordinate, computed from the trigger row's `getBoundingClientRect`
+ * passed in via the `anchorRect` prop.
  *
- * Caps to 50 changes shown + "and N more" so a step that adds 200 keys
- * doesn't blow up the layout.
+ * Closes on Escape. Caller controls hover-leave dismissal via the wrapping
+ * row's `onMouseLeave`.
+ *
+ * Caps each section at 50 rows + "and N more" so a step that adds 200
+ * keys doesn't blow up the layout.
  */
 
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import {
-  type RegistryDiff,
+  type StepDiffResult,
   changeCount,
 } from "@/lib/registryDiff";
 
 const MAX_ROWS_PER_SECTION = 50;
 const MAX_VALUE_PREVIEW_CHARS = 200;
+const PANEL_OFFSET_PX = 4;
 
 function previewValue(value: unknown): string {
   if (value === undefined) return "—";
   if (value === null) return "null";
-  if (typeof value === "string") return value.length > MAX_VALUE_PREVIEW_CHARS
-    ? `${value.slice(0, MAX_VALUE_PREVIEW_CHARS)}…`
-    : value;
+  if (typeof value === "string")
+    return value.length > MAX_VALUE_PREVIEW_CHARS
+      ? `${value.slice(0, MAX_VALUE_PREVIEW_CHARS)}…`
+      : value;
   try {
     const json = JSON.stringify(value);
     return json.length > MAX_VALUE_PREVIEW_CHARS
@@ -36,19 +44,29 @@ function previewValue(value: unknown): string {
 }
 
 interface Props {
-  diff: RegistryDiff | null;
+  /** Discriminated diff result. `unavailable` (pre-VD-2) and `truncated`
+   *  (>8 KB capture envelope) get distinct empty states. */
+  result: StepDiffResult;
   resolvedParams?: unknown;
   output?: unknown;
+  /** Bounding rect of the trigger row in viewport coordinates. The panel
+   *  positions itself just below this rect. */
+  anchorRect: DOMRect | null;
   onClose: () => void;
 }
 
 export function StepDiffHover({
-  diff,
+  result,
   resolvedParams,
   output,
+  anchorRect,
   onClose,
 }: Props) {
   const ref = useRef<HTMLDivElement>(null);
+  // Wait for the portal target to exist before rendering — avoids SSR
+  // hydration noise for the `document.body` reference.
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
 
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
@@ -58,18 +76,97 @@ export function StepDiffHover({
     return () => document.removeEventListener("keydown", onKey);
   }, [onClose]);
 
-  // Diff = null ⇒ pre-VD-2 row or runner without capture. Show graceful
-  // empty state instead of nothing.
-  if (!diff) {
+  if (!mounted || !anchorRect) return null;
+
+  // Position: fixed coordinates relative to viewport. Clamp to the right
+  // edge so the panel doesn't overflow the window (the source row is
+  // typically full-width, so left=row.left + small inset is fine).
+  const top = anchorRect.bottom + PANEL_OFFSET_PX;
+  const left = anchorRect.left + 56; // align with step-row content (past index col)
+  const maxWidth = Math.max(320, anchorRect.right - left - 16);
+
+  const panelStyle: React.CSSProperties = {
+    position: "fixed",
+    top,
+    left,
+    maxWidth,
+  };
+
+  const body = renderBody({
+    result,
+    resolvedParams,
+    output,
+  });
+
+  return createPortal(
+    <div
+      ref={ref}
+      className="step-diff-hover"
+      role="dialog"
+      aria-label="Step detail"
+      style={panelStyle}
+    >
+      {body}
+    </div>,
+    document.body,
+  );
+}
+
+function renderBody({
+  result,
+  resolvedParams,
+  output,
+}: {
+  result: StepDiffResult;
+  resolvedParams?: unknown;
+  output?: unknown;
+}) {
+  if (result.kind === "unavailable") {
     return (
-      <div ref={ref} className="step-diff-hover" role="dialog" aria-label="Step detail">
-        <div className="step-diff-section step-diff-empty">
-          Step capture unavailable for this run (pre-VD-2 or non-bridge run).
-        </div>
+      <div className="step-diff-section step-diff-empty">
+        Step capture unavailable for this run (pre-VD-2 or non-bridge run).
       </div>
     );
   }
 
+  // `truncated` still renders the params + output sections (those have
+  // their own per-field truncation envelopes that the user may want to
+  // inspect), but skips the registry-diff section since that's the noise
+  // source.
+  const isTruncated = result.kind === "truncated";
+
+  return (
+    <>
+      {resolvedParams !== undefined && (
+        <div className="step-diff-section">
+          <div className="step-diff-heading">Resolved params</div>
+          <div className="step-diff-value mono">{previewValue(resolvedParams)}</div>
+        </div>
+      )}
+
+      {output !== undefined && (
+        <div className="step-diff-section">
+          <div className="step-diff-heading">Output</div>
+          <div className="step-diff-value mono">{previewValue(output)}</div>
+        </div>
+      )}
+
+      {isTruncated ? (
+        <div className="step-diff-section">
+          <div className="step-diff-heading">Registry changes</div>
+          <div className="step-diff-empty">
+            Registry diff unavailable — this step's snapshot exceeded 8 KB and
+            was truncated. Per-field captures above are still inspectable.
+          </div>
+        </div>
+      ) : (
+        renderDiff(result.diff)
+      )}
+    </>
+  );
+}
+
+function renderDiff(diff: import("@/lib/registryDiff").RegistryDiff) {
   const totalChanges = changeCount(diff);
   const addedKeys = Object.keys(diff.added);
   const addedShown = addedKeys.slice(0, MAX_ROWS_PER_SECTION);
@@ -80,87 +177,68 @@ export function StepDiffHover({
   const removedHidden = diff.removed.length - removedShown.length;
 
   return (
-    <div ref={ref} className="step-diff-hover" role="dialog" aria-label="Step detail">
-      {/* Resolved params */}
-      {resolvedParams !== undefined && (
-        <div className="step-diff-section">
-          <div className="step-diff-heading">Resolved params</div>
-          <div className="step-diff-value mono">{previewValue(resolvedParams)}</div>
-        </div>
-      )}
-
-      {/* Output */}
-      {output !== undefined && (
-        <div className="step-diff-section">
-          <div className="step-diff-heading">Output</div>
-          <div className="step-diff-value mono">{previewValue(output)}</div>
-        </div>
-      )}
-
-      {/* Registry diff */}
-      <div className="step-diff-section">
-        <div className="step-diff-heading">
-          Registry changes <span className="muted">({totalChanges})</span>
-        </div>
-
-        {totalChanges === 0 && (
-          <div className="step-diff-empty">No registry changes from this step.</div>
-        )}
-
-        {addedShown.length > 0 && (
-          <div className="step-diff-group">
-            <div className="step-diff-group-label step-diff-added">
-              + Added ({addedKeys.length})
-            </div>
-            {addedShown.map((k) => (
-              <div key={`+${k}`} className="step-diff-row">
-                <span className="step-diff-key mono">{k}</span>
-                <span className="step-diff-value-inline mono">
-                  {previewValue(diff.added[k])}
-                </span>
-              </div>
-            ))}
-            {addedHidden > 0 && (
-              <div className="step-diff-row muted">…and {addedHidden} more</div>
-            )}
-          </div>
-        )}
-
-        {modifiedShown.length > 0 && (
-          <div className="step-diff-group">
-            <div className="step-diff-group-label step-diff-modified">
-              ~ Modified ({diff.modified.length})
-            </div>
-            {modifiedShown.map(({ key, before, after }) => (
-              <div key={`~${key}`} className="step-diff-row">
-                <span className="step-diff-key mono">{key}</span>
-                <span className="step-diff-value-inline mono">
-                  {previewValue(before)} → {previewValue(after)}
-                </span>
-              </div>
-            ))}
-            {modifiedHidden > 0 && (
-              <div className="step-diff-row muted">…and {modifiedHidden} more</div>
-            )}
-          </div>
-        )}
-
-        {removedShown.length > 0 && (
-          <div className="step-diff-group">
-            <div className="step-diff-group-label step-diff-removed">
-              − Removed ({diff.removed.length})
-            </div>
-            {removedShown.map((k) => (
-              <div key={`-${k}`} className="step-diff-row">
-                <span className="step-diff-key mono">{k}</span>
-              </div>
-            ))}
-            {removedHidden > 0 && (
-              <div className="step-diff-row muted">…and {removedHidden} more</div>
-            )}
-          </div>
-        )}
+    <div className="step-diff-section">
+      <div className="step-diff-heading">
+        Registry changes <span className="muted">({totalChanges})</span>
       </div>
+
+      {totalChanges === 0 && (
+        <div className="step-diff-empty">No registry changes from this step.</div>
+      )}
+
+      {addedShown.length > 0 && (
+        <div className="step-diff-group">
+          <div className="step-diff-group-label step-diff-added">
+            + Added ({addedKeys.length})
+          </div>
+          {addedShown.map((k) => (
+            <div key={`+${k}`} className="step-diff-row">
+              <span className="step-diff-key mono">{k}</span>
+              <span className="step-diff-value-inline mono">
+                {previewValue(diff.added[k])}
+              </span>
+            </div>
+          ))}
+          {addedHidden > 0 && (
+            <div className="step-diff-row muted">…and {addedHidden} more</div>
+          )}
+        </div>
+      )}
+
+      {modifiedShown.length > 0 && (
+        <div className="step-diff-group">
+          <div className="step-diff-group-label step-diff-modified">
+            ~ Modified ({diff.modified.length})
+          </div>
+          {modifiedShown.map(({ key, before, after }) => (
+            <div key={`~${key}`} className="step-diff-row">
+              <span className="step-diff-key mono">{key}</span>
+              <span className="step-diff-value-inline mono">
+                {previewValue(before)} → {previewValue(after)}
+              </span>
+            </div>
+          ))}
+          {modifiedHidden > 0 && (
+            <div className="step-diff-row muted">…and {modifiedHidden} more</div>
+          )}
+        </div>
+      )}
+
+      {removedShown.length > 0 && (
+        <div className="step-diff-group">
+          <div className="step-diff-group-label step-diff-removed">
+            − Removed ({diff.removed.length})
+          </div>
+          {removedShown.map((k) => (
+            <div key={`-${k}`} className="step-diff-row">
+              <span className="step-diff-key mono">{k}</span>
+            </div>
+          ))}
+          {removedHidden > 0 && (
+            <div className="step-diff-row muted">…and {removedHidden} more</div>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/dashboard/src/lib/registryDiff.ts
+++ b/dashboard/src/lib/registryDiff.ts
@@ -12,6 +12,58 @@ export interface StepWithSnapshot {
   registrySnapshot?: Record<string, unknown>;
 }
 
+/**
+ * Step shape needed for the replay pre-flight (BUG-3 fix). Mirrors
+ * what `buildMockedOutputs` looks at on the bridge side.
+ */
+export interface StepForReplayPreflight {
+  id: string;
+  status: "ok" | "skipped" | "error" | "running";
+  tool?: string;
+  output?: unknown;
+}
+
+/**
+ * Pre-flight a mocked replay: classify each step into "mocked" (will
+ * return its captured output) vs "unmocked" (will fall through to REAL
+ * execution because we have no usable capture). Mirrors `buildMockedOutputs`
+ * in `src/recipes/replayRun.ts` so the dashboard can show the user
+ * up-front what side effects to expect, instead of warning after the
+ * fact (BUG-3 from the post-merge dogfood).
+ */
+export interface ReplayPreflight {
+  mocked: string[];
+  unmocked: Array<{ id: string; tool?: string; reason: "no-capture" | "truncated" }>;
+}
+
+export function previewMockedReplay(
+  steps: StepForReplayPreflight[],
+): ReplayPreflight {
+  const mocked: string[] = [];
+  const unmocked: ReplayPreflight["unmocked"] = [];
+  for (const s of steps) {
+    if (s.status === "skipped") continue; // skipped steps aren't replayed
+    if (s.output === undefined) {
+      unmocked.push({
+        id: s.id,
+        ...(s.tool !== undefined && { tool: s.tool }),
+        reason: "no-capture",
+      });
+      continue;
+    }
+    if (isTruncatedSnapshot(s.output)) {
+      unmocked.push({
+        id: s.id,
+        ...(s.tool !== undefined && { tool: s.tool }),
+        reason: "truncated",
+      });
+      continue;
+    }
+    mocked.push(s.id);
+  }
+  return { mocked, unmocked };
+}
+
 export interface RegistryDiff {
   added: Record<string, unknown>;
   modified: Array<{ key: string; before: unknown; after: unknown }>;
@@ -19,6 +71,21 @@ export interface RegistryDiff {
 }
 
 const EMPTY: RegistryDiff = { added: {}, modified: [], removed: [] };
+
+/**
+ * True if a snapshot value is the truncation envelope produced by
+ * `captureForRunlog` for >8 KB payloads (`{[truncated]:true,bytes,preview}`).
+ * When EITHER side of a diff is the envelope, a key-by-key comparison
+ * produces meaningless noise (`bytes 15084 → 16215`), so callers should
+ * short-circuit to a "truncated" empty state instead.
+ */
+export function isTruncatedSnapshot(value: unknown): boolean {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    (value as Record<string, unknown>)["[truncated]"] === true
+  );
+}
 
 /**
  * Diff between two snapshots. `prev` may be undefined (first step or
@@ -51,20 +118,33 @@ export function diffSnapshots(
 }
 
 /**
+ * Result of `diffForStep`. Discriminated so the UI can render a distinct
+ * empty-state for truncated snapshots vs missing capture.
+ */
+export type StepDiffResult =
+  | { kind: "diff"; diff: RegistryDiff }
+  | { kind: "truncated" }
+  | { kind: "unavailable" };
+
+/**
  * Compute the diff for the step at `index` in completion order. Pulls
  * the previous step's snapshot from the array — if no prior step has a
  * snapshot, treat as initial state (everything in this step's snapshot
  * is "added").
  *
- * Returns null if the step has no `registrySnapshot` (pre-VD-2 row, or
- * runner without capture). Caller renders an "unavailable" state.
+ * Returns:
+ *  - `{kind:"unavailable"}` — step has no `registrySnapshot` (pre-VD-2
+ *    row, or runner without capture).
+ *  - `{kind:"truncated"}` — either snapshot is the >8 KB truncation
+ *    envelope; key-by-key diff would be meaningless.
+ *  - `{kind:"diff",diff}` — usable diff.
  */
 export function diffForStep(
   steps: StepWithSnapshot[],
   index: number,
-): RegistryDiff | null {
+): StepDiffResult {
   const step = steps[index];
-  if (!step?.registrySnapshot) return null;
+  if (!step?.registrySnapshot) return { kind: "unavailable" };
 
   // Walk back to find the most recent prior step with a snapshot —
   // skipped/error steps may have no snapshot, so we don't blindly use
@@ -77,7 +157,15 @@ export function diffForStep(
       break;
     }
   }
-  return diffSnapshots(prev, step.registrySnapshot);
+
+  if (
+    isTruncatedSnapshot(step.registrySnapshot) ||
+    (prev !== undefined && isTruncatedSnapshot(prev))
+  ) {
+    return { kind: "truncated" };
+  }
+
+  return { kind: "diff", diff: diffSnapshots(prev, step.registrySnapshot) };
 }
 
 /**

--- a/src/__tests__/dashboardRegistryDiff.test.ts
+++ b/src/__tests__/dashboardRegistryDiff.test.ts
@@ -92,9 +92,12 @@ describe("diffForStep", () => {
   test("first step → all of its snapshot is added", () => {
     const steps = [{ id: "s1", registrySnapshot: { s1: { data: 1 } } }];
     expect(diffForStep(steps, 0)).toEqual({
-      added: { s1: { data: 1 } },
-      modified: [],
-      removed: [],
+      kind: "diff",
+      diff: {
+        added: { s1: { data: 1 } },
+        modified: [],
+        removed: [],
+      },
     });
   });
 
@@ -103,11 +106,15 @@ describe("diffForStep", () => {
       { id: "s1", registrySnapshot: { s1: { data: 1 } } },
       { id: "s2", registrySnapshot: { s1: { data: 1 }, s2: { data: 2 } } },
     ];
-    expect(diffForStep(steps, 1)).toEqual({
-      added: { s2: { data: 2 } },
-      modified: [],
-      removed: [],
-    });
+    const result = diffForStep(steps, 1);
+    expect(result.kind).toBe("diff");
+    if (result.kind === "diff") {
+      expect(result.diff).toEqual({
+        added: { s2: { data: 2 } },
+        modified: [],
+        removed: [],
+      });
+    }
   });
 
   test("walks back past steps without snapshots", () => {
@@ -118,22 +125,77 @@ describe("diffForStep", () => {
       { id: "s2" }, // no snapshot
       { id: "s3", registrySnapshot: { s1: { data: 1 }, s3: { data: 3 } } },
     ];
-    expect(diffForStep(steps, 2)).toEqual({
-      added: { s3: { data: 3 } },
-      modified: [],
-      removed: [],
-    });
+    const result = diffForStep(steps, 2);
+    expect(result.kind).toBe("diff");
+    if (result.kind === "diff") {
+      expect(result.diff).toEqual({
+        added: { s3: { data: 3 } },
+        modified: [],
+        removed: [],
+      });
+    }
   });
 
-  test("step without snapshot → null (caller renders 'unavailable')", () => {
+  test("step without snapshot → 'unavailable'", () => {
     const steps = [{ id: "s1" }];
-    expect(diffForStep(steps, 0)).toBeNull();
+    expect(diffForStep(steps, 0)).toEqual({ kind: "unavailable" });
   });
 
-  test("respects bounds — index out of range → null", () => {
+  test("respects bounds — index out of range → 'unavailable'", () => {
     const steps = [{ id: "s1", registrySnapshot: { s1: 1 } }];
-    expect(diffForStep(steps, 5)).toBeNull();
-    expect(diffForStep(steps, -1)).toBeNull();
+    expect(diffForStep(steps, 5)).toEqual({ kind: "unavailable" });
+    expect(diffForStep(steps, -1)).toEqual({ kind: "unavailable" });
+  });
+
+  // BUG-2 (post-merge dogfood): when the registry as a whole exceeds 8 KB,
+  // VD-2's `captureForRunlog` returns a truncation envelope
+  // (`{[truncated]:true,bytes,preview}`) for `registrySnapshot`. Diffing
+  // two envelopes produces meaningless modifications like
+  // `bytes 15084 → 16215`. We short-circuit to "truncated" so the panel
+  // can render a clean empty state instead.
+
+  test("truncated current snapshot → kind:'truncated'", () => {
+    const steps = [
+      { id: "s1", registrySnapshot: { s1: { data: 1 } } },
+      {
+        id: "s2",
+        registrySnapshot: {
+          "[truncated]": true,
+          bytes: 15000,
+          preview: "...",
+        } as Record<string, unknown>,
+      },
+    ];
+    expect(diffForStep(steps, 1)).toEqual({ kind: "truncated" });
+  });
+
+  test("truncated previous snapshot → kind:'truncated'", () => {
+    const steps = [
+      {
+        id: "s1",
+        registrySnapshot: {
+          "[truncated]": true,
+          bytes: 15000,
+          preview: "...",
+        } as Record<string, unknown>,
+      },
+      { id: "s2", registrySnapshot: { s2: { data: 2 } } },
+    ];
+    expect(diffForStep(steps, 1)).toEqual({ kind: "truncated" });
+  });
+
+  test("truncated first step → kind:'truncated' (no prev to compare)", () => {
+    const steps = [
+      {
+        id: "s1",
+        registrySnapshot: {
+          "[truncated]": true,
+          bytes: 15000,
+          preview: "...",
+        } as Record<string, unknown>,
+      },
+    ];
+    expect(diffForStep(steps, 0)).toEqual({ kind: "truncated" });
   });
 });
 

--- a/src/recipes/__tests__/replayRun.test.ts
+++ b/src/recipes/__tests__/replayRun.test.ts
@@ -217,6 +217,26 @@ describe("runChainedRecipe — mockedOutputs interception", () => {
     expect(result.context.s1).toBe("hello, world");
   });
 
+  it("taskIdPrefix override produces matching taskId in run log (BUG-4)", async () => {
+    const { RecipeRunLog } = await import("../../runLog.js");
+    const log = new RecipeRunLog({ dir: tmpDir });
+    await runChainedRecipe(
+      recipe(),
+      opts({ runLog: log, taskIdPrefix: "replay:42" }),
+      realDeps(),
+    );
+    const run = log.query()[0];
+    expect(run?.taskId).toMatch(/^replay:42:test:\d+$/);
+  });
+
+  it("default taskIdPrefix is 'chained' (back-compat)", async () => {
+    const { RecipeRunLog } = await import("../../runLog.js");
+    const log = new RecipeRunLog({ dir: tmpDir });
+    await runChainedRecipe(recipe(), opts({ runLog: log }), realDeps());
+    const run = log.query()[0];
+    expect(run?.taskId).toMatch(/^chained:test:\d+$/);
+  });
+
   it("does not invoke executeAgent for mocked agent steps", async () => {
     const deps = realDeps();
     const mocked = new Map<string, unknown>([

--- a/src/recipes/chainedRunner.ts
+++ b/src/recipes/chainedRunner.ts
@@ -100,6 +100,14 @@ export interface RunOptions {
    * every step the recipe will visit.
    */
   mockedOutputs?: Map<string, unknown>;
+  /**
+   * Override the prefix used in the run log's `taskId`. Default is
+   * `chained` → `chained:<recipeName>:<startTs>`. Replay sets this to
+   * `replay:<originalSeq>` so the audit trail is searchable
+   * (`taskId LIKE 'replay:%'`) — fixes BUG-4 from the post-merge
+   * dogfood where replay runs were indistinguishable from fresh ones.
+   */
+  taskIdPrefix?: string;
 }
 
 export interface StepExecutionContext {
@@ -619,11 +627,13 @@ export async function runChainedRecipe(
       ? recipeTriggerKind
       : "recipe"
   ) as "cron" | "webhook" | "recipe";
+  const taskIdPrefix = options.taskIdPrefix ?? "chained";
+  const runTaskId = `${taskIdPrefix}:${recipe.name}:${runStartedAt}`;
   let runSeq: number | undefined;
   if (depth === 0 && options.runLog) {
     try {
       runSeq = options.runLog.startRun({
-        taskId: `chained:${recipe.name}:${runStartedAt}`,
+        taskId: runTaskId,
         recipeName: recipe.name,
         trigger: triggerKind,
         createdAt: runStartedAt,
@@ -924,7 +934,7 @@ export async function runChainedRecipe(
         const { RecipeRunLog } = await import("../runLog.js");
         const log = new RecipeRunLog({ dir: options.runLogDir });
         log.appendDirect({
-          taskId: `chained:${recipe.name}:${runStartedAt}`,
+          taskId: runTaskId,
           recipeName: recipe.name,
           trigger: triggerKind,
           status: result.success ? "done" : "error",

--- a/src/recipes/replayRun.ts
+++ b/src/recipes/replayRun.ts
@@ -115,6 +115,9 @@ export async function replayMockedRun(opts: {
     runLog: deps.runLog,
     ...(deps.activityLog !== undefined && { activityLog: deps.activityLog }),
     mockedOutputs: outputs,
+    // BUG-4 fix: tag the new run's taskId so it's distinguishable from a
+    // fresh run. Searchable as `taskId LIKE 'replay:<seq>:%'`.
+    taskIdPrefix: `replay:${originalRun.seq}`,
   };
 
   try {

--- a/src/recipes/yamlRunner.ts
+++ b/src/recipes/yamlRunner.ts
@@ -1271,6 +1271,8 @@ export async function dispatchRecipe(
       runLogDir: deps.chainedOptions?.runLogDir,
       runLog: deps.chainedOptions?.runLog,
       activityLog: deps.chainedOptions?.activityLog,
+      mockedOutputs: deps.chainedOptions?.mockedOutputs,
+      taskIdPrefix: deps.chainedOptions?.taskIdPrefix,
     };
     if (!deps.chainedDeps) {
       throw new Error(


### PR DESCRIPTION
## Summary

Four bugs caught dogfooding the merged VD arc with Playwright. All small, all surfaced together because they all sit on the same surface (the `/runs/[seq]` page + replay flow).

## BUG-1 🐞 Hover panel clipped by parent card's `overflow: hidden`

**Symptom:** only the top sliver of the diff panel showed; the bulk was hidden behind the steps card boundary.

**Cause:** `.step-diff-hover` was `position: absolute` inside a card with `overflow: hidden` (needed for the rounded inner step rows).

**Fix:** render the panel into a React Portal at `document.body` with `position: fixed` coordinates from the trigger row's `getBoundingClientRect`. Captured at hover-fire time (after the 200 ms grace) and passed via the new `anchorRect` prop.

## BUG-2 🐞 Truncated `registrySnapshot` produced noise diffs

**Symptom:** hover showed meaningless rows like `bytes 15084 → 16215` when the registry exceeded 8 KB and got VD-2's truncation envelope. Reproduced live on the `summarise` step of `branch-health` (registry held the full agent prompt context).

**Fix:** `diffForStep` now returns a discriminated union `{kind: 'diff' | 'truncated' | 'unavailable'}`. New `isTruncatedSnapshot` predicate detects the envelope on either side. `StepDiffHover` renders a clean "Registry diff unavailable — snapshot exceeded 8 KB" empty state for the truncated case (per-field captures still inspectable).

## BUG-3 🐞 Replay modal copy was misleading about side effects

**Symptom:** modal claimed *"No external API calls, no write side effects"* but `buildMockedOutputs` correctly excludes truncated outputs, which fall through to REAL execution. User only learned about it AFTER the fact via the success banner.

**Fix:** new `previewMockedReplay(steps)` helper computes the unmocked-step list client-side (mirrors `buildMockedOutputs` semantics). Modal now shows an amber pre-flight panel listing each step that will run for real, with reason (no-capture vs >8 KB truncated). Lead copy rewritten to be honest about what mocked replay actually does.

## BUG-4 🐞 Replay run's audit trail invisible

**Symptom:** replay run's `taskId` was `chained:<recipe>:<ts>` — identical shape to a fresh run. Couldn't filter `/runs` to "show me only replays" or "show me runs replayed FROM #2872".

**Fix:** new `RunOptions.taskIdPrefix` (default `"chained"`). `replayMockedRun` sets it to `replay:<originalSeq>` so every replay has a searchable `taskId LIKE 'replay:%'` shape. Threaded through both the `startRun` path and the legacy `appendDirect` fallback.

## Test plan

- [x] `dashboardRegistryDiff.test.ts` — +3 truncation cases (current/prev/first-step)
- [x] `replayRun.test.ts` — +2 (`taskIdPrefix` override produces `replay:42:test:<ts>`; default back-compat produces `chained:test:<ts>`)
- [x] `npm test` — 4278 passing (was 4273; +5 new)
- [x] `npx tsc --noEmit` — clean (root + dashboard)
- [x] **Live Playwright verification** on the post-fix dashboard:
  - **BUG-1**: panel `parentElement === document.body` (portal works) and renders past the card boundary at viewport coords
  - **BUG-2**: step 3 (summarise, truncated) shows "Registry diff unavailable — this step's snapshot exceeded 8 KB and was truncated. Per-field captures above are still inspectable."
  - **BUG-3**: modal shows amber panel `1 step will run for real (no usable capture) · git.log_since (recent) — output >8 KB, will fire real tool` + new copy `replay:2872 in its taskId`
- [ ] Reviewer: BUG-4 verified by unit tests; would need a bridge restart to dogfood live (the existing bridge process predates this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)