### PR TITLE
chore: dedupe legacy claudeDriver — delete dead ServerModeDriver, deprecate-banner the file

### DIFF
--- a/src/__tests__/automation-debug-session-end.test.ts
+++ b/src/__tests__/automation-debug-session-end.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { AutomationHooks } from "../automation.js";
-import type { IClaudeDriver } from "../claudeDriver.js";
 import { ClaudeOrchestrator } from "../claudeOrchestrator.js";
+import type { IClaudeDriver } from "../drivers/types.js";
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 

--- a/src/__tests__/automation-debug-session-start.test.ts
+++ b/src/__tests__/automation-debug-session-start.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { AutomationHooks } from "../automation.js";
-import type { IClaudeDriver } from "../claudeDriver.js";
 import { ClaudeOrchestrator } from "../claudeOrchestrator.js";
+import type { IClaudeDriver } from "../drivers/types.js";
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 

--- a/src/__tests__/automation-pre-compact.test.ts
+++ b/src/__tests__/automation-pre-compact.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { AutomationHooks } from "../automation.js";
-import type { IClaudeDriver } from "../claudeDriver.js";
 import { ClaudeOrchestrator } from "../claudeOrchestrator.js";
+import type { IClaudeDriver } from "../drivers/types.js";
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 

--- a/src/__tests__/automation-testPassAfterFailure.test.ts
+++ b/src/__tests__/automation-testPassAfterFailure.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { AutomationHooks } from "../automation.js";
-import type { IClaudeDriver } from "../claudeDriver.js";
 import { ClaudeOrchestrator } from "../claudeOrchestrator.js";
+import type { IClaudeDriver } from "../drivers/types.js";
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 

--- a/src/__tests__/automation.integration.test.ts
+++ b/src/__tests__/automation.integration.test.ts
@@ -16,8 +16,8 @@ import path from "node:path";
 import { afterAll, describe, expect, it } from "vitest";
 import type { Diagnostic } from "../automation.js";
 import { AutomationHooks } from "../automation.js";
-import type { IClaudeDriver } from "../claudeDriver.js";
 import { ClaudeOrchestrator } from "../claudeOrchestrator.js";
+import type { IClaudeDriver } from "../drivers/types.js";
 import { Logger } from "../logger.js";
 import { Server } from "../server.js";
 

--- a/src/__tests__/automation.test.ts
+++ b/src/__tests__/automation.test.ts
@@ -15,8 +15,8 @@ import {
   checkCcHookWiring,
   loadPolicy,
 } from "../automation.js";
-import type { IClaudeDriver } from "../claudeDriver.js";
 import { ClaudeOrchestrator } from "../claudeOrchestrator.js";
+import type { IClaudeDriver } from "../drivers/types.js";
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 

