### PR TITLE
chore(typecheck): fix pluginLoader.test.ts (33 → 0 errors)

### DIFF
--- a/src/__tests__/pluginLoader.test.ts
+++ b/src/__tests__/pluginLoader.test.ts
@@ -20,6 +20,8 @@ import {
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 function makeConfig(overrides: Partial<Config> = {}): Config {
+  // Tests only use a small subset of Config; cast through unknown so the
+  // helper doesn't have to track every required field as Config grows.
   return {
     workspace: process.cwd(),
     workspaceFolders: [process.cwd()],
@@ -37,8 +39,9 @@ function makeConfig(overrides: Partial<Config> = {}): Config {
     activeWorkspaceFolder: process.cwd(),
     gracePeriodMs: 30_000,
     autoTmux: false,
-    claudeDriver: "none",
+    driver: "none",
     claudeBinary: "claude",
+    antBinary: "ant",
     automationEnabled: false,
     automationPolicyPath: null,
     toolRateLimit: 60,
@@ -46,7 +49,7 @@ function makeConfig(overrides: Partial<Config> = {}): Config {
     plugins: [],
     pluginWatch: false,
     ...overrides,
-  };
+  } as unknown as Config;
 }
 
 interface LogCall {
@@ -54,7 +57,9 @@ interface LogCall {
   msg: string;
 }
 
-function makeLogger() {
+type TestLogger = import("../logger.js").Logger & { calls: LogCall[] };
+
+function makeLogger(): TestLogger {
   const calls: LogCall[] = [];
   return {
     calls,
@@ -64,7 +69,7 @@ function makeLogger() {
     debug: (msg: string) => calls.push({ level: "debug", msg }),
     event: () => {},
     child: () => makeLogger(),
-  } as unknown as import("../logger.js").Logger;
+  } as unknown as TestLogger;
 }
 
 function makeManifest(

--- a/tsconfig.tests.core.json
+++ b/tsconfig.tests.core.json
@@ -26,7 +26,6 @@
     "src/__tests__/integration.test.ts",
     "src/__tests__/lazyTools.test.ts",
     "src/__tests__/mobileOversight.e2e.test.ts",
-    "src/__tests__/pluginLoader.test.ts",
     "src/__tests__/pluginWatcher-shadow.test.ts",
     "src/__tests__/pluginWatcher.test.ts",
     "src/__tests__/pong-starvation.test.ts",


### PR DESCRIPTION
## Summary

PR B from the typecheck:tests ratchet narrowing plan. Reclaims the 3rd top-broken test file (33 errors); cumulative with #209 the top-3 are done (~22% of the original 477).

### Three boundary fixes; no runtime behavior changes

1. **`makeLogger()` return type was `as unknown as Logger`** — erased the test-only `calls` field used by every assertion. Introduce `TestLogger = Logger & { calls: LogCall[] }` and return that. Fixes 16× `TS2339` (`calls` not on `Logger`) and 16× `TS7006` (parameter `c` implicitly `any` in `.some(c => …)`).

2. **`makeConfig()` used `claudeDriver`** — renamed long ago to `driver` on `Config`; `claudeDriver` is now only a deprecated CLI alias on `FileConfig`. Updated to `driver: "none"`.

3. **`makeConfig()` was missing required `antBinary`** (and would drift again as `Config` grows). Added `antBinary` plus `as unknown as Config` cast at the return so the helper doesn't need to track every required `Config` field. Comment explains intent.

### Verification

- `npm run typecheck:tests:core` — 0 errors (was 33 after un-excluding)
- `vitest run src/__tests__/pluginLoader.test.ts` — **25 tests pass**
- File removed from `tsconfig.tests.core.json` excludes (94 → 91 across PRs A+B)

## Next in the ratchet

PR C — bulk `noUncheckedIndexedAccess` sweep across remaining ~50 files (TS2532 + TS18048, ~88 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)