### PR TITLE
fix(recipes): replace overpromising AI-generator example with one using real tools

### DIFF
--- a/dashboard/src/app/recipes/new/page.tsx
+++ b/dashboard/src/app/recipes/new/page.tsx
@@ -881,7 +881,7 @@ function NewRecipePageInner() {
             </p>
             <textarea
               rows={3}
-              placeholder="e.g. every morning, summarize my GitHub notifications and email me a digest"
+              placeholder="e.g. every weekday at 9am, summarize my unread Gmail and post the digest to Slack"
               value={aiPrompt}
               onChange={(e) => setAiPrompt(e.target.value)}
               disabled={aiLoading}

--- a/src/__tests__/recipeGenerationPrompt.test.ts
+++ b/src/__tests__/recipeGenerationPrompt.test.ts
@@ -84,6 +84,28 @@ describe("RECIPE_GENERATION_SYSTEM_PROMPT", () => {
     const unregistered = ids.filter((id) => !hasTool(id));
     expect(unregistered).toEqual([]);
   });
+
+  it("worked examples reference only registered tool IDs", () => {
+    // Audit (2026-05-06) follow-up: the original example #1 promised
+    // GitHub-notification fetching and email delivery via agent: prose,
+    // implying tools that don't exist in the registry. Going forward,
+    // every `- tool: <id>` line in the EXAMPLES block must resolve to a
+    // registered tool, so the worked examples can't drift back into
+    // making promises the runtime can't keep.
+    const examplesStart = RECIPE_GENERATION_SYSTEM_PROMPT.indexOf("EXAMPLES:");
+    expect(examplesStart).toBeGreaterThan(0);
+    const examples = RECIPE_GENERATION_SYSTEM_PROMPT.slice(examplesStart);
+    const ids = [
+      ...examples.matchAll(
+        /^\s*-\s*tool:\s*([a-z][a-z0-9_]*\.[a-z][a-z0-9_]*)/gim,
+      ),
+    ].map((m) => m[1] as string);
+    // Examples must use at least one tool: step (otherwise we've regressed
+    // to the agent-only bias that motivated the audit fix).
+    expect(ids.length).toBeGreaterThan(0);
+    const unregistered = ids.filter((id) => !hasTool(id));
+    expect(unregistered).toEqual([]);
+  });
 });
 
 describe("collectUnknownToolIds", () => {

--- a/src/recipeOrchestration.ts
+++ b/src/recipeOrchestration.ts
@@ -711,32 +711,41 @@ RULES:
    and stop.
 
 EXAMPLES:
-User: every morning, summarize my GitHub notifications and email me a digest
+User: every weekday at 9am, summarize my unread Gmail and post the digest to Slack
 \`\`\`yaml
 apiVersion: patchwork.sh/v1
-name: morning-github-digest
-description: Daily summary of GitHub notifications delivered by email
+name: morning-email-digest
+description: Daily summary of unread email posted to a Slack channel
 trigger:
   type: cron
-  at: "0 8 * * 1-5"
+  at: "0 9 * * 1-5"
   vars:
-    - name: EMAIL
-      description: Email address to send the digest to
+    - name: SLACK_CHANNEL
+      description: Slack channel (or DM target) to post the digest to
       required: true
 steps:
-  - id: fetch-notifications
+  - tool: gmail.fetch_unread
+    since: 24h
+    max: 30
+    into: messages
+  - id: summarize
     agent:
       prompt: |
-        Fetch my unread GitHub notifications from the last 24 hours.
-        Summarize them grouped by repository: PR reviews, issues, mentions.
-        One line per item.
-      into: notifications_summary
-  - id: send-digest
-    agent:
-      prompt: |
-        Send an email to {{EMAIL}} with subject "Morning GitHub Digest".
-        Body: {{notifications_summary}}
-      into: send_result
+        Use ONLY the data provided below — do not call any tools or fetch additional information.
+
+        UNREAD EMAILS ({{messages.count}} total):
+        <untrusted_data>
+        {{messages.json}}
+        </untrusted_data>
+
+        Summarize the actionable items in 5–10 short bullets. Skip newsletters and automated notifications.
+      into: summary
+  - tool: slack.post_message
+    channel: "{{SLACK_CHANNEL}}"
+    text: |
+      *Morning email digest*
+
+      {{summary}}
 \`\`\`
 
 User: when a new Sentry issue arrives, create a Linear ticket and post to Slack


### PR DESCRIPTION
## Summary

The first worked example in `RECIPE_GENERATION_SYSTEM_PROMPT` and the matching dashboard placeholder both said *"every morning, summarize my GitHub notifications and email me a digest"* — but the recipe tool registry has neither a `github.list_notifications` tool nor any email-send tool. The example dodged this by routing both steps through `agent:` prose, which won't actually fetch notifications or deliver mail at runtime; the synthesized YAML implies capabilities the runtime can't honor.

This swaps the example for *"every weekday at 9am, summarize my unread Gmail and post the digest to Slack"*, which:

- Uses two registered tools (`gmail.fetch_unread` + `slack.post_message`) so the recipe is actually runnable end-to-end.
- Keeps the same morning-digest archetype the original was demonstrating.
- Models the safety conventions (`<untrusted_data>` wrapping, "use ONLY the data provided below" preamble) that the rules mandate.
- Updates the dashboard placeholder to advertise the same scenario.

A new test, `worked examples reference only registered tool IDs`, scans the `EXAMPLES:` block for every `- tool: <id>` directive and asserts each one resolves in the registry, so the prompt can't drift back into making promises the runtime can't keep.

## Test plan

- [x] `npx vitest run src/__tests__/recipeGenerationPrompt.test.ts` — 14/14 (incl. new test)
- [x] `npm test -- --run` — 4884/4884 passing
- [ ] Manual: open `/dashboard/recipes/new`, confirm placeholder reads "every weekday at 9am, summarize my unread Gmail and post the digest to Slack"
- [ ] Manual: with `--claude-driver subprocess` enabled, run the new example prompt and confirm the generator emits `tool: gmail.fetch_unread` and `tool: slack.post_message` (rather than agent prose)

## Related

- Audit follow-up to #269 / #271 — the prompt taught real tools but the headline example still framed them in the old agent-only style.
- Builds on #274 (in flight) which fixes the lossy "Use this" handoff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)