### PR TITLE
fix(dashboard): cap proxy bodies on every bridge route

### DIFF
--- a/dashboard/src/app/api/bridge/[...path]/__tests__/route.test.ts
+++ b/dashboard/src/app/api/bridge/[...path]/__tests__/route.test.ts
@@ -1,0 +1,81 @@
+/** @vitest-environment node */
+/**
+ * Cap-enforcement smoke test for the catch-all bridge proxy.
+ *
+ * The catch-all handles any /api/bridge/* path the named routes don't
+ * capture. Pre-cap, an authenticated caller could stream a multi-GB
+ * body to ANY bridge endpoint via this route. Test asserts oversized
+ * Content-Length is rejected with 413 before the body is buffered.
+ */
+
+import type { NextRequest } from "next/server";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/demoModeServer", () => ({ isDemoModeServer: () => false }));
+vi.mock("@/lib/mockData", () => ({ mockBridgeResponse: () => null }));
+vi.mock("@/lib/bridge", () => ({
+  bridgeFetch: vi.fn(async () =>
+    new Response(JSON.stringify({ ok: true }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    }),
+  ),
+  findBridge: () => null,
+  resolveBridgeUrl: () => "",
+}));
+
+// Importing after mocks are registered.
+const { POST } = await import("../route");
+
+function makeReq(body: string, contentLength?: string): NextRequest {
+  const headers: Record<string, string> = {
+    "content-type": "application/json",
+    "sec-fetch-site": "same-origin",
+  };
+  if (contentLength !== undefined) headers["content-length"] = contentLength;
+  // The catch-all reads `req.nextUrl.search`; provide via Request URL.
+  const url = "https://dashboard.local/api/bridge/some/path?x=1";
+  const req = new Request(url, { method: "POST", headers, body });
+  // The route only uses `req.method`, `req.headers`, `req.body`, and
+  // `req.nextUrl.search`. Patch in a minimal nextUrl shim instead of
+  // pulling the whole NextRequest implementation in.
+  Object.defineProperty(req, "nextUrl", {
+    value: { search: "?x=1" },
+    configurable: true,
+  });
+  return req as unknown as NextRequest;
+}
+
+describe("catch-all bridge proxy — body cap", () => {
+  const ctx = { params: { path: ["some", "path"] } };
+
+  it("rejects Content-Length above 1 MB with 413 (security audit, 2026-05-07)", async () => {
+    const res = await POST(makeReq("x", String(2 * 1024 * 1024)), ctx);
+    expect(res.status).toBe(413);
+  });
+
+  it("rejects oversized streamed body without Content-Length", async () => {
+    // 2 MB body, 1 MB cap. Test the streaming-cap path.
+    const huge = "a".repeat(2 * 1024 * 1024);
+    const url = "https://dashboard.local/api/bridge/some/path";
+    const req = new Request(url, {
+      method: "POST",
+      headers: { "content-type": "text/plain", "sec-fetch-site": "same-origin" },
+      body: huge,
+    });
+    Object.defineProperty(req, "nextUrl", {
+      value: { search: "" },
+      configurable: true,
+    });
+    const res = await POST(req as unknown as NextRequest, ctx);
+    expect(res.status).toBe(413);
+  });
+
+  it("accepts a normal-sized body", async () => {
+    const res = await POST(
+      makeReq(JSON.stringify({ ok: true }), "16"),
+      ctx,
+    );
+    expect(res.status).toBe(200);
+  });
+});

--- a/dashboard/src/app/api/bridge/[...path]/route.ts
+++ b/dashboard/src/app/api/bridge/[...path]/route.ts
@@ -2,6 +2,11 @@ import type { NextRequest } from "next/server";
 import { bridgeFetch, findBridge, resolveBridgeUrl } from "@/lib/bridge";
 import { isDemoModeServer } from "@/lib/demoModeServer";
 import { mockBridgeResponse } from "@/lib/mockData";
+import {
+  BRIDGE_BODY_CAPS,
+  bodyTooLargeResponse,
+  readBodyWithCap,
+} from "@/lib/readBodyWithCap";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -130,10 +135,12 @@ async function proxy(req: NextRequest, segments: string[]): Promise<Response> {
     if (mock) return mock;
   }
 
