### PR TITLE
refactor(recipes): extract DISABLED_MARKER + helpers to disabledMarkers

### DIFF
--- a/src/commands/recipeInstall.ts
+++ b/src/commands/recipeInstall.ts
@@ -25,6 +25,10 @@ import https from "node:https";
 import os from "node:os";
 import path from "node:path";
 import {
+  disabledMarkerPath,
+  isInstallDirDisabled,
+} from "../recipes/disabledMarkers.js";
+import {
   getManifestRecipeFiles,
   loadManifestFromDir,
   parseManifest,
@@ -36,15 +40,6 @@ export const INSTALL_RECIPES_DIR = path.join(
   ".patchwork",
   "recipes",
 );
-
-/**
- * Marker file written into a recipe install dir to mark it as disabled.
- * Absence = enabled (the default for legacy installs predating this marker).
- * `runRecipeInstall` writes one on every fresh install so new recipes start
- * disabled per the wave2 plan's safety story; user runs `patchwork recipe
- * enable <name>` to remove it.
- */
-const DISABLED_MARKER = ".disabled";
 
 /**
  * Reject path components that aren't a single safe basename — used at every
@@ -497,9 +492,7 @@ export async function runRecipeInstall(
     // and snapshot the existing enabled state so the upgrade doesn't
     // silently re-disable a recipe the user explicitly opted into.
     const isReinstall = existsSync(installDir);
-    const wasEnabled = isReinstall
-      ? !existsSync(path.join(installDir, DISABLED_MARKER))
-      : false;
+    const wasEnabled = isReinstall ? !isInstallDirDisabled(installDir) : false;
 
     if (isReinstall) {
       // Clear stale files from the previous version so files dropped from
@@ -531,7 +524,7 @@ export async function runRecipeInstall(
     //     If the recipe was enabled before, leave it enabled; if disabled,
     //     leave it disabled. Don't silently revoke an explicit user opt-in.
     if (!isReinstall || !wasEnabled) {
-      writeFileSync(path.join(installDir, DISABLED_MARKER), "");
+      writeFileSync(disabledMarkerPath(installDir), "");
     }
 
     return {
@@ -614,7 +607,7 @@ export interface InstalledRecipeEntry {
  * therefore considered enabled — preserves backwards compatibility.
  */
 export function isRecipeEnabled(installDir: string): boolean {
-  return !existsSync(path.join(installDir, DISABLED_MARKER));
+  return !isInstallDirDisabled(installDir);
 }
 
 /**
@@ -719,7 +712,7 @@ export function runRecipeEnable(
       `No installed recipe named "${name}". Run \`patchwork recipe list\` to see installed recipes.`,
     );
   }
-  const markerPath = path.join(installDir, DISABLED_MARKER);
+  const markerPath = disabledMarkerPath(installDir);
   if (!existsSync(markerPath)) {
     return { name, installDir, alreadyEnabled: true };
   }
@@ -742,7 +735,7 @@ export function runRecipeDisable(
       `No installed recipe named "${name}". Run \`patchwork recipe list\` to see installed recipes.`,
     );
   }
-  const markerPath = path.join(installDir, DISABLED_MARKER);
+  const markerPath = disabledMarkerPath(installDir);
   if (existsSync(markerPath)) {
     return { name, installDir, alreadyDisabled: true };
   }

--- a/src/recipes/disabledMarkers.ts
+++ b/src/recipes/disabledMarkers.ts
@@ -1,0 +1,60 @@
+/**
+ * disabledMarkers — single source of truth for "is this recipe disabled?"
+ *
+ * Two parallel disable mechanisms exist, and previously each lived in a
+ * different file with the constant + check duplicated:
+ *
+ *   1. Per-install-dir `.disabled` marker file. Written by `runRecipeInstall`
+ *      on every fresh install (so newly-installed recipes are inert until
+ *      explicitly enabled) and toggled by `setRecipeEnabled` for
+ *      install-dir recipes. The trigger-side enforcement (PRs #42/#43/#49)
+ *      reads this marker on every dispatch path.
+ *
+ *   2. Legacy `cfg.recipes.disabled[]` array in `~/.patchwork/config.json`.
+ *      Used by top-level recipe files (direct children of `recipesDir`,
+ *      no install dir to put a marker in). The scheduler honors it both at
+ *      start-time scan and as a TOCTOU re-check at fire time.
+ *
+ * Both surface here so the constant + readers can't drift between
+ * `recipesHttp.ts` and `scheduler.ts`. Issue #253 follow-up.
+ */
+
+import { existsSync } from "node:fs";
+import path from "node:path";
+
+import type { PatchworkConfig } from "../config.js";
+
+/**
+ * Filename of the per-install-dir disable marker. Lives in this module
+ * (not in `commands/recipeInstall.ts` where it's also written) to avoid
+ * a circular import via commands → recipesHttp → commands.
+ */
+export const DISABLED_MARKER = ".disabled";
+
+/**
+ * Returns true if the given install dir contains a `.disabled` marker
+ * file. Pass the *install dir*, not a recipe path inside it.
+ */
+export function isInstallDirDisabled(installDir: string): boolean {
+  return existsSync(path.join(installDir, DISABLED_MARKER));
+}
+
+/**
+ * Path to the marker file for a given install dir — caller-side use when
+ * writing or removing the marker (`setRecipeEnabled`).
+ */
+export function disabledMarkerPath(installDir: string): string {
+  return path.join(installDir, DISABLED_MARKER);
+}
+
+/**
+ * Extract the legacy disabled-name set from a parsed config. Returns an
+ * empty set when the config is missing the field. Centralized so the
+ * scheduler's start-time scan and fire-time TOCTOU re-check (and
+ * `setRecipeEnabled`'s legacy fallback) all read it the same way.
+ */
+export function getConfigDisabledNames(
+  cfg: PatchworkConfig | { recipes?: { disabled?: string[] } } | undefined,
+): Set<string> {
+  return new Set(cfg?.recipes?.disabled ?? []);
+}

--- a/src/recipes/disabledMarkers.ts
+++ b/src/recipes/disabledMarkers.ts
@@ -22,7 +22,7 @@
 import { existsSync } from "node:fs";
 import path from "node:path";
 
-import type { PatchworkConfig } from "../config.js";
+import type { PatchworkConfig } from "../patchworkConfig.js";
 
 /**
  * Filename of the per-install-dir disable marker. Lives in this module

--- a/src/recipes/scheduler.ts
+++ b/src/recipes/scheduler.ts
@@ -5,13 +5,10 @@ import { parse as parseYaml } from "yaml";
 import type { Logger } from "../logger.js";
 import { loadConfig } from "../patchworkConfig.js";
 import { findYamlRecipePath, loadRecipePrompt } from "../recipesHttp.js";
-
-/**
- * Per-recipe disabled marker — must match the constant in
- * src/commands/recipeInstall.ts (kept inline here to avoid a circular
- * import via commands → recipes back to commands).
- */
-const DISABLED_MARKER = ".disabled";
+import {
+  getConfigDisabledNames,
+  isInstallDirDisabled,
+} from "./disabledMarkers.js";
 
 /**
  * RecipeScheduler — runs cron-triggered recipes on a simple interval or
@@ -69,10 +66,7 @@ export class RecipeScheduler {
     // Load disabled list from config
     let disabled: Set<string> = new Set();
     try {
-      const cfg = loadConfig();
-      if (cfg.recipes?.disabled) {
-        disabled = new Set(cfg.recipes.disabled);
-      }
+      disabled = getConfigDisabledNames(loadConfig());
     } catch {
       // non-fatal — proceed with empty disabled set
     }
@@ -106,7 +100,7 @@ export class RecipeScheduler {
 
       if (isDir) {
         // Honor the per-recipe `.disabled` marker written by recipeInstall.
-        if (existsSync(path.join(fullPath, DISABLED_MARKER))) {
+        if (isInstallDirDisabled(fullPath)) {
           this.opts.logger?.info?.(
             `[scheduler] skipping recipe in "${f}" — .disabled marker present`,
           );
@@ -292,9 +286,7 @@ export class RecipeScheduler {
     // case is handled inside findYamlRecipePath / loadRecipePrompt
     // (skip disabled install dirs) thanks to PR #49.
     try {
-      const cfg = loadConfig();
-      const disabled = new Set<string>(cfg.recipes?.disabled ?? []);
-      if (disabled.has(name)) {
+      if (getConfigDisabledNames(loadConfig()).has(name)) {
         this.opts.logger?.info?.(
           `[scheduler] skipping "${name}" — disabled via config (TOCTOU re-check)`,
         );

--- a/src/recipesHttp.ts
+++ b/src/recipesHttp.ts
@@ -16,18 +16,13 @@ import {
   type PatchworkConfig,
   saveConfig as savePatchworkConfig,
 } from "./patchworkConfig.js";
+import {
+  disabledMarkerPath,
+  getConfigDisabledNames,
+  isInstallDirDisabled,
+} from "./recipes/disabledMarkers.js";
 import { RECIPE_NAME_RE } from "./recipes/names.js";
 import { validateRecipeDefinition } from "./recipes/validation.js";
-
-/**
- * Per-recipe disabled marker — must match the constant in
- * `src/commands/recipeInstall.ts` and `src/recipes/scheduler.ts` (kept inline
- * here to avoid a circular import via commands → recipesHttp → commands).
- *
- * Absence on a recipe's install dir = enabled (legacy default).
- * Presence = disabled — `runRecipeInstall` writes one on every fresh install.
- */
-const DISABLED_MARKER = ".disabled";
 
 /**
  * Returns true unless `filePath` lives inside an install dir whose
@@ -48,7 +43,7 @@ export function isRecipeFileEnabled(
   const installDirName = rel.split(path.sep)[0];
   if (!installDirName) return true;
   const installDir = path.join(recipesDir, installDirName);
-  return !existsSync(path.join(installDir, DISABLED_MARKER));
+  return !isInstallDirDisabled(installDir);
 }
 
 /**
@@ -85,7 +80,7 @@ function* iterateInstallDirs(
       continue;
     }
     if (!isDir) continue;
-    const enabled = !existsSync(path.join(fullPath, DISABLED_MARKER));
+    const enabled = !isInstallDirDisabled(fullPath);
     if (!enabled && !includeDisabled) continue;
 
     let entrypoint: string | null = null;
@@ -175,7 +170,7 @@ export function setRecipeEnabled(
   try {
     const installDir = findInstallDirByRecipeName(recipesDir, name);
     if (installDir) {
-      const markerPath = path.join(installDir, DISABLED_MARKER);
+      const markerPath = disabledMarkerPath(installDir);
       if (enabled) {
         if (existsSync(markerPath)) rmSync(markerPath);
       } else {
@@ -186,8 +181,8 @@ export function setRecipeEnabled(
 
     // Legacy top-level path — fall back to config-file disabled list
     const cfg = (options.loadConfigFn ?? loadConfig)();
-    const disabled = new Set<string>(
-      (cfg as { recipes?: { disabled?: string[] } }).recipes?.disabled ?? [],
+    const disabled = getConfigDisabledNames(
+      cfg as { recipes?: { disabled?: string[] } },
     );
     if (enabled) disabled.delete(name);
     else disabled.add(name);


### PR DESCRIPTION
## Summary

Closes #253.

The constant \`DISABLED_MARKER = \".disabled\"\` was redeclared in three files (\`recipesHttp.ts\`, \`scheduler.ts\`, \`commands/recipeInstall.ts\`), each with a \"kept inline to avoid circular import\" comment, and the \`new Set(cfg.recipes?.disabled ?? [])\` extraction lived in three more places (\`setRecipeEnabled\`, \`scheduler.start\`, \`scheduler.fire\` TOCTOU re-check).

New \`src/recipes/disabledMarkers.ts\` exports:

- \`DISABLED_MARKER\` (the literal)
- \`isInstallDirDisabled(installDir): boolean\`
- \`disabledMarkerPath(installDir): string\`
- \`getConfigDisabledNames(cfg): Set<string>\`

Updated 12 call sites across the four files. Behavior unchanged.

## Why not the larger \"consolidation\" the issue body suggests

Per the [scoping comment](https://github.com/Oolab-labs/patchwork-os/issues/253#issuecomment-4391822312) on the issue: the four files (\`recipesHttp.ts\` 1388 LOC, \`recipeOrchestration.ts\` 1023 LOC, \`RecipeOrchestrator.ts\` 98 LOC, \`scheduler.ts\` 395 LOC) have orthogonal responsibilities. Merging would produce a ~2400-LOC megafile, strictly worse for testability. The two \"orchestrator\" classes (top-level \`RecipeOrchestration\` = wiring façade; \`src/recipes/RecipeOrchestrator\` = dedup gatekeeper) are sequential, not duplicates. The actually-useful work is the dedup this PR ships.

## Why the original circular-import worry no longer applies

The \"kept inline\" comments worried about \`commands/recipeInstall.ts\` → \`recipesHttp.ts\` → \`commands\`. The new \`disabledMarkers.ts\` only imports \`node:fs\` + \`node:path\` + a type from \`config.ts\`, so it sits below all three and can be imported from any of them.

## Test plan

- [x] \`npm test -- --run\` — 4883/4883 (same count as before; behavior unchanged)
- [x] \`npx biome check\` — clean (one pre-existing warning in \`scheduler.ts:365\` non-null assertion, unrelated to this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)