### PR TITLE
feat(dashboard): one-click bundle install on /marketplace/bundle/[...slug]

### DIFF
--- a/dashboard/src/app/marketplace/bundle/[...slug]/BundleInstallPanel.tsx
+++ b/dashboard/src/app/marketplace/bundle/[...slug]/BundleInstallPanel.tsx
@@ -1,0 +1,315 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { apiPath } from "@/lib/api";
+
+interface Props {
+  /**
+   * Bundle install source as published in the registry — the full
+   * `github:patchworkos/recipes/bundles/<name>` shape the bridge's
+   * `/recipes/install` endpoint dispatches on. Same field the recipe
+   * `InstallPanel` accepts under `install`.
+   */
+  installSource: string;
+  /** Recipe names declared in `manifest.recipes[]`, used for the
+   * "X of Y installed" count. */
+  recipes: string[];
+  /** Optional advisory surface for `manifest.plugin`. */
+  plugin?: string;
+  /** Optional advisory surface for `manifest.policy_template`. */
+  policyTemplate?: string;
+}
+
+interface BridgeStatus {
+  online: boolean;
+  /** Count of bundle recipes already installed (matched by name). */
+  installedCount: number;
+}
+
+interface BundleInstallResponse {
+  ok: boolean;
+  kind?: "bundle";
+  bundleName?: string;
+  installed?: Array<{ name: string; action: "created" | "replaced" }>;
+  failures?: Array<{ name: string; error: string }>;
+  advisory?: {
+    plugin?: string;
+    policy_template?: string;
+  };
+  error?: string;
+  code?: string;
+}
+
+const POLL_TIMEOUT_MS = 1500;
+
+export default function BundleInstallPanel({
+  installSource,
+  recipes,
+  plugin,
+  policyTemplate,
+}: Props) {
+  const [status, setStatus] = useState<BridgeStatus | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+  const [result, setResult] = useState<BundleInstallResponse | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  const cliCmd = `patchwork recipe install ${installSource}`;
+
+  useEffect(() => {
+    let cancelled = false;
+    const ac = new AbortController();
+    const timer = setTimeout(() => ac.abort(), POLL_TIMEOUT_MS);
+
+    fetch(apiPath("/api/bridge/recipes"), { signal: ac.signal })
+      .then(async (r) => {
+        if (cancelled) return;
+        if (!r.ok) {
+          setStatus({ online: false, installedCount: 0 });
+          return;
+        }
+        const data = await r.json();
+        const list = Array.isArray(data)
+          ? data
+          : Array.isArray(data?.recipes)
+            ? data.recipes
+            : [];
+        const installedNames = new Set(
+          list.map((x: { name?: string }) => x.name).filter(Boolean),
+        );
+        const installedCount = recipes.filter((r) =>
+          installedNames.has(r),
+        ).length;
+        setStatus({ online: true, installedCount });
+      })
+      .catch(() => {
+        if (!cancelled) setStatus({ online: false, installedCount: 0 });
+      })
+      .finally(() => clearTimeout(timer));
+
+    return () => {
+      cancelled = true;
+      ac.abort();
+      clearTimeout(timer);
+    };
+  }, [recipes]);
+
+  async function handleInstall() {
+    setBusy(true);
+    setErr(null);
+    setResult(null);
+    try {
+      const res = await fetch(apiPath("/api/bridge/recipes/install"), {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ source: installSource }),
+      });
+      const body = (await res.json()) as BundleInstallResponse;
+      // Bridge returns 200 on partial success (any installed) and 5xx on
+      // full failure — both shapes carry `installed[]` + `failures[]`,
+      // so render the result either way and surface a top-level error
+      // banner only if there's no structured payload.
+      setResult(body);
+      if (!res.ok && (!body.installed || body.installed.length === 0)) {
+        setErr(body.error ?? `Install failed (HTTP ${res.status})`);
+      }
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function handleCopy() {
+    try {
+      await navigator.clipboard.writeText(cliCmd);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // clipboard unavailable
+    }
+  }
+
+  const allInstalled =
+    status?.installedCount === recipes.length && recipes.length > 0;
+  const partialInstalled =
+    status !== null &&
+    status.installedCount > 0 &&
+    status.installedCount < recipes.length;
+
+  return (
+    <div
+      className="glass-card"
+      style={{
+        padding: "var(--s-5)",
+        display: "flex",
+        flexDirection: "column",
+        gap: 12,
+      }}
+    >
+      <h3 style={{ fontSize: "var(--fs-m)", marginTop: 0, marginBottom: 0 }}>
+        Install
+      </h3>
+
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          gap: 12,
+          flexWrap: "wrap",
+        }}
+      >
+        <div style={{ fontSize: "var(--fs-m)", color: "var(--ink-1)" }}>
+          {allInstalled ? (
+            <>
+              <span style={{ color: "var(--ok)", marginRight: 6 }}>✓</span>
+              All {recipes.length} recipes installed locally — enable each
+              with <code>patchwork recipe enable &lt;name&gt;</code>.
+            </>
+          ) : partialInstalled ? (
+            <>
+              {status.installedCount} of {recipes.length} recipes already
+              installed. Install button will pull the missing{" "}
+              {recipes.length - status.installedCount}.
+            </>
+          ) : status?.online ? (
+            `Bridge connected — install all ${recipes.length} recipe${recipes.length === 1 ? "" : "s"} with one click.`
+          ) : status === null ? (
+            "Checking for local bridge…"
+          ) : (
+            "No local bridge detected. Install via CLI below."
+          )}
+        </div>
+
+        {!allInstalled && status?.online && (
+          <button
+            type="button"
+            className="btn sm"
+            onClick={handleInstall}
+            disabled={busy}
+          >
+            {busy ? "Installing…" : "Install bundle"}
+          </button>
+        )}
+      </div>
+
+      <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+        <code
+          style={{
+            flex: 1,
+            background: "var(--recess)",
+            padding: "10px 12px",
+            borderRadius: "var(--r-2)",
+            fontSize: "var(--fs-s)",
+            fontFamily: "var(--font-mono, ui-monospace, monospace)",
+            overflowX: "auto",
+            color: "var(--ink-1)",
+          }}
+        >
+          {cliCmd}
+        </code>
+        <button
+          type="button"
+          className="btn sm ghost"
+          onClick={handleCopy}
+          aria-label="Copy install command"
+          style={{ flexShrink: 0 }}
+        >
+          {copied ? "Copied!" : "Copy"}
+        </button>
+      </div>
+
+      {result && (result.installed || result.failures) && (
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            gap: 8,
+            paddingTop: 4,
+            borderTop: "1px solid var(--line-1)",
+          }}
+        >
+          {result.installed && result.installed.length > 0 && (
+            <div style={{ fontSize: "var(--fs-s)", color: "var(--ink-1)" }}>
+              <span style={{ color: "var(--ok)", marginRight: 6 }}>✓</span>
+              Installed {result.installed.length} recipe
+              {result.installed.length === 1 ? "" : "s"}:{" "}
+              <span style={{ fontFamily: "var(--font-mono)" }}>
+                {result.installed.map((r) => r.name).join(", ")}
+              </span>
+            </div>
+          )}
+          {result.failures && result.failures.length > 0 && (
+            <div style={{ fontSize: "var(--fs-s)", color: "var(--err)" }}>
+              <strong>{result.failures.length} failed:</strong>
+              <ul style={{ margin: "4px 0 0 16px", padding: 0 }}>
+                {result.failures.map((f) => (
+                  <li key={f.name}>
+                    <span style={{ fontFamily: "var(--font-mono)" }}>
+                      {f.name}
+                    </span>
+                    {" — "}
+                    {f.error}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Plugin / policy template advisory — surface even before install
+          so users know what additional manual steps are required.
+          Mirrors the bridge response's `advisory.{plugin,policy_template}`
+          fields when those are declared in the bundle manifest. */}
+      {(plugin || policyTemplate) && (
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            gap: 6,
+            fontSize: "var(--fs-s)",
+            color: "var(--fg-2)",
+            paddingTop: 4,
+            borderTop: "1px solid var(--line-1)",
+          }}
+        >
+          <div style={{ fontWeight: 500, color: "var(--ink-1)" }}>
+            Manual follow-up needed:
+          </div>
+          {plugin && (
+            <div>
+              Plugin{" "}
+              <code style={{ fontSize: "var(--fs-xs)" }}>{plugin}</code> is
+              not auto-installed. Run{" "}
+              <code style={{ fontSize: "var(--fs-xs)" }}>
+                npm install -g {plugin}
+              </code>{" "}
+              and restart the bridge with{" "}
+              <code style={{ fontSize: "var(--fs-xs)" }}>--plugin {plugin}</code>
+              .
+            </div>
+          )}
+          {policyTemplate && (
+            <div>
+              Policy template{" "}
+              <code style={{ fontSize: "var(--fs-xs)" }}>{policyTemplate}</code>{" "}
+              is not auto-applied. Review and apply manually.
+            </div>
+          )}
+        </div>
+      )}
+
+      {err && (
+        <div
+          className="alert-err"
+          role="alert"
+          style={{ fontSize: "var(--fs-s)" }}
+        >
+          {err}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/dashboard/src/app/marketplace/bundle/[...slug]/__tests__/BundleInstallPanel.test.tsx
+++ b/dashboard/src/app/marketplace/bundle/[...slug]/__tests__/BundleInstallPanel.test.tsx
@@ -1,0 +1,258 @@
+/**
+ * BundleInstallPanel — install-button + partial-success rendering tests
+ * (#130 PR B).
+ *
+ * Mocks `fetch` to control bridge responses; verifies:
+ *   - status polling renders the right copy depending on bridge state
+ *   - clicking "Install bundle" POSTs to /api/bridge/recipes/install
+ *     with the exact source from the registry
+ *   - partial-success response renders both installed[] and failures[]
+ *   - plugin / policy_template advisory props render manual-followup copy
+ *
+ * Pattern: vitest + RTL + jsdom, same setup as the rest of dashboard tests.
+ */
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  type Mock,
+  vi,
+} from "vitest";
+import BundleInstallPanel from "../BundleInstallPanel";
+
+let fetchMock: Mock;
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+beforeEach(() => {
+  fetchMock = vi.fn();
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+const SOURCE = "github:patchworkos/recipes/bundles/morning";
+const RECIPES = ["a-recipe", "b-recipe", "c-recipe"];
+
+describe("BundleInstallPanel — status polling", () => {
+  it("shows 'Bridge connected' copy when none of the bundle's recipes are installed", async () => {
+    // First (and only) call fetches /api/bridge/recipes; return empty.
+    fetchMock.mockResolvedValueOnce(jsonResponse(200, { recipes: [] }));
+    render(<BundleInstallPanel installSource={SOURCE} recipes={RECIPES} />);
+    await waitFor(() =>
+      expect(
+        screen.getByText(/Bridge connected — install all 3 recipes/i),
+      ).toBeInTheDocument(),
+    );
+    // Install button rendered when bridge is online + nothing installed.
+    expect(
+      screen.getByRole("button", { name: /Install bundle/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows partial-installed copy when some recipes already exist", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse(200, { recipes: [{ name: "a-recipe" }] }),
+    );
+    render(<BundleInstallPanel installSource={SOURCE} recipes={RECIPES} />);
+    await waitFor(() =>
+      expect(
+        screen.getByText(/1 of 3 recipes already installed/i),
+      ).toBeInTheDocument(),
+    );
+    expect(
+      screen.getByRole("button", { name: /Install bundle/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("hides install button + shows ✓ copy when all recipes are installed", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse(200, {
+        recipes: RECIPES.map((name) => ({ name })),
+      }),
+    );
+    render(<BundleInstallPanel installSource={SOURCE} recipes={RECIPES} />);
+    await waitFor(() =>
+      expect(
+        screen.getByText(/All 3 recipes installed locally/i),
+      ).toBeInTheDocument(),
+    );
+    expect(
+      screen.queryByRole("button", { name: /Install bundle/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("falls back to 'No local bridge' copy when /api/bridge/recipes errors", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(503, {}));
+    render(<BundleInstallPanel installSource={SOURCE} recipes={RECIPES} />);
+    await waitFor(() =>
+      expect(
+        screen.getByText(/No local bridge detected/i),
+      ).toBeInTheDocument(),
+    );
+    // No install button when bridge is offline — only the CLI copy box.
+    expect(
+      screen.queryByRole("button", { name: /Install bundle/i }),
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe("BundleInstallPanel — install action", () => {
+  it("POSTs the installSource verbatim and renders the installed[] result", async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(200, { recipes: [] })) // status poll
+      .mockResolvedValueOnce(
+        jsonResponse(200, {
+          ok: true,
+          kind: "bundle",
+          bundleName: "morning",
+          installed: [
+            { name: "a-recipe", action: "created" },
+            { name: "b-recipe", action: "created" },
+            { name: "c-recipe", action: "created" },
+          ],
+          failures: [],
+        }),
+      );
+    render(<BundleInstallPanel installSource={SOURCE} recipes={RECIPES} />);
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: /Install bundle/i }),
+      ).toBeInTheDocument(),
+    );
+    fireEvent.click(screen.getByRole("button", { name: /Install bundle/i }));
+
+    await waitFor(() =>
+      expect(screen.getByText(/Installed 3 recipes:/i)).toBeInTheDocument(),
+    );
+
+    // Verify the install POST went to the right URL with the exact source.
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const [url, init] = fetchMock.mock.calls[1] as [string, RequestInit];
+    expect(url).toBe("/api/bridge/recipes/install");
+    expect(init.method).toBe("POST");
+    const body = JSON.parse(init.body as string) as { source: string };
+    expect(body.source).toBe(SOURCE);
+  });
+
+  it("renders both installed[] and failures[] for partial success", async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(200, { recipes: [] }))
+      .mockResolvedValueOnce(
+        jsonResponse(200, {
+          ok: true,
+          kind: "bundle",
+          installed: [{ name: "a-recipe", action: "created" }],
+          failures: [
+            { name: "b-recipe", error: "Upstream returned 404" },
+            { name: "c-recipe", error: "Recipe body exceeded 1 MB cap" },
+          ],
+        }),
+      );
+    render(<BundleInstallPanel installSource={SOURCE} recipes={RECIPES} />);
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: /Install bundle/i }),
+      ).toBeInTheDocument(),
+    );
+    fireEvent.click(screen.getByRole("button", { name: /Install bundle/i }));
+
+    await waitFor(() => expect(screen.getByText(/2 failed:/i)).toBeInTheDocument());
+    expect(screen.getByText(/Installed 1 recipe:/i)).toBeInTheDocument();
+    expect(screen.getByText(/Upstream returned 404/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/Recipe body exceeded 1 MB cap/i),
+    ).toBeInTheDocument();
+  });
+
+  it("surfaces an error banner when bridge returns 502 with no installed[]", async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(200, { recipes: [] }))
+      .mockResolvedValueOnce(
+        jsonResponse(400, {
+          ok: false,
+          error: "Bundle manifest must declare a non-empty `recipes` array",
+          code: "bundle_manifest_invalid_recipes",
+        }),
+      );
+    render(<BundleInstallPanel installSource={SOURCE} recipes={RECIPES} />);
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: /Install bundle/i }),
+      ).toBeInTheDocument(),
+    );
+    fireEvent.click(screen.getByRole("button", { name: /Install bundle/i }));
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole("alert"),
+      ).toHaveTextContent(/non-empty .recipes. array/i),
+    );
+  });
+});
+
+describe("BundleInstallPanel — advisory rendering", () => {
+  it("renders plugin advisory when manifest declares one", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(200, { recipes: [] }));
+    render(
+      <BundleInstallPanel
+        installSource={SOURCE}
+        recipes={RECIPES}
+        plugin="@example/plugin"
+      />,
+    );
+    await waitFor(() =>
+      expect(
+        screen.getByText(/Manual follow-up needed/i),
+      ).toBeInTheDocument(),
+    );
+    expect(
+      screen.getByText(/Plugin/),
+    ).toBeInTheDocument();
+    expect(screen.getByText("@example/plugin")).toBeInTheDocument();
+  });
+
+  it("renders policy template advisory when manifest declares one", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(200, { recipes: [] }));
+    render(
+      <BundleInstallPanel
+        installSource={SOURCE}
+        recipes={RECIPES}
+        policyTemplate="policies/strict.json"
+      />,
+    );
+    await waitFor(() =>
+      expect(
+        screen.getByText(/Manual follow-up needed/i),
+      ).toBeInTheDocument(),
+    );
+    expect(
+      screen.getByText(/Policy template/),
+    ).toBeInTheDocument();
+    expect(screen.getByText("policies/strict.json")).toBeInTheDocument();
+  });
+
+  it("does not render the manual-followup section when no advisory is present", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(200, { recipes: [] }));
+    render(<BundleInstallPanel installSource={SOURCE} recipes={RECIPES} />);
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: /Install bundle/i }),
+      ).toBeInTheDocument(),
+    );
+    expect(
+      screen.queryByText(/Manual follow-up needed/i),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/dashboard/src/app/marketplace/bundle/[...slug]/page.tsx
+++ b/dashboard/src/app/marketplace/bundle/[...slug]/page.tsx
@@ -11,6 +11,7 @@ import {
   type RiskLevel,
   shortName,
 } from "@/lib/registry";
+import BundleInstallPanel from "./BundleInstallPanel";
 
 export const revalidate = 300;
 
@@ -66,7 +67,14 @@ export default async function BundleDetailPage({ params }: PageProps) {
         <RequiredEnvCard vars={manifest.required_env} />
       )}
 
