### PR TITLE
fix(security): plugin shadowing/symlink + orchestrator process group/byte-cap + HTTP eviction race/leak + inbox path leak

### DIFF
--- a/src/claudeDriver.ts
+++ b/src/claudeDriver.ts
@@ -130,6 +130,20 @@ export interface IClaudeDriver {
 
 const OUTPUT_CAP = 50 * 1024; // 50KB
 
+/**
+ * Truncate `text` to at most `cap` UTF-8 bytes without splitting a multi-byte
+ * codepoint mid-sequence. `String.slice(0, cap)` operates on UTF-16 code
+ * units, so a 50K cap can store ~50K code points but emit up to ~200KB of
+ * UTF-8 wire bytes for CJK / emoji content — and may produce a lone
+ * surrogate at the boundary. `Buffer.toString("utf8")` substitutes U+FFFD
+ * for incomplete trailing sequences instead.
+ */
+function truncateUtf8Bytes(text: string, cap: number): string {
+  const buf = Buffer.from(text, "utf8");
+  if (buf.length <= cap) return text;
+  return buf.subarray(0, cap).toString("utf8");
+}
+
 /** Shape of a parsed stream-json event from `claude -p --output-format stream-json`. */
 interface StreamJsonEvent {
   type: "system" | "assistant" | "result" | string;
@@ -292,6 +306,30 @@ export class SubprocessDriver implements IClaudeDriver {
       detached: true,
     });
 
+    /**
+     * Kill the entire process group, not just the direct child. Because we
+     * spawned with `detached: true`, the child runs in its own process group.
+     * `child.kill()` and Node's AbortSignal-driven kill both target only the
+     * direct child PID, leaving grandchildren (claude's own tool subprocesses)
+     * orphaned and surviving bridge shutdown. Negative PID = process group.
+     */
+    const killProcessGroup = (signal: NodeJS.Signals = "SIGTERM"): void => {
+      if (typeof child.pid !== "number") return;
+      try {
+        process.kill(-child.pid, signal);
+      } catch {
+        // ESRCH = group already dead, EPERM = permission lost. Either way,
+        // no further action available.
+      }
+    };
+
+    // When AbortController fires (timeout, manual cancel, shutdown), Node
+    // sends SIGTERM to child PID only — escalate to the process group so
+    // grandchildren go too. Listener removed automatically when child exits.
+    const onAbort = () => killProcessGroup("SIGTERM");
+    input.signal.addEventListener("abort", onAbort, { once: true });
+    child.on("close", () => input.signal.removeEventListener("abort", onAbort));
+
     // JSONL output state
     // -------------------------------------------------------------------
     // With --output-format stream-json, claude emits one JSON object per line.
@@ -301,9 +339,27 @@ export class SubprocessDriver implements IClaudeDriver {
     // Accumulated text from assistant events — used as fallback for final text if
     // the result event is missing (old binary, crash before result, etc.)
     let accumulated = "";
-    // outputBytesSent tracks how many bytes have been forwarded to onChunk so we
+    // outputBytesSent tracks how many bytes (UTF-8) have been forwarded to onChunk so we
     // can apply OUTPUT_CAP without truncating the accumulated text used for analysis.
+    // Counted in bytes (not UTF-16 code units) because OUTPUT_CAP is a byte budget —
+    // a string slice would let multi-byte CJK / emoji content overshoot the cap by 4×.
     let outputBytesSent = 0;
+    /**
+     * Truncate `text` so it adds at most `remaining` UTF-8 bytes to the
+     * stream and never splits a multi-byte codepoint mid-sequence. Returns
+     * the safely-truncated slice plus its actual byte length.
+     */
+    const truncateToBytes = (
+      text: string,
+      remaining: number,
+    ): { send: string; bytes: number } => {
+      const buf = Buffer.from(text, "utf8");
+      if (buf.length <= remaining) return { send: text, bytes: buf.length };
+      // Buffer.toString("utf8") substitutes U+FFFD for incomplete trailing
+      // sequences, which is the correct UTF-8 truncation behavior.
+      const sliced = buf.subarray(0, remaining).toString("utf8");
+      return { send: sliced, bytes: Buffer.byteLength(sliced, "utf8") };
+    };
     // firstAssistantAt: set on the first assistant event; used to compute startupMs.
     let firstAssistantAt: number | undefined;
     // doneFromResult: set when a result event is received so the abort path can
@@ -331,10 +387,13 @@ export class SubprocessDriver implements IClaudeDriver {
           const text = `${line}\n`;
           accumulated += text;
           if (outputBytesSent < OUTPUT_CAP) {
-            const send = text.slice(0, OUTPUT_CAP - outputBytesSent);
-            if (send.length > 0) {
+            const { send, bytes } = truncateToBytes(
+              text,
+              OUTPUT_CAP - outputBytesSent,
+            );
+            if (bytes > 0) {
               input.onChunk?.(send);
-              outputBytesSent += send.length;
+              outputBytesSent += bytes;
             }
           }
           continue;
@@ -353,10 +412,13 @@ export class SubprocessDriver implements IClaudeDriver {
             if (text.length > 0) {
               accumulated += text;
               if (outputBytesSent < OUTPUT_CAP) {
-                const send = text.slice(0, OUTPUT_CAP - outputBytesSent);
-                if (send.length > 0) {
+                const { send, bytes } = truncateToBytes(
+                  text,
+                  OUTPUT_CAP - outputBytesSent,
+                );
+                if (bytes > 0) {
                   input.onChunk?.(send);
-                  outputBytesSent += send.length;
+                  outputBytesSent += bytes;
                 }
               }
             }
@@ -375,10 +437,13 @@ export class SubprocessDriver implements IClaudeDriver {
     let stderr = "";
     child.stderr.setEncoding("utf-8");
     child.stderr.on("data", (chunk: string) => {
-      // Apply the same cap to stderr to prevent unbounded memory growth
-      if (stderr.length < OUTPUT_CAP) {
+      // Apply the same byte-budget cap to stderr to prevent unbounded
+      // memory growth on multi-byte UTF-8 output.
+      if (Buffer.byteLength(stderr, "utf8") < OUTPUT_CAP) {
         stderr += chunk;
-        if (stderr.length > OUTPUT_CAP) stderr = stderr.slice(0, OUTPUT_CAP);
+        if (Buffer.byteLength(stderr, "utf8") > OUTPUT_CAP) {
+          stderr = truncateUtf8Bytes(stderr, OUTPUT_CAP);
+        }
       }
     });
 
@@ -396,7 +461,9 @@ export class SubprocessDriver implements IClaudeDriver {
       ? setTimeout(() => {
           if (firstAssistantAt === undefined && !doneFromResult) {
             startupTimedOut = true;
-            child.kill();
+            // Kill the whole group so grandchildren don't survive — same
+            // reason as in the abort handler above.
+            killProcessGroup("SIGTERM");
           }
         }, input.startupTimeoutMs)
       : null;
@@ -414,7 +481,7 @@ export class SubprocessDriver implements IClaudeDriver {
       // rather than returning wasAborted: true with partial output.
       if (doneFromResult) {
         return {
-          text: resultText.slice(0, OUTPUT_CAP),
+          text: truncateUtf8Bytes(resultText, OUTPUT_CAP),
           exitCode: resultIsError ? 1 : 0,
           durationMs: Date.now() - start,
           stderrTail: stderrTailOf(stderr),
@@ -428,7 +495,7 @@ export class SubprocessDriver implements IClaudeDriver {
         // Return rather than throw so the orchestrator can surface partial
         // output, stderrTail, and wasAborted to callers (e.g. /tasks).
         return {
-          text: accumulated.slice(0, OUTPUT_CAP),
+          text: truncateUtf8Bytes(accumulated, OUTPUT_CAP),
           exitCode: -1,
           durationMs: Date.now() - start,
           stderrTail: stderrTailOf(stderr),
@@ -469,7 +536,7 @@ export class SubprocessDriver implements IClaudeDriver {
     }
 
     return {
-      text: finalText.slice(0, OUTPUT_CAP),
+      text: truncateUtf8Bytes(finalText, OUTPUT_CAP),
       exitCode: effectiveExitCode,
       durationMs: Date.now() - start,
       stderrTail: stderrTailOf(stderr),
@@ -547,7 +614,7 @@ export class ApiDriver implements IClaudeDriver {
     _input.onChunk?.(text);
 
     return {
-      text: text.slice(0, OUTPUT_CAP),
+      text: truncateUtf8Bytes(text, OUTPUT_CAP),
       exitCode: 0,
       durationMs: Date.now() - start,
     };

--- a/src/inboxRoutes.ts
+++ b/src/inboxRoutes.ts
@@ -54,9 +54,14 @@ export function tryHandleInboxRoute(
               .filter((l) => !l.startsWith("#"))
               .join("\n")
               .trim();
+            // `path` intentionally omitted — leaking the absolute filesystem
+            // path (which includes the user's home dir / username) is a
+            // low-impact info-disclosure if the dashboard is ever proxied to
+            // an untrusted client (shared screen, screenshots, browser
+            // extensions reading the DOM). Callers identify items by `name`,
+            // and the read endpoint joins it back to inboxDir on the server.
             return {
               name,
-              path: filePath,
               modifiedAt: stats.mtime.toISOString(),
               preview: stripped.slice(0, 200),
             };

--- a/src/pluginLoader.ts
+++ b/src/pluginLoader.ts
@@ -18,6 +18,19 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 import type { Config } from "./config.js";
 import type { Logger } from "./logger.js";
+import { TOOL_CATEGORIES } from "./tools/index.js";
+
+/**
+ * Names of all built-in tools. Plugins are forbidden from registering a
+ * tool with one of these names — without this guard, a plugin declaring
+ * `toolNamePrefix: "git_"` could register `git_status` and silently shadow
+ * the built-in. `TOOL_CATEGORIES` keys are the canonical source of truth
+ * (every built-in tool is categorized for the dashboard).
+ */
+function getBuiltInToolNames(): string[] {
+  return Object.keys(TOOL_CATEGORIES);
+}
+
 import type {
   PluginContext,
   PluginManifest,
@@ -157,7 +170,12 @@ export async function loadPluginsFull(
   if (pluginSpecs.length === 0) return [];
 
   const loadedPlugins: LoadedPlugin[] = [];
-  const registeredNames = new Set<string>(); // collision guard across plugins
+  // Seed the collision guard with built-in tool names so a plugin can't
+  // shadow a built-in (e.g. declaring prefix `git_` and registering
+  // `git_status`). Without this, `registeredNames` only tracks other
+  // plugins and a plugin would silently overwrite the built-in registration
+  // depending on registration order.
+  const registeredNames = new Set<string>(getBuiltInToolNames());
 
   // Deduplicate resolved paths before loading
   const seen = new Set<string>();
@@ -283,10 +301,30 @@ export async function loadOnePluginFull(
   // 5. Dynamic import
   const entrypointPath = path.resolve(pluginDir, manifest.entrypoint);
 
-  // Prevent entrypoint path traversal — the resolved path must stay inside pluginDir
-  if (path.relative(pluginDir, entrypointPath).startsWith("..")) {
+  // Prevent entrypoint path traversal. We compare the *real* paths (after
+  // symlink resolution) so a symlinked entrypoint or a symlinked pluginDir
+  // can't escape lexically while pointing at attacker-controlled code
+  // outside the directory. `path.relative` alone is fooled by symlinks.
+  let realPluginDir: string;
+  let realEntrypoint: string;
+  try {
+    realPluginDir = fs.realpathSync(pluginDir);
+    realEntrypoint = fs.realpathSync(entrypointPath);
+  } catch (err) {
     logger.warn(
-      `Plugin "${manifest.name}" — entrypoint path "${manifest.entrypoint}" escapes plugin directory (resolved to ${entrypointPath})`,
+      `Plugin "${manifest.name}" — failed to resolve real path for entrypoint or plugin dir: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return null;
+  }
+  const escapesLexically = path
+    .relative(pluginDir, entrypointPath)
+    .startsWith("..");
+  const escapesViaSymlink = path
+    .relative(realPluginDir, realEntrypoint)
+    .startsWith("..");
+  if (escapesLexically || escapesViaSymlink) {
+    logger.warn(
+      `Plugin "${manifest.name}" — entrypoint path "${manifest.entrypoint}" escapes plugin directory (resolved to ${realEntrypoint})`,
     );
     return null;
   }

--- a/src/streamableHttp.ts
+++ b/src/streamableHttp.ts
@@ -258,6 +258,13 @@ interface HttpSession {
 /** Handles POST/GET/DELETE /mcp for all HTTP sessions. */
 export class StreamableHttpHandler {
   private sessions = new Map<string, HttpSession>();
+  /**
+   * Number of `createSession` calls currently in flight. Folded into the
+   * capacity check so two concurrent POSTs that both observe `sessions.size
+   * < MAX` cannot both pass the guard, await `instructionsProvider`, and
+   * `sessions.set` past the cap.
+   */
+  private pendingSessionCreates = 0;
   private cleanupTimer: ReturnType<typeof setInterval>;
   /**
    * Shared token-bucket for all HTTP sessions.
@@ -405,11 +412,15 @@ export class StreamableHttpHandler {
     let sessionIsNew = false;
 
     if (msg.method === "initialize") {
-      // Capacity guard — try to evict the oldest idle session before rejecting.
-      // If a client crashed without sending DELETE, its session lingers until
-      // the TTL prune fires. Eviction here gives new connections a seat without
-      // waiting up to 10 minutes for the idle sweep.
-      if (this.sessions.size >= MAX_HTTP_SESSIONS) {
+      // Capacity guard — fold `pendingSessionCreates` into the count so two
+      // concurrent initializes can't both pass the check, await
+      // `instructionsProvider`, then `sessions.set` past MAX. Try to evict
+      // the oldest idle session before rejecting; clients that crashed
+      // without sending DELETE leave sessions lingering until the TTL prune.
+      if (
+        this.sessions.size + this.pendingSessionCreates >=
+        MAX_HTTP_SESSIONS
+      ) {
         if (!this.evictOldestIdleSession()) {
           res.writeHead(503, { "Content-Type": "application/json" });
           res.end(
@@ -624,6 +635,18 @@ export class StreamableHttpHandler {
     scope: string | null = null,
     denyTools: Set<string> = new Set(),
   ): Promise<HttpSession> {
+    this.pendingSessionCreates++;
+    try {
+      return await this.createSessionImpl(scope, denyTools);
+    } finally {
+      this.pendingSessionCreates--;
+    }
+  }
+
+  private async createSessionImpl(
+    scope: string | null,
+    denyTools: Set<string>,
+  ): Promise<HttpSession> {
     const id = crypto.randomUUID();
     const session = {
       id,
@@ -692,55 +715,72 @@ export class StreamableHttpHandler {
 
     // Join the plugin watcher BEFORE registerAllTools so that if a reload fires
     // between the two, this transport is already tracked and will receive fresh tools.
+    // If anything between here and `sessions.set` throws (e.g. pluginTools getter
+    // or registerAllTools), the watcher tracks a transport that never made it into
+    // `sessions` — clean up explicitly via the catch below.
     this.getPluginWatcher()?.addTransport(transport);
-    const pluginTools = this.getPluginTools();
+    try {
+      const pluginTools = this.getPluginTools();
 
-    registerAllTools(
-      transport,
-      this.config,
-      session.openedFiles,
-      this.probes,
-      this.extensionClient,
-      this.activityLog,
-      terminalPrefix,
-      this.fileLock,
-      this.allSessions as Map<
-        string,
-        {
-          id: string;
-          transport: McpTransport;
-          openedFiles: Set<string>;
-          terminalPrefix: string;
-          graceTimer: ReturnType<typeof setTimeout> | null;
-          connectedAt: number;
-          ws: import("ws").WebSocket;
-        }
-      >,
-      this.orchestrator as
-        | import("./claudeOrchestrator.js").ClaudeOrchestrator
-        | null,
-      id,
-      pluginTools,
-      // Parity with the WebSocket call in bridge.ts — without these,
-      // `ctxSaveTrace`, `ctxQueryTraces`, and any tool gated on the
-      // remaining deps silently fail to register for Streamable-HTTP
-      // MCP sessions.
-      this.toolDeps.automationHooks,
-      this.toolDeps.getDisconnectInfo,
-      this.toolDeps.onContextCacheUpdated,
-      this.toolDeps.getExtensionDisconnectCount,
-      this.toolDeps.commitIssueLinkLog,
-      this.toolDeps.recipeRunLog,
-      this.toolDeps.decisionTraceLog,
-    );
+      registerAllTools(
+        transport,
+        this.config,
+        session.openedFiles,
+        this.probes,
+        this.extensionClient,
+        this.activityLog,
+        terminalPrefix,
+        this.fileLock,
+        this.allSessions as Map<
+          string,
+          {
+            id: string;
+            transport: McpTransport;
+            openedFiles: Set<string>;
+            terminalPrefix: string;
+            graceTimer: ReturnType<typeof setTimeout> | null;
+            connectedAt: number;
+            ws: import("ws").WebSocket;
+          }
+        >,
+        this.orchestrator as
+          | import("./claudeOrchestrator.js").ClaudeOrchestrator
+          | null,
+        id,
+        pluginTools,
+        // Parity with the WebSocket call in bridge.ts — without these,
+        // `ctxSaveTrace`, `ctxQueryTraces`, and any tool gated on the
+        // remaining deps silently fail to register for Streamable-HTTP
+        // MCP sessions.
+        this.toolDeps.automationHooks,
+        this.toolDeps.getDisconnectInfo,
+        this.toolDeps.onContextCacheUpdated,
+        this.toolDeps.getExtensionDisconnectCount,
+        this.toolDeps.commitIssueLinkLog,
+        this.toolDeps.recipeRunLog,
+        this.toolDeps.decisionTraceLog,
+      );
 
-    transport.attach(adapter as unknown as import("ws").WebSocket);
+      transport.attach(adapter as unknown as import("ws").WebSocket);
 
-    this.sessions.set(id, session);
-    this.logger.info(
-      `HTTP session created (${id.slice(0, 8)}) — ${this.sessions.size} HTTP sessions`,
-    );
-    return session;
+      this.sessions.set(id, session);
+      this.logger.info(
+        `HTTP session created (${id.slice(0, 8)}) — ${this.sessions.size} HTTP sessions`,
+      );
+      return session;
+    } catch (err) {
+      // Roll back the partial session. The pluginWatcher is the only external
+      // registration so far; transport.detach is a no-op if attach() never ran;
+      // adapter.close releases SSE resources if any heartbeat was set up.
+      this.getPluginWatcher()?.removeTransport(transport);
+      try {
+        transport.detach();
+      } catch {}
+      try {
+        adapter.close();
+      } catch {}
+      throw err;
+    }
   }
 
   private destroySession(id: string): void {


### PR DESCRIPTION
## Summary

Round-3 audit fixes — non-breaking subset, after a review pass that confirmed/refuted each finding. The breaking change (per-session ownership token) is split into a separate PR because it changes the wire contract for HTTP clients (Claude Desktop / claude.ai connectors / third-party MCP clients).

### HTTP transport (`src/streamableHttp.ts`)

- **Eviction race**: capacity check folds `pendingSessionCreates` into the count so two concurrent initializes can't both pass the check, await `instructionsProvider`, then `sessions.set` past MAX_HTTP_SESSIONS.
- **Pre-init crash leak**: try/catch around the half-built session removes the transport from pluginWatcher and closes the adapter if anything between `addTransport` and `sessions.set` throws.

### Plugin loader (`src/pluginLoader.ts`)

- **Symlink path traversal**: entrypoint escape check now compares `realpathSync` results, not just lexical `path.relative`. A symlinked entrypoint (or pluginDir) pointing outside is rejected.
- **Built-in tool shadowing**: collision-detection set seeded with `TOOL_CATEGORIES` keys so a plugin can't declare prefix `git_` and register `git_status` to silently overwrite the built-in.

### Claude orchestrator (`src/claudeDriver.ts`)

- **Process group kill**: subprocess spawned with `detached: true` runs in its own process group. Node's AbortSignal kills only the direct PID, leaving claude's tool-subprocess grandchildren alive after bridge exit. New `killProcessGroup` sends SIGTERM to `-pid`; wired into the abort listener and startup-timeout handler.
- **Byte-correct output cap**: `OUTPUT_CAP = 50*1024` is now a true 50KB UTF-8 budget. `String.slice` counted UTF-16 code units, so CJK / emoji content emitted up to ~200KB and could split a surrogate pair mid-codepoint. `truncateUtf8Bytes` substitutes U+FFFD for incomplete trailing sequences.

### Dashboard inbox (`src/inboxRoutes.ts`)

- **Path leak**: `/inbox` response no longer includes the absolute filesystem path of each item. The path leaked the user's home dir / username — low-impact info disclosure if the dashboard is ever proxied to an untrusted client.

## Items dropped after review

- Plugin prototype-pollution: REFUTED (V8 strips `__proto__` from JSON.parse).
- Plugin semver fail-open: confirmed but Low (purely advisory; line 268 also bypasses with a warn).
- Plugin hot-reload race: Low (single tick, JS single-threaded).
- Orchestrator driver swap: REFUTED (`private readonly`, no reconstruction path).
- Orchestrator resume UUID: not a bug — `sessionId` forwarded by design.
- Cancel-vs-done race: contract-clarity issue, not security/correctness; deferred.
- Dashboard SSR title / manifest 404 / mobile drawer / `limit=abc`: REFUTED.
- Dashboard favicon 500: cosmetic stub, deferred.

## Out of scope

- **Per-session ownership token** for HTTP DELETE/GET/POST hijack prevention — separate PR. Breaking change requiring client coordination (Claude Desktop, claude.ai, third-party MCP clients) and release notes.

## Test plan

- [x] `npx vitest run` — 4535/4535 pass
- [x] `npx tsc --noEmit` — clean
- [x] `npx biome check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)