### PR TITLE
ui(overview): drop inline grid override that crushed telemetry tiles on mobile

### DIFF
--- a/dashboard/src/app/page.tsx
+++ b/dashboard/src/app/page.tsx
@@ -857,12 +857,16 @@ export default function HomePage() {
         </Link>
       </div>
 
-      {/* Four telemetry tiles */}
+      {/* Four telemetry tiles. Inline grid-template-columns used to force
+          repeat(4, minmax(0,1fr)) — that wins over the responsive .stat-grid
+          class default (auto-fit minmax(180px, 1fr)) and made tile labels
+          ellipsise to "PENDING APPROV/" / "TOOLS CALLED TOD…" on mobile.
+          Drop the inline override; .stat-grid auto-fit gives 4 cols at
+          desktop (≥768px content width) and stacks gracefully on narrow. */}
       <div
         className="stat-grid"
         style={{
           marginBottom: "var(--s-5)",
-          gridTemplateColumns: "repeat(4, minmax(0,1fr))",
         }}
       >
         {!health && bridgeStatus.ok !== false ? (


### PR DESCRIPTION
## Summary

Found via dogfood at 375px viewport. The 4 telemetry tiles all rendered at 1/4 viewport width on mobile, ellipsising labels:

\`\`\`
RECIPES   PENDING    TOOLS    TOKENS
SHIPPED   APPROV/    CALLED   BURNT
26        0          TODAY    69.2
total     none …     0        +4.8…
                     no…      26.IK
                              msgs
\`\`\`

## Root cause

The \`.stat-grid\` CSS class already does responsive layout:

\`\`\`css
grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
\`\`\`

But the page added an inline override that **wins at every viewport**, including mobile:

\`\`\`tsx
style={{ gridTemplateColumns: "repeat(4, minmax(0,1fr))" }}
\`\`\`

## Fix

Remove the inline override. The class default handles all viewports:

| Viewport | Layout |
|---|---|
| ≥ 768px content | 4 tiles across (auto-fit fills the row) |
| Tablet | 2 tiles per row |
| Mobile (<376px content) | tiles stack 1 per row, full labels |

## Test plan

- [x] `tsc --noEmit` clean
- [x] biome clean
- [x] `vitest run` — 309/309 pass
- [x] **Playwright @ 1440×900**: 4 columns, 270px each (unchanged from before)
- [x] **Playwright @ 375×812**: tiles stack 1 per row, "PENDING APPROVALS" label fully visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)