### PR TITLE
fix(approval): per-IP rate limit on phone-path /approve + /reject

### DIFF
--- a/src/__tests__/server-approval-rate-limit.test.ts
+++ b/src/__tests__/server-approval-rate-limit.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Per-IP rate limit on the unauthenticated phone-path approval endpoints
+ * (`POST /approve/:callId` + `POST /reject/:callId` when `x-approval-token`
+ * is present). The auth gate intentionally bypasses bearer auth for this
+ * surface so a phone can dispatch without a bridge token; the limiter
+ * defends against an attacker spraying garbage tokens to DoS the legit
+ * approver via the per-callId failure cap.
+ *
+ * Follow-up to PR #380 (which bumped per-callId failure cap to 1000 to
+ * close the cap-as-DoS loophole) per its commit-message commitment to
+ * land HTTP-layer spray defense.
+ */
+
+import http from "node:http";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { Logger } from "../logger.js";
+import { Server } from "../server.js";
+
+const logger = new Logger(false);
+const TOKEN = "test-token-approval-rl-1234567890ab";
+const FAKE_APPROVAL_TOKEN = "deadbeef".repeat(8); // 64 hex chars
+
+let server: Server | null = null;
+let port: number;
+
+beforeEach(async () => {
+  server = new Server(TOKEN, logger);
+  port = await server.findAndListen(null);
+});
+
+afterEach(async () => {
+  await server?.close();
+  server = null;
+});
+
+/** POST /approve/<callId> with x-approval-token header (the phone-path bypass). */
+async function postApprove(
+  p: number,
+  callId: string,
+): Promise<{ status: number }> {
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      {
+        hostname: "127.0.0.1",
+        port: p,
+        path: `/approve/${callId}`,
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-approval-token": FAKE_APPROVAL_TOKEN,
+        },
+      },
+      (res) => {
+        res.on("data", () => {});
+        res.on("end", () => resolve({ status: res.statusCode ?? 0 }));
+      },
+    );
+    req.on("error", reject);
+    req.end("{}");
+  });
+}
+
+/** POST /approve/<callId> WITH valid bearer (rate-limit must not gate this path). */
+async function postApproveAsAuthed(
+  p: number,
+  callId: string,
+): Promise<{ status: number }> {
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      {
+        hostname: "127.0.0.1",
+        port: p,
+        path: `/approve/${callId}`,
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${TOKEN}`,
+        },
+      },
+      (res) => {
+        res.on("data", () => {});
+        res.on("end", () => resolve({ status: res.statusCode ?? 0 }));
+      },
+    );
+    req.on("error", reject);
+    req.end("{}");
+  });
+}
+
+describe("phone-path approval per-IP rate limit", () => {
+  it("rejects with 429 after APPROVAL_IP_MAX wrong-token POSTs from one IP", async () => {
+    // First MAX requests pass through the limiter. Without a queue dispatch
+    // wired they'll 404 (no such callId) — that's fine; we're testing the
+    // limiter, not the queue. The (MAX+1)th gets 429.
+    const max = Server.APPROVAL_IP_MAX;
+    let rejected429 = 0;
+    let other = 0;
+    for (let i = 0; i < max + 5; i++) {
+      const res = await postApprove(port, `callid-${i}`);
+      if (res.status === 429) rejected429++;
+      else other++;
+    }
+    expect(rejected429).toBeGreaterThanOrEqual(5);
+    expect(other).toBeLessThanOrEqual(max);
+  });
+
+  it("authenticated bearer requests are NOT rate-limited", async () => {
+    // Sanity: the limiter only fires on the bypass surface. A caller with a
+    // valid bearer should be unaffected.
+    const max = Server.APPROVAL_IP_MAX;
+    for (let i = 0; i < max + 10; i++) {
+      const res = await postApproveAsAuthed(port, `callid-${i}`);
+      // 404 (no such callId) is the expected dispatch outcome — what
+      // matters is that NONE of them are 429.
+      expect(res.status).not.toBe(429);
+    }
+  });
+
+  it("does not gate non-approval paths even when phone-path bypass shape is otherwise present", async () => {
+    // Sanity: a POST to /approve/* WITHOUT x-approval-token is NOT a
+    // phone-path bypass — it falls back to bearer auth and 401s. The
+    // limiter must not fire on that surface (would cause weird interactions
+    // with the bearer path).
+    const url = (i: number): http.RequestOptions => ({
+      hostname: "127.0.0.1",
+      port,
+      path: `/approve/no-token-${i}`,
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+    });
+    const post = (i: number): Promise<number> =>
+      new Promise((resolve, reject) => {
+        const req = http.request(url(i), (res) => {
+          res.on("data", () => {});
+          res.on("end", () => resolve(res.statusCode ?? 0));
+        });
+        req.on("error", reject);
+        req.end("{}");
+      });
+    // Spray > MAX without the x-approval-token header. None should be 429.
+    for (let i = 0; i < Server.APPROVAL_IP_MAX + 5; i++) {
+      const code = await post(i);
+      expect(code).toBe(401);
+    }
+  });
+});

--- a/src/server.ts
+++ b/src/server.ts
@@ -320,6 +320,29 @@ export class Server extends EventEmitter<ServerEvents> {
    * insertion order in JS), not the largest list.
    */
   static readonly MAX_WEBHOOK_RECIPES = 1000;
+  /**
+   * Per-IP rate limit on the unauthenticated phone-path approval endpoints
+   * (`POST /approve/:callId` and `POST /reject/:callId` when
+   * `x-approval-token` is present). The auth gate intentionally bypasses
+   * bearer auth for those paths so a phone can dispatch without a bridge
+   * token; without rate limiting, an attacker who learns a callId (via
+   * webhook target leak, bearer-authed `/approvals` reader, etc.) can
+   * spray garbage tokens to DoS the legitimate approver. PR #380 bumped
+   * the per-callId failure cap to 1000 (memory bound, not security
+   * bound); this is the HTTP-layer spray defense flagged as the proper
+   * fix in that commit.
+   *
+   * 60 attempts per IP per minute is generous for legitimate retries
+   * (phone re-tap, network flake) and tight enough to bound brute-force
+   * attempts during the 5-minute approval TTL to 300 — well within the
+   * per-callId cap, so no legit retry budget is consumed by sprayers.
+   */
+  private readonly approvalIpCounts = new Map<
+    string,
+    { count: number; windowStart: number }
+  >();
+  static readonly APPROVAL_IP_MAX = 60;
+  static readonly APPROVAL_IP_WINDOW_MS = 60_000;
   /** Set by bridge to handle MCP Streamable HTTP sessions (POST/GET/DELETE /mcp) */
   public httpMcpHandler:
     | ((req: http.IncomingMessage, res: http.ServerResponse) => Promise<void>)
@@ -626,6 +649,42 @@ export class Server extends EventEmitter<ServerEvents> {
         req.method === "POST" &&
         /^\/(approve|reject)\/[A-Za-z0-9-]+$/.test(parsedUrl.pathname) &&
         !!req.headers["x-approval-token"];
+      // Rate-limit the phone bypass surface. Only applies when this is
+      // actually a phone-path request that's relying on the bypass — a
+      // properly-authenticated bearer caller is unaffected. Counted +
+      // checked *before* dispatch so a sprayer can't burn the per-callId
+      // failure budget at line-rate.
+      if (isPhoneApprovalPath && !isStaticToken && !oauthResolved) {
+        const remoteIp = (req.socket?.remoteAddress ?? "unknown").slice(0, 64);
+        const now = Date.now();
+        const entry = this.approvalIpCounts.get(remoteIp);
+        if (entry && now - entry.windowStart < Server.APPROVAL_IP_WINDOW_MS) {
+          entry.count++;
+          if (entry.count > Server.APPROVAL_IP_MAX) {
+            res.writeHead(429, { "Content-Type": "application/json" });
+            res.end(
+              JSON.stringify({
+                error: "too_many_requests",
+                error_description:
+                  "per-IP approval endpoint rate limit reached",
+              }),
+            );
+            return;
+          }
+        } else {
+          this.approvalIpCounts.set(remoteIp, { count: 1, windowStart: now });
+        }
+        // GC stale entries opportunistically — bounded growth alongside
+        // the same Map. 200 is well above any legitimate concurrent IP
+        // count; well below memory pressure.
+        if (this.approvalIpCounts.size > 200) {
+          for (const [k, v] of this.approvalIpCounts) {
+            if (now - v.windowStart > Server.APPROVAL_IP_WINDOW_MS) {
+              this.approvalIpCounts.delete(k);
+            }
+          }
+        }
+      }
       // oauthResolved is the bridge token if the OAuth token is valid; null otherwise
       if (!isStaticToken && !oauthResolved && !isPhoneApprovalPath) {
         // RFC 6750: only include error= when a token was actually presented but invalid


### PR DESCRIPTION
## Summary

PR #380's commit message flagged HTTP-layer spray defense as the proper follow-up to bumping the per-callId failure cap. This PR lands it.

The phone-path bypass at \`server.ts:625\` lets \`POST /approve/:callId\` and \`POST /reject/:callId\` through without a bearer token (so a phone can dispatch). #380 raised the per-callId failure cap to 1000 to remove the cap-as-DoS loophole, but the underlying spray surface remained — an attacker could still hammer the endpoint at line-rate.

## Fix

- Per-IP request counter, **60 attempts/min/IP**, scoped to ONLY the phone-path bypass (authenticated bearer requests unaffected).
- Mirrors the existing \`/oauth/token\` + \`/oauth/register\` limiter shape (PR #374).
- Bounds attacker spray during the 5-min approval TTL to 300 — well within the per-callId cap, so legitimate retry budget is preserved.
- Opportunistic GC when the Map grows past 200 distinct IPs.

## Test plan

- [x] New: 429 fires after \`APPROVAL_IP_MAX + 1\` phone-path POSTs from one IP
- [x] New: authenticated bearer requests are NOT rate-limited (sanity)
- [x] New: non-phone-path POSTs (no \`x-approval-token\`) bypass the limiter and fall back to bearer auth (sanity — limiter scope check)
- [x] Full suite: 5099/5099 pass (was 5096; +3 new tests)
- [x] \`npm run typecheck\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)