### PR TITLE
fix(dashboard): wrap 19 unguarded bridgeFetch routes in try/catch

### DIFF
--- a/dashboard/src/app/api/bridge/connectors/status/route.ts
+++ b/dashboard/src/app/api/bridge/connectors/status/route.ts
@@ -10,14 +10,21 @@ export async function GET() {
     const mock = mockBridgeResponse("/connectors/status", "GET");
     if (mock) return mock;
   }
-  const res = await bridgeFetch("/connections");
-  if (!res.ok) {
-    const text = await res.text().catch(() => "");
+  try {
+    const res = await bridgeFetch("/connections");
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      return NextResponse.json(
+        { error: text || `Bridge returned ${res.status}` },
+        { status: res.status },
+      );
+    }
+    const data = await res.json();
+    return NextResponse.json(data);
+  } catch (err) {
     return NextResponse.json(
-      { error: text || `Bridge returned ${res.status}` },
-      { status: res.status },
+      { error: err instanceof Error ? err.message : "fetch failed" },
+      { status: 502 },
     );
   }
-  const data = await res.json();
-  return NextResponse.json(data);
 }

--- a/dashboard/src/app/api/bridge/recipes/[name]/route.ts
+++ b/dashboard/src/app/api/bridge/recipes/[name]/route.ts
@@ -23,13 +23,20 @@ export async function GET(
       { status: 200, headers: { "content-type": "application/json" } },
     );
   }
-  const name = encodeURIComponent(ctx.params.name);
-  const res = await bridgeFetch(`/recipes/${name}`);
-  const text = await res.text();
-  return new Response(text, {
-    status: res.status,
-    headers: { "content-type": "application/json" },
-  });
+  try {
+    const name = encodeURIComponent(ctx.params.name);
+    const res = await bridgeFetch(`/recipes/${name}`);
+    const text = await res.text();
+    return new Response(text, {
+      status: res.status,
+      headers: { "content-type": "application/json" },
+    });
+  } catch (err) {
+    return new Response(
+      JSON.stringify({ error: err instanceof Error ? err.message : "fetch failed" }),
+      { status: 502, headers: { "content-type": "application/json" } },
+    );
+  }
 }
 
 export async function PUT(
@@ -44,18 +51,25 @@ export async function PUT(
     });
   }
   if (isDemoModeServer()) return demoOk();
-  const name = encodeURIComponent(ctx.params.name);
-  const body = await req.text();
-  const res = await bridgeFetch(`/recipes/${name}`, {
-    method: "PUT",
-    headers: { "content-type": req.headers.get("content-type") ?? "application/json" },
-    body,
-  });
-  const text = await res.text();
-  return new Response(text, {
-    status: res.status,
-    headers: { "content-type": "application/json" },
-  });
+  try {
+    const name = encodeURIComponent(ctx.params.name);
+    const body = await req.text();
+    const res = await bridgeFetch(`/recipes/${name}`, {
+      method: "PUT",
+      headers: { "content-type": req.headers.get("content-type") ?? "application/json" },
+      body,
+    });
+    const text = await res.text();
+    return new Response(text, {
+      status: res.status,
+      headers: { "content-type": "application/json" },
+    });
+  } catch (err) {
+    return new Response(
+      JSON.stringify({ error: err instanceof Error ? err.message : "fetch failed" }),
+      { status: 502, headers: { "content-type": "application/json" } },
+    );
+  }
 }
 
 export async function PATCH(
@@ -70,16 +84,23 @@ export async function PATCH(
     });
   }
   if (isDemoModeServer()) return demoOk();
-  const name = encodeURIComponent(ctx.params.name);
-  const body = await req.text();
-  const res = await bridgeFetch(`/recipes/${name}`, {
-    method: "PATCH",
-    headers: { "content-type": req.headers.get("content-type") ?? "application/json" },
-    body,
-  });
-  const text = await res.text();
-  return new Response(text, {
-    status: res.status,
-    headers: { "content-type": "application/json" },
-  });
+  try {
+    const name = encodeURIComponent(ctx.params.name);
+    const body = await req.text();
+    const res = await bridgeFetch(`/recipes/${name}`, {
+      method: "PATCH",
+      headers: { "content-type": req.headers.get("content-type") ?? "application/json" },
+      body,
+    });
+    const text = await res.text();
+    return new Response(text, {
+      status: res.status,
+      headers: { "content-type": "application/json" },
+    });
+  } catch (err) {
+    return new Response(
+      JSON.stringify({ error: err instanceof Error ? err.message : "fetch failed" }),
+      { status: 502, headers: { "content-type": "application/json" } },
+    );
+  }
 }

