### PR TITLE
fix(useBridgeFetch): stop polling on 404 instead of looping forever

### DIFF
--- a/dashboard/src/hooks/__tests__/useBridgeFetch.test.tsx
+++ b/dashboard/src/hooks/__tests__/useBridgeFetch.test.tsx
@@ -85,6 +85,28 @@ describe("useBridgeFetch — error branches", () => {
     expect(result.current.loading).toBe(false);
   });
 
+  it("404 stops the polling loop — no further fetches fire", async () => {
+    // Regression test for the session-detail / older-bridge case where a 404
+    // would re-poll forever at intervalMs. 404 is a stable state — neither a
+    // missing endpoint nor a missing resource will materialise from polling,
+    // and the network noise was filling browser/server logs. Callers that
+    // want to retry call refetch() explicitly.
+    fetchMock.mockResolvedValueOnce(
+      new Response("nope", { status: 404, headers: { "content-type": "text/plain" } }),
+    );
+
+    const { result } = renderHook(() =>
+      useBridgeFetch("/api/missing", { intervalMs: 50 }),
+    );
+
+    await waitFor(() => expect(result.current.status).toBe(404));
+    const callsAfterFirst = fetchMock.mock.calls.length;
+    // Wait several intervals — if the hook was still polling we'd see
+    // additional fetch() invocations stack up.
+    await new Promise((r) => setTimeout(r, 250));
+    expect(fetchMock).toHaveBeenCalledTimes(callsAfterFirst);
+  });
+
   it("503 sets a 'Bridge not running' error", async () => {
     fetchMock.mockResolvedValueOnce(
       new Response("down", { status: 503 }),

--- a/dashboard/src/hooks/useBridgeFetch.ts
+++ b/dashboard/src/hooks/useBridgeFetch.ts
@@ -62,12 +62,16 @@ export function useBridgeFetch<T>(
         setStatus(res.status);
 
         if (res.status === 404) {
+          // 404 is a stable terminal state: either the endpoint isn't
+          // implemented by this bridge version (older bridge) or the resource
+          // ID doesn't exist (e.g. /sessions/<gone-uuid>). Polling won't make
+          // either appear — and on session-detail pages with a 3s interval it
+          // generates a 404-per-tick stream that fills server logs and burns
+          // network. Stop the loop. Callers that want to retry call refetch().
           setUnsupported(true);
           setData(unsupportedValueRef.current);
           setError(undefined);
           setLoading(false);
-          failures = 0;
-          schedule(intervalMs);
           return;
         }
 


### PR DESCRIPTION
## Summary

Found via dogfood. Visiting [/dashboard/sessions/&lt;gone-uuid&gt;](dashboard/src/app/sessions/[id]/page.tsx) renders "Session not found" but the underlying `useBridgeFetch` hook keeps polling `/api/bridge/sessions/<gone-uuid>` every 3 seconds — generating a 404-per-tick stream forever. Fills server logs, burns network on a state that will never change.

## Root cause

The hook handles 404 specially — sets `unsupported: true`, sets `data: unsupportedValueRef.current`, then **calls `schedule(intervalMs)` to poll again**. Two distinct meanings of 404 collapsed onto the same code path:

| Case | Reason | Will polling help? |
|---|---|---|
| Older bridge | endpoint doesn't exist | no |
| Missing resource | `/sessions/:id`, `/recipes/:name`, etc. | no |

In both cases polling can't make the response change. Removed the `schedule()` on the 404 branch — the hook now treats 404 as a **terminal state**. Callers that want to retry call `refetch()` (existing escape hatch).

## Bug-fix protocol

Wrote a regression test first per [CLAUDE.md](CLAUDE.md). Confirmed it **fails on main** (got 3 fetches when expecting 2 over 250ms) before applying the fix.

## Test plan

- [x] `tsc --noEmit` clean
- [x] biome clean
- [x] `vitest run` — **309/309 pass** (was 308; +1 regression test)
- [x] **Playwright live verification**: visited `/sessions/<gone-uuid>`, console log shows exactly **1 × 404** instead of one every 3 seconds. The "Session not found" UI is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)