### PR TITLE
feat(plugins): hello-world starter templates — JS + TS variants

### DIFF
--- a/examples/plugins/README.md
+++ b/examples/plugins/README.md
@@ -1,0 +1,28 @@
+# Plugin Examples
+
+Live Toolsmithing starters and worked examples for Patchwork OS plugins.
+
+| Directory | What it shows | Build step? |
+|-----------|--------------|-------------|
+| [`hello-world/`](hello-world/) | Minimal JS starter — one tool, no deps | No |
+| [`hello-world-ts/`](hello-world-ts/) | Same plugin with TypeScript + types | Yes (`npm run build`) |
+| [`sqlite-library/`](sqlite-library/) | Worked example — query a local SQLite DB | No |
+
+## Quick start
+
+```bash
+# JS starter — edit and save to hot-reload
+claude-ide-bridge --full \
+  --plugin ./examples/plugins/hello-world \
+  --plugin-watch
+
+# TypeScript starter — run tsc --watch alongside the bridge
+claude-ide-bridge --full \
+  --plugin ./examples/plugins/hello-world-ts \
+  --plugin-watch
+```
+
+## Learn more
+
+- [Live Toolsmithing narrative](../../documents/live-toolsmithing.md) — the full loop explained
+- [Plugin authoring reference](../../documents/plugin-authoring.md) — manifest schema, context API, distribution

--- a/examples/plugins/hello-world-ts/README.md
+++ b/examples/plugins/hello-world-ts/README.md
@@ -1,0 +1,48 @@
+# hello-world-ts plugin
+
+Minimal Live Toolsmithing starter — TypeScript variant. One tool, zero
+runtime dependencies. The compiled `index.mjs` is committed so you can
+run it immediately without building first.
+
+## What it does
+
+Exposes `hw.greet(name, language?)` — returns a greeting string.
+Not useful on its own; it's a template to replace with your own typed logic.
+
+## Run it (no build needed)
+
+```bash
+# From the repo root:
+claude-ide-bridge --full \
+  --plugin ./examples/plugins/hello-world-ts \
+  --plugin-watch
+```
+
+Then ask Claude: *"Call hw.greet with name='World' and language='fr'"*
+
+## Edit → build → reload loop
+
+1. Edit `src/index.ts`.
+2. In a terminal: `npm install && npm run dev` (runs `tsc --watch`).
+3. TypeScript compiles `src/index.ts` → `index.mjs` on each save.
+4. The bridge sees the file change and hot-reloads the plugin (`--plugin-watch`).
+5. The same Claude session calls the updated tool — no restart needed.
+
+Pair two terminals for the full loop:
+```
+Terminal 1: claude-ide-bridge --full --plugin . --plugin-watch
+Terminal 2: npm run dev
+```
+
+## JavaScript variant
+
+See [`../hello-world/`](../hello-world/) for the same plugin with no
+build step — edit `index.mjs` directly and save.
+
+## Next steps
+
+- Replace `hw.greet` with a tool that does something real for you.
+- Add npm dependencies in `package.json` and `npm install` them.
+- Change `toolNamePrefix` in `claude-ide-bridge-plugin.json` to something meaningful.
+- For the full manifest schema and context API: [`documents/plugin-authoring.md`](../../../documents/plugin-authoring.md).
+- For the Live Toolsmithing narrative: [`documents/live-toolsmithing.md`](../../../documents/live-toolsmithing.md).

--- a/examples/plugins/hello-world-ts/claude-ide-bridge-plugin.json
+++ b/examples/plugins/hello-world-ts/claude-ide-bridge-plugin.json
@@ -1,0 +1,8 @@
+{
+  "schemaVersion": 1,
+  "name": "patchwork-examples/hello-world-ts",
+  "version": "0.1.0",
+  "description": "Minimal Live Toolsmithing starter — TypeScript variant",
+  "entrypoint": "./index.mjs",
+  "toolNamePrefix": "hw"
+}

--- a/examples/plugins/hello-world-ts/index.mjs
+++ b/examples/plugins/hello-world-ts/index.mjs
@@ -1,0 +1,52 @@
+/**
+ * Compiled output of src/index.ts — committed so the plugin runs without
+ * `npm run build` first. Re-run `npm run build` after editing src/index.ts.
+ */
+const GREETINGS = {
+  en: (name) => `Hello, ${name}!`,
+  es: (name) => `¡Hola, ${name}!`,
+  fr: (name) => `Bonjour, ${name}!`,
+  de: (name) => `Hallo, ${name}!`,
+  ja: (name) => `こんにちは、${name}！`,
+};
+export function register(ctx) {
+  ctx.logger.info("hello-world-ts plugin loaded");
+  return {
+    tools: [
+      {
+        name: "hw.greet",
+        description:
+          "Returns a greeting. Replace this with your own logic to create a custom tool.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            name: {
+              type: "string",
+              description: "The name to greet",
+            },
+            language: {
+              type: "string",
+              enum: ["en", "es", "fr", "de", "ja"],
+              description: "Language for the greeting (default: en)",
+            },
+          },
+          required: ["name"],
+        },
+        outputSchema: {
+          type: "object",
+          properties: {
+            greeting: { type: "string" },
+            language: { type: "string" },
+          },
+          required: ["greeting", "language"],
+        },
+        async handler({ name, language = "en" }) {
+          const greetFn = GREETINGS[language] ?? GREETINGS.en;
+          const greeting = greetFn(name);
+          ctx.logger.info(`hw.greet called: ${greeting}`);
+          return { greeting, language };
+        },
+      },
+    ],
+  };
+}

