### PR TITLE
feat(connectors): add Asana (read-only OAuth)

### DIFF
--- a/dashboard/src/app/api/connections/asana/callback/route.ts
+++ b/dashboard/src/app/api/connections/asana/callback/route.ts
@@ -1,0 +1,21 @@
+import { bridgeFetch } from "@/lib/bridge";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function GET(req: Request): Promise<Response> {
+  const url = new URL(req.url);
+  const allowed = ["code", "state", "error"];
+  const qs = new URLSearchParams();
+  for (const key of allowed) {
+    const v = url.searchParams.get(key);
+    if (v !== null) qs.set(key, v);
+  }
+
+  const res = await bridgeFetch(`/connections/asana/callback?${qs.toString()}`);
+  const body = await res.text();
+  return new Response(body, {
+    status: res.status,
+    headers: { "content-type": res.headers.get("content-type") ?? "application/json" },
+  });
+}

--- a/dashboard/src/app/connections/asana/callback/page.tsx
+++ b/dashboard/src/app/connections/asana/callback/page.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { Suspense, useEffect, useRef } from "react";
+import { apiPath } from '@/lib/api';
+import { useRouter, useSearchParams } from "next/navigation";
+
+function AsanaCallbackInner() {
+  const params = useSearchParams();
+  const router = useRouter();
+  const called = useRef(false);
+
+  useEffect(() => {
+    if (called.current) return;
+    called.current = true;
+
+    const code = params.get("code");
+    const state = params.get("state");
+    const error = params.get("error");
+
+    const qs = new URLSearchParams();
+    if (code) qs.set("code", code);
+    if (state) qs.set("state", state);
+    if (error) qs.set("error", error);
+
+    fetch(apiPath(`/api/connections/asana/callback?${qs.toString()}`))
+      .then((r) => r.json())
+      .then(() => {
+        if (window.opener) {
+          window.opener.postMessage("patchwork:asana:connected", window.location.origin);
+          window.close();
+        } else {
+          router.push("/connections");
+        }
+      })
+      .catch(() => router.push("/connections"));
+  }, [params, router]);
+
+  return <p>Connecting Asana…</p>;
+}
+
+export default function AsanaCallbackPage() {
+  return (
+    <div style={{
+      display: "flex", alignItems: "center", justifyContent: "center",
+      minHeight: "100vh", background: "#040406", color: "#e0e0e0",
+      fontFamily: "system-ui, sans-serif",
+    }}>
+      <Suspense fallback={<p>Loading…</p>}>
+        <AsanaCallbackInner />
+      </Suspense>
+    </div>
+  );
+}

--- a/dashboard/src/app/connections/page.tsx
+++ b/dashboard/src/app/connections/page.tsx
@@ -127,6 +127,17 @@ function IconNotion() {
   );
 }
 
