### PR TITLE
feat(approvals): capture policy inputs (params, tier, riskSignals) on every approval_decision row

### DIFF
--- a/src/__tests__/approvalHttp.test.ts
+++ b/src/__tests__/approvalHttp.test.ts
@@ -326,6 +326,228 @@ describe("routeApprovalRequest", () => {
     });
   });
 
+  describe("approval-input capture (decision-replay enabler)", () => {
+    // The lifecycle row records what the policy SAW, not just what it
+    // DECIDED. A future replay debugger needs (toolName, params, tier,
+    // riskSignals) on every approval_decision row to fold a new policy
+    // over historical inputs. Tests below pin that contract on every
+    // short-circuit branch and through the queue.
+
+    async function recordOne(
+      body: Record<string, unknown>,
+      ccLoader = emptyRules(),
+      extraDeps: Record<string, unknown> = {},
+    ): Promise<Record<string, unknown>> {
+      const events: Array<Record<string, unknown>> = [];
+      const queue = new ApprovalQueue();
+      await routeApprovalRequest(
+        { method: "POST", path: "/approvals", body },
+        {
+          queue,
+          workspace: "/tmp",
+          ccLoader,
+          onDecision: (_, meta) => events.push(meta),
+          ...extraDeps,
+        },
+      );
+      expect(events).toHaveLength(1);
+      return events[0];
+    }
+
+    it("captures params, tier, riskSignals on cc_allow_rule path", async () => {
+      const meta = await recordOne(
+        {
+          toolName: "Bash",
+          params: { command: "rm -rf /tmp/foo" },
+          sessionId: "s1",
+        },
+        allowRules("Bash"),
+      );
+      expect(meta).toMatchObject({
+        decision: "allow",
+        reason: "cc_allow_rule",
+        toolName: "Bash",
+        sessionId: "s1",
+        tier: "high",
+        params: { command: "rm -rf /tmp/foo" },
+        riskSignals: expect.arrayContaining([
+          expect.objectContaining({ kind: "destructive_flag" }),
+        ]),
+      });
+    });
+
+    it("captures params + tier on cc_deny_rule path", async () => {
+      const meta = await recordOne(
+        { toolName: "gitPush", params: { remote: "origin" } },
+        denyRules("gitPush"),
+      );
+      expect(meta).toMatchObject({
+        decision: "deny",
+        reason: "cc_deny_rule",
+        tier: "high",
+        params: { remote: "origin" },
+      });
+    });
+
+    it("captures params + tier on dontAsk_mode path", async () => {
+      const meta = await recordOne({
+        toolName: "gitPush",
+        params: { remote: "origin" },
+        permissionMode: "dontAsk",
+      });
+      expect(meta).toMatchObject({
+        reason: "dontAsk_mode",
+        tier: "high",
+        params: { remote: "origin" },
+      });
+    });
+
+    it("captures params + tier on auto_mode path", async () => {
+      const meta = await recordOne({
+        toolName: "Read",
+        params: { file_path: "/tmp/x.txt" },
+        permissionMode: "auto",
+      });
+      expect(meta).toMatchObject({
+        reason: "auto_mode",
+        tier: "medium",
+        params: { file_path: "/tmp/x.txt" },
+      });
+    });
+
+    it("captures params + tier on plan_mode_read path", async () => {
+      const meta = await recordOne({
+        toolName: "Read",
+        params: { file_path: "/tmp/x.txt" },
+        permissionMode: "plan",
+      });
+      expect(meta).toMatchObject({
+        reason: "plan_mode_read",
+        tier: "medium",
+        params: { file_path: "/tmp/x.txt" },
+      });
+    });
+
+    it("captures params + tier on plan_mode_write path", async () => {
+      const meta = await recordOne({
+        toolName: "Bash",
+        params: { command: "touch x" },
+        permissionMode: "plan",
+      });
+      expect(meta).toMatchObject({
+        reason: "plan_mode_write",
+        tier: "high",
+        params: { command: "touch x" },
+      });
+    });
+
+    it("captures params + tier on gate_off path", async () => {
+      const meta = await recordOne(
+        { toolName: "Bash", params: { command: "ls" } },
+        emptyRules(),
+        { approvalGate: "off" },
+      );
+      expect(meta).toMatchObject({
+        reason: "gate_off",
+        tier: "high",
+        params: { command: "ls" },
+      });
+    });
+
+    it("captures params + tier on gate_below_threshold path", async () => {
+      const meta = await recordOne(
+        { toolName: "Read", params: { file_path: "/tmp/x" } },
+        emptyRules(),
+        { approvalGate: "high" },
+      );
+      expect(meta).toMatchObject({
+        reason: "gate_below_threshold",
+        tier: "medium",
+        params: { file_path: "/tmp/x" },
+      });
+    });
+
+    it("redacts sensitive keys in captured params (auth/token/password)", async () => {
+      const meta = await recordOne(
+        {
+          toolName: "sendHttpRequest",
+          params: {
+            url: "https://example.com/api",
+            headers: {
+              Authorization: "Bearer sk-live-secret-xyz",
+              "X-Api-Key": "hunter2",
+            },
+            body: { password: "p@ssw0rd", username: "alice" },
+          },
+        },
+        allowRules("sendHttpRequest"),
+      );
+      expect(meta.params).toEqual({
+        url: "https://example.com/api",
+        headers: {
+          Authorization: "[REDACTED]",
+          "X-Api-Key": "[REDACTED]",
+        },
+        body: { password: "[REDACTED]", username: "alice" },
+      });
+    });
+
+    it("omits params field entirely when caller sent no params", async () => {
+      // captureForRunlog of {} returns {}; we still include it so a replay
+      // can distinguish "policy saw empty params" from "row predates capture"
+      const meta = await recordOne(
+        { toolName: "gitPush" },
+        denyRules("gitPush"),
+      );
+      expect(meta.params).toEqual({});
+      expect(meta.tier).toBe("high");
+    });
+
+    it("includes params + tier + riskSignals on the queue (human-approval) path", async () => {
+      // Drive the queue path: no CC rule + interactive permissionMode + gate
+      // catches the tool. Auto-resolve so the test doesn't hang.
+      const events: Array<Record<string, unknown>> = [];
+      const queue = new ApprovalQueue();
+      const promise = routeApprovalRequest(
+        {
+          method: "POST",
+          path: "/approvals",
+          body: {
+            toolName: "Bash",
+            params: { command: "sudo rm -rf /tmp/foo" },
+            sessionId: "s2",
+          },
+        },
+        {
+          queue,
+          workspace: "/tmp",
+          ccLoader: emptyRules(),
+          approvalGate: "all",
+          onDecision: (_, meta) => events.push(meta),
+        },
+      );
+      // Resolve the queued request out-of-band so the route returns.
+      await new Promise((r) => setTimeout(r, 10));
+      const items = queue.list();
+      expect(items).toHaveLength(1);
+      queue.approve(items[0].callId);
+      await promise;
+
+      expect(events).toHaveLength(1);
+      expect(events[0]).toMatchObject({
+        decision: "allow",
+        reason: "approved",
+        tier: "high",
+        params: { command: "sudo rm -rf /tmp/foo" },
+        riskSignals: expect.arrayContaining([
+          expect.objectContaining({ kind: "destructive_flag" }),
+        ]),
+      });
+      // callId is the queue-path-specific extra
+      expect(typeof events[0].callId).toBe("string");
+    });
+  });
+
   it("unknown route → 404", async () => {
     const res = await routeApprovalRequest(
       { method: "GET", path: "/what" },

--- a/src/approvalHttp.ts
+++ b/src/approvalHttp.ts
@@ -10,6 +10,7 @@ import {
   loadCcPermissions,
   loadCcPermissionsAttributed,
 } from "./ccPermissions.js";
+import { captureForRunlog } from "./recipes/captureForRunlog.js";
 import { classifyTool } from "./riskTier.js";
 
 // Tools CC allows in plan mode (read-only — no filesystem or network writes).
@@ -517,14 +518,31 @@ async function handleApprovalRequest(
   const sessionId =
     typeof body.sessionId === "string" ? body.sessionId : undefined;
 
-  // riskSignals are computed lazily — most short-circuit branches skip the
-  // cost by never calling computeRiskSignals. The queue-awaiting branch
-  // passes the already-computed signals via the optional arg.
+  if (!toolName) {
+    return { status: 400, body: { error: "toolName required" } };
+  }
+
+  // Capture the inputs the policy saw on EVERY decision path, not just the
+  // queue-awaiting path. A future "decision replay debugger" needs to be able
+  // to fold a new policy over historical inputs — that requires `params`,
+  // `tier`, and `riskSignals` on every approval_decision row, not just rows
+  // that hit a human dashboard.
+  //
+  // Cost: classifyTool is a table lookup; computeRiskSignals is regex + one
+  // path.resolve. Both cheap. captureForRunlog redacts known secret keys and
+  // caps the JSON envelope at 8 KB so a giant `params.command` won't bloat
+  // the lifecycle log.
+  //
+  // Older rows (pre-this-PR) lack these fields. Readers must treat them as
+  // optional. There is no backfill — the inputs simply weren't captured.
+  const tier = classifyTool(toolName);
+  const riskSignals = computeRiskSignals(toolName, params, deps.workspace);
+  const capturedParams = captureForRunlog(params);
+
   const emit = (
     decision: string,
     reason: string,
     extras?: {
-      riskSignals?: RiskSignal[];
       callId?: string;
     },
   ) =>
@@ -535,17 +553,12 @@ async function handleApprovalRequest(
       reason,
       permissionMode,
       sessionId,
+      tier,
+      ...(capturedParams !== undefined && { params: capturedParams }),
+      ...(riskSignals.length > 0 && { riskSignals }),
       ...(summary !== undefined && { summary }),
-      ...(extras?.riskSignals &&
-        extras.riskSignals.length > 0 && {
-          riskSignals: extras.riskSignals,
-        }),
       ...(extras?.callId && { callId: extras.callId }),
     });
-
-  if (!toolName) {
-    return { status: 400, body: { error: "toolName required" } };
-  }
 
   // CC settings.json precedence
   const rules = (deps.ccLoader ?? loadCcPermissions)(deps.workspace, {
@@ -604,8 +617,9 @@ async function handleApprovalRequest(
     };
   }
 
-  // Fall through to dashboard approval
-  const tier = classifyTool(toolName);
+  // Fall through to dashboard approval. tier + riskSignals were already
+  // computed at the top of this function so emit() carries them on every
+  // decision path — see the comment block above the emit definition.
 
   // Respect approvalGate setting — "off" bypasses, "high" only queues high-tier tools
   const gate = deps.approvalGate ?? "off";
@@ -621,7 +635,6 @@ async function handleApprovalRequest(
     };
   }
 
-  const riskSignals = computeRiskSignals(toolName, params, deps.workspace);
   const now = Date.now();
   const { callId, approvalToken, promise } = deps.queue.request(
     { toolName, params, tier, summary, sessionId, riskSignals },
@@ -660,10 +673,7 @@ async function handleApprovalRequest(
   if (outcome !== "expired") {
     recordApprovalCompleted();
   }
-  emit(outcome === "approved" ? "allow" : "deny", outcome, {
-    riskSignals,
-    callId,
-  });
+  emit(outcome === "approved" ? "allow" : "deny", outcome, { callId });
   return {
     status: 200,
     body: {


### PR DESCRIPTION
## Summary

The approval lifecycle log currently records what the policy DECIDED (allow/deny + reason) but not what it SAW. Without the inputs, the **Decision Replay Debugger** called for in [strategic-plan.md Phase 3 §2](docs/strategic/2026-05-02/strategic-plan.md) cannot exist — there's nothing to fold a new policy over.

This PR captures \`(params, tier, riskSignals)\` on **every** \`approval_decision\` emit path, not just the queue-awaiting path:

- **\`tier\`** computed once at the top of \`handleApprovalRequest\` (cheap table lookup) and included on every decision. Previously only on the queue path.
- **\`riskSignals\`** computed once at the top (regex + one \`path.resolve\`, fast) and included whenever non-empty. Previously only on the queue path, threaded through an \`extras\` arg.
- **\`params\`** captured via the existing \`captureForRunlog\` helper, which redacts known sensitive keys (\`Authorization\`, \`X-Api-Key\`, \`password\`, \`token\`, \`cookie\`, …) and caps the JSON envelope at 8 KB. Previously params were **never** persisted in the lifecycle row.

The Memory/Ecosystem strategic-plan agent (2026-05-02) flagged this as the single highest-leverage memory-track investment per LoC: it is prerequisite for **both** the Decision Replay Debugger AND the passive personalization heuristics ("you approved similar params N times before"). See [memory-ecosystem-report.md](docs/strategic/2026-05-02/memory-ecosystem-report.md) items 1, 5, 12.

## Compatibility

- **Forward-compatible.** New fields are additions, not renames. Existing readers ([activityLog.findApprovalByCallId](src/activityLog.ts#L262), dashboard approval detail) only consume \`callId\` + \`sessionId\` and ignore extras.
- **No backfill.** Older rows (pre-this-PR) lack these fields. Replay tooling must treat them as optional — the inputs simply weren't captured.
- **Push notification** still receives the same \`riskSignals\` array, now via the up-front local instead of a later compute.

## Tests

New \`approval-input capture (decision-replay enabler)\` describe block in [approvalHttp.test.ts](src/__tests__/approvalHttp.test.ts):

- 8 cases pinning the contract on every short-circuit branch (\`cc_allow_rule\`, \`cc_deny_rule\`, \`dontAsk_mode\`, \`auto_mode\`, \`plan_mode_read\`, \`plan_mode_write\`, \`gate_off\`, \`gate_below_threshold\`)
- 1 queue-path case (drives \`approvalGate: \"all\"\`, asserts \`callId\` + \`tier\` + \`params\` + \`riskSignals\`)
- 1 redaction test confirming \`Authorization\`, \`X-Api-Key\`, and \`password\` are replaced with \`[REDACTED]\`

Full suite: **4663/4663 passing**.

## Test plan

- [ ] CI green
- [ ] Manual: trigger a real approval through the dashboard, confirm the activity log row now has \`params\`, \`tier\`, and \`riskSignals\` fields with the dashboard reader still rendering correctly
- [ ] Manual: send a request with secrets in params (\`Authorization\` header etc.), confirm \`[REDACTED]\` appears in the persisted row

🤖 Generated with [Claude Code](https://claude.com/claude-code)