### PR TITLE
feat(traces): --encrypt option for traces export, age-format passphrase encryption

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@opentelemetry/exporter-trace-otlp-http": "^0.213.0",
         "@opentelemetry/sdk-node": "^0.213.0",
         "@opentelemetry/semantic-conventions": "^1.40.0",
+        "age-encryption": "^0.3.0",
         "ajv": "^8.18.0",
         "ipaddr.js": "^2.3.0",
         "minimatch": "^10.0.0",
@@ -830,6 +831,88 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/js-sdsl"
+      }
+    },
+    "node_modules/@noble/ciphers": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-2.2.0.tgz",
+      "integrity": "sha512-Z6pjIZ/8IJcCGzb2S/0Px5J81yij85xASuk1teLNeg75bfT07MV3a/O2Mtn1I2se43k3lkVEcFaR10N4cgQcZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/curves": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.2.0.tgz",
+      "integrity": "sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.2.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/post-quantum": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@noble/post-quantum/-/post-quantum-0.5.4.tgz",
+      "integrity": "sha512-leww0zzIirrvwaYMPI9fj6aRIlA/c6Y0/lifQQ1YOOyHEr0MNH3yYpjXeiVG+tWdPps4XxGclFWX2INPO3Yo5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "~2.0.0",
+        "@noble/hashes": "~2.0.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/post-quantum/node_modules/@noble/curves": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.0.1.tgz",
+      "integrity": "sha512-vs1Az2OOTBiP4q0pwjW5aF0xp9n4MxVrmkFBxc6EKZc6ddYx5gaZiAsZoq0uRRXWbi3AT/sBqn05eRPtn1JCPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.0.1"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/post-quantum/node_modules/@noble/hashes": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.0.1.tgz",
+      "integrity": "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@opentelemetry/api": {
@@ -1770,6 +1853,15 @@
         "win32"
       ]
     },
