### PR TITLE
feat(approval-signals): heuristic 7 — risk tier escalation

### DIFF
--- a/src/__tests__/approvalSignals.test.ts
+++ b/src/__tests__/approvalSignals.test.ts
@@ -316,4 +316,107 @@ describe("computePersonalSignals", () => {
       expect(b).toEqual(a);
     });
   });
+
+  describe("heuristic 7 — risk tier escalation", () => {
+    function logWithTieredAllows(tiers: Array<"low" | "medium" | "high">) {
+      const log = new ActivityLog();
+      for (const tier of tiers) {
+        log.recordEvent("approval_decision", {
+          toolName: "anyTool",
+          decision: "allow",
+          tier,
+        });
+      }
+      return log;
+    }
+
+    it("does not surface below the 5-sample baseline", () => {
+      const log = logWithTieredAllows(["low", "low", "low"]);
+      const signals = computePersonalSignals({
+        toolName: "Bash",
+        activityLog: log,
+        currentTier: "high",
+      });
+      expect(signals.find((s) => s.kind === "tier_escalation")).toBeUndefined();
+    });
+
+    it("does not surface when current tier matches the baseline", () => {
+      const log = logWithTieredAllows(["low", "low", "low", "low", "low"]);
+      const signals = computePersonalSignals({
+        toolName: "Bash",
+        activityLog: log,
+        currentTier: "low",
+      });
+      expect(signals.find((s) => s.kind === "tier_escalation")).toBeUndefined();
+    });
+
+    it("surfaces with medium severity on a 1-tier jump (low baseline → medium)", () => {
+      const log = logWithTieredAllows(["low", "low", "low", "low", "low"]);
+      const signals = computePersonalSignals({
+        toolName: "Bash",
+        activityLog: log,
+        currentTier: "medium",
+      });
+      const sig = signals.find((s) => s.kind === "tier_escalation");
+      expect(sig).toBeDefined();
+      expect(sig?.severity).toBe("medium");
+      expect(sig?.label).toMatch(/usually approve low/);
+      expect(sig?.label).toMatch(/medium/);
+    });
+
+    it("surfaces with high severity on a 2-tier jump (low baseline → high)", () => {
+      const log = logWithTieredAllows(["low", "low", "low", "low", "low"]);
+      const signals = computePersonalSignals({
+        toolName: "Bash",
+        activityLog: log,
+        currentTier: "high",
+      });
+      const sig = signals.find((s) => s.kind === "tier_escalation");
+      expect(sig?.severity).toBe("high");
+    });
+
+    it("uses the median, not the max, of recent tiers", () => {
+      const log = logWithTieredAllows([
+        "low",
+        "low",
+        "low",
+        "low",
+        "low",
+        "high",
+      ]);
+      const signals = computePersonalSignals({
+        toolName: "Bash",
+        activityLog: log,
+        currentTier: "medium",
+      });
+      const sig = signals.find((s) => s.kind === "tier_escalation");
+      expect(sig).toBeDefined(); // baseline=low (median), current=medium → escalation
+    });
+
+    it("ignores rejections when computing baseline", () => {
+      const log = new ActivityLog();
+      for (let i = 0; i < 5; i++) {
+        log.recordEvent("approval_decision", {
+          toolName: "x",
+          decision: "deny",
+          tier: "low",
+        });
+      }
+      const signals = computePersonalSignals({
+        toolName: "Bash",
+        activityLog: log,
+        currentTier: "high",
+      });
+      expect(signals.find((s) => s.kind === "tier_escalation")).toBeUndefined();
+    });
+
+    it("is silent when currentTier is omitted", () => {
+      const log = logWithTieredAllows(["low", "low", "low", "low", "low"]);
+      const signals = computePersonalSignals({
+        toolName: "Bash",
+        activityLog: log,
+      });
+      expect(signals.find((s) => s.kind === "tier_escalation")).toBeUndefined();
+    });
+  });
 });

