### PR TITLE
ui(wave3d): analytics error icon tone + metrics SVG icons + nav promote Transactions

### DIFF
--- a/dashboard/src/app/analytics/page.tsx
+++ b/dashboard/src/app/analytics/page.tsx
@@ -191,8 +191,23 @@ export default function AnalyticsPage() {
               value={loading ? "—" : `${errorRate.toFixed(1)}%`}
               foot="Errors / total calls"
               icon={
-                <div style={{ width: 36, height: 36, borderRadius: 10, background: "var(--red-soft)", display: "flex", alignItems: "center", justifyContent: "center", color: "var(--red)" }}>
-                  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.85" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
+                <div style={{
+                  width: 36, height: 36, borderRadius: 10,
+                  background: errorRate > 0 ? "var(--red-soft)" : "var(--green-soft)",
+                  display: "flex", alignItems: "center", justifyContent: "center",
+                  color: errorRate > 0 ? "var(--red)" : "var(--green)",
+                }}>
+                  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.85" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                    {errorRate > 0 ? (
+                      <>
+                        <path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/>
+                        <line x1="12" y1="9" x2="12" y2="13"/>
+                        <line x1="12" y1="17" x2="12.01" y2="17"/>
+                      </>
+                    ) : (
+                      <path d="M22 11.08V12a10 10 0 11-5.93-9.14M22 4L12 14.01l-3-3"/>
+                    )}
+                  </svg>
                 </div>
               }
             />

--- a/dashboard/src/app/metrics/page.tsx
+++ b/dashboard/src/app/metrics/page.tsx
@@ -179,7 +179,7 @@ export default function MetricsPage() {
       >
         <div className="card" style={{ padding: "16px 20px", borderRadius: "var(--r-card)", borderLeft: "3px solid var(--orange)" }}>
           <div style={{ fontSize: "var(--fs-2xs)", fontFamily: "var(--font-mono)", fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.08em", color: "var(--ink-3)", marginBottom: 6 }}>
-            <span style={{ color: "var(--orange)", marginRight: 6 }}>{">_"}</span>Total calls
+            <svg aria-hidden="true" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="var(--orange)" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" style={{ marginRight: 6, verticalAlign: "-1px" }}><path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z"/></svg>Total calls
           </div>
           <div style={{ fontFamily: "var(--font-mono)", fontSize: "var(--fs-display)", fontWeight: 800, color: "var(--ink-0)", lineHeight: 1 }}>
             {metrics.length === 0 ? "—" : <AnimatedNumber value={totalCalls} />}
@@ -187,7 +187,7 @@ export default function MetricsPage() {
         </div>
         <div className="card" style={{ padding: "16px 20px", borderRadius: "var(--r-card)", borderLeft: "3px solid var(--err)" }}>
           <div style={{ fontSize: "var(--fs-2xs)", fontFamily: "var(--font-mono)", fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.08em", color: "var(--ink-3)", marginBottom: 6 }}>
-            <span style={{ color: "var(--err)", marginRight: 6 }}>△</span>Errors
+            <svg aria-hidden="true" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="var(--err)" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" style={{ marginRight: 6, verticalAlign: "-1px" }}><path d="M10.29 3.86 1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>Errors
           </div>
           <div style={{ fontFamily: "var(--font-mono)", fontSize: "var(--fs-display)", fontWeight: 800, color: totalErrors > 0 ? "var(--err)" : "var(--ink-0)", lineHeight: 1 }}>
             {metrics.length === 0 ? "—" : <AnimatedNumber value={totalErrors} />}
@@ -195,7 +195,7 @@ export default function MetricsPage() {
         </div>
         <div className="card" style={{ padding: "16px 20px", borderRadius: "var(--r-card)", borderLeft: "3px solid var(--green)" }}>
           <div style={{ fontSize: "var(--fs-2xs)", fontFamily: "var(--font-mono)", fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.08em", color: "var(--ink-3)", marginBottom: 6 }}>
-            <span style={{ color: "var(--green)", marginRight: 6 }}>✓</span>Success rate
+            <svg aria-hidden="true" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="var(--green)" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" style={{ marginRight: 6, verticalAlign: "-1px" }}><path d="M22 11.08V12a10 10 0 11-5.93-9.14"/><path d="M22 4L12 14.01l-3-3"/></svg>Success rate
           </div>
           <div style={{ fontFamily: "var(--font-mono)", fontSize: "var(--fs-display)", fontWeight: 800, color: "var(--ink-0)", lineHeight: 1 }}>
             {successRate !== null ? `${successRate}%` : "—"}

--- a/dashboard/src/components/Shell.tsx
+++ b/dashboard/src/components/Shell.tsx
@@ -85,7 +85,8 @@ const NAV_SECTIONS: { title: string; items: NavItem[] }[] = [
   {
     title: "Insights",
     items: [
-      { href: "/analytics",  label: "Analytics",  icon: "trending" },
+      { href: "/analytics",    label: "Analytics",    icon: "trending" },
+      { href: "/transactions",  label: "Transactions", icon: "diff" },
     ],
   },
   {
@@ -97,9 +98,7 @@ const NAV_SECTIONS: { title: string; items: NavItem[] }[] = [
   },
 ];
 
-const MORE_ITEMS: NavItem[] = [
-  { href: "/transactions", label: "Transactions", icon: "diff" },
-];
+const MORE_ITEMS: NavItem[] = [];
 
 // ------------------------------------------------------------------ approval count
 


### PR DESCRIPTION
## Summary

Three audit "misc small bugs" items.

| # | Where | What |
|---|---|---|
| 1 | [analytics/page.tsx:189-198](dashboard/src/app/analytics/page.tsx#L189) | Error-rate icon — red warning triangle at 0% reads like an alert on a healthy system. Swaps to green check-circle at 0% |
| 2 | [metrics/page.tsx:182,190,198](dashboard/src/app/metrics/page.tsx#L182) | ASCII glyphs \`>_\` \`△\` \`✓\` → inline 12×12 SVG icons (bolt, warning, check-circle) |
| 3 | [Shell.tsx:100-102](dashboard/src/components/Shell.tsx#L100) | Transactions promoted from single-child "More" group into "Insights" alongside Analytics |

## Test plan

- [x] \`tsc --noEmit\` clean
- [x] biome clean
- [x] \`vitest run\` — 308/308 pass
- [ ] **Manual** — /analytics with 0 errors → green check icon + green background on error-rate card
- [ ] **Manual** — /analytics with >0 errors → red triangle icon + red background (no change from before)
- [ ] **Manual** — /metrics → three stat cards use SVG icons, not ASCII characters
- [ ] **Manual** — sidebar → Transactions shows under "Insights" group, no "More" section

🤖 Generated with [Claude Code](https://claude.com/claude-code)