+    "node_modules/@scure/base": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.2.0.tgz",
+      "integrity": "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@types/chai": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -2002,6 +2094,19 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^8"
+      }
+    },
+    "node_modules/age-encryption": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/age-encryption/-/age-encryption-0.3.0.tgz",
+      "integrity": "sha512-vDhGGp5ZXpbKL6oc3FEBjGhyepr/0SwIWmia6CcPXvYcxGBSQNcDdMv9m2yVOkjjYuJEmtGEhOojIUcjrj0cEw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@noble/ciphers": "^2.1.1",
+        "@noble/curves": "^2.0.1",
+        "@noble/hashes": "^2.0.1",
+        "@noble/post-quantum": "^0.5.3",
+        "@scure/base": "^2.0.0"
       }
     },
     "node_modules/agent-base": {

--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "@opentelemetry/exporter-trace-otlp-http": "^0.213.0",
     "@opentelemetry/sdk-node": "^0.213.0",
     "@opentelemetry/semantic-conventions": "^1.40.0",
+    "age-encryption": "^0.3.0",
     "ajv": "^8.18.0",
     "ipaddr.js": "^2.3.0",
     "minimatch": "^10.0.0",

--- a/src/commands/__tests__/readPassphrase.test.ts
+++ b/src/commands/__tests__/readPassphrase.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest";
+import { PassphraseError, readPassphraseFromTty } from "../readPassphrase.js";
+
+/**
+ * Controllable fake stdin. Holds queued chunks until a `data`
+ * listener attaches AND `resume()` is called — matches the real
+ * stdin contract that the helper relies on. Tests `push` chunks
+ * AFTER kicking off `readPassphraseFromTty`.
+ */
+class TestStdin {
+  private listener: ((chunk: Buffer | string) => void) | null = null;
+  private queued: string[] = [];
+  private paused = true;
+
+  on(event: "data", fn: (chunk: Buffer | string) => void): void {
+    if (event === "data") this.listener = fn;
+  }
+
+  off(event: "data", fn: (chunk: Buffer | string) => void): void {
+    if (event === "data" && this.listener === fn) this.listener = null;
+  }
+
+  setRawMode(): boolean {
+    return true;
+  }
+
+  resume(): void {
+    this.paused = false;
+    this.flushQueue();
+  }
+
+  pause(): void {
+    this.paused = true;
+  }
+
+  /** Push a chunk; deliver immediately if a listener is attached and unpaused. */
+  push(chunk: string): void {
+    this.queued.push(chunk);
+    this.flushQueue();
+  }
+
+  private flushQueue(): void {
+    while (this.queued.length > 0 && !this.paused && this.listener) {
+      const chunk = this.queued.shift();
+      if (chunk !== undefined) this.listener(chunk);
+    }
+  }
+}
+
+function setup(): {
+  stdin: TestStdin;
+  promise: Promise<string>;
+} {
+  const stdin = new TestStdin();
+  const promise = readPassphraseFromTty(
+    "P: ",
+    "Confirm: ",
+    // biome-ignore lint/suspicious/noExplicitAny: test-only seam
+    stdin as any,
+  );
+  return { stdin, promise };
+}
+
+describe("readPassphraseFromTty", () => {
+  it("returns the passphrase when both prompts match", async () => {
+    const { stdin, promise } = setup();
+    stdin.push("secret\n");
+    stdin.push("secret\n");
+    expect(await promise).toBe("secret");
+  });
+
+  it("rejects when the two passphrases differ", async () => {
+    const { stdin, promise } = setup();
+    stdin.push("one\n");
+    stdin.push("two\n");
+    await expect(promise).rejects.toBeInstanceOf(PassphraseError);
+  });
+
+  it("rejects an empty passphrase before asking for confirmation", async () => {
+    const { stdin, promise } = setup();
+    stdin.push("\n");
+    await expect(promise).rejects.toThrow(/empty/);
+  });
+
+  it("strips backspace + DEL during input (no echo, no leak)", async () => {
+    // Step trace for "ab\x08X\x7fcd":
+    //   a → "a"; b → "ab"; \x08 (backspace) → "a"; X → "aX";
+    //   \x7f (DEL) → "a"; c → "ac"; d → "acd"
+    const { stdin, promise } = setup();
+    stdin.push("ab\x08X\x7fcd\n");
+    stdin.push("ab\x08X\x7fcd\n");
+    expect(await promise).toBe("acd");
+  });
+
+  it("ignores non-printable control characters (ESC byte) but lets printable bytes through", async () => {
+    // ESC (0x1b) + "[A" (printable ASCII tail of arrow-up sequence) + "ok\n"
+    const { stdin, promise } = setup();
+    stdin.push("\x1b[Aok\n");
+    stdin.push("[Aok\n"); // confirmation must equal the resulting buf
+    // Known imperfect tradeoff: full ESC-sequence parsing would be a
+    // ~50-line state machine; for a passphrase prompt the printable
+    // bytes inside an ESC sequence don't meaningfully damage anything
+    // (user retypes if confirmation fails). What this test pins is
+    // that the literal ESC byte itself is dropped.
+    expect(await promise).toBe("[Aok");
+  });
+
+  it("aborts on Ctrl-C (0x03)", async () => {
+    const { stdin, promise } = setup();
+    stdin.push("partial\x03");
+    await expect(promise).rejects.toThrow(/cancelled/);
+  });
+
+  it("returns single read when confirmPrompt is undefined (decrypt path)", async () => {
+    const stdin = new TestStdin();
+    const promise = readPassphraseFromTty(
+      "P: ",
+      undefined,
+      // biome-ignore lint/suspicious/noExplicitAny: test-only seam
+      stdin as any,
+    );
+    stdin.push("once\n");
+    expect(await promise).toBe("once");
+  });
+});

--- a/src/commands/__tests__/tracesExport.test.ts
+++ b/src/commands/__tests__/tracesExport.test.ts
@@ -2,6 +2,7 @@ import {
   createReadStream,
   existsSync,
   mkdirSync,
+  readFileSync,
   rmSync,
   statSync,
   writeFileSync,
@@ -9,6 +10,7 @@ import {
 import os from "node:os";
 import path from "node:path";
 import { createInterface } from "node:readline";
+import { Readable } from "node:stream";
 import { createGunzip } from "node:zlib";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { runTracesExport, TRACES_EXPORT_VERSION } from "../tracesExport.js";
@@ -242,5 +244,140 @@ describe("runTracesExport", () => {
         result.outputPath,
       ),
     ).toBe(true);
+  });
+
+  describe("encryption (--encrypt)", () => {
+    // The age format starts with "age-encryption.org/v1\n". Decrypt
+    // round-trip uses the same library the encrypt path uses, so the
+    // bundle is portable to anyone with `age -d -p`.
+
+    it("encrypts the bundle with a passphrase and round-trips via age-encryption", async () => {
+      writeFileSync(
+        path.join(patchworkDir, "runs.jsonl"),
+        `${JSON.stringify({ seq: 1, recipeName: "demo" })}\n${JSON.stringify({ seq: 2 })}\n`,
+      );
+      writeFileSync(
+        path.join(patchworkDir, "decision_traces.jsonl"),
+        `${JSON.stringify({ id: "t1", decision: "approve" })}\n`,
+      );
+
+      const result = await runTracesExport({
+        patchworkDir,
+        activityDir,
+        output: path.join(tmpRoot, "encrypted.jsonl.gz.age"),
+        encrypt: { passphrase: "correct horse battery staple" },
+      });
+
+      expect(existsSync(result.outputPath)).toBe(true);
+
+      // Header should be the age v1 magic. Read first 22 bytes —
+      // "age-encryption.org/v1\n" is 22 chars.
+      const head = readFileSync(result.outputPath)
+        .slice(0, 22)
+        .toString("utf8");
+      expect(head).toBe("age-encryption.org/v1\n");
+
+      // Round-trip: decrypt → gunzip → parse manifest + envelopes.
+      const ciphertext = readFileSync(result.outputPath);
+      const { Decrypter } = await import("age-encryption");
+      const dec = new Decrypter();
+      dec.addPassphrase("correct horse battery staple");
+      const gzippedBytes = await dec.decrypt(
+        new Uint8Array(
+          ciphertext.buffer,
+          ciphertext.byteOffset,
+          ciphertext.byteLength,
+        ),
+      );
+      // Gunzip the inner bundle.
+      const lines: string[] = [];
+      const gz = Readable.from(Buffer.from(gzippedBytes)).pipe(createGunzip());
+      const rl = createInterface({ input: gz, crlfDelay: Infinity });
+      for await (const line of rl) {
+        if (line.trim().length > 0) lines.push(line);
+      }
+      expect(lines.length).toBeGreaterThan(0);
+      const firstLine = lines[0];
+      if (firstLine === undefined) throw new Error("empty bundle");
+      const manifest = JSON.parse(firstLine);
+      expect(manifest.type).toBe("manifest");
+      expect(manifest.totalCount).toBe(3);
+      const rows = lines.slice(1).map((l) => JSON.parse(l));
+      expect(rows).toHaveLength(3);
+    });
+
+    it("default encrypted filename uses .jsonl.gz.age extension", async () => {
+      writeFileSync(
+        path.join(patchworkDir, "runs.jsonl"),
+        `${JSON.stringify({ seq: 1 })}\n`,
+      );
+      const result = await runTracesExport({
+        patchworkDir,
+        activityDir,
+        encrypt: { passphrase: "test-passphrase" },
+      });
+      expect(/\.jsonl\.gz\.age$/.test(result.outputPath)).toBe(true);
+      // Should be in the patchworkDir.
+      expect(result.outputPath.startsWith(patchworkDir)).toBe(true);
+    });
+
+    it("encrypted bundle does not contain plaintext content of source rows", async () => {
+      // Sanity check that we're actually encrypting — a string that
+      // appears in the source must NOT appear verbatim in the output.
+      const marker = "QUITE-DISTINCTIVE-STRING-XYZZY-9000";
+      writeFileSync(
+        path.join(patchworkDir, "runs.jsonl"),
+        `${JSON.stringify({ seq: 1, marker })}\n`,
+      );
+      const result = await runTracesExport({
+        patchworkDir,
+        activityDir,
+        output: path.join(tmpRoot, "marked.jsonl.gz.age"),
+        encrypt: { passphrase: "p" },
+      });
+      const raw = readFileSync(result.outputPath);
+      expect(raw.includes(Buffer.from(marker))).toBe(false);
+    });
+
+    it("encrypted bundle is written with 0o600 perms", async () => {
+      writeFileSync(
+        path.join(patchworkDir, "runs.jsonl"),
+        `${JSON.stringify({ seq: 1 })}\n`,
+      );
+      const result = await runTracesExport({
+        patchworkDir,
+        activityDir,
+        output: path.join(tmpRoot, "perm.jsonl.gz.age"),
+        encrypt: { passphrase: "p" },
+      });
+      const mode = statSync(result.outputPath).mode & 0o777;
+      expect(mode).toBe(0o600);
+    });
+
+    it("wrong passphrase fails to decrypt", async () => {
+      writeFileSync(
+        path.join(patchworkDir, "runs.jsonl"),
+        `${JSON.stringify({ seq: 1 })}\n`,
+      );
+      const result = await runTracesExport({
+        patchworkDir,
+        activityDir,
+        output: path.join(tmpRoot, "wrong.jsonl.gz.age"),
+        encrypt: { passphrase: "right" },
+      });
+      const ciphertext = readFileSync(result.outputPath);
+      const { Decrypter } = await import("age-encryption");
+      const dec = new Decrypter();
+      dec.addPassphrase("wrong");
+      await expect(
+        dec.decrypt(
+          new Uint8Array(
+            ciphertext.buffer,
+            ciphertext.byteOffset,
+            ciphertext.byteLength,
+          ),
+        ),
+      ).rejects.toThrow();
+    });
   });
 });

