### PR TITLE
ui(wave3e): inbox triple-date + reading-pane identity + recipes/new orange-on-orange

### DIFF
--- a/dashboard/src/app/inbox/page.tsx
+++ b/dashboard/src/app/inbox/page.tsx
@@ -46,14 +46,6 @@ function slugToTitle(name: string): string {
     .join(" ");
 }
 
-function slugToShortDate(name: string): string {
-  const base = name.replace(/\.md$/, "");
-  const m = base.match(/-(\d{4}-\d{2}-\d{2})$/);
-  if (!m) return "";
-  const d = new Date(m[1] + "T00:00:00");
-  return d.toLocaleDateString("en-GB", { day: "numeric", month: "short" });
-}
-
 function RecipeIcon({ name }: { name: string }) {
   const lower = name.toLowerCase();
   if (lower.includes("brief") || lower.includes("triage"))
@@ -688,7 +680,6 @@ const filteredItems = items.filter((item) => {
                         const isActive = selected?.name === item.name;
                         const isNew = !seenNames.has(item.name);
                         const title = slugToTitle(item.name);
-                        const shortDate = slugToShortDate(item.name);
                         const plainPreview = stripMarkdown(item.preview);
                         return (
                           <button
@@ -719,9 +710,6 @@ const filteredItems = items.filter((item) => {
                               <span style={{ flex: 1, fontWeight: isNew ? 700 : 500, fontSize: "var(--fs-m)", color: "var(--ink-0)", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>
                                 {title}
                               </span>
-                              {shortDate && (
-                                <span style={{ fontSize: "var(--fs-2xs)", color: "var(--ink-3)", flexShrink: 0 }}>{shortDate}</span>
-                              )}
                             </div>
 
                             {/* Row 2: preview */}
@@ -780,7 +768,7 @@ const filteredItems = items.filter((item) => {
                         {slugToTitle(selected.name)}
                       </div>
                       <div style={{ fontSize: "var(--fs-xs)", color: "var(--ink-3)", marginTop: 2 }}>
-                        {new Date(selected.modifiedAt).toLocaleString()} &middot; <span style={{ fontFamily: "var(--font-mono)" }}>{selected.name}</span>
+                        {new Date(selected.modifiedAt).toLocaleString()}
                       </div>
                     </div>
                     <button

--- a/dashboard/src/app/recipes/new/page.tsx
+++ b/dashboard/src/app/recipes/new/page.tsx
@@ -726,13 +726,13 @@ function NewRecipePageInner() {
             textAlign: "left",
           }}
         >
-          <span style={{ fontSize: "var(--fs-xl)" }}>{aiOpen ? "▾" : "▸"}</span>
+          <span style={{ fontSize: "var(--fs-xl)", color: "var(--ink-2)" }}>{aiOpen ? "▾" : "▸"}</span>
           Generate with AI
           <span
             style={{
-              background: "var(--accent)",
+              background: "var(--info)",
               borderRadius: 4,
-              color: "var(--on-accent)",
+              color: "#fff",
               fontSize: "var(--fs-2xs)",
               fontWeight: 700,
               letterSpacing: "0.05em",


### PR DESCRIPTION
## Summary

Three audit Wave 3 small-bug fixes.

### 1. Inbox triple-date collapse

Each list row showed two date representations simultaneously:
- Row 1: static `shortDate` extracted from the filename slug (e.g. `7 May`)
- Row 3: live `RelativeTime` from `modifiedAt` (e.g. `2h ago`)

**After:** slug date removed; `RelativeTime` is the single source. `slugToShortDate()` removed (dead code).

### 2. Inbox reading-pane double identity

The detail header showed:
> `7 May 2026, 08:12:34 · morning-brief-2026-05-07.md`

The raw filename is an internal identifier — the title already says "Morning Brief". Removed the middot + filename; only the formatted timestamp remains.

### 3. Recipes/new orange-on-orange

The "Generate with AI" toggle had two orange elements side-by-side:
- `▸` chevron inheriting `var(--fg-1)` (orange in theme)
- `NEW` pill with `background: var(--accent)` (orange)

**After:** chevron uses `var(--ink-2)` (muted chrome), NEW pill uses `var(--info)` (blue — it's a feature callout, not an action).

## Test plan

- [x] `tsc --noEmit` clean
- [x] biome clean
- [x] `vitest run` — 308/308 pass
- [ ] **Manual** — /inbox list: each row shows only one timestamp (relative), no slug date
- [ ] **Manual** — /inbox reading pane: header shows date only, not `· filename.md`
- [ ] **Manual** — /recipes/new: "Generate with AI" chevron is muted grey; NEW badge is blue

🤖 Generated with [Claude Code](https://claude.com/claude-code)