### PR TITLE
feat(traces): patchwork traces export — bundle local trace logs into a single .jsonl.gz

### DIFF
--- a/src/commands/__tests__/tracesExport.test.ts
+++ b/src/commands/__tests__/tracesExport.test.ts
@@ -1,0 +1,246 @@
+import {
+  createReadStream,
+  existsSync,
+  mkdirSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { createInterface } from "node:readline";
+import { createGunzip } from "node:zlib";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { runTracesExport, TRACES_EXPORT_VERSION } from "../tracesExport.js";
+
+interface ParsedBundle {
+  manifest: {
+    type: "manifest";
+    version: number;
+    exportedAt: string;
+    sources: string[];
+    files: Array<{
+      source: string;
+      relativePath: string;
+      count: number;
+      bytes: number;
+    }>;
+    totalCount: number;
+  };
+  rows: Array<{ source: string; entry: unknown; file?: string }>;
+}
+
+async function readBundle(file: string): Promise<ParsedBundle> {
+  const lines: string[] = [];
+  const gz = createReadStream(file).pipe(createGunzip());
+  const rl = createInterface({ input: gz, crlfDelay: Infinity });
+  for await (const line of rl) {
+    if (line.trim().length === 0) continue;
+    lines.push(line);
+  }
+  if (lines.length === 0) {
+    throw new Error("empty bundle");
+  }
+  const first = lines[0];
+  if (first === undefined) throw new Error("empty bundle");
+  const manifest = JSON.parse(first);
+  const rows = lines.slice(1).map((l) => JSON.parse(l));
+  return { manifest, rows };
+}
+
+describe("runTracesExport", () => {
+  // Use a unique tmp dir per test run; clean up after.
+  const tmpRoot = path.join(os.tmpdir(), `patchwork-traces-${Date.now()}`);
+  const patchworkDir = path.join(tmpRoot, "patchwork");
+  const activityDir = path.join(tmpRoot, "ide");
+
+  beforeEach(() => {
+    mkdirSync(patchworkDir, { recursive: true });
+    mkdirSync(activityDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    if (existsSync(tmpRoot)) rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it("exports a manifest line + one envelope per row across all four sources", async () => {
+    writeFileSync(
+      path.join(patchworkDir, "runs.jsonl"),
+      `${JSON.stringify({ seq: 1, recipeName: "demo", status: "ok" })}\n${JSON.stringify({ seq: 2, recipeName: "demo", status: "error" })}\n`,
+    );
+    writeFileSync(
+      path.join(patchworkDir, "decision_traces.jsonl"),
+      `${JSON.stringify({ id: "t1", traceType: "approval", key: "Bash" })}\n`,
+    );
+    writeFileSync(
+      path.join(patchworkDir, "commit_issue_links.jsonl"),
+      `${JSON.stringify({ commit: "abc", issue: "#42" })}\n`,
+    );
+    writeFileSync(
+      path.join(activityDir, "activity-3000.jsonl"),
+      `${JSON.stringify({ id: 1, event: "tool" })}\n${JSON.stringify({ id: 2, event: "tool" })}\n${JSON.stringify({ id: 3, event: "approval_decision" })}\n`,
+    );
+
+    const result = await runTracesExport({
+      patchworkDir,
+      activityDir,
+      output: path.join(tmpRoot, "out.jsonl.gz"),
+    });
+
+    expect(result.totalCount).toBe(7); // 2 + 1 + 1 + 3
+    expect(result.files).toHaveLength(4);
+    expect(existsSync(result.outputPath)).toBe(true);
+
+    const bundle = await readBundle(result.outputPath);
+    expect(bundle.manifest.type).toBe("manifest");
+    expect(bundle.manifest.version).toBe(TRACES_EXPORT_VERSION);
+    expect(bundle.manifest.totalCount).toBe(7);
+    expect(bundle.manifest.sources.sort()).toEqual([
+      "activity",
+      "commit_issue_links",
+      "decision_traces",
+      "runs",
+    ]);
+    expect(bundle.rows).toHaveLength(7);
+
+    // Each envelope has a recognizable source label and a parsed entry.
+    const bySource: Record<string, unknown[]> = {};
+    for (const r of bundle.rows) {
+      (bySource[r.source] ??= []).push(r.entry);
+    }
+    expect(bySource.runs).toHaveLength(2);
+    expect(bySource.decision_traces).toHaveLength(1);
+    expect(bySource.commit_issue_links).toHaveLength(1);
+    expect(bySource.activity).toHaveLength(3);
+
+    // Activity envelopes carry the source filename so multi-instance
+    // history can be reconstructed.
+    const activityEnv = bundle.rows.filter((r) => r.source === "activity");
+    for (const a of activityEnv) {
+      expect(a.file).toBe("activity-3000.jsonl");
+    }
+  });
+
+  it("round-trips entries unchanged (no field loss, no reordering inside a source)", async () => {
+    const decisionRows = [
+      { id: "d1", traceType: "approval", key: "Bash", decidedAt: 100 },
+      { id: "d2", traceType: "approval", key: "Read", decidedAt: 200 },
+      { id: "d3", traceType: "approval", key: "Write", decidedAt: 300 },
+    ];
+    writeFileSync(
+      path.join(patchworkDir, "decision_traces.jsonl"),
+      `${decisionRows.map((r) => JSON.stringify(r)).join("\n")}\n`,
+    );
+
+    const result = await runTracesExport({
+      patchworkDir,
+      activityDir,
+      output: path.join(tmpRoot, "out.jsonl.gz"),
+    });
+
+    const bundle = await readBundle(result.outputPath);
+    const exported = bundle.rows
+      .filter((r) => r.source === "decision_traces")
+      .map((r) => r.entry);
+    expect(exported).toEqual(decisionRows);
+  });
+
+  it("merges multiple activity-{port}.jsonl files in deterministic order", async () => {
+    writeFileSync(
+      path.join(activityDir, "activity-3000.jsonl"),
+      `${JSON.stringify({ id: 1, port: 3000 })}\n`,
+    );
+    writeFileSync(
+      path.join(activityDir, "activity-3001.jsonl"),
+      `${JSON.stringify({ id: 1, port: 3001 })}\n`,
+    );
+    // A non-activity file in the same dir must be ignored.
+    writeFileSync(
+      path.join(activityDir, "unrelated.jsonl"),
+      `${JSON.stringify({ id: 99 })}\n`,
+    );
+
+    const result = await runTracesExport({
+      patchworkDir,
+      activityDir,
+      output: path.join(tmpRoot, "out.jsonl.gz"),
+    });
+
+    expect(result.files.filter((f) => f.source === "activity")).toHaveLength(2);
+    const bundle = await readBundle(result.outputPath);
+    const activity = bundle.rows.filter((r) => r.source === "activity");
+    expect(activity).toHaveLength(2);
+    // Sorted by filename → 3000 before 3001.
+    expect(activity[0]?.file).toBe("activity-3000.jsonl");
+    expect(activity[1]?.file).toBe("activity-3001.jsonl");
+    // Unrelated file's row not included.
+    for (const a of activity) {
+      expect((a.entry as Record<string, unknown>).id).not.toBe(99);
+    }
+  });
+
+  it("succeeds when source directories are empty (manifest with zero files)", async () => {
+    const result = await runTracesExport({
+      patchworkDir,
+      activityDir,
+      output: path.join(tmpRoot, "out.jsonl.gz"),
+    });
+    expect(result.totalCount).toBe(0);
+    expect(result.files).toHaveLength(0);
+
+    const bundle = await readBundle(result.outputPath);
+    expect(bundle.manifest.files).toEqual([]);
+    expect(bundle.manifest.sources).toEqual([]);
+    expect(bundle.rows).toHaveLength(0);
+  });
+
+  it("drops unparseable JSONL lines without aborting the whole export", async () => {
+    writeFileSync(
+      path.join(patchworkDir, "runs.jsonl"),
+      `${JSON.stringify({ seq: 1, recipeName: "ok" })}\n` +
+        "this is not valid json\n" +
+        `${JSON.stringify({ seq: 2, recipeName: "ok" })}\n`,
+    );
+
+    const result = await runTracesExport({
+      patchworkDir,
+      activityDir,
+      output: path.join(tmpRoot, "out.jsonl.gz"),
+    });
+    expect(result.totalCount).toBe(2);
+
+    const bundle = await readBundle(result.outputPath);
+    expect(bundle.rows).toHaveLength(2);
+    for (const r of bundle.rows) {
+      expect(typeof (r.entry as Record<string, unknown>).seq).toBe("number");
+    }
+  });
+
+  it("writes the bundle with 0o600 perms (no group/world read)", async () => {
+    writeFileSync(
+      path.join(patchworkDir, "runs.jsonl"),
+      `${JSON.stringify({ seq: 1 })}\n`,
+    );
+    const result = await runTracesExport({
+      patchworkDir,
+      activityDir,
+      output: path.join(tmpRoot, "out.jsonl.gz"),
+    });
+    const mode = statSync(result.outputPath).mode & 0o777;
+    expect(mode).toBe(0o600);
+  });
+
+  it("default output filename is ISO-stamped under patchworkDir", async () => {
+    writeFileSync(
+      path.join(patchworkDir, "runs.jsonl"),
+      `${JSON.stringify({ seq: 1 })}\n`,
+    );
+    const result = await runTracesExport({ patchworkDir, activityDir });
+    expect(result.outputPath.startsWith(patchworkDir)).toBe(true);
+    expect(
+      /\/traces-export-\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}\.jsonl\.gz$/.test(
+        result.outputPath,
+      ),
+    ).toBe(true);
+  });
+});

--- a/src/commands/tracesExport.ts
+++ b/src/commands/tracesExport.ts
@@ -1,0 +1,293 @@
+/**
+ * patchwork traces export — bundle the four local trace logs into a
+ * single round-trippable file so a user can move machines, take a
+ * compliance snapshot, or share traces with another tool without the
+ * fragile-glob ritual of finding each .jsonl by hand.
+ *
+ * Output format (Decision 1 / option A in the 2026-05-02 strategic walk-through):
+ * a single gzipped JSONL file. Line 1 is a manifest envelope; every
+ * subsequent line is a per-row envelope. Encryption is intentionally NOT
+ * in this PR — encryption is a 2-hour follow-up once we know which
+ * passphrase / KMS UX the user wants.
+ *
+ *   {"type":"manifest","version":1,"exportedAt":"...","sources":[...],"counts":{...}}
+ *   {"source":"runs","entry":{...one runs.jsonl row...}}
+ *   {"source":"decision_traces","entry":{...one decision_traces.jsonl row...}}
+ *   ...
+ *
+ * Round-trip with `gunzip -c file.jsonl.gz | jq`. Filter one source with
+ * `gunzip -c file.jsonl.gz | jq 'select(.source=="decision_traces") | .entry'`.
+ *
+ * Memory/Ecosystem strategic-plan agent (2026-05-02) flagged trace
+ * durability as the top backlog item — see
+ * `docs/strategic/2026-05-02/memory-ecosystem-report.md` items 1, 3, 12.
+ * Without this, every claim about "years of personal AI memory" is
+ * undercut by the existing 1 MB / 10 000-line silent rotation.
+ */
+
+import {
+  createReadStream,
+  createWriteStream,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  statSync,
+} from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { createInterface } from "node:readline";
+import { pipeline } from "node:stream/promises";
+import { createGzip } from "node:zlib";
+
+export const TRACES_EXPORT_VERSION = 1;
+
+/**
+ * Logical sources we bundle. Adding a new source: extend this enum, add
+ * a discoverer below, and consumer tooling that filters on source.
+ */
+export type TraceSource =
+  | "runs"
+  | "decision_traces"
+  | "commit_issue_links"
+  | "activity";
+
+export interface TracesExportOptions {
+  /** Where to write the bundle. Default: `${patchworkDir}/traces-export-{ISO}.jsonl.gz`. */
+  output?: string;
+  /** Directory containing runs.jsonl / decision_traces.jsonl / commit_issue_links.jsonl. Default: `~/.patchwork/`. */
+  patchworkDir?: string;
+  /** Directory containing `activity-{port}.jsonl` files. Default: `~/.claude/ide/`. */
+  activityDir?: string;
+}
+
+export interface TracesExportSourceFile {
+  /** Logical source. */
+  source: TraceSource;
+  /** Absolute path read. */
+  path: string;
+  /** Number of JSONL rows successfully parsed and emitted. */
+  count: number;
+  /** Bytes read from disk. */
+  bytes: number;
+}
+
+export interface TracesExportResult {
+  /** Absolute path of the written `.jsonl.gz` bundle. */
+  outputPath: string;
+  /** ISO-8601 timestamp recorded in the manifest. */
+  exportedAt: string;
+  /** Per-source-file accounting. Multiple files possible for `activity` (one per bridge instance). */
+  files: TracesExportSourceFile[];
+  /** Total rows across all files. */
+  totalCount: number;
+  /** Total bytes read across all files. */
+  totalBytes: number;
+}
+
+interface ManifestEnvelope {
+  type: "manifest";
+  version: typeof TRACES_EXPORT_VERSION;
+  exportedAt: string;
+  /** Logical sources present in this bundle (deduped). */
+  sources: TraceSource[];
+  /** Per-file accounting. */
+  files: Array<{
+    source: TraceSource;
+    /** Path *relative to* the discovery dir, so the manifest doesn't leak the user's full home path. */
+    relativePath: string;
+    count: number;
+    bytes: number;
+  }>;
+  /** Total rows across all files. */
+  totalCount: number;
+}
+
+interface RowEnvelope {
+  source: TraceSource;
+  /** The original JSONL row, parsed. Unparseable rows are dropped (they would break the bundle's JSONL invariant). */
+  entry: unknown;
+  /**
+   * For `activity` source only: the bridge instance file the row came
+   * from (e.g. `activity-3000.jsonl`). Lets a downstream consumer
+   * reconstruct multi-instance history. Omitted for single-file sources.
+   */
+  file?: string;
+}
+
+function defaultPatchworkDir(): string {
+  return path.join(os.homedir(), ".patchwork");
+}
+
+function defaultActivityDir(): string {
+  return path.join(os.homedir(), ".claude", "ide");
+}
+
+/** Single-file sources live at fixed names in the patchwork dir. */
+const SINGLE_FILE_SOURCES: ReadonlyArray<{
+  source: Exclude<TraceSource, "activity">;
+  filename: string;
+}> = [
+  { source: "runs", filename: "runs.jsonl" },
+  { source: "decision_traces", filename: "decision_traces.jsonl" },
+  { source: "commit_issue_links", filename: "commit_issue_links.jsonl" },
+];
+
+/**
+ * Discover activity-log files. Bridge instances each persist to
+ * `activity-{port}.jsonl` so we glob for that pattern and include any
+ * file that exists. Single explicit `activity.jsonl` (no port suffix)
+ * is also picked up — some test harnesses use that name.
+ */
+function discoverActivityFiles(activityDir: string): string[] {
+  if (!existsSync(activityDir)) return [];
+  let entries: string[];
+  try {
+    entries = readdirSync(activityDir);
+  } catch {
+    return [];
+  }
+  return entries
+    .filter(
+      (name) =>
+        /^activity(-\d+)?\.jsonl$/i.test(name) ||
+        /^activity-log\.jsonl$/i.test(name),
+    )
+    .map((name) => path.join(activityDir, name))
+    .filter((p) => {
+      try {
+        return statSync(p).isFile();
+      } catch {
+        return false;
+      }
+    })
+    .sort();
+}
+
+async function readJsonlRows(
+  filePath: string,
+): Promise<{ rows: unknown[]; bytes: number }> {
+  const rows: unknown[] = [];
+  let bytes = 0;
+  try {
+    bytes = statSync(filePath).size;
+  } catch {
+    return { rows, bytes: 0 };
+  }
+  const stream = createReadStream(filePath, { encoding: "utf8" });
+  const rl = createInterface({ input: stream, crlfDelay: Infinity });
+  for await (const line of rl) {
+    const trimmed = line.trim();
+    if (trimmed.length === 0) continue;
+    try {
+      rows.push(JSON.parse(trimmed));
+    } catch {
+      // Drop unparseable rows. The export's invariant is "every line is
+      // valid JSON"; preserving a malformed line would break consumers.
+    }
+  }
+  return { rows, bytes };
+}
+
+/**
+ * Run the export. Pure function over filesystem state — no log instance
+ * handles needed, so it works headless (e.g. in CI restoring a snapshot)
+ * and during a running bridge alike (the export reads files atomically
+ * line-by-line; concurrent appends only add new rows beyond the export's
+ * point-in-time view).
+ */
+export async function runTracesExport(
+  opts: TracesExportOptions = {},
+): Promise<TracesExportResult> {
+  const exportedAt = new Date().toISOString();
+  const patchworkDir = opts.patchworkDir ?? defaultPatchworkDir();
+  const activityDir = opts.activityDir ?? defaultActivityDir();
+
+  // Default output: `<patchworkDir>/traces-export-<safeIso>.jsonl.gz`. ISO
+  // colons are filename-hostile on Windows so swap them for hyphens.
+  const safeStamp = exportedAt.replace(/:/g, "-").replace(/\..+$/, "");
+  const outputPath =
+    opts.output ??
+    path.join(patchworkDir, `traces-export-${safeStamp}.jsonl.gz`);
+
+  // Discover sources.
+  const files: Array<{
+    source: TraceSource;
+    path: string;
+    relativePath: string;
+    rows: unknown[];
+    bytes: number;
+    activityFile?: string;
+  }> = [];
+
+  for (const { source, filename } of SINGLE_FILE_SOURCES) {
+    const p = path.join(patchworkDir, filename);
+    if (!existsSync(p)) continue;
+    const { rows, bytes } = await readJsonlRows(p);
+    files.push({ source, path: p, relativePath: filename, rows, bytes });
+  }
+  for (const p of discoverActivityFiles(activityDir)) {
+    const { rows, bytes } = await readJsonlRows(p);
+    files.push({
+      source: "activity",
+      path: p,
+      relativePath: path.basename(p),
+      rows,
+      bytes,
+      activityFile: path.basename(p),
+    });
+  }
+
+  // Ensure output dir exists.
+  const outputDir = path.dirname(outputPath);
+  if (!existsSync(outputDir)) mkdirSync(outputDir, { recursive: true });
+
+  // Build manifest from discovered files (even ones with zero rows are
+  // recorded — "we looked here and found this" is more useful than silence).
+  const totalCount = files.reduce((sum, f) => sum + f.rows.length, 0);
+  const sources = [
+    ...new Set(files.map((f) => f.source)),
+  ].sort() as TraceSource[];
+  const manifest: ManifestEnvelope = {
+    type: "manifest",
+    version: TRACES_EXPORT_VERSION,
+    exportedAt,
+    sources,
+    files: files.map((f) => ({
+      source: f.source,
+      relativePath: f.relativePath,
+      count: f.rows.length,
+      bytes: f.bytes,
+    })),
+    totalCount,
+  };
+
+  // Emit: manifest line + one envelope per row, gzip-piped to disk.
+  const gzip = createGzip();
+  const sink = createWriteStream(outputPath, { mode: 0o600 });
+  const writeChunk = (line: string): boolean => gzip.write(`${line}\n`);
+  const drainPromise = pipeline(gzip, sink);
+
+  writeChunk(JSON.stringify(manifest));
+  for (const f of files) {
+    for (const entry of f.rows) {
+      const env: RowEnvelope = { source: f.source, entry };
+      if (f.activityFile) env.file = f.activityFile;
+      writeChunk(JSON.stringify(env));
+    }
+  }
+  gzip.end();
+  await drainPromise;
+
+  return {
+    outputPath,
+    exportedAt,
+    files: files.map((f) => ({
+      source: f.source,
+      path: f.path,
+      count: f.rows.length,
+      bytes: f.bytes,
+    })),
+    totalCount,
+    totalBytes: files.reduce((sum, f) => sum + f.bytes, 0),
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -172,6 +172,7 @@ const KNOWN_SUBCOMMANDS = [
   "status",
   "shim",
   "recipe",
+  "traces",
   "dashboard",
   "launchd",
 ] as const;
@@ -1183,6 +1184,69 @@ if (process.argv[2] === "recipe" && process.argv[3] === "install") {
 }
 
 // Patchwork: `patchwork recipe schema [outputDir]` — write generated recipe schemas to disk.
+// Patchwork: `patchwork traces export [--output <path>]` — bundle the four
+// local trace logs into a single .jsonl.gz so a user can move machines,
+// take a compliance snapshot, or share traces with another tool. See
+// docs/strategic/2026-05-02/memory-ecosystem-report.md items 1, 3, 12 for
+// the durability rationale this PR addresses.
+if (process.argv[2] === "traces" && process.argv[3] === "export") {
+  (async () => {
+    try {
+      const args = process.argv.slice(4);
+      let output: string | undefined;
+      let patchworkDir: string | undefined;
+      let activityDir: string | undefined;
+      for (let i = 0; i < args.length; i++) {
+        const a = args[i];
+        if (a === "--output" || a === "-o") {
+          output = args[i + 1];
+          i++;
+        } else if (a === "--patchwork-dir") {
+          patchworkDir = args[i + 1];
+          i++;
+        } else if (a === "--activity-dir") {
+          activityDir = args[i + 1];
+          i++;
+        } else if (a === "--help" || a === "-h") {
+          process.stdout.write(
+            "patchwork traces export [--output <path>] [--patchwork-dir <dir>] [--activity-dir <dir>]\n\n" +
+              "Bundles ~/.patchwork/{runs,decision_traces,commit_issue_links}.jsonl\n" +
+              "and ~/.claude/ide/activity-*.jsonl into a single gzipped JSONL file.\n\n" +
+              "Output is a manifest line followed by one envelope per row:\n" +
+              '  {"type":"manifest", ...}\n' +
+              '  {"source":"runs", "entry":{...}}\n' +
+              "  ...\n\n" +
+              "Filter one source with:\n" +
+              "  gunzip -c traces-export-*.jsonl.gz | jq 'select(.source==\"decision_traces\") | .entry'\n",
+          );
+          process.exit(0);
+        }
+      }
+      const { runTracesExport } = await import("./commands/tracesExport.js");
+      const result = await runTracesExport({
+        ...(output !== undefined && { output }),
+        ...(patchworkDir !== undefined && { patchworkDir }),
+        ...(activityDir !== undefined && { activityDir }),
+      });
+      process.stdout.write(`  ✓ Wrote ${result.outputPath}\n`);
+      process.stdout.write(
+        `    ${result.totalCount} rows from ${result.files.length} file${result.files.length === 1 ? "" : "s"} (${result.totalBytes} bytes read)\n`,
+      );
+      for (const f of result.files) {
+        process.stdout.write(
+          `    - ${f.source}: ${f.count} rows  (${f.path})\n`,
+        );
+      }
+      process.exit(0);
+    } catch (err) {
+      process.stderr.write(
+        `Error: ${err instanceof Error ? err.message : String(err)}\n`,
+      );
+      process.exit(1);
+    }
+  })();
+}
+
 if (process.argv[2] === "recipe" && process.argv[3] === "schema") {
   const outputDir = process.argv[4] ?? path.join(process.cwd(), "schemas");
   (async () => {


### PR DESCRIPTION
## Summary

Decision 1 / option A from the 2026-05-02 strategic walk-through: plain JSONL bundle now, encryption as a 2-hour follow-up once UX is decided.

[Memory/Ecosystem agent](docs/strategic/2026-05-02/memory-ecosystem-report.md) (items 1, 3, 12) flagged trace durability as the top backlog item: every claim about \"years of personal AI memory\" is undercut by the existing 1 MB / 10 000-line silent rotation. Traces are valuable, easy to lose, and currently inseparable from the running bridge instance.

## Format

Single gzipped JSONL file. One manifest line + one envelope per row:

\`\`\`
{\"type\":\"manifest\",\"version\":1,\"exportedAt\":\"...\",\"sources\":[...]}
{\"source\":\"runs\",\"entry\":{...one runs.jsonl row...}}
{\"source\":\"decision_traces\",\"entry\":{...}}
{\"source\":\"activity\",\"entry\":{...},\"file\":\"activity-3000.jsonl\"}
...
\`\`\`

Round-trip: \`gunzip -c file.jsonl.gz | jq\`.

Filter: \`gunzip -c file.jsonl.gz | jq 'select(.source==\"decision_traces\") | .entry'\`.

Sources bundled:
- \`~/.patchwork/runs.jsonl\` ([RecipeRunLog](src/runLog.ts))
- \`~/.patchwork/decision_traces.jsonl\` ([DecisionTraceLog](src/decisionTraceLog.ts))
- \`~/.patchwork/commit_issue_links.jsonl\` ([CommitIssueLinkLog](src/commitIssueLinkLog.ts))
- \`~/.claude/ide/activity-{port}.jsonl\` ([ActivityLog](src/activityLog.ts), multi-instance — envelope carries the source filename)

## CLI

\`\`\`
patchwork traces export [--output <path>]
                        [--patchwork-dir <dir>]
                        [--activity-dir <dir>]
\`\`\`

Default output: \`~/.patchwork/traces-export-<ISO>.jsonl.gz\` (Windows-safe ISO). Written with 0o600 permissions.

## Why \`.jsonl.gz\` not tar

1. One file is easier to email / back up / version than a tar.
2. \`jq\` works directly without extract.
3. Manifest line 1 self-describes the bundle — no sidecar.

Per-source extraction is one pipe: \`gunzip -c traces-export.jsonl.gz | jq -c 'select(.source==\"X\") | .entry' > X.jsonl\`.

## Tests

7 new cases in [tracesExport.test.ts](src/commands/__tests__/tracesExport.test.ts):

- 4-source full export with manifest + envelopes
- Round-trip preserves entries unchanged (no field loss / reordering inside a source)
- Multi-file activity merge with deterministic ordering, ignores unrelated files
- Empty source dirs → empty manifest, no error
- Unparseable JSONL lines dropped without aborting
- Output written with 0o600 perms
- Default output filename is ISO-stamped under patchworkDir

Plus a manual CLI smoke test confirming \`dist/index.js traces export\` writes a gzipped bundle with the expected shape.

**Full suite: 4670/4670 passing.**

## Encryption (deferred per Decision 1.B)

Intentionally not in this PR. Strong-typed extension point: a follow-up adds \`encrypt?: { passphrase: string }\` to \`TracesExportOptions\`, chains an age/openssl encryptor between gzip and the file sink. ~2 hours of work once the UX is decided.

## Test plan

- [ ] CI green
- [ ] Manual: \`patchwork traces export\` against a real \`~/.patchwork/\` — confirm bundle round-trips via \`gunzip -c | jq\`
- [ ] Manual: \`patchwork traces export --output /tmp/x.jsonl.gz\` — confirm explicit output path honored
- [ ] Confirm output 0o600 perms on Linux/macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)