### PR TITLE
security: centralize HTTP 500 responses, close 89 stack-trace-exposure alerts

### DIFF
--- a/dashboard/src/app/api/bridge/[...path]/route.ts
+++ b/dashboard/src/app/api/bridge/[...path]/route.ts
@@ -76,8 +76,9 @@ async function proxy(req: NextRequest, segments: string[]): Promise<Response> {
         headers: { Authorization: `Bearer ${lock.authToken}` },
       });
     } catch (err) {
+      console.error("[dashboard /api/bridge] upstream fetch failed:", err);
       return new Response(
-        JSON.stringify({ error: err instanceof Error ? err.message : String(err) }),
+        JSON.stringify({ error: "Bridge unreachable" }),
         { status: 502, headers: { "content-type": "application/json" } },
       );
     }

--- a/scripts/centralize-error-responses.mjs
+++ b/scripts/centralize-error-responses.mjs
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+/**
+ * One-shot codemod: replace every `JSON.stringify({error: err.message})` 500
+ * response in the bridge HTTP route handlers with `respond500(res, err)`.
+ *
+ * Patterns it rewrites (whitespace-tolerant):
+ *
+ *   A. with !res.headersSent guard:
+ *        if (!res.headersSent) {
+ *          res.writeHead(500, { "Content-Type": "application/json" });
+ *          res.end(
+ *            JSON.stringify({
+ *              error: err instanceof Error ? err.message : String(err),
+ *            }),
+ *          );
+ *        }
+ *
+ *   B. without guard:
+ *        res.writeHead(500, { "Content-Type": "application/json" });
+ *        res.end(
+ *          JSON.stringify({
+ *            error: err instanceof Error ? err.message : String(err),
+ *          }),
+ *        );
+ *
+ *   C. one-liner String(err):
+ *        res.writeHead(500, { "Content-Type": "application/json" });
+ *        res.end(JSON.stringify({ error: String(err) }));
+ *
+ *   D. one-liner with !res.headersSent:
+ *        if (!res.headersSent) {
+ *          res.writeHead(500, { "Content-Type": "application/json" });
+ *          res.end(JSON.stringify({ error: String(err) }));
+ *        }
+ *
+ * The error-binding identifier is whatever the catch block names it (`err`,
+ * `e`, `error`, etc.) — captured from the literal in the body.
+ *
+ * After rewriting, the script re-verifies that the file still parses by
+ * shelling out to tsc — but that's left to the caller (run `npm run
+ * typecheck` after).
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+
+const FILES = [
+  "src/connectorRoutes.ts",
+  "src/server.ts",
+  "src/recipeRoutes.ts",
+  "src/inboxRoutes.ts",
+  "src/oauthRoutes.ts",
+];
+
+const ROOT = path.resolve(process.argv[2] ?? ".");
+
+let totalReplacements = 0;
+const importLine = `import { respond500 } from "./httpErrorResponse.js";`;
+
+for (const rel of FILES) {
+  const file = path.join(ROOT, rel);
+  let src = fs.readFileSync(file, "utf-8");
+  let count = 0;
+
+  // Pattern A: with headersSent guard, multi-line stringify
+  // Capture the indentation so we can preserve it.
+  const reA =
+    /(^[ \t]*)if \(!res\.headersSent\) \{\s*\n[ \t]*res\.writeHead\(500, \{ "Content-Type": "application\/json" \}\);\s*\n[ \t]*res\.end\(\s*\n[ \t]*JSON\.stringify\(\{\s*\n[ \t]*error: (\w+) instanceof Error \? \2\.message : String\(\2\),?\s*\n[ \t]*\}\),?\s*\n[ \t]*\);\s*\n[ \t]*\}/gm;
+  src = src.replace(reA, (_m, indent, errVar) => {
+    count++;
+    return `${indent}respond500(res, ${errVar});`;
+  });
+
+  // Pattern B: no guard, multi-line stringify
+  const reB =
+    /(^[ \t]*)res\.writeHead\(500, \{ "Content-Type": "application\/json" \}\);\s*\n[ \t]*res\.end\(\s*\n[ \t]*JSON\.stringify\(\{\s*\n[ \t]*error: (\w+) instanceof Error \? \2\.message : String\(\2\),?\s*\n[ \t]*\}\),?\s*\n[ \t]*\);/gm;
+  src = src.replace(reB, (_m, indent, errVar) => {
+    count++;
+    return `${indent}respond500(res, ${errVar});`;
+  });
+
+  // Pattern D: one-liner with guard
+  const reD =
+    /(^[ \t]*)if \(!res\.headersSent\) \{\s*\n[ \t]*res\.writeHead\(500, \{ "Content-Type": "application\/json" \}\);\s*\n[ \t]*res\.end\(JSON\.stringify\(\{ error: String\((\w+)\) \}\)\);\s*\n[ \t]*\}/gm;
+  src = src.replace(reD, (_m, indent, errVar) => {
+    count++;
+    return `${indent}respond500(res, ${errVar});`;
+  });
+
+  // Pattern C: one-liner without guard
+  const reC =
+    /(^[ \t]*)res\.writeHead\(500, \{ "Content-Type": "application\/json" \}\);\s*\n[ \t]*res\.end\(JSON\.stringify\(\{ error: String\((\w+)\) \}\)\);/gm;
+  src = src.replace(reC, (_m, indent, errVar) => {
+    count++;
+    return `${indent}respond500(res, ${errVar});`;
+  });
+
+  if (count > 0) {
+    // Insert the import if not already present. Walk the file line-by-line
+    // until the import block ends — handles single-line AND multi-line
+    // (`import { … } from "…"` spanning many lines) imports correctly. The
+    // import block ends at the first non-import, non-blank, non-`//` line.
+    if (!src.includes('"./httpErrorResponse.js"')) {
+      const lines = src.split("\n");
+      let depth = 0;
+      let lastImportEnd = -1;
+      for (let i = 0; i < lines.length; i++) {
+        const line = lines[i];
+        if (depth === 0 && /^\s*import\b/.test(line)) {
+          depth += (line.match(/\{/g) ?? []).length;
+          depth -= (line.match(/\}/g) ?? []).length;
+          if (depth === 0) lastImportEnd = i;
+          continue;
+        }
+        if (depth > 0) {
+          depth += (line.match(/\{/g) ?? []).length;
+          depth -= (line.match(/\}/g) ?? []).length;
+          if (depth === 0) lastImportEnd = i;
+          continue;
+        }
+        // Allow blank / comment lines inside the import region without ending
+        // the block — but stop once we see real code.
+        if (/^\s*$/.test(line) || /^\s*\/\//.test(line)) continue;
+        break;
+      }
+      if (lastImportEnd >= 0) {
+        lines.splice(lastImportEnd + 1, 0, importLine);
+      } else {
+        lines.unshift(importLine);
+      }
+      src = lines.join("\n");
+    }
+    fs.writeFileSync(file, src);
+    console.log(`  ${rel}: ${count} replacements`);
+    totalReplacements += count;
+  } else {
+    console.log(`  ${rel}: 0 replacements`);
+  }
+}
+
+console.log(
+  `\nTotal: ${totalReplacements} replacements across ${FILES.length} files`,
+);

--- a/src/__tests__/httpErrorResponse.test.ts
+++ b/src/__tests__/httpErrorResponse.test.ts
@@ -1,0 +1,93 @@
+import type { ServerResponse } from "node:http";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { respond500 } from "../httpErrorResponse.js";
+
+interface MockRes {
+  headersSent: boolean;
+  writableEnded: boolean;
+  statusCode?: number;
+  headers?: Record<string, string>;
+  body?: string;
+  writeHead: (status: number, headers: Record<string, string>) => void;
+  end: (body?: string) => void;
+}
+
+function makeRes(opts: Partial<MockRes> = {}): MockRes & ServerResponse {
+  const res: MockRes = {
+    headersSent: false,
+    writableEnded: false,
+    ...opts,
+    writeHead(status, headers) {
+      this.statusCode = status;
+      this.headers = headers;
+      this.headersSent = true;
+    },
+    end(body) {
+      this.body = body;
+      this.writableEnded = true;
+    },
+  };
+  return res as MockRes & ServerResponse;
+}
+
+describe("respond500", () => {
+  let stderr: ReturnType<typeof vi.spyOn>;
+
+  afterEach(() => {
+    stderr?.mockRestore();
+  });
+
+  it("writes a generic body even when err is a real Error with a sensitive message", () => {
+    stderr = vi.spyOn(console, "error").mockImplementation(() => {});
+    const res = makeRes();
+    const err = new Error("DB password was rotated yesterday: hunter2");
+    respond500(res, err);
+    expect(res.statusCode).toBe(500);
+    expect(res.headers).toEqual({ "Content-Type": "application/json" });
+    expect(res.body).toBe('{"error":"Internal server error"}');
+    expect(res.body).not.toContain("hunter2");
+    expect(res.body).not.toContain("DB password");
+  });
+
+  it("works for non-Error throws (string, undefined, plain object)", () => {
+    stderr = vi.spyOn(console, "error").mockImplementation(() => {});
+    for (const thrown of ["raw string", undefined, { code: "X" }]) {
+      const res = makeRes();
+      respond500(res, thrown);
+      expect(res.body).toBe('{"error":"Internal server error"}');
+      expect(res.statusCode).toBe(500);
+    }
+  });
+
+  it("logs the underlying detail (stack preferred over message) to stderr", () => {
+    stderr = vi.spyOn(console, "error").mockImplementation(() => {});
+    const res = makeRes();
+    const err = new Error("boom");
+    respond500(res, err, "connectors/jira/connect");
+    expect(stderr).toHaveBeenCalledTimes(1);
+    const firstCall = stderr.mock.calls[0];
+    if (!firstCall) throw new Error("expected stderr call");
+    const logged = firstCall[0] as string;
+    expect(logged).toContain("[http-500] connectors/jira/connect:");
+    // Stack format guarantees the message appears too
+    expect(logged).toContain("boom");
+  });
+
+  it("does not double-write headers when headersSent is already true", () => {
+    stderr = vi.spyOn(console, "error").mockImplementation(() => {});
+    const res = makeRes({ headersSent: true, statusCode: 200 });
+    respond500(res, new Error("late failure"));
+    // statusCode unchanged because writeHead was skipped
+    expect(res.statusCode).toBe(200);
+    // body still gets written so the connection terminates cleanly
+    expect(res.body).toBe('{"error":"Internal server error"}');
+  });
+
+  it("does not double-end when writableEnded is already true", () => {
+    stderr = vi.spyOn(console, "error").mockImplementation(() => {});
+    const res = makeRes({ headersSent: true, writableEnded: true });
+    const endSpy = vi.spyOn(res, "end");
+    respond500(res, new Error("after end"));
+    expect(endSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/server-activity.test.ts
+++ b/src/__tests__/server-activity.test.ts
@@ -108,7 +108,10 @@ describe("GET /activity", () => {
     const { status, body } = await get("/activity");
     expect(status).toBe(500);
     const parsed = JSON.parse(body);
-    expect(parsed.error).toContain("log on fire");
+    // Generic body — must not leak the underlying err.message ("log on
+    // fire"). Detail is logged server-side via the respond500 helper.
+    expect(parsed.error).toBe("Internal server error");
+    expect(body).not.toContain("log on fire");
   });
 
   it("requires auth", async () => {

--- a/src/__tests__/server-approval-detail.test.ts
+++ b/src/__tests__/server-approval-detail.test.ts
@@ -130,7 +130,10 @@ describe("GET /approvals/:callId", () => {
     });
     const { status, body } = await get("/approvals/boom");
     expect(status).toBe(500);
-    expect(JSON.parse(body).error).toContain("log on fire");
+    // Generic body — never leaks the underlying err.message ("log on
+    // fire"). Detail is logged server-side via the respond500 helper.
+    expect(JSON.parse(body).error).toBe("Internal server error");
+    expect(body).not.toContain("log on fire");
   });
 
   it("requires auth", async () => {

--- a/src/__tests__/server-connector-error.test.ts
+++ b/src/__tests__/server-connector-error.test.ts
@@ -65,6 +65,9 @@ describe("connector route IIFE error handling", () => {
     // Should get a 500 rather than a hung response
     expect(status).toBe(500);
     const parsed = JSON.parse(body);
-    expect(parsed.error).toContain("connector exploded");
+    // Generic body — never leaks the underlying err.message ("connector
+    // exploded"). Detail is logged server-side via the respond500 helper.
+    expect(parsed.error).toBe("Internal server error");
+    expect(body).not.toContain("connector exploded");
   });
 });

--- a/src/__tests__/server-session-detail.test.ts
+++ b/src/__tests__/server-session-detail.test.ts
@@ -143,7 +143,10 @@ describe("GET /sessions/:id", () => {
     });
     const { status, body } = await get("/sessions/boom");
     expect(status).toBe(500);
-    expect(JSON.parse(body).error).toContain("oh no");
+    // Generic body — never leaks the underlying err.message ("oh no").
+    // Detail is logged server-side via the respond500 helper.
+    expect(JSON.parse(body).error).toBe("Internal server error");
+    expect(body).not.toContain("oh no");
   });
 
   it("requires auth", async () => {

--- a/src/__tests__/server-traces.test.ts
+++ b/src/__tests__/server-traces.test.ts
@@ -131,7 +131,10 @@ describe("GET /traces", () => {
     const { status, body } = await get("/traces");
     expect(status).toBe(500);
     const parsed = JSON.parse(body);
-    expect(parsed.error).toContain("backend on fire");
+    // Generic body — never leaks the underlying err.message ("backend on
+    // fire"). Detail is logged server-side via the respond500 helper.
+    expect(parsed.error).toBe("Internal server error");
+    expect(body).not.toContain("backend on fire");
   });
 
   it("requires auth", async () => {

--- a/src/connectorRoutes.ts
+++ b/src/connectorRoutes.ts
@@ -26,6 +26,7 @@
  */
 
 import type { IncomingMessage, ServerResponse } from "node:http";
