### PR TITLE
feat(recipes): trust graduation — PATCH /recipes/:name/trust + dashboard UX

### DIFF
--- a/dashboard/src/app/recipes/page.tsx
+++ b/dashboard/src/app/recipes/page.tsx
@@ -205,6 +205,41 @@ interface RecipeVar {
   default?: string;
 }
 
+type TrustLevel =
+  | "draft"
+  | "manual_run"
+  | "ask_every_time"
+  | "ask_novel"
+  | "mostly_trusted"
+  | "fully_trusted";
+
+const TRUST_LEVEL_LABELS: Record<TrustLevel, string> = {
+  draft: "Draft",
+  manual_run: "Manual run",
+  ask_every_time: "Ask every time",
+  ask_novel: "Ask on novel cases",
+  mostly_trusted: "Mostly trusted",
+  fully_trusted: "Fully trusted",
+};
+
+const TRUST_LEVEL_COLORS: Record<TrustLevel, string> = {
+  draft: "var(--fg-3)",
+  manual_run: "var(--fg-2)",
+  ask_every_time: "var(--warn, #e6a817)",
+  ask_novel: "var(--warn, #e6a817)",
+  mostly_trusted: "var(--ok, #22c55e)",
+  fully_trusted: "var(--ok, #22c55e)",
+};
+
+const TRUST_LEVELS: TrustLevel[] = [
+  "draft",
+  "manual_run",
+  "ask_every_time",
+  "ask_novel",
+  "mostly_trusted",
+  "fully_trusted",
+];
+
 interface Recipe {
   id?: string;
   name: string;
@@ -217,6 +252,7 @@ interface Recipe {
   stepCount?: number;
   path?: string;
   enabled?: boolean;
+  trustLevel?: TrustLevel;
   vars?: RecipeVar[];
   lastRun?: number;
   lint?: {
@@ -765,6 +801,23 @@ export default function RecipesPage() {
                               ⚠ {r.lint.warningCount}
                             </span>
                           )}
+                          {r.trustLevel && r.trustLevel !== "draft" && (
+                            <span
+                              style={{
+                                background: `color-mix(in srgb, ${TRUST_LEVEL_COLORS[r.trustLevel]} 12%, transparent)`,
+                                border: `1px solid ${TRUST_LEVEL_COLORS[r.trustLevel]}`,
+                                borderRadius: 4,
+                                color: TRUST_LEVEL_COLORS[r.trustLevel],
+                                fontSize: 10,
+                                fontWeight: 600,
+                                padding: "1px 5px",
+                                whiteSpace: "nowrap",
+                              }}
+                              title={`Trust level: ${TRUST_LEVEL_LABELS[r.trustLevel]}`}
+                            >
+                              {TRUST_LEVEL_LABELS[r.trustLevel]}
+                            </span>
+                          )}
                         </div>
                       </td>
                       <td className="mono muted">{r.stepCount ?? "—"}</td>
@@ -836,6 +889,36 @@ export default function RecipesPage() {
                           >
                             {r.enabled === false ? "Enable" : "Disable"}
                           </button>
+                          <select
+                            value={r.trustLevel ?? "draft"}
+                            title="Trust level"
+                            style={{
+                              background: "var(--bg-2)",
+                              border: "1px solid var(--border-default)",
+                              borderRadius: "var(--r-1)",
+                              color: "var(--fg-1)",
+                              cursor: "pointer",
+                              fontSize: 11,
+                              padding: "2px 4px",
+                            }}
+                            onChange={async (e) => {
+                              await fetch(
+                                apiPath(`/api/bridge/recipes/${encodeURIComponent(r.name)}/trust`),
+                                {
+                                  method: "PATCH",
+                                  headers: { "Content-Type": "application/json" },
+                                  body: JSON.stringify({ level: e.target.value }),
+                                },
+                              );
+                              void load();
+                            }}
+                          >
+                            {TRUST_LEVELS.map((lvl) => (
+                              <option key={lvl} value={lvl}>
+                                {TRUST_LEVEL_LABELS[lvl]}
+                              </option>
+                            ))}
+                          </select>
                           {r.webhookPath && (
                             <button
                               type="button"

--- a/dashboard/src/app/suggestions/page.tsx
+++ b/dashboard/src/app/suggestions/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 import Link from "next/link";
 import { useState } from "react";
+import { apiPath } from "@/lib/api";
 import { useBridgeFetch } from "@/hooks/useBridgeFetch";
 
 interface CoOccurringPairDetails {
@@ -57,6 +58,45 @@ const KIND_META: Record<
       "Recipes that have succeeded enough times that you might want to auto-approve them.",
   },
 };
+
+function GraduateButton({ recipeName }: { recipeName: string }) {
+  const [state, setState] = useState<"idle" | "loading" | "done" | "error">(
+    "idle",
+  );
+  async function graduate() {
+    setState("loading");
+    try {
+      const res = await fetch(
+        apiPath(`/api/bridge/recipes/${encodeURIComponent(recipeName)}/trust`),
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ level: "mostly_trusted" }),
+        },
+      );
+      setState(res.ok ? "done" : "error");
+    } catch {
+      setState("error");
+    }
+  }
+  if (state === "done") {
+    return (
+      <span style={{ color: "var(--ok, #22c55e)", fontSize: 13 }}>
+        ✓ Graduated to mostly trusted
+      </span>
+    );
+  }
+  return (
+    <button
+      type="button"
+      className="btn sm"
+      disabled={state === "loading"}
+      onClick={() => void graduate()}
+    >
+      {state === "loading" ? "Graduating…" : state === "error" ? "Retry" : "Graduate trust"}
+    </button>
+  );
+}
 
 function isCoOccurringPair(
   d: AutomationSuggestion["details"],
@@ -178,14 +218,9 @@ export default function SuggestionsPage() {
           items={byKind.recipe_trust_graduation}
           renderAction={(s) => {
             if (!isTrustDetails(s.details)) return null;
+            const { recipeName } = s.details;
             return (
-              <Link
-                href={`/recipes`}
-                className="btn sm ghost"
-                style={{ textDecoration: "none" }}
-              >
-                Open {s.details.recipeName} →
-              </Link>
+              <GraduateButton recipeName={recipeName} />
             );
           }}
         />

--- a/src/recipeOrchestration.ts
+++ b/src/recipeOrchestration.ts
@@ -27,6 +27,7 @@ import {
   saveRecipe,
   saveRecipeContent,
   setRecipeEnabled,
+  setTrustLevel,
 } from "./recipesHttp.js";
 import type { RecipeRunLog } from "./runLog.js";
 import type { Server } from "./server.js";
@@ -118,6 +119,15 @@ export class RecipeOrchestration {
 
     server.lintRecipeContentFn = (content: string) =>
       lintRecipeContent(content);
+
+    server.setRecipeTrustFn = (name: string, level: string) => {
+      const recipesDir = path.join(os.homedir(), ".patchwork", "recipes");
+      return setTrustLevel(
+        recipesDir,
+        name,
+        level as import("./recipesHttp.js").TrustLevel,
+      );
+    };
 
     // biome-ignore lint/suspicious/noExplicitAny: matches Server type
     server.saveRecipeFn = (draft: any) => {

--- a/src/recipeRoutes.ts
+++ b/src/recipeRoutes.ts
@@ -236,6 +236,9 @@ function respondInvalidJson(res: ServerResponse): void {
 // END A-PR2 EDIT BLOCK
 
 export interface RecipeRouteDeps {
+  setRecipeTrustFn:
+    | ((name: string, level: string) => { ok: boolean; error?: string })
+    | null;
   generateRecipeFn:
     | ((prompt: string) => Promise<{
         ok: boolean;
@@ -671,6 +674,51 @@ export function tryHandleRecipeRoute(
       } catch {
         respondInvalidJson(res);
       }
+    })();
+    return true;
+  }
+
+  // PATCH /recipes/:name/trust — update trust level for a recipe.
+  const recipeTrustMatch =
+    req.method === "PATCH"
+      ? /^\/recipes\/([^/]+)\/trust$/.exec(parsedUrl.pathname)
+      : null;
+  if (recipeTrustMatch?.[1]) {
+    const name = decodeURIComponent(recipeTrustMatch[1]);
+    void (async () => {
+      const parsedBody = await readJsonBody<{ level?: unknown }>(
+        req,
+        RECIPE_ROUTE_BODY_CAPS.install,
+      );
+      if (!parsedBody.ok) {
+        if (parsedBody.code === "too_large") {
+          respond413(res, RECIPE_ROUTE_BODY_CAPS.install);
+        } else {
+          respondInvalidJson(res);
+        }
+        return;
+      }
+      const level = (parsedBody.value as { level?: unknown } | undefined)
+        ?.level;
+      if (typeof level !== "string" || !level) {
+        res.writeHead(400, { "Content-Type": "application/json" });
+        res.end(
+          JSON.stringify({ ok: false, error: "level (string) required" }),
+        );
+        return;
+      }
+      if (!deps.setRecipeTrustFn) {
+        res.writeHead(503, { "Content-Type": "application/json" });
+        res.end(
+          JSON.stringify({ ok: false, error: "Trust management unavailable" }),
+        );
+        return;
+      }
+      const result = deps.setRecipeTrustFn(name, level);
+      res.writeHead(result.ok ? 200 : 400, {
+        "Content-Type": "application/json",
+      });
+      res.end(JSON.stringify(result));
     })();
     return true;
   }

--- a/src/recipesHttp.ts
+++ b/src/recipesHttp.ts
@@ -631,6 +631,72 @@ export function lintRecipeContent(content: string): {
   return { ok: errors.length === 0, errors, warnings };
 }
 
+// ---------------------------------------------------------------------------
+// Recipe trust levels
+// ---------------------------------------------------------------------------
+
+export const TRUST_LEVELS = [
+  "draft",
+  "manual_run",
+  "ask_every_time",
+  "ask_novel",
+  "mostly_trusted",
+  "fully_trusted",
+] as const;
+
+export type TrustLevel = (typeof TRUST_LEVELS)[number];
+
+const TRUST_LEVELS_FILE = "trust_levels.json";
+
+function trustLevelsPath(recipesDir: string): string {
+  return path.join(recipesDir, TRUST_LEVELS_FILE);
+}
+
+function loadTrustLevels(recipesDir: string): Record<string, TrustLevel> {
+  const p = trustLevelsPath(recipesDir);
+  try {
+    const raw = readFileSync(p, "utf-8");
+    return JSON.parse(raw) as Record<string, TrustLevel>;
+  } catch {
+    return {};
+  }
+}
+
+function saveTrustLevels(
+  recipesDir: string,
+  levels: Record<string, TrustLevel>,
+): void {
+  const p = trustLevelsPath(recipesDir);
+  mkdirSync(recipesDir, { recursive: true });
+  writeFileSync(p, JSON.stringify(levels, null, 2), "utf-8");
+}
+
+export function getTrustLevel(recipesDir: string, name: string): TrustLevel {
+  const levels = loadTrustLevels(recipesDir);
+  return levels[name] ?? "draft";
+}
+
+export function setTrustLevel(
+  recipesDir: string,
+  name: string,
+  level: TrustLevel,
+): { ok: boolean; error?: string } {
+  if (!TRUST_LEVELS.includes(level)) {
+    return { ok: false, error: `Invalid trust level: ${level}` };
+  }
+  try {
+    const levels = loadTrustLevels(recipesDir);
+    levels[name] = level;
+    saveTrustLevels(recipesDir, levels);
+    return { ok: true };
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
 export interface RecipeSummary {
   name: string;
   description?: string;
@@ -642,6 +708,7 @@ export interface RecipeSummary {
   installedAt: number;
   source: "user" | "project" | "unknown";
   enabled: boolean;
+  trustLevel?: TrustLevel;
   vars?: Array<{
     name: string;
     description?: string;
@@ -681,6 +748,7 @@ export function listInstalledRecipes(recipesDir: string): ListRecipesResult {
   const disabledSet = new Set<string>(
     (cfg as { recipes?: { disabled?: string[] } }).recipes?.disabled ?? [],
   );
+  const trustLevels = loadTrustLevels(recipesDir);
 
   const recipes: RecipeSummary[] = [];
   for (const f of entries) {
@@ -751,6 +819,7 @@ export function listInstalledRecipes(recipesDir: string): ListRecipesResult {
         // Top-level legacy recipes don't have install dirs to put a marker
         // in, so the `enabled` field still comes from the legacy config list.
         enabled: !disabledSet.has(parsedName),
+        trustLevel: (trustLevels[parsedName] ?? "draft") as TrustLevel,
         ...(Array.isArray(parsed.vars) && parsed.vars.length > 0
           ? { vars: parsed.vars }
           : {}),
@@ -830,6 +899,7 @@ export function listInstalledRecipes(recipesDir: string): ListRecipesResult {
         // the dashboard can't accidentally enable one disabled by an admin
         // through the legacy file.
         enabled: installEnabled && !disabledSet.has(parsedName),
+        trustLevel: (trustLevels[parsedName] ?? "draft") as TrustLevel,
         ...(Array.isArray(parsed.vars) && parsed.vars.length > 0
           ? { vars: parsed.vars }
           : {}),

--- a/src/server.ts
+++ b/src/server.ts
@@ -117,6 +117,10 @@ export class Server extends EventEmitter<ServerEvents> {
   public tasksFn: (() => { tasks: Record<string, unknown>[] }) | null = null;
   /** Set by bridge to cancel a running/pending task by id. Returns true if found. */
   public cancelTaskFn: ((id: string) => boolean) | null = null;
+  /** Patchwork: set by bridge to set the trust level for a recipe by name. */
+  public setRecipeTrustFn:
+    | ((name: string, level: string) => { ok: boolean; error?: string })
+    | null = null;
   /** Patchwork: set by bridge to generate a recipe YAML draft from a natural-language prompt. */
   public generateRecipeFn:
     | ((prompt: string) => Promise<{
@@ -1019,6 +1023,7 @@ export class Server extends EventEmitter<ServerEvents> {
       // ── Recipe / runs / templates routes (extracted to src/recipeRoutes.ts) ─
       if (
         tryHandleRecipeRoute(req, res, parsedUrl, {
+          setRecipeTrustFn: this.setRecipeTrustFn,
           generateRecipeFn: this.generateRecipeFn,
           recipesFn: this.recipesFn,
           loadRecipeContentFn: this.loadRecipeContentFn,


### PR DESCRIPTION
## Summary

Implements Phase 2 §4 (Recipe Trust Graduation) from the strategic plan.

**Bridge** (`recipesHttp.ts`, `recipeRoutes.ts`, `recipeOrchestration.ts`, `server.ts`):
- Six trust levels: `draft → manual_run → ask_every_time → ask_novel → mostly_trusted → fully_trusted`
- Persisted to `~/.patchwork/recipes/trust_levels.json` (plain JSON sidecar — no YAML mutation, no migration needed)
- `trustLevel` field on `RecipeSummary` (included in `GET /recipes` response)
- `PATCH /recipes/:name/trust` route — validates level, 400 on invalid value
- `setRecipeTrustFn` callback wired through `RecipeOrchestration.wireServerFns()`

**Dashboard**:
- Recipe list: colored trust badge in the trigger/lint column (hidden when `draft`), trust level `<select>` dropdown in the actions column — instant PATCH on change, refreshes list
- Suggestions page: `GraduateButton` for `recipe_trust_graduation` suggestions — one click promotes to `mostly_trusted`, shows confirmation in-place

## Test plan

- [ ] Bridge builds, 4778 tests pass
- [ ] Dashboard type-checks clean
- [ ] `PATCH /recipes/<name>/trust` with `{ level: "mostly_trusted" }` → 200 `{ ok: true }`
- [ ] `PATCH /recipes/<name>/trust` with `{ level: "invalid" }` → 400
- [ ] `GET /recipes` includes `trustLevel` field on each recipe
- [ ] Dashboard recipe list shows dropdown; changing it persists across reload
- [ ] Trust badge appears for non-draft levels with correct color
- [ ] Suggestions "Graduate trust" button updates and shows confirmation

🤖 Generated with [Claude Code](https://claude.com/claude-code)