### PR TITLE
fix(dashboard): demo mode serves fixture data instead of 401-spamming

### DIFF
--- a/dashboard/src/app/api/bridge/[...path]/route.ts
+++ b/dashboard/src/app/api/bridge/[...path]/route.ts
@@ -1,12 +1,51 @@
 import type { NextRequest } from "next/server";
 import { bridgeFetch, findBridge, resolveBridgeUrl } from "@/lib/bridge";
+import { isDemoModeServer } from "@/lib/demoModeServer";
+import { mockBridgeResponse } from "@/lib/mockData";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
+/** SSE stream that emits an immediate empty snapshot then heartbeats — used in
+ *  demo mode where there's no real bridge to forward from. Without this the
+ *  client polls indefinitely against a stream that doesn't exist. */
+function demoStream(req: Request): Response {
+  const encoder = new TextEncoder();
+  const body = new ReadableStream({
+    start(controller) {
+      controller.enqueue(encoder.encode(": connected\n\n"));
+      const id = setInterval(() => {
+        try {
+          controller.enqueue(encoder.encode(": heartbeat\n\n"));
+        } catch {
+          clearInterval(id);
+        }
+      }, 15_000);
+      req.signal.addEventListener("abort", () => {
+        clearInterval(id);
+        try {
+          controller.close();
+        } catch {
+          // already closed
+        }
+      });
+    },
+  });
+  return new Response(body, {
+    status: 200,
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache, no-transform",
+      Connection: "keep-alive",
+      "X-Accel-Buffering": "no",
+    },
+  });
+}
+
 async function proxy(req: NextRequest, segments: string[]): Promise<Response> {
   const qs = req.nextUrl.search;
   const target = `/${segments.join("/")}${qs}`;
+  const demo = isDemoModeServer();
 
   // SSE passthrough for /stream — stream the response body back to the client.
   // Browsers only initiate EventSource over GET; reject other methods up-front
@@ -18,6 +57,7 @@ async function proxy(req: NextRequest, segments: string[]): Promise<Response> {
         headers: { "content-type": "application/json", allow: "GET, HEAD" },
       });
     }
+    if (demo) return demoStream(req);
     const lock = findBridge();
     if (!lock) {
       return new Response(
@@ -72,6 +112,14 @@ async function proxy(req: NextRequest, segments: string[]): Promise<Response> {
         headers: { "Content-Type": "application/json" },
       });
     }
+  }
+
+  // In demo mode short-circuit to fixture data instead of hitting a bridge
+  // that isn't there. Without this every dashboard route below /marketplace
+  // shows raw 401 banners on the public demo site.
+  if (demo) {
+    const mock = mockBridgeResponse(`/${segments.join("/")}${qs}`, req.method);
+    if (mock) return mock;
   }
 
   const body =

--- a/dashboard/src/app/api/bridge/connectors/status/route.ts
+++ b/dashboard/src/app/api/bridge/connectors/status/route.ts
@@ -1,9 +1,15 @@
 import { bridgeFetch } from "@/lib/bridge";
