### PR TITLE
fix: landing version + mobile nav + bridge-poll backoff

### DIFF
--- a/dashboard/src/components/Shell.tsx
+++ b/dashboard/src/components/Shell.tsx
@@ -103,17 +103,38 @@ function useApprovalCount(): number {
   const [count, setCount] = useState(0);
   useEffect(() => {
     let alive = true;
+    let failures = 0;
+    let timerId: ReturnType<typeof setTimeout> | null = null;
+    const BASE = 5000;
+    const MAX = 30_000;
+
+    const schedule = (ms: number) => {
+      if (!alive) return;
+      timerId = setTimeout(tick, ms);
+    };
+
     const tick = async () => {
+      let ok = false;
       try {
         const res = await fetch(apiPath("/api/bridge/approvals"));
-        if (!res.ok) return;
-        const data = await res.json();
-        if (alive && Array.isArray(data)) setCount(data.length);
+        if (res.ok) {
+          const data = await res.json();
+          if (alive && Array.isArray(data)) setCount(data.length);
+          ok = true;
+        }
       } catch { /* offline */ }
+      if (ok) failures = 0;
+      else failures++;
+      // Exponential backoff with ±20% jitter, cap 30s
+      const exp = Math.min(BASE * 2 ** failures, MAX);
+      schedule(ok ? BASE : exp * (0.8 + Math.random() * 0.4));
     };
+
     tick();
-    const id = setInterval(tick, 5000);
-    return () => { alive = false; clearInterval(id); };
+    return () => {
+      alive = false;
+      if (timerId !== null) clearTimeout(timerId);
+    };
   }, []);
   return count;
 }

--- a/dashboard/src/hooks/useBridgeStatus.ts
+++ b/dashboard/src/hooks/useBridgeStatus.ts
@@ -19,31 +19,59 @@ export interface BridgeStatus {
   };
 }
 
+const BASE_INTERVAL_MS = 5000;
+const MAX_BACKOFF_MS = 30_000;
+
+function nextDelay(failures: number): number {
+  const exp = Math.min(BASE_INTERVAL_MS * 2 ** failures, MAX_BACKOFF_MS);
+  return exp * (0.8 + Math.random() * 0.4); // ±20% jitter
+}
+
 export function useBridgeStatus(): BridgeStatus {
   const [status, setStatus] = useState<BridgeStatus>({ ok: false });
   useEffect(() => {
     let alive = true;
+    let failures = 0;
+    let timerId: ReturnType<typeof setTimeout> | null = null;
+
+    const schedule = (ms: number) => {
+      if (!alive) return;
+      timerId = setTimeout(tick, ms);
+    };
+
     const tick = async () => {
+      let succeeded = false;
       try {
         const res = await fetch(apiPath("/api/bridge/status"));
         if (!res.ok) throw new Error(`status ${res.status}`);
         const ct = res.headers.get("content-type") ?? "";
-        if (!ct.includes("application/json") && !ct.includes("text/plain")) throw new Error("bad content-type");
+        if (!ct.includes("application/json") && !ct.includes("text/plain"))
+          throw new Error("bad content-type");
         const data = (await res.json()) as Partial<BridgeStatus>;
         if (alive) setStatus({ ok: true, ...data });
+        succeeded = true;
       } catch {
         try {
           const res = await fetch(apiPath("/api/bridge/approvals"));
           const ct = res.headers.get("content-type") ?? "";
-          if (alive) setStatus({ ok: res.ok && ct.includes("application/json") });
+          if (alive)
+            setStatus({ ok: res.ok && ct.includes("application/json") });
+          if (res.ok) succeeded = true;
         } catch {
           if (alive) setStatus({ ok: false });
         }
       }
+
+      if (succeeded) failures = 0;
+      else failures++;
+      schedule(succeeded ? BASE_INTERVAL_MS : nextDelay(failures));
     };
+
     tick();
-    const id = setInterval(tick, 5000);
-    return () => { alive = false; clearInterval(id); };
+    return () => {
+      alive = false;
+      if (timerId !== null) clearTimeout(timerId);
+    };
   }, []);
   return status;
 }

--- a/landing/index.html
+++ b/landing/index.html
@@ -110,6 +110,15 @@
     }
     .nav-pill:hover { border-color: var(--accent); color: var(--accent); }
 
+    /* Mobile nav: hide the inline text links so the install pill keeps fitting.
+       The hero's primary CTAs ("Install in 30 seconds", "Star on GitHub") cover
+       the same affordances a few hundred px below — no hamburger needed. */
+    @media (max-width: 600px) {
+      .nav-links a { display: none; }
+      .nav-links { gap: 0.5rem; }
+      .nav-pill { padding: 0.25rem 0.7rem; font-size: 0.7rem; }
+    }
+
     /* ── HERO ── */
     .hero {
       position: relative;
@@ -707,7 +716,7 @@
 
 <!-- ── HERO ── -->
 <section class="hero">
-  <div class="eyebrow"><span class="dot"></span>v0.2.0-alpha.26 &middot; now in alpha</div>
+  <div class="eyebrow"><span class="dot"></span>v0.2.0-alpha.35 &middot; now in alpha</div>
   <div class="hero-wordmark">Patchwork OS</div>
   <h1>AI that works while<br/>you're away.</h1>
   <p class="subhead">Watches for things that matter, acts, and asks before anything risky goes out. Runs on your machine. Doesn't lock you in.</p>
@@ -992,7 +1001,7 @@
 <!-- ── FOOTER ── -->
 <footer>
   <div class="footer-inner">
-    <div class="footer-brand">patchwork OS &middot; v0.2.0-alpha.26</div>
+    <div class="footer-brand">patchwork OS &middot; v0.2.0-alpha.35</div>
     <div class="footer-links">
       <a href="https://github.com/patchworkos/recipes" target="_blank" rel="noopener">GitHub</a>
       <a href="https://github.com/patchworkos/recipes/blob/main/CONTRIBUTING.md" target="_blank" rel="noopener">Contributing</a>


### PR DESCRIPTION
## Summary

Three small polish items from the platform assessment, bundled because they're each <30 lines and don't interact:

### 1. Landing version string was 9 versions stale
Footer + hero eyebrow read \`v0.2.0-alpha.26\`. Now \`v0.2.0-alpha.35\` (matches npm \`alpha\` tag + the GitHub release I just cut).

### 2. Marketing landing nav broke at 375px
Apex nav had no responsive rules — wordmark + 3 text links + install pill overflowed silently on mobile. Hidden the text links (\`How it works\`, \`Recipes\`, \`GitHub\`) at \`<600px\` and tightened the install pill. The hero's \`Install in 30 seconds\` and \`Star on GitHub\` CTAs are right below, so no hamburger needed for this page.

### 3. \`useBridgeStatus\` + \`useApprovalCount\` polled with no backoff
Fixed 5s setInterval. Demo mode now serves fixtures (PR #90) so 401s should be rare, but a real disconnected bridge still produced unbounded polling. Both now use exponential backoff (5s base, 30s cap, ±20% jitter) on failure, reset to base on success — same shape as \`useBridgeFetch\`.

## Out of scope

- Apex 401s themselves — already fixed by PR #91 + landing redeploy
- Demo-mode 401s on other endpoints — already fixed by PR #90

## Test plan
- [x] \`npx tsc --noEmit\` clean
- [x] \`npm run build\` clean
- [ ] Visual: landing at 375px shows wordmark + install pill only
- [ ] Visual: landing footer + hero badge show \`v0.2.0-alpha.35\`
- [ ] Demo dashboard with bridge offline: bridge-status hook backs off after first 401, doesn't spam network panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)