### PR TITLE
fix(recipes): surface truncation warning when 64 KB output cap fires

### DIFF
--- a/src/__tests__/recipeGenerationTruncation.test.ts
+++ b/src/__tests__/recipeGenerationTruncation.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Tests for the model-output truncation telemetry on /recipes/generate.
+ *
+ * Pre-fix the orchestrator silently sliced model output at 64 KB before
+ * any parse / refusal-detection pass — masking the boundary case where
+ * a `# REFUSED:` marker or the closing ```yaml fence got clipped, which
+ * surfaced to the user as the unhelpful "no_yaml_in_output" error
+ * (security audit, 2026-05-07).
+ *
+ * Post-fix, an over-cap output now adds a structured warning to the
+ * response so the dashboard can render "model output was truncated"
+ * instead of "no YAML found".
+ */
+
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../recipesHttp.js", () => ({
+  listInstalledRecipes: vi.fn(),
+  loadRecipeContent: vi.fn(),
+  saveRecipeContent: vi.fn(),
+  saveRecipe: vi.fn(),
+  loadRecipePrompt: vi.fn(),
+  findYamlRecipePath: vi.fn(),
+  findWebhookRecipe: vi.fn(),
+  renderWebhookPrompt: vi.fn(),
+  lintRecipeContent: vi.fn().mockReturnValue({
+    ok: true,
+    errors: [],
+    warnings: [],
+  }),
+}));
+
+vi.mock("../patchworkConfig.js", () => ({
+  loadConfig: vi.fn().mockReturnValue({}),
+  saveConfig: vi.fn(),
+  defaultConfigPath: "/tmp/patchwork.json",
+}));
+
+vi.mock("../activationMetrics.js", () => ({
+  recordRecipeRun: vi.fn(),
+}));
+
+vi.mock("../commands/recipe.js", () => ({
+  runRecipeDryPlan: vi.fn().mockResolvedValue({}),
+}));
+
+function makeServer() {
+  return {
+    recipesFn: null as unknown,
+    loadRecipeContentFn: null as unknown,
+    saveRecipeContentFn: null as unknown,
+    saveRecipeFn: null as unknown,
+    setRecipeEnabledFn: null as unknown,
+    runsFn: null as unknown,
+    runDetailFn: null as unknown,
+    runPlanFn: null as unknown,
+    webhookFn: null as unknown,
+    runRecipeFn: null as unknown,
+    generateRecipeFn: null as unknown,
+  };
+}
+
+function makeRecipeOrchestrator() {
+  return {
+    fire: vi.fn(),
+    isInFlight: vi.fn().mockReturnValue(false),
+    listInFlight: vi.fn().mockReturnValue([]),
+  };
+}
+
+async function makeOrchestrationWithOutput(output: string) {
+  // Existing recipeOrchestration tests intentionally type these mocks
+  // loosely (the constructor takes the full Server / Orchestrator
+  // shapes; replicating those in tests would balloon the mocks). Cast
+  // through `unknown` to satisfy tests:core typecheck without pulling
+  // in the full surface.
+  const mod = (await import("../recipeOrchestration.js")) as unknown as {
+    RecipeOrchestration: new (deps: unknown) => { wireServerFns(): void };
+    MAX_MODEL_OUTPUT_BYTES: number;
+  };
+  const orchestrator = {
+    enqueue: vi.fn(),
+    runAndWait: vi.fn().mockResolvedValue({
+      status: "done",
+      output,
+      errorMessage: null,
+    }),
+  };
+  const server = makeServer();
+  const ro = new mod.RecipeOrchestration({
+    server,
+    getOrchestrator: () => orchestrator,
+    recipeOrchestrator: makeRecipeOrchestrator(),
+    recipeRunLog: null,
+    workdir: "/tmp/ws",
+    logger: {},
+  });
+  ro.wireServerFns();
+  return { server, MAX_MODEL_OUTPUT_BYTES: mod.MAX_MODEL_OUTPUT_BYTES };
+}
+
+describe("/recipes/generate — output truncation telemetry", () => {
+  it("surfaces a warning when model output exceeds the 64 KB cap (security audit, 2026-05-07)", async () => {
+    // Wrap a valid recipe inside a payload larger than the cap so the
+    // truncated portion still leaves a parseable YAML block at the top.
+    const validRecipe =
+      "```yaml\napiVersion: patchwork.sh/v1\nname: ok\ntrigger:\n  type: manual\nsteps:\n  - id: s1\n    agent:\n      prompt: hi\n```\n";
+    const huge = validRecipe + "x".repeat(80 * 1024);
+
+    const { server, MAX_MODEL_OUTPUT_BYTES } =
+      await makeOrchestrationWithOutput(huge);
+    const result = (await (
+      server.generateRecipeFn as unknown as (p: string) => Promise<{
+        ok: boolean;
+        warnings?: string[];
+      }>
+    )("anything")) as { ok: boolean; warnings?: string[] };
+
+    expect(result.warnings).toBeDefined();
+    expect(result.warnings).toEqual(
+      expect.arrayContaining([
+        expect.stringMatching(/truncated|exceeded.*cap/i),
+      ]),
+    );
+    expect(result.warnings?.[0]).toContain(String(MAX_MODEL_OUTPUT_BYTES));
+  });
+
+  it("does NOT add the warning when output is within the cap", async () => {
+    const small =
+      "```yaml\napiVersion: patchwork.sh/v1\nname: ok\ntrigger:\n  type: manual\nsteps:\n  - id: s1\n    agent:\n      prompt: hi\n```";
+    const { server } = await makeOrchestrationWithOutput(small);
+    const result = (await (
+      server.generateRecipeFn as unknown as (p: string) => Promise<{
+        ok: boolean;
+        warnings?: string[];
+      }>
+    )("anything")) as { ok: boolean; warnings?: string[] };
+
+    const truncWarnings =
+      result.warnings?.filter((w) => /truncated|exceeded/i.test(w)) ?? [];
+    expect(truncWarnings).toHaveLength(0);
+  });
+
+  it("surfaces the truncation warning even on `no_yaml_in_output` (the most likely truncation outcome)", async () => {
+    // A 100 KB blob of garbage with no fenced yaml block. Truncation
+    // most often manifests as no_yaml_in_output (the closing fence got
+    // clipped past the cap); the warning lets the dashboard render a
+    // useful message instead of the generic error.
+    const huge = "garbage prose ".repeat(8 * 1024); // ~96 KB
+    const { server } = await makeOrchestrationWithOutput(huge);
+    const result = (await (
+      server.generateRecipeFn as unknown as (p: string) => Promise<{
+        ok: boolean;
+        error?: string;
+        warnings?: string[];
+      }>
+    )("anything")) as {
+      ok: boolean;
+      error?: string;
+      warnings?: string[];
+    };
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe("no_yaml_in_output");
+    expect(result.warnings).toEqual(
+      expect.arrayContaining([
+        expect.stringMatching(/truncated|exceeded.*cap/i),
+      ]),
+    );
+  });
+});

--- a/src/recipeOrchestration.ts
+++ b/src/recipeOrchestration.ts
@@ -482,10 +482,23 @@ export class RecipeOrchestration {
       // ignored the YAML constraint and dumped a megabyte of prose, etc.)
       // doesn't hand a CPU hog to `parseYaml`. 64 KB is ~10× the largest
       // production recipe in `~/.patchwork/recipes/`.
+      //
+      // Surface truncation as a warning (security audit, 2026-05-07): a
+      // silent slice can cut a `# REFUSED:` marker mid-line OR clip the
+      // closing fence of a ```yaml block, masking a refusal as
+      // "no_yaml_in_output". Telemetry on the boundary lets the
+      // dashboard distinguish "model produced 2 MB of garbage" from
+      // "model emitted a 4 KB recipe".
+      const truncationWarnings: string[] = [];
       const cappedOutput =