--- a/examples/plugins/hello-world-ts/package.json
+++ b/examples/plugins/hello-world-ts/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "patchwork-examples-hello-world-ts",
+  "version": "0.1.0",
+  "description": "Minimal Live Toolsmithing starter plugin (TypeScript)",
+  "type": "module",
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0"
+  }
+}

--- a/examples/plugins/hello-world-ts/src/index.ts
+++ b/examples/plugins/hello-world-ts/src/index.ts
@@ -1,0 +1,94 @@
+/**
+ * hello-world-ts — minimal Live Toolsmithing starter (TypeScript variant).
+ *
+ * Adds one tool: `hw.greet`
+ * No dependencies, no filesystem access, no network calls.
+ *
+ * Build:    npm run build   (compiles src/index.ts → index.mjs)
+ * Dev mode: npm run dev     (tsc --watch — recompile on save)
+ *
+ * Then run the bridge with --plugin-watch to hot-reload on each compile:
+ *   claude-ide-bridge --full \
+ *     --plugin ./examples/plugins/hello-world-ts \
+ *     --plugin-watch
+ *
+ * Full authoring reference: documents/plugin-authoring.md
+ */
+
+/** Logger interface provided by the bridge. */
+interface PluginLogger {
+  info(message: string): void;
+  error(message: string, error?: unknown): void;
+}
+
+/** Context object passed to register(). */
+interface PluginContext {
+  workspace: string;
+  logger: PluginLogger;
+}
+
+type Language = "en" | "es" | "fr" | "de" | "ja";
+
+interface GreetInput {
+  name: string;
+  language?: Language;
+}
+
+interface GreetOutput {
+  greeting: string;
+  language: Language;
+}
+
+const GREETINGS: Record<Language, (name: string) => string> = {
+  en: (name) => `Hello, ${name}!`,
+  es: (name) => `¡Hola, ${name}!`,
+  fr: (name) => `Bonjour, ${name}!`,
+  de: (name) => `Hallo, ${name}!`,
+  ja: (name) => `こんにちは、${name}！`,
+};
+
+export function register(ctx: PluginContext) {
+  ctx.logger.info("hello-world-ts plugin loaded");
+
+  return {
+    tools: [
+      {
+        name: "hw.greet",
+        description:
+          "Returns a greeting. Replace this with your own logic to create a custom tool.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            name: {
+              type: "string",
+              description: "The name to greet",
+            },
+            language: {
+              type: "string",
+              enum: ["en", "es", "fr", "de", "ja"],
+              description: "Language for the greeting (default: en)",
+            },
+          },
+          required: ["name"],
+        },
+        outputSchema: {
+          type: "object",
+          properties: {
+            greeting: { type: "string" },
+            language: { type: "string" },
+          },
+          required: ["greeting", "language"],
+        },
+        async handler({
+          name,
+          language = "en",
+        }: GreetInput): Promise<GreetOutput> {
+          const greetFn = GREETINGS[language] ?? GREETINGS.en;
+          const greeting = greetFn(name);
+          ctx.logger.info(`hw.greet called: ${greeting}`);
+          return { greeting, language };
+        },
+      },
+    ],
+  };
+}

--- a/examples/plugins/hello-world-ts/tsconfig.json
+++ b/examples/plugins/hello-world-ts/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": ".",
+    "rootDir": "src",
+    "strict": true,
+    "declaration": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}

--- a/examples/plugins/hello-world/README.md
+++ b/examples/plugins/hello-world/README.md
@@ -1,0 +1,42 @@
+# hello-world plugin
+
+Minimal Live Toolsmithing starter. One tool, zero dependencies — the
+smallest possible working plugin.
+
+## What it does
+
+Exposes `hw.greet(name, language?)` — returns a greeting string.
+Not useful on its own; it's a template to replace with your own logic.
+
+## Run it
+
+```bash
+# From the repo root:
+claude-ide-bridge --full \
+  --plugin ./examples/plugins/hello-world \
+  --plugin-watch
+```
+
+Then ask Claude: *"Call hw.greet with name='World'"*
+
+## Edit → reload loop
+
+1. Open `index.mjs` and change the handler (add a tool, change the output, call an API).
+2. Save the file.
+3. The bridge hot-reloads the plugin automatically (`--plugin-watch`).
+4. The same Claude session can call the updated tool immediately — no restart.
+
+This is the Live Toolsmithing loop: Claude asks for a capability that
+doesn't exist → you write it → it's available in seconds.
+
+## TypeScript variant
+
+See [`../hello-world-ts/`](../hello-world-ts/) for the same plugin with
+full TypeScript types, a `tsconfig.json`, and build/dev scripts.
+
+## Next steps
+
+- Replace `hw.greet` with a tool that does something real for you.
+- Change `toolNamePrefix` in `claude-ide-bridge-plugin.json` to something meaningful.
+- For the full manifest schema and context API: [`documents/plugin-authoring.md`](../../../documents/plugin-authoring.md).
+- For the Live Toolsmithing narrative: [`documents/live-toolsmithing.md`](../../../documents/live-toolsmithing.md).

