### PR TITLE
harden(dashboard): rate-limit failed Basic-auth attempts + constant-time compare

### DIFF
--- a/dashboard/src/lib/__tests__/authRateLimit.test.ts
+++ b/dashboard/src/lib/__tests__/authRateLimit.test.ts
@@ -1,0 +1,136 @@
+/** @vitest-environment node */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+let mod: typeof import("../authRateLimit");
+
+beforeEach(async () => {
+  // authRateLimit captures env-var thresholds at module load. The store is
+  // module-singleton; reset between tests instead of re-importing.
+  mod = await import("../authRateLimit");
+  mod._resetForTests();
+});
+
+afterEach(() => {
+  mod._resetForTests();
+});
+
+describe("authRateLimit", () => {
+  it("returns not-locked for an unknown key", () => {
+    expect(mod.checkLocked("1.2.3.4")).toEqual({ locked: false });
+  });
+
+  it("does not lock until MAX_FAILURES is reached", () => {
+    const ip = "1.2.3.4";
+    const now = 1_000_000;
+    for (let i = 0; i < mod._config.MAX_FAILURES - 1; i++) {
+      const r = mod.recordFailure(ip, now + i);
+      expect(r.locked).toBe(false);
+    }
+    expect(mod.checkLocked(ip, now + 100)).toEqual({ locked: false });
+  });
+
+  it("locks on the MAX_FAILURES-th failure within the window", () => {
+    const ip = "1.2.3.4";
+    const now = 1_000_000;
+    let result: ReturnType<typeof mod.recordFailure> = { locked: false };
+    for (let i = 0; i < mod._config.MAX_FAILURES; i++) {
+      result = mod.recordFailure(ip, now + i);
+    }
+    expect(result.locked).toBe(true);
+    if (result.locked) {
+      // ceil(LOCKOUT_MS / 1000) — for default 15min, 900s.
+      expect(result.retryAfterSec).toBe(
+        Math.ceil(mod._config.LOCKOUT_MS / 1000),
+      );
+    }
+
+    const lock = mod.checkLocked(ip, now + 100);
+    expect(lock.locked).toBe(true);
+    if (lock.locked) {
+      expect(lock.retryAfterSec).toBeGreaterThan(0);
+      expect(lock.retryAfterSec).toBeLessThanOrEqual(
+        Math.ceil(mod._config.LOCKOUT_MS / 1000),
+      );
+    }
+  });
+
+  it("checkLocked returns not-locked once the lockout has expired", () => {
+    const ip = "1.2.3.4";
+    const lockAt = 1_000_000;
+    // Record all failures at the same instant so lockedUntil = lockAt + LOCKOUT_MS.
+    for (let i = 0; i < mod._config.MAX_FAILURES; i++) {
+      mod.recordFailure(ip, lockAt);
+    }
+    expect(
+      mod.checkLocked(ip, lockAt + mod._config.LOCKOUT_MS - 1).locked,
+    ).toBe(true);
+    expect(
+      mod.checkLocked(ip, lockAt + mod._config.LOCKOUT_MS + 1).locked,
+    ).toBe(false);
+  });
+
+  it("starts a fresh window after a previous lockout expires", () => {
+    const ip = "1.2.3.4";
+    const t0 = 1_000_000;
+    for (let i = 0; i < mod._config.MAX_FAILURES; i++) {
+      mod.recordFailure(ip, t0 + i);
+    }
+    // Lockout expired; one fresh failure should NOT immediately re-lock.
+    const after = t0 + mod._config.LOCKOUT_MS + 1;
+    const r = mod.recordFailure(ip, after);
+    expect(r.locked).toBe(false);
+  });
+
+  it("prunes failures older than the sliding window", () => {
+    const ip = "1.2.3.4";
+    const t0 = 1_000_000;
+    // MAX_FAILURES - 1 failures, then wait past the window, then one more.
+    for (let i = 0; i < mod._config.MAX_FAILURES - 1; i++) {
+      mod.recordFailure(ip, t0 + i);
+    }
+    const lateBy1ms = t0 + mod._config.FAILURE_WINDOW_MS + 1;
+    // One failure outside the original window. Old failures should drop off.
+    const r = mod.recordFailure(ip, lateBy1ms);
+    expect(r.locked).toBe(false);
+  });
+
+  it("recordSuccess clears the entry", () => {
+    const ip = "1.2.3.4";
+    const now = 1_000_000;
+    mod.recordFailure(ip, now);
+    mod.recordFailure(ip, now + 1);
+    mod.recordSuccess(ip);
+    // After clearing, the IP is back to a clean slate.
+    expect(mod.checkLocked(ip, now + 2).locked).toBe(false);
+    // And the failure counter has reset — would need MAX more to re-lock.
+    let result: ReturnType<typeof mod.recordFailure> = { locked: false };
+    for (let i = 0; i < mod._config.MAX_FAILURES - 1; i++) {
+      result = mod.recordFailure(ip, now + 10 + i);
+    }
+    expect(result.locked).toBe(false);
+  });
+
+  it("tracks IPs independently — locking one does not lock another", () => {
+    const t0 = 1_000_000;
+    for (let i = 0; i < mod._config.MAX_FAILURES; i++) {
+      mod.recordFailure("attacker", t0 + i);
+    }
+    expect(mod.checkLocked("attacker", t0 + 1).locked).toBe(true);
+    expect(mod.checkLocked("legit", t0 + 1).locked).toBe(false);
+    // Legit user can still authenticate.
+    const r = mod.recordFailure("legit", t0 + 100);
+    expect(r.locked).toBe(false);
+  });
+
+  it("evicts the oldest entry when MAX_ENTRIES is exceeded", () => {
+    const t0 = 1_000_000;
+    // First IP gets some failures.
+    mod.recordFailure("first", t0);
+    // Fill up to capacity with distinct IPs.
+    for (let i = 0; i < mod._config.MAX_ENTRIES; i++) {
+      mod.recordFailure(`ip-${i}`, t0 + i + 1);
+    }
+    // "first" should be evicted now.
+    expect(mod.checkLocked("first", t0 + 1).locked).toBe(false);
+  });
+});

