### PR TITLE
feat(approval-signals): wire activityLog into approvalHttp (turn personalSignals on)

### DIFF
--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -1253,6 +1253,12 @@ export class Bridge {
       this.config.approvalWebhookUrl ?? undefined;
     this.server.onApprovalDecision = (event, meta) =>
       this.activityLog.recordEvent(event, meta);
+    // Wire activityLog into approvalHttp so passive risk personalization
+    // signals (src/approvalSignals.ts) actually compute against the
+    // user's history. Without this, the personalSignals catalog is
+    // defined but inert — every approval queue entry has
+    // personalSignals: undefined.
+    this.server.activityLog = this.activityLog;
     this.server.readyFn = () => {
       // Count tools from the first active session (all sessions share the same tool set)
       const anySession = [...this.sessions.values()][0];

--- a/src/server.ts
+++ b/src/server.ts
@@ -203,6 +203,13 @@ export class Server extends EventEmitter<ServerEvents> {
   public onApprovalDecision:
     | ((event: string, meta: Record<string, unknown>) => void)
     | undefined = undefined;
+  /**
+   * Patchwork: activity log handle, used by approvalHttp to compute
+   * passive risk personalization signals (`src/approvalSignals.ts`).
+   * When unset, personalSignals are simply omitted from queue entries.
+   */
+  public activityLog: import("./activityLog.js").ActivityLog | undefined =
+    undefined;
   /** Patchwork: set by bridge to match + fire webhook-triggered recipes. */
   public webhookFn:
     | ((
@@ -1197,6 +1204,7 @@ export class Server extends EventEmitter<ServerEvents> {
                 pushServiceUrl: this.pushServiceUrl,
                 pushServiceToken: this.pushServiceToken,
                 pushServiceBaseUrl: this.pushServiceBaseUrl,
+                activityLog: this.activityLog,
               },
             );
             res.writeHead(result.status, {


### PR DESCRIPTION
## Summary

After PRs #137 / #139 / #140 / #141 / #142 / #143 / #144 / #145 defined the 11 currently-merged personalSignals heuristics, the system was still **inert in production**: \`server.ts\` didn't pass \`activityLog\` into the \`routeApprovalRequest\` deps, so every approval queue entry had \`personalSignals: undefined\`. The catalog was complete on the function level but invisible everywhere.

This PR is the 14-line glue that turns the system on.

## Changes

| File | Change |
|---|---|
| [src/server.ts](src/server.ts) | New \`public activityLog?: ActivityLog\` field on \`Server\` class; threaded into the \`routeApprovalRequest\` deps |
| [src/bridge.ts](src/bridge.ts) | One assignment: \`this.server.activityLog = this.activityLog\`, sitting next to the existing \`this.server.onApprovalDecision\` wiring |

## End-to-end behavior change

\`GET /approvals\` (and the SSE stream) now returns \`personalSignals: PersonalSignal[]\` on each pending approval, populated by [\`computePersonalSignals\`](src/approvalSignals.ts) over the user's local activity log.

Heuristics that activate immediately:

| # | Kind | Source |
|---|---|---|
| 1 | \`prior_approvals\` | approval_history |
| 2 | \`prior_rejection\` | approval_history |
| 3 | \`first_connector_use\` / \`first_tool_use\` | activity_history |
| 5 | \`stale_tool_use\` | activity_history |
| 7 | \`tier_escalation\` | approval_history |
| 8 | \`cooccurrence_pattern\` | activity_history |
| 9 | \`workspace_mismatch\` | approval_history |
| 11 | \`param_novelty\` | approval_history |
| 12 | \`cooldown_breach\` | activity_history |

Heuristic 10 (\`time_of_day_anomaly\`) is opt-in — needs a future settings flip to surface. Heuristic 6 (\`recipe_step_trust\`, PR #146) needs an additional \`recipeRunLog\` wire-up in the same shape; deliberately deferred to a 1-line follow-up so this PR doesn't depend on #146 merging first.

## Tests

No new tests needed. Existing coverage in [src/__tests__/approvalHttp.test.ts](src/__tests__/approvalHttp.test.ts) already exercises both paths:

- \`propagates personalSignals onto queued PendingApproval when ActivityLog is wired\`
- \`does not include personalSignals when no ActivityLog is wired\`

Both still pass; this PR just changes \`server.ts\` to pass the \`ActivityLog\` it has been holding all along.

**Full suite: 4746/4746 passing.**

## Test plan

- [ ] CI green
- [ ] Manual: trigger ≥ 3 approvals on the same tool, then approve a 4th → \`GET /approvals\` response shows \`personalSignals\` array containing \`prior_approvals\` (and maybe \`cooldown_breach\` if all four happened in 5 min)
- [ ] Manual: dashboard SSE stream → \`personalSignals\` propagates on snapshot + update events

## Follow-ups

- After #146 merges: 1-line PR adding \`this.server.recipeRunLog = this.recipeRunLog\` + threading into approvalHttp deps + new optional \`recipeRunLog\` field on \`Server\` class — turns on h6 the same way this PR turns on the rest
- Dashboard surface: render the chips. Currently the data flows but the UI doesn't show them yet — separate UX-track PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)