### PR TITLE
ui(overview): "—" for unknown Health versions, not "unknown"

### DIFF
--- a/dashboard/src/app/page.tsx
+++ b/dashboard/src/app/page.tsx
@@ -750,8 +750,12 @@ export default function HomePage() {
   ).size;
   const activeRecipesCount = recipes.filter((r) => r.enabled !== false).length;
 
-  const bridgeVersion = bridgeStatus.patchwork?.version ?? "unknown";
-  const extensionVersion = health?.extensionVersion ?? "unknown";
+  // The bridge's /health endpoint doesn't currently expose a version
+  // string, so these are usually missing in practice. Render an em-dash
+  // (matches the "—" used elsewhere for missing values) instead of the
+  // contradictory "unknown" word next to the green "all green" pill.
+  const bridgeVersion = bridgeStatus.patchwork?.version ?? "—";
+  const extensionVersion = health?.extensionVersion ?? "—";
 
   return (
     <section>


### PR DESCRIPTION
## Summary

Found via dogfood. The overview Health card showed:

> **Health**                 \`all green\` <br/>
> ● Bridge (healthy)            unknown <br/>
> ● VS Code extension (healthy) unknown

The "all green" pill says everything is fine but each row reads "unknown" — contradictory.

The bridge's \`/health\` and \`/status\` endpoints don't currently expose a version string at all, so:

\`\`\`tsx
const bridgeVersion = bridgeStatus.patchwork?.version ?? "unknown";
const extensionVersion = health?.extensionVersion ?? "unknown";
\`\`\`

…always falls back. Swapped the fallback to em-dash \`—\` (matches the \`—\` already used elsewhere on this page for missing numeric values like load%/peak). Plumbing actual versions through the bridge is a separate concern.

## Test plan

- [x] `tsc --noEmit` clean
- [x] biome clean
- [x] `vitest run` — 308/308 pass
- [x] **Playwright dogfood**: Health card text reads `Bridge (healthy) —` / `VS Code extension (healthy) —`

🤖 Generated with [Claude Code](https://claude.com/claude-code)