### PR TITLE
feat(plugins): default-deny on unknown capability tokens at parse time

### DIFF
--- a/documents/plugin-authoring.md
+++ b/documents/plugin-authoring.md
@@ -64,7 +64,7 @@ All fields unless marked optional are required.
 | `entrypoint` | string | Relative path to the JS module that exports `register`. |
 | `toolNamePrefix` | string | **All tool names must start with this prefix.** 2–20 chars, must match `/^[a-zA-Z][a-zA-Z0-9_]{1,19}$/`. Prevents collisions with built-in tools and other plugins. |
 | `minBridgeVersion` | string? | Minimum bridge version (semver). Bridge logs a warning if older, but still loads. |
-| `permissions` | string[]? | Informational only in v1 (e.g. `["network", "filesystem"]`). |
+| `permissions` | string[]? | Capability tokens. Each must appear in `KNOWN_PLUGIN_CAPABILITIES` ([src/pluginLoader.ts](../src/pluginLoader.ts)); manifests with unknown tokens are rejected at load time. The allowlist starts empty and grows deliberately as bridge enforcement for each capability lands. Until then, omit the field. |
 
 ---
 

--- a/examples/plugins/sqlite-library/claude-ide-bridge-plugin.json
+++ b/examples/plugins/sqlite-library/claude-ide-bridge-plugin.json
@@ -4,6 +4,5 @@
   "version": "0.1.0",
   "description": "Live Toolsmithing example: query a personal SQLite library catalog at ~/library.sqlite3",
   "entrypoint": "./index.mjs",
-  "toolNamePrefix": "lib",
-  "permissions": ["filesystem"]
+  "toolNamePrefix": "lib"
 }

--- a/src/__tests__/pluginLoader.test.ts
+++ b/src/__tests__/pluginLoader.test.ts
@@ -241,6 +241,80 @@ describe("loadPlugins", () => {
     ).toBe(true);
   });
 
