### PR TITLE
feat(drivers): re-enable local LLMs (Ollama / LM Studio / vLLM / llama.cpp)

### DIFF
--- a/dashboard/src/app/settings/page.tsx
+++ b/dashboard/src/app/settings/page.tsx
@@ -57,19 +57,20 @@ interface DriverRow {
 }
 
 // Names omit model versions on purpose — versions go stale fast and the
-// authoritative model id is already shown on /overview hero. Ollama hidden
-// until `local` is wired into the bridge driver allowlist (see follow-up).
+// authoritative model id is already shown on /overview hero.
 //
 // "Claude" and "Claude API" are two real driver values (`subprocess` vs
 // `api`) that hit Anthropic two different ways: Claude CLI subscription
-// vs API key. Same row pattern as OpenAI/Grok for the API path. Gemini
-// will get a sibling "Gemini API" row once GeminiApiDriver lands (#361).
+// vs API key. Same row pattern for OpenAI/Grok/Gemini API. Local LLM row
+// drives a separate endpoint+model card (no key — local servers don't
+// validate one).
 const DRIVER_ROWS: DriverRow[] = [
   { id: "claude", name: "Claude", detail: "Anthropic · Claude Code subscription (subprocess)", driverValue: "subprocess", keyProvider: "anthropic" },
   { id: "claude-api", name: "Claude API", detail: "Anthropic · API key (no subscription required)", driverValue: "api", keyProvider: "anthropic" },
   { id: "gemini", name: "Gemini", detail: "Google · CLI subscription (subprocess)", driverValue: "gemini", keyProvider: "google" },
   { id: "openai", name: "OpenAI", detail: "API key required", driverValue: "openai", keyProvider: "openai" },
   { id: "grok", name: "Grok", detail: "xAI · API key required", driverValue: "grok", keyProvider: "xai" },
+  { id: "local", name: "Local LLM", detail: "Ollama · LM Studio · vLLM · llama.cpp (OpenAI-compatible)", driverValue: "local" },
 ];
 
 // Default model id each driver runs when input.model is not set.
