### PR TITLE
feat(insights): Decision Replay Debugger — Phase 3 §2

### DIFF
--- a/dashboard/src/app/insights/page.tsx
+++ b/dashboard/src/app/insights/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+import Link from "next/link";
 import { useBridgeFetch } from "@/hooks/useBridgeFetch";
 
 interface ToolInsight {
@@ -90,15 +91,20 @@ export default function InsightsPage() {
             modal, now shown in aggregate. Read-only.
           </div>
         </div>
-        {data && (
-          <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
-            <span className="pill muted">{data.totalDecisions} decisions</span>
-            <span className="pill ok">{data.trustedToolCount} trusted</span>
-            {data.rejectedToolCount > 0 && (
-              <span className="pill err">{data.rejectedToolCount} rejected</span>
-            )}
-          </div>
-        )}
+        <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
+          {data && (
+            <>
+              <span className="pill muted">{data.totalDecisions} decisions</span>
+              <span className="pill ok">{data.trustedToolCount} trusted</span>
+              {data.rejectedToolCount > 0 && (
+                <span className="pill err">{data.rejectedToolCount} rejected</span>
+              )}
+            </>
+          )}
+          <Link href="/insights/replay" className="btn sm">
+            Replay →
+          </Link>
+        </div>
       </div>
 
       {loading && tools.length === 0 && (

--- a/dashboard/src/app/insights/replay/page.tsx
+++ b/dashboard/src/app/insights/replay/page.tsx
@@ -1,0 +1,304 @@
+"use client";
+import Link from "next/link";
+import { useState } from "react";
+import { useBridgeFetch } from "@/hooks/useBridgeFetch";
+
+type ReplayDecision = "allow" | "deny" | "ask" | "none";
+type ChangeKind = "now_allowed" | "now_denied" | "now_asked";
+
+interface ReplayRow {
+  timestamp: string;
+  toolName: string;
+  specifier?: string;
+  originalDecision: string;
+  replayDecision: ReplayDecision;
+  unchanged: boolean;
+  changeKind?: ChangeKind;
+  incomplete?: boolean;
+}
+
+interface ReplayResult {
+  rows: ReplayRow[];
+  generatedAt: string;
+  totalRows: number;
+  changedCount: number;
+  nowAllowedCount: number;
+  nowDeniedCount: number;
+  workspace: string;
+}
+
+const DECISION_PILL: Record<string, string> = {
+  allow: "ok",
+  deny: "err",
+  ask: "warn",
+  none: "muted",
+};
+
+const CHANGE_LABEL: Record<ChangeKind, string> = {
+  now_allowed: "Now allowed",
+  now_denied: "Now denied",
+  now_asked: "Now requires approval",
+};
+
+const CHANGE_PILL: Record<ChangeKind, string> = {
+  now_allowed: "ok",
+  now_denied: "err",
+  now_asked: "warn",
+};
+
+function relativeTime(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime();
+  const m = Math.floor(diff / 60000);
+  if (m < 2) return "just now";
+  if (m < 60) return `${m}m ago`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h ago`;
+  return `${Math.floor(h / 24)}d ago`;
+}
+
+export default function ReplayPage() {
+  const [sinceDays, setSinceDays] = useState(7);
+  const [showUnchanged, setShowUnchanged] = useState(false);
+
+  const { data, error, loading } = useBridgeFetch<ReplayResult>(
+    `/api/bridge/approval-insights/replay?sinceDays=${sinceDays}`,
+    { intervalMs: 60000 },
+  );
+
+  const rows = data?.rows ?? [];
+  const visible = showUnchanged ? rows : rows.filter((r) => !r.unchanged);
+
+  return (
+    <section>
+      <div className="page-head">
+        <div>
+          <Link
+            href="/insights"
+            style={{ fontSize: 12, color: "var(--fg-2)", textDecoration: "none" }}
+          >
+            ← Approval Insights
+          </Link>
+          <h1 style={{ marginTop: 4 }}>Decision Replay</h1>
+          <div className="page-head-sub">
+            What would have happened if your current policy had been active in
+            the past? Each row re-evaluates a historical approval against today's
+            rules. Read-only — no tools are re-executed.
+          </div>
+        </div>
+        <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
+          <label htmlFor="since-days" style={{ fontSize: 12, color: "var(--fg-2)" }}>
+            Lookback
+          </label>
+          <select
+            id="since-days"
+            value={sinceDays}
+            onChange={(e) => setSinceDays(Number.parseInt(e.target.value, 10))}
+            style={{
+              background: "var(--bg-2)",
+              border: "1px solid var(--border-default)",
+              borderRadius: "var(--r-2)",
+              color: "var(--fg-0)",
+              fontSize: 12,
+              padding: "4px 8px",
+              outline: "none",
+            }}
+          >
+            <option value={1}>1 day</option>
+            <option value={7}>7 days</option>
+            <option value={30}>30 days</option>
+            <option value={90}>90 days</option>
+          </select>
+          {data && (
+            <>
+              <span className="pill muted">{data.totalRows} decisions</span>
+              {data.changedCount > 0 && (
+                <span className="pill warn">{data.changedCount} changed</span>
+              )}
+              {data.nowAllowedCount > 0 && (
+                <span className="pill ok">+{data.nowAllowedCount} now allowed</span>
+              )}
+              {data.nowDeniedCount > 0 && (
+                <span className="pill err">−{data.nowDeniedCount} now denied</span>
+              )}
+            </>
+          )}
+        </div>
+      </div>
+
+      {loading && rows.length === 0 && (
+        <p style={{ color: "var(--fg-2)" }}>Loading…</p>
+      )}
+      {error && <div className="alert-err">Unreachable: {error}</div>}
+
+      {!loading && !error && data && data.totalRows === 0 && (
+        <div className="empty-state">
+          <h3>No approval history in this window</h3>
+          <p>
+            Widen the lookback or come back after the bridge has processed some
+            approval decisions. Every allow/deny/ask is recorded automatically.
+          </p>
+        </div>
+      )}
+
+      {data && data.totalRows > 0 && (
+        <>
+          {data.changedCount === 0 && (
+            <div
+              style={{
+                padding: "12px 16px",
+                borderRadius: "var(--r-2)",
+                background: "color-mix(in srgb, var(--ok) 10%, transparent)",
+                border: "1px solid color-mix(in srgb, var(--ok) 25%, transparent)",
+                fontSize: 13,
+                marginBottom: "var(--s-4)",
+              }}
+            >
+              ✓ Your current policy matches all {data.totalRows} historical
+              decisions — no divergence detected.
+            </div>
+          )}
+
+          <div className="card" style={{ marginTop: "var(--s-3)" }}>
+            <div className="card-head">
+              <h2>
+                {showUnchanged
+                  ? `All decisions (${rows.length})`
+                  : `Changed decisions (${visible.length})`}
+              </h2>
+              <label
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 6,
+                  fontSize: 12,
+                  color: "var(--fg-2)",
+                  cursor: "pointer",
+                }}
+              >
+                <input
+                  type="checkbox"
+                  checked={showUnchanged}
+                  onChange={(e) => setShowUnchanged(e.target.checked)}
+                />
+                Show unchanged
+              </label>
+            </div>
+
+            {visible.length === 0 && !showUnchanged && (
+              <p style={{ fontSize: 13, color: "var(--fg-2)", margin: "12px 0" }}>
+                No changed decisions in this window. Toggle "Show unchanged" to
+                see all rows.
+              </p>
+            )}
+
+            {visible.length > 0 && (
+              <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 13 }}>
+                <thead>
+                  <tr style={{ borderBottom: "1px solid var(--border-default)" }}>
+                    <th style={{ textAlign: "left", padding: "6px 0", fontWeight: 500, color: "var(--fg-2)", fontSize: 11 }}>Tool</th>
+                    <th style={{ textAlign: "left", padding: "6px 8px", fontWeight: 500, color: "var(--fg-2)", fontSize: 11 }}>Was</th>
+                    <th style={{ textAlign: "left", padding: "6px 8px", fontWeight: 500, color: "var(--fg-2)", fontSize: 11 }}>Would be</th>
+                    <th style={{ textAlign: "left", padding: "6px 8px", fontWeight: 500, color: "var(--fg-2)", fontSize: 11 }}>Change</th>
+                    <th style={{ textAlign: "right", padding: "6px 0", fontWeight: 500, color: "var(--fg-2)", fontSize: 11 }}>When</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {visible.map((row, idx) => (
+                    <tr
+                      key={`${row.timestamp}-${row.toolName}-${idx}`}
+                      style={{
+                        borderBottom: "1px solid var(--border-subtle)",
+                        background: !row.unchanged
+                          ? "color-mix(in srgb, var(--warn) 5%, transparent)"
+                          : undefined,
+                      }}
+                    >
+                      <td style={{ padding: "9px 0", verticalAlign: "middle" }}>
+                        <div>
+                          <code style={{ fontSize: 12 }}>{row.toolName}</code>
+                          {row.specifier && (
+                            <div
+                              style={{
+                                fontSize: 10,
+                                color: "var(--fg-3)",
+                                marginTop: 2,
+                                maxWidth: 260,
+                                overflow: "hidden",
+                                textOverflow: "ellipsis",
+                                whiteSpace: "nowrap",
+                              }}
+                              title={row.specifier}
+                            >
+                              {row.specifier}
+                            </div>
+                          )}
+                          {row.incomplete && (
+                            <span
+                              className="pill muted"
+                              style={{ fontSize: 9, marginTop: 2 }}
+                              title="Row predates specifier capture — matched on tool name only"
+                            >
+                              name-only
+                            </span>
+                          )}
+                        </div>
+                      </td>
+                      <td style={{ padding: "9px 8px", verticalAlign: "middle" }}>
+                        <span
+                          className={`pill ${DECISION_PILL[row.originalDecision] ?? "muted"}`}
+                          style={{ fontSize: 10 }}
+                        >
+                          {row.originalDecision}
+                        </span>
+                      </td>
+                      <td style={{ padding: "9px 8px", verticalAlign: "middle" }}>
+                        <span
+                          className={`pill ${DECISION_PILL[row.replayDecision] ?? "muted"}`}
+                          style={{ fontSize: 10 }}
+                        >
+                          {row.replayDecision}
+                        </span>
+                      </td>
+                      <td style={{ padding: "9px 8px", verticalAlign: "middle" }}>
+                        {row.changeKind ? (
+                          <span
+                            className={`pill ${CHANGE_PILL[row.changeKind]}`}
+                            style={{ fontSize: 10 }}
+                          >
+                            {CHANGE_LABEL[row.changeKind]}
+                          </span>
+                        ) : (
+                          <span style={{ fontSize: 11, color: "var(--fg-3)" }}>—</span>
+                        )}
+                      </td>
+                      <td
+                        style={{
+                          padding: "9px 0",
+                          textAlign: "right",
+                          color: "var(--fg-3)",
+                          verticalAlign: "middle",
+                          whiteSpace: "nowrap",
+                          fontSize: 11,
+                        }}
+                      >
+                        {relativeTime(row.timestamp)}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            )}
+          </div>
+
+          {data.workspace && (
+            <p style={{ fontSize: 11, color: "var(--fg-2)", marginTop: "var(--s-5)" }}>
+              Rules loaded from workspace:{" "}
+              <code style={{ fontSize: 10 }}>{data.workspace}</code>.
+              Generated at {new Date(data.generatedAt).toLocaleTimeString()}.
+            </p>
+          )}
+        </>
+      )}
+    </section>
+  );
+}

--- a/src/decisionReplay.ts
+++ b/src/decisionReplay.ts
@@ -1,0 +1,167 @@
+/**
+ * decisionReplay — Phase 3 §2 Decision Replay Debugger.
+ *
+ * "What would have happened if this new policy had been active last Tuesday?"
+ *
+ * Reads historical `approval_decision` lifecycle entries from the activity
+ * log ring, re-evaluates each against the CURRENT CC permission rules, and
+ * returns a diff: which decisions would have changed (allow→deny, deny→allow)
+ * under the new policy.
+ *
+ * Constraints:
+ * - Read-only: no side effects, no queuing, no re-execution of tools.
+ * - Transparent: every result row links back to the original decision via
+ *   timestamp + toolName so a future "why?" UI can surface the raw row.
+ * - Graceful degradation: rows that predate the params/tier capture (before
+ *   the capture PR) are still replayed — they just miss the specifier, so
+ *   the rule match is tool-name-only. Noted in the result via `incomplete`.
+ */
+
+import type { ActivityLog } from "./activityLog.js";
+import { evaluateRules, loadCcPermissions } from "./ccPermissions.js";
+
+export type ReplayDecision = "allow" | "deny" | "ask" | "none";
+
+export interface ReplayRow {
+  /** ISO-8601 timestamp of the original decision. */
+  timestamp: string;
+  toolName: string;
+  /** Specifier (e.g. command string) captured at decision time, if present. */
+  specifier?: string;
+  /** Decision recorded in the activity log. */
+  originalDecision: string;
+  /** Decision the current policy would produce. */
+  replayDecision: ReplayDecision;
+  /** True when original === replay. */
+  unchanged: boolean;
+  /**
+   * Direction of change for changed rows:
+   *   "now_allowed"  — was deny/ask, would now be allow
+   *   "now_denied"   — was allow, would now be deny/ask
+   *   "now_asked"    — was allow/deny, would now be ask
+   */
+  changeKind?: "now_allowed" | "now_denied" | "now_asked";
+  /**
+   * True when the row lacked specifier / params capture (pre-capture rows).
+   * The replay is still computed, but only on tool name — may produce
+   * fewer/more matches than the original if specifier-scoped rules exist.
+   */
+  incomplete?: boolean;
+}
+
+export interface DecisionReplayResult {
+  /** All replayed rows in chronological order. */
+  rows: ReplayRow[];
+  /** ISO-8601 generation timestamp. */
+  generatedAt: string;
+  /** Total rows evaluated. */
+  totalRows: number;
+  /** Rows where the decision would have changed. */
+  changedCount: number;
+  /** Rows that would flip from deny/ask → allow under current policy. */
+  nowAllowedCount: number;
+  /** Rows that would flip from allow → deny/ask under current policy. */
+  nowDeniedCount: number;
+  /** Workspace path used to load current rules. */
+  workspace: string;
+}
+
+function changeKind(
+  original: string,
+  replay: ReplayDecision,
+): ReplayRow["changeKind"] | undefined {
+  if (replay === "allow" && original !== "allow") return "now_allowed";
+  if ((replay === "deny" || replay === "none") && original === "allow")
+    return "now_denied";
+  if (replay === "ask" && original !== "ask") return "now_asked";
+  return undefined;
+}
+
+export function computeDecisionReplay(
+  activityLog: ActivityLog,
+  opts: {
+    workspace: string;
+    /** Only replay decisions newer than this epoch ms. 0 = all. */
+    sinceMs?: number;
+    /** Cap at this many rows (newest-first after filter). Default 500. */
+    limit?: number;
+    /** Override the CC permissions loader — used in tests. */
+    loadRulesFn?: typeof loadCcPermissions;
+  },
+): DecisionReplayResult {
+  const { workspace, sinceMs = 0, limit = 500 } = opts;
+  const loadRules = opts.loadRulesFn ?? loadCcPermissions;
+
+  // Load current rules once — same workspace as the bridge is running in.
+  const rules = loadRules(workspace);
+
+  // Pull all approval_decision entries, apply time filter, cap.
+  const all = activityLog.queryApprovalDecisions();
+  const filtered =
+    sinceMs > 0 ? all.filter((e) => Date.parse(e.timestamp) >= sinceMs) : all;
+  const capped = filtered.slice(-Math.min(limit, 500));
+
+  const rows: ReplayRow[] = [];
+  for (const entry of capped) {
+    const toolName =
+      typeof entry.metadata?.toolName === "string"
+        ? entry.metadata.toolName
+        : null;
+    if (!toolName) continue;
+
+    const originalDecision =
+      typeof entry.metadata?.decision === "string"
+        ? entry.metadata.decision
+        : "unknown";
+
+    // Specifier: stored as metadata.specifier (string) or derived from
+    // params.command / params.path / params.url — whichever was captured.
+    let specifier: string | undefined;
+    const rawSpecifier = entry.metadata?.specifier;
+    if (typeof rawSpecifier === "string") {
+      specifier = rawSpecifier;
+    } else {
+      const params = entry.metadata?.params as
+        | Record<string, unknown>
+        | undefined;
+      const cmd =
+        params?.command ?? params?.path ?? params?.url ?? params?.pattern;
+      if (typeof cmd === "string") specifier = cmd;
+    }
+
+    const incomplete = specifier === undefined;
+    const replay = evaluateRules(toolName, specifier, rules);
+
+    const unchanged =
+      replay === originalDecision ||
+      (replay === "none" && originalDecision === "allow") ||
+      (replay === "none" && originalDecision === "deny");
+
+    rows.push({
+      timestamp: entry.timestamp,
+      toolName,
+      ...(specifier !== undefined && { specifier }),
+      originalDecision,
+      replayDecision: replay,
+      unchanged,
+      ...(changeKind(originalDecision, replay) !== undefined && {
+        changeKind: changeKind(originalDecision, replay),
+      }),
+      ...(incomplete && { incomplete: true }),
+    });
+  }
+
+  const changedRows = rows.filter((r) => !r.unchanged);
+
+  return {
+    rows,
+    generatedAt: new Date().toISOString(),
+    totalRows: rows.length,
+    changedCount: changedRows.length,
+    nowAllowedCount: changedRows.filter((r) => r.changeKind === "now_allowed")
+      .length,
+    nowDeniedCount: changedRows.filter((r) => r.changeKind === "now_denied")
+      .length,
+    workspace,
+  };
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -1045,6 +1045,34 @@ export class Server extends EventEmitter<ServerEvents> {
         res.end(JSON.stringify(result));
         return;
       }
+      // Decision replay — Phase 3 §2. Re-evaluates historical approval
+      // decisions against the current CC policy. Read-only; no side effects.
+      if (
+        parsedUrl.pathname === "/approval-insights/replay" &&
+        req.method === "GET"
+      ) {
+        if (!this.activityLog) {
+          res.writeHead(503, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ error: "activity log not wired" }));
+          return;
+        }
+        const sinceDaysParam = parsedUrl.searchParams?.get("sinceDays");
+        const sinceDays =
+          sinceDaysParam !== null && sinceDaysParam !== undefined
+            ? Number.parseInt(sinceDaysParam, 10)
+            : 7;
+        const sinceMs = Number.isFinite(sinceDays)
+          ? Date.now() - sinceDays * 24 * 60 * 60 * 1000
+          : 0;
+        const { computeDecisionReplay } = await import("./decisionReplay.js");
+        const result = computeDecisionReplay(this.activityLog, {
+          workspace: process.cwd(),
+          sinceMs,
+        });
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify(result));
+        return;
+      }
       // Reversible-refactoring surface — list active staged transactions
       // (Phase 1 §3 dashboard ask). Read-only metadata for the dashboard
       // /transactions page; no file contents leave the bridge.


### PR DESCRIPTION
## Summary

- `computeDecisionReplay()` in `src/decisionReplay.ts` re-evaluates historical `approval_decision` log entries against the current CC permission rules — read-only, no side effects
- `GET /approval-insights/replay?sinceDays=N` endpoint wired into `server.ts`
- `/insights/replay` dashboard page: lookback selector (1/7/30/90 days), changed-decisions-only table with Tool / Was / Would be / Change / When columns, "Show unchanged" toggle, no-divergence success banner
- "Replay →" link added to the `/insights` page-head so users can navigate directly to the debugger

## Test plan

- [ ] Build passes (`npm run build`)
- [ ] All 4778 tests pass (`npm test`)
- [ ] Biome clean
- [ ] Navigate to `/insights` — "Replay →" button visible in header
- [ ] Click Replay → lands on `/insights/replay` with lookback selector
- [ ] With no approval history: empty-state message shown
- [ ] With history and no policy divergence: green "no divergence" banner
- [ ] "Show unchanged" toggle reveals all rows; default shows only changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)