### PR TITLE
chore(dashboard): drop two unused exports

### DIFF
--- a/dashboard/src/app/api/connections/route.ts
+++ b/dashboard/src/app/api/connections/route.ts
@@ -3,16 +3,6 @@ import { bridgeFetch } from "@/lib/bridge";
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
-export interface ConnectorStatus {
-  id: string;
-  status: "connected" | "disconnected";
-  lastSync?: string;
-}
-
-export interface ConnectionsResponse {
-  connectors: ConnectorStatus[];
-}
-
 export async function GET(): Promise<Response> {
   try {
     const res = await bridgeFetch("/connections");

--- a/dashboard/src/components/Skeleton.tsx
+++ b/dashboard/src/components/Skeleton.tsx
@@ -62,19 +62,6 @@ export function SkeletonRow({ columns = 3 }: { columns?: number }) {
   );
 }
 
-export function SkeletonCard({ lines = 3 }: { lines?: number }) {
-  return (
-    <div className="card" aria-hidden="true" style={{ padding: 16 }}>
-      <SkeletonText width="40%" size="lg" />
-      <div style={{ marginTop: 12, display: "flex", flexDirection: "column", gap: 8 }}>
-        {Array.from({ length: lines }).map((_, i) => (
-          <SkeletonText key={i} width={`${100 - i * 12}%`} size="sm" />
-        ))}
-      </div>
-    </div>
-  );
-}
-
 export function SkeletonList({ rows = 4, columns = 3 }: { rows?: number; columns?: number }) {
   return (
     <div className="card" aria-hidden="true" style={{ padding: 0, overflow: "hidden" }}>


### PR DESCRIPTION
## Summary
Audited every named export in `dashboard/src/` for cross-file usage. Two were truly dead — declared with zero references anywhere, including their own file.

- **`SkeletonCard`** in `src/components/Skeleton.tsx` — no callers, no test. Other Skeleton helpers (`Skeleton`, `SkeletonText`, `SkeletonStatCard`, `SkeletonRow`, `SkeletonList`) kept.
- **`ConnectionsResponse` + `ConnectorStatus`** in `src/app/api/connections/route.ts` — defined but never imported. Three callsites (`AddConnectionModal`, `connections/page.tsx`, `ConnectorHealthPanel`) each declare a local copy of `ConnectorStatus` instead — deduping those is left as a follow-up; orthogonal concern.

## Test plan
- [x] `npm run tokens:check` → clean
- [x] `npm test` → 24/24 pass
- [x] `tsc --noEmit` clean (no broken imports)

🤖 Generated with [Claude Code](https://claude.com/claude-code)