### PR TITLE
fix(dashboard): cap remaining unbounded body reads + close explain-batch CSRF gap

### DIFF
--- a/dashboard/src/app/api/bridge/approval-insights/explain-batch/__tests__/route.test.ts
+++ b/dashboard/src/app/api/bridge/approval-insights/explain-batch/__tests__/route.test.ts
@@ -1,0 +1,78 @@
+/** @vitest-environment node */
+/**
+ * Smoke tests for the explain-batch fan-out route.
+ *
+ * Pre-fix the route had two gaps:
+ *   1. No CSRF check — every other dashboard mutation route uses
+ *      `requireSameOrigin`, this one was missed.
+ *   2. Unbounded `await req.json()` — same body-buffer class as the
+ *      other routes fixed in PR #285.
+ */
+
+import type { NextRequest } from "next/server";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/bridge", () => ({
+  bridgeFetch: vi.fn(async () =>
+    new Response(JSON.stringify({ explanation: "ok" }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    }),
+  ),
+}));
+
+const { POST } = await import("../route");
+
+function makeReq(
+  body: string,
+  headers: Record<string, string> = { "sec-fetch-site": "same-origin" },
+  contentLength?: string,
+): NextRequest {
+  const finalHeaders: Record<string, string> = {
+    "content-type": "application/json",
+    ...headers,
+  };
+  if (contentLength !== undefined) finalHeaders["content-length"] = contentLength;
+  return new Request("https://dashboard.local/api/bridge/approval-insights/explain-batch", {
+    method: "POST",
+    headers: finalHeaders,
+    body,
+  }) as unknown as NextRequest;
+}
+
+describe("POST /api/bridge/approval-insights/explain-batch — CSRF guard", () => {
+  it("rejects sec-fetch-site=cross-site with 403 (security audit, 2026-05-07)", async () => {
+    const res = await POST(
+      makeReq(JSON.stringify({ tools: ["foo"] }), {
+        "sec-fetch-site": "cross-site",
+      }),
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it("allows sec-fetch-site=same-origin", async () => {
+    const res = await POST(makeReq(JSON.stringify({ tools: ["foo"] })));
+    expect(res.status).toBe(200);
+  });
+});
+
+describe("POST /api/bridge/approval-insights/explain-batch — body cap", () => {
+  it("rejects oversized Content-Length with 413", async () => {
+    const res = await POST(
+      makeReq(JSON.stringify({ tools: [] }), { "sec-fetch-site": "same-origin" }, "9999999"),
+    );
+    expect(res.status).toBe(413);
+  });
+
+  it("returns 400 on invalid JSON", async () => {
+    const res = await POST(makeReq("{not json"));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns empty explanations on empty tool list", async () => {
+    const res = await POST(makeReq(JSON.stringify({ tools: [] })));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { explanations: Record<string, unknown> };
+    expect(body.explanations).toEqual({});
+  });
+});

--- a/dashboard/src/app/api/bridge/approval-insights/explain-batch/route.ts
+++ b/dashboard/src/app/api/bridge/approval-insights/explain-batch/route.ts
@@ -1,5 +1,11 @@
 import type { NextRequest } from "next/server";
 import { bridgeFetch } from "@/lib/bridge";
+import { requireSameOrigin } from "@/lib/csrf";
+import {
+  DASHBOARD_API_BODY_CAPS,
+  bodyTooLargeResponse,
+  readJsonWithCap,
+} from "@/lib/readBodyWithCap";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -8,15 +14,21 @@ export const runtime = "nodejs";
 // Bridge endpoint is per-tool only (/approval-insights/explain?tool=X);
 // proxying here keeps the wire unchanged and avoids touching bridge code.
 export async function POST(req: NextRequest): Promise<Response> {
-  let body: { tools?: unknown };
-  try {
-    body = (await req.json()) as { tools?: unknown };
-  } catch {
+  const csrf = requireSameOrigin(req);
+  if (csrf) return csrf;
+
+  const parsed = await readJsonWithCap<{ tools?: unknown }>(
+    req,
+    DASHBOARD_API_BODY_CAPS.explainBatch,
+  );
+  if (!parsed.ok) {
+    if (parsed.reason === "too_large") return bodyTooLargeResponse(parsed.maxBytes);
     return new Response(JSON.stringify({ error: "invalid JSON" }), {
       status: 400,
       headers: { "content-type": "application/json" },
     });
   }
+  const body = parsed.value ?? {};
   const tools = Array.isArray(body.tools)
     ? body.tools.filter((t): t is string => typeof t === "string").slice(0, 100)
     : [];

--- a/dashboard/src/app/api/connections/[connector]/connect/route.ts
+++ b/dashboard/src/app/api/connections/[connector]/connect/route.ts
@@ -1,5 +1,10 @@
 import { bridgeFetch } from "@/lib/bridge";
 import { requireSameOrigin } from "@/lib/csrf";
+import {
+  DASHBOARD_API_BODY_CAPS,
+  bodyTooLargeResponse,
+  readBodyWithCap,
+} from "@/lib/readBodyWithCap";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -24,12 +29,13 @@ export async function POST(
       headers: { "content-type": "application/json" },
     });
   }
+  const read = await readBodyWithCap(req, DASHBOARD_API_BODY_CAPS.connectionsConnect);
+  if (!read.ok) return bodyTooLargeResponse(DASHBOARD_API_BODY_CAPS.connectionsConnect);
   try {
-    const body = await req.text();
     const res = await bridgeFetch(`/connections/${connector}/connect`, {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body,
+      body: read.body,
     });
     const text = await res.text();
     return new Response(text, {

--- a/dashboard/src/app/api/connector-requests/route.ts
+++ b/dashboard/src/app/api/connector-requests/route.ts
@@ -3,6 +3,11 @@ import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
 import { requireSameOrigin } from "@/lib/csrf";
+import {
+  DASHBOARD_API_BODY_CAPS,
+  bodyTooLargeResponse,
+  readJsonWithCap,
+} from "@/lib/readBodyWithCap";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -16,12 +21,15 @@ interface ConnectorRequest {
 export async function POST(req: Request): Promise<Response> {
   const guard = requireSameOrigin(req);
   if (guard) return guard;
-  let body: unknown;
-  try {
-    body = await req.json();
-  } catch {
+  const parsed = await readJsonWithCap<unknown>(
+    req,
+    DASHBOARD_API_BODY_CAPS.connectorRequest,
+  );
+  if (!parsed.ok) {
+    if (parsed.reason === "too_large") return bodyTooLargeResponse(parsed.maxBytes);
     return NextResponse.json({ ok: false, error: "Invalid JSON" }, { status: 400 });
   }
+  const body = parsed.value;
 
   if (typeof body !== "object" || body === null) {
     return NextResponse.json({ ok: false, error: "Invalid request body" }, { status: 400 });

--- a/dashboard/src/app/api/push/subscribe/route.ts
+++ b/dashboard/src/app/api/push/subscribe/route.ts
@@ -1,20 +1,24 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireSameOrigin } from "@/lib/csrf";
 import { addSubscription } from "@/lib/pushStore";
+import {
+  DASHBOARD_API_BODY_CAPS,
+  bodyTooLargeResponse,
+  readJsonWithCap,
+} from "@/lib/readBodyWithCap";
 import type { PushSubscription } from "web-push";
 
 export async function POST(req: NextRequest) {
   const guard = requireSameOrigin(req);
   if (guard) return guard;
 
-  let body: unknown;
-  try {
-    body = await req.json();
-  } catch {
+  const parsed = await readJsonWithCap<unknown>(req, DASHBOARD_API_BODY_CAPS.push);
+  if (!parsed.ok) {
+    if (parsed.reason === "too_large") return bodyTooLargeResponse(parsed.maxBytes);
     return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
   }
 
-  const sub = body as PushSubscription;
+  const sub = parsed.value as PushSubscription;
   if (!sub?.endpoint || !sub?.keys?.p256dh || !sub?.keys?.auth) {
     return NextResponse.json({ error: "Invalid subscription object" }, { status: 400 });
   }

--- a/dashboard/src/app/api/push/unsubscribe/route.ts
+++ b/dashboard/src/app/api/push/unsubscribe/route.ts
@@ -1,16 +1,24 @@
 import { NextRequest, NextResponse } from "next/server";
 import { removeSubscription } from "@/lib/pushStore";
 import { requireSameOrigin } from "@/lib/csrf";
+import {
+  DASHBOARD_API_BODY_CAPS,
+  bodyTooLargeResponse,
+  readJsonWithCap,
+} from "@/lib/readBodyWithCap";
 
 export async function POST(req: NextRequest) {
   const guard = requireSameOrigin(req);
   if (guard) return guard;
-  let body: Record<string, unknown>;
-  try {
-    body = await req.json();
-  } catch {
+  const parsed = await readJsonWithCap<Record<string, unknown>>(
+    req,
+    DASHBOARD_API_BODY_CAPS.push,
+  );
+  if (!parsed.ok) {
+    if (parsed.reason === "too_large") return bodyTooLargeResponse(parsed.maxBytes);
     return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
   }
+  const body = parsed.value ?? {};
 
   const endpoint = typeof body.endpoint === "string" ? body.endpoint : null;
   if (!endpoint) {

--- a/dashboard/src/lib/__tests__/readBodyWithCap.test.ts
+++ b/dashboard/src/lib/__tests__/readBodyWithCap.test.ts
@@ -14,6 +14,7 @@ import {
   BRIDGE_BODY_CAPS,
   bodyTooLargeResponse,
   readBodyWithCap,
+  readJsonWithCap,
 } from "../readBodyWithCap";
 
 function reqWithBody(body: string, contentLength?: string): Request {
@@ -118,5 +119,50 @@ describe("bodyTooLargeResponse", () => {
     const data = (await res.json()) as { error: string; maxBytes: number };
     expect(data.error).toMatch(/too large/i);
     expect(data.maxBytes).toBe(8192);
+  });
+});
+
+describe("readJsonWithCap", () => {
+  it("parses a valid JSON body within the cap", async () => {
+    const result = await readJsonWithCap<{ x: number }>(
+      reqWithBody(JSON.stringify({ x: 42 })),
+      1024,
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toEqual({ x: 42 });
+  });
+
+  it("returns reason=too_large when Content-Length exceeds the cap", async () => {
+    const result = await readJsonWithCap(
+      reqWithBody(JSON.stringify({ x: 1 }), "9999999"),
+      1024,
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe("too_large");
+      if (result.reason === "too_large") expect(result.maxBytes).toBe(1024);
+    }
+  });
+
+  it("returns reason=invalid_json when the body fails to parse", async () => {
+    const result = await readJsonWithCap(reqWithBody("{not json"), 1024);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("invalid_json");
+  });
+
+  it("returns value=undefined for an empty body", async () => {
+    const req = new Request("https://dashboard.local/x", { method: "POST" });
+    const result = await readJsonWithCap(req, 1024);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toBeUndefined();
+  });
+});
+
+describe("DASHBOARD_API_BODY_CAPS sizing", () => {
+  it("each cap is at least 4 KB so legitimate JSON fits with overhead", async () => {
+    const { DASHBOARD_API_BODY_CAPS } = await import("../readBodyWithCap");
+    for (const [key, value] of Object.entries(DASHBOARD_API_BODY_CAPS)) {
+      expect(value, `${key} cap`).toBeGreaterThanOrEqual(4 * 1024);
+    }
   });
 });

--- a/dashboard/src/lib/readBodyWithCap.ts
+++ b/dashboard/src/lib/readBodyWithCap.ts
@@ -19,8 +19,9 @@
  */
 
 /**
- * Per-route body caps. Each value is 2× the corresponding bridge-side
- * cap in src/recipeRoutes.ts (RECIPE_ROUTE_BODY_CAPS) so the dashboard
+ * Per-route body caps for routes that proxy directly through to the
+ * bridge. Each value is 2× the corresponding bridge-side cap in
+ * src/recipeRoutes.ts (RECIPE_ROUTE_BODY_CAPS) so the dashboard
  * proxy rejects only obviously oversized payloads and lets the bridge
  * enforce the exact policy.
  *
@@ -42,6 +43,24 @@ export const BRIDGE_BODY_CAPS = {
 } as const;
 
 export type BridgeBodyCapKey = keyof typeof BRIDGE_BODY_CAPS;
+
+/**
+ * Per-route body caps for dashboard-native API routes (no bridge proxy).
+ * Sized for the legitimate payload shape with generous overhead — these
+ * are not 2×-bridge because there is no bridge cap to mirror.
+ */
+export const DASHBOARD_API_BODY_CAPS = {
+  /** /api/bridge/approval-insights/explain-batch — `{tools: string[]}`, ≤100 strings ≤~50 chars each. */
+  explainBatch: 16 * 1024,
+  /** /api/connector-requests POST — small connector metadata envelope. */
+  connectorRequest: 16 * 1024,
+  /** /api/push/{subscribe,unsubscribe} — PushSubscription JSON; spec is ~2 KB but allow headroom. */
+  push: 16 * 1024,
+  /** /api/connections/[connector]/connect — OAuth start: redirect target + provider state. */
+  connectionsConnect: 32 * 1024,
+} as const;
+
+export type DashboardApiBodyCapKey = keyof typeof DASHBOARD_API_BODY_CAPS;
 
 export type ReadBodyResult =
   | { ok: true; body: string }
@@ -100,4 +119,39 @@ export function bodyTooLargeResponse(maxBytes: number): Response {
     }),
     { status: 413, headers: { "content-type": "application/json" } },
   );
+}
+
+export type ReadJsonResult<T> =
+  | { ok: true; value: T }
+  | { ok: false; reason: "too_large"; maxBytes: number }
+  | { ok: false; reason: "invalid_json" };
+
+/**
+ * Read + parse a JSON request body up to `maxBytes`. Returns a
+ * discriminated result; the caller chooses the response shape (some
+ * routes use `{ok: false, error: ...}`, others use `{error: ...}` —
+ * keeping that decision in the route preserves existing API contracts).
+ *
+ *   const r = await readJsonWithCap<MyShape>(req, CAP);
+ *   if (!r.ok) {
+ *     if (r.reason === "too_large") return bodyTooLargeResponse(r.maxBytes);
+ *     return NextResponse.json({ ok: false, error: "Invalid JSON" }, { status: 400 });
+ *   }
+ *   // use r.value
+ *
+ * Empty bodies parse to `undefined` so callers can opt into "body
+ * required" by checking `value === undefined`.
+ */
+export async function readJsonWithCap<T = unknown>(
+  req: Request,
+  maxBytes: number,
+): Promise<ReadJsonResult<T>> {
+  const read = await readBodyWithCap(req, maxBytes);
+  if (!read.ok) return { ok: false, reason: "too_large", maxBytes };
+  if (read.body.length === 0) return { ok: true, value: undefined as T };
+  try {
+    return { ok: true, value: JSON.parse(read.body) as T };
+  } catch {
+    return { ok: false, reason: "invalid_json" };
+  }
 }


### PR DESCRIPTION
## Summary

PR #285 fixed the bridge-proxy routes that buffered request bodies without a cap. A follow-up sweep across the rest of the dashboard `/api/` tree found 5 more routes with the same body-buffer class plus one missing CSRF check.

## Changes

### New helpers in [dashboard/src/lib/readBodyWithCap.ts](dashboard/src/lib/readBodyWithCap.ts)

- `readJsonWithCap<T>(req, maxBytes)` — returns a discriminated `{ok: true, value} | {ok: false, reason: "too_large", maxBytes} | {ok: false, reason: "invalid_json"}`. Caller composes the response so each route preserves its existing error shape (some routes use `{ok: false, error: ...}`, others `{error: ...}`).
- `DASHBOARD_API_BODY_CAPS` — typed per-route caps for dashboard-native APIs (separate from `BRIDGE_BODY_CAPS` because there is no bridge-side cap to mirror).

### Routes capped

| Route | Cap | Bug class |
|---|---|---|
| `/api/bridge/approval-insights/explain-batch` | 16 KB | `await req.json()` + **missing CSRF** |
| `/api/connector-requests` POST | 16 KB | `await req.json()` |
| `/api/push/subscribe` | 16 KB | `await req.json()` |
| `/api/push/unsubscribe` | 16 KB | `await req.json()` |
| `/api/connections/[connector]/connect` | 32 KB | `await req.text()` |

`explain-batch` was the only mutation route in the dashboard without `requireSameOrigin` — every sibling route already had it. Added in this PR.

## Test plan

- [x] **Helper** — 5 new tests in [readBodyWithCap.test.ts](dashboard/src/lib/__tests__/readBodyWithCap.test.ts): valid JSON parse, 413 reason, 400 reason, empty body → undefined, sizing sanity (every cap ≥ 4 KB).
- [x] **explain-batch** — 5 tests in [explain-batch route.test.ts](dashboard/src/app/api/bridge/approval-insights/explain-batch/__tests__/route.test.ts): cross-site 403, same-origin 200, oversized 413, invalid JSON 400, empty tools fast path.
- [x] **No regressions** — connector-requests test still asserts `{ok: false, error: "Invalid JSON"}` (same shape after refactor) and passes.
- [x] `tsc --noEmit` clean.
- [x] Full dashboard suite: 276 / 276 pass.

## Related

- PR #283 (`/recipes/generate` audit fixes, merged)
- PR #284 (AI YAML round-trip regression tests, merged)
- PR #285 (bridge proxy body caps, merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)