### PR TITLE
feat(connectors): Linear addComment

### DIFF
--- a/src/connectors/__tests__/linear.test.ts
+++ b/src/connectors/__tests__/linear.test.ts
@@ -14,11 +14,13 @@ vi.mock("node:fs", async (importOriginal) => {
 
 import * as fs from "node:fs";
 import {
+  addComment,
   getStatus,
   handleLinearDisconnect,
   handleLinearTest,
   loadTokens,
 } from "../linear.js";
+import { McpClient } from "../mcpClient.js";
 
 const MOCK_TOKEN_FILE = {
   vendor: "linear",
@@ -88,5 +90,88 @@ describe("handleLinearDisconnect", () => {
     vi.mocked(fs.existsSync).mockReturnValue(false);
     const result = await handleLinearDisconnect();
     expect(result.status).toBe(200);
+  });
+});
+
+describe("addComment", () => {
+  beforeEach(() => {
+    process.env.LINEAR_API_KEY = "lin_api_test";
+  });
+
+  it("calls create_comment MCP tool with correct args and unwraps comment", async () => {
+    const callTool = vi
+      .spyOn(McpClient.prototype, "callTool")
+      .mockResolvedValue({
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify({
+              id: "cmt-1",
+              body: "hello",
+              url: "https://linear.app/c/cmt-1",
+            }),
+          },
+        ],
+      } as never);
+
+    const result = await addComment("ENG-42", "hello");
+    expect(result.id).toBe("cmt-1");
+    expect(result.body).toBe("hello");
+    expect(callTool).toHaveBeenCalledWith(
+      "create_comment",
+      { issueId: "ENG-42", body: "hello" },
+      expect.any(Object),
+    );
+    callTool.mockRestore();
+  });
+
+  it("unwraps `comment` envelope when MCP returns wrapped shape", async () => {
+    const callTool = vi
+      .spyOn(McpClient.prototype, "callTool")
+      .mockResolvedValue({
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify({
+              comment: { id: "cmt-2", body: "nudge" },
+            }),
+          },
+        ],
+      } as never);
+    const result = await addComment("ENG-7", "nudge");
+    expect(result.id).toBe("cmt-2");
+    expect(result.body).toBe("nudge");
+    callTool.mockRestore();
+  });
+
+  it("rejects empty issueId", async () => {
+    await expect(addComment("", "hi")).rejects.toThrow(/issueId/i);
+    await expect(addComment("   ", "hi")).rejects.toThrow(/issueId/i);
+  });
+
+  it("rejects empty body", async () => {
+    await expect(addComment("ENG-42", "")).rejects.toThrow(/body/i);
+    await expect(addComment("ENG-42", "   ")).rejects.toThrow(/body/i);
+  });
+
+  it("rejects malformed issue ref before calling MCP", async () => {
+    const callTool = vi.spyOn(McpClient.prototype, "callTool");
+    await expect(addComment("not-an-issue", "hi")).rejects.toThrow(
+      /Cannot parse Linear issue ID/,
+    );
+    expect(callTool).not.toHaveBeenCalled();
+    callTool.mockRestore();
+  });
+
+  it("propagates MCP error (e.g. issue not found)", async () => {
+    const callTool = vi
+      .spyOn(McpClient.prototype, "callTool")
+      .mockRejectedValue(
+        new Error("tools/call create_comment: Entity not found: Issue"),
+      );
+    await expect(addComment("ENG-99999", "hi")).rejects.toThrow(
+      /Entity not found/,
+    );
+    callTool.mockRestore();
   });
 });

