### PR TITLE
docs(api): recipe API examples — curl, Node.js, Python

### DIFF
--- a/examples/recipe-api/README.md
+++ b/examples/recipe-api/README.md
@@ -1,0 +1,134 @@
+# Recipe API Examples
+
+Call your bridge's recipe API directly — from shell scripts, Node.js
+apps, Python scripts, or any HTTP client.
+
+No OAuth required when calling from the same machine as the bridge.
+Just grab the bearer token and start calling.
+
+## Get the bearer token
+
+```bash
+BRIDGE_TOKEN=$(patchwork print-token)
+```
+
+Or read it directly:
+
+```bash
+BRIDGE_TOKEN=$(cat ~/.claude/ide/*.lock | jq -r '.authToken' | head -1)
+```
+
+For remote deployments, set `--fixed-token <uuid>` at bridge start so
+the token doesn't rotate on restart.
+
+## Endpoints at a glance
+
+| Endpoint | Method | What it does |
+|----------|--------|-------------|
+| `/recipes` | GET | List all installed recipes |
+| `/recipes/run` | POST | Run a recipe by name |
+| `/runs` | GET | List recent recipe runs (`?limit=N&recipe=name&status=done`) |
+| `/runs/:seq` | GET | Fetch one run by sequence number |
+| `/approvals` | GET | List pending approval requests |
+| `/approvals/:id` | POST | Resolve an approval (`{"decision":"allow"\|"deny"}`) |
+| `/approvals/stream` | GET | SSE stream of real-time approval events |
+| `/hooks/:path` | POST | Fire a webhook-triggered recipe |
+
+All endpoints require `Authorization: Bearer <token>`.
+
+## Examples
+
+### curl
+
+```bash
+# List recipes
+curl -s -H "Authorization: Bearer $BRIDGE_TOKEN" http://localhost:3100/recipes | jq '.recipes[].name'
+
+# Run a recipe
+curl -s -X POST \
+  -H "Authorization: Bearer $BRIDGE_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "morning-brief"}' \
+  http://localhost:3100/recipes/run | jq .
+
+# Run with variables
+curl -s -X POST \
+  -H "Authorization: Bearer $BRIDGE_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "capture-thought", "vars": {"thought": "Ship dark mode"}}' \
+  http://localhost:3100/recipes/run
+
+# Check recent runs
+curl -s -H "Authorization: Bearer $BRIDGE_TOKEN" \
+  "http://localhost:3100/runs?limit=5" | jq '.[].status'
+```
+
+See [curl-examples.sh](curl-examples.sh) for the full script.
+
+### Node.js
+
+```js
+const res = await fetch("http://localhost:3100/recipes/run", {
+  method: "POST",
+  headers: {
+    Authorization: `Bearer ${process.env.BRIDGE_TOKEN}`,
+    "Content-Type": "application/json",
+  },
+  body: JSON.stringify({ name: "morning-brief" }),
+});
+const result = await res.json();
+```
+
+See [client.mjs](client.mjs) for list, run, poll-until-done, and approval handling.
+
+### Python
+
+```python
+import urllib.request, json, os
+
+req = urllib.request.Request(
+    "http://localhost:3100/recipes/run",
+    data=json.dumps({"name": "morning-brief"}).encode(),
+    method="POST",
+    headers={
+        "Authorization": f"Bearer {os.environ['BRIDGE_TOKEN']}",
+        "Content-Type": "application/json",
+    },
+)
+with urllib.request.urlopen(req) as resp:
+    print(json.loads(resp.read()))
+```
+
+See [client.py](client.py) for the full client with polling and approval handling. No third-party dependencies.
+
+## Building your own app
+
+For a full browser-based app with OAuth (so users authenticate without
+sharing your bridge token), see
+[`../personal-api-demo/`](../personal-api-demo/) — it implements
+dynamic client registration + PKCE S256 against a bridge started with
+`--issuer-url`.
+
+For server-side apps that live on the same machine as the bridge, the
+bearer token approach above is simpler and sufficient.
+
+## Run a recipe and wait for it to finish
+
+```js
+async function runAndWait(name, vars, timeoutMs = 60_000) {
+  const { seq } = await bridgeFetch("/recipes/run", {
+    method: "POST",
+    body: JSON.stringify({ name, vars }),
+  });
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    await new Promise((r) => setTimeout(r, 1500));
+    const run = await bridgeFetch(`/runs/${seq}`);
+    if (run.status === "done") return run;
+    if (run.status === "error") throw new Error(run.error);
+  }
+  throw new Error("Timeout");
+}
+```
+
+The full Node.js version is in [client.mjs](client.mjs).

