### PR TITLE
fix(security,reliability): plugin built-in shadow + ApprovalQueue.clear pending leak + log rotation edges

### DIFF
--- a/src/__tests__/approvalQueue.test.ts
+++ b/src/__tests__/approvalQueue.test.ts
@@ -321,4 +321,39 @@ describe("ApprovalQueue dedup (inflight key)", () => {
     });
     expect(r2.callId).not.toBe(r1.callId);
   });
+
+  it("clear() resolves deduped pending promises AND empties inflight map", async () => {
+    // Bug 2: clear() walked entries.values() and resolved each entry.resolve,
+    // but never iterated entry.pendingPromises[] (deduped joiners) and never
+    // cleared this.inflight. Deduped callers' promises hung forever after
+    // shutdown / resetApprovalQueueForTests.
+    const q = new ApprovalQueue();
+    const r1 = q.request({
+      toolName: "gitPush",
+      params: { remote: "origin", branch: "main" },
+      tier: "high",
+      sessionId: "s1",
+    });
+    const r2 = q.request({
+      toolName: "gitPush",
+      params: { remote: "origin", branch: "main" },
+      tier: "high",
+      sessionId: "s1",
+    });
+    // r2 dedup-joined r1 — same callId, separate promise.
+    expect(r2.callId).toBe(r1.callId);
+
+    q.clear();
+
+    // Both the primary and the deduped joiner must wake.
+    await expect(r1.promise).resolves.toBe("expired");
+    await expect(r2.promise).resolves.toBe("expired");
+
+    // inflight map must be drained — leftover entries leak memory and
+    // prevent the next identical request from creating a fresh entry.
+    // Reach into the private field via index access (acceptable in tests).
+    const inflight = (q as unknown as { inflight: Map<string, string> })
+      .inflight;
+    expect(inflight.size).toBe(0);
+  });
 });

--- a/src/__tests__/decisionTraceLog.test.ts
+++ b/src/__tests__/decisionTraceLog.test.ts
@@ -132,4 +132,39 @@ describe("DecisionTraceLog", () => {
     expect(log.size()).toBe(3);
     expect(log.query({}).map((r) => r.ref)).toEqual(["#4", "#3", "#2"]);
   });
+
+  it("Bug 4: rotateDisk() drops a single oversized line rather than writing past the byte cap", () => {
+    // Same shape as runLog Bug 4 — the while-loop halves `lines` until under
+    // cap, but exits when `lines.length === 1`. A single forged row (e.g. a
+    // pre-existing decision trace with embedded blob) exceeding the cap was
+    // written back unchanged.
+    const file = path.join(dir, "decision_traces.jsonl");
+    const fs = require("node:fs") as typeof import("node:fs");
+
+    // Decision traces themselves cap problem/solution at 500 chars, but
+    // pre-existing lines on disk aren't re-validated. Forge an arbitrarily
+    // large line that satisfies the JSON shape.
+    const oversized = JSON.stringify({
+      seq: 1,
+      createdAt: 1,
+      ref: "#huge",
+      problem: "p",
+      solution: "s",
+      workspace: "/ws",
+      // 2 MB junk in tags, just to blow the cap.
+      tags: ["x".repeat(2 * 1024 * 1024)],
+    });
+    fs.writeFileSync(file, `${oversized}\n`);
+    expect(fs.statSync(file).size).toBeGreaterThan(1024 * 1024);
+
+    const log = new DecisionTraceLog({ dir });
+    // Trigger rotation by appending a fresh trace.
+    log.record({ ...base(), ref: "#after-drop" });
+
+    const sizeAfter = fs.statSync(file).size;
+    expect(sizeAfter).toBeLessThan(1024 * 1024);
+    const text = fs.readFileSync(file, "utf8");
+    expect(text).not.toContain('"ref":"#huge"');
+    expect(text).toContain('"ref":"#after-drop"');
+  });
 });