--- a/dashboard/src/app/api/bridge/recipes/[name]/run/route.ts
+++ b/dashboard/src/app/api/bridge/recipes/[name]/run/route.ts
@@ -29,16 +29,23 @@ export async function POST(
       { status: 200, headers: { "content-type": "application/json" } },
     );
   }
-  const name = encodeURIComponent(ctx.params.name);
-  const body = await req.text();
-  const res = await bridgeFetch(`/recipes/${name}/run`, {
-    method: "POST",
-    headers: { "content-type": req.headers.get("content-type") ?? "application/json" },
-    body: body || undefined,
-  });
-  const text = await res.text();
-  return new Response(text, {
-    status: res.status,
-    headers: { "content-type": "application/json" },
-  });
+  try {
+    const name = encodeURIComponent(ctx.params.name);
+    const body = await req.text();
+    const res = await bridgeFetch(`/recipes/${name}/run`, {
+      method: "POST",
+      headers: { "content-type": req.headers.get("content-type") ?? "application/json" },
+      body: body || undefined,
+    });
+    const text = await res.text();
+    return new Response(text, {
+      status: res.status,
+      headers: { "content-type": "application/json" },
+    });
+  } catch (err) {
+    return new Response(
+      JSON.stringify({ error: err instanceof Error ? err.message : "fetch failed" }),
+      { status: 502, headers: { "content-type": "application/json" } },
+    );
+  }
 }

--- a/dashboard/src/app/api/bridge/recipes/install/route.ts
+++ b/dashboard/src/app/api/bridge/recipes/install/route.ts
@@ -24,15 +24,22 @@ export async function POST(req: NextRequest): Promise<Response> {
     );
   }
 
-  const body = await req.text();
-  const res = await bridgeFetch("/recipes/install", {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body,
-  });
-  const text = await res.text();
-  return new Response(text, {
-    status: res.status,
-    headers: { "content-type": "application/json" },
-  });
+  try {
+    const body = await req.text();
+    const res = await bridgeFetch("/recipes/install", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body,
+    });
+    const text = await res.text();
+    return new Response(text, {
+      status: res.status,
+      headers: { "content-type": "application/json" },
+    });
+  } catch (err) {
+    return new Response(
+      JSON.stringify({ error: err instanceof Error ? err.message : "fetch failed" }),
+      { status: 502, headers: { "content-type": "application/json" } },
+    );
+  }
 }

--- a/dashboard/src/app/api/bridge/recipes/lint/route.ts
+++ b/dashboard/src/app/api/bridge/recipes/lint/route.ts
@@ -19,17 +19,24 @@ export async function POST(req: NextRequest): Promise<Response> {
       { status: 200, headers: { "content-type": "application/json" } },
     );
   }
-  const body = await req.text();
-  const res = await bridgeFetch("/recipes/lint", {
-    method: "POST",
-    headers: {
-      "content-type": req.headers.get("content-type") ?? "application/json",
-    },
-    body,
-  });
-  const text = await res.text();
-  return new Response(text, {
-    status: res.status,
-    headers: { "content-type": "application/json" },
-  });
+  try {
+    const body = await req.text();
+    const res = await bridgeFetch("/recipes/lint", {
+      method: "POST",
+      headers: {
+        "content-type": req.headers.get("content-type") ?? "application/json",
+      },
+      body,
+    });
+    const text = await res.text();
+    return new Response(text, {
+      status: res.status,
+      headers: { "content-type": "application/json" },
+    });
+  } catch (err) {
+    return new Response(
+      JSON.stringify({ error: err instanceof Error ? err.message : "fetch failed" }),
+      { status: 502, headers: { "content-type": "application/json" } },
+    );
+  }
 }

