### PR TITLE
fix(recipes): preserve tool: steps in AI-generated recipe YAML

### DIFF
--- a/dashboard/src/app/recipes/new/page.tsx
+++ b/dashboard/src/app/recipes/new/page.tsx
@@ -344,6 +344,7 @@ function NewRecipePageInner() {
   const [aiOpen, setAiOpen] = useState(false);
   const [aiPrompt, setAiPrompt] = useState("");
   const [aiLoading, setAiLoading] = useState(false);
+  const [aiSaving, setAiSaving] = useState(false);
   const [aiResult, setAiResult] = useState<{
     yaml?: string;
     warnings?: string[];
@@ -574,131 +575,102 @@ function NewRecipePageInner() {
     }
   }
 
-  function applyAiYaml(yamlText: string) {
-    // Parse the AI-generated YAML into the form's structured shape using a
-    // real parser. The previous hand-rolled line-scan dropped vars,
-    // rewrote step `into:` keys, and matched the first indented `at:`/`path:`
-    // anywhere — pulling step-level fields into `trigger`. On parse failure
-    // we leave the form alone so the user can copy YAML manually.
-    type RawStep = {
-      id?: unknown;
-      agent?: { prompt?: unknown; into?: unknown } | unknown;
-      prompt?: unknown;
-    };
-    type RawTrigger = {
-      type?: unknown;
-      at?: unknown;
-      path?: unknown;
-      vars?: unknown;
-      inputs?: unknown;
-    };
-    type RawRecipe = {
-      name?: unknown;
-      description?: unknown;
-      trigger?: RawTrigger | unknown;
-      vars?: unknown;
-      steps?: unknown;
-    };
-
-    let recipe: RawRecipe;
+  async function applyAiYaml(yamlText: string) {
+    // Save the AI-generated YAML verbatim and open it in the YAML editor.
+    // The previous flow funneled it through `applyAiYaml` → form state →
+    // `buildRecipeYaml`, but the form models only `agent:` steps — any
+    // `tool:` step the generator emitted (gmail.fetch_unread, github.list_*,
+    // file.write, etc.) was silently rewritten to an empty agent step.
+    // The structured form wizard is for hand-authoring; AI output goes
+    // straight to the raw YAML editor where the bridge's lint warnings
+    // surface and the user can review the full content unmodified.
+    let parsed: unknown;
     try {
-      recipe = (parseYaml(yamlText) ?? {}) as RawRecipe;
-      if (typeof recipe !== "object") return;
+      parsed = parseYaml(yamlText) ?? {};
     } catch {
+      setAiResult((cur) =>
+        cur ? { ...cur, error: "Generated YAML is not valid YAML." } : cur,
+      );
+      return;
+    }
+    let recipeName = "";
+    if (parsed && typeof parsed === "object") {
+      const rawName = (parsed as { name?: unknown }).name;
+      if (typeof rawName === "string") {
+        recipeName = normalizeRecipeName(rawName);
+      }
+    }
+    if (!recipeName || !NAME_RE.test(recipeName)) {
+      setAiResult((cur) =>
+        cur
+          ? {
+              ...cur,
+              error:
+                "Generated recipe is missing a valid name — regenerate or copy the YAML and create the recipe by hand.",
+            }
+          : cur,
+      );
       return;
     }
 
-    const asString = (v: unknown): string =>
-      typeof v === "string" ? v : "";
-    const asBool = (v: unknown): boolean =>
-      typeof v === "boolean" ? v : v === "true";
-
-    const trigger: RawTrigger =
-      recipe.trigger && typeof recipe.trigger === "object"
-        ? (recipe.trigger as RawTrigger)
-        : {};
-
-    const rawType = asString(trigger.type);
-    const normalizedType: "manual" | "webhook" | "schedule" =
-      rawType === "cron" || rawType === "schedule"
-        ? "schedule"
-        : rawType === "webhook"
-          ? "webhook"
-          : "manual";
-
-    const parsedCron = asString(trigger.at);
-    const parsedPath = asString(trigger.path).replace(/^\/hooks\//, "");
-
-    // vars may live under trigger.vars (canonical) or trigger.inputs
-    // (alias the validator also accepts). The AI sometimes emits top-level
-    // `vars:` despite the system prompt — accept that too as a fallback so
-    // the user doesn't lose declarations on "Use this".
-    const rawVars =
-      (Array.isArray(trigger.vars) && trigger.vars) ||
-      (Array.isArray(trigger.inputs) && trigger.inputs) ||
-      (Array.isArray(recipe.vars) && recipe.vars) ||
-      [];
-    const parsedVars: RecipeVar[] = (rawVars as unknown[])
-      .filter((v): v is Record<string, unknown> =>
-        Boolean(v) && typeof v === "object",
-      )
-      .map((v) => ({
-        name: asString(v.name),
-        description: asString(v.description),
-        required: asBool(v.required),
-        default: asString(v.default),
-      }))
-      .filter((v) => v.name);
-
-    const rawSteps = Array.isArray(recipe.steps) ? recipe.steps : [];
-    const parsedSteps: Step[] = rawSteps
-      .filter((s): s is RawStep =>
-        Boolean(s) && typeof s === "object",
-      )
-      .map((s, i) => {
-        // Step shapes we accept:
-        //   - id: foo            ← schema-canonical
-        //     agent:
-        //       prompt: ...
-        //       into: foo_output
-        //   - agent: { prompt: ..., into: ... }   ← id is optional in schema
-        //   - prompt: ...                           ← shorthand
-        const agentBlock =
-          s.agent && typeof s.agent === "object"
-            ? (s.agent as { prompt?: unknown; into?: unknown })
-            : null;
-        const prompt = agentBlock
-          ? asString(agentBlock.prompt)
-          : asString(s.prompt);
-        const into = agentBlock ? asString(agentBlock.into) : "";
-        const step: Step = {
-          id: asString(s.id) || makeStepId(i),
-          agent: true,
-          prompt: prompt.trim(),
-        };
-        if (into) step.into = into;
-        return step;
-      });
-
-    setForm((f) => ({
-      ...f,
-      name: asString(recipe.name) || f.name,
-      description: asString(recipe.description) || f.description,
-      trigger: {
-        type: normalizedType,
-        cron: parsedCron,
-        path: parsedPath,
-      },
-      vars: parsedVars.length > 0 ? parsedVars : f.vars,
-      steps: parsedSteps.length > 0 ? parsedSteps : f.steps,
-    }));
-    setValidation((cur) => ({
-      ...cur,
-      steps: parsedSteps.length > 0 ? parsedSteps.map(() => null) : cur.steps,
-      vars: parsedVars.length > 0 ? parsedVars.map(() => null) : cur.vars,
-    }));
-    setAiOpen(false);
-    setAiResult(null);
+    setAiSaving(true);
+    try {
+      const res = await fetch(
+        apiPath(`/api/bridge/recipes/${encodeURIComponent(recipeName)}`),
+        {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ content: yamlText }),
+        },
+      );
+      const data = (await res.json()) as {
+        ok?: boolean;
+        error?: string;
+        demo?: boolean;
+        warnings?: string[];
+      };
+      if (!res.ok || data.ok === false) {
+        setAiResult((cur) =>
+          cur ? { ...cur, error: data.error ?? "Failed to save recipe." } : cur,
+        );
+        return;
+      }
+      if (data.demo) {
+        // Demo mode persists nothing, so /edit would 404. Surface in place.
+        setAiResult((cur) =>
+          cur
+            ? {
+                ...cur,
+                error:
+                  "Demo mode — recipe was not persisted. Disable demo mode to save real recipes.",
+              }
+            : cur,
+        );
+        return;
+      }
+      if (data.warnings && data.warnings.length > 0) {
+        try {
+          sessionStorage.setItem(
+            `recipe-save-warnings:${recipeName}`,
+            JSON.stringify(data.warnings),
+          );
+        } catch {
+          // sessionStorage unavailable — non-fatal; edit page re-lints.
+        }
+      }
+      router.push(`/recipes/${encodeURIComponent(recipeName)}/edit`);
+    } catch (err) {
+      setAiResult((cur) =>
+        cur
+          ? {
+              ...cur,
+              error: err instanceof Error ? err.message : String(err),
+            }
+          : cur,
+      );
+    } finally {
+      setAiSaving(false);
+    }
   }
 
   async function handleSubmit(e: React.FormEvent) {
@@ -954,18 +926,20 @@ function NewRecipePageInner() {
                   <button
                     type="button"
                     onClick={() => applyAiYaml(aiResult.yaml!)}
+                    disabled={aiSaving}
                     style={{
                       background: "var(--accent)",
                       border: "none",
                       borderRadius: "var(--r-2)",
                       color: "var(--on-accent)",
-                      cursor: "pointer",
+                      cursor: aiSaving ? "not-allowed" : "pointer",
                       fontSize: "var(--fs-m)",
                       fontWeight: 500,
+                      opacity: aiSaving ? 0.6 : 1,
                       padding: "var(--s-2) var(--s-4)",
                     }}
                   >
-                    Use this
+                    {aiSaving ? "Saving…" : "Save and edit"}
                   </button>
                   <button
                     type="button"
@@ -973,13 +947,15 @@ function NewRecipePageInner() {
                       setAiResult(null);
                       setAiOpen(false);
                     }}
+                    disabled={aiSaving}
                     style={{
                       background: "var(--bg-2)",
                       border: "1px solid var(--border-default)",
                       borderRadius: "var(--r-2)",
                       color: "var(--fg-1)",
-                      cursor: "pointer",
+                      cursor: aiSaving ? "not-allowed" : "pointer",
                       fontSize: "var(--fs-m)",
+                      opacity: aiSaving ? 0.6 : 1,
                       padding: "var(--s-2) var(--s-4)",
                     }}
                   >


### PR DESCRIPTION
## Summary

The dashboard's **Generate with AI** panel for recipes had a lossy handoff: `applyAiYaml` parsed the generator's output into a `Step` model that only knows about `agent:` steps, then `buildRecipeYaml` reserialized every step as `agent: { prompt, into }`. After [#269](https://github.com/Oolab-labs/patchwork-os/pull/269) taught the system prompt to emit concrete `tool:` steps (e.g. `tool: gmail.fetch_unread`), this round-trip silently destroyed the tool ID and all its parameters. Clicking **Use this** on a perfectly valid generated recipe could yield an empty agent step.

This change routes the AI-generated YAML directly to the existing `PUT /api/bridge/recipes/:name` endpoint and redirects to `/recipes/:name/edit` (CodeMirror), bypassing the form's structured shape entirely.

- **Why direct save**: the bridge already lints + hoists `vars` server-side, and the edit page is built around full raw YAML. The structured form wizard is for hand-authoring, not for representing the AI's output.
- **Behavior**: the **Use this** button is renamed **Save and edit**, shows a saving state, and surfaces save failures inline (including demo-mode and missing-name cases).
- **Out of scope**: the placeholder example still mentions GitHub notifications + email, capabilities the registry can't fulfill — separate follow-up. Test extraction for `applyAiYaml`/`buildRecipeYaml` is also a separate follow-up since both are component-private and not currently exported.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm test` in `dashboard/` — 241 passed (no regressions)
- [x] Page loads at `/dashboard/recipes/new` with no console errors; **Generate with AI** panel toggles open
- [ ] Manual: with `--claude-driver subprocess` enabled, generate a recipe whose YAML contains `tool:` steps, click **Save and edit**, confirm the edit page opens with the **full** YAML intact (tool IDs and params present)
- [ ] Manual: regenerate without a name in the YAML and confirm the inline error fires instead of saving
- [ ] Manual: verify lint warnings on save are still forwarded to the edit page via `sessionStorage`

🤖 Generated with [Claude Code](https://claude.com/claude-code)