--- a/src/__tests__/pluginWatcher-shadow.test.ts
+++ b/src/__tests__/pluginWatcher-shadow.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Bug 1 — Plugin hot-reload must NOT shadow built-in tool names.
+ *
+ * `loadPluginsFull` seeds the collision-detection set with `getBuiltInToolNames()`.
+ * Hot-reload via `PluginWatcher._reloadPluginInner` must apply the same defense:
+ * a plugin edited mid-flight to declare e.g. `toolNamePrefix: "git"` and register
+ * `gitPush` (a built-in tool) MUST be rejected, otherwise `transport.replaceTool`
+ * silently overwrites the built-in.
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  type MockInstance,
+  vi,
+} from "vitest";
+import type { Config } from "../config.js";
+import type { LoadedPlugin } from "../pluginLoader.js";
+import { PluginWatcher } from "../pluginWatcher.js";
+import type { McpTransport } from "../transport.js";
+
+vi.mock("../pluginLoader.js", async (importOriginal) => {
+  const orig = await importOriginal<typeof import("../pluginLoader.js")>();
+  return {
+    ...orig,
+    loadOnePluginFull: vi.fn(),
+  };
+});
+
+import { loadOnePluginFull } from "../pluginLoader.js";
+
+function makeConfig(overrides: Partial<Config> = {}): Config {
+  return {
+    workspace: process.cwd(),
+    workspaceFolders: [process.cwd()],
+    ideName: "Test",
+    editorCommand: null,
+    port: null,
+    bindAddress: "127.0.0.1",
+    verbose: false,
+    jsonl: false,
+    linters: [],
+    commandAllowlist: [],
+    commandTimeout: 30_000,
+    maxResultSize: 512,
+    vscodeCommandAllowlist: [],
+    activeWorkspaceFolder: process.cwd(),
+    gracePeriodMs: 30_000,
+    autoTmux: false,
+    claudeDriver: "none",
+    claudeBinary: "claude",
+    automationEnabled: false,
+    automationPolicyPath: null,
+    toolRateLimit: 60,
+    watch: false,
+    plugins: [],
+    pluginWatch: false,
+    ...overrides,
+  };
+}
+
+function makeLogger() {
+  const calls: Array<{ level: string; msg: string }> = [];
+  return {
+    calls,
+    info: (msg: string) => calls.push({ level: "info", msg }),
+    warn: (msg: string) => calls.push({ level: "warn", msg }),
+    error: (msg: string) => calls.push({ level: "error", msg }),
+    debug: (msg: string) => calls.push({ level: "debug", msg }),
+    event: () => {},
+    child: () =>
+      ({
+        info: () => {},
+        warn: () => {},
+        error: () => {},
+        debug: () => {},
+        event: () => {},
+        child: () => ({}) as never,
+      }) as never,
+  } as unknown as import("../logger.js").Logger;
+}
+
+function makeTransport(): McpTransport {
+  return {
+    deregisterToolsByPrefix: vi.fn().mockReturnValue(1),
+    replaceTool: vi.fn(),
+  } as unknown as McpTransport;
+}
+
+function makePlugin(
+  spec: string,
+  pluginDir: string,
+  toolName: string,
+  prefix: string,
+): LoadedPlugin {
+  return {
+    spec,
+    pluginDir,
+    manifest: {
+      schemaVersion: 1,
+      name: "shadow/plugin",
+      version: "1.0.0",
+      entrypoint: "./index.mjs",
+      toolNamePrefix: prefix,
+    } as LoadedPlugin["manifest"],
+    tools: [
+      {
+        schema: {
+          name: toolName,
+          description: "Test tool",
+          inputSchema: { type: "object", properties: {} },
+        },
+        handler: async () => ({ content: [{ type: "text", text: "ok" }] }),
+      },
+    ],
+  };
+}
+
+describe("PluginWatcher hot-reload — built-in tool shadowing", () => {
+  let tmpDir: string;
+  let fsWatchSpy: MockInstance;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "plugin-shadow-test-"));
+    fsWatchSpy = vi.spyOn(fs, "watch").mockReturnValue({
+      close: vi.fn(),
+    } as unknown as fs.FSWatcher);
+    vi.mocked(loadOnePluginFull).mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("hot-reload that registers a built-in tool name (gitPush) is rejected — collision check seeded with built-ins", async () => {
+    const config = makeConfig();
+    const logger = makeLogger();
+    const sendListChanged = vi.fn();
+    const watcher = new PluginWatcher(config, logger, sendListChanged);
+
+    // Original plugin uses an innocuous prefix and tool name.
+    const spec = "./shadow-plugin";
+    const original = makePlugin(spec, tmpDir, "shadowFooBar", "shadowFoo");
+    watcher.start([original]);
+
+    const transport = makeTransport();
+    watcher.addTransport(transport);
+
+    // Mock loadOnePluginFull to capture the `existingNames` Set the watcher
+    // passes in. The real loader uses that Set to detect collisions; if the
+    // Set does NOT contain built-ins, a hot-reload trying to register
+    // `gitPush` will silently succeed and shadow the built-in.
+    let capturedExistingNames: Set<string> | null = null;
+    vi.mocked(loadOnePluginFull).mockImplementation(
+      async (_spec, _config, _logger, existingNames) => {
+        capturedExistingNames = existingNames ?? null;
+        // Simulate the loader rejecting the plugin (returning null) when
+        // a name collision exists. If existingNames doesn't include built-ins,
+        // the simulated rejection won't fire and we'll see the shadow.
+        if (existingNames?.has("gitPush")) {
+          // Loader's actual behavior — log + return null
+          return null;
+        }
+        // Otherwise the loader would happily produce a fresh plugin that
+        // registers `gitPush`, leaking past collision detection.
+        return makePlugin(spec, tmpDir, "gitPush", "git");
+      },
+    );
+
+    await watcher.reloadPlugin(spec);
+
+    // The watcher must have passed an existingNames set that contains
+    // built-in tool names (e.g. gitPush, getDiagnostics, runCommand).
+    expect(capturedExistingNames).not.toBeNull();
+    expect(capturedExistingNames!.has("gitPush")).toBe(true);
+    expect(capturedExistingNames!.has("getDiagnostics")).toBe(true);
+
+    // Because the simulated loader returned null (collision detected),
+    // transport.replaceTool must NOT have been called for the shadow tool.
+    const replaceCalls = vi.mocked(transport.replaceTool).mock.calls;
+    const shadowed = replaceCalls.find((c) => {
+      const schema = c[0] as { name?: string } | undefined;
+      return schema?.name === "gitPush";
+    });
+    expect(shadowed).toBeUndefined();
+
+    // Old tools should remain unchanged after the rejected reload.
+    const tools = watcher.getTools();
+    expect(tools).toHaveLength(1);
+    expect(tools[0]!.schema.name).toBe("shadowFooBar");
+
+    watcher.stop();
+  });
+});

