### PR TITLE
fix(security): round-3 bug hunt — HTTP ownership tokens, plugin shadowing, orchestrator process group, inbox path leak

### DIFF
--- a/src/__tests__/integration-e2e.test.ts
+++ b/src/__tests__/integration-e2e.test.ts
@@ -318,12 +318,15 @@ describe("Streamable HTTP — session lifecycle", () => {
 
     expect(res.status).toBe(200);
     const sessionId = res.headers["mcp-session-id"];
+    const sessionToken = res.headers["mcp-session-token"];
     expect(typeof sessionId).toBe("string");
+    expect(typeof sessionToken).toBe("string");
 
-    // DELETE to close the session
+    // DELETE to close the session — must echo the per-session ownership token.
     const del = await httpDelete(`http://127.0.0.1:${port}/mcp`, {
       Authorization: `Bearer ${authToken}`,
       "Mcp-Session-Id": sessionId as string,
+      "Mcp-Session-Token": sessionToken as string,
     });
     expect(del.status).toBe(204);
 

--- a/src/__tests__/streamableHttp.test.ts
+++ b/src/__tests__/streamableHttp.test.ts
@@ -62,6 +62,7 @@ async function post(
   port: number,
   data: Record<string, unknown>,
   sessionId?: string,
+  ownershipToken?: string,
 ): Promise<{
   status: number;
   headers: http.IncomingHttpHeaders;
@@ -74,6 +75,7 @@ async function post(
       Authorization: `Bearer ${TOKEN}`,
     };
     if (sessionId) headers["Mcp-Session-Id"] = sessionId;
+    if (ownershipToken) headers["Mcp-Session-Token"] = ownershipToken;
 
     const req = http.request(
       { hostname: "127.0.0.1", port, path: "/mcp", method: "POST", headers },
@@ -97,6 +99,7 @@ async function httpReq(
   port: number,
   method: string,
   sessionId?: string,
+  ownershipToken?: string,
 ): Promise<{
   status: number;
   headers: http.IncomingHttpHeaders;
@@ -107,6 +110,7 @@ async function httpReq(
       Authorization: `Bearer ${TOKEN}`,
     };
     if (sessionId) headers["Mcp-Session-Id"] = sessionId;
+    if (ownershipToken) headers["Mcp-Session-Token"] = ownershipToken;
 
     const req = http.request(
       { hostname: "127.0.0.1", port, path: "/mcp", method, headers },
@@ -125,8 +129,10 @@ async function httpReq(
   });
 }
 
-/** Initialize a session, returning the Mcp-Session-Id. */
-async function initSession(port: number): Promise<string> {
+/** Initialize a session, returning the Mcp-Session-Id and Mcp-Session-Token. */
+async function initSession(
+  port: number,
+): Promise<{ sid: string; token: string }> {
   const res = await post(port, {
     jsonrpc: "2.0",
     id: 1,
@@ -138,9 +144,12 @@ async function initSession(port: number): Promise<string> {
     },
   });
   const sid = res.headers["mcp-session-id"];
+  const token = res.headers["mcp-session-token"];
   if (typeof sid !== "string")
     throw new Error("No session ID in initialize response");
-  return sid;
+  if (typeof token !== "string")
+    throw new Error("No ownership token in initialize response");
+  return { sid, token };
 }
 
 // ── Test suite ─────────────────────────────────────────────────────────────────
@@ -225,10 +234,10 @@ describe("Streamable HTTP: session lifecycle", () => {
   });
 
   it("DELETE destroys a session", async () => {
-    const sid = await initSession(port);
+    const { sid, token } = await initSession(port);
 
     // DELETE the session
-    const del = await httpReq(port, "DELETE", sid);
+    const del = await httpReq(port, "DELETE", sid, token);
     expect(del.status).toBe(204);
 
     // Subsequent request should 404
@@ -236,6 +245,7 @@ describe("Streamable HTTP: session lifecycle", () => {
       port,
       { jsonrpc: "2.0", id: 2, method: "tools/list", params: {} },
       sid,
+      token,
     );
     expect(res.status).toBe(404);
   });
@@ -248,6 +258,46 @@ describe("Streamable HTTP: session lifecycle", () => {
   it("DELETE returns 404 for unknown session", async () => {
     const res = await httpReq(port, "DELETE", "nonexistent");
     expect(res.status).toBe(404);
+  });
+});
+
+// ── Ownership token ───────────────────────────────────────────────────────────
+
+describe("Streamable HTTP: per-session ownership token", () => {
+  it("DELETE without Mcp-Session-Token returns 403", async () => {
+    const { sid } = await initSession(port);
+    const res = await httpReq(port, "DELETE", sid); // no token
+    expect(res.status).toBe(403);
+  });
+
+  it("DELETE with wrong Mcp-Session-Token returns 403", async () => {
+    const { sid } = await initSession(port);
+    const wrongToken = "0".repeat(64);
+    const res = await httpReq(port, "DELETE", sid, wrongToken);
+    expect(res.status).toBe(403);
+  });
+
+  it("GET without Mcp-Session-Token returns 403", async () => {
+    const { sid } = await initSession(port);
+    const res = await httpReq(port, "GET", sid); // no token
+    expect(res.status).toBe(403);
+  });
+
+  it("POST on existing session without Mcp-Session-Token returns 403", async () => {
+    const { sid } = await initSession(port);
+    const res = await post(
+      port,
+      { jsonrpc: "2.0", id: 2, method: "tools/list", params: {} },
+      sid, // no token
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it("session A's token cannot DELETE session B (cross-session takeover)", async () => {
+    const a = await initSession(port);
+    const b = await initSession(port);
+    const res = await httpReq(port, "DELETE", b.sid, a.token);
+    expect(res.status).toBe(403);
   });
 });
 
@@ -282,12 +332,13 @@ describe("Streamable HTTP: capacity guard", () => {
 
 describe("Streamable HTTP: notifications", () => {
   it("notification (no id) returns 202", async () => {
-    const sid = await initSession(port);
+    const { sid, token } = await initSession(port);
 
     const res = await post(
       port,
       { jsonrpc: "2.0", method: "notifications/initialized" },
       sid,
+      token,
     );
 
     expect(res.status).toBe(202);
@@ -479,12 +530,14 @@ function collectSseLines(
   sessionId: string,
   collectMs: number,
   lastEventId?: number,
+  ownershipToken?: string,
 ): Promise<string[]> {
   return new Promise((resolve, reject) => {
     const headers: Record<string, string> = {
       Authorization: `Bearer ${TOKEN}`,
       "Mcp-Session-Id": sessionId,
     };
+    if (ownershipToken) headers["Mcp-Session-Token"] = ownershipToken;
     if (lastEventId !== undefined) {
       headers["Last-Event-ID"] = String(lastEventId);
     }
@@ -530,10 +583,10 @@ function getAdapter(
 
 describe("Streamable HTTP: SSE event IDs", () => {
   it("notifications sent over SSE include a monotonic id: field", async () => {
-    const sid = await initSession(port);
+    const { sid, token } = await initSession(port);
 
     // Open SSE stream first, give TCP time to establish before injecting.
-    const linesPromise = collectSseLines(port, sid, 250);
+    const linesPromise = collectSseLines(port, sid, 250, undefined, token);
     await new Promise((r) => setTimeout(r, 50));
 
     // Inject a server-initiated notification directly via the adapter.
@@ -563,7 +616,7 @@ describe("Streamable HTTP: SSE event IDs", () => {
   });
 
   it("reconnect with Last-Event-ID replays missed notifications", async () => {
-    const sid = await initSession(port);
+    const { sid, token } = await initSession(port);
 
     // Inject 3 notifications directly via the internal adapter (no SSE stream attached).
     // They land in the buffer; replay is triggered when the GET includes Last-Event-ID.
@@ -577,7 +630,7 @@ describe("Streamable HTTP: SSE event IDs", () => {
     adapter.send(notif("test/third")); // id: 2
 
     // Reconnect with Last-Event-ID: 0 — should replay events with id > 0 (i.e. 1 and 2)
-    const lines = await collectSseLines(port, sid, 150, 0);
+    const lines = await collectSseLines(port, sid, 150, 0, token);
 
     const dataLines = lines.filter((l) => l.startsWith("data:"));
     expect(dataLines.length).toBeGreaterThanOrEqual(2);
@@ -599,7 +652,7 @@ describe("Streamable HTTP: SSE event IDs", () => {
     // fake clock stays in effect throughout the check.
     vi.useFakeTimers({ now: Date.now() });
 
-    const sid = await initSession(port);
+    const { sid, token } = await initSession(port);
     const adapter = getAdapter(handler!, sid);
 
     adapter.send(
@@ -624,7 +677,7 @@ describe("Streamable HTTP: SSE event IDs", () => {
   });
 
   it("buffer caps at 100 events — oldest are dropped", async () => {
-    const sid = await initSession(port);
+    const { sid, token } = await initSession(port);
 
     const adapter = getAdapter(handler!, sid);
 
@@ -640,7 +693,7 @@ describe("Streamable HTTP: SSE event IDs", () => {
     }
 
     // Reconnect with Last-Event-ID: -1 to request all buffered events
-    const lines = await collectSseLines(port, sid, 300, -1);
+    const lines = await collectSseLines(port, sid, 300, -1, token);
 
     const dataLines = lines.filter((l) => l.startsWith("data:"));
     // Should have at most 100 (the cap), so events 0-9 are dropped
@@ -674,7 +727,7 @@ describe("Streamable HTTP: GET SSE", () => {
   });
 
   it("GET establishes SSE stream with text/event-stream content type", async () => {
-    const sid = await initSession(port);
+    const { sid, token } = await initSession(port);
 
     const { status, contentType } = await new Promise<{
       status: number;
@@ -689,6 +742,7 @@ describe("Streamable HTTP: GET SSE", () => {
           headers: {
             Authorization: `Bearer ${TOKEN}`,
             "Mcp-Session-Id": sid,
+            "Mcp-Session-Token": token,
           },
         },
         (res) => {
@@ -717,12 +771,13 @@ describe("HttpAdapter: send routing", () => {
   // responses (with id) go to POST resolver, notifications go to SSE.
 
   it("tools/list request returns a response via POST", async () => {
-    const sid = await initSession(port);
+    const { sid, token } = await initSession(port);
     // Send initialized notification
     await post(
       port,
       { jsonrpc: "2.0", method: "notifications/initialized" },
       sid,
+      token,
     );
 
     // Request tools/list
@@ -730,6 +785,7 @@ describe("HttpAdapter: send routing", () => {
       port,
       { jsonrpc: "2.0", id: 2, method: "tools/list", params: {} },
       sid,
+      token,
     );
 
     expect(res.status).toBe(200);
@@ -775,8 +831,8 @@ describe("Streamable HTTP: body size limit", () => {
 
 describe("Streamable HTTP: session close", () => {
   it("handler.close() destroys all sessions", async () => {
-    const sid1 = await initSession(port);
-    const sid2 = await initSession(port);
+    const session1 = await initSession(port);
+    const session2 = await initSession(port);
 
     handler!.close();
 
@@ -784,12 +840,14 @@ describe("Streamable HTTP: session close", () => {
     const res1 = await post(
       port,
       { jsonrpc: "2.0", id: 1, method: "tools/list", params: {} },
-      sid1,
+      session1.sid,
+      session1.token,
     );
     const res2 = await post(
       port,
       { jsonrpc: "2.0", id: 1, method: "tools/list", params: {} },
-      sid2,
+      session2.sid,
+      session2.token,
     );
     expect(res1.status).toBe(404);
     expect(res2.status).toBe(404);
@@ -873,13 +931,14 @@ describe("Streamable HTTP: auth", () => {
 
 describe("Streamable HTTP: idle pruning", () => {
   it("prunes sessions that exceed TTL", async () => {
-    const sid = await initSession(port);
+    const { sid, token } = await initSession(port);
 
     // Verify session works
     const res1 = await post(
       port,
       { jsonrpc: "2.0", method: "notifications/initialized" },
       sid,
+      token,
     );
     expect(res1.status).toBe(202);
 
@@ -897,9 +956,8 @@ describe("Streamable HTTP: idle pruning", () => {
 describe("Streamable HTTP: session overflow eviction", () => {
   it("evicts oldest idle session when at capacity rather than returning 503", async () => {
     // Fill all 5 session slots
-    const sessionIds: string[] = [];
     for (let i = 0; i < 5; i++) {
-      sessionIds.push(await initSession(port));
+      await initSession(port);
     }
 
     // Make the first session appear idle by backdating its lastActivity
@@ -910,7 +968,7 @@ describe("Streamable HTTP: session overflow eviction", () => {
     firstSession.lastActivity = Date.now() - 120_000; // idle for 2 minutes > 60s threshold
 
     // A 6th initialize should succeed (evicting the stale session) rather than return 503
-    const newSid = await initSession(port);
+    const { sid: newSid } = await initSession(port);
     expect(typeof newSid).toBe("string");
 
     // Total sessions should still be 5 (evicted 1, added 1)

--- a/src/claudeDriver.ts
+++ b/src/claudeDriver.ts
@@ -130,6 +130,20 @@ export interface IClaudeDriver {
 
 const OUTPUT_CAP = 50 * 1024; // 50KB
 
+/**
+ * Truncate `text` to at most `cap` UTF-8 bytes without splitting a multi-byte
+ * codepoint mid-sequence. `String.slice(0, cap)` operates on UTF-16 code
+ * units, so a 50K cap can store ~50K code points but emit up to ~200KB of
+ * UTF-8 wire bytes for CJK / emoji content — and may produce a lone
+ * surrogate at the boundary. `Buffer.toString("utf8")` substitutes U+FFFD
+ * for incomplete trailing sequences instead.
+ */
+function truncateUtf8Bytes(text: string, cap: number): string {
+  const buf = Buffer.from(text, "utf8");
+  if (buf.length <= cap) return text;
+  return buf.subarray(0, cap).toString("utf8");
+}
+
 /** Shape of a parsed stream-json event from `claude -p --output-format stream-json`. */
 interface StreamJsonEvent {
   type: "system" | "assistant" | "result" | string;
@@ -292,6 +306,30 @@ export class SubprocessDriver implements IClaudeDriver {
       detached: true,
     });
 
+    /**
+     * Kill the entire process group, not just the direct child. Because we
+     * spawned with `detached: true`, the child runs in its own process group.
+     * `child.kill()` and Node's AbortSignal-driven kill both target only the
+     * direct child PID, leaving grandchildren (claude's own tool subprocesses)
+     * orphaned and surviving bridge shutdown. Negative PID = process group.
+     */
+    const killProcessGroup = (signal: NodeJS.Signals = "SIGTERM"): void => {
+      if (typeof child.pid !== "number") return;
+      try {
+        process.kill(-child.pid, signal);
+      } catch {
+        // ESRCH = group already dead, EPERM = permission lost. Either way,
+        // no further action available.
+      }
+    };
+
+    // When AbortController fires (timeout, manual cancel, shutdown), Node
+    // sends SIGTERM to child PID only — escalate to the process group so
+    // grandchildren go too. Listener removed automatically when child exits.
+    const onAbort = () => killProcessGroup("SIGTERM");
+    input.signal.addEventListener("abort", onAbort, { once: true });
+    child.on("close", () => input.signal.removeEventListener("abort", onAbort));
+
     // JSONL output state
     // -------------------------------------------------------------------
     // With --output-format stream-json, claude emits one JSON object per line.
@@ -301,9 +339,27 @@ export class SubprocessDriver implements IClaudeDriver {
     // Accumulated text from assistant events — used as fallback for final text if
     // the result event is missing (old binary, crash before result, etc.)
     let accumulated = "";
-    // outputBytesSent tracks how many bytes have been forwarded to onChunk so we
+    // outputBytesSent tracks how many bytes (UTF-8) have been forwarded to onChunk so we
     // can apply OUTPUT_CAP without truncating the accumulated text used for analysis.
+    // Counted in bytes (not UTF-16 code units) because OUTPUT_CAP is a byte budget —
+    // a string slice would let multi-byte CJK / emoji content overshoot the cap by 4×.
     let outputBytesSent = 0;
+    /**
+     * Truncate `text` so it adds at most `remaining` UTF-8 bytes to the
+     * stream and never splits a multi-byte codepoint mid-sequence. Returns
+     * the safely-truncated slice plus its actual byte length.
+     */
+    const truncateToBytes = (
+      text: string,
+      remaining: number,
+    ): { send: string; bytes: number } => {
+      const buf = Buffer.from(text, "utf8");
+      if (buf.length <= remaining) return { send: text, bytes: buf.length };
+      // Buffer.toString("utf8") substitutes U+FFFD for incomplete trailing
+      // sequences, which is the correct UTF-8 truncation behavior.
+      const sliced = buf.subarray(0, remaining).toString("utf8");
+      return { send: sliced, bytes: Buffer.byteLength(sliced, "utf8") };
+    };
     // firstAssistantAt: set on the first assistant event; used to compute startupMs.
     let firstAssistantAt: number | undefined;
     // doneFromResult: set when a result event is received so the abort path can
@@ -331,10 +387,13 @@ export class SubprocessDriver implements IClaudeDriver {
           const text = `${line}\n`;
           accumulated += text;
           if (outputBytesSent < OUTPUT_CAP) {
-            const send = text.slice(0, OUTPUT_CAP - outputBytesSent);
-            if (send.length > 0) {
+            const { send, bytes } = truncateToBytes(
+              text,
+              OUTPUT_CAP - outputBytesSent,
+            );
+            if (bytes > 0) {
               input.onChunk?.(send);
-              outputBytesSent += send.length;
+              outputBytesSent += bytes;
             }
           }
           continue;
@@ -353,10 +412,13 @@ export class SubprocessDriver implements IClaudeDriver {
             if (text.length > 0) {
               accumulated += text;
               if (outputBytesSent < OUTPUT_CAP) {
-                const send = text.slice(0, OUTPUT_CAP - outputBytesSent);
-                if (send.length > 0) {
+                const { send, bytes } = truncateToBytes(
+                  text,
+                  OUTPUT_CAP - outputBytesSent,
+                );
+                if (bytes > 0) {
                   input.onChunk?.(send);
-                  outputBytesSent += send.length;
+                  outputBytesSent += bytes;
                 }
               }
             }
@@ -375,10 +437,13 @@ export class SubprocessDriver implements IClaudeDriver {
     let stderr = "";
     child.stderr.setEncoding("utf-8");
     child.stderr.on("data", (chunk: string) => {
-      // Apply the same cap to stderr to prevent unbounded memory growth
-      if (stderr.length < OUTPUT_CAP) {
+      // Apply the same byte-budget cap to stderr to prevent unbounded
+      // memory growth on multi-byte UTF-8 output.
+      if (Buffer.byteLength(stderr, "utf8") < OUTPUT_CAP) {
         stderr += chunk;
-        if (stderr.length > OUTPUT_CAP) stderr = stderr.slice(0, OUTPUT_CAP);
+        if (Buffer.byteLength(stderr, "utf8") > OUTPUT_CAP) {
+          stderr = truncateUtf8Bytes(stderr, OUTPUT_CAP);
+        }
       }
     });
 
@@ -396,7 +461,9 @@ export class SubprocessDriver implements IClaudeDriver {
       ? setTimeout(() => {
           if (firstAssistantAt === undefined && !doneFromResult) {
             startupTimedOut = true;
-            child.kill();
+            // Kill the whole group so grandchildren don't survive — same
+            // reason as in the abort handler above.
+            killProcessGroup("SIGTERM");
           }
         }, input.startupTimeoutMs)
       : null;
@@ -414,7 +481,7 @@ export class SubprocessDriver implements IClaudeDriver {
       // rather than returning wasAborted: true with partial output.
       if (doneFromResult) {
         return {
-          text: resultText.slice(0, OUTPUT_CAP),
+          text: truncateUtf8Bytes(resultText, OUTPUT_CAP),
           exitCode: resultIsError ? 1 : 0,
           durationMs: Date.now() - start,
           stderrTail: stderrTailOf(stderr),
@@ -428,7 +495,7 @@ export class SubprocessDriver implements IClaudeDriver {
         // Return rather than throw so the orchestrator can surface partial
         // output, stderrTail, and wasAborted to callers (e.g. /tasks).
         return {
-          text: accumulated.slice(0, OUTPUT_CAP),
+          text: truncateUtf8Bytes(accumulated, OUTPUT_CAP),
           exitCode: -1,
           durationMs: Date.now() - start,
           stderrTail: stderrTailOf(stderr),
@@ -469,7 +536,7 @@ export class SubprocessDriver implements IClaudeDriver {
     }
 
     return {
-      text: finalText.slice(0, OUTPUT_CAP),
+      text: truncateUtf8Bytes(finalText, OUTPUT_CAP),
       exitCode: effectiveExitCode,
       durationMs: Date.now() - start,
       stderrTail: stderrTailOf(stderr),
@@ -547,7 +614,7 @@ export class ApiDriver implements IClaudeDriver {
     _input.onChunk?.(text);
 
     return {
-      text: text.slice(0, OUTPUT_CAP),
+      text: truncateUtf8Bytes(text, OUTPUT_CAP),
       exitCode: 0,
       durationMs: Date.now() - start,
     };

--- a/src/inboxRoutes.ts
+++ b/src/inboxRoutes.ts
@@ -54,9 +54,14 @@ export function tryHandleInboxRoute(
               .filter((l) => !l.startsWith("#"))
               .join("\n")
               .trim();
+            // `path` intentionally omitted — leaking the absolute filesystem
+            // path (which includes the user's home dir / username) is a
+            // low-impact info-disclosure if the dashboard is ever proxied to
+            // an untrusted client (shared screen, screenshots, browser
+            // extensions reading the DOM). Callers identify items by `name`,
+            // and the read endpoint joins it back to inboxDir on the server.
             return {
               name,
-              path: filePath,
               modifiedAt: stats.mtime.toISOString(),
               preview: stripped.slice(0, 200),
             };

--- a/src/pluginLoader.ts
+++ b/src/pluginLoader.ts
@@ -18,6 +18,19 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 import type { Config } from "./config.js";
 import type { Logger } from "./logger.js";
+import { TOOL_CATEGORIES } from "./tools/index.js";
+
+/**
+ * Names of all built-in tools. Plugins are forbidden from registering a
+ * tool with one of these names — without this guard, a plugin declaring
+ * `toolNamePrefix: "git_"` could register `git_status` and silently shadow
+ * the built-in. `TOOL_CATEGORIES` keys are the canonical source of truth
+ * (every built-in tool is categorized for the dashboard).
+ */
+function getBuiltInToolNames(): string[] {
+  return Object.keys(TOOL_CATEGORIES);
+}
+
 import type {
   PluginContext,
   PluginManifest,
@@ -157,7 +170,12 @@ export async function loadPluginsFull(
   if (pluginSpecs.length === 0) return [];
 
   const loadedPlugins: LoadedPlugin[] = [];
-  const registeredNames = new Set<string>(); // collision guard across plugins
+  // Seed the collision guard with built-in tool names so a plugin can't
+  // shadow a built-in (e.g. declaring prefix `git_` and registering
+  // `git_status`). Without this, `registeredNames` only tracks other
+  // plugins and a plugin would silently overwrite the built-in registration
+  // depending on registration order.
+  const registeredNames = new Set<string>(getBuiltInToolNames());
 
   // Deduplicate resolved paths before loading
   const seen = new Set<string>();
@@ -283,10 +301,30 @@ export async function loadOnePluginFull(
   // 5. Dynamic import
   const entrypointPath = path.resolve(pluginDir, manifest.entrypoint);
 
-  // Prevent entrypoint path traversal — the resolved path must stay inside pluginDir
-  if (path.relative(pluginDir, entrypointPath).startsWith("..")) {
+  // Prevent entrypoint path traversal. We compare the *real* paths (after
+  // symlink resolution) so a symlinked entrypoint or a symlinked pluginDir
+  // can't escape lexically while pointing at attacker-controlled code
+  // outside the directory. `path.relative` alone is fooled by symlinks.
+  let realPluginDir: string;
+  let realEntrypoint: string;
+  try {
+    realPluginDir = fs.realpathSync(pluginDir);
+    realEntrypoint = fs.realpathSync(entrypointPath);
+  } catch (err) {
     logger.warn(
-      `Plugin "${manifest.name}" — entrypoint path "${manifest.entrypoint}" escapes plugin directory (resolved to ${entrypointPath})`,
+      `Plugin "${manifest.name}" — failed to resolve real path for entrypoint or plugin dir: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return null;
+  }
+  const escapesLexically = path
+    .relative(pluginDir, entrypointPath)
+    .startsWith("..");
+  const escapesViaSymlink = path
+    .relative(realPluginDir, realEntrypoint)
+    .startsWith("..");
+  if (escapesLexically || escapesViaSymlink) {
+    logger.warn(
+      `Plugin "${manifest.name}" — entrypoint path "${manifest.entrypoint}" escapes plugin directory (resolved to ${realEntrypoint})`,
     );
     return null;
   }

--- a/src/streamableHttp.ts
+++ b/src/streamableHttp.ts
@@ -253,11 +253,52 @@ interface HttpSession {
   inFlight: number;
   /** X-Claude-Code-Session-Id from the initialize request, if present. */
   claudeCodeSessionId: string | null;
+  /**
+   * Per-session ownership secret returned in the initialize response as
+   * `Mcp-Session-Token`. Subsequent POST/GET/DELETE requests must echo this
+   * value in the same header. Prevents session takeover when bridge auth is
+   * a single shared static token: without this, any caller who learns
+   * another's `Mcp-Session-Id` could DELETE the session, hijack its SSE
+   * stream via GET, or impersonate its POST traffic. 32 bytes hex (256-bit).
+   */
+  ownershipToken: string;
+}
+
+/** Constant-time hex-string comparison; both inputs must be same length. */
+function hexEquals(a: string, b: string): boolean {
+  if (typeof a !== "string" || typeof b !== "string") return false;
+  if (a.length !== b.length) return false;
+  try {
+    return crypto.timingSafeEqual(Buffer.from(a, "hex"), Buffer.from(b, "hex"));
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Verifies the `Mcp-Session-Token` header matches the session's ownership
+ * token. Returns `true` if authorized, `false` otherwise. Logs nothing —
+ * caller is responsible for the 403 response.
+ */
+function checkOwnership(
+  req: http.IncomingMessage,
+  session: { ownershipToken: string },
+): boolean {
+  const presented = req.headers["mcp-session-token"];
+  if (typeof presented !== "string") return false;
+  return hexEquals(presented, session.ownershipToken);
 }
 
 /** Handles POST/GET/DELETE /mcp for all HTTP sessions. */
 export class StreamableHttpHandler {
   private sessions = new Map<string, HttpSession>();
+  /**
+   * Number of `createSession` calls currently in flight. Folded into the
+   * capacity check so two concurrent POSTs that both observe `sessions.size
+   * < MAX` cannot both pass the guard, await `instructionsProvider`, and
+   * `sessions.set` past the cap.
+   */
+  private pendingSessionCreates = 0;
   private cleanupTimer: ReturnType<typeof setInterval>;
   /**
    * Shared token-bucket for all HTTP sessions.
@@ -334,9 +375,12 @@ export class StreamableHttpHandler {
       );
       res.setHeader(
         "Access-Control-Allow-Headers",
-        "Content-Type, Authorization, Mcp-Session-Id",
+        "Content-Type, Authorization, Mcp-Session-Id, Mcp-Session-Token",
       );
-      res.setHeader("Access-Control-Expose-Headers", "Mcp-Session-Id");
+      res.setHeader(
+        "Access-Control-Expose-Headers",
+        "Mcp-Session-Id, Mcp-Session-Token",
+      );
     }
 
     // OPTIONS is handled by server.ts before auth — this handler only sees POST/GET/DELETE.
@@ -405,11 +449,15 @@ export class StreamableHttpHandler {
     let sessionIsNew = false;
 
     if (msg.method === "initialize") {
-      // Capacity guard — try to evict the oldest idle session before rejecting.
-      // If a client crashed without sending DELETE, its session lingers until
-      // the TTL prune fires. Eviction here gives new connections a seat without
-      // waiting up to 10 minutes for the idle sweep.
-      if (this.sessions.size >= MAX_HTTP_SESSIONS) {
+      // Capacity guard — fold `pendingSessionCreates` into the count so two
+      // concurrent initializes can't both pass the check, await
+      // `instructionsProvider`, then `sessions.set` past MAX. Try to evict
+      // the oldest idle session before rejecting; clients that crashed
+      // without sending DELETE leave sessions lingering until the TTL prune.
+      if (
+        this.sessions.size + this.pendingSessionCreates >=
+        MAX_HTTP_SESSIONS
+      ) {
         if (!this.evictOldestIdleSession()) {
           res.writeHead(503, { "Content-Type": "application/json" });
           res.end(
@@ -455,6 +503,10 @@ export class StreamableHttpHandler {
         session.transport.claudeCodeSessionId = ccSessionId;
       }
       res.setHeader("Mcp-Session-Id", session.id);
+      // Per-session ownership secret — required on subsequent
+      // POST/GET/DELETE so a known session ID alone is not enough to
+      // hijack the session under shared-bridge-token deployments.
+      res.setHeader("Mcp-Session-Token", session.ownershipToken);
     } else {
       if (typeof sessionId !== "string") {
         res.writeHead(400, { "Content-Type": "application/json" });
@@ -477,6 +529,24 @@ export class StreamableHttpHandler {
             error: {
               code: -32000,
               message: "Session not found or expired — re-initialize",
+            },
+          }),
+        );
+        return;
+      }
+      // Verify the caller owns this session (Mcp-Session-Token header
+      // matches what was returned in the initialize response). Without
+      // this check, any caller with a valid bridge token who learns the
+      // session's UUID could hijack POST traffic on someone else's session.
+      if (!checkOwnership(req, session)) {
+        res.writeHead(403, { "Content-Type": "application/json" });
+        res.end(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            id: msg.id ?? null,
+            error: {
+              code: -32000,
+              message: "Mcp-Session-Token missing or invalid",
             },
           }),
         );
@@ -562,6 +632,11 @@ export class StreamableHttpHandler {
       res.end("Session not found");
       return;
     }
+    if (!checkOwnership(req, session)) {
+      res.writeHead(403, { "Content-Type": "text/plain" });
+      res.end("Mcp-Session-Token missing or invalid");
+      return;
+    }
 
     // Establish SSE stream for server→client notifications.
     // Disable the per-request timeout for this long-lived stream only.
@@ -604,13 +679,18 @@ export class StreamableHttpHandler {
       res.end("Missing Mcp-Session-Id header");
       return;
     }
-    if (!this.sessions.has(sessionId)) {
+    const session = this.sessions.get(sessionId);
+    if (!session) {
       res.writeHead(404, { "Content-Type": "text/plain" });
       res.end("Session not found");
       return;
     }
-    const session = this.sessions.get(sessionId);
-    if (session && session.inFlight > 0) {
+    if (!checkOwnership(req, session)) {
+      res.writeHead(403, { "Content-Type": "text/plain" });
+      res.end("Mcp-Session-Token missing or invalid");
+      return;
+    }
+    if (session.inFlight > 0) {
       res.writeHead(409, { "Content-Type": "application/json" });
       res.end(JSON.stringify({ error: "request in progress" }));
       return;
@@ -624,7 +704,20 @@ export class StreamableHttpHandler {
     scope: string | null = null,
     denyTools: Set<string> = new Set(),
   ): Promise<HttpSession> {
+    this.pendingSessionCreates++;
+    try {
+      return await this.createSessionImpl(scope, denyTools);
+    } finally {
+      this.pendingSessionCreates--;
+    }
+  }
+
+  private async createSessionImpl(
+    scope: string | null,
+    denyTools: Set<string>,
+  ): Promise<HttpSession> {
     const id = crypto.randomUUID();
+    const ownershipToken = crypto.randomBytes(32).toString("hex");
     const session = {
       id,
       adapter: null as unknown,
@@ -634,6 +727,7 @@ export class StreamableHttpHandler {
       lastActivity: Date.now(),
       inFlight: 0,
       claudeCodeSessionId: null,
+      ownershipToken,
     } as HttpSession;
     const adapter = new HttpAdapter(
       (msg) => this.logger.warn(msg),
@@ -692,55 +786,72 @@ export class StreamableHttpHandler {
 
     // Join the plugin watcher BEFORE registerAllTools so that if a reload fires
     // between the two, this transport is already tracked and will receive fresh tools.
+    // If anything between here and `sessions.set` throws (e.g. pluginTools getter
+    // or registerAllTools), the watcher tracks a transport that never made it into
+    // `sessions` — clean up explicitly via the catch below.
     this.getPluginWatcher()?.addTransport(transport);
-    const pluginTools = this.getPluginTools();
+    try {
+      const pluginTools = this.getPluginTools();
 
-    registerAllTools(
-      transport,
-      this.config,
-      session.openedFiles,
-      this.probes,
-      this.extensionClient,
-      this.activityLog,
-      terminalPrefix,
-      this.fileLock,
-      this.allSessions as Map<
-        string,
-        {
-          id: string;
-          transport: McpTransport;
-          openedFiles: Set<string>;
-          terminalPrefix: string;
-          graceTimer: ReturnType<typeof setTimeout> | null;
-          connectedAt: number;
-          ws: import("ws").WebSocket;
-        }
-      >,
-      this.orchestrator as
-        | import("./claudeOrchestrator.js").ClaudeOrchestrator
-        | null,
-      id,
-      pluginTools,
-      // Parity with the WebSocket call in bridge.ts — without these,
-      // `ctxSaveTrace`, `ctxQueryTraces`, and any tool gated on the
-      // remaining deps silently fail to register for Streamable-HTTP
-      // MCP sessions.
-      this.toolDeps.automationHooks,
-      this.toolDeps.getDisconnectInfo,
-      this.toolDeps.onContextCacheUpdated,
-      this.toolDeps.getExtensionDisconnectCount,
-      this.toolDeps.commitIssueLinkLog,
-      this.toolDeps.recipeRunLog,
-      this.toolDeps.decisionTraceLog,
-    );
+      registerAllTools(
+        transport,
+        this.config,
+        session.openedFiles,
+        this.probes,
+        this.extensionClient,
+        this.activityLog,
+        terminalPrefix,
+        this.fileLock,
+        this.allSessions as Map<
+          string,
+          {
+            id: string;
+            transport: McpTransport;
+            openedFiles: Set<string>;
+            terminalPrefix: string;
+            graceTimer: ReturnType<typeof setTimeout> | null;
+            connectedAt: number;
+            ws: import("ws").WebSocket;
+          }
+        >,
+        this.orchestrator as
+          | import("./claudeOrchestrator.js").ClaudeOrchestrator
+          | null,
+        id,
+        pluginTools,
+        // Parity with the WebSocket call in bridge.ts — without these,
+        // `ctxSaveTrace`, `ctxQueryTraces`, and any tool gated on the
+        // remaining deps silently fail to register for Streamable-HTTP
+        // MCP sessions.
+        this.toolDeps.automationHooks,
+        this.toolDeps.getDisconnectInfo,
+        this.toolDeps.onContextCacheUpdated,
+        this.toolDeps.getExtensionDisconnectCount,
+        this.toolDeps.commitIssueLinkLog,
+        this.toolDeps.recipeRunLog,
+        this.toolDeps.decisionTraceLog,
+      );
 
-    transport.attach(adapter as unknown as import("ws").WebSocket);
+      transport.attach(adapter as unknown as import("ws").WebSocket);
 
-    this.sessions.set(id, session);
-    this.logger.info(
-      `HTTP session created (${id.slice(0, 8)}) — ${this.sessions.size} HTTP sessions`,
-    );
-    return session;
+      this.sessions.set(id, session);
+      this.logger.info(
+        `HTTP session created (${id.slice(0, 8)}) — ${this.sessions.size} HTTP sessions`,
+      );
+      return session;
+    } catch (err) {
+      // Roll back the partial session. The pluginWatcher is the only external
+      // registration so far; transport.detach is a no-op if attach() never ran;
+      // adapter.close releases SSE resources if any heartbeat was set up.
+      this.getPluginWatcher()?.removeTransport(transport);
+      try {
+        transport.detach();
+      } catch {}
+      try {
+        adapter.close();
+      } catch {}
+      throw err;
+    }
   }
 
   private destroySession(id: string): void {


### PR DESCRIPTION
## Summary

Closes the round-3 audit findings (after a review pass that confirmed/refuted each item).

### HTTP transport (`src/streamableHttp.ts`)

**Per-session ownership token.** Initialize response now returns `Mcp-Session-Token` (32-byte random hex) alongside `Mcp-Session-Id`. POST/GET/DELETE require the header to match (timing-safe). Without this, any caller with a valid bridge bearer + a known `Mcp-Session-Id` could DELETE another session, hijack its SSE via GET, or impersonate POST traffic. Bearer-binding alone is insufficient because the bridge usually runs with a single shared bearer.

**Eviction race.** Capacity check folds `pendingSessionCreates` into the count so two concurrent inits can't both pass the guard and `sessions.set` past MAX_HTTP_SESSIONS during the `instructionsProvider` await.

**Pre-init crash leak.** try/catch around the half-built session — removes the transport from pluginWatcher and closes the adapter if anything between `addTransport` and `sessions.set` throws.

### Plugin loader (`src/pluginLoader.ts`)

**Symlink path traversal.** Entrypoint escape check now compares `realpathSync` results in addition to the lexical `path.relative`. A symlinked entrypoint or pluginDir can no longer point outside.

**Built-in tool shadowing.** Collision-detection set seeded with `TOOL_CATEGORIES` keys so a plugin declaring `toolNamePrefix: "git_"` cannot register `git_status` and silently overwrite the built-in.

### Claude orchestrator (`src/claudeDriver.ts`)

**Process group kill.** Subprocess is spawned with `detached: true` (own process group). Node's AbortSignal kills only the direct PID, leaving claude's tool grandchildren alive after bridge exit. New `killProcessGroup` sends SIGTERM to `-pid`; wired into the abort listener and startup-timeout handler.

**Byte-correct output cap.** `OUTPUT_CAP = 50*1024` is now a true 50KB UTF-8 budget. `String.slice` counted UTF-16 code units, letting CJK / emoji content emit ~200KB and split surrogate pairs at boundaries. `truncateUtf8Bytes` substitutes U+FFFD for incomplete trailing sequences.

### Dashboard (`src/inboxRoutes.ts`)

**Path leak.** `/inbox` response no longer includes `path: filePath` (absolute filesystem path with username/home dir). Low-impact info disclosure if the dashboard is ever proxied to an untrusted client.

## Items dropped after review

- Plugin prototype-pollution: REFUTED (V8 strips `__proto__` from JSON.parse).
- Plugin semver fail-open: confirmed but Low (the version check is purely advisory; line 268 also bypasses with a warn).
- Plugin hot-reload race: Low (single tick, JS single-threaded).
- Orchestrator driver swap: REFUTED (`private readonly`, no reconstruction path).
- Orchestrator resume UUID: not a bug — `sessionId` forwarded by design.
- Cancel-vs-done race: contract-clarity issue, not a security/correctness bug; deferred.
- Dashboard SSR title / manifest 404 / mobile drawer / limit=abc: REFUTED.
- Dashboard favicon 500: cosmetic stub, deferred.

## Tests

5 new ownership-token regression tests (DELETE/GET/POST without token, cross-session takeover attempt). Total 4540/4540 pass.

## Test plan

- [x] `npx vitest run` — 4540/4540 pass
- [x] `npx tsc --noEmit` — clean
- [x] `npx biome check` — clean
- [ ] Manual: connect Claude Desktop "Custom Connectors" to verify it correctly stores+sends `Mcp-Session-Token` (or document the new header in the bridge readme)

🤖 Generated with [Claude Code](https://claude.com/claude-code)