--- a/dashboard/src/lib/__tests__/clientIp.test.ts
+++ b/dashboard/src/lib/__tests__/clientIp.test.ts
@@ -1,0 +1,72 @@
+/** @vitest-environment node */
+import { describe, expect, it } from "vitest";
+import { clientKey } from "../clientIp";
+
+function h(headers: Record<string, string>): Headers {
+  return new Headers(headers);
+}
+
+describe("clientKey", () => {
+  it("returns the leftmost entry from x-forwarded-for", () => {
+    expect(clientKey(h({ "x-forwarded-for": "203.0.113.42" }))).toBe(
+      "203.0.113.42",
+    );
+  });
+
+  it("trims whitespace around x-forwarded-for entries", () => {
+    expect(clientKey(h({ "x-forwarded-for": "  198.51.100.7  " }))).toBe(
+      "198.51.100.7",
+    );
+  });
+
+  it("picks the leftmost (originating client) entry from a comma chain", () => {
+    expect(
+      clientKey(
+        h({ "x-forwarded-for": "203.0.113.1, 10.0.0.5, 10.0.0.6" }),
+      ),
+    ).toBe("203.0.113.1");
+  });
+
+  it("falls back to x-real-ip when x-forwarded-for is absent", () => {
+    expect(clientKey(h({ "x-real-ip": "203.0.113.99" }))).toBe("203.0.113.99");
+  });
+
+  it("prefers x-forwarded-for over x-real-ip when both are present", () => {
+    expect(
+      clientKey(
+        h({
+          "x-forwarded-for": "203.0.113.1",
+          "x-real-ip": "10.0.0.5",
+        }),
+      ),
+    ).toBe("203.0.113.1");
+  });
+
+  it("returns 'unknown' when neither header is set", () => {
+    expect(clientKey(h({}))).toBe("unknown");
+  });
+
+  it("returns 'unknown' when x-forwarded-for is empty string", () => {
+    expect(clientKey(h({ "x-forwarded-for": "" }))).toBe("unknown");
+  });
+
+  it("falls through to x-real-ip when x-forwarded-for is whitespace-only", () => {
+    expect(
+      clientKey(h({ "x-forwarded-for": "   ", "x-real-ip": "10.0.0.1" })),
+    ).toBe("10.0.0.1");
+  });
+
+  it("returns 'unknown' if both headers are empty / whitespace-only", () => {
+    expect(
+      clientKey(h({ "x-forwarded-for": "", "x-real-ip": "   " })),
+    ).toBe("unknown");
+  });
+
+  it("works against any HeadersLike object (not just Headers)", () => {
+    const stub = {
+      get: (name: string) =>
+        name === "x-forwarded-for" ? "192.0.2.1" : null,
+    };
+    expect(clientKey(stub)).toBe("192.0.2.1");
+  });
+});

