### PR TITLE
feat(approval-signals): heuristic 6 — recipe-step trust (closes catalog 12/12)

### DIFF
--- a/src/__tests__/approvalSignals.test.ts
+++ b/src/__tests__/approvalSignals.test.ts
@@ -682,6 +682,246 @@ describe("computePersonalSignals", () => {
     });
   });
 
+  describe("heuristic 6 — recipe-step trust", () => {
+    type FakeRun = {
+      recipeName: string;
+      status: string;
+      stepResults?: Array<{
+        id: string;
+        tool?: string;
+        status: "ok" | "skipped" | "error";
+        resolvedParams?: unknown;
+      }>;
+    };
+
+    function fakeRunLog(runs: FakeRun[]) {
+      return {
+        query(_q: { status?: string; limit?: number }): FakeRun[] {
+          // Tests call with status "done" — return all runs and let the
+          // heuristic filter on its own. Simpler than reproducing
+          // RecipeRunLog.query's filter logic here.
+          return runs.filter((r) => r.status === "done");
+        },
+      };
+    }
+
+    it("surfaces low signal when current call matches a step in a recent successful run", () => {
+      const runLog = fakeRunLog([
+        {
+          recipeName: "morning-brief",
+          status: "done",
+          stepResults: [
+            {
+              id: "fetch",
+              tool: "runCommand",
+              status: "ok",
+              resolvedParams: { command: "git fetch origin patchwork-main" },
+            },
+          ],
+        },
+        {
+          recipeName: "morning-brief",
+          status: "done",
+          stepResults: [
+            {
+              id: "fetch",
+              tool: "runCommand",
+              status: "ok",
+              resolvedParams: { command: "git fetch origin patchwork-main" },
+            },
+          ],
+        },
+      ]);
+      const signals = computePersonalSignals({
+        toolName: "runCommand",
+        activityLog: new ActivityLog(),
+        currentParams: { command: "git fetch origin patchwork-main --prune" },
+        recipeRunLog: runLog,
+      });
+      const sig = signals.find((s) => s.kind === "recipe_step_trust");
+      expect(sig).toBeDefined();
+      expect(sig?.severity).toBe("low");
+      expect(sig?.source).toBe("recipe_run_log");
+      expect(sig?.label).toMatch(/morning-brief/);
+      expect(sig?.count).toBe(2);
+    });
+
+    it("does not surface below the 2-run minimum", () => {
+      const runLog = fakeRunLog([
+        {
+          recipeName: "morning-brief",
+          status: "done",
+          stepResults: [
+            {
+              id: "fetch",
+              tool: "runCommand",
+              status: "ok",
+              resolvedParams: { command: "git fetch origin patchwork-main" },
+            },
+          ],
+        },
+      ]);
+      const signals = computePersonalSignals({
+        toolName: "runCommand",
+        activityLog: new ActivityLog(),
+        currentParams: { command: "git fetch origin patchwork-main" },
+        recipeRunLog: runLog,
+      });
+      expect(
+        signals.find((s) => s.kind === "recipe_step_trust"),
+      ).toBeUndefined();
+    });
+
+    it("does not surface when step status was error", () => {
+      const runLog = fakeRunLog([
+        {
+          recipeName: "morning-brief",
+          status: "done",
+          stepResults: [
+            {
+              id: "fetch",
+              tool: "runCommand",
+              status: "error",
+              resolvedParams: { command: "git fetch origin patchwork-main" },
+            },
+          ],
+        },
+        {
+          recipeName: "morning-brief",
+          status: "done",
+          stepResults: [
+            {
+              id: "fetch",
+              tool: "runCommand",
+              status: "error",
+              resolvedParams: { command: "git fetch origin patchwork-main" },
+            },
+          ],
+        },
+      ]);
+      const signals = computePersonalSignals({
+        toolName: "runCommand",
+        activityLog: new ActivityLog(),
+        currentParams: { command: "git fetch origin patchwork-main" },
+        recipeRunLog: runLog,
+      });
+      expect(
+        signals.find((s) => s.kind === "recipe_step_trust"),
+      ).toBeUndefined();
+    });
+
+    it("does not surface when prefix differs", () => {
+      const runLog = fakeRunLog([
+        {
+          recipeName: "morning-brief",
+          status: "done",
+          stepResults: [
+            {
+              id: "fetch",
+              tool: "runCommand",
+              status: "ok",
+              resolvedParams: { command: "git fetch origin patchwork-main" },
+            },
+          ],
+        },
+        {
+          recipeName: "morning-brief",
+          status: "done",
+          stepResults: [
+            {
+              id: "fetch",
+              tool: "runCommand",
+              status: "ok",
+              resolvedParams: { command: "git fetch origin patchwork-main" },
+            },
+          ],
+        },
+      ]);
+      const signals = computePersonalSignals({
+        toolName: "runCommand",
+        activityLog: new ActivityLog(),
+        currentParams: { command: "rm -rf /tmp/everything" },
+        recipeRunLog: runLog,
+      });
+      expect(
+        signals.find((s) => s.kind === "recipe_step_trust"),
+      ).toBeUndefined();
+    });
+
+    it("picks the recipe with the most matches when multiple recipes match", () => {
+      const runLog = fakeRunLog([
+        {
+          recipeName: "morning-brief",
+          status: "done",
+          stepResults: [
+            {
+              id: "fetch",
+              tool: "runCommand",
+              status: "ok",
+              resolvedParams: { command: "git fetch origin patchwork-main" },
+            },
+          ],
+        },
+        {
+          recipeName: "weekly-sync",
+          status: "done",
+          stepResults: [
+            {
+              id: "fetch",
+              tool: "runCommand",
+              status: "ok",
+              resolvedParams: { command: "git fetch origin patchwork-main" },
+            },
+          ],
+        },
+        {
+          recipeName: "weekly-sync",
+          status: "done",
+          stepResults: [
+            {
+              id: "fetch",
+              tool: "runCommand",
+              status: "ok",
+              resolvedParams: { command: "git fetch origin patchwork-main" },
+            },
+          ],
+        },
+        {
+          recipeName: "weekly-sync",
+          status: "done",
+          stepResults: [
+            {
+              id: "fetch",
+              tool: "runCommand",
+              status: "ok",
+              resolvedParams: { command: "git fetch origin patchwork-main" },
+            },
+          ],
+        },
+      ]);
+      const signals = computePersonalSignals({
+        toolName: "runCommand",
+        activityLog: new ActivityLog(),
+        currentParams: { command: "git fetch origin patchwork-main" },
+        recipeRunLog: runLog,
+      });
+      const sig = signals.find((s) => s.kind === "recipe_step_trust");
+      expect(sig?.label).toMatch(/weekly-sync/);
+      expect(sig?.count).toBe(4); // 1 morning-brief + 3 weekly-sync
+    });
+
+    it("is silent when recipeRunLog omitted", () => {
+      const signals = computePersonalSignals({
+        toolName: "runCommand",
+        activityLog: new ActivityLog(),
+        currentParams: { command: "git fetch origin patchwork-main" },
+      });
+      expect(
+        signals.find((s) => s.kind === "recipe_step_trust"),
+      ).toBeUndefined();
+    });
+  });
+
   describe("heuristic 11 — param novelty", () => {
     function logWithCommands(commands: string[]) {
       const log = new ActivityLog();

--- a/src/approvalSignals.ts
+++ b/src/approvalSignals.ts
@@ -19,6 +19,8 @@
  *      from the catalog is satisfied by the first_connector_use kind above)
  *   7. "Risk tier escalation" — current tier exceeds the user's typical
  *      approved tier across recent decisions
+ *   6. "Mirrors a recipe step you trust" — primary param matches a step
+ *      from a successful past recipe run
  *   8. "Often runs alongside X" — co-occurrence pairing in recent activity
  *   9. "Workspace mismatch" — call from a workspace that has never
  *      approved this tool before
@@ -55,13 +57,18 @@ export interface PersonalSignal {
     | "cooldown_breach"
     | "workspace_mismatch"
     | "time_of_day_anomaly"
-    | "param_novelty";
+    | "param_novelty"
+    | "recipe_step_trust";
   /** Human-facing label suitable for an approval modal line. */
   label: string;
   /** Severity controls visual weight. low = informational, high = warning. */
   severity: "low" | "medium" | "high";
   /** Source identifier so the UI can link the signal back to its evidence. */
-  source: "approval_history" | "activity_history" | "tool_registry";
+  source:
+    | "approval_history"
+    | "activity_history"
+    | "tool_registry"
+    | "recipe_run_log";
   /** Optional numeric backing the label, surfaced in tooltips / counts. */
   count?: number;
 }
@@ -152,6 +159,37 @@ const PARAM_NOVELTY_PREFIX_LEN = 24;
 const PARAM_NOVELTY_BASELINE_MIN = 5;
 
 /**
+ * How many recent successful recipe runs we scan for matching step
+ * results in heuristic 6. 200 is enough to catch any "you run this
+ * recipe daily" pattern without unbounded scan cost.
+ */
+const RECIPE_STEP_TRUST_LOOKBACK = 200;
+/**
+ * Minimum number of matching successful runs before we surface the
+ * "trusted recipe step" signal. ≥ 2 means "this isn't a one-off."
+ */
+const RECIPE_STEP_TRUST_MIN = 2;
+
+/**
+ * Minimal querier surface for h6. Accepting the narrow interface (rather
+ * than the full `RecipeRunLog` class) lets tests inject canned runs
+ * without instantiating the disk-backed log, and keeps the dependency
+ * graph small.
+ */
+export interface RecipeRunQuerier {
+  query(q: { status?: string; limit?: number }): Array<{
+    recipeName: string;
+    status: string;
+    stepResults?: Array<{
+      id: string;
+      tool?: string;
+      status: "ok" | "skipped" | "error";
+      resolvedParams?: unknown;
+    }>;
+  }>;
+}
+
+/**
  * Compute the personal-signal set for an incoming approval request.
  *
  * Pure function over the activity log; no I/O of its own. Tested in
@@ -191,6 +229,13 @@ export function computePersonalSignals(input: {
    * and never logs or returns the value.
    */
   currentParams?: Record<string, unknown>;
+  /**
+   * Optional recipe-run querier for heuristic 6 (recipe-step trust). When
+   * present, h6 scans recent successful runs for a step that matches
+   * this tool + the current call's primary param prefix and surfaces
+   * the recipe name. Skipped when omitted.
+   */
+  recipeRunLog?: RecipeRunQuerier;
 }): PersonalSignal[] {
   const {
     toolName,
@@ -199,6 +244,7 @@ export function computePersonalSignals(input: {
     currentWorkspace,
     enableTimeOfDayAnomaly,
     currentParams,
+    recipeRunLog,
   } = input;
   if (!toolName) return [];
 
@@ -457,6 +503,67 @@ export function computePersonalSignals(input: {
     }
   }
 
+  // Heuristic 6: "Mirrors a recipe step you trust."
+  // Scan recent SUCCESSFUL recipe runs for a step whose tool matches
+  // and whose resolvedParams primary key shares the same 24-char prefix
+  // as the current call. If we find ≥ RECIPE_STEP_TRUST_MIN such runs,
+  // surface the recipe name and the count. Reuses h11's primary-key
+  // map so "this tool needs a primary param to compare" is one decision.
+  // Trust signal — low severity (informational reassurance, not warning).
+  const recipePrimaryKey = PARAM_NOVELTY_PRIMARY_KEYS[toolName];
+  if (recipeRunLog && recipePrimaryKey && currentParams) {
+    const currentRaw = currentParams[recipePrimaryKey];
+    if (typeof currentRaw === "string" && currentRaw.length > 0) {
+      const currentPrefix = paramPrefix(currentRaw);
+      const recentRuns = recipeRunLog.query({
+        status: "done",
+        limit: RECIPE_STEP_TRUST_LOOKBACK,
+      });
+      const matchingRecipes = new Map<string, number>();
+      for (const run of recentRuns) {
+        if (!run.stepResults) continue;
+        for (const step of run.stepResults) {
+          if (step.tool !== toolName || step.status !== "ok") continue;
+          const sp = step.resolvedParams;
+          if (typeof sp !== "object" || sp === null) continue;
+          const v = (sp as Record<string, unknown>)[recipePrimaryKey];
+          if (
+            typeof v === "string" &&
+            v.length > 0 &&
+            paramPrefix(v) === currentPrefix
+          ) {
+            matchingRecipes.set(
+              run.recipeName,
+              (matchingRecipes.get(run.recipeName) ?? 0) + 1,
+            );
+            // One match per run is enough — same step run repeatedly in
+            // a single recipe execution doesn't add weight.
+            break;
+          }
+        }
+      }
+      let totalMatches = 0;
+      let topRecipe: string | null = null;
+      let topCount = 0;
+      for (const [name, count] of matchingRecipes) {
+        totalMatches += count;
+        if (count > topCount) {
+          topCount = count;
+          topRecipe = name;
+        }
+      }
+      if (totalMatches >= RECIPE_STEP_TRUST_MIN && topRecipe) {
+        signals.push({
+          kind: "recipe_step_trust",
+          label: recipeStepTrustLabel(topRecipe, totalMatches),
+          severity: "low",
+          source: "recipe_run_log",
+          count: totalMatches,
+        });
+      }
+    }
+  }
+
   // Heuristic 12: "Cooldown breach."
   // Same tool fired N+ times within a short window — pattern of a runaway
   // loop, panicked retry, or stuck recipe. Distinct from heuristic 1
@@ -491,6 +598,13 @@ function workspaceMismatchLabel(otherCount: number): string {
 function paramPrefix(s: string): string {
   // Trim leading whitespace so " git push" and "git push" hash the same.
   return s.trimStart().slice(0, PARAM_NOVELTY_PREFIX_LEN);
+}
+
+function recipeStepTrustLabel(
+  recipeName: string,
+  totalMatches: number,
+): string {
+  return `Matches a step in your ${recipeName} recipe (${totalMatches} successful runs).`;
 }
 
 function paramNoveltyLabel(paramKey: string, baselineSize: number): string {


### PR DESCRIPTION
## Summary

**Closes the catalog.** Ships heuristic 6 of 12 from [memory-ecosystem-report.md §5](docs/strategic/2026-05-02/memory-ecosystem-report.md). With this PR, all 12 catalog heuristics are defined.

| Heuristic | Surfaces when | Severity |
|---|---|---|
| 6 | Current call's primary param prefix matches a step in ≥ 2 successful recipe runs | low (trust signal) |

Example: "Matches a step in your morning-brief recipe (12 successful runs)."

## Why this one closes the loop

The eleven other heuristics tell the user "be careful" in different shapes (history, novelty, escalation, repetition). h6 is the **trust** counterweight — "you're about to do something you've already automated and trusted enough to put in a recipe; this is fine." Without it the signals layer would skew toward warnings.

## Approach

- Scans recent successful (\`status === "done"\`) recipe runs from the run log
- For each run's step where \`step.tool === toolName\` and \`step.status === "ok"\`, compares \`step.resolvedParams[primaryKey]\` against the current call's same key
- Reuses h11's [\`PARAM_NOVELTY_PRIMARY_KEYS\`](src/approvalSignals.ts) map and 24-char \`paramPrefix\` — same shape rules everywhere
- Picks the recipe with the most matches; total match count goes in \`signal.count\`
- One match per run (a step run repeatedly inside one recipe execution doesn't double-count)

## Architecture

| File | Change |
|---|---|
| [src/approvalSignals.ts](src/approvalSignals.ts) | New \`recipe_step_trust\` kind + computation block; new \`recipe_run_log\` source enum value; \`RecipeRunQuerier\` interface; \`recipeStepTrustLabel\` helper; new optional \`recipeRunLog?: RecipeRunQuerier\` arg |

\`RecipeRunQuerier\` is a deliberately narrow interface (just the fields h6 reads), not the full \`RecipeRunLog\` class. Tests inject canned runs with no disk I/O; production passes the real \`RecipeRunLog\` instance (which structurally satisfies the interface).

## Anti-scope

- Does not wire \`recipeRunLog\` through \`approvalHttp\` → \`server.ts\` yet. Current server.ts call site already doesn't pass \`activityLog\` either, so the entire personalSignals computation is inert in prod. **Turning on personalSignals end-to-end is a separate "wire personalSignals into prod" PR** — it covers \`activityLog\`, \`recipeRunLog\`, and the dashboard surface together. Defining each heuristic and turning them on are clean concerns to keep separated.
- No fuzzy matching or partial-prefix scoring — straight prefix equality
- No "show all matching recipes" — just the top one (count covers the rest)

## Tests

**6 new cases** in [src/__tests__/approvalSignals.test.ts](src/__tests__/approvalSignals.test.ts):

- 2 successful runs, matching prefix → signal with count=2 + recipe name
- 1 run only → no signal (below \`RECIPE_STEP_TRUST_MIN\`)
- Steps with \`status === "error"\` ignored even if they match
- Different prefix → no signal
- Multiple recipes match → picks the recipe with the most matches; \`count\` is the total
- \`recipeRunLog\` omitted → silent (back-compat)

**Full suite: 4752/4752 passing.**

## Catalog progress (CLOSED 12/12)

| # | Heuristic | Status |
|---|---|---|
| 1, 2, 3 | Approvals / rejections / first connector | #137 ✅ |
| 5 | Last called T days ago | #139 ✅ |
| 7 | Risk tier escalation | #140 ✅ |
| 8 | Co-occurrence pattern | #141 ✅ |
| 12 | Cooldown breach | #142 ✅ |
| 9 | Workspace mismatch | #143 ✅ |
| 10 | Time-of-day anomaly | #144 ✅ |
| 11 | Param novelty | #145 ✅ |
| **6** | **Recipe-step trust** | **this PR** |

## Test plan

- [ ] CI green
- [ ] Future "wire personalSignals into prod" PR validates h6 end-to-end against a real recipe run

🤖 Generated with [Claude Code](https://claude.com/claude-code)