### PR TITLE
feat(recipes): wire bridge /recipes/install to bundle sources

### DIFF
--- a/src/__tests__/recipeRoutes-bundle-install.test.ts
+++ b/src/__tests__/recipeRoutes-bundle-install.test.ts
@@ -1,0 +1,250 @@
+/**
+ * /recipes/install — bundle-source dispatch tests (#130 PR A).
+ *
+ * Covers the new branch that recognizes
+ * `github:patchworkos/recipes/bundles/<name>` sources, fetches
+ * `patchwork-bundle.json`, and installs each declared recipe.
+ *
+ * Tests focus on failure paths + the advisory surface — the per-recipe
+ * install side effect (writing into `~/.patchwork/recipes/`) is already
+ * covered by `recipeRoutes-install.test.ts` for the canonical
+ * `github:patchworkos/recipes/recipes/<name>` path. The bundle handler
+ * reuses that same `installRecipeFromFile` helper, so happy-path
+ * coverage there transfers.
+ *
+ * Tests stub `globalThis.fetch` to fully control upstream responses;
+ * no real network IO. Pattern mirrors `recipeRoutes-install.test.ts`.
+ */
+
+import http from "node:http";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import { Logger } from "../logger.js";
+import { Server } from "../server.js";
+
+const logger = new Logger(false);
+const TOKEN = "test-bundle-install-token-0000000000000000";
+
+let server: Server | null = null;
+let port = 0;
+const originalFetch = globalThis.fetch;
+
+function makeRequest(
+  options: http.RequestOptions,
+  body = "",
+): Promise<{ status: number; body: string }> {
+  return new Promise((resolve, reject) => {
+    let resolved = false;
+    const finish = (status: number, data: string) => {
+      if (resolved) return;
+      resolved = true;
+      resolve({ status, body: data });
+    };
+    const req = http.request(
+      { hostname: "127.0.0.1", port, ...options },
+      (res) => {
+        let data = "";
+        res.on("data", (chunk: Buffer) => (data += chunk));
+        res.on("end", () => finish(res.statusCode ?? 0, data));
+        res.on("error", () => finish(res.statusCode ?? 0, data));
+        res.on("close", () => finish(res.statusCode ?? 0, data));
+      },
+    );
+    req.on("error", (err) => {
+      if (resolved) return;
+      reject(err);
+    });
+    if (body) req.write(body);
+    req.end();
+  });
+}
+
+beforeAll(() => {
+  // Don't let host-environment env var leak into tests (matches
+  // recipeRoutes-install.test.ts pattern — same Server instance).
+  delete process.env.CLAUDE_IDE_BRIDGE_INSTALL_ALLOWED_HOSTS;
+});
+
+beforeEach(async () => {
+  server = new Server(TOKEN, logger);
+  port = await server.findAndListen(null);
+});
+
+afterEach(async () => {
+  await server?.close();
+  server = null;
+  port = 0;
+  globalThis.fetch = originalFetch;
+});
+
+afterAll(() => {
+  globalThis.fetch = originalFetch;
+});
+
+const installPath = {
+  method: "POST" as const,
+  path: "/recipes/install",
+  headers: {
+    "Content-Type": "application/json",
+    Authorization: `Bearer ${TOKEN}`,
+  },
+};
+
+describe("Server /recipes/install — bundle dispatch (#130 PR A)", () => {
+  it("rejects bundle name with path traversal → 400 invalid_bundle_name", async () => {
+    const { status, body } = await makeRequest(
+      installPath,
+      JSON.stringify({
+        source: "github:patchworkos/recipes/bundles/../etc/passwd",
+      }),
+    );
+    expect(status).toBe(400);
+    const parsed = JSON.parse(body);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.code).toBe("invalid_bundle_name");
+  });
+
+  it("returns 404 when bundle manifest is not found upstream", async () => {
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(new Response("Not Found", { status: 404 }));
+    const { status, body } = await makeRequest(
+      installPath,
+      JSON.stringify({
+        source: "github:patchworkos/recipes/bundles/missing-bundle",
+      }),
+    );
+    expect(status).toBe(404);
+    const parsed = JSON.parse(body);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.code).toBe("bundle_fetch_upstream_error");
+    expect(parsed.upstreamStatus).toBe(404);
+  });
+
+  it("returns 502 when manifest body is not valid JSON", async () => {
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(new Response("not json at all", { status: 200 }));
+    const { status, body } = await makeRequest(
+      installPath,
+      JSON.stringify({
+        source: "github:patchworkos/recipes/bundles/broken",
+      }),
+    );
+    expect(status).toBe(502);
+    const parsed = JSON.parse(body);
+    expect(parsed.code).toBe("bundle_manifest_invalid_json");
+  });
+
+  it("returns 400 when manifest has no recipes field", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValueOnce(
+      new Response(JSON.stringify({ name: "x", description: "y" }), {
+        status: 200,
+      }),
+    );
+    const { status, body } = await makeRequest(
+      installPath,
+      JSON.stringify({
+        source: "github:patchworkos/recipes/bundles/no-recipes",
+      }),
+    );
+    expect(status).toBe(400);
+    const parsed = JSON.parse(body);
+    expect(parsed.code).toBe("bundle_manifest_invalid_recipes");
+  });
+
+  it("returns 400 when manifest recipes has unsafe entries", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          name: "x",
+          recipes: ["good-recipe", "../../../etc/passwd"],
+        }),
+        { status: 200 },
+      ),
+    );
+    const { status, body } = await makeRequest(
+      installPath,
+      JSON.stringify({
+        source: "github:patchworkos/recipes/bundles/sneaky",
+      }),
+    );
+    expect(status).toBe(400);
+    const parsed = JSON.parse(body);
+    expect(parsed.code).toBe("bundle_manifest_invalid_recipes");
+  });
+
+  it("returns 400 when manifest recipes is an empty array", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValueOnce(
+      new Response(JSON.stringify({ name: "x", recipes: [] }), {
+        status: 200,
+      }),
+    );
+    const { status, body } = await makeRequest(
+      installPath,
+      JSON.stringify({
+        source: "github:patchworkos/recipes/bundles/empty",
+      }),
+    );
+    expect(status).toBe(400);
+    const parsed = JSON.parse(body);
+    expect(parsed.code).toBe("bundle_manifest_invalid_recipes");
+  });
+
+  it("returns 502 + plugin advisory when all recipes fail upstream", async () => {
+    // First fetch = manifest (succeeds, declares 1 recipe + a plugin).
+    // Second fetch = recipe yaml (404). All recipes failed → 502.
+    // Advisory still surfaced so caller knows about the plugin.
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            name: "x",
+            recipes: ["only-recipe"],
+            plugin: "@example/plugin",
+          }),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(new Response("Not Found", { status: 404 }));
+    const { status, body } = await makeRequest(
+      installPath,
+      JSON.stringify({
+        source: "github:patchworkos/recipes/bundles/all-fail",
+      }),
+    );
+    expect(status).toBe(502);
+    const parsed = JSON.parse(body);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.kind).toBe("bundle");
+    expect(parsed.installed).toEqual([]);
+    expect(parsed.failures).toHaveLength(1);
+    expect(parsed.failures[0].name).toBe("only-recipe");
+    expect(parsed.advisory.plugin).toMatch(/@example\/plugin/);
+  });
+
+  it("returns 413 when manifest exceeds 64 KB", async () => {
+    const huge = "x".repeat(70_000);
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(huge, { status: 200 }));
+    const { status, body } = await makeRequest(
+      installPath,
+      JSON.stringify({
+        source: "github:patchworkos/recipes/bundles/huge",
+      }),
+    );
+    expect(status).toBe(413);
+    const parsed = JSON.parse(body);
+    expect(parsed.code).toBe("bundle_manifest_too_large");
+  });
+});

