### PR TITLE
security(dashboard): pin transitive postcss to ^8.5.10 (closes Dependabot #6)

### DIFF
--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -3819,9 +3819,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "funding": [
         {
           "type": "opencollective",
@@ -3838,9 +3838,9 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
@@ -4652,35 +4652,6 @@
         "yaml": {
           "optional": true
         }
-      }
-    },
-    "node_modules/vite/node_modules/postcss": {
-      "version": "8.5.12",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
-      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.11",
-        "picocolors": "^1.1.1",
-        "source-map-js": "^1.2.1"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/vitest": {

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -43,5 +43,8 @@
     "jsdom": "^29.1.0",
     "typescript": "^5.4.0",
     "vitest": "^4.1.5"
+  },
+  "overrides": {
+    "postcss": "^8.5.10"
   }
 }


### PR DESCRIPTION
## Summary

Adds `overrides: { postcss: "^8.5.10" }` to `dashboard/package.json` to bump the transitive `postcss` copies pinned by `next@15.5.15` and `vite`.

## Why this PR exists

Dependabot alert #6 — GHSA-qx2v-qp2m-jg93 / CVE-2026-41305 — XSS via unescaped `</style>` in postcss's CSS stringify output, fixed in postcss 8.5.10.

The direct devDependency was already on a fixed version after #301. The alert kept firing because `next@15.5.15` itself pins `postcss@8.4.31` internally for its SWC/CSS build pipeline. Merging #306 (Next 15 bump) **does not** close this alert on its own — the `overrides` block is what actually swaps the transitive copy.

## Verification

\`\`\`
$ npm ls postcss
patchwork-dashboard@0.1.0-alpha.0
├─┬ @vitejs/plugin-react@6.0.1
│ └─┬ vite@8.0.10
│   └── postcss@8.5.14 deduped
└─┬ next@15.5.15
  └── postcss@8.5.14
\`\`\`

Both transitive copies now resolve to 8.5.14 (well above the 8.5.10 fix).

## Test plan

- [x] `npm install` regenerates lockfile cleanly
- [x] `npm audit` reports 0 vulnerabilities
- [x] `npm test` — 286/286 dashboard tests pass
- [x] `npx tsc --noEmit` — clean
- [ ] Dependabot re-scan transitions alert #6 to "fixed" after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)