### PR TITLE
fix(dashboard): /recipes mobile layout + ConnectorHealthPanel crash guard

### DIFF
--- a/dashboard/src/app/globals.css
+++ b/dashboard/src/app/globals.css
@@ -1190,6 +1190,27 @@ button.topbar-search {
 .table .mono { font-family: var(--font-mono); font-size: 12px; color: var(--ink-1); }
 .table .muted { color: var(--ink-3); }
 
+/* /recipes table on phone: 7-column desktop layout (%, RECIPE, TRIGGER,
+   LAST 14 RUNS, AVG, LAST, Actions) is 700+ px wide. Below ≈768 px the
+   declared widths plus padding push horizontal scroll to the point where
+   the RECIPE column is visually clipped — the page becomes a list of
+   nameless rows. Drop the three secondary metric columns; the values
+   still live in the selected-recipe detail panel below the table. */
+@media (max-width: 768px) {
+  .recipes-table th:nth-child(4),
+  .recipes-table td:nth-child(4),
+  .recipes-table th:nth-child(5),
+  .recipes-table td:nth-child(5),
+  .recipes-table th:nth-child(6),
+  .recipes-table td:nth-child(6) {
+    display: none;
+  }
+  .recipes-table th,
+  .recipes-table td {
+    padding: 9px 10px;
+  }
+}
+
 
 /* ---- Empty / Error ---- */
 

--- a/dashboard/src/app/recipes/page.tsx
+++ b/dashboard/src/app/recipes/page.tsx
@@ -939,7 +939,7 @@ export default function RecipesPage() {
         >
           <PatchCard padded={false} style={{ overflow: "hidden", minWidth: 0 }}>
             <div className="table-wrap" style={{ minWidth: 0, overflow: "auto" }}>
-              <table className="table" style={{ width: "100%", tableLayout: "fixed" }}>
+              <table className="table recipes-table" style={{ width: "100%", tableLayout: "fixed" }}>
                 <caption className="sr-only">
                   Installed recipes with health, trigger, last 14 runs, average duration, last run time, and actions.
                 </caption>

--- a/dashboard/src/components/ConnectorHealthPanel.tsx
+++ b/dashboard/src/components/ConnectorHealthPanel.tsx
@@ -78,6 +78,12 @@ export function ConnectorHealthPanel({ connectors, marginTop }: Props) {
           : [];
       const map: StatusMap = {};
       for (const c of list) {
+        // Defensive: the bridge has historically returned malformed entries
+        // (missing `name`) when the connector subprocess is mid-init, which
+        // crashed the panel with `Cannot read properties of undefined
+        // (reading 'toLowerCase')`. Skip silently — the next 30 s poll will
+        // pick up the populated entry.
+        if (typeof c?.name !== "string" || c.name.length === 0) continue;
         map[c.name.toLowerCase()] = c;
       }
       setStatusMap(map);


### PR DESCRIPTION
## Summary

Two real-data issues caught by the live-data mobile audit:

### 1. /recipes is unusable on phone — nameless rows

The 7-column desktop layout (`% / RECIPE / TRIGGER / LAST 14 RUNS / AVG / LAST / Actions`) is ~700 px wide. With `tableLayout: fixed` and a 390 px container, the RECIPE column gets visually clipped and the user sees 26 nameless rows distinguishable only by trigger badge.

**Fix:** at ≤768 px, hide the three secondary metric columns (`LAST 14 RUNS / AVG / LAST`) via `:nth-child` rules gated on a new `.recipes-table` class hook. Their values still live in the selected-recipe detail panel below the table. Also tighten cell padding from `12×16` to `9×10` to claw back horizontal room.

### 2. `Cannot read properties of undefined (reading 'toLowerCase')` toast

`ConnectorHealthPanel.tsx` iterates the `/api/bridge/connectors/status` response and calls `c.name.toLowerCase()` on each entry. Bridge has historically returned malformed `{name: undefined, …}` entries when a connector subprocess is mid-init, crashing the panel and surfacing a red toast.

**Fix:** skip entries without a string `name`. The next 30 s poll picks up the populated entry.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — 322/322 pass
- [x] `npm run tokens:check` clean (no token changes)
- [ ] Manual: deploy + view /recipes on iPhone, confirm RECIPE column visible
- [ ] Manual: confirm Required Connectors panel renders without red toast on cold start

🤖 Generated with [Claude Code](https://claude.com/claude-code)