### PR TITLE
fix(connectors): atomic tokenStorage write + bounded OAuth state store

### DIFF
--- a/src/connectors/__tests__/github.test.ts
+++ b/src/connectors/__tests__/github.test.ts
@@ -7,6 +7,8 @@ vi.mock("node:fs", async (importOriginal) => {
     existsSync: vi.fn(),
     readFileSync: vi.fn(),
     writeFileSync: vi.fn(),
+    renameSync: vi.fn(),
+    chmodSync: vi.fn(),
     unlinkSync: vi.fn(),
     mkdirSync: vi.fn(),
   };

--- a/src/connectors/__tests__/gmailRefresh.test.ts
+++ b/src/connectors/__tests__/gmailRefresh.test.ts
@@ -15,6 +15,7 @@ vi.mock("node:fs", async (importOriginal) => {
     existsSync: vi.fn().mockReturnValue(false),
     readFileSync: vi.fn().mockReturnValue("{}"),
     writeFileSync: vi.fn(),
+    renameSync: vi.fn(),
     chmodSync: vi.fn(),
     unlinkSync: vi.fn(),
     mkdirSync: vi.fn(),

--- a/src/connectors/__tests__/googleCalendar.test.ts
+++ b/src/connectors/__tests__/googleCalendar.test.ts
@@ -9,6 +9,7 @@ vi.mock("node:fs", async (importOriginal) => {
     existsSync: vi.fn().mockReturnValue(false),
     readFileSync: vi.fn().mockReturnValue("{}"),
     writeFileSync: vi.fn(),
+    renameSync: vi.fn(),
     chmodSync: vi.fn(),
     unlinkSync: vi.fn(),
     mkdirSync: vi.fn(),

--- a/src/connectors/__tests__/googleDrive.test.ts
+++ b/src/connectors/__tests__/googleDrive.test.ts
@@ -9,6 +9,7 @@ vi.mock("node:fs", async (importOriginal) => {
     existsSync: vi.fn().mockReturnValue(false),
     readFileSync: vi.fn().mockReturnValue("{}"),
     writeFileSync: vi.fn(),
+    renameSync: vi.fn(),
     chmodSync: vi.fn(),
     unlinkSync: vi.fn(),
     mkdirSync: vi.fn(),

--- a/src/connectors/__tests__/linear.test.ts
+++ b/src/connectors/__tests__/linear.test.ts
@@ -7,6 +7,8 @@ vi.mock("node:fs", async (importOriginal) => {
     existsSync: vi.fn(),
     readFileSync: vi.fn(),
     writeFileSync: vi.fn(),
+    renameSync: vi.fn(),
+    chmodSync: vi.fn(),
     unlinkSync: vi.fn(),
     mkdirSync: vi.fn(),
   };

--- a/src/connectors/__tests__/sentry.test.ts
+++ b/src/connectors/__tests__/sentry.test.ts
@@ -7,6 +7,8 @@ vi.mock("node:fs", async (importOriginal) => {
     existsSync: vi.fn().mockReturnValue(false),
     readFileSync: vi.fn().mockReturnValue("{}"),
     writeFileSync: vi.fn(),
+    renameSync: vi.fn(),
+    chmodSync: vi.fn(),
     unlinkSync: vi.fn(),
     mkdirSync: vi.fn(),
   };

--- a/src/connectors/asana.ts
+++ b/src/connectors/asana.ts
@@ -180,20 +180,23 @@ export function isConnected(): boolean {
 // In-memory map keyed by hex random — short-lived (5 min). Mirrors discord's
 // approach (Set + setTimeout).
 
-const pendingStates = new Set<string>();
+import { createOAuthStateStore } from "./oauthStateStore.js";
+
 const STATE_TTL_MS = 5 * 60 * 1000;
+const pendingStates = createOAuthStateStore({ ttlMs: STATE_TTL_MS });
 
 function generateState(): string {
   const state = crypto.randomBytes(32).toString("hex");
-  pendingStates.add(state);
-  setTimeout(() => pendingStates.delete(state), STATE_TTL_MS);
+  if (!pendingStates.add(state)) {
+    throw new Error(
+      "OAuth state store full — too many concurrent authorize requests",
+    );
+  }
   return state;
 }
 
 function consumeState(state: string): boolean {
-  if (!pendingStates.has(state)) return false;
-  pendingStates.delete(state);
-  return true;
+  return pendingStates.consume(state);
 }
 
 // ── Connector class ──────────────────────────────────────────────────────────

--- a/src/connectors/discord.ts
+++ b/src/connectors/discord.ts
@@ -153,20 +153,23 @@ export function isConnected(): boolean {
 // approach (Set + setTimeout) rather than slack's on-disk file because we
 // don't need cross-process resumption for an OAuth round-trip.
 
-const pendingStates = new Set<string>();
+import { createOAuthStateStore } from "./oauthStateStore.js";
+
 const STATE_TTL_MS = 5 * 60 * 1000;
+const pendingStates = createOAuthStateStore({ ttlMs: STATE_TTL_MS });
 
 function generateState(): string {
   const state = crypto.randomBytes(32).toString("hex");
-  pendingStates.add(state);
-  setTimeout(() => pendingStates.delete(state), STATE_TTL_MS);
+  if (!pendingStates.add(state)) {
+    throw new Error(
+      "OAuth state store full — too many concurrent authorize requests",
+    );
+  }
   return state;
 }
 
 function consumeState(state: string): boolean {
-  if (!pendingStates.has(state)) return false;
-  pendingStates.delete(state);
-  return true;
+  return pendingStates.consume(state);
 }
 
 // ── Connector class ──────────────────────────────────────────────────────────

--- a/src/connectors/gmail.ts
+++ b/src/connectors/gmail.ts
@@ -247,12 +247,17 @@ async function fetchUserEmail(accessToken: string): Promise<string> {
 
 // ── State map (in-memory CSRF protection) ────────────────────────────────────
 
-const pendingStates = new Set<string>();
+import { createOAuthStateStore } from "./oauthStateStore.js";
+
+const pendingStates = createOAuthStateStore();
 
 function generateState(): string {
   const state = crypto.randomBytes(32).toString("hex");
-  pendingStates.add(state);
-  setTimeout(() => pendingStates.delete(state), 10 * 60 * 1000); // 10 min TTL
+  if (!pendingStates.add(state)) {
+    throw new Error(
+      "OAuth state store full — too many concurrent authorize requests",
+    );
+  }
   return state;
 }
 
@@ -410,14 +415,13 @@ export async function handleGmailCallback(
       ),
     };
   }
-  if (!code || !state || !pendingStates.has(state)) {
+  if (!code || !state || !pendingStates.consume(state)) {
     return {
       status: 400,
       contentType: "text/html",
       body: callbackHtml("Invalid request", "Missing or expired state.", false),
     };
   }
-  pendingStates.delete(state);
   try {
     const tokens = await exchangeCode(code);
     saveTokens(tokens);

--- a/src/connectors/googleCalendar.ts
+++ b/src/connectors/googleCalendar.ts
@@ -281,12 +281,17 @@ async function revokeToken(token: string): Promise<void> {
 
 // ── State map (in-memory CSRF protection) ────────────────────────────────────
 
-const pendingStates = new Set<string>();
+import { createOAuthStateStore } from "./oauthStateStore.js";
+
+const pendingStates = createOAuthStateStore();
 
 function generateState(): string {
   const state = crypto.randomBytes(32).toString("hex");
-  pendingStates.add(state);
-  setTimeout(() => pendingStates.delete(state), 10 * 60 * 1000);
+  if (!pendingStates.add(state)) {
+    throw new Error(
+      "OAuth state store full — too many concurrent authorize requests",
+    );
+  }
   return state;
 }
 
@@ -416,14 +421,13 @@ export async function handleCalendarCallback(
       body: JSON.stringify({ ok: false, error }),
     };
   }
-  if (!code || !state || !pendingStates.has(state)) {
+  if (!code || !state || !pendingStates.consume(state)) {
     return {
       status: 400,
       contentType: "application/json",
       body: JSON.stringify({ ok: false, error: "Invalid OAuth state" }),
     };
   }
-  pendingStates.delete(state);
   try {
     const oauthTokens = await exchangeCode(code);
     // Default to "primary" calendar; user can update later

--- a/src/connectors/googleDrive.ts
+++ b/src/connectors/googleDrive.ts
@@ -293,12 +293,17 @@ export async function fetchDocName(
   }
 }
 
-const pendingStates = new Set<string>();
+import { createOAuthStateStore } from "./oauthStateStore.js";
+
+const pendingStates = createOAuthStateStore();
 
 function generateState(): string {
   const state = crypto.randomBytes(32).toString("hex");
-  pendingStates.add(state);
-  setTimeout(() => pendingStates.delete(state), 10 * 60 * 1000);
+  if (!pendingStates.add(state)) {
+    throw new Error(
+      "OAuth state store full — too many concurrent authorize requests",
+    );
+  }
   return state;
 }
 
@@ -330,14 +335,13 @@ export async function handleDriveCallback(
       body: JSON.stringify({ ok: false, error }),
     };
   }
-  if (!code || !state || !pendingStates.has(state)) {
+  if (!code || !state || !pendingStates.consume(state)) {
     return {
       status: 400,
       contentType: "application/json",
       body: JSON.stringify({ ok: false, error: "Invalid OAuth state" }),
     };
   }
-  pendingStates.delete(state);
   try {
     const oauthTokens = await exchangeCode(code);
     const tokens: DriveTokens = {

--- a/src/connectors/oauthStateStore.ts
+++ b/src/connectors/oauthStateStore.ts
@@ -1,0 +1,66 @@
+/**
+ * Shared OAuth `state` parameter store for connector authorize→callback flows.
+ *
+ * Each connector previously kept its own module-scope `Set<string>` keyed by
+ * a `setTimeout` cleanup. That works correctness-wise but is unbounded — a
+ * loop of `/authorize` calls (10k requests in 10 min) would accumulate 10k
+ * states + 10k pending timers, ~640 KB of heap that disappears 10 min later.
+ * On a busy multi-tenant relay this becomes a memory amplification vector
+ * any unauthenticated caller can drive.
+ *
+ * Defenses:
+ *   - Hard cap (default 1000 entries) — when full, new `add()` calls return
+ *     false and the caller surfaces an HTTP 429 / generic error.
+ *   - TTL eviction at access time (consume() or add()) — no per-state timer,
+ *     so 10k states cost 10k Map slots + 10k longs, nothing more.
+ *   - `consume()` is single-use; second call with the same state returns false.
+ */
+
+export interface OAuthStateStore {
+  /** Returns false if the cap is hit. */
+  add(state: string): boolean;
+  /** Consume on callback. Returns true if the state was valid and unconsumed. */
+  consume(state: string): boolean;
+  /** For tests. */
+  size(): number;
+}
+
+interface Options {
+  ttlMs?: number;
+  maxEntries?: number;
+}
+
+const DEFAULT_TTL_MS = 10 * 60_000;
+const DEFAULT_MAX_ENTRIES = 1000;
+
+export function createOAuthStateStore(opts: Options = {}): OAuthStateStore {
+  const ttlMs = opts.ttlMs ?? DEFAULT_TTL_MS;
+  const maxEntries = opts.maxEntries ?? DEFAULT_MAX_ENTRIES;
+  const states = new Map<string, number>(); // state → expiresAt ms
+
+  function pruneExpired(now: number): void {
+    for (const [s, expiry] of states) {
+      if (expiry < now) states.delete(s);
+    }
+  }
+
+  return {
+    add(state: string): boolean {
+      const now = Date.now();
+      pruneExpired(now);
+      if (states.size >= maxEntries) return false;
+      states.set(state, now + ttlMs);
+      return true;
+    },
+    consume(state: string): boolean {
+      const now = Date.now();
+      const expiry = states.get(state);
+      if (expiry === undefined) return false;
+      states.delete(state);
+      return expiry >= now;
+    },
+    size(): number {
+      return states.size;
+    },
+  };
+}

--- a/src/connectors/tokenStorage.ts
+++ b/src/connectors/tokenStorage.ts
@@ -12,10 +12,12 @@
 import { spawnSync } from "node:child_process";
 import crypto from "node:crypto";
 import {
+  chmodSync,
   existsSync,
   mkdirSync,
   readdirSync,
   readFileSync,
+  renameSync,
   unlinkSync,
   writeFileSync,
 } from "node:fs";
@@ -304,7 +306,31 @@ function setEncryptedFileSync(key: string, value: string): void {
   }
 
   const encrypted = encrypt(value);
-  writeFileSync(join(dir, `${key}.enc`), encrypted, { mode: 0o600 });
+  const finalPath = join(dir, `${key}.enc`);
+
+  // Atomic write: tmp file + rename. Without this a concurrent reader can
+  // observe torn ciphertext mid-write → decrypt() returns null → caller
+  // treats the connector as disconnected and triggers a full re-auth.
+  // The macOS keychain backend is already atomic at OS level; this guard
+  // is for the file backend.
+  const tmpPath = `${finalPath}.tmp.${process.pid}.${crypto
+    .randomBytes(8)
+    .toString("hex")}`;
+  try {
+    writeFileSync(tmpPath, encrypted, { mode: 0o600 });
+    // Belt-and-braces: writeFileSync honours mode on file create, but if
+    // the file pre-existed with a permissive mode we'd inherit it. Force
+    // 0o600 before rename takes the inode.
+    chmodSync(tmpPath, 0o600);
+    renameSync(tmpPath, finalPath);
+  } catch (err) {
+    try {
+      unlinkSync(tmpPath);
+    } catch {
+      // tmp may not exist — best-effort cleanup
+    }
+    throw err;
+  }
 }
 
 function getEncryptedFileSync(key: string): string | null {


### PR DESCRIPTION
## Summary

Two connector hardenings from the dogfood sweep:

- **Atomic tokenStorage write** — \`setEncryptedFileSync\` now uses tmp+\`renameSync\` instead of in-place \`writeFileSync\`. Closes the torn-ciphertext window where a concurrent reader could see partial bytes, fail to decrypt, treat connector as disconnected, and trigger a full re-auth.
- **Bounded OAuth state store** — extracted shared \`createOAuthStateStore\` utility. Per-connector module-scope \`Set<string>\` + \`setTimeout\` cleanup was unbounded; new store has hard cap (1000 entries), TTL eviction at access time, single-use \`consume()\`. Migrated 5 connectors (gmail, asana, discord, googleCalendar, googleDrive).

## Test plan

- [x] 354/354 connector tests pass
- [x] \`npx tsc --noEmit\` clean
- [x] biome clean
- Test mocks updated to include \`renameSync\` + \`chmodSync\` (new atomic-write surface)

## NOT in this PR

Slack 401 recovery (P2) — Slack uses bot tokens that don't normally expire; gap is graceful handling on revocation. Defer to follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)