### PR TITLE
fix(dashboard): recipe editor mobile sticky-save + textarea auto-grow

### DIFF
--- a/dashboard/src/app/globals.css
+++ b/dashboard/src/app/globals.css
@@ -2612,6 +2612,50 @@ button.topbar-search {
 }
 
 
+/* ──────────────────────────────────────────────────────────────────────
+   Recipe editor mobile sticky-save bar.
+
+   /recipes/[name]/edit hosts a CodeMirror YAML editor that grows to
+   2000+ px on a non-trivial recipe. The Save / Run buttons live in
+   the page-header on desktop — fine at 1400 px wide, but on a 390 px
+   phone the user scrolls down to read the YAML and then has to
+   scroll back to the top to save. Float a savebar at the bottom of
+   the viewport on mobile only.
+   ────────────────────────────────────────────────────────────────────── */
+.recipe-editor-mobile-savebar {
+  display: none;
+}
+@media (max-width: 768px) {
+  .recipe-editor-mobile-savebar {
+    display: flex;
+    gap: 8px;
+    position: fixed;
+    /* Sit above the bottom-nav (~62 px) + safe-area inset; small breath. */
+    bottom: calc(72px + env(safe-area-inset-bottom, 0px));
+    left: 12px;
+    right: 12px;
+    z-index: 25;
+    padding: 10px 12px;
+    background: var(--surface);
+    border: 1px solid var(--line-2);
+    border-radius: var(--r-l, 14px);
+    box-shadow: 0 6px 20px rgba(0, 0, 0, 0.22);
+    backdrop-filter: blur(14px);
+    -webkit-backdrop-filter: blur(14px);
+  }
+  .recipe-editor-mobile-savebar .btn {
+    flex: 1;
+    justify-content: center;
+    min-height: 40px;
+  }
+  /* Push the editor's last line above the floating savebar — without
+     this, the bottom of the YAML or the line-count footer hides under
+     the bar. `:has()` is supported in all evergreen browsers we target. */
+  body:has(.recipe-editor-mobile-savebar) .app-content {
+    padding-bottom: 140px;
+  }
+}
+
 /* ──────────────────────────────────────────────────────────────────────────
    Reduced-motion gate (audit Wave 1 / WCAG 2.3.3)
 

--- a/dashboard/src/app/recipes/[name]/edit/page.tsx
+++ b/dashboard/src/app/recipes/[name]/edit/page.tsx
@@ -491,6 +491,30 @@ export default function RecipeEditPage({
           </span>
         </div>
       </div>
+
+      {/* Mobile-only sticky save bar. The desktop Save button lives in
+          the page header — fine on a 1400 px screen, but on a phone the
+          editor is 2000+ px tall and the user has to scroll back to the
+          top to save. Floating savebar at the bottom of the viewport
+          mirrors the convention native iOS forms use. Hidden ≥769 px. */}
+      <div className="recipe-editor-mobile-savebar" aria-hidden={false}>
+        <button
+          type="button"
+          className="btn"
+          onClick={() => void handleRun()}
+          disabled={running || loading}
+        >
+          {running ? "Running…" : "Run"}
+        </button>
+        <button
+          type="button"
+          className="btn primary"
+          onClick={() => void handleSave()}
+          disabled={saving || loading || !dirty}
+        >
+          {saving ? "Saving…" : dirty ? "Save •" : "Save"}
+        </button>
+      </div>
     </section>
   );
 }

--- a/dashboard/src/app/recipes/new/page.tsx
+++ b/dashboard/src/app/recipes/new/page.tsx
@@ -2,6 +2,7 @@
 import { useRouter, useSearchParams } from "next/navigation";
 import { Suspense, useCallback, useMemo, useRef, useState } from "react";
 import { apiPath } from "@/lib/api";
+import { AutoGrowTextarea } from "@/components/AutoGrowTextarea";
 import { highlightYaml } from "@/components/patchwork";
 import { normalizeRecipeName, prepareAndSaveAiRecipe } from "./applyAiYaml";
 
@@ -785,8 +786,9 @@ function NewRecipePageInner() {
               Describe what you want in plain language and Claude will draft a
               recipe YAML for you.
             </p>
-            <textarea
+            <AutoGrowTextarea
               rows={3}
+              maxHeight={400}
               placeholder="e.g. every weekday at 9am, summarize my unread Gmail and post the digest to Slack"
               value={aiPrompt}
               onChange={(e) => setAiPrompt(e.target.value)}
@@ -800,7 +802,6 @@ function NewRecipePageInner() {
                 fontFamily: "var(--font-sans)",
                 outline: "none",
                 padding: "var(--s-2) var(--s-3)",
-                resize: "vertical",
                 width: "100%",
               }}
             />
