### PR TITLE
test(dashboard): regression tests for AI-generated YAML round-trip

### DIFF
--- a/dashboard/src/app/recipes/new/__tests__/applyAiYaml.test.ts
+++ b/dashboard/src/app/recipes/new/__tests__/applyAiYaml.test.ts
@@ -1,0 +1,212 @@
+/** @vitest-environment node */
+/**
+ * Regression tests for the AI Generate-with-AI save flow.
+ *
+ * Background: prior to PR #274 the dashboard /recipes/new page projected
+ * AI-generated YAML through a form model that only knew `agent:` steps.
+ * Any `tool:` / `parallel:` / `branch:` / `recipe:` step was silently
+ * rewritten to an empty agent step on save. The fix saves the YAML
+ * verbatim via PUT /api/bridge/recipes/:name and redirects to the
+ * YAML editor. These tests guard the verbatim-body contract so a
+ * future refactor can't re-introduce the lossy projection.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import { prepareAndSaveAiRecipe } from "../applyAiYaml";
+
+vi.mock("@/lib/api", () => ({
+  apiPath: (p: string) => p,
+}));
+
+function okResponse(body: object): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function errorResponse(status: number, body: object): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("prepareAndSaveAiRecipe — verbatim YAML round-trip", () => {
+  it("PUTs the original `tool:` YAML unchanged (PR #274 regression)", async () => {
+    const yaml = `apiVersion: patchwork.sh/v1
+name: morning-inbox
+trigger:
+  type: manual
+steps:
+  - tool: gmail.fetch_unread
+    since: 24h
+    max: 30
+    into: messages
+  - tool: github.list_issues
+    assignee: "@me"
+    max: 10
+    into: issues
+`;
+    const fetcher = vi.fn(async () => okResponse({ ok: true })) as unknown as typeof fetch;
+
+    const result = await prepareAndSaveAiRecipe(yaml, fetcher);
+
+    expect(result).toEqual({ ok: true, recipeName: "morning-inbox" });
+    expect(fetcher).toHaveBeenCalledTimes(1);
+    const [url, init] = (fetcher as unknown as { mock: { calls: [string, RequestInit][] } })
+      .mock.calls[0];
+    expect(url).toBe("/api/bridge/recipes/morning-inbox");
+    expect(init?.method).toBe("PUT");
+    const body = JSON.parse(init?.body as string) as { content: string };
+    expect(body.content).toBe(yaml);
+    // The verbatim contract: tool IDs and their params must survive.
+    expect(body.content).toContain("tool: gmail.fetch_unread");
+    expect(body.content).toContain("since: 24h");
+    expect(body.content).toContain("max: 30");
+    expect(body.content).toContain("tool: github.list_issues");
+  });
+
+  it("preserves `parallel:` step groups verbatim", async () => {
+    const yaml = `apiVersion: patchwork.sh/v1
+name: triage-and-notify
+trigger:
+  type: manual
+steps:
+  - parallel:
+      - id: fetch_emails
+        tool: gmail.fetch_unread
+        max: 50
+      - id: fetch_issues
+        tool: github.list_issues
+        assignee: "@me"
+`;
+    const fetcher = vi.fn(async () => okResponse({ ok: true })) as unknown as typeof fetch;
+
+    await prepareAndSaveAiRecipe(yaml, fetcher);
+
+    const [, init] = (fetcher as unknown as { mock: { calls: [string, RequestInit][] } })
+      .mock.calls[0];
+    const body = JSON.parse(init?.body as string) as { content: string };
+    expect(body.content).toBe(yaml);
+    expect(body.content).toContain("parallel:");
+    expect(body.content).toContain("tool: gmail.fetch_unread");
+  });
+
+  it("preserves nested `recipe:` step references verbatim", async () => {
+    const yaml = `apiVersion: patchwork.sh/v1
+name: pipeline
+trigger:
+  type: manual
+steps:
+  - recipe: shared-fetch-step
+    inputs:
+      lookback: 7d
+`;
+    const fetcher = vi.fn(async () => okResponse({ ok: true })) as unknown as typeof fetch;
+
+    await prepareAndSaveAiRecipe(yaml, fetcher);
+
+    const [, init] = (fetcher as unknown as { mock: { calls: [string, RequestInit][] } })
+      .mock.calls[0];
+    const body = JSON.parse(init?.body as string) as { content: string };
+    expect(body.content).toBe(yaml);
+    expect(body.content).toContain("recipe: shared-fetch-step");
+    expect(body.content).toContain("lookback: 7d");
+  });
+});
+
+describe("prepareAndSaveAiRecipe — name extraction + slug", () => {
+  it("normalizes the recipe name into the URL", async () => {
+    const yaml = `name: My_Recipe Name\ntrigger: { type: manual }\nsteps: []\n`;
+    const fetcher = vi.fn(async () => okResponse({ ok: true })) as unknown as typeof fetch;
+
+    const result = await prepareAndSaveAiRecipe(yaml, fetcher);
+
+    expect(result).toEqual({ ok: true, recipeName: "my-recipe-name" });
+    const [url] = (fetcher as unknown as { mock: { calls: [string][] } }).mock.calls[0];
+    expect(url).toBe("/api/bridge/recipes/my-recipe-name");
+  });
+
+  it("rejects YAML with no parsable name", async () => {
+    const yaml = `apiVersion: patchwork.sh/v1\ntrigger: { type: manual }\nsteps: []\n`;
+    const fetcher = vi.fn() as unknown as typeof fetch;
+
+    const result = await prepareAndSaveAiRecipe(yaml, fetcher);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toMatch(/missing a valid name/);
+    }
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+
+  it("rejects YAML that cannot be parsed", async () => {
+    const fetcher = vi.fn() as unknown as typeof fetch;
+
+    const result = await prepareAndSaveAiRecipe("name: foo\n  bad: [", fetcher);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toMatch(/not valid YAML/);
+    }
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+});
+
+describe("prepareAndSaveAiRecipe — error + demo paths", () => {
+  it("surfaces a save error from the bridge", async () => {
+    const yaml = `name: ok-recipe\ntrigger: { type: manual }\nsteps: []\n`;
+    const fetcher = vi.fn(async () =>
+      errorResponse(422, { ok: false, error: "Recipe failed lint." }),
+    ) as unknown as typeof fetch;
+
+    const result = await prepareAndSaveAiRecipe(yaml, fetcher);
+
+    expect(result).toEqual({ ok: false, error: "Recipe failed lint." });
+  });
+
+  it("blocks redirect in demo mode", async () => {
+    const yaml = `name: demo-recipe\ntrigger: { type: manual }\nsteps: []\n`;
+    const fetcher = vi.fn(async () =>
+      okResponse({ ok: true, demo: true }),
+    ) as unknown as typeof fetch;
+
+    const result = await prepareAndSaveAiRecipe(yaml, fetcher);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.demoBlocked).toBe(true);
+      expect(result.error).toMatch(/Demo mode/);
+    }
+  });
+
+  it("returns warnings alongside ok=true so caller can stash them", async () => {
+    const yaml = `name: warn-recipe\ntrigger: { type: manual }\nsteps: []\n`;
+    const fetcher = vi.fn(async () =>
+      okResponse({ ok: true, warnings: ["unknown tool id: foo"] }),
+    ) as unknown as typeof fetch;
+
+    const result = await prepareAndSaveAiRecipe(yaml, fetcher);
+
+    expect(result).toEqual({
+      ok: true,
+      recipeName: "warn-recipe",
+      warnings: ["unknown tool id: foo"],
+    });
+  });
+
+  it("recovers from a fetch network error", async () => {
+    const yaml = `name: net-fail\ntrigger: { type: manual }\nsteps: []\n`;
+    const fetcher = vi.fn(async () => {
+      throw new Error("ECONNREFUSED");
+    }) as unknown as typeof fetch;
+
+    const result = await prepareAndSaveAiRecipe(yaml, fetcher);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBe("ECONNREFUSED");
+    }
+  });
+});

--- a/dashboard/src/app/recipes/new/applyAiYaml.ts
+++ b/dashboard/src/app/recipes/new/applyAiYaml.ts
@@ -1,0 +1,113 @@
+import { parse as parseYaml } from "yaml";
+import { apiPath } from "@/lib/api";
+
+/**
+ * Slugify a free-form name into the canonical kebab-case shape that the
+ * server, schema, and filesystem all agree on (`^[a-z0-9][a-z0-9-]{0,63}$`).
+ * Lowercase, fold whitespace and underscores to dashes, strip leading/
+ * trailing dashes. Empty input → empty (caller treats as missing).
+ */
+export function normalizeRecipeName(name: string): string {
+  return name
+    .trim()
+    .toLowerCase()
+    .replace(/[\s_]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+const RECIPE_NAME_RE = /^[a-z0-9][a-z0-9-]{0,63}$/;
+
+export type AiSaveResult =
+  | { ok: true; recipeName: string; warnings?: string[] }
+  | { ok: false; demoBlocked?: boolean; error: string };
+
+/**
+ * Pure save-and-decide helper for the AI Generate flow.
+ *
+ * Saves the AI-generated YAML verbatim via PUT /api/bridge/recipes/:name and
+ * returns a result describing what the caller should do next (redirect, show
+ * error, or stash warnings for the edit page). The previous flow funneled
+ * generated YAML through a form model that only knew `agent:` steps — any
+ * `tool:` step was silently rewritten to an empty agent. This helper is the
+ * verbatim path. The body MUST be `{ content: yamlText }` with the YAML
+ * unchanged so `tool:` / `parallel:` / `branch:` / `recipe:` steps survive
+ * the round-trip (PR #274, regression-tested in applyAiYaml.test.ts).
+ *
+ * Pure with respect to UI state: takes a fetcher injectable so unit tests
+ * can assert the exact request body without spinning up MSW. The caller
+ * (page.tsx) wraps this with React state setters and `router.push`.
+ */
+export async function prepareAndSaveAiRecipe(
+  yamlText: string,
+  fetcher: typeof fetch = fetch,
+): Promise<AiSaveResult> {
+  let parsed: unknown;
+  try {
+    parsed = parseYaml(yamlText) ?? {};
+  } catch {
+    return { ok: false, error: "Generated YAML is not valid YAML." };
+  }
+
+  let recipeName = "";
+  if (parsed && typeof parsed === "object") {
+    const rawName = (parsed as { name?: unknown }).name;
+    if (typeof rawName === "string") {
+      recipeName = normalizeRecipeName(rawName);
+    }
+  }
+  if (!recipeName || !RECIPE_NAME_RE.test(recipeName)) {
+    return {
+      ok: false,
+      error:
+        "Generated recipe is missing a valid name — regenerate or copy the YAML and create the recipe by hand.",
+    };
+  }
+
+  let res: Response;
+  try {
+    res = await fetcher(
+      apiPath(`/api/bridge/recipes/${encodeURIComponent(recipeName)}`),
+      {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ content: yamlText }),
+      },
+    );
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+
+  let data: {
+    ok?: boolean;
+    error?: string;
+    demo?: boolean;
+    warnings?: string[];
+  };
+  try {
+    data = (await res.json()) as typeof data;
+  } catch {
+    return { ok: false, error: "Failed to parse save response." };
+  }
+
+  if (!res.ok || data.ok === false) {
+    return { ok: false, error: data.error ?? "Failed to save recipe." };
+  }
+  if (data.demo) {
+    return {
+      ok: false,
+      demoBlocked: true,
+      error:
+        "Demo mode — recipe was not persisted. Disable demo mode to save real recipes.",
+    };
+  }
+  return {
+    ok: true,
+    recipeName,
+    ...(data.warnings && data.warnings.length > 0
+      ? { warnings: data.warnings }
+      : {}),
+  };
+}

--- a/dashboard/src/app/recipes/new/page.tsx
+++ b/dashboard/src/app/recipes/new/page.tsx
@@ -1,8 +1,8 @@
 "use client";
 import { useRouter, useSearchParams } from "next/navigation";
 import { Suspense, useCallback, useMemo, useRef, useState } from "react";
-import { parse as parseYaml } from "yaml";
 import { apiPath } from "@/lib/api";
+import { normalizeRecipeName, prepareAndSaveAiRecipe } from "./applyAiYaml";
 
 interface Step {
   id: string;
@@ -181,20 +181,6 @@ const RECIPE_SCHEMA_HEADER =
 const RECIPE_API_VERSION = "patchwork.sh/v1";
 const SIMPLE_YAML_VALUE_RE = /^[A-Za-z0-9_./:@%+-]+$/;
 const AMBIGUOUS_YAML_VALUE_RE = /^(true|false|null|~|-?\d+(\.\d+)?)$/i;
-
-/**
- * Slugify a free-form name into the canonical kebab-case shape that the
- * server, schema, and filesystem all agree on (`^[a-z0-9][a-z0-9-]{0,63}$`).
- * Lowercase, fold whitespace and underscores to dashes, strip leading/
- * trailing dashes. Empty input → empty (caller treats as missing).
- */
-function normalizeRecipeName(name: string): string {
-  return name
-    .trim()
-    .toLowerCase()
-    .replace(/[\s_]+/g, "-")
-    .replace(/^-+|-+$/g, "");
-}
 
 function yamlScalar(value: string): string {
   if (!value) {
@@ -578,98 +564,24 @@ function NewRecipePageInner() {
   }
 
   async function applyAiYaml(yamlText: string) {
-    // Save the AI-generated YAML verbatim and open it in the YAML editor.
-    // The previous flow funneled it through `applyAiYaml` → form state →
-    // `buildRecipeYaml`, but the form models only `agent:` steps — any
-    // `tool:` step the generator emitted (gmail.fetch_unread, github.list_*,
-    // file.write, etc.) was silently rewritten to an empty agent step.
-    // The structured form wizard is for hand-authoring; AI output goes
-    // straight to the raw YAML editor where the bridge's lint warnings
-    // surface and the user can review the full content unmodified.
-    let parsed: unknown;
-    try {
-      parsed = parseYaml(yamlText) ?? {};
-    } catch {
-      setAiResult((cur) =>
-        cur ? { ...cur, error: "Generated YAML is not valid YAML." } : cur,
-      );
-      return;
-    }
-    let recipeName = "";
-    if (parsed && typeof parsed === "object") {
-      const rawName = (parsed as { name?: unknown }).name;
-      if (typeof rawName === "string") {
-        recipeName = normalizeRecipeName(rawName);
-      }
-    }
-    if (!recipeName || !NAME_RE.test(recipeName)) {
-      setAiResult((cur) =>
-        cur
-          ? {
-              ...cur,
-              error:
-                "Generated recipe is missing a valid name — regenerate or copy the YAML and create the recipe by hand.",
-            }
-          : cur,
-      );
-      return;
-    }
-
     setAiSaving(true);
     try {
-      const res = await fetch(
-        apiPath(`/api/bridge/recipes/${encodeURIComponent(recipeName)}`),
-        {
-          method: "PUT",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ content: yamlText }),
-        },
-      );
-      const data = (await res.json()) as {
-        ok?: boolean;
-        error?: string;
-        demo?: boolean;
-        warnings?: string[];
-      };
-      if (!res.ok || data.ok === false) {
-        setAiResult((cur) =>
-          cur ? { ...cur, error: data.error ?? "Failed to save recipe." } : cur,
-        );
+      const result = await prepareAndSaveAiRecipe(yamlText);
+      if (!result.ok) {
+        setAiResult((cur) => (cur ? { ...cur, error: result.error } : cur));
         return;
       }
-      if (data.demo) {
-        // Demo mode persists nothing, so /edit would 404. Surface in place.
-        setAiResult((cur) =>
-          cur
-            ? {
-                ...cur,
-                error:
-                  "Demo mode — recipe was not persisted. Disable demo mode to save real recipes.",
-              }
-            : cur,
-        );
-        return;
-      }
-      if (data.warnings && data.warnings.length > 0) {
+      if (result.warnings) {
         try {
           sessionStorage.setItem(
-            `recipe-save-warnings:${recipeName}`,
-            JSON.stringify(data.warnings),
+            `recipe-save-warnings:${result.recipeName}`,
+            JSON.stringify(result.warnings),
           );
         } catch {
           // sessionStorage unavailable — non-fatal; edit page re-lints.
         }
       }
-      router.push(`/recipes/${encodeURIComponent(recipeName)}/edit`);
-    } catch (err) {
-      setAiResult((cur) =>
-        cur
-          ? {
-              ...cur,
-              error: err instanceof Error ? err.message : String(err),
-            }
-          : cur,
-      );
+      router.push(`/recipes/${encodeURIComponent(result.recipeName)}/edit`);
     } finally {
       setAiSaving(false);
     }


### PR DESCRIPTION
## Summary

Locks in the PR #274 fix with regression tests. That PR made `/recipes/new` save AI-generated YAML verbatim instead of routing it through the agent-only form model — a silent dropper of `tool:`, `parallel:`, `branch:`, and `recipe:` steps. The fix shipped without a test guarding the verbatim contract, so anyone re-introducing form projection in the future would drop those steps again.

## Changes

- Extract `prepareAndSaveAiRecipe` from the inline closure in [dashboard/src/app/recipes/new/page.tsx](dashboard/src/app/recipes/new/page.tsx) into [dashboard/src/app/recipes/new/applyAiYaml.ts](dashboard/src/app/recipes/new/applyAiYaml.ts) as a pure helper. Takes an injectable fetcher; returns a discriminated union so callers can dispatch redirect / error / warnings without coupling to React state.
- `applyAiYaml` closure in `page.tsx` shrinks from ~95 lines to ~20 — wraps the helper with `setAiSaving`, `sessionStorage` for warnings, and `router.push`.
- 10 regression tests in `__tests__/applyAiYaml.test.ts`.

## Test plan

- [x] **Verbatim YAML round-trip** — three cases assert `body.content === yamlText` (byte-equal) for tool/parallel/recipe step shapes
- [x] **Name extraction** — slug normalization (`My_Recipe Name` → `my-recipe-name`), missing name, unparseable YAML
- [x] **Error paths** — bridge lint failure, demo-mode block, warnings stash, network error recovery
- [x] `tsc --noEmit` clean
- [x] Full dashboard suite: 261 / 261 pass

## Related

- PR #274 (the fix being guarded)
- PR #283 (sibling: backend `/recipes/generate` audit fixes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)