### PR TITLE
feat(recipes): archive + permanent delete

### DIFF
--- a/dashboard/src/app/api/bridge/recipes/[name]/route.ts
+++ b/dashboard/src/app/api/bridge/recipes/[name]/route.ts
@@ -95,3 +95,34 @@ export async function PATCH(
 ): Promise<Response> {
   return forwardWithMethod(req, ctx, "PATCH");
 }
+
+export async function DELETE(
+  req: NextRequest,
+  ctx: RouteContext,
+): Promise<Response> {
+  const sfs = req.headers.get("sec-fetch-site");
+  if (sfs && sfs !== "same-origin" && sfs !== "none") {
+    return new Response(JSON.stringify({ error: "CSRF check failed" }), {
+      status: 403,
+      headers: { "content-type": "application/json" },
+    });
+  }
+  if (await isDemoModeServer()) return demoOk();
+  try {
+    const { name } = await ctx.params;
+    const encodedName = encodeURIComponent(name);
+    const res = await bridgeFetch(`/recipes/${encodedName}`, {
+      method: "DELETE",
+    });
+    const text = await res.text();
+    return new Response(text, {
+      status: res.status,
+      headers: { "content-type": "application/json" },
+    });
+  } catch (err) {
+    return new Response(
+      JSON.stringify({ error: err instanceof Error ? err.message : "fetch failed" }),
+      { status: 502, headers: { "content-type": "application/json" } },
+    );
+  }
+}

--- a/dashboard/src/app/recipes/page.tsx
+++ b/dashboard/src/app/recipes/page.tsx
@@ -6,6 +6,7 @@ import { Dialog } from "@/components/Dialog";
 import { apiPath } from "@/lib/api";
 import { ConnectorHealthPanel } from "@/components/ConnectorHealthPanel";
 import { SkeletonList } from "@/components/Skeleton";
