### PR TITLE
feat(plugins): imessage plugin — send via macOS Messages.app

### DIFF
--- a/examples/plugins/imessage/README.md
+++ b/examples/plugins/imessage/README.md
@@ -1,0 +1,113 @@
+# imessage — Patchwork OS plugin
+
+Sends iMessage (or SMS, if iPhone-Messages-forwarding is on) from the Mac
+running the bridge. One tool: `im_send`. Backed by `osascript` driving
+Messages.app. macOS-only.
+
+## Install / load
+
+```sh
+# From a fresh checkout of patchwork-os
+claude-ide-bridge --plugin ./examples/plugins/imessage --plugin-watch
+```
+
+The plugin has no npm dependencies — `osascript` ships with macOS.
+
+## First-run permission
+
+The first time `im_send` runs, macOS will pop a one-time permission
+dialog: "*<host process>* wants to control Messages.app." Click **OK**.
+If you missed the prompt or clicked Don't Allow, fix it in:
+
+> System Settings → Privacy & Security → Automation → *<your terminal /
+> node binary>* → Messages
+
+Without that, every call returns an `im_send: osascript exited 1` error
+mentioning Automation permission.
+
+## Usage from Claude Code (chat)
+
+Once loaded, ask Claude something like:
+
+> "Use `im_send` to text +14155551234 a quick hello."
+
+Claude will call the tool with `{ to, body }`. Recipient must be E.164
+(`+1…`) or an Apple ID email.
+
+## Usage from a recipe (manual run only)
+
+Recipe YAML can't call MCP plugin tools as `tool: im_send` — the recipe
+runner's tool registry is separate from the bridge's MCP registry. Use
+an `agent:` step with `mcpAccess: true` to spawn a `claude -p`
+subprocess that has the plugin tool injected.
+
+```yaml
+# ~/.patchwork/recipes/weather-3day.yaml
+name: 3-day weather → iMessage
+trigger:
+  manual: true
+  vars:
+    - name: location
+      default: "Nairobi"
+    - name: phone
+      default: "+254XXXXXXXXX"
+steps:
+  - id: deliver
+    agent:
+      mcpAccess: true
+      prompt: |
+        Fetch a 3-day weather forecast for {{ location }} (today, +1, +2).
+        You can use https://api.open-meteo.com/v1/forecast with
+        forecast_days=3 and hourly=temperature_2m,precipitation,wind_speed_10m
+        — geocode the location first via
+        https://geocoding-api.open-meteo.com/v1/search.
+
+        Format as a tight 4-line message:
+          line 1: "{{ location }} — next 3 days:"
+          lines 2-4: "Day Mon: high/low °C, brief conditions"
+
+        Then call the `im_send` MCP tool with:
+          to:   "{{ phone }}"
+          body: <your formatted 4-line summary>
+
+        Do not ask for confirmation. Run it once and report the tool's
+        delivery status back to me.
+```
+
+Run it manually:
+
+```sh
+patchwork recipe run weather-3day
+```
+
+`mcpAccess: true` makes bridge MCP tools (including this plugin's
+`im_send`) available inside the Claude subprocess that the agent step
+spawns. Bridge must be running with `--plugin ./examples/plugins/imessage`.
+
+## Tool reference
+
+### `im_send`
+
+| Arg | Type | Required | Default | Notes |
+|---|---|---|---|---|
+| `to` | string | yes | — | E.164 phone (`+14155551234`) or Apple ID email |
+| `body` | string | yes | — | Message body, ≤10 000 bytes UTF-8 |
+| `timeoutMs` | integer | no | 15 000 | Hard timeout for the osascript subprocess (1 000 – 120 000) |
+
+Returns `{ delivered: boolean, to: string, stderr: string }` as
+`structuredContent`. Sets `isError: true` on validation failure, missing
+permission, unreachable buddy, or non-zero exit.
+
+## Limitations
+
+- macOS-only. Linux/Windows callers get a clear error.
+- "Delivered" means *Messages.app accepted the send*, not that the
+  recipient's phone has rendered it. Real delivery telemetry isn't
+  available without Messages-DB scraping, which this plugin deliberately
+  doesn't do.
+- Phone numbers must be in E.164 (`+CC...`). 10-digit US-style without
+  the `+1` is rejected to keep the failure visible.
+- The script uses `buddy ... of (1st service whose service type =
+  iMessage)`. SMS-via-iPhone forwarding will pick that up if the
+  recipient isn't on iMessage; otherwise the send may silently fail —
+  watch for `-25212` in stderr.

