### PR TITLE
fix: regression sweep (LOCAL_ENDPOINT, scheduler TOCTOU, retry-after, webhook map cap, ext version)

### DIFF
--- a/src/__tests__/extensionClient.test.ts
+++ b/src/__tests__/extensionClient.test.ts
@@ -384,7 +384,12 @@ describe("ExtensionClient", () => {
     ws3.close();
   });
 
-  it("logs warning on extension/hello major version mismatch", async () => {
+  it("logs error and marks extension unavailable on extension/hello major version mismatch", async () => {
+    // Behavior change: a major-version mismatch used to only log a warning;
+    // bridge would proceed sending requests of one protocol-major to a
+    // handler of another, surfacing as opaque field-shape errors. Now
+    // marks the extension unavailable so `extensionRequired` tools fail
+    // fast with a clear message.
     const serverConn = new Promise<WebSocket>((resolve) => {
       wss.on("connection", resolve);
     });
@@ -394,10 +399,12 @@ describe("ExtensionClient", () => {
     const serverWs = await serverConn;
     client.handleExtensionConnection(serverWs);
 
-    // Spy on the logger — Logger exposes .warn() publicly
-    const warnSpy = vi.spyOn(
-      client["logger" as never] as { warn: (msg: string) => void },
-      "warn",
+    // Sanity: connected before hello arrives.
+    expect(client.isConnected()).toBe(true);
+
+    const errorSpy = vi.spyOn(
+      client["logger" as never] as { error: (msg: string) => void },
+      "error",
     );
 
     ws.send(
@@ -409,9 +416,10 @@ describe("ExtensionClient", () => {
     );
 
     await new Promise((r) => setTimeout(r, 50));
-    expect(warnSpy).toHaveBeenCalledWith(
+    expect(errorSpy).toHaveBeenCalledWith(
       expect.stringContaining("major version mismatch"),
     );
+    expect(client.isConnected()).toBe(false);
 
     ws.close();
   });

--- a/src/connectors/baseConnector.ts
+++ b/src/connectors/baseConnector.ts
@@ -414,16 +414,42 @@ export abstract class BaseConnector {
     "x-ratelimit-reset"?: string;
     "retry-after"?: string;
   }): void {
+    // Clamp + sanitize header-derived values: a buggy or malicious provider
+    // returning `Retry-After: 9999999999` overflows setTimeout's 32-bit
+    // delay (and the int*1000 silently); a NaN result poisons backoff math
+    // for every subsequent call. Cap at 10 minutes — enough for any
+    // legitimate rate-limit window, short enough that a wedged connector
+    // recovers within a single ops cycle.
+    const MAX_BACKOFF_MS = 10 * 60 * 1000;
+    const clampNonNegative = (n: number, max: number): number => {
+      if (!Number.isFinite(n) || n < 0) return 0;
+      return Math.min(n, max);
+    };
+
     if (headers["x-ratelimit-remaining"]) {
-      this.rateLimit.remaining = parseInt(headers["x-ratelimit-remaining"], 10);
-    }
-    if (headers["x-ratelimit-reset"]) {
-      this.rateLimit.resetAt = new Date(
-        parseInt(headers["x-ratelimit-reset"], 10) * 1000,
+      const parsed = parseInt(headers["x-ratelimit-remaining"], 10);
+      this.rateLimit.remaining = clampNonNegative(
+        parsed,
+        Number.MAX_SAFE_INTEGER,
       );
     }
+    if (headers["x-ratelimit-reset"]) {
+      const parsed = parseInt(headers["x-ratelimit-reset"], 10);
+      // Cap reset at "1 day from now" so a garbage-large reset doesn't pin
+      // the connector indefinitely.
+      const epochMs = clampNonNegative(parsed, Number.MAX_SAFE_INTEGER) * 1000;
+      const cappedMs = Math.min(epochMs, Date.now() + 24 * 60 * 60 * 1000);
+      this.rateLimit.resetAt = new Date(cappedMs);
+    }
     if (headers["retry-after"]) {
-      this.rateLimit.backoffMs = parseInt(headers["retry-after"], 10) * 1000;
+      // RFC 7231 allows seconds OR HTTP-date — we only handle seconds today
+      // (the connectors we ship target APIs that always return seconds).
+      // NaN guard handles HTTP-date inputs gracefully.
+      const parsed = parseInt(headers["retry-after"], 10);
+      this.rateLimit.backoffMs = clampNonNegative(
+        parsed * 1000,
+        MAX_BACKOFF_MS,
+      );
     }
   }
 

--- a/src/drivers/__tests__/openai.test.ts
+++ b/src/drivers/__tests__/openai.test.ts
@@ -390,5 +390,43 @@ describe("LocalApiDriver", () => {
       process.env.LOCAL_ENDPOINT = "not-a-url";
       expect(() => new LocalApiDriver(log)).toThrow(/not loopback or private/i);
     });
+
+    it("rejects attacker-registered .local public domain (multi-label)", () => {
+      // Regression: `host.endsWith(".local")` previously matched
+      // `evil.com.local`, an attacker-registered domain on a public TLD.
+      process.env.LOCAL_ENDPOINT = "http://evil.com.local/v1";
+      expect(() => new LocalApiDriver(log)).toThrow(/not loopback or private/i);
+    });
+
+    it("accepts single-label .local mDNS host", () => {
+      process.env.LOCAL_ENDPOINT = "http://printer.local/v1";
+      expect(() => new LocalApiDriver(log)).not.toThrow();
+    });
+
+    it("rejects multi-label .lan host", () => {
+      process.env.LOCAL_ENDPOINT = "http://attacker.com.lan/v1";
+      expect(() => new LocalApiDriver(log)).toThrow(/not loopback or private/i);
+    });
+
+    it("rejects hostname starting with 'fc' that is NOT an IPv6 literal", () => {
+      // Regression: prior `host.startsWith("fc")` matched any hostname.
+      process.env.LOCAL_ENDPOINT = "http://fc-services.example.com/v1";
+      expect(() => new LocalApiDriver(log)).toThrow(/not loopback or private/i);
+    });
+
+    it("rejects hostname starting with 'fe8' that is NOT an IPv6 literal", () => {
+      process.env.LOCAL_ENDPOINT = "http://fe8a-test.example.com/v1";
+      expect(() => new LocalApiDriver(log)).toThrow(/not loopback or private/i);
+    });
+
+    it("accepts bracketed IPv6 fc00::/7 literal", () => {
+      process.env.LOCAL_ENDPOINT = "http://[fc00::1]:11434/v1";
+      expect(() => new LocalApiDriver(log)).not.toThrow();
+    });
+
+    it("accepts bracketed IPv6 fe80::/10 literal", () => {
+      process.env.LOCAL_ENDPOINT = "http://[fe80::1]:11434/v1";
+      expect(() => new LocalApiDriver(log)).not.toThrow();
+    });
   });
 });

--- a/src/drivers/local/index.ts
+++ b/src/drivers/local/index.ts
@@ -18,6 +18,7 @@ import { OpenAIApiDriver } from "../openai/index.js";
  */
 export function isLoopbackOrPrivateEndpoint(rawUrl: string): boolean {
   let host: string;
+  let wasBracketed = false;
   try {
     host = new URL(rawUrl).hostname.toLowerCase();
   } catch {
@@ -27,20 +28,12 @@ export function isLoopbackOrPrivateEndpoint(rawUrl: string): boolean {
   // Strip IPv6 brackets if any
   if (host.startsWith("[") && host.endsWith("]")) {
     host = host.slice(1, -1);
+    wasBracketed = true;
   }
   if (host === "localhost" || host === "127.0.0.1" || host === "::1") {
     return true;
   }
-  // mDNS / common LAN suffixes
-  if (
-    host.endsWith(".local") ||
-    host.endsWith(".lan") ||
-    host.endsWith(".home") ||
-    host.endsWith(".internal")
-  ) {
-    return true;
-  }
-  // IPv4 RFC1918 + link-local + 127/8
+  // IPv4 RFC1918 + link-local + 127/8 (check first — strict literal match)
   const v4 = host.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
   if (v4) {
     const a = Number(v4[1]);
@@ -52,17 +45,44 @@ export function isLoopbackOrPrivateEndpoint(rawUrl: string): boolean {
     if (a === 192 && b === 168) return true;
     return false;
   }
-  // IPv6 link-local fe80::/10 and unique-local fc00::/7
-  if (
-    host.startsWith("fe8") ||
-    host.startsWith("fe9") ||
-    host.startsWith("fea") ||
-    host.startsWith("feb")
-  ) {
-    return true;
+  // IPv6 ranges — only when the input looked like an IPv6 literal (was
+  // bracketed in the URL, or matches an IPv6 syntactic shape). Without this
+  // gate, a hostname like `fc-services.example.com` or `fe8a-test` would
+  // match the legacy `startsWith("fc")` / `startsWith("fe8")` checks and
+  // bypass the validator. RFC3986 allows IPv6 literals only inside `[…]`,
+  // so requiring the brackets is the conservative path.
+  if (wasBracketed || /^[0-9a-f:]+$/.test(host)) {
+    if (
+      host.startsWith("fe8") ||
+      host.startsWith("fe9") ||
+      host.startsWith("fea") ||
+      host.startsWith("feb")
+    ) {
+      return true; // link-local fe80::/10
+    }
+    if (host.startsWith("fc") || host.startsWith("fd")) {
+      return true; // unique-local fc00::/7
+    }
   }
-  if (host.startsWith("fc") || host.startsWith("fd")) {
-    return true;
+  // mDNS / common LAN suffixes — checked LAST and require a leading dot
+  // boundary so attacker-registered public domains like `evil.com.local`
+  // don't slip through (`.local` and `.lan` are not reserved TLDs at the
+  // DNS resolver level — only RFC6762 reserves them for mDNS, but public
+  // resolvers will happily look them up).
+  //
+  // The trade-off: a host literally named `printer.local` (single label
+  // before `.local`) is the legitimate mDNS form and matches; a host like
+  // `evil.com.local` (two-or-more labels before `.local`) is only the
+  // mDNS form by accident and is the bypass we're rejecting.
+  for (const suffix of [".local", ".lan", ".home", ".internal"]) {
+    if (host.endsWith(suffix)) {
+      const labels = host.split(".");
+      // 2 labels exactly: `<name>.local` — legitimate mDNS shape.
+      if (labels.length === 2) return true;
+      // More labels: ambiguous — refuse by default. Operator can opt out
+      // via LOCAL_ENDPOINT_ALLOW_REMOTE for legitimate multi-label
+      // internal DNS zones (e.g. `service.team.internal`).
+    }
   }
   return false;
 }

--- a/src/extensionClient.ts
+++ b/src/extensionClient.ts
@@ -270,6 +270,9 @@ export class ExtensionClient {
       this.diagnosticsListeners.clear();
       // Clear LSP readiness — language servers may need to re-index after reconnect
       this.lspReadyLanguages.clear();
+      // Reset protocol-mismatch flag so a fresh hello on reconnect can
+      // re-evaluate compatibility (operator may have updated the extension).
+      this.extensionProtocolMismatch = false;
       this.logger.info(`Extension disconnected: ${reason}`);
       this.safeCallback(this.onExtensionDisconnected);
     };
@@ -475,10 +478,20 @@ export class ExtensionClient {
           this.logger.debug(
             `Extension protocol version "${extVer}" is not a recognized semver format, skipping version check`,
           );
+          this.extensionProtocolMismatch = false;
         } else if (extMajor !== bridgeMajor) {
-          this.logger.warn(
-            `Extension protocol major version mismatch: bridge=${BRIDGE_PROTOCOL_VERSION}, extension=${extVer}. Consider updating.`,
+          // Mark the extension as unavailable. Without this, the bridge
+          // would proceed sending requests of one protocol-major to a
+          // handler of another, surfacing as opaque field-shape errors
+          // far from the actual cause. `extensionRequired` tools fail
+          // fast with a clear isError content block.
+          this.logger.error(
+            `Extension protocol major version mismatch: bridge=${BRIDGE_PROTOCOL_VERSION}, extension=${extVer}. ` +
+              `Marking extension as unavailable. Update the VS Code extension to a build whose protocolVersion major matches the bridge.`,
           );
+          this.extensionProtocolMismatch = true;
+        } else {
+          this.extensionProtocolMismatch = false;
         }
         break;
       }
@@ -2014,8 +2027,17 @@ export class ExtensionClient {
     };
   }
 
+  /**
+   * Tracks whether the connected extension has a protocol-major-version
+   * mismatch with the bridge. When set, `isConnected()` returns false so
+   * `extensionRequired` tools fail fast with a clear "extension protocol
+   * mismatch" error instead of attempting requests that would silently
+   * misbehave (e.g. handler accepting a v1 shape but bridge sending v2).
+   */
+  private extensionProtocolMismatch = false;
+
   isConnected(): boolean {
-    return this.connected;
+    return this.connected && !this.extensionProtocolMismatch;
   }
 
   /**

--- a/src/recipes/scheduler.ts
+++ b/src/recipes/scheduler.ts
@@ -292,15 +292,25 @@ export class RecipeScheduler {
   }
 
   private fire(name: string): void {
-    // TOCTOU defence: re-check the legacy `cfg.recipes.disabled` list at
-    // fire time. `start()` snapshots it once; if the user runs `recipe
-    // disable <name>` after start (and the recipe is a top-level legacy
-    // file, where the marker file doesn't apply), the timer would
-    // otherwise still fire until next restart(). The `.disabled` marker
-    // case is handled inside findYamlRecipePath / loadRecipePrompt
-    // (skip disabled install dirs) thanks to PR #49.
+    // TOCTOU defence: re-check the disabled list at fire time. `start()`
+    // snapshots it once; if the user runs `recipe disable <name>` after
+    // start (and the recipe is a top-level legacy file, where the marker
+    // file doesn't apply), the timer would otherwise still fire until
+    // next restart(). The `.disabled` marker case is handled inside
+    // findYamlRecipePath / loadRecipePrompt (skip disabled install dirs)
+    // thanks to PR #49.
+    //
+    // When `opts.disabledRecipes` is injected (test path), use it instead
+    // of `loadConfig()` — same reasoning as the start()-time injection in
+    // PR #375: reading the operator's real ~/.patchwork/config.json from
+    // a test process pollutes results when a fixtured recipe name
+    // collides with the dev box's disabled set.
     try {
-      if (getConfigDisabledNames(loadConfig()).has(name)) {
+      const disabled =
+        this.opts.disabledRecipes !== undefined
+          ? new Set(this.opts.disabledRecipes)
+          : getConfigDisabledNames(loadConfig());
+      if (disabled.has(name)) {
         this.opts.logger?.info?.(
           `[scheduler] skipping "${name}" — disabled via config (TOCTOU re-check)`,
         );

--- a/src/server.ts
+++ b/src/server.ts
@@ -310,6 +310,16 @@ export class Server extends EventEmitter<ServerEvents> {
     }>
   >();
   static readonly MAX_WEBHOOK_PAYLOADS = 5;
+  /**
+   * Per-list FIFO bounds the per-recipe payload count, but the Map itself
+   * needs a key cap so a recipe-rename loop or a scanner hitting many
+   * distinct legitimate hookPaths can't grow `webhookPayloads.size`
+   * without bound. 1000 is generous for any realistic operator deployment
+   * (5 payloads × 1000 recipes = ~5000 entries × ~10 KB each = 50 MB).
+   * On overflow, evict the oldest *recipe* (Map iteration order is
+   * insertion order in JS), not the largest list.
+   */
+  static readonly MAX_WEBHOOK_RECIPES = 1000;
   /** Set by bridge to handle MCP Streamable HTTP sessions (POST/GET/DELETE /mcp) */
   public httpMcpHandler:
     | ((req: http.IncomingMessage, res: http.ServerResponse) => Promise<void>)
@@ -990,6 +1000,17 @@ export class Server extends EventEmitter<ServerEvents> {
           });
           if (existing.length > Server.MAX_WEBHOOK_PAYLOADS) {
             existing.length = Server.MAX_WEBHOOK_PAYLOADS;
+          }
+          // Evict the oldest recipe entry if we'd exceed the key cap on
+          // insertion. Map iteration is insertion order, so .keys().next()
+          // returns the oldest. Skip eviction when the path is already in
+          // the Map (re-keying same path doesn't grow size).
+          if (
+            !this.webhookPayloads.has(hookPath) &&
+            this.webhookPayloads.size >= Server.MAX_WEBHOOK_RECIPES
+          ) {
+            const oldest = this.webhookPayloads.keys().next().value;
+            if (oldest !== undefined) this.webhookPayloads.delete(oldest);
           }
           this.webhookPayloads.set(hookPath, existing);
         }


### PR DESCRIPTION
## Summary

Five independent hardening fixes batched because each is small and standalone.

| Fix | File |
|-----|------|
| \`LOCAL_ENDPOINT\` validator: tighten \`.local\`/\`.lan\` suffix (single-label only) and gate IPv6 prefix checks (\`fc\`, \`fe8\`) on actual IPv6 literal shape so \`evil.com.local\` and \`fc-services.example.com\` no longer bypass | \`src/drivers/local/index.ts\` |
| Scheduler fire-time TOCTOU re-check now honors \`disabledRecipes\` injection (PR #375 fixed start() but missed the timer path) | \`src/recipes/scheduler.ts\` |
| \`Retry-After\` clamped to 10 minutes; NaN/negative guards on \`x-ratelimit-*\` headers (stop \`9999999999\` from poisoning backoff math) | \`src/connectors/baseConnector.ts\` |
| \`webhookPayloads\` Map capped at 1000 distinct recipes (LRU evict). Per-list FIFO already exists; key cap was missing | \`src/server.ts\` |
| Extension protocol-major mismatch now fails fast instead of warning + proceeding (\`isConnected()\` returns false, tools fail with a clear message) | \`src/extensionClient.ts\` |

## Test plan

- [x] 7 new \`LOCAL_ENDPOINT\` validator-bypass regression tests
- [x] Updated extensionClient mismatch test for new fail-fast behavior
- [x] All 80 driver / 21 extension / 29 scheduler tests pass
- [x] \`npm run typecheck\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)