### PR TITLE
fix(security): sink-side binary allowlist in execSafe + bump @tootallnate/once

### DIFF
--- a/services/push-relay/package-lock.json
+++ b/services/push-relay/package-lock.json
@@ -692,7 +692,9 @@
       "license": "MIT"
     },
     "node_modules/@tootallnate/once": {
-      "version": "2.0.0",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-3.0.1.tgz",
+      "integrity": "sha512-VyMVKRrpHTT8PnotUeV8L/mDaMwD5DaAKCFLP73zAqAtvF0FCqky+Ki7BYbFCYQmqFyTe9316Ed5zS70QUR9eg==",
       "license": "MIT",
       "optional": true,
       "engines": {

--- a/services/push-relay/package.json
+++ b/services/push-relay/package.json
@@ -24,5 +24,8 @@
     "tsx": "^4.7.0",
     "typescript": "^5.3.3",
     "vitest": "^4.1.5"
+  },
+  "overrides": {
+    "@tootallnate/once": "^3.0.1"
   }
 }

--- a/src/tools/__tests__/utils-security.test.ts
+++ b/src/tools/__tests__/utils-security.test.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
-import { error, findLineNumber, success } from "../utils.js";
+import { error, execSafe, findLineNumber, success } from "../utils.js";
 
 describe("success() and error() format", () => {
   it("success returns compact JSON (no pretty-printing)", () => {
@@ -88,5 +88,56 @@ describe("findLineNumber (async)", () => {
     expect(
       await findLineNumber("/tmp/nonexistent-file-12345.txt", "text"),
     ).toBeNull();
+  });
+});
+
+describe("execSafe — sink-side binary allowlist (CodeQL #14)", () => {
+  // Closes CodeQL js/shell-command-injection-from-environment by attaching
+  // the safe-binary check to the sink itself. Callers gating on their own
+  // allowlist (runCommand, terminal fallback) opt out via allowlistChecked.
+
+  it("rejects an unknown binary by basename", async () => {
+    await expect(execSafe("rm", ["-rf", "/tmp/x"])).rejects.toThrow(
+      /not in the safe-binary set/,
+    );
+  });
+
+  it("rejects an absolute-path unknown binary by basename", async () => {
+    await expect(execSafe("/usr/bin/curl", ["https://evil"])).rejects.toThrow(
+      /not in the safe-binary set/,
+    );
+  });
+
+  it("error message names the rejected command for clear diagnostics", async () => {
+    await expect(execSafe("nope-binary-xyz", [])).rejects.toThrow(
+      /"nope-binary-xyz"/,
+    );
+  });
+
+  it("accepts an allowlisted basename (git --version)", async () => {
+    const result = await execSafe("git", ["--version"], { timeout: 5000 });
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toMatch(/^git version /);
+  });
+
+  it("accepts an absolute path whose basename is allowlisted", async () => {
+    // `path.basename("/usr/bin/git") === "git"` — allowlist gate accepts.
+    // The actual spawn may ENOENT on this host but that's a non-throw error
+    // captured in the result; the assertion is that the gate didn't throw.
+    const result = await execSafe("/usr/bin/git", ["--version"], {
+      timeout: 5000,
+    });
+    expect(typeof result.exitCode).toBe("number");
+  });
+
+  it("bypasses the allowlist when allowlistChecked:true is passed", async () => {
+    // `echo` is not in SAFE_BIN_BASENAMES; allowlistChecked lets it through.
+    // This is the path used by runCommand / terminal after their own gate.
+    const result = await execSafe("echo", ["hello"], {
+      timeout: 5000,
+      allowlistChecked: true,
+    });
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.trim()).toBe("hello");
   });
 });

--- a/src/tools/runCommand.ts
+++ b/src/tools/runCommand.ts
@@ -91,6 +91,10 @@ export function createRunCommandTool(workspace: string, config: Config) {
             timeout,
             maxBuffer: maxBytes,
             signal,
+            // Already validated against config.commandAllowlist via
+            // buildCommandDescription above — skip execSafe's intrinsic
+            // SAFE_BIN_BASENAMES gate so user-allowlisted binaries work.
+            allowlistChecked: true,
             onLine: (line) => {
               lineCount++;
               progress(lineCount, undefined, line);
@@ -103,6 +107,7 @@ export function createRunCommandTool(workspace: string, config: Config) {
                 timeout,
                 maxBuffer: maxBytes,
                 signal,
+                allowlistChecked: true,
               }),
             progress,
             { message: `running ${command}…`, intervalMs: 5_000 },

--- a/src/tools/terminal.ts
+++ b/src/tools/terminal.ts
@@ -624,6 +624,10 @@ export function createRunInTerminalTool(
         cwd: workspace,
         timeout: timeoutMs,
         signal: signal ?? undefined,
+        // Already passed validateCommand at the top of this handler — skip
+        // execSafe's intrinsic SAFE_BIN_BASENAMES gate so user-allowlisted
+        // binaries work in the headless fallback path.
+        allowlistChecked: true,
       });
 
       return successStructured({ ...fallbackResult, fallback: "subprocess" });

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -367,6 +367,65 @@ export interface ExecSafeResult {
   durationMs: number;
 }
 
+/**
+ * Sink-side allowlist for execSafe / execSafeStreaming. The bridge resolves
+ * `cmd` against $PATH, so a shared environment can in principle substitute a
+ * binary; checking the basename here gates that surface to a vetted set even
+ * if a caller passes user-derived input by mistake. Callers that route
+ * through their own allowlist (runCommand, terminal fallback) opt in via
+ * `opts.allowlistChecked: true` and bypass this check.
+ *
+ * Closes CodeQL js/shell-command-injection-from-environment by attaching the
+ * sanitization to the sink itself (per the lesson in
+ * feedback_redos_bound_doesnt_help.md: structural fix at the sink, not an
+ * upstream guard CodeQL's taint-flow can't see).
+ */
+const SAFE_BIN_BASENAMES = new Set([
+  // VCS + GitHub CLI
+  "git",
+  "gh",
+  // Search / find
+  "grep",
+  "rg",
+  "fd",
+  "find",
+  // Package managers
+  "npm",
+  "yarn",
+  "pnpm",
+  "cargo",
+  "go",
+  "pip",
+  // Runtimes / typecheckers
+  "node",
+  "tsc",
+  "pyright",
+  // Linters / formatters / fixers
+  "eslint",
+  "biome",
+  "prettier",
+  "ruff",
+  "black",
+  // Repo scanning
+  "ts-prune",
+  // Browsers / file openers
+  "open",
+  "xdg-open",
+  "cmd",
+]);
+
+function assertSafeBinary(cmd: string): void {
+  // path.basename strips directory components (incl. node_modules/.bin/foo
+  // forms used for workspace-local binaries). The check is on the resolved
+  // basename so an absolute path like /usr/local/bin/git is treated as "git".
+  const basename = path.basename(cmd);
+  if (!SAFE_BIN_BASENAMES.has(basename)) {
+    throw new Error(
+      `execSafe: command "${cmd}" is not in the safe-binary set. Callers that gate on their own allowlist (e.g. runCommand) must pass opts.allowlistChecked=true.`,
+    );
+  }
+}
+
 export async function execSafe(
   cmd: string,
   args: string[],
@@ -377,8 +436,11 @@ export async function execSafe(
     signal?: AbortSignal;
     stdin?: string;
     env?: NodeJS.ProcessEnv;
+    /** Caller has gated `cmd` against its own allowlist (e.g. config.commandAllowlist). Skips the SAFE_BIN_BASENAMES check. */
+    allowlistChecked?: boolean;
   } = {},
 ): Promise<ExecSafeResult> {
+  if (!opts.allowlistChecked) assertSafeBinary(cmd);
   const timeout = opts.timeout ?? 30_000;
   const maxBuffer = opts.maxBuffer ?? 512 * 1024;
   const start = Date.now();
@@ -472,8 +534,11 @@ export async function execSafeStreaming(
     env?: NodeJS.ProcessEnv;
     onLine?: (line: string) => void;
     onStderrLine?: (line: string) => void;
+    /** Caller has gated `cmd` against its own allowlist. Skips the SAFE_BIN_BASENAMES check. */
+    allowlistChecked?: boolean;
   } = {},
 ): Promise<ExecSafeResult> {
+  if (!opts.allowlistChecked) assertSafeBinary(cmd);
   const { onLine, onStderrLine, ...restOpts } = opts;
   if (!onLine && !onStderrLine) return execSafe(cmd, args, restOpts);
 


### PR DESCRIPTION
Closes the two real items from the security tab audit:
- CodeQL #14 — js/shell-command-injection-from-environment in [src/tools/utils.ts](src/tools/utils.ts)
- Dependabot #21 — \`@tootallnate/once\` Incorrect Control Flow Scoping (low)

Five other CodeQL alerts dismissed separately as false positives with cited reasons (#12 oauth sha256, #113/#114 smoke-test scripts, #116 streamableHttp.ts, #117 transport.ts) — see commit message for full memo.

## CodeQL #14 — sink-side allowlist

\`execSafe\` and \`execSafeStreaming\` use \`execFileAsync\`/\`spawn\` (argv array, no shell) so they're inherently injection-safe at the shell layer. CodeQL flagged the rule because PATH (env-derived) influences binary resolution and \`cmd\` was traced as "uncontrolled." All user-facing dispatch already routes through \`validateCommand\` against \`config.commandAllowlist\`, but CodeQL's taint-flow can't see those upstream guards.

Per the [\`feedback_redos_bound_doesnt_help\`](https://) lesson — **structural fix at the sink, not upstream** — this PR attaches the validation to \`execSafe\` itself:

- **\`SAFE_BIN_BASENAMES\`** — vetted set of intrinsic-safe binaries used by built-in tools (\`git\`, \`gh\`, \`npm\`, \`biome\`, \`eslint\`, \`ts-prune\`, etc.). Audited every \`execSafe(...)\` call in \`src/tools/*\` and confirmed each \`cmd\` resolves to one of these basenames or routes through the allowlist-gated path.
- **\`opts.allowlistChecked: true\`** — opt-in flag for callers that have already validated against the user-facing allowlist ([runCommand.ts](src/tools/runCommand.ts), [terminal.ts](src/tools/terminal.ts)). Skips the SAFE_BIN_BASENAMES gate so user-enabled commands keep working.
- **\`path.basename(cmd)\`** is checked, so absolute paths whose basenames are allowlisted (e.g. \`node_modules/.bin/biome\`, \`/usr/local/bin/git\`) pass.

## Dependabot #21 — \`@tootallnate/once\`

Pinned to \`^3.0.1\` via \`package.json\` \`overrides\` in [services/push-relay](services/push-relay). Was 2.0.0, transitive via \`firebase-admin → @google-cloud/storage → teeny-request → http-proxy-agent\`. \`npm audit\` post-bump: **0 vulnerabilities**.

## Tests
- 6 new tests in [src/tools/__tests__/utils-security.test.ts](src/tools/__tests__/utils-security.test.ts): unknown-binary rejection, absolute-path basename handling, allowlistChecked bypass, error-message diagnostics. **16/16 pass.**
- All 1652 \`src/tools/\` tests still pass — no regression from the new gate.

## Test plan
- [x] \`npm run typecheck\` clean
- [x] \`vitest run src/tools/__tests__/utils-security.test.ts\` — 16/16 pass
- [x] \`vitest run src/tools/\` — 1652/1652 pass
- [x] \`npm audit\` in services/push-relay — 0 vulns
- [ ] Reviewer: confirm Set contents in \`SAFE_BIN_BASENAMES\` covers every \`execSafe(\` call site you find via grep
- [ ] After merge: CodeQL re-scan should clear #14; Dependabot should auto-close #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)