### PR TITLE
fix(dashboard): demo+bridge banners overlap sticky app-header at narrow viewports

### DIFF
--- a/dashboard/src/app/globals.css
+++ b/dashboard/src/app/globals.css
@@ -1884,10 +1884,12 @@ button.topbar-search {
 .toggle.on::after { transform: translateX(14px); }
 
 
-/* ---- Editorial demo banner (2.0 style) ---- */
+/* ---- Editorial demo banner (2.0 style) ----
+   Not sticky: it would overlap the sticky `.app-header` (both pinned at
+   top:0, same scroll container) and obscure the menu/theme toggle. The
+   "Demo" pill in the header keeps the indicator persistent on scroll. */
 .demo-banner {
-  position: sticky;
-  top: 0;
+  position: relative;
   z-index: 100;
   display: flex;
   align-items: center;
@@ -2191,10 +2193,11 @@ button.topbar-search {
 .app-sidebar-bridge-version { color: var(--ink-2); }
 .app-sidebar-bridge-port { color: var(--ink-3); }
 
-/* ---- Bridge offline banner (global, sticky) ------------------------- */
+/* ---- Bridge offline banner (global) ---------------------------------
+   Not sticky for the same reason as `.demo-banner` — would collide with
+   the sticky `.app-header`. Bridge errors are loud enough on first paint. */
 .bridge-banner {
-  position: sticky;
-  top: 0;
+  position: relative;
   z-index: 60;
   display: flex;
   align-items: center;
@@ -2517,9 +2520,11 @@ button.topbar-search {
     width: 20px;
     height: 20px;
   }
-  /* Make room for the bottom bar so content isn't hidden underneath */
+  /* Make room for the bottom bar so content isn't hidden underneath.
+     Bottom-nav is ~56px + 6px top + 6px bottom + safe-area; we want a
+     little extra so the form's primary CTA isn't tight against the nav. */
   .app-main {
-    padding-bottom: 64px;
+    padding-bottom: calc(80px + env(safe-area-inset-bottom, 0px));
   }
 }
 

--- a/dashboard/src/components/DemoBanner.tsx
+++ b/dashboard/src/components/DemoBanner.tsx
@@ -13,7 +13,7 @@ export function DemoBanner() {
   if (!demo) return null;
 
   return (
-    <div role="status" className="demo-banner" style={{ position: "sticky", top: 0 }}>
+    <div role="status" className="demo-banner">
       <span className="demo-banner-dot" aria-hidden="true" />
       <span className="demo-banner-text">
         <strong>Demo</strong>


### PR DESCRIPTION
## Summary

- DemoBanner and BridgeBanner were both `position: sticky; top: 0;` in the same scroll container as `.app-header` (also sticky top: 0). When scrolled, all three pinned to viewport `top: 0` — DemoBanner (z-index 100) covered the hamburger menu and theme toggle in the header.
- Surfaced by Playwright dogfood of `/dashboard/recipes/new` at 700×900.
- Make both banners flow normally (`position: relative`). The orange "Demo" pill in the header keeps the demo-mode indicator persistent on scroll, so we don't lose the safety affordance.
- Bump `.app-main` mobile bottom padding from `64px` to `calc(80px + env(safe-area-inset-bottom))` so the form's primary CTA has comfortable clearance over the bottom-nav and iOS safe area.

Closes #261

## Test plan

- [x] Verified at 700×900 via Playwright: scroll to ~200px, app-header is fully visible (hamburger + Demo pill + theme toggle), no banner overlap.
- [x] Demo pill in header still indicates demo mode after the banner scrolls away.
- [x] `npm test` — 206/206 pass.
- [x] `npm run build` — clean production build.
- [ ] Verify on a live mobile device (iOS Safari + Android Chrome) that the bottom-nav padding clears the home indicator / nav bar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)