@@ -77,12 +78,14 @@ const DRIVER_ROWS: DriverRow[] = [
 //   claude / claude-api → src/claudeDriver.ts:616, src/drivers/claude/api.ts:52
 //   openai              → src/drivers/openai/index.ts:79 (literal fallback)
 //   grok                → src/drivers/grok/index.ts:19 (defaultModel)
+//   local               → src/drivers/local/index.ts:36 (env LOCAL_MODEL or fallback)
 //   gemini              → no override; whatever the user's `gemini` CLI defaults to
 const DRIVER_DEFAULT_MODEL: Record<string, string | null> = {
   claude: "claude-haiku-4-5-20251001",
   "claude-api": "claude-haiku-4-5-20251001",
   openai: "gpt-4o",
   grok: "grok-2-latest",
+  local: null, // Reads from /status — see localEndpoint/localModel below
   gemini: null, // CLI default — not knowable without running it
 };
 
@@ -149,6 +152,16 @@ export default function SettingsPage() {
   const [keySaving, setKeySaving] = useState<ApiKeyProvider | null>(null);
   const [keyMsg, setKeyMsg] = useState<{ provider: ApiKeyProvider; ok: boolean; text: string } | null>(null);
 
+  // Local LLM endpoint + model. Drafted in the form; pushed via POST
+  // {model:"local", localEndpoint, localModel} which writes to ~/.patchwork
+  // and (on bridge restart) seeds LOCAL_ENDPOINT/LOCAL_MODEL env vars that
+  // LocalApiDriver reads.
+  const [localEndpoint, setLocalEndpoint] = useState("");
+  const [localModel, setLocalModel] = useState("");
+  const [localSaving, setLocalSaving] = useState(false);
+  const [localMsg, setLocalMsg] = useState<{ ok: boolean; text: string } | null>(null);
+  const localInitialized = useRef(false);
+
   // Approval policy
   const [gateValue, setGateValue] = useState<"off" | "high" | "all">("off");
   const [gatePending, setGatePending] = useState<"off" | "high" | "all">("off");
@@ -206,6 +219,11 @@ export default function SettingsPage() {
         if (!todayAnomalyInitialized.current) {
           setTodayAnomaly(Boolean(data.patchwork?.enableTimeOfDayAnomaly));
           todayAnomalyInitialized.current = true;
+        }
+        if (!localInitialized.current) {
+          setLocalEndpoint(data.patchwork?.localEndpoint ?? "");
+          setLocalModel(data.patchwork?.localModel ?? "");
+          localInitialized.current = true;
         }
         if (!driverInitialized.current) {
           const d = data.patchwork?.driver ?? "subprocess";
@@ -296,6 +314,46 @@ export default function SettingsPage() {
       setKeyMsg({ provider, ok: false, text: e instanceof Error ? e.message : String(e) });
     } finally {
       setKeySaving(null);
+    }
+  }
+
+  async function saveLocalConfig() {
+    if (!localEndpoint.trim()) {
+      setLocalMsg({ ok: false, text: "Endpoint URL is required." });
+      return;
+    }
+    setLocalSaving(true);
+    setLocalMsg(null);
+    try {
+      // model:"local" is required by the bridge handler to accept localEndpoint
+      // and localModel writes ([src/server.ts:1371-1376] gates them on this).
+      const res = await fetch(apiPath("/api/bridge/settings"), {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          model: "local",
+          localEndpoint: localEndpoint.trim(),
+          localModel: localModel.trim(),
+        }),
+      });
+      const body = (await res.json().catch(() => ({}))) as {
+        ok?: boolean;
+        restartRequired?: boolean;
+        error?: string;
+      };
+      if (res.ok) {
+        const text = body.restartRequired
+          ? "Saved. Restart Claude Code (quit and re-open, then /ide) to activate."
+          : "Saved.";
+        setLocalMsg({ ok: true, text });
+        flashSaved();
+      } else {
+        setLocalMsg({ ok: false, text: body.error ?? `Error ${res.status}` });
+      }
+    } catch (e) {
+      setLocalMsg({ ok: false, text: e instanceof Error ? e.message : String(e) });
+    } finally {
+      setLocalSaving(false);
     }
   }
 
@@ -686,6 +744,54 @@ export default function SettingsPage() {
                               {keyMsg.text}
                             </span>
                           )}
+                        </div>
+                      )}
+                      {row.id === "local" && (
+                        <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+                          <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
+                            <input
+                              id="local-endpoint"
+                              type="text"
+                              placeholder="http://localhost:11434/v1 (Ollama default)"
+                              value={localEndpoint}
+                              onChange={(e) => setLocalEndpoint(e.target.value)}
+                              style={{ ...inputStyle, flex: 1, minWidth: 280 }}
+                              aria-label="Local LLM endpoint URL"
+                            />
+                          </div>
+                          <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
+                            <input
+                              id="local-model"
+                              type="text"
+                              placeholder="llama3.2 (or any model your runtime serves)"
+                              value={localModel}
+                              onChange={(e) => setLocalModel(e.target.value)}
+                              style={{ ...inputStyle, flex: 1, minWidth: 280 }}
+                              aria-label="Local LLM default model"
+                            />
+                            <button
+                              type="button"
+                              onClick={saveLocalConfig}
+                              disabled={localSaving || !localEndpoint.trim()}
+                              style={{
+                                background: "transparent",
+                                color: "var(--fg-1)",
+                                border: "1px solid var(--border-default)",
+                                borderRadius: "var(--r-2)",
+                                padding: "5px 10px",
+                                fontSize: "var(--fs-s)",
+                                cursor: !localEndpoint.trim() ? "default" : "pointer",
+                                opacity: !localEndpoint.trim() ? 0.5 : 1,
+                              }}
+                            >
+                              {localSaving ? "Saving…" : "Save"}
+                            </button>
+                            {localMsg && (
+                              <span style={{ fontSize: "var(--fs-s)", color: localMsg.ok ? "var(--ok)" : "var(--err)" }}>
+                                {localMsg.text}
+                              </span>
+                            )}
+                          </div>
                         </div>
                       )}
                     </div>

