### PR TITLE
fix(security): WS resumption elicitation leak + HTTP DNS rebinding + approval dedup

### DIFF
--- a/src/__tests__/approvalQueue.test.ts
+++ b/src/__tests__/approvalQueue.test.ts
@@ -188,3 +188,137 @@ describe("ApprovalQueue — approval tokens", () => {
     expect((item as Record<string, unknown>).approvalToken).toBeUndefined();
   });
 });
+
+describe("ApprovalQueue dedup (inflight key)", () => {
+  it("identical requests return the same callId and one queue entry", () => {
+    const q = new ApprovalQueue();
+    const r1 = q.request({
+      toolName: "gitPush",
+      params: { remote: "origin", branch: "main" },
+      tier: "high",
+      sessionId: "s1",
+    });
+    const r2 = q.request({
+      toolName: "gitPush",
+      params: { remote: "origin", branch: "main" },
+      tier: "high",
+      sessionId: "s1",
+    });
+    expect(r2.callId).toBe(r1.callId);
+    expect(q.list()).toHaveLength(1);
+  });
+
+  it("dedups regardless of param key order", () => {
+    const q = new ApprovalQueue();
+    const r1 = q.request({
+      toolName: "gitPush",
+      params: { remote: "origin", branch: "main" },
+      tier: "high",
+      sessionId: "s1",
+    });
+    const r2 = q.request({
+      toolName: "gitPush",
+      params: { branch: "main", remote: "origin" },
+      tier: "high",
+      sessionId: "s1",
+    });
+    expect(r2.callId).toBe(r1.callId);
+  });
+
+  it("different params do NOT dedup", () => {
+    const q = new ApprovalQueue();
+    const r1 = q.request({
+      toolName: "gitPush",
+      params: { remote: "origin", branch: "main" },
+      tier: "high",
+      sessionId: "s1",
+    });
+    const r2 = q.request({
+      toolName: "gitPush",
+      params: { remote: "origin", branch: "feature" },
+      tier: "high",
+      sessionId: "s1",
+    });
+    expect(r2.callId).not.toBe(r1.callId);
+    expect(q.list()).toHaveLength(2);
+  });
+
+  it("different sessionIds do NOT dedup", () => {
+    const q = new ApprovalQueue();
+    const r1 = q.request({
+      toolName: "gitPush",
+      params: {},
+      tier: "high",
+      sessionId: "s1",
+    });
+    const r2 = q.request({
+      toolName: "gitPush",
+      params: {},
+      tier: "high",
+      sessionId: "s2",
+    });
+    expect(r2.callId).not.toBe(r1.callId);
+  });
+
+  it("approve() resolves both deduped promises", async () => {
+    const q = new ApprovalQueue();
+    const r1 = q.request({
+      toolName: "gitPush",
+      params: { remote: "origin" },
+      tier: "high",
+      sessionId: "s1",
+    });
+    const r2 = q.request({
+      toolName: "gitPush",
+      params: { remote: "origin" },
+      tier: "high",
+      sessionId: "s1",
+    });
+    q.approve(r1.callId);
+    await expect(r1.promise).resolves.toBe("approved");
+    await expect(r2.promise).resolves.toBe("approved");
+  });
+
+  it("expired timer resolves both deduped promises", async () => {
+    vi.useFakeTimers();
+    try {
+      const q = new ApprovalQueue({ ttlMs: 100 });
+      const r1 = q.request({
+        toolName: "gitPush",
+        params: {},
+        tier: "high",
+        sessionId: "s1",
+      });
+      const r2 = q.request({
+        toolName: "gitPush",
+        params: {},
+        tier: "high",
+        sessionId: "s1",
+      });
+      vi.advanceTimersByTime(150);
+      await expect(r1.promise).resolves.toBe("expired");
+      await expect(r2.promise).resolves.toBe("expired");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("after resolve, identical request creates a fresh entry", async () => {
+    const q = new ApprovalQueue();
+    const r1 = q.request({
+      toolName: "gitPush",
+      params: {},
+      tier: "high",
+      sessionId: "s1",
+    });
+    q.approve(r1.callId);
+    await r1.promise;
+    const r2 = q.request({
+      toolName: "gitPush",
+      params: {},
+      tier: "high",
+      sessionId: "s1",
+    });
+    expect(r2.callId).not.toBe(r1.callId);
+  });
+});

--- a/src/__tests__/server-edge-cases.test.ts
+++ b/src/__tests__/server-edge-cases.test.ts
@@ -104,6 +104,63 @@ describe("Server: DNS rebinding protection", () => {
     expect(closeCode).not.toBe(1000);
     expect(closeCode).not.toBe(1001);
   });
+
+  it("rejects HTTP requests with an external Host header (DNS rebinding)", async () => {
+    const http = await import("node:http");
+    server = new Server("test-token", logger);
+    const port = await server.findAndListen(null);
+
+    const status = await new Promise<number>((resolve, reject) => {
+      const req = http.request(
+        {
+          hostname: "127.0.0.1",
+          port,
+          path: "/health",
+          method: "GET",
+          headers: {
+            host: "evil.com",
+            authorization: "Bearer test-token",
+          },
+        },
+        (res) => {
+          res.resume();
+          res.on("end", () => resolve(res.statusCode ?? 0));
+        },
+      );
+      req.on("error", reject);
+      req.end();
+    });
+    expect(status).toBe(403);
+  });
+
+  it("accepts HTTP requests with Host: 127.0.0.1", async () => {
+    const http = await import("node:http");
+    server = new Server("test-token", logger);
+    const port = await server.findAndListen(null);
+
+    const status = await new Promise<number>((resolve, reject) => {
+      const req = http.request(
+        {
+          hostname: "127.0.0.1",
+          port,
+          path: "/health",
+          method: "GET",
+          headers: {
+            host: `127.0.0.1:${port}`,
+            authorization: "Bearer test-token",
+          },
+        },
+        (res) => {
+          res.resume();
+          res.on("end", () => resolve(res.statusCode ?? 0));
+        },
+      );
+      req.on("error", reject);
+      req.end();
+    });
+    // Whatever the route returns, the Host check should not have rejected it as 403.
+    expect(status).not.toBe(403);
+  });
 });
 
 // ── Rate limiting ─────────────────────────────────────────────────────────────

--- a/src/approvalQueue.ts
+++ b/src/approvalQueue.ts
@@ -1,4 +1,9 @@
-import { randomBytes, randomUUID, timingSafeEqual } from "node:crypto";
+import {
+  createHash,
+  randomBytes,
+  randomUUID,
+  timingSafeEqual,
+} from "node:crypto";
 import type { RiskTier } from "./riskTier.js";
 
 /**
@@ -37,10 +42,46 @@ export type ApprovalDecision = "approved" | "rejected" | "expired";
 interface Entry extends PendingApproval {
   resolve: (d: ApprovalDecision) => void;
   timer: ReturnType<typeof setTimeout>;
+  /**
+   * Stable key derived from `(sessionId, toolName, params)`. Multiple `request()`
+   * calls with the same key share the entry's promise instead of creating a
+   * new one each time. Without this, a buggy/malicious agent firing the same
+   * approval call N times spawns N queue entries and N push notifications.
+   */
+  inflightKey: string;
+  /** Promise resolvers attached to the same dedup key after the first call. */
+  pendingPromises: Array<(d: ApprovalDecision) => void>;
+}
+
+/**
+ * Stable canonical JSON used to compute the `inflightKey`. Sorts object
+ * keys at every level so logically-identical params with different key
+ * order hash the same. Returns "[uncloneable]" if input contains circular
+ * references — those won't dedup, but the queue still works.
+ */
+function canonicalJson(value: unknown): string {
+  const seen = new WeakSet<object>();
+  const stringify = (v: unknown): unknown => {
+    if (v === null || typeof v !== "object") return v;
+    if (seen.has(v as object)) return "[circular]";
+    seen.add(v as object);
+    if (Array.isArray(v)) return v.map(stringify);
+    const obj = v as Record<string, unknown>;
+    const out: Record<string, unknown> = {};
+    for (const k of Object.keys(obj).sort()) out[k] = stringify(obj[k]);
+    return out;
+  };
+  try {
+    return JSON.stringify(stringify(value));
+  } catch {
+    return "[uncloneable]";
+  }
 }
 
 export class ApprovalQueue {
   private readonly entries = new Map<string, Entry>();
+  /** inflightKey → callId, for dedup lookup on `request()`. */
+  private readonly inflight = new Map<string, string>();
   private readonly ttlMs: number;
   private readonly listeners = new Set<() => void>();
 
@@ -72,6 +113,35 @@ export class ApprovalQueue {
     approvalToken?: string;
     promise: Promise<ApprovalDecision>;
   } {
+    // Dedup: if an identical (sessionId, toolName, params) request is already
+    // queued, return its existing promise instead of allocating a fresh
+    // callId + push notification. Prevents a buggy/malicious agent that
+    // spams the same call N times from generating N prompts.
+    const inflightKey = createHash("sha256")
+      .update(input.sessionId ?? "")
+      .update("\0")
+      .update(input.toolName)
+      .update("\0")
+      .update(canonicalJson(input.params))
+      .digest("hex");
+    const existingCallId = this.inflight.get(inflightKey);
+    if (existingCallId) {
+      const existing = this.entries.get(existingCallId);
+      if (existing) {
+        const promise = new Promise<ApprovalDecision>((res) => {
+          existing.pendingPromises.push(res);
+        });
+        return {
+          callId: existing.callId,
+          approvalToken: existing.approvalToken,
+          promise,
+        };
+      }
+      // Stale inflight entry pointing at a callId that no longer exists —
+      // fall through and create a fresh request.
+      this.inflight.delete(inflightKey);
+    }
+
     const callId = randomUUID();
     const requestedAt = Date.now();
     const approvalToken = opts.withToken
@@ -85,7 +155,9 @@ export class ApprovalQueue {
       const entry = this.entries.get(callId);
       if (!entry) return;
       this.entries.delete(callId);
+      this.inflight.delete(entry.inflightKey);
       entry.resolve("expired");
+      for (const r of entry.pendingPromises) r("expired");
       this.notify();
     }, this.ttlMs);
     if (typeof timer === "object" && "unref" in timer) timer.unref();
@@ -96,8 +168,11 @@ export class ApprovalQueue {
       resolve: resolveFn,
       timer,
       approvalToken,
+      inflightKey,
+      pendingPromises: [],
       ...input,
     });