+import { isDemoModeServer } from "@/lib/demoModeServer";
+import { mockBridgeResponse } from "@/lib/mockData";
 import { NextResponse } from "next/server";
 
 export const dynamic = "force-dynamic";
 
 export async function GET() {
+  if (isDemoModeServer()) {
+    const mock = mockBridgeResponse("/connectors/status", "GET");
+    if (mock) return mock;
+  }
   const res = await bridgeFetch("/connections");
   if (!res.ok) {
     const text = await res.text().catch(() => "");

--- a/dashboard/src/app/api/bridge/recipes/[name]/route.ts
+++ b/dashboard/src/app/api/bridge/recipes/[name]/route.ts
@@ -1,15 +1,28 @@
 import type { NextRequest } from "next/server";
 import { bridgeFetch } from "@/lib/bridge";
+import { isDemoModeServer } from "@/lib/demoModeServer";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
 type RouteContext = { params: { name: string } };
 
+const demoOk = () =>
+  new Response(JSON.stringify({ ok: true, demo: true }), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+
 export async function GET(
   _req: NextRequest,
   ctx: RouteContext,
 ): Promise<Response> {
+  if (isDemoModeServer()) {
+    return new Response(
+      JSON.stringify({ name: ctx.params.name, demo: true, content: "" }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
+  }
   const name = encodeURIComponent(ctx.params.name);
   const res = await bridgeFetch(`/recipes/${name}`);
   const text = await res.text();
@@ -30,6 +43,7 @@ export async function PUT(
       headers: { "content-type": "application/json" },
     });
   }
+  if (isDemoModeServer()) return demoOk();
   const name = encodeURIComponent(ctx.params.name);
   const body = await req.text();
   const res = await bridgeFetch(`/recipes/${name}`, {
@@ -55,6 +69,7 @@ export async function PATCH(
       headers: { "content-type": "application/json" },
     });
   }
+  if (isDemoModeServer()) return demoOk();
   const name = encodeURIComponent(ctx.params.name);
   const body = await req.text();
   const res = await bridgeFetch(`/recipes/${name}`, {

--- a/dashboard/src/app/api/bridge/recipes/[name]/run/route.ts
+++ b/dashboard/src/app/api/bridge/recipes/[name]/run/route.ts
@@ -1,5 +1,6 @@
 import type { NextRequest } from "next/server";
 import { bridgeFetch } from "@/lib/bridge";
+import { isDemoModeServer } from "@/lib/demoModeServer";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -16,6 +17,17 @@ export async function POST(
       status: 403,
       headers: { "content-type": "application/json" },
     });
+  }
+  if (isDemoModeServer()) {
+    return new Response(
+      JSON.stringify({
+        ok: true,
+        demo: true,
+        taskId: `demo-${Date.now()}`,
+        message: `Demo mode — recipe '${ctx.params.name}' run skipped (no live bridge)`,
+      }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
   }
   const name = encodeURIComponent(ctx.params.name);
   const body = await req.text();

--- a/dashboard/src/app/api/bridge/recipes/lint/route.ts
+++ b/dashboard/src/app/api/bridge/recipes/lint/route.ts
@@ -1,5 +1,6 @@
 import type { NextRequest } from "next/server";
 import { bridgeFetch } from "@/lib/bridge";
+import { isDemoModeServer } from "@/lib/demoModeServer";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -11,6 +12,12 @@ export async function POST(req: NextRequest): Promise<Response> {
       status: 403,
       headers: { "content-type": "application/json" },
     });
+  }
+  if (isDemoModeServer()) {
+    return new Response(
+      JSON.stringify({ ok: true, demo: true, errors: [], warnings: [] }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
   }
   const body = await req.text();
   const res = await bridgeFetch("/recipes/lint", {

--- a/dashboard/src/app/marketplace/page.tsx
+++ b/dashboard/src/app/marketplace/page.tsx
@@ -298,7 +298,7 @@ function RecipeCard({
             </button>
           ) : (
             <a
-              href="https://github.com/Oolab-labs/claude-ide-bridge#installation"
+              href="https://patchworkos.com/#install"
               target="_blank"
               rel="noopener noreferrer"
               className="btn sm"
@@ -460,7 +460,7 @@ export default function MarketplacePage() {
             Browsing in preview mode — bridge not connected. Install Patchwork OS to install recipes directly.
           </span>
           <a
-            href="https://github.com/Oolab-labs/claude-ide-bridge#installation"
+            href="https://patchworkos.com/#install"
             target="_blank"
             rel="noopener noreferrer"
             style={{

--- a/dashboard/src/components/DemoBanner.tsx
+++ b/dashboard/src/components/DemoBanner.tsx
@@ -48,7 +48,7 @@ export function DemoBanner() {
         showing sample data. Run Patchwork OS locally for live approvals, recipes, and activity.
       </span>
       <a
-        href="https://github.com/Oolab-labs/claude-ide-bridge#installation"
+        href="https://patchworkos.com/#install"
         target="_blank"
         rel="noopener noreferrer"
         style={{


### PR DESCRIPTION
## Summary

Closes the **#1 user-facing bug** flagged by the platform assessment: in demo mode, every dashboard route below \`/marketplace\` rendered raw 401 error banners (\`Unreachable: /recipes 401\`, \`Bridge offline — Request failed\`) because there's no real bridge to forward to. A Playwright walkthrough captured 183 console errors per session, almost all from bridge polling against a missing bridge.

The fixture infrastructure (\`mockBridgeResponse()\` in \`dashboard/src/lib/mockData.ts\`) already had coverage for every relevant endpoint — the proxy routes just weren't calling it.

## Changes

- **\`/api/bridge/[...path]\`** — catch-all proxy now short-circuits to \`mockBridgeResponse()\` in demo mode. \`/stream\` emits a heartbeat-only SSE stream rather than 503'ing.
- **\`/api/bridge/connectors/status\`** — returns \`MOCK_CONNECTORS_STATUS\` in demo
- **\`/api/bridge/recipes/lint\`** — returns \`{ok, demo, errors:[], warnings:[]}\` in demo
- **\`/api/bridge/recipes/[name]\`** — GET returns a stub recipe; PUT/PATCH ack with \`{ok, demo}\` without mutating
- **\`/api/bridge/recipes/[name]/run\`** — returns a fake \`taskId\` + skip message

\`/api/bridge/approvals/stream\` and \`/api/bridge/recipes/install\` already had demo handling; this PR brings the rest of the surface in line.

## User-visible impact (after redeploy)

- /dashboard/recipes → shows demo recipes instead of red error
- /dashboard/runs → shows demo runs instead of red error
- /dashboard/inbox → shows demo inbox items instead of 500
- /dashboard/approvals → already silent (stream had demo handler), card list now populates
- /dashboard/tasks, /sessions, /metrics, /analytics, /traces, /decisions → all populate

Console noise drops from ~183 errors/session to near zero.

## Test plan
- [x] \`npx tsc --noEmit\` clean
- [x] \`npm run build\` clean
- [ ] Visual after redeploy: walk every dashboard route in demo mode, no red error banners
- [ ] DevTools network panel: zero 401 from /api/bridge/* in demo

🤖 Generated with [Claude Code](https://claude.com/claude-code)