### PR TITLE
feat(recipes): recipe variants — duplicate as variant (Phase 2 §5)

### DIFF
--- a/dashboard/src/app/recipes/page.tsx
+++ b/dashboard/src/app/recipes/page.tsx
@@ -578,6 +578,27 @@ export default function RecipesPage() {
     setModalRunning(false);
   }
 
+  async function handleDuplicate(name: string) {
+    try {
+      const res = await fetch(
+        apiPath(`/api/bridge/recipes/${encodeURIComponent(name)}/duplicate`),
+        { method: "POST" },
+      );
+      const body = (await res.json().catch(() => ({}))) as {
+        ok?: boolean;
+        variantName?: string;
+        error?: string;
+      };
+      if (!res.ok || !body.ok) {
+        setErr(body.error ?? `duplicate failed: ${res.status}`);
+        return;
+      }
+      void load();
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+    }
+  }
+
   async function handleDelete(name: string) {
     if (
       typeof window !== "undefined" &&
@@ -930,6 +951,15 @@ export default function RecipesPage() {
                               Test
                             </button>
                           )}
+                          <button
+                            type="button"
+                            className="btn sm ghost"
+                            style={{ fontSize: 11, padding: "2px 8px" }}
+                            title="Duplicate recipe as variant"
+                            onClick={() => void handleDuplicate(r.name)}
+                          >
+                            Fork
+                          </button>
                           <button
                             type="button"
                             className="btn sm ghost"

--- a/src/recipeOrchestration.ts
+++ b/src/recipeOrchestration.ts
@@ -17,6 +17,7 @@ import type {
 import { RecipeScheduler } from "./recipes/scheduler.js";
 import {
   deleteRecipeContent,
+  duplicateRecipe,
   findWebhookRecipe,
   findYamlRecipePath,
   lintRecipeContent,
@@ -115,6 +116,11 @@ export class RecipeOrchestration {
     server.deleteRecipeContentFn = (name: string) => {
       const recipesDir = path.join(os.homedir(), ".patchwork", "recipes");
       return deleteRecipeContent(recipesDir, name);
+    };
+
+    server.duplicateRecipeFn = (name: string) => {
+      const recipesDir = path.join(os.homedir(), ".patchwork", "recipes");
+      return duplicateRecipe(recipesDir, name);
     };
 
     server.lintRecipeContentFn = (content: string) =>

--- a/src/recipeRoutes.ts
+++ b/src/recipeRoutes.ts
@@ -266,6 +266,14 @@ export interface RecipeRouteDeps {
   deleteRecipeContentFn:
     | ((name: string) => { ok: boolean; path?: string; error?: string })
     | null;
+  duplicateRecipeFn:
+    | ((name: string) => {
+        ok: boolean;
+        variantName?: string;
+        path?: string;
+        error?: string;
+      })
+    | null;
   lintRecipeContentFn:
     | ((content: string) => {
         ok: boolean;
@@ -932,6 +940,28 @@ export function tryHandleRecipeRoute(
     const result = deps.deleteRecipeContentFn(name);
     const status = result.ok
       ? 200
+      : result.error === "Recipe not found"
+        ? 404
+        : 400;
+    res.writeHead(status, { "Content-Type": "application/json" });
+    res.end(JSON.stringify(result));
+    return true;
+  }
+
+  // POST /recipes/:name/duplicate — copy recipe as next available variant name
+  const duplicateMatch = /^\/recipes\/([^/]+)\/duplicate$/.exec(
+    parsedUrl.pathname,
+  );
+  if (duplicateMatch && req.method === "POST") {
+    const name = decodeURIComponent(duplicateMatch[1] ?? "");
+    if (!deps.duplicateRecipeFn) {
+      res.writeHead(503, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ ok: false, error: "Duplicate unavailable" }));
+      return true;
+    }
+    const result = deps.duplicateRecipeFn(name);
+    const status = result.ok
+      ? 201
       : result.error === "Recipe not found"
         ? 404
         : 400;

--- a/src/recipesHttp.ts
+++ b/src/recipesHttp.ts
@@ -597,6 +597,64 @@ export function deleteRecipeContent(
 }
 
 /**
+ * Duplicate a recipe as a variant. Copies the source YAML, rewrites the
+ * `name:` field to `<original>-v<N>` (first available suffix), and writes
+ * the copy to disk. Returns the new variant name and path on success.
+ *
+ * The variant name follows the same validation rules as recipe names.
+ * Suffixes v2..v9 are tried before returning an error.
+ */
+export function duplicateRecipe(
+  recipesDir: string,
+  sourceName: string,
+): {
+  ok: boolean;
+  variantName?: string;
+  path?: string;
+  error?: string;
+} {
+  const safeName = sourceName.toLowerCase();
+  if (!/^[a-z0-9][a-z0-9_-]{0,63}$/.test(safeName)) {
+    return { ok: false, error: "Invalid recipe name" };
+  }
+  const source = loadRecipeContent(recipesDir, safeName);
+  if (!source) {
+    return { ok: false, error: "Recipe not found" };
+  }
+
+  // Determine next available variant name: strip any existing -vN suffix,
+  // then try -v2 through -v9.
+  const base = safeName.replace(/-v\d+$/, "");
+  let variantName: string | null = null;
+  for (let n = 2; n <= 9; n++) {
+    const candidate = `${base}-v${n}`;
+    if (!findYamlRecipePath(recipesDir, candidate)) {
+      variantName = candidate;
+      break;
+    }
+  }
+  if (!variantName) {
+    return {
+      ok: false,
+      error: "Too many variants already exist (v2–v9 taken)",
+    };
+  }
+
+  // Rewrite the name: field in the YAML. Simple line-by-line replacement
+  // is safe here: the name field is always a scalar on its own line.
+  const newContent = source.content.replace(
+    /^name:\s*.+$/m,
+    `name: ${variantName}`,
+  );
+
+  const saveResult = saveRecipeContent(recipesDir, variantName, newContent);
+  if (!saveResult.ok) {
+    return { ok: false, error: saveResult.error };
+  }
+  return { ok: true, variantName, path: saveResult.path };
+}
+
+/**
  * Lints raw YAML/JSON recipe content without writing to disk. Used by the
  * dashboard edit UI to surface validateRecipeDefinition warnings live, in
  * addition to the warnings returned by saveRecipeContent on save.

--- a/src/server.ts
+++ b/src/server.ts
@@ -153,6 +153,15 @@ export class Server extends EventEmitter<ServerEvents> {
   public deleteRecipeContentFn:
     | ((name: string) => { ok: boolean; path?: string; error?: string })
     | null = null;
+  /** Patchwork: set by bridge to duplicate a recipe as a variant. */
+  public duplicateRecipeFn:
+    | ((name: string) => {
+        ok: boolean;
+        variantName?: string;
+        path?: string;
+        error?: string;
+      })
+    | null = null;
   /** Patchwork: set by bridge to lint raw recipe content without saving. */
   public lintRecipeContentFn:
     | ((content: string) => {
@@ -1080,6 +1089,7 @@ export class Server extends EventEmitter<ServerEvents> {
           loadRecipeContentFn: this.loadRecipeContentFn,
           saveRecipeContentFn: this.saveRecipeContentFn,
           deleteRecipeContentFn: this.deleteRecipeContentFn,
+          duplicateRecipeFn: this.duplicateRecipeFn,
           lintRecipeContentFn: this.lintRecipeContentFn,
           saveRecipeFn: this.saveRecipeFn,
           setRecipeEnabledFn: this.setRecipeEnabledFn,


### PR DESCRIPTION
## Summary

- **`src/recipesHttp.ts`** — `duplicateRecipe()`: loads source YAML, strips any existing `-vN` suffix from the name, finds the next available `-v2` through `-v9` slot, rewrites the `name:` field in the YAML, and saves via `saveRecipeContent`. Returns `{ ok, variantName, path }`.
- **`src/recipeRoutes.ts`** — `POST /recipes/:name/duplicate` → 201 `{ ok, variantName, path }`. 404 if source not found, 503 if fn not wired, 400 on other errors. Added `duplicateRecipeFn` to `RecipeRouteDeps`.
- **`src/recipeOrchestration.ts`** — wires `server.duplicateRecipeFn` to `duplicateRecipe(recipesDir, name)`.
- **`src/server.ts`** — `duplicateRecipeFn` field + threaded through `tryHandleRecipeRoute`.
- **`dashboard/src/app/recipes/page.tsx`** — `handleDuplicate()` + "Fork" button in actions column; reloads recipe list on success so the new variant appears immediately.

Next: the variant compare flow (side-by-side dry-run plan diff) follows once users have a way to fork.

## Test plan

- [ ] `npm run build` passes
- [ ] `npm test` — 4778 tests pass
- [ ] Fork button visible in recipes list actions column
- [ ] Clicking Fork on `morning-brief` creates `morning-brief-v2` and it appears in the list
- [ ] Forking `morning-brief-v2` creates `morning-brief-v3` (strips existing suffix)
- [ ] Forking a non-existent recipe → 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)