### PR TITLE
fix(security): passphrase length cap on /traces/export + fix scrypt N in JSDoc

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -720,8 +720,18 @@ export class Server extends EventEmitter<ServerEvents> {
       if (parsedUrl.pathname === "/traces/export" && req.method === "GET") {
         void (async () => {
           try {
-            const passphrase =
+            const passphraseRaw =
               parsedUrl.searchParams?.get("passphrase") ?? null;
+            if (passphraseRaw !== null && passphraseRaw.length > 4096) {
+              res.writeHead(400, { "Content-Type": "application/json" });
+              res.end(
+                JSON.stringify({
+                  error: "passphrase too long (max 4096 chars)",
+                }),
+              );
+              return;
+            }
+            const passphrase = passphraseRaw;
             const { runTracesExportToStream } = await import(
               "./commands/tracesExport.js"
             );

--- a/src/traceEncryption.ts
+++ b/src/traceEncryption.ts
@@ -11,9 +11,9 @@
  *   37      16   GCM authentication tag
  *   53      N    Ciphertext (the original .jsonl.gz bytes)
  *
- * Key derivation: scrypt(passphrase, salt, N=32768, r=8, p=1, keyLen=32).
- * The parameters match Node's `crypto.scryptSync` defaults and are safe for
- * interactive use on a modern laptop (~100ms). They are stored implicitly
+ * Key derivation: scrypt(passphrase, salt, N=16384, r=8, p=1, keyLen=32).
+ * N=2^14 matches Node's `crypto.scryptSync` default and is safe for
+ * interactive use on a modern laptop (~50ms, 16MB RAM). They are stored implicitly
  * (fixed); changing them is a version bump.
  *
  * Security properties:
@@ -42,7 +42,7 @@ const IV_LEN = 12;
 const TAG_LEN = 16;
 const HEADER_LEN = TRACE_ENCRYPT_MAGIC.length + 1 + SALT_LEN + IV_LEN + TAG_LEN; // 53
 
-const SCRYPT_N = 16384; // 2^14 — safe within Node's default 32MB maxmem (needs 16MB)
+const SCRYPT_N = 16384; // 2^14 — Node scryptSync default; needs 128*N*r = 16MB RAM
 const SCRYPT_R = 8;
 const SCRYPT_P = 1;
 const KEY_LEN = 32;


### PR DESCRIPTION
## Summary

- **Passphrase length cap**: `GET /traces/export?passphrase=...` now rejects passphrases longer than 4096 characters with a 400. scrypt iterates over the passphrase via HMAC-SHA256 internally; a very long passphrase could be used for a slow DoS against the export endpoint.
- **JSDoc fix**: `src/traceEncryption.ts` had `N=32768` in the module-level doc comment but the code (and Node's `scryptSync` default) uses `N=16384` (2^14). The code was always correct; the comment was wrong and could have misled a security reviewer into thinking parameters were different from what's actually used.

## Test plan

- [x] `npm test` — all 4794 tests pass
- [x] `npx biome check` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)