### PR TITLE
feat(approval-signals): heuristic 8 — often runs alongside X

### DIFF
--- a/src/__tests__/approvalSignals.test.ts
+++ b/src/__tests__/approvalSignals.test.ts
@@ -419,4 +419,93 @@ describe("computePersonalSignals", () => {
       expect(signals.find((s) => s.kind === "tier_escalation")).toBeUndefined();
     });
   });
+
+  describe("heuristic 8 — co-occurrence pattern", () => {
+    function logWithCoOccurrence(
+      pairs: Array<[string, string]>,
+      gapMs = 1_000,
+    ): ActivityLog {
+      const log = new ActivityLog();
+      let t = Date.now() - 60_000;
+      for (const [a, b] of pairs) {
+        log.record(a, 5, "success");
+        const ea = (
+          log as unknown as { entries: Array<{ timestamp: string }> }
+        ).entries.at(-1);
+        if (ea) ea.timestamp = new Date(t).toISOString();
+        t += gapMs;
+        log.record(b, 5, "success");
+        const eb = (
+          log as unknown as { entries: Array<{ timestamp: string }> }
+        ).entries.at(-1);
+        if (eb) eb.timestamp = new Date(t).toISOString();
+        t += gapMs;
+      }
+      return log;
+    }
+
+    it("does not surface below the 3-occurrence floor", () => {
+      // Single pair → count = 1 (one ordered entry pair within window).
+      const log = logWithCoOccurrence([["Bash", "Read"]]);
+      const signals = computePersonalSignals({
+        toolName: "Bash",
+        activityLog: log,
+      });
+      expect(
+        signals.find((s) => s.kind === "cooccurrence_pattern"),
+      ).toBeUndefined();
+    });
+
+    it("surfaces the partner once the count crosses the floor", () => {
+      // 2 emissions produce 4 ordered entry pairs within the window —
+      // well past the 3-count floor.
+      const log = logWithCoOccurrence([
+        ["Bash", "Read"],
+        ["Bash", "Read"],
+      ]);
+      const signals = computePersonalSignals({
+        toolName: "Bash",
+        activityLog: log,
+      });
+      const sig = signals.find((s) => s.kind === "cooccurrence_pattern");
+      expect(sig).toBeDefined();
+      expect(sig?.severity).toBe("low");
+      expect(sig?.label).toMatch(/Read/);
+      expect(sig?.count).toBeGreaterThanOrEqual(3);
+    });
+
+    it("picks the strongest partner, not just any partner", () => {
+      const log = logWithCoOccurrence([
+        ["Bash", "Read"],
+        ["Bash", "Read"],
+        ["Bash", "Read"],
+        ["Bash", "Edit"],
+        ["Bash", "Edit"],
+        ["Bash", "Edit"],
+        ["Bash", "Edit"],
+        ["Bash", "Edit"],
+      ]);
+      const signals = computePersonalSignals({
+        toolName: "Bash",
+        activityLog: log,
+      });
+      const sig = signals.find((s) => s.kind === "cooccurrence_pattern");
+      expect(sig?.label).toMatch(/Edit/);
+    });
+
+    it("does not surface when this tool is not part of any pair", () => {
+      const log = logWithCoOccurrence([
+        ["Read", "Edit"],
+        ["Read", "Edit"],
+        ["Read", "Edit"],
+      ]);
+      const signals = computePersonalSignals({
+        toolName: "Bash",
+        activityLog: log,
+      });
+      expect(
+        signals.find((s) => s.kind === "cooccurrence_pattern"),
+      ).toBeUndefined();
+    });
+  });
 });

--- a/src/approvalSignals.ts
+++ b/src/approvalSignals.ts
@@ -19,6 +19,7 @@
  *      from the catalog is satisfied by the first_connector_use kind above)
  *   7. "Risk tier escalation" — current tier exceeds the user's typical
  *      approved tier across recent decisions
+ *   8. "Often runs alongside X" — co-occurrence pairing in recent activity
  *
  * The signals are **transparent**: every signal has a `source` enum so a
  * future "why is this signal here?" UI can link back to the rows that
