### PR TITLE
docs(starter-pack): align with reality — '# requires:' markers + vision-tier framing

### DIFF
--- a/examples/recipes/starter-pack/README.md
+++ b/examples/recipes/starter-pack/README.md
@@ -1,5 +1,13 @@
 # Starter Pack — 20 Recipes for the Rest of Your Life
 
+> **Vision tier.** Most recipes here reference MCP integrations that are
+> not yet bundled with `patchwork-os` — `gmail-mcp`, `calendar-mcp`,
+> `notify-mcp`, `dashboard-mcp`, `notes-mcp`, etc. They're shipped here
+> as design artifacts: the shape of what daily-life automation in
+> Patchwork should look like once those integrations land. You can read,
+> fork, and reason about them today — but expect most steps to skip
+> (with a warning) when run, because their tools aren't registered yet.
+
 Recipes are the connective tissue of Patchwork OS. This pack covers the
 non-coder parts of daily life: the inbox, the calendar, the money, the
 relationships, the self-observation that lives in the margins of notebooks.
@@ -8,11 +16,29 @@ Each recipe is a single YAML file with a trigger, steps, and an approval
 surface. Nothing here sends or deletes without a human tap, except where
 explicitly marked `risk: low` and reversible (appending to a log file, etc.).
 
-Recipes that depend on unbuilt integrations are marked with a
-`# requires: <mcp-name>` comment at the top. You can still read, fork, and
-reason about them — they'll run once the integration lands.
+Every recipe in this pack carries a `# requires: <mcp-1>, <mcp-2>, …`
+comment at the top listing which integrations it depends on. You can
+still read, fork, and reason about them today — they'll run end-to-end
+once the integrations land.
 
