### PR TITLE
feat(dashboard): live "Tokens burnt" from Claude Code JSONL transcripts

### DIFF
--- a/dashboard/src/app/page.tsx
+++ b/dashboard/src/app/page.tsx
@@ -21,6 +21,15 @@ import {
 // Types
 // ---------------------------------------------------------------------------
 
+interface TokenTotals {
+  input: number;
+  output: number;
+  cacheCreate: number;
+  cacheRead: number;
+  total: number;
+  messages: number;
+}
+
 interface BridgeHealth {
   status: string;
   uptimeMs: number;
@@ -28,6 +37,7 @@ interface BridgeHealth {
   extensionConnected: boolean;
   extensionVersion: string | null;
   activeSessions: number;
+  tokens?: TokenTotals;
 }
 
 interface Pending {
@@ -742,8 +752,18 @@ export default function HomePage() {
             />
             <StatCard
               label="Tokens burnt"
-              value="—"
-              foot={`${sess} session${sess === 1 ? "" : "s"} · ${conns} connection${conns === 1 ? "" : "s"}`}
+              value={
+                health?.tokens ? (
+                  <AnimatedNumber value={health.tokens.total} />
+                ) : (
+                  "—"
+                )
+              }
+              foot={
+                health?.tokens && health.tokens.messages > 0
+                  ? `${health.tokens.messages} msg${health.tokens.messages === 1 ? "" : "s"} · ${sess} session${sess === 1 ? "" : "s"}`
+                  : `${sess} session${sess === 1 ? "" : "s"} · ${conns} connection${conns === 1 ? "" : "s"}`
+              }
               href="/metrics"
             />
           </>

--- a/src/__tests__/tokenUsageTracker.test.ts
+++ b/src/__tests__/tokenUsageTracker.test.ts
@@ -1,0 +1,159 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  TokenUsageTracker,
+  workspaceToProjectSlug,
+} from "../tokenUsageTracker.js";
+
+function makeAssistantLine(opts: {
+  id: string;
+  input?: number;
+  output?: number;
+  cacheCreate?: number;
+  cacheRead?: number;
+}): string {
+  return (
+    JSON.stringify({
+      type: "assistant",
+      message: {
+        id: opts.id,
+        usage: {
+          input_tokens: opts.input ?? 0,
+          output_tokens: opts.output ?? 0,
+          cache_creation_input_tokens: opts.cacheCreate ?? 0,
+          cache_read_input_tokens: opts.cacheRead ?? 0,
+        },
+      },
+    }) + "\n"
+  );
+}
+
+describe("workspaceToProjectSlug", () => {
+  it("matches Claude Code's path encoding", () => {
+    expect(
+      workspaceToProjectSlug(
+        "/Users/wesh/Documents/Anthropic Workspace/Patchwork OS",
+      ),
+    ).toBe("-Users-wesh-Documents-Anthropic-Workspace-Patchwork-OS");
+  });
+});
+
+describe("TokenUsageTracker", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), "tokens-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  function newTracker(): TokenUsageTracker {
+    return new TokenUsageTracker({
+      workspace: "/x",
+      projectsDir: dir,
+      pollIntervalMs: 60_000,
+    });
+  }
+
+  it("returns zeros when projects dir is missing", () => {
+    const t = new TokenUsageTracker({
+      workspace: "/x",
+      projectsDir: path.join(dir, "missing"),
+    });
+    t.start();
+    expect(t.getTotals()).toEqual({
+      input: 0,
+      output: 0,
+      cacheCreate: 0,
+      cacheRead: 0,
+      total: 0,
+      messages: 0,
+    });
+    t.stop();
+  });
+
+  it("aggregates usage across files and dedupes by message.id", () => {
+    fs.writeFileSync(
+      path.join(dir, "a.jsonl"),
+      makeAssistantLine({ id: "msg_1", input: 10, output: 5 }) +
+        makeAssistantLine({ id: "msg_1", input: 10, output: 5 }) +
+        makeAssistantLine({ id: "msg_2", input: 3, output: 7, cacheRead: 100 }),
+    );
+    fs.writeFileSync(
+      path.join(dir, "b.jsonl"),
+      makeAssistantLine({ id: "msg_3", output: 2, cacheCreate: 50 }),
+    );
+    const t = newTracker();
+    t.start();
+    expect(t.getTotals()).toEqual({
+      input: 13,
+      output: 14,
+      cacheCreate: 50,
+      cacheRead: 100,
+      total: 27,
+      messages: 3,
+    });
+    t.stop();
+  });
+
+  it("ignores non-assistant lines and malformed JSON", () => {
+    fs.writeFileSync(
+      path.join(dir, "x.jsonl"),
+      JSON.stringify({ type: "user", message: { id: "u_1" } }) +
+        "\n" +
+        "not-json\n" +
+        makeAssistantLine({ id: "msg_a", input: 1, output: 2 }),
+    );
+    const t = newTracker();
+    t.start();
+    expect(t.getTotals().total).toBe(3);
+    expect(t.getTotals().messages).toBe(1);
+    t.stop();
+  });
+
+  it("incrementally picks up appended lines on subsequent scans", () => {
+    const file = path.join(dir, "live.jsonl");
+    fs.writeFileSync(
+      file,
+      makeAssistantLine({ id: "m1", input: 1, output: 1 }),
+    );
+    const t = new TokenUsageTracker({
+      workspace: "/x",
+      projectsDir: dir,
+      pollIntervalMs: 1_000_000,
+    });
+    t.start();
+    expect(t.getTotals().messages).toBe(1);
+
+    fs.appendFileSync(
+      file,
+      makeAssistantLine({ id: "m2", input: 4, output: 6 }),
+    );
+    // trigger a manual scan via private method through a fresh start cycle
+    t.stop();
+    t.start();
+    expect(t.getTotals()).toMatchObject({ input: 5, output: 7, messages: 2 });
+    t.stop();
+  });
+
+  it("handles partial trailing line written across two scans", () => {
+    const file = path.join(dir, "partial.jsonl");
+    const line = makeAssistantLine({ id: "m_p", input: 2, output: 3 });
+    const half = line.slice(0, line.length - 5);
+    fs.writeFileSync(file, half);
+    const t = newTracker();
+    t.start();
+    expect(t.getTotals().messages).toBe(0);
+
+    fs.writeFileSync(file, line);
+    t.stop();
+    t.start();
+    expect(t.getTotals().messages).toBe(1);
+    expect(t.getTotals().total).toBe(5);
+    t.stop();
+  });
+});

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -39,6 +39,7 @@ import { Server } from "./server.js";
 import { type CheckpointData, SessionCheckpoint } from "./sessionCheckpoint.js";
 import { StreamableHttpHandler } from "./streamableHttp.js";
 import { initTelemetry, shutdownTelemetry } from "./telemetry.js";
