### PR TITLE
fix(dashboard): round-3 mobile follow-ups (decisions, approvals, metrics, recipes)

### DIFF
--- a/dashboard/src/app/approvals/page.tsx
+++ b/dashboard/src/app/approvals/page.tsx
@@ -882,6 +882,7 @@ function ApprovalsContent() {
             })()}
           </div>
           <div
+            className="kbd-hint-row"
             style={{
               display: "flex",
               alignItems: "center",

--- a/dashboard/src/app/decisions/page.tsx
+++ b/dashboard/src/app/decisions/page.tsx
@@ -356,15 +356,13 @@ function DecisionsContent() {
                   </span>
                 </div>
 
-                {/* two-column body: problem | solution */}
+                {/* two-column body: problem | solution. Use .grid-2 utility
+                    (collapses to single column at ≤760 px) — at 390 px each
+                    side was getting ~140 px and PROBLEM/SOLUTION text was
+                    wrapping every 3-4 words. PR #407 added the suggestion
+                    fix but missed this file in the cherry-pick. */}
                 {(b.problem || b.solution) && (
-                  <div
-                    style={{
-                      display: "grid",
-                      gridTemplateColumns: "1fr 1fr",
-                      gap: 12,
-                    }}
-                  >
+                  <div className="grid-2">
                     {b.problem && (
                       <div
                         style={{

--- a/dashboard/src/app/globals.css
+++ b/dashboard/src/app/globals.css
@@ -2891,6 +2891,80 @@ button.topbar-search {
 }
 
 /* ──────────────────────────────────────────────────────────────────────
+   Mobile-only multi-page polish (round 3):
+   - Hide `.kbd-hint-row` on /approvals at phone width (the J/K/E/X
+     palette hint is meaningless without a physical keyboard; PR #403
+     hid the chips themselves but the surrounding "next prev approve"
+     labels remained, which read as broken text on touch).
+   - Metrics KPI tile grid: 4-up on desktop, 2-up on phone so the
+     numbers don't crush at ~80 px each.
+   - Recipe row: stack vertically on phone so the name has full width,
+     PR #391/#409 column-tweak approach didn't survive `tableLayout:
+     fixed` constraints in production.
+   ────────────────────────────────────────────────────────────────────── */
+.metrics-kpi-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: var(--s-4, 16px);
+}
+@media (max-width: 768px) {
+  .metrics-kpi-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: var(--s-3, 12px);
+  }
+  /* Hide the keyboard-shortcut hint row on phone (no physical keys
+     so the labels are misleading even with the chips hidden). */
+  .kbd-hint-row {
+    display: none !important;
+  }
+  /* Recipe row: switch from `tableLayout: fixed` to a stacked card
+     so the name gets the whole row width. The earlier column-width
+     tweaks couldn't reliably override `tableLayout: fixed` + inline
+     `minWidth: 160`. */
+  .recipes-table,
+  .recipes-table thead,
+  .recipes-table tbody,
+  .recipes-table tr,
+  .recipes-table td {
+    display: block !important;
+    width: 100% !important;
+  }
+  .recipes-table thead {
+    display: none !important;
+  }
+  .recipes-table tr {
+    border: 1px solid var(--line-1);
+    border-radius: var(--r-l, 12px);
+    margin-bottom: 8px;
+    padding: 10px 14px;
+    background: var(--surface);
+  }
+  .recipes-table td {
+    border-bottom: none !important;
+    padding: 4px 0 !important;
+    text-align: left !important;
+  }
+  /* Hide secondary metric columns and the success ring */
+  .recipes-table td:nth-child(1),
+  .recipes-table td:nth-child(4),
+  .recipes-table td:nth-child(5),
+  .recipes-table td:nth-child(6) {
+    display: none !important;
+  }
+  /* Recipe name (col 2) gets full row */
+  .recipes-table td:nth-child(2) {
+    font-weight: 600;
+  }
+  /* Trigger pill (col 3) and Actions (col 7) inline below the name */
+  .recipes-table td:nth-child(3),
+  .recipes-table td:nth-child(7) {
+    display: inline-block !important;
+    width: auto !important;
+    margin-right: 8px;
+  }
+}
+
+/* ──────────────────────────────────────────────────────────────────────
    Touch tap-target floor.
 
    Apple HIG and WCAG 2.5.5 (AAA) both want touch targets at ≥44 pt /

--- a/dashboard/src/app/metrics/page.tsx
+++ b/dashboard/src/app/metrics/page.tsx
@@ -169,14 +169,11 @@ export default function MetricsPage() {
         )}
       </div>
 
-      <div
-        style={{
-          display: "grid",
-          gridTemplateColumns: "repeat(4, minmax(0,1fr))",
-          gap: "var(--s-4)",
-          marginBottom: "var(--s-5)",
-        }}
-      >
+      {/* KPI tile row: 4-col on desktop, 2-col on phone (.grid-4 utility
+          collapses 4→2 at ≤1100, then to 1 at ≤760; we use a dedicated
+          class so the 4-up tiles stay 2-up at phone size where the
+          per-tile values are short enough to share a row). */}
+      <div className="metrics-kpi-grid" style={{ marginBottom: "var(--s-5)" }}>
         <div className="card" style={{ padding: "16px 20px", borderRadius: "var(--r-card)", borderLeft: "3px solid var(--orange)" }}>
           <div style={{ fontSize: "var(--fs-2xs)", fontFamily: "var(--font-mono)", fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.08em", color: "var(--ink-3)", marginBottom: 6 }}>
             <svg aria-hidden="true" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="var(--orange)" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" style={{ marginRight: 6, verticalAlign: "-1px" }}><path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z"/></svg>Total calls


### PR DESCRIPTION
## Summary

Round-3 audit on the deployed dashboard validated round-2 fixes and surfaced regressions/stragglers. This bundle ships four:

| Page | Fix |
|---|---|
| `/decisions` | PROBLEM/SOLUTION cards still 2-col on phone — PR #407 missed this file in cherry-pick. Switch inline `1fr 1fr` to `.grid-2`. |
| `/approvals` | "J/K/E/X/⌘K palette" hint row still visible on touch even with `.kbd` chips hidden. Tag the wrapper `.kbd-hint-row` and hide the whole row at `≤768 px`. |
| `/metrics` | KPI tile grid was 4-up on every viewport; at 390 px tiles crushed to ~80 px and lost units. New `.metrics-kpi-grid` class — 4-up desktop, 2-up phone. |
| `/recipes` | Name truncation persisted because `tableLayout: fixed` + inline `minWidth: 160` defeated PR #391/#409 column-width tweaks. Switch to stacked card layout at ≤768 px: each `<tr>` renders as a bordered card, name on its own row, trigger + actions inline below. |

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx next build` clean
- [x] `npm run tokens:check` clean
- [ ] Manual: scroll /decisions, /metrics, /recipes on iPhone — confirm fixes
- [ ] Manual: /approvals on iPhone — kbd-hint row gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)