### PR TITLE
feat(dashboard): toggle for time-of-day anomaly signal (h10 opt-in via UI)

### DIFF
--- a/dashboard/src/app/settings/page.tsx
+++ b/dashboard/src/app/settings/page.tsx
@@ -12,6 +12,7 @@ interface StatusResponse {
     port?: number;
     workspace?: string;
     approvalGate?: string;
+    enableTimeOfDayAnomaly?: boolean;
     fullMode?: boolean;
     driver?: string;
     model?: string;
@@ -79,6 +80,16 @@ export default function SettingsPage() {
   } | null>(null);
   const gateInitialized = useRef(false);
 
+  // Time-of-day anomaly toggle (personalSignals h10) — opt-in.
+  // Mirrors --enable-time-of-day-anomaly CLI flag (PR #155).
+  const [todayAnomaly, setTodayAnomaly] = useState(false);
+  const [todayAnomalySaving, setTodayAnomalySaving] = useState(false);
+  const [todayAnomalySaveMsg, setTodayAnomalySaveMsg] = useState<{
+    ok: boolean;
+    text: string;
+  } | null>(null);
+  const todayAnomalyInitialized = useRef(false);
+
   // AI driver state
   const [driverValue, setDriverValue] = useState("none");
   const [apiKeyInput, setApiKeyInput] = useState("");
@@ -121,6 +132,10 @@ export default function SettingsPage() {
           setGateValue(gv);
           setGatePending(gv);
           gateInitialized.current = true;
+        }
+        if (!todayAnomalyInitialized.current) {
+          setTodayAnomaly(Boolean(data.patchwork?.enableTimeOfDayAnomaly));
+          todayAnomalyInitialized.current = true;
         }
         if (!driverInitialized.current) {
           const d = data.patchwork?.driver ?? "none";
@@ -169,6 +184,38 @@ export default function SettingsPage() {
       });
     } finally {
       setGateSaving(false);
+    }
+  }
+
+  async function saveTimeOfDayAnomaly(value: boolean) {
+    setTodayAnomalySaving(true);
+    setTodayAnomalySaveMsg(null);
+    try {
+      const res = await fetch(apiPath("/api/bridge/settings"), {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ enableTimeOfDayAnomaly: value }),
+      });
+      if (res.ok) {
+        setTodayAnomaly(value);
+        setTodayAnomalySaveMsg({
+          ok: true,
+          text: value ? "Enabled." : "Disabled.",
+        });
+      } else {
+        const body = (await res.json().catch(() => ({}))) as { error?: string };
+        setTodayAnomalySaveMsg({
+          ok: false,
+          text: body.error ?? `Error ${res.status}`,
+        });
+      }
+    } catch (e) {
+      setTodayAnomalySaveMsg({
+        ok: false,
+        text: e instanceof Error ? e.message : String(e),
+      });
+    } finally {
+      setTodayAnomalySaving(false);
     }
   }
 
@@ -721,6 +768,59 @@ export default function SettingsPage() {
                   }}
                 >
                   {gateSaveMsg.text}
+                </p>
+              )}
+            </div>
+
+            <div
+              style={{
+                padding: "16px 0 8px",
+                borderBottom: "1px solid var(--border-subtle)",
+              }}
+            >
+              <label
+                htmlFor="time-of-day-anomaly"
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 8,
+                  fontSize: 13,
+                  fontWeight: 500,
+                  cursor: todayAnomalySaving ? "default" : "pointer",
+                }}
+              >
+                <input
+                  id="time-of-day-anomaly"
+                  type="checkbox"
+                  checked={todayAnomaly}
+                  disabled={todayAnomalySaving}
+                  onChange={(e) => saveTimeOfDayAnomaly(e.target.checked)}
+                />
+                Time-of-day anomaly signal
+              </label>
+              <p
+                style={{
+                  fontSize: 12,
+                  color: "var(--muted)",
+                  marginTop: 4,
+                  marginLeft: 24,
+                }}
+              >
+                Surfaces a chip on approvals when a tool runs outside your
+                usual hours. Off by default — flagged as medium false-positive
+                for users with irregular schedules. Takes effect on the next
+                approval; no restart needed.
+              </p>
+              {todayAnomalySaveMsg && (
+                <p
+                  style={{
+                    fontSize: 12,
+                    marginTop: 6,
+                    marginLeft: 24,
+                    color: todayAnomalySaveMsg.ok ? "var(--ok)" : "var(--err)",
+                  }}
+                >
+                  {todayAnomalySaveMsg.text}
                 </p>
               )}
             </div>

