### PR TITLE
chore(recipes): drop dead collect_baseline + awaits refs from approval-queue-ui-test

### DIFF
--- a/templates/recipes/approval-queue-ui-test.yaml
+++ b/templates/recipes/approval-queue-ui-test.yaml
@@ -54,16 +54,7 @@ trigger:
       required: false
       default: "http://localhost:3000"
 steps:
-  - id: collect_baseline
-    parallel:
-      - id: now
-        tool: time.now
-      - id: recent_commits
-        tool: git.log_since
-        since: 1h
-
   - id: drive_browser
-    awaits: [collect_baseline]
     agent:
       driver: claude-code
       model: claude-haiku-4-5-20251001
@@ -209,7 +200,6 @@ steps:
       into: report
 
   - id: write_report
-    awaits: [drive_browser]
     tool: file.write
     path: ~/.patchwork/inbox/approval-queue-ui-test-{{date}}.md
     content: "{{report}}\n"


### PR DESCRIPTION
## Summary
Follow-up cleanup to #324 — re-reviewed the recipe right after merge and found that `collect_baseline` and the two `awaits:` refs are dead weight:

1. `tool: time.now` is **not registered** anywhere in the tool registry (only `git.log_since` lives in the `git` namespace; there's no `time` namespace). At runtime [yamlRunner.ts:848-849](src/recipes/yamlRunner.ts#L848-L849) silently skips unknown tools, so the step *looked* like it ran.
2. The whole `parallel:` block is dead anyway — `yamlRunner.ts` (which executes `trigger: manual` recipes) does **not** walk `step.parallel`. Only `chainedRunner.ts` handles parallel groups. Manual recipes get the parallel container ignored entirely.
3. Neither `{{now}}` nor `{{recent_commits}}` is referenced anywhere in the recipe — only `{{date}}` and `{{time}}`, which come from the template engine's [built-in globals](src/recipes/names.ts#L44-L45), not from any explicit step.

Removing 10 lines (the `collect_baseline` block + both `awaits:` lines). Recipe still works identically: `{{date}}/{{time}}` come from globals, step ordering is preserved by YAML order under the manual-trigger runner.

## Pre-existing preflight gap (exposed, not fixed here)
[`src/commands/recipe.ts:1449`](src/commands/recipe.ts#L1449) `buildSimpleRecipeDryRunSteps` walks `recipe.steps` top-level only — it doesn't recurse into `step.parallel` children for non-chained recipes. That's why `preflight` didn't catch the unresolved `time.now` in #324. Worth a separate PR; keeping this one focused on the recipe.

## Test plan
- [x] `patchwork recipe preflight` clean (only the standard `unacknowledged-write` runtime ack error, same as before)
- [x] Diff confirmed: -10 LOC, no other changes
- [x] Re-read full recipe: no remaining references to removed step ids

🤖 Generated with [Claude Code](https://claude.com/claude-code)