--- a/examples/plugins/imessage/README.md
+++ b/examples/plugins/imessage/README.md
@@ -13,17 +13,103 @@ claude-ide-bridge --plugin ./examples/plugins/imessage --plugin-watch
 
 The plugin has no npm dependencies — `osascript` ships with macOS.
 
-## First-run permission
+## Set up iMessage on the host Mac
 
-The first time `im_send` runs, macOS will pop a one-time permission
-dialog: "*<host process>* wants to control Messages.app." Click **OK**.
+The plugin doesn't configure iMessage — it just drives Messages.app. Do
+this once before your first `im_send` call.
+
+### 1. Sign Messages.app into iMessage
+
+1. Open **Messages.app** (Cmd+Space → "Messages").
+2. **Messages → Settings… → iMessage**.
+3. Sign in with your Apple ID. Same one your iPhone uses, ideally —
+   then sends are routed through the same identity.
+4. Tick **Enable Messages in iCloud** so conversations sync.
+5. Under **You can be reached for messages at**, check the phone number
+   and emails you want to be reachable on.
+6. Under **Start new conversations from**, pick the address recipients
+   should see — usually your `+CC…` phone number or your Apple ID email.
+
+If the iMessage tab says **"Waiting for activation"** for more than a
+few minutes, sign out, reboot, sign back in. First-time activation
+occasionally hangs on a single attempt.
+
+### 2. Send a manual test message first
+
+Before AppleScript drives anything, you must successfully send one
+message manually from this Mac. Otherwise the `buddy` lookup the
+plugin uses fails with iMessage error `-25212`.
+
+In Messages.app, open a new chat → To: **your own Apple ID email** →
+type "test" → send.
+
+- Blue bubble, no red `!` → iMessage works. Use this email as your
+  default `to:` for `im_send` testing.
+- Red `!` "Not Delivered" → fix below.
+
+> **Apple ID email is the most reliable test target.** It always
+> resolves to iMessage and bypasses any phone-routing issues. Numbers
+> not on iMessage (most non-US/EU prefixes, including `+254`) will fail
+> from a Mac unless you set up SMS forwarding (step 4).
+
+### 3. Make production recipients reachable
+
+For real recipients (not yourself), the AppleScript looks up the
+address as a `buddy` of the iMessage service. That works reliably when
+**any one** of these is true:
+
+- The recipient is in your **Contacts.app**, OR
+- You've manually messaged them at least once from this Mac, OR
+- The recipient's address is itself an Apple ID
+
+For a number you've never messaged, add a Contact first
+(Contacts.app → New Contact → save phone in `+CC…` format) and send a
+manual hello. After that, `im_send` works for them.
+
+### 4. (Optional) Enable SMS fallback for non-iMessage numbers
+
+Without this, sending to a green-bubble number from a Mac fails. With
+it, Messages.app on the Mac proxies the send through your iPhone as
+SMS.
+
+1. On the **iPhone** (must be signed into the same Apple ID and on the
+   same Wi-Fi or paired via Bluetooth):
+2. Settings → **Messages** → **Text Message Forwarding**.
+3. Toggle the Mac on. The Mac pops a 6-digit code; enter it on the
+   iPhone.
+
+This is the only path to reach non-iMessage recipients — including
+most numbers in regions where iMessage adoption is low — from a
+Mac-driven plugin.
+
+### 5. First `im_send` call: grant Automation permission
+
+The very first invocation triggers a one-time macOS dialog:
+
+> *"<host process>* wants to control Messages.app."
+
+Click **OK**. The host process is whatever launched the bridge —
+Terminal, iTerm, Cursor, Windsurf, VS Code, or `node` if you ran the
+bridge directly. macOS records the grant per process binary.
+
 If you missed the prompt or clicked Don't Allow, fix it in:
 
