### PR TITLE
chore: README prerequisites + start-all --bridge-port flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Same codebase. Bridge is the foundation; Patchwork OS is the optional layer on t
 
 ## 🔌 Claude IDE Bridge — Quick Start
 
+**Prerequisites:** a supported code editor — **VS Code, Cursor, Windsurf, or Google Antigravity** (or JetBrains via the [companion plugin](#jetbrains-plugin)) — plus Node.js 20+ and the [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code). The bridge's LSP, debugger, and editor-state tools run through the editor extension; without one you're limited to the headless CLI subset.
+
 ```bash
 # 1. Install the npm package
 npm install -g patchwork-os

--- a/scripts/start-all.sh
+++ b/scripts/start-all.sh
@@ -53,6 +53,7 @@ VPS=""
 FULL_MODE=""
 NO_DASHBOARD=""
 DASHBOARD_PORT="3200"
+BRIDGE_PORT_FLAG=""
 AUTOMATION_POLICY=""
 CLAUDE_DRIVER="subprocess"
 BRIDGE_READY_TIMEOUT="${BRIDGE_READY_TIMEOUT:-30}"
@@ -71,6 +72,7 @@ while [[ $# -gt 0 ]]; do
     --full)              FULL_MODE="--full"; shift ;;
     --no-dashboard)      NO_DASHBOARD=1; shift ;;
     --dashboard-port)    DASHBOARD_PORT="$2"; shift 2 ;;
+    --bridge-port)       BRIDGE_PORT_FLAG="--port $2"; shift 2 ;;
     --automation-policy) AUTOMATION_POLICY="$2"; shift 2 ;;
     --claude-driver)     CLAUDE_DRIVER="$2"; shift 2 ;;
     *)                   echo "Unknown option: $1" >&2; exit 1 ;;
@@ -147,7 +149,7 @@ if [[ -z "${TMUX:-}" ]]; then
   fi
   # Create session detached, re-run this script inside it, then attach
   tmux new-session -d -s "$SESSION" -x 200 -y 50
-  tmux send-keys -t "$SESSION" "\"$SCRIPT_PATH\" --workspace \"$WORKSPACE\"$([ -n "$NTFY_TOPIC" ] && echo " --notify \"$NTFY_TOPIC\"")$([ -n "$IDE_NAME" ] && echo " --ide \"$IDE_NAME\"")$([ -n "$VPS" ] && echo " --vps \"$VPS\"")$([ -n "$FULL_MODE" ] && echo " --full")" Enter
+  tmux send-keys -t "$SESSION" "\"$SCRIPT_PATH\" --workspace \"$WORKSPACE\"$([ -n "$NTFY_TOPIC" ] && echo " --notify \"$NTFY_TOPIC\"")$([ -n "$IDE_NAME" ] && echo " --ide \"$IDE_NAME\"")$([ -n "$VPS" ] && echo " --vps \"$VPS\"")$([ -n "$FULL_MODE" ] && echo " --full")$([ -n "$BRIDGE_PORT_FLAG" ] && echo " ${BRIDGE_PORT_FLAG/--port /--bridge-port }")" Enter
   exec tmux attach -t "$SESSION"
 fi
 
@@ -213,7 +215,7 @@ if [[ -f "$BRIDGE_DIR/src/index.ts" ]]; then
 else
   BRIDGE_BIN="node dist/index.js"
 fi
-BRIDGE_CMD="cd $(printf '%q' "$BRIDGE_DIR") && $BRIDGE_BIN --workspace $(printf '%q' "$WORKSPACE")${BRIDGE_IDE_FLAGS:+ $BRIDGE_IDE_FLAGS}${FULL_MODE:+ $FULL_MODE}${BRIDGE_AUTOMATION_FLAGS:+ $BRIDGE_AUTOMATION_FLAGS}"
+BRIDGE_CMD="cd $(printf '%q' "$BRIDGE_DIR") && $BRIDGE_BIN --workspace $(printf '%q' "$WORKSPACE")${BRIDGE_IDE_FLAGS:+ $BRIDGE_IDE_FLAGS}${FULL_MODE:+ $FULL_MODE}${BRIDGE_AUTOMATION_FLAGS:+ $BRIDGE_AUTOMATION_FLAGS}${BRIDGE_PORT_FLAG:+ $BRIDGE_PORT_FLAG}"
 # Derive a short display name for the Claude session from the workspace directory name.
 # This appears in Claude Code's session list, making multi-workspace tmux setups identifiable.
 WS_BASENAME=$(basename "$WORKSPACE")


### PR DESCRIPTION
## Summary

- **README**: prerequisite section before the install snippet — supported editor (VS Code/Cursor/Windsurf/Antigravity, or JetBrains via the companion plugin) + Node 20+ + Claude Code CLI. Surfaces the editor-extension dependency up-front so people don't get the headless-CLI subset and wonder where the LSP/debugger tools went.
- **start-all.sh**: \`--bridge-port <port>\` flag, plumbed through both the tmux re-exec and the bridge command line. Lets you pin the bridge to a specific port — useful when running multiple workspaces side-by-side and the auto-picked port collides.

## Test plan

- [x] \`bash -n scripts/start-all.sh\` clean
- [ ] Manual: \`scripts/start-all.sh --workspace . --bridge-port 9876\` confirms bridge listens on 9876

🤖 Generated with [Claude Code](https://claude.com/claude-code)