### PR TITLE
ui(overview): include cache_creation in "Tokens burnt"; surface cache reads

### DIFF
--- a/dashboard/src/app/page.tsx
+++ b/dashboard/src/app/page.tsx
@@ -227,6 +227,16 @@ function parseUptimeMs(text: string): number | null {
   return null;
 }
 
+// Compact human-readable counts: 4_752_583_497 → "4.8B", 58_376_273 → "58M".
+// Used in tile sub-stats where digits would crowd out other content. Falls
+// back to toLocaleString below 10k where readable digits are still cheap.
+function formatCompact(n: number): string {
+  if (n < 10_000) return n.toLocaleString();
+  if (n < 1_000_000) return `${(n / 1_000).toFixed(n < 100_000 ? 1 : 0)}K`;
+  if (n < 1_000_000_000) return `${(n / 1_000_000).toFixed(n < 100_000_000 ? 1 : 0)}M`;
+  return `${(n / 1_000_000_000).toFixed(n < 100_000_000_000 ? 1 : 0)}B`;
+}
+
 function parseToolCallTotal(text: string): number {
   if (!text) return 0;
   let total = 0;
@@ -882,19 +892,41 @@ export default function HomePage() {
               label="Tokens burnt"
               value={
                 health?.tokens ? (
-                  <AnimatedNumber value={health.tokens.total} />
+                  <AnimatedNumber
+                    // The bridge's tokens.total is just input + output, but cache
+                    // creation is also billed (~1.25× input rate). Cache reads
+                    // (often 100×–1000× larger than the rest combined) are billed
+                    // at 0.1× and excluded — they'd dwarf the headline and
+                    // mislead. Show the full-rate-ish slice; cache reads get a
+                    // sub-stat in the foot. Compact format ("68.5M" not
+                    // "68,540,195") so the digit count doesn't hijack the tile.
+                    value={
+                      health.tokens.input +
+                      health.tokens.output +
+                      health.tokens.cacheCreate
+                    }
+                    format={formatCompact}
+                  />
                 ) : (
                   "—"
                 )
               }
               foot={
-                health?.tokens && health.tokens.messages > 0
-                  ? `${health.tokens.messages.toLocaleString()} msg${health.tokens.messages === 1 ? "" : "s"}`
-                  : undefined
+                health?.tokens && health.tokens.cacheRead > 0
+                  ? `+${formatCompact(health.tokens.cacheRead)} cache reads · ${formatCompact(health.tokens.messages)} msg${health.tokens.messages === 1 ? "" : "s"}`
+                  : health?.tokens && health.tokens.messages > 0
+                    ? `${formatCompact(health.tokens.messages)} msg${health.tokens.messages === 1 ? "" : "s"}`
+                    : undefined
               }
               title={
                 health?.tokens
-                  ? `Input: ${health.tokens.input.toLocaleString()}\nOutput: ${health.tokens.output.toLocaleString()}\nCache create: ${health.tokens.cacheCreate.toLocaleString()}\nCache read: ${health.tokens.cacheRead.toLocaleString()}\nMessages: ${health.tokens.messages.toLocaleString()}`
+                  ? [
+                      `Input:        ${health.tokens.input.toLocaleString()}`,
+                      `Output:       ${health.tokens.output.toLocaleString()}`,
+                      `Cache create: ${health.tokens.cacheCreate.toLocaleString()}  (billed ~1.25× input)`,
+                      `Cache read:   ${health.tokens.cacheRead.toLocaleString()}  (billed 0.1× input)`,
+                      `Messages:     ${health.tokens.messages.toLocaleString()}`,
+                    ].join("\n")
                   : undefined
               }
               href="/metrics"


### PR DESCRIPTION
## Summary

Two improvements to the **TOKENS BURNT** tile, found via dogfood.

### 1. Correctness — include cache_creation in headline

The tile read **10.1M** while the bridge's tracker had **58.4M cache_creation tokens** silently excluded. The displayed value undercounted billed usage by **~85%** in this workspace.

Root cause: [`src/tokenUsageTracker.ts:156`](src/tokenUsageTracker.ts#L156) defines `total = input + output`. `cache_creation_input_tokens` is tracked but never folded in. Anthropic bills cache writes at **~1.25× the input rate** — they're real cost, not free.

| Field | Bill rate | This workspace |
|---|---|---|
| `input` | 1× | 110,613 |
| `output` | 4× | 10,039,866 |
| `cacheCreate` | 1.25× | 58,389,424 ← **was excluded** |
| `cacheRead` | 0.1× | 4,757,546,455 ← correctly excluded (would dwarf 100×) |

Headline now computes `input + output + cacheCreate` on the dashboard side. Bridge `tokens.total` semantics unchanged (touching that ripples through Prometheus + snapshots).

### 2. Readability — compact number, compact messages

Long numbers hijack the tile's visual weight. **68,540,195** has 8 digits + commas while neighbouring tiles read **26**, **0**, **0**. Same problem with **25,943 msgs** in the foot.

New `formatCompact()` helper (`4_752_583_497` → `"4.8B"`, `58_376_273` → `"58M"`; falls through to `toLocaleString()` under 10k for small values where readable digits are still cheap). Threaded through `AnimatedNumber`'s `format` prop so the headline still animates between values smoothly.

## Before / After

| | Before | After |
|---|---|---|
| Headline | `10,143,914` | `68.6M` |
| Foot | `25,929 msgs` | `+4.8B cache reads · 26.0K msgs` |
| Tooltip | breakdown w/o billing notes | breakdown + billing multipliers |

## Test plan

- [x] `tsc --noEmit` clean
- [x] biome clean
- [x] `vitest run` — 308/308 pass
- [x] **Playwright dogfood**: tile reads `68.6M / +4.8B cache reads · 26.0K msgs`; arithmetic checks (110,613 + 10,039,866 + 58,389,424 ≈ 68.5M)
- [x] **Headline animation** preserved via custom `format` prop on `AnimatedNumber`

## Follow-up (separate concern)

The bridge's `tokens.total` field still excludes `cacheCreate`. The field name `total` arguably promises "all of them" — but fixing it touches Prometheus output. Filing as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)