--- a/src/__tests__/runLog.test.ts
+++ b/src/__tests__/runLog.test.ts
@@ -485,4 +485,122 @@ describe("RecipeRunLog.record", () => {
     const text = fs.readFileSync(file, "utf8");
     expect(text).toContain('"taskId":"fresh"');
   });
+
+  it("Bug 3: rotateDisk() updates lastFileSize so syncFromDisk() re-reads after rotation", () => {
+    // After rotation, the file shrinks. `lastFileSize` was left at the
+    // pre-rotation size; the very next `syncFromDisk()` saw `size <=
+    // lastFileSize` and returned early. New rows appended after rotation
+    // were silently invisible to query() until the file regrew.
+    const file = path.join(tmp, "runs.jsonl");
+    const fs = require("node:fs") as typeof import("node:fs");
+    const longRun = JSON.stringify({
+      seq: 0,
+      taskId: "x".repeat(2000),
+      recipeName: "r",
+      trigger: "recipe",
+      status: "done",
+      createdAt: 1,
+      doneAt: 2,
+      durationMs: 1,
+    });
+    const seedLines: string[] = [];
+    for (let i = 0; i < 600; i++) seedLines.push(longRun);
+    fs.writeFileSync(file, `${seedLines.join("\n")}\n`);
+
+    const log = new RecipeRunLog({ dir: tmp });
+    // Trigger rotation by appending a fresh row past the byte cap.
+    log.appendDirect({
+      taskId: "post-rotation-task",
+      recipeName: "r",
+      trigger: "recipe",
+      status: "done",
+      createdAt: 0,
+      startedAt: 0,
+      doneAt: 1,
+      durationMs: 1,
+    });
+
+    // Inspect the private lastFileSize after rotation. If the bug is live
+    // it would still equal the pre-rotation size (>1 MB). After the fix,
+    // it must be the post-rotation size (well under the cap). Note: an
+    // append happens after rotation inside the same `append()` call, so
+    // the file on disk is slightly larger than `lastFileSize` recorded by
+    // rotateDisk. The key invariant is that the recorded size is the
+    // post-rotation snapshot, not the >1 MB pre-rotation value.
+    const lastFileSize = (log as unknown as { lastFileSize: number })
+      .lastFileSize;
+    expect(lastFileSize).toBeLessThan(1024 * 1024);
+    expect(lastFileSize).toBeGreaterThan(0);
+
+    // External writer (e.g. another process) appends a new row directly
+    // to the file. syncFromDisk() (via query()) should pick it up.
+    const extra = {
+      seq: 99_999,
+      taskId: "external-writer",
+      recipeName: "r",
+      trigger: "recipe",
+      status: "done",
+      createdAt: 10,
+      doneAt: 11,
+      durationMs: 1,
+    };
+    fs.appendFileSync(file, `${JSON.stringify(extra)}\n`);
+    const refreshed = log.query({ limit: 500 });
+    const found = refreshed.find((r) => r.taskId === "external-writer");
+    expect(found).toBeDefined();
+    expect(found!.seq).toBe(99_999);
+  });
+
+  it("Bug 4: rotateDisk() drops a single line that exceeds the byte cap rather than writing oversized", () => {
+    // The while-loop halves `lines` until under cap, but exits when
+    // `lines.length === 1`. If that single line itself exceeds the cap,
+    // the file is written anyway — defeating the cap. registrySnapshot
+    // is unbounded user JSON, a realistic offender.
+    const file = path.join(tmp, "runs.jsonl");
+    const fs = require("node:fs") as typeof import("node:fs");
+
+    // Forge a single >1 MB line (legal JSON, just enormous).
+    const oversized = JSON.stringify({
+      seq: 1,
+      taskId: "huge",
+      recipeName: "r",
+      trigger: "recipe",
+      status: "done",
+      createdAt: 1,
+      doneAt: 2,
+      durationMs: 1,
+      // 2 MB of payload — far over the 1 MB rotation cap.
+      stepResults: [
+        {
+          id: "blow-up",
+          status: "ok",
+          durationMs: 1,
+          registrySnapshot: { junk: "x".repeat(2 * 1024 * 1024) },
+        },
+      ],
+    });
+    fs.writeFileSync(file, `${oversized}\n`);
+    expect(fs.statSync(file).size).toBeGreaterThan(1024 * 1024);
+
+    const log = new RecipeRunLog({ dir: tmp });
+    // Trigger rotation by appending any new row.
+    log.appendDirect({
+      taskId: "after-drop",
+      recipeName: "r",
+      trigger: "recipe",
+      status: "done",
+      createdAt: 5,
+      startedAt: 5,
+      doneAt: 6,
+      durationMs: 1,
+    });
+
+    // Post-rotation file must NOT contain the oversized row, and MUST be
+    // honestly under the cap (plus the small fresh appended row).
+    const sizeAfter = fs.statSync(file).size;
+    expect(sizeAfter).toBeLessThan(1024 * 1024);
+    const text = fs.readFileSync(file, "utf8");
+    expect(text).not.toContain('"taskId":"huge"');
+    expect(text).toContain('"taskId":"after-drop"');
+  });
 });

