### PR TITLE
fix(automation): serialize _runInterpreter to close concurrent-event race

### DIFF
--- a/src/__tests__/automation-debug-session-end.test.ts
+++ b/src/__tests__/automation-debug-session-end.test.ts
@@ -119,6 +119,7 @@ describe("AutomationHooks.onDebugSessionEnd", () => {
       sessionName: "App",
       sessionType: "node",
     });
+    await hooks.flush();
     expect(orch.list().length).toBe(1);
 
     vi.setSystemTime(Date.now() + 10_000);
@@ -127,6 +128,7 @@ describe("AutomationHooks.onDebugSessionEnd", () => {
       sessionName: "App2",
       sessionType: "python",
     });
+    await hooks.flush();
     expect(orch.list().length).toBe(2);
   });
 

--- a/src/__tests__/automation-debug-session-start.test.ts
+++ b/src/__tests__/automation-debug-session-start.test.ts
@@ -118,6 +118,7 @@ describe("AutomationHooks.onDebugSessionStart", () => {
     const hooks = new AutomationHooks(BASE_POLICY, orch, () => {});
 
     await hooks.handleDebugSessionStart(BASE_RESULT);
+    await hooks.flush();
     expect(orch.list().length).toBe(1);
 
     vi.setSystemTime(Date.now() + 10_000);
@@ -127,6 +128,7 @@ describe("AutomationHooks.onDebugSessionStart", () => {
       sessionName: "App2",
       sessionType: "python",
     });
+    await hooks.flush();
     expect(orch.list().length).toBe(2);
   });
 

--- a/src/__tests__/automation-pre-compact.test.ts
+++ b/src/__tests__/automation-pre-compact.test.ts
@@ -91,12 +91,14 @@ describe("AutomationHooks.onPreCompact", () => {
     const orch = makeInstantOrchestrator();
     const hooks = new AutomationHooks(BASE_POLICY, orch, () => {});
 
-    await hooks.handlePreCompact();
+    hooks.handlePreCompact();
+    await hooks.flush();
     expect(orch.list().length).toBe(1);
 
     vi.setSystemTime(Date.now() + 10_000);
 
-    await hooks.handlePreCompact();
+    hooks.handlePreCompact();
+    await hooks.flush();
     expect(orch.list().length).toBe(2);
   });
 

--- a/src/__tests__/automation.test.ts
+++ b/src/__tests__/automation.test.ts
@@ -532,7 +532,13 @@ describe("AutomationHooks.handleCwdChanged", () => {
     expect(orch.list().length).toBe(1);
   });
 
