### PR TITLE
fix(overview): filter connection-churn from Activity Thread + dedupe NOISE_EVENTS

### DIFF
--- a/dashboard/src/app/activity/page.tsx
+++ b/dashboard/src/app/activity/page.tsx
@@ -3,6 +3,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { apiPath } from "@/lib/api";
 import { relTime } from "@/components/time";
+import { ACTIVITY_NOISE_EVENTS } from "@/lib/activityNoise";
 import { isDemoMode } from "@/lib/demoMode";
 import {
   EmptyState,
@@ -58,16 +59,6 @@ const MAX_EVENTS = 200;
 
 const RECIPE_START_EVENTS = new Set(["recipe_step_start", "TaskCreated", "InstructionsLoaded", "session_start"]);
 const RECIPE_END_EVENTS = new Set(["recipe_step_done", "recipe_done", "PostCompact", "session_end", "recipe_end"]);
-
-/** Connection-churn events that dominate the log but aren't actionable. */
-const NOISE_EVENTS = new Set([
-  "claude_connected",
-  "claude_disconnected",
-  "extension_connected",
-  "extension_disconnected",
-  "grace_started",
-  "grace_expired",
-]);
 
 function withAt(e: ActivityEvent): ActivityEvent {
   if (typeof e.at === "number") return e;
@@ -190,7 +181,7 @@ export default function ActivityPage() {
       );
     } else {
       out = out.filter(
-        (e) => !(e.kind === "lifecycle" && NOISE_EVENTS.has(e.event ?? "")),
+        (e) => !(e.kind === "lifecycle" && ACTIVITY_NOISE_EVENTS.has(e.event ?? "")),
       );
     }
     return out;

--- a/dashboard/src/app/page.tsx
+++ b/dashboard/src/app/page.tsx
@@ -7,6 +7,7 @@ import { SkeletonStatCard } from "@/components/Skeleton";
 import { relTime } from "@/components/time";
 import { useBridgeFetch } from "@/hooks/useBridgeFetch";
 import { useBridgeStatus } from "@/hooks/useBridgeStatus";
+import { isNoiseEvent } from "@/lib/activityNoise";
 import {
   ActionPill,
   QuiltHero,
@@ -925,7 +926,9 @@ export default function HomePage() {
           marginBottom: "var(--s-5)",
         }}
       >
-        <ActivityThread events={activityEvents.slice(-8).reverse()} />
+        <ActivityThread
+          events={activityEvents.filter((e) => !isNoiseEvent(e)).slice(-8).reverse()}
+        />
         <RecentRecipesCard recipes={recipes} />
       </div>
 

--- a/dashboard/src/app/sessions/[id]/page.tsx
+++ b/dashboard/src/app/sessions/[id]/page.tsx
@@ -4,6 +4,7 @@ import { useParams } from "next/navigation";
 import dynamic from "next/dynamic";
 import { relTime } from "@/components/time";
 import { useBridgeFetch } from "@/hooks/useBridgeFetch";
+import { ACTIVITY_NOISE_EVENTS } from "@/lib/activityNoise";
 import { arr, isRecord, shape, type ShapeCheck } from "@/lib/validate";
 
 const MessageMarkdown = dynamic(() => import("@/components/MessageMarkdown"), {
@@ -153,14 +154,7 @@ const validateDetail: ShapeCheck<DetailResponse> = shape(
   },
 );
 
-const NOISE_EVENTS = new Set([
-  "claude_connected",
-  "claude_disconnected",
-  "extension_connected",
-  "extension_disconnected",
-  "grace_started",
-  "grace_expired",
-]);
+const NOISE_EVENTS = ACTIVITY_NOISE_EVENTS;
 
 export default function SessionDetailPage() {
   const params = useParams<{ id: string }>();

--- a/dashboard/src/lib/activityNoise.ts
+++ b/dashboard/src/lib/activityNoise.ts
@@ -1,0 +1,21 @@
+// Lifecycle event names that dominate the activity log but aren't
+// actionable for the user — bridge connect/disconnect churn and the
+// short reconnect grace window. Three pages render activity feeds and
+// each had its own copy; consolidate so the next consumer doesn't get
+// a different list.
+//
+//   - /dashboard/activity        — filters these out from the default tab
+//   - /dashboard/                 — overview Activity Thread filters them out
+//   - /dashboard/sessions/[id]    — keeps them, but renders dimmed (isNoise flag)
+export const ACTIVITY_NOISE_EVENTS: ReadonlySet<string> = new Set([
+  "claude_connected",
+  "claude_disconnected",
+  "extension_connected",
+  "extension_disconnected",
+  "grace_started",
+  "grace_expired",
+]);
+
+export function isNoiseEvent(e: { kind?: string; event?: string }): boolean {
+  return e.kind === "lifecycle" && ACTIVITY_NOISE_EVENTS.has(e.event ?? "");
+}


### PR DESCRIPTION
## Summary

Found via dogfood: the overview **Activity Thread** (top of /dashboard) was dominated by alternating `extension connected` / `extension disconnected` lifecycle pairs — exactly the connection-churn events that `/dashboard/activity` already filters out.

Three pages handle the same set of "noise lifecycle events":

| Page | Behavior |
|---|---|
| `/dashboard/activity` | Filters them out from default tab |
| `/dashboard/` (overview) | **Was passing them through — THIS FIX** |
| `/dashboard/sessions/[id]` | Keeps them but renders dimmed (`isNoise` flag) |

Each held its own copy of the set. Extracted to a single source: `src/lib/activityNoise.ts` exporting `ACTIVITY_NOISE_EVENTS` + `isNoiseEvent(e)` helper. All three consumers now import from there.

## Test plan

- [x] `tsc --noEmit` clean
- [x] biome clean
- [x] `vitest run` — 308/308 pass
- [x] **Playwright dogfood** of `/dashboard`: Activity Thread now shows actual "approval decision" events instead of connect/disconnect churn (DOM check found 0 noise terms in the thread)

## Before / After

Before: 8x "extension connected" / "extension disconnected" alternating  
After: 8x "approval decision" lifecycle events

🤖 Generated with [Claude Code](https://claude.com/claude-code)