### PR TITLE
ci: gate on typecheck:tests:core + dashboard typecheck/tests (phase 4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Type check
         run: npm run typecheck
+      - name: Type check tests (core ratchet)
+        run: npm run typecheck:tests:core
       - name: Lint
         run: npm run lint
       - name: Guard against optional-chaining on prompt variables
@@ -224,6 +226,27 @@ jobs:
           name: benchmark-results-${{ github.sha }}
           path: /tmp/benchmark-results.json
           retention-days: 30
+
+  dashboard:
+    name: Dashboard typecheck + tests
+    runs-on: ubuntu-latest
+    needs: ci
+    defaults:
+      run:
+        working-directory: dashboard
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: dashboard/package-lock.json
+      - name: Install dependencies
+        run: npm ci
+      - name: Type check
+        run: npx tsc --noEmit
+      - name: Test
+        run: npm test
 
   extension:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Phase 4 of post-assessment cleanup. Wires the green ratchets from #203 and #207 into CI so they can't silently regress.

### Changes to `.github/workflows/ci.yml`

1. **`ci` job** — adds `npm run typecheck:tests:core` after `npm run typecheck`. Gates on the 255-file green ratchet from #207.
2. **New `dashboard` job** (`needs: ci`) — runs `tsc --noEmit` + `vitest run` inside `dashboard/`. PR #203 fixed dashboard typecheck; this stops it from drifting again.

### Already covered, no change needed

- `npm run schema:check` — existing `schema-audit` job runs `audit-schema-changes.mjs`.
- `biome check src` — existing `lint` step runs `biome check .` (full repo, now clean after #205).

## Test plan
- [ ] CI green on this PR
- [ ] If `typecheck:tests:core` ever needs to grow, add the file to `tsconfig.tests.core.json` excludes; do not weaken the gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)