+import { useToast } from "@/components/Toast";
 import {
   CodeBlock,
   ErrorState,
@@ -440,6 +441,8 @@ function RecipeDetailPanel({
   recentRuns,
   onClose,
   onRun,
+  onArchive,
+  onDelete,
   running,
   isLive,
 }: {
@@ -447,6 +450,8 @@ function RecipeDetailPanel({
   recentRuns: RunRecord[];
   onClose: () => void;
   onRun: () => void;
+  onArchive: () => void;
+  onDelete: () => void;
   running: Record<string, string>;
   isLive: boolean;
 }) {
@@ -563,6 +568,36 @@ function RecipeDetailPanel({
           </div>
         )}
       </div>
+
+      <div
+        style={{
+          marginTop: 18,
+          paddingTop: 12,
+          borderTop: "1px solid var(--line-2)",
+          display: "flex",
+          gap: 8,
+          justifyContent: "flex-end",
+        }}
+      >
+        <button
+          type="button"
+          className="btn sm ghost"
+          style={{ fontSize: "var(--fs-xs)", color: "var(--ink-3)" }}
+          onClick={onArchive}
+          title="Move to ~/.patchwork/recipes/.archive — hidden from this list, restorable from disk"
+        >
+          Archive
+        </button>
+        <button
+          type="button"
+          className="btn sm ghost"
+          style={{ fontSize: "var(--fs-xs)", color: "var(--err)" }}
+          onClick={onDelete}
+          title="Permanently delete the recipe file. Cannot be undone."
+        >
+          Delete permanently
+        </button>
+      </div>
     </PatchCard>
   );
 }
@@ -579,6 +614,7 @@ export default function RecipesPage() {
   const [modal, setModal] = useState<RunModalState | null>(null);
   const [modalRunning, setModalRunning] = useState(false);
   const [search, setSearch] = useState("");
+  const toast = useToast();
 
   const load = React.useCallback(async () => {
     try {
@@ -738,6 +774,54 @@ export default function RecipesPage() {
             )
           : prev,
       );
+    }
+  }
+
+  async function handleArchiveRecipe(recipe: Recipe) {
+    const proceed = window.confirm(
+      `Archive "${recipe.name}"? It will be moved to ~/.patchwork/recipes/.archive and hidden from this list. Trigger "${recipe.trigger ?? "?"}" stops firing once archived.`,
+    );
+    if (!proceed) return;
+    try {
+      const res = await fetch(
+        apiPath(
+          `/api/bridge/recipes/${encodeURIComponent(recipe.name)}/archive`,
+        ),
+        { method: "POST" },
+      );
+      if (!res.ok) {
+        const text = await res.text().catch(() => res.statusText);
+        toast.error(`Archive failed: ${text || res.status}`);
+        return;
+      }
+      toast.success(`Archived “${recipe.name}”`);
+      setSelectedName(null);
+      void load();
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : String(e));
+    }
+  }
+
+  async function handleDeleteRecipe(recipe: Recipe) {
+    const proceed = window.confirm(
+      `Permanently delete "${recipe.name}"? This removes the YAML file and any sidecar permissions. Cannot be undone.`,
+    );
+    if (!proceed) return;
+    try {
+      const res = await fetch(
+        apiPath(`/api/bridge/recipes/${encodeURIComponent(recipe.name)}`),
+        { method: "DELETE" },
+      );
+      if (!res.ok) {
+        const text = await res.text().catch(() => res.statusText);
+        toast.error(`Delete failed: ${text || res.status}`);
+        return;
+      }
+      toast.success(`Deleted “${recipe.name}”`);
+      setSelectedName(null);
+      void load();
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : String(e));
     }
   }
 
@@ -1069,6 +1153,8 @@ export default function RecipesPage() {
               recentRuns={recentRunsMap.get(selectedRecipe.name) ?? []}
               onClose={() => setSelectedName(null)}
               onRun={() => handleRunClick(selectedRecipe)}
+              onArchive={() => void handleArchiveRecipe(selectedRecipe)}
+              onDelete={() => void handleDeleteRecipe(selectedRecipe)}
               running={running}
               isLive={isLive(selectedRecipe.name)}
             />

--- a/src/__tests__/recipes-archive.test.ts
+++ b/src/__tests__/recipes-archive.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Unit tests for archiveRecipe — covers happy path, sidecar move, missing
+ * recipe, invalid name, and timestamped collision suffix.
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { archiveRecipe } from "../recipesHttp.js";
+
+let recipesDir = "";
+
+beforeEach(() => {
+  recipesDir = mkdtempSync(path.join(os.tmpdir(), "archive-recipe-"));
+});
+
+afterEach(() => {
+  if (recipesDir && existsSync(recipesDir)) {
+    rmSync(recipesDir, { recursive: true, force: true });
+  }
+});
+
+describe("archiveRecipe", () => {
+  it("moves a yaml recipe and its sidecar into .archive/", () => {
+    writeFileSync(
+      path.join(recipesDir, "demo.yaml"),
+      "name: demo\ntrigger:\n  type: manual\n",
+    );
+    writeFileSync(
+      path.join(recipesDir, "demo.yaml.permissions.json"),
+      JSON.stringify({ trust: "auto" }),
+    );
+
+    const result = archiveRecipe(recipesDir, "demo");
+
+    expect(result.ok).toBe(true);
+    expect(result.path).toMatch(/\.archive\/demo\.yaml$/);
+    expect(existsSync(path.join(recipesDir, "demo.yaml"))).toBe(false);
+    expect(existsSync(path.join(recipesDir, ".archive", "demo.yaml"))).toBe(
+      true,
+    );
+    expect(
+      existsSync(
+        path.join(recipesDir, ".archive", "demo.yaml.permissions.json"),
+      ),
+    ).toBe(true);
+  });
+
+  it("returns 404-style error for unknown recipe", () => {
+    const result = archiveRecipe(recipesDir, "nope");
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe("Recipe not found");
+  });
+
+  it("rejects invalid recipe names", () => {
+    const result = archiveRecipe(recipesDir, "../etc/passwd");
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe("Invalid recipe name");
+  });
+
+  it("suffixes archives on collision so history survives", () => {
+    // First archive lands at .archive/demo.yaml.
+    writeFileSync(path.join(recipesDir, "demo.yaml"), "name: demo\n");
+    expect(archiveRecipe(recipesDir, "demo").ok).toBe(true);
+
+    // Re-create demo.yaml and archive again — must NOT overwrite.
+    writeFileSync(path.join(recipesDir, "demo.yaml"), "name: demo\nv: 2\n");
+    const result = archiveRecipe(recipesDir, "demo");
+
+    expect(result.ok).toBe(true);
+    expect(result.path).not.toBe(
+      path.join(recipesDir, ".archive", "demo.yaml"),
+    );
+    expect(result.path).toMatch(/\.archive\/demo\..+\.yaml$/);
+
+    const archived = readdirSync(path.join(recipesDir, ".archive"));
+    expect(archived.filter((f) => f.startsWith("demo")).length).toBe(2);
+  });
+
+  it("moves a json recipe (no yaml present)", () => {
+    writeFileSync(
+      path.join(recipesDir, "json-only.json"),
+      JSON.stringify({ name: "json-only", trigger: { type: "manual" } }),
+    );
+
+    const result = archiveRecipe(recipesDir, "json-only");
+    expect(result.ok).toBe(true);
+    expect(existsSync(path.join(recipesDir, "json-only.json"))).toBe(false);
+    expect(
+      existsSync(path.join(recipesDir, ".archive", "json-only.json")),
+    ).toBe(true);
+  });
+
+  it("creates .archive/ on demand", () => {
+    writeFileSync(path.join(recipesDir, "fresh.yaml"), "name: fresh\n");
+    expect(existsSync(path.join(recipesDir, ".archive"))).toBe(false);
+
+    const result = archiveRecipe(recipesDir, "fresh");
+    expect(result.ok).toBe(true);
+    expect(existsSync(path.join(recipesDir, ".archive"))).toBe(true);
+  });
+});

--- a/src/__tests__/recipes-archive.test.ts
+++ b/src/__tests__/recipes-archive.test.ts
@@ -5,7 +5,6 @@
 
 import {
   existsSync,
-  mkdirSync,
   mkdtempSync,
   readdirSync,
   rmSync,

--- a/src/recipeOrchestration.ts
+++ b/src/recipeOrchestration.ts
@@ -18,6 +18,7 @@ import type {
 import { RecipeScheduler } from "./recipes/scheduler.js";
 import { hasTool } from "./recipes/toolRegistry.js";
 import {
+  archiveRecipe,
   deleteRecipeContent,
   duplicateRecipe,
   findWebhookRecipe,
@@ -119,6 +120,11 @@ export class RecipeOrchestration {
     server.deleteRecipeContentFn = (name: string) => {
       const recipesDir = join(homedir(), ".patchwork", "recipes");
       return deleteRecipeContent(recipesDir, name);
+    };
+
+    server.archiveRecipeFn = (name: string) => {
+      const recipesDir = join(homedir(), ".patchwork", "recipes");
+      return archiveRecipe(recipesDir, name);
     };
 
     server.duplicateRecipeFn = (name: string) => {

--- a/src/recipeRoutes.ts
+++ b/src/recipeRoutes.ts
@@ -320,6 +320,9 @@ export interface RecipeRouteDeps {
   deleteRecipeContentFn:
     | ((name: string) => { ok: boolean; path?: string; error?: string })
     | null;
+  archiveRecipeFn:
+    | ((name: string) => { ok: boolean; path?: string; error?: string })
+    | null;
   duplicateRecipeFn:
     | ((name: string) => {
         ok: boolean;
@@ -1023,6 +1026,28 @@ export function tryHandleRecipeRoute(
       return true;
     }
     const result = deps.deleteRecipeContentFn(name);
+    const status = result.ok
+      ? 200
+      : result.error === "Recipe not found"
+        ? 404
+        : 400;
+    res.writeHead(status, { "Content-Type": "application/json" });
+    res.end(JSON.stringify(result));
+    return true;
+  }
+
+  // POST /recipes/:name/archive — move recipe (+ sidecar) into <recipesDir>/.archive/
+  const archiveMatch = /^\/recipes\/([^/]+)\/archive$/.exec(parsedUrl.pathname);
+  if (archiveMatch && req.method === "POST") {
+    const name = decodeURIComponent(archiveMatch[1] ?? "");
+    if (!deps.archiveRecipeFn) {
+      res.writeHead(503, { "Content-Type": "application/json" });
+      res.end(
+        JSON.stringify({ ok: false, error: "Recipe archive unavailable" }),
+      );
+      return true;
+    }
+    const result = deps.archiveRecipeFn(name);
     const status = result.ok
       ? 200
       : result.error === "Recipe not found"

--- a/src/recipesHttp.ts
+++ b/src/recipesHttp.ts
@@ -4,6 +4,7 @@ import {
   mkdirSync,
   readdirSync,
   readFileSync,
+  renameSync,
   rmSync,
   statSync,
   writeFileSync,
@@ -72,6 +73,9 @@ function* iterateInstallDirs(
     return;
   }
   for (const f of entries) {
+    // Skip dotfile-prefixed dirs (`.archive/`, `.disabled/`, …). Conventionally
+    // hidden; reserves the namespace for archive/recovery features.
+    if (f.startsWith(".")) continue;
     const fullPath = path.join(recipesDir, f);
     let isDir = false;
     try {
@@ -637,6 +641,63 @@ export function deleteRecipeContent(
       }
     }
     return { ok: true, path: resolved };
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+/**
+ * Archives a recipe by moving its file (and sidecar `.permissions.json`)
+ * into `<recipesDir>/.archive/`. The archive directory is created on demand.
+ * On filename collision the moved file is suffixed with the current
+ * timestamp so historical archives never overwrite each other.
+ *
+ * Returns the absolute archived path on success, ok=false with a 404-style
+ * error when the recipe cannot be located.
+ */
+export function archiveRecipe(
+  recipesDir: string,
+  name: string,
+): { ok: boolean; path?: string; error?: string } {
+  const safeName = name.toLowerCase();
+  if (!RECIPE_NAME_RE.test(safeName)) {
+    return { ok: false, error: "Invalid recipe name" };
+  }
+  const base = path.resolve(recipesDir);
+  const target =
+    findYamlRecipePath(recipesDir, safeName) ??
+    resolveJsonRecipePathByName(recipesDir, safeName);
+  if (!target) {
+    return { ok: false, error: "Recipe not found" };
+  }
+  const resolved = path.resolve(target);
+  if (!resolved.startsWith(base + path.sep)) {
+    return { ok: false, error: "Invalid path" };
+  }
+  const archiveDir = path.join(base, ".archive");
+  try {
+    mkdirSync(archiveDir, { recursive: true });
+    const basename = path.basename(resolved);
+    let dest = path.join(archiveDir, basename);
+    if (existsSync(dest)) {
+      const ext = path.extname(basename);
+      const stem = basename.slice(0, basename.length - ext.length);
+      const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+      dest = path.join(archiveDir, `${stem}.${stamp}${ext}`);
+    }
+    renameSync(resolved, dest);
+    const sidecar = `${resolved}.permissions.json`;
+    if (existsSync(sidecar)) {
+      try {
+        renameSync(sidecar, `${dest}.permissions.json`);
+      } catch {
+        // sidecar move best-effort — primary archive already succeeded
+      }
+    }
+    return { ok: true, path: dest };
   } catch (err) {
     return {
       ok: false,

--- a/src/server.ts
+++ b/src/server.ts
@@ -166,6 +166,10 @@ export class Server extends EventEmitter<ServerEvents> {
   public deleteRecipeContentFn:
     | ((name: string) => { ok: boolean; path?: string; error?: string })
     | null = null;
+  /** Patchwork: set by bridge to archive a recipe (move to .archive/). */
+  public archiveRecipeFn:
+    | ((name: string) => { ok: boolean; path?: string; error?: string })
+    | null = null;
   /** Patchwork: set by bridge to promote a variant recipe to the canonical name. */
   public promoteRecipeVariantFn:
     | ((
@@ -1187,6 +1191,7 @@ export class Server extends EventEmitter<ServerEvents> {
           loadRecipeContentFn: this.loadRecipeContentFn,
           saveRecipeContentFn: this.saveRecipeContentFn,
           deleteRecipeContentFn: this.deleteRecipeContentFn,
+          archiveRecipeFn: this.archiveRecipeFn,
           duplicateRecipeFn: this.duplicateRecipeFn,
           promoteRecipeVariantFn: this.promoteRecipeVariantFn,
           lintRecipeContentFn: this.lintRecipeContentFn,


### PR DESCRIPTION
## Summary
- New bridge endpoint: `POST /recipes/<name>/archive` — moves the recipe yaml/json and its `.permissions.json` sidecar into `~/.patchwork/recipes/.archive/`, timestamp-suffixed on collision so historical archives are preserved.
- `iterateInstallDirs` now skips dotfile-prefixed dirs so the new `.archive/` (and any future reserved `.foo/` namespace) isn't re-discovered as an install dir during listing/scheduling.
- Dashboard: adds `DELETE` export to `/api/bridge/recipes/[name]/route.ts` — the existing file routed only GET/PUT/PATCH which made DELETE return 405 instead of falling through to the catch-all proxy.
- Recipe detail panel grows a footer action row with "Archive" and "Delete permanently" buttons, each behind a confirm dialog with toast feedback.

The pre-existing `DELETE /recipes/<name>` for permanent removal is left untouched — this PR just wires it into the dashboard surface.

## Test plan
- [x] `src/__tests__/recipes-archive.test.ts` — 6 cases: happy path with sidecar move, missing recipe → 404-style, invalid name, timestamped collision suffix, json-only variant, on-demand `.archive/` creation.
- [x] Bridge typecheck clean; dashboard suite 307/307 passes.
- [ ] In the dashboard recipe detail panel, click Archive on a yaml recipe → confirm dialog → file lands in `~/.patchwork/recipes/.archive/`, list refreshes without it, sidecar moves too.
- [ ] Click "Delete permanently" → confirm dialog → file gone, no `.archive/` copy.
- [ ] Confirm scheduler does not re-fire archived cron recipes (dotfile-skip check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)