### PR TITLE
fix(dashboard): /recipes mobile — let name column actually breathe

### DIFF
--- a/dashboard/src/app/globals.css
+++ b/dashboard/src/app/globals.css
@@ -1203,6 +1203,15 @@ button.topbar-search {
    nameless rows. Drop the three secondary metric columns; the values
    still live in the selected-recipe detail panel below the table. */
 @media (max-width: 768px) {
+  /* Hide secondary metric columns (LAST 14 RUNS, AVG, LAST). Round-2
+     audit found PR #391's first pass wasn't enough — the success-ring
+     col 1 (48 px) + trigger col 3 (120 px) + actions col 7 (110 px)
+     still left only ~110 px for the RECIPE name on a 390 px viewport,
+     and names continued to truncate to "morni…", "incid…". Hide col 1
+     too (the success ring is in the detail panel below) and let the
+     RECIPE column take the slack. Tighten cell padding further. */
+  .recipes-table th:nth-child(1),
+  .recipes-table td:nth-child(1),
   .recipes-table th:nth-child(4),
   .recipes-table td:nth-child(4),
   .recipes-table th:nth-child(5),
@@ -1213,7 +1222,22 @@ button.topbar-search {
   }
   .recipes-table th,
   .recipes-table td {
-    padding: 9px 10px;
+    padding: 9px 8px;
+  }
+  /* RECIPE name column: take all available width, no width clamp */
+  .recipes-table th:nth-child(2),
+  .recipes-table td:nth-child(2) {
+    width: auto;
+  }
+  /* TRIGGER column: tighter (was 120 px) */
+  .recipes-table th:nth-child(3),
+  .recipes-table td:nth-child(3) {
+    width: 90px;
+  }
+  /* Actions column: tighter (was 110 px) */
+  .recipes-table th:nth-child(7),
+  .recipes-table td:nth-child(7) {
+    width: 96px;
   }
 }
 


### PR DESCRIPTION
## Summary

PR #391's first pass at the /recipes mobile table hid 3 columns (LAST 14 RUNS, AVG, LAST) but kept the 48 px success-ring + 120 px trigger + 110 px actions. Round-2 audit measured the RECIPE name column getting only ~110 px on a 390 px viewport — names still truncating to `"morni…"`, `"incid…"`, `"daily-…"`.

## Fix

| Change | Was | After |
|---|---|---|
| Hide success-ring col 1 on mobile | 48 px | 0 (lives in detail panel) |
| Tighten TRIGGER col 3 | 120 px | 90 px |
| Tighten Actions col 7 | 110 px | 96 px |
| RECIPE col 2 | min 160 px clamp | `width: auto` (takes all slack) |
| Cell horizontal padding | 10 px | 8 px |

Result: RECIPE name gets ~180 px on a 390 px viewport — enough room for `"morning-brief-engineering"` and `"incident-war-room"` without truncation.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run tokens:check` clean
- [ ] Manual: scroll /recipes on iPhone, confirm full names visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)