### PR TITLE
ui(wave2b-2): EmptyState codemod batch 2 — insights/replay/traces/settings/metrics

### DIFF
--- a/dashboard/src/app/insights/page.tsx
+++ b/dashboard/src/app/insights/page.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 import { useEffect, useState } from "react";
 import { useBridgeFetch } from "@/hooks/useBridgeFetch";
 import { apiPath } from "@/lib/api";
-import { ErrorState } from "@/components/patchwork";
+import { EmptyState, ErrorState } from "@/components/patchwork";
 
 interface ToolInsight {
   toolName: string;
@@ -219,14 +219,10 @@ export default function InsightsPage() {
       )}
 
       {!loading && !error && tools.length === 0 && (
-        <div className="empty-state">
-          <h3>No approval history yet</h3>
-          <p>
-            Once you start approving or rejecting tool calls in the approval
-            queue, this page will show you your patterns — "you approved this
-            27 times", "you rejected this tool before", and so on.
-          </p>
-        </div>
+        <EmptyState
+          title="No approval history yet"
+          description={`Once you start approving or rejecting tool calls in the approval queue, this page will show you your patterns — "you approved this 27 times", "you rejected this tool before", and so on.`}
+        />
       )}
 
       {tools.length > 0 && (

--- a/dashboard/src/app/insights/replay/page.tsx
+++ b/dashboard/src/app/insights/replay/page.tsx
@@ -2,6 +2,7 @@
 import Link from "next/link";
 import { useState } from "react";
 import { useBridgeFetch } from "@/hooks/useBridgeFetch";
+import { EmptyState } from "@/components/patchwork";
 
 type ReplayDecision = "allow" | "deny" | "ask" | "none";
 type ChangeKind = "now_allowed" | "now_denied" | "now_asked";
@@ -131,13 +132,10 @@ export default function ReplayPage() {
       {error && <div className="alert-err">Unreachable: {error}</div>}
 
       {!loading && !error && data && data.totalRows === 0 && (
-        <div className="empty-state">
-          <h3>No approval history in this window</h3>
-          <p>
-            Widen the lookback or come back after the bridge has processed some
-            approval decisions. Every allow/deny/ask is recorded automatically.
-          </p>
-        </div>
+        <EmptyState
+          title="No approval history in this window"
+          description="Widen the lookback or come back after the bridge has processed some approval decisions. Every allow/deny/ask is recorded automatically."
+        />
       )}
 
       {data && data.totalRows > 0 && (

--- a/dashboard/src/app/metrics/page.tsx
+++ b/dashboard/src/app/metrics/page.tsx
@@ -2,7 +2,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { apiPath } from "@/lib/api";
 import { relTime, fmtDuration } from "@/components/time";
-import { MetricsDonut, HBarList, ErrorState, AnimatedNumber } from "@/components/patchwork";
+import { AnimatedNumber, EmptyState, ErrorState, HBarList, MetricsDonut } from "@/components/patchwork";
 import type { DonutSegment, HBarItem } from "@/components/patchwork";
 
 interface Metric {
@@ -290,24 +290,10 @@ export default function MetricsPage() {
       )}
 
       {metrics.length === 0 && !err && (
-        <div
-          style={{
-            border: "1.5px dashed var(--line-2)",
-            borderRadius: "var(--r-card)",
-            minHeight: 200,
-            display: "flex",
-            flexDirection: "column",
-            alignItems: "center",
-            justifyContent: "center",
-            padding: "var(--s-5)",
-            textAlign: "center",
-          }}
-        >
-          <h3 style={{ color: "var(--ink-1)", marginBottom: 8 }}>No metrics yet</h3>
-          <p style={{ color: "var(--ink-3)", fontSize: "var(--fs-m)", maxWidth: 380, margin: 0 }}>
-            Metrics appear once the bridge begins serving tool calls. Make a tool call or wait for the next scrape interval.
-          </p>
-        </div>
+        <EmptyState
+          title="No metrics yet"
+          description="Metrics appear once the bridge begins serving tool calls. Make a tool call or wait for the next scrape interval."
+        />
       )}
     </section>
   );

--- a/dashboard/src/app/settings/page.tsx
+++ b/dashboard/src/app/settings/page.tsx
@@ -2,7 +2,7 @@
 import { useEffect, useRef, useState } from "react";
 import { fmtDuration } from "@/components/time";
 import { apiPath } from "@/lib/api";
-import { StatusPill } from "@/components/patchwork";
+import { EmptyState, StatusPill } from "@/components/patchwork";
 
 interface StatusResponse {
   uptimeMs?: number;
@@ -329,13 +329,15 @@ export default function SettingsPage() {
       {err && <div className="alert-err">Unreachable: {err}</div>}
 
       {unsupported ? (
-        <div className="empty-state">
-          <h3>Settings endpoint coming in next phase</h3>
-          <p>
-            This bridge version does not expose <code>/status</code>. Run <code>patchwork print-token</code> for
-            connection details.
-          </p>
-        </div>
+        <EmptyState
+          title="Settings endpoint coming in next phase"
+          description={
+            <>
+              This bridge version does not expose <code>/status</code>. Run <code>patchwork print-token</code> for
+              connection details.
+            </>
+          }
+        />
       ) : !settings ? (
         <div className="empty-state">
           <p>Loading…</p>

--- a/dashboard/src/app/traces/page.tsx
+++ b/dashboard/src/app/traces/page.tsx
@@ -5,7 +5,7 @@ import { apiPath } from "@/lib/api";
 import { useBridgeFetch } from "@/hooks/useBridgeFetch";
 import { useDebounced } from "@/hooks/useDebounced";
 import { arr, isRecord, shape, type ShapeCheck } from "@/lib/validate";
-import { ErrorState, LivePill } from "@/components/patchwork";
+import { EmptyState, ErrorState, LivePill } from "@/components/patchwork";
 import { ActivityTabs } from "@/components/ActivityTabs";
 
 type TraceType = "approval" | "enrichment" | "recipe_run" | "decision";
@@ -743,10 +743,10 @@ export default function TracesPage() {
       )}
 
       {visible.length === 0 && !loading ? (
-        <div className="empty-state">
-          <h3>No traces</h3>
-          <p>Traces appear as recipes run and approvals are processed.</p>
-        </div>
+        <EmptyState
+          title="No traces"
+          description="Traces appear as recipes run and approvals are processed."
+        />
       ) : view === "flat" ? (
         <div className="card" style={{ padding: 0, overflow: "hidden", marginBottom: "var(--s-5)" }}>
           {visible.map(t => {


### PR DESCRIPTION
## Summary

Continuation of [#333](https://github.com/Oolab-labs/patchwork-os/pull/333). Five more pages migrated from hand-rolled empty markup to the shared `EmptyState`.

| File | Empty state |
|---|---|
| `insights/page.tsx` | "No approval history yet" + "you approved this 27 times…" tutorial hint |
| `insights/replay/page.tsx` | "No approval history in this window" + widen-lookback hint |
| `traces/page.tsx` | "No traces" + run-a-recipe hint |
| `settings/page.tsx` | "Settings endpoint coming in next phase" — inline `<code>` tags preserved as ReactNode description |
| `metrics/page.tsx` | "No metrics yet" — was hand-rolled with inline 1.5px dashed border + flex centering; now uses the standard `.empty-state` look |

## Skipped

- `settings/page.tsx` loading-state misuse (`<div className="empty-state"><p>Loading…</p></div>`) — that's a loading placeholder, not an empty state; separate concern
- `app/page.tsx` "No enabled recipes yet" — 2-line in-card hint (different visual pattern, not a full empty-state card)

## Test plan

- [x] `tsc --noEmit` clean
- [x] biome clean
- [x] `vitest run` — 308/308 pass
- [x] **Playwright dogfood**: all five pages load with no console errors. Dev workspace has data on every page so the empty path doesn't fire visually; structural correctness covered by typecheck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)