+import { respond500 } from "./httpErrorResponse.js";
 import { readBodyWithCap, respond413 } from "./recipeRoutes.js";
 
 /**
@@ -71,14 +72,7 @@ async function dispatchConnectorConnect(
     });
     res.end(result.body);
   } catch (err) {
-    if (!res.headersSent) {
-      res.writeHead(500, { "Content-Type": "application/json" });
-      res.end(
-        JSON.stringify({
-          error: err instanceof Error ? err.message : String(err),
-        }),
-      );
-    }
+    respond500(res, err);
   }
 }
 
@@ -108,14 +102,7 @@ export function tryHandlePublicConnectorRoute(
         });
         res.end(result.body);
       } catch (err) {
-        if (!res.headersSent) {
-          res.writeHead(500, { "Content-Type": "application/json" });
-          res.end(
-            JSON.stringify({
-              error: err instanceof Error ? err.message : String(err),
-            }),
-          );
-        }
+        respond500(res, err);
       }
     })();
     return true;
@@ -136,14 +123,7 @@ export function tryHandlePublicConnectorRoute(
         });
         res.end(result.body);
       } catch (err) {
-        if (!res.headersSent) {
-          res.writeHead(500, { "Content-Type": "application/json" });
-          res.end(
-            JSON.stringify({
-              error: err instanceof Error ? err.message : String(err),
-            }),
-          );
-        }
+        respond500(res, err);
       }
     })();
     return true;
@@ -164,14 +144,7 @@ export function tryHandlePublicConnectorRoute(
         });
         res.end(result.body);
       } catch (err) {
-        if (!res.headersSent) {
-          res.writeHead(500, { "Content-Type": "application/json" });
-          res.end(
-            JSON.stringify({
-              error: err instanceof Error ? err.message : String(err),
-            }),
-          );
-        }
+        respond500(res, err);
       }
     })();
     return true;
@@ -194,14 +167,7 @@ export function tryHandlePublicConnectorRoute(
         });
         res.end(result.body);
       } catch (err) {
-        if (!res.headersSent) {
-          res.writeHead(500, { "Content-Type": "application/json" });
-          res.end(
-            JSON.stringify({
-              error: err instanceof Error ? err.message : String(err),
-            }),
-          );
-        }
+        respond500(res, err);
       }
     })();
     return true;
@@ -224,14 +190,7 @@ export function tryHandlePublicConnectorRoute(
         });
         res.end(result.body);
       } catch (err) {
-        if (!res.headersSent) {
-          res.writeHead(500, { "Content-Type": "application/json" });
-          res.end(
-            JSON.stringify({
-              error: err instanceof Error ? err.message : String(err),
-            }),
-          );
-        }
+        respond500(res, err);
       }
     })();
     return true;
@@ -252,14 +211,7 @@ export function tryHandlePublicConnectorRoute(
         });
         res.end(result.body);
       } catch (err) {
-        if (!res.headersSent) {
-          res.writeHead(500, { "Content-Type": "application/json" });
-          res.end(
-            JSON.stringify({
-              error: err instanceof Error ? err.message : String(err),
-            }),
-          );
-        }
+        respond500(res, err);
       }
     })();
     return true;
@@ -280,14 +232,7 @@ export function tryHandlePublicConnectorRoute(
         });
         res.end(result.body);
       } catch (err) {
-        if (!res.headersSent) {
-          res.writeHead(500, { "Content-Type": "application/json" });
-          res.end(
-            JSON.stringify({
-              error: err instanceof Error ? err.message : String(err),
-            }),
-          );
-        }
+        respond500(res, err);
       }
     })();
     return true;
@@ -320,14 +265,7 @@ export function tryHandleConnectorRoute(
         });
         res.end(result.body);
       } catch (err) {
-        if (!res.headersSent) {
-          res.writeHead(500, { "Content-Type": "application/json" });
-          res.end(
-            JSON.stringify({
-              error: err instanceof Error ? err.message : String(err),
-            }),
-          );
-        }
+        respond500(res, err);
       }
     })();
     return true;
@@ -352,14 +290,7 @@ export function tryHandleConnectorRoute(
           res.end(result.body);
         }
       } catch (err) {
-        if (!res.headersSent) {
-          res.writeHead(500, { "Content-Type": "application/json" });
-          res.end(
-            JSON.stringify({
-              error: err instanceof Error ? err.message : String(err),
-            }),
-          );
-        }
+        respond500(res, err);
       }
     })();
     return true;
@@ -374,14 +305,7 @@ export function tryHandleConnectorRoute(
         });
         res.end(result.body);
       } catch (err) {
-        if (!res.headersSent) {
-          res.writeHead(500, { "Content-Type": "application/json" });
-          res.end(
-            JSON.stringify({
-              error: err instanceof Error ? err.message : String(err),
-            }),
-          );
-        }
+        respond500(res, err);
       }
     })();
     return true;
@@ -399,14 +323,7 @@ export function tryHandleConnectorRoute(
         });
         res.end(result.body);
       } catch (err) {
-        if (!res.headersSent) {
-          res.writeHead(500, { "Content-Type": "application/json" });
-          res.end(
-            JSON.stringify({
-              error: err instanceof Error ? err.message : String(err),
-            }),
-          );
-        }
+        respond500(res, err);
       }
     })();
     return true;
@@ -433,14 +350,7 @@ export function tryHandleConnectorRoute(
           res.end(result.body);
         }
       } catch (err) {
-        if (!res.headersSent) {
-          res.writeHead(500, { "Content-Type": "application/json" });
-          res.end(
-            JSON.stringify({
-              error: err instanceof Error ? err.message : String(err),
-            }),
-          );
-        }
+        respond500(res, err);
       }
     })();
     return true;
@@ -458,14 +368,7 @@ export function tryHandleConnectorRoute(
         });
         res.end(result.body);
       } catch (err) {
-        if (!res.headersSent) {
-          res.writeHead(500, { "Content-Type": "application/json" });
-          res.end(
-            JSON.stringify({
-              error: err instanceof Error ? err.message : String(err),
-            }),
-          );
-        }
+        respond500(res, err);
       }
     })();
     return true;
@@ -482,14 +385,7 @@ export function tryHandleConnectorRoute(
         });
         res.end(result.body);
       } catch (err) {
-        if (!res.headersSent) {
-          res.writeHead(500, { "Content-Type": "application/json" });
-          res.end(
-            JSON.stringify({
-              error: err instanceof Error ? err.message : String(err),
-            }),
-          );
-        }
+        respond500(res, err);
       }
     })();
     return true;
@@ -516,14 +412,7 @@ export function tryHandleConnectorRoute(
           res.end(result.body);
         }
       } catch (err) {
-        if (!res.headersSent) {
-          res.writeHead(500, { "Content-Type": "application/json" });
-          res.end(
-            JSON.stringify({
-              error: err instanceof Error ? err.message : String(err),
-            }),
-          );
-        }
+        respond500(res, err);
       }
     })();
     return true;
@@ -544,14 +433,7 @@ export function tryHandleConnectorRoute(
         });
         res.end(result.body);
       } catch (err) {
-        if (!res.headersSent) {
-          res.writeHead(500, { "Content-Type": "application/json" });
-          res.end(
-            JSON.stringify({
-              error: err instanceof Error ? err.message : String(err),
-            }),
-          );
-        }
+        respond500(res, err);
       }
     })();
     return true;
@@ -569,14 +451,7 @@ export function tryHandleConnectorRoute(
         });
         res.end(result.body);
       } catch (err) {
-        if (!res.headersSent) {
-          res.writeHead(500, { "Content-Type": "application/json" });
-          res.end(
-            JSON.stringify({
-              error: err instanceof Error ? err.message : String(err),
-            }),
-          );
-        }
+        respond500(res, err);
       }
     })();
     return true;
@@ -593,14 +468,7 @@ export function tryHandleConnectorRoute(
         });
         res.end(result.body);
       } catch (err) {
-        if (!res.headersSent) {
-          res.writeHead(500, { "Content-Type": "application/json" });
-          res.end(
-            JSON.stringify({
-              error: err instanceof Error ? err.message : String(err),
-            }),
-          );
-        }
+        respond500(res, err);
       }
     })();
     return true;
@@ -627,14 +495,7 @@ export function tryHandleConnectorRoute(
           res.end(result.body);
         }
       } catch (err) {
-        if (!res.headersSent) {
-          res.writeHead(500, { "Content-Type": "application/json" });
-          res.end(
-            JSON.stringify({
-              error: err instanceof Error ? err.message : String(err),
-            }),
-          );
-        }
+        respond500(res, err);
       }
     })();
     return true;
@@ -655,14 +516,7 @@ export function tryHandleConnectorRoute(
         });
         res.end(result.body);
       } catch (err) {
-        if (!res.headersSent) {
-          res.writeHead(500, { "Content-Type": "application/json" });
-          res.end(
-            JSON.stringify({
-              error: err instanceof Error ? err.message : String(err),
-            }),
-          );
-        }
+        respond500(res, err);
       }
     })();
     return true;
@@ -680,14 +534,7 @@ export function tryHandleConnectorRoute(
         });
         res.end(result.body);
       } catch (err) {
-        if (!res.headersSent) {
-          res.writeHead(500, { "Content-Type": "application/json" });
-          res.end(
-            JSON.stringify({
-              error: err instanceof Error ? err.message : String(err),
-            }),
-          );
-        }
+        respond500(res, err);
       }
     })();
     return true;
@@ -704,14 +551,7 @@ export function tryHandleConnectorRoute(
         });
         res.end(result.body);
       } catch (err) {
-        if (!res.headersSent) {
-          res.writeHead(500, { "Content-Type": "application/json" });
-          res.end(
-            JSON.stringify({
-              error: err instanceof Error ? err.message : String(err),
-            }),
-          );
-        }
+        respond500(res, err);
       }
     })();
     return true;
@@ -737,14 +577,7 @@ export function tryHandleConnectorRoute(
           res.end(result.body);
         }
       } catch (err) {
-        if (!res.headersSent) {
-          res.writeHead(500, { "Content-Type": "application/json" });
-          res.end(
-            JSON.stringify({
-              error: err instanceof Error ? err.message : String(err),
-            }),
-          );
-        }
+        respond500(res, err);
       }
     })();
     return true;
@@ -762,14 +595,7 @@ export function tryHandleConnectorRoute(
         });
         res.end(result.body);
       } catch (err) {
-        if (!res.headersSent) {
-          res.writeHead(500, { "Content-Type": "application/json" });
-          res.end(
-            JSON.stringify({
-              error: err instanceof Error ? err.message : String(err),
-            }),
-          );
-        }
+        respond500(res, err);
       }
     })();
     return true;
@@ -784,14 +610,7 @@ export function tryHandleConnectorRoute(
         });
         res.end(result.body);
       } catch (err) {
-        if (!res.headersSent) {
-          res.writeHead(500, { "Content-Type": "application/json" });
-          res.end(
-            JSON.stringify({
-              error: err instanceof Error ? err.message : String(err),
-            }),
-          );
-        }
+        respond500(res, err);
       }
     })();
     return true;
@@ -819,14 +638,7 @@ export function tryHandleConnectorRoute(
           res.end(result.body);
         }
       } catch (err) {
-        if (!res.headersSent) {
-          res.writeHead(500, { "Content-Type": "application/json" });
-          res.end(
-            JSON.stringify({
-              error: err instanceof Error ? err.message : String(err),
-            }),
-          );
-        }
+        respond500(res, err);
       }
     })();
     return true;
@@ -849,14 +661,7 @@ export function tryHandleConnectorRoute(
         });
         res.end(result.body);
       } catch (err) {
-        if (!res.headersSent) {
-          res.writeHead(500, { "Content-Type": "application/json" });
-          res.end(
-            JSON.stringify({
-              error: err instanceof Error ? err.message : String(err),
-            }),
-          );
-        }
+        respond500(res, err);
       }
     })();
     return true;
@@ -874,14 +679,7 @@ export function tryHandleConnectorRoute(
         });
         res.end(result.body);
       } catch (err) {
-        if (!res.headersSent) {
-          res.writeHead(500, { "Content-Type": "application/json" });
-          res.end(
-            JSON.stringify({
-              error: err instanceof Error ? err.message : String(err),
-            }),
-          );
-        }
+        respond500(res, err);
       }
     })();
     return true;
@@ -901,14 +699,7 @@ export function tryHandleConnectorRoute(
         });
         res.end(result.body);
       } catch (err) {
-        if (!res.headersSent) {
-          res.writeHead(500, { "Content-Type": "application/json" });
-          res.end(
-            JSON.stringify({
-              error: err instanceof Error ? err.message : String(err),
-            }),
-          );
-        }
+        respond500(res, err);
       }
     })();
     return true;
@@ -934,14 +725,7 @@ export function tryHandleConnectorRoute(
           res.end(result.body);
         }
       } catch (err) {
-        if (!res.headersSent) {
-          res.writeHead(500, { "Content-Type": "application/json" });
-          res.end(
-            JSON.stringify({
-              error: err instanceof Error ? err.message : String(err),
-            }),
-          );
-        }
+        respond500(res, err);
       }
     })();
     return true;
@@ -962,14 +746,7 @@ export function tryHandleConnectorRoute(
         });
         res.end(result.body);
       } catch (err) {
-        if (!res.headersSent) {
-          res.writeHead(500, { "Content-Type": "application/json" });
-          res.end(
-            JSON.stringify({
-              error: err instanceof Error ? err.message : String(err),
-            }),
-          );
-        }
+        respond500(res, err);
       }
     })();
     return true;
@@ -987,14 +764,7 @@ export function tryHandleConnectorRoute(
         });
         res.end(result.body);
       } catch (err) {
-        if (!res.headersSent) {
-          res.writeHead(500, { "Content-Type": "application/json" });
-          res.end(
-            JSON.stringify({
-              error: err instanceof Error ? err.message : String(err),
-            }),
-          );
-        }
+        respond500(res, err);
       }
     })();
     return true;
@@ -1009,14 +779,7 @@ export function tryHandleConnectorRoute(
         });
         res.end(result.body);
       } catch (err) {
-        if (!res.headersSent) {
-          res.writeHead(500, { "Content-Type": "application/json" });
-          res.end(
-            JSON.stringify({
-              error: err instanceof Error ? err.message : String(err),
-            }),
-          );
-        }
+        respond500(res, err);
       }
     })();
     return true;
@@ -1044,14 +807,7 @@ export function tryHandleConnectorRoute(
           res.end(result.body);
         }
       } catch (err) {
-        if (!res.headersSent) {
-          res.writeHead(500, { "Content-Type": "application/json" });
-          res.end(
-            JSON.stringify({
-              error: err instanceof Error ? err.message : String(err),
-            }),
-          );
-        }
+        respond500(res, err);
       }
     })();
     return true;
@@ -1072,14 +828,7 @@ export function tryHandleConnectorRoute(
         });
         res.end(result.body);
       } catch (err) {
-        if (!res.headersSent) {
-          res.writeHead(500, { "Content-Type": "application/json" });
-          res.end(
-            JSON.stringify({
-              error: err instanceof Error ? err.message : String(err),
-            }),
-          );
-        }
+        respond500(res, err);
       }
     })();
     return true;
@@ -1097,14 +846,7 @@ export function tryHandleConnectorRoute(
         });
         res.end(result.body);
       } catch (err) {
-        if (!res.headersSent) {
-          res.writeHead(500, { "Content-Type": "application/json" });
-          res.end(
-            JSON.stringify({
-              error: err instanceof Error ? err.message : String(err),
-            }),
-          );
-        }
+        respond500(res, err);
       }
     })();
     return true;
@@ -1121,14 +863,7 @@ export function tryHandleConnectorRoute(
         });
         res.end(result.body);
       } catch (err) {
-        if (!res.headersSent) {
-          res.writeHead(500, { "Content-Type": "application/json" });
-          res.end(
-            JSON.stringify({
-              error: err instanceof Error ? err.message : String(err),
-            }),
-          );
-        }
+        respond500(res, err);
       }
     })();
     return true;
@@ -1158,14 +893,7 @@ export function tryHandleConnectorRoute(
         });
         res.end(result.body);
       } catch (err) {
-        if (!res.headersSent) {
-          res.writeHead(500, { "Content-Type": "application/json" });
-          res.end(
-            JSON.stringify({
-              error: err instanceof Error ? err.message : String(err),
-            }),
-          );
-        }
+        respond500(res, err);
       }
     })();
     return true;
@@ -1182,14 +910,7 @@ export function tryHandleConnectorRoute(
         });
         res.end(result.body);
       } catch (err) {
-        if (!res.headersSent) {
-          res.writeHead(500, { "Content-Type": "application/json" });
-          res.end(
-            JSON.stringify({
-              error: err instanceof Error ? err.message : String(err),
-            }),
-          );
-        }
+        respond500(res, err);
       }
     })();
     return true;
@@ -1221,14 +942,7 @@ export function tryHandleConnectorRoute(
         });
         res.end(result.body);
       } catch (err) {
-        if (!res.headersSent) {
-          res.writeHead(500, { "Content-Type": "application/json" });
-          res.end(
-            JSON.stringify({
-              error: err instanceof Error ? err.message : String(err),
-            }),
-          );
-        }
+        respond500(res, err);
       }
     })();
     return true;
@@ -1248,14 +962,7 @@ export function tryHandleConnectorRoute(
         });
         res.end(result.body);
       } catch (err) {
-        if (!res.headersSent) {
-          res.writeHead(500, { "Content-Type": "application/json" });
-          res.end(
-            JSON.stringify({
-              error: err instanceof Error ? err.message : String(err),
-            }),
-          );
-        }
+        respond500(res, err);
       }
     })();
     return true;
@@ -1285,14 +992,7 @@ export function tryHandleConnectorRoute(
         });
         res.end(result.body);
       } catch (err) {
-        if (!res.headersSent) {
-          res.writeHead(500, { "Content-Type": "application/json" });
-          res.end(
-            JSON.stringify({
-              error: err instanceof Error ? err.message : String(err),
-            }),
-          );
-        }
+        respond500(res, err);
       }
     })();
     return true;
@@ -1312,14 +1012,7 @@ export function tryHandleConnectorRoute(
         });
         res.end(result.body);
       } catch (err) {
-        if (!res.headersSent) {
-          res.writeHead(500, { "Content-Type": "application/json" });
-          res.end(
-            JSON.stringify({
-              error: err instanceof Error ? err.message : String(err),
-            }),
-          );
-        }
+        respond500(res, err);
       }
     })();
     return true;
@@ -1349,14 +1042,7 @@ export function tryHandleConnectorRoute(
         });
         res.end(result.body);
       } catch (err) {
-        if (!res.headersSent) {
-          res.writeHead(500, { "Content-Type": "application/json" });
-          res.end(
-            JSON.stringify({
-              error: err instanceof Error ? err.message : String(err),
-            }),
-          );
-        }
+        respond500(res, err);
       }
     })();
     return true;
@@ -1376,14 +1062,7 @@ export function tryHandleConnectorRoute(
         });
         res.end(result.body);
       } catch (err) {
-        if (!res.headersSent) {
-          res.writeHead(500, { "Content-Type": "application/json" });
-          res.end(
-            JSON.stringify({
-              error: err instanceof Error ? err.message : String(err),
-            }),
-          );
-        }
+        respond500(res, err);
       }
     })();
     return true;
@@ -1413,14 +1092,7 @@ export function tryHandleConnectorRoute(
         });
         res.end(result.body);
       } catch (err) {
-        if (!res.headersSent) {
-          res.writeHead(500, { "Content-Type": "application/json" });
-          res.end(
-            JSON.stringify({
-              error: err instanceof Error ? err.message : String(err),
-            }),
-          );
-        }
+        respond500(res, err);
       }
     })();
     return true;
@@ -1440,14 +1112,7 @@ export function tryHandleConnectorRoute(
         });
         res.end(result.body);
       } catch (err) {
-        if (!res.headersSent) {
-          res.writeHead(500, { "Content-Type": "application/json" });
-          res.end(
-            JSON.stringify({
-              error: err instanceof Error ? err.message : String(err),
-            }),
-          );
-        }
+        respond500(res, err);
       }
     })();
     return true;
@@ -1477,14 +1142,7 @@ export function tryHandleConnectorRoute(
         });
         res.end(result.body);
       } catch (err) {
-        if (!res.headersSent) {
-          res.writeHead(500, { "Content-Type": "application/json" });
-          res.end(
-            JSON.stringify({
-              error: err instanceof Error ? err.message : String(err),
-            }),
-          );
-        }
+        respond500(res, err);
       }
     })();
     return true;
@@ -1504,14 +1162,7 @@ export function tryHandleConnectorRoute(
         });
         res.end(result.body);
       } catch (err) {
-        if (!res.headersSent) {
-          res.writeHead(500, { "Content-Type": "application/json" });
-          res.end(
-            JSON.stringify({
-              error: err instanceof Error ? err.message : String(err),
-            }),
-          );
-        }
+        respond500(res, err);
       }
     })();
     return true;
@@ -1543,14 +1194,7 @@ export function tryHandleConnectorRoute(
         });
         res.end(result.body);
       } catch (err) {
-        if (!res.headersSent) {
-          res.writeHead(500, { "Content-Type": "application/json" });
-          res.end(
-            JSON.stringify({
-              error: err instanceof Error ? err.message : String(err),
-            }),
-          );
-        }
+        respond500(res, err);
       }
     })();
     return true;
@@ -1570,14 +1214,7 @@ export function tryHandleConnectorRoute(
         });
         res.end(result.body);
       } catch (err) {
-        if (!res.headersSent) {
-          res.writeHead(500, { "Content-Type": "application/json" });
-          res.end(
-            JSON.stringify({
-              error: err instanceof Error ? err.message : String(err),
-            }),
-          );
-        }
+        respond500(res, err);
       }
     })();
     return true;
@@ -1607,14 +1244,7 @@ export function tryHandleConnectorRoute(
         });
         res.end(result.body);
       } catch (err) {
-        if (!res.headersSent) {
-          res.writeHead(500, { "Content-Type": "application/json" });
-          res.end(
-            JSON.stringify({
-              error: err instanceof Error ? err.message : String(err),
-            }),
-          );
-        }
+        respond500(res, err);
       }
     })();
     return true;
@@ -1631,14 +1261,7 @@ export function tryHandleConnectorRoute(
         });
         res.end(result.body);
       } catch (err) {
-        if (!res.headersSent) {
-          res.writeHead(500, { "Content-Type": "application/json" });
-          res.end(
-            JSON.stringify({
-              error: err instanceof Error ? err.message : String(err),
-            }),
-          );
-        }
+        respond500(res, err);
       }
     })();
     return true;
@@ -1665,14 +1288,7 @@ export function tryHandleConnectorRoute(
           res.end(result.body);
         }
       } catch (err) {
-        if (!res.headersSent) {
-          res.writeHead(500, { "Content-Type": "application/json" });
-          res.end(
-            JSON.stringify({
-              error: err instanceof Error ? err.message : String(err),
-            }),
-          );
-        }
+        respond500(res, err);
       }
     })();
     return true;
@@ -1695,14 +1311,7 @@ export function tryHandleConnectorRoute(
         });
         res.end(result.body);
       } catch (err) {
-        if (!res.headersSent) {
-          res.writeHead(500, { "Content-Type": "application/json" });
-          res.end(
-            JSON.stringify({
-              error: err instanceof Error ? err.message : String(err),
-            }),
-          );
-        }
+        respond500(res, err);
       }
     })();
     return true;
@@ -1722,14 +1331,7 @@ export function tryHandleConnectorRoute(
         });
         res.end(result.body);
       } catch (err) {
-        if (!res.headersSent) {
-          res.writeHead(500, { "Content-Type": "application/json" });
-          res.end(
-            JSON.stringify({
-              error: err instanceof Error ? err.message : String(err),
-            }),
-          );
-        }
+        respond500(res, err);
       }
     })();
     return true;
@@ -1749,14 +1351,7 @@ export function tryHandleConnectorRoute(
         });
         res.end(result.body);
       } catch (err) {
-        if (!res.headersSent) {
-          res.writeHead(500, { "Content-Type": "application/json" });
-          res.end(
-            JSON.stringify({
-              error: err instanceof Error ? err.message : String(err),
-            }),
-          );
-        }
+        respond500(res, err);
       }
     })();
     return true;
@@ -1783,14 +1378,7 @@ export function tryHandleConnectorRoute(
           res.end(result.body);
         }
       } catch (err) {
-        if (!res.headersSent) {
-          res.writeHead(500, { "Content-Type": "application/json" });
-          res.end(
-            JSON.stringify({
-              error: err instanceof Error ? err.message : String(err),
-            }),
-          );
-        }
+        respond500(res, err);
       }
     })();
     return true;
@@ -1813,14 +1401,7 @@ export function tryHandleConnectorRoute(
         });
         res.end(result.body);
       } catch (err) {
-        if (!res.headersSent) {
-          res.writeHead(500, { "Content-Type": "application/json" });
-          res.end(
-            JSON.stringify({
-              error: err instanceof Error ? err.message : String(err),
-            }),
-          );
-        }
+        respond500(res, err);
       }
     })();
     return true;
@@ -1838,14 +1419,7 @@ export function tryHandleConnectorRoute(
         });
         res.end(result.body);
       } catch (err) {
-        if (!res.headersSent) {
-          res.writeHead(500, { "Content-Type": "application/json" });
-          res.end(
-            JSON.stringify({
-              error: err instanceof Error ? err.message : String(err),
-            }),
-          );
-        }
+        respond500(res, err);
       }
     })();
     return true;
@@ -1865,14 +1439,7 @@ export function tryHandleConnectorRoute(
         });
         res.end(result.body);
       } catch (err) {
-        if (!res.headersSent) {
-          res.writeHead(500, { "Content-Type": "application/json" });
-          res.end(
-            JSON.stringify({
-              error: err instanceof Error ? err.message : String(err),
-            }),
-          );
-        }
+        respond500(res, err);
       }
     })();
     return true;

--- a/src/httpErrorResponse.ts
+++ b/src/httpErrorResponse.ts
@@ -1,0 +1,54 @@
+/**
+ * Centralized HTTP error responder for the bridge's plain-`http` route
+ * handlers.
+ *
+ * Replaces the ~96 inline `res.end(JSON.stringify({error: err.message}))`
+ * blocks scattered across `server.ts`, `connectorRoutes.ts`,
+ * `recipeRoutes.ts`, `inboxRoutes.ts`, and `oauthRoutes.ts` — every one of
+ * which leaked the underlying error message (and sometimes a stack frame
+ * via `Error.toString`) to the network. CodeQL flagged each as
+ * `js/stack-trace-exposure` (89 open alerts at the time of writing).
+ *
+ * Contract:
+ *   - Always returns a generic `{error: "Internal server error"}` body, never
+ *     the underlying error.message — even for non-Error throws.
+ *   - Logs the full detail (stack preferred, message fallback, String(err)
+ *     last) to stderr with an optional context label so post-incident
+ *     debugging is unaffected.
+ *   - Idempotent on `headersSent` / `writableEnded` so callers nested inside
+ *     other try/catch blocks can safely call this without re-throwing.
+ *
+ * Note: the dashboard's Next.js route handlers (`dashboard/src/app/api/**`)
+ * are a separate runtime — they use `NextResponse.json(...)` and have their
+ * own (smaller) leak surface; this helper is bridge-side only.
+ */
+
+import type { ServerResponse } from "node:http";
+
+const GENERIC_BODY = JSON.stringify({ error: "Internal server error" });
+
+/**
+ * Write a generic 500 response and log the underlying error detail
+ * server-side.
+ *
+ * @param res     The Node http response to write to.
+ * @param err     The thrown value caught by the route handler.
+ * @param context Optional short tag identifying the route ("recipes/lint",
+ *                "connectors/jira/connect", etc.). Surfaces in the server
+ *                log only — never sent to the client.
+ */
+export function respond500(
+  res: ServerResponse,
+  err: unknown,
+  context?: string,
+): void {
+  const detail =
+    err instanceof Error ? (err.stack ?? err.message) : String(err);
+  console.error(`[http-500]${context ? ` ${context}` : ""}: ${detail}`);
+  if (!res.headersSent) {
+    res.writeHead(500, { "Content-Type": "application/json" });
+  }
+  if (!res.writableEnded) {
+    res.end(GENERIC_BODY);
+  }
+}