-        task.output.length > 64 * 1024
-          ? task.output.slice(0, 64 * 1024)
+        task.output.length > MAX_MODEL_OUTPUT_BYTES
+          ? task.output.slice(0, MAX_MODEL_OUTPUT_BYTES)
           : task.output;
+      if (task.output.length > MAX_MODEL_OUTPUT_BYTES) {
+        truncationWarnings.push(
+          `Model output exceeded ${MAX_MODEL_OUTPUT_BYTES}-byte cap (was ${task.output.length} bytes); truncated before parse. Regenerate with a shorter prompt if the recipe was cut off.`,
+        );
+      }
 
       // Honor the abuse-filter clause in the system prompt: when the model
       // refuses an unsafe request it emits `# REFUSED: <reason>`. Don't try
@@ -509,7 +522,15 @@ export class RecipeOrchestration {
 
       const rawYaml = extractYamlBlock(cappedOutput);
       if (!rawYaml) {
-        return { ok: false, error: "no_yaml_in_output" };
+        // Surface truncation here too — it's the most likely cause of a
+        // missing YAML block (the closing ``` got clipped past the cap).
+        return {
+          ok: false,
+          error: "no_yaml_in_output",
+          ...(truncationWarnings.length > 0
+            ? { warnings: truncationWarnings }
+            : {}),
+        };
       }
 
       // Defense-in-depth: also catch a refusal smuggled inside the YAML
@@ -547,7 +568,12 @@ export class RecipeOrchestration {
         return {
           ok: false,
           yaml: normalizedYaml,
-          warnings: [...lint.errors, ...lint.warnings, ...toolIdWarnings],
+          warnings: [
+            ...truncationWarnings,
+            ...lint.errors,
+            ...lint.warnings,
+            ...toolIdWarnings,
+          ],
           error: "invalid_yaml_generated",
         };
       }
@@ -555,7 +581,7 @@ export class RecipeOrchestration {
       return {
         ok: true,
         yaml: normalizedYaml,
-        warnings: [...lint.warnings, ...toolIdWarnings],
+        warnings: [...truncationWarnings, ...lint.warnings, ...toolIdWarnings],
       };
     };
   }
