### PR TITLE
fix(dashboard): add aria-label to step prompt textareas

### DIFF
--- a/dashboard/src/app/recipes/new/page.tsx
+++ b/dashboard/src/app/recipes/new/page.tsx
@@ -1443,6 +1443,7 @@ function NewRecipePageInner() {
                       value={step.prompt}
                       onChange={(e) => updateStep(i, e.target.value)}
                       placeholder="Describe what Claude should do in this step…"
+                      aria-label={`Step ${i + 1} prompt`}
                       rows={3}
                       style={{
                         width: "100%",


### PR DESCRIPTION
## Summary

- Step prompt textareas had only a placeholder; variable inputs already have descriptive aria-labels (`Variable 1 name`, etc.).
- The visible "Step N — Agent prompt" label is associated via `htmlFor`/`id`, but parity with the variable inputs helps screen-reader navigation when tabbing through repeated step rows.
- Adds `aria-label={\`Step \${i + 1} prompt\`}` to each step textarea.

Closes #262

## Test plan

- [x] Verified via Playwright: textareas at `step-prompt-0` and `step-prompt-1` both expose `aria-label="Step N prompt"`.
- [x] Existing `htmlFor`/`id` association is preserved.
- [x] `npm test` — 206/206 pass.
- [x] `npm run build` — clean production build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)