### PR TITLE
feat(connectors): Discord sendMessage

### DIFF
--- a/src/connectors/__tests__/discord.test.ts
+++ b/src/connectors/__tests__/discord.test.ts
@@ -446,3 +446,234 @@ describe("handleDiscordDisconnect", () => {
     rmSync(tmpDir, { recursive: true, force: true });
   });
 });
+
+// ── writes (sendMessage) ─────────────────────────────────────────────────────
+
+describe("DiscordConnector.sendMessage (writes)", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  function mockOk(json: unknown) {
+    return {
+      ok: true,
+      status: 200,
+      json: async () => json,
+      headers: { get: () => null },
+    };
+  }
+
+  function mockResponseStatus(status: number) {
+    const r = {
+      ok: false,
+      status,
+      headers: { get: () => null },
+    };
+    Object.setPrototypeOf(r, Response.prototype);
+    return r;
+  }
+
+  async function makeConnector() {
+    const { DiscordConnector } = await import("../discord.js");
+    const conn = new DiscordConnector();
+    vi.spyOn(
+      conn as unknown as {
+        authenticate: () => Promise<{ token: string; scopes: string[] }>;
+      },
+      "authenticate",
+    ).mockResolvedValue({ token: "k", scopes: [] });
+    return conn;
+  }
+
+  it("happy path: POSTs to /channels/{id}/messages with {content, tts:false}", async () => {
+    const sent = {
+      id: "m99",
+      channel_id: "c1",
+      content: "hello",
+      timestamp: "2026-04-29T12:00:00Z",
+      author: { id: "u1", username: "alice" },
+    };
+    const fetchSpy = vi.fn().mockResolvedValueOnce(mockOk(sent));
+    global.fetch = fetchSpy as unknown as typeof fetch;
+
+    const conn = await makeConnector();
+    const result = await conn.sendMessage("c1", { content: "hello" });
+    expect(result).toEqual(sent);
+
+    const url = String(fetchSpy.mock.calls[0]?.[0] ?? "");
+    expect(url).toContain("/channels/c1/messages");
+    const init = fetchSpy.mock.calls[0]?.[1] as RequestInit;
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(init.body as string)).toEqual({
+      content: "hello",
+      tts: false,
+    });
+  });
+
+  it("rejects empty channelId", async () => {
+    const conn = await makeConnector();
+    await expect(conn.sendMessage("", { content: "x" })).rejects.toThrow(
+      /channelId/,
+    );
+  });
+
+  it("rejects empty content", async () => {
+    const conn = await makeConnector();
+    await expect(conn.sendMessage("c1", { content: "" })).rejects.toThrow(
+      /content/,
+    );
+  });
+
+  it("rejects content longer than 2000 chars", async () => {
+    const conn = await makeConnector();
+    const long = "a".repeat(2001);
+    await expect(conn.sendMessage("c1", { content: long })).rejects.toThrow(
+      /2000/,
+    );
+  });
+
+  it("403 surfaces permission_denied with bot-scope guidance", async () => {
+    const fetchSpy = vi.fn().mockResolvedValueOnce(mockResponseStatus(403));
+    global.fetch = fetchSpy as unknown as typeof fetch;
+
+    const conn = await makeConnector();
+    await expect(conn.sendMessage("c1", { content: "hi" })).rejects.toThrow(
+      /bot scope/i,
+    );
+  });
+
+  it("404 surfaces not_found", async () => {
+    const fetchSpy = vi.fn().mockResolvedValueOnce(mockResponseStatus(404));
+    global.fetch = fetchSpy as unknown as typeof fetch;
+
+    const conn = await makeConnector();
+    await expect(conn.sendMessage("c1", { content: "hi" })).rejects.toThrow(
+      /not found/i,
+    );
+  });
+
+  it("honors explicit tts: true", async () => {
+    const fetchSpy = vi.fn().mockResolvedValueOnce(
+      mockOk({
+        id: "m1",
+        channel_id: "c1",
+        content: "spoken",
+        timestamp: "2026-04-29T12:00:00Z",
+        author: { id: "u1", username: "alice" },
+      }),
+    );
+    global.fetch = fetchSpy as unknown as typeof fetch;
+
+    const conn = await makeConnector();
+    await conn.sendMessage("c1", { content: "spoken", tts: true });
+    const init = fetchSpy.mock.calls[0]?.[1] as RequestInit;
+    expect(JSON.parse(init.body as string)).toEqual({
+      content: "spoken",
+      tts: true,
+    });
+  });
+});
+
+// ── writes: refresh-on-401 ───────────────────────────────────────────────────
+
+describe("DiscordConnector.sendMessage refresh on 401", () => {
+  const tmpDir = join(
+    os.tmpdir(),
+    `patchwork-discord-write-refresh-${Date.now()}`,
+  );
+  const homeDir = join(tmpDir, "home");
+  const patchworkHome = join(homeDir, ".patchwork");
+  const tokensDir = join(patchworkHome, "tokens");
+
+  beforeEach(() => {
+    process.env.HOME = homeDir;
+    process.env.PATCHWORK_HOME = patchworkHome;
+    process.env.PATCHWORK_TOKEN_STORAGE_BACKEND = "file";
+    process.env.DISCORD_CLIENT_ID = "cid";
+    process.env.DISCORD_CLIENT_SECRET = "csecret";
+    mkdirSync(tokensDir, { recursive: true });
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    delete process.env.HOME;
+    delete process.env.PATCHWORK_HOME;
+    delete process.env.PATCHWORK_TOKEN_STORAGE_BACKEND;
+    delete process.env.DISCORD_CLIENT_ID;
+    delete process.env.DISCORD_CLIENT_SECRET;
+    if (existsSync(tmpDir)) {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("on 401, refreshes token and retries the POST once", async () => {
+    const expired = {
+      ok: false,
+      status: 401,
+      headers: { get: () => null },
+    };
+    Object.setPrototypeOf(expired, Response.prototype);
+
+    const fetchSpy = vi
+      .fn()
+      // initial POST: 401
+      .mockResolvedValueOnce(expired)
+      // refresh: 200
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          access_token: "new-access",
+          refresh_token: "new-refresh",
+          expires_in: 604800,
+          scope: "identify guilds messages.read",
+          token_type: "Bearer",
+        }),
+        headers: { get: () => null },
+      })
+      // retry POST: 200 with the message
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          id: "m42",
+          channel_id: "c1",
+          content: "after-refresh",
+          timestamp: "2026-04-29T12:00:00Z",
+          author: { id: "u1", username: "alice" },
+        }),
+        headers: { get: () => null },
+      });
+
+    global.fetch = fetchSpy as unknown as typeof fetch;
+
+    const { DiscordConnector, saveTokens, loadTokens } = await import(
+      "../discord.js"
+    );
+    saveTokens({
+      access_token: "stale-access",
+      refresh_token: "stale-refresh",
+      expires_at: Date.now() + 60_000,
+      scope: "identify guilds messages.read",
+      token_type: "Bearer",
+      _client_id: "cid",
+      _client_secret: "csecret",
+      connected_at: new Date().toISOString(),
+    });
+
+    const conn = new DiscordConnector();
+    const result = await conn.sendMessage("c1", { content: "after-refresh" });
+
+    expect(result.id).toBe("m42");
+    expect(fetchSpy).toHaveBeenCalledTimes(3);
+    const url1 = String(fetchSpy.mock.calls[0]?.[0] ?? "");
+    const url2 = String(fetchSpy.mock.calls[1]?.[0] ?? "");
+    const url3 = String(fetchSpy.mock.calls[2]?.[0] ?? "");
+    expect(url1).toContain("/channels/c1/messages");
+    expect(url2).toContain("/oauth2/token");
+    expect(url3).toContain("/channels/c1/messages");
+
+    const stored = loadTokens();
+    expect(stored?.access_token).toBe("new-access");
+  });
+});