--- a/src/claudeDriver.ts
+++ b/src/claudeDriver.ts
@@ -1,3 +1,22 @@
+/**
+ * @deprecated LEGACY DRIVER FILE — kept for test backward compat.
+ *
+ * Production code (src/bridge.ts, src/recipes/yamlRunner.ts) wires drivers
+ * through src/drivers/index.ts → src/drivers/claude/subprocess.ts. The
+ * SubprocessDriver / ApiDriver classes in this file are NOT in the runtime
+ * call path — only legacy tests (src/__tests__/claudeDriver.test.ts,
+ * src/__tests__/ant-driver.test.ts) still construct them directly.
+ *
+ * For new code:
+ *   - SubprocessDriver / ApiDriver  → src/drivers/claude/subprocess.ts, src/drivers/claude/api.ts
+ *   - createDriver()                 → src/drivers/index.ts
+ *   - ProviderDriver / Provider*     → src/drivers/types.ts (canonical)
+ *   - IClaudeDriver type             → src/drivers/types.ts (alias for ProviderDriver)
+ *
+ * This file should eventually be deleted once the legacy tests migrate to
+ * the new SubprocessDriver shape. Touching it for new behavior is almost
+ * always wrong — edit src/drivers/claude/ instead.
+ */
 import { spawn } from "node:child_process";
 import { writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -618,31 +637,6 @@ export class ApiDriver implements IClaudeDriver {
       exitCode: 0,
       durationMs: Date.now() - start,
     };
-  }
-}
-
-/**
- * ServerModeDriver — future adapter for `claude --server` stdio JSON-RPC API.
- * Stub: documents the exact extension point; throws immediately if instantiated.
- *
- * When `claude --server` is confirmed and documented:
- * 1. Spawn: `const child = spawn(binary, ["--server"], { stdio: "pipe", ... })`
- * 2. Write JSON-RPC requests to child.stdin
- * 3. Read JSON-RPC responses from child.stdout (readline + JSON.parse)
- * 4. Map streaming partial responses to onChunk callbacks
- * 5. Implement spawnForSession / killForSession for persistent-per-session lifecycle
- */
-export class ServerModeDriver implements IClaudeDriver {
-  readonly name = "server";
-
-  constructor(_binary: string, _log: (msg: string) => void) {
-    throw new Error(
-      "ServerModeDriver is not yet implemented — awaiting confirmed claude --server stdio JSON-RPC API",
-    );
-  }
-
-  run(_input: ClaudeTaskInput): Promise<ClaudeTaskOutput> {
-    throw new Error("ServerModeDriver not implemented");
   }
 }
 


### PR DESCRIPTION
## Summary

Three small, low-risk cleanups to [src/claudeDriver.ts](src/claudeDriver.ts) — the legacy file I almost mis-edited in PR #313 (the argv-guard work). Production already uses the canonical drivers under [src/drivers/claude/](src/drivers/claude/) via [src/drivers/index.ts](src/drivers/index.ts) → [src/bridge.ts](src/bridge.ts); this file is only kept alive by tests.

### 1. Delete `ServerModeDriver` (dead code)

Constructor throws `\"not yet implemented\"`. `run()` throws too. No production references, no test coverage. 28 lines removed.

### 2. Deprecation banner on [src/claudeDriver.ts](src/claudeDriver.ts)

Big JSDoc block at the top pointing future readers at [src/drivers/claude/](src/drivers/claude/) and [src/drivers/types.ts](src/drivers/types.ts). Avoids the trap I almost fell into — searching for \`SubprocessDriver\` and editing the wrong one.

### 3. Migrate 6 type-only test imports to canonical path

[src/drivers/types.ts:108](src/drivers/types.ts#L108) already exports \`IClaudeDriver\` as a type alias for \`ProviderDriver\`. Same name, canonical home, no semantic change. Migrated:

- [automation.integration.test.ts](src/__tests__/automation.integration.test.ts)
- [automation-debug-session-start.test.ts](src/__tests__/automation-debug-session-start.test.ts)
- [automation-debug-session-end.test.ts](src/__tests__/automation-debug-session-end.test.ts)
- [automation-pre-compact.test.ts](src/__tests__/automation-pre-compact.test.ts)
- [automation.test.ts](src/__tests__/automation.test.ts)
- [automation-testPassAfterFailure.test.ts](src/__tests__/automation-testPassAfterFailure.test.ts)

## Out of scope (separate larger migration)

[claudeDriver.test.ts](src/__tests__/claudeDriver.test.ts) (745 lines, ~50 tests) and [ant-driver.test.ts](src/__tests__/ant-driver.test.ts) still import the legacy \`SubprocessDriver\` / \`ApiDriver\` classes and use \`ClaudeTaskInput\` / \`ClaudeTaskOutput\` shapes (with \`effort\` / \`fallbackModel\` at top level, vs. \`providerOptions\` in the new \`ProviderTaskInput\`). Migrating them means rewriting ~50 tests against a different input/output type — worth doing as its own focused PR.

After that future migration, [src/claudeDriver.ts](src/claudeDriver.ts) can be deleted entirely.

## Test plan

- [x] \`npx tsc --noEmit\` — clean
- [x] \`npx vitest run\` — 5019 passing (unchanged — no behavior change)
- [x] \`npx biome check --write\` on all touched files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)