--- a/dashboard/src/app/settings/page.tsx
+++ b/dashboard/src/app/settings/page.tsx
@@ -64,10 +64,14 @@ interface DriverRow {
 // vs API key. Same row pattern for OpenAI/Grok/Gemini API. Local LLM row
 // drives a separate endpoint+model card (no key — local servers don't
 // validate one).
+//
+// Subprocess rows (Claude, Gemini) authenticate via the CLI's own login
+// (Claude Code subscription / Gemini CLI gcloud auth) — they don't read
+// an API key from env, so no keyProvider on those rows.
 const DRIVER_ROWS: DriverRow[] = [
-  { id: "claude", name: "Claude", detail: "Anthropic · Claude Code subscription (subprocess)", driverValue: "subprocess", keyProvider: "anthropic" },
+  { id: "claude", name: "Claude", detail: "Anthropic · Claude Code subscription (subprocess)", driverValue: "subprocess" },
   { id: "claude-api", name: "Claude API", detail: "Anthropic · API key (no subscription required)", driverValue: "api", keyProvider: "anthropic" },
-  { id: "gemini", name: "Gemini", detail: "Google · CLI subscription (subprocess)", driverValue: "gemini", keyProvider: "google" },
+  { id: "gemini", name: "Gemini", detail: "Google · CLI subscription (subprocess)", driverValue: "gemini" },
   { id: "openai", name: "OpenAI", detail: "API key required", driverValue: "openai", keyProvider: "openai" },
   { id: "grok", name: "Grok", detail: "xAI · API key required", driverValue: "grok", keyProvider: "xai" },
   { id: "local", name: "Local LLM", detail: "Ollama · LM Studio · vLLM · llama.cpp (OpenAI-compatible)", driverValue: "local" },

--- a/src/config.ts
+++ b/src/config.ts
@@ -32,6 +32,7 @@ export interface Config {
     | "grok"
     | "gemini"
     | "gemini-api"
+    | "local"
     | "none";
   claudeBinary: string;
   antBinary: string;
@@ -209,6 +210,7 @@ interface ConfigFile {
     | "grok"
     | "gemini"
     | "gemini-api"
+    | "local"
     | "none";
   /** @deprecated Use driver instead. */
   claudeDriver?:
@@ -218,6 +220,7 @@ interface ConfigFile {
     | "grok"
     | "gemini"
     | "gemini-api"
+    | "local"
     | "none";
   claudeBinary?: string;
   antBinary?: string;
@@ -458,6 +461,7 @@ export function parseConfig(argv: string[]): Config {
     "grok",
     "gemini",
     "gemini-api",
+    "local",
     "none",
   ] as const;
   const rawFileDriver = (fileConfig as Record<string, unknown>).driver;
@@ -478,6 +482,7 @@ export function parseConfig(argv: string[]): Config {
     | "grok"
     | "gemini"
     | "gemini-api"
+    | "local"
     | "none" = fileConfig.driver ?? fileConfig.claudeDriver ?? "none";
   let claudeBinary = fileConfig.claudeBinary ?? "claude";
   let antBinary = fileConfig.antBinary ?? "ant";
@@ -506,6 +511,13 @@ export function parseConfig(argv: string[]): Config {
       if (pw.driver && driver === "none") {
         driver = pw.driver;
       }
+      // Seed local-LLM endpoint + model as env vars (non-destructive). The
+      // LocalApiDriver reads these at construction time, so a dashboard save
+      // round-trips through patchwork config → env → driver on next restart.
+      if (pw.localEndpoint && !process.env.LOCAL_ENDPOINT)
+        process.env.LOCAL_ENDPOINT = pw.localEndpoint;
+      if (pw.localModel && !process.env.LOCAL_MODEL)
+        process.env.LOCAL_MODEL = pw.localModel;
       // Seed API keys as env vars if not already set (non-destructive)
       if (pw.apiKeys) {
         if (pw.apiKeys.openai && !process.env.OPENAI_API_KEY)
@@ -658,10 +670,11 @@ export function parseConfig(argv: string[]): Config {
           driverVal !== "grok" &&
           driverVal !== "gemini" &&
           driverVal !== "gemini-api" &&
+          driverVal !== "local" &&
           driverVal !== "none"
         ) {
           throw new Error(
-            `Invalid ${flagName} value: "${driverVal}". Must be "subprocess", "api", "openai", "grok", "gemini", "gemini-api", or "none".`,
+            `Invalid ${flagName} value: "${driverVal}". Must be "subprocess", "api", "openai", "grok", "gemini", "gemini-api", "local", or "none".`,
           );
         }
         driver = driverVal;
@@ -866,7 +879,7 @@ Patchwork:
   --managed-settings <path> Admin-controlled settings file (highest rule precedence, cannot be overridden by users)
 
 Automation:
-  --driver <mode>           AI driver: "subprocess" | "api" | "openai" | "grok" | "gemini" | "gemini-api" | "none" (default: "none")
+  --driver <mode>           AI driver: "subprocess" | "api" | "openai" | "grok" | "gemini" | "gemini-api" | "local" | "none" (default: "none")
   --claude-driver <mode>    Deprecated alias for --driver
   --claude-binary <path>    Path to claude binary (default: "claude")
   --automation              Enable event-driven automation hooks (requires --claude-driver != none and --automation-policy)

--- a/src/drivers/__tests__/index.test.ts
+++ b/src/drivers/__tests__/index.test.ts
@@ -5,6 +5,7 @@ import { GeminiApiDriver } from "../gemini/api.js";
 import { GeminiSubprocessDriver } from "../gemini/index.js";
 import { GrokApiDriver } from "../grok/index.js";
 import { createDriver } from "../index.js";
+import { LocalApiDriver } from "../local/index.js";
 import { OpenAIApiDriver } from "../openai/index.js";
 
 const log = () => {};
@@ -14,6 +15,7 @@ beforeEach(() => {
   process.env.XAI_API_KEY = "test-xai-key";
   process.env.ANTHROPIC_API_KEY = "test-anthropic-key";
   process.env.GEMINI_API_KEY = "test-gemini-key";
+  process.env.LOCAL_ENDPOINT = "http://localhost:11434/v1";
 });
 
 afterEach(() => {
@@ -21,6 +23,7 @@ afterEach(() => {
   delete process.env.XAI_API_KEY;
   delete process.env.ANTHROPIC_API_KEY;
   delete process.env.GEMINI_API_KEY;
+  delete process.env.LOCAL_ENDPOINT;
 });
 
 const opts = { binary: "claude", antBinary: "ant" };
@@ -76,6 +79,10 @@ describe("createDriver", () => {
     expect(createDriver("gemini-api", opts, log)).toBeInstanceOf(
       GeminiApiDriver,
     );
+  });
+
+  it("returns LocalApiDriver for mode=local", () => {
+    expect(createDriver("local", opts, log)).toBeInstanceOf(LocalApiDriver);
   });
 
   it("throws for unknown driver mode", () => {

--- a/src/drivers/__tests__/openai.test.ts
+++ b/src/drivers/__tests__/openai.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { GeminiApiDriver } from "../gemini/api.js";
 import { GrokApiDriver } from "../grok/index.js";
+import { LocalApiDriver } from "../local/index.js";
 import { OpenAIApiDriver } from "../openai/index.js";
 
 const mockCreate = vi.fn();
@@ -16,6 +17,8 @@ beforeEach(() => {
   process.env.OPENAI_API_KEY = "test-openai-key";
   process.env.XAI_API_KEY = "test-xai-key";
   process.env.GEMINI_API_KEY = "test-gemini-key";
+  process.env.LOCAL_ENDPOINT = "http://localhost:11434/v1";
+  process.env.LOCAL_MODEL = "llama3.2";
   mockCreate.mockReset();
   log.mockReset();
 });
@@ -24,6 +27,9 @@ afterEach(() => {
   delete process.env.OPENAI_API_KEY;
   delete process.env.XAI_API_KEY;
   delete process.env.GEMINI_API_KEY;
+  delete process.env.LOCAL_ENDPOINT;
+  delete process.env.LOCAL_MODEL;
+  delete process.env.LOCAL_API_KEY;
 });
 
 function makeStream(chunks: string[]): AsyncIterable<unknown> {
@@ -259,5 +265,69 @@ describe("GeminiApiDriver", () => {
       expect.objectContaining({ model: "gemini-2.5-flash" }),
       expect.anything(),
     );
+  });
+});
+
+describe("LocalApiDriver", () => {
+  // Subclasses OpenAIApiDriver with the configured LOCAL_ENDPOINT and
+  // LOCAL_MODEL env vars. The bridge auto-injects these from
+  // patchworkConfig.localEndpoint / localModel at startup
+  // (src/config.ts), so a dashboard save → next-restart round-trip works
+  // without any explicit driver wiring.
+
+  it("uses LOCAL_MODEL env value as default model", async () => {
+    mockCreate.mockResolvedValue(makeStream(["ok"]));
+    const driver = new LocalApiDriver(log);
+    await driver.run({
+      prompt: "hi",
+      workspace: "/tmp",
+      timeoutMs: 5000,
+      signal: AbortSignal.timeout(5000),
+    });
+    expect(mockCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ model: "llama3.2" }),
+      expect.anything(),
+    );
+  });
+
+  it("falls back to llama3.2 when LOCAL_MODEL is unset", async () => {
+    delete process.env.LOCAL_MODEL;
+    mockCreate.mockResolvedValue(makeStream(["ok"]));
+    const driver = new LocalApiDriver(log);
+    await driver.run({
+      prompt: "hi",
+      workspace: "/tmp",
+      timeoutMs: 5000,
+      signal: AbortSignal.timeout(5000),
+    });
+    expect(mockCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ model: "llama3.2" }),
+      expect.anything(),
+    );
+  });
+
+  it("respects model override (e.g. qwen3-coder:30b)", async () => {
+    mockCreate.mockResolvedValue(makeStream(["ok"]));
+    const driver = new LocalApiDriver(log);
+    await driver.run({
+      prompt: "hi",
+      workspace: "/tmp",
+      timeoutMs: 5000,
+      signal: AbortSignal.timeout(5000),
+      model: "qwen3-coder:30b",
+    });
+    expect(mockCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ model: "qwen3-coder:30b" }),
+      expect.anything(),
+    );
+  });
+
+  it("has name local", () => {
+    expect(new LocalApiDriver(log).name).toBe("local");
+  });
+
+  it("throws if LOCAL_ENDPOINT missing", () => {
+    delete process.env.LOCAL_ENDPOINT;
+    expect(() => new LocalApiDriver(log)).toThrow(/LOCAL_ENDPOINT/);
   });
 });

--- a/src/drivers/index.ts
+++ b/src/drivers/index.ts
@@ -3,6 +3,7 @@ import { SubprocessDriver } from "./claude/subprocess.js";
 import { GeminiApiDriver } from "./gemini/api.js";
 import { GeminiSubprocessDriver } from "./gemini/index.js";
 import { GrokApiDriver } from "./grok/index.js";
+import { LocalApiDriver } from "./local/index.js";
 import { OpenAIApiDriver } from "./openai/index.js";
 import type { ProviderDriver } from "./types.js";
 
@@ -13,6 +14,7 @@ export type DriverMode =
   | "grok"
   | "gemini"
   | "gemini-api"
+  | "local"
   | "none";
 
 export interface DriverFactoryOpts {
@@ -49,6 +51,7 @@ export function createDriver(
       opts.bridgeMcp,
     );
   if (mode === "gemini-api") return new GeminiApiDriver(log);
+  if (mode === "local") return new LocalApiDriver(log);
   throw new Error(`Unknown driver mode: ${mode}`);
 }
 
@@ -57,6 +60,7 @@ export { SubprocessDriver } from "./claude/subprocess.js";
 export { GeminiApiDriver } from "./gemini/api.js";
 export { GeminiSubprocessDriver } from "./gemini/index.js";
 export { GrokApiDriver } from "./grok/index.js";
+export { LocalApiDriver } from "./local/index.js";
 export { OpenAIApiDriver } from "./openai/index.js";
 export type {
   ProviderDriver,

--- a/src/drivers/local/index.ts
+++ b/src/drivers/local/index.ts
@@ -1,0 +1,45 @@
+import { OpenAIApiDriver } from "../openai/index.js";
+
+/**
+ * Local LLM driver — Ollama, LM Studio, vLLM, llama.cpp server, and most
+ * other self-hosted runtimes expose an OpenAI-compatible chat-completions
+ * endpoint at /v1/chat/completions. Same trick as Grok / Gemini API:
+ * subclass OpenAIApiDriver with a different baseURL + default model.
+ *
+ * Auth: most local runtimes don't validate the API key, but the OpenAI SDK
+ * requires *something* in the apiKey field — we send a constant placeholder.
+ *
+ * Configuration: LOCAL_ENDPOINT and LOCAL_MODEL environment variables.
+ * The bridge auto-injects `patchwork.localEndpoint` / `patchwork.localModel`
+ * into these env vars at startup (see config.ts), so saving via the
+ * dashboard's Local LLM card flows straight through to the driver.
+ *
+ * Examples:
+ *   Ollama     → http://localhost:11434/v1
+ *   LM Studio  → http://localhost:1234/v1
+ *   vLLM       → http://localhost:8000/v1
+ *   llama.cpp  → http://localhost:8080/v1
+ */
+export class LocalApiDriver extends OpenAIApiDriver {
+  override readonly name = "local";
+
+  constructor(log: (msg: string) => void) {
+    const baseURL = process.env.LOCAL_ENDPOINT;
+    if (!baseURL) {
+      throw new Error(
+        "LocalApiDriver requires LOCAL_ENDPOINT environment variable (e.g. http://localhost:11434/v1)",
+      );
+    }
+    super(log, {
+      baseURL,
+      // Per-install default — caller can still override via input.model.
+      defaultModel: process.env.LOCAL_MODEL ?? "llama3.2",
+    });
+  }
+
+  protected override apiKey(): string | undefined {
+    // Most local runtimes ignore the key but the OpenAI SDK requires a
+    // non-empty value. "ollama" is the conventional placeholder.
+    return process.env.LOCAL_API_KEY ?? "ollama";
+  }
+}

--- a/src/patchworkConfig.ts
+++ b/src/patchworkConfig.ts
@@ -48,6 +48,7 @@ export interface PatchworkConfig {
     | "grok"
     | "gemini"
     | "gemini-api"
+    | "local"
     | "none";
   /** Notification channel config */
   notifications?: {

--- a/src/server.ts
+++ b/src/server.ts
@@ -1334,6 +1334,7 @@ export class Server extends EventEmitter<ServerEvents> {
                 "grok",
                 "gemini",
                 "gemini-api",
+                "local",
                 "none",
               ];
               if (!validDrivers.includes(driverRaw)) {


### PR DESCRIPTION
Closes #359.

## Summary

Same OpenAI-compat trick as Grok and the recently-merged Gemini API driver: most local LLM runtimes expose \`/v1/chat/completions\` and ignore the API key, so a 30-line driver covers Ollama, LM Studio, vLLM, llama.cpp server, and anything else OpenAI-compat.

## Compatible runtimes

| Runtime | Endpoint to enter | Model field |
|---|---|---|
| Ollama | \`http://localhost:11434/v1\` | name from \`ollama list\` (e.g. \`mistral-large\`, \`qwen3-coder:30b\`, \`llama3.2\`) |
| LM Studio | \`http://localhost:1234/v1\` | name LM Studio shows for the loaded model |
| vLLM | \`http://localhost:8000/v1\` | HF id you started vLLM with |
| llama.cpp server | \`http://localhost:8080/v1\` | whatever you started it with |

Confirmed-supported model families that the user listed: Mistral Large 3, GLM-4.5-Air, Qwen3-Coder-30B, Qwen3-7B/14B, LFM2 family, Llama 3.x, Gemma 2 9B — all just text strings the runtime serves.

## What this wires

**Backend ([src/drivers/local/index.ts](src/drivers/local/index.ts)** — new file):
- Subclasses [OpenAIApiDriver](src/drivers/openai/index.ts).
- Reads \`LOCAL_ENDPOINT\` (required) and \`LOCAL_MODEL\` (optional, defaults to \`llama3.2\`) from env.
- Returns \`"ollama"\` placeholder for the apiKey field — the OpenAI SDK requires *something* in that field, and local servers ignore it. \`LOCAL_API_KEY\` env var lets you override if your runtime actually validates.

**Driver chain plumbing:**
- [src/drivers/index.ts](src/drivers/index.ts) — \`DriverMode\` union, \`createDriver\` branch, export.
- [src/server.ts](src/server.ts) — POST \`/settings\` allowlist gets \`local\`.
- [src/patchworkConfig.ts](src/patchworkConfig.ts) — \`PatchworkConfig["driver"]\` union.
- [src/config.ts](src/config.ts) — \`VALID_DRIVER_MODES\`, \`BridgeConfig.driver\`, \`FileConfig.driver\` + \`claudeDriver\` alias, \`--driver\` CLI flag, \`--help\` text.

**Dashboard config-→-env round-trip:**
[src/config.ts:514-519](src/config.ts#L514-L519) — extended the patchwork-config seed at startup to push \`patchwork.localEndpoint\` into \`LOCAL_ENDPOINT\` and \`patchwork.localModel\` into \`LOCAL_MODEL\`, mirroring the existing \`apiKeys.google → GEMINI_API_KEY\` pattern. Dashboard saves → next restart picks up.

**Dashboard ([dashboard/src/app/settings/page.tsx](dashboard/src/app/settings/page.tsx)):**
- New "Local LLM" row in \`DRIVER_ROWS\` (no \`keyProvider\` — local servers don't validate keys).
- Endpoint URL + default model inputs render underneath, populated from \`/status.patchwork.localEndpoint\` and \`localModel\`.
- "Save" button POSTs \`{model:"local", localEndpoint, localModel}\` which the bridge persists.

## Tests

- 5 new tests in \`src/drivers/__tests__/openai.test.ts\` mirror the Grok / Gemini-API suites: default model from \`LOCAL_MODEL\` env, fallback when unset, model override, name=\`"local"\`, missing-\`LOCAL_ENDPOINT\` throw. **23/23 pass in this file** (was 18).
- 1 new test in \`src/drivers/__tests__/index.test.ts\`: \`createDriver("local")\` returns \`LocalApiDriver\`. **11/11 pass.**
- All 46 driver tests pass (was 40).
- Typecheck (full + dashboard) clean.

## Known limitations (same as Grok / Gemini API)
- Single-turn streaming only — no agentic tool-use loop yet. Recipes that depend on tool calls against a local model would need a separate driver path.
- Text only — no multimodal pass-through.

## Test plan
- [x] \`npm run typecheck\` (full + dashboard) clean
- [x] \`vitest run src/drivers/__tests__/\` — 46/46 pass
- [x] Live dogfood on /dashboard/settings: 6 rows render with Local LLM at the bottom; endpoint + model inputs populate from \`/status\` and Save button responds
- [ ] Reviewer: with a real Ollama instance running, save endpoint+model, restart bridge, run a recipe through driver=local and verify it routes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)