### PR TITLE
fix(dashboard): slow status + approvals polls while SSE is healthy

### DIFF
--- a/dashboard/src/components/Shell.tsx
+++ b/dashboard/src/components/Shell.tsx
@@ -7,6 +7,7 @@ import { apiPath } from "@/lib/api";
 import { useBridgeStatus, type BridgeStatus } from "@/hooks/useBridgeStatus";
 import { isDemoMode, onDemoModeChange, setDemoMode } from "@/lib/demoMode";
 import { useFocusTrap } from "@/lib/useFocusTrap";
+import { subscribeStreamLiveness } from "@/lib/streamLiveness";
 import { CardGlow } from "./CardGlow";
 import { CommandPalette } from "./CommandPalette";
 
@@ -109,17 +110,25 @@ function useApprovalCount(): number {
     let alive = true;
     let failures = 0;
     let timerId: ReturnType<typeof setTimeout> | null = null;
+    let sseLive = false;
     const BASE = 5000;
+    /** Slow cadence while SSE is healthy — SSE pushes approval-decision
+     *  events directly, so this becomes a periodic correctness check. */
+    const SSE_LIVE = 30_000;
     const MAX = 30_000;
 
-    const schedule = (ms: number) => {
+    const reschedule = (ms: number) => {
+      if (timerId !== null) {
+        clearTimeout(timerId);
+        timerId = null;
+      }
       if (!alive) return;
       timerId = setTimeout(tick, ms);
     };
 
     const tick = async () => {
       if (typeof document !== "undefined" && document.hidden) {
-        schedule(BASE);
+        reschedule(BASE);
         return;
       }
       let ok = false;
@@ -133,14 +142,22 @@ function useApprovalCount(): number {
       } catch { /* offline */ }
       if (ok) failures = 0;
       else failures++;
+      const baseInterval = sseLive ? SSE_LIVE : BASE;
       const exp = Math.min(BASE * 2 ** failures, MAX);
-      schedule(ok ? BASE : exp * (0.8 + Math.random() * 0.4));
+      reschedule(ok ? baseInterval : exp * (0.8 + Math.random() * 0.4));
     };
+
+    const unsubLiveness = subscribeStreamLiveness((live) => {
+      const wasLive = sseLive;
+      sseLive = live;
+      // SSE just dropped — refresh now so the badge doesn't sit stale
+      // for up to 30 s after the bridge goes offline.
+      if (wasLive && !live) reschedule(0);
+    });
 
     const onVisible = () => {
       if (!document.hidden && alive) {
-        if (timerId !== null) clearTimeout(timerId);
-        tick();
+        reschedule(0);
       }
     };
     document.addEventListener("visibilitychange", onVisible);
@@ -149,6 +166,7 @@ function useApprovalCount(): number {
       alive = false;
       if (timerId !== null) clearTimeout(timerId);
       document.removeEventListener("visibilitychange", onVisible);
+      unsubLiveness();
     };
   }, []);
   return count;

--- a/dashboard/src/hooks/useBridgeStatus.ts
+++ b/dashboard/src/hooks/useBridgeStatus.ts
@@ -1,6 +1,7 @@
 "use client";
 import { useEffect, useState } from "react";
 import { apiPath } from "@/lib/api";