--- a/src/inboxRoutes.ts
+++ b/src/inboxRoutes.ts
@@ -18,6 +18,7 @@ import { existsSync } from "node:fs";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import os from "node:os";
 import path from "node:path";
+import { respond500 } from "./httpErrorResponse.js";
 
 /**
  * Try to handle an `/inbox` or `/inbox/<filename>.md` route. Returns true
@@ -74,12 +75,7 @@ export function tryHandleInboxRoute(
         res.writeHead(200, { "Content-Type": "application/json" });
         res.end(JSON.stringify({ items }));
       } catch (err) {
-        res.writeHead(500, { "Content-Type": "application/json" });
-        res.end(
-          JSON.stringify({
-            error: err instanceof Error ? err.message : String(err),
-          }),
-        );
+        respond500(res, err);
       }
     })();
     return true;
@@ -121,12 +117,7 @@ export function tryHandleInboxRoute(
           res.writeHead(404, { "Content-Type": "application/json" });
           res.end(JSON.stringify({ error: "Not found" }));
         } else {
-          res.writeHead(500, { "Content-Type": "application/json" });
-          res.end(
-            JSON.stringify({
-              error: err instanceof Error ? err.message : String(err),
-            }),
-          );
+          respond500(res, err);
         }
       }
     })();

--- a/src/oauthRoutes.ts
+++ b/src/oauthRoutes.ts
@@ -18,6 +18,7 @@
  */
 
 import type { IncomingMessage, ServerResponse } from "node:http";
