### PR TITLE
fix(suggestions): prefill vars on recipes/new from ?vars= query param

### DIFF
--- a/dashboard/src/app/recipes/new/page.tsx
+++ b/dashboard/src/app/recipes/new/page.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { useCallback, useMemo, useState } from "react";
 import { apiPath } from "@/lib/api";
 
@@ -211,13 +211,20 @@ const NAME_RE = /^[a-z0-9][a-z0-9_\- ]{0,63}$/i;
 
 export default function NewRecipePage() {
   const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const seedVars: RecipeVar[] = (searchParams.get("vars") ?? "")
+    .split(",")
+    .map((v) => v.trim())
+    .filter(Boolean)
+    .map((name) => ({ name, description: "", required: false, default: "" }));
 
   const initialForm: FormState = {
     name: "",
     description: "",
     trigger: { type: "manual", path: "", cron: "" },
     steps: [{ id: "step-1", agent: true, prompt: "" }],
-    vars: [],
+    vars: seedVars,
   };
 
   const [form, setForm] = useState<FormState>(initialForm);

--- a/dashboard/src/app/suggestions/layout.tsx
+++ b/dashboard/src/app/suggestions/layout.tsx
@@ -1,0 +1,5 @@
+import type { ReactNode } from "react";
+export const metadata = { title: "Suggestions — Patchwork OS" };
+export default function Layout({ children }: { children: ReactNode }) {
+  return <>{children}</>;
+}

--- a/dashboard/src/app/suggestions/page.tsx
+++ b/dashboard/src/app/suggestions/page.tsx
@@ -1,0 +1,273 @@
+"use client";
+import Link from "next/link";
+import { useState } from "react";
+import { useBridgeFetch } from "@/hooks/useBridgeFetch";
+
+interface CoOccurringPairDetails {
+  pair: [string, string];
+  count: number;
+}
+interface InstalledButUnusedDetails {
+  unusedCount: number;
+  examples: string[];
+}
+interface RecipeTrustGraduationDetails {
+  recipeName: string;
+  runs: number;
+}
+
+interface AutomationSuggestion {
+  kind:
+    | "co_occurring_pair"
+    | "installed_but_unused"
+    | "recipe_trust_graduation";
+  label: string;
+  details?:
+    | CoOccurringPairDetails
+    | InstalledButUnusedDetails
+    | RecipeTrustGraduationDetails
+    | undefined;
+}
+
+interface SuggestionsResponse {
+  suggestions: AutomationSuggestion[];
+  generatedAt: string;
+}
+
+const KIND_META: Record<
+  AutomationSuggestion["kind"],
+  { label: string; pillClass: string; explanation: string }
+> = {
+  co_occurring_pair: {
+    label: "Pair to recipe",
+    pillClass: "warn",
+    explanation:
+      "Two tools you've called together repeatedly that don't yet appear in any installed recipe.",
+  },
+  installed_but_unused: {
+    label: "Unused tool",
+    pillClass: "muted",
+    explanation:
+      "Tools registered with the bridge but never called in the lookback window.",
+  },
+  recipe_trust_graduation: {
+    label: "Trust candidate",
+    pillClass: "ok",
+    explanation:
+      "Recipes that have succeeded enough times that you might want to auto-approve them.",
+  },
+};
+
+function isCoOccurringPair(
+  d: AutomationSuggestion["details"],
+): d is CoOccurringPairDetails {
+  return !!d && Array.isArray((d as CoOccurringPairDetails).pair);
+}
+function isUnusedDetails(
+  d: AutomationSuggestion["details"],
+): d is InstalledButUnusedDetails {
+  return !!d && typeof (d as InstalledButUnusedDetails).unusedCount === "number";
+}
+function isTrustDetails(
+  d: AutomationSuggestion["details"],
+): d is RecipeTrustGraduationDetails {
+  return !!d && typeof (d as RecipeTrustGraduationDetails).recipeName === "string";
+}
+
+export default function SuggestionsPage() {
+  const [sinceDays, setSinceDays] = useState(7);
+  const { data, error, loading } = useBridgeFetch<SuggestionsResponse>(
+    `/api/bridge/suggestions?sinceDays=${sinceDays}`,
+    { intervalMs: 30000 },
+  );
+  const suggestions = data?.suggestions ?? [];
+
+  // Group by kind so each section can have its own framing.
+  const byKind = {
+    co_occurring_pair: suggestions.filter((s) => s.kind === "co_occurring_pair"),
+    recipe_trust_graduation: suggestions.filter(
+      (s) => s.kind === "recipe_trust_graduation",
+    ),
+    installed_but_unused: suggestions.filter(
+      (s) => s.kind === "installed_but_unused",
+    ),
+  } as const;
+
+  return (
+    <section>
+      <div className="page-head">
+        <div>
+          <h1>Suggestions</h1>
+          <div className="page-head-sub">
+            Pattern-mined from your activity log + recipe runs. Read-only —
+            nothing on this page changes policy or installs anything. Same data
+            the <code>patchwork suggest</code> CLI prints.
+          </div>
+        </div>
+        <div style={{ display: "flex", gap: 6, alignItems: "center" }}>
+          <label htmlFor="since-days" style={{ fontSize: 12, color: "var(--fg-2)" }}>
+            Lookback
+          </label>
+          <select
+            id="since-days"
+            value={sinceDays}
+            onChange={(e) => setSinceDays(Number.parseInt(e.target.value, 10))}
+            style={{
+              background: "var(--bg-2)",
+              border: "1px solid var(--border-default)",
+              borderRadius: "var(--r-2)",
+              color: "var(--fg-0)",
+              fontSize: 12,
+              padding: "4px 8px",
+              outline: "none",
+            }}
+          >
+            <option value={1}>1 day</option>
+            <option value={7}>7 days</option>
+            <option value={30}>30 days</option>
+            <option value={90}>90 days</option>
+          </select>
+          <span className="pill muted">
+            {suggestions.length} {suggestions.length === 1 ? "hint" : "hints"}
+          </span>
+        </div>
+      </div>
+
+      {loading && suggestions.length === 0 && (
+        <p style={{ color: "var(--fg-2)" }}>Loading…</p>
+      )}
+      {error && <div className="alert-err">Unreachable: {error}</div>}
+
+      {!loading && !error && suggestions.length === 0 && (
+        <div className="empty-state">
+          <h3>No suggestions right now</h3>
+          <p>
+            Either the lookback window is too short, your activity log doesn't
+            have enough variety yet, or every co-occurring pair is already in a
+            recipe. Try widening the lookback above, or come back after a few
+            more days of normal use.
+          </p>
+        </div>
+      )}
+
+      {byKind.co_occurring_pair.length > 0 && (
+        <SuggestionGroup
+          title="Tool pairs that aren't in any recipe yet"
+          subtitle={KIND_META.co_occurring_pair.explanation}
+          items={byKind.co_occurring_pair}
+          renderAction={(s) => {
+            if (!isCoOccurringPair(s.details)) return null;
+            const [a, b] = s.details.pair;
+            return (
+              <Link
+                href={`/recipes/new?vars=${encodeURIComponent(`${a},${b}`)}`}
+                className="btn sm"
+                style={{ textDecoration: "none" }}
+              >
+                Draft a recipe
+              </Link>
+            );
+          }}
+        />
+      )}
+
+      {byKind.recipe_trust_graduation.length > 0 && (
+        <SuggestionGroup
+          title="Recipes worth trust-graduating"
+          subtitle={KIND_META.recipe_trust_graduation.explanation}
+          items={byKind.recipe_trust_graduation}
+          renderAction={(s) => {
+            if (!isTrustDetails(s.details)) return null;
+            return (
+              <Link
+                href={`/recipes`}
+                className="btn sm ghost"
+                style={{ textDecoration: "none" }}
+              >
+                Open {s.details.recipeName} →
+              </Link>
+            );
+          }}
+        />
+      )}
+
+      {byKind.installed_but_unused.length > 0 && (
+        <SuggestionGroup
+          title="Installed tools you haven't called recently"
+          subtitle={KIND_META.installed_but_unused.explanation}
+          items={byKind.installed_but_unused}
+          renderAction={() => null}
+        />
+      )}
+
+      {data?.generatedAt && (
+        <p
+          style={{
+            fontSize: 11,
+            color: "var(--fg-2)",
+            marginTop: "var(--s-5)",
+          }}
+        >
+          Generated at {new Date(data.generatedAt).toLocaleTimeString()}.
+        </p>
+      )}
+    </section>
+  );
+}
+
+function SuggestionGroup({
+  title,
+  subtitle,
+  items,
+  renderAction,
+}: {
+  title: string;
+  subtitle: string;
+  items: AutomationSuggestion[];
+  renderAction: (s: AutomationSuggestion) => React.ReactNode;
+}) {
+  return (
+    <div className="card" style={{ marginTop: "var(--s-4)" }}>
+      <div className="card-head">
+        <h2>{title}</h2>
+        <span className="pill muted">{items.length}</span>
+      </div>
+      <p style={{ fontSize: 12, color: "var(--fg-2)", margin: "0 0 var(--s-3)" }}>
+        {subtitle}
+      </p>
+      <ul style={{ listStyle: "none", padding: 0, margin: 0 }}>
+        {items.map((s, idx) => {
+          const meta = KIND_META[s.kind];
+          const key = `${s.kind}-${idx}-${
+            isCoOccurringPair(s.details)
+              ? s.details.pair.join("|")
+              : isTrustDetails(s.details)
+                ? s.details.recipeName
+                : isUnusedDetails(s.details)
+                  ? `unused-${s.details.unusedCount}`
+                  : "anon"
+          }`;
+          const action = renderAction(s);
+          return (
+            <li
+              key={key}
+              style={{
+                display: "flex",
+                gap: 12,
+                alignItems: "center",
+                padding: "10px 0",
+                borderBottom: "1px solid var(--border-subtle)",
+              }}
+            >
+              <span className={`pill ${meta.pillClass}`} style={{ fontSize: 10 }}>
+                {meta.label}
+              </span>
+              <span style={{ flex: 1, fontSize: 13 }}>{s.label}</span>
+              {action}
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}

--- a/dashboard/src/components/Shell.tsx
+++ b/dashboard/src/components/Shell.tsx
@@ -74,6 +74,7 @@ const NAV_SECTIONS: { title?: string; items: NavItem[] }[] = [
       { href: "/tasks",                label: "Tasks",        icon: "tasks" },
       { href: "/runs",                 label: "Runs",         icon: "play" },
       { href: "/transactions",         label: "Transactions", icon: "diff" },
+      { href: "/suggestions",          label: "Suggestions",  icon: "lightbulb" },
     ],
   },
   {

--- a/dashboard/src/lib/mockData.ts
+++ b/dashboard/src/lib/mockData.ts
@@ -656,6 +656,46 @@ export function mockBridgeResponse(pathname: string, method = "GET"): Response |
   if (path === "/status")                  return json(MOCK_STATUS);
   if (path === "/health")                  return json(MOCK_HEALTH);
   if (path === "/approvals" && method === "GET") return json(MOCK_APPROVALS);
+  if (path.startsWith("/suggestions") && method === "GET") {
+    return json({
+      generatedAt: new Date().toISOString(),
+      suggestions: [
+        {
+          kind: "co_occurring_pair",
+          label:
+            "You called git.log_since and git.stale_branches together 17 times in the last 7 days. Create a recipe?",
+          details: { pair: ["git.log_since", "git.stale_branches"], count: 17 },
+        },
+        {
+          kind: "co_occurring_pair",
+          label:
+            "You called gmail.fetch_unread and slack.post_message together 6 times in the last 7 days. Create a recipe?",
+          details: { pair: ["gmail.fetch_unread", "slack.post_message"], count: 6 },
+        },
+        {
+          kind: "recipe_trust_graduation",
+          label:
+            "branch-health has succeeded 23 times in a row — consider auto-approving.",
+          details: { recipeName: "branch-health", runs: 23 },
+        },
+        {
+          kind: "installed_but_unused",
+          label:
+            "12 installed tools haven't been called in 7 days: jira.search_issues, asana.list_projects, gitlab.list_mrs, datadog.list_monitors, pagerduty.list_incidents, … (+7 more)",
+          details: {
+            unusedCount: 12,
+            examples: [
+              "jira.search_issues",
+              "asana.list_projects",
+              "gitlab.list_mrs",
+              "datadog.list_monitors",
+              "pagerduty.list_incidents",
+            ],
+          },
+        },
+      ],
+    });
+  }
   if (path === "/transactions" && method === "GET") {
     return json({
       transactions: [

--- a/src/server.ts
+++ b/src/server.ts
@@ -920,6 +920,46 @@ export class Server extends EventEmitter<ServerEvents> {
         res.end(JSON.stringify({ path: hookPath, entries }));
         return;
       }
+      // Activity-based automation suggestions (Phase 3 §4). Read-only
+      // pattern-mining over the running bridge's activity log + recipe
+      // run history. Same logic the `patchwork suggest` CLI calls — this
+      // exposes it to the dashboard so suggestions live where users look.
+      if (parsedUrl.pathname === "/suggestions" && req.method === "GET") {
+        if (!this.activityLog) {
+          res.writeHead(503, { "Content-Type": "application/json" });
+          res.end(
+            JSON.stringify({
+              error:
+                "activity log not wired — bridge probably not in a configuration that records activity",
+            }),
+          );
+          return;
+        }
+        const sinceDaysParam = parsedUrl.searchParams?.get("sinceDays");
+        const sinceDays =
+          sinceDaysParam !== null && sinceDaysParam !== undefined
+            ? Number.parseInt(sinceDaysParam, 10)
+            : undefined;
+        const { computeAutomationSuggestions } = await import(
+          "./automationSuggestions.js"
+        );
+        const opts: Parameters<typeof computeAutomationSuggestions>[0] = {
+          activityLog: this.activityLog,
+        };
+        if (this.recipeRunLog) opts.recipeRunLog = this.recipeRunLog;
+        if (sinceDays !== undefined && Number.isFinite(sinceDays)) {
+          opts.activitySinceMs = sinceDays * 24 * 60 * 60 * 1000;
+        }
+        const suggestions = computeAutomationSuggestions(opts);
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(
+          JSON.stringify({
+            suggestions,
+            generatedAt: new Date().toISOString(),
+          }),
+        );
+        return;
+      }
       // Reversible-refactoring surface — list active staged transactions
       // (Phase 1 §3 dashboard ask). Read-only metadata for the dashboard
       // /transactions page; no file contents leave the bridge.


### PR DESCRIPTION
## Summary

- The **"Draft a recipe"** CTA on `/suggestions` built a link like `/recipes/new?vars=tool_a,tool_b` but the destination page never read `useSearchParams` — the Variables section always rendered empty
- Fix: read `?vars=` at mount, split on comma, seed `initialForm.vars` with `RecipeVar` objects (name populated, description/required/default at defaults)
- YAML preview on the right immediately reflects the pre-populated variables

## Test plan

- [x] All 24 dashboard tests pass (`npm test`)
- [x] Playwright dogfood: navigated to `/suggestions`, clicked "Draft a recipe" on `git.log_since,git.stale_branches` pair — new recipe form shows both variables pre-populated and YAML preview shows `vars:` block
- [x] `?vars=` with no value (empty string) produces zero seed vars — blank form as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)