+import { subscribeStreamLiveness } from "@/lib/streamLiveness";
 
 export interface BridgeStatus {
   ok: boolean;
@@ -24,6 +25,10 @@ export interface BridgeStatus {
 }
 
 const BASE_INTERVAL_MS = 5000;
+/** Polling cadence while SSE liveness is healthy. Status doesn't drift
+ *  fast and SSE pushes meaningful state changes; this becomes a slow
+ *  metadata refresh rather than a heartbeat. */
+const SSE_LIVE_INTERVAL_MS = 30_000;
 const MAX_BACKOFF_MS = 30_000;
 
 function nextDelay(failures: number): number {
@@ -37,8 +42,13 @@ export function useBridgeStatus(): BridgeStatus {
     let alive = true;
     let failures = 0;
     let timerId: ReturnType<typeof setTimeout> | null = null;
+    let sseLive = false;
 
-    const schedule = (ms: number) => {
+    const reschedule = (ms: number) => {
+      if (timerId !== null) {
+        clearTimeout(timerId);
+        timerId = null;
+      }
       if (!alive) return;
       timerId = setTimeout(tick, ms);
     };
@@ -71,13 +81,30 @@ export function useBridgeStatus(): BridgeStatus {
 
       if (succeeded) failures = 0;
       else failures++;
-      schedule(succeeded ? BASE_INTERVAL_MS : nextDelay(failures));
+      // Slow polling when the SSE stream is healthy: the bridge pushes
+      // state changes through it, so the every-5-s heartbeat poll is
+      // redundant traffic. On cellular this matters.
+      const baseInterval = sseLive ? SSE_LIVE_INTERVAL_MS : BASE_INTERVAL_MS;
+      reschedule(succeeded ? baseInterval : nextDelay(failures));
     };
+
+    // Subscribe to SSE liveness so we slow polls when the stream is
+    // healthy and accelerate them when it drops. The callback fires
+    // immediately with the current value on subscribe.
+    const unsubLiveness = subscribeStreamLiveness((live) => {
+      const wasLive = sseLive;
+      sseLive = live;
+      // SSE just dropped — don't wait the full 30 s slow interval to
+      // re-poll; refresh now so the user sees the bridge going offline
+      // promptly.
+      if (wasLive && !live) reschedule(0);
+    });
 
     tick();
     return () => {
       alive = false;
       if (timerId !== null) clearTimeout(timerId);
+      unsubLiveness();
     };
   }, []);
   return status;

--- a/dashboard/src/lib/streamLiveness.ts
+++ b/dashboard/src/lib/streamLiveness.ts
@@ -1,0 +1,134 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { apiPath } from "@/lib/api";
+
+/**
+ * Singleton SSE liveness watcher.
+ *
+ * The dashboard polls `/api/bridge/status` every 5 s and
+ * `/api/bridge/approvals` every 5 s from multiple consumers (header
+ * approval-count badge, home page metrics, settings page). It also
+ * holds a live SSE connection (`/api/bridge/stream`) for approval
+ * decision events. While the SSE is healthy and pushing heartbeats,
+ * the polls are redundant traffic — on a phone over cellular this
+ * adds up to ~720 needless requests/hour.
+ *
+ * This module opens ONE shared EventSource (per browser tab) and
+ * exposes a tiny pub-sub: poll consumers subscribe with
+ * `subscribeStreamLiveness` and slow their cadence when `isLive`
+ * goes true. When SSE drops, consumers accelerate back to 5 s
+ * polling automatically.
+ *
+ * The stream is opened lazily on first subscription and closed when
+ * the last subscriber unsubscribes (typical on full-page nav).
+ */
+
+const listeners = new Set<(live: boolean) => void>();
+let es: EventSource | null = null;
+let isLive = false;
+let lastHeartbeatAt = 0;
+
+/** SSE is "live" if connected AND we've seen activity in the last 90 s. */
+const HEARTBEAT_TIMEOUT_MS = 90_000;
+
+function notify() {
+  for (const l of listeners) l(isLive);
+}
+
+function setLive(next: boolean) {
+  if (next === isLive) return;
+  isLive = next;
+  notify();
+}
+
+function ensureStream() {
+  if (es) return;
+  if (typeof window === "undefined") return;
+  // Skip in demo mode — there's no real bridge to stream from.
+  // Demo state is a localStorage-backed module (lib/demoMode.ts); we
+  // read the "pw-demo" key directly to avoid pulling demoMode in via
+  // dynamic import + the runtime cycle that creates with Shell.
+  try {
+    if (window.localStorage.getItem("pw-demo") === "true") return;
+  } catch {
+    // localStorage unavailable — assume not demo.
+  }
+
+  try {
+    es = new EventSource(apiPath("/api/bridge/stream"));
+  } catch {
+    return;
+  }
+
+  es.onopen = () => {
+    lastHeartbeatAt = Date.now();
+    setLive(true);
+  };
+
+  es.onmessage = () => {
+    lastHeartbeatAt = Date.now();
+    if (!isLive) setLive(true);
+  };
+
+  es.onerror = () => {
+    setLive(false);
+    // EventSource auto-reconnects; we'll re-fire onopen if it
+    // succeeds. No manual cleanup here — keep the reference so
+    // subsequent ensureStream() calls don't open a second one.
+  };
+}
+
+function teardownStream() {
+  if (!es) return;
+  es.close();
+  es = null;
+  isLive = false;
+}
+
+/**
+ * Subscribe to SSE liveness changes.
+ *
+ * The callback is invoked once on subscription with the current
+ * value, and again whenever liveness flips. Returns an unsubscribe.
+ */
+export function subscribeStreamLiveness(
+  cb: (live: boolean) => void,
+): () => void {
+  listeners.add(cb);
+  ensureStream();
+  cb(isLive);
+  // Stale-heartbeat sweep: if we've been "live" but haven't received
+  // an event in 90 s, downgrade to not-live so polls resume. Cheap
+  // belt-and-suspenders against EventSource's silent disconnects.
+  const sweepId = setInterval(() => {
+    if (isLive && Date.now() - lastHeartbeatAt > HEARTBEAT_TIMEOUT_MS) {
+      setLive(false);
+    }
+  }, 30_000);
+
+  return () => {
+    listeners.delete(cb);
+    clearInterval(sweepId);
+    if (listeners.size === 0) {
+      teardownStream();
+    }
+  };
+}
+
+/** React hook wrapping the subscription. Re-renders on liveness change. */
+export function useStreamLiveness(): boolean {
+  const [live, setLiveState] = useState(false);
+  useEffect(() => subscribeStreamLiveness(setLiveState), []);
+  return live;
+}
+
+/**
+ * Synchronous read of current liveness for non-React callers that just
+ * need a snapshot at tick time. Stays in sync via the same subscription
+ * mechanism — anyone using this should call `subscribeStreamLiveness`
+ * elsewhere to keep the stream open.
+ */
+export function getStreamLiveness(): boolean {
+  return isLive;
+}


### PR DESCRIPTION
## Summary

The dashboard polls `/api/bridge/status` (every 5 s) and `/api/bridge/approvals` (every 5 s) in addition to holding a live SSE connection to `/api/bridge/stream` that pushes meaningful state changes. On cellular this is ~720 needless requests/hour. The audit measured both pollers firing every ~2-3 s in practice (multiple consumers + jitter).

## Approach

Add a shared SSE-liveness watcher (`lib/streamLiveness.ts`):

- Opens ONE singleton EventSource per tab, lazily on first subscribe.
- Broadcasts liveness changes to subscribers via tiny pub-sub.
- Liveness is `true` on `onopen` + each `onmessage`, `false` on `onerror`.
- 90 s heartbeat-stale sweep guards against EventSource silently disconnecting.

Wire two consumers:

| Consumer | Normal cadence | SSE-live cadence |
|---|---|---|
| `useBridgeStatus` | 5 s | 30 s |
| `useApprovalCount` (Shell) | 5 s | 30 s |

SSE-drop accelerates back to immediate re-poll so the bridge-offline banner / approval-count badge don't sit stale for up to 30 s.

**Net:** ~720 req/hr → ~120 req/hr on cellular when SSE is healthy, with no perceived latency change (SSE delivers approval events directly anyway).

## Trade-off

`useApprovalPatterns` (/approvals) and `useBridgeStream` (/runs) still open their own EventSource — total 2 connections from any page that uses them. A future pass can consolidate, but the sites that need liveness for polling-suppression don't overlap with those, so no immediate dup.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — 330/330 pass
- [x] `npx next build` clean
- [ ] Manual: open dashboard with bridge running, confirm /status + /approvals network traffic drops to ~30 s cadence after stream connects
- [ ] Manual: kill the bridge, confirm polls accelerate back to 5 s within ~3 s of SSE drop

🤖 Generated with [Claude Code](https://claude.com/claude-code)