--- a/src/__tests__/server-settings.test.ts
+++ b/src/__tests__/server-settings.test.ts
@@ -231,4 +231,56 @@ describe("POST /settings — driver persistence to bridge config file", () => {
       error: expect.stringContaining("driver"),
     });
   });
+
+  it("POST /settings { enableTimeOfDayAnomaly: true } live-mutates Server", async () => {
+    expect(server!.enableTimeOfDayAnomaly).toBe(false);
+    const { status } = await makeRequest(
+      {
+        method: "POST",
+        path: "/settings",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${TOKEN}`,
+        },
+      },
+      JSON.stringify({ enableTimeOfDayAnomaly: true }),
+    );
+    expect(status).toBe(200);
+    expect(server!.enableTimeOfDayAnomaly).toBe(true);
+  });
+
+  it("POST /settings { enableTimeOfDayAnomaly: false } turns it back off", async () => {
+    server!.enableTimeOfDayAnomaly = true;
+    const { status } = await makeRequest(
+      {
+        method: "POST",
+        path: "/settings",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${TOKEN}`,
+        },
+      },
+      JSON.stringify({ enableTimeOfDayAnomaly: false }),
+    );
+    expect(status).toBe(200);
+    expect(server!.enableTimeOfDayAnomaly).toBe(false);
+  });
+
+  it("rejects non-boolean enableTimeOfDayAnomaly with 400", async () => {
+    const { status, body } = await makeRequest(
+      {
+        method: "POST",
+        path: "/settings",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${TOKEN}`,
+        },
+      },
+      JSON.stringify({ enableTimeOfDayAnomaly: "yes" }),
+    );
+    expect(status).toBe(400);
+    expect(JSON.parse(body)).toMatchObject({
+      error: expect.stringContaining("enableTimeOfDayAnomaly"),
+    });
+  });
 });

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -1328,6 +1328,7 @@ export class Bridge {
         patchwork: {
           workspace: this.config.workspace,
           approvalGate: this.server.approvalGate,
+          enableTimeOfDayAnomaly: this.server.enableTimeOfDayAnomaly,
           fullMode: this.config.fullMode,
           driver: this.config.driver,
           model: loadPatchworkConfig().model,

--- a/src/patchworkConfig.ts
+++ b/src/patchworkConfig.ts
@@ -23,6 +23,13 @@ export interface PatchworkConfig {
   recipesDir?: string;
   /** Approval gate level — mirrors CLI --approval-gate. Persisted so dashboard changes survive restart. */
   approvalGate?: "off" | "high" | "all";
+  /**
+   * Opt-in toggle for personalSignals heuristic 10 (time-of-day anomaly).
+   * Mirrors CLI --enable-time-of-day-anomaly. Persisted so dashboard
+   * changes survive restart. Default false — h10 is off until the user
+   * explicitly enables it.
+   */
+  enableTimeOfDayAnomaly?: boolean;
   /** Absolute path to a managed settings file (admin-controlled, highest rule precedence). */
   managedSettingsPath?: string;
   recipes?: {

--- a/src/server.ts
+++ b/src/server.ts
@@ -954,6 +954,7 @@ export class Server extends EventEmitter<ServerEvents> {
             ) as {
               webhookUrl?: string;
               approvalGate?: string;
+              enableTimeOfDayAnomaly?: boolean;
               driver?: string;
               model?: string;
               localEndpoint?: string;
@@ -1000,6 +1001,23 @@ export class Server extends EventEmitter<ServerEvents> {
             if (gateRaw !== undefined) {
               cfg.approvalGate = gateRaw as "off" | "high" | "all";
               this.approvalGate = gateRaw as "off" | "high" | "all";
+            }
+            // h10 toggle: must be boolean if present. Persists to
+            // ~/.patchwork/config.json AND live-mutates the Server
+            // field so the next /approvals POST honors it without
+            // needing a bridge restart.
+            if (body.enableTimeOfDayAnomaly !== undefined) {
+              if (typeof body.enableTimeOfDayAnomaly !== "boolean") {
+                res.writeHead(400, { "Content-Type": "application/json" });
+                res.end(
+                  JSON.stringify({
+                    error: "enableTimeOfDayAnomaly must be a boolean",
+                  }),
+                );
+                return;
+              }
+              cfg.enableTimeOfDayAnomaly = body.enableTimeOfDayAnomaly;
+              this.enableTimeOfDayAnomaly = body.enableTimeOfDayAnomaly;
             }
             const driverRaw = body.driver;
             if (driverRaw !== undefined) {


### PR DESCRIPTION
## Summary

PR #155 added the CLI flag \`--enable-time-of-day-anomaly\` that turns personalSignals heuristic 10 on. CLI is fine for power users but invisible to anyone running the dashboard. This PR mirrors the toggle into the existing /settings page so users can opt in/out without editing config files or restarting the bridge.

## What lands

| Layer | File | Change |
|---|---|---|
| Persistence | [src/patchworkConfig.ts](src/patchworkConfig.ts) | New optional \`enableTimeOfDayAnomaly?: boolean\` field |
| Backend handler | [src/server.ts](src/server.ts) | \`/settings\` POST accepts \`enableTimeOfDayAnomaly\`, validates boolean type, persists to config + live-mutates \`Server.enableTimeOfDayAnomaly\` |
| Status response | [src/bridge.ts](src/bridge.ts) | Adds \`patchwork.enableTimeOfDayAnomaly\` so the dashboard sees current state on load |
| Dashboard UI | [dashboard/src/app/settings/page.tsx](dashboard/src/app/settings/page.tsx) | Checkbox + helper text, sits between Approval Gate and Webhook URL — same visual rhythm as existing toggles |

## UX shape

Toggle sits in the existing settings page next to Approval Gate (its sibling concept):

> **☐ Time-of-day anomaly signal**
> Surfaces a chip on approvals when a tool runs outside your usual hours. Off by default — flagged as medium false-positive for users with irregular schedules. Takes effect on the next approval; no restart needed.

Click it → POST to \`/api/bridge/settings\` → backend persists + live-mutates → next approval renders the new state. Polling refresh doesn't clobber user edits (same \`todayAnomalyInitialized\` ref pattern as the existing gate selector).

## Tests

3 new cases in [src/__tests__/server-settings.test.ts](src/__tests__/server-settings.test.ts):
- POST \`{ enableTimeOfDayAnomaly: true }\` → \`Server.enableTimeOfDayAnomaly\` flips to true (live mutation)
- POST \`{ enableTimeOfDayAnomaly: false }\` → flips back
- POST \`{ enableTimeOfDayAnomaly: "yes" }\` → 400 with type-error message

Dashboard typecheck clean; existing 24 dashboard vitest cases still pass.

**Full bridge suite: 4768/4768.**

## Anti-scope

- Does NOT add toggles for the other 11 heuristics — the other 11 are always-on (no per-heuristic gating). Only h10 has an opt-in flag because the catalog flagged it as medium-FP for irregular schedules. The other 10 either always fire or always require their dep (recipeRunLog for h6).
- Does NOT add a "see all my personalSignals settings" group page — h10 is the only togglable one right now. If more opt-in settings ship later, they'd promote into a sub-section.

## Catalog state — h10 fully reachable

| Surface | h10 toggle |
|---|---|
| CLI | \`--enable-time-of-day-anomaly\` (#155) |
| Config file | \`enableTimeOfDayAnomaly: true\` in \`~/.patchwork/config.json\` (#155) |
| Dashboard UI | Settings page checkbox (**this PR**) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)