### PR TITLE
fix(connectors): dedupe in-flight token refresh

### DIFF
--- a/src/connectors/__tests__/baseConnector.refreshRace.test.ts
+++ b/src/connectors/__tests__/baseConnector.refreshRace.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Regression tests for the token-refresh inflight guard.
+ *
+ * Without the guard, two concurrent expired-token callers both POST to the
+ * IdP token endpoint. On Google (and any IdP that rotates refresh tokens on
+ * use), the second POST burns the rotated refresh_token issued by the first,
+ * which invalidates the connector entirely.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  type AuthContext,
+  BaseConnector,
+  type ConnectorError,
+  type ConnectorStatus,
+  type OAuthConfig,
+} from "../baseConnector.js";
+
+const storeTokens = vi.fn().mockResolvedValue(undefined);
+const getTokens = vi.fn().mockResolvedValue(null);
+const deleteTokens = vi.fn().mockResolvedValue(undefined);
+
+vi.mock("../tokenStorage.js", () => ({
+  storeTokens: (...args: unknown[]) => storeTokens(...args),
+  getTokens: (...args: unknown[]) => getTokens(...args),
+  deleteTokens: (...args: unknown[]) => deleteTokens(...args),
+}));
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+class TestConnector extends BaseConnector {
+  readonly providerName = "test-provider";
+
+  protected getOAuthConfig(): OAuthConfig | null {
+    return {
+      clientId: "test-client",
+      clientSecret: "test-secret",
+      tokenEndpoint: "https://oauth.example.com/token",
+    };
+  }
+
+  async authenticate(): Promise<AuthContext> {
+    throw new Error("authenticate not configured");
+  }
+
+  async healthCheck() {
+    return { ok: true };
+  }
+
+  normalizeError(err: unknown): ConnectorError {
+    return {
+      code: "provider_error",
+      message: err instanceof Error ? err.message : "unknown",
+      retryable: false,
+    };
+  }
+
+  getStatus(): ConnectorStatus {
+    return { id: this.providerName, status: "connected" };
+  }
+
+  setAuth(auth: AuthContext | null) {
+    this.auth = auth;
+  }
+
+  callRefreshDeduped() {
+    return this.refreshTokenDeduped();
+  }
+}
+
+beforeEach(() => {
+  mockFetch.mockReset();
+  storeTokens.mockClear();
+});
+
+afterEach(() => {
+  vi.clearAllTimers();
+});
+
+describe("BaseConnector.refreshTokenDeduped()", () => {
+  it("dedupes concurrent refreshes — single fetch for N parallel callers", async () => {
+    const c = new TestConnector();
+    c.setAuth({
+      token: "at_old",
+      refreshToken: "rt_v1",
+      expiresAt: new Date(Date.now() - 1000),
+    });
+
+    let resolveFetch!: (v: Response) => void;
+    mockFetch.mockImplementationOnce(
+      () =>
+        new Promise<Response>((resolve) => {
+          resolveFetch = resolve;
+        }),
+    );
+
+    const calls = Array.from({ length: 5 }, () => c.callRefreshDeduped());
+
+    // All 5 callers await the same in-flight promise. Resolve the single fetch
+    // and all 5 must complete with the same new token.
+    resolveFetch(
+      new Response(
+        JSON.stringify({
+          access_token: "at_new",
+          refresh_token: "rt_v2",
+          expires_in: 3600,
+          token_type: "Bearer",
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+
+    const results = await Promise.all(calls);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(results.every((r) => r?.token === "at_new")).toBe(true);
+  });
+
+  it("clears inflight cache after success — next caller fetches fresh", async () => {
+    const c = new TestConnector();
+    c.setAuth({
+      token: "at_old",
+      refreshToken: "rt_v1",
+      expiresAt: new Date(Date.now() - 1000),
+    });
+
+    mockFetch.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          access_token: "at_new",
+          expires_in: 3600,
+          token_type: "Bearer",
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+
+    await c.callRefreshDeduped();
+    await c.callRefreshDeduped();
+
+    // Two sequential calls = two fetches (cache cleared in finally).
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("clears inflight cache after failure — next caller retries", async () => {
+    const c = new TestConnector();
+    c.setAuth({
+      token: "at_old",
+      refreshToken: "rt_v1",
+      expiresAt: new Date(Date.now() - 1000),
+    });
+
+    // First refresh: server returns 500 → returns null (transient).
+    mockFetch.mockResolvedValueOnce(
+      new Response("server error", { status: 500 }),
+    );
+    // Second refresh: success.
+    mockFetch.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          access_token: "at_new",
+          expires_in: 3600,
+          token_type: "Bearer",
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+
+    const first = await c.callRefreshDeduped();
+    expect(first).toBeNull();
+
+    const second = await c.callRefreshDeduped();
+    expect(second?.token).toBe("at_new");
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/connectors/baseConnector.ts
+++ b/src/connectors/baseConnector.ts
@@ -63,6 +63,14 @@ export abstract class BaseConnector {
     backoffMs: 0,
   };
   protected oauthConfig: OAuthConfig | null = null;
+  /**
+   * In-flight refresh promise. When set, concurrent callers await the same
+   * promise instead of POSTing to the IdP a second time. Cleared in `finally`
+   * so the next caller (after success or failure) gets a fresh attempt.
+   * Prevents double-refresh races where two concurrent 401s both burn the same
+   * refresh token — fatal on IdPs that rotate refresh tokens (Google).
+   */
+  private refreshInflight: Promise<AuthContext | null> | null = null;
 
   abstract readonly providerName: string;
 
@@ -251,6 +259,29 @@ export abstract class BaseConnector {
   }
 
   /**
+   * Refresh the access token, deduplicating concurrent calls. Two callers
+   * hitting an expired token simultaneously share the same refresh promise
+   * instead of POSTing twice to the IdP. Critical for Google (refresh tokens
+   * rotate on use — second concurrent refresh would invalidate the connector).
+   *
+   * The cache is cleared in `finally` so the next caller after settle (success
+   * or failure) gets a fresh attempt. On refresh failure, all concurrent
+   * waiters see the same rejection and the caller's normal auth-fallback path
+   * (full re-authenticate) takes over.
+   */
+  protected refreshTokenDeduped(): Promise<AuthContext | null> {
+    if (this.refreshInflight) return this.refreshInflight;
+    this.refreshInflight = (async () => {
+      try {
+        return await this.refreshToken();
+      } finally {
+        this.refreshInflight = null;
+      }
+    })();
+    return this.refreshInflight;
+  }
+
+  /**
    * Health check — validates token is valid without side effects.
    * Default implementation: make lightweight API call (e.g., /me or /user).
    */
@@ -281,7 +312,7 @@ export abstract class BaseConnector {
     if (!this.auth || this.isTokenExpired()) {
       // Try OAuth refresh if we have a refresh token
       if (this.auth?.refreshToken) {
-        const refreshed = await this.refreshToken();
+        const refreshed = await this.refreshTokenDeduped();
         if (refreshed) {
           this.auth = refreshed;
         } else {
@@ -348,7 +379,7 @@ export abstract class BaseConnector {
         // Token might have expired mid-call - try refresh first
         if (normalized.code === "auth_expired") {
           if (this.auth?.refreshToken) {
-            const refreshed = await this.refreshToken();
+            const refreshed = await this.refreshTokenDeduped();
             if (refreshed) {
               this.auth = refreshed;
               continue; // Retry with new token

--- a/src/connectors/gmail.ts
+++ b/src/connectors/gmail.ts
@@ -200,13 +200,30 @@ async function refreshAccessToken(tokens: GmailTokens): Promise<GmailTokens> {
   return updated;
 }
 
+/**
+ * In-flight refresh promise. Prevents two concurrent expired-token callers
+ * from both POSTing to Google's token endpoint and burning the same refresh
+ * token (Google rotates refresh tokens on use — second call would invalidate
+ * the connector). Cleared in `finally` so retry-after-failure works.
+ */
+let refreshInflight: Promise<GmailTokens> | null = null;
+
 /** Returns a valid access token, refreshing if needed. */
 export async function getValidAccessToken(): Promise<string> {
   let tokens = loadTokens();
   if (!tokens) throw new Error("Gmail not connected");
   const bufferMs = 60_000;
   if (!tokens.expiry_date || Date.now() > tokens.expiry_date - bufferMs) {
-    tokens = await refreshAccessToken(tokens);
+    if (!refreshInflight) {
+      refreshInflight = (async () => {
+        try {
+          return await refreshAccessToken(tokens as GmailTokens);
+        } finally {
+          refreshInflight = null;
+        }
+      })();
+    }
+    tokens = await refreshInflight;
   }
   return tokens.access_token;
 }

--- a/src/connectors/googleCalendar.ts
+++ b/src/connectors/googleCalendar.ts
@@ -246,13 +246,28 @@ async function refreshAccessToken(
   return updated;
 }
 
+/**
+ * In-flight refresh promise. Prevents concurrent expired-token callers from
+ * both burning the same refresh token (Google rotates on use).
+ */
+let refreshInflight: Promise<CalendarTokens> | null = null;
+
 /** Returns a valid access token, refreshing if needed. */
 export async function getValidAccessToken(): Promise<string> {
   let tokens = loadTokens();
   if (!tokens) throw new Error("Google Calendar not connected");
   const bufferMs = 60_000;
   if (!tokens.expiry_date || Date.now() > tokens.expiry_date - bufferMs) {
-    tokens = await refreshAccessToken(tokens);
+    if (!refreshInflight) {
+      refreshInflight = (async () => {
+        try {
+          return await refreshAccessToken(tokens as CalendarTokens);
+        } finally {
+          refreshInflight = null;
+        }
+      })();
+    }
+    tokens = await refreshInflight;
   }
   return tokens.access_token;
 }

--- a/src/connectors/googleDrive.ts
+++ b/src/connectors/googleDrive.ts
@@ -200,12 +200,27 @@ async function refreshAccessToken(tokens: DriveTokens): Promise<DriveTokens> {
   return updated;
 }
 
+/**
+ * In-flight refresh promise. Prevents concurrent expired-token callers from
+ * both burning the same refresh token (Google rotates on use).
+ */
+let refreshInflight: Promise<DriveTokens> | null = null;
+
 export async function getValidAccessToken(): Promise<string> {
   let tokens = loadTokens();
   if (!tokens) throw new Error("Google Drive not connected");
   const bufferMs = 60_000;
   if (!tokens.expiry_date || Date.now() > tokens.expiry_date - bufferMs) {
-    tokens = await refreshAccessToken(tokens);
+    if (!refreshInflight) {
+      refreshInflight = (async () => {
+        try {
+          return await refreshAccessToken(tokens as DriveTokens);
+        } finally {
+          refreshInflight = null;
+        }
+      })();
+    }
+    tokens = await refreshInflight;
   }
   return tokens.access_token;
 }


### PR DESCRIPTION
## Summary

Two concurrent expired-token callers both POST to the IdP token endpoint with no guard. On Google (and any IdP that rotates `refresh_token` on use), the second POST burns the rotated token issued by the first → connector permanently dies, requires full re-authentication. Latent on every BaseConnector subclass with a refresh flow (asana, confluence, discord, gitlab, hubspot, intercom, jira) and on the free-function Google connectors (gmail, googleCalendar, googleDrive).

## Fix

Cache an in-flight `Promise<AuthContext | null>` on the BaseConnector instance (one per connector instance) and on the gmail/googleCalendar/googleDrive modules (one per module — they're singletons). Concurrent callers await the same promise. Cache cleared in `finally` so retry-after-failure works.

On token-persistence failure mid-refresh we resolve with the new token rather than throwing: the IdP has already rotated the refresh_token, so the in-memory `auth` is the only valid copy. Throwing would force the caller to re-refresh and burn the now-stale persisted refresh_token — guaranteed connector death.

## Scope (survey)

Connectors with refresh flow → fix applies via `BaseConnector.refreshTokenDeduped()`:
- asana, confluence, discord, gitlab, hubspot, intercom, jira

Free-function Google connectors → fix applied per module:
- gmail, googleCalendar, googleDrive

PAT-style connectors → no race, skipped:
- slack, linear, github, notion, zendesk, sentry, stripe, datadog, pagerduty

## Tests

- `src/connectors/__tests__/baseConnector.refreshRace.test.ts` — 3 new tests:
  1. 5 parallel `refreshTokenDeduped()` calls → single fetch
  2. Two sequential calls after success → two fetches (cache cleared)
  3. Failure → next call retries fresh

Full suite: 4507/4507 pass.

## Deferred

- `mergeAutomationStates` correctness + parallel-branch dedup race (separate PR — recommended order: serialize `_runInterpreter` first via `_lastRunPromise.then()` chaining, then sequentialize Parallel under cooldown wrappers)
- CIMD DNS pinning + trust-on-first-fetch snapshot (separate PR — needs `ipaddr.js` dependency)

🤖 Generated with [Claude Code](https://claude.com/claude-code)