@@ -844,6 +870,14 @@ steps:
 export function sanitizeUserRequestTags(input: string): string {
   return input.replace(/<\s*\/?\s*user_request\b[^>]*>/gi, "[tag_removed]");
 }
+
+/**
+ * Cap on model output bytes before any parse / refusal-detection passes.
+ * 64 KB is ~10× the largest production recipe in `~/.patchwork/recipes/`;
+ * exposed for tests so they can drive the truncation path with a small
+ * synthetic payload.
+ */
+export const MAX_MODEL_OUTPUT_BYTES = 64 * 1024;
 
 const REFUSED_MARKER = /^#\s*REFUSED\b\s*[:\-—]?\s*(.*)$/i;
 // How many top-level (column-0) lines to scan before giving up. A refusal


### PR DESCRIPTION
## Summary

Closes the last open audit-residue item from the 2026-05-07 `/recipes/generate` review. The orchestrator silently sliced model output at 64 KB before any parse or refusal-detection pass — masking the boundary case where a `# REFUSED:` marker or the closing ```yaml fence got clipped, which surfaced to the user as the unhelpful `"no_yaml_in_output"` error instead of a "model output was truncated" explanation.

## Changes

- Extract `MAX_MODEL_OUTPUT_BYTES = 64 * 1024` as a named exported constant (was inline).
- Build `truncationWarnings: string[]` when the slice fires; the warning carries both the cap and the actual byte count so the dashboard can render specifics.
- Plumb the warning into:
  - **success path** (`{ok: true, yaml, warnings}`)
  - **lint-failure path** (`{ok: false, error: "invalid_yaml_generated", warnings}`)
  - **`no_yaml_in_output` path** — most common visible symptom of severe truncation. Pre-fix the user saw a generic error with no hint of *why*.
- Refusal paths intentionally **don't** add the warning — the user already sees the refusal reason; the cap is incidental there.

## Test plan

- [x] 80 KB+ output with valid recipe at the top → `ok: true` AND truncation warning surfaces, contains the cap byte count.
- [x] Small (under-cap) output → no truncation warning.
- [x] 96 KB of garbage → `ok: false`, `error: "no_yaml_in_output"` AND truncation warning surfaces.
- [x] All 4914 bridge tests pass.
- [x] `tsc --noEmit` clean (main + `tsc -p tsconfig.tests.core.json`).
- [x] Biome autoformatted.

## Audit residue status after this lands

| Item | Status |
|---|---|
| Refusal-detection bypass | ✅ #283 |
| `<user_request>` tag-strip bypass | ✅ #283 |
| Dashboard `/recipes/generate` body cap | ✅ #283 |
| Dashboard regression tests for AI YAML round-trip | ✅ #284 |
| Bridge proxy body caps (6 routes) | ✅ #285 |
| Dashboard API body caps (5 routes) + explain-batch CSRF | ✅ #286 |
| Bridge connector body caps (8 routes) | ✅ #287 |
| **64 KB output truncation telemetry** | 🆕 this PR |
| OAuth-keyed rate bucket | deferred (design change, not a fix) |
| YAML alias-bomb explicit `maxAliasCount` | skipped (yaml v2 default is already 100) |
| Refusal scrubbed by yaml round-trip | verified false (refusal checks run before round-trip) |
| Log injection via recipe `name` | mitigated upstream (kebab-case validation excludes control chars) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)