### PR TITLE
feat(connectors): add Discord (read-only OAuth)

### DIFF
--- a/dashboard/src/app/api/connections/discord/callback/route.ts
+++ b/dashboard/src/app/api/connections/discord/callback/route.ts
@@ -1,0 +1,21 @@
+import { bridgeFetch } from "@/lib/bridge";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function GET(req: Request): Promise<Response> {
+  const url = new URL(req.url);
+  const allowed = ["code", "state", "error"];
+  const qs = new URLSearchParams();
+  for (const key of allowed) {
+    const v = url.searchParams.get(key);
+    if (v !== null) qs.set(key, v);
+  }
+
+  const res = await bridgeFetch(`/connections/discord/callback?${qs.toString()}`);
+  const body = await res.text();
+  return new Response(body, {
+    status: res.status,
+    headers: { "content-type": res.headers.get("content-type") ?? "application/json" },
+  });
+}

--- a/dashboard/src/app/connections/discord/callback/page.tsx
+++ b/dashboard/src/app/connections/discord/callback/page.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { Suspense, useEffect, useRef } from "react";
+import { apiPath } from '@/lib/api';
+import { useRouter, useSearchParams } from "next/navigation";
+
+function DiscordCallbackInner() {
+  const params = useSearchParams();
+  const router = useRouter();
+  const called = useRef(false);
+
+  useEffect(() => {
+    if (called.current) return;
+    called.current = true;
+
+    const code = params.get("code");
+    const state = params.get("state");
+    const error = params.get("error");
+
+    const qs = new URLSearchParams();
+    if (code) qs.set("code", code);
+    if (state) qs.set("state", state);
+    if (error) qs.set("error", error);
+
+    fetch(apiPath(`/api/connections/discord/callback?${qs.toString()}`))
+      .then((r) => r.json())
+      .then(() => {
+        if (window.opener) {
+          window.opener.postMessage("patchwork:discord:connected", window.location.origin);
+          window.close();
+        } else {
+          router.push("/connections");
+        }
+      })
+      .catch(() => router.push("/connections"));
+  }, [params, router]);
+
+  return <p>Connecting Discord…</p>;
+}
+
+export default function DiscordCallbackPage() {
+  return (
+    <div style={{
+      display: "flex", alignItems: "center", justifyContent: "center",
+      minHeight: "100vh", background: "#040406", color: "#e0e0e0",
+      fontFamily: "system-ui, sans-serif",
+    }}>
+      <Suspense fallback={<p>Loading…</p>}>
+        <DiscordCallbackInner />
+      </Suspense>
+    </div>
+  );
+}

--- a/dashboard/src/app/connections/page.tsx
+++ b/dashboard/src/app/connections/page.tsx
@@ -42,6 +42,7 @@ const CATALOG: ConnectorDef[] = [
   { id: "confluence",       name: "Confluence",       initials: "CF", category: "Docs",       wave: 1, tools: 5,  bg: "#0052CC" },
   { id: "linear",           name: "Linear",           initials: "LI", category: "Project",    wave: 1, tools: 6,  bg: "#5E6AD2" },
   { id: "slack",            name: "Slack",            initials: "SL", category: "Comms",      wave: 1, tools: 7,  bg: "#4A154B" },
+  { id: "discord",          name: "Discord",          initials: "DC", category: "Comms",      wave: 1, tools: 6,  bg: "#5865F2" },
   // Wave 2
   { id: "zendesk",          name: "Zendesk",          initials: "ZD", category: "Support",    wave: 2, tools: 6,  bg: "#03363D" },
   { id: "github",           name: "GitHub",           initials: "GH", category: "Dev",        wave: 2, tools: 10, bg: "#24292E" },
@@ -135,6 +136,17 @@ function IconConfluence() {
   );
 }
 
