### PR TITLE
docs(policy): delegation policy guide + 5 ready-made policy profiles

### DIFF
--- a/documents/delegation-policy.md
+++ b/documents/delegation-policy.md
@@ -1,0 +1,249 @@
+# Delegation Policy
+
+> Define what AI may do, what needs approval, and what is forbidden.
+
+Patchwork enforces a three-tier permission model inherited from Claude Code's
+settings system. Every tool call is classified before execution:
+
+| Tier | Meaning |
+|------|---------|
+| **allow** | Execute without interrupting the user |
+| **ask** | Pause and wait for human approval |
+| **deny** | Block unconditionally — no override |
+
+Precedence: `deny` at any level beats everything. `ask` beats `allow`.
+Any `allow` match grants.
+
+---
+
+## Where settings live
+
+Patchwork reads Claude Code's standard settings files in this order
+(highest precedence first):
+
+| File | Scope | Notes |
+|------|-------|-------|
+| Managed settings | Platform | Set by admins; cannot be overridden |
+| `.claude/settings.local.json` | Project (local only) | Not committed to VCS |
+| `.claude/settings.json` | Project (shared) | Committed — team-wide defaults |
+| `~/.claude/settings.json` | User | Your personal baseline |
+
+Rules from all matching files are merged. A `deny` in any file wins.
+
+---
+
+## Policy syntax
+
+Settings files use the `permissions` key:
+
+```json
+{
+  "permissions": {
+    "allow": ["Read", "Bash(git status)", "Bash(npm run *)"],
+    "ask":   ["Bash(git push *)", "Edit"],
+    "deny":  ["Bash(rm -rf *)", "Bash(sudo *)"]
+  }
+}
+```
+
+### Rule forms
+
+| Pattern | Matches |
+|---------|---------|
+| `Read` | The `Read` tool with any or no specifier |
+| `Bash(git status)` | `Bash` with specifier exactly `git status` |
+| `Bash(npm run *)` | `Bash` where specifier starts with `npm run ` |
+| `Bash(*)` | Any `Bash` call |
+| `WebFetch(https://api.example.com/*)` | Fetch calls to that URL prefix |
+
+Glob rules: `*` matches any sequence (including separators), `?` matches
+any single character. No path semantics — `*` crosses slashes.
+
+---
+
+## Checking what rule matched
+
+The bridge exposes a read-only endpoint so the dashboard (and you) can
+always inspect *why* a specific tool required approval:
+
+```
+GET /approval-insights/explain?tool=Bash&specifier=git+push+origin+main
+```
+
+Response:
+
+```json
+{
+  "tool": "Bash",
+  "specifier": "git push origin main",
+  "explanation": {
+    "matchedRule": "Bash(git push *)",
+    "tier": "ask",
+    "source": "project"
+  }
+}
+```
+
+`source` is one of `managed`, `project-local`, `project`, `user`. The
+Approval Insights dashboard shows this inline for every tool in your
+history.
+
+---
+
+## Ready-made profiles
+
+Five example policies live in [`examples/policies/`](../examples/policies/).
+Copy the one closest to your situation into `.claude/settings.json`
+(project-wide) or `~/.claude/settings.json` (personal baseline), then
+tune from there.
+
+### conservative
+
+**Use when:** first-time setup, shared machine, you want to understand
+what Claude is doing before trusting it more.
+
+- Auto-approves: `Read`, documentation `WebFetch`
+- Asks for: any write, any shell command, web requests
+- Blocks: `rm`, `sudo`, pipe-to-bash patterns
+
+```json
+// .claude/settings.json
+{ "permissions": { ... } }  // see examples/policies/conservative.json
+```
+
+### developer
+
+**Use when:** solo developer work, single-user machine, active coding
+sessions where interruptions for safe commands feel noisy.
+
+- Auto-approves: reads, edits, writes, safe npm/git commands, grep/find
+- Asks for: `git push`, `rm`, Docker, network-mutating `curl`
+- Blocks: `rm -rf /`, `sudo rm`, pipe-to-bash
+
+```json
+// .claude/settings.json
+{ "permissions": { ... } }  // see examples/policies/developer.json
+```
+
+### headless-ci
+
+**Use when:** fully unattended pipeline — CI/CD, scheduled overnight
+agents, batch processing. No human available to approve.
+
+- Auto-approves: everything needed to build, test, deploy, and push
+- Asks for: nothing (empty `ask` list)
+- Blocks: `sudo`, pipe-to-bash patterns
+
+> **Important:** never use this profile on an interactive machine. The
+> absence of `ask` rules means Claude will execute without pausing.
+
+```json
+// .claude/settings.local.json  (don't commit this to VCS)
+{ "permissions": { ... } }  // see examples/policies/headless-ci.json
+```
+
+### regulated-industry
+
+**Use when:** medicine, law, finance, journalism, government — anywhere
+data governance and audit trails matter.
+
+- Auto-approves: `Read`, `WebSearch` only
+- Asks for: every write, every shell command, every network call
+- Blocks: `rm`, `sudo`, `ssh`, `scp`, pipe-to-bash
+
+Every action that leaves a trace passes through a human decision. The
+bridge records each approval/rejection, giving you a timestamped audit log.
+
+```json
+// .claude/settings.json
+{ "permissions": { ... } }  // see examples/policies/regulated-industry.json
+```
+
+### personal-assistant
+
+**Use when:** life-automation, home workflows, personal productivity —
+iPhone Shortcuts, morning briefs, calendar management, smart home.
+
+- Auto-approves: reads, writes, web requests, recipe runs, safe file ops
+- Asks for: sending email, calendar mutations, network-mutating `curl`, `rm`
+- Blocks: `sudo`, `rm -rf`, pipe-to-bash
+
+```json
+// ~/.claude/settings.json
+{ "permissions": { ... } }  // see examples/policies/personal-assistant.json
+```
+
+---
+
+## Layering policies
+
+You can combine profiles across scopes:
+
+```
+~/.claude/settings.json          ← personal baseline (e.g. developer)
+.claude/settings.json            ← project tightening (e.g. ask for push)
+.claude/settings.local.json      ← local override (e.g. allow force-push on this machine)
+```
+
+A `deny` in any layer is permanent — the next-less-specific layer cannot
+override it. Use this to enforce team-wide blocks (in `.claude/settings.json`)
+while giving individuals latitude in their personal `~/.claude/settings.json`.
+
+---
+
+## Showing active policy in the dashboard
+
+The Approval Insights page (`/insights`) shows:
+
+- **Matched rule column** — the exact rule pattern that classified each
+  tool in your history, plus the tier and settings file it came from.
+- **Decision replay** (`/insights/replay`) — re-evaluates your past
+  approval decisions against the *current* policy. Use this after
+  tightening rules to see what would now auto-block.
+
+---
+
+## Common patterns
+
+### Protect a single dangerous command
+
+```json
+{
+  "permissions": {
+    "deny": ["Bash(git push --force *)"]
+  }
+}
+```
+
+### Allow a specific URL, ask for everything else on the web
+
+```json
+{
+  "permissions": {
+    "allow": ["WebFetch(https://api.mycompany.internal/*)"],
+    "ask":   ["WebFetch(*)"]
+  }
+}
+```
+
+### Auto-approve all reads, ask for all writes
+
+```json
+{
+  "permissions": {
+    "allow": ["Read"],
+    "ask":   ["Edit", "Write", "Bash(*)"]
+  }
+}
+```
+
+### Lock a project to read-only for a code review session
+
+```json
+{
+  "permissions": {
+    "allow": ["Read", "WebSearch"],
+    "deny":  ["Edit", "Write", "Bash(*)"]
+  }
+}
+```

