### PR TITLE
fix(recipes): demo+live dogfood findings (3 PR-original bugs + 4 audit followups)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ dist/
 # Old design mockups / local archives
 patchwork 2.0/
 patchwork 2.0.zip
+
+# Patchwork runtime output (recipe artifacts, daily status, etc.)
+.patchwork/
 *.tsbuildinfo
 vscode-extension/out/
 vscode-extension/*.vsix

--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -8,6 +8,14 @@
       "name": "patchwork-dashboard",
       "version": "0.1.0-alpha.0",
       "dependencies": {
+        "@codemirror/commands": "^6.10.3",
+        "@codemirror/lang-yaml": "^6.1.3",
+        "@codemirror/language": "^6.12.3",
+        "@codemirror/lint": "^6.9.6",
+        "@codemirror/state": "^6.6.0",
+        "@codemirror/theme-one-dark": "^6.1.3",
+        "@codemirror/view": "^6.42.0",
+        "codemirror": "^6.0.2",
         "next": "^14.2.0",
         "react": "^18.3.0",
         "react-dom": "^18.3.0",
@@ -136,6 +144,114 @@
       },
       "bin": {
         "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@codemirror/autocomplete": {
+      "version": "6.20.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.20.2.tgz",
+      "integrity": "sha512-G5FPkgIiLjOgZMjqVjvuKQ1rGPtHogLldJr33eFJdVLtmwY+giGrlv/ewljLz6b9BSQLkjxuwBc6g6omDM+YxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/commands": {
+      "version": "6.10.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.10.3.tgz",
+      "integrity": "sha512-JFRiqhKu+bvSkDLI+rUhJwSxQxYb759W5GBezE8Uc8mHLqC9aV/9aTC7yJSqCtB3F00pylrLCwnyS91Ap5ej4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.6.0",
+        "@codemirror/view": "^6.27.0",
+        "@lezer/common": "^1.1.0"
+      }
+    },
+    "node_modules/@codemirror/lang-yaml": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-yaml/-/lang-yaml-6.1.3.tgz",
+      "integrity": "sha512-AZ8DJBuXGVHybpBQhmZtgew5//4hv3tdkXnr3vDmOUMJRuB6vn/uuwtmTOTlqEaQFg3hQSVeA90NmvIQyUV6FQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.2.0",
+        "@lezer/lr": "^1.0.0",
+        "@lezer/yaml": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/language": {
+      "version": "6.12.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.3.tgz",
+      "integrity": "sha512-QwCZW6Tt1siP37Jet9Tb02Zs81TQt6qQrZR2H+eGMcFsL1zMrk2/b9CLC7/9ieP1fjIUMgviLWMmgiHoJrj+ZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.23.0",
+        "@lezer/common": "^1.5.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0",
+        "style-mod": "^4.0.0"
+      }
+    },
+    "node_modules/@codemirror/lint": {
+      "version": "6.9.6",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.6.tgz",
+      "integrity": "sha512-6Kp7r6XfCi/D/5sdXieMfg9pJU1bUEx96WITuLU6ESaKizCz0QHFMjY/TaFSbigDdEAIgi93itLBIUETP4oK+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.42.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/search": {
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.7.0.tgz",
+      "integrity": "sha512-ZvGm99wc/s2cITtMT15LFdn8aH/aS+V+DqyGq/N5ZlV5vWtH+nILvC2nw0zX7ByNoHHDZ2IxxdW38O0tc5nVHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.37.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/state": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.6.0.tgz",
+      "integrity": "sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@marijn/find-cluster-break": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/theme-one-dark": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/theme-one-dark/-/theme-one-dark-6.1.3.tgz",
+      "integrity": "sha512-NzBdIvEJmx6fjeremiGp3t/okrLPYT0d9orIc7AFun8oZcRk58aejkqhv6spnz4MLAevrKNPMQYXEWMg4s+sKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/highlight": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/view": {
+      "version": "6.42.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.42.0.tgz",
+      "integrity": "sha512-+PJEyndSCrsS2oLH3DfWoLBcF3xfeyGXtLnpXqHY01kL3TogyCLD12hNvSu73ww2KFftrx3Rd0nGOigbSkU3Hw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.6.0",
+        "crelt": "^1.0.6",
+        "style-mod": "^4.1.0",
+        "w3c-keyname": "^2.2.4"
       }
     },
     "node_modules/@csstools/color-helpers": {
@@ -335,6 +451,47 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@lezer/common": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.2.tgz",
+      "integrity": "sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==",
+      "license": "MIT"
+    },
+    "node_modules/@lezer/highlight": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.3.tgz",
+      "integrity": "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/lr": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.10.tgz",
+      "integrity": "sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/yaml": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@lezer/yaml/-/yaml-1.0.4.tgz",
+      "integrity": "sha512-2lrrHqxalACEbxIbsjhqGpSW8kWpUKuY6RHgnSAFZa6qK62wvnPxA8hGOwOoDbwHcOFs5M4o27mjGu+P7TvBmw==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.4.0"
+      }
+    },
+    "node_modules/@marijn/find-cluster-break": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
+      "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
       "license": "MIT"
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -1370,6 +1527,21 @@
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
     },
+    "node_modules/codemirror": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-6.0.2.tgz",
+      "integrity": "sha512-VhydHotNW5w1UGK0Qj96BwSk/Zqbp9WbnyK2W/eVMv4QyF41INRGpjUhFJY7/uDNuudSc33a/PKr4iDqRduvHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/commands": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/search": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0"
+      }
+    },
     "node_modules/comma-separated-tokens": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
@@ -1385,6 +1557,12 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/crelt": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
+      "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
       "license": "MIT"
     },
     "node_modules/css-tree": {
@@ -3604,6 +3782,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/style-mod": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
+      "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
+      "license": "MIT"
+    },
     "node_modules/style-to-js": {
       "version": "1.1.21",
       "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
@@ -4110,6 +4294,12 @@
           "optional": false
         }
       }
+    },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "license": "MIT"
     },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",

--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -22,7 +22,8 @@
         "react-markdown": "^10.1.0",
         "rehype-sanitize": "^6.0.0",
         "remark-gfm": "^4.0.1",
-        "web-push": "^3.6.7"
+        "web-push": "^3.6.7",
+        "yaml": "^2.8.4"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.9.1",
@@ -4401,6 +4402,21 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/yaml": {
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.4.tgz",
+      "integrity": "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/zwitch": {
       "version": "2.0.4",

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -14,6 +14,14 @@
     "clean": "rm -rf .next tsconfig.tsbuildinfo"
   },
   "dependencies": {
+    "@codemirror/commands": "^6.10.3",
+    "@codemirror/lang-yaml": "^6.1.3",
+    "@codemirror/language": "^6.12.3",
+    "@codemirror/lint": "^6.9.6",
+    "@codemirror/state": "^6.6.0",
+    "@codemirror/theme-one-dark": "^6.1.3",
+    "@codemirror/view": "^6.42.0",
+    "codemirror": "^6.0.2",
     "next": "^14.2.0",
     "react": "^18.3.0",
     "react-dom": "^18.3.0",

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -28,7 +28,8 @@
     "react-markdown": "^10.1.0",
     "rehype-sanitize": "^6.0.0",
     "remark-gfm": "^4.0.1",
-    "web-push": "^3.6.7"
+    "web-push": "^3.6.7",
+    "yaml": "^2.8.4"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.9.1",

--- a/dashboard/src/app/activity/page.tsx
+++ b/dashboard/src/app/activity/page.tsx
@@ -1,11 +1,17 @@
 "use client";
 import { useEffect, useMemo, useRef, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
 import { apiPath } from "@/lib/api";
 import { relTime } from "@/components/time";
 import { isDemoMode } from "@/lib/demoMode";
 import { EventsHistogram, HBarList } from "@/components/patchwork";
 import { SkeletonList } from "@/components/Skeleton";
 import { ActivityTabs } from "@/components/ActivityTabs";
+
+const TABS: readonly Tab[] = ["all", "tools", "recipe_start", "recipe_end"];
+function isTab(v: string | null): v is Tab {
+  return v !== null && (TABS as readonly string[]).includes(v);
+}
 
 type Tab = "all" | "tools" | "recipe_start" | "recipe_end";
 
@@ -72,7 +78,18 @@ export default function ActivityPage() {
   const [seeded, setSeeded] = useState(false);
   const [connected, setConnected] = useState(false);
   const [err, setErr] = useState<string>();
-  const [tab, setTab] = useState<Tab>("all");
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const tabFromUrl = searchParams?.get("tab");
+  const [tab, setTabState] = useState<Tab>(isTab(tabFromUrl) ? tabFromUrl : "all");
+  const setTab = (next: Tab) => {
+    setTabState(next);
+    const params = new URLSearchParams(searchParams?.toString() ?? "");
+    if (next === "all") params.delete("tab");
+    else params.set("tab", next);
+    const qs = params.toString();
+    router.replace(qs ? `?${qs}` : "?", { scroll: false });
+  };
   const [, setTick] = useState(0);
   const esRef = useRef<EventSource | null>(null);
 

--- a/dashboard/src/app/analytics/layout.tsx
+++ b/dashboard/src/app/analytics/layout.tsx
@@ -1,5 +1,11 @@
 import type { ReactNode } from "react";
+import { AnalyticsTabs } from "@/components/AnalyticsTabs";
 export const metadata = { title: "Analytics — Patchwork OS" };
 export default function Layout({ children }: { children: ReactNode }) {
-  return <>{children}</>;
+  return (
+    <>
+      <AnalyticsTabs />
+      {children}
+    </>
+  );
 }

--- a/dashboard/src/app/analytics/page.tsx
+++ b/dashboard/src/app/analytics/page.tsx
@@ -3,7 +3,6 @@ import { useEffect, useMemo, useState } from "react";
 import { StatCard } from "@/components/StatCard";
 import { useBridgeFetch } from "@/hooks/useBridgeFetch";
 import { AreaChart, ErrorState } from "@/components/patchwork";
-import { AnalyticsTabs } from "@/components/AnalyticsTabs";
 import type { AreaChartSeries } from "@/components/patchwork";
 
 interface ToolStat {
@@ -68,7 +67,7 @@ export default function AnalyticsPage() {
   const [clientNow, setClientNow] = useState(0);
   useEffect(() => { setClientNow(Date.now()); }, []);
 
-  const { data, error, loading } = useBridgeFetch<AnalyticsData>(
+  const { data, error, loading, refetch } = useBridgeFetch<AnalyticsData>(
     `/api/bridge/analytics?windowHours=${windowHours}`,
     { intervalMs: 30000 },
   );
@@ -133,7 +132,6 @@ export default function AnalyticsPage() {
 
   return (
     <section>
-      <AnalyticsTabs />
       <div className="page-head">
         <div>
           <h1 className="editorial-h1">
@@ -150,7 +148,7 @@ export default function AnalyticsPage() {
           title="Couldn't load analytics"
           description="The bridge isn't responding. Once it's back, this view will refresh on its own."
           error={error}
-          onRetry={() => window.location.reload()}
+          onRetry={refetch}
         />
       )}
       {error && data && <div className="alert-err">Refresh failed — {error}</div>}

--- a/dashboard/src/app/api/bridge/recipes/generate/route.ts
+++ b/dashboard/src/app/api/bridge/recipes/generate/route.ts
@@ -1,0 +1,48 @@
+import type { NextRequest } from "next/server";
+import { bridgeFetch } from "@/lib/bridge";
+import { isDemoModeServer } from "@/lib/demoModeServer";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function POST(req: NextRequest): Promise<Response> {
+  const sfs = req.headers.get("sec-fetch-site");
+  if (sfs && sfs !== "same-origin" && sfs !== "none") {
+    return new Response(JSON.stringify({ error: "CSRF check failed" }), {
+      status: 403,
+      headers: { "content-type": "application/json" },
+    });
+  }
+  if (isDemoModeServer()) {
+    return new Response(
+      JSON.stringify({
+        ok: false,
+        unavailable: true,
+        error: "AI generation is not available in demo mode.",
+      }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
+  }
+  try {
+    const body = await req.text();
+    const res = await bridgeFetch("/recipes/generate", {
+      method: "POST",
+      headers: {
+        "content-type": req.headers.get("content-type") ?? "application/json",
+      },
+      body,
+    });
+    const text = await res.text();
+    return new Response(text, {
+      status: res.status,
+      headers: { "content-type": "application/json" },
+    });
+  } catch (err) {
+    return new Response(
+      JSON.stringify({
+        error: err instanceof Error ? err.message : "fetch failed",
+      }),
+      { status: 502, headers: { "content-type": "application/json" } },
+    );
+  }
+}

--- a/dashboard/src/app/approvals/page.tsx
+++ b/dashboard/src/app/approvals/page.tsx
@@ -6,6 +6,7 @@ import { apiPath } from "@/lib/api";
 import { KeyChip, CodeBlock } from "@/components/patchwork";
 import { SkeletonList } from "@/components/Skeleton";
 import { DecisionsTabs } from "@/components/DecisionsTabs";
+import { useToast } from "@/components/Toast";
 import { CountdownTimer } from "./_components/CountdownTimer";
 import { Spinner } from "./_components/Spinner";
 import { RiskMeter } from "./_components/RiskMeter";
@@ -186,7 +187,7 @@ function ApprovalCard({
 }: ApprovalCardProps) {
   const [approving, setApproving] = useState(false);
   const [rejecting, setRejecting] = useState(false);
-  const [actionError, setActionError] = useState<string | null>(null);
+  const toast = useToast();
   const [editCopied, setEditCopied] = useState(false);
   const [cliCopied, setCliCopied] = useState(false);
   const [paramsCopied, setParamsCopied] = useState(false);
@@ -197,13 +198,14 @@ function ApprovalCard({
   const match = matchRule(p.toolName, rules);
 
   async function handleDecide(decision: "approve" | "reject") {
-    setActionError(null);
     if (decision === "approve") setApproving(true);
     else setRejecting(true);
     try {
       await onDecide(p.callId, decision);
     } catch (e) {
-      setActionError(e instanceof Error ? e.message : String(e));
+      toast.error(
+        `${decision === "approve" ? "Approve" : "Reject"} failed: ${e instanceof Error ? e.message : String(e)}`,
+      );
       setApproving(false);
       setRejecting(false);
     }
@@ -456,15 +458,6 @@ function ApprovalCard({
         </button>
       </div>
 
-      {actionError && (
-        <div
-          className="alert-err"
-          style={{ marginTop: "var(--s-3)", marginBottom: 0 }}
-          role="alert"
-        >
-          {actionError}
-        </div>
-      )}
     </article>
   );
 }
@@ -554,7 +547,20 @@ function ApprovalsContent() {
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
   const [dismissed, setDismissed] = useState<Set<string>>(new Set());
   const [copied, setCopied] = useState<string | null>(null);
-  const [riskFilter, setRiskFilter] = useState<RiskFilter>("all");
+  const riskFromUrl = searchParams.get("risk");
+  const [riskFilter, setRiskFilterState] = useState<RiskFilter>(
+    riskFromUrl === "low" || riskFromUrl === "medium" || riskFromUrl === "high"
+      ? riskFromUrl
+      : "all",
+  );
+  const setRiskFilter = (next: RiskFilter) => {
+    setRiskFilterState(next);
+    const params = new URLSearchParams(searchParams.toString());
+    if (next === "all") params.delete("risk");
+    else params.set("risk", next);
+    const qs = params.toString();
+    router.replace(qs ? `?${qs}` : "?", { scroll: false });
+  };
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [fadingOut, setFadingOut] = useState<Set<string>>(new Set());
   const [batchApproving, setBatchApproving] = useState(false);
@@ -757,6 +763,13 @@ function ApprovalsContent() {
 
   async function batchDecide(decision: "approve" | "reject") {
     const ids = selectedInView.map((p) => p.callId);
+    if (ids.length >= 3) {
+      const verb = decision === "approve" ? "Approve" : "Reject";
+      const proceed = window.confirm(
+        `${verb} ${ids.length} approvals at once? This action can't be undone.`,
+      );
+      if (!proceed) return;
+    }
     if (decision === "approve") setBatchApproving(true);
     else setBatchRejecting(true);
     setBatchErr(null);

--- a/dashboard/src/app/connections/page.tsx
+++ b/dashboard/src/app/connections/page.tsx
@@ -3,6 +3,7 @@ import { useEffect, useRef, useState } from "react";
 import { apiPath } from "@/lib/api";
 import AddConnectionModal from "./AddConnectionModal";
 import { Dialog } from "@/components/Dialog";
+import { useToast } from "@/components/Toast";
 import type { ConnectorStatus } from "./types";
 
 // ------------------------------------------------------------------ helpers
@@ -265,6 +266,7 @@ interface TokenModalConfig {
   instructions: React.ReactNode;
   placeholder: string;
   tokenKey: string;
+  extraFields?: { key: string; label: string; placeholder: string; type?: "text" | "email" | "url"; required?: boolean }[];
 }
 
 // Connectors that have a backend wired in the bridge — anything not listed
@@ -306,6 +308,9 @@ const TOKEN_MODAL_CONNECTORS: Record<string, TokenModalConfig> = {
     ),
     placeholder: "Atlassian API token",
     tokenKey: "token",
+    extraFields: [
+      { key: "baseUrl", label: "Atlassian base URL", placeholder: "https://your-org.atlassian.net", type: "url", required: true },
+    ],
   },
   datadog: {
     name: "Datadog",
@@ -366,6 +371,10 @@ const TOKEN_MODAL_CONNECTORS: Record<string, TokenModalConfig> = {
     ),
     placeholder: "Atlassian API token",
     tokenKey: "token",
+    extraFields: [
+      { key: "baseUrl", label: "Atlassian base URL", placeholder: "https://your-org.atlassian.net", type: "url", required: true },
+      { key: "email", label: "Atlassian account email", placeholder: "you@your-org.com", type: "email", required: true },
+    ],
   },
   pagerduty: {
     name: "PagerDuty",
@@ -411,6 +420,10 @@ const TOKEN_MODAL_CONNECTORS: Record<string, TokenModalConfig> = {
     ),
     placeholder: "Zendesk API token",
     tokenKey: "token",
+    extraFields: [
+      { key: "subdomain", label: "Zendesk subdomain", placeholder: "your-org", type: "text", required: true },
+      { key: "email", label: "Agent email", placeholder: "you@your-org.com", type: "email", required: true },
+    ],
   },
 };
 
@@ -847,7 +860,8 @@ export default function ConnectionsPage() {
   const [err, setErr] = useState<string>();
   const [bridgeOffline, setBridgeOffline] = useState(false);
   const [acting, setActing] = useState<string | null>(null);
-  const [actionErr, setActionErr] = useState<string | null>(null);
+  const toast = useToast();
+  const [confirmDisconnectId, setConfirmDisconnectId] = useState<string | null>(null);
   // Notion modal
   const [notionModalOpen, setNotionModalOpen] = useState(false);
   const [notionToken, setNotionToken] = useState("");
@@ -856,6 +870,7 @@ export default function ConnectionsPage() {
   // Generic token modal
   const [tokenModal, setTokenModal] = useState<string | null>(null);
   const [tokenValue, setTokenValue] = useState("");
+  const [tokenExtras, setTokenExtras] = useState<Record<string, string>>({});
   const [tokenConnecting, setTokenConnecting] = useState(false);
   const [tokenErr, setTokenErr] = useState<string | null>(null);
   // Add connection modal
@@ -924,11 +939,23 @@ export default function ConnectionsPage() {
     setTokenConnecting(true);
     setTokenErr(null);
     const cfg = TOKEN_MODAL_CONNECTORS[tokenModal];
+    const missing = (cfg.extraFields ?? [])
+      .filter((f) => f.required && !tokenExtras[f.key]?.trim())
+      .map((f) => f.label);
+    if (missing.length > 0) {
+      setTokenErr(`Missing required field${missing.length === 1 ? "" : "s"}: ${missing.join(", ")}`);
+      return;
+    }
+    const payload: Record<string, string> = { [cfg.tokenKey]: tokenValue };
+    for (const f of cfg.extraFields ?? []) {
+      const v = tokenExtras[f.key]?.trim();
+      if (v) payload[f.key] = v;
+    }
     try {
       const res = await fetch(apiPath(`/api/connections/${tokenModal}/connect`), {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ [cfg.tokenKey]: tokenValue }),
+        body: JSON.stringify(payload),
       });
       const body = (await res.json().catch(() => ({}))) as { ok?: boolean; error?: string };
       if (!res.ok || !body.ok) {
@@ -936,6 +963,7 @@ export default function ConnectionsPage() {
         return;
       }
       setTokenValue("");
+      setTokenExtras({});
       setTokenModal(null);
       await fetchConnectors();
     } catch (e) {
@@ -954,6 +982,7 @@ export default function ConnectionsPage() {
     if (id in TOKEN_MODAL_CONNECTORS) {
       setTokenModal(id);
       setTokenValue("");
+      setTokenExtras({});
       setTokenErr(null);
       return Promise.resolve("connected");
     }
@@ -1026,9 +1055,18 @@ export default function ConnectionsPage() {
     function onMessage(e: MessageEvent) {
       if (e.origin !== window.location.origin) return;
       if (typeof e.data !== "string") return;
-      const m = /^patchwork:([a-z-]+):connected$/.exec(e.data);
-      if (!m) return;
-      fetchConnectors();
+      const ok = /^patchwork:([a-z-]+):connected$/.exec(e.data);
+      if (ok) {
+        fetchConnectors();
+        return;
+      }
+      const errMatch = /^patchwork:([a-z-]+):error(?::(.*))?$/.exec(e.data);
+      if (errMatch) {
+        const [, connectorId, reason] = errMatch;
+        const decoded = reason ? decodeURIComponent(reason) : "Authorization failed";
+        toast.error(`${connectorId}: ${decoded}`);
+        return;
+      }
     }
     window.addEventListener("message", onMessage);
     return () => {
@@ -1042,19 +1080,19 @@ export default function ConnectionsPage() {
 
   async function handleDisconnect(id: string) {
     setActing(id);
-    setActionErr(null);
     try {
       const res = await fetch(apiPath(`/api/connections/${id}`), { method: "DELETE" });
       if (!res.ok) {
         const body = (await res.json().catch(() => ({}))) as { error?: string };
-        setActionErr(body.error ?? `Error ${res.status}`);
+        toast.error(body.error ?? `Error ${res.status}`);
         return;
       }
       setConnectors((prev) =>
         prev.map((c) => (c.id === id ? { ...c, status: "disconnected", lastSync: undefined } : c)),
       );
+      toast.success(`Disconnected ${id}`);
     } catch (e) {
-      setActionErr(e instanceof Error ? e.message : String(e));
+      toast.error(e instanceof Error ? e.message : String(e));
     } finally {
       setActing(null);
     }
@@ -1147,7 +1185,6 @@ export default function ConnectionsPage() {
       </div>
 
       {err && <div className="alert-err" role="alert">{err}</div>}
-      {actionErr && <div className="alert-err" role="alert">{actionErr}</div>}
 
       {bridgeOffline ? (
         <div className="empty-state" role="status">
@@ -1213,7 +1250,7 @@ export default function ConnectionsPage() {
                 def={def}
                 statusEntry={getConnector(def.id)}
                 onConnect={() => handleConnect(def.id)}
-                onDisconnect={() => handleDisconnect(def.id)}
+                onDisconnect={() => setConfirmDisconnectId(def.id)}
                 onTest={() => handleTest(def.id)}
                 loading={acting === def.id}
               />
@@ -1273,7 +1310,7 @@ export default function ConnectionsPage() {
       {/* Generic token-paste modal */}
       <Dialog
         open={Boolean(tokenModal && TOKEN_MODAL_CONNECTORS[tokenModal])}
-        onClose={() => { setTokenModal(null); setTokenValue(""); setTokenErr(null); }}
+        onClose={() => { setTokenModal(null); setTokenValue(""); setTokenExtras({}); setTokenErr(null); }}
         ariaLabelledBy="token-modal-title"
         maxWidth={440}
       >
