### PR TITLE
fix(dashboard): mobile input zoom regression — 16-px floor mandatory

### DIFF
--- a/dashboard/src/app/globals.css
+++ b/dashboard/src/app/globals.css
@@ -2795,10 +2795,15 @@ button.topbar-search {
    it. Bumping form-controls to 16px on mobile suppresses the zoom.
    ────────────────────────────────────────────────────────────────────── */
 @media (max-width: 768px) {
+  /* `!important` is load-bearing: round-2 audit found this rule was
+     being shadowed by inline `style={{ fontSize: "var(--fs-m)" }}`
+     (13.5 px) on /settings driver fields, /recipes/new form, login —
+     inline styles win against regular CSS rules regardless of source
+     order. The override below makes the 16-px floor mandatory. */
   input,
   select,
   textarea {
-    font-size: 16px;
+    font-size: 16px !important;
   }
 }
 


### PR DESCRIPTION
## Summary

PR #389 added a 16 px floor on form-controls at ≤768 px to suppress iOS Safari's non-restorable zoom-on-focus. Round-2 audit found the rule was shadowed: every input on /settings, /recipes/new, and login uses inline `style={{ fontSize: "var(--fs-m)" }}` (13.5 px) which always beats regular CSS rules.

## Fix

Add `!important` to the 16-px rule. The floor is non-negotiable — a 13-px input focus on iOS triggers a non-restorable zoom that breaks the entire PWA.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run tokens:check` clean
- [ ] Manual: focus any input on /settings or /recipes/new on iPhone, confirm page does not zoom

🤖 Generated with [Claude Code](https://claude.com/claude-code)