### PR TITLE
chore(docker): rename ghcr image to patchwork-os + add channel-aware tagging

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -17,19 +17,28 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      # Promote :latest only for stable semver tags (no `-alpha`, `-beta`, `-rc`).
-      # Alpha tags publish only as `:<tag>` and `:alpha`, so `docker pull
-      # ghcr.io/.../claude-ide-bridge:latest` never silently lands on a
-      # prerelease build.
+      # Channel-aware tagging:
+      #   - Stable semver        → `:<tag>` + `:latest`
+      #   - `-alpha` prerelease  → `:<tag>` + `:alpha`
+      #   - `-beta` prerelease   → `:<tag>` + `:beta`
+      #   - `-rc` prerelease     → `:<tag>` + `:rc`
+      # `:latest` is gated on stable so `docker pull ghcr.io/.../patchwork-os:latest`
+      # never silently lands on a prerelease build. Each prerelease channel has
+      # its own moving tag so beta consumers don't get pulled back to alpha.
       - name: Compute Docker tags
         id: tags
         run: |
           REF="${{ github.ref_name }}"
-          TAGS="ghcr.io/oolab-labs/claude-ide-bridge:${REF}"
-          if [[ "$REF" =~ -(alpha|beta|rc) ]]; then
-            TAGS="${TAGS}"$'\n'"ghcr.io/oolab-labs/claude-ide-bridge:alpha"
+          IMAGE="ghcr.io/oolab-labs/patchwork-os"
+          TAGS="${IMAGE}:${REF}"
+          if [[ "$REF" =~ -alpha ]]; then
+            TAGS="${TAGS}"$'\n'"${IMAGE}:alpha"
+          elif [[ "$REF" =~ -beta ]]; then
+            TAGS="${TAGS}"$'\n'"${IMAGE}:beta"
+          elif [[ "$REF" =~ -rc ]]; then
+            TAGS="${TAGS}"$'\n'"${IMAGE}:rc"
           else
-            TAGS="${TAGS}"$'\n'"ghcr.io/oolab-labs/claude-ide-bridge:latest"
+            TAGS="${TAGS}"$'\n'"${IMAGE}:latest"
           fi
           {
             echo 'tags<<EOF'

--- a/docs/demo-setup.md
+++ b/docs/demo-setup.md
@@ -83,7 +83,7 @@ restarts and upgrades.
 ## Upgrading
 
 ```bash
-docker pull ghcr.io/oolab-labs/claude-ide-bridge:latest
+docker pull ghcr.io/oolab-labs/patchwork-os:latest
 docker rm -f claude-ide-bridge
 bash scripts/provision-demo.sh   # re-runs with existing token
 ```

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -58,11 +58,11 @@ Check version compatibility: bridge `getBridgeStatus` reports `extensionPackageV
 
 ### Docker
 ```bash
-docker pull ghcr.io/oolab-labs/claude-ide-bridge:latest
+docker pull ghcr.io/oolab-labs/patchwork-os:latest
 ```
 Pin to a tag for stability:
 ```bash
-docker pull ghcr.io/oolab-labs/claude-ide-bridge:v2.30.1
+docker pull ghcr.io/oolab-labs/patchwork-os:v0.2.0-beta.0
 ```
 
 ---

--- a/documents/headless-quickstart.md
+++ b/documents/headless-quickstart.md
@@ -141,7 +141,7 @@ Under the hood: `quick-task` POSTs to `/launch-quick-task` with bearer auth from
 The official Docker image includes all probes pre-installed:
 
 ```dockerfile
-FROM ghcr.io/oolab-labs/claude-ide-bridge:latest
+FROM ghcr.io/oolab-labs/patchwork-os:latest
 ```
 
 Or build your own Dockerfile (Alpine base):
@@ -166,7 +166,7 @@ docker run \
   -v /your/project:/workspace \
   -v ~/.claude:/root/.claude \
   -p 18765:18765 \
-  ghcr.io/oolab-labs/claude-ide-bridge:latest \
+  ghcr.io/oolab-labs/patchwork-os:latest \
   --workspace /workspace --bind 0.0.0.0
 ```
 
@@ -181,7 +181,7 @@ claude-ide-bridge print-token --port 18765
 ```yaml
 services:
   bridge:
-    image: ghcr.io/oolab-labs/claude-ide-bridge:latest
+    image: ghcr.io/oolab-labs/patchwork-os:latest
     ports:
       - "18765:18765"
     volumes:


### PR DESCRIPTION
## Why

Realigns the Docker image name with the renamed npm package and GitHub repo (was `claude-ide-bridge`, now `patchwork-os` everywhere else).

The old image name is what caused the silent docker-publish failures since the repo rename — the renamed repo doesn't have package-write permissions to the legacy `claude-ide-bridge` ghcr package, so every `v*` tag push has been failing with `permission_denied: write_package`. Surfaced when the `v0.2.0-beta.0` tag fired the docker workflow earlier today.

## Fixes

### Image rename: `ghcr.io/oolab-labs/claude-ide-bridge` → `ghcr.io/oolab-labs/patchwork-os`
The new package is created on first successful push (no manual ghcr setup needed).

### Channel-aware tagging
Previously every prerelease tag (alpha, beta, rc) all promoted to `:alpha`, so a beta publish would have pulled beta consumers back to alpha. Now each channel has its own moving tag:

| Tag pattern | Tags pushed |
|---|---|
| `v0.2.0` (stable) | `:v0.2.0` + `:latest` |
| `v0.2.0-alpha.X` | `:v0.2.0-alpha.X` + `:alpha` |
| `v0.2.0-beta.X` | `:v0.2.0-beta.X` + `:beta` |
| `v0.2.0-rc.X` | `:v0.2.0-rc.X` + `:rc` |

`:latest` remains gated on stable so no prerelease ever lands there.

### Docs updated

- `docs/demo-setup.md` (Upgrading section)
- `docs/migration.md` (Upgrading Steps → Docker section)
- `documents/headless-quickstart.md` (Dockerfile FROM, docker run, compose example)

### Intentionally preserved

- `docs/migration.md:16` "New in v2.29" changelog entry — historical fact; the image WAS at the old name when v2.29 shipped. Changing it would falsify the changelog.

## Migration impact

Users on the old `ghcr.io/oolab-labs/claude-ide-bridge:*` image won't get future updates after this lands. They'll need to update their `FROM`, `docker pull`, and `docker compose` lines to `patchwork-os`. The doc updates in this PR cover that.

## Test plan

After merge, the next `v*-beta*` or `v*-alpha*` tag push will exercise the channel-aware logic. The current `v0.2.0-beta.0` tag's docker run will need to be re-triggered (delete + re-push tag, or `gh workflow run` once the workflow is on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)