### PR TITLE
fix(dashboard): portal Dialog into document.body to escape inert app root

### DIFF
--- a/dashboard/src/components/Dialog.tsx
+++ b/dashboard/src/components/Dialog.tsx
@@ -8,7 +8,9 @@ import {
   useEffect,
   useId,
   useRef,
+  useState,
 } from "react";
+import { createPortal } from "react-dom";
 
 type DialogProps = {
   open: boolean;
@@ -50,6 +52,13 @@ export function Dialog({
   const panelRef = useRef<HTMLDivElement | null>(null);
   const previousActiveRef = useRef<HTMLElement | null>(null);
   const fallbackId = useId();
+  // Portal into document.body so the dialog escapes the [data-app-root] subtree
+  // that gets `inert` + `aria-hidden` while the dialog is open. Without this,
+  // the dialog's own buttons would be inert and unclickable.
+  const [portalTarget, setPortalTarget] = useState<HTMLElement | null>(null);
+  useEffect(() => {
+    setPortalTarget(document.body);
+  }, []);
 
   // Capture the previously-focused element BEFORE the dialog renders so that
   // a rapid open/close/open sequence doesn't end up storing the dialog itself
@@ -131,9 +140,9 @@ export function Dialog({
     [onClose],
   );
 
-  if (!open) return null;
+  if (!open || !portalTarget) return null;
 
-  return (
+  return createPortal(
     <div
       role="presentation"
       onClick={(e) => {
@@ -175,6 +184,7 @@ export function Dialog({
       >
         {children}
       </div>
-    </div>
+    </div>,
+    portalTarget,
   );
 }

--- a/dashboard/src/components/__tests__/Dialog.inert.test.tsx
+++ b/dashboard/src/components/__tests__/Dialog.inert.test.tsx
@@ -1,0 +1,53 @@
+/**
+ * Regression test for the "Cancel button doesn't work" bug on the
+ * Disconnect-Slack confirmation modal.
+ *
+ * Cause: <Dialog> sets the `inert` attribute on `[data-app-root]` while open
+ * to mark the rest of the app non-interactive. The dialog itself is rendered
+ * inline in the React tree, so before the portal fix it lived as a *descendant*
+ * of `[data-app-root]` — making the dialog (and its Cancel/Confirm buttons)
+ * inert too. Clicking Cancel did nothing.
+ *
+ * Fix: render the dialog through a portal into `document.body`, escaping the
+ * inert subtree.
+ */
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+import { describe, expect, it } from "vitest";
+import { Dialog } from "@/components/Dialog";
+
+function Harness() {
+  const [open, setOpen] = useState(true);
+  return (
+    <div data-app-root>
+      <main>app shell content</main>
+      <Dialog open={open} onClose={() => setOpen(false)} ariaLabel="confirm">
+        <button type="button" onClick={() => setOpen(false)}>
+          Cancel
+        </button>
+      </Dialog>
+    </div>
+  );
+}
+
+describe("<Dialog/> escapes the inert app root", () => {
+  it("renders the dialog panel outside [data-app-root]", () => {
+    render(<Harness />);
+    const panel = screen.getByRole("dialog");
+    // Before the fix, panel.closest('[data-app-root]') resolves to the wrapper
+    // div — the dialog is a descendant of the inert subtree and its buttons
+    // can't be clicked. After the fix (createPortal to document.body) the
+    // closest data-app-root ancestor is null.
+    expect(panel.closest("[data-app-root]")).toBeNull();
+  });
+
+  it("Cancel click closes the dialog", async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

- Dialog set \`inert\` + \`aria-hidden\` on \`[data-app-root]\` while open, but rendered inline in the React tree → its own buttons were inert, breaking flows like the Disconnect-Slack confirm modal.
- Render the dialog via \`createPortal(document.body)\` so it escapes the inert subtree.
- Adds [Dialog.inert.test.tsx](dashboard/src/components/__tests__/Dialog.inert.test.tsx): asserts the panel has no \`[data-app-root]\` ancestor and that a Cancel click actually closes the dialog (would have failed before the fix).

## Test plan

- [x] \`vitest run dashboard/src/components/__tests__/Dialog.inert.test.tsx\` — 2/2 pass
- [x] biome clean
- [ ] Manual: open any dashboard confirmation modal (e.g. Disconnect connector) and confirm Cancel + ESC + backdrop-click all close it

🤖 Generated with [Claude Code](https://claude.com/claude-code)