+    this.inflight.set(inflightKey, callId);
     this.notify();
     return { callId, approvalToken, promise };
   }
@@ -158,7 +233,10 @@ export class ApprovalQueue {
     if (!entry) return false;
     clearTimeout(entry.timer);
     this.entries.delete(callId);
+    this.inflight.delete(entry.inflightKey);
     entry.resolve(decision);
+    // Wake up any duplicate callers who joined this entry via dedup.
+    for (const r of entry.pendingPromises) r(decision);
     this.notify();
     return true;
   }

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -212,6 +212,15 @@ export class Bridge {
           existing.graceTimer = null;
           existing.ws = ws;
           existing.wsAlive = true;
+          // Clean up old WS listener + reject stale pending elicitations
+          // before attaching the new socket. Without this, the previous
+          // listener accumulates and pending elicitations from the old
+          // client can resolve against the new connection's `activeWs`,
+          // surfacing prompts to a client that didn't request them.
+          // Intentionally NOT calling `detach()` — that would abort
+          // in-flight tool calls, but grace-period semantics preserve
+          // those across the reconnect.
+          existing.transport.detachSoft();
           existing.transport.attach(ws);
           ws.on("pong", () => {
             existing.wsAlive = true;

--- a/src/server.ts
+++ b/src/server.ts
@@ -355,6 +355,26 @@ export class Server extends EventEmitter<ServerEvents> {
         res.setHeader("Access-Control-Expose-Headers", "Mcp-Session-Id");
       }
 
+      // DNS rebinding defense: validate Host header on every HTTP request,
+      // mirroring the WS upgrade handler below. Without this, attacker DNS
+      // can rebind a public hostname to 127.0.0.1 in the victim's browser
+      // and reach `/dashboard`, `/health`, `/metrics`, `/mcp`, OAuth
+      // endpoints, etc. with arbitrary Host headers. CORS gates browser
+      // *reads* of responses but does NOT gate top-level navigations or
+      // simple side-effect-bearing POSTs (e.g. `/oauth/authorize`).
+      const rawHost = req.headers.host ?? "";
+      const host = rawHost.startsWith("[")
+        ? rawHost.slice(0, rawHost.indexOf("]") + 1)
+        : rawHost.replace(/:\d+$/, "");
+      if (!host || !this.allowedHosts.has(host)) {
+        this.logger.warn(
+          `Rejected HTTP request with invalid Host header: ${rawHost}`,
+        );
+        res.writeHead(403, { "Content-Type": "text/plain" });
+        res.end("Invalid Host header");
+        return;
+      }
+
       const parsedUrl = new URL(req.url ?? "/", "http://localhost");
 
       // ── OAuth 2.0 endpoints (extracted to src/oauthRoutes.ts) ────────────

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -460,6 +460,40 @@ export class McpTransport {
     return count;
   }
 
+  /**
+   * Soft cleanup of stale per-connection state, used by the bridge's
+   * grace-period resumption path BEFORE calling `attach(ws)` with a new
+   * WebSocket. Unlike `detach()`, this does NOT abort in-flight tool calls
+   * or zero `activeToolCalls` — grace-period semantics preserve those
+   * across the reconnect. It only:
+   *
+   *  1. Removes the old WebSocket's "message" listener so it can't fire
+   *     against the new connection's state.
+   *  2. Rejects any pending elicitation requests, because the original
+   *     client that issued them may not be the one reattaching, and an
+   *     unrelated client should not be allowed to answer another client's
+   *     elicitation by id collision.
+   *
+   * Without this, two leaks survive a resumption:
+   *  - The old `ws.on("message", ...)` listener accumulates (gen-guarded
+   *    so it no-ops, but still attached to the now-closed socket).
+   *  - `pendingElicitations` from the old connection persist in the map;
+   *    the elicit timer keeps ticking and resolving against the NEW
+   *    `activeWs`, surfacing prompts to a client that didn't request them.
+   */
+  detachSoft(): void {
+    if (this.activeWs && this.activeListener) {
+      this.activeWs.removeListener("message", this.activeListener);
+      this.activeListener = null;
+    }
+    for (const [, pending] of this.pendingElicitations) {
+      pending.reject(
+        new Error("Client disconnected before responding to elicitation"),
+      );
+    }
+    this.pendingElicitations.clear();
+  }
+
   detach(): void {
     // Remove listener from old WebSocket to prevent accumulation
     if (this.activeWs && this.activeListener) {


### PR DESCRIPTION
## Summary

Three round-4 fixes that survived the verification pass. Lots of original findings dropped after review — see commit message for the full refute list.

### `src/transport.ts` + `src/bridge.ts` — resumption pendingElicitations leak

Grace-period reconnect called `transport.attach(ws)` without prior cleanup. Pending elicitations from the original client persisted in the map; the elicit timer kept ticking and resolved against the NEW connection's `activeWs` — surfacing prompts to a client that didn't request them.

New `detachSoft()` method: removes the old listener + rejects pending elicitations without aborting in-flight tool calls (grace-period intentionally preserves those). `bridge.ts:215` now calls it before `attach()`.

### `src/server.ts` — HTTP DNS rebinding

`allowedHosts` validation existed only on WS upgrade. The HTTP request handler had no Host check, so DNS rebinding could reach `/dashboard`, `/health`, `/metrics`, `/mcp`, OAuth endpoints with arbitrary Host headers. CORS gates browser READS but does NOT gate top-level navigations or simple side-effect POSTs (e.g. `/oauth/authorize`). Added the same Host validation at the top of the HTTP request handler, mirroring the WS upgrade.

### `src/approvalQueue.ts` — request dedup

100 identical `request()` calls produced 100 queue entries + 100 push notifications. Added an inflight-key dedup keyed by SHA-256(sessionId, toolName, canonicalJson(params)). Duplicate callers join the existing entry's `pendingPromises[]`; all resolve on approve/reject/expire.

## Items dropped after verification

- `classifyTool` case + Unicode bypass: REFUTED (bridge has no `bash` registered tool; /approvals is bearer-gated)
- Path-escape risk signal gap: cosmetic (writes already blocked at tool layer)
- Token plaintext in memory: low impact (heap-read attacker already owns bridge token)
- Same approve/reject token: mitigated by HTTPS-to-relay
- graceTimer race: REFUTED (Node timer semantics)
- Lockfile O_NOFOLLOW asymmetry: immaterial (O_EXCL+O_CREAT already rejects)
- Multi-client reattach race: REFUTED (falls through to fresh session)
- Hardlink guard race: REFUTED (realpath check kills bypass)
- `--require`/`--loader` bypass: REFUTED (DANGEROUS_PATH_FLAGS)
- macOS case-insensitive workspace: UX only
- searchAndReplace ReDoS: by design (undecidable)

## Tests

9 new regressions:
- 7 in `approvalQueue.test.ts`: dedup happy paths, key-order stability, different params/sessions don't dedup, approve/expire wakes both, fresh request after resolve
- 2 in `server-edge-cases.test.ts`: HTTP request rejected with external Host, accepted with Host: 127.0.0.1

Suite: 4549/4549 pass.

## Related

Round-1 through round-3 audits closed in #103, #104, #105, #106, #107, #108, #110, #111. This PR closes round 4 (the final sweep is still in progress in the background — separate PR if anything material surfaces).

🤖 Generated with [Claude Code](https://claude.com/claude-code)