### PR TITLE
feat(runs): parent/child run linking — data layer (Phase 2 §3)

### DIFF
--- a/src/__tests__/runLog.test.ts
+++ b/src/__tests__/runLog.test.ts
@@ -33,6 +33,25 @@ describe("RecipeRunLog.parseTrigger", () => {
       recipeName: "foo:bar",
     });
   });
+
+  it("extracts parentSeq from :p<N> suffix", () => {
+    expect(RecipeRunLog.parseTrigger("recipe:review:p7")).toEqual({
+      trigger: "recipe",
+      recipeName: "review",
+      parentSeq: 7,
+    });
+    // Colon-containing name + parentSeq suffix
+    expect(RecipeRunLog.parseTrigger("recipe:foo:bar:p42")).toEqual({
+      trigger: "recipe",
+      recipeName: "foo:bar",
+      parentSeq: 42,
+    });
+    // No suffix — no parentSeq
+    expect(RecipeRunLog.parseTrigger("recipe:review")).toEqual({
+      trigger: "recipe",
+      recipeName: "review",
+    });
+  });
 });
 
 describe("RecipeRunLog.record", () => {
@@ -360,6 +379,58 @@ describe("RecipeRunLog.record", () => {
     const running = log.query({ status: "running" });
     expect(running).toHaveLength(1);
     expect(running[0]!.seq).toBe(seq);
+  });
+
+  it("startRun stores parentSeq and getChildSeqs returns matching seqs", () => {
+    const log = new RecipeRunLog({ dir: tmp });
+    const parentSeq = log.startRun({
+      taskId: "chained:parent:1",
+      recipeName: "parent",
+      trigger: "recipe",
+      createdAt: 1_000,
+    });
+    const childSeq1 = log.startRun({
+      taskId: "chained:child-a:2",
+      recipeName: "child-a",
+      trigger: "recipe",
+      createdAt: 2_000,
+      parentSeq,
+    });
+    const childSeq2 = log.startRun({
+      taskId: "chained:child-b:3",
+      recipeName: "child-b",
+      trigger: "recipe",
+      createdAt: 3_000,
+      parentSeq,
+    });
+    log.startRun({
+      taskId: "chained:unrelated:4",
+      recipeName: "unrelated",
+      trigger: "recipe",
+      createdAt: 4_000,
+    });
+
+    expect(log.getBySeq(childSeq1)?.parentSeq).toBe(parentSeq);
+    expect(log.getBySeq(childSeq2)?.parentSeq).toBe(parentSeq);
+    const children = log.getChildSeqs(parentSeq);
+    expect(children).toHaveLength(2);
+    expect(children).toContain(childSeq1);
+    expect(children).toContain(childSeq2);
+    expect(log.getChildSeqs(99)).toEqual([]);
+  });
+
+  it("record() stores parentSeq from :p<N> triggerSource suffix", () => {
+    const log = new RecipeRunLog({ dir: tmp });
+    const rec = log.record({
+      id: "child-task",
+      triggerSource: "recipe:child-recipe:p5",
+      status: "done",
+      createdAt: 1_000,
+      doneAt: 2_000,
+    });
+    expect(rec).not.toBeNull();
+    expect(rec!.recipeName).toBe("child-recipe");
+    expect(rec!.parentSeq).toBe(5);
   });
 
   it("completeRun with non-existent seq is a no-op (does not throw)", () => {

--- a/src/recipeOrchestration.ts
+++ b/src/recipeOrchestration.ts
@@ -164,10 +164,13 @@ export class RecipeOrchestration {
 
     server.runDetailFn = (seq: number) => {
       if (!this.deps.recipeRunLog) return null;
-      return this.deps.recipeRunLog.getBySeq(seq) as unknown as Record<
-        string,
-        unknown
-      > | null;
+      const run = this.deps.recipeRunLog.getBySeq(seq);
+      if (!run) return null;
+      const childSeqs = this.deps.recipeRunLog.getChildSeqs(seq);
+      return {
+        ...(run as unknown as Record<string, unknown>),
+        ...(childSeqs.length > 0 && { childSeqs }),
+      };
     };
 
     server.runPlanFn = async (recipeName: string) => {

--- a/src/recipes/chainedRunner.ts
+++ b/src/recipes/chainedRunner.ts
@@ -109,6 +109,11 @@ export interface RunOptions {
    * dogfood where replay runs were indistinguishable from fresh ones.
    */
   taskIdPrefix?: string;
+  /**
+   * seq of the parent run that caused this recipe to fire. Stored in the
+   * run log entry so the dashboard can render the causal chain.
+   */
+  parentSeq?: number;
 }
 
 export interface StepExecutionContext {
@@ -658,6 +663,9 @@ export async function runChainedRecipe(
         trigger: triggerKind,
         createdAt: runStartedAt,
         startedAt: runStartedAt,
+        ...(options.parentSeq !== undefined && {
+          parentSeq: options.parentSeq,
+        }),
       });
     } catch {
       // Non-fatal — run-log failures must never break recipe execution.

--- a/src/runLog.ts
+++ b/src/runLog.ts
@@ -79,6 +79,8 @@ export interface RecipeRun {
   durationMs: number;
   /** Per-step execution results — present when run via yamlRunner or chainedRunner. */
   stepResults?: RunStepResult[];
+  /** seq of the parent run that triggered this one, if trigger === "recipe". */
+  parentSeq?: number;
   /** Assertion failures from the recipe's expect block — present when assertions fail. */
   assertionFailures?: Array<{
     assertion: string;
@@ -157,11 +159,17 @@ export class RecipeRunLog {
    */
   static parseTrigger(
     triggerSource: string | undefined,
-  ): { trigger: RunTrigger; recipeName: string } | null {
+  ): { trigger: RunTrigger; recipeName: string; parentSeq?: number } | null {
     if (!triggerSource) return null;
-    const m = /^(cron|webhook|recipe):(.+)$/.exec(triggerSource);
+    // Format: "<kind>:<name>" or "<kind>:<name>:p<parentSeq>"
+    // parentSeq suffix ":p<N>" is always at the end and uses a numeric-only value.
+    const m = /^(cron|webhook|recipe):(.+?)(?::p(\d+))?$/.exec(triggerSource);
     if (!m?.[1] || !m[2]) return null;
-    return { trigger: m[1] as RunTrigger, recipeName: m[2] };
+    return {
+      trigger: m[1] as RunTrigger,
+      recipeName: m[2],
+      ...(m[3] !== undefined && { parentSeq: parseInt(m[3], 10) }),
+    };
   }
 
   record(task: {
@@ -207,6 +215,7 @@ export class RecipeRunLog {
         errorMessage: task.errorMessage,
       }),
       durationMs,
+      ...(parsed.parentSeq !== undefined && { parentSeq: parsed.parentSeq }),
     };
     this.runs.push(run);
     if (this.runs.length > this.memoryCap) {
@@ -251,6 +260,12 @@ export class RecipeRunLog {
     const inMem = this.runs.find((r) => r.seq === seq);
     if (inMem) return inMem;
     return this.readFromDiskBySeq(seq);
+  }
+
+  /** Return seqs of all in-memory runs whose parentSeq matches this seq. */
+  getChildSeqs(parentSeq: number): number[] {
+    this.syncFromDisk();
+    return this.runs.filter((r) => r.parentSeq === parentSeq).map((r) => r.seq);
   }
 
   private readFromDiskBySeq(seq: number): RecipeRun | null {
@@ -303,6 +318,7 @@ export class RecipeRunLog {
     createdAt: number;
     startedAt?: number;
     model?: string;
+    parentSeq?: number;
   }): number {
     const seq = ++this.seq;
     const run: RecipeRun = {
@@ -319,6 +335,7 @@ export class RecipeRunLog {
       doneAt: opts.createdAt,
       durationMs: 0,
       stepResults: [],
+      ...(opts.parentSeq !== undefined && { parentSeq: opts.parentSeq }),
     };
     this.runs.push(run);
     if (this.runs.length > this.memoryCap) this.runs.shift();


### PR DESCRIPTION
## Summary

Prerequisite data layer for the **Run Timeline** (Phase 2 §3 — causal observability). Without parent→child linkage in the run log, the dashboard can't render `webhook received → recipe A → recipe B` chains.

- **`RecipeRun.parentSeq?: number`** — stored when a run was launched by a parent recipe run
- **`RunOptions.parentSeq?: number`** — threads parent context through `chainedRunner` to `startRun()`
- **`RecipeRunLog.getChildSeqs(parentSeq)`** — fast in-memory lookup, used by the HTTP layer
- **`GET /runs/:seq`** — now returns `childSeqs: number[]` alongside the run (when non-empty)
- **Wire format** — `triggerSource` gains optional `:p<N>` suffix (`"recipe:<name>:p<seq>"`); `parseTrigger()` extracts it; colon-in-name compatibility preserved via non-greedy regex + `$` anchor

## Test plan

- [x] 3 new `runLog.test.ts` cases: `parseTrigger` `:p<N>` suffix, `startRun` parentSeq storage + `getChildSeqs`, `record()` with parent suffix
- [x] Existing `parseTrigger("recipe:foo:bar")` test still passes — colons in recipe names unaffected
- [x] All 4778 tests pass

## What's next

Dashboard PR (`feat/run-timeline-dashboard`) will consume `parentSeq` + `childSeqs` from the run detail endpoint to render the causal timeline in `/runs/[seq]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)