### PR TITLE
fix(security): mobile approval token URL leak + functional bug; runLog/decisionTraceLog rotation

### DIFF
--- a/dashboard/public/sw.js
+++ b/dashboard/public/sw.js
@@ -60,12 +60,20 @@ self.addEventListener("push", (event) => {
     return;
   }
 
-  const { callId, toolName, tier, summary, approveUrl, rejectUrl, expiresAt } = data;
+  const {
+    callId,
+    toolName,
+    tier,
+    summary,
+    approveUrl,
+    rejectUrl,
+    approvalToken,
+    expiresAt,
+  } = data;
   const urgency = tier === "high" ? "⚠️ " : "";
   const title = `${urgency}Approval required`;
   const body = summary ?? `Tool: ${toolName}`;
   const tag = `approval-${callId}`;
-  const ttl = expiresAt ? Math.max(0, Math.floor((expiresAt - Date.now()) / 1000)) : 300;
 
   event.waitUntil(
     self.registration.showNotification(title, {
@@ -74,7 +82,8 @@ self.addEventListener("push", (event) => {
       icon: "/icons/icon-192.png",
       badge: "/icons/icon-192.png",
       requireInteraction: true,
-      data: { callId, approveUrl, rejectUrl },
+      // expiresAt is consulted on click — see notificationclick handler.
+      data: { callId, approveUrl, rejectUrl, approvalToken, expiresAt },
       actions: [
         { action: "approve", title: "Approve" },
         { action: "reject", title: "Reject" },
@@ -83,22 +92,40 @@ self.addEventListener("push", (event) => {
       silent: tier !== "high",
     }),
   );
-  void ttl; // used for future expiry hint
 });
 
 // ── Notification click ────────────────────────────────────────────────────
 
 self.addEventListener("notificationclick", (event) => {
   event.notification.close();
-  const { callId, approveUrl, rejectUrl } = event.notification.data ?? {};
+  const { callId, approveUrl, rejectUrl, approvalToken, expiresAt } =
+    event.notification.data ?? {};
+
+  // Stale notification: token-clearing path on the bridge runs single-use,
+  // so a click after expiry would 401 anyway, but we short-circuit to avoid
+  // surfacing failure noise to the user / log.
+  if (typeof expiresAt === "number" && Date.now() >= expiresAt) {
+    return;
+  }
+
+  // The bridge reads the approval token from the `x-approval-token` header,
+  // NOT from a query-string. The token in `approveUrl`/`rejectUrl` is
+  // ignored server-side and would leak to access logs / Referer if used in
+  // the URL. Send it as a header instead, with `credentials: "omit"` so a
+  // future cookie-auth dashboard can't accidentally CSRF it.
+  const fetchOpts = {
+    method: "POST",
+    credentials: "omit",
+    headers: approvalToken ? { "x-approval-token": approvalToken } : {},
+  };
 
   // Inline approve/reject actions — no need to open browser
   if (event.action === "approve" && approveUrl) {
-    event.waitUntil(fetch(approveUrl, { method: "POST" }).catch(() => {}));
+    event.waitUntil(fetch(approveUrl, fetchOpts).catch(() => {}));
     return;
   }
   if (event.action === "reject" && rejectUrl) {
-    event.waitUntil(fetch(rejectUrl, { method: "POST" }).catch(() => {}));
+    event.waitUntil(fetch(rejectUrl, fetchOpts).catch(() => {}));
     return;
   }
 

--- a/services/push-relay/src/__tests__/relay.test.ts
+++ b/services/push-relay/src/__tests__/relay.test.ts
@@ -143,6 +143,11 @@ describe("POST /push", () => {
     expect(data.callId).toBe("abc-123");
     expect(data.approvalToken).toBe("token-xyz");
     expect(data.approveUrl).toContain("/approve/abc-123");
+    // Token must NOT appear in the URL — it leaks to access logs and Referer.
+    // The service worker pulls `approvalToken` from the data payload and
+    // sends it as an `x-approval-token` header on the approve POST.
+    expect(data.approveUrl).not.toContain("token=");
+    expect(data.approveUrl).not.toContain("token-xyz");
   });
 
   it("rejects missing callId", async () => {

--- a/services/push-relay/src/dispatcher.ts
+++ b/services/push-relay/src/dispatcher.ts
@@ -75,8 +75,12 @@ export async function dispatchToUser(
   const title = buildTitle(payload.toolName, payload.tier);
   const body = buildBody(payload.toolName, payload.summary);
 
-  const approveUrl = `${payload.bridgeCallbackBase}/approve/${payload.callId}?token=${payload.approvalToken}`;
-  const rejectUrl = `${payload.bridgeCallbackBase}/reject/${payload.callId}?token=${payload.approvalToken}`;
+  // Token is sent in the FCM/APNS data payload (out of the URL) so it does
+  // not appear in HTTP access logs, browser history, or Referer headers.
+  // The service worker pulls `approvalToken` from `data` and sends it as
+  // an `x-approval-token` header on the approve/reject POST.
+  const approveUrl = `${payload.bridgeCallbackBase}/approve/${payload.callId}`;
+  const rejectUrl = `${payload.bridgeCallbackBase}/reject/${payload.callId}`;
 
   const fcmDevices = devices.filter((d) => d.platform === "fcm");
   const apnsDevices = devices.filter((d) => d.platform === "apns");

--- a/src/__tests__/runLog.test.ts
+++ b/src/__tests__/runLog.test.ts
@@ -446,4 +446,43 @@ describe("RecipeRunLog.record", () => {
     expect(log.size()).toBe(1);
     expect(log.query()[0]!.taskId).toBe("x");
   });
+
+  it("rotates runs.jsonl when it exceeds the byte cap", () => {
+    const file = path.join(tmp, "runs.jsonl");
+    // Pre-seed > 1 MB so the next append triggers rotation.
+    const fs = require("node:fs") as typeof import("node:fs");
+    const longRun = JSON.stringify({
+      seq: 0,
+      taskId: "x".repeat(2000),
+      recipeName: "r",
+      trigger: "recipe",
+      status: "done",
+      createdAt: 1,
+      doneAt: 2,
+      durationMs: 1,
+    });
+    const lines: string[] = [];
+    for (let i = 0; i < 600; i++) lines.push(longRun);
+    fs.writeFileSync(file, `${lines.join("\n")}\n`);
+    expect(fs.statSync(file).size).toBeGreaterThan(1024 * 1024);
+
+    const log = new RecipeRunLog({ dir: tmp });
+    log.appendDirect({
+      taskId: "fresh",
+      recipeName: "r",
+      trigger: "recipe",
+      status: "done",
+      createdAt: 0,
+      startedAt: 0,
+      doneAt: 1,
+      durationMs: 1,
+    });
+
+    // After rotation + append, file must be roughly under the cap and
+    // still contain the fresh line we can read back.
+    const sizeAfter = fs.statSync(file).size;
+    expect(sizeAfter).toBeLessThan(1024 * 1024 + longRun.length + 1024);
+    const text = fs.readFileSync(file, "utf8");
+    expect(text).toContain('"taskId":"fresh"');
+  });
 });

--- a/src/decisionTraceLog.ts
+++ b/src/decisionTraceLog.ts
@@ -1,4 +1,10 @@
-import { appendFileSync, mkdirSync, readFileSync, statSync } from "node:fs";
+import {
+  appendFileSync,
+  mkdirSync,
+  readFileSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
 import path from "node:path";
 import type { Logger } from "./logger.js";
 
@@ -37,6 +43,14 @@ export interface DecisionTrace {
 }
 
 const DEFAULT_MEMORY_CAP = 2_000;
+
+/**
+ * Disk rotation thresholds. Without these, decision_traces.jsonl grows
+ * unbounded as agents call `ctxSaveTrace`; on a busy bridge this fills
+ * `~/.claude/ide/` and OOMs `loadExisting` at next boot.
+ */
+const MAX_PERSIST_BYTES = 1024 * 1024; // 1 MB
+const MAX_PERSIST_LINES = 10_000;
 const MAX_PROBLEM_LEN = 500;
 const MAX_SOLUTION_LEN = 500;
 const MAX_TAGS = 10;
@@ -82,7 +96,7 @@ export class DecisionTraceLog {
     this.memoryCap = opts.memoryCap ?? DEFAULT_MEMORY_CAP;
     this.now = opts.now ?? Date.now;
     try {
-      mkdirSync(opts.dir, { recursive: true });
+      mkdirSync(opts.dir, { recursive: true, mode: 0o700 });
     } catch (err) {
       opts.logger?.warn?.(
         `[dtrace-log] could not create ${opts.dir}: ${err instanceof Error ? err.message : String(err)}`,
@@ -165,10 +179,42 @@ export class DecisionTraceLog {
 
   private append(trace: DecisionTrace): void {
     try {
+      try {
+        const st = statSync(this.file);
+        if (st.size > MAX_PERSIST_BYTES) this.rotateDisk();
+      } catch (err) {
+        const code = (err as NodeJS.ErrnoException).code;
+        if (code !== "ENOENT") throw err;
+      }
       appendFileSync(this.file, `${JSON.stringify(trace)}\n`, { mode: 0o600 });
     } catch (err) {
       this.opts.logger?.warn?.(
         `[dtrace-log] append failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  /**
+   * Trim decision_traces.jsonl to the most recent MAX_PERSIST_LINES (or
+   * whatever fits under MAX_PERSIST_BYTES). Best-effort — failure logs and
+   * the next append proceeds against the un-rotated file.
+   */
+  private rotateDisk(): void {
+    try {
+      const raw = readFileSync(this.file, "utf-8");
+      let lines = raw.split("\n").filter((l) => l.trim());
+      if (lines.length > MAX_PERSIST_LINES) {
+        lines = lines.slice(-MAX_PERSIST_LINES);
+      }
+      let joined = lines.join("\n");
+      while (joined.length + 1 > MAX_PERSIST_BYTES && lines.length > 1) {
+        lines = lines.slice(-Math.max(1, Math.floor(lines.length / 2)));
+        joined = lines.join("\n");
+      }
+      writeFileSync(this.file, `${joined}\n`, { mode: 0o600 });
+    } catch (err) {
+      this.opts.logger?.warn?.(
+        `[dtrace-log] rotate failed: ${err instanceof Error ? err.message : String(err)}`,
       );
     }
   }

--- a/src/runLog.ts
+++ b/src/runLog.ts
@@ -1,4 +1,10 @@
-import { appendFileSync, mkdirSync, readFileSync, statSync } from "node:fs";
+import {
+  appendFileSync,
+  mkdirSync,
+  readFileSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
 import path from "node:path";
 import type { Logger } from "./logger.js";
 
@@ -85,6 +91,16 @@ export interface RecipeRun {
 const MAX_OUTPUT_TAIL = 2_000;
 const DEFAULT_MEMORY_CAP = 500;
 
+/**
+ * Disk rotation thresholds. The file grows append-only via `appendFileSync`
+ * on every recipe run; without rotation a busy automation policy will fill
+ * `~/.claude/ide/` over time and OOM the bridge at next boot via
+ * `loadExisting`'s full `readFileSync`. We rotate at either limit, keeping
+ * the most recent N lines.
+ */
+const MAX_PERSIST_BYTES = 1024 * 1024; // 1 MB
+const MAX_PERSIST_LINES = 10_000;
+
 export interface RunLogOptions {
   /** Directory holding runs.jsonl. Created if missing. */
   dir: string;
@@ -117,7 +133,11 @@ export class RecipeRunLog {
     this.memoryCap = opts.memoryCap ?? DEFAULT_MEMORY_CAP;
     this.now = opts.now ?? Date.now;
     try {
-      mkdirSync(opts.dir, { recursive: true });
+      // 0o700 — restrict directory listing to the bridge's user. Without
+      // an explicit mode here we fall through to the umask, which is
+      // typically 0o022 → world-traversable dir. File entries are 0o600
+      // so contents are safe; only listing leaks.
+      mkdirSync(opts.dir, { recursive: true, mode: 0o700 });
     } catch (err) {
       opts.logger?.warn?.(
         `[runlog] could not create ${opts.dir}: ${err instanceof Error ? err.message : String(err)}`,
@@ -361,10 +381,46 @@ export class RecipeRunLog {
 
   private append(run: RecipeRun): void {
     try {
+      // Rotate first if the file is over the limit. Cheap stat call; only
+      // rewrites when needed. Without this, runs.jsonl grows unbounded.
+      try {
+        const st = statSync(this.file);
+        if (st.size > MAX_PERSIST_BYTES) this.rotateDisk();
+      } catch (err) {
+        const code = (err as NodeJS.ErrnoException).code;
+        if (code !== "ENOENT") throw err;
+      }
       appendFileSync(this.file, `${JSON.stringify(run)}\n`, { mode: 0o600 });
     } catch (err) {
       this.opts.logger?.warn?.(
         `[runlog] append failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  /**
+   * Trim runs.jsonl to the most recent MAX_PERSIST_LINES (or whatever
+   * fits under MAX_PERSIST_BYTES). Lines beyond the cap are dropped from
+   * disk; in-memory `runs[]` is unaffected (separately bounded by
+   * memoryCap). Best-effort — failure is logged and the next append
+   * proceeds against the un-rotated file.
+   */
+  private rotateDisk(): void {
+    try {
+      const raw = readFileSync(this.file, "utf8");
+      let lines = raw.split("\n").filter((l) => l.trim());
+      if (lines.length > MAX_PERSIST_LINES) {
+        lines = lines.slice(-MAX_PERSIST_LINES);
+      }
+      let joined = lines.join("\n");
+      while (joined.length + 1 > MAX_PERSIST_BYTES && lines.length > 1) {
+        lines = lines.slice(-Math.max(1, Math.floor(lines.length / 2)));
+        joined = lines.join("\n");
+      }
+      writeFileSync(this.file, `${joined}\n`, { mode: 0o600 });
+    } catch (err) {
+      this.opts.logger?.warn?.(
+        `[runlog] rotate failed: ${err instanceof Error ? err.message : String(err)}`,
       );
     }
   }


### PR DESCRIPTION
## Summary

Round-5 final sweep: two critical mobile-oversight fixes (one of which restored a broken feature) plus log rotation to prevent unbounded disk growth.

### Mobile approval token: URL leak + 401 silent fail

The push relay was building `approveUrl`/`rejectUrl` with `?token=<approvalToken>` in the query string. The bridge ONLY reads the token from the `x-approval-token` header (`server.ts:528`), never from the URL.

**Two compounding problems:**
1. **The feature was broken.** Phone-path approve/reject clicks all 401'd silently — the SW fetched the URL with no header, so the bridge's bearer-auth gate ran and rejected the request.
2. **Token leaked.** The same token appeared in HTTP access logs, browser history, Referer headers, and any CDN/proxy in front of the bridge.

**Fix:**
- Dispatcher removes `?token=` from the URLs. Token already lived in the FCM/APNS `data` payload — the correct channel.
- Service worker pulls `approvalToken` from notification data and sends it as an `x-approval-token` header on POST.
- Adds `credentials: "omit"` to defend against future cookie-auth dashboard CSRF.
- Short-circuits stale clicks past `expiresAt`.

### runLog + decisionTraceLog rotation

`runs.jsonl` and `decision_traces.jsonl` had only an in-memory cap. The underlying files grew unbounded via `appendFileSync`. A busy automation policy or `ctxSaveTrace`-calling agent would fill `~/.claude/ide/` over time, and the next bridge boot would OOM in `loadExisting`'s full `readFileSync`.

Ported activityLog's rotation pattern: 1 MB / 10 000-line cap, keep most recent N.

Constructor `mkdirSync` also gets `mode: 0o700` so the directory isn't world-traversable on permissive umasks (file entries were already 0o600).

## Items dropped after review

From the round-5 sweep:
- **Cleartext approvalToken in FCM/APNS payload + token replay**: real risk on insider-of-push-provider / log-breach attacker, but proper fix is HMAC-bound JWT (signed `{callId, action, exp}`) — that's a redesign of the token contract and warrants its own PR.
- **Token not action-bound (approve↔reject flip)**: same redesign as above.
- **`/push/test` lets bridge fire bogus-token push**: minor, defer.
- **Push relay shared secret rotation**: defer.
- **No-scrub on `ctxSaveTrace` free-text**: agent-discipline concern; auto-scrubbing would mangle legitimate text.
- **Sync `appendFileSync` blocks event loop**: real but low-impact in practice (disk-full / slow-disk only); defer.

## Tests

- New `src/__tests__/runLog.test.ts` regression: pre-seed > 1 MB, append once, assert file rotates under cap and fresh line is preserved.
- Strengthened `services/push-relay/src/__tests__/relay.test.ts`: assert `approveUrl` does NOT contain `token=` or the token value.

Suite: 4550/4550 pass (bridge 4541, push-relay 9).

## Round summary

Rounds 1-5 audit closed in #103, #104, #105, #106, #107, #108, #110, #111, #112, this PR. Outstanding security work intentionally deferred:
- HMAC-signed action-bound approval tokens (replaces the opaque-secret model)
- Push relay env-token rotation
- Async `appendFileSync` in runLog/decisionTraceLog

🤖 Generated with [Claude Code](https://claude.com/claude-code)