### PR TITLE
feat(approval-signals): heuristic 12 — cooldown breach

### DIFF
--- a/src/__tests__/approvalSignals.test.ts
+++ b/src/__tests__/approvalSignals.test.ts
@@ -508,4 +508,81 @@ describe("computePersonalSignals", () => {
       ).toBeUndefined();
     });
   });
+
+  describe("heuristic 12 — cooldown breach", () => {
+    function logWithBurst(toolName: string, count: number, gapMs = 1_000) {
+      const log = new ActivityLog();
+      let t = Date.now() - count * gapMs;
+      for (let i = 0; i < count; i++) {
+        log.record(toolName, 5, "success");
+        const e = (
+          log as unknown as { entries: Array<{ timestamp: string }> }
+        ).entries.at(-1);
+        if (e) e.timestamp = new Date(t).toISOString();
+        t += gapMs;
+      }
+      return log;
+    }
+
+    it("does not surface below 3 calls in window", () => {
+      const log = logWithBurst("Bash", 2);
+      const signals = computePersonalSignals({
+        toolName: "Bash",
+        activityLog: log,
+      });
+      expect(signals.find((s) => s.kind === "cooldown_breach")).toBeUndefined();
+    });
+
+    it("surfaces with medium severity at 3 calls in window", () => {
+      const log = logWithBurst("Bash", 3);
+      const signals = computePersonalSignals({
+        toolName: "Bash",
+        activityLog: log,
+      });
+      const sig = signals.find((s) => s.kind === "cooldown_breach");
+      expect(sig).toBeDefined();
+      expect(sig?.severity).toBe("medium");
+      expect(sig?.count).toBe(3);
+      expect(sig?.label).toMatch(/runaway loop/);
+    });
+
+    it("escalates to high severity at 6+ calls", () => {
+      const log = logWithBurst("Bash", 7);
+      const signals = computePersonalSignals({
+        toolName: "Bash",
+        activityLog: log,
+      });
+      const sig = signals.find((s) => s.kind === "cooldown_breach");
+      expect(sig?.severity).toBe("high");
+      expect(sig?.count).toBe(7);
+    });
+
+    it("ignores calls older than the 5-minute window", () => {
+      const log = new ActivityLog();
+      // Three old calls (10 min ago) — outside window
+      const oldTime = Date.now() - 10 * 60 * 1_000;
+      for (let i = 0; i < 3; i++) {
+        log.record("Bash", 5, "success");
+        const e = (
+          log as unknown as { entries: Array<{ timestamp: string }> }
+        ).entries.at(-1);
+        if (e) e.timestamp = new Date(oldTime + i * 1_000).toISOString();
+      }
+      const signals = computePersonalSignals({
+        toolName: "Bash",
+        activityLog: log,
+      });
+      expect(signals.find((s) => s.kind === "cooldown_breach")).toBeUndefined();
+    });
+
+    it("only counts calls to the same tool", () => {
+      const log = new ActivityLog();
+      for (let i = 0; i < 3; i++) log.record("Read", 5, "success");
+      const signals = computePersonalSignals({
+        toolName: "Bash",
+        activityLog: log,
+      });
+      expect(signals.find((s) => s.kind === "cooldown_breach")).toBeUndefined();
+    });
+  });
 });

--- a/src/approvalSignals.ts
+++ b/src/approvalSignals.ts
@@ -20,6 +20,7 @@
  *   7. "Risk tier escalation" — current tier exceeds the user's typical
  *      approved tier across recent decisions
  *   8. "Often runs alongside X" — co-occurrence pairing in recent activity
+ *  12. "Cooldown breach" — same tool fired N+ times in a short window
  *
  * The signals are **transparent**: every signal has a `source` enum so a
  * future "why is this signal here?" UI can link back to the rows that
