### PR TITLE
feat(connectors): add PagerDuty (read-only)

### DIFF
--- a/dashboard/src/app/connections/page.tsx
+++ b/dashboard/src/app/connections/page.tsx
@@ -164,6 +164,15 @@ function IconHubspot() {
   );
 }
 
+function IconPagerduty() {
+  return (
+    <svg width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden="true" style={{ flexShrink: 0 }}>
+      <path d="M10 2a4 4 0 00-4 4v3a3 3 0 01-1.5 2.6L3 13h14l-1.5-1.4A3 3 0 0114 9V6a4 4 0 00-4-4z" stroke="currentColor" strokeWidth="1.5" strokeLinejoin="round" />
+      <path d="M8.5 16a1.5 1.5 0 003 0" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+    </svg>
+  );
+}
+
 function IconIntercom() {
   return (
     <svg width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden="true" style={{ flexShrink: 0 }}>
@@ -221,6 +230,7 @@ const SUPPORTED_CONNECTORS = new Set([
   "hubspot",
   "intercom",
   "jira",
+  "pagerduty",
   "stripe",
   "zendesk",
 ]);
@@ -301,6 +311,21 @@ const TOKEN_MODAL_CONNECTORS: Record<string, TokenModalConfig> = {
     placeholder: "Atlassian API token",
     tokenKey: "token",
   },
+  pagerduty: {
+    name: "PagerDuty",
+    icon: <IconPagerduty />,
+    instructions: (
+      <>
+        Generate a personal or general API access key in{" "}
+        <a href="https://support.pagerduty.com/docs/api-access-keys" target="_blank" rel="noreferrer" style={{ color: "var(--info)" }}>
+          PagerDuty → Integrations → API Access Keys
+        </a>
+        . Read-only keys are sufficient for this PR's incident, service, and on-call queries.
+      </>
+    ),
+    placeholder: "PagerDuty API key",
+    tokenKey: "token",
+  },
   stripe: {
     name: "Stripe",
     icon: <IconStripe />,
@@ -351,6 +376,7 @@ const PROVIDERS: {
   { id: "hubspot",         name: "HubSpot",         description: "Read contacts, deals, and companies.",                                                             icon: IconHubspot },
   { id: "intercom",        name: "Intercom",        description: "Read conversations and customer data.",                                                             icon: IconIntercom },
   { id: "jira",            name: "Jira",            description: "Read and create Jira issues across projects.",                                                       icon: IconJira },
+  { id: "pagerduty",       name: "PagerDuty",       description: "Read incidents, services, and on-call rotations.",                                                  icon: IconPagerduty },
   { id: "stripe",          name: "Stripe",          description: "Read payment events, customers, and subscriptions.",                                               icon: IconStripe },
   { id: "zendesk",         name: "Zendesk",         description: "Read support tickets and customer context.",                                                        icon: IconZendesk },
   { id: "google-calendar", name: "Google Calendar", description: "View your schedule.",                                                                              icon: IconCalendar },

--- a/src/connectors/__tests__/pagerduty.test.ts
+++ b/src/connectors/__tests__/pagerduty.test.ts
@@ -1,0 +1,276 @@
+import { existsSync, mkdirSync, rmSync } from "node:fs";
+import os from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("pagerduty token helpers", () => {
+  const tmpDir = join(os.tmpdir(), `patchwork-pagerduty-${Date.now()}`);
+  const homeDir = join(tmpDir, "home");
+  const patchworkHome = join(homeDir, ".patchwork");
+  const tokensDir = join(patchworkHome, "tokens");
+
+  beforeEach(() => {
+    process.env.HOME = homeDir;
+    process.env.PATCHWORK_HOME = patchworkHome;
+    process.env.PATCHWORK_TOKEN_STORAGE_BACKEND = "file";
+    mkdirSync(tokensDir, { recursive: true });
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    delete process.env.HOME;
+    delete process.env.PATCHWORK_HOME;
+    delete process.env.PATCHWORK_TOKEN_STORAGE_BACKEND;
+    delete process.env.PAGERDUTY_TOKEN;
+    if (existsSync(tmpDir)) {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("loadTokens returns env var without reading storage", async () => {
+    process.env.PAGERDUTY_TOKEN = "pd-key-123";
+    const { loadTokens } = await import("../pagerduty.js");
+    const tokens = loadTokens();
+    expect(tokens).not.toBeNull();
+    expect(tokens!.token).toBe("pd-key-123");
+  });
+
+  it("loadTokens returns null when no env and no stored token", async () => {
+    const { loadTokens } = await import("../pagerduty.js");
+    expect(loadTokens()).toBeNull();
+  });
+
+  it("saveTokens + loadTokens round-trips", async () => {
+    const { loadTokens, saveTokens } = await import("../pagerduty.js");
+    const tokens = {
+      token: "pd-secret-key",
+      userEmail: "ops@example.com",
+      userName: "Ops Bot",
+      connected_at: "2026-04-29T00:00:00.000Z",
+    };
+    saveTokens(tokens);
+    const loaded = loadTokens();
+    expect(loaded).toMatchObject({
+      token: "pd-secret-key",
+      userEmail: "ops@example.com",
+    });
+  });
+
+  it("clearTokens does not throw even when no file exists", async () => {
+    const { clearTokens } = await import("../pagerduty.js");
+    expect(() => clearTokens()).not.toThrow();
+  });
+});
+
+describe("PagerDutyConnector.healthCheck", () => {
+  it("returns ok:true when API responds 200", async () => {
+    global.fetch = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ user: { name: "Ops", email: "ops@example.com" } }),
+      headers: { get: () => null },
+    }) as unknown as typeof fetch;
+
+    vi.resetModules();
+    const { PagerDutyConnector } = await import("../pagerduty.js");
+    const conn = new PagerDutyConnector();
+    (conn as unknown as { tokens: object }).tokens = {
+      token: "good",
+      connected_at: new Date().toISOString(),
+    };
+    vi.spyOn(
+      conn as unknown as {
+        authenticate: () => Promise<{ token: string; scopes: string[] }>;
+      },
+      "authenticate",
+    ).mockResolvedValue({ token: "good", scopes: [] });
+
+    const result = await conn.healthCheck();
+    expect(result.ok).toBe(true);
+  });
+
+  it("returns ok:false with auth_expired when API responds 401", async () => {
+    const fakeResponse = {
+      ok: false,
+      status: 401,
+      headers: { get: () => null },
+    };
+    // Make instanceof Response true via prototype manipulation
+    Object.setPrototypeOf(fakeResponse, Response.prototype);
+    global.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(fakeResponse) as unknown as typeof fetch;
+
+    vi.resetModules();
+    const { PagerDutyConnector } = await import("../pagerduty.js");
+    const conn = new PagerDutyConnector();
+    (conn as unknown as { tokens: object }).tokens = {
+      token: "bad",
+      connected_at: new Date().toISOString(),
+    };
+    vi.spyOn(
+      conn as unknown as {
+        authenticate: () => Promise<{ token: string; scopes: string[] }>;
+      },
+      "authenticate",
+    ).mockResolvedValue({ token: "bad", scopes: [] });
+
+    const result = await conn.healthCheck();
+    expect(result.ok).toBe(false);
+    expect(result.error?.code).toBe("auth_expired");
+  });
+});
+
+describe("PagerDutyConnector.listIncidents", () => {
+  it("includes status filter in query string", async () => {
+    const fetchSpy = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ incidents: [] }),
+      headers: { get: () => null },
+    });
+    global.fetch = fetchSpy as unknown as typeof fetch;
+
+    vi.resetModules();
+    const { PagerDutyConnector } = await import("../pagerduty.js");
+    const conn = new PagerDutyConnector();
+    (conn as unknown as { tokens: object }).tokens = {
+      token: "k",
+      connected_at: new Date().toISOString(),
+    };
+    vi.spyOn(
+      conn as unknown as {
+        authenticate: () => Promise<{ token: string; scopes: string[] }>;
+      },
+      "authenticate",
+    ).mockResolvedValue({ token: "k", scopes: [] });
+
+    await conn.listIncidents({ statuses: ["triggered", "acknowledged"] });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const url = String(fetchSpy.mock.calls[0]?.[0] ?? "");
+    expect(url).toContain("statuses%5B%5D=triggered");
+    expect(url).toContain("statuses%5B%5D=acknowledged");
+  });
+});
+
+describe("PagerDutyConnector.getIncident", () => {
+  it("translates 404 → not_found error code", async () => {
+    const fakeResponse = {
+      ok: false,
+      status: 404,
+      headers: { get: () => null },
+    };
+    Object.setPrototypeOf(fakeResponse, Response.prototype);
+    global.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(fakeResponse) as unknown as typeof fetch;
+
+    vi.resetModules();
+    const { PagerDutyConnector } = await import("../pagerduty.js");
+    const conn = new PagerDutyConnector();
+    (conn as unknown as { tokens: object }).tokens = {
+      token: "k",
+      connected_at: new Date().toISOString(),
+    };
+    vi.spyOn(
+      conn as unknown as {
+        authenticate: () => Promise<{ token: string; scopes: string[] }>;
+      },
+      "authenticate",
+    ).mockResolvedValue({ token: "k", scopes: [] });
+
+    // not_found is non-retryable so the connector throws once apiCall returns
+    // the error. The thrown message is `normalizeError(...).message`.
+    await expect(conn.getIncident("PXXX")).rejects.toThrow(/not found/i);
+  });
+});
+
+describe("handlePagerDutyConnect", () => {
+  it("returns 400 when token missing", async () => {
+    vi.resetModules();
+    const { handlePagerDutyConnect } = await import("../pagerduty.js");
+    const result = await handlePagerDutyConnect(JSON.stringify({}));
+    expect(result.status).toBe(400);
+    expect(JSON.parse(result.body).ok).toBe(false);
+  });
+
+  it("returns 400 on invalid JSON", async () => {
+    vi.resetModules();
+    const { handlePagerDutyConnect } = await import("../pagerduty.js");
+    const result = await handlePagerDutyConnect("not-json");
+    expect(result.status).toBe(400);
+  });
+
+  it("returns 401 when PagerDuty rejects credentials", async () => {
+    global.fetch = vi.fn().mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+    }) as unknown as typeof fetch;
+
+    vi.resetModules();
+    const { handlePagerDutyConnect } = await import("../pagerduty.js");
+    const result = await handlePagerDutyConnect(
+      JSON.stringify({ token: "bad" }),
+    );
+    expect(result.status).toBe(401);
+    expect(JSON.parse(result.body).ok).toBe(false);
+  });
+
+  it("returns 200 and stores tokens on success", async () => {
+    const tmpDir2 = join(
+      os.tmpdir(),
+      `patchwork-pagerduty-connect-${Date.now()}`,
+    );
+    const pHome = join(tmpDir2, ".patchwork");
+    mkdirSync(join(pHome, "tokens"), { recursive: true });
+    process.env.PATCHWORK_HOME = pHome;
+    process.env.PATCHWORK_TOKEN_STORAGE_BACKEND = "file";
+
+    global.fetch = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        user: { name: "Ops", email: "ops@example.com" },
+      }),
+    }) as unknown as typeof fetch;
+
+    vi.resetModules();
+    const { handlePagerDutyConnect, loadTokens } = await import(
+      "../pagerduty.js"
+    );
+    const result = await handlePagerDutyConnect(
+      JSON.stringify({ token: "good-key" }),
+    );
+    expect(result.status).toBe(200);
+    const body = JSON.parse(result.body);
+    expect(body.ok).toBe(true);
+    expect(body.userEmail).toBe("ops@example.com");
+
+    const stored = loadTokens();
+    expect(stored?.token).toBe("good-key");
+
+    delete process.env.PATCHWORK_HOME;
+    delete process.env.PATCHWORK_TOKEN_STORAGE_BACKEND;
+    rmSync(tmpDir2, { recursive: true, force: true });
+  });
+});
+
+describe("handlePagerDutyTest", () => {
+  it("returns 400 when not connected", async () => {
+    vi.resetModules();
+    const { handlePagerDutyTest } = await import("../pagerduty.js");
+    const result = await handlePagerDutyTest();
+    expect(result.status).toBe(400);
+  });
+});
+
+describe("handlePagerDutyDisconnect", () => {
+  it("returns 200 always", async () => {
+    vi.resetModules();
+    const { handlePagerDutyDisconnect } = await import("../pagerduty.js");
+    const result = handlePagerDutyDisconnect();
+    expect(result.status).toBe(200);
+    expect(JSON.parse(result.body).ok).toBe(true);
+  });
+});

