### PR TITLE
docs(strategic-phase0): five-primitive expansion + comparison page + architecture diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,22 @@
 
 > Patchwork OS is a local-first personal AI runtime: pluggable model providers, hot-reloadable tools, YAML recipes, a delegation policy with approval queue, and a durable trace memory — all running on your machine, all under your policy.
 
+You decide which model. You decide which actions need a human nod. You own the credentials, the logs, and the deployment. Nothing phones home.
+
+**Five primitives, one runtime:**
+
+- **Tools** — 170+ built-in (LSP, git, terminal, debugger, files) plus any plugin you write. Plugins hot-reload — Claude can author a tool mid-session and call it on the next turn. See [Live Toolsmithing](documents/live-toolsmithing.md).
+- **Recipes** — YAML automations triggered by cron, file save, git commit, test run, or webhook. Anything that can POST a JSON payload can fire a recipe.
+- **Delegation Policy** — three risk tiers, four-source precedence (managed → project-local → project → user). Auto-approve safe, require approval for risky, block dangerous.
+- **Trace memory** — every approval, every recipe run, every enrichment is durable JSONL. Past decisions are surfaced into future sessions automatically. Bundle and back up with [`patchwork traces export`](src/commands/tracesExport.ts).
+- **OAuth** — turn your runtime into a private personal API. PKCE S256, dynamic client registration, deployable on a VPS in minutes.
+
+> **Why not [an MCP server / Zapier / a hosted assistant / a local agent framework]?** See [the comparison page](documents/comparison.md) for the honest tradeoff against each.
+>
+> **What does this look like in one diagram?** See the [architecture overview](documents/architecture.md).
+
+---
+
 The same codebase ships **two ways to use it.** Pick the layer you need.
 
 | | What you get | Install | Best for |
@@ -293,6 +309,8 @@ patchwork patchwork-init
 | [documents/data-reference.md](documents/data-reference.md) | Data flows, state management, protocol details |
 | [documents/plugin-authoring.md](documents/plugin-authoring.md) | Plugin manifest schema, entrypoint API, distribution |
 | [documents/live-toolsmithing.md](documents/live-toolsmithing.md) | Write tools while the AI is using them — hot-reload narrative + worked example |
+| [documents/architecture.md](documents/architecture.md) | One-page architecture diagram + how to read it |
+| [documents/comparison.md](documents/comparison.md) | Patchwork vs MCP server / Zapier / hosted assistants / agent frameworks — honest tradeoffs |
 | [docs/adr/](docs/adr/) | Architecture Decision Records |
 | [docs/remote-access.md](docs/remote-access.md) | VPS deployment guide |
 