-  const body =
-    req.method === "GET" || req.method === "HEAD"
-      ? undefined
-      : await req.text();
+  let body: string | undefined;
+  if (req.method !== "GET" && req.method !== "HEAD") {
+    const read = await readBodyWithCap(req, BRIDGE_BODY_CAPS.genericProxy);
+    if (!read.ok) return bodyTooLargeResponse(BRIDGE_BODY_CAPS.genericProxy);
+    body = read.body;
+  }
   const forwardHeaders: Record<string, string> = {
     "content-type": req.headers.get("content-type") ?? "",
   };

--- a/dashboard/src/app/api/bridge/recipes/[name]/route.ts
+++ b/dashboard/src/app/api/bridge/recipes/[name]/route.ts
@@ -1,6 +1,11 @@
 import type { NextRequest } from "next/server";
 import { bridgeFetch } from "@/lib/bridge";
 import { isDemoModeServer } from "@/lib/demoModeServer";
+import {
+  BRIDGE_BODY_CAPS,
+  bodyTooLargeResponse,
+  readBodyWithCap,
+} from "@/lib/readBodyWithCap";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -39,9 +44,10 @@ export async function GET(
   }
 }
 
-export async function PUT(
+async function forwardWithMethod(
   req: NextRequest,
   ctx: RouteContext,
+  method: "PUT" | "PATCH",
 ): Promise<Response> {
   const sfs = req.headers.get("sec-fetch-site");
   if (sfs && sfs !== "same-origin" && sfs !== "none") {
@@ -51,13 +57,14 @@ export async function PUT(
     });
   }
   if (isDemoModeServer()) return demoOk();
+  const read = await readBodyWithCap(req, BRIDGE_BODY_CAPS.content);
+  if (!read.ok) return bodyTooLargeResponse(BRIDGE_BODY_CAPS.content);
   try {
     const name = encodeURIComponent(ctx.params.name);
-    const body = await req.text();
     const res = await bridgeFetch(`/recipes/${name}`, {
-      method: "PUT",
+      method,
       headers: { "content-type": req.headers.get("content-type") ?? "application/json" },
-      body,
+      body: read.body,
     });
     const text = await res.text();
     return new Response(text, {
@@ -72,35 +79,16 @@ export async function PUT(
   }
 }
 
+export async function PUT(
+  req: NextRequest,
+  ctx: RouteContext,
+): Promise<Response> {
+  return forwardWithMethod(req, ctx, "PUT");
+}
+
 export async function PATCH(
   req: NextRequest,
   ctx: RouteContext,
 ): Promise<Response> {
-  const sfs = req.headers.get("sec-fetch-site");
-  if (sfs && sfs !== "same-origin" && sfs !== "none") {
-    return new Response(JSON.stringify({ error: "CSRF check failed" }), {
-      status: 403,
-      headers: { "content-type": "application/json" },
-    });
-  }
-  if (isDemoModeServer()) return demoOk();
-  try {
-    const name = encodeURIComponent(ctx.params.name);
-    const body = await req.text();
-    const res = await bridgeFetch(`/recipes/${name}`, {
-      method: "PATCH",
-      headers: { "content-type": req.headers.get("content-type") ?? "application/json" },
-      body,
-    });
-    const text = await res.text();
-    return new Response(text, {
-      status: res.status,
-      headers: { "content-type": "application/json" },
-    });
-  } catch (err) {
-    return new Response(
-      JSON.stringify({ error: err instanceof Error ? err.message : "fetch failed" }),
-      { status: 502, headers: { "content-type": "application/json" } },
-    );
-  }
+  return forwardWithMethod(req, ctx, "PATCH");
 }

--- a/dashboard/src/app/api/bridge/recipes/[name]/run/route.ts
+++ b/dashboard/src/app/api/bridge/recipes/[name]/run/route.ts
@@ -1,6 +1,11 @@
 import type { NextRequest } from "next/server";
 import { bridgeFetch } from "@/lib/bridge";
 import { isDemoModeServer } from "@/lib/demoModeServer";
+import {
+  BRIDGE_BODY_CAPS,
+  bodyTooLargeResponse,
+  readBodyWithCap,
+} from "@/lib/readBodyWithCap";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -29,13 +34,14 @@ export async function POST(
       { status: 200, headers: { "content-type": "application/json" } },
     );
   }
+  const read = await readBodyWithCap(req, BRIDGE_BODY_CAPS.run);
+  if (!read.ok) return bodyTooLargeResponse(BRIDGE_BODY_CAPS.run);
   try {
     const name = encodeURIComponent(ctx.params.name);
-    const body = await req.text();
     const res = await bridgeFetch(`/recipes/${name}/run`, {
       method: "POST",
       headers: { "content-type": req.headers.get("content-type") ?? "application/json" },
-      body: body || undefined,
+      body: read.body || undefined,
     });
     const text = await res.text();
     return new Response(text, {

--- a/dashboard/src/app/api/bridge/recipes/generate/route.ts
+++ b/dashboard/src/app/api/bridge/recipes/generate/route.ts
@@ -1,51 +1,13 @@
 import { bridgeFetch } from "@/lib/bridge";
 import { isDemoModeServer } from "@/lib/demoModeServer";
+import {
+  BRIDGE_BODY_CAPS,
+  bodyTooLargeResponse,
+  readBodyWithCap,
+} from "@/lib/readBodyWithCap";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
-
-// Bridge caps `/recipes/generate` body at 4 KB. Cap the proxy at 8 KB
-// (2× headroom for Content-Type / Content-Length variance) so an
-// authenticated caller can't burn dashboard heap streaming a multi-GB
-// body before the bridge cap kicks in (security audit 2026-05-07).
-const MAX_BODY_BYTES = 8 * 1024;
-
-function tooLarge(): Response {
-  return new Response(
-    JSON.stringify({ error: "request body too large" }),
-    { status: 413, headers: { "content-type": "application/json" } },
-  );
-}
-
-async function readBodyWithCap(
-  req: Request,
-  maxBytes: number,
-): Promise<{ ok: true; body: string } | { ok: false }> {
-  const declared = Number(req.headers.get("content-length"));
-  if (Number.isFinite(declared) && declared > maxBytes) {
-    return { ok: false };
-  }
-  const reader = req.body?.getReader();
-  if (!reader) return { ok: true, body: "" };
-  let total = 0;
-  const chunks: Uint8Array[] = [];
-  while (true) {
-    const { done, value } = await reader.read();
-    if (done) break;
-    if (!value) continue;
-    total += value.byteLength;
-    if (total > maxBytes) {
-      try {
-        await reader.cancel();
-      } catch {
-        // best-effort drain — already over the cap, response is 413
-      }
-      return { ok: false };
-    }
-    chunks.push(value);
-  }
-  return { ok: true, body: Buffer.concat(chunks).toString("utf8") };
-}
 
 export async function POST(req: Request): Promise<Response> {
   const sfs = req.headers.get("sec-fetch-site");
@@ -65,8 +27,8 @@ export async function POST(req: Request): Promise<Response> {
       { status: 200, headers: { "content-type": "application/json" } },
     );
   }
-  const read = await readBodyWithCap(req, MAX_BODY_BYTES);
-  if (!read.ok) return tooLarge();
+  const read = await readBodyWithCap(req, BRIDGE_BODY_CAPS.generate);
+  if (!read.ok) return bodyTooLargeResponse(BRIDGE_BODY_CAPS.generate);
   try {
     const res = await bridgeFetch("/recipes/generate", {
       method: "POST",

--- a/dashboard/src/app/api/bridge/recipes/install/route.ts
+++ b/dashboard/src/app/api/bridge/recipes/install/route.ts
@@ -1,6 +1,11 @@
 import type { NextRequest } from "next/server";
 import { bridgeFetch } from "@/lib/bridge";
 import { isDemoModeServer } from "@/lib/demoModeServer";
+import {
+  BRIDGE_BODY_CAPS,
+  bodyTooLargeResponse,
+  readBodyWithCap,
+} from "@/lib/readBodyWithCap";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -24,12 +29,13 @@ export async function POST(req: NextRequest): Promise<Response> {
     );
   }
 
+  const read = await readBodyWithCap(req, BRIDGE_BODY_CAPS.install);
+  if (!read.ok) return bodyTooLargeResponse(BRIDGE_BODY_CAPS.install);
   try {
-    const body = await req.text();
     const res = await bridgeFetch("/recipes/install", {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body,
+      body: read.body,
     });
     const text = await res.text();
     return new Response(text, {

--- a/dashboard/src/app/api/bridge/recipes/lint/route.ts
+++ b/dashboard/src/app/api/bridge/recipes/lint/route.ts
@@ -1,6 +1,11 @@
 import type { NextRequest } from "next/server";
 import { bridgeFetch } from "@/lib/bridge";
 import { isDemoModeServer } from "@/lib/demoModeServer";
+import {
+  BRIDGE_BODY_CAPS,
+  bodyTooLargeResponse,
+  readBodyWithCap,
+} from "@/lib/readBodyWithCap";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -19,14 +24,15 @@ export async function POST(req: NextRequest): Promise<Response> {
       { status: 200, headers: { "content-type": "application/json" } },
     );
   }
+  const read = await readBodyWithCap(req, BRIDGE_BODY_CAPS.content);
+  if (!read.ok) return bodyTooLargeResponse(BRIDGE_BODY_CAPS.content);
   try {
-    const body = await req.text();
     const res = await bridgeFetch("/recipes/lint", {
       method: "POST",
       headers: {
         "content-type": req.headers.get("content-type") ?? "application/json",
       },
-      body,
+      body: read.body,
     });
     const text = await res.text();
     return new Response(text, {

--- a/dashboard/src/lib/__tests__/readBodyWithCap.test.ts
+++ b/dashboard/src/lib/__tests__/readBodyWithCap.test.ts
@@ -1,0 +1,122 @@
+/** @vitest-environment node */
+/**
+ * Tests for the shared body-cap helper used by every dashboard → bridge
+ * proxy route. The helper protects dashboard heap from authenticated
+ * callers streaming oversized bodies. Layered defenses:
+ *   1. Content-Length pre-check rejects obviously oversized declarations
+ *      before reading any body bytes.
+ *   2. Streamed accumulation aborts the moment cumulative bytes exceed
+ *      the cap — defeats chunked-encoded uploads with no Content-Length.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  BRIDGE_BODY_CAPS,
+  bodyTooLargeResponse,
+  readBodyWithCap,
+} from "../readBodyWithCap";
+
+function reqWithBody(body: string, contentLength?: string): Request {
+  const headers: Record<string, string> = {
+    "content-type": "application/json",
+  };
+  if (contentLength !== undefined) headers["content-length"] = contentLength;
+  return new Request("https://dashboard.local/x", {
+    method: "POST",
+    headers,
+    body,
+  });
+}
+
+describe("readBodyWithCap — Content-Length pre-check", () => {
+  it("rejects declared Content-Length exceeding the cap", async () => {
+    const result = await readBodyWithCap(reqWithBody("x", "999999"), 1024);
+    expect(result.ok).toBe(false);
+  });
+
+  it("accepts declared Content-Length under the cap", async () => {
+    const body = "hello";
+    const result = await readBodyWithCap(
+      reqWithBody(body, String(Buffer.byteLength(body))),
+      1024,
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.body).toBe("hello");
+  });
+
+  it("ignores non-numeric Content-Length and still streams safely", async () => {
+    const body = "ok";
+    const result = await readBodyWithCap(
+      reqWithBody(body, "not-a-number"),
+      1024,
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.body).toBe("ok");
+  });
+});
+
+describe("readBodyWithCap — streamed accumulation cap", () => {
+  it("aborts when accumulated bytes exceed the cap (no Content-Length)", async () => {
+    // 4 KB body, 1 KB cap. Don't include Content-Length so the pre-check
+    // can't short-circuit; force the streaming path to enforce the cap.
+    const body = "a".repeat(4 * 1024);
+    const req = new Request("https://dashboard.local/x", {
+      method: "POST",
+      body,
+    });
+    // Strip Content-Length that fetch added implicitly.
+    const stripped = new Request(req, { headers: { "content-type": "text/plain" } });
+    const result = await readBodyWithCap(stripped, 1024);
+    expect(result.ok).toBe(false);
+  });
+
+  it("returns empty body when there is no body stream", async () => {
+    const req = new Request("https://dashboard.local/x", { method: "GET" });
+    const result = await readBodyWithCap(req, 1024);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.body).toBe("");
+  });
+
+  it("returns the full body when under the cap", async () => {
+    const result = await readBodyWithCap(reqWithBody("under cap"), 1024);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.body).toBe("under cap");
+  });
+});
+
+describe("BRIDGE_BODY_CAPS sizing", () => {
+  it("each cap is at least 2× the bridge-side cap (sanity check)", () => {
+    // Bridge-side caps from src/recipeRoutes.ts RECIPE_ROUTE_BODY_CAPS.
+    // If these change without updating BRIDGE_BODY_CAPS the proxy can
+    // either over-reject (legitimate requests get 413) or under-reject
+    // (defense gap re-opens). Locked here so future changes hit a test.
+    const bridgeSide = {
+      install: 4 * 1024,
+      generate: 4 * 1024,
+      run: 32 * 1024,
+      content: 256 * 1024,
+    };
+    expect(BRIDGE_BODY_CAPS.install).toBeGreaterThanOrEqual(bridgeSide.install * 2);
+    expect(BRIDGE_BODY_CAPS.generate).toBeGreaterThanOrEqual(bridgeSide.generate * 2);
+    expect(BRIDGE_BODY_CAPS.run).toBeGreaterThanOrEqual(bridgeSide.run * 2);
+    expect(BRIDGE_BODY_CAPS.content).toBeGreaterThanOrEqual(bridgeSide.content * 2);
+  });
+
+  it("genericProxy is at least the streamable HTTP transport cap (1 MB)", () => {
+    // src/streamableHttp.ts: BODY_SIZE_LIMIT = 1 MB. Catch-all proxy
+    // covers any path the named routes don't, so it needs at least the
+    // largest bridge cap.
+    expect(BRIDGE_BODY_CAPS.genericProxy).toBeGreaterThanOrEqual(1024 * 1024);
+  });
+});
+
+describe("bodyTooLargeResponse", () => {
+  it("returns 413 with JSON body containing maxBytes", async () => {
+    const res = bodyTooLargeResponse(8192);
+    expect(res.status).toBe(413);
+    expect(res.headers.get("content-type")).toBe("application/json");
+    const data = (await res.json()) as { error: string; maxBytes: number };
+    expect(data.error).toMatch(/too large/i);
+    expect(data.maxBytes).toBe(8192);
+  });
+});

--- a/dashboard/src/lib/readBodyWithCap.ts
+++ b/dashboard/src/lib/readBodyWithCap.ts
@@ -1,0 +1,103 @@
+/**
+ * Shared helper for capping incoming proxy request bodies before they get
+ * buffered in dashboard heap. Without this, an authenticated caller can
+ * stream a multi-GB body through the proxy before the bridge's per-route
+ * cap kicks in and rejects it (the bridge cap protects bridge memory, not
+ * dashboard memory).
+ *
+ * Defense layers, in order:
+ *   1. Content-Length pre-check — reject obviously oversized declarations
+ *      before reading any body bytes (HTTP 413).
+ *   2. Streamed accumulation — read chunks, abort + cancel the reader the
+ *      moment cumulative bytes exceed the cap. Defeats chunked-encoded
+ *      uploads that omit Content-Length.
+ *
+ * Each proxy route picks a cap from BRIDGE_BODY_CAPS that matches its
+ * downstream bridge route. Caps are 2× the bridge cap so legitimate
+ * Content-Type / Content-Length / minor-encoding overhead doesn't false-
+ * positive (the bridge then enforces the precise limit).
+ */
+
+/**
+ * Per-route body caps. Each value is 2× the corresponding bridge-side
+ * cap in src/recipeRoutes.ts (RECIPE_ROUTE_BODY_CAPS) so the dashboard
+ * proxy rejects only obviously oversized payloads and lets the bridge
+ * enforce the exact policy.
+ *
+ * `genericProxy` matches the bridge's streamable HTTP transport limit
+ * (src/streamableHttp.ts: BODY_SIZE_LIMIT = 1 MB) — used by the catch-
+ * all proxy that handles any path the named routes don't capture.
+ */
+export const BRIDGE_BODY_CAPS = {
+  /** /recipes/install — `{ source: string }`. Bridge cap 4 KB. */
+  install: 8 * 1024,
+  /** /recipes/generate — NL prompt. Bridge cap 4 KB. */
+  generate: 8 * 1024,
+  /** /recipes/:name/run — vars envelope. Bridge cap 32 KB. */
+  run: 64 * 1024,
+  /** /recipes/:name PUT/PATCH, /recipes POST, /recipes/lint — yaml. Bridge cap 256 KB. */
+  content: 512 * 1024,
+  /** Catch-all [...path] proxy — matches bridge streamable HTTP cap (1 MB). */
+  genericProxy: 1 * 1024 * 1024,
+} as const;
+
+export type BridgeBodyCapKey = keyof typeof BRIDGE_BODY_CAPS;
+
+export type ReadBodyResult =
+  | { ok: true; body: string }
+  | { ok: false };
+
+/**
+ * Read a request body up to `maxBytes`, rejecting overflow without
+ * letting the buffer grow unbounded. Returns `{ ok: false }` if the
+ * request is too large; the caller should respond with 413 via
+ * `bodyTooLargeResponse(maxBytes)`.
+ *
+ * Treats a missing body (no `req.body` stream) as an empty string so
+ * callers can pipe the result straight into a fetch() body without
+ * branching.
+ */
+export async function readBodyWithCap(
+  req: Request,
+  maxBytes: number,
+): Promise<ReadBodyResult> {
+  const declared = Number(req.headers.get("content-length"));
+  if (Number.isFinite(declared) && declared > maxBytes) {
+    return { ok: false };
+  }
+  const reader = req.body?.getReader();
+  if (!reader) return { ok: true, body: "" };
+  let total = 0;
+  const chunks: Uint8Array[] = [];
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    if (!value) continue;
+    total += value.byteLength;
+    if (total > maxBytes) {
+      try {
+        await reader.cancel();
+      } catch {
+        // best-effort drain — already over the cap, response is 413
+      }
+      return { ok: false };
+    }
+    chunks.push(value);
+  }
+  return { ok: true, body: Buffer.concat(chunks).toString("utf8") };
+}
+
+/**
+ * Standard 413 Payload Too Large response with a hint about the cap.
+ * Body is JSON so dashboard fetch wrappers can parse it like any other
+ * error response.
+ */
+export function bodyTooLargeResponse(maxBytes: number): Response {
+  return new Response(
+    JSON.stringify({
+      error: "request body too large",
+      maxBytes,
+    }),
+    { status: 413, headers: { "content-type": "application/json" } },
+  );
+}


### PR DESCRIPTION
## Summary

Extends the body-cap defense from PR #283 to the 6 sibling proxy routes that had the same unbounded `await req.text()` pattern. Most consequential: the catch-all `[...path]/route.ts` which proxies any path the named routes don't capture — an authenticated caller could stream a multi-GB body to *any* bridge endpoint via that route.

## Routes capped

| Route | Cap | Bridge-side cap |
|---|---|---|
| `[...path]/route.ts` (catch-all) | 1 MB | streamable HTTP (1 MB) |
| `recipes/[name]/route.ts` (PUT/PATCH) | 512 KB | content (256 KB) |
| `recipes/[name]/run/route.ts` | 64 KB | run (32 KB) |
| `recipes/install/route.ts` | 8 KB | install (4 KB) |
| `recipes/lint/route.ts` | 512 KB | content (256 KB) |
| `recipes/generate/route.ts` | 8 KB | generate (4 KB) — migrated to shared helper |

Each cap is 2× the corresponding bridge-side cap (RECIPE_ROUTE_BODY_CAPS) so legitimate Content-Type / Content-Length / encoding overhead doesn't false-positive; the bridge then enforces the precise limit.

## Changes

- New shared module [dashboard/src/lib/readBodyWithCap.ts](dashboard/src/lib/readBodyWithCap.ts):
  - `readBodyWithCap(req, maxBytes)` — Content-Length pre-check + streamed accumulation with `reader.cancel()` on overflow
  - `bodyTooLargeResponse(maxBytes)` — standard 413 with JSON body containing the cap
  - `BRIDGE_BODY_CAPS` — typed per-route cap constants
- Migrated PR #283's inline helper in `generate/route.ts` to import from the shared module (-43 lines).
- Applied helper to 5 other proxy routes.

## Test plan

- [x] **Helper** — 8 unit tests in [readBodyWithCap.test.ts](dashboard/src/lib/__tests__/readBodyWithCap.test.ts): Content-Length pre-check (over/under/non-numeric), streamed-cap path (4 KB body / 1 KB cap), missing body, sizing sanity (caps ≥ 2× bridge), genericProxy ≥ 1 MB, 413 response shape
- [x] **Catch-all** — 3 smoke tests in [`[...path]/__tests__/route.test.ts`](dashboard/src/app/api/bridge/[...path]/__tests__/route.test.ts): declared Content-Length above cap, streamed body without Content-Length, normal pass-through
- [x] **Existing generate test** still passes (API unchanged)
- [x] `tsc --noEmit` clean
- [x] Full dashboard suite: 266 / 266 pass

## Related

- PR #283 (sibling: same fix for /recipes/generate, merged)
- PR #284 (regression tests for AI YAML round-trip, open)

🤖 Generated with [Claude Code](https://claude.com/claude-code)