### PR TITLE
feat(dashboard): /api/relay/push — make the dashboard a drop-in for push-relay

### DIFF
--- a/dashboard/.env.example
+++ b/dashboard/.env.example
@@ -24,3 +24,11 @@ PUSH_RELAY_TOKEN=
 NEXT_PUBLIC_VAPID_PUBLIC_KEY=
 VAPID_PRIVATE_KEY=
 VAPID_SUBJECT=mailto:you@example.com
+
+# OPTIONAL — dashboard-as-push-relay. When set, the dashboard exposes
+# POST /api/relay/push as a drop-in for services/push-relay/. Point the
+# bridge's `pushServiceUrl` at this dashboard's URL (without /push) and
+# its `pushServiceToken` at the SAME value, and bridge-dispatched
+# approvals fan out to dashboard Web Push subscribers without a separate
+# relay process. Leave empty to disable.
+PATCHWORK_PUSH_TOKEN=

--- a/dashboard/src/app/api/relay/push/__tests__/route.test.ts
+++ b/dashboard/src/app/api/relay/push/__tests__/route.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Tests for the bridge → dashboard push relay (`POST /api/relay/push`).
+ *
+ * The dashboard acts as a drop-in for the standalone push-relay service:
+ * the bridge POSTs an approval payload here, the dashboard fans out via
+ * Web Push (VAPID) to every browser subscription. Auth is a Bearer
+ * token compared timing-safe against `PATCHWORK_PUSH_TOKEN`.
+ */
+
+import { NextRequest } from "next/server";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("web-push", () => ({
+  default: {
+    setVapidDetails: vi.fn(),
+    sendNotification: vi.fn(async () => ({ statusCode: 201 })),
+  },
+}));
+
+vi.mock("@/lib/pushStore", () => ({
+  getSubscriptions: vi.fn(() => []),
+}));
+
+import webpush from "web-push";
+import { POST } from "@/app/api/relay/push/route";
+import { getSubscriptions } from "@/lib/pushStore";
+
+const TOKEN = "relay-test-token-1234567890abcdef";
+
+const validSub = {
+  endpoint: "https://example.com/push/abc",
+  keys: { p256dh: "p256dh-key", auth: "auth-key" },
+};
+
+const validBody = {
+  callId: "call-123",
+  toolName: "Bash",
+  tier: "high",
+  approvalToken: "deadbeef".repeat(8),
+  bridgeCallbackBase: "https://bridge.example.com",
+  summary: "rm -rf /tmp/test",
+  expiresAt: Date.now() + 5 * 60_000,
+};
+
+function req(headers: Record<string, string>, body: unknown): NextRequest {
+  return new NextRequest("http://localhost:3200/api/relay/push", {
+    method: "POST",
+    headers: { "content-type": "application/json", ...headers },
+    body: JSON.stringify(body),
+  });
+}
+
+const ENV_KEYS = [
+  "PATCHWORK_PUSH_TOKEN",
+  "NEXT_PUBLIC_VAPID_PUBLIC_KEY",
+  "VAPID_PRIVATE_KEY",
+  "VAPID_SUBJECT",
+] as const;
+
+let originalEnv: Record<string, string | undefined>;
+
+beforeEach(() => {
+  originalEnv = Object.fromEntries(
+    ENV_KEYS.map((k) => [k, process.env[k]]),
+  );
+  process.env.PATCHWORK_PUSH_TOKEN = TOKEN;
+  process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY = "test-vapid-public";
+  process.env.VAPID_PRIVATE_KEY = "test-vapid-private";
+  process.env.VAPID_SUBJECT = "mailto:test@example.com";
+  vi.mocked(getSubscriptions).mockReturnValue([validSub]);
+  vi.mocked(webpush.sendNotification).mockClear();
+  vi.mocked(webpush.setVapidDetails).mockClear();
+});
+
+afterEach(() => {
+  for (const k of ENV_KEYS) {
+    if (originalEnv[k] === undefined) delete process.env[k];
+    else process.env[k] = originalEnv[k];
+  }
+});
+
+describe("POST /api/relay/push — auth", () => {
+  it("401 when Authorization header is missing", async () => {
+    const r = await POST(req({}, validBody));
+    expect(r.status).toBe(401);
+    expect(webpush.sendNotification).not.toHaveBeenCalled();
+  });
+
+  it("401 when Bearer token does not match PATCHWORK_PUSH_TOKEN", async () => {
+    const r = await POST(req({ authorization: "Bearer wrong-token" }, validBody));
+    expect(r.status).toBe(401);
+  });
+
+  it("401 when PATCHWORK_PUSH_TOKEN env var is unset (fail-closed)", async () => {
+    delete process.env.PATCHWORK_PUSH_TOKEN;
+    const r = await POST(req({ authorization: `Bearer ${TOKEN}` }, validBody));
+    expect(r.status).toBe(401);
+  });
+
+  it("401 when scheme is not Bearer", async () => {
+    const r = await POST(req({ authorization: `Basic ${TOKEN}` }, validBody));
+    expect(r.status).toBe(401);
+  });
+});
+
+describe("POST /api/relay/push — VAPID config", () => {
+  it("503 when VAPID keys are not configured", async () => {
+    delete process.env.VAPID_PRIVATE_KEY;
+    const r = await POST(req({ authorization: `Bearer ${TOKEN}` }, validBody));
+    expect(r.status).toBe(503);
+    const body = (await r.json()) as { error: string };
+    expect(body.error).toMatch(/VAPID/i);
+  });
+});
+
+describe("POST /api/relay/push — payload validation", () => {
+  it("400 when callId is missing", async () => {
+    const { callId: _, ...rest } = validBody;
+    const r = await POST(req({ authorization: `Bearer ${TOKEN}` }, rest));
+    expect(r.status).toBe(400);
+  });
+
+  it("400 when approvalToken is missing", async () => {
+    const { approvalToken: _, ...rest } = validBody;
+    const r = await POST(req({ authorization: `Bearer ${TOKEN}` }, rest));
+    expect(r.status).toBe(400);
+  });
+
+  it("400 when bridgeCallbackBase is http:// (must be HTTPS)", async () => {
+    const r = await POST(
+      req(
+        { authorization: `Bearer ${TOKEN}` },
+        { ...validBody, bridgeCallbackBase: "http://attacker.tld" },
+      ),
+    );
+    expect(r.status).toBe(400);
+    const body = (await r.json()) as { error: string };
+    expect(body.error).toMatch(/HTTPS/i);
+  });
+
+  it("400 when expiresAt is in the past", async () => {
+    const r = await POST(
+      req(
+        { authorization: `Bearer ${TOKEN}` },
+        { ...validBody, expiresAt: Date.now() - 1000 },
+      ),
+    );
+    expect(r.status).toBe(400);
+  });
+});
+
+describe("POST /api/relay/push — fan-out", () => {
+  it("404 when no subscriptions registered (informational, not an error)", async () => {
+    vi.mocked(getSubscriptions).mockReturnValue([]);
+    const r = await POST(req({ authorization: `Bearer ${TOKEN}` }, validBody));
+    expect(r.status).toBe(404);
+    expect(webpush.sendNotification).not.toHaveBeenCalled();
+  });
+
+  it("200 + per-subscription fan-out, sent count reflects fulfilled deliveries", async () => {
+    const subs = [
+      validSub,
+      { endpoint: "https://e2.com/p", keys: { p256dh: "k1", auth: "k2" } },
+      { endpoint: "https://e3.com/p", keys: { p256dh: "k3", auth: "k4" } },
+    ];
+    vi.mocked(getSubscriptions).mockReturnValue(subs);
+    // Make the 2nd subscription fail — sent should be 2/3.
+    vi.mocked(webpush.sendNotification).mockImplementation(async (sub) => {
+      if (sub.endpoint === subs[1].endpoint) throw new Error("410 gone");
+      return { statusCode: 201, body: "", headers: {} };
+    });
+
+    const r = await POST(req({ authorization: `Bearer ${TOKEN}` }, validBody));
+    expect(r.status).toBe(200);
+    expect(webpush.sendNotification).toHaveBeenCalledTimes(3);
+    const body = (await r.json()) as { ok: boolean; sent: number; total: number };
+    expect(body).toEqual({ ok: true, sent: 2, total: 3 });
+  });
+
+  it("forwarded payload includes computed approveUrl/rejectUrl from bridgeCallbackBase", async () => {
+    await POST(req({ authorization: `Bearer ${TOKEN}` }, validBody));
+    expect(webpush.sendNotification).toHaveBeenCalledOnce();
+    const [, payloadStr] = vi.mocked(webpush.sendNotification).mock.calls[0]!;
+    const payload = JSON.parse(payloadStr as string) as {
+      approveUrl: string;
+      rejectUrl: string;
+      approvalToken: string;
+      callId: string;
+    };
+    expect(payload.approveUrl).toBe("https://bridge.example.com/approve/call-123");
+    expect(payload.rejectUrl).toBe("https://bridge.example.com/reject/call-123");
+    expect(payload.approvalToken).toBe(validBody.approvalToken);
+    expect(payload.callId).toBe(validBody.callId);
+  });
+
+  it("trailing slash on bridgeCallbackBase does not produce //approve/...", async () => {
+    await POST(
+      req(
+        { authorization: `Bearer ${TOKEN}` },
+        { ...validBody, bridgeCallbackBase: "https://bridge.example.com/" },
+      ),
+    );
+    const [, payloadStr] = vi.mocked(webpush.sendNotification).mock.calls[0]!;
+    const payload = JSON.parse(payloadStr as string) as { approveUrl: string };
+    expect(payload.approveUrl).toBe("https://bridge.example.com/approve/call-123");
+  });
+});