+import { respond500 } from "./httpErrorResponse.js";
 import type { OAuthServer } from "./oauth.js";
 
 export interface OAuthRouteDeps {
@@ -96,10 +97,7 @@ export function tryHandleOAuthRoute(
   if (parsedUrl.pathname === "/oauth/register") {
     if (deps.oauthServer) {
       deps.oauthServer.handleRegister(req, res).catch((err) => {
-        if (!res.headersSent) {
-          res.writeHead(500, { "Content-Type": "application/json" });
-          res.end(JSON.stringify({ error: String(err) }));
-        }
+        respond500(res, err);
       });
     } else {
       res.writeHead(404, { "Content-Type": "text/plain" });
@@ -112,10 +110,7 @@ export function tryHandleOAuthRoute(
   if (parsedUrl.pathname === "/oauth/token" && req.method === "POST") {
     if (deps.oauthServer) {
       deps.oauthServer.handleToken(req, res).catch((err) => {
-        if (!res.headersSent) {
-          res.writeHead(500, { "Content-Type": "application/json" });
-          res.end(JSON.stringify({ error: String(err) }));
-        }
+        respond500(res, err);
       });
     } else {
       res.writeHead(404, { "Content-Type": "text/plain" });

--- a/src/recipeRoutes.ts
+++ b/src/recipeRoutes.ts
@@ -39,6 +39,7 @@ import {
   refillBucket,
   type TokenBucketState,
 } from "./fp/tokenBucket.js";
+import { respond500 } from "./httpErrorResponse.js";
 import type { RecipeDraft } from "./recipesHttp.js";
 import { validateSafeUrl } from "./ssrfGuard.js";
 
@@ -513,12 +514,7 @@ export function tryHandleRecipeRoute(
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({ metrics, summary }));
     } catch (err) {
-      res.writeHead(500, { "Content-Type": "application/json" });
-      res.end(
-        JSON.stringify({
-          error: err instanceof Error ? err.message : String(err),
-        }),
-      );
+      respond500(res, err);
     }
     return true;
   }
@@ -544,12 +540,7 @@ export function tryHandleRecipeRoute(
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({ runs }));
     } catch (err) {
-      res.writeHead(500, { "Content-Type": "application/json" });
-      res.end(
-        JSON.stringify({
-          error: err instanceof Error ? err.message : String(err),
-        }),
-      );
+      respond500(res, err);
     }
     return true;
   }
@@ -569,12 +560,7 @@ export function tryHandleRecipeRoute(
         res.end(JSON.stringify({ run }));
       }
     } catch (err) {
-      res.writeHead(500, { "Content-Type": "application/json" });
-      res.end(
-        JSON.stringify({
-          error: err instanceof Error ? err.message : String(err),
-        }),
-      );
+      respond500(res, err);
     }
     return true;
   }
@@ -607,9 +593,7 @@ export function tryHandleRecipeRoute(
         }
         res.end(JSON.stringify(result));
       } catch (err) {
-        const msg = err instanceof Error ? err.message : String(err);
-        res.writeHead(500, { "Content-Type": "application/json" });
-        res.end(JSON.stringify({ error: msg }));
+        respond500(res, err, "runs/:seq detail");
       }
     })();
     return true;
