### PR TITLE
docs(triggers): align with delegation-policy + webhook surface PRs

### DIFF
--- a/documents/triggers.md
+++ b/documents/triggers.md
@@ -34,7 +34,7 @@ What happens:
 
 1. The bridge looks up `~/.patchwork/recipes/*.yaml` for a recipe whose trigger declares `path: /hooks/<your-path-here>`.
 2. If found, the recipe runs with `payload` (the parsed JSON body) bound into the template context.
-3. Approval gates fire on any write/external step — the recipe doesn't bypass policy because a webhook fired it.
+3. Your delegation policy fires on any write/external step — the recipe doesn't bypass policy because a webhook fired it.
 
 Returns:
 
@@ -64,12 +64,11 @@ Or read it from the lock file: `~/.claude/ide/<port>.lock`'s `authToken` field.
 Save this as `~/.patchwork/recipes/capture-thought.yaml`:
 
 ```yaml
-apiVersion: patchwork.sh/v1
 name: capture-thought
 description: Append a payload to ~/.patchwork/inbox/thoughts.md with timestamp
 trigger:
   type: webhook
-  path: /hooks/thought
+  path: /thought
 steps:
   - tool: file.append
     path: ~/.patchwork/inbox/thoughts.md
@@ -78,6 +77,8 @@ steps:
       {{payload.text}}
       ---
 ```
+
+> **Note on the path field.** The recipe declares `path: /thought` but you POST to `/hooks/thought`. The bridge serves `/hooks/<path>` on its HTTP listener and looks up recipes whose `trigger.path` matches the suffix — don't include `/hooks/` in `trigger.path` or it will never fire. Five ready-to-copy webhook recipes (capture-thought, morning-brief, meeting-prep, incident-intake, customer-escalation) ship in [`templates/recipes/webhook/`](../templates/recipes/webhook/).
 
 Confirm it's installed:
 
@@ -302,9 +303,10 @@ Fires only on `patchwork run <recipe-name>`. Useful for one-shots and debug reci
 
 Webhooks don't bypass anything. Specifically:
 
-- **Approval gates still fire.** A webhook recipe that writes to disk or calls a connector still goes through `--approval-gate` if active. Risk-tier escalation works the same way.
+- **Delegation policy still fires.** A webhook recipe that writes to disk or calls a connector still goes through `--approval-gate` (the CLI flag is preserved for back-compat; the user-facing concept is the delegation policy — see [`templates/policies/`](../templates/policies/) for persona presets). Risk-tier escalation works the same way.
 - **Trace memory still records.** Every webhook-triggered run lands in `~/.patchwork/runs.jsonl` with the full lifecycle. `patchwork traces export` includes it.
 - **The dashboard shows in-flight runs.** Open `http://localhost:3100/runs` to watch a webhook-fired recipe execute step by step.
+- **The dashboard surfaces the URL + curl + last payload per recipe.** Expand any webhook recipe row at `/recipes` to copy the full URL, copy a runnable `curl` example, and inspect the last 5 payloads received (most recent on top, with ok/err status, timestamps, and pretty-printed JSON bodies). The Test button fires a sample POST so you can confirm the wiring before configuring an external trigger.
 - **Replay works.** Webhook-fired runs can be mocked-replayed via `POST /runs/:seq/replay` like any other run.
 
 ---


### PR DESCRIPTION
## Summary

Phase 1 §4 doc cleanup. The walkthrough doc \`documents/triggers.md\` shipped via #135 but predates the recent §2 + §4 work. Three substantive fixes:

### 1. Recipe \`trigger.path\` example was wrong
Old example used \`path: /hooks/thought\`, which would never match — the bridge serves \`/hooks/<path>\` on its HTTP listener and matches recipes by the suffix only. \`/hooks/thought\` would mean URL \`/hooks//hooks/thought\`. Fixed to \`path: /thought\` plus an inline callout explaining why.

Also dropped the \`apiVersion: patchwork.sh/v1\` field — no current template uses it; it doesn't exist in the schema.

### 2. \"Approval gate\" → \"Delegation policy\"
Two mentions updated (PR #157). The \`--approval-gate\` CLI flag is preserved for back-compat; just the user-facing concept name changed.

### 3. Trust+observability section now reflects new dashboard surface
- Adds a bullet for the copyable URL + curl example + last-payload card (PRs #161, #163)
- Calls out the five new webhook recipe templates (PR #162) so readers know they don't have to write the YAML from scratch

Diff: 1 file, +6/-4. Cosmetic — the doc was structurally fine.

## Phase 1 §4 status after this

- ✅ #161 — copyable webhook URL + curl on dashboard
- ✅ #162 — five webhook recipe templates
- ✅ #163 — last-payload card
- ✅ this PR — doc walkthrough aligned with all of the above

§4 is closed.

## Test plan
- [x] \`grep\` for stale \"approval gate\" references → none remain in \`documents/triggers.md\`
- [x] All cross-links resolve (\`templates/policies/\`, \`templates/recipes/webhook/\`)
- [ ] Visual: render the markdown in GitHub's preview to confirm formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)