### PR TITLE
test(dashboard): tests for all 7 OAuth callback routes

### DIFF
--- a/dashboard/src/app/api/connections/__tests__/oauth-callbacks.test.ts
+++ b/dashboard/src/app/api/connections/__tests__/oauth-callbacks.test.ts
@@ -1,0 +1,107 @@
+/** @vitest-environment node */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// All 7 OAuth callback routes proxy through bridgeFetch with an
+// allowlisted query string. Mock once and parameterize over the routes.
+const bridgeFetchMock = vi.fn();
+vi.mock("@/lib/bridge", () => ({
+  bridgeFetch: (...args: unknown[]) => bridgeFetchMock(...args),
+}));
+
+import { GET as gmailCallback } from "../gmail/callback/route";
+import { GET as asanaCallback } from "../asana/callback/route";
+import { GET as discordCallback } from "../discord/callback/route";
+import { GET as gitlabCallback } from "../gitlab/callback/route";
+import { GET as slackCallback } from "../slack/callback/route";
+import { GET as gcalCallback } from "../google-calendar/callback/route";
+import { GET as gdriveCallback } from "../google-drive/callback/route";
+
+type Handler = (req: Request) => Promise<Response>;
+
+const ROUTES: { name: string; bridgePath: string; handler: Handler }[] = [
+  { name: "gmail",            bridgePath: "/connections/gmail/callback",            handler: gmailCallback },
+  { name: "asana",            bridgePath: "/connections/asana/callback",            handler: asanaCallback },
+  { name: "discord",          bridgePath: "/connections/discord/callback",          handler: discordCallback },
+  { name: "gitlab",           bridgePath: "/connections/gitlab/callback",           handler: gitlabCallback },
+  { name: "slack",            bridgePath: "/connections/slack/callback",            handler: slackCallback },
+  { name: "google-calendar",  bridgePath: "/connections/google-calendar/callback",  handler: gcalCallback },
+  { name: "google-drive",     bridgePath: "/connections/google-drive/callback",     handler: gdriveCallback },
+];
+
+beforeEach(() => {
+  bridgeFetchMock.mockReset();
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function reqWithQuery(query: string): Request {
+  return new Request(`https://dashboard.local/cb?${query}`);
+}
+
+describe.each(ROUTES)("$name OAuth callback", ({ bridgePath, handler }) => {
+  it(`forwards code+state to ${bridgePath} and passes status + body through`, async () => {
+    bridgeFetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    const res = await handler(reqWithQuery("code=abc123&state=nonce"));
+    expect(bridgeFetchMock).toHaveBeenCalledOnce();
+    const [calledPath] = bridgeFetchMock.mock.calls[0]!;
+    expect(calledPath).toContain(bridgePath);
+    expect(calledPath).toContain("code=abc123");
+    expect(calledPath).toContain("state=nonce");
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+  });
+
+  it("forwards an error param when the provider denied the request", async () => {
+    bridgeFetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ ok: false }), {
+        status: 400,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    const res = await handler(reqWithQuery("error=access_denied&state=x"));
+    const [calledPath] = bridgeFetchMock.mock.calls[0]!;
+    expect(calledPath).toContain("error=access_denied");
+    expect(calledPath).toContain("state=x");
+    expect(res.status).toBe(400);
+  });
+
+  it("strips unallowed query params (only code/state/error reach the bridge)", async () => {
+    // Allowlist matters — without it, an attacker could inject arbitrary
+    // query params (e.g. ?bridge_secret=...) into the upstream call.
+    bridgeFetchMock.mockResolvedValueOnce(new Response("", { status: 200 }));
+    await handler(
+      reqWithQuery("code=ok&utm_source=phish&bridge_secret=oops&state=s"),
+    );
+    const [calledPath] = bridgeFetchMock.mock.calls[0]!;
+    expect(calledPath).toContain("code=ok");
+    expect(calledPath).toContain("state=s");
+    expect(calledPath).not.toContain("utm_source");
+    expect(calledPath).not.toContain("bridge_secret");
+  });
+
+  it("502s with the error message when bridgeFetch throws", async () => {
+    bridgeFetchMock.mockRejectedValueOnce(new Error("connection reset"));
+    const res = await handler(reqWithQuery("code=x"));
+    expect(res.status).toBe(502);
+    expect(await res.json()).toEqual({ error: "connection reset" });
+  });
+
+  it("passes a 5xx response from the bridge through with body + status", async () => {
+    bridgeFetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: "exchange failed" }), {
+        status: 500,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    const res = await handler(reqWithQuery("code=x&state=y"));
+    expect(res.status).toBe(500);
+    expect(await res.json()).toEqual({ error: "exchange failed" });
+  });
+});


### PR DESCRIPTION
## Summary
35 vitest cases (5 × 7 connectors) for the OAuth callback handlers under `src/app/api/connections/<connector>/callback`: gmail, asana, discord, gitlab, slack, google-calendar, google-drive.

All 7 routes have identical structure (parse `code`/`state`/`error` from the query string, allowlist them, forward to bridge), so the tests use `describe.each()` over a route table instead of duplicating the suite.

**Coverage (per connector):**
- Forwards `code` + `state` to `/connections/<id>/callback`; status + body passed through.
- Forwards `error` param when the provider denied the request.
- **Strips un-allowed query params** — pinned because without the allowlist an attacker could inject arbitrary params into the upstream call (`utm_source`, `bridge_secret`, …).
- `bridgeFetch` throw → 502 with `err.message`.
- 5xx from bridge → status + body passed through unchanged.

Test count: **206 → 241**.

## Heads-up
There's a stash on this checkout (`stash@{0}: tokens-tooltip-WIP`) holding an unrelated `title`-tooltip change to `StatCard`/`GlassCard`/`page.tsx`. Got bundled into my initial commit by accident; I split it back out. Recover with `git stash pop stash@{0}` if you want to keep that work — I left it untouched.

## Test plan
- [x] `npm test` → 19 files / 241 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)