--- a/dashboard/src/app/api/connections/[connector]/auth/route.ts
+++ b/dashboard/src/app/api/connections/[connector]/auth/route.ts
@@ -31,20 +31,27 @@ export async function GET(
     });
   }
   // Fetch the bridge auth endpoint server-side (with auth token) to get the
-  // Google redirect URL, then forward that URL to the browser.
-  const res = await bridgeFetch(`/connections/${connector}/auth`, {
-    redirect: "manual",
-  });
-  if (res.status >= 300 && res.status < 400) {
-    const location = res.headers.get("location");
-    if (location) return Response.redirect(location, 302);
-    return new Response(JSON.stringify({ error: "Bridge returned redirect without Location header" }), {
-      status: 502, headers: { "content-type": "application/json" },
+  // OAuth redirect URL, then forward that URL to the browser.
+  try {
+    const res = await bridgeFetch(`/connections/${connector}/auth`, {
+      redirect: "manual",
     });
+    if (res.status >= 300 && res.status < 400) {
+      const location = res.headers.get("location");
+      if (location) return Response.redirect(location, 302);
+      return new Response(JSON.stringify({ error: "Bridge returned redirect without Location header" }), {
+        status: 502, headers: { "content-type": "application/json" },
+      });
+    }
+    const body = await res.text();
+    return new Response(body, {
+      status: res.status,
+      headers: { "content-type": res.headers.get("content-type") ?? "application/json" },
+    });
+  } catch (err) {
+    return new Response(
+      JSON.stringify({ error: err instanceof Error ? err.message : "fetch failed" }),
+      { status: 502, headers: { "content-type": "application/json" } },
+    );
   }
-  const body = await res.text();
-  return new Response(body, {
-    status: res.status,
-    headers: { "content-type": res.headers.get("content-type") ?? "application/json" },
-  });
 }

--- a/dashboard/src/app/api/connections/[connector]/connect/route.ts
+++ b/dashboard/src/app/api/connections/[connector]/connect/route.ts
@@ -24,17 +24,22 @@ export async function POST(
       headers: { "content-type": "application/json" },
     });
   }
-  const body = await req.text();
-  const res = await bridgeFetch(`/connections/${connector}/connect`, {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body,
-  });
-  const text = await res.text();
-  return new Response(text, {
-    status: res.status,
-    headers: {
-      "content-type": res.headers.get("content-type") ?? "application/json",
-    },
-  });
+  try {
+    const body = await req.text();
+    const res = await bridgeFetch(`/connections/${connector}/connect`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body,
+    });
+    const text = await res.text();
+    return new Response(text, {
+      status: res.status,
+      headers: { "content-type": res.headers.get("content-type") ?? "application/json" },
+    });
+  } catch (err) {
+    return new Response(
+      JSON.stringify({ error: err instanceof Error ? err.message : "fetch failed" }),
+      { status: 502, headers: { "content-type": "application/json" } },
+    );
+  }
 }

--- a/dashboard/src/app/api/connections/[connector]/route.ts
+++ b/dashboard/src/app/api/connections/[connector]/route.ts
@@ -21,14 +21,19 @@ export async function DELETE(
       status: 404, headers: { "content-type": "application/json" },
     });
   }
-  const res = await bridgeFetch(`/connections/${connector}`, {
-    method: "DELETE",
-  });
-  const text = await res.text();
-  return new Response(text, {
-    status: res.status,
-    headers: {
-      "content-type": res.headers.get("content-type") ?? "application/json",
-    },
-  });
+  try {
+    const res = await bridgeFetch(`/connections/${connector}`, {
+      method: "DELETE",
+    });
+    const text = await res.text();
+    return new Response(text, {
+      status: res.status,
+      headers: { "content-type": res.headers.get("content-type") ?? "application/json" },
+    });
+  } catch (err) {
+    return new Response(
+      JSON.stringify({ error: err instanceof Error ? err.message : "fetch failed" }),
+      { status: 502, headers: { "content-type": "application/json" } },
+    );
+  }
 }

--- a/dashboard/src/app/api/connections/[connector]/test/route.ts
+++ b/dashboard/src/app/api/connections/[connector]/test/route.ts
@@ -18,14 +18,19 @@ export async function POST(
       status: 404, headers: { "content-type": "application/json" },
     });
   }