@@ -642,10 +626,13 @@ export function tryHandleRecipeRoute(
         res.end(JSON.stringify({ plan }));
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
-        const status =
-          msg.includes("not found") || msg.includes("ENOENT") ? 404 : 500;
-        res.writeHead(status, { "Content-Type": "application/json" });
-        res.end(JSON.stringify({ error: msg }));
+        const isNotFound = msg.includes("not found") || msg.includes("ENOENT");
+        if (isNotFound) {
+          res.writeHead(404, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ error: "Run not found" }));
+        } else {
+          respond500(res, err, "recipes plan");
+        }
       }
     })();
     return true;
@@ -724,11 +711,12 @@ export function tryHandleRecipeRoute(
         res.writeHead(status, { "Content-Type": "application/json" });
         res.end(JSON.stringify(result));
       } catch (err) {
+        console.error(`[recipes/install] internal error:`, err);
         res.writeHead(500, { "Content-Type": "application/json" });
         res.end(
           JSON.stringify({
             ok: false,
-            error: err instanceof Error ? err.message : String(err),
+            error: "Internal server error",
           }),
         );
       }
@@ -939,10 +927,13 @@ export function tryHandleRecipeRoute(
         res.end(JSON.stringify({ plan }));
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
-        const status =
-          msg.includes("not found") || msg.includes("ENOENT") ? 404 : 500;
-        res.writeHead(status, { "Content-Type": "application/json" });
-        res.end(JSON.stringify({ error: msg }));
+        const isNotFound = msg.includes("not found") || msg.includes("ENOENT");
+        if (isNotFound) {
+          res.writeHead(404, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ error: "Run not found" }));
+        } else {
+          respond500(res, err, "recipes plan");
+        }
       }
     })();
     return true;
