### PR TITLE
fix(recipes): hard error on duplicate YAML recipe names

### DIFF
--- a/src/__tests__/webhookRecipes.test.ts
+++ b/src/__tests__/webhookRecipes.test.ts
@@ -15,6 +15,7 @@ import {
   listInstalledRecipes,
   loadRecipeContent,
   loadRecipePrompt,
+  RecipeNameConflictError,
   renderWebhookPrompt,
   saveRecipe,
   saveRecipeContent,
@@ -129,6 +130,43 @@ describe("findWebhookRecipe", () => {
     expect(findYamlRecipePath(tmp, "declared-yaml-name")).toBe(
       path.join(tmp, "custom-filename.yaml"),
     );
+  });
+
+  it("throws RecipeNameConflictError when two YAML recipes declare the same name", () => {
+    const yamlBody = (name: string) =>
+      [
+        `name: ${name}`,
+        "trigger:",
+        "  type: manual",
+        "steps:",
+        "  - tool: file.write",
+        "    path: /tmp/out.txt",
+        "    content: ok",
+        "",
+      ].join("\n");
+
+    writeFileSync(
+      path.join(tmp, "daily-status.yaml"),
+      yamlBody("daily-status"),
+    );
+    writeFileSync(path.join(tmp, "copy.yaml"), yamlBody("daily-status"));
+
+    let caught: unknown;
+    try {
+      findYamlRecipePath(tmp, "daily-status");
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(RecipeNameConflictError);
+    const err = caught as RecipeNameConflictError;
+    expect(err.recipeName).toBe("daily-status");
+    expect(err.paths).toHaveLength(2);
+    expect(err.paths.map((p) => path.basename(p)).sort()).toEqual([
+      "copy.yaml",
+      "daily-status.yaml",
+    ]);
+    expect(err.message).toContain("daily-status");
+    expect(err.message).toContain("copy.yaml");
   });
 });
 

