### PR TITLE
feat(policies): five persona delegation-policy templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,8 @@ The package ships these in `templates/recipes/`. Recipes that need API keys are 
 
 **Connectors available** (all writes governed by your delegation policy): Slack, GitHub, Linear, Gmail, Google Calendar, Google Drive, Sentry, Notion, Confluence, Datadog, HubSpot, Intercom, Stripe, Zendesk, Jira, PagerDuty, Discord, Asana, GitLab.
 
+**Delegation policy presets** ([`templates/policies/`](templates/policies/)): five persona starters — conservative, developer, headless-CI, regulated-industry, personal-assistant. Copy one into `~/.patchwork/config.json` and restart.
+
 ### Automation hooks
 
 Event-driven hooks trigger Claude tasks automatically. Activate with `--automation --automation-policy <path.json> --claude-driver subprocess`.

--- a/templates/policies/README.md
+++ b/templates/policies/README.md
@@ -1,0 +1,72 @@
+# Delegation policy templates
+
+Five starter delegation policies for common personas. Each file is a partial
+`~/.patchwork/config.json` you can copy or merge into your own config.
+
+> A delegation policy answers three questions: *what may my AI do without
+> asking, what needs approval, and what is forbidden?* See the strategic
+> plan §1.2 for the framing.
+
+## Personas
+
+| File | Mode | Push | When to pick |
+|---|---|---|---|
+| [`conservative.json`](conservative.json) | `all` | yes | First-time users, sensitive personal data, learning what your AI actually does. |
+| [`developer.json`](developer.json) | `high` | no | Solo engineer at workstation. Dashboard-only oversight is enough. |
+| [`headless-ci.json`](headless-ci.json) | `off` | no | Build agents, schedulers, CI runners. **No human in the loop** — pair with disabled write recipes. |
+| [`regulated-industry.json`](regulated-industry.json) | `all` | yes | Medicine, law, journalism, finance, gov. Includes managed-settings pointer for compliance-team override. |
+| [`personal-assistant.json`](personal-assistant.json) | `high` | yes | Non-developer life automation. Inbox, calendar, smart home — approve from phone. |
+
+## How to apply
+
+### Fresh install
+
+Copy the file into place:
+
+```sh
+cp templates/policies/developer.json ~/.patchwork/config.json
+```
+
+Then add your driver/model (run `patchwork init` for guided setup, or edit
+`config.json` to add `model`, `driver`, `apiKeys`, `localEndpoint`, etc.).
+
+### Already configured
+
+Merge with `jq` (drops the `_persona` / `_summary` documentation fields):
+
+```sh
+jq -s '.[0] * (.[1] | with_entries(select(.key | startswith("_") | not)))' \
+   ~/.patchwork/config.json templates/policies/developer.json \
+   > ~/.patchwork/config.json.new \
+&& mv ~/.patchwork/config.json.new ~/.patchwork/config.json
+```
+
+### Restart
+
+```sh
+patchwork stop
+patchwork start
+```
+
+Restart Claude Code too — the `PreToolUse` hook reads bridge state at session
+start.
+
+## Verify
+
+Open the dashboard at `http://localhost:3000/settings`. The **Delegation
+policy** card should reflect your chosen mode. Trigger a tool call and watch
+`/approvals` — the detail page shows *why* a call was gated (matched rule +
+risk tier).
+
+## Key fields
+
+- `approvalGate` — `"off" | "high" | "all"`. Coarse gate for `PreToolUse`
+  routing.
+- `dashboard.requireApproval` — `["low" | "medium" | "high"]`. Which risk
+  tiers require human approval inside the dashboard queue.
+- `dashboard.pushNotifications` — send approval requests to your phone.
+- `enableTimeOfDayAnomaly` — opt-in heuristic 10. Flags calls happening
+  outside your typical activity window. Off by default.
+- `managedSettingsPath` — admin-controlled overrides, highest precedence.
+  Users cannot override fields set there.
+- `recipes.disabled` — opt out of specific recipes by name.

--- a/templates/policies/conservative.json
+++ b/templates/policies/conservative.json
@@ -1,0 +1,14 @@
+{
+  "_persona": "conservative",
+  "_summary": "Gate every tool call. Notify on phone. Maximum oversight. Best for first-time users, sensitive personal data, or while learning what your AI actually does.",
+  "_usage": "Copy fields into ~/.patchwork/config.json (or merge with `jq`). Restart the bridge and Claude Code.",
+
+  "approvalGate": "all",
+  "enableTimeOfDayAnomaly": true,
+
+  "dashboard": {
+    "port": 3000,
+    "requireApproval": ["low", "medium", "high"],
+    "pushNotifications": true
+  }
+}

--- a/templates/policies/developer.json
+++ b/templates/policies/developer.json
@@ -1,0 +1,14 @@
+{
+  "_persona": "developer",
+  "_summary": "Gate high-risk tool calls only. No phone push (dashboard is enough — you're already at your machine). Time-of-day anomaly on. Sensible default for solo engineers running Patchwork on their workstation.",
+  "_usage": "Copy fields into ~/.patchwork/config.json (or merge with `jq`). Restart the bridge and Claude Code.",
+
+  "approvalGate": "high",
+  "enableTimeOfDayAnomaly": true,
+
+  "dashboard": {
+    "port": 3000,
+    "requireApproval": ["high"],
+    "pushNotifications": false
+  }
+}

