### PR TITLE
fix(security): tighten execSafe sink + driver hygiene

### DIFF
--- a/src/drivers/__tests__/openai.test.ts
+++ b/src/drivers/__tests__/openai.test.ts
@@ -330,4 +330,65 @@ describe("LocalApiDriver", () => {
     delete process.env.LOCAL_ENDPOINT;
     expect(() => new LocalApiDriver(log)).toThrow(/LOCAL_ENDPOINT/);
   });
+
+  describe("LOCAL_ENDPOINT host validation", () => {
+    afterEach(() => {
+      delete process.env.LOCAL_ENDPOINT_ALLOW_REMOTE;
+    });
+
+    it("rejects non-loopback / non-private hostnames", () => {
+      process.env.LOCAL_ENDPOINT = "https://attacker.example.com/v1";
+      expect(() => new LocalApiDriver(log)).toThrow(/not loopback or private/i);
+    });
+
+    it("rejects public IPv4 addresses", () => {
+      process.env.LOCAL_ENDPOINT = "http://8.8.8.8:11434/v1";
+      expect(() => new LocalApiDriver(log)).toThrow(/not loopback or private/i);
+    });
+
+    it("accepts localhost", () => {
+      process.env.LOCAL_ENDPOINT = "http://localhost:11434/v1";
+      expect(() => new LocalApiDriver(log)).not.toThrow();
+    });
+
+    it("accepts 127.0.0.1", () => {
+      process.env.LOCAL_ENDPOINT = "http://127.0.0.1:11434/v1";
+      expect(() => new LocalApiDriver(log)).not.toThrow();
+    });
+
+    it("accepts RFC1918 (192.168.x.x)", () => {
+      process.env.LOCAL_ENDPOINT = "http://192.168.1.50:11434/v1";
+      expect(() => new LocalApiDriver(log)).not.toThrow();
+    });
+
+    it("accepts 10.x.x.x", () => {
+      process.env.LOCAL_ENDPOINT = "http://10.0.0.5:11434/v1";
+      expect(() => new LocalApiDriver(log)).not.toThrow();
+    });
+
+    it("accepts 172.16-31.x.x but rejects 172.32+", () => {
+      process.env.LOCAL_ENDPOINT = "http://172.16.0.1:11434/v1";
+      expect(() => new LocalApiDriver(log)).not.toThrow();
+      process.env.LOCAL_ENDPOINT = "http://172.31.255.255:11434/v1";
+      expect(() => new LocalApiDriver(log)).not.toThrow();
+      process.env.LOCAL_ENDPOINT = "http://172.32.0.1:11434/v1";
+      expect(() => new LocalApiDriver(log)).toThrow(/not loopback or private/i);
+    });
+
+    it("accepts .local mDNS hostnames", () => {
+      process.env.LOCAL_ENDPOINT = "http://printer.local:11434/v1";
+      expect(() => new LocalApiDriver(log)).not.toThrow();
+    });
+
+    it("LOCAL_ENDPOINT_ALLOW_REMOTE=1 bypasses validation", () => {
+      process.env.LOCAL_ENDPOINT = "https://remote-llm.example.com/v1";
+      process.env.LOCAL_ENDPOINT_ALLOW_REMOTE = "1";
+      expect(() => new LocalApiDriver(log)).not.toThrow();
+    });
+
+    it("rejects malformed URLs", () => {
+      process.env.LOCAL_ENDPOINT = "not-a-url";
+      expect(() => new LocalApiDriver(log)).toThrow(/not loopback or private/i);
+    });
+  });
 });

