### PR TITLE
fix(security): per-session ownership token for HTTP MCP transport [BREAKING]

### DIFF
--- a/scripts/smoke/cat5-http.mjs
+++ b/scripts/smoke/cat5-http.mjs
@@ -31,23 +31,34 @@ const INIT = {
 
 console.log("\n[CAT-5] Streamable HTTP transport");
 
-// 5.1 POST /mcp initialize → 200 + session header
+// 5.1 POST /mcp initialize → 200 + session header + ownership token
 let sessionId;
+let sessionToken;
 {
   const r = await httpPost(`${BASE}/mcp`, INIT, { ...AUTH, ...CT_JSON });
   assertEq(r.status, 200, "5.1 initialize → 200");
   sessionId = r.headers["mcp-session-id"];
+  sessionToken = r.headers["mcp-session-token"];
   assert(
     typeof sessionId === "string" && sessionId.length > 0,
     "5.1 Mcp-Session-Id header set",
   );
+  assert(
+    typeof sessionToken === "string" && sessionToken.length > 0,
+    "5.1 Mcp-Session-Token header set",
+  );
 }
+
+const SESSION_HEADERS = {
+  "Mcp-Session-Id": sessionId,
+  "Mcp-Session-Token": sessionToken,
+};
 
 // Send notifications/initialized (required by MCP protocol before other requests)
 await httpPost(
   `${BASE}/mcp`,
   { jsonrpc: "2.0", method: "notifications/initialized" },
-  { ...AUTH, ...CT_JSON, "Mcp-Session-Id": sessionId },
+  { ...AUTH, ...CT_JSON, ...SESSION_HEADERS },
 );
 
 // 5.2 Reuse session — tools/list
@@ -55,7 +66,7 @@ await httpPost(
   const r = await httpPost(
     `${BASE}/mcp`,
     { jsonrpc: "2.0", id: 2, method: "tools/list", params: {} },
-    { ...AUTH, ...CT_JSON, "Mcp-Session-Id": sessionId },
+    { ...AUTH, ...CT_JSON, ...SESSION_HEADERS },
   );
   assertEq(r.status, 200, "5.2 session reuse → 200");
   const body = JSON.parse(r.body);
@@ -75,7 +86,7 @@ await httpPost(
         headers: {
           ...AUTH,
           Accept: "text/event-stream",
-          "Mcp-Session-Id": sessionId,
+          ...SESSION_HEADERS,
         },
       },
       (res) => {
@@ -97,7 +108,7 @@ await httpPost(
 {
   const r = await httpDelete(`${BASE}/mcp`, {
     ...AUTH,
-    "Mcp-Session-Id": sessionId,
+    ...SESSION_HEADERS,
   });
   assert(
     r.status === 200 || r.status === 204,
@@ -110,7 +121,7 @@ await httpPost(
   const r = await httpPost(
     `${BASE}/mcp`,
     { jsonrpc: "2.0", id: 3, method: "tools/list", params: {} },
-    { ...AUTH, ...CT_JSON, "Mcp-Session-Id": sessionId },
+    { ...AUTH, ...CT_JSON, ...SESSION_HEADERS },
   );
   assertEq(r.status, 404, `5.5 deleted session → 404 (got ${r.status})`);
 }
@@ -120,7 +131,11 @@ await httpPost(
   const sessions = [];
   for (let i = 0; i < 5; i++) {
     const r = await httpPost(`${BASE}/mcp`, INIT, { ...AUTH, ...CT_JSON });
-    if (r.status === 200) sessions.push(r.headers["mcp-session-id"]);
+    if (r.status === 200)
+      sessions.push({
+        sid: r.headers["mcp-session-id"],
+        token: r.headers["mcp-session-token"],
+      });
   }
   // 6th session: either 200 (oldest idle evicted) or 503
   const r6 = await httpPost(`${BASE}/mcp`, INIT, { ...AUTH, ...CT_JSON });
@@ -129,10 +144,12 @@ await httpPost(
     `5.6 6th session → 200 (eviction) or 503 (no idle) (got ${r6.status})`,
   );
   // Cleanup
-  for (const sid of sessions) {
-    await httpDelete(`${BASE}/mcp`, { ...AUTH, "Mcp-Session-Id": sid }).catch(
-      () => {},
-    );
+  for (const s of sessions) {
+    await httpDelete(`${BASE}/mcp`, {
+      ...AUTH,
+      "Mcp-Session-Id": s.sid,
+      "Mcp-Session-Token": s.token,
+    }).catch(() => {});
   }
 }
 

--- a/scripts/smoke/cat6-oauth.mjs
+++ b/scripts/smoke/cat6-oauth.mjs
@@ -297,20 +297,29 @@ try {
     `6.6 OAuth access token authorizes HTTP MCP initialize (got ${initResp.status})`,
   );
   const sessionId = initResp.headers["mcp-session-id"];
+  const sessionToken = initResp.headers["mcp-session-token"];
   assert(
     typeof sessionId === "string",
     "6.6 initialize returns Mcp-Session-Id",
   );
+  assert(
+    typeof sessionToken === "string",
+    "6.6 initialize returns Mcp-Session-Token",
+  );
+  const SESSION_HEADERS = {
+    "Mcp-Session-Id": sessionId,
+    "Mcp-Session-Token": sessionToken,
+  };
   // Send notifications/initialized then tools/list
   await httpPostJson(
     `${ISSUER}/mcp`,
     { jsonrpc: "2.0", method: "notifications/initialized" },
-    { ...CT_JSON, ...BEARER, "Mcp-Session-Id": sessionId },
+    { ...CT_JSON, ...BEARER, ...SESSION_HEADERS },
   );
   const toolsHttpResp = await httpPostJson(
     `${ISSUER}/mcp`,
     { jsonrpc: "2.0", id: 2, method: "tools/list", params: {} },
-    { ...CT_JSON, ...BEARER, "Mcp-Session-Id": sessionId },
+    { ...CT_JSON, ...BEARER, ...SESSION_HEADERS },
   );
   assert(
     Array.isArray(toolsHttpResp.body?.result?.tools),

--- a/src/__tests__/integration-e2e.test.ts
+++ b/src/__tests__/integration-e2e.test.ts
@@ -318,12 +318,15 @@ describe("Streamable HTTP — session lifecycle", () => {
 
     expect(res.status).toBe(200);
     const sessionId = res.headers["mcp-session-id"];
+    const sessionToken = res.headers["mcp-session-token"];
     expect(typeof sessionId).toBe("string");
+    expect(typeof sessionToken).toBe("string");
 
-    // DELETE to close the session
+    // DELETE to close the session — must echo the per-session ownership token.
     const del = await httpDelete(`http://127.0.0.1:${port}/mcp`, {
       Authorization: `Bearer ${authToken}`,
       "Mcp-Session-Id": sessionId as string,
+      "Mcp-Session-Token": sessionToken as string,
     });
     expect(del.status).toBe(204);
 

--- a/src/__tests__/streamableHttp.test.ts
+++ b/src/__tests__/streamableHttp.test.ts
@@ -62,6 +62,7 @@ async function post(
   port: number,
   data: Record<string, unknown>,
   sessionId?: string,
+  ownershipToken?: string,
 ): Promise<{
   status: number;
   headers: http.IncomingHttpHeaders;
@@ -74,6 +75,7 @@ async function post(
       Authorization: `Bearer ${TOKEN}`,
     };
     if (sessionId) headers["Mcp-Session-Id"] = sessionId;
+    if (ownershipToken) headers["Mcp-Session-Token"] = ownershipToken;
 
     const req = http.request(
       { hostname: "127.0.0.1", port, path: "/mcp", method: "POST", headers },
@@ -97,6 +99,7 @@ async function httpReq(
   port: number,
   method: string,
   sessionId?: string,
+  ownershipToken?: string,
 ): Promise<{
   status: number;
   headers: http.IncomingHttpHeaders;
@@ -107,6 +110,7 @@ async function httpReq(
       Authorization: `Bearer ${TOKEN}`,
     };
     if (sessionId) headers["Mcp-Session-Id"] = sessionId;
+    if (ownershipToken) headers["Mcp-Session-Token"] = ownershipToken;
 
     const req = http.request(
       { hostname: "127.0.0.1", port, path: "/mcp", method, headers },
@@ -125,8 +129,10 @@ async function httpReq(
   });
 }
 
-/** Initialize a session, returning the Mcp-Session-Id. */
-async function initSession(port: number): Promise<string> {
+/** Initialize a session, returning the Mcp-Session-Id and Mcp-Session-Token. */
+async function initSession(
+  port: number,
+): Promise<{ sid: string; token: string }> {
   const res = await post(port, {
     jsonrpc: "2.0",
     id: 1,
@@ -138,9 +144,12 @@ async function initSession(port: number): Promise<string> {
     },
   });
   const sid = res.headers["mcp-session-id"];
+  const token = res.headers["mcp-session-token"];
   if (typeof sid !== "string")
     throw new Error("No session ID in initialize response");
-  return sid;
+  if (typeof token !== "string")
+    throw new Error("No ownership token in initialize response");
+  return { sid, token };
 }
 
 // ── Test suite ─────────────────────────────────────────────────────────────────
@@ -225,10 +234,10 @@ describe("Streamable HTTP: session lifecycle", () => {
   });
 
   it("DELETE destroys a session", async () => {
-    const sid = await initSession(port);
+    const { sid, token } = await initSession(port);
 
     // DELETE the session
-    const del = await httpReq(port, "DELETE", sid);
+    const del = await httpReq(port, "DELETE", sid, token);
     expect(del.status).toBe(204);
 
     // Subsequent request should 404
@@ -236,6 +245,7 @@ describe("Streamable HTTP: session lifecycle", () => {
       port,
       { jsonrpc: "2.0", id: 2, method: "tools/list", params: {} },
       sid,
+      token,
     );
     expect(res.status).toBe(404);
   });
@@ -248,6 +258,46 @@ describe("Streamable HTTP: session lifecycle", () => {
   it("DELETE returns 404 for unknown session", async () => {
     const res = await httpReq(port, "DELETE", "nonexistent");
     expect(res.status).toBe(404);
+  });
+});
+
+// ── Ownership token ───────────────────────────────────────────────────────────
+
+describe("Streamable HTTP: per-session ownership token", () => {
+  it("DELETE without Mcp-Session-Token returns 403", async () => {
+    const { sid } = await initSession(port);
+    const res = await httpReq(port, "DELETE", sid); // no token
+    expect(res.status).toBe(403);
+  });
+
+  it("DELETE with wrong Mcp-Session-Token returns 403", async () => {
+    const { sid } = await initSession(port);
+    const wrongToken = "0".repeat(64);
+    const res = await httpReq(port, "DELETE", sid, wrongToken);
+    expect(res.status).toBe(403);
+  });
+
+  it("GET without Mcp-Session-Token returns 403", async () => {
+    const { sid } = await initSession(port);
+    const res = await httpReq(port, "GET", sid); // no token
+    expect(res.status).toBe(403);
+  });
+
+  it("POST on existing session without Mcp-Session-Token returns 403", async () => {
+    const { sid } = await initSession(port);
+    const res = await post(
+      port,
+      { jsonrpc: "2.0", id: 2, method: "tools/list", params: {} },
+      sid, // no token
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it("session A's token cannot DELETE session B (cross-session takeover)", async () => {
+    const a = await initSession(port);
+    const b = await initSession(port);
+    const res = await httpReq(port, "DELETE", b.sid, a.token);
+    expect(res.status).toBe(403);
   });
 });
 
@@ -282,12 +332,13 @@ describe("Streamable HTTP: capacity guard", () => {
 
 describe("Streamable HTTP: notifications", () => {
   it("notification (no id) returns 202", async () => {
-    const sid = await initSession(port);
+    const { sid, token } = await initSession(port);
 
     const res = await post(
       port,
       { jsonrpc: "2.0", method: "notifications/initialized" },
       sid,
+      token,
     );
 
     expect(res.status).toBe(202);
@@ -479,12 +530,14 @@ function collectSseLines(
   sessionId: string,
   collectMs: number,
   lastEventId?: number,
+  ownershipToken?: string,
 ): Promise<string[]> {
   return new Promise((resolve, reject) => {
     const headers: Record<string, string> = {
       Authorization: `Bearer ${TOKEN}`,
       "Mcp-Session-Id": sessionId,
     };
+    if (ownershipToken) headers["Mcp-Session-Token"] = ownershipToken;
     if (lastEventId !== undefined) {
       headers["Last-Event-ID"] = String(lastEventId);
     }
@@ -530,10 +583,10 @@ function getAdapter(
 
 describe("Streamable HTTP: SSE event IDs", () => {
   it("notifications sent over SSE include a monotonic id: field", async () => {
-    const sid = await initSession(port);
+    const { sid, token } = await initSession(port);
 
     // Open SSE stream first, give TCP time to establish before injecting.
-    const linesPromise = collectSseLines(port, sid, 250);
+    const linesPromise = collectSseLines(port, sid, 250, undefined, token);
     await new Promise((r) => setTimeout(r, 50));
 
     // Inject a server-initiated notification directly via the adapter.
@@ -563,7 +616,7 @@ describe("Streamable HTTP: SSE event IDs", () => {
   });
 
   it("reconnect with Last-Event-ID replays missed notifications", async () => {
-    const sid = await initSession(port);
+    const { sid, token } = await initSession(port);
 
     // Inject 3 notifications directly via the internal adapter (no SSE stream attached).
     // They land in the buffer; replay is triggered when the GET includes Last-Event-ID.
@@ -577,7 +630,7 @@ describe("Streamable HTTP: SSE event IDs", () => {
     adapter.send(notif("test/third")); // id: 2
 
     // Reconnect with Last-Event-ID: 0 — should replay events with id > 0 (i.e. 1 and 2)
-    const lines = await collectSseLines(port, sid, 150, 0);
+    const lines = await collectSseLines(port, sid, 150, 0, token);
 
     const dataLines = lines.filter((l) => l.startsWith("data:"));
     expect(dataLines.length).toBeGreaterThanOrEqual(2);
@@ -599,7 +652,7 @@ describe("Streamable HTTP: SSE event IDs", () => {
     // fake clock stays in effect throughout the check.
     vi.useFakeTimers({ now: Date.now() });
 
-    const sid = await initSession(port);
+    const { sid, token } = await initSession(port);
     const adapter = getAdapter(handler!, sid);
 
     adapter.send(
@@ -624,7 +677,7 @@ describe("Streamable HTTP: SSE event IDs", () => {
   });
 
   it("buffer caps at 100 events — oldest are dropped", async () => {
-    const sid = await initSession(port);
+    const { sid, token } = await initSession(port);
 
     const adapter = getAdapter(handler!, sid);
 
@@ -640,7 +693,7 @@ describe("Streamable HTTP: SSE event IDs", () => {
     }
 
     // Reconnect with Last-Event-ID: -1 to request all buffered events
-    const lines = await collectSseLines(port, sid, 300, -1);
+    const lines = await collectSseLines(port, sid, 300, -1, token);
 
     const dataLines = lines.filter((l) => l.startsWith("data:"));
     // Should have at most 100 (the cap), so events 0-9 are dropped
@@ -674,7 +727,7 @@ describe("Streamable HTTP: GET SSE", () => {
   });
 
   it("GET establishes SSE stream with text/event-stream content type", async () => {
-    const sid = await initSession(port);
+    const { sid, token } = await initSession(port);
 
     const { status, contentType } = await new Promise<{
       status: number;
@@ -689,6 +742,7 @@ describe("Streamable HTTP: GET SSE", () => {
           headers: {
             Authorization: `Bearer ${TOKEN}`,
             "Mcp-Session-Id": sid,
+            "Mcp-Session-Token": token,
           },
         },
         (res) => {
@@ -717,12 +771,13 @@ describe("HttpAdapter: send routing", () => {
   // responses (with id) go to POST resolver, notifications go to SSE.
 
   it("tools/list request returns a response via POST", async () => {
-    const sid = await initSession(port);
+    const { sid, token } = await initSession(port);
     // Send initialized notification
     await post(
       port,
       { jsonrpc: "2.0", method: "notifications/initialized" },
       sid,
+      token,
     );
 
     // Request tools/list
@@ -730,6 +785,7 @@ describe("HttpAdapter: send routing", () => {
       port,
       { jsonrpc: "2.0", id: 2, method: "tools/list", params: {} },
       sid,
+      token,
     );
 
     expect(res.status).toBe(200);
@@ -775,8 +831,8 @@ describe("Streamable HTTP: body size limit", () => {
 
 describe("Streamable HTTP: session close", () => {
   it("handler.close() destroys all sessions", async () => {
-    const sid1 = await initSession(port);
-    const sid2 = await initSession(port);
+    const session1 = await initSession(port);
+    const session2 = await initSession(port);
 
     handler!.close();
 
@@ -784,12 +840,14 @@ describe("Streamable HTTP: session close", () => {
     const res1 = await post(
       port,
       { jsonrpc: "2.0", id: 1, method: "tools/list", params: {} },
-      sid1,
+      session1.sid,
+      session1.token,
     );
     const res2 = await post(
       port,
       { jsonrpc: "2.0", id: 1, method: "tools/list", params: {} },
-      sid2,
+      session2.sid,
+      session2.token,
     );
     expect(res1.status).toBe(404);
     expect(res2.status).toBe(404);
@@ -873,13 +931,14 @@ describe("Streamable HTTP: auth", () => {
 
 describe("Streamable HTTP: idle pruning", () => {
   it("prunes sessions that exceed TTL", async () => {
-    const sid = await initSession(port);
+    const { sid, token } = await initSession(port);
 
     // Verify session works
     const res1 = await post(
       port,
       { jsonrpc: "2.0", method: "notifications/initialized" },
       sid,
+      token,
     );
     expect(res1.status).toBe(202);
 
@@ -897,9 +956,8 @@ describe("Streamable HTTP: idle pruning", () => {
 describe("Streamable HTTP: session overflow eviction", () => {
   it("evicts oldest idle session when at capacity rather than returning 503", async () => {
     // Fill all 5 session slots
-    const sessionIds: string[] = [];
     for (let i = 0; i < 5; i++) {
-      sessionIds.push(await initSession(port));
+      await initSession(port);
     }
 
     // Make the first session appear idle by backdating its lastActivity
@@ -910,7 +968,7 @@ describe("Streamable HTTP: session overflow eviction", () => {
     firstSession.lastActivity = Date.now() - 120_000; // idle for 2 minutes > 60s threshold
 
     // A 6th initialize should succeed (evicting the stale session) rather than return 503
-    const newSid = await initSession(port);
+    const { sid: newSid } = await initSession(port);
     expect(typeof newSid).toBe("string");
 
     // Total sessions should still be 5 (evicted 1, added 1)

--- a/src/streamableHttp.ts
+++ b/src/streamableHttp.ts
@@ -253,6 +253,41 @@ interface HttpSession {
   inFlight: number;
   /** X-Claude-Code-Session-Id from the initialize request, if present. */
   claudeCodeSessionId: string | null;
+  /**
+   * Per-session ownership secret returned in the initialize response as
+   * `Mcp-Session-Token`. Subsequent POST/GET/DELETE requests must echo it
+   * in the same header. Closes the session-takeover hole where any caller
+   * with a valid bridge bearer plus a known `Mcp-Session-Id` could DELETE
+   * the session, hijack its SSE stream via GET, or impersonate POST
+   * traffic. 32 bytes hex (256-bit). Necessary because the bridge often
+   * runs with a single shared bearer token, so bearer-binding alone is
+   * insufficient.
+   */
+  ownershipToken: string;
+}
+
+/** Constant-time hex-string comparison; both inputs must be same length. */
+function hexEquals(a: string, b: string): boolean {
+  if (typeof a !== "string" || typeof b !== "string") return false;
+  if (a.length !== b.length) return false;
+  try {
+    return crypto.timingSafeEqual(Buffer.from(a, "hex"), Buffer.from(b, "hex"));
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Verifies the `Mcp-Session-Token` header matches the session's ownership
+ * token. Returns `true` if authorized.
+ */
+function checkOwnership(
+  req: http.IncomingMessage,
+  session: { ownershipToken: string },
+): boolean {
+  const presented = req.headers["mcp-session-token"];
+  if (typeof presented !== "string") return false;
+  return hexEquals(presented, session.ownershipToken);
 }
 
 /** Handles POST/GET/DELETE /mcp for all HTTP sessions. */
@@ -334,9 +369,12 @@ export class StreamableHttpHandler {
       );
       res.setHeader(
         "Access-Control-Allow-Headers",
-        "Content-Type, Authorization, Mcp-Session-Id",
+        "Content-Type, Authorization, Mcp-Session-Id, Mcp-Session-Token",
       );
-      res.setHeader("Access-Control-Expose-Headers", "Mcp-Session-Id");
+      res.setHeader(
+        "Access-Control-Expose-Headers",
+        "Mcp-Session-Id, Mcp-Session-Token",
+      );
     }
 
     // OPTIONS is handled by server.ts before auth — this handler only sees POST/GET/DELETE.
@@ -455,6 +493,10 @@ export class StreamableHttpHandler {
         session.transport.claudeCodeSessionId = ccSessionId;
       }
       res.setHeader("Mcp-Session-Id", session.id);
+      // Per-session ownership secret — required on subsequent
+      // POST/GET/DELETE so a known session ID alone is not enough to
+      // hijack the session under shared-bridge-token deployments.
+      res.setHeader("Mcp-Session-Token", session.ownershipToken);
     } else {
       if (typeof sessionId !== "string") {
         res.writeHead(400, { "Content-Type": "application/json" });
@@ -477,6 +519,22 @@ export class StreamableHttpHandler {
             error: {
               code: -32000,
               message: "Session not found or expired — re-initialize",
+            },
+          }),
+        );
+        return;
+      }
+      // Verify the caller owns this session (Mcp-Session-Token header
+      // matches what was returned in the initialize response).
+      if (!checkOwnership(req, session)) {
+        res.writeHead(403, { "Content-Type": "application/json" });
+        res.end(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            id: msg.id ?? null,
+            error: {
+              code: -32000,
+              message: "Mcp-Session-Token missing or invalid",
             },
           }),
         );
@@ -562,6 +620,11 @@ export class StreamableHttpHandler {
       res.end("Session not found");
       return;
     }
+    if (!checkOwnership(req, session)) {
+      res.writeHead(403, { "Content-Type": "text/plain" });
+      res.end("Mcp-Session-Token missing or invalid");
+      return;
+    }
 
     // Establish SSE stream for server→client notifications.
     // Disable the per-request timeout for this long-lived stream only.
@@ -604,13 +667,18 @@ export class StreamableHttpHandler {
       res.end("Missing Mcp-Session-Id header");
       return;
     }
-    if (!this.sessions.has(sessionId)) {
+    const session = this.sessions.get(sessionId);
+    if (!session) {
       res.writeHead(404, { "Content-Type": "text/plain" });
       res.end("Session not found");
       return;
     }
-    const session = this.sessions.get(sessionId);
-    if (session && session.inFlight > 0) {
+    if (!checkOwnership(req, session)) {
+      res.writeHead(403, { "Content-Type": "text/plain" });
+      res.end("Mcp-Session-Token missing or invalid");
+      return;
+    }
+    if (session.inFlight > 0) {
       res.writeHead(409, { "Content-Type": "application/json" });
       res.end(JSON.stringify({ error: "request in progress" }));
       return;
@@ -625,6 +693,7 @@ export class StreamableHttpHandler {
     denyTools: Set<string> = new Set(),
   ): Promise<HttpSession> {
     const id = crypto.randomUUID();
+    const ownershipToken = crypto.randomBytes(32).toString("hex");
     const session = {
       id,
       adapter: null as unknown,
@@ -634,6 +703,7 @@ export class StreamableHttpHandler {
       lastActivity: Date.now(),
       inFlight: 0,
       claudeCodeSessionId: null,
+      ownershipToken,
     } as HttpSession;
     const adapter = new HttpAdapter(
       (msg) => this.logger.warn(msg),


### PR DESCRIPTION
## Summary

Prevent session takeover where any caller with a valid bridge bearer plus a known `Mcp-Session-Id` could DELETE another client's session, hijack its SSE stream via GET, or impersonate POST traffic. The bridge often runs with a single shared bearer token, so bearer-binding alone is insufficient.

## Wire change

- `initialize` response now includes `Mcp-Session-Token` header — 32-byte random hex (256-bit) per session.
- POST (non-init), GET, DELETE require the same header to match (timing-safe). Mismatch → 403.
- CORS `Access-Control-Allow-Headers` / `Expose-Headers` updated to include the new header.

## ⚠️ Breaking change

HTTP MCP clients that don't echo `Mcp-Session-Token` will get 403s after init. WebSocket sessions unaffected.

**Affected:** Claude Desktop "Custom Connectors" UI, claude.ai web custom connectors, third-party MCP clients using `@modelcontextprotocol/sdk`'s HTTP transport, custom in-house HTTP MCP integrations.

**Mitigation paths before merge:**
1. Verify whether `@modelcontextprotocol/sdk` already passes through unknown headers from init responses — needs testing.
2. If not, coordinate an SDK release that reads + echoes `Mcp-Session-Token`.
3. Or ship behind a config flag (`--strict-session-ownership`) defaulting off for one release.

Holding for path 1 signal before merging.

## Tests

5 new regressions: DELETE/GET/POST without token, DELETE with wrong token, cross-session takeover (session A's token used against session B). All return 403. Helpers updated to forward the token. 4540/4540 pass.

## Related

Non-breaking subset of the round-3 audit lands in #110 (plugin shadowing/symlink, orchestrator process group + byte-cap, HTTP eviction race + pre-init leak, inbox path leak). Both PRs together close the round-3 deferred list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)