### PR TITLE
chore: fix test pollution + doc drift + stale deprecation dates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 Comply with all docs in `/documents/`. Consult before changes:
 
-- **[documents/platform-docs.md](documents/platform-docs.md)** — Full feature reference (170 tools). Consult before adding/modifying features.
+- **[documents/platform-docs.md](documents/platform-docs.md)** — Full feature reference (177 tools registered). Consult before adding/modifying features. Authoritative count: `node scripts/audit-lsp-tools.mjs` Stats line.
 - **[documents/prompts-reference.md](documents/prompts-reference.md)** — All 72 MCP prompts reference.
 - **[documents/styleguide.md](documents/styleguide.md)** — Code conventions, UI patterns, output formats. Follow for all new tools, handlers, responses.
 - **[documents/roadmap.md](documents/roadmap.md)** — Development direction. Check before exploratory work.
@@ -188,7 +188,7 @@ Event-driven hooks that trigger Claude tasks automatically.
   - `onFileSave` — matching files saved. Minimatch glob patterns. Placeholder: `{{file}}`.
   - `onFileChanged` — matching files changed (buffer change, not save). Minimatch glob patterns. Placeholder: `{{file}}`.
   - `onRecipeSave` — fires when any `.yaml`/`.yml` file is saved. Placeholder: `{{file}}`. Default prompt (when no `prompt`/`promptName`) runs `patchwork recipe preflight {{file}}` and reports issues as a Claude task. Override with explicit prompt for custom behavior. Cooldown key: per-file, default 10 000 ms.
-  - `onCompaction` (v2.43.0+) — unified hook. `phase: "pre"` fires before compaction (snapshot state); `phase: "post"` fires after (re-inject IDE state). Replaces the now-deprecated `onPreCompact` + `onPostCompact` pair; legacy names still work but emit a deprecation warning. Removed no earlier than v2.46 + 30 days.
+  - `onCompaction` (v2.43.0+) — unified hook. `phase: "pre"` fires before compaction (snapshot state); `phase: "post"` fires after (re-inject IDE state). Replaces the now-deprecated `onPreCompact` + `onPostCompact` pair; legacy names still work but emit a deprecation warning. Removed no earlier than 2026-09-01.
   - `onInstructionsLoaded` — fires at session start. Injects bridge status summary.
   - `onGitCommit` — fires after successful `gitCommit`. Placeholders: `{{hash}}`, `{{branch}}`, `{{message}}`, `{{count}}`, `{{files}}`.
   - `onGitPull` — fires after successful `gitPull`. Placeholders: `{{remote}}`, `{{branch}}`.

--- a/documents/prompts-reference.md
+++ b/documents/prompts-reference.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-MCP prompts are reusable prompt templates invocable via `prompts/get` or `/name` in Claude Desktop. The bridge ships 72 prompts across four categories. Invoke with `/prompt-name` in any chat session.
+MCP prompts are reusable prompt templates invocable via `prompts/get` or `/name` in Claude Desktop. The bridge currently ships **36** prompts in `src/prompts.ts`; this document catalogs both shipped and *proposed* prompts across four categories. The runtime `prompts/list` call is the authoritative list of what's actually invocable. Invoke shipped prompts with `/prompt-name` in any chat session.
 
 Prompts appear in the Claude Desktop prompt picker automatically when the bridge is connected. In Claude Code CLI, use `/prompt-name args`.
 

