### PR TITLE
fix(dashboard): post-merge regressions + a11y hardening

### DIFF
--- a/dashboard/src/app/approvals/[callId]/page.tsx
+++ b/dashboard/src/app/approvals/[callId]/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 import Link from "next/link";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { apiPath } from '@/lib/api';
 import { relTime } from "@/components/time";
 import { useBridgeFetch } from "@/hooks/useBridgeFetch";
@@ -137,10 +137,17 @@ export default function ApprovalDetailPage() {
   const [decideErr, setDecideErr] = useState<string | null>(null);
   const [deciding, setDeciding] = useState<"approve" | "reject" | null>(null);
 
+  // Stop polling once a decision arrives — page is in a terminal state.
+  // We need the most recent value to gate the hook, so we read it via a
+  // separate ref-like state rather than letting `useBridgeFetch` run forever.
+  const [hasDecision, setHasDecision] = useState(false);
   const { data, error, loading, status } = useBridgeFetch<DetailResponse>(
     `/api/bridge/approvals/${callId}`,
-    { intervalMs: 2000 },
+    { intervalMs: 2000, enabled: !hasDecision },
   );
+  useEffect(() => {
+    if (data?.decision) setHasDecision(true);
+  }, [data?.decision]);
   const { data: bridgeStatus } = useBridgeFetch<BridgeStatus>(
     "/api/bridge/status",
     { intervalMs: 5000 },

--- a/dashboard/src/app/approvals/[callId]/page.tsx
+++ b/dashboard/src/app/approvals/[callId]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 import Link from "next/link";
-import { useParams, useRouter } from "next/navigation";
+import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { useState } from "react";
 import { apiPath } from '@/lib/api';
 import { relTime } from "@/components/time";
@@ -131,8 +131,11 @@ function explainMatch(
 export default function ApprovalDetailPage() {
   const params = useParams<{ callId: string }>();
   const router = useRouter();
+  const search = useSearchParams();
   const callId = params.callId;
+  const approvalToken = search.get("approvalToken") ?? undefined;
   const [decideErr, setDecideErr] = useState<string | null>(null);
+  const [deciding, setDeciding] = useState<"approve" | "reject" | null>(null);
 
   const { data, error, loading, status } = useBridgeFetch<DetailResponse>(
     `/api/bridge/approvals/${callId}`,
@@ -144,18 +147,33 @@ export default function ApprovalDetailPage() {
   );
 
   async function decide(choice: "approve" | "reject") {
+    if (deciding) return;
     setDecideErr(null);
+    setDeciding(choice);
     try {
+      const headers: Record<string, string> = {};
+      if (approvalToken) {
+        headers.Authorization = `Bearer ${approvalToken}`;
+      }
       const res = await fetch(apiPath(`/api/bridge/${choice}/${callId}`), {
         method: "POST",
+        headers,
       });
       if (!res.ok) {
-        setDecideErr(`${choice} failed: ${res.status}`);
+        let detail = "";
+        try {
+          detail = (await res.text()).slice(0, 200);
+        } catch {}
+        setDecideErr(
+          `${choice} failed: ${res.status}${detail ? ` — ${detail}` : ""}`,
+        );
         return;
       }
       router.push("/approvals");
     } catch (e) {
       setDecideErr(e instanceof Error ? e.message : String(e));
+    } finally {
+      setDeciding(null);
     }
   }
 
@@ -288,15 +306,19 @@ export default function ApprovalDetailPage() {
               type="button"
               className="btn success"
               onClick={() => decide("approve")}
+              disabled={deciding !== null}
+              aria-busy={deciding === "approve"}
             >
-              Approve
+              {deciding === "approve" ? "Approving…" : "Approve"}
             </button>
             <button
               type="button"
               className="btn danger"
               onClick={() => decide("reject")}
+              disabled={deciding !== null}
+              aria-busy={deciding === "reject"}
             >
-              Reject
+              {deciding === "reject" ? "Rejecting…" : "Reject"}
             </button>
             <span className="approval-spacer" />
             <Link href="/approvals" className="btn sm ghost" style={{ textDecoration: "none" }}>

--- a/dashboard/src/app/approvals/page.tsx
+++ b/dashboard/src/app/approvals/page.tsx
@@ -243,6 +243,7 @@ interface ApprovalCardProps {
   isSelected: boolean;
   onToggleSelect: (callId: string) => void;
   fadingOut: boolean;
+  isKeyboardFocused?: boolean;
 }
 
 function ApprovalCard({
@@ -254,6 +255,7 @@ function ApprovalCard({
   isSelected,
   onToggleSelect,
   fadingOut,
+  isKeyboardFocused = false,
 }: ApprovalCardProps) {
   const [approving, setApproving] = useState(false);
   const [rejecting, setRejecting] = useState(false);
@@ -284,15 +286,25 @@ function ApprovalCard({
   const codeLines = commandPreview(p.toolName, p.params ?? {}).split("\n");
   const icon = toolIcon(p.toolName);
 
+  const cardRef = useRef<HTMLElement | null>(null);
+  useEffect(() => {
+    if (isKeyboardFocused && cardRef.current) {
+      cardRef.current.scrollIntoView({ block: "nearest", behavior: "smooth" });
+    }
+  }, [isKeyboardFocused]);
+
   return (
     <article
+      ref={cardRef}
       className="card"
       style={{
         opacity: fadingOut ? 0 : 1,
         transform: fadingOut ? "translateY(-4px)" : "translateY(0)",
-        transition: "opacity 300ms ease, transform 300ms ease",
+        transition: "opacity 300ms ease, transform 300ms ease, box-shadow 150ms ease, border-color 150ms ease",
         padding: "16px 18px",
         marginBottom: "var(--s-3)",
+        outline: isKeyboardFocused ? "2px solid var(--accent)" : "none",
+        outlineOffset: isKeyboardFocused ? 2 : 0,
       }}
     >
       <div style={{ display: "flex", alignItems: "flex-start", gap: 12 }}>
@@ -468,7 +480,7 @@ function ApprovalCard({
         <button
           type="button"
           className="btn primary"
-          style={{ background: "var(--green, #16a34a)", borderColor: "var(--green, #16a34a)", color: "#fff", display: "inline-flex", alignItems: "center", gap: 6 }}
+          style={{ background: "var(--green)", borderColor: "var(--green)", color: "#fff", display: "inline-flex", alignItems: "center", gap: 6 }}
           onClick={() => handleDecide("approve")}
           disabled={approving || rejecting}
           aria-label={`Approve ${p.toolName}`}
@@ -620,6 +632,9 @@ function ApprovalsContent() {
   const [batchApproving, setBatchApproving] = useState(false);
   const [batchRejecting, setBatchRejecting] = useState(false);
   const [batchErr, setBatchErr] = useState<string | null>(null);
+  const [focusIndex, setFocusIndex] = useState(0);
+  const [announcement, setAnnouncement] = useState("");
+  const inFlightRef = useRef<Set<string>>(new Set());
   const { patterns, clearPatterns } = useApprovalPatterns();
 
   useEffect(() => {
@@ -809,6 +824,59 @@ function ApprovalsContent() {
     setDismissed((prev) => new Set([...prev, toolName]));
   }, []);
 
+  // Clamp focus index when the visible list shrinks.
+  useEffect(() => {
+    setFocusIndex((i) => {
+      if (filtered.length === 0) return 0;
+      return Math.min(i, filtered.length - 1);
+    });
+  }, [filtered.length]);
+
+  // J/K/E/X keyboard shortcuts. Skip when typing in inputs.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      const t = e.target as HTMLElement | null;
+      if (!t) return;
+      const tag = t.tagName;
+      if (
+        tag === "INPUT" ||
+        tag === "TEXTAREA" ||
+        tag === "SELECT" ||
+        t.isContentEditable
+      )
+        return;
+      if (e.metaKey || e.ctrlKey || e.altKey) return;
+      if (filtered.length === 0) return;
+
+      const key = e.key.toLowerCase();
+      if (key === "j" || e.key === "ArrowDown") {
+        e.preventDefault();
+        setFocusIndex((i) => Math.min(i + 1, filtered.length - 1));
+      } else if (key === "k" || e.key === "ArrowUp") {
+        e.preventDefault();
+        setFocusIndex((i) => Math.max(i - 1, 0));
+      } else if (key === "e" || key === "x") {
+        const target = filtered[focusIndex];
+        if (!target) return;
+        if (inFlightRef.current.has(target.callId)) return;
+        e.preventDefault();
+        const choice = key === "e" ? "approve" : "reject";
+        const verb = key === "e" ? "Approved" : "Rejected";
+        inFlightRef.current.add(target.callId);
+        decide(target.callId, choice)
+          .then(() => setAnnouncement(`${verb} ${target.toolName}`))
+          .catch((err: unknown) =>
+            setAnnouncement(
+              `${choice} failed: ${err instanceof Error ? err.message : String(err)}`,
+            ),
+          )
+          .finally(() => inFlightRef.current.delete(target.callId));
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [filtered, focusIndex]);
+
   const copyRule = useCallback((toolName: string) => {
     const snippet = JSON.stringify({ allow: [toolName] }, null, 2);
     navigator.clipboard.writeText(snippet).then(() => {
@@ -848,6 +916,25 @@ function ApprovalsContent() {
       `}</style>
 
       <DecisionsTabs pendingCount={pending.length} />
+
+      <div
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+        style={{
+          position: "absolute",
+          width: 1,
+          height: 1,
+          padding: 0,
+          margin: -1,
+          overflow: "hidden",
+          clip: "rect(0,0,0,0)",
+          whiteSpace: "nowrap",
+          border: 0,
+        }}
+      >
+        {announcement}
+      </div>
 
       <div className="page-head">
         <div>
@@ -1130,7 +1217,7 @@ function ApprovalsContent() {
           )}
 
           <div className="approval-list">
-            {filtered.map((p) => (
+            {filtered.map((p, idx) => (
               <ApprovalCard
                 key={p.callId}
                 p={p}
@@ -1141,6 +1228,7 @@ function ApprovalsContent() {
                 isSelected={selected.has(p.callId)}
                 onToggleSelect={toggleSelect}
                 fadingOut={fadingOut.has(p.callId)}
+                isKeyboardFocused={idx === focusIndex}
               />
             ))}
           </div>

--- a/dashboard/src/app/connections/asana/callback/page.tsx
+++ b/dashboard/src/app/connections/asana/callback/page.tsx
@@ -1,53 +1,5 @@
-"use client";
-
-import { Suspense, useEffect, useRef } from "react";
-import { apiPath } from '@/lib/api';
-import { useRouter, useSearchParams } from "next/navigation";
-
-function AsanaCallbackInner() {
-  const params = useSearchParams();
-  const router = useRouter();
-  const called = useRef(false);
-
-  useEffect(() => {
-    if (called.current) return;
-    called.current = true;
-
-    const code = params.get("code");
-    const state = params.get("state");
-    const error = params.get("error");
-
-    const qs = new URLSearchParams();
-    if (code) qs.set("code", code);
-    if (state) qs.set("state", state);
-    if (error) qs.set("error", error);
-
-    fetch(apiPath(`/api/connections/asana/callback?${qs.toString()}`))
-      .then((r) => r.json())
-      .then(() => {
-        if (window.opener) {
-          window.opener.postMessage("patchwork:asana:connected", window.location.origin);
-          window.close();
-        } else {
-          router.push("/connections");
-        }
-      })
-      .catch(() => router.push("/connections"));
-  }, [params, router]);
-
-  return <p>Connecting Asana…</p>;
-}
+import { OAuthCallback } from "@/components/OAuthCallback";
 
 export default function AsanaCallbackPage() {
-  return (
-    <div style={{
-      display: "flex", alignItems: "center", justifyContent: "center",
-      minHeight: "100vh", background: "#040406", color: "#e0e0e0",
-      fontFamily: "system-ui, sans-serif",
-    }}>
-      <Suspense fallback={<p>Loading…</p>}>
-        <AsanaCallbackInner />
-      </Suspense>
-    </div>
-  );
+  return <OAuthCallback provider={{ id: "asana", label: "Asana" }} />;
 }

--- a/dashboard/src/app/connections/discord/callback/page.tsx
+++ b/dashboard/src/app/connections/discord/callback/page.tsx
@@ -1,53 +1,5 @@
-"use client";
-
-import { Suspense, useEffect, useRef } from "react";
-import { apiPath } from '@/lib/api';
-import { useRouter, useSearchParams } from "next/navigation";
-
-function DiscordCallbackInner() {
-  const params = useSearchParams();
-  const router = useRouter();
-  const called = useRef(false);
-
-  useEffect(() => {
-    if (called.current) return;
-    called.current = true;
-
-    const code = params.get("code");
-    const state = params.get("state");
-    const error = params.get("error");
-
-    const qs = new URLSearchParams();
-    if (code) qs.set("code", code);
-    if (state) qs.set("state", state);
-    if (error) qs.set("error", error);
-
-    fetch(apiPath(`/api/connections/discord/callback?${qs.toString()}`))
-      .then((r) => r.json())
-      .then(() => {
-        if (window.opener) {
-          window.opener.postMessage("patchwork:discord:connected", window.location.origin);
-          window.close();
-        } else {
-          router.push("/connections");
-        }
-      })
-      .catch(() => router.push("/connections"));
-  }, [params, router]);
-
-  return <p>Connecting Discord…</p>;
-}
+import { OAuthCallback } from "@/components/OAuthCallback";
 
 export default function DiscordCallbackPage() {
-  return (
-    <div style={{
-      display: "flex", alignItems: "center", justifyContent: "center",
-      minHeight: "100vh", background: "#040406", color: "#e0e0e0",
-      fontFamily: "system-ui, sans-serif",
-    }}>
-      <Suspense fallback={<p>Loading…</p>}>
-        <DiscordCallbackInner />
-      </Suspense>
-    </div>
-  );
+  return <OAuthCallback provider={{ id: "discord", label: "Discord" }} />;
 }

--- a/dashboard/src/app/connections/gitlab/callback/page.tsx
+++ b/dashboard/src/app/connections/gitlab/callback/page.tsx
@@ -1,53 +1,5 @@
-"use client";
-
-import { Suspense, useEffect, useRef } from "react";
-import { apiPath } from '@/lib/api';
-import { useRouter, useSearchParams } from "next/navigation";
-
-function GitLabCallbackInner() {
-  const params = useSearchParams();
-  const router = useRouter();
-  const called = useRef(false);
-
-  useEffect(() => {
-    if (called.current) return;
-    called.current = true;
-
-    const code = params.get("code");
-    const state = params.get("state");
-    const error = params.get("error");
-
-    const qs = new URLSearchParams();
-    if (code) qs.set("code", code);
-    if (state) qs.set("state", state);
-    if (error) qs.set("error", error);
-
-    fetch(apiPath(`/api/connections/gitlab/callback?${qs.toString()}`))
-      .then((r) => r.json())
-      .then(() => {
-        if (window.opener) {
-          window.opener.postMessage("patchwork:gitlab:connected", window.location.origin);
-          window.close();
-        } else {
-          router.push("/connections");
-        }
-      })
-      .catch(() => router.push("/connections"));
-  }, [params, router]);
-
-  return <p>Connecting GitLab…</p>;
-}
+import { OAuthCallback } from "@/components/OAuthCallback";
 
 export default function GitLabCallbackPage() {
-  return (
-    <div style={{
-      display: "flex", alignItems: "center", justifyContent: "center",
-      minHeight: "100vh", background: "#040406", color: "#e0e0e0",
-      fontFamily: "system-ui, sans-serif",
-    }}>
-      <Suspense fallback={<p>Loading…</p>}>
-        <GitLabCallbackInner />
-      </Suspense>
-    </div>
-  );
+  return <OAuthCallback provider={{ id: "gitlab", label: "GitLab" }} />;
 }

--- a/dashboard/src/app/connections/gmail/callback/page.tsx
+++ b/dashboard/src/app/connections/gmail/callback/page.tsx
@@ -1,53 +1,5 @@
-"use client";
-
-import { Suspense, useEffect, useRef } from "react";
-import { apiPath } from '@/lib/api';
-import { useRouter, useSearchParams } from "next/navigation";
-
-function GmailCallbackInner() {
-  const params = useSearchParams();
-  const router = useRouter();
-  const called = useRef(false);
-
-  useEffect(() => {
-    if (called.current) return;
-    called.current = true;
-
-    const code = params.get("code");
-    const state = params.get("state");
-    const error = params.get("error");
-
-    const qs = new URLSearchParams();
-    if (code) qs.set("code", code);
-    if (state) qs.set("state", state);
-    if (error) qs.set("error", error);
-
-    fetch(apiPath(`/api/connections/gmail/callback?${qs.toString()}`))
-      .then((r) => r.json())
-      .then(() => {
-        if (window.opener) {
-          window.opener.postMessage("patchwork:gmail:connected", window.location.origin);
-          window.close();
-        } else {
-          router.push("/connections");
-        }
-      })
-      .catch(() => router.push("/connections"));
-  }, [params, router]);
-
-  return <p>Connecting Gmail…</p>;
-}
+import { OAuthCallback } from "@/components/OAuthCallback";
 
 export default function GmailCallbackPage() {
-  return (
-    <div style={{
-      display: "flex", alignItems: "center", justifyContent: "center",
-      minHeight: "100vh", background: "#040406", color: "#e0e0e0",
-      fontFamily: "system-ui, sans-serif",
-    }}>
-      <Suspense fallback={<p>Loading…</p>}>
-        <GmailCallbackInner />
-      </Suspense>
-    </div>
-  );
+  return <OAuthCallback provider={{ id: "gmail", label: "Gmail" }} />;
 }

--- a/dashboard/src/app/connections/google-calendar/callback/page.tsx
+++ b/dashboard/src/app/connections/google-calendar/callback/page.tsx
@@ -1,62 +1,9 @@
-"use client";
-
-import { Suspense, useEffect, useRef } from "react";
-import { apiPath } from '@/lib/api';
-import { useRouter, useSearchParams } from "next/navigation";
-
-function CalendarCallbackInner() {
-  const params = useSearchParams();
-  const router = useRouter();
-  const called = useRef(false);
-
-  useEffect(() => {
-    if (called.current) return;
-    called.current = true;
-
-    const code = params.get("code");
-    const state = params.get("state");
-    const error = params.get("error");
-
-    const qs = new URLSearchParams();
-    if (code) qs.set("code", code);
-    if (state) qs.set("state", state);
-    if (error) qs.set("error", error);
-
-    fetch(apiPath(`/api/connections/google-calendar/callback?${qs.toString()}`))
-      .then((r) => r.json())
-      .then(() => {
-        if (window.opener) {
-          window.opener.postMessage(
-            "patchwork:google-calendar:connected",
-            window.location.origin,
-          );
-          window.close();
-        } else {
-          router.push("/connections");
-        }
-      })
-      .catch(() => router.push("/connections"));
-  }, [params, router]);
-
-  return <p>Connecting Google Calendar…</p>;
-}
+import { OAuthCallback } from "@/components/OAuthCallback";
 
 export default function CalendarCallbackPage() {
   return (
-    <div
-      style={{
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
-        minHeight: "100vh",
-        background: "#040406",
-        color: "#e0e0e0",
-        fontFamily: "system-ui, sans-serif",
-      }}
-    >
-      <Suspense fallback={<p>Loading…</p>}>
-        <CalendarCallbackInner />
-      </Suspense>
-    </div>
+    <OAuthCallback
+      provider={{ id: "google-calendar", label: "Google Calendar" }}
+    />
   );
 }

--- a/dashboard/src/app/connections/google-drive/callback/page.tsx
+++ b/dashboard/src/app/connections/google-drive/callback/page.tsx
@@ -1,62 +1,7 @@
-"use client";
-
-import { Suspense, useEffect, useRef } from "react";
-import { apiPath } from "@/lib/api";
-import { useRouter, useSearchParams } from "next/navigation";
-
-function DriveCallbackInner() {
-  const params = useSearchParams();
-  const router = useRouter();
-  const called = useRef(false);
-
-  useEffect(() => {
-    if (called.current) return;
-    called.current = true;
-
-    const code = params.get("code");
-    const state = params.get("state");
-    const error = params.get("error");
-
-    const qs = new URLSearchParams();
-    if (code) qs.set("code", code);
-    if (state) qs.set("state", state);
-    if (error) qs.set("error", error);
-
-    fetch(apiPath(`/api/connections/google-drive/callback?${qs.toString()}`))
-      .then((r) => r.json())
-      .then(() => {
-        if (window.opener) {
-          window.opener.postMessage(
-            "patchwork:google-drive:connected",
-            window.location.origin,
-          );
-          window.close();
-        } else {
-          router.push("/connections");
-        }
-      })
-      .catch(() => router.push("/connections"));
-  }, [params, router]);
-
-  return <p>Connecting Google Drive…</p>;
-}
+import { OAuthCallback } from "@/components/OAuthCallback";
 
 export default function DriveCallbackPage() {
   return (
-    <div
-      style={{
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
-        minHeight: "100vh",
-        background: "#040406",
-        color: "#e0e0e0",
-        fontFamily: "system-ui, sans-serif",
-      }}
-    >
-      <Suspense fallback={<p>Loading…</p>}>
-        <DriveCallbackInner />
-      </Suspense>
-    </div>
+    <OAuthCallback provider={{ id: "google-drive", label: "Google Drive" }} />
   );
 }

--- a/dashboard/src/app/connections/page.tsx
+++ b/dashboard/src/app/connections/page.tsx
@@ -2,6 +2,7 @@
 import { useEffect, useRef, useState } from "react";
 import { apiPath } from "@/lib/api";
 import AddConnectionModal from "./AddConnectionModal";
+import { Dialog } from "@/components/Dialog";
 
 interface ConnectorStatus {
   id: string;
@@ -573,14 +574,14 @@ function ConnectorGridCard({ def, statusEntry, onConnect, onDisconnect, onTest, 
   const borderColor = isDegraded
     ? "var(--warn)"
     : isConnected
-    ? "rgba(34,197,94,0.35)"
+    ? "var(--ok)"
     : "var(--border-default)";
 
   return (
     <div
       className="card beam"
       style={{
-        background: isDegraded ? "rgba(234,179,8,0.03)" : undefined,
+        background: isDegraded ? "var(--warn-soft)" : undefined,
         borderColor: borderColor,
         display: "flex",
         flexDirection: "column",
@@ -608,8 +609,8 @@ function ConnectorGridCard({ def, statusEntry, onConnect, onDisconnect, onTest, 
           <div style={{
             display: "inline-flex", alignItems: "center", gap: 5,
             padding: "3px 9px", borderRadius: 999,
-            background: "rgba(34,197,94,0.10)", border: "1px solid rgba(34,197,94,0.22)",
-            fontSize: 10, fontWeight: 700, color: "#15803d",
+            background: "var(--ok-soft)", border: "1px solid var(--ok)",
+            fontSize: 10, fontWeight: 700, color: "var(--ok)",
             textTransform: "uppercase", letterSpacing: "0.07em",
             marginBottom: 10,
           }}>
@@ -619,8 +620,8 @@ function ConnectorGridCard({ def, statusEntry, onConnect, onDisconnect, onTest, 
           <div style={{
             display: "inline-flex", alignItems: "center", gap: 5,
             padding: "3px 9px", borderRadius: 999,
-            background: "rgba(234,179,8,0.10)", border: "1px solid rgba(234,179,8,0.28)",
-            fontSize: 10, fontWeight: 700, color: "#92400e",
+            background: "var(--warn-soft)", border: "1px solid var(--warn)",
+            fontSize: 10, fontWeight: 700, color: "var(--warn)",
             textTransform: "uppercase", letterSpacing: "0.07em",
             marginBottom: 10,
           }}>
@@ -692,16 +693,16 @@ function ConnectorGridCard({ def, statusEntry, onConnect, onDisconnect, onTest, 
       {(isConnected || isDegraded) && (
         <div
           style={{
-            borderTop: `1px solid ${isDegraded ? "rgba(234,179,8,0.18)" : "var(--border-default)"}`,
+            borderTop: `1px solid ${isDegraded ? "var(--warn)" : "var(--border-default)"}`,
             padding: "9px 14px",
             display: "flex",
             alignItems: "center",
             justifyContent: "space-between",
-            background: isDegraded ? "rgba(234,179,8,0.03)" : "rgba(0,0,0,0.012)",
+            background: isDegraded ? "var(--warn-soft)" : "rgba(0,0,0,0.012)",
             gap: 6,
           }}
         >
-          <div style={{ display: "flex", alignItems: "center", gap: 5, fontSize: 12, color: isDegraded ? "#92400e" : "var(--ink-2)", minWidth: 0, overflow: "hidden" }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 5, fontSize: 12, color: isDegraded ? "var(--warn)" : "var(--ink-2)", minWidth: 0, overflow: "hidden" }}>
             <span
               style={{
                 width: 6, height: 6, borderRadius: "50%",
@@ -778,8 +779,8 @@ function ConnectorGridCard({ def, statusEntry, onConnect, onDisconnect, onTest, 
               style={{
                 fontSize: 11, fontWeight: 500, padding: "3px 9px",
                 borderRadius: 5, border: "none",
-                background: isDegraded ? "rgba(234,179,8,0.14)" : "rgba(239,68,68,0.09)",
-                color: isDegraded ? "#92400e" : "#dc2626",
+                background: isDegraded ? "var(--warn-soft)" : "var(--err-soft)",
+                color: isDegraded ? "var(--warn)" : "var(--err)",
                 cursor: loading ? "wait" : "pointer",
                 opacity: loading ? 0.55 : 1,
               }}
@@ -834,7 +835,7 @@ function RecentCard({ def, lastSync }: { def: ConnectorDef; lastSync: string }) 
       <LogoTile def={def} size={40} />
       <div>
         <div style={{ fontWeight: 700, fontSize: 13, color: "var(--ink-0)" }}>{def.name}</div>
-        <div style={{ fontSize: 11, color: "#16a34a", marginTop: 2, fontWeight: 500 }}>
+        <div style={{ fontSize: 11, color: "var(--ok)", marginTop: 2, fontWeight: 500 }}>
           ✓ {relativeTime(lastSync)}
         </div>
       </div>
@@ -1180,76 +1181,78 @@ export default function ConnectionsPage() {
       )}
 
       {/* Notion token-paste modal */}
-      {notionModalOpen && (
-        <div
-          style={{ position: "fixed", inset: 0, zIndex: 50, background: "rgba(0,0,0,0.5)", display: "flex", alignItems: "center", justifyContent: "center" }}
-          onClick={(e) => { if (e.target === e.currentTarget) { setNotionModalOpen(false); setNotionToken(""); setNotionErr(null); } }}
-        >
-          <div className="card" style={{ width: "100%", maxWidth: 420, padding: 24, display: "flex", flexDirection: "column", gap: 16 }}>
-            <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
-              <IconNotion />
-              <strong style={{ fontSize: 15 }}>Connect Notion</strong>
-            </div>
-            <p style={{ fontSize: 13, color: "var(--fg-2)", margin: 0 }}>
-              Create an internal integration at{" "}
-              <a href="https://www.notion.so/my-integrations" target="_blank" rel="noreferrer" style={{ color: "var(--info)" }}>
-                notion.so/my-integrations
-              </a>
-              , copy the integration token, and paste it below. Then share your databases/pages with the integration inside Notion.
-            </p>
-            <input
-              type="password"
-              autoFocus
-              placeholder="secret_..."
-              value={notionToken}
-              onChange={(e) => setNotionToken(e.target.value)}
-              onKeyDown={(e) => { if (e.key === "Enter") void handleNotionConnect(); }}
-              style={{ fontFamily: "var(--font-mono)", fontSize: 13, padding: "8px 12px", borderRadius: 6, border: "1px solid var(--border-subtle)", background: "var(--bg-0)", color: "var(--fg-1)", width: "100%", boxSizing: "border-box" }}
-            />
-            {notionErr && <div className="alert-err" style={{ fontSize: 12 }}>{notionErr}</div>}
-            <div style={{ display: "flex", gap: 8, justifyContent: "flex-end" }}>
-              <button
-                onClick={() => { setNotionModalOpen(false); setNotionToken(""); setNotionErr(null); }}
-                style={{ padding: "6px 16px", fontSize: 13, cursor: "pointer", borderRadius: 6, border: "1px solid var(--border-subtle)", background: "var(--bg-1)", color: "var(--fg-1)" }}
-              >
-                Cancel
-              </button>
-              <button
-                onClick={() => void handleNotionConnect()}
-                disabled={notionConnecting || !notionToken}
-                style={{ padding: "6px 16px", fontSize: 13, cursor: notionConnecting ? "wait" : "pointer", borderRadius: 6, border: "none", background: "var(--fg-1)", color: "var(--bg-0)", opacity: !notionToken ? 0.5 : 1 }}
-              >
-                {notionConnecting ? "Connecting…" : "Connect"}
-              </button>
-            </div>
+      <Dialog
+        open={notionModalOpen}
+        onClose={() => { setNotionModalOpen(false); setNotionToken(""); setNotionErr(null); }}
+        ariaLabelledBy="notion-modal-title"
+        maxWidth={420}
+      >
+        <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+            <IconNotion />
+            <strong id="notion-modal-title" style={{ fontSize: 15 }}>Connect Notion</strong>
+          </div>
+          <p style={{ fontSize: 13, color: "var(--fg-2)", margin: 0 }}>
+            Create an internal integration at{" "}
+            <a href="https://www.notion.so/my-integrations" target="_blank" rel="noreferrer" style={{ color: "var(--info)" }}>
+              notion.so/my-integrations
+            </a>
+            , copy the integration token, and paste it below. Then share your databases/pages with the integration inside Notion.
+          </p>
+          <input
+            type="password"
+            placeholder="secret_..."
+            value={notionToken}
+            onChange={(e) => setNotionToken(e.target.value)}
+            onKeyDown={(e) => { if (e.key === "Enter") void handleNotionConnect(); }}
+            style={{ fontFamily: "var(--font-mono)", fontSize: 13, padding: "8px 12px", borderRadius: 6, border: "1px solid var(--border-subtle)", background: "var(--bg-0)", color: "var(--fg-1)", width: "100%", boxSizing: "border-box" }}
+          />
+          {notionErr && <div className="alert-err" role="alert" style={{ fontSize: 12 }}>{notionErr}</div>}
+          <div style={{ display: "flex", gap: 8, justifyContent: "flex-end" }}>
+            <button
+              type="button"
+              onClick={() => { setNotionModalOpen(false); setNotionToken(""); setNotionErr(null); }}
+              style={{ padding: "6px 16px", fontSize: 13, cursor: "pointer", borderRadius: 6, border: "1px solid var(--border-subtle)", background: "var(--bg-1)", color: "var(--fg-1)" }}
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={() => void handleNotionConnect()}
+              disabled={notionConnecting || !notionToken}
+              style={{ padding: "6px 16px", fontSize: 13, cursor: notionConnecting ? "wait" : "pointer", borderRadius: 6, border: "none", background: "var(--fg-1)", color: "var(--bg-0)", opacity: !notionToken ? 0.5 : 1 }}
+            >
+              {notionConnecting ? "Connecting…" : "Connect"}
+            </button>
           </div>
         </div>
-      )}
+      </Dialog>
 
       {/* Generic token-paste modal */}
-      {tokenModal && TOKEN_MODAL_CONNECTORS[tokenModal] && (
-        <div
-          style={{ position: "fixed", inset: 0, zIndex: 50, background: "rgba(0,0,0,0.5)", display: "flex", alignItems: "center", justifyContent: "center" }}
-          onClick={(e) => { if (e.target === e.currentTarget) { setTokenModal(null); setTokenValue(""); setTokenErr(null); } }}
-        >
-          <div className="card" style={{ width: "100%", maxWidth: 440, padding: 24, display: "flex", flexDirection: "column", gap: 16 }}>
+      <Dialog
+        open={Boolean(tokenModal && TOKEN_MODAL_CONNECTORS[tokenModal])}
+        onClose={() => { setTokenModal(null); setTokenValue(""); setTokenErr(null); }}
+        ariaLabelledBy="token-modal-title"
+        maxWidth={440}
+      >
+        {tokenModal && TOKEN_MODAL_CONNECTORS[tokenModal] && (
+          <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
             <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
               {TOKEN_MODAL_CONNECTORS[tokenModal].icon}
-              <strong style={{ fontSize: 15 }}>Connect {TOKEN_MODAL_CONNECTORS[tokenModal].name}</strong>
+              <strong id="token-modal-title" style={{ fontSize: 15 }}>Connect {TOKEN_MODAL_CONNECTORS[tokenModal].name}</strong>
             </div>
             <p style={{ fontSize: 13, color: "var(--fg-2)", margin: 0, lineHeight: 1.6 }}>
               {TOKEN_MODAL_CONNECTORS[tokenModal].instructions}
             </p>
             <input
               type="password"
-              autoFocus
               placeholder={TOKEN_MODAL_CONNECTORS[tokenModal].placeholder}
               value={tokenValue}
               onChange={(e) => setTokenValue(e.target.value)}
               onKeyDown={(e) => { if (e.key === "Enter") void handleTokenConnect(); }}
               style={{ fontFamily: "var(--font-mono)", fontSize: 13, padding: "8px 12px", borderRadius: 6, border: "1px solid var(--border-subtle)", background: "var(--bg-0)", color: "var(--fg-1)", width: "100%", boxSizing: "border-box" }}
             />
-            {tokenErr && <div className="alert-err" style={{ fontSize: 12 }}>{tokenErr}</div>}
+            {tokenErr && <div className="alert-err" role="alert" style={{ fontSize: 12 }}>{tokenErr}</div>}
             <div style={{ display: "flex", gap: 8, justifyContent: "flex-end" }}>
               <button
                 type="button"
@@ -1268,8 +1271,8 @@ export default function ConnectionsPage() {
               </button>
             </div>
           </div>
-        </div>
-      )}
+        )}
+      </Dialog>
 
       <AddConnectionModal
         open={modalOpen}

--- a/dashboard/src/app/connections/slack/callback/page.tsx
+++ b/dashboard/src/app/connections/slack/callback/page.tsx
@@ -1,53 +1,5 @@
-"use client";
-
-import { Suspense, useEffect, useRef } from "react";
-import { apiPath } from '@/lib/api';
-import { useRouter, useSearchParams } from "next/navigation";
-
-function SlackCallbackInner() {
-  const params = useSearchParams();
-  const router = useRouter();
-  const called = useRef(false);
-
-  useEffect(() => {
-    if (called.current) return;
-    called.current = true;
-
-    const code = params.get("code");
-    const state = params.get("state");
-    const error = params.get("error");
-
-    const qs = new URLSearchParams();
-    if (code) qs.set("code", code);
-    if (state) qs.set("state", state);
-    if (error) qs.set("error", error);
-
-    fetch(apiPath(`/api/connections/slack/callback?${qs.toString()}`))
-      .then((r) => r.json())
-      .then(() => {
-        if (window.opener) {
-          window.opener.postMessage("patchwork:slack:connected", window.location.origin);
-          window.close();
-        } else {
-          router.push("/connections");
-        }
-      })
-      .catch(() => router.push("/connections"));
-  }, [params, router]);
-
-  return <p>Connecting Slack…</p>;
-}
+import { OAuthCallback } from "@/components/OAuthCallback";
 
 export default function SlackCallbackPage() {
-  return (
-    <div style={{
-      display: "flex", alignItems: "center", justifyContent: "center",
-      minHeight: "100vh", background: "#040406", color: "#e0e0e0",
-      fontFamily: "system-ui, sans-serif",
-    }}>
-      <Suspense fallback={<p>Loading…</p>}>
-        <SlackCallbackInner />
-      </Suspense>
-    </div>
-  );
+  return <OAuthCallback provider={{ id: "slack", label: "Slack" }} />;
 }

--- a/dashboard/src/app/decisions/page.tsx
+++ b/dashboard/src/app/decisions/page.tsx
@@ -157,14 +157,48 @@ function DecisionsContent() {
             <LivePill label="5s" tone="muted" />
           </div>
         </div>
-        <input
-          type="text"
-          value={textQuery}
-          onChange={(e) => setTextQuery(e.target.value)}
-          placeholder="Search problems & solutions…"
-          className="input"
-          style={{ minWidth: 280, width: 320 }}
-        />
+        <div style={{ display: "flex", gap: 8, flexWrap: "wrap", alignItems: "center" }}>
+          <label style={{ display: "flex", flexDirection: "column", gap: 2 }}>
+            <span className="visually-hidden" style={{ position: "absolute", width: 1, height: 1, overflow: "hidden", clip: "rect(0,0,0,0)" }}>
+              Search decisions
+            </span>
+            <input
+              type="text"
+              value={textQuery}
+              onChange={(e) => setTextQuery(e.target.value)}
+              placeholder="Search problems & solutions…"
+              className="input"
+              aria-label="Search decisions"
+              style={{ minWidth: 240, width: 280 }}
+            />
+          </label>
+          <label style={{ display: "flex", flexDirection: "column", gap: 2 }}>
+            <input
+              type="text"
+              value={keyQuery}
+              onChange={(e) => setKeyQuery(e.target.value)}
+              placeholder="Filter by ref (e.g. PR-42)"
+              className="input"
+              aria-label="Filter by ref"
+              style={{ minWidth: 160, width: 180, fontFamily: "var(--font-mono)" }}
+            />
+          </label>
+          <label style={{ display: "flex", flexDirection: "column", gap: 2 }}>
+            <select
+              value={since}
+              onChange={(e) => setSince(e.target.value as SinceFilter)}
+              className="input"
+              aria-label="Time window"
+              style={{ width: "auto", cursor: "pointer" }}
+            >
+              {SINCE_OPTIONS.map((o) => (
+                <option key={o.k} value={o.k}>
+                  {o.label}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
       </div>
 
       {allTags.length > 0 && (
@@ -235,6 +269,7 @@ function DecisionsContent() {
                 setTag("");
                 setKeyQuery("");
                 setTextQuery("");
+                setSince("30d");
               }}
               className="pill muted"
               style={{ cursor: "pointer", marginTop: "var(--s-3)" }}

--- a/dashboard/src/app/globals.css
+++ b/dashboard/src/app/globals.css
@@ -60,8 +60,14 @@
   --warn-soft:     var(--amber-soft);
   --err:           var(--red);
   --err-soft:      var(--red-soft);
+  --err-bg:        var(--red-soft);
   --info:          var(--blue);
   --info-soft:     var(--blue-soft);
+  --overlay-bg:    rgba(10, 11, 13, 0.55);
+  --terminal-bg:        #0b0d10;
+  --terminal-fg:        #d8e0e8;
+  --terminal-prompt:    #7fd1a8;
+  --terminal-comment:   #9aa7b3;
 
   /* legacy dark-mode compat aliases */
   --bg-0: var(--canvas);
@@ -486,7 +492,6 @@ button { font-family: inherit; }
   min-width: 0;
   position: relative;
   overflow-x: hidden;
-  overflow-y: auto;
   background:
     radial-gradient(600px 400px at 15% 20%, var(--aurora-2), transparent 60%),
     radial-gradient(500px 350px at 90% 70%, var(--aurora-1), transparent 65%),
@@ -1145,7 +1150,7 @@ button.topbar-search {
   font-weight: 600;
   margin-bottom: 4px;
 }
-.step-diff-added    { color: var(--green, #4ade80); }
+.step-diff-added    { color: var(--green); }
 .step-diff-modified { color: var(--amber, #fbbf24); }
 .step-diff-removed  { color: var(--red, #f87171); }
 .step-diff-row {

--- a/dashboard/src/app/inbox/page.tsx
+++ b/dashboard/src/app/inbox/page.tsx
@@ -68,8 +68,8 @@ function RecipeIcon({ name }: { name: string }) {
 function senderBadgeColor(name: string): string {
   const lower = name.toLowerCase();
   if (lower.includes("morning-brief")) return "var(--orange)";
-  if (lower.includes("health") || lower.includes("check")) return "var(--ok, #0d8a5e)";
-  if (lower.includes("sentry") || lower.includes("error") || lower.includes("incident")) return "var(--err, #b91c1c)";
+  if (lower.includes("health") || lower.includes("check")) return "var(--ok)";
+  if (lower.includes("sentry") || lower.includes("error") || lower.includes("incident")) return "var(--err)";
   if (lower.includes("recipe") || lower.includes("ctx-loop")) return "#6b6bff";
   return "var(--ink-2)";
 }
@@ -303,6 +303,7 @@ export default function InboxPage() {
   const [refreshing, setRefreshing] = useState(false);
   const [seenNames] = useState<Set<string>>(() => new Set());
   const [replaying, setReplaying] = useState(false);
+  const [actionErr, setActionErr] = useState<string | null>(null);
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const detailRef = useRef<HTMLDivElement | null>(null);
   const selectedRef = useRef<InboxDetail | null>(null);
@@ -724,6 +725,7 @@ const filteredItems = items.filter((item) => {
                   {(() => {
                     const recipeNameForSelected = selected.name.replace(/\.md$/, "").replace(/-\d{4}-\d{2}-\d{2}$/, "");
                     return (
+                      <>
                       <div style={{ display: "flex", gap: 6, marginTop: 16, paddingTop: 16, borderTop: "1px solid var(--line-1)" }}>
                         <button
                           type="button"
@@ -742,7 +744,7 @@ const filteredItems = items.filter((item) => {
                           {replaying ? "Running…" : "Replay recipe"}
                         </button>
                         <a
-                          href={"/dashboard/traces?q=" + recipeNameForSelected}
+                          href={`/traces?q=${encodeURIComponent(recipeNameForSelected)}`}
                           className="btn sm ghost"
                           style={{ fontSize: 11, textDecoration: "none" }}
                         >
@@ -753,14 +755,39 @@ const filteredItems = items.filter((item) => {
                           className="btn sm ghost"
                           style={{ fontSize: 11, color: "var(--ink-3)" }}
                           onClick={async () => {
-                            await fetch(apiPath(`/api/bridge/inbox/${encodeURIComponent(selected.name)}`), { method: "DELETE" });
-                            fetchList(true);
-                            setSelected(null);
+                            setActionErr(null);
+                            try {
+                              const res = await fetch(
+                                apiPath(`/api/bridge/inbox/${encodeURIComponent(selected.name)}`),
+                                { method: "DELETE" },
+                              );
+                              if (!res.ok) {
+                                const text = await res.text().catch(() => res.statusText);
+                                setActionErr(`Archive failed: ${text || res.status}`);
+                                return;
+                              }
+                              fetchList(true);
+                              setSelected(null);
+                            } catch (e) {
+                              setActionErr(
+                                e instanceof Error ? e.message : String(e),
+                              );
+                            }
                           }}
                         >
                           Archive
                         </button>
                       </div>
+                      {actionErr && (
+                        <div
+                          role="alert"
+                          className="alert-err"
+                          style={{ marginTop: 8, fontSize: 12 }}
+                        >
+                          {actionErr}
+                        </div>
+                      )}
+                    </>
                     );
                   })()}
                 </div>

--- a/dashboard/src/app/insights/page.tsx
+++ b/dashboard/src/app/insights/page.tsx
@@ -82,10 +82,10 @@ function approvalBar(approvals: number, rejections: number) {
           width: `${pct}%`,
           background:
             pct >= 80
-              ? "var(--ok, #22c55e)"
+              ? "var(--ok)"
               : pct >= 50
                 ? "var(--warn, #f59e0b)"
-                : "var(--err, #ef4444)",
+                : "var(--err)",
           transition: "width 0.2s",
         }}
       />
@@ -358,7 +358,7 @@ export default function InsightsPage() {
                     style={{
                       padding: "10px 8px",
                       textAlign: "right",
-                      color: "var(--ok, #22c55e)",
+                      color: "var(--ok)",
                       verticalAlign: "middle",
                       fontVariantNumeric: "tabular-nums",
                     }}
@@ -371,7 +371,7 @@ export default function InsightsPage() {
                       textAlign: "right",
                       color:
                         t.rejections > 0
-                          ? "var(--err, #ef4444)"
+                          ? "var(--err)"
                           : "var(--fg-3)",
                       verticalAlign: "middle",
                       fontVariantNumeric: "tabular-nums",

--- a/dashboard/src/app/layout.tsx
+++ b/dashboard/src/app/layout.tsx
@@ -78,10 +78,12 @@ export default function RootLayout({ children }: { children: ReactNode }) {
         <link rel="apple-touch-icon" href="/dashboard/icons/icon-192.png" />
       </head>
       <body>
-        <DemoBanner />
-        <BridgeBanner />
-        <Shell>{children}</Shell>
-        <MobileBottomNav />
+        <div data-app-root>
+          <DemoBanner />
+          <BridgeBanner />
+          <Shell>{children}</Shell>
+          <MobileBottomNav />
+        </div>
         <script
           dangerouslySetInnerHTML={{
             __html: `if('serviceWorker' in navigator){navigator.serviceWorker.register('/dashboard/sw.js',{scope:'/dashboard/'}).catch(()=>{})}`,

--- a/dashboard/src/app/marketplace/[...slug]/page.tsx
+++ b/dashboard/src/app/marketplace/[...slug]/page.tsx
@@ -345,8 +345,8 @@ function TrustNote() {
     <div
       style={{
         padding: "12px 16px",
-        background: "rgba(180,83,9,0.06)",
-        border: "1px solid rgba(180,83,9,0.18)",
+        background: "var(--warn-soft)",
+        border: "1px solid var(--warn)",
         borderRadius: "var(--r-3)",
         fontSize: 12,
         color: "var(--ink-2)",

--- a/dashboard/src/app/marketplace/bundle/[...slug]/page.tsx
+++ b/dashboard/src/app/marketplace/bundle/[...slug]/page.tsx
@@ -148,8 +148,13 @@ function WhatIsIncluded({
             </div>
             <ul style={{ listStyle: "none", padding: 0, margin: 0, display: "flex", flexDirection: "column", gap: 4 }}>
               {recipes.map((r) => (
-                <li key={r} style={{ fontSize: 12, fontFamily: "var(--font-mono, ui-monospace, monospace)", color: "var(--fg-1)" }}>
-                  {r}
+                <li key={r} style={{ fontSize: 12, fontFamily: "var(--font-mono)", color: "var(--fg-1)" }}>
+                  <Link
+                    href={`/marketplace/${encodeURIComponent(r)}`}
+                    style={{ color: "inherit", textDecoration: "underline", textDecorationColor: "var(--line-2)" }}
+                  >
+                    {r}
+                  </Link>
                 </li>
               ))}
             </ul>
@@ -290,8 +295,8 @@ function TrustNote() {
     <div
       style={{
         padding: "12px 16px",
-        background: "rgba(180,83,9,0.06)",
-        border: "1px solid rgba(180,83,9,0.18)",
+        background: "var(--warn-soft)",
+        border: "1px solid var(--warn)",
         borderRadius: "var(--r-3)",
         fontSize: 12,
         color: "var(--ink-2)",

--- a/dashboard/src/app/marketplace/page.tsx
+++ b/dashboard/src/app/marketplace/page.tsx
@@ -489,8 +489,9 @@ export default function MarketplacePage() {
     );
   });
 
-  const featured = filtered[0];
-  const rest = filtered.slice(1);
+  const isSearching = search.trim().length > 0;
+  const featured = isSearching ? undefined : filtered[0];
+  const rest = isSearching ? filtered : filtered.slice(1);
   const totalVisible = filtered.length;
 
   return (

--- a/dashboard/src/app/page.tsx
+++ b/dashboard/src/app/page.tsx
@@ -324,8 +324,12 @@ function ActiveRecipeCard() {
         >
           Active recipe
         </h3>
-        <span className="pill ok" style={{ fontSize: 10 }}>
-          running
+        <span
+          className="pill muted"
+          style={{ fontSize: 10 }}
+          title="Live wiring pending — preview only"
+        >
+          preview
         </span>
       </div>
 
@@ -365,17 +369,25 @@ function ActiveRecipeCard() {
 function HealthCard({
   bridgeVersion,
   extensionVersion,
+  bridgeOk,
+  extensionConnected,
 }: {
   bridgeVersion: string;
   extensionVersion: string;
+  bridgeOk: boolean;
+  extensionConnected: boolean;
 }) {
-  const rows: { label: string; value: string; tone?: "ok" | "muted" }[] = [
-    { label: "Bridge connected", value: bridgeVersion, tone: "ok" },
-    { label: "VS Code extension", value: extensionVersion, tone: "ok" },
-    { label: "JetBrains plugin", value: "1.0.0", tone: "ok" },
-    { label: "Ollama qwen2.5-coder", value: "7B", tone: "ok" },
-    { label: "Push relay iOS", value: "1 device", tone: "ok" },
-    { label: "Free disk", value: "38.4 GB", tone: "muted" },
+  const rows: { label: string; value: string; tone?: "ok" | "muted" | "warn" }[] = [
+    {
+      label: "Bridge",
+      value: bridgeOk ? bridgeVersion : "offline",
+      tone: bridgeOk ? "ok" : "warn",
+    },
+    {
+      label: "VS Code extension",
+      value: extensionConnected ? extensionVersion : "disconnected",
+      tone: extensionConnected ? "ok" : "muted",
+    },
   ];
 
   return (
@@ -401,8 +413,15 @@ function HealthCard({
         >
           Health
         </h3>
-        <span className="pill ok" style={{ fontSize: 10 }}>
-          all green
+        <span
+          className={`pill ${bridgeOk && extensionConnected ? "ok" : bridgeOk ? "muted" : "warn"}`}
+          style={{ fontSize: 10 }}
+        >
+          {bridgeOk && extensionConnected
+            ? "all green"
+            : bridgeOk
+              ? "extension off"
+              : "bridge offline"}
         </span>
       </div>
 
@@ -588,8 +607,8 @@ export default function HomePage() {
   ).size;
   const activeRecipesCount = recipes.filter((r) => r.enabled !== false).length;
 
-  const bridgeVersion = "0.4.2";
-  const extensionVersion = health?.extensionVersion ?? "0.4.2";
+  const bridgeVersion = bridgeStatus.patchwork?.version ?? "unknown";
+  const extensionVersion = health?.extensionVersion ?? "unknown";
 
   return (
     <section>
@@ -795,6 +814,8 @@ export default function HomePage() {
         <HealthCard
           bridgeVersion={bridgeVersion}
           extensionVersion={extensionVersion}
+          bridgeOk={bridgeStatus.ok === true}
+          extensionConnected={Boolean(health?.extensionConnected)}
         />
       </div>
     </section>

--- a/dashboard/src/app/recipes/[name]/edit/page.tsx
+++ b/dashboard/src/app/recipes/[name]/edit/page.tsx
@@ -224,8 +224,8 @@ export default function RecipeEditPage({
               fontSize: 13,
               borderRadius: "var(--r-2)",
               background: t.kind === "ok" ? "var(--ok-soft, #1a3a2a)" : "var(--err-soft, #3a1a1a)",
-              border: `1px solid ${t.kind === "ok" ? "var(--ok, #4ade80)" : "var(--err, #f87171)"}`,
-              color: t.kind === "ok" ? "var(--ok, #4ade80)" : "var(--err, #f87171)",
+              border: `1px solid ${t.kind === "ok" ? "var(--ok)" : "var(--err)"}`,
+              color: t.kind === "ok" ? "var(--ok)" : "var(--err)",
               boxShadow: "0 4px 16px rgba(0,0,0,0.4)",
               pointerEvents: "auto",
             }}
@@ -304,8 +304,8 @@ export default function RecipeEditPage({
             padding: "var(--s-3) var(--s-4)",
             borderRadius: "var(--r-2)",
             background: "var(--err-soft, #3a1a1a)",
-            border: "1px solid var(--err, #f87171)",
-            color: "var(--err, #f87171)",
+            border: "1px solid var(--err)",
+            color: "var(--err)",
             display: "flex",
             justifyContent: "space-between",
             alignItems: "flex-start",
@@ -349,8 +349,8 @@ export default function RecipeEditPage({
             padding: "var(--s-3) var(--s-4)",
             borderRadius: "var(--r-2)",
             background: "var(--err-soft, #3a1a1a)",
-            border: "1px solid var(--err, #f87171)",
-            color: "var(--err, #f87171)",
+            border: "1px solid var(--err)",
+            color: "var(--err)",
             fontSize: 13,
           }}
         >
@@ -410,9 +410,9 @@ export default function RecipeEditPage({
             style={{
               width: "100%",
               minHeight: 400,
-              background: "#0f0f1a",
-              color: "#e2e2f0",
-              border: "1px solid var(--glass-border)",
+              background: "var(--recess)",
+              color: "var(--ink-0)",
+              border: "1px solid var(--line-2)",
               borderRadius: "var(--r-2)",
               fontFamily: "var(--font-mono, 'JetBrains Mono', 'Fira Code', monospace)",
               fontSize: 13,
@@ -427,7 +427,7 @@ export default function RecipeEditPage({
               e.currentTarget.style.borderColor = "var(--accent)";
             }}
             onBlur={(e) => {
-              e.currentTarget.style.borderColor = "var(--glass-border)";
+              e.currentTarget.style.borderColor = "var(--line-2)";
             }}
             onKeyDown={(e) => {
               if (e.key === "Tab") {

--- a/dashboard/src/app/recipes/[name]/plan/page.tsx
+++ b/dashboard/src/app/recipes/[name]/plan/page.tsx
@@ -34,9 +34,9 @@ interface DryRunPlan {
 }
 
 const RISK_COLORS: Record<string, string> = {
-  low: "var(--ok, #22c55e)",
+  low: "var(--ok)",
   medium: "var(--warn, #e6a817)",
-  high: "var(--err, #ef4444)",
+  high: "var(--err)",
 };
 
 function RiskBadge({ risk }: { risk?: string }) {
@@ -181,7 +181,7 @@ export default function RecipePlanPage({
       {error && (
         <div
           style={{
-            background: "var(--err-bg, #2a1a1a)",
+            background: "var(--err-soft)",
             border: "1px solid var(--err)",
             borderRadius: "var(--r-2)",
             color: "var(--err)",
@@ -250,7 +250,7 @@ export default function RecipePlanPage({
                 <div
                   key={e}
                   style={{
-                    background: "var(--err-bg, #2a1a1a)",
+                    background: "var(--err-soft)",
                     border: "1px solid var(--err)",
                     borderRadius: "var(--r-2)",
                     color: "var(--err)",

--- a/dashboard/src/app/recipes/new/page.tsx
+++ b/dashboard/src/app/recipes/new/page.tsx
@@ -667,7 +667,7 @@ function NewRecipePageInner() {
             {aiResult?.error && (
               <p
                 style={{
-                  background: "var(--err-bg, #2a1a1a)",
+                  background: "var(--err-soft)",
                   border: "1px solid var(--err)",
                   borderRadius: "var(--r-2)",
                   color: "var(--err)",

--- a/dashboard/src/app/recipes/page.tsx
+++ b/dashboard/src/app/recipes/page.tsx
@@ -280,10 +280,10 @@ function SuccessRing({
     pct == null
       ? "var(--line-3)"
       : safePct >= 90
-        ? "var(--ok, #22c55e)"
+        ? "var(--ok)"
         : safePct >= 60
           ? "var(--warn, #e6a817)"
-          : "var(--err, #ef4444)";
+          : "var(--err)";
   return (
     <svg
       width={size}
@@ -355,11 +355,11 @@ function highlightYaml(yaml: string): React.ReactNode {
       body = (
         <>
           <span>{lead}</span>
-          <span className="yaml-key" style={{ color: "var(--accent, #7aa2f7)" }}>{key}</span>
+          <span className="yaml-key" style={{ color: "var(--accent)" }}>{key}</span>
           <span>{colon}</span>
           <span>{ws}</span>
           {rest && (
-            <span className="yaml-string" style={{ color: "var(--ok, #9ece6a)" }}>{rest}</span>
+            <span className="yaml-string" style={{ color: "var(--ok)" }}>{rest}</span>
           )}
         </>
       );
@@ -980,7 +980,7 @@ export default function RecipesPage() {
                               height: 20,
                               borderRadius: 999,
                               border: "1px solid var(--line-2)",
-                              background: enabled ? "var(--ok, #22c55e)" : "var(--bg-2)",
+                              background: enabled ? "var(--ok)" : "var(--bg-2)",
                               cursor: "pointer",
                               padding: 0,
                               transition: "background 0.15s",
@@ -995,9 +995,9 @@ export default function RecipesPage() {
                                 width: 16,
                                 height: 16,
                                 borderRadius: "50%",
-                                background: "white",
+                                background: "var(--surface)",
                                 transition: "left 0.15s",
-                                boxShadow: "0 1px 2px rgba(0,0,0,0.2)",
+                                boxShadow: "var(--shadow-s, 0 1px 2px rgba(0,0,0,0.2))",
                               }}
                             />
                           </button>

--- a/dashboard/src/app/runs/[seq]/page.tsx
+++ b/dashboard/src/app/runs/[seq]/page.tsx
@@ -4,6 +4,7 @@ import { useParams } from "next/navigation";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { apiPath } from "@/lib/api";
 import { StepDiffHover } from "@/components/StepDiffHover";
+import { Dialog } from "@/components/Dialog";
 import { useBridgeStream } from "@/hooks/useBridgeStream";
 import { diffForStep, previewMockedReplay } from "@/lib/registryDiff";
 
@@ -582,6 +583,55 @@ function CausalChainCard({ run }: { run: RunDetail }) {
   );
 }
 
+function ReplayPreflight({ stepResults }: { stepResults: StepResult[] }) {
+  const preflight = previewMockedReplay(stepResults);
+  if (preflight.unmocked.length === 0) {
+    return (
+      <p style={{ fontSize: 12, color: "var(--ink-3)", margin: "0 0 16px" }}>
+        All {preflight.mocked.length} step
+        {preflight.mocked.length === 1 ? "" : "s"} will be mocked from captures.
+        No external API calls.
+      </p>
+    );
+  }
+  return (
+    <div
+      style={{
+        fontSize: 12,
+        margin: "0 0 16px",
+        padding: "8px 10px",
+        borderRadius: "var(--r-1)",
+        border: "1px solid var(--amber)",
+        background: "var(--amber-soft)",
+        color: "var(--amber)",
+      }}
+    >
+      <div style={{ fontWeight: 600, marginBottom: 4 }}>
+        {preflight.unmocked.length} step
+        {preflight.unmocked.length === 1 ? "" : "s"} will run for real (no
+        usable capture)
+      </div>
+      <ul style={{ margin: "4px 0 0", paddingLeft: 20, color: "var(--ink-2)" }}>
+        {preflight.unmocked.slice(0, 8).map((u) => (
+          <li key={u.id} className="mono" style={{ fontSize: 11 }}>
+            {u.tool ? `${u.tool} ` : ""}
+            <span style={{ color: "var(--ink-3)" }}>({u.id})</span>
+            {" — "}
+            {u.reason === "truncated"
+              ? "output >8 KB, will fire real tool"
+              : "no capture"}
+          </li>
+        ))}
+        {preflight.unmocked.length > 8 && (
+          <li style={{ fontSize: 11, color: "var(--ink-3)" }}>
+            …and {preflight.unmocked.length - 8} more
+          </li>
+        )}
+      </ul>
+    </div>
+  );
+}
+
 // ------------------------------------------------------------------ page
 
 export default function RunDetailPage() {
@@ -802,10 +852,10 @@ export default function RunDetailPage() {
           <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
             <span className="pill muted" style={{ fontSize: 11 }}>{run.trigger}</span>
             <span
-              className={`pill ${run.status === "done" && !(run.assertionFailures?.length) ? "ok" : (run.status === "cancelled" || run.status === "interrupted") ? "warn" : "err"}`}
+              className={`pill ${run.assertionFailures?.length ? "err" : statusPillClass(run.status)}`}
               style={{ fontSize: 11 }}
             >
-              <span className="pill-dot" />
+              {run.status !== "running" && <span className="pill-dot" />}
               {run.status}
             </span>
             <span className="pill muted" style={{ fontSize: 11 }}>
@@ -857,125 +907,56 @@ export default function RunDetailPage() {
         </div>
       )}
 
-      {/* Replay confirm modal */}
-      {replayState === "confirming" && (
-        <div
-          role="dialog"
-          aria-label="Confirm mocked replay"
-          style={{
-            position: "fixed",
-            inset: 0,
-            background: "rgba(0,0,0,0.6)",
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            zIndex: 100,
-          }}
-          onClick={() => setReplayState("idle")}
-        >
-          <div
-            className="card"
-            onClick={(e) => e.stopPropagation()}
-            style={{ maxWidth: 480, padding: 20 }}
+      <Dialog
+        open={replayState === "confirming"}
+        onClose={() => setReplayState("idle")}
+        ariaLabelledBy="replay-confirm-heading"
+      >
+        <h3 id="replay-confirm-heading" style={{ marginTop: 0, marginBottom: 8 }}>
+          Replay this run?
+        </h3>
+        <p style={{ fontSize: 13, color: "var(--ink-2)", margin: "0 0 12px" }}>
+          Re-runs the recipe with each step's tool / agent call replaced by its
+          captured output from this run. Templates, transforms, and
+          <code className="mono"> when:</code> conditions re-evaluate against the
+          new state — useful for verifying recipe edits without re-hitting
+          connected services.
+        </p>
+        <ReplayPreflight stepResults={run?.stepResults ?? []} />
+        <p style={{ fontSize: 12, color: "var(--ink-3)", margin: "0 0 16px" }}>
+          A new run will be created with{" "}
+          <code className="mono">replay:{seq}</code> in its taskId.
+        </p>
+        <div style={{ display: "flex", justifyContent: "flex-end", gap: 8 }}>
+          <button
+            type="button"
+            onClick={() => setReplayState("idle")}
+            style={{
+              padding: "6px 12px",
+              borderRadius: "var(--r-1)",
+              border: "1px solid var(--line-2)",
+              background: "transparent",
+              cursor: "pointer",
+            }}
           >
-            <h3 style={{ marginTop: 0, marginBottom: 8 }}>Replay this run?</h3>
-            <p style={{ fontSize: 13, color: "var(--ink-2)", margin: "0 0 12px" }}>
-              Re-runs the recipe with each step's tool / agent call replaced
-              by its captured output from this run. Templates, transforms, and
-              <code className="mono"> when:</code> conditions re-evaluate against
-              the new state — useful for verifying recipe edits without
-              re-hitting connected services.
-            </p>
-            {(() => {
-              const preflight = previewMockedReplay(run?.stepResults ?? []);
-              if (preflight.unmocked.length === 0) {
-                return (
-                  <p style={{ fontSize: 12, color: "var(--ink-3)", margin: "0 0 16px" }}>
-                    All {preflight.mocked.length} step
-                    {preflight.mocked.length === 1 ? "" : "s"} will be mocked
-                    from captures. No external API calls.
-                  </p>
-                );
-              }
-              return (
-                <div
-                  style={{
-                    fontSize: 12,
-                    margin: "0 0 16px",
-                    padding: "8px 10px",
-                    borderRadius: "var(--r-1, 4px)",
-                    border: "1px solid var(--amber, #fbbf24)",
-                    background: "rgba(251,191,36,0.08)",
-                    color: "var(--amber, #fbbf24)",
-                  }}
-                >
-                  <div style={{ fontWeight: 600, marginBottom: 4 }}>
-                    {preflight.unmocked.length} step
-                    {preflight.unmocked.length === 1 ? "" : "s"} will run for
-                    real (no usable capture)
-                  </div>
-                  <ul
-                    style={{
-                      margin: "4px 0 0",
-                      paddingLeft: 20,
-                      color: "var(--ink-2)",
-                    }}
-                  >
-                    {preflight.unmocked.slice(0, 8).map((u) => (
-                      <li key={u.id} className="mono" style={{ fontSize: 11 }}>
-                        {u.tool ? `${u.tool} ` : ""}
-                        <span style={{ color: "var(--ink-3)" }}>({u.id})</span>
-                        {" — "}
-                        {u.reason === "truncated"
-                          ? "output >8 KB, will fire real tool"
-                          : "no capture"}
-                      </li>
-                    ))}
-                    {preflight.unmocked.length > 8 && (
-                      <li style={{ fontSize: 11, color: "var(--ink-3)" }}>
-                        …and {preflight.unmocked.length - 8} more
-                      </li>
-                    )}
-                  </ul>
-                </div>
-              );
-            })()}
-            <p style={{ fontSize: 12, color: "var(--ink-3)", margin: "0 0 16px" }}>
-              A new run will be created with{" "}
-              <code className="mono">replay:{seq}</code> in its taskId.
-            </p>
-            <div style={{ display: "flex", justifyContent: "flex-end", gap: 8 }}>
-              <button
-                type="button"
-                onClick={() => setReplayState("idle")}
-                style={{
-                  padding: "6px 12px",
-                  borderRadius: "var(--r-1, 4px)",
-                  border: "1px solid var(--line-2)",
-                  background: "transparent",
-                  cursor: "pointer",
-                }}
-              >
-                Cancel
-              </button>
-              <button
-                type="button"
-                onClick={() => void handleReplay()}
-                style={{
-                  padding: "6px 12px",
-                  borderRadius: "var(--r-1, 4px)",
-                  border: "1px solid var(--blue, #3b82f6)",
-                  background: "var(--blue, #3b82f6)",
-                  color: "#fff",
-                  cursor: "pointer",
-                }}
-              >
-                Replay (mocked)
-              </button>
-            </div>
-          </div>
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={() => void handleReplay()}
+            style={{
+              padding: "6px 12px",
+              borderRadius: "var(--r-1)",
+              border: "1px solid var(--blue)",
+              background: "var(--blue)",
+              color: "#fff",
+              cursor: "pointer",
+            }}
+          >
+            Replay (mocked)
+          </button>
         </div>
-      )}
+      </Dialog>
 
       {runErr && <div className="alert-err">Failed to load run: {runErr}</div>}
       {!run && !runErr && <div className="empty-state"><p>Loading…</p></div>}

--- a/dashboard/src/app/runs/page.tsx
+++ b/dashboard/src/app/runs/page.tsx
@@ -166,9 +166,8 @@ export default function RunsPage() {
           style={{
             textAlign: "left",
             padding: "20px 24px",
-            borderLeft: "3px solid var(--orange)",
+            borderLeft: `3px solid ${status === "all" ? "var(--orange)" : "var(--line-2)"}`,
             cursor: "pointer",
-            borderColor: status === "all" ? "var(--orange)" : undefined,
             background: "transparent",
           }}
           aria-pressed={status === "all"}
@@ -184,9 +183,8 @@ export default function RunsPage() {
           style={{
             textAlign: "left",
             padding: "20px 24px",
-            borderLeft: "3px solid var(--ok)",
+            borderLeft: `3px solid ${status === "done" ? "var(--ok)" : "var(--line-2)"}`,
             cursor: "pointer",
-            borderColor: status === "done" ? "var(--ok)" : undefined,
             background: "transparent",
           }}
           aria-pressed={status === "done"}
@@ -202,9 +200,8 @@ export default function RunsPage() {
           style={{
             textAlign: "left",
             padding: "20px 24px",
-            borderLeft: "3px solid var(--err)",
+            borderLeft: `3px solid ${status === "error" ? "var(--err)" : "var(--line-2)"}`,
             cursor: "pointer",
-            borderColor: status === "error" ? "var(--err)" : undefined,
             background: "transparent",
           }}
           aria-pressed={status === "error"}

--- a/dashboard/src/app/sessions/page.tsx
+++ b/dashboard/src/app/sessions/page.tsx
@@ -20,25 +20,13 @@ interface SessionSummary {
   clientType?: string;
 }
 
-function recipeFor(s: SessionSummary, idx: number): string {
-  if (s.firstTool) return s.firstTool;
-  const fallbacks = ["morning-brief", "inbox-triage", "pr-review", "stand-up"];
-  return fallbacks[idx % fallbacks.length];
+function recipeFor(s: SessionSummary): string {
+  return s.firstTool ?? "session";
 }
 
-function descriptionFor(recipe: string): string {
-  switch (recipe) {
-    case "morning-brief":
-      return "morning-brief — assembling Slack + Gmail …";
-    case "inbox-triage":
-      return "inbox-triage — sorting unread threads …";
-    case "pr-review":
-      return "pr-review — reading diff + writing notes …";
-    case "stand-up":
-      return "stand-up — summarising yesterday + today …";
-    default:
-      return `${recipe} — running …`;
-  }
+function descriptionFor(recipe: string, hasRealRecipe: boolean): string {
+  if (!hasRealRecipe) return "no recipe metadata reported";
+  return `${recipe} — running …`;
 }
 
 function activityState(
@@ -65,8 +53,7 @@ function SessionLogPanel({
   const lines = [
     `$ patchwork run ${recipe}`,
     `→ resolving recipe templates/recipes/${recipe}.yaml`,
-    `→ model: claude-3.5-sonnet · provider: anthropic`,
-    `→ context: 4 connectors · 170 tools`,
+    `→ session ${shortId} streaming · live tail not yet wired`,
   ];
 
   return (
@@ -108,8 +95,8 @@ function SessionLogPanel({
       {/* terminal body */}
       <div
         style={{
-          background: "#0b0d10",
-          color: "#d8e0e8",
+          background: "var(--terminal-bg)",
+          color: "var(--terminal-fg)",
           fontFamily: "var(--font-mono)",
           fontSize: 12.5,
           lineHeight: 1.65,
@@ -123,7 +110,9 @@ function SessionLogPanel({
           <div
             key={i}
             style={{
-              color: l.startsWith("$") ? "#7fd1a8" : "#9aa7b3",
+              color: l.startsWith("$")
+                ? "var(--terminal-prompt)"
+                : "var(--terminal-comment)",
               whiteSpace: "pre-wrap",
             }}
           >
@@ -136,7 +125,7 @@ function SessionLogPanel({
             alignItems: "center",
             gap: 10,
             marginTop: 14,
-            color: "#d8e0e8",
+            color: "var(--terminal-fg)",
           }}
         >
           <Spinner size={12} />
@@ -266,8 +255,8 @@ export default function SessionsPage() {
               const act = activityState(lastMs);
               const toolCount = s.toolCount ?? 0;
               const isSelected = selectedId === s.id;
-              const recipe = recipeFor(s, idx);
-              const description = descriptionFor(recipe);
+              const recipe = recipeFor(s);
+              const description = descriptionFor(recipe, Boolean(s.firstTool));
 
               return (
                 <button
@@ -459,7 +448,7 @@ export default function SessionsPage() {
             {selectedId && selectedSession ? (
               <SessionLogPanel
                 shortId={`s${selectedIndex + 1}`}
-                recipe={recipeFor(selectedSession, selectedIndex)}
+                recipe={recipeFor(selectedSession)}
                 toolCount={selectedSession.toolCount ?? 0}
               />
             ) : (

--- a/dashboard/src/app/settings/page.tsx
+++ b/dashboard/src/app/settings/page.tsx
@@ -88,7 +88,7 @@ export default function SettingsPage() {
   const [err, setErr] = useState<string>();
   const [unsupported, setUnsupported] = useState(false);
   const [active, setActive] = useState<SectionId>("s-bridge");
-  const [savedFlash, setSavedFlash] = useState(true);
+  const [saveState, setSaveState] = useState<"idle" | "saving" | "saved">("idle");
 
   // Bridge form state
   const [workspacePath, setWorkspacePath] = useState("");
@@ -208,14 +208,9 @@ export default function SettingsPage() {
   }, []);
 
   function flashSaved() {
-    setSavedFlash(false);
-    setTimeout(() => setSavedFlash(true), 1500);
-  }
-
-  // TODO(backend): wire to /api/bridge/settings PUT for workspace/inbox/ports.
-  // Until then, Apply still flashes "saved" to keep the design's UX shape.
-  async function saveBridge() {
-    flashSaved();
+    setSaveState("saving");
+    setTimeout(() => setSaveState("saved"), 600);
+    setTimeout(() => setSaveState("idle"), 2400);
   }
 
   async function setPrimary(rowId: string) {
@@ -303,18 +298,27 @@ export default function SettingsPage() {
         </div>
         <div
           aria-live="polite"
+          aria-atomic="true"
           style={{
             fontSize: 12,
-            color: savedFlash ? "var(--ok)" : "var(--fg-2)",
+            color: saveState === "saved" ? "var(--ok)" : "var(--fg-2)",
             display: "flex",
             alignItems: "center",
             gap: 6,
             paddingTop: 8,
-            transition: "color 0.2s",
+            minHeight: 16,
+            transition: "color 0.2s, opacity 0.2s",
+            opacity: saveState === "idle" ? 0 : 1,
           }}
         >
-          <span aria-hidden style={{ fontSize: 13 }}>{savedFlash ? "✓" : "…"}</span>
-          {savedFlash ? "All changes saved" : "Saving…"}
+          {saveState !== "idle" && (
+            <>
+              <span aria-hidden style={{ fontSize: 13 }}>
+                {saveState === "saved" ? "✓" : "…"}
+              </span>
+              {saveState === "saved" ? "Saved" : "Saving…"}
+            </>
+          )}
         </div>
       </div>
 
@@ -457,21 +461,24 @@ export default function SettingsPage() {
                 <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
                   <button
                     type="button"
-                    onClick={saveBridge}
+                    disabled
+                    title="Editing not wired yet — change values in the config file below and restart the bridge."
+                    aria-describedby="bridge-apply-help"
                     style={{
-                      background: "var(--accent)",
-                      color: "#fff",
-                      border: "none",
+                      background: "var(--bg-2)",
+                      color: "var(--fg-3)",
+                      border: "1px solid var(--border-default)",
                       borderRadius: "var(--r-2)",
                       padding: "6px 14px",
                       fontSize: 13,
-                      cursor: "pointer",
+                      cursor: "not-allowed",
+                      opacity: 0.6,
                     }}
                   >
                     Apply
                   </button>
-                  <span style={{ fontSize: 12, color: "var(--fg-3)" }}>
-                    Restart the bridge for port changes to take effect.
+                  <span id="bridge-apply-help" style={{ fontSize: 12, color: "var(--fg-3)" }}>
+                    Read-only — edit the config file directly and restart the bridge.
                   </span>
                 </div>
               </div>
@@ -540,14 +547,17 @@ export default function SettingsPage() {
                       </button>
                       <button
                         type="button"
+                        disabled
+                        title="Per-driver configuration UI coming soon — edit the config file directly."
                         style={{
                           background: "transparent",
-                          color: "var(--fg-1)",
+                          color: "var(--fg-3)",
                           border: "1px solid var(--border-default)",
                           borderRadius: "var(--r-2)",
                           padding: "5px 10px",
                           fontSize: 12,
-                          cursor: "pointer",
+                          cursor: "not-allowed",
+                          opacity: 0.5,
                         }}
                       >
                         Configure
@@ -671,35 +681,29 @@ export default function SettingsPage() {
               </div>
 
               <div style={{ padding: "16px 0", display: "flex", flexDirection: "column", gap: 14 }}>
+                <div role="status" style={{ fontSize: 12, color: "var(--fg-3)", marginBottom: 4 }}>
+                  Preview only — toggles do not yet persist between reloads.
+                </div>
                 <ToggleRow
                   id="tel-crash"
                   label="Crash reports"
                   help="Send anonymized stack traces to help diagnose bridge crashes. No source files, no env vars."
                   checked={telCrash}
-                  onChange={(v) => {
-                    setTelCrash(v);
-                    flashSaved();
-                  }}
+                  onChange={setTelCrash}
                 />
                 <ToggleRow
                   id="tel-usage"
                   label="Anonymous usage stats"
                   help="Tool-call counts and feature flag usage. No prompts, no file paths, no identifiers."
                   checked={telUsage}
-                  onChange={(v) => {
-                    setTelUsage(v);
-                    flashSaved();
-                  }}
+                  onChange={setTelUsage}
                 />
                 <ToggleRow
                   id="tel-diag"
                   label="Local diagnostics retention"
                   help="Keep last 7 days of bridge logs on this machine for debugging. Never leaves your computer."
                   checked={telDiag}
-                  onChange={(v) => {
-                    setTelDiag(v);
-                    flashSaved();
-                  }}
+                  onChange={setTelDiag}
                 />
               </div>
             </div>

--- a/dashboard/src/app/suggestions/page.tsx
+++ b/dashboard/src/app/suggestions/page.tsx
@@ -83,7 +83,7 @@ function GraduateButton({ recipeName }: { recipeName: string }) {
   }
   if (state === "done") {
     return (
-      <span style={{ color: "var(--ok, #22c55e)", fontSize: 13 }}>
+      <span style={{ color: "var(--ok)", fontSize: 13 }}>
         ✓ Graduated to mostly trusted
       </span>
     );

--- a/dashboard/src/app/tasks/page.tsx
+++ b/dashboard/src/app/tasks/page.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { apiPath } from "@/lib/api";
 import { fmtDuration } from "@/components/time";
 import { SkeletonList } from "@/components/Skeleton";
@@ -267,6 +267,8 @@ export default function TasksPage() {
   const [search, setSearch] = useState("");
   const [statusFilter, setStatusFilter] = useState<"all" | "live" | "done" | "error">("all");
 
+  const refetchRef = useRef<() => void>(() => {});
+
   useEffect(() => {
     let fastId: ReturnType<typeof setInterval> | null = null;
     let slowId: ReturnType<typeof setInterval> | null = null;
@@ -296,6 +298,7 @@ export default function TasksPage() {
         setErr(e instanceof Error ? e.message : String(e));
       }
     };
+    refetchRef.current = () => void tick();
     tick();
     fastId = setInterval(tick, 2000);
     return () => {
@@ -388,7 +391,7 @@ export default function TasksPage() {
           <button
             type="button"
             className="btn sm ghost"
-            onClick={() => setTick((t) => t + 1)}
+            onClick={() => refetchRef.current()}
           >
             Sync
           </button>
@@ -401,7 +404,7 @@ export default function TasksPage() {
           title="Couldn't load tasks"
           description="The bridge isn't responding. The next poll will try again automatically."
           error={err}
-          onRetry={() => setTick((t) => t + 1)}
+          onRetry={() => refetchRef.current()}
         />
       )}
       {err && tasks.length > 0 && (
@@ -518,8 +521,8 @@ export default function TasksPage() {
                 t.status === "error"
                   ? "var(--err)"
                   : t.status === "running" || t.status === "pending"
-                    ? "var(--blue, #6ea8fe)"
-                    : "var(--ok, #22c55e)";
+                    ? "var(--blue)"
+                    : "var(--ok)";
               return (
                 <button
                   key={t.taskId}
@@ -582,7 +585,7 @@ export default function TasksPage() {
                             position: "absolute",
                             inset: 0,
                             width: `${intensity * 100}%`,
-                            background: intensity > 0.7 ? "var(--orange, var(--accent))" : "var(--ok, #22c55e)",
+                            background: intensity > 0.7 ? "var(--orange, var(--accent))" : "var(--ok)",
                           }}
                         />
                       </span>

--- a/dashboard/src/app/tasks/page.tsx
+++ b/dashboard/src/app/tasks/page.tsx
@@ -430,7 +430,7 @@ export default function TasksPage() {
             style={{ flex: "1 1 280px", maxWidth: 360, fontSize: 13 }}
             aria-label="Filter tasks"
           />
-          <div style={{ display: "flex", gap: 4 }} role="tablist" aria-label="Status filter">
+          <div style={{ display: "flex", gap: 4 }} role="group" aria-label="Status filter">
             {([
               ["all", "All", statusCounts.all],
               ["live", "Live", statusCounts.live],
@@ -440,8 +440,7 @@ export default function TasksPage() {
               <button
                 key={k}
                 type="button"
-                role="tab"
-                aria-selected={statusFilter === k}
+                aria-pressed={statusFilter === k}
                 onClick={() => setStatusFilter(k)}
                 className={`btn sm ${statusFilter === k ? "primary" : "ghost"}`}
                 style={{ fontSize: 12 }}

--- a/dashboard/src/components/Dialog.tsx
+++ b/dashboard/src/components/Dialog.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import {
+  type CSSProperties,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useId,
+  useRef,
+} from "react";
+
+type DialogProps = {
+  open: boolean;
+  onClose: () => void;
+  ariaLabel?: string;
+  ariaLabelledBy?: string;
+  children: ReactNode;
+  /** Optional max width for the panel; defaults to 480px. */
+  maxWidth?: number | string;
+  /** Whether clicking the backdrop closes the dialog. Default true. */
+  dismissOnBackdrop?: boolean;
+  panelStyle?: CSSProperties;
+};
+
+const FOCUSABLE_SELECTOR = [
+  "a[href]",
+  "button:not([disabled])",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  "textarea:not([disabled])",
+  '[tabindex]:not([tabindex="-1"])',
+].join(",");
+
+export function Dialog({
+  open,
+  onClose,
+  ariaLabel,
+  ariaLabelledBy,
+  children,
+  maxWidth = 480,
+  dismissOnBackdrop = true,
+  panelStyle,
+}: DialogProps) {
+  const panelRef = useRef<HTMLDivElement | null>(null);
+  const previousActiveRef = useRef<HTMLElement | null>(null);
+  const fallbackId = useId();
+
+  // Move focus into panel on open; restore on close.
+  useEffect(() => {
+    if (!open) return;
+    previousActiveRef.current = document.activeElement as HTMLElement | null;
+    const panel = panelRef.current;
+    if (!panel) return;
+    const focusables = panel.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR);
+    const target = focusables[0] ?? panel;
+    target.focus({ preventScroll: true });
+    return () => {
+      previousActiveRef.current?.focus?.({ preventScroll: true });
+    };
+  }, [open]);
+
+  // Prevent body scroll while open.
+  useEffect(() => {
+    if (!open) return;
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = prev;
+    };
+  }, [open]);
+
+  const handleKeyDown = useCallback(
+    (e: ReactKeyboardEvent<HTMLDivElement>) => {
+      if (e.key === "Escape") {
+        e.stopPropagation();
+        onClose();
+        return;
+      }
+      if (e.key !== "Tab") return;
+      const panel = panelRef.current;
+      if (!panel) return;
+      const nodes = Array.from(
+        panel.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR),
+      ).filter((n) => !n.hasAttribute("aria-hidden"));
+      if (nodes.length === 0) {
+        e.preventDefault();
+        panel.focus();
+        return;
+      }
+      const first = nodes[0]!;
+      const last = nodes[nodes.length - 1]!;
+      const active = document.activeElement as HTMLElement | null;
+      if (e.shiftKey) {
+        if (active === first || !panel.contains(active)) {
+          e.preventDefault();
+          last.focus();
+        }
+      } else {
+        if (active === last) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    },
+    [onClose],
+  );
+
+  if (!open) return null;
+
+  return (
+    <div
+      role="presentation"
+      onClick={(e) => {
+        if (dismissOnBackdrop && e.target === e.currentTarget) onClose();
+      }}
+      style={{
+        position: "fixed",
+        inset: 0,
+        background: "var(--overlay-bg, rgba(10, 11, 13, 0.55))",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        zIndex: 1000,
+        padding: "var(--s-4, 16px)",
+      }}
+    >
+      <div
+        ref={panelRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label={ariaLabelledBy ? undefined : ariaLabel}
+        aria-labelledby={ariaLabelledBy}
+        tabIndex={-1}
+        onKeyDown={handleKeyDown}
+        id={fallbackId}
+        style={{
+          background: "var(--surface)",
+          color: "var(--ink-0)",
+          border: "1px solid var(--line-2)",
+          borderRadius: "var(--r-2, 10px)",
+          boxShadow: "0 20px 50px rgba(0, 0, 0, 0.35)",
+          padding: "var(--s-5, 20px)",
+          width: "100%",
+          maxWidth,
+          maxHeight: "calc(100vh - 32px)",
+          overflowY: "auto",
+          ...panelStyle,
+        }}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/dashboard/src/components/Dialog.tsx
+++ b/dashboard/src/components/Dialog.tsx
@@ -46,27 +46,47 @@ export function Dialog({
   const previousActiveRef = useRef<HTMLElement | null>(null);
   const fallbackId = useId();
 
+  // Capture the previously-focused element BEFORE the dialog renders so that
+  // a rapid open/close/open sequence doesn't end up storing the dialog itself
+  // as the "previous" element.
+  if (open && previousActiveRef.current === null) {
+    const active = document.activeElement as HTMLElement | null;
+    if (active && !panelRef.current?.contains(active)) {
+      previousActiveRef.current = active;
+    }
+  }
+
   // Move focus into panel on open; restore on close.
   useEffect(() => {
     if (!open) return;
-    previousActiveRef.current = document.activeElement as HTMLElement | null;
     const panel = panelRef.current;
     if (!panel) return;
     const focusables = panel.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR);
     const target = focusables[0] ?? panel;
     target.focus({ preventScroll: true });
     return () => {
-      previousActiveRef.current?.focus?.({ preventScroll: true });
+      const restore = previousActiveRef.current;
+      previousActiveRef.current = null;
+      restore?.focus?.({ preventScroll: true });
     };
   }, [open]);
 
-  // Prevent body scroll while open.
+  // Prevent body scroll while open + mark the rest of the app inert.
   useEffect(() => {
     if (!open) return;
-    const prev = document.body.style.overflow;
+    const prevOverflow = document.body.style.overflow;
     document.body.style.overflow = "hidden";
+    const main = document.querySelector<HTMLElement>("[data-app-root]");
+    if (main) {
+      main.setAttribute("inert", "");
+      main.setAttribute("aria-hidden", "true");
+    }
     return () => {
-      document.body.style.overflow = prev;
+      document.body.style.overflow = prevOverflow;
+      if (main) {
+        main.removeAttribute("inert");
+        main.removeAttribute("aria-hidden");
+      }
     };
   }, [open]);
 

--- a/dashboard/src/components/OAuthCallback.tsx
+++ b/dashboard/src/components/OAuthCallback.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import { Suspense, useEffect, useRef, useState } from "react";
+import { apiPath } from "@/lib/api";
+import { useRouter, useSearchParams } from "next/navigation";
+
+type Provider = {
+  id: string;
+  label: string;
+};
+
+function CallbackInner({ provider }: { provider: Provider }) {
+  const params = useSearchParams();
+  const router = useRouter();
+  const called = useRef(false);
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (called.current) return;
+    called.current = true;
+
+    const code = params.get("code");
+    const state = params.get("state");
+    const error = params.get("error");
+
+    const qs = new URLSearchParams();
+    if (code) qs.set("code", code);
+    if (state) qs.set("state", state);
+    if (error) qs.set("error", error);
+
+    const fail = (msg: string) => {
+      setErrorMsg(msg);
+      if (window.opener) {
+        try {
+          window.opener.postMessage(
+            `patchwork:${provider.id}:error:${msg}`,
+            window.location.origin,
+          );
+        } catch {}
+        setTimeout(() => window.close(), 1500);
+      } else {
+        setTimeout(
+          () => router.push(`/connections?error=${encodeURIComponent(msg)}`),
+          1500,
+        );
+      }
+    };
+
+    fetch(apiPath(`/api/connections/${provider.id}/callback?${qs.toString()}`))
+      .then(async (r) => {
+        let body: unknown = null;
+        try {
+          body = await r.json();
+        } catch {}
+
+        const ok =
+          r.ok &&
+          (body == null ||
+            typeof body !== "object" ||
+            (body as { ok?: unknown }).ok !== false);
+
+        if (!ok) {
+          const msg =
+            (body && typeof body === "object" && "error" in body
+              ? String((body as { error?: unknown }).error ?? "")
+              : "") ||
+            (error ? `oauth_${error}` : `http_${r.status}`);
+          fail(msg);
+          return;
+        }
+
+        if (window.opener) {
+          window.opener.postMessage(
+            `patchwork:${provider.id}:connected`,
+            window.location.origin,
+          );
+          window.close();
+        } else {
+          router.push("/connections");
+        }
+      })
+      .catch((err) => {
+        fail(err instanceof Error ? err.message : "network_error");
+      });
+  }, [params, router, provider.id]);
+
+  if (errorMsg) {
+    return (
+      <p role="alert" aria-live="assertive">
+        {provider.label} connection failed: {errorMsg}
+      </p>
+    );
+  }
+  return (
+    <p role="status" aria-live="polite">
+      Connecting {provider.label}…
+    </p>
+  );
+}
+
+export function OAuthCallback({ provider }: { provider: Provider }) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        minHeight: "100vh",
+        background: "var(--canvas)",
+        color: "var(--ink-0)",
+        fontFamily: "var(--font-sans, system-ui, sans-serif)",
+        padding: "var(--s-4, 16px)",
+        textAlign: "center",
+      }}
+    >
+      <Suspense fallback={<p role="status">Loading…</p>}>
+        <CallbackInner provider={provider} />
+      </Suspense>
+    </div>
+  );
+}

--- a/dashboard/src/components/patchwork/ErrorState.tsx
+++ b/dashboard/src/components/patchwork/ErrorState.tsx
@@ -27,7 +27,7 @@ export function ErrorState({
           marginBottom: 12,
           display: "flex",
           justifyContent: "center",
-          color: "var(--err, #d14343)",
+          color: "var(--err)",
         }}
         aria-hidden="true"
       >

--- a/dashboard/src/components/patchwork/RunSparkBars.tsx
+++ b/dashboard/src/components/patchwork/RunSparkBars.tsx
@@ -7,8 +7,8 @@ interface RunSparkBarsProps {
 
 function statusColor(status: string): string {
   const s = status.toLowerCase();
-  if (s === "done" || s === "success") return "var(--ok, #22c55e)";
-  if (s === "error" || s === "failed" || s === "errored") return "var(--err, #ef4444)";
+  if (s === "done" || s === "success") return "var(--ok)";
+  if (s === "error" || s === "failed" || s === "errored") return "var(--err)";
   if (s === "running") return "var(--warn, #e6a817)";
   return "var(--ink-3, #9ca3af)";
 }


### PR DESCRIPTION
## Summary

Follow-up to #215 (design-system migration). Three rounds of per-page review found regressions and gaps; this PR addresses them.

### Round 1 + 2 (commit 1) — blockers from per-page review
- OAuth callbacks now check `r.ok` and the body's `ok` field before posting `connected` (every connector previously claimed success on 4xx/5xx)
- Settings: replace deceptive auto-saved indicator and disable no-op Apply/Configure buttons; mark telemetry preview-only
- Approvals list: J/K/E/X keyboard shortcuts wired (were decorative); E/X in-flight guard prevents duplicate POSTs; aria-live announcement region survives final-card decisions
- Approvals `[callId]`: forward `approvalToken` query param as Bearer for phone-path; double-submit guard
- Home: drop hardcoded versions and synthetic HealthCard rows; HealthCard now reflects real bridge + extension state
- Editor textarea no longer hardcoded dark; theme-adaptive via tokens
- Runs list selection state actually visible; runs `[seq]` running pill no longer renders red error
- Tasks Sync button now actually re-fetches (was a no-op)
- Sessions: drop fabricated recipe-name/description fallbacks; tokenize terminal panel hex
- Inbox: surface Archive failure as alert; fix hardcoded `/dashboard/traces` path
- New primitives: `Dialog.tsx` (focus trap + Escape + body-scroll lock + restore focus), `OAuthCallback.tsx`
- Tokens: add `--err-bg`, `--overlay-bg`, `--terminal-*`; strip 13 wrong-color `var(--token, #hex)` fallbacks across 13 files

### Round 3 (commit 2) — carried-forward items
- Connections Notion + generic-token modals migrated to Dialog; 13 hardcoded status hex/rgba colors tokenized
- Decisions: surface ref filter + since-window UI controls (state was wired to URL/API but had no UI)
- Approvals `[callId]`: stop polling once decision reaches terminal state
- Tasks: replace invalid `role="tab"` with `aria-pressed` toggle buttons
- Marketplace: hide Featured during search; link bundle recipes to detail pages; tokenize TrustNote
- Dialog: harden focus restore against rapid open/close; apply `inert`/`aria-hidden` to `[data-app-root]`

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm test -- --run` (24/24 passing)
- [ ] Manual smoke: open replay modal → Escape closes; tab cycles inside; focus restored on close
- [ ] Manual smoke: trigger an OAuth callback failure (bad bridge token) → success popup is not posted
- [ ] Manual smoke: J/K/E/X on approvals list with multiple cards
- [ ] Manual smoke: phone-path approval `[callId]?approvalToken=…`