### PR TITLE
feat(recipes): variant compare + promote — Phase 2 §5 complete

### DIFF
--- a/dashboard/src/app/recipes/compare/page.tsx
+++ b/dashboard/src/app/recipes/compare/page.tsx
@@ -1,0 +1,349 @@
+"use client";
+
+import Link from "next/link";
+import { useSearchParams } from "next/navigation";
+import { Suspense, useEffect, useState } from "react";
+import { apiPath } from "@/lib/api";
+
+interface PlanStep {
+  id: string;
+  type: "tool" | "agent" | "recipe";
+  tool?: string;
+  into?: string;
+  optional?: boolean;
+  risk?: "low" | "medium" | "high";
+  isWrite?: boolean;
+  resolved?: boolean;
+}
+
+interface DryRunPlan {
+  recipe: string;
+  triggerType: string;
+  steps: PlanStep[];
+  connectorNamespaces?: string[];
+  hasWriteSteps?: boolean;
+  lint: { errors: string[]; warnings: string[] };
+}
+
+const RISK_PILL: Record<string, string> = {
+  low: "ok",
+  medium: "warn",
+  high: "err",
+};
+
+function StepRow({ step, highlight }: { step: PlanStep; highlight?: boolean }) {
+  return (
+    <tr
+      style={{
+        borderBottom: "1px solid var(--border-subtle)",
+        background: highlight ? "color-mix(in srgb, var(--warn) 8%, transparent)" : undefined,
+      }}
+    >
+      <td style={{ padding: "8px 0", fontSize: 12, fontFamily: "monospace" }}>
+        {step.tool ?? step.type}
+      </td>
+      <td style={{ padding: "8px 6px", textAlign: "center" }}>
+        {step.risk && (
+          <span className={`pill ${RISK_PILL[step.risk]}`} style={{ fontSize: 10 }}>
+            {step.risk}
+          </span>
+        )}
+      </td>
+      <td style={{ padding: "8px 6px", textAlign: "center", fontSize: 11, color: "var(--fg-2)" }}>
+        {step.isWrite ? "write" : "read"}
+      </td>
+      <td style={{ padding: "8px 0", textAlign: "center" }}>
+        {step.resolved === false && (
+          <span className="pill err" style={{ fontSize: 10 }}>unresolved</span>
+        )}
+      </td>
+    </tr>
+  );
+}
+
+function PlanColumn({
+  name,
+  plan,
+  error,
+  loading,
+  otherStepIds,
+  onPromote,
+  promoting,
+  targetName,
+}: {
+  name: string;
+  plan: DryRunPlan | null;
+  error: string | null;
+  loading: boolean;
+  otherStepIds: Set<string>;
+  onPromote: () => void;
+  promoting: boolean;
+  targetName: string;
+}) {
+  const stepIds = new Set(plan?.steps.map((s) => s.id) ?? []);
+  const addedSteps = plan?.steps.filter((s) => !otherStepIds.has(s.id)) ?? [];
+  const removedCount = [...otherStepIds].filter((id) => !stepIds.has(id)).length;
+
+  return (
+    <div
+      style={{
+        flex: 1,
+        minWidth: 0,
+        border: "1px solid var(--border-default)",
+        borderRadius: "var(--r-3)",
+        overflow: "hidden",
+      }}
+    >
+      <div
+        style={{
+          padding: "12px 16px",
+          background: "var(--bg-2)",
+          borderBottom: "1px solid var(--border-default)",
+          display: "flex",
+          alignItems: "center",
+          gap: 8,
+        }}
+      >
+        <code style={{ flex: 1, fontSize: 13 }}>{name}</code>
+        {plan && (
+          <>
+            <span className="pill muted" style={{ fontSize: 10 }}>
+              {plan.steps.length} steps
+            </span>
+            {addedSteps.length > 0 && (
+              <span className="pill ok" style={{ fontSize: 10 }}>
+                +{addedSteps.length} new
+              </span>
+            )}
+            {removedCount > 0 && (
+              <span className="pill err" style={{ fontSize: 10 }}>
+                -{removedCount} removed
+              </span>
+            )}
+          </>
+        )}
+        <button
+          type="button"
+          className="btn sm"
+          disabled={promoting || !plan || loading}
+          onClick={onPromote}
+          title={`Promote ${name} → ${targetName}`}
+        >
+          {promoting ? "Promoting…" : `Promote → ${targetName}`}
+        </button>
+      </div>
+
+      <div style={{ padding: "12px 16px" }}>
+        {loading && <p style={{ color: "var(--fg-2)", fontSize: 13 }}>Loading plan…</p>}
+        {error && <div className="alert-err" style={{ fontSize: 12 }}>{error}</div>}
+
+        {plan && (
+          <>
+            {plan.lint.errors.length > 0 && (
+              <div className="alert-err" style={{ marginBottom: 8, fontSize: 12 }}>
+                {plan.lint.errors.join(" · ")}
+              </div>
+            )}
+            {plan.lint.warnings.length > 0 && (
+              <div
+                style={{
+                  background: "color-mix(in srgb, var(--warn) 10%, transparent)",
+                  border: "1px solid color-mix(in srgb, var(--warn) 30%, transparent)",
+                  borderRadius: "var(--r-2)",
+                  padding: "6px 10px",
+                  fontSize: 11,
+                  color: "var(--fg-1)",
+                  marginBottom: 8,
+                }}
+              >
+                {plan.lint.warnings.join(" · ")}
+              </div>
+            )}
+            <table style={{ width: "100%", borderCollapse: "collapse" }}>
+              <thead>
+                <tr style={{ borderBottom: "1px solid var(--border-default)" }}>
+                  <th style={{ textAlign: "left", fontSize: 10, color: "var(--fg-2)", fontWeight: 500, padding: "4px 0" }}>Step</th>
+                  <th style={{ textAlign: "center", fontSize: 10, color: "var(--fg-2)", fontWeight: 500, padding: "4px 6px" }}>Risk</th>
+                  <th style={{ textAlign: "center", fontSize: 10, color: "var(--fg-2)", fontWeight: 500, padding: "4px 6px" }}>Mode</th>
+                  <th style={{ textAlign: "center", fontSize: 10, color: "var(--fg-2)", fontWeight: 500, padding: "4px 0" }} />
+                </tr>
+              </thead>
+              <tbody>
+                {plan.steps.map((step) => (
+                  <StepRow
+                    key={step.id}
+                    step={step}
+                    highlight={!otherStepIds.has(step.id)}
+                  />
+                ))}
+              </tbody>
+            </table>
+            {plan.connectorNamespaces && plan.connectorNamespaces.length > 0 && (
+              <p style={{ fontSize: 11, color: "var(--fg-2)", marginTop: 8 }}>
+                Connectors: {plan.connectorNamespaces.join(", ")}
+              </p>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function CompareInner() {
+  const params = useSearchParams();
+  const nameA = params.get("a") ?? "";
+  const nameB = params.get("b") ?? "";
+
+  const [planA, setPlanA] = useState<DryRunPlan | null>(null);
+  const [planB, setPlanB] = useState<DryRunPlan | null>(null);
+  const [errA, setErrA] = useState<string | null>(null);
+  const [errB, setErrB] = useState<string | null>(null);
+  const [loadingA, setLoadingA] = useState(true);
+  const [loadingB, setLoadingB] = useState(true);
+  const [promoteResult, setPromoteResult] = useState<string | null>(null);
+  const [promotingA, setPromotingA] = useState(false);
+  const [promotingB, setPromotingB] = useState(false);
+
+  useEffect(() => {
+    if (!nameA) return;
+    setLoadingA(true);
+    fetch(apiPath(`/api/bridge/recipes/${encodeURIComponent(nameA)}/plan`))
+      .then((r) => r.json())
+      .then((d: DryRunPlan & { error?: string }) => {
+        if (d.error) setErrA(d.error);
+        else setPlanA(d);
+      })
+      .catch((e: unknown) => setErrA(e instanceof Error ? e.message : String(e)))
+      .finally(() => setLoadingA(false));
+  }, [nameA]);
+
+  useEffect(() => {
+    if (!nameB) return;
+    setLoadingB(true);
+    fetch(apiPath(`/api/bridge/recipes/${encodeURIComponent(nameB)}/plan`))
+      .then((r) => r.json())
+      .then((d: DryRunPlan & { error?: string }) => {
+        if (d.error) setErrB(d.error);
+        else setPlanB(d);
+      })
+      .catch((e: unknown) => setErrB(e instanceof Error ? e.message : String(e)))
+      .finally(() => setLoadingB(false));
+  }, [nameB]);
+
+  // Determine which is the "base" name (no -vN suffix) for the promote target.
+  const baseName = nameA.replace(/-v\d+$/, "");
+
+  async function promote(variantName: string, setPromoting: (v: boolean) => void) {
+    setPromoting(true);
+    setPromoteResult(null);
+    try {
+      const res = await fetch(
+        apiPath(`/api/bridge/recipes/${encodeURIComponent(variantName)}/promote`),
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ targetName: baseName }),
+        },
+      );
+      const body = (await res.json()) as { ok?: boolean; error?: string };
+      if (body.ok) {
+        setPromoteResult(`✓ ${variantName} promoted to ${baseName}`);
+      } else {
+        setPromoteResult(`Error: ${body.error ?? "promote failed"}`);
+      }
+    } catch (e) {
+      setPromoteResult(e instanceof Error ? e.message : String(e));
+    } finally {
+      setPromoting(false);
+    }
+  }
+
+  if (!nameA || !nameB) {
+    return (
+      <div className="empty-state">
+        <h3>Missing recipe names</h3>
+        <p>
+          Use <code>/recipes/compare?a=recipe-name&b=recipe-name-v2</code>. The
+          Fork button on the Recipes page links here automatically.
+        </p>
+      </div>
+    );
+  }
+
+  const stepIdsA = new Set(planA?.steps.map((s) => s.id) ?? []);
+  const stepIdsB = new Set(planB?.steps.map((s) => s.id) ?? []);
+
+  return (
+    <section>
+      <div className="page-head">
+        <div>
+          <Link href="/recipes" style={{ fontSize: 12, color: "var(--fg-2)", textDecoration: "none" }}>
+            ← Recipes
+          </Link>
+          <h1 style={{ marginTop: 4 }}>Compare variants</h1>
+          <div className="page-head-sub">
+            Dry-run plan diff — highlighted rows are steps unique to each
+            variant. Promote to replace the base recipe with this variant.
+          </div>
+        </div>
+      </div>
+
+      {promoteResult && (
+        <div
+          style={{
+            marginBottom: "var(--s-4)",
+            padding: "10px 14px",
+            borderRadius: "var(--r-2)",
+            background: promoteResult.startsWith("✓")
+              ? "color-mix(in srgb, var(--ok) 12%, transparent)"
+              : "color-mix(in srgb, var(--err) 12%, transparent)",
+            border: `1px solid ${promoteResult.startsWith("✓") ? "color-mix(in srgb, var(--ok) 30%, transparent)" : "color-mix(in srgb, var(--err) 30%, transparent)"}`,
+            fontSize: 13,
+          }}
+        >
+          {promoteResult}
+          {promoteResult.startsWith("✓") && (
+            <>
+              {" "}
+              <Link href="/recipes" style={{ color: "var(--ok)", fontSize: 12 }}>
+                Back to recipes →
+              </Link>
+            </>
+          )}
+        </div>
+      )}
+
+      <div style={{ display: "flex", gap: 16, alignItems: "flex-start" }}>
+        <PlanColumn
+          name={nameA}
+          plan={planA}
+          error={errA}
+          loading={loadingA}
+          otherStepIds={stepIdsB}
+          onPromote={() => void promote(nameA, setPromotingA)}
+          promoting={promotingA}
+          targetName={baseName}
+        />
+        <PlanColumn
+          name={nameB}
+          plan={planB}
+          error={errB}
+          loading={loadingB}
+          otherStepIds={stepIdsA}
+          onPromote={() => void promote(nameB, setPromotingB)}
+          promoting={promotingB}
+          targetName={baseName}
+        />
+      </div>
+    </section>
+  );
+}
+
+export default function ComparePage() {
+  return (
+    <Suspense fallback={<p style={{ color: "var(--fg-2)" }}>Loading…</p>}>
+      <CompareInner />
+    </Suspense>
+  );
+}

--- a/dashboard/src/app/recipes/page.tsx
+++ b/dashboard/src/app/recipes/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 import React from "react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 import { apiPath } from "@/lib/api";
 import { ConnectorHealthPanel } from "@/components/ConnectorHealthPanel";
@@ -462,6 +463,7 @@ export default function RecipesPage() {
     { intervalMs: 10000 },
   );
   const bridgePort = bridgeStatus?.patchwork?.port ?? bridgeStatus?.port;
+  const router = useRouter();
   const [recipes, setRecipes] = useState<Recipe[] | null>(null);
   const [runMap, setRunMap] = useState<Map<string, RunRecord>>(new Map());
   const [err, setErr] = useState<string>();
@@ -593,7 +595,13 @@ export default function RecipesPage() {
         setErr(body.error ?? `duplicate failed: ${res.status}`);
         return;
       }
-      void load();
+      if (body.variantName) {
+        router.push(
+          `/recipes/compare?a=${encodeURIComponent(name)}&b=${encodeURIComponent(body.variantName)}`,
+        );
+      } else {
+        void load();
+      }
     } catch (e) {
       setErr(e instanceof Error ? e.message : String(e));
     }

--- a/src/recipeOrchestration.ts
+++ b/src/recipeOrchestration.ts
@@ -24,6 +24,7 @@ import {
   listInstalledRecipes,
   loadRecipeContent,
   loadRecipePrompt,
+  promoteRecipeVariant,
   renderWebhookPrompt,
   saveRecipe,
   saveRecipeContent,
@@ -121,6 +122,14 @@ export class RecipeOrchestration {
     server.duplicateRecipeFn = (name: string) => {
       const recipesDir = path.join(os.homedir(), ".patchwork", "recipes");
       return duplicateRecipe(recipesDir, name);
+    };
+
+    server.promoteRecipeVariantFn = (
+      variantName: string,
+      targetName: string,
+    ) => {
+      const recipesDir = path.join(os.homedir(), ".patchwork", "recipes");
+      return promoteRecipeVariant(recipesDir, variantName, targetName);
     };
 
     server.lintRecipeContentFn = (content: string) =>

--- a/src/recipeRoutes.ts
+++ b/src/recipeRoutes.ts
@@ -274,6 +274,16 @@ export interface RecipeRouteDeps {
         error?: string;
       })
     | null;
+  promoteRecipeVariantFn:
+    | ((
+        variantName: string,
+        targetName: string,
+      ) => {
+        ok: boolean;
+        path?: string;
+        error?: string;
+      })
+    | null;
   lintRecipeContentFn:
     | ((content: string) => {
         ok: boolean;
@@ -967,6 +977,43 @@ export function tryHandleRecipeRoute(
         : 400;
     res.writeHead(status, { "Content-Type": "application/json" });
     res.end(JSON.stringify(result));
+    return true;
+  }
+
+  // POST /recipes/:name/promote — promote variant to canonical name.
+  // Body: { targetName: string }
+  const promoteMatch = /^\/recipes\/([^/]+)\/promote$/.exec(parsedUrl.pathname);
+  if (promoteMatch && req.method === "POST") {
+    const variantName = decodeURIComponent(promoteMatch[1] ?? "");
+    void (async () => {
+      const parsedBody = await readJsonBody<{ targetName?: string }>(
+        req,
+        RECIPE_ROUTE_BODY_CAPS.content,
+      );
+      if (!parsedBody.ok) {
+        respondInvalidJson(res);
+        return;
+      }
+      const { targetName } = parsedBody.value ?? {};
+      if (typeof targetName !== "string" || !targetName.trim()) {
+        res.writeHead(400, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ ok: false, error: "targetName required" }));
+        return;
+      }
+      if (!deps.promoteRecipeVariantFn) {
+        res.writeHead(503, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ ok: false, error: "Promote unavailable" }));
+        return;
+      }
+      const result = deps.promoteRecipeVariantFn(variantName, targetName);
+      const httpStatus = result.ok
+        ? 200
+        : result.error?.includes("not found")
+          ? 404
+          : 400;
+      res.writeHead(httpStatus, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(result));
+    })();
     return true;
   }
 

--- a/src/recipesHttp.ts
+++ b/src/recipesHttp.ts
@@ -655,6 +655,55 @@ export function duplicateRecipe(
 }
 
 /**
+ * Promote a variant recipe to become the canonical name.
+ *
+ * Steps:
+ *   1. Load the variant's YAML.
+ *   2. Rewrite its `name:` field to `targetName`.
+ *   3. Save under `targetName` (overwrites any existing file at that name).
+ *   4. Delete the variant file so only one copy exists.
+ *
+ * The caller supplies `variantName` (e.g. "morning-brief-v2") and
+ * `targetName` (e.g. "morning-brief"). Both must pass the recipe name
+ * validation regex. Returns `{ ok, path }` on success.
+ */
+export function promoteRecipeVariant(
+  recipesDir: string,
+  variantName: string,
+  targetName: string,
+): { ok: boolean; path?: string; error?: string } {
+  const safeVariant = variantName.toLowerCase();
+  const safeTarget = targetName.toLowerCase();
+  const nameRe = /^[a-z0-9][a-z0-9_-]{0,63}$/;
+  if (!nameRe.test(safeVariant) || !nameRe.test(safeTarget)) {
+    return { ok: false, error: "Invalid recipe name" };
+  }
+  if (safeVariant === safeTarget) {
+    return { ok: false, error: "Variant and target names must differ" };
+  }
+
+  const source = loadRecipeContent(recipesDir, safeVariant);
+  if (!source) {
+    return { ok: false, error: "Variant recipe not found" };
+  }
+
+  const newContent = source.content.replace(
+    /^name:\s*.+$/m,
+    `name: ${safeTarget}`,
+  );
+
+  const saveResult = saveRecipeContent(recipesDir, safeTarget, newContent);
+  if (!saveResult.ok) {
+    return { ok: false, error: saveResult.error };
+  }
+
+  // Delete the variant file — best-effort; don't fail the promote if cleanup fails.
+  deleteRecipeContent(recipesDir, safeVariant);
+
+  return { ok: true, path: saveResult.path };
+}
+
+/**
  * Lints raw YAML/JSON recipe content without writing to disk. Used by the
  * dashboard edit UI to surface validateRecipeDefinition warnings live, in
  * addition to the warnings returned by saveRecipeContent on save.

--- a/src/server.ts
+++ b/src/server.ts
@@ -153,6 +153,17 @@ export class Server extends EventEmitter<ServerEvents> {
   public deleteRecipeContentFn:
     | ((name: string) => { ok: boolean; path?: string; error?: string })
     | null = null;
+  /** Patchwork: set by bridge to promote a variant recipe to the canonical name. */
+  public promoteRecipeVariantFn:
+    | ((
+        variantName: string,
+        targetName: string,
+      ) => {
+        ok: boolean;
+        path?: string;
+        error?: string;
+      })
+    | null = null;
   /** Patchwork: set by bridge to duplicate a recipe as a variant. */
   public duplicateRecipeFn:
     | ((name: string) => {
@@ -1090,6 +1101,7 @@ export class Server extends EventEmitter<ServerEvents> {
           saveRecipeContentFn: this.saveRecipeContentFn,
           deleteRecipeContentFn: this.deleteRecipeContentFn,
           duplicateRecipeFn: this.duplicateRecipeFn,
+          promoteRecipeVariantFn: this.promoteRecipeVariantFn,
           lintRecipeContentFn: this.lintRecipeContentFn,
           saveRecipeFn: this.saveRecipeFn,
           setRecipeEnabledFn: this.setRecipeEnabledFn,


### PR DESCRIPTION
## Summary

Completes the Phase 2 §5 Recipe Variants lifecycle: Fork → Compare → Promote → Archive.

- **`src/recipesHttp.ts`** — `promoteRecipeVariant(recipesDir, variantName, targetName)`: loads variant YAML, rewrites `name:` field, saves under `targetName` (overwrites existing), then best-effort deletes the variant file.
- **`src/recipeRoutes.ts`** — `POST /recipes/:name/promote { targetName }` → 200 `{ ok, path }`. 404 if variant not found. Added `promoteRecipeVariantFn` to `RecipeRouteDeps`.
- **`src/recipeOrchestration.ts`** + **`src/server.ts`** — wiring.
- **`dashboard/src/app/recipes/compare/page.tsx`** — Two-column dry-run plan diff. Rows unique to each variant are amber-highlighted. Per-column step count + "+N new / -N removed" pills. Promote button sends `POST /promote` with the base name as `targetName`; shows success/error banner with a "Back to recipes →" link on success.
- **`dashboard/src/app/recipes/page.tsx`** — Fork button now navigates to `/recipes/compare?a=<original>&b=<variant>` after a successful duplicate, so the compare flow is automatic.

## Full Phase 2 §5 flow

1. Recipes list → **Fork** → creates `morning-brief-v2`, navigates to `/recipes/compare?a=morning-brief&b=morning-brief-v2`
2. Compare page loads both dry-run plans in parallel; unique steps highlighted
3. Click **Promote → morning-brief** on either column → `POST /recipes/morning-brief-v2/promote { targetName: "morning-brief" }` → variant replaces base, variant file deleted
4. Success banner + link back to recipes list

## Test plan

- [ ] `npm run build` passes
- [ ] `npm test` — 4778 tests pass
- [ ] Fork on recipes page → lands on compare page with correct `?a=&b=` params
- [ ] Compare page: two columns render, unique steps highlighted amber
- [ ] Promote button → `morning-brief-v2` → `morning-brief`, variant file deleted
- [ ] Promoting a non-existent variant → 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)