### PR TITLE
feat(approval-signals): heuristic 9 — workspace mismatch

### DIFF
--- a/src/__tests__/approvalSignals.test.ts
+++ b/src/__tests__/approvalSignals.test.ts
@@ -509,6 +509,101 @@ describe("computePersonalSignals", () => {
     });
   });
 
+  describe("heuristic 9 — workspace mismatch", () => {
+    function logWithWorkspaceApprovals(
+      rows: Array<{ toolName: string; workspace: string }>,
+    ) {
+      const log = new ActivityLog();
+      for (const r of rows) {
+        log.recordEvent("approval_decision", {
+          toolName: r.toolName,
+          decision: "allow",
+          workspace: r.workspace,
+        });
+      }
+      return log;
+    }
+
+    it("surfaces when this workspace has no prior approval but others do", () => {
+      const log = logWithWorkspaceApprovals([
+        { toolName: "Bash", workspace: "/repo/alpha" },
+        { toolName: "Bash", workspace: "/repo/alpha" },
+      ]);
+      const signals = computePersonalSignals({
+        toolName: "Bash",
+        activityLog: log,
+        currentWorkspace: "/repo/beta",
+      });
+      const sig = signals.find((s) => s.kind === "workspace_mismatch");
+      expect(sig).toBeDefined();
+      expect(sig?.severity).toBe("medium");
+      expect(sig?.count).toBe(1); // 1 other unique workspace
+      expect(sig?.label).toMatch(/different workspace/);
+    });
+
+    it("does not surface when current workspace has prior approval", () => {
+      const log = logWithWorkspaceApprovals([
+        { toolName: "Bash", workspace: "/repo/alpha" },
+        { toolName: "Bash", workspace: "/repo/beta" },
+      ]);
+      const signals = computePersonalSignals({
+        toolName: "Bash",
+        activityLog: log,
+        currentWorkspace: "/repo/beta",
+      });
+      expect(
+        signals.find((s) => s.kind === "workspace_mismatch"),
+      ).toBeUndefined();
+    });
+
+    it("does not surface when no prior rows carry workspace metadata", () => {
+      // Older rows (pre-this-PR) — no workspace field. h9 must treat as
+      // "no baseline" rather than firing on every call.
+      const log = new ActivityLog();
+      log.recordEvent("approval_decision", {
+        toolName: "Bash",
+        decision: "allow",
+      });
+      const signals = computePersonalSignals({
+        toolName: "Bash",
+        activityLog: log,
+        currentWorkspace: "/repo/beta",
+      });
+      expect(
+        signals.find((s) => s.kind === "workspace_mismatch"),
+      ).toBeUndefined();
+    });
+
+    it("counts unique workspaces, not raw rows", () => {
+      const log = logWithWorkspaceApprovals([
+        { toolName: "Bash", workspace: "/repo/alpha" },
+        { toolName: "Bash", workspace: "/repo/alpha" },
+        { toolName: "Bash", workspace: "/repo/alpha" },
+        { toolName: "Bash", workspace: "/repo/gamma" },
+      ]);
+      const signals = computePersonalSignals({
+        toolName: "Bash",
+        activityLog: log,
+        currentWorkspace: "/repo/beta",
+      });
+      const sig = signals.find((s) => s.kind === "workspace_mismatch");
+      expect(sig?.count).toBe(2); // alpha + gamma
+    });
+
+    it("is silent when currentWorkspace omitted", () => {
+      const log = logWithWorkspaceApprovals([
+        { toolName: "Bash", workspace: "/repo/alpha" },
+      ]);
+      const signals = computePersonalSignals({
+        toolName: "Bash",
+        activityLog: log,
+      });
+      expect(
+        signals.find((s) => s.kind === "workspace_mismatch"),
+      ).toBeUndefined();
+    });
+  });
+
   describe("heuristic 12 — cooldown breach", () => {
     function logWithBurst(toolName: string, count: number, gapMs = 1_000) {
       const log = new ActivityLog();

--- a/src/approvalHttp.ts
+++ b/src/approvalHttp.ts
@@ -563,6 +563,11 @@ async function handleApprovalRequest(
       permissionMode,
       sessionId,
       tier,
+      // Workspace path captured so heuristic 9 (workspace mismatch) can
+      // tell "this tool was approved in workspace A; the call coming in
+      // from workspace B is novel here." Older rows lack this field —
+      // h9 treats absent workspace as "no baseline", same as new tools.
+      workspace: deps.workspace,
       ...(capturedParams !== undefined && { params: capturedParams }),
       ...(riskSignals.length > 0 && { riskSignals }),
       ...(summary !== undefined && { summary }),
@@ -662,6 +667,7 @@ async function handleApprovalRequest(
         toolName,
         activityLog: deps.activityLog,
         currentTier: tier,
+        currentWorkspace: deps.workspace,
       })
     : undefined;
 

--- a/src/approvalSignals.ts
+++ b/src/approvalSignals.ts
@@ -20,6 +20,8 @@
  *   7. "Risk tier escalation" — current tier exceeds the user's typical
  *      approved tier across recent decisions
  *   8. "Often runs alongside X" — co-occurrence pairing in recent activity
+ *   9. "Workspace mismatch" — call from a workspace that has never
+ *      approved this tool before
  *  12. "Cooldown breach" — same tool fired N+ times in a short window
  *
  * The signals are **transparent**: every signal has a `source` enum so a
@@ -46,7 +48,8 @@ export interface PersonalSignal {
     | "stale_tool_use"
     | "tier_escalation"
     | "cooccurrence_pattern"
-    | "cooldown_breach";
+    | "cooldown_breach"
+    | "workspace_mismatch";
   /** Human-facing label suitable for an approval modal line. */
   label: string;
   /** Severity controls visual weight. low = informational, high = warning. */
@@ -126,8 +129,16 @@ export function computePersonalSignals(input: {
    * tier-escalation evaluation.
    */
   currentTier?: RiskTier;
+  /**
+   * Absolute workspace path of the *current* call, used by heuristic 9
+   * (workspace mismatch). Optional — when omitted, h9 is skipped.
+   * Approval-decision rows persisted before workspace was captured on
+   * the lifecycle metadata also degrade gracefully (treated as having
+   * no baseline).
+   */
+  currentWorkspace?: string;
 }): PersonalSignal[] {
-  const { toolName, activityLog, currentTier } = input;
+  const { toolName, activityLog, currentTier, currentWorkspace } = input;
   if (!toolName) return [];
 
   const signals: PersonalSignal[] = [];
@@ -279,6 +290,40 @@ export function computePersonalSignals(input: {
     });
   }
 
+  // Heuristic 9: "Workspace mismatch."
+  // Surfaces when this tool has been approved (allow OR deny — any
+  // human decision counts as a "this workspace has seen this tool"
+  // signal) in other workspaces but not in the one the call is coming
+  // from. Catches "I just opened a new project and the agent wants to
+  // run the same risky tool — fresh workspace, no consent record."
+  // Skipped when currentWorkspace is missing (test fixtures, callers
+  // without a workspace context).
+  if (currentWorkspace) {
+    const allDecisions = activityLog.queryApprovalDecisions({ toolName });
+    const seenWorkspaces = new Set<string>();
+    let priorWithWorkspace = 0;
+    for (const e of allDecisions) {
+      const ws = e.metadata?.workspace;
+      if (typeof ws === "string" && ws.length > 0) {
+        seenWorkspaces.add(ws);
+        priorWithWorkspace++;
+      }
+    }
+    // Need ≥ 1 prior decision *with workspace metadata* to claim a
+    // baseline. Older rows lacking the field can't tell us anything.
+    if (priorWithWorkspace > 0 && !seenWorkspaces.has(currentWorkspace)) {
+      signals.push({
+        kind: "workspace_mismatch",
+        label: workspaceMismatchLabel(seenWorkspaces.size),
+        // Catalog says "FP low" — workspace is a strong intent boundary.
+        // But it's still informational rather than a hard warning.
+        severity: "medium",
+        source: "approval_history",
+        count: seenWorkspaces.size,
+      });
+    }
+  }
+
   // Heuristic 12: "Cooldown breach."
   // Same tool fired N+ times within a short window — pattern of a runaway
   // loop, panicked retry, or stuck recipe. Distinct from heuristic 1
@@ -301,6 +346,13 @@ export function computePersonalSignals(input: {
   }
 
   return signals;
+}
+
+function workspaceMismatchLabel(otherCount: number): string {
+  if (otherCount === 1) {
+    return "Approved in a different workspace before — first time you've allowed it here.";
+  }
+  return `Approved in ${otherCount} other workspaces before — first time you've allowed it here.`;
 }
 
 function cooldownBreachLabel(count: number): string {


### PR DESCRIPTION
## Summary

Sibling PR to #137 / #139 / #140 / #141 / #142. Ships heuristic 9 of 12 from [memory-ecosystem-report.md §5](docs/strategic/2026-05-02/memory-ecosystem-report.md). 8 of 12 catalog heuristics now live.

| Heuristic | Surfaces when | Severity |
|---|---|---|
| 9 | Tool was approved in other workspaces but never in this one | medium |

Example: "Approved in 2 other workspaces before — first time you've allowed it here."

## Why this one

- Catches the real-world case: you just opened a new project, the same agent template wants to run the same risky tool, but you've never granted consent *here*. Workspace is a strong intent boundary that other heuristics don't capture.
- Catalog flags h9 as **low-FP** — workspace switches are deliberate user actions, so this signal is reliable.
- Composes cleanly with h1 (history of this tool) — the user might "usually approve this" but only in a specific repo.

## Prereq plumbing (one-line)

The current approval-decision lifecycle row didn't include the workspace path. \`deps.workspace\` is already available in [src/approvalHttp.ts](src/approvalHttp.ts), so the prereq was just adding one field on the emit:

\`\`\`ts
deps.onDecision?.("approval_decision", {
  // ...existing fields
  workspace: deps.workspace,  // new — h9 reads this back
  // ...
});
\`\`\`

Older rows lacking the field are treated as "no baseline" rather than firing on every call — preserves backward compatibility for existing logs.

## Architecture

| File | Change |
|---|---|
| [src/approvalSignals.ts](src/approvalSignals.ts) | New \`workspace_mismatch\` kind + computation block; new optional \`currentWorkspace?: string\` arg on \`computePersonalSignals\` |
| [src/approvalHttp.ts](src/approvalHttp.ts) | Persist \`deps.workspace\` on approval_decision rows; thread \`currentWorkspace\` through to the signals call |

\`currentWorkspace\` is optional so test fixtures and any caller without workspace context degrade silently.

## Anti-scope

- No retroactive backfill of older rows — they remain \`workspace: undefined\` and h9 ignores them
- No "this tool was approved in workspace X" suggestion (would require redacting workspace paths before display); just the count of other workspaces
- No dashboard rendering — same wire shape, UI is downstream

## Tests

**5 new cases** in [src/__tests__/approvalSignals.test.ts](src/__tests__/approvalSignals.test.ts):

- Surfaces when this workspace is novel and others have approved it (medium, count = unique others)
- Does not surface when current workspace already approved
- Does not surface when no prior rows carry workspace metadata (back-compat)
- Counts unique workspaces, not raw rows
- Silent when \`currentWorkspace\` omitted

**Full suite: 4736/4736 passing.**

## Catalog progress

| # | Heuristic | Status |
|---|---|---|
| 1 | Prior approvals | #137 |
| 2 | Prior rejections | #137 |
| 3 | First connector use | #137 |
| 5 | Last called T days ago | #139 |
| 7 | Risk tier escalation | #140 |
| 8 | Co-occurrence pattern | #141 |
| 12 | Cooldown breach | #142 |
| 9 | Workspace mismatch | **this PR** |
| 6 | Recipe-step trust | needs RecipeRunLog integration |
| 10 | Time-of-day anomaly | needs opt-in setting |
| 11 | Path/URL novelty | needs redacted-param storage |

## Test plan

- [ ] CI green
- [ ] Manual: approve a tool in repo A, switch to repo B and trigger same tool → \`workspace_mismatch\` chip appears in \`GET /approvals\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)