--- a/examples/policies/conservative.json
+++ b/examples/policies/conservative.json
@@ -1,0 +1,28 @@
+{
+  "_comment": "Conservative policy — safe for first-time users and shared machines.",
+  "_description": "Ask before almost everything. Only read-only filesystem ops and documentation lookups auto-approve. No shell, no git push, no network writes.",
+  "permissions": {
+    "allow": [
+      "Read",
+      "WebSearch",
+      "WebFetch(https://docs.*)",
+      "WebFetch(https://*.readthedocs.io/*)",
+      "WebFetch(https://developer.mozilla.org/*)"
+    ],
+    "ask": [
+      "Edit",
+      "Write",
+      "Bash(*)",
+      "WebFetch(*)",
+      "mcp__patchwork__runRecipe(*)"
+    ],
+    "deny": [
+      "Bash(rm *)",
+      "Bash(rm -rf *)",
+      "Bash(sudo *)",
+      "Bash(curl * | bash*)",
+      "Bash(wget * | bash*)",
+      "mcp__patchwork__gitPush(*)"
+    ]
+  }
+}

--- a/examples/policies/developer.json
+++ b/examples/policies/developer.json
@@ -1,0 +1,47 @@
+{
+  "_comment": "Developer policy — streamlined for solo developer workflows.",
+  "_description": "Auto-approve read ops, safe build commands, and common git read ops. Ask before git push, file deletes, and network writes. Block destructive shell ops.",
+  "permissions": {
+    "allow": [
+      "Read",
+      "WebSearch",
+      "WebFetch(*)",
+      "Bash(npm run *)",
+      "Bash(npm test*)",
+      "Bash(npm install*)",
+      "Bash(npx *)",
+      "Bash(git status)",
+      "Bash(git log *)",
+      "Bash(git diff *)",
+      "Bash(git add *)",
+      "Bash(git commit *)",
+      "Bash(git checkout *)",
+      "Bash(git branch *)",
+      "Bash(git pull *)",
+      "Bash(ls *)",
+      "Bash(cat *)",
+      "Bash(find *)",
+      "Bash(grep *)",
+      "Bash(echo *)",
+      "Edit",
+      "Write"
+    ],
+    "ask": [
+      "Bash(git push *)",
+      "Bash(git push --force *)",
+      "Bash(rm *)",
+      "Bash(docker *)",
+      "Bash(kubectl *)",
+      "Bash(curl * -X POST *)",
+      "Bash(curl * -X PUT *)",
+      "Bash(curl * -X DELETE *)"
+    ],
+    "deny": [
+      "Bash(rm -rf /)",
+      "Bash(sudo rm *)",
+      "Bash(curl * | bash*)",
+      "Bash(wget * | bash*)",
+      "Bash(chmod 777 *)"
+    ]
+  }
+}

