### PR TITLE
feat(triggers-anything): last-payload card on webhook recipes

### DIFF
--- a/dashboard/src/app/recipes/page.tsx
+++ b/dashboard/src/app/recipes/page.tsx
@@ -26,6 +26,111 @@ function buildCurlExample(port: number | undefined, path: string): string {
   return `curl -X POST ${url} \\\n  -H 'Content-Type: application/json' \\\n  -d '{"hello":"world"}'`;
 }
 
+interface WebhookPayloadEntry {
+  receivedAt: number;
+  payload: unknown;
+  ok: boolean;
+  error?: string;
+  taskId?: string;
+  recipeName?: string;
+}
+interface WebhookPayloadsResponse {
+  path: string;
+  entries: WebhookPayloadEntry[];
+}
+
+function WebhookPayloadsCard({ webhookPath }: { webhookPath: string }) {
+  const { data, error, loading } = useBridgeFetch<WebhookPayloadsResponse>(
+    `/api/bridge/webhook-payloads${webhookPath}`,
+    { intervalMs: 5000 },
+  );
+  const entries = data?.entries ?? [];
+  return (
+    <div style={{ gridColumn: "1 / -1", marginTop: 8 }}>
+      <span className="muted">Last payloads</span>
+      {loading && entries.length === 0 && (
+        <p style={{ fontSize: 11, color: "var(--fg-2)", margin: "4px 0 0" }}>
+          Loading…
+        </p>
+      )}
+      {error && (
+        <p style={{ fontSize: 11, color: "var(--err)", margin: "4px 0 0" }}>
+          {error}
+        </p>
+      )}
+      {!loading && !error && entries.length === 0 && (
+        <p style={{ fontSize: 11, color: "var(--fg-2)", margin: "4px 0 0" }}>
+          No payloads received yet. Send a test or fire from your trigger
+          source — recent bodies will appear here.
+        </p>
+      )}
+      {entries.length > 0 && (
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            gap: 6,
+            marginTop: 4,
+          }}
+        >
+          {entries.map((e) => (
+            <details
+              key={`${e.receivedAt}-${e.taskId ?? "anon"}`}
+              style={{
+                background: "var(--bg-1)",
+                border: "1px solid var(--border-subtle)",
+                borderRadius: "var(--r-2)",
+              }}
+            >
+              <summary
+                style={{
+                  fontSize: 11,
+                  padding: "6px 10px",
+                  cursor: "pointer",
+                  display: "flex",
+                  gap: 8,
+                  alignItems: "center",
+                  flexWrap: "wrap",
+                }}
+              >
+                <span
+                  className={`pill ${e.ok ? "ok" : "err"}`}
+                  style={{ fontSize: 10 }}
+                >
+                  {e.ok ? "ok" : "err"}
+                </span>
+                <span className="muted">{relTime(e.receivedAt)}</span>
+                {e.taskId && (
+                  <code style={{ fontSize: 11 }}>
+                    task {e.taskId.slice(0, 8)}
+                  </code>
+                )}
+                {e.error && (
+                  <span style={{ color: "var(--err)" }}>{e.error}</span>
+                )}
+              </summary>
+              <pre
+                style={{
+                  fontSize: 11,
+                  margin: 0,
+                  padding: "0 10px 8px",
+                  whiteSpace: "pre-wrap",
+                  wordBreak: "break-word",
+                  overflowX: "auto",
+                }}
+              >
+                {typeof e.payload === "string"
+                  ? e.payload
+                  : JSON.stringify(e.payload, null, 2)}
+              </pre>
+            </details>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
 function CopyButton({ text, label = "Copy" }: { text: string; label?: string }) {
   const [copied, setCopied] = useState(false);
   return (
@@ -876,6 +981,7 @@ export default function RecipesPage() {
                                   iPhone Shortcut, Stream Deck, Home Assistant,
                                   NFC tag, cron job, or another service.
                                 </p>
+                                <WebhookPayloadsCard webhookPath={r.webhookPath} />
                               </div>
                             )}
                             {r.lint && (r.lint.errorCount > 0 || r.lint.warningCount > 0) && (

--- a/dashboard/src/lib/mockData.ts
+++ b/dashboard/src/lib/mockData.ts
@@ -656,6 +656,43 @@ export function mockBridgeResponse(pathname: string, method = "GET"): Response |
   if (path === "/status")                  return json(MOCK_STATUS);
   if (path === "/health")                  return json(MOCK_HEALTH);
   if (path === "/approvals" && method === "GET") return json(MOCK_APPROVALS);
+  if (path.startsWith("/webhook-payloads/") && method === "GET") {
+    const hookPath = path.substring("/webhook-payloads".length);
+    if (hookPath === "/incident-war-room") {
+      return json({
+        path: hookPath,
+        entries: [
+          {
+            receivedAt: ago(7 * 60 * 1000),
+            payload: {
+              alert_id: "PD-93812",
+              service: "checkout-api",
+              severity: "critical",
+              summary: "p99 latency over 2s for 5min",
+            },
+            ok: true,
+            taskId: "task-incident-7",
+            recipeName: "incident-war-room",
+          },
+          {
+            receivedAt: ago(2 * 60 * 60 * 1000),
+            payload: { test: true, sentAt: new Date(ago(2 * 60 * 60 * 1000)).toISOString() },
+            ok: true,
+            taskId: "task-incident-6",
+            recipeName: "incident-war-room",
+          },
+          {
+            receivedAt: ago(8 * 60 * 60 * 1000),
+            payload: "raw text body — non-JSON sender",
+            ok: false,
+            error: "step 2 failed: linear.create_issue rate-limited",
+            recipeName: "incident-war-room",
+          },
+        ],
+      });
+    }
+    return json({ path: hookPath, entries: [] });
+  }
   // Detail fixture: synthesize a pending response from MOCK_APPROVALS so the
   // detail page renders cards (matched-rule, risk signals, params, nearby) in
   // demo mode. Without this, every detail URL hits the empty fallthrough and

--- a/src/server.ts
+++ b/src/server.ts
@@ -237,6 +237,26 @@ export class Server extends EventEmitter<ServerEvents> {
         error?: string;
       }>)
     | null = null;
+  /**
+   * Patchwork: ring buffer of recent webhook payloads, keyed by path
+   * (e.g. "/incident-war-room"). The last MAX_WEBHOOK_PAYLOADS entries are
+   * retained per path so the dashboard can show what the recipe most
+   * recently received — answers "did the trigger fire? what did it send?"
+   * without forcing the user to dig through bridge logs. In-memory only;
+   * cleared on restart.
+   */
+  public webhookPayloads = new Map<
+    string,
+    Array<{
+      receivedAt: number;
+      payload: unknown;
+      ok: boolean;
+      error?: string;
+      taskId?: string;
+      recipeName?: string;
+    }>
+  >();
+  static readonly MAX_WEBHOOK_PAYLOADS = 5;
   /** Set by bridge to handle MCP Streamable HTTP sessions (POST/GET/DELETE /mcp) */
   public httpMcpHandler:
     | ((req: http.IncomingMessage, res: http.ServerResponse) => Promise<void>)
@@ -864,10 +884,40 @@ export class Server extends EventEmitter<ServerEvents> {
               : result.error === "not_found"
                 ? 404
                 : 400;
+            // Record in ring buffer so the dashboard can show "last
+            // payload" per recipe. Skip not_found so unknown paths don't
+            // pollute the buffer with garbage / scanner traffic.
+            if (result.error !== "not_found") {
+              const existing = this.webhookPayloads.get(hookPath) ?? [];
+              existing.unshift({
+                receivedAt: Date.now(),
+                payload,
+                ok: result.ok,
+                error: result.error,
+                taskId: result.taskId,
+                recipeName: result.name,
+              });
+              if (existing.length > Server.MAX_WEBHOOK_PAYLOADS) {
+                existing.length = Server.MAX_WEBHOOK_PAYLOADS;
+              }
+              this.webhookPayloads.set(hookPath, existing);
+            }
             res.writeHead(status, { "Content-Type": "application/json" });
             res.end(JSON.stringify(result));
           })();
         });
+        return;
+      }
+      if (
+        parsedUrl.pathname?.startsWith("/webhook-payloads/") &&
+        req.method === "GET"
+      ) {
+        const hookPath = parsedUrl.pathname.substring(
+          "/webhook-payloads".length,
+        );
+        const entries = this.webhookPayloads.get(hookPath) ?? [];
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ path: hookPath, entries }));
         return;
       }
 