--- a/src/commands/readPassphrase.ts
+++ b/src/commands/readPassphrase.ts
@@ -1,0 +1,125 @@
+/**
+ * readPassphraseFromTty — no-echo TTY passphrase prompt with confirmation.
+ *
+ * Used by `patchwork traces export --encrypt` when no
+ * `PATCHWORK_TRACES_PASSPHRASE` env var is set and the process is
+ * attached to a TTY. The non-TTY path is rejected by the caller — there
+ * is no scenario where silently reading from a redirected stdin would
+ * be the right choice for a passphrase.
+ *
+ * Why this isn't using `readline.question`: readline echoes by default
+ * and toggling echo off after the prompt is fired races against the
+ * user typing. We use raw mode + manual character read so the first
+ * keystroke is already silent.
+ */
+
+import { Readable } from "node:stream";
+
+export class PassphraseError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "PassphraseError";
+  }
+}
+
+interface ReadlineLite {
+  on(event: "data", fn: (chunk: Buffer | string) => void): void;
+  off(event: "data", fn: (chunk: Buffer | string) => void): void;
+  setRawMode?(mode: boolean): boolean;
+  resume(): unknown;
+  pause(): unknown;
+}
+
+async function readLineSilent(stdin: ReadlineLite): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let buf = "";
+    const onData = (chunkRaw: Buffer | string) => {
+      const chunk =
+        typeof chunkRaw === "string" ? chunkRaw : chunkRaw.toString("utf8");
+      for (const ch of chunk) {
+        const code = ch.charCodeAt(0);
+        // Ctrl-C (0x03) — abort.
+        if (code === 0x03) {
+          stdin.off("data", onData);
+          stdin.setRawMode?.(false);
+          stdin.pause();
+          reject(new PassphraseError("passphrase prompt cancelled"));
+          return;
+        }
+        // CR (0x0d) or LF (0x0a) — line terminator.
+        if (code === 0x0d || code === 0x0a) {
+          stdin.off("data", onData);
+          stdin.setRawMode?.(false);
+          stdin.pause();
+          process.stdout.write("\n");
+          resolve(buf);
+          return;
+        }
+        // Backspace (0x08) or DEL (0x7f) — strip last char.
+        if (code === 0x08 || code === 0x7f) {
+          buf = buf.slice(0, -1);
+          continue;
+        }
+        // Any other control char (0x00–0x1f, except tab 0x09) — ignore
+        // (no echo of arrow keys, ESC sequences, etc.).
+        if (code < 0x20 && code !== 0x09) continue;
+        buf += ch;
+      }
+    };
+    stdin.on("data", onData);
+    stdin.setRawMode?.(true);
+    stdin.resume();
+  });
+}
+
+/**
+ * Prompt for a passphrase on the controlling TTY, twice, with no echo.
+ * Returns the matching passphrase. Throws `PassphraseError` if the two
+ * entries don't match, the user hits Ctrl-C, or the passphrase is empty.
+ *
+ * `confirmPrompt` may be undefined for callers (tests, decrypt flows)
+ * that only want one read.
+ */
+export async function readPassphraseFromTty(
+  prompt: string,
+  /**
+   * If a non-empty string, prompt twice and require both entries to
+   * match. If `undefined` (the decrypt path) prompt once. JS default-
+   * parameter semantics mean we cannot give this a default — callers
+   * passing `undefined` would trigger the default and get an
+   * accidental confirmation prompt.
+   */
+  confirmPrompt: string | undefined,
+  /** Test seam — defaults to process.stdin. */
+  stdin: ReadlineLite = process.stdin as unknown as ReadlineLite,
+): Promise<string> {
+  process.stdout.write(prompt);
+  const first = await readLineSilent(stdin);
+  if (first.length === 0) {
+    throw new PassphraseError("empty passphrase rejected");
+  }
+  if (confirmPrompt === undefined) return first;
+  process.stdout.write(confirmPrompt);
+  const second = await readLineSilent(stdin);
+  if (first !== second) {
+    throw new PassphraseError("passphrases did not match");
+  }
+  return first;
+}
+
+/**
+ * Construct a fake stdin from a sequence of strings — used by tests so
+ * the no-echo path can be exercised without an actual TTY. The
+ * resulting object has the minimal `on/off/setRawMode/resume/pause`
+ * shape `readLineSilent` consumes.
+ */
+export function makeFakeStdin(input: string): ReadlineLite {
+  const stream = Readable.from([input]);
+  return {
+    on: (event, fn) => stream.on(event, fn),
+    off: (event, fn) => stream.off(event, fn),
+    setRawMode: () => true,
+    resume: () => stream.resume(),
+    pause: () => stream.pause(),
+  };
+}

