### PR TITLE
fix(dashboard): add scope banner to /recipes/new

### DIFF
--- a/dashboard/src/app/recipes/new/page.tsx
+++ b/dashboard/src/app/recipes/new/page.tsx
@@ -783,6 +783,36 @@ function NewRecipePageInner() {
         </div>
       </div>
 
+      {/*
+        Scope banner — the structured form covers the common case (agent
+        steps with manual/webhook/cron triggers). The schema also supports
+        `tool:` steps, `recipe:`/`chain:` nested recipes, `parallel:` groups,
+        and `file_watch`/`git_hook`/`on_file_save`/`on_test_run`/`chained`
+        triggers. None of those have UI here yet — production recipes that
+        use them (morning-brief, branch-health, etc.) are authored in the
+        YAML editor directly. This banner tells the user that's the path
+        rather than letting them assume the form is exhaustive.
+      */}
+      <div
+        role="note"
+        style={{
+          background: "var(--bg-2)",
+          border: "1px solid var(--border-subtle)",
+          borderRadius: "var(--r-2)",
+          color: "var(--fg-2)",
+          fontSize: "var(--fs-s)",
+          marginBottom: "var(--s-4)",
+          padding: "var(--s-3) var(--s-4)",
+        }}
+      >
+        <strong style={{ color: "var(--fg-1)" }}>Form scope:</strong> agent
+        steps with manual, webhook, or schedule triggers. For advanced shapes
+        — <code>tool:</code> steps, <code>parallel:</code> groups, nested
+        recipes, or file-watch / git-hook / test-run triggers — save a stub
+        here and continue in the YAML editor, or use{" "}
+        <strong>Generate with AI</strong> below.
+      </div>
+
       <div
         style={{
           border: "1px solid var(--border-default)",


### PR DESCRIPTION
## Summary
Closes the last open item from the 2026-05-06 recipe-creation audit. The structured form at \`/dashboard/recipes/new\` covers the common case — \`agent:\` steps with manual/webhook/schedule triggers — but the schema/runtime also support \`tool:\` steps, \`recipe:\`/\`chain:\` nested recipes, \`parallel:\` groups, and 5 more trigger types (\`file_watch\`, \`git_hook\`, \`on_file_save\`, \`on_test_run\`, \`chained\`). None of those have form UI.

All 4 production recipes (\`morning-brief.yaml\`, \`inbox-triage.yaml\`, \`branch-health.yaml\`, \`daily-status.yaml\`) use shapes the form can't represent — they're authored in the YAML editor directly. Without a banner, users opening this form assume it's the canonical authoring surface and find their way to the YAML editor only by accident.

## Why a banner, not expanded UI
Audit's two options:
- (a) Narrow the form's promise with a banner — shippable in an hour.
- (b) Expand the form (step-type radio for \`agent | tool | recipe\`, tool-id autocomplete, parallel-group editor, more trigger types). Multi-PR, needs design pass.

This PR is (a). (b) can land as a separate effort if you want.

## Banner copy
> **Form scope:** agent steps with manual, webhook, or schedule triggers. For advanced shapes — \`tool:\` steps, \`parallel:\` groups, nested recipes, or file-watch / git-hook / test-run triggers — save a stub here and continue in the YAML editor, or use **Generate with AI** below.

Renders as a low-emphasis info note (\`role="note"\`) above the Generate-with-AI disclosure. Same visual weight as the existing demo notice. Inline \`<code>\` for the YAML keys. Verified visually via Playwright at default + narrow viewport.

## Test plan
- [x] \`tsc --noEmit\` clean (bridge + dashboard)
- [x] Visual verify in demo mode at full viewport — banner renders cleanly above the Generate-with-AI disclosure
- [x] No existing tests reference the scope language; no test changes needed

## Audit closure
This is the final PR from the 2026-05-06 audit. Five themes total:
1. ✓ AI generator system prompt teaches no real tool integrations — #269
2. ✓ \`applyAiYaml\` hand-rolled parser data loss — #259
3. ✓ Form coverage gap — name regex parity in #268, **scope banner here**
4. ✓ Save-flow validation drift (cron, var-name, warnings) — #259 + #268
5. ✓ \`/recipes/generate\` hardening (rate limit, output cap, abuse filter, injection wrap) — #267

Out-of-audit: CSRF check at bridge handler level remains open as a separate concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)