### PR TITLE
fix(slack,push-relay): structured Slack auth-expired error + unauth'd push-relay /health

### DIFF
--- a/services/push-relay/src/index.ts
+++ b/services/push-relay/src/index.ts
@@ -116,10 +116,22 @@ async function main() {
   const tokenStore = new EnvTokenStore(authTokens);
   const app = express();
   app.use(express.json());
+
+  // /health is mounted BEFORE the bearer middleware so uptime checkers
+  // (Cloud Run, k8s liveness probes, ELB target groups) can hit it without
+  // a token. The body is intentionally minimal — just `{ok:true}` — to
+  // avoid leaking deployment shape (which providers are configured) to
+  // unauthenticated callers.
+  app.get("/health", (_req, res) => {
+    res.json({ ok: true });
+  });
+
   app.use(bearerAuthMiddleware(tokenStore));
   app.use(buildRouter(registry, { fcm, apns, apnsTopic }));
 
-  app.get("/health", (_req, res) => {
+  // Authenticated extended-status endpoint for the dashboard / settings page
+  // when it wants to know which adapters are live.
+  app.get("/status", (_req, res) => {
     res.json({ ok: true, fcm: !!fcm, apns: !!apns });
   });
 

--- a/src/connectors/slack.ts
+++ b/src/connectors/slack.ts
@@ -165,6 +165,49 @@ function consumeState(): string | null {
 
 // ── API helper ────────────────────────────────────────────────────────────────
 
+/**
+ * Thrown when Slack signals the bot token is no longer usable. Slack bot
+ * tokens don't normally expire, but they can be revoked from the workspace
+ * admin panel or by an org-wide app uninstall. Without a structured signal,
+ * a revoked-token error from `slackGet`/`slackPost` would surface as a
+ * generic `Slack API X error: invalid_auth` and the dashboard would have
+ * no path to prompt the user to reconnect.
+ *
+ * Mirrors `BaseConnector`'s `auth_expired` ConnectorError code so callers
+ * can branch uniformly on either path.
+ */
+export class SlackAuthExpiredError extends Error {
+  readonly code = "auth_expired" as const;
+  constructor(slackError: string, method: string) {
+    super(
+      `Slack ${method}: ${slackError} — token revoked or workspace uninstalled. Reconnect via /connections/slack/auth.`,
+    );
+    this.name = "SlackAuthExpiredError";
+  }
+}
+
+// Slack error codes that mean "the token won't work — re-auth needed". The
+// remaining `!json.ok` codes are recoverable / parameter errors and shouldn't
+// trigger a reconnect flow.
+//
+// References:
+//   https://api.slack.com/methods/auth.test#errors
+//   https://api.slack.com/authentication/token-types#bot
+const SLACK_AUTH_DEAD_ERRORS = new Set([
+  "invalid_auth",
+  "not_authed",
+  "token_revoked",
+  "token_expired",
+  "account_inactive",
+  "no_permission",
+]);
+
+function isAuthDeadError(slackError: string | undefined): boolean {
+  return (
+    typeof slackError === "string" && SLACK_AUTH_DEAD_ERRORS.has(slackError)
+  );
+}
+
 async function slackGet(
   method: string,
   params: Record<string, string>,
@@ -177,10 +220,16 @@ async function slackGet(
     headers: { Authorization: `Bearer ${token}`, Accept: "application/json" },
     signal,
   });
+  if (res.status === 401) {
+    throw new SlackAuthExpiredError(`HTTP 401`, method);
+  }
   if (!res.ok) throw new Error(`Slack API ${method} HTTP ${res.status}`);
   const json = (await res.json()) as Record<string, unknown>;
-  if (!json.ok)
-    throw new Error(`Slack API ${method} error: ${json.error ?? "unknown"}`);
+  if (!json.ok) {
+    const err = typeof json.error === "string" ? json.error : "unknown";
+    if (isAuthDeadError(err)) throw new SlackAuthExpiredError(err, method);
+    throw new Error(`Slack API ${method} error: ${err}`);
+  }
   return json;
 }
 
@@ -200,10 +249,16 @@ async function slackPost(
     body: JSON.stringify(body),
     signal,
   });
+  if (res.status === 401) {
+    throw new SlackAuthExpiredError(`HTTP 401`, method);
+  }
   if (!res.ok) throw new Error(`Slack API ${method} HTTP ${res.status}`);
   const json = (await res.json()) as Record<string, unknown>;
-  if (!json.ok)
-    throw new Error(`Slack API ${method} error: ${json.error ?? "unknown"}`);
+  if (!json.ok) {
+    const err = typeof json.error === "string" ? json.error : "unknown";
+    if (isAuthDeadError(err)) throw new SlackAuthExpiredError(err, method);
+    throw new Error(`Slack API ${method} error: ${err}`);
+  }
   return json;
 }
 


### PR DESCRIPTION
## Summary

Two small follow-ons from the dogfood sweep:

- **Slack auth recovery (P2)** — \`slackGet\`/\`slackPost\` now route revoked-token errors (\`invalid_auth\`, \`token_revoked\`, \`account_inactive\`, etc.) through a typed \`SlackAuthExpiredError\` with code \`"auth_expired"\` matching BaseConnector's contract. Also catches HTTP 401 explicitly. Recoverable errors stay as generic \`Error\`.
- **push-relay /health auth (P2)** — \`/health\` was mounted AFTER bearerAuthMiddleware, so unauth'd uptime checkers (k8s liveness probes, ELB target groups, Cloud Run health checks) couldn't hit it. Moved /health BEFORE auth middleware. Body trimmed to \`{ok:true}\` to avoid leaking deployment shape (FCM/APNS configured?). Added authenticated \`/status\` for the dashboard's settings card.

## Test plan

- [x] push-relay 19/19 tests pass
- [x] bridge connector 354/354 tests pass
- [x] \`npx tsc --noEmit\` clean
- [x] biome clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)