### PR TITLE
fix(dashboard): /tasks horizontal overflow on mobile

### DIFF
--- a/dashboard/src/app/globals.css
+++ b/dashboard/src/app/globals.css
@@ -1392,6 +1392,21 @@ button.topbar-search {
   color: var(--ink-1);
 }
 
+/* /tasks two-pane layout: 440 px rail + flex detail on desktop,
+   single column on phone. The inline 440 px column was wider than a
+   390 px iPhone viewport, so the whole `.app-content` was scrolling
+   horizontally with the task summary text clipped at the edge. */
+.tasks-layout {
+  display: grid;
+  grid-template-columns: 440px minmax(0, 1fr);
+  gap: var(--s-4);
+}
+@media (max-width: 768px) {
+  .tasks-layout {
+    grid-template-columns: 1fr;
+  }
+}
+
 
 /* ---- Decision rows ---- */
 

--- a/dashboard/src/app/tasks/page.tsx
+++ b/dashboard/src/app/tasks/page.tsx
@@ -515,14 +515,12 @@ export default function TasksPage() {
           <SkeletonList rows={3} columns={3} />
         )
       ) : (
-        <div
-          style={{
-            display: "grid",
-            gridTemplateColumns: "440px minmax(0,1fr)",
-            gap: "var(--s-4)",
-            alignItems: "start",
-          }}
-        >
+        // Tasks two-pane layout: 440 px left rail + flex right detail
+        // on desktop, single column on mobile (the inline 440 px was
+        // wider than a 390 px iPhone viewport, causing 148 px of
+        // horizontal overflow on the whole `app-content`). The
+        // `.tasks-layout` class collapses to one column at ≤768 px.
+        <div className="tasks-layout" style={{ alignItems: "start" }}>
           {/* left: timeline rail + task list */}
           <div style={{ position: "relative" }}>
             <div


### PR DESCRIPTION
## Summary

Round-2 audit measured **148 px of horizontal overflow** on `/tasks` at 390 px viewport — `.app-content` rendered at 538 px and scrolled horizontally with task summary text clipping at the edge.

Root cause: inline `gridTemplateColumns: "440px minmax(0, 1fr)"` — fixed 440 px left column is wider than the iPhone viewport itself.

## Fix

Convert to a `.tasks-layout` class with the same desktop grid but a `grid-template-columns: 1fr` collapse at ≤768 px so list + detail stack vertically. Same pattern as the /inbox two-pane switcher (#393) and the home-page grid collapse (#392).

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run tokens:check` clean
- [ ] Manual: scroll /tasks on iPhone, confirm no horizontal scroll, summary text fully visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)