### PR TITLE
docs(positioning): adopt canonical "personal AI runtime" sentence in README + npm description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
-# Claude IDE Bridge & Patchwork OS
+# Patchwork OS
 
-**One npm package. Two products.** Pick the layer you need.
+### Your personal AI runtime, local-first.
+
+> Patchwork OS is a local-first personal AI runtime: pluggable model providers, hot-reloadable tools, YAML recipes, a delegation policy with approval queue, and a durable trace memory — all running on your machine, all under your policy.
+
+The same codebase ships **two ways to use it.** Pick the layer you need.
 
 | | What you get | Install | Best for |
 |---|---|---|---|

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "patchwork-os",
   "version": "0.2.0-alpha.35",
-  "description": "Patchwork OS — proactive, multi-model AI teammate built on the Claude IDE Bridge. One agent, any model, works while you're away.",
+  "description": "Your personal AI runtime, local-first. Patchwork OS gives any AI model a consistent set of tools, YAML recipes, a delegation policy with approval queue, and a durable trace memory — all on your machine, all under your policy.",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

Decision B from the 2026-05-02 strategic walk-through. Two-tier positioning:

- **Hero (subtitle)**: \`Your personal AI runtime, local-first.\`
- **Canonical (top of README + npm description)**: the [Positioning agent](docs/strategic/2026-05-02/positioning-report.md)'s full sentence — five concrete primitives + trust statement.

Replaces the previous \"proactive, multi-model AI teammate\" framing, which the Positioning agent flagged as the wrong category claim. Patchwork is a runtime users write tools/policy/recipes for, not an agent that \"works while you're away.\"

## Why two-tier

The full canonical sentence is load-bearing — every clause maps to a verified feature in the codebase. It belongs anywhere readers want substance.

The 7-word hero is the truncation-safe distillation for socials, npm registry tiles, package metadata previews, and IDE-marketplace blurbs that cut at ~50 chars. Both ship together.

## Why \"two products\" became \"two ways to use it\"

The previous \"One npm package. Two products.\" opening conflicted with the new positioning: Bridge and Patchwork OS are configuration choices, not separate products. \"Two ways to use it\" preserves the table without the SKU-pair framing mistake.

## Scope

- README hero + canonical sentence + lead phrase
- package.json description (drives npm registry tiles)

**Not in scope** (per Decision B): full homepage rewrite, comparison page, architecture diagram. Those ship as their own PRs from sections 4-6 of [positioning-report.md](docs/strategic/2026-05-02/positioning-report.md) once the sentence here is locked in.

## Test plan

- [ ] CI green (no code changes)
- [ ] Manual: render README on GitHub, confirm hero + canonical readable
- [ ] Manual: \`npm view patchwork-os\` after publish — confirm description reads correctly in tile

🤖 Generated with [Claude Code](https://claude.com/claude-code)