### PR TITLE
refactor(server): extract OAuth 2.0 endpoints to oauthRoutes.ts

### DIFF
--- a/src/oauthRoutes.ts
+++ b/src/oauthRoutes.ts
@@ -1,0 +1,145 @@
+/**
+ * OAuth 2.0 route dispatcher — extracted from src/server.ts.
+ *
+ * Owns the public OAuth endpoints (RFC 8414 discovery, RFC 9396 protected-
+ * resource metadata, RFC 7591 dynamic client registration, authorize,
+ * token, RFC 7009 revoke). All routes are unauthenticated — they MUST
+ * run before the bearer-auth gate.
+ *
+ * DI shape: handlers depend on a nullable `OAuthServer` member object and
+ * an issuer URL. Both are assigned post-construction via `setOAuthServer`
+ * on the bridge Server, so `tryHandleOAuthRoute` accepts them as a deps
+ * argument (vs. closing over `this`). When OAuth isn't configured, every
+ * route falls through to 404 (or 200 for `/oauth/revoke` per RFC 7009).
+ *
+ * Mechanical-equivalent lift: handler bodies are identical to the
+ * originals save for `deps.oauthServer` replacing `this.oauthServer` and
+ * `deps.oauthIssuerUrl` replacing `this.oauthIssuerUrl`.
+ */
+
+import type { IncomingMessage, ServerResponse } from "node:http";
+import type { OAuthServer } from "./oauth.js";
+
+export interface OAuthRouteDeps {
+  oauthServer: OAuthServer | null;
+  oauthIssuerUrl: string | null;
+}
+
+/**
+ * Try to handle a `/.well-known/oauth-*` or `/oauth/*` route. Returns
+ * true if the route was dispatched (caller should `return` from the
+ * request handler), false if no route matched.
+ *
+ * MUST be called before the bearer-auth gate.
+ */
+export function tryHandleOAuthRoute(
+  req: IncomingMessage,
+  res: ServerResponse,
+  parsedUrl: URL,
+  deps: OAuthRouteDeps,
+): boolean {
+  // RFC 8414 discovery document
+  if (
+    parsedUrl.pathname === "/.well-known/oauth-authorization-server" &&
+    req.method === "GET"
+  ) {
+    if (deps.oauthServer) {
+      deps.oauthServer.handleDiscovery(res);
+    } else {
+      res.writeHead(404, { "Content-Type": "text/plain" });
+      res.end("OAuth not configured");
+    }
+    return true;
+  }
+
+  // RFC 9396 Protected Resource Metadata — Claude.ai probes this to discover
+  // which authorization server protects this resource. Both the bare and
+  // resource-path variants are handled.
+  if (
+    req.method === "GET" &&
+    (parsedUrl.pathname === "/.well-known/oauth-protected-resource" ||
+      parsedUrl.pathname.startsWith("/.well-known/oauth-protected-resource/"))
+  ) {
+    if (deps.oauthServer && deps.oauthIssuerUrl) {
+      res.writeHead(200, {
+        "Content-Type": "application/json",
+        "Cache-Control": "no-store",
+      });
+      res.end(
+        JSON.stringify({
+          resource: deps.oauthIssuerUrl,
+          authorization_servers: [deps.oauthIssuerUrl],
+        }),
+      );
+    } else {
+      res.writeHead(404, { "Content-Type": "text/plain" });
+      res.end("OAuth not configured");
+    }
+    return true;
+  }
+
+  // Authorization endpoint
+  if (
+    parsedUrl.pathname === "/oauth/authorize" &&
+    (req.method === "GET" || req.method === "POST")
+  ) {
+    if (deps.oauthServer) {
+      deps.oauthServer.handleAuthorize(req, res);
+    } else {
+      res.writeHead(404, { "Content-Type": "text/plain" });
+      res.end("OAuth not configured");
+    }
+    return true;
+  }
+
+  // Dynamic Client Registration endpoint (RFC 7591)
+  if (parsedUrl.pathname === "/oauth/register") {
+    if (deps.oauthServer) {
+      deps.oauthServer.handleRegister(req, res).catch((err) => {
+        if (!res.headersSent) {
+          res.writeHead(500, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ error: String(err) }));
+        }
+      });
+    } else {
+      res.writeHead(404, { "Content-Type": "text/plain" });
+      res.end("OAuth not configured");
+    }
+    return true;
+  }
+
+  // Token endpoint
+  if (parsedUrl.pathname === "/oauth/token" && req.method === "POST") {
+    if (deps.oauthServer) {
+      deps.oauthServer.handleToken(req, res).catch((err) => {
+        if (!res.headersSent) {
+          res.writeHead(500, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ error: String(err) }));
+        }
+      });
+    } else {
+      res.writeHead(404, { "Content-Type": "text/plain" });
+      res.end("OAuth not configured");
+    }
+    return true;
+  }
+
+  // Revocation endpoint (RFC 7009)
+  if (parsedUrl.pathname === "/oauth/revoke" && req.method === "POST") {
+    if (deps.oauthServer) {
+      deps.oauthServer.handleRevoke(req, res).catch(() => {
+        // RFC 7009: always 200
+        if (!res.headersSent) {
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end("{}");
+        }
+      });
+    } else {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end("{}");
+    }
+    return true;
+  }
+
+  return false;
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -19,6 +19,7 @@ import { renderDashboardHtml } from "./dashboard.js";
 import { tryHandleInboxRoute } from "./inboxRoutes.js";
 import type { Logger } from "./logger.js";
 import type { OAuthServer } from "./oauth.js";
