### PR TITLE
feat(connectors): add GitLab (read-only OAuth)

### DIFF
--- a/dashboard/src/app/api/connections/gitlab/callback/route.ts
+++ b/dashboard/src/app/api/connections/gitlab/callback/route.ts
@@ -1,0 +1,21 @@
+import { bridgeFetch } from "@/lib/bridge";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function GET(req: Request): Promise<Response> {
+  const url = new URL(req.url);
+  const allowed = ["code", "state", "error"];
+  const qs = new URLSearchParams();
+  for (const key of allowed) {
+    const v = url.searchParams.get(key);
+    if (v !== null) qs.set(key, v);
+  }
+
+  const res = await bridgeFetch(`/connections/gitlab/callback?${qs.toString()}`);
+  const body = await res.text();
+  return new Response(body, {
+    status: res.status,
+    headers: { "content-type": res.headers.get("content-type") ?? "application/json" },
+  });
+}

--- a/dashboard/src/app/connections/gitlab/callback/page.tsx
+++ b/dashboard/src/app/connections/gitlab/callback/page.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { Suspense, useEffect, useRef } from "react";
+import { apiPath } from '@/lib/api';
+import { useRouter, useSearchParams } from "next/navigation";
+
+function GitLabCallbackInner() {
+  const params = useSearchParams();
+  const router = useRouter();
+  const called = useRef(false);
+
+  useEffect(() => {
+    if (called.current) return;
+    called.current = true;
+
+    const code = params.get("code");
+    const state = params.get("state");
+    const error = params.get("error");
+
+    const qs = new URLSearchParams();
+    if (code) qs.set("code", code);
+    if (state) qs.set("state", state);
+    if (error) qs.set("error", error);
+
+    fetch(apiPath(`/api/connections/gitlab/callback?${qs.toString()}`))
+      .then((r) => r.json())
+      .then(() => {
+        if (window.opener) {
+          window.opener.postMessage("patchwork:gitlab:connected", window.location.origin);
+          window.close();
+        } else {
+          router.push("/connections");
+        }
+      })
+      .catch(() => router.push("/connections"));
+  }, [params, router]);
+
+  return <p>Connecting GitLab…</p>;
+}
+
+export default function GitLabCallbackPage() {
+  return (
+    <div style={{
+      display: "flex", alignItems: "center", justifyContent: "center",
+      minHeight: "100vh", background: "#040406", color: "#e0e0e0",
+      fontFamily: "system-ui, sans-serif",
+    }}>
+      <Suspense fallback={<p>Loading…</p>}>
+        <GitLabCallbackInner />
+      </Suspense>
+    </div>
+  );
+}

--- a/dashboard/src/app/connections/page.tsx
+++ b/dashboard/src/app/connections/page.tsx
@@ -101,6 +101,16 @@ function IconGitHub() {
   );
 }
 
