### PR TITLE
chore(lint): exclude gradle/legacy/generated artifacts from root biome

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -24,12 +24,16 @@
     "includes": [
       "**",
       "!**/dist",
+      "!**/build",
       "!**/node_modules",
       "!**/vscode-extension/out",
       "!**/coverage",
       "!**/docs",
       "!**/.claude/worktrees",
-      "!dashboard"
+      "!dashboard",
+      "!intellij-plugin/build",
+      "!patchwork 2.0",
+      "!diagnostics-dashboard.html"
     ]
   },
   "overrides": [


### PR DESCRIPTION
## Summary

Root `npm run lint` was reporting 2544 errors + 1009 warnings. All error-level diagnostics came from untracked local artifacts, not tracked source:

- `intellij-plugin/build/` (Gradle output; ~3084 diagnostics)
- `patchwork 2.0/` (legacy static dashboard; ~84 diagnostics)
- `diagnostics-dashboard.html` (generated root-level HTML)

Excluding these from biome's `includes` restores signal. Also adds a general `!**/build` pattern alongside the existing `!**/dist`.

**Before**: 2544 errors, 1009 warnings, 23 infos across 1529 files.
**After**: 0 errors, 51 warnings, 1 info across 876 files. exit 0.

## Test plan
- [ ] `npm run lint` exits 0
- [ ] No tracked source files newly excluded

🤖 Generated with [Claude Code](https://claude.com/claude-code)