### PR TITLE
fix(bridge): Streamable-HTTP tool registration parity with WebSocket

### DIFF
--- a/docs/dogfood/recipe-dogfood-results.md
+++ b/docs/dogfood/recipe-dogfood-results.md
@@ -1,0 +1,168 @@
+# Recipe Dogfood Results — 2026-04-29
+
+Live bridge: `http://localhost:3101` (alpha.34, MCP server `patchwork-local`).
+Workspace: `/Users/wesh/Documents/Anthropic Workspace/Patchwork OS`.
+Recipes dir: `~/.patchwork/recipes/`.
+
+## Safety triage
+
+| Recipe | Trigger | Verdict | Notes |
+|---|---|---|---|
+| ambient-journal | git_hook | SKIP | git_hook trigger — not safe to fire manually (would no-op without commit data). Local file.append only. |
+| branch-health | chained | FIRE | local git tools + agent + file.write to `~/.patchwork/inbox/`. |
+| ctx-loop-test | manual | FIRE | local file.write only; agent calls ctxSaveTrace/ctxQueryTraces (read+write to local jsonl). |
+| daily-status (json) | manual | FIRE | single-prompt agent, no explicit writes. |
+| daily-status (yaml) | cron | (shadowed) | same `name` as JSON variant — JSON wins on registration. Couldn't fire independently. |
+| debug-env | manual | FIRE | file.write to `/tmp/debug-env-output.txt`. |
+| debug-flatten | manual | SKIP | calls `gmail.search`/`gmail.resolveMeetingNotes` against real inbox; reads only but pulls live email content into `/tmp`. Defer. |
+| google-meet-debrief | manual | SKIP-EXTERNAL | `slack.post_message` + `meetingNotes.createLinearIssues` — would post real Slack + create real Linear issues. |
+| greet | manual | FIRE | agent-only, prints text. |
+| lint-on-save | on_file_save | SKIP | event-triggered (`{{file}}` placeholder unbound on manual fire). |
+| local-noop | manual | FIRE | agent-only "say hello" prompt. |
+| morning-brief | cron | FIRE | reads gmail/github/linear, writes only to `~/.patchwork/inbox/`. No external writes. |
+| morning-brief-slack | cron | SKIP-EXTERNAL | `slack.post_message`. |
+| my-test-recipe | manual | FAIL-PARSE | YAML parser rejects (`description: Recipe: my-test-recipe` — colon-in-value not quoted). Bridge returns 400. |
+| stale-branches | cron | FIRE | local `git.stale_branches` + file.write. |
+| triage-brief | chained | SKIP-EXTERNAL | `slack.post_message`. |
+| watch-failing-tests | on_test_run | SKIP | event-triggered. |
+
+Total fired: 8 distinct recipes. 4 skipped as external-write. 3 skipped as event-only. 1 failed YAML parse. 1 shadowed.
+
+---
+
+## Per-recipe results
+
+### 1. greet — PASS
+
+- Run seq **2892**, durationMs **8160**, status **done**.
+- JSON-format single-prompt recipe → goes through `runClaudeTask` path; no `stepResults` array on the run record.
+- Output (outputTail): `UTC timestamp: 2026-04-29T09:03:02Z\n\nRECIPE DONE: Greeted from Patchwork OS at 2026-04-29T09:03:02Z.`
+- Grounding: timestamp matches actual time of run (`createdAt: 1777453377813` = 2026-04-29 ~09:03 UTC). Grounded.
+
+### 2. local-noop — PASS
+
+- Run seq **2893**, durationMs **4031**, status **done**.
+- YAML runner. `stepResults` has one entry `id: agent_output, tool: agent, status: ok` — **no `resolvedParams` / `output` / `registrySnapshot` / `startedAt`**. VD-2 captures missing for the YAML runner.
+- outputTail: `[ok] agent`. No agent body persisted.
+- Pattern: bare YAML runner does not capture VD-2 fields. Only the chained runner does (see `branch-health`).
+
+### 3. stale-branches — RAN-BUT-QUESTIONABLE
+
+- Run seq **2894**, durationMs **12** (yes, twelve milliseconds), status **done**.
+- stepResults: `git.stale_branches → ok`, `file.write → ok` — both with no VD-2 capture (YAML runner).
+- File written: `~/.patchwork/inbox/stale-branches-2026-04-29.md`:
+  > Branches with no activity in 30+ days:
+  > **(git branches unavailable)**
+- This is the **same `(... unavailable)` bug the user said was fixed in PR #70** (commit `38b32b2 fix(recipes): defaultGitStaleBranches actually finds stale branches`). The merged fix is in `git log` but the running bridge is still serving the broken implementation. Either:
+  - (a) running bridge is a stale build (was started before the fix landed), or
+  - (b) the fix didn't actually fix `git.stale_branches` when invoked from the recipe runner code path (the fix may be on a different code path).
+- The 12-ms total runtime is also suspicious — a real `git for-each-ref` on this repo would take longer; this looks like the function bailed before exec'ing git. Strongly recommend re-checking on a freshly restarted bridge.
+
+### 4. branch-health — RAN-BUT-QUESTIONABLE (but agent caught it)
+
+- Run seq **2896**, durationMs **14859**, status **done**.
+- chained runner — VD-2 captures present. Per-step inspection:
+  - `stale` (`git.stale_branches`): `output: "(git branches unavailable)"` — same bug as #3 above. registrySnapshot reflects the broken value.
+  - `recent` (`git.log_since`): output is real commit log (15KB, truncated). Grounded — first commit `38b32b2 fix(recipes): defaultGitStaleBranches actually finds stale branches` matches HEAD.
+  - `summarise` (agent, `claude-haiku-4-5`): Agent OUTPUT explicitly flagged the bug:
+    > "Stale branches: data unavailable — `git for-each-ref` failed; rerun once branch listing is restored before drawing conclusions."
+    > "Current branch `fix/git-stale-branches` HEAD (`38b32b2`) directly fixes the stale-branch detector — re-run the recipe to confirm it now returns data."
+  - `write` (`file.write`): bytesWritten 1276, file present at `~/.patchwork/inbox/branch-health-2026-04-29.md`.
+- **Grounding verdict for the agent step: passed.** Agent did NOT fabricate stale-branch data; it correctly noticed the upstream `(git branches unavailable)` placeholder and surfaced it as a blocker. Citation in agent output literally references commit `38b32b2` (which is HEAD) — that's the agent reading the `recent` step's output, not training data.
+- However: the agent invented two SHAs not present in the upstream tool data — `d3aeaca` and `e08addd` (cited as "fix CI / typecheck / biome" commits). I grepped the tool's `output` preview — neither SHA appears. The `recent` output's preview was truncated at 15057 bytes so they could be in the truncated tail, but two unverifiable SHAs in a "Risk flag" line is mild fabrication risk. Quote:
+    > "Risk flag: multiple "fix CI / typecheck / biome" commits (`3853554`, `81d99cd`, `ace7a0c`, `d3aeaca`, `e08addd`) suggest CI was red repeatedly"
+  - `3853554`, `81d99cd`, `ace7a0c` are all in the visible portion of the output and check out. `d3aeaca` and `e08addd` are not. Could be in the truncated tail (the full output is 15KB, preview shows ~7KB), but I can't verify either way from VD-2 captures alone.
+- **Lint disagreement**: `/recipes` reports lint failed for branch-health with 6 errors, e.g. `Step 3: Unknown template reference '{{steps.stale.data}}' in agent.prompt`. But the chained runner DID resolve those placeholders correctly at runtime (the `summarise` step's `agentPrompt` contains the substituted commit log). Linter false-positives on `{{steps.<id>.data}}` syntax that the chained runner natively supports.
+
+### 5. debug-env — PASS
+
+- Run seq **2897**, durationMs **0** (literally zero — same-millisecond create/done).
+- stepResults: `file.write → ok` (no VD-2 capture).
+- File at `/tmp/debug-env-output.txt` contains `SLACK_CHANNEL_ENGINEERING=C0AUZEY8Y0Y` — env var was resolved at runtime. Note: this exposes a Slack channel ID into world-readable `/tmp` — minor info-leak in the recipe, not a bridge bug.
+
+### 6. daily-status — PASS (JSON variant only — YAML shadowed)
+
+- Run seq **2900**, durationMs **12076**, status **done**.
+- JSON-format single-prompt agent. No stepResults (single-prompt path).
+- Agent ran `git status --short`, `git log --oneline -3`, and `gh issue list` (or equivalent) and produced grounded output:
+  > "Uncommitted: 1 untracked directory `docs/dogfood/` (no staged/modified tracked files)."
+  > "Last 3 commits: `38b32b2`, `3fdfe84`, `09d3774`"
+  > "Open issues: 0"
+- Verified externally: `git status` does show only the untracked `docs/dogfood/` directory, the three SHAs match `git log --oneline -3` exactly. **Grounded — no fabrication.**
+- BUG: there are TWO recipes both named `daily-status` (one JSON, one YAML, with different content and trigger types). The bridge's `/recipes` endpoint lists both, but `/recipes/daily-status/run` resolves to the JSON one only. The YAML variant is silently unreachable. Name collisions are not validated at recipe-load time.
+
+### 7. morning-brief — RAN-BUT-QUESTIONABLE (silent agent skip)
+
+- Run seq **2899**, durationMs **4742**, status **done**.
+- All 7 stepResults report `status: ok`, including the agent step. But the agent's `durationMs: 0` is suspicious for a real LLM call.
+- File written at `~/.patchwork/inbox/morning-brief-2026-04-29.md`:
+    > # Morning brief — 2026-04-29
+    > [agent step skipped: ANTHROPIC_API_KEY not set]
+- The agent step was **silently skipped** because `ANTHROPIC_API_KEY` is unset (recipe uses `driver: claude` not `claude-code`). The runner inserted a placeholder string and reported `status: ok` to the run log. No warning in `outputTail`, no `error` field, nothing for an operator to act on.
+- **This is exactly the failure mode the user flagged — placeholder/(unavailable)-style strings being passed downstream invisibly.** Same bug pattern as `git.stale_branches` (returns a string masquerading as data when the underlying call failed).
+- The connector calls (`gmail.fetch_unread`, `github.list_issues`, etc.) all reported `ok` in 14ms–2.3s — would need VD-2 captures to know if those returned real data or also-empty placeholders. YAML runner doesn't capture VD-2, so we can't tell from runlog alone.
+
+### 8. ctx-loop-test — RAN-AND-FOUND-A-REAL-BUG
+
+- Run seq **2901**, durationMs **186320** (~3 minutes — long but completed).
+- YAML runner; agent step took 186306ms (subprocess Claude Code — expected slow).
+- Recipe self-test of the cross-session memory loop. Agent attempted `ctxSaveTrace` then `ctxQueryTraces`. Output file at `~/.patchwork/inbox/ctx-loop-test-2026-04-29.md`:
+    > **Result: FAIL**
+    >
+    > Step 1 — ctxSaveTrace
+    > Status: ERROR: `ctxSaveTrace` is not registered as an MCP tool on the running bridge. JSON-RPC error -32003 ("Tool not found", data: "ctxSaveTrace"). Root cause: `src/streamableHttp.ts:679` calls `registerAllTools` with only 14 positional args (stopping at `pluginTools`); it does NOT forward `automationHooks`, `getDisconnectInfo`, `onContextCacheUpdated`, `getExtensionDisconnectCount`, `commitIssueLinkLog`, `recipeRunLog`, or `decisionTraceLog`. The WebSocket path at `src/bridge.ts:385` passes all of them. Since `ctxSaveTrace` is conditionally registered only when `decisionTraceLog` is truthy (`src/tools/index.ts:697-705`), every Streamable-HTTP MCP session loses the tool.
+- **Verified by direct source read.** WS path (bridge.ts:385) passes 19+ args through `decisionTraceLog`; HTTP path (streamableHttp.ts:679-705) stops at `pluginTools` (12 positional args). Last positional in the HTTP call is `pluginTools` followed by closing `)`.
+- Affected tools (registered behind one of the missing deps): anything gated on `decisionTraceLog`, `recipeRunLog`, `commitIssueLinkLog`, `automationHooks`, `getDisconnectInfo`, `onContextCacheUpdated`, `getExtensionDisconnectCount`. At minimum `ctxSaveTrace`, `ctxQueryTraces`. Likely also some run-related context tools.
+- **Severity: HIGH.** The whole "context platform" (`ctx*` tools, recipe-run-aware tools) is silently unavailable to claude.ai/Codex/remote MCP clients via Streamable HTTP. Local CLI WebSocket clients are unaffected. This is also why the dashboard "RECENT DECISIONS" digest at session start works in some sessions but not others.
+
+### 9. my-test-recipe — FAIL (YAML parse error)
+
+- Bridge response: `{"ok":false,"error":"Nested mappings are not allowed in compact mappings at line 4, column 14:\n\ndescription: Recipe: my-test-recipe\n             ^\n"}`
+- Source: `description: Recipe: my-test-recipe` — second `:` confuses the YAML parser. Recipe author bug, not a bridge bug, but: the bridge could provide a clearer error pointing at `quote the description value or escape the colon`.
+
+---
+
+## VD-2 capture coverage observation
+
+Of the 8 fired recipes, **only 1 (`branch-health`, chained type) produced full VD-2 capture data** (`resolvedParams` + `output` + `registrySnapshot` + `startedAt` per step).
+
+| Recipe | Runner | VD-2 fields present? |
+|---|---|---|
+| greet | runClaudeTask (single-prompt) | n/a — no stepResults |
+| local-noop | YAML | NO — only `id/tool/status/durationMs` |
+| stale-branches | YAML | NO |
+| branch-health | chained | **YES** (full capture) |
+| debug-env | YAML | NO |
+| daily-status (json) | runClaudeTask | n/a |
+| morning-brief | YAML | NO |
+| ctx-loop-test | YAML | NO |
+
+The post-merge build the user mentioned ("VD-2 captures on each step") only emits VD-2 fields from the chained runner. The YAML runner (used by `~85%` of safe recipes including dogfood favorites like morning-brief) still emits the bare 4-field stepResult shape. If chained-runner-only is intentional, document it; if not, port the captureForRunlog hook into yamlRunner too.
+
+---
+
+## TL;DR
+
+- **`git.stale_branches` still returns `"(git branches unavailable)"`** in the running bridge — same bug PR #70 (commit `38b32b2`) was supposed to fix. Either bridge is stale or the merged fix doesn't cover this code path. Reproduces in both `stale-branches` and `branch-health` recipes.
+- **Real bug surfaced by `ctx-loop-test`**: `src/streamableHttp.ts:679` only passes 14 positional args to `registerAllTools`, while the WebSocket path passes 19. Net effect: `ctxSaveTrace`, `ctxQueryTraces`, and any tool gated on `automationHooks`/`recipeRunLog`/`commitIssueLinkLog`/`decisionTraceLog` are unregistered for HTTP-transport MCP sessions. Verified by source read.
+- **Silent agent skip in `morning-brief`**: when `ANTHROPIC_API_KEY` is unset, the `driver: claude` agent step is skipped, a placeholder string is written, and the step still reports `status: ok` with `durationMs: 0`. Same anti-pattern as the `(...unavailable)` strings we just fixed.
+- **VD-2 capture is chained-runner-only.** The YAML runner (used by most safe recipes) still emits bare stepResults. Documentation/scope mismatch with what was advertised.
+- **Recipe-name collision allowed**: `daily-status.json` and `daily-status.yaml` both registered, JSON wins, YAML is silently unreachable. Add a uniqueness check at recipe-load time.
+
+## Broken-recipe queue (ranked by severity)
+
+1. **HIGH — Streamable-HTTP `registerAllTools` truncated arg list** (streamableHttp.ts:679-705 vs bridge.ts:385). Silently disables ctx platform on remote MCP. Fix: forward the remaining 7 deps.
+2. **HIGH — `git.stale_branches` returns placeholder `"(git branches unavailable)"`** despite PR #70 in HEAD. Reproduces in `stale-branches` + `branch-health`. Action: restart bridge with latest build, retest; if still broken open follow-up.
+3. **MED — Silent agent skip when ANTHROPIC_API_KEY unset** (`morning-brief`). Recipe should error or warn loudly, not write placeholder + status:ok. Likely lives in `agentExecutor.ts` driver-selection path.
+4. **MED — VD-2 captures missing from YAML runner**. Either port `captureForRunlog` to yamlRunner, or document chained-only and update the `roadmap` claim.
+5. **LOW — `daily-status` name collision** (json + yaml). Add load-time uniqueness check; prefer the explicit `apiVersion: patchwork.sh/v1` variant when both exist.
+6. **LOW — Lint false-positives on chained-runner placeholder syntax**. `{{steps.<id>.data}}` works at runtime but lint flags 6 errors in `branch-health` and 5 in `triage-brief`. Update linter to recognize the chained-runner template grammar.
+7. **LOW — `my-test-recipe` YAML parse failure surfaces a generic parser message.** Could detect "colon-in-description" and suggest quoting.
+8. **LOW — `debug-env` writes `SLACK_CHANNEL_ENGINEERING` to world-readable `/tmp`.** Recipe author issue, not bridge. Low impact (channel ID is not a secret), but worth noting if the recipe is ever shared.
+
+## General patterns
+
+- **Placeholder-string failure mode is pervasive.** Three independent instances surfaced in 8 recipes: `(git branches unavailable)` (git tool), `[agent step skipped: ANTHROPIC_API_KEY not set]` (agent driver), and the upstream cause of the `ctx-loop-test` failure (HTTP transport returning `tool not found` rather than the run aborting). Pattern: a sub-component fails, returns an explanatory string, the runner dutifully marks it `status: ok` and passes the string downstream. Downstream agents either fabricate around it or propagate it. **Strong case for `result.success = false` + `result.error` envelopes everywhere a tool can fail soft.**
+- **Agent grounding is generally good when upstream data is real.** `branch-health` agent honestly flagged the bad `git.stale_branches` data. `daily-status.json` agent verifiably read git status. Two minor SHA-fabrication candidates in `branch-health` summary, but those could be inside the truncated VD-2 preview.
+- **Run detail JSON is heavy.** A 14-second `branch-health` run produces a 49KB run-detail response because the registrySnapshot is duplicated at every step (each step has the entire prior chain's data). Consider diffing snapshots or capping individual field bytes.
+- **Recipe lint and runtime semantics are out of sync** in two places: chained-runner `{{steps.X.data}}` (runtime OK, lint fails), and the JSON `daily-status.json` `kind: prompt` field (runtime OK, lint fails). Treat lint:false as advisory only and surface it in `/recipes` more prominently if so.

--- a/docs/dogfood/recipe-inventory.md
+++ b/docs/dogfood/recipe-inventory.md
@@ -1,0 +1,152 @@
+# Patchwork Recipe Inventory — Dogfood Audit
+
+Survey of every recipe in `~/.patchwork/recipes/` (user installs) and `examples/recipes/` (bundled). Inspection only — nothing executed.
+
+Tool registry source-of-truth: [src/recipes/tools/](../../src/recipes/tools/) (60 registered ids across 16 namespaces).
+
+## 1. Recipe roster
+
+### `~/.patchwork/recipes/` (user-installed)
+
+| Name | Trigger | Steps | Tools | Agent | Safety |
+|---|---|---|---|---|---|
+| [ambient-journal](../../../../.patchwork/recipes/ambient-journal.yaml) | git_hook (post-commit) | 1 | `file.append` | no | WRITE-LOCAL |
+| [branch-health](../../../../.patchwork/recipes/branch-health.yaml) | chained | 4 | `git.stale_branches`, `git.log_since`, `file.write` | yes | WRITE-LOCAL |
+| [ctx-loop-test](../../../../.patchwork/recipes/ctx-loop-test.yaml) | manual | 3 | `git.log_since`, `file.write` (+ agent calls `ctxSaveTrace`/`ctxQueryTraces` via MCP) | yes | WRITE-LOCAL |
+| [daily-status.json](../../../../.patchwork/recipes/daily-status.json) | manual | 1 (prompt) | none (raw shell via prompt) | yes | SAFE-READ |
+| [daily-status.yaml](../../../../.patchwork/recipes/daily-status.yaml) | cron `0 8 * * *` | 4 | `git.log_since`, `file.read`, `file.write` | yes | WRITE-LOCAL |
+| [debug-env](../../../../.patchwork/recipes/debug-env.yaml) | manual | 1 | `file.write` (to `/tmp`) | no | WRITE-LOCAL |
+| [debug-flatten](../../../../.patchwork/recipes/debug-flatten.yaml) | manual | 5 | `gmail.search`, `gmail.resolveMeetingNotes`, `meetingNotes.parse`, `meetingNotes.flatten`, `file.write` | no | WRITE-LOCAL |
+| [google-meet-debrief](../../../../.patchwork/recipes/google-meet-debrief.yaml) | manual | 7 | `gmail.search`, `gmail.resolveMeetingNotes`, `meetingNotes.parse`, `meetingNotes.createLinearIssues`, `meetingNotes.flatten`, `slack.post_message`, `notify.push` | no | WRITE-EXTERNAL |
+| [greet.json](../../../../.patchwork/recipes/greet.json) | manual | 1 | none | yes | SAFE-READ |
+| [lint-on-save](../../../../.patchwork/recipes/lint-on-save.yaml) | on_file_save | 2 | `diagnostics.get`, `file.append` | no | WRITE-LOCAL |
+| [morning-brief-slack](../../../../.patchwork/recipes/morning-brief-slack.yaml) | cron `0 8 * * 1-5` | 5 | `github.list_prs`, `linear.list_issues`, `calendar.list_events`, `file.write`, `slack.post_message` | yes | WRITE-EXTERNAL |
+| [morning-brief](../../../../.patchwork/recipes/morning-brief.yaml) | cron `0 8 * * 1-5` | 6 | `gmail.fetch_unread`, `git.log_since`, `github.list_issues`, `github.list_prs`, `linear.list_issues`, `file.write` | yes | WRITE-LOCAL |
+| [my-test-recipe](../../../../.patchwork/recipes/my-test-recipe.yaml) | manual | 1 | `file.write` | no | WRITE-LOCAL |
+| [stale-branches](../../../../.patchwork/recipes/stale-branches.yaml) | cron `0 9 * * MON` | 2 | `git.stale_branches`, `file.write` | no | WRITE-LOCAL |
+| [test-recipe-local/local-noop](../../../../.patchwork/recipes/test-recipe-local/local-noop.yaml) | manual | 1 | none | yes | SAFE-READ |
+| [triage-brief](../../../../.patchwork/recipes/triage-brief.yaml) | chained | 4 | `linear.list_issues`, `git.log_since`, `slack.post_message` | yes | WRITE-EXTERNAL |
+| [watch-failing-tests](../../../../.patchwork/recipes/watch-failing-tests.yaml) | on_test_run (filter:failure) | 2 | `file.append` | yes | WRITE-LOCAL |
+
+### `examples/recipes/` (bundled)
+
+| Name | Trigger | Steps | Tools | Agent | Safety |
+|---|---|---|---|---|---|
+| [chained-followup-child](../../examples/recipes/chained-followup-child.yaml) | chained | 1 | none | yes | SAFE-READ |
+| [chained-followup-demo](../../examples/recipes/chained-followup-demo.yaml) | chained | 4 | `inbox.fetch_threads`*, `notes.lookup_recent_context`*, sub-recipe call | yes | BROKEN-LIKELY |
+| [google-meet-debrief-single](../../examples/recipes/google-meet-debrief-single.yaml) | manual | 3 | `gmail.getMessage`, `drive.fetchDoc`, `meetingNotes.parse` | yes | SAFE-READ |
+| [google-meet-debrief](../../examples/recipes/google-meet-debrief.yaml) | manual | 7 | `gmail.search`, `gmail.resolveMeetingNotes`, `meetingNotes.parse`, `meetingNotes.createLinearIssues`, `meetingNotes.flatten`, `slack.post_message`, `notify.push`* | no | WRITE-EXTERNAL |
+| [morning-inbox-triage](../../examples/recipes/morning-inbox-triage.yaml) | cron `30 4 * * *` | 7 | `inbox.fetch`*, `inbox.getThread`*, `inbox.draftReply`*, `inbox.archive`*, `dashboard.render`*, `notify.push`* | yes | BROKEN-LIKELY |
+
+### `examples/recipes/starter-pack/` (bundled — vision/draft tier)
+
+| Name | Trigger | Steps | Tools | Agent | Safety |
+|---|---|---|---|---|---|
+| [apology-drafter](../../examples/recipes/starter-pack/apology-drafter.yaml) | manual | 3 | `dashboard.render`* | yes | BROKEN-LIKELY |
+| [awkward-message-rewriter](../../examples/recipes/starter-pack/awkward-message-rewriter.yaml) | manual | 3 | `dashboard.render`* | yes | BROKEN-LIKELY |
+| [birthday-watcher](../../examples/recipes/starter-pack/birthday-watcher.yaml) | cron `0 8 * * *` | 4 | `contacts.upcomingDates`*, `inbox.search`*, `notes.search`*, `dashboard.render`* | yes | BROKEN-LIKELY |
+| [calendar-defense](../../examples/recipes/starter-pack/calendar-defense.yaml) | cron `0 7 * * 1-5` | 4 | `calendar.list`*, `dashboard.render`* | yes | BROKEN-LIKELY |
+| [compliment-archive](../../examples/recipes/starter-pack/compliment-archive.yaml) | event `inbox.new_message` | 3 | `file.append`, `log.info`* | yes | BROKEN-LIKELY |
+| [decision-journal](../../examples/recipes/starter-pack/decision-journal.yaml) | manual | 3 | `file.write`, `scheduler.enqueue`* | yes | BROKEN-LIKELY |
+| [disagreement-cooldown](../../examples/recipes/starter-pack/disagreement-cooldown.yaml) | event `inbox.draft_saved` | 5 | `queue.delay`*, `dashboard.render`* | yes | BROKEN-LIKELY |
+| [errand-batcher](../../examples/recipes/starter-pack/errand-batcher.yaml) | cron `0 9 * * 6` | 3 | `notes.search`*, `inbox.search`*, `dashboard.render`* | yes | BROKEN-LIKELY |
+| [evening-shutdown](../../examples/recipes/starter-pack/evening-shutdown.yaml) | cron `0 18 * * 1-5` | 5 | `calendar.list`*, `inbox.search`*, `file.append`, `system.setDND`* | yes | BROKEN-LIKELY |
+| [gift-brain](../../examples/recipes/starter-pack/gift-brain.yaml) | cron `0 9 * * *` | 5 | `notes.search`*, `contacts.list`*, `file.merge_yaml`*, `contacts.upcomingDates`*, `notify.push`* | yes | BROKEN-LIKELY |
+| [lost-thread-finder](../../examples/recipes/starter-pack/lost-thread-finder.yaml) | cron `0 17 * * 5` | 4 | `inbox.search`*, `inbox.getThread`*, `dashboard.render`* | yes | BROKEN-LIKELY |
+| [meeting-prep](../../examples/recipes/starter-pack/meeting-prep.yaml) | event `calendar.upcoming` | 4 | `calendar.get`*, `inbox.search`*, `fetch.url`*, `notify.push`* | yes | BROKEN-LIKELY |
+| [mood-tagger](../../examples/recipes/starter-pack/mood-tagger.yaml) | cron `0 10,14,20 * * *` | 2 | `notify.ask`*, `file.append` | no | BROKEN-LIKELY |
+| [morning-brief (starter)](../../examples/recipes/starter-pack/morning-brief.yaml) | cron `0 6 * * 1-5` | 2 | `weather.today`*, `calendar.list`*, `inbox.search`*, `notes.last`*, `notify.push`* | yes | BROKEN-LIKELY |
+| [quiet-hours-enforcer](../../examples/recipes/starter-pack/quiet-hours-enforcer.yaml) | event `notification.incoming` | 2 | `notify.push`*, `queue.append`* | yes | BROKEN-LIKELY |
+| [reading-capture](../../examples/recipes/starter-pack/reading-capture.yaml) | event `inbox.new_message` | 3 | `file.append` | yes | BROKEN-LIKELY (trigger filter unsupported) |
+| [receipt-logger](../../examples/recipes/starter-pack/receipt-logger.yaml) | event `inbox.new_message` | 4 | `file.append`, `notify.push`* | yes | BROKEN-LIKELY |
+| [social-battery-planner](../../examples/recipes/starter-pack/social-battery-planner.yaml) | cron `0 19 * * 0` | 3 | `calendar.list`*, `dashboard.render`* | yes | BROKEN-LIKELY |
+| [subscription-watchdog](../../examples/recipes/starter-pack/subscription-watchdog.yaml) | cron `0 10 1 * *` | 4 | `notes.search`*, `inbox.search`*, `dashboard.render`* | yes | BROKEN-LIKELY |
+| [sunday-reset](../../examples/recipes/starter-pack/sunday-reset.yaml) | cron `0 18 * * 0` | 5 | `calendar.list`*, `inbox.search`*, `notes.list`*, `dashboard.render`* | yes | BROKEN-LIKELY |
+| [travel-prep](../../examples/recipes/starter-pack/travel-prep.yaml) | event `calendar.upcoming` | 4 | `inbox.search`*, `calendar.get`*, `weather.forecast`*, `dashboard.render`* | yes | BROKEN-LIKELY |
+
+`*` = tool not in `src/recipes/tools/` registry (see [§4](#4-anything-weird)).
+
+## 2. Safety classification
+
+### SAFE-READ (4)
+Only read-only registered tools or pure-agent steps. No writes anywhere.
+- `daily-status.json`, `greet.json`, `test-recipe-local/local-noop`, `chained-followup-child`
+- `google-meet-debrief-single` (chain ends at `meetingNotes.parse` — no write/post step)
+
+### WRITE-LOCAL (10)
+Read tools + writes confined to `~/.patchwork/`, workspace, or `/tmp`.
+- `ambient-journal`, `branch-health`, `ctx-loop-test`, `daily-status.yaml`, `debug-env`, `debug-flatten`, `lint-on-save`, `morning-brief`, `my-test-recipe`, `stale-branches`, `watch-failing-tests`
+
+### WRITE-EXTERNAL (3) — DO NOT DOGFOOD WITHOUT APPROVAL
+- `~/.patchwork/recipes/google-meet-debrief.yaml` — posts to Slack + creates Linear issues
+- `~/.patchwork/recipes/morning-brief-slack.yaml` — posts to `all-massappealdesigns` daily 08:00
+- `~/.patchwork/recipes/triage-brief.yaml` — posts to `all-massappealdesigns`
+- `examples/recipes/google-meet-debrief.yaml` — same external footprint as the user copy
+
+### BROKEN-LIKELY (21)
+All starter-pack recipes plus `chained-followup-demo` and `morning-inbox-triage`. They reference unregistered tool namespaces that have no implementation under [src/recipes/tools/](../../src/recipes/tools/):
+
+| Missing tool | Recipes |
+|---|---|
+| `inbox.*` (`fetch`, `fetch_threads`, `getThread`, `search`, `draftReply`, `archive`) | morning-inbox-triage, chained-followup-demo, birthday-watcher, errand-batcher, evening-shutdown, lost-thread-finder, meeting-prep, morning-brief (starter), receipt-logger, sunday-reset, subscription-watchdog, travel-prep |
+| `notes.*` (`search`, `list`, `last`, `lookup_recent_context`) | gift-brain, errand-batcher, sunday-reset, subscription-watchdog, chained-followup-demo, morning-brief (starter) |
+| `dashboard.render` | apology-drafter, awkward-message-rewriter, birthday-watcher, calendar-defense, disagreement-cooldown, errand-batcher, lost-thread-finder, social-battery-planner, subscription-watchdog, sunday-reset, travel-prep, morning-inbox-triage |
+| `notify.push` / `notify.ask` | gift-brain, meeting-prep, mood-tagger, morning-brief (starter), quiet-hours-enforcer, receipt-logger, travel-prep, morning-inbox-triage, both google-meet-debrief copies |
+| `contacts.*` (`upcomingDates`, `list`) | birthday-watcher, gift-brain |
+| `calendar.list`, `calendar.get` | calendar-defense, evening-shutdown, social-battery-planner, sunday-reset, meeting-prep, travel-prep, morning-brief (starter). Registry has `calendar.list_events`, not `calendar.list`. |
+| `weather.today`, `weather.forecast` | morning-brief (starter), travel-prep |
+| `queue.delay`, `queue.append` | disagreement-cooldown, quiet-hours-enforcer |
+| `scheduler.enqueue`, `system.setDND`, `log.info`, `file.merge_yaml`, `fetch.url` | decision-journal, evening-shutdown, compliment-archive, gift-brain, meeting-prep |
+
+The starter-pack recipes are vision-tier sketches — they describe a future surface area, not a runnable surface. They should likely be moved to `examples/recipes/vision/` or annotated with a `# vision-only` banner so users don't try to install them.
+
+Note: `git.stale_branches` was returning `(git branches unavailable)` per CLAUDE.md PR #70 context, but the registry entry is present and the implementation is delegated through `deps.gitStaleBranches`. Recipes using it (`branch-health`, `stale-branches`) classify as WRITE-LOCAL rather than BROKEN-LIKELY pending PR #70 landing.
+
+## 3. Dogfood recommendations
+
+Recipes I'd actually fire (SAFE-READ + WRITE-LOCAL only):
+
+| Recipe | Rationale |
+|---|---|
+| `greet.json` | Sanity-check single-step agent recipe; zero side effects. |
+| `test-recipe-local/local-noop` | Pure agent hello-world — confirms recipe loader + agent driver wiring. |
+| `daily-status.json` | Plain prompt, no tools — validates agent-only recipe path. |
+| `my-test-recipe` | Single `file.write` to inbox — confirms templating (`{{date}}` is intentionally absent here). |
+| `ambient-journal` | post-commit hook → file.append to `~/.patchwork/journal/`. Good chained-trigger smoke test. |
+| `lint-on-save` | on_file_save trigger → diagnostics + inbox append. Tests on-save hook glob filtering. |
+| `stale-branches` | Cron → git.stale_branches → inbox file. Will dogfood the PR #70 fix. |
+| `daily-status.yaml` | Cron + git.log_since + file.read (optional) + agent + file.write. Multi-step parity test. |
+| `branch-health` | Chained trigger w/ 4 steps incl. parallel `awaits` — exercises chained DAG. |
+| `morning-brief` | Heaviest read-only fan-out: gmail + git + github + linear + agent + local file. Best end-to-end SAFE-READ workhorse if connectors authed. |
+| `watch-failing-tests` | on_test_run trigger → agent + file.append. Validates failure-filter automation hook. |
+| `google-meet-debrief-single` (examples) | Manual, parses one Gmail message ID, no posting/issue creation. Safe meeting-notes pipeline test. |
+| `ctx-loop-test` | Validates ctxSaveTrace/ctxQueryTraces round-trip — only run via Dashboard, NOT `patchwork recipe run` (per its own NOTE block). |
+| `debug-env`, `debug-flatten` | Diagnostics only; both write to `/tmp`. Useful when triaging env-var or meeting-flatten regressions. |
+
+Skip these without explicit user approval (WRITE-EXTERNAL):
+- `morning-brief-slack` — posts to `all-massappealdesigns` (real channel).
+- `triage-brief` — same channel.
+- both `google-meet-debrief` recipes — create Linear issues + Slack post.
+
+## 4. Anything weird
+
+- **Hardcoded Slack channel ID in bundled example**: [examples/recipes/google-meet-debrief.yaml](../../examples/recipes/google-meet-debrief.yaml) lines 60-62 use literal `C0AUZEY8Y0Y` for all three team channels (Sales/Marketing/Engineering all routed to the same id). The user copy at `~/.patchwork/recipes/google-meet-debrief.yaml` correctly reads from env vars. Bundled example should be templated.
+- **Bare channel name in user recipes**: `morning-brief-slack` and `triage-brief` post to `channel: all-massappealdesigns` literal. Hardcoded org/channel in user-owned files is fine, but if either is the canonical example, scrub before publishing.
+- **`notify.push` used by user-installed recipe but not registered**: `~/.patchwork/recipes/google-meet-debrief.yaml` step `notify` calls `notify.push` — same gap as the bundled examples. Step will likely no-op or error. Consider stripping or replacing with a `file.append` to inbox.
+- **`drive.fetchDoc` referenced but not declared as a step tool**: [google-meet-debrief-single.yaml](../../examples/recipes/google-meet-debrief-single.yaml) declares `tools: [drive.fetchDoc]` *under an agent step* — the agent is expected to call it. `drive.fetchDoc` IS in the registry, so this works only if the agent driver supports per-step tool grants. Worth confirming this code path is wired.
+- **Cron at 04:30 UTC**: `morning-inbox-triage` at `30 4 * * *` is fine if user is in a -5 to -8 timezone, but on a UTC server it fires at 4:30am UTC. Sanity-check before scheduling.
+- **`reading-capture` event filter syntax**: uses `from:` array of literal addresses on `inbox.new_message`. Even if `inbox.new_message` existed, the filter shape is undocumented in [src/recipes/tools/](../../src/recipes/tools/).
+- **`{{YYYY-MM-DD}}` placeholder convention**: starter-pack uses `{{YYYY-MM-DD}}`, `{{ISO_NOW}}`, `{{YYYY-MM}}` — the runtime supports `{{date}}` and `{{time}}` (per `ambient-journal` and others). These won't substitute.
+- **Mixed `output:` vs `into:`**: `branch-health` and `triage-brief` use `output: <name>` for step result naming; every other recipe uses `into:`. Both syntaxes appear to work but the inconsistency is confusing. Worth normalizing in a follow-up cleanup.
+- **`risk` field used inconsistently**: bundled examples and starter-pack tag every step with `risk: low|medium|high`; user recipes mostly omit it. Either it's load-bearing for approvals (in which case the user recipes are unsafe by default) or it's documentation-only (in which case the bundled examples are noisy). Spec gap.
+- **`maxConcurrency` / `maxDepth` only on chained recipes**: `branch-health`, `triage-brief`, `chained-followup-demo`, `chained-followup-child` set them; nothing else. Confirm defaults exist for the other trigger types.
+- **`parallel:` block in starter-pack `morning-brief.yaml` and `travel-prep.yaml`**: this isn't the `awaits:`-based DAG used by `branch-health`/`triage-brief`. Two different parallelism dialects in one repo.
+- **`apiVersion: patchwork.sh/v1` only on `my-test-recipe`**: every other recipe uses `version: 1.0.0` or no version field. Schema-version drift.
+- **`branch:` step in `quiet-hours-enforcer`**: conditional branching syntax (`when:` / `otherwise:`) appears nowhere else in the corpus and isn't reflected in [src/recipes/tools/](../../src/recipes/tools/). Likely vision-only.
+- **No `playwright/` recipes despite directory existing**: `examples/recipes/playwright/` is empty. Either drop the dir or land the recipes that explain why it's there.
+
+## TL;DR
+
+- 27 recipes total: **17 user-installed** (4 SAFE-READ, 10 WRITE-LOCAL, 3 WRITE-EXTERNAL), **5 examples**, **21 starter-pack** — most starter-pack recipes are BROKEN-LIKELY because they reference unregistered tool namespaces (`inbox.*`, `notes.*`, `dashboard.render`, `notify.*`, `weather.*`, `contacts.*`, etc.).
+- Safe dogfood targets: `greet`, `local-noop`, `daily-status.*`, `ambient-journal`, `lint-on-save`, `stale-branches`, `branch-health`, `morning-brief`, `watch-failing-tests`, `google-meet-debrief-single`. Skip `morning-brief-slack`, `triage-brief`, and both `google-meet-debrief` recipes — they post to a real Slack channel.
+- Highest-leverage cleanups: (a) move starter-pack to `examples/recipes/vision/` until tools land, (b) fix hardcoded channel id in bundled `google-meet-debrief.yaml`, (c) normalize `output:`/`into:` and `version`/`apiVersion` schema drift, (d) confirm `git.stale_branches` PR #70 is merged before relying on `branch-health`/`stale-branches` output.

--- a/docs/dogfood/tool-audit.md
+++ b/docs/dogfood/tool-audit.md
@@ -1,0 +1,148 @@
+# Recipe tool audit — silent-failure patterns
+
+**Scope:** `src/recipes/tools/*`, `src/recipes/yamlRunner.ts`, `src/recipes/agentExecutor.ts`, and the connector adapters they invoke.
+**Trigger:** the `defaultGitStaleBranches` regression — `git branch --since=<date>` is not a real flag, so the tool silently returned `(git branches unavailable)` for every invocation while the recipe agent dutifully summarised "data unavailable". Audit looks for the same class of bug elsewhere.
+**Method:** read every registered recipe tool + every default `RunnerDeps` impl. Cross-checked against the connectors they delegate to. No tests run, no code changed.
+
+---
+
+## Findings
+
+### 1. `defaultGitLogSince` — silent placeholder swallows every failure
+- **File:** `src/recipes/yamlRunner.ts:834-851`
+- **Pattern:** silent placeholder return (category 2)
+- **Reproduction:** invoke `git.log_since` from a non-git directory, or with a malformed `since` value, or when git itself is missing on PATH:
+  ```ts
+  // From inside /tmp:
+  defaultGitLogSince("24h", "/tmp")
+  // → "(git log unavailable)"
+  ```
+  Identical output for: not a git repo, exit-code 128, git binary missing, malformed `--since` arg. Caller cannot distinguish.
+- **Severity:** **HIGH** — used by shipped recipe `daily-status.yaml` (`templates/recipes/daily-status.yaml:7`) and `morning-brief*.yaml`. The downstream agent prompt embeds `{{commits}}` directly and has no way to detect the placeholder.
+- **Suggested fix:** stop returning a string placeholder — surface `result.stderr` and exit code via a `JSON.stringify({ok:false, error:...})` payload so the runner's `parsed.ok===false` branch (yamlRunner.ts:531-538) can mark the step as `error`.
+
+### 2. `defaultGitStaleBranches` — same placeholder pattern (but now CORRECT impl)
+- **File:** `src/recipes/yamlRunner.ts:855-908`
+- **Pattern:** silent placeholder return (category 2). The original bug (invalid flag) is fixed, but the placeholder pattern remains.
+- **Reproduction:** same as #1 — non-git dir, missing binary, etc. all collapse to `"(git branches unavailable)"`.
+- **Severity:** **MEDIUM** — used by `templates/recipes/stale-branches.yaml`. Same agent-can't-tell problem as #1, just less common path now that the underlying CLI is correct.
+- **Suggested fix:** ditto — return `{ok:false, error:result.stderr}` JSON so yamlRunner marks the step error rather than passing the placeholder through to the downstream prompt.
+
+### 3. `defaultGetDiagnostics` — hardcoded empty-string stub
+- **File:** `src/recipes/yamlRunner.ts:936` (the entire impl is `() => ""`).
+- **Pattern:** missing implementation (category 3) / stub default (category 4).
+- **Reproduction:** any recipe step `tool: diagnostics.get` with no override:
+  ```yaml
+  - tool: diagnostics.get
+    uri: file:///some/path.ts
+    into: diags
+  ```
+  → `ctx.diags === ""` regardless of what the file looks like.
+- **Severity:** **MEDIUM** — `diagnostics.get` is publicly registered (`src/recipes/tools/diagnostics.ts:13-41`), advertised in the schema (`outputSchema: { type: "string", description: "errors, warnings count or detailed list" }`) and the description claims `(requires bridge connection; returns stub if unavailable)` — but no production caller wires a real `getDiagnostics` impl. The result is the tool *always* returns empty regardless of bridge connectivity.
+- **Suggested fix:** either delete the registration outright (no shipped recipe uses it), or wire `bridgeClient.getDiagnostics({uri})` through `RunnerDeps.getDiagnostics` from the bridge entrypoint that constructs `RunnerDeps`. Until then, returning `""` indistinguishably from "no errors" is the same class of bug as #1/#2.
+
+### 4. `sinceToGmailQuery` — silently coerces non-{Nh,Nd} input to "1d"
+- **File:** `src/recipes/tools/gmail.ts:214-222`
+- **Pattern:** invalid CLI flag handling (category 1) / hardcoded default leak (category 5).
+- **Reproduction:** `gmail.fetch_unread`'s schema (`CommonSchemas.since` in `toolRegistry.ts:381-384`) advertises `'2026-01-01'` as a valid form, but:
+  ```ts
+  sinceToGmailQuery("2026-01-01")  // includes("d") → false; includes("h") → false → "1d"
+  sinceToGmailQuery("48h")         // → "48h" (correct)
+  sinceToGmailQuery("2d")          // → "2d"  (correct)
+  sinceToGmailQuery("3w")          // → "1d"  (silently!)
+  sinceToGmailQuery("60m")         // → "1d"  (silently!)
+  sinceToGmailQuery("today")       // includes("d") → true → "toayd" → Gmail rejects, returns 0 results
+  ```
+  Worst case: ISO date silently becomes "last 24h"; minutes/weeks silently become "last 24h"; `"today"` produces a malformed `newer_than:toayd` query that Gmail returns no rows for. None of these surface as errors — count just comes back as 0.
+- **Severity:** **HIGH** — `gmail.fetch_unread` ships in `morning-brief*.yaml` and `inbox-triage.yaml`. Schema mismatch + silent coercion = the inbox briefs may report 0 emails when many exist.
+- **Suggested fix:** parse with `^(\d+)([hd])$/i`; for non-matching input throw `Error(\`Unsupported since format: ${since}\`)` so the runner's outer try/catch (yamlRunner.ts:540-543) propagates the failure into a step error.
+
+### 5. `listIssues`/`listPRs` (GitHub connector) — swallow ALL errors into `[]`
+- **File:** `src/connectors/github.ts:143-156` and `:177-192`
+- **Pattern:** silent placeholder (category 2).
+- **Reproduction:** any MCP failure (rate limit, expired token, network, `list_issues` tool removed, GraphQL schema change) collapses to `[]` indistinguishably from "user has no open issues":
+  ```ts
+  // Token expired:
+  await listIssues({ assignee: "@me" })  // → []
+  // Repo doesn't exist:
+  await listIssues({ repo: "ghost/nonexistent" })  // → []
+  ```
+- **Severity:** **HIGH** — `github.list_issues`/`github.list_prs` recipe tools (`src/recipes/tools/github.ts:13-52,58-97`) wrap these directly. The recipe step receives `{count:0,issues:[]}` with NO error field on either failure mode. Any morning-brief / triage recipe that tries to count issues silently reports zero.
+- **Suggested fix:** distinguish "not connected" (return `[]` is OK — but log a warning) from runtime errors. For runtime errors, throw. The recipe-tool wrapper already catches exceptions (it wraps in JSON), so throwing here actually surfaces the error.
+
+### 6. `linear.listIssues` (connector) — same swallow-to-`[]` pattern
+- **File:** `src/connectors/linear.ts:148-179`
+- **Pattern:** silent placeholder (category 2). Same shape as #5 but with one wrinkle — it re-throws when the message contains `"not connected"` (line 175-176), so disconnect IS surfaced. Other errors (rate-limit, schema drift, MCP transport error) silently → `[]`.
+- **Reproduction:**
+  ```ts
+  // Connected, but Linear MCP rate-limits us:
+  await listIssues({ assigneeMe: true })  // → [] (rate-limit response swallowed)
+  ```
+- **Severity:** **MEDIUM** — `linear.list_issues` recipe tool (`src/recipes/tools/linear.ts:51-92`) sets `error: "Linear not connected"` only on `loadTokens()===false`. The connector's catch-all eats every other failure mode silently.
+- **Suggested fix:** rethrow non-disconnect errors; let the recipe tool's `try/catch` (linear.ts:84-90) translate them into the `error` field.
+
+### 7. `gmailSearch` / `gmailFetchThread` / `gmailGetMessage` — collapse all transport errors to a single string
+- **File:** `src/recipes/tools/gmail.ts:9-80`, `:100-141`, `:143-212`
+- **Pattern:** silent placeholder with low-fidelity error string (category 2).
+- **Reproduction:**
+  ```ts
+  // Network blip mid-fetch
+  await gmailSearch("is:unread", 10, deps)  // catches → returns {count:0, messages:[], error:"Gmail fetch failed"}
+  ```
+  Any fetch throw becomes `"Gmail fetch failed"` (line 78). Any non-OK HTTP becomes `"Gmail API error"` (line 42, 129, 169). Caller sees no status code, no body, no method, no URL.
+- **Severity:** **MEDIUM** — error IS surfaced as a string in the JSON, so the runner's `parsed.ok===false` check doesn't fire (the JSON has `count:0` not `ok:false`). Recipe step shows status `ok` despite Gmail being down. See yamlRunner.ts:531-538 — only `{ok:false}` triggers `stepError`.
+- **Suggested fix:** include `ok:false` in the error-result envelope so the runner sees the failure, OR change yamlRunner's heuristic to also treat non-empty `error` field as a step failure.
+
+### 8. `meetingNotes.createLinearIssues` — `listLabels()` failure → silently drops all labels
+- **File:** `src/recipes/tools/meetingNotes.ts:517-528`
+- **Pattern:** silent fallback (category 2, narrow scope).
+- **Reproduction:** if Linear's `list_labels` API fails, the catch sets `allowedLabels = undefined`, every issue is created label-less. The output JSON contains no warning. The route via `meetingNotes` is the *only* labelling path, so a transient list_labels failure removes all routing labels with no signal.
+- **Severity:** **MEDIUM** — production-shipped (meeting-notes recipes use it). Silent label loss is harder to spot than silent issue-create failure.
+- **Suggested fix:** push a warning into `out.warning` (alongside `teamFallbackNote` at line 600), e.g. `"Could not list Linear labels — created issues without routing labels"`.
+
+### 9. `meetingNotes.createLinearIssues` — `updateIssue` (assignment) failure swallowed
+- **File:** `src/recipes/tools/meetingNotes.ts:582-585`
+- **Pattern:** silent error swallow (category 2).
+- **Reproduction:** if `updateIssue({assignee})` throws (assignee not found, name not unique, permission), the issue is created unassigned and no warning surfaces.
+- **Severity:** **LOW–MEDIUM** — explicitly commented "non-fatal — issue is already created". The argument for the silence is sound; the argument against is that the user has no way to find the unassigned issues afterwards. Add an `unassignedFailures: [...]` array to the response so the agent step can mention them.
+- **Suggested fix:** collect `{task, attemptedAssignee, error}` into the existing `errors` array (or a separate `assignmentFailures` field) and surface in the final JSON.
+
+### 10. Connector handler patterns vs `tryRequest` — drift
+
+This isn't a tool-level bug, but worth flagging for the codebase rule in CLAUDE.md (`extensionClient` shape validation): the same antipattern from the bridge side is repeated in connectors. `github.listIssues`, `linear.listIssues`, `gmail.fetchDocContent`, `googleDrive.fetchDocName` all `catch { return ""; }` / `catch { return []; }`. CLAUDE.md guidance for bridge code is to use `tryRequest` / `validatedRequest` / inline unwrap to *distinguish* error paths. Connectors have no equivalent helper and the bare `catch { return [] }` pattern leaks the same class of bug.
+
+- **File:** the policy lives in `CLAUDE.md` "extensionClient shape validation" section; the connector files have no equivalent rule.
+- **Severity:** **LOW** (process/codebase-rules, not a single bug).
+- **Suggested fix:** add a `connectorRequest<T>(fn, label)` helper in `src/connectors/baseConnector.ts` that catches, classifies (auth / network / 4xx / 5xx), and returns a tagged union — then replace the bare catches in github/linear/gmail incrementally.
+
+### 11. `executeTool` (recipe registry) — unknown-tool throws but `executeStep` returns `null`
+- **File:** `src/recipes/yamlRunner.ts:725-771` (executeStep) and `src/recipes/toolRegistry.ts:113-115` (executeTool).
+- **Pattern:** missing implementation handled inconsistently (category 3).
+- **Reproduction:** YAML step `tool: nonexistent.thing` → `hasTool()` returns false → executeStep:769-770 returns `null` → step status `"skipped"` → no error. Comment says `// Unknown tool — skip, don't throw (forward compat)` but this is also indistinguishable from a typo.
+- **Severity:** **LOW** — typos in tool names produce silent skips. The "forward compat" justification holds for plugin tools but not for misspelled built-ins.
+- **Suggested fix:** when `toolId` matches a known prefix (`file.`, `git.`, `gmail.`, etc.) but the suffix is unknown, throw rather than skip. Plugins can use unknown prefixes legitimately.
+
+### 12. `slack.post_message` — disconnected returns `ok:false` (correct), but other errors stringify to message only
+- **File:** `src/recipes/tools/slack.ts:57-91`
+- **Pattern:** lossy error reporting (category 2).
+- **Reproduction:** `not_in_channel`, `channel_not_found`, rate-limit (`429`) all become `JSON.stringify({ok:false, error: <message>})`. No status code, no Slack response_metadata. Less bad than the gmail tools because at least `ok:false` triggers the runner's failure detection (yamlRunner.ts:531-538). Logged here for completeness — it is NOT a silent failure, just a lossy one.
+- **Severity:** **LOW**.
+- **Suggested fix:** include the original Slack error code in the JSON body.
+
+---
+
+## Patterns I saw repeatedly
+
+1. **`catch { return [] }` / `catch { return "" }` in connectors** — github/linear/gmail/googleDrive all do this. Recipes built on top can never tell "no data" from "transport broke". This is the root cause of #1, #2, #3, #4, #5, #6, #7.
+2. **String placeholder vs `{ok:false}` JSON inconsistency** — yamlRunner only treats a step as failed when result is parseable JSON with `ok:false`. Tools that return `(unavailable)` placeholder strings or `{count:0,messages:[],error:"…"}` payloads (no `ok` key) succeed-with-empty as far as the runner is concerned. See yamlRunner.ts:531-538.
+3. **Schema descriptions promise more than impls deliver** — `CommonSchemas.since` lists `'2026-01-01'` but `sinceToGmailQuery` doesn't handle it; `diagnostics.get` description says "requires bridge connection" but the default impl is hard-wired to `""`.
+
+## TL;DR — top 5 most-actionable
+
+1. **`sinceToGmailQuery` (gmail.ts:214)** — silently coerces unsupported `since` formats (ISO dates, weeks, minutes, free text) to `"1d"`. Production morning-brief recipes pass these. **Highest impact: silently underreports inbox volume.**
+2. **`defaultGitLogSince` (yamlRunner.ts:834)** — `(git log unavailable)` placeholder swallows every git failure. Used by every shipped daily-brief recipe. Same class as the original `defaultGitStaleBranches` bug.
+3. **`defaultGetDiagnostics` (yamlRunner.ts:936)** — hardcoded `() => ""`. The `diagnostics.get` tool is registered but its production default is a stub. Either wire it through the bridge or unregister.
+4. **`github.listIssues` / `github.listPRs` (github.ts:143, 177)** — bare `catch { return [] }` masks token expiry, rate limits, and MCP outages as "no issues". Surface these as throws so the recipe-tool wrapper can encode them into the `error` field.
+5. **`linear.listIssues` (linear.ts:148)** — same pattern as #4. Already partially right (it rethrows "not connected") — extend the rethrow whitelist to all non-empty-result errors.
+
+(Honourable mention: yamlRunner's success/failure detection should also treat any `{error: "…"}` payload — not just `{ok:false}` — as a step failure. That single change would make most of the gmail/linear lossy-error patterns visible without per-tool fixes.)

--- a/src/__tests__/streamableHttpToolRegistration.test.ts
+++ b/src/__tests__/streamableHttpToolRegistration.test.ts
@@ -1,0 +1,254 @@
+/**
+ * Regression: ensure the Streamable-HTTP transport registers the same tool
+ * deps as the WebSocket transport.
+ *
+ * Backstory: dogfood (recipe live-fire) found that `ctxSaveTrace`,
+ * `ctxQueryTraces`, and any tool gated on disconnect-info,
+ * `commitIssueLinkLog`, `recipeRunLog`, or `decisionTraceLog` were
+ * silently NOT registering on the Streamable-HTTP MCP path. The root
+ * cause was a positional-arg mismatch: bridge.ts passed 19 args to
+ * `registerAllTools`, streamableHttp.ts only passed 12 (stopped at
+ * `pluginTools`). The handler had no fields for the missing 7 deps.
+ *
+ * This test pins the parity: when given a fully-populated `toolDeps`
+ * object, the handler must invoke `registerAllTools` with all the
+ * tail-end dep arguments populated. Catches future drift if anyone
+ * adds another dep to the WS path without updating the HTTP path.
+ */
+
+import http from "node:http";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Logger } from "../logger.js";
+import { Server } from "../server.js";
+import { StreamableHttpHandler } from "../streamableHttp.js";
+
+// Capture every call to registerAllTools so we can assert the arg list.
+const registerCalls: unknown[][] = [];
+vi.mock("../tools/index.js", () => ({
+  registerAllTools: (...args: unknown[]) => {
+    registerCalls.push(args);
+  },
+}));
+
+const logger = new Logger(false);
+const TOKEN = "test-token-streamable-http-parity-1234567890";
+
+function makeDeps() {
+  const config = {
+    workspace: "/tmp/test-workspace",
+    port: null,
+    bindAddress: "127.0.0.1",
+    preferredPortRange: null,
+    ide: null,
+    ideName: "test",
+    debug: false,
+    editor: null,
+    noReady: false,
+    configFile: null,
+    noLockFile: false,
+    claudeDriver: "subprocess" as const,
+    claudeBinary: "claude",
+    automationPolicy: null,
+  };
+  const extensionClient = {
+    isConnected: () => false,
+    on: () => {},
+    request: () => Promise.resolve(null),
+    removeListener: () => {},
+  };
+  const activityLog = {
+    recordTool: () => {},
+    recordEvent: () => {},
+    getStats: () => ({
+      totalToolCalls: 0,
+      errorCount: 0,
+      avgDurationMs: 0,
+      toolBreakdown: {},
+    }),
+    queryTimeline: () => [],
+  };
+  const fileLock = {
+    acquire: () => Promise.resolve({ release: () => {} }),
+  };
+  return { config, extensionClient, activityLog, fileLock };
+}
+
+async function post(
+  port: number,
+  data: Record<string, unknown>,
+  sessionId?: string,
+): Promise<{
+  status: number;
+  headers: http.IncomingHttpHeaders;
+  body: string;
+}> {
+  return new Promise((resolve, reject) => {
+    const payload = JSON.stringify(data);
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${TOKEN}`,
+    };
+    if (sessionId) headers["Mcp-Session-Id"] = sessionId;
+    const req = http.request(
+      { hostname: "127.0.0.1", port, path: "/mcp", method: "POST", headers },
+      (res) => {
+        let body = "";
+        res.on("data", (c: Buffer) => {
+          body += c.toString();
+        });
+        res.on("end", () =>
+          resolve({ status: res.statusCode!, headers: res.headers, body }),
+        );
+      },
+    );
+    req.on("error", reject);
+    req.end(payload);
+  });
+}
+
+let server: Server | null = null;
+let handler: StreamableHttpHandler | null = null;
+let port: number;
+
+beforeEach(() => {
+  registerCalls.length = 0;
+});
+
+afterEach(async () => {
+  handler?.close();
+  handler = null;
+  await server?.close();
+  server = null;
+});
+
+describe("StreamableHttpHandler — registerAllTools arg parity", () => {
+  it("passes all tail-end deps when toolDeps is provided", async () => {
+    const deps = makeDeps();
+    server = new Server(TOKEN, logger);
+
+    // Sentinel objects so we can assert each was forwarded.
+    const sentinelAutomation = { kind: "automationHooks" } as never;
+    const sentinelCommitLog = { kind: "commitIssueLinkLog" } as never;
+    const sentinelRunLog = { kind: "recipeRunLog" } as never;
+    const sentinelDecisionLog = { kind: "decisionTraceLog" } as never;
+    const sentinelDisconnect = () => ({
+      at: "2026-04-29T00:00:00Z",
+      code: 1006,
+      reason: "test",
+    });
+    const sentinelCacheUpdated = (_: string) => {};
+    const sentinelDisconnectCount = () => 7;
+
+    handler = new StreamableHttpHandler(
+      deps.config as never,
+      {} as never,
+      deps.extensionClient as never,
+      deps.activityLog as never,
+      deps.fileLock as never,
+      new Map(),
+      null,
+      logger,
+      undefined, // getPluginTools
+      undefined, // getPluginWatcher
+      null, // resolveScopeFn
+      null, // instructionsProvider
+      {
+        automationHooks: sentinelAutomation,
+        getDisconnectInfo: sentinelDisconnect,
+        onContextCacheUpdated: sentinelCacheUpdated,
+        getExtensionDisconnectCount: sentinelDisconnectCount,
+        commitIssueLinkLog: sentinelCommitLog,
+        recipeRunLog: sentinelRunLog,
+        decisionTraceLog: sentinelDecisionLog,
+      },
+    );
+
+    server.httpMcpHandler = (req, res) => handler!.handle(req, res);
+    port = await server.findAndListen(null);
+
+    // Initialize a session — that's what triggers registerAllTools.
+    const res = await post(port, {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {
+        protocolVersion: "2025-11-25",
+        capabilities: {},
+        clientInfo: { name: "parity-test", version: "1.0" },
+      },
+    });
+    expect(res.status).toBe(200);
+
+    // The handler should have called registerAllTools exactly once.
+    expect(registerCalls).toHaveLength(1);
+    const args = registerCalls[0]!;
+
+    // Position contract — must match the WS-side call in bridge.ts.
+    // 0  transport
+    // 1  config
+    // 2  openedFiles
+    // 3  probes
+    // 4  extensionClient
+    // 5  activityLog
+    // 6  terminalPrefix
+    // 7  fileLock
+    // 8  sessions
+    // 9  orchestrator
+    // 10 sessionId
+    // 11 pluginTools
+    // 12 automationHooks            ← was missing pre-fix
+    // 13 getDisconnectInfo          ← was missing
+    // 14 onContextCacheUpdated      ← was missing
+    // 15 getExtensionDisconnectCount← was missing
+    // 16 commitIssueLinkLog         ← was missing
+    // 17 recipeRunLog               ← was missing
+    // 18 decisionTraceLog           ← was missing
+    expect(args.length).toBe(19);
+    expect(args[12]).toBe(sentinelAutomation);
+    expect(args[13]).toBe(sentinelDisconnect);
+    expect(args[14]).toBe(sentinelCacheUpdated);
+    expect(args[15]).toBe(sentinelDisconnectCount);
+    expect(args[16]).toBe(sentinelCommitLog);
+    expect(args[17]).toBe(sentinelRunLog);
+    expect(args[18]).toBe(sentinelDecisionLog);
+  });
+
+  it("passes undefined for tail-end deps when toolDeps is omitted (back-compat)", async () => {
+    const deps = makeDeps();
+    server = new Server(TOKEN, logger);
+
+    // Construct without the toolDeps argument — pre-fix call shape.
+    handler = new StreamableHttpHandler(
+      deps.config as never,
+      {} as never,
+      deps.extensionClient as never,
+      deps.activityLog as never,
+      deps.fileLock as never,
+      new Map(),
+      null,
+      logger,
+    );
+    server.httpMcpHandler = (req, res) => handler!.handle(req, res);
+    port = await server.findAndListen(null);
+
+    const res = await post(port, {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {
+        protocolVersion: "2025-11-25",
+        capabilities: {},
+        clientInfo: { name: "parity-test", version: "1.0" },
+      },
+    });
+    expect(res.status).toBe(200);
+
+    expect(registerCalls).toHaveLength(1);
+    const args = registerCalls[0]!;
+    // Still 19 args — the trailing positions are explicitly undefined.
+    expect(args.length).toBe(19);
+    for (let i = 12; i <= 18; i++) {
+      expect(args[i]).toBeUndefined();
+    }
+  });
+});

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -1401,6 +1401,31 @@ export class Bridge {
         await this.refreshRecentTracesDigest();
         return this.buildInstructions();
       },
+      // Tail-end deps so `registerAllTools` registers the same tool set
+      // on Streamable-HTTP sessions as on WebSocket. Without this object,
+      // `ctxSaveTrace`, `ctxQueryTraces`, and any tool gated on the
+      // remaining deps silently failed to register over Streamable HTTP
+      // (caught dogfooding `ctx-loop-test` from a remote MCP client).
+      {
+        automationHooks: this.automationHooks,
+        getDisconnectInfo: () => ({
+          at: this.lastDisconnectAt,
+          code: this.lastDisconnectCode,
+          reason: this.lastDisconnectReason,
+        }),
+        onContextCacheUpdated: (generatedAt: string) => {
+          this._lastContextCachedAt = generatedAt;
+          this._emitLiveState();
+        },
+        getExtensionDisconnectCount: () => this.extensionDisconnectCount,
+        ...(this.commitIssueLinkLog && {
+          commitIssueLinkLog: this.commitIssueLinkLog,
+        }),
+        ...(this.recipeRunLog && { recipeRunLog: this.recipeRunLog }),
+        ...(this.decisionTraceLog && {
+          decisionTraceLog: this.decisionTraceLog,
+        }),
+      },
     );
     this.server.httpMcpHandler = (req, res) =>
       this.httpMcpHandler?.handle(req, res) ?? Promise.resolve();

--- a/src/streamableHttp.ts
+++ b/src/streamableHttp.ts
@@ -291,6 +291,25 @@ export class StreamableHttpHandler {
     private instructionsProvider:
       | (() => Promise<string> | string)
       | null = null,
+    /**
+     * Tail-end deps that `registerAllTools` needs for the Patchwork-layer
+     * tools (`ctxSaveTrace`, `ctxQueryTraces`, recipe-run helpers,
+     * disconnect-aware compaction tools, etc.). Without these, those
+     * tools were silently NOT registered for Streamable-HTTP MCP sessions
+     * — they DID register on the WebSocket path because that call site
+     * passes them. This is the parity fix.
+     *
+     * Caught dogfooding `ctx-loop-test` against a remote MCP client.
+     */
+    private toolDeps: {
+      automationHooks?: import("./automation.js").AutomationHooks;
+      getDisconnectInfo?: () => import("./tools/bridgeStatus.js").DisconnectInfo;
+      onContextCacheUpdated?: (generatedAt: string) => void;
+      getExtensionDisconnectCount?: () => number;
+      commitIssueLinkLog?: import("./commitIssueLinkLog.js").CommitIssueLinkLog;
+      recipeRunLog?: import("./runLog.js").RecipeRunLog;
+      decisionTraceLog?: import("./decisionTraceLog.js").DecisionTraceLog;
+    } = {},
   ) {
     // Prune idle sessions every 2 minutes.
     // .unref() prevents this timer from keeping the Node process alive when
@@ -702,6 +721,17 @@ export class StreamableHttpHandler {
         | null,
       id,
       pluginTools,
+      // Parity with the WebSocket call in bridge.ts — without these,
+      // `ctxSaveTrace`, `ctxQueryTraces`, and any tool gated on the
+      // remaining deps silently fail to register for Streamable-HTTP
+      // MCP sessions.
+      this.toolDeps.automationHooks,
+      this.toolDeps.getDisconnectInfo,
+      this.toolDeps.onContextCacheUpdated,
+      this.toolDeps.getExtensionDisconnectCount,
+      this.toolDeps.commitIssueLinkLog,
+      this.toolDeps.recipeRunLog,
+      this.toolDeps.decisionTraceLog,
     );
 
     transport.attach(adapter as unknown as import("ws").WebSocket);


### PR DESCRIPTION
## Summary

The Streamable-HTTP transport was silently registering FEWER tools than the WebSocket transport. Caught dogfooding the Patchwork recipe collection (`ctx-loop-test` fired against a remote MCP client) — `ctxSaveTrace` / `ctxQueryTraces` were missing for any non-WebSocket client.

## Root cause

`registerAllTools` takes 19 positional args. The WebSocket call site at [src/bridge.ts:385](src/bridge.ts#L385) passes all 19. The Streamable-HTTP call site at [src/streamableHttp.ts:679](src/streamableHttp.ts#L679) was passing only **12** — stopped at `pluginTools`.

The 7 missing args:

```
automationHooks  ·  getDisconnectInfo  ·  onContextCacheUpdated
getExtensionDisconnectCount  ·  commitIssueLinkLog
recipeRunLog  ·  decisionTraceLog
```

Tools gated on these deps were silently NOT registered for any client connecting over Streamable HTTP (claude.ai connectors, Codex CLI, any remote MCP client). WebSocket clients (Claude Code CLI, stdio shim) had the full set.

## Fix

`StreamableHttpHandler` constructor accepts a new optional `toolDeps` object carrying the 7 deps. `bridge.ts` instantiation threads them using the same closures as the WS path:

```ts
new StreamableHttpHandler(/* … existing args … */, {
  automationHooks: this.automationHooks,
  getDisconnectInfo: () => ({ at: this.lastDisconnectAt, code: ..., reason: ... }),
  onContextCacheUpdated: (g) => { this._lastContextCachedAt = g; this._emitLiveState(); },
  getExtensionDisconnectCount: () => this.extensionDisconnectCount,
  commitIssueLinkLog: this.commitIssueLinkLog,
  recipeRunLog: this.recipeRunLog,
  decisionTraceLog: this.decisionTraceLog,
});
```

Optional with `= {}` default so existing test setups and any out-of-tree consumers still work — they get the pre-fix degraded tool set, which is what they had before.

## Regression sentinel

[`src/__tests__/streamableHttpToolRegistration.test.ts`](src/__tests__/streamableHttpToolRegistration.test.ts) — 2 tests:

1. **With sentinels in `toolDeps`** — asserts `registerAllTools` was called with 19 args AND positions 12-18 carry the exact sentinel objects passed in. Catches future drift if anyone adds another arg to the WS path without updating HTTP.
2. **Back-compat** — when `toolDeps` is omitted, the tail positions are explicitly `undefined` (still 19 args, just empty).

## Audit reports included

The dogfood pass that surfaced this bug also produced three audit reports under `docs/dogfood/`:

| File | Contents |
|---|---|
| [recipe-inventory.md](docs/dogfood/recipe-inventory.md) | All 43 recipes classified by safety; 21 BROKEN-LIKELY (reference unregistered tool namespaces) |
| [tool-audit.md](docs/dogfood/tool-audit.md) | 12 silent-failure findings — runner step-error detection is the highest-leverage future fix |
| [recipe-dogfood-results.md](docs/dogfood/recipe-dogfood-results.md) | 8 recipes fired live; surfaced this bug + others |

Bundling them with this PR so the rationale is visible. Future fixes (P1 runner heuristic, BROKEN-LIKELY starter pack cleanup) can be tracked from these.

## Test plan

- [x] `npm test` — 4284 passing (was 4282 on main; +2 new)
- [x] `npx tsc --noEmit` — clean
- [x] Regression test sentinel pins arg-list shape
- [ ] Reviewer: smoke against a remote MCP client (claude.ai connector or Codex CLI). Pre-fix: `tools/list` is missing `ctxSaveTrace` / `ctxQueryTraces` / etc. Post-fix: full set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)