--- a/src/connectors/discord.ts
+++ b/src/connectors/discord.ts
@@ -10,8 +10,16 @@
  *   - Stored: getSecretJsonSync("discord") → DiscordTokens
  *   - Header: Authorization: Bearer <access_token>
  *
- * Tools (read-only this PR): getCurrentUser, listGuilds, listChannels,
- *   listMessages. Write methods (sendMessage) deferred to a follow-up PR.
+ * Tools: getCurrentUser, listGuilds, listChannels, listMessages (read);
+ *   sendMessage (write).
+ *
+ * NOTE on writes: Discord's REST API does NOT permit user-context OAuth tokens
+ * to send messages on behalf of the user — only bot-scope tokens can hit
+ * `POST /channels/{id}/messages`. The current connector authenticates as a
+ * regular user (scopes: identify, guilds, messages.read), so `sendMessage`
+ * will return a `permission_denied` error until the user re-authenticates
+ * with the `bot` scope. The method is wired correctly; the gap is the auth
+ * scope, which is left to operators to upgrade when they want write access.
  *
  * HTTP routes (wired in src/server.ts):
  *   GET    /connections/discord/auth     — redirect to Discord consent
@@ -251,7 +259,8 @@ export class DiscordConnector extends BaseConnector {
       if (s === 403)
         return {
           code: "permission_denied",
-          message: "Insufficient Discord permissions for this resource",
+          message:
+            "Discord write requires bot scope — re-authenticate with the bot scope to enable sendMessage. (Other 403s indicate insufficient permissions for this resource.)",
           retryable: false,
         };
       if (s === 404)
@@ -371,6 +380,54 @@ export class DiscordConnector extends BaseConnector {
 
     if ("error" in result) throw new Error(result.error.message);
     return result.data as DiscordMessage[];
+  }
+
+  /**
+   * Send a message to a Discord channel.
+   *
+   * Caveat: requires bot-scope OAuth — regular user-context tokens cannot
+   * send via this endpoint. On 403 the connector surfaces a
+   * `permission_denied` error pointing at the bot-scope requirement.
+   *
+   * @param channelId Discord channel id (non-empty)
+   * @param body { content (≤2000 chars), tts? defaults false }
+   */
+  async sendMessage(
+    channelId: string,
+    body: { content: string; tts?: boolean },
+  ): Promise<DiscordMessage> {
+    if (!channelId || typeof channelId !== "string") {
+      throw new Error("sendMessage requires a non-empty channelId");
+    }
+    if (!body?.content || typeof body.content !== "string") {
+      throw new Error("sendMessage requires a non-empty content string");
+    }
+    if (body.content.length > 2000) {
+      throw new Error(
+        `sendMessage content exceeds Discord's 2000-character limit (${body.content.length})`,
+      );
+    }
+    const payload = {
+      content: body.content,
+      tts: body.tts ?? false,
+    };
+
+    const result = await this.apiCall(async (token) => {
+      const res = await fetch(
+        `${DISCORD_API_BASE}/channels/${encodeURIComponent(channelId)}/messages`,
+        {
+          method: "POST",
+          headers: this.buildHeaders(token),
+          body: JSON.stringify(payload),
+        },
+      );
+      this.captureRateLimit(res);
+      if (!res.ok) throw res;
+      return res.json() as Promise<DiscordMessage>;
+    });
+
+    if ("error" in result) throw new Error(result.error.message);
+    return result.data as DiscordMessage;
   }
 
   // ── Helpers ────────────────────────────────────────────────────────────────

--- a/src/recipes/tools/discord.ts
+++ b/src/recipes/tools/discord.ts
@@ -1,12 +1,19 @@
 /**
- * Discord tools — read-only wrappers for guilds, channels, messages, user.
+ * Discord tools — wrappers for guilds, channels, messages, user, and send.
  *
- * Self-registering tool module for the recipe tool registry. Read-only this PR;
- * write methods (sendMessage) are deferred.
+ * Self-registering tool module for the recipe tool registry. Read tools wrap
+ * connector throws into the `{count, items, error}` shape; the write tool
+ * (`discord.send_message`) returns the single-object `{ok, ..., error?}` shape
+ * and is gated through the approval queue (`isWrite: true`).
  *
  * Each tool wraps connector throws into the `{count, items, error}` shape that
  * the runner's silent-fail detector (PR #75) catches as a step error rather
  * than a silent empty list.
+ *
+ * NOTE on `discord.send_message`: Discord's REST API only accepts message
+ * sends from bot-scope OAuth tokens. The connector currently uses user-scope
+ * (identify/guilds/messages.read), so the underlying call will surface a
+ * `permission_denied` error until operators re-auth with the bot scope.
  */
 
 import { CommonSchemas, registerTool } from "../toolRegistry.js";
@@ -189,6 +196,69 @@ registerTool({
       return JSON.stringify({
         count: 0,
         items: [],
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  },
+});
+
+// ============================================================================
+// discord.send_message  (write-gated)
+// ============================================================================
+
+registerTool({
+  id: "discord.send_message",
+  namespace: "discord",
+  description:
+    "Send a message to a Discord channel. Requires bot-scope OAuth — user-context tokens will fail with permission_denied.",
+  paramsSchema: {
+    type: "object",
+    properties: {
+      channel_id: { type: "string", description: "Discord channel id" },
+      content: {
+        type: "string",
+        description: "Message content (≤2000 chars)",
+      },
+      tts: {
+        type: "boolean",
+        description: "Send as text-to-speech (default false)",
+      },
+      into: CommonSchemas.into,
+    },
+    required: ["channel_id", "content"],
+  },
+  outputSchema: {
+    type: "object",
+    properties: {
+      ok: { type: "boolean" },
+      id: { type: "string" },
+      channel_id: { type: "string" },
+      content: { type: "string" },
+      timestamp: { type: "string" },
+      error: { type: "string" },
+    },
+  },
+  riskDefault: "medium",
+  isWrite: true,
+  isConnector: true,
+  execute: async ({ params }) => {
+    const { getDiscordConnector } = await import("../../connectors/discord.js");
+    try {
+      const connector = getDiscordConnector();
+      const message = await connector.sendMessage(params.channel_id as string, {
+        content: params.content as string,
+        tts: typeof params.tts === "boolean" ? params.tts : undefined,
+      });
+      return JSON.stringify({
+        ok: true,
+        id: message.id,
+        channel_id: message.channel_id,
+        content: message.content,
+        timestamp: message.timestamp,
+      });
+    } catch (err) {
+      return JSON.stringify({
+        ok: false,
         error: err instanceof Error ? err.message : String(err),
       });
     }


### PR DESCRIPTION
## Summary

Adds `sendMessage(channelId, { content, tts? })` on `DiscordConnector` and the matching `discord.send_message` recipe tool wrapper. Deferred follow-up to #80 (read-only Discord).

- POSTs to `/channels/{id}/messages` via `apiCall` (covers retry + 401 refresh)
- Validates non-empty `channelId` / `content`, enforces Discord's 2000-char content cap at the **connector** layer (not just the tool wrapper) so any internal caller is protected
- Forwards only `{ content, tts: tts ?? false }` — `embeds` and `allowed_mentions` deliberately deferred
- `normalizeError` 403 now points at the bot-scope requirement (see caveat below)
- New recipe tool: `discord.send_message`, `isWrite: true`, `riskDefault: "medium"`, `isConnector: true`. Returns the single-object `{ ok, id, channel_id, content, timestamp, error? }` shape consistent with #82 / #83.

## Caveat — bot scope required for writes

Discord's REST API does **not** allow user-context OAuth tokens to send messages on behalf of the user; only bot-scope tokens can hit `POST /channels/{id}/messages`. The connector currently authenticates as a regular user (`identify`, `guilds`, `messages.read`), so `sendMessage` will return `permission_denied` until operators re-authenticate with the `bot` scope. The method is wired correctly — the gap is purely the auth scope, intentionally left to operators to upgrade.

The 403 path's error message reflects this so it's actionable in the runner UI:

> "Discord write requires bot scope — re-authenticate with the bot scope to enable sendMessage."

## Test plan

- [x] `npm run build` — clean
- [x] `npx vitest run src/connectors/__tests__/discord.test.ts` — 23/23 pass (8 new write-path cases)
- [x] Full vitest suite — 4392/4392 pass
- [x] `npx biome check --write` on changed files — clean

New test coverage:
- happy path POST body shape (`{ content, tts: false }`)
- empty channelId / empty content / >2000-char content rejection
- 403 → `permission_denied` (exercises the bot-scope path)
- 404 → `not_found`
- explicit `tts: true` honored
- 401 → refresh → 200 retry on the write path

🤖 Generated with [Claude Code](https://claude.com/claude-code)