### PR TITLE
fix(automation): plumb retry state back into AutomationHooks

### DIFF
--- a/src/automation.ts
+++ b/src/automation.ts
@@ -1375,6 +1375,12 @@ export class AutomationHooks {
       eventData,
       backend: this._interpreterBackend,
       log: this.log.bind(this),
+      getLiveState: () => this._automationState,
+      mergeRetryState: (state) => {
+        this._enqueueMutation(() => {
+          this._automationState = state;
+        });
+      },
     };
     const result = await executeAutomationPolicy(this._programAST, ctx);
     if (result.ok) {

--- a/src/fp/__tests__/automationInterpreter.test.ts
+++ b/src/fp/__tests__/automationInterpreter.test.ts
@@ -634,6 +634,122 @@ describe("Parallel state merge", () => {
 // ── WithRetry re-execution ────────────────────────────────────────────────────
 
 describe("WithRetry re-execution", () => {
+  it("retry merges its resulting state via mergeRetryState (no state loss)", async () => {
+    // Backend that fails first enqueue but succeeds on retry. We assert that
+    // after the retry fires, the AutomationState produced by the retry's
+    // interpret() is published via mergeRetryState — and that it includes
+    // both a cleared pendingRetries entry AND a taskTimestamps entry for
+    // the retry-spawned task. Previously the retry result was discarded, so
+    // pendingRetries leaked and taskTimestamps undercounted.
+    let attempts = 0;
+    const realRetryBackend = new TestBackend();
+    realRetryBackend.enqueueTask = async (opts) => {
+      attempts++;
+      if (attempts === 1) throw new Error("first-try-failure");
+      realRetryBackend.collector.enqueuedTasks.push(opts);
+      return `task-${attempts}`;
+    };
+    realRetryBackend.scheduleRetry = (key, delayMs, fn) => {
+      realRetryBackend.collector.scheduledRetries.push({ key, delayMs });
+      fn();
+      return () => {};
+    };
+
+    const merged: import("../automationState.js").AutomationState[] = [];
+    let live = EMPTY_AUTOMATION_STATE;
+
+    const prog = withRetry(
+      "retry-key",
+      2,
+      5000,
+      hook({
+        hookType: "onFileSave",
+        enabled: true,
+        promptSource: INLINE_SOURCE,
+      }),
+    );
+    const ctx = makeCtx({
+      backend: realRetryBackend,
+      getLiveState: () => live,
+      mergeRetryState: (s) => {
+        merged.push(s);
+        live = s;
+      },
+    });
+    const result = await executeAutomationPolicy([prog], ctx);
+    if (!result.ok) throw new Error("not ok");
+    // Initial run set live = post-initial state with pendingRetries entry
+    live = result.value.updatedState;
+    // Allow the void async retry callback to settle
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect(attempts).toBeGreaterThanOrEqual(2);
+    expect(merged.length).toBe(1);
+    const after = merged[0]!;
+    // BUG #1: pendingRetries must be cleared after a successful retry
+    expect(after.pendingRetries.has("retry-key")).toBe(false);
+    // BUG #1: taskTimestamps must include the retry-spawned task
+    expect(after.taskTimestamps.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("retry reads live state at fire time (not scheduling-time snapshot)", async () => {
+    // Verifies BUG #2: between scheduling and firing, live state has gained a
+    // cooldown record for the same hook. The retry MUST read live state and
+    // therefore skip on cooldown, NOT re-fire from the stale snapshot.
+    let attempts = 0;
+    const realRetryBackend = new TestBackend();
+    let firedFn: (() => void) | null = null;
+    realRetryBackend.enqueueTask = async (opts) => {
+      attempts++;
+      if (attempts === 1) throw new Error("first-try-failure");
+      realRetryBackend.collector.enqueuedTasks.push(opts);
+      return `task-${attempts}`;
+    };
+    realRetryBackend.scheduleRetry = (_key, _delayMs, fn) => {
+      // Defer firing — caller will mutate live state, then fire.
+      firedFn = fn;
+      return () => {};
+    };
+
+    let live = EMPTY_AUTOMATION_STATE;
+
+    const prog = withRetry(
+      "retry-key",
+      2,
+      5000,
+      withCooldown(
+        "cooldown-key",
+        60_000,
+        hook({
+          hookType: "onFileSave",
+          enabled: true,
+          promptSource: INLINE_SOURCE,
+        }),
+      ),
+    );
+    const ctx = makeCtx({
+      backend: realRetryBackend,
+      getLiveState: () => live,
+      mergeRetryState: (s) => {
+        live = s;
+      },
+    });
+    const result = await executeAutomationPolicy([prog], ctx);
+    if (!result.ok) throw new Error("not ok");
+    live = result.value.updatedState;
+    // Simulate another (concurrent) hook that recorded a cooldown trigger for
+    // the same key between scheduling and firing.
+    live = recordTrigger(live, "cooldown-key", "task-existing", Date.now());
+    // Now fire the retry.
+    expect(firedFn).not.toBeNull();
+    firedFn?.();
+    await new Promise((r) => setTimeout(r, 20));
+    // BUG #2: retry read the snapshot and ignored the new cooldown — would
+    // have produced a 2nd enqueueTask attempt. Live-state read means the
+    // retry sees the cooldown and short-circuits.
+    expect(attempts).toBe(1);
+  });
+
   it("retry callback re-invokes the wrapped program on next tick", async () => {
     // Backend that fails first enqueue but succeeds on retry
     let attempts = 0;

--- a/src/fp/automationInterpreter.ts
+++ b/src/fp/automationInterpreter.ts
@@ -590,27 +590,41 @@ async function interpret(
           const nextRetryAt = ctx.now + program.retryDelayMs;
 
           // Schedule retry: re-invoke the wrapped program when the timer
-          // fires. State is a snapshot of when the retry was scheduled; for
-          // typical retryDelayMs (seconds) drift is negligible. TestBackend
-          // records the call but does not actually fire the timer.
+          // fires. Read live state at fire time (not the scheduling-time
+          // snapshot) so the retry honours cooldown / dedup / rate-limit
+          // mutations that landed between scheduling and fire. Merge the
+          // retry's resulting state back via mergeRetryState so cooldown,
+          // dedup, rateLimit, pendingRetries, and taskTimestamps writes
+          // performed during the retry are not silently dropped.
+          // TestBackend records the call but does not actually fire the timer.
           const wrappedProgram = program.program;
           const retrySnapshot = innerAcc.state;
+          const liveStateFn = ctx.getLiveState;
+          const mergeFn = ctx.mergeRetryState;
           ctx.backend.scheduleRetry(program.key, program.retryDelayMs, () => {
             ctx.log(
               `[interpreter] retry attempt ${nextAttempt} for ${program.key}`,
             );
             void (async () => {
               try {
+                const liveState = liveStateFn ? liveStateFn() : retrySnapshot;
                 const retryCtx: InterpreterContext = {
                   ...ctx,
-                  state: retrySnapshot,
+                  state: liveState,
                   now: Date.now(),
                 };
-                await interpret(
+                const retryResult = await interpret(
                   wrappedProgram,
                   retryCtx,
-                  emptyAcc(retrySnapshot),
+                  emptyAcc(liveState),
                 );
+                // Always clear the pendingRetries entry — the retry has run,
+                // whether it spawned a task or not — then publish state.
+                const finalState = clearPendingRetry(
+                  retryResult.state,
+                  program.key,
+                );
+                if (mergeFn) mergeFn(finalState);
               } catch (e) {
                 const m = e instanceof Error ? e.message : String(e);
                 ctx.log(`[interpreter] retry ${program.key} failed: ${m}`);

--- a/src/fp/interpreterContext.ts
+++ b/src/fp/interpreterContext.ts
@@ -36,6 +36,22 @@ export interface InterpreterContext {
   readonly eventData: Readonly<Record<string, string>>;
   readonly backend: Backend;
   readonly log: (msg: string) => void;
+  /**
+   * Optional accessor for the live AutomationState at retry-fire time. If
+   * present, WithRetry uses this instead of the snapshot taken when the retry
+   * was scheduled — preventing retries from re-firing hooks that have since
+   * entered cooldown / dedup. AutomationHooks supplies a function that returns
+   * `this._automationState`; tests may omit.
+   */
+  readonly getLiveState?: () => AutomationState;
+  /**
+   * Optional sink for the AutomationState produced by a retry's interpret()
+   * call. Without this, cooldown / dedup / rateLimit / pendingRetries /
+   * taskTimestamps writes performed during the retry are silently dropped.
+   * AutomationHooks supplies a sink that merges the result into
+   * `this._automationState` via `_enqueueMutation`; tests may omit.
+   */
+  readonly mergeRetryState?: (state: AutomationState) => void;
 }
 
 // ── Interpreter result ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- WithRetry's scheduled-retry callback discarded the result of `interpret()` on the retried program — cooldown / dedup / rateLimit / pendingRetries / taskTimestamps writes performed during the retry were silently dropped.
- Retry also ran against the state snapshot taken at scheduling time, ignoring any cooldown / dedup recorded by other events between scheduling and firing.
- Adds `getLiveState` + `mergeRetryState` to `InterpreterContext`; AutomationHooks wires them so retries read live state at fire time and publish results back through `_enqueueMutation`.

## Symptoms (pre-fix)

- After a successful retry, `state.pendingRetries.get(key)` still resolved — leaking entries indefinitely.
- `state.taskTimestamps` undercounted retry-spawned tasks → \`maxTasksPerHour\` rate-limit could be misconfigured below intent.
- A hook that entered cooldown via a concurrent event (e.g. another file save, diagnostics tick) before the retry timer fired would still get re-fired from the stale snapshot, double-spawning the same task.

## Test plan

- [x] New: \`retry merges its resulting state via mergeRetryState (no state loss)\` — fails on main, passes here. Asserts cleared pendingRetries + taskTimestamps grew.
- [x] New: \`retry reads live state at fire time (not scheduling-time snapshot)\` — fails on main, passes here. Records a cooldown between scheduling and firing, asserts retry honours it.
- [x] All 36 existing interpreter tests pass.
- [x] All 230 automation tests pass.
- [x] \`npm run typecheck\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)