### PR TITLE
harden(security): close 4 CodeQL alerts (#119/#112/#120/#109)

### DIFF
--- a/dashboard/src/app/api/bridge/[...path]/__tests__/route.test.ts
+++ b/dashboard/src/app/api/bridge/[...path]/__tests__/route.test.ts
@@ -79,3 +79,34 @@ describe("catch-all bridge proxy — body cap", () => {
     expect(res.status).toBe(200);
   });
 });
+
+describe("catch-all bridge proxy — error body does not leak internals", () => {
+  const ctx = { params: Promise.resolve({ path: ["some", "path"] }) };
+
+  it("returns generic 502 body when bridgeFetch throws (CodeQL #120)", async () => {
+    const lib = await import("@/lib/bridge");
+    const internal =
+      "ECONNREFUSED 127.0.0.1:9876 at /Users/secret/path/internal.ts:42";
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      vi.mocked(lib.bridgeFetch).mockImplementationOnce(async () => {
+        throw new Error(internal);
+      });
+      const res = await POST(
+        makeReq(JSON.stringify({ ok: true }), "16"),
+        ctx,
+      );
+      expect(res.status).toBe(502);
+      const text = await res.text();
+      expect(text).not.toContain("ECONNREFUSED");
+      expect(text).not.toContain("/Users/");
+      expect(text).not.toContain("internal.ts");
+      // The generic message that should be returned instead.
+      expect(JSON.parse(text)).toEqual({ error: "Bridge unreachable" });
+      // Detail still goes to server logs for ops visibility.
+      expect(consoleSpy).toHaveBeenCalled();
+    } finally {
+      consoleSpy.mockRestore();
+    }
+  });
+});

--- a/dashboard/src/app/api/bridge/[...path]/route.ts
+++ b/dashboard/src/app/api/bridge/[...path]/route.ts
@@ -155,8 +155,12 @@ async function proxy(req: NextRequest, segments: string[]): Promise<Response> {
       body,
     });
   } catch (err) {
+    // Detail (ECONNREFUSED, file paths, etc.) goes to server logs only —
+    // returning err.message to the browser exposed internals (CodeQL #120,
+    // js/stack-trace-exposure). Body matches the SSE branch above.
+    console.error("[dashboard /api/bridge] proxy fetch failed:", err);
     return new Response(
-      JSON.stringify({ error: err instanceof Error ? err.message : String(err) }),
+      JSON.stringify({ error: "Bridge unreachable" }),
       { status: 502, headers: { "content-type": "application/json" } },
     );
   }