--- a/dashboard/src/lib/authRateLimit.ts
+++ b/dashboard/src/lib/authRateLimit.ts
@@ -1,0 +1,110 @@
+/**
+ * In-memory failure tracker for dashboard Basic auth.
+ *
+ * Scope: single-instance, self-hosted Next.js. State is per-process; multi-
+ * instance deployments would need a shared store (Redis, etc.). For
+ * Patchwork's typical deployment (one Next.js process per workstation /
+ * server) this is sufficient.
+ *
+ * Algorithm: sliding window over recent failure timestamps. After
+ * MAX_FAILURES within FAILURE_WINDOW_MS, lock the IP for LOCKOUT_MS. A
+ * successful auth clears the entry for that IP.
+ */
+
+function parsePositiveInt(raw: string | undefined, fallback: number): number {
+  if (!raw) return fallback;
+  const n = Number.parseInt(raw, 10);
+  return Number.isFinite(n) && n > 0 ? n : fallback;
+}
+
+const MAX_FAILURES = parsePositiveInt(
+  process.env.DASHBOARD_AUTH_MAX_FAILURES,
+  5,
+);
+const FAILURE_WINDOW_MS = parsePositiveInt(
+  process.env.DASHBOARD_AUTH_FAILURE_WINDOW_MS,
+  15 * 60 * 1000,
+);
+const LOCKOUT_MS = parsePositiveInt(
+  process.env.DASHBOARD_AUTH_LOCKOUT_MS,
+  15 * 60 * 1000,
+);
+
+// Bound memory under attack. When exceeded, evict the oldest entry by
+// insertion order. This is best-effort: a determined attacker rotating IPs
+// can churn the cache, but they don't gain auth bypass — they only push
+// other entries out, and tracked failures are an additive defense, not the
+// primary one.
+const MAX_ENTRIES = 10_000;
+
+interface Entry {
+  failures: number[]; // timestamps in ms
+  lockedUntil: number; // 0 when not locked
+}
+
+const store = new Map<string, Entry>();
+
+function getOrInit(key: string): Entry {
+  let entry = store.get(key);
+  if (!entry) {
+    if (store.size >= MAX_ENTRIES) {
+      const oldest = store.keys().next().value;
+      if (oldest !== undefined) store.delete(oldest);
+    }
+    entry = { failures: [], lockedUntil: 0 };
+    store.set(key, entry);
+  }
+  return entry;
+}
+
+export type LockResult =
+  | { locked: false }
+  | { locked: true; retryAfterSec: number };
+
+export function checkLocked(key: string, now: number = Date.now()): LockResult {
+  const entry = store.get(key);
+  if (!entry) return { locked: false };
+  if (entry.lockedUntil > now) {
+    return {
+      locked: true,
+      retryAfterSec: Math.ceil((entry.lockedUntil - now) / 1000),
+    };
+  }
+  return { locked: false };
+}
+
+export function recordFailure(
+  key: string,
+  now: number = Date.now(),
+): LockResult {
+  const entry = getOrInit(key);
+  // If a previous lockout has expired, allow a fresh window.
+  if (entry.lockedUntil !== 0 && entry.lockedUntil <= now) {
+    entry.lockedUntil = 0;
+    entry.failures = [];
+  }
+  const cutoff = now - FAILURE_WINDOW_MS;
+  entry.failures = entry.failures.filter((t) => t > cutoff);
+  entry.failures.push(now);
+  if (entry.failures.length >= MAX_FAILURES) {
+    entry.lockedUntil = now + LOCKOUT_MS;
+    entry.failures = [];
+    return { locked: true, retryAfterSec: Math.ceil(LOCKOUT_MS / 1000) };
+  }
+  return { locked: false };
+}
+
+export function recordSuccess(key: string): void {
+  store.delete(key);
+}
+
+export function _resetForTests(): void {
+  store.clear();
+}
+
+export const _config = {
+  MAX_FAILURES,
+  FAILURE_WINDOW_MS,
+  LOCKOUT_MS,
+  MAX_ENTRIES,
+};

