### PR TITLE
fix(approval): wire --trust-proxy through CLI/config/Bridge into Server

### DIFF
--- a/src/__tests__/bridge-activation-metrics.test.ts
+++ b/src/__tests__/bridge-activation-metrics.test.ts
@@ -117,6 +117,7 @@ function makeConfig(workspace: string): Config {
     issuerUrl: null,
     oauthTokenTtlMs: 86_400_000,
     corsOrigins: [],
+    trustedProxies: [],
     auditLogPath: null,
     fullMode: false,
     maxSessions: 5,
@@ -165,6 +166,25 @@ describe("Bridge activation metrics", () => {
       process.env.CLAUDE_CONFIG_DIR = previousClaudeConfigDir;
     }
     fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("forwards config.trustedProxies into the underlying Server constructor", async () => {
+    // Regression guard for PR #383's dead-code wiring: the constructor
+    // parameter on Server existed but bridge.ts:174 was passing only three
+    // args, so trustedProxies was always []. Reverse-proxy operators got
+    // no rate-limit fix.
+    const workspace = fs.mkdtempSync(path.join(tempDir, "workspace-tp-"));
+    const cfg = makeConfig(workspace);
+    cfg.trustedProxies = ["127.0.0.1", "10.0.0.1"];
+    const bridge = new Bridge(cfg);
+    try {
+      const proxies = (
+        bridge as unknown as { server: { trustedProxies: string[] } }
+      ).server.trustedProxies;
+      expect(proxies).toEqual(["127.0.0.1", "10.0.0.1"]);
+    } finally {
+      await bridge.stop();
+    }
   });
 
   it("records a successful YAML recipe run", async () => {

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -348,6 +348,45 @@ describe("parseConfig --db flag", () => {
   });
 });
 
+describe("parseConfig --trust-proxy flag", () => {
+  // PR #383 added a `trustedProxies` constructor parameter on Server but
+  // shipped without a CLI flag, so bridge.ts:174 was always passing the
+  // default `[]`. These tests pin the wiring: the parser must populate
+  // config.trustedProxies, which bridge.ts must then forward to Server.
+
+  it("defaults trustedProxies to []", () => {
+    expect(cfg().trustedProxies).toEqual([]);
+  });
+
+  it("collects --trust-proxy 1.1.1.1 into trustedProxies", () => {
+    expect(cfg("--trust-proxy", "127.0.0.1").trustedProxies).toEqual([
+      "127.0.0.1",
+    ]);
+  });
+
+  it("repeats: --trust-proxy can appear multiple times for multi-hop chains", () => {
+    expect(
+      cfg("--trust-proxy", "127.0.0.1", "--trust-proxy", "10.0.0.1")
+        .trustedProxies,
+    ).toEqual(["127.0.0.1", "10.0.0.1"]);
+  });
+
+  it("throws when --trust-proxy has an empty value", () => {
+    expect(() => cfg("--trust-proxy", "")).toThrow(/non-empty/);
+  });
+
+  it("env var CLAUDE_IDE_BRIDGE_TRUST_PROXY (comma-separated) overrides file/CLI", () => {
+    const prev = process.env.CLAUDE_IDE_BRIDGE_TRUST_PROXY;
+    process.env.CLAUDE_IDE_BRIDGE_TRUST_PROXY = "10.1.1.1, 10.1.1.2 ,";
+    try {
+      expect(cfg().trustedProxies).toEqual(["10.1.1.1", "10.1.1.2"]);
+    } finally {
+      if (prev === undefined) delete process.env.CLAUDE_IDE_BRIDGE_TRUST_PROXY;
+      else process.env.CLAUDE_IDE_BRIDGE_TRUST_PROXY = prev;
+    }
+  });
+});
+
 describe("parseConfig --allow-private-http flag", () => {
   it("sets allowPrivateHttp to true when --allow-private-http is set", () => {
     expect(cfg("--allow-private-http").allowPrivateHttp).toBe(true);

--- a/src/__tests__/registration-coverage.test.ts
+++ b/src/__tests__/registration-coverage.test.ts
@@ -70,6 +70,7 @@ function baseConfig(overrides: Partial<{ fullMode: boolean }> = {}) {
     fixedToken: null,
     issuerUrl: null,
     corsOrigins: [],
+    trustedProxies: [],
     auditLogPath: null,
     fullMode: true,
     maxSessions: 5,

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -171,7 +171,13 @@ export class Bridge {
     const configDir =
       process.env.CLAUDE_CONFIG_DIR ?? path.join(os.homedir(), ".claude");
     this.authToken = config.fixedToken ?? loadOrCreateBridgeToken(configDir);
-    this.server = new Server(this.authToken, this.logger, config.corsOrigins);
+    this.server = new Server(
+      this.authToken,
+      this.logger,
+      config.corsOrigins,
+      undefined,
+      config.trustedProxies,
+    );
     this.server.bridgeConfigPath = config.configFilePath ?? undefined;
     if (config.issuerUrl) {
       this.oauthServer = new OAuthServerImpl(this.authToken, config.issuerUrl, {

--- a/src/config.ts
+++ b/src/config.ts
@@ -64,6 +64,13 @@ export interface Config {
   /** Access token TTL in milliseconds (derived from oauthTokenTtlDays config; default 24h). */
   oauthTokenTtlMs: number;
   corsOrigins: string[];
+  /**
+   * IPs of trusted reverse proxies. When the immediate socket peer is one
+   * of these, the bridge honors the X-Forwarded-For header for per-IP
+   * rate-limit bucketing on the phone-path approval bypass. Empty by
+   * default; X-Forwarded-For from an untrusted peer is ignored.
+   */
+  trustedProxies: string[];
   auditLogPath: string | null;
   fullMode: boolean;
   maxSessions: number;
@@ -232,6 +239,7 @@ interface ConfigFile {
   issuerUrl?: string;
   oauthTokenTtlDays?: number;
   corsOrigins?: string[];
+  trustedProxies?: string[];
   fullMode?: boolean;
   maxSessions?: number;
   githubDefaultRepo?: string;
@@ -264,6 +272,7 @@ const KNOWN_CONFIG_FILE_KEYS = new Set<string>([
   "issuerUrl",
   "oauthTokenTtlDays",
   "corsOrigins",
+  "trustedProxies",
   "fullMode",
   "maxSessions",
   "githubDefaultRepo",
@@ -448,6 +457,7 @@ export function parseConfig(argv: string[]): Config {
       ? Math.min(Math.max(rawTtlDays, 1), 90) * 24 * 60 * 60 * 1_000
       : 24 * 60 * 60 * 1_000; // default 24h
   let corsOrigins: string[] = fileConfig.corsOrigins ?? [];
+  let trustedProxies: string[] = fileConfig.trustedProxies ?? [];
   // "driver" is the canonical field; "claudeDriver" is the deprecated alias.
   if (fileConfig.claudeDriver && !fileConfig.driver) {
     console.warn(
@@ -747,6 +757,16 @@ export function parseConfig(argv: string[]): Config {
         corsOrigins.push(origin);
         break;
       }
+      case "--trust-proxy": {
+        const ip = requireArg(args, ++i, "--trust-proxy");
+        // Accept any non-empty token; the runtime check (Server.getClientIp)
+        // does an exact-match against req.socket.remoteAddress, so the
+        // operator must match the format Node reports (e.g. IPv4
+        // "127.0.0.1" or IPv6 "::1"). Repeat the flag for multiple hops.
+        if (!ip) throw new Error("--trust-proxy requires a non-empty IP");
+        trustedProxies.push(ip);
+        break;
+      }
       case "--full":
         fullMode = true;
         break;
@@ -973,6 +993,11 @@ Environment Variables:
       (s) => s.trim(),
     );
   }
+  if (process.env.CLAUDE_IDE_BRIDGE_TRUST_PROXY) {
+    trustedProxies = process.env.CLAUDE_IDE_BRIDGE_TRUST_PROXY.split(",")
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0);
+  }
   if (process.env.CLAUDE_IDE_BRIDGE_LINTERS) {
     linters = process.env.CLAUDE_IDE_BRIDGE_LINTERS.split(",").map((s) =>
       s.trim(),
@@ -1066,6 +1091,7 @@ Environment Variables:
     issuerUrl,
     oauthTokenTtlMs,
     corsOrigins,
+    trustedProxies,
     vps,
     db,
     allowPrivateHttp,

--- a/src/tools/__tests__/slimMode.test.ts
+++ b/src/tools/__tests__/slimMode.test.ts
@@ -124,6 +124,7 @@ describe("registerAllTools tool set filtering", () => {
       fixedToken: null,
       issuerUrl: null,
       corsOrigins: [],
+      trustedProxies: [],
       auditLogPath: null,
       fullMode: false,
       maxSessions: 5,


### PR DESCRIPTION
## Summary

PR #383 added a `trustedProxies` constructor parameter on `Server` and a `getClientIp` helper that walks `X-Forwarded-For`. But `bridge.ts:174` was still calling `new Server(authToken, logger, corsOrigins)` — three args only. The 4th and 5th defaulted, so `trustedProxies` was always `[]` in production. The C2 rate-limit fix from #383 didn't actually apply for any reverse-proxy deployment.

Surfaced by audit agent A while inventorying bridge endpoints. Cited as: "PR #383 added the parameter but no caller passes a value."

## Wiring closed

- `Config.trustedProxies: string[]` (`src/config.ts`)
- `FileConfig.trustedProxies?: string[]` + entry in `KNOWN_CONFIG_FILE_KEYS`
- `--trust-proxy <ip>` CLI flag, repeatable for multi-hop chains (`src/config.ts:759`)
- `CLAUDE_IDE_BRIDGE_TRUST_PROXY` env var, comma-separated
- `bridge.ts:174` forwards `config.trustedProxies` as the 5th constructor arg (passes `undefined` for `pingIntervalMs` to keep the default)

## Test plan

- [x] 5 new `parseConfig --trust-proxy` cases — default empty, single value, repeated values, empty-string throws, env-var override
- [x] 1 new `Bridge → Server` regression guard in `bridge-activation-metrics.test.ts` — instantiates `new Bridge(makeConfig(...))` with `trustedProxies: ["127.0.0.1", "10.0.0.1"]` and asserts the private field on the underlying `Server` matches. This is the test that would have caught PR #383's gap.
- [x] 3 existing Config fixtures updated for the new required field
- [x] 95 tests pass across config + bridge + slimMode + server-approval-rate-limit
- [x] `tsc --noEmit` clean
- [x] `biome check` clean

## Operator-facing change

Reverse-proxy deployments now have a way to opt in:

```bash
patchwork start-all --bind 0.0.0.0 --trust-proxy 127.0.0.1
# or via env
CLAUDE_IDE_BRIDGE_TRUST_PROXY=127.0.0.1,10.0.0.1 patchwork start-all
```

Without the flag, behavior is unchanged: `X-Forwarded-For` is ignored as a spoofable header.

## Out of scope

Read-only display of `trustedProxies` in the dashboard `/settings` Bridge card — flagged by agent C, will land in the broader "bridge launch info card" PR alongside `bind`, `gracePeriodMs`, `tool-rate-limit`, `corsOrigins`, etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)