--- a/src/drivers/local/index.ts
+++ b/src/drivers/local/index.ts
@@ -1,6 +1,73 @@
 import { OpenAIApiDriver } from "../openai/index.js";
 
 /**
+ * Reject any LOCAL_ENDPOINT that doesn't resolve to loopback or RFC1918
+ * private space. The local driver streams the user prompt + context-file
+ * paths to whatever URL is set; if a malicious recipe (or a user pasting
+ * a phishy "free local LLM" link) sets `LOCAL_ENDPOINT=https://attacker/v1`,
+ * everything the local driver receives gets exfiltrated.
+ *
+ * Rule: hostname must be one of
+ *   - localhost / 127.0.0.1 / ::1
+ *   - RFC1918 private space (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16)
+ *   - link-local (169.254.0.0/16, fe80::/10)
+ *   - .local mDNS / .lan / .home / .internal suffixes
+ *
+ * To opt out (e.g. authorized remote inference cluster), the operator can
+ * set LOCAL_ENDPOINT_ALLOW_REMOTE=1 — explicit override, audited via env.
+ */
+export function isLoopbackOrPrivateEndpoint(rawUrl: string): boolean {
+  let host: string;
+  try {
+    host = new URL(rawUrl).hostname.toLowerCase();
+  } catch {
+    return false;
+  }
+  if (!host) return false;
+  // Strip IPv6 brackets if any
+  if (host.startsWith("[") && host.endsWith("]")) {
+    host = host.slice(1, -1);
+  }
+  if (host === "localhost" || host === "127.0.0.1" || host === "::1") {
+    return true;
+  }
+  // mDNS / common LAN suffixes
+  if (
+    host.endsWith(".local") ||
+    host.endsWith(".lan") ||
+    host.endsWith(".home") ||
+    host.endsWith(".internal")
+  ) {
+    return true;
+  }
+  // IPv4 RFC1918 + link-local + 127/8
+  const v4 = host.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
+  if (v4) {
+    const a = Number(v4[1]);
+    const b = Number(v4[2]);
+    if (a === 10) return true;
+    if (a === 127) return true;
+    if (a === 169 && b === 254) return true;
+    if (a === 172 && b >= 16 && b <= 31) return true;
+    if (a === 192 && b === 168) return true;
+    return false;
+  }
+  // IPv6 link-local fe80::/10 and unique-local fc00::/7
+  if (
+    host.startsWith("fe8") ||
+    host.startsWith("fe9") ||
+    host.startsWith("fea") ||
+    host.startsWith("feb")
+  ) {
+    return true;
+  }
+  if (host.startsWith("fc") || host.startsWith("fd")) {
+    return true;
+  }
+  return false;
+}
+
+/**
  * Local LLM driver — Ollama, LM Studio, vLLM, llama.cpp server, and most
  * other self-hosted runtimes expose an OpenAI-compatible chat-completions
  * endpoint at /v1/chat/completions. Same trick as Grok / Gemini API:
@@ -28,6 +95,17 @@ export class LocalApiDriver extends OpenAIApiDriver {
     if (!baseURL) {
       throw new Error(
         "LocalApiDriver requires LOCAL_ENDPOINT environment variable (e.g. http://localhost:11434/v1)",
+      );
+    }
+    if (
+      process.env.LOCAL_ENDPOINT_ALLOW_REMOTE !== "1" &&
+      !isLoopbackOrPrivateEndpoint(baseURL)
+    ) {
+      throw new Error(
+        `LocalApiDriver: LOCAL_ENDPOINT="${baseURL}" is not loopback or private. ` +
+          `The local driver streams prompts + context to this URL — a public host ` +
+          `would exfiltrate them. Set LOCAL_ENDPOINT_ALLOW_REMOTE=1 to override ` +
+          `(only for audited internal inference clusters).`,
       );
     }
     super(log, {

--- a/src/drivers/openai/index.ts
+++ b/src/drivers/openai/index.ts
@@ -33,6 +33,18 @@ export class OpenAIApiDriver implements ProviderDriver {
         "OpenAIApiDriver requires OPENAI_API_KEY environment variable",
       );
     }
+    // Subclasses (Grok, Gemini, Local) MUST set their own defaultModel —
+    // a bare OpenAI driver defaults to gpt-4o here, but a subclass that
+    // overrides baseURL without defaultModel would otherwise silently dial
+    // the foreign endpoint asking for gpt-4o (which doesn't exist on Grok,
+    // Gemini, or local LLMs) and surface as a confusing 404 / phantom-model
+    // error far from the actual misconfiguration.
+    if (opts.baseURL && !opts.defaultModel) {
+      throw new Error(
+        "OpenAIApiDriver: subclass must set defaultModel when baseURL is " +
+          "overridden — bare 'gpt-4o' fallback only applies to OpenAI's API.",
+      );
+    }
   }
 
   async run(input: ProviderTaskInput): Promise<ProviderTaskResult> {
@@ -103,9 +115,25 @@ export class OpenAIApiDriver implements ProviderDriver {
         const delta: string = chunk.choices?.[0]?.delta?.content ?? "";
         if (delta) {
           if (firstChunkAt === undefined) firstChunkAt = Date.now();
-          text += delta;
-          if (text.length <= OUTPUT_CAP) {
+          if (text.length < OUTPUT_CAP) {
+            // Cap accumulation in-loop to bound memory under runaway streams
+            // (e.g. local LLMs that loop). Once we hit the cap, stop appending
+            // and abort the upstream stream so sockets and decoder buffers
+            // are released. onChunk is gated by the same cap so partial
+            // listeners stop receiving deltas.
+            text += delta;
             input.onChunk?.(delta);
+          } else {
+            // biome-ignore lint/suspicious/noExplicitAny: stream shape
+            const ctrl = (stream as any).controller;
+            if (ctrl && typeof ctrl.abort === "function") {
+              try {
+                ctrl.abort();
+              } catch {
+                /* best effort */
+              }
+            }
+            break;
           }
         }
       }