--- a/src/__tests__/dashboard-cli-state-unification.test.ts
+++ b/src/__tests__/dashboard-cli-state-unification.test.ts
@@ -119,7 +119,7 @@ describe("setRecipeEnabled — install-dir recipe writes marker", () => {
 describe("listInstalledRecipes — install-dir recipes report enabled state from marker", () => {
   it("reports enabled=true for an install-dir recipe with no marker", () => {
     writeInstallDirRecipe("morning-pkg", "morning-brief");
-    const list = listInstalledRecipes(tmp);
+    const list = listInstalledRecipes(tmp, { disabledRecipes: [] });
     const entry = list.recipes.find((r) => r.name === "morning-brief");
     expect(entry).toBeDefined();
     expect(entry?.enabled).toBe(true);
@@ -127,7 +127,7 @@ describe("listInstalledRecipes — install-dir recipes report enabled state from
 
   it("reports enabled=false for an install-dir recipe with .disabled marker", () => {
     writeInstallDirRecipe("morning-pkg", "morning-brief", { disabled: true });
-    const list = listInstalledRecipes(tmp);
+    const list = listInstalledRecipes(tmp, { disabledRecipes: [] });
     const entry = list.recipes.find((r) => r.name === "morning-brief");
     expect(entry).toBeDefined();
     expect(entry?.enabled).toBe(false);
@@ -135,13 +135,13 @@ describe("listInstalledRecipes — install-dir recipes report enabled state from
 
   it("install-dir recipes still appear in the list (visibility regression check)", () => {
     writeInstallDirRecipe("standup-pkg", "standup-digest");
-    const list = listInstalledRecipes(tmp);
+    const list = listInstalledRecipes(tmp, { disabledRecipes: [] });
     expect(list.recipes.some((r) => r.name === "standup-digest")).toBe(true);
   });
 
   it("top-level legacy recipes still report enabled=true by default", () => {
     writeTopLevelRecipe("legacy.json", "legacy-recipe");
-    const list = listInstalledRecipes(tmp);
+    const list = listInstalledRecipes(tmp, { disabledRecipes: [] });
     const entry = list.recipes.find((r) => r.name === "legacy-recipe");
     expect(entry?.enabled).toBe(true);
   });

--- a/src/automation.ts
+++ b/src/automation.ts
@@ -414,7 +414,7 @@ export interface OnDiagnosticsClearedPolicy extends PromptSource {
  * Unified diagnostics-state hook (v2.43.0+) — replaces `onDiagnosticsError`
  * and `onDiagnosticsCleared` with a single schema entry carrying a `state`
  * discriminator. Expanded at load time. Legacy names still accepted with a
- * deprecation warning. Removed no earlier than v2.46 + 30 days.
+ * deprecation warning. Removed no earlier than 2026-09-01.
  */
 export type OnDiagnosticsStateChangePolicy =
   | ({ state: "error" } & OnDiagnosticsErrorPolicy)
@@ -476,9 +476,9 @@ export interface AutomationPolicy {
    * slot based on `phase`. Prefer this form in new policies.
    */
   onCompaction?: OnCompactionPolicy;
-  /** @deprecated v2.43.0 — use `onCompaction` with `phase: "post"`. Removed no earlier than v2.46 / 30 days. */
+  /** @deprecated v2.43.0 — use `onCompaction` with `phase: "post"`. Removed no earlier than 2026-09-01. */
   onPostCompact?: OnPostCompactPolicy;
-  /** @deprecated v2.43.0 — use `onCompaction` with `phase: "pre"`. Removed no earlier than v2.46 / 30 days. */
+  /** @deprecated v2.43.0 — use `onCompaction` with `phase: "pre"`. Removed no earlier than 2026-09-01. */
   onPreCompact?: OnPreCompactPolicy;
   /** Fired by Claude Code 2.1.76+ InstructionsLoaded hook — injects bridge status at session start. */
   onInstructionsLoaded?: OnInstructionsLoadedPolicy;
@@ -742,12 +742,12 @@ export function loadPolicy(filePath: string): AutomationPolicy {
   );
   if (hadLegacyPreCompact) {
     console.warn(
-      `[automation-policy] "onPreCompact" in "${filePath}" is deprecated — migrate to "onCompaction" with phase: "pre". Legacy name removed no earlier than v2.46 + 30 days after v2.43.0 release.`,
+      `[automation-policy] "onPreCompact" in "${filePath}" is deprecated — migrate to "onCompaction" with phase: "pre". Legacy name removed no earlier than 2026-09-01.`,
     );
   }
   if (hadLegacyPostCompact) {
     console.warn(
-      `[automation-policy] "onPostCompact" in "${filePath}" is deprecated — migrate to "onCompaction" with phase: "post". Legacy name removed no earlier than v2.46 + 30 days after v2.43.0 release.`,
+      `[automation-policy] "onPostCompact" in "${filePath}" is deprecated — migrate to "onCompaction" with phase: "post". Legacy name removed no earlier than 2026-09-01.`,
     );
   }
 
@@ -769,12 +769,12 @@ export function loadPolicy(filePath: string): AutomationPolicy {
   );
   if (hadLegacyDiagError) {
     console.warn(
-      `[automation-policy] "onDiagnosticsError" in "${filePath}" is deprecated — migrate to "onDiagnosticsStateChange" with state: "error". Legacy name removed no earlier than v2.46 + 30 days after v2.43.0 release.`,
+      `[automation-policy] "onDiagnosticsError" in "${filePath}" is deprecated — migrate to "onDiagnosticsStateChange" with state: "error". Legacy name removed no earlier than 2026-09-01.`,
     );
   }
   if (hadLegacyDiagCleared) {
     console.warn(
-      `[automation-policy] "onDiagnosticsCleared" in "${filePath}" is deprecated — migrate to "onDiagnosticsStateChange" with state: "cleared". Legacy name removed no earlier than v2.46 + 30 days after v2.43.0 release.`,
+      `[automation-policy] "onDiagnosticsCleared" in "${filePath}" is deprecated — migrate to "onDiagnosticsStateChange" with state: "cleared". Legacy name removed no earlier than 2026-09-01.`,
     );
   }
 
@@ -796,12 +796,12 @@ export function loadPolicy(filePath: string): AutomationPolicy {
   );
   if (hadLegacyDebugStart) {
     console.warn(
-      `[automation-policy] "onDebugSessionStart" in "${filePath}" is deprecated — migrate to "onDebugSession" with phase: "start". Legacy name removed no earlier than v2.46 + 30 days after v2.43.0 release.`,
+      `[automation-policy] "onDebugSessionStart" in "${filePath}" is deprecated — migrate to "onDebugSession" with phase: "start". Legacy name removed no earlier than 2026-09-01.`,
     );
   }
   if (hadLegacyDebugEnd) {
     console.warn(
-      `[automation-policy] "onDebugSessionEnd" in "${filePath}" is deprecated — migrate to "onDebugSession" with phase: "end". Legacy name removed no earlier than v2.46 + 30 days after v2.43.0 release.`,
+      `[automation-policy] "onDebugSessionEnd" in "${filePath}" is deprecated — migrate to "onDebugSession" with phase: "end". Legacy name removed no earlier than 2026-09-01.`,
     );
   }
 
@@ -860,12 +860,12 @@ export function loadPolicy(filePath: string): AutomationPolicy {
   }
   if (hadLegacyOnFailureOnly) {
     console.warn(
-      `[automation-policy] "onTestRun.onFailureOnly" in "${filePath}" is deprecated — migrate to "onTestRun.filter" ("failure" or "any"). Legacy field removed no earlier than v2.46 + 30 days after v2.43.0 release.`,
+      `[automation-policy] "onTestRun.onFailureOnly" in "${filePath}" is deprecated — migrate to "onTestRun.filter" ("failure" or "any"). Legacy field removed no earlier than 2026-09-01.`,
     );
   }
   if (hadLegacyTestPassAfterFailure) {
     console.warn(
-      `[automation-policy] "onTestPassAfterFailure" in "${filePath}" is deprecated — migrate to "onTestRun" with filter: "pass-after-fail". Legacy hook removed no earlier than v2.46 + 30 days after v2.43.0 release.`,
+      `[automation-policy] "onTestPassAfterFailure" in "${filePath}" is deprecated — migrate to "onTestRun" with filter: "pass-after-fail". Legacy hook removed no earlier than 2026-09-01.`,
     );
   }
 

--- a/src/recipes/__tests__/scheduler.test.ts
+++ b/src/recipes/__tests__/scheduler.test.ts
@@ -258,6 +258,7 @@ describe("RecipeScheduler", () => {
       recipesDir: tmp,
       enqueue: () => "tid",
       runYaml: async () => {},
+      disabledRecipes: [],
     });
 
     const scheduled = scheduler.start();

--- a/src/recipes/scheduler.ts
+++ b/src/recipes/scheduler.ts
@@ -48,6 +48,13 @@ export interface SchedulerOptions {
   setInterval?: typeof setInterval;
   /** Override for tests — defaults to clearInterval. */
   clearInterval?: typeof clearInterval;
+  /**
+   * Override the disabled-recipe set. Defaults to reading from
+   * `loadConfig()` (the operator's ~/.patchwork/config.json). Tests inject
+   * an empty array so a stale disabled entry on the dev machine doesn't
+   * silently make the scheduler skip a freshly-fixtured recipe.
+   */
+  disabledRecipes?: ReadonlyArray<string>;
 }
 
 export class RecipeScheduler {
@@ -63,12 +70,19 @@ export class RecipeScheduler {
   start(): ScheduledRecipe[] {
     this.stop();
 
-    // Load disabled list from config
+    // Load disabled list — tests can inject `opts.disabledRecipes` to bypass
+    // reading the operator's real ~/.patchwork/config.json (which would
+    // otherwise silently skip a recipe whose name happens to be in the dev
+    // machine's disabled set).
     let disabled: Set<string> = new Set();
-    try {
-      disabled = getConfigDisabledNames(loadConfig());
-    } catch {
-      // non-fatal — proceed with empty disabled set
+    if (this.opts.disabledRecipes !== undefined) {
+      disabled = new Set(this.opts.disabledRecipes);
+    } else {
+      try {
+        disabled = getConfigDisabledNames(loadConfig());
+      } catch {
+        // non-fatal — proceed with empty disabled set
+      }
     }
 
     let entries: string[];

--- a/src/recipesHttp.ts
+++ b/src/recipesHttp.ts
@@ -1026,7 +1026,10 @@ export interface WebhookRecipeMatch {
   format: "json" | "yaml";
 }
 
-export function listInstalledRecipes(recipesDir: string): ListRecipesResult {
+export function listInstalledRecipes(
+  recipesDir: string,
+  opts: { disabledRecipes?: ReadonlyArray<string> } = {},
+): ListRecipesResult {
   let entries: string[];
   try {
     entries = readdirSync(recipesDir);
@@ -1034,10 +1037,15 @@ export function listInstalledRecipes(recipesDir: string): ListRecipesResult {
     return { recipesDir, recipes: [] };
   }
 
-  const cfg = loadConfig();
-  const disabledSet = new Set<string>(
-    (cfg as { recipes?: { disabled?: string[] } }).recipes?.disabled ?? [],
-  );
+  // Tests inject a `disabledRecipes` list to avoid reading the user's
+  // real ~/.patchwork/config.json (which holds the operator's actual
+  // disabled set and pollutes test results when a recipe name happens to
+  // match). Default falls back to loadConfig() for production callers.
+  const disabledList =
+    opts.disabledRecipes ??
+    (loadConfig() as { recipes?: { disabled?: string[] } }).recipes?.disabled ??
+    [];
+  const disabledSet = new Set<string>(disabledList);
   const trustLevels = loadTrustLevels(recipesDir);
 
   const recipes: RecipeSummary[] = [];


### PR DESCRIPTION
## Summary

Three unrelated cleanups, batched because each is a one-liner.

### Test pollution
- \`listInstalledRecipes\` and \`RecipeScheduler.start()\` both read the operator's real \`~/.patchwork/config.json\` via \`loadConfig()\`. Fixtures used names like \`morning-brief\` that happen to be in the disabled-recipe list of any Patchwork dogfooding user, making both tests pass on a clean machine and fail on every dev box.
- Added optional \`disabledRecipes\` injection to both. Tests pass \`[]\`. Production callers unchanged.
- These were the **two pre-existing failures** that have been stable in CI for weeks but failed on \`npm test\` locally.

### Doc count drift
- CLAUDE.md said "170 tools"; actual is **177** (\`node scripts/audit-lsp-tools.mjs\` Stats line is the authoritative source).
- prompts-reference.md claimed "72 prompts"; \`src/prompts.ts\` actually ships **36**. The doc catalogues 72 entries — many are *proposed* prompts that were never implemented (\`code-review\`, \`lint-fix\`, \`security-audit\`, \`find-symbol\`, ...).
- Updated overview honesty: "currently ships **36**; doc catalogs both shipped and proposed; runtime \`prompts/list\` is authoritative." A separate ship-vs-trim decision is left for product.

### Stale deprecation removal-date strings
- 9 runtime warnings + 4 JSDoc lines pointed at "v2.46 + 30 days after v2.43.0 release". Package is now \`0.2.0-beta.1\`; that semver scheme no longer exists.
- Replaced with calendar date \`2026-09-01\` (~4-month migration window from this commit). One CLAUDE.md mirror also updated.

## Test plan

- [x] All 7 \`dashboard-cli-state-unification\` tests pass (failed on main)
- [x] All 29 \`scheduler.test.ts\` tests pass (one failed on main)
- [x] All 230 automation tests pass (deprecation warnings still emit, just with new date string)
- [x] \`npm run typecheck\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)