### PR TITLE
feat(marketplace): capability bundle format — Phase 5 §1+§2

### DIFF
--- a/dashboard/src/app/marketplace/bundle/[...slug]/page.tsx
+++ b/dashboard/src/app/marketplace/bundle/[...slug]/page.tsx
@@ -1,0 +1,305 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { ConnectorHealthPanel } from "@/components/ConnectorHealthPanel";
+import {
+  fetchBundleManifest,
+  fetchRegistry,
+  parseInstallSource,
+  type ApprovalBehavior,
+  type BundleManifest,
+  type RegistryBundle,
+  type RiskLevel,
+  shortName,
+} from "@/lib/registry";
+
+export const revalidate = 300;
+
+interface PageProps {
+  params: { slug: string[] };
+}
+
+export async function generateMetadata({ params }: PageProps) {
+  const fullName = decodeURIComponent(params.slug.join("/"));
+  const registry = await fetchRegistry();
+  const bundle = registry?.bundles?.find((b) => b.name === fullName);
+  if (!bundle) return { title: "Not found — Marketplace · Patchwork OS" };
+  return {
+    title: `${shortName(bundle.name)} — Bundle · Marketplace · Patchwork OS`,
+    description: bundle.description,
+  };
+}
+
+export default async function BundleDetailPage({ params }: PageProps) {
+  const fullName = decodeURIComponent(params.slug.join("/"));
+
+  const registry = await fetchRegistry();
+  const bundle = registry?.bundles?.find((b) => b.name === fullName);
+  if (!bundle) notFound();
+
+  const src = parseInstallSource(bundle.install);
+  let manifest: BundleManifest | null = null;
+  if (src) manifest = await fetchBundleManifest(src);
+
+  return (
+    <section style={{ display: "flex", flexDirection: "column", gap: "var(--s-6)" }}>
+      <Link
+        href="/marketplace"
+        className="btn sm ghost"
+        style={{ alignSelf: "flex-start", textDecoration: "none", fontSize: 12 }}
+      >
+        ← Back to marketplace
+      </Link>
+
+      <BundleHeader bundle={bundle} manifest={manifest} />
+
+      <p style={{ fontSize: 14, color: "var(--ink-1)", lineHeight: 1.6, maxWidth: 760 }}>
+        {manifest?.description ?? bundle.description}
+      </p>
+
+      <WhatIsIncluded bundle={bundle} manifest={manifest} />
+
+      <ConnectorHealthPanel connectors={bundle.connectors} marginTop={0} />
+
+      <TrustCard bundle={bundle} />
+
+      {manifest?.required_env && manifest.required_env.length > 0 && (
+        <RequiredEnvCard vars={manifest.required_env} />
+      )}
+
+      <InstallInstructions bundle={bundle} manifest={manifest} />
+
+      <TrustNote />
+    </section>
+  );
+}
+
+// ----------------------------------------------------------------- subcomponents
+
+const RISK_PILL_CLASS: Record<RiskLevel, string> = { low: "ok", medium: "warn", high: "err" };
+const APPROVAL_LABEL: Record<ApprovalBehavior, string> = {
+  always_ask: "Always asks for approval",
+  ask_on_novel: "Asks on new tools / specifiers",
+  auto_approve: "Designed to run unattended once trusted",
+};
+
+function BundleHeader({
+  bundle,
+  manifest,
+}: {
+  bundle: RegistryBundle;
+  manifest: BundleManifest | null;
+}) {
+  const author = manifest?.author ?? bundle.maintainer;
+  return (
+    <div className="page-head">
+      <div>
+        <div style={{ fontSize: 11, color: "var(--fg-3)", textTransform: "uppercase", letterSpacing: "0.05em", marginBottom: 4 }}>
+          Capability Bundle
+        </div>
+        <h1 style={{ fontFamily: "var(--font-mono, ui-monospace, monospace)", letterSpacing: "-0.01em" }}>
+          {shortName(bundle.name)}
+        </h1>
+        <div className="page-head-sub" style={{ fontSize: 13, color: "var(--ink-2)" }}>
+          {bundle.name}
+          <span style={{ margin: "0 8px", color: "var(--ink-3)" }}>·</span>
+          <span>v{bundle.version}</span>
+          {author && (
+            <>
+              <span style={{ margin: "0 8px", color: "var(--ink-3)" }}>·</span>
+              <span>by {author}</span>
+            </>
+          )}
+          {manifest?.license && (
+            <>
+              <span style={{ margin: "0 8px", color: "var(--ink-3)" }}>·</span>
+              <span>{manifest.license}</span>
+            </>
+          )}
+        </div>
+      </div>
+      <div style={{ display: "flex", gap: 6, flexWrap: "wrap", justifyContent: "flex-end" }}>
+        {bundle.tags.map((t) => (
+          <span key={t} className="tag-pill">{t}</span>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function WhatIsIncluded({
+  bundle,
+  manifest,
+}: {
+  bundle: RegistryBundle;
+  manifest: BundleManifest | null;
+}) {
+  const recipes = manifest?.recipes ?? [];
+  const plugin = manifest?.plugin ?? (bundle.has_plugin ? "companion plugin" : null);
+  const hasPolicy = manifest?.policy_template ?? bundle.has_policy;
+
+  return (
+    <div className="glass-card" style={{ padding: "var(--s-5)" }}>
+      <h3 style={{ fontSize: 13, marginTop: 0, marginBottom: "var(--s-3)" }}>What&apos;s included</h3>
+      <div style={{ display: "flex", flexDirection: "column", gap: "var(--s-2)" }}>
+        {recipes.length > 0 && (
+          <div>
+            <div style={{ fontSize: 11, color: "var(--fg-3)", textTransform: "uppercase", letterSpacing: "0.04em", marginBottom: "var(--s-1)" }}>
+              Recipes ({recipes.length})
+            </div>
+            <ul style={{ listStyle: "none", padding: 0, margin: 0, display: "flex", flexDirection: "column", gap: 4 }}>
+              {recipes.map((r) => (
+                <li key={r} style={{ fontSize: 12, fontFamily: "var(--font-mono, ui-monospace, monospace)", color: "var(--fg-1)" }}>
+                  {r}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        {recipes.length === 0 && bundle.recipe_count != null && bundle.recipe_count > 0 && (
+          <div style={{ fontSize: 12, color: "var(--fg-2)" }}>
+            {bundle.recipe_count} recipe{bundle.recipe_count !== 1 ? "s" : ""} included
+          </div>
+        )}
+
+        {plugin && (
+          <div>
+            <div style={{ fontSize: 11, color: "var(--fg-3)", textTransform: "uppercase", letterSpacing: "0.04em", marginBottom: "var(--s-1)" }}>
+              Plugin
+            </div>
+            <code style={{ fontSize: 12 }}>{plugin}</code>
+            <p style={{ fontSize: 11, color: "var(--fg-3)", marginTop: 4 }}>
+              Installed via <code>npm install -g {plugin}</code> during bundle setup.
+            </p>
+          </div>
+        )}
+
+        {hasPolicy && (
+          <div>
+            <div style={{ fontSize: 11, color: "var(--fg-3)", textTransform: "uppercase", letterSpacing: "0.04em", marginBottom: "var(--s-1)" }}>
+              Policy template
+            </div>
+            <p style={{ fontSize: 12, color: "var(--fg-2)", margin: 0 }}>
+              A delegation policy fragment is included. It will be shown for your review and requires explicit approval before being applied — never applied silently.
+            </p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function TrustCard({ bundle }: { bundle: RegistryBundle }) {
+  const { risk_level, network_access, file_access, approval_behavior } = bundle;
+  const hasAny = risk_level || network_access != null || file_access != null || approval_behavior;
+  if (!hasAny) return null;
+
+  const rows: Array<{ label: string; value: React.ReactNode }> = [];
+  if (risk_level) {
+    rows.push({
+      label: "Risk level",
+      value: <span className={`pill ${RISK_PILL_CLASS[risk_level]}`} style={{ fontSize: 11 }}>{risk_level}</span>,
+    });
+  }
+  if (approval_behavior) {
+    rows.push({ label: "Approval", value: APPROVAL_LABEL[approval_behavior] });
+  }
+  if (network_access != null) {
+    rows.push({ label: "Network access", value: network_access ? "Yes — makes outbound HTTP requests" : "No" });
+  }
+  if (file_access != null) {
+    rows.push({ label: "File access", value: file_access ? "Yes — reads or writes local files" : "No" });
+  }
+
+  return (
+    <div className="glass-card" style={{ padding: "var(--s-5)" }}>
+      <h3 style={{ fontSize: 13, marginTop: 0, marginBottom: "var(--s-3)" }}>Trust &amp; permissions</h3>
+      <table style={{ width: "100%", fontSize: 12, borderCollapse: "collapse" }}>
+        <tbody>
+          {rows.map(({ label, value }) => (
+            <tr key={label} style={{ borderBottom: "1px solid var(--line-1)" }}>
+              <td style={{ padding: "7px 8px", color: "var(--ink-2)", width: 160, verticalAlign: "middle" }}>{label}</td>
+              <td style={{ padding: "7px 8px", color: "var(--ink-1)", verticalAlign: "middle" }}>{value}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function RequiredEnvCard({ vars }: { vars: string[] }) {
+  return (
+    <div className="glass-card" style={{ padding: "var(--s-5)" }}>
+      <h3 style={{ fontSize: 13, marginTop: 0, marginBottom: "var(--s-3)" }}>Required environment variables</h3>
+      <p style={{ fontSize: 12, color: "var(--fg-2)", marginTop: 0, marginBottom: "var(--s-3)" }}>
+        Set these in your bridge environment before activating the bundle:
+      </p>
+      <ul style={{ listStyle: "none", padding: 0, margin: 0, display: "flex", flexDirection: "column", gap: 6 }}>
+        {vars.map((v) => (
+          <li key={v} style={{ display: "flex", alignItems: "center", gap: 8 }}>
+            <code style={{ fontSize: 12, background: "var(--bg-2)", padding: "2px 6px", borderRadius: "var(--r-1)" }}>{v}</code>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function InstallInstructions({
+  bundle,
+  manifest,
+}: {
+  bundle: RegistryBundle;
+  manifest: BundleManifest | null;
+}) {
+  const plugin = manifest?.plugin;
+  return (
+    <div className="glass-card" style={{ padding: "var(--s-5)" }}>
+      <h3 style={{ fontSize: 13, marginTop: 0, marginBottom: "var(--s-3)" }}>Install</h3>
+      <p style={{ fontSize: 12, color: "var(--fg-2)", marginTop: 0 }}>
+        Bundle install support is coming in a future bridge release. Until then, install each recipe individually from the Marketplace.
+      </p>
+      {plugin && (
+        <p style={{ fontSize: 12, color: "var(--fg-2)" }}>
+          Plugin: <code style={{ fontSize: 11 }}>npm install -g {plugin}</code>, then restart the bridge with{" "}
+          <code style={{ fontSize: 11 }}>--plugin {plugin}</code>.
+        </p>
+      )}
+      <div style={{ marginTop: "var(--s-3)", display: "flex", gap: 8 }}>
+        <code
+          style={{
+            fontSize: 11,
+            background: "var(--bg-1)",
+            border: "1px solid var(--border-subtle)",
+            borderRadius: "var(--r-2)",
+            padding: "6px 10px",
+            color: "var(--fg-1)",
+          }}
+        >
+          patchwork install-bundle {bundle.name}
+        </code>
+        <span style={{ fontSize: 11, color: "var(--fg-3)", alignSelf: "center" }}>coming soon</span>
+      </div>
+    </div>
+  );
+}
+
+function TrustNote() {
+  return (
+    <div
+      style={{
+        padding: "12px 16px",
+        background: "rgba(180,83,9,0.06)",
+        border: "1px solid rgba(180,83,9,0.18)",
+        borderRadius: "var(--r-3)",
+        fontSize: 12,
+        color: "var(--ink-2)",
+        lineHeight: 1.6,
+      }}
+    >
+      <strong style={{ color: "var(--ink-1)" }}>Review before installing.</strong>{" "}
+      Bundles can include recipes, plugins, and policy changes. Read the included components carefully. Policy templates are never applied without your explicit confirmation.
+    </div>
+  );
+}

--- a/dashboard/src/app/marketplace/page.tsx
+++ b/dashboard/src/app/marketplace/page.tsx
@@ -3,7 +3,15 @@ import Link from "next/link";
 import { useEffect, useState } from "react";
 import { Skeleton, SkeletonText } from "@/components/Skeleton";
 import { apiPath } from "@/lib/api";
-import { assertValidInstallSource, type RegistryData, type RegistryRecipe, shortName, type RiskLevel, type ApprovalBehavior } from "@/lib/registry";
+import {
+  assertValidInstallSource,
+  type ApprovalBehavior,
+  type RegistryBundle,
+  type RegistryData,
+  type RegistryRecipe,
+  type RiskLevel,
+  shortName,
+} from "@/lib/registry";
 
 // ------------------------------------------------------------------ fallback data (shown when bridge offline)
 
@@ -89,6 +97,45 @@ const FALLBACK_REGISTRY: RegistryData = {
   ],
 };
 
+const FALLBACK_BUNDLES: RegistryBundle[] = [
+  {
+    name: "@patchworkos/gmail-vip-support",
+    version: "1.0.0",
+    description:
+      "Full VIP support pipeline: Gmail connector + triage recipe + escalation recipe + conservative approval policy. One install configures everything.",
+    tags: ["support", "gmail", "productivity"],
+    connectors: ["gmail", "linear", "slack"],
+    install: "github:patchworkos/bundles/bundles/gmail-vip-support",
+    downloads: 0,
+    has_plugin: false,
+    recipe_count: 2,
+    has_policy: true,
+    risk_level: "medium",
+    network_access: true,
+    file_access: false,
+    approval_behavior: "always_ask",
+    maintainer: "@patchworkos",
+  },
+  {
+    name: "@patchworkos/dev-workflow",
+    version: "1.0.0",
+    description:
+      "Developer automation bundle: PR reviewer plugin + sprint-prep recipe + test-failure recipe + developer approval policy.",
+    tags: ["engineering", "github", "developer"],
+    connectors: ["github", "linear", "slack"],
+    install: "github:patchworkos/bundles/bundles/dev-workflow",
+    downloads: 0,
+    has_plugin: true,
+    recipe_count: 3,
+    has_policy: true,
+    risk_level: "medium",
+    network_access: true,
+    file_access: true,
+    approval_behavior: "ask_on_novel",
+    maintainer: "@patchworkos",
+  },
+];
+
 // ------------------------------------------------------------------ constants
 
 const PROVIDER_COLORS: Record<string, string> = {
@@ -109,6 +156,9 @@ const PROVIDER_COLORS: Record<string, string> = {
   sentry: "#362D59",
   pagerduty: "#06AC38",
 };
+
+const TYPE_FILTERS = ["All", "Recipes", "Bundles"] as const;
+type TypeFilter = (typeof TYPE_FILTERS)[number];
 
 const CATEGORIES = ["All", "Productivity", "Incident Ops", "Engineering", "Customer", "Sales"];
 
@@ -151,6 +201,17 @@ function recipeMatchesCategory(recipe: RegistryRecipe, category: string): boolea
   if (category === "All") return true;
   const allowed = CATEGORY_TAG_MAP[category] ?? [];
   return recipe.tags.some((t) => allowed.includes(t.toLowerCase()));
+}
+
+function bundleMatchesSearch(bundle: RegistryBundle, search: string): boolean {
+  if (!search.trim()) return true;
+  const q = search.toLowerCase();
+  return (
+    bundle.name.toLowerCase().includes(q) ||
+    bundle.description.toLowerCase().includes(q) ||
+    bundle.tags.some((t) => t.toLowerCase().includes(q)) ||
+    bundle.connectors.some((c) => c.toLowerCase().includes(q))
+  );
 }
 
 // ------------------------------------------------------------------ toast
@@ -402,15 +463,92 @@ function RecipeCard({
   );
 }
 
+// ------------------------------------------------------------------ bundle card
+
+function BundleCard({ bundle }: { bundle: RegistryBundle }) {
+  const displayTags = bundle.tags.slice(0, 2);
+
+  return (
+    <div className="template-card glass-card">
+      {/* top: name + tags */}
+      <div style={{ display: "flex", alignItems: "flex-start", justifyContent: "space-between", gap: 8, marginBottom: "var(--s-2)" }}>
+        <div style={{ display: "flex", flexDirection: "column", gap: 2, minWidth: 0 }}>
+          <span style={{ fontWeight: 600, fontSize: 14, color: "var(--fg-0)", wordBreak: "break-word", lineHeight: 1.4 }}>
+            {shortName(bundle.name)}
+          </span>
+          <span style={{ fontSize: 10, color: "var(--fg-3)", letterSpacing: "0.04em", textTransform: "uppercase" }}>
+            Bundle
+          </span>
+        </div>
+        <div style={{ display: "flex", flexWrap: "wrap", gap: 4, justifyContent: "flex-end", flexShrink: 0 }}>
+          {displayTags.map((tag) => (
+            <span key={tag} className="tag-pill">{tag}</span>
+          ))}
+        </div>
+      </div>
+
+      {/* description */}
+      <p style={{ fontSize: 12, color: "var(--fg-2)", lineHeight: 1.55, flex: 1, overflow: "hidden", display: "-webkit-box", WebkitLineClamp: 3, WebkitBoxOrient: "vertical", margin: 0 }}>
+        {bundle.description}
+      </p>
+
+      {/* what's included */}
+      <div style={{ display: "flex", gap: 4, flexWrap: "wrap", marginTop: "var(--s-2)" }}>
+        {bundle.recipe_count != null && (
+          <span className="pill muted" style={{ fontSize: 9 }}>
+            {bundle.recipe_count} recipe{bundle.recipe_count !== 1 ? "s" : ""}
+          </span>
+        )}
+        {bundle.has_plugin && (
+          <span className="pill muted" style={{ fontSize: 9 }}>plugin</span>
+        )}
+        {bundle.has_policy && (
+          <span className="pill muted" style={{ fontSize: 9 }}>policy</span>
+        )}
+        {bundle.risk_level && (
+          <span className={`pill ${RISK_PILL_CLASS[bundle.risk_level]}`} style={{ fontSize: 9 }}>
+            {bundle.risk_level} risk
+          </span>
+        )}
+        {bundle.approval_behavior && (
+          <span className="pill muted" style={{ fontSize: 9 }}>
+            {APPROVAL_LABEL[bundle.approval_behavior]}
+          </span>
+        )}
+      </div>
+
+      {/* bottom: connectors */}
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginTop: "var(--s-3)", gap: "var(--s-2)" }}>
+        <div style={{ display: "flex", gap: 6, alignItems: "center", flexWrap: "wrap" }}>
+          {bundle.connectors.map((c) => (
+            <span key={c} className="connector-dot" title={c} style={{ background: connectorColor(c) }} aria-label={c}>
+              {connectorInitials(c)}
+            </span>
+          ))}
+        </div>
+        <a
+          href={`/marketplace/bundle/${encodeURIComponent(bundle.name)}`}
+          className="btn sm"
+          style={{ textDecoration: "none", flexShrink: 0 }}
+        >
+          View bundle
+        </a>
+      </div>
+    </div>
+  );
+}
+
 // ------------------------------------------------------------------ page
 
 export default function MarketplacePage() {
   const [registry, setRegistry] = useState<RegistryRecipe[] | null>(null);
+  const [bundles, setBundles] = useState<RegistryBundle[]>(FALLBACK_BUNDLES);
   const [installedNames, setInstalledNames] = useState<Set<string>>(new Set());
   const [bridgeOnline, setBridgeOnline] = useState(false);
   const [loadErr, setLoadErr] = useState<string | null>(null);
   const [search, setSearch] = useState("");
   const [category, setCategory] = useState("All");
+  const [typeFilter, setTypeFilter] = useState<TypeFilter>("All");
   const [toast, setToast] = useState<string | null>(null);
 
   useEffect(() => {
@@ -466,6 +604,22 @@ export default function MarketplacePage() {
       }
 
       setRegistry(recipes ?? FALLBACK_REGISTRY.recipes);
+
+      // Bundles: parse from registry if present (registry v2+), else use fallback
+      if (!recipes) return;
+      try {
+        const res = await fetch(
+          "https://raw.githubusercontent.com/patchworkos/recipes/main/index.json",
+        );
+        if (res.ok) {
+          const data = (await res.json()) as RegistryData;
+          if (data.bundles && data.bundles.length > 0) {
+            setBundles(data.bundles);
+          }
+        }
+      } catch {
+        // keep fallback bundles
+      }
     }
 
     load().catch((e) => setLoadErr(e instanceof Error ? e.message : String(e)));
@@ -512,6 +666,12 @@ export default function MarketplacePage() {
       r.connectors.some((c) => c.toLowerCase().includes(q))
     );
   });
+
+  const filteredBundles = bundles.filter((b) => bundleMatchesSearch(b, search));
+
+  const showRecipes = typeFilter === "All" || typeFilter === "Recipes";
+  const showBundles = typeFilter === "All" || typeFilter === "Bundles";
+  const totalVisible = (showRecipes ? filtered.length : 0) + (showBundles ? filteredBundles.length : 0);
 
   return (
     <section>
@@ -565,7 +725,7 @@ export default function MarketplacePage() {
         <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
           {registry && (
             <span className="pill muted">
-              {filtered.length} recipe{filtered.length !== 1 ? "s" : ""}
+              {totalVisible} item{totalVisible !== 1 ? "s" : ""}
             </span>
           )}
           <a
@@ -576,7 +736,7 @@ export default function MarketplacePage() {
             style={{ textDecoration: "none", fontSize: 12 }}
             aria-label="Submit a recipe to the marketplace"
           >
-            Submit a recipe →
+            Submit →
           </a>
         </div>
       </div>
@@ -590,17 +750,43 @@ export default function MarketplacePage() {
           marginBottom: "var(--s-6)",
         }}
       >
+        {/* type filter */}
+        <div style={{ display: "flex", gap: "var(--s-2)" }}>
+          {TYPE_FILTERS.map((tf) => (
+            <button
+              key={tf}
+              type="button"
+              onClick={() => setTypeFilter(tf)}
+              style={{
+                padding: "3px 12px",
+                borderRadius: "var(--r-full)",
+                fontSize: 12,
+                fontWeight: 500,
+                cursor: "pointer",
+                border: "1px solid",
+                transition: "all 0.15s",
+                borderColor: typeFilter === tf ? "var(--accent)" : "var(--border-default)",
+                background: typeFilter === tf ? "var(--accent-soft)" : "transparent",
+                color: typeFilter === tf ? "var(--accent-strong)" : "var(--fg-2)",
+              }}
+              aria-pressed={typeFilter === tf}
+            >
+              {tf}
+            </button>
+          ))}
+        </div>
+
         <input
           type="search"
           className="input"
-          placeholder="Search recipes (name, tags, connectors)…"
+          placeholder="Search by name, tags, connectors…"
           value={search}
           onChange={(e) => setSearch(e.target.value)}
           style={{ maxWidth: 360 }}
-          aria-label="Search marketplace recipes"
+          aria-label="Search marketplace"
         />
 
-        <div style={{ display: "flex", gap: "var(--s-2)", flexWrap: "wrap" }}>
+        {showRecipes && <div style={{ display: "flex", gap: "var(--s-2)", flexWrap: "wrap" }}>
           {CATEGORIES.map((cat) => (
             <button
               key={cat}
@@ -623,7 +809,7 @@ export default function MarketplacePage() {
               {cat}
             </button>
           ))}
-        </div>
+        </div>}
       </div>
 
       {loadErr && (
@@ -650,23 +836,50 @@ export default function MarketplacePage() {
             </div>
           ))}
         </div>
-      ) : filtered.length === 0 ? (
+      ) : totalVisible === 0 ? (
         <div className="empty-state">
-          <h3>No recipes found</h3>
+          <h3>No results found</h3>
           <p>Try a different search term or category.</p>
         </div>
       ) : (
-        <div className="marketplace-grid">
-          {filtered.map((recipe) => (
-            <RecipeCard
-              key={recipe.name}
-              recipe={recipe}
-              installed={installedNames.has(recipe.name)}
-              bridgeOnline={bridgeOnline}
-              onInstall={handleInstall}
-            />
-          ))}
-        </div>
+        <>
+          {showRecipes && filtered.length > 0 && (
+            <>
+              {typeFilter === "All" && (
+                <h2 style={{ fontSize: 13, fontWeight: 600, color: "var(--fg-2)", marginBottom: "var(--s-3)", marginTop: 0 }}>
+                  Recipes
+                </h2>
+              )}
+              <div className="marketplace-grid">
+                {filtered.map((recipe) => (
+                  <RecipeCard
+                    key={recipe.name}
+                    recipe={recipe}
+                    installed={installedNames.has(recipe.name)}
+                    bridgeOnline={bridgeOnline}
+                    onInstall={handleInstall}
+                  />
+                ))}
+              </div>
+            </>
+          )}
+
+          {showBundles && filteredBundles.length > 0 && (
+            <>
+              <h2 style={{ fontSize: 13, fontWeight: 600, color: "var(--fg-2)", marginBottom: "var(--s-3)", marginTop: showRecipes && filtered.length > 0 ? "var(--s-8)" : 0 }}>
+                Bundles
+                <span style={{ marginLeft: 8, fontWeight: 400, fontSize: 11, color: "var(--fg-3)" }}>
+                  Plugin + recipes + policy in one install
+                </span>
+              </h2>
+              <div className="marketplace-grid">
+                {filteredBundles.map((bundle) => (
+                  <BundleCard key={bundle.name} bundle={bundle} />
+                ))}
+              </div>
+            </>
+          )}
+        </>
       )}
     </section>
   );

--- a/dashboard/src/lib/registry.ts
+++ b/dashboard/src/lib/registry.ts
@@ -35,10 +35,78 @@ export interface RegistryRecipe extends TrustMetadata {
   downloads: number;
 }
 
+/**
+ * A capability bundle packages a plugin + recipes + policy template +
+ * connector requirements into a single installable unit.
+ *
+ * Structure on disk / in the registry:
+ *
+ *   my-bundle/
+ *     patchwork-bundle.json   ← this manifest
+ *     recipes/                ← one or more recipe YAML files
+ *     policy-template.json    ← delegation policy fragment (optional)
+ *     plugin/                 ← npm package or local plugin dir (optional)
+ *     README.md
+ *
+ * The install field uses the same `github:owner/repo/path@ref` shape
+ * as RegistryRecipe so the same parseInstallSource helper works.
+ */
+export interface BundleManifest {
+  /** Scoped package name, e.g. "@patchworkos/gmail-vip-support". */
+  name: string;
+  version: string;
+  description: string;
+  /** Short human label shown in the marketplace tile. */
+  display_name?: string;
+  author?: string;
+  license?: string;
+  homepage?: string;
+  tags: string[];
+  /** Connector namespaces required by the bundle (e.g. "gmail", "linear"). */
+  connectors: string[];
+  /** Recipe YAML files included in the bundle (relative paths). */
+  recipes: string[];
+  /**
+   * npm package name of the companion plugin, if the bundle ships one.
+   * When present the install flow prompts the user to `npm install -g`
+   * the plugin before activating recipes.
+   */
+  plugin?: string;
+  /**
+   * Relative path to the policy-template.json fragment inside the bundle.
+   * Applied with user confirmation during install — never silently.
+   */
+  policy_template?: string;
+  /**
+   * Environment variable names the bundle requires (connector credentials,
+   * API keys, etc.). Shown as a checklist before install.
+   */
+  required_env?: string[];
+} & TrustMetadata;
+
+export interface RegistryBundle extends TrustMetadata {
+  name: string;
+  version: string;
+  description: string;
+  tags: string[];
+  connectors: string[];
+  /** Same `github:owner/repo/path@ref` shape as RegistryRecipe. */
+  install: string;
+  downloads: number;
+  /** Whether the bundle ships a companion plugin. */
+  has_plugin?: boolean;
+  /** Number of recipes included in the bundle. */
+  recipe_count?: number;
+  /** Whether the bundle includes a policy template fragment. */
+  has_policy?: boolean;
+}
+
 export interface RegistryData {
   version: string;
   updated_at: string;
   recipes: RegistryRecipe[];
+  /** Capability bundles (plugin + recipes + policy template). Added in registry v2. */
+  bundles?: RegistryBundle[];
 }
 
 export interface RecipeManifest {
@@ -178,6 +246,21 @@ export function summarizeRisk(yaml: string): {
   const high = (yaml.match(/^\s*risk:\s*high\b/gm) ?? []).length;
   const steps = (yaml.match(/^\s*-\s*id:\s+\S/gm) ?? []).length;
   return { low, medium, high, steps };
+}
+
+export async function fetchBundleManifest(
+  src: ParsedInstallSource,
+  opts: FetchOpts = {},
+): Promise<BundleManifest | null> {
+  try {
+    const res = await fetch(rawUrlFor(src, "patchwork-bundle.json"), {
+      next: { revalidate: opts.revalidate ?? 300 },
+    });
+    if (!res.ok) return null;
+    return (await res.json()) as BundleManifest;
+  } catch {
+    return null;
+  }
 }
 
 /** Strip the `@scope/` prefix for display. */


### PR DESCRIPTION
## Summary

- **`BundleManifest` + `RegistryBundle` types** in `registry.ts` — the `patchwork-bundle.json` schema for distributing plugin + recipes + policy template + connector requirements as one installable unit
- **`fetchBundleManifest()`** helper — fetches `patchwork-bundle.json` from a `github:owner/repo/path@ref` install source
- **`RegistryData.bundles?`** field — backwards-compatible, populated when registry ships v2
- **Marketplace list**: All / Recipes / Bundles type filter; bundle cards show "Bundle" label, recipe/plugin/policy inclusion pills, risk + approval badges; separate grid section with header when both types visible
- **`/marketplace/bundle/[...slug]` detail page**: what's included (recipe list, plugin, policy template fragment), trust & permissions table, required env vars checklist, install instructions with `patchwork install-bundle` CLI stub (marked coming soon)
- **Two fallback bundles** (`gmail-vip-support`, `dev-workflow`) shown when the live registry doesn't yet include a bundles array

## Test plan

- [ ] Build passes, all 4778 tests pass
- [ ] Marketplace list shows "All / Recipes / Bundles" type filter
- [ ] "Bundles" filter hides recipes; "Recipes" hides bundles; "All" shows both with section headers
- [ ] Bundle cards show inclusion pills (recipes, plugin, policy) and trust badges
- [ ] "View bundle" navigates to `/marketplace/bundle/@patchworkos/...`
- [ ] Bundle detail page renders what's included, trust card, install instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)