-## Install
+## What works today vs. what's vision-tier
+
+The core `patchwork-os` runner ships with a registered tool set covering
+**git, github, gmail, slack, notion, confluence, zendesk, intercom,
+hubspot, datadog, stripe, calendar.list_events, googleDrive, file, git,
+diagnostics, meetingNotes**. Recipes that ONLY use those work today.
+
+Anything in this `starter-pack/` directory references at least one tool
+namespace not yet in the registry (`inbox.*`, `notes.*`, `dashboard.render`,
+`notify.*`, `weather.*`, `contacts.*`, `queue.*`, `scheduler.*`, etc.). The
+runner will skip those steps gracefully — see [`docs/dogfood/recipe-inventory.md`](../../../docs/dogfood/recipe-inventory.md)
+for the full classification.
+
+For runnable recipes today, see the sibling [`examples/recipes/`](../) directory
+or [`templates/recipes/`](../../../templates/recipes/) (which ships in the
+npm package).
+
+## Install (when integrations land)
 
 ```bash
 patchwork recipe install examples/recipes/starter-pack/*.yaml
@@ -23,6 +49,9 @@ Or pick individual ones:
 ```bash
 patchwork recipe install examples/recipes/starter-pack/sunday-reset.yaml
 ```
+
+> Until then, installing them will succeed but most steps will report
+> `skipped` (with a warning naming the missing tool) on every run.
 
 ## The 20, by category
 

--- a/examples/recipes/starter-pack/apology-drafter.yaml
+++ b/examples/recipes/starter-pack/apology-drafter.yaml
@@ -1,3 +1,7 @@
+# vision-tier — this recipe references integrations that are not yet
+# bundled with patchwork-os. Steps that depend on a missing tool will
+# `skip` (with a warning) rather than crash; see ./README.md for status.
+# requires: dashboard-mcp
 version: 1.0.0
 name: apology-drafter
 description: >

--- a/examples/recipes/starter-pack/awkward-message-rewriter.yaml
+++ b/examples/recipes/starter-pack/awkward-message-rewriter.yaml
@@ -1,3 +1,7 @@
+# vision-tier — this recipe references integrations that are not yet
+# bundled with patchwork-os. Steps that depend on a missing tool will
+# `skip` (with a warning) rather than crash; see ./README.md for status.
+# requires: dashboard-mcp
 version: 1.0.0
 name: awkward-message-rewriter
 description: >

--- a/examples/recipes/starter-pack/birthday-watcher.yaml
+++ b/examples/recipes/starter-pack/birthday-watcher.yaml
@@ -1,3 +1,7 @@
+# vision-tier — this recipe references integrations that are not yet
+# bundled with patchwork-os. Steps that depend on a missing tool will
+# `skip` (with a warning) rather than crash; see ./README.md for status.
+# requires: contacts-mcp, dashboard-mcp, gmail-mcp, notes-mcp
 version: 1.0.0
 name: birthday-watcher
 description: >

--- a/examples/recipes/starter-pack/calendar-defense.yaml
+++ b/examples/recipes/starter-pack/calendar-defense.yaml
@@ -1,3 +1,7 @@
+# vision-tier — this recipe references integrations that are not yet
+# bundled with patchwork-os. Steps that depend on a missing tool will
+# `skip` (with a warning) rather than crash; see ./README.md for status.
+# requires: calendar-mcp, dashboard-mcp
 version: 1.0.0
 name: calendar-defense
 description: >

--- a/examples/recipes/starter-pack/compliment-archive.yaml
+++ b/examples/recipes/starter-pack/compliment-archive.yaml
@@ -1,3 +1,7 @@
+# vision-tier — this recipe references integrations that are not yet
+# bundled with patchwork-os. Steps that depend on a missing tool will
+# `skip` (with a warning) rather than crash; see ./README.md for status.
+# requires: gmail-mcp, log-mcp
 version: 1.0.0
 name: compliment-archive
 description: >

--- a/examples/recipes/starter-pack/decision-journal.yaml
+++ b/examples/recipes/starter-pack/decision-journal.yaml
@@ -1,3 +1,7 @@
+# vision-tier — this recipe references integrations that are not yet
+# bundled with patchwork-os. Steps that depend on a missing tool will
+# `skip` (with a warning) rather than crash; see ./README.md for status.
+# requires: scheduler-mcp
 version: 1.0.0
 name: decision-journal
 description: >

--- a/examples/recipes/starter-pack/disagreement-cooldown.yaml
+++ b/examples/recipes/starter-pack/disagreement-cooldown.yaml
@@ -1,3 +1,7 @@
+# vision-tier — this recipe references integrations that are not yet
+# bundled with patchwork-os. Steps that depend on a missing tool will
+# `skip` (with a warning) rather than crash; see ./README.md for status.
+# requires: dashboard-mcp, gmail-mcp, queue-mcp
 version: 1.0.0
 name: disagreement-cooldown
 description: >

--- a/examples/recipes/starter-pack/errand-batcher.yaml
+++ b/examples/recipes/starter-pack/errand-batcher.yaml
@@ -1,3 +1,7 @@
+# vision-tier — this recipe references integrations that are not yet
+# bundled with patchwork-os. Steps that depend on a missing tool will
+# `skip` (with a warning) rather than crash; see ./README.md for status.
+# requires: dashboard-mcp, gmail-mcp, notes-mcp
 version: 1.0.0
 name: errand-batcher
 description: >

--- a/examples/recipes/starter-pack/evening-shutdown.yaml
+++ b/examples/recipes/starter-pack/evening-shutdown.yaml
@@ -1,3 +1,7 @@
+# vision-tier — this recipe references integrations that are not yet
+# bundled with patchwork-os. Steps that depend on a missing tool will
+# `skip` (with a warning) rather than crash; see ./README.md for status.
+# requires: calendar-mcp, gmail-mcp, system-mcp
 version: 1.0.0
 name: evening-shutdown
 description: >

--- a/examples/recipes/starter-pack/gift-brain.yaml
+++ b/examples/recipes/starter-pack/gift-brain.yaml
@@ -1,3 +1,7 @@
+# vision-tier — this recipe references integrations that are not yet
+# bundled with patchwork-os. Steps that depend on a missing tool will
+# `skip` (with a warning) rather than crash; see ./README.md for status.
+# requires: contacts-mcp, notes-mcp, notify-mcp
 version: 1.0.0
 name: gift-brain
 description: >

--- a/examples/recipes/starter-pack/lost-thread-finder.yaml
+++ b/examples/recipes/starter-pack/lost-thread-finder.yaml
@@ -1,3 +1,7 @@
+# vision-tier — this recipe references integrations that are not yet
+# bundled with patchwork-os. Steps that depend on a missing tool will
+# `skip` (with a warning) rather than crash; see ./README.md for status.
+# requires: dashboard-mcp, gmail-mcp
 version: 1.0.0
 name: lost-thread-finder
 description: >

--- a/examples/recipes/starter-pack/meeting-prep.yaml
+++ b/examples/recipes/starter-pack/meeting-prep.yaml
@@ -1,3 +1,7 @@
+# vision-tier — this recipe references integrations that are not yet
+# bundled with patchwork-os. Steps that depend on a missing tool will
+# `skip` (with a warning) rather than crash; see ./README.md for status.
+# requires: calendar-mcp, fetch-mcp, gmail-mcp, notify-mcp
 version: 1.0.0
 name: meeting-prep
 description: >

--- a/examples/recipes/starter-pack/mood-tagger.yaml
+++ b/examples/recipes/starter-pack/mood-tagger.yaml
@@ -1,3 +1,7 @@
+# vision-tier — this recipe references integrations that are not yet
+# bundled with patchwork-os. Steps that depend on a missing tool will
+# `skip` (with a warning) rather than crash; see ./README.md for status.
+# requires: notify-mcp
 version: 1.0.0
 name: mood-tagger
 description: >

--- a/examples/recipes/starter-pack/morning-brief.yaml
+++ b/examples/recipes/starter-pack/morning-brief.yaml
@@ -1,3 +1,7 @@
+# vision-tier — this recipe references integrations that are not yet
+# bundled with patchwork-os. Steps that depend on a missing tool will
+# `skip` (with a warning) rather than crash; see ./README.md for status.
+# requires: calendar-mcp, gmail-mcp, notes-mcp, notify-mcp, weather-mcp
 version: 1.0.0
 name: morning-brief
 description: >

--- a/examples/recipes/starter-pack/quiet-hours-enforcer.yaml
+++ b/examples/recipes/starter-pack/quiet-hours-enforcer.yaml
@@ -1,3 +1,7 @@
+# vision-tier — this recipe references integrations that are not yet
+# bundled with patchwork-os. Steps that depend on a missing tool will
+# `skip` (with a warning) rather than crash; see ./README.md for status.
+# requires: notify-mcp, queue-mcp
 version: 1.0.0
 name: quiet-hours-enforcer
 description: >

--- a/examples/recipes/starter-pack/reading-capture.yaml
+++ b/examples/recipes/starter-pack/reading-capture.yaml
@@ -1,3 +1,7 @@
+# vision-tier — this recipe references integrations that are not yet
+# bundled with patchwork-os. Steps that depend on a missing tool will
+# `skip` (with a warning) rather than crash; see ./README.md for status.
+# requires: gmail-mcp
 version: 1.0.0
 name: reading-capture
 description: >

--- a/examples/recipes/starter-pack/receipt-logger.yaml
+++ b/examples/recipes/starter-pack/receipt-logger.yaml
@@ -1,3 +1,7 @@
+# vision-tier — this recipe references integrations that are not yet
+# bundled with patchwork-os. Steps that depend on a missing tool will
+# `skip` (with a warning) rather than crash; see ./README.md for status.
+# requires: gmail-mcp, notify-mcp
 version: 1.0.0
 name: receipt-logger
 description: >

--- a/examples/recipes/starter-pack/social-battery-planner.yaml
+++ b/examples/recipes/starter-pack/social-battery-planner.yaml
@@ -1,3 +1,7 @@
+# vision-tier — this recipe references integrations that are not yet
+# bundled with patchwork-os. Steps that depend on a missing tool will
+# `skip` (with a warning) rather than crash; see ./README.md for status.
+# requires: calendar-mcp, dashboard-mcp
 version: 1.0.0
 name: social-battery-planner
 description: >

--- a/examples/recipes/starter-pack/subscription-watchdog.yaml
+++ b/examples/recipes/starter-pack/subscription-watchdog.yaml
@@ -1,3 +1,7 @@
+# vision-tier — this recipe references integrations that are not yet
+# bundled with patchwork-os. Steps that depend on a missing tool will
+# `skip` (with a warning) rather than crash; see ./README.md for status.
+# requires: dashboard-mcp, gmail-mcp, notes-mcp
 version: 1.0.0
 name: subscription-watchdog
 description: >

--- a/examples/recipes/starter-pack/sunday-reset.yaml
+++ b/examples/recipes/starter-pack/sunday-reset.yaml
@@ -1,3 +1,7 @@
+# vision-tier — this recipe references integrations that are not yet
+# bundled with patchwork-os. Steps that depend on a missing tool will
+# `skip` (with a warning) rather than crash; see ./README.md for status.
+# requires: calendar-mcp, dashboard-mcp, gmail-mcp, notes-mcp
 version: 1.0.0
 name: sunday-reset
 description: >

--- a/examples/recipes/starter-pack/travel-prep.yaml
+++ b/examples/recipes/starter-pack/travel-prep.yaml
@@ -1,3 +1,7 @@
+# vision-tier — this recipe references integrations that are not yet
+# bundled with patchwork-os. Steps that depend on a missing tool will
+# `skip` (with a warning) rather than crash; see ./README.md for status.
+# requires: calendar-mcp, dashboard-mcp, gmail-mcp, weather-mcp
 version: 1.0.0
 name: travel-prep
 description: >


### PR DESCRIPTION
## Summary

The starter-pack README promised a `# requires: <mcp-name>` convention on each recipe, then listed which MCPs each needs. **The audit caught that 0 of 21 recipes actually had the marker** — users running them got silent step skips with no upfront signal that an integration was missing.

