### PR TITLE
refactor(dashboard): dedupe ConnectorStatus + rename clashing health type

### DIFF
--- a/dashboard/src/app/connections/AddConnectionModal.tsx
+++ b/dashboard/src/app/connections/AddConnectionModal.tsx
@@ -2,12 +2,7 @@
 import { useState } from "react";
 import { apiPath } from "@/lib/api";
 import { Dialog } from "@/components/Dialog";
-
-interface ConnectorStatus {
-  id: string;
-  status: "connected" | "disconnected" | "needs_reauth";
-  lastSync?: string;
-}
+import type { ConnectorStatus } from "./types";
 
 interface ProviderDef {
   id: string;

--- a/dashboard/src/app/connections/page.tsx
+++ b/dashboard/src/app/connections/page.tsx
@@ -3,12 +3,7 @@ import { useEffect, useRef, useState } from "react";
 import { apiPath } from "@/lib/api";
 import AddConnectionModal from "./AddConnectionModal";
 import { Dialog } from "@/components/Dialog";
-
-interface ConnectorStatus {
-  id: string;
-  status: "connected" | "disconnected" | "needs_reauth";
-  lastSync?: string;
-}
+import type { ConnectorStatus } from "./types";
 
 // ------------------------------------------------------------------ helpers
 

--- a/dashboard/src/app/connections/types.ts
+++ b/dashboard/src/app/connections/types.ts
@@ -1,0 +1,5 @@
+export interface ConnectorStatus {
+  id: string;
+  status: "connected" | "disconnected" | "needs_reauth";
+  lastSync?: string;
+}

--- a/dashboard/src/components/ConnectorHealthPanel.tsx
+++ b/dashboard/src/components/ConnectorHealthPanel.tsx
@@ -4,13 +4,13 @@ import Link from "next/link";
 import { useEffect, useState } from "react";
 import { apiPath } from "@/lib/api";
 
-interface ConnectorStatus {
+interface ConnectorHealth {
   name: string;
   status: "connected" | "degraded" | "error" | "missing" | string;
   message?: string;
 }
 
-type StatusMap = Record<string, ConnectorStatus>;
+type StatusMap = Record<string, ConnectorHealth>;
 type DotColor = "green" | "yellow" | "red" | "gray";
 
 function resolveColor(status: string | undefined): DotColor {
@@ -67,14 +67,14 @@ export function ConnectorHealthPanel({ connectors, marginTop }: Props) {
         return;
       }
       const data = (await res.json()) as
-        | ConnectorStatus[]
-        | { connectors?: ConnectorStatus[] };
-      const list: ConnectorStatus[] = Array.isArray(data)
+        | ConnectorHealth[]
+        | { connectors?: ConnectorHealth[] };
+      const list: ConnectorHealth[] = Array.isArray(data)
         ? data
         : Array.isArray(
-              (data as { connectors?: ConnectorStatus[] }).connectors,
+              (data as { connectors?: ConnectorHealth[] }).connectors,
             )
-          ? (data as { connectors: ConnectorStatus[] }).connectors
+          ? (data as { connectors: ConnectorHealth[] }).connectors
           : [];
       const map: StatusMap = {};
       for (const c of list) {


### PR DESCRIPTION
## Summary
Two distinct shapes were sharing the name `ConnectorStatus`:

1. **User-connection status** — `{id, status: "connected"|"disconnected"|"needs_reauth", lastSync?}`. Declared as a duplicate local copy in both `connections/page.tsx` and `connections/AddConnectionModal.tsx`. **Extracted** to `src/app/connections/types.ts` and imported in both.

2. **Bridge connector health** — `{name, status: "connected"|"degraded"|"error"|"missing"|string, message?}`. Declared in `ConnectorHealthPanel.tsx`. Different field names (`name` vs `id`), different status enum, different optional field — wholly unrelated to (1) despite the shared name. **Renamed** to `ConnectorHealth` to match the component's purpose and remove the false equivalence.

Follow-up to #230 (which deleted the dead `ConnectorStatus` export from `api/connections/route.ts`).

## Test plan
- [x] `npx tsc --noEmit` → clean
- [x] `npm test` → 24/24 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)