### PR TITLE
feat(approval-signals): heuristic 11 — param novelty

### DIFF
--- a/src/__tests__/approvalSignals.test.ts
+++ b/src/__tests__/approvalSignals.test.ts
@@ -682,6 +682,121 @@ describe("computePersonalSignals", () => {
     });
   });
 
+  describe("heuristic 11 — param novelty", () => {
+    function logWithCommands(commands: string[]) {
+      const log = new ActivityLog();
+      for (const cmd of commands) {
+        log.recordEvent("approval_decision", {
+          toolName: "runCommand",
+          decision: "allow",
+          params: { command: cmd },
+        });
+      }
+      return log;
+    }
+
+    it("does not surface for tools without a known primary param", () => {
+      const log = new ActivityLog();
+      // Seed plenty of approvals — but tool isn't in PARAM_NOVELTY_PRIMARY_KEYS
+      for (let i = 0; i < 10; i++) {
+        log.recordEvent("approval_decision", {
+          toolName: "myTool",
+          decision: "allow",
+          params: { foo: `value-${i}` },
+        });
+      }
+      const signals = computePersonalSignals({
+        toolName: "myTool",
+        activityLog: log,
+        currentParams: { foo: "totally-new-value" },
+      });
+      expect(signals.find((s) => s.kind === "param_novelty")).toBeUndefined();
+    });
+
+    it("does not surface below the 5-prefix baseline", () => {
+      const log = logWithCommands(["git status", "git log"]);
+      const signals = computePersonalSignals({
+        toolName: "runCommand",
+        activityLog: log,
+        currentParams: { command: "rm -rf /" },
+      });
+      expect(signals.find((s) => s.kind === "param_novelty")).toBeUndefined();
+    });
+
+    it("surfaces when current prefix is novel and baseline met", () => {
+      const log = logWithCommands([
+        "git status",
+        "git log",
+        "git diff",
+        "ls -la",
+        "cat README.md",
+      ]);
+      const signals = computePersonalSignals({
+        toolName: "runCommand",
+        activityLog: log,
+        currentParams: { command: "rm -rf /" },
+      });
+      const sig = signals.find((s) => s.kind === "param_novelty");
+      expect(sig).toBeDefined();
+      expect(sig?.severity).toBe("medium");
+      expect(sig?.label).toMatch(/Novel command prefix/);
+      expect(sig?.count).toBe(5);
+    });
+
+    it("does not surface when first 24 chars match a prior call", () => {
+      // Prefix length is 24 chars verbatim — choose seeds and a current
+      // command that share their first 24 chars exactly. "npm install
+      // some-package-name" and "npm install some-package-name --save"
+      // both begin with "npm install some-package" (24 chars).
+      const log = logWithCommands([
+        "npm install some-package-name",
+        "git status",
+        "git log",
+        "git diff",
+        "ls -la",
+      ]);
+      const signals = computePersonalSignals({
+        toolName: "runCommand",
+        activityLog: log,
+        currentParams: { command: "npm install some-package-name --save" },
+      });
+      expect(signals.find((s) => s.kind === "param_novelty")).toBeUndefined();
+    });
+
+    it("ignores prior decisions whose params lack the primary key", () => {
+      const log = new ActivityLog();
+      for (let i = 0; i < 5; i++) {
+        log.recordEvent("approval_decision", {
+          toolName: "runCommand",
+          decision: "allow",
+          params: { foo: "bar" }, // no `command` field
+        });
+      }
+      const signals = computePersonalSignals({
+        toolName: "runCommand",
+        activityLog: log,
+        currentParams: { command: "git status" },
+      });
+      // No baseline established → no signal
+      expect(signals.find((s) => s.kind === "param_novelty")).toBeUndefined();
+    });
+
+    it("is silent when currentParams omitted", () => {
+      const log = logWithCommands([
+        "git status",
+        "git log",
+        "git diff",
+        "ls -la",
+        "cat README.md",
+      ]);
+      const signals = computePersonalSignals({
+        toolName: "runCommand",
+        activityLog: log,
+      });
+      expect(signals.find((s) => s.kind === "param_novelty")).toBeUndefined();
+    });
+  });
+
   describe("heuristic 12 — cooldown breach", () => {
     function logWithBurst(toolName: string, count: number, gapMs = 1_000) {
       const log = new ActivityLog();

--- a/src/approvalHttp.ts
+++ b/src/approvalHttp.ts
@@ -668,6 +668,7 @@ async function handleApprovalRequest(
         activityLog: deps.activityLog,
         currentTier: tier,
         currentWorkspace: deps.workspace,
+        currentParams: params,
       })
     : undefined;
 

--- a/src/approvalSignals.ts
+++ b/src/approvalSignals.ts
@@ -24,6 +24,8 @@
  *      approved this tool before
  *  10. "Time-of-day anomaly" — call hour outside the user's usual window
  *      for this tool (opt-in: gate via `enableTimeOfDayAnomaly`)
+ *  11. "Param novelty" — primary param (command/url/pattern) prefix never
+ *      seen on prior approvals of this tool
  *  12. "Cooldown breach" — same tool fired N+ times in a short window
  *
  * The signals are **transparent**: every signal has a `source` enum so a
@@ -52,7 +54,8 @@ export interface PersonalSignal {
     | "cooccurrence_pattern"
     | "cooldown_breach"
     | "workspace_mismatch"
-    | "time_of_day_anomaly";
+    | "time_of_day_anomaly"
+    | "param_novelty";
   /** Human-facing label suitable for an approval modal line. */
   label: string;
   /** Severity controls visual weight. low = informational, high = warning. */
@@ -125,6 +128,30 @@ const TIME_OF_DAY_BASELINE_MIN = 10;
 const TIME_OF_DAY_LOOKBACK = 200;
 
 /**
+ * Tools whose calls have a single high-signal "primary param" that's
+ * worth tracking for novelty. Map value = the param key. Other tools
+ * skip h11 entirely — generic approval-modal fields like "specifier"
+ * are too noisy to compare across calls.
+ */
+const PARAM_NOVELTY_PRIMARY_KEYS: Record<string, string> = {
+  runCommand: "command",
+  Bash: "command",
+  sendHttpRequest: "url",
+  WebFetch: "url",
+  searchAndReplace: "pattern",
+};
+
+/**
+ * Number of leading characters used as the prefix key for novelty
+ * comparison. Long enough to distinguish `git push` from `git pull` but
+ * short enough that param tail variation (file paths, sha args) doesn't
+ * make every call look novel.
+ */
+const PARAM_NOVELTY_PREFIX_LEN = 24;
+/** Minimum prior calls before the novelty signal is trustworthy. */
+const PARAM_NOVELTY_BASELINE_MIN = 5;
+
+/**
  * Compute the personal-signal set for an incoming approval request.
  *
  * Pure function over the activity log; no I/O of its own. Tested in
@@ -156,6 +183,14 @@ export function computePersonalSignals(input: {
    * user enables the corresponding setting.
    */
   enableTimeOfDayAnomaly?: boolean;
+  /**
+   * Params of the *current* call, used by heuristic 11 (param novelty).
+   * Optional — when omitted, h11 is skipped. The bridge passes the same
+   * (un-redacted) params used elsewhere in the approval flow; the
+   * heuristic extracts only the primary key (command / url / pattern)
+   * and never logs or returns the value.
+   */
+  currentParams?: Record<string, unknown>;
 }): PersonalSignal[] {
   const {
     toolName,
@@ -163,6 +198,7 @@ export function computePersonalSignals(input: {
     currentTier,
     currentWorkspace,
     enableTimeOfDayAnomaly,
+    currentParams,
   } = input;
   if (!toolName) return [];
 
@@ -381,6 +417,46 @@ export function computePersonalSignals(input: {
     }
   }
 
+  // Heuristic 11: "Param novelty."
+  // For tools with a clear primary string param (runCommand → command,
+  // sendHttpRequest → url, etc.), build a Set of past param prefixes
+  // from approval_decision metadata. If the current call's prefix isn't
+  // in that set AND we have enough baseline, surface as informational.
+  // Compares only the leading PARAM_NOVELTY_PREFIX_LEN chars so the
+  // tail (file paths, sha args, query params) doesn't make every call
+  // look novel.
+  const primaryKey = PARAM_NOVELTY_PRIMARY_KEYS[toolName];
+  if (primaryKey && currentParams) {
+    const currentRaw = currentParams[primaryKey];
+    if (typeof currentRaw === "string" && currentRaw.length > 0) {
+      const currentPrefix = paramPrefix(currentRaw);
+      const priorDecisions = activityLog.queryApprovalDecisions({
+        toolName,
+      });
+      const seenPrefixes = new Set<string>();
+      for (const e of priorDecisions) {
+        const params = e.metadata?.params;
+        if (typeof params !== "object" || params === null) continue;
+        const v = (params as Record<string, unknown>)[primaryKey];
+        if (typeof v === "string" && v.length > 0) {
+          seenPrefixes.add(paramPrefix(v));
+        }
+      }
+      if (
+        seenPrefixes.size >= PARAM_NOVELTY_BASELINE_MIN &&
+        !seenPrefixes.has(currentPrefix)
+      ) {
+        signals.push({
+          kind: "param_novelty",
+          label: paramNoveltyLabel(primaryKey, seenPrefixes.size),
+          severity: "medium",
+          source: "approval_history",
+          count: seenPrefixes.size,
+        });
+      }
+    }
+  }
+
   // Heuristic 12: "Cooldown breach."
   // Same tool fired N+ times within a short window — pattern of a runaway
   // loop, panicked retry, or stuck recipe. Distinct from heuristic 1
@@ -410,6 +486,15 @@ function workspaceMismatchLabel(otherCount: number): string {
     return "Approved in a different workspace before — first time you've allowed it here.";
   }
   return `Approved in ${otherCount} other workspaces before — first time you've allowed it here.`;
+}
+
+function paramPrefix(s: string): string {
+  // Trim leading whitespace so " git push" and "git push" hash the same.
+  return s.trimStart().slice(0, PARAM_NOVELTY_PREFIX_LEN);
+}
+
+function paramNoveltyLabel(paramKey: string, baselineSize: number): string {
+  return `Novel ${paramKey} prefix — across ${baselineSize} prior approvals you've never run this exact shape.`;
 }
 
 function timeOfDayLabel(hour: number, baselineCount: number): string {


### PR DESCRIPTION
## Summary

Sibling PR. Ships heuristic 11 of 12 from [memory-ecosystem-report.md §5](docs/strategic/2026-05-02/memory-ecosystem-report.md). 10 of 12 catalog heuristics now defined.

| Heuristic | Surfaces when | Severity |
|---|---|---|
| 11 | Primary param prefix (24 chars verbatim) novel vs. ≥ 5 prior unique prefixes for this tool | medium |

Example: "Novel command prefix — across 12 prior approvals you've never run this exact shape." (Surfaces if you've been running \`git status\`, \`npm install\`, \`ls\`... and a fresh \`rm -rf /\` shows up.)

## Why this one

- Catalog explicitly calls out: *"for runCommand, sendHttpRequest, searchAndReplace: check the first significant param against past redacted param prefixes."*
- Reuses \`captureForRunlog(params)\` data already stored on approval_decision rows since #126 — no new schema, no new query path. The prereq for h11 was already shipped.
- Tightly scoped to a known tool→key map (\`PARAM_NOVELTY_PRIMARY_KEYS\`); other tools skip the heuristic entirely. Prevents noise from tools without a comparable primary param.

## Architecture

| File | Change |
|---|---|
| [src/approvalSignals.ts](src/approvalSignals.ts) | New \`param_novelty\` kind + computation block; \`PARAM_NOVELTY_PRIMARY_KEYS\` map; \`paramPrefix\` / \`paramNoveltyLabel\` helpers; new optional \`currentParams?: Record<string, unknown>\` arg on \`computePersonalSignals\` |
| [src/approvalHttp.ts](src/approvalHttp.ts) | Pass already-validated \`params\` through to the signals call |

\`currentParams\` is optional so test fixtures and any caller without param context degrade silently.

## Tool→key map (initial)

| Tool | Primary param key |
|---|---|
| \`runCommand\` | \`command\` |
| \`Bash\` | \`command\` |
| \`sendHttpRequest\` | \`url\` |
| \`WebFetch\` | \`url\` |
| \`searchAndReplace\` | \`pattern\` |

Other tools skip h11. Easy to extend by adding to \`PARAM_NOVELTY_PRIMARY_KEYS\` — separate PR if dashboard feedback suggests adding e.g. \`gitCheckout\` (branch name) or connector-specific params.

## Anti-scope

- No fuzzy/word-boundary matching — straight \`slice(0, 24)\` verbatim. \`"git push"\` and \`"git pull"\` are distinct prefixes; \`"npm install some-package-name"\` and \`"npm install some-package-name --save"\` share the same 24-char prefix and don't fire the signal. This is intentional; the heuristic is fast and predictable, and dashboard feedback can drive future refinement.
- No n-gram / LCS analysis — catalog flagged that as future work; the simple-prefix version proves the pattern.
- No dashboard rendering — same wire shape as prior heuristics, UI is downstream.

## Tests

**6 new cases** in [src/__tests__/approvalSignals.test.ts](src/__tests__/approvalSignals.test.ts):

- Tool not in \`PARAM_NOVELTY_PRIMARY_KEYS\` → no signal even with rich history
- Below 5-prefix baseline → no signal
- Novel current prefix + baseline met → medium signal with count
- Current call's first 24 chars match a prior prefix exactly → no signal (e.g. \`npm install some-package-name --save\` matches the prefix of \`npm install some-package-name\`)
- Prior decisions lack the primary key → no baseline established
- \`currentParams\` omitted → silent (back-compat)

**Full suite: 4746/4746 passing.**

## Catalog progress

| # | Heuristic | Status |
|---|---|---|
| 1, 2, 3 | Approvals / rejections / first connector | #137 ✅ |
| 5 | Last called T days ago | #139 ✅ |
| 7 | Risk tier escalation | #140 ✅ |
| 8 | Co-occurrence pattern | #141 ✅ |
| 12 | Cooldown breach | #142 ✅ |
| 9 | Workspace mismatch | #143 ✅ |
| 10 | Time-of-day anomaly | #144 ✅ |
| 11 | Param novelty | **this PR** |
| 6 | Recipe-step trust | needs RecipeRunLog integration (the only remaining catalog heuristic) |

## Test plan

- [ ] CI green
- [ ] Manual: approve 5+ \`runCommand\` calls with \`git\` / \`ls\` / \`cat\` commands, then trigger \`rm -rf /tmp/foo\` → \`param_novelty\` chip in \`GET /approvals\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)