+import { TokenUsageTracker } from "./tokenUsageTracker.js";
 import { createCtxQueryTracesTool } from "./tools/ctxQueryTraces.js";
 import { readNote, writeNote } from "./tools/handoffNote.js";
 import { registerAllTools } from "./tools/index.js";
@@ -158,6 +159,7 @@ export class Bridge {
   /** ISO timestamp of last getProjectContext cache write — drives status-bar "context X min ago". */
   private _lastContextCachedAt: string | null = null;
   private wsHeartbeatInterval: ReturnType<typeof setInterval> | null = null;
+  private tokenUsageTracker: TokenUsageTracker;
 
   constructor(private config: Config) {
     this.logger = new Logger(config.verbose, config.jsonl);
@@ -181,6 +183,10 @@ export class Bridge {
       this.logger.info(`Audit log: ${config.auditLogPath}`);
     }
     this.extensionClient = new ExtensionClient(this.logger);
+    this.tokenUsageTracker = new TokenUsageTracker({
+      workspace: config.workspace,
+      logger: { warn: (m) => this.logger.warn(m) },
+    });
 
     // Handle new Claude Code connections
     this.server.on("connection", async (ws: WebSocket) => {
@@ -882,6 +888,8 @@ export class Bridge {
     this.probes = await probeAll(this.config.workspace);
     this.ready = true;
 
+    this.tokenUsageTracker.start();
+
     // 2. Load plugins (after probes, before accepting sessions)
     this.pluginTools = await loadPlugins(
       this.config.plugins,
@@ -1075,6 +1083,7 @@ export class Bridge {
         extensionCircuitBreaker: this.extensionClient.getCircuitBreakerState(),
         extensionDisconnectCount: this.extensionDisconnectCount,
         recentActivity: this.activityLog.query({ last: 10 }),
+        tokens: this.tokenUsageTracker.getTotals(),
       };
     };
     this.server.metricsFn = () =>
@@ -1719,6 +1728,7 @@ export class Bridge {
     this.stopped = true;
     this.logger.info("Shutting down...");
     this._stopPeriodicSnapshots();
+    this.tokenUsageTracker.stop();
     this.automationHooks?.destroy();
     this.recipeScheduler?.stop();
     this.recipeScheduler = null;

--- a/src/tokenUsageTracker.ts
+++ b/src/tokenUsageTracker.ts
@@ -1,0 +1,164 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+export interface TokenTotals {
+  input: number;
+  output: number;
+  cacheCreate: number;
+  cacheRead: number;
+  total: number;
+  messages: number;
+}
+
+export interface TokenUsageTrackerOptions {
+  workspace: string;
+  projectsDir?: string;
+  pollIntervalMs?: number;
+  logger?: { warn: (msg: string) => void };
+}
+
+interface FileState {
+  offset: number;
+  partial: string;
+}
+
+export function workspaceToProjectSlug(workspace: string): string {
+  return workspace.replace(/[^a-zA-Z0-9]+/g, "-");
+}
+
+export class TokenUsageTracker {
+  private readonly projectsDir: string;
+  private readonly pollIntervalMs: number;
+  private readonly logger?: { warn: (msg: string) => void };
+  private readonly files = new Map<string, FileState>();
+  private readonly seenMessageIds = new Set<string>();
+  private totals: TokenTotals = {
+    input: 0,
+    output: 0,
+    cacheCreate: 0,
+    cacheRead: 0,
+    total: 0,
+    messages: 0,
+  };
+  private timer: NodeJS.Timeout | null = null;
+
+  constructor(opts: TokenUsageTrackerOptions) {
+    const slug = workspaceToProjectSlug(opts.workspace);
+    this.projectsDir =
+      opts.projectsDir ?? path.join(os.homedir(), ".claude", "projects", slug);
+    this.pollIntervalMs = opts.pollIntervalMs ?? 5000;
+    this.logger = opts.logger;
+  }
+
+  start(): void {
+    if (this.timer) return;
+    this.scan();
+    this.timer = setInterval(() => this.scan(), this.pollIntervalMs);
+    this.timer.unref?.();
+  }
+
+  stop(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+
+  getTotals(): TokenTotals {
+    return { ...this.totals };
+  }
+
+  private scan(): void {
+    let entries: string[];
+    try {
+      entries = fs.readdirSync(this.projectsDir);
+    } catch {
+      return;
+    }
+    for (const name of entries) {
+      if (!name.endsWith(".jsonl")) continue;
+      const full = path.join(this.projectsDir, name);
+      this.readDelta(full);
+    }
+  }
+
+  private readDelta(filePath: string): void {
+    let stat: fs.Stats;
+    try {
+      stat = fs.statSync(filePath);
+    } catch {
+      return;
+    }
+    const state = this.files.get(filePath) ?? { offset: 0, partial: "" };
+    if (stat.size < state.offset) {
+      // truncated/rotated — restart from beginning
+      state.offset = 0;
+      state.partial = "";
+    }
+    if (stat.size === state.offset) {
+      this.files.set(filePath, state);
+      return;
+    }
+    let chunk: Buffer;
+    try {
+      const fd = fs.openSync(filePath, "r");
+      try {
+        const len = stat.size - state.offset;
+        chunk = Buffer.alloc(len);
+        fs.readSync(fd, chunk, 0, len, state.offset);
+      } finally {
+        fs.closeSync(fd);
+      }
+    } catch (err) {
+      this.logger?.warn(
+        `[tokens] read failed ${filePath}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      return;
+    }
+    const text = state.partial + chunk.toString("utf8");
+    const lines = text.split("\n");
+    state.partial = lines.pop() ?? "";
+    state.offset = stat.size;
+    for (const line of lines) {
+      if (!line.trim()) continue;
+      this.ingestLine(line);
+    }
+    this.files.set(filePath, state);
+  }
+
+  private ingestLine(line: string): void {
+    let obj: unknown;
+    try {
+      obj = JSON.parse(line);
+    } catch {
+      return;
+    }
+    if (!obj || typeof obj !== "object") return;
+    const o = obj as Record<string, unknown>;
+    if (o.type !== "assistant") return;
+    const message = o.message as Record<string, unknown> | undefined;
+    if (!message) return;
+    const id = typeof message.id === "string" ? message.id : null;
+    if (!id || this.seenMessageIds.has(id)) return;
+    const usage = message.usage as Record<string, unknown> | undefined;
+    if (!usage) return;
+    const input = numField(usage, "input_tokens");
+    const output = numField(usage, "output_tokens");
+    const cacheCreate = numField(usage, "cache_creation_input_tokens");
+    const cacheRead = numField(usage, "cache_read_input_tokens");
+    if (input + output + cacheCreate + cacheRead === 0) return;
+    this.seenMessageIds.add(id);
+    this.totals.input += input;
+    this.totals.output += output;
+    this.totals.cacheCreate += cacheCreate;
+    this.totals.cacheRead += cacheRead;
+    this.totals.total = this.totals.input + this.totals.output;
+    this.totals.messages += 1;
+  }
+}
+
+function numField(obj: Record<string, unknown>, key: string): number {
+  const v = obj[key];
+  return typeof v === "number" && Number.isFinite(v) ? v : 0;
+}


### PR DESCRIPTION
## Summary

The "Tokens burnt" StatCard on the dashboard rendered a hardcoded em-dash. The bridge had no path to LLM usage data because it dispatches Claude's tool calls — it doesn't drive the Anthropic API. Real billing-grade usage lives in `~/.claude/projects/<workspace-slug>/*.jsonl`, where Claude Code writes every assistant message with its full `usage` block.

- New `TokenUsageTracker` (`src/tokenUsageTracker.ts`) tails those JSONL files: 5 s poll, incremental reads with partial-line stitching, file rotation handling, dedupes by `message.id`. Aggregates `input`, `output`, `cache_creation`, `cache_read`.
- Wired into `Bridge.healthDataFn` so the existing `/health` → dashboard polling path surfaces `tokens` unchanged.
- `dashboard/src/app/page.tsx`: card now renders `<AnimatedNumber value={tokens.total} />` with a `N msgs · K sessions` foot, falls back to `—` until the first message lands.

Total is `input + output` only (cache reads aren't billed at full rate). The full breakdown is on the wire for a future tooltip.

Verified end-to-end: bridge restarted with the new build, dashboard card flipped from `—` to `7,950,472` (21,943 messages) within seconds.

## Test plan

- [x] `vitest run src/__tests__/tokenUsageTracker.test.ts` — 6 tests passing (slug encoding, missing dir, dedup, malformed JSON, incremental tail, partial-line stitching)
- [x] `tsc --noEmit` clean on bridge and dashboard
- [x] `biome check` clean on changed files
- [x] Manual: `/health` returns populated `tokens` object after restart
- [x] Manual: dashboard card shows live number, ticks up as new assistant messages land

🤖 Generated with [Claude Code](https://claude.com/claude-code)