### PR TITLE
fix(recipes): plumb claudeBinary through agent-step spawn

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -55,7 +55,8 @@
       "properties": {
         "slackChannel": { "type": "string" }
       }
-    }
+    },
+    "claudeBinary": { "type": "string" }
   },
   "additionalProperties": false
 }

--- a/src/patchworkConfig.ts
+++ b/src/patchworkConfig.ts
@@ -54,6 +54,22 @@ export interface PatchworkConfig {
   notifications?: {
     slackChannel?: string;
   };
+  /**
+   * Path to the `claude` CLI binary. Used by recipe `agent:` steps
+   * (`defaultClaudeCodeFn`) when the runtime can't rely on PATH-based
+   * lookup — e.g. a launchd-managed bridge whose env diverges from the
+   * developer's interactive shell, or a `npm link`-ed install where
+   * the global `claude` symlink resolves into a sandboxed dir.
+   *
+   * Override priority (highest first):
+   *   1. `PATCHWORK_CLAUDE_BINARY` env var
+   *   2. this `claudeBinary` config field
+   *   3. plain `"claude"` (PATH lookup)
+   *
+   * Default: omitted → spawn falls back to PATH lookup, matching
+   * pre-existing behavior.
+   */
+  claudeBinary?: string;
 }
 
 const DEFAULTS: PatchworkConfig = {

--- a/src/recipes/__tests__/yamlRunner.test.ts
+++ b/src/recipes/__tests__/yamlRunner.test.ts
@@ -2443,3 +2443,65 @@ describe("listYamlRecipes — JSON recipe files", () => {
     }
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────
+// resolveClaudeBinary — override precedence
+//
+// The recipe `agent:` step's `claude` spawn uses this resolver so a
+// launchd-managed bridge (whose PATH may not include the developer's
+// local install) can configure the binary explicitly via env or config.
+// ─────────────────────────────────────────────────────────────────────
+
+describe("resolveClaudeBinary — override precedence", async () => {
+  const { resolveClaudeBinary } = await import("../yamlRunner.js");
+
+  // Wrap each test in env restore: process.env mutations leak across
+  // tests within the same vitest worker.
+  const originalEnv = process.env.PATCHWORK_CLAUDE_BINARY;
+
+  function withEnv(value: string | undefined, fn: () => void) {
+    if (value === undefined) {
+      delete process.env.PATCHWORK_CLAUDE_BINARY;
+    } else {
+      process.env.PATCHWORK_CLAUDE_BINARY = value;
+    }
+    try {
+      fn();
+    } finally {
+      if (originalEnv === undefined) {
+        delete process.env.PATCHWORK_CLAUDE_BINARY;
+      } else {
+        process.env.PATCHWORK_CLAUDE_BINARY = originalEnv;
+      }
+    }
+  }
+
+  it("env var beats config + default", () => {
+    withEnv("/from/env/claude", () => {
+      expect(resolveClaudeBinary()).toBe("/from/env/claude");
+    });
+  });
+
+  it("empty env var is treated as unset (falls through to default)", () => {
+    withEnv("", () => {
+      // No PatchworkConfig.claudeBinary mocked here, so this falls through
+      // to the literal "claude" default. The point is: empty string in
+      // env shouldn't mean "spawn empty-string-binary".
+      expect(resolveClaudeBinary()).toBe("claude");
+    });
+  });
+
+  it("no env, no config → 'claude' default (PATH lookup)", () => {
+    withEnv(undefined, () => {
+      // This will call loadPatchworkConfigSync which reads the real
+      // ~/.patchwork/config.json — if the developer running the test
+      // has claudeBinary set there, this would return that value. The
+      // assertion below tolerates either: the default OR a configured
+      // override path. The strict env-precedence test above is the
+      // load-bearing assertion.
+      const result = resolveClaudeBinary();
+      expect(typeof result).toBe("string");
+      expect(result.length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/src/recipes/yamlRunner.ts
+++ b/src/recipes/yamlRunner.ts
@@ -1153,7 +1153,10 @@ function buildAgentExecutorDeps(
     localFn: (prompt, model) => stepDeps.localFn(prompt, model),
     probeClaudeCli: () => {
       if (runnerDeps.claudeFn !== undefined) return false;
-      const probe = spawnSync("claude", ["--version"], {
+      // Use the same resolution as defaultClaudeCodeFn so the auto-detect
+      // branch in agentExecutor.ts doesn't probe "claude" via PATH and
+      // then later fail to spawn the configured override (or vice versa).
+      const probe = spawnSync(resolveClaudeBinary(), ["--version"], {
         encoding: "utf-8",
         timeout: 5000,
       });
@@ -1172,13 +1175,37 @@ function buildAgentExecutorDeps(
   };
 }
 
+/**
+ * Resolve the `claude` binary path with override precedence:
+ *   1. PATCHWORK_CLAUDE_BINARY env var (set by the bridge LaunchAgent
+ *      or any wrapper script)
+ *   2. `~/.patchwork/config.json` `claudeBinary` field
+ *   3. plain `"claude"` (PATH lookup — pre-existing default)
+ *
+ * Resolved per-call, not memoised, so config edits + env-var changes
+ * take effect on the next agent step without a bridge restart.
+ */
+export function resolveClaudeBinary(): string {
+  const envOverride = process.env.PATCHWORK_CLAUDE_BINARY;
+  if (envOverride && envOverride.length > 0) return envOverride;
+  try {
+    const cfg = loadPatchworkConfigSync();
+    if (cfg.claudeBinary && cfg.claudeBinary.length > 0)
+      return cfg.claudeBinary;
+  } catch {
+    // ignore — fall through to the "claude" default
+  }
+  return "claude";
+}
+
 function defaultClaudeCodeFn(
   prompt: string,
   _opts?: { mcpAccess?: boolean },
 ): Promise<string> {
+  const binary = resolveClaudeBinary();
   try {
     const result = spawnSync(
-      "claude",
+      binary,
       [
         "-p",
         prompt,
@@ -1193,8 +1220,12 @@ function defaultClaudeCodeFn(
       },
     );
     if (result.error) {
+      // Surface the configured binary path in the error so users diagnosing
+      // ENOENT can see whether resolveClaudeBinary picked up their override.
+      // Hint includes the env var + config field names so the fix is one
+      // click away.
       return Promise.resolve(
-        "[agent step failed: claude CLI not found — install Claude Code or set ANTHROPIC_API_KEY]",
+        `[agent step failed: claude CLI not found at "${binary}" — install Claude Code, set PATCHWORK_CLAUDE_BINARY, or set ANTHROPIC_API_KEY]`,
       );
     }
     if (result.status !== 0) {


### PR DESCRIPTION
## Summary

Recipe `agent:` steps fail with `spawn claude ENOENT` whenever the `claude` CLI isn't on the spawning process's default PATH. Two real-world hits:

1. **Bridge launched by macOS launchd** — the plist's PATH is honored by the bridge process itself but doesn't always reach deeply-nested spawn contexts (recipe runner inside an orchestrator task). spawnSync hits launchd's default `/usr/bin:/bin:…` and ENOENTs.
2. **`npm install -g @anthropic-ai/claude-code`** puts the binary at `~/.local/bin/claude` — fine interactively, invisible to system-default PATH.

## Fix

`resolveClaudeBinary()` consults overrides in priority order:

| Priority | Source |
|---|---|
| 1 | `PATCHWORK_CLAUDE_BINARY` env var |
| 2 | `~/.patchwork/config.json` `claudeBinary` field (new) |
| 3 | `"claude"` (PATH lookup — pre-existing default) |

Both `defaultClaudeCodeFn` (the spawn) and `probeClaudeCli` (auto-detect probe) now use the same resolver. The error message surfaces the resolved binary path:

```
[agent step failed: claude CLI not found at "/Users/me/.local/bin/claude" —
 install Claude Code, set PATCHWORK_CLAUDE_BINARY, or set ANTHROPIC_API_KEY]
```

## Test plan

- [x] `resolveClaudeBinary()` exported + 3 precedence tests (env-beats-default, empty-env-treated-as-unset, no-overrides-fallthrough)
- [x] `configSchemaAlignment` regression updated for new field
- [x] `npx tsc --noEmit` clean
- [x] `npm run build` clean
- [x] `npm test` — 5124/5124 pass
- [ ] Manual: set `PATCHWORK_CLAUDE_BINARY=/Users/me/.local/bin/claude` on a launchd-managed bridge, run a recipe with an `agent:` step, confirm draft generates instead of ENOENT

## Workaround for users (until merged)

Set the env var when starting the bridge:
```bash
PATCHWORK_CLAUDE_BINARY=/Users/me/.local/bin/claude claude-ide-bridge …
```
Or add `claudeBinary` to `~/.patchwork/config.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)