### PR TITLE
feat(connectors): Asana write methods (create, update, complete, comment)

### DIFF
--- a/src/connectors/__tests__/asana.test.ts
+++ b/src/connectors/__tests__/asana.test.ts
@@ -548,3 +548,255 @@ describe("handleAsanaDisconnect", () => {
     rmSync(tmpDir, { recursive: true, force: true });
   });
 });
+
+// ── writes ───────────────────────────────────────────────────────────────────
+
+/**
+ * Build a minimal mocked-fetch Response stub the connector can read.
+ * Supports `clone()` (used by attachErrorDetail) and a synthetic header bag.
+ */
+function makeJsonResponse(body: unknown, status = 200) {
+  const r = {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+    clone() {
+      return this;
+    },
+    headers: { get: () => null },
+  };
+  Object.setPrototypeOf(r, Response.prototype);
+  return r;
+}
+
+function mockAuthenticate(conn: { authenticate?: unknown }) {
+  vi.spyOn(
+    conn as unknown as {
+      authenticate: () => Promise<{ token: string; scopes: string[] }>;
+    },
+    "authenticate",
+  ).mockResolvedValue({ token: "k", scopes: [] });
+}
+
+describe("AsanaConnector writes", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  // ── createTask ─────────────────────────────────────────────────────────────
+
+  it("createTask happy path: POSTs `{data:{...}}` and unwraps response", async () => {
+    const fetchSpy = vi.fn().mockResolvedValueOnce(
+      makeJsonResponse({
+        data: {
+          gid: "t100",
+          name: "New task",
+          resource_type: "task",
+          completed: false,
+        },
+      }),
+    );
+    global.fetch = fetchSpy as unknown as typeof fetch;
+
+    const { AsanaConnector } = await import("../asana.js");
+    const conn = new AsanaConnector();
+    mockAuthenticate(conn);
+
+    const task = await conn.createTask({
+      workspaceGid: "w1",
+      name: "New task",
+    });
+
+    expect(task.gid).toBe("t100");
+    expect(task.name).toBe("New task");
+
+    const call = fetchSpy.mock.calls[0];
+    expect(String(call?.[0])).toContain("/tasks");
+    const init = call?.[1] as { method?: string; body?: string };
+    expect(init?.method).toBe("POST");
+    const sent = JSON.parse(init?.body ?? "{}");
+    expect(sent).toEqual({
+      data: { workspace: "w1", name: "New task" },
+    });
+  });
+
+  it("createTask rejects when name is missing", async () => {
+    const { AsanaConnector } = await import("../asana.js");
+    const conn = new AsanaConnector();
+    await expect(
+      conn.createTask({ workspaceGid: "w1", name: "" }),
+    ).rejects.toThrow(/name/);
+  });
+
+  it("createTask rejects when workspaceGid is missing", async () => {
+    const { AsanaConnector } = await import("../asana.js");
+    const conn = new AsanaConnector();
+    await expect(
+      conn.createTask({ workspaceGid: "", name: "x" }),
+    ).rejects.toThrow(/workspaceGid/);
+  });
+
+  it("createTask only includes optional fields when provided", async () => {
+    const fetchSpy = vi
+      .fn()
+      .mockResolvedValueOnce(
+        makeJsonResponse({ data: { gid: "t101", name: "Full" } }),
+      );
+    global.fetch = fetchSpy as unknown as typeof fetch;
+
+    const { AsanaConnector } = await import("../asana.js");
+    const conn = new AsanaConnector();
+    mockAuthenticate(conn);
+
+    await conn.createTask({
+      workspaceGid: "w1",
+      name: "Full",
+      projectGid: "p1",
+      notes: "details",
+      assigneeGid: "u1",
+      dueOn: "2026-05-01",
+      parentTaskGid: "t99",
+    });
+
+    const init = fetchSpy.mock.calls[0]?.[1] as { body?: string };
+    const sent = JSON.parse(init?.body ?? "{}");
+    expect(sent.data).toEqual({
+      workspace: "w1",
+      name: "Full",
+      projects: ["p1"],
+      notes: "details",
+      assignee: "u1",
+      due_on: "2026-05-01",
+      parent: "t99",
+    });
+  });
+
+  // ── updateTask ─────────────────────────────────────────────────────────────
+
+  it("updateTask happy path: PUT with only provided fields, unwraps data", async () => {
+    const fetchSpy = vi.fn().mockResolvedValueOnce(
+      makeJsonResponse({
+        data: { gid: "t1", name: "Renamed", completed: false },
+      }),
+    );
+    global.fetch = fetchSpy as unknown as typeof fetch;
+
+    const { AsanaConnector } = await import("../asana.js");
+    const conn = new AsanaConnector();
+    mockAuthenticate(conn);
+
+    const task = await conn.updateTask("t1", { name: "Renamed" });
+
+    expect(task.gid).toBe("t1");
+    expect(task.name).toBe("Renamed");
+
+    const call = fetchSpy.mock.calls[0];
+    expect(String(call?.[0])).toContain("/tasks/t1");
+    const init = call?.[1] as { method?: string; body?: string };
+    expect(init?.method).toBe("PUT");
+
+    const sent = JSON.parse(init?.body ?? "{}");
+    // Only `name` should be present — no `undefined` keys leaked.
+    expect(sent).toEqual({ data: { name: "Renamed" } });
+    expect(Object.keys(sent.data)).toEqual(["name"]);
+  });
+
+  it("updateTask rejects when no update fields provided", async () => {
+    const { AsanaConnector } = await import("../asana.js");
+    const conn = new AsanaConnector();
+    await expect(conn.updateTask("t1", {})).rejects.toThrow(
+      /at least one field/i,
+    );
+  });
+
+  it("updateTask normalizes 404 into not_found error", async () => {
+    const r404 = {
+      ok: false,
+      status: 404,
+      headers: { get: () => null },
+      clone() {
+        return this;
+      },
+      json: async () => ({ errors: [{ message: "Not found" }] }),
+    };
+    Object.setPrototypeOf(r404, Response.prototype);
+    // apiCall does not retry on 404 (retryable=false), so a single mock is enough.
+    global.fetch = vi.fn().mockResolvedValue(r404) as unknown as typeof fetch;
+
+    const { AsanaConnector } = await import("../asana.js");
+    const conn = new AsanaConnector();
+    mockAuthenticate(conn);
+
+    await expect(conn.updateTask("missing", { name: "x" })).rejects.toThrow(
+      /not found/i,
+    );
+  });
+
+  // ── completeTask ───────────────────────────────────────────────────────────
+
+  it("completeTask sends `completed: true` via updateTask", async () => {
+    const fetchSpy = vi.fn().mockResolvedValueOnce(
+      makeJsonResponse({
+        data: { gid: "t1", name: "Task", completed: true },
+      }),
+    );
+    global.fetch = fetchSpy as unknown as typeof fetch;
+
+    const { AsanaConnector } = await import("../asana.js");
+    const conn = new AsanaConnector();
+    mockAuthenticate(conn);
+
+    const task = await conn.completeTask("t1");
+
+    expect(task.completed).toBe(true);
+
+    const init = fetchSpy.mock.calls[0]?.[1] as {
+      method?: string;
+      body?: string;
+    };
+    expect(init?.method).toBe("PUT");
+    const sent = JSON.parse(init?.body ?? "{}");
+    expect(sent).toEqual({ data: { completed: true } });
+  });
+
+  // ── addTaskComment ─────────────────────────────────────────────────────────
+
+  it("addTaskComment posts `{data:{text, type:'comment'}}` and unwraps", async () => {
+    const fetchSpy = vi.fn().mockResolvedValueOnce(
+      makeJsonResponse({
+        data: {
+          gid: "s1",
+          type: "comment",
+          text: "hi",
+          created_at: "2026-04-29T00:00:00.000Z",
+        },
+      }),
+    );
+    global.fetch = fetchSpy as unknown as typeof fetch;
+
+    const { AsanaConnector } = await import("../asana.js");
+    const conn = new AsanaConnector();
+    mockAuthenticate(conn);
+
+    const story = await conn.addTaskComment("t1", { text: "hi" });
+
+    expect(story.gid).toBe("s1");
+    expect(story.text).toBe("hi");
+
+    const call = fetchSpy.mock.calls[0];
+    expect(String(call?.[0])).toContain("/tasks/t1/stories");
+    const init = call?.[1] as { method?: string; body?: string };
+    expect(init?.method).toBe("POST");
+
+    const sent = JSON.parse(init?.body ?? "{}");
+    expect(sent).toEqual({ data: { text: "hi", type: "comment" } });
+  });
+
+  it("addTaskComment rejects when text is empty", async () => {
+    const { AsanaConnector } = await import("../asana.js");
+    const conn = new AsanaConnector();
+    await expect(conn.addTaskComment("t1", { text: "" })).rejects.toThrow(
+      /text/,
+    );
+  });
+});

