### PR TITLE
fix(recipes): defaultGitStaleBranches actually finds stale branches

### DIFF
--- a/src/recipes/__tests__/defaultGitStaleBranches.test.ts
+++ b/src/recipes/__tests__/defaultGitStaleBranches.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Regression test for `defaultGitStaleBranches`.
+ *
+ * Caught dogfooding the `branch-health` recipe: the implementation used
+ * `git branch --since=<date>`, but `--since` is NOT a valid flag on
+ * `git branch` (git exits 129 with `error: unknown option`). The
+ * function ALWAYS returned the `(git branches unavailable)` placeholder
+ * — the agent in the recipe correctly flagged "data unavailable".
+ *
+ * Fix uses `git for-each-ref` + JS-side date parse to identify branches
+ * whose last commit is OLDER than the cutoff (true "stale" semantics —
+ * the previous code's `--since` would have inverted the meaning even
+ * if the flag had existed).
+ */
+
+import { execSync, spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { defaultGitStaleBranches } from "../yamlRunner.js";
+
+let repoDir: string;
+
+beforeEach(() => {
+  repoDir = mkdtempSync(path.join(os.tmpdir(), "stale-branches-"));
+  // init repo with a default branch + one commit
+  execSync("git init -q -b main", { cwd: repoDir });
+  execSync("git config user.email t@t.local && git config user.name t", {
+    cwd: repoDir,
+    shell: "/bin/bash",
+  });
+  writeFileSync(path.join(repoDir, "f.txt"), "hello\n");
+  execSync("git add . && git commit -q -m init", {
+    cwd: repoDir,
+    shell: "/bin/bash",
+  });
+});
+
+afterEach(() => {
+  rmSync(repoDir, { recursive: true, force: true });
+});
+
+function commitOnNewBranch(name: string, ageDays: number) {
+  execSync(`git checkout -q -b ${name}`, { cwd: repoDir });
+  writeFileSync(path.join(repoDir, `${name}.txt`), name);
+  const ts = new Date(Date.now() - ageDays * 86_400_000).toISOString();
+  // Backdate both AUTHOR and COMMITTER so for-each-ref's committerdate
+  // sort matches the simulated age.
+  execSync(`git add . && git commit -q -m '${name}'`, {
+    cwd: repoDir,
+    shell: "/bin/bash",
+    env: {
+      ...process.env,
+      GIT_AUTHOR_DATE: ts,
+      GIT_COMMITTER_DATE: ts,
+    },
+  });
+  // Return to main so subsequent commits don't pile up on the new branch.
+  execSync("git checkout -q main", { cwd: repoDir });
+}
+
+describe("defaultGitStaleBranches", () => {
+  it("returns branches with last commit older than the cutoff", () => {
+    commitOnNewBranch("ancient", 90);
+    commitOnNewBranch("kinda-old", 45);
+    commitOnNewBranch("fresh", 1);
+
+    const out = defaultGitStaleBranches(30, repoDir);
+    // Stale: ancient (90d) + kinda-old (45d). Fresh (1d) excluded. main:
+    // committed during beforeEach (~now), excluded.
+    expect(out).toContain("ancient");
+    expect(out).toContain("kinda-old");
+    expect(out).not.toContain("fresh");
+    // Format: branch \t YYYY-MM-DD per line
+    for (const line of out.split("\n")) {
+      expect(line).toMatch(/^[a-z0-9_-]+\t\d{4}-\d{2}-\d{2}$/);
+    }
+  });
+
+  it("emits a clean 'no stale branches' message when none exceed the cutoff", () => {
+    commitOnNewBranch("recent", 5);
+    const out = defaultGitStaleBranches(30, repoDir);
+    expect(out).toBe("(no branches inactive >30d)");
+  });
+
+  it("returns the unavailable placeholder when git fails", () => {
+    // Point at a non-git directory to force a non-zero exit.
+    const nonRepo = mkdtempSync(path.join(os.tmpdir(), "not-a-repo-"));
+    try {
+      const out = defaultGitStaleBranches(30, nonRepo);
+      expect(out).toBe("(git branches unavailable)");
+    } finally {
+      rmSync(nonRepo, { recursive: true, force: true });
+    }
+  });
+
+  // Regression sentinel: prove the original `git branch --since=...` form
+  // doesn't work, so the new implementation actually had to change.
+  it("regression sentinel: 'git branch --since=...' was never a valid flag", () => {
+    const r = spawnSync(
+      "git",
+      ["branch", "--no-column", "--sort=-committerdate", "--since=2026-01-01"],
+      { cwd: repoDir, encoding: "utf-8" },
+    );
+    expect(r.status).not.toBe(0);
+    expect(`${r.stderr}`).toMatch(/unknown option `since/);
+  });
+});

--- a/src/recipes/yamlRunner.ts
+++ b/src/recipes/yamlRunner.ts
@@ -388,7 +388,8 @@ export async function runYamlRecipe(
       const b = block as Record<string, unknown>;
       if (b.type === "env" && Array.isArray(b.keys)) {
         for (const key of b.keys as string[]) {
-          if (process.env[key] !== undefined) envCtx[key] = process.env[key]!;
+          const v = process.env[key];
+          if (v !== undefined) envCtx[key] = v;
         }
       }
     }
@@ -480,7 +481,7 @@ export async function runYamlRecipe(
               const jsonMatch = /```(?:json)?\s*([\s\S]*?)```/.exec(
                 stripped,
               ) ?? [null, stripped];
-              const parsed = JSON.parse(jsonMatch[1]!.trim());
+              const parsed = JSON.parse((jsonMatch[1] ?? "").trim());
               ctx[intoKey] = parsed;
             } catch {
               ctx[intoKey] = stripped;
@@ -782,7 +783,7 @@ export function render(template: string, ctx: RunContext): string {
     if (Object.hasOwn(ctx, key)) return coerce(ctx[key]);
     // Dot-notation: resolve nested path into ctx values (JSON-parse string intermediates)
     const parts = key.split(".");
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    // biome-ignore lint/suspicious/noExplicitAny: resolved values are dynamic JSON shapes
     let val: any = ctx;
     for (const part of parts) {
       if (val == null) return "";
@@ -849,19 +850,33 @@ function defaultGitLogSince(since: string, workdir?: string): string {
   }
 }
 
-function defaultGitStaleBranches(days: number, workdir?: string): string {
+// Exported for test coverage of the regression fix (was using `git branch
+// --since=<date>` which isn't a real flag).
+export function defaultGitStaleBranches(
+  days: number,
+  workdir?: string,
+): string {
+  // Two bugs were caught dogfooding the `branch-health` recipe:
+  //   1) `git branch --since=<date>` is NOT a valid flag — git exits 129
+  //      with "unknown option `since=...`". The function used to ALWAYS
+  //      fall through to the "(git branches unavailable)" placeholder.
+  //   2) Even if `--since` had been a real flag, its semantics ("commits
+  //      since") would have produced the OPPOSITE list of what
+  //      "stale_branches" implies — branches with recent activity, not
+  //      ones that have gone quiet.
+  //
+  // Fix: use `git for-each-ref` with a `committerdate` format, parse the
+  // ISO date in JS, and emit branches whose last commit is OLDER than
+  // the cutoff. Output is one per line: `<short-name>  <YYYY-MM-DD>`.
   try {
-    const cutoff = new Date(Date.now() - days * 86_400_000)
-      .toISOString()
-      .slice(0, 10);
+    const cutoffMs = Date.now() - days * 86_400_000;
     const r = spawnSync(
       "git",
       [
-        "branch",
-        "--no-column",
-        "--sort=-committerdate",
-        "--format=%(refname:short)",
-        `--since=${cutoff}`,
+        "for-each-ref",
+        "--sort=committerdate",
+        "--format=%(refname:short)\t%(committerdate:iso-strict)",
+        "refs/heads/",
       ],
       {
         cwd: workdir ?? process.cwd(),
@@ -870,7 +885,23 @@ function defaultGitStaleBranches(days: number, workdir?: string): string {
       },
     );
     if (r.error || r.status !== 0) return "(git branches unavailable)";
-    return (r.stdout ?? "").trim();
+    const lines = (r.stdout ?? "").split("\n").filter(Boolean);
+    const stale: string[] = [];
+    for (const line of lines) {
+      const tab = line.indexOf("\t");
+      if (tab < 0) continue;
+      const name = line.slice(0, tab);
+      const dateStr = line.slice(tab + 1);
+      const ts = Date.parse(dateStr);
+      if (Number.isNaN(ts)) continue;
+      if (ts < cutoffMs) {
+        stale.push(`${name}\t${dateStr.slice(0, 10)}`);
+      }
+    }
+    if (stale.length === 0) {
+      return `(no branches inactive >${days}d)`;
+    }
+    return stale.join("\n");
   } catch {
     return "(git branches unavailable)";
   }


### PR DESCRIPTION
## Summary

The `git.stale_branches` tool has been silently broken since the file was written. Two bugs were masking each other; both caught dogfooding the post-merge `branch-health` recipe via Playwright. The agent's actual output (a screenshot the user shared) literally said *"Stale branches: data unavailable"* — turned out the tool was hardcoded to that path.

## Bug 1: invalid git flag

`defaultGitStaleBranches` used `git branch --since=<date>`. `--since` is NOT a valid flag on `git branch` (it's a `git log` flag). Git exits 129 with `error: unknown option 'since=...'`. The function ALWAYS hit the `r.status !== 0` branch and returned the `(git branches unavailable)` placeholder. No recipe ever surfaced real data.

```
$ git branch --since=2026-04-15
error: unknown option `since=2026-04-15'
$ echo "exit: $?"
exit: 129
```

## Bug 2: inverted semantics

Even if `--since` had been a real `git branch` flag, its meaning ("branches with commits since X") would have produced the OPPOSITE list of what `stale_branches` implies — fresh branches, not stale ones.

## Fix

Rewrote to use `git for-each-ref` with `committerdate:iso-strict` format. JS-side parses the date and filters to commits **older** than the cutoff:

```ts
git for-each-ref --sort=committerdate
  --format=%(refname:short)\t%(committerdate:iso-strict) refs/heads/
```

Output: one per line, `<short-name>\t<YYYY-MM-DD>`. Empty case emits `(no branches inactive >Nd)` instead of the unavailable placeholder.

## Drive-by

While re-staging `yamlRunner.ts`, biome flagged 3 pre-existing warnings I touched as part of staging. Cleaned all three: 2 non-null assertions (`process.env[k]!`, `jsonMatch[1]!` → safer fallbacks), 1 `any` annotation given a biome-ignore comment with a clear reason. Same pattern as PRs #67/#68.

## Test plan

- [x] `defaultGitStaleBranches.test.ts` — 4 tests against ephemeral real git repos:
  - 3 branches at 90d / 45d / 1d ages → returns the 2 stale, drops the fresh + main
  - All recent → emits `(no branches inactive >30d)` clean message
  - Non-git directory → returns `(git branches unavailable)` placeholder
  - **Regression sentinel**: `git branch --since=...` exits non-zero with `unknown option 'since` — locks the bug in so the fix can't be silently reverted
- [x] `npm test` — 4277 passing (was 4273; +4 new)
- [x] `npx tsc --noEmit` — clean
- [ ] Reviewer: re-run `branch-health` recipe after merge — agent's output should now show real branch names instead of "data unavailable"

🤖 Generated with [Claude Code](https://claude.com/claude-code)