### PR TITLE
fix(recipes): honor step.when guard in yamlRunner (matches chainedRunner)

### DIFF
--- a/src/recipes/__tests__/yamlRunner.test.ts
+++ b/src/recipes/__tests__/yamlRunner.test.ts
@@ -605,6 +605,165 @@ describe("runYamlRecipe — seed context", () => {
   });
 });
 
+// ── step.when guard ───────────────────────────────────────────────────────────
+//
+// Regression: the `when:` clause is honored by chainedRunner but was silently
+// dropped in yamlRunner — every non-chained trigger (manual, cron, file_watch,
+// on_file_save, on_test_run, webhook, git_hook) ignored it. The 4 bridge-dev
+// iMessage recipes use `when: "{{phone}}"` to suppress an agent step when the
+// phone variable is empty; without this guard the agent ran every time.
+//
+// Match chainedRunner.ts:248-266 semantics: render template, truthy check
+// (empty string, "0", "false", "null", "undefined" are falsy).
+
+describe("runYamlRecipe — step.when guard", () => {
+  it("skips a tool step when `when` template renders empty", async () => {
+    const written: Record<string, string> = {};
+    const recipe = makeRecipe({
+      steps: [
+        { tool: "file.write", path: "/tmp/first.md", content: "always" },
+        {
+          tool: "file.write",
+          path: "/tmp/second.md",
+          content: "guarded",
+          when: "{{flag}}",
+        },
+      ],
+    });
+    const result = await runYamlRecipe(
+      recipe,
+      {
+        ...noop(),
+        writeFile: (p, c) => {
+          written[p] = c;
+        },
+      },
+      { flag: "" },
+    );
+    expect(written["/tmp/first.md"]).toBe("always");
+    expect(written["/tmp/second.md"]).toBeUndefined();
+    expect(result.stepResults[1]!.status).toBe("skipped");
+    expect(result.errorMessage).toBeUndefined();
+  });
+
+  it("runs a tool step when `when` template renders truthy", async () => {
+    const written: Record<string, string> = {};
+    const recipe = makeRecipe({
+      steps: [
+        { tool: "file.write", path: "/tmp/first.md", content: "always" },
+        {
+          tool: "file.write",
+          path: "/tmp/second.md",
+          content: "guarded",
+          when: "{{flag}}",
+        },
+      ],
+    });
+    const result = await runYamlRecipe(
+      recipe,
+      {
+        ...noop(),
+        writeFile: (p, c) => {
+          written[p] = c;
+        },
+      },
+      { flag: "yes" },
+    );
+    expect(written["/tmp/first.md"]).toBe("always");
+    expect(written["/tmp/second.md"]).toBe("guarded");
+    expect(result.stepResults[1]!.status).toBe("ok");
+  });
+
+  it("skips an agent step when `when` is empty (no agent invocation)", async () => {
+    let agentCalls = 0;
+    const recipe = makeRecipe({
+      steps: [
+        { tool: "file.write", path: "/tmp/report.md", content: "report" },
+        {
+          when: "{{phone}}",
+          agent: {
+            driver: "claude-code",
+            prompt: "send to {{phone}}",
+            into: "im_result",
+          },
+        },
+      ],
+    });
+    const result = await runYamlRecipe(
+      recipe,
+      {
+        ...noop(),
+        writeFile: () => {},
+        claudeCodeFn: async () => {
+          agentCalls++;
+          return "should never run";
+        },
+      },
+      { phone: "" },
+    );
+    expect(agentCalls).toBe(0);
+    expect(result.stepResults[1]!.status).toBe("skipped");
+    expect(result.errorMessage).toBeUndefined();
+  });
+
+  it("runs the agent step when `when` is truthy", async () => {
+    let agentCalls = 0;
+    const recipe = makeRecipe({
+      steps: [
+        { tool: "file.write", path: "/tmp/report.md", content: "report" },
+        {
+          when: "{{phone}}",
+          agent: {
+            driver: "claude-code",
+            prompt: "send to {{phone}}",
+            into: "im_result",
+          },
+        },
+      ],
+    });
+    await runYamlRecipe(
+      recipe,
+      {
+        ...noop(),
+        writeFile: () => {},
+        claudeCodeFn: async () => {
+          agentCalls++;
+          return "ok";
+        },
+      },
+      { phone: "+15551234567" },
+    );
+    expect(agentCalls).toBe(1);
+  });
+
+  it("treats '0' / 'false' / 'null' / 'undefined' as falsy (matches chainedRunner)", async () => {
+    for (const falsy of ["0", "false", "null", "undefined", " "]) {
+      const written: Record<string, string> = {};
+      const recipe = makeRecipe({
+        steps: [
+          {
+            tool: "file.write",
+            path: "/tmp/x.md",
+            content: "x",
+            when: "{{flag}}",
+          },
+        ],
+      });
+      await runYamlRecipe(
+        recipe,
+        {
+          ...noop(),
+          writeFile: (p, c) => {
+            written[p] = c;
+          },
+        },
+        { flag: falsy },
+      );
+      expect(written["/tmp/x.md"]).toBeUndefined();
+    }
+  });
+});
+
 // ── recipe-level context blocks (type: env) ───────────────────────────────────
 
 describe("runYamlRecipe — context: env blocks", () => {

--- a/src/recipes/tools/file.ts
+++ b/src/recipes/tools/file.ts
@@ -137,8 +137,11 @@ registerTool({
     assertWriteAllowed("file.append");
     const p = jailedPath(params.path as string, deps.workdir, true);
     const content = params.content as string;
-    // 'when' condition is evaluated before executeStep is called in yamlRunner
-    // but we check here too for direct registry usage
+    // 'when' is evaluated by both runners before executeStep is called
+    // (yamlRunner.ts step loop + chainedRunner.ts:248-266). This in-tool
+    // fallback only runs when the registry is invoked directly (no runner),
+    // and uses the limited evalCondition below — runner paths render the
+    // template against the recipe's context first, which this fallback can't.
     const when = step.when as string | undefined;
     if (when && !evalCondition(when, {})) {
       return null;

--- a/src/recipes/yamlRunner.ts
+++ b/src/recipes/yamlRunner.ts
@@ -490,6 +490,33 @@ export async function runYamlRecipe(
   let runError: string | undefined;
 
   for (const step of recipe.steps) {
+    // Evaluate `when` guard before running anything. Mirrors
+    // chainedRunner.ts:248-266 — render the template, then truthy-check the
+    // result (empty string, "0", "false", "null", "undefined" are falsy).
+    // A falsy guard records the step as `skipped`, increments stepsRun, and
+    // continues — it is NOT a failure. Bridge-dev iMessage recipes rely on
+    // this to suppress the iMessage agent step when phone is empty.
+    if (typeof step.when === "string" && step.when.length > 0) {
+      const rendered = render(step.when, ctx).trim().toLowerCase();
+      const truthy =
+        !!rendered &&
+        rendered !== "0" &&
+        rendered !== "false" &&
+        rendered !== "null" &&
+        rendered !== "undefined";
+      if (!truthy) {
+        const skipId = step.into ?? step.agent?.into ?? `step_${stepsRun}`;
+        stepResults.push({
+          id: skipId,
+          tool: step.agent ? "agent" : step.tool,
+          status: "skipped",
+          durationMs: 0,
+        });
+        stepsRun++;
+        continue;
+      }
+    }
+
     // Handle agent steps separately
     if (step.agent) {
       const agentCfg = step.agent;


### PR DESCRIPTION
## Why

The 4 bridge-dev iMessage recipes at `examples/recipes/bridge-dev/` use `when: "{{phone}}"` on the iMessage agent step to suppress sending when the phone variable is empty. That guard was a no-op — `runYamlRecipe` never read `step.when`, so the agent step ran every time and we paid for an agent invocation per run.

Only `chainedRunner.ts:248-266` evaluated `step.when`. Everything else (`manual`, `cron`, `file_watch`, `on_file_save`, `on_test_run`, `webhook`, `git_hook` triggers) silently dropped it. A stale comment at `src/recipes/tools/file.ts:140` claimed yamlRunner did honor it — it didn't.

## What

- Extend `runYamlRecipe`'s step loop to evaluate `step.when` *before* dispatching to either the agent or tool branch. Renders the template, applies the same truthy semantics as chainedRunner (`""`, `"0"`, `"false"`, `"null"`, `"undefined"` are falsy after trim+lowercase), and records the step as `status: "skipped"` (non-fatal, `runError` unchanged).
- Skip uses the same StepResult shape as the existing skipped path so the dashboard's Runs page and `~/.patchwork/runs.jsonl` see it correctly.
- Update the stale comment in `src/recipes/tools/file.ts` to describe what the in-tool fallback actually does (only meaningful for direct registry usage; runners pre-evaluate the template).

## Tests

Bug-fix protocol: failing test first.

`src/recipes/__tests__/yamlRunner.test.ts` — 5 new cases under `describe("runYamlRecipe — step.when guard")`:
- skips a tool step when `when` template renders empty
- runs a tool step when `when` template renders truthy
- skips an agent step when `when` is empty (asserts no agent invocation via `claudeCodeFn` spy — the bridge-dev iMessage scenario)
- runs the agent step when `when` is truthy
- treats `"0"` / `"false"` / `"null"` / `"undefined"` / whitespace as falsy (chainedRunner parity)

Verified: 3 of 5 fail before the fix, all 5 pass after. Full `npm test` clean (5121 tests, 375 files). `npm run typecheck` clean.

## Test plan
- [ ] CI green
- [ ] One of the bridge-dev iMessage recipes (e.g. `dual-version-drift-watcher.yaml`) skips `ping_phone` when `phone` is empty (no agent invocation, no error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)