### PR TITLE
refactor(server): extract MCP card + CORS preflight to mcpRoutes.ts (+ test coverage)

### DIFF
--- a/src/__tests__/server-mcp-card.test.ts
+++ b/src/__tests__/server-mcp-card.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Tests for the MCP server-card discovery endpoint and the /mcp CORS
+ * preflight handler. These ran with zero coverage before the extraction
+ * to src/mcpRoutes.ts (slice 5 of the server.ts split) — the agent-driven
+ * audit flagged the gap, and this file closes it.
+ *
+ * The card content is part of the public discovery surface (Claude.ai
+ * probes it before connecting), so any change to its shape is a wire
+ * break. CORS preflight is the gate that decides whether browsers can
+ * POST to /mcp at all, so its origin-validation logic is security-
+ * sensitive and worth pinning.
+ */
+
+import http from "node:http";
+import { afterEach, describe, expect, it } from "vitest";
+import { Logger } from "../logger.js";
+import { Server } from "../server.js";
+
+const logger = new Logger(false);
+let server: Server | null = null;
+
+afterEach(async () => {
+  if (server) await server.close();
+  server = null;
+});
+
+interface RawResponse {
+  status: number;
+  headers: http.IncomingHttpHeaders;
+  body: string;
+}
+
+function request(
+  port: number,
+  path: string,
+  init: { method?: string; headers?: Record<string, string> } = {},
+): Promise<RawResponse> {
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      {
+        host: "127.0.0.1",
+        port,
+        path,
+        method: init.method ?? "GET",
+        headers: init.headers,
+      },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on("data", (c: Buffer) => chunks.push(c));
+        res.on("end", () =>
+          resolve({
+            status: res.statusCode ?? 0,
+            headers: res.headers,
+            body: Buffer.concat(chunks).toString("utf-8"),
+          }),
+        );
+      },
+    );
+    req.on("error", reject);
+    req.end();
+  });
+}
+
+describe("/.well-known/mcp/server-card.json (and /.well-known/mcp alias)", () => {
+  it("returns a server-card JSON with required fields", async () => {
+    server = new Server("test-token", logger);
+    const port = await server.findAndListen(null);
+
+    const res = await request(port, "/.well-known/mcp/server-card.json");
+    expect(res.status).toBe(200);
+    expect(res.headers["content-type"]).toContain("application/json");
+    const card = JSON.parse(res.body) as Record<string, unknown>;
+    expect(card.name).toBe("claude-ide-bridge");
+    expect(typeof card.version).toBe("string");
+    expect(typeof card.description).toBe("string");
+    expect(card.transport).toEqual(["websocket", "stdio", "streamable-http"]);
+    expect(card.capabilities).toMatchObject({
+      tools: true,
+      resources: true,
+      prompts: true,
+      elicitation: true,
+    });
+    expect(card.author).toBe("Oolab Labs");
+    expect(typeof card.license).toBe("string");
+  });
+
+  it("aliased path /.well-known/mcp returns the same card", async () => {
+    server = new Server("test-token", logger);
+    const port = await server.findAndListen(null);
+
+    const res = await request(port, "/.well-known/mcp");
+    expect(res.status).toBe(200);
+    const card = JSON.parse(res.body) as { name: string };
+    expect(card.name).toBe("claude-ide-bridge");
+  });
+
+  it("sets Access-Control-Allow-Origin: * (public discovery)", async () => {
+    server = new Server("test-token", logger);
+    const port = await server.findAndListen(null);
+
+    const res = await request(port, "/.well-known/mcp/server-card.json");
+    expect(res.headers["access-control-allow-origin"]).toBe("*");
+  });
+
+  it("does not require auth", async () => {
+    server = new Server("test-token", logger);
+    const port = await server.findAndListen(null);
+
+    // No Authorization header — must still return 200
+    const res = await request(port, "/.well-known/mcp/server-card.json");
+    expect(res.status).toBe(200);
+  });
+});
+
+describe("OPTIONS /mcp — CORS preflight", () => {
+  it("returns 204 and reflects loopback origin even without --cors-origin", async () => {
+    server = new Server("test-token", logger);
+    const port = await server.findAndListen(null);
+
+    const res = await request(port, "/mcp", {
+      method: "OPTIONS",
+      headers: { Origin: `http://127.0.0.1:${port}` },
+    });
+    expect(res.status).toBe(204);
+    expect(res.headers["access-control-allow-origin"]).toBe(
+      `http://127.0.0.1:${port}`,
+    );
+    expect(res.headers["access-control-allow-methods"]).toContain("POST");
+    expect(res.headers["access-control-allow-methods"]).toContain("DELETE");
+    expect(res.headers["access-control-allow-headers"]).toContain(
+      "Authorization",
+    );
+    expect(res.headers["access-control-allow-headers"]).toContain(
+      "Mcp-Session-Id",
+    );
+    expect(res.headers["access-control-expose-headers"]).toContain(
+      "Mcp-Session-Id",
+    );
+  });
+
+  it("reflects an explicitly-allowed origin from extraCorsOrigins", async () => {
+    server = new Server("test-token", logger, ["https://claude.ai"]);
+    const port = await server.findAndListen(null);
+
+    const res = await request(port, "/mcp", {
+      method: "OPTIONS",
+      headers: { Origin: "https://claude.ai" },
+    });
+    expect(res.status).toBe(204);
+    expect(res.headers["access-control-allow-origin"]).toBe(
+      "https://claude.ai",
+    );
+  });
+
+  it("does NOT reflect an untrusted non-loopback origin", async () => {
+    server = new Server("test-token", logger);
+    const port = await server.findAndListen(null);
+
+    const res = await request(port, "/mcp", {
+      method: "OPTIONS",
+      headers: { Origin: "https://evil.example.com" },
+    });
+    expect(res.status).toBe(204);
+    // The CORS escape: if this header is set to evil.example.com, browsers
+    // will let evil.example.com POST to /mcp. Must remain unset/null.
+    expect(res.headers["access-control-allow-origin"]).toBeUndefined();
+  });
+
+  it("returns 204 with no Access-Control-Allow-Origin when Origin header is absent", async () => {
+    server = new Server("test-token", logger);
+    const port = await server.findAndListen(null);
+
+    const res = await request(port, "/mcp", { method: "OPTIONS" });
+    expect(res.status).toBe(204);
+    expect(res.headers["access-control-allow-origin"]).toBeUndefined();
+  });
+});

