### PR TITLE
docs: add SECURITY.md with disclosure policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,65 @@
+# Security Policy
+
+Patchwork OS ships an npm package, IDE extensions, a Docker image, an OAuth 2.0 server for remote MCP connectors, and 19+ connectors that handle credentials and personal data (Slack, Stripe, GitHub, Gmail, calendar, etc.). We take vulnerability reports seriously.
+
+## Supported Versions
+
+The current prerelease channel is **beta** (`patchwork-os@0.2.0-beta.x`).
+
+| Channel | Status | Get fixes? |
+|---|---|---|
+| `beta` (current) | Active | Yes |
+| `alpha` | Frozen at `0.2.0-alpha.37` | Critical only, case-by-case |
+| Older `claude-ide-bridge` v2.x | End-of-life after the rename to Patchwork OS | No |
+
+The npm `latest` dist-tag tracks the active beta. The VS Code / Open VSX extension `claude-ide-bridge-extension@1.4.x` is the supported extension line.
+
+## Reporting a Vulnerability
+
+**Please do not file vulnerabilities as public GitHub issues.**
+
+Use **GitHub private vulnerability reporting**:
+
+1. Go to [the Security tab](https://github.com/Oolab-labs/patchwork-os/security) on this repo.
+2. Click **Report a vulnerability**.
+3. Fill in the form — this creates a private advisory thread visible only to you and the maintainers.
+
+Please include, where possible:
+
+- A description of the issue and the affected surface (CLI, dashboard, bridge endpoint, recipe, connector, plugin).
+- Reproduction steps or a minimal proof-of-concept.
+- Affected versions you've verified (npm version, extension version, ghcr tag).
+- Your assessment of impact and any mitigations a user could apply today.
+
+## What to Expect
+
+- **Acknowledgement**: within 3 business days.
+- **Initial assessment**: within 7 days, including a severity estimate (CVSS 3.1) and our planned response timeline.
+- **Patch + disclosure**: critical issues are typically patched within 14 days; lower severity issues may take longer. We coordinate disclosure with you and credit you in the advisory unless you prefer otherwise.
+
+## Scope
+
+In scope:
+
+- The bridge process (`patchwork-os` / `claude-ide-bridge` npm package).
+- The IDE extensions (`claude-ide-bridge-extension` on VS Code Marketplace + Open VSX, the JetBrains plugin).
+- The Docker image (`ghcr.io/oolab-labs/patchwork-os`).
+- The dashboard (`dashboard/`) including the OAuth approval pages and approval HTTP routes.
+- The plugin loader and any code path that handles connector tokens, recipe YAML, or webhook input.
+
+Out of scope (please do not test against without permission):
+
+- Hosted environments belonging to other users.
+- Third-party services Patchwork connects to (Slack, GitHub, Stripe, etc.) — report those upstream.
+- Self-XSS that requires a user to paste hostile content into their own workspace.
+- Findings against unsupported alpha versions where the same issue is already fixed on `beta`.
+
+## Hardening Notes
+
+For users running Patchwork OS:
+
+- Pin to a specific `0.2.0-beta.X` rather than the floating `@beta` or `@latest` tag if reproducibility matters more than fast updates.
+- The bridge auth token in `~/.claude/ide/<port>.lock` is mode `0o600`; preserve those permissions.
+- The write kill switch (`PATCHWORK_WRITES_DISABLED`) is captured at startup and frozen — do not rely on runtime mutation to disable writes.
+- For remote deployments, always front the bridge with a TLS-terminating reverse proxy. See [docs/remote-access.md](docs/remote-access.md).
+- Plugin manifests with unknown capability tokens are rejected at parse time. The capability allowlist is intentionally empty until specific runtime enforcement is wired per capability — see [src/pluginLoader.ts](src/pluginLoader.ts) for the current allowlist and [docs/adr/](docs/adr/) for the rationale.


### PR DESCRIPTION
## Why

Item 1 from the recent project health audit: there's no documented vulnerability disclosure path, despite the repo shipping an npm package, IDE extensions, a Docker image, OAuth 2.0 server, and 19+ connectors that handle credentials and personal data.

Closes the documentation half of that gap. The other half — actually enabling Dependabot alerts + secret scanning + private vulnerability reporting in the repo Security settings — needs admin permissions I don't have. See "Pairs with" below.

## What this includes

- **Supported version channels** — beta is active, alpha is frozen at `0.2.0-alpha.37`, older `claude-ide-bridge` v2.x is EOL after the rename.
- **Reporting flow** — GitHub private vulnerability reporting only (no email placeholder). Once you enable "Private vulnerability reporting" in repo Security settings, the "Report a vulnerability" button on the linked security tab activates.
- **Response SLAs** — acknowledge in 3 business days, initial assessment in 7, critical patches in 14.
- **In-scope / out-of-scope surfaces** — covers the bridge, extensions, Docker image, dashboard, plugin loader, connector token paths.
- **Hardening notes** — kill switch, lock-file mode, reverse proxy for remote, plugin capability allowlist.

## Pairs with (admin-only follow-ups)

These can't be done from a non-admin token. Run as repo admin:

\`\`\`bash
gh api -X PUT repos/Oolab-labs/patchwork-os/vulnerability-alerts
gh api -X PUT repos/Oolab-labs/patchwork-os/automated-security-fixes
gh api -X PATCH repos/Oolab-labs/patchwork-os \\
  -F 'security_and_analysis[secret_scanning][status]=enabled' \\
  -F 'security_and_analysis[secret_scanning_push_protection][status]=enabled'
\`\`\`

Private vulnerability reporting can be toggled in the GitHub UI: repo → Settings → Code security → Private vulnerability reporting → Enable. (The API endpoint moved between GH versions and this UI toggle is the most reliable.)

## Test plan

- [x] Markdown renders cleanly (no broken links inside the doc itself).

🤖 Generated with [Claude Code](https://claude.com/claude-code)