### PR TITLE
docs(recipes): phone notifications via ntfy + iMessage TCC findings

### DIFF
--- a/docs/automation.md
+++ b/docs/automation.md
@@ -4,6 +4,8 @@
 
 Automation hooks let Claude act autonomously on IDE and git events without user input. When a Claude Code lifecycle event fires — a file is saved, a test run completes, a branch is checked out — the bridge evaluates your policy file, and if the matching hook is enabled and its cooldown has elapsed, the bridge spawns a Claude Code subprocess with the configured prompt. The subprocess has full access to bridge tools (full mode is the default since v2.43.0), runs to completion, and exits. No user interaction is required at any step.
 
+> **Reaching your phone from a hook or recipe:** the bridge subprocess runs under `launchd`'s TCC identity, so AppleScript / iMessage paths are silently denied. Use [ntfy.sh](recipe-phone-notifications.md) instead — one `curl POST` from any hook step, no signing, no permissions, action-button round-trip supported.
+
 ---
 
 ## Prerequisites

--- a/docs/recipe-phone-notifications.md
+++ b/docs/recipe-phone-notifications.md
@@ -1,0 +1,99 @@
+# Sending recipe output to your phone
+
+You will eventually want a recipe to ping your phone — a daily brief, a "this PR is ready for review" nudge, a tweet draft to approve. This doc walks through the path that works and the dead ends to skip.
+
+## TL;DR
+
+Use **[ntfy.sh](https://ntfy.sh)**, not iMessage. One `curl POST` from any recipe step lands as a push on your phone with optional action buttons. No signing, no permissions, no platform-specific code paths.
+
+```yaml
+- id: push-to-phone
+  agent:
+    driver: claude-code
+    tools: [Bash]
+    prompt: |
+      Run EXACTLY:
+      curl -fsS -X POST \
+        -H "Title: Daily brief" \
+        -d "Three PRs need review" \
+        https://ntfy.sh/<your-unguessable-topic>
+```
+
+Pick a long random topic (`openssl rand -hex 6` is enough — topics are unauthenticated by default; treat the topic name as the secret). Install the ntfy app on iOS or Android, subscribe to the topic, done.
+
+## Why not iMessage / AppleScript
+
+This is the path most people try first. It looks like five lines of AppleScript. It does not work reliably from a recipe.
+
+The blocker is macOS TCC (Transparency, Consent, Control). When a process tries to send AppleEvents to Messages.app, TCC checks the **responsible process** — not the immediate caller, but the bundle identity at the top of the spawn chain. For a recipe step, that chain is:
+
+```
+launchd → patchwork bridge (node) → claude CLI → osascript → Messages.app
+```
+
+`launchd` is the responsible process. It is not in System Settings → Privacy & Security → Automation, and macOS will not prompt for it. The AppleEvent is denied silently — `osascript` exits 0, no error reaches the recipe, no message is delivered. From an interactive Terminal session the same script works fine, because Terminal.app is the responsible process and TCC knows about it.
+
+We tried the obvious workarounds:
+
+- **Custom `SendIMessage.app` helper with a stable bundle ID.** Modern macOS (Sequoia 15+) pins TCC grants to `(bundle ID, code-signing-identity-hash)`. Ad-hoc signatures hash to the binary's CDHash, which changes on every rebuild — so the grant invalidates. You need a real Developer ID team identifier, which means a paid Apple Developer account and notarization for every helper update. Not viable for a personal automation.
+- **Apple Shortcuts via `shortcuts run`.** Same TCC chain, plus the Send Message action prompts for confirmation in many configurations. Unreliable.
+- **Re-bootstrapping the bridge LaunchAgent into the GUI session** (`launchctl bootstrap gui/$UID`). Helps for some Aqua-only services but does not change Automation→Messages — TCC still demands a Developer-ID-signed responsible process.
+
+If you absolutely need iMessage delivery and accept the limitations, the only path that works without a paid Developer ID is running the bridge inside Terminal.app via a Login Item (a `.command` script that backgrounds the bridge in tmux/screen). Terminal then becomes the responsible process. You lose headless-after-reboot recovery.
+
+## Why ntfy
+
+ntfy is a thin pub-sub HTTP server. The recipe POSTs a message; the iOS/Android app receives a push. Architecture-wise it sidesteps every TCC question because no AppleEvent is involved.
+
+Practical advantages over iMessage for recipe output:
+
+- **Works from any spawn context.** LaunchAgent, cron, ssh, bridge subprocess — anywhere `curl` can reach the public internet.
+- **Action buttons.** Up to three buttons per notification, either `view` (opens a URL) or `http` (POSTs/PUTs back to a URL — true round-trip into your bridge).
+- **Tags, priorities, click URLs, attachments.** A `Click` header makes the entire notification tap-to-open-URL.
+- **Self-hostable.** If you outgrow the public ntfy.sh server, the same `curl` URL pattern points at your own deployment.
+
+Limitations to know about:
+
+- The public `ntfy.sh` topic namespace is shared. Use a long random topic name; treat it like a bearer token.
+- Public ntfy keeps messages for 12h by default. For longer retention or auth, self-host.
+- iOS app uses Apple Push Notification Service, so deep-background reliability matches anything else on iOS.
+
+## Action buttons (round-trip approval)
+
+For approve/reject style flows where tapping a button should land state back on the bridge, use the JSON publish form (avoids HTTP-header encoding issues with non-ASCII content) and `http` actions:
+
+```bash
+curl -X POST https://ntfy.sh/ \
+  -H "Content-Type: application/json" \
+  -d '{
+    "topic": "your-topic",
+    "title": "Approve tool call?",
+    "message": "Agent wants to run rm -rf node_modules in three repos.",
+    "actions": [
+      {
+        "action": "http",
+        "label": "Approve",
+        "url": "https://bridge.example.com/approvals/abc123/approve",
+        "method": "POST",
+        "headers": { "Authorization": "Bearer <bridge-token>" }
+      },
+      {
+        "action": "http",
+        "label": "Reject",
+        "url": "https://bridge.example.com/approvals/abc123/reject",
+        "method": "POST",
+        "headers": { "Authorization": "Bearer <bridge-token>" }
+      }
+    ]
+  }'
+```
+
+The bridge endpoint is whatever your reverse tunnel exposes (see [docs/remote-access.md](remote-access.md)). Use a short-lived approval token in the URL path so a leaked notification doesn't grant indefinite access.
+
+## Header encoding gotcha
+
+ntfy supports two publish forms: header-based (`-H "Title: ..."` against `https://ntfy.sh/<topic>`) and JSON (`POST https://ntfy.sh/` with `{"topic": ..., "title": ...}`). HTTP headers are latin-1 only — em-dashes, smart quotes, emoji in titles or messages will fail. Use the JSON form whenever the content is not pure ASCII. Use the header form for one-off scripts where you control the content.
+
+## Working example
+
+[`oolabs-daily-tweets.yaml`](../examples/recipes/oolabs-daily-tweets.yaml) drafts three tweets from recent merged PRs and pushes them to the user's phone via ntfy with a `Click: https://x.com/compose/tweet` header so tapping the notification opens X compose. The push step is a single `curl` against the topic — the entire path from `patchwork recipe run` to phone-buzz is under five seconds after the agent step completes.

--- a/examples/recipes/oolabs-daily-tweets.yaml
+++ b/examples/recipes/oolabs-daily-tweets.yaml
@@ -1,0 +1,112 @@
+apiVersion: patchwork.sh/v1
+name: daily-tweets-from-prs
+description: |
+  Draft 3 tweets about your project based on recent merged PRs and open
+  issues, then push the drafts to your phone via ntfy.sh for pick-and-post.
+  Demonstrates the recipe → phone push pattern documented in
+  docs/recipe-phone-notifications.md.
+
+  Replace the REPO, HANDLE, and NTFY_TOPIC placeholders before running.
+  Generate an unguessable topic with `openssl rand -hex 6`.
+trigger:
+  type: manual
+
+steps:
+  - tool: github.list_prs
+    repo: "your-org/your-repo"
+    author: "@me"
+    max: 12
+    into: recent_prs
+  - tool: github.list_issues
+    repo: "your-org/your-repo"
+    assignee: "@me"
+    max: 8
+    into: recent_issues
+
+  - id: draft-tweets
+    agent:
+      driver: claude-code
+      model: claude-haiku-4-5-20251001
+      prompt: |
+        Use ONLY the data provided below.
+
+        You are drafting 3 tweets for @your_handle about your open-source
+        project. Replace this paragraph with your project's one-liner.
+
+        RECENT MERGED PRs:
+        <untrusted_data>
+        {{recent_prs.json}}
+        </untrusted_data>
+
+        OPEN ISSUES:
+        <untrusted_data>
+        {{recent_issues.json}}
+        </untrusted_data>
+
+        Draft 3 tweets with DIFFERENT angles:
+          1. SHIPPED — pick one PR, explain what users can now do.
+          2. CRAFT — a small architectural observation. Thread opener.
+          3. USE-CASE — a workflow scenario with a soft CTA.
+
+        Hard rules:
+          - <= 280 chars including link.
+          - No "excited to announce", "thrilled", "leveraging".
+          - Max 1 hashtag per tweet, only if genuinely discoverable.
+
+        Output (plain text, exactly this shape):
+
+        Tweet 1 (shipped):
+        <tweet text>
+
+        Tweet 2 (craft):
+        <tweet text>
+
+        Tweet 3 (use-case):
+        <tweet text>
+      into: tweet_drafts
+
+  - tool: file.write
+    path: "~/.patchwork/inbox/tweet-drafts-{{date}}.md"
+    content: |
+      # Tweet drafts -- {{date}}
+
+      ---
+
+      {{tweet_drafts}}
+
+      ---
+
+      Pick one (or remix), then paste into https://x.com/compose/tweet.
+
+  # Push to phone via ntfy.sh -- no TCC, no AppleEvents, no signing.
+  # Replace NTFY_TOPIC with your unguessable random topic.
+  # Subscribe to the same topic in the ntfy iOS/Android app.
+  - id: push-to-phone
+    agent:
+      driver: claude-code
+      model: claude-haiku-4-5-20251001
+      tools:
+        - Bash
+      prompt: |
+        Run EXACTLY this Bash command:
+
+        curl -fsS -X POST \
+          -H "Title: Tweet drafts ready" \
+          -H "Tags: bird,memo" \
+          -H "Click: https://x.com/compose/tweet" \
+          -d "$(cat <<'NTFY_BODY_EOF'
+        {{tweet_drafts}}
+
+        ---
+        Pick 1 / 2 / 3, paste into https://x.com/compose/tweet
+        NTFY_BODY_EOF
+        )" \
+          https://ntfy.sh/NTFY_TOPIC
+
+        Print "ok" if curl exited 0, otherwise print the curl error.
+      into: push_result
+
+on_error:
+  notify: true
+  retry: 0
+  fallback: log_only