--- a/src/connectors/gmail.ts
+++ b/src/connectors/gmail.ts
@@ -276,6 +276,7 @@ export async function handleConnectionsList(): Promise<ConnectorHandlerResult> {
     { id: "datadog", mod: () => import("./datadog.js") },
     { id: "hubspot", mod: () => import("./hubspot.js") },
     { id: "intercom", mod: () => import("./intercom.js") },
+    { id: "pagerduty", mod: () => import("./pagerduty.js") },
     { id: "stripe", mod: () => import("./stripe.js") },
     { id: "zendesk", mod: () => import("./zendesk.js") },
     { id: "jira", mod: () => import("./jira.js") },

--- a/src/connectors/pagerduty.ts
+++ b/src/connectors/pagerduty.ts
@@ -1,0 +1,442 @@
+/**
+ * PagerDuty connector — read incidents, services, and on-call rotations.
+ *
+ * Auth: API key (paste from PagerDuty Console → Integrations → API Access Keys).
+ *   - Env var: PAGERDUTY_TOKEN
+ *   - Stored: getSecretJsonSync("pagerduty") → PagerDutyTokens
+ *   - Header: Authorization: Token token=<key>   (PagerDuty's specific format —
+ *     not Bearer.)
+ *
+ * Tools (read-only this PR): listIncidents, getIncident, listServices, listOnCalls.
+ * Write methods (createIncident / ack / resolve) deferred to a follow-up PR.
+ *
+ * Extends BaseConnector for unified auth, retry, rate-limit, error handling.
+ */
+
+import {
+  type AuthContext,
+  BaseConnector,
+  type ConnectorError,
+  type ConnectorStatus,
+} from "./baseConnector.js";
+import {
+  deleteSecretJsonSync,
+  getSecretJsonSync,
+  storeSecretJsonSync,
+} from "./tokenStorage.js";
+
+const PAGERDUTY_BASE = "https://api.pagerduty.com";
+const PAGERDUTY_ACCEPT = "application/vnd.pagerduty+json;version=2";
+
+export interface PagerDutyTokens {
+  token: string;
+  userEmail?: string;
+  userName?: string;
+  connected_at: string;
+}
+
+export interface PagerDutyIncident {
+  id: string;
+  incident_number: number;
+  title: string;
+  status: string;
+  urgency: string;
+  created_at: string;
+  updated_at: string;
+  service?: { id: string; summary: string; type: string };
+  assignments?: Array<{
+    at: string;
+    assignee: { id: string; summary: string; type: string };
+  }>;
+  html_url: string;
+}
+
+export interface PagerDutyService {
+  id: string;
+  name: string;
+  description?: string;
+  status: string;
+  created_at: string;
+  html_url: string;
+}
+
+export interface PagerDutyOnCall {
+  user: { id: string; summary: string; type: string };
+  schedule?: { id: string; summary: string; type: string };
+  escalation_policy?: { id: string; summary: string; type: string };
+  escalation_level: number;
+  start?: string;
+  end?: string;
+}
+
+export class PagerDutyConnector extends BaseConnector {
+  readonly providerName = "pagerduty";
+
+  protected getOAuthConfig() {
+    return null;
+  }
+
+  async authenticate(): Promise<AuthContext> {
+    const tokens = loadTokens();
+    if (!tokens) {
+      throw new Error(
+        "PagerDuty not connected. Run: patchwork-os connect pagerduty or set PAGERDUTY_TOKEN",
+      );
+    }
+    return {
+      token: tokens.token,
+      scopes: ["read"],
+    };
+  }
+
+  async healthCheck(): Promise<{ ok: boolean; error?: ConnectorError }> {
+    try {
+      const result = await this.apiCall(async (token) => {
+        const res = await fetch(`${PAGERDUTY_BASE}/users/me`, {
+          headers: this.buildHeaders(token),
+        });
+        if (!res.ok) throw res;
+        return res.json();
+      });
+      if ("error" in result) return { ok: false, error: result.error };
+      return { ok: true };
+    } catch (err) {
+      return { ok: false, error: this.normalizeError(err) };
+    }
+  }
+
+  normalizeError(error: unknown): ConnectorError {
+    if (error instanceof Response) {
+      const s = error.status;
+      if (s === 401)
+        return {
+          code: "auth_expired",
+          message: "PagerDuty authentication failed — check API key",
+          retryable: false,
+          suggestedAction: "patchwork-os connect pagerduty",
+        };
+      if (s === 403)
+        return {
+          code: "permission_denied",
+          message: "Insufficient PagerDuty permissions for this resource",
+          retryable: false,
+        };
+      if (s === 404)
+        return {
+          code: "not_found",
+          message: "PagerDuty resource not found",
+          retryable: false,
+        };
+      if (s === 429)
+        return {
+          code: "rate_limited",
+          message: "PagerDuty API rate limit exceeded",
+          retryable: true,
+          suggestedAction: "Wait and retry",
+        };
+      return {
+        code: "provider_error",
+        message: `PagerDuty API error: HTTP ${s}`,
+        retryable: s >= 500,
+      };
+    }
+    if (error instanceof Error) {
+      if (
+        error.message.includes("ENOTFOUND") ||
+        error.message.includes("ECONNREFUSED")
+      ) {
+        return {
+          code: "network_error",
+          message: `Cannot connect to PagerDuty: ${error.message}`,
+          retryable: true,
+        };
+      }
+    }
+    return {
+      code: "provider_error",
+      message: error instanceof Error ? error.message : String(error),
+      retryable: false,
+    };
+  }
+
+  getStatus(): ConnectorStatus {
+    const tokens = loadTokens();
+    return {
+      id: "pagerduty",
+      status: tokens ? "connected" : "disconnected",
+      lastSync: tokens?.connected_at,
+      workspace: tokens?.userName ?? tokens?.userEmail ?? undefined,
+    };
+  }
+
+  // ── API Methods ────────────────────────────────────────────────────────────
+
+  async listIncidents(
+    params: {
+      statuses?: string[];
+      urgencies?: string[];
+      since?: string;
+      until?: string;
+      limit?: number;
+    } = {},
+  ): Promise<{ incidents: PagerDutyIncident[] }> {
+    const result = await this.apiCall(async (token) => {
+      const qs = new URLSearchParams();
+      qs.set("limit", String(params.limit ?? 25));
+      if (params.statuses?.length)
+        for (const s of params.statuses) qs.append("statuses[]", s);
+      if (params.urgencies?.length)
+        for (const u of params.urgencies) qs.append("urgencies[]", u);
+      if (params.since) qs.set("since", params.since);
+      if (params.until) qs.set("until", params.until);
+
+      const res = await fetch(`${PAGERDUTY_BASE}/incidents?${qs}`, {
+        headers: this.buildHeaders(token),
+      });
+      this.updateRateLimitFromHeaders({
+        "x-ratelimit-remaining":
+          res.headers.get("x-ratelimit-remaining") ?? undefined,
+        "retry-after": res.headers.get("retry-after") ?? undefined,
+      });
+      if (!res.ok) throw res;
+      return res.json() as Promise<{ incidents: PagerDutyIncident[] }>;
+    });
+
+    if ("error" in result) throw new Error(result.error.message);
+    return result.data as { incidents: PagerDutyIncident[] };
+  }
+
+  async getIncident(id: string): Promise<PagerDutyIncident> {
+    const result = await this.apiCall(async (token) => {
+      const res = await fetch(`${PAGERDUTY_BASE}/incidents/${id}`, {
+        headers: this.buildHeaders(token),
+      });
+      if (!res.ok) throw res;
+      const data = (await res.json()) as { incident: PagerDutyIncident };
+      return data.incident;
+    });
+
+    if ("error" in result) throw new Error(result.error.message);
+    return result.data as PagerDutyIncident;
+  }
+
+  async listServices(
+    params: { limit?: number } = {},
+  ): Promise<{ services: PagerDutyService[] }> {
+    const result = await this.apiCall(async (token) => {
+      const qs = new URLSearchParams({ limit: String(params.limit ?? 25) });
+      const res = await fetch(`${PAGERDUTY_BASE}/services?${qs}`, {
+        headers: this.buildHeaders(token),
+      });
+      if (!res.ok) throw res;
+      return res.json() as Promise<{ services: PagerDutyService[] }>;
+    });
+
+    if ("error" in result) throw new Error(result.error.message);
+    return result.data as { services: PagerDutyService[] };
+  }
+
+  async listOnCalls(
+    params: { scheduleIds?: string[]; limit?: number } = {},
+  ): Promise<{ oncalls: PagerDutyOnCall[] }> {
+    const result = await this.apiCall(async (token) => {
+      const qs = new URLSearchParams({ limit: String(params.limit ?? 25) });
+      if (params.scheduleIds?.length)
+        for (const id of params.scheduleIds) qs.append("schedule_ids[]", id);
+      const res = await fetch(`${PAGERDUTY_BASE}/oncalls?${qs}`, {
+        headers: this.buildHeaders(token),
+      });
+      if (!res.ok) throw res;
+      return res.json() as Promise<{ oncalls: PagerDutyOnCall[] }>;
+    });
+
+    if ("error" in result) throw new Error(result.error.message);
+    return result.data as { oncalls: PagerDutyOnCall[] };
+  }
+
+  // ── Helpers ────────────────────────────────────────────────────────────────
+
+  private buildHeaders(token: string): Record<string, string> {
+    return {
+      Authorization: `Token token=${token}`,
+      Accept: PAGERDUTY_ACCEPT,
+      "Content-Type": "application/json",
+    };
+  }
+}
+
+// ── Token persistence ────────────────────────────────────────────────────────
+
+export function loadTokens(): PagerDutyTokens | null {
+  const envToken = process.env.PAGERDUTY_TOKEN;
+  if (envToken) {
+    return {
+      token: envToken,
+      connected_at: new Date().toISOString(),
+    };
+  }
+  return getSecretJsonSync<PagerDutyTokens>("pagerduty");
+}
+
+export function saveTokens(tokens: PagerDutyTokens): void {
+  storeSecretJsonSync("pagerduty", tokens);
+}
+
+export function clearTokens(): void {
+  try {
+    deleteSecretJsonSync("pagerduty");
+  } catch {
+    // ignore
+  }
+}
+
+// ── Singleton instance ───────────────────────────────────────────────────────
+
+let _instance: PagerDutyConnector | null = null;
+
+function resetPagerDutyConnector(): void {
+  _instance = null;
+}
+
+export function getPagerDutyConnector(): PagerDutyConnector {
+  if (!_instance) {
+    _instance = new PagerDutyConnector();
+  }
+  return _instance;
+}
+
+export { getPagerDutyConnector as pagerduty };
+
+// ── HTTP Handlers ────────────────────────────────────────────────────────────
+// Wired in src/server.ts under /connections/pagerduty/*
+
+export interface ConnectorHandlerResult {
+  status: number;
+  body: string;
+  contentType?: string;
+}
+
+/**
+ * POST /connections/pagerduty/connect  { token }
+ */
+export async function handlePagerDutyConnect(
+  body: string,
+): Promise<ConnectorHandlerResult> {
+  let token: string;
+
+  try {
+    const parsed = JSON.parse(body) as { token?: unknown };
+    if (typeof parsed.token !== "string" || !parsed.token) {
+      return {
+        status: 400,
+        contentType: "application/json",
+        body: JSON.stringify({ ok: false, error: "token is required" }),
+      };
+    }
+    token = parsed.token;
+  } catch {
+    return {
+      status: 400,
+      contentType: "application/json",
+      body: JSON.stringify({ ok: false, error: "Invalid JSON body" }),
+    };
+  }
+
+  try {
+    const res = await fetch(`${PAGERDUTY_BASE}/users/me`, {
+      headers: {
+        Authorization: `Token token=${token}`,
+        Accept: PAGERDUTY_ACCEPT,
+      },
+    });
+    if (!res.ok) {
+      return {
+        status: 401,
+        contentType: "application/json",
+        body: JSON.stringify({
+          ok: false,
+          error: `Credentials rejected by PagerDuty (HTTP ${res.status}) — check API key`,
+        }),
+      };
+    }
+    const detail = (await res.json().catch(() => ({}))) as {
+      user?: { name?: string; email?: string };
+    };
+
+    const tokens: PagerDutyTokens = {
+      token,
+      userEmail: detail.user?.email,
+      userName: detail.user?.name,
+      connected_at: new Date().toISOString(),
+    };
+    saveTokens(tokens);
+    resetPagerDutyConnector();
+
+    return {
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        ok: true,
+        userEmail: tokens.userEmail,
+        userName: tokens.userName,
+        connectedAt: tokens.connected_at,
+      }),
+    };
+  } catch (err) {
+    return {
+      status: 500,
+      contentType: "application/json",
+      body: JSON.stringify({
+        ok: false,
+        error: err instanceof Error ? err.message : String(err),
+      }),
+    };
+  }
+}
+
+/**
+ * POST /connections/pagerduty/test
+ */
+export async function handlePagerDutyTest(): Promise<ConnectorHandlerResult> {
+  const tokens = loadTokens();
+  if (!tokens) {
+    return {
+      status: 400,
+      contentType: "application/json",
+      body: JSON.stringify({ ok: false, error: "PagerDuty not connected" }),
+    };
+  }
+  try {
+    const connector = getPagerDutyConnector();
+    const check = await connector.healthCheck();
+    return {
+      status: check.ok ? 200 : 401,
+      contentType: "application/json",
+      body: JSON.stringify(
+        check.ok ? { ok: true } : { ok: false, error: check.error?.message },
+      ),
+    };
+  } catch (err) {
+    return {
+      status: 500,
+      contentType: "application/json",
+      body: JSON.stringify({
+        ok: false,
+        error: err instanceof Error ? err.message : String(err),
+      }),
+    };
+  }
+}
+
+/**
+ * DELETE /connections/pagerduty
+ */
+export function handlePagerDutyDisconnect(): ConnectorHandlerResult {
+  clearTokens();
+  resetPagerDutyConnector();
+  return {
+    status: 200,
+    contentType: "application/json",
+    body: JSON.stringify({ ok: true }),
+  };
+}