--- a/templates/policies/headless-ci.json
+++ b/templates/policies/headless-ci.json
@@ -1,0 +1,24 @@
+{
+  "_persona": "headless-ci",
+  "_summary": "No human in the loop. Approval gate off. Disable recipes that touch external systems with side effects. For build agents, scheduled jobs, and CI runners that must not block waiting for a phone tap.",
+  "_warning": "Off-mode means *every* tool call passes. Use only when (a) the underlying recipes are auditable and (b) the runner has narrowly-scoped credentials. Pair with managedSettingsPath if running on shared infra.",
+  "_usage": "Copy fields into ~/.patchwork/config.json (or merge with `jq`). Restart the bridge.",
+
+  "approvalGate": "off",
+  "enableTimeOfDayAnomaly": false,
+
+  "dashboard": {
+    "port": 3000,
+    "requireApproval": [],
+    "pushNotifications": false
+  },
+
+  "recipes": {
+    "disabled": [
+      "send-email",
+      "send-slack",
+      "github-create-pr",
+      "linear-create-issue"
+    ]
+  }
+}

--- a/templates/policies/personal-assistant.json
+++ b/templates/policies/personal-assistant.json
@@ -1,0 +1,15 @@
+{
+  "_persona": "personal-assistant",
+  "_summary": "Friendly default for non-developer use cases — life automation, inbox triage, journal prompts, household ops. Gate high-risk only, push to phone so you can approve while away from your machine.",
+  "_targets": "people who want their AI to act on email, calendar, smart home, and notes without watching the dashboard.",
+  "_usage": "Copy fields into ~/.patchwork/config.json (or merge with `jq`). Restart the bridge.",
+
+  "approvalGate": "high",
+  "enableTimeOfDayAnomaly": true,
+
+  "dashboard": {
+    "port": 3000,
+    "requireApproval": ["high"],
+    "pushNotifications": true
+  }
+}

--- a/templates/policies/regulated-industry.json
+++ b/templates/policies/regulated-industry.json
@@ -1,0 +1,18 @@
+{
+  "_persona": "regulated-industry",
+  "_summary": "Maximum oversight + audit posture. Gate everything, push to phone, time-of-day anomaly on, point at a managed settings file that your compliance team controls (highest precedence — users cannot override).",
+  "_targets": "medicine, law, journalism, finance, gov, security work — anywhere you need a paper trail for every AI-initiated action.",
+  "_usage": "Copy fields into ~/.patchwork/config.json. Have your compliance team produce the managed settings file at /etc/patchwork/managed-settings.json (or anywhere admin-writable, user-readable). Restart the bridge and Claude Code.",
+  "_audit_note": "Decision traces are persisted under ~/.patchwork/traces/ — exportable via `patchwork traces export --encrypt`.",
+
+  "approvalGate": "all",
+  "enableTimeOfDayAnomaly": true,
+
+  "dashboard": {
+    "port": 3000,
+    "requireApproval": ["low", "medium", "high"],
+    "pushNotifications": true
+  },
+
+  "managedSettingsPath": "/etc/patchwork/managed-settings.json"
+}


### PR DESCRIPTION
## Summary

Phase 1 §2, PR 3/3 — closes the strategic theme. Adds starter delegation policies for the five personas named in the plan, plus a README explaining how to apply them.

| Template | Mode | Push | Audience |
|---|---|---|---|
| \`conservative.json\` | \`all\` | yes | First-time users, sensitive personal data |
| \`developer.json\` | \`high\` | no | Solo engineer at workstation |
| \`headless-ci.json\` | \`off\` | no | Build agents, schedulers (write recipes disabled) |
| \`regulated-industry.json\` | \`all\` | yes | Medicine/law/finance — includes managedSettingsPath pointer |
| \`personal-assistant.json\` | \`high\` | yes | Inbox/calendar/smart-home life automation |

Each template carries \`_persona\` / \`_summary\` / \`_usage\` documentation fields so a user opening the file in an editor immediately understands what they're picking. \`headless-ci.json\` carries an explicit \`_warning\` about scope — off-mode passes every call.

\`templates/policies/README.md\` covers:
- one-line table of when to pick which
- fresh-install \`cp\` flow
- merge-with-\`jq\` flow that drops the underscore-prefixed doc fields
- restart + verify steps (linking the new dashboard \"Delegation policy\" card from PR #158)
- key-fields reference

Main \`README.md\` links to \`templates/policies/\` from the connectors block so people see the presets near where the delegation-policy concept first appears.

Diff: 7 files, +159/-0.

## Theme wrap-up

Phase 1 §2 is done across PRs #157 + #158 + this PR:
- **#157** — user-facing rename \"Approval Gate\" → \"Delegation Policy\"
- **#158** — dashboard detail page surfaces matched rule + risk tier
- **this PR** — five persona example configs

## Test plan
- [x] All five JSON files parse (\`node -e 'JSON.parse(...)'\`)
- [ ] Visual: \`cp templates/policies/developer.json ~/.patchwork/config.json\` (or merge), restart, confirm settings page reflects mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)