### PR TITLE
fix(settings/ai-drivers): hide broken Ollama row, drop dead Configure button, distinguish disk-write 500s

### DIFF
--- a/dashboard/src/app/settings/page.tsx
+++ b/dashboard/src/app/settings/page.tsx
@@ -47,11 +47,13 @@ interface DriverRow {
   driverValue: string; // bridge driver setting that maps to this row
 }
 
+// Names omit model versions on purpose — versions go stale fast and the
+// authoritative model id is already shown on /overview hero. Ollama hidden
+// until `local` is wired into the bridge driver allowlist (see follow-up).
 const DRIVER_ROWS: DriverRow[] = [
-  { id: "claude", name: "Claude 3.5 Sonnet", detail: "Anthropic · subprocess or API", driverValue: "subprocess" },
-  { id: "gemini", name: "Gemini 2.5 Flash", detail: "Google · CLI or API", driverValue: "gemini" },
-  { id: "ollama", name: "Ollama qwen2.5-coder", detail: "Local · Ollama / LM Studio", driverValue: "local" },
-  { id: "openai", name: "OpenAI GPT-4o", detail: "OpenAI · requires API key", driverValue: "openai" },
+  { id: "claude", name: "Claude", detail: "Anthropic · subprocess (subscription) or API", driverValue: "subprocess" },
+  { id: "gemini", name: "Gemini", detail: "Google · CLI subscription or API key", driverValue: "gemini" },
+  { id: "openai", name: "OpenAI", detail: "API key required", driverValue: "openai" },
 ];
 
 // Inline style objects intentionally use the canonical --ink/--line tokens
@@ -244,7 +246,7 @@ export default function SettingsPage() {
       if (res.ok) {
         setPrimaryDriver(rowId);
         const text = body.restartRequired
-          ? `${row.name} set as primary — restart the bridge to activate.`
+          ? `${row.name} set as primary. Restart Claude Code (quit and re-open, then run /ide) to activate the new driver.`
           : `${row.name} set as primary.`;
         setDriverMsg({ ok: true, text });
         flashSaved();
@@ -539,23 +541,6 @@ export default function SettingsPage() {
                         }}
                       >
                         {driverSaving === row.id ? "Saving…" : "Set primary"}
-                      </button>
-                      <button
-                        type="button"
-                        disabled
-                        title="Per-driver configuration UI coming soon — edit the config file directly."
-                        style={{
-                          background: "transparent",
-                          color: "var(--fg-3)",
-                          border: "1px solid var(--border-default)",
-                          borderRadius: "var(--r-2)",
-                          padding: "5px 10px",
-                          fontSize: "var(--fs-s)",
-                          cursor: "not-allowed",
-                          opacity: 0.5,
-                        }}
-                      >
-                        Configure
                       </button>
                     </div>
                   );

--- a/src/__tests__/server-settings.test.ts
+++ b/src/__tests__/server-settings.test.ts
@@ -284,6 +284,44 @@ describe("POST /settings — driver persistence to bridge config file", () => {
     });
   });
 
