### PR TITLE
ui(recipes): wrap YAML in detail panel — long {{template}} lines were silently truncated

### DIFF
--- a/dashboard/src/app/recipes/page.tsx
+++ b/dashboard/src/app/recipes/page.tsx
@@ -383,6 +383,13 @@ function RecipeYamlPanel({ recipe }: { recipe: Recipe }) {
         lineHeight: 1.55,
         maxHeight: 360,
         overflow: "auto",
+        // Detail panel is ~384px wide; without these the long
+        // {{...}} template values push past the right edge into a
+        // hidden horizontal scroll bar (no scroll affordance shown,
+        // so the visible YAML is silently truncated). Wrap and break
+        // long words — matches the /recipes/new preview behaviour.
+        whiteSpace: "pre-wrap",
+        wordBreak: "break-word",
         fontFamily: "var(--font-mono)",
       }}
     >


### PR DESCRIPTION
## Summary

Found via dogfood. The /dashboard/recipes detail panel renders a recipe's YAML in a `CodeBlock`. The `.code-block` CSS has `overflow-x: auto` and `<pre>` default `white-space: pre` — together, long lines extended past the panel's ~384px right edge into a hidden horizontal scrollbar.

**No scroll affordance was rendered**, so the visible YAML was silently truncated mid-string with no indication anything was missing.

## Confirmed via DOM

\`\`\`
scrollWidth = 599
clientWidth = 384
truncated   = true
\`\`\`

Every multi-line recipe with `{{template}}` interpolations (like `content: "- {{time}} committed {{hash}} — {{message}}"`) lost ~215px of content per line.

## Fix

Add `whiteSpace: "pre-wrap"` + `wordBreak: "break-word"` to the inline style on the detail panel's `CodeBlock`. Matches the `/recipes/new` YAML preview behaviour (which already wraps).

## Test plan

- [x] `tsc --noEmit` clean
- [x] biome clean
- [x] `vitest run` — 308/308 pass
- [x] **Playwright dogfood**: clicked `ambient-journal` in the recipes list. Full YAML now visible (description wraps to 2 lines, content shows full template including trailing `\n`). DOM check: `scrollWidth === clientWidth` (384 === 384), no horizontal overflow. Indent preserved on wrapped lines, syntax highlighting still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)