### PR TITLE
feat(approval-signals): heuristic 10 — time-of-day anomaly (opt-in)

### DIFF
--- a/src/__tests__/approvalSignals.test.ts
+++ b/src/__tests__/approvalSignals.test.ts
@@ -557,7 +557,7 @@ describe("computePersonalSignals", () => {
     });
 
     it("does not surface when no prior rows carry workspace metadata", () => {
-      // Older rows (pre-this-PR) — no workspace field. h9 must treat as
+      // Older rows (pre-h9) — no workspace field. h9 must treat as
       // "no baseline" rather than firing on every call.
       const log = new ActivityLog();
       log.recordEvent("approval_decision", {
@@ -601,6 +601,84 @@ describe("computePersonalSignals", () => {
       expect(
         signals.find((s) => s.kind === "workspace_mismatch"),
       ).toBeUndefined();
+    });
+  });
+
+  describe("heuristic 10 — time-of-day anomaly", () => {
+    /**
+     * Seed `count` activity entries for `toolName`, each timestamped at
+     * the given hour (today). Heuristic uses local-tz Date.getHours(),
+     * so we build timestamps that we know land in that hour locally.
+     */
+    function logAtHour(toolName: string, count: number, hour: number) {
+      const log = new ActivityLog();
+      const today = new Date();
+      today.setHours(hour, 0, 0, 0);
+      for (let i = 0; i < count; i++) {
+        log.record(toolName, 5, "success");
+        const e = (
+          log as unknown as { entries: Array<{ timestamp: string }> }
+        ).entries.at(-1);
+        // Spread timestamps across that hour (1-min apart) so they all
+        // land in the same hour bucket.
+        if (e) {
+          e.timestamp = new Date(
+            today.getTime() + i * 60 * 1_000,
+          ).toISOString();
+        }
+      }
+      return log;
+    }
+
+    it("does not surface when opt-in is off (default)", () => {
+      const log = logAtHour("Bash", 15, 14); // 15 calls at 2pm
+      const signals = computePersonalSignals({
+        toolName: "Bash",
+        activityLog: log,
+        // enableTimeOfDayAnomaly omitted → off
+      });
+      expect(
+        signals.find((s) => s.kind === "time_of_day_anomaly"),
+      ).toBeUndefined();
+    });
+
+    it("does not surface below the 10-call baseline", () => {
+      const log = logAtHour("Bash", 5, 14); // only 5 calls
+      const signals = computePersonalSignals({
+        toolName: "Bash",
+        activityLog: log,
+        enableTimeOfDayAnomaly: true,
+      });
+      expect(
+        signals.find((s) => s.kind === "time_of_day_anomaly"),
+      ).toBeUndefined();
+    });
+
+    it("does not surface when current hour has prior calls", () => {
+      const log = logAtHour("Bash", 12, new Date().getHours());
+      const signals = computePersonalSignals({
+        toolName: "Bash",
+        activityLog: log,
+        enableTimeOfDayAnomaly: true,
+      });
+      expect(
+        signals.find((s) => s.kind === "time_of_day_anomaly"),
+      ).toBeUndefined();
+    });
+
+    it("surfaces low-severity when current hour has zero prior calls", () => {
+      const otherHour = (new Date().getHours() + 12) % 24;
+      const log = logAtHour("Bash", 12, otherHour);
+      const signals = computePersonalSignals({
+        toolName: "Bash",
+        activityLog: log,
+        enableTimeOfDayAnomaly: true,
+      });
+      const sig = signals.find((s) => s.kind === "time_of_day_anomaly");
+      expect(sig).toBeDefined();
+      expect(sig?.severity).toBe("low");
+      expect(sig?.count).toBe(12);
+      expect(sig?.label).toMatch(/outside your usual hours/);
     });
   });
 

--- a/src/approvalSignals.ts
+++ b/src/approvalSignals.ts
@@ -22,6 +22,8 @@
  *   8. "Often runs alongside X" — co-occurrence pairing in recent activity
  *   9. "Workspace mismatch" — call from a workspace that has never
  *      approved this tool before
+ *  10. "Time-of-day anomaly" — call hour outside the user's usual window
+ *      for this tool (opt-in: gate via `enableTimeOfDayAnomaly`)
  *  12. "Cooldown breach" — same tool fired N+ times in a short window
  *
  * The signals are **transparent**: every signal has a `source` enum so a
@@ -49,7 +51,8 @@ export interface PersonalSignal {
     | "tier_escalation"
     | "cooccurrence_pattern"
     | "cooldown_breach"
-    | "workspace_mismatch";
+    | "workspace_mismatch"
+    | "time_of_day_anomaly";
   /** Human-facing label suitable for an approval modal line. */
   label: string;
   /** Severity controls visual weight. low = informational, high = warning. */
@@ -113,6 +116,15 @@ const COOLDOWN_BREACH_MIN = 3;
 const COOLDOWN_BREACH_HIGH = 6;
 
 /**
+ * Minimum prior calls (any hour) before the time-of-day histogram is
+ * trustworthy. Below this we don't claim to know the user's pattern —
+ * any single hour could legitimately be the first time the tool runs.
+ */
+const TIME_OF_DAY_BASELINE_MIN = 10;
+/** Most recent calls considered when building the per-hour histogram. */
+const TIME_OF_DAY_LOOKBACK = 200;
+
+/**
  * Compute the personal-signal set for an incoming approval request.
  *
  * Pure function over the activity log; no I/O of its own. Tested in
@@ -137,8 +149,21 @@ export function computePersonalSignals(input: {
    * no baseline).
    */
   currentWorkspace?: string;
+  /**
+   * Opt-in switch for heuristic 10 (time-of-day anomaly). The catalog
+   * flags this as medium-FP — noisy for power users with irregular
+   * schedules — so the default is off. Bridge wires it on when the
+   * user enables the corresponding setting.
+   */
+  enableTimeOfDayAnomaly?: boolean;
 }): PersonalSignal[] {
-  const { toolName, activityLog, currentTier, currentWorkspace } = input;
+  const {
+    toolName,
+    activityLog,
+    currentTier,
+    currentWorkspace,
+    enableTimeOfDayAnomaly,
+  } = input;
   if (!toolName) return [];
 
   const signals: PersonalSignal[] = [];
@@ -324,6 +349,38 @@ export function computePersonalSignals(input: {
     }
   }
 
+  // Heuristic 10: "Time-of-day anomaly."
+  // Build a 24-bucket hour-of-day histogram for past calls of this tool.
+  // If the current hour has zero prior calls AND total prior calls is
+  // past the baseline, surface as informational (low severity). Catalog
+  // flags this as medium-FP so it stays opt-in and never escalates to
+  // medium/high — purely a "huh, that's unusual" chip.
+  if (enableTimeOfDayAnomaly) {
+    const recent = activityLog.query({
+      tool: toolName,
+      last: TIME_OF_DAY_LOOKBACK,
+    });
+    if (recent.length >= TIME_OF_DAY_BASELINE_MIN) {
+      const hourCounts = new Array<number>(24).fill(0);
+      for (const e of recent) {
+        const hr = new Date(e.timestamp).getHours();
+        if (Number.isFinite(hr) && hr >= 0 && hr < 24) {
+          hourCounts[hr] = (hourCounts[hr] ?? 0) + 1;
+        }
+      }
+      const currentHour = new Date().getHours();
+      if ((hourCounts[currentHour] ?? 0) === 0) {
+        signals.push({
+          kind: "time_of_day_anomaly",
+          label: timeOfDayLabel(currentHour, recent.length),
+          severity: "low",
+          source: "activity_history",
+          count: recent.length,
+        });
+      }
+    }
+  }
+
   // Heuristic 12: "Cooldown breach."
   // Same tool fired N+ times within a short window — pattern of a runaway
   // loop, panicked retry, or stuck recipe. Distinct from heuristic 1
@@ -353,6 +410,11 @@ function workspaceMismatchLabel(otherCount: number): string {
     return "Approved in a different workspace before — first time you've allowed it here.";
   }
   return `Approved in ${otherCount} other workspaces before — first time you've allowed it here.`;
+}
+
+function timeOfDayLabel(hour: number, baselineCount: number): string {
+  const hh = hour.toString().padStart(2, "0");
+  return `First call at ${hh}:00 — outside your usual hours for this tool (across ${baselineCount} prior calls).`;
 }
 
 function cooldownBreachLabel(count: number): string {


### PR DESCRIPTION
## Summary

Sibling PR. Ships heuristic 10 of 12 from [memory-ecosystem-report.md §5](docs/strategic/2026-05-02/memory-ecosystem-report.md). 9 of 12 catalog heuristics now defined (will be 10 after #143 merges).

| Heuristic | Surfaces when | Severity |
|---|---|---|
| 10 | Current local hour has zero prior calls of this tool, baseline ≥ 10 | low (informational only) |

Example: "First call at 03:00 — outside your usual hours for this tool (across 47 prior calls)."

## Why opt-in

Catalog: *"FP medium — noisy for power users; gate behind a setting."*

Power users with irregular schedules — overnight batch jobs, distributed teams across timezones, anyone who codes at weird hours — would see this fire constantly. Defaulting to off and letting users flip it on (via a future bridge setting) keeps the signal high-trust for the people who actually want it.

The function-level gate ships now (\`enableTimeOfDayAnomaly?: boolean\`) so the wire shape doesn't change again when the bridge wires up the user-facing setting.

## Architecture

| File | Change |
|---|---|
| [src/approvalSignals.ts](src/approvalSignals.ts) | New \`time_of_day_anomaly\` kind + 24-bucket histogram + \`timeOfDayLabel\` helper; new optional \`enableTimeOfDayAnomaly?: boolean\` arg |

Uses local-tz \`Date.getHours()\` per the catalog's "first-ever call at 03:14 local" framing. \`TIME_OF_DAY_BASELINE_MIN = 10\`, \`TIME_OF_DAY_LOOKBACK = 200\` — both tunable constants.

## Anti-scope

- No bridge-side setting wiring — separate follow-up PR. The signal is computed with the input flag; bridge surfaces the user-toggleable setting.
- No "fuzzy" hour matching (e.g. ±1 hour grace) — keep the first cut strict; revisit if dashboard feedback says it's too sensitive
- Severity never escalates above \`low\` — this is "huh, that's unusual," not a warning
- No dashboard rendering

## Tests

**4 new cases** in [src/__tests__/approvalSignals.test.ts](src/__tests__/approvalSignals.test.ts):

- Default off — no signal when \`enableTimeOfDayAnomaly\` is omitted (even with 15 calls in a different hour)
- Below baseline (5 calls) — no signal even when opted in
- Current hour has prior calls — no signal
- Current hour empty + baseline met — low-severity signal with hour + count

**Full suite: 4735/4735 passing.**

## Catalog progress

| # | Heuristic | Status |
|---|---|---|
| 1, 2, 3 | Approvals / rejections / first connector | #137 |
| 5 | Last called T days ago | #139 |
| 7 | Risk tier escalation | #140 |
| 8 | Co-occurrence pattern | #141 |
| 12 | Cooldown breach | #142 |
| 9 | Workspace mismatch | #143 (open) |
| 10 | Time-of-day anomaly | **this PR** |
| 6 | Recipe-step trust | needs RecipeRunLog integration |
| 11 | Path/URL novelty | needs redacted-param storage |

## Follow-up

Bridge-side opt-in: add \`automation.timeOfDayAnomaly\` (or similar) to settings.json + thread through to \`computePersonalSignals\` call site in [src/approvalHttp.ts](src/approvalHttp.ts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)