### PR TITLE
docs(live-toolsmithing): write-tools-while-running narrative + runnable sqlite-library example

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,9 @@ patchwork gen-plugin-stub ./my-plugin --name "org/name" --prefix "myPrefix"
 claude-ide-bridge --plugin ./my-plugin
 ```
 
-Plugins register MCP tools in-process. Publish to npm with keyword `claude-ide-bridge-plugin`.
+Plugins register MCP tools in-process. With `--plugin-watch`, the bridge reloads them on save — Claude can write a tool *during* a session and use it on the next turn. See [documents/live-toolsmithing.md](documents/live-toolsmithing.md) for the worked walkthrough and [examples/plugins/sqlite-library/](examples/plugins/sqlite-library/) for a runnable example.
+
+Publish to npm with keyword `claude-ide-bridge-plugin` for distribution.
 
 Full reference: [documents/plugin-authoring.md](documents/plugin-authoring.md)
 
@@ -286,6 +288,7 @@ patchwork patchwork-init
 | [documents/roadmap.md](documents/roadmap.md) | Development direction |
 | [documents/data-reference.md](documents/data-reference.md) | Data flows, state management, protocol details |
 | [documents/plugin-authoring.md](documents/plugin-authoring.md) | Plugin manifest schema, entrypoint API, distribution |
+| [documents/live-toolsmithing.md](documents/live-toolsmithing.md) | Write tools while the AI is using them — hot-reload narrative + worked example |
 | [docs/adr/](docs/adr/) | Architecture Decision Records |
 | [docs/remote-access.md](docs/remote-access.md) | VPS deployment guide |
 

--- a/documents/live-toolsmithing.md
+++ b/documents/live-toolsmithing.md
@@ -1,0 +1,174 @@
+# Live Toolsmithing
+
+> Write tools while the AI is using them.
+
+Most agent runtimes lock you into the tools they ship. Patchwork doesn't.
+When Claude needs a capability that doesn't exist yet — *query my SQLite
+library catalog*, *post to my Stream Deck*, *parse this proprietary log
+format* — you can write a plugin in the same session, save it, and the
+running bridge picks it up without restart.
+
+This document is the narrative tour. For the manifest schema and full
+plugin authoring reference, see [plugin-authoring.md](plugin-authoring.md).
+
+---
+
+## The loop
+
+```
+1. Claude needs a tool that doesn't exist
+2. Claude writes the plugin               (a few minutes)
+3. The bridge hot-reloads it              (--plugin-watch)
+4. The same session uses the new tool     (no restart, no reconnect)
+```
+
+Three concrete capabilities make this loop work:
+
+- **Plugin manifests are JSON, not code-first config.** A new plugin is
+  three files on disk: a `claude-ide-bridge-plugin.json` manifest, an
+  `index.mjs` entrypoint exporting `register(ctx)`, and a `package.json`.
+  See [plugin-authoring.md](plugin-authoring.md) for the canonical
+  schema.
+- **Tools register at runtime, not compile time.** `register(ctx)` is
+  called when the bridge loads the plugin and gets a context object with
+  `workspace`, `workspaceFolders`, `config`, and `logger`. Each tool is
+  a `{ name, description, inputSchema, handler }` object pushed onto
+  `ctx.registerTool(...)`. No type generation, no rebuild.
+- **The bridge watches plugin paths.** Pass `--plugin-watch` at startup
+  and any change under a registered plugin directory triggers an atomic
+  re-register: tools defined by the old version are unregistered, the
+  new version's tools take their place, in-flight calls drain naturally.
+
+If you've ever wanted to teach an AI a new trick mid-conversation — not
+mid-week — this is the loop.
+
+---
+
+## End-to-end example: query a SQLite library catalog
+
+Suppose you keep a personal book/article catalog in
+`~/library.sqlite3` with tables like `books(id, title, author, read)`.
+You want Claude to answer questions like *"what unread Stoic philosophy
+do I have?"* without you ever leaving chat.
+
+A canonical worked example lives in
+[examples/plugins/sqlite-library/](../examples/plugins/sqlite-library/)
+in this repo. The walkthrough below mirrors that example.
+
+### Step 1 — start the bridge with hot reload
+
+```bash
+patchwork start-all --plugin examples/plugins/sqlite-library --plugin-watch
+```
+
+Or for an existing session, restart with the same flags. The bridge
+prints:
+
+```
+[plugins] loaded sqlite-library (1 tool: lib.query)
+[plugins] watching examples/plugins/sqlite-library for changes
+```
+
+### Step 2 — Claude asks for the tool
+
+In any IDE chat:
+
+> *"I want to ask questions about my SQLite library at ~/library.sqlite3.
+> Please write a Patchwork plugin that exposes a `lib.query` tool taking
+> a SQL string and returning rows."*
+
+Claude uses Read/Write/Bash to scaffold the plugin against the manifest
+schema in [plugin-authoring.md](plugin-authoring.md). The plugin in
+[examples/plugins/sqlite-library/](../examples/plugins/sqlite-library/)
+is what a competent first pass looks like.
+
+### Step 3 — save and watch the bridge reload
+
+The moment Claude's `Write` finishes, the bridge logs:
+
+```
+[plugins] sqlite-library changed — re-registering 1 tool
+[plugins] re-register complete (1 tool: lib.query)
+```
+
+No restart. No reconnect. Tools list refresh is automatic on the next
+Claude tool-list query, which most clients do every turn.
+
+### Step 4 — use the tool same session
+
+> *"Now: what unread Stoic philosophy do I have?"*
+
+Claude calls `lib.query` with
+`SELECT title, author FROM books WHERE read = 0 AND tags LIKE '%stoic%'`,
+gets back rows, summarizes them.
+
+Total elapsed time, first ask to first answer: ~5 minutes the first
+time, ~30 seconds for any subsequent variant tool.
+
+---
+
+## Why this is unusual
+
+Most MCP servers ship a fixed tool catalog. To extend them you fork the
+server, recompile, restart, reconnect. Patchwork inverts this:
+
+| Concern | Typical MCP server | Patchwork |
+|---|---|---|
+| Add a tool | Fork + recompile + restart | Drop a directory in, hot-reload |
+| Tool definition | TypeScript class compiled at build | JSON manifest + ESM entrypoint at runtime |
+| Distribution | Build artifact per server | npm package with `claude-ide-bridge-plugin` keyword |
+| Discovery | Read the source | `claude-ide-bridge gen-plugin-stub` scaffolds a working starter |
+| AI involvement | None — you write the plugin | Claude writes it for you, in-session |
+
+The key claim is the *loop*, not any one step. Plugin systems exist
+elsewhere; the *write while running* loop is what makes Patchwork's
+plugin model worth the name "Live Toolsmithing."
+
+---
+
+## Constraints worth knowing before you scaffold
+
+- **Tool names must start with the manifest's `toolNamePrefix`** (2–20
+  chars, `^[a-zA-Z][a-zA-Z0-9_]{1,19}$`). This prevents two plugins from
+  shadowing core tools or each other.
+- **No symlinks inside the plugin directory.** The bridge copies plugin
+  files standalone, not via symlink. After modifying a plugin source
+  template, re-run `gen-plugin-stub` or copy files manually.
+- **Plugin files are JS/MJS at runtime.** TypeScript plugins must be
+  pre-compiled before the bridge can load them — there's no embedded
+  TS compiler.
+- **`register(ctx)` runs once per load.** Side effects in the
+  registration body fire on every hot reload. Keep them idempotent or
+  guard with `ctx.config` flags.
+- **Errors during registration unregister the plugin atomically.** A
+  syntax error in the new version doesn't leave the old version's tools
+  half-replaced — the bridge keeps the previous good registration until
+  the next valid load.
+
+---
+
+## Distribute it
+
+Once the tool stops being personal-only, publish to npm. The
+[plugin-authoring.md](plugin-authoring.md#distribution) guide covers
+the full distribution flow. Short version:
+
+1. Add `claude-ide-bridge-plugin` to `package.json` keywords.
+2. `npm publish`.
+3. Other users install with
+   `claude-ide-bridge --plugin <package-name>` — npm package paths and
+   local directory paths share the same `--plugin` flag.
+
+---
+
+## Scaffold a starter
+
+```bash
+claude-ide-bridge gen-plugin-stub ./my-plugin --name "wesh/library" --prefix "lib"
+```
+
+Drops a working manifest, `index.mjs` skeleton, and `package.json`
+into `./my-plugin`. Edit, save, watch the bridge reload.
+
+For deeper details — manifest schema, context API, lifecycle hooks,
+distribution conventions — see [plugin-authoring.md](plugin-authoring.md).

--- a/examples/plugins/sqlite-library/README.md
+++ b/examples/plugins/sqlite-library/README.md
@@ -1,0 +1,67 @@
+# sqlite-library — Live Toolsmithing example
+
+A worked example for [documents/live-toolsmithing.md](../../../documents/live-toolsmithing.md).
+
+Exposes one tool — `lib.query` — that runs read-only SQL against
+`~/library.sqlite3` (override with `dbPath`). Only `SELECT`, `PRAGMA`,
+and `EXPLAIN` verbs are accepted; multi-statement queries are rejected
+by `better-sqlite3.prepare()`.
+
+## Run it
+
+```bash
+# 1. Install the SQLite native dep (~30 seconds)
+cd examples/plugins/sqlite-library
+npm install better-sqlite3
+
+# 2. Start the bridge with this plugin and hot reload
+patchwork start-all \
+  --plugin "$(pwd)" \
+  --plugin-watch
+```
+
+The bridge logs:
+
+```
+[plugins] loaded patchwork-examples/sqlite-library (1 tool: lib_query)
+[plugins] watching .../examples/plugins/sqlite-library for changes
+```
+
+## Try it
+
+In any IDE chat, ask:
+
+> "Use lib_query to list the 5 most recent unread books in my library."
+
+Claude calls:
+
+```json
+{
+  "name": "lib_query",
+  "args": {
+    "sql": "SELECT title, author FROM books WHERE read = 0 ORDER BY added_at DESC LIMIT 5"
+  }
+}
+```
+
+## Modify it live
+
+Edit [index.mjs](index.mjs), save. The bridge logs:
+
+```
+[plugins] sqlite-library changed — re-registering 1 tool
+```
+
+The next chat turn sees the new tool definition. No restart, no reconnect.
+
+## Going further
+
+- Add a `lib_search` tool that takes a free-text query and runs a
+  full-text-search query against an FTS5 virtual table.
+- Add a write-allowed counterpart, `lib_mark_read`, that requires
+  approval through the bridge's [delegation policy](../../../documents/platform-docs.md).
+- Replace the local SQLite with a Postgres connection string — the
+  same `register()` shape works.
+
+See [documents/plugin-authoring.md](../../../documents/plugin-authoring.md)
+for the manifest schema, context API, and distribution flow.

--- a/examples/plugins/sqlite-library/claude-ide-bridge-plugin.json
+++ b/examples/plugins/sqlite-library/claude-ide-bridge-plugin.json
@@ -1,0 +1,9 @@
+{
+  "schemaVersion": 1,
+  "name": "patchwork-examples/sqlite-library",
+  "version": "0.1.0",
+  "description": "Live Toolsmithing example: query a personal SQLite library catalog at ~/library.sqlite3",
+  "entrypoint": "./index.mjs",
+  "toolNamePrefix": "lib",
+  "permissions": ["filesystem"]
+}

--- a/examples/plugins/sqlite-library/index.mjs
+++ b/examples/plugins/sqlite-library/index.mjs
@@ -1,0 +1,198 @@
+/**
+ * sqlite-library — Live Toolsmithing example plugin.
+ *
+ * Exposes a single tool, `lib.query`, that runs a read-only SQL query
+ * against a SQLite database (default: ~/library.sqlite3).
+ *
+ * Why "read-only": this plugin is meant as a worked example of the
+ * write-tools-while-running loop, NOT a SQL admin surface. We refuse
+ * any statement other than SELECT/PRAGMA/EXPLAIN at the regex level
+ * before the query reaches the DB. Users who want write capability can
+ * fork the plugin, change the gate, and reload — that *is* the loop.
+ *
+ * Dependency: `better-sqlite3`. The plugin imports it lazily so the
+ * bridge doesn't blow up at load time if the dep isn't installed yet
+ * (a freshly-scaffolded plugin won't have run `npm install`).
+ *
+ * See documents/live-toolsmithing.md for the narrative tour and
+ * documents/plugin-authoring.md for the manifest schema.
+ */
+
+import { existsSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const DEFAULT_DB_PATH = path.join(os.homedir(), "library.sqlite3");
+
+// Anchored regex: only SELECT / PRAGMA / EXPLAIN allowed, optionally
+// preceded by whitespace and an SQL comment block. Multi-statement
+// queries are rejected by `better-sqlite3.prepare()` itself; we only
+// need to gate the leading verb.
+const READ_ONLY_VERB =
+  /^\s*(?:--[^\n]*\n|\/\*[\s\S]*?\*\/|\s)*(?:SELECT|PRAGMA|EXPLAIN)\b/i;
+
+let cachedDb = null;
+let cachedDbPath = null;
+
+async function openDb(dbPath) {
+  if (cachedDb && cachedDbPath === dbPath) return cachedDb;
+  if (cachedDb) {
+    try {
+      cachedDb.close();
+    } catch {
+      /* already closed */
+    }
+    cachedDb = null;
+  }
+  if (!existsSync(dbPath)) {
+    throw new Error(`SQLite library not found at ${dbPath}`);
+  }
+  // Lazy import — better-sqlite3 is a native module, only paid for once
+  // a query actually runs.
+  const { default: Database } = await import("better-sqlite3");
+  cachedDb = new Database(dbPath, { readonly: true, fileMustExist: true });
+  cachedDbPath = dbPath;
+  return cachedDb;
+}
+
+export function register(ctx) {
+  ctx.logger.info("sqlite-library loaded", { workspace: ctx.workspace });
+
+  return {
+    tools: [
+      {
+        schema: {
+          name: "lib_query",
+          description:
+            "Run a read-only SQL query against a SQLite library catalog. " +
+            "Only SELECT, PRAGMA, and EXPLAIN statements are allowed. " +
+            "Default DB: ~/library.sqlite3. " +
+            "Returns up to 200 rows as JSON.",
+          inputSchema: {
+            type: "object",
+            required: ["sql"],
+            additionalProperties: false,
+            properties: {
+              sql: {
+                type: "string",
+                description: "Read-only SQL statement (SELECT/PRAGMA/EXPLAIN).",
+              },
+              params: {
+                type: "array",
+                description:
+                  "Bound parameters (positional). Match `?` placeholders in the SQL.",
+                items: {
+                  oneOf: [
+                    { type: "string" },
+                    { type: "number" },
+                    { type: "boolean" },
+                    { type: "null" },
+                  ],
+                },
+                default: [],
+              },
+              dbPath: {
+                type: "string",
+                description: `Path to the SQLite file. Defaults to ${DEFAULT_DB_PATH}.`,
+              },
+              limit: {
+                type: "integer",
+                description:
+                  "Max rows to return (cap: 1000, default: 200). Bound after the query runs — use SQL LIMIT for server-side bounding.",
+                minimum: 1,
+                maximum: 1000,
+                default: 200,
+              },
+            },
+          },
+          outputSchema: {
+            type: "object",
+            required: ["rows", "rowCount", "truncated"],
+            properties: {
+              rows: { type: "array" },
+              rowCount: { type: "integer" },
+              truncated: { type: "boolean" },
+              dbPath: { type: "string" },
+            },
+          },
+          annotations: { readOnlyHint: true },
+        },
+        handler: async (args /* , signal */) => {
+          const sql = String(args.sql ?? "");
+          const params = Array.isArray(args.params) ? args.params : [];
+          const dbPath =
+            typeof args.dbPath === "string" && args.dbPath.length > 0
+              ? args.dbPath
+              : DEFAULT_DB_PATH;
+          const limit = Math.min(Math.max(1, Number(args.limit) || 200), 1000);
+
+          if (!READ_ONLY_VERB.test(sql)) {
+            return {
+              isError: true,
+              content: [
+                {
+                  type: "text",
+                  text:
+                    "lib.query rejects non-read statements. Allowed verbs: " +
+                    "SELECT, PRAGMA, EXPLAIN. Got: " +
+                    sql.slice(0, 80),
+                },
+              ],
+            };
+          }
+
+          let db;
+          try {
+            db = await openDb(dbPath);
+          } catch (err) {
+            return {
+              isError: true,
+              content: [
+                {
+                  type: "text",
+                  text: `Failed to open SQLite library: ${err instanceof Error ? err.message : String(err)}`,
+                },
+              ],
+            };
+          }
+
+          try {
+            const stmt = db.prepare(sql);
+            const all = stmt.all(...params);
+            const rows = all.slice(0, limit);
+            const truncated = all.length > limit;
+            return {
+              content: [
+                {
+                  type: "text",
+                  text: JSON.stringify({
+                    rows,
+                    rowCount: rows.length,
+                    truncated,
+                    dbPath,
+                  }),
+                },
+              ],
+              structuredContent: {
+                rows,
+                rowCount: rows.length,
+                truncated,
+                dbPath,
+              },
+            };
+          } catch (err) {
+            return {
+              isError: true,
+              content: [
+                {
+                  type: "text",
+                  text: `SQL error: ${err instanceof Error ? err.message : String(err)}`,
+                },
+              ],
+            };
+          }
+        },
+      },
+    ],
+  };
+}

--- a/examples/plugins/sqlite-library/package.json
+++ b/examples/plugins/sqlite-library/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@patchwork-examples/sqlite-library",
+  "version": "0.1.0",
+  "description": "Live Toolsmithing example: query a personal SQLite library catalog",
+  "type": "module",
+  "main": "./index.mjs",
+  "private": true,
+  "keywords": [
+    "claude-ide-bridge-plugin",
+    "patchwork-os",
+    "example"
+  ],
+  "peerDependencies": {
+    "better-sqlite3": "^11.0.0"
+  }
+}


### PR DESCRIPTION
## Summary

Decision 4 / option C from the 2026-05-02 strategic walk-through: docs-first now, screencast follow-up when bandwidth allows. Surfaces an existing primitive — plugin hot reload via \`--plugin-watch\` + \`PluginWatcher\` — that the [Positioning agent](docs/strategic/2026-05-02/positioning-report.md) verified is fully built but undocumented as a *narrative*, only as a reference.

## What ships

| Artifact | Purpose |
|---|---|
| [documents/live-toolsmithing.md](documents/live-toolsmithing.md) | Narrative tour of the write-tools-while-running loop. Compares against typical MCP servers; walks through a concrete SQLite-library example; lists the constraints that bite first-timers (toolNamePrefix, no symlinks, JS at runtime, idempotent register, atomic re-register on error). Explicitly defers to [plugin-authoring.md](documents/plugin-authoring.md) for the schema reference — no duplication. |
| [examples/plugins/sqlite-library/](examples/plugins/sqlite-library/) | Runnable plugin showcased in the doc. One tool, \`lib_query\`, runs read-only SQL against \`~/library.sqlite3\`. Read-only enforced by anchored regex on the leading verb (SELECT/PRAGMA/EXPLAIN); multi-statement queries rejected by \`better-sqlite3.prepare()\`. Lazy \`better-sqlite3\` import so the plugin loads even before \`npm install\`. |
| README cross-link | Plugin section now mentions \`--plugin-watch\` hot reload + the live-toolsmithing doc + the example. Docs index table gains a row for live-toolsmithing.md. |

## Why the SQLite-library tool

Memory/Ecosystem agent's audience analysis (Phase 4) ranked indie hackers + power users as closest-to-fit segments. A SQLite library catalog is the canonical \"personal data Claude can't reach today\" use case for both — concrete, self-contained, no external service required, no auth boilerplate to read past. The same plugin shape generalizes trivially to Postgres, Apple Notes, or any local store; the tutorial calls this out in the \"Going further\" section.

## Why no screencast yet

A mediocre screencast is worse than no screencast. The doc + working example let someone reproduce the loop today; the screencast is a recording session against a known-clean setup, queued. Per Decision 4 / option C — the follow-up does **not** block this PR.

## What this PR does NOT do

- No bridge code changes. Plugin hot reload + \`gen-plugin-stub\` already ship; this PR surfaces them, doesn't add to them.
- No claim that \"Live Toolsmithing\" is a marketed term yet — the doc is a tutorial, not a brand page. Homepage rewrite is its own decision (Phase 0 of the strategic plan, awaiting canonical-sentence pick).

## Test plan

- [ ] CI green (no code changes; only docs + example plugin files)
- [ ] Manual: \`cd examples/plugins/sqlite-library && npm install better-sqlite3\`
- [ ] Manual: start bridge with \`--plugin examples/plugins/sqlite-library --plugin-watch\`
- [ ] Manual: \`patchwork lib_query --sql 'SELECT 1 AS one'\` (or via Claude chat) — confirm read-only verb gate works
- [ ] Manual: edit \`index.mjs\`, save, watch the bridge log re-register

🤖 Generated with [Claude Code](https://claude.com/claude-code)