### PR TITLE
refactor(dashboard): migrate inline fontSize literals to tokens

### DIFF
--- a/dashboard/src/app/activity/page.tsx
+++ b/dashboard/src/app/activity/page.tsx
@@ -212,7 +212,7 @@ export default function ActivityPage() {
           <div
             style={{
               fontFamily: "var(--font-mono)",
-              fontSize: 10,
+              fontSize: "var(--fs-2xs)",
               fontWeight: 700,
               letterSpacing: "0.08em",
               textTransform: "uppercase",
@@ -229,7 +229,7 @@ export default function ActivityPage() {
             <div
               style={{
                 fontFamily: "var(--font-mono)",
-                fontSize: 10,
+                fontSize: "var(--fs-2xs)",
                 fontWeight: 700,
                 letterSpacing: "0.08em",
                 textTransform: "uppercase",
@@ -283,7 +283,7 @@ export default function ActivityPage() {
               onClick={() => setTab(t)}
               style={{
                 padding: "6px 16px",
-                fontSize: 12,
+                fontSize: "var(--fs-s)",
                 fontWeight: 500,
                 cursor: "pointer",
                 color: tab === t ? "var(--fg-0)" : "var(--fg-2)",
@@ -298,7 +298,7 @@ export default function ActivityPage() {
               {labels[t]}{" "}
               <span
                 style={{
-                  fontSize: 11,
+                  fontSize: "var(--fs-xs)",
                   color: tab === t ? "var(--accent)" : "var(--fg-3)",
                   fontFamily: "var(--font-mono)",
                 }}

--- a/dashboard/src/app/analytics/page.tsx
+++ b/dashboard/src/app/analytics/page.tsx
@@ -203,15 +203,15 @@ export default function AnalyticsPage() {
           {/* Area chart — runs per hour */}
           <div className="card" style={{ padding: "14px 20px 10px", marginTop: "var(--s-4)", marginBottom: "var(--s-4)" }}>
             <div style={{ display: "flex", alignItems: "center", gap: "var(--s-3)", marginBottom: 8 }}>
-              <span style={{ fontFamily: "var(--font-mono)", fontSize: 10, fontWeight: 700, letterSpacing: "0.08em", textTransform: "uppercase", color: "var(--ink-3)" }}>
+              <span style={{ fontFamily: "var(--font-mono)", fontSize: "var(--fs-2xs)", fontWeight: 700, letterSpacing: "0.08em", textTransform: "uppercase", color: "var(--ink-3)" }}>
                 Calls — last 24 hours
               </span>
               <span style={{ flex: 1 }} />
               <span style={{ display: "inline-flex", alignItems: "center", gap: 6 }}>
                 <span style={{ width: 8, height: 3, background: "var(--orange)", borderRadius: 2, display: "inline-block" }} />
-                <span style={{ fontFamily: "var(--font-mono)", fontSize: 10, color: "var(--ink-2)" }}>runs</span>
+                <span style={{ fontFamily: "var(--font-mono)", fontSize: "var(--fs-2xs)", color: "var(--ink-2)" }}>runs</span>
                 <span style={{ width: 8, height: 3, background: "var(--red)", borderRadius: 2, display: "inline-block", marginLeft: 8 }} />
-                <span style={{ fontFamily: "var(--font-mono)", fontSize: 10, color: "var(--ink-2)" }}>errors</span>
+                <span style={{ fontFamily: "var(--font-mono)", fontSize: "var(--fs-2xs)", color: "var(--ink-2)" }}>errors</span>
               </span>
             </div>
             {clientNow === 0 ? (
@@ -230,21 +230,21 @@ export default function AnalyticsPage() {
           {loading ? (
             <div
               className="card"
-              style={{ color: "var(--fg-3)", fontSize: 13 }}
+              style={{ color: "var(--fg-3)", fontSize: "var(--fs-m)" }}
             >
               Loading…
             </div>
           ) : topTools.length === 0 ? (
             <div className="empty-state">
               <h3>No tool call data yet</h3>
-              <p style={{ marginTop: "var(--s-2)", fontSize: 13 }}>
+              <p style={{ marginTop: "var(--s-2)", fontSize: "var(--fs-m)" }}>
                 Analytics data accumulates over time. Make a few tool calls and
                 refresh.
               </p>
             </div>
           ) : (
             <div className="card" style={{ padding: "var(--s-5)" }}>
-              <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 12 }}>
+              <table style={{ width: "100%", borderCollapse: "collapse", fontSize: "var(--fs-s)" }}>
                 <tbody>
                   {topTools.map((t) => (
                     <tr key={t.tool} style={{ borderBottom: "1px solid var(--line-3)" }}>
@@ -302,7 +302,7 @@ export default function AnalyticsPage() {
                             {task.name && (
                               <span
                                 className="muted"
-                                style={{ marginLeft: 8, fontSize: 11 }}
+                                style={{ marginLeft: 8, fontSize: "var(--fs-xs)" }}
                               >
                                 {task.id}
                               </span>

--- a/dashboard/src/app/approvals/[callId]/page.tsx
+++ b/dashboard/src/app/approvals/[callId]/page.tsx
@@ -215,14 +215,14 @@ export default function ApprovalDetailPage() {
     <section>
       <div className="page-head">
         <div>
-          <div style={{ fontSize: 12, marginBottom: 4 }}>
+          <div style={{ fontSize: "var(--fs-s)", marginBottom: 4 }}>
             <Link href="/approvals" style={{ color: "var(--fg-2)" }}>
               ← Approvals
             </Link>
           </div>
           <h1>{toolName}</h1>
           <div className="page-head-sub">
-            <code style={{ fontFamily: "var(--font-mono)", fontSize: 12 }}>
+            <code style={{ fontFamily: "var(--font-mono)", fontSize: "var(--fs-s)" }}>
               {callId}
             </code>
           </div>
@@ -295,7 +295,7 @@ export default function ApprovalDetailPage() {
           />
           <p
             style={{
-              fontSize: 13,
+              fontSize: "var(--fs-m)",
               color: "var(--fg-1)",
               marginTop: 10,
               lineHeight: 1.5,
@@ -319,11 +319,11 @@ export default function ApprovalDetailPage() {
         >
           <div className="card-head">
             <h2>Decide</h2>
-            <span className="pill warn" style={{ fontSize: 11 }}>
+            <span className="pill warn" style={{ fontSize: "var(--fs-xs)" }}>
               <span className="pill-dot" /> awaiting you
             </span>
           </div>
-          <p style={{ fontSize: 13, color: "var(--ink-2)", marginBottom: "var(--s-3)" }}>
+          <p style={{ fontSize: "var(--fs-m)", color: "var(--ink-2)", marginBottom: "var(--s-3)" }}>
             Still in the queue. Approve or reject to unblock the caller.
           </p>
           <div style={{ display: "flex", gap: "var(--s-2)", flexWrap: "wrap" }}>
@@ -431,12 +431,12 @@ export default function ApprovalDetailPage() {
             <h2>Session</h2>
           </div>
           <div style={{ display: "flex", gap: "var(--s-3)", flexWrap: "wrap" }}>
-            <code style={{ fontFamily: "var(--font-mono)", fontSize: 12 }}>
+            <code style={{ fontFamily: "var(--font-mono)", fontSize: "var(--fs-s)" }}>
               {sessionId}
             </code>
             <Link
               href={`/approvals?session=${sessionId}`}
-              style={{ fontSize: 13, color: "var(--accent)" }}
+              style={{ fontSize: "var(--fs-m)", color: "var(--accent)" }}
             >
               All approvals for this session →
             </Link>
@@ -535,7 +535,7 @@ function Row({
         gap: 16,
         padding: "10px 0",
         borderBottom: "1px solid var(--border-subtle)",
-        fontSize: 13,
+        fontSize: "var(--fs-m)",
       }}
     >
       <span style={{ color: "var(--fg-2)" }}>{label}</span>

--- a/dashboard/src/app/approvals/page.tsx
+++ b/dashboard/src/app/approvals/page.tsx
@@ -326,14 +326,14 @@ function ApprovalCard({
             borderRadius: 6,
             background: "var(--recess)",
             border: "1px solid var(--line-1)",
-            fontSize: 14,
+            fontSize: "var(--fs-base)",
             flexShrink: 0,
           }}
         >
           {icon}
         </span>
         <div style={{ flex: 1, minWidth: 0 }}>
-          <h3 style={{ margin: 0, fontFamily: "var(--font-mono)", fontSize: 14, fontWeight: 700, color: "var(--ink-0)", wordBreak: "break-all" }}>
+          <h3 style={{ margin: 0, fontFamily: "var(--font-mono)", fontSize: "var(--fs-base)", fontWeight: 700, color: "var(--ink-0)", wordBreak: "break-all" }}>
             {heading}
           </h3>
         </div>
@@ -354,7 +354,7 @@ function ApprovalCard({
       </div>
 
       {p.summary && (
-        <p style={{ margin: "10px 0 0 52px", fontSize: 13, color: "var(--ink-2)", lineHeight: 1.5 }}>
+        <p style={{ margin: "10px 0 0 52px", fontSize: "var(--fs-m)", color: "var(--ink-2)", lineHeight: 1.5 }}>
           {p.summary}
         </p>
       )}
@@ -443,7 +443,7 @@ function ApprovalCard({
                   position: "absolute",
                   top: 6,
                   right: 6,
-                  fontSize: 11,
+                  fontSize: "var(--fs-xs)",
                   padding: "3px 8px",
                   borderRadius: 4,
                   background: "var(--surface)",
@@ -579,7 +579,7 @@ function BatchActionBar({
       role="toolbar"
       aria-label="Batch actions"
     >
-      <span style={{ fontSize: 13, color: "var(--fg-1)", fontWeight: 500 }}>
+      <span style={{ fontSize: "var(--fs-m)", color: "var(--fg-1)", fontWeight: 500 }}>
         {selectedCount} selected
       </span>
       <span className="approval-spacer" />
@@ -993,7 +993,7 @@ function ApprovalsContent() {
               alignItems: "center",
               gap: 14,
               marginTop: 8,
-              fontSize: 11,
+              fontSize: "var(--fs-xs)",
               color: "var(--ink-3)",
               flexWrap: "wrap",
             }}
@@ -1049,7 +1049,7 @@ function ApprovalsContent() {
         <div style={{ flex: 1, minWidth: 180 }}>
           <div
             style={{
-              fontSize: 10,
+              fontSize: "var(--fs-2xs)",
               color: "var(--ink-2)",
               fontWeight: 600,
               textTransform: "uppercase",
@@ -1059,7 +1059,7 @@ function ApprovalsContent() {
           >
             Queue
           </div>
-          <div style={{ fontSize: 20, fontWeight: 800, color: "var(--ink-0)", lineHeight: 1.1 }}>
+          <div style={{ fontSize: "var(--fs-3xl)", fontWeight: 800, color: "var(--ink-0)", lineHeight: 1.1 }}>
             {pending.length === 0 ? "All clear" : `${pending.length} awaiting decision`}
           </div>
         </div>
@@ -1088,7 +1088,7 @@ function ApprovalsContent() {
                 </div>
                 <div
                   style={{
-                    fontSize: 10,
+                    fontSize: "var(--fs-2xs)",
                     color: "var(--ink-2)",
                     marginTop: 4,
                     fontWeight: 600,
@@ -1126,20 +1126,20 @@ function ApprovalsContent() {
                 borderLeft: "1px solid var(--line-2)",
               }}
             >
-              <div style={{ fontSize: 10, color: "var(--ink-2)", fontWeight: 600, textTransform: "uppercase", letterSpacing: "0.07em" }}>
+              <div style={{ fontSize: "var(--fs-2xs)", color: "var(--ink-2)", fontWeight: 600, textTransform: "uppercase", letterSpacing: "0.07em" }}>
                 Historical rate
               </div>
               <div style={{ display: "flex", gap: 6, alignItems: "center" }}>
                 <span
                   className="pill ok"
-                  style={{ fontSize: 11, fontFamily: "var(--font-mono)", fontWeight: 700 }}
+                  style={{ fontSize: "var(--fs-xs)", fontFamily: "var(--font-mono)", fontWeight: 700 }}
                   title={`${totalApproved} approved`}
                 >
                   {approvePct}% approved
                 </span>
                 <span
                   className="pill err"
-                  style={{ fontSize: 11, fontFamily: "var(--font-mono)", fontWeight: 700 }}
+                  style={{ fontSize: "var(--fs-xs)", fontFamily: "var(--font-mono)", fontWeight: 700 }}
                   title={`${totalRejected} rejected`}
                 >
                   {rejectPct}% rejected
@@ -1161,7 +1161,7 @@ function ApprovalsContent() {
                   <div style={{ flex: 1, background: "var(--err)", borderRadius: "0 3px 3px 0" }} />
                 )}
               </div>
-              <div style={{ fontSize: 10, color: "var(--ink-3)" }}>
+              <div style={{ fontSize: "var(--fs-2xs)", color: "var(--ink-3)" }}>
                 {total} decision{total !== 1 ? "s" : ""} this session
               </div>
             </div>
@@ -1248,7 +1248,7 @@ function ApprovalsContent() {
                 aria-label="Select all approvals"
                 style={{ cursor: "pointer", accentColor: "var(--accent)" }}
               />
-              <span style={{ fontSize: 12, color: "var(--fg-2)" }}>
+              <span style={{ fontSize: "var(--fs-s)", color: "var(--fg-2)" }}>
                 Select all
               </span>
             </div>
@@ -1295,7 +1295,7 @@ function ApprovalsContent() {
           </div>
           <p
             style={{
-              fontSize: 13,
+              fontSize: "var(--fs-m)",
               color: "var(--fg-2)",
               marginBottom: "var(--s-4)",
             }}
@@ -1327,7 +1327,7 @@ function ApprovalsContent() {
                 <code
                   style={{
                     fontFamily: "var(--font-mono)",
-                    fontSize: 13,
+                    fontSize: "var(--fs-m)",
                     color: "var(--fg-0)",
                     flex: 1,
                     minWidth: 140,
@@ -1336,7 +1336,7 @@ function ApprovalsContent() {
                   {toolName}
                 </code>
                 <span
-                  style={{ fontSize: 13, color: "var(--fg-2)", flexShrink: 0 }}
+                  style={{ fontSize: "var(--fs-m)", color: "var(--fg-2)", flexShrink: 0 }}
                 >
                   approved {p.approved}&times;
                 </span>

--- a/dashboard/src/app/connections/AddConnectionModal.tsx
+++ b/dashboard/src/app/connections/AddConnectionModal.tsx
@@ -103,7 +103,7 @@ export default function AddConnectionModal({
           zIndex: 1,
         }}
       >
-        <h2 id="add-connection-title" style={{ fontSize: 16, margin: 0 }}>
+        <h2 id="add-connection-title" style={{ fontSize: "var(--fs-xl)", margin: 0 }}>
           Add connection
         </h2>
         <button
@@ -115,7 +115,7 @@ export default function AddConnectionModal({
             border: "none",
             cursor: "pointer",
             color: "var(--fg-2)",
-            fontSize: 20,
+            fontSize: "var(--fs-3xl)",
             lineHeight: 1,
             padding: "4px 6px",
             borderRadius: "var(--r-2)",
@@ -170,7 +170,7 @@ export default function AddConnectionModal({
                     marginBottom: 2,
                   }}
                 >
-                  <span style={{ fontWeight: 600, fontSize: 13, color: "var(--fg-0)" }}>
+                  <span style={{ fontWeight: 600, fontSize: "var(--fs-m)", color: "var(--fg-0)" }}>
                     {name}
                   </span>
                   <span
@@ -205,7 +205,7 @@ export default function AddConnectionModal({
                 <div
                   title={description}
                   style={{
-                    fontSize: 12,
+                    fontSize: "var(--fs-s)",
                     color: "var(--fg-2)",
                     lineHeight: 1.4,
                     whiteSpace: "nowrap",
@@ -268,7 +268,7 @@ export default function AddConnectionModal({
               border: "none",
               padding: 0,
               cursor: "pointer",
-              fontSize: 12,
+              fontSize: "var(--fs-s)",
               color: "var(--fg-2)",
               textDecoration: "underline",
             }}
@@ -278,7 +278,7 @@ export default function AddConnectionModal({
         )}
 
         {reqSuccess && (
-          <p role="status" style={{ fontSize: 12, color: "var(--ok)", margin: 0 }}>
+          <p role="status" style={{ fontSize: "var(--fs-s)", color: "var(--ok)", margin: 0 }}>
             <span aria-hidden="true">✓ </span>Request submitted. We&apos;ll add
             it to the roadmap.
           </p>
@@ -300,7 +300,7 @@ export default function AddConnectionModal({
               style={{
                 width: "100%",
                 padding: "6px 10px",
-                fontSize: 13,
+                fontSize: "var(--fs-m)",
                 background: "var(--bg-1)",
                 border: "1px solid var(--line-2)",
                 borderRadius: "var(--r-2)",
@@ -318,7 +318,7 @@ export default function AddConnectionModal({
               style={{
                 width: "100%",
                 padding: "6px 10px",
-                fontSize: 13,
+                fontSize: "var(--fs-m)",
                 background: "var(--bg-1)",
                 border: "1px solid var(--line-2)",
                 borderRadius: "var(--r-2)",
@@ -328,7 +328,7 @@ export default function AddConnectionModal({
               }}
             />
             {reqError && (
-              <p role="alert" style={{ fontSize: 12, color: "var(--err)", margin: 0 }}>
+              <p role="alert" style={{ fontSize: "var(--fs-s)", color: "var(--err)", margin: 0 }}>
                 {reqError}
               </p>
             )}
@@ -348,7 +348,7 @@ export default function AddConnectionModal({
                   border: "none",
                   padding: 0,
                   cursor: "pointer",
-                  fontSize: 12,
+                  fontSize: "var(--fs-s)",
                   color: "var(--fg-2)",
                   textDecoration: "underline",
                 }}

--- a/dashboard/src/app/connections/page.tsx
+++ b/dashboard/src/app/connections/page.tsx
@@ -598,10 +598,10 @@ function ConnectorGridCard({ def, statusEntry, onConnect, onDisconnect, onTest, 
 
         {/* Name + category */}
         <div style={{ marginBottom: 10 }}>
-          <div style={{ fontWeight: 700, fontSize: 14, color: "var(--ink-0)", lineHeight: 1.25, marginBottom: 2 }}>
+          <div style={{ fontWeight: 700, fontSize: "var(--fs-base)", color: "var(--ink-0)", lineHeight: 1.25, marginBottom: 2 }}>
             {def.name}
           </div>
-          <div style={{ fontSize: 12, color: "var(--ink-2)", fontWeight: 400 }}>{def.category}</div>
+          <div style={{ fontSize: "var(--fs-s)", color: "var(--ink-2)", fontWeight: 400 }}>{def.category}</div>
         </div>
 
         {/* Status badge */}
@@ -610,7 +610,7 @@ function ConnectorGridCard({ def, statusEntry, onConnect, onDisconnect, onTest, 
             display: "inline-flex", alignItems: "center", gap: 5,
             padding: "3px 9px", borderRadius: 999,
             background: "var(--ok-soft)", border: "1px solid var(--ok)",
-            fontSize: 10, fontWeight: 700, color: "var(--ok)",
+            fontSize: "var(--fs-2xs)", fontWeight: 700, color: "var(--ok)",
             textTransform: "uppercase", letterSpacing: "0.07em",
             marginBottom: 10,
           }}>
@@ -621,7 +621,7 @@ function ConnectorGridCard({ def, statusEntry, onConnect, onDisconnect, onTest, 
             display: "inline-flex", alignItems: "center", gap: 5,
             padding: "3px 9px", borderRadius: 999,
             background: "var(--warn-soft)", border: "1px solid var(--warn)",
-            fontSize: 10, fontWeight: 700, color: "var(--warn)",
+            fontSize: "var(--fs-2xs)", fontWeight: 700, color: "var(--warn)",
             textTransform: "uppercase", letterSpacing: "0.07em",
             marginBottom: 10,
           }}>
@@ -633,7 +633,7 @@ function ConnectorGridCard({ def, statusEntry, onConnect, onDisconnect, onTest, 
             padding: "3px 9px", borderRadius: 999,
             background: isComingSoon ? "var(--purple-soft)" : "var(--recess)",
             border: `1px solid ${isComingSoon ? "var(--purple)" : "var(--line-2)"}`,
-            fontSize: 10, fontWeight: 700, color: isComingSoon ? "var(--purple)" : "var(--ink-3)",
+            fontSize: "var(--fs-2xs)", fontWeight: 700, color: isComingSoon ? "var(--purple)" : "var(--ink-3)",
             textTransform: "uppercase", letterSpacing: "0.07em",
             marginBottom: 10,
           }}>
@@ -649,7 +649,7 @@ function ConnectorGridCard({ def, statusEntry, onConnect, onDisconnect, onTest, 
                 key={s}
                 style={{
                   fontFamily: "var(--font-mono)",
-                  fontSize: 10,
+                  fontSize: "var(--fs-2xs)",
                   padding: "2px 6px",
                   borderRadius: 4,
                   background: "var(--purple-soft)",
@@ -663,7 +663,7 @@ function ConnectorGridCard({ def, statusEntry, onConnect, onDisconnect, onTest, 
             ))}
           </div>
         ) : (
-          <div style={{ fontSize: 12, color: "var(--ink-3)", fontWeight: 400 }}>
+          <div style={{ fontSize: "var(--fs-s)", color: "var(--ink-3)", fontWeight: 400 }}>
             {def.tools} available tools
           </div>
         )}
@@ -677,7 +677,7 @@ function ConnectorGridCard({ def, statusEntry, onConnect, onDisconnect, onTest, 
               marginTop: 8,
               padding: "6px 10px",
               borderRadius: "var(--r-2)",
-              fontSize: 11,
+              fontSize: "var(--fs-xs)",
               background: testResult.ok ? "var(--ok-soft)" : "var(--err-soft)",
               color: testResult.ok ? "var(--ok)" : "var(--err)",
             }}
@@ -702,7 +702,7 @@ function ConnectorGridCard({ def, statusEntry, onConnect, onDisconnect, onTest, 
             gap: 6,
           }}
         >
-          <div style={{ display: "flex", alignItems: "center", gap: 5, fontSize: 12, color: isDegraded ? "var(--warn)" : "var(--ink-2)", minWidth: 0, overflow: "hidden" }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 5, fontSize: "var(--fs-s)", color: isDegraded ? "var(--warn)" : "var(--ink-2)", minWidth: 0, overflow: "hidden" }}>
             <span
               style={{
                 width: 6, height: 6, borderRadius: "50%",
@@ -761,7 +761,7 @@ function ConnectorGridCard({ def, statusEntry, onConnect, onDisconnect, onTest, 
                 disabled={testing || loading}
                 aria-label={`Test ${def.name} connection`}
                 style={{
-                  fontSize: 11, fontWeight: 500, padding: "3px 9px",
+                  fontSize: "var(--fs-xs)", fontWeight: 500, padding: "3px 9px",
                   borderRadius: 5, border: "1px solid var(--border-default)",
                   background: "var(--card-bg)", color: "var(--ink-1)",
                   cursor: testing ? "wait" : "pointer",
@@ -777,7 +777,7 @@ function ConnectorGridCard({ def, statusEntry, onConnect, onDisconnect, onTest, 
               disabled={loading}
               aria-label={isDegraded ? `Reconnect ${def.name}` : `Disconnect ${def.name}`}
               style={{
-                fontSize: 11, fontWeight: 500, padding: "3px 9px",
+                fontSize: "var(--fs-xs)", fontWeight: 500, padding: "3px 9px",
                 borderRadius: 5, border: "none",
                 background: isDegraded ? "var(--warn-soft)" : "var(--err-soft)",
                 color: isDegraded ? "var(--warn)" : "var(--err)",
@@ -800,7 +800,7 @@ function ConnectorGridCard({ def, statusEntry, onConnect, onDisconnect, onTest, 
             disabled={loading}
             aria-label={`Connect ${def.name}`}
             style={{
-              width: "100%", fontSize: 12, fontWeight: 600, padding: "7px 0",
+              width: "100%", fontSize: "var(--fs-s)", fontWeight: 600, padding: "7px 0",
               borderRadius: 6, border: "none",
               background: "var(--accent)", color: "var(--on-accent)",
               cursor: loading ? "wait" : "pointer",
@@ -834,8 +834,8 @@ function RecentCard({ def, lastSync }: { def: ConnectorDef; lastSync: string }) 
     >
       <LogoTile def={def} size={40} />
       <div>
-        <div style={{ fontWeight: 700, fontSize: 13, color: "var(--ink-0)" }}>{def.name}</div>
-        <div style={{ fontSize: 11, color: "var(--ok)", marginTop: 2, fontWeight: 500 }}>
+        <div style={{ fontWeight: 700, fontSize: "var(--fs-m)", color: "var(--ink-0)" }}>{def.name}</div>
+        <div style={{ fontSize: "var(--fs-xs)", color: "var(--ok)", marginTop: 2, fontWeight: 500 }}>
           ✓ {relativeTime(lastSync)}
         </div>
       </div>
@@ -1143,7 +1143,7 @@ export default function ConnectionsPage() {
               {reAuthing ? "Re-authing…" : "↻ Re-auth all"}
             </button>
             {reAuthMsg && (
-              <span role="status" style={{ fontSize: 12, color: "var(--warn)" }}>
+              <span role="status" style={{ fontSize: "var(--fs-s)", color: "var(--warn)" }}>
                 {reAuthMsg}
               </span>
             )}
@@ -1168,7 +1168,7 @@ export default function ConnectionsPage() {
           {/* Recently used strip */}
           {recentlyUsed.length > 0 && (
             <div style={{ marginBottom: "var(--s-5)" }}>
-              <div style={{ fontSize: 11, fontWeight: 700, color: "var(--ink-2)", textTransform: "uppercase", letterSpacing: "0.07em", marginBottom: 10 }}>
+              <div style={{ fontSize: "var(--fs-xs)", fontWeight: 700, color: "var(--ink-2)", textTransform: "uppercase", letterSpacing: "0.07em", marginBottom: 10 }}>
                 Recently used
               </div>
               <div style={{ display: "flex", gap: 10, overflowX: "auto", paddingBottom: 4 }}>
@@ -1182,7 +1182,7 @@ export default function ConnectionsPage() {
           {/* Empty state CTA */}
           {!hasAnyConnected && (
             <div style={{ textAlign: "center", padding: "var(--s-6) 0", marginBottom: "var(--s-5)" }}>
-              <p style={{ color: "var(--ink-2)", fontSize: 14, marginBottom: "var(--s-4)" }}>
+              <p style={{ color: "var(--ink-2)", fontSize: "var(--fs-base)", marginBottom: "var(--s-4)" }}>
                 No connections yet. Add one to get started.
               </p>
               <button type="button" className="btn primary" onClick={() => setModalOpen(true)}>
@@ -1204,7 +1204,7 @@ export default function ConnectionsPage() {
                 type="button"
                 onClick={() => setStatusFilter(k)}
                 className={statusFilter === k ? "pill accent" : "pill muted"}
-                style={{ cursor: "pointer", border: "none", fontSize: 12 }}
+                style={{ cursor: "pointer", border: "none", fontSize: "var(--fs-s)" }}
               >
                 {label}
               </button>
@@ -1237,9 +1237,9 @@ export default function ConnectionsPage() {
         <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
           <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
             <IconNotion />
-            <strong id="notion-modal-title" style={{ fontSize: 15 }}>Connect Notion</strong>
+            <strong id="notion-modal-title" style={{ fontSize: "var(--fs-l)" }}>Connect Notion</strong>
           </div>
-          <p style={{ fontSize: 13, color: "var(--fg-2)", margin: 0 }}>
+          <p style={{ fontSize: "var(--fs-m)", color: "var(--fg-2)", margin: 0 }}>
             Create an internal integration at{" "}
             <a href="https://www.notion.so/my-integrations" target="_blank" rel="noreferrer" style={{ color: "var(--info)" }}>
               notion.so/my-integrations
@@ -1252,14 +1252,14 @@ export default function ConnectionsPage() {
             value={notionToken}
             onChange={(e) => setNotionToken(e.target.value)}
             onKeyDown={(e) => { if (e.key === "Enter") void handleNotionConnect(); }}
-            style={{ fontFamily: "var(--font-mono)", fontSize: 13, padding: "8px 12px", borderRadius: 6, border: "1px solid var(--border-subtle)", background: "var(--bg-0)", color: "var(--fg-1)", width: "100%", boxSizing: "border-box" }}
+            style={{ fontFamily: "var(--font-mono)", fontSize: "var(--fs-m)", padding: "8px 12px", borderRadius: 6, border: "1px solid var(--border-subtle)", background: "var(--bg-0)", color: "var(--fg-1)", width: "100%", boxSizing: "border-box" }}
           />
-          {notionErr && <div className="alert-err" role="alert" style={{ fontSize: 12 }}>{notionErr}</div>}
+          {notionErr && <div className="alert-err" role="alert" style={{ fontSize: "var(--fs-s)" }}>{notionErr}</div>}
           <div style={{ display: "flex", gap: 8, justifyContent: "flex-end" }}>
             <button
               type="button"
               onClick={() => { setNotionModalOpen(false); setNotionToken(""); setNotionErr(null); }}
-              style={{ padding: "6px 16px", fontSize: 13, cursor: "pointer", borderRadius: 6, border: "1px solid var(--border-subtle)", background: "var(--bg-1)", color: "var(--fg-1)" }}
+              style={{ padding: "6px 16px", fontSize: "var(--fs-m)", cursor: "pointer", borderRadius: 6, border: "1px solid var(--border-subtle)", background: "var(--bg-1)", color: "var(--fg-1)" }}
             >
               Cancel
             </button>
@@ -1267,7 +1267,7 @@ export default function ConnectionsPage() {
               type="button"
               onClick={() => void handleNotionConnect()}
               disabled={notionConnecting || !notionToken}
-              style={{ padding: "6px 16px", fontSize: 13, cursor: notionConnecting ? "wait" : "pointer", borderRadius: 6, border: "none", background: "var(--fg-1)", color: "var(--bg-0)", opacity: !notionToken ? 0.5 : 1 }}
+              style={{ padding: "6px 16px", fontSize: "var(--fs-m)", cursor: notionConnecting ? "wait" : "pointer", borderRadius: 6, border: "none", background: "var(--fg-1)", color: "var(--bg-0)", opacity: !notionToken ? 0.5 : 1 }}
             >
               {notionConnecting ? "Connecting…" : "Connect"}
             </button>
@@ -1286,9 +1286,9 @@ export default function ConnectionsPage() {
           <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
             <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
               {TOKEN_MODAL_CONNECTORS[tokenModal].icon}
-              <strong id="token-modal-title" style={{ fontSize: 15 }}>Connect {TOKEN_MODAL_CONNECTORS[tokenModal].name}</strong>
+              <strong id="token-modal-title" style={{ fontSize: "var(--fs-l)" }}>Connect {TOKEN_MODAL_CONNECTORS[tokenModal].name}</strong>
             </div>
-            <p style={{ fontSize: 13, color: "var(--fg-2)", margin: 0, lineHeight: 1.6 }}>
+            <p style={{ fontSize: "var(--fs-m)", color: "var(--fg-2)", margin: 0, lineHeight: 1.6 }}>
               {TOKEN_MODAL_CONNECTORS[tokenModal].instructions}
             </p>
             <input
@@ -1297,14 +1297,14 @@ export default function ConnectionsPage() {
               value={tokenValue}
               onChange={(e) => setTokenValue(e.target.value)}
               onKeyDown={(e) => { if (e.key === "Enter") void handleTokenConnect(); }}
-              style={{ fontFamily: "var(--font-mono)", fontSize: 13, padding: "8px 12px", borderRadius: 6, border: "1px solid var(--border-subtle)", background: "var(--bg-0)", color: "var(--fg-1)", width: "100%", boxSizing: "border-box" }}
+              style={{ fontFamily: "var(--font-mono)", fontSize: "var(--fs-m)", padding: "8px 12px", borderRadius: 6, border: "1px solid var(--border-subtle)", background: "var(--bg-0)", color: "var(--fg-1)", width: "100%", boxSizing: "border-box" }}
             />
-            {tokenErr && <div className="alert-err" role="alert" style={{ fontSize: 12 }}>{tokenErr}</div>}
+            {tokenErr && <div className="alert-err" role="alert" style={{ fontSize: "var(--fs-s)" }}>{tokenErr}</div>}
             <div style={{ display: "flex", gap: 8, justifyContent: "flex-end" }}>
               <button
                 type="button"
                 onClick={() => { setTokenModal(null); setTokenValue(""); setTokenErr(null); }}
-                style={{ padding: "6px 16px", fontSize: 13, cursor: "pointer", borderRadius: 6, border: "1px solid var(--border-subtle)", background: "var(--bg-1)", color: "var(--fg-1)" }}
+                style={{ padding: "6px 16px", fontSize: "var(--fs-m)", cursor: "pointer", borderRadius: 6, border: "1px solid var(--border-subtle)", background: "var(--bg-1)", color: "var(--fg-1)" }}
               >
                 Cancel
               </button>
@@ -1312,7 +1312,7 @@ export default function ConnectionsPage() {
                 type="button"
                 onClick={() => void handleTokenConnect()}
                 disabled={tokenConnecting || !tokenValue.trim()}
-                style={{ padding: "6px 16px", fontSize: 13, cursor: tokenConnecting ? "wait" : "pointer", borderRadius: 6, border: "none", background: "var(--fg-1)", color: "var(--bg-0)", opacity: !tokenValue.trim() ? 0.5 : 1 }}
+                style={{ padding: "6px 16px", fontSize: "var(--fs-m)", cursor: tokenConnecting ? "wait" : "pointer", borderRadius: 6, border: "none", background: "var(--fg-1)", color: "var(--bg-0)", opacity: !tokenValue.trim() ? 0.5 : 1 }}
               >
                 {tokenConnecting ? "Connecting…" : "Connect"}
               </button>

--- a/dashboard/src/app/decisions/page.tsx
+++ b/dashboard/src/app/decisions/page.tsx
@@ -209,12 +209,12 @@ function DecisionsContent() {
             gap: 6,
             flexWrap: "wrap",
             marginBottom: "var(--s-3)",
-            fontSize: 12,
+            fontSize: "var(--fs-s)",
             color: "var(--fg-3)",
             alignItems: "center",
           }}
         >
-          <span style={{ fontFamily: "var(--font-mono)", fontSize: 10, fontWeight: 700, letterSpacing: "0.08em", textTransform: "uppercase", color: "var(--ink-3)" }}>
+          <span style={{ fontFamily: "var(--font-mono)", fontSize: "var(--fs-2xs)", fontWeight: 700, letterSpacing: "0.08em", textTransform: "uppercase", color: "var(--ink-3)" }}>
             Tags
           </span>
           {(showAllTags ? allTags : allTags.slice(0, 20)).map((t) => (
@@ -321,14 +321,14 @@ function DecisionsContent() {
                     className={`chip chip-${
                       variant === "err" ? "red" : variant === "warn" ? "amber" : variant === "info" ? "blue" : "accent"
                     }`}
-                    style={{ textTransform: "uppercase", letterSpacing: "0.06em", fontFamily: "var(--font-mono)", fontSize: 10 }}
+                    style={{ textTransform: "uppercase", letterSpacing: "0.06em", fontFamily: "var(--font-mono)", fontSize: "var(--fs-2xs)" }}
                   >
                     {variant === "err" ? "bug" : variant === "warn" ? "risk" : variant === "info" ? "decision" : "feature"}
                   </span>
                   <span
                     style={{
                       fontFamily: "var(--font-mono)",
-                      fontSize: 12,
+                      fontSize: "var(--fs-s)",
                       fontWeight: 600,
                       color: "var(--ink-1)",
                       flexShrink: 0,
@@ -341,13 +341,13 @@ function DecisionsContent() {
                     <Link
                       href={`/sessions/${b.sessionId}`}
                       className="pill muted"
-                      style={{ fontFamily: "var(--font-mono)", fontSize: 10, textDecoration: "none" }}
+                      style={{ fontFamily: "var(--font-mono)", fontSize: "var(--fs-2xs)", textDecoration: "none" }}
                       title={`session ${b.sessionId}`}
                     >
                       {b.sessionId.slice(0, 8)}
                     </Link>
                   )}
-                  <span style={{ fontSize: 11, color: "var(--ink-3)", flexShrink: 0 }}>
+                  <span style={{ fontSize: "var(--fs-xs)", color: "var(--ink-3)", flexShrink: 0 }}>
                     {relTime(t.ts)}
                   </span>
                 </div>
@@ -370,10 +370,10 @@ function DecisionsContent() {
                           border: "1px solid var(--orange-tint)",
                         }}
                       >
-                        <div style={{ fontFamily: "var(--font-mono)", fontSize: 10, fontWeight: 700, color: "var(--orange)", letterSpacing: "0.08em", marginBottom: 6, textTransform: "uppercase" }}>
+                        <div style={{ fontFamily: "var(--font-mono)", fontSize: "var(--fs-2xs)", fontWeight: 700, color: "var(--orange)", letterSpacing: "0.08em", marginBottom: 6, textTransform: "uppercase" }}>
                           ✻ Problem
                         </div>
-                        <div style={{ fontSize: 13, color: "var(--ink-1)", lineHeight: 1.55 }}>
+                        <div style={{ fontSize: "var(--fs-m)", color: "var(--ink-1)", lineHeight: 1.55 }}>
                           {b.problem as string}
                         </div>
                       </div>
@@ -387,10 +387,10 @@ function DecisionsContent() {
                           border: "1px solid color-mix(in srgb, var(--green) 30%, transparent)",
                         }}
                       >
-                        <div style={{ fontFamily: "var(--font-mono)", fontSize: 10, fontWeight: 700, color: "var(--green)", letterSpacing: "0.08em", marginBottom: 6, textTransform: "uppercase" }}>
+                        <div style={{ fontFamily: "var(--font-mono)", fontSize: "var(--fs-2xs)", fontWeight: 700, color: "var(--green)", letterSpacing: "0.08em", marginBottom: 6, textTransform: "uppercase" }}>
                           ✻ Solution
                         </div>
-                        <div style={{ fontSize: 13, color: "var(--ink-0)", lineHeight: 1.55 }}>
+                        <div style={{ fontSize: "var(--fs-m)", color: "var(--ink-0)", lineHeight: 1.55 }}>
                           {b.solution as string}
                         </div>
                       </div>

--- a/dashboard/src/app/inbox/page.tsx
+++ b/dashboard/src/app/inbox/page.tsx
@@ -142,7 +142,7 @@ function H2WithCopy({ children }: { children?: React.ReactNode }) {
     <h2
       ref={headingRef}
       style={{
-        fontSize: 15,
+        fontSize: "var(--fs-l)",
         fontWeight: 600,
         margin: "24px 0 8px",
         color: "var(--ink-0)",
@@ -183,7 +183,7 @@ const markdownComponents = {
   h3: ({ children }: { children?: React.ReactNode }) => (
     <h3
       style={{
-        fontSize: 12,
+        fontSize: "var(--fs-s)",
         fontWeight: 700,
         margin: "16px 0 4px",
         color: "var(--ink-3)",
@@ -197,7 +197,7 @@ const markdownComponents = {
   p: ({ children }: { children?: React.ReactNode }) => (
     <p
       style={{
-        fontSize: 14,
+        fontSize: "var(--fs-base)",
         lineHeight: 1.75,
         margin: "0 0 10px",
         color: "var(--ink-1)",
@@ -450,11 +450,11 @@ const filteredItems = items.filter((item) => {
           </div>
           <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
             {unseen > 0 && (
-              <span className="pill info" style={{ fontSize: 11 }}>
+              <span className="pill info" style={{ fontSize: "var(--fs-xs)" }}>
                 {unseen} new
               </span>
             )}
-            <span className="pill muted" style={{ fontSize: 11 }}>
+            <span className="pill muted" style={{ fontSize: "var(--fs-xs)" }}>
               {items.length} item{items.length !== 1 ? "s" : ""}
             </span>
             <button
@@ -471,7 +471,7 @@ const filteredItems = items.filter((item) => {
                 border: "1px solid var(--line-2)",
                 background: "transparent",
                 color: "var(--ink-2)",
-                fontSize: 12,
+                fontSize: "var(--fs-s)",
                 fontWeight: 600,
                 cursor: refreshing ? "default" : "pointer",
                 opacity: refreshing ? 0.6 : 1,
@@ -497,7 +497,7 @@ const filteredItems = items.filter((item) => {
             <button
               type="button"
               onClick={() => fetchList(true)}
-              style={{ fontSize: 11, fontWeight: 600, color: "inherit", background: "none", border: "1px solid currentColor", borderRadius: "var(--r-full)", padding: "2px 10px", cursor: "pointer", opacity: 0.8, flexShrink: 0 }}
+              style={{ fontSize: "var(--fs-xs)", fontWeight: 600, color: "inherit", background: "none", border: "1px solid currentColor", borderRadius: "var(--r-full)", padding: "2px 10px", cursor: "pointer", opacity: 0.8, flexShrink: 0 }}
             >
               Retry
             </button>
@@ -517,8 +517,8 @@ const filteredItems = items.filter((item) => {
                 <path d="M2 7l10 7 10-7"/>
               </svg>
             </div>
-            <p style={{ color: "var(--ink-1)", fontSize: 15, fontWeight: 600, margin: 0 }}>No items yet</p>
-            <p style={{ color: "var(--ink-3)", fontSize: 13, margin: 0 }}>Run a recipe to generate your first brief.</p>
+            <p style={{ color: "var(--ink-1)", fontSize: "var(--fs-l)", fontWeight: 600, margin: 0 }}>No items yet</p>
+            <p style={{ color: "var(--ink-3)", fontSize: "var(--fs-m)", margin: 0 }}>Run a recipe to generate your first brief.</p>
           </div>
         ) : (
           <div style={{ display: "flex", flex: 1, minHeight: 0, border: "1px solid var(--line-1)", borderRadius: "var(--r-l)", overflow: "hidden", background: "var(--surface)" }}>
@@ -530,18 +530,18 @@ const filteredItems = items.filter((item) => {
               <div style={{ padding: "10px 10px 10px 14px", borderBottom: "1px solid var(--line-1)", display: "flex", alignItems: "center", gap: 8, flexShrink: 0 }}>
                 {sidebarOpen ? (
                   <>
-                    <span style={{ fontSize: 11, fontWeight: 700, letterSpacing: "0.06em", textTransform: "uppercase", color: "var(--ink-3)", flex: 1 }}>
+                    <span style={{ fontSize: "var(--fs-xs)", fontWeight: 700, letterSpacing: "0.06em", textTransform: "uppercase", color: "var(--ink-3)", flex: 1 }}>
                       Messages
                     </span>
                     {unseen > 0 && (
-                      <span className="pill info" style={{ fontSize: 10, padding: "2px 7px" }}>{unseen} new</span>
+                      <span className="pill info" style={{ fontSize: "var(--fs-2xs)", padding: "2px 7px" }}>{unseen} new</span>
                     )}
                     <button
                       type="button"
                       onClick={() => setSidebarOpen(false)}
                       title="Collapse sidebar"
                       aria-label="Collapse message sidebar"
-                      style={{ background: "none", border: "none", cursor: "pointer", color: "var(--ink-3)", padding: "3px 5px", borderRadius: "var(--r-s)", fontSize: 11, lineHeight: 1 }}
+                      style={{ background: "none", border: "none", cursor: "pointer", color: "var(--ink-3)", padding: "3px 5px", borderRadius: "var(--r-s)", fontSize: "var(--fs-xs)", lineHeight: 1 }}
                     >
                       <span aria-hidden="true">◀</span>
                     </button>
@@ -552,7 +552,7 @@ const filteredItems = items.filter((item) => {
                     onClick={() => setSidebarOpen(true)}
                     title="Expand sidebar"
                     aria-label="Expand message sidebar"
-                    style={{ background: "none", border: "none", cursor: "pointer", color: "var(--ink-3)", padding: "3px 5px", borderRadius: "var(--r-s)", fontSize: 11, lineHeight: 1, width: "100%", display: "flex", flexDirection: "column", alignItems: "center", gap: 6 }}
+                    style={{ background: "none", border: "none", cursor: "pointer", color: "var(--ink-3)", padding: "3px 5px", borderRadius: "var(--r-s)", fontSize: "var(--fs-xs)", lineHeight: 1, width: "100%", display: "flex", flexDirection: "column", alignItems: "center", gap: 6 }}
                   >
                     <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
                       <rect x="2" y="4" width="20" height="16" rx="2"/>
@@ -576,7 +576,7 @@ const filteredItems = items.filter((item) => {
                       value={search}
                       onChange={(e) => setSearch(e.target.value)}
                       aria-label="Search inbox"
-                      style={{ width: "100%", fontSize: 12 }}
+                      style={{ width: "100%", fontSize: "var(--fs-s)" }}
                     />
                   </div>
 
@@ -590,7 +590,7 @@ const filteredItems = items.filter((item) => {
                         style={{
                           padding: "3px 10px",
                           borderRadius: "var(--r-full)",
-                          fontSize: 11,
+                          fontSize: "var(--fs-xs)",
                           fontWeight: 600,
                           cursor: "pointer",
                           border: "1px solid",
@@ -610,7 +610,7 @@ const filteredItems = items.filter((item) => {
                   {/* Item list */}
                   <div style={{ overflowY: "auto", flex: 1 }}>
                     {filteredItems.length === 0 ? (
-                      <div style={{ padding: "20px 16px", textAlign: "center", color: "var(--ink-3)", fontSize: 12 }}>
+                      <div style={{ padding: "20px 16px", textAlign: "center", color: "var(--ink-3)", fontSize: "var(--fs-s)" }}>
                         No items match
                       </div>
                     ) : (
@@ -646,28 +646,28 @@ const filteredItems = items.filter((item) => {
                               <span style={{ color: senderBadgeColor(item.name), lineHeight: 1, flexShrink: 0 }}>
                                 <RecipeIcon name={item.name} />
                               </span>
-                              <span style={{ flex: 1, fontWeight: isNew ? 700 : 500, fontSize: 13, color: "var(--ink-0)", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>
+                              <span style={{ flex: 1, fontWeight: isNew ? 700 : 500, fontSize: "var(--fs-m)", color: "var(--ink-0)", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>
                                 {title}
                               </span>
                               {shortDate && (
-                                <span style={{ fontSize: 10, color: "var(--ink-3)", flexShrink: 0 }}>{shortDate}</span>
+                                <span style={{ fontSize: "var(--fs-2xs)", color: "var(--ink-3)", flexShrink: 0 }}>{shortDate}</span>
                               )}
                             </div>
 
                             {/* Row 2: preview */}
                             {plainPreview && (
-                              <div style={{ fontSize: 12, color: "var(--ink-2)", lineHeight: 1.4, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis", marginBottom: 4 }}>
+                              <div style={{ fontSize: "var(--fs-s)", color: "var(--ink-2)", lineHeight: 1.4, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis", marginBottom: 4 }}>
                                 {plainPreview}
                               </div>
                             )}
 
                             {/* Row 3: timestamp + new badge */}
                             <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
-                              <span style={{ fontSize: 11, color: "var(--ink-3)" }}>
+                              <span style={{ fontSize: "var(--fs-xs)", color: "var(--ink-3)" }}>
                                 <RelativeTime iso={item.modifiedAt} />
                               </span>
                               {isNew && (
-                                <span className="pill info" style={{ fontSize: 9, padding: "1px 6px" }}>new</span>
+                                <span className="pill info" style={{ fontSize: "var(--fs-3xs)", padding: "1px 6px" }}>new</span>
                               )}
                             </div>
                           </button>
@@ -696,7 +696,7 @@ const filteredItems = items.filter((item) => {
                   }}
                 >
                   <Spinner />
-                  <span style={{ fontSize: 13, color: "var(--ink-2)" }}>Loading message…</span>
+                  <span style={{ fontSize: "var(--fs-m)", color: "var(--ink-2)" }}>Loading message…</span>
                 </div>
               ) : selected ? (
                 <div style={{ padding: "28px 40px 48px", maxWidth: 700 }}>
@@ -706,10 +706,10 @@ const filteredItems = items.filter((item) => {
                       <RecipeIcon name={selected.name} />
                     </span>
                     <div style={{ flex: 1, minWidth: 0 }}>
-                      <div style={{ fontSize: 13, fontWeight: 600, color: "var(--ink-0)", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>
+                      <div style={{ fontSize: "var(--fs-m)", fontWeight: 600, color: "var(--ink-0)", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>
                         {slugToTitle(selected.name)}
                       </div>
-                      <div style={{ fontSize: 11, color: "var(--ink-3)", marginTop: 2 }}>
+                      <div style={{ fontSize: "var(--fs-xs)", color: "var(--ink-3)", marginTop: 2 }}>
                         {new Date(selected.modifiedAt).toLocaleString()} &middot; <span style={{ fontFamily: "var(--font-mono)" }}>{selected.name}</span>
                       </div>
                     </div>
@@ -718,7 +718,7 @@ const filteredItems = items.filter((item) => {
                       onClick={() => setSelected(null)}
                       title="Close"
                       aria-label="Close detail"
-                      style={{ background: "none", border: "1px solid var(--line-2)", cursor: "pointer", color: "var(--ink-3)", fontSize: 13, lineHeight: 1, padding: "4px 8px", borderRadius: "var(--r-s)", flexShrink: 0, transition: "background 120ms" }}
+                      style={{ background: "none", border: "1px solid var(--line-2)", cursor: "pointer", color: "var(--ink-3)", fontSize: "var(--fs-m)", lineHeight: 1, padding: "4px 8px", borderRadius: "var(--r-s)", flexShrink: 0, transition: "background 120ms" }}
                     >
                       ✕
                     </button>
@@ -729,7 +729,7 @@ const filteredItems = items.filter((item) => {
                     ref={detailRef}
                     tabIndex={-1}
                     aria-label={`Message: ${slugToTitle(selected.name)}`}
-                    style={{ fontSize: 14, lineHeight: 1.7, color: "var(--ink-1)", outline: "none" }}
+                    style={{ fontSize: "var(--fs-base)", lineHeight: 1.7, color: "var(--ink-1)", outline: "none" }}
                   >
                     <MessageMarkdown
                       content={selected.content}
@@ -741,7 +741,7 @@ const filteredItems = items.filter((item) => {
                   <p
                     style={{
                       fontStyle: "italic",
-                      fontSize: 12,
+                      fontSize: "var(--fs-s)",
                       color: "var(--ink-3)",
                       marginTop: 24,
                       marginBottom: 20,
@@ -759,7 +759,7 @@ const filteredItems = items.filter((item) => {
                         <button
                           type="button"
                           className="btn sm primary"
-                          style={{ background: "var(--orange)", border: "none", fontSize: 11 }}
+                          style={{ background: "var(--orange)", border: "none", fontSize: "var(--fs-xs)" }}
                           disabled={replayingFor === selected.name}
                           onClick={async () => {
                             setActionErr(null);
@@ -788,14 +788,14 @@ const filteredItems = items.filter((item) => {
                         <a
                           href={`/traces?q=${encodeURIComponent(recipeNameForSelected)}`}
                           className="btn sm ghost"
-                          style={{ fontSize: 11, textDecoration: "none" }}
+                          style={{ fontSize: "var(--fs-xs)", textDecoration: "none" }}
                         >
                           View trace
                         </a>
                         <button
                           type="button"
                           className="btn sm ghost"
-                          style={{ fontSize: 11, color: "var(--ink-3)" }}
+                          style={{ fontSize: "var(--fs-xs)", color: "var(--ink-3)" }}
                           onClick={async () => {
                             setActionErr(null);
                             try {
@@ -824,7 +824,7 @@ const filteredItems = items.filter((item) => {
                         <div
                           role="alert"
                           className="alert-err"
-                          style={{ marginTop: 8, fontSize: 12 }}
+                          style={{ marginTop: 8, fontSize: "var(--fs-s)" }}
                         >
                           {actionErr}
                         </div>
@@ -839,11 +839,11 @@ const filteredItems = items.filter((item) => {
                     <rect x="2" y="4" width="20" height="16" rx="2"/>
                     <path d="M2 7l10 7 10-7"/>
                   </svg>
-                  <p style={{ fontSize: 13, color: "var(--ink-2)", margin: 0, fontWeight: 500 }}>
+                  <p style={{ fontSize: "var(--fs-m)", color: "var(--ink-2)", margin: 0, fontWeight: 500 }}>
                     Select a message to read it
                   </p>
                   {filteredItems.length > 0 && (
-                    <p style={{ fontSize: 12, color: "var(--ink-3)", margin: 0 }}>
+                    <p style={{ fontSize: "var(--fs-s)", color: "var(--ink-3)", margin: 0 }}>
                       {filteredItems.length} message{filteredItems.length !== 1 ? "s" : ""} in this view
                     </p>
                   )}

--- a/dashboard/src/app/insights/page.tsx
+++ b/dashboard/src/app/insights/page.tsx
@@ -107,18 +107,18 @@ function relativeTime(iso: string | null): string {
 
 function RuleCell({ explanation }: { explanation: RuleExplanation | null | undefined }) {
   if (explanation === undefined) {
-    return <span style={{ color: "var(--fg-3)", fontSize: 11 }}>…</span>;
+    return <span style={{ color: "var(--fg-3)", fontSize: "var(--fs-xs)" }}>…</span>;
   }
   if (explanation === null) {
-    return <span style={{ color: "var(--fg-3)", fontSize: 11 }}>no rule</span>;
+    return <span style={{ color: "var(--fg-3)", fontSize: "var(--fs-xs)" }}>no rule</span>;
   }
   return (
     <div style={{ display: "flex", alignItems: "center", gap: 6, flexWrap: "wrap" }}>
-      <code style={{ fontSize: 11, color: "var(--fg-1)" }}>{explanation.matchedRule}</code>
-      <span className={`pill ${TIER_PILL[explanation.tier]}`} style={{ fontSize: 10 }}>
+      <code style={{ fontSize: "var(--fs-xs)", color: "var(--fg-1)" }}>{explanation.matchedRule}</code>
+      <span className={`pill ${TIER_PILL[explanation.tier]}`} style={{ fontSize: "var(--fs-2xs)" }}>
         {explanation.tier}
       </span>
-      <span className="pill muted" style={{ fontSize: 10 }}>
+      <span className="pill muted" style={{ fontSize: "var(--fs-2xs)" }}>
         {SOURCE_LABEL[explanation.source]}
       </span>
     </div>
@@ -236,7 +236,7 @@ export default function InsightsPage() {
             <span className="pill muted">{tools.length}</span>
           </div>
           <table
-            style={{ width: "100%", borderCollapse: "collapse", fontSize: 13 }}
+            style={{ width: "100%", borderCollapse: "collapse", fontSize: "var(--fs-m)" }}
           >
             <thead>
               <tr
@@ -248,7 +248,7 @@ export default function InsightsPage() {
                     padding: "8px 0",
                     fontWeight: 500,
                     color: "var(--fg-2)",
-                    fontSize: 11,
+                    fontSize: "var(--fs-xs)",
                   }}
                 >
                   Tool
@@ -259,7 +259,7 @@ export default function InsightsPage() {
                     padding: "8px 8px",
                     fontWeight: 500,
                     color: "var(--fg-2)",
-                    fontSize: 11,
+                    fontSize: "var(--fs-xs)",
                   }}
                 >
                   Heuristic
@@ -270,7 +270,7 @@ export default function InsightsPage() {
                     padding: "8px 8px",
                     fontWeight: 500,
                     color: "var(--fg-2)",
-                    fontSize: 11,
+                    fontSize: "var(--fs-xs)",
                   }}
                 >
                   Matched rule
@@ -281,7 +281,7 @@ export default function InsightsPage() {
                     padding: "8px 8px",
                     fontWeight: 500,
                     color: "var(--fg-2)",
-                    fontSize: 11,
+                    fontSize: "var(--fs-xs)",
                   }}
                 >
                   ✓
@@ -292,7 +292,7 @@ export default function InsightsPage() {
                     padding: "8px 8px",
                     fontWeight: 500,
                     color: "var(--fg-2)",
-                    fontSize: 11,
+                    fontSize: "var(--fs-xs)",
                   }}
                 >
                   ✗
@@ -303,7 +303,7 @@ export default function InsightsPage() {
                     padding: "8px 8px",
                     fontWeight: 500,
                     color: "var(--fg-2)",
-                    fontSize: 11,
+                    fontSize: "var(--fs-xs)",
                   }}
                 >
                   Rate
@@ -314,7 +314,7 @@ export default function InsightsPage() {
                     padding: "8px 0",
                     fontWeight: 500,
                     color: "var(--fg-2)",
-                    fontSize: 11,
+                    fontSize: "var(--fs-xs)",
                   }}
                 >
                   Last
@@ -331,11 +331,11 @@ export default function InsightsPage() {
                     <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
                       <span
                         className={`pill ${SEVERITY_PILL[t.severity]}`}
-                        style={{ fontSize: 10 }}
+                        style={{ fontSize: "var(--fs-2xs)" }}
                       >
                         {SEVERITY_LABEL[t.severity]}
                       </span>
-                      <code style={{ fontSize: 12 }}>{t.toolName}</code>
+                      <code style={{ fontSize: "var(--fs-s)" }}>{t.toolName}</code>
                     </div>
                   </td>
                   <td
@@ -412,7 +412,7 @@ export default function InsightsPage() {
       {data?.generatedAt && (
         <p
           style={{
-            fontSize: 11,
+            fontSize: "var(--fs-xs)",
             color: "var(--fg-2)",
             marginTop: "var(--s-5)",
           }}

--- a/dashboard/src/app/insights/replay/page.tsx
+++ b/dashboard/src/app/insights/replay/page.tsx
@@ -74,7 +74,7 @@ export default function ReplayPage() {
         <div>
           <Link
             href="/insights"
-            style={{ fontSize: 12, color: "var(--fg-2)", textDecoration: "none" }}
+            style={{ fontSize: "var(--fs-s)", color: "var(--fg-2)", textDecoration: "none" }}
           >
             ← Approval Insights
           </Link>
@@ -86,7 +86,7 @@ export default function ReplayPage() {
           </div>
         </div>
         <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
-          <label htmlFor="since-days" style={{ fontSize: 12, color: "var(--fg-2)" }}>
+          <label htmlFor="since-days" style={{ fontSize: "var(--fs-s)", color: "var(--fg-2)" }}>
             Lookback
           </label>
           <select
@@ -98,7 +98,7 @@ export default function ReplayPage() {
               border: "1px solid var(--border-default)",
               borderRadius: "var(--r-2)",
               color: "var(--fg-0)",
-              fontSize: 12,
+              fontSize: "var(--fs-s)",
               padding: "4px 8px",
               outline: "none",
             }}
@@ -149,7 +149,7 @@ export default function ReplayPage() {
                 borderRadius: "var(--r-2)",
                 background: "var(--ok-soft)",
                 border: "1px solid var(--ok)",
-                fontSize: 13,
+                fontSize: "var(--fs-m)",
                 marginBottom: "var(--s-4)",
               }}
             >
@@ -170,7 +170,7 @@ export default function ReplayPage() {
                   display: "flex",
                   alignItems: "center",
                   gap: 6,
-                  fontSize: 12,
+                  fontSize: "var(--fs-s)",
                   color: "var(--fg-2)",
                   cursor: "pointer",
                 }}
@@ -185,21 +185,21 @@ export default function ReplayPage() {
             </div>
 
             {visible.length === 0 && !showUnchanged && (
-              <p style={{ fontSize: 13, color: "var(--fg-2)", margin: "12px 0" }}>
+              <p style={{ fontSize: "var(--fs-m)", color: "var(--fg-2)", margin: "12px 0" }}>
                 No changed decisions in this window. Toggle "Show unchanged" to
                 see all rows.
               </p>
             )}
 
             {visible.length > 0 && (
-              <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 13 }}>
+              <table style={{ width: "100%", borderCollapse: "collapse", fontSize: "var(--fs-m)" }}>
                 <thead>
                   <tr style={{ borderBottom: "1px solid var(--border-default)" }}>
-                    <th style={{ textAlign: "left", padding: "6px 0", fontWeight: 500, color: "var(--fg-2)", fontSize: 11 }}>Tool</th>
-                    <th style={{ textAlign: "left", padding: "6px 8px", fontWeight: 500, color: "var(--fg-2)", fontSize: 11 }}>Was</th>
-                    <th style={{ textAlign: "left", padding: "6px 8px", fontWeight: 500, color: "var(--fg-2)", fontSize: 11 }}>Would be</th>
-                    <th style={{ textAlign: "left", padding: "6px 8px", fontWeight: 500, color: "var(--fg-2)", fontSize: 11 }}>Change</th>
-                    <th style={{ textAlign: "right", padding: "6px 0", fontWeight: 500, color: "var(--fg-2)", fontSize: 11 }}>When</th>
+                    <th style={{ textAlign: "left", padding: "6px 0", fontWeight: 500, color: "var(--fg-2)", fontSize: "var(--fs-xs)" }}>Tool</th>
+                    <th style={{ textAlign: "left", padding: "6px 8px", fontWeight: 500, color: "var(--fg-2)", fontSize: "var(--fs-xs)" }}>Was</th>
+                    <th style={{ textAlign: "left", padding: "6px 8px", fontWeight: 500, color: "var(--fg-2)", fontSize: "var(--fs-xs)" }}>Would be</th>
+                    <th style={{ textAlign: "left", padding: "6px 8px", fontWeight: 500, color: "var(--fg-2)", fontSize: "var(--fs-xs)" }}>Change</th>
+                    <th style={{ textAlign: "right", padding: "6px 0", fontWeight: 500, color: "var(--fg-2)", fontSize: "var(--fs-xs)" }}>When</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -213,11 +213,11 @@ export default function ReplayPage() {
                     >
                       <td style={{ padding: "9px 0", verticalAlign: "middle" }}>
                         <div>
-                          <code style={{ fontSize: 12 }}>{row.toolName}</code>
+                          <code style={{ fontSize: "var(--fs-s)" }}>{row.toolName}</code>
                           {row.specifier && (
                             <div
                               style={{
-                                fontSize: 10,
+                                fontSize: "var(--fs-2xs)",
                                 color: "var(--fg-3)",
                                 marginTop: 2,
                                 maxWidth: 260,
@@ -233,7 +233,7 @@ export default function ReplayPage() {
                           {row.incomplete && (
                             <span
                               className="pill muted"
-                              style={{ fontSize: 9, marginTop: 2 }}
+                              style={{ fontSize: "var(--fs-3xs)", marginTop: 2 }}
                               title="Row predates specifier capture — matched on tool name only"
                             >
                               name-only
@@ -244,7 +244,7 @@ export default function ReplayPage() {
                       <td style={{ padding: "9px 8px", verticalAlign: "middle" }}>
                         <span
                           className={`pill ${DECISION_PILL[row.originalDecision] ?? "muted"}`}
-                          style={{ fontSize: 10 }}
+                          style={{ fontSize: "var(--fs-2xs)" }}
                         >
                           {row.originalDecision}
                         </span>
@@ -252,7 +252,7 @@ export default function ReplayPage() {
                       <td style={{ padding: "9px 8px", verticalAlign: "middle" }}>
                         <span
                           className={`pill ${DECISION_PILL[row.replayDecision] ?? "muted"}`}
-                          style={{ fontSize: 10 }}
+                          style={{ fontSize: "var(--fs-2xs)" }}
                         >
                           {row.replayDecision}
                         </span>
@@ -261,12 +261,12 @@ export default function ReplayPage() {
                         {row.changeKind ? (
                           <span
                             className={`pill ${CHANGE_PILL[row.changeKind]}`}
-                            style={{ fontSize: 10 }}
+                            style={{ fontSize: "var(--fs-2xs)" }}
                           >
                             {CHANGE_LABEL[row.changeKind]}
                           </span>
                         ) : (
-                          <span style={{ fontSize: 11, color: "var(--fg-3)" }}>—</span>
+                          <span style={{ fontSize: "var(--fs-xs)", color: "var(--fg-3)" }}>—</span>
                         )}
                       </td>
                       <td
@@ -276,7 +276,7 @@ export default function ReplayPage() {
                           color: "var(--fg-3)",
                           verticalAlign: "middle",
                           whiteSpace: "nowrap",
-                          fontSize: 11,
+                          fontSize: "var(--fs-xs)",
                         }}
                       >
                         {relativeTime(row.timestamp)}
@@ -289,9 +289,9 @@ export default function ReplayPage() {
           </div>
 
           {data.workspace && (
-            <p style={{ fontSize: 11, color: "var(--fg-2)", marginTop: "var(--s-5)" }}>
+            <p style={{ fontSize: "var(--fs-xs)", color: "var(--fg-2)", marginTop: "var(--s-5)" }}>
               Rules loaded from workspace:{" "}
-              <code style={{ fontSize: 10 }}>{data.workspace}</code>.
+              <code style={{ fontSize: "var(--fs-2xs)" }}>{data.workspace}</code>.
               Generated at {new Date(data.generatedAt).toLocaleTimeString()}.
             </p>
           )}

--- a/dashboard/src/app/marketplace/[...slug]/InstallPanel.tsx
+++ b/dashboard/src/app/marketplace/[...slug]/InstallPanel.tsx
@@ -99,7 +99,7 @@ export default function InstallPanel({ install, name }: Props) {
   return (
     <div className="glass-card" style={{ padding: "var(--s-5)", display: "flex", flexDirection: "column", gap: 12 }}>
       <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 12, flexWrap: "wrap" }}>
-        <div style={{ fontSize: 13, color: "var(--ink-1)" }}>
+        <div style={{ fontSize: "var(--fs-m)", color: "var(--ink-1)" }}>
           {installed ? (
             <>
               <span style={{ color: "var(--ok)", marginRight: 6 }}>✓</span>
@@ -131,7 +131,7 @@ export default function InstallPanel({ install, name }: Props) {
             background: "var(--recess)",
             padding: "10px 12px",
             borderRadius: "var(--r-2)",
-            fontSize: 12,
+            fontSize: "var(--fs-s)",
             fontFamily: "var(--font-mono, ui-monospace, monospace)",
             overflowX: "auto",
             color: "var(--ink-1)",
@@ -151,7 +151,7 @@ export default function InstallPanel({ install, name }: Props) {
       </div>
 
       {err && (
-        <div className="alert-err" role="alert" style={{ fontSize: 12 }}>
+        <div className="alert-err" role="alert" style={{ fontSize: "var(--fs-s)" }}>
           {err}
         </div>
       )}

--- a/dashboard/src/app/marketplace/[...slug]/page.tsx
+++ b/dashboard/src/app/marketplace/[...slug]/page.tsx
@@ -83,7 +83,7 @@ export default async function RecipeDetailPage({ params }: PageProps) {
       <Link
         href="/marketplace"
         className="btn sm ghost"
-        style={{ alignSelf: "flex-start", textDecoration: "none", fontSize: 12 }}
+        style={{ alignSelf: "flex-start", textDecoration: "none", fontSize: "var(--fs-s)" }}
       >
         ← Back to marketplace
       </Link>
@@ -124,7 +124,7 @@ function Header({
         <h1 style={{ fontFamily: "var(--font-mono, ui-monospace, monospace)", letterSpacing: "-0.01em" }}>
           {shortName(recipe.name)}
         </h1>
-        <div className="page-head-sub" style={{ fontSize: 13, color: "var(--ink-2)" }}>
+        <div className="page-head-sub" style={{ fontSize: "var(--fs-m)", color: "var(--ink-2)" }}>
           {recipe.name}
           <span style={{ margin: "0 8px", color: "var(--ink-3)" }}>·</span>
           <span>v{recipe.version}</span>
@@ -162,7 +162,7 @@ function Description({
 }) {
   const description = manifest?.description ?? recipe.description;
   return (
-    <p style={{ fontSize: 14, color: "var(--ink-1)", lineHeight: 1.6, maxWidth: 760 }}>
+    <p style={{ fontSize: "var(--fs-base)", color: "var(--ink-1)", lineHeight: 1.6, maxWidth: 760 }}>
       {description}
     </p>
   );
@@ -175,8 +175,8 @@ function Variables({ manifest }: { manifest: RecipeManifest | null }) {
   const entries = Object.entries(vars);
   return (
     <div className="glass-card" style={{ padding: "var(--s-5)" }}>
-      <h3 style={{ fontSize: 13, marginTop: 0, marginBottom: "var(--s-3)" }}>Configuration</h3>
-      <table style={{ width: "100%", fontSize: 12, borderCollapse: "collapse" }}>
+      <h3 style={{ fontSize: "var(--fs-m)", marginTop: 0, marginBottom: "var(--s-3)" }}>Configuration</h3>
+      <table style={{ width: "100%", fontSize: "var(--fs-s)", borderCollapse: "collapse" }}>
         <thead>
           <tr style={{ textAlign: "left", color: "var(--ink-2)" }}>
             <th scope="col" style={{ padding: "6px 8px", borderBottom: "1px solid var(--line-1)", textAlign: "left" }}>Variable</th>
@@ -213,8 +213,8 @@ function Steps({ yaml }: { yaml: string | null }) {
 
   return (
     <div className="glass-card" style={{ padding: "var(--s-5)" }}>
-      <h3 style={{ fontSize: 13, marginTop: 0, marginBottom: "var(--s-3)" }}>Steps & risk</h3>
-      <div style={{ display: "flex", gap: 12, fontSize: 12, color: "var(--ink-1)" }}>
+      <h3 style={{ fontSize: "var(--fs-m)", marginTop: 0, marginBottom: "var(--s-3)" }}>Steps & risk</h3>
+      <div style={{ display: "flex", gap: 12, fontSize: "var(--fs-s)", color: "var(--ink-1)" }}>
         <span>
           <strong>{r.steps}</strong> step{r.steps === 1 ? "" : "s"}
         </span>
@@ -249,7 +249,7 @@ function YamlPreview({
 }) {
   if (!yaml) {
     return (
-      <div className="glass-card" style={{ padding: "var(--s-5)", color: "var(--ink-2)", fontSize: 13 }}>
+      <div className="glass-card" style={{ padding: "var(--s-5)", color: "var(--ink-2)", fontSize: "var(--fs-m)" }}>
         Recipe source unavailable.
       </div>
     );
@@ -263,7 +263,7 @@ function YamlPreview({
           display: "flex",
           alignItems: "center",
           justifyContent: "space-between",
-          fontSize: 12,
+          fontSize: "var(--fs-s)",
           color: "var(--ink-2)",
         }}
       >
@@ -275,7 +275,7 @@ function YamlPreview({
             href={githubBlobUrlFor(src, mainFile)}
             target="_blank"
             rel="noopener noreferrer"
-            style={{ color: "var(--accent-strong)", textDecoration: "none", fontSize: 11 }}
+            style={{ color: "var(--accent-strong)", textDecoration: "none", fontSize: "var(--fs-xs)" }}
           >
             View on GitHub →
           </a>
@@ -286,7 +286,7 @@ function YamlPreview({
           margin: 0,
           padding: "16px",
           fontFamily: "var(--font-mono, ui-monospace, monospace)",
-          fontSize: 12,
+          fontSize: "var(--fs-s)",
           lineHeight: 1.55,
           color: "var(--ink-1)",
           background: "var(--recess)",
@@ -317,7 +317,7 @@ function TrustMetadataCard({ recipe }: { recipe: RegistryRecipe }) {
     rows.push({
       label: "Risk level",
       value: (
-        <span className={`pill ${RISK_PILL_CLASS[risk_level]}`} style={{ fontSize: 11 }}>
+        <span className={`pill ${RISK_PILL_CLASS[risk_level]}`} style={{ fontSize: "var(--fs-xs)" }}>
           {risk_level}
         </span>
       ),
@@ -338,8 +338,8 @@ function TrustMetadataCard({ recipe }: { recipe: RegistryRecipe }) {
 
   return (
     <div className="glass-card" style={{ padding: "var(--s-5)" }}>
-      <h3 style={{ fontSize: 13, marginTop: 0, marginBottom: "var(--s-3)" }}>Trust &amp; permissions</h3>
-      <table style={{ width: "100%", fontSize: 12, borderCollapse: "collapse" }}>
+      <h3 style={{ fontSize: "var(--fs-m)", marginTop: 0, marginBottom: "var(--s-3)" }}>Trust &amp; permissions</h3>
+      <table style={{ width: "100%", fontSize: "var(--fs-s)", borderCollapse: "collapse" }}>
         <tbody>
           {rows.map(({ label, value }) => (
             <tr key={label} style={{ borderBottom: "1px solid var(--line-1)" }}>
@@ -361,7 +361,7 @@ function TrustNote() {
         background: "var(--warn-soft)",
         border: "1px solid var(--warn)",
         borderRadius: "var(--r-3)",
-        fontSize: 12,
+        fontSize: "var(--fs-s)",
         color: "var(--ink-2)",
         lineHeight: 1.6,
       }}

--- a/dashboard/src/app/marketplace/bundle/[...slug]/page.tsx
+++ b/dashboard/src/app/marketplace/bundle/[...slug]/page.tsx
@@ -45,14 +45,14 @@ export default async function BundleDetailPage({ params }: PageProps) {
       <Link
         href="/marketplace"
         className="btn sm ghost"
-        style={{ alignSelf: "flex-start", textDecoration: "none", fontSize: 12 }}
+        style={{ alignSelf: "flex-start", textDecoration: "none", fontSize: "var(--fs-s)" }}
       >
         ← Back to marketplace
       </Link>
 
       <BundleHeader bundle={bundle} manifest={manifest} />
 
-      <p style={{ fontSize: 14, color: "var(--ink-1)", lineHeight: 1.6, maxWidth: 760 }}>
+      <p style={{ fontSize: "var(--fs-base)", color: "var(--ink-1)", lineHeight: 1.6, maxWidth: 760 }}>
         {manifest?.description ?? bundle.description}
       </p>
 
@@ -93,13 +93,13 @@ function BundleHeader({
   return (
     <div className="page-head">
       <div>
-        <div style={{ fontSize: 11, color: "var(--fg-3)", textTransform: "uppercase", letterSpacing: "0.05em", marginBottom: 4 }}>
+        <div style={{ fontSize: "var(--fs-xs)", color: "var(--fg-3)", textTransform: "uppercase", letterSpacing: "0.05em", marginBottom: 4 }}>
           Capability Bundle
         </div>
         <h1 style={{ fontFamily: "var(--font-mono, ui-monospace, monospace)", letterSpacing: "-0.01em" }}>
           {shortName(bundle.name)}
         </h1>
-        <div className="page-head-sub" style={{ fontSize: 13, color: "var(--ink-2)" }}>
+        <div className="page-head-sub" style={{ fontSize: "var(--fs-m)", color: "var(--ink-2)" }}>
           {bundle.name}
           <span style={{ margin: "0 8px", color: "var(--ink-3)" }}>·</span>
           <span>v{bundle.version}</span>
@@ -139,16 +139,16 @@ function WhatIsIncluded({
 
   return (
     <div className="glass-card" style={{ padding: "var(--s-5)" }}>
-      <h3 style={{ fontSize: 13, marginTop: 0, marginBottom: "var(--s-3)" }}>What&apos;s included</h3>
+      <h3 style={{ fontSize: "var(--fs-m)", marginTop: 0, marginBottom: "var(--s-3)" }}>What&apos;s included</h3>
       <div style={{ display: "flex", flexDirection: "column", gap: "var(--s-2)" }}>
         {recipes.length > 0 && (
           <div>
-            <div style={{ fontSize: 11, color: "var(--fg-3)", textTransform: "uppercase", letterSpacing: "0.04em", marginBottom: "var(--s-1)" }}>
+            <div style={{ fontSize: "var(--fs-xs)", color: "var(--fg-3)", textTransform: "uppercase", letterSpacing: "0.04em", marginBottom: "var(--s-1)" }}>
               Recipes ({recipes.length})
             </div>
             <ul style={{ listStyle: "none", padding: 0, margin: 0, display: "flex", flexDirection: "column", gap: 4 }}>
               {recipes.map((r) => (
-                <li key={r} style={{ fontSize: 12, fontFamily: "var(--font-mono)", color: "var(--fg-1)" }}>
+                <li key={r} style={{ fontSize: "var(--fs-s)", fontFamily: "var(--font-mono)", color: "var(--fg-1)" }}>
                   <Link
                     href={`/marketplace/${encodeURIComponent(r)}`}
                     style={{ color: "inherit", textDecoration: "underline", textDecorationColor: "var(--line-2)" }}
@@ -162,18 +162,18 @@ function WhatIsIncluded({
         )}
 
         {recipes.length === 0 && bundle.recipe_count != null && bundle.recipe_count > 0 && (
-          <div style={{ fontSize: 12, color: "var(--fg-2)" }}>
+          <div style={{ fontSize: "var(--fs-s)", color: "var(--fg-2)" }}>
             {bundle.recipe_count} recipe{bundle.recipe_count !== 1 ? "s" : ""} included
           </div>
         )}
 
         {plugin && (
           <div>
-            <div style={{ fontSize: 11, color: "var(--fg-3)", textTransform: "uppercase", letterSpacing: "0.04em", marginBottom: "var(--s-1)" }}>
+            <div style={{ fontSize: "var(--fs-xs)", color: "var(--fg-3)", textTransform: "uppercase", letterSpacing: "0.04em", marginBottom: "var(--s-1)" }}>
               Plugin
             </div>
-            <code style={{ fontSize: 12 }}>{plugin}</code>
-            <p style={{ fontSize: 11, color: "var(--fg-3)", marginTop: 4 }}>
+            <code style={{ fontSize: "var(--fs-s)" }}>{plugin}</code>
+            <p style={{ fontSize: "var(--fs-xs)", color: "var(--fg-3)", marginTop: 4 }}>
               Installed via <code>npm install -g {plugin}</code> during bundle setup.
             </p>
           </div>
@@ -181,10 +181,10 @@ function WhatIsIncluded({
 
         {hasPolicy && (
           <div>
-            <div style={{ fontSize: 11, color: "var(--fg-3)", textTransform: "uppercase", letterSpacing: "0.04em", marginBottom: "var(--s-1)" }}>
+            <div style={{ fontSize: "var(--fs-xs)", color: "var(--fg-3)", textTransform: "uppercase", letterSpacing: "0.04em", marginBottom: "var(--s-1)" }}>
               Policy template
             </div>
-            <p style={{ fontSize: 12, color: "var(--fg-2)", margin: 0 }}>
+            <p style={{ fontSize: "var(--fs-s)", color: "var(--fg-2)", margin: 0 }}>
               A delegation policy fragment is included. It will be shown for your review and requires explicit approval before being applied — never applied silently.
             </p>
           </div>
@@ -203,7 +203,7 @@ function TrustCard({ bundle }: { bundle: RegistryBundle }) {
   if (risk_level) {
     rows.push({
       label: "Risk level",
-      value: <span className={`pill ${RISK_PILL_CLASS[risk_level]}`} style={{ fontSize: 11 }}>{risk_level}</span>,
+      value: <span className={`pill ${RISK_PILL_CLASS[risk_level]}`} style={{ fontSize: "var(--fs-xs)" }}>{risk_level}</span>,
     });
   }
   if (approval_behavior) {
@@ -218,8 +218,8 @@ function TrustCard({ bundle }: { bundle: RegistryBundle }) {
 
   return (
     <div className="glass-card" style={{ padding: "var(--s-5)" }}>
-      <h3 style={{ fontSize: 13, marginTop: 0, marginBottom: "var(--s-3)" }}>Trust &amp; permissions</h3>
-      <table style={{ width: "100%", fontSize: 12, borderCollapse: "collapse" }}>
+      <h3 style={{ fontSize: "var(--fs-m)", marginTop: 0, marginBottom: "var(--s-3)" }}>Trust &amp; permissions</h3>
+      <table style={{ width: "100%", fontSize: "var(--fs-s)", borderCollapse: "collapse" }}>
         <tbody>
           {rows.map(({ label, value }) => (
             <tr key={label} style={{ borderBottom: "1px solid var(--line-1)" }}>
@@ -236,14 +236,14 @@ function TrustCard({ bundle }: { bundle: RegistryBundle }) {
 function RequiredEnvCard({ vars }: { vars: string[] }) {
   return (
     <div className="glass-card" style={{ padding: "var(--s-5)" }}>
-      <h3 style={{ fontSize: 13, marginTop: 0, marginBottom: "var(--s-3)" }}>Required environment variables</h3>
-      <p style={{ fontSize: 12, color: "var(--fg-2)", marginTop: 0, marginBottom: "var(--s-3)" }}>
+      <h3 style={{ fontSize: "var(--fs-m)", marginTop: 0, marginBottom: "var(--s-3)" }}>Required environment variables</h3>
+      <p style={{ fontSize: "var(--fs-s)", color: "var(--fg-2)", marginTop: 0, marginBottom: "var(--s-3)" }}>
         Set these in your bridge environment before activating the bundle:
       </p>
       <ul style={{ listStyle: "none", padding: 0, margin: 0, display: "flex", flexDirection: "column", gap: 6 }}>
         {vars.map((v) => (
           <li key={v} style={{ display: "flex", alignItems: "center", gap: 8 }}>
-            <code style={{ fontSize: 12, background: "var(--bg-2)", padding: "2px 6px", borderRadius: "var(--r-1)" }}>{v}</code>
+            <code style={{ fontSize: "var(--fs-s)", background: "var(--bg-2)", padding: "2px 6px", borderRadius: "var(--r-1)" }}>{v}</code>
           </li>
         ))}
       </ul>
@@ -262,8 +262,8 @@ function InstallInstructions({
   const recipes = manifest?.recipes ?? [];
   return (
     <div className="glass-card" style={{ padding: "var(--s-5)" }}>
-      <h3 style={{ fontSize: 13, marginTop: 0, marginBottom: "var(--s-3)" }}>Install</h3>
-      <p style={{ fontSize: 12, color: "var(--fg-2)", marginTop: 0 }}>
+      <h3 style={{ fontSize: "var(--fs-m)", marginTop: 0, marginBottom: "var(--s-3)" }}>Install</h3>
+      <p style={{ fontSize: "var(--fs-s)", color: "var(--fg-2)", marginTop: 0 }}>
         Bundle install via a single command isn&apos;t wired through the
         bridge yet. Install each constituent recipe from the Marketplace —
         the trust + risk metadata above carries over per-recipe.
@@ -283,7 +283,7 @@ function InstallInstructions({
             <li
               key={r}
               style={{
-                fontSize: 12,
+                fontSize: "var(--fs-s)",
                 fontFamily: "var(--font-mono)",
                 color: "var(--fg-1)",
               }}
@@ -303,9 +303,9 @@ function InstallInstructions({
         </ul>
       )}
       {plugin && (
-        <p style={{ fontSize: 12, color: "var(--fg-2)" }}>
-          Plugin: <code style={{ fontSize: 11 }}>npm install -g {plugin}</code>, then restart the bridge with{" "}
-          <code style={{ fontSize: 11 }}>--plugin {plugin}</code>.
+        <p style={{ fontSize: "var(--fs-s)", color: "var(--fg-2)" }}>
+          Plugin: <code style={{ fontSize: "var(--fs-xs)" }}>npm install -g {plugin}</code>, then restart the bridge with{" "}
+          <code style={{ fontSize: "var(--fs-xs)" }}>--plugin {plugin}</code>.
         </p>
       )}
     </div>
@@ -320,7 +320,7 @@ function TrustNote() {
         background: "var(--warn-soft)",
         border: "1px solid var(--warn)",
         borderRadius: "var(--r-3)",
-        fontSize: 12,
+        fontSize: "var(--fs-s)",
         color: "var(--ink-2)",
         lineHeight: 1.6,
       }}

--- a/dashboard/src/app/marketplace/page.tsx
+++ b/dashboard/src/app/marketplace/page.tsx
@@ -166,7 +166,7 @@ function Toast({ message, onDone }: { message: string; onDone: () => void }) {
         border: "1px solid var(--border-default)",
         borderRadius: "var(--r-3)",
         padding: "12px 18px",
-        fontSize: 13,
+        fontSize: "var(--fs-m)",
         color: "var(--fg-0)",
         boxShadow: "0 8px 32px var(--overlay-bg)",
         zIndex: 9999,
@@ -175,7 +175,7 @@ function Toast({ message, onDone }: { message: string; onDone: () => void }) {
         gap: 10,
       }}
     >
-      <span style={{ color: "var(--ok)", fontSize: 16 }}>&#10003;</span>
+      <span style={{ color: "var(--ok)", fontSize: "var(--fs-xl)" }}>&#10003;</span>
       {message}
     </div>
   );
@@ -221,7 +221,7 @@ function RecipeCard({
           href={`/marketplace/${recipe.name}`}
           style={{
             fontWeight: 600,
-            fontSize: 14,
+            fontSize: "var(--fs-base)",
             color: "var(--fg-0)",
             wordBreak: "break-word",
             lineHeight: 1.4,
@@ -236,7 +236,7 @@ function RecipeCard({
       {/* middle: description */}
       <p
         style={{
-          fontSize: 12,
+          fontSize: "var(--fs-s)",
           color: "var(--fg-2)",
           lineHeight: 1.55,
           flex: 1,
@@ -256,7 +256,7 @@ function RecipeCard({
           {recipe.risk_level && (
             <span
               className={`pill ${RISK_PILL_CLASS[recipe.risk_level]}`}
-              style={{ fontSize: 9 }}
+              style={{ fontSize: "var(--fs-3xs)" }}
               title={`Risk level: ${recipe.risk_level}`}
             >
               {recipe.risk_level} risk
@@ -265,19 +265,19 @@ function RecipeCard({
           {recipe.approval_behavior && (
             <span
               className="pill muted"
-              style={{ fontSize: 9 }}
+              style={{ fontSize: "var(--fs-3xs)" }}
               title={`Approval: ${recipe.approval_behavior}`}
             >
               {APPROVAL_LABEL[recipe.approval_behavior]}
             </span>
           )}
           {recipe.network_access && (
-            <span className="pill muted" style={{ fontSize: 9 }} title="Makes outbound network requests">
+            <span className="pill muted" style={{ fontSize: "var(--fs-3xs)" }} title="Makes outbound network requests">
               network
             </span>
           )}
           {recipe.file_access && (
-            <span className="pill muted" style={{ fontSize: 9 }} title="Reads or writes local files">
+            <span className="pill muted" style={{ fontSize: "var(--fs-3xs)" }} title="Reads or writes local files">
               file I/O
             </span>
           )}
@@ -309,7 +309,7 @@ function RecipeCard({
           {recipe.downloads > 0 && (
             <span
               style={{
-                fontSize: 11,
+                fontSize: "var(--fs-xs)",
                 color: "var(--ink-3)",
                 marginLeft: 2,
               }}
@@ -330,7 +330,7 @@ function RecipeCard({
                 background: "var(--ok-soft)",
                 color: "var(--ok)",
                 border: "1px solid var(--ok)",
-                fontSize: 11,
+                fontSize: "var(--fs-xs)",
               }}
             >
               &#10003; Installed
@@ -365,7 +365,7 @@ function RecipeCard({
         <div
           style={{
             marginTop: "var(--s-2)",
-            fontSize: 11,
+            fontSize: "var(--fs-xs)",
             color: "var(--err)",
             lineHeight: 1.5,
           }}
@@ -528,7 +528,7 @@ export default function MarketplacePage() {
             alignItems: "center",
             justifyContent: "space-between",
             gap: 12,
-            fontSize: 13,
+            fontSize: "var(--fs-m)",
           }}
         >
           <span style={{ color: "var(--fg-2)" }}>
@@ -540,7 +540,7 @@ export default function MarketplacePage() {
             rel="noopener noreferrer"
             style={{
               flexShrink: 0,
-              fontSize: 12,
+              fontSize: "var(--fs-s)",
               fontWeight: 600,
               padding: "4px 14px",
               borderRadius: "var(--r-full)",
@@ -569,7 +569,7 @@ export default function MarketplacePage() {
             type="button"
             onClick={() => setSearchOpen((v) => !v)}
             className="btn sm ghost"
-            style={{ fontSize: 12 }}
+            style={{ fontSize: "var(--fs-s)" }}
             aria-label="Toggle search"
             aria-expanded={searchOpen}
           >
@@ -580,7 +580,7 @@ export default function MarketplacePage() {
             target="_blank"
             rel="noopener noreferrer"
             className="btn sm"
-            style={{ textDecoration: "none", fontSize: 12 }}
+            style={{ textDecoration: "none", fontSize: "var(--fs-s)" }}
             aria-label="Submit a recipe to the marketplace"
           >
             + Submit recipe
@@ -636,7 +636,7 @@ export default function MarketplacePage() {
         <>
           {featured && (
             <>
-              <h2 style={{ fontSize: 13, fontWeight: 600, color: "var(--fg-2)", marginBottom: "var(--s-3)", marginTop: 0 }}>
+              <h2 style={{ fontSize: "var(--fs-m)", fontWeight: 600, color: "var(--fg-2)", marginBottom: "var(--s-3)", marginTop: 0 }}>
                 Featured this week
               </h2>
               <div
@@ -662,7 +662,7 @@ export default function MarketplacePage() {
                       top: 12,
                       right: 12,
                       zIndex: 2,
-                      fontSize: 10,
+                      fontSize: "var(--fs-2xs)",
                       fontFamily: "var(--font-mono)",
                       letterSpacing: "0.06em",
                       background: "var(--accent-soft)",
@@ -686,7 +686,7 @@ export default function MarketplacePage() {
 
           {rest.length > 0 && (
             <>
-              <h2 style={{ fontSize: 13, fontWeight: 600, color: "var(--fg-2)", marginBottom: "var(--s-3)", marginTop: 0 }}>
+              <h2 style={{ fontSize: "var(--fs-m)", fontWeight: 600, color: "var(--fg-2)", marginBottom: "var(--s-3)", marginTop: 0 }}>
                 All recipes
               </h2>
               <div className="marketplace-grid">

--- a/dashboard/src/app/metrics/page.tsx
+++ b/dashboard/src/app/metrics/page.tsx
@@ -165,37 +165,37 @@ export default function MetricsPage() {
         }}
       >
         <div className="card" style={{ padding: "16px 20px", borderRadius: "var(--r-card)", borderLeft: "3px solid var(--orange)" }}>
-          <div style={{ fontSize: 10, fontFamily: "var(--font-mono)", fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.08em", color: "var(--ink-3)", marginBottom: 6 }}>
+          <div style={{ fontSize: "var(--fs-2xs)", fontFamily: "var(--font-mono)", fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.08em", color: "var(--ink-3)", marginBottom: 6 }}>
             <span style={{ color: "var(--orange)", marginRight: 6 }}>{">_"}</span>Total calls
           </div>
-          <div style={{ fontFamily: "var(--font-mono)", fontSize: 28, fontWeight: 800, color: "var(--ink-0)", lineHeight: 1 }}>
+          <div style={{ fontFamily: "var(--font-mono)", fontSize: "var(--fs-display)", fontWeight: 800, color: "var(--ink-0)", lineHeight: 1 }}>
             {metrics.length === 0 ? "—" : <AnimatedNumber value={totalCalls} />}
           </div>
         </div>
         <div className="card" style={{ padding: "16px 20px", borderRadius: "var(--r-card)", borderLeft: "3px solid var(--err)" }}>
-          <div style={{ fontSize: 10, fontFamily: "var(--font-mono)", fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.08em", color: "var(--ink-3)", marginBottom: 6 }}>
+          <div style={{ fontSize: "var(--fs-2xs)", fontFamily: "var(--font-mono)", fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.08em", color: "var(--ink-3)", marginBottom: 6 }}>
             <span style={{ color: "var(--err)", marginRight: 6 }}>△</span>Errors
           </div>
-          <div style={{ fontFamily: "var(--font-mono)", fontSize: 28, fontWeight: 800, color: totalErrors > 0 ? "var(--err)" : "var(--ink-0)", lineHeight: 1 }}>
+          <div style={{ fontFamily: "var(--font-mono)", fontSize: "var(--fs-display)", fontWeight: 800, color: totalErrors > 0 ? "var(--err)" : "var(--ink-0)", lineHeight: 1 }}>
             {metrics.length === 0 ? "—" : <AnimatedNumber value={totalErrors} />}
           </div>
         </div>
         <div className="card" style={{ padding: "16px 20px", borderRadius: "var(--r-card)", borderLeft: "3px solid var(--green)" }}>
-          <div style={{ fontSize: 10, fontFamily: "var(--font-mono)", fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.08em", color: "var(--ink-3)", marginBottom: 6 }}>
+          <div style={{ fontSize: "var(--fs-2xs)", fontFamily: "var(--font-mono)", fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.08em", color: "var(--ink-3)", marginBottom: 6 }}>
             <span style={{ color: "var(--green)", marginRight: 6 }}>✓</span>Success rate
           </div>
-          <div style={{ fontFamily: "var(--font-mono)", fontSize: 28, fontWeight: 800, color: "var(--ink-0)", lineHeight: 1 }}>
+          <div style={{ fontFamily: "var(--font-mono)", fontSize: "var(--fs-display)", fontWeight: 800, color: "var(--ink-0)", lineHeight: 1 }}>
             {successRate !== null ? `${successRate}%` : "—"}
           </div>
           {successRate === null && (
-            <div style={{ fontSize: 11, color: "var(--ink-3)", marginTop: 4 }}>no calls yet</div>
+            <div style={{ fontSize: "var(--fs-xs)", color: "var(--ink-3)", marginTop: 4 }}>no calls yet</div>
           )}
         </div>
         <div className="card" style={{ padding: "16px 20px", borderRadius: "var(--r-card)", borderLeft: "3px solid var(--blue)" }}>
-          <div style={{ fontSize: 10, fontFamily: "var(--font-mono)", fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.08em", color: "var(--ink-3)", marginBottom: 6 }}>
+          <div style={{ fontSize: "var(--fs-2xs)", fontFamily: "var(--font-mono)", fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.08em", color: "var(--ink-3)", marginBottom: 6 }}>
             <span style={{ color: "var(--blue)", marginRight: 6 }}>◎</span>Uptime
           </div>
-          <div style={{ fontFamily: "var(--font-mono)", fontSize: 28, fontWeight: 800, color: "var(--ink-0)", lineHeight: 1 }}>
+          <div style={{ fontFamily: "var(--font-mono)", fontSize: "var(--fs-display)", fontWeight: 800, color: "var(--ink-0)", lineHeight: 1 }}>
             {uptimeSeconds != null ? `${Math.round(uptimeSeconds)}s` : "—"}
           </div>
         </div>
@@ -229,7 +229,7 @@ export default function MetricsPage() {
               <div
                 style={{
                   fontFamily: "var(--font-mono)",
-                  fontSize: 10,
+                  fontSize: "var(--fs-2xs)",
                   fontWeight: 700,
                   letterSpacing: "0.08em",
                   textTransform: "uppercase",
@@ -241,7 +241,7 @@ export default function MetricsPage() {
               </div>
               <div style={{ display: "grid", gridTemplateColumns: "auto 1fr", gap: "var(--s-4)", alignItems: "center" }}>
                 <MetricsDonut segments={toolCallDonut} size={110} strokeWidth={16} label="calls" />
-                <ul style={{ listStyle: "none", margin: 0, padding: 0, fontFamily: "var(--font-mono)", fontSize: 12, color: "var(--ink-1)", display: "flex", flexDirection: "column", gap: 4 }}>
+                <ul style={{ listStyle: "none", margin: 0, padding: 0, fontFamily: "var(--font-mono)", fontSize: "var(--fs-s)", color: "var(--ink-1)", display: "flex", flexDirection: "column", gap: 4 }}>
                   {callsByToolStatus.map((row, i) => (
                     <li key={`${row.tool}-${row.status}-${i}`} style={{ display: "flex", justifyContent: "space-between", gap: 12, borderBottom: "1px dashed var(--line-2)", paddingBottom: 3 }}>
                       <span style={{ color: "var(--ink-2)" }}>
@@ -260,7 +260,7 @@ export default function MetricsPage() {
               <div
                 style={{
                   fontFamily: "var(--font-mono)",
-                  fontSize: 10,
+                  fontSize: "var(--fs-2xs)",
                   fontWeight: 700,
                   letterSpacing: "0.08em",
                   textTransform: "uppercase",
@@ -291,7 +291,7 @@ export default function MetricsPage() {
           }}
         >
           <h3 style={{ color: "var(--ink-1)", marginBottom: 8 }}>No metrics yet</h3>
-          <p style={{ color: "var(--ink-3)", fontSize: 13, maxWidth: 380, margin: 0 }}>
+          <p style={{ color: "var(--ink-3)", fontSize: "var(--fs-m)", maxWidth: 380, margin: 0 }}>
             Metrics appear once the bridge begins serving tool calls. Make a tool call or wait for the next scrape interval.
           </p>
         </div>

--- a/dashboard/src/app/page.tsx
+++ b/dashboard/src/app/page.tsx
@@ -135,7 +135,7 @@ function ActivityThread({ events }: { events: ActivityEvent[] }) {
       >
         <h3
           style={{
-            fontSize: 13,
+            fontSize: "var(--fs-m)",
             fontWeight: 700,
             margin: 0,
             color: "var(--ink-0)",
@@ -148,14 +148,14 @@ function ActivityThread({ events }: { events: ActivityEvent[] }) {
         </h3>
         <Link
           href="/activity"
-          style={{ fontSize: 11, color: "var(--orange)", textDecoration: "none" }}
+          style={{ fontSize: "var(--fs-xs)", color: "var(--orange)", textDecoration: "none" }}
         >
           view all →
         </Link>
       </div>
 
       {events.length === 0 ? (
-        <div style={{ fontSize: 12, color: "var(--ink-3)", padding: "var(--s-4) 0" }}>
+        <div style={{ fontSize: "var(--fs-s)", color: "var(--ink-3)", padding: "var(--s-4) 0" }}>
           No recent events.
         </div>
       ) : (
@@ -196,7 +196,7 @@ function ActivityThread({ events }: { events: ActivityEvent[] }) {
                   gap: 10,
                   padding: "7px 0 7px 18px",
                   position: "relative",
-                  fontSize: 12,
+                  fontSize: "var(--fs-s)",
                   minWidth: 0,
                 }}
               >
@@ -217,7 +217,7 @@ function ActivityThread({ events }: { events: ActivityEvent[] }) {
                 <span
                   style={{
                     fontFamily: "var(--font-mono)",
-                    fontSize: 11,
+                    fontSize: "var(--fs-xs)",
                     color: "var(--ink-3)",
                     minWidth: 56,
                     flexShrink: 0,
@@ -228,7 +228,7 @@ function ActivityThread({ events }: { events: ActivityEvent[] }) {
                 <span
                   style={{
                     fontFamily: "var(--font-mono)",
-                    fontSize: 12,
+                    fontSize: "var(--fs-s)",
                     color: "var(--ink-0)",
                     fontWeight: 600,
                     flex: 1,
@@ -242,7 +242,7 @@ function ActivityThread({ events }: { events: ActivityEvent[] }) {
                 </span>
                 <span
                   className="pill muted"
-                  style={{ fontSize: 9, flexShrink: 0 }}
+                  style={{ fontSize: "var(--fs-3xs)", flexShrink: 0 }}
                 >
                   {kind}
                 </span>
@@ -250,7 +250,7 @@ function ActivityThread({ events }: { events: ActivityEvent[] }) {
                   <span
                     style={{
                       fontFamily: "var(--font-mono)",
-                      fontSize: 10,
+                      fontSize: "var(--fs-2xs)",
                       color: "var(--ink-2)",
                       flexShrink: 0,
                     }}
@@ -260,7 +260,7 @@ function ActivityThread({ events }: { events: ActivityEvent[] }) {
                 )}
                 <span
                   className={`pill ${isErr ? "err" : "ok"}`}
-                  style={{ fontSize: 9, flexShrink: 0 }}
+                  style={{ fontSize: "var(--fs-3xs)", flexShrink: 0 }}
                 >
                   {isErr ? "err" : "ok"}
                 </span>
@@ -290,7 +290,7 @@ function ActiveRecipeCard() {
       >
         <h3
           style={{
-            fontSize: 13,
+            fontSize: "var(--fs-m)",
             fontWeight: 700,
             margin: 0,
             color: "var(--ink-0)",
@@ -303,7 +303,7 @@ function ActiveRecipeCard() {
         </h3>
         <span
           className="pill muted"
-          style={{ fontSize: 10 }}
+          style={{ fontSize: "var(--fs-2xs)" }}
           title="Live wiring pending — preview only"
         >
           preview
@@ -316,7 +316,7 @@ function ActiveRecipeCard() {
           alignItems: "center",
           gap: 8,
           marginBottom: 10,
-          fontSize: 12,
+          fontSize: "var(--fs-s)",
           color: "var(--ink-1)",
         }}
       >
@@ -379,7 +379,7 @@ function HealthCard({
       >
         <h3
           style={{
-            fontSize: 13,
+            fontSize: "var(--fs-m)",
             fontWeight: 700,
             margin: 0,
             color: "var(--ink-0)",
@@ -392,7 +392,7 @@ function HealthCard({
         </h3>
         <span
           className={`pill ${bridgeOk && extensionConnected ? "ok" : bridgeOk ? "muted" : "warn"}`}
-          style={{ fontSize: 10 }}
+          style={{ fontSize: "var(--fs-2xs)" }}
         >
           {bridgeOk && extensionConnected
             ? "all green"
@@ -664,7 +664,7 @@ export default function HomePage() {
         <span
           style={{
             fontFamily: "var(--font-mono)",
-            fontSize: 10,
+            fontSize: "var(--fs-2xs)",
             fontWeight: 700,
             letterSpacing: "0.1em",
             textTransform: "uppercase",
@@ -679,7 +679,7 @@ export default function HomePage() {
           className="btn sm ghost"
           onClick={() => tickRef.current()}
           style={{
-            fontSize: 11,
+            fontSize: "var(--fs-xs)",
             display: "inline-flex",
             alignItems: "center",
             gap: 6,
@@ -696,7 +696,7 @@ export default function HomePage() {
           className="btn sm primary"
           style={{
             textDecoration: "none",
-            fontSize: 11,
+            fontSize: "var(--fs-xs)",
             background: "var(--orange)",
             border: "none",
           }}
@@ -770,7 +770,7 @@ export default function HomePage() {
         >
           <span
             style={{
-              fontSize: 13,
+              fontSize: "var(--fs-m)",
               fontWeight: 700,
               color: "var(--ink-0)",
               flex: 1,
@@ -781,7 +781,7 @@ export default function HomePage() {
           <span
             style={{
               fontFamily: "var(--font-mono)",
-              fontSize: 11,
+              fontSize: "var(--fs-xs)",
               color: "var(--orange)",
               fontWeight: 700,
             }}
@@ -792,7 +792,7 @@ export default function HomePage() {
         <div
           style={{
             fontFamily: "var(--font-mono)",
-            fontSize: 11,
+            fontSize: "var(--fs-xs)",
             color: "var(--ink-3)",
             marginBottom: 10,
           }}

--- a/dashboard/src/app/recipes/[name]/edit/page.tsx
+++ b/dashboard/src/app/recipes/[name]/edit/page.tsx
@@ -221,7 +221,7 @@ export default function RecipeEditPage({
             className={`pill ${t.kind === "ok" ? "ok" : "err"}`}
             style={{
               padding: "var(--s-2) var(--s-4)",
-              fontSize: 13,
+              fontSize: "var(--fs-m)",
               borderRadius: "var(--r-2)",
               background: t.kind === "ok" ? "var(--ok-soft)" : "var(--err-soft)",
               border: `1px solid ${t.kind === "ok" ? "var(--ok)" : "var(--err)"}`,
@@ -243,7 +243,7 @@ export default function RecipeEditPage({
               href="/recipes"
               style={{
                 color: "var(--fg-3)",
-                fontSize: 13,
+                fontSize: "var(--fs-m)",
                 textDecoration: "none",
                 display: "inline-flex",
                 alignItems: "center",
@@ -310,14 +310,14 @@ export default function RecipeEditPage({
             justifyContent: "space-between",
             alignItems: "flex-start",
             gap: "var(--s-3)",
-            fontSize: 13,
+            fontSize: "var(--fs-m)",
           }}
         >
           <div>
             <strong style={{ display: "block", marginBottom: 2 }}>
               Save failed
             </strong>
-            <span style={{ fontFamily: "var(--font-mono)", fontSize: 12 }}>
+            <span style={{ fontFamily: "var(--font-mono)", fontSize: "var(--fs-s)" }}>
               {saveError}
             </span>
           </div>
@@ -330,7 +330,7 @@ export default function RecipeEditPage({
               border: "none",
               color: "inherit",
               cursor: "pointer",
-              fontSize: 16,
+              fontSize: "var(--fs-xl)",
               lineHeight: 1,
               padding: 0,
             }}
@@ -351,13 +351,13 @@ export default function RecipeEditPage({
             background: "var(--err-soft)",
             border: "1px solid var(--err)",
             color: "var(--err)",
-            fontSize: 13,
+            fontSize: "var(--fs-m)",
           }}
         >
           <strong style={{ display: "block", marginBottom: 4 }}>
             {lintErrors.length} lint error{lintErrors.length === 1 ? "" : "s"}
           </strong>
-          <ul style={{ margin: 0, paddingLeft: 18, fontFamily: "var(--font-mono)", fontSize: 12 }}>
+          <ul style={{ margin: 0, paddingLeft: 18, fontFamily: "var(--font-mono)", fontSize: "var(--fs-s)" }}>
             {lintErrors.map((msg, idx) => (
               <li key={`lint-err-${idx}`}>{msg}</li>
             ))}
@@ -376,14 +376,14 @@ export default function RecipeEditPage({
             background: "var(--warn-soft)",
             border: "1px solid var(--warn)",
             color: "var(--warn)",
-            fontSize: 13,
+            fontSize: "var(--fs-m)",
           }}
         >
           <strong style={{ display: "block", marginBottom: 4 }}>
             {lintWarnings.length} lint warning
             {lintWarnings.length === 1 ? "" : "s"}
           </strong>
-          <ul style={{ margin: 0, paddingLeft: 18, fontFamily: "var(--font-mono)", fontSize: 12 }}>
+          <ul style={{ margin: 0, paddingLeft: 18, fontFamily: "var(--font-mono)", fontSize: "var(--fs-s)" }}>
             {lintWarnings.map((msg, idx) => (
               <li key={`lint-warn-${idx}`}>{msg}</li>
             ))}
@@ -415,7 +415,7 @@ export default function RecipeEditPage({
               border: "1px solid var(--line-2)",
               borderRadius: "var(--r-2)",
               fontFamily: "var(--font-mono, 'JetBrains Mono', 'Fira Code', monospace)",
-              fontSize: 13,
+              fontSize: "var(--fs-m)",
               lineHeight: 1.6,
               padding: "var(--s-4)",
               resize: "vertical",
@@ -457,7 +457,7 @@ export default function RecipeEditPage({
         <div
           style={{
             marginTop: "var(--s-3)",
-            fontSize: 12,
+            fontSize: "var(--fs-s)",
             color: "var(--fg-3)",
             display: "flex",
             justifyContent: "space-between",

--- a/dashboard/src/app/recipes/[name]/plan/page.tsx
+++ b/dashboard/src/app/recipes/[name]/plan/page.tsx
@@ -48,7 +48,7 @@ function RiskBadge({ risk }: { risk?: string }) {
         border: `1px solid ${RISK_COLORS[risk] ?? "var(--border-default)"}`,
         borderRadius: 4,
         color: RISK_COLORS[risk] ?? "var(--fg-3)",
-        fontSize: 11,
+        fontSize: "var(--fs-xs)",
         fontWeight: 600,
         letterSpacing: "0.04em",
         padding: "1px 6px",
@@ -74,7 +74,7 @@ function TypeBadge({ type }: { type: string }) {
         border: `1px solid ${color}`,
         borderRadius: 4,
         color,
-        fontSize: 11,
+        fontSize: "var(--fs-xs)",
         fontWeight: 600,
         letterSpacing: "0.04em",
         padding: "1px 6px",
@@ -136,7 +136,7 @@ export default function RecipePlanPage({
               href={`/recipes/${encodeURIComponent(name)}/edit`}
               style={{
                 color: "var(--fg-3)",
-                fontSize: 13,
+                fontSize: "var(--fs-m)",
                 textDecoration: "none",
                 display: "inline-flex",
                 alignItems: "center",
@@ -175,7 +175,7 @@ export default function RecipePlanPage({
       </div>
 
       {loading && (
-        <p style={{ color: "var(--fg-3)", fontSize: 14 }}>Loading plan…</p>
+        <p style={{ color: "var(--fg-3)", fontSize: "var(--fs-base)" }}>Loading plan…</p>
       )}
 
       {error && (
@@ -185,7 +185,7 @@ export default function RecipePlanPage({
             border: "1px solid var(--err)",
             borderRadius: "var(--r-2)",
             color: "var(--err)",
-            fontSize: 13,
+            fontSize: "var(--fs-m)",
             padding: "var(--s-3) var(--s-4)",
           }}
         >
@@ -203,7 +203,7 @@ export default function RecipePlanPage({
               display: "flex",
               flexWrap: "wrap",
               gap: "var(--s-4)",
-              fontSize: 13,
+              fontSize: "var(--fs-m)",
               color: "var(--fg-2)",
             }}
           >
@@ -254,7 +254,7 @@ export default function RecipePlanPage({
                     border: "1px solid var(--err)",
                     borderRadius: "var(--r-2)",
                     color: "var(--err)",
-                    fontSize: 13,
+                    fontSize: "var(--fs-m)",
                     padding: "var(--s-2) var(--s-3)",
                   }}
                 >
@@ -270,7 +270,7 @@ export default function RecipePlanPage({
                     border: "1px solid var(--warn)",
                     borderRadius: "var(--r-2)",
                     color: "var(--warn)",
-                    fontSize: 13,
+                    fontSize: "var(--fs-m)",
                     padding: "var(--s-2) var(--s-3)",
                   }}
                 >
@@ -291,7 +291,7 @@ export default function RecipePlanPage({
             <table
               style={{
                 borderCollapse: "collapse",
-                fontSize: 13,
+                fontSize: "var(--fs-m)",
                 width: "100%",
               }}
             >
@@ -309,7 +309,7 @@ export default function RecipePlanPage({
                         style={{
                           color: "var(--fg-2)",
                           fontWeight: 600,
-                          fontSize: 11,
+                          fontSize: "var(--fs-xs)",
                           letterSpacing: "0.04em",
                           padding: "var(--s-2) var(--s-3)",
                           textAlign: "left",
@@ -350,7 +350,7 @@ export default function RecipePlanPage({
                     <td
                       style={{
                         fontFamily: "var(--font-mono)",
-                        fontSize: 12,
+                        fontSize: "var(--fs-s)",
                         padding: "var(--s-2) var(--s-3)",
                         color: "var(--fg-0)",
                       }}
@@ -360,7 +360,7 @@ export default function RecipePlanPage({
                         <span
                           style={{
                             color: "var(--fg-3)",
-                            fontSize: 11,
+                            fontSize: "var(--fs-xs)",
                             marginLeft: 4,
                           }}
                         >
@@ -390,7 +390,7 @@ export default function RecipePlanPage({
                             <span
                               style={{
                                 color: "var(--err)",
-                                fontSize: 11,
+                                fontSize: "var(--fs-xs)",
                                 marginLeft: 6,
                               }}
                             >
@@ -399,7 +399,7 @@ export default function RecipePlanPage({
                           )}
                         </>
                       ) : step.recipe ? (
-                        <span style={{ fontFamily: "var(--font-mono)", fontSize: 12 }}>
+                        <span style={{ fontFamily: "var(--font-mono)", fontSize: "var(--fs-s)" }}>
                           recipe: {step.recipe}
                         </span>
                       ) : step.prompt ? (
@@ -422,7 +422,7 @@ export default function RecipePlanPage({
                       style={{
                         color: "var(--fg-3)",
                         fontFamily: "var(--font-mono)",
-                        fontSize: 11,
+                        fontSize: "var(--fs-xs)",
                         padding: "var(--s-2) var(--s-3)",
                         whiteSpace: "nowrap",
                       }}
@@ -435,7 +435,7 @@ export default function RecipePlanPage({
                     <td
                       style={{
                         color: "var(--fg-3)",
-                        fontSize: 12,
+                        fontSize: "var(--fs-s)",
                         padding: "var(--s-2) var(--s-3)",
                         whiteSpace: "nowrap",
                       }}
@@ -460,7 +460,7 @@ export default function RecipePlanPage({
               <h3
                 style={{
                   color: "var(--fg-1)",
-                  fontSize: 13,
+                  fontSize: "var(--fs-m)",
                   fontWeight: 600,
                   margin: "0 0 var(--s-2) 0",
                 }}
@@ -481,7 +481,7 @@ export default function RecipePlanPage({
                       background: "var(--bg-2)",
                       border: "1px solid var(--border-default)",
                       borderRadius: "var(--r-2)",
-                      fontSize: 12,
+                      fontSize: "var(--fs-s)",
                       fontFamily: "var(--font-mono)",
                       padding: "var(--s-1) var(--s-3)",
                     }}

--- a/dashboard/src/app/recipes/compare/page.tsx
+++ b/dashboard/src/app/recipes/compare/page.tsx
@@ -40,22 +40,22 @@ function StepRow({ step, highlight }: { step: PlanStep; highlight?: boolean }) {
         background: highlight ? "color-mix(in srgb, var(--warn) 8%, transparent)" : undefined,
       }}
     >
-      <td style={{ padding: "8px 0", fontSize: 12, fontFamily: "monospace" }}>
+      <td style={{ padding: "8px 0", fontSize: "var(--fs-s)", fontFamily: "monospace" }}>
         {step.tool ?? step.type}
       </td>
       <td style={{ padding: "8px 6px", textAlign: "center" }}>
         {step.risk && (
-          <span className={`pill ${RISK_PILL[step.risk]}`} style={{ fontSize: 10 }}>
+          <span className={`pill ${RISK_PILL[step.risk]}`} style={{ fontSize: "var(--fs-2xs)" }}>
             {step.risk}
           </span>
         )}
       </td>
-      <td style={{ padding: "8px 6px", textAlign: "center", fontSize: 11, color: "var(--fg-2)" }}>
+      <td style={{ padding: "8px 6px", textAlign: "center", fontSize: "var(--fs-xs)", color: "var(--fg-2)" }}>
         {step.isWrite ? "write" : "read"}
       </td>
       <td style={{ padding: "8px 0", textAlign: "center" }}>
         {step.resolved === false && (
-          <span className="pill err" style={{ fontSize: 10 }}>unresolved</span>
+          <span className="pill err" style={{ fontSize: "var(--fs-2xs)" }}>unresolved</span>
         )}
       </td>
     </tr>
@@ -105,19 +105,19 @@ function PlanColumn({
           gap: 8,
         }}
       >
-        <code style={{ flex: 1, fontSize: 13 }}>{name}</code>
+        <code style={{ flex: 1, fontSize: "var(--fs-m)" }}>{name}</code>
         {plan && (
           <>
-            <span className="pill muted" style={{ fontSize: 10 }}>
+            <span className="pill muted" style={{ fontSize: "var(--fs-2xs)" }}>
               {plan.steps.length} steps
             </span>
             {addedSteps.length > 0 && (
-              <span className="pill ok" style={{ fontSize: 10 }}>
+              <span className="pill ok" style={{ fontSize: "var(--fs-2xs)" }}>
                 +{addedSteps.length} new
               </span>
             )}
             {removedCount > 0 && (
-              <span className="pill err" style={{ fontSize: 10 }}>
+              <span className="pill err" style={{ fontSize: "var(--fs-2xs)" }}>
                 -{removedCount} removed
               </span>
             )}
@@ -135,13 +135,13 @@ function PlanColumn({
       </div>
 
       <div style={{ padding: "12px 16px" }}>
-        {loading && <p style={{ color: "var(--fg-2)", fontSize: 13 }}>Loading plan…</p>}
-        {error && <div className="alert-err" style={{ fontSize: 12 }}>{error}</div>}
+        {loading && <p style={{ color: "var(--fg-2)", fontSize: "var(--fs-m)" }}>Loading plan…</p>}
+        {error && <div className="alert-err" style={{ fontSize: "var(--fs-s)" }}>{error}</div>}
 
         {plan && (
           <>
             {plan.lint.errors.length > 0 && (
-              <div className="alert-err" style={{ marginBottom: 8, fontSize: 12 }}>
+              <div className="alert-err" style={{ marginBottom: 8, fontSize: "var(--fs-s)" }}>
                 {plan.lint.errors.join(" · ")}
               </div>
             )}
@@ -152,7 +152,7 @@ function PlanColumn({
                   border: "1px solid color-mix(in srgb, var(--warn) 30%, transparent)",
                   borderRadius: "var(--r-2)",
                   padding: "6px 10px",
-                  fontSize: 11,
+                  fontSize: "var(--fs-xs)",
                   color: "var(--fg-1)",
                   marginBottom: 8,
                 }}
@@ -163,10 +163,10 @@ function PlanColumn({
             <table style={{ width: "100%", borderCollapse: "collapse" }}>
               <thead>
                 <tr style={{ borderBottom: "1px solid var(--border-default)" }}>
-                  <th style={{ textAlign: "left", fontSize: 10, color: "var(--fg-2)", fontWeight: 500, padding: "4px 0" }}>Step</th>
-                  <th style={{ textAlign: "center", fontSize: 10, color: "var(--fg-2)", fontWeight: 500, padding: "4px 6px" }}>Risk</th>
-                  <th style={{ textAlign: "center", fontSize: 10, color: "var(--fg-2)", fontWeight: 500, padding: "4px 6px" }}>Mode</th>
-                  <th style={{ textAlign: "center", fontSize: 10, color: "var(--fg-2)", fontWeight: 500, padding: "4px 0" }} />
+                  <th style={{ textAlign: "left", fontSize: "var(--fs-2xs)", color: "var(--fg-2)", fontWeight: 500, padding: "4px 0" }}>Step</th>
+                  <th style={{ textAlign: "center", fontSize: "var(--fs-2xs)", color: "var(--fg-2)", fontWeight: 500, padding: "4px 6px" }}>Risk</th>
+                  <th style={{ textAlign: "center", fontSize: "var(--fs-2xs)", color: "var(--fg-2)", fontWeight: 500, padding: "4px 6px" }}>Mode</th>
+                  <th style={{ textAlign: "center", fontSize: "var(--fs-2xs)", color: "var(--fg-2)", fontWeight: 500, padding: "4px 0" }} />
                 </tr>
               </thead>
               <tbody>
@@ -180,7 +180,7 @@ function PlanColumn({
               </tbody>
             </table>
             {plan.connectorNamespaces && plan.connectorNamespaces.length > 0 && (
-              <p style={{ fontSize: 11, color: "var(--fg-2)", marginTop: 8 }}>
+              <p style={{ fontSize: "var(--fs-xs)", color: "var(--fg-2)", marginTop: 8 }}>
                 Connectors: {plan.connectorNamespaces.join(", ")}
               </p>
             )}
@@ -305,7 +305,7 @@ function CompareInner() {
     <section>
       <div className="page-head">
         <div>
-          <Link href="/recipes" style={{ fontSize: 12, color: "var(--fg-2)", textDecoration: "none" }}>
+          <Link href="/recipes" style={{ fontSize: "var(--fs-s)", color: "var(--fg-2)", textDecoration: "none" }}>
             ← Recipes
           </Link>
           <h1 style={{ marginTop: 4 }}>Compare variants</h1>
@@ -326,7 +326,7 @@ function CompareInner() {
             background:
               promoteResultKind === "ok" ? "var(--ok-soft)" : "var(--err-soft)",
             border: `1px solid ${promoteResultKind === "ok" ? "var(--ok)" : "var(--err)"}`,
-            fontSize: 13,
+            fontSize: "var(--fs-m)",
           }}
         >
           <span aria-hidden="true">
@@ -336,7 +336,7 @@ function CompareInner() {
           {promoteResultKind === "ok" && (
             <>
               {" "}
-              <Link href="/recipes" style={{ color: "var(--ok)", fontSize: 12 }}>
+              <Link href="/recipes" style={{ color: "var(--ok)", fontSize: "var(--fs-s)" }}>
                 Back to recipes →
               </Link>
             </>
@@ -378,7 +378,7 @@ function CompareInner() {
             <h3 id="promote-confirm-heading" style={{ marginTop: 0, marginBottom: 8 }}>
               Overwrite <code>{baseName}</code>?
             </h3>
-            <p style={{ fontSize: 13, color: "var(--ink-2)", margin: "0 0 16px", lineHeight: 1.5 }}>
+            <p style={{ fontSize: "var(--fs-m)", color: "var(--ink-2)", margin: "0 0 16px", lineHeight: 1.5 }}>
               <code>{baseName}</code> already exists. Promoting{" "}
               <code>{confirm.variantName}</code> will replace it. The existing
               recipe file will be overwritten.

--- a/dashboard/src/app/recipes/new/page.tsx
+++ b/dashboard/src/app/recipes/new/page.tsx
@@ -659,20 +659,20 @@ function NewRecipePageInner() {
             borderBottom: aiOpen ? "1px solid var(--border-default)" : "none",
             color: "var(--fg-1)",
             cursor: "pointer",
-            fontSize: 13,
+            fontSize: "var(--fs-m)",
             fontWeight: 500,
             padding: "var(--s-3) var(--s-4)",
             textAlign: "left",
           }}
         >
-          <span style={{ fontSize: 16 }}>{aiOpen ? "▾" : "▸"}</span>
+          <span style={{ fontSize: "var(--fs-xl)" }}>{aiOpen ? "▾" : "▸"}</span>
           Generate with AI
           <span
             style={{
               background: "var(--accent)",
               borderRadius: 4,
               color: "var(--on-accent)",
-              fontSize: 10,
+              fontSize: "var(--fs-2xs)",
               fontWeight: 700,
               letterSpacing: "0.05em",
               padding: "1px 5px",
@@ -695,7 +695,7 @@ function NewRecipePageInner() {
             <p
               style={{
                 color: "var(--fg-2)",
-                fontSize: 13,
+                fontSize: "var(--fs-m)",
                 margin: 0,
               }}
             >
@@ -713,7 +713,7 @@ function NewRecipePageInner() {
                 border: "1px solid var(--border-default)",
                 borderRadius: "var(--r-2)",
                 color: "var(--fg-0)",
-                fontSize: 13,
+                fontSize: "var(--fs-m)",
                 fontFamily: "var(--font-sans)",
                 outline: "none",
                 padding: "var(--s-2) var(--s-3)",
@@ -733,7 +733,7 @@ function NewRecipePageInner() {
                   color: "var(--on-accent)",
                   cursor:
                     aiLoading || !aiPrompt.trim() ? "not-allowed" : "pointer",
-                  fontSize: 13,
+                  fontSize: "var(--fs-m)",
                   fontWeight: 500,
                   opacity: aiLoading || !aiPrompt.trim() ? 0.6 : 1,
                   padding: "var(--s-2) var(--s-4)",
@@ -750,7 +750,7 @@ function NewRecipePageInner() {
                   border: "1px solid var(--err)",
                   borderRadius: "var(--r-2)",
                   color: "var(--err)",
-                  fontSize: 12,
+                  fontSize: "var(--fs-s)",
                   margin: 0,
                   padding: "var(--s-2) var(--s-3)",
                 }}
@@ -760,7 +760,7 @@ function NewRecipePageInner() {
             )}
 
             {aiResult?.warnings && aiResult.warnings.length > 0 && (
-              <details style={{ fontSize: 12 }}>
+              <details style={{ fontSize: "var(--fs-s)" }}>
                 <summary
                   style={{
                     color: "var(--warn)",
@@ -794,7 +794,7 @@ function NewRecipePageInner() {
                     border: "1px solid var(--border-default)",
                     borderRadius: "var(--r-2)",
                     color: "var(--fg-0)",
-                    fontSize: 12,
+                    fontSize: "var(--fs-s)",
                     fontFamily: "var(--font-mono)",
                     margin: 0,
                     maxHeight: 300,
@@ -815,7 +815,7 @@ function NewRecipePageInner() {
                       borderRadius: "var(--r-2)",
                       color: "var(--on-accent)",
                       cursor: "pointer",
-                      fontSize: 13,
+                      fontSize: "var(--fs-m)",
                       fontWeight: 500,
                       padding: "var(--s-2) var(--s-4)",
                     }}
@@ -834,7 +834,7 @@ function NewRecipePageInner() {
                       borderRadius: "var(--r-2)",
                       color: "var(--fg-1)",
                       cursor: "pointer",
-                      fontSize: 13,
+                      fontSize: "var(--fs-m)",
                       padding: "var(--s-2) var(--s-4)",
                     }}
                   >
@@ -879,7 +879,7 @@ function NewRecipePageInner() {
                   display: "block",
                   marginBottom: "var(--s-2)",
                   color: "var(--fg-1)",
-                  fontSize: 13,
+                  fontSize: "var(--fs-m)",
                   fontWeight: 500,
                 }}
               >
@@ -898,7 +898,7 @@ function NewRecipePageInner() {
                   border: `1px solid ${nameError ? "var(--err)" : "var(--border-default)"}`,
                   borderRadius: "var(--r-2)",
                   color: "var(--fg-0)",
-                  fontSize: 14,
+                  fontSize: "var(--fs-base)",
                   padding: "var(--s-2) var(--s-3)",
                   outline: "none",
                   fontFamily: "var(--font-mono)",
@@ -908,7 +908,7 @@ function NewRecipePageInner() {
                 <div
                   style={{
                     marginTop: "var(--s-1)",
-                    fontSize: 12,
+                    fontSize: "var(--fs-s)",
                     color: "var(--err)",
                   }}
                 >
@@ -925,7 +925,7 @@ function NewRecipePageInner() {
                   display: "block",
                   marginBottom: "var(--s-2)",
                   color: "var(--fg-1)",
-                  fontSize: 13,
+                  fontSize: "var(--fs-m)",
                   fontWeight: 500,
                 }}
               >
@@ -946,7 +946,7 @@ function NewRecipePageInner() {
                   border: "1px solid var(--border-default)",
                   borderRadius: "var(--r-2)",
                   color: "var(--fg-0)",
-                  fontSize: 14,
+                  fontSize: "var(--fs-base)",
                   padding: "var(--s-2) var(--s-3)",
                   outline: "none",
                   resize: "vertical",
@@ -963,7 +963,7 @@ function NewRecipePageInner() {
                   display: "block",
                   marginBottom: "var(--s-2)",
                   color: "var(--fg-1)",
-                  fontSize: 13,
+                  fontSize: "var(--fs-m)",
                   fontWeight: 500,
                 }}
               >
@@ -983,7 +983,7 @@ function NewRecipePageInner() {
                   border: "1px solid var(--border-default)",
                   borderRadius: "var(--r-2)",
                   color: "var(--fg-0)",
-                  fontSize: 14,
+                  fontSize: "var(--fs-base)",
                   padding: "var(--s-2) var(--s-3)",
                   outline: "none",
                   cursor: "pointer",
@@ -1001,7 +1001,7 @@ function NewRecipePageInner() {
                     style={{
                       display: "block",
                       marginBottom: "var(--s-2)",
-                      fontSize: 12,
+                      fontSize: "var(--fs-s)",
                       color: "var(--fg-2)",
                     }}
                   >
@@ -1017,7 +1017,7 @@ function NewRecipePageInner() {
                         borderRight: "none",
                         borderRadius: "var(--r-2) 0 0 var(--r-2)",
                         padding: "var(--s-2) var(--s-3)",
-                        fontSize: 13,
+                        fontSize: "var(--fs-m)",
                         color: "var(--fg-2)",
                         fontFamily: "var(--font-mono)",
                         whiteSpace: "nowrap",
@@ -1037,7 +1037,7 @@ function NewRecipePageInner() {
                         border: `1px solid ${validation.triggerPath ? "var(--err)" : "var(--border-default)"}`,
                         borderRadius: "0 var(--r-2) var(--r-2) 0",
                         color: "var(--fg-0)",
-                        fontSize: 13,
+                        fontSize: "var(--fs-m)",
                         padding: "var(--s-2) var(--s-3)",
                         outline: "none",
                         fontFamily: "var(--font-mono)",
@@ -1048,7 +1048,7 @@ function NewRecipePageInner() {
                     <div
                       style={{
                         marginTop: "var(--s-1)",
-                        fontSize: 12,
+                        fontSize: "var(--fs-s)",
                         color: "var(--err)",
                       }}
                     >
@@ -1065,7 +1065,7 @@ function NewRecipePageInner() {
                     style={{
                       display: "block",
                       marginBottom: "var(--s-2)",
-                      fontSize: 12,
+                      fontSize: "var(--fs-s)",
                       color: "var(--fg-2)",
                     }}
                   >
@@ -1083,7 +1083,7 @@ function NewRecipePageInner() {
                       border: `1px solid ${validation.cron ? "var(--err)" : "var(--border-default)"}`,
                       borderRadius: "var(--r-2)",
                       color: "var(--fg-0)",
-                      fontSize: 13,
+                      fontSize: "var(--fs-m)",
                       padding: "var(--s-2) var(--s-3)",
                       outline: "none",
                       fontFamily: "var(--font-mono)",
@@ -1093,7 +1093,7 @@ function NewRecipePageInner() {
                     <div
                       style={{
                         marginTop: "var(--s-1)",
-                        fontSize: 12,
+                        fontSize: "var(--fs-s)",
                         color: "var(--err)",
                       }}
                     >
@@ -1115,7 +1115,7 @@ function NewRecipePageInner() {
                 }}
               >
                 <span
-                  style={{ color: "var(--fg-1)", fontSize: 13, fontWeight: 500 }}
+                  style={{ color: "var(--fg-1)", fontSize: "var(--fs-m)", fontWeight: 500 }}
                 >
                   Variables{" "}
                   <span style={{ color: "var(--fg-3)", fontWeight: 400 }}>
@@ -1130,7 +1130,7 @@ function NewRecipePageInner() {
               {form.vars.length === 0 && (
                 <div
                   style={{
-                    fontSize: 12,
+                    fontSize: "var(--fs-s)",
                     color: "var(--fg-3)",
                     padding: "var(--s-2) 0",
                   }}
@@ -1179,7 +1179,7 @@ function NewRecipePageInner() {
                             border: `1px solid ${validation.vars[i] ? "var(--err)" : "var(--border-subtle)"}`,
                             borderRadius: "var(--r-2)",
                             color: "var(--fg-0)",
-                            fontSize: 13,
+                            fontSize: "var(--fs-m)",
                             padding: "var(--s-2) var(--s-3)",
                             outline: "none",
                             fontFamily: "var(--font-mono)",
@@ -1198,7 +1198,7 @@ function NewRecipePageInner() {
                             border: "1px solid var(--border-subtle)",
                             borderRadius: "var(--r-2)",
                             color: "var(--fg-0)",
-                            fontSize: 13,
+                            fontSize: "var(--fs-m)",
                             padding: "var(--s-2) var(--s-3)",
                             outline: "none",
                             fontFamily: "var(--font-sans)",
@@ -1217,7 +1217,7 @@ function NewRecipePageInner() {
                       {validation.vars[i] && (
                         <div
                           style={{
-                            fontSize: 12,
+                            fontSize: "var(--fs-s)",
                             color: "var(--err)",
                           }}
                         >
@@ -1237,7 +1237,7 @@ function NewRecipePageInner() {
                             display: "flex",
                             alignItems: "center",
                             gap: "var(--s-2)",
-                            fontSize: 12,
+                            fontSize: "var(--fs-s)",
                             color: "var(--fg-2)",
                             cursor: "pointer",
                             userSelect: "none",
@@ -1265,7 +1265,7 @@ function NewRecipePageInner() {
                             border: "1px solid var(--border-subtle)",
                             borderRadius: "var(--r-2)",
                             color: "var(--fg-0)",
-                            fontSize: 12,
+                            fontSize: "var(--fs-s)",
                             padding: "var(--s-1) var(--s-3)",
                             outline: "none",
                             fontFamily: "var(--font-mono)",
@@ -1291,7 +1291,7 @@ function NewRecipePageInner() {
                 <span
                   style={{
                     color: "var(--fg-1)",
-                    fontSize: 13,
+                    fontSize: "var(--fs-m)",
                     fontWeight: 500,
                   }}
                 >
@@ -1331,7 +1331,7 @@ function NewRecipePageInner() {
                       <label
                         htmlFor={`step-prompt-${i}`}
                         style={{
-                          fontSize: 12,
+                          fontSize: "var(--fs-s)",
                           color: "var(--fg-2)",
                           fontWeight: 500,
                         }}
@@ -1386,7 +1386,7 @@ function NewRecipePageInner() {
                         border: `1px solid ${validation.steps[i] ? "var(--err)" : "var(--border-subtle)"}`,
                         borderRadius: "var(--r-2)",
                         color: "var(--fg-0)",
-                        fontSize: 13,
+                        fontSize: "var(--fs-m)",
                         padding: "var(--s-2) var(--s-3)",
                         outline: "none",
                         resize: "vertical",
@@ -1397,7 +1397,7 @@ function NewRecipePageInner() {
                       <div
                         style={{
                           marginTop: "var(--s-1)",
-                          fontSize: 12,
+                          fontSize: "var(--fs-s)",
                           color: "var(--err)",
                         }}
                       >
@@ -1435,7 +1435,7 @@ function NewRecipePageInner() {
           <div>
             <div
               style={{
-                fontSize: 12,
+                fontSize: "var(--fs-s)",
                 color: "var(--fg-2)",
                 fontWeight: 500,
                 marginBottom: "var(--s-2)",
@@ -1447,7 +1447,7 @@ function NewRecipePageInner() {
             </div>
             <div
               style={{
-                fontSize: 12,
+                fontSize: "var(--fs-s)",
                 color: "var(--fg-3)",
                 marginBottom: "var(--s-2)",
               }}
@@ -1460,7 +1460,7 @@ function NewRecipePageInner() {
                 border: "1px solid var(--border-subtle)",
                 borderRadius: "var(--r-3)",
                 padding: "var(--s-4)",
-                fontSize: 12,
+                fontSize: "var(--fs-s)",
                 fontFamily: "var(--font-mono)",
                 color: "var(--fg-1)",
                 overflowX: "auto",

--- a/dashboard/src/app/recipes/page.tsx
+++ b/dashboard/src/app/recipes/page.tsx
@@ -175,7 +175,7 @@ function RunModal({
               marginBottom: "var(--s-4)",
             }}
           >
-            <h2 id="run-modal-title" style={{ margin: 0, fontSize: 16, fontWeight: 600 }}>
+            <h2 id="run-modal-title" style={{ margin: 0, fontSize: "var(--fs-xl)", fontWeight: 600 }}>
               Run <code>{state.recipe.name}</code>
             </h2>
             <button
@@ -198,13 +198,13 @@ function RunModal({
                 <div key={v.name}>
                   <label
                     htmlFor={`run-var-${v.name}`}
-                    style={{ display: "block", marginBottom: 4, fontSize: 13, fontFamily: "var(--font-mono)" }}
+                    style={{ display: "block", marginBottom: 4, fontSize: "var(--fs-m)", fontFamily: "var(--font-mono)" }}
                   >
                     {v.name}
                     {v.required && <span style={{ color: "var(--err)", marginLeft: 4 }}>*</span>}
                   </label>
                   {v.description && (
-                    <div style={{ fontSize: 12, color: "var(--fg-3)", marginBottom: 4 }}>
+                    <div style={{ fontSize: "var(--fs-s)", color: "var(--fg-3)", marginBottom: 4 }}>
                       {v.description}
                     </div>
                   )}
@@ -423,7 +423,7 @@ function RecipeYamlPanel({ recipe }: { recipe: Recipe }) {
         border: "1px solid var(--line-2)",
         borderRadius: "var(--r-2)",
         padding: "10px 12px",
-        fontSize: 11,
+        fontSize: "var(--fs-xs)",
         lineHeight: 1.55,
         maxHeight: 360,
         overflow: "auto",
@@ -466,7 +466,7 @@ function RecipeDetailPanel({
           style={{
             fontFamily: "var(--font-mono)",
             fontWeight: 700,
-            fontSize: 13,
+            fontSize: "var(--fs-m)",
             flex: 1,
             overflow: "hidden",
             textOverflow: "ellipsis",
@@ -477,7 +477,7 @@ function RecipeDetailPanel({
           {recipe.name}
         </span>
         {isLive && <LivePill tone="ok" />}
-        <button type="button" onClick={onRun} className="btn sm primary" style={{ fontSize: 11 }}>
+        <button type="button" onClick={onRun} className="btn sm primary" style={{ fontSize: "var(--fs-xs)" }}>
           ▶ Run
         </button>
         <button
@@ -489,7 +489,7 @@ function RecipeDetailPanel({
             border: "none",
             cursor: "pointer",
             color: "var(--ink-3)",
-            fontSize: 18,
+            fontSize: "var(--fs-2xl)",
             lineHeight: 1,
           }}
         >
@@ -506,7 +506,7 @@ function RecipeDetailPanel({
       <div style={{ marginBottom: 14 }}>
         <div
           style={{
-            fontSize: 10,
+            fontSize: "var(--fs-2xs)",
             fontWeight: 700,
             textTransform: "uppercase",
             letterSpacing: "0.08em",
@@ -522,7 +522,7 @@ function RecipeDetailPanel({
       <div>
         <div
           style={{
-            fontSize: 10,
+            fontSize: "var(--fs-2xs)",
             fontWeight: 700,
             textTransform: "uppercase",
             letterSpacing: "0.08em",
@@ -533,7 +533,7 @@ function RecipeDetailPanel({
           Recent runs
         </div>
         {recentRuns.length === 0 ? (
-          <div style={{ fontSize: 12, color: "var(--ink-3)" }}>No runs yet.</div>
+          <div style={{ fontSize: "var(--fs-s)", color: "var(--ink-3)" }}>No runs yet.</div>
         ) : (
           <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
             {recentRuns.map((run, i) => {
@@ -547,7 +547,7 @@ function RecipeDetailPanel({
                     display: "flex",
                     alignItems: "center",
                     gap: 8,
-                    fontSize: 11,
+                    fontSize: "var(--fs-xs)",
                     fontFamily: "var(--font-mono)",
                   }}
                 >
@@ -861,7 +861,7 @@ export default function RecipesPage() {
             </Link>
           </div>
           {unsupported && (
-            <p style={{ marginTop: 12, fontSize: 12 }}>
+            <p style={{ marginTop: 12, fontSize: "var(--fs-s)" }}>
               Recipe listing endpoint not available on this bridge version.
             </p>
           )}
@@ -947,7 +947,7 @@ export default function RecipesPage() {
                             <div
                               className="muted"
                               style={{
-                                fontSize: 11,
+                                fontSize: "var(--fs-xs)",
                                 marginTop: 2,
                                 whiteSpace: "nowrap",
                                 overflow: "hidden",
@@ -968,10 +968,10 @@ export default function RecipesPage() {
                             height={20}
                           />
                         </td>
-                        <td className="mono muted" style={{ fontSize: 12 }}>
+                        <td className="mono muted" style={{ fontSize: "var(--fs-s)" }}>
                           {formatDuration(avg)}
                         </td>
-                        <td className="muted" style={{ fontSize: 12 }}>
+                        <td className="muted" style={{ fontSize: "var(--fs-s)" }}>
                           {last ? relTime(last.startedAt) : "—"}
                         </td>
                         <td
@@ -1014,7 +1014,7 @@ export default function RecipesPage() {
                           <button
                             type="button"
                             className="btn sm"
-                            style={{ marginLeft: 8, fontSize: 11 }}
+                            style={{ marginLeft: 8, fontSize: "var(--fs-xs)" }}
                             onClick={() => handleRunClick(r)}
                             disabled={!enabled}
                           >

--- a/dashboard/src/app/runs/[seq]/page.tsx
+++ b/dashboard/src/app/runs/[seq]/page.tsx
@@ -109,10 +109,10 @@ function AssertionFailuresPanel({ failures }: { failures: AssertionFailure[] }) 
           background: "color-mix(in srgb, var(--err) 8%, var(--bg-1))",
         }}
       >
-        <span style={{ fontSize: 13, fontWeight: 600, color: "var(--err)" }}>
+        <span style={{ fontSize: "var(--fs-m)", fontWeight: 600, color: "var(--err)" }}>
           Assertion Failures ({failures.length})
         </span>
-        <span className="pill err" style={{ fontSize: 10 }}>expect</span>
+        <span className="pill err" style={{ fontSize: "var(--fs-2xs)" }}>expect</span>
       </div>
       {failures.map((f, i) => (
         <div
@@ -126,14 +126,14 @@ function AssertionFailuresPanel({ failures }: { failures: AssertionFailure[] }) 
             alignItems: "start",
           }}
         >
-          <span className="pill err" style={{ fontSize: 10, marginTop: 1 }}>{f.assertion}</span>
+          <span className="pill err" style={{ fontSize: "var(--fs-2xs)", marginTop: 1 }}>{f.assertion}</span>
           <div>
-            <div style={{ fontSize: 13, color: "var(--err)" }}>{f.message}</div>
+            <div style={{ fontSize: "var(--fs-m)", color: "var(--err)" }}>{f.message}</div>
             <div style={{ display: "flex", gap: 16, marginTop: 4 }}>
-              <span className="mono muted" style={{ fontSize: 11 }}>
+              <span className="mono muted" style={{ fontSize: "var(--fs-xs)" }}>
                 expected: {JSON.stringify(f.expected)}
               </span>
-              <span className="mono muted" style={{ fontSize: 11 }}>
+              <span className="mono muted" style={{ fontSize: "var(--fs-xs)" }}>
                 actual: {JSON.stringify(f.actual)}
               </span>
             </div>
@@ -240,14 +240,14 @@ function StepRow({
           padding: "10px 16px",
         }}
       >
-        <span className="mono muted" style={{ fontSize: 11, textAlign: "right" }}>
+        <span className="mono muted" style={{ fontSize: "var(--fs-xs)", textAlign: "right" }}>
           {index + 1}
         </span>
         <div style={{ minWidth: 0 }}>
           <div
             className="mono"
             style={{
-              fontSize: 13,
+              fontSize: "var(--fs-m)",
               overflow: "hidden",
               textOverflow: "ellipsis",
               whiteSpace: "nowrap",
@@ -256,7 +256,7 @@ function StepRow({
             {step.tool ?? step.id}
           </div>
           {step.tool && step.tool !== step.id && (
-            <div className="mono muted" style={{ fontSize: 11, marginTop: 2 }}>
+            <div className="mono muted" style={{ fontSize: "var(--fs-xs)", marginTop: 2 }}>
               {step.id}
             </div>
           )}
@@ -286,22 +286,22 @@ function StepRow({
         </div>
         <div style={{ display: "flex", gap: 4, alignItems: "center" }}>
           {step.tool?.includes(".") && (
-            <span className="pill muted" style={{ fontSize: 10 }}>connector</span>
+            <span className="pill muted" style={{ fontSize: "var(--fs-2xs)" }}>connector</span>
           )}
           <span
             className={`pill ${stepStatusClass(step.status)}`}
-            style={{ fontSize: 10 }}
+            style={{ fontSize: "var(--fs-2xs)" }}
           >
             {stepStatusLabel(step.status)}
           </span>
         </div>
-        <span className="mono muted" style={{ fontSize: 11, minWidth: 40, textAlign: "right" }}>
+        <span className="mono muted" style={{ fontSize: "var(--fs-xs)", minWidth: 40, textAlign: "right" }}>
           {fmtDur(step.durationMs)}
         </span>
       </div>
       {open && step.error && (
         <div style={{ padding: "8px 16px 12px 56px", background: "var(--bg-0)" }}>
-          <pre style={{ margin: 0, fontSize: 11, color: "var(--err)", whiteSpace: "pre-wrap", wordBreak: "break-word" }}>
+          <pre style={{ margin: 0, fontSize: "var(--fs-xs)", color: "var(--err)", whiteSpace: "pre-wrap", wordBreak: "break-word" }}>
             {step.error}
           </pre>
         </div>
@@ -339,14 +339,14 @@ function PlanStepRow({ step, index, groupIndex }: { step: PlanStep; index: numbe
         alignItems: "center",
       }}
     >
-      <span className="mono muted" style={{ fontSize: 11, textAlign: "right" }}>
+      <span className="mono muted" style={{ fontSize: "var(--fs-xs)", textAlign: "right" }}>
         {index + 1}
       </span>
       <div style={{ minWidth: 0 }}>
         <div
           className="mono"
           style={{
-            fontSize: 13,
+            fontSize: "var(--fs-m)",
             overflow: "hidden",
             textOverflow: "ellipsis",
             whiteSpace: "nowrap",
@@ -355,41 +355,41 @@ function PlanStepRow({ step, index, groupIndex }: { step: PlanStep; index: numbe
           {step.tool ?? step.id}
         </div>
         {step.tool && step.tool !== step.id && (
-          <div className="mono muted" style={{ fontSize: 11, marginTop: 2 }}>
+          <div className="mono muted" style={{ fontSize: "var(--fs-xs)", marginTop: 2 }}>
             id: {step.id}
           </div>
         )}
         {step.dependencies && step.dependencies.length > 0 && (
-          <div className="mono muted" style={{ fontSize: 11, marginTop: 2 }}>
+          <div className="mono muted" style={{ fontSize: "var(--fs-xs)", marginTop: 2 }}>
             awaits: {step.dependencies.join(", ")}
           </div>
         )}
         {step.condition && (
-          <div className="mono muted" style={{ fontSize: 11, marginTop: 2 }}>
+          <div className="mono muted" style={{ fontSize: "var(--fs-xs)", marginTop: 2 }}>
             when: {step.condition}
           </div>
         )}
         {groupIndex !== undefined && (
-          <div className="muted" style={{ fontSize: 10, marginTop: 3 }}>
+          <div className="muted" style={{ fontSize: "var(--fs-2xs)", marginTop: 3 }}>
             parallel group {groupIndex + 1}
           </div>
         )}
       </div>
       <div style={{ display: "flex", gap: 4, alignItems: "center", flexWrap: "wrap", justifyContent: "flex-end" }}>
         {step.isConnector && (
-          <span className="pill muted" style={{ fontSize: 10 }}>connector</span>
+          <span className="pill muted" style={{ fontSize: "var(--fs-2xs)" }}>connector</span>
         )}
         {step.isWrite && (
-          <span className="pill warn" style={{ fontSize: 10 }}>write</span>
+          <span className="pill warn" style={{ fontSize: "var(--fs-2xs)" }}>write</span>
         )}
         {!step.resolved && step.type === "tool" && (
-          <span className="pill err" style={{ fontSize: 10 }}>unresolved</span>
+          <span className="pill err" style={{ fontSize: "var(--fs-2xs)" }}>unresolved</span>
         )}
         {step.optional && (
-          <span className="pill muted" style={{ fontSize: 10 }}>optional</span>
+          <span className="pill muted" style={{ fontSize: "var(--fs-2xs)" }}>optional</span>
         )}
         {step.risk && step.risk !== "low" && (
-          <span className={`pill ${riskClass(step.risk)}`} style={{ fontSize: 10 }}>
+          <span className={`pill ${riskClass(step.risk)}`} style={{ fontSize: "var(--fs-2xs)" }}>
             {step.risk}
           </span>
         )}
@@ -413,24 +413,24 @@ function PlanView({ plan }: { plan: DryRunPlan }) {
     <div>
       {/* summary badges */}
       <div style={{ padding: "12px 16px", display: "flex", gap: 8, flexWrap: "wrap", borderBottom: "1px solid var(--border-subtle)" }}>
-        <span className="pill muted" style={{ fontSize: 11 }}>{plan.triggerType}</span>
+        <span className="pill muted" style={{ fontSize: "var(--fs-xs)" }}>{plan.triggerType}</span>
         {plan.connectorNamespaces && plan.connectorNamespaces.length > 0 && (
-          <span className="pill muted" style={{ fontSize: 11 }}>
+          <span className="pill muted" style={{ fontSize: "var(--fs-xs)" }}>
             connectors: {plan.connectorNamespaces.join(", ")}
           </span>
         )}
         {plan.hasWriteSteps && (
-          <span className="pill warn" style={{ fontSize: 11 }}>has writes</span>
+          <span className="pill warn" style={{ fontSize: "var(--fs-xs)" }}>has writes</span>
         )}
         {plan.parallelGroups && plan.parallelGroups.length > 0 && (
-          <span className="pill info" style={{ fontSize: 11 }}>
+          <span className="pill info" style={{ fontSize: "var(--fs-xs)" }}>
             {plan.parallelGroups.length} parallel group{plan.parallelGroups.length !== 1 ? "s" : ""}
           </span>
         )}
         {plan.maxDepth !== undefined && plan.maxDepth > 0 && (
-          <span className="pill muted" style={{ fontSize: 11 }}>depth {plan.maxDepth}</span>
+          <span className="pill muted" style={{ fontSize: "var(--fs-xs)" }}>depth {plan.maxDepth}</span>
         )}
-        <span className="pill muted" style={{ fontSize: 11, marginLeft: "auto" }}>
+        <span className="pill muted" style={{ fontSize: "var(--fs-xs)", marginLeft: "auto" }}>
           generated {new Date(plan.generatedAt).toISOString().replace("T", " ").slice(0, 19)}
         </span>
       </div>
@@ -501,7 +501,7 @@ function CausalChainCard({ run }: { run: RunDetail }) {
         style={{
           padding: "10px 16px",
           borderBottom: "1px solid var(--border-subtle)",
-          fontSize: 12,
+          fontSize: "var(--fs-s)",
           fontWeight: 600,
           color: "var(--ink-2)",
           display: "flex",
@@ -524,17 +524,17 @@ function CausalChainCard({ run }: { run: RunDetail }) {
               color: "inherit",
             }}
           >
-            <span style={{ fontSize: 11, color: "var(--ink-3)", minWidth: 56 }}>triggered by</span>
-            <span className="pill muted" style={{ fontSize: 11 }}>#{run.parentSeq}</span>
-            <span style={{ fontSize: 13 }}>
+            <span style={{ fontSize: "var(--fs-xs)", color: "var(--ink-3)", minWidth: 56 }}>triggered by</span>
+            <span className="pill muted" style={{ fontSize: "var(--fs-xs)" }}>#{run.parentSeq}</span>
+            <span style={{ fontSize: "var(--fs-m)" }}>
               {parent ? parent.recipeName : <span style={{ color: "var(--ink-3)" }}>…</span>}
             </span>
             {parent && (
               <>
-                <span className={`pill ${statusPillClass(parent.status)}`} style={{ fontSize: 10 }}>
+                <span className={`pill ${statusPillClass(parent.status)}`} style={{ fontSize: "var(--fs-2xs)" }}>
                   {parent.status}
                 </span>
-                <span className="mono muted" style={{ fontSize: 11, marginLeft: "auto" }}>
+                <span className="mono muted" style={{ fontSize: "var(--fs-xs)", marginLeft: "auto" }}>
                   {fmtDur(parent.durationMs)}
                 </span>
               </>
@@ -560,17 +560,17 @@ function CausalChainCard({ run }: { run: RunDetail }) {
                 borderTop: i > 0 ? "1px solid var(--border-subtle)" : undefined,
               }}
             >
-              <span style={{ fontSize: 11, color: "var(--ink-3)", minWidth: 56 }}>triggered</span>
-              <span className="pill muted" style={{ fontSize: 11 }}>#{childSeq}</span>
-              <span style={{ fontSize: 13 }}>
+              <span style={{ fontSize: "var(--fs-xs)", color: "var(--ink-3)", minWidth: 56 }}>triggered</span>
+              <span className="pill muted" style={{ fontSize: "var(--fs-xs)" }}>#{childSeq}</span>
+              <span style={{ fontSize: "var(--fs-m)" }}>
                 {child ? child.recipeName : <span style={{ color: "var(--ink-3)" }}>…</span>}
               </span>
               {child && (
                 <>
-                  <span className={`pill ${statusPillClass(child.status)}`} style={{ fontSize: 10 }}>
+                  <span className={`pill ${statusPillClass(child.status)}`} style={{ fontSize: "var(--fs-2xs)" }}>
                     {child.status}
                   </span>
-                  <span className="mono muted" style={{ fontSize: 11, marginLeft: "auto" }}>
+                  <span className="mono muted" style={{ fontSize: "var(--fs-xs)", marginLeft: "auto" }}>
                     {fmtDur(child.durationMs)}
                   </span>
                 </>
@@ -587,7 +587,7 @@ function ReplayPreflight({ stepResults }: { stepResults: StepResult[] }) {
   const preflight = previewMockedReplay(stepResults);
   if (preflight.unmocked.length === 0) {
     return (
-      <p style={{ fontSize: 12, color: "var(--ink-3)", margin: "0 0 16px" }}>
+      <p style={{ fontSize: "var(--fs-s)", color: "var(--ink-3)", margin: "0 0 16px" }}>
         All {preflight.mocked.length} step
         {preflight.mocked.length === 1 ? "" : "s"} will be mocked from captures.
         No external API calls.
@@ -597,7 +597,7 @@ function ReplayPreflight({ stepResults }: { stepResults: StepResult[] }) {
   return (
     <div
       style={{
-        fontSize: 12,
+        fontSize: "var(--fs-s)",
         margin: "0 0 16px",
         padding: "8px 10px",
         borderRadius: "var(--r-1)",
@@ -613,7 +613,7 @@ function ReplayPreflight({ stepResults }: { stepResults: StepResult[] }) {
       </div>
       <ul style={{ margin: "4px 0 0", paddingLeft: 20, color: "var(--ink-2)" }}>
         {preflight.unmocked.slice(0, 8).map((u) => (
-          <li key={u.id} className="mono" style={{ fontSize: 11 }}>
+          <li key={u.id} className="mono" style={{ fontSize: "var(--fs-xs)" }}>
             {u.tool ? `${u.tool} ` : ""}
             <span style={{ color: "var(--ink-3)" }}>({u.id})</span>
             {" — "}
@@ -623,7 +623,7 @@ function ReplayPreflight({ stepResults }: { stepResults: StepResult[] }) {
           </li>
         ))}
         {preflight.unmocked.length > 8 && (
-          <li style={{ fontSize: 11, color: "var(--ink-3)" }}>
+          <li style={{ fontSize: "var(--fs-xs)", color: "var(--ink-3)" }}>
             …and {preflight.unmocked.length - 8} more
           </li>
         )}
@@ -819,7 +819,7 @@ export default function RunDetailPage() {
 
   const tabStyle = (t: Tab): React.CSSProperties => ({
     padding: "6px 14px",
-    fontSize: 12,
+    fontSize: "var(--fs-s)",
     fontWeight: 500,
     cursor: "pointer",
     color: tab === t ? "var(--fg-1)" : "var(--fg-2)",
@@ -846,7 +846,7 @@ export default function RunDetailPage() {
         }}
       >
         <div style={{ flex: 1, minWidth: "min(200px, 100%)" }}>
-          <div style={{ fontSize: 12, color: "var(--ink-2)", marginBottom: 2 }}>
+          <div style={{ fontSize: "var(--fs-s)", color: "var(--ink-2)", marginBottom: 2 }}>
             <Link href="/runs" style={{ color: "var(--ink-2)" }}>Runs</Link>
             {" / "}
             <span className="mono">#{seq}</span>
@@ -857,26 +857,26 @@ export default function RunDetailPage() {
         </div>
         {run && (
           <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
-            <span className="pill muted" style={{ fontSize: 11 }}>{run.trigger}</span>
+            <span className="pill muted" style={{ fontSize: "var(--fs-xs)" }}>{run.trigger}</span>
             <span
               className={`pill ${run.assertionFailures?.length ? "err" : statusPillClass(run.status)}`}
-              style={{ fontSize: 11 }}
+              style={{ fontSize: "var(--fs-xs)" }}
             >
               {run.status !== "running" && <span className="pill-dot" />}
               {run.status}
             </span>
-            <span className="pill muted" style={{ fontSize: 11 }}>
+            <span className="pill muted" style={{ fontSize: "var(--fs-xs)" }}>
               {fmtDur(run.durationMs)}
             </span>
             {run.model && (
-              <span className="pill muted" style={{ fontSize: 11 }}>{run.model}</span>
+              <span className="pill muted" style={{ fontSize: "var(--fs-xs)" }}>{run.model}</span>
             )}
             {run.assertionFailures && run.assertionFailures.length > 0 && (
-              <span className="pill err" style={{ fontSize: 11 }}>
+              <span className="pill err" style={{ fontSize: "var(--fs-xs)" }}>
                 {run.assertionFailures.length} assertion{run.assertionFailures.length !== 1 ? "s" : ""} failed
               </span>
             )}
-            <span style={{ fontSize: 11, color: "var(--ink-3)", marginLeft: 4 }}>
+            <span style={{ fontSize: "var(--fs-xs)", color: "var(--ink-3)", marginLeft: 4 }}>
               {fmtTs(run.createdAt)}
             </span>
             {/* VD-4: replay button (mocked-only). Real replay TBD. */}
@@ -887,7 +887,7 @@ export default function RunDetailPage() {
                 disabled={replayState === "running"}
                 title="Re-run the recipe with all tool/agent calls mocked from this run's captured outputs. No external IO, no side effects."
                 style={{
-                  fontSize: 11,
+                  fontSize: "var(--fs-xs)",
                   padding: "4px 10px",
                   borderRadius: "var(--r-1, 4px)",
                   border: "1px solid var(--line-2)",
@@ -922,7 +922,7 @@ export default function RunDetailPage() {
         <h3 id="replay-confirm-heading" style={{ marginTop: 0, marginBottom: 8 }}>
           Replay this run?
         </h3>
-        <p style={{ fontSize: 13, color: "var(--ink-2)", margin: "0 0 12px" }}>
+        <p style={{ fontSize: "var(--fs-m)", color: "var(--ink-2)", margin: "0 0 12px" }}>
           Re-runs the recipe with each step's tool / agent call replaced by its
           captured output from this run. Templates, transforms, and
           <code className="mono"> when:</code> conditions re-evaluate against the
@@ -930,7 +930,7 @@ export default function RunDetailPage() {
           connected services.
         </p>
         <ReplayPreflight stepResults={run?.stepResults ?? []} />
-        <p style={{ fontSize: 12, color: "var(--ink-3)", margin: "0 0 16px" }}>
+        <p style={{ fontSize: "var(--fs-s)", color: "var(--ink-3)", margin: "0 0 16px" }}>
           A new run will be created with{" "}
           <code className="mono">replay:{seq}</code> in its taskId.
         </p>
@@ -1008,10 +1008,10 @@ export default function RunDetailPage() {
                       justifyContent: "space-between",
                     }}
                   >
-                    <span style={{ fontSize: 13, fontWeight: 600 }}>
+                    <span style={{ fontSize: "var(--fs-m)", fontWeight: 600 }}>
                       Steps ({run.stepResults.length})
                     </span>
-                    <span className="mono muted" style={{ fontSize: 11 }}>
+                    <span className="mono muted" style={{ fontSize: "var(--fs-xs)" }}>
                       total {fmtDur(run.durationMs)}
                     </span>
                   </div>
@@ -1051,13 +1051,13 @@ export default function RunDetailPage() {
                   justifyContent: "space-between",
                 }}
               >
-                <span style={{ fontSize: 13, fontWeight: 600 }}>Execution Plan</span>
-                <span className="muted" style={{ fontSize: 11 }}>
+                <span style={{ fontSize: "var(--fs-m)", fontWeight: 600 }}>Execution Plan</span>
+                <span className="muted" style={{ fontSize: "var(--fs-xs)" }}>
                   re-generated from current registry
                 </span>
               </div>
               {planLoading && (
-                <div style={{ padding: 20, color: "var(--fg-2)", fontSize: 13 }}>Generating…</div>
+                <div style={{ padding: 20, color: "var(--fg-2)", fontSize: "var(--fs-m)" }}>Generating…</div>
               )}
               {planErr && (
                 <div className="alert-err" style={{ margin: 16 }}>
@@ -1080,37 +1080,37 @@ export default function RunDetailPage() {
               }}
             >
               <div>
-                <div style={{ fontSize: 10, color: "var(--fg-2)", marginBottom: 2 }}>TASK ID</div>
-                <span className="mono" style={{ fontSize: 12 }}>{run.taskId}</span>
+                <div style={{ fontSize: "var(--fs-2xs)", color: "var(--fg-2)", marginBottom: 2 }}>TASK ID</div>
+                <span className="mono" style={{ fontSize: "var(--fs-s)" }}>{run.taskId}</span>
               </div>
               <div>
-                <div style={{ fontSize: 10, color: "var(--fg-2)", marginBottom: 2 }}>STARTED</div>
-                <span className="mono" style={{ fontSize: 12 }}>
+                <div style={{ fontSize: "var(--fs-2xs)", color: "var(--fg-2)", marginBottom: 2 }}>STARTED</div>
+                <span className="mono" style={{ fontSize: "var(--fs-s)" }}>
                   {run.startedAt ? fmtTs(run.startedAt) : "—"}
                 </span>
               </div>
               <div>
-                <div style={{ fontSize: 10, color: "var(--fg-2)", marginBottom: 2 }}>FINISHED</div>
-                <span className="mono" style={{ fontSize: 12 }}>{fmtTs(run.doneAt)}</span>
+                <div style={{ fontSize: "var(--fs-2xs)", color: "var(--fg-2)", marginBottom: 2 }}>FINISHED</div>
+                <span className="mono" style={{ fontSize: "var(--fs-s)" }}>{fmtTs(run.doneAt)}</span>
               </div>
               {run.model && (
                 <div>
-                  <div style={{ fontSize: 10, color: "var(--fg-2)", marginBottom: 2 }}>MODEL</div>
-                  <span className="mono" style={{ fontSize: 12 }}>{run.model}</span>
+                  <div style={{ fontSize: "var(--fs-2xs)", color: "var(--fg-2)", marginBottom: 2 }}>MODEL</div>
+                  <span className="mono" style={{ fontSize: "var(--fs-s)" }}>{run.model}</span>
                 </div>
               )}
             </div>
             {run.errorMessage && (
               <div style={{ marginTop: 12 }}>
-                <div style={{ fontSize: 10, color: "var(--err)", marginBottom: 4 }}>ERROR</div>
-                <pre style={{ margin: 0, fontSize: 12, color: "var(--err)", whiteSpace: "pre-wrap", wordBreak: "break-word" }}>
+                <div style={{ fontSize: "var(--fs-2xs)", color: "var(--err)", marginBottom: 4 }}>ERROR</div>
+                <pre style={{ margin: 0, fontSize: "var(--fs-s)", color: "var(--err)", whiteSpace: "pre-wrap", wordBreak: "break-word" }}>
                   {run.errorMessage}
                 </pre>
               </div>
             )}
             {run.outputTail && (
               <div style={{ marginTop: 12 }}>
-                <div style={{ fontSize: 10, color: "var(--fg-2)", marginBottom: 4 }}>OUTPUT TAIL</div>
+                <div style={{ fontSize: "var(--fs-2xs)", color: "var(--fg-2)", marginBottom: 4 }}>OUTPUT TAIL</div>
                 <pre className="task-output" style={{ borderTop: "none", padding: 0 }}>
                   {run.outputTail}
                 </pre>

--- a/dashboard/src/app/runs/page.tsx
+++ b/dashboard/src/app/runs/page.tsx
@@ -223,9 +223,9 @@ export default function RunsPage() {
           }}
           aria-pressed={status === "all"}
         >
-          <div style={{ fontSize: 11, fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.08em", color: "var(--ink-3)", marginBottom: 8 }}>All runs</div>
+          <div style={{ fontSize: "var(--fs-xs)", fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.08em", color: "var(--ink-3)", marginBottom: 8 }}>All runs</div>
           <div style={{ fontFamily: "var(--font-mono)", fontSize: 36, fontWeight: 800, color: "var(--ink-0)", lineHeight: 1 }}>{stats.total}</div>
-          <div style={{ fontSize: 11, color: "var(--ink-3)", marginTop: 4 }}>Last 24h</div>
+          <div style={{ fontSize: "var(--fs-xs)", color: "var(--ink-3)", marginTop: 4 }}>Last 24h</div>
         </button>
         <button
           type="button"
@@ -240,9 +240,9 @@ export default function RunsPage() {
           }}
           aria-pressed={status === "done"}
         >
-          <div style={{ fontSize: 11, fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.08em", color: "var(--ok)", marginBottom: 8 }}>✓ Successful</div>
+          <div style={{ fontSize: "var(--fs-xs)", fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.08em", color: "var(--ok)", marginBottom: 8 }}>✓ Successful</div>
           <div style={{ fontFamily: "var(--font-mono)", fontSize: 36, fontWeight: 800, color: "var(--ink-0)", lineHeight: 1 }}>{stats.ok}</div>
-          <div style={{ fontSize: 11, color: "var(--ink-3)", marginTop: 4 }}>{stats.total > 0 ? Math.round(stats.ok / stats.total * 100) + "%" : "—"} success rate</div>
+          <div style={{ fontSize: "var(--fs-xs)", color: "var(--ink-3)", marginTop: 4 }}>{stats.total > 0 ? Math.round(stats.ok / stats.total * 100) + "%" : "—"} success rate</div>
         </button>
         <button
           type="button"
@@ -257,9 +257,9 @@ export default function RunsPage() {
           }}
           aria-pressed={status === "error"}
         >
-          <div style={{ fontSize: 11, fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.08em", color: "var(--err)", marginBottom: 8 }}>⚠ Errored</div>
+          <div style={{ fontSize: "var(--fs-xs)", fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.08em", color: "var(--err)", marginBottom: 8 }}>⚠ Errored</div>
           <div style={{ fontFamily: "var(--font-mono)", fontSize: 36, fontWeight: 800, color: stats.err > 0 ? "var(--err)" : "var(--ink-0)", lineHeight: 1 }}>{stats.err}</div>
-          <div style={{ fontSize: 11, color: "var(--ink-3)", marginTop: 4 }}>{stats.total > 0 ? Math.round(stats.err / stats.total * 100) + "%" : "—"} error rate</div>
+          <div style={{ fontSize: "var(--fs-xs)", color: "var(--ink-3)", marginTop: 4 }}>{stats.total > 0 ? Math.round(stats.err / stats.total * 100) + "%" : "—"} error rate</div>
         </button>
       </div>
 
@@ -353,7 +353,7 @@ export default function RunsPage() {
                       <td>
                         <span
                           className={`pill ${sClass}`}
-                          style={{ fontSize: 11 }}
+                          style={{ fontSize: "var(--fs-xs)" }}
                         >
                           {sClass !== "running" && (
                             <span className="pill-dot" />
@@ -388,7 +388,7 @@ export default function RunsPage() {
                           <span
                             className="mono"
                             style={{
-                              fontSize: 11,
+                              fontSize: "var(--fs-xs)",
                               color: "var(--ink-2)",
                               minWidth: 42,
                               textAlign: "right",
@@ -410,7 +410,7 @@ export default function RunsPage() {
                           <div
                             style={{
                               padding: "12px 14px",
-                              fontSize: 12,
+                              fontSize: "var(--fs-s)",
                               display: "flex",
                               flexDirection: "column",
                               gap: 8,
@@ -446,7 +446,7 @@ export default function RunsPage() {
                               <div>
                                 <div
                                   style={{
-                                    fontSize: 10,
+                                    fontSize: "var(--fs-2xs)",
                                     color: "var(--red)",
                                     fontWeight: 600,
                                     textTransform: "uppercase",
@@ -469,7 +469,7 @@ export default function RunsPage() {
                                 <div>
                                   <div
                                     style={{
-                                      fontSize: 10,
+                                      fontSize: "var(--fs-2xs)",
                                       color: "var(--red)",
                                       fontWeight: 600,
                                       textTransform: "uppercase",
@@ -494,7 +494,7 @@ export default function RunsPage() {
                                       <li
                                         key={i}
                                         style={{
-                                          fontSize: 12,
+                                          fontSize: "var(--fs-s)",
                                           color: "var(--red)",
                                         }}
                                       >
@@ -515,7 +515,7 @@ export default function RunsPage() {
                               <div>
                                 <div
                                   style={{
-                                    fontSize: 10,
+                                    fontSize: "var(--fs-2xs)",
                                     color: "var(--ink-2)",
                                     fontWeight: 600,
                                     textTransform: "uppercase",

--- a/dashboard/src/app/sessions/[id]/page.tsx
+++ b/dashboard/src/app/sessions/[id]/page.tsx
@@ -121,20 +121,20 @@ export default function SessionDetailPage() {
     <section>
       <div className="page-head">
         <div>
-          <div style={{ fontSize: 12, marginBottom: 4 }}>
+          <div style={{ fontSize: "var(--fs-s)", marginBottom: 4 }}>
             <Link href="/sessions" style={{ color: "var(--fg-2)" }}>
               ← Sessions
             </Link>
           </div>
           <h1>
-            <code style={{ fontFamily: "var(--font-mono)", fontSize: 20 }}>
+            <code style={{ fontFamily: "var(--font-mono)", fontSize: "var(--fs-3xl)" }}>
               {id.slice(0, 8)}
             </code>
           </h1>
           <div
             className="page-head-sub"
             title={id}
-            style={{ fontFamily: "var(--font-mono)", fontSize: 12 }}
+            style={{ fontFamily: "var(--font-mono)", fontSize: "var(--fs-s)" }}
           >
             {id}
           </div>
@@ -193,7 +193,7 @@ export default function SessionDetailPage() {
           <div>
             <div
               style={{
-                fontSize: 10,
+                fontSize: "var(--fs-2xs)",
                 color: "var(--ink-2)",
                 fontWeight: 600,
                 textTransform: "uppercase",
@@ -204,7 +204,7 @@ export default function SessionDetailPage() {
               Connected
             </div>
             <div
-              style={{ fontSize: 13, color: "var(--ink-0)", fontWeight: 500 }}
+              style={{ fontSize: "var(--fs-m)", color: "var(--ink-0)", fontWeight: 500 }}
               title={new Date(summary.connectedAt).toLocaleString()}
             >
               {relTime(new Date(summary.connectedAt).getTime())}
@@ -213,7 +213,7 @@ export default function SessionDetailPage() {
           <div>
             <div
               style={{
-                fontSize: 10,
+                fontSize: "var(--fs-2xs)",
                 color: "var(--ink-2)",
                 fontWeight: 600,
                 textTransform: "uppercase",
@@ -237,7 +237,7 @@ export default function SessionDetailPage() {
           <div>
             <div
               style={{
-                fontSize: 10,
+                fontSize: "var(--fs-2xs)",
                 color: "var(--ink-2)",
                 fontWeight: 600,
                 textTransform: "uppercase",
@@ -264,7 +264,7 @@ export default function SessionDetailPage() {
           <div>
             <div
               style={{
-                fontSize: 10,
+                fontSize: "var(--fs-2xs)",
                 color: "var(--ink-2)",
                 fontWeight: 600,
                 textTransform: "uppercase",
@@ -316,14 +316,14 @@ export default function SessionDetailPage() {
                 >
                   {a.tier}
                 </span>
-                <span className="mono" style={{ fontSize: 13 }}>
+                <span className="mono" style={{ fontSize: "var(--fs-m)" }}>
                   {a.toolName}
                 </span>
                 <span
                   style={{
                     flex: 1,
                     color: "var(--fg-2)",
-                    fontSize: 13,
+                    fontSize: "var(--fs-m)",
                     whiteSpace: "nowrap",
                     overflow: "hidden",
                     textOverflow: "ellipsis",
@@ -331,7 +331,7 @@ export default function SessionDetailPage() {
                 >
                   {a.summary ?? "—"}
                 </span>
-                <span style={{ color: "var(--fg-3)", fontSize: 12 }}>
+                <span style={{ color: "var(--fg-3)", fontSize: "var(--fs-s)" }}>
                   {relTime(a.requestedAt)}
                 </span>
               </Link>
@@ -368,7 +368,7 @@ export default function SessionDetailPage() {
                   <span
                     style={{
                       fontFamily: "var(--font-mono)",
-                      fontSize: 12,
+                      fontSize: "var(--fs-s)",
                       color: "var(--purple)",
                       flexShrink: 0,
                     }}
@@ -378,7 +378,7 @@ export default function SessionDetailPage() {
                   <span
                     style={{
                       flex: 1,
-                      fontSize: 13,
+                      fontSize: "var(--fs-m)",
                       color: "var(--fg-1)",
                       whiteSpace: "nowrap",
                       overflow: "hidden",
@@ -390,7 +390,7 @@ export default function SessionDetailPage() {
                   {tags.length > 0 && (
                     <span
                       style={{
-                        fontSize: 11,
+                        fontSize: "var(--fs-xs)",
                         fontFamily: "var(--font-mono)",
                         color: "var(--fg-3)",
                         flexShrink: 0,
@@ -401,7 +401,7 @@ export default function SessionDetailPage() {
                   )}
                   <span
                     style={{
-                      fontSize: 12,
+                      fontSize: "var(--fs-s)",
                       color: "var(--fg-3)",
                       flexShrink: 0,
                     }}
@@ -424,7 +424,7 @@ export default function SessionDetailPage() {
                 display: "inline-flex",
                 alignItems: "center",
                 gap: 5,
-                fontSize: 11,
+                fontSize: "var(--fs-xs)",
                 color: "var(--green)",
                 fontWeight: 600,
               }}
@@ -467,7 +467,7 @@ export default function SessionDetailPage() {
                             {t.tool}
                           </span>
                         </td>
-                        <td style={{ fontSize: 13 }}>
+                        <td style={{ fontSize: "var(--fs-m)" }}>
                           {t.status === "error" && t.errorMessage
                             ? t.errorMessage
                             : `${t.durationMs}ms`}
@@ -504,7 +504,7 @@ export default function SessionDetailPage() {
                           {e.event}
                         </span>
                       </td>
-                      <td style={{ fontSize: 13 }}>{detail}</td>
+                      <td style={{ fontSize: "var(--fs-m)" }}>{detail}</td>
                     </tr>
                   );
                 })}

--- a/dashboard/src/app/sessions/page.tsx
+++ b/dashboard/src/app/sessions/page.tsx
@@ -67,7 +67,7 @@ function SessionLogPanel({
           padding: "12px 16px",
           borderBottom: "1px solid var(--line-3)",
           fontFamily: "var(--font-mono)",
-          fontSize: 13,
+          fontSize: "var(--fs-m)",
           color: "var(--ink-0)",
           fontWeight: 600,
         }}
@@ -82,7 +82,7 @@ function SessionLogPanel({
             display: "inline-flex",
             alignItems: "center",
             gap: 6,
-            fontSize: 10,
+            fontSize: "var(--fs-2xs)",
             textTransform: "uppercase",
             letterSpacing: "0.07em",
           }}
@@ -215,10 +215,10 @@ export default function SessionsPage() {
       {!loading && sessions.length === 0 && !error ? (
         <div className="empty">
           <h3 style={{ color: "var(--ink-1)", marginBottom: 8 }}>No active sessions</h3>
-          <p style={{ color: "var(--ink-2)", fontSize: 13, maxWidth: 420, margin: "0 auto 12px" }}>
+          <p style={{ color: "var(--ink-2)", fontSize: "var(--fs-m)", maxWidth: 420, margin: "0 auto 12px" }}>
             No Claude Code agents are currently connected to the bridge.
           </p>
-          <p style={{ color: "var(--ink-3)", fontSize: 13, maxWidth: 420, margin: "0 auto 16px" }}>
+          <p style={{ color: "var(--ink-3)", fontSize: "var(--fs-m)", maxWidth: 420, margin: "0 auto 16px" }}>
             Connect a Claude Code session to the bridge to see live activity here.{" "}
             <a href="https://docs.anthropic.com/claude-code" target="_blank" rel="noreferrer" style={{ color: "var(--accent)" }}>
               Learn more →
@@ -291,7 +291,7 @@ export default function SessionsPage() {
                       <div
                         style={{
                           fontFamily: "var(--font-mono)",
-                          fontSize: 14,
+                          fontSize: "var(--fs-base)",
                           fontWeight: 700,
                           color: "var(--ink-0)",
                           overflow: "hidden",
@@ -314,7 +314,7 @@ export default function SessionsPage() {
                         flexShrink: 0,
                         textTransform: "uppercase",
                         fontFamily: "var(--font-mono)",
-                        fontSize: 10,
+                        fontSize: "var(--fs-2xs)",
                         letterSpacing: "0.06em",
                       }}
                     >
@@ -326,7 +326,7 @@ export default function SessionsPage() {
                   {/* description */}
                   <div
                     style={{
-                      fontSize: 12,
+                      fontSize: "var(--fs-s)",
                       color: "var(--ink-2)",
                       overflow: "hidden",
                       textOverflow: "ellipsis",
@@ -360,7 +360,7 @@ export default function SessionsPage() {
                       </div>
                       <div
                         style={{
-                          fontSize: 10,
+                          fontSize: "var(--fs-2xs)",
                           color: "var(--ink-2)",
                           marginTop: 3,
                           fontWeight: 600,
@@ -385,7 +385,7 @@ export default function SessionsPage() {
                       </div>
                       <div
                         style={{
-                          fontSize: 10,
+                          fontSize: "var(--fs-2xs)",
                           color: "var(--ink-2)",
                           marginTop: 3,
                           fontWeight: 600,
@@ -411,7 +411,7 @@ export default function SessionsPage() {
                       </div>
                       <div
                         style={{
-                          fontSize: 10,
+                          fontSize: "var(--fs-2xs)",
                           color: "var(--ink-2)",
                           marginTop: 3,
                           fontWeight: 600,
@@ -429,7 +429,7 @@ export default function SessionsPage() {
                     style={{
                       display: "flex",
                       justifyContent: "space-between",
-                      fontSize: 11,
+                      fontSize: "var(--fs-xs)",
                       color: "var(--ink-3)",
                     }}
                   >
@@ -455,7 +455,7 @@ export default function SessionsPage() {
               <div
                 style={{
                   color: "var(--ink-3)",
-                  fontSize: 13,
+                  fontSize: "var(--fs-m)",
                   padding: 24,
                   textAlign: "center",
                 }}

--- a/dashboard/src/app/settings/page.tsx
+++ b/dashboard/src/app/settings/page.tsx
@@ -64,7 +64,7 @@ const inputStyle = {
   border: "1px solid var(--line-2)",
   borderRadius: "var(--r-2)",
   color: "var(--ink-0)",
-  fontSize: 13,
+  fontSize: "var(--fs-m)",
   fontFamily: "var(--font-mono)",
   padding: "6px 10px",
   outline: "none",
@@ -74,14 +74,14 @@ const inputStyle = {
 
 const labelStyle = {
   display: "block",
-  fontSize: 13,
+  fontSize: "var(--fs-m)",
   color: "var(--ink-1)",
   marginBottom: 4,
   fontWeight: 500,
 };
 
 const helpStyle = {
-  fontSize: 12,
+  fontSize: "var(--fs-s)",
   color: "var(--ink-2)",
   margin: "4px 0 0",
   lineHeight: 1.5,
@@ -304,7 +304,7 @@ export default function SettingsPage() {
           aria-live="polite"
           aria-atomic="true"
           style={{
-            fontSize: 12,
+            fontSize: "var(--fs-s)",
             color: saveState === "saved" ? "var(--ok)" : "var(--fg-2)",
             display: "flex",
             alignItems: "center",
@@ -317,7 +317,7 @@ export default function SettingsPage() {
         >
           {saveState !== "idle" && (
             <>
-              <span aria-hidden style={{ fontSize: 13 }}>
+              <span aria-hidden style={{ fontSize: "var(--fs-m)" }}>
                 {saveState === "saved" ? "✓" : "…"}
               </span>
               {saveState === "saved" ? "Saved" : "Saving…"}
@@ -362,7 +362,7 @@ export default function SettingsPage() {
                     href={`#${id}`}
                     onClick={() => setActive(id)}
                     style={{
-                      fontSize: 13,
+                      fontSize: "var(--fs-m)",
                       fontWeight: isActive ? 600 : 500,
                       color: isActive ? "var(--ink-0)" : "var(--ink-2)",
                       background: isActive ? "var(--bg-2)" : "transparent",
@@ -387,7 +387,7 @@ export default function SettingsPage() {
               <div className="card-head">
                 <div>
                   <h2 style={{ margin: 0 }}>Bridge</h2>
-                  <div style={{ fontSize: 12, color: "var(--ink-2)", marginTop: 2 }}>
+                  <div style={{ fontSize: "var(--fs-s)", color: "var(--ink-2)", marginTop: 2 }}>
                     Runtime ports, workspace binding, inbox path
                   </div>
                 </div>
@@ -474,20 +474,20 @@ export default function SettingsPage() {
                       border: "1px solid var(--border-default)",
                       borderRadius: "var(--r-2)",
                       padding: "6px 14px",
-                      fontSize: 13,
+                      fontSize: "var(--fs-m)",
                       cursor: "not-allowed",
                       opacity: 0.6,
                     }}
                   >
                     Apply
                   </button>
-                  <span id="bridge-apply-help" style={{ fontSize: 12, color: "var(--fg-3)" }}>
+                  <span id="bridge-apply-help" style={{ fontSize: "var(--fs-s)", color: "var(--fg-3)" }}>
                     Read-only — edit the config file directly and restart the bridge.
                   </span>
                 </div>
               </div>
 
-              <div style={{ display: "flex", gap: 16, paddingTop: 12, borderTop: "1px solid var(--border-subtle)", fontSize: 12, color: "var(--fg-2)" }}>
+              <div style={{ display: "flex", gap: 16, paddingTop: 12, borderTop: "1px solid var(--border-subtle)", fontSize: "var(--fs-s)", color: "var(--fg-2)" }}>
                 <span>Mode: <span style={{ color: "var(--fg-0)" }}>{settings.patchwork?.fullMode === false ? "slim" : "full"}</span></span>
                 <span>Sessions: <span className="mono" style={{ color: "var(--fg-0)" }}>{settings.activeSessions ?? 0}</span></span>
                 <span>Uptime: <span className="mono" style={{ color: "var(--fg-0)" }}>{settings.uptimeMs != null ? fmtDuration(settings.uptimeMs) : "—"}</span></span>
@@ -499,7 +499,7 @@ export default function SettingsPage() {
               <div className="card-head">
                 <div>
                   <h2 style={{ margin: 0 }}>AI drivers</h2>
-                  <div style={{ fontSize: 12, color: "var(--ink-2)", marginTop: 2 }}>
+                  <div style={{ fontSize: "var(--fs-s)", color: "var(--ink-2)", marginTop: 2 }}>
                     Configure the models available for recipes and orchestrated tasks.
                   </div>
                 </div>
@@ -524,13 +524,13 @@ export default function SettingsPage() {
                     >
                       <div style={{ flex: 1, minWidth: 0 }}>
                         <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
-                          <span style={{ fontSize: 13, fontWeight: 600, color: "var(--fg-0)" }}>{row.name}</span>
+                          <span style={{ fontSize: "var(--fs-m)", fontWeight: 600, color: "var(--fg-0)" }}>{row.name}</span>
                           {isPrimary && <StatusPill tone="ok">primary</StatusPill>}
                           <StatusPill tone={activeDriver ? "ok" : "muted"}>
                             {activeDriver ? "active" : "inactive"}
                           </StatusPill>
                         </div>
-                        <div style={{ fontSize: 12, color: "var(--fg-2)", marginTop: 2 }}>{row.detail}</div>
+                        <div style={{ fontSize: "var(--fs-s)", color: "var(--fg-2)", marginTop: 2 }}>{row.detail}</div>
                       </div>
                       <button
                         type="button"
@@ -542,7 +542,7 @@ export default function SettingsPage() {
                           border: "1px solid var(--border-default)",
                           borderRadius: "var(--r-2)",
                           padding: "5px 10px",
-                          fontSize: 12,
+                          fontSize: "var(--fs-s)",
                           cursor: isPrimary ? "default" : "pointer",
                           opacity: isPrimary ? 0.5 : 1,
                         }}
@@ -559,7 +559,7 @@ export default function SettingsPage() {
                           border: "1px solid var(--border-default)",
                           borderRadius: "var(--r-2)",
                           padding: "5px 10px",
-                          fontSize: 12,
+                          fontSize: "var(--fs-s)",
                           cursor: "not-allowed",
                           opacity: 0.5,
                         }}
@@ -570,7 +570,7 @@ export default function SettingsPage() {
                   );
                 })}
                 {driverMsg && (
-                  <p style={{ fontSize: 12, marginTop: 4, color: driverMsg.ok ? "var(--ok)" : "var(--err)" }}>
+                  <p style={{ fontSize: "var(--fs-s)", marginTop: 4, color: driverMsg.ok ? "var(--ok)" : "var(--err)" }}>
                     {driverMsg.text}
                   </p>
                 )}
@@ -582,7 +582,7 @@ export default function SettingsPage() {
               <div className="card-head">
                 <div>
                   <h2 style={{ margin: 0 }}>Approval policy</h2>
-                  <div style={{ fontSize: 12, color: "var(--ink-2)", marginTop: 2 }}>
+                  <div style={{ fontSize: "var(--fs-s)", color: "var(--ink-2)", marginTop: 2 }}>
                     Autopilot rules and Claude Code permission tiers.
                   </div>
                 </div>
@@ -616,7 +616,7 @@ export default function SettingsPage() {
                     disabled={gateSaving || gatePending === gateValue}
                     onClick={() => saveGate(gatePending)}
                     style={{
-                      fontSize: 12,
+                      fontSize: "var(--fs-s)",
                       fontWeight: 600,
                       padding: "6px 12px",
                       borderRadius: "var(--r-2)",
@@ -630,7 +630,7 @@ export default function SettingsPage() {
                     {gateSaving ? "Saving…" : "Save"}
                   </button>
                   {gateSaveMsg && (
-                    <span style={{ fontSize: 12, color: gateSaveMsg.ok ? "var(--ok)" : "var(--err)" }}>
+                    <span style={{ fontSize: "var(--fs-s)", color: gateSaveMsg.ok ? "var(--ok)" : "var(--err)" }}>
                       {gateSaveMsg.text}
                     </span>
                   )}
@@ -640,7 +640,7 @@ export default function SettingsPage() {
               <div style={{ padding: "16px 0", borderBottom: "1px solid var(--border-subtle)" }}>
                 <label
                   htmlFor="time-of-day-anomaly"
-                  style={{ display: "flex", alignItems: "center", gap: 8, fontSize: 13, fontWeight: 500, cursor: "pointer" }}
+                  style={{ display: "flex", alignItems: "center", gap: 8, fontSize: "var(--fs-m)", fontWeight: 500, cursor: "pointer" }}
                 >
                   <input
                     id="time-of-day-anomaly"
@@ -678,14 +678,14 @@ export default function SettingsPage() {
               <div className="card-head">
                 <div>
                   <h2 style={{ margin: 0 }}>Telemetry</h2>
-                  <div style={{ fontSize: 12, color: "var(--ink-2)", marginTop: 2 }}>
+                  <div style={{ fontSize: "var(--fs-s)", color: "var(--ink-2)", marginTop: 2 }}>
                     Opt-in. Everything off by default. Local-only until you flip a switch.
                   </div>
                 </div>
               </div>
 
               <div style={{ padding: "16px 0", display: "flex", flexDirection: "column", gap: 14 }}>
-                <div role="status" style={{ fontSize: 12, color: "var(--fg-3)", marginBottom: 4 }}>
+                <div role="status" style={{ fontSize: "var(--fs-s)", color: "var(--fg-3)", marginBottom: 4 }}>
                   Preview only — toggles do not yet persist between reloads.
                 </div>
                 <ToggleRow
@@ -741,8 +741,8 @@ function ToggleRow({
         style={{ marginTop: 2 }}
       />
       <label htmlFor={id} style={{ flex: 1, cursor: "pointer" }}>
-        <div style={{ fontSize: 13, fontWeight: 500, color: "var(--fg-0)" }}>{label}</div>
-        <div style={{ fontSize: 12, color: "var(--fg-2)", marginTop: 2, lineHeight: 1.5 }}>{help}</div>
+        <div style={{ fontSize: "var(--fs-m)", fontWeight: 500, color: "var(--fg-0)" }}>{label}</div>
+        <div style={{ fontSize: "var(--fs-s)", color: "var(--fg-2)", marginTop: 2, lineHeight: 1.5 }}>{help}</div>
       </label>
     </div>
   );
@@ -769,19 +769,19 @@ function PermColumn({
     >
       <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 8 }}>
         <StatusPill tone={tone}>{title}</StatusPill>
-        <span style={{ fontSize: 11, color: "var(--fg-3)" }}>{rules.length}</span>
+        <span style={{ fontSize: "var(--fs-xs)", color: "var(--fg-3)" }}>{rules.length}</span>
       </div>
       {rules.length === 0 ? (
-        <div style={{ fontSize: 11, color: "var(--fg-3)" }}>—</div>
+        <div style={{ fontSize: "var(--fs-xs)", color: "var(--fg-3)" }}>—</div>
       ) : (
         <ul style={{ listStyle: "none", margin: 0, padding: 0, display: "flex", flexDirection: "column", gap: 3 }}>
           {rules.slice(0, 8).map((r) => (
-            <li key={r} className="mono" style={{ fontSize: 11, color: "var(--fg-1)", wordBreak: "break-all" }}>
+            <li key={r} className="mono" style={{ fontSize: "var(--fs-xs)", color: "var(--fg-1)", wordBreak: "break-all" }}>
               {r}
             </li>
           ))}
           {rules.length > 8 && (
-            <li style={{ fontSize: 11, color: "var(--fg-3)" }}>+{rules.length - 8} more</li>
+            <li style={{ fontSize: "var(--fs-xs)", color: "var(--fg-3)" }}>+{rules.length - 8} more</li>
           )}
         </ul>
       )}
@@ -812,12 +812,12 @@ function ConfigFileCard({ path }: { path: string }) {
         padding: 10,
       }}
     >
-      <div style={{ fontSize: 10, fontWeight: 600, letterSpacing: "0.05em", color: "var(--fg-3)", textTransform: "uppercase" }}>
+      <div style={{ fontSize: "var(--fs-2xs)", fontWeight: 600, letterSpacing: "0.05em", color: "var(--fg-3)", textTransform: "uppercase" }}>
         Config file
       </div>
       <div
         className="mono"
-        style={{ fontSize: 11, color: "var(--fg-1)", marginTop: 6, wordBreak: "break-all", lineHeight: 1.4 }}
+        style={{ fontSize: "var(--fs-xs)", color: "var(--fg-1)", marginTop: 6, wordBreak: "break-all", lineHeight: 1.4 }}
       >
         {path}
       </div>
@@ -831,7 +831,7 @@ function ConfigFileCard({ path }: { path: string }) {
           border: "1px solid var(--border-default)",
           borderRadius: "var(--r-s)",
           color: copied ? "var(--ok)" : "var(--fg-1)",
-          fontSize: 11,
+          fontSize: "var(--fs-xs)",
           padding: "3px 8px",
           cursor: "pointer",
           display: "inline-flex",

--- a/dashboard/src/app/suggestions/page.tsx
+++ b/dashboard/src/app/suggestions/page.tsx
@@ -92,7 +92,7 @@ function GraduateButton({ recipeName }: { recipeName: string }) {
   }
   if (state === "done") {
     return (
-      <span style={{ color: "var(--ok)", fontSize: 13 }} role="status">
+      <span style={{ color: "var(--ok)", fontSize: "var(--fs-m)" }} role="status">
         <span aria-hidden="true">✓ </span>Graduated to mostly trusted
       </span>
     );
@@ -114,7 +114,7 @@ function GraduateButton({ recipeName }: { recipeName: string }) {
             : "Graduate trust"}
       </button>
       {state === "error" && errorMsg && (
-        <span role="alert" style={{ fontSize: 12, color: "var(--err)" }}>
+        <span role="alert" style={{ fontSize: "var(--fs-s)", color: "var(--err)" }}>
           {errorMsg}
         </span>
       )}
@@ -170,7 +170,7 @@ export default function SuggestionsPage() {
           </div>
         </div>
         <div style={{ display: "flex", gap: 6, alignItems: "center" }}>
-          <label htmlFor="since-days" style={{ fontSize: 12, color: "var(--fg-2)" }}>
+          <label htmlFor="since-days" style={{ fontSize: "var(--fs-s)", color: "var(--fg-2)" }}>
             Lookback
           </label>
           <select
@@ -182,7 +182,7 @@ export default function SuggestionsPage() {
               border: "1px solid var(--border-default)",
               borderRadius: "var(--r-2)",
               color: "var(--fg-0)",
-              fontSize: 12,
+              fontSize: "var(--fs-s)",
               padding: "4px 8px",
               outline: "none",
             }}
@@ -273,7 +273,7 @@ export default function SuggestionsPage() {
       {data?.generatedAt && (
         <p
           style={{
-            fontSize: 11,
+            fontSize: "var(--fs-xs)",
             color: "var(--fg-2)",
             marginTop: "var(--s-5)",
           }}
@@ -307,7 +307,7 @@ function SuggestionGroup({
         <h2>{title}</h2>
         <span className="pill muted">{items.length}</span>
       </div>
-      <p style={{ fontSize: 12, color: "var(--fg-2)", margin: "0 0 var(--s-3)" }}>
+      <p style={{ fontSize: "var(--fs-s)", color: "var(--fg-2)", margin: "0 0 var(--s-3)" }}>
         {subtitle}
       </p>
       <ul role="list" aria-label={title} style={{ listStyle: "none", padding: 0, margin: 0 }}>
@@ -334,10 +334,10 @@ function SuggestionGroup({
                 borderBottom: "1px solid var(--border-subtle)",
               }}
             >
-              <span className={`pill ${meta.pillClass}`} style={{ fontSize: 10 }}>
+              <span className={`pill ${meta.pillClass}`} style={{ fontSize: "var(--fs-2xs)" }}>
                 {meta.label}
               </span>
-              <span style={{ flex: 1, fontSize: 13 }}>{s.label}</span>
+              <span style={{ flex: 1, fontSize: "var(--fs-m)" }}>{s.label}</span>
               {action}
             </li>
           );
@@ -348,7 +348,7 @@ function SuggestionGroup({
           type="button"
           className="btn sm ghost"
           onClick={() => setShowAll(true)}
-          style={{ marginTop: "var(--s-3)", fontSize: 12 }}
+          style={{ marginTop: "var(--s-3)", fontSize: "var(--fs-s)" }}
         >
           Show {hidden} more
         </button>

--- a/dashboard/src/app/tasks/page.tsx
+++ b/dashboard/src/app/tasks/page.tsx
@@ -56,7 +56,7 @@ function DriverBadge({ name }: { name: string }) {
     <span
       className="pill"
       style={{
-        fontSize: 10,
+        fontSize: "var(--fs-2xs)",
         background: c.bg,
         color: c.fg,
         border: "none",
@@ -120,14 +120,14 @@ function TaskDetail({ task, onCancel, cancelling }: {
           flexWrap: "wrap",
         }}
       >
-        <span className={`pill ${statusClass(task.status)}`} style={{ fontSize: 11 }}>
+        <span className={`pill ${statusClass(task.status)}`} style={{ fontSize: "var(--fs-xs)" }}>
           <span className="pill-dot" />
           {task.status}
         </span>
-        <span className="mono" style={{ fontSize: 12, color: "var(--ink-1)" }}>
+        <span className="mono" style={{ fontSize: "var(--fs-s)", color: "var(--ink-1)" }}>
           {task.taskId.slice(0, 8)}
         </span>
-        <span style={{ fontSize: 12, color: "var(--ink-2)", marginLeft: "auto" }}>
+        <span style={{ fontSize: "var(--fs-s)", color: "var(--ink-2)", marginLeft: "auto" }}>
           <span className="mono">{dur}</span>
           <span style={{ margin: "0 6px", color: "var(--ink-3)" }}>·</span>
           <span className="mono">{model}</span>
@@ -138,7 +138,7 @@ function TaskDetail({ task, onCancel, cancelling }: {
       <div style={{ marginBottom: 14 }}>
         <div
           style={{
-            fontSize: 10,
+            fontSize: "var(--fs-2xs)",
             color: "var(--ink-2)",
             fontWeight: 600,
             textTransform: "uppercase",
@@ -168,7 +168,7 @@ function TaskDetail({ task, onCancel, cancelling }: {
           </pre>
         ) : (
           !errText && (
-            <div style={{ color: "var(--ink-3)", fontSize: 12, padding: "8px 0" }}>
+            <div style={{ color: "var(--ink-3)", fontSize: "var(--fs-s)", padding: "8px 0" }}>
               No output yet.
             </div>
           )
@@ -180,7 +180,7 @@ function TaskDetail({ task, onCancel, cancelling }: {
         <div style={{ marginBottom: 14 }}>
           <div
             style={{
-              fontSize: 10,
+              fontSize: "var(--fs-2xs)",
               color: "var(--ink-2)",
               fontWeight: 600,
               textTransform: "uppercase",
@@ -195,7 +195,7 @@ function TaskDetail({ task, onCancel, cancelling }: {
               <span
                 key={f}
                 className="pill muted mono"
-                style={{ fontSize: 11 }}
+                style={{ fontSize: "var(--fs-xs)" }}
               >
                 {f}
               </span>
@@ -217,7 +217,7 @@ function TaskDetail({ task, onCancel, cancelling }: {
         <button
           type="button"
           className="btn sm ghost"
-          style={{ fontSize: 12 }}
+          style={{ fontSize: "var(--fs-s)" }}
           onClick={async () => {
             await navigator.clipboard.writeText(`patchwork task resume ${task.taskId}`);
             flash("term");
@@ -228,7 +228,7 @@ function TaskDetail({ task, onCancel, cancelling }: {
         <button
           type="button"
           className="btn sm ghost"
-          style={{ fontSize: 12 }}
+          style={{ fontSize: "var(--fs-s)" }}
           onClick={async () => {
             try {
               const res = await fetch(
@@ -247,7 +247,7 @@ function TaskDetail({ task, onCancel, cancelling }: {
           type="button"
           className="btn sm ghost"
           aria-label="Copy task ID"
-          style={{ fontSize: 12 }}
+          style={{ fontSize: "var(--fs-s)" }}
           onClick={async () => {
             await navigator.clipboard.writeText(task.taskId);
             flash("id");
@@ -263,7 +263,7 @@ function TaskDetail({ task, onCancel, cancelling }: {
           <button
             type="button"
             className="btn sm ghost"
-            style={{ fontSize: 12, color: "var(--red)", marginLeft: "auto" }}
+            style={{ fontSize: "var(--fs-s)", color: "var(--red)", marginLeft: "auto" }}
             disabled={!!cancelling[task.taskId]}
             onClick={() => onCancel(task.taskId)}
           >
@@ -459,7 +459,7 @@ export default function TasksPage() {
             onChange={(e) => setSearch(e.target.value)}
             placeholder="Search id, session, driver, output…"
             className="input"
-            style={{ flex: "1 1 280px", maxWidth: 360, fontSize: 13 }}
+            style={{ flex: "1 1 280px", maxWidth: 360, fontSize: "var(--fs-m)" }}
             aria-label="Filter tasks"
           />
           <div style={{ display: "flex", gap: 4 }} role="group" aria-label="Status filter">
@@ -475,14 +475,14 @@ export default function TasksPage() {
                 aria-pressed={statusFilter === k}
                 onClick={() => setStatusFilter(k)}
                 className={`btn sm ${statusFilter === k ? "primary" : "ghost"}`}
-                style={{ fontSize: 12 }}
+                style={{ fontSize: "var(--fs-s)" }}
               >
                 {label} <span style={{ opacity: 0.7, marginLeft: 4 }}>{n}</span>
               </button>
             ))}
           </div>
           {(search || statusFilter !== "all") && (
-            <span style={{ fontSize: 12, color: "var(--ink-3)" }}>
+            <span style={{ fontSize: "var(--fs-s)", color: "var(--ink-3)" }}>
               {filteredTasks.length} of {tasks.length}
             </span>
           )}
@@ -527,7 +527,7 @@ export default function TasksPage() {
             />
           <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
             {filteredTasks.length === 0 && (
-              <div style={{ padding: "var(--s-4)", color: "var(--ink-3)", fontSize: 13 }}>
+              <div style={{ padding: "var(--s-4)", color: "var(--ink-3)", fontSize: "var(--fs-m)" }}>
                 No tasks match this filter.
               </div>
             )}
@@ -597,7 +597,7 @@ export default function TasksPage() {
                     }}
                   />
                   <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 5 }}>
-                    <span className="mono" style={{ fontSize: 11, color: "var(--ink-2)", fontWeight: 500 }}>
+                    <span className="mono" style={{ fontSize: "var(--fs-xs)", color: "var(--ink-2)", fontWeight: 500 }}>
                       {t.taskId.slice(0, 8)}
                     </span>
                     <span style={{ marginLeft: "auto", display: "flex", alignItems: "center", gap: 6 }}>
@@ -623,7 +623,7 @@ export default function TasksPage() {
                         />
                       </span>
                       <DriverBadge name={driver} />
-                      <span className={`pill ${statusClass(t.status)}`} style={{ fontSize: 10 }}>
+                      <span className={`pill ${statusClass(t.status)}`} style={{ fontSize: "var(--fs-2xs)" }}>
                         <span className="pill-dot" />
                         {t.status}
                       </span>
@@ -631,7 +631,7 @@ export default function TasksPage() {
                   </div>
                   <div
                     style={{
-                      fontSize: 12,
+                      fontSize: "var(--fs-s)",
                       color: isSelected ? "var(--ink-1)" : "var(--ink-2)",
                       lineHeight: 1.5,
                       display: "-webkit-box",
@@ -643,7 +643,7 @@ export default function TasksPage() {
                   >
                     {firstOutputLine || <span style={{ color: "var(--ink-3)" }}>(running…)</span>}
                   </div>
-                  <div style={{ fontSize: 11, color: isLive ? "var(--blue)" : "var(--ink-3)", fontFamily: "var(--font-mono)", marginTop: 4 }}>
+                  <div style={{ fontSize: "var(--fs-xs)", color: isLive ? "var(--blue)" : "var(--ink-3)", fontFamily: "var(--font-mono)", marginTop: 4 }}>
                     {dur}
                   </div>
                 </button>
@@ -664,7 +664,7 @@ export default function TasksPage() {
               <div
                 style={{
                   color: "var(--ink-3)",
-                  fontSize: 13,
+                  fontSize: "var(--fs-m)",
                   padding: 24,
                   textAlign: "center",
                 }}

--- a/dashboard/src/app/traces/page.tsx
+++ b/dashboard/src/app/traces/page.tsx
@@ -139,7 +139,7 @@ function TraceActions({
         <button
           type="button"
           className="btn sm primary"
-          style={{ fontSize: 11, background: "var(--orange)", border: "none" }}
+          style={{ fontSize: "var(--fs-xs)", background: "var(--orange)", border: "none" }}
           disabled={replaying}
           onClick={() => void handleReplay()}
         >
@@ -150,7 +150,7 @@ function TraceActions({
         <button
           type="button"
           className="btn sm ghost"
-          style={{ fontSize: 11, fontFamily: "var(--font-mono)" }}
+          style={{ fontSize: "var(--fs-xs)", fontFamily: "var(--font-mono)" }}
           onClick={handleCopyCli}
         >
           {copied ? "Copied ✓" : "⌗ Open in CLI"}
@@ -159,7 +159,7 @@ function TraceActions({
       {replayMsg && (
         <span
           style={{
-            fontSize: 11,
+            fontSize: "var(--fs-xs)",
             color: replayMsg.ok ? "var(--ok)" : "var(--err)",
             fontFamily: "var(--font-mono)",
           }}
@@ -204,7 +204,7 @@ function TraceDetail({
         borderRadius: "var(--r-s)",
         border: "1px solid var(--line-2)",
         overflow: "hidden",
-        fontSize: 12,
+        fontSize: "var(--fs-s)",
       }}
     >
       {/* scalar fields as key/value grid */}
@@ -224,7 +224,7 @@ function TraceDetail({
                   fontFamily: "var(--font-mono)",
                   color: theme.fg,
                   fontWeight: 600,
-                  fontSize: 11,
+                  fontSize: "var(--fs-xs)",
                   background: i % 2 === 0 ? "var(--recess)" : "transparent",
                   borderRight: "1px solid var(--line-2)",
                   whiteSpace: "nowrap",
@@ -237,7 +237,7 @@ function TraceDetail({
                   padding: "5px 12px",
                   fontFamily: "var(--font-mono)",
                   color: "var(--ink-1)",
-                  fontSize: 11,
+                  fontSize: "var(--fs-xs)",
                   background: i % 2 === 0 ? "var(--recess)" : "transparent",
                   wordBreak: "break-all",
                 }}
@@ -255,7 +255,7 @@ function TraceDetail({
             style={{
               padding: "5px 12px",
               fontFamily: "var(--font-mono)",
-              fontSize: 11,
+              fontSize: "var(--fs-xs)",
               fontWeight: 600,
               color: theme.fg,
               cursor: "pointer",
@@ -266,7 +266,7 @@ function TraceDetail({
               gap: 6,
             }}
           >
-            <span style={{ color: "var(--ink-3)", fontSize: 9 }}>▸</span>
+            <span style={{ color: "var(--ink-3)", fontSize: "var(--fs-3xs)" }}>▸</span>
             {k}
             {Array.isArray(v) && (
               <span style={{ color: "var(--ink-3)", fontWeight: 400 }}>
@@ -279,7 +279,7 @@ function TraceDetail({
               margin: 0,
               padding: "8px 12px 10px 24px",
               background: "var(--bg-0)",
-              fontSize: 11,
+              fontSize: "var(--fs-xs)",
               fontFamily: "var(--font-mono)",
               overflow: "auto",
               whiteSpace: "pre-wrap",
@@ -389,7 +389,7 @@ function ExportButton({ disabled: outerDisabled }: { disabled?: boolean }) {
             boxShadow: "0 4px 16px rgba(0,0,0,0.2)",
           }}
         >
-          <p style={{ margin: "0 0 var(--s-3)", fontSize: 12, color: "var(--fg-2)" }}>
+          <p style={{ margin: "0 0 var(--s-3)", fontSize: "var(--fs-s)", color: "var(--fg-2)" }}>
             Optional: encrypt with a passphrase (AES-256-GCM). Leave blank for a
             plain <code>.jsonl.gz</code>.
           </p>
@@ -408,12 +408,12 @@ function ExportButton({ disabled: outerDisabled }: { disabled?: boolean }) {
               border: "1px solid var(--border-default)",
               borderRadius: 6,
               color: "var(--fg-1)",
-              fontSize: 13,
+              fontSize: "var(--fs-m)",
             }}
             autoFocus
           />
           {error && (
-            <p style={{ margin: "0 0 var(--s-3)", fontSize: 12, color: "var(--red)" }}>
+            <p style={{ margin: "0 0 var(--s-3)", fontSize: "var(--fs-s)", color: "var(--red)" }}>
               {error}
             </p>
           )}
@@ -426,7 +426,7 @@ function ExportButton({ disabled: outerDisabled }: { disabled?: boolean }) {
             </button>
           </div>
           {passphrase.trim() && (
-            <p style={{ margin: "var(--s-3) 0 0", fontSize: 11, color: "var(--fg-3)" }}>
+            <p style={{ margin: "var(--s-3) 0 0", fontSize: "var(--fs-xs)", color: "var(--fg-3)" }}>
               Import: <code>patchwork traces import bundle.enc --passphrase …</code>
             </p>
           )}
@@ -513,7 +513,7 @@ export default function TracesPage() {
             style={{
               minWidth: "min(260px, 100%)",
               padding: "6px 10px",
-              fontSize: 13,
+              fontSize: "var(--fs-m)",
               fontFamily: "var(--font-mono)",
               background: "var(--recess)",
               border: "1px solid var(--line-2)",
@@ -542,7 +542,7 @@ export default function TracesPage() {
               type="button"
               onClick={() => setStatusFilter(k)}
               className={statusFilter === k ? "pill accent" : "pill muted"}
-              style={{ cursor: "pointer", border: "none", fontSize: 12 }}
+              style={{ cursor: "pointer", border: "none", fontSize: "var(--fs-s)" }}
             >
               {k === "all" ? `All (${traces.length})` : k === "done" ? `Done (${doneCount})` : `Errors (${errorCount})`}
             </button>
@@ -612,7 +612,7 @@ export default function TracesPage() {
                       cursor: "pointer",
                       color: "var(--ink-3)",
                       fontFamily: "var(--font-mono)",
-                      fontSize: 12,
+                      fontSize: "var(--fs-s)",
                       padding: 0,
                       textAlign: "left",
                     }}
@@ -634,7 +634,7 @@ export default function TracesPage() {
                     onClick={() => toggle(rowKey)}
                     style={{
                       fontFamily: "var(--font-mono)",
-                      fontSize: 11,
+                      fontSize: "var(--fs-xs)",
                       color: theme.fg,
                       background: "transparent",
                       border: "none",
@@ -652,7 +652,7 @@ export default function TracesPage() {
                     type="button"
                     onClick={() => toggle(rowKey)}
                     style={{
-                      fontSize: 13,
+                      fontSize: "var(--fs-m)",
                       color: "var(--ink-1)",
                       background: "transparent",
                       border: "none",
@@ -666,11 +666,11 @@ export default function TracesPage() {
                   >
                     {String(t.body?.recipeName ?? t.key)}
                   </button>
-                  <span style={{ fontSize: 11, color: "var(--ink-3)", textAlign: "right" }}>
+                  <span style={{ fontSize: "var(--fs-xs)", color: "var(--ink-3)", textAlign: "right" }}>
                     {relTime(t.ts)}
                   </span>
                   <span style={{ display: "flex", justifyContent: "flex-end" }}>
-                    <span className="pill" style={{ background: statusBg, color: statusColor, fontSize: 10, fontWeight: 700 }}>
+                    <span className="pill" style={{ background: statusBg, color: statusColor, fontSize: "var(--fs-2xs)", fontWeight: 700 }}>
                       {statusLabel}
                     </span>
                   </span>
@@ -697,11 +697,11 @@ export default function TracesPage() {
                 </div>
                 {isOpen && (
                   <div style={{ padding: "0 16px 12px 16px", borderTop: "1px solid var(--line-3)", background: "var(--recess)" }}>
-                    <div style={{ fontFamily: "var(--font-mono)", fontSize: 11, color: "var(--ink-2)", margin: "8px 0 4px", wordBreak: "break-all" }}>
+                    <div style={{ fontFamily: "var(--font-mono)", fontSize: "var(--fs-xs)", color: "var(--ink-2)", margin: "8px 0 4px", wordBreak: "break-all" }}>
                       {t.key}
                     </div>
                     {t.summary && (
-                      <div style={{ fontSize: 12, color: "var(--ink-1)", marginBottom: 8 }}>{t.summary}</div>
+                      <div style={{ fontSize: "var(--fs-s)", color: "var(--ink-1)", marginBottom: 8 }}>{t.summary}</div>
                     )}
                     <TraceActions traceType={t.traceType} body={t.body} />
                     <TraceDetail body={t.body} theme={theme} traceType={t.traceType} />

--- a/dashboard/src/app/transactions/page.tsx
+++ b/dashboard/src/app/transactions/page.tsx
@@ -204,7 +204,7 @@ export default function TransactionsPage() {
           >
             <div className="card-head">
               <h2>
-                <code style={{ fontSize: 14 }}>{tx.id}</code>
+                <code style={{ fontSize: "var(--fs-base)" }}>{tx.id}</code>
               </h2>
               <div style={{ display: "flex", gap: 6, alignItems: "center" }}>
                 <span className="pill muted" title={new Date(tx.createdAt).toISOString()}>
@@ -273,7 +273,7 @@ export default function TransactionsPage() {
               >
                 {state === "rolling-back" ? "Discarding…" : "Discard"}
               </button>
-              <span style={{ fontSize: 12, color: "var(--fg-2)" }}>
+              <span style={{ fontSize: "var(--fs-s)", color: "var(--fg-2)" }}>
                 Commit happens from the agent — call{" "}
                 <code>commitTransaction</code> with this ID. Discard is safe;
                 nothing has touched disk.

--- a/dashboard/src/components/ConnectorHealthPanel.tsx
+++ b/dashboard/src/components/ConnectorHealthPanel.tsx
@@ -123,7 +123,7 @@ export function ConnectorHealthPanel({ connectors, marginTop }: Props) {
           <h3
             style={{
               margin: 0,
-              fontSize: 11,
+              fontSize: "var(--fs-xs)",
               color: "var(--ink-2)",
               fontWeight: 700,
               textTransform: "uppercase",
@@ -132,16 +132,16 @@ export function ConnectorHealthPanel({ connectors, marginTop }: Props) {
           >
             Required connectors
           </h3>
-          <span className="pill muted" style={{ fontSize: 10 }}>{total}</span>
-          {okCount > 0 && <span className="pill ok" style={{ fontSize: 10 }}>{okCount} ok</span>}
-          {degCount > 0 && <span className="pill warn" style={{ fontSize: 10 }}>{degCount} degraded</span>}
-          {errCount > 0 && <span className="pill err" style={{ fontSize: 10 }}>{errCount} issue{errCount !== 1 ? "s" : ""}</span>}
+          <span className="pill muted" style={{ fontSize: "var(--fs-2xs)" }}>{total}</span>
+          {okCount > 0 && <span className="pill ok" style={{ fontSize: "var(--fs-2xs)" }}>{okCount} ok</span>}
+          {degCount > 0 && <span className="pill warn" style={{ fontSize: "var(--fs-2xs)" }}>{degCount} degraded</span>}
+          {errCount > 0 && <span className="pill err" style={{ fontSize: "var(--fs-2xs)" }}>{errCount} issue{errCount !== 1 ? "s" : ""}</span>}
         </div>
         {fetchErr && (
-          <span style={{ fontSize: 11, color: "var(--err)" }}>{fetchErr}</span>
+          <span style={{ fontSize: "var(--fs-xs)", color: "var(--err)" }}>{fetchErr}</span>
         )}
         {statusMap === null && !fetchErr && (
-          <span style={{ fontSize: 11, color: "var(--fg-3)" }}>Loading…</span>
+          <span style={{ fontSize: "var(--fs-xs)", color: "var(--fg-3)" }}>Loading…</span>
         )}
       </div>
 
@@ -164,7 +164,7 @@ export function ConnectorHealthPanel({ connectors, marginTop }: Props) {
                 padding: "7px 10px",
                 borderRadius: "var(--r-s)",
                 background: "var(--recess)",
-                fontSize: 13,
+                fontSize: "var(--fs-m)",
               }}
             >
               {/* Status dot — uses .connector-dot class + inline bg for color */}
@@ -178,16 +178,16 @@ export function ConnectorHealthPanel({ connectors, marginTop }: Props) {
                   flex: 1,
                   color: "var(--fg-1)",
                   fontFamily: "var(--font-mono)",
-                  fontSize: 12,
+                  fontSize: "var(--fs-s)",
                 }}
               >
                 {name}
               </span>
-              <span style={{ fontSize: 11, color: cssColor }}>{label}</span>
+              <span style={{ fontSize: "var(--fs-xs)", color: cssColor }}>{label}</span>
               {info?.message && (
                 <span
                   style={{
-                    fontSize: 11,
+                    fontSize: "var(--fs-xs)",
                     color: "var(--fg-3)",
                     marginLeft: "var(--s-1)",
                     maxWidth: 200,

--- a/dashboard/src/components/Shell.tsx
+++ b/dashboard/src/components/Shell.tsx
@@ -313,7 +313,7 @@ export function Shell({ children }: { children: ReactNode }) {
             aria-label="Open terminal"
             title="Terminal"
           >
-            <span aria-hidden="true" style={{ fontFamily: "var(--font-mono)", fontSize: 12, fontWeight: 700, letterSpacing: "-0.05em" }}>
+            <span aria-hidden="true" style={{ fontFamily: "var(--font-mono)", fontSize: "var(--fs-s)", fontWeight: 700, letterSpacing: "-0.05em" }}>
               {">_"}
             </span>
           </button>

--- a/dashboard/src/components/StatCard.tsx
+++ b/dashboard/src/components/StatCard.tsx
@@ -30,7 +30,7 @@ function DeltaBadge({ delta }: { delta: string }) {
         display: "inline-flex",
         alignItems: "center",
         gap: 2,
-        fontSize: 11,
+        fontSize: "var(--fs-xs)",
         fontWeight: 600,
         color,
         background: isPositive

--- a/dashboard/src/components/patchwork/AreaChart.tsx
+++ b/dashboard/src/components/patchwork/AreaChart.tsx
@@ -153,7 +153,7 @@ export function AreaChart({
           height: "100%",
           pointerEvents: "none",
           fontFamily: "var(--font-mono)",
-          fontSize: 10,
+          fontSize: "var(--fs-2xs)",
           color: "var(--ink-3)",
         }}
       >
@@ -190,7 +190,7 @@ export function AreaChart({
           height: PAD.bottom - 4,
           pointerEvents: "none",
           fontFamily: "var(--font-mono)",
-          fontSize: 10,
+          fontSize: "var(--fs-2xs)",
           color: "var(--ink-3)",
         }}
       >

--- a/dashboard/src/components/patchwork/EmptyState.tsx
+++ b/dashboard/src/components/patchwork/EmptyState.tsx
@@ -20,7 +20,7 @@ export function EmptyState({
       )}
       <h3 style={{ color: "var(--ink-1)", marginBottom: 8 }}>{title}</h3>
       {description && (
-        <p style={{ color: "var(--ink-2)", fontSize: 13, maxWidth: 420, margin: "0 auto 16px" }}>
+        <p style={{ color: "var(--ink-2)", fontSize: "var(--fs-m)", maxWidth: 420, margin: "0 auto 16px" }}>
           {description}
         </p>
       )}

--- a/dashboard/src/components/patchwork/ErrorState.tsx
+++ b/dashboard/src/components/patchwork/ErrorState.tsx
@@ -39,7 +39,7 @@ export function ErrorState({
       </div>
       <h3 style={{ color: "var(--ink-1)", marginBottom: 8 }}>{title}</h3>
       {description && (
-        <p style={{ color: "var(--ink-2)", fontSize: 13, maxWidth: 420, margin: "0 auto 12px" }}>
+        <p style={{ color: "var(--ink-2)", fontSize: "var(--fs-m)", maxWidth: 420, margin: "0 auto 12px" }}>
           {description}
         </p>
       )}
@@ -47,7 +47,7 @@ export function ErrorState({
         <pre
           style={{
             fontFamily: "var(--font-mono)",
-            fontSize: 11,
+            fontSize: "var(--fs-xs)",
             color: "var(--ink-3)",
             background: "var(--recess)",
             border: "1px solid var(--line-1)",
@@ -77,7 +77,7 @@ export function ErrorState({
                   border: "none",
                   borderRadius: "var(--r-2)",
                   padding: "6px 14px",
-                  fontSize: 13,
+                  fontSize: "var(--fs-m)",
                   cursor: "pointer",
                 }}
               >

--- a/dashboard/src/components/patchwork/EventsHistogram.tsx
+++ b/dashboard/src/components/patchwork/EventsHistogram.tsx
@@ -113,7 +113,7 @@ export function EventsHistogram({
           justifyContent: "space-between",
           marginTop: 3,
           fontFamily: "var(--font-mono)",
-          fontSize: 9,
+          fontSize: "var(--fs-3xs)",
           color: "var(--ink-3)",
         }}
       >

--- a/dashboard/src/components/patchwork/HBarList.tsx
+++ b/dashboard/src/components/patchwork/HBarList.tsx
@@ -26,7 +26,7 @@ export function HBarList({
               <span
                 style={{
                   fontFamily: "var(--font-mono)",
-                  fontSize: 11,
+                  fontSize: "var(--fs-xs)",
                   color: "var(--ink-1)",
                   overflow: "hidden",
                   textOverflow: "ellipsis",
@@ -36,7 +36,7 @@ export function HBarList({
                 {item.label}
               </span>
               {item.sub && (
-                <span style={{ fontFamily: "var(--font-mono)", fontSize: 10, color: "var(--ink-3)" }}>
+                <span style={{ fontFamily: "var(--font-mono)", fontSize: "var(--fs-2xs)", color: "var(--ink-3)" }}>
                   {item.sub}
                 </span>
               )}
@@ -57,7 +57,7 @@ export function HBarList({
             <span
               style={{
                 fontFamily: "var(--font-mono)",
-                fontSize: 11,
+                fontSize: "var(--fs-xs)",
                 color: "var(--ink-2)",
                 textAlign: "right",
                 minWidth: 36,

--- a/dashboard/src/components/patchwork/LivePill.tsx
+++ b/dashboard/src/components/patchwork/LivePill.tsx
@@ -3,7 +3,7 @@ export function LivePill({ label = "live", tone = "accent" }: { label?: string; 
   return (
     <span
       className={`chip ${cls}`}
-      style={{ textTransform: "uppercase", letterSpacing: "0.08em", fontFamily: "var(--font-mono)", fontSize: 10, fontWeight: 600 }}
+      style={{ textTransform: "uppercase", letterSpacing: "0.08em", fontFamily: "var(--font-mono)", fontSize: "var(--fs-2xs)", fontWeight: 600 }}
     >
       <span className="dot-live" aria-hidden="true" />
       {label}

--- a/dashboard/src/components/patchwork/MetricsDonut.tsx
+++ b/dashboard/src/components/patchwork/MetricsDonut.tsx
@@ -32,7 +32,7 @@ export function MetricsDonut({
   if (total === 0) {
     return (
       <div style={{ width: size, height: size, display: "flex", alignItems: "center", justifyContent: "center" }}>
-        <span style={{ fontFamily: "var(--font-mono)", fontSize: 11, color: "var(--ink-3)" }}>no data</span>
+        <span style={{ fontFamily: "var(--font-mono)", fontSize: "var(--fs-xs)", color: "var(--ink-3)" }}>no data</span>
       </div>
     );
   }
@@ -69,7 +69,7 @@ export function MetricsDonut({
             y={cy + 1}
             textAnchor="middle"
             dominantBaseline="middle"
-            style={{ fontFamily: "var(--font-mono)", fontSize: 10, fill: "var(--ink-2)", fontWeight: 700 }}
+            style={{ fontFamily: "var(--font-mono)", fontSize: "var(--fs-2xs)", fill: "var(--ink-2)", fontWeight: 700 }}
           >
             {label}
           </text>
@@ -79,8 +79,8 @@ export function MetricsDonut({
         {arcs.map((arc) => (
           <div key={arc.label} style={{ display: "flex", alignItems: "center", gap: 6 }}>
             <span style={{ width: 8, height: 8, borderRadius: 2, background: arc.color, flexShrink: 0 }} />
-            <span style={{ fontFamily: "var(--font-mono)", fontSize: 10, color: "var(--ink-1)" }}>{arc.label}</span>
-            <span style={{ fontFamily: "var(--font-mono)", fontSize: 10, color: "var(--ink-3)", marginLeft: 4 }}>
+            <span style={{ fontFamily: "var(--font-mono)", fontSize: "var(--fs-2xs)", color: "var(--ink-1)" }}>{arc.label}</span>
+            <span style={{ fontFamily: "var(--font-mono)", fontSize: "var(--fs-2xs)", color: "var(--ink-3)", marginLeft: 4 }}>
               {((arc.value / total) * 100).toFixed(0)}%
             </span>
           </div>

--- a/dashboard/src/components/patchwork/RiskPill.tsx
+++ b/dashboard/src/components/patchwork/RiskPill.tsx
@@ -14,7 +14,7 @@ export function RiskPill({ level, label }: { level: RiskLevel; label?: string })
         textTransform: "uppercase",
         letterSpacing: "0.06em",
         fontFamily: "var(--font-mono)",
-        fontSize: 10,
+        fontSize: "var(--fs-2xs)",
         fontWeight: 700,
       }}
     >

--- a/dashboard/src/components/patchwork/SearchInput.tsx
+++ b/dashboard/src/components/patchwork/SearchInput.tsx
@@ -51,7 +51,7 @@ export function SearchInput({
           background: "transparent",
           color: "var(--ink-0)",
           font: "inherit",
-          fontSize: 13,
+          fontSize: "var(--fs-m)",
         }}
       />
     </label>


### PR DESCRIPTION
## Summary
- Mechanical sweep across 41 dashboard files: 587 inline `fontSize: <int>` literals replaced with the `--fs-*` tokens introduced in #224.
- Regex uses a negative-lookahead boundary so `.5` values (11.5, 12.5, 13.5, 10.5) and any future 100+ values are preserved.
- Off-scale residuals deliberately left inline: `17` (6 uses, sits between --fs-xl/16 and --fs-2xl/18), `21`, `22`, `36`, `48`, em-based `"0.85"`/`"0.875"`/`"1.125"`, and the single `fontSize: 0`. Easy follow-up to fold these into the scale once we decide whether 17 deserves its own token.

## Stacked on
This PR targets `dashboard/phase2-fontsize-tokens` (#224) — the tokens land first, then this swap-in. Will retarget `main` once #224 merges, or merge the chain together.

## Test plan
- [x] `npm run tokens:check` → clean
- [x] `npm test` → 24/24 pass
- [ ] Visual smoke: pixel values are identical, so any visible diff is a regression. Spot-check a dense route (`/runs/[seq]`, `/inbox`, `/recipes/new`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)