--- a/dashboard/src/lib/clientIp.ts
+++ b/dashboard/src/lib/clientIp.ts
@@ -1,0 +1,33 @@
+/**
+ * Resolve the client IP for rate-limiting / lockout bucketing.
+ *
+ * Trusts the leftmost entry of x-forwarded-for, falls back to x-real-ip,
+ * then to the literal "unknown" so unidentified clients share a single
+ * bucket. The "unknown" bucket only DOSes itself; legitimate identifiable
+ * clients are unaffected.
+ *
+ * Next 15 dropped NextRequest.ip, so we rely on forwarded headers. The
+ * canonical Patchwork deploy (deploy/deploy-dashboard.sh) sets both headers
+ * via nginx; if you front the dashboard differently, ensure your terminator
+ * sets one of them.
+ */
+export interface HeadersLike {
+  get(name: string): string | null;
+}
+
+export function clientKey(headers: HeadersLike): string {
+  const xff = headers.get("x-forwarded-for");
+  if (xff) {
+    const first = xff.split(",")[0];
+    if (first) {
+      const trimmed = first.trim();
+      if (trimmed.length > 0) return trimmed;
+    }
+  }
+  const xri = headers.get("x-real-ip");
+  if (xri) {
+    const trimmed = xri.trim();
+    if (trimmed.length > 0) return trimmed;
+  }
+  return "unknown";
+}

--- a/dashboard/src/middleware.ts
+++ b/dashboard/src/middleware.ts
@@ -4,6 +4,7 @@ import {
   recordFailure,
   recordSuccess,
 } from "@/lib/authRateLimit";
+import { clientKey } from "@/lib/clientIp";
 
 const DASHBOARD_PASSWORD = process.env.DASHBOARD_PASSWORD;
 const ALLOW_UNAUTHENTICATED =
@@ -19,22 +20,6 @@ function constantTimeEq(a: string, b: string): boolean {
     diff |= (a.charCodeAt(i) || 0) ^ (b.charCodeAt(i) || 0);
   }
   return diff === 0;
