### PR TITLE
fix(approval-gate): warn when approval gate is on but PreToolUse hook is missing

### DIFF
--- a/src/__tests__/preToolUseHook.test.ts
+++ b/src/__tests__/preToolUseHook.test.ts
@@ -2,7 +2,10 @@ import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { registerPreToolUseHook } from "../preToolUseHook.js";
+import {
+  isPreToolUseHookRegistered,
+  registerPreToolUseHook,
+} from "../preToolUseHook.js";
 
 let dir: string;
 let settingsPath: string;
@@ -97,5 +100,44 @@ describe("registerPreToolUseHook", () => {
     });
     expect(r.action).toBe("error");
     expect(r.error).toBeDefined();
+  });
+});
+
+describe("isPreToolUseHookRegistered", () => {
+  it("returns false when settings file does not exist", () => {
+    expect(isPreToolUseHookRegistered(settingsPath)).toBe(false);
+  });
+
+  it("returns false when settings has no PreToolUse hooks", () => {
+    writeFileSync(settingsPath, JSON.stringify({ hooks: {} }));
+    expect(isPreToolUseHookRegistered(settingsPath)).toBe(false);
+  });
+
+  it("returns true after registerPreToolUseHook runs successfully", () => {
+    registerPreToolUseHook(settingsPath, { hookScriptPath: hookScript });
+    expect(isPreToolUseHookRegistered(settingsPath)).toBe(true);
+  });
+
+  it("returns false when an unrelated PreToolUse hook is registered", () => {
+    writeFileSync(
+      settingsPath,
+      JSON.stringify({
+        hooks: {
+          PreToolUse: [
+            {
+              matcher: "*",
+              hooks: [{ type: "command", command: "/some/other/hook.sh" }],
+            },
+          ],
+        },
+      }),
+    );
+    expect(isPreToolUseHookRegistered(settingsPath)).toBe(false);
+  });
+
+  it("does not throw on malformed settings.json", () => {
+    writeFileSync(settingsPath, "{not json");
+    expect(() => isPreToolUseHookRegistered(settingsPath)).not.toThrow();
+    expect(isPreToolUseHookRegistered(settingsPath)).toBe(false);
   });
 });

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -27,6 +27,7 @@ import { loadConfig as loadPatchworkConfig } from "./patchworkConfig.js";
 import type { LoadedPluginTool } from "./pluginLoader.js";
 import { loadPlugins, loadPluginsFull } from "./pluginLoader.js";
 import { PluginWatcher } from "./pluginWatcher.js";
+import { isPreToolUseHookRegistered } from "./preToolUseHook.js";
 import type { ProbeResults } from "./probe.js";
 import { probeAll } from "./probe.js";
 import { RecipeOrchestration } from "./recipeOrchestration.js";