+function IconGitlab() {
+  // Stylized geometric mark — three triangles converging on a center line.
+  return (
+    <svg width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden="true" style={{ flexShrink: 0 }}>
+      <path d="M10 17l-7-9 2-5 2 5h6l2-5 2 5z" stroke="currentColor" strokeWidth="1.5" strokeLinejoin="round" />
+      <path d="M10 17L7 8M10 17l3-9" stroke="currentColor" strokeWidth="1.5" strokeLinejoin="round" />
+    </svg>
+  );
+}
+
 function IconLinear() {
   return (
     <svg width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden="true" style={{ flexShrink: 0 }}>
@@ -245,6 +255,7 @@ const SUPPORTED_CONNECTORS = new Set([
   "google-calendar",
   "google-drive",
   "github",
+  "gitlab",
   "linear",
   "sentry",
   "slack",
@@ -393,6 +404,7 @@ const PROVIDERS: {
 }[] = [
   { id: "gmail",           name: "Gmail",           description: "Read and triage your inbox.",                                                                     icon: IconEnvelope },
   { id: "github",          name: "GitHub",          description: "Read open issues and pull requests via GitHub's official MCP server.",                             icon: IconGitHub },
+  { id: "gitlab",          name: "GitLab",          description: "Read projects, issues, and merge requests.",                                                       icon: IconGitlab },
   { id: "linear",          name: "Linear",          description: "Read and manage issues.",                                                                          icon: IconLinear },
   { id: "slack",           name: "Slack",           description: "Post messages and list channels.",                                                                  icon: IconSlack },
   { id: "discord",         name: "Discord",         description: "Read messages, channels, and guilds.",                                                              icon: IconDiscord },

--- a/src/connectors/__tests__/gitlab.test.ts
+++ b/src/connectors/__tests__/gitlab.test.ts
@@ -1,0 +1,414 @@
+import { existsSync, mkdirSync, rmSync } from "node:fs";
+import os from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+function makeJsonResponse(
+  body: unknown,
+  status = 200,
+  headers: Record<string, string> = {},
+) {
+  const r = {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+    clone() {
+      return this;
+    },
+    headers: {
+      get: (k: string) => headers[k.toLowerCase()] ?? headers[k] ?? null,
+    },
+  };
+  Object.setPrototypeOf(r, Response.prototype);
+  return r;
+}
+
+function mockAuthenticate(conn: { authenticate?: unknown }) {
+  vi.spyOn(
+    conn as unknown as {
+      authenticate: () => Promise<{ token: string; scopes: string[] }>;
+    },
+    "authenticate",
+  ).mockResolvedValue({ token: "k", scopes: [] });
+}
+
+// ── Token storage ────────────────────────────────────────────────────────────
+
+describe("gitlab token storage", () => {
+  const tmpDir = join(os.tmpdir(), `patchwork-gitlab-${Date.now()}`);
+  const homeDir = join(tmpDir, "home");
+  const patchworkHome = join(homeDir, ".patchwork");
+  const tokensDir = join(patchworkHome, "tokens");
+
+  beforeEach(() => {
+    process.env.HOME = homeDir;
+    process.env.PATCHWORK_HOME = patchworkHome;
+    process.env.PATCHWORK_TOKEN_STORAGE_BACKEND = "file";
+    mkdirSync(tokensDir, { recursive: true });
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    delete process.env.HOME;
+    delete process.env.PATCHWORK_HOME;
+    delete process.env.PATCHWORK_TOKEN_STORAGE_BACKEND;
+    delete process.env.GITLAB_CLIENT_ID;
+    delete process.env.GITLAB_CLIENT_SECRET;
+    delete process.env.GITLAB_BASE_URL;
+    if (existsSync(tmpDir)) rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("loadTokens returns null when nothing stored", async () => {
+    const { loadTokens } = await import("../gitlab.js");
+    expect(loadTokens()).toBeNull();
+  });
+
+  it("save + load round-trips", async () => {
+    const { loadTokens, saveTokens } = await import("../gitlab.js");
+    saveTokens({
+      access_token: "gl-access",
+      refresh_token: "gl-refresh",
+      username: "alice",
+      user_id: 42,
+      connected_at: "2026-04-29T00:00:00.000Z",
+    });
+    const loaded = loadTokens();
+    expect(loaded).toMatchObject({
+      access_token: "gl-access",
+      refresh_token: "gl-refresh",
+      username: "alice",
+    });
+  });
+});
+
+// ── healthCheck ──────────────────────────────────────────────────────────────
+
+describe("GitLabConnector.healthCheck", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("returns ok:true on 200", async () => {
+    global.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        makeJsonResponse({ id: 1, username: "alice" }),
+      ) as unknown as typeof fetch;
+
+    const { GitLabConnector } = await import("../gitlab.js");
+    const conn = new GitLabConnector();
+    mockAuthenticate(conn);
+
+    const result = await conn.healthCheck();
+    expect(result.ok).toBe(true);
+  });
+
+  it("returns ok:false with auth_expired on 401", async () => {
+    const r = makeJsonResponse({}, 401);
+    global.fetch = vi.fn().mockResolvedValue(r) as unknown as typeof fetch;
+
+    const { GitLabConnector } = await import("../gitlab.js");
+    const conn = new GitLabConnector();
+    mockAuthenticate(conn);
+
+    const result = await conn.healthCheck();
+    expect(result.ok).toBe(false);
+    expect(result.error?.code).toBe("auth_expired");
+  });
+});
+
+// ── listProjects ─────────────────────────────────────────────────────────────
+
+describe("GitLabConnector.listProjects", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("defaults to membership=true", async () => {
+    const fetchSpy = vi
+      .fn()
+      .mockResolvedValueOnce(
+        makeJsonResponse([{ id: 1, name: "p", path_with_namespace: "g/p" }]),
+      );
+    global.fetch = fetchSpy as unknown as typeof fetch;
+
+    const { GitLabConnector } = await import("../gitlab.js");
+    const conn = new GitLabConnector();
+    mockAuthenticate(conn);
+
+    const projects = await conn.listProjects();
+    expect(projects).toHaveLength(1);
+    const url = String(fetchSpy.mock.calls[0]?.[0] ?? "");
+    expect(url).toContain("membership=true");
+    expect(url).toContain("/api/v4/projects");
+  });
+});
+
+// ── listIssues ───────────────────────────────────────────────────────────────
+
+describe("GitLabConnector.listIssues", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("with assignedToMe + no projectId hits /issues with scope=assigned_to_me", async () => {
+    const fetchSpy = vi
+      .fn()
+      .mockResolvedValueOnce(
+        makeJsonResponse([
+          { id: 5, iid: 1, project_id: 9, title: "x", state: "opened" },
+        ]),
+      );
+    global.fetch = fetchSpy as unknown as typeof fetch;
+
+    const { GitLabConnector } = await import("../gitlab.js");
+    const conn = new GitLabConnector();
+    mockAuthenticate(conn);
+
+    const issues = await conn.listIssues({ assignedToMe: true });
+    expect(issues).toHaveLength(1);
+    const url = String(fetchSpy.mock.calls[0]?.[0] ?? "");
+    expect(url).toMatch(/\/api\/v4\/issues\?/);
+    expect(url).toContain("scope=assigned_to_me");
+  });
+
+  it("rejects invalid state value", async () => {
+    const { GitLabConnector } = await import("../gitlab.js");
+    const conn = new GitLabConnector();
+    await expect(
+      conn.listIssues({ state: "bogus" as unknown as "opened" }),
+    ).rejects.toThrow(/state/);
+  });
+});
+
+// ── getIssue ─────────────────────────────────────────────────────────────────
+
+describe("GitLabConnector.getIssue", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("normalizes 404 into not_found", async () => {
+    const r = makeJsonResponse({}, 404);
+    global.fetch = vi.fn().mockResolvedValue(r) as unknown as typeof fetch;
+
+    const { GitLabConnector } = await import("../gitlab.js");
+    const conn = new GitLabConnector();
+    mockAuthenticate(conn);
+
+    await expect(conn.getIssue("group/repo", 999)).rejects.toThrow(
+      /not found/i,
+    );
+  });
+});
+
+// ── listMergeRequests ────────────────────────────────────────────────────────
+
+describe("GitLabConnector.listMergeRequests", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("happy path with projectId hits project MR endpoint", async () => {
+    const fetchSpy = vi
+      .fn()
+      .mockResolvedValueOnce(
+        makeJsonResponse([
+          { id: 11, iid: 2, project_id: 7, title: "mr", state: "opened" },
+        ]),
+      );
+    global.fetch = fetchSpy as unknown as typeof fetch;
+
+    const { GitLabConnector } = await import("../gitlab.js");
+    const conn = new GitLabConnector();
+    mockAuthenticate(conn);
+
+    const mrs = await conn.listMergeRequests({ projectId: 7, state: "opened" });
+    expect(mrs).toHaveLength(1);
+    const url = String(fetchSpy.mock.calls[0]?.[0] ?? "");
+    expect(url).toContain("/api/v4/projects/7/merge_requests");
+    expect(url).toContain("state=opened");
+  });
+});
+
+// ── 429 rate-limited ─────────────────────────────────────────────────────────
+
+describe("GitLabConnector 429 handling", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("normalizes 429 with Retry-After into rate_limited", async () => {
+    const make429 = () => makeJsonResponse({}, 429, { "retry-after": "30" });
+    global.fetch = vi
+      .fn()
+      .mockImplementation(async () => make429()) as unknown as typeof fetch;
+
+    const { GitLabConnector } = await import("../gitlab.js");
+    const conn = new GitLabConnector();
+    mockAuthenticate(conn);
+
+    const result = await conn.healthCheck();
+    expect(result.ok).toBe(false);
+    expect(result.error?.code).toBe("rate_limited");
+    expect(result.error?.message).toContain("30");
+  }, 30_000);
+});
+
+// ── GITLAB_BASE_URL override ─────────────────────────────────────────────────
+
+describe("GitLabConnector self-hosted base URL", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    delete process.env.GITLAB_BASE_URL;
+  });
+
+  it("GITLAB_BASE_URL changes the request URL", async () => {
+    process.env.GITLAB_BASE_URL = "https://gitlab.example.com";
+
+    const fetchSpy = vi
+      .fn()
+      .mockResolvedValueOnce(makeJsonResponse({ id: 1, username: "alice" }));
+    global.fetch = fetchSpy as unknown as typeof fetch;
+
+    const { GitLabConnector } = await import("../gitlab.js");
+    const conn = new GitLabConnector();
+    mockAuthenticate(conn);
+
+    await conn.getCurrentUser();
+    const url = String(fetchSpy.mock.calls[0]?.[0] ?? "");
+    expect(url).toBe("https://gitlab.example.com/api/v4/user");
+  });
+});
+
+// ── Token refresh on 401 ─────────────────────────────────────────────────────
+
+describe("GitLabConnector token refresh on 401", () => {
+  const tmpDir = join(os.tmpdir(), `patchwork-gitlab-refresh-${Date.now()}`);
+  const homeDir = join(tmpDir, "home");
+  const patchworkHome = join(homeDir, ".patchwork");
+  const tokensDir = join(patchworkHome, "tokens");
+
+  beforeEach(() => {
+    process.env.HOME = homeDir;
+    process.env.PATCHWORK_HOME = patchworkHome;
+    process.env.PATCHWORK_TOKEN_STORAGE_BACKEND = "file";
+    process.env.GITLAB_CLIENT_ID = "cid";
+    process.env.GITLAB_CLIENT_SECRET = "csecret";
+    mkdirSync(tokensDir, { recursive: true });
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    delete process.env.HOME;
+    delete process.env.PATCHWORK_HOME;
+    delete process.env.PATCHWORK_TOKEN_STORAGE_BACKEND;
+    delete process.env.GITLAB_CLIENT_ID;
+    delete process.env.GITLAB_CLIENT_SECRET;
+    if (existsSync(tmpDir)) rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("on 401, refreshes token and retries the API call once", async () => {
+    const expired = makeJsonResponse({}, 401);
+
+    const fetchSpy = vi
+      .fn()
+      .mockResolvedValueOnce(expired)
+      .mockResolvedValueOnce(
+        makeJsonResponse({
+          access_token: "new-access",
+          refresh_token: "new-refresh",
+          expires_in: 7200,
+          scope: "read_user read_api read_repository",
+          token_type: "Bearer",
+        }),
+      )
+      .mockResolvedValueOnce(makeJsonResponse({ id: 1, username: "alice" }));
+
+    global.fetch = fetchSpy as unknown as typeof fetch;
+
+    const { GitLabConnector, saveTokens, loadTokens } = await import(
+      "../gitlab.js"
+    );
+    saveTokens({
+      access_token: "stale-access",
+      refresh_token: "stale-refresh",
+      expires_at: Date.now() + 60_000,
+      scope: "read_user read_api read_repository",
+      token_type: "Bearer",
+      _client_id: "cid",
+      _client_secret: "csecret",
+      connected_at: new Date().toISOString(),
+    });
+
+    const conn = new GitLabConnector();
+    const result = await conn.healthCheck();
+
+    expect(result.ok).toBe(true);
+    expect(fetchSpy).toHaveBeenCalledTimes(3);
+    const url1 = String(fetchSpy.mock.calls[0]?.[0] ?? "");
+    const url2 = String(fetchSpy.mock.calls[1]?.[0] ?? "");
+    const url3 = String(fetchSpy.mock.calls[2]?.[0] ?? "");
+    expect(url1).toContain("/user");
+    expect(url2).toContain("/oauth/token");
+    expect(url3).toContain("/user");
+
+    const stored = loadTokens();
+    expect(stored?.access_token).toBe("new-access");
+    expect(stored?.refresh_token).toBe("new-refresh");
+  });
+});
+
+// ── HTTP handlers ────────────────────────────────────────────────────────────
+
+describe("handleGitLabAuthorize", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    delete process.env.GITLAB_CLIENT_ID;
+    delete process.env.GITLAB_CLIENT_SECRET;
+    delete process.env.GITLAB_BASE_URL;
+  });
+
+  it("returns 503 when env vars not set", async () => {
+    const { handleGitLabAuthorize } = await import("../gitlab.js");
+    const result = handleGitLabAuthorize();
+    expect(result.status).toBe(503);
+    const body = JSON.parse(result.body);
+    expect(body.error).toMatch(/GITLAB_CLIENT_ID/);
+  });
+
+  it("returns 302 redirect with state when configured", async () => {
+    process.env.GITLAB_CLIENT_ID = "cid";
+    process.env.GITLAB_CLIENT_SECRET = "csecret";
+    const { handleGitLabAuthorize } = await import("../gitlab.js");
+    const result = handleGitLabAuthorize();
+    expect(result.status).toBe(302);
+    expect(result.redirect).toMatch(
+      /^https:\/\/gitlab\.com\/oauth\/authorize\?/,
+    );
+    const url = new URL(result.redirect ?? "");
+    expect(url.searchParams.get("client_id")).toBe("cid");
+    expect(url.searchParams.get("response_type")).toBe("code");
+    expect(url.searchParams.get("scope")).toBe(
+      "read_user read_api read_repository",
+    );
+    expect(url.searchParams.get("state")).toBeTruthy();
+  });
+
+  it("authorize URL respects GITLAB_BASE_URL", async () => {
+    process.env.GITLAB_CLIENT_ID = "cid";
+    process.env.GITLAB_CLIENT_SECRET = "csecret";
+    process.env.GITLAB_BASE_URL = "https://gitlab.example.com";
+    const { handleGitLabAuthorize } = await import("../gitlab.js");
+    const result = handleGitLabAuthorize();
+    expect(result.redirect).toMatch(
+      /^https:\/\/gitlab\.example\.com\/oauth\/authorize\?/,
+    );
+  });
+});

