### PR TITLE
feat(traces): GET /traces/export — HTTP streaming export + dashboard download button

### DIFF
--- a/dashboard/src/app/traces/page.tsx
+++ b/dashboard/src/app/traces/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { Fragment, useMemo, useState } from "react";
 import { relTime } from "@/components/time";
+import { apiPath } from "@/lib/api";
 import { useBridgeFetch } from "@/hooks/useBridgeFetch";
 import { arr, isRecord, shape, type ShapeCheck } from "@/lib/validate";
 
@@ -281,9 +282,19 @@ export default function TracesPage() {
             Approval history, recipe runs, and enrichment links.
           </div>
         </div>
-        <span className="pill muted">
-          {traces.length} trace{traces.length !== 1 ? "s" : ""}
-        </span>
+        <div style={{ display: "flex", gap: "var(--s-3)", alignItems: "center" }}>
+          <span className="pill muted">
+            {traces.length} trace{traces.length !== 1 ? "s" : ""}
+          </span>
+          <a
+            href={apiPath("/api/bridge/traces/export")}
+            download
+            className="btn sm"
+            style={{ textDecoration: "none" }}
+          >
+            Export
+          </a>
+        </div>
       </div>
 
       {/* filter bar */}

--- a/src/commands/tracesExport.ts
+++ b/src/commands/tracesExport.ts
@@ -291,3 +291,98 @@ export async function runTracesExport(
     totalBytes: files.reduce((sum, f) => sum + f.bytes, 0),
   };
 }
+
+/**
+ * Stream-variant of `runTracesExport` — writes gzip-compressed JSONL
+ * directly into a caller-supplied `Writable` (e.g. an HTTP response).
+ * No temp file is created; the manifest/rows are emitted in one pass.
+ *
+ * The caller is responsible for setting `Content-Type`,
+ * `Content-Encoding`, and `Content-Disposition` headers BEFORE calling
+ * this function because Node's HTTP response is not writable after headers
+ * have been flushed.
+ *
+ * Returns row/byte accounting but omits `outputPath` (no disk file).
+ */
+export async function runTracesExportToStream(
+  writable: import("node:stream").Writable,
+  opts: Omit<TracesExportOptions, "output"> = {},
+): Promise<Omit<TracesExportResult, "outputPath">> {
+  const exportedAt = new Date().toISOString();
+  const patchworkDir = opts.patchworkDir ?? defaultPatchworkDir();
+  const activityDir = opts.activityDir ?? defaultActivityDir();
+
+  const files: Array<{
+    source: TraceSource;
+    path: string;
+    relativePath: string;
+    rows: unknown[];
+    bytes: number;
+    activityFile?: string;
+  }> = [];
+
+  for (const { source, filename } of SINGLE_FILE_SOURCES) {
+    const p = path.join(patchworkDir, filename);
+    if (!existsSync(p)) continue;
+    const { rows, bytes } = await readJsonlRows(p);
+    files.push({ source, path: p, relativePath: filename, rows, bytes });
+  }
+  for (const p of discoverActivityFiles(activityDir)) {
+    const { rows, bytes } = await readJsonlRows(p);
+    files.push({
+      source: "activity",
+      path: p,
+      relativePath: path.relative(activityDir, p),
+      rows,
+      bytes,
+      activityFile: path.basename(p),
+    });
+  }
+
+  const totalCount = files.reduce((s, f) => s + f.rows.length, 0);
+  const sources = [
+    ...new Set(files.map((f) => f.source)),
+  ].sort() as TraceSource[];
+  const manifest: ManifestEnvelope = {
+    type: "manifest",
+    version: TRACES_EXPORT_VERSION,
+    exportedAt,
+    sources,
+    files: files.map((f) => ({
+      source: f.source,
+      relativePath: f.relativePath,
+      count: f.rows.length,
+      bytes: f.bytes,
+    })),
+    totalCount,
+  };
+
+  const gzip = createGzip();
+  const drainPromise = pipeline(gzip, writable);
+
+  const writeChunk = (line: string): void => {
+    gzip.write(`${line}\n`);
+  };
+  writeChunk(JSON.stringify(manifest));
+  for (const f of files) {
+    for (const entry of f.rows) {
+      const env: RowEnvelope = { source: f.source, entry };
+      if (f.activityFile) env.file = f.activityFile;
+      writeChunk(JSON.stringify(env));
+    }
+  }
+  gzip.end();
+  await drainPromise;
+
+  return {
+    exportedAt,
+    files: files.map((f) => ({
+      source: f.source,
+      path: f.path,
+      count: f.rows.length,
+      bytes: f.bytes,
+    })),
+    totalCount,
+    totalBytes: files.reduce((sum, f) => sum + f.bytes, 0),
+  };
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -697,6 +697,37 @@ export class Server extends EventEmitter<ServerEvents> {
         }
         return;
       }
+      if (parsedUrl.pathname === "/traces/export" && req.method === "GET") {
+        void (async () => {
+          try {
+            const { runTracesExportToStream } = await import(
+              "./commands/tracesExport.js"
+            );
+            const stamp = new Date()
+              .toISOString()
+              .replace(/:/g, "-")
+              .replace(/\..+$/, "");
+            const filename = `traces-export-${stamp}.jsonl.gz`;
+            res.writeHead(200, {
+              "Content-Type": "application/gzip",
+              "Content-Disposition": `attachment; filename="${filename}"`,
+              "Cache-Control": "no-store",
+            });
+            await runTracesExportToStream(res);
+          } catch (err) {
+            if (!res.headersSent) {
+              res.writeHead(500, { "Content-Type": "application/json" });
+              res.end(
+                JSON.stringify({
+                  error: err instanceof Error ? err.message : String(err),
+                }),
+              );
+            }
+          }
+        })();
+        return;
+      }
+
       if (parsedUrl.pathname === "/analytics" && req.method === "GET") {
         try {
           const wh = parsedUrl.searchParams.get("windowHours");


### PR DESCRIPTION
## Summary

Phase 3 §1 (Trace Backup and Sync) — adds the HTTP surface for trace export so dashboard users can back up their decision/run/activity logs without CLI access.

- **`runTracesExportToStream(writable, opts)`** in `tracesExport.ts` — mirrors the existing `runTracesExport` but pipes the gzip-compressed JSONL bundle directly into a caller-supplied `Writable`. No temp file; same manifest + row envelope format for full round-trip compatibility with `patchwork traces import`.
- **`GET /traces/export`** in `server.ts` — streams the bundle behind the same bearer-token gate as all other `/traces` routes. Sets `Content-Disposition: attachment` with a timestamped filename.
- **"Export" button** on the `/traces` dashboard page — native `<a download>` link, no JS required. Browser saves the `.jsonl.gz` file directly.

Import side (restoring the bundle) already shipped in PR #167.

## Test plan

- [ ] Bridge builds, 4778 tests pass
- [ ] `curl -H 'Authorization: Bearer <token>' http://localhost:3101/traces/export --output test.jsonl.gz` produces a valid gzip file
- [ ] `gunzip -c test.jsonl.gz | head -1 | jq .type` → `"manifest"`
- [ ] Dashboard `/traces` page shows "Export" button; clicking it downloads a `.jsonl.gz` file
- [ ] Empty trace store (no `.jsonl` files) returns a valid bundle with `totalCount: 0`
- [ ] Round-trip: export → `patchwork traces import --mode append` restores without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)