### PR TITLE
fix(dashboard): minimalist Tokens burnt card foot

### DIFF
--- a/dashboard/src/app/page.tsx
+++ b/dashboard/src/app/page.tsx
@@ -761,8 +761,8 @@ export default function HomePage() {
               }
               foot={
                 health?.tokens && health.tokens.messages > 0
-                  ? `${health.tokens.messages} msg${health.tokens.messages === 1 ? "" : "s"} · ${sess} session${sess === 1 ? "" : "s"}`
-                  : `${sess} session${sess === 1 ? "" : "s"} · ${conns} connection${conns === 1 ? "" : "s"}`
+                  ? `${health.tokens.messages.toLocaleString()} msg${health.tokens.messages === 1 ? "" : "s"}`
+                  : undefined
               }
               title={
                 health?.tokens


### PR DESCRIPTION
## Summary
Two issues on the home StatCard for "Tokens burnt":

1. **Missing thousands separator** — `22026 msgs` vs the rest of the page using `toLocaleString()`. Now: `22,026 msgs`.
2. **Phantom `· 0 sessions`** — the suffix was reading `health.activeSessions` (live bridge sessions), not anything from `tokens` (which doesn't expose a sessions count). Conflating system stats with token stats. The no-tokens fallback was even worse — it dragged in `connections` too. Removed both: when tokens are present, show only the message count; otherwise no foot.

## Verified live (Playwright + dev hot-reload)

**Before:**
```
Tokens burnt
7,997,654
22026 msgs · 0 sessions
```

**After:**
```
Tokens burnt
8,001,510
22,035 msgs
```

## Test plan
- [x] `npx tsc --noEmit` clean (caught the original misuse — `tokens.sessions` doesn't exist on `TokenTotals`, which was the latent bug behind the always-zero suffix)
- [x] `npm test` → 19 files / 241 tests pass
- [x] Visual smoke via Playwright on localhost:3200

🤖 Generated with [Claude Code](https://claude.com/claude-code)