### PR TITLE
ui(wave2b): EmptyState codemod — approvals + activity + tasks + inbox

### DIFF
--- a/dashboard/src/app/activity/page.tsx
+++ b/dashboard/src/app/activity/page.tsx
@@ -4,7 +4,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { apiPath } from "@/lib/api";
 import { relTime } from "@/components/time";
 import { isDemoMode } from "@/lib/demoMode";
-import { EventsHistogram, HBarList, LivePill } from "@/components/patchwork";
+import { EmptyState, EventsHistogram, HBarList, LivePill } from "@/components/patchwork";
 import { SkeletonList } from "@/components/Skeleton";
 import { ActivityTabs } from "@/components/ActivityTabs";
 
@@ -328,28 +328,32 @@ export default function ActivityPage() {
 
       {events.length === 0 ? (
         seeded ? (
-          <div className="empty-state">
-            <h3>No activity yet</h3>
-            <p>Tool calls and bridge events will appear here — most recent first.</p>
-            <p
-              style={{
-                color: "var(--ink-3)",
-                fontSize: "var(--fs-s)",
-                marginTop: "var(--s-3)",
-              }}
-            >
-              Connect a Claude Code session to the bridge and call any
-              MCP tool to see your first event.
-            </p>
-          </div>
+          <EmptyState
+            title="No activity yet"
+            description={
+              <>
+                Tool calls and bridge events will appear here — most recent first.
+                <span
+                  style={{
+                    display: "block",
+                    color: "var(--ink-3)",
+                    fontSize: "var(--fs-s)",
+                    marginTop: "var(--s-3)",
+                  }}
+                >
+                  Connect a Claude Code session to the bridge and call any MCP tool to see your first event.
+                </span>
+              </>
+            }
+          />
         ) : (
           <SkeletonList rows={5} columns={4} />
         )
       ) : filtered.length === 0 ? (
-        <div className="empty-state">
-          <h3>No events in this view</h3>
-          <p>Try a different tab.</p>
-        </div>
+        <EmptyState
+          title="No events in this view"
+          description="Try a different tab."
+        />
       ) : (
         <div className="table-wrap">
           <table className="table">

--- a/dashboard/src/app/approvals/page.tsx
+++ b/dashboard/src/app/approvals/page.tsx
@@ -3,7 +3,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { Suspense, useCallback, useEffect, useRef, useState } from "react";
 import { useApprovalPatterns } from "../../hooks/useApprovalPatterns";
 import { apiPath } from "@/lib/api";
-import { KeyChip, CodeBlock } from "@/components/patchwork";
+import { CodeBlock, EmptyState, KeyChip } from "@/components/patchwork";
 import { SkeletonList } from "@/components/Skeleton";
 import { DecisionsTabs } from "@/components/DecisionsTabs";
 import { useToast } from "@/components/Toast";
@@ -112,53 +112,6 @@ function primaryParam(
 const SUGGESTION_MIN_APPROVED = 3;
 
 // --- CountdownTimer component ---
-
-// --- EmptyState component ---
-
-function EmptyState({
-  riskFilter,
-  onClearFilter,
-}: {
-  riskFilter: RiskFilter;
-  onClearFilter: () => void;
-}) {
-  const isFiltered = riskFilter !== "all";
-
-  return (
-    <div
-      className="empty-state"
-      style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: "var(--s-3)" }}
-    >
-      <span
-        style={{
-          fontSize: 48,
-          lineHeight: 1,
-          color: "var(--ok)",
-          display: "block",
-        }}
-        aria-hidden="true"
-      >
-        ✓
-      </span>
-      <h3 style={{ color: "var(--fg-0)" }}>All caught up!</h3>
-      {isFiltered ? (
-        <>
-          <p>No {riskFilter} risk approvals pending.</p>
-          <button
-            type="button"
-            className="btn sm ghost"
-            onClick={onClearFilter}
-            style={{ color: "var(--accent)", borderColor: "var(--accent)" }}
-          >
-            Clear filter
-          </button>
-        </>
-      ) : (
-        <p>No pending approvals. All tool calls handled by policy or already decided.</p>
-      )}
-    </div>
-  );
-}
 
 // --- ApprovalCard ---
 
@@ -1170,8 +1123,29 @@ function ApprovalsContent() {
       {filtered.length === 0 && !err ? (
         hasLoaded ? (
           <EmptyState
-            riskFilter={riskFilter}
-            onClearFilter={() => setRiskFilter("all")}
+            icon={
+              <span style={{ fontSize: 48, lineHeight: 1, color: "var(--ok)" }} aria-hidden="true">
+                ✓
+              </span>
+            }
+            title="All caught up!"
+            description={
+              riskFilter !== "all"
+                ? `No ${riskFilter} risk approvals pending.`
+                : "No pending approvals. All tool calls handled by policy or already decided."
+            }
+            action={
+              riskFilter !== "all" ? (
+                <button
+                  type="button"
+                  className="btn sm ghost"
+                  onClick={() => setRiskFilter("all")}
+                  style={{ color: "var(--accent)", borderColor: "var(--accent)" }}
+                >
+                  Clear filter
+                </button>
+              ) : undefined
+            }
           />
         ) : (
           <SkeletonList rows={3} columns={3} />

--- a/dashboard/src/app/inbox/page.tsx
+++ b/dashboard/src/app/inbox/page.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import dynamic from "next/dynamic";
 import { apiPath } from "@/lib/api";
+import { EmptyState } from "@/components/patchwork";
 import { useToast } from "@/components/Toast";
 
 function isFilterCategory(v: string | null): v is FilterCategory {
@@ -572,16 +573,16 @@ const filteredItems = items.filter((item) => {
             <span>Loading…</span>
           </div>
         ) : items.length === 0 ? (
-          <div className="empty-state" role="status" style={{ display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", gap: 8, flex: 1, minHeight: 200 }}>
-            <div className="empty-state-icon">
-              <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-                <rect x="2" y="4" width="20" height="16" rx="2"/>
-                <path d="M2 7l10 7 10-7"/>
+          <EmptyState
+            icon={
+              <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                <rect x="2" y="4" width="20" height="16" rx="2" />
+                <path d="M2 7l10 7 10-7" />
               </svg>
-            </div>
-            <p style={{ color: "var(--ink-1)", fontSize: "var(--fs-l)", fontWeight: 600, margin: 0 }}>No items yet</p>
-            <p style={{ color: "var(--ink-3)", fontSize: "var(--fs-m)", margin: 0 }}>Run a recipe to generate your first brief.</p>
-          </div>
+            }
+            title="No items yet"
+            description="Run a recipe to generate your first brief."
+          />
         ) : (
           <div style={{ display: "flex", flex: 1, minHeight: 0, border: "1px solid var(--line-1)", borderRadius: "var(--r-l)", overflow: "hidden", background: "var(--surface)" }}>
 

--- a/dashboard/src/app/tasks/page.tsx
+++ b/dashboard/src/app/tasks/page.tsx
@@ -3,7 +3,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { apiPath } from "@/lib/api";
 import { fmtDuration } from "@/components/time";
 import { SkeletonList } from "@/components/Skeleton";
-import { ErrorState } from "@/components/patchwork";
+import { EmptyState, ErrorState } from "@/components/patchwork";
 import { ActivityTabs } from "@/components/ActivityTabs";
 
 interface Task {
@@ -502,13 +502,15 @@ export default function TasksPage() {
 
       {tasks.length === 0 && !err ? (
         hasLoaded ? (
-          <div className="empty-state">
-            <h3>No tasks yet</h3>
-            <p>
-              Run one with <code>runClaudeTask</code> or{" "}
-              <code>patchwork start-task "…"</code>.
-            </p>
-          </div>
+          <EmptyState
+            title="No tasks yet"
+            description={
+              <>
+                Run one with <code>runClaudeTask</code> or{" "}
+                <code>patchwork start-task "…"</code>.
+              </>
+            }
+          />
         ) : (
           <SkeletonList rows={3} columns={3} />
         )

--- a/dashboard/src/components/patchwork/EmptyState.tsx
+++ b/dashboard/src/components/patchwork/EmptyState.tsx
@@ -12,13 +12,13 @@ export function EmptyState({
   icon?: ReactNode;
 }) {
   return (
-    <div className="empty">
+    <div className="empty-state">
       {icon && (
         <div style={{ marginBottom: 12, display: "flex", justifyContent: "center", color: "var(--ink-3)" }}>
           {icon}
         </div>
       )}
-      <h3 style={{ color: "var(--ink-1)", marginBottom: 8 }}>{title}</h3>
+      <h3>{title}</h3>
       {description && (
         <p style={{ color: "var(--ink-2)", fontSize: "var(--fs-m)", maxWidth: 420, margin: "0 auto 16px" }}>
           {description}


### PR DESCRIPTION
## Summary

First slice of the Wave 2B EmptyState codemod. Four trafficked pages had hand-rolled empty-state markup; **approvals** even had its own local `EmptyState` fork that shadowed the shared one. Consolidate onto `src/components/patchwork/EmptyState.tsx`.

## Changes

| File | Change |
|---|---|
| `EmptyState.tsx` | Wrapper class `empty` → `empty-state` so the shared component uses the richer `--card-bg` + blur look that all four manual usages already had |
| `approvals/page.tsx` | Delete local `EmptyState` fn; shared call site passes `icon`/`title`/`description`/`action` (filter-aware) |
| `activity/page.tsx` | Two sites: "No activity yet" + setup hint; "No events in this view" tab-empty |
| `tasks/page.tsx` | "No tasks yet" with `<code>` chunks preserved as ReactNode description |
| `inbox/page.tsx` | "No items yet" with inline mailbox SVG promoted to 32px to fit the EmptyState icon slot |

## Test plan

- [x] `tsc --noEmit` clean
- [x] biome clean
- [x] `vitest run` — 308/308 pass
- [x] **Playwright dogfood**: /approvals zero-state shows ✓ + "All caught up!" + description (shared component)
- [x] **Playwright dogfood**: /activity, /tasks, /inbox render cleanly, no console errors

## Out of scope (next slice)

Other empty patterns surfaced by `grep "no.*yet|empty-state"` exist in:
- `app/page.tsx` (overview)
- `insights/page.tsx`, `insights/replay/page.tsx`
- `traces/page.tsx`
- `metrics/page.tsx`
- `settings/page.tsx` (smaller card-internal empties)

Will batch in a follow-up to keep this PR readable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)