### PR TITLE
fix(dashboard): pre-paint theme script eliminates paper-theme flash on refresh

### DIFF
--- a/dashboard/src/app/layout.tsx
+++ b/dashboard/src/app/layout.tsx
@@ -85,6 +85,14 @@ export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en" className={`${albertSans.variable} ${instrumentSerif.variable} ${jetbrainsMono.variable}`}>
       <head>
+        {/* Blocking inline script: set data-theme before first paint to
+            prevent the paper-theme flash on refresh. Must stay in sync
+            with normalizeTheme/useTheme in components/Shell.tsx. */}
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `(function(){try{var v=localStorage.getItem('patchwork.theme')||localStorage.getItem('pw-theme');var t=(v==='paper'||v==='light')?'paper':'dark';document.documentElement.setAttribute('data-theme',t);}catch(e){document.documentElement.setAttribute('data-theme','dark');}})();`,
+          }}
+        />
         <meta name="theme-color" content="#faf7f2" media="(prefers-color-scheme: light)" />
         <meta name="theme-color" content="#0d0c0b" media="(prefers-color-scheme: dark)" />
         <meta name="mobile-web-app-capable" content="yes" />


### PR DESCRIPTION
## Summary

- `useTheme` (in `Shell.tsx`) applies `data-theme` inside `useEffect`, so SSR ships HTML with no theme attribute and the `:root` paper defaults paint until hydration runs. On dark-theme users this manifests as a brief paper flash on every page refresh.
- Add a tiny blocking inline script in `<head>` that reads the same localStorage keys (`patchwork.theme`, with `pw-theme` fallback) and sets `data-theme` on `<html>` before first paint. Falls back to `dark` if storage is unavailable.
- Kept in sync with `normalizeTheme` in `components/Shell.tsx` — `paper`/`light` → `paper`, anything else → `dark`. Comment in the file flags the coupling.

## Test plan

- [ ] Hard refresh `/dashboard` on dark theme — no paper flash
- [ ] Toggle to paper theme, refresh — no dark flash
- [ ] Clear localStorage + refresh — defaults to dark, no flash
- [ ] Disable JS in DevTools + reload — defaults to dark (script no-ops, `:root` paper still applies; acceptable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)