### PR TITLE
docs(delegation-policy): rename user-facing 'approval gate' to 'delegation policy'

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ The package ships these in `templates/recipes/`. Recipes that need API keys are 
 | `inbox-triage` | manual | Triage Gmail unread → suggest archive/reply | Gmail |
 | `sentry-to-linear` | manual | Sentry issue → Linear ticket (one-shot) | Sentry, Linear |
 
-**Connectors available** (all approval-gated for writes): Slack, GitHub, Linear, Gmail, Google Calendar, Google Drive, Sentry, Notion, Confluence, Datadog, HubSpot, Intercom, Stripe, Zendesk, Jira, PagerDuty, Discord, Asana, GitLab.
+**Connectors available** (all writes governed by your delegation policy): Slack, GitHub, Linear, Gmail, Google Calendar, Google Drive, Sentry, Notion, Confluence, Datadog, HubSpot, Intercom, Stripe, Zendesk, Jira, PagerDuty, Discord, Asana, GitLab.
 
 ### Automation hooks
 

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -57,7 +57,7 @@ npm run clean && npm run build
 | `/decisions` | Decision log |
 | `/traces`, `/metrics`, `/analytics` | OpenTelemetry + Prometheus surfaces |
 | `/connections` | Connector OAuth + token management |
-| `/settings` | Driver / model / API key / approval gate |
+| `/settings` | Driver / model / API key / delegation policy |
 
 ## Design reference
 

--- a/dashboard/src/app/settings/page.tsx
+++ b/dashboard/src/app/settings/page.tsx
@@ -69,7 +69,7 @@ export default function SettingsPage() {
   } | null>(null);
   const webhookInitialized = useRef(false);
 
-  // Approval gate state
+  // Delegation policy state
   const [gateValue, setGateValue] = useState<"off" | "high" | "all">("off");
   const [gatePending, setGatePending] = useState<"off" | "high" | "all">("off");
   const [gateSaving, setGateSaving] = useState(false);
