### PR TITLE
feat(patchwork-init): prompt to restart Claude Code on first hook registration

### DIFF
--- a/src/__tests__/patchworkInit.test.ts
+++ b/src/__tests__/patchworkInit.test.ts
@@ -123,6 +123,42 @@ describe("patchwork-init", () => {
     expect(second.preToolUseHook).toBe("already-wired");
   });
 
+  it("prompts to restart Claude Code on first hook registration", async () => {
+    // Capture stdout so we can assert the restart-CC nudge appears
+    // exactly when the hook was newly added (not on already-wired runs).
+    const writes: string[] = [];
+    const origWrite = process.stdout.write.bind(process.stdout);
+    process.stdout.write = ((chunk: string | Uint8Array): boolean => {
+      writes.push(chunk.toString());
+      return true;
+    }) as typeof process.stdout.write;
+    try {
+      await runPatchworkInit([], { home: fakeHome });
+    } finally {
+      process.stdout.write = origWrite;
+    }
+    const out = writes.join("");
+    expect(out).toMatch(/Restart Claude Code/);
+    expect(out).toMatch(/PreToolUse hook takes effect/);
+  });
+
+  it("does not prompt to restart on a re-run when hook already wired", async () => {
+    await runPatchworkInit([], { home: fakeHome, quiet: true });
+    const writes: string[] = [];
+    const origWrite = process.stdout.write.bind(process.stdout);
+    process.stdout.write = ((chunk: string | Uint8Array): boolean => {
+      writes.push(chunk.toString());
+      return true;
+    }) as typeof process.stdout.write;
+    try {
+      await runPatchworkInit([], { home: fakeHome });
+    } finally {
+      process.stdout.write = origWrite;
+    }
+    const out = writes.join("");
+    expect(out).not.toMatch(/Restart Claude Code/);
+  });
+
   it("preserves unrelated PreToolUse hooks already in settings.json", async () => {
     const { mkdirSync } = await import("node:fs");
     const ccDir = join(fakeHome, ".claude");

--- a/src/commands/patchworkInit.ts
+++ b/src/commands/patchworkInit.ts
@@ -203,7 +203,17 @@ export async function runPatchworkInit(
     preToolUseHook = "error";
   }
 
-  log(`\nNext:
+  // CC reads hooks at session start, so the registration we just did
+  // (or confirmed) only takes effect for *future* sessions. Without
+  // this prompt, users follow the docs, run init, and the approval gate
+  // still appears inert — the trap that wasted hours of investigation
+  // during dogfood verification on 2026-05-03.
+  const restartLine =
+    preToolUseHook === "added"
+      ? `\n  ⚠  Restart Claude Code so the new PreToolUse hook takes effect.\n     (CC reads hooks at session start — existing sessions won't see the change.)\n`
+      : "";
+
+  log(`${restartLine}\nNext:
   1. patchwork-os recipe run ambient-journal   # try a local recipe
   2. patchwork-os                              # launch terminal dashboard
   3. Connect Gmail (coming in W2) — see docs/adr/0008-connector-scope-decision.md\n`);


### PR DESCRIPTION
## Summary

Closes the third (and presumably final) silent-trap layer surfaced by the live verification pass.

## The trap, layer by layer

1. **Layer 1 — wire-up missing entirely.** \`activityLog\` not threaded through to \`approvalHttp\`. **Fixed by #147.**
2. **Layer 2 — wire-up present, but no upstream traffic.** \`patchwork-init\` didn't register the CC PreToolUse hook. **Fixed by #151.**
3. **Layer 3 — hook registered, but CC needs restart to load it.** No prompt anywhere telling the user. **Fixed here.**

I hit all three layers myself walking through the verification. By the time I noticed layer 3, I was already debugging and could explain it. A fresh user with no context would just see "I followed the docs, ran init, gate is still inert" — same disease, harder to diagnose because the obvious red flag (#150's warning) doesn't fire (the hook IS registered, just not loaded by the running CC instance).

## Output before / after

**Before:**

\`\`\`
patchwork-os init
  ✓ ~/.patchwork scaffolded
  ✓ recipes: 12 copied, 0 preserved
  ✓ Ollama detected at localhost:11434
  ✓ config created: ~/.patchwork/config.json
  ✓ Claude Code PreToolUse hook registered: ~/.claude/settings.json

Next:
  1. patchwork-os recipe run ambient-journal
  ...
\`\`\`

**After:**

\`\`\`
patchwork-os init
  ✓ ~/.patchwork scaffolded
  ✓ recipes: 12 copied, 0 preserved
  ✓ Ollama detected at localhost:11434
  ✓ config created: ~/.patchwork/config.json
  ✓ Claude Code PreToolUse hook registered: ~/.claude/settings.json

  ⚠  Restart Claude Code so the new PreToolUse hook takes effect.
     (CC reads hooks at session start — existing sessions won't see the change.)

Next:
  1. patchwork-os recipe run ambient-journal
  ...
\`\`\`

The ⚠ stands out without being alarming. Visual hierarchy puts it between the success lines and the next-steps prompt — exactly where a user's eye lands looking for "OK what now?"

## Behavior

The prompt only appears when the hook was **newly added** (\`preToolUseHook === "added"\`). On idempotent re-runs (\`"already-wired"\`) the line is suppressed — no point nagging users who run init for any other reason. Errors still print their own warning, no restart line.

## Tests

| File | Change |
|---|---|
| [src/__tests__/patchworkInit.test.ts](src/__tests__/patchworkInit.test.ts) | 2 new cases: prompt appears on first registration, does NOT appear on re-run after already wired |

**Full suite: 4762/4762.**

## What this completes

The full first-time install story for the personalization layer is now self-explaining:

\`\`\`
$ npm install -g patchwork-os
$ claude-ide-bridge patchwork-init        # ← scaffolds + registers hook
  ✓ ...
  ⚠  Restart Claude Code so the new PreToolUse hook takes effect.
$ # (user restarts CC)
$ # personalSignals layer is now live
\`\`\`

No silent traps left in the bootstrap path.

## Test plan

- [ ] CI green
- [ ] Manual: \`rm ~/.claude/settings.json && claude-ide-bridge patchwork-init\` — see the new ⚠ line
- [ ] Manual: re-run \`claude-ide-bridge patchwork-init\` — line disappears (hook already wired)

🤖 Generated with [Claude Code](https://claude.com/claude-code)