### PR TITLE
feat(settings/ai-drivers): show default model id under each row

### DIFF
--- a/dashboard/src/app/settings/page.tsx
+++ b/dashboard/src/app/settings/page.tsx
@@ -66,6 +66,19 @@ const DRIVER_ROWS: DriverRow[] = [
   { id: "grok", name: "Grok", detail: "xAI · API key required", driverValue: "grok", keyProvider: "xai" },
 ];
 
+// Default model id each driver runs when input.model is not set.
+// Source of truth (update when driver defaults move):
+//   claude  → src/claudeDriver.ts:616, src/drivers/claude/api.ts:52
+//   openai  → src/drivers/openai/index.ts:79 (literal fallback)
+//   grok    → src/drivers/grok/index.ts:19 (defaultModel)
+//   gemini  → no override; whatever the user's `gemini` CLI defaults to
+const DRIVER_DEFAULT_MODEL: Record<string, string | null> = {
+  claude: "claude-haiku-4-5-20251001",
+  openai: "gpt-4o",
+  grok: "grok-2-latest",
+  gemini: null, // CLI default — not knowable without running it
+};
+
 // Inline style objects intentionally use the canonical --ink/--line tokens
 // (not the legacy --fg-*/--border-* aliases). The aliases are kept in
 // globals.css for back-compat but new surfaces should pick the canonical
@@ -586,6 +599,11 @@ export default function SettingsPage() {
                             )}
                           </div>
                           <div style={{ fontSize: "var(--fs-s)", color: "var(--fg-2)", marginTop: 2 }}>{row.detail}</div>
+                          {DRIVER_DEFAULT_MODEL[row.id] && (
+                            <div className="mono" style={{ fontSize: "var(--fs-s)", color: "var(--fg-3)", marginTop: 2 }}>
+                              Default model: {DRIVER_DEFAULT_MODEL[row.id]}
+                            </div>
+                          )}
                         </div>
                         <button
                           type="button"


### PR DESCRIPTION
Closes #358 (minimal slice).

**Stacked on #362** — base branch is \`feat/ai-drivers-key-entry-grok\`, not \`main\`. Merge #362 first; this will auto-retarget to main.

## Why constants, not /status

Triage said "source labels from /status." But \`/status.patchwork.model\` only exposes the driver family enum (\`"claude"\` / \`"openai"\` / \`"gemini"\` / \`"grok"\` / \`"local"\`), not the actual model id. Surfacing the real id would require every driver to track and report its selected model — out of scope for a surgical fix.

Lifted the four hardcoded driver defaults into a `DRIVER_DEFAULT_MODEL` constant in the dashboard, with comments pointing to the source-of-truth files:
- claude → [src/claudeDriver.ts:616](src/claudeDriver.ts#L616), [src/drivers/claude/api.ts:52](src/drivers/claude/api.ts#L52)
- openai → [src/drivers/openai/index.ts:79](src/drivers/openai/index.ts#L79)
- grok → [src/drivers/grok/index.ts:19](src/drivers/grok/index.ts#L19)

Renders under each row's detail line as \`Default model: claude-haiku-4-5-20251001\`.

Gemini intentionally renders no default — the subprocess driver passes no model override, so the value depends entirely on whatever the user's \`gemini\` CLI runs. Showing a guess would be misleading.

## Test plan
- [x] Dashboard typecheck clean
- [x] Live dogfood: all four rows render, defaults visible under Claude/OpenAI/Grok, omitted under Gemini
- [ ] Reviewer: confirm the comment in \`DRIVER_DEFAULT_MODEL\` actually points to current default sites (these defaults move when drivers update)

## Follow-up consideration (NOT this PR)

When a driver call returns an effective model in its response (Anthropic API does, OpenAI does), pipe it back through \`/status\` as \`effectiveModel\` so the dashboard can show the runtime value rather than just the static default. Worth a separate issue if anyone hits it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)