--- a/examples/plugins/hello-world/claude-ide-bridge-plugin.json
+++ b/examples/plugins/hello-world/claude-ide-bridge-plugin.json
@@ -1,0 +1,8 @@
+{
+  "schemaVersion": 1,
+  "name": "patchwork-examples/hello-world",
+  "version": "0.1.0",
+  "description": "Minimal Live Toolsmithing starter — one tool, no dependencies",
+  "entrypoint": "./index.mjs",
+  "toolNamePrefix": "hw"
+}

--- a/examples/plugins/hello-world/index.mjs
+++ b/examples/plugins/hello-world/index.mjs
@@ -1,0 +1,68 @@
+/**
+ * hello-world — minimal Live Toolsmithing starter plugin.
+ *
+ * Adds one tool: `hw.greet`
+ * No dependencies, no filesystem access, no network calls.
+ *
+ * To use:
+ *   claude-ide-bridge --full --plugin ./examples/plugins/hello-world --plugin-watch
+ *
+ * Then ask Claude: "Call hw.greet with name='World'"
+ *
+ * To extend:
+ *   1. Edit this file and save.
+ *   2. The bridge hot-reloads it (--plugin-watch).
+ *   3. The same Claude session can immediately call the updated tool.
+ *
+ * Full authoring reference: documents/plugin-authoring.md
+ */
+
+/** @param {{ workspace: string, logger: { info: Function, error: Function } }} ctx */
+export function register(ctx) {
+  ctx.logger.info("hello-world plugin loaded");
+
+  return {
+    tools: [
+      {
+        name: "hw.greet",
+        description:
+          "Returns a greeting. Replace this with your own logic to create a custom tool.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            name: {
+              type: "string",
+              description: "The name to greet",
+            },
+            language: {
+              type: "string",
+              enum: ["en", "es", "fr", "de", "ja"],
+              description: "Language for the greeting (default: en)",
+            },
+          },
+          required: ["name"],
+        },
+        outputSchema: {
+          type: "object",
+          properties: {
+            greeting: { type: "string" },
+            language: { type: "string" },
+          },
+          required: ["greeting", "language"],
+        },
+        async handler({ name, language = "en" }) {
+          const greetings = {
+            en: `Hello, ${name}!`,
+            es: `¡Hola, ${name}!`,
+            fr: `Bonjour, ${name}!`,
+            de: `Hallo, ${name}!`,
+            ja: `こんにちは、${name}！`,
+          };
+          const greeting = greetings[language] ?? `Hello, ${name}!`;
+          ctx.logger.info(`hw.greet called: ${greeting}`);
+          return { greeting, language };
+        },
+      },
+    ],
+  };
+}

--- a/examples/plugins/hello-world/package.json
+++ b/examples/plugins/hello-world/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "patchwork-examples-hello-world",
+  "version": "0.1.0",
+  "description": "Minimal Live Toolsmithing starter plugin",
+  "type": "module"
+}


### PR DESCRIPTION
## Summary

Closes the **Phase 1 §1 Live Toolsmithing starter template** gap from the strategic plan ("minimal plugin manifest, one example tool, TS + JS variants").

- **`examples/plugins/hello-world/`** — JS variant. Zero deps, no build step. `index.mjs` exports `register(ctx)` with one tool (`hw.greet`). Edit and save → bridge hot-reloads.
- **`examples/plugins/hello-world-ts/`** — TypeScript variant. Typed `PluginContext`, `PluginLogger`, input/output interfaces. `src/index.ts` → `index.mjs` via `tsc`. Pre-compiled `index.mjs` committed so users can run immediately without building. `npm run dev` (tsc --watch) pairs with `--plugin-watch` for the full edit→compile→reload loop.
- **`examples/plugins/README.md`** — index of all three plugin examples with quick-start commands and links to `live-toolsmithing.md` + `plugin-authoring.md`.

## Test plan

- [ ] `claude-ide-bridge --full --plugin examples/plugins/hello-world --plugin-watch` starts cleanly
- [ ] Ask Claude "Call hw.greet with name='World'" → returns `{ greeting: "Hello, World!", language: "en" }`
- [ ] Ask Claude "Call hw.greet with name='Claude' language='fr'" → `{ greeting: "Bonjour, Claude!", language: "fr" }`
- [ ] Edit `examples/plugins/hello-world/index.mjs`, save → bridge logs hot-reload, updated tool available in same session
- [ ] TS variant: `cd examples/plugins/hello-world-ts && npm install && npm run build` succeeds, `index.mjs` is valid ESM
- [ ] `npx biome check examples/plugins/` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)