@@ -1292,13 +1329,30 @@ export default function ConnectionsPage() {
               value={tokenValue}
               onChange={(e) => setTokenValue(e.target.value)}
               onKeyDown={(e) => { if (e.key === "Enter") void handleTokenConnect(); }}
+              aria-label={`${TOKEN_MODAL_CONNECTORS[tokenModal].name} ${TOKEN_MODAL_CONNECTORS[tokenModal].placeholder}`}
               style={{ fontFamily: "var(--font-mono)", fontSize: "var(--fs-m)", padding: "8px 12px", borderRadius: 6, border: "1px solid var(--border-subtle)", background: "var(--bg-0)", color: "var(--fg-1)", width: "100%", boxSizing: "border-box" }}
             />
+            {(TOKEN_MODAL_CONNECTORS[tokenModal].extraFields ?? []).map((f) => (
+              <div key={f.key} style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+                <label htmlFor={`token-extra-${f.key}`} style={{ fontSize: "var(--fs-s)", color: "var(--fg-2)" }}>
+                  {f.label}{f.required ? " *" : ""}
+                </label>
+                <input
+                  id={`token-extra-${f.key}`}
+                  type={f.type ?? "text"}
+                  placeholder={f.placeholder}
+                  value={tokenExtras[f.key] ?? ""}
+                  onChange={(e) => setTokenExtras((prev) => ({ ...prev, [f.key]: e.target.value }))}
+                  onKeyDown={(e) => { if (e.key === "Enter") void handleTokenConnect(); }}
+                  style={{ fontFamily: "var(--font-mono)", fontSize: "var(--fs-m)", padding: "8px 12px", borderRadius: 6, border: "1px solid var(--border-subtle)", background: "var(--bg-0)", color: "var(--fg-1)", width: "100%", boxSizing: "border-box" }}
+                />
+              </div>
+            ))}
             {tokenErr && <div className="alert-err" role="alert" style={{ fontSize: "var(--fs-s)" }}>{tokenErr}</div>}
             <div style={{ display: "flex", gap: 8, justifyContent: "flex-end" }}>
               <button
                 type="button"
-                onClick={() => { setTokenModal(null); setTokenValue(""); setTokenErr(null); }}
+                onClick={() => { setTokenModal(null); setTokenValue(""); setTokenExtras({}); setTokenErr(null); }}
                 style={{ padding: "6px 16px", fontSize: "var(--fs-m)", cursor: "pointer", borderRadius: 6, border: "1px solid var(--border-subtle)", background: "var(--bg-1)", color: "var(--fg-1)" }}
               >
                 Cancel
@@ -1324,6 +1378,71 @@ export default function ConnectionsPage() {
         onConnect={handleConnect}
         providers={PROVIDERS}
       />
+
+      <Dialog
+        open={confirmDisconnectId !== null}
+        onClose={() => setConfirmDisconnectId(null)}
+        ariaLabelledBy="disconnect-confirm-title"
+        maxWidth={420}
+      >
+        {(() => {
+          const id = confirmDisconnectId;
+          const def = id ? CATALOG.find((d) => d.id === id) : undefined;
+          const displayName = def?.name ?? id ?? "this connector";
+          const busy = id ? acting === id : false;
+          return (
+            <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
+              <strong id="disconnect-confirm-title" style={{ fontSize: "var(--fs-l)" }}>
+                Disconnect {displayName}?
+              </strong>
+              <p style={{ fontSize: "var(--fs-m)", color: "var(--fg-2)", margin: 0, lineHeight: 1.5 }}>
+                Recipes and automations that use {displayName} will fail until you reconnect.
+                Patchwork will keep your existing recipe definitions; only the auth token is removed.
+              </p>
+              <div style={{ display: "flex", gap: 8, justifyContent: "flex-end", marginTop: 4 }}>
+                <button
+                  type="button"
+                  onClick={() => setConfirmDisconnectId(null)}
+                  disabled={busy}
+                  style={{
+                    padding: "6px 14px",
+                    fontSize: "var(--fs-m)",
+                    cursor: busy ? "wait" : "pointer",
+                    borderRadius: 6,
+                    border: "1px solid var(--border-default)",
+                    background: "var(--card-bg)",
+                    color: "var(--ink-1)",
+                  }}
+                >
+                  Cancel
+                </button>
+                <button
+                  type="button"
+                  onClick={async () => {
+                    if (!id) return;
+                    await handleDisconnect(id);
+                    setConfirmDisconnectId(null);
+                  }}
+                  disabled={busy}
+                  style={{
+                    padding: "6px 14px",
+                    fontSize: "var(--fs-m)",
+                    cursor: busy ? "wait" : "pointer",
+                    borderRadius: 6,
+                    border: "none",
+                    background: "var(--err)",
+                    color: "#fff",
+                    fontWeight: 600,
+                    opacity: busy ? 0.6 : 1,
+                  }}
+                >
+                  {busy ? "Disconnecting…" : "Disconnect"}
+                </button>
+              </div>
+            </div>
+          );
+        })()}
+      </Dialog>
     </section>
   );
 }

--- a/dashboard/src/app/decisions/page.tsx
+++ b/dashboard/src/app/decisions/page.tsx
@@ -4,6 +4,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { Suspense, useEffect, useMemo, useRef, useState } from "react";
 import { relTime } from "@/components/time";
 import { useBridgeFetch } from "@/hooks/useBridgeFetch";
+import { useDebounced } from "@/hooks/useDebounced";
 import { arr, isRecord, shape, type ShapeCheck } from "@/lib/validate";
 import { DecisionsTabs } from "@/components/DecisionsTabs";
 import { ErrorState, LivePill } from "@/components/patchwork";
@@ -90,21 +91,24 @@ function DecisionsContent() {
     router.replace(qs ? `/decisions?${qs}` : "/decisions", { scroll: false });
   }, [tag, keyQuery, textQuery, since, router]);
 
+  const debouncedKey = useDebounced(keyQuery, 250);
+  const debouncedText = useDebounced(textQuery, 250);
+
   const qs = useMemo(() => {
     const params = new URLSearchParams();
     params.set("traceType", "decision");
     if (tag.trim()) params.set("tag", tag.trim());
-    if (keyQuery.trim()) params.set("key", keyQuery.trim());
-    if (textQuery.trim()) params.set("q", textQuery.trim());
+    if (debouncedKey.trim()) params.set("key", debouncedKey.trim());
+    if (debouncedText.trim()) params.set("q", debouncedText.trim());
     const sinceMs = SINCE_OPTIONS.find((o) => o.k === since)?.ms;
     if (sinceMs != null) {
       params.set("since", String(Date.now() - sinceMs));
     }
     params.set("limit", "200");
     return `?${params.toString()}`;
-  }, [tag, keyQuery, textQuery, since]);
+  }, [tag, debouncedKey, debouncedText, since]);
 