@@ -1107,11 +1098,12 @@ export function tryHandleRecipeRoute(
         res.writeHead(httpStatus, { "Content-Type": "application/json" });
         res.end(JSON.stringify(result));
       } catch (err) {
+        console.error(`[recipes/install] internal error:`, err);
         res.writeHead(500, { "Content-Type": "application/json" });
         res.end(
           JSON.stringify({
             ok: false,
-            error: err instanceof Error ? err.message : String(err),
+            error: "Internal server error",
           }),
         );
       }
@@ -1125,12 +1117,7 @@ export function tryHandleRecipeRoute(
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify(data));
     } catch (err) {
-      res.writeHead(500, { "Content-Type": "application/json" });
-      res.end(
-        JSON.stringify({
-          error: err instanceof Error ? err.message : String(err),
-        }),
-      );
+      respond500(res, err);
     }
     return true;
   }
@@ -1152,11 +1139,12 @@ export function tryHandleRecipeRoute(
         res.writeHead(200, { "Content-Type": "application/json" });
         res.end(JSON.stringify(templatesCache));
       } catch (err) {
+        console.error(`[recipes/install] upstream error:`, err);
         res.writeHead(502, { "Content-Type": "application/json" });
         res.end(
           JSON.stringify({
             ok: false,
-            error: err instanceof Error ? err.message : String(err),
+            error: "Upstream fetch failed",
           }),
         );
       }
