### PR TITLE
feat(inbox): archive + permanent delete

### DIFF
--- a/dashboard/src/app/inbox/page.tsx
+++ b/dashboard/src/app/inbox/page.tsx
@@ -869,13 +869,15 @@ const filteredItems = items.filter((item) => {
                           style={{ fontSize: "var(--fs-xs)", color: "var(--ink-3)" }}
                           onClick={async () => {
                             const proceed = window.confirm(
-                              `Archive "${selected.name}"? This permanently deletes the inbox item.`,
+                              `Archive "${selected.name}"? It will be moved to ~/.patchwork/inbox/.archive and hidden from the list.`,
                             );
                             if (!proceed) return;
                             try {
                               const res = await fetch(
-                                apiPath(`/api/bridge/inbox/${encodeURIComponent(selected.name)}`),
-                                { method: "DELETE" },
+                                apiPath(
+                                  `/api/bridge/inbox/${encodeURIComponent(selected.name)}/archive`,
+                                ),
+                                { method: "POST" },
                               );
                               if (!res.ok) {
                                 const text = await res.text().catch(() => res.statusText);
@@ -893,6 +895,37 @@ const filteredItems = items.filter((item) => {
                           }}
                         >
                           Archive
+                        </button>
+                        <button
+                          type="button"
+                          className="btn sm ghost"
+                          style={{ fontSize: "var(--fs-xs)", color: "var(--err)" }}
+                          onClick={async () => {
+                            const proceed = window.confirm(
+                              `Permanently delete "${selected.name}"? This cannot be undone.`,
+                            );
+                            if (!proceed) return;
+                            try {
+                              const res = await fetch(
+                                apiPath(`/api/bridge/inbox/${encodeURIComponent(selected.name)}`),
+                                { method: "DELETE" },
+                              );
+                              if (!res.ok) {
+                                const text = await res.text().catch(() => res.statusText);
+                                toast.error(`Delete failed: ${text || res.status}`);
+                                return;
+                              }
+                              toast.success(`Deleted “${selected.name}”`);
+                              fetchList(true);
+                              setSelected(null);
+                            } catch (e) {
+                              toast.error(
+                                e instanceof Error ? e.message : String(e),
+                              );
+                            }
+                          }}
+                        >
+                          Delete permanently
                         </button>
                       </div>
                     </>

--- a/src/__tests__/inbox-archive-delete.test.ts
+++ b/src/__tests__/inbox-archive-delete.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Integration tests for inbox archive + permanent-delete routes.
+ *
+ * tryHandleInboxRoute reads from `~/.patchwork/inbox` directly via
+ * `os.homedir()`. We override `process.env.HOME` (and `USERPROFILE` for
+ * Windows-y env shims) to point at a tmp dir per test so writes don't
+ * touch the real inbox.
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { tryHandleInboxRoute } from "../inboxRoutes.js";
+
+let fakeHome = "";
+let realHome: string | undefined;
+let realUserProfile: string | undefined;
+
+beforeEach(() => {
+  fakeHome = mkdtempSync(path.join(os.tmpdir(), "inbox-routes-"));
+  realHome = process.env.HOME;
+  realUserProfile = process.env.USERPROFILE;
+  process.env.HOME = fakeHome;
+  process.env.USERPROFILE = fakeHome;
+  mkdirSync(path.join(fakeHome, ".patchwork", "inbox"), { recursive: true });
+});
+
+afterEach(() => {
+  if (realHome === undefined) delete process.env.HOME;
+  else process.env.HOME = realHome;
+  if (realUserProfile === undefined) delete process.env.USERPROFILE;
+  else process.env.USERPROFILE = realUserProfile;
+  if (fakeHome && existsSync(fakeHome)) {
+    rmSync(fakeHome, { recursive: true, force: true });
+  }
+});
+
+type Captured = { status: number; body: string };
+
+function captureResponse(): { res: ServerResponse; result: Captured } {
+  const result: Captured = { status: 0, body: "" };
+  const chunks: string[] = [];
+  const res = {
+    writeHead: (status: number) => {
+      result.status = status;
+    },
+    end: (chunk?: string) => {
+      if (chunk) chunks.push(chunk);
+      result.body = chunks.join("");
+    },
+  } as unknown as ServerResponse;
+  return { res, result };
+}
+
+function fakeRequest(method: string): IncomingMessage {
+  return { method } as IncomingMessage;
+}
+
+async function flush(): Promise<void> {
+  // Route handlers are dispatched via `void (async () => {...})()` and may
+  // call `await import("node:fs/promises")` internally, so we need a real
+  // tick (not just the microtask queue) before asserting.
+  await new Promise((r) => setTimeout(r, 30));
+}
+
+describe("inboxRoutes — archive + delete", () => {
+  it("archives an inbox file into ~/.patchwork/inbox/.archive/", async () => {
+    const filename = "daily-status-2026-05-07.md";
+    writeFileSync(
+      path.join(fakeHome, ".patchwork", "inbox", filename),
+      "# daily status\n",
+    );
+
+    const { res, result } = captureResponse();
+    const handled = tryHandleInboxRoute(
+      fakeRequest("POST"),
+      res,
+      new URL(`http://x/inbox/${filename}/archive`),
+    );
+    expect(handled).toBe(true);
+    await flush();
+
+    expect(result.status).toBe(200);
+    const body = JSON.parse(result.body) as { ok: boolean; path: string };
+    expect(body.ok).toBe(true);
+    expect(body.path.endsWith(`.archive/${filename}`)).toBe(true);
+
+    const inboxDir = path.join(fakeHome, ".patchwork", "inbox");
+    expect(existsSync(path.join(inboxDir, filename))).toBe(false);
+    expect(existsSync(path.join(inboxDir, ".archive", filename))).toBe(true);
+  });
+
+  it("permanently deletes an inbox file via DELETE", async () => {
+    const filename = "ctx-loop-test-2026-05-07.md";
+    const inboxDir = path.join(fakeHome, ".patchwork", "inbox");
+    writeFileSync(path.join(inboxDir, filename), "ctx output");
+
+    const { res, result } = captureResponse();
+    const handled = tryHandleInboxRoute(
+      fakeRequest("DELETE"),
+      res,
+      new URL(`http://x/inbox/${filename}`),
+    );
+    expect(handled).toBe(true);
+    await flush();
+
+    expect(result.status).toBe(200);
+    expect(JSON.parse(result.body).ok).toBe(true);
+    expect(existsSync(path.join(inboxDir, filename))).toBe(false);
+    // Hard delete — must NOT have stashed it in .archive/.
+    expect(existsSync(path.join(inboxDir, ".archive", filename))).toBe(false);
+  });
+
+  it("returns 404 when archiving a missing inbox item", async () => {
+    const { res, result } = captureResponse();
+    tryHandleInboxRoute(
+      fakeRequest("POST"),
+      res,
+      new URL("http://x/inbox/nope.md/archive"),
+    );
+    await flush();
+    expect(result.status).toBe(404);
+    expect(JSON.parse(result.body).ok).toBe(false);
+  });
+
+  it("returns 404 when deleting a missing inbox item", async () => {
+    const { res, result } = captureResponse();
+    tryHandleInboxRoute(
+      fakeRequest("DELETE"),
+      res,
+      new URL("http://x/inbox/nope.md"),
+    );
+    await flush();
+    expect(result.status).toBe(404);
+  });
+
+  it("rejects path traversal on archive", async () => {
+    const { res, result } = captureResponse();
+    tryHandleInboxRoute(
+      fakeRequest("POST"),
+      res,
+      // The filename regex requires `.md` and rejects `/`, but URL-encoded
+      // slash decodes back to `/` — must still be rejected.
+      new URL("http://x/inbox/%2E%2E%2Fpasswd.md/archive"),
+    );
+    await flush();
+    expect(result.status).toBe(400);
+  });
+
+  it("does not let archive overwrite an existing archived file", async () => {
+    const filename = "branch-health-2026-05-07.md";
+    const inboxDir = path.join(fakeHome, ".patchwork", "inbox");
+    writeFileSync(path.join(inboxDir, filename), "v1");
+
+    const r1 = captureResponse();
+    tryHandleInboxRoute(
+      fakeRequest("POST"),
+      r1.res,
+      new URL(`http://x/inbox/${filename}/archive`),
+    );
+    await flush();
+    expect(r1.result.status).toBe(200);
+
+    // Re-create at the same name and archive again.
+    writeFileSync(path.join(inboxDir, filename), "v2");
+    const r2 = captureResponse();
+    tryHandleInboxRoute(
+      fakeRequest("POST"),
+      r2.res,
+      new URL(`http://x/inbox/${filename}/archive`),
+    );
+    await flush();
+    expect(r2.result.status).toBe(200);
+
+    const archived = readdirSync(path.join(inboxDir, ".archive"));
+    expect(archived.filter((f) => f.startsWith("branch-health")).length).toBe(
+      2,
+    );
+  });
+
+  it("inbox list excludes the .archive directory", async () => {
+    const filename = "active.md";
+    const inboxDir = path.join(fakeHome, ".patchwork", "inbox");
+    writeFileSync(path.join(inboxDir, filename), "active");
+
+    // Archive it, then call GET /inbox.
+    const arch = captureResponse();
+    tryHandleInboxRoute(
+      fakeRequest("POST"),
+      arch.res,
+      new URL(`http://x/inbox/${filename}/archive`),
+    );
+    await flush();
+
+    const { res, result } = captureResponse();
+    tryHandleInboxRoute(fakeRequest("GET"), res, new URL("http://x/inbox"));
+    await flush();
+    expect(result.status).toBe(200);
+    const body = JSON.parse(result.body) as { items: { name: string }[] };
+    expect(body.items.find((i) => i.name === filename)).toBeUndefined();
+  });
+});

--- a/src/inboxRoutes.ts
+++ b/src/inboxRoutes.ts
@@ -21,6 +21,20 @@ import path from "node:path";
 import { respond500 } from "./httpErrorResponse.js";
 
 /**
+ * Filename guard shared by every inbox sub-route. Rejects directory
+ * separators and `..` segments so the request can never escape the inbox
+ * directory. Returns the joined absolute path on success, or null with the
+ * caller responsible for emitting a 400.
+ */
+function safeInboxPath(filename: string): string | null {
+  if (!filename) return null;
+  if (filename.includes("/") || filename.includes("\\")) return null;
+  if (filename === "." || filename === "..") return null;
+  if (filename.startsWith(".")) return null; // no dotfiles, reserves `.archive/` namespace
+  return path.join(os.homedir(), ".patchwork", "inbox", filename);
+}
+
+/**
  * Try to handle an `/inbox` or `/inbox/<filename>.md` route. Returns true
  * if the route was dispatched (caller should `return` from the request
  * handler), false if no route matched.
@@ -87,18 +101,12 @@ export function tryHandleInboxRoute(
       try {
         const { readFile, stat } = await import("node:fs/promises");
         const filename = decodeURIComponent(inboxFileMatch[1] ?? "");
-        // Prevent path traversal — filename must not contain directory separators
-        if (filename.includes("/") || filename.includes("\\")) {
+        const filePath = safeInboxPath(filename);
+        if (!filePath) {
           res.writeHead(400, { "Content-Type": "application/json" });
           res.end(JSON.stringify({ error: "Invalid filename" }));
           return;
         }
-        const filePath = path.join(
-          os.homedir(),
-          ".patchwork",
-          "inbox",
-          filename,
-        );
         const [content, stats] = await Promise.all([
           readFile(filePath, "utf8"),
           stat(filePath),
@@ -116,6 +124,79 @@ export function tryHandleInboxRoute(
         if (code === "ENOENT") {
           res.writeHead(404, { "Content-Type": "application/json" });
           res.end(JSON.stringify({ error: "Not found" }));
+        } else {
+          respond500(res, err);
+        }
+      }
+    })();
+    return true;
+  }
+
+  if (inboxFileMatch && req.method === "DELETE") {
+    void (async () => {
+      try {
+        const { unlink } = await import("node:fs/promises");
+        const filename = decodeURIComponent(inboxFileMatch[1] ?? "");
+        const filePath = safeInboxPath(filename);
+        if (!filePath) {
+          res.writeHead(400, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ ok: false, error: "Invalid filename" }));
+          return;
+        }
+        await unlink(filePath);
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ ok: true, path: filePath }));
+      } catch (err: unknown) {
+        const code = (err as NodeJS.ErrnoException).code;
+        if (code === "ENOENT") {
+          res.writeHead(404, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ ok: false, error: "Not found" }));
+        } else {
+          respond500(res, err);
+        }
+      }
+    })();
+    return true;
+  }
+
+  // POST /inbox/<filename>.md/archive — move to ~/.patchwork/inbox/.archive/
+  const inboxArchiveMatch = parsedUrl.pathname?.match(
+    /^\/inbox\/([^/]+\.md)\/archive$/,
+  );
+  if (inboxArchiveMatch && req.method === "POST") {
+    void (async () => {
+      try {
+        const { mkdir, rename } = await import("node:fs/promises");
+        const filename = decodeURIComponent(inboxArchiveMatch[1] ?? "");
+        const filePath = safeInboxPath(filename);
+        if (!filePath) {
+          res.writeHead(400, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ ok: false, error: "Invalid filename" }));
+          return;
+        }
+        const archiveDir = path.join(
+          os.homedir(),
+          ".patchwork",
+          "inbox",
+          ".archive",
+        );
+        await mkdir(archiveDir, { recursive: true });
+        let dest = path.join(archiveDir, filename);
+        // Suffix with timestamp on collision so historical archives survive.
+        if (existsSync(dest)) {
+          const ext = path.extname(filename);
+          const stem = filename.slice(0, filename.length - ext.length);
+          const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+          dest = path.join(archiveDir, `${stem}.${stamp}${ext}`);
+        }
+        await rename(filePath, dest);
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ ok: true, path: dest }));
+      } catch (err: unknown) {
+        const code = (err as NodeJS.ErrnoException).code;
+        if (code === "ENOENT") {
+          res.writeHead(404, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ ok: false, error: "Not found" }));
         } else {
           respond500(res, err);
         }


### PR DESCRIPTION
## Summary
- New bridge endpoints: `POST /inbox/<filename>.md/archive` (move into `~/.patchwork/inbox/.archive/`, timestamp-suffixed on collision) and `DELETE /inbox/<filename>.md` (hard delete).
- Refactors the inbox filename guard into a shared `safeInboxPath` helper that also blocks dotfile prefixes — reserves the `.archive/` namespace and tightens the existing GET handler in passing.
- Dashboard: the inbox page's existing "Archive" button was hard-deleting via `DELETE` despite its label. Repointed to the new archive endpoint, and added a separate "Delete permanently" button with an explicit cannot-be-undone confirmation.

The bridge's existing `/api/bridge/[...path]` catch-all proxies both methods, so no new dashboard API routes are required.

## Test plan
- [x] `src/__tests__/inbox-archive-delete.test.ts` — 7 cases: archive happy path, hard delete, 404s, traversal rejection, collision-suffix, hard-delete-vs-archive, list endpoint excludes `.archive/`.
- [x] Bridge typecheck clean.
- [x] Dashboard suite 307/307 passes.
- [ ] Click "Archive" on an inbox item → file lands in `~/.patchwork/inbox/.archive/`, list refreshes without it.
- [ ] Click "Delete permanently" → confirm dialog → file gone, no `.archive/` copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)