### PR TITLE
test(typecheck): close 77 typecheck:tests errors via three pattern fixes

### DIFF
--- a/src/__tests__/approvalHttp.test.ts
+++ b/src/__tests__/approvalHttp.test.ts
@@ -6,13 +6,14 @@ vi.mock("node:dns/promises", () => ({
   lookup: vi.fn().mockResolvedValue({ address: "93.184.216.34", family: 4 }),
 }));
 
-function emptyRules() {
+type Rules = { allow: string[]; ask: string[]; deny: string[] };
+function emptyRules(): () => Rules {
   return () => ({ allow: [], ask: [], deny: [] });
 }
-function denyRules(...names: string[]) {
+function denyRules(...names: string[]): () => Rules {
   return () => ({ allow: [], ask: [], deny: names });
 }
-function allowRules(...names: string[]) {
+function allowRules(...names: string[]): () => Rules {
   return () => ({ allow: names, ask: [], deny: [] });
 }
 

--- a/src/__tests__/wsHelpers.ts
+++ b/src/__tests__/wsHelpers.ts
@@ -34,14 +34,35 @@ export function assertNoMessage(
 }
 
 /**
+ * Loose JSON-RPC response shape used by tests. `result` is `any` so test
+ * assertions like `resp.result.tools.find(...)` compile without per-callsite
+ * casts; production code should use a proper schema. `error` is narrowly
+ * typed because the test assertions on `.error.code` and `.error.message`
+ * are uniform across the codebase.
+ */
+export interface JsonRpcTestResponse {
+  jsonrpc: "2.0";
+  id?: number | string | null;
+  // biome-ignore lint/suspicious/noExplicitAny: tests assert nested fields
+  result?: any;
+  error?: { code: number; message: string; data?: unknown };
+  method?: string;
+  params?: unknown;
+}
+
+/**
  * Wait for the next WebSocket message that satisfies `predicate`.
  * Rejects with a timeout error if no matching message arrives within `timeoutMs`.
+ *
+ * Defaults to `JsonRpcTestResponse` so callers can directly do
+ * `resp.result.tools` / `resp.error.code` without per-callsite casts.
+ * Pass a more specific type as the generic argument if needed.
  */
-export function waitFor(
+export function waitFor<T = JsonRpcTestResponse>(
   ws: WebSocket,
   predicate: (msg: Record<string, unknown>) => boolean,
   timeoutMs = 5000,
-): Promise<Record<string, unknown>> {
+): Promise<T> {
   return new Promise((resolve, reject) => {
     const timer = setTimeout(
       () => reject(new Error("Timed out waiting for message")),
@@ -52,7 +73,7 @@ export function waitFor(
       if (predicate(parsed)) {
         clearTimeout(timer);
         ws.off("message", handler);
-        resolve(parsed);
+        resolve(parsed as T);
       }
     };
     ws.on("message", handler);

--- a/src/__tests__/wsUtils.test.ts
+++ b/src/__tests__/wsUtils.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { WebSocket } from "ws";
+import type { Logger } from "../logger.js";
 import { BACKPRESSURE_THRESHOLD, safeSend, waitForDrain } from "../wsUtils.js";
 
 function makeWs(readyState = WebSocket.OPEN, bufferedAmount = 0) {
@@ -16,7 +17,7 @@ const logger = {
   warn: vi.fn(),
   error: vi.fn(),
   debug: vi.fn(),
-};
+} as unknown as Logger;
 
 beforeEach(() => vi.clearAllMocks());
 

--- a/src/tools/__tests__/githubReview.test.ts
+++ b/src/tools/__tests__/githubReview.test.ts
@@ -19,10 +19,11 @@ import { execSafe } from "../utils.js";
 
 const mockExecSafe = vi.mocked(execSafe);
 
+// biome-ignore lint/suspicious/noExplicitAny: tests assert nested JSON fields
 function parse(result: {
   content: Array<{ type: string; text: string }>;
   isError?: true;
-}) {
+}): any {
   const raw = JSON.parse(result.content.at(0)?.text ?? "{}") as unknown;
   // New error format: { error: "...", code?: "..." } — unwrap to the error string for backward-compat
   if (

--- a/src/tools/__tests__/githubTools.test.ts
+++ b/src/tools/__tests__/githubTools.test.ts
@@ -24,10 +24,11 @@ import { execSafe } from "../utils.js";
 const mockExecSafe = vi.mocked(execSafe);
 const ws = "/fake/workspace";
 
+// biome-ignore lint/suspicious/noExplicitAny: tests assert nested JSON fields
 function parse(r: {
   content: Array<{ type: string; text: string }>;
   isError?: true;
-}) {
+}): any {
   const raw = JSON.parse(r.content.at(0)?.text ?? "{}") as unknown;
   if (
     r.isError &&


### PR DESCRIPTION
## Summary

First slice of the typecheck:tests campaign (Finding 3 from the audit). Three pattern fixes that knock out ~24% of the 323-error backlog without per-error fixups.

### 1. Generic \`JsonRpcTestResponse\` default for \`waitFor()\` ([wsHelpers.ts](src/__tests__/wsHelpers.ts))

Replaces the previous \`Record<string, unknown>\` default with a permissive shape that types \`result\` as \`any\` and \`error\` as \`{ code; message; data? }\`. Tests can now do \`resp.result.tools.find(...)\` and \`resp.error.code\` without per-callsite casts.

**Closes 33 TS18046 errors** across [lazyTools](src/__tests__/lazyTools.test.ts), [transport-tools-list](src/__tests__/transport-tools-list.test.ts), [transport](src/__tests__/transport.test.ts), [transport-ajv](src/__tests__/transport-ajv.test.ts).

### 2. Permissive \`parse()\` return on github tool test helpers

[githubReview.test.ts](src/tools/__tests__/githubReview.test.ts) and [githubTools.test.ts](src/tools/__tests__/githubTools.test.ts) decode JSON tool results into \`unknown\`, then assertions like \`data.title\` errored. Typed the helpers as returning \`any\` (with \`biome-ignore\` note).

**Closes 30 TS18046 errors.**

### 3. Logger cast + rule helper annotations

- [wsUtils.test.ts](src/__tests__/wsUtils.test.ts) — Logger mock was missing \`event\`/\`child\` methods. \`as unknown as Logger\` cast.
- [approvalHttp.test.ts](src/__tests__/approvalHttp.test.ts) — \`emptyRules()\` / \`denyRules()\` / \`allowRules()\` had narrow inferred return types from \`[]\` literals. Added explicit \`Rules\` return annotation.

**Closes 15 errors** (11 TS2345 from wsUtils + 4 TS2345 from approvalHttp).

## Net effect

| Category | Before | After |
|---|---|---|
| Total \`typecheck:tests\` errors | 323 | **246** |
| TS18046 ('unknown' access) | 73 | 0 |
| TS2345 (assignment) | 82 | 68 |

Closed: **77 errors (-24%)**.

## Out of scope (next slices)

- **Remaining 68 TS2345** — split across [generateTests](src/tools/__tests__/generateTests.test.ts) (11, Buffer type drift), [automation.test](src/__tests__/automation.test.ts) (10, \`IClaudeDriver\` / \`ProviderDriver\` — auto-fixed when **PR #315** merges), and a long tail of per-file mock issues.
- **37 TS2532** 'possibly undefined' on array index access — needs case-by-case judgment (add \`!\`, refactor, or proper guard).
- **15 TS6133** unused locals — most are \`_\`-prefixed scaffolding the test author kept; deletion is per-site judgment.

## Test plan

- [x] \`npx tsc --noEmit\` (production) — clean
- [x] \`npx tsc --noEmit -p tsconfig.tests.json\` — 246 errors (was 323)
- [x] \`npx vitest run\` — 5017 passing (2 pre-existing failures on main, not introduced here: dashboard-cli-state-unification + recipes/scheduler)
- [x] \`npx biome check --write\` on changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)