### PR TITLE
ui(wave3b): connections re-auth confirm + marketplace polish

### DIFF
--- a/dashboard/src/app/connections/page.tsx
+++ b/dashboard/src/app/connections/page.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { apiPath } from "@/lib/api";
 import AddConnectionModal from "./AddConnectionModal";
 import { Dialog } from "@/components/Dialog";
@@ -1030,12 +1030,22 @@ export default function ConnectionsPage() {
 
   const [reAuthing, setReAuthing] = useState(false);
   const [reAuthMsg, setReAuthMsg] = useState<string | null>(null);
+  const [reAuthConfirmOpen, setReAuthConfirmOpen] = useState(false);
 
-  async function handleReAuthAll() {
+  // Targets resolved at click-time so the confirm dialog enumerates the
+  // exact connectors that will be re-authed.
+  const reAuthTargets = useMemo(
+    () =>
+      connectors.filter(
+        (c) => c.status === "connected" || c.status === "needs_reauth",
+      ),
+    [connectors],
+  );
+
+  async function runReAuthAll() {
+    setReAuthConfirmOpen(false);
     if (reAuthing) return;
-    const targets = connectors
-      .filter((c) => c.status === "connected" || c.status === "needs_reauth")
-      .map((c) => c.id);
+    const targets = reAuthTargets.map((c) => c.id);
     if (targets.length === 0) return;
     setReAuthing(true);
     setReAuthMsg(null);
@@ -1175,8 +1185,8 @@ export default function ConnectionsPage() {
             <button
               type="button"
               className="btn sm"
-              onClick={() => void handleReAuthAll()}
-              disabled={reAuthing}
+              onClick={() => setReAuthConfirmOpen(true)}
+              disabled={reAuthing || reAuthTargets.length === 0}
               title="Re-authorize all connected providers (one at a time)"
               aria-busy={reAuthing}
             >
@@ -1265,6 +1275,59 @@ export default function ConnectionsPage() {
           </div>
         </>
       )}
+
+      {/* Re-auth-all confirmation */}
+      <Dialog
+        open={reAuthConfirmOpen}
+        onClose={() => setReAuthConfirmOpen(false)}
+        ariaLabelledBy="reauth-confirm-title"
+        maxWidth={420}
+      >
+        <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+          <strong id="reauth-confirm-title" style={{ fontSize: "var(--fs-l)" }}>
+            Re-authorize {reAuthTargets.length} connector
+            {reAuthTargets.length === 1 ? "" : "s"}?
+          </strong>
+          <p style={{ fontSize: "var(--fs-m)", color: "var(--fg-2)", margin: 0 }}>
+            One OAuth popup will open at a time, in order. Each waits for you to
+            finish before the next one opens — you can cancel between popups by
+            closing the window.
+          </p>
+          {reAuthTargets.length > 0 && (
+            <ul
+              style={{
+                margin: 0,
+                paddingLeft: 18,
+                fontSize: "var(--fs-s)",
+                color: "var(--fg-1)",
+                maxHeight: 180,
+                overflow: "auto",
+              }}
+            >
+              {reAuthTargets.map((c) => (
+                <li key={c.id}>{c.id}</li>
+              ))}
+            </ul>
+          )}
+          <div style={{ display: "flex", gap: 8, justifyContent: "flex-end" }}>
+            <button
+              type="button"
+              className="btn sm ghost"
+              onClick={() => setReAuthConfirmOpen(false)}
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              className="btn sm"
+              onClick={() => void runReAuthAll()}
+              disabled={reAuthTargets.length === 0}
+            >
+              Start re-auth
+            </button>
+          </div>
+        </div>
+      </Dialog>
 
       {/* Notion token-paste modal */}
       <Dialog

--- a/dashboard/src/app/marketplace/page.tsx
+++ b/dashboard/src/app/marketplace/page.tsx
@@ -202,7 +202,7 @@ function RecipeCard({
 
   return (
     <div className="template-card glass-card">
-      {/* top: name */}
+      {/* top: name + maintainer attribution */}
       <div style={{ marginBottom: "var(--s-2)" }}>
         <Link
           href={`/marketplace/${recipe.name}`}
@@ -218,6 +218,17 @@ function RecipeCard({
         >
           {shortName(recipe.name)}
         </Link>
+        {recipe.maintainer && (
+          <div
+            style={{
+              fontSize: "var(--fs-xs)",
+              color: "var(--ink-3)",
+              marginTop: 2,
+            }}
+          >
+            by {recipe.maintainer}
+          </div>
+        )}
       </div>
 
       {/* middle: description */}
@@ -325,7 +336,7 @@ function RecipeCard({
           ) : bridgeOnline ? (
             <button
               type="button"
-              className="btn sm"
+              className="btn sm primary"
               onClick={handleInstall}
               disabled={loading}
               aria-label={`Install ${shortName(recipe.name)}`}


### PR DESCRIPTION
## Summary

Two unrelated Wave 3 items, bundled because each is small.

### Connections "Re-auth all" → confirm dialog

The button kicked off the OAuth dance immediately on click — fine for one connector, painful when you have eight (a sequence of popups stretching over many minutes, no way out once started). Gate behind a confirm Dialog enumerating the connectors that will be re-authed.

- Dialog renders via the patchwork \`Dialog\` primitive (the [#319 portal fix](https://github.com/Oolab-labs/patchwork-os/pull/319) makes sure the Cancel button works).
- The serialized re-auth loop in \`runReAuthAll\` is unchanged — same connector-by-connector OAuth dance, just no longer fires uninvited.
- Targets memoised so the dialog body and the loop see the same list.

### Marketplace card polish

- \`Install\` button: \`btn sm\` → \`btn sm primary\` — the primary action on each card now actually reads as primary.
- Render \`recipe.maintainer\` as a small \`by @name\` line under the title. The field has existed on the type since [src/lib/registry.ts](dashboard/src/lib/registry.ts) landed and every registry entry has it populated; the UI just wasn't surfacing it.

## Test plan

- [x] \`tsc --noEmit\` clean (dashboard)
- [x] biome clean
- [x] \`vitest run\` — 308/308 pass
- [ ] **Manual** — /connections with ≥2 connected connectors → click "Re-auth all" → confirm dialog enumerates them, Cancel closes without firing OAuth, "Start re-auth" begins the loop
- [ ] **Manual** — /connections with 0 connected connectors → "Re-auth all" button is disabled
- [ ] **Manual** — /marketplace → recipe cards show "by @patchworkos" line; Install button reads as primary (orange / accent), not ghost

🤖 Generated with [Claude Code](https://claude.com/claude-code)