--- a/src/connectors/linear.ts
+++ b/src/connectors/linear.ts
@@ -390,6 +390,12 @@ export async function addComment(
   body: string,
   signal?: AbortSignal,
 ): Promise<{ id: string; body: string; url?: string }> {
+  if (!issueId || !issueId.trim()) {
+    throw new Error("addComment requires non-empty issueId");
+  }
+  if (!body || !body.trim()) {
+    throw new Error("addComment requires non-empty body");
+  }
   const id = extractIssueId(issueId);
   const res = await client().callTool(
     "create_comment",

--- a/src/recipes/tools/linear.ts
+++ b/src/recipes/tools/linear.ts
@@ -1,5 +1,6 @@
 /**
- * Linear tools — linear.list_issues, linear.createIssue, linear.updateIssue
+ * Linear tools — linear.list_issues, linear.createIssue, linear.updateIssue,
+ * linear.addComment.
  *
  * Self-registering tool module for the recipe tool registry.
  */
@@ -243,6 +244,82 @@ registerTool({
       return JSON.stringify(result);
     } catch (err) {
       return JSON.stringify({
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  },
+});
+
+// ============================================================================
+// linear.addComment  (write-gated)
+// ============================================================================
+
+registerTool({
+  id: "linear.addComment",
+  namespace: "linear",
+  description:
+    "Append a comment to a Linear issue's timeline. Body supports Markdown.",
+  paramsSchema: {
+    type: "object",
+    required: ["issue_id", "body"],
+    properties: {
+      issue_id: {
+        type: "string",
+        description: "Issue identifier (e.g., 'ENG-42'), UUID, or full URL",
+      },
+      body: {
+        type: "string",
+        description: "Comment body (Markdown supported, non-empty)",
+        minLength: 1,
+      },
+      into: CommonSchemas.into,
+    },
+  },
+  outputSchema: {
+    type: "object",
+    properties: {
+      ok: { type: "boolean" },
+      id: { type: "string" },
+      body: { type: "string" },
+      url: { type: "string" },
+      error: { type: "string" },
+    },
+  },
+  riskDefault: "low",
+  isWrite: true,
+  isConnector: true,
+  execute: async ({ params }) => {
+    const { loadTokens, addComment } = await import(
+      "../../connectors/linear.js"
+    );
+    if (!loadTokens()) {
+      return JSON.stringify({ ok: false, error: "Linear not connected" });
+    }
+    const issueId = typeof params.issue_id === "string" ? params.issue_id : "";
+    const body = typeof params.body === "string" ? params.body : "";
+    if (!issueId) {
+      return JSON.stringify({
+        ok: false,
+        error: "addComment requires issue_id",
+      });
+    }
+    if (!body) {
+      return JSON.stringify({
+        ok: false,
+        error: "addComment requires non-empty body",
+      });
+    }
+    try {
+      const comment = await addComment(issueId, body);
+      return JSON.stringify({
+        ok: true,
+        id: comment.id,
+        body: comment.body,
+        url: comment.url,
+      });
+    } catch (err) {
+      return JSON.stringify({
+        ok: false,
         error: err instanceof Error ? err.message : String(err),
       });
     }


### PR DESCRIPTION
## Summary

- Adds `linear.addComment` recipe tool wrapping the existing `addComment` connector method (calls Linear's MCP `create_comment`)
- Method now validates non-empty `issueId` and `body` before hitting the wire
- Fills the comment-on-issue gap that Asana (`add_task_comment`, #83) and PagerDuty already cover, enabling follow-up recipes (e.g. "Linear issue stale → add a nudge comment")

## Shape

- Tool id: `linear.addComment` (matches `linear.createIssue` / `linear.updateIssue` camelCase convention)
- `isWrite: true`, `riskDefault: "low"`, `isConnector: true`
- Required params: `issue_id`, `body`. Returns `{ok, id, body, url, error?}`

## Test plan

- [x] `npx vitest run src/connectors/__tests__/linear.test.ts` — 13 pass (6 new for `addComment`: arg shape, wrapped envelope, empty issueId, empty body, malformed-ref short-circuit, MCP error propagation)
- [x] Full `npx vitest run` — 4408 pass
- [x] `npm run build` — clean
- [x] `npx biome check --write` on changed files

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>