### PR TITLE
feat(automation): webhook fan-out from onCompaction

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -203,6 +203,21 @@ Event-driven hooks that trigger Claude tasks automatically.
   - `onDebugSession` (v2.43.0+) — unified debug-session hook. `phase: "start"` fires on session start (`{{sessionName}}`, `{{sessionType}}`, `{{breakpointCount}}`, `{{activeFile}}`). `phase: "end"` fires on termination (`{{sessionName}}`, `{{sessionType}}`). Replaces deprecated `onDebugSessionStart` + `onDebugSessionEnd`.
 - **Shared options**: all hooks support inline `prompt` string or `promptName`/`promptArgs` named prompt references. All support `cooldownMs` (min 5000).
 - **Cooldown**: min 5s between triggers for same file/event. Max prompt size: 32KB.
+- **Webhook fan-out** (v1, `onCompaction` only — see [ADR-0009](docs/adr/0009-automation-webhook-fanout.md)) — any opted-in hook may add an optional `webhook: { url, method?, headers? }` config. When the hook fires, the interpreter POSTs (or PUT/PATCH) a JSON body to the URL AFTER the inline prompt enqueue. Body shape: `{ hookType, phase?, timestamp, ...eventData }`. 10s timeout; non-2xx and network errors are logged but never block other hooks. SSRF guard: loopback (127.0.0.0/8, ::1, localhost) and public hosts allowed; other private ranges blocked unless `--automation-allow-private-webhooks` is set (CLI flag is a follow-up). Both inline `prompt` AND `webhook` may be set on the same entry — they run sequentially: prompt first, then webhook. Hook entries with only a `webhook` (no `prompt` / `promptName`) are valid and skip the task enqueue. Example:
+  ```json
+  {
+    "onCompaction": {
+      "phase": "pre",
+      "enabled": true,
+      "cooldownMs": 5000,
+      "webhook": {
+        "url": "http://127.0.0.1:54321/hooks/compaction-snapshot-pre",
+        "method": "POST",
+        "headers": { "Content-Type": "application/json" }
+      }
+    }
+  }
+  ```
 - **CC hook wiring** — hooks relying on Claude Code's hook system need MCP notify tools called from `settings.json`. Bridge registers these automatically when `--automation` active:
 
   | CC hook event | Shell command (settings.json) |

--- a/docs/adr/0009-automation-webhook-fanout.md
+++ b/docs/adr/0009-automation-webhook-fanout.md
@@ -1,0 +1,64 @@
+# ADR-0009: Webhook Fan-out for Automation Hooks
+
+**Status:** Accepted
+**Date:** 2026-05-09
+
+## Context
+
+The bridge ships an automation policy DSL ([src/fp/automationProgram.ts](../../src/fp/automationProgram.ts)) that fires Claude tasks on IDE events: file save, diagnostic state change, compaction, test run, etc. Each hook entry is a `{ prompt | promptName, cooldownMs, ... }` record that flows through the `AutomationProgram` ADT, gets parsed by [src/fp/policyParser.ts](../../src/fp/policyParser.ts), and runs through [src/fp/automationInterpreter.ts](../../src/fp/automationInterpreter.ts).
+
+Recipe 6 (`examples/recipes/bridge-dev/compaction-snapshot-pre.yaml` and `compaction-snapshot-post.yaml`) wants to capture and restore IDE state across compaction. Both recipes use `trigger.type: webhook`, which means they fire when the bridge POSTs to a configured URL. But the existing `onCompaction` hook only knows how to enqueue a Claude task — it has no native way to POST to a webhook. So recipe 6 is currently unrunnable from automation; the operator has to manually fire it from the dashboard or wire a `curl` into the CC `PreCompact` hook command.
+
+## Decision
+
+Extend the `Hook` ADT node with an optional `webhook?: WebhookConfig` field and the `Backend` interface with `postWebhook(opts)`. The interpreter fires the webhook AFTER the inline prompt has been enqueued (sequential, not parallel) on the success path of every Hook node that has it set.
+
+Wire the new field through the parser ONLY for `onCompaction` hook types (`onPreCompact` / `onPostCompact`) in this slice. Other hook types parse the field successfully — the schema is forward-compatible — but the parser silently drops it for non-opted-in types, gated by a single `WEBHOOK_ENABLED_HOOK_TYPES` set in [src/fp/policyParser.ts](../../src/fp/policyParser.ts). Adding `onGitCommit`, `onTestRun`, etc. is then a one-line change.
+
+A new `PromptSourceNode` variant `{ kind: "none" }` represents webhook-only hook entries — entries with no inline prompt and no named prompt, just a webhook. The interpreter's Hook case skips the task enqueue but still proceeds to the webhook fan-out. `WithCooldown` was extended to detect webhook firing (delta in `lastWebhookFiredAt`) so cooldowns gate webhook-only hooks the same way they gate prompt-bearing ones.
+
+`AutomationState` gains a `lastWebhookFiredAt: ReadonlyMap<string, number>` field. Recorded on every webhook attempt regardless of HTTP outcome — operators debugging webhook delivery want the "we tried at T" timestamp. Merged via max-per-key in `mergeAutomationStates`.
+
+### Body shape (v1)
+
+```json
+{
+  "hookType": "onPreCompact",
+  "phase": "pre",
+  "timestamp": 1700000000000
+}
+```
+
+Plus any keys in the hook's `eventData` map (compaction has none today; future hooks will add their own placeholders).
+
+### Failure semantics
+
+`Backend.postWebhook` is contractually "never rejects" — it always resolves with `{ ok, status?, error? }`. The interpreter wraps the call in a defensive try/catch anyway (a buggy backend could throw). Failures are recorded as interpreter errors and logged; they do NOT block other hooks in the same run, and they do NOT block the prompt enqueue (which already happened, sequentially before the webhook). 10 second timeout. Non-2xx counts as failure.
+
+### SSRF policy
+
+The production `VsCodeBackend` allows webhook URLs that are loopback (127.0.0.0/8, ::1, localhost, *.localhost) OR public, and BLOCKS all other RFC 1918 / link-local / ULA / CGNAT / 0.0.0.0/8 ranges by default. Opt out via constructor flag (CLI `--automation-allow-private-webhooks` is a follow-up).
+
+This is a deliberate divergence from `sendHttpRequest` (which blocks ALL private addresses by default, loopback included). The reasoning:
+
+- A `sendHttpRequest` URL is potentially LLM-controlled — a compromised session could craft URLs. SSRF is real attack surface.
+- An automation webhook URL comes from a trusted policy file the operator wrote. Loopback is the intended common case, not the exceptional one. Recipe-6 webhooks target `http://127.0.0.1:${BRIDGE_PORT}/...` — the bridge talking to itself.
+
+Other private ranges (10/8, 192.168/16, etc.) are still blocked by default — those would mostly indicate misconfiguration where a webhook URL accidentally points at the operator's home network or a shared dev VPC. The opt-in covers the rare case where an operator does want that.
+
+## Alternatives considered
+
+1. **Run webhook in `Parallel` with prompt** — rejected. The interpreter changed `Parallel` to be sequential (see commit history, automationInterpreter.ts case `"Parallel"`) precisely because branches need to see each other's state writes. A webhook firing in parallel with a prompt enqueue would race `lastWebhookFiredAt` against `lastTrigger`, and one would clobber the other in the cooldown record. Sequential is correct.
+
+2. **Add a `notify` URL to the existing `Backend.notify` channel** — rejected. `notify` is a fire-and-forget log line, not a structured HTTP call. Conflating them would make the test ergonomics ugly (`notifications: string[]` vs `webhookCalls: BackendWebhookOpts[]`).
+
+3. **New top-level node type `WebhookNode`** — rejected. Would require duplicating cooldown/dedup/rateLimit wrapping to apply to webhook-only entries. Attaching `webhook` to `HookNode` lets all the existing combinators (`WithCooldown`, `WithRetry`, `WithDedup`, `WithRateLimit`) wrap it for free.
+
+4. **Loopback-by-default, no opt-in for other private** — rejected. Power users will run the bridge inside Docker / k8s / WSL2 where the "loopback" target is reachable only via 172.x or 10.x. They need an escape hatch.
+
+## Consequences
+
+- Recipe 6 unblocks once recipes are wired in via `compaction-snapshot-pre.yaml`'s webhook path (operator points the policy's `webhook.url` at the recipe's webhook trigger endpoint).
+- New `webhook` field accepted on every hook config but no-op for non-opted-in types. Operators who set it on `onGitCommit` today will see no effect; we can flip the bit later.
+- One new state field; all serialization (state checkpoint, dashboards) needs to keep accepting state without it for backward compat. `EMPTY_AUTOMATION_STATE` covers initial construction; `mergeAutomationStates` covers the reconciliation path.
+- `Backend` interface gained one method — every implementation (prod + test + future) must add it.