This PR adds the markers per the README's existing convention + a short vision-tier banner at the top of each recipe so readers see the framing in the file itself, not just the README.

## What changed per recipe

Banner block + `# requires:` line at the top of each YAML:

```yaml
# vision-tier — this recipe references integrations that are not yet
# bundled with patchwork-os. Steps that depend on a missing tool will
# `skip` (with a warning) rather than crash; see ./README.md for status.
# requires: contacts-mcp, dashboard-mcp, gmail-mcp, notes-mcp
version: 1.0.0
name: birthday-watcher
…
```

Mappings derived from [docs/dogfood/recipe-inventory.md §2](docs/dogfood/recipe-inventory.md) (the audit's "BROKEN-LIKELY (21)" classification):

| Recipe | Requires |
|---|---|
| apology-drafter, awkward-message-rewriter | `dashboard-mcp` |
| birthday-watcher | `contacts-mcp, dashboard-mcp, gmail-mcp, notes-mcp` |
| calendar-defense, social-battery-planner | `calendar-mcp, dashboard-mcp` |
| compliment-archive | `gmail-mcp, log-mcp` |
| decision-journal | `scheduler-mcp` |
| disagreement-cooldown | `dashboard-mcp, gmail-mcp, queue-mcp` |
| errand-batcher, subscription-watchdog | `dashboard-mcp, gmail-mcp, notes-mcp` |
| evening-shutdown | `calendar-mcp, gmail-mcp, system-mcp` |
| gift-brain | `contacts-mcp, notes-mcp, notify-mcp` |
| lost-thread-finder | `dashboard-mcp, gmail-mcp` |
| meeting-prep | `calendar-mcp, fetch-mcp, gmail-mcp, notify-mcp` |
| mood-tagger | `notify-mcp` |
| morning-brief | `calendar-mcp, gmail-mcp, notes-mcp, notify-mcp, weather-mcp` |
| quiet-hours-enforcer | `notify-mcp, queue-mcp` |
| reading-capture | `gmail-mcp` |
| receipt-logger | `gmail-mcp, notify-mcp` |
| sunday-reset | `calendar-mcp, dashboard-mcp, gmail-mcp, notes-mcp` |
| travel-prep | `calendar-mcp, dashboard-mcp, gmail-mcp, weather-mcp` |

## README changes

- **New top-of-file VISION-TIER blockquote** — explicit framing that most steps will skip on run because the integrations aren't registered yet.
- **New "What works today vs. what's vision-tier" section** — lists what the core runner DOES register today (`git/github/gmail/slack/notion/confluence/zendesk/intercom/hubspot/datadog/stripe/calendar.list_events/googleDrive/file/git/diagnostics/meetingNotes`) and points readers to runnable alternatives in `examples/recipes/` and `templates/recipes/`.
- **Install section retained** but with an explicit note that installing today succeeds but yields lots of step skips.
- **Cross-link to** [docs/dogfood/recipe-inventory.md](docs/dogfood/recipe-inventory.md) for the canonical classification.

## What this is NOT

Not a tool-implementation push. The 12+ missing namespaces (`inbox.*`, `notes.*`, `dashboard.render`, `notify.*`, `weather.*`, `contacts.*`, `queue.*`, `scheduler.*`, `system.*`, `log.*`, `fetch.url`, `file.merge_yaml`) still aren't registered. Landing them is the next chunk; this PR only makes the existing recipes honest about their dependencies so a reader knows up front.

## Verification

- All 21 recipes still YAML-parseable
- `# requires:` marker present in all 21 (was 0)
- `npm test` — 4311/4311 passing (doc/comment-only changes)

## Audit closure

Closes the "21 BROKEN-LIKELY recipes" finding from [docs/dogfood/recipe-inventory.md §2](docs/dogfood/recipe-inventory.md) — they're no longer surprising; they're labeled. Implementing the missing tool namespaces is now an explicit, scoped piece of work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)