@@ -300,6 +301,26 @@ export class Bridge {
         this.logger.info(
           `[patchwork] approval gate active: ${this.server.approvalGate} tier(s) require dashboard approval`,
         );
+        // The approval gate only sees traffic if Claude Code's PreToolUse
+        // hook is registered to POST into /approvals. If it isn't, every
+        // CC tool call bypasses the bridge entirely — the queue stays
+        // empty, no `approval_decision` rows accumulate, and the entire
+        // personalSignals catalog has no input data. Silent foot-gun
+        // that wasted hours of investigation; surface it loudly.
+        try {
+          const ccSettingsPath = path.join(
+            process.env.CLAUDE_CONFIG_DIR ?? path.join(os.homedir(), ".claude"),
+            "settings.json",
+          );
+          if (!isPreToolUseHookRegistered(ccSettingsPath)) {
+            this.logger.warn?.(
+              `[patchwork] WARNING: approval gate is on but no PreToolUse hook found in ${ccSettingsPath}. ` +
+                `Claude Code will bypass the approval queue. Run 'patchwork-init' to register the hook.`,
+            );
+          }
+        } catch {
+          // Best-effort warning — never block startup on a hook check failure.
+        }
         transport.setApprovalGate(async ({ toolName, params, sessionId }) => {
           const tier = classifyTool(toolName);
           if (this.server.approvalGate === "off") return "bypass";

--- a/src/preToolUseHook.ts
+++ b/src/preToolUseHook.ts
@@ -76,6 +76,34 @@ export function registerPreToolUseHook(
   }
 }
 
+/**
+ * Read-only check: is the Patchwork PreToolUse hook present in the
+ * given Claude Code settings.json? Used by bridge startup to warn the
+ * user when they've enabled the approval gate but never ran
+ * `patchwork-init` to wire up the hook — a silent foot-gun that leaves
+ * the entire personalSignals layer with no input data because Claude
+ * Code never POSTs approval requests to the bridge.
+ *
+ * Missing file → not registered. Unparseable file → not registered
+ * (we don't want to throw out of a startup banner check).
+ */
+export function isPreToolUseHookRegistered(ccSettingsPath: string): boolean {
+  try {
+    if (!existsSync(ccSettingsPath)) return false;
+    const ccSettings = JSON.parse(readFileSync(ccSettingsPath, "utf-8")) as {
+      hooks?: Record<string, HookEntry[]>;
+    };
+    const entries = (ccSettings.hooks?.[HOOK_EVENT] ?? []).map(normalize);
+    return entries.some((entry) =>
+      (entry.hooks ?? []).some(
+        (h) => typeof h.command === "string" && h.command.includes(HOOK_MARKER),
+      ),
+    );
+  } catch {
+    return false;
+  }
+}
+
 function normalize(e: HookEntry): NestedHook {
   if (e && Array.isArray((e as NestedHook).hooks)) {
     return {


### PR DESCRIPTION
## Summary

Surfaces a silent foot-gun discovered while dogfooding (#149): if the user enables \`--approval-gate\` but never registered the PreToolUse hook in Claude Code's \`settings.json\`, **the entire approval queue + personalSignals layer is inert** — Claude Code bypasses the bridge for every tool call and nothing ever logs the wiring gap.

## How I found this

Ran the dogfood script (#149) against my own \`~/.claude/ide/activity-3101.jsonl\` — 258 tool rows, **zero \`approval_decision\` rows**. h1/h2/h7/h9/h11 baselines were empty. Spent time tracing whether the catalog was broken, then realized: my own \`~/.claude/settings.json\` has \`"PreToolUse": []\`. Claude Code never POSTs to \`/approvals\`, so \`routeApprovalRequest\` never runs, so \`emit("approval_decision")\` never fires.

\`patchwork-init\` registers the hook. Plain \`claude-ide-bridge init\` (or no init at all) does not. Anyone who installed the bridge manually has the gate sitting silently inert.

## Fix

When the bridge starts and the approval gate is enabled, check whether the Patchwork PreToolUse hook is registered. If not, log a warning with the fix:

\`\`\`
[patchwork] approval gate active: high tier(s) require dashboard approval
[patchwork] WARNING: approval gate is on but no PreToolUse hook found in
  /Users/wesh/.claude/settings.json. Claude Code will bypass the approval
  queue. Run 'patchwork-init' to register the hook.
\`\`\`

## Architecture

| File | Change |
|---|---|
| [src/preToolUseHook.ts](src/preToolUseHook.ts) | New read-only \`isPreToolUseHookRegistered(ccSettingsPath): boolean\`. Returns false on missing/malformed file — never throws. |
| [src/bridge.ts](src/bridge.ts) | Detection wrapped in try/catch right where the existing \`approval gate active\` banner prints. Best-effort; never block startup on a hook check failure. |
| [src/__tests__/preToolUseHook.test.ts](src/__tests__/preToolUseHook.test.ts) | 5 new cases for the read-only check |

## Anti-scope

- Does NOT auto-register the hook — that would silently mutate the user's settings.json on every bridge start, which is more invasive than the disease. The warning tells the user the one command to run; they keep control.
- Does NOT change \`patchwork-init\` behavior — it already registers the hook correctly.
- Does NOT enforce — the warning is informational. If someone *wants* the gate on without the hook (testing, debugging), they're free to ignore.

## Tests

5 new cases covering: missing file, no PreToolUse hooks, registered, unrelated PreToolUse hook present, malformed settings.json.

**Full suite: 4757/4757 passing.**

Verified on my own machine: \`isPreToolUseHookRegistered('~/.claude/settings.json')\` returns \`false\` — exactly the case the warning catches. After running \`patchwork-init\` it'll return \`true\` and the warning won't fire.

## Test plan

- [ ] CI green
- [ ] Manual: with approval gate on but no hook, restart bridge → see WARNING in stderr
- [ ] Manual: run \`patchwork-init\` → restart bridge → no warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)