--- a/src/connectors/gitlab.ts
+++ b/src/connectors/gitlab.ts
@@ -1,0 +1,757 @@
+/**
+ * GitLab connector — read-only: projects, issues, merge requests, current user.
+ *
+ * OAuth 2.0 Authorization Code Grant. GitLab is a confidential client (bridge
+ * holds client secret), so PKCE is not used here. Refresh tokens are issued;
+ * access tokens default to 2 hours.
+ *
+ * Auth: standard OAuth 2.0 with `client_id` + `client_secret` + `redirect_uri`.
+ *   - Env vars: GITLAB_CLIENT_ID, GITLAB_CLIENT_SECRET (mirrors asana/discord)
+ *   - Optional: GITLAB_BASE_URL — override base for self-hosted GitLab.
+ *               Default https://gitlab.com. `/api/v4` is appended internally.
+ *   - Stored: getSecretJsonSync("gitlab") → GitLabTokens
+ *   - Header: Authorization: Bearer <access_token>
+ *
+ * Read-only scopes: read_user read_api read_repository.
+ *
+ * Read tools: getCurrentUser, listProjects, listIssues, getIssue,
+ *   listMergeRequests.
+ * Write methods (createIssue, createMergeRequestNote) are deferred to a
+ * follow-up PR.
+ *
+ * HTTP routes (wired in src/server.ts):
+ *   GET    /connections/gitlab/auth     — redirect to GitLab consent
+ *   GET    /connections/gitlab/callback — exchange code for tokens
+ *   POST   /connections/gitlab/test     — ping GitLab API
+ *   DELETE /connections/gitlab          — best-effort revoke + clear local
+ *
+ * Extends BaseConnector for unified auth, retry, rate-limit, error handling.
+ * Token refresh is delegated to BaseConnector.refreshToken() via apiCall.
+ */
+
+import crypto from "node:crypto";
+import {
+  type AuthContext,
+  BaseConnector,
+  type ConnectorError,
+  type ConnectorStatus,
+  type OAuthConfig,
+} from "./baseConnector.js";
+import { escHtml } from "./htmlEscape.js";
+import {
+  deleteSecretJsonSync,
+  getSecretJsonSync,
+  storeSecretJsonSync,
+} from "./tokenStorage.js";
+
+const SCOPES = ["read_user", "read_api", "read_repository"];
+
+// ── Config ───────────────────────────────────────────────────────────────────
+
+function clientId(): string {
+  return process.env.GITLAB_CLIENT_ID ?? "";
+}
+
+function clientSecret(): string {
+  return process.env.GITLAB_CLIENT_SECRET ?? "";
+}
+
+/**
+ * Base host for the GitLab instance, e.g. `https://gitlab.com` (default) or
+ * `https://gitlab.example.com` for self-hosted. Trailing slash trimmed; the
+ * `/api/v4` path is appended internally so users only configure host.
+ */
+export function gitlabBaseUrl(): string {
+  return (process.env.GITLAB_BASE_URL ?? "https://gitlab.com").replace(
+    /\/$/,
+    "",
+  );
+}
+
+function apiBase(): string {
+  return `${gitlabBaseUrl()}/api/v4`;
+}
+
+function authorizeUrl(): string {
+  return `${gitlabBaseUrl()}/oauth/authorize`;
+}
+
+function tokenUrl(): string {
+  return `${gitlabBaseUrl()}/oauth/token`;
+}
+
+function revokeUrl(): string {
+  return `${gitlabBaseUrl()}/oauth/revoke`;
+}
+
+function redirectUri(): string {
+  const base = (
+    process.env.PATCHWORK_BRIDGE_URL ??
+    `http://localhost:${process.env.PATCHWORK_BRIDGE_PORT ?? "3101"}`
+  ).replace(/\/$/, "");
+  return `${base}/connections/gitlab/callback`;
+}
+
+function isConfigured(): boolean {
+  return Boolean(clientId() && clientSecret());
+}
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export interface GitLabTokens {
+  access_token: string;
+  refresh_token?: string;
+  /** ms since epoch; absolute, not relative */
+  expires_at?: number;
+  scope?: string;
+  token_type?: string;
+  /** stored at auth time so refresh works even if env vars are absent */
+  _client_id?: string;
+  _client_secret?: string;
+  /** snapshot of base URL at connect time so refresh hits the right host */
+  _base_url?: string;
+  username?: string;
+  user_id?: number;
+  email?: string;
+  connected_at: string;
+}
+
+export interface GitLabUser {
+  id: number;
+  username: string;
+  name?: string;
+  email?: string;
+  avatar_url?: string | null;
+}
+
+export interface GitLabProject {
+  id: number;
+  name: string;
+  path_with_namespace: string;
+  description?: string | null;
+  web_url?: string;
+  default_branch?: string | null;
+  visibility?: string;
+  archived?: boolean;
+}
+
+export interface GitLabIssue {
+  id: number;
+  iid: number;
+  project_id: number;
+  title: string;
+  description?: string | null;
+  state: string;
+  web_url?: string;
+  author?: { id: number; username: string; name?: string };
+  assignees?: Array<{ id: number; username: string; name?: string }>;
+  labels?: string[];
+  created_at?: string;
+  updated_at?: string;
+}
+
+export interface GitLabMergeRequest {
+  id: number;
+  iid: number;
+  project_id: number;
+  title: string;
+  description?: string | null;
+  state: string;
+  source_branch?: string;
+  target_branch?: string;
+  web_url?: string;
+  author?: { id: number; username: string; name?: string };
+  draft?: boolean;
+  merge_status?: string;
+  created_at?: string;
+  updated_at?: string;
+}
+
+// ── Token persistence ────────────────────────────────────────────────────────
+
+export function loadTokens(): GitLabTokens | null {
+  return getSecretJsonSync<GitLabTokens>("gitlab");
+}
+
+export function saveTokens(tokens: GitLabTokens): void {
+  storeSecretJsonSync("gitlab", tokens);
+}
+
+export function clearTokens(): void {
+  try {
+    deleteSecretJsonSync("gitlab");
+  } catch {
+    // ignore
+  }
+}
+
+export function isConnected(): boolean {
+  return loadTokens() !== null;
+}
+
+// ── State (CSRF) ─────────────────────────────────────────────────────────────
+
+const pendingStates = new Set<string>();
+const STATE_TTL_MS = 5 * 60 * 1000;
+
+function generateState(): string {
+  const state = crypto.randomBytes(32).toString("hex");
+  pendingStates.add(state);
+  setTimeout(() => pendingStates.delete(state), STATE_TTL_MS);
+  return state;
+}
+
+function consumeState(state: string): boolean {
+  if (!pendingStates.has(state)) return false;
+  pendingStates.delete(state);
+  return true;
+}
+
+// ── Connector class ──────────────────────────────────────────────────────────
+
+export class GitLabConnector extends BaseConnector {
+  readonly providerName = "gitlab";
+
+  protected getOAuthConfig(): OAuthConfig | null {
+    const tokens = loadTokens();
+    const id = clientId() || tokens?._client_id || "";
+    const secret = clientSecret() || tokens?._client_secret || "";
+    if (!id || !secret) return null;
+    return {
+      clientId: id,
+      clientSecret: secret,
+      tokenEndpoint: tokenUrl(),
+      scopes: SCOPES,
+    };
+  }
+
+  async authenticate(): Promise<AuthContext> {
+    const tokens = loadTokens();
+    if (!tokens) {
+      throw new Error(
+        "GitLab not connected. Visit /connections/gitlab/auth to authorize.",
+      );
+    }
+    return {
+      token: tokens.access_token,
+      refreshToken: tokens.refresh_token,
+      expiresAt: tokens.expires_at ? new Date(tokens.expires_at) : undefined,
+      scopes: tokens.scope ? tokens.scope.split(" ") : SCOPES,
+    };
+  }
+
+  /**
+   * Persist refreshed tokens after BaseConnector.refreshToken() updates
+   * `this.auth`. Mirror to our GitLab-specific JSON so loadTokens() keeps
+   * working for HTTP probes.
+   */
+  override async saveTokens(): Promise<void> {
+    await super.saveTokens();
+    if (!this.auth) return;
+    const existing = loadTokens();
+    saveTokens({
+      access_token: this.auth.token,
+      refresh_token: this.auth.refreshToken,
+      expires_at: this.auth.expiresAt
+        ? this.auth.expiresAt.getTime()
+        : undefined,
+      scope: this.auth.scopes?.join(" "),
+      token_type: existing?.token_type ?? "Bearer",
+      _client_id: existing?._client_id,
+      _client_secret: existing?._client_secret,
+      _base_url: existing?._base_url,
+      username: existing?.username,
+      user_id: existing?.user_id,
+      email: existing?.email,
+      connected_at: existing?.connected_at ?? new Date().toISOString(),
+    });
+  }
+
+  async healthCheck(): Promise<{ ok: boolean; error?: ConnectorError }> {
+    try {
+      const result = await this.apiCall(async (token) => {
+        const res = await fetch(`${apiBase()}/user`, {
+          headers: this.buildHeaders(token),
+        });
+        if (!res.ok) throw res;
+        return res.json();
+      });
+      if ("error" in result) return { ok: false, error: result.error };
+      return { ok: true };
+    } catch (err) {
+      return { ok: false, error: this.normalizeError(err) };
+    }
+  }
+
+  normalizeError(error: unknown): ConnectorError {
+    if (error instanceof Response) {
+      const s = error.status;
+      if (s === 401)
+        return {
+          code: "auth_expired",
+          message: "GitLab authentication failed — token expired or revoked",
+          retryable: true,
+          suggestedAction: "Reconnect via /connections/gitlab/auth",
+        };
+      if (s === 403)
+        return {
+          code: "permission_denied",
+          message: "Insufficient GitLab permissions for this resource",
+          retryable: false,
+        };
+      if (s === 404)
+        return {
+          code: "not_found",
+          message: "GitLab resource not found",
+          retryable: false,
+        };
+      if (s === 429) {
+        const reset = error.headers.get("ratelimit-reset");
+        const retryAfter = error.headers.get("retry-after");
+        return {
+          code: "rate_limited",
+          message: `GitLab API rate limit exceeded${retryAfter ? ` (retry after ${retryAfter}s)` : ""}`,
+          retryable: true,
+          suggestedAction: retryAfter
+            ? `Wait ${retryAfter}s and retry`
+            : "Wait and retry",
+          providerDetail: {
+            ...(retryAfter ? { retryAfter } : {}),
+            ...(reset ? { reset } : {}),
+          },
+        };
+      }
+      return {
+        code: "provider_error",
+        message: `GitLab API error: HTTP ${s}`,
+        retryable: s >= 500,
+      };
+    }
+    if (error instanceof Error) {
+      if (
+        error.message.includes("ENOTFOUND") ||
+        error.message.includes("ECONNREFUSED")
+      ) {
+        return {
+          code: "network_error",
+          message: `Cannot connect to GitLab: ${error.message}`,
+          retryable: true,
+        };
+      }
+    }
+    return {
+      code: "provider_error",
+      message: error instanceof Error ? error.message : String(error),
+      retryable: false,
+    };
+  }
+
+  getStatus(): ConnectorStatus {
+    const tokens = loadTokens();
+    return {
+      id: "gitlab",
+      status: tokens ? "connected" : "disconnected",
+      lastSync: tokens?.connected_at,
+      workspace: tokens?.username,
+    };
+  }
+
+  // ── API Methods ────────────────────────────────────────────────────────────
+
+  async getCurrentUser(): Promise<GitLabUser> {
+    const result = await this.apiCall(async (token) => {
+      const res = await fetch(`${apiBase()}/user`, {
+        headers: this.buildHeaders(token),
+      });
+      this.captureRateLimit(res);
+      if (!res.ok) throw res;
+      return res.json() as Promise<GitLabUser>;
+    });
+
+    if ("error" in result) throw new Error(result.error.message);
+    return result.data as GitLabUser;
+  }
+
+  async listProjects(
+    params: {
+      membership?: boolean;
+      owned?: boolean;
+      search?: string;
+      limit?: number;
+    } = {},
+  ): Promise<GitLabProject[]> {
+    const limit = Math.min(Math.max(params.limit ?? 50, 1), 100);
+    const result = await this.apiCall(async (token) => {
+      const qs = new URLSearchParams({
+        per_page: String(limit),
+        // Default to membership=true so users only see their projects unless
+        // they explicitly opt out (e.g. for public-search use cases).
+        membership: String(params.membership ?? true),
+      });
+      if (params.owned) qs.set("owned", "true");
+      if (params.search) qs.set("search", params.search);
+      const res = await fetch(`${apiBase()}/projects?${qs}`, {
+        headers: this.buildHeaders(token),
+      });
+      this.captureRateLimit(res);
+      if (!res.ok) throw res;
+      return res.json() as Promise<GitLabProject[]>;
+    });
+
+    if ("error" in result) throw new Error(result.error.message);
+    return result.data as GitLabProject[];
+  }
+
+  async listIssues(
+    params: {
+      projectId?: string | number;
+      assignedToMe?: boolean;
+      state?: "opened" | "closed" | "all";
+      limit?: number;
+    } = {},
+  ): Promise<GitLabIssue[]> {
+    if (params.state && !["opened", "closed", "all"].includes(params.state)) {
+      throw new Error(
+        `listIssues: invalid state "${params.state}" (expected opened|closed|all)`,
+      );
+    }
+    const limit = Math.min(Math.max(params.limit ?? 50, 1), 100);
+    const result = await this.apiCall(async (token) => {
+      const qs = new URLSearchParams({ per_page: String(limit) });
+      if (params.state) qs.set("state", params.state);
+      let url: string;
+      if (params.projectId !== undefined && params.projectId !== "") {
+        url = `${apiBase()}/projects/${encodeURIComponent(String(params.projectId))}/issues?${qs}`;
+      } else {
+        // Per-user issues endpoint. `assigned_to_me` is the default when
+        // `assignedToMe: true`; otherwise it returns issues created by user.
+        if (params.assignedToMe) qs.set("scope", "assigned_to_me");
+        url = `${apiBase()}/issues?${qs}`;
+      }
+      const res = await fetch(url, { headers: this.buildHeaders(token) });
+      this.captureRateLimit(res);
+      if (!res.ok) throw res;
+      return res.json() as Promise<GitLabIssue[]>;
+    });
+
+    if ("error" in result) throw new Error(result.error.message);
+    return result.data as GitLabIssue[];
+  }
+
+  async getIssue(
+    projectId: string | number,
+    issueIid: number,
+  ): Promise<GitLabIssue> {
+    if (projectId === undefined || projectId === "" || !issueIid) {
+      throw new Error("getIssue requires projectId and issueIid");
+    }
+    const result = await this.apiCall(async (token) => {
+      const res = await fetch(
+        `${apiBase()}/projects/${encodeURIComponent(String(projectId))}/issues/${issueIid}`,
+        { headers: this.buildHeaders(token) },
+      );
+      this.captureRateLimit(res);
+      if (!res.ok) throw res;
+      return res.json() as Promise<GitLabIssue>;
+    });
+
+    if ("error" in result) throw new Error(result.error.message);
+    return result.data as GitLabIssue;
+  }
+
+  async listMergeRequests(
+    params: {
+      projectId?: string | number;
+      state?: "opened" | "closed" | "merged" | "all";
+      scope?: "created_by_me" | "assigned_to_me" | "all";
+      limit?: number;
+    } = {},
+  ): Promise<GitLabMergeRequest[]> {
+    if (
+      params.state &&
+      !["opened", "closed", "merged", "all"].includes(params.state)
+    ) {
+      throw new Error(
+        `listMergeRequests: invalid state "${params.state}" (expected opened|closed|merged|all)`,
+      );
+    }
+    const limit = Math.min(Math.max(params.limit ?? 50, 1), 100);
+    const result = await this.apiCall(async (token) => {
+      const qs = new URLSearchParams({ per_page: String(limit) });
+      if (params.state) qs.set("state", params.state);
+      if (params.scope) qs.set("scope", params.scope);
+      let url: string;
+      if (params.projectId !== undefined && params.projectId !== "") {
+        url = `${apiBase()}/projects/${encodeURIComponent(String(params.projectId))}/merge_requests?${qs}`;
+      } else {
+        url = `${apiBase()}/merge_requests?${qs}`;
+      }
+      const res = await fetch(url, { headers: this.buildHeaders(token) });
+      this.captureRateLimit(res);
+      if (!res.ok) throw res;
+      return res.json() as Promise<GitLabMergeRequest[]>;
+    });
+
+    if ("error" in result) throw new Error(result.error.message);
+    return result.data as GitLabMergeRequest[];
+  }
+
+  // ── Helpers ────────────────────────────────────────────────────────────────
+
+  private buildHeaders(token: string): Record<string, string> {
+    return {
+      Authorization: `Bearer ${token}`,
+      Accept: "application/json",
+      "Content-Type": "application/json",
+    };
+  }
+
+  private captureRateLimit(res: Response): void {
+    this.updateRateLimitFromHeaders({
+      "x-ratelimit-remaining":
+        res.headers.get("ratelimit-remaining") ??
+        res.headers.get("x-ratelimit-remaining") ??
+        undefined,
+      "x-ratelimit-reset":
+        res.headers.get("ratelimit-reset") ??
+        res.headers.get("x-ratelimit-reset") ??
+        undefined,
+      "retry-after": res.headers.get("retry-after") ?? undefined,
+    });
+  }
+}
+
+// ── Singleton ────────────────────────────────────────────────────────────────
+
+let _instance: GitLabConnector | null = null;
+
+function resetGitLabConnector(): void {
+  _instance = null;
+}
+
+export function getGitLabConnector(): GitLabConnector {
+  if (!_instance) {
+    _instance = new GitLabConnector();
+  }
+  return _instance;
+}
+
+export { getGitLabConnector as gitlab };
+
+// ── HTTP Handlers ────────────────────────────────────────────────────────────
+
+export interface ConnectorHandlerResult {
+  status: number;
+  body: string;
+  contentType?: string;
+  redirect?: string;
+}
+
+/**
+ * GET /connections/gitlab/auth — redirect to GitLab consent screen.
+ */
+export function handleGitLabAuthorize(): ConnectorHandlerResult {
+  if (!isConfigured()) {
+    return {
+      status: 503,
+      contentType: "application/json",
+      body: JSON.stringify({
+        ok: false,
+        error:
+          "GitLab connector not configured. Set GITLAB_CLIENT_ID and GITLAB_CLIENT_SECRET.",
+      }),
+    };
+  }
+  const state = generateState();
+  const params = new URLSearchParams({
+    client_id: clientId(),
+    redirect_uri: redirectUri(),
+    response_type: "code",
+    scope: SCOPES.join(" "),
+    state,
+  });
+  return {
+    status: 302,
+    body: "",
+    redirect: `${authorizeUrl()}?${params.toString()}`,
+  };
+}
+
+/**
+ * GET /connections/gitlab/callback — exchange code for tokens.
+ */
+export async function handleGitLabCallback(
+  code: string | null,
+  state: string | null,
+  error: string | null,
+): Promise<ConnectorHandlerResult> {
+  if (error) {
+    return {
+      status: 400,
+      contentType: "text/html",
+      body: `<html><body><h2>GitLab connect failed</h2><pre>${escHtml(error)}</pre></body></html>`,
+    };
+  }
+  if (!code || !state) {
+    return {
+      status: 400,
+      contentType: "text/html",
+      body: `<html><body><h2>GitLab connect failed</h2><pre>missing code or state</pre></body></html>`,
+    };
+  }
+  if (!consumeState(state)) {
+    return {
+      status: 400,
+      contentType: "text/html",
+      body: `<html><body><h2>GitLab connect failed</h2><pre>invalid or expired state</pre></body></html>`,
+    };
+  }
+
+  try {
+    const params = new URLSearchParams({
+      grant_type: "authorization_code",
+      code,
+      redirect_uri: redirectUri(),
+      client_id: clientId(),
+      client_secret: clientSecret(),
+    });
+    const res = await fetch(tokenUrl(), {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        Accept: "application/json",
+      },
+      body: params.toString(),
+    });
+    if (!res.ok) {
+      const body = await res.text();
+      throw new Error(`Token exchange HTTP ${res.status}: ${body}`);
+    }
+    const json = (await res.json()) as {
+      access_token?: string;
+      refresh_token?: string;
+      expires_in?: number;
+      scope?: string;
+      token_type?: string;
+    };
+    if (!json.access_token) {
+      throw new Error("Token exchange returned no access_token");
+    }
+
+    // Best-effort fetch of user info so the dashboard can show "connected as X".
+    let username: string | undefined;
+    let userId: number | undefined;
+    let userEmail: string | undefined;
+    try {
+      const userRes = await fetch(`${apiBase()}/user`, {
+        headers: { Authorization: `Bearer ${json.access_token}` },
+      });
+      if (userRes.ok) {
+        const u = (await userRes.json()) as GitLabUser;
+        username = u.name ?? u.username;
+        userId = u.id;
+        userEmail = u.email;
+      }
+    } catch {
+      // best-effort
+    }
+
+    const expiresAt =
+      typeof json.expires_in === "number" && json.expires_in > 0
+        ? Date.now() + json.expires_in * 1000
+        : undefined;
+
+    saveTokens({
+      access_token: json.access_token,
+      refresh_token: json.refresh_token,
+      expires_at: expiresAt,
+      scope: json.scope,
+      token_type: json.token_type ?? "Bearer",
+      _client_id: clientId() || undefined,
+      _client_secret: clientSecret() || undefined,
+      _base_url: gitlabBaseUrl(),
+      username,
+      user_id: userId,
+      email: userEmail,
+      connected_at: new Date().toISOString(),
+    });
+    resetGitLabConnector();
+
+    return {
+      status: 200,
+      contentType: "text/html",
+      body: `<html><body><h2>GitLab connected${username ? ` as ${escHtml(username)}` : ""}</h2><script>try { window.opener.postMessage('patchwork:gitlab:connected', '*'); } catch(_) {} window.close();</script></body></html>`,
+    };
+  } catch (err) {
+    return {
+      status: 400,
+      contentType: "text/html",
+      body: `<html><body><h2>GitLab connect failed</h2><pre>${escHtml(err instanceof Error ? err.message : String(err))}</pre></body></html>`,
+    };
+  }
+}
+
+/**
+ * POST /connections/gitlab/test — verify stored token works.
+ */
+export async function handleGitLabTest(): Promise<ConnectorHandlerResult> {
+  const tokens = loadTokens();
+  if (!tokens) {
+    return {
+      status: 400,
+      contentType: "application/json",
+      body: JSON.stringify({ ok: false, error: "GitLab not connected" }),
+    };
+  }
+  try {
+    const connector = getGitLabConnector();
+    const check = await connector.healthCheck();
+    return {
+      status: check.ok ? 200 : 401,
+      contentType: "application/json",
+      body: JSON.stringify(
+        check.ok
+          ? { ok: true, username: tokens.username }
+          : { ok: false, error: check.error?.message },
+      ),
+    };
+  } catch (err) {
+    return {
+      status: 500,
+      contentType: "application/json",
+      body: JSON.stringify({
+        ok: false,
+        error: err instanceof Error ? err.message : String(err),
+      }),
+    };
+  }
+}
+
+/**
+ * DELETE /connections/gitlab — best-effort revoke at GitLab + drop locally.
+ */
+export async function handleGitLabDisconnect(): Promise<ConnectorHandlerResult> {
+  const tokens = loadTokens();
+  if (tokens?.access_token && isConfigured()) {
+    try {
+      await fetch(revokeUrl(), {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({
+          token: tokens.access_token,
+          client_id: clientId(),
+          client_secret: clientSecret(),
+        }).toString(),
+      });
+    } catch {
+      // ignore — still drop local tokens
+    }
+  }
+  clearTokens();
+  resetGitLabConnector();
+  return {
+    status: 200,
+    contentType: "application/json",
+    body: JSON.stringify({ ok: true }),
+  };
+}