-> System Settings → Privacy & Security → Automation → *<your terminal /
-> node binary>* → Messages
+> System Settings → **Privacy & Security** → **Automation** → expand
+> the host process row → tick **Messages**.
 
-Without that, every call returns an `im_send: osascript exited 1` error
-mentioning Automation permission.
+If the row isn't there yet, run `im_send` once to register it; the row
+appears after the first attempt regardless of outcome.
+
+### 6. Verify the plugin end-to-end
+
+In a Claude Code chat connected to the bridge:
+
+> "Use `im_send` to text `your.appleid@example.com` 'plugin works'."
+
+Expected: blue bubble in Messages.app within a second; tool returns
+`{ delivered: true, to: "your.appleid@example.com" }`. If you see an
+error, the message points at the fix (Automation permission missing,
+recipient unreachable, etc.).
 
 ## Usage from Claude Code (chat)
 

--- a/examples/plugins/imessage/claude-ide-bridge-plugin.json
+++ b/examples/plugins/imessage/claude-ide-bridge-plugin.json
@@ -1,0 +1,9 @@
+{
+  "schemaVersion": 1,
+  "name": "patchwork-os/imessage",
+  "version": "0.1.0",
+  "description": "Send iMessage / SMS via macOS Messages.app (osascript-backed)",
+  "entrypoint": "./index.mjs",
+  "toolNamePrefix": "im",
+  "minBridgeVersion": "0.2.0-alpha.0"
+}