--- a/src/approvalHttp.ts
+++ b/src/approvalHttp.ts
@@ -661,6 +661,7 @@ async function handleApprovalRequest(
     ? computePersonalSignals({
         toolName,
         activityLog: deps.activityLog,
+        currentTier: tier,
       })
     : undefined;
 

--- a/src/approvalSignals.ts
+++ b/src/approvalSignals.ts
@@ -17,6 +17,8 @@
  *   3. "First use of this connector" — connector namespace ∩ activity log
  *   5. "Last called T days ago" — gap since most recent call (heuristic 4
  *      from the catalog is satisfied by the first_connector_use kind above)
+ *   7. "Risk tier escalation" — current tier exceeds the user's typical
+ *      approved tier across recent decisions
  *
  * The signals are **transparent**: every signal has a `source` enum so a
  * future "why is this signal here?" UI can link back to the rows that
@@ -31,6 +33,7 @@
 
 import type { ActivityLog } from "./activityLog.js";
 import { isConnectorNamespace } from "./recipes/toolRegistry.js";
+import type { RiskTier } from "./riskTier.js";
 
 export interface PersonalSignal {
   kind:
@@ -38,7 +41,8 @@ export interface PersonalSignal {
     | "prior_rejection"
     | "first_connector_use"
     | "first_tool_use"
-    | "stale_tool_use";
+    | "stale_tool_use"
+    | "tier_escalation";
   /** Human-facing label suitable for an approval modal line. */
   label: string;
   /** Severity controls visual weight. low = informational, high = warning. */
@@ -69,6 +73,16 @@ const STALE_TOOL_MS = STALE_TOOL_DAYS * 24 * 60 * 60 * 1_000;
 const STALE_TOOL_HIGH_DAYS = 30;
 
 /**
+ * Minimum prior-allow decisions needed to establish a "typical tier"
+ * baseline for heuristic 7. Below this we don't claim to know the user's
+ * pattern — first few approvals could be anything. 5 is small but enough
+ * to make a single outlier not dominate.
+ */
+const TIER_BASELINE_MIN_SAMPLES = 5;
+
+const TIER_RANK: Record<RiskTier, number> = { low: 0, medium: 1, high: 2 };
+
+/**
  * Compute the personal-signal set for an incoming approval request.
  *
  * Pure function over the activity log; no I/O of its own. Tested in
@@ -79,8 +93,14 @@ const STALE_TOOL_HIGH_DAYS = 30;
 export function computePersonalSignals(input: {
   toolName: string;
   activityLog: ActivityLog;
+  /**
+   * Risk tier of the *current* call, used by heuristic 7. Optional —
+   * pre-#126 callers and the test fixtures that omit it simply skip
+   * tier-escalation evaluation.
+   */
+  currentTier?: RiskTier;
 }): PersonalSignal[] {
-  const { toolName, activityLog } = input;
+  const { toolName, activityLog, currentTier } = input;
   if (!toolName) return [];
 
   const signals: PersonalSignal[] = [];
@@ -164,7 +184,51 @@ export function computePersonalSignals(input: {
     }
   }
 
+  // Heuristic 7: "Risk tier escalation."
+  // Compare the incoming call's tier against the user's typical approved
+  // tier across recent allow-decisions. If the user usually approves low
+  // and this is medium/high — or usually medium and this is high — surface.
+  // Cross-tool: the question is "is this user's threshold being exceeded",
+  // not "is this tool a step up from this tool's history". The latter is
+  // covered by heuristic 1 (prior approvals on the same tool).
+  if (currentTier) {
+    const recentAllows = activityLog
+      .queryApprovalDecisions({ decision: "allow", last: 50 })
+      .filter(
+        (e): e is typeof e & { metadata: { tier: RiskTier } } =>
+          e.metadata?.tier === "low" ||
+          e.metadata?.tier === "medium" ||
+          e.metadata?.tier === "high",
+      );
+    if (recentAllows.length >= TIER_BASELINE_MIN_SAMPLES) {
+      // p50 over rank space — sort ranks, pick the middle. Equivalent to
+      // median; cheaper than a full distribution and stable on small N.
+      const ranks = recentAllows
+        .map((e) => TIER_RANK[e.metadata.tier])
+        .sort((a, b) => a - b);
+      const baselineRank = ranks[Math.floor(ranks.length / 2)] ?? 0;
+      const currentRank = TIER_RANK[currentTier];
+      if (currentRank > baselineRank) {
+        const baselineTier = (Object.keys(TIER_RANK) as RiskTier[]).find(
+          (t) => TIER_RANK[t] === baselineRank,
+        );
+        const jump = currentRank - baselineRank;
+        signals.push({
+          kind: "tier_escalation",
+          label: tierEscalationLabel(baselineTier ?? "low", currentTier),
+          // jump of 1 (low→med, med→high) = medium; jump of 2 (low→high) = high
+          severity: jump >= 2 ? "high" : "medium",
+          source: "approval_history",
+        });
+      }
+    }
+  }
+
   return signals;
+}
+
+function tierEscalationLabel(baseline: RiskTier, current: RiskTier): string {
+  return `You usually approve ${baseline}-tier calls — this one is ${current}.`;
 }
 
 function priorApprovalsLabel(count: number): string {


### PR DESCRIPTION
## Summary

Sibling PR to #137 (and #139 for h5). Ships heuristic 7 of 12 from [memory-ecosystem-report.md §5](docs/strategic/2026-05-02/memory-ecosystem-report.md).

| Heuristic | Surfaces when | Severity |
|---|---|---|
| 7 | Current call's tier > median tier across the user's last 50 allow decisions | medium (1-tier jump), high (2-tier jump) |

Example: user has approved 12 \`low\` calls in a row → median = low. A new \`high\` call surfaces \`tier_escalation\` with severity \`high\` and the label "You usually approve low-tier calls — this one is high."

## Why this one next

- Zero-prereq: \`tier\` is already captured on every \`approval_decision\` row since [#126](https://github.com/Oolab-labs/patchwork-os/pull/126). No new metadata, no new query.
- **Cross-tool by design** — the question is "is this user's threshold being exceeded right now", not "is this tool a step up from this tool's history". The latter is heuristic 1 (prior approvals, same tool). These two compose: a tool you've never seen + above your usual tier should fire both.
- 5-sample baseline floor: avoids declaring a "pattern" before one exists. Median (rather than mean / max) keeps a single outlier from dominating.

## Architecture

| File | Change |
|---|---|
| [src/approvalSignals.ts](src/approvalSignals.ts) | New \`tier_escalation\` kind + computation block; new optional \`currentTier?: RiskTier\` arg on \`computePersonalSignals\` |
| [src/approvalHttp.ts](src/approvalHttp.ts) | Pass already-computed \`tier\` into \`computePersonalSignals\` |

\`currentTier\` is optional so test fixtures and any pre-#126 callers degrade silently to "no escalation signal" rather than throwing.

## Anti-scope

- No new dashboard rendering — same wire shape as #137 / #139, UI is downstream
- No heuristics 4, 6, 8-12 (sibling PRs)

## Tests

**7 new cases** in [src/__tests__/approvalSignals.test.ts](src/__tests__/approvalSignals.test.ts):

- Below 5-sample baseline → no signal
- Current matches baseline → no signal
- 1-tier jump (low baseline → medium current) → medium severity
- 2-tier jump (low baseline → high) → high severity
- Median (not max) — 5 lows + 1 high outlier still has low baseline, so medium current escalates
- Rejections excluded from baseline computation
- Silent when \`currentTier\` omitted (back-compat)

**Full suite: 4718/4718 passing.**

## Test plan

- [ ] CI green
- [ ] Manual: dashboard with multiple low approvals, then trigger a high-tier tool → \`tier_escalation\` shows up in \`GET /approvals\`
- [ ] Manual: confirm same call without baseline (fresh \`~/.patchwork\`) doesn't produce the signal

🤖 Generated with [Claude Code](https://claude.com/claude-code)