### PR TITLE
chore: bump 0.2.0-beta.0 → 0.2.0-beta.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "patchwork-os",
-  "version": "0.2.0-beta.0",
+  "version": "0.2.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "patchwork-os",
-      "version": "0.2.0-beta.0",
+      "version": "0.2.0-beta.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "patchwork-os",
-  "version": "0.2.0-beta.0",
+  "version": "0.2.0-beta.1",
   "description": "Your personal AI runtime, local-first. Patchwork OS gives any AI model a consistent set of tools, YAML recipes, a delegation policy with approval queue, and a durable trace memory — all on your machine, all under your policy.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Patch beta bump rolling up this session's 8 merged PRs.

## Changelog (#354 → #369)

| PR | Summary |
|---|---|
| **#354** | Bridge \`/status\` exposes \`inboxDir\` / \`httpPort\` / \`configPath\` so the dashboard Settings card stops falling back to hardcoded defaults |
| **#355** | Hide broken Ollama row, drop dead Configure button, distinguish disk-write 500s from JSON-parse 400s in POST \`/config/patchwork\` |
| **#362** | Per-row API key entry UI + Grok row + \`apiKeysPresent\` in \`/status\` (closes #356, #357) |
| **#365** | Re-land #358 (default model labels) + Claude API row (#360-Claude) — recovered after a stacked-PR squash-merge stranded the changes |
| **#366** | New \`GeminiApiDriver\` via Google's OpenAI-compat endpoint at \`generativelanguage.googleapis.com/v1beta/openai/\` (closes #361) |
| **#367** | "Gemini API" row in dashboard (Gemini half of #360 — closes #360) |
| **#368** | Re-enable local LLMs — \`LocalApiDriver\` works with Ollama / LM Studio / vLLM / llama.cpp (closes #359) |
| **#369** | Sink-side \`SAFE_BIN_BASENAMES\` allowlist in \`execSafe\` + bump \`@tootallnate/once\` to 3.0.1 (security hardening) |

## Net delta on the AI drivers card

Pre-session: 4 rows (Claude / Gemini / Ollama-broken / OpenAI), each in inconsistent states; misleading model labels; dead Configure button on every row; no API key UI; Ollama row 400'd silently.

After: 7 rows in a clean grid:
- **Claude** (subprocess, Claude Code subscription, no key)
- **Claude API** (anthropic key)
- **Gemini** (subprocess, Gemini CLI, no key)
- **Gemini API** (google key, OpenAI-compat backend)
- **OpenAI** (openai key)
- **Grok** (xai key)
- **Local LLM** (endpoint + model fields, no key — works with any OpenAI-compat self-hosted runtime)

Each API row has Save/Clear key inputs backed by the secure store (Keychain / DPAPI / Secret Service / AES-256-GCM file fallback). \`apiKeysPresent\` in \`/status\` drives the "key set" badge without exposing raw keys to the dashboard.

## Test plan

- [x] All 1652 \`src/tools\` tests pass
- [x] All 46 driver tests pass (was 40 — +6 for new GeminiApiDriver/LocalApiDriver/createDriver coverage)
- [x] All 16 utils-security tests pass (+6 for sink-side allowlist contract)
- [x] Typecheck clean (full + dashboard)
- [x] CodeQL: 0 open alerts; Dependabot: 0 open alerts
- [ ] Reviewer: this is a chore commit; CI greenlights merge

Not bumping \`vscode-extension/package.json\` — no extension code changed this session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)