### PR TITLE
fix(ci): release-create targets the renamed repo

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -45,7 +45,7 @@ jobs:
             --title "${{ github.ref_name }}" \
             --prerelease \
             --generate-notes \
-            --repo Oolab-labs/claude-ide-bridge
+            --repo Oolab-labs/patchwork-os
 
   publish-beta:
     # Mirror of publish-alpha but uses --tag beta. Beta is the active
@@ -80,7 +80,7 @@ jobs:
             --title "${{ github.ref_name }}" \
             --prerelease \
             --generate-notes \
-            --repo Oolab-labs/claude-ide-bridge
+            --repo Oolab-labs/patchwork-os
 
   publish:
     # Stable publish runs only on manual workflow_dispatch. Without this guard
@@ -146,4 +146,4 @@ jobs:
           gh release create "v${{ env.VERSION }}" \
             --title "v${{ env.VERSION }}" \
             --generate-notes \
-            --repo Oolab-labs/claude-ide-bridge
+            --repo Oolab-labs/patchwork-os


### PR DESCRIPTION
## Summary

Three sites in [.github/workflows/publish-npm.yml](.github/workflows/publish-npm.yml) passed `--repo Oolab-labs/claude-ide-bridge` to `gh release create` — the repo was renamed to `Oolab-labs/patchwork-os` a while back, so release notes would either 404 or land in a stale redirect target.

Spotted while debugging the failed `v0.2.0-beta.0` publish run after the secrets rotation. The `npm publish` step itself is unaffected; only the GitHub-release-creation step is wrong.

## Changes

- `publish-alpha` (line 48): `--repo Oolab-labs/claude-ide-bridge` → `--repo Oolab-labs/patchwork-os`
- `publish-beta` (line 83): same
- `publish` / stable (line 149): same

## Not changed

- **`publish-docker.yml`** — `ghcr.io/oolab-labs/claude-ide-bridge:*` is the published Docker image NAME, not a GitHub repo URL. Renaming would orphan existing pulls. Out of scope; needs its own decision.
- **`ci.yml`** — `claude-ide-bridge-plugin/` is a directory in this repo (Claude Code plugin packaging), not a GitHub repo reference. Correct as-is.
- **`publish-extension.yml`** — has no `gh release create` step, doesn't need this fix.

## Test plan

- [x] `grep "Oolab-labs/" .github/workflows/publish-npm.yml` shows only `Oolab-labs/patchwork-os`
- Will be exercised on the next `v*-alpha*` / `v*-beta*` tag push (or `workflow_dispatch` for stable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)