### PR TITLE
fix: server-side hardening (SSE DoS, Gemini token leak, OAuth rate-limit)

### DIFF
--- a/src/__tests__/streamableHttp.test.ts
+++ b/src/__tests__/streamableHttp.test.ts
@@ -960,12 +960,18 @@ describe("Streamable HTTP: session overflow eviction", () => {
       await initSession(port);
     }
 
-    // Make the first session appear idle by backdating its lastActivity
-    const sessions: Map<string, { lastActivity: number }> = (handler as any)
-      .sessions;
+    // Make the first session appear client-idle. Eviction now reads
+    // `lastClientActivity` (POST/GET/DELETE only) so server-side SSE pushes
+    // can't refresh the slot and DoS new clients — backdate that field.
+    const sessions: Map<
+      string,
+      { lastActivity: number; lastClientActivity: number }
+    > = (handler as any).sessions;
     const [firstId] = sessions.keys();
     const firstSession = sessions.get(firstId)!;
-    firstSession.lastActivity = Date.now() - 120_000; // idle for 2 minutes > 60s threshold
+    const idleTime = Date.now() - 120_000; // 2 minutes > 60s threshold
+    firstSession.lastActivity = idleTime;
+    firstSession.lastClientActivity = idleTime;
 
     // A 6th initialize should succeed (evicting the stale session) rather than return 503
     const { sid: newSid } = await initSession(port);
@@ -978,6 +984,31 @@ describe("Streamable HTTP: session overflow eviction", () => {
     expect(sessions.has(firstId)).toBe(false);
 
     // New session should be present
+    expect(sessions.has(newSid)).toBe(true);
+  });
+
+  it("eviction ignores SSE-only refresh — server-side pushes don't keep slot alive", async () => {
+    // Regression: an attacker holding 5 SSE streams open could refresh
+    // `lastActivity` via server-pushed broadcasts (notifications/tools/list_changed
+    // etc.) and indefinitely block new clients. Eviction now reads
+    // `lastClientActivity`, which only POST/GET/DELETE refresh. Simulate by
+    // backdating client-activity but keeping lastActivity recent.
+    for (let i = 0; i < 5; i++) {
+      await initSession(port);
+    }
+    const sessions: Map<
+      string,
+      { lastActivity: number; lastClientActivity: number }
+    > = (handler as any).sessions;
+    const [firstId] = sessions.keys();
+    const firstSession = sessions.get(firstId)!;
+    firstSession.lastActivity = Date.now(); // SSE-refreshed, looks fresh
+    firstSession.lastClientActivity = Date.now() - 120_000; // but no client traffic in 2min
+
+    const { sid: newSid } = await initSession(port);
+    expect(typeof newSid).toBe("string");
+    expect(sessions.size).toBe(5);
+    expect(sessions.has(firstId)).toBe(false);
     expect(sessions.has(newSid)).toBe(true);
   });
 

--- a/src/claudeOrchestrator.ts
+++ b/src/claudeOrchestrator.ts
@@ -483,8 +483,13 @@ export class ClaudeOrchestrator {
 
       this.notifyDone?.(id, task.status);
       this._fireCompletion(id);
-      void Promise.resolve(this.checkpoint?.save()).catch(() => {
-        /* best-effort */
+      void Promise.resolve(this.checkpoint?.save()).catch((err) => {
+        // Persistent disk-write failure here means task state is no longer
+        // crash-safe. Best-effort persistence — but log so a degraded disk
+        // shows up in operator logs instead of failing silently.
+        this.log(
+          `[orchestrator] checkpoint save failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
       });
       this._drain();
       this._pruneHistory();

--- a/src/drivers/gemini/index.ts
+++ b/src/drivers/gemini/index.ts
@@ -1,5 +1,11 @@
 import { spawn } from "node:child_process";
-import { chmodSync, existsSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  chmodSync,
+  existsSync,
+  readFileSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { homedir } from "node:os";
 import { isAbsolute, join, resolve } from "node:path";
 import { sanitizeEnv } from "../claude/envSanitizer.js";
@@ -58,24 +64,48 @@ export class GeminiSubprocessDriver implements ProviderDriver {
       typeof opts.approvalMode === "string" ? opts.approvalMode : "yolo";
 
     // Inject bridge MCP into ~/.gemini/settings.json before spawning so the
-    // subprocess can call bridge tools. Gemini CLI reads settings.json at startup.
+    // subprocess can call bridge tools. Gemini CLI reads settings.json at
+    // startup. We snapshot whatever was there before (or remember "absent")
+    // and restore it in a finally block at the end of run() — the bearer
+    // token must NOT outlive this single invocation in a shared-home file.
+    //
+    // URL is rewritten to 127.0.0.1:<port> for the spawned subprocess: the
+    // bridge may be bound 0.0.0.0 with a public --issuer-url, but the local
+    // child should always dial loopback so neither the URL nor the token
+    // ever leave this machine.
     const mcp = this.bridgeMcp?.();
+    let settingsCleanup: (() => void) | null = null;
     if (mcp) {
       const settingsFile = join(homedir(), ".gemini", "settings.json");
       try {
+        let originalContent: string | null = null;
         let settings: Record<string, unknown> = {};
         if (existsSync(settingsFile)) {
-          settings = JSON.parse(readFileSync(settingsFile, "utf-8")) as Record<
-            string,
-            unknown
-          >;
+          originalContent = readFileSync(settingsFile, "utf-8");
+          settings = JSON.parse(originalContent) as Record<string, unknown>;
         }
         const mcpServers = (settings.mcpServers ?? {}) as Record<
           string,
           unknown
         >;
+        const previousBridgeEntry = Object.hasOwn(
+          mcpServers,
+          "claude-ide-bridge",
+        )
+          ? mcpServers["claude-ide-bridge"]
+          : undefined;
+        const localUrl = (() => {
+          try {
+            const u = new URL(mcp.url);
+            // Force loopback — keeps token off the wire even if bridge bound 0.0.0.0
+            u.hostname = "127.0.0.1";
+            return u.toString();
+          } catch {
+            return mcp.url;
+          }
+        })();
         mcpServers["claude-ide-bridge"] = {
-          url: mcp.url,
+          url: localUrl,
           headers: { Authorization: `Bearer ${mcp.authToken}` },
         };
         settings.mcpServers = mcpServers;
@@ -83,6 +113,44 @@ export class GeminiSubprocessDriver implements ProviderDriver {
           mode: 0o600,
         });
         chmodSync(settingsFile, 0o600);
+        // Schedule restoration. If the original file existed, write back its
+        // exact bytes; if the bridge entry was absent, remove the key. If the
+        // file did not exist before, delete it. Best-effort; logged on failure.
+        settingsCleanup = () => {
+          try {
+            if (originalContent === null) {
+              // File was created by us — try to remove. Tolerate ENOENT.
+              try {
+                unlinkSync(settingsFile);
+              } catch {
+                /* ignore */
+              }
+              return;
+            }
+            const parsed = JSON.parse(originalContent) as Record<
+              string,
+              unknown
+            >;
+            if (previousBridgeEntry === undefined) {
+              const restoredServers = (parsed.mcpServers ?? {}) as Record<
+                string,
+                unknown
+              >;
+              if (Object.hasOwn(restoredServers, "claude-ide-bridge")) {
+                delete restoredServers["claude-ide-bridge"];
+              }
+              parsed.mcpServers = restoredServers;
+            }
+            writeFileSync(settingsFile, JSON.stringify(parsed, null, 2), {
+              mode: 0o600,
+            });
+            chmodSync(settingsFile, 0o600);
+          } catch (err) {
+            this.log(
+              `[GeminiSubprocessDriver] WARN: could not restore ~/.gemini/settings.json: ${err instanceof Error ? err.message : String(err)}`,
+            );
+          }
+        };
       } catch (err) {
         this.log(
           `[GeminiSubprocessDriver] WARN: could not update ~/.gemini/settings.json: ${err instanceof Error ? err.message : String(err)}`,
@@ -90,166 +158,172 @@ export class GeminiSubprocessDriver implements ProviderDriver {
       }
     }
 
-    const args = [
-      "-p",
-      input.prompt,
-      "--output-format",
-      "stream-json",
-      "--approval-mode",
-      approvalMode,
-    ];
-    if (input.model) args.push("-m", input.model);
-    // contextFiles: pass as --include-directories; normalize relative paths against workspace
-    for (const f of input.contextFiles ?? []) {
-      if (typeof f === "string" && f.length > 0 && !f.startsWith("-")) {
-        const abs = isAbsolute(f) ? f : resolve(input.workspace, f);
-        args.push("--include-directories", abs);
-      }
-    }
-
-    // Strip MCP_* and CLAUDECODE vars; preserve GEMINI_API_KEY + GOOGLE_* vars
-    const env = sanitizeEnv(process.env);
-    // Also strip Claude-specific auth vars that could confuse Gemini
-    for (const key of Object.keys(env)) {
-      if (key.startsWith("ANTHROPIC_") || key === "CLAUDE_API_KEY") {
-        delete env[key];
-      }
-    }
-
-    this.log(
-      `[GeminiSubprocessDriver] spawning: ${this.binary} -p <prompt> (workspace: ${input.workspace})`,
-    );
-
-    const child = spawn(this.binary, args, {
-      cwd: homedir(),
-      env,
-      signal: input.signal,
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-    // unref() so the bridge can exit without waiting for the subprocess,
-    // but keep detached=false so the subprocess dies cleanly with the bridge
-    // rather than getting SIGPIPE when the pipe closes mid-run.
-    child.unref();
-
-    let lineBuf = "";
-    let accumulated = "";
-    let outputBytesSent = 0;
-    let firstAssistantAt: number | undefined;
-    let doneFromResult = false;
-    let resultSuccess = true;
-
-    child.stdout.setEncoding("utf-8");
-    child.stdout.on("data", (chunk: string) => {
-      const { lines, remainder } = splitLines(lineBuf, chunk);
-      lineBuf = remainder;
-
-      for (const line of lines) {
-        if (line.trim() === "") continue;
-        let event: GeminiEvent;
-        try {
-          event = JSON.parse(line) as GeminiEvent;
-        } catch {
-          // Non-JSON stderr/warning lines — skip (Gemini prints "YOLO mode..." to stdout)
-          continue;
-        }
-
-        if (
-          event.type === "message" &&
-          event.role === "assistant" &&
-          event.content
-        ) {
-          if (firstAssistantAt === undefined) firstAssistantAt = Date.now();
-          const text = event.content;
-          accumulated += text;
-          if (outputBytesSent < OUTPUT_CAP) {
-            const send = text.slice(0, OUTPUT_CAP - outputBytesSent);
-            if (send.length > 0) {
-              input.onChunk?.(send);
-              outputBytesSent += send.length;
-            }
-          }
-        } else if (event.type === "result") {
-          doneFromResult = true;
-          resultSuccess = event.status === "success";
-        }
-      }
-    });
-
-    let stderr = "";
-    child.stderr.setEncoding("utf-8");
-    child.stderr.on("data", (chunk: string) => {
-      if (stderr.length < OUTPUT_CAP) {
-        stderr += chunk;
-        if (stderr.length > OUTPUT_CAP) stderr = stderr.slice(0, OUTPUT_CAP);
-      }
-    });
-
-    const start = Date.now();
-    const stderrTailOf = (s: string): string | undefined =>
-      s.length > 0 ? scrubSecrets(s.slice(-2048)) : undefined;
-    const startupMsOf = (): number | undefined =>
-      firstAssistantAt !== undefined ? firstAssistantAt - start : undefined;
-
-    let startupTimedOut = false;
-    const startupHandle = input.startupTimeoutMs
-      ? setTimeout(() => {
-          if (firstAssistantAt === undefined && !doneFromResult) {
-            startupTimedOut = true;
-            child.kill();
-          }
-        }, input.startupTimeoutMs)
-      : null;
-
-    let exitCode: number;
     try {
-      exitCode = await new Promise<number>((resolve, reject) => {
-        child.on("close", (code) => resolve(code ?? 0));
-        child.on("error", reject);
+      const args = [
+        "-p",
+        input.prompt,
+        "--output-format",
+        "stream-json",
+        "--approval-mode",
+        approvalMode,
+      ];
+      if (input.model) args.push("-m", input.model);
+      // contextFiles: pass as --include-directories; normalize relative paths against workspace
+      for (const f of input.contextFiles ?? []) {
+        if (typeof f === "string" && f.length > 0 && !f.startsWith("-")) {
+          const abs = isAbsolute(f) ? f : resolve(input.workspace, f);
+          args.push("--include-directories", abs);
+        }
+      }
+
+      // Strip MCP_* and CLAUDECODE vars; preserve GEMINI_API_KEY + GOOGLE_* vars
+      const env = sanitizeEnv(process.env);
+      // Also strip Claude-specific auth vars that could confuse Gemini
+      for (const key of Object.keys(env)) {
+        if (key.startsWith("ANTHROPIC_") || key === "CLAUDE_API_KEY") {
+          delete env[key];
+        }
+      }
+
+      this.log(
+        `[GeminiSubprocessDriver] spawning: ${this.binary} -p <prompt> (workspace: ${input.workspace})`,
+      );
+
+      const child = spawn(this.binary, args, {
+        cwd: homedir(),
+        env,
+        signal: input.signal,
+        stdio: ["ignore", "pipe", "pipe"],
       });
-    } catch (err) {
+      // unref() so the bridge can exit without waiting for the subprocess,
+      // but keep detached=false so the subprocess dies cleanly with the bridge
+      // rather than getting SIGPIPE when the pipe closes mid-run.
+      child.unref();
+
+      let lineBuf = "";
+      let accumulated = "";
+      let outputBytesSent = 0;
+      let firstAssistantAt: number | undefined;
+      let doneFromResult = false;
+      let resultSuccess = true;
+
+      child.stdout.setEncoding("utf-8");
+      child.stdout.on("data", (chunk: string) => {
+        const { lines, remainder } = splitLines(lineBuf, chunk);
+        lineBuf = remainder;
+
+        for (const line of lines) {
+          if (line.trim() === "") continue;
+          let event: GeminiEvent;
+          try {
+            event = JSON.parse(line) as GeminiEvent;
+          } catch {
+            // Non-JSON stderr/warning lines — skip (Gemini prints "YOLO mode..." to stdout)
+            continue;
+          }
+
+          if (
+            event.type === "message" &&
+            event.role === "assistant" &&
+            event.content
+          ) {
+            if (firstAssistantAt === undefined) firstAssistantAt = Date.now();
+            const text = event.content;
+            accumulated += text;
+            if (outputBytesSent < OUTPUT_CAP) {
+              const send = text.slice(0, OUTPUT_CAP - outputBytesSent);
+              if (send.length > 0) {
+                input.onChunk?.(send);
+                outputBytesSent += send.length;
+              }
+            }
+          } else if (event.type === "result") {
+            doneFromResult = true;
+            resultSuccess = event.status === "success";
+          }
+        }
+      });
+
+      let stderr = "";
+      child.stderr.setEncoding("utf-8");
+      child.stderr.on("data", (chunk: string) => {
+        if (stderr.length < OUTPUT_CAP) {
+          stderr += chunk;
+          if (stderr.length > OUTPUT_CAP) stderr = stderr.slice(0, OUTPUT_CAP);
+        }
+      });
+
+      const start = Date.now();
+      const stderrTailOf = (s: string): string | undefined =>
+        s.length > 0 ? scrubSecrets(s.slice(-2048)) : undefined;
+      const startupMsOf = (): number | undefined =>
+        firstAssistantAt !== undefined ? firstAssistantAt - start : undefined;
+
+      let startupTimedOut = false;
+      const startupHandle = input.startupTimeoutMs
+        ? setTimeout(() => {
+            if (firstAssistantAt === undefined && !doneFromResult) {
+              startupTimedOut = true;
+              child.kill();
+            }
+          }, input.startupTimeoutMs)
+        : null;
+
+      let exitCode: number;
+      try {
+        exitCode = await new Promise<number>((resolve, reject) => {
+          child.on("close", (code) => resolve(code ?? 0));
+          child.on("error", reject);
+        });
+      } catch (err) {
+        if (startupHandle) clearTimeout(startupHandle);
+        const isAbort =
+          (err instanceof Error && err.name === "AbortError") ||
+          input.signal.aborted;
+        if (isAbort) {
+          return {
+            text: accumulated.slice(0, OUTPUT_CAP),
+            durationMs: Date.now() - start,
+            wasAborted: true,
+            startupMs: startupMsOf(),
+            stderrTail: stderrTailOf(stderr),
+          };
+        }
+        throw err;
+      }
       if (startupHandle) clearTimeout(startupHandle);
-      const isAbort =
-        (err instanceof Error && err.name === "AbortError") ||
-        input.signal.aborted;
-      if (isAbort) {
+
+      if (startupTimedOut) {
         return {
           text: accumulated.slice(0, OUTPUT_CAP),
           durationMs: Date.now() - start,
           wasAborted: true,
-          startupMs: startupMsOf(),
+          startupTimedOut: true,
           stderrTail: stderrTailOf(stderr),
         };
       }
-      throw err;
-    }
-    if (startupHandle) clearTimeout(startupHandle);
 
-    if (startupTimedOut) {
+      const effectiveExitCode = doneFromResult
+        ? resultSuccess
+          ? 0
+          : 1
+        : exitCode;
+      if (effectiveExitCode !== 0 && stderr) {
+        this.log(`[GeminiSubprocessDriver] stderr: ${stderr.slice(0, 500)}`);
+      }
+
       return {
         text: accumulated.slice(0, OUTPUT_CAP),
+        exitCode: effectiveExitCode,
         durationMs: Date.now() - start,
-        wasAborted: true,
-        startupTimedOut: true,
         stderrTail: stderrTailOf(stderr),
+        startupMs: startupMsOf(),
       };
+    } finally {
+      // Always restore ~/.gemini/settings.json — bridge bearer token must
+      // not survive in this shared-home file past one invocation.
+      settingsCleanup?.();
     }
-
-    const effectiveExitCode = doneFromResult
-      ? resultSuccess
-        ? 0
-        : 1
-      : exitCode;
-    if (effectiveExitCode !== 0 && stderr) {
-      this.log(`[GeminiSubprocessDriver] stderr: ${stderr.slice(0, 500)}`);
-    }
-
-    return {
-      text: accumulated.slice(0, OUTPUT_CAP),
-      exitCode: effectiveExitCode,
-      durationMs: Date.now() - start,
-      stderrTail: stderrTailOf(stderr),
-      startupMs: startupMsOf(),
-    };
   }
 
   async runOutcome(input: ProviderTaskInput) {

--- a/src/fp/automationState.ts
+++ b/src/fp/automationState.ts
@@ -288,10 +288,13 @@ export function setLatestDiagnostics(
 // ── Merge helper (for Parallel node) ──────────────────────────────────────────
 
 /**
- * Merge two AutomationStates produced by parallel branches that share the same
- * initial state. For each map, keeps the max timestamp / last value per key.
- * taskTimestamps are unioned. Used by the Parallel interpreter case so both
- * branches' cooldown / trigger records are preserved.
+ * @deprecated Not called from production code. Parallel was rewritten to be
+ * sequential (see automationInterpreter.ts case "Parallel") so that branches
+ * see each other's cooldown/dedup writes — the merge-max semantics here lost
+ * those guarantees. Function + tests retained as a reference for any future
+ * truly-concurrent execution model. NOTE: `unionMap` of `activeTasks` is
+ * last-write-wins, which silently drops one taskId when both branches record
+ * the same key — restore as union-of-arrays before re-introducing parallelism.
  */
 export function mergeAutomationStates(
   a: AutomationState,

--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -161,8 +161,20 @@ export class OAuthServerImpl implements OAuthServer {
     string,
     { count: number; windowStart: number }
   >();
+  /** Per-IP token-endpoint rate limit: IP → { count, windowStart } */
+  private readonly tokenIpCounts = new Map<
+    string,
+    { count: number; windowStart: number }
+  >();
   private static readonly REGISTER_IP_MAX = 10; // max registrations per IP per minute
   private static readonly REGISTER_IP_WINDOW_MS = 60 * 1_000;
+  /** Per-IP rate limit on /oauth/token. Code-grant verifier brute-force is
+   *  bounded by entropy, but unbounded /token traffic can stuff in-memory
+   *  maps and burn auth-code-validation CPU. 30/min/IP is generous for
+   *  legitimate clients (one /token call per authorize flow) and shuts
+   *  down trivial inflight stuffing. */
+  private static readonly TOKEN_IP_MAX = 30;
+  private static readonly TOKEN_IP_WINDOW_MS = 60 * 1_000;
   private readonly gcTimer: ReturnType<typeof setInterval>;
   /** CSRF nonces: flowId → { nonce, clientId, expiresAt } */
   private readonly csrfNonces = new Map<
@@ -226,6 +238,9 @@ export class OAuthServerImpl implements OAuthServer {
         for (const [k, v] of this.registerIpCounts)
           if (now - v.windowStart > OAuthServerImpl.REGISTER_IP_WINDOW_MS)
             this.registerIpCounts.delete(k);
+        for (const [k, v] of this.tokenIpCounts)
+          if (now - v.windowStart > OAuthServerImpl.TOKEN_IP_WINDOW_MS)
+            this.tokenIpCounts.delete(k);
         for (const [k, v] of this.cimdCache)
           if (now - v.fetchedAt > OAuthServerImpl.CIMD_CACHE_TTL_MS)
             this.cimdCache.delete(k);
@@ -575,6 +590,29 @@ export class OAuthServerImpl implements OAuthServer {
   // ── Token endpoint ────────────────────────────────────────────────────────
 
   async handleToken(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    // Per-IP rate limit. Mirrors the /oauth/register limiter: cheap window
+    // counter, GC'd alongside the registration map. Without this, an
+    // attacker can stuff CPU into auth-code-validation + PKCE verification
+    // by hammering /token with bogus codes.
+    const remoteIp = (req.socket?.remoteAddress ?? "unknown").slice(0, 64);
+    const rlNow = Date.now();
+    const tokenIpEntry = this.tokenIpCounts.get(remoteIp);
+    if (
+      tokenIpEntry &&
+      rlNow - tokenIpEntry.windowStart < OAuthServerImpl.TOKEN_IP_WINDOW_MS
+    ) {
+      tokenIpEntry.count++;
+      if (tokenIpEntry.count > OAuthServerImpl.TOKEN_IP_MAX) {
+        this.sendJson(res, 429, {
+          error: "too_many_requests",
+          error_description: "per-IP token endpoint rate limit reached",
+        });
+        return;
+      }
+    } else {
+      this.tokenIpCounts.set(remoteIp, { count: 1, windowStart: rlNow });
+    }
+
     let body: URLSearchParams;
     try {
       body = await this.readBody(req);

--- a/src/streamableHttp.ts
+++ b/src/streamableHttp.ts
@@ -248,7 +248,20 @@ interface HttpSession {
   transport: McpTransport;
   openedFiles: Set<string>;
   terminalPrefix: string;
+  /**
+   * Last interaction of any kind (POST/GET/DELETE OR server-initiated SSE
+   * push). Used by the long-TTL idle pruner so a healthy SSE client receiving
+   * server-pushed notifications is not pruned during quiet periods.
+   */
   lastActivity: number;
+  /**
+   * Last *client-initiated* request (POST/GET/DELETE only). Used by the
+   * capacity-eviction guard so an attacker holding 5 open SSE streams cannot
+   * keep refreshing their slot via server-side broadcasts and DoS new
+   * clients. Diverges from `lastActivity` only when SSE pushes happen
+   * without paired client traffic.
+   */
+  lastClientActivity: number;
   /** Number of POST requests currently being processed (tool calls in flight). */
   inFlight: number;
   /** X-Claude-Code-Session-Id from the initialize request, if present. */
@@ -554,6 +567,7 @@ export class StreamableHttpHandler {
     }
 
     session.lastActivity = Date.now();
+    session.lastClientActivity = session.lastActivity;
 
     // Notifications have no `id` field at all per JSON-RPC 2.0.
     // id:null is technically a malformed request but treat it as a notification
@@ -662,6 +676,7 @@ export class StreamableHttpHandler {
 
     session.adapter.attachSSE(res);
     session.lastActivity = Date.now();
+    session.lastClientActivity = session.lastActivity;
 
     req.on("close", () => {
       session.adapter.attachSSE(null); // detach SSE stream on client disconnect
@@ -724,6 +739,7 @@ export class StreamableHttpHandler {
       openedFiles: new Set<string>(),
       terminalPrefix: `http-${id.slice(0, 8)}`,
       lastActivity: Date.now(),
+      lastClientActivity: Date.now(),
       inFlight: 0,
       claudeCodeSessionId: null,
       ownershipToken,
@@ -878,26 +894,31 @@ export class StreamableHttpHandler {
   }
 
   /**
-   * Evict the oldest idle HTTP session to make room for a new connection.
-   * Only evicts if the oldest session has been idle for more than 60 seconds,
-   * which indicates the client is gone (crashed, network dropped, no DELETE sent).
-   * Returns true if a slot was freed, false if all sessions are actively in use.
+   * Evict the oldest client-idle HTTP session to make room for a new
+   * connection. Only evicts if the oldest session's *client-initiated*
+   * activity is more than 60 seconds stale — server-pushed SSE events do NOT
+   * count, so an attacker can't hold 5 SSE streams open and DoS new clients
+   * by riding on bridge-initiated broadcasts (notifications/tools/list_changed,
+   * etc.) refreshing their slot.
+   *
+   * Returns true if a slot was freed, false if all sessions have made a
+   * client request within the threshold.
    */
   private evictOldestIdleSession(): boolean {
     const IDLE_THRESHOLD_MS = 60_000;
     const now = Date.now();
     let oldestId: string | null = null;
-    let oldestActivity = now;
+    let oldestClientActivity = now;
     for (const [id, session] of this.sessions) {
       if (session.inFlight > 0) continue; // skip sessions with in-flight tool calls
-      if (session.lastActivity < oldestActivity) {
-        oldestActivity = session.lastActivity;
+      if (session.lastClientActivity < oldestClientActivity) {
+        oldestClientActivity = session.lastClientActivity;
         oldestId = id;
       }
     }
-    if (oldestId && now - oldestActivity > IDLE_THRESHOLD_MS) {
+    if (oldestId && now - oldestClientActivity > IDLE_THRESHOLD_MS) {
       this.logger.warn(
-        `Evicting idle HTTP session ${oldestId.slice(0, 8)} (idle ${Math.round((now - oldestActivity) / 1000)}s) to make room`,
+        `Evicting client-idle HTTP session ${oldestId.slice(0, 8)} (no client traffic ${Math.round((now - oldestClientActivity) / 1000)}s) to make room`,
       );
       this.destroySession(oldestId);
       return true;


### PR DESCRIPTION
## Summary

Five independent server-side fixes, none related except all live on the bridge process.

| Fix | Severity | File |
|-----|----------|------|
| SSE keep-alive DoS — server-pushed broadcasts refreshed eviction timestamp, letting 5 parked SSE clients block all new initialize calls | P1 | \`src/streamableHttp.ts\` |
| Gemini bearer token persisted in \`~/.gemini/settings.json\`, no cleanup, clobbered existing \`mcpServers\` | HIGH security | \`src/drivers/gemini/index.ts\` |
| \`/oauth/token\` lacked per-IP rate limit (\`/register\` had one) | MEDIUM | \`src/oauth.ts\` |
| Checkpoint save errors silently swallowed | P2 | \`src/claudeOrchestrator.ts\` |
| Dead \`mergeAutomationStates\` left undocumented (Parallel rewritten sequential) | P3 cleanup | \`src/fp/automationState.ts\` |

### SSE DoS detail
Eviction now reads \`lastClientActivity\` (POST/GET/DELETE only) instead of \`lastActivity\` (which includes server-side SSE writes). Long-TTL prune still uses \`lastActivity\` so a healthy SSE client receiving server pushes is not pruned during quiet periods.

### Gemini token detail
Snapshot original content / "absent" before write → restore on finally. URL pinned to \`127.0.0.1:<port>\` for the spawned subprocess so neither URL nor token leaves the machine even when bridge is bound \`0.0.0.0\` with a public \`--issuer-url\`.

## Test plan

- [x] New regression test: SSE-only refresh doesn't keep slot alive at capacity
- [x] All 35 streamableHttp tests pass
- [x] All oauth tests pass (no behavior change for valid token requests)
- [x] All gemini driver tests pass
- [x] \`npm run typecheck\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)