### PR TITLE
chore(lint): add lint:src script scoped to src/

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "test:coverage": "vitest run --coverage",
     "test:watch": "vitest",
     "lint": "biome check .",
+    "lint:src": "biome check src",
     "lint:fix": "biome check --write .",
     "typecheck": "tsc --noEmit",
     "typecheck:tests": "tsc --noEmit -p tsconfig.tests.json",


### PR DESCRIPTION
## Summary
Adds `npm run lint:src` → `biome check src`, mirroring the existing narrower lint targets pattern.

## Why
Root `npm run lint` currently surfaces thousands of diagnostics from IDE/workspace artifacts. A scoped `src` target is useful for:
- Local iteration while root biome `includes`/`excludes` cleanup is still pending.
- CI wiring (Phase 4) — gives us a stable, signal-heavy lint gate today.

## Verification
```
npm run lint:src
Checked 698 files in 314ms. No fixes applied.
Found 50 warnings. Found 1 info. exit=0
```

## Scope
Single-line `package.json` addition. No behavior changes to existing scripts. Follow-ups (separate PRs):
- Biome `includes`/`excludes` cleanup for root `lint`.
- `typecheck:tests` triage / split.
- CI gates in `.github/workflows/ci.yml`.