### PR TITLE
feat(dashboard): render personalSignals chips on approvals

### DIFF
--- a/dashboard/src/app/approvals/[callId]/page.tsx
+++ b/dashboard/src/app/approvals/[callId]/page.tsx
@@ -12,6 +12,18 @@ interface RiskSignal {
   severity: "low" | "medium" | "high";
 }
 
+interface PersonalSignal {
+  kind: string;
+  label: string;
+  severity: "low" | "medium" | "high";
+  source:
+    | "approval_history"
+    | "activity_history"
+    | "tool_registry"
+    | "recipe_run_log";
+  count?: number;
+}
+
 interface PendingRecord {
   callId: string;
   toolName: string;
@@ -22,6 +34,7 @@ interface PendingRecord {
   sessionId?: string;
   expiresAt?: number;
   riskSignals?: RiskSignal[];
+  personalSignals?: PersonalSignal[];
 }
 
 interface DecisionRecord {
@@ -234,6 +247,32 @@ export default function ApprovalDetailPage() {
                 key={`${s.kind}-${s.label}`}
                 className={`pill ${s.severity === "high" ? "err" : s.severity === "medium" ? "warn" : "muted"}`}
                 title={s.kind}
+              >
+                {s.label}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {pending?.personalSignals && pending.personalSignals.length > 0 && (
+        <div className="card" style={{ marginTop: "var(--s-4)" }}>
+          <div className="card-head">
+            <h2>Your history with this call</h2>
+          </div>
+          <div
+            style={{
+              display: "flex",
+              gap: 6,
+              flexWrap: "wrap",
+              marginTop: 6,
+            }}
+          >
+            {pending.personalSignals.map((s) => (
+              <span
+                key={`personal-${s.kind}-${s.label}`}
+                className={`pill ${s.severity === "high" ? "err" : s.severity === "medium" ? "warn" : "muted"}`}
+                title={`${s.kind} (from ${s.source})`}
               >
                 {s.label}
               </span>

--- a/dashboard/src/app/approvals/page.tsx
+++ b/dashboard/src/app/approvals/page.tsx
@@ -11,6 +11,31 @@ interface RiskSignal {
   severity: "low" | "medium" | "high";
 }
 
+/**
+ * personalSignals = the user's RELATIONSHIP to this call (history,
+ * novelty, workflow patterns). Distinct from riskSignals which describe
+ * the call's CONTENT (destructive flags, etc.). Both render as chip
+ * rows under the summary, but personal signals get their own visual
+ * group so the user can tell "the policy thinks this is dangerous"
+ * (riskSignals) from "you've done this before / this is unusual for
+ * you" (personalSignals).
+ *
+ * Catalog defined in src/approvalSignals.ts (12 heuristics) — kind is
+ * loosely typed here so the dashboard doesn't have to recompile every
+ * time a new heuristic ships.
+ */
+interface PersonalSignal {
+  kind: string;
+  label: string;
+  severity: "low" | "medium" | "high";
+  source:
+    | "approval_history"
+    | "activity_history"
+    | "tool_registry"
+    | "recipe_run_log";
+  count?: number;
+}
+
 interface Pending {
   callId: string;
   toolName: string;
@@ -21,6 +46,7 @@ interface Pending {
   sessionId?: string;
   expiresAt?: number;
   riskSignals?: RiskSignal[];
+  personalSignals?: PersonalSignal[];
 }
 
 type RuleSource = "managed" | "project-local" | "project" | "user";
@@ -298,6 +324,29 @@ function ApprovalCard({
               key={`${s.kind}-${s.label}`}
               className={`pill ${s.severity === "high" ? "err" : s.severity === "medium" ? "warn" : "muted"}`}
               title={s.kind}
+            >
+              {s.label}
+            </span>
+          ))}
+        </div>
+      )}
+
+      {p.personalSignals && p.personalSignals.length > 0 && (
+        <div
+          style={{
+            display: "flex",
+            gap: 6,
+            flexWrap: "wrap",
+            marginTop: 6,
+          }}
+        >
+          {p.personalSignals.map((s) => (
+            <span
+              key={`personal-${s.kind}-${s.label}`}
+              className={`pill ${s.severity === "high" ? "err" : s.severity === "medium" ? "warn" : "muted"}`}
+              // Title shows kind + source so a future "why this signal?"
+              // popover has somewhere to start; for now it's hover text.
+              title={`${s.kind} (from ${s.source})`}
             >
               {s.label}
             </span>


### PR DESCRIPTION
## Summary

PR #147 wires \`activityLog\` into \`approvalHttp\` so every pending approval now carries \`personalSignals\` computed by the 11 currently-merged catalog heuristics. This PR is the user-facing surface for that data.

The data flowed; users couldn't see it. Now they can.

## Changes

| File | Change |
|---|---|
| [dashboard/src/app/approvals/page.tsx](dashboard/src/app/approvals/page.tsx) (list view) | Chip row right under the existing \`riskSignals\` chips. Same pill styling — existing CSS carries over. |
| [dashboard/src/app/approvals/[callId]/page.tsx](dashboard/src/app/approvals/[callId]/page.tsx) (detail view) | Full **"Your history with this call"** card next to the existing **"Risk signals"** card. Title hover shows \`kind (from source)\` for the future "why this signal?" popover. |

\`PersonalSignal.kind\` is typed loosely as \`string\` in the dashboard rather than mirroring the bridge's union — keeps dashboard from needing a recompile every time a new heuristic ships.

## Visual hierarchy

Two chip rows by design:

1. **Risk signals** (call **content** — \`rm -rf\`, non-HTTPS URL, path traversal). Same for every user.
2. **Personal signals** (your **relationship** to the call — "approved 47 times before", "never run on a Sunday before", "first use of the gmail connector").

Users should be able to tell at a glance "the policy thinks this is dangerous" from "you've done this before / this is unusual for you."

## Severity color mapping (mirrors riskSignals)

- \`high\` → \`pill err\` (red)
- \`medium\` → \`pill warn\` (orange)
- \`low\` → \`pill muted\` (grey/informational)

So a green-styled "you've approved this 47 times" lives quietly next to a red "rm -rf in command" without pulling visual focus.

## Tests

Dashboard has 24 vitest cases — all still pass. No new tests added; this PR is presentational glue against an interface contract that's already covered on the bridge side.

\`\`\`
Test Files  5 passed (5)
     Tests  24 passed (24)
\`\`\`

\`tsc --noEmit\` is clean.

## Test plan

- [ ] CI green
- [ ] Manual: with #147 merged + dashboard running, trigger ≥ 3 approvals on Bash, then approve a 4th → list view shows green "You've approved this tool 4 times before" chip; detail view shows the full "Your history with this call" card
- [ ] Manual: hover a chip → tooltip says e.g. \`prior_approvals (from approval_history)\`

## Follow-ups

- Optional "why this signal?" popover replacing the hover tooltip — links each chip back to the rows that triggered it (catalog already records \`source\` for this purpose)
- After PR #146 merges + the 1-line h6 wire-up: \`recipe_step_trust\` chips will start appearing automatically — no further dashboard changes needed because \`kind\` is a string

🤖 Generated with [Claude Code](https://claude.com/claude-code)