### PR TITLE
fix(dashboard): focus newly-added row when clicking + Add variable / + Add step

### DIFF
--- a/dashboard/src/app/recipes/new/page.tsx
+++ b/dashboard/src/app/recipes/new/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { useRouter, useSearchParams } from "next/navigation";
-import { Suspense, useCallback, useMemo, useState } from "react";
+import { Suspense, useCallback, useMemo, useRef, useState } from "react";
 import { parse as parseYaml } from "yaml";
 import { apiPath } from "@/lib/api";
 
@@ -284,6 +284,14 @@ function NewRecipePageInner() {
     error?: string;
   } | null>(null);
 
+  // Refs used to focus newly-appended rows on mount.
+  // Keys are list indexes; the matching ref callback consumes pendingFocus when it attaches.
+  const varNameRefs = useRef<Map<number, HTMLInputElement | null>>(new Map());
+  const stepPromptRefs = useRef<Map<number, HTMLTextAreaElement | null>>(new Map());
+  const pendingFocus = useRef<{ kind: "var" | "step"; index: number } | null>(
+    null,
+  );
+
   const setName = useCallback((v: string) => {
     setForm((f) => ({ ...f, name: v }));
     if (v && !NAME_RE.test(v)) {
@@ -344,6 +352,7 @@ function NewRecipePageInner() {
         ...f.steps,
         { id: makeNextStepId(f.steps), agent: true, prompt: "" },
       ];
+      pendingFocus.current = { kind: "step", index: steps.length - 1 };
       return { ...f, steps };
     });
     setValidation((current) => ({ ...current, steps: [...current.steps, null] }));
@@ -386,13 +395,14 @@ function NewRecipePageInner() {
   }, []);
 
   const addVar = useCallback(() => {
-    setForm((f) => ({
-      ...f,
-      vars: [
+    setForm((f) => {
+      const vars = [
         ...f.vars,
         { name: "", description: "", required: false, default: "" },
-      ],
-    }));
+      ];
+      pendingFocus.current = { kind: "var", index: vars.length - 1 };
+      return { ...f, vars };
+    });
     setValidation((current) => ({ ...current, vars: [...current.vars, null] }));
     setSubmitError(null);
   }, []);
@@ -1233,6 +1243,20 @@ function NewRecipePageInner() {
                         }}
                       >
                         <input
+                          ref={(node) => {
+                            if (node) varNameRefs.current.set(i, node);
+                            else varNameRefs.current.delete(i);
+                            const target = pendingFocus.current;
+                            if (
+                              node &&
+                              target &&
+                              target.kind === "var" &&
+                              target.index === i
+                            ) {
+                              pendingFocus.current = null;
+                              node.focus();
+                            }
+                          }}
                           type="text"
                           value={v.name}
                           onChange={(e) => updateVar(i, "name", e.target.value)}
@@ -1439,6 +1463,20 @@ function NewRecipePageInner() {
                       </div>
                     </div>
                     <textarea
+                      ref={(node) => {
+                        if (node) stepPromptRefs.current.set(i, node);
+                        else stepPromptRefs.current.delete(i);
+                        const target = pendingFocus.current;
+                        if (
+                          node &&
+                          target &&
+                          target.kind === "step" &&
+                          target.index === i
+                        ) {
+                          pendingFocus.current = null;
+                          node.focus();
+                        }
+                      }}
                       id={`step-prompt-${i}`}
                       value={step.prompt}
                       onChange={(e) => updateStep(i, e.target.value)}


### PR DESCRIPTION
## Summary

- Clicking **"+ Add variable"** or **"+ Add step"** in `/dashboard/recipes/new` appended a row but left focus on the button. For a tab-heavy form that's friction — the user had to mouse over to the new name input.
- Surfaced by Playwright dogfood of the recipe form.
- `addVar` / `addStep` now set a `pendingFocus` ref to `{ kind, index }`. The variable-name input and step-prompt textarea each have a ref-callback that consumes `pendingFocus` on mount and calls `.focus()`.
- A ref callback is more reliable than `useEffect` keyed on list length, because it fires exactly when the DOM node is attached (no race with the layout effect).

Closes #260

## Test plan

- [x] Verified via Playwright at 700×900: clicking "+ Add variable" focuses the new `Variable N name` input; clicking "+ Add step" focuses the new `Step N prompt` textarea.
- [x] Re-clicking "+ Add variable" focuses the *next* new row, not the previous one.
- [x] `npm test` — 241/241 pass.
- [x] `npm run build` — clean production build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)