### PR TITLE
feat(settings/ai-drivers): per-row API key entry + Grok row + apiKeysPresent in /status

### DIFF
--- a/dashboard/src/app/settings/page.tsx
+++ b/dashboard/src/app/settings/page.tsx
@@ -27,9 +27,17 @@ interface StatusResponse {
     inboxDir?: string;
     httpPort?: number;
     configPath?: string;
+    apiKeysPresent?: {
+      anthropic?: boolean;
+      openai?: boolean;
+      google?: boolean;
+      xai?: boolean;
+    };
   };
   [k: string]: unknown;
 }
+
+type ApiKeyProvider = "anthropic" | "openai" | "google" | "xai";
 
 type SectionId = "s-bridge" | "s-ai" | "s-approval" | "s-telemetry";
 
@@ -45,15 +53,17 @@ interface DriverRow {
   name: string;
   detail: string;
   driverValue: string; // bridge driver setting that maps to this row
+  keyProvider?: ApiKeyProvider; // shows API-key input when set
 }
 
 // Names omit model versions on purpose — versions go stale fast and the
 // authoritative model id is already shown on /overview hero. Ollama hidden
 // until `local` is wired into the bridge driver allowlist (see follow-up).
 const DRIVER_ROWS: DriverRow[] = [
-  { id: "claude", name: "Claude", detail: "Anthropic · subprocess (subscription) or API", driverValue: "subprocess" },
-  { id: "gemini", name: "Gemini", detail: "Google · CLI subscription or API key", driverValue: "gemini" },
-  { id: "openai", name: "OpenAI", detail: "API key required", driverValue: "openai" },
+  { id: "claude", name: "Claude", detail: "Anthropic · subprocess (subscription) or API", driverValue: "subprocess", keyProvider: "anthropic" },
+  { id: "gemini", name: "Gemini", detail: "Google · CLI subscription or API key", driverValue: "gemini", keyProvider: "google" },
+  { id: "openai", name: "OpenAI", detail: "API key required", driverValue: "openai", keyProvider: "openai" },
+  { id: "grok", name: "Grok", detail: "xAI · API key required", driverValue: "grok", keyProvider: "xai" },
 ];
 
 // Inline style objects intentionally use the canonical --ink/--line tokens
