### PR TITLE
feat(settings/ai-drivers): add 'Claude API' row (Claude half of #360)

### DIFF
--- a/dashboard/src/app/settings/page.tsx
+++ b/dashboard/src/app/settings/page.tsx
@@ -59,21 +59,28 @@ interface DriverRow {
 // Names omit model versions on purpose — versions go stale fast and the
 // authoritative model id is already shown on /overview hero. Ollama hidden
 // until `local` is wired into the bridge driver allowlist (see follow-up).
+//
+// "Claude" and "Claude API" are two real driver values (`subprocess` vs
+// `api`) that hit Anthropic two different ways: Claude CLI subscription
+// vs API key. Same row pattern as OpenAI/Grok for the API path. Gemini
+// will get a sibling "Gemini API" row once GeminiApiDriver lands (#361).
 const DRIVER_ROWS: DriverRow[] = [
-  { id: "claude", name: "Claude", detail: "Anthropic · subprocess (subscription) or API", driverValue: "subprocess", keyProvider: "anthropic" },
-  { id: "gemini", name: "Gemini", detail: "Google · CLI subscription or API key", driverValue: "gemini", keyProvider: "google" },
+  { id: "claude", name: "Claude", detail: "Anthropic · Claude Code subscription (subprocess)", driverValue: "subprocess", keyProvider: "anthropic" },
+  { id: "claude-api", name: "Claude API", detail: "Anthropic · API key (no subscription required)", driverValue: "api", keyProvider: "anthropic" },
+  { id: "gemini", name: "Gemini", detail: "Google · CLI subscription (subprocess)", driverValue: "gemini", keyProvider: "google" },
   { id: "openai", name: "OpenAI", detail: "API key required", driverValue: "openai", keyProvider: "openai" },
   { id: "grok", name: "Grok", detail: "xAI · API key required", driverValue: "grok", keyProvider: "xai" },
 ];
 
 // Default model id each driver runs when input.model is not set.
 // Source of truth (update when driver defaults move):
-//   claude  → src/claudeDriver.ts:616, src/drivers/claude/api.ts:52
-//   openai  → src/drivers/openai/index.ts:79 (literal fallback)
-//   grok    → src/drivers/grok/index.ts:19 (defaultModel)
-//   gemini  → no override; whatever the user's `gemini` CLI defaults to
+//   claude / claude-api → src/claudeDriver.ts:616, src/drivers/claude/api.ts:52
+//   openai              → src/drivers/openai/index.ts:79 (literal fallback)
+//   grok                → src/drivers/grok/index.ts:19 (defaultModel)
+//   gemini              → no override; whatever the user's `gemini` CLI defaults to
 const DRIVER_DEFAULT_MODEL: Record<string, string | null> = {
   claude: "claude-haiku-4-5-20251001",
+  "claude-api": "claude-haiku-4-5-20251001",
   openai: "gpt-4o",
   grok: "grok-2-latest",
   gemini: null, // CLI default — not knowable without running it


### PR DESCRIPTION
Addresses Claude half of #360.

**Stacked on #363** (which is stacked on #362). Merge order: #362 → #363 → this. Each will auto-retarget to main as the parent merges.

## Summary

Adds a fifth driver row (\`id: "claude-api"\`) mapping to the existing \`api\` driver value. The bridge's allowlist, \`createDriver\`, and Anthropic API driver were all already present — UI was the only gap.

Result: users can pick Anthropic's API path (no Claude Code subscription needed) directly from the dashboard, after entering a key via #357's UI.

Both Claude rows share the \`anthropic\` provider for the API key — saving on either populates the same secure-store entry, and the "key set" badge shows on both when a key is present. Slightly redundant but honest: both rows can use the key, and the user only has to save once.

## Out of scope (Gemini half of #360)

The Gemini half of #360 is blocked on #361 (build GeminiApiDriver). Once #361 lands, a sibling "Gemini API" row gets added with the same pattern. Tracked in #360.

## Test plan
- [x] Dashboard typecheck clean
- [x] 5 rows render in expected order: Claude / Claude API / Gemini / OpenAI / Grok
- [x] Live dogfood: clicking Set primary on Claude API POSTs \`{driver:"api"}\`, returns 200 with restartRequired:true
- [x] Reverting to Claude (subprocess) works
- [ ] Reviewer: confirm the row split reads naturally (vs. the alternative — a subprocess/api segmented toggle on a single row)

## Why two rows instead of a toggle?

Considered a "Subprocess | API" segmented control on the existing Claude row. Decided against it because:
1. Two rows match the existing pattern (each row → one driverValue).
2. Once #361 ships, Gemini will need the same split — easier to extend rows than toggles.
3. State management for "selected mode per row" complicates the read-back from \`/status.driver\` (a string).

If reviewers prefer the toggle approach, easy to revisit before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)