### PR TITLE
fix(automation): sequentialize Parallel branches under cooldown/dedup wrappers

### DIFF
--- a/src/fp/__tests__/automationInterpreter.test.ts
+++ b/src/fp/__tests__/automationInterpreter.test.ts
@@ -578,6 +578,41 @@ describe("Parallel state merge", () => {
     expect(result.value.updatedState.lastTrigger.get("B")).toBeDefined();
   });
 
+  it("two branches sharing one cooldown key — second branch is suppressed", async () => {
+    // Regression: prior implementation seeded each branch from the same
+    // initialState, so both saw an empty cooldown record and both fired.
+    // With sequential semantics, branch B reads state mutated by branch A
+    // and is correctly suppressed.
+    const backend = new TestBackend();
+    const sharedKey = "shared-cooldown";
+    const branchA = withCooldown(
+      sharedKey,
+      60_000,
+      hook({
+        hookType: "onFileSave",
+        enabled: true,
+        promptSource: INLINE_SOURCE,
+      }),
+    );
+    const branchB = withCooldown(
+      sharedKey,
+      60_000,
+      hook({
+        hookType: "onFileSave",
+        enabled: true,
+        promptSource: INLINE_SOURCE,
+      }),
+    );
+    const par = parallel([branchA, branchB]);
+    const ctx = makeCtx({ backend });
+    const result = await executeAutomationPolicy([par], ctx);
+    if (!result.ok) throw new Error("not ok");
+    expect(result.value.taskIds.length).toBe(1);
+    expect(
+      result.value.skipped.some((s) => s.reason.startsWith("cooldown:")),
+    ).toBe(true);
+  });
+
   it("unions taskIds from all branches", async () => {
     const backend = new TestBackend();
     const mkHook = () =>

--- a/src/fp/automationInterpreter.ts
+++ b/src/fp/automationInterpreter.ts
@@ -17,7 +17,6 @@ import {
   clearPendingRetry,
   isDeduped,
   isOnCooldown,
-  mergeAutomationStates,
   recordDedup,
   recordPendingRetry,
   recordTrigger,
@@ -463,36 +462,35 @@ async function interpret(
     }
 
     case "Parallel": {
-      const initialState = acc.state;
-      const results = await Promise.allSettled(
-        program.programs.map((p) =>
-          interpret(p, { ...ctx, state: initialState }, emptyAcc(initialState)),
-        ),
-      );
-
-      let merged = acc;
-      for (const result of results) {
-        if (result.status === "fulfilled") {
-          merged = {
-            taskIds: [...merged.taskIds, ...result.value.taskIds],
-            skipped: [...merged.skipped, ...result.value.skipped],
-            errors: [...merged.errors, ...result.value.errors],
-            // Merge branch state into accumulator: keep max timestamp per key
-            // and union maps so cooldowns / dedup / triggers from each branch
-            // are preserved (prior code overwrote via last-wins).
-            state: mergeAutomationStates(merged.state, result.value.state),
-          };
-        } else {
-          merged = {
-            ...merged,
+      // Walk Parallel children sequentially, threading state forward exactly
+      // like Sequence. Prior implementation used Promise.allSettled with each
+      // branch seeded from the same `initialState`, which meant both branches
+      // observed cooldown/dedup state BEFORE either branch had recorded its
+      // trigger — so both bypassed cooldown and fired. The "merge max
+      // timestamp per key" reconciliation then arbitrarily picked one
+      // recorded trigger and threw the other away.
+      //
+      // Sequential semantics are correct: each branch reads state mutated by
+      // the previous branch, so a cooldown recorded in branch A is visible
+      // to branch B. The wall-clock cost is small in practice — the
+      // expensive work (LLM dispatch) happens inside the orchestrator queue,
+      // which is already serialized; only the synchronous predicate /
+      // state-update pass changes from parallel to sequential.
+      let current = acc;
+      for (const p of program.programs) {
+        try {
+          current = await interpret(p, ctx, current);
+        } catch (err) {
+          current = {
+            ...current,
             errors: [
-              ...merged.errors,
-              { message: String(result.reason), hook: "parallel" },
+              ...current.errors,
+              { message: String(err), hook: "parallel" },
             ],
           };
         }
       }
-      return merged;
+      return current;
     }
 
     case "WithCooldown": {


### PR DESCRIPTION
## Summary

`Parallel` previously seeded each branch from the same `initialState` and ran via `Promise.allSettled`. Both branches observed cooldown / dedup state **before** either branch had recorded its trigger → both bypassed cooldown and fired. `mergeAutomationStates` then arbitrarily kept one of the two recorded triggers and discarded the other.

## Fix

Walk Parallel children sequentially, threading state forward like `Sequence`. Branch B now reads state mutated by branch A — a cooldown recorded in A is visible to B.

The wall-clock cost is small: the expensive work (LLM dispatch) happens inside the orchestrator queue which is already serialized; only the synchronous predicate / state-update pass changes from parallel to sequential.

## mergeAutomationStates

No longer called from the interpreter (its only production caller). Left in place — its existing tests still pass — for any future re-parallelization that needs branch-merge semantics. The taskTimestamps double-count and `unionMap` collision issues identified in the round-2 audit are now unreachable in production paths; deferred until a real consumer reappears.

## Test

New regression: 'two branches sharing one cooldown key — second branch is suppressed' locks in the fix. Suite: 4509/4509 pass.

## Closes the round-2 automation-race tracker

This was the last automation-race finding from the round-2 audit. Combined with PR-106 (`_runInterpreter` serialization), the cooldown / dedup invariants are now correct under concurrent events both within a single run (Parallel) and across runs (handler-side races).

🤖 Generated with [Claude Code](https://claude.com/claude-code)