@@ -106,6 +116,18 @@ export default function SettingsPage() {
   const [driverSaving, setDriverSaving] = useState<string | null>(null);
   const [driverMsg, setDriverMsg] = useState<{ ok: boolean; text: string } | null>(null);
   const driverInitialized = useRef(false);
+
+  // Per-row API key entry state. Inputs are uncontrolled w.r.t. /status —
+  // the dashboard never sees the stored value (secure store is one-way),
+  // so this map only tracks the current draft text.
+  const [keyDrafts, setKeyDrafts] = useState<Record<ApiKeyProvider, string>>({
+    anthropic: "",
+    openai: "",
+    google: "",
+    xai: "",
+  });
+  const [keySaving, setKeySaving] = useState<ApiKeyProvider | null>(null);
+  const [keyMsg, setKeyMsg] = useState<{ provider: ApiKeyProvider; ok: boolean; text: string } | null>(null);
 
   // Approval policy
   const [gateValue, setGateValue] = useState<"off" | "high" | "all">("off");
@@ -223,6 +245,38 @@ export default function SettingsPage() {
     setSaveState("saving");
     setTimeout(() => setSaveState("saved"), 600);
     setTimeout(() => setSaveState("idle"), 2400);
+  }
+
+  async function saveApiKey(provider: ApiKeyProvider) {
+    const key = keyDrafts[provider];
+    setKeySaving(provider);
+    setKeyMsg(null);
+    try {
+      const res = await fetch(apiPath("/api/bridge/settings"), {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ apiKey: { provider, key } }),
+      });
+      const body = (await res.json().catch(() => ({}))) as { ok?: boolean; error?: string };
+      if (res.ok) {
+        setKeyDrafts((d) => ({ ...d, [provider]: "" }));
+        setKeyMsg({ provider, ok: true, text: key ? "Key saved." : "Key cleared." });
+        flashSaved();
+        // Refresh /status so the "key set" badge reflects the change immediately.
+        try {
+          const refreshed = await (await fetch(apiPath("/api/bridge/status"))).json();
+          setSettings(refreshed);
+        } catch {
+          /* badge will update on next poll tick */
+        }
+      } else {
+        setKeyMsg({ provider, ok: false, text: body.error ?? `Error ${res.status}` });
+      }
+    } catch (e) {
+      setKeyMsg({ provider, ok: false, text: e instanceof Error ? e.message : String(e) });
+    } finally {
+      setKeySaving(null);
+    }
   }
 
   async function setPrimary(rowId: string) {
@@ -498,50 +552,117 @@ export default function SettingsPage() {
                   // hasn't switched yet, surface that as a clear pending-restart
                   // state instead of the contradictory `primary` + `inactive`.
                   const pendingRestart = isPrimary && !activeDriver;
+                  const provider = row.keyProvider;
+                  const keyPresent = provider
+                    ? Boolean(settings.patchwork?.apiKeysPresent?.[provider])
+                    : false;
                   return (
                     <div
                       key={row.id}
                       style={{
                         display: "flex",
-                        alignItems: "center",
-                        gap: 12,
+                        flexDirection: "column",
+                        gap: 10,
                         padding: "12px 14px",
                         background: isPrimary ? "var(--bg-3)" : "var(--bg-2)",
                         border: isPrimary ? "1px solid var(--line-1)" : "1px solid var(--border-default)",
                         borderRadius: "var(--r-2)",
                       }}
                     >
-                      <div style={{ flex: 1, minWidth: 0 }}>
+                      <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+                        <div style={{ flex: 1, minWidth: 0 }}>
+                          <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
+                            <span style={{ fontSize: "var(--fs-m)", fontWeight: 600, color: "var(--fg-0)" }}>{row.name}</span>
+                            {isPrimary && <StatusPill tone="ok">primary</StatusPill>}
+                            {pendingRestart ? (
+                              <StatusPill tone="warn">pending restart</StatusPill>
+                            ) : (
+                              <StatusPill tone={activeDriver ? "ok" : "muted"}>
+                                {activeDriver ? "active" : "inactive"}
+                              </StatusPill>
+                            )}
+                            {provider && keyPresent && (
+                              <StatusPill tone="ok">key set</StatusPill>
+                            )}
+                          </div>
+                          <div style={{ fontSize: "var(--fs-s)", color: "var(--fg-2)", marginTop: 2 }}>{row.detail}</div>
+                        </div>
+                        <button
+                          type="button"
+                          onClick={() => setPrimary(row.id)}
+                          disabled={isPrimary || driverSaving === row.id}
+                          style={{
+                            background: "transparent",
+                            color: "var(--fg-1)",
+                            border: "1px solid var(--border-default)",
+                            borderRadius: "var(--r-2)",
+                            padding: "5px 10px",
+                            fontSize: "var(--fs-s)",
+                            cursor: isPrimary ? "default" : "pointer",
+                            opacity: isPrimary ? 0.5 : 1,
+                          }}
+                        >
+                          {driverSaving === row.id ? "Saving…" : "Set primary"}
+                        </button>
+                      </div>
+                      {provider && (
                         <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
-                          <span style={{ fontSize: "var(--fs-m)", fontWeight: 600, color: "var(--fg-0)" }}>{row.name}</span>
-                          {isPrimary && <StatusPill tone="ok">primary</StatusPill>}
-                          {pendingRestart ? (
-                            <StatusPill tone="warn">pending restart</StatusPill>
-                          ) : (
-                            <StatusPill tone={activeDriver ? "ok" : "muted"}>
-                              {activeDriver ? "active" : "inactive"}
-                            </StatusPill>
+                          <input
+                            id={`api-key-${provider}`}
+                            type="password"
+                            placeholder={keyPresent ? "Replace key…" : `${provider} API key`}
+                            autoComplete="off"
+                            value={keyDrafts[provider]}
+                            onChange={(e) => setKeyDrafts((d) => ({ ...d, [provider]: e.target.value }))}
+                            style={{ ...inputStyle, flex: 1, minWidth: 200, maxWidth: 480 }}
+                          />
+                          <button
+                            type="button"
+                            onClick={() => saveApiKey(provider)}
+                            disabled={keySaving === provider || keyDrafts[provider].length === 0}
+                            style={{
+                              background: "transparent",
+                              color: "var(--fg-1)",
+                              border: "1px solid var(--border-default)",
+                              borderRadius: "var(--r-2)",
+                              padding: "5px 10px",
+                              fontSize: "var(--fs-s)",
+                              cursor: keyDrafts[provider].length === 0 ? "default" : "pointer",
+                              opacity: keyDrafts[provider].length === 0 ? 0.5 : 1,
+                            }}
+                          >
+                            {keySaving === provider ? "Saving…" : "Save"}
+                          </button>
+                          {keyPresent && (
+                            <button
+                              type="button"
+                              onClick={() => {
+                                setKeyDrafts((d) => ({ ...d, [provider]: "" }));
+                                // Empty string deletes from secure store.
+                                void saveApiKey(provider);
+                              }}
+                              disabled={keySaving === provider}
+                              title="Remove the stored key from the secure store"
+                              style={{
+                                background: "transparent",
+                                color: "var(--fg-2)",
+                                border: "1px solid var(--border-default)",
+                                borderRadius: "var(--r-2)",
+                                padding: "5px 10px",
+                                fontSize: "var(--fs-s)",
+                                cursor: "pointer",
+                              }}
+                            >
+                              Clear
+                            </button>
+                          )}
+                          {keyMsg && keyMsg.provider === provider && (
+                            <span style={{ fontSize: "var(--fs-s)", color: keyMsg.ok ? "var(--ok)" : "var(--err)" }}>
+                              {keyMsg.text}
+                            </span>
                           )}
                         </div>
-                        <div style={{ fontSize: "var(--fs-s)", color: "var(--fg-2)", marginTop: 2 }}>{row.detail}</div>
-                      </div>
-                      <button
-                        type="button"
-                        onClick={() => setPrimary(row.id)}
-                        disabled={isPrimary || driverSaving === row.id}
-                        style={{
-                          background: "transparent",
-                          color: "var(--fg-1)",
-                          border: "1px solid var(--border-default)",
-                          borderRadius: "var(--r-2)",
-                          padding: "5px 10px",
-                          fontSize: "var(--fs-s)",
-                          cursor: isPrimary ? "default" : "pointer",
-                          opacity: isPrimary ? 0.5 : 1,
-                        }}
-                      >
-                        {driverSaving === row.id ? "Saving…" : "Set primary"}
-                      </button>
+                      )}
                     </div>
                   );
                 })}

--- a/src/__tests__/patchworkConfig.test.ts
+++ b/src/__tests__/patchworkConfig.test.ts
@@ -25,6 +25,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
+  getApiKeysPresent,
   loadConfig,
   saveApiKeyToSecureStore,
   saveConfig,
@@ -153,5 +154,47 @@ describe("saveApiKeyToSecureStore", () => {
       const buf = readFileSync(join(tokenDir, name), "utf-8");
       expect(buf).not.toContain("secret-google-key-xyz");
     }
+  });
+});
+
+describe("getApiKeysPresent", () => {
+  // Used by /status to surface which providers have a key without ever
+  // exposing the key itself to the dashboard. Must return a boolean for all
+  // four providers regardless of which (or none) are stored.
+
+  it("returns false for every provider when the store is empty", () => {
+    const present = getApiKeysPresent();
+    expect(present).toEqual({
+      anthropic: false,
+      openai: false,
+      google: false,
+      xai: false,
+    });
+  });
+
+  it("flips a provider to true when its key is saved", () => {
+    saveApiKeyToSecureStore("openai", "sk-present-test");
+    const present = getApiKeysPresent();
+    expect(present.openai).toBe(true);
+    // Other providers stay false
+    expect(present.anthropic).toBe(false);
+    expect(present.google).toBe(false);
+    expect(present.xai).toBe(false);
+  });
+
+  it("flips back to false after the key is cleared", () => {
+    saveApiKeyToSecureStore("xai", "xai-key-temp");
+    expect(getApiKeysPresent().xai).toBe(true);
+
+    saveApiKeyToSecureStore("xai", "");
+    expect(getApiKeysPresent().xai).toBe(false);
+  });
+
+  it("never includes the actual key in the return value", () => {
+    const secret = "anthropic-key-do-not-leak-zzz";
+    saveApiKeyToSecureStore("anthropic", secret);
+    const present = getApiKeysPresent();
+    // Stringify and grep — the secret must not appear anywhere in the value.
+    expect(JSON.stringify(present)).not.toContain(secret);
   });
 });

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -25,6 +25,7 @@ import { Logger } from "./logger.js";
 import { OAuthServerImpl } from "./oauth.js";
 import {
   defaultConfigPath,
+  getApiKeysPresent,
   loadConfig as loadPatchworkConfig,
 } from "./patchworkConfig.js";
 import type { LoadedPluginTool } from "./pluginLoader.js";