@@ -44,7 +45,8 @@ export interface PersonalSignal {
     | "first_tool_use"
     | "stale_tool_use"
     | "tier_escalation"
-    | "cooccurrence_pattern";
+    | "cooccurrence_pattern"
+    | "cooldown_breach";
   /** Human-facing label suitable for an approval modal line. */
   label: string;
   /** Severity controls visual weight. low = informational, high = warning. */
@@ -93,6 +95,19 @@ const TIER_RANK: Record<RiskTier, number> = { low: 0, medium: 1, high: 2 };
 const COOCCURRENCE_WINDOW_MS = 15 * 60 * 1_000;
 /** Minimum co-occurrence count before the chip surfaces. < 3 is noise. */
 const COOCCURRENCE_MIN_COUNT = 3;
+
+/**
+ * Cooldown-breach window — five minutes is short enough that "fired N
+ * times" is a behavioral pattern (a runaway loop, a panicked retry, a
+ * stuck recipe) rather than ordinary use. ApprovalQueue.inflightKey
+ * already deduplicates concurrent identical requests; this surfaces the
+ * cumulative pattern that inflight dedup hides.
+ */
+const COOLDOWN_WINDOW_MS = 5 * 60 * 1_000;
+/** Min repeat count inside the window before the chip surfaces. */
+const COOLDOWN_BREACH_MIN = 3;
+/** Severity bumps to high once the burst is unmistakable. */
+const COOLDOWN_BREACH_HIGH = 6;
 
 /**
  * Compute the personal-signal set for an incoming approval request.
@@ -264,7 +279,32 @@ export function computePersonalSignals(input: {
     });
   }
 
+  // Heuristic 12: "Cooldown breach."
+  // Same tool fired N+ times within a short window — pattern of a runaway
+  // loop, panicked retry, or stuck recipe. Distinct from heuristic 1
+  // (long-tail history): h1 says "you usually approve this", h12 says
+  // "you're approving this RIGHT NOW more than usual." Approvals modal
+  // should show both when both fire.
+  const recentCalls = activityLog.query({ tool: toolName, last: 50 });
+  const cutoff = Date.now() - COOLDOWN_WINDOW_MS;
+  const burstCount = recentCalls.filter(
+    (e) => Date.parse(e.timestamp) >= cutoff,
+  ).length;
+  if (burstCount >= COOLDOWN_BREACH_MIN) {
+    signals.push({
+      kind: "cooldown_breach",
+      label: cooldownBreachLabel(burstCount),
+      severity: burstCount >= COOLDOWN_BREACH_HIGH ? "high" : "medium",
+      source: "activity_history",
+      count: burstCount,
+    });
+  }
+
   return signals;
+}
+
+function cooldownBreachLabel(count: number): string {
+  return `Called ${count} times in the last 5 minutes — possible runaway loop or panicked retry.`;
 }
 
 function tierEscalationLabel(baseline: RiskTier, current: RiskTier): string {


### PR DESCRIPTION
## Summary

Sibling PR to #137 / #139 / #140 / #141. Ships heuristic 12 of 12 from [memory-ecosystem-report.md §5](docs/strategic/2026-05-02/memory-ecosystem-report.md).

| Heuristic | Surfaces when | Severity |
|---|---|---|
| 12 | Same tool fired ≥ 3 times within last 5 minutes | medium (3-5), high (6+) |

Example: "Called 8 times in the last 5 minutes — possible runaway loop or panicked retry."

## Why this one

- Catalog explicitly notes \`ApprovalQueue.inflightKey\` already deduplicates *concurrent* identical requests. h12 surfaces the *cumulative* pattern that inflight dedup hides — the panicked retry, the recipe stuck in a loop, the agent that won't stop.
- Distinct from heuristic 1 (long-tail history): h1 says "you usually approve this", h12 says "you're approving this RIGHT NOW more than usual." Both should fire together when both match.
- Pure activity-log scan via existing \`query({tool, last:50})\` filtered by timestamp — no new infra.

## Architecture

| File | Change |
|---|---|
| [src/approvalSignals.ts](src/approvalSignals.ts) | New \`cooldown_breach\` kind + computation block; \`cooldownBreachLabel\` helper |

Append-only wire shape; existing consumers need no changes.

## Anti-scope

- No queue-side throttling — h12 is *informational only*. The catalog is clear that the throttle decision belongs upstream (in policy / inflight dedup), not in the signals layer.
- No params-hash bucketing — catalog mentions \`(toolName, params-hash)\` but \`captureForRunlog(params)\` redaction makes hash stability shaky. Tool-only count is the safer first cut. Future PR can add params-hash if dashboard feedback shows it's noisy on the same tool with different params.
- No dashboard chip rendering — same wire shape, UI is downstream.

## Tests

**5 new cases** in [src/__tests__/approvalSignals.test.ts](src/__tests__/approvalSignals.test.ts):

- 2 calls in window → no signal (below floor)
- 3 calls → medium severity, count = 3
- 7 calls → high severity, count = 7
- 3 old calls (10 min ago) → no signal (window enforced)
- 3 calls to a different tool → no signal (tool isolation)

**Full suite: 4727/4727 passing.**

## Closes the catalog (sort of)

This is the seventh heuristic shipped (1, 2, 3 in #137; 5 in #139; 7 in #140; 8 in #141; 12 here). Remaining: heuristics 6 (recipe-step trust), 9 (workspace mismatch), 10 (time-of-day anomaly), 11 (path/URL novelty). Each needs prereq plumbing — recipe-run integration (h6), workspace metadata on approval rows (h9), opt-in setting (h10), redacted-param storage (h11) — so they're explicitly future PRs.

## Test plan

- [ ] CI green
- [ ] Manual: trigger same tool 3+ times within 5 minutes → \`cooldown_breach\` chip appears in \`GET /approvals\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)