--- a/examples/recipe-api/client.mjs
+++ b/examples/recipe-api/client.mjs
@@ -1,0 +1,120 @@
+/**
+ * Patchwork OS — minimal Node.js recipe API client.
+ *
+ * Usage:
+ *   BRIDGE_TOKEN=$(patchwork print-token) node client.mjs
+ *
+ * Or inline:
+ *   BRIDGE_TOKEN=<token> node client.mjs
+ */
+
+const BRIDGE_URL = process.env.BRIDGE_URL ?? "http://localhost:3100";
+const BRIDGE_TOKEN = process.env.BRIDGE_TOKEN;
+
+if (!BRIDGE_TOKEN) {
+  console.error(
+    "Set BRIDGE_TOKEN env var. Run: BRIDGE_TOKEN=$(patchwork print-token) node client.mjs",
+  );
+  process.exit(1);
+}
+
+/** Authenticated fetch wrapper. */
+async function bridgeFetch(path, init = {}) {
+  const res = await fetch(`${BRIDGE_URL}${path}`, {
+    ...init,
+    headers: {
+      Authorization: `Bearer ${BRIDGE_TOKEN}`,
+      "Content-Type": "application/json",
+      ...init.headers,
+    },
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(
+      `Bridge ${init.method ?? "GET"} ${path} → ${res.status}: ${text}`,
+    );
+  }
+  return res.json();
+}
+
+// ── List recipes ─────────────────────────────────────────────────────────────
+
+const { recipes } = await bridgeFetch("/recipes");
+console.log(
+  "Installed recipes:",
+  recipes.map((r) => r.name),
+);
+
+// ── Run a recipe ─────────────────────────────────────────────────────────────
+
+const runResult = await bridgeFetch("/recipes/run", {
+  method: "POST",
+  body: JSON.stringify({ name: "morning-brief" }),
+});
+console.log("Run result:", runResult);
+
+// Run with variables
+const runWithVars = await bridgeFetch("/recipes/run", {
+  method: "POST",
+  body: JSON.stringify({
+    name: "capture-thought",
+    vars: { thought: "Add dark mode to the dashboard" },
+  }),
+});
+console.log("Run with vars:", runWithVars);
+
+// ── Check recent runs ─────────────────────────────────────────────────────────
+
+const runs = await bridgeFetch("/runs?limit=5");
+console.log(
+  "Recent runs:",
+  runs.map((r) => ({ seq: r.seq, recipe: r.recipe, status: r.status })),
+);
+
+// ── Check pending approvals ───────────────────────────────────────────────────
+
+const approvals = await bridgeFetch("/approvals");
+console.log("Pending approvals:", approvals.length);
+
+if (approvals.length > 0) {
+  const first = approvals[0];
+  console.log("First pending:", {
+    id: first.id,
+    tool: first.tool,
+    specifier: first.specifier,
+  });
+
+  // Allow it programmatically
+  // const decision = await bridgeFetch(`/approvals/${first.id}`, {
+  //   method: "POST",
+  //   body: JSON.stringify({ decision: "allow" }),
+  // });
+  // console.log("Decision:", decision);
+}
+
+// ── Poll until a recipe run completes ────────────────────────────────────────
+
+async function runAndWait(name, vars, timeoutMs = 60_000) {
+  const { seq } = await bridgeFetch("/recipes/run", {
+    method: "POST",
+    body: JSON.stringify({ name, vars }),
+  });
+  if (!seq) return null;
+
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    await new Promise((r) => setTimeout(r, 1500));
+    const run = await bridgeFetch(`/runs/${seq}`);
+    if (run.status === "done") return run;
+    if (run.status === "error")
+      throw new Error(`Recipe failed: ${run.error ?? "unknown"}`);
+    if (run.status === "awaiting_approval") {
+      console.log("Waiting for human approval...");
+    }
+  }
+  throw new Error(`Timed out waiting for run #${seq}`);
+}
+
+// Uncomment to use:
+// const result = await runAndWait("morning-brief");
+// console.log("Output:", result.output);