--- a/src/recipeRoutes.ts
+++ b/src/recipeRoutes.ts
@@ -1177,6 +1177,216 @@ export function tryHandleRecipeRoute(
           res.end(JSON.stringify({ ok: false, error: "Missing source field" }));
           return;
         }
+
+        // -----------------------------------------------------------------
+        // BUNDLE INSTALL DISPATCH (#130 PR A).
+        //
+        // `github:patchworkos/recipes/bundles/<name>` installs every recipe
+        // listed in the bundle's `patchwork-bundle.json`. Plugin (`plugin`)
+        // and policy template (`policy_template`) declared in the manifest
+        // are surfaced as advisory-only — wiring those needs separate
+        // decisions (npm-install surface, policy application UX) tracked
+        // outside this PR. See the #130 scoping comment.
+        // -----------------------------------------------------------------
+        const bundlePrefix = "github:patchworkos/recipes/bundles/";
+        if (source.startsWith(bundlePrefix)) {
+          const bundleName = source.slice(bundlePrefix.length);
+          const { isSafeBasename } = await import(
+            "./commands/recipeInstall.js"
+          );
+          if (!isSafeBasename(bundleName)) {
+            res.writeHead(400, { "Content-Type": "application/json" });
+            res.end(
+              JSON.stringify({
+                ok: false,
+                error: "Invalid bundle name in source",
+                code: "invalid_bundle_name",
+              }),
+            );
+            return;
+          }
+          const manifestUrl = `https://raw.githubusercontent.com/patchworkos/recipes/main/bundles/${bundleName}/patchwork-bundle.json`;
+
+          const ctl = new AbortController();
+          const timeout = setTimeout(() => ctl.abort(), 30_000);
+          let manifestRes: Response;
+          try {
+            manifestRes = await fetch(manifestUrl, {
+              signal: ctl.signal,
+              redirect: "follow",
+            });
+          } catch (err) {
+            clearTimeout(timeout);
+            res.writeHead(502, { "Content-Type": "application/json" });
+            res.end(
+              JSON.stringify({
+                ok: false,
+                error: `Bundle manifest fetch failed: ${err instanceof Error ? err.message : String(err)}`,
+                code: "bundle_fetch_network_error",
+              }),
+            );
+            return;
+          }
+          clearTimeout(timeout);
+          if (!manifestRes.ok) {
+            const outStatus = manifestRes.status === 404 ? 404 : 502;
+            res.writeHead(outStatus, { "Content-Type": "application/json" });
+            res.end(
+              JSON.stringify({
+                ok: false,
+                error: `Bundle manifest at ${manifestUrl} returned ${manifestRes.status}`,
+                code: "bundle_fetch_upstream_error",
+                upstreamStatus: manifestRes.status,
+              }),
+            );
+            return;
+          }
+          // 64 KB hard cap on manifest body — real `patchwork-bundle.json`
+          // is single-digit KB; anything past 64 KB is hostile or malformed.
+          const manifestBuf = await manifestRes.arrayBuffer();
+          if (manifestBuf.byteLength > 64 * 1024) {
+            res.writeHead(413, { "Content-Type": "application/json" });
+            res.end(
+              JSON.stringify({
+                ok: false,
+                error: "Bundle manifest exceeds 64 KB cap",
+                code: "bundle_manifest_too_large",
+              }),
+            );
+            return;
+          }
+          let manifest: {
+            name?: unknown;
+            recipes?: unknown;
+            plugin?: unknown;
+            policy_template?: unknown;
+          };
+          try {
+            manifest = JSON.parse(Buffer.from(manifestBuf).toString("utf-8"));
+          } catch (err) {
+            res.writeHead(502, { "Content-Type": "application/json" });
+            res.end(
+              JSON.stringify({
+                ok: false,
+                error: `Bundle manifest is not valid JSON: ${err instanceof Error ? err.message : String(err)}`,
+                code: "bundle_manifest_invalid_json",
+              }),
+            );
+            return;
+          }
+          if (
+            !Array.isArray(manifest.recipes) ||
+            manifest.recipes.length === 0 ||
+            !manifest.recipes.every(
+              (r) => typeof r === "string" && isSafeBasename(r),
+            )
+          ) {
+            res.writeHead(400, { "Content-Type": "application/json" });
+            res.end(
+              JSON.stringify({
+                ok: false,
+                error:
+                  "Bundle manifest must declare a non-empty `recipes` array of safe recipe names",
+                code: "bundle_manifest_invalid_recipes",
+              }),
+            );
+            return;
+          }
+
+          // Install each declared recipe. Errors are collected but don't
+          // abort the loop — partial bundle install is more useful than
+          // all-or-nothing when one of N recipes is broken.
+          const installed: Array<{
+            name: string;
+            action: "created" | "replaced";
+          }> = [];
+          const failures: Array<{ name: string; error: string }> = [];
+          const { writeFileSync, mkdirSync, unlinkSync } = await import(
+            "node:fs"
+          );
+          const { installRecipeFromFile } = await import(
+            "./recipes/installer.js"
+          );
+          const recipesDir = path.join(os.homedir(), ".patchwork", "recipes");
+          mkdirSync(recipesDir, { recursive: true });
+
+          for (const r of manifest.recipes as string[]) {
+            const recipeUrl = `https://raw.githubusercontent.com/patchworkos/recipes/main/recipes/${r}/${r}.yaml`;
+            const recipeCtl = new AbortController();
+            const recipeTimeout = setTimeout(() => recipeCtl.abort(), 30_000);
+            try {
+              const recipeRes = await fetch(recipeUrl, {
+                signal: recipeCtl.signal,
+                redirect: "follow",
+              });
+              clearTimeout(recipeTimeout);
+              if (!recipeRes.ok) {
+                failures.push({
+                  name: r,
+                  error: `Upstream returned ${recipeRes.status}`,
+                });
+                continue;
+              }
+              const recipeBuf = await recipeRes.arrayBuffer();
+              if (recipeBuf.byteLength > 1024 * 1024) {
+                failures.push({
+                  name: r,
+                  error: "Recipe body exceeded 1 MB cap",
+                });
+                continue;
+              }
+              const yamlText = Buffer.from(recipeBuf).toString("utf-8");
+              const tmpFile = path.join(
+                os.tmpdir(),
+                `patchwork-bundle-install-${Date.now()}-${r}.yaml`,
+              );
+              writeFileSync(tmpFile, yamlText, "utf-8");
+              try {
+                const installResult = installRecipeFromFile(tmpFile, {
+                  recipesDir,
+                });
+                installed.push({ name: r, action: installResult.action });
+              } finally {
+                try {
+                  unlinkSync(tmpFile);
+                } catch {
+                  // best-effort cleanup
+                }
+              }
+            } catch (err) {
+              clearTimeout(recipeTimeout);
+              failures.push({
+                name: r,
+                error: err instanceof Error ? err.message : String(err),
+              });
+            }
+          }
+
+          // Plugin / policy_template surfaced advisory-only.
+          const advisory: Record<string, string> = {};
+          if (typeof manifest.plugin === "string") {
+            advisory.plugin = `Bundle declares plugin "${manifest.plugin}" — not installed; run \`npm install -g ${manifest.plugin}\` separately.`;
+          }
+          if (typeof manifest.policy_template === "string") {
+            advisory.policy_template = `Bundle declares policy template "${manifest.policy_template}" — not applied; review and apply manually.`;
+          }
+          // 200 if any recipe installed; 502 otherwise. Always include both
+          // arrays so callers (CLI + dashboard) can render partial-success.
+          const status = installed.length > 0 ? 200 : 502;
+          res.writeHead(status, { "Content-Type": "application/json" });
+          res.end(
+            JSON.stringify({
+              ok: installed.length > 0,
+              kind: "bundle",
+              bundleName,
+              installed,
+              failures,
+              ...(Object.keys(advisory).length > 0 && { advisory }),
+            }),
+          );
+          return;
+        }
+
         const githubPrefix = "github:patchworkos/recipes/recipes/";
         let fetchUrl: string;
         let recipeName: string;