--- a/examples/recipes/oolabs-daily-tweets.yaml
+++ b/examples/recipes/oolabs-daily-tweets.yaml
@@ -28,40 +28,70 @@ steps:
       driver: claude-code
       model: claude-haiku-4-5-20251001
       prompt: |
-        Use ONLY the data provided below.
+        Use ONLY the data below.
 
         You are drafting 3 tweets for @your_handle about your open-source
-        project. Replace this paragraph with your project's one-liner.
+        project. Replace this paragraph with your project's one-liner in
+        plain words — no buzzwords, no marketing voice.
 
-        RECENT MERGED PRs:
+        RECENT MERGES (what just shipped):
         <untrusted_data>
         {{recent_prs.json}}
         </untrusted_data>
 
-        OPEN ISSUES:
+        OPEN WORK (what's still in flight):
         <untrusted_data>
         {{recent_issues.json}}
         </untrusted_data>
 
-        Draft 3 tweets with DIFFERENT angles:
-          1. SHIPPED — pick one PR, explain what users can now do.
-          2. CRAFT — a small architectural observation. Thread opener.
-          3. USE-CASE — a workflow scenario with a soft CTA.
+        TODAY'S DATE: {{date}}
+        Use the day-of-month modulo 9 to pick THREE distinct angles from
+        the pool below. Do not repeat angles within a single day.
 
-        Hard rules:
-          - <= 280 chars including link.
-          - No "excited to announce", "thrilled", "leveraging".
-          - Max 1 hashtag per tweet, only if genuinely discoverable.
+        ANGLE POOL:
+          A. Just-shipped: pick one PR. Describe the thing a user can now
+             do that they couldn't yesterday. One sentence, no buzzwords.
+          B. Tiny win: a small daily moment your project makes better.
+             Concrete, sensory, no abstractions.
+          C. Behind the curtain: one small design choice and the reason
+             for it, told the way you'd tell another developer over coffee.
+          D. Caught one: a real moment your project stopped a mistake.
+             Short anecdote.
+          E. Open question: pick a real open issue. Ask the timeline.
+             Invite replies. No fake humility.
+          F. The pitch in 3 lines: what it is, who it's for, what it
+             costs to try. Plain language only.
+          G. Comparison: one specific way your project differs from the
+             default tool. Name a behavior, contrast it.
+          H. Quiet brag: one true stat or fact. No vanity metrics.
+          I. Honest tradeoff: something your project does NOT do, and
+             why that's a deliberate choice.
 
-        Output (plain text, exactly this shape):
+        TONE (also rotate by day-of-month modulo 4, apply to all 3):
+          0. Dry and matter-of-fact. Short sentences.
+          1. Slightly playful, like texting a friend.
+          2. Reflective. Notice something small.
+          3. Direct and useful. Each tweet teaches one thing.
 
-        Tweet 1 (shipped):
+        HARD RULES:
+          - <= 280 chars including any link.
+          - Plain everyday language. Talk like you're talking to a friend.
+          - BANNED: "excited", "thrilled", "leveraging", "powerful",
+            "seamless", "robust", "game-changer", "unlock", "empower",
+            "ecosystem", "we're", and any project-specific jargon.
+          - Don't open with the project name. Don't end with "check it out".
+          - Zero hashtags by default.
+          - No emoji unless the angle genuinely calls for one (max 1).
+
+        Output (plain text, EXACTLY this shape, no JSON, no fences):
+
+        Tweet 1:
         <tweet text>
 
-        Tweet 2 (craft):
+        Tweet 2:
         <tweet text>
 
-        Tweet 3 (use-case):
+        Tweet 3:
         <tweet text>
       into: tweet_drafts
 

--- a/examples/recipes/oolabs-daily-tweets.yaml
+++ b/examples/recipes/oolabs-daily-tweets.yaml
@@ -83,6 +83,19 @@ steps:
           - Zero hashtags by default.
           - No emoji unless the angle genuinely calls for one (max 1).
 
+        SUNDAY WILDCARD:
+        Compute today's day-of-week from {{date}} (Sunday = 0). If today
+        is Sunday, ALSO produce a fourth tweet from the WILDCARD POOL
+        below (can break 280 chars if it earns the length, e.g. as a
+        thread opener). On any other day, output exactly 3 and stop.
+
+        WILDCARD POOL (Sundays only):
+          W1. Thread starter: longer first post, ends with "(1/n)" cue.
+          W2. Week in review: the most interesting thing that landed.
+          W3. What I'm thinking about: an in-progress thought, not a roadmap.
+          W4. Reader question: a real design question to the timeline.
+          W5. Field note: an observation from using your own tool all week.
+
         Output (plain text, EXACTLY this shape, no JSON, no fences):
 
         Tweet 1:
@@ -92,6 +105,10 @@ steps:
         <tweet text>
 
         Tweet 3:
+        <tweet text>
+
+        (Sunday only — omit on every other day:)
+        Tweet 4 (wildcard):
         <tweet text>
       into: tweet_drafts
 


### PR DESCRIPTION
## Summary

- New [docs/recipe-phone-notifications.md](docs/recipe-phone-notifications.md) explaining why iMessage/AppleScript silently fails from recipe steps (launchd TCC responsible-process chain) and the working ntfy.sh alternative.
- New [examples/recipes/oolabs-daily-tweets.yaml](examples/recipes/oolabs-daily-tweets.yaml) — sanitized version of the recipe pattern (placeholder repo/handle/topic).
- Cross-link callout in [docs/automation.md](docs/automation.md) so hook authors hit this doc before going down the AppleScript rabbit hole.

## Why

Built a daily-tweets recipe that tried to deliver via iMessage. Recipe step exited 0; no message ever arrived. Spent a session diagnosing — turns out modern macOS (Sequoia 15+) pins TCC Automation grants to `(bundle ID, signing-identity-hash)`. Ad-hoc-signed helper apps invalidate the grant on every rebuild because CDHash changes; LaunchAgent-spawned subprocesses (`launchd → node → claude → osascript`) resolve to `launchd` as the responsible process and macOS never prompts. No `tccutil`/`defaults`/MDM workaround without a paid Apple Developer ID.

ntfy.sh sidesteps the entire surface — it's a `curl POST` from any spawn context. Verified end-to-end on the working recipe; action buttons (`view`, `http`) work on iOS with JSON-publish form.

## Test plan

- [ ] Read [docs/recipe-phone-notifications.md](docs/recipe-phone-notifications.md) start to finish
- [ ] Verify [examples/recipes/oolabs-daily-tweets.yaml](examples/recipes/oolabs-daily-tweets.yaml) parses (`patchwork recipe preflight examples/recipes/oolabs-daily-tweets.yaml`)
- [ ] Confirm cross-link in [docs/automation.md](docs/automation.md) renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)