--- a/examples/recipe-api/client.py
+++ b/examples/recipe-api/client.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""
+Patchwork OS — minimal Python recipe API client.
+
+Usage:
+    BRIDGE_TOKEN=$(patchwork print-token) python3 client.py
+
+Or inline:
+    BRIDGE_TOKEN=<token> python3 client.py
+
+Requires Python 3.8+ (uses urllib only — no third-party deps).
+"""
+
+import json
+import os
+import time
+import urllib.request
+from typing import Any, Optional
+from urllib.error import HTTPError
+
+BRIDGE_URL = os.environ.get("BRIDGE_URL", "http://localhost:3100")
+BRIDGE_TOKEN = os.environ.get("BRIDGE_TOKEN", "")
+
+if not BRIDGE_TOKEN:
+    raise SystemExit(
+        "Set BRIDGE_TOKEN env var.\n"
+        "Run: BRIDGE_TOKEN=$(patchwork print-token) python3 client.py"
+    )
+
+
+def bridge_request(
+    path: str,
+    method: str = "GET",
+    body: Optional[dict] = None,
+) -> Any:
+    """Authenticated request to the bridge. Returns parsed JSON."""
+    url = f"{BRIDGE_URL}{path}"
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(
+        url,
+        data=data,
+        method=method,
+        headers={
+            "Authorization": f"Bearer {BRIDGE_TOKEN}",
+            "Content-Type": "application/json",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req) as resp:
+            return json.loads(resp.read())
+    except HTTPError as e:
+        raise RuntimeError(
+            f"Bridge {method} {path} → {e.code}: {e.read().decode()}"
+        ) from e
+
+
+# ── List recipes ──────────────────────────────────────────────────────────────
+
+result = bridge_request("/recipes")
+print("Installed recipes:", [r["name"] for r in result.get("recipes", [])])
+
+# ── Run a recipe ──────────────────────────────────────────────────────────────
+
+run_result = bridge_request("/recipes/run", method="POST", body={"name": "morning-brief"})
+print("Run result:", run_result)
+
+# Run with variables
+run_with_vars = bridge_request(
+    "/recipes/run",
+    method="POST",
+    body={"name": "capture-thought", "vars": {"thought": "Add dark mode to the dashboard"}},
+)
+print("Run with vars:", run_with_vars)
+
+# ── Check recent runs ─────────────────────────────────────────────────────────
+
+runs = bridge_request("/runs?limit=5")
+for r in runs:
+    print(f"  run #{r['seq']} {r['recipe']} → {r['status']}")
+
+# ── Check pending approvals ───────────────────────────────────────────────────
+
+approvals = bridge_request("/approvals")
+print(f"Pending approvals: {len(approvals)}")
+for a in approvals:
+    print(f"  [{a['id']}] {a.get('tool')}({a.get('specifier', '')})")
+
+
+def run_and_wait(name: str, vars: Optional[dict] = None, timeout_s: int = 60) -> dict:
+    """Run a recipe and poll until completion. Returns the finished run record."""
+    result = bridge_request("/recipes/run", method="POST", body={"name": name, "vars": vars})
+    seq = result.get("seq")
+    if not seq:
+        return result
+
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        time.sleep(1.5)
+        run = bridge_request(f"/runs/{seq}")
+        status = run.get("status")
+        if status == "done":
+            return run
+        if status == "error":
+            raise RuntimeError(f"Recipe failed: {run.get('error', 'unknown')}")
+        if status == "awaiting_approval":
+            print("Waiting for human approval...")
+
+    raise TimeoutError(f"Timed out waiting for run #{seq}")
+
+
+# Uncomment to use:
+# result = run_and_wait("morning-brief")
+# print("Output:", result.get("output"))

--- a/examples/recipe-api/curl-examples.sh
+++ b/examples/recipe-api/curl-examples.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Patchwork OS — Recipe API curl examples
+#
+# Prerequisites:
+#   1. Bridge running:  claude-ide-bridge --full
+#   2. Token:          BRIDGE_TOKEN=$(patchwork print-token)
+#
+# All endpoints require:
+#   Authorization: Bearer <token>
+#   Content-Type: application/json  (for POST requests)
+
+set -euo pipefail
+
+BRIDGE_URL="${BRIDGE_URL:-http://localhost:3100}"
+BRIDGE_TOKEN="${BRIDGE_TOKEN:-$(patchwork print-token 2>/dev/null || echo 'SET_YOUR_TOKEN_HERE')}"
+
+AUTH=(-H "Authorization: Bearer $BRIDGE_TOKEN")
+
+# ── List installed recipes ────────────────────────────────────────────────────
+
+echo "=== List recipes ==="
+curl -s "${AUTH[@]}" "$BRIDGE_URL/recipes" | jq '.recipes[].name'
+
+# ── Run a recipe ─────────────────────────────────────────────────────────────
+
+echo "=== Run morning-brief ==="
+curl -s -X POST "${AUTH[@]}" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "morning-brief"}' \
+  "$BRIDGE_URL/recipes/run" | jq .
+
+# Run a recipe with variables
+echo "=== Run a recipe with variables ==="
+curl -s -X POST "${AUTH[@]}" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "capture-thought", "vars": {"thought": "Add dark mode to the dashboard"}}' \
+  "$BRIDGE_URL/recipes/run" | jq .
+
+# ── Check recent runs ─────────────────────────────────────────────────────────
+
+echo "=== Recent runs (last 10) ==="
+curl -s "${AUTH[@]}" "$BRIDGE_URL/runs?limit=10" | jq '.[] | {seq, recipe, status, triggeredAt}'
+
+# Filter runs by recipe name
+echo "=== Runs for morning-brief ==="
+curl -s "${AUTH[@]}" "$BRIDGE_URL/runs?recipe=morning-brief&limit=5" | jq '.[].status'
+
+# Filter by status
+echo "=== Failed runs ==="
+curl -s "${AUTH[@]}" "$BRIDGE_URL/runs?status=error&limit=5" | jq '.[].recipe'
+
+# ── Fetch a single run ────────────────────────────────────────────────────────
+
+echo "=== Fetch run #1 ==="
+curl -s "${AUTH[@]}" "$BRIDGE_URL/runs/1" | jq '{seq, recipe, status, steps: (.steps | length)}'
+
+# ── Check pending approvals ───────────────────────────────────────────────────
+
+echo "=== Pending approvals ==="
+curl -s "${AUTH[@]}" "$BRIDGE_URL/approvals" | jq '.[] | {id, tool, specifier}'
+
+# Allow a pending approval (replace ID with real value)
+# curl -s -X POST "${AUTH[@]}" \
+#   -H "Content-Type: application/json" \
+#   -d '{"decision": "allow"}' \
+#   "$BRIDGE_URL/approvals/<approval-id>"
+
+# ── Send a test webhook ───────────────────────────────────────────────────────
+
+echo "=== POST to a webhook-triggered recipe ==="
+# Recipe must have trigger.type: webhook  and  trigger.path: /my-recipe
+curl -s -X POST "${AUTH[@]}" \
+  -H "Content-Type: application/json" \
+  -d '{"source": "my-app", "event": "user.signup", "userId": "u_123"}' \
+  "$BRIDGE_URL/hooks/my-recipe" | jq .
+
+# ── Stream approval events (SSE) ─────────────────────────────────────────────
+
+echo "=== Stream approvals (Ctrl-C to stop) ==="
+# curl -sN "${AUTH[@]}" "$BRIDGE_URL/approvals/stream"


### PR DESCRIPTION
## Summary

Closes the Phase 4 "indie hackers" gap: "recipe execution API examples." Adds `examples/recipe-api/` with three self-contained clients that demonstrate calling the bridge API using a plain bearer token (no OAuth required).

- **`curl-examples.sh`** — one-liners for every common operation: list recipes, run recipe, run with vars, recent runs (filter by recipe/status), pending approvals, webhook POST, SSE stream
- **`client.mjs`** — Node.js client using native `fetch`; `bridgeFetch` wrapper, all CRUD operations, poll-until-done helper
- **`client.py`** — Python 3.8+ using `urllib` only — zero third-party dependencies; same operations plus typed `run_and_wait(name, vars, timeout_s)` 
- **`README.md`** — endpoint reference table, inline snippets for all three languages, bearer token setup, link to `personal-api-demo` for browser OAuth apps

## Test plan

- [ ] `BRIDGE_TOKEN=$(patchwork print-token) bash curl-examples.sh` — endpoints respond (bridge running)
- [ ] `BRIDGE_TOKEN=$(patchwork print-token) node client.mjs` — runs cleanly
- [ ] `BRIDGE_TOKEN=$(patchwork print-token) python3 client.py` — runs cleanly with no pip installs
- [ ] `npx biome check examples/recipe-api/` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)