--- a/examples/policies/headless-ci.json
+++ b/examples/policies/headless-ci.json
@@ -1,0 +1,45 @@
+{
+  "_comment": "Headless CI policy — designed for fully unattended pipeline execution.",
+  "_description": "Auto-approve everything needed to build, test, and deploy. Block operations that would pause for human input or mutate outside the workspace scope. Copy to project .claude/settings.json in CI environments.",
+  "permissions": {
+    "allow": [
+      "Read",
+      "Edit",
+      "Write",
+      "WebSearch",
+      "WebFetch(*)",
+      "Bash(npm *)",
+      "Bash(npx *)",
+      "Bash(node *)",
+      "Bash(python *)",
+      "Bash(python3 *)",
+      "Bash(pip *)",
+      "Bash(pip3 *)",
+      "Bash(git *)",
+      "Bash(ls *)",
+      "Bash(find *)",
+      "Bash(grep *)",
+      "Bash(cat *)",
+      "Bash(echo *)",
+      "Bash(mkdir *)",
+      "Bash(cp *)",
+      "Bash(mv *)",
+      "Bash(rm *)",
+      "Bash(chmod *)",
+      "Bash(curl *)",
+      "Bash(docker build *)",
+      "Bash(docker push *)",
+      "Bash(docker run *)",
+      "mcp__patchwork__runRecipe(*)",
+      "mcp__patchwork__gitPush(*)",
+      "mcp__patchwork__githubCreatePR(*)"
+    ],
+    "ask": [],
+    "deny": [
+      "Bash(sudo *)",
+      "Bash(su *)",
+      "Bash(curl * | bash*)",
+      "Bash(wget * | bash*)"
+    ]
+  }
+}

