### PR TITLE
feat(dashboard): hover-tooltip breakdown on Tokens burnt card

### DIFF
--- a/dashboard/src/app/page.tsx
+++ b/dashboard/src/app/page.tsx
@@ -764,6 +764,11 @@ export default function HomePage() {
                   ? `${health.tokens.messages} msg${health.tokens.messages === 1 ? "" : "s"} · ${sess} session${sess === 1 ? "" : "s"}`
                   : `${sess} session${sess === 1 ? "" : "s"} · ${conns} connection${conns === 1 ? "" : "s"}`
               }
+              title={
+                health?.tokens
+                  ? `Input: ${health.tokens.input.toLocaleString()}\nOutput: ${health.tokens.output.toLocaleString()}\nCache create: ${health.tokens.cacheCreate.toLocaleString()}\nCache read: ${health.tokens.cacheRead.toLocaleString()}\nMessages: ${health.tokens.messages.toLocaleString()}`
+                  : undefined
+              }
               href="/metrics"
             />
           </>

--- a/dashboard/src/components/GlassCard.tsx
+++ b/dashboard/src/components/GlassCard.tsx
@@ -12,6 +12,7 @@ interface GlassCardProps {
    */
   padding?: string;
   style?: CSSProperties;
+  title?: string;
 }
 
 export function GlassCard({
@@ -20,6 +21,7 @@ export function GlassCard({
   hover = true,
   padding = "var(--s-5)",
   style,
+  title,
 }: GlassCardProps) {
   const classes = [
     "glass-card",
@@ -34,7 +36,7 @@ export function GlassCard({
     : { ...style };
 
   return (
-    <div className={classes} style={merged}>
+    <div className={classes} style={merged} title={title}>
       {children}
     </div>
   );

--- a/dashboard/src/components/StatCard.tsx
+++ b/dashboard/src/components/StatCard.tsx
@@ -12,6 +12,8 @@ interface StatCardProps {
   foot?: React.ReactNode;
   href?: string;
   className?: string;
+  /** Native tooltip shown on hover. Newlines are preserved by browsers. */
+  title?: string;
 }
 
 function DeltaBadge({ delta }: { delta: string }) {
@@ -107,6 +109,7 @@ export function StatCard({
   foot,
   href,
   className,
+  title,
 }: StatCardProps) {
   const inner = (
     <CardInner
@@ -120,7 +123,11 @@ export function StatCard({
 
   if (href) {
     return (
-      <Link href={href} style={{ display: "block", textDecoration: "none", color: "inherit" }}>
+      <Link
+        href={href}
+        title={title}
+        style={{ display: "block", textDecoration: "none", color: "inherit" }}
+      >
         <GlassCard className={`stat-card ${className ?? ""}`.trim()}>
           {inner}
         </GlassCard>
@@ -129,7 +136,10 @@ export function StatCard({
   }
 
   return (
-    <GlassCard className={`stat-card ${className ?? ""}`.trim()}>
+    <GlassCard
+      className={`stat-card ${className ?? ""}`.trim()}
+      title={title}
+    >
       {inner}
     </GlassCard>
   );


### PR DESCRIPTION
## Summary
The `/health` endpoint already exposes the full token breakdown (`input` / `output` / `cache_create` / `cache_read` / `messages`) but the StatCard surfaced only the headline total. Adds a `title` prop to `StatCard` + `GlassCard` so hovering the card reveals the line-by-line breakdown via a native browser tooltip — no new component, no JS positioning, accessible by default.

Verified live earlier with Playwright:
- Card text: `Tokens burnt 7,972,971 21985 msgs · 0 sessions`
- Tooltip: `Input: 91,838 · Output: 7,881,222 · Cache create: 47,369,408 · Cache read: 3,859,145,525 · Messages: 21,985`

## Background
Recovered from `stash@{0}` after a prior session accidentally interleaved this work with PR #246 (OAuth-callback tests). Branch named `*-v2` because an empty `feat/dashboard-tokens-tooltip` branch from that incident still exists on origin and should be deleted as a follow-up.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm test` → 18 files / 206 tests pass (no test changes; verifying no regressions)
- [ ] Visual smoke: hover the card on `/`, confirm native browser tooltip shows the 5-line breakdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)