### PR TITLE
fix(security): move trace-export passphrase to X-Trace-Passphrase header

### DIFF
--- a/dashboard/src/app/api/bridge/[...path]/route.ts
+++ b/dashboard/src/app/api/bridge/[...path]/route.ts
@@ -126,13 +126,28 @@ async function proxy(req: NextRequest, segments: string[]): Promise<Response> {
     req.method === "GET" || req.method === "HEAD"
       ? undefined
       : await req.text();
+  const forwardHeaders: Record<string, string> = {
+    "content-type": req.headers.get("content-type") ?? "",
+  };
+  const tracePassphrase = req.headers.get("x-trace-passphrase");
+  if (tracePassphrase) forwardHeaders["x-trace-passphrase"] = tracePassphrase;
   const res = await bridgeFetch(target, {
     method: req.method,
-    headers: { "content-type": req.headers.get("content-type") ?? "" },
+    headers: forwardHeaders,
     body,
   });
-  const text = await res.text();
   const upstreamCt = res.headers.get("content-type") ?? "";
+  // Binary downloads (encrypted export, gzip) — stream bytes through directly.
+  if (
+    upstreamCt.includes("application/octet-stream") ||
+    upstreamCt.includes("application/gzip")
+  ) {
+    const cd = res.headers.get("content-disposition");
+    const responseHeaders: Record<string, string> = { "content-type": upstreamCt };
+    if (cd) responseHeaders["content-disposition"] = cd;
+    return new Response(res.body, { status: res.status, headers: responseHeaders });
+  }
+  const text = await res.text();
   const ct =
     upstreamCt.includes("application/json") || upstreamCt === ""
       ? "application/json"

--- a/dashboard/src/app/traces/page.tsx
+++ b/dashboard/src/app/traces/page.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { Fragment, useMemo, useRef, useState } from "react";
+import { Fragment, useMemo, useState } from "react";
 import { relTime } from "@/components/time";
 import { apiPath } from "@/lib/api";
 import { useBridgeFetch } from "@/hooks/useBridgeFetch";
@@ -208,32 +208,44 @@ const SINCE_OPTIONS: { k: SinceFilter; label: string; ms: number | null }[] = [
 function ExportButton() {
   const [open, setOpen] = useState(false);
   const [passphrase, setPassphrase] = useState("");
-  const linkRef = useRef<HTMLAnchorElement>(null);
+  const [downloading, setDownloading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
-  function buildUrl() {
-    const base = apiPath("/api/bridge/traces/export");
-    return passphrase.trim()
-      ? `${base}?passphrase=${encodeURIComponent(passphrase.trim())}`
-      : base;
-  }
-
-  function handleDownload() {
-    const a = linkRef.current;
-    if (!a) return;
-    a.href = buildUrl();
-    a.download = passphrase.trim()
-      ? `traces-export.enc`
-      : `traces-export.jsonl.gz`;
-    a.click();
-    setOpen(false);
-    setPassphrase("");
+  async function handleDownload() {
+    const phrase = passphrase.trim();
+    if (phrase && phrase.length < 12) {
+      setError("Passphrase must be at least 12 characters.");
+      return;
+    }
+    setError(null);
+    setDownloading(true);
+    try {
+      const headers: Record<string, string> = {};
+      if (phrase) headers["x-trace-passphrase"] = phrase;
+      const res = await fetch(apiPath("/api/bridge/traces/export"), { headers });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        setError((body as { error?: string }).error ?? `Export failed (${res.status})`);
+        return;
+      }
+      const blob = await res.blob();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = phrase ? "traces-export.enc" : "traces-export.jsonl.gz";
+      a.click();
+      URL.revokeObjectURL(url);
+      setOpen(false);
+      setPassphrase("");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Download failed");
+    } finally {
+      setDownloading(false);
+    }
   }
 
   return (
     <div style={{ position: "relative" }}>
-      {/* Hidden anchor used for programmatic download */}
-      {/* biome-ignore lint/a11y/useValidAnchor: programmatic download anchor */}
-      <a ref={linkRef} style={{ display: "none" }} aria-hidden="true" />
       <button type="button" className="btn sm" onClick={() => setOpen((v) => !v)}>
         Export
       </button>
@@ -275,12 +287,17 @@ function ExportButton() {
             }}
             autoFocus
           />
+          {error && (
+            <p style={{ margin: "0 0 var(--s-3)", fontSize: 12, color: "var(--red)" }}>
+              {error}
+            </p>
+          )}
           <div style={{ display: "flex", gap: "var(--s-3)", justifyContent: "flex-end" }}>
-            <button type="button" className="btn sm" onClick={() => { setOpen(false); setPassphrase(""); }}>
+            <button type="button" className="btn sm" onClick={() => { setOpen(false); setPassphrase(""); setError(null); }}>
               Cancel
             </button>
-            <button type="button" className="btn sm primary" onClick={handleDownload}>
-              {passphrase.trim() ? "Download encrypted" : "Download"}
+            <button type="button" className="btn sm primary" onClick={handleDownload} disabled={downloading}>
+              {downloading ? "Downloading…" : passphrase.trim() ? "Download encrypted" : "Download"}
             </button>
           </div>
           {passphrase.trim() && (

--- a/src/server.ts
+++ b/src/server.ts
@@ -720,13 +720,34 @@ export class Server extends EventEmitter<ServerEvents> {
       if (parsedUrl.pathname === "/traces/export" && req.method === "GET") {
         void (async () => {
           try {
+            // Accept passphrase only via header — never query string (prevents
+            // proxy access-log exposure and browser-history leakage).
+            if (parsedUrl.searchParams?.get("passphrase")) {
+              res.writeHead(400, { "Content-Type": "application/json" });
+              res.end(
+                JSON.stringify({
+                  error:
+                    "passphrase must be sent in the X-Trace-Passphrase header, not the URL",
+                }),
+              );
+              return;
+            }
             const passphraseRaw =
-              parsedUrl.searchParams?.get("passphrase") ?? null;
+              (req.headers["x-trace-passphrase"] as string | undefined) ?? null;
             if (passphraseRaw !== null && passphraseRaw.length > 4096) {
               res.writeHead(400, { "Content-Type": "application/json" });
               res.end(
                 JSON.stringify({
                   error: "passphrase too long (max 4096 chars)",
+                }),
+              );
+              return;
+            }
+            if (passphraseRaw !== null && passphraseRaw.length < 12) {
+              res.writeHead(400, { "Content-Type": "application/json" });
+              res.end(
+                JSON.stringify({
+                  error: "passphrase too short (min 12 chars)",
                 }),
               );
               return;


### PR DESCRIPTION
## Summary

- **H1 from security audit**: passphrase on `/traces/export?passphrase=…` was routinely logged by reverse proxies, stored in browser history, and leaked via Referrer — defeating the entire threat model for at-rest-encrypted exports
- `/traces/export` now rejects query-string passphrase with 400; reads only from `X-Trace-Passphrase` header
- Added 12-char minimum passphrase enforcement at server + dashboard (Sec M2)
- Dashboard `ExportButton` switched from `<a href>` anchor to `fetch()` + blob URL; shows inline error and loading state
- Catch-all proxy forwards `X-Trace-Passphrase` and streams binary responses through without text-corruption

## Test plan

- [ ] Build passes (`npm run build`)
- [ ] All 4794 tests pass (`npm test`)
- [ ] Export without passphrase → `.jsonl.gz` downloads correctly
- [ ] Export with passphrase ≥12 chars → `.enc` downloads correctly
- [ ] Export with passphrase <12 chars → inline error shown
- [ ] `GET /traces/export?passphrase=…` returns 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)