--- a/examples/policies/personal-assistant.json
+++ b/examples/policies/personal-assistant.json
@@ -1,0 +1,38 @@
+{
+  "_comment": "Personal-assistant policy — for life-automation, home, and personal productivity.",
+  "_description": "Generous read + write access for personal workflows. Approve recipe runs and web requests automatically. Ask before sending email, making purchases, or modifying calendar events. Block system-level commands.",
+  "permissions": {
+    "allow": [
+      "Read",
+      "Edit",
+      "Write",
+      "WebSearch",
+      "WebFetch(*)",
+      "mcp__patchwork__runRecipe(*)",
+      "Bash(ls *)",
+      "Bash(find *)",
+      "Bash(cat *)",
+      "Bash(echo *)",
+      "Bash(mkdir *)",
+      "Bash(cp *)",
+      "Bash(mv *)"
+    ],
+    "ask": [
+      "mcp__patchwork__sendEmail(*)",
+      "mcp__patchwork__calendarCreate(*)",
+      "mcp__patchwork__calendarUpdate(*)",
+      "mcp__patchwork__calendarDelete(*)",
+      "Bash(curl * -X POST *)",
+      "Bash(curl * -X PUT *)",
+      "Bash(curl * -X DELETE *)",
+      "Bash(rm *)"
+    ],
+    "deny": [
+      "Bash(sudo *)",
+      "Bash(su *)",
+      "Bash(curl * | bash*)",
+      "Bash(wget * | bash*)",
+      "Bash(rm -rf *)"
+    ]
+  }
+}

--- a/examples/policies/regulated-industry.json
+++ b/examples/policies/regulated-industry.json
@@ -1,0 +1,26 @@
+{
+  "_comment": "Regulated-industry policy — for medicine, law, finance, journalism, government.",
+  "_description": "Read-only by default. All writes, network requests, and shell commands require explicit approval. No data leaves the local machine without a human decision. Maintains full audit trail by ensuring every action passes through the approval gate.",
+  "permissions": {
+    "allow": ["Read", "WebSearch"],
+    "ask": [
+      "Edit",
+      "Write",
+      "Bash(*)",
+      "WebFetch(*)",
+      "mcp__patchwork__runRecipe(*)",
+      "mcp__patchwork__gitCommit(*)",
+      "mcp__patchwork__gitPush(*)",
+      "mcp__patchwork__githubCreatePR(*)"
+    ],
+    "deny": [
+      "Bash(rm *)",
+      "Bash(sudo *)",
+      "Bash(curl * | bash*)",
+      "Bash(wget * | bash*)",
+      "Bash(ssh *)",
+      "Bash(scp *)",
+      "Bash(rsync *)"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

- **`documents/delegation-policy.md`** — full narrative doc covering: deny→ask→allow precedence, settings file layering (managed → project-local → project → user), rule syntax + glob semantics, the `/approval-insights/explain` endpoint, layering multiple profiles, and copy-paste pattern recipes.
- **`examples/policies/`** — five ready-made profiles:
  - `conservative.json` — ask before almost everything; ideal for first-time users and shared machines
  - `developer.json` — auto-approve safe npm/git/grep ops, ask before push/rm/docker
  - `headless-ci.json` — empty `ask` list for fully unattended pipelines
  - `regulated-industry.json` — read-only baseline (medicine/law/finance/gov); all writes/network require approval
  - `personal-assistant.json` — generous for life-automation; ask before email/calendar mutations

Completes the Phase 1 §2 Delegation Policy **examples + docs** deliverable from the strategic plan.

## Test plan

- [ ] All 5 JSON files parse cleanly (`npx biome check examples/policies/`)
- [ ] `documents/delegation-policy.md` renders correctly in GitHub (check table + code block formatting)
- [ ] Each example's `_description` matches its actual `permissions` content

🤖 Generated with [Claude Code](https://claude.com/claude-code)