### PR TITLE
chore(positioning): refresh stale doc header + dead-branch error messages

### DIFF
--- a/documents/platform-docs.md
+++ b/documents/platform-docs.md
@@ -1,6 +1,6 @@
 # Claude IDE Bridge — Platform Documentation
 
-Version **0.2.0-alpha.3** · 170+ tools · 72 MCP prompts · 20 automation hooks · 4 connectors
+Version **0.2.0-alpha.35** · 170+ tools · 72 MCP prompts · 20 automation hooks · 19 connectors (Slack, GitHub, Linear, Gmail, Google Calendar, Google Drive, Sentry, Notion, Confluence, Datadog, HubSpot, Intercom, Stripe, Zendesk, Jira, PagerDuty, Discord, Asana, GitLab — see [README](../README.md) for canonical list)
 
 > **Deployment model:** Remote deployment (VPS + reverse proxy, systemd service, `--bind 0.0.0.0 --issuer-url <https-url>`) is a first-class, production-ready pattern and is the recommended architecture for team or cloud access. Local mode (`127.0.0.1`, no `--issuer-url`) is for individual development.
 

--- a/src/recipes/__tests__/compiler.test.ts
+++ b/src/recipes/__tests__/compiler.test.ts
@@ -171,7 +171,7 @@ describe("compileRecipe", () => {
         ...BASE,
         trigger: { type: "cron", schedule: "0 9 * * *" },
       }),
-    ).toThrow(/scheduler wiring/);
+    ).toThrow(/RecipeScheduler/);
     expect(() =>
       compileRecipe({ ...BASE, trigger: { type: "manual" } }),
     ).toThrow(/patchwork run/);

--- a/src/recipes/compiler.ts
+++ b/src/recipes/compiler.ts
@@ -166,15 +166,15 @@ function mapTrigger(
       break;
     case "webhook":
       throw new RecipeCompileError(
-        `recipe '${recipeName}': webhook trigger requires the /hooks/* HTTP endpoint, not yet wired. Skip until Phase-2 HTTP patch.`,
+        `recipe '${recipeName}': webhook triggers fire via POST /hooks/* (server.webhookFn) and bypass the automation interpreter — installer.ts skips compileRecipeFull for them. Reaching this branch means a non-bypass caller invoked compileTrigger directly; check the call site.`,
       );
     case "cron":
       throw new RecipeCompileError(
-        `recipe '${recipeName}': cron trigger requires the scheduler wiring, not yet landed. Use ~/.claude/scheduled-tasks/ templates as a workaround.`,
+        `recipe '${recipeName}': cron triggers fire via RecipeScheduler and bypass the automation interpreter — installer.ts skips compileRecipeFull for them. Reaching this branch means a non-bypass caller invoked compileTrigger directly; check the call site.`,
       );
     case "manual":
       throw new RecipeCompileError(
-        `recipe '${recipeName}': manual trigger runs via the 'patchwork run <name>' CLI subcommand, not the automation interpreter.`,
+        `recipe '${recipeName}': manual triggers run via 'patchwork run <name>' and bypass the automation interpreter — installer.ts skips compileRecipeFull for them. Reaching this branch means a non-bypass caller invoked compileTrigger directly; check the call site.`,
       );
   }
   throw new RecipeCompileError(`recipe '${recipeName}': unknown trigger type`);


### PR DESCRIPTION
## Summary

Two zero-risk fixes flagged independently by the Positioning and Memory/Ecosystem strategic-plan agents (2026-05-02):

- [documents/platform-docs.md:3](documents/platform-docs.md#L3) — version was \`alpha.3\` (current \`alpha.35\`), connector count "4" understates the 19 connectors listed in README. Replaced with current version + canonical list, pointing at README as source of truth.
- [src/recipes/compiler.ts:167-178](src/recipes/compiler.ts#L167) — \`compileTrigger\` error messages for webhook/cron/manual still claimed those triggers were "not yet wired" / "not yet landed". They actually fire via \`server.webhookFn\`, \`RecipeScheduler\`, and the CLI respectively, and [installer.ts:65-68](src/recipes/installer.ts#L65) skips \`compileRecipeFull\` for them entirely. Updated messages to describe the bypass path so anyone hitting the throw understands it signals a non-bypass caller, not a missing feature.

No behavior change. Cleans up two contradictions before strategic-plan work touches positioning surfaces.

## Test plan

- [ ] CI green (no behavior change; only error-message strings + a doc header line)
- [ ] Manual sanity: \`grep -n "not yet" src/recipes/compiler.ts\` returns no hits

## Context

Spawned from #124's broader strategic-plan effort. See \`docs/strategic/2026-05-02/{positioning,recipe-lifecycle,memory-ecosystem}-report.md\` for the full audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)