### PR TITLE
ci: default permissions: contents: read on workflows (closes 11 CodeQL alerts)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/publish-extension.yml
+++ b/.github/workflows/publish-extension.yml
@@ -17,6 +17,9 @@ on:
         type: choice
         options: [patch, minor, major]
 
+permissions:
+  contents: read
+
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -14,6 +14,9 @@ on:
         type: choice
         options: [patch, minor, major]
 
+permissions:
+  contents: read
+
 jobs:
   publish-alpha:
     if: startsWith(github.ref, 'refs/tags/') && contains(github.ref, '-alpha')


### PR DESCRIPTION
## Summary

Adds top-level `permissions: contents: read` to the three workflows that lacked an explicit permissions block:

- `.github/workflows/ci.yml`
- `.github/workflows/publish-extension.yml`
- `.github/workflows/publish-npm.yml`

Per-job overrides in `publish-docker.yml` and `publish-npm.yml`'s `publish` job (which already declare `packages: write` / `contents: write` at job scope) continue to take precedence — those were never flagged.

## Why

CodeQL `actions/missing-workflow-permissions` was firing 11 times. Without an explicit permissions block, GITHUB_TOKEN is granted the repo's default scopes, which is broader than these jobs need.

The `publish-alpha` and `publish-beta` jobs use `OOLAB_PAT` (release creation) and `NPM_TOKEN` (npm publish) — they don't write through GITHUB_TOKEN at all, so `contents: read` is correct.

## Closes

Code scanning alerts #1–#11.

## Test plan

- [x] No code change — workflow YAML only.
- [ ] CI green on this branch (will verify when PR is open).
- [ ] Code scanning alerts #1–#11 transition to "fixed" once this PR is merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)