### PR TITLE
feat(tools): getDocumentSymbols filters + categories typo + getSecurityAdvisories cross-package wording

### DIFF
--- a/src/tools/getDocumentSymbols.ts
+++ b/src/tools/getDocumentSymbols.ts
@@ -40,6 +40,28 @@ export function createGetDocumentSymbolsTool(
             type: "string",
             description: "Workspace or absolute path to the file",
           },
+          kind: {
+            description:
+              "Filter to one or more symbol kinds (e.g. ['Class','Function','Method','Interface']). Case-insensitive. Cuts variable noise on large bundled files.",
+            oneOf: [
+              { type: "string" },
+              { type: "array", items: { type: "string" } },
+            ],
+          },
+          maxDepth: {
+            type: "integer",
+            minimum: 0,
+            maximum: 10,
+            description:
+              "Max nesting depth to include (0=top-level only, 1=top + immediate children, …). Default: no depth filter. LSP returns a flattened list keyed by 'parent' name; depth is computed by walking the parent chain.",
+          },
+          topN: {
+            type: "integer",
+            minimum: 1,
+            maximum: 5000,
+            description:
+              "Cap returned symbols. Default 500. Combined with kind/maxDepth filters which apply first.",
+          },
         },
         required: ["filePath"],
         additionalProperties: false as const,
@@ -75,6 +97,28 @@ export function createGetDocumentSymbolsTool(
       const rawPath = requireString(args, "filePath");
       const filePath = resolveFilePath(rawPath, workspace);
 
+      const kindArg = args.kind;
+      const kindFilter: Set<string> | null = (() => {
+        if (typeof kindArg === "string")
+          return new Set([kindArg.toLowerCase()]);
+        if (Array.isArray(kindArg)) {
+          return new Set(
+            kindArg
+              .filter((k): k is string => typeof k === "string")
+              .map((k) => k.toLowerCase()),
+          );
+        }
+        return null;
+      })();
+      const maxDepth =
+        typeof args.maxDepth === "number" && Number.isFinite(args.maxDepth)
+          ? Math.max(0, Math.floor(args.maxDepth))
+          : null;
+      const topN =
+        typeof args.topN === "number" && Number.isFinite(args.topN)
+          ? Math.max(1, Math.floor(args.topN))
+          : 500;
+
       // Extension path: full LSP document symbols
       if (extensionClient?.isConnected()) {
         try {
@@ -84,19 +128,55 @@ export function createGetDocumentSymbolsTool(
           );
           if (result !== null && typeof result === "object") {
             const r = result as Record<string, unknown>;
-            // Cap symbols array at 500 to avoid bloating context on large bundled files.
-            const DOCUMENT_SYMBOLS_MAX = 500;
-            if (
-              Array.isArray(r.symbols) &&
-              r.symbols.length > DOCUMENT_SYMBOLS_MAX
-            ) {
-              const full = r.symbols;
+            if (Array.isArray(r.symbols)) {
+              type Sym = {
+                name?: string;
+                kind?: string;
+                parent?: string | null;
+              };
+              const all = r.symbols as Sym[];
+              const totalCount = all.length;
+
+              // Build parent-depth map by walking the parent chain. LSP
+              // returns a flattened list with `parent: <name|null>`; depth
+              // is the chain length to a null parent.
+              const byName = new Map<string, Sym>();
+              for (const s of all) {
+                if (typeof s.name === "string") byName.set(s.name, s);
+              }
+              const depthOf = (s: Sym): number => {
+                let d = 0;
+                let cur: Sym | undefined = s;
+                while (cur && typeof cur.parent === "string") {
+                  d += 1;
+                  if (d > 32) break; // cycle guard
+                  cur = byName.get(cur.parent);
+                }
+                return d;
+              };
+
+              const filtered = all.filter((s) => {
+                if (
+                  kindFilter &&
+                  typeof s.kind === "string" &&
+                  !kindFilter.has(s.kind.toLowerCase())
+                ) {
+                  return false;
+                }
+                if (maxDepth !== null && depthOf(s) > maxDepth) return false;
+                return true;
+              });
+
+              const truncated = filtered.length > topN;
+              const symbols = truncated ? filtered.slice(0, topN) : filtered;
+
               return successStructured({
                 ...r,
-                symbols: full.slice(0, DOCUMENT_SYMBOLS_MAX),
+                symbols,
                 source: "lsp",
-                truncated: true,
-                totalCount: full.length,
+                ...(truncated || filtered.length !== totalCount
+                  ? { truncated: true, totalCount }
+                  : {}),
               });
             }
             return successStructured({ ...r, source: "lsp" });

--- a/src/tools/getSecurityAdvisories.ts
+++ b/src/tools/getSecurityAdvisories.ts
@@ -71,7 +71,15 @@ function parseNpmAuditJson(raw: string, packageManager: string): AuditResult {
       typeof viaEntry === "object" && viaEntry.url ? viaEntry.url : undefined;
     let fix: string | undefined;
     if (typeof vuln.fixAvailable === "object" && vuln.fixAvailable) {
-      fix = `upgrade to ${vuln.fixAvailable.name}@${vuln.fixAvailable.version}`;
+      // npm reports a transitive fix on the dependent: e.g. uuid (a child
+      // of node-cron) gets `fixAvailable.name = "node-cron"`. The literal
+      // "upgrade to X@Y" message is then misleading because the affected
+      // package and the upgrade target differ. Surface that explicitly.
+      if (vuln.fixAvailable.name !== pkg) {
+        fix = `upgrade ${vuln.fixAvailable.name}@${vuln.fixAvailable.version} (parent of ${pkg})`;
+      } else {
+        fix = `upgrade to ${vuln.fixAvailable.name}@${vuln.fixAvailable.version}`;
+      }
     } else if (vuln.fixAvailable === true) {
       fix = `run ${packageManager} audit fix`;
     }

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -977,7 +977,8 @@ export const TOOL_CATEGORIES: Record<string, string[]> = {
   generateAPIDocumentation: ["analysis"],
   findRelatedTests: ["analysis"],
   getDependencyTree: ["analysis"],
-  getGitHotspot: ["analysis", "git"],
+  // (getGitHotspots is canonically listed above with categories ["git","analysis"];
+  // a stray "getGitHotspot" typo was here historically and never matched.)
   screenshotAndAnnotate: ["analysis", "editor"],
   // GitHub
   githubCreatePR: ["github"],


### PR DESCRIPTION
## Summary

Three small bridge-tool enhancements from the dogfood sweep:

- **\`getDocumentSymbols\` input filters** — adds \`kind?\`, \`maxDepth?\`, \`topN?\` to make the tool usable on large files (was tripping result-size limit on bridge.ts at 86k chars). Bridge-side filtering, non-breaking.
- **TOOL_CATEGORIES typo fix** — removed dead \`getGitHotspot\` entry (canonical \`getGitHotspots\` already at line 917).
- **getSecurityAdvisories cross-package wording** — when npm returns a transitive fix on a dependent (e.g. \`uuid\` → \`fixAvailable.name: "node-cron"\`), now formatted as \`"upgrade node-cron@4.2.1 (parent of uuid)"\`.

## Test plan

- [x] 4567/4567 vitest pass
- [x] \`npx tsc --noEmit\` clean
- [x] biome clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)