--- a/src/automation.ts
+++ b/src/automation.ts
@@ -53,6 +53,28 @@ export interface AutomationCondition {
   testRunnerLastStatus?: "passed" | "failed" | "any";
 }
 
+/**
+ * Outbound webhook configuration for an automation hook.
+ *
+ * Currently wired only for `onCompaction` (onPreCompact/onPostCompact slots);
+ * other hook types may opt in later. When set on a hook entry, the interpreter
+ * POSTs a JSON body containing `{ phase?, timestamp, hookType, ...eventData }`
+ * to `url` after the inline prompt (if any) has been enqueued.
+ *
+ * Security: by default, only loopback URLs (127.0.0.1, ::1, localhost) and
+ * public hosts are allowed. Other RFC 1918 / link-local / ULA / CGNAT
+ * addresses are blocked unless the bridge is started with the
+ * `--automation-allow-private-webhooks` flag (TODO follow-up).
+ */
+export interface AutomationWebhookConfig {
+  /** Full http:// or https:// URL. Loopback OK by default; other private ranges blocked. */
+  url: string;
+  /** HTTP method. Default: "POST". */
+  method?: "POST" | "PUT" | "PATCH";
+  /** Optional request headers. Content-Type defaults to application/json. */
+  headers?: Record<string, string>;
+}
+
 export interface PromptSource {
   prompt?: string;
   promptName?: string;
@@ -75,6 +97,16 @@ export interface PromptSource {
    * Enforced minimum: 5_000.
    */
   retryDelayMs?: number;
+  /**
+   * Optional outbound webhook fired AFTER the inline prompt enqueue.
+   *
+   * As of v1, only honored on `onCompaction` (onPreCompact/onPostCompact).
+   * Setting it on other hooks is silently ignored by the parser. Both
+   * `prompt` (or `promptName`) AND `webhook` may be set on the same hook
+   * entry — they run sequentially: prompt enqueue first, then webhook.
+   * See ADR-0009.
+   */
+  webhook?: AutomationWebhookConfig;
 }
 
 export interface OnDiagnosticsErrorPolicy extends PromptSource {
@@ -546,21 +578,26 @@ const MAX_PROMPT_NAME_CHARS = 64;
 /**
  * Validates that a hook config has exactly one of `prompt` (non-empty inline string)
  * or `promptName` (reference to a built-in MCP prompt), plus optional `promptArgs`.
+ * Hook configs that wire only a `webhook` are allowed to omit both prompt fields.
  * Throws a descriptive error on violation.
  */
 function validatePromptSource(hookName: string, cfg: PromptSource): void {
   const hasPrompt = typeof cfg.prompt === "string" && cfg.prompt.trim() !== "";
   const hasPromptName =
     typeof cfg.promptName === "string" && cfg.promptName.trim() !== "";
+  const hasWebhook =
+    cfg.webhook !== undefined &&
+    typeof cfg.webhook === "object" &&
+    cfg.webhook !== null;
 
   if (hasPrompt && hasPromptName) {
     throw new Error(
       `"${hookName}" must specify either "prompt" or "promptName", not both`,
     );
   }
-  if (!hasPrompt && !hasPromptName) {
+  if (!hasPrompt && !hasPromptName && !hasWebhook) {
     throw new Error(
-      `"${hookName}" must have a non-empty "prompt" or "promptName"`,
+      `"${hookName}" must have a non-empty "prompt", "promptName", or "webhook"`,
     );
   }
   if (hasPrompt && (cfg.prompt?.length ?? 0) > MAX_POLICY_PROMPT_CHARS) {
@@ -606,6 +643,66 @@ function validatePromptSource(hookName: string, cfg: PromptSource): void {
       throw new Error(
         `"${hookName}.effort" must be one of "low", "medium", "high", "max"`,
       );
+    }
+  }
+  if (cfg.webhook !== undefined) {
+    const wh = cfg.webhook as unknown;
+    if (typeof wh !== "object" || wh === null || Array.isArray(wh)) {
+      throw new Error(`"${hookName}.webhook" must be a plain object`);
+    }
+    const w = wh as Record<string, unknown>;
+    if (typeof w.url !== "string" || w.url.trim() === "") {
+      throw new Error(`"${hookName}.webhook.url" must be a non-empty string`);
+    }
+    if (w.url.length > 2048) {
+      throw new Error(`"${hookName}.webhook.url" must be ≤ 2048 characters`);
+    }
+    try {
+      const parsed = new URL(w.url);
+      if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+        throw new Error(
+          `"${hookName}.webhook.url" must use http:// or https:// (got ${parsed.protocol})`,
+        );
+      }
+    } catch (e) {
+      // Re-throw protocol errors verbatim; wrap parse errors.
+      if (e instanceof Error && e.message.includes("must use http")) throw e;
+      throw new Error(
+        `"${hookName}.webhook.url" is not a valid URL: ${e instanceof Error ? e.message : String(e)}`,
+      );
+    }
+    if (w.method !== undefined) {
+      if (
+        typeof w.method !== "string" ||
+        !["POST", "PUT", "PATCH"].includes(w.method)
+      ) {
+        throw new Error(
+          `"${hookName}.webhook.method" must be one of "POST", "PUT", "PATCH"`,
+        );
+      }
+    }
+    if (w.headers !== undefined) {
+      if (
+        typeof w.headers !== "object" ||
+        w.headers === null ||
+        Array.isArray(w.headers)
+      ) {
+        throw new Error(`"${hookName}.webhook.headers" must be a plain object`);
+      }
+      for (const [k, v] of Object.entries(
+        w.headers as Record<string, unknown>,
+      )) {
+        if (typeof v !== "string") {
+          throw new Error(
+            `"${hookName}.webhook.headers.${k}" must be a string`,
+          );
+        }
+        if (k.length > 128 || v.length > 1024) {
+          throw new Error(
+            `"${hookName}.webhook.headers.${k}" exceeds size limits (key ≤128, value ≤1024)`,
+          );
+        }
+      }
     }
   }
 }

--- a/src/fp/__tests__/automationInterpreter.test.ts
+++ b/src/fp/__tests__/automationInterpreter.test.ts
@@ -832,6 +832,167 @@ describe("WithRetry re-execution", () => {
   });
 });
 
