### PR TITLE
fix(security): connector + oauth + automation hardening (round 2 bug hunt)

### DIFF
--- a/src/connectors/baseConnector.ts
+++ b/src/connectors/baseConnector.ts
@@ -315,9 +315,17 @@ export abstract class BaseConnector {
       };
     }
 
-    // Apply rate limit backoff
+    // Apply rate limit backoff. Clear it once the reset window has elapsed —
+    // otherwise a single 429 with `Retry-After: 60` causes every subsequent
+    // request to wait 60s indefinitely.
     if (this.rateLimit.backoffMs > 0) {
-      await sleep(this.rateLimit.backoffMs);
+      const resetAt = this.rateLimit.resetAt?.getTime();
+      if (resetAt && Date.now() >= resetAt) {
+        this.rateLimit.backoffMs = 0;
+      } else {
+        await sleep(this.rateLimit.backoffMs);
+        this.rateLimit.backoffMs = 0;
+      }
     }
 
     // Execute with retry

--- a/src/connectors/gmail.ts
+++ b/src/connectors/gmail.ts
@@ -130,8 +130,13 @@ async function exchangeCode(code: string): Promise<GmailTokens> {
     }).toString(),
   });
   if (!res.ok) {
-    const body = await res.text();
-    throw new Error(`Token exchange failed: ${res.status} ${body}`);
+    // Body may echo client_secret in malformed-grant responses — log code only.
+    const body = await res.text().catch(() => "");
+    let code = "unknown";
+    try {
+      code = (JSON.parse(body) as { error?: string }).error ?? "unknown";
+    } catch {}
+    throw new Error(`Token exchange failed: ${res.status} (${code})`);
   }
   const json = (await res.json()) as {
     access_token: string;
@@ -172,8 +177,12 @@ async function refreshAccessToken(tokens: GmailTokens): Promise<GmailTokens> {
     }).toString(),
   });
   if (!res.ok) {
-    const body = await res.text();
-    throw new Error(`Token refresh failed: ${res.status} ${body}`);
+    const body = await res.text().catch(() => "");
+    let code = "unknown";
+    try {
+      code = (JSON.parse(body) as { error?: string }).error ?? "unknown";
+    } catch {}
+    throw new Error(`Token refresh failed: ${res.status} (${code})`);
   }
   const json = (await res.json()) as {
     access_token: string;

--- a/src/connectors/googleCalendar.ts
+++ b/src/connectors/googleCalendar.ts
@@ -175,8 +175,12 @@ async function exchangeCode(
     }).toString(),
   });
   if (!res.ok) {
-    const body = await res.text();
-    throw new Error(`Token exchange failed: ${res.status} ${body}`);
+    const body = await res.text().catch(() => "");
+    let code = "unknown";
+    try {
+      code = (JSON.parse(body) as { error?: string }).error ?? "unknown";
+    } catch {}
+    throw new Error(`Token exchange failed: ${res.status} (${code})`);
   }
   const json = (await res.json()) as {
     access_token: string;
@@ -219,8 +223,12 @@ async function refreshAccessToken(
     }).toString(),
   });
   if (!res.ok) {
-    const body = await res.text();
-    throw new Error(`Token refresh failed: ${res.status} ${body}`);
+    const body = await res.text().catch(() => "");
+    let code = "unknown";
+    try {
+      code = (JSON.parse(body) as { error?: string }).error ?? "unknown";
+    } catch {}
+    throw new Error(`Token refresh failed: ${res.status} (${code})`);
   }
   const json = (await res.json()) as {
     access_token: string;

--- a/src/connectors/zendesk.ts
+++ b/src/connectors/zendesk.ts
@@ -336,7 +336,12 @@ export class ZendeskConnector extends BaseConnector {
   // ── Helpers ────────────────────────────────────────────────────────────────
 
   private baseUrl(): string {
-    return `https://${this.tokens?.subdomain}.zendesk.com`;
+    const sub = this.tokens?.subdomain;
+    if (!sub) throw new Error("Zendesk not connected");
+    if (!/^[a-z0-9-]{1,63}$/i.test(sub)) {
+      throw new Error("Zendesk subdomain has invalid format");
+    }
+    return `https://${sub}.zendesk.com`;
   }
 
   private buildHeaders(token: string): Record<string, string> {
@@ -448,6 +453,19 @@ export async function handleZendeskConnect(
     apiToken = parsed.apiToken;
     email = parsed.email;
     subdomain = parsed.subdomain.replace(/\.zendesk\.com$/, ""); // strip if full domain given
+    // Validate subdomain shape after suffix strip — prevents URL injection /
+    // SSRF via `https://${subdomain}.zendesk.com` interpolation in baseUrl().
+    if (!/^[a-z0-9-]{1,63}$/i.test(subdomain)) {
+      return {
+        status: 400,
+        contentType: "application/json",
+        body: JSON.stringify({
+          ok: false,
+          error:
+            "subdomain must be 1-63 alphanumeric/hyphen characters (no dots, slashes, or special chars)",
+        }),
+      };
+    }
   } catch {
     return {
       status: 400,

--- a/src/fp/automationState.ts
+++ b/src/fp/automationState.ts
@@ -206,9 +206,12 @@ export function recordDedup(
   now: number,
 ): AutomationState {
   const newMap = new Map(state.deduplicationWindow);
+  // Delete-then-set so re-recording an existing key bumps it to the most
+  // recent insertion-order slot (LRU semantics under FIFO eviction). Without
+  // this, hot keys can be evicted while cold keys survive.
+  newMap.delete(key);
   newMap.set(key, now);
   if (newMap.size > DEDUP_MAX_SIZE) {
-    // Evict oldest by insertion order (Map preserves insertion order)
     const firstKey = newMap.keys().next().value as string;
     newMap.delete(firstKey);
   }

--- a/src/fp/policyParser.ts
+++ b/src/fp/policyParser.ts
@@ -145,9 +145,12 @@ function buildHook(
     extras?.kind === "diagnosticsError" &&
     extras.dedupeByContent;
 
+  // Enforce min 5s cooldown at runtime — schema validators may pass 0 or
+  // sub-5000 values past AJV (callers can construct hooks programmatically).
+  const safeCooldownMs = Math.max(5_000, cooldownMs);
   let program: AutomationProgram = useDedup
     ? hookNode
-    : withCooldown(key, cooldownMs, hookNode);
+    : withCooldown(key, safeCooldownMs, hookNode);
 
   // Wrap WithRetry around WithCooldown if retryCount > 0
   const retryCount = src.retryCount ?? 0;

--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -281,6 +281,11 @@ export class OAuthServerImpl implements OAuthServer {
           this.sendJson(res, 400, { error: "invalid_redirect_uri" });
           return;
         }
+        // RFC 6749 §3.1.2 — redirect_uri MUST NOT include a fragment.
+        if (u.hash) {
+          this.sendJson(res, 400, { error: "invalid_redirect_uri" });
+          return;
+        }
       } catch {
         this.sendJson(res, 400, { error: "invalid_redirect_uri" });
         return;
@@ -402,6 +407,7 @@ export class OAuthServerImpl implements OAuthServer {
       "Content-Security-Policy":
         "default-src 'none'; style-src 'unsafe-inline'; form-action 'self'; frame-ancestors 'none'",
       "X-Frame-Options": "DENY",
+      "Referrer-Policy": "no-referrer",
     });
     res.end(
       this.approvalPage({
@@ -472,6 +478,8 @@ export class OAuthServerImpl implements OAuthServer {
       const u = new URL(redirectUri);
       u.searchParams.set("error", "access_denied");
       if (state) u.searchParams.set("state", state);
+      // RFC 9207 — echo iss to mitigate authorization-server mix-up attacks.
+      u.searchParams.set("iss", this.issuerUrl);
       res.writeHead(302, { Location: u.toString() });
       res.end();
       return;
@@ -523,6 +531,8 @@ export class OAuthServerImpl implements OAuthServer {
     const dest = new URL(redirectUri);
     dest.searchParams.set("code", code);
     if (state) dest.searchParams.set("state", state);
+    // RFC 9207 — echo iss to mitigate authorization-server mix-up attacks.
+    dest.searchParams.set("iss", this.issuerUrl);
     res.writeHead(302, { Location: dest.toString() });
     res.end();
   }
@@ -919,6 +929,10 @@ export class OAuthServerImpl implements OAuthServer {
           redirect: "error",
         });
         if (!resp.ok) return null;
+        // Reject non-JSON responses — prevents an attacker-controlled HTTPS
+        // endpoint from serving a JSON-shaped HTML/script body.
+        const ct = resp.headers.get("content-type") ?? "";
+        if (!/^application\/json\b/i.test(ct)) return null;
         // Stream with size cap to prevent OOM
         const reader = resp.body?.getReader();
         if (!reader) return null;
@@ -973,6 +987,9 @@ export class OAuthServerImpl implements OAuthServer {
     if (!clientId || !redirectUri || !codeChallenge)
       return { error: "invalid_request" };
     if (codeChallengeMethod !== "S256") return { error: "invalid_request" };
+    // Cap state length to prevent memory amplification via huge reflected
+    // query strings.
+    if (state && state.length > 512) return { error: "invalid_request" };
 
     // CIMD: if client_id is an HTTPS URL, fetch its metadata document to get
     // redirect_uris dynamically (SEP-991 / Claude Code v2.1.81+).


### PR DESCRIPTION
## Summary

Round-2 bug-hunt sweep covering connectors, OAuth 2.0 server, and the automation hook system. 10 low-risk hardening fixes consolidated into one PR. Higher-effort findings (token-refresh inflight guards, CIMD DNS pinning, automation parallel-branch dedup race) deferred to separate work.

## Connectors (`src/connectors/`)

- **Zendesk SSRF / URL injection** — `subdomain` (user-supplied at `/connections/zendesk/connect`) was interpolated into `\`https://${subdomain}.zendesk.com\`` unchecked. Values containing `/`, `@`, `#`, etc. could route requests to arbitrary hosts. Now validated against `/^[a-z0-9-]{1,63}$/` after the existing `.zendesk.com`-suffix strip, and re-validated in `baseUrl()` (which also throws on uninitialized tokens instead of silently producing `https://undefined.zendesk.com`).
- **Token-exchange / token-refresh secret leakage (Gmail, Google Calendar)** — `Token exchange failed: ${res.status} ${body}` embedded the raw Google response, which can echo the malformed `client_secret` in some grant-error flows. Now logs only `status (oauth_error_code)`.
- **Rate-limit backoff never reset (baseConnector)** — a single 429 with `Retry-After: 60` left `rateLimit.backoffMs = 60000` forever. Now cleared after the reset window or after applying the wait once.

## OAuth 2.0 server (`src/oauth.ts`)

- **`redirect_uri` fragment rejection** at `/oauth/register` (RFC 6749 §3.1.2).
- **`state` length cap** (512 chars) at `/oauth/authorize` to prevent memory amplification via huge reflected query strings.
- **`Referrer-Policy: no-referrer`** on the approval page response so the POST referrer doesn't leak the GET URL (which carries `state` + `code_challenge`).
- **`iss` echoed in redirect** on both success and `access_denied` (RFC 9207 mix-up mitigation).
- **CIMD `Content-Type` enforcement** — fetch now rejects any response whose `Content-Type` does not start with `application/json`, preventing an attacker-controlled HTTPS endpoint from serving JSON-shaped HTML/script as a CIMD document.

## Automation (`src/fp/`)

- **`cooldownMs` runtime min-5000 enforcement** in `policyParser.buildHook`. Previously enforced only via AJV; programmatic hook construction could pass sub-5000 values straight to `withCooldown`.
- **`recordDedup` LRU semantics** — `delete` then `set` so re-recording an existing key bumps it to the most-recent insertion-order slot. Previously hot keys could be evicted while cold ones survived under FIFO eviction.

## Deferred (separate PRs)

- Token-refresh inflight guard for gmail/calendar/baseConnector — needs concurrency testing
- CIMD DNS pre-resolution + lookup pinning + decimal-IP normalization
- CIMD trust-on-first-fetch divergence between cached `registeredClients` and live CIMD content
- Automation parallel-branch dedup race (`WithCooldown` / `WithDedup` check-then-write across `Parallel` branches)
- `mergeAutomationStates` `taskTimestamps` double-count + `unionMap` last-wins
- Verification of whether unified hook names (`onCompaction`, `onDiagnosticsStateChange`, `onDebugSession`) are actually implemented in the parser/interpreter as CLAUDE.md claims

## Test plan

- [x] `npx vitest run` — 4504/4504 pass
- [x] `npx biome check` — clean
- [ ] Manual: connect a Zendesk account with valid + invalid subdomains, verify error envelopes
- [ ] Manual: trigger a 429 on a connector and confirm subsequent requests don't stall

🤖 Generated with [Claude Code](https://claude.com/claude-code)