@@ -1237,11 +1225,15 @@ export function tryHandleRecipeRoute(
             });
           } catch (err) {
             clearTimeout(timeout);
+            console.error(
+              `[recipes/install] bundle manifest fetch failed:`,
+              err,
+            );
             res.writeHead(502, { "Content-Type": "application/json" });
             res.end(
               JSON.stringify({
                 ok: false,
-                error: `Bundle manifest fetch failed: ${err instanceof Error ? err.message : String(err)}`,
+                error: "Bundle manifest fetch failed",
                 code: "bundle_fetch_network_error",
               }),
             );
@@ -1284,11 +1276,15 @@ export function tryHandleRecipeRoute(
           try {
             manifest = JSON.parse(Buffer.from(manifestBuf).toString("utf-8"));
           } catch (err) {
+            console.error(
+              `[recipes/install] bundle manifest invalid JSON:`,
+              err,
+            );
             res.writeHead(502, { "Content-Type": "application/json" });
             res.end(
               JSON.stringify({
                 ok: false,
-                error: `Bundle manifest is not valid JSON: ${err instanceof Error ? err.message : String(err)}`,
+                error: "Bundle manifest is not valid JSON",
                 code: "bundle_manifest_invalid_json",
               }),
             );
@@ -1375,9 +1371,10 @@ export function tryHandleRecipeRoute(
               }
             } catch (err) {
               clearTimeout(recipeTimeout);
+              console.error(`[recipes/install] recipe "${r}" failed:`, err);
               failures.push({
                 name: r,
-                error: err instanceof Error ? err.message : String(err),
+                error: "Recipe install failed",
               });
             }
           }
@@ -1517,12 +1514,13 @@ export function tryHandleRecipeRoute(
           });
         } catch (err) {
           clearTimeout(fetchTimeout);
+          console.error(`[recipes/install] fetch failed:`, err);
           // Network-level error → 502 (upstream unreachable), not 500.
           res.writeHead(502, { "Content-Type": "application/json" });
           res.end(
             JSON.stringify({
               ok: false,
-              error: `Fetch failed: ${err instanceof Error ? err.message : String(err)}`,
+              error: "Fetch failed",
               code: "fetch_network_error",
             }),
           );
@@ -1618,11 +1616,12 @@ export function tryHandleRecipeRoute(
         res.end(JSON.stringify({ ok: true, ...result }));
       } catch (err) {
         // Truly unexpected — installer crash, manifest validation throw, etc.
+        console.error(`[recipes/install] internal install error:`, err);
         res.writeHead(500, { "Content-Type": "application/json" });
         res.end(
           JSON.stringify({
             ok: false,
-            error: err instanceof Error ? err.message : String(err),
+            error: "Internal server error",
             code: "install_internal_error",
           }),
         );

--- a/src/server.ts
+++ b/src/server.ts
@@ -12,6 +12,7 @@ import {
 } from "./connectorRoutes.js";
 import { timingSafeStringEqual } from "./crypto.js";
 import { renderDashboardHtml } from "./dashboard.js";
+import { respond500 } from "./httpErrorResponse.js";
 import { tryHandleInboxRoute } from "./inboxRoutes.js";
 import type { Logger } from "./logger.js";
 import { tryHandleMcpRoute } from "./mcpRoutes.js";
@@ -575,12 +576,7 @@ export class Server extends EventEmitter<ServerEvents> {
           });
           res.end(JSON.stringify(body, null, 2));
         } catch (err) {
-          res.writeHead(500, { "Content-Type": "application/json" });
-          res.end(
-            JSON.stringify({
-              error: err instanceof Error ? err.message : String(err),
-            }),
-          );
+          respond500(res, err);
         }
         return;
       }
@@ -634,12 +630,7 @@ export class Server extends EventEmitter<ServerEvents> {
           });
           res.end(body);
         } catch (err) {
-          res.writeHead(500, { "Content-Type": "application/json" });
-          res.end(
-            JSON.stringify({
-              error: err instanceof Error ? err.message : String(err),
-            }),
-          );
+          respond500(res, err);
         }
         return;
       }
@@ -654,12 +645,7 @@ export class Server extends EventEmitter<ServerEvents> {
           res.writeHead(200, { "Content-Type": "application/json" });
           res.end(JSON.stringify(data));
         } catch (err) {
-          res.writeHead(500, { "Content-Type": "application/json" });
-          res.end(
-            JSON.stringify({
-              error: err instanceof Error ? err.message : String(err),
-            }),
-          );
+          respond500(res, err);
         }
         return;
       }
@@ -674,12 +660,7 @@ export class Server extends EventEmitter<ServerEvents> {
           res.writeHead(200, { "Content-Type": "application/json" });
           res.end(JSON.stringify({ events: data, count: data.length }));
         } catch (err) {
-          res.writeHead(500, { "Content-Type": "application/json" });
-          res.end(
-            JSON.stringify({
-              error: err instanceof Error ? err.message : String(err),
-            }),
-          );
+          respond500(res, err);
         }
         return;
       }
@@ -716,12 +697,7 @@ export class Server extends EventEmitter<ServerEvents> {
           res.writeHead(200, { "Content-Type": "application/json" });
           res.end(JSON.stringify(data));
         } catch (err) {
-          res.writeHead(500, { "Content-Type": "application/json" });
-          res.end(
-            JSON.stringify({
-              error: err instanceof Error ? err.message : String(err),
-            }),
-          );
+          respond500(res, err);
         }
         return;
       }
@@ -805,14 +781,7 @@ export class Server extends EventEmitter<ServerEvents> {
               await runTracesExportToStream(res);
             }
           } catch (err) {
-            if (!res.headersSent) {
-              res.writeHead(500, { "Content-Type": "application/json" });
-              res.end(
-                JSON.stringify({
-                  error: err instanceof Error ? err.message : String(err),
-                }),
-              );
-            }
+            respond500(res, err);
           }
         })();
         return;
@@ -836,12 +805,7 @@ export class Server extends EventEmitter<ServerEvents> {
           res.writeHead(200, { "Content-Type": "application/json" });
           res.end(JSON.stringify(data));
         } catch (err) {
-          res.writeHead(500, { "Content-Type": "application/json" });
-          res.end(
-            JSON.stringify({
-              error: err instanceof Error ? err.message : String(err),
-            }),
-          );
+          respond500(res, err);
         }
         return;
       }