--- a/examples/plugins/imessage/index.mjs
+++ b/examples/plugins/imessage/index.mjs
@@ -1,0 +1,267 @@
+/**
+ * imessage — Patchwork OS plugin.
+ *
+ * Single tool `im_send`: deliver a message via macOS Messages.app to a
+ * phone number (E.164) or Apple ID email. Backed by `osascript`; the
+ * Mac running the bridge must be signed into iMessage and the user
+ * must approve Automation access for the host process the first time
+ * the tool runs (System Settings → Privacy & Security → Automation).
+ *
+ * The AppleScript is fed `to` and `body` as argv items, so the
+ * message body is safe even if it contains quotes, backticks, or
+ * shell metacharacters — no string interpolation into the script
+ * source.
+ */
+
+import { spawn } from "node:child_process";
+import os from "node:os";
+
+const MAX_BODY_BYTES = 10_000;
+
+// E.164 ("+14155551234") or basic email shape — anything else is rejected
+// before we shell out, so user mistakes surface as a clear error rather
+// than a silent Messages.app no-op.
+const PHONE_RE = /^\+[1-9]\d{6,14}$/;
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+function isValidRecipient(to) {
+  if (typeof to !== "string") return false;
+  return PHONE_RE.test(to) || EMAIL_RE.test(to);
+}
+
+const APPLESCRIPT = `on run argv
+  set toAddr to item 1 of argv
+  set msgText to item 2 of argv
+  tell application "Messages"
+    set targetService to 1st service whose service type = iMessage
+    set targetBuddy to buddy toAddr of targetService
+    send msgText to targetBuddy
+  end tell
+end run`;
+
+/**
+ * Run osascript with the recipient + body passed as argv (osascript
+ * shell-escapes them for us; we never interpolate into AppleScript
+ * source). Resolves with stdout/stderr/exitCode regardless of success.
+ */
+function runOsascript(to, body, signal, timeoutMs) {
+  return new Promise((resolve, reject) => {
+    const proc = spawn("osascript", ["-e", APPLESCRIPT, "--", to, body], {
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+    proc.stdout.on("data", (chunk) => {
+      stdout += chunk.toString();
+    });
+    proc.stderr.on("data", (chunk) => {
+      stderr += chunk.toString();
+    });
+
+    const timer = setTimeout(() => {
+      proc.kill("SIGKILL");
+    }, timeoutMs);
+
+    const onAbort = () => {
+      clearTimeout(timer);
+      proc.kill("SIGKILL");
+    };
+    if (signal) {
+      if (signal.aborted) {
+        onAbort();
+      } else {
+        signal.addEventListener("abort", onAbort, { once: true });
+      }
+    }
+
+    proc.on("error", (err) => {
+      clearTimeout(timer);
+      if (signal) signal.removeEventListener?.("abort", onAbort);
+      reject(err);
+    });
+    proc.on("close", (code) => {
+      clearTimeout(timer);
+      if (signal) signal.removeEventListener?.("abort", onAbort);
+      resolve({ stdout, stderr, exitCode: code ?? -1 });
+    });
+  });
+}
+
+/** @param {import('patchwork-os/plugin').PluginContext} ctx */
+export function register(ctx) {
+  ctx.logger.info("imessage plugin loaded", {
+    workspace: ctx.workspace,
+    platform: os.platform(),
+  });
+
+  return {
+    tools: [
+      {
+        schema: {
+          name: "im_send",
+          description:
+            "Send an iMessage to a phone number (E.164 like +14155551234) or " +
+            "Apple ID email. Requires macOS with Messages.app signed in. " +
+            "Falls back to SMS only if SMS-via-iPhone forwarding is enabled. " +
+            "First run will trigger a one-time macOS Automation permission prompt.",
+          inputSchema: {
+            type: "object",
+            required: ["to", "body"],
+            additionalProperties: false,
+            properties: {
+              to: {
+                type: "string",
+                description:
+                  "Recipient: E.164 phone number (e.g. +14155551234) or Apple ID email.",
+              },
+              body: {
+                type: "string",
+                description: `Message body. Max ${MAX_BODY_BYTES} bytes UTF-8.`,
+              },
+              timeoutMs: {
+                type: "integer",
+                description:
+                  "Hard timeout for the osascript subprocess. Default 15000.",
+                minimum: 1000,
+                maximum: 120_000,
+                default: 15_000,
+              },
+            },
+          },
+          outputSchema: {
+            type: "object",
+            required: ["delivered", "to"],
+            properties: {
+              delivered: { type: "boolean" },
+              to: { type: "string" },
+              stderr: { type: "string" },
+            },
+          },
+          annotations: {
+            // Sending a message is a side effect on the user's phone +
+            // contact's phone — never advertise this as read-only.
+            destructiveHint: false,
+            idempotentHint: false,
+            openWorldHint: true,
+          },
+        },
+        handler: async (args, signal) => {
+          if (os.platform() !== "darwin") {
+            return {
+              isError: true,
+              content: [
+                {
+                  type: "text",
+                  text:
+                    "im_send only works on macOS — Messages.app is required. " +
+                    `Detected platform: ${os.platform()}.`,
+                },
+              ],
+            };
+          }
+
+          const to = String(args.to ?? "");
+          const body = String(args.body ?? "");
+          const timeoutMs = Math.min(
+            Math.max(1000, Number(args.timeoutMs) || 15_000),
+            120_000,
+          );
+
+          if (!isValidRecipient(to)) {
+            return {
+              isError: true,
+              content: [
+                {
+                  type: "text",
+                  text:
+                    `im_send: invalid 'to' value. Expected E.164 phone number ` +
+                    `(e.g. +14155551234) or Apple ID email. Got: ${to.slice(0, 80)}`,
+                },
+              ],
+            };
+          }
+          if (body.length === 0) {
+            return {
+              isError: true,
+              content: [
+                { type: "text", text: "im_send: 'body' must be non-empty." },
+              ],
+            };
+          }
+          if (Buffer.byteLength(body, "utf8") > MAX_BODY_BYTES) {
+            return {
+              isError: true,
+              content: [
+                {
+                  type: "text",
+                  text: `im_send: body exceeds ${MAX_BODY_BYTES} bytes UTF-8.`,
+                },
+              ],
+            };
+          }
+
+          let result;
+          try {
+            result = await runOsascript(to, body, signal, timeoutMs);
+          } catch (err) {
+            return {
+              isError: true,
+              content: [
+                {
+                  type: "text",
+                  text: `im_send: failed to spawn osascript — ${
+                    err instanceof Error ? err.message : String(err)
+                  }`,
+                },
+              ],
+            };
+          }
+
+          if (result.exitCode !== 0) {
+            // Common failure modes the user can act on without reading logs:
+            //   - "-1743" / "Not authorized" → Automation permission missing
+            //   - "execution error: ... (-25212)" → buddy not found / no iMessage account
+            const hint = /-1743|not authorized|automation/i.test(result.stderr)
+              ? " Grant Automation → Messages permission in System Settings → Privacy & Security."
+              : /-25212|buddy/i.test(result.stderr)
+                ? " Recipient not reachable on iMessage from this Mac. Check the number/email and that Messages is signed in."
+                : "";
+            return {
+              isError: true,
+              content: [
+                {
+                  type: "text",
+                  text:
+                    `im_send: osascript exited ${result.exitCode}.${hint}\n` +
+                    (result.stderr ? `stderr: ${result.stderr.trim()}` : ""),
+                },
+              ],
+              structuredContent: {
+                delivered: false,
+                to,
+                stderr: result.stderr,
+              },
+            };
+          }
+
+          ctx.logger.info("im_send delivered", { to, bytes: body.length });
+          return {
+            content: [
+              {
+                type: "text",
+                text: `Sent to ${to} (${body.length} chars).`,
+              },
+            ],
+            structuredContent: {
+              delivered: true,
+              to,
+              stderr: result.stderr,
+            },
+          };
+        },
+        timeoutMs: 30_000,
+      },
+    ],
+  };
+}

--- a/examples/plugins/imessage/package.json
+++ b/examples/plugins/imessage/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "patchwork-os-imessage",
+  "version": "0.1.0",
+  "description": "Send iMessage / SMS via macOS Messages.app — Patchwork OS plugin",
+  "type": "module",
+  "main": "index.mjs",
+  "keywords": [
+    "patchwork-os",
+    "claude-ide-bridge-plugin",
+    "imessage",
+    "macos"
+  ],
+  "peerDependencies": {
+    "patchwork-os": ">=0.2.0-alpha.0"
+  },
+  "os": [
+    "darwin"
+  ]
+}


### PR DESCRIPTION
## Summary
- New example plugin `examples/plugins/imessage/` exposing `im_send(to, body, timeoutMs?)` — drives Messages.app via `osascript`.
- Closes the gap left by the aspirational `imessage-mcp` reference in `examples/recipes/starter-pack/README.md:133`. Recipes can now call iMessage delivery via an `agent:` step with `mcpAccess: true`.
- Single tool, JS variant (no native deps), macOS-only. Recipient validated as E.164 phone or Apple ID email before shelling out; body capped at 10 000 bytes UTF-8; AppleScript receives `to`/`body` as positional `argv` items so message bodies can't escape into script source.

## Test plan
- [x] Plugin manifest loads cleanly via `loadOnePluginFull` — 1 tool registered (`im_send`)
- [x] Validation gates: bad phone format, empty body, oversized body, non-darwin platform, abort signal — all return `isError: true` with actionable messages
- [x] End-to-end live send: open-meteo 3-day forecast for Nairobi → formatted 4-line message → `im_send` to Apple ID email → blue bubble in Messages.app, `delivered: true`
- [x] `npx biome check --write` clean on all new files

🤖 Generated with [Claude Code](https://claude.com/claude-code)