### PR TITLE
ui(connections): drop redundant "Connected · 1w ago" that ellipsised to "C"

### DIFF
--- a/dashboard/src/app/connections/page.tsx
+++ b/dashboard/src/app/connections/page.tsx
@@ -719,6 +719,20 @@ function ConnectorGridCard({ def, statusEntry, onConnect, onDisconnect, onTest, 
         >
           <div style={{ display: "flex", alignItems: "center", gap: 5, fontSize: "var(--fs-s)", color: isDegraded ? "var(--warn)" : "var(--ink-2)", minWidth: 0, overflow: "hidden" }}>
             <span
+              // The toggle + Test + Disconnect cluster on the right squeezes
+              // this left half down to ~25px of usable width. Putting "Connected
+              // · 1w ago" inline made the text ellipsise to a single letter ("C"
+              // / "0" / "1."). Status is already conveyed by the green dot, the
+              // CONNECTED status pill at the top of the card, and the toggle's
+              // ON position; the only signal that gets lost is the lastSync time,
+              // surfaced here as a title tooltip on the dot.
+              title={
+                statusEntry.lastSync
+                  ? `Last sync: ${relativeTime(statusEntry.lastSync)}`
+                  : isDegraded
+                    ? "Degraded — re-auth required"
+                    : "Connected"
+              }
               style={{
                 width: 6, height: 6, borderRadius: "50%",
                 background: isDegraded ? "#f59e0b" : "var(--ok)",
@@ -726,12 +740,10 @@ function ConnectorGridCard({ def, statusEntry, onConnect, onDisconnect, onTest, 
               }}
               aria-hidden="true"
             />
-            <span style={{ fontWeight: 500, flexShrink: 0 }}>{isDegraded ? "Degraded" : "Connected"}</span>
-            {statusEntry.lastSync && (
-              <span style={{ color: "var(--ink-3)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
-                · {relativeTime(statusEntry.lastSync)}
-              </span>
-            )}
+            {/* "Degraded" label kept — it's a distinct warning state worth
+                naming inline. "Connected" word + lastSync are now on the
+                dot's title tooltip (see comment above). */}
+            {isDegraded && <span style={{ fontWeight: 500, flexShrink: 0 }}>Degraded</span>}
           </div>
           <div style={{ display: "flex", gap: 6, flexShrink: 0, alignItems: "center" }}>
             {isConnected && (


### PR DESCRIPTION
## Summary

Found via dogfood. Connected cards rendered:

\`\`\`
●  C   [toggle]  Test  Disconnect
\`\`\`

The "C" was the visible remnant of \`Connected · 1w ago\` after the right-side button cluster (toggle + Test + Disconnect, all \`flex-shrink: 0\`) ate ~150px of the ~175px card width, leaving the left half to ellipsise the entire phrase down to a single character.

## Decision

Status is already conveyed three other ways on the same card:

| Signal | Where |
|---|---|
| Green dot | Toolbar row (kept) |
| `CONNECTED` status pill | Top of card (kept) |
| Toggle in ON position | Toolbar row (kept) |

Inline "Connected" word was the 4th repetition. The lastSync time was the only signal that would actually be lost — surfaced as a `title` tooltip on the green dot.

\`Degraded\` state still labels itself inline — distinct warning worth naming.

## After

\`\`\`
●   [toggle]  Test  Disconnect
\`\`\`

Hovering the green dot shows: `Last sync: 1w ago` (or `Connected` / `Degraded — re-auth required` when no lastSync).

## Test plan

- [x] `tsc --noEmit` clean
- [x] biome clean
- [x] `vitest run` — 308/308 pass
- [x] **Playwright dogfood**: connected card toolbar reads `● [toggle] Test Disconnect` with no truncated text
- [ ] **Manual hover** on a real device — title tooltip on the green dot shows full lastSync

🤖 Generated with [Claude Code](https://claude.com/claude-code)