--- a/dashboard/src/app/api/relay/push/route.ts
+++ b/dashboard/src/app/api/relay/push/route.ts
@@ -1,0 +1,161 @@
+import crypto from "node:crypto";
+import { NextResponse } from "next/server";
+import webpush from "web-push";
+import { getSubscriptions } from "@/lib/pushStore";
+import {
+  DASHBOARD_API_BODY_CAPS,
+  bodyTooLargeResponse,
+  readJsonWithCap,
+} from "@/lib/readBodyWithCap";
+
+/**
+ * Bridge → dashboard push relay.
+ *
+ * The bridge POSTs here when an approval is queued, the same way it would
+ * POST to a hosted FCM/APNS push-relay service (`services/push-relay/`).
+ * Wire-shape matches that service so an operator can point
+ * `pushServiceUrl` at this dashboard's URL instead of running a separate
+ * relay process. Fan-out is via Web Push (VAPID) to every browser
+ * subscription stored in `~/.claude/patchwork-push-subscriptions.json`.
+ *
+ * Auth: Bearer token compared timing-safe against `PATCHWORK_PUSH_TOKEN`.
+ * The operator sets this env var on the dashboard AND configures the
+ * bridge with the same value via `pushServiceToken`.
+ *
+ * Replay protection is intentionally NOT implemented here (v1). A
+ * replayed push only re-fires a notification — the SW still validates the
+ * one-shot `approvalToken` against the bridge, so a replay can't
+ * double-approve. The push-relay service implements replay defense for
+ * a different reason (per-user device flooding); we'd add it here later.
+ */
+
+// Env vars are read at REQUEST time (not module load) so test setup and
+// dev-server HMR pick up changes without a process restart.
+function readVapidConfig(): {
+  publicKey: string;
+  privateKey: string;
+  subject: string;
+} {
+  return {
+    publicKey: process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY ?? "",
+    privateKey: process.env.VAPID_PRIVATE_KEY ?? "",
+    subject: process.env.VAPID_SUBJECT ?? "mailto:admin@example.com",
+  };
+}
+
+interface RelayPushBody {
+  callId?: string;
+  toolName?: string;
+  tier?: string;
+  summary?: string;
+  riskSignals?: unknown;
+  approvalToken?: string;
+  bridgeCallbackBase?: string;
+  requestedAt?: number;
+  expiresAt?: number;
+}
+
+function unauthorized(): NextResponse {
+  return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+}
+
+function verifyBearer(req: Request): boolean {
+  const expected = process.env.PATCHWORK_PUSH_TOKEN ?? "";
+  if (!expected) return false;
+  const header = req.headers.get("authorization") ?? "";
+  if (!header.startsWith("Bearer ")) return false;
+  const presented = header.slice(7);
+  if (presented.length !== expected.length) return false;
+  try {
+    return crypto.timingSafeEqual(
+      Buffer.from(presented, "utf8"),
+      Buffer.from(expected, "utf8"),
+    );
+  } catch {
+    return false;
+  }
+}
+
+export async function POST(req: Request) {
+  if (!verifyBearer(req)) return unauthorized();
+
+  const vapid = readVapidConfig();
+  if (!vapid.publicKey || !vapid.privateKey) {
+    return NextResponse.json(
+      { error: "VAPID keys not configured" },
+      { status: 503 },
+    );
+  }
+
+  const parsed = await readJsonWithCap<RelayPushBody>(
+    req,
+    DASHBOARD_API_BODY_CAPS.relayPush,
+  );
+  if (!parsed.ok) {
+    if (parsed.reason === "too_large")
+      return bodyTooLargeResponse(parsed.maxBytes);
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+  const body = parsed.value;
+
+  const { callId, toolName, tier, approvalToken, bridgeCallbackBase } = body;
+  if (!callId || !toolName || !tier || !approvalToken) {
+    return NextResponse.json(
+      {
+        error:
+          "missing required fields: callId, toolName, tier, approvalToken",
+      },
+      { status: 400 },
+    );
+  }
+  if (!bridgeCallbackBase || !bridgeCallbackBase.startsWith("https://")) {
+    return NextResponse.json(
+      { error: "bridgeCallbackBase must be HTTPS" },
+      { status: 400 },
+    );
+  }
+
+  const now = Date.now();
+  if (typeof body.expiresAt === "number" && body.expiresAt < now) {
+    return NextResponse.json(
+      { error: "payload already expired" },
+      { status: 400 },
+    );
+  }
+
+  const subs = getSubscriptions();
+  if (subs.length === 0) {
+    // Bridge fires fire-and-forget so this 404 is informational only —
+    // the ok:false form lets curl-based debugging see the empty state.
+    return NextResponse.json(
+      { ok: false, sent: 0, total: 0, error: "no subscriptions" },
+      { status: 404 },
+    );
+  }
+
+  // Construct the payload the SW expects. URL-construct (don't concat) so
+  // a trailing slash on bridgeCallbackBase doesn't double up.
+  const approveUrl = new URL(`/approve/${callId}`, bridgeCallbackBase).toString();
+  const rejectUrl = new URL(`/reject/${callId}`, bridgeCallbackBase).toString();
+
+  const payload = JSON.stringify({
+    callId,
+    toolName,
+    tier,
+    summary: body.summary,
+    requestedAt: body.requestedAt ?? now,
+    expiresAt: body.expiresAt ?? now + 5 * 60_000,
+    approvalToken,
+    approveUrl,
+    rejectUrl,
+  });
+
+  webpush.setVapidDetails(vapid.subject, vapid.publicKey, vapid.privateKey);
+
+  const results = await Promise.allSettled(
+    subs.map((sub) => webpush.sendNotification(sub, payload)),
+  );
+  const sent = results.filter((r) => r.status === "fulfilled").length;
+
+  return NextResponse.json({ ok: true, sent, total: subs.length });
+}

--- a/dashboard/src/lib/readBodyWithCap.ts
+++ b/dashboard/src/lib/readBodyWithCap.ts
@@ -56,6 +56,8 @@ export const DASHBOARD_API_BODY_CAPS = {
   connectorRequest: 16 * 1024,
   /** /api/push/{subscribe,unsubscribe} — PushSubscription JSON; spec is ~2 KB but allow headroom. */
   push: 16 * 1024,
+  /** /api/relay/push — bridge → dashboard relay (callId/toolName/tier/approvalToken/bridgeCallbackBase + optional summary, riskSignals). 8 KB is generous. */
+  relayPush: 8 * 1024,
   /** /api/connections/[connector]/connect — OAuth start: redirect target + provider state. */
   connectionsConnect: 32 * 1024,
 } as const;


### PR DESCRIPTION
## Summary

The audit thread surfaced that today's mobile-oversight L4 dogfood is incomplete: even with the Mobile section landed (#384), VAPID keys configured, and a phone subscribed, the **real approval flow** never fires a push because the bridge dispatches to a separate `services/push-relay/` process (FCM/APNS) that nobody has running locally. So you'd get a "Send test notification" ping and nothing else.

This PR closes that gap with a single dashboard route: `POST /api/relay/push`. The bridge POSTs here with the **same wire-shape** it would use for the standalone push-relay; the dashboard fans out via Web Push to every browser subscription. No new bridge code, no relay process, no FCM/APNS setup — just point the bridge's `pushServiceUrl` at the dashboard.

## Operator wiring

```bash
# dashboard/.env.local
PATCHWORK_PUSH_TOKEN=<random uuid>
NEXT_PUBLIC_VAPID_PUBLIC_KEY=<from npx web-push generate-vapid-keys>
VAPID_PRIVATE_KEY=<same>
VAPID_SUBJECT=mailto:you@example.com

# Then via dashboard /settings (or curl POST /settings on the bridge):
{
  "pushServiceUrl":     "https://<your-dashboard>/dashboard/api/relay",
  "pushServiceToken":   "<same PATCHWORK_PUSH_TOKEN as above>",
  "pushServiceBaseUrl": "https://<your-bridge-callback-origin>"
}
```

The bridge appends `/push` to `pushServiceUrl`, so the route lives at `/api/relay/push` and the configured value is `…/api/relay`.

## Wire-shape compatibility with services/push-relay

| Behavior | push-relay (services/) | this PR |
|---|---|---|
| Auth scheme | `Bearer <token>` | `Bearer <token>` |
| Token check | timingSafeEqual against EnvTokenStore | timingSafeEqual against `PATCHWORK_PUSH_TOKEN` |
| Required fields | callId, toolName, tier, approvalToken | same |
| HTTPS-required `bridgeCallbackBase` | yes | yes (rejects http:// with 400) |
| Expired-payload reject | yes | yes (400) |
| Replay defense | per-(callId,token), 15-min window | **not in v1** — see "Out of scope" |
| Empty registry | 404 informational | 404 informational |

A fully drop-in replacement for the dogfood / single-user case. Multi-tenant FCM/APNS still belongs in the standalone service.

## Test plan

- [x] 13 new tests covering auth (4), VAPID-unset (1), validation (4), fan-out (4) — `src/app/api/relay/push/__tests__/route.test.ts`
- [x] 322 dashboard tests pass overall (was 309 — no regressions)
- [x] `tsc --noEmit` clean
- [x] `tokens:check` + `lint:inline-fontsize` ratchets unchanged
- [x] Test caught a real bug during dev — module-level `process.env` reads were stale; fixed by reading at request time (also makes Next.js HMR pick up env changes without a restart)

## Out of scope (deliberate, with reasoning)

- **Replay protection** — a replayed push only re-fires a notification. The SW still validates the one-shot `approvalToken` against the bridge's `validateToken()` (single-use, cleared after first call). Replays cannot double-approve. The standalone push-relay implements replay defense for a different reason (per-user device flooding); a v2 of this route can mirror that with a per-(callId, token) table.
- **Per-user fan-out** — this PR fans out to ALL stored subscriptions, matching the behavior of dashboard `/api/push/test`. Multi-user `userId` partitioning belongs in the standalone relay, not here.
- **Replacing the standalone push-relay** — both can coexist. Native FCM/APNS to non-PWA devices still needs the relay.

## Dogfood now possible

With this route + #384 (Mobile section UI) + an SSH reverse tunnel from your laptop to `bridge.example.com`, the full L4 flow works end-to-end on a phone:

1. PWA installed once, persistent VAPID subscription
2. Trigger any high-tier tool from a Claude Code session connected to the bridge
3. Bridge → `dispatchPushNotification` → this route → web-push → SW → notification on the phone
4. Tap **Approve** → SW POSTs `x-approval-token` to the bridge → tool unblocks, no PWA open required

🤖 Generated with [Claude Code](https://claude.com/claude-code)
