### PR TITLE
fix(dashboard): /inbox mobile two-pane → list/reader switcher

### DIFF
--- a/dashboard/src/app/globals.css
+++ b/dashboard/src/app/globals.css
@@ -2622,6 +2622,64 @@ button.topbar-search {
    still fires, in case a component depends on it. Cells in QuiltBg are
    gated separately (cell flicker is JS-driven, not CSS-driven).
    ────────────────────────────────────────────────────────────────────── */
+
+/* ──────────────────────────────────────────────────────────────────────
+   /inbox mobile two-pane collapse.
+
+   Desktop is sidebar (300 px or 48 px) + reader side-by-side. On a
+   390 px phone that crushed the reader to ~56 px and rotated text into
+   vertical strips — messages were unreadable. Switch to a list/reader
+   switcher pattern at ≤768 px:
+
+     * No message selected → full-width LIST pane (reader hidden).
+     * Message selected → full-width READER pane with a Back-to-list
+       button at the top (list hidden).
+
+   Container gets `inbox-twopane--list` or `inbox-twopane--reader` based
+   on selection state; CSS swaps which pane is visible. Desktop renders
+   unchanged.
+   ────────────────────────────────────────────────────────────────────── */
+@media (max-width: 768px) {
+  .inbox-twopane {
+    flex-direction: column;
+  }
+  .inbox-twopane .inbox-list-pane,
+  .inbox-twopane .inbox-reader-pane {
+    /* Inline styles set width/flex on the desktop layout; override here. */
+    width: 100% !important;
+    flex: 1 1 auto !important;
+    border-right: none !important;
+  }
+  .inbox-twopane--reader .inbox-list-pane {
+    display: none;
+  }
+  .inbox-twopane--list .inbox-reader-pane {
+    display: none;
+  }
+}
+
+.inbox-back-mobile {
+  display: none;
+}
+@media (max-width: 768px) {
+  .inbox-back-mobile {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    margin-bottom: 16px;
+    padding: 8px 12px;
+    background: var(--recess);
+    border: 1px solid var(--line-1);
+    border-radius: var(--r-full, 999px);
+    color: var(--ink-1);
+    font-size: var(--fs-xs);
+    font-weight: 600;
+    cursor: pointer;
+    -webkit-appearance: none;
+    appearance: none;
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   *,
   *::before,

--- a/dashboard/src/app/inbox/page.tsx
+++ b/dashboard/src/app/inbox/page.tsx
@@ -584,10 +584,16 @@ const filteredItems = items.filter((item) => {
             description="Run a recipe to generate your first brief."
           />
         ) : (
-          <div style={{ display: "flex", flex: 1, minHeight: 0, border: "1px solid var(--line-1)", borderRadius: "var(--r-l)", overflow: "hidden", background: "var(--surface)" }}>
+          <div
+            className={`inbox-twopane${selected ? " inbox-twopane--reader" : " inbox-twopane--list"}`}
+            style={{ display: "flex", flex: 1, minHeight: 0, border: "1px solid var(--line-1)", borderRadius: "var(--r-l)", overflow: "hidden", background: "var(--surface)" }}
+          >
 
-            {/* ── Left sidebar ── */}
-            <div style={{ width: sidebarOpen ? 300 : 48, flexShrink: 0, borderRight: "1px solid var(--line-1)", display: "flex", flexDirection: "column", transition: "width 200ms ease", overflow: "hidden" }}>
+            {/* ── Left sidebar (list) ── */}
+            <div
+              className="inbox-list-pane"
+              style={{ width: sidebarOpen ? 300 : 48, flexShrink: 0, borderRight: "1px solid var(--line-1)", display: "flex", flexDirection: "column", transition: "width 200ms ease", overflow: "hidden" }}
+            >
 
               {/* Sidebar header */}
               <div style={{ padding: "10px 10px 10px 14px", borderBottom: "1px solid var(--line-1)", display: "flex", alignItems: "center", gap: 8, flexShrink: 0 }}>
@@ -738,8 +744,8 @@ const filteredItems = items.filter((item) => {
               )}
             </div>
 
-            {/* ── Right content panel ── */}
-            <div style={{ flex: 1, overflowY: "auto", minWidth: 0 }}>
+            {/* ── Right content panel (reader) ── */}
+            <div className="inbox-reader-pane" style={{ flex: 1, overflowY: "auto", minWidth: 0 }}>
               {detailLoading ? (
                 <div
                   role="status"
@@ -759,6 +765,31 @@ const filteredItems = items.filter((item) => {
                 </div>
               ) : selected ? (
                 <div style={{ padding: "28px 40px 48px", maxWidth: 700 }}>
+                  {/* Mobile-only back-to-list button. Hidden on desktop
+                      where the list is always visible alongside the
+                      reader — there's no "back" mental model on a
+                      two-pane view. */}
+                  <button
+                    type="button"
+                    className="inbox-back-mobile"
+                    onClick={() => setSelected(null)}
+                    aria-label="Back to message list"
+                  >
+                    <svg
+                      width="14"
+                      height="14"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="2.2"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      aria-hidden="true"
+                    >
+                      <path d="M19 12H5M12 19l-7-7 7-7" />
+                    </svg>
+                    <span>Messages</span>
+                  </button>
                   {/* Detail header */}
                   <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 20, paddingBottom: 14, borderBottom: "1px solid var(--line-1)" }}>
                     <span style={{ color: senderBadgeColor(selected.name), lineHeight: 1, flexShrink: 0 }}>


### PR DESCRIPTION
## Summary

The inbox page rendered the desktop two-pane layout (300 px sidebar + reader) on every viewport. On a 390 px phone, the reader pane gets crushed to **~56 px wide** and the text rotates onto vertical strips — messages are completely unreadable. The list view shows but tapping an item just highlights it; the body never becomes visible.

The live-data audit flagged this as the single highest-impact mobile fix.

## Approach

Switch to a list/reader switcher pattern at ≤768 px:

- **No message selected** → full-width LIST pane (reader hidden).
- **Message selected** → full-width READER pane with a Back-to-list button at the top (list hidden).

Tag the existing two-pane container with `inbox-twopane--list` or `inbox-twopane--reader` based on selection state. CSS at ≤768 px stacks the panes vertically and hides whichever isn't active. Inline width/flex styles get overridden via `!important`.

The `.inbox-back-mobile` button only renders on mobile — on desktop the list is always visible alongside the reader, so there's no "back" mental model.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx next build` clean
- [x] `npm run tokens:check` clean
- [ ] Manual: deploy + open /inbox on iPhone, confirm list shows full-width
- [ ] Manual: tap a message, confirm reader fills the viewport with Back button
- [ ] Manual: tap Back, confirm list returns
- [ ] Manual: confirm desktop layout is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)