### PR TITLE
feat(traces): patchwork traces import — restore an export bundle

### DIFF
--- a/src/commands/__tests__/tracesImport.test.ts
+++ b/src/commands/__tests__/tracesImport.test.ts
@@ -1,0 +1,203 @@
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { runTracesExport } from "../tracesExport.js";
+import { runTracesImport } from "../tracesImport.js";
+
+describe("tracesImport", () => {
+  let workDir: string;
+  let srcPatchwork: string;
+  let srcActivity: string;
+  let dstPatchwork: string;
+  let dstActivity: string;
+  let bundlePath: string;
+
+  beforeEach(() => {
+    workDir = path.join(
+      os.tmpdir(),
+      `traces-import-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    srcPatchwork = path.join(workDir, "src-pw");
+    srcActivity = path.join(workDir, "src-act");
+    dstPatchwork = path.join(workDir, "dst-pw");
+    dstActivity = path.join(workDir, "dst-act");
+    mkdirSync(srcPatchwork, { recursive: true });
+    mkdirSync(srcActivity, { recursive: true });
+    bundlePath = path.join(workDir, "bundle.jsonl.gz");
+  });
+
+  afterEach(() => {
+    if (existsSync(workDir)) rmSync(workDir, { recursive: true, force: true });
+  });
+
+  async function exportFromSrc() {
+    return runTracesExport({
+      output: bundlePath,
+      patchworkDir: srcPatchwork,
+      activityDir: srcActivity,
+    });
+  }
+
+  it("round-trips a multi-source export through import (append mode)", async () => {
+    writeFileSync(
+      path.join(srcPatchwork, "runs.jsonl"),
+      `${JSON.stringify({ seq: 1, recipe: "morning-brief" })}\n${JSON.stringify({ seq: 2, recipe: "capture-thought" })}\n`,
+    );
+    writeFileSync(
+      path.join(srcPatchwork, "decision_traces.jsonl"),
+      `${JSON.stringify({ id: "t1", problem: "X", solution: "Y" })}\n`,
+    );
+    writeFileSync(
+      path.join(srcActivity, "activity-3000.jsonl"),
+      `${JSON.stringify({ kind: "tool", tool: "git.log_since" })}\n`,
+    );
+
+    await exportFromSrc();
+    expect(existsSync(bundlePath)).toBe(true);
+
+    const result = await runTracesImport({
+      input: bundlePath,
+      patchworkDir: dstPatchwork,
+      activityDir: dstActivity,
+    });
+
+    expect(result.totalCount).toBe(4);
+    expect(result.mode).toBe("append");
+    const runsContent = readFileSync(
+      path.join(dstPatchwork, "runs.jsonl"),
+      "utf-8",
+    );
+    expect(runsContent).toContain('"seq":1');
+    expect(runsContent).toContain('"seq":2');
+    const decisionsContent = readFileSync(
+      path.join(dstPatchwork, "decision_traces.jsonl"),
+      "utf-8",
+    );
+    expect(decisionsContent).toContain('"problem":"X"');
+    const activityContent = readFileSync(
+      path.join(dstActivity, "activity-3000.jsonl"),
+      "utf-8",
+    );
+    expect(activityContent).toContain("git.log_since");
+  });
+
+  it("append mode duplicates rows when re-importing the same bundle", async () => {
+    writeFileSync(
+      path.join(srcPatchwork, "runs.jsonl"),
+      `${JSON.stringify({ seq: 1 })}\n`,
+    );
+    await exportFromSrc();
+
+    await runTracesImport({
+      input: bundlePath,
+      patchworkDir: dstPatchwork,
+      activityDir: dstActivity,
+    });
+    await runTracesImport({
+      input: bundlePath,
+      patchworkDir: dstPatchwork,
+      activityDir: dstActivity,
+    });
+
+    const content = readFileSync(
+      path.join(dstPatchwork, "runs.jsonl"),
+      "utf-8",
+    );
+    // documented behavior — append mode does not dedup
+    expect(content.match(/"seq":1/g)?.length).toBe(2);
+  });
+
+  it("overwrite mode truncates target before writing", async () => {
+    writeFileSync(
+      path.join(srcPatchwork, "runs.jsonl"),
+      `${JSON.stringify({ seq: 99 })}\n`,
+    );
+    await exportFromSrc();
+
+    // Pre-existing content in destination — should be wiped by overwrite.
+    mkdirSync(dstPatchwork, { recursive: true });
+    writeFileSync(
+      path.join(dstPatchwork, "runs.jsonl"),
+      `${JSON.stringify({ seq: 1, stale: true })}\n`,
+    );
+
+    await runTracesImport({
+      input: bundlePath,
+      patchworkDir: dstPatchwork,
+      activityDir: dstActivity,
+      mode: "overwrite",
+    });
+
+    const content = readFileSync(
+      path.join(dstPatchwork, "runs.jsonl"),
+      "utf-8",
+    );
+    expect(content).not.toContain("stale");
+    expect(content).toContain('"seq":99');
+  });
+
+  it("dry-run reports rows without touching disk", async () => {
+    writeFileSync(
+      path.join(srcPatchwork, "runs.jsonl"),
+      `${JSON.stringify({ seq: 1 })}\n${JSON.stringify({ seq: 2 })}\n`,
+    );
+    await exportFromSrc();
+
+    const result = await runTracesImport({
+      input: bundlePath,
+      patchworkDir: dstPatchwork,
+      activityDir: dstActivity,
+      dryRun: true,
+    });
+
+    expect(result.dryRun).toBe(true);
+    expect(result.totalCount).toBe(2);
+    expect(existsSync(path.join(dstPatchwork, "runs.jsonl"))).toBe(false);
+  });
+
+  it("rejects a bundle with no manifest line", async () => {
+    writeFileSync(
+      bundlePath.replace(/\.gz$/, ""),
+      '{"source":"runs","entry":{"seq":1}}\n',
+    );
+    await expect(
+      runTracesImport({
+        input: bundlePath.replace(/\.gz$/, ""),
+        patchworkDir: dstPatchwork,
+        activityDir: dstActivity,
+      }),
+    ).rejects.toThrow(/manifest/i);
+  });
+
+  it("rejects an unsupported bundle version", async () => {
+    const plainBundle = bundlePath.replace(/\.gz$/, "");
+    writeFileSync(
+      plainBundle,
+      `${JSON.stringify({ type: "manifest", version: 999, exportedAt: "now", sources: [], files: [], totalCount: 0 })}\n`,
+    );
+    await expect(
+      runTracesImport({
+        input: plainBundle,
+        patchworkDir: dstPatchwork,
+        activityDir: dstActivity,
+      }),
+    ).rejects.toThrow(/version 999/);
+  });
+
+  it("missing input file errors clearly", async () => {
+    await expect(
+      runTracesImport({
+        input: path.join(workDir, "does-not-exist.jsonl.gz"),
+        patchworkDir: dstPatchwork,
+        activityDir: dstActivity,
+      }),
+    ).rejects.toThrow(/not found/);
+  });
+});

--- a/src/commands/tracesImport.ts
+++ b/src/commands/tracesImport.ts
@@ -1,0 +1,243 @@
+/**
+ * patchwork traces import — restore a bundle written by `tracesExport` into
+ * the local patchwork dirs. Closes the export → backup → restore-on-new-
+ * machine loop that was half-shipped (export landed, import did not).
+ *
+ * Bundle format is the manifest+row-envelope schema from tracesExport.ts:
+ *
+ *   {"type":"manifest","version":1,"exportedAt":"...","sources":[...],"files":[...]}
+ *   {"source":"runs","entry":{...}}
+ *   {"source":"decision_traces","entry":{...}}
+ *   ...
+ *
+ * Modes:
+ *   - "append" (default) — entries are appended to the target file. The
+ *     bundle's row order is preserved. No dedup; if you import the same
+ *     bundle twice, you get duplicates. This is by design — dedup needs
+ *     a stable key choice per source and we'd rather ship the simple
+ *     thing now and add it as a follow-up.
+ *   - "overwrite" — target file is truncated before any writes. Use
+ *     this for "clean restore on a fresh machine" — never use it when
+ *     there's local data you want to keep.
+ *
+ * Encryption: `.age` bundles must be decrypted out-of-band first
+ * (`age -d bundle.jsonl.gz.age | gunzip > bundle.jsonl`). A `--decrypt`
+ * flag is a small follow-up.
+ */
+
+import {
+  appendFileSync,
+  createReadStream,
+  existsSync,
+  mkdirSync,
+  writeFileSync,
+} from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { createInterface } from "node:readline";
+import { createGunzip } from "node:zlib";
+import { TRACES_EXPORT_VERSION, type TraceSource } from "./tracesExport.js";
+
+export type ImportMode = "append" | "overwrite";
+
+export interface TracesImportOptions {
+  /** Path to a `.jsonl.gz` (or plain `.jsonl`) bundle written by tracesExport. */
+  input: string;
+  /** Where to restore single-file sources. Default: `~/.patchwork/`. */
+  patchworkDir?: string;
+  /** Where to restore activity-*.jsonl. Default: `~/.claude/ide/`. */
+  activityDir?: string;
+  /** "append" (default) or "overwrite". */
+  mode?: ImportMode;
+  /** Don't write anything — return what would happen. */
+  dryRun?: boolean;
+}
+
+export interface TracesImportResult {
+  inputPath: string;
+  exportedAt: string;
+  mode: ImportMode;
+  dryRun: boolean;
+  /** Per target-file accounting. Multiple files possible for activity (one per source bridge instance). */
+  files: Array<{
+    source: TraceSource;
+    targetPath: string;
+    /** Rows written (or that would be written, in dry-run). */
+    count: number;
+  }>;
+  /** Total rows across all target files. */
+  totalCount: number;
+}
+
+interface ManifestEnvelope {
+  type: "manifest";
+  version: number;
+  exportedAt: string;
+  sources: TraceSource[];
+  files: Array<{
+    source: TraceSource;
+    relativePath: string;
+    count: number;
+    bytes: number;
+  }>;
+  totalCount: number;
+}
+
+const SINGLE_FILE_TARGETS: Record<Exclude<TraceSource, "activity">, string> = {
+  runs: "runs.jsonl",
+  decision_traces: "decision_traces.jsonl",
+  commit_issue_links: "commit_issue_links.jsonl",
+};
+
+function defaultPatchworkDir(): string {
+  return path.join(os.homedir(), ".patchwork");
+}
+
+function defaultActivityDir(): string {
+  return path.join(os.homedir(), ".claude", "ide");
+}
+
+function resolveTargetPath(
+  source: TraceSource,
+  envelopeFile: string | undefined,
+  patchworkDir: string,
+  activityDir: string,
+): string {
+  if (source === "activity") {
+    // activity rows carry the original file name — preserve it so a
+    // multi-instance export round-trips per-port. Default fallback if
+    // the envelope didn't include one.
+    const name = envelopeFile ?? "activity.jsonl";
+    return path.join(activityDir, name);
+  }
+  return path.join(patchworkDir, SINGLE_FILE_TARGETS[source]);
+}
+
+export async function runTracesImport(
+  opts: TracesImportOptions,
+): Promise<TracesImportResult> {
+  const inputPath = path.resolve(opts.input);
+  if (!existsSync(inputPath)) {
+    throw new Error(`Input bundle not found: ${inputPath}`);
+  }
+  const mode: ImportMode = opts.mode ?? "append";
+  const dryRun = opts.dryRun === true;
+  const patchworkDir = opts.patchworkDir ?? defaultPatchworkDir();
+  const activityDir = opts.activityDir ?? defaultActivityDir();
+
+  if (!dryRun) {
+    if (!existsSync(patchworkDir)) mkdirSync(patchworkDir, { recursive: true });
+    if (!existsSync(activityDir)) mkdirSync(activityDir, { recursive: true });
+  }
+
+  // Stream-read the bundle. Auto-detect gzip via `.gz` suffix; users who
+  // already gunzipped manually can pass the plain .jsonl.
+  const baseStream = createReadStream(inputPath);
+  const lineStream = inputPath.endsWith(".gz")
+    ? baseStream.pipe(createGunzip())
+    : baseStream;
+  const rl = createInterface({ input: lineStream, crlfDelay: Infinity });
+
+  let manifest: ManifestEnvelope | null = null;
+  // Group writes by target so we can truncate-once for overwrite mode and
+  // batch the appends. Memory cost is one row's worth of buffer per target,
+  // which is acceptable for a CLI command operating on user-machine-sized
+  // data.
+  const buffers = new Map<string, { source: TraceSource; lines: string[] }>();
+  let lineNum = 0;
+
+  for await (const raw of rl) {
+    lineNum++;
+    const line = raw.trim();
+    if (line === "") continue;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      throw new Error(`Bundle parse error at line ${lineNum}: not valid JSON`);
+    }
+
+    if (lineNum === 1) {
+      // First non-empty line must be the manifest.
+      if (
+        !parsed ||
+        typeof parsed !== "object" ||
+        (parsed as { type?: unknown }).type !== "manifest"
+      ) {
+        throw new Error(
+          `First line of bundle is not a manifest envelope (got: ${line.slice(0, 80)}…)`,
+        );
+      }
+      manifest = parsed as ManifestEnvelope;
+      if (manifest.version !== TRACES_EXPORT_VERSION) {
+        throw new Error(
+          `Bundle version ${manifest.version} not supported (expected ${TRACES_EXPORT_VERSION})`,
+        );
+      }
+      continue;
+    }
+
+    if (manifest === null) {
+      throw new Error("Bundle has rows before a manifest line");
+    }
+
+    const env = parsed as {
+      source?: unknown;
+      entry?: unknown;
+      file?: unknown;
+    };
+    if (typeof env.source !== "string" || env.entry === undefined) {
+      throw new Error(`Bundle row at line ${lineNum} missing source/entry`);
+    }
+    const source = env.source as TraceSource;
+    const file = typeof env.file === "string" ? env.file : undefined;
+    const targetPath = resolveTargetPath(
+      source,
+      file,
+      patchworkDir,
+      activityDir,
+    );
+    const buf = buffers.get(targetPath) ?? { source, lines: [] };
+    // Re-serialize the entry as one JSONL line. Tools downstream of these
+    // files expect one JSON object per line, no envelope.
+    buf.lines.push(JSON.stringify(env.entry));
+    buffers.set(targetPath, buf);
+  }
+
+  if (manifest === null) {
+    throw new Error("Bundle is empty (no manifest line)");
+  }
+
+  // Apply: in overwrite mode, truncate each target before appending its
+  // batch. In append mode, just append.
+  const files: TracesImportResult["files"] = [];
+  let totalCount = 0;
+  for (const [targetPath, buf] of buffers) {
+    const count = buf.lines.length;
+    totalCount += count;
+    if (!dryRun) {
+      // Ensure the target directory exists (activity-port files might
+      // land in a dir we don't control — covered by the mkdir above for
+      // the configured activityDir, but parent dir of arbitrary path
+      // needs its own check).
+      const parent = path.dirname(targetPath);
+      if (!existsSync(parent)) mkdirSync(parent, { recursive: true });
+      const payload = `${buf.lines.join("\n")}\n`;
+      if (mode === "overwrite") {
+        writeFileSync(targetPath, payload, "utf-8");
+      } else {
+        appendFileSync(targetPath, payload, "utf-8");
+      }
+    }
+    files.push({ source: buf.source, targetPath, count });
+  }
+
+  return {
+    inputPath,
+    exportedAt: manifest.exportedAt,
+    mode,
+    dryRun,
+    files: files.sort((a, b) => a.targetPath.localeCompare(b.targetPath)),
+    totalCount,
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1564,6 +1564,98 @@ if (process.argv[2] === "traces" && process.argv[3] === "export") {
   })();
 }
 
+// Patchwork: `patchwork traces import <bundle>` — restore an export bundle
+// into the local patchwork dirs. Closes the half-shipped backup loop.
+if (process.argv[2] === "traces" && process.argv[3] === "import") {
+  (async () => {
+    try {
+      const args = process.argv.slice(4);
+      let input: string | undefined;
+      let patchworkDir: string | undefined;
+      let activityDir: string | undefined;
+      let mode: "append" | "overwrite" = "append";
+      let dryRun = false;
+      for (let i = 0; i < args.length; i++) {
+        const a = args[i];
+        if (a === "--patchwork-dir") {
+          patchworkDir = args[i + 1];
+          i++;
+        } else if (a === "--activity-dir") {
+          activityDir = args[i + 1];
+          i++;
+        } else if (a === "--mode") {
+          const m = args[i + 1];
+          if (m !== "append" && m !== "overwrite") {
+            process.stderr.write(
+              `Error: --mode must be "append" or "overwrite" (got: ${m})\n`,
+            );
+            process.exit(1);
+          }
+          mode = m;
+          i++;
+        } else if (a === "--dry-run") {
+          dryRun = true;
+        } else if (a === "--help" || a === "-h") {
+          process.stdout.write(
+            "patchwork traces import <bundle.jsonl.gz> [--mode append|overwrite] [--dry-run]\n" +
+              "                              [--patchwork-dir <dir>] [--activity-dir <dir>]\n\n" +
+              "Restore a bundle written by `patchwork traces export` into the local\n" +
+              "patchwork dirs (~/.patchwork/ and ~/.claude/ide/ by default).\n\n" +
+              "Modes:\n" +
+              "  append     (default) Append rows to existing files. Re-importing the\n" +
+              "             same bundle produces duplicates — bundle dedup is a follow-up.\n" +
+              "  overwrite  Truncate target files before writing. Use for fresh-machine\n" +
+              "             restore; never use when there's local data you want to keep.\n\n" +
+              "Encrypted (.age) bundles must be decrypted out-of-band first:\n" +
+              "  age -d bundle.jsonl.gz.age > bundle.jsonl.gz\n",
+          );
+          process.exit(0);
+        } else if (
+          a !== undefined &&
+          !a.startsWith("--") &&
+          input === undefined
+        ) {
+          input = a;
+        }
+      }
+      if (!input) {
+        process.stderr.write(
+          "Usage: patchwork traces import <bundle.jsonl.gz> [--mode append|overwrite] [--dry-run]\n",
+        );
+        process.exit(1);
+      }
+      const { runTracesImport } = await import("./commands/tracesImport.js");
+      const result = await runTracesImport({
+        input,
+        ...(patchworkDir !== undefined && { patchworkDir }),
+        ...(activityDir !== undefined && { activityDir }),
+        mode,
+        dryRun,
+      });
+      const verb = result.dryRun
+        ? "Would restore"
+        : result.mode === "overwrite"
+          ? "Restored (overwrite)"
+          : "Restored (append)";
+      process.stdout.write(
+        `  ${result.dryRun ? "•" : "✓"} ${verb} ${result.totalCount} rows from ${result.inputPath}\n`,
+      );
+      process.stdout.write(`    Bundle exportedAt: ${result.exportedAt}\n`);
+      for (const f of result.files) {
+        process.stdout.write(
+          `    - ${f.source}: ${f.count} rows  →  ${f.targetPath}\n`,
+        );
+      }
+      process.exit(0);
+    } catch (err) {
+      process.stderr.write(
+        `Error: ${err instanceof Error ? err.message : String(err)}\n`,
+      );
+      process.exit(1);
+    }
+  })();
+}
+
 if (process.argv[2] === "recipe" && process.argv[3] === "schema") {
   const outputDir = process.argv[4] ?? path.join(process.cwd(), "schemas");
   (async () => {


### PR DESCRIPTION
## Summary

Phase 3 §1 (Trace Backup and Sync). Closes the half-shipped backup loop — export landed earlier; import didn't, so a user could bundle their traces but had no clean way to restore them on a new machine.

\`\`\`sh
patchwork traces import <bundle.jsonl.gz>
\`\`\`

Reads a bundle written by \`patchwork traces export\`, validates the manifest envelope (version 1), groups rows by target file, and writes to \`~/.patchwork/{runs,decision_traces,commit_issue_links}.jsonl\` plus \`~/.claude/ide/activity-*.jsonl\`. Activity-port suffix is preserved so multi-instance exports round-trip correctly.

## Modes

| Mode | Behavior |
|---|---|
| \`append\` (default) | Adds rows to existing files. Re-importing the same bundle produces duplicates — documented; dedup needs a stable per-source key choice and is a follow-up. |
| \`overwrite\` | Truncates target files before writing. For fresh-machine restore. |
| \`--dry-run\` | Parses + reports what would happen, writes nothing. |

## Encryption

The earlier \`--encrypt\` export landed before this. \`.age\` bundles must be decrypted out-of-band (\`age -d bundle.age | gunzip > bundle.jsonl.gz\`) because we don't yet take a passphrase on import. A \`--decrypt\` flag is the obvious follow-up.

## Tests

7 new tests covering: round-trip, append-duplicates, overwrite-truncates, dry-run-no-writes, no-manifest rejection, bad-version rejection, missing-input error.

All 4775 tests pass locally (4768 existing + 7 new).

CLI smoke-tested end-to-end:
\`\`\`
✓ Wrote /tmp/bundle.jsonl.gz
  3 rows from 3 files
✓ Restored (append) 3 rows from /tmp/bundle.jsonl.gz
  - activity: 1 rows  →  /tmp/dst/act/activity-3000.jsonl
  - decision_traces: 1 rows  →  /tmp/dst/pw/decision_traces.jsonl
  - runs: 1 rows  →  /tmp/dst/pw/runs.jsonl
\`\`\`

## Test plan
- [x] \`npm run build\` clean
- [x] \`npm test\` 4775/4775 pass
- [x] CLI: export → bundle → import → contents match
- [x] CLI: \`--dry-run\` writes nothing
- [x] CLI: \`--mode overwrite\` truncates pre-existing target file
- [ ] Real machine: backup laptop → fresh machine → restore round-trip

🤖 Generated with [Claude Code](https://claude.com/claude-code)