+import { tryHandleOAuthRoute } from "./oauthRoutes.js";
 import {
   loadConfig as loadPatchworkConfig,
   type PatchworkConfig,
@@ -388,110 +389,14 @@ export class Server extends EventEmitter<ServerEvents> {
 
       const parsedUrl = new URL(req.url ?? "/", "http://localhost");
 
-      // ── OAuth 2.0 endpoints (unauthenticated — handled before bearer check) ──
-
-      // RFC 8414 discovery document
+      // ── OAuth 2.0 endpoints (extracted to src/oauthRoutes.ts) ────────────
+      // Unauthenticated — must run BEFORE the bearer-auth gate.
       if (
-        parsedUrl.pathname === "/.well-known/oauth-authorization-server" &&
-        req.method === "GET"
+        tryHandleOAuthRoute(req, res, parsedUrl, {
+          oauthServer: this.oauthServer,
+          oauthIssuerUrl: this.oauthIssuerUrl,
+        })
       ) {
-        if (this.oauthServer) {
-          this.oauthServer.handleDiscovery(res);
-        } else {
-          res.writeHead(404, { "Content-Type": "text/plain" });
-          res.end("OAuth not configured");
-        }
-        return;
-      }
-
-      // RFC 9396 Protected Resource Metadata — Claude.ai probes this to discover
-      // which authorization server protects this resource. Both the bare and
-      // resource-path variants are handled.
-      if (
-        req.method === "GET" &&
-        (parsedUrl.pathname === "/.well-known/oauth-protected-resource" ||
-          parsedUrl.pathname.startsWith(
-            "/.well-known/oauth-protected-resource/",
-          ))
-      ) {
-        if (this.oauthServer && this.oauthIssuerUrl) {
-          res.writeHead(200, {
-            "Content-Type": "application/json",
-            "Cache-Control": "no-store",
-          });
-          res.end(
-            JSON.stringify({
-              resource: this.oauthIssuerUrl,
-              authorization_servers: [this.oauthIssuerUrl],
-            }),
-          );
-        } else {
-          res.writeHead(404, { "Content-Type": "text/plain" });
-          res.end("OAuth not configured");
-        }
-        return;
-      }
-
-      // Authorization endpoint
-      if (
-        parsedUrl.pathname === "/oauth/authorize" &&
-        (req.method === "GET" || req.method === "POST")
-      ) {
-        if (this.oauthServer) {
-          this.oauthServer.handleAuthorize(req, res);
-        } else {
-          res.writeHead(404, { "Content-Type": "text/plain" });
-          res.end("OAuth not configured");
-        }
-        return;
-      }
-
-      // Dynamic Client Registration endpoint (RFC 7591)
-      if (parsedUrl.pathname === "/oauth/register") {
-        if (this.oauthServer) {
-          this.oauthServer.handleRegister(req, res).catch((err) => {
-            if (!res.headersSent) {
-              res.writeHead(500, { "Content-Type": "application/json" });
-              res.end(JSON.stringify({ error: String(err) }));
-            }
-          });
-        } else {
-          res.writeHead(404, { "Content-Type": "text/plain" });
-          res.end("OAuth not configured");
-        }
-        return;
-      }
-
-      // Token endpoint
-      if (parsedUrl.pathname === "/oauth/token" && req.method === "POST") {
-        if (this.oauthServer) {
-          this.oauthServer.handleToken(req, res).catch((err) => {
-            if (!res.headersSent) {
-              res.writeHead(500, { "Content-Type": "application/json" });
-              res.end(JSON.stringify({ error: String(err) }));
-            }
-          });
-        } else {
-          res.writeHead(404, { "Content-Type": "text/plain" });
-          res.end("OAuth not configured");
-        }
-        return;
-      }
-
-      // Revocation endpoint (RFC 7009)
-      if (parsedUrl.pathname === "/oauth/revoke" && req.method === "POST") {
-        if (this.oauthServer) {
-          this.oauthServer.handleRevoke(req, res).catch(() => {
-            // RFC 7009: always 200
-            if (!res.headersSent) {
-              res.writeHead(200, { "Content-Type": "application/json" });
-              res.end("{}");
-            }
-          });
-        } else {
-          res.writeHead(200, { "Content-Type": "application/json" });
-          res.end("{}");
-        }
         return;
       }
 


### PR DESCRIPTION
## Summary

Slice 4 of the `server.ts` split — **first slice with closure deps**. Lifts the 6 OAuth routes out of [src/server.ts](src/server.ts):391-496 into a new module [src/oauthRoutes.ts](src/oauthRoutes.ts):

- `/.well-known/oauth-authorization-server` (RFC 8414 discovery)
- `/.well-known/oauth-protected-resource[/*]` (RFC 9396 protected-resource metadata)
- `/oauth/authorize`
- `/oauth/register` (RFC 7591 dynamic client registration)
- `/oauth/token`
- `/oauth/revoke` (RFC 7009)

`server.ts`: **2266 → 2174 lines**. Cumulative across slices #97–#99 + this: **-1405 lines (-39%)** of route boilerplate.

## New pattern: deps interface

This is the first slice where the block had `this.` references (2 unique: `oauthServer` and `oauthIssuerUrl`). Rather than the zero-deps mechanical lift used in the prior PRs, the function takes an explicit `OAuthRouteDeps` struct:

```ts
if (
  tryHandleOAuthRoute(req, res, parsedUrl, {
    oauthServer: this.oauthServer,
    oauthIssuerUrl: this.oauthIssuerUrl,
  })
) return;
```

This pattern was chosen for: minimum surface change in `server.ts`, no test rewrites needed (the existing 52 tests in [src/__tests__/oauth.test.ts](src/__tests__/oauth.test.ts) target `OAuthServerImpl` directly, not through `Server`), explicit naming of deps at the call site, and so the same shape can extend to the upcoming MCP-card and recipe-routes slices.

## No behavior change

Handler bodies are byte-identical save for `deps.oauthServer` replacing `this.oauthServer`. Specifically preserved:

- The RFC 7009 always-200 behavior on `/oauth/revoke` (even when oauthServer is null)
- The "OAuth not configured" 404 fallback on every other route
- The `Cache-Control: no-store` header on protected-resource metadata
- The `headersSent` guard inside the .catch() handlers on register/token

## Test plan

- [x] Full bridge test suite: `npm test` → **322 files / 4492 tests pass** (no regressions)
- [x] OAuth-specific tests: 52 tests in `oauth.test.ts` → all pass
- [x] LSP diagnostics on `src/server.ts` and `src/oauthRoutes.ts` → zero (errors + warnings)
- [x] `npx biome check` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)