### PR TITLE
feat(ux): surface Morning Brief as hero workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,26 @@ npx patchwork-os@alpha patchwork-init
 
 Sets up 5 local recipes, detects Ollama, and opens a terminal dashboard — under 90 seconds.
 
+### ☀️ Morning Brief — the hero workflow
+
+Get an AI digest of your Gmail, calendar, and tasks every morning — or on demand:
+
+```bash
+# First-time setup (connect Gmail + Google Calendar)
+patchwork-os patchwork-init
+patchwork-os connections connect gmail
+patchwork-os connections connect google-calendar
+
+# Run it now
+patchwork-os recipe run morning-brief
+```
+
+The brief lands in `~/.patchwork/inbox/` as a Markdown file. Open the dashboard (`http://localhost:3100`) to read it, approve any drafted replies, or let it auto-send at 08:00 via the built-in cron trigger.
+
+No connectors yet? Run with `--local` using Ollama — it summarises your clipboard and last-touched files instead.
+
+---
+
 ### What it adds on top of the bridge
 
 Patchwork OS is a local automation platform that watches your workspace for events, runs AI-powered recipes in response, and routes anything risky through an approval queue before it goes anywhere.

--- a/dashboard/src/app/page.tsx
+++ b/dashboard/src/app/page.tsx
@@ -1148,6 +1148,47 @@ export default function HomePage() {
       </div>
 
       {/* ------------------------------------------------------------------ */}
+      {/* Morning Brief CTA                                                     */}
+      {/* ------------------------------------------------------------------ */}
+      <div
+        className="card"
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: "var(--s-5)",
+          padding: "18px 24px",
+          marginBottom: "var(--s-4)",
+          background: "linear-gradient(135deg, rgba(var(--orange-rgb),0.06) 0%, var(--card-bg) 100%)",
+          borderColor: "rgba(var(--orange-rgb),0.18)",
+          flexWrap: "wrap",
+        }}
+      >
+        <div style={{ fontSize: 28, lineHeight: 1, flexShrink: 0 }}>☀️</div>
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div style={{ fontWeight: 700, fontSize: 14, color: "var(--ink-0)" }}>Morning Brief</div>
+          <div style={{ fontSize: 12, color: "var(--ink-2)", marginTop: 2 }}>
+            AI digest of Gmail, calendar, and tasks — ready in your inbox each morning.
+          </div>
+        </div>
+        <div style={{ display: "flex", gap: "var(--s-2)", flexShrink: 0, alignItems: "center" }}>
+          <Link
+            href="/recipes?name=morning-brief"
+            className="btn sm ghost"
+            style={{ textDecoration: "none", fontSize: 12 }}
+          >
+            Configure
+          </Link>
+          <Link
+            href="/recipes"
+            className="btn sm primary"
+            style={{ textDecoration: "none", fontSize: 12, background: "var(--orange)", border: "none" }}
+          >
+            Run now →
+          </Link>
+        </div>
+      </div>
+
+      {/* ------------------------------------------------------------------ */}
       {/* 3-column bottom section                                               */}
       {/* ------------------------------------------------------------------ */}
       <div

--- a/src/commands/patchworkInit.ts
+++ b/src/commands/patchworkInit.ts
@@ -214,9 +214,9 @@ export async function runPatchworkInit(
       : "";
 
   log(`${restartLine}\nNext:
-  1. patchwork-os recipe run ambient-journal   # try a local recipe
-  2. patchwork-os                              # launch terminal dashboard
-  3. Connect Gmail (coming in W2) — see docs/adr/0008-connector-scope-decision.md\n`);
+  1. patchwork-os recipe run morning-brief     # AI digest: Gmail + calendar + tasks
+  2. patchwork-os                              # launch terminal dashboard → http://localhost:3100
+  3. patchwork-os recipe list                  # browse installed recipes\n`);
 
   return {
     configPath,


### PR DESCRIPTION
## Summary
- `patchwork-init` next-steps now leads with `recipe run morning-brief` — clearer first call to action
- Dashboard home gets a Morning Brief banner card between the main grid and the bottom 3-column section (Configure + Run now CTAs)
- README Patchwork OS section gets a dedicated Morning Brief Quick Start block showing connector setup + `--local` Ollama fallback

## Test plan
- [x] `npm run build` — clean
- [x] `npx tsc --noEmit` in dashboard — no new errors
- [x] `npx biome check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)