-  const { data, error, loading } = useBridgeFetch<TracesResponse>(
+  const { data, error, loading, refetch } = useBridgeFetch<TracesResponse>(
     `/api/bridge/traces${qs}`,
     { intervalMs: 5000, transform: validateTraces },
   );
@@ -256,7 +260,7 @@ function DecisionsContent() {
               : "The bridge isn't responding. Decisions will reload on the next tick."
           }
           error={error}
-          onRetry={() => window.location.reload()}
+          onRetry={refetch}
         />
       )}
       {error && traces.length > 0 && (

--- a/dashboard/src/app/globals.css
+++ b/dashboard/src/app/globals.css
@@ -1431,20 +1431,6 @@ button.topbar-search {
   box-shadow: var(--shadow-s);
 }
 .theme-toggle:hover { background: var(--recess); color: var(--ink-0); border-color: var(--line-2); }
-.theme-toggle-auto {
-  position: absolute;
-  right: -3px;
-  bottom: -3px;
-  border: 1px solid var(--line);
-  border-radius: 4px;
-  background: var(--pressed);
-  color: var(--ink-2);
-  font-family: var(--font-mono);
-  font-size: 8px;
-  line-height: 1;
-  padding: 2px 3px;
-  pointer-events: none;
-}
 
 /* ---- Animations ---- */
 

--- a/dashboard/src/app/inbox/page.tsx
+++ b/dashboard/src/app/inbox/page.tsx
@@ -1,7 +1,13 @@
 "use client";
 import { useCallback, useEffect, useRef, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
 import dynamic from "next/dynamic";
 import { apiPath } from "@/lib/api";
+import { useToast } from "@/components/Toast";
+
+function isFilterCategory(v: string | null): v is FilterCategory {
+  return v === "All" || v === "Morning Briefs" || v === "Recipe Outputs" || v === "Agent Reports";
+}
 
 // react-markdown + its rehype/remark plugins ship ~80KB gzipped of
 // mdast/hast/micromark machinery. They're only needed to render the
@@ -217,18 +223,6 @@ const markdownComponents = {
       {children}
     </ul>
   ),
-  li: ({ children }: { children?: React.ReactNode }) => (
-    <li
-      style={{
-        fontSize: 13.5,
-        lineHeight: 1.65,
-        marginBottom: 4,
-        color: "var(--ink-1)",
-      }}
-    >
-      {children}
-    </li>
-  ),
   hr: () => (
     <hr
       style={{
@@ -241,6 +235,59 @@ const markdownComponents = {
   strong: ({ children }: { children?: React.ReactNode }) => (
     <strong style={{ color: "var(--fg-0)" }}>{children}</strong>
   ),
+  li: ({ children }: { children?: React.ReactNode }) => (
+    <li
+      style={{
+        fontSize: 13.5,
+        lineHeight: 1.65,
+        marginBottom: 4,
+        color: "var(--ink-1)",
+        overflowWrap: "break-word",
+        wordBreak: "break-word",
+      }}
+    >
+      {children}
+    </li>
+  ),
+  pre: ({ children }: { children?: React.ReactNode }) => (
+    <pre
+      style={{
+        background: "var(--recess)",
+        border: "1px solid var(--line-2)",
+        borderRadius: "var(--r-s)",
+        padding: "10px 14px",
+        margin: "8px 0 12px",
+        fontSize: "var(--fs-xs)",
+        fontFamily: "var(--font-mono)",
+        lineHeight: 1.6,
+        overflowX: "auto",
+        whiteSpace: "pre-wrap",
+        wordBreak: "break-all",
+      }}
+    >
+      {children}
+    </pre>
+  ),
+  code: ({ children, className }: { children?: React.ReactNode; className?: string }) => {
+    const isBlock = !!className;
+    return isBlock ? (
+      <code style={{ fontFamily: "var(--font-mono)", fontSize: "var(--fs-xs)" }}>{children}</code>
+    ) : (
+      <code
+        style={{
+          fontFamily: "var(--font-mono)",
+          fontSize: "0.875em",
+          background: "var(--recess)",
+          border: "1px solid var(--line-1)",
+          borderRadius: 4,
+          padding: "1px 5px",
+          wordBreak: "break-all",
+        }}
+      >
+        {children}
+      </code>
+    );
+  },
 };
 
 // ------------------------------------------------------------------ relative time (live)
@@ -312,12 +359,25 @@ export default function InboxPage() {
   const [detailLoading, setDetailLoading] = useState(false);
   const [err, setErr] = useState<string | undefined>();
   const [sidebarOpen, setSidebarOpen] = useState(true);
-  const [activeFilter, setActiveFilter] = useState<FilterCategory>("All");
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const filterFromUrl = searchParams?.get("filter");
+  const [activeFilter, setActiveFilterState] = useState<FilterCategory>(
+    isFilterCategory(filterFromUrl) ? filterFromUrl : "All",
+  );
+  const setActiveFilter = (next: FilterCategory) => {
+    setActiveFilterState(next);
+    const params = new URLSearchParams(searchParams?.toString() ?? "");
+    if (next === "All") params.delete("filter");
+    else params.set("filter", next);
+    const qs = params.toString();
+    router.replace(qs ? `?${qs}` : "?", { scroll: false });
+  };
   const [search, setSearch] = useState("");
   const [refreshing, setRefreshing] = useState(false);
   const [seenNames] = useState<Set<string>>(() => new Set());
   const [replayingFor, setReplayingFor] = useState<string | null>(null);
-  const [actionErr, setActionErr] = useState<string | null>(null);
+  const toast = useToast();
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const detailRef = useRef<HTMLDivElement | null>(null);
   const selectedRef = useRef<InboxDetail | null>(null);
@@ -362,8 +422,18 @@ export default function InboxPage() {
   useEffect(() => {
     fetchList();
     pollRef.current = setInterval(() => fetchList(), 30_000);
+    const onVisible = () => {
+      if (document.hidden) {
+        if (pollRef.current) { clearInterval(pollRef.current); pollRef.current = null; }
+      } else if (!pollRef.current) {
+        void fetchList();
+        pollRef.current = setInterval(() => fetchList(), 30_000);
+      }
+    };
+    document.addEventListener("visibilitychange", onVisible);
     return () => {
       if (pollRef.current) clearInterval(pollRef.current);
+      document.removeEventListener("visibilitychange", onVisible);
     };
   }, [fetchList]);
 
@@ -729,7 +799,7 @@ const filteredItems = items.filter((item) => {
                     ref={detailRef}
                     tabIndex={-1}
                     aria-label={`Message: ${slugToTitle(selected.name)}`}
-                    style={{ fontSize: "var(--fs-base)", lineHeight: 1.7, color: "var(--ink-1)", outline: "none" }}
+                    style={{ fontSize: "var(--fs-base)", lineHeight: 1.7, color: "var(--ink-1)", outline: "none", overflowWrap: "break-word", wordBreak: "break-word" }}
                   >
                     <MessageMarkdown
                       content={selected.content}
@@ -762,7 +832,6 @@ const filteredItems = items.filter((item) => {
                           style={{ background: "var(--orange)", border: "none", fontSize: "var(--fs-xs)" }}
                           disabled={replayingFor === selected.name}
                           onClick={async () => {
-                            setActionErr(null);
                             const itemName = selected.name;
                             setReplayingFor(itemName);
                             try {
@@ -772,10 +841,12 @@ const filteredItems = items.filter((item) => {
                               );
                               if (!res.ok) {
                                 const text = await res.text().catch(() => res.statusText);
-                                setActionErr(`Replay failed: ${text || res.status}`);
+                                toast.error(`Replay failed: ${text || res.status}`);
+                              } else {
+                                toast.success(`Replayed “${recipeNameForSelected}”`);
                               }
                             } catch (e) {
-                              setActionErr(e instanceof Error ? e.message : String(e));
+                              toast.error(e instanceof Error ? e.message : String(e));
                             } finally {
                               setTimeout(() => {
                                 setReplayingFor((cur) => (cur === itemName ? null : cur));
@@ -797,7 +868,10 @@ const filteredItems = items.filter((item) => {
                           className="btn sm ghost"
                           style={{ fontSize: "var(--fs-xs)", color: "var(--ink-3)" }}
                           onClick={async () => {
-                            setActionErr(null);
+                            const proceed = window.confirm(
+                              `Archive "${selected.name}"? This permanently deletes the inbox item.`,
+                            );
+                            if (!proceed) return;
                             try {
                               const res = await fetch(
                                 apiPath(`/api/bridge/inbox/${encodeURIComponent(selected.name)}`),
@@ -805,13 +879,14 @@ const filteredItems = items.filter((item) => {
                               );
                               if (!res.ok) {
                                 const text = await res.text().catch(() => res.statusText);
-                                setActionErr(`Archive failed: ${text || res.status}`);
+                                toast.error(`Archive failed: ${text || res.status}`);
                                 return;
                               }
+                              toast.success(`Archived “${selected.name}”`);
                               fetchList(true);
                               setSelected(null);
                             } catch (e) {
-                              setActionErr(
+                              toast.error(
                                 e instanceof Error ? e.message : String(e),
                               );
                             }
@@ -820,15 +895,6 @@ const filteredItems = items.filter((item) => {
                           Archive
                         </button>
                       </div>
-                      {actionErr && (
-                        <div
-                          role="alert"
-                          className="alert-err"
-                          style={{ marginTop: 8, fontSize: "var(--fs-s)" }}
-                        >
-                          {actionErr}
-                        </div>
-                      )}
                     </>
                     );
                   })()}

--- a/dashboard/src/app/insights/page.tsx
+++ b/dashboard/src/app/insights/page.tsx
@@ -126,7 +126,7 @@ function RuleCell({ explanation }: { explanation: RuleExplanation | null | undef
 }
 
 export default function InsightsPage() {
-  const { data, error, loading } = useBridgeFetch<InsightsResponse>(
+  const { data, error, loading, refetch } = useBridgeFetch<InsightsResponse>(
     "/api/bridge/approval-insights",
     { intervalMs: 30000 },
   );
@@ -211,7 +211,7 @@ export default function InsightsPage() {
           title="Couldn't load insights"
           description="The bridge isn't responding to /approval-insights."
           error={error}
-          onRetry={() => window.location.reload()}
+          onRetry={refetch}
         />
       )}
       {error && tools.length > 0 && (

--- a/dashboard/src/app/layout.tsx
+++ b/dashboard/src/app/layout.tsx
@@ -5,6 +5,7 @@ import { Shell } from "@/components/Shell";
 import { DemoBanner } from "@/components/DemoBanner";
 import { BridgeBanner } from "@/components/BridgeBanner";
 import { MobileBottomNav } from "@/components/MobileBottomNav";
+import { ToastProvider } from "@/components/Toast";
 
 const albertSans = Albert_Sans({
   subsets: ["latin"],
@@ -85,12 +86,14 @@ export default function RootLayout({ children }: { children: ReactNode }) {
         <a href="#main-content" className="skip-nav">
           Skip to main content
         </a>
-        <div data-app-root>
-          <DemoBanner />
-          <BridgeBanner />
-          <Shell>{children}</Shell>
-          <MobileBottomNav />
-        </div>
+        <ToastProvider>
+          <div data-app-root>
+            <DemoBanner />
+            <BridgeBanner />
+            <Shell>{children}</Shell>
+            <MobileBottomNav />
+          </div>
+        </ToastProvider>
         <script
           dangerouslySetInnerHTML={{
             __html: `if('serviceWorker' in navigator){navigator.serviceWorker.register('/dashboard/sw.js',{scope:'/dashboard/'}).catch(()=>{})}`,

--- a/dashboard/src/app/marketplace/page.tsx
+++ b/dashboard/src/app/marketplace/page.tsx
@@ -6,11 +6,13 @@ import { apiPath } from "@/lib/api";
 import {
   assertValidInstallSource,
   type ApprovalBehavior,
+  type RegistryBundle,
   type RegistryData,
   type RegistryRecipe,
   type RiskLevel,
   shortName,
 } from "@/lib/registry";
+import { useToast } from "@/components/Toast";
 
 // ------------------------------------------------------------------ fallback data (shown when bridge offline)
 
@@ -146,41 +148,6 @@ function connectorColor(id: string): string {
 }
 
 
-// ------------------------------------------------------------------ toast
-
-function Toast({ message, onDone }: { message: string; onDone: () => void }) {
-  useEffect(() => {
-    const id = setTimeout(onDone, 3000);
-    return () => clearTimeout(id);
-  }, [onDone]);
-
-  return (
-    <div
-      role="status"
-      aria-live="polite"
-      style={{
-        position: "fixed",
-        bottom: 24,
-        right: 24,
-        background: "var(--bg-3)",
-        border: "1px solid var(--border-default)",
-        borderRadius: "var(--r-3)",
-        padding: "12px 18px",
-        fontSize: "var(--fs-m)",
-        color: "var(--fg-0)",
-        boxShadow: "0 8px 32px var(--overlay-bg)",
-        zIndex: 9999,
-        display: "flex",
-        alignItems: "center",
-        gap: 10,
-      }}
-    >
-      <span style={{ color: "var(--ok)", fontSize: "var(--fs-xl)" }}>&#10003;</span>
-      {message}
-    </div>
-  );
-}
-
 // ------------------------------------------------------------------ card
 
 function RecipeCard({
@@ -201,6 +168,26 @@ function RecipeCard({
   const isInstalled = installed || justInstalled;
 
   async function handleInstall() {
+    // Risk-aware confirmation. Low-risk recipes can install on a single click
+    // (preserves the existing one-click flow); medium/high or any recipe that
+    // requests network/file access shows a summary dialog so the operator
+    // sees what they're agreeing to before the bridge fetches it.
+    const elevated =
+      recipe.risk_level === "medium" ||
+      recipe.risk_level === "high" ||
+      recipe.network_access ||
+      recipe.file_access;
+    if (elevated) {
+      const summary: string[] = [];
+      if (recipe.risk_level) summary.push(`Risk: ${recipe.risk_level}`);
+      if (recipe.connectors?.length) summary.push(`Connectors: ${recipe.connectors.join(", ")}`);
+      if (recipe.network_access) summary.push("Network access");
+      if (recipe.file_access) summary.push("File access");
+      const proceed = window.confirm(
+        `Install ${shortName(recipe.name)}?\n\n${summary.join("\n")}\n\nThe recipe YAML will be fetched from ${recipe.install} and stored locally.`,
+      );
+      if (!proceed) return;
+    }
     setLoading(true);
     setErr(null);
     try {
@@ -378,16 +365,65 @@ function RecipeCard({
   );
 }
 
+// ------------------------------------------------------------------ bundle card
+
+function BundleCard({ bundle }: { bundle: RegistryBundle }) {
+  const href = `/marketplace/bundle/${encodeURIComponent(bundle.name)}`;
+  return (
+    <Link
+      href={href}
+      style={{ textDecoration: "none" }}
+      className="template-card glass-card"
+    >
+      <div style={{ display: "flex", flexDirection: "column", gap: 10, padding: "18px 18px 16px", height: "100%" }}>
+        <div style={{ display: "flex", alignItems: "flex-start", justifyContent: "space-between", gap: 8 }}>
+          <span
+            style={{
+              fontFamily: "var(--font-mono)",
+              fontSize: "var(--fs-xs)",
+              fontWeight: 600,
+              color: "var(--accent)",
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+              whiteSpace: "nowrap",
+            }}
+          >
+            {shortName(bundle.name)}
+          </span>
+          <span className="pill info" style={{ fontSize: "var(--fs-2xs)", flexShrink: 0 }}>bundle</span>
+        </div>
+        <p style={{ margin: 0, fontSize: "var(--fs-m)", color: "var(--ink-1)", lineHeight: 1.5 }}>
+          {bundle.description}
+        </p>
+        <div style={{ display: "flex", flexWrap: "wrap", gap: 4, marginTop: "auto" }}>
+          {bundle.connectors.slice(0, 4).map((c) => (
+            <span key={c} className="pill" style={{ fontSize: "var(--fs-2xs)" }}>{c}</span>
+          ))}
+          {bundle.connectors.length > 4 && (
+            <span className="pill" style={{ fontSize: "var(--fs-2xs)", color: "var(--ink-3)" }}>+{bundle.connectors.length - 4}</span>
+          )}
+        </div>
+        <div style={{ display: "flex", gap: 12, fontSize: "var(--fs-xs)", color: "var(--ink-3)", marginTop: 4 }}>
+          {bundle.recipe_count != null && <span>{bundle.recipe_count} recipes</span>}
+          {bundle.has_plugin && <span>+ plugin</span>}
+          {bundle.has_policy && <span>+ policy</span>}
+        </div>
+      </div>
+    </Link>
+  );
+}
+
 // ------------------------------------------------------------------ page
 
 export default function MarketplacePage() {
   const [registry, setRegistry] = useState<RegistryRecipe[] | null>(null);
+  const [bundles, setBundles] = useState<RegistryBundle[]>([]);
   const [installedNames, setInstalledNames] = useState<Set<string>>(new Set());
   const [bridgeOnline, setBridgeOnline] = useState(false);
   const [loadErr, setLoadErr] = useState<string | null>(null);
   const [search, setSearch] = useState("");
   const [searchOpen, setSearchOpen] = useState(false);
-  const [toast, setToast] = useState<string | null>(null);
+  const toast = useToast();
 
   useEffect(() => {
     async function load() {
@@ -422,16 +458,20 @@ export default function MarketplacePage() {
       };
 
       let recipes: RegistryRecipe[] | null = null;
+      let registryBundles: RegistryBundle[] = [];
 
       try {
         const res = await fetchWithTimeout(apiPath("/api/bridge/templates"), 4000);
         if (res.ok) {
-          const data = (await res.json()) as { recipes?: RegistryRecipe[] } | RegistryRecipe[];
+          const data = (await res.json()) as { recipes?: RegistryRecipe[]; bundles?: RegistryBundle[] } | RegistryRecipe[];
           recipes = Array.isArray(data)
             ? data
             : Array.isArray(data?.recipes)
               ? (data.recipes ?? null)
               : null;
+          if (!Array.isArray(data) && Array.isArray(data?.bundles)) {
+            registryBundles = data.bundles ?? [];
+          }
         }
       } catch {
         // bridge offline / timed out — try GitHub
@@ -446,6 +486,7 @@ export default function MarketplacePage() {
           if (res.ok) {
             const data = (await res.json()) as RegistryData;
             recipes = data.recipes ?? null;
+            registryBundles = data.bundles ?? [];
           }
         } catch {
           // GitHub also failed / timed out — use hardcoded fallback
@@ -453,6 +494,7 @@ export default function MarketplacePage() {
       }
 
       setRegistry(recipes ?? FALLBACK_REGISTRY.recipes);
+      setBundles(registryBundles);
     }
 
     load().catch((e) => setLoadErr(e instanceof Error ? e.message : String(e)));
@@ -492,7 +534,7 @@ export default function MarketplacePage() {
     }
 
     setInstalledNames((prev) => new Set([...prev, recipe.name]));
-    setToast("Recipe installed successfully");
+    toast.success("Recipe installed successfully");
   }
 
   const filtered = (registry ?? []).filter((r) => {
@@ -513,8 +555,6 @@ export default function MarketplacePage() {
 
   return (
     <section>
-      {toast && <Toast message={toast} onDone={() => setToast(null)} />}
-
       {/* offline banner */}
       {!bridgeOnline && (
         <div
@@ -634,6 +674,20 @@ export default function MarketplacePage() {
         </div>
       ) : (
         <>
+          {bundles.length > 0 && (
+            <>
+              <h2 style={{ fontSize: "var(--fs-m)", fontWeight: 600, color: "var(--fg-2)", marginBottom: "var(--s-3)", marginTop: 0 }}>
+                Capability bundles
+              </h2>
+              <p style={{ fontSize: "var(--fs-s)", color: "var(--ink-2)", marginBottom: "var(--s-4)", marginTop: "-var(--s-2)" }}>
+                Recipes + connectors + policy templates — install as one unit.
+              </p>
+              <div className="marketplace-grid" style={{ marginBottom: "var(--s-8)" }}>
+                {bundles.map((b) => <BundleCard key={b.name} bundle={b} />)}
+              </div>
+            </>
+          )}
+
           {featured && (
             <>
               <h2 style={{ fontSize: "var(--fs-m)", fontWeight: 600, color: "var(--fg-2)", marginBottom: "var(--s-3)", marginTop: 0 }}>

--- a/dashboard/src/app/metrics/layout.tsx
+++ b/dashboard/src/app/metrics/layout.tsx
@@ -1,5 +1,11 @@
 import type { ReactNode } from "react";
+import { AnalyticsTabs } from "@/components/AnalyticsTabs";
 export const metadata = { title: "Metrics — Patchwork OS" };
 export default function Layout({ children }: { children: ReactNode }) {
-  return <>{children}</>;
+  return (
+    <>
+      <AnalyticsTabs />
+      {children}
+    </>
+  );
 }

--- a/dashboard/src/app/metrics/page.tsx
+++ b/dashboard/src/app/metrics/page.tsx
@@ -1,9 +1,8 @@
 "use client";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { apiPath } from "@/lib/api";
-import { relTime } from "@/components/time";
+import { relTime, fmtDuration } from "@/components/time";
 import { MetricsDonut, HBarList, ErrorState, AnimatedNumber } from "@/components/patchwork";
-import { AnalyticsTabs } from "@/components/AnalyticsTabs";
 import type { DonutSegment, HBarItem } from "@/components/patchwork";
 
 interface Metric {
@@ -27,6 +26,8 @@ export default function MetricsPage() {
   const [err, setErr] = useState<string>();
   const [updatedAt, setUpdatedAt] = useState<number>();
 
+  const tickRef = useRef<() => void>(() => {});
+
   useEffect(() => {
     const tick = async () => {
       try {
@@ -40,9 +41,22 @@ export default function MetricsPage() {
         setErr(e instanceof Error ? e.message : String(e));
       }
     };
+    tickRef.current = () => void tick();
     tick();
-    const id = setInterval(tick, 3000);
-    return () => clearInterval(id);
+    let id: ReturnType<typeof setInterval> | null = setInterval(tick, 3000);
+    const onVisible = () => {
+      if (document.hidden) {
+        if (id !== null) { clearInterval(id); id = null; }
+      } else if (id === null) {
+        tick();
+        id = setInterval(tick, 3000);
+      }
+    };
+    document.addEventListener("visibilitychange", onVisible);
+    return () => {
+      if (id !== null) clearInterval(id);
+      document.removeEventListener("visibilitychange", onVisible);
+    };
   }, []);
 
   const totalCalls = useMemo(() => {
@@ -141,14 +155,13 @@ export default function MetricsPage() {
 
   return (
     <section>
-      <AnalyticsTabs />
       <div className="page-head">
         <div>
           <h1 className="editorial-h1">
             Metrics — <span className="accent">Prometheus counters, exposed locally.</span>
           </h1>
           <div className="editorial-sub">
-            polled every 3s · uptime {uptimeSeconds != null ? Math.round(uptimeSeconds) + "s" : "—"} · rate-limits {rateLimitCount}
+            polled every 3s · uptime {uptimeSeconds != null ? fmtDuration(uptimeSeconds * 1000) : "—"} · rate-limits {rateLimitCount}
           </div>
         </div>
         {updatedAt && (
@@ -196,7 +209,7 @@ export default function MetricsPage() {
             <span style={{ color: "var(--blue)", marginRight: 6 }}>◎</span>Uptime
           </div>
           <div style={{ fontFamily: "var(--font-mono)", fontSize: "var(--fs-display)", fontWeight: 800, color: "var(--ink-0)", lineHeight: 1 }}>
-            {uptimeSeconds != null ? `${Math.round(uptimeSeconds)}s` : "—"}
+            {uptimeSeconds != null ? fmtDuration(uptimeSeconds * 1000) : "—"}
           </div>
         </div>
       </div>
@@ -206,7 +219,7 @@ export default function MetricsPage() {
           title="Couldn't load metrics"
           description="The bridge isn't responding to /metrics."
           error={err}
-          onRetry={() => window.location.reload()}
+          onRetry={() => tickRef.current()}
         />
       )}
       {err && metrics.length > 0 && (

--- a/dashboard/src/app/page.tsx
+++ b/dashboard/src/app/page.tsx
@@ -11,9 +11,6 @@ import {
   QuiltHero,
   WeatherRing,
   AreaChart,
-  CodeBlock,
-  YamlLine,
-  Spinner,
   AnimatedNumber,
 } from "@/components/patchwork";
 
@@ -287,7 +284,11 @@ function ActivityThread({ events }: { events: ActivityEvent[] }) {
 // Active recipe (live YAML + spinner)
 // ---------------------------------------------------------------------------
 
-function ActiveRecipeCard() {
+function RecentRecipesCard({ recipes }: { recipes: Recipe[] }) {
+  const top = [...recipes]
+    .filter((r) => r.enabled !== false)
+    .sort((a, b) => (b.lastRun ?? 0) - (a.lastRun ?? 0))
+    .slice(0, 6);
   return (
     <div className="card" style={{ padding: "18px 20px" }}>
       <div
@@ -309,42 +310,54 @@ function ActiveRecipeCard() {
             letterSpacing: "0.06em",
           }}
         >
-          Active recipe
+          Recent recipes
         </h3>
-        <span
-          className="pill muted"
-          style={{ fontSize: "var(--fs-2xs)" }}
-          title="Live wiring pending — preview only"
+        <Link
+          href="/recipes"
+          style={{
+            fontSize: "var(--fs-xs)",
+            color: "var(--accent)",
+            textDecoration: "none",
+          }}
         >
-          preview
-        </span>
+          all →
+        </Link>
       </div>
 
-      <div
-        style={{
-          display: "flex",
-          alignItems: "center",
-          gap: 8,
-          marginBottom: 10,
-          fontSize: "var(--fs-s)",
-          color: "var(--ink-1)",
-        }}
-      >
-        <Spinner size={12} />
-        <span style={{ fontStyle: "italic" }}>
-          assembling Slack digest…
-        </span>
-      </div>
-
-      <CodeBlock>
-        <YamlLine k="name" v="slack-digest" />
-        <YamlLine k="trigger" v="cron 0 9 * * *" />
-        <YamlLine k="steps" />
-        <YamlLine k="- fetch" v="slack.channels.history" indent={1} />
-        <YamlLine k="- summarize" v="claude.haiku" indent={1} />
-        <YamlLine k="- post" v="slack.chat.postMessage" indent={1} />
-        <YamlLine k="status" v="running" comment="3/5 steps" />
-      </CodeBlock>
+      {top.length === 0 ? (
+        <div style={{ fontSize: "var(--fs-s)", color: "var(--ink-3)", padding: "8px 0" }}>
+          No enabled recipes yet.{" "}
+          <Link href="/recipes/new" style={{ color: "var(--accent)" }}>
+            Create one →
+          </Link>
+        </div>
+      ) : (
+        <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+          {top.map((r) => (
+            <Link
+              key={r.id ?? r.name}
+              href={`/recipes/${encodeURIComponent(r.name)}/edit`}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 10,
+                padding: "6px 8px",
+                borderRadius: "var(--r-sm)",
+                textDecoration: "none",
+                color: "var(--ink-1)",
+                fontSize: "var(--fs-s)",
+              }}
+            >
+              <span style={{ fontFamily: "var(--font-mono)", color: "var(--ink-0)", flex: 1, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                {r.name}
+              </span>
+              <span style={{ fontSize: "var(--fs-xs)", color: "var(--ink-3)" }}>
+                {r.lastRun ? relTime(r.lastRun) : "never run"}
+              </span>
+            </Link>
+          ))}
+        </div>
+      )}
     </div>
   );
 }
@@ -842,7 +855,7 @@ export default function HomePage() {
         }}
       >
         <ActivityThread events={activityEvents.slice(-8).reverse()} />
-        <ActiveRecipeCard />
+        <RecentRecipesCard recipes={recipes} />
       </div>
 
       {/* ------------------------------------------------------------------ */}

--- a/dashboard/src/app/page.tsx
+++ b/dashboard/src/app/page.tsx
@@ -761,8 +761,8 @@ export default function HomePage() {
               }
               foot={
                 health?.tokens && health.tokens.messages > 0
-                  ? `${health.tokens.messages} msg${health.tokens.messages === 1 ? "" : "s"} · ${sess} session${sess === 1 ? "" : "s"}`
-                  : `${sess} session${sess === 1 ? "" : "s"} · ${conns} connection${conns === 1 ? "" : "s"}`
+                  ? `${health.tokens.messages.toLocaleString()} msg${health.tokens.messages === 1 ? "" : "s"}`
+                  : undefined
               }
               title={
                 health?.tokens

--- a/dashboard/src/app/recipes/[name]/edit/_components/YamlEditor.tsx
+++ b/dashboard/src/app/recipes/[name]/edit/_components/YamlEditor.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { EditorView, keymap, lineNumbers, highlightActiveLineGutter, drawSelection, dropCursor, rectangularSelection, crosshairCursor, highlightActiveLine } from "@codemirror/view";
+import { EditorState, type Extension } from "@codemirror/state";
+import { defaultKeymap, history, historyKeymap, indentWithTab } from "@codemirror/commands";
+import { foldGutter, indentOnInput, syntaxHighlighting, defaultHighlightStyle, bracketMatching, foldKeymap } from "@codemirror/language";
+import { yaml } from "@codemirror/lang-yaml";
+
+// Minimal theme matching patchwork design tokens (both light/dark via CSS vars).
+// CM themes use static strings, so we inject a <style> for var() mappings.
+const STYLE_ID = "patchwork-cm-style";
+
+function ensureStyle() {
+  if (typeof document === "undefined") return;
+  if (document.getElementById(STYLE_ID)) return;
+  const el = document.createElement("style");
+  el.id = STYLE_ID;
+  el.textContent = `
+    .pw-cm-editor .cm-editor {
+      border: 1px solid var(--line-2);
+      border-radius: var(--r-2, 8px);
+      min-height: inherit;
+      font-family: var(--font-mono, 'JetBrains Mono', monospace);
+      font-size: 13px;
+      line-height: 1.6;
+      outline: none;
+    }
+    .pw-cm-editor .cm-editor.cm-focused {
+      border-color: var(--accent);
+    }
+    .pw-cm-editor .cm-scroller {
+      min-height: inherit;
+    }
+    .pw-cm-editor .cm-content {
+      padding: 12px 4px;
+      caret-color: var(--ink-0);
+    }
+    .pw-cm-editor .cm-line { color: var(--ink-0); }
+    .pw-cm-editor .cm-gutters {
+      background: var(--recess);
+      border-right: 1px solid var(--line-1);
+      color: var(--ink-3);
+    }
+    .pw-cm-editor .cm-activeLineGutter { background: var(--line-1); }
+    .pw-cm-editor .cm-activeLine { background: var(--line-1); }
+    .pw-cm-editor .cm-cursor { border-left-color: var(--ink-0); }
+    .pw-cm-editor .cm-selectionBackground, .pw-cm-editor .cm-focused .cm-selectionBackground {
+      background: rgba(var(--accent-rgb, 197,83,42), 0.2) !important;
+    }
+    /* YAML token colours — orange for keys, blue-ish for strings */
+    .pw-cm-editor .ͼo { color: var(--orange); }          /* keyword */
+    .pw-cm-editor .ͼm { color: var(--green); }           /* string */
+    .pw-cm-editor .ͼl { color: var(--blue, #5080c0); }   /* number */
+    .pw-cm-editor .ͼc { color: var(--ink-3); font-style: italic; }  /* comment */
+    .pw-cm-editor .ͼd { color: var(--accent); }          /* definition */
+    .pw-cm-editor .ͼi { color: var(--blue, #5080c0); }   /* bool */
+  `;
+  document.head.appendChild(el);
+}
+
+function makeExtensions(onSave: () => void): Extension[] {
+  return [
+    lineNumbers(),
+    highlightActiveLineGutter(),
+    history(),
+    foldGutter(),
+    drawSelection(),
+    dropCursor(),
+    indentOnInput(),
+    syntaxHighlighting(defaultHighlightStyle, { fallback: true }),
+    bracketMatching(),
+    rectangularSelection(),
+    crosshairCursor(),
+    highlightActiveLine(),
+    yaml(),
+    keymap.of([
+      ...defaultKeymap,
+      ...historyKeymap,
+      ...foldKeymap,
+      indentWithTab,
+      { key: "Mod-s", run: () => { onSave(); return true; } },
+    ]),
+    EditorView.lineWrapping,
+  ];
+}
+
+export default function YamlEditor({
+  value,
+  onChange,
+  onSave,
+  minHeight = 400,
+}: {
+  value: string;
+  onChange: (value: string) => void;
+  onSave?: () => void;
+  minHeight?: number;
+}) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const viewRef = useRef<EditorView | null>(null);
+  const onChangeRef = useRef(onChange);
+  const onSaveRef = useRef(onSave);
+  onChangeRef.current = onChange;
+  onSaveRef.current = onSave;
+
+  // Mount editor once
+  useEffect(() => {
+    ensureStyle();
+    if (!containerRef.current) return;
+
+    const state = EditorState.create({
+      doc: value,
+      extensions: [
+        ...makeExtensions(() => onSaveRef.current?.()),
+        EditorView.updateListener.of((update) => {
+          if (update.docChanged) {
+            onChangeRef.current(update.state.doc.toString());
+          }
+        }),
+      ],
+    });
+
+    const view = new EditorView({ state, parent: containerRef.current });
+    viewRef.current = view;
+
+    return () => {
+      view.destroy();
+      viewRef.current = null;
+    };
+    // mount once
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Sync external value changes (e.g. initial load from API) without
+  // clobbering cursor position if the change came from within the editor.
+  useEffect(() => {
+    const view = viewRef.current;
+    if (!view) return;
+    const current = view.state.doc.toString();
+    if (current !== value) {
+      view.dispatch({
+        changes: { from: 0, to: current.length, insert: value },
+      });
+    }
+  }, [value]);
+
+  return (
+    <div
+      ref={containerRef}
+      className="pw-cm-editor"
+      style={{ minHeight, borderRadius: "var(--r-2)" }}
+    />
+  );
+}

--- a/dashboard/src/app/recipes/[name]/edit/page.tsx
+++ b/dashboard/src/app/recipes/[name]/edit/page.tsx
@@ -3,28 +3,18 @@
 import Link from "next/link";
 import { useEffect, useRef, useState } from "react";
 import { apiPath } from "@/lib/api";
+import { useToast } from "@/components/Toast";
+import dynamic from "next/dynamic";
 
-interface Toast {
-  id: number;
-  message: string;
-  kind: "ok" | "err";
-}
+const YamlEditor = dynamic(() => import("./_components/YamlEditor"), {
+  ssr: false,
+  loading: () => (
+    <div style={{ minHeight: 400, background: "var(--recess)", borderRadius: "var(--r-2)", border: "1px solid var(--line-2)", display: "flex", alignItems: "center", justifyContent: "center", color: "var(--ink-3)", fontFamily: "var(--font-mono)", fontSize: "var(--fs-xs)" }}>
+      Loading editor…
+    </div>
+  ),
+});
 
-let toastSeq = 0;
-
-function useToasts() {
-  const [toasts, setToasts] = useState<Toast[]>([]);
-
-  function push(message: string, kind: Toast["kind"]) {
-    const id = ++toastSeq;
-    setToasts((prev) => [...prev, { id, message, kind }]);
-    setTimeout(() => {
-      setToasts((prev) => prev.filter((t) => t.id !== id));
-    }, 4000);
-  }
-
-  return { toasts, push };
-}
 
 export default function RecipeEditPage({
   params,
@@ -33,6 +23,7 @@ export default function RecipeEditPage({
 }) {
   const name = decodeURIComponent(params.name);
   const [content, setContent] = useState<string>("");
+  const [savedContent, setSavedContent] = useState<string>("");
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [running, setRunning] = useState(false);
@@ -40,8 +31,7 @@ export default function RecipeEditPage({
   const [lintErrors, setLintErrors] = useState<string[]>([]);
   const [lintWarnings, setLintWarnings] = useState<string[]>([]);
   const [linting, setLinting] = useState(false);
-  const { toasts, push } = useToasts();
-  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const toast = useToast();
   const lintTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const lintReqIdRef = useRef(0);
 
@@ -61,16 +51,22 @@ export default function RecipeEditPage({
               : typeof data === "object" && data !== null && "content" in data
                 ? (data.content ?? "")
                 : "";
-          if (!cancelled) setContent(text);
+          if (!cancelled) {
+            setContent(text);
+            setSavedContent(text);
+          }
         } else if (res.status === 404) {
-          if (!cancelled) setContent("");
+          if (!cancelled) {
+            setContent("");
+            setSavedContent("");
+          }
         } else {
           const err = await res.text().catch(() => "unknown error");
-          if (!cancelled) push(`Load failed: ${err}`, "err");
+          if (!cancelled) toast.error(`Load failed: ${err}`);
         }
       } catch (e) {
         if (!cancelled)
-          push(`Load failed: ${e instanceof Error ? e.message : String(e)}`, "err");
+          toast.error(`Load failed: ${e instanceof Error ? e.message : String(e)}`);
       } finally {
         if (!cancelled) setLoading(false);
       }
@@ -151,29 +147,60 @@ export default function RecipeEditPage({
       if (res.ok) {
         setLintWarnings(warnings);
         setLintErrors([]);
-        push(
+        setSavedContent(content);
+        toast.success(
           warnings.length > 0
             ? `Saved with ${warnings.length} warning${warnings.length === 1 ? "" : "s"}.`
             : "Saved.",
-          "ok",
         );
       } else {
         const message =
           (data as { error?: string }).error ?? res.statusText ?? "Save failed";
         setSaveError(message);
         setLintWarnings(warnings);
-        push(`Save failed: ${message}`, "err");
+        toast.error(`Save failed: ${message}`);
       }
     } catch (e) {
       const message = e instanceof Error ? e.message : String(e);
       setSaveError(message);
-      push(`Save failed: ${message}`, "err");
+      toast.error(`Save failed: ${message}`);
     } finally {
       setSaving(false);
     }
   }
 
+  const dirty = content !== savedContent;
+
+  useEffect(() => {
+    if (!dirty) return;
+    const onBeforeUnload = (e: BeforeUnloadEvent) => {
+      e.preventDefault();
+      e.returnValue = "";
+    };
+    window.addEventListener("beforeunload", onBeforeUnload);
+    return () => window.removeEventListener("beforeunload", onBeforeUnload);
+  }, [dirty]);
+
+  // Global Cmd/Ctrl+S to save when dirty — works even if textarea isn't focused.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === "s") {
+        e.preventDefault();
+        if (!saving && !loading && dirty) void handleSave();
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dirty, saving, loading]);
+
   async function handleRun() {
+    if (dirty) {
+      const proceed = window.confirm(
+        "You have unsaved changes. Run will execute the SAVED version, not your edits. Continue?",
+      );
+      if (!proceed) return;
+    }
     setRunning(true);
     try {
       const res = await fetch(
@@ -182,19 +209,17 @@ export default function RecipeEditPage({
       );
       if (res.ok) {
         const data = (await res.json()) as { taskId?: string; ok?: boolean };
-        push(
+        toast.success(
           data.taskId ? `Queued task ${data.taskId.slice(0, 8)}` : "Recipe started.",
-          "ok",
         );
       } else {
         const data = await res.json().catch(() => ({ error: res.statusText }));
-        push(
+        toast.error(
           `Run failed: ${(data as { error?: string }).error ?? res.statusText}`,
-          "err",
         );
       }
     } catch (e) {
-      push(`Run failed: ${e instanceof Error ? e.message : String(e)}`, "err");
+      toast.error(`Run failed: ${e instanceof Error ? e.message : String(e)}`);
     } finally {
       setRunning(false);
     }
@@ -202,39 +227,6 @@ export default function RecipeEditPage({
 
   return (
     <section>
-      {/* Toast container */}
-      <div
-        style={{
-          position: "fixed",
-          bottom: "var(--s-6)",
-          right: "var(--s-6)",
-          display: "flex",
-          flexDirection: "column",
-          gap: "var(--s-2)",
-          zIndex: 9000,
-          pointerEvents: "none",
-        }}
-      >
-        {toasts.map((t) => (
-          <div
-            key={t.id}
-            className={`pill ${t.kind === "ok" ? "ok" : "err"}`}
-            style={{
-              padding: "var(--s-2) var(--s-4)",
-              fontSize: "var(--fs-m)",
-              borderRadius: "var(--r-2)",
-              background: t.kind === "ok" ? "var(--ok-soft)" : "var(--err-soft)",
-              border: `1px solid ${t.kind === "ok" ? "var(--ok)" : "var(--err)"}`,
-              color: t.kind === "ok" ? "var(--ok)" : "var(--err)",
-              boxShadow: "0 4px 16px rgba(0,0,0,0.4)",
-              pointerEvents: "auto",
-            }}
-          >
-            {t.message}
-          </div>
-        ))}
-      </div>
-
       {/* Header */}
       <div className="page-head">
         <div>
@@ -288,9 +280,10 @@ export default function RecipeEditPage({
             type="button"
             className="btn primary"
             onClick={() => void handleSave()}
-            disabled={saving || loading}
+            disabled={saving || loading || !dirty}
+            title={!dirty && !saving ? "No unsaved changes" : undefined}
           >
-            {saving ? "Saving…" : "Save"}
+            {saving ? "Saving…" : dirty ? "Save •" : "Save"}
           </button>
         </div>
       </div>
@@ -398,60 +391,14 @@ export default function RecipeEditPage({
             <p>Loading…</p>
           </div>
         ) : (
-          <textarea
-            ref={textareaRef}
+          <YamlEditor
             value={content}
-            onChange={(e) => {
-              setContent(e.target.value);
+            onChange={(v) => {
+              setContent(v);
               if (saveError) setSaveError(null);
             }}
-            spellCheck={false}
-            aria-label={`YAML content for recipe ${name}`}
-            style={{
-              width: "100%",
-              minHeight: 400,
-              background: "var(--recess)",
-              color: "var(--ink-0)",
-              border: "1px solid var(--line-2)",
-              borderRadius: "var(--r-2)",
-              fontFamily: "var(--font-mono, 'JetBrains Mono', 'Fira Code', monospace)",
-              fontSize: "var(--fs-m)",
-              lineHeight: 1.6,
-              padding: "var(--s-4)",
-              resize: "vertical",
-              outline: "none",
-              boxSizing: "border-box",
-              tabSize: 2,
-            }}
-            onFocus={(e) => {
-              e.currentTarget.style.borderColor = "var(--accent)";
-            }}
-            onBlur={(e) => {
-              e.currentTarget.style.borderColor = "var(--line-2)";
-            }}
-            onKeyDown={(e) => {
-              if (e.key === "Tab" && !e.shiftKey && !e.altKey && !e.ctrlKey && !e.metaKey) {
-                e.preventDefault();
-                const ta = e.currentTarget;
-                const start = ta.selectionStart;
-                const end = ta.selectionEnd;
-                const newContent =
-                  content.substring(0, start) + "  " + content.substring(end);
-                setContent(newContent);
-                requestAnimationFrame(() => {
-                  ta.selectionStart = start + 2;
-                  ta.selectionEnd = start + 2;
-                });
-              }
-              if (e.key === "Escape") {
-                e.currentTarget.blur();
-                return;
-              }
-              if ((e.metaKey || e.ctrlKey) && e.key === "s") {
-                e.preventDefault();
-                void handleSave();
-              }
-            }}
+            onSave={() => void handleSave()}
+            minHeight={400}
           />
         )}
         <div

--- a/dashboard/src/app/recipes/[name]/edit/page.tsx
+++ b/dashboard/src/app/recipes/[name]/edit/page.tsx
@@ -72,6 +72,29 @@ export default function RecipeEditPage({
       }
     }
     void load();
+    // The new-recipe form stashes any save-time `warnings` in
+    // sessionStorage so we can show them once on first paint here.
+    // (The debounced lint pass below will re-derive its own list a few
+    // hundred ms later — this just avoids a "saved successfully ✓"
+    // moment that hides server-side feedback.)
+    try {
+      const key = `recipe-save-warnings:${name}`;
+      const stashed = sessionStorage.getItem(key);
+      if (stashed) {
+        sessionStorage.removeItem(key);
+        const parsed = JSON.parse(stashed) as unknown;
+        if (Array.isArray(parsed) && parsed.length > 0) {
+          toast.info(
+            `Saved with ${parsed.length} warning${parsed.length === 1 ? "" : "s"}: ${parsed
+              .filter((w): w is string => typeof w === "string")
+              .slice(0, 3)
+              .join("; ")}${parsed.length > 3 ? "…" : ""}`,
+          );
+        }
+      }
+    } catch {
+      // sessionStorage parse failure is benign — lint will re-derive.
+    }
     return () => {
       cancelled = true;
     };

--- a/dashboard/src/app/recipes/[name]/plan/page.tsx
+++ b/dashboard/src/app/recipes/[name]/plan/page.tsx
@@ -60,6 +60,37 @@ function RiskBadge({ risk }: { risk?: string }) {
   );
 }
 
+// Mirrors src/claudeOrchestrator.ts: ~4 chars per token for English/code.
+// Steps without a prompt (raw tool calls) still consume a small request-
+// envelope baseline, so we charge a flat 40 tokens to avoid implying free
+// execution for tool-only steps.
+const TOKENS_PER_CHAR = 0.25;
+const TOOL_STEP_BASELINE_TOKENS = 40;
+
+function estimateStepTokens(step: PlanStep): number {
+  if (step.prompt) return Math.ceil(step.prompt.length * TOKENS_PER_CHAR);
+  return TOOL_STEP_BASELINE_TOKENS;
+}
+
+function formatTokens(n: number): string {
+  if (n >= 1000) return `${(n / 1000).toFixed(n >= 10_000 ? 0 : 1)}k`;
+  return n.toLocaleString();
+}
+
+// Rough lower-bound cost using Claude Sonnet input pricing ($3 / 1M tokens).
+// Output tokens cost more, but we have no way to estimate output size from
+// a static plan. Surfacing the input-only floor keeps users honest about
+// "approximately, at least this much" without overpromising.
+const INPUT_COST_PER_TOKEN = 3 / 1_000_000;
+
+function formatCost(tokens: number): string {
+  const usd = tokens * INPUT_COST_PER_TOKEN;
+  if (usd < 0.001) return "<$0.001";
+  if (usd < 0.01) return `$${usd.toFixed(4)}`;
+  if (usd < 1) return `$${usd.toFixed(3)}`;
+  return `$${usd.toFixed(2)}`;
+}
+
 function TypeBadge({ type }: { type: string }) {
   const colors: Record<string, string> = {
     tool: "var(--accent)",
@@ -193,7 +224,12 @@ export default function RecipePlanPage({
         </div>
       )}
 
-      {plan && (
+      {plan && (() => {
+        const totalTokens = plan.steps.reduce(
+          (sum, s) => sum + estimateStepTokens(s),
+          0,
+        );
+        return (
         <div
           style={{ display: "flex", flexDirection: "column", gap: "var(--s-5)" }}
         >
@@ -217,6 +253,22 @@ export default function RecipePlanPage({
               Steps:{" "}
               <strong style={{ color: "var(--fg-0)" }}>
                 {plan.steps.length}
+              </strong>
+            </span>
+            <span
+              title={`Est. ${totalTokens.toLocaleString()} input tokens (≈4 chars/token, +${TOOL_STEP_BASELINE_TOKENS} baseline per tool-only step). Output tokens not counted.`}
+            >
+              Est. tokens:{" "}
+              <strong style={{ color: "var(--fg-0)" }}>
+                ~{formatTokens(totalTokens)}
+              </strong>
+            </span>
+            <span
+              title="Lower-bound input-only cost @ $3/M (Sonnet pricing). Output tokens & cache effects not modelled — actual bill will be higher."
+            >
+              Min. cost:{" "}
+              <strong style={{ color: "var(--fg-0)" }}>
+                ≥ {formatCost(totalTokens)}
               </strong>
             </span>
             {plan.hasWriteSteps && (
@@ -493,7 +545,8 @@ export default function RecipePlanPage({
             </div>
           )}
         </div>
-      )}
+        );
+      })()}
     </section>
   );
 }

--- a/dashboard/src/app/recipes/new/page.tsx
+++ b/dashboard/src/app/recipes/new/page.tsx
@@ -247,6 +247,7 @@ function NewRecipePageInner() {
     emptyValidationState(initialForm),
   );
   const [submitError, setSubmitError] = useState<string | null>(null);
+  const [submitNotice, setSubmitNotice] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
 
   const [aiOpen, setAiOpen] = useState(false);
@@ -419,16 +420,32 @@ function NewRecipePageInner() {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ prompt: aiPrompt }),
       });
-      const data = (await res.json()) as {
-        ok: boolean;
+      const text = await res.text();
+      let data: {
+        ok?: boolean;
         yaml?: string;
         warnings?: string[];
         error?: string;
         unavailable?: boolean;
-      };
+      } = {};
+      try {
+        data = text ? JSON.parse(text) : {};
+      } catch {
+        setAiResult({
+          error: `Generation failed: HTTP ${res.status} ${res.statusText || ""}`.trim(),
+        });
+        return;
+      }
+      if (!res.ok && !data.error && !data.unavailable) {
+        setAiResult({
+          error: `Generation failed: HTTP ${res.status} ${res.statusText || ""}`.trim(),
+        });
+        return;
+      }
       if (data.unavailable) {
         setAiResult({
           error:
+            data.error ??
             "AI generation is not available — start the bridge with --claude-driver subprocess.",
         });
       } else if (data.ok && data.yaml) {
@@ -603,6 +620,7 @@ function NewRecipePageInner() {
     const content = buildRecipeYaml(form, safeName);
 
     setSaving(true);
+    setSubmitNotice(null);
     try {
       const res = await fetch(
         apiPath(`/api/bridge/recipes/${encodeURIComponent(safeName)}`),
@@ -612,9 +630,19 @@ function NewRecipePageInner() {
           body: JSON.stringify({ content }),
         },
       );
-      const data = (await res.json()) as { ok?: boolean; error?: string };
+      const data = (await res.json()) as {
+        ok?: boolean;
+        error?: string;
+        demo?: boolean;
+      };
       if (res.ok && data.ok !== false) {
-        router.push(`/recipes/${encodeURIComponent(safeName)}/edit`);
+        if (data.demo) {
+          setSubmitNotice(
+            "Demo mode — recipe was not persisted. Disable demo mode to save real recipes.",
+          );
+        } else {
+          router.push(`/recipes/${encodeURIComponent(safeName)}/edit`);
+        }
       } else if (data.error === "Invalid recipe name") {
         setNameError(data.error);
       } else {
@@ -1411,6 +1439,21 @@ function NewRecipePageInner() {
 
             {/* Actions */}
             {submitError && <div className="alert-err">{submitError}</div>}
+            {submitNotice && (
+              <div
+                role="status"
+                style={{
+                  background: "var(--bg-2)",
+                  border: "1px solid var(--border-default)",
+                  borderRadius: "var(--r-2)",
+                  color: "var(--fg-1)",
+                  fontSize: "var(--fs-s)",
+                  padding: "var(--s-2) var(--s-3)",
+                }}
+              >
+                {submitNotice}
+              </div>
+            )}
             <div
               style={{
                 display: "flex",

--- a/dashboard/src/app/recipes/new/page.tsx
+++ b/dashboard/src/app/recipes/new/page.tsx
@@ -1,12 +1,18 @@
 "use client";
 import { useRouter, useSearchParams } from "next/navigation";
 import { Suspense, useCallback, useMemo, useState } from "react";
+import { parse as parseYaml } from "yaml";
 import { apiPath } from "@/lib/api";
 
 interface Step {
   id: string;
   agent: boolean;
   prompt: string;
+  // When present, used verbatim instead of deriving from `id` via
+  // `makeStepOutputKey`. Lets us preserve the AI generator's semantic
+  // `into:` keys (e.g. `notifications_summary`) so step→step references
+  // like `{{notifications_summary}}` keep resolving.
+  into?: string;
 }
 
 interface RecipeVar {
@@ -68,8 +74,20 @@ function validateForm(form: FormState): ValidationState {
     errors.triggerPath = "Webhook path is required.";
   }
 
-  if (form.trigger.type === "schedule" && !form.trigger.cron.trim()) {
-    errors.cron = "Cron expression is required.";
+  if (form.trigger.type === "schedule") {
+    const at = form.trigger.cron.trim();
+    if (!at) {
+      errors.cron = "Cron expression is required.";
+    } else if (
+      !/^@every\s+\d+\s*(ms|s|m|h)$/i.test(at) &&
+      !/^\S+\s+\S+\s+\S+\s+\S+\s+\S+$/.test(at)
+    ) {
+      // Cheap shape check — server runs node-cron's full validator. Catches
+      // obvious typos ("bogus", 3-field, 6-field) without pulling node-cron
+      // into the bundle.
+      errors.cron =
+        'Expected 5-field cron (e.g. "0 9 * * 1-5") or "@every Ns|Nm|Nh".';
+    }
   }
 
   for (let i = 0; i < form.steps.length; i++) {
@@ -204,7 +222,11 @@ function buildRecipeYaml(form: FormState, safeName: string): string {
     lines.push(`  - id: ${yamlScalar(stepId)}`);
     lines.push("    agent:");
     pushYamlField(lines, 6, "prompt", step?.prompt.trim() || "(empty)");
-    lines.push(`      into: ${yamlScalar(makeStepOutputKey(stepId))}`);
+    // Preserve a parsed `into:` (e.g. from AI-generated YAML) verbatim;
+    // otherwise derive a slug from the step id. This keeps semantic keys
+    // like `notifications_summary` intact across the form round-trip.
+    const intoKey = step?.into?.trim() || makeStepOutputKey(stepId);
+    lines.push(`      into: ${yamlScalar(intoKey)}`);
   }
 
   return lines.join("\n");
@@ -471,137 +493,131 @@ function NewRecipePageInner() {
     }
   }
 
-  function applyAiYaml(yaml: string) {
-    // Best-effort parse into form fields. On failure, keep the YAML visible
-    // so the user can copy it manually.
+  function applyAiYaml(yamlText: string) {
+    // Parse the AI-generated YAML into the form's structured shape using a
+    // real parser. The previous hand-rolled line-scan dropped vars,
+    // rewrote step `into:` keys, and matched the first indented `at:`/`path:`
+    // anywhere — pulling step-level fields into `trigger`. On parse failure
+    // we leave the form alone so the user can copy YAML manually.
+    type RawStep = {
+      id?: unknown;
+      agent?: { prompt?: unknown; into?: unknown } | unknown;
+      prompt?: unknown;
+    };
+    type RawTrigger = {
+      type?: unknown;
+      at?: unknown;
+      path?: unknown;
+      vars?: unknown;
+      inputs?: unknown;
+    };
+    type RawRecipe = {
+      name?: unknown;
+      description?: unknown;
+      trigger?: RawTrigger | unknown;
+      vars?: unknown;
+      steps?: unknown;
+    };
+
+    let recipe: RawRecipe;
     try {
-      const lines = yaml.split("\n");
-      const nameMatch = lines.find((l) => /^name:\s/.test(l));
-      const descMatch = lines.find((l) => /^description:\s/.test(l));
-      const triggerTypeMatch = lines.find((l) => /^\s+type:\s/.test(l));
-      const triggerAtMatch = lines.find((l) => /^\s+at:\s/.test(l));
-      const triggerPathMatch = lines.find((l) => /^\s+path:\s/.test(l));
-
-      const parsedName = nameMatch
-        ? (nameMatch.replace(/^name:\s*/, "").trim().replace(/^"|"$/g, "") ?? "")
-        : "";
-      const parsedDesc = descMatch
-        ? (descMatch
-            .replace(/^description:\s*/, "")
-            .trim()
-            .replace(/^"|"$/g, "") ?? "")
-        : "";
-      const parsedTriggerType = triggerTypeMatch
-        ? (triggerTypeMatch.replace(/^\s+type:\s*/, "").trim() as
-            | "manual"
-            | "webhook"
-            | "schedule"
-            | "cron")
-        : "manual";
-      const normalizedType: "manual" | "webhook" | "schedule" =
-        parsedTriggerType === "cron" ? "schedule" : parsedTriggerType === "webhook" ? "webhook" : "manual";
-      const parsedCron = triggerAtMatch
-        ? triggerAtMatch
-            .replace(/^\s+at:\s*/, "")
-            .trim()
-            .replace(/^"|"$/g, "")
-        : "";
-      const parsedPath = triggerPathMatch
-        ? triggerPathMatch
-            .replace(/^\s+path:\s*/, "")
-            .trim()
-            .replace(/^"|"$/g, "")
-            .replace(/^\/hooks\//, "")
-        : "";
-
-      // Parse steps: collect prompt strings from `- id: step-X` blocks under
-      // the top-level `steps:` key. We don't pull a full YAML parser in just
-      // for this — the AI generator emits a predictable shape.
-      const parsedSteps: Step[] = [];
-      const stepsIdx = lines.findIndex((l) => /^steps:\s*$/.test(l));
-      if (stepsIdx >= 0) {
-        let i = stepsIdx + 1;
-        let current: Partial<Step> | null = null;
-        // Multiline prompt buffer for `prompt: |` block scalars.
-        let promptBuf: string[] | null = null;
-        let promptBaseIndent = 0;
-        const flush = () => {
-          if (current && current.id) {
-            parsedSteps.push({
-              id: current.id,
-              agent: current.agent ?? true,
-              prompt: (current.prompt ?? "").trim(),
-            });
-          }
-          current = null;
-          promptBuf = null;
-        };
-        while (i < lines.length) {
-          const raw = lines[i] ?? "";
-          // Stop at a new top-level key (no leading space and ends with `:`).
-          if (/^[a-zA-Z_]/.test(raw)) break;
-          if (promptBuf) {
-            const indent = raw.match(/^(\s*)/)?.[1].length ?? 0;
-            if (raw.trim() === "" || indent > promptBaseIndent) {
-              promptBuf.push(raw.slice(Math.min(promptBaseIndent + 2, indent)));
-              i++;
-              continue;
-            }
-            current = { ...current, prompt: promptBuf.join("\n").trim() };
-            promptBuf = null;
-            // fall through to handle this line as a new key
-          }
-          const itemMatch = raw.match(/^\s*-\s*id:\s*(.+?)\s*$/);
-          if (itemMatch) {
-            flush();
-            current = { id: itemMatch[1]?.replace(/^"|"$/g, "") };
-            i++;
-            continue;
-          }
-          const kvMatch = raw.match(/^\s+([a-zA-Z_]+):\s*(.*)$/);
-          if (kvMatch && current) {
-            const key = kvMatch[1];
-            const value = kvMatch[2]?.trim() ?? "";
-            if (key === "agent") {
-              current.agent = value === "true";
-            } else if (key === "prompt") {
-              if (value === "|" || value === ">" || value === "|-" || value === ">-") {
-                promptBuf = [];
-                promptBaseIndent =
-                  (raw.match(/^(\s*)/)?.[1].length ?? 0);
-              } else {
-                current.prompt = value.replace(/^"|"$/g, "").replace(/^'|'$/g, "");
-              }
-            }
-          }
-          i++;
-        }
-        flush();
-      }
-
-      setForm((f) => ({
-        ...f,
-        name: parsedName || f.name,
-        description: parsedDesc || f.description,
-        trigger: {
-          type: normalizedType,
-          cron: parsedCron,
-          path: parsedPath,
-        },
-        steps: parsedSteps.length > 0 ? parsedSteps : f.steps,
-      }));
-      setValidation((cur) => ({
-        ...cur,
-        steps:
-          parsedSteps.length > 0
-            ? parsedSteps.map(() => null)
-            : cur.steps,
-      }));
-      setAiOpen(false);
-      setAiResult(null);
+      recipe = (parseYaml(yamlText) ?? {}) as RawRecipe;
+      if (typeof recipe !== "object") return;
     } catch {
-      // If parsing fails, leave everything as-is — user can see the YAML
+      return;
     }
+
+    const asString = (v: unknown): string =>
+      typeof v === "string" ? v : "";
+    const asBool = (v: unknown): boolean =>
+      typeof v === "boolean" ? v : v === "true";
+
+    const trigger: RawTrigger =
+      recipe.trigger && typeof recipe.trigger === "object"
+        ? (recipe.trigger as RawTrigger)
+        : {};
+
+    const rawType = asString(trigger.type);
+    const normalizedType: "manual" | "webhook" | "schedule" =
+      rawType === "cron" || rawType === "schedule"
+        ? "schedule"
+        : rawType === "webhook"
+          ? "webhook"
+          : "manual";
+
+    const parsedCron = asString(trigger.at);
+    const parsedPath = asString(trigger.path).replace(/^\/hooks\//, "");
+
+    // vars may live under trigger.vars (canonical) or trigger.inputs
+    // (alias the validator also accepts). The AI sometimes emits top-level
+    // `vars:` despite the system prompt — accept that too as a fallback so
+    // the user doesn't lose declarations on "Use this".
+    const rawVars =
+      (Array.isArray(trigger.vars) && trigger.vars) ||
+      (Array.isArray(trigger.inputs) && trigger.inputs) ||
+      (Array.isArray(recipe.vars) && recipe.vars) ||
+      [];
+    const parsedVars: RecipeVar[] = (rawVars as unknown[])
+      .filter((v): v is Record<string, unknown> =>
+        Boolean(v) && typeof v === "object",
+      )
+      .map((v) => ({
+        name: asString(v.name),
+        description: asString(v.description),
+        required: asBool(v.required),
+        default: asString(v.default),
+      }))
+      .filter((v) => v.name);
+
+    const rawSteps = Array.isArray(recipe.steps) ? recipe.steps : [];
+    const parsedSteps: Step[] = rawSteps
+      .filter((s): s is RawStep =>
+        Boolean(s) && typeof s === "object",
+      )
+      .map((s, i) => {
+        // Step shapes we accept:
+        //   - id: foo            ← schema-canonical
+        //     agent:
+        //       prompt: ...
+        //       into: foo_output
+        //   - agent: { prompt: ..., into: ... }   ← id is optional in schema
+        //   - prompt: ...                           ← shorthand
+        const agentBlock =
+          s.agent && typeof s.agent === "object"
+            ? (s.agent as { prompt?: unknown; into?: unknown })
+            : null;
+        const prompt = agentBlock
+          ? asString(agentBlock.prompt)
+          : asString(s.prompt);
+        const into = agentBlock ? asString(agentBlock.into) : "";
+        const step: Step = {
+          id: asString(s.id) || makeStepId(i),
+          agent: true,
+          prompt: prompt.trim(),
+        };
+        if (into) step.into = into;
+        return step;
+      });
+
+    setForm((f) => ({
+      ...f,
+      name: asString(recipe.name) || f.name,
+      description: asString(recipe.description) || f.description,
+      trigger: {
+        type: normalizedType,
+        cron: parsedCron,
+        path: parsedPath,
+      },
+      vars: parsedVars.length > 0 ? parsedVars : f.vars,
+      steps: parsedSteps.length > 0 ? parsedSteps : f.steps,
+    }));
+    setValidation((cur) => ({
+      ...cur,
+      steps: parsedSteps.length > 0 ? parsedSteps.map(() => null) : cur.steps,
+      vars: parsedVars.length > 0 ? parsedVars.map(() => null) : cur.vars,
+    }));
+    setAiOpen(false);
+    setAiResult(null);
   }
 
   async function handleSubmit(e: React.FormEvent) {
@@ -637,12 +653,29 @@ function NewRecipePageInner() {
         ok?: boolean;
         error?: string;
         demo?: boolean;
+        warnings?: string[];
       };
       if (res.ok && data.ok !== false) {
         if (data.demo) {
           setSubmitNotice(
             "Demo mode — recipe was not persisted. Disable demo mode to save real recipes.",
           );
+        } else if (data.warnings && data.warnings.length > 0) {
+          // Forward warnings to the edit page via sessionStorage so the
+          // user sees them on first paint there. The edit page does its
+          // own lint pass on mount, but that runs ~400ms after content
+          // settles and uses different copy — handing off here avoids a
+          // confusing flash.
+          try {
+            sessionStorage.setItem(
+              `recipe-save-warnings:${safeName}`,
+              JSON.stringify(data.warnings),
+            );
+          } catch {
+            // sessionStorage unavailable — non-fatal, edit page will
+            // re-derive warnings on its own lint pass.
+          }
+          router.push(`/recipes/${encodeURIComponent(safeName)}/edit`);
         } else {
           router.push(`/recipes/${encodeURIComponent(safeName)}/edit`);
         }

--- a/dashboard/src/app/recipes/new/page.tsx
+++ b/dashboard/src/app/recipes/new/page.tsx
@@ -178,18 +178,21 @@ function buildRecipeYaml(form: FormState, safeName: string): string {
     lines.push("  type: manual");
   }
 
+  // vars nest under trigger — validator (src/recipes/validation.ts) only
+  // reads trigger.vars when building available template-ref roots; a
+  // top-level `vars:` is not in schemas/recipe.v1.json.
   if (form.vars.length > 0) {
-    lines.push("vars:");
+    lines.push("  vars:");
     for (const variable of form.vars) {
-      lines.push(`  - name: ${yamlScalar(variable.name.trim() || "(name)")}`);
+      lines.push(`    - name: ${yamlScalar(variable.name.trim() || "(name)")}`);
       if (variable.description.trim()) {
-        pushYamlField(lines, 4, "description", variable.description.trim());
+        pushYamlField(lines, 6, "description", variable.description.trim());
       }
       if (variable.required) {
-        lines.push("    required: true");
+        lines.push("      required: true");
       }
       if (variable.default) {
-        pushYamlField(lines, 4, "default", variable.default);
+        pushYamlField(lines, 6, "default", variable.default);
       }
     }
   }

--- a/dashboard/src/app/recipes/page.tsx
+++ b/dashboard/src/app/recipes/page.tsx
@@ -695,6 +695,17 @@ export default function RecipesPage() {
 
   async function handleToggleEnabled(recipe: Recipe) {
     const target = recipe.enabled === false;
+    // Disabling a non-manual trigger (cron/webhook/event) silently stops a
+    // recurring job — confirm before the optimistic flip so the operator
+    // doesn't kill a production schedule with a stray click.
+    const trigger = recipe.trigger ?? "manual";
+    const isAutonomous = trigger !== "manual";
+    if (!target && isAutonomous) {
+      const proceed = window.confirm(
+        `Disable "${recipe.name}"? Trigger "${trigger}" will stop firing until you re-enable.`,
+      );
+      if (!proceed) return;
+    }
     // Optimistic flip — the toggle was tap-then-wait-2s before, which felt
     // unresponsive. Roll back to the previous state if the PATCH fails.
     setRecipes((prev) =>
@@ -839,7 +850,7 @@ export default function RecipesPage() {
           title="Couldn't load recipes"
           description="The bridge isn't responding to /recipes. Check that the bridge is running."
           error={err}
-          onRetry={() => window.location.reload()}
+          onRetry={() => void load()}
         />
       )}
       {err && recipes && recipes.length > 0 && (
@@ -975,51 +986,74 @@ export default function RecipesPage() {
                           {last ? relTime(last.startedAt) : "—"}
                         </td>
                         <td
-                          style={{ textAlign: "right" }}
+                          style={{ textAlign: "right", whiteSpace: "nowrap" }}
                           onClick={(e) => e.stopPropagation()}
                         >
-                          <button
-                            type="button"
-                            role="switch"
-                            aria-checked={enabled}
-                            aria-label={`${enabled ? "Disable" : "Enable"} ${r.name}`}
-                            onClick={() => void handleToggleEnabled(r)}
+                          <div
                             style={{
-                              position: "relative",
-                              width: 36,
-                              height: 20,
-                              borderRadius: 999,
-                              border: "1px solid var(--line-2)",
-                              background: enabled ? "var(--ok)" : "var(--bg-2)",
-                              cursor: "pointer",
-                              padding: 0,
-                              transition: "background 0.15s",
+                              display: "inline-flex",
+                              alignItems: "center",
+                              gap: 8,
+                              opacity: enabled ? 1 : 0.85,
                             }}
                           >
-                            <span
-                              aria-hidden="true"
+                            <button
+                              type="button"
+                              role="switch"
+                              aria-checked={enabled}
+                              aria-label={`${enabled ? "Disable" : "Enable"} ${r.name}`}
+                              title={enabled ? "Enabled — click to disable" : "Disabled — click to enable"}
+                              onClick={() => void handleToggleEnabled(r)}
                               style={{
-                                position: "absolute",
-                                top: 1,
-                                left: enabled ? 17 : 1,
-                                width: 16,
-                                height: 16,
-                                borderRadius: "50%",
-                                background: "var(--surface)",
-                                transition: "left 0.15s",
-                                boxShadow: "var(--shadow-s, 0 1px 2px rgba(0,0,0,0.2))",
+                                position: "relative",
+                                width: 26,
+                                height: 14,
+                                borderRadius: 999,
+                                border: `1px solid ${enabled ? "var(--ok)" : "var(--line-2)"}`,
+                                background: enabled ? "var(--green-soft)" : "var(--bg-2)",
+                                cursor: "pointer",
+                                padding: 0,
+                                flexShrink: 0,
+                                transition: "background 0.15s, border-color 0.15s",
                               }}
-                            />
-                          </button>
-                          <button
-                            type="button"
-                            className="btn sm"
-                            style={{ marginLeft: 8, fontSize: "var(--fs-xs)" }}
-                            onClick={() => handleRunClick(r)}
-                            disabled={!enabled}
-                          >
-                            Run{r.vars && r.vars.length > 0 ? "…" : ""}
-                          </button>
+                            >
+                              <span
+                                aria-hidden="true"
+                                style={{
+                                  position: "absolute",
+                                  top: 1,
+                                  left: 1,
+                                  width: 10,
+                                  height: 10,
+                                  borderRadius: "50%",
+                                  background: enabled ? "var(--ok)" : "var(--ink-3)",
+                                  transform: enabled ? "translateX(12px)" : "translateX(0)",
+                                  transition: "transform 0.18s ease, background 0.15s",
+                                  boxShadow: "0 1px 1px rgba(0,0,0,0.12)",
+                                }}
+                              />
+                            </button>
+                            <button
+                              type="button"
+                              className="btn sm"
+                              style={{
+                                fontSize: "var(--fs-xs)",
+                                display: "inline-flex",
+                                alignItems: "center",
+                                gap: 4,
+                              }}
+                              onClick={() => handleRunClick(r)}
+                              disabled={!enabled}
+                            >
+                              <span
+                                aria-hidden="true"
+                                style={{ fontSize: 8, lineHeight: 1, color: "var(--accent)" }}
+                              >
+                                ▶
+                              </span>
+                              Run{r.vars && r.vars.length > 0 ? "…" : ""}
+                            </button>
+                          </div>
                         </td>
                       </tr>
                     );

--- a/dashboard/src/app/runs/page.tsx
+++ b/dashboard/src/app/runs/page.tsx
@@ -6,6 +6,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { LivePill } from "@/components/patchwork/LivePill";
 import { ErrorState } from "@/components/patchwork";
 import { ActivityTabs } from "@/components/ActivityTabs";
+import { useDebounced } from "@/hooks/useDebounced";
 
 interface AssertionFailure {
   assertion: string;
@@ -95,6 +96,7 @@ export default function RunsPage() {
   const [trigger, setTrigger] = useState<TriggerFilter>("all");
   const [status, setStatus] = useState<StatusFilter>("all");
   const [recipeQuery, setRecipeQuery] = useState("");
+  const debouncedRecipeQuery = useDebounced(recipeQuery, 250);
   const [limit, setLimit] = useState(RUNS_PAGE_SIZE);
   const [expanded, setExpanded] = useState<string | null>(null);
 
@@ -106,7 +108,7 @@ export default function RunsPage() {
         const params = new URLSearchParams({ limit: String(limit) });
         if (trigger !== "all") params.set("trigger", trigger);
         if (status !== "all") params.set("status", status);
-        if (recipeQuery) params.set("recipe", recipeQuery);
+        if (debouncedRecipeQuery) params.set("recipe", debouncedRecipeQuery);
         const res = await fetch(apiPath(`/api/bridge/runs?${params}`));
         if (!res.ok) throw new Error(`/runs ${res.status}`);
         const data = (await res.json()) as { runs?: Run[] };
@@ -120,12 +122,12 @@ export default function RunsPage() {
     load();
     const id = setInterval(load, 5000);
     return () => clearInterval(id);
-  }, [trigger, status, recipeQuery, limit]);
+  }, [trigger, status, debouncedRecipeQuery, limit]);
 
   // Reset page size when filters change so we don't accidentally hold a giant fetch.
   useEffect(() => {
     setLimit(RUNS_PAGE_SIZE);
-  }, [trigger, status, recipeQuery]);
+  }, [trigger, status, debouncedRecipeQuery]);
 
   const stats = useMemo(() => {
     const list = runs ?? [];

--- a/dashboard/src/app/sessions/[id]/page.tsx
+++ b/dashboard/src/app/sessions/[id]/page.tsx
@@ -1,9 +1,79 @@
 "use client";
 import Link from "next/link";
 import { useParams } from "next/navigation";
+import dynamic from "next/dynamic";
 import { relTime } from "@/components/time";
 import { useBridgeFetch } from "@/hooks/useBridgeFetch";
 import { arr, isRecord, shape, type ShapeCheck } from "@/lib/validate";
+
+const MessageMarkdown = dynamic(() => import("@/components/MessageMarkdown"), {
+  ssr: false,
+  loading: () => null,
+});
+
+// Inline markdown for the narrow "Detail" column: keeps paragraphs flush
+// (no top/bottom margins), styles inline code as a soft pill, and lets
+// long unbroken tokens (paths, hashes) wrap instead of overflowing.
+const detailMarkdownComponents = {
+  p: ({ children }: { children?: React.ReactNode }) => (
+    <span
+      style={{
+        display: "inline",
+        overflowWrap: "break-word",
+        wordBreak: "break-word",
+      }}
+    >
+      {children}
+    </span>
+  ),
+  code: ({ children, className }: { children?: React.ReactNode; className?: string }) => {
+    const isBlock = !!className;
+    return isBlock ? (
+      <code style={{ fontFamily: "var(--font-mono)", fontSize: "var(--fs-xs)" }}>{children}</code>
+    ) : (
+      <code
+        style={{
+          fontFamily: "var(--font-mono)",
+          fontSize: "0.875em",
+          background: "var(--recess)",
+          border: "1px solid var(--line-1)",
+          borderRadius: 4,
+          padding: "1px 5px",
+          wordBreak: "break-all",
+        }}
+      >
+        {children}
+      </code>
+    );
+  },
+  pre: ({ children }: { children?: React.ReactNode }) => (
+    <pre
+      style={{
+        background: "var(--recess)",
+        border: "1px solid var(--line-2)",
+        borderRadius: "var(--r-s)",
+        padding: "8px 10px",
+        margin: "4px 0 0",
+        fontSize: "var(--fs-xs)",
+        fontFamily: "var(--font-mono)",
+        lineHeight: 1.55,
+        overflowX: "auto",
+        whiteSpace: "pre-wrap",
+        wordBreak: "break-all",
+      }}
+    >
+      {children}
+    </pre>
+  ),
+  a: ({ children, href }: { children?: React.ReactNode; href?: string }) => (
+    <a href={href} style={{ color: "var(--accent)" }} target="_blank" rel="noreferrer">
+      {children}
+    </a>
+  ),
+  strong: ({ children }: { children?: React.ReactNode }) => (
+    <strong style={{ color: "var(--fg-0)" }}>{children}</strong>
+  ),
+};
 
 interface SessionSummary {
   id: string;
@@ -468,9 +538,14 @@ export default function SessionDetailPage() {
                           </span>
                         </td>
                         <td style={{ fontSize: "var(--fs-m)" }}>
-                          {t.status === "error" && t.errorMessage
-                            ? t.errorMessage
-                            : `${t.durationMs}ms`}
+                          {t.status === "error" && t.errorMessage ? (
+                            <MessageMarkdown
+                              content={t.errorMessage}
+                              components={detailMarkdownComponents}
+                            />
+                          ) : (
+                            `${t.durationMs}ms`
+                          )}
                         </td>
                       </tr>
                     );
@@ -504,7 +579,16 @@ export default function SessionDetailPage() {
                           {e.event}
                         </span>
                       </td>
-                      <td style={{ fontSize: "var(--fs-m)" }}>{detail}</td>
+                      <td style={{ fontSize: "var(--fs-m)" }}>
+                        {detail === "—" ? (
+                          detail
+                        ) : (
+                          <MessageMarkdown
+                            content={detail}
+                            components={detailMarkdownComponents}
+                          />
+                        )}
+                      </td>
                     </tr>
                   );
                 })}

--- a/dashboard/src/app/sessions/page.tsx
+++ b/dashboard/src/app/sessions/page.tsx
@@ -1,9 +1,8 @@
 "use client";
-import { useState } from "react";
+import { Fragment, useState } from "react";
 import { relTime } from "@/components/time";
 import { useBridgeFetch } from "@/hooks/useBridgeFetch";
 import { apiPath } from "@/lib/api";
-import { Spinner } from "@/components/patchwork/Spinner";
 import { ErrorState } from "@/components/patchwork";
 import { SkeletonList } from "@/components/Skeleton";
 import { ActivityTabs } from "@/components/ActivityTabs";
@@ -25,8 +24,8 @@ function recipeFor(s: SessionSummary): string {
 }
 
 function descriptionFor(recipe: string, hasRealRecipe: boolean): string {
-  if (!hasRealRecipe) return "no recipe metadata reported";
-  return `${recipe} — running …`;
+  if (!hasRealRecipe) return "no first tool reported";
+  return `first tool · ${recipe}`;
 }
 
 function activityState(
@@ -41,24 +40,33 @@ function activityState(
 
 // ----------------------------------------------------------- log panel
 
-function SessionLogPanel({
+function SessionSummaryPanel({
+  session,
   shortId,
-  recipe,
-  toolCount,
 }: {
+  session: SessionSummary;
   shortId: string;
-  recipe: string;
-  toolCount: number;
 }) {
-  const lines = [
-    `$ patchwork run ${recipe}`,
-    `→ resolving recipe templates/recipes/${recipe}.yaml`,
-    `→ session ${shortId} streaming · live tail not yet wired`,
+  const firstTool = session.firstTool ?? "—";
+  const connectedRel = relTime(new Date(session.connectedAt).getTime());
+  const lastActivity =
+    session.lastActivityAt !== undefined
+      ? relTime(typeof session.lastActivityAt === "number" ? session.lastActivityAt : new Date(session.lastActivityAt).getTime())
+      : "—";
+  const rows: { k: string; v: string }[] = [
+    { k: "session", v: shortId },
+    { k: "client", v: session.clientType ?? "unknown" },
+    { k: "connected", v: connectedRel },
+    { k: "last activity", v: lastActivity },
+    { k: "first tool", v: firstTool },
+    { k: "tools called", v: String(session.toolCount ?? 0) },
+    { k: "open files", v: String(session.openedFileCount) },
+    { k: "pending approvals", v: String(session.pendingApprovals) },
   ];
+  if (session.remoteAddr) rows.push({ k: "remote", v: session.remoteAddr });
 
   return (
     <div className="card" style={{ padding: 0, overflow: "hidden" }}>
-      {/* header */}
       <div
         style={{
           display: "flex",
@@ -73,66 +81,36 @@ function SessionLogPanel({
         }}
       >
         <span>
-          <span style={{ color: "var(--ink-2)" }}>&gt;_</span> {shortId} ·{" "}
-          <span style={{ color: "var(--orange)" }}>{recipe}</span>
+          <span style={{ color: "var(--ink-2)" }}>session</span> · {shortId}
         </span>
-        <span
-          className="chip chip-accent"
-          style={{
-            display: "inline-flex",
-            alignItems: "center",
-            gap: 6,
-            fontSize: "var(--fs-2xs)",
-            textTransform: "uppercase",
-            letterSpacing: "0.07em",
-          }}
+        <a
+          href={`/dashboard/sessions/${session.id}`}
+          className="btn sm ghost"
+          style={{ fontSize: "var(--fs-xs)" }}
         >
-          <span className="dot-live" aria-hidden />
-          streaming
-        </span>
+          Open detail →
+        </a>
       </div>
-
-      {/* terminal body */}
       <div
         style={{
-          background: "var(--terminal-bg)",
-          color: "var(--terminal-fg)",
           fontFamily: "var(--font-mono)",
-          fontSize: 12.5,
-          lineHeight: 1.65,
-          padding: "16px 18px",
-          minHeight: 260,
-          maxHeight: "calc(100vh - 280px)",
-          overflowY: "auto",
+          fontSize: "var(--fs-s)",
+          padding: "14px 18px",
+          display: "grid",
+          gridTemplateColumns: "auto 1fr",
+          columnGap: 16,
+          rowGap: 6,
         }}
       >
-        {lines.map((l, i) => (
-          <div
-            key={i}
-            style={{
-              color: l.startsWith("$")
-                ? "var(--terminal-prompt)"
-                : "var(--terminal-comment)",
-              whiteSpace: "pre-wrap",
-            }}
-          >
-            {l}
-          </div>
+        {rows.map((r) => (
+          <Fragment key={r.k}>
+            <span style={{ color: "var(--ink-3)" }}>{r.k}</span>
+            <span style={{ color: "var(--ink-0)" }}>{r.v}</span>
+          </Fragment>
         ))}
-        <div
-          style={{
-            display: "flex",
-            alignItems: "center",
-            gap: 10,
-            marginTop: 14,
-            color: "var(--terminal-fg)",
-          }}
-        >
-          <Spinner size={12} />
-          <span>
-            composing brief… ( {toolCount} tools called)
-          </span>
-        </div>
+      </div>
+      <div style={{ padding: "10px 18px 14px", fontSize: "var(--fs-xs)", color: "var(--ink-3)", borderTop: "1px solid var(--line-3)" }}>
+        Live event stream available on the session detail page.
       </div>
     </div>
   );
@@ -141,7 +119,7 @@ function SessionLogPanel({
 // ----------------------------------------------------------- page
 
 export default function SessionsPage() {
-  const { data, error, loading } = useBridgeFetch<SessionSummary[]>(
+  const { data, error, loading, refetch } = useBridgeFetch<SessionSummary[]>(
     "/api/bridge/sessions",
     { intervalMs: 3000 },
   );
@@ -201,7 +179,7 @@ export default function SessionsPage() {
           title="Couldn't load sessions"
           description="The bridge isn't responding to /sessions."
           error={error}
-          onRetry={() => window.location.reload()}
+          onRetry={refetch}
         />
       )}
       {error && sessions.length > 0 && (
@@ -227,9 +205,7 @@ export default function SessionsPage() {
           <button
             type="button"
             className="btn sm ghost"
-            onClick={() => {
-              void fetch(apiPath("/api/bridge/sessions")).then(() => window.location.reload());
-            }}
+            onClick={refetch}
           >
             Refresh
           </button>
@@ -446,10 +422,9 @@ export default function SessionsPage() {
           {/* right: log panel */}
           <div style={{ position: "sticky", top: 80 }}>
             {selectedId && selectedSession ? (
-              <SessionLogPanel
+              <SessionSummaryPanel
                 shortId={`s${selectedIndex + 1}`}
-                recipe={recipeFor(selectedSession)}
-                toolCount={selectedSession.toolCount ?? 0}
+                session={selectedSession}
               />
             ) : (
               <div

--- a/dashboard/src/app/settings/page.tsx
+++ b/dashboard/src/app/settings/page.tsx
@@ -405,9 +405,9 @@ export default function SettingsPage() {
                     id="bridge-workspace"
                     type="text"
                     value={workspacePath}
-                    onChange={(e) => setWorkspacePath(e.target.value)}
+                    readOnly
                     placeholder="/Users/you/Projects/your-repo"
-                    style={inputStyle}
+                    style={{ ...inputStyle, background: "var(--bg-2)", cursor: "not-allowed" }}
                   />
                   <p style={helpStyle}>
                     Absolute path to the project Patchwork operates in. Tools resolve paths relative to this root.
@@ -422,9 +422,9 @@ export default function SettingsPage() {
                     id="bridge-inbox"
                     type="text"
                     value={inboxDir}
-                    onChange={(e) => setInboxDir(e.target.value)}
+                    readOnly
                     placeholder="~/.patchwork/inbox"
-                    style={inputStyle}
+                    style={{ ...inputStyle, background: "var(--bg-2)", cursor: "not-allowed" }}
                   />
                   <p style={helpStyle}>
                     Where queued tasks, drafts, and pending approvals live on disk.
@@ -440,9 +440,9 @@ export default function SettingsPage() {
                       id="bridge-http-port"
                       type="number"
                       value={httpPort}
-                      onChange={(e) => setHttpPort(e.target.value)}
+                      readOnly
                       placeholder="3101"
-                      style={inputStyle}
+                      style={{ ...inputStyle, background: "var(--bg-2)", cursor: "not-allowed" }}
                     />
                     <p style={helpStyle}>Dashboard + REST API listen here.</p>
                   </div>
@@ -454,9 +454,9 @@ export default function SettingsPage() {
                       id="bridge-ws-port"
                       type="number"
                       value={wsPort}
-                      onChange={(e) => setWsPort(e.target.value)}
+                      readOnly
                       placeholder="3100"
-                      style={inputStyle}
+                      style={{ ...inputStyle, background: "var(--bg-2)", cursor: "not-allowed" }}
                     />
                     <p style={helpStyle}>Claude Code IDE bridge transport.</p>
                   </div>

--- a/dashboard/src/app/suggestions/page.tsx
+++ b/dashboard/src/app/suggestions/page.tsx
@@ -1,10 +1,18 @@
 "use client";
 import Link from "next/link";
 import { useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
 import { apiPath } from "@/lib/api";
 import { useBridgeFetch } from "@/hooks/useBridgeFetch";
 import { DecisionsTabs } from "@/components/DecisionsTabs";
 import { ErrorState } from "@/components/patchwork";
+
+const SINCE_DAYS_OPTIONS = [1, 7, 30, 90] as const;
+type SinceDays = (typeof SINCE_DAYS_OPTIONS)[number];
+function parseSinceDays(v: string | null): SinceDays {
+  const n = v ? Number(v) : NaN;
+  return SINCE_DAYS_OPTIONS.includes(n as SinceDays) ? (n as SinceDays) : 7;
+}
 
 interface CoOccurringPairDetails {
   pair: [string, string];
@@ -139,8 +147,18 @@ function isTrustDetails(
 }
 
 export default function SuggestionsPage() {
-  const [sinceDays, setSinceDays] = useState(7);
-  const { data, error, loading } = useBridgeFetch<SuggestionsResponse>(
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [sinceDays, setSinceDaysState] = useState<SinceDays>(() => parseSinceDays(searchParams?.get("since")));
+  const setSinceDays = (next: SinceDays) => {
+    setSinceDaysState(next);
+    const params = new URLSearchParams(searchParams?.toString() ?? "");
+    if (next === 7) params.delete("since");
+    else params.set("since", String(next));
+    const qs = params.toString();
+    router.replace(qs ? `?${qs}` : "?", { scroll: false });
+  };
+  const { data, error, loading, refetch } = useBridgeFetch<SuggestionsResponse>(
     `/api/bridge/suggestions?sinceDays=${sinceDays}`,
     { intervalMs: 30000 },
   );
@@ -176,7 +194,7 @@ export default function SuggestionsPage() {
           <select
             id="since-days"
             value={sinceDays}
-            onChange={(e) => setSinceDays(Number.parseInt(e.target.value, 10))}
+            onChange={(e) => setSinceDays(parseSinceDays(e.target.value))}
             style={{
               background: "var(--bg-2)",
               border: "1px solid var(--border-default)",
@@ -206,7 +224,7 @@ export default function SuggestionsPage() {
           title="Couldn't load suggestions"
           description="The bridge isn't responding to /suggestions."
           error={error}
-          onRetry={() => window.location.reload()}
+          onRetry={refetch}
         />
       )}
       {error && suggestions.length > 0 && (

--- a/dashboard/src/app/tasks/page.tsx
+++ b/dashboard/src/app/tasks/page.tsx
@@ -331,9 +331,20 @@ export default function TasksPage() {
     refetchRef.current = () => void tick();
     tick();
     fastId = setInterval(tick, 2000);
+    const onVisible = () => {
+      if (document.hidden) {
+        if (fastId !== null) { clearInterval(fastId); fastId = null; }
+        if (slowId !== null) { clearInterval(slowId); slowId = null; }
+      } else if (fastId === null && slowId === null) {
+        void tick();
+        fastId = setInterval(tick, 2000);
+      }
+    };
+    document.addEventListener("visibilitychange", onVisible);
     return () => {
       if (fastId !== null) clearInterval(fastId);
       if (slowId !== null) clearInterval(slowId);
+      document.removeEventListener("visibilitychange", onVisible);
     };
   }, []);
 

--- a/dashboard/src/app/traces/page.tsx
+++ b/dashboard/src/app/traces/page.tsx
@@ -3,6 +3,7 @@ import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from "rea
 import { relTime } from "@/components/time";
 import { apiPath } from "@/lib/api";
 import { useBridgeFetch } from "@/hooks/useBridgeFetch";
+import { useDebounced } from "@/hooks/useDebounced";
 import { arr, isRecord, shape, type ShapeCheck } from "@/lib/validate";
 import { ErrorState, LivePill } from "@/components/patchwork";
 import { ActivityTabs } from "@/components/ActivityTabs";
@@ -295,6 +296,136 @@ function TraceDetail({
   );
 }
 
+// ------------------------------------------------------------------ span tree
+
+type SpanGroup = {
+  root: DecisionTrace;
+  children: DecisionTrace[];
+};
+
+function buildSpanGroups(traces: DecisionTrace[]): SpanGroup[] {
+  const roots = traces.filter((t) => t.traceType === "recipe_run");
+  const nonRoots = traces.filter((t) => t.traceType !== "recipe_run");
+
+  // Group roots by recipeName
+  const rootsByRecipe = new Map<string, DecisionTrace[]>();
+  for (const r of roots) {
+    const name = typeof r.body.recipeName === "string" ? r.body.recipeName : r.key;
+    const arr = rootsByRecipe.get(name) ?? [];
+    arr.push(r);
+    rootsByRecipe.set(name, arr);
+  }
+
+  const groups: SpanGroup[] = [];
+  const assignedKeys = new Set<string>();
+
+  for (const r of roots) {
+    if (assignedKeys.has(r.key)) continue;
+    assignedKeys.add(r.key);
+
+    const recipeName = typeof r.body.recipeName === "string" ? r.body.recipeName : null;
+    let children: DecisionTrace[] = [];
+
+    if (recipeName !== null) {
+      // Find children: same recipeName, not a root, not already assigned
+      const candidates = nonRoots.filter(
+        (t) => typeof t.body.recipeName === "string" && t.body.recipeName === recipeName && !assignedKeys.has(t.key),
+      );
+      // Find the root closest in time for each child
+      const rootsForRecipe = rootsByRecipe.get(recipeName) ?? [r];
+      children = candidates.filter((child) => {
+        const closest = rootsForRecipe.reduce((best, candidate) =>
+          Math.abs(candidate.ts - child.ts) < Math.abs(best.ts - child.ts) ? candidate : best,
+        );
+        return closest.key === r.key;
+      });
+      for (const c of children) assignedKeys.add(c.key);
+    }
+
+    children.sort((a, b) => a.ts - b.ts);
+    groups.push({ root: r, children });
+  }
+
+  // Remaining traces become singletons
+  for (const t of traces) {
+    if (!assignedKeys.has(t.key)) {
+      groups.push({ root: t, children: [] });
+    }
+  }
+
+  // Sort groups by root.ts descending
+  groups.sort((a, b) => b.root.ts - a.root.ts);
+  return groups;
+}
+
+// ------------------------------------------------------------------ waterfall bar
+
+function SpanBar({
+  startMs,
+  durationMs,
+  groupStartMs,
+  groupEndMs,
+  color,
+}: {
+  startMs: number;
+  durationMs: number;
+  groupStartMs: number;
+  groupEndMs: number;
+  color: string;
+  label?: string;
+}) {
+  const range = groupEndMs - groupStartMs;
+
+  if (range <= 0) {
+    // Full-width bar
+    return (
+      <div style={{ position: "relative", width: "100%", height: 4, background: "var(--line-3)", borderRadius: 2 }}>
+        <div style={{ position: "absolute", inset: 0, background: color, borderRadius: 2 }} />
+      </div>
+    );
+  }
+
+  const leftPct = ((startMs - groupStartMs) / range) * 100;
+
+  if (durationMs <= 0) {
+    // Tick mark
+    return (
+      <div style={{ position: "relative", width: "100%", height: 4, background: "var(--line-3)", borderRadius: 2 }}>
+        <div
+          style={{
+            position: "absolute",
+            left: `${Math.min(leftPct, 98)}%`,
+            top: -2,
+            width: 2,
+            height: 8,
+            background: color,
+            borderRadius: 1,
+          }}
+        />
+      </div>
+    );
+  }
+
+  const widthPct = Math.max(2, (durationMs / range) * 100);
+
+  return (
+    <div style={{ position: "relative", width: "100%", height: 4, background: "var(--line-3)", borderRadius: 2 }}>
+      <div
+        style={{
+          position: "absolute",
+          left: `${Math.min(leftPct, 96)}%`,
+          width: `${Math.min(widthPct, 100 - Math.min(leftPct, 96))}%`,
+          height: "100%",
+          background: color,
+          borderRadius: 2,
+        }}
+      />
+    </div>
+  );
+}
+
+// ------------------------------------------------------------------ since filter
+
 type SinceFilter = "1h" | "24h" | "7d" | "30d" | "all";
 
 const SINCE_OPTIONS: { k: SinceFilter; label: string; ms: number | null }[] = [
@@ -439,14 +570,16 @@ function ExportButton({ disabled: outerDisabled }: { disabled?: boolean }) {
 export default function TracesPage() {
   const [statusFilter, setStatusFilter] = useState<"all" | "done" | "errors">("all");
   const [searchQuery, setSearchQuery] = useState("");
+  const debouncedSearch = useDebounced(searchQuery, 250);
   const [since, setSince] = useState<SinceFilter>("24h");
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const [view, setView] = useState<"flat" | "tree">("tree");
 
   const qs = useMemo(() => {
     const params = new URLSearchParams();
-    if (searchQuery.trim()) {
-      params.set("key", searchQuery.trim());
-      params.set("q", searchQuery.trim());
+    if (debouncedSearch.trim()) {
+      params.set("key", debouncedSearch.trim());
+      params.set("q", debouncedSearch.trim());
     }
     const sinceMs = SINCE_OPTIONS.find((o) => o.k === since)?.ms;
     if (sinceMs != null) {
@@ -455,9 +588,9 @@ export default function TracesPage() {
     params.set("limit", "50");
     const s = params.toString();
     return s ? `?${s}` : "";
-  }, [searchQuery, since]);
+  }, [debouncedSearch, since]);
 
-  const { data, error, loading } = useBridgeFetch<TracesResponse>(
+  const { data, error, loading, refetch } = useBridgeFetch<TracesResponse>(
     `/api/bridge/traces${qs}`,
     { intervalMs: 3000, transform: validateTraces },
   );
@@ -548,6 +681,41 @@ export default function TracesPage() {
             </button>
           ))}
         </div>
+        <label style={{ display: "inline-flex", alignItems: "center", gap: 6, fontSize: "var(--fs-s)", color: "var(--ink-2)" }}>
+          <span>since</span>
+          <select
+            value={since}
+            onChange={(e) => setSince(e.target.value as SinceFilter)}
+            style={{
+              fontSize: "var(--fs-s)",
+              fontFamily: "var(--font-mono)",
+              background: "var(--recess)",
+              border: "1px solid var(--line-2)",
+              borderRadius: "var(--r-s)",
+              color: "var(--ink-0)",
+              padding: "4px 8px",
+              cursor: "pointer",
+            }}
+          >
+            {SINCE_OPTIONS.map((o) => (
+              <option key={o.k} value={o.k}>{o.label}</option>
+            ))}
+          </select>
+        </label>
+        <div className="filter-chips" style={{ marginBottom: 0 }}>
+          <span style={{ fontSize: "var(--fs-s)", color: "var(--ink-2)", marginRight: 2 }}>View:</span>
+          {(["flat", "tree"] as const).map((v) => (
+            <button
+              key={v}
+              type="button"
+              onClick={() => setView(v)}
+              className={view === v ? "pill accent" : "pill muted"}
+              style={{ cursor: "pointer", border: "none", fontSize: "var(--fs-s)", textTransform: "capitalize" }}
+            >
+              {v}
+            </button>
+          ))}
+        </div>
       </div>
 
       {loading && traces.length === 0 && (
@@ -563,7 +731,7 @@ export default function TracesPage() {
               : "The bridge isn't responding. Traces will reload on its next tick."
           }
           error={error}
-          onRetry={() => window.location.reload()}
+          onRetry={refetch}
         />
       )}
       {error && traces.length > 0 && (
@@ -579,7 +747,7 @@ export default function TracesPage() {
           <h3>No traces</h3>
           <p>Traces appear as recipes run and approvals are processed.</p>
         </div>
-      ) : (
+      ) : view === "flat" ? (
         <div className="card" style={{ padding: 0, overflow: "hidden", marginBottom: "var(--s-5)" }}>
           {visible.map(t => {
             const rowKey = `${t.traceType}:${t.ts}:${t.key}`;
@@ -706,6 +874,244 @@ export default function TracesPage() {
                     <TraceActions traceType={t.traceType} body={t.body} />
                     <TraceDetail body={t.body} theme={theme} traceType={t.traceType} />
                   </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      ) : (
+        // Tree view
+        <div className="card" style={{ padding: 0, overflow: "hidden", marginBottom: "var(--s-5)" }}>
+          {buildSpanGroups(visible).map((group) => {
+            const { root, children } = group;
+            const rootKey = `${root.traceType}:${root.ts}:${root.key}`;
+            const isOpen = expanded.has(rootKey);
+            const rootStatus = traceStatus(root);
+            const rootTheme = TYPE_THEME[root.traceType];
+            const rootStatusColor = rootStatus === "done" ? "var(--ok)" : rootStatus === "error" ? "var(--err)" : "var(--ink-3)";
+            const rootStatusBg = rootStatus === "done" ? "var(--ok-soft)" : rootStatus === "error" ? "var(--err-soft)" : "var(--recess)";
+            const rootStatusLabel = rootStatus === "done" ? "done" : rootStatus === "error" ? "error" : "running";
+
+            // Compute group time range for waterfall
+            const rootDuration = typeof root.body.durationMs === "number" ? root.body.durationMs : 0;
+            const childrenEnd = children.reduce((max, c) => {
+              const cd = typeof c.body.durationMs === "number" ? c.body.durationMs : 0;
+              return Math.max(max, c.ts + cd);
+            }, root.ts);
+            const groupStartMs = root.ts;
+            const groupEndMs = rootDuration > 0 ? root.ts + rootDuration : childrenEnd;
+
+            return (
+              <div key={rootKey} style={{ borderBottom: "1px solid var(--line-3)" }}>
+                {/* Root row */}
+                <div
+                  style={{
+                    display: "grid",
+                    gridTemplateColumns: "20px 18px minmax(280px, auto) 1fr 100px 80px",
+                    alignItems: "center",
+                    gap: "var(--s-3)",
+                    width: "100%",
+                    padding: "10px 16px 6px 16px",
+                    minHeight: 44,
+                    boxSizing: "border-box",
+                  }}
+                >
+                  <button
+                    type="button"
+                    onClick={() => toggle(rootKey)}
+                    aria-label={isOpen ? "Collapse" : "Expand"}
+                    style={{
+                      background: "transparent",
+                      border: "none",
+                      cursor: "pointer",
+                      color: "var(--ink-3)",
+                      fontFamily: "var(--font-mono)",
+                      fontSize: "var(--fs-s)",
+                      padding: 0,
+                      textAlign: "left",
+                    }}
+                  >
+                    {isOpen ? "v" : ">"}
+                  </button>
+                  <span
+                    aria-hidden="true"
+                    style={{
+                      width: 14,
+                      height: 14,
+                      borderRadius: 3,
+                      background: rootTheme.bg,
+                      border: `1px solid ${rootTheme.fg}`,
+                    }}
+                  />
+                  <button
+                    type="button"
+                    onClick={() => toggle(rootKey)}
+                    style={{
+                      fontFamily: "var(--font-mono)",
+                      fontSize: "var(--fs-xs)",
+                      color: rootTheme.fg,
+                      background: "transparent",
+                      border: "none",
+                      padding: 0,
+                      cursor: "pointer",
+                      textAlign: "left",
+                      whiteSpace: "nowrap",
+                      overflow: "hidden",
+                      textOverflow: "ellipsis",
+                    }}
+                  >
+                    {root.key}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => toggle(rootKey)}
+                    style={{
+                      fontSize: "var(--fs-m)",
+                      color: "var(--ink-1)",
+                      background: "transparent",
+                      border: "none",
+                      padding: 0,
+                      cursor: "pointer",
+                      textAlign: "left",
+                      overflow: "hidden",
+                      textOverflow: "ellipsis",
+                      whiteSpace: "nowrap",
+                    }}
+                  >
+                    {String(root.body?.recipeName ?? root.key)}
+                  </button>
+                  <span style={{ fontSize: "var(--fs-xs)", color: "var(--ink-3)", textAlign: "right" }}>
+                    {relTime(root.ts)}
+                  </span>
+                  <span style={{ display: "flex", justifyContent: "flex-end" }}>
+                    <span className="pill" style={{ background: rootStatusBg, color: rootStatusColor, fontSize: "var(--fs-2xs)", fontWeight: 700 }}>
+                      {rootStatusLabel}
+                    </span>
+                  </span>
+                </div>
+                {/* Waterfall bar row for root */}
+                <div style={{ padding: "0 16px 8px 16px" }}>
+                  <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                    <div style={{ flex: 1 }}>
+                      <SpanBar
+                        startMs={groupStartMs}
+                        durationMs={rootDuration}
+                        groupStartMs={groupStartMs}
+                        groupEndMs={groupEndMs}
+                        color={rootTheme.fg}
+                        label={rootDuration > 0 ? `${rootDuration}ms` : undefined}
+                      />
+                    </div>
+                    {rootDuration > 0 && (
+                      <span style={{ fontSize: "var(--fs-2xs)", color: "var(--ink-3)", whiteSpace: "nowrap", fontFamily: "var(--font-mono)" }}>
+                        {rootDuration}ms
+                      </span>
+                    )}
+                  </div>
+                </div>
+                {/* Expanded detail for root */}
+                {isOpen && (
+                  <>
+                    <div style={{ padding: "0 16px 12px 16px", borderTop: "1px solid var(--line-3)", background: "var(--recess)" }}>
+                      <div style={{ fontFamily: "var(--font-mono)", fontSize: "var(--fs-xs)", color: "var(--ink-2)", margin: "8px 0 4px", wordBreak: "break-all" }}>
+                        {root.key}
+                      </div>
+                      {root.summary && (
+                        <div style={{ fontSize: "var(--fs-s)", color: "var(--ink-1)", marginBottom: 8 }}>{root.summary}</div>
+                      )}
+                      <TraceActions traceType={root.traceType} body={root.body} />
+                      <TraceDetail body={root.body} theme={rootTheme} traceType={root.traceType} />
+                    </div>
+                    {/* Children rows */}
+                    {children.map((child) => {
+                      const childStatus = traceStatus(child);
+                      const childTheme = TYPE_THEME[child.traceType];
+                      const childStatusColor = childStatus === "done" ? "var(--ok)" : childStatus === "error" ? "var(--err)" : "var(--ink-3)";
+                      const childStatusBg = childStatus === "done" ? "var(--ok-soft)" : childStatus === "error" ? "var(--err-soft)" : "var(--recess)";
+                      const childStatusLabel = childStatus === "done" ? "done" : childStatus === "error" ? "error" : "running";
+                      const childDuration = typeof child.body.durationMs === "number" ? child.body.durationMs : 0;
+                      return (
+                        <div
+                          key={`${child.traceType}:${child.ts}:${child.key}`}
+                          style={{ borderTop: "1px solid var(--line-3)", background: "var(--recess)", paddingLeft: 24 }}
+                        >
+                          <div
+                            style={{
+                              display: "grid",
+                              gridTemplateColumns: "18px minmax(200px, auto) 1fr 100px 80px",
+                              alignItems: "center",
+                              gap: "var(--s-3)",
+                              padding: "6px 16px 4px 0",
+                              minHeight: 34,
+                              boxSizing: "border-box",
+                            }}
+                          >
+                            <span
+                              aria-hidden="true"
+                              style={{
+                                width: 12,
+                                height: 12,
+                                borderRadius: 2,
+                                background: childTheme.bg,
+                                border: `1px solid ${childTheme.fg}`,
+                                flexShrink: 0,
+                              }}
+                            />
+                            <span
+                              style={{
+                                fontFamily: "var(--font-mono)",
+                                fontSize: "var(--fs-xs)",
+                                color: childTheme.fg,
+                                whiteSpace: "nowrap",
+                                overflow: "hidden",
+                                textOverflow: "ellipsis",
+                              }}
+                            >
+                              {child.key}
+                            </span>
+                            <span
+                              style={{
+                                fontSize: "var(--fs-xs)",
+                                color: "var(--ink-2)",
+                                overflow: "hidden",
+                                textOverflow: "ellipsis",
+                                whiteSpace: "nowrap",
+                              }}
+                            >
+                              {String(child.body?.recipeName ?? child.key)}
+                            </span>
+                            <span style={{ fontSize: "var(--fs-xs)", color: "var(--ink-3)", textAlign: "right" }}>
+                              {relTime(child.ts)}
+                            </span>
+                            <span style={{ display: "flex", justifyContent: "flex-end" }}>
+                              <span className="pill" style={{ background: childStatusBg, color: childStatusColor, fontSize: "var(--fs-2xs)", fontWeight: 700 }}>
+                                {childStatusLabel}
+                              </span>
+                            </span>
+                          </div>
+                          {/* Waterfall bar for child */}
+                          <div style={{ padding: "0 16px 6px 0" }}>
+                            <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                              <div style={{ flex: 1 }}>
+                                <SpanBar
+                                  startMs={child.ts}
+                                  durationMs={childDuration}
+                                  groupStartMs={groupStartMs}
+                                  groupEndMs={groupEndMs}
+                                  color={childTheme.fg}
+                                />
+                              </div>
+                              {childDuration > 0 && (
+                                <span style={{ fontSize: "var(--fs-2xs)", color: "var(--ink-3)", whiteSpace: "nowrap", fontFamily: "var(--font-mono)" }}>
+                                  {childDuration}ms
+                                </span>
+                              )}
+                            </div>
+                          </div>
+                        </div>
+                      );
+                    })}
+                  </>
                 )}
               </div>
             );

--- a/dashboard/src/components/CommandPalette.tsx
+++ b/dashboard/src/components/CommandPalette.tsx
@@ -123,16 +123,13 @@ export function CommandPalette({
     const actionCmds: Command[] = [
       {
         id: "action:toggle-theme",
-        label: "Toggle theme (paper / dark / system)",
+        label: "Toggle theme (paper / dark)",
         group: "Actions",
         perform: () => {
-          const order = ["paper", "dark", "system"] as const;
-          const current = (localStorage.getItem("patchwork-theme") ??
-            "system") as (typeof order)[number];
-          const idx = order.indexOf(current);
-          const next = order[(idx + 1) % order.length];
-          localStorage.setItem("patchwork-theme", next);
-          window.dispatchEvent(new Event("patchwork-theme-change"));
+          const current = localStorage.getItem("patchwork.theme") === "paper" ? "paper" : "dark";
+          const next = current === "dark" ? "paper" : "dark";
+          localStorage.setItem("patchwork.theme", next);
+          window.dispatchEvent(new StorageEvent("storage", { key: "patchwork.theme", newValue: next }));
         },
       },
       {

--- a/dashboard/src/components/Shell.tsx
+++ b/dashboard/src/components/Shell.tsx
@@ -5,6 +5,7 @@ import type { ReactNode } from "react";
 import { useEffect, useState } from "react";
 import { apiPath } from "@/lib/api";
 import { useBridgeStatus, type BridgeStatus } from "@/hooks/useBridgeStatus";
+import { isDemoMode, onDemoModeChange, setDemoMode } from "@/lib/demoMode";
 import { CardGlow } from "./CardGlow";
 import { CommandPalette } from "./CommandPalette";
 
@@ -117,6 +118,10 @@ function useApprovalCount(): number {
     };
 
     const tick = async () => {
+      if (typeof document !== "undefined" && document.hidden) {
+        schedule(BASE);
+        return;
+      }
       let ok = false;
       try {
         const res = await fetch(apiPath("/api/bridge/approvals"));
@@ -132,10 +137,18 @@ function useApprovalCount(): number {
       schedule(ok ? BASE : exp * (0.8 + Math.random() * 0.4));
     };
 
+    const onVisible = () => {
+      if (!document.hidden && alive) {
+        if (timerId !== null) clearTimeout(timerId);
+        tick();
+      }
+    };
+    document.addEventListener("visibilitychange", onVisible);
     tick();
     return () => {
       alive = false;
       if (timerId !== null) clearTimeout(timerId);
+      document.removeEventListener("visibilitychange", onVisible);
     };
   }, []);
   return count;
@@ -157,54 +170,58 @@ function useIdentity(status: BridgeStatus): { user: string; host: string; port: 
   return { user, host: `${user}@${wsName}`, port };
 }
 
+// ------------------------------------------------------------------ demo mode
+
+function useDemo() {
+  const [demo, setDemo] = useState(false);
+  useEffect(() => {
+    setDemo(isDemoMode());
+    return onDemoModeChange(setDemo);
+  }, []);
+  const toggle = () => setDemoMode(!demo);
+  return { demo, toggle };
+}
+
 // ------------------------------------------------------------------ theme
 
-type ThemePref = "system" | "dark" | "paper";
+type ThemePref = "dark" | "paper";
 
 function normalizeTheme(value: string | null): ThemePref {
-  if (value === "dark" || value === "paper" || value === "system") return value;
-  if (value === "light") return "paper";
-  return "system";
+  if (value === "paper" || value === "light") return "paper";
+  return "dark";
 }
 
-function systemTheme(): Exclude<ThemePref, "system"> {
-  return window.matchMedia("(prefers-color-scheme: light)").matches ? "paper" : "dark";
-}
-
-function applyTheme(theme: Exclude<ThemePref, "system">) {
+function applyTheme(theme: ThemePref) {
   document.documentElement.setAttribute("data-theme", theme);
   document.body.dataset.theme = theme;
 }
 
 function useTheme() {
-  const [pref, setPref] = useState<ThemePref>("system");
-  const [active, setActive] = useState<Exclude<ThemePref, "system">>("dark");
+  const [active, setActive] = useState<ThemePref>("dark");
   useEffect(() => {
-    const stored = normalizeTheme(localStorage.getItem("patchwork.theme") ?? localStorage.getItem("pw-theme"));
-    const resolved = stored === "system" ? systemTheme() : stored;
-    setPref(stored);
-    setActive(resolved);
-    applyTheme(resolved);
-    const media = window.matchMedia("(prefers-color-scheme: light)");
-    const onChange = () => {
-      if (localStorage.getItem("patchwork.theme") === "system" || !localStorage.getItem("patchwork.theme")) {
-        const next = systemTheme();
-        setActive(next);
-        applyTheme(next);
-      }
+    const stored = normalizeTheme(
+      localStorage.getItem("patchwork.theme") ?? localStorage.getItem("pw-theme"),
+    );
+    setActive(stored);
+    applyTheme(stored);
+    const onStorage = (e: StorageEvent) => {
+      if (e.key !== "patchwork.theme") return;
+      const next = normalizeTheme(e.newValue);
+      setActive(next);
+      applyTheme(next);
     };
-    media.addEventListener("change", onChange);
-    return () => media.removeEventListener("change", onChange);
+    window.addEventListener("storage", onStorage);
+    return () => {
+      window.removeEventListener("storage", onStorage);
+    };
   }, []);
   const toggle = () => {
-    const nextPref: ThemePref = pref === "system" ? "dark" : pref === "dark" ? "paper" : "system";
-    const resolved = nextPref === "system" ? systemTheme() : nextPref;
-    setPref(nextPref);
-    setActive(resolved);
-    applyTheme(resolved);
-    localStorage.setItem("patchwork.theme", nextPref);
+    const next: ThemePref = active === "dark" ? "paper" : "dark";
+    setActive(next);
+    applyTheme(next);
+    localStorage.setItem("patchwork.theme", next);
   };
-  return { active, pref, toggle };
+  return { active, toggle };
 }
 
 // ------------------------------------------------------------------ shell
@@ -213,12 +230,11 @@ export function Shell({ children }: { children: ReactNode }) {
   const pathname = usePathname();
   const status = useBridgeStatus();
   const approvalCount = useApprovalCount();
-  const { active, pref, toggle } = useTheme();
+  const { active, toggle } = useTheme();
+  const { demo, toggle: toggleDemo } = useDemo();
   const identity = useIdentity(status);
   const [mobileOpen, setMobileOpen] = useState(false);
-  const [moreOpen, setMoreOpen] = useState(() =>
-    MORE_ITEMS.some((it) => typeof window !== "undefined" && window.location?.pathname?.startsWith(it.href))
-  );
+  const [moreOpen, setMoreOpen] = useState(false);
   // Demo: replace with real notification count when available
   const hasNotifications = approvalCount > 0;
   const [paletteOpen, setPaletteOpen] = useState(false);
@@ -290,10 +306,44 @@ export function Shell({ children }: { children: ReactNode }) {
         <div className="app-header-actions">
           <IdentityPill ok={status.ok} host={identity.host} port={identity.port} />
           <button
+            type="button"
+            onClick={toggleDemo}
+            title={demo ? "Disable demo mode" : "Enable demo mode (sample data)"}
+            aria-label="Toggle demo mode"
+            aria-pressed={demo}
+            style={{
+              display: "inline-flex",
+              alignItems: "center",
+              gap: 5,
+              fontSize: "var(--fs-2xs)",
+              fontWeight: 600,
+              padding: "4px 10px",
+              borderRadius: 999,
+              border: `1px solid ${demo ? "var(--orange)" : "var(--line-2)"}`,
+              background: demo ? "color-mix(in srgb, var(--orange) 12%, transparent)" : "transparent",
+              color: demo ? "var(--orange)" : "var(--ink-2)",
+              cursor: "pointer",
+              transition: "background 150ms, border-color 150ms, color 150ms",
+            }}
+          >
+            <span
+              aria-hidden="true"
+              style={{
+                width: 6,
+                height: 6,
+                borderRadius: "50%",
+                background: demo ? "var(--orange)" : "var(--ink-3)",
+                display: "inline-block",
+                flexShrink: 0,
+              }}
+            />
+            Demo
+          </button>
+          <button
             className="theme-toggle"
             onClick={toggle}
-            title={`Theme: ${pref}${pref === "system" ? ` (${active})` : ""}`}
-            aria-label="Cycle theme"
+            title={`Theme: ${active} — click for ${active === "dark" ? "paper" : "dark"}`}
+            aria-label={`Switch to ${active === "dark" ? "paper" : "dark"} theme`}
           >
             {active === "paper" ? (
               <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.85" strokeLinecap="round" strokeLinejoin="round">
@@ -305,38 +355,27 @@ export function Shell({ children }: { children: ReactNode }) {
                 <path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z" />
               </svg>
             )}
-            {pref === "system" && <span className="theme-toggle-auto" aria-hidden="true">auto</span>}
           </button>
-          <button
-            type="button"
-            className="topbar-icon-btn"
-            aria-label="Open terminal"
-            title="Terminal"
-          >
-            <span aria-hidden="true" style={{ fontFamily: "var(--font-mono)", fontSize: "var(--fs-s)", fontWeight: 700, letterSpacing: "-0.05em" }}>
-              {">_"}
-            </span>
-          </button>
-          <button
-            type="button"
+          <Link
+            href="/approvals"
             className="topbar-icon-btn topbar-bell"
-            aria-label={hasNotifications ? "Notifications (unread)" : "Notifications"}
-            title="Notifications"
+            aria-label={hasNotifications ? `Notifications: ${approvalCount} pending approval${approvalCount === 1 ? "" : "s"}` : "Notifications"}
+            title={hasNotifications ? `${approvalCount} pending approval${approvalCount === 1 ? "" : "s"}` : "No pending approvals"}
           >
             <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.85" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
               <path d="M18 8a6 6 0 10-12 0c0 7-3 9-3 9h18s-3-2-3-9" />
               <path d="M13.73 21a2 2 0 01-3.46 0" />
             </svg>
             {hasNotifications && <span className="topbar-bell-dot" aria-hidden="true" />}
-          </button>
-          <button
-            type="button"
+          </Link>
+          <Link
+            href="/settings"
             className="topbar-avatar"
-            aria-label="Account"
+            aria-label="Settings"
             title={identity.host}
           >
             <span aria-hidden="true">{(identity.user[0] ?? "?").toUpperCase()}</span>
-          </button>
+          </Link>
         </div>
       </header>
       <aside className="app-sidebar" aria-label="Primary navigation">

--- a/dashboard/src/components/StatCard.tsx
+++ b/dashboard/src/components/StatCard.tsx
@@ -48,7 +48,7 @@ function DeltaBadge({ delta }: { delta: string }) {
       }}
     >
       {arrow && <span aria-hidden="true">{arrow}</span>}
-      {delta.replace(/^[+-]/, (m) => m)}
+      {delta.replace(/^[+-]/, "")}
     </span>
   );
 }

--- a/dashboard/src/components/Toast.tsx
+++ b/dashboard/src/components/Toast.tsx
@@ -1,0 +1,282 @@
+"use client";
+
+import {
+  type ReactNode,
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+
+export type ToastVariant = "success" | "error" | "info" | "warn";
+
+export type ToastOptions = {
+  variant?: ToastVariant;
+  /** Milliseconds before auto-dismiss. 0 disables auto-dismiss. Default 5000. */
+  duration?: number;
+  /** Optional action button. */
+  action?: { label: string; onClick: () => void };
+  /** Stable id; if provided and a toast with this id already exists, it is replaced. */
+  id?: string;
+};
+
+type Toast = Required<Pick<ToastOptions, "variant" | "duration">> & {
+  id: string;
+  message: string;
+  action?: ToastOptions["action"];
+};
+
+type ToastApi = {
+  toast: (message: string, opts?: ToastOptions) => string;
+  success: (message: string, opts?: Omit<ToastOptions, "variant">) => string;
+  error: (message: string, opts?: Omit<ToastOptions, "variant">) => string;
+  info: (message: string, opts?: Omit<ToastOptions, "variant">) => string;
+  warn: (message: string, opts?: Omit<ToastOptions, "variant">) => string;
+  dismiss: (id: string) => void;
+};
+
+const ToastCtx = createContext<ToastApi | null>(null);
+
+export function useToast(): ToastApi {
+  const ctx = useContext(ToastCtx);
+  if (!ctx) {
+    // Fallback: never throw; allow components to call useToast without a provider
+    // (e.g. in tests), no-oping silently.
+    return {
+      toast: () => "",
+      success: () => "",
+      error: () => "",
+      info: () => "",
+      warn: () => "",
+      dismiss: () => {},
+    };
+  }
+  return ctx;
+}
+
+let counter = 0;
+const nextId = () => `t${Date.now().toString(36)}-${(counter++).toString(36)}`;
+
+export function ToastProvider({ children }: { children: ReactNode }) {
+  const [toasts, setToasts] = useState<Toast[]>([]);
+  const timers = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
+
+  const dismiss = useCallback((id: string) => {
+    const t = timers.current.get(id);
+    if (t) {
+      clearTimeout(t);
+      timers.current.delete(id);
+    }
+    setToasts((curr) => curr.filter((x) => x.id !== id));
+  }, []);
+
+  const push = useCallback(
+    (message: string, opts?: ToastOptions) => {
+      const id = opts?.id ?? nextId();
+      const variant = opts?.variant ?? "info";
+      const duration = opts?.duration ?? 5000;
+      const t: Toast = { id, message, variant, duration, action: opts?.action };
+      setToasts((curr) => {
+        const without = curr.filter((x) => x.id !== id);
+        // Cap at 5 visible.
+        const trimmed = without.length >= 5 ? without.slice(without.length - 4) : without;
+        return [...trimmed, t];
+      });
+      const existing = timers.current.get(id);
+      if (existing) clearTimeout(existing);
+      if (duration > 0) {
+        const handle = setTimeout(() => dismiss(id), duration);
+        timers.current.set(id, handle);
+      }
+      return id;
+    },
+    [dismiss],
+  );
+
+  useEffect(() => {
+    return () => {
+      for (const handle of timers.current.values()) clearTimeout(handle);
+      timers.current.clear();
+    };
+  }, []);
+
+  const api = useMemo<ToastApi>(
+    () => ({
+      toast: (m, o) => push(m, o),
+      success: (m, o) => push(m, { ...o, variant: "success" }),
+      error: (m, o) => push(m, { ...o, variant: "error", duration: o?.duration ?? 7000 }),
+      info: (m, o) => push(m, { ...o, variant: "info" }),
+      warn: (m, o) => push(m, { ...o, variant: "warn" }),
+      dismiss,
+    }),
+    [push, dismiss],
+  );
+
+  return (
+    <ToastCtx.Provider value={api}>
+      {children}
+      <ToastViewport toasts={toasts} dismiss={dismiss} />
+    </ToastCtx.Provider>
+  );
+}
+
+function variantStyles(v: ToastVariant): {
+  bg: string;
+  border: string;
+  fg: string;
+  iconColor: string;
+  icon: string;
+} {
+  switch (v) {
+    case "success":
+      return {
+        bg: "var(--green-soft)",
+        border: "var(--green)",
+        fg: "var(--ink-0)",
+        iconColor: "var(--green)",
+        icon: "✓",
+      };
+    case "error":
+      return {
+        bg: "var(--red-soft)",
+        border: "var(--red)",
+        fg: "var(--ink-0)",
+        iconColor: "var(--red)",
+        icon: "!",
+      };
+    case "warn":
+      return {
+        bg: "var(--amber-soft, var(--warn-soft))",
+        border: "var(--amber, var(--warn))",
+        fg: "var(--ink-0)",
+        iconColor: "var(--amber, var(--warn))",
+        icon: "!",
+      };
+    default:
+      return {
+        bg: "var(--surface)",
+        border: "var(--line-2)",
+        fg: "var(--ink-0)",
+        iconColor: "var(--ink-2)",
+        icon: "i",
+      };
+  }
+}
+
+function ToastViewport({
+  toasts,
+  dismiss,
+}: {
+  toasts: Toast[];
+  dismiss: (id: string) => void;
+}) {
+  return (
+    <div
+      aria-live="polite"
+      aria-atomic="false"
+      role="region"
+      aria-label="Toast notifications"
+      data-toast-viewport
+      style={{
+        position: "fixed",
+        bottom: 16,
+        right: 16,
+        zIndex: 1100,
+        display: "flex",
+        flexDirection: "column",
+        gap: 8,
+        pointerEvents: "none",
+        maxWidth: "min(calc(100vw - 32px), 420px)",
+      }}
+    >
+      {toasts.map((t) => {
+        const s = variantStyles(t.variant);
+        return (
+          <div
+            key={t.id}
+            role={t.variant === "error" ? "alert" : "status"}
+            style={{
+              pointerEvents: "auto",
+              background: s.bg,
+              color: s.fg,
+              border: `1px solid ${s.border}`,
+              borderRadius: "var(--r-2, 10px)",
+              boxShadow: "var(--shadow-modal, 0 10px 30px rgba(0,0,0,0.18))",
+              padding: "10px 12px",
+              display: "flex",
+              alignItems: "flex-start",
+              gap: 10,
+              fontSize: 13,
+              lineHeight: 1.4,
+              animation: "patchwork-toast-in 160ms ease-out",
+            }}
+          >
+            <span
+              aria-hidden="true"
+              style={{
+                flex: "0 0 auto",
+                width: 18,
+                height: 18,
+                borderRadius: "50%",
+                background: s.iconColor,
+                color: "var(--surface)",
+                display: "inline-flex",
+                alignItems: "center",
+                justifyContent: "center",
+                fontSize: 11,
+                fontWeight: 700,
+                marginTop: 1,
+              }}
+            >
+              {s.icon}
+            </span>
+            <div style={{ flex: 1, minWidth: 0, wordBreak: "break-word" }}>{t.message}</div>
+            {t.action ? (
+              <button
+                type="button"
+                onClick={() => {
+                  t.action?.onClick();
+                  dismiss(t.id);
+                }}
+                style={{
+                  flex: "0 0 auto",
+                  background: "transparent",
+                  border: "1px solid var(--line-2)",
+                  borderRadius: 6,
+                  padding: "2px 8px",
+                  fontSize: 12,
+                  color: "var(--ink-0)",
+                  cursor: "pointer",
+                }}
+              >
+                {t.action.label}
+              </button>
+            ) : null}
+            <button
+              type="button"
+              aria-label="Dismiss notification"
+              onClick={() => dismiss(t.id)}
+              style={{
+                flex: "0 0 auto",
+                background: "transparent",
+                border: "none",
+                color: "var(--ink-2)",
+                cursor: "pointer",
+                fontSize: 16,
+                lineHeight: 1,
+                padding: 0,
+                marginLeft: 2,
+              }}
+            >
+              ×
+            </button>
+          </div>
+        );
+      })}
+      <style>{`@keyframes patchwork-toast-in { from { opacity: 0; transform: translateY(6px); } to { opacity: 1; transform: translateY(0); } }`}</style>
+    </div>
+  );
+}

--- a/dashboard/src/components/patchwork/AreaChart.tsx
+++ b/dashboard/src/components/patchwork/AreaChart.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 
 export interface AreaChartSeries {
   values: number[];
@@ -37,6 +37,7 @@ export function AreaChart({
   height?: number;
   yTicks?: number;
 }) {
+  const [tooltip, setTooltip] = useState<{ x: number; y: number; text: string } | null>(null);
   const { maxVal, n, tickVals, paths } = useMemo(() => {
     const allVals = series.flatMap((s) => s.values);
     const rawMax = Math.max(...allVals, 0);
@@ -78,6 +79,7 @@ export function AreaChart({
         width: "100%",
         height,
         margin: 0,
+        overflow: "hidden",
       }}
     >
       <svg
@@ -125,6 +127,10 @@ export function AreaChart({
         {series.map((s, si) => {
           const { line, area } = paths[si];
           if (!line) return null;
+          const safeMax = Math.max(maxVal, 1);
+          const yTop = PAD.top;
+          const yBottom = height - PAD.bottom;
+          const chartH = yBottom - yTop;
           return (
             <g key={si}>
               <path d={area} fill={`url(#acGrad${si})`} />
@@ -137,6 +143,49 @@ export function AreaChart({
                 strokeLinejoin="round"
                 vectorEffect="non-scaling-stroke"
               />
+              {/* focusable data points */}
+              {s.values.map((v, vi) => {
+                const px = (vi / Math.max(n - 1, 1)) * 100;
+                const py = yTop + chartH - (v / safeMax) * chartH;
+                const lbl = xLabels?.[vi] ?? `${vi}`;
+                const tip = `${s.label ?? ""} ${lbl}: ${v}`.trim();
+                return (
+                  <circle
+                    key={vi}
+                    cx={px}
+                    cy={py}
+                    r={3}
+                    fill={colors[si]}
+                    stroke="var(--surface)"
+                    strokeWidth={1}
+                    vectorEffect="non-scaling-stroke"
+                    style={{ opacity: 0, transition: "opacity 100ms", cursor: "default" }}
+                    tabIndex={0}
+                    role="img"
+                    aria-label={tip}
+                    onFocus={(e) => {
+                      const rect = (e.currentTarget.closest("figure") as HTMLElement)?.getBoundingClientRect();
+                      const cr = (e.currentTarget as SVGCircleElement).getBoundingClientRect();
+                      if (rect) setTooltip({ x: cr.left - rect.left, y: cr.top - rect.top, text: tip });
+                      (e.currentTarget as SVGCircleElement).style.opacity = "1";
+                    }}
+                    onBlur={(e) => {
+                      setTooltip(null);
+                      (e.currentTarget as SVGCircleElement).style.opacity = "0";
+                    }}
+                    onMouseEnter={(e) => {
+                      const rect = (e.currentTarget.closest("figure") as HTMLElement)?.getBoundingClientRect();
+                      const cr = (e.currentTarget as SVGCircleElement).getBoundingClientRect();
+                      if (rect) setTooltip({ x: cr.left - rect.left, y: cr.top - rect.top, text: tip });
+                      (e.currentTarget as SVGCircleElement).style.opacity = "1";
+                    }}
+                    onMouseLeave={(e) => {
+                      setTooltip(null);
+                      (e.currentTarget as SVGCircleElement).style.opacity = "0";
+                    }}
+                  />
+                );
+              })}
             </g>
           );
         })}
@@ -217,6 +266,64 @@ export function AreaChart({
           );
         })}
       </div>
+      {/* hover/focus tooltip */}
+      {tooltip && (
+        <div
+          aria-hidden="true"
+          style={{
+            position: "absolute",
+            left: tooltip.x,
+            top: tooltip.y - 28,
+            transform: "translateX(-50%)",
+            background: "var(--surface)",
+            border: "1px solid var(--line-2)",
+            borderRadius: 6,
+            padding: "2px 7px",
+            fontSize: "var(--fs-2xs)",
+            fontFamily: "var(--font-mono)",
+            color: "var(--ink-1)",
+            pointerEvents: "none",
+            whiteSpace: "nowrap",
+            boxShadow: "0 2px 8px rgba(0,0,0,0.12)",
+            zIndex: 10,
+          }}
+        >
+          {tooltip.text}
+        </div>
+      )}
+
+      {/* <table> fallback — visually hidden, read by screen readers */}
+      <table
+        style={{
+          position: "absolute",
+          width: 1,
+          height: 1,
+          overflow: "hidden",
+          clip: "rect(0,0,0,0)",
+          whiteSpace: "nowrap",
+          border: 0,
+        }}
+      >
+        <caption>{summary || "chart data"}</caption>
+        <thead>
+          <tr>
+            <th scope="col">Time</th>
+            {series.map((s, si) => (
+              <th key={si} scope="col">{s.label ?? `Series ${si + 1}`}</th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {Array.from({ length: n }, (_, i) => (
+            <tr key={i}>
+              <td>{xLabels?.[i] ?? i}</td>
+              {series.map((s, si) => (
+                <td key={si}>{s.values[i] ?? 0}</td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
     </figure>
   );
 }

--- a/dashboard/src/components/patchwork/HBarList.tsx
+++ b/dashboard/src/components/patchwork/HBarList.tsx
@@ -18,56 +18,67 @@ export function HBarList({
 }) {
   const m = max ?? Math.max(...items.map((i) => i.value), 1);
   return (
-    <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
-      {items.map((item) => (
-        <div key={item.label} style={{ display: "grid", gridTemplateColumns: "minmax(0,1fr) auto", alignItems: "center", gap: 8 }}>
-          <div>
-            <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 4 }}>
+    <ul role="list" style={{ display: "flex", flexDirection: "column", gap: 8, listStyle: "none", padding: 0, margin: 0 }}>
+      {items.map((item) => {
+        const pct = Math.round((item.value / m) * 100);
+        return (
+          <li key={item.label} style={{ display: "grid", gridTemplateColumns: "minmax(0,1fr) auto", alignItems: "center", gap: 8 }}>
+            <div>
+              <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 4 }}>
+                <span
+                  style={{
+                    fontFamily: "var(--font-mono)",
+                    fontSize: "var(--fs-xs)",
+                    color: "var(--ink-1)",
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                    whiteSpace: "nowrap",
+                  }}
+                >
+                  {item.label}
+                </span>
+                {item.sub && (
+                  <span style={{ fontFamily: "var(--font-mono)", fontSize: "var(--fs-2xs)", color: "var(--ink-3)" }}>
+                    {item.sub}
+                  </span>
+                )}
+              </div>
+              <div
+                role="progressbar"
+                aria-label={`${item.label}: ${item.value.toLocaleString()} (${pct}%)`}
+                aria-valuenow={item.value}
+                aria-valuemin={0}
+                aria-valuemax={m}
+                style={{ height, background: "var(--line-3)", borderRadius: height }}
+              >
+                <div
+                  style={{
+                    width: `${Math.max(2, pct)}%`,
+                    height: "100%",
+                    background: item.color ?? "var(--orange)",
+                    borderRadius: height,
+                    transition: "width 0.4s ease",
+                  }}
+                />
+              </div>
+            </div>
+            {showValues && (
               <span
+                aria-hidden="true"
                 style={{
                   fontFamily: "var(--font-mono)",
                   fontSize: "var(--fs-xs)",
-                  color: "var(--ink-1)",
-                  overflow: "hidden",
-                  textOverflow: "ellipsis",
-                  whiteSpace: "nowrap",
+                  color: "var(--ink-2)",
+                  textAlign: "right",
+                  minWidth: 36,
                 }}
               >
-                {item.label}
+                {item.value.toLocaleString()}
               </span>
-              {item.sub && (
-                <span style={{ fontFamily: "var(--font-mono)", fontSize: "var(--fs-2xs)", color: "var(--ink-3)" }}>
-                  {item.sub}
-                </span>
-              )}
-            </div>
-            <div style={{ height, background: "var(--line-3)", borderRadius: height }}>
-              <div
-                style={{
-                  width: `${Math.max(2, (item.value / m) * 100)}%`,
-                  height: "100%",
-                  background: item.color ?? "var(--orange)",
-                  borderRadius: height,
-                  transition: "width 0.4s ease",
-                }}
-              />
-            </div>
-          </div>
-          {showValues && (
-            <span
-              style={{
-                fontFamily: "var(--font-mono)",
-                fontSize: "var(--fs-xs)",
-                color: "var(--ink-2)",
-                textAlign: "right",
-                minWidth: 36,
-              }}
-            >
-              {item.value.toLocaleString()}
-            </span>
-          )}
-        </div>
-      ))}
-    </div>
+            )}
+          </li>
+        );
+      })}
+    </ul>
   );
 }

--- a/dashboard/src/components/patchwork/MetricsDonut.tsx
+++ b/dashboard/src/components/patchwork/MetricsDonut.tsx
@@ -46,9 +46,20 @@ export function MetricsDonut({
     return { ...seg, start, end: cursor };
   });
 
+  const svgLabel =
+    (label ? `${label}: ` : "") +
+    arcs.map((a) => `${a.label} ${a.value.toLocaleString()} (${((a.value / total) * 100).toFixed(0)}%)`).join(", ");
+
   return (
     <div style={{ display: "flex", alignItems: "center", gap: 16 }}>
-      <svg viewBox="0 0 100 100" width={size} height={size} style={{ flexShrink: 0 }}>
+      <svg
+        viewBox="0 0 100 100"
+        width={size}
+        height={size}
+        style={{ flexShrink: 0 }}
+        role="img"
+        aria-label={svgLabel}
+      >
         {/* track */}
         <circle cx={cx} cy={cy} r={r} fill="none" stroke="var(--line-3)" strokeWidth={strokeWidth} />
         {arcs.map((arc, i) => (
@@ -59,9 +70,8 @@ export function MetricsDonut({
             stroke={arc.color}
             strokeWidth={strokeWidth}
             strokeLinecap="butt"
-          >
-            <title>{arc.label}: {arc.value.toLocaleString()}</title>
-          </path>
+            aria-hidden="true"
+          />
         ))}
         {label && (
           <text
@@ -69,18 +79,24 @@ export function MetricsDonut({
             y={cy + 1}
             textAnchor="middle"
             dominantBaseline="middle"
+            aria-hidden="true"
             style={{ fontFamily: "var(--font-mono)", fontSize: "var(--fs-2xs)", fill: "var(--ink-2)", fontWeight: 700 }}
           >
             {label}
           </text>
         )}
       </svg>
-      <div style={{ display: "flex", flexDirection: "column", gap: 5 }}>
+      <div role="list" style={{ display: "flex", flexDirection: "column", gap: 5, listStyle: "none", padding: 0, margin: 0 }}>
         {arcs.map((arc) => (
-          <div key={arc.label} style={{ display: "flex", alignItems: "center", gap: 6 }}>
-            <span style={{ width: 8, height: 8, borderRadius: 2, background: arc.color, flexShrink: 0 }} />
-            <span style={{ fontFamily: "var(--font-mono)", fontSize: "var(--fs-2xs)", color: "var(--ink-1)" }}>{arc.label}</span>
-            <span style={{ fontFamily: "var(--font-mono)", fontSize: "var(--fs-2xs)", color: "var(--ink-3)", marginLeft: 4 }}>
+          <div
+            key={arc.label}
+            role="listitem"
+            aria-label={`${arc.label}: ${arc.value.toLocaleString()}, ${((arc.value / total) * 100).toFixed(0)}%`}
+            style={{ display: "flex", alignItems: "center", gap: 6 }}
+          >
+            <span aria-hidden="true" style={{ width: 8, height: 8, borderRadius: 2, background: arc.color, flexShrink: 0 }} />
+            <span aria-hidden="true" style={{ fontFamily: "var(--font-mono)", fontSize: "var(--fs-2xs)", color: "var(--ink-1)" }}>{arc.label}</span>
+            <span aria-hidden="true" style={{ fontFamily: "var(--font-mono)", fontSize: "var(--fs-2xs)", color: "var(--ink-3)", marginLeft: 4 }}>
               {((arc.value / total) * 100).toFixed(0)}%
             </span>
           </div>

--- a/dashboard/src/hooks/__tests__/useBridgeFetch.test.tsx
+++ b/dashboard/src/hooks/__tests__/useBridgeFetch.test.tsx
@@ -146,7 +146,7 @@ describe("useBridgeFetch — enabled flag", () => {
 });
 
 describe("useBridgeFetch — initial state", () => {
-  it("starts as { data: null, loading: true, status: null, unsupported: false }", () => {
+  it("starts as { data: null, loading: true, status: null, unsupported: false, refetch: fn }", () => {
     fetchMock.mockImplementation(() => new Promise(() => {}));
     const { result } = renderHook(() => useBridgeFetch("/api/x"));
     expect(result.current).toEqual({
@@ -155,6 +155,7 @@ describe("useBridgeFetch — initial state", () => {
       loading: true,
       status: null,
       unsupported: false,
+      refetch: expect.any(Function),
     });
   });
 });

--- a/dashboard/src/hooks/useBridgeFetch.ts
+++ b/dashboard/src/hooks/useBridgeFetch.ts
@@ -1,5 +1,5 @@
 "use client";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { apiPath } from "@/lib/api";
 
 export interface UseBridgeFetchResult<T> {
@@ -8,6 +8,7 @@ export interface UseBridgeFetchResult<T> {
   loading: boolean;
   status: number | null;
   unsupported: boolean;
+  refetch: () => void;
 }
 
 const MAX_BACKOFF_MS = 30_000;
@@ -43,6 +44,9 @@ export function useBridgeFetch<T>(
   const [loading, setLoading] = useState(true);
   const [status, setStatus] = useState<number | null>(null);
   const [unsupported, setUnsupported] = useState(false);
+  // Caller-triggered re-fetch token; bumping it triggers an immediate tick.
+  const [refetchToken, setRefetchToken] = useState(0);
+  const refetch = useCallback(() => setRefetchToken((n) => n + 1), []);
 
   useEffect(() => {
     if (!enabled) return;
@@ -111,7 +115,7 @@ export function useBridgeFetch<T>(
       alive = false;
       if (timerId !== null) clearTimeout(timerId);
     };
-  }, [path, intervalMs, enabled]);
+  }, [path, intervalMs, enabled, refetchToken]);
 
-  return { data, error, loading, status, unsupported };
+  return { data, error, loading, status, unsupported, refetch };
 }

--- a/dashboard/src/hooks/useDebounced.ts
+++ b/dashboard/src/hooks/useDebounced.ts
@@ -1,0 +1,11 @@
+"use client";
+import { useEffect, useState } from "react";
+
+export function useDebounced<T>(value: T, delayMs = 250): T {
+  const [debounced, setDebounced] = useState(value);
+  useEffect(() => {
+    const id = setTimeout(() => setDebounced(value), delayMs);
+    return () => clearTimeout(id);
+  }, [value, delayMs]);
+  return debounced;
+}

--- a/scripts/start-all.sh
+++ b/scripts/start-all.sh
@@ -383,6 +383,8 @@ if [[ -z "$NO_DASHBOARD" ]] && [[ -d "$DASHBOARD_DIR" ]]; then
   DASHBOARD_CMD="cd $(printf '%q' "$DASHBOARD_DIR") && PATCHWORK_BRIDGE_PORT=${BRIDGE_PORT} npm run dev"
   notify "Starting dashboard on http://localhost:${DASHBOARD_PORT}"
   tmux send-keys -t "${SESSION}:0.4" "$DASHBOARD_CMD" Enter
+  # Open dashboard in browser after a short delay to let Next.js start
+  (sleep 8 && open "http://localhost:${DASHBOARD_PORT}" 2>/dev/null || xdg-open "http://localhost:${DASHBOARD_PORT}" 2>/dev/null || true) &
 fi
 
 # Pane 5: SSH reverse tunnel (only if --vps was set)

--- a/src/commands/patchworkInit.ts
+++ b/src/commands/patchworkInit.ts
@@ -12,6 +12,7 @@ import { registerPreToolUseHook } from "../preToolUseHook.js";
 interface InitOptions {
   force: boolean;
   skipOllama: boolean;
+  withConnectors: boolean;
 }
 
 function parseArgs(argv: string[]): InitOptions | { help: true } {
@@ -19,8 +20,20 @@ function parseArgs(argv: string[]): InitOptions | { help: true } {
   return {
     force: argv.includes("--force"),
     skipOllama: argv.includes("--no-ollama"),
+    withConnectors: argv.includes("--with-connectors"),
   };
 }
+
+// Recipes that run with no external service credentials (local file/git only).
+// Anything not in this set requires a connector (gmail, github, linear, slack,
+// sentry, calendar, …) and is skipped on first init unless --with-connectors.
+const LOCAL_ONLY_RECIPES: ReadonlySet<string> = new Set([
+  "ambient-journal.yaml",
+  "daily-status.yaml",
+  "lint-on-save.yaml",
+  "stale-branches.yaml",
+  "watch-failing-tests.yaml",
+]);
 
 function printHelp(): void {
   process.stdout.write(`patchwork-os init — Set up ~/.patchwork on this machine
@@ -28,13 +41,15 @@ function printHelp(): void {
 Usage: patchwork-os init [options]
 
 Options:
-  --force      Overwrite existing config (default: merge, preserve)
-  --no-ollama  Skip Ollama detection
-  --help, -h   Show this help
+  --force             Overwrite existing config (default: merge, preserve)
+  --no-ollama         Skip Ollama detection
+  --with-connectors   Also copy connector-dependent recipes (gmail, github, …)
+  --help, -h          Show this help
 
 What it does:
   1. Create ~/.patchwork/{config.json,recipes,inbox,journal}
-  2. Copy 5 local-only recipe templates to ~/.patchwork/recipes/
+  2. Copy local-only recipe templates to ~/.patchwork/recipes/
+     (add --with-connectors to also copy gmail/github/etc. recipes)
   3. Detect Ollama at localhost:11434 → set provider to ollama-local
   4. Register the Patchwork PreToolUse hook in ~/.claude/settings.json
      so Claude Code routes tool calls through your delegation policy
@@ -114,9 +129,14 @@ export async function runPatchworkInit(
   const templatesDir = findTemplatesDir();
   let recipesCopied = 0;
   let recipesSkipped = 0;
+  let recipesGated = 0;
   if (templatesDir) {
     for (const name of readdirSync(templatesDir)) {
       if (!name.endsWith(".yaml")) continue;
+      if (!parsed.withConnectors && !LOCAL_ONLY_RECIPES.has(name)) {
+        recipesGated++;
+        continue;
+      }
       const dest = join(recipesDir, name);
       if (existsSync(dest) && !parsed.force) {
         recipesSkipped++;
@@ -125,7 +145,12 @@ export async function runPatchworkInit(
       copyFileSync(join(templatesDir, name), dest);
       recipesCopied++;
     }
-    log(`  ✓ recipes: ${recipesCopied} copied, ${recipesSkipped} preserved\n`);
+    const gatedNote = recipesGated
+      ? ` (${recipesGated} connector-recipes skipped — re-run with --with-connectors)`
+      : "";
+    log(
+      `  ✓ recipes: ${recipesCopied} copied, ${recipesSkipped} preserved${gatedNote}\n`,
+    );
   } else {
     log(`  ! recipe templates not found (expected templates/recipes/)\n`);
   }
@@ -214,10 +239,11 @@ export async function runPatchworkInit(
       : "";
 
   log(`${restartLine}\nNext:
-  1. patchwork-os recipe run morning-brief     # AI digest: Gmail + calendar + tasks
+  1. patchwork-os recipe run daily-status      # zero-config: yesterday's commits + today's hints
   2. patchwork-os                              # launch terminal dashboard (TUI)
-  2b. cd dashboard && npm run dev              # launch web dashboard → http://localhost:3200
-  3. patchwork-os recipe list                  # browse installed recipes\n`);
+  3. cd dashboard && npm run dev               # launch web dashboard → http://localhost:3200
+  4. patchwork-os recipe list                  # browse installed recipes
+  5. patchwork-os init --with-connectors       # add gmail/github/linear/etc. recipes\n`);
 
   return {
     configPath,

--- a/src/commands/patchworkInit.ts
+++ b/src/commands/patchworkInit.ts
@@ -166,7 +166,7 @@ export async function runPatchworkInit(
       model: ollamaDetected ? "local" : "claude",
       recipesDir,
       dashboard: {
-        port: 3000,
+        port: 3200,
         requireApproval: ["high"],
         pushNotifications: false,
       },
@@ -215,7 +215,8 @@ export async function runPatchworkInit(
 
   log(`${restartLine}\nNext:
   1. patchwork-os recipe run morning-brief     # AI digest: Gmail + calendar + tasks
-  2. patchwork-os                              # launch terminal dashboard → http://localhost:3100
+  2. patchwork-os                              # launch terminal dashboard (TUI)
+  2b. cd dashboard && npm run dev              # launch web dashboard → http://localhost:3200
   3. patchwork-os recipe list                  # browse installed recipes\n`);
 
   return {

--- a/src/commands/patchworkInit.ts
+++ b/src/commands/patchworkInit.ts
@@ -35,6 +35,12 @@ const LOCAL_ONLY_RECIPES: ReadonlySet<string> = new Set([
   "watch-failing-tests.yaml",
 ]);
 
+// Dev/dogfood fixtures that aren't user-facing and shouldn't be seeded by
+// either init mode. Skipped silently regardless of --with-connectors.
+const DEV_FIXTURE_RECIPES: ReadonlySet<string> = new Set([
+  "ctx-loop-test.yaml",
+]);
+
 function printHelp(): void {
   process.stdout.write(`patchwork-os init — Set up ~/.patchwork on this machine
 
@@ -133,6 +139,7 @@ export async function runPatchworkInit(
   if (templatesDir) {
     for (const name of readdirSync(templatesDir)) {
       if (!name.endsWith(".yaml")) continue;
+      if (DEV_FIXTURE_RECIPES.has(name)) continue;
       if (!parsed.withConnectors && !LOCAL_ONLY_RECIPES.has(name)) {
         recipesGated++;
         continue;

--- a/src/commands/patchworkInit.ts
+++ b/src/commands/patchworkInit.ts
@@ -239,9 +239,9 @@ export async function runPatchworkInit(
       : "";
 
   log(`${restartLine}\nNext:
-  1. patchwork-os recipe run daily-status      # zero-config: yesterday's commits + today's hints
-  2. patchwork-os                              # launch terminal dashboard (TUI)
-  3. cd dashboard && npm run dev               # launch web dashboard → http://localhost:3200
+  1. patchwork start                           # launch bridge + Claude + dashboard (one command)
+  2. patchwork-os recipe run daily-status      # zero-config: yesterday's commits + today's hints
+  3. patchwork-os                              # terminal dashboard (TUI, alternative to web)
   4. patchwork-os recipe list                  # browse installed recipes
   5. patchwork-os init --with-connectors       # add gmail/github/linear/etc. recipes\n`);
 

--- a/src/connectors/gmail.ts
+++ b/src/connectors/gmail.ts
@@ -519,7 +519,7 @@ function callbackHtml(
 </div>
 <script>
   // Notify the opener tab that auth completed so it can poll.
-  if (window.opener) { try { window.opener.postMessage('patchwork:gmail:connected', 'http://localhost:3100'); } catch(_) {} }
+  if (window.opener) { try { window.opener.postMessage('patchwork:gmail:connected', 'http://localhost:3200'); } catch(_) {} }
 </script>
 </body></html>`;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -189,7 +189,7 @@ const __invokedSubcommand = (() => {
 })();
 
 const __invokedBareBinaryDashboard = (() => {
-  if (process.argv[2]) return false;
+  if (process.argv[2] && process.argv[2] !== "dashboard") return false;
   const binName = path.basename(process.argv[1] ?? "");
   return (
     binName === "patchwork-os" ||
@@ -3115,7 +3115,7 @@ if (process.argv[2] === "launchd") {
     binName === "patchwork-os" ||
     binName === "patchwork" ||
     binName === "patchwork.js";
-  if (isPatchworkBin && !process.argv[2]) {
+  if (isPatchworkBin && (!process.argv[2] || process.argv[2] === "dashboard")) {
     (async () => {
       const { runDashboard } = await import("./commands/dashboard.js");
       await runDashboard();

--- a/src/index.ts
+++ b/src/index.ts
@@ -176,6 +176,7 @@ const KNOWN_SUBCOMMANDS = [
   "suggest",
   "dashboard",
   "launchd",
+  "start",
 ] as const;
 
 const __invokedSubcommand = (() => {
@@ -233,6 +234,54 @@ if (isStartAll) {
     "start-all.sh",
   );
   const result = spawnSync("bash", [scriptPath, ...startAllArgs], {
+    stdio: "inherit",
+  });
+  process.exit(result.status ?? 1);
+}
+
+// `patchwork start` — opinionated front door over start-all.
+// Defaults to full mode (all tools registered) and the web dashboard, so the
+// doc-promised "patchwork start → everything works" path actually works.
+// Pass-through args still go to start-all.sh; --help short-circuits.
+if (process.argv[2] === "start") {
+  const passthrough = process.argv.slice(3);
+  if (passthrough.includes("--help") || passthrough.includes("-h")) {
+    process.stdout.write(`patchwork start — Launch the full Patchwork stack
+
+Starts bridge + Claude Code + dashboard in a tmux session.
+Defaults to full mode so all bridge tools are registered.
+
+Usage: patchwork start [options]
+
+Options:
+  --workspace <path>    Directory to open (default: current directory)
+  --no-dashboard        Skip the web dashboard
+  --dashboard-port <N>  Dashboard port (default: 3200)
+  --notify <topic>      Push notifications via ntfy.sh
+  --vps <user@host>     SSH reverse tunnel for stable claude.ai URL
+  --slim                Slim mode (27 IDE-exclusive tools only — overrides default)
+  --help, -h            Show this help
+
+This is a thin wrapper over \`start-all\`. For advanced flags see:
+  patchwork start-all --help
+`);
+    process.exit(0);
+  }
+  // Default to --full unless caller opted into slim explicitly.
+  const args = [...passthrough];
+  const slimIdx = args.indexOf("--slim");
+  if (slimIdx >= 0) {
+    args.splice(slimIdx, 1); // strip — start-all.sh has no --slim flag, slim is its default
+  } else if (!args.includes("--full")) {
+    args.push("--full");
+  }
+  const scriptPath = path.resolve(
+    __dirnameTop,
+    "..",
+    "scripts",
+    "start-all.sh",
+  );
+  const result = spawnSync("bash", [scriptPath, ...args], {
     stdio: "inherit",
   });
   process.exit(result.status ?? 1);

--- a/src/patchworkConfig.ts
+++ b/src/patchworkConfig.ts
@@ -46,7 +46,7 @@ export interface PatchworkConfig {
 const DEFAULTS: PatchworkConfig = {
   model: "claude",
   dashboard: {
-    port: 3000,
+    port: 3200,
     requireApproval: ["high"],
     pushNotifications: false,
   },

--- a/src/recipeOrchestration.ts
+++ b/src/recipeOrchestration.ts
@@ -580,11 +580,11 @@ SCHEMA:
     type: manual | cron | webhook
     at: "<cron expression>"             # only when type=cron
     path: "/hooks/<slug>"               # only when type=webhook
-  vars:                                 # optional
-    - name: VAR_NAME
-      description: hint for caller
-      required: true | false
-      default: "value"
+    vars:                               # optional — MUST be nested under trigger
+      - name: VAR_NAME
+        description: hint for caller
+        required: true | false
+        default: "value"
   steps:
     - id: step-1
       agent:
@@ -608,10 +608,10 @@ description: Daily summary of GitHub notifications delivered by email
 trigger:
   type: cron
   at: "0 8 * * 1-5"
-vars:
-  - name: EMAIL
-    description: Email address to send the digest to
-    required: true
+  vars:
+    - name: EMAIL
+      description: Email address to send the digest to
+      required: true
 steps:
   - id: fetch-notifications
     agent:
@@ -636,11 +636,11 @@ description: Triage new Sentry issues to Linear and Slack
 trigger:
   type: webhook
   path: "/hooks/sentry-issues"
-vars:
-  - name: SLACK_CHANNEL
-    description: Slack channel to notify
-    required: false
-    default: "#incidents"
+  vars:
+    - name: SLACK_CHANNEL
+      description: Slack channel to notify
+      required: false
+      default: "#incidents"
 steps:
   - id: create-linear-ticket
     agent:

--- a/src/recipeOrchestration.ts
+++ b/src/recipeOrchestration.ts
@@ -7,7 +7,7 @@ import { readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { basename, extname, join } from "node:path";
 
-import { parse as parseYaml } from "yaml";
+import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
 import { recordRecipeRun } from "./activationMetrics.js";
 import type { ClaudeOrchestrator } from "./claudeOrchestrator.js";
 import type { RecipeOrchestrator } from "./recipes/RecipeOrchestrator.js";
@@ -468,17 +468,26 @@ export class RecipeOrchestration {
         return { ok: false, error: "no_yaml_in_output" };
       }
 
-      const lint = lintRecipeContent(rawYaml);
+      // The model frequently emits `vars:` at the top level despite the
+      // system prompt teaching the nested form. The validator only reads
+      // `trigger.vars`/`trigger.inputs`, so a top-level `vars:` would be
+      // silently dropped at runtime and any `{{VAR_NAME}}` references in
+      // step prompts would fail with "Unknown template reference". Hoist
+      // the block under `trigger:` here so the lint and the saved file
+      // see a schema-correct shape regardless of model drift.
+      const normalizedYaml = hoistTopLevelVarsUnderTrigger(rawYaml);
+
+      const lint = lintRecipeContent(normalizedYaml);
       if (!lint.ok) {
         return {
           ok: false,
-          yaml: rawYaml,
+          yaml: normalizedYaml,
           warnings: [...lint.errors, ...lint.warnings],
           error: "invalid_yaml_generated",
         };
       }
 
-      return { ok: true, yaml: rawYaml, warnings: lint.warnings };
+      return { ok: true, yaml: normalizedYaml, warnings: lint.warnings };
     };
   }
 
@@ -657,12 +666,59 @@ steps:
 \`\`\``;
 
 function extractYamlBlock(text: string): string | null {
-  const fenced = /```(?:yaml)?\n([\s\S]*?)```/.exec(text);
+  // Accept ```yaml, ```yml, ```YAML, ~~~yaml, or unfenced YAML starting
+  // with a recognizable header. Tolerates surrounding prose ("Here's
+  // your recipe:" before the fence) and CRLF line endings.
+  const fenced =
+    /(?:^|\n)\s*(?:```|~~~)(?:[ \t]*(?:yaml|yml|YAML))?\s*\r?\n([\s\S]*?)(?:```|~~~)/i.exec(
+      text,
+    );
   if (fenced?.[1]) return fenced[1].trim();
   const trimmed = text.trim();
   if (/^(?:apiVersion:|name:|#\s*yaml-language-server)/.test(trimmed))
     return trimmed;
   return null;
+}
+
+/**
+ * The recipe schema only allows `vars:` (and `inputs:`) under `trigger:`.
+ * The Claude generator drifts and frequently emits `vars:` at the top
+ * level — those declarations are silently dropped by the validator, then
+ * any `{{VAR_NAME}}` reference in a step prompt is flagged as Unknown.
+ * Parse the YAML, move a top-level `vars` array under `trigger.vars`
+ * (without overwriting an existing nested vars array), and re-emit. On
+ * any parse error we return the input untouched so lint can surface the
+ * underlying problem.
+ */
+function hoistTopLevelVarsUnderTrigger(yaml: string): string {
+  let doc: unknown;
+  try {
+    doc = parseYaml(yaml);
+  } catch {
+    return yaml;
+  }
+  if (!doc || typeof doc !== "object") return yaml;
+  const recipe = doc as Record<string, unknown>;
+  const topVars = recipe.vars;
+  if (!Array.isArray(topVars) || topVars.length === 0) return yaml;
+  const trigger =
+    recipe.trigger && typeof recipe.trigger === "object"
+      ? (recipe.trigger as Record<string, unknown>)
+      : {};
+  if (Array.isArray(trigger.vars) && trigger.vars.length > 0) {
+    // Caller emitted both — prefer the (correctly-placed) nested form
+    // and just drop the top-level dupe.
+    delete recipe.vars;
+  } else {
+    trigger.vars = topVars;
+    delete recipe.vars;
+  }
+  recipe.trigger = trigger;
+  try {
+    return stringifyYaml(recipe);
+  } catch {
+    return yaml;
+  }
 }
 
 /**

--- a/src/recipes/validation.ts
+++ b/src/recipes/validation.ts
@@ -1,4 +1,5 @@
 import { Ajv, type ErrorObject } from "ajv";
+import cron from "node-cron";
 import { FLAG_SCHEMA_LINT, isEnabled } from "../featureFlags.js";
 import {
   defaultDeprecationWarn,
@@ -75,6 +76,28 @@ export function validateRecipeDefinition(recipe: unknown): LintResult {
           level: "warning",
           message: "cron trigger should have 'at' (cron expression)",
         });
+      }
+      if (trigger.type === "cron" && typeof trigger.at === "string") {
+        // Reject bogus expressions early so users see the error at save
+        // time, not when the scheduler silently fails to register the
+        // recipe and it never fires. Mirrors the parse path in
+        // src/recipes/scheduler.ts:parseSchedule.
+        const at = trigger.at.trim();
+        const isInterval = /^@every\s+\d+\s*(ms|s|m|h)$/i.test(at);
+        const isCron5 = /^\S+\s+\S+\s+\S+\s+\S+\s+\S+$/.test(at);
+        if (!isInterval && !isCron5) {
+          issues.push({
+            level: "error",
+            message: `trigger.at "${at}" is not a valid schedule — expected 5-field cron (e.g. "0 9 * * 1-5") or "@every Ns|Nm|Nh"`,
+          });
+        } else if (isCron5 && !cron.validate(at)) {
+          // node-cron catches range/step typos a field-count check
+          // misses — e.g. "0 25 * * *", "* / 5 * * *".
+          issues.push({
+            level: "error",
+            message: `trigger.at "${at}" is not a valid 5-field cron expression`,
+          });
+        }
       }
     }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -1342,7 +1342,7 @@ export class Server extends EventEmitter<ServerEvents> {
             const configPath = patchworkConfigPath();
             const cfg = loadPatchworkConfig(configPath);
             cfg.dashboard = {
-              port: cfg.dashboard?.port ?? 3000,
+              port: cfg.dashboard?.port ?? 3200,
               requireApproval: cfg.dashboard?.requireApproval ?? ["high"],
               pushNotifications: cfg.dashboard?.pushNotifications ?? false,
               webhookUrl: hasWebhookUpdate

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "claude-ide-bridge-extension",
   "displayName": "Claude IDE Bridge",
   "description": "MCP bridge between Claude Code and your IDE. 170+ tools — diagnostics, LSP, debugger, terminal, git. Optional Patchwork OS layer adds recipes, oversight, and approval queue.",
-  "version": "1.4.11",
+  "version": "1.4.12",
   "extensionKind": [
     "workspace"
   ],
@@ -64,7 +64,7 @@
           {
             "id": "checkConnection",
             "title": "Verify bridge is running",
-            "description": "Run `claude-ide-bridge start` in your terminal, then click Reconnect.\n\n[Reconnect](command:claudeIdeBridge.reconnect)",
+            "description": "Run `claude-ide-bridge start-all` in your terminal, then click Reconnect.\n\n[Reconnect](command:claudeIdeBridge.reconnect)",
             "completionEvents": [
               "onCommand:claudeIdeBridge.reconnect"
             ],

--- a/vscode-extension/src/bridgeInstaller.ts
+++ b/vscode-extension/src/bridgeInstaller.ts
@@ -36,9 +36,11 @@ function semverGte(a: string, b: string): boolean {
 }
 
 /**
- * Handles detection and silent global install/upgrade of `claude-ide-bridge`.
- * Compares the installed semver against BRIDGE_VERSION (bundled at build time)
- * and runs `npm install -g claude-ide-bridge@<version>` when needed.
+ * Handles detection and silent global install/upgrade of the bridge.
+ * The npm package is `patchwork-os` (which provides the `claude-ide-bridge`
+ * binary as one of its bin aliases). Compares the installed semver against
+ * BRIDGE_VERSION (bundled at build time) and runs
+ * `npm install -g patchwork-os@<version>` when needed.
  */
 export class BridgeInstaller {
   constructor(private readonly output: vscode.OutputChannel) {}
@@ -82,21 +84,21 @@ export class BridgeInstaller {
   }
 
   /**
-   * Run `npm install -g claude-ide-bridge@<version>` and pipe output to the
+   * Run `npm install -g patchwork-os@<version>` and pipe output to the
    * output channel. Rejects on non-zero exit.
    */
   async installOrUpgrade(version: string): Promise<void> {
-    this.log(`Installing claude-ide-bridge@${version} globally...`);
+    this.log(`Installing patchwork-os@${version} globally...`);
     const npmCmd = process.platform === "win32" ? "npm.cmd" : "npm";
     try {
       const { stdout, stderr } = await execFileAsync(
         npmCmd,
-        ["install", "-g", `claude-ide-bridge@${version}`],
+        ["install", "-g", `patchwork-os@${version}`],
         { timeout: 120_000 },
       );
       if (stdout) this.log(stdout.trim());
       if (stderr) this.log(stderr.trim());
-      this.log(`Installed claude-ide-bridge@${version} successfully.`);
+      this.log(`Installed patchwork-os@${version} successfully.`);
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : String(err);
       // Surface npm-not-found as a distinct, actionable error.
@@ -105,7 +107,7 @@ export class BridgeInstaller {
       const code = (err as NodeJS.ErrnoException).code;
       if (code === "ENOENT" || msg.includes("ENOENT")) {
         const notice = "Node.js/npm is required to auto-install the bridge.";
-        const action = "Install manually: npm install -g claude-ide-bridge";
+        const action = "Install manually: npm install -g patchwork-os";
         void vscode.window.showWarningMessage(`${notice} ${action}`);
         throw new Error(`npm not found: ${msg}`);
       }
@@ -124,14 +126,14 @@ export class BridgeInstaller {
 
     if (installed !== null && semverGte(installed, required)) {
       this.log(
-        `claude-ide-bridge@${installed} already installed (>= required ${required}) — no action needed.`,
+        `patchwork-os (claude-ide-bridge@${installed}) already installed (>= required ${required}) — no action needed.`,
       );
       return;
     }
 
     const isFirstInstall = installed === null;
     const verb = isFirstInstall ? "Installing" : `Upgrading ${installed} →`;
-    this.log(`${verb} claude-ide-bridge@${required}...`);
+    this.log(`${verb} patchwork-os@${required}...`);
 
     await vscode.window.withProgress(
       {


### PR DESCRIPTION
## Summary
Originally three bugs from a Playwright dogfood of `/dashboard/recipes/new`. Cross-agent audit on top of those surfaced four more — fixed in commit `36b3026`. All findings cited at file:line in linked source.

## Original three (commits c841124, dd478c4)

### [P0] Form + AI generator emit `vars:` at top level
[`schemas/recipe.v1.json`](schemas/recipe.v1.json) has no top-level `vars`. Validator at [src/recipes/validation.ts:339](src/recipes/validation.ts#L339) only reads `trigger.vars`/`trigger.inputs`. Both the form's `buildRecipeYaml` and the AI generator's system prompt emitted `vars:` at the top level — every recipe with variables failed lint. Fixed both.

### [P1] Generate with AI → 405 in demo mode
`POST /api/bridge/recipes/generate` was being shadowed by the `[name]` dynamic route, which only exports GET/PUT/PATCH. Added explicit handler.

### [P1] Demo-mode save redirected into empty editor
`PUT` short-circuits to `{ok:true, demo:true}` but client redirected anyway, landing on `1 lines · 0 chars` editor. `handleSubmit` now shows a notice and stays on the form.

## Audit followups (commit 36b3026)

### [P0] `applyAiYaml` was a hand-rolled line scanner with three silent-data-loss bugs
[dashboard/src/app/recipes/new/page.tsx:474](dashboard/src/app/recipes/new/page.tsx#L474):
- Silently dropped `vars` on "Use this".
- Rewrote step `into:` keys via `makeStepOutputKey(stepId)`, breaking AI-emitted `{{step_output}}` chains (e.g. AI emitted `into: notifications_summary` → form re-derived `into: fetch_notifications` → step 2's `{{notifications_summary}}` reference broke).
- Regex `/^\s+(at|path):\s/` matched the first indented occurrence anywhere → step-level `tool: file.write\n    path: ~/...` got pulled into `trigger.path`.

**Fix**: replaced with the `yaml` parser (already a bridge dep; new dashboard dep). Walks the AST. Added optional `Step.into` so the form preserves AI's semantic keys instead of always re-deriving.

### [P1] AI generator drifts on `vars:` placement despite the prompt
The model kept emitting top-level `vars:` even after the prompt fix in `dd478c4`. Added `hoistTopLevelVarsUnderTrigger` in [src/recipeOrchestration.ts](src/recipeOrchestration.ts) that runs after `extractYamlBlock` and before lint — moves a top-level `vars` array under `trigger.vars` (preserves an existing nested array if both are present). Defense-in-depth.

### [P1] `extractYamlBlock` regex was fragile
[src/recipeOrchestration.ts:660](src/recipeOrchestration.ts#L660) only matched ` ```yaml ` (lowercase, no leading prose). Failed on ` ```yml `, ` ```YAML `, `~~~yaml`, fences with surrounding prose, CRLF. Caused non-deterministic `no_yaml_in_output` errors when user prompts contained code fences. Now accepts all of those.

### [P1] Cron expressions never validated
[src/recipes/validation.ts:73](src/recipes/validation.ts#L73) only checked `trigger.at` was *present*. `bogus`, `0 25 * * *`, 6-field expressions all saved HTTP 200 then silently never fired. Now validates field count + uses node-cron's own validator. Form does cheap shape pre-flight before submit.

### [P1] handleSubmit dropped server `warnings`
Form typed PUT response as `{ok, error, demo}` and discarded `warnings`. Now stashes them in `sessionStorage` and the edit page surfaces them as a `toast.info` on first paint.

## Test plan
- [x] All 481 tests in `src/recipes/__tests__/` pass
- [x] `tsc --noEmit` clean (bridge + dashboard)
- [x] `biome check src/recipeOrchestration.ts src/recipes/validation.ts` clean
- [x] Live PUT recipe with cron `0 9 * * 1-5` accepts; with `bogus` rejects (lint level=error)
- [x] Live PUT recipe with `vars` correctly nested passes lint
- [x] Form preview emits `trigger.vars` (verified in dogfood)
- [ ] Followup: rebuild + restart bridge, re-run live "Generate with AI" with the new system prompt + hoisting

## Audit findings NOT addressed in this PR
The audit found additional structural gaps that are out of scope for a bugfix PR — tracked in [project_recipe_audit_2026_05_06.md](https://github.com/Oolab-labs/patchwork-os/) memory note (TBD as issues if you want them filed):
- AI generator system prompt teaches no real tool integrations (P0, big product gap)
- Form supports only `agent:` steps and 3 trigger types; schema/runtime support `tool:`/`recipe:`/`parallel:` and 5 more trigger types (P0, scope decision needed)
- No rate limit / output cap / abuse filter on `/recipes/generate` (P0/P1, security)
- Var-name validation, recipe-name regex parity (form vs server vs schema), CSRF at bridge level (P1 each)

🤖 Generated with [Claude Code](https://claude.com/claude-code)