@@ -639,7 +639,7 @@ export default function SettingsPage() {
               <h2>Integrations</h2>
             </div>
 
-            {/* Approval gate control */}
+            {/* Delegation policy control */}
             <div
               style={{
                 padding: "16px 0 8px",
@@ -647,7 +647,7 @@ export default function SettingsPage() {
               }}
             >
               <label
-                htmlFor="approval-gate"
+                htmlFor="delegation-policy"
                 style={{
                   display: "block",
                   fontSize: 13,
@@ -656,7 +656,7 @@ export default function SettingsPage() {
                   fontWeight: 500,
                 }}
               >
-                Approval gate
+                Delegation policy
               </label>
               <p
                 style={{
@@ -666,12 +666,13 @@ export default function SettingsPage() {
                   lineHeight: 1.5,
                 }}
               >
-                Hold high-risk or all tool calls for dashboard review before
-                execution. Takes effect for new sessions immediately.
+                Define what AI may do without asking, what needs approval, and
+                what is forbidden. Hold high-risk or all tool calls for review
+                before execution. Takes effect for new sessions immediately.
               </p>
               <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
                 <select
-                  id="approval-gate"
+                  id="delegation-policy"
                   value={gatePending}
                   disabled={gateSaving}
                   onChange={(e) => {

--- a/landing/index.html
+++ b/landing/index.html
@@ -3,15 +3,15 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Patchwork OS — Local AI Operating System with Approval Gates</title>
-  <meta name="description" content="Patchwork OS watches for things that matter, acts, and asks before anything risky goes out. Runs on your machine. Your keys. Approval-gated everything." />
-  <meta property="og:title" content="Patchwork OS — Local AI Operating System with Approval Gates" />
-  <meta property="og:description" content="Patchwork OS watches for things that matter, acts, and asks before anything risky goes out. Runs on your machine. Your keys. Approval-gated everything." />
+  <title>Patchwork OS — Local AI Operating System with Delegation Policy</title>
+  <meta name="description" content="Patchwork OS watches for things that matter, acts, and asks before anything risky goes out. Runs on your machine. Your keys. Delegation policy on everything." />
+  <meta property="og:title" content="Patchwork OS — Local AI Operating System with Delegation Policy" />
+  <meta property="og:description" content="Patchwork OS watches for things that matter, acts, and asks before anything risky goes out. Runs on your machine. Your keys. Delegation policy on everything." />
   <meta property="og:image" content="https://patchworkos.com/og-image.png" />
   <meta property="og:url" content="https://patchworkos.com/" />
   <meta property="og:type" content="website" />
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Patchwork OS — Local AI Operating System with Approval Gates" />
+  <meta name="twitter:title" content="Patchwork OS — Local AI Operating System with Delegation Policy" />
   <meta name="twitter:description" content="Watches for things that matter, acts, and asks before anything risky goes out." />
   <meta name="twitter:image" content="https://patchworkos.com/og-image.png" />
   <style>
@@ -747,7 +747,7 @@
       <div class="what-text">
         <div class="section-label">What is Patchwork OS</div>
         <div class="section-title">An AI operating system built for humans who need sleep.</div>
-        <p>Patchwork OS gives you approval gates, recipe lifecycle, multi-model adapters, and an oversight dashboard — all running locally on your machine. Nothing phones home. Your keys stay yours.</p>
+        <p>Patchwork OS gives you a delegation policy, recipe lifecycle, multi-model adapters, and an oversight dashboard — all running locally on your machine. Nothing phones home. Your keys stay yours.</p>
         <p>Write a recipe in plain YAML. Point it at your tools. Go to bed. Anything risky lands in your approval queue first.</p>
       </div>
       <div class="scenario-list">

--- a/src/commands/patchworkInit.ts
+++ b/src/commands/patchworkInit.ts
@@ -37,7 +37,7 @@ What it does:
   2. Copy 5 local-only recipe templates to ~/.patchwork/recipes/
   3. Detect Ollama at localhost:11434 → set provider to ollama-local
   4. Register the Patchwork PreToolUse hook in ~/.claude/settings.json
-     so Claude Code routes tool calls through the approval gate
+     so Claude Code routes tool calls through your delegation policy
   5. Print next steps
 `);
 }
@@ -198,14 +198,14 @@ export async function runPatchworkInit(
   } else {
     log(
       `  ! Could not register Claude Code PreToolUse hook: ${hookResult.error ?? "unknown"}\n` +
-        `    Approval gate will not see traffic until you add the hook manually.\n`,
+        `    Delegation policy will not see traffic until you add the hook manually.\n`,
     );
     preToolUseHook = "error";
   }
 
   // CC reads hooks at session start, so the registration we just did
   // (or confirmed) only takes effect for *future* sessions. Without
-  // this prompt, users follow the docs, run init, and the approval gate
+  // this prompt, users follow the docs, run init, and the delegation policy
   // still appears inert — the trap that wasted hours of investigation
   // during dogfood verification on 2026-05-03.
   const restartLine =

--- a/src/config.ts
+++ b/src/config.ts
@@ -833,7 +833,7 @@ Options:
   --help                    Show this help
 
 Patchwork:
-  --approval-gate <level>   Gate tool calls via oversight dashboard: "off" | "high" | "all" (default: "off")
+  --approval-gate <level>   Delegation policy: gate tool calls via oversight dashboard: "off" | "high" | "all" (default: "off")
   --managed-settings <path> Admin-controlled settings file (highest rule precedence, cannot be overridden by users)
 
 Automation:


### PR DESCRIPTION
## Summary

First PR of Phase 1 §2 (strategic-plan.md) — reframe the approval gate as a **delegation policy** across user-facing surfaces.

- **Why now**: \"Define what AI may do, what needs approval, and what is forbidden\" is the trust foundation for everything else in the strategic plan. \"Approval gate\" undersold this — it implied a single chokepoint, not a policy with rules and tiers.
- **Scope kept tight**: copy/labels only. Internal symbols (\`approvalGate\`, \`--approval-gate\` CLI flag, \`/settings\` API) untouched — no breaking changes for existing scripts or dashboards.

## What changed
- **dashboard/settings**: label \`Approval gate\` → \`Delegation policy\` with an expanded description.
- **landing page**: title, OG/Twitter meta, hero/about copy.
- **README + dashboard/README**: connector descriptor + settings table row.
- **CLI**: \`patchwork-init\` help text + \`--approval-gate\` flag description (flag name preserved).

Diff: 6 files, +20/-19.

## Follow-up PRs in this theme
1. Dashboard detail page surfaces *which rule matched* + risk tier (the \"show your work\" UX).
2. Five persona example configs: conservative / developer / headless CI / regulated-industry / personal-assistant.
3. Internal symbol rename audit (optional, deferred until callers settle).

## Test plan
- [x] \`npm run build\` (bridge tsc clean)
- [x] dashboard \`tsc --noEmit\` clean
- [x] biome check clean
- [ ] Visual check of settings page label after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)