--- a/documents/architecture.md
+++ b/documents/architecture.md
@@ -1,0 +1,137 @@
+# Architecture
+
+> One runtime. Bring your own model. Bring your own triggers. Every action passes through a policy you wrote and a log you own.
+
+The diagram below describes how the seven external surfaces (model providers, triggers, MCP clients, OAuth, dashboard, IDE extensions, external targets) connect to the four internal subsystems of the bridge runtime. Every clause in the [canonical positioning sentence](../README.md) maps to a box on this diagram.
+
+```mermaid
+flowchart LR
+    %% External left side
+    Models["<b>Model Providers</b><br/>Claude · GPT · Gemini · Grok · Ollama<br/><i>Pluggable. Subscriptions or API keys.</i>"]
+    Triggers["<b>Triggers</b><br/>Cron · File save · Git event · Test run<br/>Webhook · CLI · Phone (Shortcut/PWA)<br/><i>Anything that can fire.</i>"]
+    Extension["<b>VS Code / JetBrains Extension</b><br/>LSP · debugger · editor state"]
+
+    %% MCP clients
+    MCPClients["<b>MCP Clients</b><br/>Claude Code CLI<br/>Claude Desktop<br/>claude.ai · Codex CLI<br/>Mobile PWA"]
+
+    %% Bridge runtime — the heart
+    subgraph Bridge["Patchwork Bridge Runtime"]
+        direction TB
+        ToolRegistry["<b>Tool Registry</b><br/>170+ built-in + plugins<br/><i>hot reload via --plugin-watch</i>"]
+        RecipeEngine["<b>Recipe Engine</b><br/>RecipeOrchestrator · parser · scheduler"]
+        Policy{{"<b>Delegation Policy</b><br/>risk tiers · 4-source precedence<br/>(managed → project-local<br/>→ project → user)<br/>+ approval queue"}}
+        Trace[("<b>Trace Memory</b><br/>decision_traces.jsonl<br/>RecipeRunLog · ActivityLog<br/>ctxQueryTraces")]
+    end
+
+    %% Right side
+    Transports["<b>MCP Transports</b><br/>WebSocket · stdio shim<br/>Streamable HTTP"]
+    OAuth["<b>OAuth Surface</b><br/>/.well-known/* · /oauth/*<br/>PKCE S256 · CIMD<br/><i>Optional. Activate with --issuer-url.</i>"]
+    Dashboard["<b>Dashboard + Mobile PWA</b><br/>localhost:3100<br/>push approvals"]
+    External["<b>External Targets</b><br/>Connectors (Slack, GitHub,<br/>Linear, Gmail, …)<br/>filesystem · terminal"]
+
+    %% Inputs
+    Triggers --> RecipeEngine
+    MCPClients --> Transports
+    Transports --> Bridge
+    OAuth -. gates .-> Transports
+
+    %% LLM round-trips
+    Models <--> Bridge
+
+    %% Tool dispatch — every outbound call passes through the policy gate
+    RecipeEngine --> ToolRegistry
+    ToolRegistry --> Policy
+    Policy -- approved --> External
+    Policy -- needs nod --> Dashboard
+    Dashboard -- decision --> Policy
+
+    %% Trace writes
+    ToolRegistry --> Trace
+    Policy --> Trace
+    RecipeEngine --> Trace
+
+    %% Trace reads
+    Trace -. session-start digest .-> Bridge
+
+    %% Extension
+    Extension <--> Bridge
+
+    classDef external fill:#fef3c7,stroke:#a16207,color:#000
+    classDef gate fill:#fee2e2,stroke:#b91c1c,color:#000
+    classDef store fill:#dbeafe,stroke:#1e40af,color:#000
+    class Models,Triggers,MCPClients,Extension,External,Dashboard,OAuth external
+    class Policy gate
+    class Trace store
+```
+
+## How to read this
+
+The five primitives from the [canonical positioning sentence](../README.md) line up with the four boxes inside the **Patchwork Bridge Runtime** subgraph:
+
+| Sentence clause | Box | Why this box |
+|---|---|---|
+| *pluggable model providers* | (Model Providers ↔ Bridge) | Bridge is provider-agnostic; arrow direction is bidirectional because LLM round-trips can originate from either side |
+| *hot-reloadable tools* | Tool Registry | The `--plugin-watch` flag re-registers atomically on plugin file changes |
+| *YAML recipes* | Recipe Engine | RecipeOrchestrator + parser + scheduler |
+| *delegation policy with approval queue* | Delegation Policy (gate-shaped) | Every tool dispatch passes through this — it's a structural checkpoint, not a sidecar |
+| *durable trace memory* | Trace Memory (cylinder) | Three log files under `~/.patchwork/` plus the activity log under `~/.claude/ide/` |
+
+## Five things to notice
+
+1. **Every outbound action passes through the policy gate.** The arrow from Tool Registry to External Targets does *not* exist as a direct edge — it goes through Delegation Policy first. This is the structural invariant that makes "delegation policy" load-bearing rather than decorative. See [src/approvalHttp.ts](../src/approvalHttp.ts) for the implementation.
+
+2. **Trace Memory is the only multi-source sink.** Tool calls, policy decisions, and recipe runs all write to the same trace store. That's what makes [`patchwork traces export`](../src/commands/tracesExport.ts) a single bundle and what makes the (planned) Decision Replay Debugger possible.
+
+3. **Triggers are inputs, not outputs.** Cron, file save, git, test run, webhook, CLI, and the mobile PWA all enter at the same point — the Recipe Engine. The trigger surface is the *non-developer onboarding* story; recipes don't care which trigger fired them.
+
+4. **OAuth is optional and only gates one transport.** The bridge runs without `--issuer-url` and accepts WebSocket / stdio clients on the loopback interface only. OAuth activates the Streamable HTTP transport for remote MCP clients (claude.ai, the mobile PWA). See [src/oauth.ts](../src/oauth.ts).
+
+5. **The dashboard is a policy reader, not a separate brain.** Approval prompts come *from* the Delegation Policy (when a human nod is required) and decisions flow *back* into the Delegation Policy. The dashboard does not have its own approval state; it is a UI over the bridge's queue. See [src/approvalQueue.ts](../src/approvalQueue.ts) and [dashboard/src/app/approvals/](../dashboard/src/app/approvals/).
+
+## What's not in the diagram
+
+Things that exist but are deliberately omitted to keep the page legible:
+
+- **Per-language LSP fallbacks** (TypeScript LS, ctags, etc.) for when the IDE extension is disconnected.
+- **Plugin watcher** as a separate component — folded into Tool Registry.
+- **Session checkpoint / handoff** — operates orthogonally to this diagram.
+- **Connector OAuth flows** (Gmail, Slack, etc.) — separate from the bridge OAuth surface; lives inside the connector implementations.
+
+For the unabridged tour: [documents/data-reference.md](data-reference.md) and [documents/platform-docs.md](platform-docs.md).
+
+---
+
+## Layered view
+
+If the flowchart above is too dense, the same architecture in three layers:
+
+```mermaid
+flowchart TB
+    subgraph L1["1. Where requests come from"]
+        direction LR
+        T1[Triggers]
+        T2[MCP Clients]
+        T3[IDE Extension]
+    end
+
+    subgraph L2["2. The runtime"]
+        direction LR
+        Tools[Tool Registry]
+        Recipes[Recipe Engine]
+        Pol{{Delegation Policy}}
+        Mem[(Trace Memory)]
+    end
+
+    subgraph L3["3. What requests reach"]
+        direction LR
+        Models[Model Providers]
+        Ext[External Targets]
+        Dash[Dashboard / PWA]
+    end
+
+    L1 --> L2
+    L2 --> L3
+    L2 -. policy gate .-> L3
+```
+
+The compression is honest: every request enters at layer 1, every effect lands at layer 3, and layer 2 — *the runtime* — is the part that distinguishes Patchwork from each of the alternatives in [comparison.md](comparison.md).

