### PR TITLE
feat(approval-signals): passive risk personalization — heuristics 1-3 from the agent catalog

### DIFF
--- a/src/__tests__/approvalHttp.test.ts
+++ b/src/__tests__/approvalHttp.test.ts
@@ -546,6 +546,83 @@ describe("routeApprovalRequest", () => {
       // callId is the queue-path-specific extra
       expect(typeof events[0].callId).toBe("string");
     });
+
+    it("propagates personalSignals onto queued PendingApproval when ActivityLog is wired", async () => {
+      // Pre-populate the activity log so the prior_approvals heuristic
+      // fires (≥ 3 past approvals on the same tool). Then drive the
+      // queue path and confirm queue.list() includes the signal.
+      const { ActivityLog } = await import("../activityLog.js");
+      const activityLog = new ActivityLog();
+      for (let i = 0; i < 4; i++) {
+        activityLog.recordEvent("approval_decision", {
+          toolName: "Bash",
+          decision: "allow",
+        });
+      }
+
+      const queue = new ApprovalQueue();
+      const promise = routeApprovalRequest(
+        {
+          method: "POST",
+          path: "/approvals",
+          body: {
+            toolName: "Bash",
+            params: { command: "ls" },
+            sessionId: "s-personal",
+          },
+        },
+        {
+          queue,
+          workspace: "/tmp",
+          ccLoader: emptyRules(),
+          approvalGate: "all",
+          activityLog,
+        },
+      );
+
+      await new Promise((r) => setTimeout(r, 10));
+      const items = queue.list();
+      expect(items).toHaveLength(1);
+      expect(items[0]?.personalSignals).toBeDefined();
+      const priorApprovals = items[0]?.personalSignals?.find(
+        (s) => s.kind === "prior_approvals",
+      );
+      expect(priorApprovals).toBeDefined();
+      expect(priorApprovals?.count).toBe(4);
+
+      // Resolve so the test doesn't hang.
+      const callId = items[0]?.callId;
+      if (callId) queue.approve(callId);
+      await promise;
+    });
+
+    it("does not include personalSignals when no ActivityLog is wired", async () => {
+      // The integration is opt-in by deps. Tests that don't wire an
+      // ActivityLog must still see the queue without a personalSignals
+      // field — confirms the integration is non-breaking.
+      const queue = new ApprovalQueue();
+      const promise = routeApprovalRequest(
+        {
+          method: "POST",
+          path: "/approvals",
+          body: { toolName: "Bash", params: {} },
+        },
+        {
+          queue,
+          workspace: "/tmp",
+          ccLoader: emptyRules(),
+          approvalGate: "all",
+        },
+      );
+      await new Promise((r) => setTimeout(r, 10));
+      const items = queue.list();
+      expect(items).toHaveLength(1);
+      expect(items[0]?.personalSignals).toBeUndefined();
+
+      const callId = items[0]?.callId;
+      if (callId) queue.approve(callId);
+      await promise;
+    });
   });
 
   it("unknown route → 404", async () => {

--- a/src/__tests__/approvalSignals.test.ts
+++ b/src/__tests__/approvalSignals.test.ts
@@ -1,0 +1,261 @@
+import { describe, expect, it } from "vitest";
+// Importing the tools index for its side-effect: it registers all
+// built-in tools (including the connector-flagged ones like gmail.*,
+// linear.*, slack.*) into the toolRegistry that
+// isConnectorNamespace consults. Without this, every connector test
+// falls back to the "first_tool_use" branch.
+import "../recipes/tools/index.js";
+import { ActivityLog } from "../activityLog.js";
+import { computePersonalSignals } from "../approvalSignals.js";
+
+/**
+ * Convenience helper — feed N approval_decision lifecycle rows for a
+ * given tool/decision pair into a fresh ActivityLog. The signal-
+ * computation path is the same one a real approval would walk; this
+ * just bypasses the HTTP handler.
+ */
+function logWithApprovals(
+  rows: Array<{ toolName: string; decision: "allow" | "deny" }>,
+): ActivityLog {
+  const log = new ActivityLog();
+  for (const r of rows) {
+    log.recordEvent("approval_decision", {
+      toolName: r.toolName,
+      decision: r.decision,
+    });
+  }
+  return log;
+}
+
+describe("computePersonalSignals", () => {
+  describe("heuristic 1 — prior approvals", () => {
+    it("does not surface below the 3-approval threshold", () => {
+      const log = logWithApprovals([
+        { toolName: "Bash", decision: "allow" },
+        { toolName: "Bash", decision: "allow" },
+      ]);
+      const signals = computePersonalSignals({
+        toolName: "Bash",
+        activityLog: log,
+      });
+      expect(signals.find((s) => s.kind === "prior_approvals")).toBeUndefined();
+    });
+
+    it("surfaces at exactly 3 approvals", () => {
+      const log = logWithApprovals([
+        { toolName: "Bash", decision: "allow" },
+        { toolName: "Bash", decision: "allow" },
+        { toolName: "Bash", decision: "allow" },
+      ]);
+      const signals = computePersonalSignals({
+        toolName: "Bash",
+        activityLog: log,
+      });
+      const sig = signals.find((s) => s.kind === "prior_approvals");
+      expect(sig).toBeDefined();
+      expect(sig?.count).toBe(3);
+      expect(sig?.severity).toBe("low");
+      expect(sig?.source).toBe("approval_history");
+    });
+
+    it("does not include rejections in the approval count", () => {
+      const log = logWithApprovals([
+        { toolName: "Bash", decision: "allow" },
+        { toolName: "Bash", decision: "allow" },
+        { toolName: "Bash", decision: "deny" }, // not counted
+        { toolName: "Bash", decision: "deny" },
+      ]);
+      const signals = computePersonalSignals({
+        toolName: "Bash",
+        activityLog: log,
+      });
+      expect(signals.find((s) => s.kind === "prior_approvals")).toBeUndefined();
+    });
+
+    it("does not include other tools", () => {
+      const log = logWithApprovals([
+        { toolName: "Read", decision: "allow" },
+        { toolName: "Read", decision: "allow" },
+        { toolName: "Read", decision: "allow" },
+      ]);
+      const signals = computePersonalSignals({
+        toolName: "Bash",
+        activityLog: log,
+      });
+      expect(signals.find((s) => s.kind === "prior_approvals")).toBeUndefined();
+    });
+
+    it("upgrades the label phrasing past 100 approvals", () => {
+      const rows = Array.from({ length: 105 }, () => ({
+        toolName: "Bash",
+        decision: "allow" as const,
+      }));
+      const log = logWithApprovals(rows);
+      const signals = computePersonalSignals({
+        toolName: "Bash",
+        activityLog: log,
+      });
+      const sig = signals.find((s) => s.kind === "prior_approvals");
+      expect(sig?.label).toMatch(/well-trusted/);
+      expect(sig?.count).toBe(105);
+    });
+  });
+
+  describe("heuristic 2 — prior rejections", () => {
+    it("surfaces at any prior rejection (≥ 1)", () => {
+      const log = logWithApprovals([{ toolName: "gitPush", decision: "deny" }]);
+      const signals = computePersonalSignals({
+        toolName: "gitPush",
+        activityLog: log,
+      });
+      const sig = signals.find((s) => s.kind === "prior_rejection");
+      expect(sig).toBeDefined();
+      expect(sig?.severity).toBe("medium"); // single rejection
+      expect(sig?.count).toBe(1);
+    });
+
+    it("escalates to high severity at ≥ 2 rejections", () => {
+      const log = logWithApprovals([
+        { toolName: "gitPush", decision: "deny" },
+        { toolName: "gitPush", decision: "deny" },
+      ]);
+      const signals = computePersonalSignals({
+        toolName: "gitPush",
+        activityLog: log,
+      });
+      const sig = signals.find((s) => s.kind === "prior_rejection");
+      expect(sig?.severity).toBe("high");
+      expect(sig?.count).toBe(2);
+      expect(sig?.label).toMatch(/recurring pattern/);
+    });
+
+    it("does not surface when prior decisions were all allows", () => {
+      const log = logWithApprovals([
+        { toolName: "Bash", decision: "allow" },
+        { toolName: "Bash", decision: "allow" },
+        { toolName: "Bash", decision: "allow" },
+      ]);
+      const signals = computePersonalSignals({
+        toolName: "Bash",
+        activityLog: log,
+      });
+      expect(signals.find((s) => s.kind === "prior_rejection")).toBeUndefined();
+    });
+
+    it("co-exists with prior_approvals when the user both approved and rejected", () => {
+      const log = logWithApprovals([
+        { toolName: "Bash", decision: "allow" },
+        { toolName: "Bash", decision: "allow" },
+        { toolName: "Bash", decision: "allow" },
+        { toolName: "Bash", decision: "deny" },
+      ]);
+      const signals = computePersonalSignals({
+        toolName: "Bash",
+        activityLog: log,
+      });
+      // Both heuristics should fire — the user's history is genuinely
+      // mixed and the modal should show both signals so the human sees
+      // the full picture, not just the most-recent decision.
+      expect(signals.find((s) => s.kind === "prior_approvals")).toBeDefined();
+      expect(signals.find((s) => s.kind === "prior_rejection")).toBeDefined();
+    });
+  });
+
+  describe("heuristic 3 — first connector / first tool use", () => {
+    it("flags first connector use with high severity for known connector namespaces", () => {
+      const log = new ActivityLog();
+      // No prior gmail.* activity.
+      const signals = computePersonalSignals({
+        toolName: "gmail.fetch_unread",
+        activityLog: log,
+      });
+      const sig = signals.find((s) => s.kind === "first_connector_use");
+      expect(sig).toBeDefined();
+      expect(sig?.severity).toBe("high");
+      expect(sig?.label).toMatch(/gmail connector/);
+    });
+
+    it("does not flag connector use when prior namespace activity exists", () => {
+      const log = new ActivityLog();
+      log.record("gmail.fetch_unread", 100, "success");
+      const signals = computePersonalSignals({
+        toolName: "gmail.send",
+        activityLog: log,
+      });
+      expect(
+        signals.find((s) => s.kind === "first_connector_use"),
+      ).toBeUndefined();
+    });
+
+    it("flags first_tool_use for unknown namespace (low severity)", () => {
+      const log = new ActivityLog();
+      const signals = computePersonalSignals({
+        toolName: "myCustom.doThing",
+        activityLog: log,
+      });
+      const sig = signals.find((s) => s.kind === "first_tool_use");
+      expect(sig).toBeDefined();
+      expect(sig?.severity).toBe("low");
+      expect(sig?.label).toMatch(/myCustom/);
+    });
+
+    it("does not flag for top-level (non-namespaced) tools — those would fire on every fresh session", () => {
+      const log = new ActivityLog();
+      const signals = computePersonalSignals({
+        toolName: "Bash",
+        activityLog: log,
+      });
+      expect(
+        signals.find(
+          (s) =>
+            s.kind === "first_connector_use" || s.kind === "first_tool_use",
+        ),
+      ).toBeUndefined();
+    });
+  });
+
+  describe("composition", () => {
+    it("returns an empty array for an empty log + non-namespaced tool", () => {
+      const signals = computePersonalSignals({
+        toolName: "Bash",
+        activityLog: new ActivityLog(),
+      });
+      expect(signals).toEqual([]);
+    });
+
+    it("returns multiple signals when multiple heuristics fire", () => {
+      const log = new ActivityLog();
+      // Three prior approvals + zero prior gmail.* activity.
+      for (let i = 0; i < 3; i++) {
+        log.recordEvent("approval_decision", {
+          toolName: "gmail.send",
+          decision: "allow",
+        });
+      }
+      const signals = computePersonalSignals({
+        toolName: "gmail.send",
+        activityLog: log,
+      });
+      // prior_approvals fires (3 ≥ threshold); first_connector_use does
+      // NOT fire (the recorded items are LIFECYCLE rows, not activity
+      // rows — so queryByNamespace returns empty even though there are
+      // prior approvals). This is intentional: connector novelty tracks
+      // tool execution, not approval decisions.
+      expect(signals.find((s) => s.kind === "prior_approvals")).toBeDefined();
+      expect(
+        signals.find((s) => s.kind === "first_connector_use"),
+      ).toBeDefined();
+    });
+
+    it("is idempotent — calling twice with the same inputs returns the same signals", () => {
+      const log = logWithApprovals([
+        { toolName: "Bash", decision: "allow" },
+        { toolName: "Bash", decision: "allow" },
+        { toolName: "Bash", decision: "allow" },
+      ]);
+      const a = computePersonalSignals({ toolName: "Bash", activityLog: log });
+      const b = computePersonalSignals({ toolName: "Bash", activityLog: log });
+      expect(b).toEqual(a);
+    });
+  });
+});

--- a/src/activityLog.ts
+++ b/src/activityLog.ts
@@ -337,6 +337,52 @@ export class ActivityLog {
     return matches.slice(-limit);
   }
 
+  /**
+   * Cross-session query for approval-decision lifecycle rows. Used by the
+   * passive risk personalization signals (`src/approvalSignals.ts`) to
+   * answer questions like "how many times has the user approved this tool
+   * before?" without paying the cost of `queryTimeline`'s combined-sort.
+   *
+   * Filters honored:
+   *   - `toolName` — match `metadata.toolName` exactly
+   *   - `decision` — match `metadata.decision` ("allow" | "deny")
+   *   - `last`     — return at most this many most-recent matches (cap 1000)
+   *
+   * Returns rows ordered oldest → newest (the natural append order of the
+   * lifecycle log) so callers can compute counts or "last decision" cheaply.
+   */
+  queryApprovalDecisions(opts?: {
+    toolName?: string;
+    decision?: string;
+    last?: number;
+  }): LifecycleEntry[] {
+    const matches: LifecycleEntry[] = [];
+    for (const e of this.lifecycleEntries) {
+      if (e.event !== "approval_decision") continue;
+      if (opts?.toolName && e.metadata?.toolName !== opts.toolName) continue;
+      if (opts?.decision && e.metadata?.decision !== opts.decision) continue;
+      matches.push(e);
+    }
+    const last = Math.min(opts?.last ?? 1000, 1000);
+    return matches.slice(-last);
+  }
+
+  /**
+   * Cross-session query for tool entries by namespace prefix (e.g. "gmail"
+   * matches "gmail.fetch_unread", "gmail.send"). Used by personalization
+   * heuristic 3 ("first use of this connector") to detect whether the
+   * connector has been used before. Cap at 1000 most-recent matches.
+   */
+  queryByNamespace(namespace: string, last = 1000): ActivityEntry[] {
+    const prefix = `${namespace}.`;
+    const matches: ActivityEntry[] = [];
+    for (const e of this.entries) {
+      if (e.tool && e.tool.startsWith(prefix)) matches.push(e);
+    }
+    const cap = Math.min(last, 1000);
+    return matches.slice(-cap);
+  }
+
   queryTimeline(opts?: { last?: number }): TimelineEntry[] {
     const tools: TimelineEntry[] = this.entries.map((e) => ({
       kind: "tool" as const,

--- a/src/approvalHttp.ts
+++ b/src/approvalHttp.ts
@@ -63,6 +63,14 @@ export interface ApprovalHttpDeps {
   pushServiceToken?: string;
   /** Public base URL of this bridge (e.g. https://mybridge.example.com). Embedded in push payload as callback base. */
   pushServiceBaseUrl?: string;
+  /**
+   * Optional ActivityLog used to compute passive risk personalization
+   * signals (`src/approvalSignals.ts`). When omitted, personalSignals are
+   * not computed and the queue entry simply has `personalSignals: undefined` —
+   * the rest of the approval flow is unaffected. Tests that care only about
+   * the policy-engine path can leave this off.
+   */
+  activityLog?: import("./activityLog.js").ActivityLog;
 }
 
 export interface HttpRequest {
@@ -635,9 +643,27 @@ async function handleApprovalRequest(
     };
   }
 
+  // Personal signals — passive risk personalization. Only computed when
+  // an ActivityLog is wired up; tests / minimal harnesses leave it
+  // undefined. See src/approvalSignals.ts for the catalog.
+  const personalSignals = deps.activityLog
+    ? (await import("./approvalSignals.js")).computePersonalSignals({
+        toolName,
+        activityLog: deps.activityLog,
+      })
+    : undefined;
+
   const now = Date.now();
   const { callId, approvalToken, promise } = deps.queue.request(
-    { toolName, params, tier, summary, sessionId, riskSignals },
+    {
+      toolName,
+      params,
+      tier,
+      summary,
+      sessionId,
+      riskSignals,
+      ...(personalSignals && personalSignals.length > 0 && { personalSignals }),
+    },
     { withToken: !!deps.pushServiceUrl },
   );
   recordApprovalPrompted();

--- a/src/approvalQueue.ts
+++ b/src/approvalQueue.ts
@@ -33,6 +33,15 @@ export interface PendingApproval {
   sessionId?: string;
   summary?: string;
   riskSignals?: RiskSignal[];
+  /**
+   * Passive risk personalization signals (`src/approvalSignals.ts`).
+   * Distinct from `riskSignals`: those describe call CONTENT (rm -rf,
+   * non-HTTPS URL); these describe the user's RELATIONSHIP to the tool
+   * (prior approvals, prior rejections, first-time use). Both should
+   * reach the dashboard approval modal. Omitted when no signals fire
+   * to keep the lifecycle/wire payload small.
+   */
+  personalSignals?: import("./approvalSignals.js").PersonalSignal[];
   /** 256-bit hex token for phone-path approve/reject. Only present when push is configured. */
   approvalToken?: string;
 }
@@ -211,6 +220,7 @@ export class ApprovalQueue {
       sessionId: e.sessionId,
       summary: e.summary,
       riskSignals: e.riskSignals,
+      personalSignals: e.personalSignals,
       // approvalToken intentionally omitted from list — never expose to untrusted callers
     }));
   }

--- a/src/approvalSignals.ts
+++ b/src/approvalSignals.ts
@@ -1,0 +1,149 @@
+/**
+ * approvalSignals — passive risk personalization for the approval queue.
+ *
+ * Computes user-specific signals based on past approval / activity history.
+ * These supplement (not replace) the policy-engine `riskSignals` which are
+ * computed from the call's CONTENT (params shape, destructive flags, etc.).
+ *
+ * Personal signals describe the user's RELATIONSHIP to this tool/call:
+ * "you approved this 27 times" is a different signal class from "this
+ * command contains rm -rf". Both should reach the approval modal.
+ *
+ * Catalog (from docs/strategic/2026-05-02/memory-ecosystem-report.md §5):
+ * three of the twelve heuristics shipped here. Heuristics 4-12 follow.
+ *
+ *   1. "You approved similar actions N times" — past allow on same tool
+ *   2. "You rejected this tool before" — past deny on same tool
+ *   3. "First use of this connector" — connector namespace ∩ activity log
+ *
+ * The signals are **transparent**: every signal has a `source` enum so a
+ * future "why is this signal here?" UI can link back to the rows that
+ * produced it. We do not infer; we count and match. No model, no
+ * fine-tuning. Honesty is the value proposition.
+ *
+ * Privacy: signals are computed locally over local logs. They flow into
+ * the approval queue's PendingApproval shape, which is exposed via
+ * GET /approvals (bearer-auth-gated) and the SSE stream (same auth).
+ * Nothing leaves the machine.
+ */
+
+import type { ActivityLog } from "./activityLog.js";
+import { isConnectorNamespace } from "./recipes/toolRegistry.js";
+
+export interface PersonalSignal {
+  kind:
+    | "prior_approvals"
+    | "prior_rejection"
+    | "first_connector_use"
+    | "first_tool_use";
+  /** Human-facing label suitable for an approval modal line. */
+  label: string;
+  /** Severity controls visual weight. low = informational, high = warning. */
+  severity: "low" | "medium" | "high";
+  /** Source identifier so the UI can link the signal back to its evidence. */
+  source: "approval_history" | "activity_history" | "tool_registry";
+  /** Optional numeric backing the label, surfaced in tooltips / counts. */
+  count?: number;
+}
+
+/**
+ * Threshold under which heuristic 1 ("you approved this N times") does
+ * not surface. With < 3 prior approvals the signal is noise — it could
+ * be the first three exploratory calls a user always rubber-stamps. ≥ 3
+ * is "you have a pattern here."
+ */
+const PRIOR_APPROVALS_THRESHOLD = 3;
+
+/**
+ * Compute the personal-signal set for an incoming approval request.
+ *
+ * Pure function over the activity log; no I/O of its own. Tested in
+ * isolation by feeding a mock ActivityLog. The activityLog argument is
+ * passed positionally rather than wired through deps so the surface
+ * stays inspectable.
+ */
+export function computePersonalSignals(input: {
+  toolName: string;
+  activityLog: ActivityLog;
+}): PersonalSignal[] {
+  const { toolName, activityLog } = input;
+  if (!toolName) return [];
+
+  const signals: PersonalSignal[] = [];
+
+  // Heuristic 1: "You approved this N times before."
+  // Surface only when count crosses PRIOR_APPROVALS_THRESHOLD so we don't
+  // flag every second call. Cap the message at three buckets for legibility.
+  const priorApprovals = activityLog.queryApprovalDecisions({
+    toolName,
+    decision: "allow",
+  });
+  if (priorApprovals.length >= PRIOR_APPROVALS_THRESHOLD) {
+    signals.push({
+      kind: "prior_approvals",
+      label: priorApprovalsLabel(priorApprovals.length),
+      severity: "low",
+      source: "approval_history",
+      count: priorApprovals.length,
+    });
+  }
+
+  // Heuristic 2: "You rejected this tool before."
+  // Any prior rejection is signal — explicit rejections are rare and
+  // intentional. Severity scales with how recent and how many.
+  const priorRejections = activityLog.queryApprovalDecisions({
+    toolName,
+    decision: "deny",
+  });
+  if (priorRejections.length > 0) {
+    signals.push({
+      kind: "prior_rejection",
+      label: priorRejectionLabel(priorRejections.length),
+      severity: priorRejections.length >= 2 ? "high" : "medium",
+      source: "approval_history",
+      count: priorRejections.length,
+    });
+  }
+
+  // Heuristic 3: "First use of this connector" / "first use of this tool".
+  // For namespaced tool ids only (`namespace.subtool` shape). Two flavors:
+  //   - If the namespace is in the connector registry → "first connector use"
+  //     (high salience: connectors hit external services with credentials).
+  //   - Otherwise, plain "first use" with low salience.
+  // We require a namespaced tool id so we don't flag every CLI tool ever
+  // called with no prior history (which would fire on every fresh session).
+  const namespace = toolName.split(".")[0];
+  if (namespace && namespace !== toolName) {
+    const priorInNamespace = activityLog.queryByNamespace(namespace, 50);
+    if (priorInNamespace.length === 0) {
+      const isConnector = isConnectorNamespace(namespace);
+      signals.push({
+        kind: isConnector ? "first_connector_use" : "first_tool_use",
+        label: isConnector
+          ? `First use of the ${namespace} connector — credentials and external calls about to fire.`
+          : `First use of any ${namespace}.* tool in this workspace.`,
+        severity: isConnector ? "high" : "low",
+        source: "activity_history",
+      });
+    }
+  }
+
+  return signals;
+}
+
+function priorApprovalsLabel(count: number): string {
+  if (count >= 100) {
+    return `You've approved this tool ${count}+ times — well-trusted in your workflow.`;
+  }
+  if (count >= 20) {
+    return `You've approved this tool ${count} times before.`;
+  }
+  return `You've approved this tool ${count} times before.`;
+}
+
+function priorRejectionLabel(count: number): string {
+  if (count === 1) {
+    return "You rejected this tool once before — context may have changed since.";
+  }
+  return `You've rejected this tool ${count} times before — recurring pattern of caution.`;
+}


### PR DESCRIPTION
## Summary

Ships the first 3 of 12 heuristics from [memory-ecosystem-report.md §5](docs/strategic/2026-05-02/memory-ecosystem-report.md). The remaining 9 follow as 1-day PRs each — the wire shape is append-only, so each future heuristic is a single new \`kind\` enum value + computation block.

| # | Heuristic | Surfaces when |
|---|---|---|
| 1 | \"You approved this tool N times before.\" | ≥ 3 prior approvals (low severity) |
| 2 | \"You rejected this tool before.\" | any prior rejection (medium; high if ≥ 2) |
| 3 | \"First use of this connector / tool.\" | namespaced tool, no prior activity (connector → high; tool → low) |

## Why these three first

- All depend only on data PR #126 already shipped (approval-input capture). Zero prerequisite work.
- They cover the three most common \"should I be cautious here\" questions a real user asks.
- Together they exercise both the approval-decision history (1, 2) and the activity-tool history (3) — validates the query path on each side.

## Architecture

| File | Role |
|---|---|
| [src/approvalSignals.ts](src/approvalSignals.ts) (new) | \`computePersonalSignals({toolName, activityLog})\` — pure function returning \`PersonalSignal[]\` |
| [src/activityLog.ts](src/activityLog.ts) | Two new queries: \`queryApprovalDecisions\` (heuristics 1+2), \`queryByNamespace\` (heuristic 3) |
| [src/approvalHttp.ts](src/approvalHttp.ts) | Optional \`activityLog\` dep; lazy-imports \`computePersonalSignals\` and threads result into queue |
| [src/approvalQueue.ts](src/approvalQueue.ts) | \`PendingApproval\` gains \`personalSignals?: PersonalSignal[]\`; \`list()\` propagates |

## Why personal signals are distinct from riskSignals

- **\`riskSignals\`** = call CONTENT (\`rm -rf\`, non-HTTPS URL, path-escape). Identical for every user.
- **\`personalSignals\`** = user's RELATIONSHIP to this call (history, novelty). Different per-user.

Keeping them separate lets the dashboard render with appropriate visual hierarchy: content risk → warning, history → informational.

## Privacy + transparency

Signals computed locally over local logs. Flow into queue \`PendingApproval\` exposed via \`GET /approvals\` (bearer-auth-gated). Nothing leaves the machine. Every signal carries a \`source\` field (\"approval_history\", \"activity_history\", \"tool_registry\") so a future \"why this signal?\" UI can link back to the rows.

## Anti-scope

- No dashboard UI rendering — data shape ships first, UI is a follow-up
- No heuristics 4-12 from the catalog
- No Decision Replay Debugger integration (separate design doc in #134)

## Tests

**16 cases** in [src/__tests__/approvalSignals.test.ts](src/__tests__/approvalSignals.test.ts):

- 5 cases for heuristic 1 (threshold, decision filter, tool isolation, label upgrades)
- 4 cases for heuristic 2 (single → medium, ≥ 2 → high, allow-only baseline, co-existence with 1)
- 4 cases for heuristic 3 (connector, prior activity guards, unknown namespace, top-level guard)
- 3 composition cases (empty, multi-heuristic, idempotence)

**2 integration cases** in [approvalHttp.test.ts](src/__tests__/approvalHttp.test.ts):

- personalSignals propagate onto \`queue.list()\` when ActivityLog wired
- Absent ActivityLog is non-breaking

**Full suite: 4696/4696 passing.**

## Test plan

- [ ] CI green
- [ ] Manual: trigger ≥ 3 approvals on a tool, then approve again — confirm \`personalSignals\` shows up in \`GET /approvals\` response
- [ ] Manual: reject a tool, approve a different one — confirm prior_rejection shows on the rejected tool only
- [ ] Manual: call a fresh connector tool (e.g. first \`gmail.*\` call this session) — confirm \`first_connector_use\` with high severity

🤖 Generated with [Claude Code](https://claude.com/claude-code)