### PR TITLE
harden(subprocess): mirror argv guard onto prompt/model/effort/systemPrompt/fallbackModel

### DIFF
--- a/src/drivers/claude/__tests__/subprocess.argv-guards.test.ts
+++ b/src/drivers/claude/__tests__/subprocess.argv-guards.test.ts
@@ -1,0 +1,133 @@
+import { EventEmitter } from "node:events";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+class MockChild extends EventEmitter {
+  stdout = new EventEmitter();
+  stderr = new EventEmitter();
+  exitCode: number | null = null;
+  killed = false;
+  kill = vi.fn(() => {
+    this.killed = true;
+    this.emit("close", 0);
+    return true;
+  });
+}
+
+let mockChild: MockChild;
+
+vi.mock("node:child_process", async (importOriginal) => {
+  const original = await importOriginal<typeof import("node:child_process")>();
+  return {
+    ...original,
+    spawn: vi.fn(() => {
+      mockChild = new MockChild();
+      mockChild.stdout = new EventEmitter();
+      mockChild.stderr = new EventEmitter();
+      (mockChild.stdout as { setEncoding?: () => void }).setEncoding = vi.fn();
+      (mockChild.stderr as { setEncoding?: () => void }).setEncoding = vi.fn();
+      return mockChild;
+    }),
+  };
+});
+
+import { spawn } from "node:child_process";
+import type { ProviderTaskInput } from "../../types.js";
+import { SubprocessDriver } from "../subprocess.js";
+
+const spawnMock = vi.mocked(spawn);
+
+function makeInput(
+  overrides: Partial<ProviderTaskInput> = {},
+): ProviderTaskInput {
+  return {
+    prompt: "hello",
+    workspace: "/tmp/test",
+    timeoutMs: 5000,
+    signal: new AbortController().signal,
+    ...overrides,
+  };
+}
+
+async function emitSuccessAndAwait(promise: Promise<unknown>): Promise<void> {
+  await new Promise<void>((r) => setTimeout(r, 0));
+  mockChild.stdout.emit(
+    "data",
+    `${JSON.stringify({ type: "result", is_error: false, result: "ok" })}\n`,
+  );
+  mockChild.emit("close", 0);
+  await promise;
+}
+
+describe("SubprocessDriver argv injection guards", () => {
+  let driver: SubprocessDriver;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    driver = new SubprocessDriver("claude", "ant", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("throws synchronously when prompt starts with '-' (spawn never called)", async () => {
+    await expect(driver.run(makeInput({ prompt: "-rf /" }))).rejects.toThrow(
+      /prompt cannot start with '-'/,
+    );
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it("drops --model when input.model starts with '-'", async () => {
+    const p = driver.run(makeInput({ model: "--evil" }));
+    await emitSuccessAndAwait(p);
+    const args = spawnMock.mock.calls[0]![1] as string[];
+    expect(args).not.toContain("--model");
+    expect(args).not.toContain("--evil");
+  });
+
+  it("still passes --model when input.model is a normal model id", async () => {
+    const p = driver.run(makeInput({ model: "claude-sonnet-4-6" }));
+    await emitSuccessAndAwait(p);
+    const args = spawnMock.mock.calls[0]![1] as string[];
+    expect(args).toContain("--model");
+    expect(args[args.indexOf("--model") + 1]).toBe("claude-sonnet-4-6");
+  });
+
+  it("drops --system-prompt when systemPrompt starts with '-'", async () => {
+    const p = driver.run(makeInput({ systemPrompt: "--malicious-flag" }));
+    await emitSuccessAndAwait(p);
+    const args = spawnMock.mock.calls[0]![1] as string[];
+    expect(args).not.toContain("--system-prompt");
+    expect(args).not.toContain("--malicious-flag");
+  });
+
+  it("drops --effort when providerOptions.effort starts with '-'", async () => {
+    const p = driver.run(makeInput({ providerOptions: { effort: "-x" } }));
+    await emitSuccessAndAwait(p);
+    const args = spawnMock.mock.calls[0]![1] as string[];
+    expect(args).not.toContain("--effort");
+    expect(args).not.toContain("-x");
+  });
+
+  it("drops --fallback-model when providerOptions.fallbackModel starts with '-'", async () => {
+    const p = driver.run(
+      makeInput({ providerOptions: { fallbackModel: "-rm" } }),
+    );
+    await emitSuccessAndAwait(p);
+    const args = spawnMock.mock.calls[0]![1] as string[];
+    expect(args).not.toContain("--fallback-model");
+    expect(args).not.toContain("-rm");
+  });
+
+  it("drops --add-dir entries when contextFile starts with '-' (existing line-75 guard, regression coverage)", async () => {
+    const p = driver.run(
+      makeInput({ contextFiles: ["--evil-flag", "/safe/path"] }),
+    );
+    await emitSuccessAndAwait(p);
+    const args = spawnMock.mock.calls[0]![1] as string[];
+    expect(args).not.toContain("--evil-flag");
+    const addDirIdx = args.indexOf("--add-dir");
+    expect(addDirIdx).toBeGreaterThan(-1);
+    expect(args[addDirIdx + 1]).toBe("/safe/path");
+  });
+});

--- a/src/drivers/claude/subprocess.ts
+++ b/src/drivers/claude/subprocess.ts
@@ -51,6 +51,17 @@ export class SubprocessDriver implements ProviderDriver {
     // Re-write before each run — /tmp may be cleared on long-running servers.
     this.settings.write();
 
+    // Defense-in-depth: reject argv-confusable user-controlled strings. Spawn
+    // is called with an array (no shell), so this is not shell-injection
+    // defense — it's argv defense for the child's flag parser, which may
+    // misinterpret a leading `-` as a new flag. Mirrors the contextFiles
+    // guard below.
+    if (input.prompt.startsWith("-")) {
+      throw new Error(
+        "[SubprocessDriver] prompt cannot start with '-' (argv injection guard)",
+      );
+    }
+
     const args = [
       "-p",
       input.prompt,
@@ -63,10 +74,16 @@ export class SubprocessDriver implements ProviderDriver {
       "--include-partial-messages",
       "--no-session-persistence",
     ];
-    if (input.model) args.push("--model", input.model);
-    if (effort) args.push("--effort", effort);
-    if (input.systemPrompt) args.push("--system-prompt", input.systemPrompt);
-    if (fallbackModel) args.push("--fallback-model", fallbackModel);
+    if (input.model && !input.model.startsWith("-")) {
+      args.push("--model", input.model);
+    }
+    if (effort && !effort.startsWith("-")) args.push("--effort", effort);
+    if (input.systemPrompt && !input.systemPrompt.startsWith("-")) {
+      args.push("--system-prompt", input.systemPrompt);
+    }
+    if (fallbackModel && !fallbackModel.startsWith("-")) {
+      args.push("--fallback-model", fallbackModel);
+    }
     if (maxBudgetUsd !== undefined)
       args.push("--max-budget-usd", String(maxBudgetUsd));
     // Always skip permissions: headless subprocesses can't respond to prompts.


### PR DESCRIPTION
## Summary

Defense-in-depth follow-up to PR #312 (audit fixes). Mirror the existing `contextFiles` argv guard (`!startsWith(\"-\")`) onto the other four user-controlled argv positions in [src/drivers/claude/subprocess.ts](src/drivers/claude/subprocess.ts).

`spawn` is called with an array (no shell), so this is **not** shell-injection defense — it's argv defense for the child process's flag parser, which may misinterpret a leading `-` as a new flag.

### Behavior

- **prompt** — required. Reject (throw) on leading `-` rather than skip; bare leading-dash prompts are pathological.
- **model / systemPrompt / effort / fallbackModel** — optional. Skip silently, matching the existing line-75 `contextFiles` guard.

### Tests

New file [src/drivers/claude/__tests__/subprocess.argv-guards.test.ts](src/drivers/claude/__tests__/subprocess.argv-guards.test.ts), 7 cases:
- prompt with `-` → throws synchronously, spawn never called
- model `--evil` → `--model` not in argv
- model `claude-sonnet-4-6` (happy path) → `--model claude-sonnet-4-6` in argv
- systemPrompt `--malicious-flag` → `--system-prompt` not in argv
- providerOptions.effort `-x` → `--effort` not in argv
- providerOptions.fallbackModel `-rm` → `--fallback-model` not in argv
- contextFiles `[--evil-flag, /safe/path]` → drops the dash entry, keeps the safe path (regression test for the pre-existing line-75 guard, which had no direct coverage before)

## Scope note

Tested against the **new** `SubprocessDriver` in [src/drivers/claude/subprocess.ts](src/drivers/claude/subprocess.ts) — the one production wires up via [src/drivers/index.ts](src/drivers/index.ts) → [src/bridge.ts](src/bridge.ts). The legacy duplicate `SubprocessDriver` in [src/claudeDriver.ts:163](src/claudeDriver.ts#L163) is no longer referenced by `bridge.ts` or `yamlRunner.ts` (only test files import it); deliberately leaving it out of scope.

## Severity

LOW — defense-in-depth, no known exploit. The guard prevents future bugs where caller-supplied strings could end up looking like flags to the spawned process.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 5019 passing (was 5012; +7 new)
- [x] `npx biome check --write` on changed files — formatting applied to test file

🤖 Generated with [Claude Code](https://claude.com/claude-code)