-      <InstallInstructions bundle={bundle} manifest={manifest} />
+      <BundleInstallPanel
+        installSource={bundle.install}
+        recipes={manifest?.recipes ?? []}
+        {...(manifest?.plugin && { plugin: manifest.plugin })}
+        {...(manifest?.policy_template && {
+          policyTemplate: manifest.policy_template,
+        })}
+      />
 
       <TrustNote />
     </section>
@@ -247,67 +255,6 @@ function RequiredEnvCard({ vars }: { vars: string[] }) {
           </li>
         ))}
       </ul>
-    </div>
-  );
-}
-
-function InstallInstructions({
-  bundle,
-  manifest,
-}: {
-  bundle: RegistryBundle;
-  manifest: BundleManifest | null;
-}) {
-  const plugin = manifest?.plugin;
-  const recipes = manifest?.recipes ?? [];
-  return (
-    <div className="glass-card" style={{ padding: "var(--s-5)" }}>
-      <h3 style={{ fontSize: "var(--fs-m)", marginTop: 0, marginBottom: "var(--s-3)" }}>Install</h3>
-      <p style={{ fontSize: "var(--fs-s)", color: "var(--fg-2)", marginTop: 0 }}>
-        Bundle install via a single command isn&apos;t wired through the
-        bridge yet. Install each constituent recipe from the Marketplace —
-        the trust + risk metadata above carries over per-recipe.
-      </p>
-      {recipes.length > 0 && (
-        <ul
-          style={{
-            listStyle: "none",
-            padding: 0,
-            margin: "var(--s-3) 0",
-            display: "flex",
-            flexDirection: "column",
-            gap: 4,
-          }}
-        >
-          {recipes.map((r) => (
-            <li
-              key={r}
-              style={{
-                fontSize: "var(--fs-s)",
-                fontFamily: "var(--font-mono)",
-                color: "var(--fg-1)",
-              }}
-            >
-              <Link
-                href={`/marketplace/${encodeURIComponent(r)}`}
-                style={{
-                  color: "inherit",
-                  textDecoration: "underline",
-                  textDecorationColor: "var(--line-2)",
-                }}
-              >
-                {r}
-              </Link>
-            </li>
-          ))}
-        </ul>
-      )}
-      {plugin && (
-        <p style={{ fontSize: "var(--fs-s)", color: "var(--fg-2)" }}>
-          Plugin: <code style={{ fontSize: "var(--fs-xs)" }}>npm install -g {plugin}</code>, then restart the bridge with{" "}
-          <code style={{ fontSize: "var(--fs-xs)" }}>--plugin {plugin}</code>.
-        </p>
-      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Closes #130. Pairs with #281 (bridge bundle-install endpoint, already merged).

Replaces the placeholder "bundle install isn't wired through the bridge yet — copy these recipe links" block on the bundle detail page with a live `BundleInstallPanel` that:

- polls `/api/bridge/recipes` to detect how many of the bundle's recipes are already installed locally;
- shows an "Install bundle" button when the bridge is online and at least one recipe is missing;
- POSTs the bundle's `installSource` (e.g. `github:patchworkos/recipes/bundles/morning`) to `/api/bridge/recipes/install` — same source string the registry publishes, no client-side reconstruction;
- renders the bridge's partial-success response: which recipes were installed, which failed and why;
- surfaces `manifest.plugin` and `manifest.policy_template` as "manual follow-up needed" guidance, since neither is auto-installed in this iteration (per the #130 scoping decision).

## Status copy

| Bridge state | Copy shown |
|---|---|
| Online, none installed | "Bridge connected — install all N recipes with one click." + Install button |
| Online, partial | "X of N recipes already installed. Install button will pull the missing N−X." + Install button |
| Online, all installed | "✓ All N recipes installed locally — enable each with `patchwork recipe enable <name>`." (no button) |
| Offline | "No local bridge detected. Install via CLI below." (no button, copy command still visible) |
| Pre-poll | "Checking for local bridge…" |

## Test plan

- [x] `npm test` in `dashboard/` — 251/251 (10 new + 241 existing)
- [x] `npx tsc --noEmit` in `dashboard/` — clean
- [x] `npm run typecheck` (root) — clean
- [x] `npx tsc -p tsconfig.tests.core.json` (strict CI ratchet) — clean
- [x] Marketplace page renders with no console errors
- [ ] Manual end-to-end: when `patchworkos/recipes` registry actually publishes a bundle (currently bundles list is empty), navigate to its detail page, verify status copy + click "Install bundle" → bridge installs the listed recipes.

## Note on browser smoke testing

The live `patchworkos/recipes` registry currently has **no bundles** — `index.json` doesn't return any `bundles[]` entries. The bundle detail page can't be smoke-tested against real data until the first bundle is published. The 10 RTL tests cover the panel behavior end-to-end with mocked fetch; the bridge handler is covered by #281's tests.

## What's left for #130

- **#279 (already filed)** Skills CLI direction (npm packages vs bundle dispatch) — separate product question. Not blocking this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)