### PR TITLE
fix: re-land #358 (default model labels) + #360-Claude (Claude API row)

### DIFF
--- a/dashboard/src/app/settings/page.tsx
+++ b/dashboard/src/app/settings/page.tsx
@@ -59,21 +59,28 @@ interface DriverRow {
 // Names omit model versions on purpose — versions go stale fast and the
 // authoritative model id is already shown on /overview hero. Ollama hidden
 // until `local` is wired into the bridge driver allowlist (see follow-up).
+//
+// "Claude" and "Claude API" are two real driver values (`subprocess` vs
+// `api`) that hit Anthropic two different ways: Claude CLI subscription
+// vs API key. Same row pattern as OpenAI/Grok for the API path. Gemini
+// will get a sibling "Gemini API" row once GeminiApiDriver lands (#361).
 const DRIVER_ROWS: DriverRow[] = [
-  { id: "claude", name: "Claude", detail: "Anthropic · subprocess (subscription) or API", driverValue: "subprocess", keyProvider: "anthropic" },
-  { id: "gemini", name: "Gemini", detail: "Google · CLI subscription or API key", driverValue: "gemini", keyProvider: "google" },
+  { id: "claude", name: "Claude", detail: "Anthropic · Claude Code subscription (subprocess)", driverValue: "subprocess", keyProvider: "anthropic" },
+  { id: "claude-api", name: "Claude API", detail: "Anthropic · API key (no subscription required)", driverValue: "api", keyProvider: "anthropic" },
+  { id: "gemini", name: "Gemini", detail: "Google · CLI subscription (subprocess)", driverValue: "gemini", keyProvider: "google" },
   { id: "openai", name: "OpenAI", detail: "API key required", driverValue: "openai", keyProvider: "openai" },
   { id: "grok", name: "Grok", detail: "xAI · API key required", driverValue: "grok", keyProvider: "xai" },
 ];
 
 // Default model id each driver runs when input.model is not set.
 // Source of truth (update when driver defaults move):
-//   claude  → src/claudeDriver.ts:616, src/drivers/claude/api.ts:52
-//   openai  → src/drivers/openai/index.ts:79 (literal fallback)
-//   grok    → src/drivers/grok/index.ts:19 (defaultModel)
-//   gemini  → no override; whatever the user's `gemini` CLI defaults to
+//   claude / claude-api → src/claudeDriver.ts:616, src/drivers/claude/api.ts:52
+//   openai              → src/drivers/openai/index.ts:79 (literal fallback)
+//   grok                → src/drivers/grok/index.ts:19 (defaultModel)
+//   gemini              → no override; whatever the user's `gemini` CLI defaults to
 const DRIVER_DEFAULT_MODEL: Record<string, string | null> = {
   claude: "claude-haiku-4-5-20251001",
+  "claude-api": "claude-haiku-4-5-20251001",
   openai: "gpt-4o",
   grok: "grok-2-latest",
   gemini: null, // CLI default — not knowable without running it

--- a/dashboard/src/app/settings/page.tsx
+++ b/dashboard/src/app/settings/page.tsx
@@ -66,6 +66,19 @@ const DRIVER_ROWS: DriverRow[] = [
   { id: "grok", name: "Grok", detail: "xAI · API key required", driverValue: "grok", keyProvider: "xai" },
 ];
 
+// Default model id each driver runs when input.model is not set.
+// Source of truth (update when driver defaults move):
+//   claude  → src/claudeDriver.ts:616, src/drivers/claude/api.ts:52
+//   openai  → src/drivers/openai/index.ts:79 (literal fallback)
+//   grok    → src/drivers/grok/index.ts:19 (defaultModel)
+//   gemini  → no override; whatever the user's `gemini` CLI defaults to
+const DRIVER_DEFAULT_MODEL: Record<string, string | null> = {
+  claude: "claude-haiku-4-5-20251001",
+  openai: "gpt-4o",
+  grok: "grok-2-latest",
+  gemini: null, // CLI default — not knowable without running it
+};
+
 // Inline style objects intentionally use the canonical --ink/--line tokens
 // (not the legacy --fg-*/--border-* aliases). The aliases are kept in
 // globals.css for back-compat but new surfaces should pick the canonical
@@ -586,6 +599,11 @@ export default function SettingsPage() {
                             )}
                           </div>
                           <div style={{ fontSize: "var(--fs-s)", color: "var(--fg-2)", marginTop: 2 }}>{row.detail}</div>
+                          {DRIVER_DEFAULT_MODEL[row.id] && (
+                            <div className="mono" style={{ fontSize: "var(--fs-s)", color: "var(--fg-3)", marginTop: 2 }}>
+                              Default model: {DRIVER_DEFAULT_MODEL[row.id]}
+                            </div>
+                          )}
                         </div>
                         <button
                           type="button"


### PR DESCRIPTION
## What happened

PRs #363 (default model labels, closes #358) and #364 (Claude API row, Claude half of #360) were stacked on #362. When #362 squash-merged to main, the squash commit \`bfe937b\` replaced \`feat/ai-drivers-key-entry-grok\`'s history. #363 and #364 were then squash-merged into their *parent stacked branches* — \`be8b8c7\` on \`feat/ai-drivers-key-entry-grok\` and \`9f679b4\` on \`feat/ai-drivers-live-model-labels\` — neither of which is reachable from main. \`gh pr view\` reports them as MERGED, but the changes are stranded on orphan branches.

This is the squash-merge-on-stacked-PRs gotcha called out in [my own memory](https://github.com/Oolab-labs/patchwork-os/blob/main/CLAUDE.md): "Stacked PRs lose content on squash-merge — patchwork-os squashes; retarget leaf to main before merging." The previous PR descriptions even said "stacked on #362" but didn't make the cascade requirement loud enough.

## What this PR does

Cherry-picks the two stranded commits (\`f06a33b\` and \`1ac3615\`) onto main. Single-file diff in \`dashboard/src/app/settings/page.tsx\`.

**From #363 (closes #358):**
- \`DRIVER_DEFAULT_MODEL\` constant with the real default model id per driver, sourced from the driver files (comments point to \`src/claudeDriver.ts:616\`, \`src/drivers/openai/index.ts:79\`, \`src/drivers/grok/index.ts:19\`).
- Renders \`Default model: claude-haiku-4-5-20251001\` (and the rest) under each row's detail line. Gemini intentionally renders no default — its CLI default isn't knowable from outside.

**From #364 (Claude half of #360):**
- New "Claude API" row mapping to the existing \`api\` driver value. Both Claude rows share the \`anthropic\` provider for the API key.
- Five-row order: Claude / Claude API / Gemini / OpenAI / Grok.

Already dogfooded live during the original PRs.

## Test plan
- [x] \`npm run typecheck\` (full + dashboard) clean
- [x] Cherry-picks applied cleanly with no conflicts
- [ ] Reviewer: \`/dashboard/settings\` → AI drivers card should show 5 rows including "Claude API", with default model lines under Claude / Claude API / OpenAI / Grok

## Closes
- #358 (default model labels)
- Claude half of #360 (Gemini half still blocked on #361)

🤖 Generated with [Claude Code](https://claude.com/claude-code)