@@ -42,7 +43,8 @@ export interface PersonalSignal {
     | "first_connector_use"
     | "first_tool_use"
     | "stale_tool_use"
-    | "tier_escalation";
+    | "tier_escalation"
+    | "cooccurrence_pattern";
   /** Human-facing label suitable for an approval modal line. */
   label: string;
   /** Severity controls visual weight. low = informational, high = warning. */
@@ -81,6 +83,16 @@ const STALE_TOOL_HIGH_DAYS = 30;
 const TIER_BASELINE_MIN_SAMPLES = 5;
 
 const TIER_RANK: Record<RiskTier, number> = { low: 0, medium: 1, high: 2 };
+
+/**
+ * Window for co-occurrence detection — 15 minutes lines up with the
+ * catalog's heuristic 8 description and is wide enough to capture an
+ * "I'm in the middle of doing X" workflow without crossing session
+ * boundaries.
+ */
+const COOCCURRENCE_WINDOW_MS = 15 * 60 * 1_000;
+/** Minimum co-occurrence count before the chip surfaces. < 3 is noise. */
+const COOCCURRENCE_MIN_COUNT = 3;
 
 /**
  * Compute the personal-signal set for an incoming approval request.
@@ -222,6 +234,34 @@ export function computePersonalSignals(input: {
         });
       }
     }
+  }
+
+  // Heuristic 8: "Often runs alongside X."
+  // Informational chip — when the user calls this tool it tends to run
+  // near another tool (within 15min). Surfaces the strongest partner.
+  // Distinct from heuristic 1 (history of THIS tool); this signal is
+  // about the workflow shape: "you're probably mid-deploy" / "this is
+  // your morning-brief sequence". Severity always low — this is context,
+  // not warning. Catalog flags this as medium-FP, so we underclaim.
+  const pairs = activityLog.coOccurrence(COOCCURRENCE_WINDOW_MS);
+  let bestPartner: { name: string; count: number } | null = null;
+  for (const { pair, count } of pairs) {
+    if (count < COOCCURRENCE_MIN_COUNT) continue;
+    const [a, b] = pair.split("|");
+    const partner = a === toolName ? b : b === toolName ? a : null;
+    if (!partner) continue;
+    // pairs is sorted by count desc, so the first match is the strongest.
+    bestPartner = { name: partner, count };
+    break;
+  }
+  if (bestPartner) {
+    signals.push({
+      kind: "cooccurrence_pattern",
+      label: `Often runs alongside ${bestPartner.name} (${bestPartner.count} co-occurrences in your recent activity).`,
+      severity: "low",
+      source: "activity_history",
+      count: bestPartner.count,
+    });
   }
 
   return signals;


### PR DESCRIPTION
## Summary

Sibling PR to #137 / #139. Ships heuristic 8 of 12 from [memory-ecosystem-report.md §5](docs/strategic/2026-05-02/memory-ecosystem-report.md). h5 is now merged on main; this PR layers on top cleanly.

| Heuristic | Surfaces when | Severity |
|---|---|---|
| 8 | This tool appears in a co-occurrence pair (15min window) with count ≥ 3 | low (informational) |

Example chip: "Often runs alongside Read (8 co-occurrences in your recent activity)."

## Why this one next

- Reuses existing infra — \`ActivityLog.coOccurrence(15min)\` (heuristic 8's named source) already exists, sorted by count desc, capped at 200 keys.
- Distinct from heuristic 1 (this tool's own history). h8 is about *workflow shape*: "you're probably mid-deploy", "this is your morning-brief sequence". The two compose: a tool you've never seen + that pairs strongly with one you use a lot is a different signal than either alone.
- Underclaims severity: catalog flags h8 as medium-FP, so it ships as a low-severity informational chip rather than a warning.

## MVP scope

Catalog says "co-occurrence today vs past baseline." Shipping the simpler version first — strongest partner over the in-memory ring, no baseline diff. The "today vs baseline" upgrade is a future PR; until then, this is honest as-is (the label says "in your recent activity," which is accurate).

## Architecture

| File | Change |
|---|---|
| [src/approvalSignals.ts](src/approvalSignals.ts) | New \`cooccurrence_pattern\` kind + computation block over \`activityLog.coOccurrence(15min)\` |

Append-only wire shape; existing consumers need no changes.

## Anti-scope

- No "today vs baseline" comparison — future upgrade
- No co-occurrence chip rendering on the dashboard — same wire shape, UI is downstream
- No heuristics 4, 6, 9-12 (sibling PRs)

## Tests

**4 new cases** in [src/__tests__/approvalSignals.test.ts](src/__tests__/approvalSignals.test.ts):

- 1 emission of (Bash, Read) → count = 1, no signal (below floor)
- 2 emissions → count = 4 (ordered entry pairs), signal surfaces with low severity
- Strongest partner wins (3 Read pairs vs 5 Edit pairs → label says Edit)
- This tool not in any pair → no signal

**Full suite: 4719/4719 passing.**

> Subtle: \`computeCoOccurrence\` counts *every* ordered (i, j) where j > i is in the time window. So 2 emissions of the same pair yield 4 counts, not 2 — the 3-floor is calibrated against that reality.

## Test plan

- [ ] CI green
- [ ] Manual: run a tool a few times alongside another within 15min, then approve a third call → chip mentions the partner

🤖 Generated with [Claude Code](https://claude.com/claude-code)