--- a/src/approvalQueue.ts
+++ b/src/approvalQueue.ts
@@ -224,8 +224,16 @@ export class ApprovalQueue {
     for (const entry of this.entries.values()) {
       clearTimeout(entry.timer);
       entry.resolve("expired");
+      // Wake up any duplicate callers who joined this entry via dedup —
+      // their promises would otherwise hang forever after shutdown /
+      // resetApprovalQueueForTests.
+      for (const r of entry.pendingPromises) r("expired");
     }
     this.entries.clear();
+    // Drain dedup map. Stale entries are self-healing on the next request,
+    // but leaving them around leaks memory across shutdown cycles and is
+    // the wrong invariant for `clear()`.
+    this.inflight.clear();
   }
 
   private resolveEntry(callId: string, decision: ApprovalDecision): boolean {

--- a/src/decisionTraceLog.ts
+++ b/src/decisionTraceLog.ts
@@ -211,7 +211,21 @@ export class DecisionTraceLog {
         lines = lines.slice(-Math.max(1, Math.floor(lines.length / 2)));
         joined = lines.join("\n");
       }
-      writeFileSync(this.file, `${joined}\n`, { mode: 0o600 });
+      // If we're down to a single line that still exceeds the cap, drop it
+      // entirely. Without this guard the while-loop exits at length===1 and
+      // we'd write an oversized row back, defeating rotation. Pre-existing
+      // rows on disk aren't re-validated against the per-record limits, so
+      // a forged/legacy row can in principle exceed the cap.
+      if (lines.length === 1 && joined.length + 1 > MAX_PERSIST_BYTES) {
+        this.opts.logger?.warn?.(
+          `[dtrace-log] rotate dropped 1 oversized row (${joined.length} bytes > ${MAX_PERSIST_BYTES} cap)`,
+        );
+        lines = [];
+        joined = "";
+      }
+      writeFileSync(this.file, joined.length > 0 ? `${joined}\n` : "", {
+        mode: 0o600,
+      });
     } catch (err) {
       this.opts.logger?.warn?.(
         `[dtrace-log] rotate failed: ${err instanceof Error ? err.message : String(err)}`,

--- a/src/pluginLoader.ts
+++ b/src/pluginLoader.ts
@@ -26,8 +26,12 @@ import { TOOL_CATEGORIES } from "./tools/index.js";
  * `toolNamePrefix: "git_"` could register `git_status` and silently shadow
  * the built-in. `TOOL_CATEGORIES` keys are the canonical source of truth
  * (every built-in tool is categorized for the dashboard).
+ *
+ * Exported so `PluginWatcher` can seed its hot-reload collision check with
+ * the same set of built-in names — without this, hot-reload only blocks
+ * collisions across sibling plugins, leaving built-ins shadowable.
  */
-function getBuiltInToolNames(): string[] {
+export function getBuiltInToolNames(): string[] {
   return Object.keys(TOOL_CATEGORIES);
 }
 

--- a/src/pluginWatcher.ts
+++ b/src/pluginWatcher.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import type { Config } from "./config.js";
 import type { Logger } from "./logger.js";
 import {
+  getBuiltInToolNames,
   type LoadedPlugin,
   type LoadedPluginTool,
   loadOnePluginFull,
@@ -103,8 +104,13 @@ export class PluginWatcher {
       `[plugin-watch] Reloading plugin "${old.manifest.name}" ...`,
     );
 
-    // Collision names = all names from OTHER plugins
-    const otherNames = new Set<string>();
+    // Collision names = built-in tool names + all names from OTHER plugins.
+    // Seeding with built-ins matches the initial-load defense in
+    // `loadPluginsFull`; without it a plugin edited mid-flight to declare
+    // e.g. `toolNamePrefix: "git"` and register `gitPush` would slip past
+    // collision detection during hot-reload and `transport.replaceTool`
+    // would silently shadow the built-in.
+    const otherNames = new Set<string>(getBuiltInToolNames());
     for (const [s, p] of this.loadedPlugins) {
       if (s !== spec) {
         for (const t of p.tools) otherNames.add(t.schema.name);

--- a/src/runLog.ts
+++ b/src/runLog.ts
@@ -417,7 +417,29 @@ export class RecipeRunLog {
         lines = lines.slice(-Math.max(1, Math.floor(lines.length / 2)));
         joined = lines.join("\n");
       }
-      writeFileSync(this.file, `${joined}\n`, { mode: 0o600 });
+      // If we're down to a single line that still exceeds the cap, drop it
+      // entirely. Without this guard the while-loop exits at length===1 and
+      // we'd write an oversized row back, defeating rotation. A realistic
+      // offender is `RunStepResult.registrySnapshot` which is unbounded
+      // user JSON.
+      if (lines.length === 1 && joined.length + 1 > MAX_PERSIST_BYTES) {
+        this.opts.logger?.warn?.(
+          `[runlog] rotate dropped 1 oversized row (${joined.length} bytes > ${MAX_PERSIST_BYTES} cap)`,
+        );
+        lines = [];
+        joined = "";
+      }
+      writeFileSync(this.file, joined.length > 0 ? `${joined}\n` : "", {
+        mode: 0o600,
+      });
+      // Refresh `lastFileSize` so the next syncFromDisk() doesn't see
+      // `size <= lastFileSize` (stale pre-rotation value) and silently
+      // skip freshly-appended rows.
+      try {
+        this.lastFileSize = statSync(this.file).size;
+      } catch {
+        this.lastFileSize = 0;
+      }
     } catch (err) {
       this.opts.logger?.warn?.(
         `[runlog] rotate failed: ${err instanceof Error ? err.message : String(err)}`,


### PR DESCRIPTION
## Summary

4 bugs from the dogfood sweep, all small and disjoint:

- **Plugin hot-reload shadow (security)** — \`_reloadPluginInner\` didn't seed built-in tool names into the collision check; a plugin reloaded mid-flight could shadow \`gitPush\`/\`runCommand\` etc.
- **\`ApprovalQueue.clear()\` deduped-caller leak** — primary promise resolved but \`pendingPromises[]\` joined via dedup hung forever; \`inflight\` never cleared.
- **\`RecipeRunLog.rotateDisk()\` stale \`lastFileSize\`** — multi-process readers silently dropped freshly-appended rows after rotation until file regrew past pre-rotation size.
- **Rotation byte-cap edge** — both \`decisionTraceLog\` and \`runLog\` would write oversized single-line rows when length hit 1; now drop + warn.

## Test plan

- [x] Direct test scope: 61 tests across 4 files (approvalQueue, decisionTraceLog, runLog, pluginWatcher-shadow) — all green.
- [x] Plugin & registration tests: pluginLoader (25), pluginWatcher (9), streamableHttpToolRegistration (2) — all green.
- [x] \`npx tsc --noEmit\` clean.
- [x] biome clean on changed files.

## Notes

Companion to PR #114 (transport stats + detachSoft + mcpOAuth dedup + ToolContext overload). Keeping these in separate PRs because the surface areas don't overlap and the change footprints are small.

🤖 Generated with [Claude Code](https://claude.com/claude-code)