### PR TITLE
fix(approval-signals): always include personalSignals field when wired (even if empty)

### DIFF
--- a/src/__tests__/approvalHttp.test.ts
+++ b/src/__tests__/approvalHttp.test.ts
@@ -596,6 +596,41 @@ describe("routeApprovalRequest", () => {
       await promise;
     });
 
+    it("includes personalSignals: [] when ActivityLog is wired but no signals fired", async () => {
+      // Regression test for the dogfood finding: prior code conditionally
+      // omitted the field when the array was empty, making it impossible
+      // to tell "wire is broken" from "wire works, no history yet."
+      // Empty array = wire live; missing key = wire not configured.
+      const queue = new ApprovalQueue();
+      const { ActivityLog } = await import("../activityLog.js");
+      const activityLog = new ActivityLog();
+      const promise = routeApprovalRequest(
+        {
+          method: "POST",
+          path: "/approvals",
+          body: { toolName: "totally-unknown-tool", params: {} },
+        },
+        {
+          queue,
+          workspace: "/tmp",
+          ccLoader: emptyRules(),
+          approvalGate: "all",
+          activityLog,
+        },
+      );
+      await new Promise((r) => setTimeout(r, 10));
+      const items = queue.list();
+      expect(items).toHaveLength(1);
+      // Field present, even though there's no history to fire any signals
+      // (top-level tool with no namespace, no prior approvals, etc.)
+      expect(items[0]?.personalSignals).toBeDefined();
+      expect(Array.isArray(items[0]?.personalSignals)).toBe(true);
+
+      const callId = items[0]?.callId;
+      if (callId) queue.approve(callId);
+      await promise;
+    });
+
     it("does not include personalSignals when no ActivityLog is wired", async () => {
       // The integration is opt-in by deps. Tests that don't wire an
       // ActivityLog must still see the queue without a personalSignals

--- a/src/approvalHttp.ts
+++ b/src/approvalHttp.ts
@@ -67,7 +67,9 @@ export interface ApprovalHttpDeps {
   /**
    * Optional ActivityLog used to compute passive risk personalization
    * signals (`src/approvalSignals.ts`). When omitted, personalSignals are
-   * not computed and the queue entry simply has `personalSignals: undefined` —
+   * not computed and the queue entry has the `personalSignals` field
+   * absent entirely (distinguishable from `personalSignals: []` which means
+   * "wire is live, just no history yet") —
    * the rest of the approval flow is unaffected. Tests that care only about
    * the policy-engine path can leave this off.
    */
@@ -681,7 +683,15 @@ async function handleApprovalRequest(
       summary,
       sessionId,
       riskSignals,
-      ...(personalSignals && personalSignals.length > 0 && { personalSignals }),
+      // Always include personalSignals when activityLog is wired, even
+      // if the array is empty. The presence of the key is the signal
+      // that the wire is live; conditionally omitting it made it
+      // impossible to distinguish "wire broken" from "no signals fired"
+      // during dogfooding (verified end-to-end on 2026-05-03 — first
+      // three test runs looked broken when they were just empty).
+      // When activityLog isn't wired (no signals computed at all), the
+      // field stays absent — that case still means "not configured."
+      ...(personalSignals !== undefined && { personalSignals }),
     },
     { withToken: !!deps.pushServiceUrl },
   );


### PR DESCRIPTION
## Summary

Dogfood-finding fix from end-to-end live verification on 2026-05-03. The \`personalSignals\` field was conditionally omitted from \`/approvals\` responses when the array was empty, making it impossible to distinguish "wire broken" from "no signals fired."

## How this surfaced

After every other layer landed (#137-#151), I ran a live test against my own machine to verify the entire stack. First three runs returned this:

\`\`\`json
[{ "callId": "...", "toolName": "Bash", "tier": "high", "riskSignals": [] }]
\`\`\`

No \`personalSignals\` key. Looked like the wire-up was broken — spent time tracing whether \`deps.activityLog\` was getting threaded through. It wasn't broken. I just had no prior history, so the catalog returned \`[]\`, and [src/approvalHttp.ts:684](src/approvalHttp.ts) was conditionally omitting the field on empty:

\`\`\`ts
...(personalSignals && personalSignals.length > 0 && { personalSignals })
\`\`\`

After bootstrapping 3 prior approvals and seeing \`prior_approvals\` fire, the field appeared and the catalog was provably live. But the verification path required hand-rolled bootstrap; nobody hitting the API in the wild can tell broken vs empty.

## Fix

One-line change. Spread the field whenever it isn't undefined:

\`\`\`ts
...(personalSignals !== undefined && { personalSignals })
\`\`\`

| State | Before | After |
|---|---|---|
| activityLog wired, signals fired | \`personalSignals: [...]\` | \`personalSignals: [...]\` |
| activityLog wired, no signals | (key absent) | \`personalSignals: []\` |
| activityLog NOT wired | (key absent) | (key absent) |

The "absent" case still means "not configured." Empty array now means "wire live, just no history." Two distinct, observable states.

## Tests

| File | Change |
|---|---|
| [src/__tests__/approvalHttp.test.ts](src/__tests__/approvalHttp.test.ts) | New regression: ActivityLog wired + no history → \`personalSignals\` defined and is an array (possibly empty). Existing "no ActivityLog → undefined" case unchanged. |

**Full suite: 4761/4761 passing.**

## Anti-scope

- Doesn't change the "ActivityLog omitted entirely" case — that still produces an absent field, which correctly signals "feature not configured for this deployment."
- Doesn't touch the dashboard render path (#148) — \`p.personalSignals && p.personalSignals.length > 0\` already handles empty arrays correctly (no chips render, no extra UI noise).

## Test plan

- [ ] CI green
- [ ] Manual: live test from session can now succeed on a fresh bridge with no bootstrap — \`personalSignals: []\` proves the wire on first POST

🤖 Generated with [Claude Code](https://claude.com/claude-code)