### PR TITLE
fix(recipes): unify var-name + recipe-name validation across form, server, schema

### DIFF
--- a/dashboard/public/schema/recipe.v1.json
+++ b/dashboard/public/schema/recipe.v1.json
@@ -11,8 +11,8 @@
   "properties": {
     "name": {
       "type": "string",
-      "description": "Recipe name (kebab-case recommended)",
-      "pattern": "^[a-z0-9-]+$"
+      "description": "Recipe name (kebab-case, 1-64 chars). Scoped names like @scope/name are accepted for registry recipes.",
+      "pattern": "^(@[a-z0-9-]+/)?[a-z0-9][a-z0-9-]{0,63}$"
     },
     "description": {
       "type": "string",
@@ -100,6 +100,37 @@
           "type": "string",
           "enum": ["event"],
           "description": "Original trigger type preserved during legacy normalization"
+        },
+        "vars": {
+          "type": "array",
+          "description": "Caller-supplied variables. Referenced in step prompts as {{NAME}}.",
+          "items": {
+            "type": "object",
+            "required": ["name"],
+            "properties": {
+              "name": {
+                "type": "string",
+                "pattern": "^[A-Za-z_][A-Za-z0-9_]{0,63}$",
+                "description": "Variable identifier — letters, digits, underscores only. Must start with a letter or underscore."
+              },
+              "description": {
+                "type": "string"
+              },
+              "required": {
+                "type": "boolean"
+              },
+              "default": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "inputs": {
+          "type": "array",
+          "description": "Alias of `vars` accepted by the runtime. Same shape, same semantics.",
+          "items": {
+            "$ref": "#/properties/trigger/properties/vars/items"
+          }
         }
       }
     },
@@ -162,6 +193,14 @@
               "transform": {
                 "type": "string",
                 "description": "Template rendered after tool execution. Use $result to reference the tool output. Supports all template expressions."
+              },
+              "retry": {
+                "type": "number",
+                "description": "Number of times to retry this step on failure (overrides recipe-level on_error.retry)"
+              },
+              "retryDelay": {
+                "type": "number",
+                "description": "Milliseconds to wait between retries (default 1000)"
               },
               "agent": {
                 "type": "object",
@@ -229,6 +268,14 @@
                 "type": "string",
                 "description": "Template rendered after tool execution. Use $result to reference the tool output. Supports all template expressions."
               },
+              "retry": {
+                "type": "number",
+                "description": "Number of times to retry this step on failure (overrides recipe-level on_error.retry)"
+              },
+              "retryDelay": {
+                "type": "number",
+                "description": "Milliseconds to wait between retries (default 1000)"
+              },
               "tool": {
                 "type": "string",
                 "not": {
@@ -242,7 +289,14 @@
           },
           {
             "type": "object",
-            "required": ["recipe"],
+            "anyOf": [
+              {
+                "required": ["recipe"]
+              },
+              {
+                "required": ["chain"]
+              }
+            ],
             "properties": {
               "id": {
                 "type": "string",
@@ -272,9 +326,21 @@
                 "type": "string",
                 "description": "Template rendered after tool execution. Use $result to reference the tool output. Supports all template expressions."
               },
+              "retry": {
+                "type": "number",
+                "description": "Number of times to retry this step on failure (overrides recipe-level on_error.retry)"
+              },
+              "retryDelay": {
+                "type": "number",
+                "description": "Milliseconds to wait between retries (default 1000)"
+              },
               "recipe": {
                 "type": "string",
                 "description": "Nested recipe name or path"
+              },
+              "chain": {
+                "type": "string",
+                "description": "Alias for nested recipe name or path"
               },
               "vars": {
                 "type": "object",
@@ -286,6 +352,220 @@
               "output": {
                 "type": "string",
                 "description": "Output key for the nested recipe result"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": ["parallel"],
+            "properties": {
+              "id": {
+                "type": "string",
+                "description": "Optional group id — used as awaits target by later steps"
+              },
+              "awaits": {
+                "type": "array",
+                "description": "Step IDs that must complete before this group starts",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "parallel": {
+                "type": "array",
+                "description": "Run these steps concurrently. All must finish before later steps that await this group.",
+                "items": {
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "required": ["agent"],
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "description": "Unique chained step identifier used for outputs and dependencies"
+                        },
+                        "awaits": {
+                          "type": "array",
+                          "description": "Step IDs that must complete before this step runs",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "when": {
+                          "type": "string",
+                          "description": "Template condition that controls whether this step runs"
+                        },
+                        "optional": {
+                          "type": "boolean",
+                          "description": "Whether step failure should be tolerated"
+                        },
+                        "risk": {
+                          "type": "string",
+                          "enum": ["low", "medium", "high"],
+                          "description": "Risk level for this step"
+                        },
+                        "transform": {
+                          "type": "string",
+                          "description": "Template rendered after tool execution. Use $result to reference the tool output. Supports all template expressions."
+                        },
+                        "retry": {
+                          "type": "number",
+                          "description": "Number of times to retry this step on failure (overrides recipe-level on_error.retry)"
+                        },
+                        "retryDelay": {
+                          "type": "number",
+                          "description": "Milliseconds to wait between retries (default 1000)"
+                        },
+                        "agent": {
+                          "type": "object",
+                          "required": ["prompt"],
+                          "description": "Agent step configuration",
+                          "properties": {
+                            "prompt": {
+                              "type": "string"
+                            },
+                            "model": {
+                              "type": "string"
+                            },
+                            "driver": {
+                              "type": "string",
+                              "enum": [
+                                "claude",
+                                "claude-code",
+                                "api",
+                                "openai",
+                                "grok",
+                                "gemini",
+                                "anthropic"
+                              ]
+                            },
+                            "into": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "required": ["tool"],
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "description": "Unique chained step identifier used for outputs and dependencies"
+                        },
+                        "awaits": {
+                          "type": "array",
+                          "description": "Step IDs that must complete before this step runs",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "when": {
+                          "type": "string",
+                          "description": "Template condition that controls whether this step runs"
+                        },
+                        "optional": {
+                          "type": "boolean",
+                          "description": "Whether step failure should be tolerated"
+                        },
+                        "risk": {
+                          "type": "string",
+                          "enum": ["low", "medium", "high"],
+                          "description": "Risk level for this step"
+                        },
+                        "transform": {
+                          "type": "string",
+                          "description": "Template rendered after tool execution. Use $result to reference the tool output. Supports all template expressions."
+                        },
+                        "retry": {
+                          "type": "number",
+                          "description": "Number of times to retry this step on failure (overrides recipe-level on_error.retry)"
+                        },
+                        "retryDelay": {
+                          "type": "number",
+                          "description": "Milliseconds to wait between retries (default 1000)"
+                        },
+                        "tool": {
+                          "type": "string",
+                          "not": {
+                            "enum": []
+                          }
+                        },
+                        "into": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "anyOf": [
+                        {
+                          "required": ["recipe"]
+                        },
+                        {
+                          "required": ["chain"]
+                        }
+                      ],
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "description": "Unique chained step identifier used for outputs and dependencies"
+                        },
+                        "awaits": {
+                          "type": "array",
+                          "description": "Step IDs that must complete before this step runs",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "when": {
+                          "type": "string",
+                          "description": "Template condition that controls whether this step runs"
+                        },
+                        "optional": {
+                          "type": "boolean",
+                          "description": "Whether step failure should be tolerated"
+                        },
+                        "risk": {
+                          "type": "string",
+                          "enum": ["low", "medium", "high"],
+                          "description": "Risk level for this step"
+                        },
+                        "transform": {
+                          "type": "string",
+                          "description": "Template rendered after tool execution. Use $result to reference the tool output. Supports all template expressions."
+                        },
+                        "retry": {
+                          "type": "number",
+                          "description": "Number of times to retry this step on failure (overrides recipe-level on_error.retry)"
+                        },
+                        "retryDelay": {
+                          "type": "number",
+                          "description": "Milliseconds to wait between retries (default 1000)"
+                        },
+                        "recipe": {
+                          "type": "string",
+                          "description": "Nested recipe name or path"
+                        },
+                        "chain": {
+                          "type": "string",
+                          "description": "Alias for nested recipe name or path"
+                        },
+                        "vars": {
+                          "type": "object",
+                          "description": "Template variables passed into a nested recipe step",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "output": {
+                          "type": "string",
+                          "description": "Output key for the nested recipe result"
+                        }
+                      }
+                    }
+                  ]
+                }
               }
             }
           }
@@ -336,17 +616,22 @@
       "properties": {
         "retry": {
           "type": "number",
-          "description": "Number of retries",
+          "description": "Number of retries per failing step (overridden by step.retry)",
           "default": 0
+        },
+        "retryDelay": {
+          "type": "number",
+          "description": "Milliseconds between retries (overridden by step.retryDelay)",
+          "default": 1000
         },
         "fallback": {
           "type": "string",
           "enum": ["log_only", "abort", "deliver_original"],
-          "description": "Fallback action on error"
+          "description": "log_only / deliver_original: treat step failure as non-fatal (like optional); fail-open. abort (default): propagate failure."
         },
         "notify": {
           "type": "boolean",
-          "description": "Whether to notify on error",
+          "description": "Reserved. yamlRunner currently posts Slack notifications on any step failure when slack is connected; gating on this flag is not yet wired.",
           "default": true
         }
       }

--- a/dashboard/src/app/recipes/new/page.tsx
+++ b/dashboard/src/app/recipes/new/page.tsx
@@ -103,6 +103,19 @@ function validateForm(form: FormState): ValidationState {
       errors.vars[i] = "Variable name is required.";
       continue;
     }
+    if (!VAR_NAME_RE.test(name)) {
+      // Mirror the runtime template-reference regex
+      // (src/recipes/validation.ts: extractTemplateDottedPaths). Names that
+      // can't match `{{...}}` will silently never resolve at runtime —
+      // reject them at save time instead.
+      errors.vars[i] =
+        "Variable name must start with a letter or underscore, then letters, digits, or underscores only.";
+      continue;
+    }
+    if (RESERVED_VAR_NAMES.has(name)) {
+      errors.vars[i] = `'${name}' is a reserved built-in context key.`;
+      continue;
+    }
     const existingIndex = firstVarIndexByName.get(name);
     if (existingIndex !== undefined) {
       errors.vars[i] = "Variable name must be unique.";
@@ -114,6 +127,43 @@ function validateForm(form: FormState): ValidationState {
 
   return errors;
 }
+
+// Mirrors the runtime template-reference regex root group in
+// src/recipes/validation.ts:extractTemplateDottedPaths. Var names that
+// don't match this can never resolve as `{{name}}` at runtime — silently
+// rendering as empty string. Reject at save time.
+const VAR_NAME_RE = /^[A-Za-z_][A-Za-z0-9_]{0,63}$/;
+
+// Built-in context keys reserved by the runtime — declaring a var with
+// any of these names would shadow trigger-emitted data silently. The
+// list is the simple-identifier subset from registerRecipeContextKeys
+// + extractTemplateExpressions builtinKeys (src/recipes/validation.ts).
+const RESERVED_VAR_NAMES = new Set([
+  "date",
+  "time",
+  "YYYY",
+  "ISO_NOW",
+  "HH",
+  "MM",
+  "SS",
+  "this",
+  "hash",
+  "message",
+  "branch",
+  "payload",
+  "webhook_payload",
+  "hook_path",
+  "webhook_path",
+  "file",
+  "file_ext",
+  "file_basename",
+  "runner",
+  "failed",
+  "passed",
+  "total",
+  "failures",
+  "event",
+]);
 
 function hasValidationErrors(errors: ValidationState): boolean {
   return Boolean(
@@ -130,8 +180,18 @@ const RECIPE_API_VERSION = "patchwork.sh/v1";
 const SIMPLE_YAML_VALUE_RE = /^[A-Za-z0-9_./:@%+-]+$/;
 const AMBIGUOUS_YAML_VALUE_RE = /^(true|false|null|~|-?\d+(\.\d+)?)$/i;
 
+/**
+ * Slugify a free-form name into the canonical kebab-case shape that the
+ * server, schema, and filesystem all agree on (`^[a-z0-9][a-z0-9-]{0,63}$`).
+ * Lowercase, fold whitespace and underscores to dashes, strip leading/
+ * trailing dashes. Empty input → empty (caller treats as missing).
+ */
 function normalizeRecipeName(name: string): string {
-  return name.trim().toLowerCase().replace(/\s+/g, "-");
+  return name
+    .trim()
+    .toLowerCase()
+    .replace(/[\s_]+/g, "-")
+    .replace(/^-+|-+$/g, "");
 }
 
 function yamlScalar(value: string): string {
@@ -232,7 +292,13 @@ function buildRecipeYaml(form: FormState, safeName: string): string {
   return lines.join("\n");
 }
 
-const NAME_RE = /^[a-z0-9][a-z0-9_\- ]{0,63}$/i;
+// Loose form-side check that mirrors the canonical server regex AFTER
+// `normalizeRecipeName` runs. We accept uppercase/spaces/underscores in
+// the input so users can type naturally; the slug shown in the YAML
+// preview and used for the file path is the normalized form. The error
+// only fires when normalization can't produce a valid slug at all
+// (empty, leading dash, too long, or non-letter/digit chars left over).
+const NAME_RE = /^[a-z0-9][a-z0-9-]{0,63}$/;
 
 export default function NewRecipePage() {
   return (
@@ -294,9 +360,14 @@ function NewRecipePageInner() {
 
   const setName = useCallback((v: string) => {
     setForm((f) => ({ ...f, name: v }));
-    if (v && !NAME_RE.test(v)) {
+    // Validate the *slug* (after normalization), not the raw input.
+    // Users may type "My Recipe" and that's fine — the form will save
+    // it as `my-recipe.yaml`. Only reject if the normalized result
+    // can't satisfy the canonical kebab-case rule.
+    const slug = normalizeRecipeName(v);
+    if (v.trim() && !NAME_RE.test(slug)) {
       setNameError(
-        "Name must start with a letter or digit and contain only letters, digits, spaces, hyphens, or underscores (max 64 chars).",
+        "Name must produce a slug starting with a letter or digit and containing only letters, digits, or hyphens (max 64 chars).",
       );
     } else {
       setNameError(null);

--- a/schemas/recipe.v1.json
+++ b/schemas/recipe.v1.json
@@ -11,8 +11,8 @@
   "properties": {
     "name": {
       "type": "string",
-      "description": "Recipe name (kebab-case recommended)",
-      "pattern": "^[a-z0-9-]+$"
+      "description": "Recipe name (kebab-case, 1-64 chars). Scoped names like @scope/name are accepted for registry recipes.",
+      "pattern": "^(@[a-z0-9-]+/)?[a-z0-9][a-z0-9-]{0,63}$"
     },
     "description": {
       "type": "string",
@@ -100,6 +100,37 @@
           "type": "string",
           "enum": ["event"],
           "description": "Original trigger type preserved during legacy normalization"
+        },
+        "vars": {
+          "type": "array",
+          "description": "Caller-supplied variables. Referenced in step prompts as {{NAME}}.",
+          "items": {
+            "type": "object",
+            "required": ["name"],
+            "properties": {
+              "name": {
+                "type": "string",
+                "pattern": "^[A-Za-z_][A-Za-z0-9_]{0,63}$",
+                "description": "Variable identifier — letters, digits, underscores only. Must start with a letter or underscore."
+              },
+              "description": {
+                "type": "string"
+              },
+              "required": {
+                "type": "boolean"
+              },
+              "default": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "inputs": {
+          "type": "array",
+          "description": "Alias of `vars` accepted by the runtime. Same shape, same semantics.",
+          "items": {
+            "$ref": "#/properties/trigger/properties/vars/items"
+          }
         }
       }
     },

--- a/src/__tests__/recipeName-validation.test.ts
+++ b/src/__tests__/recipeName-validation.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Tests for recipe-name validation + body↔filename auto-rewrite in
+ * `saveRecipeContent`. The audit (2026-05-06) found `MyRecipe` saved
+ * to `myrecipe.yaml` with body `name: MyRecipe` — silent body↔filename
+ * mismatch. This test exercises the new behavior:
+ *  - server regex tightened to drop `_`
+ *  - body `name:` auto-rewritten to match filename when they differ
+ *  - warning surfaced on the rewrite
+ */
+
+import { mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { saveRecipeContent } from "../recipesHttp.js";
+
+const VALID_BODY = (name = "test-recipe") =>
+  `apiVersion: patchwork.sh/v1
+name: ${name}
+description: test
+trigger:
+  type: manual
+steps:
+  - id: s1
+    agent:
+      prompt: hi
+`;
+
+let dir = "";
+
+beforeEach(() => {
+  dir = mkdtempSync(path.join(tmpdir(), "recipe-name-test-"));
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("saveRecipeContent — name regex", () => {
+  it("rejects names with underscores (newly tightened to match the schema)", () => {
+    const result = saveRecipeContent(dir, "my_recipe", VALID_BODY("my_recipe"));
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/Invalid recipe name/);
+  });
+
+  it("rejects uppercase even after caller-side toLowerCase", () => {
+    // saveRecipeContent already lowercases — but a caller passing the
+    // already-cased value should still pass. The actual upper-case
+    // rejection happens earlier (URL routing) in the server.
+    const result = saveRecipeContent(dir, "MyRecipe", VALID_BODY("MyRecipe"));
+    expect(result.ok).toBe(true); // lowercased to "myrecipe"
+  });
+
+  it("rejects names with spaces", () => {
+    const result = saveRecipeContent(dir, "my recipe", VALID_BODY("my recipe"));
+    expect(result.ok).toBe(false);
+  });
+
+  it("rejects names that are too long (>64 chars)", () => {
+    const long = "a".repeat(65);
+    const result = saveRecipeContent(dir, long, VALID_BODY(long));
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/Invalid recipe name/);
+  });
+
+  it("accepts canonical kebab-case", () => {
+    const result = saveRecipeContent(
+      dir,
+      "my-good-recipe",
+      VALID_BODY("my-good-recipe"),
+    );
+    expect(result.ok).toBe(true);
+  });
+});
+
+describe("saveRecipeContent — body↔filename auto-rewrite", () => {
+  it("rewrites body name to match filename when they differ", () => {
+    // Caller PUTs to /recipes/foo with a body whose `name:` is `bar`.
+    // The filename wins; body is rewritten and a warning is returned.
+    const result = saveRecipeContent(dir, "foo", VALID_BODY("bar"));
+    expect(result.ok).toBe(true);
+    expect(result.path).toBeDefined();
+    const written = readFileSync(result.path as string, "utf-8");
+    expect(written).toMatch(/^name: foo$/m);
+    expect(written).not.toMatch(/^name: bar$/m);
+    expect((result as { warnings?: string[] }).warnings ?? []).toContainEqual(
+      expect.stringMatching(/rewritten to "foo"/),
+    );
+  });
+
+  it("does NOT rewrite when body name already matches", () => {
+    const result = saveRecipeContent(
+      dir,
+      "exact-match",
+      VALID_BODY("exact-match"),
+    );
+    expect(result.ok).toBe(true);
+    const written = readFileSync(result.path as string, "utf-8");
+    expect(written).toMatch(/^name: exact-match$/m);
+    // No body-rewrite warning
+    const warnings = (result as { warnings?: string[] }).warnings ?? [];
+    expect(warnings.some((w) => w.includes("rewritten"))).toBe(false);
+  });
+
+  it("rewrites body name when caller PUT URL was uppercase", () => {
+    // Server lowercases the URL name, so MyRecipe → myrecipe; body keeps
+    // `name: MyRecipe`. Auto-rewrite catches the divergence.
+    const result = saveRecipeContent(dir, "MyRecipe", VALID_BODY("MyRecipe"));
+    expect(result.ok).toBe(true);
+    const written = readFileSync(result.path as string, "utf-8");
+    expect(written).toMatch(/^name: myrecipe$/m);
+    expect((result as { warnings?: string[] }).warnings ?? []).toContainEqual(
+      expect.stringMatching(/rewritten to "myrecipe"/),
+    );
+  });
+
+  it("preserves a multiline description after rewriting name", () => {
+    // Make sure `^name:\s*.+$/m` only touches the name line, not other
+    // lines that happen to start with whitespace + the same prefix.
+    const body = `apiVersion: patchwork.sh/v1
+name: wrong-name
+description: |
+  This recipe also has
+  a name field that should NOT be touched.
+trigger:
+  type: manual
+steps:
+  - id: s1
+    agent:
+      prompt: hi
+`;
+    const result = saveRecipeContent(dir, "right-name", body);
+    expect(result.ok).toBe(true);
+    const written = readFileSync(result.path as string, "utf-8");
+    expect(written).toMatch(/^name: right-name$/m);
+    expect(written).toContain("a name field that should NOT be touched");
+  });
+});

--- a/src/__tests__/recipeName-validation.test.ts
+++ b/src/__tests__/recipeName-validation.test.ts
@@ -8,7 +8,7 @@
  *  - warning surfaced on the rewrite
  */
 
-import { mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";

--- a/src/recipes/__tests__/varNameValidation.test.ts
+++ b/src/recipes/__tests__/varNameValidation.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Tests for `trigger.vars` / `trigger.inputs` name validation in
+ * `validateRecipeDefinition`. The audit (2026-05-06) found `MY VAR`,
+ * `123start`, and `my.var` all saved HTTP 200, then silently never
+ * resolved as `{{...}}` at runtime because the template-reference
+ * regex needs a valid identifier.
+ */
+
+import { describe, expect, it } from "vitest";
+import { validateRecipeDefinition } from "../validation.js";
+
+const baseRecipe = {
+  name: "var-test",
+  description: "test recipe",
+  trigger: { type: "manual" as const },
+  steps: [{ id: "s1", agent: { prompt: "hi" } }],
+};
+
+function validateWithVar(name: string) {
+  return validateRecipeDefinition({
+    ...baseRecipe,
+    trigger: { type: "manual", vars: [{ name }] },
+  });
+}
+
+describe("trigger.vars[].name validation", () => {
+  it.each([
+    "MY VAR",
+    "my.var",
+    "123start",
+    "with-hyphen",
+    "spaces in name",
+    "trailing ",
+    " leading",
+    "$result",
+    "weird@char",
+  ])("rejects invalid name: %s", (name) => {
+    const result = validateWithVar(name);
+    const errors = result.issues.filter((i) => i.level === "error");
+    expect(errors.some((e) => e.message.includes(`"${name}"`))).toBe(true);
+  });
+
+  it.each([
+    "SENTRY_ISSUE_ID",
+    "LINEAR_TEAM_KEY",
+    "output_path",
+    "team",
+    "_internal",
+    "x",
+    "X",
+  ])("accepts valid name: %s", (name) => {
+    const result = validateWithVar(name);
+    const errors = result.issues.filter(
+      (i) => i.level === "error" && i.message.includes("trigger.vars"),
+    );
+    expect(errors).toEqual([]);
+  });
+
+  it("rejects empty name", () => {
+    const result = validateWithVar("");
+    const errors = result.issues.filter((i) => i.level === "error");
+    expect(errors.some((e) => e.message.includes("required"))).toBe(true);
+  });
+
+  it.each([
+    "payload",
+    "file",
+    "hash",
+    "date",
+    "this",
+    "branch",
+    "webhook_payload",
+  ])("rejects reserved built-in name: %s", (name) => {
+    const result = validateWithVar(name);
+    const errors = result.issues.filter((i) => i.level === "error");
+    expect(
+      errors.some((e) => e.message.includes("shadows a reserved built-in")),
+    ).toBe(true);
+  });
+
+  it("validates trigger.inputs the same way as trigger.vars", () => {
+    const result = validateRecipeDefinition({
+      ...baseRecipe,
+      trigger: { type: "webhook", inputs: [{ name: "MY BAD" }] },
+    });
+    const errors = result.issues.filter((i) => i.level === "error");
+    expect(
+      errors.some((e) => e.message.includes("trigger.inputs[0].name")),
+    ).toBe(true);
+  });
+
+  it("valid recipes from production survey lint clean", () => {
+    // Mirrors the var-name conventions in ~/.patchwork/recipes/.
+    const validVarShapes = [
+      // SCREAMING_SNAKE (sentry-to-linear)
+      ["SENTRY_ISSUE_ID", "LINEAR_TEAM_KEY", "LINEAR_PRIORITY"],
+      // lowercase_snake (most others)
+      ["message_id", "team", "channel", "draft", "input_glob", "output_path"],
+    ];
+    for (const names of validVarShapes) {
+      const result = validateRecipeDefinition({
+        ...baseRecipe,
+        trigger: {
+          type: "manual",
+          vars: names.map((n) => ({ name: n, required: true })),
+        },
+      });
+      const varErrors = result.issues.filter(
+        (i) =>
+          i.level === "error" &&
+          (i.message.includes("trigger.vars") || i.message.includes("shadows")),
+      );
+      expect(varErrors).toEqual([]);
+    }
+  });
+
+  it("multi-entry list reports each invalid entry by index", () => {
+    const result = validateRecipeDefinition({
+      ...baseRecipe,
+      trigger: {
+        type: "manual",
+        vars: [
+          { name: "VALID_ONE" },
+          { name: "MY BAD" },
+          { name: "VALID_TWO" },
+          { name: "payload" }, // reserved
+        ],
+      },
+    });
+    const errors = result.issues.filter((i) => i.level === "error");
+    // index 1 is invalid shape
+    expect(
+      errors.some((e) => e.message.match(/trigger\.vars\[1\].*MY BAD/)),
+    ).toBe(true);
+    // index 3 is reserved
+    expect(
+      errors.some((e) =>
+        e.message.match(/trigger\.vars\[3\].*payload.*shadows/),
+      ),
+    ).toBe(true);
+    // valid entries (0 and 2) should NOT generate errors
+    expect(
+      errors.filter((e) => e.message.match(/trigger\.vars\[(0|2)\]/)),
+    ).toEqual([]);
+  });
+});

--- a/src/recipes/names.ts
+++ b/src/recipes/names.ts
@@ -1,0 +1,68 @@
+/**
+ * Canonical name + variable-name rules for recipes.
+ *
+ * Single source of truth used by:
+ *   - `src/recipesHttp.ts`        — file-system + HTTP route validation
+ *   - `src/recipes/validation.ts` — `validateRecipeDefinition` lint
+ *   - `dashboard/src/app/recipes/new/page.tsx` — form-side mirroring
+ *     (the dashboard package re-declares them, kept in sync by hand)
+ *   - `schemas/recipe.v1.json`    — IDE-time JSON-Schema validation
+ *
+ * Lives in its own module to avoid the circular import that arises if
+ * the constants live in `recipesHttp.ts` (which imports
+ * `validateRecipeDefinition` from `validation.ts`, which would then
+ * import the constants back).
+ */
+
+/**
+ * Canonical recipe-name regex. kebab-case, 1–64 chars, must start with
+ * a letter or digit. Survey of all 22 production recipes in
+ * `~/.patchwork/recipes/` confirmed none use underscore filenames; this
+ * matches the JSON Schema `pattern` and the previous strict server
+ * regex (which disagreed with the schema by also allowing `_`).
+ */
+export const RECIPE_NAME_RE = /^[a-z0-9][a-z0-9-]{0,63}$/;
+
+/**
+ * Canonical variable-name regex (for `trigger.vars[].name` and
+ * `trigger.inputs[].name`). Mirrors the runtime template-reference
+ * regex root group in `validation.ts:extractTemplateDottedPaths`,
+ * minus `-` (hyphens in var names parse oddly in template expressions).
+ * Permits both SCREAMING_SNAKE and lowercase_snake conventions seen in
+ * production recipes.
+ */
+export const RECIPE_VAR_NAME_RE = /^[A-Za-z_][A-Za-z0-9_]{0,63}$/;
+
+/**
+ * Built-in context keys reserved by the runtime. Declaring a `vars` or
+ * `inputs` entry with any of these names would shadow trigger-emitted
+ * data silently. The simple-identifier subset of
+ * `registerRecipeContextKeys` + `extractTemplateExpressions builtinKeys`
+ * (see `src/recipes/validation.ts`).
+ */
+export const RESERVED_VAR_NAMES: ReadonlySet<string> = new Set([
+  "date",
+  "time",
+  "YYYY",
+  "ISO_NOW",
+  "HH",
+  "MM",
+  "SS",
+  "this",
+  "hash",
+  "message",
+  "branch",
+  "payload",
+  "webhook_payload",
+  "hook_path",
+  "webhook_path",
+  "file",
+  "file_ext",
+  "file_basename",
+  "runner",
+  "failed",
+  "passed",
+  "total",
+  "failures",
+  "event",
+]);

--- a/src/recipes/validation.ts
+++ b/src/recipes/validation.ts
@@ -5,6 +5,7 @@ import {
   defaultDeprecationWarn,
   normalizeRecipeForRuntime,
 } from "./legacyRecipeCompat.js";
+import { RECIPE_VAR_NAME_RE, RESERVED_VAR_NAMES } from "./names.js";
 import { generateSchemaSet } from "./schemaGenerator.js";
 import { listToolOutputContextKeys } from "./toolRegistry.js";
 
@@ -99,6 +100,9 @@ export function validateRecipeDefinition(recipe: unknown): LintResult {
           });
         }
       }
+
+      validateTriggerVarsList(trigger.vars, "vars", issues);
+      validateTriggerVarsList(trigger.inputs, "inputs", issues);
     }
 
     if (!Array.isArray(r.steps) || r.steps.length === 0) {
@@ -148,6 +152,52 @@ export function validateRecipeDefinition(recipe: unknown): LintResult {
     warnings,
     errors,
   };
+}
+
+/**
+ * Validate `trigger.vars` / `trigger.inputs` array entries. Catches names
+ * the runtime template engine can't resolve as `{{var}}` (e.g. spaces,
+ * dots, leading digits) and shadowing of built-in context keys
+ * (`payload`, `file`, `hash`, `date`, etc.). Both classes save HTTP 200
+ * silently today and only blow up at run time.
+ */
+function validateTriggerVarsList(
+  list: unknown,
+  fieldName: "vars" | "inputs",
+  issues: LintIssue[],
+): void {
+  if (!Array.isArray(list)) return;
+  for (let i = 0; i < list.length; i++) {
+    const entry = list[i];
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+      issues.push({
+        level: "error",
+        message: `trigger.${fieldName}[${i}] must be an object with at least a 'name' field`,
+      });
+      continue;
+    }
+    const name = (entry as Record<string, unknown>).name;
+    if (typeof name !== "string" || name.length === 0) {
+      issues.push({
+        level: "error",
+        message: `trigger.${fieldName}[${i}].name is required and must be a non-empty string`,
+      });
+      continue;
+    }
+    if (!RECIPE_VAR_NAME_RE.test(name)) {
+      issues.push({
+        level: "error",
+        message: `trigger.${fieldName}[${i}].name "${name}" is invalid — must start with a letter or underscore, then letters, digits, or underscores only (max 64 chars). Names not matching this can never resolve as {{${name}}} at runtime.`,
+      });
+      continue;
+    }
+    if (RESERVED_VAR_NAMES.has(name)) {
+      issues.push({
+        level: "error",
+        message: `trigger.${fieldName}[${i}].name "${name}" shadows a reserved built-in context key — pick a different name`,
+      });
+    }
+  }
 }
 
 function normalizeRecipeForValidation(recipe: unknown): unknown {

--- a/src/recipesHttp.ts
+++ b/src/recipesHttp.ts
@@ -16,6 +16,7 @@ import {
   type PatchworkConfig,
   saveConfig as savePatchworkConfig,
 } from "./patchworkConfig.js";
+import { RECIPE_NAME_RE } from "./recipes/names.js";
 import { validateRecipeDefinition } from "./recipes/validation.js";
 
 /**
@@ -346,7 +347,7 @@ export function saveRecipe(
   draft: RecipeDraft,
 ): { ok: boolean; path?: string; error?: string } {
   const safeName = draft.name.toLowerCase().replace(/\s+/g, "-");
-  if (!/^[a-z0-9][a-z0-9_-]{0,63}$/.test(safeName)) {
+  if (!RECIPE_NAME_RE.test(safeName)) {
     return { ok: false, error: "Invalid recipe name" };
   }
   const candidate = path.resolve(recipesDir, `${safeName}.json`);
@@ -459,7 +460,7 @@ export function loadRecipeContent(
   name: string,
 ): RecipeContentResult | null {
   const safeName = name.toLowerCase();
-  if (!/^[a-z0-9][a-z0-9_-]{0,63}$/.test(safeName)) return null;
+  if (!RECIPE_NAME_RE.test(safeName)) return null;
 
   const yamlPath = findYamlRecipePath(recipesDir, safeName);
   if (yamlPath) {
@@ -494,7 +495,7 @@ export function saveRecipeContent(
   content: string,
 ): { ok: boolean; path?: string; error?: string } {
   const safeName = name.toLowerCase();
-  if (!/^[a-z0-9][a-z0-9_-]{0,63}$/.test(safeName)) {
+  if (!RECIPE_NAME_RE.test(safeName)) {
     return { ok: false, error: "Invalid recipe name" };
   }
   if (!content.trim()) {
@@ -526,6 +527,28 @@ export function saveRecipeContent(
     };
   }
 
+  // If the parsed body's `name:` field disagrees with the filename
+  // (e.g. caller PUT to /recipes/myrecipe with a body whose `name:` is
+  // `MyRecipe`), rewrite it to match. The filename is the source of
+  // truth for routing, dashboard list keys, and webhook resolution;
+  // body drift just causes silent confusion. Same `^name:\s*.+$/m`
+  // pattern that `duplicateRecipe` and `promoteRecipeVariant` already
+  // use to rewrite `name:` lines.
+  let normalizedContent = content;
+  if (
+    parsed &&
+    typeof parsed === "object" &&
+    !Array.isArray(parsed) &&
+    typeof (parsed as Record<string, unknown>).name === "string" &&
+    (parsed as Record<string, unknown>).name !== safeName
+  ) {
+    const oldName = (parsed as Record<string, unknown>).name as string;
+    normalizedContent = content.replace(/^name:\s*.+$/m, `name: ${safeName}`);
+    warnings.push(
+      `Recipe body name "${oldName}" was rewritten to "${safeName}" to match the filename.`,
+    );
+  }
+
   try {
     mkdirSync(recipesDir, { recursive: true });
     const base = path.resolve(recipesDir);
@@ -537,7 +560,9 @@ export function saveRecipeContent(
     }
     writeFileSync(
       candidate,
-      content.endsWith("\n") ? content : `${content}\n`,
+      normalizedContent.endsWith("\n")
+        ? normalizedContent
+        : `${normalizedContent}\n`,
       "utf-8",
     );
     return {
@@ -562,7 +587,7 @@ export function deleteRecipeContent(
   name: string,
 ): { ok: boolean; path?: string; error?: string } {
   const safeName = name.toLowerCase();
-  if (!/^[a-z0-9][a-z0-9_-]{0,63}$/.test(safeName)) {
+  if (!RECIPE_NAME_RE.test(safeName)) {
     return { ok: false, error: "Invalid recipe name" };
   }
   const base = path.resolve(recipesDir);
@@ -613,7 +638,7 @@ export function duplicateRecipe(
   error?: string;
 } {
   const safeName = sourceName.toLowerCase();
-  if (!/^[a-z0-9][a-z0-9_-]{0,63}$/.test(safeName)) {
+  if (!RECIPE_NAME_RE.test(safeName)) {
     return { ok: false, error: "Invalid recipe name" };
   }
   const source = loadRecipeContent(recipesDir, safeName);
@@ -692,8 +717,7 @@ export async function promoteRecipeVariant(
 }> {
   const safeVariant = variantName.toLowerCase();
   const safeTarget = targetName.toLowerCase();
-  const nameRe = /^[a-z0-9][a-z0-9_-]{0,63}$/;
-  if (!nameRe.test(safeVariant) || !nameRe.test(safeTarget)) {
+  if (!RECIPE_NAME_RE.test(safeVariant) || !RECIPE_NAME_RE.test(safeTarget)) {
     return { ok: false, error: "Invalid recipe name" };
   }
   if (safeVariant === safeTarget) {
@@ -1122,7 +1146,7 @@ export function findYamlRecipePath(
   name: string,
 ): string | null {
   const safeName = name.toLowerCase();
-  if (!/^[a-z0-9][a-z0-9_-]{0,63}$/.test(safeName)) return null;
+  if (!RECIPE_NAME_RE.test(safeName)) return null;
 
   const base = path.resolve(recipesDir);
   const matches = new Set<string>();
@@ -1263,7 +1287,7 @@ export function loadRecipePrompt(
   name: string,
 ): { prompt: string; path: string } | null {
   const safeName = name.toLowerCase();
-  if (!/^[a-z0-9][a-z0-9_-]{0,63}$/.test(safeName)) return null;
+  if (!RECIPE_NAME_RE.test(safeName)) return null;
 
   const recipePath = resolveJsonRecipePathByName(recipesDir, safeName);
   if (!recipePath) {


### PR DESCRIPTION
## Summary
Two related validation drift bugs from the 2026-05-06 cross-agent audit. Cohesive enough to ship together (shared regex constants + same validator code path).

## Bug 1 — \`trigger.vars[].name\` was unvalidated everywhere
Audit found \`MY VAR\`, \`123start\`, \`my.var\` all saved HTTP 200, then silently never resolved as \`{{...}}\` at runtime. None of the form / server / schema gates checked the var-name shape; the runtime template engine (\`extractTemplateDottedPaths\` at [src/recipes/validation.ts](src/recipes/validation.ts)) requires a valid identifier.

**Fix**: canonical \`RECIPE_VAR_NAME_RE = /^[A-Za-z_][A-Za-z0-9_]{0,63}$/\`. Mirrors the runtime root-group regex minus \`-\`. Permits both SCREAMING_SNAKE and lowercase_snake conventions seen in production recipes. Plus a \`RESERVED_VAR_NAMES\` set (24 keys) that catches collisions with built-in context keys (\`payload\`, \`file\`, \`hash\`, \`date\`, \`this\`, etc.).

Validated at three layers:
- Form ([dashboard/src/app/recipes/new/page.tsx](dashboard/src/app/recipes/new/page.tsx)) — inline error in \`validateForm\` before submit.
- Server ([src/recipes/validation.ts](src/recipes/validation.ts)) — new \`validateTriggerVarsList\` called for both \`trigger.vars\` and \`trigger.inputs\`, error-level issues block save.
- Schema ([schemas/recipe.v1.json](schemas/recipe.v1.json)) — added \`trigger.vars\` and \`trigger.inputs\` array schemas with the var-name pattern, so IDE-time JSON-Schema validators agree with the bridge.

## Bug 2 — Three recipe-name regexes disagreed
- Form: \`/^[a-z0-9][a-z0-9_\\- ]{0,63}$/i\` (allowed uppercase + spaces)
- Server (8 inline copies): \`/^[a-z0-9][a-z0-9_-]{0,63}$/\` (allowed \`_\`)
- Schema: \`/^[a-z0-9-]+$/\` (rejected \`_\`)

\`MyRecipe\` form-passed → server lowercased to \`myrecipe.yaml\` → body kept \`name: MyRecipe\`. Silent body↔filename mismatch.

**Fix**: canonical \`RECIPE_NAME_RE = /^[a-z0-9][a-z0-9-]{0,63}$/\`. Single source of truth in new \`src/recipes/names.ts\`. Schema updated to \`^(@[a-z0-9-]+/)?[a-z0-9][a-z0-9-]{0,63}$\` (registry-scoped names like \`@patchworkos/morning-brief\` pass).

Server \`saveRecipeContent\` now **auto-rewrites the body's \`name:\` line** when it disagrees with the filename, surfacing a warning. Filename remains the source of truth (matches \`duplicateRecipe\` and \`promoteRecipeVariant\` behavior). The form's \`setName\` validates the *slug* (after normalization), so users can still type "My Recipe" naturally.

## Why one PR, not two
- Both bugs share the validator code path (\`validateRecipeDefinition\`).
- Both end up in \`src/recipes/names.ts\` (extracted to break the circular import that would arise if constants lived in \`recipesHttp.ts\`).
- Test fixtures benefit from being landed together (the \`saveRecipeContent\` test exercises both gates).

## Migration
**None for user recipes.** Survey of 22 production recipes in \`~/.patchwork/recipes/\` confirmed:
- All filenames are kebab-case (no underscores) — server tightening is a no-op.
- All body \`name:\` fields match their filename — auto-rewrite never fires on existing recipes.
- All var names are SCREAMING_SNAKE or lowercase_snake — all pass the new regex.

Registry recipes with \`@scope/name\` shape pass via the schema's scoped-name allowlist.

## Test plan
- [x] new \`src/recipes/__tests__/varNameValidation.test.ts\` — 27 cases (invalid shapes, valid shapes, empty, reserved built-ins, inputs parity, multi-entry indexing)
- [x] new \`src/__tests__/recipeName-validation.test.ts\` — 9 cases (underscore reject, length cap, body↔filename auto-rewrite, multi-line description preservation)
- [x] All **2247** existing tests pass
- [x] \`tsc --noEmit\` clean (bridge + dashboard)
- [x] \`biome check\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)