-  const res = await bridgeFetch(`/connections/${connector}/test`, {
-    method: "POST",
-  });
-  const text = await res.text();
-  return new Response(text, {
-    status: res.status,
-    headers: {
-      "content-type": res.headers.get("content-type") ?? "application/json",
-    },
-  });
+  try {
+    const res = await bridgeFetch(`/connections/${connector}/test`, {
+      method: "POST",
+    });
+    const text = await res.text();
+    return new Response(text, {
+      status: res.status,
+      headers: { "content-type": res.headers.get("content-type") ?? "application/json" },
+    });
+  } catch (err) {
+    return new Response(
+      JSON.stringify({ error: err instanceof Error ? err.message : "fetch failed" }),
+      { status: 502, headers: { "content-type": "application/json" } },
+    );
+  }
 }

--- a/dashboard/src/app/api/connections/asana/callback/route.ts
+++ b/dashboard/src/app/api/connections/asana/callback/route.ts
@@ -12,10 +12,17 @@ export async function GET(req: Request): Promise<Response> {
     if (v !== null) qs.set(key, v);
   }
 
-  const res = await bridgeFetch(`/connections/asana/callback?${qs.toString()}`);
-  const body = await res.text();
-  return new Response(body, {
-    status: res.status,
-    headers: { "content-type": res.headers.get("content-type") ?? "application/json" },
-  });
+  try {
+    const res = await bridgeFetch(`/connections/asana/callback?${qs.toString()}`);
+    const body = await res.text();
+    return new Response(body, {
+      status: res.status,
+      headers: { "content-type": res.headers.get("content-type") ?? "application/json" },
+    });
+  } catch (err) {
+    return new Response(
+      JSON.stringify({ error: err instanceof Error ? err.message : "fetch failed" }),
+      { status: 502, headers: { "content-type": "application/json" } },
+    );
+  }
 }

--- a/dashboard/src/app/api/connections/discord/callback/route.ts
+++ b/dashboard/src/app/api/connections/discord/callback/route.ts
@@ -12,10 +12,17 @@ export async function GET(req: Request): Promise<Response> {
     if (v !== null) qs.set(key, v);
   }
 
-  const res = await bridgeFetch(`/connections/discord/callback?${qs.toString()}`);
-  const body = await res.text();
-  return new Response(body, {
-    status: res.status,
-    headers: { "content-type": res.headers.get("content-type") ?? "application/json" },
-  });
+  try {
+    const res = await bridgeFetch(`/connections/discord/callback?${qs.toString()}`);
+    const body = await res.text();
+    return new Response(body, {
+      status: res.status,
+      headers: { "content-type": res.headers.get("content-type") ?? "application/json" },
+    });
+  } catch (err) {
+    return new Response(
+      JSON.stringify({ error: err instanceof Error ? err.message : "fetch failed" }),
+      { status: 502, headers: { "content-type": "application/json" } },
+    );
+  }
 }

--- a/dashboard/src/app/api/connections/gitlab/callback/route.ts
+++ b/dashboard/src/app/api/connections/gitlab/callback/route.ts
@@ -12,10 +12,17 @@ export async function GET(req: Request): Promise<Response> {
     if (v !== null) qs.set(key, v);
   }
 
-  const res = await bridgeFetch(`/connections/gitlab/callback?${qs.toString()}`);
-  const body = await res.text();
-  return new Response(body, {
-    status: res.status,
-    headers: { "content-type": res.headers.get("content-type") ?? "application/json" },
-  });
+  try {
+    const res = await bridgeFetch(`/connections/gitlab/callback?${qs.toString()}`);
+    const body = await res.text();
+    return new Response(body, {
+      status: res.status,
+      headers: { "content-type": res.headers.get("content-type") ?? "application/json" },
+    });
+  } catch (err) {
+    return new Response(
+      JSON.stringify({ error: err instanceof Error ? err.message : "fetch failed" }),
+      { status: 502, headers: { "content-type": "application/json" } },
+    );
+  }
 }

--- a/dashboard/src/app/api/connections/gmail/callback/route.ts
+++ b/dashboard/src/app/api/connections/gmail/callback/route.ts
@@ -12,10 +12,17 @@ export async function GET(req: Request): Promise<Response> {
     if (v !== null) qs.set(key, v);
   }
 
