### PR TITLE
fix(dashboard): prune dead .pill aliases + define missing .pill.accent

### DIFF
--- a/dashboard/src/app/globals.css
+++ b/dashboard/src/app/globals.css
@@ -1246,15 +1246,15 @@ button.topbar-search {
   50%      { opacity: 0.4; transform: scale(0.7); }
 }
 
-/* Prototype color name aliases */
-.pill.green  { background: var(--green-soft);  color: var(--green);  border-color: transparent; }
-.pill.amber  { background: var(--amber-soft);  color: var(--amber);  border-color: transparent; }
+/* .pill.purp — used by traces page for `decision` event tone. Other
+   color-named aliases (.green/.amber/.red/.blue) and .round were
+   prototype leftovers with no callsites; the canonical state names
+   (.ok/.warn/.err/.info) cover those tones. */
 .pill.purp   { background: var(--purple-soft); color: var(--purple); border-color: transparent; }
-.pill.red    { background: var(--red-soft);    color: var(--red);    border-color: transparent; }
-.pill.blue   { background: var(--blue-soft);   color: var(--blue);   border-color: transparent; }
 
-/* round variant for nav/count chips */
-.pill.round { border-radius: 999px; }
+/* Active filter / accent state — used by traces filter buttons
+   (`pill accent` / `pill muted` toggle). */
+.pill.accent { background: var(--orange-soft); color: var(--orange); border-color: var(--orange-tint); }
 
 /* ---- Connector dot (marketplace + health panel) ---- */
 .connector-dot {


### PR DESCRIPTION
## Summary
- Audited every `.pill.*` modifier in `globals.css` against actual className usage in `src/`.
- **Dead (deleted):** `.pill.green / .amber / .red / .blue` (prototype color aliases — canonical `.ok/.warn/.err/.info` cover the same tones and are widely used) and `.pill.round` (no callsites).
- **Kept:** `.pill.purp` — used by `traces/page.tsx` for the `decision` event tone.
- **Bug fix:** `.pill.accent` was referenced by the traces filter button row (`statusFilter === k ? "pill accent" : "pill muted"`) but never defined in CSS, so the active filter had no visual treatment. Added using the existing accent palette (orange-soft bg / orange fg / orange-tint border).

CSS net change: -5 lines, +missing rule. No callsite changes.

## Test plan
- [x] `npm run tokens:check` → clean
- [x] `npm test` → 24/24 pass
- [ ] Visual smoke `/traces`: active filter chip should now have an orange-tinted background instead of looking identical to inactive ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)