### PR TITLE
fix(recipes/compare): unwrap data.plan from /plan response — page was crashing

### DIFF
--- a/dashboard/src/app/recipes/compare/page.tsx
+++ b/dashboard/src/app/recipes/compare/page.tsx
@@ -211,14 +211,20 @@ function CompareInner() {
     setPromoting: (v: boolean) => void;
   } | null>(null);
 
+  // The bridge wraps the response: { plan: DryRunPlan, error?: string }.
+  // The /recipes/[name]/plan page already extracts data.plan; this one was
+  // stuffing the whole envelope into setPlanA, then crashing on
+  // `plan.steps.map(...)` — TypeError: Cannot read properties of undefined
+  // (reading 'map'). Match the /plan page's load() shape: pull data.plan
+  // out and treat missing plan as an error.
   useEffect(() => {
     if (!nameA) return;
     setLoadingA(true);
     fetch(apiPath(`/api/bridge/recipes/${encodeURIComponent(nameA)}/plan`))
       .then((r) => r.json())
-      .then((d: DryRunPlan & { error?: string }) => {
-        if (d.error) setErrA(d.error);
-        else setPlanA(d);
+      .then((d: { plan?: DryRunPlan; error?: string }) => {
+        if (d.error || !d.plan) setErrA(d.error ?? "Failed to load plan.");
+        else setPlanA(d.plan);
       })
       .catch((e: unknown) => setErrA(e instanceof Error ? e.message : String(e)))
       .finally(() => setLoadingA(false));
@@ -229,9 +235,9 @@ function CompareInner() {
     setLoadingB(true);
     fetch(apiPath(`/api/bridge/recipes/${encodeURIComponent(nameB)}/plan`))
       .then((r) => r.json())
-      .then((d: DryRunPlan & { error?: string }) => {
-        if (d.error) setErrB(d.error);
-        else setPlanB(d);
+      .then((d: { plan?: DryRunPlan; error?: string }) => {
+        if (d.error || !d.plan) setErrB(d.error ?? "Failed to load plan.");
+        else setPlanB(d.plan);
       })
       .catch((e: unknown) => setErrB(e instanceof Error ? e.message : String(e)))
       .finally(() => setLoadingB(false));


### PR DESCRIPTION
## Summary

Found via dogfood. `/dashboard/recipes/compare?a=A&b=B` **crashes**:

> **Something went wrong**  
> Cannot read properties of undefined (reading 'map')  
> [Try again]

## Root cause

The `/api/bridge/recipes/:name/plan` endpoint returns `{ plan: DryRunPlan, error?: string }` — the actual plan is **wrapped**. The sibling [/recipes/[name]/plan](dashboard/src/app/recipes/[name]/plan/page.tsx#L149) page extracts `data.plan` correctly. The compare page did not:

\`\`\`tsx
.then((d: DryRunPlan & { error?: string }) => {
  if (d.error) setErrA(d.error);
  else setPlanA(d);   // ← whole envelope, not data.plan
})
\`\`\`

So `planA` became `{ plan: {...}, error: undefined }`, and `planA.steps` was undefined. The render at line 173 — `plan.steps.map(...)` — then crashed.

The type cast lied — `d` is the envelope, not `DryRunPlan` itself. TypeScript happily compiled because we asserted the wrong shape.

## Fix

Mirror the shape used by the working `/plan` page: extract `data.plan`, treat missing-or-error as an `setErr` call.

\`\`\`tsx
.then((d: { plan?: DryRunPlan; error?: string }) => {
  if (d.error || !d.plan) setErrA(d.error ?? "Failed to load plan.");
  else setPlanA(d.plan);
})
\`\`\`

## Test plan

- [x] `tsc --noEmit` clean
- [x] biome clean
- [x] `vitest run` — 308/308 pass
- [x] **Playwright dogfood**: `/recipes/compare?a=ambient-journal&b=approval-queue-ui-test` now renders both side-by-side cards with step rows + risk/mode columns + diff badges (`+1 new`, `-3 removed`) + Promote actions. No runtime error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)