--- a/src/commands/recipe.ts
+++ b/src/commands/recipe.ts
@@ -372,9 +372,18 @@ function lintStep(
   // Emit a warning rather than error: the recipe may be installed on the
   // deploy target but not the author's machine.
   if (existsSync(RECIPES_DIR)) {
-    const found =
-      findYamlRecipePath(RECIPES_DIR, ref) ??
-      (existsSync(join(RECIPES_DIR, ref)) ? join(RECIPES_DIR, ref) : null);
+    let found: string | null = null;
+    try {
+      found =
+        findYamlRecipePath(RECIPES_DIR, ref) ??
+        (existsSync(join(RECIPES_DIR, ref)) ? join(RECIPES_DIR, ref) : null);
+    } catch (err) {
+      issues.push({
+        level: "error",
+        message: `Step ${stepLabel}: '${field}: ${ref}' — ${err instanceof Error ? err.message : String(err)}`,
+      });
+      return issues;
+    }
     if (!found) {
       issues.push({
         level: "warning",

--- a/src/recipeOrchestration.ts
+++ b/src/recipeOrchestration.ts
@@ -397,7 +397,15 @@ export class RecipeOrchestration {
       }
 
       // Fall through to YAML runner for .yaml/.yml recipes.
-      const ymlPath = findYamlRecipePath(recipesDir, name);
+      let ymlPath: string | null;
+      try {
+        ymlPath = findYamlRecipePath(recipesDir, name);
+      } catch (err) {
+        return {
+          ok: false,
+          error: err instanceof Error ? err.message : String(err),
+        };
+      }
       if (!ymlPath) {
         return {
           ok: false,

--- a/src/recipes/scheduler.ts
+++ b/src/recipes/scheduler.ts
@@ -304,8 +304,18 @@ export class RecipeScheduler {
       // proceed if config unreadable — falling back to scan-time snapshot
     }
 
-    // YAML recipe — delegate to runYaml if provided
-    const yamlPath = findYamlRecipePath(this.opts.recipesDir, name);
+    // YAML recipe — delegate to runYaml if provided. findYamlRecipePath
+    // now throws RecipeNameConflictError when two recipes declare the same
+    // name; surface that loudly instead of letting the timer crash silently.
+    let yamlPath: string | null;
+    try {
+      yamlPath = findYamlRecipePath(this.opts.recipesDir, name);
+    } catch (err) {
+      this.opts.logger?.warn?.(
+        `[scheduler] skipped "${name}" — ${err instanceof Error ? err.message : String(err)}`,
+      );
+      return;
+    }
 
     if (yamlPath) {
       if (!this.opts.runYaml) {

--- a/src/recipesHttp.ts
+++ b/src/recipesHttp.ts
@@ -1095,6 +1095,28 @@ export function listInstalledRecipes(recipesDir: string): ListRecipesResult {
   return { recipesDir, recipes };
 }
 
+/**
+ * Thrown by `findYamlRecipePath` (and listing/lint paths that surface this)
+ * when more than one enabled YAML recipe declares the same `name`. Callers
+ * must surface this loudly rather than silently picking the first match —
+ * dashboard run buttons, scheduler fires, and webhook resolution would all
+ * be ambiguous otherwise.
+ */
+export class RecipeNameConflictError extends Error {
+  readonly recipeName: string;
+  readonly paths: string[];
+  constructor(recipeName: string, paths: string[]) {
+    super(
+      `Multiple YAML recipes declare name "${recipeName}": ${paths
+        .map((p) => path.basename(p))
+        .join(", ")}`,
+    );
+    this.name = "RecipeNameConflictError";
+    this.recipeName = recipeName;
+    this.paths = paths;
+  }
+}
+
 export function findYamlRecipePath(
   recipesDir: string,
   name: string,
@@ -1103,57 +1125,62 @@ export function findYamlRecipePath(
   if (!/^[a-z0-9][a-z0-9_-]{0,63}$/.test(safeName)) return null;
 
   const base = path.resolve(recipesDir);
-  const candidates = [
-    path.resolve(recipesDir, `${safeName}.yaml`),
-    path.resolve(recipesDir, `${safeName}.yml`),
-  ];
-  for (const candidate of candidates) {
+  const matches = new Set<string>();
+
+  // Exact-filename matches (top-level legacy layout). The parsed `name`
+  // field is allowed to differ from the filename, so we still scan below.
+  for (const ext of [".yaml", ".yml"]) {
+    const candidate = path.resolve(recipesDir, `${safeName}${ext}`);
     if (!candidate.startsWith(base + path.sep)) return null;
-    if (existsSync(candidate)) {
-      return candidate;
-    }
+    if (existsSync(candidate)) matches.add(candidate);
   }
 
-  let entries: string[];
+  let entries: string[] = [];
   try {
     entries = readdirSync(recipesDir);
   } catch {
-    return null;
+    // recipesDir missing — fall through; matches may still be empty
   }
 
   for (const entry of entries) {
     if (!entry.endsWith(".yaml") && !entry.endsWith(".yml")) continue;
     const entryPath = path.join(recipesDir, entry);
+    if (matches.has(entryPath)) continue;
     try {
-      const entryRaw = readFileSync(entryPath, "utf-8");
-      const entryParsed = parseYaml(entryRaw) as { name?: string };
-      if (entryParsed.name?.toLowerCase() !== safeName) {
-        continue;
+      const entryParsed = parseYaml(readFileSync(entryPath, "utf-8")) as {
+        name?: string;
+      };
+      if (entryParsed.name?.toLowerCase() === safeName) {
+        matches.add(entryPath);
       }
-      return entryPath;
     } catch {
       // skip malformed candidate
     }
   }
 
-  // Also search install dirs from `recipeInstall`. Skips dirs with
+  // Install dirs from `recipeInstall`. iterateInstallDirs skips dirs with
   // `.disabled` marker so the manual-fire / orchestrator path can't
   // resolve a recipe the user has explicitly disabled.
   for (const { entrypointPath } of iterateInstallDirs(recipesDir)) {
     if (!/\.ya?ml$/i.test(entrypointPath)) continue;
+    if (matches.has(entrypointPath)) continue;
     try {
       const parsed = parseYaml(readFileSync(entrypointPath, "utf-8")) as {
         name?: string;
       };
       if (parsed.name?.toLowerCase() === safeName) {
-        return entrypointPath;
+        matches.add(entrypointPath);
       }
     } catch {
       // skip malformed
     }
   }
 
-  return null;
+  if (matches.size === 0) return null;
+  if (matches.size > 1) {
+    throw new RecipeNameConflictError(safeName, [...matches].sort());
+  }
+  return [...matches][0] ?? null;
 }
 
 /**


### PR DESCRIPTION
## Summary
- `findYamlRecipePath` now scans all candidates (exact filename, declared `name`, install dirs), dedupes, and throws a typed `RecipeNameConflictError` when more than one distinct file declares the same recipe name.
- Single-match and not-found behavior unchanged.
- Callers (`scheduler.fire`, orchestration manual-fire, recipe lint) wrap the call so conflicts surface as a clear message instead of crashing the timer or HTTP handler.

Fixes the dogfood gap where two YAMLs with `name: daily-status` would silently resolve to whichever the directory scan hit first, making dashboard "Run", scheduler fires, and webhook resolution non-deterministic.

Error format:
\`\`\`
Multiple YAML recipes declare name "daily-status": copy.yaml, daily-status.yaml
\`\`\`

## Test plan
- [x] New unit test in `webhookRecipes.test.ts` covering the `daily-status.yaml` + `copy.yaml` collision case
- [x] Existing `findYamlRecipePath` tests still pass (`webhookRecipes`, `disabled-marker-enforcement`, `recipeOrchestration`)
- [x] `npx tsc --noEmit` clean on touched files
- [x] `npx biome check` clean on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)