### PR TITLE
fix(dashboard): mobile home grid + drawer + nav polish

### DIFF
--- a/dashboard/src/app/globals.css
+++ b/dashboard/src/app/globals.css
@@ -1566,6 +1566,26 @@ button.topbar-search {
 
 /* ---- Grids ---- */
 .grid { display: grid; gap: 16px; }
+.grid-2 {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  gap: var(--s-4, 16px);
+}
+.grid-3 {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: var(--s-4, 16px);
+}
+.grid-4 {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: var(--s-4, 16px);
+}
+.grid-2-3 {
+  display: grid;
+  grid-template-columns: minmax(0, 2fr) minmax(0, 3fr);
+  gap: var(--s-4, 16px);
+}
 @media (max-width: 1100px) {
   .grid-4 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
   .grid-3 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
@@ -2041,6 +2061,16 @@ button.topbar-search {
   .app-shell.mobile-open .mobile-scrim {
     opacity: 1;
     pointer-events: auto;
+  }
+  /* Hide the bottom-nav while the drawer is open. The drawer is
+     min(82vw, 320px) wide and the bottom-nav is full-width, so the
+     ~75 px tail to the right of the drawer was visibly leaking the
+     bottom-nav under the drawer's right edge. The drawer's focus trap
+     already inerts the bottom-nav for keyboard + AT; this hides it
+     visually too. */
+  .app-shell.mobile-open ~ .mobile-bottom-nav,
+  .app-shell.mobile-open .mobile-bottom-nav {
+    display: none;
   }
   .mobile-menu-btn {
     display: inline-flex;

--- a/dashboard/src/app/globals.css
+++ b/dashboard/src/app/globals.css
@@ -2081,7 +2081,13 @@ button.topbar-search {
   .app-header-left {
     gap: 12px;
   }
+  /* Mobile header: keep the wordmark visible (shorter "Patchwork", drop
+     "OS"). The bare brand-mark icon alone left the topbar feeling
+     unbranded and lopsided with everything else hidden. */
   .topbar-brand span:not(.topbar-local) {
+    font-size: 15px;
+  }
+  .topbar-brand-suffix {
     display: none;
   }
   /* Specificity bumped via .app-header ancestor — the base rules for these
@@ -2092,9 +2098,21 @@ button.topbar-search {
   .app-header .demo-toggle,
   .app-header .bridge-status-pill,
   .app-header .identity-pill,
-  .app-header .topbar-icon-btn,
   .app-header .topbar-avatar {
     display: none;
+  }
+  /* Theme toggle + bell stay on the right so the user can see pending
+     approvals at a glance and switch themes without opening the drawer.
+     The catch-all `.topbar-icon-btn` hide above would also hide them, so
+     re-show them with an even more specific selector. Theme toggle is a
+     `.theme-toggle` button not `.topbar-icon-btn`, so it survives — but
+     the bell IS `.topbar-icon-btn`, hence the re-show. */
+  .app-header .topbar-icon-btn.topbar-bell {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 36px;
+    height: 36px;
   }
   .app-header-title {
     font-size: 13px;

--- a/dashboard/src/app/page.tsx
+++ b/dashboard/src/app/page.tsx
@@ -1136,16 +1136,13 @@ export default function HomePage() {
       />
 
       {/* ------------------------------------------------------------------ */}
-      {/* Activity thread + Active recipe                                      */}
+      {/* Activity thread + Recent recipes                                     */}
       {/* ------------------------------------------------------------------ */}
-      <div
-        style={{
-          display: "grid",
-          gridTemplateColumns: "minmax(0, 1fr) minmax(0, 1fr)",
-          gap: "var(--s-4)",
-          marginBottom: "var(--s-5)",
-        }}
-      >
+      {/* Use the .grid-2 utility (collapses to a single column at ≤760 px)
+          rather than an inline 2-col grid that ignored viewport. Side-by-
+          side at phone width forced both cards to ~150 px wide and made
+          activity timestamps + recipe slugs collide. */}
+      <div className="grid-2" style={{ marginBottom: "var(--s-5)" }}>
         <ActivityThread
           events={activityEvents.filter((e) => !isNoiseEvent(e)).slice(-8).reverse()}
         />

--- a/dashboard/src/components/Shell.tsx
+++ b/dashboard/src/components/Shell.tsx
@@ -285,7 +285,14 @@ export function Shell({ children }: { children: ReactNode }) {
           </button>
           <Link href="/" className="topbar-brand">
             <BrandMark />
-            <span>Patchwork OS</span>
+            <span>
+              Patchwork
+              {/* "OS" suffix shown on desktop, dropped on mobile via the
+                  .topbar-brand-suffix rule in globals.css. Keeps the
+                  full wordmark on wide screens and the short form on
+                  phones where horizontal room is tight. */}
+              <span className="topbar-brand-suffix"> OS</span>
+            </span>
             <span className="topbar-local">local</span>
           </Link>
         </div>


### PR DESCRIPTION
## Summary

Three mobile-UI fixes from screenshots taken on the live dashboard.

### 1. Activity Thread + Recent Recipes 2-col → 1-col on phone

`app/page.tsx` had `gridTemplateColumns: "minmax(0, 1fr) minmax(0, 1fr)"` inline — locked side-by-side at every viewport. At 390 px each card was ~150 px wide; activity timestamps and recipe slugs collided / wrapped.

Switch to the `.grid-2` utility, which collapses to a single column at ≤760 px.

**Bonus cleanup:** `.grid-2`, `.grid-3`, `.grid-4`, `.grid-2-3` only had responsive media-query rules — no base declaration. Anything that tried to use the className got `display: initial` at desktop sizes. Add the missing base rules.

### 2. Bottom-nav leaking under the open drawer

The drawer is `min(82vw, 320px)` wide; the ~75 px tail to its right was visibly leaking the full-width `.mobile-bottom-nav` under the drawer's edge. PR #390 already inerted the bottom-nav for keyboard + AT while the drawer is open; hide it visually too.

### 3. Mobile header was sparse + unbranded

Just hamburger + a tiny brand-mark icon, empty right side. Two adjustments:

- **Show "Patchwork" wordmark** (drop only the "OS" suffix on mobile). Splits the brand text into a base span + `.topbar-brand-suffix` that's display:none on mobile.
- **Re-show the bell** (`.topbar-bell`) that the catch-all `.topbar-icon-btn` hide was sweeping up. The bell carries the pending-approval count badge — the single most useful at-a-glance signal. Pinned at 36×36.

Demo toggle, identity pill, search, avatar stay hidden on mobile — those move into the drawer.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx next build` clean
- [x] `npm run tokens:check` clean
- [ ] Manual: deploy + view home page on iPhone, confirm cards stack vertically
- [ ] Manual: open drawer, confirm bottom-nav no longer visible underneath
- [ ] Manual: confirm "Patchwork" wordmark + bell visible on mobile header

🤖 Generated with [Claude Code](https://claude.com/claude-code)