### PR TITLE
fix(dashboard): add loading indicator to Traces page

### DIFF
--- a/dashboard/src/app/decisions/page.tsx
+++ b/dashboard/src/app/decisions/page.tsx
@@ -267,6 +267,10 @@ function DecisionsContent() {
         </div>
       )}
 
+      {loading && traces.length === 0 && (
+        <p style={{ color: "var(--fg-2)" }}>Loading…</p>
+      )}
+
       {error && (
         <div className="alert-err">
           {error.startsWith("/traces")

--- a/dashboard/src/app/traces/page.tsx
+++ b/dashboard/src/app/traces/page.tsx
@@ -492,6 +492,10 @@ export default function TracesPage() {
         </div>
       )}
 
+      {loading && traces.length === 0 && (
+        <p style={{ color: "var(--fg-2)" }}>Loading…</p>
+      )}
+
       {error && (
         <div className="alert-err">
           {error.startsWith("/traces")


### PR DESCRIPTION
## Summary

- The `/traces` dashboard page had no loading state: while the initial fetch was in flight with zero cached traces, users saw a blank area — no spinner, no text.
- Added `{loading && traces.length === 0 && <p>Loading…</p>}` before the error block, matching the pattern already used by the Insights and Approval Insights pages.

## Test plan

- [x] `npm test` — all 4794 tests pass
- [ ] Manual: open Traces page on a fresh bridge with no traces — confirm "Loading…" appears briefly before empty-state

🤖 Generated with [Claude Code](https://claude.com/claude-code)