### PR TITLE
chore: graduate from alpha to beta channel

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - 'v*-alpha*'
+      - 'v*-beta*'
   workflow_dispatch:
     inputs:
       bump:
@@ -33,6 +34,41 @@ jobs:
 
       - name: Publish alpha to npm
         run: npm publish --access public --tag alpha
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Create GitHub pre-release
+        env:
+          GH_TOKEN: ${{ secrets.OOLAB_PAT }}
+        run: |
+          gh release create "${{ github.ref_name }}" \
+            --title "${{ github.ref_name }}" \
+            --prerelease \
+            --generate-notes \
+            --repo Oolab-labs/claude-ide-bridge
+
+  publish-beta:
+    # Mirror of publish-alpha but uses --tag beta. Beta is the active
+    # prerelease channel as of 0.2.0-beta.0; alpha path is retained so
+    # an emergency hotfix to the alpha line can still ship if needed.
+    if: startsWith(github.ref, 'refs/tags/') && contains(github.ref, '-beta')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+          registry-url: 'https://registry.npmjs.org'
+
+      - run: npm ci
+      - run: npm run build
+      - run: npm test -- --reporter=dot
+        timeout-minutes: 5
+
+      - name: Publish beta to npm
+        run: npm publish --access public --tag beta
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Bridge-only docs: [documents/platform-docs.md](documents/platform-docs.md)
 ## 🤖 Patchwork OS — Quick Start
 
 ```bash
-npx patchwork-os@alpha patchwork-init
+npx patchwork-os@beta patchwork-init
 ```
 
 Sets up 5 local recipes, detects Ollama, and opens a terminal dashboard — under 90 seconds.
@@ -223,7 +223,7 @@ Use whichever fits your mental model.
 
 ---
 
-## Tool surface (v0.2.0-alpha.35)
+## Tool surface (v0.2.0-beta.0)
 
 170+ MCP tools across 15 categories. Highlights:
 
@@ -301,7 +301,7 @@ Systemd service and deploy scripts in [`deploy/`](deploy/). Full guide: [docs/re
 | Multi-provider LLM (Claude, Gemini, OpenAI, Grok, Ollama) | **shipped** |
 | Connectors: Linear, Sentry, Slack, Google Calendar, Intercom, HubSpot, Datadog, Stripe | **shipped** |
 | Cross-session memory (traces, handoff notes) | **shipped** |
-| Mobile oversight PWA (push approvals) | **shipped (alpha)** |
+| Mobile oversight PWA (push approvals) | **shipped (beta)** |
 | Community recipe marketplace | Q3 2026 |
 
 ---

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "patchwork-os",
-  "version": "0.2.0-alpha.35",
+  "version": "0.2.0-beta.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "patchwork-os",
-      "version": "0.2.0-alpha.35",
+      "version": "0.2.0-beta.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "patchwork-os",
-  "version": "0.2.0-alpha.37",
+  "version": "0.2.0-beta.0",
   "description": "Your personal AI runtime, local-first. Patchwork OS gives any AI model a consistent set of tools, YAML recipes, a delegation policy with approval queue, and a durable trace memory — all on your machine, all under your policy.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

Bump npm package from `0.2.0-alpha.37` to `0.2.0-beta.0` and add a beta publish path to [.github/workflows/publish-npm.yml](.github/workflows/publish-npm.yml).

The alpha publish path is retained (so an emergency hotfix to the alpha line can still ship if needed); new prerelease publishes ship on the beta channel via `v*-beta*` tag pushes — mirrors the existing alpha flow, just with `--tag beta`.

## Changes

- **`.github/workflows/publish-npm.yml`** — adds `publish-beta` job + adds `'v*-beta*'` to the trigger tag patterns.
- **`package.json` + `package-lock.json`** — version `0.2.0-alpha.37` → `0.2.0-beta.0`.
- **[README.md](README.md)** — install command (`patchwork-os@alpha` → `patchwork-os@beta`), tool surface header (`v0.2.0-alpha.35` → `v0.2.0-beta.0`), Mobile oversight PWA row (`shipped (alpha)` → `shipped (beta)`).

## Intentionally not changed

- **Historical alpha mentions** in `docs/`, planning files, ADRs, and `dashboard/src/lib/mockData.ts` — these describe past plans and demo seed data, not forward-looking install guidance.
- **`dashboard/src/app/marketplace/page.tsx:522`** — `"Install requires bridge v0.2.0-alpha.26+"` — `alpha.26` is when the install endpoint shipped, not a current-version reference. Changing it to `beta.0` would falsely reject working `0.2.0-alpha.26+` setups that have the endpoint.

## Follow-ups (require explicit go-ahead from @kungfuk3nnyyy)

- [ ] Push `v0.2.0-beta.0` tag → triggers the new `publish-beta` job → publishes to npm with `--tag beta`.
- [ ] Run `npm dist-tag add patchwork-os@0.2.0-beta.0 latest` to unstick the `latest` dist-tag (currently pointing at the older `0.2.0-alpha.33`, so `npm install patchwork-os` resolves to a stale build).
- [ ] Separately: push `ext-v1.4.12` tag to publish the already-bumped extension to OpenVSX + VS Code Marketplace (no version change needed; the bump was committed in PR #251 but the workflow only fires on tag push).

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run typecheck:tests:core` clean
- [x] `npm run build` succeeds (banner now shows `0.2.0-beta.0`)
- [x] `npx vitest run src/commands/__tests__/dashboard.test.ts` — 15/15 pass (version-rendering test uses fixture, unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)