### PR TITLE
fix(intellij): dynamic plugin version + signatureHelp empty-list shape + CI parity ratchet

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,8 @@ jobs:
         run: node scripts/audit-lsp-tools.mjs
       - name: Audit shape safety (proxy<T> usage)
         run: node scripts/audit-shape-safety.mjs
+      - name: Audit IntelliJ ↔ VSCode wire-method parity
+        run: node scripts/audit-intellij-parity.mjs
 
   plugin-validate:
     name: Validate plugin manifest

--- a/intellij-plugin/src/main/kotlin/com/patchwork/bridge/BridgeService.kt
+++ b/intellij-plugin/src/main/kotlin/com/patchwork/bridge/BridgeService.kt
@@ -2,9 +2,11 @@ package com.patchwork.bridge
 
 import com.google.gson.Gson
 import com.google.gson.JsonObject
+import com.intellij.ide.plugins.PluginManagerCore
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.extensions.PluginId
 import com.intellij.openapi.project.Project
 import org.java_websocket.client.WebSocketClient
 import org.java_websocket.handshake.ServerHandshake
@@ -24,8 +26,29 @@ class BridgeService {
 
     companion object {
         private val LOG = Logger.getInstance(BridgeService::class.java)
-        const val PLUGIN_VERSION = "1.0.0"
+
+        // Wire-protocol version. Matches vscode-extension/src/constants.ts and
+        // the bridge's BRIDGE_PROTOCOL_VERSION. Bump only on breaking-handshake
+        // changes — see ADR-0001.
         const val EXTENSION_PROTOCOL_VERSION = "1.1.0"
+
+        /**
+         * Plugin package version as seen by the JetBrains Marketplace.
+         *
+         * Read at runtime from the installed plugin descriptor so it stays in
+         * lock-step with `intellij-plugin/gradle.properties`. Hardcoding here
+         * (the previous behavior) drifted: 1.0.1 shipped to the Marketplace
+         * while this constant still said "1.0.0", and the bridge's
+         * `extension/hello` digests + logs reflected the stale value.
+         *
+         * Falls back to "0.0.0-dev" if the plugin descriptor isn't available
+         * (e.g. running unit tests outside the IntelliJ runtime).
+         */
+        @JvmStatic
+        val PLUGIN_VERSION: String by lazy {
+            val pluginId = PluginId.getId("com.patchwork.bridge")
+            PluginManagerCore.getPlugin(pluginId)?.version ?: "0.0.0-dev"
+        }
 
         // Auth header name — confirmed from vscode-extension/src/connection.ts line 320
         private const val AUTH_HEADER = "x-claude-ide-extension"

--- a/intellij-plugin/src/main/kotlin/com/patchwork/bridge/handlers/LspHandlers.kt
+++ b/intellij-plugin/src/main/kotlin/com/patchwork/bridge/handlers/LspHandlers.kt
@@ -747,7 +747,20 @@ class FormatRangeHandler : BridgeHandler {
 // ---------------------------------------------------------------------------
 
 class SignatureHelpHandler : BridgeHandler {
-    override fun handle(params: JsonObject?, project: Project?): JsonElement = JsonNull.INSTANCE
+    /**
+     * Bridge expects `{signatures, activeSignature, activeParameter}`. Returning
+     * JsonNull made callers unable to distinguish "no signature here" from
+     * "not implemented" — the wrapped tool would surface the result as null
+     * and downstream `tryRequest` / `validatedRequest` couldn't tell whether
+     * to fall back. Emit an empty `{signatures:[]}` shape instead, matching
+     * the convention used by `getCodeActions` (line 700) and other stubs.
+     */
+    override fun handle(params: JsonObject?, project: Project?): JsonElement =
+        JsonObject().apply {
+            add("signatures", JsonArray())
+            addProperty("activeSignature", -1)
+            addProperty("activeParameter", -1)
+        }
 }
 
 // ---------------------------------------------------------------------------

--- a/scripts/audit-intellij-parity.mjs
+++ b/scripts/audit-intellij-parity.mjs
@@ -1,0 +1,134 @@
+#!/usr/bin/env node
+/**
+ * IntelliJ ↔ VSCode wire-method parity ratchet.
+ *
+ * Enumerates the wire methods registered by both extensions and fails CI if
+ * the IntelliJ plugin is missing a method the VSCode extension knows about.
+ * Stub handlers are fine — they satisfy the wire contract, they just signal
+ * "not implemented in this IDE." Missing entirely means a bridge-side tool
+ * that calls this method will silently 404 on JetBrains hosts.
+ *
+ * Method discovery:
+ *   VSCode side — `vscode-extension/src/handlers/index.ts` exports a
+ *     `handlers: Record<string, …>` map; the keys are the wire methods.
+ *   IntelliJ side — `intellij-plugin/src/main/kotlin/com/patchwork/bridge/BridgeService.kt`
+ *     declares each method via `register("methodName", HandlerClass())`.
+ *
+ * Both are parsed with cheap regexes (no TS/Kotlin compiler). The discovery
+ * regexes are anchored on the patterns already used in those files; if the
+ * patterns change, this script needs to be updated alongside.
+ */
+
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(__dirname, "..");
+
+const VSCODE_HANDLERS = join(
+  repoRoot,
+  "vscode-extension",
+  "src",
+  "handlers",
+  "index.ts",
+);
+const IJ_BRIDGE_SERVICE = join(
+  repoRoot,
+  "intellij-plugin",
+  "src",
+  "main",
+  "kotlin",
+  "com",
+  "patchwork",
+  "bridge",
+  "BridgeService.kt",
+);
+
+function readSrc(path) {
+  try {
+    return readFileSync(path, "utf8");
+  } catch (err) {
+    console.error(`audit-intellij-parity: cannot read ${path}: ${err.message}`);
+    process.exit(2);
+  }
+}
+
+function extractVsCodeMethods(src) {
+  // Wire methods are namespaced (`extension/getDiagnostics`), so they appear
+  // as quoted keys in handler maps. Scan for any `"extension/<name>":` shape
+  // anywhere in the file — that pattern is unambiguous and matches every
+  // current handler map (`baseHandlers`, factory return value, etc.).
+  const methods = new Set();
+  const re = /"(extension\/[a-zA-Z][a-zA-Z0-9_]*)"\s*:/g;
+  let m;
+  while ((m = re.exec(src)) !== null) {
+    methods.add(m[1]);
+  }
+  if (methods.size === 0) {
+    console.error(
+      "audit-intellij-parity: could not extract any wire methods from vscode-extension/src/handlers/index.ts — regex out of date?",
+    );
+    process.exit(2);
+  }
+  return methods;
+}
+
+function extractIjMethods(src) {
+  // IJ registers wire methods two ways:
+  //   1. Direct: `handlerRegistry.register("extension/foo", FooHandler())`
+  //   2. Loop:   `val stubs = listOf("extension/a", "extension/b", ...);
+  //                for (m in stubs) handlerRegistry.register(m, stub)`
+  // We grab any quoted "extension/..." literal in the file. False positives
+  // are unlikely — wire-method strings don't appear in unrelated contexts
+  // in BridgeService.kt — and the cost of an extra match is just an extra
+  // entry in the IJ side of the diff (which can't fail CI).
+  const methods = new Set();
+  const re = /"(extension\/[a-zA-Z][a-zA-Z0-9_/]*)"/g;
+  let m;
+  while ((m = re.exec(src)) !== null) {
+    methods.add(m[1]);
+  }
+  return methods;
+}
+
+const vscodeSrc = readSrc(VSCODE_HANDLERS);
+const ijSrc = readSrc(IJ_BRIDGE_SERVICE);
+
+const vscodeMethods = extractVsCodeMethods(vscodeSrc);
+const ijMethods = extractIjMethods(ijSrc);
+
+const missingInIj = [...vscodeMethods].filter((m) => !ijMethods.has(m)).sort();
+const extraInIj = [...ijMethods].filter((m) => !vscodeMethods.has(m)).sort();
+
+console.log(`VSCode wire methods : ${vscodeMethods.size}`);
+console.log(`IntelliJ wire methods: ${ijMethods.size}`);
+
+if (missingInIj.length > 0) {
+  console.error(
+    `\nFAIL: ${missingInIj.length} VSCode wire methods missing in IntelliJ plugin:`,
+  );
+  for (const m of missingInIj) console.error(`  - ${m}`);
+  console.error(
+    "\nFix: add a handler (real or stub returning the documented empty shape) in",
+  );
+  console.error(
+    "  intellij-plugin/src/main/kotlin/com/patchwork/bridge/BridgeService.kt registerHandlers().",
+  );
+  console.error(
+    "  Stub handlers are acceptable — they make the wire contract explicit.\n",
+  );
+  process.exit(1);
+}
+
+if (extraInIj.length > 0) {
+  console.warn(
+    `\nWARN: ${extraInIj.length} methods registered in IntelliJ but not in VSCode (likely VSCode-only or stale):`,
+  );
+  for (const m of extraInIj) console.warn(`  - ${m}`);
+  console.warn(
+    "\nNot a CI fail — IntelliJ may have implemented something ahead of VSCode, or the VSCode entry was renamed.",
+  );
+}
+
+console.log("\nOK: IntelliJ has handlers for every VSCode wire method.");


### PR DESCRIPTION
## Summary

Three IntelliJ plugin fixes from the dogfood sweep:

- **PLUGIN_VERSION drift** — was hardcoded \`"1.0.0"\` while \`gradle.properties\` shipped \`1.0.1\` to the Marketplace. Now read at runtime via \`PluginManagerCore.getPlugin(...)?.version\` so it stays in lock-step.
- **SignatureHelpHandler shape** — was returning \`JsonNull\`; bridge expects \`{signatures, activeSignature, activeParameter}\`. Now returns \`{signatures: [], activeSignature: -1, activeParameter: -1}\` matching the convention of \`getCodeActions\` and other stubs.
- **CI parity ratchet** — new \`scripts/audit-intellij-parity.mjs\` enumerates wire methods on both sides; fails CI if IntelliJ is missing a VSCode method. Wired into \`.github/workflows/ci.yml\` alongside existing audits.

## Test plan

- [x] Parity script passes locally (39 VSCode methods all covered on IJ side, mostly via stubs)
- [ ] Gradle build verification — deferred to user's local env (no JDK in audit shell)
- [x] biome clean

## Notes

10 IJ-side extra wire methods (LSP/refactor/debug-extras like \`renameSymbol\`, \`signatureHelp\`, \`selectionRanges\`) are warned but not failed — those are IJ ahead of VSCode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)