### PR DESCRIPTION
## Summary

Phase 1 §4 (\"Anything Can Trigger Your AI\"), PR 3/N. Bridge stores the last 5 payloads per webhook path in memory; dashboard renders them under each webhook recipe in the Recipes page detail expansion. Closes the strategic plan's third dashboard ask: *\"copyable webhook URL, last payload, test webhook button, example request.\"*

> **Stacks on #161** (URL + curl) — that PR adds the helpers and webhook-detail block this one extends. If #161 lands first, this rebases cleanly. If this lands first, #161's added view is unaffected.

## What changed

### Bridge (\`src/server.ts\`)
- New \`webhookPayloads: Map<string, Entry[]>\` ring buffer, capped at \`MAX_WEBHOOK_PAYLOADS = 5\` per path.
- Webhook handler in \`/hooks/<path>\` POST records each payload + result. \`not_found\` paths skipped so scanner traffic doesn't pollute the buffer.
- New \`GET /webhook-payloads/<path>\` returns \`{path, entries[]}\`.
- In-memory only; cleared on restart. This is diagnostic surface, not durable storage.

### Dashboard (\`dashboard/src/app/recipes/page.tsx\`)
- New \`WebhookPayloadsCard\` component fetched lazily on row expansion (5s poll so test fires appear).
- Each entry: ok/err pill, relative timestamp, task ID prefix, error message if any.
- Clickable \`<details>\` reveals the body — plain text renders as text, JSON pretty-prints.
- Empty state hints at the Test button + user's own trigger source.

### Mock fixture
- \`incident-war-room\` now has 3 entries spanning all states the card handles (ok+JSON, ok+test, err+step failure).

Diff: 3 files, +193/-0.

## Verified via Playwright (demo mode)

- Expanded \`incident-war-room\` row → \`Last payloads\` card visible with 3 entries
- All pills/timestamps/task IDs/error messages render correctly
- Clicking the \`7 min ago\` summary expanded the JSON body to:
  ```
  {\"alert_id\":\"PD-93812\",\"service\":\"checkout-api\",\"severity\":\"critical\",...}
  ```

## Test plan
- [x] \`npm run build\` (bridge) clean
- [x] dashboard \`tsc --noEmit\` clean
- [x] Playwright: card renders all entry states
- [x] Playwright: details expand → JSON pretty-printed
- [ ] Real bridge: \`curl -X POST localhost:3101/hooks/foo -d '{}'\` then refresh dashboard → entry appears

## Phase 1 §4 status after this
- ✅ #161 — copyable webhook URL + curl
- ✅ #162 — five webhook recipe templates
- ✅ this PR — last-payload card

Theme is feature-complete on the dashboard side. Remaining: docs walkthroughs (\`docs/triggers-anything-2026-05-02\` branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)