### PR TITLE
fix(dashboard): round 4 — observability fixes + dialog migration

### DIFF
--- a/dashboard/src/app/activity/page.tsx
+++ b/dashboard/src/app/activity/page.tsx
@@ -188,11 +188,9 @@ export default function ActivityPage() {
             Activity — <span className="accent">every tool, every event, in real time.</span>
           </h1>
           <div className="editorial-sub">
-            {(() => {
-              const total = events.length || 100;
-              const errored = stats.errors || (events.length === 0 ? 8 : 0);
-              return `${total} events · last 24h · ${errored} errored`;
-            })()}
+            {events.length === 0
+              ? "No events yet"
+              : `${events.length} events · last 24h · ${stats.errors} errored`}
           </div>
         </div>
         <span className={`pill ${connected ? "ok" : "err"}`}>

--- a/dashboard/src/app/analytics/page.tsx
+++ b/dashboard/src/app/analytics/page.tsx
@@ -62,7 +62,9 @@ function taskStatusPill(status: string) {
 
 export default function AnalyticsPage() {
   const windowHours = 24;
-  const [clientNow, setClientNow] = useState(0);
+  const [clientNow, setClientNow] = useState(() =>
+    typeof window === "undefined" ? 0 : Date.now(),
+  );
   useEffect(() => { setClientNow(Date.now()); }, []);
 
   const { data, error, loading } = useBridgeFetch<AnalyticsData>(
@@ -163,7 +165,7 @@ export default function AnalyticsPage() {
               value={loading ? "—" : topTools.length.toLocaleString()}
               foot="Distinct tools invoked"
               icon={
-                <div style={{ width: 36, height: 36, borderRadius: 10, background: "rgba(107,107,255,0.12)", display: "flex", alignItems: "center", justifyContent: "center", color: "#6b6bff" }}>
+                <div style={{ width: 36, height: 36, borderRadius: 10, background: "var(--purple-soft)", display: "flex", alignItems: "center", justifyContent: "center", color: "var(--purple)" }}>
                   <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.85" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><path d="M4 6h16M4 12h16M4 18h10"/></svg>
                 </div>
               }
@@ -173,7 +175,7 @@ export default function AnalyticsPage() {
               value={loading ? "—" : hooksFired.toLocaleString()}
               foot="Automation hook triggers"
               icon={
-                <div style={{ width: 36, height: 36, borderRadius: 10, background: "rgba(34,197,94,0.12)", display: "flex", alignItems: "center", justifyContent: "center", color: "var(--green)" }}>
+                <div style={{ width: 36, height: 36, borderRadius: 10, background: "var(--green-soft)", display: "flex", alignItems: "center", justifyContent: "center", color: "var(--green)" }}>
                   <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.85" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><path d="M3 12h4l3-9 4 18 3-9h4"/></svg>
                 </div>
               }
@@ -183,7 +185,7 @@ export default function AnalyticsPage() {
               value={loading ? "—" : `${errorRate.toFixed(1)}%`}
               foot="Errors / total calls"
               icon={
-                <div style={{ width: 36, height: 36, borderRadius: 10, background: "rgba(var(--red-rgb, 239 68 68), 0.12)", display: "flex", alignItems: "center", justifyContent: "center", color: "var(--red)" }}>
+                <div style={{ width: 36, height: 36, borderRadius: 10, background: "var(--red-soft)", display: "flex", alignItems: "center", justifyContent: "center", color: "var(--red)" }}>
                   <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.85" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
                 </div>
               }

--- a/dashboard/src/app/connections/page.tsx
+++ b/dashboard/src/app/connections/page.tsx
@@ -950,37 +950,81 @@ export default function ConnectionsPage() {
     }
   }
 
-  function handleConnect(id: string) {
+  function handleConnect(id: string): Promise<"connected" | "timeout" | "blocked"> {
     if (id === "notion") {
       setNotionModalOpen(true);
       setNotionErr(null);
-      return;
+      return Promise.resolve("connected");
     }
     if (id in TOKEN_MODAL_CONNECTORS) {
       setTokenModal(id);
       setTokenValue("");
       setTokenErr(null);
-      return;
+      return Promise.resolve("connected");
     }
-    window.open(apiPath(`/api/connections/${id}/auth`), "_blank");
-    oauthPollRef.current = setInterval(async () => {
-      const res = await fetch(apiPath("/api/connections")).catch(() => null);
-      if (!res) return;
-      const data = (await res.json().catch(() => null)) as { connectors: ConnectorStatus[] } | null;
-      if (!data) return;
-      const updated = data.connectors.find((c) => c.id === id);
-      if (updated?.status === "connected") {
-        setConnectors(data.connectors);
-        clearInterval(oauthPollRef.current!);
-        oauthPollRef.current = null;
+    const popup = window.open(apiPath(`/api/connections/${id}/auth`), "_blank");
+    if (!popup) {
+      return Promise.resolve("blocked");
+    }
+    return new Promise((resolve) => {
+      const poll = setInterval(async () => {
+        if (popup.closed) {
+          clearInterval(poll);
+          clearTimeout(timeoutId);
+          await fetchConnectors();
+          resolve("connected");
+          return;
+        }
+        const res = await fetch(apiPath("/api/connections")).catch(() => null);
+        if (!res) return;
+        const data = (await res.json().catch(() => null)) as { connectors: ConnectorStatus[] } | null;
+        if (!data) return;
+        const updated = data.connectors.find((c) => c.id === id);
+        if (updated?.status === "connected") {
+          setConnectors(data.connectors);
+          clearInterval(poll);
+          clearTimeout(timeoutId);
+          try { popup.close(); } catch {}
+          resolve("connected");
+        }
+      }, 3000);
+      oauthPollRef.current = poll;
+      const timeoutId = setTimeout(() => {
+        clearInterval(poll);
+        if (oauthPollRef.current === poll) oauthPollRef.current = null;
+        resolve("timeout");
+      }, 120_000);
+    });
+  }
+
+  const [reAuthing, setReAuthing] = useState(false);
+  const [reAuthMsg, setReAuthMsg] = useState<string | null>(null);
+
+  async function handleReAuthAll() {
+    if (reAuthing) return;
+    const targets = connectors
+      .filter((c) => c.status === "connected" || c.status === "needs_reauth")
+      .map((c) => c.id);
+    if (targets.length === 0) return;
+    setReAuthing(true);
+    setReAuthMsg(null);
+    try {
+      let blocked = 0;
+      for (const id of targets) {
+        const result = await handleConnect(id);
+        if (result === "blocked") {
+          blocked++;
+          break;
+        }
       }
-    }, 3000);
-    setTimeout(() => {
-      if (oauthPollRef.current !== null) {
-        clearInterval(oauthPollRef.current);
-        oauthPollRef.current = null;
+      if (blocked > 0) {
+        setReAuthMsg(
+          "Browser blocked the popup. Allow popups for this site, then click Re-auth all again.",
+        );
       }
-    }, 120_000);
+    } finally {
+      setReAuthing(false);
+    }
   }
 
   useEffect(() => {
@@ -1091,15 +1135,18 @@ export default function ConnectionsPage() {
             <button
               type="button"
               className="btn sm"
-              onClick={() => {
-                connectors
-                  .filter((c) => c.status === "connected" || c.status === "needs_reauth")
-                  .forEach((c) => handleConnect(c.id));
-              }}
-              title="Re-authorize all connected providers"
+              onClick={() => void handleReAuthAll()}
+              disabled={reAuthing}
+              title="Re-authorize all connected providers (one at a time)"
+              aria-busy={reAuthing}
             >
-              ↻ Re-auth all
+              {reAuthing ? "Re-authing…" : "↻ Re-auth all"}
             </button>
+            {reAuthMsg && (
+              <span role="status" style={{ fontSize: 12, color: "var(--warn)" }}>
+                {reAuthMsg}
+              </span>
+            )}
           </div>
         )}
       </div>

--- a/dashboard/src/app/globals.css
+++ b/dashboard/src/app/globals.css
@@ -32,6 +32,10 @@
   --orange-soft:   rgba(197,83,42,0.13);
   --orange-tint:   rgba(197,83,42,0.24);
   --orange-rgb:    197, 83, 42;
+  --green-rgb:     91, 138, 79;
+  --amber-rgb:     201, 142, 43;
+  --red-rgb:       181, 67, 67;
+  --blue-rgb:      74, 111, 165;
   --accent-glow:   rgba(197,83,42,0.28);
 
   /* secondary palette */
@@ -64,6 +68,7 @@
   --info:          var(--blue);
   --info-soft:     var(--blue-soft);
   --overlay-bg:    rgba(10, 11, 13, 0.55);
+  --shadow-modal:  0 20px 50px rgba(10, 11, 13, 0.35);
   --terminal-bg:        #0b0d10;
   --terminal-fg:        #d8e0e8;
   --terminal-prompt:    #7fd1a8;
@@ -98,6 +103,7 @@
   --r-3:  10px;
   --r-4:  14px;
   --r-full: 999px;
+  --r-card: var(--r-l);
   --radius: 10px;
 
   /* shadows */

--- a/dashboard/src/app/inbox/page.tsx
+++ b/dashboard/src/app/inbox/page.tsx
@@ -302,7 +302,7 @@ export default function InboxPage() {
   const [search, setSearch] = useState("");
   const [refreshing, setRefreshing] = useState(false);
   const [seenNames] = useState<Set<string>>(() => new Set());
-  const [replaying, setReplaying] = useState(false);
+  const [replayingFor, setReplayingFor] = useState<string | null>(null);
   const [actionErr, setActionErr] = useState<string | null>(null);
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const detailRef = useRef<HTMLDivElement | null>(null);
@@ -520,17 +520,19 @@ const filteredItems = items.filter((item) => {
                     <button
                       type="button"
                       onClick={() => setSidebarOpen(false)}
-                      title="Collapse"
+                      title="Collapse sidebar"
+                      aria-label="Collapse message sidebar"
                       style={{ background: "none", border: "none", cursor: "pointer", color: "var(--ink-3)", padding: "3px 5px", borderRadius: "var(--r-s)", fontSize: 11, lineHeight: 1 }}
                     >
-                      ◀
+                      <span aria-hidden="true">◀</span>
                     </button>
                   </>
                 ) : (
                   <button
                     type="button"
                     onClick={() => setSidebarOpen(true)}
-                    title="Expand"
+                    title="Expand sidebar"
+                    aria-label="Expand message sidebar"
                     style={{ background: "none", border: "none", cursor: "pointer", color: "var(--ink-3)", padding: "3px 5px", borderRadius: "var(--r-s)", fontSize: 11, lineHeight: 1, width: "100%", display: "flex", flexDirection: "column", alignItems: "center", gap: 6 }}
                   >
                     <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
@@ -731,17 +733,30 @@ const filteredItems = items.filter((item) => {
                           type="button"
                           className="btn sm primary"
                           style={{ background: "var(--orange)", border: "none", fontSize: 11 }}
-                          disabled={replaying}
+                          disabled={replayingFor === selected.name}
                           onClick={async () => {
-                            setReplaying(true);
+                            setActionErr(null);
+                            const itemName = selected.name;
+                            setReplayingFor(itemName);
                             try {
-                              await fetch(apiPath(`/api/bridge/recipes/${encodeURIComponent(recipeNameForSelected)}/run`), { method: "POST" });
+                              const res = await fetch(
+                                apiPath(`/api/bridge/recipes/${encodeURIComponent(recipeNameForSelected)}/run`),
+                                { method: "POST" },
+                              );
+                              if (!res.ok) {
+                                const text = await res.text().catch(() => res.statusText);
+                                setActionErr(`Replay failed: ${text || res.status}`);
+                              }
+                            } catch (e) {
+                              setActionErr(e instanceof Error ? e.message : String(e));
                             } finally {
-                              setTimeout(() => setReplaying(false), 2000);
+                              setTimeout(() => {
+                                setReplayingFor((cur) => (cur === itemName ? null : cur));
+                              }, 2000);
                             }
                           }}
                         >
-                          {replaying ? "Running…" : "Replay recipe"}
+                          {replayingFor === selected.name ? "Running…" : "Replay recipe"}
                         </button>
                         <a
                           href={`/traces?q=${encodeURIComponent(recipeNameForSelected)}`}

--- a/dashboard/src/app/marketplace/page.tsx
+++ b/dashboard/src/app/marketplace/page.tsx
@@ -168,7 +168,7 @@ function Toast({ message, onDone }: { message: string; onDone: () => void }) {
         padding: "12px 18px",
         fontSize: 13,
         color: "var(--fg-0)",
-        boxShadow: "0 8px 32px rgba(0,0,0,0.5)",
+        boxShadow: "0 8px 32px var(--overlay-bg)",
         zIndex: 9999,
         display: "flex",
         alignItems: "center",
@@ -329,7 +329,7 @@ function RecipeCard({
               style={{
                 background: "var(--ok-soft)",
                 color: "var(--ok)",
-                border: "1px solid rgba(52,211,153,0.2)",
+                border: "1px solid var(--ok)",
                 fontSize: 11,
               }}
             >
@@ -504,8 +504,8 @@ export default function MarketplacePage() {
           style={{
             marginBottom: "var(--s-6)",
             padding: "12px 16px",
-            background: "rgba(99,102,241,0.06)",
-            border: "1px solid rgba(99,102,241,0.18)",
+            background: "var(--purple-soft)",
+            border: "1px solid var(--purple)",
             borderRadius: "var(--r-3)",
             display: "flex",
             alignItems: "center",
@@ -529,7 +529,7 @@ export default function MarketplacePage() {
               borderRadius: "var(--r-full)",
               background: "var(--accent-soft)",
               color: "var(--accent-strong)",
-              border: "1px solid rgba(99,102,241,0.25)",
+              border: "1px solid var(--purple)",
               textDecoration: "none",
             }}
           >
@@ -650,7 +650,7 @@ export default function MarketplacePage() {
                       letterSpacing: "0.06em",
                       background: "var(--accent-soft)",
                       color: "var(--accent)",
-                      border: "1px solid rgba(255,122,69,0.25)",
+                      border: "1px solid var(--accent-tint)",
                     }}
                   >
                     ★ FEATURED

--- a/dashboard/src/app/metrics/page.tsx
+++ b/dashboard/src/app/metrics/page.tsx
@@ -138,7 +138,7 @@ export default function MetricsPage() {
             Metrics — <span className="accent">Prometheus counters, exposed locally.</span>
           </h1>
           <div className="editorial-sub">
-            scrape interval 15s · uptime {uptimeSeconds != null ? Math.round(uptimeSeconds) + "s" : "…"} · rate-limits {rateLimitCount}
+            polled every 3s · uptime {uptimeSeconds != null ? Math.round(uptimeSeconds) + "s" : "…"} · rate-limits {rateLimitCount}
           </div>
         </div>
         {updatedAt && (

--- a/dashboard/src/app/recipes/[name]/plan/page.tsx
+++ b/dashboard/src/app/recipes/[name]/plan/page.tsx
@@ -35,7 +35,7 @@ interface DryRunPlan {
 
 const RISK_COLORS: Record<string, string> = {
   low: "var(--ok)",
-  medium: "var(--warn, #e6a817)",
+  medium: "var(--warn)",
   high: "var(--err)",
 };
 
@@ -63,8 +63,8 @@ function RiskBadge({ risk }: { risk?: string }) {
 function TypeBadge({ type }: { type: string }) {
   const colors: Record<string, string> = {
     tool: "var(--accent)",
-    agent: "#8b5cf6",
-    recipe: "#06b6d4",
+    agent: "var(--purple)",
+    recipe: "var(--blue)",
   };
   const color = colors[type] ?? "var(--fg-3)";
   return (
@@ -220,7 +220,7 @@ export default function RecipePlanPage({
               </strong>
             </span>
             {plan.hasWriteSteps && (
-              <span style={{ color: "var(--warn, #e6a817)" }}>
+              <span style={{ color: "var(--warn)" }}>
                 ⚠ Has write steps
               </span>
             )}
@@ -266,10 +266,10 @@ export default function RecipePlanPage({
                   key={w}
                   style={{
                     background:
-                      "color-mix(in srgb, var(--warn, #e6a817) 10%, transparent)",
-                    border: "1px solid var(--warn, #e6a817)",
+                      "color-mix(in srgb, var(--warn) 10%, transparent)",
+                    border: "1px solid var(--warn)",
                     borderRadius: "var(--r-2)",
-                    color: "var(--warn, #e6a817)",
+                    color: "var(--warn)",
                     fontSize: 13,
                     padding: "var(--s-2) var(--s-3)",
                   }}

--- a/dashboard/src/app/recipes/compare/page.tsx
+++ b/dashboard/src/app/recipes/compare/page.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import { Suspense, useEffect, useState } from "react";
 import { apiPath } from "@/lib/api";
+import { Dialog } from "@/components/Dialog";
 
 interface PlanStep {
   id: string;
@@ -202,8 +203,13 @@ function CompareInner() {
   const [loadingA, setLoadingA] = useState(true);
   const [loadingB, setLoadingB] = useState(true);
   const [promoteResult, setPromoteResult] = useState<string | null>(null);
+  const [promoteResultKind, setPromoteResultKind] = useState<"ok" | "err" | null>(null);
   const [promotingA, setPromotingA] = useState(false);
   const [promotingB, setPromotingB] = useState(false);
+  const [confirm, setConfirm] = useState<{
+    variantName: string;
+    setPromoting: (v: boolean) => void;
+  } | null>(null);
 
   useEffect(() => {
     if (!nameA) return;
@@ -241,6 +247,7 @@ function CompareInner() {
   ) {
     setPromoting(true);
     setPromoteResult(null);
+    setPromoteResultKind(null);
     try {
       const res = await fetch(
         apiPath(`/api/bridge/recipes/${encodeURIComponent(variantName)}/promote`),
@@ -256,23 +263,19 @@ function CompareInner() {
         targetExists?: boolean;
       };
       if (body.ok) {
-        setPromoteResult(`✓ ${variantName} promoted to ${baseName}`);
-      } else if (body.targetExists) {
-        // Ask the user to confirm before overwriting the canonical recipe.
-        const confirmed = window.confirm(
-          `"${baseName}" already exists. Overwrite it with "${variantName}"?\n\nThe existing recipe will be replaced.`,
-        );
-        if (confirmed) {
-          setPromoting(false);
-          await promote(variantName, setPromoting, true);
-          return;
-        }
-        setPromoteResult(null);
+        setPromoteResult(`${variantName} promoted to ${baseName}`);
+        setPromoteResultKind("ok");
+      } else if (body.targetExists && !force) {
+        setPromoting(false);
+        setConfirm({ variantName, setPromoting });
+        return;
       } else {
-        setPromoteResult(`Error: ${body.error ?? "promote failed"}`);
+        setPromoteResult(body.error ?? "promote failed");
+        setPromoteResultKind("err");
       }
     } catch (e) {
       setPromoteResult(e instanceof Error ? e.message : String(e));
+      setPromoteResultKind("err");
     } finally {
       setPromoting(false);
     }
@@ -308,21 +311,24 @@ function CompareInner() {
         </div>
       </div>
 
-      {promoteResult && (
+      {promoteResult && promoteResultKind && (
         <div
+          role={promoteResultKind === "err" ? "alert" : "status"}
           style={{
             marginBottom: "var(--s-4)",
             padding: "10px 14px",
             borderRadius: "var(--r-2)",
-            background: promoteResult.startsWith("✓")
-              ? "color-mix(in srgb, var(--ok) 12%, transparent)"
-              : "color-mix(in srgb, var(--err) 12%, transparent)",
-            border: `1px solid ${promoteResult.startsWith("✓") ? "color-mix(in srgb, var(--ok) 30%, transparent)" : "color-mix(in srgb, var(--err) 30%, transparent)"}`,
+            background:
+              promoteResultKind === "ok" ? "var(--ok-soft)" : "var(--err-soft)",
+            border: `1px solid ${promoteResultKind === "ok" ? "var(--ok)" : "var(--err)"}`,
             fontSize: 13,
           }}
         >
+          <span aria-hidden="true">
+            {promoteResultKind === "ok" ? "✓ " : ""}
+          </span>
           {promoteResult}
-          {promoteResult.startsWith("✓") && (
+          {promoteResultKind === "ok" && (
             <>
               {" "}
               <Link href="/recipes" style={{ color: "var(--ok)", fontSize: 12 }}>
@@ -355,6 +361,59 @@ function CompareInner() {
           targetName={baseName}
         />
       </div>
+
+      <Dialog
+        open={confirm !== null}
+        onClose={() => setConfirm(null)}
+        ariaLabelledBy="promote-confirm-heading"
+        maxWidth={460}
+      >
+        {confirm && (
+          <>
+            <h3 id="promote-confirm-heading" style={{ marginTop: 0, marginBottom: 8 }}>
+              Overwrite <code>{baseName}</code>?
+            </h3>
+            <p style={{ fontSize: 13, color: "var(--ink-2)", margin: "0 0 16px", lineHeight: 1.5 }}>
+              <code>{baseName}</code> already exists. Promoting{" "}
+              <code>{confirm.variantName}</code> will replace it. The existing
+              recipe file will be overwritten.
+            </p>
+            <div style={{ display: "flex", justifyContent: "flex-end", gap: 8 }}>
+              <button
+                type="button"
+                onClick={() => setConfirm(null)}
+                style={{
+                  padding: "6px 12px",
+                  borderRadius: "var(--r-1)",
+                  border: "1px solid var(--line-2)",
+                  background: "transparent",
+                  cursor: "pointer",
+                }}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  const c = confirm;
+                  setConfirm(null);
+                  void promote(c.variantName, c.setPromoting, true);
+                }}
+                style={{
+                  padding: "6px 12px",
+                  borderRadius: "var(--r-1)",
+                  border: "1px solid var(--err)",
+                  background: "var(--err)",
+                  color: "var(--surface)",
+                  cursor: "pointer",
+                }}
+              >
+                Overwrite
+              </button>
+            </div>
+          </>
+        )}
+      </Dialog>
     </section>
   );
 }

--- a/dashboard/src/app/recipes/new/page.tsx
+++ b/dashboard/src/app/recipes/new/page.tsx
@@ -684,7 +684,7 @@ function NewRecipePageInner() {
               <details style={{ fontSize: 12 }}>
                 <summary
                   style={{
-                    color: "var(--warn, #e6a817)",
+                    color: "var(--warn)",
                     cursor: "pointer",
                   }}
                 >

--- a/dashboard/src/app/recipes/page.tsx
+++ b/dashboard/src/app/recipes/page.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useEffect, useMemo, useRef, useState } from "react";
+import { Dialog } from "@/components/Dialog";
 import { apiPath } from "@/lib/api";
 import { ConnectorHealthPanel } from "@/components/ConnectorHealthPanel";
 import { SkeletonList } from "@/components/Skeleton";
@@ -140,125 +141,108 @@ function RunModal({
   onConfirm,
   running,
 }: {
-  state: RunModalState;
+  state: RunModalState | null;
   onClose: () => void;
   onConfirm: (vars: Record<string, string>) => void;
   running: boolean;
 }) {
-  const overlayRef = useRef<HTMLDivElement>(null);
-  const [values, setValues] = useState<Record<string, string>>(() => {
+  const [values, setValues] = useState<Record<string, string>>({});
+
+  // Reset form values when the recipe being run changes.
+  useEffect(() => {
+    if (!state) return;
     const init: Record<string, string> = {};
     for (const v of state.recipe.vars ?? []) {
       init[v.name] = v.default ?? "";
     }
-    return init;
-  });
+    setValues(init);
+  }, [state]);
 
-  function handleOverlayClick(e: React.MouseEvent) {
-    if (e.target === overlayRef.current) onClose();
-  }
-
-  const vars = state.recipe.vars ?? [];
+  const vars = state?.recipe.vars ?? [];
 
   return (
-    <div
-      ref={overlayRef}
-      onClick={handleOverlayClick}
-      style={{
-        position: "fixed",
-        inset: 0,
-        background: "rgba(0,0,0,0.5)",
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
-        zIndex: 1000,
-      }}
+    <Dialog
+      open={state !== null}
+      onClose={onClose}
+      ariaLabelledBy="run-modal-title"
+      maxWidth={480}
     >
-      <div
-        style={{
-          background: "var(--bg-1)",
-          border: "1px solid var(--border-default)",
-          borderRadius: "var(--r-3)",
-          padding: "var(--s-6)",
-          minWidth: 360,
-          maxWidth: 480,
-          width: "100%",
-          boxShadow: "0 8px 32px rgba(0,0,0,0.3)",
-        }}
-      >
-        <div
-          style={{
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "space-between",
-            marginBottom: "var(--s-4)",
-          }}
-        >
-          <h2 style={{ margin: 0, fontSize: 16, fontWeight: 600 }}>
-            Run <code>{state.recipe.name}</code>
-          </h2>
-          <button
-            type="button"
-            className="btn sm ghost"
-            onClick={onClose}
-            aria-label="Close"
-          >
-            ×
-          </button>
-        </div>
-        <form
-          onSubmit={(e) => {
-            e.preventDefault();
-            onConfirm(values);
-          }}
-        >
-          <div style={{ display: "flex", flexDirection: "column", gap: "var(--s-4)" }}>
-            {vars.map((v) => (
-              <div key={v.name}>
-                <label
-                  htmlFor={`run-var-${v.name}`}
-                  style={{ display: "block", marginBottom: 4, fontSize: 13, fontFamily: "var(--font-mono)" }}
-                >
-                  {v.name}
-                  {v.required && <span style={{ color: "var(--err)", marginLeft: 4 }}>*</span>}
-                </label>
-                {v.description && (
-                  <div style={{ fontSize: 12, color: "var(--fg-3)", marginBottom: 4 }}>
-                    {v.description}
-                  </div>
-                )}
-                <input
-                  id={`run-var-${v.name}`}
-                  type="text"
-                  required={v.required}
-                  value={values[v.name] ?? ""}
-                  onChange={(e) =>
-                    setValues((prev) => ({ ...prev, [v.name]: e.target.value }))
-                  }
-                  className="input"
-                  style={{ width: "100%" }}
-                />
-              </div>
-            ))}
-          </div>
+      {state && (
+        <>
           <div
             style={{
               display: "flex",
-              gap: "var(--s-3)",
-              marginTop: "var(--s-5)",
-              justifyContent: "flex-end",
+              alignItems: "center",
+              justifyContent: "space-between",
+              marginBottom: "var(--s-4)",
             }}
           >
-            <button type="button" className="btn ghost" onClick={onClose} disabled={running}>
-              Cancel
-            </button>
-            <button type="submit" className="btn" disabled={running}>
-              {running ? "Starting…" : "Run recipe"}
+            <h2 id="run-modal-title" style={{ margin: 0, fontSize: 16, fontWeight: 600 }}>
+              Run <code>{state.recipe.name}</code>
+            </h2>
+            <button
+              type="button"
+              className="btn sm ghost"
+              onClick={onClose}
+              aria-label="Close"
+            >
+              ×
             </button>
           </div>
-        </form>
-      </div>
-    </div>
+          <form
+            onSubmit={(e) => {
+              e.preventDefault();
+              onConfirm(values);
+            }}
+          >
+            <div style={{ display: "flex", flexDirection: "column", gap: "var(--s-4)" }}>
+              {vars.map((v) => (
+                <div key={v.name}>
+                  <label
+                    htmlFor={`run-var-${v.name}`}
+                    style={{ display: "block", marginBottom: 4, fontSize: 13, fontFamily: "var(--font-mono)" }}
+                  >
+                    {v.name}
+                    {v.required && <span style={{ color: "var(--err)", marginLeft: 4 }}>*</span>}
+                  </label>
+                  {v.description && (
+                    <div style={{ fontSize: 12, color: "var(--fg-3)", marginBottom: 4 }}>
+                      {v.description}
+                    </div>
+                  )}
+                  <input
+                    id={`run-var-${v.name}`}
+                    type="text"
+                    required={v.required}
+                    value={values[v.name] ?? ""}
+                    onChange={(e) =>
+                      setValues((prev) => ({ ...prev, [v.name]: e.target.value }))
+                    }
+                    className="input"
+                    style={{ width: "100%" }}
+                  />
+                </div>
+              ))}
+            </div>
+            <div
+              style={{
+                display: "flex",
+                gap: "var(--s-3)",
+                marginTop: "var(--s-5)",
+                justifyContent: "flex-end",
+              }}
+            >
+              <button type="button" className="btn ghost" onClick={onClose} disabled={running}>
+                Cancel
+              </button>
+              <button type="submit" className="btn" disabled={running}>
+                {running ? "Starting…" : "Run recipe"}
+              </button>
+            </div>
+          </form>
+        </>
+      )}
+    </Dialog>
   );
 }
 
@@ -282,7 +266,7 @@ function SuccessRing({
       : safePct >= 90
         ? "var(--ok)"
         : safePct >= 60
-          ? "var(--warn, #e6a817)"
+          ? "var(--warn)"
           : "var(--err)";
   return (
     <svg
@@ -788,14 +772,12 @@ export default function RecipesPage() {
 
   return (
     <section>
-      {modal && (
-        <RunModal
-          state={modal}
-          onClose={() => setModal(null)}
-          onConfirm={handleModalConfirm}
-          running={modalRunning}
-        />
-      )}
+      <RunModal
+        state={modal}
+        onClose={() => setModal(null)}
+        onConfirm={handleModalConfirm}
+        running={modalRunning}
+      />
 
       <div className="page-head">
         <div>

--- a/dashboard/src/app/runs/[seq]/page.tsx
+++ b/dashboard/src/app/runs/[seq]/page.tsx
@@ -949,7 +949,7 @@ export default function RunDetailPage() {
               borderRadius: "var(--r-1)",
               border: "1px solid var(--blue)",
               background: "var(--blue)",
-              color: "#fff",
+              color: "var(--surface)",
               cursor: "pointer",
             }}
           >

--- a/dashboard/src/app/sessions/[id]/page.tsx
+++ b/dashboard/src/app/sessions/[id]/page.tsx
@@ -360,7 +360,7 @@ export default function SessionDetailPage() {
                     style={{
                       fontFamily: "var(--font-mono)",
                       fontSize: 12,
-                      color: "#a78bfa",
+                      color: "var(--purple)",
                       flexShrink: 0,
                     }}
                   >

--- a/dashboard/src/app/traces/page.tsx
+++ b/dashboard/src/app/traces/page.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { Fragment, useCallback, useMemo, useState } from "react";
+import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { relTime } from "@/components/time";
 import { apiPath } from "@/lib/api";
 import { useBridgeFetch } from "@/hooks/useBridgeFetch";
@@ -291,7 +291,6 @@ function TraceDetail({
           </pre>
         </details>
       ))}
-      <TraceActions traceType={traceType} body={body} />
     </div>
   );
 }
@@ -311,6 +310,23 @@ function ExportButton({ disabled: outerDisabled }: { disabled?: boolean }) {
   const [passphrase, setPassphrase] = useState("");
   const [downloading, setDownloading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const wrapRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onDocDown = (e: MouseEvent) => {
+      if (!wrapRef.current?.contains(e.target as Node)) setOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("mousedown", onDocDown);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onDocDown);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
 
   async function handleDownload() {
     const phrase = passphrase.trim();
@@ -346,12 +362,14 @@ function ExportButton({ disabled: outerDisabled }: { disabled?: boolean }) {
   }
 
   return (
-    <div style={{ position: "relative" }}>
+    <div ref={wrapRef} style={{ position: "relative" }}>
       <button
         type="button"
         className="btn sm"
         onClick={() => setOpen((v) => !v)}
         disabled={outerDisabled}
+        aria-expanded={open}
+        aria-haspopup="dialog"
         style={{ opacity: outerDisabled ? 0.4 : 1 }}
       >
         Export
@@ -566,6 +584,7 @@ export default function TracesPage() {
             const status = traceStatus(t);
             const theme = TYPE_THEME[t.traceType];
             const statusColor = status === "done" ? "var(--ok)" : status === "error" ? "var(--err)" : "var(--ink-3)";
+            const statusBg = status === "done" ? "var(--ok-soft)" : status === "error" ? "var(--err-soft)" : "var(--recess)";
             const statusLabel = status === "done" ? "done" : status === "error" ? "error" : "running";
             return (
               <div key={rowKey} style={{ borderBottom: "1px solid var(--line-3)" }}>
@@ -648,7 +667,7 @@ export default function TracesPage() {
                     {relTime(t.ts)}
                   </span>
                   <span style={{ display: "flex", justifyContent: "flex-end" }}>
-                    <span className="pill" style={{ background: statusColor + "22", color: statusColor, fontSize: 10, fontWeight: 700 }}>
+                    <span className="pill" style={{ background: statusBg, color: statusColor, fontSize: 10, fontWeight: 700 }}>
                       {statusLabel}
                     </span>
                   </span>

--- a/dashboard/src/app/transactions/page.tsx
+++ b/dashboard/src/app/transactions/page.tsx
@@ -52,7 +52,12 @@ function TtlPill({ expiresAt }: { expiresAt: number }) {
   const expired = ms === 0;
   const critical = !expired && ms < 30_000;
   const warning = !expired && !critical && ms < 60_000;
-  const cls = expired || critical || warning ? "pill err" : "pill warn";
+  const cls =
+    expired || critical
+      ? "pill err"
+      : warning
+        ? "pill warn"
+        : "pill muted";
   return (
     <span
       className={cls}

--- a/dashboard/src/components/Dialog.tsx
+++ b/dashboard/src/components/Dialog.tsx
@@ -159,7 +159,7 @@ export function Dialog({
           color: "var(--ink-0)",
           border: "1px solid var(--line-2)",
           borderRadius: "var(--r-2, 10px)",
-          boxShadow: "0 20px 50px rgba(0, 0, 0, 0.35)",
+          boxShadow: "var(--shadow-modal)",
           padding: "var(--s-5, 20px)",
           width: "100%",
           maxWidth,

--- a/dashboard/src/components/patchwork/RunSparkBars.tsx
+++ b/dashboard/src/components/patchwork/RunSparkBars.tsx
@@ -9,7 +9,7 @@ function statusColor(status: string): string {
   const s = status.toLowerCase();
   if (s === "done" || s === "success") return "var(--ok)";
   if (s === "error" || s === "failed" || s === "errored") return "var(--err)";
-  if (s === "running") return "var(--warn, #e6a817)";
+  if (s === "running") return "var(--warn)";
   return "var(--ink-3, #9ca3af)";
 }
 


### PR DESCRIPTION
## Summary

Round 4 of post-merge dashboard cleanup, mostly addressing the observability slice (which the reviewer hadn't reached in earlier passes) plus carried-forward Dialog/UX items.

### Correctness fixes
- **traces status pill background** was permanently transparent — `var(--ok)22` is invalid CSS. Now uses `--ok-soft` / `--err-soft` / `--recess`.
- **traces** rendered `TraceActions` twice per expanded row (once inside `TraceDetail`, once in the row body). Duplicate removed.
- **traces ExportButton** dropdown gained click-outside + Escape close handlers; `aria-expanded` + `aria-haspopup`.
- **transactions TtlPill** rendered the 45–60s "warning" state with the red `pill err` class (same as expired). Now: expired/critical → err, warning → warn, else → muted.
- **activity** drops the misleading "8 errored" placeholder when there are zero events.
- **analytics** `clientNow` initialised to `0` caused the area chart to render blank on first paint. Now `Date.now()` on client.
- **recipes/compare** replaces `window.confirm()` with a themed Dialog overwrite confirmation; `promoteResult` kind tracked separately so styling no longer depends on string-prefix inspection.
- **recipes/page.tsx RunModal** migrated to the Dialog primitive (focus trap, Escape, scroll lock, inert background).
- **connections Re-auth all** no longer fires N concurrent OAuth popups. Serialized via `popup.closed` polling with a single in-flight popup; status message when browser blocks.
- **inbox** per-item replaying state (was a single shared boolean); replay errors now surface as alerts; collapse/expand sidebar buttons get `aria-label`.

### Design system / tokens
- `globals.css`: add `--r-card` (alias of `--r-l`), `--green-rgb` / `--amber-rgb` / `--red-rgb` / `--blue-rgb`, `--shadow-modal`.
- `Dialog.tsx` panel `boxShadow` now uses `--shadow-modal`.
- analytics: drop hardcoded `#6b6bff` / `rgba(34,197,94,…)` / `var(--red-rgb, 239 68 68)` → `--purple-soft` / `--green-soft` / `--red-soft`.
- marketplace: tokenize indigo/teal/dark-orange/black `rgba` → `--purple-soft` / `--purple` / `--ok` / `--accent-tint` / `--overlay-bg` / `--shadow-modal`.
- marketplace bundle: link constituent recipe slugs to detail pages.
- recipes plan: `TypeBadge` raw hex `#8b5cf6`/`#06b6d4` → `--purple`/`--blue`; remaining `var(--warn, #e6a817)` survivors stripped repo-wide.
- sessions/[id]: hardcoded purple `#a78bfa` → `--purple`.
- runs/[seq]: replay confirm button `#fff` → `--surface`.
- metrics: subtitle "scrape interval 15s" was wrong (poll loop is 3s) → "polled every 3s".

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm test -- --run` (24/24 passing)
- [ ] Manual smoke: open recipes/compare → click promote on existing recipe → Dialog overwrite confirmation
- [ ] Manual smoke: traces filter to a status that has rows → verify pill backgrounds visible
- [ ] Manual smoke: traces export dropdown → click outside or press Escape → closes
- [ ] Manual smoke: connections Re-auth all with multiple connected providers → popups are serialized