+function IconDiscord() {
+  return (
+    <svg width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden="true" style={{ flexShrink: 0 }}>
+      <rect x="2" y="4" width="16" height="12" rx="3" stroke="currentColor" strokeWidth="1.5" />
+      <circle cx="7.5" cy="10" r="1" fill="currentColor" />
+      <circle cx="12.5" cy="10" r="1" fill="currentColor" />
+      <path d="M5 16l1.5 2M15 16l-1.5 2" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+    </svg>
+  );
+}
+
 function IconJira() {
   return (
     <svg width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden="true" style={{ flexShrink: 0 }}>
@@ -224,6 +236,7 @@ const SUPPORTED_CONNECTORS = new Set([
   "linear",
   "sentry",
   "slack",
+  "discord",
   "notion",
   "confluence",
   "datadog",
@@ -370,6 +383,7 @@ const PROVIDERS: {
   { id: "github",          name: "GitHub",          description: "Read open issues and pull requests via GitHub's official MCP server.",                             icon: IconGitHub },
   { id: "linear",          name: "Linear",          description: "Read and manage issues.",                                                                          icon: IconLinear },
   { id: "slack",           name: "Slack",           description: "Post messages and list channels.",                                                                  icon: IconSlack },
+  { id: "discord",         name: "Discord",         description: "Read messages, channels, and guilds.",                                                              icon: IconDiscord },
   { id: "notion",          name: "Notion",          description: "Query databases, read pages, and create content.",                                                  icon: IconNotion },
   { id: "confluence",      name: "Confluence",      description: "Read and write Confluence pages and spaces.",                                                       icon: IconConfluence },
   { id: "datadog",         name: "Datadog",         description: "Query monitors, dashboards, and events.",                                                          icon: IconDatadog },
@@ -402,6 +416,7 @@ function logoUrl(id: string): string | null {
     confluence:       `${SI_CDN}/confluence/ffffff`,
     linear:           `${SI_CDN}/linear/ffffff`,
     slack:            `${SI_V13}/slack.svg`,
+    discord:          `${SI_CDN}/discord/ffffff`,
     zendesk:          `${SI_CDN}/zendesk/ffffff`,
     github:           `${SI_CDN}/github/ffffff`,
     gitlab:           `${SI_CDN}/gitlab/ffffff`,

--- a/src/connectors/__tests__/discord.test.ts
+++ b/src/connectors/__tests__/discord.test.ts
@@ -1,0 +1,448 @@
+import { existsSync, mkdirSync, rmSync } from "node:fs";
+import os from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ── Token storage ────────────────────────────────────────────────────────────
+
+describe("discord token storage", () => {
+  const tmpDir = join(os.tmpdir(), `patchwork-discord-${Date.now()}`);
+  const homeDir = join(tmpDir, "home");
+  const patchworkHome = join(homeDir, ".patchwork");
+  const tokensDir = join(patchworkHome, "tokens");
+
+  beforeEach(() => {
+    process.env.HOME = homeDir;
+    process.env.PATCHWORK_HOME = patchworkHome;
+    process.env.PATCHWORK_TOKEN_STORAGE_BACKEND = "file";
+    mkdirSync(tokensDir, { recursive: true });
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    delete process.env.HOME;
+    delete process.env.PATCHWORK_HOME;
+    delete process.env.PATCHWORK_TOKEN_STORAGE_BACKEND;
+    delete process.env.DISCORD_CLIENT_ID;
+    delete process.env.DISCORD_CLIENT_SECRET;
+    if (existsSync(tmpDir)) {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("loadTokens returns null when no token stored", async () => {
+    const { loadTokens } = await import("../discord.js");
+    expect(loadTokens()).toBeNull();
+  });
+
+  it("saveTokens + loadTokens round-trips", async () => {
+    const { loadTokens, saveTokens } = await import("../discord.js");
+    const tokens = {
+      access_token: "discord-access-123",
+      refresh_token: "discord-refresh-123",
+      expires_at: Date.now() + 7 * 24 * 60 * 60 * 1000,
+      scope: "identify guilds messages.read",
+      username: "patchwork-bot",
+      user_id: "1234567890",
+      connected_at: "2026-04-29T00:00:00.000Z",
+    };
+    saveTokens(tokens);
+    const loaded = loadTokens();
+    expect(loaded).toMatchObject({
+      access_token: "discord-access-123",
+      refresh_token: "discord-refresh-123",
+      username: "patchwork-bot",
+    });
+  });
+
+  it("clearTokens does not throw when no file exists", async () => {
+    const { clearTokens } = await import("../discord.js");
+    expect(() => clearTokens()).not.toThrow();
+  });
+
+  it("isConnected reflects stored token presence", async () => {
+    const { isConnected, saveTokens, clearTokens } = await import(
+      "../discord.js"
+    );
+    expect(isConnected()).toBe(false);
+    saveTokens({
+      access_token: "x",
+      connected_at: new Date().toISOString(),
+    });
+    expect(isConnected()).toBe(true);
+    clearTokens();
+    expect(isConnected()).toBe(false);
+  });
+});
+
+// ── healthCheck ──────────────────────────────────────────────────────────────
+
+describe("DiscordConnector.healthCheck", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("returns ok:true when API responds 200", async () => {
+    global.fetch = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ id: "u1", username: "patchwork" }),
+      headers: { get: () => null },
+    }) as unknown as typeof fetch;
+
+    const { DiscordConnector } = await import("../discord.js");
+    const conn = new DiscordConnector();
+    vi.spyOn(
+      conn as unknown as {
+        authenticate: () => Promise<{ token: string; scopes: string[] }>;
+      },
+      "authenticate",
+    ).mockResolvedValue({ token: "good", scopes: [] });
+
+    const result = await conn.healthCheck();
+    expect(result.ok).toBe(true);
+  });
+
+  it("returns ok:false with auth_expired when API responds 401", async () => {
+    const fakeResponse = {
+      ok: false,
+      status: 401,
+      headers: { get: () => null },
+    };
+    Object.setPrototypeOf(fakeResponse, Response.prototype);
+    global.fetch = vi
+      .fn()
+      .mockResolvedValue(fakeResponse) as unknown as typeof fetch;
+
+    const { DiscordConnector } = await import("../discord.js");
+    const conn = new DiscordConnector();
+    vi.spyOn(
+      conn as unknown as {
+        authenticate: () => Promise<{ token: string; scopes: string[] }>;
+      },
+      "authenticate",
+    ).mockResolvedValue({ token: "bad", scopes: [] });
+
+    const result = await conn.healthCheck();
+    expect(result.ok).toBe(false);
+    expect(result.error?.code).toBe("auth_expired");
+  });
+});
+
+// ── listGuilds ───────────────────────────────────────────────────────────────
+
+describe("DiscordConnector.listGuilds", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("returns the guild array verbatim", async () => {
+    const guilds = [
+      { id: "g1", name: "Patchwork", icon: null, owner: true },
+      { id: "g2", name: "Other", icon: null, owner: false },
+    ];
+    global.fetch = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => guilds,
+      headers: { get: () => null },
+    }) as unknown as typeof fetch;
+
+    const { DiscordConnector } = await import("../discord.js");
+    const conn = new DiscordConnector();
+    vi.spyOn(
+      conn as unknown as {
+        authenticate: () => Promise<{ token: string; scopes: string[] }>;
+      },
+      "authenticate",
+    ).mockResolvedValue({ token: "k", scopes: [] });
+
+    const result = await conn.listGuilds();
+    expect(result).toEqual(guilds);
+  });
+
+  it("clamps limit to 200", async () => {
+    const fetchSpy = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => [],
+      headers: { get: () => null },
+    });
+    global.fetch = fetchSpy as unknown as typeof fetch;
+
+    const { DiscordConnector } = await import("../discord.js");
+    const conn = new DiscordConnector();
+    vi.spyOn(
+      conn as unknown as {
+        authenticate: () => Promise<{ token: string; scopes: string[] }>;
+      },
+      "authenticate",
+    ).mockResolvedValue({ token: "k", scopes: [] });
+
+    await conn.listGuilds({ limit: 999 });
+    const url = String(fetchSpy.mock.calls[0]?.[0] ?? "");
+    expect(url).toContain("limit=200");
+  });
+});
+
+// ── listChannels ─────────────────────────────────────────────────────────────
+
+describe("DiscordConnector.listChannels", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("filters out non-text channels (type !== 0)", async () => {
+    const apiResponse = [
+      { id: "c1", name: "general", type: 0, guild_id: "g1" }, // text — keep
+      { id: "c2", name: "Voice Lobby", type: 2, guild_id: "g1" }, // voice — drop
+      { id: "c3", name: "category", type: 4, guild_id: "g1" }, // category — drop
+      { id: "c4", name: "thread", type: 11, guild_id: "g1" }, // thread — drop
+      { id: "c5", name: "random", type: 0, guild_id: "g1" }, // text — keep
+    ];
+    global.fetch = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => apiResponse,
+      headers: { get: () => null },
+    }) as unknown as typeof fetch;
+
+    const { DiscordConnector } = await import("../discord.js");
+    const conn = new DiscordConnector();
+    vi.spyOn(
+      conn as unknown as {
+        authenticate: () => Promise<{ token: string; scopes: string[] }>;
+      },
+      "authenticate",
+    ).mockResolvedValue({ token: "k", scopes: [] });
+
+    const channels = await conn.listChannels("g1");
+    expect(channels.map((c) => c.id)).toEqual(["c1", "c5"]);
+    expect(channels.every((c) => c.type === 0)).toBe(true);
+  });
+});
+
+// ── listMessages ─────────────────────────────────────────────────────────────
+
+describe("DiscordConnector.listMessages", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("passes limit through to the URL and clamps to 100", async () => {
+    const fetchSpy = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => [
+        {
+          id: "m1",
+          channel_id: "c1",
+          content: "hi",
+          timestamp: "2026-04-29T00:00:00Z",
+          author: { id: "u1", username: "alice" },
+        },
+      ],
+      headers: { get: () => null },
+    });
+    global.fetch = fetchSpy as unknown as typeof fetch;
+
+    const { DiscordConnector } = await import("../discord.js");
+    const conn = new DiscordConnector();
+    vi.spyOn(
+      conn as unknown as {
+        authenticate: () => Promise<{ token: string; scopes: string[] }>;
+      },
+      "authenticate",
+    ).mockResolvedValue({ token: "k", scopes: [] });
+
+    const messages = await conn.listMessages("c1", { limit: 250 });
+    expect(messages).toHaveLength(1);
+    const url = String(fetchSpy.mock.calls[0]?.[0] ?? "");
+    expect(url).toContain("/channels/c1/messages");
+    expect(url).toContain("limit=100"); // clamped
+  });
+});
+
+// ── Token refresh on 401 ─────────────────────────────────────────────────────
+
+describe("DiscordConnector token refresh on 401", () => {
+  const tmpDir = join(os.tmpdir(), `patchwork-discord-refresh-${Date.now()}`);
+  const homeDir = join(tmpDir, "home");
+  const patchworkHome = join(homeDir, ".patchwork");
+  const tokensDir = join(patchworkHome, "tokens");
+
+  beforeEach(() => {
+    process.env.HOME = homeDir;
+    process.env.PATCHWORK_HOME = patchworkHome;
+    process.env.PATCHWORK_TOKEN_STORAGE_BACKEND = "file";
+    process.env.DISCORD_CLIENT_ID = "cid";
+    process.env.DISCORD_CLIENT_SECRET = "csecret";
+    mkdirSync(tokensDir, { recursive: true });
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    delete process.env.HOME;
+    delete process.env.PATCHWORK_HOME;
+    delete process.env.PATCHWORK_TOKEN_STORAGE_BACKEND;
+    delete process.env.DISCORD_CLIENT_ID;
+    delete process.env.DISCORD_CLIENT_SECRET;
+    if (existsSync(tmpDir)) {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("on 401, refreshes token and retries the API call once", async () => {
+    // Three fetch calls in sequence:
+    //   1) /users/@me → 401 (auth_expired, retryable per Discord normalizeError)
+    //   2) /oauth2/token (refresh) → 200 with new access_token
+    //   3) /users/@me retry → 200
+    const expired = {
+      ok: false,
+      status: 401,
+      headers: { get: () => null },
+    };
+    Object.setPrototypeOf(expired, Response.prototype);
+
+    const fetchSpy = vi
+      .fn()
+      // initial call: 401
+      .mockResolvedValueOnce(expired)
+      // refresh call: 200 with new tokens
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          access_token: "new-access",
+          refresh_token: "new-refresh",
+          expires_in: 604800,
+          scope: "identify guilds messages.read",
+          token_type: "Bearer",
+        }),
+        headers: { get: () => null },
+      })
+      // retry: 200
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ id: "u1", username: "patchwork" }),
+        headers: { get: () => null },
+      });
+
+    global.fetch = fetchSpy as unknown as typeof fetch;
+
+    const { DiscordConnector, saveTokens, loadTokens } = await import(
+      "../discord.js"
+    );
+    // Pre-seed stored tokens with a refresh_token so the connector has something
+    // to refresh with.
+    saveTokens({
+      access_token: "stale-access",
+      refresh_token: "stale-refresh",
+      expires_at: Date.now() + 60_000, // not yet expired by clock
+      scope: "identify guilds messages.read",
+      token_type: "Bearer",
+      _client_id: "cid",
+      _client_secret: "csecret",
+      connected_at: new Date().toISOString(),
+    });
+
+    const conn = new DiscordConnector();
+    // authenticate() will be called by apiCall on the first run since this.auth
+    // starts null; it reads from loadTokens() which we pre-seeded above.
+    const result = await conn.healthCheck();
+
+    expect(result.ok).toBe(true);
+    // Verify the three fetch calls happened in order.
+    expect(fetchSpy).toHaveBeenCalledTimes(3);
+    const url1 = String(fetchSpy.mock.calls[0]?.[0] ?? "");
+    const url2 = String(fetchSpy.mock.calls[1]?.[0] ?? "");
+    const url3 = String(fetchSpy.mock.calls[2]?.[0] ?? "");
+    expect(url1).toContain("/users/@me");
+    expect(url2).toContain("/oauth2/token");
+    expect(url3).toContain("/users/@me");
+
+    // Stored tokens should now reflect the refreshed access_token.
+    const stored = loadTokens();
+    expect(stored?.access_token).toBe("new-access");
+    expect(stored?.refresh_token).toBe("new-refresh");
+  });
+});
+
+// ── HTTP handlers ────────────────────────────────────────────────────────────
+
+describe("handleDiscordAuthorize", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    delete process.env.DISCORD_CLIENT_ID;
+    delete process.env.DISCORD_CLIENT_SECRET;
+  });
+
+  it("returns 503 when DISCORD_CLIENT_ID/SECRET are not set", async () => {
+    const { handleDiscordAuthorize } = await import("../discord.js");
+    const result = handleDiscordAuthorize();
+    expect(result.status).toBe(503);
+    const body = JSON.parse(result.body);
+    expect(body.ok).toBe(false);
+    expect(body.error).toMatch(/DISCORD_CLIENT_ID/);
+  });
+
+  it("returns 302 redirect with state when configured", async () => {
+    process.env.DISCORD_CLIENT_ID = "cid";
+    process.env.DISCORD_CLIENT_SECRET = "csecret";
+    const { handleDiscordAuthorize } = await import("../discord.js");
+    const result = handleDiscordAuthorize();
+    expect(result.status).toBe(302);
+    expect(result.redirect).toMatch(
+      /^https:\/\/discord\.com\/api\/oauth2\/authorize\?/,
+    );
+    const url = new URL(result.redirect ?? "");
+    expect(url.searchParams.get("client_id")).toBe("cid");
+    expect(url.searchParams.get("response_type")).toBe("code");
+    expect(url.searchParams.get("scope")).toBe("identify guilds messages.read");
+    expect(url.searchParams.get("state")).toBeTruthy();
+  });
+});
+
+describe("handleDiscordTest", () => {
+  it("returns 400 when not connected", async () => {
+    const tmpDir = join(os.tmpdir(), `patchwork-discord-test-${Date.now()}`);
+    process.env.HOME = join(tmpDir, "home");
+    process.env.PATCHWORK_HOME = join(tmpDir, "home", ".patchwork");
+    process.env.PATCHWORK_TOKEN_STORAGE_BACKEND = "file";
+    mkdirSync(join(process.env.PATCHWORK_HOME, "tokens"), { recursive: true });
+    vi.resetModules();
+    const { handleDiscordTest } = await import("../discord.js");
+    const result = await handleDiscordTest();
+    expect(result.status).toBe(400);
+    delete process.env.HOME;
+    delete process.env.PATCHWORK_HOME;
+    delete process.env.PATCHWORK_TOKEN_STORAGE_BACKEND;
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+});
+
+describe("handleDiscordDisconnect", () => {
+  it("returns 200 always", async () => {
+    const tmpDir = join(
+      os.tmpdir(),
+      `patchwork-discord-disconnect-${Date.now()}`,
+    );
+    process.env.HOME = join(tmpDir, "home");
+    process.env.PATCHWORK_HOME = join(tmpDir, "home", ".patchwork");
+    process.env.PATCHWORK_TOKEN_STORAGE_BACKEND = "file";
+    mkdirSync(join(process.env.PATCHWORK_HOME, "tokens"), { recursive: true });
+    vi.resetModules();
+    const { handleDiscordDisconnect } = await import("../discord.js");
+    const result = await handleDiscordDisconnect();
+    expect(result.status).toBe(200);
+    expect(JSON.parse(result.body).ok).toBe(true);
+    delete process.env.HOME;
+    delete process.env.PATCHWORK_HOME;
+    delete process.env.PATCHWORK_TOKEN_STORAGE_BACKEND;
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+});

--- a/src/connectors/discord.ts
+++ b/src/connectors/discord.ts
@@ -1,0 +1,628 @@
+/**
+ * Discord connector — read guilds, channels, messages.
+ *
+ * OAuth 2.0 Authorization Code Grant. Discord is a confidential client
+ * (bridge holds the client secret), so PKCE is not required. Refresh
+ * tokens are issued; access tokens expire (typically 7 days).
+ *
+ * Auth: standard OAuth 2.0 with `client_id` + `client_secret` + `redirect_uri`.
+ *   - Env vars: DISCORD_CLIENT_ID, DISCORD_CLIENT_SECRET (mirrors slack)
+ *   - Stored: getSecretJsonSync("discord") → DiscordTokens
+ *   - Header: Authorization: Bearer <access_token>
+ *
+ * Tools (read-only this PR): getCurrentUser, listGuilds, listChannels,
+ *   listMessages. Write methods (sendMessage) deferred to a follow-up PR.
+ *
+ * HTTP routes (wired in src/server.ts):
+ *   GET    /connections/discord/auth     — redirect to Discord consent
+ *   GET    /connections/discord/callback — exchange code for tokens
+ *   POST   /connections/discord/test     — ping Discord API
+ *   DELETE /connections/discord          — clear stored tokens
+ *
+ * Extends BaseConnector for unified auth, retry, rate-limit, error handling.
+ * Token refresh is delegated to BaseConnector.refreshToken() via apiCall.
+ */
+
+import crypto from "node:crypto";
+import {
+  type AuthContext,
+  BaseConnector,
+  type ConnectorError,
+  type ConnectorStatus,
+  type OAuthConfig,
+} from "./baseConnector.js";
+import { escHtml } from "./htmlEscape.js";
+import {
+  deleteSecretJsonSync,
+  getSecretJsonSync,
+  storeSecretJsonSync,
+} from "./tokenStorage.js";
+
+const DISCORD_API_BASE = "https://discord.com/api/v10";
+const DISCORD_AUTH_URL = "https://discord.com/api/oauth2/authorize";
+const DISCORD_TOKEN_URL = "https://discord.com/api/oauth2/token";
+const DISCORD_REVOKE_URL = "https://discord.com/api/oauth2/token/revoke";
+const SCOPES = ["identify", "guilds", "messages.read"];
+
+export interface DiscordTokens {
+  access_token: string;
+  refresh_token?: string;
+  /** ms since epoch; absolute, not relative */
+  expires_at?: number;
+  scope?: string;
+  token_type?: string;
+  /** stored at auth time so refresh works even if env vars are absent */
+  _client_id?: string;
+  _client_secret?: string;
+  username?: string;
+  user_id?: string;
+  connected_at: string;
+}
+
+export interface DiscordUser {
+  id: string;
+  username: string;
+  discriminator?: string;
+  global_name?: string | null;
+  avatar?: string | null;
+}
+
+export interface DiscordGuild {
+  id: string;
+  name: string;
+  icon?: string | null;
+  owner?: boolean;
+  permissions?: string;
+}
+
+export interface DiscordChannel {
+  id: string;
+  type: number;
+  name?: string;
+  guild_id?: string;
+  topic?: string | null;
+  position?: number;
+}
+
+export interface DiscordMessage {
+  id: string;
+  channel_id: string;
+  content: string;
+  timestamp: string;
+  author: {
+    id: string;
+    username: string;
+    global_name?: string | null;
+  };
+}
+
+// ── Config ───────────────────────────────────────────────────────────────────
+
+function clientId(): string {
+  return process.env.DISCORD_CLIENT_ID ?? "";
+}
+
+function clientSecret(): string {
+  return process.env.DISCORD_CLIENT_SECRET ?? "";
+}
+
+function redirectUri(): string {
+  const base = (
+    process.env.PATCHWORK_BRIDGE_URL ??
+    `http://localhost:${process.env.PATCHWORK_BRIDGE_PORT ?? "3101"}`
+  ).replace(/\/$/, "");
+  return `${base}/connections/discord/callback`;
+}
+
+function isConfigured(): boolean {
+  return Boolean(clientId() && clientSecret());
+}
+
+// ── Token persistence ────────────────────────────────────────────────────────
+
+export function loadTokens(): DiscordTokens | null {
+  return getSecretJsonSync<DiscordTokens>("discord");
+}
+
+export function saveTokens(tokens: DiscordTokens): void {
+  storeSecretJsonSync("discord", tokens);
+}
+
+export function clearTokens(): void {
+  try {
+    deleteSecretJsonSync("discord");
+  } catch {
+    // ignore
+  }
+}
+
+export function isConnected(): boolean {
+  return loadTokens() !== null;
+}
+
+// ── State (CSRF) ─────────────────────────────────────────────────────────────
+// In-memory map keyed by hex random — short-lived (5 min). Mirrors gmail's
+// approach (Set + setTimeout) rather than slack's on-disk file because we
+// don't need cross-process resumption for an OAuth round-trip.
+
+const pendingStates = new Set<string>();
+const STATE_TTL_MS = 5 * 60 * 1000;
+
+function generateState(): string {
+  const state = crypto.randomBytes(32).toString("hex");
+  pendingStates.add(state);
+  setTimeout(() => pendingStates.delete(state), STATE_TTL_MS);
+  return state;
+}
+
+function consumeState(state: string): boolean {
+  if (!pendingStates.has(state)) return false;
+  pendingStates.delete(state);
+  return true;
+}
+
+// ── Connector class ──────────────────────────────────────────────────────────
+
+export class DiscordConnector extends BaseConnector {
+  readonly providerName = "discord";
+
+  protected getOAuthConfig(): OAuthConfig | null {
+    // Resolve credentials from env first, then fall back to credentials we
+    // stored at auth time (so refresh keeps working even if env is unset).
+    const tokens = loadTokens();
+    const id = clientId() || tokens?._client_id || "";
+    const secret = clientSecret() || tokens?._client_secret || "";
+    if (!id || !secret) return null;
+    return {
+      clientId: id,
+      clientSecret: secret,
+      tokenEndpoint: DISCORD_TOKEN_URL,
+      scopes: SCOPES,
+    };
+  }
+
+  async authenticate(): Promise<AuthContext> {
+    const tokens = loadTokens();
+    if (!tokens) {
+      throw new Error(
+        "Discord not connected. Visit /connections/discord/auth to authorize.",
+      );
+    }
+    return {
+      token: tokens.access_token,
+      refreshToken: tokens.refresh_token,
+      expiresAt: tokens.expires_at ? new Date(tokens.expires_at) : undefined,
+      scopes: tokens.scope ? tokens.scope.split(" ") : SCOPES,
+    };
+  }
+
+  /**
+   * Persist refreshed tokens after BaseConnector.refreshToken() updates
+   * `this.auth`. BaseConnector calls `saveTokens()` (its own method on the
+   * tokenStorage StoredToken shape); we additionally mirror to our
+   * Discord-specific JSON so loadTokens() keeps working for HTTP probes.
+   */
+  override async saveTokens(): Promise<void> {
+    await super.saveTokens();
+    if (!this.auth) return;
+    const existing = loadTokens();
+    saveTokens({
+      access_token: this.auth.token,
+      refresh_token: this.auth.refreshToken,
+      expires_at: this.auth.expiresAt
+        ? this.auth.expiresAt.getTime()
+        : undefined,
+      scope: this.auth.scopes?.join(" "),
+      token_type: existing?.token_type ?? "Bearer",
+      _client_id: existing?._client_id,
+      _client_secret: existing?._client_secret,
+      username: existing?.username,
+      user_id: existing?.user_id,
+      connected_at: existing?.connected_at ?? new Date().toISOString(),
+    });
+  }
+
+  async healthCheck(): Promise<{ ok: boolean; error?: ConnectorError }> {
+    try {
+      const result = await this.apiCall(async (token) => {
+        const res = await fetch(`${DISCORD_API_BASE}/users/@me`, {
+          headers: this.buildHeaders(token),
+        });
+        if (!res.ok) throw res;
+        return res.json();
+      });
+      if ("error" in result) return { ok: false, error: result.error };
+      return { ok: true };
+    } catch (err) {
+      return { ok: false, error: this.normalizeError(err) };
+    }
+  }
+
+  normalizeError(error: unknown): ConnectorError {
+    if (error instanceof Response) {
+      const s = error.status;
+      if (s === 401)
+        return {
+          code: "auth_expired",
+          message: "Discord authentication failed — token expired or revoked",
+          retryable: true,
+          suggestedAction: "Reconnect via /connections/discord/auth",
+        };
+      if (s === 403)
+        return {
+          code: "permission_denied",
+          message: "Insufficient Discord permissions for this resource",
+          retryable: false,
+        };
+      if (s === 404)
+        return {
+          code: "not_found",
+          message: "Discord resource not found",
+          retryable: false,
+        };
+      if (s === 429)
+        return {
+          code: "rate_limited",
+          message: "Discord API rate limit exceeded",
+          retryable: true,
+          suggestedAction: "Wait and retry",
+        };
+      return {
+        code: "provider_error",
+        message: `Discord API error: HTTP ${s}`,
+        retryable: s >= 500,
+      };
+    }
+    if (error instanceof Error) {
+      if (
+        error.message.includes("ENOTFOUND") ||
+        error.message.includes("ECONNREFUSED")
+      ) {
+        return {
+          code: "network_error",
+          message: `Cannot connect to Discord: ${error.message}`,
+          retryable: true,
+        };
+      }
+    }
+    return {
+      code: "provider_error",
+      message: error instanceof Error ? error.message : String(error),
+      retryable: false,
+    };
+  }
+
+  getStatus(): ConnectorStatus {
+    const tokens = loadTokens();
+    return {
+      id: "discord",
+      status: tokens ? "connected" : "disconnected",
+      lastSync: tokens?.connected_at,
+      workspace: tokens?.username,
+    };
+  }
+
+  // ── API Methods ────────────────────────────────────────────────────────────
+
+  async getCurrentUser(): Promise<DiscordUser> {
+    const result = await this.apiCall(async (token) => {
+      const res = await fetch(`${DISCORD_API_BASE}/users/@me`, {
+        headers: this.buildHeaders(token),
+      });
+      this.captureRateLimit(res);
+      if (!res.ok) throw res;
+      return res.json() as Promise<DiscordUser>;
+    });
+
+    if ("error" in result) throw new Error(result.error.message);
+    return result.data as DiscordUser;
+  }
+
+  async listGuilds(params: { limit?: number } = {}): Promise<DiscordGuild[]> {
+    const result = await this.apiCall(async (token) => {
+      const qs = new URLSearchParams({
+        limit: String(Math.min(params.limit ?? 100, 200)),
+      });
+      const res = await fetch(`${DISCORD_API_BASE}/users/@me/guilds?${qs}`, {
+        headers: this.buildHeaders(token),
+      });
+      this.captureRateLimit(res);
+      if (!res.ok) throw res;
+      return res.json() as Promise<DiscordGuild[]>;
+    });
+
+    if ("error" in result) throw new Error(result.error.message);
+    return result.data as DiscordGuild[];
+  }
+
+  async listChannels(guildId: string): Promise<DiscordChannel[]> {
+    const result = await this.apiCall(async (token) => {
+      const res = await fetch(
+        `${DISCORD_API_BASE}/guilds/${encodeURIComponent(guildId)}/channels`,
+        { headers: this.buildHeaders(token) },
+      );
+      this.captureRateLimit(res);
+      if (!res.ok) throw res;
+      return res.json() as Promise<DiscordChannel[]>;
+    });
+
+    if ("error" in result) throw new Error(result.error.message);
+    // Filter to text channels only (type 0). Voice/category/thread channels
+    // are excluded — recipe consumers only care about messageable text rooms.
+    return (result.data as DiscordChannel[]).filter((c) => c.type === 0);
+  }
+
+  async listMessages(
+    channelId: string,
+    params: { limit?: number } = {},
+  ): Promise<DiscordMessage[]> {
+    const result = await this.apiCall(async (token) => {
+      const qs = new URLSearchParams({
+        limit: String(Math.min(params.limit ?? 50, 100)),
+      });
+      const res = await fetch(
+        `${DISCORD_API_BASE}/channels/${encodeURIComponent(channelId)}/messages?${qs}`,
+        { headers: this.buildHeaders(token) },
+      );
+      this.captureRateLimit(res);
+      if (!res.ok) throw res;
+      return res.json() as Promise<DiscordMessage[]>;
+    });
+
+    if ("error" in result) throw new Error(result.error.message);
+    return result.data as DiscordMessage[];
+  }
+
+  // ── Helpers ────────────────────────────────────────────────────────────────
+
+  private buildHeaders(token: string): Record<string, string> {
+    return {
+      Authorization: `Bearer ${token}`,
+      Accept: "application/json",
+      "Content-Type": "application/json",
+    };
+  }
+
+  private captureRateLimit(res: Response): void {
+    this.updateRateLimitFromHeaders({
+      "x-ratelimit-remaining":
+        res.headers.get("x-ratelimit-remaining") ?? undefined,
+      "x-ratelimit-reset": res.headers.get("x-ratelimit-reset") ?? undefined,
+      "retry-after": res.headers.get("retry-after") ?? undefined,
+    });
+  }
+}
+
+// ── Singleton ────────────────────────────────────────────────────────────────
+
+let _instance: DiscordConnector | null = null;
+
+function resetDiscordConnector(): void {
+  _instance = null;
+}
+
+export function getDiscordConnector(): DiscordConnector {
+  if (!_instance) {
+    _instance = new DiscordConnector();
+  }
+  return _instance;
+}
+
+export { getDiscordConnector as discord };
+
+// ── HTTP Handlers ────────────────────────────────────────────────────────────
+
+export interface ConnectorHandlerResult {
+  status: number;
+  body: string;
+  contentType?: string;
+  redirect?: string;
+}
+
+/**
+ * GET /connections/discord/auth — redirect to Discord consent screen.
+ */
+export function handleDiscordAuthorize(): ConnectorHandlerResult {
+  if (!isConfigured()) {
+    return {
+      status: 503,
+      contentType: "application/json",
+      body: JSON.stringify({
+        ok: false,
+        error:
+          "Discord connector not configured. Set DISCORD_CLIENT_ID and DISCORD_CLIENT_SECRET.",
+      }),
+    };
+  }
+  const state = generateState();
+  const params = new URLSearchParams({
+    client_id: clientId(),
+    redirect_uri: redirectUri(),
+    response_type: "code",
+    scope: SCOPES.join(" "),
+    state,
+  });
+  return {
+    status: 302,
+    body: "",
+    redirect: `${DISCORD_AUTH_URL}?${params.toString()}`,
+  };
+}
+
+/**
+ * GET /connections/discord/callback — exchange code for tokens.
+ */
+export async function handleDiscordCallback(
+  code: string | null,
+  state: string | null,
+  error: string | null,
+): Promise<ConnectorHandlerResult> {
+  if (error) {
+    return {
+      status: 400,
+      contentType: "text/html",
+      body: `<html><body><h2>Discord connect failed</h2><pre>${escHtml(error)}</pre></body></html>`,
+    };
+  }
+  if (!code || !state) {
+    return {
+      status: 400,
+      contentType: "text/html",
+      body: `<html><body><h2>Discord connect failed</h2><pre>missing code or state</pre></body></html>`,
+    };
+  }
+  if (!consumeState(state)) {
+    return {
+      status: 400,
+      contentType: "text/html",
+      body: `<html><body><h2>Discord connect failed</h2><pre>invalid or expired state</pre></body></html>`,
+    };
+  }
+
+  try {
+    const params = new URLSearchParams({
+      grant_type: "authorization_code",
+      code,
+      redirect_uri: redirectUri(),
+      client_id: clientId(),
+      client_secret: clientSecret(),
+    });
+    const res = await fetch(DISCORD_TOKEN_URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        Accept: "application/json",
+      },
+      body: params.toString(),
+    });
+    if (!res.ok) {
+      const body = await res.text();
+      throw new Error(`Token exchange HTTP ${res.status}: ${body}`);
+    }
+    const json = (await res.json()) as {
+      access_token?: string;
+      refresh_token?: string;
+      expires_in?: number;
+      scope?: string;
+      token_type?: string;
+    };
+    if (!json.access_token) {
+      throw new Error("Token exchange returned no access_token");
+    }
+
+    // Fetch user info so we can show "connected as <username>" on the dash.
+    let username: string | undefined;
+    let userId: string | undefined;
+    try {
+      const userRes = await fetch(`${DISCORD_API_BASE}/users/@me`, {
+        headers: { Authorization: `Bearer ${json.access_token}` },
+      });
+      if (userRes.ok) {
+        const u = (await userRes.json()) as DiscordUser;
+        username = u.global_name ?? u.username;
+        userId = u.id;
+      }
+    } catch {
+      // best-effort — don't fail connect just because /users/@me hiccuped
+    }
+
+    const expiresAt =
+      typeof json.expires_in === "number" && json.expires_in > 0
+        ? Date.now() + json.expires_in * 1000
+        : undefined;
+
+    saveTokens({
+      access_token: json.access_token,
+      refresh_token: json.refresh_token,
+      expires_at: expiresAt,
+      scope: json.scope,
+      token_type: json.token_type ?? "Bearer",
+      _client_id: clientId() || undefined,
+      _client_secret: clientSecret() || undefined,
+      username,
+      user_id: userId,
+      connected_at: new Date().toISOString(),
+    });
+    resetDiscordConnector();
+
+    return {
+      status: 200,
+      contentType: "text/html",
+      body: `<html><body><h2>Discord connected${username ? ` as ${escHtml(username)}` : ""}</h2><script>try { window.opener.postMessage('patchwork:discord:connected', '*'); } catch(_) {} window.close();</script></body></html>`,
+    };
+  } catch (err) {
+    return {
+      status: 400,
+      contentType: "text/html",
+      body: `<html><body><h2>Discord connect failed</h2><pre>${escHtml(err instanceof Error ? err.message : String(err))}</pre></body></html>`,
+    };
+  }
+}
+
+/**
+ * POST /connections/discord/test — verify stored token works.
+ */
+export async function handleDiscordTest(): Promise<ConnectorHandlerResult> {
+  const tokens = loadTokens();
+  if (!tokens) {
+    return {
+      status: 400,
+      contentType: "application/json",
+      body: JSON.stringify({ ok: false, error: "Discord not connected" }),
+    };
+  }
+  try {
+    const connector = getDiscordConnector();
+    const check = await connector.healthCheck();
+    return {
+      status: check.ok ? 200 : 401,
+      contentType: "application/json",
+      body: JSON.stringify(
+        check.ok
+          ? { ok: true, username: tokens.username }
+          : { ok: false, error: check.error?.message },
+      ),
+    };
+  } catch (err) {
+    return {
+      status: 500,
+      contentType: "application/json",
+      body: JSON.stringify({
+        ok: false,
+        error: err instanceof Error ? err.message : String(err),
+      }),
+    };
+  }
+}
+
+/**
+ * DELETE /connections/discord — clear stored tokens (and revoke at Discord).
+ */
+export async function handleDiscordDisconnect(): Promise<ConnectorHandlerResult> {
+  const tokens = loadTokens();
+  // Best-effort revoke at Discord. Slack doesn't do this but Discord exposes
+  // a standard RFC 7009 revocation endpoint, and the spec allowlist permits
+  // it. Failure to revoke must NOT block the local disconnect.
+  if (tokens?.access_token && isConfigured()) {
+    try {
+      await fetch(DISCORD_REVOKE_URL, {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({
+          token: tokens.access_token,
+          client_id: clientId(),
+          client_secret: clientSecret(),
+        }).toString(),
+      });
+    } catch {
+      // ignore — still drop local tokens
+    }
+  }
+  clearTokens();
+  resetDiscordConnector();
+  return {
+    status: 200,
+    contentType: "application/json",
+    body: JSON.stringify({ ok: true }),
+  };
+}

--- a/src/connectors/gmail.ts
+++ b/src/connectors/gmail.ts
@@ -274,6 +274,7 @@ export async function handleConnectionsList(): Promise<ConnectorHandlerResult> {
     { id: "notion", mod: () => import("./notion.js") },
     { id: "confluence", mod: () => import("./confluence.js") },
     { id: "datadog", mod: () => import("./datadog.js") },
+    { id: "discord", mod: () => import("./discord.js") },
     { id: "hubspot", mod: () => import("./hubspot.js") },
     { id: "intercom", mod: () => import("./intercom.js") },
     { id: "pagerduty", mod: () => import("./pagerduty.js") },

--- a/src/recipes/tools/discord.ts
+++ b/src/recipes/tools/discord.ts
@@ -1,0 +1,196 @@
+/**
+ * Discord tools — read-only wrappers for guilds, channels, messages, user.
+ *
+ * Self-registering tool module for the recipe tool registry. Read-only this PR;
+ * write methods (sendMessage) are deferred.
+ *
+ * Each tool wraps connector throws into the `{count, items, error}` shape that
+ * the runner's silent-fail detector (PR #75) catches as a step error rather
+ * than a silent empty list.
+ */
+
+import { CommonSchemas, registerTool } from "../toolRegistry.js";
+
+// ============================================================================
+// discord.get_current_user
+// ============================================================================
+
+registerTool({
+  id: "discord.get_current_user",
+  namespace: "discord",
+  description:
+    "Fetch the authenticated Discord user (username, id, discriminator).",
+  paramsSchema: {
+    type: "object",
+    properties: {
+      into: CommonSchemas.into,
+    },
+  },
+  outputSchema: {
+    type: "object",
+    properties: {
+      count: { type: "number" },
+      items: { type: "array", items: { type: "object" } },
+      error: { type: "string" },
+    },
+  },
+  riskDefault: "low",
+  isWrite: false,
+  isConnector: true,
+  execute: async () => {
+    const { getDiscordConnector } = await import("../../connectors/discord.js");
+    try {
+      const connector = getDiscordConnector();
+      const user = await connector.getCurrentUser();
+      return JSON.stringify({ count: 1, items: [user] });
+    } catch (err) {
+      return JSON.stringify({
+        count: 0,
+        items: [],
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  },
+});
+
+// ============================================================================
+// discord.list_guilds
+// ============================================================================
+
+registerTool({
+  id: "discord.list_guilds",
+  namespace: "discord",
+  description:
+    "List Discord guilds (servers) the authenticated user belongs to.",
+  paramsSchema: {
+    type: "object",
+    properties: {
+      max: CommonSchemas.max,
+      into: CommonSchemas.into,
+    },
+  },
+  outputSchema: {
+    type: "object",
+    properties: {
+      count: { type: "number" },
+      items: { type: "array", items: { type: "object" } },
+      error: { type: "string" },
+    },
+  },
+  riskDefault: "low",
+  isWrite: false,
+  isConnector: true,
+  execute: async ({ params }) => {
+    const { getDiscordConnector } = await import("../../connectors/discord.js");
+    const limit = typeof params.max === "number" ? params.max : 100;
+    try {
+      const connector = getDiscordConnector();
+      const guilds = await connector.listGuilds({ limit });
+      return JSON.stringify({ count: guilds.length, items: guilds });
+    } catch (err) {
+      return JSON.stringify({
+        count: 0,
+        items: [],
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  },
+});
+
+// ============================================================================
+// discord.list_channels
+// ============================================================================
+
+registerTool({
+  id: "discord.list_channels",
+  namespace: "discord",
+  description:
+    "List text channels in a Discord guild (filters out voice / category / threads).",
+  paramsSchema: {
+    type: "object",
+    properties: {
+      guildId: {
+        type: "string",
+        description: "Discord guild (server) id",
+      },
+      into: CommonSchemas.into,
+    },
+    required: ["guildId"],
+  },
+  outputSchema: {
+    type: "object",
+    properties: {
+      count: { type: "number" },
+      items: { type: "array", items: { type: "object" } },
+      error: { type: "string" },
+    },
+  },
+  riskDefault: "low",
+  isWrite: false,
+  isConnector: true,
+  execute: async ({ params }) => {
+    const { getDiscordConnector } = await import("../../connectors/discord.js");
+    try {
+      const connector = getDiscordConnector();
+      const channels = await connector.listChannels(params.guildId as string);
+      return JSON.stringify({ count: channels.length, items: channels });
+    } catch (err) {
+      return JSON.stringify({
+        count: 0,
+        items: [],
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  },
+});
+
+// ============================================================================
+// discord.list_messages
+// ============================================================================
+
+registerTool({
+  id: "discord.list_messages",
+  namespace: "discord",
+  description: "List recent messages in a Discord channel (newest first).",
+  paramsSchema: {
+    type: "object",
+    properties: {
+      channelId: {
+        type: "string",
+        description: "Discord channel id",
+      },
+      max: CommonSchemas.max,
+      into: CommonSchemas.into,
+    },
+    required: ["channelId"],
+  },
+  outputSchema: {
+    type: "object",
+    properties: {
+      count: { type: "number" },
+      items: { type: "array", items: { type: "object" } },
+      error: { type: "string" },
+    },
+  },
+  riskDefault: "low",
+  isWrite: false,
+  isConnector: true,
+  execute: async ({ params }) => {
+    const { getDiscordConnector } = await import("../../connectors/discord.js");
+    const limit = typeof params.max === "number" ? params.max : 50;
+    try {
+      const connector = getDiscordConnector();
+      const messages = await connector.listMessages(
+        params.channelId as string,
+        { limit },
+      );
+      return JSON.stringify({ count: messages.length, items: messages });
+    } catch (err) {
+      return JSON.stringify({
+        count: 0,
+        items: [],
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  },
+});

--- a/src/recipes/tools/index.ts
+++ b/src/recipes/tools/index.ts
@@ -22,6 +22,7 @@ import "./zendesk.js";
 import "./intercom.js";
 import "./hubspot.js";
 import "./datadog.js";
+import "./discord.js";
 import "./pagerduty.js";
 import "./stripe.js";
 import "./meetingNotes.js";

--- a/src/server.ts
+++ b/src/server.ts
@@ -1428,6 +1428,77 @@ export class Server extends EventEmitter<ServerEvents> {
         return;
       }
 
+      // ── Discord connector routes ───────────────────────────────────
+      if (
+        (parsedUrl.pathname === "/connections/discord/auth" ||
+          parsedUrl.pathname === "/connections/discord/authorize") &&
+        req.method === "GET"
+      ) {
+        const { handleDiscordAuthorize } = await import(
+          "./connectors/discord.js"
+        );
+        const result = handleDiscordAuthorize();
+        if (result.redirect) {
+          res.writeHead(302, { Location: result.redirect });
+          res.end();
+        } else {
+          res.writeHead(result.status, {
+            "Content-Type": result.contentType ?? "application/json",
+          });
+          res.end(result.body);
+        }
+        return;
+      }
+      if (
+        parsedUrl.pathname === "/connections/discord/callback" &&
+        req.method === "GET"
+      ) {
+        void (async () => {
+          const { handleDiscordCallback } = await import(
+            "./connectors/discord.js"
+          );
+          const code = parsedUrl.searchParams.get("code");
+          const state = parsedUrl.searchParams.get("state");
+          const error = parsedUrl.searchParams.get("error");
+          const result = await handleDiscordCallback(code, state, error);
+          res.writeHead(result.status, {
+            "Content-Type": result.contentType ?? "text/html",
+          });
+          res.end(result.body);
+        })();
+        return;
+      }
+      if (
+        parsedUrl.pathname === "/connections/discord/test" &&
+        req.method === "POST"
+      ) {
+        void (async () => {
+          const { handleDiscordTest } = await import("./connectors/discord.js");
+          const result = await handleDiscordTest();
+          res.writeHead(result.status, {
+            "Content-Type": result.contentType ?? "application/json",
+          });
+          res.end(result.body);
+        })();
+        return;
+      }
+      if (
+        parsedUrl.pathname === "/connections/discord" &&
+        req.method === "DELETE"
+      ) {
+        void (async () => {
+          const { handleDiscordDisconnect } = await import(
+            "./connectors/discord.js"
+          );
+          const result = await handleDiscordDisconnect();
+          res.writeHead(result.status, {
+            "Content-Type": result.contentType ?? "application/json",
+          });
+          res.end(result.body);
+        })();
+        return;
+      }
+
       // ── Notion routes ──────────────────────────────────────────────
       if (
         parsedUrl.pathname === "/connections/notion/connect" &&


### PR DESCRIPTION
## Summary

Adds a Discord connector via OAuth 2.0 Authorization Code Grant (confidential client — bridge holds the secret, no PKCE). Read-only this PR; write methods (`sendMessage`) deferred to a follow-up.

- **Connector** (`src/connectors/discord.ts`) extends `BaseConnector` — `getCurrentUser`, `listGuilds`, `listChannels` (filters to text channels, `type === 0`), `listMessages`. `normalizeError` maps 401 → `auth_expired`, 404 → `not_found`, 429 → `rate_limited`. Token refresh delegated to `BaseConnector.refreshToken()` via `apiCall`; refreshed tokens are persisted back to the discord secret JSON via an `override saveTokens()` so HTTP probes (`/connections`) keep reflecting the right state.
- **OAuth flow** — `/connections/discord/auth` redirects to Discord consent with 32-byte hex `state` (5-min in-memory TTL); `/connections/discord/callback` exchanges code via standard `application/x-www-form-urlencoded` POST and persists `accessToken`/`refreshToken`/`expiresAt`/`scopes`. Disconnect best-efforts the RFC 7009 revoke endpoint before clearing local tokens.
- **Recipe tools** (`src/recipes/tools/discord.ts`) — `discord.list_guilds`, `discord.list_channels`, `discord.list_messages`, `discord.get_current_user`. All `riskDefault: "low"`, `isWrite: false`, `isConnector: true`. Returns `{count, items, error}` shape (silent-fail-detector friendly).
- **Server routes** (`src/server.ts`) — auth / callback / test / disconnect wired alongside the existing Slack block. Discord added to gmail's `tokenPasteProbes` list so `/connections` reports its actual state.
- **Dashboard** — Discord entry in `CATALOG` (Wave 1, Comms, next to Slack), `SUPPORTED_CONNECTORS`, `PROVIDERS` modal list, `IconDiscord` SVG glyph, simpleicons CDN logo URL, callback page + API route mirroring slack's exact shape.

## Tests

`npx vitest run src/connectors/__tests__/discord.test.ts` — 15 / 15 pass.

- Token storage: round-trip, `loadTokens`/`saveTokens`/`clearTokens`/`isConnected`
- `healthCheck`: 200 → ok; 401 → `auth_expired`
- `listGuilds`: returns array verbatim; clamps `limit` to 200
- `listChannels`: drops voice/category/thread channels (only `type === 0` survives)
- `listMessages`: clamps `limit` to 100, URL contains channel id
- Token refresh on 401: 3-call sequence (api 401 → refresh endpoint → api retry 200) and stored tokens reflect refreshed `access_token`/`refresh_token`
- HTTP handlers: `handleDiscordAuthorize` 503 when env missing / 302 with state when configured; `handleDiscordTest` 400 when not connected; `handleDiscordDisconnect` 200 always

Full vitest suite (318 files, 4357 tests) green. Bridge `npm run build` and dashboard `npx tsc --noEmit` both clean. `scripts/audit-lsp-tools.mjs` passes with no allowlist additions.

## Deferred

- `sendMessage` (write) — needs separate PR with `assertWriteAllowed` gating like `slack.post_message`.
- Pagination cursors (`before`/`after` for `listMessages`, `after` for `listGuilds`).

## Test plan

- [x] `npm run build`
- [x] `npx tsc --noEmit` in dashboard
- [x] `npx vitest run src/connectors/__tests__/discord.test.ts`
- [x] full vitest suite
- [ ] Manual: set `DISCORD_CLIENT_ID` / `DISCORD_CLIENT_SECRET`, hit `/connections/discord/auth`, complete consent, verify `/connections/discord/test` returns `{ok: true}` and a recipe step `discord.list_guilds` returns guilds.