### PR TITLE
feat(connectors): PagerDuty write methods (ack, resolve, note, create)

### DIFF
--- a/src/connectors/__tests__/pagerduty.test.ts
+++ b/src/connectors/__tests__/pagerduty.test.ts
@@ -274,3 +274,210 @@ describe("handlePagerDutyDisconnect", () => {
     expect(JSON.parse(result.body).ok).toBe(true);
   });
 });
+
+// ─── writes ────────────────────────────────────────────────────────────────
+
+describe("PagerDutyConnector writes", () => {
+  const FROM = "ops@example.com";
+
+  // Build a connector with stub auth + spied fetch.
+  async function makeConn(fetchImpl: ReturnType<typeof vi.fn>) {
+    global.fetch = fetchImpl as unknown as typeof fetch;
+    vi.resetModules();
+    const { PagerDutyConnector } = await import("../pagerduty.js");
+    const conn = new PagerDutyConnector();
+    (conn as unknown as { tokens: object }).tokens = {
+      token: "k",
+      connected_at: new Date().toISOString(),
+    };
+    vi.spyOn(
+      conn as unknown as {
+        authenticate: () => Promise<{ token: string; scopes: string[] }>;
+      },
+      "authenticate",
+    ).mockResolvedValue({ token: "k", scopes: [] });
+    return conn;
+  }
+
+  function jsonOk<T>(payload: T) {
+    return {
+      ok: true,
+      status: 200,
+      json: async () => payload,
+      headers: { get: () => null },
+    };
+  }
+
+  function jsonErr(status: number) {
+    const fake = { ok: false, status, headers: { get: () => null } };
+    Object.setPrototypeOf(fake, Response.prototype);
+    return fake;
+  }
+
+  beforeEach(() => {
+    process.env.PAGERDUTY_FROM_EMAIL = FROM;
+  });
+
+  afterEach(() => {
+    delete process.env.PAGERDUTY_FROM_EMAIL;
+    vi.restoreAllMocks();
+  });
+
+  it("acknowledgeIncident PUTs correct status and includes From header", async () => {
+    const fetchSpy = vi.fn().mockResolvedValueOnce(
+      jsonOk({
+        incident: { id: "P1", status: "acknowledged", incident_number: 1 },
+      }),
+    );
+    const conn = await makeConn(fetchSpy);
+
+    const result = await conn.acknowledgeIncident("P1");
+
+    expect(result.id).toBe("P1");
+    expect(result.status).toBe("acknowledged");
+    const call = fetchSpy.mock.calls[0];
+    expect(String(call?.[0])).toContain("/incidents/P1");
+    expect(call?.[1]?.method).toBe("PUT");
+    const body = JSON.parse(call?.[1]?.body as string);
+    expect(body.incident.status).toBe("acknowledged");
+    expect(body.incident.type).toBe("incident_reference");
+    const headers = call?.[1]?.headers as Record<string, string>;
+    expect(headers.From).toBe(FROM);
+  });
+
+  it("acknowledgeIncident 404 → not_found error message", async () => {
+    const fetchSpy = vi.fn().mockResolvedValueOnce(jsonErr(404));
+    const conn = await makeConn(fetchSpy);
+    await expect(conn.acknowledgeIncident("PXX")).rejects.toThrow(/not found/i);
+  });
+
+  it("acknowledgeIncident throws if PAGERDUTY_FROM_EMAIL unset and no override", async () => {
+    delete process.env.PAGERDUTY_FROM_EMAIL;
+    const fetchSpy = vi.fn(); // never called
+    const conn = await makeConn(fetchSpy);
+    await expect(conn.acknowledgeIncident("P1")).rejects.toThrow(
+      /PAGERDUTY_FROM_EMAIL/,
+    );
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("resolveIncident sends resolution string in body", async () => {
+    const fetchSpy = vi.fn().mockResolvedValueOnce(
+      jsonOk({
+        incident: { id: "P2", status: "resolved", incident_number: 2 },
+      }),
+    );
+    const conn = await makeConn(fetchSpy);
+
+    const result = await conn.resolveIncident("P2", {
+      resolution: "fixed by rolling back deploy abc123",
+    });
+
+    expect(result.status).toBe("resolved");
+    const call = fetchSpy.mock.calls[0];
+    const body = JSON.parse(call?.[1]?.body as string);
+    expect(body.incident.status).toBe("resolved");
+    expect(body.incident.resolution).toBe(
+      "fixed by rolling back deploy abc123",
+    );
+    const headers = call?.[1]?.headers as Record<string, string>;
+    expect(headers.From).toBe(FROM);
+  });
+
+  it("addIncidentNote POSTs note content", async () => {
+    const fetchSpy = vi.fn().mockResolvedValueOnce(
+      jsonOk({
+        note: {
+          id: "N1",
+          content: "Investigating",
+          created_at: "2026-04-29T00:00:00Z",
+        },
+      }),
+    );
+    const conn = await makeConn(fetchSpy);
+
+    const result = await conn.addIncidentNote("P3", {
+      content: "Investigating",
+    });
+
+    expect(result.id).toBe("N1");
+    expect(result.content).toBe("Investigating");
+    const call = fetchSpy.mock.calls[0];
+    expect(String(call?.[0])).toContain("/incidents/P3/notes");
+    expect(call?.[1]?.method).toBe("POST");
+    const body = JSON.parse(call?.[1]?.body as string);
+    expect(body.note.content).toBe("Investigating");
+    const headers = call?.[1]?.headers as Record<string, string>;
+    expect(headers.From).toBe(FROM);
+  });
+
+  it("createIncident defaults urgency to 'high' and sends From header", async () => {
+    const fetchSpy = vi.fn().mockResolvedValueOnce(
+      jsonOk({
+        incident: {
+          id: "P4",
+          incident_number: 4,
+          status: "triggered",
+          urgency: "high",
+        },
+      }),
+    );
+    const conn = await makeConn(fetchSpy);
+
+    const result = await conn.createIncident({
+      title: "DB down",
+      serviceId: "SVC1",
+    });
+
+    expect(result.id).toBe("P4");
+    const call = fetchSpy.mock.calls[0];
+    expect(String(call?.[0])).toContain("/incidents");
+    expect(call?.[1]?.method).toBe("POST");
+    const body = JSON.parse(call?.[1]?.body as string);
+    expect(body.incident.urgency).toBe("high");
+    expect(body.incident.title).toBe("DB down");
+    expect(body.incident.service.id).toBe("SVC1");
+    expect(body.incident.service.type).toBe("service_reference");
+    const headers = call?.[1]?.headers as Record<string, string>;
+    expect(headers.From).toBe(FROM);
+  });
+
+  it("createIncident rejects when serviceId missing", async () => {
+    const fetchSpy = vi.fn();
+    const conn = await makeConn(fetchSpy);
+    await expect(
+      conn.createIncident({
+        title: "x",
+        serviceId: "",
+      }),
+    ).rejects.toThrow(/serviceId/);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("createIncident respects explicit urgency=low and includes body", async () => {
+    const fetchSpy = vi.fn().mockResolvedValueOnce(
+      jsonOk({
+        incident: {
+          id: "P5",
+          incident_number: 5,
+          status: "triggered",
+          urgency: "low",
+        },
+      }),
+    );
+    const conn = await makeConn(fetchSpy);
+
+    await conn.createIncident({
+      title: "minor blip",
+      serviceId: "SVC2",
+      urgency: "low",
+      body: "intermittent 502s on edge",
+    });
+
+    const call = fetchSpy.mock.calls[0];
+    const body = JSON.parse(call?.[1]?.body as string);
+    expect(body.incident.urgency).toBe("low");
+    expect(body.incident.body.type).toBe("incident_body");
+    expect(body.incident.body.details).toBe("intermittent 502s on edge");
+  });
+});

--- a/src/connectors/pagerduty.ts
+++ b/src/connectors/pagerduty.ts
@@ -7,8 +7,12 @@
  *   - Header: Authorization: Token token=<key>   (PagerDuty's specific format —
  *     not Bearer.)
  *
- * Tools (read-only this PR): listIncidents, getIncident, listServices, listOnCalls.
- * Write methods (createIncident / ack / resolve) deferred to a follow-up PR.
+ * Read tools: listIncidents, getIncident, listServices, listOnCalls.
+ * Write tools: acknowledgeIncident, resolveIncident, addIncidentNote, createIncident.
+ *
+ * Writes require a `From` header (PagerDuty API requirement) sourced from
+ * PAGERDUTY_FROM_EMAIL env var. Identity is NOT exposed via recipe params —
+ * recipes can't spoof who performed the action.
  *
  * Extends BaseConnector for unified auth, retry, rate-limit, error handling.
  */
@@ -67,6 +71,21 @@ export interface PagerDutyOnCall {
   escalation_level: number;
   start?: string;
   end?: string;
+}
+
+export interface PagerDutyNote {
+  id: string;
+  content: string;
+  created_at: string;
+  user?: { id: string; summary: string; type: string };
+}
+
+export interface CreateIncidentParams {
+  title: string;
+  serviceId: string;
+  urgency?: "high" | "low";
+  body?: string;
+  fromEmail?: string;
 }
 
 export class PagerDutyConnector extends BaseConnector {
@@ -254,15 +273,152 @@ export class PagerDutyConnector extends BaseConnector {
     return result.data as { oncalls: PagerDutyOnCall[] };
   }
 
+  // ── Write methods ──────────────────────────────────────────────────────────
+  // All writes require a `From` header set to the email of the user performing
+  // the action. Read from PAGERDUTY_FROM_EMAIL env var (or per-call override).
+  // Identity is intentionally NOT exposed to recipe tools — recipes shouldn't
+  // be able to spoof identity.
+
+  async acknowledgeIncident(
+    incidentId: string,
+    options: { fromEmail?: string } = {},
+  ): Promise<PagerDutyIncident> {
+    const fromEmail = resolveFromEmail(options.fromEmail);
+    const result = await this.apiCall(async (token) => {
+      const res = await fetch(`${PAGERDUTY_BASE}/incidents/${incidentId}`, {
+        method: "PUT",
+        headers: this.buildHeaders(token, fromEmail),
+        body: JSON.stringify({
+          incident: {
+            type: "incident_reference",
+            status: "acknowledged",
+          },
+        }),
+      });
+      if (!res.ok) throw res;
+      const data = (await res.json()) as { incident: PagerDutyIncident };
+      return data.incident;
+    });
+
+    if ("error" in result) throw new Error(result.error.message);
+    return result.data as PagerDutyIncident;
+  }
+
+  async resolveIncident(
+    incidentId: string,
+    options: { fromEmail?: string; resolution?: string } = {},
+  ): Promise<PagerDutyIncident> {
+    const fromEmail = resolveFromEmail(options.fromEmail);
+    const result = await this.apiCall(async (token) => {
+      const incident: Record<string, unknown> = {
+        type: "incident_reference",
+        status: "resolved",
+      };
+      if (options.resolution) incident.resolution = options.resolution;
+
+      const res = await fetch(`${PAGERDUTY_BASE}/incidents/${incidentId}`, {
+        method: "PUT",
+        headers: this.buildHeaders(token, fromEmail),
+        body: JSON.stringify({ incident }),
+      });
+      if (!res.ok) throw res;
+      const data = (await res.json()) as { incident: PagerDutyIncident };
+      return data.incident;
+    });
+
+    if ("error" in result) throw new Error(result.error.message);
+    return result.data as PagerDutyIncident;
+  }
+
+  async addIncidentNote(
+    incidentId: string,
+    options: { content: string; fromEmail?: string },
+  ): Promise<PagerDutyNote> {
+    const fromEmail = resolveFromEmail(options.fromEmail);
+    const result = await this.apiCall(async (token) => {
+      const res = await fetch(
+        `${PAGERDUTY_BASE}/incidents/${incidentId}/notes`,
+        {
+          method: "POST",
+          headers: this.buildHeaders(token, fromEmail),
+          body: JSON.stringify({ note: { content: options.content } }),
+        },
+      );
+      if (!res.ok) throw res;
+      const data = (await res.json()) as { note: PagerDutyNote };
+      return data.note;
+    });
+
+    if ("error" in result) throw new Error(result.error.message);
+    return result.data as PagerDutyNote;
+  }
+
+  async createIncident(
+    params: CreateIncidentParams,
+  ): Promise<PagerDutyIncident> {
+    if (!params.serviceId) {
+      throw new Error("serviceId is required to create a PagerDuty incident");
+    }
+    if (!params.title) {
+      throw new Error("title is required to create a PagerDuty incident");
+    }
+    const fromEmail = resolveFromEmail(params.fromEmail);
+    const urgency = params.urgency ?? "high";
+
+    const result = await this.apiCall(async (token) => {
+      const incident: Record<string, unknown> = {
+        type: "incident",
+        title: params.title,
+        service: { id: params.serviceId, type: "service_reference" },
+        urgency,
+      };
+      if (params.body) {
+        incident.body = { type: "incident_body", details: params.body };
+      }
+
+      const res = await fetch(`${PAGERDUTY_BASE}/incidents`, {
+        method: "POST",
+        headers: this.buildHeaders(token, fromEmail),
+        body: JSON.stringify({ incident }),
+      });
+      if (!res.ok) throw res;
+      const data = (await res.json()) as { incident: PagerDutyIncident };
+      return data.incident;
+    });
+
+    if ("error" in result) throw new Error(result.error.message);
+    return result.data as PagerDutyIncident;
+  }
+
   // ── Helpers ────────────────────────────────────────────────────────────────
 
-  private buildHeaders(token: string): Record<string, string> {
-    return {
+  private buildHeaders(
+    token: string,
+    fromEmail?: string,
+  ): Record<string, string> {
+    const headers: Record<string, string> = {
       Authorization: `Token token=${token}`,
       Accept: PAGERDUTY_ACCEPT,
       "Content-Type": "application/json",
     };
+    if (fromEmail) headers.From = fromEmail;
+    return headers;
   }
+}
+
+/**
+ * Resolve identity (`From` header value) for a PagerDuty write.
+ * Per-call override > PAGERDUTY_FROM_EMAIL env var. Throws if neither set.
+ */
+function resolveFromEmail(override?: string): string {
+  const fromEmail = override ?? process.env.PAGERDUTY_FROM_EMAIL;
+  if (!fromEmail) {
+    throw new Error(
+      "PagerDuty write methods require an identity. Set PAGERDUTY_FROM_EMAIL " +
+        "to the email of the user performing the action.",
+    );
+  }
+  return fromEmail;
 }
 
 // ── Token persistence ────────────────────────────────────────────────────────

--- a/src/recipes/tools/pagerduty.ts
+++ b/src/recipes/tools/pagerduty.ts
@@ -1,12 +1,16 @@
 /**
- * PagerDuty tools — read incidents, services, and on-call rotations.
+ * PagerDuty tools — read incidents, services, on-call rotations, plus writes
+ * (acknowledge, resolve, add note, create incident).
  *
- * Self-registering tool module for the recipe tool registry. Read-only this PR;
- * write methods (createIncident / ack / resolve) are deferred.
+ * Self-registering tool module for the recipe tool registry. Read tools wrap
+ * connector throws into the `{count, items, error}` shape that the runner's
+ * silent-fail detector (PR #75) catches as a step error rather than a silent
+ * empty list. Write tools use a single-object response shape (no count/items)
+ * but still surface failures via an `error` field.
  *
- * Each tool wraps connector throws into the `{count, items, error}` shape that
- * the runner's silent-fail detector (PR #75) catches as a step error rather
- * than a silent empty list.
+ * Identity for writes (PagerDuty `From` header) is sourced exclusively from
+ * the PAGERDUTY_FROM_EMAIL env var, NOT from recipe tool params — recipes
+ * can't spoof who acknowledged / resolved / created an incident.
  */
 
 import { CommonSchemas, registerTool } from "../toolRegistry.js";
@@ -226,6 +230,262 @@ registerTool({
       return JSON.stringify({
         count: 0,
         items: [],
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  },
+});
+
+// ============================================================================
+// pagerduty.acknowledge_incident  (write-gated)
+// ============================================================================
+
+registerTool({
+  id: "pagerduty.acknowledge_incident",
+  namespace: "pagerduty",
+  description:
+    "Acknowledge a PagerDuty incident (status -> acknowledged). Identity sourced from PAGERDUTY_FROM_EMAIL env var.",
+  paramsSchema: {
+    type: "object",
+    properties: {
+      incident_id: {
+        type: "string",
+        description: "PagerDuty incident id (e.g. 'PXXXX')",
+      },
+      into: CommonSchemas.into,
+    },
+    required: ["incident_id"],
+  },
+  outputSchema: {
+    type: "object",
+    properties: {
+      ok: { type: "boolean" },
+      id: { type: "string" },
+      status: { type: "string" },
+      error: { type: "string" },
+    },
+  },
+  riskDefault: "medium",
+  isWrite: true,
+  isConnector: true,
+  execute: async ({ params }) => {
+    const { getPagerDutyConnector } = await import(
+      "../../connectors/pagerduty.js"
+    );
+    try {
+      const connector = getPagerDutyConnector();
+      const incident = await connector.acknowledgeIncident(
+        params.incident_id as string,
+      );
+      return JSON.stringify({
+        ok: true,
+        id: incident.id,
+        status: incident.status,
+      });
+    } catch (err) {
+      return JSON.stringify({
+        ok: false,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  },
+});
+
+// ============================================================================
+// pagerduty.resolve_incident  (write-gated)
+// ============================================================================
+
+registerTool({
+  id: "pagerduty.resolve_incident",
+  namespace: "pagerduty",
+  description:
+    "Resolve a PagerDuty incident (status -> resolved), optionally with a resolution note. Identity sourced from PAGERDUTY_FROM_EMAIL env var.",
+  paramsSchema: {
+    type: "object",
+    properties: {
+      incident_id: {
+        type: "string",
+        description: "PagerDuty incident id (e.g. 'PXXXX')",
+      },
+      resolution: {
+        type: "string",
+        description: "Optional resolution note attached to the close",
+      },
+      into: CommonSchemas.into,
+    },
+    required: ["incident_id"],
+  },
+  outputSchema: {
+    type: "object",
+    properties: {
+      ok: { type: "boolean" },
+      id: { type: "string" },
+      status: { type: "string" },
+      error: { type: "string" },
+    },
+  },
+  riskDefault: "medium",
+  isWrite: true,
+  isConnector: true,
+  execute: async ({ params }) => {
+    const { getPagerDutyConnector } = await import(
+      "../../connectors/pagerduty.js"
+    );
+    try {
+      const connector = getPagerDutyConnector();
+      const incident = await connector.resolveIncident(
+        params.incident_id as string,
+        {
+          resolution:
+            typeof params.resolution === "string"
+              ? params.resolution
+              : undefined,
+        },
+      );
+      return JSON.stringify({
+        ok: true,
+        id: incident.id,
+        status: incident.status,
+      });
+    } catch (err) {
+      return JSON.stringify({
+        ok: false,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  },
+});
+
+// ============================================================================
+// pagerduty.add_incident_note  (write-gated)
+// ============================================================================
+
+registerTool({
+  id: "pagerduty.add_incident_note",
+  namespace: "pagerduty",
+  description:
+    "Append a note to a PagerDuty incident timeline. Identity sourced from PAGERDUTY_FROM_EMAIL env var.",
+  paramsSchema: {
+    type: "object",
+    properties: {
+      incident_id: {
+        type: "string",
+        description: "PagerDuty incident id (e.g. 'PXXXX')",
+      },
+      content: { type: "string", description: "Note content (plain text)" },
+      into: CommonSchemas.into,
+    },
+    required: ["incident_id", "content"],
+  },
+  outputSchema: {
+    type: "object",
+    properties: {
+      ok: { type: "boolean" },
+      id: { type: "string" },
+      content: { type: "string" },
+      created_at: { type: "string" },
+      error: { type: "string" },
+    },
+  },
+  riskDefault: "low",
+  isWrite: true,
+  isConnector: true,
+  execute: async ({ params }) => {
+    const { getPagerDutyConnector } = await import(
+      "../../connectors/pagerduty.js"
+    );
+    try {
+      const connector = getPagerDutyConnector();
+      const note = await connector.addIncidentNote(
+        params.incident_id as string,
+        { content: params.content as string },
+      );
+      return JSON.stringify({
+        ok: true,
+        id: note.id,
+        content: note.content,
+        created_at: note.created_at,
+      });
+    } catch (err) {
+      return JSON.stringify({
+        ok: false,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  },
+});
+
+// ============================================================================
+// pagerduty.create_incident  (write-gated)
+// ============================================================================
+
+registerTool({
+  id: "pagerduty.create_incident",
+  namespace: "pagerduty",
+  description:
+    "Create a new PagerDuty incident on a service. Default urgency: high. Identity sourced from PAGERDUTY_FROM_EMAIL env var.",
+  paramsSchema: {
+    type: "object",
+    properties: {
+      title: { type: "string", description: "Incident title" },
+      service_id: {
+        type: "string",
+        description:
+          "PagerDuty service id (PD service the incident attaches to)",
+      },
+      urgency: {
+        type: "string",
+        enum: ["high", "low"],
+        description: "Incident urgency. Defaults to 'high'.",
+        default: "high",
+      },
+      body: {
+        type: "string",
+        description: "Optional incident body (free-form details)",
+      },
+      into: CommonSchemas.into,
+    },
+    required: ["title", "service_id"],
+  },
+  outputSchema: {
+    type: "object",
+    properties: {
+      ok: { type: "boolean" },
+      id: { type: "string" },
+      incident_number: { type: "number" },
+      status: { type: "string" },
+      html_url: { type: "string" },
+      error: { type: "string" },
+    },
+  },
+  riskDefault: "medium",
+  isWrite: true,
+  isConnector: true,
+  execute: async ({ params }) => {
+    const { getPagerDutyConnector } = await import(
+      "../../connectors/pagerduty.js"
+    );
+    try {
+      const connector = getPagerDutyConnector();
+      const incident = await connector.createIncident({
+        title: params.title as string,
+        serviceId: params.service_id as string,
+        urgency:
+          params.urgency === "low" || params.urgency === "high"
+            ? (params.urgency as "high" | "low")
+            : "high",
+        body: typeof params.body === "string" ? params.body : undefined,
+      });
+      return JSON.stringify({
+        ok: true,
+        id: incident.id,
+        incident_number: incident.incident_number,
+        status: incident.status,
+        html_url: incident.html_url,
+      });
+    } catch (err) {
+      return JSON.stringify({
+        ok: false,
         error: err instanceof Error ? err.message : String(err),
       });
     }


### PR DESCRIPTION
## Summary

Deferred follow-up to #79 (read-only PagerDuty connector). Adds four write methods plus matching recipe tool wrappers, all gated `isWrite: true` so they hit the approval queue.

### Connector methods (`src/connectors/pagerduty.ts`)

- `acknowledgeIncident(id)` — `PUT /incidents/{id}` → `status=acknowledged`
- `resolveIncident(id, {resolution?})` — `PUT /incidents/{id}` → `status=resolved`, optional resolution note
- `addIncidentNote(id, {content})` — `POST /incidents/{id}/notes`
- `createIncident({title, serviceId, urgency?, body?})` — `POST /incidents`, default urgency `high`

All four use `apiCall<T>()` for retry / auth-refresh and return the unwrapped object (incident or note), not the PD `{incident: ...}` envelope. 404 → `not_found`, 401 → `auth_expired`, 429 → `rate_limited` per the existing `normalizeError` map.

### Recipe tool wrappers (`src/recipes/tools/pagerduty.ts`)

| Tool id | Risk |
|---|---|
| `pagerduty.acknowledge_incident` | medium |
| `pagerduty.resolve_incident` | medium |
| `pagerduty.add_incident_note` | low |
| `pagerduty.create_incident` | medium |

Single-object response shape (`{ok, ...fields, error?}`) with try/catch around connector calls so the silent-fail detector still gets an `error` field on failure.

### Identity / `From` header — security boundary

PagerDuty requires a `From` header on writes (email of the user performing the action). Sourced **exclusively** from the `PAGERDUTY_FROM_EMAIL` env var — **NOT** exposed as a recipe tool param. Recipes can't spoof identity. The connector throws a clear error from any write method (not from `healthCheck`) if the env var is unset.

### What's NOT in this PR

- No dashboard changes (`src/app/connections/page.tsx` is in-flight on #81; deliberate hands-off).
- No `src/server.ts` changes — connector status routes already wired in #79; new methods are recipe-only.
- No changes to existing read-only methods — append-only.

## Test plan

- [x] `npm run build` — clean
- [x] `npx vitest run src/connectors/__tests__/pagerduty.test.ts` — 22/22 (14 existing read + 8 new write)
- [x] Full vitest suite — 4365/4365 green
- [x] biome check — clean (auto-formatted)
- [x] Searched for stray imports of new write methods — none

New write tests cover: happy paths for all four methods, 404 → `not_found`, throws when `PAGERDUTY_FROM_EMAIL` unset, `serviceId` required check, `From` header present on every write, default urgency `high`, explicit urgency `low` + body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)