+// ── Hook: webhook fan-out ─────────────────────────────────────────────────────
+
+describe("Hook: webhook fan-out", () => {
+  it("fires a webhook with correct URL, method, headers, and body for onPreCompact", async () => {
+    const backend = new TestBackend();
+    const ctx = makeCtx({
+      backend,
+      eventType: "onPreCompact",
+      eventData: {},
+      now: NOW,
+    });
+    const h = hook({
+      hookType: "onPreCompact",
+      enabled: true,
+      promptSource: { kind: "none" },
+      webhook: {
+        url: "http://127.0.0.1:54321/hooks/compaction-snapshot-pre",
+        method: "POST",
+        headers: { "Content-Type": "application/json", "X-Test": "1" },
+      },
+    });
+    const result = await executeAutomationPolicy([h], ctx);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    // No Claude task was enqueued (webhook-only hook)
+    expect(backend.collector.enqueuedTasks).toHaveLength(0);
+    expect(result.value.taskIds).toHaveLength(0);
+
+    // Webhook was fired exactly once with expected shape
+    expect(backend.collector.webhookCalls).toHaveLength(1);
+    const call = backend.collector.webhookCalls[0];
+    if (!call) throw new Error("expected webhookCall[0]");
+    expect(call.url).toBe(
+      "http://127.0.0.1:54321/hooks/compaction-snapshot-pre",
+    );
+    expect(call.method).toBe("POST");
+    expect(call.headers["X-Test"]).toBe("1");
+    expect(call.body.hookType).toBe("onPreCompact");
+    expect(call.body.timestamp).toBe(NOW);
+    expect(call.body.phase).toBe("pre");
+
+    // State recorded the webhook fan-out time
+    expect(
+      result.value.updatedState.lastWebhookFiredAt.get("onPreCompact"),
+    ).toBe(NOW);
+  });
+
+  it("fires a webhook AND enqueues a task when both prompt and webhook are set", async () => {
+    const backend = new TestBackend();
+    const ctx = makeCtx({
+      backend,
+      eventType: "onPreCompact",
+      eventData: {},
+      now: NOW,
+    });
+    const h = hook({
+      hookType: "onPreCompact",
+      enabled: true,
+      promptSource: { kind: "inline", prompt: "Snapshot IDE state" },
+      webhook: {
+        url: "http://localhost:9999/hook",
+      },
+    });
+    const result = await executeAutomationPolicy([h], ctx);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    // Task enqueued first, webhook fired after
+    expect(backend.collector.enqueuedTasks).toHaveLength(1);
+    expect(backend.collector.webhookCalls).toHaveLength(1);
+    expect(result.value.taskIds).toHaveLength(1);
+  });
+
+  it("records error and continues when webhook returns non-2xx", async () => {
+    const backend = new TestBackend();
+    backend.webhookResponse = { ok: false, status: 500, error: "boom" };
+    const ctx = makeCtx({
+      backend,
+      eventType: "onPostCompact",
+      eventData: {},
+      now: NOW,
+    });
+    const h = hook({
+      hookType: "onPostCompact",
+      enabled: true,
+      promptSource: { kind: "none" },
+      webhook: { url: "http://127.0.0.1:54321/missing" },
+    });
+    const result = await executeAutomationPolicy([h], ctx);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(backend.collector.webhookCalls).toHaveLength(1);
+    expect(result.value.errors).toHaveLength(1);
+    expect(result.value.errors[0]?.message).toContain("status=500");
+    // lastWebhookFiredAt is recorded even on non-2xx — the operator wants the
+    // "we tried at T" timestamp for telemetry.
+    expect(
+      result.value.updatedState.lastWebhookFiredAt.get("onPostCompact"),
+    ).toBe(NOW);
+  });
+
+  it("does not throw when backend.postWebhook itself throws", async () => {
+    const backend = new TestBackend();
+    backend.postWebhook = async () => {
+      throw new Error("network blew up");
+    };
+    const ctx = makeCtx({
+      backend,
+      eventType: "onPreCompact",
+      eventData: {},
+      now: NOW,
+    });
+    const h = hook({
+      hookType: "onPreCompact",
+      enabled: true,
+      promptSource: { kind: "none" },
+      webhook: { url: "http://127.0.0.1:54321/x" },
+    });
+    const result = await executeAutomationPolicy([h], ctx);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.errors[0]?.message).toContain("threw");
+  });
+
+  it("respects WithCooldown for webhook-only hooks", async () => {
+    const backend = new TestBackend();
+    const inner = hook({
+      hookType: "onPreCompact",
+      enabled: true,
+      promptSource: { kind: "none" },
+      webhook: { url: "http://127.0.0.1:54321/hook" },
+    });
+    const wrapped = withCooldown("precompact", 60_000, inner);
+
+    // First fire: webhook posted, cooldown recorded
+    const result1 = await executeAutomationPolicy([wrapped], {
+      ...makeCtx({ backend, eventType: "onPreCompact", eventData: {} }),
+    });
+    expect(result1.ok).toBe(true);
+    if (!result1.ok) return;
+    expect(backend.collector.webhookCalls).toHaveLength(1);
+
+    // Second fire 1s later: should be blocked by cooldown
+    const result2 = await executeAutomationPolicy([wrapped], {
+      ...makeCtx({
+        backend,
+        eventType: "onPreCompact",
+        eventData: {},
+        state: result1.value.updatedState,
+        now: NOW + 1_000,
+      }),
+    });
+    expect(result2.ok).toBe(true);
+    if (!result2.ok) return;
+    expect(backend.collector.webhookCalls).toHaveLength(1);
+    expect(result2.value.skipped[0]?.reason).toBe("cooldown:precompact");
+  });
+});
+
 // ── PBT: parallel merge ───────────────────────────────────────────────────────
 
 describe("PBT: parallel merge", () => {

--- a/src/fp/automationInterpreter.ts
+++ b/src/fp/automationInterpreter.ts
@@ -20,6 +20,7 @@ import {
   recordDedup,
   recordPendingRetry,
   recordTrigger,
+  recordWebhookFired,
   tasksInLastHour,
 } from "./automationState.js";
 import {
@@ -176,7 +177,14 @@ export function primaryValue(
  * Resolve a PromptSourceNode to a string.
  * For named prompts, calls getPrompt() and concatenates user messages.
  * Returns null if a named prompt cannot be resolved (unknown name / missing args).
+ *
+ * When `source.kind === "none"`, returns the symbol `NO_PROMPT` so callers
+ * can distinguish "no inline prompt configured" (webhook-only hook) from
+ * "named prompt failed to resolve" (skip silently).
  */
+export const NO_PROMPT = Symbol("no-prompt");
+export type ResolvedPrompt = string | null | typeof NO_PROMPT;
+
 export function resolvePromptSource(
   source:
     | { kind: "inline"; prompt: string }
@@ -184,9 +192,11 @@ export function resolvePromptSource(
         kind: "named";
         promptName: string;
         promptArgs?: Record<string, string>;
-      },
+      }
+    | { kind: "none" },
   eventData: Readonly<Record<string, string>>,
-): string | null {
+): ResolvedPrompt {
+  if (source.kind === "none") return NO_PROMPT;
   if (source.kind === "inline") return source.prompt;
   // Substitute event placeholders into promptArgs values
   const resolvedArgs: Record<string, string> = {};
@@ -412,45 +422,115 @@ async function interpret(
           ],
         };
       }
-      const nonce = crypto.randomBytes(8).toString("hex");
-      const finalPrompt = buildFinalPrompt(
-        promptTemplate,
-        program.hookType,
-        ctx.eventData,
-        nonce,
-      );
 
-      try {
-        const taskId = await ctx.backend.enqueueTask({
-          prompt: finalPrompt,
-          triggerSource: program.hookType,
-          sessionId: "",
-          isAutomationTask: true,
-          model: program.model,
-          effort: program.effort,
-          systemPrompt: program.systemPrompt,
-        });
-        const newState = recordTrigger(
-          acc.state,
+      // When promptTemplate is a string, enqueue a Claude task. When it is
+      // NO_PROMPT, the hook is webhook-only — skip the enqueue but still
+      // proceed to webhook fan-out below. A webhook-only hook still records
+      // a trigger in state so cooldown gating can observe its firing.
+      let working = acc;
+      if (promptTemplate !== NO_PROMPT) {
+        const nonce = crypto.randomBytes(8).toString("hex");
+        const finalPrompt = buildFinalPrompt(
+          promptTemplate,
           program.hookType,
-          taskId,
-          ctx.now,
+          ctx.eventData,
+          nonce,
         );
-        return {
-          ...acc,
-          taskIds: [...acc.taskIds, taskId],
-          state: newState,
-        };
-      } catch (e) {
-        const message = e instanceof Error ? e.message : String(e);
-        ctx.log(
-          `[interpreter] hook ${program.hookType} enqueue failed: ${message}`,
-        );
-        return {
-          ...acc,
-          errors: [...acc.errors, { message, hook: program.hookType }],
-        };
+
+        try {
+          const taskId = await ctx.backend.enqueueTask({
+            prompt: finalPrompt,
+            triggerSource: program.hookType,
+            sessionId: "",
+            isAutomationTask: true,
+            model: program.model,
+            effort: program.effort,
+            systemPrompt: program.systemPrompt,
+          });
+          const newState = recordTrigger(
+            working.state,
+            program.hookType,
+            taskId,
+            ctx.now,
+          );
+          working = {
+            ...working,
+            taskIds: [...working.taskIds, taskId],
+            state: newState,
+          };
+        } catch (e) {
+          const message = e instanceof Error ? e.message : String(e);
+          ctx.log(
+            `[interpreter] hook ${program.hookType} enqueue failed: ${message}`,
+          );
+          return {
+            ...working,
+            errors: [...working.errors, { message, hook: program.hookType }],
+          };
+        }
       }
+
+      // Webhook fan-out — runs AFTER the inline prompt enqueue (if any).
+      // Failures are recorded as interpreter errors and do not throw, so
+      // other hooks in the same run continue to fire. Always records
+      // `lastWebhookFiredAt` regardless of HTTP outcome — operators
+      // debugging webhook delivery want "we attempted X" telemetry.
+      if (program.webhook) {
+        const phase =
+          program.hookType === "onPreCompact"
+            ? "pre"
+            : program.hookType === "onPostCompact"
+              ? "post"
+              : undefined;
+        const body: Record<string, unknown> = {
+          hookType: program.hookType,
+          timestamp: ctx.now,
+          ...ctx.eventData,
+        };
+        if (phase) body.phase = phase;
+
+        try {
+          const result = await ctx.backend.postWebhook({
+            url: program.webhook.url,
+            method: program.webhook.method ?? "POST",
+            headers: program.webhook.headers ?? {},
+            body,
+            hookKey: program.hookType,
+          });
+          working = {
+            ...working,
+            state: recordWebhookFired(working.state, program.hookType, ctx.now),
+          };
+          if (!result.ok) {
+            const message = `webhook fan-out failed: ${result.error ?? "unknown"}${result.status !== undefined ? ` (status=${result.status})` : ""}`;
+            ctx.log(`[interpreter] hook ${program.hookType} ${message}`);
+            working = {
+              ...working,
+              errors: [...working.errors, { message, hook: program.hookType }],
+            };
+          }
+        } catch (e) {
+          // Defensive: postWebhook contract is "never rejects", but a buggy
+          // backend could still throw. Log + record but do not propagate.
+          const message = e instanceof Error ? e.message : String(e);
+          ctx.log(
+            `[interpreter] hook ${program.hookType} webhook threw: ${message}`,
+          );
+          working = {
+            ...working,
+            state: recordWebhookFired(working.state, program.hookType, ctx.now),
+            errors: [
+              ...working.errors,
+              {
+                message: `webhook fan-out threw: ${message}`,
+                hook: program.hookType,
+              },
+            ],
+          };
+        }
+      }
+
+      return working;
     }
 
     case "Sequence": {
@@ -510,14 +590,35 @@ async function interpret(
 
       const innerAcc = await interpret(program.program, ctx, acc);
 
-      // If we produced new task IDs, record the cooldown trigger
+      // If we produced new task IDs, record the cooldown trigger.
+      // For webhook-only hooks (kind: "none") no taskId is produced, but the
+      // webhook firing still counts as a trigger — detected via a delta in
+      // `lastWebhookFiredAt`. Without this branch, cooldowns never apply to
+      // webhook-only hooks, defeating the cooldown gate the operator
+      // configured.
       const newTaskIds = innerAcc.taskIds.slice(acc.taskIds.length);
+      const webhookFired =
+        innerAcc.state.lastWebhookFiredAt.size >
+          acc.state.lastWebhookFiredAt.size ||
+        // Same key was already in the map but timestamp moved forward
+        Array.from(innerAcc.state.lastWebhookFiredAt.entries()).some(
+          ([k, v]) => (acc.state.lastWebhookFiredAt.get(k) ?? -1) < v,
+        );
       if (newTaskIds.length > 0) {
         const lastTaskId = newTaskIds[newTaskIds.length - 1] ?? "";
         const newState = recordTrigger(
           innerAcc.state,
           program.key,
           lastTaskId,
+          ctx.now,
+        );
+        return { ...innerAcc, state: newState };
+      }
+      if (webhookFired) {
+        const newState = recordTrigger(
+          innerAcc.state,
+          program.key,
+          "webhook",
           ctx.now,
         );
         return { ...innerAcc, state: newState };

--- a/src/fp/automationProgram.ts
+++ b/src/fp/automationProgram.ts
@@ -38,7 +38,13 @@ export type PromptSourceNode =
       readonly kind: "named";
       readonly promptName: string;
       readonly promptArgs?: Record<string, string>;
-    };
+    }
+  /**
+   * Webhook-only hook entry — no inline prompt, no task enqueue. The hook
+   * still flows through cooldown/dedup/rateLimit gates and fires its
+   * `webhook` (if configured) on the success path.
+   */
+  | { readonly kind: "none" };
 
 // ── When condition ────────────────────────────────────────────────────────────
 
@@ -70,6 +76,25 @@ export type HookExtras =
   | TestRunExtras
   | { readonly kind: "none" };
 
+// ── Webhook config ────────────────────────────────────────────────────────────
+
+/**
+ * Outbound webhook configuration for an automation hook.
+ *
+ * When attached to a HookNode, the interpreter POSTs (or sends via the chosen
+ * method) a JSON body to `url` AFTER any inline prompt has been enqueued. The
+ * body shape is `{ phase, timestamp, hookType, ...eventData }` for v1.
+ *
+ * Failure modes (timeout, non-2xx, network error) are recorded and logged
+ * via the Backend, never thrown — webhook fan-out is always best-effort and
+ * does not block other hooks or the prompt enqueue.
+ */
+export interface WebhookConfig {
+  readonly url: string;
+  readonly method?: "POST" | "PUT" | "PATCH";
+  readonly headers?: Readonly<Record<string, string>>;
+}
+
 // ── Node types ────────────────────────────────────────────────────────────────
 
 export interface HookNode {
@@ -84,6 +109,12 @@ export interface HookNode {
   readonly effort?: "low" | "medium" | "high" | "max";
   readonly systemPrompt?: string;
   readonly extras?: HookExtras;
+  /**
+   * Optional outbound webhook fired AFTER the inline prompt enqueue. Wired
+   * for `onCompaction` (onPreCompact/onPostCompact) only in v1; other hook
+   * types may opt in later by widening the parser. See ADR-0009.
+   */
+  readonly webhook?: WebhookConfig;
 }
 
 export interface SequenceNode {

--- a/src/fp/automationState.ts
+++ b/src/fp/automationState.ts
@@ -59,6 +59,14 @@ export interface AutomationState {
    * Last known test runner outcome (pass/fail) for evaluateWhen checks.
    */
   readonly lastTestRunnerStatusByRunner: ReadonlyMap<string, "pass" | "fail">;
+  /**
+   * Last successful webhook fan-out time (ms since epoch) per hook key.
+   * Recorded after `Backend.postWebhook` resolves regardless of `ok` —
+   * the timestamp marks "we attempted to deliver", which is what an
+   * operator wants when debugging webhook health. Merged via max-per-key
+   * in `mergeAutomationStates`.
+   */
+  readonly lastWebhookFiredAt: ReadonlyMap<string, number>;
 }
 
 export const EMPTY_AUTOMATION_STATE: AutomationState = {
@@ -71,6 +79,7 @@ export const EMPTY_AUTOMATION_STATE: AutomationState = {
   pendingRetries: new Map(),
   latestDiagnosticsByFile: new Map(),
   lastTestRunnerStatusByRunner: new Map(),
+  lastWebhookFiredAt: new Map(),
 };
 
 // ── Cooldown helpers ──────────────────────────────────────────────────────────
@@ -344,6 +353,7 @@ export function mergeAutomationStates(
       a.lastTestRunnerStatusByRunner,
       b.lastTestRunnerStatusByRunner,
     ),
+    lastWebhookFiredAt: maxNumMap(a.lastWebhookFiredAt, b.lastWebhookFiredAt),
   };
 }
 
@@ -360,4 +370,30 @@ export function setTestRunnerStatus(
   const newMap = new Map(state.lastTestRunnerStatusByRunner);
   newMap.set(runner, outcome);
   return { ...state, lastTestRunnerStatusByRunner: newMap };
+}
+
+// ── Webhook helpers ───────────────────────────────────────────────────────────
+
+const WEBHOOK_FIRED_MAX_SIZE = 5_000;
+
+/**
+ * Record that an automation webhook fan-out attempt for `key` resolved at
+ * `now`. Used for telemetry / dashboards — does NOT gate future fires on its
+ * own (cooldown is already enforced by WithCooldown around the parent hook).
+ *
+ * Bounded at 5_000 entries, FIFO eviction.
+ */
+export function recordWebhookFired(
+  state: AutomationState,
+  key: string,
+  now: number,
+): AutomationState {
+  const newMap = new Map(state.lastWebhookFiredAt);
+  newMap.delete(key);
+  newMap.set(key, now);
+  if (newMap.size > WEBHOOK_FIRED_MAX_SIZE) {
+    const firstKey = newMap.keys().next().value as string;
+    newMap.delete(firstKey);
+  }
+  return { ...state, lastWebhookFiredAt: newMap };
 }

--- a/src/fp/interpreterContext.ts
+++ b/src/fp/interpreterContext.ts
@@ -17,6 +17,34 @@ export interface BackendEnqueueOpts {
   systemPrompt?: string;
 }
 
+/**
+ * Options for an outbound webhook fired by an automation hook.
+ *
+ * `body` is the JSON-serializable payload. Backends serialize and set
+ * Content-Type if not already in `headers`. SSRF guarding is the backend's
+ * responsibility (production: loopback-only by default; tests: collect).
+ */
+export interface BackendWebhookOpts {
+  url: string;
+  method: "POST" | "PUT" | "PATCH";
+  headers: Readonly<Record<string, string>>;
+  body: Readonly<Record<string, unknown>>;
+  /** Hook key for diagnostic logging (e.g. "precompact"). */
+  hookKey: string;
+}
+
+/**
+ * Result of a webhook call. Always resolves — never throws — so a failed
+ * webhook does not block the rest of the interpreter run.
+ */
+export interface BackendWebhookResult {
+  ok: boolean;
+  /** HTTP status code on a completed request; absent on network error / timeout. */
+  status?: number;
+  /** Reason on failure — surfaced in the interpreter error list and logs. */
+  error?: string;
+}
+
 export interface Backend {
   /** Enqueue a task and return the task ID. */
   enqueueTask(opts: BackendEnqueueOpts): Promise<string>;
@@ -24,6 +52,12 @@ export interface Backend {
   scheduleRetry(key: string, delayMs: number, fn: () => void): () => void;
   /** Emit an informational notification (fire-and-forget). */
   notify(msg: string): void;
+  /**
+   * Fire an outbound webhook. Always resolves — never rejects — so failures
+   * never block other hooks. Production impl applies a 10s timeout and SSRF
+   * guard. Test impl pushes to `webhookCalls`.
+   */
+  postWebhook(opts: BackendWebhookOpts): Promise<BackendWebhookResult>;
 }
 
 // ── Interpreter context ───────────────────────────────────────────────────────
@@ -75,10 +109,73 @@ export interface InterpreterResult {
 
 // ── VsCodeBackend ─────────────────────────────────────────────────────────────
 
+/**
+ * SSRF guard for automation webhooks.
+ *
+ * Default policy (`allowPrivate=false`):
+ *   - Loopback (127.0.0.0/8, ::1, localhost, *.localhost) → ALLOWED.
+ *     Automation hooks fire INTO the same machine on the common path;
+ *     the bridge itself listens on 127.0.0.1, and recipe-6 webhooks
+ *     target `http://127.0.0.1:${BRIDGE_PORT}/...`.
+ *   - Other RFC 1918 / link-local / ULA / CGNAT / 0.0.0.0/8 → BLOCKED.
+ *   - Public hosts → ALLOWED.
+ *
+ * Opt-in (`allowPrivate=true`) drops the private-range check entirely.
+ *
+ * This is a deliberate divergence from `sendHttpRequest` which blocks ALL
+ * private addresses by default (loopback included). The reasoning: a
+ * MCP-tool-driven HTTP request is potentially attacker-controlled (a
+ * compromised LLM session could craft URLs); an automation webhook URL
+ * comes from a trusted policy file that the operator wrote. Loopback is
+ * the common case there, not the exceptional one.
+ */
+function isLoopbackHost(hostname: string): boolean {
+  const host =
+    hostname.startsWith("[") && hostname.endsWith("]")
+      ? hostname.slice(1, -1).toLowerCase()
+      : hostname.toLowerCase();
+  if (host === "localhost" || host.endsWith(".localhost")) return true;
+  if (host === "::1") return true;
+  const ipv4 = host.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
+  if (ipv4 && Number(ipv4[1]) === 127) return true;
+  return false;
+}
+
+function isPrivateNonLoopbackHost(hostname: string): boolean {
+  if (isLoopbackHost(hostname)) return false;
+  const host =
+    hostname.startsWith("[") && hostname.endsWith("]")
+      ? hostname.slice(1, -1).toLowerCase()
+      : hostname.toLowerCase();
+  if (host === "0.0.0.0") return true;
+  if (/^0x[0-9a-f]+$/i.test(host) || /^0[0-7]{7,}$/.test(host)) return true;
+  const ipv4 = host.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
+  if (ipv4) {
+    const a = Number(ipv4[1]);
+    const b = Number(ipv4[2]);
+    if (a === 10) return true;
+    if (a === 172 && b >= 16 && b <= 31) return true;
+    if (a === 192 && b === 168) return true;
+    if (a === 169 && b === 254) return true;
+    if (a === 100 && b >= 64 && b <= 127) return true;
+    if (a === 0) return true;
+  }
+  if (host.startsWith("fe80:")) return true;
+  if (host.startsWith("fc") || host.startsWith("fd")) return true;
+  if (host.startsWith("::ffff:"))
+    return isPrivateNonLoopbackHost(host.slice(7));
+  if (host.startsWith("::ffff:0:"))
+    return isPrivateNonLoopbackHost(host.slice(9));
+  return false;
+}
+
+const WEBHOOK_TIMEOUT_MS = 10_000;
+
 export class VsCodeBackend implements Backend {
   constructor(
     private readonly orchestrator: ClaudeOrchestrator,
     private readonly logger?: { info: (msg: string) => void },
+    private readonly allowPrivateWebhooks: boolean = false,
   ) {}
 
   async enqueueTask(opts: BackendEnqueueOpts): Promise<string> {
@@ -105,6 +202,77 @@ export class VsCodeBackend implements Backend {
   notify(msg: string): void {
     this.logger?.info(msg);
   }
+
+  async postWebhook(opts: BackendWebhookOpts): Promise<BackendWebhookResult> {
+    let parsed: URL;
+    try {
+      parsed = new URL(opts.url);
+    } catch (e) {
+      const error = `invalid url: ${e instanceof Error ? e.message : String(e)}`;
+      this.logger?.info(
+        `[automation-webhook] ${opts.hookKey} blocked: ${error}`,
+      );
+      return { ok: false, error };
+    }
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      const error = `unsupported protocol "${parsed.protocol}"`;
+      this.logger?.info(
+        `[automation-webhook] ${opts.hookKey} blocked: ${error}`,
+      );
+      return { ok: false, error };
+    }
+    if (
+      !this.allowPrivateWebhooks &&
+      isPrivateNonLoopbackHost(parsed.hostname)
+    ) {
+      const error = `private/non-loopback host "${parsed.hostname}" blocked (use --automation-allow-private-webhooks to enable)`;
+      this.logger?.info(
+        `[automation-webhook] ${opts.hookKey} blocked: ${error}`,
+      );
+      return { ok: false, error };
+    }
+
+    const headers: Record<string, string> = { ...opts.headers };
+    const hasContentType = Object.keys(headers).some(
+      (k) => k.toLowerCase() === "content-type",
+    );
+    if (!hasContentType) headers["Content-Type"] = "application/json";
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), WEBHOOK_TIMEOUT_MS);
+    try {
+      const res = await fetch(opts.url, {
+        method: opts.method,
+        headers,
+        body: JSON.stringify(opts.body),
+        signal: controller.signal,
+      });
+      clearTimeout(timer);
+      if (!res.ok) {
+        const error = `non-2xx response: ${res.status}`;
+        this.logger?.info(
+          `[automation-webhook] ${opts.hookKey} ${opts.method} ${opts.url} → ${res.status}`,
+        );
+        return { ok: false, status: res.status, error };
+      }
+      this.logger?.info(
+        `[automation-webhook] ${opts.hookKey} ${opts.method} ${opts.url} → ${res.status}`,
+      );
+      return { ok: true, status: res.status };
+    } catch (e) {
+      clearTimeout(timer);
+      const error =
+        e instanceof Error
+          ? e.name === "AbortError"
+            ? `timeout after ${WEBHOOK_TIMEOUT_MS}ms`
+            : e.message
+          : String(e);
+      this.logger?.info(
+        `[automation-webhook] ${opts.hookKey} ${opts.method} ${opts.url} failed: ${error}`,
+      );
+      return { ok: false, error };
+    }
+  }
 }
 
 // ── TestBackend ───────────────────────────────────────────────────────────────
@@ -113,6 +281,7 @@ export interface TestBackendCollector {
   enqueuedTasks: BackendEnqueueOpts[];
   scheduledRetries: Array<{ key: string; delayMs: number }>;
   notifications: string[];
+  webhookCalls: BackendWebhookOpts[];
 }
 
 export class TestBackend implements Backend {
@@ -120,7 +289,14 @@ export class TestBackend implements Backend {
     enqueuedTasks: [],
     scheduledRetries: [],
     notifications: [],
+    webhookCalls: [],
   };
+
+  /**
+   * Optional override for the webhook result a test wants to simulate.
+   * When unset, postWebhook returns `{ ok: true, status: 200 }`.
+   */
+  webhookResponse: BackendWebhookResult = { ok: true, status: 200 };
 
   async enqueueTask(opts: BackendEnqueueOpts): Promise<string> {
     this.collector.enqueuedTasks.push(opts);
@@ -137,9 +313,16 @@ export class TestBackend implements Backend {
     this.collector.notifications.push(msg);
   }
 
+  async postWebhook(opts: BackendWebhookOpts): Promise<BackendWebhookResult> {
+    this.collector.webhookCalls.push(opts);
+    return this.webhookResponse;
+  }
+
   reset(): void {
     this.collector.enqueuedTasks = [];
     this.collector.scheduledRetries = [];
     this.collector.notifications = [];
+    this.collector.webhookCalls = [];
+    this.webhookResponse = { ok: true, status: 200 };
   }
 }

--- a/src/fp/policyParser.ts
+++ b/src/fp/policyParser.ts
@@ -12,6 +12,7 @@ import {
   type HookType,
   hook,
   type PromptSourceNode,
+  type WebhookConfig,
   type WhenCondition,
   withCooldown,
   withDedup,
@@ -82,9 +83,15 @@ function buildPromptSource(src: PromptSource): ToolResult<PromptSourceNode> {
       promptArgs: src.promptArgs,
     });
   }
+  // Webhook-only hook (e.g. recipe-6 compaction triggers): no inline prompt,
+  // no named prompt, just a webhook fan-out. Caller is responsible for
+  // ensuring `webhook` is configured — `validatePromptSource` enforces this.
+  if (src.webhook !== undefined) {
+    return ok({ kind: "none" as const });
+  }
   return err(
     "invalid_arg",
-    "Hook must specify either `prompt` or `promptName`",
+    "Hook must specify either `prompt`, `promptName`, or `webhook`",
   );
 }
 
@@ -107,6 +114,17 @@ function buildWhen(src: PromptSource): WhenCondition | undefined {
 
 // ── Hook builder ──────────────────────────────────────────────────────────────
 
+/**
+ * Hook types that opt into webhook fan-out as of v1. Other types parse the
+ * `webhook` field successfully (per validatePromptSource) but the parser
+ * silently drops it — keeps the schema forward-compatible without enabling
+ * fan-out where it hasn't been thought through yet.
+ */
+const WEBHOOK_ENABLED_HOOK_TYPES = new Set<HookType>([
+  "onPreCompact",
+  "onPostCompact",
+]);
+
 function buildHook(
   hookType: HookType,
   src: PromptSource,
@@ -122,6 +140,19 @@ function buildHook(
   const promptSourceResult = buildPromptSource(src);
   if (!promptSourceResult.ok) return promptSourceResult;
 
+  // Wire `webhook` into the HookNode only for opted-in hook types. This keeps
+  // the v1 surface area focused on `onCompaction` (recipe-6 unblock) while
+  // letting the schema parse the field everywhere — adding a new hook type
+  // later is a one-line change to WEBHOOK_ENABLED_HOOK_TYPES.
+  const webhook: WebhookConfig | undefined =
+    src.webhook && WEBHOOK_ENABLED_HOOK_TYPES.has(hookType)
+      ? {
+          url: src.webhook.url,
+          method: src.webhook.method,
+          headers: src.webhook.headers,
+        }
+      : undefined;
+
   const hookNode: HookNode = hook({
     hookType,
     enabled,
@@ -133,6 +164,7 @@ function buildHook(
     effort,
     systemPrompt,
     extras,
+    webhook,
   });
 
   const key = cooldownKey(hookType, condition);


### PR DESCRIPTION
## Summary

Adds optional `webhook: { url, method?, headers? }` config to automation hooks, with the interpreter POSTing a JSON body to the URL after the inline prompt enqueue. Wired in the parser for `onCompaction` (onPreCompact / onPostCompact) only — the schema is forward-compatible for other hooks via a single-line addition to `WEBHOOK_ENABLED_HOOK_TYPES`.

**Why:** unblocks recipe 6 — `examples/recipes/bridge-dev/compaction-snapshot-pre.yaml` and `compaction-snapshot-post.yaml` are `webhook`-triggered recipes that snapshot and restore IDE state across compaction. They cannot fire today because `onCompaction` only supported inline `prompt` / `promptName`. Now the policy can do:

```json
{
  "onCompaction": {
    "phase": "pre",
    "enabled": true,
    "cooldownMs": 5000,
    "webhook": {
      "url": "http://127.0.0.1:54321/hooks/compaction-snapshot-pre",
      "method": "POST",
      "headers": { "Content-Type": "application/json" }
    }
  }
}
```

Body shape: `{ hookType, phase?, timestamp, ...eventData }`. 10s timeout. Non-2xx + network errors recorded as interpreter errors and logged; never throw, never block other hooks. Both inline `prompt` AND `webhook` may be set on the same entry — they run sequentially: prompt first, then webhook.

## Design

- **Backend interface** (`src/fp/interpreterContext.ts`) gained `postWebhook(opts) → Promise<{ok, status?, error?}>`, contractually never rejects. `VsCodeBackend` uses node `fetch`. `TestBackend` pushes to a `webhookCalls` collector + `reset()`.
- **New PromptSourceNode variant `{ kind: "none" }`** represents webhook-only hook entries (no inline prompt). Interpreter Hook case skips the task enqueue but still fans out to the webhook on the success path.
- **AutomationState** gains `lastWebhookFiredAt: ReadonlyMap<string, number>` (recorded regardless of HTTP outcome — operator wants the "we tried at T" telemetry). Bounded at 5_000 entries, FIFO eviction, merged via max-per-key in `mergeAutomationStates`.
- **WithCooldown** extended to detect webhook firing (delta in `lastWebhookFiredAt`) so cooldowns gate webhook-only hooks the same way they gate prompt-bearing ones — without this, cooldown was silently defeated for the webhook-only case.
- **Parser gating** — `WEBHOOK_ENABLED_HOOK_TYPES = { onPreCompact, onPostCompact }`. Other hook types parse the `webhook` field cleanly (validatePromptSource accepts it) but the parser drops it before constructing the HookNode. Forward-compatible: opting in `onGitCommit` later is a one-line change.

### SSRF policy

`VsCodeBackend.postWebhook` allows webhook URLs that are loopback (127.0.0.0/8, ::1, localhost, *.localhost) OR public, and BLOCKS other RFC 1918 / link-local / ULA / CGNAT / 0.0.0.0/8 ranges. Opt-out via constructor flag (CLI flag `--automation-allow-private-webhooks` is a follow-up — kept out of this PR to keep the diff focused).

This is a deliberate divergence from `sendHttpRequest` which blocks ALL private addresses by default (loopback included). Reasoning:

- A `sendHttpRequest` URL is potentially LLM-controlled — a compromised session could craft attacker URLs. Loopback can hit the bridge's own admin endpoints. SSRF is real attack surface.
- An automation webhook URL comes from a trusted policy file the operator wrote. Loopback is the intended common case (recipe 6 webhooks target `http://127.0.0.1:${BRIDGE_PORT}/...` — the bridge talking to itself).

Other private ranges blocked by default to catch typos; opt-in covers Docker / k8s / WSL2 setups where the loopback target is reachable only via 172.x or 10.x.

See [docs/adr/0009-automation-webhook-fanout.md](docs/adr/0009-automation-webhook-fanout.md) for the full design rationale, including alternatives considered.

## Files changed

```
 CLAUDE.md                                      |  15 ++
 docs/adr/0009-automation-webhook-fanout.md     |  72 +++++++++++ (new)
 src/automation.ts                              | 101 ++++++++++++++-
 src/fp/__tests__/automationInterpreter.test.ts | 161 +++++++++++++++++++++ (new tests)
 src/fp/automationInterpreter.ts                | 175 ++++++++++++++++++-----
 src/fp/automationProgram.ts                    |  33 ++++-
 src/fp/automationState.ts                      |  36 +++++
 src/fp/interpreterContext.ts                   | 183 ++++++++++++++++++++++++
 src/fp/policyParser.ts                         |  34 ++++-
```

## Test plan

- [x] 5 new unit tests in `src/fp/__tests__/automationInterpreter.test.ts`:
  - webhook-only hook posts correct URL/method/headers/body and records state
  - prompt + webhook on same entry runs sequentially (task enqueued, webhook posted)
  - non-2xx response recorded as interpreter error, state still updated
  - backend-throws defense (postWebhook contract is "never rejects" but a buggy backend could still throw)
  - WithCooldown gates webhook-only hooks correctly
- [x] Full FP layer: `npm test -- src/fp/` → 270 / 270 pass
- [x] Full suite: `npm test` → 5116 / 5116 pass
- [x] `npm run typecheck` clean
- [x] `npx biome check --write` clean
- [x] `node scripts/audit-lsp-tools.mjs` — registry intact, no drift

## Follow-ups (not in this PR)

- CLI flag `--automation-allow-private-webhooks` to flip the SSRF opt-in at runtime; currently the constructor default of `false` is hardcoded in `bridge.ts` `new VsCodeBackend(orchestrator, logger)`.
- Wire webhook fan-out for `onGitCommit`, `onTestRun`, `onPullRequest` (one-line additions to `WEBHOOK_ENABLED_HOOK_TYPES` + corresponding eventData passed through to the body).
- Dashboard surface for `lastWebhookFiredAt` so operators can see webhook health without grepping bridge logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)