### PR TITLE
fix(dashboard): guard enable/trust onClick handlers with try/catch

### DIFF
--- a/dashboard/src/app/recipes/page.tsx
+++ b/dashboard/src/app/recipes/page.tsx
@@ -905,14 +905,18 @@ export default function RecipesPage() {
                             }}
                             title={r.enabled === false ? "Enable recipe" : "Disable recipe"}
                             onClick={async () => {
-                              await fetch(
-                                apiPath(`/api/bridge/recipes/${encodeURIComponent(r.name)}`),
-                                {
-                                  method: "PATCH",
-                                  headers: { "Content-Type": "application/json" },
-                                  body: JSON.stringify({ enabled: r.enabled === false }),
-                                },
-                              );
+                              try {
+                                await fetch(
+                                  apiPath(`/api/bridge/recipes/${encodeURIComponent(r.name)}`),
+                                  {
+                                    method: "PATCH",
+                                    headers: { "Content-Type": "application/json" },
+                                    body: JSON.stringify({ enabled: r.enabled === false }),
+                                  },
+                                );
+                              } catch (e) {
+                                setErr(e instanceof Error ? e.message : String(e));
+                              }
                               void load();
                             }}
                           >
@@ -931,14 +935,18 @@ export default function RecipesPage() {
                               padding: "2px 4px",
                             }}
                             onChange={async (e) => {
-                              await fetch(
-                                apiPath(`/api/bridge/recipes/${encodeURIComponent(r.name)}/trust`),
-                                {
-                                  method: "PATCH",
-                                  headers: { "Content-Type": "application/json" },
-                                  body: JSON.stringify({ level: e.target.value }),
-                                },
-                              );
+                              try {
+                                await fetch(
+                                  apiPath(`/api/bridge/recipes/${encodeURIComponent(r.name)}/trust`),
+                                  {
+                                    method: "PATCH",
+                                    headers: { "Content-Type": "application/json" },
+                                    body: JSON.stringify({ level: e.target.value }),
+                                  },
+                                );
+                              } catch (e) {
+                                setErr(e instanceof Error ? e.message : String(e));
+                              }
                               void load();
                             }}
                           >


### PR DESCRIPTION
## Summary
- Two async `onClick`/`onChange` handlers in the recipes list page were calling `await fetch(...)` without try/catch
- Network failures would become unhandled promise rejections visible in the browser console instead of the existing error banner
- Wrapped both with `try { ... } catch (e) { setErr(...) }` so failures surface inline

## Test plan
- [ ] Disable/enable a recipe while bridge is offline — verify error message appears rather than a silent console error
- [ ] Change a recipe's trust level while bridge is offline — same check

🤖 Generated with [Claude Code](https://claude.com/claude-code)