### PR TITLE
fix(dashboard): point install CTAs at patchworkos.com/#install

### DIFF
--- a/dashboard/src/app/marketplace/page.tsx
+++ b/dashboard/src/app/marketplace/page.tsx
@@ -298,7 +298,7 @@ function RecipeCard({
             </button>
           ) : (
             <a
-              href="https://github.com/Oolab-labs/claude-ide-bridge#installation"
+              href="https://patchworkos.com/#install"
               target="_blank"
               rel="noopener noreferrer"
               className="btn sm"
@@ -460,7 +460,7 @@ export default function MarketplacePage() {
             Browsing in preview mode — bridge not connected. Install Patchwork OS to install recipes directly.
           </span>
           <a
-            href="https://github.com/Oolab-labs/claude-ide-bridge#installation"
+            href="https://patchworkos.com/#install"
             target="_blank"
             rel="noopener noreferrer"
             style={{

--- a/dashboard/src/components/DemoBanner.tsx
+++ b/dashboard/src/components/DemoBanner.tsx
@@ -48,7 +48,7 @@ export function DemoBanner() {
         showing sample data. Run Patchwork OS locally for live approvals, recipes, and activity.
       </span>
       <a
-        href="https://github.com/Oolab-labs/claude-ide-bridge#installation"
+        href="https://patchworkos.com/#install"
         target="_blank"
         rel="noopener noreferrer"
         style={{


### PR DESCRIPTION
## Summary

Three install CTAs in the dashboard pointed at \`github.com/Oolab-labs/claude-ide-bridge\` — the *pre-rename* repo URL. Cold visitors hitting "Get Patchwork" on a marketplace card (or clicking Install in the demo-mode banner) landed on a 404 or stale README.

Now they deep-link to \`https://patchworkos.com/#install\`, which the live landing page already has as a section anchor with the correct \`npm i -g patchwork-os\` command.

## Files

- \`dashboard/src/app/marketplace/page.tsx\` — card "Get Patchwork" + preview-mode banner Install link (2 occurrences)
- \`dashboard/src/components/DemoBanner.tsx\` — global demo-mode banner Install link

## Test plan
- [x] \`npx tsc --noEmit\` clean
- [x] \`grep -r "claude-ide-bridge"\` returns 0 hits in \`dashboard/src/\`
- [ ] After redeploy: click "Get Patchwork" on a marketplace card → lands on patchworkos.com install section

🤖 Generated with [Claude Code](https://claude.com/claude-code)