-  const res = await bridgeFetch(`/connections/gmail/callback?${qs.toString()}`);
-  const body = await res.text();
-  return new Response(body, {
-    status: res.status,
-    headers: { "content-type": res.headers.get("content-type") ?? "application/json" },
-  });
+  try {
+    const res = await bridgeFetch(`/connections/gmail/callback?${qs.toString()}`);
+    const body = await res.text();
+    return new Response(body, {
+      status: res.status,
+      headers: { "content-type": res.headers.get("content-type") ?? "application/json" },
+    });
+  } catch (err) {
+    return new Response(
+      JSON.stringify({ error: err instanceof Error ? err.message : "fetch failed" }),
+      { status: 502, headers: { "content-type": "application/json" } },
+    );
+  }
 }

--- a/dashboard/src/app/api/connections/google-calendar/callback/route.ts
+++ b/dashboard/src/app/api/connections/google-calendar/callback/route.ts
@@ -12,15 +12,19 @@ export async function GET(req: Request): Promise<Response> {
     if (v !== null) qs.set(key, v);
   }
 
-  const res = await bridgeFetch(
+  try {
+    const res = await bridgeFetch(
     `/connections/google-calendar/callback?${qs.toString()}`,
   );
-  const body = await res.text();
-  return new Response(body, {
-    status: res.status,
-    headers: {
-      "content-type":
-        res.headers.get("content-type") ?? "application/json",
-    },
-  });
+    const body = await res.text();
+    return new Response(body, {
+      status: res.status,
+      headers: { "content-type": res.headers.get("content-type") ?? "application/json" },
+    });
+  } catch (err) {
+    return new Response(
+      JSON.stringify({ error: err instanceof Error ? err.message : "fetch failed" }),
+      { status: 502, headers: { "content-type": "application/json" } },
+    );
+  }
 }

--- a/dashboard/src/app/api/connections/google-drive/callback/route.ts
+++ b/dashboard/src/app/api/connections/google-drive/callback/route.ts
@@ -12,15 +12,19 @@ export async function GET(req: Request): Promise<Response> {
     if (v !== null) qs.set(key, v);
   }
 
-  const res = await bridgeFetch(
+  try {
+    const res = await bridgeFetch(
     `/connections/google-drive/callback?${qs.toString()}`,
   );
-  const body = await res.text();
-  return new Response(body, {
-    status: res.status,
-    headers: {
-      "content-type":
-        res.headers.get("content-type") ?? "application/json",
-    },
-  });
+    const body = await res.text();
+    return new Response(body, {
+      status: res.status,
+      headers: { "content-type": res.headers.get("content-type") ?? "application/json" },
+    });
+  } catch (err) {
+    return new Response(
+      JSON.stringify({ error: err instanceof Error ? err.message : "fetch failed" }),
+      { status: 502, headers: { "content-type": "application/json" } },
+    );
+  }
 }

--- a/dashboard/src/app/api/connections/route.ts
+++ b/dashboard/src/app/api/connections/route.ts
@@ -14,28 +14,24 @@ export interface ConnectionsResponse {
 }
 
 export async function GET(): Promise<Response> {
-  const res = await bridgeFetch("/connections");
-  if (res.status === 503) {
+  try {
+    const res = await bridgeFetch("/connections");
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      return new Response(
+        JSON.stringify({ error: text || `Bridge returned ${res.status}` }),
+        { status: res.status, headers: { "content-type": "application/json" } },
+      );
+    }
+    const text = await res.text();
+    return new Response(text, {
+      status: res.status,
+      headers: { "content-type": res.headers.get("content-type") ?? "application/json" },
+    });
+  } catch (err) {
     return new Response(
-      JSON.stringify({ error: "No running bridge found" }),
-      { status: 503, headers: { "content-type": "application/json" } },
+      JSON.stringify({ error: err instanceof Error ? err.message : "fetch failed" }),
+      { status: 502, headers: { "content-type": "application/json" } },
     );
   }
-  if (!res.ok) {
-    // Bridge is up but doesn't know about /connections yet — return defaults.
-    const body: ConnectionsResponse = {
-      connectors: [{ id: "gmail", status: "disconnected" }],
-    };
-    return new Response(JSON.stringify(body), {
-      status: 200,
-      headers: { "content-type": "application/json" },
-    });
-  }
-  const text = await res.text();
-  return new Response(text, {
-    status: res.status,
-    headers: {
-      "content-type": res.headers.get("content-type") ?? "application/json",
-    },
-  });
 }

