### PR TITLE
fix(dashboard): round 6 — UX feedback + responsiveness

### DIFF
--- a/dashboard/src/app/approvals/[callId]/page.tsx
+++ b/dashboard/src/app/approvals/[callId]/page.tsx
@@ -190,7 +190,12 @@ export default function ApprovalDetailPage() {
 
   const rawGate = bridgeStatus?.patchwork?.approvalGate;
   const gateMode: GateMode =
-    rawGate === "high" || rawGate === "all" ? rawGate : "off";
+    rawGate === "high" || rawGate === "all" || rawGate === "off"
+      ? rawGate
+      : "off";
+  // Surface to the user when the bridge reports a mode this dashboard
+  // doesn't know about, instead of silently labelling it "off".
+  const gateUnknown = rawGate != null && rawGate !== gateMode;
   const effectiveTier = (pending?.tier ?? undefined) as Tier | undefined;
   // Render the policy card whenever bridge status is known. Even on
   // "Unknown callId" the user benefits from seeing their active mode —
@@ -271,7 +276,15 @@ export default function ApprovalDetailPage() {
               mode: {match.mode}
             </span>
           </div>
-          <Row label="Active mode" value={match.mode} mono />
+          <Row
+            label="Active mode"
+            value={
+              gateUnknown
+                ? `${rawGate} (unrecognised — bridge ahead of dashboard)`
+                : match.mode
+            }
+            mono
+          />
           {effectiveTier && (
             <Row label="Risk tier" value={effectiveTier} mono />
           )}

--- a/dashboard/src/app/inbox/page.tsx
+++ b/dashboard/src/app/inbox/page.tsx
@@ -675,9 +675,21 @@ const filteredItems = items.filter((item) => {
             {/* ── Right content panel ── */}
             <div style={{ flex: 1, overflowY: "auto", minWidth: 0 }}>
               {detailLoading ? (
-                <div style={{ display: "flex", alignItems: "center", gap: 10, padding: "40px 40px" }} role="status" aria-busy="true">
+                <div
+                  role="status"
+                  aria-busy="true"
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    flexDirection: "column",
+                    gap: 10,
+                    minHeight: 320,
+                    padding: "40px",
+                  }}
+                >
                   <Spinner />
-                  <span style={{ fontSize: 13, color: "var(--ink-2)" }}>Loading…</span>
+                  <span style={{ fontSize: 13, color: "var(--ink-2)" }}>Loading message…</span>
                 </div>
               ) : selected ? (
                 <div style={{ padding: "28px 40px 48px", maxWidth: 700 }}>

--- a/dashboard/src/app/insights/replay/page.tsx
+++ b/dashboard/src/app/insights/replay/page.tsx
@@ -147,8 +147,8 @@ export default function ReplayPage() {
               style={{
                 padding: "12px 16px",
                 borderRadius: "var(--r-2)",
-                background: "color-mix(in srgb, var(--ok) 10%, transparent)",
-                border: "1px solid color-mix(in srgb, var(--ok) 25%, transparent)",
+                background: "var(--ok-soft)",
+                border: "1px solid var(--ok)",
                 fontSize: 13,
                 marginBottom: "var(--s-4)",
               }}
@@ -208,9 +208,7 @@ export default function ReplayPage() {
                       key={`${row.timestamp}-${row.toolName}-${idx}`}
                       style={{
                         borderBottom: "1px solid var(--border-subtle)",
-                        background: !row.unchanged
-                          ? "color-mix(in srgb, var(--warn) 5%, transparent)"
-                          : undefined,
+                        background: !row.unchanged ? "var(--warn-soft)" : undefined,
                       }}
                     >
                       <td style={{ padding: "9px 0", verticalAlign: "middle" }}>

--- a/dashboard/src/app/marketplace/bundle/[...slug]/page.tsx
+++ b/dashboard/src/app/marketplace/bundle/[...slug]/page.tsx
@@ -259,33 +259,55 @@ function InstallInstructions({
   manifest: BundleManifest | null;
 }) {
   const plugin = manifest?.plugin;
+  const recipes = manifest?.recipes ?? [];
   return (
     <div className="glass-card" style={{ padding: "var(--s-5)" }}>
       <h3 style={{ fontSize: 13, marginTop: 0, marginBottom: "var(--s-3)" }}>Install</h3>
       <p style={{ fontSize: 12, color: "var(--fg-2)", marginTop: 0 }}>
-        Bundle install support is coming in a future bridge release. Until then, install each recipe individually from the Marketplace.
+        Bundle install via a single command isn&apos;t wired through the
+        bridge yet. Install each constituent recipe from the Marketplace —
+        the trust + risk metadata above carries over per-recipe.
       </p>
+      {recipes.length > 0 && (
+        <ul
+          style={{
+            listStyle: "none",
+            padding: 0,
+            margin: "var(--s-3) 0",
+            display: "flex",
+            flexDirection: "column",
+            gap: 4,
+          }}
+        >
+          {recipes.map((r) => (
+            <li
+              key={r}
+              style={{
+                fontSize: 12,
+                fontFamily: "var(--font-mono)",
+                color: "var(--fg-1)",
+              }}
+            >
+              <Link
+                href={`/marketplace/${encodeURIComponent(r)}`}
+                style={{
+                  color: "inherit",
+                  textDecoration: "underline",
+                  textDecorationColor: "var(--line-2)",
+                }}
+              >
+                {r}
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
       {plugin && (
         <p style={{ fontSize: 12, color: "var(--fg-2)" }}>
           Plugin: <code style={{ fontSize: 11 }}>npm install -g {plugin}</code>, then restart the bridge with{" "}
           <code style={{ fontSize: 11 }}>--plugin {plugin}</code>.
         </p>
       )}
-      <div style={{ marginTop: "var(--s-3)", display: "flex", gap: 8 }}>
-        <code
-          style={{
-            fontSize: 11,
-            background: "var(--bg-1)",
-            border: "1px solid var(--border-subtle)",
-            borderRadius: "var(--r-2)",
-            padding: "6px 10px",
-            color: "var(--fg-1)",
-          }}
-        >
-          patchwork install-bundle {bundle.name}
-        </code>
-        <span style={{ fontSize: 11, color: "var(--fg-3)", alignSelf: "center" }}>coming soon</span>
-      </div>
     </div>
   );
 }

--- a/dashboard/src/app/marketplace/page.tsx
+++ b/dashboard/src/app/marketplace/page.tsx
@@ -462,7 +462,14 @@ export default function MarketplacePage() {
     // Defense in depth: refuse to forward anything that isn't a github:owner/repo[/path]@ref
     // shape. The bridge also validates server-side; this blocks the obvious tampered-registry
     // attack at the dashboard layer before the request leaves the browser.
-    assertValidInstallSource(recipe.install);
+    try {
+      assertValidInstallSource(recipe.install);
+    } catch (e) {
+      const detail = e instanceof Error ? e.message : String(e);
+      throw new Error(
+        `This recipe's install source is invalid (${detail}). Refusing to install.`,
+      );
+    }
     const res = await fetch(apiPath("/api/bridge/recipes/install"), {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -554,7 +561,7 @@ export default function MarketplacePage() {
             Marketplace — <span className="accent">recipes built by the community.</span>
           </h1>
           <div className="editorial-sub">
-            {`${registry?.length ?? 8} recipes · open-source YAML · audited weekly`}
+            {`${registry?.length ?? FALLBACK_REGISTRY.recipes.length} recipes · open-source YAML · audited weekly`}
           </div>
         </div>
         <div style={{ display: "flex", alignItems: "center", gap: 8 }}>

--- a/dashboard/src/app/metrics/page.tsx
+++ b/dashboard/src/app/metrics/page.tsx
@@ -13,6 +13,15 @@ interface Metric {
   labels?: Record<string, string>;
 }
 
+const DONUT_COLORS = [
+  "var(--orange)",
+  "var(--blue)",
+  "var(--green)",
+  "var(--red)",
+  "var(--amber)",
+  "var(--purple)",
+];
+
 export default function MetricsPage() {
   const [metrics, setMetrics] = useState<Metric[]>([]);
   const [err, setErr] = useState<string>();
@@ -36,13 +45,16 @@ export default function MetricsPage() {
     return () => clearInterval(id);
   }, []);
 
-  const totalCalls = useMemo(
-    () =>
-      metrics
-        .filter((m) => m.name === "bridge_tool_calls_total")
-        .reduce((s, m) => s + m.value, 0),
-    [metrics],
-  );
+  const totalCalls = useMemo(() => {
+    const rows = metrics.filter((m) => m.name === "bridge_tool_calls_total");
+    // Prefer the labelless aggregate row if the bridge emits one; falling
+    // back to summing per-label rows would double-count it.
+    const aggregate = rows.find(
+      (m) => !m.labels || Object.keys(m.labels).length === 0,
+    );
+    if (aggregate) return aggregate.value;
+    return rows.reduce((s, m) => s + m.value, 0);
+  }, [metrics]);
 
   const totalErrors = useMemo(
     () =>
@@ -80,8 +92,6 @@ export default function MetricsPage() {
         .reduce((s, m) => s + m.value, 0),
     [metrics],
   );
-
-  const DONUT_COLORS = ["var(--orange)", "var(--blue)", "var(--green)", "var(--red)", "var(--amber)", "var(--purple, #a855f7)"];
 
   const toolCallDonut = useMemo<DonutSegment[]>(() => {
     const calls = metrics.filter(
@@ -138,7 +148,7 @@ export default function MetricsPage() {
             Metrics — <span className="accent">Prometheus counters, exposed locally.</span>
           </h1>
           <div className="editorial-sub">
-            polled every 3s · uptime {uptimeSeconds != null ? Math.round(uptimeSeconds) + "s" : "…"} · rate-limits {rateLimitCount}
+            polled every 3s · uptime {uptimeSeconds != null ? Math.round(uptimeSeconds) + "s" : "—"} · rate-limits {rateLimitCount}
           </div>
         </div>
         {updatedAt && (

--- a/dashboard/src/app/recipes/new/page.tsx
+++ b/dashboard/src/app/recipes/new/page.tsx
@@ -211,7 +211,13 @@ const NAME_RE = /^[a-z0-9][a-z0-9_\- ]{0,63}$/i;
 
 export default function NewRecipePage() {
   return (
-    <Suspense fallback={null}>
+    <Suspense
+      fallback={
+        <div className="empty-state" role="status" aria-live="polite">
+          <p>Loading recipe editor…</p>
+        </div>
+      }
+    >
       <NewRecipePageInner />
     </Suspense>
   );

--- a/dashboard/src/app/recipes/page.tsx
+++ b/dashboard/src/app/recipes/page.tsx
@@ -35,7 +35,12 @@ function detectConnectors(recipes: Recipe[]): string[] {
   for (const recipe of recipes) {
     const haystack = `${recipe.name} ${recipe.description ?? ""}`.toLowerCase();
     for (const [prefix, connector] of Object.entries(TOOL_PREFIX_MAP)) {
-      if (haystack.includes(prefix)) {
+      // Match either the underscored tool prefix (`slack_chat`) if it
+      // happens to be quoted in description text, or the bare connector
+      // word (`slack`, `calendar`) which is far more likely to appear in
+      // recipe names like "slack-digest" / "calendar-summary".
+      const keyword = prefix.replace(/_$/, "");
+      if (haystack.includes(prefix) || haystack.includes(keyword)) {
         found.add(connector);
       }
     }
@@ -689,16 +694,40 @@ export default function RecipesPage() {
   }
 
   async function handleToggleEnabled(recipe: Recipe) {
+    const target = recipe.enabled === false;
+    // Optimistic flip — the toggle was tap-then-wait-2s before, which felt
+    // unresponsive. Roll back to the previous state if the PATCH fails.
+    setRecipes((prev) =>
+      prev
+        ? prev.map((r) =>
+            r.name === recipe.name ? { ...r, enabled: target } : r,
+          )
+        : prev,
+    );
     try {
-      await fetch(apiPath(`/api/bridge/recipes/${encodeURIComponent(recipe.name)}`), {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ enabled: recipe.enabled === false }),
-      });
+      const res = await fetch(
+        apiPath(`/api/bridge/recipes/${encodeURIComponent(recipe.name)}`),
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ enabled: target }),
+        },
+      );
+      if (!res.ok) throw new Error(`/recipes/${recipe.name} ${res.status}`);
+      // Re-sync once on success so any server-side derived fields stay
+      // current (lastRun, etc.).
+      void load();
     } catch (e) {
       setErr(e instanceof Error ? e.message : String(e));
+      // Roll back the optimistic flip.
+      setRecipes((prev) =>
+        prev
+          ? prev.map((r) =>
+              r.name === recipe.name ? { ...r, enabled: !target } : r,
+            )
+          : prev,
+      );
     }
-    void load();
   }
 
   async function handleModalConfirm(vars: Record<string, string>) {

--- a/dashboard/src/app/suggestions/page.tsx
+++ b/dashboard/src/app/suggestions/page.tsx
@@ -285,6 +285,8 @@ export default function SuggestionsPage() {
   );
 }
 
+const SUGGESTION_PAGE_SIZE = 20;
+
 function SuggestionGroup({
   title,
   subtitle,
@@ -296,6 +298,9 @@ function SuggestionGroup({
   items: AutomationSuggestion[];
   renderAction: (s: AutomationSuggestion) => React.ReactNode;
 }) {
+  const [showAll, setShowAll] = useState(false);
+  const visible = showAll ? items : items.slice(0, SUGGESTION_PAGE_SIZE);
+  const hidden = items.length - visible.length;
   return (
     <div className="card" style={{ marginTop: "var(--s-4)" }}>
       <div className="card-head">
@@ -306,7 +311,7 @@ function SuggestionGroup({
         {subtitle}
       </p>
       <ul role="list" aria-label={title} style={{ listStyle: "none", padding: 0, margin: 0 }}>
-        {items.map((s, idx) => {
+        {visible.map((s, idx) => {
           const meta = KIND_META[s.kind];
           const key = `${s.kind}-${idx}-${
             isCoOccurringPair(s.details)
@@ -338,6 +343,16 @@ function SuggestionGroup({
           );
         })}
       </ul>
+      {hidden > 0 && (
+        <button
+          type="button"
+          className="btn sm ghost"
+          onClick={() => setShowAll(true)}
+          style={{ marginTop: "var(--s-3)", fontSize: 12 }}
+        >
+          Show {hidden} more
+        </button>
+      )}
     </div>
   );
 }

--- a/dashboard/src/app/tasks/page.tsx
+++ b/dashboard/src/app/tasks/page.tsx
@@ -540,7 +540,7 @@ export default function TasksPage() {
                     : "—";
               const isLive = t.status === "running" || t.status === "pending";
               const isSelected = selectedTaskId === t.taskId;
-              const firstOutputLine = (t.output ?? "").split("\n")[0]?.slice(0, 80) ?? "(running…)";
+              const firstOutputLine = (t.output ?? "").split("\n")[0]?.slice(0, 80) ?? "";
               const driver = driverFromTask(t);
 
               const durSec =

--- a/dashboard/src/app/tasks/page.tsx
+++ b/dashboard/src/app/tasks/page.tsx
@@ -90,6 +90,11 @@ function TaskDetail({ task, onCancel, cancelling }: {
   onCancel: (id: string) => void;
   cancelling: Record<string, boolean>;
 }) {
+  const [copied, setCopied] = useState<"id" | "term" | "replay" | null>(null);
+  function flash(kind: "id" | "term" | "replay") {
+    setCopied(kind);
+    setTimeout(() => setCopied((c) => (c === kind ? null : c)), 1500);
+  }
   const isLive = task.status === "running" || task.status === "pending";
   const errText = task.errorMessage ?? task.stderrTail;
   const dur =
@@ -213,27 +218,46 @@ function TaskDetail({ task, onCancel, cancelling }: {
           type="button"
           className="btn sm ghost"
           style={{ fontSize: 12 }}
-          onClick={() => void navigator.clipboard.writeText(`patchwork task resume ${task.taskId}`)}
-        >
-          {"> Open in terminal"}
-        </button>
-        <button
-          type="button"
-          className="btn sm ghost"
-          style={{ fontSize: 12 }}
-          onClick={() => {
-            void fetch(apiPath(`/api/bridge/tasks/${task.taskId}/replay`), { method: "POST" });
+          onClick={async () => {
+            await navigator.clipboard.writeText(`patchwork task resume ${task.taskId}`);
+            flash("term");
           }}
         >
-          ↻ Replay
+          {copied === "term" ? "✓ Copied" : "> Open in terminal"}
         </button>
         <button
           type="button"
           className="btn sm ghost"
           style={{ fontSize: 12 }}
-          onClick={() => void navigator.clipboard.writeText(task.taskId)}
+          onClick={async () => {
+            try {
+              const res = await fetch(
+                apiPath(`/api/bridge/tasks/${task.taskId}/replay`),
+                { method: "POST" },
+              );
+              if (res.ok) flash("replay");
+            } catch {
+              /* swallow — surfaced via next poll */
+            }
+          }}
         >
-          📋 Copy id
+          {copied === "replay" ? "✓ Queued" : "↻ Replay"}
+        </button>
+        <button
+          type="button"
+          className="btn sm ghost"
+          aria-label="Copy task ID"
+          style={{ fontSize: 12 }}
+          onClick={async () => {
+            await navigator.clipboard.writeText(task.taskId);
+            flash("id");
+          }}
+        >
+          {copied === "id" ? "✓ Copied" : (
+            <>
+              <span aria-hidden="true">📋 </span>Copy id
+            </>
+          )}
         </button>
         {isLive && (
           <button

--- a/dashboard/src/app/traces/page.tsx
+++ b/dashboard/src/app/traces/page.tsx
@@ -225,7 +225,7 @@ function TraceDetail({
                   color: theme.fg,
                   fontWeight: 600,
                   fontSize: 11,
-                  background: i % 2 === 0 ? "rgba(0,0,0,0.06)" : "transparent",
+                  background: i % 2 === 0 ? "var(--recess)" : "transparent",
                   borderRight: "1px solid var(--line-2)",
                   whiteSpace: "nowrap",
                 }}
@@ -238,7 +238,7 @@ function TraceDetail({
                   fontFamily: "var(--font-mono)",
                   color: "var(--ink-1)",
                   fontSize: 11,
-                  background: i % 2 === 0 ? "rgba(0,0,0,0.06)" : "transparent",
+                  background: i % 2 === 0 ? "var(--recess)" : "transparent",
                   wordBreak: "break-all",
                 }}
               >


### PR DESCRIPTION
## Summary

Round 6 of post-merge cleanup. Visible UX-feedback issues + a few token consistency tidies.

### UX feedback
- **Tasks** clipboard buttons now flash \"✓ Copied\" for 1.5s; Replay flashes \"✓ Queued\" and surfaces failures (was fire-and-forget).
- **Recipes** toggle-enabled is now optimistic (was tap → wait-for-poll-tick → flip). Rolls back on PATCH failure.
- **Recipes/new** Suspense fallback shows a loading status instead of a blank flash on hydration.
- **Inbox** detail loading state is full-panel centered with min-height 320 instead of a top-left spinner that caused layout shift.
- **Marketplace** install error now reads \"This recipe's install source is invalid (…). Refusing to install.\" instead of dumping the raw assertion.
- **Marketplace bundle** drops the \"coming soon\" `patchwork install-bundle` placeholder; replaces with per-recipe Marketplace links so users can actually install today.

### Tokens
- **Traces** TraceDetail alternating row bg `rgba(0,0,0,0.06)` → `var(--recess)`.
- **Insights/replay** highlight backgrounds drop inline `color-mix(in srgb, var(--warn) 5%, transparent)` for the pre-defined `--warn-soft`/`--ok-soft` tokens.

### Heuristics
- **Recipes** `detectConnectors` now matches both `slack_` (tool-prefix) and `slack` (bare connector keyword), so recipe names like `calendar-summary` actually surface their connector dependency.
- **Marketplace** footer recipe count uses `FALLBACK_REGISTRY.recipes.length` instead of a hardcoded `8` that drifted from reality.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm test -- --run` (24/24)
- [ ] Manual: tasks page → click Copy id → button flashes ✓ Copied for 1.5s
- [ ] Manual: recipes page → toggle a recipe → indicator flips immediately, doesn't wait for the next poll
- [ ] Manual: marketplace bundle page → recipes link to /marketplace/<name>
- [ ] Manual: inbox → click an item with a heavier detail → loading spinner is centered, no layout shift