--- a/documents/comparison.md
+++ b/documents/comparison.md
@@ -1,0 +1,119 @@
+# Patchwork OS vs. *
+
+> Honest tradeoffs against the closest alternatives. Pick the right tool — that may not always be Patchwork.
+
+Patchwork OS is a *local-first personal AI runtime* — pluggable model providers, hot-reloadable tools, YAML recipes, a delegation policy with approval queue, and a durable trace memory, all running on your machine. The four sections below contrast it with the categories users most often confuse it for.
+
+---
+
+## Patchwork OS vs. an MCP server
+
+**Short version:** an MCP server exposes tools to one model client. Patchwork is a runtime *around* the tool surface.
+
+| | MCP server | Patchwork OS |
+|---|---|---|
+| Tool catalogue | Yes | Yes (170+ built-in + plugins) |
+| Model providers | One (whatever called you) | Pluggable (Claude, GPT, Gemini, Grok, Ollama) |
+| Hot-reload tools | No | `--plugin-watch` re-registers atomically |
+| Trigger types | Tool call | Cron, file save, git, test run, webhook, CLI, mobile |
+| Policy gate | None | Three risk tiers, four-source precedence |
+| Trace log | None | `decision_traces.jsonl` + activity log + run history |
+| Distribution | Each server forks separately | Plugins as npm packages |
+
+Pointing an MCP client at a Patchwork bridge gets you all of the above without changing the client. Pointing it at a bare MCP server gets you a tool list. Patchwork *is* an MCP server — and a recipe runner, an approval gate, a trace store, a plugin host, a webhook receiver, and an OAuth provider.
+
+**Pick a plain MCP server when:** you only need to expose 1–10 tools to a single client and have no policy, lifecycle, or audit needs. Forking [@modelcontextprotocol/typescript-sdk](https://github.com/modelcontextprotocol/typescript-sdk) and shipping is the smaller footprint.
+
+**Pick Patchwork when:** you want any of policy, recipes, traces, hot-reload, multi-model, or webhook triggers without writing them yourself.
+
+---
+
+## Patchwork OS vs. Zapier / Make / n8n
+
+**Short version:** SaaS automation tools host your credentials, your data, and your workflows on their infrastructure. Patchwork runs on your machine.
+
+| | Zapier / Make / n8n cloud | Patchwork OS |
+|---|---|---|
+| Where credentials live | Their vault | Your OS keychain |
+| Where data flows through | Their infrastructure | Your process |
+| Pre-built integrations | 5,000+ (Zapier), 1,500+ (Make) | ~19 connectors |
+| Authoring UX | Polished GUI workflow builder | YAML files + CLI lint/test loop |
+| Trigger types | Webhooks, polling, schedule | Cron, file save, git, test run, webhook, CLI, mobile |
+| AI integration | Add-on (Zapier AI, Make AI) | First-class — every recipe step can call a model |
+| Pricing | Per-task / per-month | Free; you pay your model provider |
+| Audit log | Their dashboard | Your filesystem (JSONL you can grep) |
+
+The trade-off is honest: Zapier has a polished GUI and 5,000+ pre-built integrations; Patchwork has a smaller connector library, a CLI-first authoring loop, and zero data exfiltration. The right answer depends on **who you trust with your tokens** and how much you value the polished UX vs. owning the data flow.
+
+**Pick Zapier-class tools when:** you need the long tail of obscure SaaS connectors and don't want to write any code or YAML. The GUI authoring is genuinely a feature.
+
+**Pick Patchwork when:** you care about data residency, want recipes you can dotfile and version, or need an audit log no third party can rewrite.
+
+---
+
+## Patchwork OS vs. hosted AI assistants (ChatGPT plugins, Claude projects, Copilot Workspace)
+
+**Short version:** hosted assistants give you one model behind their UI with their tool catalogue and their policy. Patchwork inverts every part of that.
+
+| | Hosted assistants | Patchwork OS |
+|---|---|---|
+| Model | Theirs (one) | Yours (any) |
+| Tool catalogue | Theirs | Yours (170+ built-in + plugins) |
+| Policy | Theirs | Yours (`--approval-gate`, risk tiers, ccPermissions) |
+| Where tools execute | Their sandbox | Your machine |
+| Where credentials live | Their vault | Your OS keychain |
+| Memory | Their session store | Your `decision_traces.jsonl` + activity log |
+| Provider lock-in | Total | None — swap models with a config change |
+| Setup cost | Zero | Run `patchwork patchwork-init` |
+
+The cost is setup: you provision the runtime, you write the recipes, you wire the OAuth. The benefit is that swapping model providers is a config change, not a migration.
+
+**Pick a hosted assistant when:** you don't care about provider lock-in, you trust the vendor's policy as defaults, and you'd rather not run anything on your machine.
+
+**Pick Patchwork when:** you want to be able to leave any single model provider on a Tuesday afternoon without losing your tools, recipes, or history.
+
+---
+
+## Patchwork OS vs. local agent frameworks (LangGraph, AutoGPT, CrewAI, Open Interpreter)
+
+**Short version:** local agent frameworks are libraries — you write Python to compose chains. Patchwork is a runtime — you write YAML recipes, declare a policy, and call tools over MCP from any compatible client.
+
+| | LangGraph / AutoGPT / CrewAI / Open Interpreter | Patchwork OS |
+|---|---|---|
+| Authoring | Python code (or DSL) | YAML recipes + plugin manifests |
+| Composition primitive | Graph / chain / crew of agents | Recipes (steps + dependencies + triggers) |
+| Approval / policy | DIY (or absent) | Built-in (`--approval-gate`, risk tiers, four-source precedence) |
+| Observability | DIY (LangSmith etc. are SaaS add-ons) | Built-in (`decision_traces.jsonl`, dashboard, replay) |
+| Tool integration | Library calls inside the agent process | MCP — any compatible client can use the runtime |
+| Trigger surface | Whatever you wire | Cron, file save, git, test run, webhook, CLI, mobile |
+| Non-developer authoring | None — Python required | Webhook recipes + (planned) conversational builder |
+
+Agent frameworks excel at **programmatic orchestration** — when you need fine-grained control over a multi-step LLM workflow inside a Python service. Patchwork excels at **policy, observability, and access** — giving non-developers (via webhooks, mobile approvals, conversational recipe authoring) a way in without writing Python.
+
+**Pick a local agent framework when:** you're building a software product whose core feature is a complex LLM workflow, and you need code-level control over routing, retries, and state.
+
+**Pick Patchwork when:** the AI is a tool you and a small group use to do work, not a feature you ship to customers — and you want approval, audit, and trigger machinery you don't have to write yourself.
+
+---
+
+## When *not* to use Patchwork
+
+Be honest with yourself if any of these are you:
+
+- **You only need a chat UI.** ChatGPT, Claude.ai, or Copilot Chat will serve you better. Patchwork's leverage is in tools, recipes, and policy — none of which matter for a pure-chat use case.
+- **You don't run anything on your machine.** Patchwork is local-first. If you can't or won't run a process on your laptop / VPS, the whole value proposition collapses to "an MCP server you self-host," which is real but smaller.
+- **You need 50+ third-party integrations.** Patchwork has ~19 connectors. The plugin model lets you add more, but if you need everything Zapier has on day one, Zapier is the right answer.
+- **You're shipping a customer-facing AI product.** Patchwork is a runtime for *you*, not infrastructure to embed in a SaaS. LangGraph, the OpenAI Assistants API, or building on raw model APIs are better starting points.
+
+---
+
+## Where Patchwork is unusual
+
+The architecture choice that distinguishes Patchwork is composing five primitives — tools, recipes, delegation policy, trace memory, OAuth — into one runtime instead of separate boxes. The closest analogues each pick a subset:
+
+- MCP servers ship tools without recipes, policy, or memory.
+- Zapier ships recipes and a partial policy without your model choice or your trust boundary.
+- Hosted assistants ship a model and tools without your policy, your memory, or your trigger surface.
+- Agent frameworks ship the orchestration primitive without the policy, the audit, or the non-developer authoring path.
+
+If you've ever needed two of those at once and ended up gluing them together, Patchwork is the consolidation. If you only ever need one, use the better-specialized alternative.


### PR DESCRIPTION
## Summary

Closes the remaining work from the [Positioning agent's report](docs/strategic/2026-05-02/positioning-report.md) sections 4-6, queued after the canonical sentence landed in #131. All three pieces were drafted by the agent and verified against repo state in section 2 of that report; this PR translates them into real files.

## Three artifacts

| Artifact | What |
|---|---|
| README — five-primitive expansion | Bulleted breakdown of Tools / Recipes / Delegation Policy / Trace Memory / OAuth with one verified-feature claim per bullet. Callout box pointing at the new comparison + architecture docs. |
| [documents/comparison.md](documents/comparison.md) (new) | Patchwork vs MCP server / Zapier / hosted assistants / local agent frameworks. Honest-tradeoff tables + explicit \"pick X when...\" paragraphs per section. Includes a \"When NOT to use Patchwork\" section. |
| [documents/architecture.md](documents/architecture.md) (new) | Mermaid flowchart rendering the agent's section-6 spec. Eight external surfaces around four internal subsystems. Every outbound action passes through the policy gate; trace memory is the only multi-source sink. Plus mapping table linking each canonical-sentence clause to a box, \"Five things to notice\" structural invariants, layered three-row variant. |

## Why one PR

The three artifacts cross-reference each other. Splitting into three PRs would require strict ordering with broken links in between, or stubbing forward references — worse than one merged review.

## Anti-scope

- Does NOT change the canonical positioning sentence (#131 owns that).
- Does NOT add a screencast / launch demo GIF.
- Does NOT touch the dual-mode \"two ways to use it\" framing — preserved as-is below the new content.

## Test plan

- [ ] CI green (no code changes; only docs)
- [ ] Manual: render README on GitHub — hero + canonical + five-primitive list + callout box read cleanly
- [ ] Manual: render comparison.md and architecture.md on GitHub — Mermaid renders correctly, tables render correctly, all cross-links resolve
- [ ] Manual: scan for any unverified claim — every \"Patchwork has X\" should map to an existing file path or a previously-merged PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)