### PR DESCRIPTION
## Summary

Closes #130 partially (the bridge half). Adds a new dispatch branch in \`POST /recipes/install\` that recognizes \`github:patchworkos/recipes/bundles/<name>\` sources, fetches the bundle's \`patchwork-bundle.json\`, and installs each declared recipe via the existing per-recipe install path.

\`\`\`
github:patchworkos/recipes/bundles/morning  →  fetch bundles/morning/patchwork-bundle.json
                                            →  for each name in manifest.recipes[]:
                                                 fetch recipes/<name>/<name>.yaml
                                                 install via existing installRecipeFromFile
                                            →  return { ok, kind: \"bundle\", installed[], failures[], advisory? }
\`\`\`

## What's deliberately out of scope

The bundle manifest can declare a \`plugin\` (npm package) and a \`policy_template\` (a delegation-policy JSON fragment). **Neither is installed by this PR.** Both are surfaced as \`advisory.{plugin,policy_template}\` strings in the response so callers can render manual-action guidance — but actually wiring them needs separate decisions (npm-install surface; policy-application UX) tracked outside #130.

## Failure modes

| Scenario | Status | Code |
|---|---|---|
| Invalid bundle name (traversal etc.) | 400 | \`invalid_bundle_name\` |
| Bundle manifest 404 | 404 | \`bundle_fetch_upstream_error\` |
| Manifest network error | 502 | \`bundle_fetch_network_error\` |
| Manifest > 64 KB | 413 | \`bundle_manifest_too_large\` |
| Manifest invalid JSON | 502 | \`bundle_manifest_invalid_json\` |
| Missing/bad \`recipes\` array | 400 | \`bundle_manifest_invalid_recipes\` |
| One+ recipe fails upstream | 200 | with non-empty \`failures[]\` |
| All recipes fail | 502 | with \`failures[]\` only |

## Partial-success behavior

A bundle declaring 5 recipes where 1 has been pulled from the registry still installs the other 4. The response always returns both \`installed[]\` and \`failures[]\` so the caller can render which-installed/which-failed UI. \`ok: true\` if anything installed, \`ok: false\` if nothing did.

## Test plan

- [x] \`npx vitest run src/__tests__/recipeRoutes-bundle-install.test.ts\` — 8/8
- [x] \`npm test -- --run\` — 4891/4891 (8 new + 4883 existing)
- [x] \`npm run typecheck\` — clean
- [x] \`npx tsc -p tsconfig.tests.core.json\` (strict CI ratchet) — clean
- [ ] Manual: with a real \`patchwork-bundle.json\` published in \`patchworkos/recipes\`, run \`patchwork recipe install github:patchworkos/recipes/bundles/<name>\` end-to-end

## Follow-ups

- **#130 PR B**: dashboard install button on \`/marketplace/bundle/[...slug]\`. Will stack on this PR.
- **#279**: Skills CLI direction (npm packages vs bundle dispatch) — needs product decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)