--- a/dashboard/src/app/api/connections/slack/callback/route.ts
+++ b/dashboard/src/app/api/connections/slack/callback/route.ts
@@ -12,10 +12,17 @@ export async function GET(req: Request): Promise<Response> {
     if (v !== null) qs.set(key, v);
   }
 
-  const res = await bridgeFetch(`/connections/slack/callback?${qs.toString()}`);
-  const body = await res.text();
-  return new Response(body, {
-    status: res.status,
-    headers: { "content-type": res.headers.get("content-type") ?? "application/json" },
-  });
+  try {
+    const res = await bridgeFetch(`/connections/slack/callback?${qs.toString()}`);
+    const body = await res.text();
+    return new Response(body, {
+      status: res.status,
+      headers: { "content-type": res.headers.get("content-type") ?? "application/json" },
+    });
+  } catch (err) {
+    return new Response(
+      JSON.stringify({ error: err instanceof Error ? err.message : "fetch failed" }),
+      { status: 502, headers: { "content-type": "application/json" } },
+    );
+  }
 }

--- a/dashboard/src/app/api/inbox/[filename]/route.ts
+++ b/dashboard/src/app/api/inbox/[filename]/route.ts
@@ -8,7 +8,14 @@ export async function GET(
   { params }: { params: Promise<{ filename: string }> },
 ) {
   const { filename } = await params;
-  const res = await bridgeFetch(`/inbox/${encodeURIComponent(filename)}`);
-  const data = await res.json();
-  return NextResponse.json(data, { status: res.status });
+  try {
+    const res = await bridgeFetch(`/inbox/${encodeURIComponent(filename)}`);
+    const data = await res.json();
+    return NextResponse.json(data, { status: res.status });
+  } catch (err) {
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : "fetch failed" },
+      { status: 502 },
+    );
+  }
 }

--- a/dashboard/src/app/api/inbox/route.ts
+++ b/dashboard/src/app/api/inbox/route.ts
@@ -4,7 +4,14 @@ import { NextResponse } from "next/server";
 export const dynamic = "force-dynamic";
 
 export async function GET() {
-  const res = await bridgeFetch("/inbox");
-  const data = await res.json();
-  return NextResponse.json(data, { status: res.status });
+  try {
+    const res = await bridgeFetch("/inbox");
+    const data = await res.json();
+    return NextResponse.json(data, { status: res.status });
+  } catch (err) {
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : "fetch failed" },
+      { status: 502 },
+    );
+  }
 }


### PR DESCRIPTION
## Summary

- 19 dashboard API routes called `bridgeFetch()` with no `try/catch` — a network timeout, ECONNREFUSED, or DNS failure threw unhandled, and Next.js surfaced it as opaque 500 HTML instead of JSON
- The dashboard UI's error display path expects `{ error: "..." }` JSON; HTML responses silently broke it (spinner forever or blank page)
- All 19 routes now catch and return `{ error: message }` with **502**
- Also fixed `connections/route.ts` which was masking bridge errors behind a fabricated `200` with stale connector defaults — now propagates the real error status

## Affected routes
`inbox/`, `inbox/[filename]/`, `bridge/connectors/status`, `bridge/recipes/lint`, `bridge/recipes/install`, `bridge/recipes/[name]` (GET/PUT/PATCH), `bridge/recipes/[name]/run`, `connections/` (GET), `connections/[connector]` (DELETE), `connections/[connector]/test`, `connections/[connector]/auth`, `connections/[connector]/connect`, and all 7 OAuth callback routes (gmail, slack, discord, gitlab, google-calendar, google-drive, asana).

## Test plan

- [ ] Build passes (`npm run build`)
- [ ] All 4794 tests pass (`npm test`)
- [ ] With bridge stopped: dashboard API routes return `{ "error": "..." }` 502 instead of HTML
- [ ] `connections/route.ts`: bridge error surfaces as non-200 status, not as `{ connectors: [{...}] }` 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)