--- a/src/connectors/asana.ts
+++ b/src/connectors/asana.ts
@@ -1,5 +1,6 @@
 /**
- * Asana connector — read workspaces, projects, tasks, and current user.
+ * Asana connector — read workspaces, projects, tasks, and current user, plus
+ * writes (createTask, updateTask, completeTask, addTaskComment).
  *
  * OAuth 2.0 Authorization Code Grant. Asana is a confidential client (bridge
  * holds client secret), so PKCE is not used. Refresh tokens are issued; access
@@ -12,12 +13,14 @@
  *
  * Scope note: Asana's only OAuth scope is `default`, which grants read+write
  * combined — there is no read-only-only scope. Defense lives at the recipe-tool
- * layer where every tool declares `isWrite: false`. Newer Asana accounts may
- * also expose granular scopes; we set `default` for compatibility.
+ * layer where each tool declares `isWrite: true|false`. Newer Asana accounts
+ * may also expose granular scopes; we set `default` for compatibility.
  *
- * Tools (read-only this PR): getCurrentUser, listWorkspaces, listProjects,
- *   listTasks, getTask. Write methods (createTask, updateTask) deferred to a
- *   follow-up PR.
+ * Read tools: getCurrentUser, listWorkspaces, listProjects, listTasks, getTask.
+ * Write tools: createTask, updateTask, completeTask, addTaskComment.
+ *
+ * Idempotency: Asana doesn't honor an Idempotency-Key header. Writes simply
+ * throw on error — callers must dedupe via app-level checks if needed.
  *
  * HTTP routes (wired in src/server.ts):
  *   GET    /connections/asana/auth     — redirect to Asana consent
@@ -98,6 +101,35 @@ export interface AsanaTask {
   assignee?: { gid: string; name?: string } | null;
   due_on?: string | null;
   notes?: string;
+}
+
+export interface AsanaStory {
+  gid: string;
+  resource_type?: string;
+  type?: string;
+  text?: string;
+  created_at?: string;
+  created_by?: { gid: string; name?: string } | null;
+}
+
+export interface CreateTaskParams {
+  workspaceGid: string;
+  name: string;
+  projectGid?: string;
+  notes?: string;
+  assigneeGid?: string;
+  /** ISO date YYYY-MM-DD */
+  dueOn?: string;
+  parentTaskGid?: string;
+}
+
+export interface UpdateTaskParams {
+  name?: string;
+  notes?: string;
+  completed?: boolean;
+  assigneeGid?: string;
+  /** ISO date YYYY-MM-DD */
+  dueOn?: string;
 }
 
 // ── Config ───────────────────────────────────────────────────────────────────
