### PR TITLE
chore(lint-staged): drop redundant root glob

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,7 +133,6 @@
     "vitest": "^3.0.0"
   },
   "lint-staged": {
-    "{src,vscode-extension/src,scripts,deploy}/**/*.{ts,js,mjs,cjs,json}": "biome check --no-errors-on-unmatched",
-    "*.{ts,js,mjs,cjs,json}": "biome check --no-errors-on-unmatched"
+    "{src,vscode-extension/src,scripts,deploy}/**/*.{ts,js,mjs,cjs,json}": "biome check --no-errors-on-unmatched"
   }
 }


### PR DESCRIPTION
## Summary

Drops the second `*.{ts,js,mjs,cjs,json}` pattern from the `lint-staged` config. It duplicates the scoped `{src,vscode-extension/src,scripts,deploy}/**/*` pattern for any owned source, but additionally matches root-level configs and (the suspected stall vector) `package-lock.json` churn.

Biome v2 + a freshly stashed working tree + a staged lockfile is the most plausible cause of the multi-minute `npx lint-staged` stalls observed during the Phase 1+2 session. The scoped pattern already covers all owned source.

## Test plan
- [ ] Commit a `src/*.ts` change → biome runs as before
- [ ] Commit a `package.json` / `package-lock.json` change → no biome run, no stall

🤖 Generated with [Claude Code](https://claude.com/claude-code)