+  it("returns 500 (not 400 'Invalid request body') when bridge config write fails", async () => {
+    // Audit found that disk-write failures inside POST /settings were caught
+    // by the outer try and reported as HTTP 400 'Invalid request body' — the
+    // same shape as a JSON parse error. Callers (the dashboard) couldn't
+    // distinguish a malformed payload from a permissions error on the bridge
+    // config file. The fix wraps saveBridgeConfigDriver in its own try/catch
+    // and returns HTTP 500 with a distinct message.
+    const bridgeCfgPath = path.join(tempDir!, "ro", "bridge.json");
+    mkdirSync(path.dirname(bridgeCfgPath), { recursive: true });
+    // Make the parent directory read-only so the atomic write inside
+    // saveBridgeConfigDriver fails on the temp-file rename.
+    const fs = await import("node:fs");
+    fs.chmodSync(path.dirname(bridgeCfgPath), 0o500);
+    server!.bridgeConfigPath = bridgeCfgPath;
+
+    try {
+      const { status, body } = await makeRequest(
+        {
+          method: "POST",
+          path: "/settings",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${TOKEN}`,
+          },
+        },
+        JSON.stringify({ driver: "gemini" }),
+      );
+
+      expect(status).toBe(500);
+      const parsed = JSON.parse(body) as { error: string };
+      expect(parsed.error).not.toBe("Invalid request body");
+      expect(parsed.error.toLowerCase()).toContain("config");
+    } finally {
+      // Restore permissions so cleanup in afterEach can rm -rf.
+      fs.chmodSync(path.dirname(bridgeCfgPath), 0o700);
+    }
+  });
+
   it("returns 413 when /settings body exceeds 16 KB cap", async () => {
     // Pad a valid-shape body past the 16 KB cap. Without the cap an
     // authenticated caller could stream gigabytes; the cap rejects the

--- a/src/server.ts
+++ b/src/server.ts
@@ -1348,7 +1348,20 @@ export class Server extends EventEmitter<ServerEvents> {
                 PatchworkConfig["driver"]
               >;
               cfg.driver = driver;
-              saveBridgeConfigDriver(driver, this.bridgeConfigPath);
+              try {
+                saveBridgeConfigDriver(driver, this.bridgeConfigPath);
+              } catch (writeErr) {
+                this.logger.error(
+                  `[/config/patchwork] saveBridgeConfigDriver failed: ${writeErr instanceof Error ? (writeErr.stack ?? writeErr.message) : String(writeErr)}`,
+                );
+                res.writeHead(500, { "Content-Type": "application/json" });
+                res.end(
+                  JSON.stringify({
+                    error: "Failed to write bridge driver config",
+                  }),
+                );
+                return;
+              }
             }
             if (body.model !== undefined) {
               const validModels = [
@@ -1391,12 +1404,38 @@ export class Server extends EventEmitter<ServerEvents> {
               // Provider keys go to the secure store (Keychain/DPAPI/Secret
               // Service / AES-256-GCM file fallback) — never persisted to
               // ~/.patchwork/config.json. Empty string clears.
-              saveApiKeyToSecureStore(
-                provider as "anthropic" | "openai" | "google" | "xai",
-                key,
-              );
+              try {
+                saveApiKeyToSecureStore(
+                  provider as "anthropic" | "openai" | "google" | "xai",
+                  key,
+                );
+              } catch (writeErr) {
+                this.logger.error(
+                  `[/config/patchwork] saveApiKeyToSecureStore failed: ${writeErr instanceof Error ? (writeErr.stack ?? writeErr.message) : String(writeErr)}`,
+                );
+                res.writeHead(500, { "Content-Type": "application/json" });
+                res.end(
+                  JSON.stringify({
+                    error: "Failed to write provider API key",
+                  }),
+                );
+                return;
+              }
             }
-            savePatchworkConfig(cfg, configPath);
+            try {
+              savePatchworkConfig(cfg, configPath);
+            } catch (writeErr) {
+              this.logger.error(
+                `[/config/patchwork] savePatchworkConfig failed: ${writeErr instanceof Error ? (writeErr.stack ?? writeErr.message) : String(writeErr)}`,
+              );
+              res.writeHead(500, { "Content-Type": "application/json" });
+              res.end(
+                JSON.stringify({
+                  error: "Failed to write patchwork config",
+                }),
+              );
+              return;
+            }
             if (hasWebhookUpdate) {
               this.approvalWebhookUrl = raw || undefined;
             }


### PR DESCRIPTION
## Summary

Audit on the AI drivers card surfaced five P0/P1 issues. This PR fixes the surgical ones; product-gap items get follow-up issues.

**Dashboard ([dashboard/src/app/settings/page.tsx](dashboard/src/app/settings/page.tsx)):**
- **Hide Ollama row.** Bridge `/settings` allowlist is `subprocess|api|openai|grok|gemini|none` — `local` was never accepted, so clicking Set primary on Ollama silently 400'd. Even if the write had succeeded, `PatchworkConfig["driver"]` union, `VALID_DRIVER_MODES`, and `createDriver` all lack a `local` branch. Row hidden until the full chain is wired (tracked as follow-up).
- **Remove dead Configure button.** Was unconditionally `disabled={true}` with no `onClick` and identical "coming soon" tooltip on every row. Pure placeholder UI.
- **Generic model labels.** Dropped stale versions ("Claude 3.5 Sonnet", "Gemini 2.5 Flash", "OpenAI GPT-4o"). Two model generations behind reality. Authoritative id is already on `/overview` hero and `/status`.
- **Restart hint clarified** — now says "quit and re-open Claude Code, then /ide" instead of vague "restart the bridge to activate".

**Bridge ([src/server.ts](src/server.ts)):**
- POST `/config/patchwork` wrapped `saveBridgeConfigDriver`, `saveApiKeyToSecureStore`, and `savePatchworkConfig` in their own `try`/`catch` blocks. Disk failures used to fall through to the outer handler and return HTTP 400 `'Invalid request body'` — the **same shape** as a JSON parse error. Dashboard couldn't distinguish a malformed payload from a permissions error on disk. They now return HTTP 500 with distinct messages per failed write.

## Out of scope (follow-up issues)
- Add Grok row (driver exists at `src/drivers/grok/`, just missing from UI)
- Per-driver API-key entry UI (bridge already accepts `{apiKey:{provider,key}}`)
- Source labels from `/status` instead of hardcoded constants
- Re-enable Ollama with full `local` driver wiring + endpoint/model UI
- Subprocess-vs-API toggle for Claude/Gemini

## Test plan
- [x] `npm run typecheck` clean
- [x] `npx vitest run src/__tests__/server-settings.test.ts` — 11/11 pass, including new regression test that chmod 0o500's the bridge config dir, POSTs `{driver:"gemini"}`, asserts HTTP 500 with non-`'Invalid request body'` message
- [ ] Reviewer: open `/dashboard/settings` → AI drivers card should show only Claude / Gemini / OpenAI rows (no Ollama, no Configure buttons)
- [ ] Reviewer: click Set primary, verify the new restart message text appears

## Note on agent audit
The code-review agent flagged a P1 about "optimistic primaryDriver desync on validation error". On re-read, `setPrimaryDriver(rowId)` is only called inside `if (res.ok)` — there's no optimistic update to roll back. Skipping that fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)