### PR TITLE
ui(wave1): motion gate + QuiltBg pause/RM + recipes a11y + Overview h2 + Shell SVGs

### DIFF
--- a/dashboard/src/app/globals.css
+++ b/dashboard/src/app/globals.css
@@ -2541,3 +2541,27 @@ button.topbar-search {
   white-space: nowrap;
   border: 0;
 }
+
+
+/* ──────────────────────────────────────────────────────────────────────────
+   Reduced-motion gate (audit Wave 1 / WCAG 2.3.3)
+
+   Audit found 13 keyframe animations and 0 prefers-reduced-motion guards.
+   The rule below collapses every transition + animation to instant for
+   users who've set their OS preference to "reduce motion". Targeted decay
+   to ~0.01s rather than `none` so an animation-end / transition-end event
+   still fires, in case a component depends on it. Cells in QuiltBg are
+   gated separately (cell flicker is JS-driven, not CSS-driven).
+   ────────────────────────────────────────────────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    animation-delay: 0ms !important;
+    transition-duration: 0.01ms !important;
+    transition-delay: 0ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/dashboard/src/app/page.tsx
+++ b/dashboard/src/app/page.tsx
@@ -251,7 +251,7 @@ function ActivityThread({ events }: { events: ActivityEvent[] }) {
           marginBottom: 14,
         }}
       >
-        <h3
+        <h2
           style={{
             fontSize: "var(--fs-m)",
             fontWeight: 700,
@@ -263,7 +263,7 @@ function ActivityThread({ events }: { events: ActivityEvent[] }) {
           }}
         >
           Activity thread
-        </h3>
+        </h2>
         <Link
           href="/activity"
           style={{ fontSize: "var(--fs-xs)", color: "var(--orange)", textDecoration: "none" }}
@@ -422,7 +422,7 @@ function RecentRecipesCard({ recipes }: { recipes: Recipe[] }) {
           marginBottom: 14,
         }}
       >
-        <h3
+        <h2
           style={{
             fontSize: "var(--fs-m)",
             fontWeight: 700,
@@ -434,7 +434,7 @@ function RecentRecipesCard({ recipes }: { recipes: Recipe[] }) {
           }}
         >
           Recent recipes
-        </h3>
+        </h2>
         <Link
           href="/recipes"
           style={{
@@ -523,7 +523,7 @@ function HealthCard({
           marginBottom: 12,
         }}
       >
-        <h3
+        <h2
           style={{
             fontSize: "var(--fs-m)",
             fontWeight: 700,
@@ -535,7 +535,7 @@ function HealthCard({
           }}
         >
           Health
-        </h3>
+        </h2>
         <span
           className={`pill ${bridgeOk && extensionConnected ? "ok" : bridgeOk ? "muted" : "warn"}`}
           style={{ fontSize: "var(--fs-2xs)" }}

--- a/dashboard/src/app/recipes/page.tsx
+++ b/dashboard/src/app/recipes/page.tsx
@@ -975,15 +975,23 @@ export default function RecipesPage() {
           <PatchCard padded={false} style={{ overflow: "hidden", minWidth: 0 }}>
             <div className="table-wrap" style={{ minWidth: 0, overflow: "auto" }}>
               <table className="table" style={{ width: "100%", tableLayout: "fixed" }}>
+                <caption className="sr-only">
+                  Installed recipes with health, trigger, last 14 runs, average duration, last run time, and actions.
+                </caption>
                 <thead>
                   <tr>
-                    <th style={{ width: 48, textAlign: "center" }}>%</th>
-                    <th style={{ minWidth: 160 }}>RECIPE</th>
-                    <th style={{ width: 120 }}>TRIGGER</th>
-                    <th style={{ width: 90, textAlign: "center" }}>LAST 14 RUNS</th>
-                    <th style={{ width: 80 }}>AVG</th>
-                    <th style={{ width: 100 }}>LAST</th>
-                    <th style={{ width: 110, textAlign: "right" }}>&nbsp;</th>
+                    <th scope="col" style={{ width: 48, textAlign: "center" }}>
+                      <span aria-hidden="true">%</span>
+                      <span className="sr-only">Health</span>
+                    </th>
+                    <th scope="col" style={{ minWidth: 160 }}>RECIPE</th>
+                    <th scope="col" style={{ width: 120 }}>TRIGGER</th>
+                    <th scope="col" style={{ width: 90, textAlign: "center" }}>LAST 14 RUNS</th>
+                    <th scope="col" style={{ width: 80 }}>AVG</th>
+                    <th scope="col" style={{ width: 100 }}>LAST</th>
+                    <th scope="col" style={{ width: 110, textAlign: "right" }}>
+                      <span className="sr-only">Actions</span>
+                    </th>
                   </tr>
                 </thead>
                 <tbody>

--- a/dashboard/src/components/Shell.tsx
+++ b/dashboard/src/components/Shell.tsx
@@ -346,12 +346,12 @@ export function Shell({ children }: { children: ReactNode }) {
             aria-label={`Switch to ${active === "dark" ? "paper" : "dark"} theme`}
           >
             {active === "paper" ? (
-              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.85" strokeLinecap="round" strokeLinejoin="round">
+              <svg aria-hidden="true" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.85" strokeLinecap="round" strokeLinejoin="round">
                 <circle cx="12" cy="12" r="4" />
                 <path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42" />
               </svg>
             ) : (
-              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.85" strokeLinecap="round" strokeLinejoin="round">
+              <svg aria-hidden="true" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.85" strokeLinecap="round" strokeLinejoin="round">
                 <path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z" />
               </svg>
             )}
@@ -380,7 +380,7 @@ export function Shell({ children }: { children: ReactNode }) {
       </header>
       <aside className="app-sidebar" aria-label="Primary navigation">
         <Link href="/recipes/new" className="sidebar-create" style={{ textDecoration: "none" }}>
-          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" style={{ position: "relative", zIndex: 1 }}>
+          <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" style={{ position: "relative", zIndex: 1 }}>
             <path d={PATHS.plus} />
           </svg>
           <span style={{ position: "relative", zIndex: 1 }}>New recipe</span>

--- a/dashboard/src/components/patchwork/QuiltBg.tsx
+++ b/dashboard/src/components/patchwork/QuiltBg.tsx
@@ -55,8 +55,16 @@ export function QuiltBg({
   const [cells, setCells] = useState<Cell[]>(initial);
 
   // After mount, splash a fresh randomised palette across the grid so
-  // the visual richness isn't just a deterministic checker pattern.
+  // the visual richness isn't just a deterministic checker pattern. Skip
+  // when the user has prefers-reduced-motion set — they get the stable
+  // deterministic layout.
   useEffect(() => {
+    if (
+      typeof window !== "undefined" &&
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches
+    ) {
+      return;
+    }
     setCells((prev) =>
       prev.map((c) => ({
         ...c,
@@ -65,19 +73,56 @@ export function QuiltBg({
     );
   }, []);
 
+  // Background mosaic flicker — gated on (a) prefers-reduced-motion, and
+  // (b) document.visibilityState. Without (a), reduced-motion users still
+  // see the cells re-flip every 1.4 s. Without (b), the timer keeps firing
+  // on hidden tabs, repainting 140 cells off-screen.
   useEffect(() => {
-    const id = setInterval(() => {
-      setCells((prev) => {
-        const next = prev.slice();
-        const flips = 3 + Math.floor(Math.random() * 3);
-        for (let i = 0; i < flips; i++) {
-          const idx = Math.floor(Math.random() * next.length);
-          next[idx] = { ...next[idx], fill: PALETTE[Math.floor(Math.random() * PALETTE.length)] };
-        }
-        return next;
-      });
-    }, 1400);
-    return () => clearInterval(id);
+    if (typeof window === "undefined") return;
+    const reduced = window.matchMedia("(prefers-reduced-motion: reduce)");
+    if (reduced.matches) return;
+
+    let id: ReturnType<typeof setInterval> | null = null;
+    const start = () => {
+      if (id !== null) return;
+      id = setInterval(() => {
+        setCells((prev) => {
+          const next = prev.slice();
+          const flips = 3 + Math.floor(Math.random() * 3);
+          for (let i = 0; i < flips; i++) {
+            const idx = Math.floor(Math.random() * next.length);
+            next[idx] = {
+              ...next[idx],
+              fill: PALETTE[Math.floor(Math.random() * PALETTE.length)],
+            };
+          }
+          return next;
+        });
+      }, 1400);
+    };
+    const stop = () => {
+      if (id !== null) {
+        clearInterval(id);
+        id = null;
+      }
+    };
+    const onVisibility = () => {
+      if (document.visibilityState === "visible") start();
+      else stop();
+    };
+    const onMotionChange = () => {
+      if (reduced.matches) stop();
+      else if (document.visibilityState === "visible") start();
+    };
+
+    if (document.visibilityState === "visible") start();
+    document.addEventListener("visibilitychange", onVisibility);
+    reduced.addEventListener("change", onMotionChange);
+    return () => {
+      stop();
+      document.removeEventListener("visibilitychange", onVisibility);
+      reduced.removeEventListener("change", onMotionChange);
+    };
   }, []);
 
   return (


### PR DESCRIPTION
## Summary

Five small, independent Wave 1 fixes from the audit punch list. No new dependencies; no visual change for users without \`prefers-reduced-motion\` or hidden tabs.

| # | Audit ref | Where | What |
|---|---|---|---|
| 1 | #5 | [globals.css](dashboard/src/app/globals.css) | One \`@media (prefers-reduced-motion: reduce)\` block — collapses 13 keyframes + every transition to ~0.01 ms |
| 2 | #5 (JS path) | [patchwork/QuiltBg.tsx](dashboard/src/components/patchwork/QuiltBg.tsx) | Skip palette splash + interval under RM; pause interval on \`visibilitychange\`; live-react to media-query change |
| 3 | #10 | [recipes/page.tsx:977-989](dashboard/src/app/recipes/page.tsx#L977-L989) | \`<caption className="sr-only">\`, \`scope="col"\` on every \`<th>\`, sr-only "Health" / "Actions" labels |
| 4 | #6 | [page.tsx:254/425/526](dashboard/src/app/page.tsx#L254) | Three \`<h3>\` section headings → \`<h2>\` (h1 → h2 → cards) |
| 5 | #3 (Shell subset) | [Shell.tsx:349/354/383](dashboard/src/components/Shell.tsx#L349) | \`aria-hidden="true"\` on theme-toggle sun/moon + sidebar-create plus icons |

## What I deliberately deferred

- **Contrast token tweak** (\`--err\` darken, \`--ink-3\` retune). Plan called it out as needing measurement + visual diff before merge — values I'd picked were eyeballed. Separate PR with a contrast-ratio script.
- **\`@axe-core/playwright\` smoke gate.** Adds Playwright as a new dev-dep, browser binaries, and a dev-server-in-CI step. Significant tooling lift; deserves its own PR. Wave 1's tests are in-source vitest where applicable + manual verification below.

## Test plan

- [x] \`tsc --noEmit -p dashboard/tsconfig.json\` clean
- [x] \`vitest run\` — 305/305 pass (no regressions in QuiltBg-adjacent or page tests)
- [x] biome clean
- [ ] **Manual** — open Overview, set System Settings → Accessibility → Reduce motion ON; confirm the QuiltBg cells stop flipping and the editorial-h1 stops animating
- [ ] **Manual** — open dashboard, switch to a different tab for ~10 s, switch back; confirm QuiltBg resumes flipping smoothly
- [ ] **Manual** — VoiceOver / NVDA on \`/recipes\`: confirm column headers announce "Health, column 1 of 7", "Recipe, column 2 of 7", etc., and the trailing actions column reads "Actions"
- [ ] **Manual** — outline check on \`/\` (Overview): h1 "Patchwork" → three h2 sections (no skipped levels)

## Audit claims this PR does *not* address

Per the synthesis review: skip-link / nav landmarks (#11), sidebar contrast (#2 sidebar specifically), three-font discipline (#13), 1100/768 dead zone (#12), chart SVG titles (#3 charts) — all already shipped per the agent investigations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)