### PR TITLE
test(dashboard): unit tests for demoMode + demoModeServer

### DIFF
--- a/dashboard/src/lib/__tests__/demoMode.test.ts
+++ b/dashboard/src/lib/__tests__/demoMode.test.ts
@@ -1,0 +1,123 @@
+/** @vitest-environment jsdom */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  isDemoMode,
+  onDemoModeChange,
+  setDemoMode,
+} from "@/lib/demoMode";
+
+const ORIGINAL_ENV = process.env.NEXT_PUBLIC_DEMO_MODE;
+
+beforeEach(() => {
+  localStorage.clear();
+  // jsdom sets a default cookie store — wipe it via expiry to keep tests
+  // independent of one another.
+  document.cookie = "pw-demo=; path=/; max-age=0";
+  delete process.env.NEXT_PUBLIC_DEMO_MODE;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  if (ORIGINAL_ENV === undefined) {
+    delete process.env.NEXT_PUBLIC_DEMO_MODE;
+  } else {
+    process.env.NEXT_PUBLIC_DEMO_MODE = ORIGINAL_ENV;
+  }
+});
+
+describe("isDemoMode (browser)", () => {
+  it("returns false by default (no localStorage, no env var)", () => {
+    expect(isDemoMode()).toBe(false);
+  });
+
+  it("returns true when localStorage has 'true'", () => {
+    localStorage.setItem("pw-demo", "true");
+    expect(isDemoMode()).toBe(true);
+  });
+
+  it("localStorage 'false' wins over env var 'true'", () => {
+    // The cookie/localStorage flag is the user's explicit override and
+    // must beat the build-time env default — pin that precedence.
+    process.env.NEXT_PUBLIC_DEMO_MODE = "true";
+    localStorage.setItem("pw-demo", "false");
+    expect(isDemoMode()).toBe(false);
+  });
+
+  it("falls back to env var when localStorage is unset", () => {
+    process.env.NEXT_PUBLIC_DEMO_MODE = "true";
+    expect(isDemoMode()).toBe(true);
+  });
+
+  it("treats env vars other than the literal 'true' string as false", () => {
+    process.env.NEXT_PUBLIC_DEMO_MODE = "1";
+    expect(isDemoMode()).toBe(false);
+    process.env.NEXT_PUBLIC_DEMO_MODE = "TRUE";
+    expect(isDemoMode()).toBe(false);
+  });
+});
+
+describe("setDemoMode", () => {
+  it("writes the flag to localStorage, sets a cookie, dispatches the event, and reloads", () => {
+    const dispatchSpy = vi.spyOn(window, "dispatchEvent");
+    // window.location.reload is non-configurable on jsdom — replace the
+    // whole `location` object with a stub so we can observe the call
+    // without actually reloading the test runner's frame.
+    const reload = vi.fn();
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: { reload, href: "http://test/" },
+    });
+
+    setDemoMode(true);
+
+    expect(localStorage.getItem("pw-demo")).toBe("true");
+    expect(document.cookie).toContain("pw-demo=true");
+    expect(dispatchSpy).toHaveBeenCalledWith(expect.any(CustomEvent));
+    const ev = dispatchSpy.mock.calls[0]![0] as CustomEvent<boolean>;
+    expect(ev.type).toBe("pw-demo-change");
+    expect(ev.detail).toBe(true);
+    expect(reload).toHaveBeenCalledOnce();
+  });
+
+  it("writes 'false' on disable", () => {
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: { reload: vi.fn(), href: "http://test/" },
+    });
+    setDemoMode(false);
+    expect(localStorage.getItem("pw-demo")).toBe("false");
+    expect(document.cookie).toContain("pw-demo=false");
+  });
+});
+
+describe("onDemoModeChange", () => {
+  it("invokes the listener with the new value when the event fires", () => {
+    const listener = vi.fn();
+    onDemoModeChange(listener);
+    window.dispatchEvent(new CustomEvent("pw-demo-change", { detail: true }));
+    expect(listener).toHaveBeenCalledExactlyOnceWith(true);
+  });
+
+  it("returns an unsubscribe fn that removes the listener", () => {
+    const listener = vi.fn();
+    const off = onDemoModeChange(listener);
+    off();
+    window.dispatchEvent(new CustomEvent("pw-demo-change", { detail: true }));
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it("supports multiple subscribers independently", () => {
+    const a = vi.fn();
+    const b = vi.fn();
+    const offA = onDemoModeChange(a);
+    onDemoModeChange(b);
+    window.dispatchEvent(new CustomEvent("pw-demo-change", { detail: false }));
+    expect(a).toHaveBeenCalledExactlyOnceWith(false);
+    expect(b).toHaveBeenCalledExactlyOnceWith(false);
+    offA();
+    window.dispatchEvent(new CustomEvent("pw-demo-change", { detail: true }));
+    // a unsubscribed; b still active
+    expect(a).toHaveBeenCalledOnce();
+    expect(b).toHaveBeenCalledTimes(2);
+  });
+});

--- a/dashboard/src/lib/__tests__/demoModeServer.test.ts
+++ b/dashboard/src/lib/__tests__/demoModeServer.test.ts
@@ -1,0 +1,84 @@
+/** @vitest-environment node */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// `next/headers` only works inside a request lifecycle, so we mock the
+// `cookies()` helper. The `cookies` export is the function under test;
+// each case overrides its behavior.
+let cookieStore: Map<string, { value: string }> | { throws: true };
+
+vi.mock("next/headers", () => ({
+  cookies: () => {
+    if (
+      typeof cookieStore === "object" &&
+      "throws" in cookieStore &&
+      cookieStore.throws
+    ) {
+      throw new Error("called outside request context");
+    }
+    const map = cookieStore as Map<string, { value: string }>;
+    return {
+      get: (k: string) => map.get(k),
+    };
+  },
+}));
+
+import { isDemoModeServer } from "@/lib/demoModeServer";
+
+const ORIGINAL_ENV = process.env.NEXT_PUBLIC_DEMO_MODE;
+
+beforeEach(() => {
+  cookieStore = new Map();
+  delete process.env.NEXT_PUBLIC_DEMO_MODE;
+});
+
+afterEach(() => {
+  if (ORIGINAL_ENV === undefined) {
+    delete process.env.NEXT_PUBLIC_DEMO_MODE;
+  } else {
+    process.env.NEXT_PUBLIC_DEMO_MODE = ORIGINAL_ENV;
+  }
+});
+
+describe("isDemoModeServer", () => {
+  it("returns false by default (no cookie, no env var)", () => {
+    expect(isDemoModeServer()).toBe(false);
+  });
+
+  it("returns true when the pw-demo cookie is 'true'", () => {
+    (cookieStore as Map<string, { value: string }>).set("pw-demo", {
+      value: "true",
+    });
+    expect(isDemoModeServer()).toBe(true);
+  });
+
+  it("cookie 'false' wins over env var 'true' (explicit user override)", () => {
+    process.env.NEXT_PUBLIC_DEMO_MODE = "true";
+    (cookieStore as Map<string, { value: string }>).set("pw-demo", {
+      value: "false",
+    });
+    expect(isDemoModeServer()).toBe(false);
+  });
+
+  it("falls back to env var when no cookie is set", () => {
+    process.env.NEXT_PUBLIC_DEMO_MODE = "true";
+    expect(isDemoModeServer()).toBe(true);
+  });
+
+  it("only accepts the literal 'true' env value (not '1' / 'TRUE')", () => {
+    process.env.NEXT_PUBLIC_DEMO_MODE = "1";
+    expect(isDemoModeServer()).toBe(false);
+    process.env.NEXT_PUBLIC_DEMO_MODE = "TRUE";
+    expect(isDemoModeServer()).toBe(false);
+  });
+
+  it("falls back to env var when cookies() throws (outside request context, e.g. build)", () => {
+    cookieStore = { throws: true };
+    process.env.NEXT_PUBLIC_DEMO_MODE = "true";
+    expect(isDemoModeServer()).toBe(true);
+  });
+
+  it("returns false when cookies() throws and env var is unset", () => {
+    cookieStore = { throws: true };
+    expect(isDemoModeServer()).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
17 vitest cases covering the client and server demo-mode flag helpers — previously untested.

**`demoMode.test.ts`** (jsdom):
- `isDemoMode` — default false; `localStorage 'true'` on; `localStorage 'false'` wins over env `'true'` (explicit override); env fallback when localStorage unset; only literal `'true'` is truthy.
- `setDemoMode` — writes `localStorage`; sets cookie; dispatches `pw-demo-change` `CustomEvent` with the boolean as `detail`; reloads. `window.location` is replaced with a stub so the reload call is observable without taking down the test runner frame.
- `onDemoModeChange` — listener called with new value; returned unsubscribe fn removes the listener; multiple subscribers are independent.

**`demoModeServer.test.ts`** (node, `next/headers` mocked):
- `isDemoModeServer` — default false; cookie `'true'` on; cookie `'false'` wins over env `'true'`; env fallback when no cookie; only literal `'true'` env is truthy; `cookies()` throw → falls back to env var (build-context safety), including the throw-and-no-env case.

Test count: **111 → 128**.

## Test plan
- [x] `npm test` → 12 files / 128 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)