### PR TITLE
fix: 3rd-pass corrections from waves 5-8 audit

### DIFF
--- a/src/__tests__/approvalQueue.test.ts
+++ b/src/__tests__/approvalQueue.test.ts
@@ -190,20 +190,22 @@ describe("ApprovalQueue — approval tokens", () => {
     expect(q.validateToken(callId, approvalToken!)).toBe(true);
   });
 
-  it("validateToken locks out after MAX_TOKEN_FAILURES wrong attempts", () => {
-    // Brute-force defense: 5 mismatches and the token is dead, even when the
-    // 6th attempt would have been correct. Bounds spray attacks at 5 ×
-    // token-TTL even if an attacker has unlimited callIds.
+  it("survives sustained wrong-token spray without locking out the legit approver", () => {
+    // Regression: prior cap of 5 enabled its own DoS — an attacker burning
+    // 4 failures on a leaked callId locked the legit approver out after one
+    // typo. Same applied to dedup-reused entries inheriting accumulated
+    // tokenFailures. Cap bumped to 1000 (memory/CPU bound, not security
+    // bound — token entropy is 256 bits). 100 wrong attempts must still
+    // leave room for the legit one to win.
     const q = new ApprovalQueue();
     const { callId, approvalToken } = q.request(
       { toolName: "gitPush", params: {}, tier: "high" },
       { withToken: true },
     );
-    for (let i = 0; i < 5; i++) {
+    for (let i = 0; i < 100; i++) {
       expect(q.validateToken(callId, "deadbeef".repeat(8))).toBe(false);
     }
-    // Even the correct token fails after lockout.
-    expect(q.validateToken(callId, approvalToken!)).toBe(false);
+    expect(q.validateToken(callId, approvalToken!)).toBe(true);
   });
 
   it("validateToken returns false for unknown callId", () => {

--- a/src/approvalQueue.ts
+++ b/src/approvalQueue.ts
@@ -201,28 +201,33 @@ export class ApprovalQueue {
   }
 
   /**
-   * Maximum failed validateToken attempts per callId before the token is
-   * locked out (treated as expired). 5 is generous for legitimate retries
-   * (typo on phone, copy-paste error) and tight enough to bound brute-force
-   * to 5 / token-TTL — for 256-bit tokens this is astronomically below the
-   * keyspace, so the limit is functionally only a DoS / spray defense.
+   * Hard cap on failed validateToken attempts per callId. Once exceeded,
+   * the token is treated as expired.
+   *
+   * The cap is **memory/CPU theatre, not a brute-force defense** — token
+   * entropy is 256 bits, so even at 200 req/s × 5-min TTL = 60 000
+   * attempts vs 2^256 keyspace is astronomically below the keyspace. The
+   * earlier 5-attempt cap was found by audit to enable a *new* DoS:
+   * an attacker who burned 4 failures on a leaked callId locked the
+   * legitimate approver out after one typo. Same scenario applied to
+   * dedup-reused entries (an agent re-requesting the same
+   * `(sessionId, toolName, params)` inherited the entry's accumulated
+   * `tokenFailures`).
+   *
+   * Bumping the cap to 1000 leaves the legitimate approver with ample
+   * retry budget while still bounding memory/CPU on a sustained
+   * misbehaving client. The HTTP-level rate limit on `/approve` /
+   * `/reject` is where real spray defense should live; track in a
+   * follow-up.
    */
-  private static readonly MAX_TOKEN_FAILURES = 5;
+  private static readonly MAX_TOKEN_FAILURES = 1000;
 
   /**
    * Validate a phone-path approval token for the given callId.
    *
    * On a successful match, the token is cleared (single-use against
    * approver-side replay). On a mismatch, the token is preserved so a
-   * subsequent legitimate POST still works — but a per-entry failure
-   * counter is incremented and the token locks out after
-   * MAX_TOKEN_FAILURES attempts.
-   *
-   * Prior behavior cleared the token on first check regardless of outcome,
-   * which let any unauthenticated POST with a known callId (e.g. one
-   * leaked via a webhook target or /approvals reader) DoS every queued
-   * approval by spraying garbage tokens. Closes that hole while preserving
-   * the brute-force defense (5 attempts × 256-bit keyspace).
+   * subsequent legitimate POST still works.
    *
    * Uses timing-safe comparison.
    */

--- a/src/connectors/baseConnector.ts
+++ b/src/connectors/baseConnector.ts
@@ -417,10 +417,10 @@ export abstract class BaseConnector {
     // Clamp + sanitize header-derived values: a buggy or malicious provider
     // returning `Retry-After: 9999999999` overflows setTimeout's 32-bit
     // delay (and the int*1000 silently); a NaN result poisons backoff math
-    // for every subsequent call. Cap at 10 minutes — enough for any
-    // legitimate rate-limit window, short enough that a wedged connector
-    // recovers within a single ops cycle.
-    const MAX_BACKOFF_MS = 10 * 60 * 1000;
+    // for every subsequent call. Cap at 1 hour — covers documented IdP
+    // lockout windows (Okta, Azure AD) and PagerDuty/Asana sustained-outage
+    // backoff while still bounding pathological values.
+    const MAX_BACKOFF_MS = 60 * 60 * 1000;
     const clampNonNegative = (n: number, max: number): number => {
       if (!Number.isFinite(n) || n < 0) return 0;
       return Math.min(n, max);

--- a/src/drivers/gemini/index.ts
+++ b/src/drivers/gemini/index.ts
@@ -81,10 +81,15 @@ export class GeminiSubprocessDriver implements ProviderDriver {
   ) {}
 
   async run(input: ProviderTaskInput): Promise<ProviderTaskResult> {
-    // If we're going to mutate ~/.gemini/settings.json, wait for any prior
-    // Gemini run holding the same file to finish first. This is a no-op when
-    // bridgeMcp is unset (no settings injection → no race).
-    if (this.bridgeMcp?.()) {
+    // Resolve bridgeMcp ONCE per run() and pass the result down. The
+    // closure may be cheap today, but calling it twice (once at the lock
+    // gate, once inside _runLocked) opens a TOCTOU window: if the value
+    // ever flips falsy→truthy between the two calls, the gate skips the
+    // mutex but _runLocked writes settings.json without a lock.
+    const mcp = this.bridgeMcp?.();
+    if (mcp) {
+      // If we're going to mutate ~/.gemini/settings.json, wait for any prior
+      // Gemini run holding the same file to finish first.
       const prior = GeminiSubprocessDriver.settingsMutex;
       let releaseLock!: () => void;
       const ourLock = new Promise<void>((resolve) => {
@@ -93,16 +98,18 @@ export class GeminiSubprocessDriver implements ProviderDriver {
       GeminiSubprocessDriver.settingsMutex = ourLock;
       try {
         await prior;
-        return await this._runLocked(input);
+        return await this._runLocked(input, mcp);
       } finally {
         releaseLock();
       }
     }
-    return this._runLocked(input);
+    // No mcp injection → no settings file write → no mutex needed.
+    return this._runLocked(input, undefined);
   }
 
   private async _runLocked(
     input: ProviderTaskInput,
+    mcp: { url: string; authToken: string } | undefined,
   ): Promise<ProviderTaskResult> {
     const opts = input.providerOptions ?? {};
     const approvalMode =
@@ -118,7 +125,6 @@ export class GeminiSubprocessDriver implements ProviderDriver {
     // bridge may be bound 0.0.0.0 with a public --issuer-url, but the local
     // child should always dial loopback so neither the URL nor the token
     // ever leave this machine.
-    const mcp = this.bridgeMcp?.();
     let settingsCleanup: (() => void) | null = null;
     if (mcp) {
       const settingsFile = join(homedir(), ".gemini", "settings.json");

--- a/src/server.ts
+++ b/src/server.ts
@@ -1001,14 +1001,15 @@ export class Server extends EventEmitter<ServerEvents> {
           if (existing.length > Server.MAX_WEBHOOK_PAYLOADS) {
             existing.length = Server.MAX_WEBHOOK_PAYLOADS;
           }
-          // Evict the oldest recipe entry if we'd exceed the key cap on
-          // insertion. Map iteration is insertion order, so .keys().next()
-          // returns the oldest. Skip eviction when the path is already in
-          // the Map (re-keying same path doesn't grow size).
-          if (
-            !this.webhookPayloads.has(hookPath) &&
-            this.webhookPayloads.size >= Server.MAX_WEBHOOK_RECIPES
-          ) {
+          // LRU eviction: Map.set() on an existing key keeps original
+          // insertion-order position (per spec), so a hot recipe registered
+          // at startup would otherwise be evicted in favor of a cold
+          // scanner-spam recipe just because it was registered earlier.
+          // Delete + re-set re-anchors the key to the END of insertion
+          // order, making `.keys().next()` correctly point at the
+          // least-recently-fired recipe.
+          this.webhookPayloads.delete(hookPath);
+          if (this.webhookPayloads.size >= Server.MAX_WEBHOOK_RECIPES) {
             const oldest = this.webhookPayloads.keys().next().value;
             if (oldest !== undefined) this.webhookPayloads.delete(oldest);
           }


### PR DESCRIPTION
## Summary

Four small follow-ups identified by post-merge audit of waves 5–8.

| Fix | File | Why |
|-----|------|-----|
| Bump \`MAX_TOKEN_FAILURES\` 5 → 1000 | \`src/approvalQueue.ts\` | The 5-cap added in #376 enabled its OWN DoS — attacker burns 4, legit approver typos once → locked out. Cap was always theatre (256-bit token entropy moots brute-force). |
| Cache \`bridgeMcp()\` result, single-call | \`src/drivers/gemini/index.ts\` | TOCTOU: closure called twice (gate + inner). If value flips falsy→truthy, lock is skipped but settings.json gets written. |
| \`Retry-After\` cap 10m → 1h | \`src/connectors/baseConnector.ts\` | 10m too tight for documented Okta/Azure AD/PagerDuty lockout windows. |
| \`webhookPayloads\` eviction LRU not FIFO-by-creation | \`src/server.ts\` | Map.set() on existing key keeps original position; hot startup-registered recipes were evicted for cold scanner-spam recipes. Delete+re-set fixes insertion-order to track LRU-by-fire. |

## Test plan

- [x] All 29 approval-queue tests pass; the renamed lockout test asserts 100 wrong attempts still leave the legit token usable
- [x] All 12 gemini tests pass (sequential semantics unchanged)
- [x] All 13 baseConnector tests pass
- [x] \`npm run typecheck\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)