### PR TITLE
fix(dashboard): focus-trap mobile drawer + More sheet

### DIFF
--- a/dashboard/src/components/MobileBottomNav.tsx
+++ b/dashboard/src/components/MobileBottomNav.tsx
@@ -1,7 +1,8 @@
 "use client";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
+import { useFocusTrap } from "@/lib/useFocusTrap";
 
 interface BottomNavItem {
   href: string;
@@ -39,21 +40,25 @@ const MORE_ICON = "M12 6h.01M12 12h.01M12 18h.01";
 export function MobileBottomNav() {
   const pathname = usePathname() ?? "/";
   const [sheetOpen, setSheetOpen] = useState(false);
+  const sheetRef = useRef<HTMLDivElement | null>(null);
 
   // Close on route change
   useEffect(() => {
     setSheetOpen(false);
   }, [pathname]);
 
-  // Close on Escape
-  useEffect(() => {
-    if (!sheetOpen) return;
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setSheetOpen(false);
-    };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [sheetOpen]);
+  // Sheet focus trap: lock body scroll, inert the rest of the app
+  // (main content, header, sidebar, bottom-nav) so Tab and screen-
+  // reader navigation stay inside the sheet, close on Escape.
+  // Pointer events on the bottom-nav still work, so a second tap on
+  // "More" still closes the sheet — inert affects keyboard + AT only.
+  useFocusTrap({
+    open: sheetOpen,
+    onClose: () => setSheetOpen(false),
+    containerRef: sheetRef,
+    inertSelector:
+      "main, .app-header, .app-sidebar, .mobile-bottom-nav",
+  });
 
   const moreActive = MORE_LINKS.some((l) => pathname.startsWith(l.href));
 
@@ -121,11 +126,13 @@ export function MobileBottomNav() {
             onClick={() => setSheetOpen(false)}
           />
           <div
+            ref={sheetRef}
             id="mobile-more-sheet"
             className="mobile-more-sheet"
             role="dialog"
             aria-modal="true"
             aria-label="More navigation"
+            tabIndex={-1}
           >
             <div className="mobile-more-sheet-handle" aria-hidden="true" />
             <div className="mobile-more-sheet-grid">

--- a/dashboard/src/components/Shell.tsx
+++ b/dashboard/src/components/Shell.tsx
@@ -2,10 +2,11 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import type { ReactNode } from "react";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { apiPath } from "@/lib/api";
 import { useBridgeStatus, type BridgeStatus } from "@/hooks/useBridgeStatus";
 import { isDemoMode, onDemoModeChange, setDemoMode } from "@/lib/demoMode";
+import { useFocusTrap } from "@/lib/useFocusTrap";
 import { CardGlow } from "./CardGlow";
 import { CommandPalette } from "./CommandPalette";
 
@@ -237,11 +238,23 @@ export function Shell({ children }: { children: ReactNode }) {
   // Demo: replace with real notification count when available
   const hasNotifications = approvalCount > 0;
   const [paletteOpen, setPaletteOpen] = useState(false);
+  const drawerRef = useRef<HTMLElement | null>(null);
 
   useEffect(() => {
     setMobileOpen(false);
     setPaletteOpen(false);
   }, [pathname]);
+
+  // Drawer focus trap: lock body scroll, mark non-drawer regions inert,
+  // cycle Tab inside the drawer, close on Escape. Selector excludes the
+  // drawer itself (`.app-sidebar`) and its scrim (`.mobile-scrim`) so
+  // both remain interactive while the rest of the app goes inert.
+  useFocusTrap({
+    open: mobileOpen,
+    onClose: () => setMobileOpen(false),
+    containerRef: drawerRef,
+    inertSelector: "main, .app-header, .mobile-bottom-nav",
+  });
 
   // Global ⌘K / Ctrl+K hotkey
   useEffect(() => {
@@ -381,7 +394,7 @@ export function Shell({ children }: { children: ReactNode }) {
           </Link>
         </div>
       </header>
-      <aside className="app-sidebar" aria-label="Primary navigation">
+      <aside ref={drawerRef} className="app-sidebar" aria-label="Primary navigation">
         <Link href="/recipes/new" className="sidebar-create" style={{ textDecoration: "none" }}>
           <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" style={{ position: "relative", zIndex: 1 }}>
             <path d={PATHS.plus} />

--- a/dashboard/src/lib/__tests__/useFocusTrap.test.tsx
+++ b/dashboard/src/lib/__tests__/useFocusTrap.test.tsx
@@ -1,0 +1,185 @@
+/**
+ * Tests for the useFocusTrap hook used by the mobile drawer (Shell.tsx)
+ * and the More sheet (MobileBottomNav.tsx).
+ *
+ * Covers the four behaviors the hook owes its callers:
+ *   1. Focus enters the container on open, returns to the trigger on close.
+ *   2. Tab + Shift+Tab cycle within the container.
+ *   3. Escape calls onClose.
+ *   4. Body scroll is locked + the inertSelector targets are marked
+ *      inert + aria-hidden while open, restored on close.
+ */
+
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { useRef, useState } from "react";
+import { fireEvent, render, screen, act } from "@testing-library/react";
+import { useFocusTrap } from "@/lib/useFocusTrap";
+
+type FixtureProps = {
+  onClose?: () => void;
+  inertSelector?: string;
+  lockScroll?: boolean;
+};
+
+function Fixture({ onClose, inertSelector, lockScroll }: FixtureProps) {
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  useFocusTrap({
+    open,
+    onClose: () => {
+      onClose?.();
+      setOpen(false);
+    },
+    containerRef,
+    inertSelector,
+    lockScroll,
+  });
+  return (
+    <div>
+      <button type="button" data-testid="trigger" onClick={() => setOpen(true)}>
+        open
+      </button>
+      <main data-testid="main">
+        <button type="button">outside-1</button>
+      </main>
+      <header data-testid="hdr" className="app-header">
+        <button type="button">outside-2</button>
+      </header>
+      {open && (
+        <div ref={containerRef} data-testid="trap" tabIndex={-1}>
+          <button type="button" data-testid="t-first">
+            first
+          </button>
+          <button type="button" data-testid="t-mid">
+            middle
+          </button>
+          <button type="button" data-testid="t-last">
+            last
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+describe("useFocusTrap", () => {
+  beforeEach(() => {
+    document.body.style.overflow = "";
+  });
+
+  afterEach(() => {
+    // jsdom quirk: HTMLElement.inert isn't fully reflected; clear by hand.
+    for (const el of document.querySelectorAll("[inert]")) {
+      el.removeAttribute("inert");
+      el.removeAttribute("aria-hidden");
+    }
+    document.body.style.overflow = "";
+  });
+
+  it("moves focus to the first focusable on open", () => {
+    render(<Fixture />);
+    act(() => {
+      screen.getByTestId("trigger").focus();
+      fireEvent.click(screen.getByTestId("trigger"));
+    });
+    expect(document.activeElement).toBe(screen.getByTestId("t-first"));
+  });
+
+  it("restores focus to the trigger when the trap closes", () => {
+    const onClose = vi.fn();
+    render(<Fixture onClose={onClose} />);
+    const trigger = screen.getByTestId("trigger");
+    act(() => {
+      trigger.focus();
+      fireEvent.click(trigger);
+    });
+    expect(document.activeElement).toBe(screen.getByTestId("t-first"));
+    act(() => {
+      fireEvent.keyDown(document, { key: "Escape" });
+    });
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(document.activeElement).toBe(trigger);
+  });
+
+  it("cycles Tab from last to first focusable", () => {
+    render(<Fixture />);
+    act(() => {
+      fireEvent.click(screen.getByTestId("trigger"));
+    });
+    const last = screen.getByTestId("t-last");
+    act(() => {
+      last.focus();
+      fireEvent.keyDown(document, { key: "Tab" });
+    });
+    expect(document.activeElement).toBe(screen.getByTestId("t-first"));
+  });
+
+  it("cycles Shift+Tab from first to last focusable", () => {
+    render(<Fixture />);
+    act(() => {
+      fireEvent.click(screen.getByTestId("trigger"));
+    });
+    const first = screen.getByTestId("t-first");
+    act(() => {
+      first.focus();
+      fireEvent.keyDown(document, { key: "Tab", shiftKey: true });
+    });
+    expect(document.activeElement).toBe(screen.getByTestId("t-last"));
+  });
+
+  it("locks body scroll while open and restores it on close", () => {
+    document.body.style.overflow = "auto";
+    render(<Fixture />);
+    expect(document.body.style.overflow).toBe("auto");
+    act(() => {
+      fireEvent.click(screen.getByTestId("trigger"));
+    });
+    expect(document.body.style.overflow).toBe("hidden");
+    act(() => {
+      fireEvent.keyDown(document, { key: "Escape" });
+    });
+    expect(document.body.style.overflow).toBe("auto");
+  });
+
+  it("marks inertSelector targets inert + aria-hidden while open", () => {
+    render(
+      <Fixture inertSelector="main, .app-header" />,
+    );
+    const main = screen.getByTestId("main");
+    const hdr = screen.getByTestId("hdr");
+    expect(main.hasAttribute("inert")).toBe(false);
+    expect(hdr.hasAttribute("inert")).toBe(false);
+
+    act(() => {
+      fireEvent.click(screen.getByTestId("trigger"));
+    });
+    expect(main.hasAttribute("inert")).toBe(true);
+    expect(main.getAttribute("aria-hidden")).toBe("true");
+    expect(hdr.hasAttribute("inert")).toBe(true);
+    expect(hdr.getAttribute("aria-hidden")).toBe("true");
+
+    act(() => {
+      fireEvent.keyDown(document, { key: "Escape" });
+    });
+    expect(main.hasAttribute("inert")).toBe(false);
+    expect(main.hasAttribute("aria-hidden")).toBe(false);
+    expect(hdr.hasAttribute("inert")).toBe(false);
+    expect(hdr.hasAttribute("aria-hidden")).toBe(false);
+  });
+
+  it("respects lockScroll: false and leaves body overflow alone", () => {
+    document.body.style.overflow = "auto";
+    render(<Fixture lockScroll={false} />);
+    act(() => {
+      fireEvent.click(screen.getByTestId("trigger"));
+    });
+    expect(document.body.style.overflow).toBe("auto");
+  });
+
+  it("does not run trap behavior when closed", () => {
+    document.body.style.overflow = "auto";
+    render(<Fixture />);
+    expect(document.body.style.overflow).toBe("auto");
+    expect(document.querySelectorAll("[inert]").length).toBe(0);
+  });
+});

--- a/dashboard/src/lib/useFocusTrap.ts
+++ b/dashboard/src/lib/useFocusTrap.ts
@@ -1,0 +1,155 @@
+"use client";
+
+import { type RefObject, useEffect, useRef } from "react";
+
+/**
+ * Focus-trap hook for mobile drawers, sheets, and modals.
+ *
+ * Mirrors `Dialog.tsx`'s integrated trap behavior, but factored out so
+ * non-portal containers can opt in. The Dialog component portals into
+ * `body` and marks `[data-app-root]` inert — a pattern that doesn't
+ * compose for in-tree containers (the mobile drawer is a child of
+ * data-app-root; marking the root inert would inert the drawer too).
+ *
+ * While `open` is true:
+ *   - Move focus to the first focusable element inside `containerRef`.
+ *   - Cycle Tab / Shift+Tab to keep focus inside the container.
+ *   - Escape calls `onClose`.
+ *   - Lock `document.body` scroll (unless `lockScroll: false`).
+ *   - Mark elements matching `inertSelector` as `inert` + `aria-hidden`.
+ *
+ * On close: restore focus to the element that had it before open.
+ */
+
+const FOCUSABLE_SELECTOR = [
+  "a[href]",
+  "button:not([disabled])",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  "textarea:not([disabled])",
+  "summary",
+  "audio[controls]",
+  "video[controls]",
+  '[tabindex]:not([tabindex="-1"])',
+  '[contenteditable=""]',
+  '[contenteditable="true"]',
+].join(",");
+
+interface FocusTrapOptions {
+  open: boolean;
+  onClose: () => void;
+  containerRef: RefObject<HTMLElement | null>;
+  /**
+   * CSS selector for elements to mark inert + aria-hidden while open.
+   * Default `"[data-app-root]"` (correct for portaled dialogs).
+   *
+   * For in-tree containers, pass a selector that EXCLUDES the trap
+   * container itself, e.g. `"main, .app-header, .mobile-bottom-nav"`
+   * for a sidebar drawer that lives inside data-app-root.
+   */
+  inertSelector?: string;
+  /** Lock body scroll while open. Default true. */
+  lockScroll?: boolean;
+}
+
+export function useFocusTrap({
+  open,
+  onClose,
+  containerRef,
+  inertSelector = "[data-app-root]",
+  lockScroll = true,
+}: FocusTrapOptions) {
+  const previousActiveRef = useRef<HTMLElement | null>(null);
+
+  // Capture the previously-focused element BEFORE trap-driven focus
+  // moves run. Idempotent across renders within one open cycle.
+  if (
+    open &&
+    previousActiveRef.current === null &&
+    typeof document !== "undefined"
+  ) {
+    const active = document.activeElement as HTMLElement | null;
+    if (active && !containerRef.current?.contains(active)) {
+      previousActiveRef.current = active;
+    }
+  }
+
+  // Move focus into the container on open; restore on close.
+  useEffect(() => {
+    if (!open) return;
+    const container = containerRef.current;
+    if (!container) return;
+    const focusables =
+      container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR);
+    const target = focusables[0] ?? container;
+    target.focus({ preventScroll: true });
+    return () => {
+      const restore = previousActiveRef.current;
+      previousActiveRef.current = null;
+      restore?.focus?.({ preventScroll: true });
+    };
+  }, [open, containerRef]);
+
+  // Body scroll lock + sibling inert / aria-hidden.
+  useEffect(() => {
+    if (!open) return;
+    let prevOverflow = "";
+    if (lockScroll) {
+      prevOverflow = document.body.style.overflow;
+      document.body.style.overflow = "hidden";
+    }
+    const inertEls = Array.from(
+      document.querySelectorAll<HTMLElement>(inertSelector),
+    );
+    for (const el of inertEls) {
+      el.setAttribute("inert", "");
+      el.setAttribute("aria-hidden", "true");
+    }
+    return () => {
+      if (lockScroll) {
+        document.body.style.overflow = prevOverflow;
+      }
+      for (const el of inertEls) {
+        el.removeAttribute("inert");
+        el.removeAttribute("aria-hidden");
+      }
+    };
+  }, [open, lockScroll, inertSelector]);
+
+  // Tab cycling + Escape.
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.stopPropagation();
+        onClose();
+        return;
+      }
+      if (e.key !== "Tab") return;
+      const container = containerRef.current;
+      if (!container) return;
+      const nodes = Array.from(
+        container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR),
+      ).filter((n) => !n.hasAttribute("aria-hidden"));
+      if (nodes.length === 0) {
+        e.preventDefault();
+        container.focus();
+        return;
+      }
+      const first = nodes[0]!;
+      const last = nodes[nodes.length - 1]!;
+      const active = document.activeElement as HTMLElement | null;
+      if (e.shiftKey) {
+        if (active === first || (active && !container.contains(active))) {
+          e.preventDefault();
+          last.focus();
+        }
+      } else if (active === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [open, onClose, containerRef]);
+}


### PR DESCRIPTION
## Summary

The mobile drawer (`Shell.tsx`) and the bottom-nav More sheet (`MobileBottomNav.tsx`) were both labeled `role="dialog" aria-modal="true"` but had no actual modal behavior:

- Tab / Shift+Tab leaked focus into the obscured page beneath.
- Background page kept scrolling under the open drawer / sheet.
- Drawer ignored Escape entirely.
- Screen readers could still navigate to elements behind the scrim.

`Dialog.tsx` already implements the correct trap, but it portals into `body` and inerts `[data-app-root]` — a pattern that doesn't compose for in-tree containers (the drawer is a child of data-app-root; inerting the root would inert the drawer itself).

## Approach

Factor the trap into `lib/useFocusTrap.ts` with an `inertSelector` parameter:

- **Drawer**: `inertSelector: "main, .app-header, .mobile-bottom-nav"` (excludes the drawer + scrim).
- **More sheet**: `inertSelector: "main, .app-header, .app-sidebar, .mobile-bottom-nav"` (sheet stays interactive; pointer events on the bottom-nav still work, so a second tap on "More" still closes the sheet).

The hook handles: focus entry to first focusable, restoration on close, Tab cycling, Escape → onClose, body scroll lock, `inert` + `aria-hidden` on selector matches.

## Test plan

- [x] 8 new tests in `src/lib/__tests__/useFocusTrap.test.tsx` cover focus enter/restore, Tab + Shift+Tab cycling, Escape, scroll-lock + restore, inert apply + remove, `lockScroll: false`, no-op when closed.
- [x] 330/330 vitest tests pass.
- [x] `npx tsc --noEmit` clean.
- [x] `npx next build` clean.
- [ ] Manual: reinstall PWA, open drawer on iPhone, confirm Escape closes (BT keyboard), background scroll is locked, screen reader stays inside drawer.

## Follow-up

`Dialog.tsx` could later refactor onto this hook, but its portal target + body inertSelector make it not a 1:1 swap. Out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)