--- a/examples/personal-api-demo/index.html
+++ b/examples/personal-api-demo/index.html
@@ -357,8 +357,24 @@ function randomBase64Url(len = 48) {
 
 // ── State ─────────────────────────────────────────────────────────────────────
 
+// Reject anything that isn't http(s) — CodeQL #112 (js/xss-through-dom):
+// without this guard, a `javascript:` value in the bridge-url input ends up
+// concatenated into `window.location.href` below and runs as script.
+function isHttpUrl(value) {
+  if (typeof value !== 'string' || value.length === 0) return false;
+  try {
+    const u = new URL(value);
+    return u.protocol === 'http:' || u.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
 const S = {
-  bridgeUrl: () => document.getElementById('bridge-url').value.replace(/\/$/, ''),
+  bridgeUrl: () => {
+    const raw = document.getElementById('bridge-url').value.replace(/\/$/, '');
+    return isHttpUrl(raw) ? raw : '';
+  },
   token: null,
   clientId: null,
 };
@@ -477,7 +493,12 @@ async function handleCallback() {
 
   const verifier = sessionStorage.getItem('pkce_verifier');
   const clientId = sessionStorage.getItem('pwa_client_id');
-  const bridgeUrl = sessionStorage.getItem('pwa_bridge') ?? S.bridgeUrl();
+  const storedBridge = sessionStorage.getItem('pwa_bridge');
+  const bridgeUrl = isHttpUrl(storedBridge) ? storedBridge : S.bridgeUrl();
+  if (!bridgeUrl) {
+    showAuthError('Bridge URL missing or invalid. Re-enter and retry.');
+    return false;
+  }
 
   // Exchange code for token
   try {

--- a/examples/personal-api-demo/index.html
+++ b/examples/personal-api-demo/index.html
@@ -460,7 +460,24 @@ async function startOAuthFlow() {
   sessionStorage.setItem('pwa_client_id', clientId);
   sessionStorage.setItem('pwa_bridge', bridgeUrl);
 
-  // 3. Redirect to bridge authorization endpoint
+  // 3. Redirect to bridge authorization endpoint. Build the target via the
+  // URL constructor (relative path resolved against the validated bridge
+  // origin) — CodeQL's xss-through-dom analyzer recognises this as proper
+  // sanitisation, and the constructor rejects values without a parseable
+  // origin. We re-check the protocol on the parsed URL as a belt-and-braces
+  // guard since `bridgeUrl` could in principle be a sessionStorage value
+  // poisoned out of band.
+  let target;
+  try {
+    target = new URL('/oauth/authorize', bridgeUrl);
+  } catch {
+    showAuthError('Bridge URL is not a valid origin.');
+    return;
+  }
+  if (target.protocol !== 'http:' && target.protocol !== 'https:') {
+    showAuthError('Bridge URL must be http(s).');
+    return;
+  }
   const params = new URLSearchParams({
     response_type: 'code',
     client_id: clientId,
@@ -470,7 +487,8 @@ async function startOAuthFlow() {
     state,
     scope: 'mcp',
   });
-  window.location.href = `${bridgeUrl}/oauth/authorize?${params}`;
+  for (const [k, v] of params) target.searchParams.set(k, v);
+  window.location.href = target.toString();
 }
 
 async function handleCallback() {

--- a/examples/plugins/sqlite-library/index.mjs
+++ b/examples/plugins/sqlite-library/index.mjs
@@ -24,12 +24,53 @@ import path from "node:path";
 
 const DEFAULT_DB_PATH = path.join(os.homedir(), "library.sqlite3");
 
-// Anchored regex: only SELECT / PRAGMA / EXPLAIN allowed, optionally
-// preceded by whitespace and an SQL comment block. Multi-statement
-// queries are rejected by `better-sqlite3.prepare()` itself; we only
-// need to gate the leading verb.
-const READ_ONLY_VERB =
-  /^\s*(?:--[^\n]*\n|\/\*[\s\S]*?\*\/|\s)*(?:SELECT|PRAGMA|EXPLAIN)\b/i;
+// Only SELECT / PRAGMA / EXPLAIN allowed, optionally preceded by whitespace
+// and SQL comment blocks. Multi-statement queries are rejected by
+// `better-sqlite3.prepare()` itself; we only need to gate the leading verb.
+//
+// Hand-rolled scanner instead of one big regex: the prior version mixed a
+// lazy `[\s\S]*?` block-comment branch with a `\s` whitespace branch under a
+// `(?:...)*` outer quantifier, which CodeQL flagged for polynomial backtracking
+// on adversarial input like `/*` repeated. indexOf-based scanning is O(n)
+// regardless of input.
+const VERB_RE = /^(?:SELECT|PRAGMA|EXPLAIN)\b/i;
+export function isReadOnlyVerb(sql) {
+  if (typeof sql !== "string") return false;
+  let i = 0;
+  const n = sql.length;
+  while (i < n) {
+    const c = sql.charCodeAt(i);
+    // whitespace: space, \t, \n, \r, \f, \v
+    if (
+      c === 0x20 ||
+      c === 0x09 ||
+      c === 0x0a ||
+      c === 0x0d ||
+      c === 0x0c ||
+      c === 0x0b
+    ) {
+      i++;
+      continue;
+    }
+    // line comment "-- … \n"
+    if (c === 0x2d && sql.charCodeAt(i + 1) === 0x2d) {
+      const nl = sql.indexOf("\n", i + 2);
+      if (nl === -1) return false;
+      i = nl + 1;
+      continue;
+    }
+    // block comment "/* … */"
+    if (c === 0x2f && sql.charCodeAt(i + 1) === 0x2a) {
+      const end = sql.indexOf("*/", i + 2);
+      if (end === -1) return false;
+      i = end + 2;
+      continue;
+    }
+    // first non-whitespace, non-comment character: must be a permitted verb.
+    return VERB_RE.test(sql.slice(i));
+  }
+  return false;
+}
 
 let cachedDb = null;
 let cachedDbPath = null;
@@ -126,7 +167,7 @@ export function register(ctx) {
               : DEFAULT_DB_PATH;
           const limit = Math.min(Math.max(1, Number(args.limit) || 200), 1000);
 
-          if (!READ_ONLY_VERB.test(sql)) {
+          if (!isReadOnlyVerb(sql)) {
             return {
               isError: true,
               content: [

--- a/src/__tests__/approvalHttp.test.ts
+++ b/src/__tests__/approvalHttp.test.ts
@@ -1066,9 +1066,17 @@ describe("push notification dispatch", () => {
       const item = queue.list()[0];
       if (item) queue.approve(item.callId);
       await pending;
-      expect(calls.filter((u) => u.includes("push.example.com"))).toHaveLength(
-        0,
-      );
+      // Hostname-exact check (not String.includes — CodeQL #109,
+      // js/incomplete-url-substring-sanitization).
+      expect(
+        calls.filter((u) => {
+          try {
+            return new URL(u).hostname === "push.example.com";
+          } catch {
+            return false;
+          }
+        }),
+      ).toHaveLength(0);
     } finally {
       globalThis.fetch = originalFetch;
     }

--- a/src/__tests__/sqlite-library-readonly.test.ts
+++ b/src/__tests__/sqlite-library-readonly.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Regression test for CodeQL #119 (js/redos) on the sqlite-library example
+ * plugin's read-only verb gate.
+ *
+ * The original gate used a single regex with overlapping alternatives under a
+ * `(?:...)*` quantifier, which backtracks polynomially on adversarial input
+ * like `/*` repeated. The replacement is an indexOf-based scanner that is
+ * O(n) regardless of input.
+ *
+ * Tests cover both the adversarial timing case and the legitimate-use cases
+ * the gate is supposed to allow / reject.
+ */
+
+import { describe, expect, it } from "vitest";
+
+// Dynamic import — plugin lives outside src/, but vitest can resolve it
+// relative to repo root.
+const { isReadOnlyVerb } = (await import(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  "../../examples/plugins/sqlite-library/index.mjs" as any
+)) as { isReadOnlyVerb: (s: string) => boolean };
+
+describe("sqlite-library isReadOnlyVerb — adversarial input", () => {
+  it("returns in well under 100 ms on the CodeQL ReDoS payload (no match)", () => {
+    // The exact shape CodeQL #119 flagged: '/*' followed by many '*//*'
+    // with no terminating '*/'. The old regex backtracks through every
+    // partition of the run trying to match the trailing verb and hangs
+    // (8 s+ on N=60 in CI, exponential past that). The scanner moves
+    // strictly forward via indexOf, so the whole pass is O(n).
+    const adversarial = "/*" + "*//*".repeat(200);
+    const start = Date.now();
+    const result = isReadOnlyVerb(adversarial);
+    const elapsed = Date.now() - start;
+    expect(result).toBe(false);
+    expect(elapsed).toBeLessThan(100);
+  });
+
+  it("returns in well under 100 ms on a 50_000-char benign comment chain", () => {
+    // Same shape but balanced + followed by SELECT — exercises the
+    // happy-path scanner cost on a long input.
+    const balanced = "/*" + "*//*".repeat(25_000) + "*/ SELECT 1";
+    const start = Date.now();
+    const result = isReadOnlyVerb(balanced);
+    const elapsed = Date.now() - start;
+    expect(result).toBe(true);
+    expect(elapsed).toBeLessThan(100);
+  });
+
+  it("rejects unterminated block comment without scanning past the end", () => {
+    const unterminated = "/*" + "x".repeat(10_000);
+    expect(isReadOnlyVerb(unterminated)).toBe(false);
+  });
+
+  it("rejects unterminated line comment at EOF", () => {
+    expect(isReadOnlyVerb("-- never closed")).toBe(false);
+  });
+});
+
+describe("sqlite-library isReadOnlyVerb — happy path", () => {
+  it("accepts plain SELECT", () => {
+    expect(isReadOnlyVerb("SELECT 1")).toBe(true);
+  });
+
+  it("accepts PRAGMA and EXPLAIN", () => {
+    expect(isReadOnlyVerb("PRAGMA table_info(books)")).toBe(true);
+    expect(isReadOnlyVerb("EXPLAIN QUERY PLAN SELECT * FROM books")).toBe(true);
+  });
+
+  it("accepts case-insensitive verbs", () => {
+    expect(isReadOnlyVerb("select 1")).toBe(true);
+    expect(isReadOnlyVerb("SeLeCt 1")).toBe(true);
+  });
+
+  it("accepts leading whitespace and line comments", () => {
+    expect(isReadOnlyVerb("   \n\t  SELECT 1")).toBe(true);
+    expect(isReadOnlyVerb("-- catalog read\nSELECT title FROM books")).toBe(
+      true,
+    );
+  });
+
+  it("accepts leading block comments", () => {
+    expect(isReadOnlyVerb("/* read-only */ SELECT 1")).toBe(true);
+    expect(
+      isReadOnlyVerb(
+        "/* multi\n * line\n * comment */\n-- and a line comment\nSELECT 1",
+      ),
+    ).toBe(true);
+  });
+});
+
+describe("sqlite-library isReadOnlyVerb — rejection", () => {
+  it("rejects INSERT / UPDATE / DELETE / DROP", () => {
+    expect(isReadOnlyVerb("INSERT INTO books VALUES (1)")).toBe(false);
+    expect(isReadOnlyVerb("UPDATE books SET x=1")).toBe(false);
+    expect(isReadOnlyVerb("DELETE FROM books")).toBe(false);
+    expect(isReadOnlyVerb("DROP TABLE books")).toBe(false);
+  });
+
+  it("rejects empty / non-string input", () => {
+    expect(isReadOnlyVerb("")).toBe(false);
+    expect(isReadOnlyVerb("   \n\t  ")).toBe(false);
+    // @ts-expect-error — guard checks typeof
+    expect(isReadOnlyVerb(undefined)).toBe(false);
+    // @ts-expect-error — guard checks typeof
+    expect(isReadOnlyVerb(null)).toBe(false);
+  });
+
+  it("rejects verb-like prefix that isn't a word (no \\b)", () => {
+    expect(isReadOnlyVerb("SELECTOR FROM books")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Three real vulnerabilities + one test-only sharpening from the open code-scanning queue. Each landed with a failing-then-passing regression test where testable; for the static demo HTML the CodeQL re-scan is the verification surface.

| Alert | Severity | Where | Fix |
|---|---|---|---|
| **#119** js/redos | High | [examples/plugins/sqlite-library/index.mjs:32](examples/plugins/sqlite-library/index.mjs#L32) | Replace overlapping-alternation regex with an indexOf-based scanner; O(n) regardless of input |
| **#112** js/xss-through-dom | High | [examples/personal-api-demo/index.html:457](examples/personal-api-demo/index.html#L457) | \`isHttpUrl()\` guard rejects \`javascript:\` (and any non-http(s)) before \`location.href\` / \`fetch\` |
| **#120** js/stack-trace-exposure | Medium | [dashboard/src/app/api/bridge/\[...path\]/route.ts:159](dashboard/src/app/api/bridge/%5B...path%5D/route.ts#L159) | Generic 502 body \`{"error":"Bridge unreachable"}\`; detail to \`console.error\` only |
| **#109** js/incomplete-url-substring-sanitization | High (test-only) | [src/\_\_tests\_\_/approvalHttp.test.ts:1069](src/__tests__/approvalHttp.test.ts#L1069) | Hostname-exact via \`new URL().hostname\` instead of \`String.includes\` |

## Why these three are real (and four others are not)

Investigation triaged all 10 open code-scanning alerts. The remaining six:

- **#117 / #116 / #114 / #113** (\`js/unvalidated-dynamic-method-call\`) — Map\<string, fn\> lookups where we control population (compiled AJV validators, pendingSends resolvers). Safe but worth a \`typeof === "function"\` guard in a follow-up.
- **#14** (\`js/shell-command-injection-from-environment\`) — \`execFileAsync\` with explicit \`args[]\`, **not** shell. Forwarded env names are an allowlist.
- **#12** (\`js/insufficient-password-hash\`) — sha256 of 256-bit cryptographically random opaque tokens. The in-code comment at [src/oauth.ts:735–746](src/oauth.ts#L735-L746) explains why a slow KDF would defeat O(1) lookup with zero security gain. To be dismissed on the alert thread post-merge.

## Lesson reinforced (memory)

Per the 2026-05-07 memory note on \`feedback_redos_bound_doesnt_help.md\`: CodeQL flags the backtracking *shape*, not worst-case length. Bounding the quantifier doesn't silence it — restructure to remove the backtracking surface entirely. The scanner approach here matches that pattern.

## Test plan

- [x] \`vitest run src/__tests__/sqlite-library-readonly.test.ts\` — 12/12 pass; CodeQL adversarial payload completes in <2 ms
- [x] \`vitest run src/__tests__/approvalHttp.test.ts\` — 48/48 pass with the URL-hostname assertion
- [x] \`vitest run "dashboard/src/app/api/bridge/[...path]/__tests__/route.test.ts"\` — 4/4 pass (new stack-trace assertion was failing before the route fix)
- [x] \`tsc --noEmit -p tsconfig.tests.core.json\` clean
- [x] \`tsc --noEmit -p dashboard/tsconfig.json\` clean
- [x] biome clean
- [ ] Confirm CodeQL re-scan closes all four alerts on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)