### PR TITLE
feat(marketplace): recipe detail view at /marketplace/[name]

### DIFF
--- a/dashboard/src/app/api/bridge/recipes/install/route.ts
+++ b/dashboard/src/app/api/bridge/recipes/install/route.ts
@@ -1,5 +1,6 @@
 import type { NextRequest } from "next/server";
 import { bridgeFetch } from "@/lib/bridge";
+import { isDemoModeServer } from "@/lib/demoModeServer";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -11,6 +12,16 @@ export async function POST(req: NextRequest): Promise<Response> {
       status: 403,
       headers: { "content-type": "application/json" },
     });
+  }
+
+  if (isDemoModeServer()) {
+    return new Response(
+      JSON.stringify({
+        error:
+          "Install requires a running Patchwork bridge. Run `npm i -g patchwork-os && patchwork start` locally, then revisit this page.",
+      }),
+      { status: 501, headers: { "content-type": "application/json" } },
+    );
   }
 
   const body = await req.text();

--- a/dashboard/src/app/marketplace/[...slug]/InstallPanel.tsx
+++ b/dashboard/src/app/marketplace/[...slug]/InstallPanel.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { apiPath } from "@/lib/api";
+
+interface Props {
+  install: string;
+  name: string;
+}
+
+interface BridgeStatus {
+  online: boolean;
+  installed: boolean;
+}
+
+const POLL_TIMEOUT_MS = 1500;
+
+export default function InstallPanel({ install, name }: Props) {
+  const [status, setStatus] = useState<BridgeStatus | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+  const [done, setDone] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    const ac = new AbortController();
+    const timer = setTimeout(() => ac.abort(), POLL_TIMEOUT_MS);
+
+    fetch(apiPath("/api/bridge/recipes"), { signal: ac.signal })
+      .then(async (r) => {
+        if (cancelled) return;
+        if (!r.ok) {
+          setStatus({ online: false, installed: false });
+          return;
+        }
+        const data = await r.json();
+        const list = Array.isArray(data) ? data : Array.isArray(data?.recipes) ? data.recipes : [];
+        const installed = list.some((x: { name: string }) => x.name === name);
+        setStatus({ online: true, installed });
+      })
+      .catch(() => {
+        if (!cancelled) setStatus({ online: false, installed: false });
+      })
+      .finally(() => clearTimeout(timer));
+
+    return () => {
+      cancelled = true;
+      ac.abort();
+      clearTimeout(timer);
+    };
+  }, [name]);
+
+  async function handleInstall() {
+    setBusy(true);
+    setErr(null);
+    try {
+      const res = await fetch(apiPath("/api/bridge/recipes/install"), {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ source: install }),
+      });
+      if (!res.ok) {
+        let msg = `Error ${res.status}`;
+        try {
+          const body = (await res.json()) as { error?: string };
+          if (body.error) msg = body.error;
+        } catch {
+          // ignore parse failure
+        }
+        throw new Error(msg);
+      }
+      setDone(true);
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const cliCmd = `patchwork recipe install ${install}`;
+  async function handleCopy() {
+    try {
+      await navigator.clipboard.writeText(cliCmd);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // clipboard unavailable
+    }
+  }
+
+  const installed = status?.installed === true || done;
+
+  return (
+    <div className="glass-card" style={{ padding: "var(--s-5)", display: "flex", flexDirection: "column", gap: 12 }}>
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 12, flexWrap: "wrap" }}>
+        <div style={{ fontSize: 13, color: "var(--ink-1)" }}>
+          {installed ? (
+            <>
+              <span style={{ color: "var(--ok)", marginRight: 6 }}>✓</span>
+              Installed locally — enable with{" "}
+              <code style={{ background: "var(--recess)", padding: "2px 6px", borderRadius: 4 }}>
+                patchwork recipe enable {name.replace(/^@[^/]+\//, "")}
+              </code>
+            </>
+          ) : status?.online ? (
+            "Bridge connected — install with one click."
+          ) : status === null ? (
+            "Checking for local bridge…"
+          ) : (
+            "No local bridge detected. Install via CLI below."
+          )}
+        </div>
+
+        {!installed && status?.online && (
+          <button type="button" className="btn sm" onClick={handleInstall} disabled={busy}>
+            {busy ? "Installing…" : "Install"}
+          </button>
+        )}
+      </div>
+
+      <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+        <code
+          style={{
+            flex: 1,
+            background: "var(--recess)",
+            padding: "10px 12px",
+            borderRadius: "var(--r-2)",
+            fontSize: 12,
+            fontFamily: "var(--font-mono, ui-monospace, monospace)",
+            overflowX: "auto",
+            color: "var(--ink-1)",
+          }}
+        >
+          {cliCmd}
+        </code>
+        <button
+          type="button"
+          className="btn sm ghost"
+          onClick={handleCopy}
+          aria-label="Copy install command"
+          style={{ flexShrink: 0 }}
+        >
+          {copied ? "Copied!" : "Copy"}
+        </button>
+      </div>
+
+      {err && (
+        <div className="alert-err" role="alert" style={{ fontSize: 12 }}>
+          {err}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/dashboard/src/app/marketplace/[...slug]/page.tsx
+++ b/dashboard/src/app/marketplace/[...slug]/page.tsx
@@ -1,0 +1,282 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import {
+  fetchManifest,
+  fetchRecipeYaml,
+  fetchRegistry,
+  githubBlobUrlFor,
+  parseInstallSource,
+  type RecipeManifest,
+  type RegistryRecipe,
+  shortName,
+  summarizeRisk,
+} from "@/lib/registry";
+import InstallPanel from "./InstallPanel";
+
+export const revalidate = 300;
+
+interface PageProps {
+  params: { slug: string[] };
+}
+
+export async function generateMetadata({ params }: PageProps) {
+  const fullName = decodeURIComponent(params.slug.join("/"));
+  return {
+    title: `${shortName(fullName)} — Marketplace · Patchwork OS`,
+  };
+}
+
+export default async function RecipeDetailPage({ params }: PageProps) {
+  const fullName = decodeURIComponent(params.slug.join("/"));
+
+  const registry = await fetchRegistry();
+  const recipe = registry?.recipes.find((r) => r.name === fullName);
+  if (!recipe) notFound();
+
+  const src = parseInstallSource(recipe.install);
+  let manifest: RecipeManifest | null = null;
+  let yaml: string | null = null;
+  if (src) {
+    manifest = await fetchManifest(src);
+    const main = manifest?.recipes?.main;
+    if (main) yaml = await fetchRecipeYaml(src, main);
+  }
+
+  return (
+    <section style={{ display: "flex", flexDirection: "column", gap: "var(--s-6)" }}>
+      <Link
+        href="/marketplace"
+        className="btn sm ghost"
+        style={{ alignSelf: "flex-start", textDecoration: "none", fontSize: 12 }}
+      >
+        ← Back to marketplace
+      </Link>
+
+      <Header recipe={recipe} manifest={manifest} />
+
+      <Description recipe={recipe} manifest={manifest} />
+
+      <InstallPanel install={recipe.install} name={recipe.name} />
+
+      <Variables manifest={manifest} />
+
+      <Steps yaml={yaml} />
+
+      <YamlPreview yaml={yaml} src={src} mainFile={manifest?.recipes?.main} />
+
+      <TrustNote />
+    </section>
+  );
+}
+
+// ----------------------------------------------------------------- subcomponents
+
+function Header({
+  recipe,
+  manifest,
+}: {
+  recipe: RegistryRecipe;
+  manifest: RecipeManifest | null;
+}) {
+  return (
+    <div className="page-head">
+      <div>
+        <h1 style={{ fontFamily: "var(--font-mono, ui-monospace, monospace)", letterSpacing: "-0.01em" }}>
+          {shortName(recipe.name)}
+        </h1>
+        <div className="page-head-sub" style={{ fontSize: 13, color: "var(--ink-2)" }}>
+          {recipe.name}
+          <span style={{ margin: "0 8px", color: "var(--ink-3)" }}>·</span>
+          <span>v{recipe.version}</span>
+          {manifest?.author && (
+            <>
+              <span style={{ margin: "0 8px", color: "var(--ink-3)" }}>·</span>
+              <span>by {manifest.author}</span>
+            </>
+          )}
+          {manifest?.license && (
+            <>
+              <span style={{ margin: "0 8px", color: "var(--ink-3)" }}>·</span>
+              <span>{manifest.license}</span>
+            </>
+          )}
+        </div>
+      </div>
+      <div style={{ display: "flex", gap: 6, flexWrap: "wrap", justifyContent: "flex-end" }}>
+        {recipe.tags.map((t) => (
+          <span key={t} className="tag-pill">
+            {t}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function Description({
+  recipe,
+  manifest,
+}: {
+  recipe: RegistryRecipe;
+  manifest: RecipeManifest | null;
+}) {
+  const description = manifest?.description ?? recipe.description;
+  return (
+    <p style={{ fontSize: 14, color: "var(--ink-1)", lineHeight: 1.6, maxWidth: 760 }}>
+      {description}
+    </p>
+  );
+}
+
+function Variables({ manifest }: { manifest: RecipeManifest | null }) {
+  const vars = manifest?.variables;
+  if (!vars || Object.keys(vars).length === 0) return null;
+
+  const entries = Object.entries(vars);
+  return (
+    <div className="glass-card" style={{ padding: "var(--s-5)" }}>
+      <h3 style={{ fontSize: 13, marginTop: 0, marginBottom: "var(--s-3)" }}>Configuration</h3>
+      <table style={{ width: "100%", fontSize: 12, borderCollapse: "collapse" }}>
+        <thead>
+          <tr style={{ textAlign: "left", color: "var(--ink-2)" }}>
+            <th style={{ padding: "6px 8px", borderBottom: "1px solid var(--line-1)" }}>Variable</th>
+            <th style={{ padding: "6px 8px", borderBottom: "1px solid var(--line-1)" }}>Required</th>
+            <th style={{ padding: "6px 8px", borderBottom: "1px solid var(--line-1)" }}>Default</th>
+            <th style={{ padding: "6px 8px", borderBottom: "1px solid var(--line-1)" }}>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          {entries.map(([key, info]) => (
+            <tr key={key}>
+              <td style={{ padding: "8px", fontFamily: "var(--font-mono, ui-monospace, monospace)" }}>
+                {key}
+              </td>
+              <td style={{ padding: "8px", color: info.required ? "var(--accent-strong)" : "var(--ink-3)" }}>
+                {info.required ? "yes" : "no"}
+              </td>
+              <td style={{ padding: "8px", fontFamily: "var(--font-mono, ui-monospace, monospace)" }}>
+                {info.default ?? "—"}
+              </td>
+              <td style={{ padding: "8px", color: "var(--ink-2)" }}>{info.description ?? ""}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function Steps({ yaml }: { yaml: string | null }) {
+  if (!yaml) return null;
+  const r = summarizeRisk(yaml);
+  if (r.steps === 0) return null;
+
+  return (
+    <div className="glass-card" style={{ padding: "var(--s-5)" }}>
+      <h3 style={{ fontSize: 13, marginTop: 0, marginBottom: "var(--s-3)" }}>Steps & risk</h3>
+      <div style={{ display: "flex", gap: 12, fontSize: 12, color: "var(--ink-1)" }}>
+        <span>
+          <strong>{r.steps}</strong> step{r.steps === 1 ? "" : "s"}
+        </span>
+        {r.low > 0 && (
+          <span style={{ color: "var(--ok)" }}>
+            <strong>{r.low}</strong> low risk
+          </span>
+        )}
+        {r.medium > 0 && (
+          <span style={{ color: "var(--warn)" }}>
+            <strong>{r.medium}</strong> medium risk
+          </span>
+        )}
+        {r.high > 0 && (
+          <span style={{ color: "var(--err)" }}>
+            <strong>{r.high}</strong> high risk
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function YamlPreview({
+  yaml,
+  src,
+  mainFile,
+}: {
+  yaml: string | null;
+  src: ReturnType<typeof parseInstallSource>;
+  mainFile: string | undefined;
+}) {
+  if (!yaml) {
+    return (
+      <div className="glass-card" style={{ padding: "var(--s-5)", color: "var(--ink-2)", fontSize: 13 }}>
+        Recipe source unavailable.
+      </div>
+    );
+  }
+  return (
+    <div className="glass-card" style={{ padding: 0, overflow: "hidden" }}>
+      <div
+        style={{
+          padding: "10px 16px",
+          borderBottom: "1px solid var(--line-1)",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          fontSize: 12,
+          color: "var(--ink-2)",
+        }}
+      >
+        <span style={{ fontFamily: "var(--font-mono, ui-monospace, monospace)" }}>
+          {mainFile ?? "recipe.yaml"}
+        </span>
+        {src && mainFile && (
+          <a
+            href={githubBlobUrlFor(src, mainFile)}
+            target="_blank"
+            rel="noopener noreferrer"
+            style={{ color: "var(--accent-strong)", textDecoration: "none", fontSize: 11 }}
+          >
+            View on GitHub →
+          </a>
+        )}
+      </div>
+      <pre
+        style={{
+          margin: 0,
+          padding: "16px",
+          fontFamily: "var(--font-mono, ui-monospace, monospace)",
+          fontSize: 12,
+          lineHeight: 1.55,
+          color: "var(--ink-1)",
+          background: "var(--recess)",
+          overflowX: "auto",
+          whiteSpace: "pre",
+        }}
+      >
+        {yaml}
+      </pre>
+    </div>
+  );
+}
+
+function TrustNote() {
+  return (
+    <div
+      style={{
+        padding: "12px 16px",
+        background: "rgba(180,83,9,0.06)",
+        border: "1px solid rgba(180,83,9,0.18)",
+        borderRadius: "var(--r-3)",
+        fontSize: 12,
+        color: "var(--ink-2)",
+        lineHeight: 1.6,
+      }}
+    >
+      <strong style={{ color: "var(--ink-0)" }}>Trust note.</strong> Marketplace recipes are open-source
+      community contributions and are not signature-verified. Patchwork OS installs every recipe in a
+      <em> disabled </em>state and gates each write through the approval inbox before it leaves your
+      machine. Review the YAML above before enabling.
+    </div>
+  );
+}

--- a/dashboard/src/app/marketplace/[...slug]/page.tsx
+++ b/dashboard/src/app/marketplace/[...slug]/page.tsx
@@ -22,8 +22,28 @@ interface PageProps {
 
 export async function generateMetadata({ params }: PageProps) {
   const fullName = decodeURIComponent(params.slug.join("/"));
+  const registry = await fetchRegistry();
+  const recipe = registry?.recipes.find((r) => r.name === fullName);
+
+  if (!recipe) {
+    return { title: "Not found — Marketplace · Patchwork OS" };
+  }
+
+  const title = `${shortName(recipe.name)} — Marketplace · Patchwork OS`;
   return {
-    title: `${shortName(fullName)} — Marketplace · Patchwork OS`,
+    title,
+    description: recipe.description,
+    openGraph: {
+      title: shortName(recipe.name),
+      description: recipe.description,
+      type: "article",
+      tags: recipe.tags,
+    },
+    twitter: {
+      card: "summary",
+      title: shortName(recipe.name),
+      description: recipe.description,
+    },
   };
 }
 

--- a/dashboard/src/app/marketplace/[...slug]/page.tsx
+++ b/dashboard/src/app/marketplace/[...slug]/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
+import { ConnectorHealthPanel } from "@/components/ConnectorHealthPanel";
 import {
   fetchManifest,
   fetchRecipeYaml,
@@ -57,6 +58,8 @@ export default async function RecipeDetailPage({ params }: PageProps) {
       <Description recipe={recipe} manifest={manifest} />
 
       <InstallPanel install={recipe.install} name={recipe.name} />
+
+      <ConnectorHealthPanel connectors={recipe.connectors} marginTop={0} />
 
       <Variables manifest={manifest} />
 

--- a/dashboard/src/app/marketplace/page.tsx
+++ b/dashboard/src/app/marketplace/page.tsx
@@ -507,6 +507,16 @@ export default function MarketplacePage() {
               {filtered.length} recipe{filtered.length !== 1 ? "s" : ""}
             </span>
           )}
+          <a
+            href="https://github.com/patchworkos/recipes/blob/main/CONTRIBUTING.md"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="btn sm ghost"
+            style={{ textDecoration: "none", fontSize: 12 }}
+            aria-label="Submit a recipe to the marketplace"
+          >
+            Submit a recipe →
+          </a>
         </div>
       </div>
 

--- a/dashboard/src/app/marketplace/page.tsx
+++ b/dashboard/src/app/marketplace/page.tsx
@@ -452,7 +452,8 @@ export default function MarketplacePage() {
     return (
       r.name.toLowerCase().includes(q) ||
       r.description.toLowerCase().includes(q) ||
-      r.tags.some((t) => t.toLowerCase().includes(q))
+      r.tags.some((t) => t.toLowerCase().includes(q)) ||
+      r.connectors.some((c) => c.toLowerCase().includes(q))
     );
   });
 
@@ -536,7 +537,7 @@ export default function MarketplacePage() {
         <input
           type="search"
           className="input"
-          placeholder="Search recipes…"
+          placeholder="Search recipes (name, tags, connectors)…"
           value={search}
           onChange={(e) => setSearch(e.target.value)}
           style={{ maxWidth: 360 }}

--- a/dashboard/src/app/marketplace/page.tsx
+++ b/dashboard/src/app/marketplace/page.tsx
@@ -3,24 +3,7 @@ import Link from "next/link";
 import { useEffect, useState } from "react";
 import { Skeleton, SkeletonText } from "@/components/Skeleton";
 import { apiPath } from "@/lib/api";
-
-// ------------------------------------------------------------------ types
-
-interface RegistryRecipe {
-  name: string;
-  version: string;
-  description: string;
-  tags: string[];
-  connectors: string[];
-  install: string;
-  downloads: number;
-}
-
-interface RegistryData {
-  version: string;
-  updated_at: string;
-  recipes: RegistryRecipe[];
-}
+import { type RegistryData, type RegistryRecipe, shortName } from "@/lib/registry";
 
 // ------------------------------------------------------------------ fallback data (shown when bridge offline)
 
@@ -113,10 +96,6 @@ const CATEGORY_TAG_MAP: Record<string, string[]> = {
 };
 
 // ------------------------------------------------------------------ helpers
-
-function shortName(name: string): string {
-  return name.replace(/^@[^/]+\//, "");
-}
 
 function connectorInitials(id: string): string {
   const norm = id.toLowerCase().replace(/[^a-z]/g, "");

--- a/dashboard/src/app/marketplace/page.tsx
+++ b/dashboard/src/app/marketplace/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+import Link from "next/link";
 import { useEffect, useState } from "react";
 import { Skeleton, SkeletonText } from "@/components/Skeleton";
 import { apiPath } from "@/lib/api";
@@ -215,17 +216,20 @@ function RecipeCard({
           marginBottom: "var(--s-2)",
         }}
       >
-        <div
+        <Link
+          href={`/marketplace/${recipe.name}`}
           style={{
             fontWeight: 600,
             fontSize: 14,
             color: "var(--fg-0)",
             wordBreak: "break-word",
             lineHeight: 1.4,
+            textDecoration: "none",
           }}
+          aria-label={`View details for ${shortName(recipe.name)}`}
         >
           {shortName(recipe.name)}
-        </div>
+        </Link>
         <div style={{ display: "flex", flexWrap: "wrap", gap: 4, justifyContent: "flex-end", flexShrink: 0 }}>
           {displayTags.map((tag) => (
             <span key={tag} className="tag-pill">

--- a/dashboard/src/components/ConnectorHealthPanel.tsx
+++ b/dashboard/src/components/ConnectorHealthPanel.tsx
@@ -46,9 +46,11 @@ function needsConnect(status: string | undefined): boolean {
 
 interface Props {
   connectors: string[];
+  /** Override the default top margin (var(--s-6)). Use 0 inside flex-gap layouts. */
+  marginTop?: string | number;
 }
 
-export function ConnectorHealthPanel({ connectors }: Props) {
+export function ConnectorHealthPanel({ connectors, marginTop }: Props) {
   const [statusMap, setStatusMap] = useState<StatusMap | null>(null);
   const [fetchErr, setFetchErr] = useState<string>();
 
@@ -105,7 +107,7 @@ export function ConnectorHealthPanel({ connectors }: Props) {
   return (
     <div
       className="glass-card"
-      style={{ padding: "var(--s-5)", marginTop: "var(--s-6)" }}
+      style={{ padding: "var(--s-5)", marginTop: marginTop ?? "var(--s-6)" }}
     >
       <div
         style={{

--- a/dashboard/src/lib/registry.ts
+++ b/dashboard/src/lib/registry.ts
@@ -1,0 +1,141 @@
+/**
+ * Shared types + helpers for the marketplace registry (read-only).
+ *
+ * Sources data from `https://raw.githubusercontent.com/patchworkos/recipes/main/`.
+ */
+
+export interface RegistryRecipe {
+  name: string;
+  version: string;
+  description: string;
+  tags: string[];
+  connectors: string[];
+  install: string;
+  downloads: number;
+}
+
+export interface RegistryData {
+  version: string;
+  updated_at: string;
+  recipes: RegistryRecipe[];
+}
+
+export interface RecipeManifest {
+  name: string;
+  version: string;
+  description?: string;
+  author?: string;
+  license?: string;
+  tags?: string[];
+  connectors?: string[];
+  recipes?: { main?: string; children?: string[] };
+  variables?: Record<
+    string,
+    { description?: string; required?: boolean; default?: string }
+  >;
+  homepage?: string;
+}
+
+export interface ParsedInstallSource {
+  owner: string;
+  repo: string;
+  path: string;
+  ref: string;
+}
+
+const REGISTRY_INDEX_URL =
+  "https://raw.githubusercontent.com/patchworkos/recipes/main/index.json";
+
+const RAW_BASE = "https://raw.githubusercontent.com";
+
+/** Parse an install string like `github:owner/repo/sub/dir@ref`. */
+export function parseInstallSource(install: string): ParsedInstallSource | null {
+  const match = /^github:([^/]+)\/([^/@]+)(?:\/([^@]+))?(?:@(.+))?$/.exec(install);
+  if (!match) return null;
+  return {
+    owner: match[1] ?? "",
+    repo: match[2] ?? "",
+    path: (match[3] ?? "").replace(/\/$/, ""),
+    ref: match[4] ?? "main",
+  };
+}
+
+export function rawUrlFor(src: ParsedInstallSource, file: string): string {
+  const parts = [src.owner, src.repo, src.ref, src.path, file].filter(Boolean);
+  return `${RAW_BASE}/${parts.join("/")}`;
+}
+
+export function githubBlobUrlFor(src: ParsedInstallSource, file: string): string {
+  const parts = [src.path, file].filter(Boolean).join("/");
+  return `https://github.com/${src.owner}/${src.repo}/blob/${src.ref}/${parts}`;
+}
+
+interface FetchOpts {
+  /** Cache TTL in seconds for ISR. Default 300. */
+  revalidate?: number;
+}
+
+export async function fetchRegistry(opts: FetchOpts = {}): Promise<RegistryData | null> {
+  try {
+    const res = await fetch(REGISTRY_INDEX_URL, {
+      next: { revalidate: opts.revalidate ?? 300 },
+    });
+    if (!res.ok) return null;
+    return (await res.json()) as RegistryData;
+  } catch {
+    return null;
+  }
+}
+
+export async function fetchManifest(
+  src: ParsedInstallSource,
+  opts: FetchOpts = {},
+): Promise<RecipeManifest | null> {
+  try {
+    const res = await fetch(rawUrlFor(src, "recipe.json"), {
+      next: { revalidate: opts.revalidate ?? 300 },
+    });
+    if (!res.ok) return null;
+    return (await res.json()) as RecipeManifest;
+  } catch {
+    return null;
+  }
+}
+
+export async function fetchRecipeYaml(
+  src: ParsedInstallSource,
+  mainFile: string,
+  opts: FetchOpts = {},
+): Promise<string | null> {
+  try {
+    const res = await fetch(rawUrlFor(src, mainFile), {
+      next: { revalidate: opts.revalidate ?? 300 },
+    });
+    if (!res.ok) return null;
+    return await res.text();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Crude risk-level extractor — counts `risk: low|medium|high` occurrences in YAML.
+ * Avoids a full YAML parser dependency for what's just a UI summary.
+ */
+export function summarizeRisk(yaml: string): {
+  low: number;
+  medium: number;
+  high: number;
+  steps: number;
+} {
+  const low = (yaml.match(/^\s*risk:\s*low\b/gm) ?? []).length;
+  const medium = (yaml.match(/^\s*risk:\s*medium\b/gm) ?? []).length;
+  const high = (yaml.match(/^\s*risk:\s*high\b/gm) ?? []).length;
+  const steps = (yaml.match(/^\s*-\s*id:\s+\S/gm) ?? []).length;
+  return { low, medium, high, steps };
+}
+
+/** Strip the `@scope/` prefix for display. */
+export function shortName(name: string): string {
+  return name.replace(/^@[^/]+\//, "");
+}


### PR DESCRIPTION
## Summary

Closes the biggest remaining trust gap on the marketplace: recipe cards were not clickable, so users had no way to inspect a recipe before installing it.

### Detail view at `/marketplace/[...slug]`

Catch-all route so scoped names like `@patchworkos/morning-brief` route natively. Server component with 5-min ISR.

- **Header** — name, full scoped id, version, author, license, tags
- **Description** — uses `recipe.json` description, falls back to registry index
- **Install panel** — bridge-online detection + one-click install + copyable `patchwork recipe install <source>` snippet (works whether or not the bridge is connected)
- **Connector status** — reuses the existing `ConnectorHealthPanel` so the user sees "you have Slack, need to connect Gmail" with a Connect button on missing connectors
- **Variables table** — required / default / description parsed from `recipe.json`
- **Step + risk summary** — counts of low/medium/high steps parsed from YAML
- **YAML preview** — full source in `<pre>`, plus "View on GitHub" deep link
- **Trust note** — explains the disabled-by-default install + approval-inbox safety model

### Other marketplace improvements bundled in

- **Search now matches connector names** — searching "gmail" finds Gmail-using recipes (was previously name/description/tags only)
- **OG + Twitter metadata** on the detail page so Slack/Twitter renders a card on share, not a bare URL
- **Shared `dashboard/src/lib/registry.ts`** — types + `parseInstallSource` + raw-URL helpers, reusable across the dashboard. The marketplace page now imports from it instead of redeclaring types.
- **`ConnectorHealthPanel` gained an optional `marginTop` prop** so flex-gap layouts can opt out of its default spacing (avoids the hard-coded `var(--s-6)` double-stacking with the parent's gap).

## Out of scope

- Live install counts (registry's `downloads` is always 0; needs telemetry backend)
- Author identity verification (manifest `author` is freeform string)
- YAML syntax highlighting (kept it as a plain `<pre>` to avoid a heavyweight client-side highlighter)

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run build` clean — route registered as `ƒ /marketplace/[...slug]`
- [ ] Visual: visit `/marketplace`, click a card title → detail page renders, copy command works, install button reflects bridge state
- [ ] Edge: visit `/marketplace/@nonexistent/foo` → 404
- [ ] Search: type "gmail" → only Gmail recipes show
- [ ] Share: paste detail URL into Slack → card renders with description

🤖 Generated with [Claude Code](https://claude.com/claude-code)