--- a/src/commands/tracesExport.ts
+++ b/src/commands/tracesExport.ts
@@ -52,12 +52,31 @@ export type TraceSource =
   | "activity";
 
 export interface TracesExportOptions {
-  /** Where to write the bundle. Default: `${patchworkDir}/traces-export-{ISO}.jsonl.gz`. */
+  /** Where to write the bundle. Default: `${patchworkDir}/traces-export-{ISO}.jsonl.gz` (or `.jsonl.gz.age` if encrypted). */
   output?: string;
   /** Directory containing runs.jsonl / decision_traces.jsonl / commit_issue_links.jsonl. Default: `~/.patchwork/`. */
   patchworkDir?: string;
   /** Directory containing `activity-{port}.jsonl` files. Default: `~/.claude/ide/`. */
   activityDir?: string;
+  /**
+   * Encrypt the bundle with a passphrase using the age format
+   * (https://age-encryption.org/v1). When set:
+   *   - Pipeline becomes data → gzip → age-encrypt → file
+   *   - Default output extension changes to `.jsonl.gz.age`
+   *   - Decrypt with the standard `age` CLI:
+   *       age -d -o traces.jsonl.gz traces-export-...jsonl.gz.age
+   *     followed by `gunzip -c traces.jsonl.gz | jq`
+   *   - Or with `age-encryption` JS lib in the same one-liner shape as encrypt
+   *
+   * Buffering vs streaming: age's encrypt() takes a Uint8Array, not a
+   * stream, so we buffer the gzipped bundle before encrypting. For
+   * personal traces this is fine — the upstream logs rotate at
+   * ~1 MB / 10 000 lines so the buffered worst-case is single-digit MB.
+   * If a future bundle source pushes this beyond memory comfort, swap
+   * to age's streaming wrapper (when one ships) or chunk into multiple
+   * encrypted files keyed by source.
+   */
+  encrypt?: { passphrase: string };
 }
 
 export interface TracesExportSourceFile {
@@ -202,12 +221,13 @@ export async function runTracesExport(
   const patchworkDir = opts.patchworkDir ?? defaultPatchworkDir();
   const activityDir = opts.activityDir ?? defaultActivityDir();
 
-  // Default output: `<patchworkDir>/traces-export-<safeIso>.jsonl.gz`. ISO
-  // colons are filename-hostile on Windows so swap them for hyphens.
+  // Default output: `<patchworkDir>/traces-export-<safeIso>.jsonl.gz`
+  // (or `.jsonl.gz.age` when --encrypt is set). ISO colons are
+  // filename-hostile on Windows so swap them for hyphens.
   const safeStamp = exportedAt.replace(/:/g, "-").replace(/\..+$/, "");
+  const ext = opts.encrypt ? "jsonl.gz.age" : "jsonl.gz";
   const outputPath =
-    opts.output ??
-    path.join(patchworkDir, `traces-export-${safeStamp}.jsonl.gz`);
+    opts.output ?? path.join(patchworkDir, `traces-export-${safeStamp}.${ext}`);
 
   // Discover sources.
   const files: Array<{
@@ -261,22 +281,64 @@ export async function runTracesExport(
     totalCount,
   };
 
-  // Emit: manifest line + one envelope per row, gzip-piped to disk.
-  const gzip = createGzip();
-  const sink = createWriteStream(outputPath, { mode: 0o600 });
-  const writeChunk = (line: string): boolean => gzip.write(`${line}\n`);
-  const drainPromise = pipeline(gzip, sink);
-
-  writeChunk(JSON.stringify(manifest));
-  for (const f of files) {
-    for (const entry of f.rows) {
-      const env: RowEnvelope = { source: f.source, entry };
-      if (f.activityFile) env.file = f.activityFile;
-      writeChunk(JSON.stringify(env));
+  // Build the JSONL stream first. When encrypting, we collect into a
+  // buffer because age's encrypt() takes a Uint8Array, not a stream
+  // (see TracesExportOptions.encrypt comment for the buffering tradeoff).
+  // When not encrypting, we pipe gzip directly to disk.
+  if (opts.encrypt) {
+    const collected: Buffer[] = [];
+    const gzip = createGzip();
+    const collectPromise = (async () => {
+      for await (const chunk of gzip) {
+        collected.push(chunk as Buffer);
+      }
+    })();
+    gzip.write(`${JSON.stringify(manifest)}\n`);
+    for (const f of files) {
+      for (const entry of f.rows) {
+        const env: RowEnvelope = { source: f.source, entry };
+        if (f.activityFile) env.file = f.activityFile;
+        gzip.write(`${JSON.stringify(env)}\n`);
+      }
     }
+    gzip.end();
+    await collectPromise;
+    const gzippedBytes = Buffer.concat(collected);
+
+    // Lazy-import age-encryption so users who never use --encrypt don't
+    // pay the load cost. The dep is small but module init does scrypt
+    // parameter discovery on first call.
+    const { Encrypter } = await import("age-encryption");
+    const encrypter = new Encrypter();
+    encrypter.setPassphrase(opts.encrypt.passphrase);
+    const ciphertext = await encrypter.encrypt(
+      new Uint8Array(
+        gzippedBytes.buffer,
+        gzippedBytes.byteOffset,
+        gzippedBytes.byteLength,
+      ),
+    );
+    // Write directly — fs.writeFileSync respects mode on creation.
+    const { writeFileSync } = await import("node:fs");
+    writeFileSync(outputPath, Buffer.from(ciphertext), { mode: 0o600 });
+  } else {
+    // Plain pipeline: data → gzip → file.
+    const gzip = createGzip();
+    const sink = createWriteStream(outputPath, { mode: 0o600 });
+    const writeChunk = (line: string): boolean => gzip.write(`${line}\n`);
+    const drainPromise = pipeline(gzip, sink);
+
+    writeChunk(JSON.stringify(manifest));
+    for (const f of files) {
+      for (const entry of f.rows) {
+        const env: RowEnvelope = { source: f.source, entry };
+        if (f.activityFile) env.file = f.activityFile;
+        writeChunk(JSON.stringify(env));
+      }
+    }
+    gzip.end();
+    await drainPromise;
   }
-  gzip.end();
-  await drainPromise;
 
   return {
     outputPath,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1196,6 +1196,7 @@ if (process.argv[2] === "traces" && process.argv[3] === "export") {
       let output: string | undefined;
       let patchworkDir: string | undefined;
       let activityDir: string | undefined;
+      let encrypt = false;
       for (let i = 0; i < args.length; i++) {
         const a = args[i];
         if (a === "--output" || a === "-o") {
@@ -1207,11 +1208,19 @@ if (process.argv[2] === "traces" && process.argv[3] === "export") {
         } else if (a === "--activity-dir") {
           activityDir = args[i + 1];
           i++;
+        } else if (a === "--encrypt") {
+          encrypt = true;
         } else if (a === "--help" || a === "-h") {
           process.stdout.write(
-            "patchwork traces export [--output <path>] [--patchwork-dir <dir>] [--activity-dir <dir>]\n\n" +
+            "patchwork traces export [--output <path>] [--patchwork-dir <dir>] [--activity-dir <dir>] [--encrypt]\n\n" +
               "Bundles ~/.patchwork/{runs,decision_traces,commit_issue_links}.jsonl\n" +
               "and ~/.claude/ide/activity-*.jsonl into a single gzipped JSONL file.\n\n" +
+              "With --encrypt, the bundle is encrypted using the age format\n" +
+              "(https://age-encryption.org/v1) with a passphrase. Decrypt with:\n" +
+              "  age -d -o traces.jsonl.gz traces-export-*.jsonl.gz.age\n\n" +
+              "The passphrase is read from PATCHWORK_TRACES_PASSPHRASE if set,\n" +
+              "otherwise from a no-echo TTY prompt. Non-TTY without the env var\n" +
+              "exits with an error rather than silently using an empty passphrase.\n\n" +
               "Output is a manifest line followed by one envelope per row:\n" +
               '  {"type":"manifest", ...}\n' +
               '  {"source":"runs", "entry":{...}}\n' +
@@ -1222,11 +1231,39 @@ if (process.argv[2] === "traces" && process.argv[3] === "export") {
           process.exit(0);
         }
       }
+
+      // Resolve passphrase if --encrypt was passed.
+      let encryptPassphrase: string | undefined;
+      if (encrypt) {
+        const envPass = process.env.PATCHWORK_TRACES_PASSPHRASE;
+        if (envPass && envPass.length > 0) {
+          encryptPassphrase = envPass;
+        } else if (process.stdin.isTTY) {
+          // No-echo TTY prompt with confirmation.
+          const { readPassphraseFromTty } = await import(
+            "./commands/readPassphrase.js"
+          );
+          encryptPassphrase = await readPassphraseFromTty(
+            "Passphrase for traces bundle: ",
+            "Confirm passphrase: ",
+          );
+        } else {
+          process.stderr.write(
+            "Error: --encrypt requires a passphrase. Set PATCHWORK_TRACES_PASSPHRASE\n" +
+              "or run interactively from a TTY so the prompt can read with no echo.\n",
+          );
+          process.exit(1);
+        }
+      }
+
       const { runTracesExport } = await import("./commands/tracesExport.js");
       const result = await runTracesExport({
         ...(output !== undefined && { output }),
         ...(patchworkDir !== undefined && { patchworkDir }),
         ...(activityDir !== undefined && { activityDir }),
+        ...(encryptPassphrase !== undefined && {
+          encrypt: { passphrase: encryptPassphrase },
+        }),
       });
       process.stdout.write(`  ✓ Wrote ${result.outputPath}\n`);
       process.stdout.write(


### PR DESCRIPTION
## Summary

Decision A from the 2026-05-02 strategic walk-through: passphrase encryption now (option A); age-recipient mode deferred until someone asks. **Stacked on #128** (the unencrypted bundle) — review #128 first, this rebases cleanly when #128 squash-merges.

## What ships

- **\`TracesExportOptions.encrypt: { passphrase: string }\`** — pipeline becomes data → gzip → age-encrypt → file. Default extension gains \`.age\` (\`.jsonl.gz.age\`). Format: standard [age](https://age-encryption.org/v1) v1, BSD-3-Clause, decryptable with the standalone \`age\` CLI:

  \`\`\`
  age -d -o traces.jsonl.gz traces-export-*.jsonl.gz.age
  \`\`\`

- **CLI \`--encrypt\` flag** — passphrase resolution order:
  1. \`PATCHWORK_TRACES_PASSPHRASE\` env var (CI / scripted)
  2. No-echo TTY prompt + confirmation (interactive)
  3. Error out if non-TTY without env var (no silent empty-passphrase fallback)

- **[src/commands/readPassphrase.ts](src/commands/readPassphrase.ts)** — TTY raw-mode reader. Handles backspace (0x08), DEL (0x7f), Ctrl-C (0x03), drops other control bytes. Returns rejected Promise on empty passphrase or mismatched confirmation. Stdin injectable for tests.

## Why \`age-encryption\` (npm) over alternatives

| Considered | Rejected because |
|---|---|
| Custom Node crypto (scrypt + AES-256-GCM) | Decryption would require Patchwork installed forever; that's the wrong UX for a long-lived personal archive |
| Shell out to \`age\` CLI | Brittle on Windows; binary detection mess; not always installed |
| GnuPG | Heavyweight; users who don't already have GPG configured won't set it up for this |

\`age-encryption@0.3.0\` is pure JS, ~30 KB, no native deps, lazy-imported only when \`--encrypt\` is set. The output is a standard age v1 file, decryptable by:
- \`age\` CLI (Homebrew, apt, scoop, GitHub releases)
- \`age-encryption\` JS lib (this dep)
- Any other age-compat implementation (Go, Rust, Swift)

## Buffering tradeoff (documented in source)

\`age.encrypt()\` takes a \`Uint8Array\`, not a stream. We buffer the gzipped bundle before encryption. Personal trace exports are single-digit MB worst case (logs rotate at ~1 MB / 10 000 lines), so this is fine. If future bundle sources push beyond memory comfort, swap to age's streaming wrapper (when one ships) or chunk by source. Comment in [tracesExport.ts](src/commands/tracesExport.ts) flags this for the next contributor.

## Tests

**5 new cases** in [tracesExport.test.ts](src/commands/__tests__/tracesExport.test.ts) (on top of #128's existing 7):

- Encrypted round-trip via age-encryption → gunzip → manifest matches
- Default encrypted filename uses \`.jsonl.gz.age\`
- Encrypted bundle doesn't contain plaintext (marker-string sanity check)
- Encrypted bundle 0o600 perms
- Wrong passphrase fails to decrypt

**7 new cases** in [readPassphrase.test.ts](src/commands/__tests__/readPassphrase.test.ts):

- Matching prompts → return passphrase
- Mismatched → \`PassphraseError\`
- Empty passphrase → reject before confirmation
- Backspace + DEL strip last char
- ESC byte dropped, trailing printable bytes pass (documented imperfect tradeoff)
- Ctrl-C aborts
- Single-read mode (decrypt path)

**Full suite: 4682/4682 passing.**

## Anti-scope

- No age-recipient (X25519 keypair) mode. Defer.
- No CI key-management UX. Defer.
- No streaming encryption. Defer until the buffer becomes a real problem.

## Test plan

- [ ] CI green
- [ ] Manual: \`patchwork traces export --encrypt\` interactively — TTY prompt + confirmation
- [ ] Manual: \`PATCHWORK_TRACES_PASSPHRASE=test patchwork traces export --encrypt\` — env-var path
- [ ] Manual: pipe an \`echo\` to stdin without env var — confirm error path
- [ ] Manual: decrypt a \`.jsonl.gz.age\` with the \`age\` CLI from Homebrew

🤖 Generated with [Claude Code](https://claude.com/claude-code)