### PR TITLE
fix(dashboard): mobile tap-target floor — 44px on touch

### DIFF
--- a/dashboard/src/app/globals.css
+++ b/dashboard/src/app/globals.css
@@ -2803,6 +2803,37 @@ button.topbar-search {
 }
 
 /* ──────────────────────────────────────────────────────────────────────
+   Touch tap-target floor.
+
+   Apple HIG and WCAG 2.5.5 (AAA) both want touch targets at ≥44 pt /
+   ≥44 px. Round-2 audit measured several controls below that:
+     .btn.sm                   32 × auto    (recipe/approval CTAs)
+     .topbar-icon-btn          32 × 32      (bell, theme, demo)
+     .cluster-tab              33 tall      (Pending/Suggested/History)
+
+   Bump the floor on touch devices specifically; desktop stays compact.
+   ────────────────────────────────────────────────────────────────────── */
+@media (hover: none) and (pointer: coarse) {
+  .btn.sm {
+    min-height: 44px;
+    padding: 0 14px;
+  }
+  .topbar-icon-btn,
+  .theme-toggle {
+    width: 44px;
+    height: 44px;
+  }
+  .cluster-tab {
+    min-height: 44px;
+    padding-top: 12px;
+    padding-bottom: 12px;
+  }
+  .sidebar-create {
+    min-height: 44px;
+  }
+}
+
+/* ──────────────────────────────────────────────────────────────────────
    Touch device hover neutralization.
 
    ~31 :hover rules in this stylesheet were authored without an


### PR DESCRIPTION
## Summary

Round-2 audit measured controls below Apple HIG / WCAG 2.5.5's 44 px touch-target minimum:

| Selector | Was | After |
|---|---|---|
| `.btn.sm` | 32 × auto | min-height 44 |
| `.topbar-icon-btn` / `.theme-toggle` | 32 × 32 | 44 × 44 |
| `.cluster-tab` | 33 tall | min-height 44 |
| `.sidebar-create` | unset | min-height 44 |

Gated under `@media (hover: none) and (pointer: coarse)` so desktop stays compact — same query PR #389 used for the hover neutralizer and PR #403 used for the kbd-hint hide.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run tokens:check` clean
- [ ] Manual: confirm controls are tap-able on iPhone, desktop unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)