--- a/src/connectors/gmail.ts
+++ b/src/connectors/gmail.ts
@@ -276,6 +276,7 @@ export async function handleConnectionsList(): Promise<ConnectorHandlerResult> {
     { id: "confluence", mod: () => import("./confluence.js") },
     { id: "datadog", mod: () => import("./datadog.js") },
     { id: "discord", mod: () => import("./discord.js") },
+    { id: "gitlab", mod: () => import("./gitlab.js") },
     { id: "hubspot", mod: () => import("./hubspot.js") },
     { id: "intercom", mod: () => import("./intercom.js") },
     { id: "pagerduty", mod: () => import("./pagerduty.js") },

--- a/src/recipes/tools/gitlab.ts
+++ b/src/recipes/tools/gitlab.ts
@@ -1,0 +1,311 @@
+/**
+ * GitLab tools — read-only wrappers (projects, issues, merge requests, user).
+ *
+ * Self-registering tool module for the recipe tool registry. Read-list tools
+ * use `{count, items, error}` — single-object lookups (`get_issue`,
+ * `get_current_user`) return the object spread with an optional `error`.
+ *
+ * Write tools (createIssue, createMergeRequestNote) are intentionally deferred
+ * to a follow-up PR; this module only registers read-only methods.
+ */
+
+import { CommonSchemas, registerTool } from "../toolRegistry.js";
+
+// ============================================================================
+// gitlab.get_current_user
+// ============================================================================
+
+registerTool({
+  id: "gitlab.get_current_user",
+  namespace: "gitlab",
+  description: "Fetch the authenticated GitLab user (id, username, email).",
+  paramsSchema: {
+    type: "object",
+    properties: {
+      into: CommonSchemas.into,
+    },
+  },
+  outputSchema: {
+    type: "object",
+    properties: {
+      id: { type: "number" },
+      username: { type: "string" },
+      name: { type: "string" },
+      email: { type: "string" },
+      error: { type: "string" },
+    },
+  },
+  riskDefault: "low",
+  isWrite: false,
+  isConnector: true,
+  execute: async () => {
+    const { getGitLabConnector } = await import("../../connectors/gitlab.js");
+    try {
+      const connector = getGitLabConnector();
+      const user = await connector.getCurrentUser();
+      return JSON.stringify({ ...user });
+    } catch (err) {
+      return JSON.stringify({
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  },
+});
+
+// ============================================================================
+// gitlab.list_projects
+// ============================================================================
+
+registerTool({
+  id: "gitlab.list_projects",
+  namespace: "gitlab",
+  description:
+    "List GitLab projects. Defaults to the authenticated user's memberships.",
+  paramsSchema: {
+    type: "object",
+    properties: {
+      membership: {
+        type: "boolean",
+        description:
+          "If true (default), only return projects the user is a member of.",
+      },
+      owned: {
+        type: "boolean",
+        description: "If true, only return projects owned by the user.",
+      },
+      search: {
+        type: "string",
+        description: "Optional substring search applied to project name/path.",
+      },
+      max: CommonSchemas.max,
+      into: CommonSchemas.into,
+    },
+  },
+  outputSchema: {
+    type: "object",
+    properties: {
+      count: { type: "number" },
+      items: { type: "array", items: { type: "object" } },
+      error: { type: "string" },
+    },
+  },
+  riskDefault: "low",
+  isWrite: false,
+  isConnector: true,
+  execute: async ({ params }) => {
+    const { getGitLabConnector } = await import("../../connectors/gitlab.js");
+    const limit = typeof params.max === "number" ? params.max : 50;
+    try {
+      const connector = getGitLabConnector();
+      const projects = await connector.listProjects({
+        membership:
+          typeof params.membership === "boolean"
+            ? params.membership
+            : undefined,
+        owned: typeof params.owned === "boolean" ? params.owned : undefined,
+        search: typeof params.search === "string" ? params.search : undefined,
+        limit,
+      });
+      return JSON.stringify({ count: projects.length, items: projects });
+    } catch (err) {
+      return JSON.stringify({
+        count: 0,
+        items: [],
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  },
+});
+
+// ============================================================================
+// gitlab.list_issues
+// ============================================================================
+
+registerTool({
+  id: "gitlab.list_issues",
+  namespace: "gitlab",
+  description:
+    "List GitLab issues. Pass projectId to scope to a project, or omit for issues across the user's projects.",
+  paramsSchema: {
+    type: "object",
+    properties: {
+      projectId: {
+        type: ["string", "number"],
+        description:
+          "GitLab project id or URL-encoded path (e.g. 'group/repo').",
+      },
+      assignedToMe: {
+        type: "boolean",
+        description:
+          "When projectId is omitted, restrict to issues assigned to the current user.",
+      },
+      state: {
+        type: "string",
+        enum: ["opened", "closed", "all"],
+        description: "Filter by state. Default: GitLab returns 'opened'.",
+      },
+      max: CommonSchemas.max,
+      into: CommonSchemas.into,
+    },
+  },
+  outputSchema: {
+    type: "object",
+    properties: {
+      count: { type: "number" },
+      items: { type: "array", items: { type: "object" } },
+      error: { type: "string" },
+    },
+  },
+  riskDefault: "low",
+  isWrite: false,
+  isConnector: true,
+  execute: async ({ params }) => {
+    const { getGitLabConnector } = await import("../../connectors/gitlab.js");
+    const limit = typeof params.max === "number" ? params.max : 50;
+    try {
+      const connector = getGitLabConnector();
+      const issues = await connector.listIssues({
+        projectId: params.projectId as string | number | undefined,
+        assignedToMe:
+          typeof params.assignedToMe === "boolean"
+            ? params.assignedToMe
+            : undefined,
+        state: params.state as "opened" | "closed" | "all" | undefined,
+        limit,
+      });
+      return JSON.stringify({ count: issues.length, items: issues });
+    } catch (err) {
+      return JSON.stringify({
+        count: 0,
+        items: [],
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  },
+});
+
+// ============================================================================
+// gitlab.get_issue
+// ============================================================================
+
+registerTool({
+  id: "gitlab.get_issue",
+  namespace: "gitlab",
+  description: "Fetch a single GitLab issue by project + issue iid.",
+  paramsSchema: {
+    type: "object",
+    properties: {
+      projectId: {
+        type: ["string", "number"],
+        description: "GitLab project id or URL-encoded path.",
+      },
+      issueIid: {
+        type: "number",
+        description: "Per-project issue iid (the number you see in URLs).",
+      },
+      into: CommonSchemas.into,
+    },
+    required: ["projectId", "issueIid"],
+  },
+  outputSchema: {
+    type: "object",
+    properties: {
+      id: { type: "number" },
+      iid: { type: "number" },
+      title: { type: "string" },
+      state: { type: "string" },
+      error: { type: "string" },
+    },
+  },
+  riskDefault: "low",
+  isWrite: false,
+  isConnector: true,
+  execute: async ({ params }) => {
+    const { getGitLabConnector } = await import("../../connectors/gitlab.js");
+    try {
+      const connector = getGitLabConnector();
+      const issue = await connector.getIssue(
+        params.projectId as string | number,
+        params.issueIid as number,
+      );
+      return JSON.stringify({ ...issue });
+    } catch (err) {
+      return JSON.stringify({
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  },
+});
+
+// ============================================================================
+// gitlab.list_merge_requests
+// ============================================================================
+
+registerTool({
+  id: "gitlab.list_merge_requests",
+  namespace: "gitlab",
+  description:
+    "List GitLab merge requests. Pass projectId to scope to a project, or omit for cross-project queries.",
+  paramsSchema: {
+    type: "object",
+    properties: {
+      projectId: {
+        type: ["string", "number"],
+        description: "GitLab project id or URL-encoded path.",
+      },
+      state: {
+        type: "string",
+        enum: ["opened", "closed", "merged", "all"],
+        description: "Filter by state. Default: GitLab returns 'opened'.",
+      },
+      scope: {
+        type: "string",
+        enum: ["created_by_me", "assigned_to_me", "all"],
+        description:
+          "Cross-project scope when projectId is omitted. Default: 'created_by_me'.",
+      },
+      max: CommonSchemas.max,
+      into: CommonSchemas.into,
+    },
+  },
+  outputSchema: {
+    type: "object",
+    properties: {
+      count: { type: "number" },
+      items: { type: "array", items: { type: "object" } },
+      error: { type: "string" },
+    },
+  },
+  riskDefault: "low",
+  isWrite: false,
+  isConnector: true,
+  execute: async ({ params }) => {
+    const { getGitLabConnector } = await import("../../connectors/gitlab.js");
+    const limit = typeof params.max === "number" ? params.max : 50;
+    try {
+      const connector = getGitLabConnector();
+      const mrs = await connector.listMergeRequests({
+        projectId: params.projectId as string | number | undefined,
+        state: params.state as
+          | "opened"
+          | "closed"
+          | "merged"
+          | "all"
+          | undefined,
+        scope: params.scope as
+          | "created_by_me"
+          | "assigned_to_me"
+          | "all"
+          | undefined,
+        limit,
+      });
+      return JSON.stringify({ count: mrs.length, items: mrs });
+    } catch (err) {
+      return JSON.stringify({
+        count: 0,
+        items: [],
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  },
+});

--- a/src/recipes/tools/index.ts
+++ b/src/recipes/tools/index.ts
@@ -14,6 +14,7 @@ import "./asana.js";
 import "./gmail.js";
 import "./googleDrive.js";
 import "./github.js";
+import "./gitlab.js";
 import "./linear.js";
 import "./calendar.js";
 import "./slack.js";

--- a/src/server.ts
+++ b/src/server.ts
@@ -1566,6 +1566,77 @@ export class Server extends EventEmitter<ServerEvents> {
         return;
       }
 
+      // ── GitLab connector routes ────────────────────────────────────
+      if (
+        (parsedUrl.pathname === "/connections/gitlab/auth" ||
+          parsedUrl.pathname === "/connections/gitlab/authorize") &&
+        req.method === "GET"
+      ) {
+        const { handleGitLabAuthorize } = await import(
+          "./connectors/gitlab.js"
+        );
+        const result = handleGitLabAuthorize();
+        if (result.redirect) {
+          res.writeHead(302, { Location: result.redirect });
+          res.end();
+        } else {
+          res.writeHead(result.status, {
+            "Content-Type": result.contentType ?? "application/json",
+          });
+          res.end(result.body);
+        }
+        return;
+      }
+      if (
+        parsedUrl.pathname === "/connections/gitlab/callback" &&
+        req.method === "GET"
+      ) {
+        void (async () => {
+          const { handleGitLabCallback } = await import(
+            "./connectors/gitlab.js"
+          );
+          const code = parsedUrl.searchParams.get("code");
+          const state = parsedUrl.searchParams.get("state");
+          const error = parsedUrl.searchParams.get("error");
+          const result = await handleGitLabCallback(code, state, error);
+          res.writeHead(result.status, {
+            "Content-Type": result.contentType ?? "text/html",
+          });
+          res.end(result.body);
+        })();
+        return;
+      }
+      if (
+        parsedUrl.pathname === "/connections/gitlab/test" &&
+        req.method === "POST"
+      ) {
+        void (async () => {
+          const { handleGitLabTest } = await import("./connectors/gitlab.js");
+          const result = await handleGitLabTest();
+          res.writeHead(result.status, {
+            "Content-Type": result.contentType ?? "application/json",
+          });
+          res.end(result.body);
+        })();
+        return;
+      }
+      if (
+        parsedUrl.pathname === "/connections/gitlab" &&
+        req.method === "DELETE"
+      ) {
+        void (async () => {
+          const { handleGitLabDisconnect } = await import(
+            "./connectors/gitlab.js"
+          );
+          const result = await handleGitLabDisconnect();
+          res.writeHead(result.status, {
+            "Content-Type": result.contentType ?? "application/json",
+          });
+          res.end(result.body);
+        })();
+        return;
+      }
+
       // ── Notion routes ──────────────────────────────────────────────
       if (
         parsedUrl.pathname === "/connections/notion/connect" &&


### PR DESCRIPTION
## Summary

Adds a GitLab connector following the just-merged Asana/Discord OAuth 2.0 pattern.

- **Connector** (`src/connectors/gitlab.ts`): `GitLabConnector` extends `BaseConnector` with token refresh, retry, rate-limit, error normalization (401 -> `auth_expired`, 403 -> `permission_denied`, 404 -> `not_found`, 429 -> `rate_limited`). Mirrors refreshed tokens to disk via `saveTokens()` override so the HTTP probe keeps working.
- **Read-only methods**: `getCurrentUser`, `listProjects` (membership default), `listIssues` (per-project or assigned-to-me), `getIssue` (by `iid`), `listMergeRequests`.
- **Self-hosted support**: `GITLAB_BASE_URL` env var (default `https://gitlab.com`). The `/api/v4` path is appended internally so users only configure the host. Authorize URL also respects this.
- **HTTP routes** (`src/server.ts`): `/connections/gitlab/{auth,callback,test}` + `DELETE /connections/gitlab` with best-effort `POST /oauth/revoke`. Added to `/connections` listing.
- **Recipe tools** (`src/recipes/tools/gitlab.ts`): `gitlab.get_current_user`, `gitlab.list_projects`, `gitlab.list_issues`, `gitlab.get_issue`, `gitlab.list_merge_requests`. All `riskDefault: low`, `isWrite: false`, `isConnector: true`.
- **Dashboard**: `gitlab` added to `SUPPORTED_CONNECTORS` and the `PROVIDERS` modal with `IconGitlab` (geometric SVG mark). Callback page + bridge proxy route mirror the Discord shape. The existing CATALOG entry (Wave 2 Dev, `#FC6D26`, 9 tools) is no longer Coming Soon.

## Configuration

- Required: `GITLAB_CLIENT_ID`, `GITLAB_CLIENT_SECRET`. Missing creds return 503 with a clear error from the auth endpoint (matches Asana/Discord behavior).
- Optional: `GITLAB_BASE_URL` for self-hosted instances (e.g. `https://gitlab.example.com`).
- Scopes: `read_user read_api read_repository`.

## Deferred

- `createIssue`, `createMergeRequestNote` — follow-up PR.

## Test plan

- [x] `npm run build` (bridge tsc) green
- [x] `npx tsc --noEmit` in `dashboard/` green
- [x] `npx vitest run src/connectors/__tests__/gitlab.test.ts` — 15/15 passed
- [x] Full vitest suite — 4417/4417 passed
- [x] `npx biome check --write` on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)