@@ -1383,6 +1384,7 @@ export class Bridge {
             httpPort: this.port,
             inboxDir: path.join(os.homedir(), ".patchwork", "inbox"),
             configPath: defaultConfigPath(),
+            apiKeysPresent: getApiKeysPresent(),
             webhookUrl: this.server.approvalWebhookUrl ?? null,
             pushServiceUrl: this.server.pushServiceUrl ?? null,
             pushServiceToken: this.server.pushServiceToken ? "***" : null,

--- a/src/patchworkConfig.ts
+++ b/src/patchworkConfig.ts
@@ -102,6 +102,25 @@ function loadApiKeysFromSecureStore(): NonNullable<PatchworkConfig["apiKeys"]> {
   return out;
 }
 
+/**
+ * Boolean presence check per provider — returns whether a key is in the
+ * secure store, never the key itself. Used by /status so the dashboard can
+ * render "key set" badges and gate the picker without ever seeing a raw key.
+ */
+export function getApiKeysPresent(): Record<ApiKeyProvider, boolean> {
+  const out: Record<ApiKeyProvider, boolean> = {
+    anthropic: false,
+    openai: false,
+    google: false,
+    xai: false,
+  };
+  for (const provider of API_KEY_PROVIDERS) {
+    const stored = getSecretJsonSync<StoredApiKey>(secretKeyFor(provider));
+    out[provider] = Boolean(stored?.key);
+  }
+  return out;
+}
+
 export function loadConfig(path = defaultConfigPath()): PatchworkConfig {
   if (!existsSync(path)) {
     const fromStore = loadApiKeysFromSecureStore();


### PR DESCRIPTION
Closes #356, #357.

## Summary

Bundled the keystone PR identified in the audit triage. Without these, every other AI-drivers issue is blocked on dead UI.

**Bridge ([src/patchworkConfig.ts](src/patchworkConfig.ts), [src/bridge.ts](src/bridge.ts)):**
- New \`getApiKeysPresent()\` helper — returns booleans per provider, never the key itself. \`/status.patchwork\` exposes \`apiKeysPresent: {anthropic, openai, google, xai}\` so the dashboard can render "key set" badges and (eventually) gate the picker without seeing raw keys.

**Dashboard ([dashboard/src/app/settings/page.tsx](dashboard/src/app/settings/page.tsx)):**
- **Grok row added.** \`GrokApiDriver\` ([src/drivers/grok/index.ts](src/drivers/grok/index.ts)) and the \`grok\` allowlist entry already existed — UI was the only gap.
- **Per-row API key UI.** Rows with \`keyProvider\` render an inline password input + Save + Clear (when present) + "key set" pill. POSTs \`{apiKey:{provider,key}}\` to \`/api/bridge/settings\`; empty key deletes from the secure store. After save/clear, \`/status\` is re-fetched so the badge updates immediately.
- All four rows (Claude, Gemini, OpenAI, Grok) get a key field — Claude/Gemini keys sit ready in the keychain for when #360's subprocess/API toggle ships.

## Tests

4 new unit tests in [src/__tests__/patchworkConfig.test.ts](src/__tests__/patchworkConfig.test.ts):
- \`getApiKeysPresent\` returns all-false on empty store
- single provider flips to true on save
- flips back to false on clear
- **never includes the raw key in its return value** (regression guard against accidental leaks)

11/11 patchworkConfig tests pass.

## Live dogfood (Playwright on running 3200→3101)

1. Restarted bridge with new code, confirmed \`/status.patchwork.apiKeysPresent\` is exposed and starts all-false.
2. Loaded \`/dashboard/settings\` — all 4 rows render with key inputs (Claude/Gemini/OpenAI/Grok).
3. Typed fake key into OpenAI row + Save → \`apiKeysPresent.openai\` flipped to \`true\`, "key set" badge appeared next to row name.
4. Clear button → \`apiKeysPresent.openai\` flipped back to \`false\`, "Key cleared." message displayed.

## Test plan
- [x] \`npm run typecheck\` clean
- [x] \`npm run typecheck\` (dashboard) clean
- [x] \`vitest run src/__tests__/patchworkConfig.test.ts\` — 11/11 pass
- [x] Live key save/clear round-trip verified end-to-end
- [ ] Reviewer: confirm no raw key text appears in \`/status\` payload (curl with auth + grep)

## Out of scope (related issues still open)

- **#358** — source labels from \`/status\` instead of constants
- **#359** — re-enable Ollama with full \`local\`-driver wiring
- **#360** — subprocess/API toggle (Claude-only after #361 builds GeminiApiDriver)
- **#361** — build \`GeminiApiDriver\` (uncovered during triage; blocker for #360's Gemini half)

🤖 Generated with [Claude Code](https://claude.com/claude-code)