### PR TITLE
ui(wave3f): recipes/new YAML preview parity — highlight + copy

### DIFF
--- a/dashboard/src/app/recipes/new/page.tsx
+++ b/dashboard/src/app/recipes/new/page.tsx
@@ -2,6 +2,7 @@
 import { useRouter, useSearchParams } from "next/navigation";
 import { Suspense, useCallback, useMemo, useRef, useState } from "react";
 import { apiPath } from "@/lib/api";
+import { highlightYaml } from "@/components/patchwork";
 import { normalizeRecipeName, prepareAndSaveAiRecipe } from "./applyAiYaml";
 
 interface Step {
@@ -287,6 +288,27 @@ function buildRecipeYaml(form: FormState, safeName: string): string {
 // only fires when normalization can't produce a valid slug at all
 // (empty, leading dash, too long, or non-letter/digit chars left over).
 const NAME_RE = /^[a-z0-9][a-z0-9-]{0,63}$/;
+
+function CopyYamlButton({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false);
+  const onCopy = useCallback(() => {
+    void navigator.clipboard.writeText(text).then(() => {
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1800);
+    });
+  }, [text]);
+  return (
+    <button
+      type="button"
+      onClick={onCopy}
+      className="btn sm ghost"
+      aria-label={copied ? "YAML copied to clipboard" : "Copy YAML to clipboard"}
+      style={{ fontSize: "var(--fs-xs)" }}
+    >
+      {copied ? "Copied ✓" : "Copy"}
+    </button>
+  );
+}
 
 export default function NewRecipePage() {
   return (
@@ -1544,15 +1566,25 @@ function NewRecipePageInner() {
           <div>
             <div
               style={{
-                fontSize: "var(--fs-s)",
-                color: "var(--fg-2)",
-                fontWeight: 500,
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "space-between",
+                gap: "var(--s-2)",
                 marginBottom: "var(--s-2)",
-                textTransform: "uppercase",
-                letterSpacing: "0.06em",
               }}
             >
-              YAML preview
+              <div
+                style={{
+                  fontSize: "var(--fs-s)",
+                  color: "var(--fg-2)",
+                  fontWeight: 500,
+                  textTransform: "uppercase",
+                  letterSpacing: "0.06em",
+                }}
+              >
+                YAML preview
+              </div>
+              <CopyYamlButton text={previewYaml} />
             </div>
             <div
               style={{
@@ -1579,7 +1611,7 @@ function NewRecipePageInner() {
                 minHeight: 200,
               }}
             >
-              <code>{previewYaml}</code>
+              {highlightYaml(previewYaml)}
             </pre>
           </div>
         </div>

--- a/dashboard/src/app/recipes/page.tsx
+++ b/dashboard/src/app/recipes/page.tsx
@@ -10,6 +10,7 @@ import { useToast } from "@/components/Toast";
 import {
   CodeBlock,
   ErrorState,
+  highlightYaml,
   LivePill,
   PatchCard,
   RunSparkBars,
@@ -313,52 +314,6 @@ function SuccessRing({
       </text>
     </svg>
   );
-}
-
-/** Lightweight YAML coloriser — keys, values, comments. */
-function highlightYaml(yaml: string): React.ReactNode {
-  const lines = yaml.split("\n");
-  return lines.map((line, i) => {
-    const commentIdx = line.indexOf("#");
-    let codePart = line;
-    let comment = "";
-    if (commentIdx >= 0) {
-      // Naively avoid splitting inside quoted strings; good enough for recipes.
-      const before = line.slice(0, commentIdx);
-      const quoteOpen = (before.match(/"/g) ?? []).length % 2 === 1;
-      if (!quoteOpen) {
-        codePart = before;
-        comment = line.slice(commentIdx);
-      }
-    }
-    const m = codePart.match(/^(\s*-?\s*)([A-Za-z0-9_./-]+)(\s*:)(\s*)(.*)$/);
-    let body: React.ReactNode = codePart;
-    if (m) {
-      const [, lead, key, colon, ws, rest] = m;
-      body = (
-        <>
-          <span>{lead}</span>
-          <span className="yaml-key" style={{ color: "var(--accent)" }}>{key}</span>
-          <span>{colon}</span>
-          <span>{ws}</span>
-          {rest && (
-            <span className="yaml-string" style={{ color: "var(--ok)" }}>{rest}</span>
-          )}
-        </>
-      );
-    }
-    return (
-      <div key={i}>
-        {body}
-        {comment && (
-          <span className="yaml-comment" style={{ color: "var(--ink-3)", fontStyle: "italic" }}>
-            {comment}
-          </span>
-        )}
-        {!line && " "}
-      </div>
-    );
-  });
 }
 
 /** Build a presentable YAML string from recipe metadata when raw isn't available. */

--- a/dashboard/src/components/patchwork/CodeBlock.tsx
+++ b/dashboard/src/components/patchwork/CodeBlock.tsx
@@ -14,6 +14,52 @@ export function CodeBlock({
   );
 }
 
+/** Lightweight YAML coloriser — keys, values, comments. */
+export function highlightYaml(yaml: string): ReactNode {
+  const lines = yaml.split("\n");
+  return lines.map((line, i) => {
+    const commentIdx = line.indexOf("#");
+    let codePart = line;
+    let comment = "";
+    if (commentIdx >= 0) {
+      const before = line.slice(0, commentIdx);
+      const quoteOpen = (before.match(/"/g) ?? []).length % 2 === 1;
+      if (!quoteOpen) {
+        codePart = before;
+        comment = line.slice(commentIdx);
+      }
+    }
+    const m = codePart.match(/^(\s*-?\s*)([A-Za-z0-9_./-]+)(\s*:)(\s*)(.*)$/);
+    let body: ReactNode = codePart;
+    if (m) {
+      const [, lead, key, colon, ws, rest] = m;
+      body = (
+        <>
+          <span>{lead}</span>
+          <span className="yaml-key" style={{ color: "var(--accent)" }}>{key}</span>
+          <span>{colon}</span>
+          <span>{ws}</span>
+          {rest && (
+            <span className="yaml-string" style={{ color: "var(--ok)" }}>{rest}</span>
+          )}
+        </>
+      );
+    }
+    // biome-ignore lint/suspicious/noArrayIndexKey: rendering raw text lines, no stable id available
+    return (
+      <div key={i}>
+        {body}
+        {comment && (
+          <span className="yaml-comment" style={{ color: "var(--ink-3)", fontStyle: "italic" }}>
+            {comment}
+          </span>
+        )}
+        {!line && " "}
+      </div>
+    );
+  });
+}
+
 export function YamlLine({
   k,
   v,

--- a/dashboard/src/components/patchwork/index.ts
+++ b/dashboard/src/components/patchwork/index.ts
@@ -17,7 +17,7 @@ export { WeatherRing } from "./WeatherRing";
 export { Sparkline } from "./Sparkline";
 export { AnimatedNumber } from "./AnimatedNumber";
 export { Spinner } from "./Spinner";
-export { CodeBlock, YamlLine } from "./CodeBlock";
+export { CodeBlock, YamlLine, highlightYaml } from "./CodeBlock";
 export { HBarList, type HBarItem } from "./HBarList";
 export { EventsHistogram } from "./EventsHistogram";
 export { MetricsDonut, type DonutSegment } from "./MetricsDonut";


### PR DESCRIPTION
## Summary

Final Wave 3 audit item.

| Where | Before | After |
|---|---|---|
| /recipes detail panel | Highlighted YAML (orange keys / green values / italic comments) | unchanged |
| /recipes/new YAML preview | Plain monospace `<pre>` | Same highlighter + Copy button |

## Changes

1. **Extract `highlightYaml` to shared module** — moved from `recipes/page.tsx` to `components/patchwork/CodeBlock.tsx` + barrel export. Same parser, same tokens (`--accent` keys, `--ok` values, `--ink-3` italic comments). `recipes/page.tsx` imports from `@/components/patchwork`.
2. **Apply to /recipes/new preview** — `<pre>{previewYaml}</pre>` → `<pre>{highlightYaml(previewYaml)}</pre>`.
3. **Add `CopyYamlButton`** — sits in the YAML PREVIEW header. Writes `previewYaml` to the clipboard and flips label to `Copied ✓` for 1.8s. Same copy-and-revert pattern as `H2WithCopy` in /inbox.

## Test plan

- [x] `tsc --noEmit` clean
- [x] biome clean
- [x] `vitest run` — 308/308 pass
- [x] **Playwright dogfood**: /recipes/new shows orange keys (`apiVersion`, `name`, `trigger`, `steps`…) + green values (`patchwork.sh/v1`, `manual`, `step-1`) + italic grey schema comment
- [x] **Playwright dogfood**: Copy button click → label becomes `Copied ✓`; clipboard contains `# yaml-language-server: …` + full YAML including `apiVersion`
- [x] **Playwright regression**: /recipes detail panel still highlights `ambient-journal` YAML correctly after the refactor

🤖 Generated with [Claude Code](https://claude.com/claude-code)