### PR TITLE
feat(drivers): add GeminiApiDriver via Google's OpenAI-compat endpoint

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -25,7 +25,14 @@ export interface Config {
   activeWorkspaceFolder: string;
   gracePeriodMs: number;
   autoTmux: boolean;
-  driver: "subprocess" | "api" | "openai" | "grok" | "gemini" | "none";
+  driver:
+    | "subprocess"
+    | "api"
+    | "openai"
+    | "grok"
+    | "gemini"
+    | "gemini-api"
+    | "none";
   claudeBinary: string;
   antBinary: string;
   automationEnabled: boolean;
@@ -195,9 +202,23 @@ interface ConfigFile {
   editorCommand?: string;
   ideName?: string;
   autoTmux?: boolean;
-  driver?: "subprocess" | "api" | "openai" | "grok" | "gemini" | "none";
+  driver?:
+    | "subprocess"
+    | "api"
+    | "openai"
+    | "grok"
+    | "gemini"
+    | "gemini-api"
+    | "none";
   /** @deprecated Use driver instead. */
-  claudeDriver?: "subprocess" | "api" | "openai" | "grok" | "gemini" | "none";
+  claudeDriver?:
+    | "subprocess"
+    | "api"
+    | "openai"
+    | "grok"
+    | "gemini"
+    | "gemini-api"
+    | "none";
   claudeBinary?: string;
   antBinary?: string;
   automationEnabled?: boolean;
@@ -436,6 +457,7 @@ export function parseConfig(argv: string[]): Config {
     "openai",
     "grok",
     "gemini",
+    "gemini-api",
     "none",
   ] as const;
   const rawFileDriver = (fileConfig as Record<string, unknown>).driver;
@@ -449,8 +471,14 @@ export function parseConfig(argv: string[]): Config {
       `[patchwork-os] Warning: Unknown driver value "${rawFileDriver}" in config file — falling back to "none". Valid values: ${VALID_DRIVER_MODES.join(", ")}.`,
     );
   }
-  let driver: "subprocess" | "api" | "openai" | "grok" | "gemini" | "none" =
-    fileConfig.driver ?? fileConfig.claudeDriver ?? "none";
+  let driver:
+    | "subprocess"
+    | "api"
+    | "openai"
+    | "grok"
+    | "gemini"
+    | "gemini-api"
+    | "none" = fileConfig.driver ?? fileConfig.claudeDriver ?? "none";
   let claudeBinary = fileConfig.claudeBinary ?? "claude";
   let antBinary = fileConfig.antBinary ?? "ant";
   let automationEnabled = fileConfig.automationEnabled ?? false;
@@ -629,10 +657,11 @@ export function parseConfig(argv: string[]): Config {
           driverVal !== "openai" &&
           driverVal !== "grok" &&
           driverVal !== "gemini" &&
+          driverVal !== "gemini-api" &&
           driverVal !== "none"
         ) {
           throw new Error(
-            `Invalid ${flagName} value: "${driverVal}". Must be "subprocess", "api", "openai", "grok", "gemini", or "none".`,
+            `Invalid ${flagName} value: "${driverVal}". Must be "subprocess", "api", "openai", "grok", "gemini", "gemini-api", or "none".`,
           );
         }
         driver = driverVal;
@@ -837,7 +866,7 @@ Patchwork:
   --managed-settings <path> Admin-controlled settings file (highest rule precedence, cannot be overridden by users)
 
 Automation:
-  --driver <mode>           AI driver: "subprocess" | "api" | "openai" | "grok" | "gemini" | "none" (default: "none")
+  --driver <mode>           AI driver: "subprocess" | "api" | "openai" | "grok" | "gemini" | "gemini-api" | "none" (default: "none")
   --claude-driver <mode>    Deprecated alias for --driver
   --claude-binary <path>    Path to claude binary (default: "claude")
   --automation              Enable event-driven automation hooks (requires --claude-driver != none and --automation-policy)

--- a/src/drivers/__tests__/index.test.ts
+++ b/src/drivers/__tests__/index.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { ApiDriver } from "../claude/api.js";
 import { SubprocessDriver } from "../claude/subprocess.js";
+import { GeminiApiDriver } from "../gemini/api.js";
 import { GeminiSubprocessDriver } from "../gemini/index.js";
 import { GrokApiDriver } from "../grok/index.js";
 import { createDriver } from "../index.js";
@@ -12,12 +13,14 @@ beforeEach(() => {
   process.env.OPENAI_API_KEY = "test-openai-key";
   process.env.XAI_API_KEY = "test-xai-key";
   process.env.ANTHROPIC_API_KEY = "test-anthropic-key";
+  process.env.GEMINI_API_KEY = "test-gemini-key";
 });
 
 afterEach(() => {
   delete process.env.OPENAI_API_KEY;
   delete process.env.XAI_API_KEY;
   delete process.env.ANTHROPIC_API_KEY;
+  delete process.env.GEMINI_API_KEY;
 });
 
 const opts = { binary: "claude", antBinary: "ant" };
@@ -67,6 +70,12 @@ describe("createDriver", () => {
     });
     const driver = createDriver("gemini", { ...opts, bridgeMcp }, log);
     expect(driver).toBeInstanceOf(GeminiSubprocessDriver);
+  });
+
+  it("returns GeminiApiDriver for mode=gemini-api", () => {
+    expect(createDriver("gemini-api", opts, log)).toBeInstanceOf(
+      GeminiApiDriver,
+    );
   });
 
   it("throws for unknown driver mode", () => {

--- a/src/drivers/__tests__/openai.test.ts
+++ b/src/drivers/__tests__/openai.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { GeminiApiDriver } from "../gemini/api.js";
 import { GrokApiDriver } from "../grok/index.js";
 import { OpenAIApiDriver } from "../openai/index.js";
 
@@ -14,6 +15,7 @@ const log = vi.fn();
 beforeEach(() => {
   process.env.OPENAI_API_KEY = "test-openai-key";
   process.env.XAI_API_KEY = "test-xai-key";
+  process.env.GEMINI_API_KEY = "test-gemini-key";
   mockCreate.mockReset();
   log.mockReset();
 });
@@ -21,6 +23,7 @@ beforeEach(() => {
 afterEach(() => {
   delete process.env.OPENAI_API_KEY;
   delete process.env.XAI_API_KEY;
+  delete process.env.GEMINI_API_KEY;
 });
 
 function makeStream(chunks: string[]): AsyncIterable<unknown> {
@@ -210,5 +213,51 @@ describe("GrokApiDriver", () => {
   it("throws if XAI_API_KEY missing", () => {
     delete process.env.XAI_API_KEY;
     expect(() => new GrokApiDriver(log)).toThrow(/XAI_API_KEY/);
+  });
+});
+
+describe("GeminiApiDriver", () => {
+  // Same approach as GrokApiDriver: subclass OpenAIApiDriver with Google's
+  // OpenAI-compatible chat-completions endpoint as baseURL. Tests mirror
+  // the Grok suite (default model, name, missing-key throw).
+
+  it("uses gemini-2.5-pro as default model", async () => {
+    mockCreate.mockResolvedValue(makeStream(["ok"]));
+    const driver = new GeminiApiDriver(log);
+    await driver.run({
+      prompt: "hi",
+      workspace: "/tmp",
+      timeoutMs: 5000,
+      signal: AbortSignal.timeout(5000),
+    });
+    expect(mockCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ model: "gemini-2.5-pro" }),
+      expect.anything(),
+    );
+  });
+
+  it("has name gemini-api", () => {
+    expect(new GeminiApiDriver(log).name).toBe("gemini-api");
+  });
+
+  it("throws if GEMINI_API_KEY missing", () => {
+    delete process.env.GEMINI_API_KEY;
+    expect(() => new GeminiApiDriver(log)).toThrow(/GEMINI_API_KEY/);
+  });
+
+  it("respects model override (e.g. gemini-2.5-flash)", async () => {
+    mockCreate.mockResolvedValue(makeStream(["ok"]));
+    const driver = new GeminiApiDriver(log);
+    await driver.run({
+      prompt: "hi",
+      workspace: "/tmp",
+      timeoutMs: 5000,
+      signal: AbortSignal.timeout(5000),
+      model: "gemini-2.5-flash",
+    });
+    expect(mockCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ model: "gemini-2.5-flash" }),
+      expect.anything(),
+    );
   });
 });

--- a/src/drivers/gemini/api.ts
+++ b/src/drivers/gemini/api.ts
@@ -1,0 +1,33 @@
+import { OpenAIApiDriver } from "../openai/index.js";
+
+/**
+ * Gemini API driver — Google exposes an OpenAI-compatible chat-completions
+ * endpoint at https://generativelanguage.googleapis.com/v1beta/openai/, so
+ * the existing OpenAIApiDriver streaming + tool-handling can be reused with
+ * just a different baseURL + default model + key source. Same trick as Grok.
+ *
+ * Auth: GEMINI_API_KEY environment variable (the bridge auto-injects the
+ * dashboard-saved `apiKeys.google` value into GEMINI_API_KEY at startup —
+ * see config.ts:487).
+ *
+ * Install: npm install openai  (reuses OpenAI SDK with custom baseURL)
+ */
+export class GeminiApiDriver extends OpenAIApiDriver {
+  override readonly name = "gemini-api";
+
+  constructor(log: (msg: string) => void) {
+    if (!process.env.GEMINI_API_KEY) {
+      throw new Error(
+        "GeminiApiDriver requires GEMINI_API_KEY environment variable",
+      );
+    }
+    super(log, {
+      baseURL: "https://generativelanguage.googleapis.com/v1beta/openai/",
+      defaultModel: "gemini-2.5-pro",
+    });
+  }
+
+  protected override apiKey(): string | undefined {
+    return process.env.GEMINI_API_KEY;
+  }
+}

--- a/src/drivers/index.ts
+++ b/src/drivers/index.ts
@@ -1,5 +1,6 @@
 import { ApiDriver } from "./claude/api.js";
 import { SubprocessDriver } from "./claude/subprocess.js";
+import { GeminiApiDriver } from "./gemini/api.js";
 import { GeminiSubprocessDriver } from "./gemini/index.js";
 import { GrokApiDriver } from "./grok/index.js";
 import { OpenAIApiDriver } from "./openai/index.js";
@@ -11,6 +12,7 @@ export type DriverMode =
   | "openai"
   | "grok"
   | "gemini"
+  | "gemini-api"
   | "none";
 
 export interface DriverFactoryOpts {
@@ -46,11 +48,13 @@ export function createDriver(
       log,
       opts.bridgeMcp,
     );
+  if (mode === "gemini-api") return new GeminiApiDriver(log);
   throw new Error(`Unknown driver mode: ${mode}`);
 }
 
 export { ApiDriver } from "./claude/api.js";
 export { SubprocessDriver } from "./claude/subprocess.js";
+export { GeminiApiDriver } from "./gemini/api.js";
 export { GeminiSubprocessDriver } from "./gemini/index.js";
 export { GrokApiDriver } from "./grok/index.js";
 export { OpenAIApiDriver } from "./openai/index.js";

--- a/src/patchworkConfig.ts
+++ b/src/patchworkConfig.ts
@@ -41,7 +41,14 @@ export interface PatchworkConfig {
     disabled?: string[];
   };
   /** AI driver mode — persisted so dashboard changes survive restart. */
-  driver?: "subprocess" | "api" | "openai" | "grok" | "gemini" | "none";
+  driver?:
+    | "subprocess"
+    | "api"
+    | "openai"
+    | "grok"
+    | "gemini"
+    | "gemini-api"
+    | "none";
   /** Notification channel config */
   notifications?: {
     slackChannel?: string;

--- a/src/server.ts
+++ b/src/server.ts
@@ -1333,6 +1333,7 @@ export class Server extends EventEmitter<ServerEvents> {
                 "openai",
                 "grok",
                 "gemini",
+                "gemini-api",
                 "none",
               ];
               if (!validDrivers.includes(driverRaw)) {


### PR DESCRIPTION
Closes #361.

## Summary

Google exposes an OpenAI-compatible chat-completions endpoint at \`https://generativelanguage.googleapis.com/v1beta/openai/\`, so \`GeminiApiDriver\` can subclass [OpenAIApiDriver](src/drivers/openai/index.ts) with a different baseURL + default model + key source — same shape as \`GrokApiDriver\`. **~30-line driver file, no new SDK dependency.**

The triage agent that filed this issue assumed Gemini needed \`@google/generative-ai\` and a from-scratch implementation. Google's OpenAI-compat path makes the actual scope much smaller.

## What this wires

- [src/drivers/gemini/api.ts](src/drivers/gemini/api.ts) — new file
- [src/drivers/index.ts](src/drivers/index.ts) — \`DriverMode\` union + \`createDriver\` branch + export
- [src/server.ts](src/server.ts) — POST \`/settings\` allowlist
- [src/patchworkConfig.ts](src/patchworkConfig.ts) — \`PatchworkConfig["driver"]\` union
- [src/config.ts](src/config.ts) — \`VALID_DRIVER_MODES\`, two driver-typed fields, \`--driver\` CLI flag validation, \`--help\` text

**Auth:** \`GEMINI_API_KEY\` environment variable. The bridge already auto-injects the dashboard-saved \`apiKeys.google\` value into \`GEMINI_API_KEY\` at startup ([src/config.ts:487](src/config.ts#L487)), so once a Google key is saved via #357's UI it flows straight through. No new wiring needed.

**Default model:** \`gemini-2.5-pro\`. Override with \`input.model\`.

## Tests

- 4 new tests in \`src/drivers/__tests__/openai.test.ts\` mirror the existing \`GrokApiDriver\` suite (default model, name, missing-key throw, model override). 18/18 pass.
- 1 new test in \`src/drivers/__tests__/index.test.ts\` for \`createDriver(\"gemini-api\")\`. 10/10 pass.
- All 40 driver tests pass.
- Existing 11 server-settings tests unchanged and still pass.
- TypeScript clean across all union/literal-type touchpoints.

## Out of scope (follow-up)

**Dashboard "Gemini API" row** (the Gemini half of #360). Would conflict with #365 (re-landing of stranded stacked PRs). Trivial single-row follow-up after #365 lands: one \`DRIVER_ROWS\` entry mirroring "Claude API".

## Test plan
- [x] \`npm run typecheck\` clean
- [x] \`vitest run src/drivers/__tests__/\` — 40/40 pass
- [x] \`vitest run src/__tests__/server-settings.test.ts\` — 11/11 pass (unchanged)
- [ ] Reviewer: with a real \`GEMINI_API_KEY\` set, restart the bridge with \`--driver gemini-api\` and verify a recipe call routes to Gemini

🤖 Generated with [Claude Code](https://claude.com/claude-code)