+  it("loads when permissions field is omitted", async () => {
+    const pluginDir = path.join(tmpDir, "no-permissions");
+    fs.mkdirSync(pluginDir);
+    writePlugin(pluginDir, makeManifest(), validRegisterCode());
+
+    const log = makeLogger();
+    const tools = await loadPlugins([pluginDir], makeConfig(), log);
+
+    expect(tools).toHaveLength(1);
+    expect(log.calls.some((c) => c.level === "warn")).toBe(false);
+  });
+
+  it("loads when permissions field is an empty array", async () => {
+    const pluginDir = path.join(tmpDir, "empty-permissions");
+    fs.mkdirSync(pluginDir);
+    writePlugin(
+      pluginDir,
+      makeManifest({ permissions: [] }),
+      validRegisterCode(),
+    );
+
+    const log = makeLogger();
+    const tools = await loadPlugins([pluginDir], makeConfig(), log);
+
+    expect(tools).toHaveLength(1);
+    expect(log.calls.some((c) => c.level === "warn")).toBe(false);
+  });
+
+  it("rejects manifest with unknown capability tokens (default-deny)", async () => {
+    const pluginDir = path.join(tmpDir, "unknown-permission");
+    fs.mkdirSync(pluginDir);
+    writePlugin(
+      pluginDir,
+      makeManifest({ permissions: ["filesystem"] }),
+      validRegisterCode(),
+    );
+
+    const log = makeLogger();
+    const tools = await loadPlugins([pluginDir], makeConfig(), log);
+
+    expect(tools).toEqual([]);
+    expect(
+      log.calls.some(
+        (c) =>
+          c.level === "warn" &&
+          c.msg.includes("permissions") &&
+          c.msg.includes("filesystem"),
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects manifest where permissions is not an array of strings", async () => {
+    const pluginDir = path.join(tmpDir, "bad-permissions-shape");
+    fs.mkdirSync(pluginDir);
+    writePlugin(
+      pluginDir,
+      makeManifest({ permissions: "filesystem" }),
+      validRegisterCode(),
+    );
+
+    const log = makeLogger();
+    const tools = await loadPlugins([pluginDir], makeConfig(), log);
+
+    expect(tools).toEqual([]);
+    expect(
+      log.calls.some(
+        (c) =>
+          c.level === "warn" &&
+          c.msg.includes("permissions") &&
+          c.msg.includes("array of strings"),
+      ),
+    ).toBe(true);
+  });
+
   it("warns and skips when entrypoint import fails", async () => {
     const pluginDir = path.join(tmpDir, "bad-import");
     fs.mkdirSync(pluginDir);

--- a/src/pluginLoader.ts
+++ b/src/pluginLoader.ts
@@ -77,6 +77,23 @@ function semverGte(actual: string, required: string): boolean {
 
 const PREFIX_RE = /^[a-zA-Z][a-zA-Z0-9_]{1,19}$/;
 
+/**
+ * Allowlist of capability tokens that may appear in a plugin manifest's
+ * `permissions` field. Phase 9 step 1 of the FP roadmap: default-deny on
+ * unknown capability tokens at parse time. The allowlist starts empty and
+ * grows explicitly per future PRs that tie a capability to a runtime
+ * enforcement mechanism — never inferred from what existing plugins happen
+ * to declare.
+ *
+ * Today (informational only): a plugin manifest may omit `permissions`.
+ * Declaring an unknown capability now rejects the manifest at load time,
+ * preventing plugin authors from inventing tokens that won't be enforced
+ * later.
+ *
+ * Exported for tests; the validator below is the only production consumer.
+ */
+export const KNOWN_PLUGIN_CAPABILITIES: readonly string[] = Object.freeze([]);
+
 function validateManifest(
   raw: unknown,
   source: string,
@@ -110,15 +127,29 @@ function validateManifest(
   if (m.version !== undefined && typeof m.version !== "string") {
     return { ok: false, reason: '"version" must be a string if present' };
   }
-  if (
-    m.permissions !== undefined &&
-    (!Array.isArray(m.permissions) ||
-      m.permissions.some((p) => typeof p !== "string"))
-  ) {
-    return {
-      ok: false,
-      reason: '"permissions" must be an array of strings if present',
-    };
+  if (m.permissions !== undefined) {
+    if (
+      !Array.isArray(m.permissions) ||
+      m.permissions.some((p) => typeof p !== "string")
+    ) {
+      return {
+        ok: false,
+        reason: '"permissions" must be an array of strings if present',
+      };
+    }
+    const unknown = (m.permissions as string[]).filter(
+      (p) => !KNOWN_PLUGIN_CAPABILITIES.includes(p),
+    );
+    if (unknown.length > 0) {
+      const known =
+        KNOWN_PLUGIN_CAPABILITIES.length === 0
+          ? "(none yet — see KNOWN_PLUGIN_CAPABILITIES in src/pluginLoader.ts)"
+          : KNOWN_PLUGIN_CAPABILITIES.join(", ");
+      return {
+        ok: false,
+        reason: `"permissions" contains unknown capability tokens: ${unknown.map((u) => `"${u}"`).join(", ")}. Allowed tokens: ${known}.`,
+      };
+    }
   }
 
   void source; // used by caller for log context


### PR DESCRIPTION
## Summary

Phase 9 step 1 of the FP roadmap: prevent capability vocabulary creep by rejecting plugin manifests that declare unknown permission tokens.

Today the manifest parser at [src/pluginLoader.ts:114-122](src/pluginLoader.ts#L114-L122) accepts any string array as `permissions` and only logs the value (no enforcement). That gap means a plugin author can ship a manifest with tokens like `"filesystem"` or `"network"` today and have them silently accepted, then those tokens become de-facto vocabulary that future enforcement has to honor — even if the bridge never deliberately blessed them.

## Changes

- **`KNOWN_PLUGIN_CAPABILITIES`** added to [src/pluginLoader.ts](src/pluginLoader.ts) as an explicit allowlist (initially empty). The list will grow per future PRs that tie a capability to a runtime enforcement mechanism, never inferred from what existing plugins happen to declare.
- **Reject manifests with unknown tokens** — error message names the rejected tokens and the current allowlist, so plugin authors aren't guessing.
- **`examples/plugins/sqlite-library/claude-ide-bridge-plugin.json`** drops its `"permissions": ["filesystem"]` field (the only bridge-internal manifest that declared one; `filesystem` was informational, not enforced).
- **[documents/plugin-authoring.md](documents/plugin-authoring.md)** updated to describe the new behavior.
- **4 new test cases**: manifest with omitted, empty, unknown, and malformed `permissions`.

## Why this ordering

Phase 9 step 1 ships *first*, alone, before any other Phase 9 work (capability ADT migration, enforcement matrix, etc.). Without this gate, plugin authors land manifests now that won't be enforced until later, creating a "land permissions before enforcement exists" attack window.

## Test plan

- [x] `npx vitest run src/__tests__/pluginLoader.test.ts src/__tests__/pluginWatcher.test.ts src/__tests__/pluginWatcher-shadow.test.ts` — 39/39 pass (4 new + 35 existing)
- [x] `npm run typecheck:tests:core` clean
- [x] `npx biome check --write` clean

## Migration notes

- **Existing plugin authors:** if your manifest declares `permissions`, drop the field for now (it was informational anyway). Re-add specific tokens once the corresponding enforcement lands and the token is added to `KNOWN_PLUGIN_CAPABILITIES`.
- **Internal:** the only repo-internal manifest with a `permissions` field was `examples/plugins/sqlite-library`; updated in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)