### PR TITLE
fix(dashboard): close CSRF gap on connector + push routes; validate marketplace install shape

### DIFF
--- a/dashboard/src/app/api/connections/[connector]/connect/route.ts
+++ b/dashboard/src/app/api/connections/[connector]/connect/route.ts
@@ -1,4 +1,5 @@
 import { bridgeFetch } from "@/lib/bridge";
+import { requireSameOrigin } from "@/lib/csrf";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -14,6 +15,8 @@ export async function POST(
   req: Request,
   ctx: { params: { connector: string } },
 ): Promise<Response> {
+  const guard = requireSameOrigin(req);
+  if (guard) return guard;
   const { connector } = ctx.params;
   if (!ALLOWED_CONNECTORS.has(connector)) {
     return new Response(JSON.stringify({ error: "Unknown connector" }), {

--- a/dashboard/src/app/api/connections/[connector]/route.ts
+++ b/dashboard/src/app/api/connections/[connector]/route.ts
@@ -1,4 +1,5 @@
 import { bridgeFetch } from "@/lib/bridge";
+import { requireSameOrigin } from "@/lib/csrf";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -9,9 +10,11 @@ const ALLOWED_CONNECTORS = new Set([
 ]);
 
 export async function DELETE(
-  _req: Request,
+  req: Request,
   ctx: { params: { connector: string } },
 ): Promise<Response> {
+  const guard = requireSameOrigin(req);
+  if (guard) return guard;
   const { connector } = ctx.params;
   if (!ALLOWED_CONNECTORS.has(connector)) {
     return new Response(JSON.stringify({ error: "Unknown connector" }), {

--- a/dashboard/src/app/api/connector-requests/route.ts
+++ b/dashboard/src/app/api/connector-requests/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
+import { requireSameOrigin } from "@/lib/csrf";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -13,6 +14,8 @@ interface ConnectorRequest {
 }
 
 export async function POST(req: Request): Promise<Response> {
+  const guard = requireSameOrigin(req);
+  if (guard) return guard;
   let body: unknown;
   try {
     body = await req.json();

--- a/dashboard/src/app/api/push/subscribe/__tests__/route.test.ts
+++ b/dashboard/src/app/api/push/subscribe/__tests__/route.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Regression test: the push/subscribe POST handler must reject cross-site
+ * requests via the same sec-fetch-site check the bridge proxy uses.
+ *
+ * Without the guard, any third-party page can register a push subscription
+ * for a victim's bridge by submitting a hidden form / fetch from a different
+ * origin. Browsers send the cookies, the route accepts the body, and the
+ * attacker-controlled endpoint receives every approval push from then on.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/lib/pushStore", () => ({
+  addSubscription: vi.fn(),
+}));
+
+import { POST } from "@/app/api/push/subscribe/route";
+import { addSubscription } from "@/lib/pushStore";
+
+beforeEach(() => {
+  vi.mocked(addSubscription).mockReset();
+});
+
+function makeReq(secFetchSite: string | null, body: unknown): NextRequest {
+  const headers = new Headers({ "content-type": "application/json" });
+  if (secFetchSite !== null) headers.set("sec-fetch-site", secFetchSite);
+  return new NextRequest("http://localhost:3200/api/push/subscribe", {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+  });
+}
+
+const validSub = {
+  endpoint: "https://example.com/push/abc",
+  keys: { p256dh: "p256dh-key", auth: "auth-key" },
+};
+
+describe("POST /api/push/subscribe — CSRF guard", () => {
+  it("rejects cross-site requests with 403", async () => {
+    const res = await POST(makeReq("cross-site", validSub));
+    expect(res.status).toBe(403);
+    expect(addSubscription).not.toHaveBeenCalled();
+  });
+
+  it("rejects same-site (subdomain) requests with 403", async () => {
+    const res = await POST(makeReq("same-site", validSub));
+    expect(res.status).toBe(403);
+    expect(addSubscription).not.toHaveBeenCalled();
+  });
+
+  it("accepts same-origin requests", async () => {
+    const res = await POST(makeReq("same-origin", validSub));
+    expect(res.status).toBe(200);
+    expect(addSubscription).toHaveBeenCalledOnce();
+  });
+});

--- a/dashboard/src/app/api/push/subscribe/route.ts
+++ b/dashboard/src/app/api/push/subscribe/route.ts
@@ -1,8 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
+import { requireSameOrigin } from "@/lib/csrf";
 import { addSubscription } from "@/lib/pushStore";
 import type { PushSubscription } from "web-push";
 
 export async function POST(req: NextRequest) {
+  const guard = requireSameOrigin(req);
+  if (guard) return guard;
+
   let body: unknown;
   try {
     body = await req.json();

--- a/dashboard/src/app/api/push/test/route.ts
+++ b/dashboard/src/app/api/push/test/route.ts
@@ -1,12 +1,15 @@
 import { NextResponse } from "next/server";
 import webpush from "web-push";
 import { getSubscriptions } from "@/lib/pushStore";
+import { requireSameOrigin } from "@/lib/csrf";
 
 const vapidPublicKey = process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY ?? "";
 const vapidPrivateKey = process.env.VAPID_PRIVATE_KEY ?? "";
 const vapidSubject = process.env.VAPID_SUBJECT ?? "mailto:admin@example.com";
 
-export async function POST() {
+export async function POST(req: Request) {
+  const guard = requireSameOrigin(req);
+  if (guard) return guard;
   if (!vapidPublicKey || !vapidPrivateKey) {
     return NextResponse.json({ error: "VAPID keys not configured" }, { status: 503 });
   }

--- a/dashboard/src/app/api/push/unsubscribe/route.ts
+++ b/dashboard/src/app/api/push/unsubscribe/route.ts
@@ -1,7 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
 import { removeSubscription } from "@/lib/pushStore";
+import { requireSameOrigin } from "@/lib/csrf";
 
 export async function POST(req: NextRequest) {
+  const guard = requireSameOrigin(req);
+  if (guard) return guard;
   let body: Record<string, unknown>;
   try {
     body = await req.json();

--- a/dashboard/src/app/marketplace/[...slug]/InstallPanel.tsx
+++ b/dashboard/src/app/marketplace/[...slug]/InstallPanel.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { apiPath } from "@/lib/api";
+import { assertValidInstallSource } from "@/lib/registry";
 
 interface Props {
   install: string;
@@ -55,6 +56,10 @@ export default function InstallPanel({ install, name }: Props) {
     setBusy(true);
     setErr(null);
     try {
+      // Defense in depth: refuse to forward anything that isn't a
+      // github:owner/repo[/path]@ref shape. Tampered registry indexes
+      // could otherwise pass opaque strings (https://, file://, etc).
+      assertValidInstallSource(install);
       const res = await fetch(apiPath("/api/bridge/recipes/install"), {
         method: "POST",
         headers: { "Content-Type": "application/json" },

--- a/dashboard/src/app/marketplace/page.tsx
+++ b/dashboard/src/app/marketplace/page.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 import { useEffect, useState } from "react";
 import { Skeleton, SkeletonText } from "@/components/Skeleton";
 import { apiPath } from "@/lib/api";
-import { type RegistryData, type RegistryRecipe, shortName } from "@/lib/registry";
+import { assertValidInstallSource, type RegistryData, type RegistryRecipe, shortName } from "@/lib/registry";
 
 // ------------------------------------------------------------------ fallback data (shown when bridge offline)
 
@@ -399,6 +399,10 @@ export default function MarketplacePage() {
   }, []);
 
   async function handleInstall(recipe: RegistryRecipe) {
+    // Defense in depth: refuse to forward anything that isn't a github:owner/repo[/path]@ref
+    // shape. The bridge also validates server-side; this blocks the obvious tampered-registry
+    // attack at the dashboard layer before the request leaves the browser.
+    assertValidInstallSource(recipe.install);
     const res = await fetch(apiPath("/api/bridge/recipes/install"), {
       method: "POST",
       headers: { "Content-Type": "application/json" },

--- a/dashboard/src/lib/__tests__/csrf.test.ts
+++ b/dashboard/src/lib/__tests__/csrf.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Unit tests for the requireSameOrigin CSRF guard helper.
+ *
+ * Mirrors the inline check that already lives in the bridge proxy + several
+ * recipe routes. Centralising it here lets us cover the remaining mutation
+ * routes (connector connect/disconnect, connector requests, push subscribe/
+ * unsubscribe/test) without re-implementing the same five-line check six
+ * times.
+ */
+
+import { describe, expect, it } from "vitest";
+import { NextRequest } from "next/server";
+import { requireSameOrigin } from "@/lib/csrf";
+
+function makeReq(secFetchSite: string | null): NextRequest {
+  const headers = new Headers();
+  if (secFetchSite !== null) headers.set("sec-fetch-site", secFetchSite);
+  return new NextRequest("http://localhost:3200/api/test", {
+    method: "POST",
+    headers,
+  });
+}
+
+describe("requireSameOrigin", () => {
+  it("returns null when sec-fetch-site is same-origin", () => {
+    expect(requireSameOrigin(makeReq("same-origin"))).toBeNull();
+  });
+
+  it("returns null when sec-fetch-site is none (address bar / bookmark)", () => {
+    expect(requireSameOrigin(makeReq("none"))).toBeNull();
+  });
+
+  it("returns null when sec-fetch-site header is absent (older browsers)", () => {
+    // Matches the existing bridge proxy behaviour — header missing → allow.
+    // sec-fetch-site is universally supported in modern browsers, but legacy
+    // automation tools may omit it.
+    expect(requireSameOrigin(makeReq(null))).toBeNull();
+  });
+
+  it("returns 403 when sec-fetch-site is cross-site", () => {
+    const res = requireSameOrigin(makeReq("cross-site"));
+    expect(res).not.toBeNull();
+    expect(res?.status).toBe(403);
+  });
+
+  it("returns 403 when sec-fetch-site is same-site (subdomain attacker)", () => {
+    const res = requireSameOrigin(makeReq("same-site"));
+    expect(res).not.toBeNull();
+    expect(res?.status).toBe(403);
+  });
+
+  it("returns JSON error body on rejection", async () => {
+    const res = requireSameOrigin(makeReq("cross-site"));
+    expect(res).not.toBeNull();
+    const body = await res!.json();
+    expect(body).toEqual({ error: "CSRF check failed" });
+  });
+});

--- a/dashboard/src/lib/__tests__/installSourceValidation.test.ts
+++ b/dashboard/src/lib/__tests__/installSourceValidation.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Regression test for Bug 2: marketplace install must validate the install
+ * source string against parseInstallSource BEFORE POSTing to the bridge.
+ *
+ * If a tampered registry index sneaks an opaque or attacker-shaped install
+ * string through (e.g. `https://evil/cmd`, `file:///etc/passwd`, a leading
+ * dash to confuse downstream argv parsing), the dashboard must surface a
+ * user-visible error and refuse to forward to the bridge.
+ *
+ * The dashboard call sites in marketplace/page.tsx and marketplace/[...slug]/
+ * InstallPanel.tsx use `assertValidInstallSource` from registry.ts as the
+ * single source of truth.
+ */
+
+import { describe, expect, it } from "vitest";
+import { assertValidInstallSource, parseInstallSource } from "@/lib/registry";
+
+describe("parseInstallSource (regex shape)", () => {
+  it("accepts canonical github:owner/repo@ref", () => {
+    expect(parseInstallSource("github:patchworkos/recipes@v1")).toEqual({
+      owner: "patchworkos",
+      repo: "recipes",
+      path: "",
+      ref: "v1",
+    });
+  });
+
+  it("accepts github:owner/repo/sub/dir@ref", () => {
+    expect(parseInstallSource("github:patchworkos/recipes/triage@main")).toEqual({
+      owner: "patchworkos",
+      repo: "recipes",
+      path: "triage",
+      ref: "main",
+    });
+  });
+
+  it("rejects http/https URLs", () => {
+    expect(parseInstallSource("https://evil.example.com/recipe")).toBeNull();
+  });
+
+  it("rejects file:// URLs", () => {
+    expect(parseInstallSource("file:///etc/passwd")).toBeNull();
+  });
+
+  it("rejects strings missing the github: scheme", () => {
+    expect(parseInstallSource("patchworkos/recipes@main")).toBeNull();
+  });
+
+  it("rejects empty owner / repo", () => {
+    expect(parseInstallSource("github:/repo@main")).toBeNull();
+    expect(parseInstallSource("github:owner/@main")).toBeNull();
+  });
+});
+
+describe("assertValidInstallSource — defence-in-depth at the call site", () => {
+  it("returns the parsed shape for valid sources", () => {
+    const parsed = assertValidInstallSource("github:patchworkos/recipes@v1");
+    expect(parsed.owner).toBe("patchworkos");
+    expect(parsed.repo).toBe("recipes");
+  });
+
+  it("throws a user-facing Error for opaque sources", () => {
+    expect(() => assertValidInstallSource("https://evil/cmd")).toThrow(
+      /invalid install source/i,
+    );
+  });
+
+  it("throws for empty / whitespace input", () => {
+    expect(() => assertValidInstallSource("")).toThrow();
+    expect(() => assertValidInstallSource("   ")).toThrow();
+  });
+
+  it("throws for non-string input", () => {
+    // The marketplace registry types `install` as string, but a tampered
+    // index can ship anything — the helper must coerce-check defensively.
+    expect(() => assertValidInstallSource(undefined as unknown as string)).toThrow();
+    expect(() => assertValidInstallSource(null as unknown as string)).toThrow();
+    expect(() => assertValidInstallSource(42 as unknown as string)).toThrow();
+  });
+});

--- a/dashboard/src/lib/csrf.ts
+++ b/dashboard/src/lib/csrf.ts
@@ -1,0 +1,34 @@
+/**
+ * Centralised CSRF guard for dashboard mutation routes.
+ *
+ * Mirrors the inline check that previously lived in the bridge proxy and a
+ * handful of recipe routes: rely on the browser-issued `sec-fetch-site`
+ * Fetch Metadata header, accept only `same-origin` / `none` (the latter for
+ * direct address-bar navigation in the dashboard's same-origin XHR flow),
+ * reject anything else with 403.
+ *
+ * `sec-fetch-site` is forgeable from a non-browser client, but it can NOT be
+ * set by JavaScript inside a page — which is exactly the threat model
+ * (cross-origin page submitting a form / fetch with the user's cookies).
+ * For server-to-server callers there is no header at all, which we allow:
+ * those callers either present a Bearer token, hit a separate auth path, or
+ * are blocked by the bridge itself.
+ *
+ * Returns `null` when the request is allowed, or a 403 NextResponse to be
+ * returned directly to the client otherwise.
+ */
+
+import { NextResponse } from "next/server";
+
+export function requireSameOrigin(
+  req: { headers: { get(name: string): string | null } },
+): NextResponse | null {
+  const sfs = req.headers.get("sec-fetch-site");
+  if (sfs && sfs !== "same-origin" && sfs !== "none") {
+    return NextResponse.json(
+      { error: "CSRF check failed" },
+      { status: 403 },
+    );
+  }
+  return null;
+}

--- a/dashboard/src/lib/registry.ts
+++ b/dashboard/src/lib/registry.ts
@@ -60,6 +60,30 @@ export function parseInstallSource(install: string): ParsedInstallSource | null 
   };
 }
 
+/**
+ * Defense-in-depth validator for marketplace install POST sites.
+ *
+ * Throws a user-facing Error when the install string isn't shaped like a
+ * `github:owner/repo[/path]@ref` URL — covers tampered registry indexes,
+ * MITM-flipped responses, and accidental opaque-passthrough at call sites.
+ * The bridge also validates server-side; this is the dashboard layer's
+ * "block the obvious attack before we forward" safety net.
+ */
+export function assertValidInstallSource(install: string): ParsedInstallSource {
+  if (typeof install !== "string" || install.trim().length === 0) {
+    throw new Error(
+      "Invalid install source: expected non-empty string in `github:owner/repo[/path]@ref` form",
+    );
+  }
+  const parsed = parseInstallSource(install);
+  if (!parsed || !parsed.owner || !parsed.repo) {
+    throw new Error(
+      "Invalid install source: must match `github:owner/repo[/path]@ref` (refusing to forward to bridge)",
+    );
+  }
+  return parsed;
+}
+
 export function rawUrlFor(src: ParsedInstallSource, file: string): string {
   const parts = [src.owner, src.repo, src.ref, src.path, file].filter(Boolean);
   return `${RAW_BASE}/${parts.join("/")}`;


### PR DESCRIPTION
## Summary

Two dashboard fixes from the dogfood sweep:

- **CSRF gap (medium)** — the bridge proxy enforces \`sec-fetch-site\` but the connector + push mutation routes did not. New \`dashboard/src/lib/csrf.ts\` centralises the guard; applied to 6 routes (connect / disconnect / connector-requests / push subscribe-unsubscribe-test).
- **Marketplace install shape (medium)** — \`recipe.install\` was POSTed opaquely to the bridge. New \`assertValidInstallSource\` helper rejects anything that isn't \`github:owner/repo[/path]@ref\` before forwarding. Both call sites updated.

## Test plan

- [x] 19/19 tests in scope (csrf + installSourceValidation + push subscribe)
- [x] Manual: review each modified route imports + applies guard at top of POST/DELETE handler

## NOT in this PR

The inbox hand-rolled markdown sanitizer (P2, low) — defers to follow-up. Lib swap (\`react-markdown\` + \`rehype-sanitize\`) is non-trivial; current sanitizer is functionally correct, just brittle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)