@@ -434,6 +466,118 @@ export class AsanaConnector extends BaseConnector {
 
     if ("error" in result) throw new Error(result.error.message);
     return result.data as AsanaTask;
+  }
+
+  // ── Write methods ──────────────────────────────────────────────────────────
+  // Asana wraps both request and response bodies in `{ data: ... }`. We
+  // unwrap the response consistently here so recipe-tool wrappers see the
+  // clean object. Required-param validation happens up front so recipe
+  // authors get a clear error instead of an Asana 400.
+
+  async createTask(params: CreateTaskParams): Promise<AsanaTask> {
+    if (!params.name) throw new Error("createTask requires name");
+    if (!params.workspaceGid) {
+      throw new Error("createTask requires workspaceGid");
+    }
+    const result = await this.apiCall(async (token) => {
+      const data: Record<string, unknown> = {
+        workspace: params.workspaceGid,
+        name: params.name,
+      };
+      if (params.projectGid) data.projects = [params.projectGid];
+      if (params.notes !== undefined) data.notes = params.notes;
+      if (params.assigneeGid) data.assignee = params.assigneeGid;
+      if (params.dueOn) data.due_on = params.dueOn;
+      if (params.parentTaskGid) data.parent = params.parentTaskGid;
+
+      const res = await fetch(`${ASANA_API_BASE}/tasks`, {
+        method: "POST",
+        headers: this.buildHeaders(token),
+        body: JSON.stringify({ data }),
+      });
+      this.captureRateLimit(res);
+      if (!res.ok) throw await this.attachErrorDetail(res);
+      const json = (await res.json()) as { data: AsanaTask };
+      return json.data;
+    });
+
+    if ("error" in result) throw new Error(result.error.message);
+    return result.data as AsanaTask;
+  }
+
+  async updateTask(
+    taskGid: string,
+    updates: UpdateTaskParams,
+  ): Promise<AsanaTask> {
+    if (!taskGid) throw new Error("updateTask requires taskGid");
+    // Strip undefined keys — Asana interprets `undefined`-stringified values
+    // differently than missing keys. Only forward fields that were explicitly
+    // provided by the caller.
+    const data: Record<string, unknown> = {};
+    if (updates.name !== undefined) data.name = updates.name;
+    if (updates.notes !== undefined) data.notes = updates.notes;
+    if (updates.completed !== undefined) data.completed = updates.completed;
+    if (updates.assigneeGid !== undefined) data.assignee = updates.assigneeGid;
+    if (updates.dueOn !== undefined) data.due_on = updates.dueOn;
+
+    if (Object.keys(data).length === 0) {
+      throw new Error("updateTask requires at least one field to update");
+    }
+
+    const result = await this.apiCall(async (token) => {
+      const res = await fetch(
+        `${ASANA_API_BASE}/tasks/${encodeURIComponent(taskGid)}`,
+        {
+          method: "PUT",
+          headers: this.buildHeaders(token),
+          body: JSON.stringify({ data }),
+        },
+      );
+      this.captureRateLimit(res);
+      if (!res.ok) throw await this.attachErrorDetail(res);
+      const json = (await res.json()) as { data: AsanaTask };
+      return json.data;
+    });
+
+    if ("error" in result) throw new Error(result.error.message);
+    return result.data as AsanaTask;
+  }
+
+  /**
+   * Convenience wrapper around updateTask that flips `completed: true`. Lower
+   * risk than other updates since it's a single, well-known state transition.
+   */
+  async completeTask(taskGid: string): Promise<AsanaTask> {
+    if (!taskGid) throw new Error("completeTask requires taskGid");
+    return this.updateTask(taskGid, { completed: true });
+  }
+
+  async addTaskComment(
+    taskGid: string,
+    options: { text: string },
+  ): Promise<AsanaStory> {
+    if (!taskGid) throw new Error("addTaskComment requires taskGid");
+    if (!options.text)
+      throw new Error("addTaskComment requires non-empty text");
+    const result = await this.apiCall(async (token) => {
+      const res = await fetch(
+        `${ASANA_API_BASE}/tasks/${encodeURIComponent(taskGid)}/stories`,
+        {
+          method: "POST",
+          headers: this.buildHeaders(token),
+          body: JSON.stringify({
+            data: { text: options.text, type: "comment" },
+          }),
+        },
+      );
+      this.captureRateLimit(res);
+      if (!res.ok) throw await this.attachErrorDetail(res);
+      const json = (await res.json()) as { data: AsanaStory };
+      return json.data;
+    });
+
+    if ("error" in result) throw new Error(result.error.message);
+    return result.data as AsanaStory;
   }
 
   // ── Helpers ────────────────────────────────────────────────────────────────

