### PR TITLE
feat(dashboard): --fs-stat token for big-number displays

### DIFF
--- a/dashboard/scripts/check-tokens.mjs
+++ b/dashboard/scripts/check-tokens.mjs
@@ -97,6 +97,7 @@ const RENAMES = {
   "fontSize.2xl": "fs-2xl",
   "fontSize.3xl": "fs-3xl",
   "fontSize.display": "fs-display",
+  "fontSize.stat": "fs-stat",
 };
 
 for (const { name: themeName, json, css: cssVars } of themes) {

--- a/dashboard/src/app/globals.css
+++ b/dashboard/src/app/globals.css
@@ -84,6 +84,8 @@
   --fs-2xl:    18px;
   --fs-3xl:    20px;
   --fs-display: 28px;
+  /* role-named: stat-number displays in sessions/inbox cards */
+  --fs-stat:   17px;
 
   /* Visually-hidden until focused; surfaces for keyboard users only. */
 }

--- a/dashboard/src/app/sessions/[id]/page.tsx
+++ b/dashboard/src/app/sessions/[id]/page.tsx
@@ -225,7 +225,7 @@ export default function SessionDetailPage() {
             </div>
             <div
               style={{
-                fontSize: 17,
+                fontSize: "var(--fs-stat)",
                 fontFamily: "var(--font-mono)",
                 fontWeight: 700,
                 color: "var(--ink-0)",
@@ -249,7 +249,7 @@ export default function SessionDetailPage() {
             </div>
             <div
               style={{
-                fontSize: 17,
+                fontSize: "var(--fs-stat)",
                 fontFamily: "var(--font-mono)",
                 fontWeight: 700,
                 color:
@@ -276,7 +276,7 @@ export default function SessionDetailPage() {
             </div>
             <div
               style={{
-                fontSize: 17,
+                fontSize: "var(--fs-stat)",
                 fontFamily: "var(--font-mono)",
                 fontWeight: 700,
                 color: "var(--ink-0)",

--- a/dashboard/src/app/sessions/page.tsx
+++ b/dashboard/src/app/sessions/page.tsx
@@ -349,7 +349,7 @@ export default function SessionsPage() {
                     <div>
                       <div
                         style={{
-                          fontSize: 17,
+                          fontSize: "var(--fs-stat)",
                           fontWeight: 700,
                           fontFamily: "var(--font-mono)",
                           color: "var(--ink-0)",
@@ -374,7 +374,7 @@ export default function SessionsPage() {
                     <div>
                       <div
                         style={{
-                          fontSize: 17,
+                          fontSize: "var(--fs-stat)",
                           fontWeight: 700,
                           fontFamily: "var(--font-mono)",
                           color: "var(--ink-0)",
@@ -399,7 +399,7 @@ export default function SessionsPage() {
                     <div>
                       <div
                         style={{
-                          fontSize: 17,
+                          fontSize: "var(--fs-stat)",
                           fontWeight: 700,
                           fontFamily: "var(--font-mono)",
                           color:

--- a/dashboard/tokens.json
+++ b/dashboard/tokens.json
@@ -53,7 +53,8 @@
       "xl":      "16px",
       "2xl":     "18px",
       "3xl":     "20px",
-      "display": "28px"
+      "display": "28px",
+      "stat":    "17px"
     },
     "radius": {
       "s":    "6px",


### PR DESCRIPTION
## Summary
- Adds `--fs-stat: 17px` (mirrored in tokens.json + check-tokens RENAMES) for the big-number stat displays in sessions cards and session detail header.
- Migrates the 6 remaining `fontSize: 17` callsites in `src/app/sessions/page.tsx` and `src/app/sessions/[id]/page.tsx`.
- Other off-scale residuals (21, 22, 36, 48 and em-based literals) stay inline — they don't share a role.

## Test plan
- [x] `npm run tokens:check` → clean (131 light vars, +1 from --fs-stat)
- [x] `npm test` → 24/24 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)