### PR TITLE
test(backoff): flush microtasks to deflake CI circuit-breaker test

### DIFF
--- a/src/__tests__/backoff.test.ts
+++ b/src/__tests__/backoff.test.ts
@@ -53,6 +53,12 @@ async function triggerTimeouts(n: number): Promise<void> {
     const req = client.getDiagnostics().catch(() => null);
     await vi.advanceTimersByTimeAsync(10_001); // past REQUEST_TIMEOUT
     await req;
+    // The connector's failure-recording catch lives later in the same promise
+    // chain than our `.catch(() => null)`. Flush a couple of microtask turns
+    // so circuit-breaker state has settled before the test asserts on it —
+    // otherwise CI sporadically reads stale state under load.
+    await Promise.resolve();
+    await Promise.resolve();
   }
 }
 


### PR DESCRIPTION
## Summary

`src/__tests__/backoff.test.ts:96` flaked in CI on PR #81 (Asana) — `expected false to be true`. The test asserts on circuit-breaker state immediately after awaiting a timed-out request, but the connector's failure-recording catch lives later in the same promise chain than the test's user-side `.catch(() => null)`. Locally the ordering is reliable; in CI under load the race lost intermittently.

Fix: two extra microtask turns inside `triggerTimeouts()` after `await req` so the connector's catch has run before assertions read state. Test still passes locally in 20ms.

## Test plan
- [x] `npx vitest run src/__tests__/backoff.test.ts` — 7/7 pass
- [ ] Watch CI on this PR — should be green; rerun the historical flake by checking subsequent PRs don't see the same false red

🤖 Generated with [Claude Code](https://claude.com/claude-code)