--- a/src/recipes/tools/asana.ts
+++ b/src/recipes/tools/asana.ts
@@ -1,16 +1,17 @@
 /**
- * Asana tools — read-only wrappers for workspaces, projects, tasks, user.
+ * Asana tools — read wrappers (workspaces, projects, tasks, user) plus writes
+ * (create_task, update_task, complete_task, add_task_comment).
  *
- * Self-registering tool module for the recipe tool registry. Read-only this PR;
- * write methods (createTask, updateTask) are deferred.
+ * Self-registering tool module for the recipe tool registry. Read tools wrap
+ * connector throws into the `{count, items, error}` shape that the runner's
+ * silent-fail detector (PR #75) catches as a step error rather than a silent
+ * empty list. Write tools use a single-object response shape (no count/items)
+ * but still surface failures via an `error` field.
  *
- * Each tool wraps connector throws into the `{count, items, error}` shape that
- * the runner's silent-fail detector (PR #75) catches as a step error rather
- * than a silent empty list.
- *
- * Note: Asana's only OAuth scope (`default`) grants read+write combined — there
- * is no read-only-only scope. Defense lives here at the recipe-tool layer where
- * every tool declares `isWrite: false`.
+ * Note: Asana's only OAuth scope (`default`) grants read+write combined —
+ * there is no read-only-only scope. Defense lives here at the recipe-tool
+ * layer: read tools declare `isWrite: false`, write tools declare
+ * `isWrite: true` so the approval queue gates them appropriately.
  */
 
 import { CommonSchemas, registerTool } from "../toolRegistry.js";
