### PR TITLE
fix(recipes): close 3 silent-fail antipatterns from the audit (P2)

### DIFF
--- a/src/recipes/__tests__/defaultGitLogSince.test.ts
+++ b/src/recipes/__tests__/defaultGitLogSince.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Regression test for `defaultGitLogSince`.
+ *
+ * Caught in the post-merge tool audit (docs/dogfood/tool-audit.md): the
+ * function returned the literal string `(git log unavailable)` on any
+ * failure, which the runner saw as success-with-empty-data. Downstream
+ * agents summarized "no recent commits" — false signal.
+ *
+ * Fix returns a `{ok:false,error}` JSON shape on failure so the runner's
+ * existing JSON-error detection (and #72's silent-fail detector) flag
+ * the step as `error`. Successful runs still return bare git output.
+ */
+
+import { execSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { defaultGitLogSince } from "../yamlRunner.js";
+
+let repoDir: string;
+
+beforeEach(() => {
+  repoDir = mkdtempSync(path.join(os.tmpdir(), "git-log-since-"));
+  execSync("git init -q -b main", { cwd: repoDir });
+  execSync("git config user.email t@t.local && git config user.name t", {
+    cwd: repoDir,
+    shell: "/bin/bash",
+  });
+});
+
+afterEach(() => {
+  rmSync(repoDir, { recursive: true, force: true });
+});
+
+describe("defaultGitLogSince", () => {
+  it("returns oneline log on success", () => {
+    writeFileSync(path.join(repoDir, "a.txt"), "x");
+    execSync("git add . && git commit -q -m 'first commit'", {
+      cwd: repoDir,
+      shell: "/bin/bash",
+    });
+    const out = defaultGitLogSince("1 year ago", repoDir);
+    // Bare git oneline output (NOT a JSON shape on success).
+    expect(out).toMatch(/[a-f0-9]{7,}\s+first commit/);
+  });
+
+  it("returns JSON error shape when run outside a git repo", () => {
+    const nonRepo = mkdtempSync(path.join(os.tmpdir(), "not-a-repo-"));
+    try {
+      const out = defaultGitLogSince("1 day ago", nonRepo);
+      // Now the failure is detectable: parses as JSON with ok:false.
+      const parsed = JSON.parse(out) as { ok: boolean; error: string };
+      expect(parsed.ok).toBe(false);
+      expect(parsed.error).toMatch(/git log/i);
+    } finally {
+      rmSync(nonRepo, { recursive: true, force: true });
+    }
+  });
+
+  it("does NOT return the bare '(git log unavailable)' placeholder anymore", () => {
+    const nonRepo = mkdtempSync(path.join(os.tmpdir(), "not-a-repo-"));
+    try {
+      const out = defaultGitLogSince("1 day ago", nonRepo);
+      // Regression sentinel: the OLD code returned the literal placeholder.
+      // The fix returns a JSON shape instead so the runner can detect failure.
+      expect(out).not.toBe("(git log unavailable)");
+      expect(() => JSON.parse(out)).not.toThrow();
+    } finally {
+      rmSync(nonRepo, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/recipes/tools/__tests__/sinceToGmailQuery.test.ts
+++ b/src/recipes/tools/__tests__/sinceToGmailQuery.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Regression test for `sinceToGmailQuery`.
+ *
+ * Caught in the post-merge tool audit (docs/dogfood/tool-audit.md): the
+ * function silently coerced anything that wasn't `<N>d` or `<N>h` into
+ * `"1d"`. Users specifying `since: '2026-01-01'` got the last 24 hours.
+ * `since: '7days'` produced the malformed `"7aysd"` because the naive
+ * `.replace("d", "")` stripped EVERY 'd' in the input.
+ *
+ * Fix uses a strict regex `/^(\d+)([dhmy])$/` and throws on
+ * unparseable input so the recipe runner's error path triggers loudly.
+ */
+
+import { describe, expect, it } from "vitest";
+import { sinceToGmailQuery } from "../gmail.js";
+
+describe("sinceToGmailQuery — happy path", () => {
+  it("passes through valid '<N>d' format", () => {
+    expect(sinceToGmailQuery("7d")).toBe("7d");
+    expect(sinceToGmailQuery("1d")).toBe("1d");
+    expect(sinceToGmailQuery("365d")).toBe("365d");
+  });
+
+  it("passes through valid '<N>h' format", () => {
+    expect(sinceToGmailQuery("24h")).toBe("24h");
+    expect(sinceToGmailQuery("1h")).toBe("1h");
+  });
+
+  it("accepts months ('<N>m') and years ('<N>y') — Gmail supports both", () => {
+    expect(sinceToGmailQuery("3m")).toBe("3m");
+    expect(sinceToGmailQuery("1y")).toBe("1y");
+  });
+
+  it("trims whitespace", () => {
+    expect(sinceToGmailQuery("  7d  ")).toBe("7d");
+  });
+});
+
+describe("sinceToGmailQuery — throws on invalid input (regression)", () => {
+  it("throws on ISO date (was silently → '1d')", () => {
+    expect(() => sinceToGmailQuery("2026-01-01")).toThrow(/invalid since/);
+  });
+
+  it("throws on natural-language relative time (was silently → '1d')", () => {
+    expect(() => sinceToGmailQuery("1 week ago")).toThrow(/invalid since/);
+    expect(() => sinceToGmailQuery("yesterday")).toThrow(/invalid since/);
+  });
+
+  it("throws on '7days' (was producing malformed '7aysd')", () => {
+    // The pre-fix code did `'7days'.replace('d', '') + 'd'` →
+    // `'7ays' + 'd'` = `'7aysd'`. Sentinel: assert the strict
+    // regex now rejects this rather than silently producing garbage.
+    expect(() => sinceToGmailQuery("7days")).toThrow(/invalid since/);
+  });
+
+  it("throws on empty string (was → '1d')", () => {
+    expect(() => sinceToGmailQuery("")).toThrow(/invalid since/);
+  });
+
+  it("throws on bare number without unit", () => {
+    expect(() => sinceToGmailQuery("7")).toThrow(/invalid since/);
+  });
+
+  it("throws on multi-character or upper-case units", () => {
+    expect(() => sinceToGmailQuery("7D")).toThrow(/invalid since/);
+    expect(() => sinceToGmailQuery("1week")).toThrow(/invalid since/);
+  });
+});

--- a/src/recipes/tools/gmail.ts
+++ b/src/recipes/tools/gmail.ts
@@ -211,14 +211,31 @@ async function gmailGetMessage(
   return JSON.stringify({ id, subject, body: body.slice(0, 16_000), links });
 }
 
-function sinceToGmailQuery(since: string): string {
-  if (since.includes("d")) {
-    return `${since.replace("d", "")}d`;
+// Exported for test coverage of the regression fix.
+//
+// Pre-fix this function silently coerced any unrecognized format
+// (`"2026-01-01"`, `"1 week ago"`, free text) → `"1d"`. The audit
+// caught this in `morning-brief*` and `inbox-triage` recipes — users
+// specifying an explicit date got the last 24 hours instead with no
+// indication anything was wrong.
+//
+// It also broke on `"7days"` because the naive `.replace("d", "")`
+// stripped EVERY 'd' in the string → `"7days".replace("d","") + "d"`
+// = `"7aysd"`. Two bugs masking each other.
+//
+// Gmail's `newer_than:` operator accepts `<number><unit>` where unit
+// is one of `d` (days), `h` (hours), `m` (months), `y` (years).
+// Anything else throws so the runner's error path triggers loudly.
+export function sinceToGmailQuery(since: string): string {
+  const trimmed = since.trim();
+  // Strict regex: one or more digits + a single valid unit.
+  const match = /^(\d+)([dhmy])$/.exec(trimmed);
+  if (match) {
+    return `${match[1]}${match[2]}`;
   }
-  if (since.includes("h")) {
-    return `${since.replace("h", "")}h`;
-  }
-  return "1d";
+  throw new Error(
+    `invalid since='${since}' for gmail.fetch_unread — expected '<N>(d|h|m|y)' (e.g. '24h', '7d'), got unparseable input`,
+  );
 }
 
 // ============================================================================

--- a/src/recipes/yamlRunner.ts
+++ b/src/recipes/yamlRunner.ts
@@ -866,7 +866,19 @@ function parseSinceToGitArg(since: string): string {
   return unit.toLowerCase() === "h" ? `${num} hours ago` : `${num} days ago`;
 }
 
-function defaultGitLogSince(since: string, workdir?: string): string {
+// Exported for test coverage of the regression fix (was returning the
+// `(git log unavailable)` placeholder string on any failure, which
+// silently looked like success to pre-#72 runners).
+export function defaultGitLogSince(since: string, workdir?: string): string {
+  // Same antipattern that broke `defaultGitStaleBranches` (PR #70): on
+  // any error this used to return `(git log unavailable)`. The runner
+  // saw that as success-with-empty-data and downstream agents
+  // summarized "no recent commits" — false signal.
+  //
+  // Fix: return a JSON `{ok: false, error}` shape on failure so the
+  // runner's existing JSON-error detection (yamlRunner step-error
+  // block) flags the step as `error`. Successful runs still return
+  // bare git output text.
   try {
     const sinceArg = parseSinceToGitArg(since);
     const result = spawnSync(
@@ -878,10 +890,25 @@ function defaultGitLogSince(since: string, workdir?: string): string {
         timeout: 5000,
       },
     );
-    if (result.error || result.status !== 0) return "(git log unavailable)";
+    if (result.error) {
+      return JSON.stringify({
+        ok: false,
+        error: `git log failed: ${result.error.message}`,
+      });
+    }
+    if (result.status !== 0) {
+      const stderr = (result.stderr ?? "").toString().trim().slice(0, 200);
+      return JSON.stringify({
+        ok: false,
+        error: `git log exited ${result.status}${stderr ? `: ${stderr}` : ""}`,
+      });
+    }
     return (result.stdout ?? "").trim();
-  } catch {
-    return "(git log unavailable)";
+  } catch (err) {
+    return JSON.stringify({
+      ok: false,
+      error: `git log threw: ${err instanceof Error ? err.message : String(err)}`,
+    });
   }
 }
 
@@ -968,7 +995,20 @@ function resolveStepDeps(deps: RunnerDeps): StepDeps {
     workdir,
     gitLogSince: deps.gitLogSince ?? defaultGitLogSince,
     gitStaleBranches: deps.gitStaleBranches ?? defaultGitStaleBranches,
-    getDiagnostics: deps.getDiagnostics ?? (() => ""),
+    // The `diagnostics.get` recipe tool is registered (src/recipes/tools/
+    // diagnostics.ts) but only meaningful when the bridge wires a real
+    // `getDiagnostics` impl backed by the LSP / extension client. CLI runs
+    // and tests have no bridge to ask, so the default returns a JSON error
+    // shape that the step-error detector flags as `error` instead of the
+    // pre-fix empty string that silently passed as success.
+    getDiagnostics:
+      deps.getDiagnostics ??
+      (() =>
+        JSON.stringify({
+          ok: false,
+          error:
+            "diagnostics.get unavailable (no bridge / no `deps.getDiagnostics` injected)",
+        })),
     fetchFn: deps.fetchFn ?? (globalThis.fetch as FetchFn),
     claudeFn: deps.claudeFn ?? defaultClaudeFn,
     claudeCodeFn: deps.claudeCodeFn ?? defaultClaudeCodeFn,


### PR DESCRIPTION
## Summary

Same class as **#70** (git.stale_branches) and **#72** (silent-fail detector). Three tools were returning placeholder strings or empty strings on failure, which the runner used to accept as success. After #72's detector landed those three started failing visibly in CI/dashboard — this PR fixes the underlying tools so the failures become real errors with useful messages.

## The 3 fixes

### 1. `defaultGitLogSince` ([src/recipes/yamlRunner.ts](src/recipes/yamlRunner.ts))

| | |
|---|---|
| **Pre-fix** | Returned bare string `(git log unavailable)` on any failure. Used by every daily-brief recipe. Downstream agents summarized *"no recent commits"* — false negative. |
| **Fix** | Returns `{ok:false, error: '<actual git error>'}` JSON on failure → existing runner JSON-error path catches it → step is `error`. Successful runs still return bare git output (back-compat preserved). |

### 2. `defaultGetDiagnostics` ([src/recipes/yamlRunner.ts](src/recipes/yamlRunner.ts))

| | |
|---|---|
| **Pre-fix** | Hardcoded `() => ""` stub. `diagnostics.get` is registered but only meaningful when the bridge wires a real impl backed by the LSP / extension client. CLI runs got an empty string — silent fail. |
| **Fix** | Returns `{ok:false, error:'diagnostics.get unavailable...'}` when no impl is injected. `lint-on-save` and `watch-failing-tests` recipes now error loudly in non-bridge environments. |

### 3. `sinceToGmailQuery` ([src/recipes/tools/gmail.ts](src/recipes/tools/gmail.ts))

Two bugs masking each other:

| | |
|---|---|
| **Bug A** | ANY input not containing `'d'` or `'h'` silently coerced to `'1d'`. User specifying `since: '2026-01-01'` got the last day. |
| **Bug B** | `'7days'` produced `'7aysd'` because the naive `.replace("d","")` stripped EVERY `'d'` in the string. |
| **Fix** | Strict regex `/^(\d+)([dhmy])$/`, throws on unparseable input. Throw is caught by the runner's `thrownError` path → step error with `"invalid since='X' for gmail.fetch_unread — expected '<N>(d|h|m|y)'"`. Also adds `m`/`y` units (Gmail's `newer_than:` accepts both). |

## Test plan

- [x] `defaultGitLogSince.test.ts` — 3 tests: happy path returns oneline log, non-git directory returns parseable `{ok:false,error}`, **regression sentinel**: NOT the bare `'(git log unavailable)'` string anymore
- [x] `sinceToGmailQuery.test.ts` — 10 tests:
  - happy path: `7d`, `24h`, `3m`, `1y`, whitespace-trim
  - regression: throws on ISO dates, `'1 week ago'`, empty string, bare number, `'7days'` (the malformed-output bug), uppercase units, multi-char units
- [x] `npm test` — 4324 passing (was 4311; +13 new)
- [x] `npx tsc --noEmit` — clean

## Audit category closure

This completes the same-class category from [docs/dogfood/tool-audit.md](docs/dogfood/tool-audit.md). Remaining audit findings:

- **21 BROKEN-LIKELY starter-pack recipes** referencing unregistered tool namespaces (`inbox.*`, `notes.*`, `dashboard.render`, etc.) — needs a decision: delete vs implement
- **`github.listIssues` / `linear.listIssues`** swallow errors → `[]` — separate fix shape (those need `try/throw` wrapped at the top level rather than placeholder returns)

🤖 Generated with [Claude Code](https://claude.com/claude-code)