-  it("different cwd values each get their own cooldown", () => {
+  it("two cwd events within the cooldown window — second is suppressed", async () => {
+    // Note: onCwdChanged uses a static cooldown key ("cwdchanged"), not a
+    // per-cwd-value key, so the cooldown applies across cwd values. Before
+    // the `_runInterpreter` serialization fix, two concurrent events both
+    // observed an empty cooldown state and both fired — that was a race,
+    // not a feature. With the fix, the second event correctly waits for
+    // the first to write the cooldown record and is suppressed.
     const orch = makeInstantOrchestrator();
     const hooks = new AutomationHooks(
       {
@@ -547,7 +553,8 @@ describe("AutomationHooks.handleCwdChanged", () => {
     );
     hooks.handleCwdChanged("/workspace/a");
     hooks.handleCwdChanged("/workspace/b");
-    expect(orch.list().length).toBe(2);
+    await hooks.flush();
+    expect(orch.list().length).toBe(1);
   });
 
   it("getStatus includes onCwdChanged", () => {
@@ -2730,7 +2737,7 @@ describe("AutomationHooks — promptName support", () => {
 // ── B2: onDiagnosticsCleared tests ───────────────────────────────────────────
 
 describe("AutomationHooks.handleDiagnosticsCleared (B2)", () => {
-  it("fires when transitioning from non-zero to zero errors", () => {
+  it("fires when transitioning from non-zero to zero errors", async () => {
     const orch = makeInstantOrchestrator();
     const hooks = new AutomationHooks(
       {
@@ -2744,8 +2751,10 @@ describe("AutomationHooks.handleDiagnosticsCleared (B2)", () => {
       () => {},
     );
     hooks.handleDiagnosticsChanged("/src/foo.ts", errorDiag);
+    await hooks.flush();
     expect(orch.list().length).toBe(0); // onDiagnosticsError not configured
     hooks.handleDiagnosticsChanged("/src/foo.ts", []);
+    await hooks.flush();
     expect(orch.list().length).toBe(1);
     expect(orch.list()[0]?.prompt).toContain("foo.ts");
   });
@@ -4075,7 +4084,7 @@ describe("AutomationHooks — hook metadata prefix", () => {
     expect(prompt).toContain("| file: N/A");
   });
 
-  it("onDiagnosticsCleared metadata includes the cleared file path", () => {
+  it("onDiagnosticsCleared metadata includes the cleared file path", async () => {
     const orch = makeInstantOrchestrator();
     const hooks = new AutomationHooks(
       {
@@ -4091,6 +4100,7 @@ describe("AutomationHooks — hook metadata prefix", () => {
     // Seed errors first so the transition non-zero → zero fires the hook
     hooks.handleDiagnosticsChanged("/src/cleared.ts", errorDiag);
     hooks.handleDiagnosticsChanged("/src/cleared.ts", []);
+    await hooks.flush();
     const prompt = orch.list()[0]?.prompt ?? "";
     expect(prompt).toContain("@@ HOOK: onDiagnosticsCleared");
     expect(prompt).toContain("cleared.ts");
@@ -4456,7 +4466,7 @@ describe("token-efficiency: _enqueueAutomationTask passes model/effort/systemPro
 // ── F3: phantom counter fix ───────────────────────────────────────────────────
 
 describe("_enqueueAutomationTask: tasksThisHour does not phantom-increment on enqueue failure", () => {
-  it("does not increment taskTimestamps when orchestrator.enqueue throws", () => {
+  it("does not increment taskTimestamps when orchestrator.enqueue throws", async () => {
     let enqueueCount = 0;
     const failOrch = {
       enqueue: () => {
@@ -4481,10 +4491,12 @@ describe("_enqueueAutomationTask: tasksThisHour does not phantom-increment on en
     );
     // The hook swallows the error; tasksThisHour should not have incremented.
     hooks.handleFileSaved("id1", "save", "/src/foo.ts");
+    await hooks.flush();
     expect(enqueueCount).toBe(1); // enqueue was attempted
     // Fire again — if the timestamp was NOT phantom-pushed, the rate-limit
     // counter is still 0 and a second attempt goes through.
     hooks.handleFileSaved("id2", "save", "/src/bar.ts");
+    await hooks.flush();
     expect(enqueueCount).toBe(2);
   });
 
@@ -4926,6 +4938,38 @@ describe("interpreter shadow mode", () => {
 
     // Neither old path (disabled) nor interpreter (disabled) should enqueue
     expect(orch.list().length).toBe(0);
+    hooks.destroy();
+  });
+});
+
+// ── Race regression: two concurrent events with shared cooldown key ──────────
+//
+// Pre-fix: handlers overwrote `_lastRunPromise` instead of chaining, so two
+// events arriving in the same tick both observed `_automationState` before
+// either had recorded its cooldown trigger. Both bypassed cooldown and fired,
+// burning the cooldown invariant.
+describe("race regression — concurrent events with shared cooldown key", () => {
+  it("two onFileSave events in the same tick: second is suppressed by cooldown", async () => {
+    const orch = makeInstantOrchestrator();
+    const hooks = new AutomationHooks(
+      {
+        onFileSave: {
+          enabled: true,
+          patterns: ["**/*.ts"],
+          prompt: "Review {{file}}",
+          cooldownMs: 5_000,
+        },
+      },
+      orch,
+      () => {},
+    );
+
+    // Two saves dispatched synchronously, no awaits between them.
+    hooks.handleFileSaved("id1", "save", "/workspace/a.ts");
+    hooks.handleFileSaved("id2", "save", "/workspace/b.ts");
+    await hooks.flush();
+
+    expect(orch.list().length).toBe(1);
     hooks.destroy();
   });
 });

--- a/src/automation.ts
+++ b/src/automation.ts
@@ -1295,6 +1295,74 @@ export class AutomationHooks {
     }
   }
 
+  /**
+   * Tracks whether `_lastRunPromise` represents a still-running interpreter
+   * call. When false, we know the prior promise is settled and can start the
+   * next run synchronously (preserving start-sync semantics tests depend on).
+   * When true, we chain via `.then()` so the new run reads the post-state of
+   * the prior one — fixing the race where two concurrent events both observed
+   * stale `_automationState` and the second writer clobbered the first.
+   */
+  private _chainBusy = false;
+
+  /**
+   * Enqueue an interpreter run, serializing it after any prior in-flight run.
+   *
+   * Concurrent events (e.g. a file save and a diagnostic update in the same
+   * tick) used to overwrite `_lastRunPromise`, so both runs read the same
+   * stale `_automationState` and the second writer's `updatedState` clobbered
+   * the first's. Cooldown/dedup writes from one event were silently lost;
+   * orphaned tasks accumulated in `activeTasks`.
+   *
+   * Chain through `_lastRunPromise` so each run sees the post-state of the
+   * previous one. We start the next run synchronously when the chain is idle
+   * (preserves the contract that `_runInterpreter` body executes up to its
+   * first await before this call returns); only when a run is in flight do
+   * we defer via `.then()`.
+   */
+  private _enqueueRun(
+    eventType: string,
+    eventData: Record<string, string>,
+  ): void {
+    if (this._chainBusy) {
+      this._lastRunPromise = this._lastRunPromise
+        .catch(() => {})
+        .then(() => {
+          this._chainBusy = true;
+          return this._runInterpreter(eventType, eventData);
+        })
+        .finally(() => {
+          this._chainBusy = false;
+        });
+    } else {
+      this._chainBusy = true;
+      this._lastRunPromise = this._runInterpreter(eventType, eventData).finally(
+        () => {
+          this._chainBusy = false;
+        },
+      );
+    }
+  }
+
+  /**
+   * Enqueue a synchronous state mutation to run after any in-flight
+   * interpreter call. Without this, handler-side `_automationState =
+   * setLatestDiagnostics(...)` writes done synchronously between
+   * `_enqueueRun` calls would be overwritten when the first run's
+   * `result.value.updatedState` writeback fires (the writeback replaces
+   * the full state, including the handler's incremental change).
+   *
+   * When the chain is idle, run the mutation synchronously to preserve
+   * test ergonomics that assume state is observable on the next line.
+   */
+  private _enqueueMutation(fn: () => void): void {
+    if (this._chainBusy) {
+      this._lastRunPromise = this._lastRunPromise.catch(() => {}).then(fn);
+    } else {
+      fn();
+    }
+  }
+
   private async _runInterpreter(
     eventType: string,
     eventData: Record<string, string>,
@@ -1387,12 +1455,14 @@ export class AutomationHooks {
       const rank = severityToNum[d.severity] ?? 3;
       return rank < min ? rank : min;
     }, 4); // 4 = no diagnostics / below hint
-    this._automationState = setLatestDiagnostics(
-      this._automationState,
-      normalizedFile,
-      maxSeverityNum,
-      diagnostics.length,
-    );
+    this._enqueueMutation(() => {
+      this._automationState = setLatestDiagnostics(
+        this._automationState,
+        normalizedFile,
+        maxSeverityNum,
+        diagnostics.length,
+      );
+    });
 
     // Build diagnostics text for {{diagnostics}} placeholder (capped at 20)
     const diagsForPrompt = diagnostics.slice(0, 20);
@@ -1416,29 +1486,19 @@ export class AutomationHooks {
 
     const diagnosticSig = diagnosticSignature(diagnostics);
 
-    // Fire onDiagnosticsCleared if transitioning from non-zero → zero; chain
-    // the interpreter runs so flush() awaits both and state is updated correctly.
+    // Fire onDiagnosticsCleared if transitioning from non-zero → zero. Two
+    // consecutive _enqueueRun calls append to the chain in order, so cleared
+    // settles before error and state is observed correctly.
     if (prevErrorCount > 0 && currentErrorCount === 0) {
-      this._lastRunPromise = this._runInterpreter("onDiagnosticsCleared", {
-        file: normalizedFile,
-      }).then(() =>
-        this._runInterpreter("onDiagnosticsError", {
-          file: normalizedFile,
-          diagnostics: diagnosticsText,
-          diagnosticSources,
-          diagnosticSig,
-          count: String(diagnostics.length),
-        }),
-      );
-    } else {
-      this._lastRunPromise = this._runInterpreter("onDiagnosticsError", {
-        file: normalizedFile,
-        diagnostics: diagnosticsText,
-        diagnosticSources,
-        diagnosticSig,
-        count: String(diagnostics.length),
-      });
+      this._enqueueRun("onDiagnosticsCleared", { file: normalizedFile });
     }
+    this._enqueueRun("onDiagnosticsError", {
+      file: normalizedFile,
+      diagnostics: diagnosticsText,
+      diagnosticSources,
+      diagnosticSig,
+      count: String(diagnostics.length),
+    });
   }
 
   /**
@@ -1446,9 +1506,7 @@ export class AutomationHooks {
    * Fires when CC's working directory changes — useful for re-snapshotting workspace context.
    */
   handleCwdChanged(newCwd: string): void {
-    this._lastRunPromise = this._runInterpreter("onCwdChanged", {
-      cwd: newCwd,
-    });
+    this._enqueueRun("onCwdChanged", { cwd: newCwd });
   }
 
   /**
@@ -1457,7 +1515,7 @@ export class AutomationHooks {
    * write a handoff note before Claude loses context.
    */
   handlePreCompact(): void {
-    this._lastRunPromise = this._runInterpreter("onPreCompact", {});
+    this._enqueueRun("onPreCompact", {});
   }
 
   /**
@@ -1465,7 +1523,7 @@ export class AutomationHooks {
    * Re-enqueues the configured prompt so Claude can re-snapshot IDE state after losing context.
    */
   handlePostCompact(): void {
-    this._lastRunPromise = this._runInterpreter("onPostCompact", {});
+    this._enqueueRun("onPostCompact", {});
   }
 
   /**
@@ -1473,20 +1531,16 @@ export class AutomationHooks {
    * Fires once per session; injects bridge status / tool capability summary at start.
    */
   handleInstructionsLoaded(): void {
-    this._lastRunPromise = this._runInterpreter("onInstructionsLoaded", {});
+    this._enqueueRun("onInstructionsLoaded", {});
   }
 
   handleFileSaved(_id: string, type: string, file: string): void {
     if (type !== "save") return;
     const normalizedFile = path.resolve(file);
-    this._lastRunPromise = this._runInterpreter("onFileSave", {
-      file: normalizedFile,
-    });
+    this._enqueueRun("onFileSave", { file: normalizedFile });
     // Also fire onRecipeSave for .yaml files
     if (normalizedFile.endsWith(".yaml") || normalizedFile.endsWith(".yml")) {
-      this._lastRunPromise = this._runInterpreter("onRecipeSave", {
-        file: normalizedFile,
-      });
+      this._enqueueRun("onRecipeSave", { file: normalizedFile });
     }
   }
 
@@ -1498,9 +1552,7 @@ export class AutomationHooks {
   handleFileChanged(_id: string, type: string, file: string): void {
     if (type !== "change") return;
     const normalizedFile = path.resolve(file);
-    this._lastRunPromise = this._runInterpreter("onFileChanged", {
-      file: normalizedFile,
-    });
+    this._enqueueRun("onFileChanged", { file: normalizedFile });
   }
 
   /**
@@ -1517,12 +1569,15 @@ export class AutomationHooks {
     for (const runner of result.runners) {
       const prev = this.lastTestOutcomeByRunner.get(runner);
       this.lastTestOutcomeByRunner.set(runner, current);
-      // Feed interpreter state
-      this._automationState = setTestRunnerStatus(
-        this._automationState,
-        runner,
-        current,
-      );
+      // Feed interpreter state through the chain so the writeback from any
+      // in-flight `_runInterpreter` doesn't clobber it.
+      this._enqueueMutation(() => {
+        this._automationState = setTestRunnerStatus(
+          this._automationState,
+          runner,
+          current,
+        );
+      });
       if (prev === "fail" && current === "pass") {
         passAfterFailRunners.push(runner);
       }
@@ -1537,25 +1592,13 @@ export class AutomationHooks {
       durationMs: String(result.summary.durationMs ?? ""),
     };
 
-    // Chain interpreter runs so flush() awaits all of them and state is updated
-    // sequentially. If any runner had a fail→pass transition, run that first so
-    // its cooldown state is visible to subsequent runs within the same flush.
-    if (passAfterFailRunners.length > 0) {
-      let chain = Promise.resolve();
-      for (const runner of passAfterFailRunners) {
-        chain = chain.then(() =>
-          this._runInterpreter("onTestPassAfterFailure", { runner }),
-        );
-      }
-      this._lastRunPromise = chain.then(() =>
-        this._runInterpreter("onTestRun", testRunEventData),
-      );
-    } else {
-      this._lastRunPromise = this._runInterpreter(
-        "onTestRun",
-        testRunEventData,
-      );
+    // Enqueue per-runner pass-after-fail transitions first so their cooldown
+    // state is visible to the subsequent onTestRun. Each _enqueueRun appends
+    // to the shared chain in order.
+    for (const runner of passAfterFailRunners) {
+      this._enqueueRun("onTestPassAfterFailure", { runner });
     }
+    this._enqueueRun("onTestRun", testRunEventData);
   }
 
   /**
@@ -1563,7 +1606,7 @@ export class AutomationHooks {
    * Fires the onGitCommit automation hook if configured.
    */
   async handleGitCommit(result: GitCommitResult): Promise<void> {
-    this._lastRunPromise = this._runInterpreter("onGitCommit", {
+    this._enqueueRun("onGitCommit", {
       hash: result.hash,
       branch: result.branch,
       message: result.message,
@@ -1577,7 +1620,7 @@ export class AutomationHooks {
    * Fires the onGitPush automation hook if configured.
    */
   handleGitPush(result: GitPushResult): void {
-    this._lastRunPromise = this._runInterpreter("onGitPush", {
+    this._enqueueRun("onGitPush", {
       branch: result.branch,
       remote: result.remote,
       hash: result.hash,
@@ -1588,7 +1631,7 @@ export class AutomationHooks {
    * Fires the onGitPull automation hook if configured.
    */
   handleGitPull(result: GitPullResult): void {
-    this._lastRunPromise = this._runInterpreter("onGitPull", {
+    this._enqueueRun("onGitPull", {
       branch: result.branch,
       remote: result.remote,
     });
@@ -1599,7 +1642,7 @@ export class AutomationHooks {
    * Fires the onBranchCheckout automation hook if configured.
    */
   handleBranchCheckout(result: BranchCheckoutResult): void {
-    this._lastRunPromise = this._runInterpreter("onBranchCheckout", {
+    this._enqueueRun("onBranchCheckout", {
       branch: result.branch,
       previousBranch: result.previousBranch ?? "(detached HEAD)",
       created: String(result.created),
@@ -1610,7 +1653,7 @@ export class AutomationHooks {
    * Fires the onPullRequest automation hook if configured.
    */
   handlePullRequest(result: PullRequestResult): void {
-    this._lastRunPromise = this._runInterpreter("onPullRequest", {
+    this._enqueueRun("onPullRequest", {
       title: result.title,
       url: result.url,
       branch: result.branch,
@@ -1619,14 +1662,14 @@ export class AutomationHooks {
   }
 
   handleTaskCreated(result: TaskCreatedResult): void {
-    this._lastRunPromise = this._runInterpreter("onTaskCreated", {
+    this._enqueueRun("onTaskCreated", {
       taskId: result.taskId,
       prompt: result.prompt,
     });
   }
 
   handlePermissionDenied(result: PermissionDeniedResult): void {
-    this._lastRunPromise = this._runInterpreter("onPermissionDenied", {
+    this._enqueueRun("onPermissionDenied", {
       tool: result.tool,
       reason: result.reason,
     });
@@ -1637,7 +1680,7 @@ export class AutomationHooks {
    * Called internally by handleDiagnosticsChanged.
    */
   handleDiagnosticsCleared(normalizedFile: string): void {
-    this._lastRunPromise = this._runInterpreter("onDiagnosticsCleared", {
+    this._enqueueRun("onDiagnosticsCleared", {
       file: normalizedFile,
       diagnosticSig: "",
     });
@@ -1648,7 +1691,7 @@ export class AutomationHooks {
    * Call from bridge.ts when a task transitions to done.
    */
   handleTaskSuccess(result: TaskSuccessResult): void {
-    this._lastRunPromise = this._runInterpreter("onTaskSuccess", {
+    this._enqueueRun("onTaskSuccess", {
       taskId: result.taskId,
       output: result.output,
     });
@@ -1659,7 +1702,7 @@ export class AutomationHooks {
    * Fires the onDebugSessionEnd automation hook if configured.
    */
   async handleDebugSessionEnd(result: DebugSessionEndResult): Promise<void> {
-    this._lastRunPromise = this._runInterpreter("onDebugSessionEnd", {
+    this._enqueueRun("onDebugSessionEnd", {
       sessionName: result.sessionName,
       sessionType: result.sessionType,
     });
@@ -1672,7 +1715,7 @@ export class AutomationHooks {
   async handleDebugSessionStart(
     result: DebugSessionStartResult,
   ): Promise<void> {
-    this._lastRunPromise = this._runInterpreter("onDebugSessionStart", {
+    this._enqueueRun("onDebugSessionStart", {
       sessionName: result.sessionName,
       sessionType: result.sessionType,
       breakpointCount: String(result.breakpointCount),


### PR DESCRIPTION
Concurrent events overwrote `_lastRunPromise` instead of chaining → both runs read same state, second writer's `updatedState` clobbered the first's, cooldown/dedup writes lost.

## Fix

`_enqueueRun()` chains via `_lastRunPromise.then()` when busy; starts sync when idle (preserves test contract via `_chainBusy` flag toggled in `.finally()`). `_enqueueMutation()` extends the same pattern to synchronous handler-side state writes (`setLatestDiagnostics`, `setTestRunnerStatus`) that would otherwise be clobbered by an in-flight run's `updatedState` writeback.

20+ handler callsites converted. 5 tests updated (mostly + `flush()` calls between events). One test ('different cwd values each get their own cooldown') was asserting a feature that doesn't exist (per-cwd cooldown key) — the old pass was a race artifact. Renamed and inverted to assert the now-correct cooldown suppression. New regression test 'two onFileSave events in same tick: second is suppressed by cooldown' locks in the fix.

Suite: 4508/4508 pass.

## Deferred (separate PRs per research plan)

- PR-2: serialize `Parallel` branches under cooldown/dedup wrappers (intra-run race) + fix `mergeAutomationStates.taskTimestamps` double-count + collision-aware `unionMap` for `activeTasks`/`pendingRetries`
- CIMD DNS pinning + trust-on-first-fetch snapshot (needs `ipaddr.js` dep)

🤖 Generated with [Claude Code](https://claude.com/claude-code)