### PR TITLE
ci: tighten release-workflow triggers to prevent cross-contamination

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -17,9 +17,26 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      # Promote :latest only for stable semver tags (no `-alpha`, `-beta`, `-rc`).
+      # Alpha tags publish only as `:<tag>` and `:alpha`, so `docker pull
+      # ghcr.io/.../claude-ide-bridge:latest` never silently lands on a
+      # prerelease build.
+      - name: Compute Docker tags
+        id: tags
+        run: |
+          REF="${{ github.ref_name }}"
+          TAGS="ghcr.io/oolab-labs/claude-ide-bridge:${REF}"
+          if [[ "$REF" =~ -(alpha|beta|rc) ]]; then
+            TAGS="${TAGS}"$'\n'"ghcr.io/oolab-labs/claude-ide-bridge:alpha"
+          else
+            TAGS="${TAGS}"$'\n'"ghcr.io/oolab-labs/claude-ide-bridge:latest"
+          fi
+          {
+            echo 'tags<<EOF'
+            echo "$TAGS"
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
       - uses: docker/build-push-action@v6
         with:
           push: true
-          tags: |
-            ghcr.io/oolab-labs/claude-ide-bridge:${{ github.ref_name }}
-            ghcr.io/oolab-labs/claude-ide-bridge:latest
+          tags: ${{ steps.tags.outputs.tags }}

--- a/.github/workflows/publish-extension.yml
+++ b/.github/workflows/publish-extension.yml
@@ -2,7 +2,12 @@ name: Publish Extension
 
 on:
   push:
-    tags: ['v*']
+    # Extension publishes are gated on `ext-v*` tags (the dispatch path below
+    # creates them). Listening on the bridge's `v*` tags would publish the
+    # extension on every Patchwork OS release, regardless of whether an
+    # extension change shipped — causing duplicate marketplace publishes /
+    # accidental releases.
+    tags: ['ext-v*']
   workflow_dispatch:
     inputs:
       bump:

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -47,6 +47,11 @@ jobs:
             --repo Oolab-labs/claude-ide-bridge
 
   publish:
+    # Stable publish runs only on manual workflow_dispatch. Without this guard
+    # an alpha tag push (`v*-alpha*`) would also trigger this job, which would
+    # then fail noisily because `inputs.bump` is unset on tag events — or, if
+    # ever edited, could publish a stable bump from an alpha tag.
+    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
Source: read-only platform health (second pass), items #1-#3.

Three release workflows had overly broad triggers that could publish the wrong artifacts on a tag push.

**publish-npm.yml** — stable `publish` job had no event guard. Alpha tag pushes (`v*-alpha*`) would trigger both jobs. `inputs.bump` is unset on tag events, so `publish` fails noisily today — and a future edit could accidentally publish/bump a stable release from an alpha tag. Fix: `if: github.event_name == 'workflow_dispatch'` on the stable job.

**publish-docker.yml** — every `v*` tag pushed `:latest`. A `v0.2.0-alpha.x` tag silently became `:latest`. Fix: compute tags conditionally — stable semver → `:<ref>` + `:latest`; `alpha`/`beta`/`rc` → `:<ref>` + `:alpha`.

**publish-extension.yml** — listened on root `v*` tags, so a bridge release also published the extension even when no extension change shipped. Fix: trigger on `ext-v*` tags only.

## Test plan
- [x] All three YAML files parse OK
- [ ] Next alpha tag push: only `publish-alpha` runs; `:latest` not updated; extension workflow does not trigger
- [ ] Next stable `workflow_dispatch`: `publish` runs; `:latest` updates
- [ ] Next `ext-v*` tag: extension publishes

🤖 Generated with [Claude Code](https://claude.com/claude-code)