### PR TITLE
feat(marketplace): submit-recipe CTA + demo-mode install handler

### DIFF
--- a/dashboard/src/app/api/bridge/recipes/install/route.ts
+++ b/dashboard/src/app/api/bridge/recipes/install/route.ts
@@ -1,5 +1,6 @@
 import type { NextRequest } from "next/server";
 import { bridgeFetch } from "@/lib/bridge";
+import { isDemoModeServer } from "@/lib/demoModeServer";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -11,6 +12,16 @@ export async function POST(req: NextRequest): Promise<Response> {
       status: 403,
       headers: { "content-type": "application/json" },
     });
+  }
+
+  if (isDemoModeServer()) {
+    return new Response(
+      JSON.stringify({
+        error:
+          "Install requires a running Patchwork bridge. Run `npm i -g patchwork-os && patchwork start` locally, then revisit this page.",
+      }),
+      { status: 501, headers: { "content-type": "application/json" } },
+    );
   }
 
   const body = await req.text();

--- a/dashboard/src/app/marketplace/page.tsx
+++ b/dashboard/src/app/marketplace/page.tsx
@@ -507,6 +507,16 @@ export default function MarketplacePage() {
               {filtered.length} recipe{filtered.length !== 1 ? "s" : ""}
             </span>
           )}
+          <a
+            href="https://github.com/patchworkos/recipes/blob/main/CONTRIBUTING.md"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="btn sm ghost"
+            style={{ textDecoration: "none", fontSize: 12 }}
+            aria-label="Submit a recipe to the marketplace"
+          >
+            Submit a recipe →
+          </a>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary

Two user-facing fixes surfaced by a Playwright walkthrough of the live deployed dashboard at `patchworkos.com/dashboard`:

1. **No submission affordance anywhere.** The author flow (fork `patchworkos/recipes`, add YAML + manifest, edit `index.json`, open PR) was invisible. Added a `Submit a recipe →` link in the marketplace page header, pointing at the registry's CONTRIBUTING.md.

2. **Demo-mode install returned a confusing 405.** The proxy at `/api/bridge/recipes/install` forwarded blindly to a nonexistent bridge. It now short-circuits with a 501 + clear message: *"Install requires a running Patchwork bridge. Run `npm i -g patchwork-os && patchwork start` locally..."*. The error renders inline under the card via the existing error path in `MarketplacePage.handleInstall`.

## Out of scope

The marketplace is still missing a recipe **detail view** (cards aren't clickable, no YAML preview, no risk/version/author metadata) and **author identity / verification**. Those are bigger surface changes and warrant their own PR.

## Test plan
- [x] `npx tsc --noEmit` clean in `dashboard/`
- [ ] Visual: load `/dashboard/marketplace` in demo mode → submit CTA visible top-right; clicking Install returns inline 501 message instead of 405

🤖 Generated with [Claude Code](https://claude.com/claude-code)