@@ -1021,12 +1022,13 @@ function NewRecipePageInner() {
                   (optional)
                 </span>
               </label>
-              <textarea
+              <AutoGrowTextarea
                 id="recipe-desc"
                 value={form.description}
                 onChange={(e) => setDescription(e.target.value)}
                 placeholder="What does this recipe do?"
                 rows={2}
+                maxHeight={240}
                 style={{
                   width: "100%",
                   background: "var(--bg-2)",
@@ -1036,7 +1038,6 @@ function NewRecipePageInner() {
                   fontSize: "var(--fs-base)",
                   padding: "var(--s-2) var(--s-3)",
                   outline: "none",
-                  resize: "vertical",
                   fontFamily: "var(--font-sans)",
                 }}
               />

--- a/dashboard/src/components/AutoGrowTextarea.tsx
+++ b/dashboard/src/components/AutoGrowTextarea.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import {
+  type ChangeEvent,
+  type CSSProperties,
+  type TextareaHTMLAttributes,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+} from "react";
+
+/**
+ * Drop-in replacement for `<textarea>` that auto-resizes its height to
+ * fit content as the user types or pastes.
+ *
+ * Why: pasting >3 rows of content into a fixed `rows={3}` textarea
+ * leaves the user scrolling inside a 66 px window — the audit found
+ * users assumed something was broken when 1100 chars vanished into a
+ * 3-line scroll buffer.
+ *
+ * Implementation: on every value change, set height to "auto" (collapse
+ * to one row), read scrollHeight (now reflects the wrapped content),
+ * then set height to that value (capped by the prop). useLayoutEffect
+ * so the resize happens before paint and avoids a flash.
+ */
+
+interface Props
+  extends Omit<TextareaHTMLAttributes<HTMLTextAreaElement>, "ref"> {
+  /** Maximum height in px before scrolling kicks in. Default 400. */
+  maxHeight?: number;
+  /** Minimum height in px. Defaults to the textarea's `rows` × line height. */
+  minHeight?: number;
+}
+
+export function AutoGrowTextarea({
+  maxHeight = 400,
+  minHeight,
+  style,
+  onChange,
+  value,
+  ...rest
+}: Props) {
+  const ref = useRef<HTMLTextAreaElement | null>(null);
+
+  const resize = () => {
+    const el = ref.current;
+    if (!el) return;
+    el.style.height = "auto";
+    const next = Math.min(el.scrollHeight, maxHeight);
+    el.style.height = `${Math.max(next, minHeight ?? 0)}px`;
+  };
+
+  // Resize on every value change. useLayoutEffect (not useEffect) so the
+  // height update is committed before paint — avoids a 1-frame jump.
+  useLayoutEffect(() => {
+    resize();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [value, maxHeight, minHeight]);
+
+  // Resize once on mount in case server-rendered HTML (initial value)
+  // wraps differently than the empty case the rows attribute assumes.
+  useEffect(() => {
+    resize();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const handleChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
+    onChange?.(e);
+  };
+
+  const mergedStyle: CSSProperties = {
+    overflowY: "auto",
+    resize: "none",
+    ...style,
+  };
+
+  return (
+    <textarea
+      ref={ref}
+      value={value}
+      onChange={handleChange}
+      style={mergedStyle}
+      {...rest}
+    />
+  );
+}


### PR DESCRIPTION
## Summary

Two recipe-authoring papercuts from the live-data audit:

### 1. Save button is unreachable on mobile during editing

`/recipes/[name]/edit` hosts a CodeMirror YAML editor that grows to **2000+ px** on a non-trivial recipe. The Save / Run buttons live in the page header — fine at 1400 px wide, but on a 390 px phone the user has to scroll all the way back up to save.

**Fix:** add a fixed-position savebar at the bottom of the viewport, visible only at ≤768 px. It sits above the bottom-nav (72 px + safe-area inset) and contains Run + Save. `body:has(.recipe-editor-mobile-savebar) .app-content` gets +140 px bottom padding so the editor's last line doesn't hide under the bar.

### 2. Textareas don't auto-grow on /recipes/new

`rows={3}` textareas stay 66 px tall regardless of content. The audit pasted 1140 chars into the AI-prompt textarea, saw `scrollHeight` spike to 400 px while rendered height stayed at 66 px — the user was scrolling inside a 3-line window assuming the paste failed.

**Fix:** new `<AutoGrowTextarea>` component (`dashboard/src/components/AutoGrowTextarea.tsx`) that resizes via `useLayoutEffect` on every value change. Capped at `maxHeight` (default 400 px). Applied to the AI prompt + description textareas.

The step prompt textarea uses a per-step ref system that's more invasive to convert — left for a follow-up since each step is short and rarely paste-dumped.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx next build` clean
- [x] `npx vitest run` — 330/330 pass
- [x] `npm run tokens:check` clean
- [ ] Manual: edit a recipe on iPhone, scroll to bottom, confirm savebar visible + Save dirty-aware
- [ ] Manual: paste 500+ chars into AI prompt on /recipes/new, confirm textarea grows

🤖 Generated with [Claude Code](https://claude.com/claude-code)