--- a/src/recipes/tools/index.ts
+++ b/src/recipes/tools/index.ts
@@ -22,6 +22,7 @@ import "./zendesk.js";
 import "./intercom.js";
 import "./hubspot.js";
 import "./datadog.js";
+import "./pagerduty.js";
 import "./stripe.js";
 import "./meetingNotes.js";
 

--- a/src/recipes/tools/pagerduty.ts
+++ b/src/recipes/tools/pagerduty.ts
@@ -1,0 +1,233 @@
+/**
+ * PagerDuty tools — read incidents, services, and on-call rotations.
+ *
+ * Self-registering tool module for the recipe tool registry. Read-only this PR;
+ * write methods (createIncident / ack / resolve) are deferred.
+ *
+ * Each tool wraps connector throws into the `{count, items, error}` shape that
+ * the runner's silent-fail detector (PR #75) catches as a step error rather
+ * than a silent empty list.
+ */
+
+import { CommonSchemas, registerTool } from "../toolRegistry.js";
+
+// ============================================================================
+// pagerduty.list_incidents
+// ============================================================================
+
+registerTool({
+  id: "pagerduty.list_incidents",
+  namespace: "pagerduty",
+  description:
+    "List PagerDuty incidents, optionally filtered by status, urgency, and time range.",
+  paramsSchema: {
+    type: "object",
+    properties: {
+      statuses: {
+        type: "array",
+        items: { type: "string" },
+        description:
+          'Filter by incident status (e.g. ["triggered", "acknowledged", "resolved"])',
+      },
+      urgencies: {
+        type: "array",
+        items: { type: "string" },
+        description: 'Filter by urgency (e.g. ["high", "low"])',
+      },
+      since: {
+        type: "string",
+        description: "ISO 8601 lower bound on created_at",
+      },
+      until: {
+        type: "string",
+        description: "ISO 8601 upper bound on created_at",
+      },
+      max: CommonSchemas.max,
+      into: CommonSchemas.into,
+    },
+  },
+  outputSchema: {
+    type: "object",
+    properties: {
+      count: { type: "number" },
+      items: { type: "array", items: { type: "object" } },
+      error: { type: "string" },
+    },
+  },
+  riskDefault: "low",
+  isWrite: false,
+  isConnector: true,
+  execute: async ({ params }) => {
+    const { getPagerDutyConnector } = await import(
+      "../../connectors/pagerduty.js"
+    );
+    const limit = typeof params.max === "number" ? params.max : 25;
+    try {
+      const connector = getPagerDutyConnector();
+      const { incidents } = await connector.listIncidents({
+        statuses: Array.isArray(params.statuses)
+          ? (params.statuses as string[])
+          : undefined,
+        urgencies: Array.isArray(params.urgencies)
+          ? (params.urgencies as string[])
+          : undefined,
+        since: typeof params.since === "string" ? params.since : undefined,
+        until: typeof params.until === "string" ? params.until : undefined,
+        limit,
+      });
+      return JSON.stringify({ count: incidents.length, items: incidents });
+    } catch (err) {
+      return JSON.stringify({
+        count: 0,
+        items: [],
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  },
+});
+
+// ============================================================================
+// pagerduty.get_incident
+// ============================================================================
+
+registerTool({
+  id: "pagerduty.get_incident",
+  namespace: "pagerduty",
+  description: "Fetch a single PagerDuty incident by id (e.g. 'PXXXX').",
+  paramsSchema: {
+    type: "object",
+    properties: {
+      id: { type: "string", description: "PagerDuty incident id" },
+      into: CommonSchemas.into,
+    },
+    required: ["id"],
+  },
+  outputSchema: {
+    type: "object",
+    properties: {
+      count: { type: "number" },
+      items: { type: "array", items: { type: "object" } },
+      error: { type: "string" },
+    },
+  },
+  riskDefault: "low",
+  isWrite: false,
+  isConnector: true,
+  execute: async ({ params }) => {
+    const { getPagerDutyConnector } = await import(
+      "../../connectors/pagerduty.js"
+    );
+    try {
+      const connector = getPagerDutyConnector();
+      const incident = await connector.getIncident(params.id as string);
+      return JSON.stringify({ count: 1, items: [incident] });
+    } catch (err) {
+      return JSON.stringify({
+        count: 0,
+        items: [],
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  },
+});
+
+// ============================================================================
+// pagerduty.list_services
+// ============================================================================
+
+registerTool({
+  id: "pagerduty.list_services",
+  namespace: "pagerduty",
+  description: "List PagerDuty services (technical components paged by PD).",
+  paramsSchema: {
+    type: "object",
+    properties: {
+      max: CommonSchemas.max,
+      into: CommonSchemas.into,
+    },
+  },
+  outputSchema: {
+    type: "object",
+    properties: {
+      count: { type: "number" },
+      items: { type: "array", items: { type: "object" } },
+      error: { type: "string" },
+    },
+  },
+  riskDefault: "low",
+  isWrite: false,
+  isConnector: true,
+  execute: async ({ params }) => {
+    const { getPagerDutyConnector } = await import(
+      "../../connectors/pagerduty.js"
+    );
+    const limit = typeof params.max === "number" ? params.max : 25;
+    try {
+      const connector = getPagerDutyConnector();
+      const { services } = await connector.listServices({ limit });
+      return JSON.stringify({ count: services.length, items: services });
+    } catch (err) {
+      return JSON.stringify({
+        count: 0,
+        items: [],
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  },
+});
+
+// ============================================================================
+// pagerduty.list_on_calls
+// ============================================================================
+
+registerTool({
+  id: "pagerduty.list_on_calls",
+  namespace: "pagerduty",
+  description:
+    "List current PagerDuty on-call assignments, optionally filtered by schedule ids.",
+  paramsSchema: {
+    type: "object",
+    properties: {
+      scheduleIds: {
+        type: "array",
+        items: { type: "string" },
+        description: "Restrict results to these schedule ids",
+      },
+      max: CommonSchemas.max,
+      into: CommonSchemas.into,
+    },
+  },
+  outputSchema: {
+    type: "object",
+    properties: {
+      count: { type: "number" },
+      items: { type: "array", items: { type: "object" } },
+      error: { type: "string" },
+    },
+  },
+  riskDefault: "low",
+  isWrite: false,
+  isConnector: true,
+  execute: async ({ params }) => {
+    const { getPagerDutyConnector } = await import(
+      "../../connectors/pagerduty.js"
+    );
+    const limit = typeof params.max === "number" ? params.max : 25;
+    try {
+      const connector = getPagerDutyConnector();
+      const { oncalls } = await connector.listOnCalls({
+        scheduleIds: Array.isArray(params.scheduleIds)
+          ? (params.scheduleIds as string[])
+          : undefined,
+        limit,
+      });
+      return JSON.stringify({ count: oncalls.length, items: oncalls });
+    } catch (err) {
+      return JSON.stringify({
+        count: 0,
+        items: [],
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  },
+});

--- a/src/server.ts
+++ b/src/server.ts
@@ -1746,6 +1746,62 @@ export class Server extends EventEmitter<ServerEvents> {
         return;
       }
 
+      // ── PagerDuty routes ───────────────────────────────────────────
+      if (
+        parsedUrl.pathname === "/connections/pagerduty/connect" &&
+        req.method === "POST"
+      ) {
+        const chunks: Buffer[] = [];
+        req.on("data", (c: Buffer) => chunks.push(c));
+        req.on("end", () => {
+          void (async () => {
+            const { handlePagerDutyConnect } = await import(
+              "./connectors/pagerduty.js"
+            );
+            const result = await handlePagerDutyConnect(
+              Buffer.concat(chunks).toString("utf-8"),
+            );
+            res.writeHead(result.status, {
+              "Content-Type": result.contentType ?? "application/json",
+            });
+            res.end(result.body);
+          })();
+        });
+        return;
+      }
+
+      if (
+        parsedUrl.pathname === "/connections/pagerduty/test" &&
+        req.method === "POST"
+      ) {
+        void (async () => {
+          const { handlePagerDutyTest } = await import(
+            "./connectors/pagerduty.js"
+          );
+          const result = await handlePagerDutyTest();
+          res.writeHead(result.status, {
+            "Content-Type": result.contentType ?? "application/json",
+          });
+          res.end(result.body);
+        })();
+        return;
+      }
+
+      if (
+        parsedUrl.pathname === "/connections/pagerduty" &&
+        req.method === "DELETE"
+      ) {
+        const { handlePagerDutyDisconnect } = await import(
+          "./connectors/pagerduty.js"
+        );
+        const result = handlePagerDutyDisconnect();
+        res.writeHead(result.status, {
+          "Content-Type": result.contentType ?? "application/json",
+        });
+        res.end(result.body);
+        return;
+      }
+
       // ── Stripe routes ───────────────────────────────────────────────
       if (
         parsedUrl.pathname === "/connections/stripe/connect" &&


### PR DESCRIPTION
## Summary

Wires the existing PagerDuty catalog card (Coming Soon) end-to-end so users can paste an API key and start querying.

- New connector class `PagerDutyConnector` extending `BaseConnector`. Auth uses PD's `Authorization: Token token=KEY` format (not Bearer); all responses set `Accept: application/vnd.pagerduty+json;version=2`.
- Read-only methods this PR: `listIncidents({statuses,urgencies,since,until,limit})`, `getIncident(id)`, `listServices({limit})`, `listOnCalls({scheduleIds,limit})`. Write methods (createIncident / ack / resolve) deferred to a follow-up.
- Recipe tool wrappers `pagerduty.list_incidents`, `pagerduty.get_incident`, `pagerduty.list_services`, `pagerduty.list_on_calls` in the `{count, items, error}` silent-fail-detector shape (PR #75 convention). Registered in `src/recipes/tools/index.ts`.
- Server wiring: PagerDuty added to `/connections` GET probe in `gmail.ts`, plus new `POST /connections/pagerduty/connect` (validates with `GET /users/me`), `POST /connections/pagerduty/test`, `DELETE /connections/pagerduty`.
- Dashboard wiring: added to `SUPPORTED_CONNECTORS`, new `IconPagerduty` glyph, `TOKEN_MODAL_CONNECTORS.pagerduty` config pointing at PagerDuty's API access keys docs, PROVIDERS entry. Existing `pagerduty` CATALOG row (line 40) flips from Coming Soon to connectable.

## Tests

- `src/connectors/__tests__/pagerduty.test.ts` — 14 tests, all green:
  - token helpers: env-var loading, file roundtrip, clear-when-missing
  - `healthCheck` 200 (ok) + 401 (auth_expired)
  - `listIncidents` status filter encoding
  - `getIncident` 404 → not_found
  - `handlePagerDutyConnect` 400 (missing/invalid body), 401 (rejected), 200 (stores tokens)
  - `handlePagerDutyTest` 400 when not connected
  - `handlePagerDutyDisconnect` always 200

## Verification

- [x] `npm run build` (bridge) passes
- [x] `npx tsc --noEmit` in `dashboard/` passes
- [x] `npx vitest run src/connectors/__tests__/pagerduty.test.ts` — 14/14 pass
- [x] Full connector suite still green: 199/199 (21 files)
- [x] Recipe suite still green: 467/467 (28 files)
- [x] `biome check --write` clean on all changed files

## Deferred

- Write methods: `createIncident`, `acknowledgeIncident`, `resolveIncident`
- Snooze / annotation operations
- Webhook subscription endpoints

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>