### PR TITLE
chore(ci): make alpha/beta publish workflows idempotent

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -32,7 +32,21 @@ jobs:
       - run: npm test -- --reporter=dot
         timeout-minutes: 5
 
+      # Idempotency guard — re-pushing the same tag (e.g. to re-trigger a
+      # sibling workflow on a fixed file) would otherwise fail loudly with
+      # E403 because the version is already on the registry. Skip cleanly
+      # when that's the case.
+      - name: Check if version already published
+        id: npm_check
+        run: |
+          V=$(node -p "require('./package.json').version")
+          if npm view "patchwork-os@$V" version > /dev/null 2>&1; then
+            echo "Already published: patchwork-os@$V — skipping npm publish"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Publish alpha to npm
+        if: steps.npm_check.outputs.skip != 'true'
         run: npm publish --access public --tag alpha
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -41,6 +55,10 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.OOLAB_PAT }}
         run: |
+          if gh release view "${{ github.ref_name }}" --repo Oolab-labs/patchwork-os > /dev/null 2>&1; then
+            echo "Release ${{ github.ref_name }} already exists — skipping"
+            exit 0
+          fi
           gh release create "${{ github.ref_name }}" \
             --title "${{ github.ref_name }}" \
             --prerelease \
@@ -67,7 +85,18 @@ jobs:
       - run: npm test -- --reporter=dot
         timeout-minutes: 5
 
+      # Idempotency guard — see publish-alpha for rationale.
+      - name: Check if version already published
+        id: npm_check
+        run: |
+          V=$(node -p "require('./package.json').version")
+          if npm view "patchwork-os@$V" version > /dev/null 2>&1; then
+            echo "Already published: patchwork-os@$V — skipping npm publish"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Publish beta to npm
+        if: steps.npm_check.outputs.skip != 'true'
         run: npm publish --access public --tag beta
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -76,6 +105,10 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.OOLAB_PAT }}
         run: |
+          if gh release view "${{ github.ref_name }}" --repo Oolab-labs/patchwork-os > /dev/null 2>&1; then
+            echo "Release ${{ github.ref_name }} already exists — skipping"
+            exit 0
+          fi
           gh release create "${{ github.ref_name }}" \
             --title "${{ github.ref_name }}" \
             --prerelease \


### PR DESCRIPTION
## Why

Re-pushing the same tag (e.g. to re-trigger a sibling workflow on a fixed file — which we did three times today during the alpha→beta migration) would otherwise fail two steps loudly:

- **`npm publish`** with `E403 You cannot publish over the previously published versions: 0.2.0-beta.0`
- **`gh release create`** with `release already exists`

Both are harmless but produce red CI runs that hide real failures.

## Fix

Adds two idempotency guards to both `publish-alpha` and `publish-beta`:

1. **Pre-publish check** — `npm view patchwork-os@<version>` to detect if the version is already on the registry; the publish step is gated on the resulting flag.
2. **Pre-release-create check** — `gh release view <tag>` to detect an existing release; the create command is skipped if one exists.

The stable `publish` job (workflow_dispatch only) doesn't need this — `npm version <bump>` always produces a fresh version, and the workflow tags + commits the bump in the same run, so the release tag is always new.

## Test plan

- [x] YAML parses (`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/publish-npm.yml'))"`)
- Will be exercised on the next tag re-push or on a brand-new tag. New-version path: pre-check finds nothing, publish proceeds normally. Re-tag path: pre-check finds the existing version, publish step skipped, workflow exits green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)