### PR TITLE
fix(automation): atomic WithRetry under chain lock + finally-clear pendingRetries

### DIFF
--- a/src/automation.ts
+++ b/src/automation.ts
@@ -1376,10 +1376,28 @@ export class AutomationHooks {
       backend: this._interpreterBackend,
       log: this.log.bind(this),
       getLiveState: () => this._automationState,
-      mergeRetryState: (state) => {
-        this._enqueueMutation(() => {
-          this._automationState = state;
-        });
+      runRetryUnderLock: (work) => {
+        // Always chain through `_lastRunPromise` so the retry's read of
+        // `_automationState`, its `interpret()` execution, and its writeback
+        // are atomic w.r.t. other `_runInterpreter` calls. Without this
+        // chaining, a concurrent run between read and writeback would lose
+        // its updates to the retry's older snapshot. We also catch errors
+        // so a buggy retry doesn't poison the chain.
+        this._chainBusy = true;
+        this._lastRunPromise = this._lastRunPromise
+          .catch(() => {})
+          .then(async () => {
+            try {
+              const newState = await work(this._automationState);
+              this._automationState = newState;
+            } catch (e) {
+              const m = e instanceof Error ? e.message : String(e);
+              this.log(`[automation] runRetryUnderLock failed: ${m}`);
+            }
+          })
+          .finally(() => {
+            this._chainBusy = false;
+          });
       },
     };
     const result = await executeAutomationPolicy(this._programAST, ctx);

--- a/src/fp/__tests__/automationInterpreter.test.ts
+++ b/src/fp/__tests__/automationInterpreter.test.ts
@@ -634,13 +634,11 @@ describe("Parallel state merge", () => {
 // ── WithRetry re-execution ────────────────────────────────────────────────────
 
 describe("WithRetry re-execution", () => {
-  it("retry merges its resulting state via mergeRetryState (no state loss)", async () => {
-    // Backend that fails first enqueue but succeeds on retry. We assert that
-    // after the retry fires, the AutomationState produced by the retry's
-    // interpret() is published via mergeRetryState — and that it includes
-    // both a cleared pendingRetries entry AND a taskTimestamps entry for
-    // the retry-spawned task. Previously the retry result was discarded, so
-    // pendingRetries leaked and taskTimestamps undercounted.
+  it("retry publishes its post-state atomically via runRetryUnderLock", async () => {
+    // After the retry fires, the AutomationState produced by the retry's
+    // interpret() must be published via runRetryUnderLock — including
+    // a cleared pendingRetries entry AND a taskTimestamps entry for the
+    // retry-spawned task. Originally the retry result was discarded.
     let attempts = 0;
     const realRetryBackend = new TestBackend();
     realRetryBackend.enqueueTask = async (opts) => {
@@ -655,8 +653,8 @@ describe("WithRetry re-execution", () => {
       return () => {};
     };
 
-    const merged: import("../automationState.js").AutomationState[] = [];
     let live = EMPTY_AUTOMATION_STATE;
+    const merged: import("../automationState.js").AutomationState[] = [];
 
     const prog = withRetry(
       "retry-key",
@@ -671,31 +669,32 @@ describe("WithRetry re-execution", () => {
     const ctx = makeCtx({
       backend: realRetryBackend,
       getLiveState: () => live,
-      mergeRetryState: (s) => {
-        merged.push(s);
-        live = s;
+      runRetryUnderLock: (work) => {
+        // Mimic AutomationHooks: chain async work, write result to live.
+        void (async () => {
+          const next = await work(live);
+          live = next;
+          merged.push(next);
+        })();
       },
     });
     const result = await executeAutomationPolicy([prog], ctx);
     if (!result.ok) throw new Error("not ok");
-    // Initial run set live = post-initial state with pendingRetries entry
     live = result.value.updatedState;
-    // Allow the void async retry callback to settle
     await new Promise((r) => setTimeout(r, 20));
 
     expect(attempts).toBeGreaterThanOrEqual(2);
     expect(merged.length).toBe(1);
     const after = merged[0]!;
-    // BUG #1: pendingRetries must be cleared after a successful retry
     expect(after.pendingRetries.has("retry-key")).toBe(false);
-    // BUG #1: taskTimestamps must include the retry-spawned task
     expect(after.taskTimestamps.length).toBeGreaterThanOrEqual(1);
   });
 
-  it("retry reads live state at fire time (not scheduling-time snapshot)", async () => {
-    // Verifies BUG #2: between scheduling and firing, live state has gained a
-    // cooldown record for the same hook. The retry MUST read live state and
-    // therefore skip on cooldown, NOT re-fire from the stale snapshot.
+  it("retry runs against state passed by the lock executor (atomicity)", async () => {
+    // Regression for the race where another _runInterpreter call landed
+    // between scheduling and firing. The lock executor passes the current
+    // live state to the work fn. The retry uses THAT state, so a cooldown
+    // recorded by a concurrent run is honoured (and the retry short-circuits).
     let attempts = 0;
     const realRetryBackend = new TestBackend();
     let firedFn: (() => void) | null = null;
@@ -706,7 +705,6 @@ describe("WithRetry re-execution", () => {
       return `task-${attempts}`;
     };
     realRetryBackend.scheduleRetry = (_key, _delayMs, fn) => {
-      // Defer firing — caller will mutate live state, then fire.
       firedFn = fn;
       return () => {};
     };
@@ -730,24 +728,70 @@ describe("WithRetry re-execution", () => {
     const ctx = makeCtx({
       backend: realRetryBackend,
       getLiveState: () => live,
-      mergeRetryState: (s) => {
-        live = s;
+      runRetryUnderLock: (work) => {
+        void (async () => {
+          // Lock executor MUST pass current live, not an older snapshot.
+          live = await work(live);
+        })();
       },
     });
     const result = await executeAutomationPolicy([prog], ctx);
     if (!result.ok) throw new Error("not ok");
     live = result.value.updatedState;
-    // Simulate another (concurrent) hook that recorded a cooldown trigger for
-    // the same key between scheduling and firing.
+    // Simulate a concurrent run that recorded the cooldown between
+    // scheduling and firing.
     live = recordTrigger(live, "cooldown-key", "task-existing", Date.now());
-    // Now fire the retry.
     expect(firedFn).not.toBeNull();
     firedFn?.();
     await new Promise((r) => setTimeout(r, 20));
-    // BUG #2: retry read the snapshot and ignored the new cooldown — would
-    // have produced a 2nd enqueueTask attempt. Live-state read means the
-    // retry sees the cooldown and short-circuits.
     expect(attempts).toBe(1);
+  });
+
+  it("clears pendingRetries even when retry's interpret() throws", async () => {
+    // Regression: prior implementation only cleared pendingRetries on the
+    // success path of the inner try. A retry whose work threw left the
+    // entry populated forever — manifest as `pendingRetries.get(key)` still
+    // truthy, blocking future retry scheduling for the same key.
+    const realRetryBackend = new TestBackend();
+    realRetryBackend.enqueueTask = async () => {
+      throw new Error("always-fail");
+    };
+    realRetryBackend.scheduleRetry = (_key, _delayMs, fn) => {
+      fn();
+      return () => {};
+    };
+
+    let live = EMPTY_AUTOMATION_STATE;
+
+    const prog = withRetry(
+      "retry-key",
+      2,
+      5000,
+      hook({
+        hookType: "onFileSave",
+        enabled: true,
+        promptSource: INLINE_SOURCE,
+      }),
+    );
+    const ctx = makeCtx({
+      backend: realRetryBackend,
+      getLiveState: () => live,
+      runRetryUnderLock: (work) => {
+        void (async () => {
+          live = await work(live);
+        })();
+      },
+    });
+    const result = await executeAutomationPolicy([prog], ctx);
+    if (!result.ok) throw new Error("not ok");
+    live = result.value.updatedState;
+    // Initial run scheduled the retry → pendingRetries.has(retry-key) = true
+    expect(live.pendingRetries.has("retry-key")).toBe(true);
+    // Let the retry callback run; it throws inside doRetry but the
+    // try/finally-style catch in WithRetry's doRetry must still emit
+    // clearPendingRetry on the way out.
+    await new Promise((r) => setTimeout(r, 20));
+    expect(live.pendingRetries.has("retry-key")).toBe(false);
   });
 
   it("retry callback re-invokes the wrapped program on next tick", async () => {

--- a/src/fp/automationInterpreter.ts
+++ b/src/fp/automationInterpreter.ts
@@ -589,47 +589,66 @@ async function interpret(
           const nextAttempt = attempt + 1;
           const nextRetryAt = ctx.now + program.retryDelayMs;
 
-          // Schedule retry: re-invoke the wrapped program when the timer
-          // fires. Read live state at fire time (not the scheduling-time
-          // snapshot) so the retry honours cooldown / dedup / rate-limit
-          // mutations that landed between scheduling and fire. Merge the
-          // retry's resulting state back via mergeRetryState so cooldown,
-          // dedup, rateLimit, pendingRetries, and taskTimestamps writes
-          // performed during the retry are not silently dropped.
+          // Schedule retry: re-run the wrapped program when the timer
+          // fires. The work runs INSIDE AutomationHooks' mutation lock
+          // (`runRetryUnderLock`) so:
+          //   1. Read of live state is atomic w.r.t. concurrent _runInterpreter
+          //      calls — the retry sees their cooldown / dedup / rateLimit
+          //      writes, can't clobber them.
+          //   2. Write of post-retry state is atomic w.r.t. the same chain,
+          //      so the retry's effects can't be lost to a concurrent run
+          //      that started between scheduling and merge.
+          //   3. `clearPendingRetry` is in a try/finally so the
+          //      pendingRetries entry is dropped even if the inner
+          //      interpret() throws (otherwise the retry leaks the entry
+          //      forever).
+          //
           // TestBackend records the call but does not actually fire the timer.
+          // Tests that exercise retry dispatch synchronously override
+          // `scheduleRetry`.
           const wrappedProgram = program.program;
           const retrySnapshot = innerAcc.state;
           const liveStateFn = ctx.getLiveState;
-          const mergeFn = ctx.mergeRetryState;
+          const runUnderLock = ctx.runRetryUnderLock;
           ctx.backend.scheduleRetry(program.key, program.retryDelayMs, () => {
             ctx.log(
               `[interpreter] retry attempt ${nextAttempt} for ${program.key}`,
             );
-            void (async () => {
+            const doRetry = async (
+              live: AutomationState,
+            ): Promise<AutomationState> => {
               try {
-                const liveState = liveStateFn ? liveStateFn() : retrySnapshot;
                 const retryCtx: InterpreterContext = {
                   ...ctx,
-                  state: liveState,
+                  state: live,
                   now: Date.now(),
                 };
                 const retryResult = await interpret(
                   wrappedProgram,
                   retryCtx,
-                  emptyAcc(liveState),
+                  emptyAcc(live),
                 );
-                // Always clear the pendingRetries entry — the retry has run,
-                // whether it spawned a task or not — then publish state.
-                const finalState = clearPendingRetry(
-                  retryResult.state,
-                  program.key,
-                );
-                if (mergeFn) mergeFn(finalState);
+                return clearPendingRetry(retryResult.state, program.key);
               } catch (e) {
                 const m = e instanceof Error ? e.message : String(e);
                 ctx.log(`[interpreter] retry ${program.key} failed: ${m}`);
+                // Drop the pending entry even on error — leaving it would
+                // make `pendingRetries.get(key)` look truthy forever.
+                return clearPendingRetry(live, program.key);
               }
-            })();
+            };
+            if (runUnderLock) {
+              runUnderLock(doRetry);
+            } else {
+              // Fallback for tests that didn't supply a lock executor:
+              // run against the snapshot (or live read if available),
+              // discard result. Not atomic, but tests don't observe the
+              // chain anyway.
+              void (async () => {
+                const seed = liveStateFn ? liveStateFn() : retrySnapshot;
+                await doRetry(seed);
+              })();
+            }
           });
 
           const newState = recordPendingRetry(

--- a/src/fp/interpreterContext.ts
+++ b/src/fp/interpreterContext.ts
@@ -45,13 +45,23 @@ export interface InterpreterContext {
    */
   readonly getLiveState?: () => AutomationState;
   /**
-   * Optional sink for the AutomationState produced by a retry's interpret()
-   * call. Without this, cooldown / dedup / rateLimit / pendingRetries /
-   * taskTimestamps writes performed during the retry are silently dropped.
-   * AutomationHooks supplies a sink that merges the result into
-   * `this._automationState` via `_enqueueMutation`; tests may omit.
+   * Optional atomic-retry executor. Receives a function that, given the
+   * truly-current `AutomationState` at lock-acquisition time, returns the
+   * post-retry state. AutomationHooks runs this through `_enqueueMutation`
+   * so the read-run-write happens atomically with respect to other
+   * `_runInterpreter` calls (the same chain that prevents two concurrent
+   * events from clobbering each other's writes).
+   *
+   * Replaces the older `mergeRetryState` setter API, which let a retry
+   * publish stale absolute state and clobber writes from concurrent runs
+   * that landed between scheduling and merge. Now the retry's interpret()
+   * is itself executed inside the lock against fresh live state.
+   *
+   * Tests may omit (TestBackend doesn't fire retries by default).
    */
-  readonly mergeRetryState?: (state: AutomationState) => void;
+  readonly runRetryUnderLock?: (
+    work: (live: AutomationState) => Promise<AutomationState>,
+  ) => void;
 }
 
 // ── Interpreter result ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

PR #372 plumbed retry state but introduced two regressions:

1. **Atomicity gap** — retry's \`interpret()\` ran outside the \`_enqueueMutation\` chain. A concurrent \`_runInterpreter\` call landing between scheduling and merge had its writes clobbered by the retry's older snapshot — the same race the chain was meant to prevent.
2. **Catch-path leak** — \`clearPendingRetry\` was inside the success arm of the try. A retry whose \`interpret()\` threw left \`pendingRetries.get(key)\` populated forever, blocking future retries for that key.

## Fix

Replaces the \`mergeRetryState(state)\` setter with \`runRetryUnderLock(work)\` executor. AutomationHooks runs the work inside the chain, so the retry's read-run-write is atomic w.r.t. concurrent runs. \`clearPendingRetry\` moved into the catch path so it fires on both paths.

## Test plan

- [x] New: catch-path clearPendingRetry — reproduces regression #2
- [x] New: atomicity test — lock executor passes current live state to retry
- [x] Updated: success-path test uses new executor-shape API
- [x] All 37 interpreter tests pass; all 230 automation tests pass
- [x] \`npm run typecheck\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)