@@ -854,12 +818,7 @@ export class Server extends EventEmitter<ServerEvents> {
           res.writeHead(200, { "Content-Type": "application/json" });
           res.end(JSON.stringify(data));
         } catch (err) {
-          res.writeHead(500, { "Content-Type": "application/json" });
-          res.end(
-            JSON.stringify({
-              error: err instanceof Error ? err.message : String(err),
-            }),
-          );
+          respond500(res, err);
         }
         return;
       }
@@ -889,12 +848,7 @@ export class Server extends EventEmitter<ServerEvents> {
             );
           }
         } catch (err) {
-          res.writeHead(500, { "Content-Type": "application/json" });
-          res.end(
-            JSON.stringify({
-              error: err instanceof Error ? err.message : String(err),
-            }),
-          );
+          respond500(res, err);
         }
         return;
       }
@@ -950,12 +904,7 @@ export class Server extends EventEmitter<ServerEvents> {
           res.writeHead(200, { "Content-Type": "application/json" });
           res.end(JSON.stringify(data));
         } catch (err) {
-          res.writeHead(500, { "Content-Type": "application/json" });
-          res.end(
-            JSON.stringify({
-              error: err instanceof Error ? err.message : String(err),
-            }),
-          );
+          respond500(res, err);
         }
         return;
       }
@@ -976,12 +925,7 @@ export class Server extends EventEmitter<ServerEvents> {
             res.end(JSON.stringify({ ok: true }));
           }
         } catch (err) {
-          res.writeHead(500, { "Content-Type": "application/json" });
-          res.end(
-            JSON.stringify({
-              error: err instanceof Error ? err.message : String(err),
-            }),
-          );
+          respond500(res, err);
         }
         return;
       }
@@ -1266,12 +1210,7 @@ export class Server extends EventEmitter<ServerEvents> {
           res.writeHead(200, { "Content-Type": "application/json" });
           res.end(JSON.stringify(data));
         } catch (err) {
-          res.writeHead(500, { "Content-Type": "application/json" });
-          res.end(
-            JSON.stringify({
-              error: err instanceof Error ? err.message : String(err),
-            }),
-          );
+          respond500(res, err);
         }
         return;
       }
@@ -1286,12 +1225,7 @@ export class Server extends EventEmitter<ServerEvents> {
           res.writeHead(200, { "Content-Type": "application/json" });
           res.end(JSON.stringify(data));
         } catch (err) {
-          res.writeHead(500, { "Content-Type": "application/json" });
-          res.end(
-            JSON.stringify({
-              error: err instanceof Error ? err.message : String(err),
-            }),
-          );
+          respond500(res, err);
         }
         return;
       }
@@ -1464,12 +1398,11 @@ export class Server extends EventEmitter<ServerEvents> {
             res.writeHead(200, { "Content-Type": "application/json" });
             res.end(JSON.stringify({ ok: true, restartRequired }));
           } catch (err) {
-            res.writeHead(400, { "Content-Type": "application/json" });
-            res.end(
-              JSON.stringify({
-                error: err instanceof Error ? err.message : String(err),
-              }),
+            this.logger.error(
+              `[/config/patchwork] error: ${err instanceof Error ? (err.stack ?? err.message) : String(err)}`,
             );
+            res.writeHead(400, { "Content-Type": "application/json" });
+            res.end(JSON.stringify({ error: "Invalid request body" }));
           }
         });
         return;
@@ -1525,12 +1458,7 @@ export class Server extends EventEmitter<ServerEvents> {
           res.writeHead(200, { "Content-Type": "application/json" });
           res.end(JSON.stringify(data));
         } catch (err) {
-          res.writeHead(500, { "Content-Type": "application/json" });
-          res.end(
-            JSON.stringify({
-              error: err instanceof Error ? err.message : String(err),
-            }),
-          );
+          respond500(res, err);
         }
         return;
       }
@@ -1606,12 +1534,7 @@ export class Server extends EventEmitter<ServerEvents> {
             });
             res.end(JSON.stringify(result.body));
           } catch (err) {
-            res.writeHead(500, { "Content-Type": "application/json" });
-            res.end(
-              JSON.stringify({
-                error: err instanceof Error ? err.message : String(err),
-              }),
-            );
+            respond500(res, err);
           }
         });
         return;
@@ -1680,13 +1603,9 @@ export class Server extends EventEmitter<ServerEvents> {
           req.method === "DELETE"
         ) {
           this.httpMcpHandler(req, res).catch((err) => {
-            this.logger.error(
-              `HTTP MCP handler error: ${err instanceof Error ? err.message : String(err)}`,
-            );
-            if (!res.headersSent) {
-              res.writeHead(500, { "Content-Type": "application/json" });
-              res.end(JSON.stringify({ error: String(err) }));
-            }
+            // respond500 logs the underlying error detail server-side; no
+            // need to also funnel it through this.logger.
+            respond500(res, err, "/mcp HTTP handler");
           });
           return;
         }


### PR DESCRIPTION
## Summary

Closes the largest remaining bucket of CodeQL alerts on `main` — 89 `js/stack-trace-exposure` findings — by centralizing the 500 error path that every bridge route handler had its own copy of.

| | Before | After |
|---|---|---|
| Code scanning total | 96 | **~7** |
| `js/stack-trace-exposure` | 89 | **0** |
| High severity remaining | 7 | 7 (all dismissable) |

After this lands, every remaining open alert is a known false-positive or example/test fixture that doesn't ship.

## What changed

**New: [src/httpErrorResponse.ts](../blob/security/centralize-error-responses/src/httpErrorResponse.ts)** — `respond500(res, err, context?)`
- Writes generic `{"error":"Internal server error"}`, never the underlying message.
- Logs full detail (stack preferred, message fallback) server-side via `console.error` with an optional context tag.
- Idempotent on `headersSent` / `writableEnded` so nested catches can't double-write.

**Codemod: [scripts/centralize-error-responses.mjs](../blob/security/centralize-error-responses/scripts/centralize-error-responses.mjs)** — one-shot script that rewrote the four canonical patterns. Kept in the tree for auditability and so a future maintainer can run it again if a new route is added with the old pattern.

**Replacements (96 sites total):**
- `connectorRoutes.ts` — 62 sites (mechanical)
- `server.ts` — 17 sites (mechanical) + 2 manual (`/config` 400 handler genericized, `/mcp` catch deduplicated)
- `recipeRoutes.ts` — 4 mechanical + 10 manual fixups for variants the codemod can't safely touch (`{ ok: false, error, code }` envelopes, `failures.push` array entries, dispatch-by-message 404/500 split)
- `inboxRoutes.ts` — 2 sites (mechanical)
- `oauthRoutes.ts` — 2 sites (mechanical)
- `dashboard/src/app/api/bridge/[...path]/route.ts` — 1 site (Next.js Response runtime, parallel fix)

**Test contract update.** Five unit tests previously asserted that the response body contained the underlying `err.message` (the exact thing CodeQL flagged). Each now asserts the new contract: status 500, generic body, `body.not.toContain(secret)`. So any future regression that re-introduces the leak fails loudly:

- `server-activity.test.ts`
- `server-approval-detail.test.ts`
- `server-connector-error.test.ts`
- `server-session-detail.test.ts`
- `server-traces.test.ts`

Plus 5 new cases in `httpErrorResponse.test.ts` covering: sensitive Error message, non-Error throws, stderr logging contract, headersSent guard, writableEnded guard.

## API contract change

Public response shape changes for 5xx error bodies on these routes — they now always return `{"error":"Internal server error"}` instead of the underlying message. `code`/`ok` envelope fields are preserved where they existed, only the human-readable `error` text becomes generic. Status codes are unchanged.

If anything depends on parsing those 5xx error strings, it'll need to switch to status code + `code` field (which is the right contract anyway). The dashboard and CLI clients already key off status, not body text.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run typecheck:tests:core` — clean
- [x] `npm test` — 5003/5003 (incl. 5 new respond500 cases + 5 updated leak-regression assertions)
- [x] `cd dashboard && npm test` — 286/286
- [x] `cd dashboard && npx tsc --noEmit` — clean
- [x] `npx biome check` — clean
- [x] `npm run build` — clean
- [ ] CodeQL re-scan after merge → 89 `js/stack-trace-exposure` alerts transition to "fixed"

🤖 Generated with [Claude Code](https://claude.com/claude-code)