-}
-
-function clientKey(req: NextRequest): string {
-  // Self-hosted Next.js typically sits behind a reverse proxy that sets
-  // x-forwarded-for. Trust the leftmost entry as the originating client.
-  // Next 15 removed NextRequest.ip; rely on forwarded headers. Fall back to
-  // "unknown" so unidentified clients share a single bucket — they can DOS
-  // themselves but not legitimate users with known IPs.
-  const xff = req.headers.get("x-forwarded-for");
-  if (xff) {
-    const first = xff.split(",")[0];
-    if (first) return first.trim();
-  }
-  const xri = req.headers.get("x-real-ip");
-  if (xri) return xri.trim();
-  return "unknown";
 }
 
 function lockedResponse(retryAfterSec: number): NextResponse {
@@ -59,7 +44,7 @@ export function middleware(req: NextRequest) {
     return NextResponse.next();
   }
 
-  const ip = clientKey(req);
+  const ip = clientKey(req.headers);
 
   // Check lockout BEFORE inspecting credentials so a locked-out client
   // can't keep probing.

--- a/dashboard/src/middleware.ts
+++ b/dashboard/src/middleware.ts
@@ -1,25 +1,55 @@
 import { NextRequest, NextResponse } from "next/server";
+import {
+  checkLocked,
+  recordFailure,
+  recordSuccess,
+} from "@/lib/authRateLimit";
 
 const DASHBOARD_PASSWORD = process.env.DASHBOARD_PASSWORD;
 const ALLOW_UNAUTHENTICATED =
   process.env.DASHBOARD_ALLOW_UNAUTHENTICATED === "1";
 const DEMO_MODE = process.env.NEXT_PUBLIC_DEMO_MODE === "true";
 
+// Constant-time string comparison. Length difference is folded into the
+// final XOR so a length-only timing leak doesn't bypass the loop.
+function constantTimeEq(a: string, b: string): boolean {
+  const len = Math.max(a.length, b.length);
+  let diff = a.length ^ b.length;
+  for (let i = 0; i < len; i++) {
+    diff |= (a.charCodeAt(i) || 0) ^ (b.charCodeAt(i) || 0);
+  }
+  return diff === 0;
+}
+
+function clientKey(req: NextRequest): string {
+  // Self-hosted Next.js typically sits behind a reverse proxy that sets
+  // x-forwarded-for. Trust the leftmost entry as the originating client.
+  // Next 15 removed NextRequest.ip; rely on forwarded headers. Fall back to
+  // "unknown" so unidentified clients share a single bucket — they can DOS
+  // themselves but not legitimate users with known IPs.
+  const xff = req.headers.get("x-forwarded-for");
+  if (xff) {
+    const first = xff.split(",")[0];
+    if (first) return first.trim();
+  }
+  const xri = req.headers.get("x-real-ip");
+  if (xri) return xri.trim();
+  return "unknown";
+}
+
+function lockedResponse(retryAfterSec: number): NextResponse {
+  return new NextResponse("Too Many Requests", {
+    status: 429,
+    headers: { "Retry-After": String(retryAfterSec) },
+  });
+}
+
 export function middleware(req: NextRequest) {
-  // Demo mode is the public face of the dashboard — no real bridge data is
-  // ever served, so auth is unnecessary and gating behind a 503 just means
-  // first-time visitors hit "Dashboard auth not configured" on every route
-  // except /marketplace.
   if (DEMO_MODE) {
     return NextResponse.next();
   }
 
-  // No password configured.
   if (!DASHBOARD_PASSWORD) {
-    // In dev, default to open access. In production, refuse to expose
-    // the bridge proxy unless the operator opts in via
-    // DASHBOARD_ALLOW_UNAUTHENTICATED=1 (e.g. behind a reverse proxy
-    // that handles auth).
     if (process.env.NODE_ENV === "production" && !ALLOW_UNAUTHENTICATED) {
       return new NextResponse(
         "Dashboard auth not configured. Set DASHBOARD_PASSWORD or DASHBOARD_ALLOW_UNAUTHENTICATED=1.",
@@ -29,6 +59,13 @@ export function middleware(req: NextRequest) {
     return NextResponse.next();
   }
 
+  const ip = clientKey(req);
+
+  // Check lockout BEFORE inspecting credentials so a locked-out client
+  // can't keep probing.
+  const lock = checkLocked(ip);
+  if (lock.locked) return lockedResponse(lock.retryAfterSec);
+
   const auth = req.headers.get("authorization");
   if (auth) {
     const [scheme, encoded] = auth.split(" ");
@@ -36,9 +73,15 @@ export function middleware(req: NextRequest) {
       const decoded = Buffer.from(encoded, "base64").toString("utf-8");
       const colonIdx = decoded.indexOf(":");
       const password = colonIdx !== -1 ? decoded.slice(colonIdx + 1) : "";
-      if (password === DASHBOARD_PASSWORD) return NextResponse.next();
+      if (constantTimeEq(password, DASHBOARD_PASSWORD)) {
+        recordSuccess(ip);
+        return NextResponse.next();
+      }
     }
   }
+
+  const result = recordFailure(ip);
+  if (result.locked) return lockedResponse(result.retryAfterSec);
 
   return new NextResponse("Unauthorized", {
     status: 401,


### PR DESCRIPTION
## Summary

Closes Finding 6 from the multi-agent audit. Two-pronged defense on [dashboard/src/middleware.ts](dashboard/src/middleware.ts).

### 1. Per-IP failure tracking

New module [dashboard/src/lib/authRateLimit.ts](dashboard/src/lib/authRateLimit.ts) — sliding window over recent failure timestamps. After `MAX_FAILURES` within `FAILURE_WINDOW_MS`, the IP is locked for `LOCKOUT_MS` and gets **429 + Retry-After**. The lockout check runs **before** credential inspection so locked clients can't probe at all. A successful auth clears the IP's entry.

**Defaults**: 5 failures / 15 min → 15 min lock. Configurable via `DASHBOARD_AUTH_MAX_FAILURES`, `DASHBOARD_AUTH_FAILURE_WINDOW_MS`, `DASHBOARD_AUTH_LOCKOUT_MS`.

### 2. Constant-time password compare

Replaces the `===` flagged by the audit. Length difference is folded into the final XOR so the loop runs over the max length regardless of input. Cheap defense-in-depth alongside the rate limiter — the \"theatre over HTTPS\" framing is real but timing-safe is ~10 lines and removes one class of side channel.

## Implementation notes

- **Storage** — in-memory `Map`, scoped to a single Next.js process. Patchwork's typical deployment is one process per workstation/server, so this is sufficient. Multi-instance deployments would need a shared store (Redis, etc.); a comment in [authRateLimit.ts](dashboard/src/lib/authRateLimit.ts) flags this.
- **Memory bound** — `MAX_ENTRIES = 10_000`. Oldest entry evicted on overflow. A determined IP-rotating attacker can churn the cache but can't bypass auth — they only push other entries out, and the rate limiter is additive defense.
- **IP source** — `x-forwarded-for` (leftmost), then `x-real-ip`, then `\"unknown\"`. Next 15 dropped `NextRequest.ip`, so we rely on forwarded headers. Expectation: dashboard sits behind a reverse proxy / terminator that sets one of these.
- **Unidentified clients** — share the `\"unknown\"` bucket. They can DOS themselves but not legitimate users with known IPs.

## Tests

[dashboard/src/lib/__tests__/authRateLimit.test.ts](dashboard/src/lib/__tests__/authRateLimit.test.ts) — 9 unit tests:

- Unknown key not locked
- Below-threshold failures don't lock
- MAX-th failure flips to locked with correct Retry-After
- `checkLocked` returns not-locked once `lockedUntil` has passed
- Fresh window opens after a previous lockout expires
- Failures older than the window are pruned
- `recordSuccess` clears the entry
- Per-IP isolation — locking one doesn't lock another
- `MAX_ENTRIES` eviction works (oldest goes first)

## Test plan

- [x] Dashboard `npx tsc --noEmit` — clean
- [x] Root `npx tsc --noEmit` — clean
- [x] Dashboard `npx vitest run` — 295 passing (was 286; +9 new)
- [ ] Manual smoke: hit dashboard with wrong password 5× from same IP → 6th attempt returns 429 with Retry-After header

## Out of scope (future work)

- Shared-store backend (Redis) for multi-instance deployments. Not needed today.
- Username-aware tracking. The current scheme ignores the username (only password is checked), so per-IP is the right scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)