+function IconAsana() {
+  // Asana brand mark — three dots arranged in a triangle (top, bottom-left, bottom-right).
+  return (
+    <svg width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden="true" style={{ flexShrink: 0 }}>
+      <circle cx="10" cy="6" r="2.5" fill="currentColor" />
+      <circle cx="5.5" cy="13" r="2.5" fill="currentColor" />
+      <circle cx="14.5" cy="13" r="2.5" fill="currentColor" />
+    </svg>
+  );
+}
+
 function IconConfluence() {
   return (
     <svg width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden="true" style={{ flexShrink: 0 }}>
@@ -229,6 +240,7 @@ interface TokenModalConfig {
 // Connectors that have a backend wired in the bridge — anything not listed
 // here renders as "Coming Soon" in the catalog regardless of wave.
 const SUPPORTED_CONNECTORS = new Set([
+  "asana",
   "gmail",
   "google-calendar",
   "google-drive",
@@ -384,6 +396,7 @@ const PROVIDERS: {
   { id: "linear",          name: "Linear",          description: "Read and manage issues.",                                                                          icon: IconLinear },
   { id: "slack",           name: "Slack",           description: "Post messages and list channels.",                                                                  icon: IconSlack },
   { id: "discord",         name: "Discord",         description: "Read messages, channels, and guilds.",                                                              icon: IconDiscord },
+  { id: "asana",           name: "Asana",           description: "Read workspaces, projects, and tasks.",                                                              icon: IconAsana },
   { id: "notion",          name: "Notion",          description: "Query databases, read pages, and create content.",                                                  icon: IconNotion },
   { id: "confluence",      name: "Confluence",      description: "Read and write Confluence pages and spaces.",                                                       icon: IconConfluence },
   { id: "datadog",         name: "Datadog",         description: "Query monitors, dashboards, and events.",                                                          icon: IconDatadog },

--- a/src/connectors/__tests__/asana.test.ts
+++ b/src/connectors/__tests__/asana.test.ts
@@ -1,0 +1,550 @@
+import { existsSync, mkdirSync, rmSync } from "node:fs";
+import os from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ── Token storage ────────────────────────────────────────────────────────────
+
+describe("asana token storage", () => {
+  const tmpDir = join(os.tmpdir(), `patchwork-asana-${Date.now()}`);
+  const homeDir = join(tmpDir, "home");
+  const patchworkHome = join(homeDir, ".patchwork");
+  const tokensDir = join(patchworkHome, "tokens");
+
+  beforeEach(() => {
+    process.env.HOME = homeDir;
+    process.env.PATCHWORK_HOME = patchworkHome;
+    process.env.PATCHWORK_TOKEN_STORAGE_BACKEND = "file";
+    mkdirSync(tokensDir, { recursive: true });
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    delete process.env.HOME;
+    delete process.env.PATCHWORK_HOME;
+    delete process.env.PATCHWORK_TOKEN_STORAGE_BACKEND;
+    delete process.env.ASANA_CLIENT_ID;
+    delete process.env.ASANA_CLIENT_SECRET;
+    if (existsSync(tmpDir)) {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("loadTokens returns null when no token stored", async () => {
+    const { loadTokens } = await import("../asana.js");
+    expect(loadTokens()).toBeNull();
+  });
+
+  it("saveTokens + loadTokens round-trips", async () => {
+    const { loadTokens, saveTokens } = await import("../asana.js");
+    const tokens = {
+      access_token: "asana-access-123",
+      refresh_token: "asana-refresh-123",
+      expires_at: Date.now() + 3600 * 1000,
+      scope: "default",
+      username: "Patchwork Bot",
+      user_gid: "1234567890",
+      email: "bot@example.com",
+      connected_at: "2026-04-29T00:00:00.000Z",
+    };
+    saveTokens(tokens);
+    const loaded = loadTokens();
+    expect(loaded).toMatchObject({
+      access_token: "asana-access-123",
+      refresh_token: "asana-refresh-123",
+      username: "Patchwork Bot",
+      email: "bot@example.com",
+    });
+  });
+
+  it("clearTokens does not throw when no file exists", async () => {
+    const { clearTokens } = await import("../asana.js");
+    expect(() => clearTokens()).not.toThrow();
+  });
+
+  it("isConnected reflects stored token presence", async () => {
+    const { isConnected, saveTokens, clearTokens } = await import(
+      "../asana.js"
+    );
+    expect(isConnected()).toBe(false);
+    saveTokens({
+      access_token: "x",
+      connected_at: new Date().toISOString(),
+    });
+    expect(isConnected()).toBe(true);
+    clearTokens();
+    expect(isConnected()).toBe(false);
+  });
+});
+
+// ── healthCheck ──────────────────────────────────────────────────────────────
+
+describe("AsanaConnector.healthCheck", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("returns ok:true when API responds 200", async () => {
+    global.fetch = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ data: { gid: "u1", name: "Patchwork" } }),
+      headers: { get: () => null },
+    }) as unknown as typeof fetch;
+
+    const { AsanaConnector } = await import("../asana.js");
+    const conn = new AsanaConnector();
+    vi.spyOn(
+      conn as unknown as {
+        authenticate: () => Promise<{ token: string; scopes: string[] }>;
+      },
+      "authenticate",
+    ).mockResolvedValue({ token: "good", scopes: [] });
+
+    const result = await conn.healthCheck();
+    expect(result.ok).toBe(true);
+  });
+
+  it("returns ok:false with auth_expired when API responds 401", async () => {
+    const fakeResponse = {
+      ok: false,
+      status: 401,
+      headers: { get: () => null },
+    };
+    Object.setPrototypeOf(fakeResponse, Response.prototype);
+    global.fetch = vi
+      .fn()
+      .mockResolvedValue(fakeResponse) as unknown as typeof fetch;
+
+    const { AsanaConnector } = await import("../asana.js");
+    const conn = new AsanaConnector();
+    vi.spyOn(
+      conn as unknown as {
+        authenticate: () => Promise<{ token: string; scopes: string[] }>;
+      },
+      "authenticate",
+    ).mockResolvedValue({ token: "bad", scopes: [] });
+
+    const result = await conn.healthCheck();
+    expect(result.ok).toBe(false);
+    expect(result.error?.code).toBe("auth_expired");
+  });
+});
+
+// ── listWorkspaces ───────────────────────────────────────────────────────────
+
+describe("AsanaConnector.listWorkspaces", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("unwraps `data` and returns the workspace array", async () => {
+    const workspaces = [
+      { gid: "w1", name: "Patchwork", resource_type: "workspace" },
+      { gid: "w2", name: "Other", resource_type: "workspace" },
+    ];
+    global.fetch = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ data: workspaces }),
+      clone() {
+        return this;
+      },
+      headers: { get: () => null },
+    }) as unknown as typeof fetch;
+
+    const { AsanaConnector } = await import("../asana.js");
+    const conn = new AsanaConnector();
+    vi.spyOn(
+      conn as unknown as {
+        authenticate: () => Promise<{ token: string; scopes: string[] }>;
+      },
+      "authenticate",
+    ).mockResolvedValue({ token: "k", scopes: [] });
+
+    const result = await conn.listWorkspaces();
+    expect(result).toEqual(workspaces);
+  });
+
+  it("clamps limit to 100", async () => {
+    const fetchSpy = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ data: [] }),
+      clone() {
+        return this;
+      },
+      headers: { get: () => null },
+    });
+    global.fetch = fetchSpy as unknown as typeof fetch;
+
+    const { AsanaConnector } = await import("../asana.js");
+    const conn = new AsanaConnector();
+    vi.spyOn(
+      conn as unknown as {
+        authenticate: () => Promise<{ token: string; scopes: string[] }>;
+      },
+      "authenticate",
+    ).mockResolvedValue({ token: "k", scopes: [] });
+
+    await conn.listWorkspaces({ limit: 999 });
+    const url = String(fetchSpy.mock.calls[0]?.[0] ?? "");
+    expect(url).toContain("limit=100");
+  });
+});
+
+// ── listProjects ─────────────────────────────────────────────────────────────
+
+describe("AsanaConnector.listProjects", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("rejects when workspaceGid is missing", async () => {
+    const { AsanaConnector } = await import("../asana.js");
+    const conn = new AsanaConnector();
+    await expect(conn.listProjects({ workspaceGid: "" })).rejects.toThrow(
+      /workspaceGid/,
+    );
+  });
+
+  it("passes workspace into the URL", async () => {
+    const fetchSpy = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        data: [{ gid: "p1", name: "Sprint Q2", resource_type: "project" }],
+      }),
+      clone() {
+        return this;
+      },
+      headers: { get: () => null },
+    });
+    global.fetch = fetchSpy as unknown as typeof fetch;
+
+    const { AsanaConnector } = await import("../asana.js");
+    const conn = new AsanaConnector();
+    vi.spyOn(
+      conn as unknown as {
+        authenticate: () => Promise<{ token: string; scopes: string[] }>;
+      },
+      "authenticate",
+    ).mockResolvedValue({ token: "k", scopes: [] });
+
+    const projects = await conn.listProjects({ workspaceGid: "w1" });
+    expect(projects).toHaveLength(1);
+    const url = String(fetchSpy.mock.calls[0]?.[0] ?? "");
+    expect(url).toContain("workspace=w1");
+  });
+});
+
+// ── listTasks ────────────────────────────────────────────────────────────────
+
+describe("AsanaConnector.listTasks", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("rejects when neither projectGid nor assignee+workspace is provided", async () => {
+    const { AsanaConnector } = await import("../asana.js");
+    const conn = new AsanaConnector();
+    await expect(conn.listTasks({})).rejects.toThrow(/projectGid|assignee/);
+    // assignee alone (without workspace) should also reject
+    await expect(conn.listTasks({ assignee: "me" })).rejects.toThrow(
+      /projectGid|assignee/,
+    );
+    // workspace alone (without assignee or project) should also reject
+    await expect(conn.listTasks({ workspaceGid: "w1" })).rejects.toThrow(
+      /projectGid|assignee/,
+    );
+  });
+
+  it("happy path with project filter unwraps data and passes project to URL", async () => {
+    const tasks = [
+      { gid: "t1", name: "Fix login bug", completed: false },
+      { gid: "t2", name: "Write tests", completed: true },
+    ];
+    const fetchSpy = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ data: tasks }),
+      clone() {
+        return this;
+      },
+      headers: { get: () => null },
+    });
+    global.fetch = fetchSpy as unknown as typeof fetch;
+
+    const { AsanaConnector } = await import("../asana.js");
+    const conn = new AsanaConnector();
+    vi.spyOn(
+      conn as unknown as {
+        authenticate: () => Promise<{ token: string; scopes: string[] }>;
+      },
+      "authenticate",
+    ).mockResolvedValue({ token: "k", scopes: [] });
+
+    const result = await conn.listTasks({ projectGid: "p1", limit: 10 });
+    expect(result).toEqual(tasks);
+    const url = String(fetchSpy.mock.calls[0]?.[0] ?? "");
+    expect(url).toContain("project=p1");
+    expect(url).toContain("limit=10");
+  });
+
+  it("accepts assignee + workspaceGid pair", async () => {
+    const fetchSpy = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ data: [] }),
+      clone() {
+        return this;
+      },
+      headers: { get: () => null },
+    });
+    global.fetch = fetchSpy as unknown as typeof fetch;
+
+    const { AsanaConnector } = await import("../asana.js");
+    const conn = new AsanaConnector();
+    vi.spyOn(
+      conn as unknown as {
+        authenticate: () => Promise<{ token: string; scopes: string[] }>;
+      },
+      "authenticate",
+    ).mockResolvedValue({ token: "k", scopes: [] });
+
+    await conn.listTasks({ assignee: "me", workspaceGid: "w1" });
+    const url = String(fetchSpy.mock.calls[0]?.[0] ?? "");
+    expect(url).toContain("assignee=me");
+    expect(url).toContain("workspace=w1");
+  });
+});
+
+// ── 429 rate-limited with Retry-After ────────────────────────────────────────
+
+describe("AsanaConnector 429 handling", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("normalizes 429 with Retry-After header into rate_limited", async () => {
+    // Build a 429 Response stub. apiCall retries up to 2x on retryable
+    // errors, so return 429 for every call to exhaust retries quickly.
+    const make429 = () => {
+      const r = {
+        ok: false,
+        status: 429,
+        headers: {
+          get: (k: string) => (k.toLowerCase() === "retry-after" ? "30" : null),
+        },
+        clone() {
+          return this;
+        },
+        json: async () => ({}),
+      };
+      Object.setPrototypeOf(r, Response.prototype);
+      return r;
+    };
+    global.fetch = vi
+      .fn()
+      .mockImplementation(async () => make429()) as unknown as typeof fetch;
+
+    const { AsanaConnector } = await import("../asana.js");
+    const conn = new AsanaConnector();
+    vi.spyOn(
+      conn as unknown as {
+        authenticate: () => Promise<{ token: string; scopes: string[] }>;
+      },
+      "authenticate",
+    ).mockResolvedValue({ token: "k", scopes: [] });
+
+    const result = await conn.healthCheck();
+    expect(result.ok).toBe(false);
+    expect(result.error?.code).toBe("rate_limited");
+    expect(result.error?.message).toContain("30");
+    expect(
+      (result.error?.providerDetail as { retryAfter?: string })?.retryAfter,
+    ).toBe("30");
+  }, 30_000);
+});
+
+// ── Token refresh on 401 ─────────────────────────────────────────────────────
+
+describe("AsanaConnector token refresh on 401", () => {
+  const tmpDir = join(os.tmpdir(), `patchwork-asana-refresh-${Date.now()}`);
+  const homeDir = join(tmpDir, "home");
+  const patchworkHome = join(homeDir, ".patchwork");
+  const tokensDir = join(patchworkHome, "tokens");
+
+  beforeEach(() => {
+    process.env.HOME = homeDir;
+    process.env.PATCHWORK_HOME = patchworkHome;
+    process.env.PATCHWORK_TOKEN_STORAGE_BACKEND = "file";
+    process.env.ASANA_CLIENT_ID = "cid";
+    process.env.ASANA_CLIENT_SECRET = "csecret";
+    mkdirSync(tokensDir, { recursive: true });
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    delete process.env.HOME;
+    delete process.env.PATCHWORK_HOME;
+    delete process.env.PATCHWORK_TOKEN_STORAGE_BACKEND;
+    delete process.env.ASANA_CLIENT_ID;
+    delete process.env.ASANA_CLIENT_SECRET;
+    if (existsSync(tmpDir)) {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("on 401, refreshes token and retries the API call once", async () => {
+    // Three fetch calls in sequence:
+    //   1) /users/me → 401 (auth_expired, retryable per Asana normalizeError)
+    //   2) /-/oauth_token (refresh) → 200 with new access_token
+    //   3) /users/me retry → 200
+    const expired = {
+      ok: false,
+      status: 401,
+      headers: { get: () => null },
+    };
+    Object.setPrototypeOf(expired, Response.prototype);
+
+    const fetchSpy = vi
+      .fn()
+      // initial call: 401
+      .mockResolvedValueOnce(expired)
+      // refresh call: 200 with new tokens
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          access_token: "new-access",
+          refresh_token: "new-refresh",
+          expires_in: 3600,
+          scope: "default",
+          token_type: "Bearer",
+        }),
+        headers: { get: () => null },
+      })
+      // retry: 200
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ data: { gid: "u1", name: "Patchwork" } }),
+        headers: { get: () => null },
+      });
+
+    global.fetch = fetchSpy as unknown as typeof fetch;
+
+    const { AsanaConnector, saveTokens, loadTokens } = await import(
+      "../asana.js"
+    );
+    // Pre-seed stored tokens with a refresh_token so the connector has something
+    // to refresh with.
+    saveTokens({
+      access_token: "stale-access",
+      refresh_token: "stale-refresh",
+      expires_at: Date.now() + 60_000, // not yet expired by clock
+      scope: "default",
+      token_type: "Bearer",
+      _client_id: "cid",
+      _client_secret: "csecret",
+      connected_at: new Date().toISOString(),
+    });
+
+    const conn = new AsanaConnector();
+    const result = await conn.healthCheck();
+
+    expect(result.ok).toBe(true);
+    // Verify the three fetch calls happened in order.
+    expect(fetchSpy).toHaveBeenCalledTimes(3);
+    const url1 = String(fetchSpy.mock.calls[0]?.[0] ?? "");
+    const url2 = String(fetchSpy.mock.calls[1]?.[0] ?? "");
+    const url3 = String(fetchSpy.mock.calls[2]?.[0] ?? "");
+    expect(url1).toContain("/users/me");
+    expect(url2).toContain("/-/oauth_token");
+    expect(url3).toContain("/users/me");
+
+    // Stored tokens should now reflect the refreshed access_token.
+    const stored = loadTokens();
+    expect(stored?.access_token).toBe("new-access");
+    expect(stored?.refresh_token).toBe("new-refresh");
+  });
+});
+
+// ── HTTP handlers ────────────────────────────────────────────────────────────
+
+describe("handleAsanaAuthorize", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    delete process.env.ASANA_CLIENT_ID;
+    delete process.env.ASANA_CLIENT_SECRET;
+  });
+
+  it("returns 503 when ASANA_CLIENT_ID/SECRET are not set", async () => {
+    const { handleAsanaAuthorize } = await import("../asana.js");
+    const result = handleAsanaAuthorize();
+    expect(result.status).toBe(503);
+    const body = JSON.parse(result.body);
+    expect(body.ok).toBe(false);
+    expect(body.error).toMatch(/ASANA_CLIENT_ID/);
+  });
+
+  it("returns 302 redirect with state when configured", async () => {
+    process.env.ASANA_CLIENT_ID = "cid";
+    process.env.ASANA_CLIENT_SECRET = "csecret";
+    const { handleAsanaAuthorize } = await import("../asana.js");
+    const result = handleAsanaAuthorize();
+    expect(result.status).toBe(302);
+    expect(result.redirect).toMatch(
+      /^https:\/\/app\.asana\.com\/-\/oauth_authorize\?/,
+    );
+    const url = new URL(result.redirect ?? "");
+    expect(url.searchParams.get("client_id")).toBe("cid");
+    expect(url.searchParams.get("response_type")).toBe("code");
+    expect(url.searchParams.get("scope")).toBe("default");
+    expect(url.searchParams.get("state")).toBeTruthy();
+  });
+});
+
+describe("handleAsanaTest", () => {
+  it("returns 400 when not connected", async () => {
+    const tmpDir = join(os.tmpdir(), `patchwork-asana-test-${Date.now()}`);
+    process.env.HOME = join(tmpDir, "home");
+    process.env.PATCHWORK_HOME = join(tmpDir, "home", ".patchwork");
+    process.env.PATCHWORK_TOKEN_STORAGE_BACKEND = "file";
+    mkdirSync(join(process.env.PATCHWORK_HOME, "tokens"), { recursive: true });
+    vi.resetModules();
+    const { handleAsanaTest } = await import("../asana.js");
+    const result = await handleAsanaTest();
+    expect(result.status).toBe(400);
+    delete process.env.HOME;
+    delete process.env.PATCHWORK_HOME;
+    delete process.env.PATCHWORK_TOKEN_STORAGE_BACKEND;
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+});
+
+describe("handleAsanaDisconnect", () => {
+  it("returns 200 always", async () => {
+    const tmpDir = join(
+      os.tmpdir(),
+      `patchwork-asana-disconnect-${Date.now()}`,
+    );
+    process.env.HOME = join(tmpDir, "home");
+    process.env.PATCHWORK_HOME = join(tmpDir, "home", ".patchwork");
+    process.env.PATCHWORK_TOKEN_STORAGE_BACKEND = "file";
+    mkdirSync(join(process.env.PATCHWORK_HOME, "tokens"), { recursive: true });
+    vi.resetModules();
+    const { handleAsanaDisconnect } = await import("../asana.js");
+    const result = await handleAsanaDisconnect();
+    expect(result.status).toBe(200);
+    expect(JSON.parse(result.body).ok).toBe(true);
+    delete process.env.HOME;
+    delete process.env.PATCHWORK_HOME;
+    delete process.env.PATCHWORK_TOKEN_STORAGE_BACKEND;
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+});

--- a/src/connectors/asana.ts
+++ b/src/connectors/asana.ts
@@ -1,0 +1,706 @@
+/**
+ * Asana connector — read workspaces, projects, tasks, and current user.
+ *
+ * OAuth 2.0 Authorization Code Grant. Asana is a confidential client (bridge
+ * holds client secret), so PKCE is not used. Refresh tokens are issued; access
+ * tokens expire after 1 hour (3600s).
+ *
+ * Auth: standard OAuth 2.0 with `client_id` + `client_secret` + `redirect_uri`.
+ *   - Env vars: ASANA_CLIENT_ID, ASANA_CLIENT_SECRET (mirrors discord/slack)
+ *   - Stored: getSecretJsonSync("asana") → AsanaTokens
+ *   - Header: Authorization: Bearer <access_token>
+ *
+ * Scope note: Asana's only OAuth scope is `default`, which grants read+write
+ * combined — there is no read-only-only scope. Defense lives at the recipe-tool
+ * layer where every tool declares `isWrite: false`. Newer Asana accounts may
+ * also expose granular scopes; we set `default` for compatibility.
+ *
+ * Tools (read-only this PR): getCurrentUser, listWorkspaces, listProjects,
+ *   listTasks, getTask. Write methods (createTask, updateTask) deferred to a
+ *   follow-up PR.
+ *
+ * HTTP routes (wired in src/server.ts):
+ *   GET    /connections/asana/auth     — redirect to Asana consent
+ *   GET    /connections/asana/callback — exchange code for tokens
+ *   POST   /connections/asana/test     — ping Asana API
+ *   DELETE /connections/asana          — clear stored tokens
+ *
+ * Asana wraps every API response in `{ data: ... }`. We unwrap consistently
+ * inside this class so recipe-tool wrappers see clean arrays/objects.
+ *
+ * Extends BaseConnector for unified auth, retry, rate-limit, error handling.
+ * Token refresh is delegated to BaseConnector.refreshToken() via apiCall.
+ */
+
+import crypto from "node:crypto";
+import {
+  type AuthContext,
+  BaseConnector,
+  type ConnectorError,
+  type ConnectorStatus,
+  type OAuthConfig,
+} from "./baseConnector.js";
+import { escHtml } from "./htmlEscape.js";
+import {
+  deleteSecretJsonSync,
+  getSecretJsonSync,
+  storeSecretJsonSync,
+} from "./tokenStorage.js";
+
+const ASANA_API_BASE = "https://app.asana.com/api/1.0";
+const ASANA_AUTH_URL = "https://app.asana.com/-/oauth_authorize";
+const ASANA_TOKEN_URL = "https://app.asana.com/-/oauth_token";
+const SCOPES = ["default"];
+
+export interface AsanaTokens {
+  access_token: string;
+  refresh_token?: string;
+  /** ms since epoch; absolute, not relative */
+  expires_at?: number;
+  scope?: string;
+  token_type?: string;
+  /** stored at auth time so refresh works even if env vars are absent */
+  _client_id?: string;
+  _client_secret?: string;
+  username?: string;
+  user_gid?: string;
+  email?: string;
+  connected_at: string;
+}
+
+export interface AsanaUser {
+  gid: string;
+  name: string;
+  email?: string;
+  resource_type?: string;
+  photo?: { image_60x60?: string } | null;
+}
+
+export interface AsanaWorkspace {
+  gid: string;
+  name: string;
+  resource_type?: string;
+  is_organization?: boolean;
+}
+
+export interface AsanaProject {
+  gid: string;
+  name: string;
+  resource_type?: string;
+  archived?: boolean;
+}
+
+export interface AsanaTask {
+  gid: string;
+  name: string;
+  resource_type?: string;
+  completed?: boolean;
+  assignee?: { gid: string; name?: string } | null;
+  due_on?: string | null;
+  notes?: string;
+}
+
+// ── Config ───────────────────────────────────────────────────────────────────
+
+function clientId(): string {
+  return process.env.ASANA_CLIENT_ID ?? "";
+}
+
+function clientSecret(): string {
+  return process.env.ASANA_CLIENT_SECRET ?? "";
+}
+
+function redirectUri(): string {
+  const base = (
+    process.env.PATCHWORK_BRIDGE_URL ??
+    `http://localhost:${process.env.PATCHWORK_BRIDGE_PORT ?? "3101"}`
+  ).replace(/\/$/, "");
+  return `${base}/connections/asana/callback`;
+}
+
+function isConfigured(): boolean {
+  return Boolean(clientId() && clientSecret());
+}
+
+// ── Token persistence ────────────────────────────────────────────────────────
+
+export function loadTokens(): AsanaTokens | null {
+  return getSecretJsonSync<AsanaTokens>("asana");
+}
+
+export function saveTokens(tokens: AsanaTokens): void {
+  storeSecretJsonSync("asana", tokens);
+}
+
+export function clearTokens(): void {
+  try {
+    deleteSecretJsonSync("asana");
+  } catch {
+    // ignore
+  }
+}
+
+export function isConnected(): boolean {
+  return loadTokens() !== null;
+}
+
+// ── State (CSRF) ─────────────────────────────────────────────────────────────
+// In-memory map keyed by hex random — short-lived (5 min). Mirrors discord's
+// approach (Set + setTimeout).
+
+const pendingStates = new Set<string>();
+const STATE_TTL_MS = 5 * 60 * 1000;
+
+function generateState(): string {
+  const state = crypto.randomBytes(32).toString("hex");
+  pendingStates.add(state);
+  setTimeout(() => pendingStates.delete(state), STATE_TTL_MS);
+  return state;
+}
+
+function consumeState(state: string): boolean {
+  if (!pendingStates.has(state)) return false;
+  pendingStates.delete(state);
+  return true;
+}
+
+// ── Connector class ──────────────────────────────────────────────────────────
+
+export class AsanaConnector extends BaseConnector {
+  readonly providerName = "asana";
+
+  protected getOAuthConfig(): OAuthConfig | null {
+    // Resolve credentials from env first, then fall back to credentials we
+    // stored at auth time (so refresh keeps working even if env is unset).
+    const tokens = loadTokens();
+    const id = clientId() || tokens?._client_id || "";
+    const secret = clientSecret() || tokens?._client_secret || "";
+    if (!id || !secret) return null;
+    return {
+      clientId: id,
+      clientSecret: secret,
+      tokenEndpoint: ASANA_TOKEN_URL,
+      scopes: SCOPES,
+    };
+  }
+
+  async authenticate(): Promise<AuthContext> {
+    const tokens = loadTokens();
+    if (!tokens) {
+      throw new Error(
+        "Asana not connected. Visit /connections/asana/auth to authorize.",
+      );
+    }
+    return {
+      token: tokens.access_token,
+      refreshToken: tokens.refresh_token,
+      expiresAt: tokens.expires_at ? new Date(tokens.expires_at) : undefined,
+      scopes: tokens.scope ? tokens.scope.split(" ") : SCOPES,
+    };
+  }
+
+  /**
+   * Persist refreshed tokens after BaseConnector.refreshToken() updates
+   * `this.auth`. BaseConnector calls `saveTokens()` (its own method on the
+   * tokenStorage StoredToken shape); we additionally mirror to our
+   * Asana-specific JSON so loadTokens() keeps working for HTTP probes.
+   */
+  override async saveTokens(): Promise<void> {
+    await super.saveTokens();
+    if (!this.auth) return;
+    const existing = loadTokens();
+    saveTokens({
+      access_token: this.auth.token,
+      refresh_token: this.auth.refreshToken,
+      expires_at: this.auth.expiresAt
+        ? this.auth.expiresAt.getTime()
+        : undefined,
+      scope: this.auth.scopes?.join(" "),
+      token_type: existing?.token_type ?? "Bearer",
+      _client_id: existing?._client_id,
+      _client_secret: existing?._client_secret,
+      username: existing?.username,
+      user_gid: existing?.user_gid,
+      email: existing?.email,
+      connected_at: existing?.connected_at ?? new Date().toISOString(),
+    });
+  }
+
+  async healthCheck(): Promise<{ ok: boolean; error?: ConnectorError }> {
+    try {
+      const result = await this.apiCall(async (token) => {
+        const res = await fetch(`${ASANA_API_BASE}/users/me`, {
+          headers: this.buildHeaders(token),
+        });
+        if (!res.ok) throw res;
+        return res.json();
+      });
+      if ("error" in result) return { ok: false, error: result.error };
+      return { ok: true };
+    } catch (err) {
+      return { ok: false, error: this.normalizeError(err) };
+    }
+  }
+
+  normalizeError(error: unknown): ConnectorError {
+    if (error instanceof Response) {
+      const s = error.status;
+      // Asana 4xx payloads have an `errors: [{message, help}]` array — surface
+      // the first message when we can. We can't await here because the body
+      // may already be consumed; callers that want detail should pre-read.
+      const detail = (error as Response & { _asanaDetail?: string })
+        ._asanaDetail;
+      const tag = detail ? `: ${detail}` : "";
+      if (s === 401)
+        return {
+          code: "auth_expired",
+          message: `Asana authentication failed — token expired or revoked${tag}`,
+          retryable: true,
+          suggestedAction: "Reconnect via /connections/asana/auth",
+        };
+      if (s === 403)
+        return {
+          code: "permission_denied",
+          message: `Insufficient Asana permissions for this resource${tag}`,
+          retryable: false,
+        };
+      if (s === 404)
+        return {
+          code: "not_found",
+          message: `Asana resource not found${tag}`,
+          retryable: false,
+        };
+      if (s === 429) {
+        const retryAfter = error.headers.get("retry-after");
+        return {
+          code: "rate_limited",
+          message: `Asana API rate limit exceeded${retryAfter ? ` (retry after ${retryAfter}s)` : ""}${tag}`,
+          retryable: true,
+          suggestedAction: retryAfter
+            ? `Wait ${retryAfter}s and retry`
+            : "Wait and retry",
+          providerDetail: retryAfter ? { retryAfter } : undefined,
+        };
+      }
+      return {
+        code: "provider_error",
+        message: `Asana API error: HTTP ${s}${tag}`,
+        retryable: s >= 500,
+      };
+    }
+    if (error instanceof Error) {
+      if (
+        error.message.includes("ENOTFOUND") ||
+        error.message.includes("ECONNREFUSED")
+      ) {
+        return {
+          code: "network_error",
+          message: `Cannot connect to Asana: ${error.message}`,
+          retryable: true,
+        };
+      }
+    }
+    return {
+      code: "provider_error",
+      message: error instanceof Error ? error.message : String(error),
+      retryable: false,
+    };
+  }
+
+  getStatus(): ConnectorStatus {
+    const tokens = loadTokens();
+    return {
+      id: "asana",
+      status: tokens ? "connected" : "disconnected",
+      lastSync: tokens?.connected_at,
+      workspace: tokens?.username,
+    };
+  }
+
+  // ── API Methods ────────────────────────────────────────────────────────────
+
+  async getCurrentUser(): Promise<AsanaUser> {
+    const result = await this.apiCall(async (token) => {
+      const res = await fetch(`${ASANA_API_BASE}/users/me`, {
+        headers: this.buildHeaders(token),
+      });
+      this.captureRateLimit(res);
+      if (!res.ok) throw await this.attachErrorDetail(res);
+      const json = (await res.json()) as { data: AsanaUser };
+      return json.data;
+    });
+
+    if ("error" in result) throw new Error(result.error.message);
+    return result.data as AsanaUser;
+  }
+
+  async listWorkspaces(
+    params: { limit?: number } = {},
+  ): Promise<AsanaWorkspace[]> {
+    const result = await this.apiCall(async (token) => {
+      const qs = new URLSearchParams({
+        limit: String(Math.min(Math.max(params.limit ?? 50, 1), 100)),
+      });
+      const res = await fetch(`${ASANA_API_BASE}/workspaces?${qs}`, {
+        headers: this.buildHeaders(token),
+      });
+      this.captureRateLimit(res);
+      if (!res.ok) throw await this.attachErrorDetail(res);
+      const json = (await res.json()) as { data: AsanaWorkspace[] };
+      return json.data;
+    });
+
+    if ("error" in result) throw new Error(result.error.message);
+    return result.data as AsanaWorkspace[];
+  }
+
+  async listProjects(params: {
+    workspaceGid: string;
+    limit?: number;
+  }): Promise<AsanaProject[]> {
+    if (!params.workspaceGid) {
+      throw new Error("listProjects requires workspaceGid");
+    }
+    const result = await this.apiCall(async (token) => {
+      const qs = new URLSearchParams({
+        workspace: params.workspaceGid,
+        limit: String(Math.min(Math.max(params.limit ?? 50, 1), 100)),
+      });
+      const res = await fetch(`${ASANA_API_BASE}/projects?${qs}`, {
+        headers: this.buildHeaders(token),
+      });
+      this.captureRateLimit(res);
+      if (!res.ok) throw await this.attachErrorDetail(res);
+      const json = (await res.json()) as { data: AsanaProject[] };
+      return json.data;
+    });
+
+    if ("error" in result) throw new Error(result.error.message);
+    return result.data as AsanaProject[];
+  }
+
+  async listTasks(
+    params: {
+      projectGid?: string;
+      assignee?: string;
+      workspaceGid?: string;
+      limit?: number;
+    } = {},
+  ): Promise<AsanaTask[]> {
+    // Asana's GET /tasks requires either `project` OR (`assignee` + `workspace`).
+    // Asana itself returns a 400 when this is wrong; we surface a clearer error
+    // up front so recipe authors see the real problem instantly.
+    const hasProject = Boolean(params.projectGid);
+    const hasAssigneePair = Boolean(params.assignee && params.workspaceGid);
+    if (!hasProject && !hasAssigneePair) {
+      throw new Error(
+        "listTasks requires either projectGid, or assignee + workspaceGid",
+      );
+    }
+
+    const result = await this.apiCall(async (token) => {
+      const qs = new URLSearchParams({
+        limit: String(Math.min(Math.max(params.limit ?? 50, 1), 100)),
+      });
+      if (params.projectGid) qs.set("project", params.projectGid);
+      if (params.assignee) qs.set("assignee", params.assignee);
+      if (params.workspaceGid) qs.set("workspace", params.workspaceGid);
+
+      const res = await fetch(`${ASANA_API_BASE}/tasks?${qs}`, {
+        headers: this.buildHeaders(token),
+      });
+      this.captureRateLimit(res);
+      if (!res.ok) throw await this.attachErrorDetail(res);
+      const json = (await res.json()) as { data: AsanaTask[] };
+      return json.data;
+    });
+
+    if ("error" in result) throw new Error(result.error.message);
+    return result.data as AsanaTask[];
+  }
+
+  async getTask(taskGid: string): Promise<AsanaTask> {
+    if (!taskGid) throw new Error("getTask requires taskGid");
+    const result = await this.apiCall(async (token) => {
+      const res = await fetch(
+        `${ASANA_API_BASE}/tasks/${encodeURIComponent(taskGid)}`,
+        { headers: this.buildHeaders(token) },
+      );
+      this.captureRateLimit(res);
+      if (!res.ok) throw await this.attachErrorDetail(res);
+      const json = (await res.json()) as { data: AsanaTask };
+      return json.data;
+    });
+
+    if ("error" in result) throw new Error(result.error.message);
+    return result.data as AsanaTask;
+  }
+
+  // ── Helpers ────────────────────────────────────────────────────────────────
+
+  private buildHeaders(token: string): Record<string, string> {
+    return {
+      Authorization: `Bearer ${token}`,
+      Accept: "application/json",
+      "Content-Type": "application/json",
+    };
+  }
+
+  private captureRateLimit(res: Response): void {
+    this.updateRateLimitFromHeaders({
+      "x-ratelimit-remaining":
+        res.headers.get("x-ratelimit-remaining") ?? undefined,
+      "x-ratelimit-reset": res.headers.get("x-ratelimit-reset") ?? undefined,
+      "retry-after": res.headers.get("retry-after") ?? undefined,
+    });
+  }
+
+  /**
+   * Read the response body once and stash the first Asana `errors[].message`
+   * onto a sidecar property so normalizeError can include it without a second
+   * read. Returns the same Response for `throw` to consume.
+   */
+  private async attachErrorDetail(res: Response): Promise<Response> {
+    try {
+      const body = (await res.clone().json()) as {
+        errors?: Array<{ message?: string }>;
+      };
+      const first = body?.errors?.[0]?.message;
+      if (first) {
+        (res as Response & { _asanaDetail?: string })._asanaDetail = first;
+      }
+    } catch {
+      // body wasn't JSON or already consumed — proceed without detail
+    }
+    return res;
+  }
+}
+
+// ── Singleton ────────────────────────────────────────────────────────────────
+
+let _instance: AsanaConnector | null = null;
+
+function resetAsanaConnector(): void {
+  _instance = null;
+}
+
+export function getAsanaConnector(): AsanaConnector {
+  if (!_instance) {
+    _instance = new AsanaConnector();
+  }
+  return _instance;
+}
+
+export { getAsanaConnector as asana };
+
+// ── HTTP Handlers ────────────────────────────────────────────────────────────
+
+export interface ConnectorHandlerResult {
+  status: number;
+  body: string;
+  contentType?: string;
+  redirect?: string;
+}
+
+/**
+ * GET /connections/asana/auth — redirect to Asana consent screen.
+ */
+export function handleAsanaAuthorize(): ConnectorHandlerResult {
+  if (!isConfigured()) {
+    return {
+      status: 503,
+      contentType: "application/json",
+      body: JSON.stringify({
+        ok: false,
+        error:
+          "Asana connector not configured. Set ASANA_CLIENT_ID and ASANA_CLIENT_SECRET.",
+      }),
+    };
+  }
+  const state = generateState();
+  const params = new URLSearchParams({
+    client_id: clientId(),
+    redirect_uri: redirectUri(),
+    response_type: "code",
+    scope: SCOPES.join(" "),
+    state,
+  });
+  return {
+    status: 302,
+    body: "",
+    redirect: `${ASANA_AUTH_URL}?${params.toString()}`,
+  };
+}
+
+/**
+ * GET /connections/asana/callback — exchange code for tokens.
+ */
+export async function handleAsanaCallback(
+  code: string | null,
+  state: string | null,
+  error: string | null,
+): Promise<ConnectorHandlerResult> {
+  if (error) {
+    return {
+      status: 400,
+      contentType: "text/html",
+      body: `<html><body><h2>Asana connect failed</h2><pre>${escHtml(error)}</pre></body></html>`,
+    };
+  }
+  if (!code || !state) {
+    return {
+      status: 400,
+      contentType: "text/html",
+      body: `<html><body><h2>Asana connect failed</h2><pre>missing code or state</pre></body></html>`,
+    };
+  }
+  if (!consumeState(state)) {
+    return {
+      status: 400,
+      contentType: "text/html",
+      body: `<html><body><h2>Asana connect failed</h2><pre>invalid or expired state</pre></body></html>`,
+    };
+  }
+
+  try {
+    const params = new URLSearchParams({
+      grant_type: "authorization_code",
+      code,
+      redirect_uri: redirectUri(),
+      client_id: clientId(),
+      client_secret: clientSecret(),
+    });
+    const res = await fetch(ASANA_TOKEN_URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        Accept: "application/json",
+      },
+      body: params.toString(),
+    });
+    if (!res.ok) {
+      const body = await res.text();
+      throw new Error(`Token exchange HTTP ${res.status}: ${body}`);
+    }
+    const json = (await res.json()) as {
+      access_token?: string;
+      refresh_token?: string;
+      expires_in?: number;
+      scope?: string;
+      token_type?: string;
+      data?: { id?: number; gid?: string; name?: string; email?: string };
+    };
+    if (!json.access_token) {
+      throw new Error("Token exchange returned no access_token");
+    }
+
+    // Asana's token response includes `data: { gid, name, email }` for the
+    // authorizing user — use that if present, otherwise fall back to /users/me.
+    let username: string | undefined = json.data?.name;
+    let userGid: string | undefined =
+      json.data?.gid ??
+      (typeof json.data?.id === "number" ? String(json.data.id) : undefined);
+    let userEmail: string | undefined = json.data?.email;
+    if (!username) {
+      try {
+        const userRes = await fetch(`${ASANA_API_BASE}/users/me`, {
+          headers: { Authorization: `Bearer ${json.access_token}` },
+        });
+        if (userRes.ok) {
+          const u = (await userRes.json()) as { data: AsanaUser };
+          username = u.data?.name;
+          userGid = u.data?.gid ?? userGid;
+          userEmail = u.data?.email ?? userEmail;
+        }
+      } catch {
+        // best-effort
+      }
+    }
+
+    const expiresAt =
+      typeof json.expires_in === "number" && json.expires_in > 0
+        ? Date.now() + json.expires_in * 1000
+        : undefined;
+
+    saveTokens({
+      access_token: json.access_token,
+      refresh_token: json.refresh_token,
+      expires_at: expiresAt,
+      scope: json.scope,
+      token_type: json.token_type ?? "Bearer",
+      _client_id: clientId() || undefined,
+      _client_secret: clientSecret() || undefined,
+      username,
+      user_gid: userGid,
+      email: userEmail,
+      connected_at: new Date().toISOString(),
+    });
+    resetAsanaConnector();
+
+    return {
+      status: 200,
+      contentType: "text/html",
+      body: `<html><body><h2>Asana connected${username ? ` as ${escHtml(username)}` : ""}</h2><script>try { window.opener.postMessage('patchwork:asana:connected', '*'); } catch(_) {} window.close();</script></body></html>`,
+    };
+  } catch (err) {
+    return {
+      status: 400,
+      contentType: "text/html",
+      body: `<html><body><h2>Asana connect failed</h2><pre>${escHtml(err instanceof Error ? err.message : String(err))}</pre></body></html>`,
+    };
+  }
+}
+
+/**
+ * POST /connections/asana/test — verify stored token works.
+ */
+export async function handleAsanaTest(): Promise<ConnectorHandlerResult> {
+  const tokens = loadTokens();
+  if (!tokens) {
+    return {
+      status: 400,
+      contentType: "application/json",
+      body: JSON.stringify({ ok: false, error: "Asana not connected" }),
+    };
+  }
+  try {
+    const connector = getAsanaConnector();
+    const check = await connector.healthCheck();
+    return {
+      status: check.ok ? 200 : 401,
+      contentType: "application/json",
+      body: JSON.stringify(
+        check.ok
+          ? { ok: true, username: tokens.username }
+          : { ok: false, error: check.error?.message },
+      ),
+    };
+  } catch (err) {
+    return {
+      status: 500,
+      contentType: "application/json",
+      body: JSON.stringify({
+        ok: false,
+        error: err instanceof Error ? err.message : String(err),
+      }),
+    };
+  }
+}
+
+/**
+ * DELETE /connections/asana — clear stored tokens.
+ *
+ * Asana does not expose a public OAuth revocation endpoint, so we just drop
+ * local credentials. The token remains valid at Asana until it naturally
+ * expires (1h) or the user revokes the integration in their Asana account
+ * settings.
+ */
+export async function handleAsanaDisconnect(): Promise<ConnectorHandlerResult> {
+  clearTokens();
+  resetAsanaConnector();
+  return {
+    status: 200,
+    contentType: "application/json",
+    body: JSON.stringify({ ok: true }),
+  };
+}

--- a/src/connectors/gmail.ts
+++ b/src/connectors/gmail.ts
@@ -271,6 +271,7 @@ export async function handleConnectionsList(): Promise<ConnectorHandlerResult> {
   // no credentials are stored. Probe each one so the dashboard reflects
   // their actual state instead of always-disconnected.
   const tokenPasteProbes = [
+    { id: "asana", mod: () => import("./asana.js") },
     { id: "notion", mod: () => import("./notion.js") },
     { id: "confluence", mod: () => import("./confluence.js") },
     { id: "datadog", mod: () => import("./datadog.js") },

--- a/src/recipes/tools/asana.ts
+++ b/src/recipes/tools/asana.ts
@@ -1,0 +1,259 @@
+/**
+ * Asana tools — read-only wrappers for workspaces, projects, tasks, user.
+ *
+ * Self-registering tool module for the recipe tool registry. Read-only this PR;
+ * write methods (createTask, updateTask) are deferred.
+ *
+ * Each tool wraps connector throws into the `{count, items, error}` shape that
+ * the runner's silent-fail detector (PR #75) catches as a step error rather
+ * than a silent empty list.
+ *
+ * Note: Asana's only OAuth scope (`default`) grants read+write combined — there
+ * is no read-only-only scope. Defense lives here at the recipe-tool layer where
+ * every tool declares `isWrite: false`.
+ */
+
+import { CommonSchemas, registerTool } from "../toolRegistry.js";
+
+// ============================================================================
+// asana.get_current_user
+// ============================================================================
+
+registerTool({
+  id: "asana.get_current_user",
+  namespace: "asana",
+  description: "Fetch the authenticated Asana user (gid, name, email).",
+  paramsSchema: {
+    type: "object",
+    properties: {
+      into: CommonSchemas.into,
+    },
+  },
+  outputSchema: {
+    type: "object",
+    properties: {
+      count: { type: "number" },
+      items: { type: "array", items: { type: "object" } },
+      error: { type: "string" },
+    },
+  },
+  riskDefault: "low",
+  isWrite: false,
+  isConnector: true,
+  execute: async () => {
+    const { getAsanaConnector } = await import("../../connectors/asana.js");
+    try {
+      const connector = getAsanaConnector();
+      const user = await connector.getCurrentUser();
+      return JSON.stringify({ count: 1, items: [user] });
+    } catch (err) {
+      return JSON.stringify({
+        count: 0,
+        items: [],
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  },
+});
+
+// ============================================================================
+// asana.list_workspaces
+// ============================================================================
+
+registerTool({
+  id: "asana.list_workspaces",
+  namespace: "asana",
+  description: "List Asana workspaces the authenticated user belongs to.",
+  paramsSchema: {
+    type: "object",
+    properties: {
+      max: CommonSchemas.max,
+      into: CommonSchemas.into,
+    },
+  },
+  outputSchema: {
+    type: "object",
+    properties: {
+      count: { type: "number" },
+      items: { type: "array", items: { type: "object" } },
+      error: { type: "string" },
+    },
+  },
+  riskDefault: "low",
+  isWrite: false,
+  isConnector: true,
+  execute: async ({ params }) => {
+    const { getAsanaConnector } = await import("../../connectors/asana.js");
+    const limit = typeof params.max === "number" ? params.max : 50;
+    try {
+      const connector = getAsanaConnector();
+      const workspaces = await connector.listWorkspaces({ limit });
+      return JSON.stringify({ count: workspaces.length, items: workspaces });
+    } catch (err) {
+      return JSON.stringify({
+        count: 0,
+        items: [],
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  },
+});
+
+// ============================================================================
+// asana.list_projects
+// ============================================================================
+
+registerTool({
+  id: "asana.list_projects",
+  namespace: "asana",
+  description: "List projects within an Asana workspace.",
+  paramsSchema: {
+    type: "object",
+    properties: {
+      workspaceGid: {
+        type: "string",
+        description: "Asana workspace gid",
+      },
+      max: CommonSchemas.max,
+      into: CommonSchemas.into,
+    },
+    required: ["workspaceGid"],
+  },
+  outputSchema: {
+    type: "object",
+    properties: {
+      count: { type: "number" },
+      items: { type: "array", items: { type: "object" } },
+      error: { type: "string" },
+    },
+  },
+  riskDefault: "low",
+  isWrite: false,
+  isConnector: true,
+  execute: async ({ params }) => {
+    const { getAsanaConnector } = await import("../../connectors/asana.js");
+    const limit = typeof params.max === "number" ? params.max : 50;
+    try {
+      const connector = getAsanaConnector();
+      const projects = await connector.listProjects({
+        workspaceGid: params.workspaceGid as string,
+        limit,
+      });
+      return JSON.stringify({ count: projects.length, items: projects });
+    } catch (err) {
+      return JSON.stringify({
+        count: 0,
+        items: [],
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  },
+});
+
+// ============================================================================
+// asana.list_tasks
+// ============================================================================
+
+registerTool({
+  id: "asana.list_tasks",
+  namespace: "asana",
+  description:
+    "List Asana tasks. Requires either projectGid, or assignee + workspaceGid.",
+  paramsSchema: {
+    type: "object",
+    properties: {
+      projectGid: {
+        type: "string",
+        description: "Asana project gid (filter by project)",
+      },
+      assignee: {
+        type: "string",
+        description: "Asana user gid or 'me' (filter by assignee)",
+      },
+      workspaceGid: {
+        type: "string",
+        description:
+          "Asana workspace gid (required when filtering by assignee)",
+      },
+      max: CommonSchemas.max,
+      into: CommonSchemas.into,
+    },
+  },
+  outputSchema: {
+    type: "object",
+    properties: {
+      count: { type: "number" },
+      items: { type: "array", items: { type: "object" } },
+      error: { type: "string" },
+    },
+  },
+  riskDefault: "low",
+  isWrite: false,
+  isConnector: true,
+  execute: async ({ params }) => {
+    const { getAsanaConnector } = await import("../../connectors/asana.js");
+    const limit = typeof params.max === "number" ? params.max : 50;
+    try {
+      const connector = getAsanaConnector();
+      const tasks = await connector.listTasks({
+        projectGid: params.projectGid as string | undefined,
+        assignee: params.assignee as string | undefined,
+        workspaceGid: params.workspaceGid as string | undefined,
+        limit,
+      });
+      return JSON.stringify({ count: tasks.length, items: tasks });
+    } catch (err) {
+      return JSON.stringify({
+        count: 0,
+        items: [],
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  },
+});
+
+// ============================================================================
+// asana.get_task
+// ============================================================================
+
+registerTool({
+  id: "asana.get_task",
+  namespace: "asana",
+  description: "Fetch a single Asana task by gid.",
+  paramsSchema: {
+    type: "object",
+    properties: {
+      taskGid: {
+        type: "string",
+        description: "Asana task gid",
+      },
+      into: CommonSchemas.into,
+    },
+    required: ["taskGid"],
+  },
+  outputSchema: {
+    type: "object",
+    properties: {
+      count: { type: "number" },
+      items: { type: "array", items: { type: "object" } },
+      error: { type: "string" },
+    },
+  },
+  riskDefault: "low",
+  isWrite: false,
+  isConnector: true,
+  execute: async ({ params }) => {
+    const { getAsanaConnector } = await import("../../connectors/asana.js");
+    try {
+      const connector = getAsanaConnector();
+      const task = await connector.getTask(params.taskGid as string);
+      return JSON.stringify({ count: 1, items: [task] });
+    } catch (err) {
+      return JSON.stringify({
+        count: 0,
+        items: [],
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  },
+});

--- a/src/recipes/tools/index.ts
+++ b/src/recipes/tools/index.ts
@@ -10,6 +10,7 @@ import "./git.js";
 import "./diagnostics.js";
 
 // Connector-based tools
+import "./asana.js";
 import "./gmail.js";
 import "./googleDrive.js";
 import "./github.js";

--- a/src/server.ts
+++ b/src/server.ts
@@ -1499,6 +1499,73 @@ export class Server extends EventEmitter<ServerEvents> {
         return;
       }
 
+      // ── Asana connector routes ─────────────────────────────────────
+      if (
+        (parsedUrl.pathname === "/connections/asana/auth" ||
+          parsedUrl.pathname === "/connections/asana/authorize") &&
+        req.method === "GET"
+      ) {
+        const { handleAsanaAuthorize } = await import("./connectors/asana.js");
+        const result = handleAsanaAuthorize();
+        if (result.redirect) {
+          res.writeHead(302, { Location: result.redirect });
+          res.end();
+        } else {
+          res.writeHead(result.status, {
+            "Content-Type": result.contentType ?? "application/json",
+          });
+          res.end(result.body);
+        }
+        return;
+      }
+      if (
+        parsedUrl.pathname === "/connections/asana/callback" &&
+        req.method === "GET"
+      ) {
+        void (async () => {
+          const { handleAsanaCallback } = await import("./connectors/asana.js");
+          const code = parsedUrl.searchParams.get("code");
+          const state = parsedUrl.searchParams.get("state");
+          const error = parsedUrl.searchParams.get("error");
+          const result = await handleAsanaCallback(code, state, error);
+          res.writeHead(result.status, {
+            "Content-Type": result.contentType ?? "text/html",
+          });
+          res.end(result.body);
+        })();
+        return;
+      }
+      if (
+        parsedUrl.pathname === "/connections/asana/test" &&
+        req.method === "POST"
+      ) {
+        void (async () => {
+          const { handleAsanaTest } = await import("./connectors/asana.js");
+          const result = await handleAsanaTest();
+          res.writeHead(result.status, {
+            "Content-Type": result.contentType ?? "application/json",
+          });
+          res.end(result.body);
+        })();
+        return;
+      }
+      if (
+        parsedUrl.pathname === "/connections/asana" &&
+        req.method === "DELETE"
+      ) {
+        void (async () => {
+          const { handleAsanaDisconnect } = await import(
+            "./connectors/asana.js"
+          );
+          const result = await handleAsanaDisconnect();
+          res.writeHead(result.status, {
+            "Content-Type": result.contentType ?? "application/json",
+          });
+          res.end(result.body);
+        })();
+        return;
+      }
+
       // ── Notion routes ──────────────────────────────────────────────
       if (
         parsedUrl.pathname === "/connections/notion/connect" &&


### PR DESCRIPTION
## Summary

End-to-end Asana integration via OAuth 2.0 Authorization Code Grant with refresh tokens. Mirrors the Discord connector shape (PR #80) and existing Slack patterns.

- **Bridge connector** — `src/connectors/asana.ts` (`AsanaConnector` extends `BaseConnector`); methods: `getCurrentUser`, `listWorkspaces`, `listProjects`, `listTasks`, `getTask`. Asana wraps all payloads in `{ data: ... }` — the connector unwraps consistently so callers see clean arrays/objects.
- **OAuth flow** — auth/callback/test/disconnect routes wired in `src/server.ts`. CSRF defense via 32-byte hex `state` (5-min in-memory TTL). Token exchange POSTs `application/x-www-form-urlencoded` to `https://app.asana.com/-/oauth_token`.
- **Refresh tokens** — Asana access tokens expire after 1h; refresh delegated to `BaseConnector.refreshToken()` via `apiCall`, with `saveTokens()` overridden to mirror to disk so HTTP probes stay accurate.
- **Recipe tools** — `asana.get_current_user`, `list_workspaces`, `list_projects`, `list_tasks`, `get_task`. All `riskDefault: "low"`, `isWrite: false`, `isConnector: true`. Use the `{count, items, error}` shape per PR #75. `listTasks` rejects up front if neither `projectGid` nor `assignee + workspaceGid` is supplied (Asana itself 400s either way; we surface a clearer error).
- **Error normalization** — 401 → `auth_expired`, 404 → `not_found`, 403 → `permission_denied`, 429 → `rate_limited` (with `Retry-After`). Asana 4xx payloads include an `errors[].message` array — first message is surfaced via a sidecar property.
- **Dashboard** — `IconAsana` (three-dot triangle brand mark), Asana added to `SUPPORTED_CONNECTORS` and the `PROVIDERS` "Add connection" modal. Existing CATALOG entry (`#F06A6A`, Wave 2 Project) stays as-is. Callback page + API route mirror Discord.

## Scope note

Asana's only OAuth scope is `default`, which grants **read+write combined** — there is no read-only-only scope. Defense lives at the recipe-tool layer where every tool declares `isWrite: false`. Newer Asana accounts may also expose granular scopes; we set `default` for compatibility.

## What is deferred

Write methods — `createTask`, `updateTask`, completing/assigning tasks — go in a follow-up PR, behind the same `isWrite: true` gate the rest of the connector ecosystem uses.

## Test plan

- [x] `npm run build` (bridge) — passes
- [x] `npx tsc --noEmit` in `dashboard/` — passes
- [x] `npx vitest run src/connectors/__tests__/asana.test.ts` — 19/19 pass (token storage, healthCheck 200 + 401, listWorkspaces unwrap + clamp, listProjects requires workspaceGid, listTasks param validation + project-filter happy path + assignee+workspace pair, 429 with Retry-After parsed, full token-refresh-on-401 retry flow, HTTP handler endpoints)
- [x] Full vitest suite — 4376/4376 pass
- [x] `node scripts/audit-lsp-tools.mjs` — passes
- [ ] Manual OAuth round-trip with real Asana credentials (deferred to follow-up smoke test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)