### PR TITLE
fix(recipes): close two prototype-walk vectors in template renderers

### DIFF
--- a/src/recipes/__tests__/parser.test.ts
+++ b/src/recipes/__tests__/parser.test.ts
@@ -92,4 +92,25 @@ describe("renderTemplate", () => {
   it("leaves non-template text untouched", () => {
     expect(renderTemplate("no templates here", {})).toBe("no templates here");
   });
+
+  it("does not walk Object.prototype for top-level keys", () => {
+    // Without the Object.hasOwn guard, `"toString" in {}` is true and
+    // `{}["toString"]` returns Object.prototype.toString — a function whose
+    // source would leak into recipe output via String() coercion.
+    expect(renderTemplate("{{ toString }}", {})).toBe("");
+    expect(renderTemplate("{{ constructor }}", {})).toBe("");
+    expect(renderTemplate("{{ valueOf }}", {})).toBe("");
+    expect(renderTemplate("{{ hasOwnProperty }}", {})).toBe("");
+  });
+
+  it("does not walk Object.prototype on nested paths", () => {
+    expect(renderTemplate("{{ trigger.constructor }}", { trigger: {} })).toBe(
+      "",
+    );
+    expect(
+      renderTemplate("{{ trigger.payload.toString }}", {
+        trigger: { payload: { other: "x" } },
+      }),
+    ).toBe("");
+  });
 });

--- a/src/recipes/__tests__/yamlRunner.test.ts
+++ b/src/recipes/__tests__/yamlRunner.test.ts
@@ -93,6 +93,16 @@ describe("render", () => {
   it("is whitespace-tolerant in braces", () => {
     expect(render("{{ date }}", { date: "2026-04-18" })).toBe("2026-04-18");
   });
+  it("does not walk Object.prototype on dotted paths", () => {
+    // RunContext is flat string-valued; the dotted-path branch only fires
+    // when an intermediate string JSON-parses to an object. Without the
+    // Object.hasOwn guard, the parsed object's prototype keys would resolve
+    // to Object.prototype methods and String() would leak function source.
+    const json = JSON.stringify({ other: "x" });
+    expect(render("{{ obj.toString }}", { obj: json })).toBe("");
+    expect(render("{{ obj.constructor }}", { obj: json })).toBe("");
+    expect(render("{{ obj.valueOf }}", { obj: json })).toBe("");
+  });
 });
 
 // ── validateYamlRecipe ────────────────────────────────────────────────────────

--- a/src/recipes/parser.ts
+++ b/src/recipes/parser.ts
@@ -164,7 +164,10 @@ export function renderTemplate(
     const parts = expr.split(".").map((s) => s.trim());
     let cur: unknown = context;
     for (const p of parts) {
-      if (cur && typeof cur === "object" && p in (cur as object)) {
+      // Object.hasOwn — `in` walks the prototype chain, which would expose
+      // Object.prototype members (toString, constructor, etc.) to attacker-
+      // controllable template paths.
+      if (cur && typeof cur === "object" && Object.hasOwn(cur as object, p)) {
         cur = (cur as Record<string, unknown>)[p];
       } else {
         return "";

--- a/src/recipes/yamlRunner.ts
+++ b/src/recipes/yamlRunner.ts
@@ -875,7 +875,12 @@ export function render(template: string, ctx: RunContext): string {
         }
       }
       if (typeof val !== "object") return "";
-      val = (val as Record<string, unknown>)[part];
+      // Object.hasOwn — bracket access on a Record walks the prototype chain,
+      // which would expose Object.prototype members (toString, constructor,
+      // etc.) to attacker-controllable template paths. String(toString)
+      // renders the function source and leaks it into recipe output.
+      const obj = val as Record<string, unknown>;
+      val = Object.hasOwn(obj, part) ? obj[part] : undefined;
     }
     return val == null
       ? ""


### PR DESCRIPTION
## Summary

Two recipe template renderers walked the prototype chain on attacker-controllable path segments. Both fixed with `Object.hasOwn` and regression-tested.

- **`src/recipes/parser.ts:168`** (`renderTemplate`) — used `p in (cur as object)` as the guard. The `in` operator walks the prototype chain, so `"toString" in {x:1}` is `true`. The bracket access then returned `Object.prototype.toString` and the outer `String()` coercion leaked the function source code into recipe output.
- **`src/recipes/yamlRunner.ts:878`** (`render`, dotted-path JSON walk) — had no guard at all. A recipe template like `{{obj.toString}}` against a string-encoded JSON object resolved to `Object.prototype.toString` and leaked the function source.

Same class as the [templateEngine fix](https://github.com/Oolab-labs/patchwork-os/pull/290) — that PR's property tests surfaced the pattern, this PR sweeps the recipe-template equivalents.

## Why

Recipe templates run against trigger payloads, webhook bodies, and step outputs. Any of those can carry arbitrary string keys. An attacker who can influence template paths or step output keys could read function source via the `toString`/`constructor`/`valueOf`/`hasOwnProperty` chain.

## Test plan

- [x] `npx vitest run src/recipes/__tests__/parser.test.ts src/recipes/__tests__/yamlRunner.test.ts` — 124/124 pass (including 5 new prototype-walk regression tests)
- [x] `npx vitest run src/recipes/__tests__/` — all 511 recipe tests pass
- [x] `npm run typecheck:tests:core` clean
- [x] `npx biome check --write` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)