### PR TITLE
fix(dashboard): demo fixtures + render delegation-policy card on empty state

### DIFF
--- a/dashboard/src/app/approvals/[callId]/page.tsx
+++ b/dashboard/src/app/approvals/[callId]/page.tsx
@@ -167,7 +167,10 @@ export default function ApprovalDetailPage() {
   const gateMode: GateMode =
     rawGate === "high" || rawGate === "all" ? rawGate : "off";
   const effectiveTier = (pending?.tier ?? undefined) as Tier | undefined;
-  const showPolicyCard = Boolean(pending || decision);
+  // Render the policy card whenever bridge status is known. Even on
+  // "Unknown callId" the user benefits from seeing their active mode —
+  // it answers "is anything being gated right now at all?"
+  const showPolicyCard = bridgeStatus !== null && bridgeStatus !== undefined;
   const match = showPolicyCard
     ? explainMatch(gateMode, effectiveTier)
     : null;

--- a/dashboard/src/lib/mockData.ts
+++ b/dashboard/src/lib/mockData.ts
@@ -339,11 +339,24 @@ const MOCK_STATUS = {
   ok: true,
   port: 3100,
   workspace: "~/projects/patchwork-os",
-  approvalGate: "medium",
   uptimeMs: Date.now() - SESSION_START,
   activeSessions: 1,
   extensionConnected: true,
+  extension: true,
   slim: false,
+  // Nested under `patchwork` so dashboard components see the same shape
+  // they get from the real bridge `/status` response.
+  patchwork: {
+    workspace: "~/projects/patchwork-os",
+    port: 3100,
+    approvalGate: "high" as const,
+    enableTimeOfDayAnomaly: true,
+    fullMode: true,
+    driver: "subprocess",
+    model: "claude",
+    automationEnabled: false,
+    webhookUrl: null,
+  },
 };
 
 const MOCK_HEALTH = {
@@ -642,6 +655,40 @@ export function mockBridgeResponse(pathname: string, method = "GET"): Response |
   if (path === "/status")                  return json(MOCK_STATUS);
   if (path === "/health")                  return json(MOCK_HEALTH);
   if (path === "/approvals" && method === "GET") return json(MOCK_APPROVALS);
+  // Detail fixture: synthesize a pending response from MOCK_APPROVALS so the
+  // detail page renders cards (matched-rule, risk signals, params, nearby) in
+  // demo mode. Without this, every detail URL hits the empty fallthrough and
+  // shows "Unknown callId" — confusing for someone exploring the demo.
+  {
+    const m = path.match(/^\/approvals\/([^/]+)$/);
+    if (m && method === "GET") {
+      const id = decodeURIComponent(m[1]);
+      const a = MOCK_APPROVALS.find((x) => x.callId === id);
+      if (a) {
+        return json({
+          pending: {
+            ...a,
+            params:
+              id === "demo-1"
+                ? { repo: "Oolab-labs/patchwork-os", title: "feat/demo-mode dashboard" }
+                : id === "demo-2"
+                  ? { channel: "#engineering", text: "Sprint review prep at 3pm" }
+                  : { team: "Engineering", title: "Fix bridge status inconsistency", priority: "High" },
+            riskSignals:
+              id === "demo-3"
+                ? [
+                    { kind: "external_write", label: "external write", severity: "high" as const },
+                    { kind: "first_use", label: "first time used today", severity: "medium" as const },
+                  ]
+                : [],
+          },
+          decision: null,
+          nearby: [],
+        });
+      }
+      return json({ pending: null, decision: null, nearby: [] }, 404);
+    }
+  }
   if (path === "/recipes" && method === "GET")   return json({ recipes: MOCK_RECIPES });
   if (path === "/tasks" && method === "GET")     return json(MOCK_TASKS);
   if (path === "/activity")               return json(MOCK_ACTIVITY);


### PR DESCRIPTION
## Summary

Three follow-ups discovered while dogfooding Phase 1 §2 delegation-policy theme end-to-end with Playwright against a live dashboard.

## Findings

### 1. Demo mode broke the approval detail page
\`mockBridgeResponse\` had no handler for \`GET /approvals/<callId>\` — every detail URL fell through to the empty-\`{}\` fallback and showed \"Unknown callId\". This made it impossible to demo the most important page in the dashboard without a real bridge.

**Fix:** added a regex handler that synthesizes a pending detail response from the existing \`MOCK_APPROVALS\` list, plus params + risk-signal fixtures. \`demo-3\` is now a high-tier external write that demonstrates the matched-rule card.

### 2. \`MOCK_STATUS\` had invalid + wrong-shape data
- \`approvalGate: \"medium\"\` — not a real value (field is \`off | high | all\`)
- Field was top-level, but real bridge nests it under \`patchwork\` — components reading \`data.patchwork?.approvalGate\` always saw \`undefined\` and defaulted to \"off\" in demo mode

**Fix:** nested under \`patchwork\`, set to \`\"high\"\`, added the other fields the dashboard reads (\`driver\`, \`model\`, \`fullMode\`, \`enableTimeOfDayAnomaly\`, etc.).

### 3. Policy card hidden when callId unknown
Original guard was \`Boolean(pending || decision)\` — but the active mode is useful info even on the empty state. Answers \"is anything being gated right now?\" without forcing the user to navigate elsewhere.

**Fix:** guard is now \`bridgeStatus !== null\`. Card renders whenever bridge status is known.

## Verified end-to-end via Playwright
- \`/approvals/demo-3\` (demo mode) → \`mode=high, tier=high, matched=yes\`, rule reads *\"Policy is high and this tool is tier high — high-risk calls require approval.\"*
- \`/approvals/nonexistent\` → empty state still shows \`mode=high\` policy card
- \`/settings\` (real bridge) → label \"Delegation policy\" rendered correctly (PR #157 confirmed live)

## Test plan
- [x] \`npx tsc --noEmit\` clean
- [x] \`npm run build\` clean
- [x] Playwright: \`/approvals/demo-3\` shows full card with matched=yes
- [x] Playwright: \`/approvals/nonexistent\` shows mode-only card
- [x] Real bridge mode: settings page label confirmed

🤖 Generated with [Claude Code](https://claude.com/claude-code)