### PR TITLE
fix(dashboard): bottom-nav clipping content on every inner page

### DIFF
--- a/dashboard/src/app/globals.css
+++ b/dashboard/src/app/globals.css
@@ -2150,7 +2150,13 @@ button.topbar-search {
     font-size: 13px;
   }
   .app-content {
-    padding: 16px;
+    /* Bottom padding clears the fixed bottom-nav (≈ 62 px) plus the iOS
+       home-indicator safe-area inset so the last row of content never
+       hides under the nav. The audit found this clipping content on
+       /tasks /decisions /activity /transactions /traces /settings
+       /marketplace and more — adding the padding here covers every
+       inner page in one rule. */
+    padding: 16px 16px calc(80px + env(safe-area-inset-bottom, 0px));
   }
   .app-main {
     grid-column: 1 / 2;


### PR DESCRIPTION
## Summary

Round-2 audit's universal P0: every inner page renders the fixed bottom-nav (62 px tall) over real content because `.app-content` mobile rule only sets `padding: 16px` all around. The last ~46 px of any scrollable page is hidden under the nav.

Confirmed broken pages from audit:
- `/tasks` — task summary text clips
- `/decisions` — last trace card
- `/activity` — bottom of feed
- `/transactions` — transaction-id row
- `/traces`, `/settings`, `/marketplace`, `/runs`, `/recipes` — last row in each

## Fix

Bump `.app-content` mobile padding-bottom to `calc(80px + env(safe-area-inset-bottom, 0px))`. Covers nav height (62 px) + breathing room + iOS home-indicator inset. One rule, every inner page.

Doesn't conflict with the recipe-editor savebar rule from #394 which sets a larger 140 px override via `body:has()` on those specific pages.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx next build` clean
- [x] `npm run tokens:check` clean
- [ ] Manual: scroll to bottom of /tasks, /transactions on iPhone — confirm last row visible above bottom-nav

🤖 Generated with [Claude Code](https://claude.com/claude-code)