### PR TITLE
ui(wave2a): tap-target fixes + LivePill connection prop

### DIFF
--- a/dashboard/src/app/activity/page.tsx
+++ b/dashboard/src/app/activity/page.tsx
@@ -4,7 +4,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { apiPath } from "@/lib/api";
 import { relTime } from "@/components/time";
 import { isDemoMode } from "@/lib/demoMode";
-import { EventsHistogram, HBarList } from "@/components/patchwork";
+import { EventsHistogram, HBarList, LivePill } from "@/components/patchwork";
 import { SkeletonList } from "@/components/Skeleton";
 import { ActivityTabs } from "@/components/ActivityTabs";
 
@@ -210,10 +210,7 @@ export default function ActivityPage() {
               : `${events.length} events · last 24h · ${stats.errors} errored`}
           </div>
         </div>
-        <span className={`pill ${connected ? "ok" : "err"}`}>
-          <span className="pill-dot" />
-          {connected ? "Live" : "Offline"}
-        </span>
+        <LivePill connection={connected ? "live" : "offline"} />
       </div>
 
       {/* Charts row: histogram + top tools */}

--- a/dashboard/src/app/page.tsx
+++ b/dashboard/src/app/page.tsx
@@ -8,6 +8,7 @@ import { relTime } from "@/components/time";
 import { useBridgeFetch } from "@/hooks/useBridgeFetch";
 import { useBridgeStatus } from "@/hooks/useBridgeStatus";
 import {
+  ActionPill,
   QuiltHero,
   WeatherRing,
   AreaChart,
@@ -264,12 +265,9 @@ function ActivityThread({ events }: { events: ActivityEvent[] }) {
         >
           Activity thread
         </h2>
-        <Link
-          href="/activity"
-          style={{ fontSize: "var(--fs-xs)", color: "var(--orange)", textDecoration: "none" }}
-        >
+        <ActionPill href="/activity" ariaLabel="View all activity">
           view all →
-        </Link>
+        </ActionPill>
       </div>
 
       {events.length === 0 ? (
@@ -435,16 +433,9 @@ function RecentRecipesCard({ recipes }: { recipes: Recipe[] }) {
         >
           Recent recipes
         </h2>
-        <Link
-          href="/recipes"
-          style={{
-            fontSize: "var(--fs-xs)",
-            color: "var(--accent)",
-            textDecoration: "none",
-          }}
-        >
+        <ActionPill href="/recipes" ariaLabel="View all recipes">
           all →
-        </Link>
+        </ActionPill>
       </div>
 
       {top.length === 0 ? (

--- a/dashboard/src/components/Shell.tsx
+++ b/dashboard/src/components/Shell.tsx
@@ -312,12 +312,16 @@ export function Shell({ children }: { children: ReactNode }) {
             aria-label="Toggle demo mode"
             aria-pressed={demo}
             style={{
+              // Min-height 32 px to satisfy WCAG 2.5.5 target size (was ~22 px).
+              // Keep the pill aesthetic — increased vertical padding + explicit
+              // min-height; horizontal stays narrow so it doesn't hog the bar.
               display: "inline-flex",
               alignItems: "center",
-              gap: 5,
+              gap: 6,
+              minHeight: 32,
               fontSize: "var(--fs-2xs)",
               fontWeight: 600,
-              padding: "4px 10px",
+              padding: "0 12px",
               borderRadius: 999,
               border: `1px solid ${demo ? "var(--orange)" : "var(--line-2)"}`,
               background: demo ? "color-mix(in srgb, var(--orange) 12%, transparent)" : "transparent",

--- a/dashboard/src/components/patchwork/LivePill.tsx
+++ b/dashboard/src/components/patchwork/LivePill.tsx
@@ -1,12 +1,75 @@
-export function LivePill({ label = "live", tone = "accent" }: { label?: string; tone?: "accent" | "ok" | "muted" }) {
-  const cls = tone === "ok" ? "chip-green" : tone === "muted" ? "chip-muted" : "chip-accent";
+/**
+ * LivePill — small status chip in the same visual register as `chip` /
+ * `chip-{tone}`. Two callable shapes:
+ *
+ *   <LivePill label="5s" tone="muted" />        — generic label + tone
+ *   <LivePill connection="live" />              — connection-state preset
+ *
+ * Use `connection` for SSE / live-stream health on Activity / Approvals /
+ * elsewhere — it maps to label + tone + dot animation so every page agrees
+ * on what "Live", "Reconnecting…", and "Offline" look like. Passing
+ * `connection` overrides any `label`/`tone` also provided.
+ */
+
+export type LivePillConnection = "live" | "reconnecting" | "offline";
+
+const CONNECTION_PRESETS: Record<
+  LivePillConnection,
+  { label: string; tone: "ok" | "muted" | "accent"; pulse: boolean }
+> = {
+  live: { label: "Live", tone: "ok", pulse: true },
+  reconnecting: { label: "Reconnecting…", tone: "accent", pulse: true },
+  offline: { label: "Offline", tone: "muted", pulse: false },
+};
+
+export function LivePill({
+  label = "live",
+  tone = "accent",
+  connection,
+}: {
+  label?: string;
+  tone?: "accent" | "ok" | "muted";
+  connection?: LivePillConnection;
+}) {
+  const resolved = connection
+    ? CONNECTION_PRESETS[connection]
+    : { label, tone, pulse: true };
+  const cls =
+    resolved.tone === "ok"
+      ? "chip-green"
+      : resolved.tone === "muted"
+        ? "chip-muted"
+        : "chip-accent";
   return (
     <span
       className={`chip ${cls}`}
-      style={{ textTransform: "uppercase", letterSpacing: "0.08em", fontFamily: "var(--font-mono)", fontSize: "var(--fs-2xs)", fontWeight: 600 }}
+      aria-live={connection ? "polite" : undefined}
+      style={{
+        textTransform: "uppercase",
+        letterSpacing: "0.08em",
+        fontFamily: "var(--font-mono)",
+        fontSize: "var(--fs-2xs)",
+        fontWeight: 600,
+      }}
     >
-      <span className="dot-live" aria-hidden="true" />
-      {label}
+      <span
+        className={resolved.pulse ? "dot-live" : undefined}
+        aria-hidden="true"
+        style={
+          resolved.pulse
+            ? undefined
+            : {
+                width: 6,
+                height: 6,
+                borderRadius: "50%",
+                background: "currentColor",
+                opacity: 0.6,
+                display: "inline-block",
+                marginRight: 6,
+              }
+        }
+      />
+      {resolved.label}
     </span>
   );
 }


### PR DESCRIPTION
## Summary

Three small adoptions of patchwork primitives that were already shipped but unused.

| What | Where | Before → After |
|---|---|---|
| Overview "view all →" / "all →" | [page.tsx:267-272, 438-447](dashboard/src/app/page.tsx#L267) | bare \`<Link>\` (~14 px text) → \`<ActionPill>\` (32 px target) |
| Shell "Demo" toggle | [Shell.tsx:308-341](dashboard/src/components/Shell.tsx#L308) | ~22 px pill → 32 px min-height (kept custom pressed-state styling) |
| LivePill connection state | [LivePill.tsx](dashboard/src/components/patchwork/LivePill.tsx) | label/tone only → adds \`connection: "live" | "reconnecting" | "offline"\` preset |

## Why these three

Audit refs: #4 (tap targets), #9 (primitive duplication), #14-partial (orange overloaded as a live-status accent in custom pills). The pieces in this PR are the ones where a primitive *already exists* — the Demo button kept its custom styling because \`<ActionPill>\` doesn't have a pressed-state and converting would have lost the orange-when-active visual.

First adopter of \`connection\`: Activity page swaps its custom \`<span className=\"pill ok|err\">\` for \`<LivePill connection={connected ? \"live\" : \"offline\"}>\`. The "Reconnecting…" state is wired in the preset but not yet emitted by the Activity reducer (separate PR — needs a tri-state in the SSE hook).

## Test plan

- [x] \`tsc --noEmit\` clean (dashboard)
- [x] biome clean
- [x] \`vitest run\` — 308/308 pass (no regressions; existing LivePill callers in tests unchanged)
- [ ] **Manual** — Overview at narrow widths (mobile): "view all →" / "all →" buttons tap-test
- [ ] **Manual** — toggle Demo mode in the header; confirm the pressed-state orange border + dot still fires and the button is still ~32 px tall
- [ ] **Manual** — kill the bridge while on /activity; confirm the LivePill flips from "Live" (green) to "Offline" (muted, no pulse)

## Deferred

- Approvals header doesn't have an analogous live-status pill yet — would be a richer change (it currently shows pending count). Slot for Wave 2B if desired.
- LivePill "Reconnecting…" state needs producer support: the SSE hook currently flips boolean only. Small follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)