### PR TITLE
fix(approval): HTTPS-validate pushServiceBaseUrl + trust-proxy IP bucketing

### DIFF
--- a/src/__tests__/server-approval-rate-limit.test.ts
+++ b/src/__tests__/server-approval-rate-limit.test.ts
@@ -37,6 +37,7 @@ afterEach(async () => {
 async function postApprove(
   p: number,
   callId: string,
+  extraHeaders: Record<string, string> = {},
 ): Promise<{ status: number }> {
   return new Promise((resolve, reject) => {
     const req = http.request(
@@ -48,6 +49,7 @@ async function postApprove(
         headers: {
           "Content-Type": "application/json",
           "x-approval-token": FAKE_APPROVAL_TOKEN,
+          ...extraHeaders,
         },
       },
       (res) => {
@@ -114,6 +116,84 @@ describe("phone-path approval per-IP rate limit", () => {
       // matters is that NONE of them are 429.
       expect(res.status).not.toBe(429);
     }
+  });
+
+  it("ignores X-Forwarded-For by default (untrusted proxy header is spoofable)", async () => {
+    // Without an explicit trustedProxies allowlist, X-Forwarded-For must
+    // NOT influence the bucket key — otherwise any sprayer rotates the
+    // header to bypass the limit. Spray > MAX from one socket-IP with
+    // distinct XFF values; at least 5 must 429.
+    const max = Server.APPROVAL_IP_MAX;
+    let rejected429 = 0;
+    for (let i = 0; i < max + 5; i++) {
+      const res = await postApprove(port, `callid-${i}`, {
+        "X-Forwarded-For": `10.${i & 0xff}.${(i >> 8) & 0xff}.1`,
+      });
+      if (res.status === 429) rejected429++;
+    }
+    expect(rejected429).toBeGreaterThanOrEqual(5);
+  });
+
+  it("honors X-Forwarded-For when the socket peer is a trusted proxy", async () => {
+    // Behind nginx/Caddy/Cloudflare every request's socket peer is the
+    // proxy itself — without this logic, a single sprayer DoSes the legit
+    // approver. With trustedProxies=["127.0.0.1"], distinct XFF clients get
+    // distinct buckets.
+    await server?.close();
+    server = new Server(TOKEN, logger, [], 30_000, ["127.0.0.1"]);
+    port = await server.findAndListen(null);
+
+    const max = Server.APPROVAL_IP_MAX;
+
+    // Spray MAX requests from "1.1.1.1" — should fill its bucket (some 429s
+    // expected on overflow if we go further, but at MAX exactly we should
+    // still be under the cap).
+    for (let i = 0; i < max; i++) {
+      const res = await postApprove(port, `a-${i}`, {
+        "X-Forwarded-For": "1.1.1.1",
+      });
+      expect(res.status).not.toBe(429);
+    }
+
+    // Now MAX requests from a different XFF — must be on an independent
+    // bucket. ZERO 429s expected.
+    for (let i = 0; i < max; i++) {
+      const res = await postApprove(port, `b-${i}`, {
+        "X-Forwarded-For": "2.2.2.2",
+      });
+      expect(res.status).not.toBe(429);
+    }
+  });
+
+  it("with trustedProxies set, rightmost untrusted XFF entry is the client", async () => {
+    // Multi-hop: client → trusted-proxy-A → trusted-proxy-B → bridge.
+    // XFF reads "client, proxy-A" (each hop appends to the right).
+    // We trust 127.0.0.1 (the immediate peer in tests). The rightmost
+    // entry NOT in trustedProxies is the client.
+    await server?.close();
+    server = new Server(TOKEN, logger, [], 30_000, ["127.0.0.1", "10.0.0.1"]);
+    port = await server.findAndListen(null);
+
+    const max = Server.APPROVAL_IP_MAX;
+
+    // Spray MAX from "client-A" via the proxy chain; should fill that
+    // single bucket if buckets are correctly keyed on client-A.
+    for (let i = 0; i < max; i++) {
+      await postApprove(port, `m-${i}`, {
+        "X-Forwarded-For": "203.0.113.5, 10.0.0.1",
+      });
+    }
+    // (max+1)th from same client → 429.
+    const overflow = await postApprove(port, "m-overflow", {
+      "X-Forwarded-For": "203.0.113.5, 10.0.0.1",
+    });
+    expect(overflow.status).toBe(429);
+
+    // But a different client through the same proxy chain → fresh bucket.
+    const fresh = await postApprove(port, "n-1", {
+      "X-Forwarded-For": "203.0.113.6, 10.0.0.1",
+    });
+    expect(fresh.status).not.toBe(429);
   });
 
   it("does not gate non-approval paths even when phone-path bypass shape is otherwise present", async () => {

--- a/src/__tests__/server-settings.test.ts
+++ b/src/__tests__/server-settings.test.ts
@@ -349,3 +349,64 @@ describe("POST /settings — driver persistence to bridge config file", () => {
     });
   });
 });
+
+describe("POST /settings — pushServiceBaseUrl HTTPS guard", () => {
+  // pushServiceBaseUrl is the bridge callback origin embedded in the SW's
+  // approveUrl/rejectUrl. If it can be set to plain http:// (or any private
+  // host the operator didn't intend), the SW will POST the one-shot
+  // approvalToken to that host. An attacker holding the dashboard bearer
+  // could redirect every future approval token to attacker.tld and replay
+  // them to the real bridge for silent auto-approve. Mirror the existing
+  // pushServiceUrl HTTPS check.
+  it("rejects http:// pushServiceBaseUrl with 400", async () => {
+    const { status, body } = await makeRequest(
+      {
+        method: "POST",
+        path: "/settings",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${TOKEN}`,
+        },
+      },
+      JSON.stringify({ pushServiceBaseUrl: "http://attacker.example.com" }),
+    );
+    expect(status).toBe(400);
+    expect(JSON.parse(body)).toMatchObject({
+      error: expect.stringContaining("HTTPS"),
+    });
+    expect(server!.pushServiceBaseUrl).toBeUndefined();
+  });
+
+  it("accepts https:// pushServiceBaseUrl and live-mutates the field", async () => {
+    const { status } = await makeRequest(
+      {
+        method: "POST",
+        path: "/settings",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${TOKEN}`,
+        },
+      },
+      JSON.stringify({ pushServiceBaseUrl: "https://bridge.example.com" }),
+    );
+    expect(status).toBe(200);
+    expect(server!.pushServiceBaseUrl).toBe("https://bridge.example.com");
+  });
+
+  it("treats empty-string pushServiceBaseUrl as a clear (no HTTPS check)", async () => {
+    server!.pushServiceBaseUrl = "https://old.example.com";
+    const { status } = await makeRequest(
+      {
+        method: "POST",
+        path: "/settings",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${TOKEN}`,
+        },
+      },
+      JSON.stringify({ pushServiceBaseUrl: "" }),
+    );
+    expect(status).toBe(200);
+    expect(server!.pushServiceBaseUrl).toBeUndefined();
+  });
+});

--- a/src/server.ts
+++ b/src/server.ts
@@ -436,6 +436,12 @@ export class Server extends EventEmitter<ServerEvents> {
     private logger: Logger,
     private extraCorsOrigins: string[] = [],
     private pingIntervalMs = 30_000,
+    // Reverse-proxy hops whose X-Forwarded-For values we trust. Empty by
+    // default — the per-IP rate limiter buckets on the direct socket peer.
+    // Behind nginx/Caddy/Cloudflare set this to the proxy's IP so distinct
+    // real clients get distinct buckets; otherwise every request looks
+    // like 127.0.0.1 and a single sprayer DoSes the legit approver.
+    private trustedProxies: string[] = [],
   ) {
     super();
     // Defense-in-depth: ensure token is non-empty so timingSafeTokenCompare
@@ -655,7 +661,20 @@ export class Server extends EventEmitter<ServerEvents> {
       // checked *before* dispatch so a sprayer can't burn the per-callId
       // failure budget at line-rate.
       if (isPhoneApprovalPath && !isStaticToken && !oauthResolved) {
-        const remoteIp = (req.socket?.remoteAddress ?? "unknown").slice(0, 64);
+        const remoteIp = this.getClientIp(req);
+        if (!remoteIp) {
+          // Fail closed — without an attributable IP we cannot bucket
+          // safely, and the original "unknown" string was a single shared
+          // counter every IP-less request rolled up into.
+          res.writeHead(400, { "Content-Type": "application/json" });
+          res.end(
+            JSON.stringify({
+              error: "bad_request",
+              error_description: "could not determine client IP",
+            }),
+          );
+          return;
+        }
         const now = Date.now();
         const entry = this.approvalIpCounts.get(remoteIp);
         if (entry && now - entry.windowStart < Server.APPROVAL_IP_WINDOW_MS) {
@@ -1537,8 +1556,21 @@ export class Server extends EventEmitter<ServerEvents> {
               this.pushServiceToken = body.pushServiceToken.trim() || undefined;
             }
             if (body.pushServiceBaseUrl !== undefined) {
-              this.pushServiceBaseUrl =
-                body.pushServiceBaseUrl.trim() || undefined;
+              const baseUrl = body.pushServiceBaseUrl.trim();
+              // pushServiceBaseUrl is the bridge callback origin embedded in
+              // the SW's approveUrl/rejectUrl. If it can be set to plain
+              // http:// or to a host the operator didn't intend, the SW will
+              // POST the one-shot approvalToken there — letting an attacker
+              // who sets this redirect every approval to attacker.tld and
+              // replay tokens to the real bridge for silent auto-approve.
+              if (baseUrl && !baseUrl.startsWith("https://")) {
+                res.writeHead(400, { "Content-Type": "application/json" });
+                res.end(
+                  JSON.stringify({ error: "pushServiceBaseUrl must be HTTPS" }),
+                );
+                return;
+              }
+              this.pushServiceBaseUrl = baseUrl || undefined;
             }
             const restartRequired =
               driverRaw !== undefined ||
@@ -1918,6 +1950,44 @@ export class Server extends EventEmitter<ServerEvents> {
         req.socket.remoteAddress;
       this.emit("connection", ws);
     });
+  }
+
+  /**
+   * Resolve the client IP for rate-limit bucketing on the phone-path
+   * approval bypass. Default: the direct socket peer. When trustedProxies
+   * is set AND the socket peer is one of them, the rightmost X-Forwarded-For
+   * entry not in the trusted list is the real client. XFF from an untrusted
+   * peer is ignored — that header is spoofable by anyone who can reach the
+   * server directly. Returns null when no IP can be determined; the caller
+   * should fail closed.
+   */
+  private getClientIp(req: http.IncomingMessage): string | null {
+    const socketIp = req.socket?.remoteAddress;
+    if (
+      socketIp &&
+      this.trustedProxies.length > 0 &&
+      this.trustedProxies.includes(socketIp)
+    ) {
+      const xffRaw = req.headers["x-forwarded-for"];
+      const xffStr = Array.isArray(xffRaw) ? xffRaw[0] : xffRaw;
+      if (typeof xffStr === "string" && xffStr.length > 0) {
+        const hops = xffStr
+          .split(",")
+          .map((s) => s.trim())
+          .filter((s): s is string => s.length > 0);
+        // Walk right→left (proxies append to the right). The rightmost hop
+        // we DON'T trust is the client; everything to its right is our own
+        // hop chain.
+        for (let i = hops.length - 1; i >= 0; i--) {
+          const hop = hops[i];
+          if (hop !== undefined && !this.trustedProxies.includes(hop)) {
+            return hop.slice(0, 64);
+          }
+        }
+        // Edge case: every hop is in trustedProxies — unusual; fall through.
+      }
+    }
+    return socketIp ? socketIp.slice(0, 64) : null;
   }
 
   async listen(port: number, bindAddress = "127.0.0.1"): Promise<number> {


### PR DESCRIPTION
## Summary

Two phone-path security gaps surfaced by a multi-agent audit (security-reviewer + ide-test-runner + general-purpose) of the mobile-oversight surface.

- **C1 — `pushServiceBaseUrl` not HTTPS-validated.** Plain http:// was accepted on POST /settings. The base URL is embedded in the SW's `approveUrl`/`rejectUrl`; an attacker holding the dashboard bearer could redirect every future approval to attacker.tld, harvest the one-shot `approvalToken`, and replay it to the real bridge for silent auto-approve. Now mirrors the existing `pushServiceUrl` HTTPS check.
- **C2 — Per-IP rate limit (PR #381) buckets on `req.socket.remoteAddress`.** Behind nginx/Caddy/Cloudflare every request looks like `127.0.0.1`, so a single sprayer DoSes the legit approver via the per-callId failure cap. New optional `trustedProxies` constructor param: when set and the socket peer matches, `getClientIp` walks `X-Forwarded-For` right→left and returns the first untrusted hop. Untrusted XFF is ignored (spoofable). Fail-closed 400 when no IP can be attributed (the old `"unknown"` fallback was a single shared bucket every IP-less request rolled up into).

Default behavior unchanged — `trustedProxies` defaults to `[]`, so reverse-proxy operators must opt in. CLI wiring (`--trust-proxy`) intentionally out of scope; follow-up.

## Test plan

- [x] `src/__tests__/server-settings.test.ts` — 3 new cases: rejects http://, accepts https://, empty string clears the field
- [x] `src/__tests__/server-approval-rate-limit.test.ts` — 3 new cases: XFF ignored without `trustedProxies` (regression guard), independent buckets per real client when peer is trusted, multi-hop XFF resolves to the rightmost untrusted hop
- [x] All written failing-first per Bug Fix Protocol; confirmed 3 of them failed before the fix and pass after
- [x] Full phone-path suite green: 105 tests across `approvalQueue.test.ts`, `approvalHttp.test.ts`, `mobileOversight.e2e.test.ts`, `approvalGate.e2e.test.ts`, `approvalMount.test.ts`, `server-approval-rate-limit.test.ts`, `server-settings.test.ts`
- [x] `npx tsc --noEmit` clean
- [x] `npx biome check` clean

## Out of scope (audit follow-ups)

Other findings from the same audit, in rough priority:
- Don't store `approvalToken` in `notification.data` (OS notification center keeps it past TTL — Android `READ_NOTIFICATIONS`, screen-share viewers)
- SW registration scope assertion + `Service-Worker-Allowed` lockdown
- Replay-table per-user caps (currently global → DoS primitive across users)
- IPv6 SSRF (current guard is IPv4-only — ULA, link-local, IPv4-mapped bypass)
- `/api/push/test` auth + rate limit (no auth today beyond `sec-fetch-site`)
- Out-of-band confirmation before evicting active devices in `RedisRegistry`

🤖 Generated with [Claude Code](https://claude.com/claude-code)