--- a/src/tools/__tests__/openInBrowser.test.ts
+++ b/src/tools/__tests__/openInBrowser.test.ts
@@ -123,11 +123,13 @@ describe("createOpenInBrowserTool", () => {
     const html = "<html></html>";
     await tool.handler({ html });
 
-    expect(execSafe).toHaveBeenCalledWith("cmd", [
-      "/c",
-      "start",
-      "",
-      expect.stringMatching(/\.html$/),
-    ]);
+    expect(execSafe).toHaveBeenCalledWith(
+      "cmd",
+      ["/c", "start", "", expect.stringMatching(/\.html$/)],
+      // cmd is no longer in SAFE_BIN_BASENAMES; openInBrowser opts in via
+      // allowlistChecked since the argv shape is fixed and tmpPath is
+      // mkdtemp-generated, never user input.
+      { allowlistChecked: true },
+    );
   });
 });

--- a/src/tools/__tests__/utils-extended.test.ts
+++ b/src/tools/__tests__/utils-extended.test.ts
@@ -143,8 +143,13 @@ describe("successStructured", () => {
 });
 
 describe("execSafe", () => {
+  // node is intentionally excluded from SAFE_BIN_BASENAMES (interpreters via
+  // -e/-c can run arbitrary code). These tests opt in via allowlistChecked
+  // since the argv is hand-written and bounded.
   it("runs a real command and returns stdout", async () => {
-    const result = await execSafe("node", ["-e", "console.log('hi')"]);
+    const result = await execSafe("node", ["-e", "console.log('hi')"], {
+      allowlistChecked: true,
+    });
     expect(result.stdout.trim()).toBe("hi");
     expect(result.exitCode).toBe(0);
     expect(result.timedOut).toBe(false);
@@ -152,13 +157,17 @@ describe("execSafe", () => {
   });
 
   it("returns non-zero exit code for failing commands", async () => {
-    const result = await execSafe("node", ["-e", "process.exit(2)"]);
+    const result = await execSafe("node", ["-e", "process.exit(2)"], {
+      allowlistChecked: true,
+    });
     expect(result.exitCode).toBeGreaterThan(0);
     expect(result.timedOut).toBe(false);
   });
 
   it("captures stderr", async () => {
-    const result = await execSafe("node", ["-e", "console.error('oops')"]);
+    const result = await execSafe("node", ["-e", "console.error('oops')"], {
+      allowlistChecked: true,
+    });
     expect(result.stderr.trim()).toBe("oops");
   });
 
@@ -166,11 +175,23 @@ describe("execSafe", () => {
     const result = await execSafe(
       "node",
       ["-e", "setTimeout(() => {}, 5000)"],
-      { timeout: 500 },
+      { timeout: 500, allowlistChecked: true },
     );
     expect(result.timedOut).toBe(true);
     expect(result.durationMs).toBeGreaterThanOrEqual(400);
   }, 10000);
+
+  it("rejects 'node' without allowlistChecked (interpreter blocked at sink)", async () => {
+    await expect(execSafe("node", ["-e", "console.log(1)"])).rejects.toThrow(
+      /safe-binary set/i,
+    );
+  });
+
+  it("rejects 'cmd' without allowlistChecked (Windows shell blocked at sink)", async () => {
+    await expect(execSafe("cmd", ["/c", "echo", "hi"])).rejects.toThrow(
+      /safe-binary set/i,
+    );
+  });
 });
 
 describe("withHeartbeat", () => {

--- a/src/tools/openInBrowser.ts
+++ b/src/tools/openInBrowser.ts
@@ -134,7 +134,12 @@ export function createOpenInBrowserTool() {
       if (platform === "darwin") {
         await execSafe("open", [tmpPath]);
       } else if (platform === "win32") {
-        await execSafe("cmd", ["/c", "start", "", tmpPath]);
+        // tmpPath is bridge-generated (mkdtempSync), never user input — gate
+        // on this static call shape rather than the global SAFE_BIN_BASENAMES
+        // set so cmd.exe stays out of the general sink-side allowlist.
+        await execSafe("cmd", ["/c", "start", "", tmpPath], {
+          allowlistChecked: true,
+        });
       } else {
         await execSafe("xdg-open", [tmpPath]);
       }

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -396,8 +396,10 @@ const SAFE_BIN_BASENAMES = new Set([
   "cargo",
   "go",
   "pip",
-  // Runtimes / typecheckers
-  "node",
+  // Typecheckers (interpreters like `node`, `python`, `bash` deliberately
+  // excluded — even with allowlisted argv, an interpreter accepts arbitrary
+  // code via -e/-c. Callers with a known-safe argv shape opt in via
+  // `opts.allowlistChecked: true`.)
   "tsc",
   "pyright",
   // Linters / formatters / fixers
@@ -408,10 +410,11 @@ const SAFE_BIN_BASENAMES = new Set([
   "black",
   // Repo scanning
   "ts-prune",
-  // Browsers / file openers
+  // Browsers / file openers (cmd.exe is excluded for the same reason as
+  // interpreters — Windows browser-launch in openInBrowser uses
+  // allowlistChecked:true with a fixed argv shape.)
   "open",
   "xdg-open",
-  "cmd",
 ]);
 
 function assertSafeBinary(cmd: string): void {


### PR DESCRIPTION
## Summary

Three independent hardening fixes:

1. **execSafe** — drop \`node\` and \`cmd\` from \`SAFE_BIN_BASENAMES\`. Both are interpreters that accept arbitrary code via \`-e\` / \`/c\`. PR #369's sink-side guarantee only holds if interpreters can't ride the safe set. Sole caller (\`openInBrowser\` Windows path) now opts in via \`allowlistChecked: true\` since its argv shape is fixed and \`tmpPath\` is bridge-mkdtemp.
2. **OpenAI driver streaming** — \`text += delta\` was unbounded (only \`onChunk\` was capped). Looping local LLM blew memory. Cap in-loop + abort upstream \`stream.controller\` on cap hit. Bonus: subclasses with \`baseURL\` override now MUST set \`defaultModel\` (no silent \`gpt-4o\` fallback to non-OpenAI endpoints).
3. **LocalApiDriver endpoint validation** — \`LOCAL_ENDPOINT\` accepted any URL. New \`isLoopbackOrPrivateEndpoint\` rejects public hosts. \`LOCAL_ENDPOINT_ALLOW_REMOTE=1\` opt-out for audited internal clusters.

## Test plan

- [x] 2 new execSafe regression tests (node + cmd both throw without \`allowlistChecked\`)
- [x] 9 new \`LOCAL_ENDPOINT\` boundary tests (RFC1918 edges, mDNS, public hosts, malformed URLs, override)
- [x] All 33 \`utils-extended\` tests pass
- [x] All 33 \`openai.test.ts\` tests pass
- [x] All 8 \`openInBrowser.test.ts\` tests pass
- [x] \`npm run typecheck\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)