### PR TITLE
ui(wave3): three small page-level bug fixes

### DIFF
--- a/dashboard/src/app/activity/page.tsx
+++ b/dashboard/src/app/activity/page.tsx
@@ -204,11 +204,11 @@ export default function ActivityPage() {
           <h1 className="editorial-h1">
             Activity — <span className="accent">every tool, every event, in real time.</span>
           </h1>
-          <div className="editorial-sub">
-            {events.length === 0
-              ? "No events yet"
-              : `${events.length} events · last 24h · ${stats.errors} errored`}
-          </div>
+          {events.length > 0 && (
+            <div className="editorial-sub">
+              {events.length} events · last 24h · {stats.errors} errored
+            </div>
+          )}
         </div>
         <span className={`pill ${connected ? "ok" : "err"}`}>
           <span className="pill-dot" />

--- a/dashboard/src/app/connections/page.tsx
+++ b/dashboard/src/app/connections/page.tsx
@@ -15,7 +15,14 @@ function relativeTime(iso: string): string {
   const m = Math.floor(s / 60);
   if (m < 60) return `${m}m ago`;
   const h = Math.floor(m / 60);
-  return `${h}h ago`;
+  if (h < 24) return `${h}h ago`;
+  const d = Math.floor(h / 24);
+  if (d < 7) return `${d}d ago`;
+  const w = Math.floor(d / 7);
+  if (w < 5) return `${w}w ago`;
+  const mo = Math.floor(d / 30);
+  if (mo < 12) return `${mo}mo ago`;
+  return `${Math.floor(d / 365)}y ago`;
 }
 
 // ------------------------------------------------------------------ catalog

--- a/dashboard/src/app/settings/page.tsx
+++ b/dashboard/src/app/settings/page.tsx
@@ -462,28 +462,8 @@ export default function SettingsPage() {
                   </div>
                 </div>
 
-                <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
-                  <button
-                    type="button"
-                    disabled
-                    title="Editing not wired yet — change values in the config file below and restart the bridge."
-                    aria-describedby="bridge-apply-help"
-                    style={{
-                      background: "var(--bg-2)",
-                      color: "var(--fg-3)",
-                      border: "1px solid var(--border-default)",
-                      borderRadius: "var(--r-2)",
-                      padding: "6px 14px",
-                      fontSize: "var(--fs-m)",
-                      cursor: "not-allowed",
-                      opacity: 0.6,
-                    }}
-                  >
-                    Apply
-                  </button>
-                  <span id="bridge-apply-help" style={{ fontSize: "var(--fs-s)", color: "var(--fg-3)" }}>
-                    Read-only — edit the config file directly and restart the bridge.
-                  </span>
+                <div style={{ fontSize: "var(--fs-s)", color: "var(--fg-3)" }}>
+                  Read-only — edit the config file directly and restart the bridge.
                 </div>
               </div>
 


### PR DESCRIPTION
## Summary

Three discrete bugs from the Wave 3 punch list.

| # | Where | What |
|---|---|---|
| 1 | [activity/page.tsx:208-212](dashboard/src/app/activity/page.tsx#L208) | "No events yet" rendered in editorial-sub on top of an empty-state card with the same message. Drop the sub when empty — card carries it. |
| 2 | [connections/page.tsx:11-19](dashboard/src/app/connections/page.tsx#L11-L19) | \`relativeTime\` stuck at hours — \`53h ago\` for any timestamp older than a day. Extended through days/weeks/months/years. |
| 3 | [settings/page.tsx:465-487](dashboard/src/app/settings/page.tsx#L465-L487) | Permanently-disabled "Apply" button kept around with a help span explaining why it doesn't work. Removed the button + redundant help id; kept the explanatory copy. |

## Test plan

- [x] \`tsc --noEmit\` clean (dashboard)
- [x] biome clean
- [x] \`vitest run\` — 308/308 pass (no regressions; relativeTime not under test)
- [ ] **Manual** — visit /activity with zero events → confirm only one "No activity yet" message
- [ ] **Manual** — visit /connections with a connector last-checked > 24 h ago → confirm "2d ago" / "1w ago" formatting
- [ ] **Manual** — visit /settings → confirm the bridge config row no longer shows the disabled grey "Apply" button

🤖 Generated with [Claude Code](https://claude.com/claude-code)