### PR TITLE
fix(recipes): replace ESM-broken require() in yamlRunner

### DIFF
--- a/src/recipes/__tests__/yamlRunner.test.ts
+++ b/src/recipes/__tests__/yamlRunner.test.ts
@@ -3,6 +3,20 @@ import os from "node:os";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 
+// Isolate from the developer's real ~/.patchwork/config.json — agent steps
+// now read it via a static import (was a broken `require()` under ESM that
+// always returned {}). Tests assert default model / driver behavior, so we
+// hold the config to {} here.
+vi.mock("../../patchworkConfig.js", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../patchworkConfig.js")
+  >("../../patchworkConfig.js");
+  return {
+    ...actual,
+    loadConfig: vi.fn(() => ({})),
+  };
+});
+
 vi.mock("../../connectors/linear.js", () => ({
   loadTokens: vi.fn(),
   listIssues: vi.fn(),

--- a/src/recipes/yamlRunner.ts
+++ b/src/recipes/yamlRunner.ts
@@ -35,6 +35,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { parse as parseYaml } from "yaml";
 import { captureFixture } from "../connectors/fixtureRecorder.js";
+import { loadConfig as loadPatchworkConfigSync } from "../patchworkConfig.js";
 import { findYamlRecipePath } from "../recipesHttp.js";
 import type { RecipeRunLog } from "../runLog.js";
 import {
@@ -1104,12 +1105,11 @@ function buildAgentExecutorDeps(
       return !probe.error;
     },
     loadPatchworkConfig: () => {
+      // Synchronous static import — earlier `require()` form silently failed
+      // under "type": "module" and returned {}, dropping config-driven
+      // model/driver preferences for no-driver agent steps.
       try {
-        // Lazy sync load — patchworkConfig exports a synchronous loadConfig.
-        // eslint-disable-next-line @typescript-eslint/no-require-imports
-        const { loadConfig } =
-          require("../patchworkConfig.js") as typeof import("../patchworkConfig.js");
-        return loadConfig();
+        return loadPatchworkConfigSync();
       } catch {
         return {};
       }


### PR DESCRIPTION
## Summary
- `buildAgentExecutorDeps.loadPatchworkConfig` used a lazy `require("../patchworkConfig.js")` inside a package marked `"type": "module"`. `require` is not defined under ESM, so the call always threw, the catch returned `{}`, and **config-driven `model` / `driver` preferences were silently dropped for no-driver agent steps** (e.g. `model: local` in `~/.patchwork/config.json` had no effect).
- Replaced with a static `import { loadConfig as loadPatchworkConfigSync } from "../patchworkConfig.js"`. No cycle (`patchworkConfig.ts` only type-imports from `adapters/index`).
- `yamlRunner.test.ts` now mocks `patchworkConfig.loadConfig` to return `{}`. Without this, the previously-broken require silently masked the developer's real `~/.patchwork/config.json`, and several default-model tests started failing once the static import actually loaded the real config.

Source: read-only platform health assessment, finding #2 (high correctness).

## Test plan
- [x] `vitest run src/recipes` — 497 pass
- [x] `tsc --noEmit` clean
- [x] `biome check` clean on touched files
- [ ] Manual: set `model: local` in `~/.patchwork/config.json` and run a no-driver agent recipe — verify `localFn` is invoked

🤖 Generated with [Claude Code](https://claude.com/claude-code)