--- a/src/cors.ts
+++ b/src/cors.ts
@@ -1,0 +1,31 @@
+/**
+ * CORS origin validator. Extracted from server.ts so that route modules
+ * (mcpRoutes.ts, etc.) can use it without circular imports.
+ */
+
+/**
+ * Return the CORS origin to reflect, or null if the origin is untrusted.
+ * Loopback origins are always allowed. Additional origins can be passed via
+ * --cors-origin (e.g. https://claude.ai for remote deployments).
+ */
+export function corsOrigin(
+  requestOrigin: string | undefined,
+  extraOrigins: string[] = [],
+): string | null {
+  if (!requestOrigin) return null;
+  if (extraOrigins.includes(requestOrigin)) return requestOrigin;
+  try {
+    const { hostname, protocol } = new URL(requestOrigin);
+    if (
+      protocol === "http:" &&
+      (hostname === "localhost" ||
+        hostname === "127.0.0.1" ||
+        hostname === "[::1]")
+    ) {
+      return requestOrigin;
+    }
+  } catch {
+    // malformed origin — deny
+  }
+  return null;
+}

--- a/src/mcpRoutes.ts
+++ b/src/mcpRoutes.ts
@@ -1,0 +1,99 @@
+/**
+ * MCP server-card + CORS preflight dispatcher — extracted from
+ * src/server.ts.
+ *
+ * Owns two unauthenticated routes that must run BEFORE the bearer-auth
+ * gate:
+ *
+ *   - GET /.well-known/mcp/server-card.json (and /.well-known/mcp alias)
+ *     The public discovery card. Claude.ai probes this before connecting
+ *     to learn capabilities and transports. Always returns 200 + JSON
+ *     with `Access-Control-Allow-Origin: *` (intentional — discovery is
+ *     public; no secrets).
+ *
+ *   - OPTIONS /mcp
+ *     CORS preflight. Browsers (and Claude Desktop's web renderer) send
+ *     this before POSTing. Origin validation goes through `corsOrigin()`
+ *     which reflects loopback origins by default and any extra origins
+ *     passed via --cors-origin. UNTRUSTED ORIGINS GET NO Access-Control-
+ *     Allow-Origin HEADER — that's the gate that prevents CORS escape.
+ *
+ * DI shape: only the CORS-preflight handler needs `extraCorsOrigins`
+ * (the --cors-origin allowlist). Server.ts passes it as a deps struct
+ * matching the pattern established in oauthRoutes.ts.
+ */
+
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { corsOrigin } from "./cors.js";
+import { BRIDGE_PROTOCOL_VERSION, PACKAGE_LICENSE } from "./version.js";
+
+export interface McpRouteDeps {
+  /** Extra trusted origins from --cors-origin / CLAUDE_IDE_BRIDGE_CORS_ORIGINS. */
+  extraCorsOrigins: string[];
+}
+
+/**
+ * Try to handle the MCP server-card discovery routes or the /mcp CORS
+ * preflight. Returns true if the route was dispatched (caller should
+ * `return` from the request handler), false otherwise.
+ *
+ * MUST be called before the bearer-auth gate.
+ */
+export function tryHandleMcpRoute(
+  req: IncomingMessage,
+  res: ServerResponse,
+  parsedUrl: URL,
+  deps: McpRouteDeps,
+): boolean {
+  if (
+    req.url === "/.well-known/mcp/server-card.json" ||
+    req.url === "/.well-known/mcp"
+  ) {
+    const card = {
+      name: "claude-ide-bridge",
+      version: BRIDGE_PROTOCOL_VERSION,
+      description:
+        "MCP bridge providing full IDE integration for Claude Code — LSP, diagnostics, file operations, terminal, debug adapters, and AI task orchestration",
+      homepage: "https://github.com/Oolab-labs/claude-ide-bridge",
+      transport: ["websocket", "stdio", "streamable-http"],
+      capabilities: {
+        tools: true,
+        resources: true,
+        prompts: true,
+        elicitation: true,
+      },
+      author: "Oolab Labs",
+      license: PACKAGE_LICENSE,
+      repository: "https://github.com/Oolab-labs/claude-ide-bridge",
+    };
+    res.writeHead(200, {
+      "Content-Type": "application/json",
+      "Access-Control-Allow-Origin": "*",
+    });
+    res.end(JSON.stringify(card, null, 2));
+    return true;
+  }
+
+  // CORS preflight for /mcp — browsers (and Claude Desktop's web renderer) send
+  // OPTIONS before POST. Respond without requiring auth so the preflight succeeds.
+  if (req.method === "OPTIONS" && parsedUrl.pathname === "/mcp") {
+    const origin = corsOrigin(req.headers.origin, deps.extraCorsOrigins);
+    if (origin) {
+      res.setHeader("Access-Control-Allow-Origin", origin);
+      res.setHeader(
+        "Access-Control-Allow-Methods",
+        "GET, POST, DELETE, OPTIONS",
+      );
+      res.setHeader(
+        "Access-Control-Allow-Headers",
+        "Content-Type, Authorization, Mcp-Session-Id",
+      );
+      res.setHeader("Access-Control-Expose-Headers", "Mcp-Session-Id");
+    }
+    res.writeHead(204);
+    res.end();
+    return true;
+  }
+
+  return false;
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -18,6 +18,7 @@ import { timingSafeStringEqual } from "./crypto.js";
 import { renderDashboardHtml } from "./dashboard.js";
 import { tryHandleInboxRoute } from "./inboxRoutes.js";
 import type { Logger } from "./logger.js";
+import { tryHandleMcpRoute } from "./mcpRoutes.js";
 import type { OAuthServer } from "./oauth.js";
 import { tryHandleOAuthRoute } from "./oauthRoutes.js";
 import {
@@ -26,11 +27,7 @@ import {
   defaultConfigPath as patchworkConfigPath,
   saveConfig as savePatchworkConfig,
 } from "./patchworkConfig.js";
-import {
-  BRIDGE_PROTOCOL_VERSION,
-  PACKAGE_LICENSE,
-  PACKAGE_VERSION,
-} from "./version.js";
+import { PACKAGE_VERSION } from "./version.js";
 
 const LOOPBACK_HOSTS = new Set(["localhost", "127.0.0.1", "[::1]"]);
 const SESSION_ID_RE =
@@ -62,32 +59,11 @@ interface ServerEvents {
   extension: [ws: WebSocket];
 }
 
-/**
- * Return the CORS origin to reflect, or null if the origin is untrusted.
- * Loopback origins are always allowed. Additional origins can be passed via
- * --cors-origin (e.g. https://claude.ai for remote deployments).
- */
-export function corsOrigin(
-  requestOrigin: string | undefined,
-  extraOrigins: string[] = [],
-): string | null {
-  if (!requestOrigin) return null;
-  if (extraOrigins.includes(requestOrigin)) return requestOrigin;
-  try {
-    const { hostname, protocol } = new URL(requestOrigin);
-    if (
-      protocol === "http:" &&
-      (hostname === "localhost" ||
-        hostname === "127.0.0.1" ||
-        hostname === "[::1]")
-    ) {
-      return requestOrigin;
-    }
-  } catch {
-    // malformed origin — deny
-  }
-  return null;
-}
+import { corsOrigin } from "./cors.js";
+
+// Re-exported for streamableHttp.ts and any external callers; new code
+// should import directly from "./cors.js".
+export { corsOrigin };
 
 // Re-export canonical constant-time comparison for use in this module.
 // Implementation lives in src/crypto.ts — see there for security notes.
@@ -400,55 +376,13 @@ export class Server extends EventEmitter<ServerEvents> {
         return;
       }
 
-      // ── MCP server-card (public) ──────────────────────────────────────────
-
+      // ── MCP server-card + CORS preflight (extracted to src/mcpRoutes.ts) ─
+      // Unauthenticated — must run BEFORE the bearer-auth gate.
       if (
-        req.url === "/.well-known/mcp/server-card.json" ||
-        req.url === "/.well-known/mcp"
+        tryHandleMcpRoute(req, res, parsedUrl, {
+          extraCorsOrigins: this.extraCorsOrigins,
+        })
       ) {
-        const card = {
-          name: "claude-ide-bridge",
-          version: BRIDGE_PROTOCOL_VERSION,
-          description:
-            "MCP bridge providing full IDE integration for Claude Code — LSP, diagnostics, file operations, terminal, debug adapters, and AI task orchestration",
-          homepage: "https://github.com/Oolab-labs/claude-ide-bridge",
-          transport: ["websocket", "stdio", "streamable-http"],
-          capabilities: {
-            tools: true,
-            resources: true,
-            prompts: true,
-            elicitation: true,
-          },
-          author: "Oolab Labs",
-          license: PACKAGE_LICENSE,
-          repository: "https://github.com/Oolab-labs/claude-ide-bridge",
-        };
-        res.writeHead(200, {
-          "Content-Type": "application/json",
-          "Access-Control-Allow-Origin": "*",
-        });
-        res.end(JSON.stringify(card, null, 2));
-        return;
-      }
-
-      // CORS preflight for /mcp — browsers (and Claude Desktop's web renderer) send
-      // OPTIONS before POST. Respond without requiring auth so the preflight succeeds.
-      if (req.method === "OPTIONS" && parsedUrl.pathname === "/mcp") {
-        const origin = corsOrigin(req.headers.origin, this.extraCorsOrigins);
-        if (origin) {
-          res.setHeader("Access-Control-Allow-Origin", origin);
-          res.setHeader(
-            "Access-Control-Allow-Methods",
-            "GET, POST, DELETE, OPTIONS",
-          );
-          res.setHeader(
-            "Access-Control-Allow-Headers",
-            "Content-Type, Authorization, Mcp-Session-Id",
-          );
-          res.setHeader("Access-Control-Expose-Headers", "Mcp-Session-Id");
-        }
-        res.writeHead(204);
-        res.end();
         return;
       }
 


### PR DESCRIPTION
## Summary

Slice 5 of the `server.ts` split. Two changes bundled (per the agent-driven extraction plan): **lift the routes** + **close the test-coverage gap** the audit flagged.

**3 new files:**

- [src/mcpRoutes.ts](src/mcpRoutes.ts) — `tryHandleMcpRoute(req, res, parsedUrl, deps)` with `McpRouteDeps { extraCorsOrigins }`. Same deps-interface pattern as [PR #100](https://github.com/Oolab-labs/patchwork-os/pull/100).
- [src/cors.ts](src/cors.ts) — `corsOrigin()` validator hoisted out of server.ts so route modules can use it without circular imports. `server.ts` re-exports for [streamableHttp.ts](src/streamableHttp.ts) (which still imports from `./server.js`).
- [src/__tests__/server-mcp-card.test.ts](src/__tests__/server-mcp-card.test.ts) — **8 tests** covering the card shape, the `/.well-known/mcp` alias, the always-on `Access-Control-Allow-Origin: *`, the CORS preflight reflecting loopback + `extraCorsOrigins`, and the security gate: **untrusted origins must NOT receive `Access-Control-Allow-Origin` in the preflight response**.

**Tests-first:** written and verified green against the un-extracted code, then re-verified green after the lift. Real safety net before the move.

`server.ts`: **2174 → 2107 lines** (-3% this slice). Cumulative across slices #97/#98/#99/#100/this: **-1472 lines (-41%)** from session start.

## Routes covered

| Method | Path | Auth |
|---|---|---|
| GET | `/.well-known/mcp/server-card.json` | none — public discovery |
| GET | `/.well-known/mcp` (alias) | none — public discovery |
| OPTIONS | `/mcp` | none — preflight |

## Why a separate cors.ts

server.ts imports mcpRoutes.ts (which needs `corsOrigin`); mcpRoutes.ts importing back from server.ts would be a circular module graph. ES modules tolerate it for runtime function calls but it's flaky and a smell. Hoisting to a tiny shared module is cleaner and unblocks future route extractions that need the same validator.

## Bonus cleanup

Biome flagged two now-unused imports in server.ts (`BRIDGE_PROTOCOL_VERSION`, `PACKAGE_LICENSE` — only used in the moved card body). Pruned in this PR.

## Test plan

- [x] Full bridge test suite: `npm test` → **323 files / 4500 tests pass** (+1 file, +8 tests vs main)
- [x] LSP diagnostics on all 4 files → zero (errors + warnings)
- [x] `npx biome check` → clean
- [x] streamableHttp.ts re-imports `corsOrigin` from server.ts → still resolves via re-export

🤖 Generated with [Claude Code](https://claude.com/claude-code)