@@ -252,6 +253,295 @@ registerTool({
       return JSON.stringify({
         count: 0,
         items: [],
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  },
+});
+
+// ============================================================================
+// asana.create_task  (write-gated)
+// ============================================================================
+
+registerTool({
+  id: "asana.create_task",
+  namespace: "asana",
+  description:
+    "Create a new Asana task in a workspace, optionally attached to a project, assigned, due-dated, or nested under a parent task.",
+  paramsSchema: {
+    type: "object",
+    properties: {
+      workspace_gid: {
+        type: "string",
+        description: "Asana workspace gid (required)",
+      },
+      name: { type: "string", description: "Task title (required)" },
+      project_gid: {
+        type: "string",
+        description: "Optional project gid to attach the task to",
+      },
+      notes: {
+        type: "string",
+        description: "Optional task body / notes (free-form text)",
+      },
+      assignee_gid: {
+        type: "string",
+        description: "Optional Asana user gid to assign the task to",
+      },
+      due_on: {
+        type: "string",
+        description: "Optional ISO date YYYY-MM-DD",
+      },
+      parent_task_gid: {
+        type: "string",
+        description: "Optional parent task gid (creates a subtask)",
+      },
+      into: CommonSchemas.into,
+    },
+    required: ["workspace_gid", "name"],
+  },
+  outputSchema: {
+    type: "object",
+    properties: {
+      ok: { type: "boolean" },
+      gid: { type: "string" },
+      name: { type: "string" },
+      error: { type: "string" },
+    },
+  },
+  riskDefault: "medium",
+  isWrite: true,
+  isConnector: true,
+  execute: async ({ params }) => {
+    const { getAsanaConnector } = await import("../../connectors/asana.js");
+    try {
+      const connector = getAsanaConnector();
+      const task = await connector.createTask({
+        workspaceGid: params.workspace_gid as string,
+        name: params.name as string,
+        projectGid:
+          typeof params.project_gid === "string"
+            ? params.project_gid
+            : undefined,
+        notes: typeof params.notes === "string" ? params.notes : undefined,
+        assigneeGid:
+          typeof params.assignee_gid === "string"
+            ? params.assignee_gid
+            : undefined,
+        dueOn: typeof params.due_on === "string" ? params.due_on : undefined,
+        parentTaskGid:
+          typeof params.parent_task_gid === "string"
+            ? params.parent_task_gid
+            : undefined,
+      });
+      return JSON.stringify({ ok: true, gid: task.gid, name: task.name });
+    } catch (err) {
+      return JSON.stringify({
+        ok: false,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  },
+});
+
+// ============================================================================
+// asana.update_task  (write-gated)
+// ============================================================================
+
+registerTool({
+  id: "asana.update_task",
+  namespace: "asana",
+  description:
+    "Update fields on an Asana task. At least one of name/notes/completed/assignee_gid/due_on must be supplied.",
+  paramsSchema: {
+    type: "object",
+    properties: {
+      task_gid: { type: "string", description: "Asana task gid (required)" },
+      name: { type: "string", description: "New task title" },
+      notes: { type: "string", description: "New task notes / body" },
+      completed: {
+        type: "boolean",
+        description: "Mark task completed/uncompleted",
+      },
+      assignee_gid: {
+        type: "string",
+        description: "New assignee user gid",
+      },
+      due_on: {
+        type: "string",
+        description: "ISO date YYYY-MM-DD",
+      },
+      into: CommonSchemas.into,
+    },
+    required: ["task_gid"],
+  },
+  outputSchema: {
+    type: "object",
+    properties: {
+      ok: { type: "boolean" },
+      gid: { type: "string" },
+      name: { type: "string" },
+      completed: { type: "boolean" },
+      error: { type: "string" },
+    },
+  },
+  riskDefault: "medium",
+  isWrite: true,
+  isConnector: true,
+  execute: async ({ params }) => {
+    const { getAsanaConnector } = await import("../../connectors/asana.js");
+    // Defense at wrapper level — refuse when no update fields supplied so the
+    // recipe author sees a clear error rather than an Asana 400.
+    const updates: Record<string, unknown> = {};
+    if (typeof params.name === "string") updates.name = params.name;
+    if (typeof params.notes === "string") updates.notes = params.notes;
+    if (typeof params.completed === "boolean") {
+      updates.completed = params.completed;
+    }
+    if (typeof params.assignee_gid === "string") {
+      updates.assigneeGid = params.assignee_gid;
+    }
+    if (typeof params.due_on === "string") updates.dueOn = params.due_on;
+
+    if (Object.keys(updates).length === 0) {
+      return JSON.stringify({
+        ok: false,
+        error:
+          "update_task requires at least one of name/notes/completed/assignee_gid/due_on",
+      });
+    }
+
+    try {
+      const connector = getAsanaConnector();
+      const task = await connector.updateTask(
+        params.task_gid as string,
+        updates as {
+          name?: string;
+          notes?: string;
+          completed?: boolean;
+          assigneeGid?: string;
+          dueOn?: string;
+        },
+      );
+      return JSON.stringify({
+        ok: true,
+        gid: task.gid,
+        name: task.name,
+        completed: task.completed,
+      });
+    } catch (err) {
+      return JSON.stringify({
+        ok: false,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  },
+});
+
+// ============================================================================
+// asana.complete_task  (write-gated)
+// ============================================================================
+
+registerTool({
+  id: "asana.complete_task",
+  namespace: "asana",
+  description: "Mark an Asana task completed (sets completed: true).",
+  paramsSchema: {
+    type: "object",
+    properties: {
+      task_gid: { type: "string", description: "Asana task gid (required)" },
+      into: CommonSchemas.into,
+    },
+    required: ["task_gid"],
+  },
+  outputSchema: {
+    type: "object",
+    properties: {
+      ok: { type: "boolean" },
+      gid: { type: "string" },
+      completed: { type: "boolean" },
+      error: { type: "string" },
+    },
+  },
+  riskDefault: "low",
+  isWrite: true,
+  isConnector: true,
+  execute: async ({ params }) => {
+    const { getAsanaConnector } = await import("../../connectors/asana.js");
+    try {
+      const connector = getAsanaConnector();
+      const task = await connector.completeTask(params.task_gid as string);
+      return JSON.stringify({
+        ok: true,
+        gid: task.gid,
+        completed: task.completed,
+      });
+    } catch (err) {
+      return JSON.stringify({
+        ok: false,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  },
+});
+
+// ============================================================================
+// asana.add_task_comment  (write-gated)
+// ============================================================================
+
+registerTool({
+  id: "asana.add_task_comment",
+  namespace: "asana",
+  description: "Append a comment story to an Asana task's timeline.",
+  paramsSchema: {
+    type: "object",
+    properties: {
+      task_gid: { type: "string", description: "Asana task gid (required)" },
+      text: {
+        type: "string",
+        description: "Comment text (non-empty, plain text)",
+        minLength: 1,
+      },
+      into: CommonSchemas.into,
+    },
+    required: ["task_gid", "text"],
+  },
+  outputSchema: {
+    type: "object",
+    properties: {
+      ok: { type: "boolean" },
+      gid: { type: "string" },
+      text: { type: "string" },
+      created_at: { type: "string" },
+      error: { type: "string" },
+    },
+  },
+  riskDefault: "low",
+  isWrite: true,
+  isConnector: true,
+  execute: async ({ params }) => {
+    const { getAsanaConnector } = await import("../../connectors/asana.js");
+    const text = typeof params.text === "string" ? params.text : "";
+    if (!text) {
+      return JSON.stringify({
+        ok: false,
+        error: "add_task_comment requires non-empty text",
+      });
+    }
+    try {
+      const connector = getAsanaConnector();
+      const story = await connector.addTaskComment(params.task_gid as string, {
+        text,
+      });
+      return JSON.stringify({
+        ok: true,
+        gid: story.gid,
+        text: story.text,
+        created_at: story.created_at,
+      });
+    } catch (err) {
+      return JSON.stringify({
+        ok: false,
         error: err instanceof Error ? err.message : String(err),
       });
     }


### PR DESCRIPTION
## Summary

Deferred half of #81 — adds write methods to the Asana connector landed last week.

**Connector methods (`src/connectors/asana.ts`):**
- `createTask({ workspaceGid, name, projectGid?, notes?, assigneeGid?, dueOn?, parentTaskGid? })` → `POST /tasks`
- `updateTask(taskGid, { name?, notes?, completed?, assigneeGid?, dueOn? })` → `PUT /tasks/<gid>`
- `completeTask(taskGid)` — convenience wrapper that flips `completed: true`
- `addTaskComment(taskGid, { text })` → `POST /tasks/<gid>/stories`

**Recipe tools (`src/recipes/tools/asana.ts`):**
- `asana.create_task` (riskDefault: medium, isWrite: true)
- `asana.update_task` (riskDefault: medium, isWrite: true)
- `asana.complete_task` (riskDefault: low, isWrite: true)
- `asana.add_task_comment` (riskDefault: low, isWrite: true)

All four wrappers use the single-object `{ ok, ...result, error? }` response shape established in #82's PagerDuty writes.

## Implementation notes

- `updateTask` strips `undefined` keys before serializing — Asana treats explicit-`undefined` payloads differently from missing keys. Wrapper-level guard refuses empty patches with a clear error rather than letting Asana return a 400.
- `addTaskComment` requires non-empty `text` (validated at both connector and wrapper layers).
- Asana wraps both request bodies and responses in `{ data: ... }`; the connector unwraps consistently so recipe wrappers see clean objects.
- Asana doesn't honor `Idempotency-Key` — writes simply throw on error.

## Security boundary

Asana's only OAuth scope (`default`) grants **read + write together** — there is no read-only scope. The `isWrite: true` flag at the recipe-tool layer is the security boundary the approval queue gates on. The connector itself has no scope-level distinction.

## Test plan

- [x] `npm run build` — clean
- [x] `npx vitest run src/connectors/__tests__/asana.test.ts` — 29 tests pass (19 existing + 10 new)
- [x] Full vitest suite — 4394 tests pass across 319 files
- [x] `npx biome check --write` on changed files
- [x] New `describe("AsanaConnector writes")` covers: createTask happy/missing-name/missing-workspace/optional-fields, updateTask happy/empty-rejection/404→not_found, completeTask delegates with `completed:true`, addTaskComment happy/empty-text. All confirm `{data:...}` envelope unwrap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>