### PR TITLE
ui(recipes/plan): show recipe-specific not-found message instead of bridge Run not found

### DIFF
--- a/dashboard/src/app/recipes/[name]/plan/page.tsx
+++ b/dashboard/src/app/recipes/[name]/plan/page.tsx
@@ -144,7 +144,18 @@ export default function RecipePlanPage({
         };
         if (cancelled) return;
         if (!res.ok || !data.plan) {
-          setError(data.error ?? "Failed to load plan.");
+          // Bridge returns `{"error":"Run not found"}` with 404 for
+          // both unknown recipes and unknown runs (the underlying runner
+          // doesn't distinguish). On a recipe page the literal string
+          // is misleading — the user is staring at "Dry-run plan:
+          // <recipe>" with "Run not found" below it. Override to a
+          // recipe-specific message on 404; surface the bridge error
+          // verbatim only on other failures.
+          if (res.status === 404) {
+            setError(`Recipe "${name}" not found.`);
+          } else {
+            setError(data.error ?? "Failed to load plan.");
+          }
         } else {
           setPlan(data.plan);
         }


### PR DESCRIPTION
Found via dogfood. `/dashboard/recipes/<not-exist>/plan` showed "Run not found" under "Dry-run plan: <recipe>" — misleading because the bridge collapses recipe-not-found and run-not-found into one error string.

The dashboard knows it's on a recipe page. On 404, override with a recipe-specific message; surface bridge error verbatim only on non-404.

After: `Recipe "not-a-recipe" not found.`

- [x] tsc clean, biome clean, vitest 309/309
- [x] Playwright: shows recipe-specific message
