### PR TITLE
feat(approvals): ntfy.sh as a relay-free phone-path option

### DIFF
--- a/docs/mobile-oversight.md
+++ b/docs/mobile-oversight.md
@@ -28,8 +28,49 @@ within 500 ms.
 ## Prerequisites
 
 - Patchwork bridge v0.2.0-alpha.18+ running locally or on a VPS.
-- A push relay service reachable from the bridge (self-hosted or hosted at `notify.patchwork.dev`).
-- The dashboard installed as a PWA on your phone (see step 4).
+- A push path. Pick one:
+  - **ntfy.sh** (simplest, recommended for personal use) — free, hosted, action-button approvals straight from the lock screen. No relay infrastructure to run. See [Step 1B](#step-1b--ntfysh-no-relay-needed) below.
+  - **Push relay** (FCM/APNS, recommended for teams) — full PWA + service worker integration, custom branding. Self-hosted or hosted at `notify.patchwork.dev`. See [Step 1A](#step-1--deploy-the-push-relay) below.
+  - You can also run **both** in parallel; they're independent.
+- For the relay path: the dashboard installed as a PWA on your phone (see step 4).
+- For the ntfy path: the [ntfy iOS / Android app](https://ntfy.sh/) installed and subscribed to your topic.
+
+---
+
+## Step 1B — ntfy.sh (no relay needed)
+
+Skip this section if you're going with FCM/APNS via the push relay (Step 1 below).
+
+ntfy.sh is a thin pub-sub HTTPS server with iOS/Android apps. The bridge POSTs each pending approval as a notification with two HTTP action buttons (Approve / Reject) that POST back to the bridge with the same single-use token the relay path uses. Tap a button on the lock screen, the approval lands. No FCM, no APNS, no service worker.
+
+1. Pick an unguessable topic. The topic name is your bearer-equivalent — anyone subscribed sees the approval payload and the single-use token.
+
+   ```bash
+   openssl rand -hex 6
+   # → e.g. d1949fe75b5e — use as the topic suffix
+   ```
+
+2. Install the [ntfy app](https://ntfy.sh/) on your phone, open it, **+** → **Subscribe to topic** → enter `patchwork-<your-suffix>`. Leave server as `ntfy.sh` unless you're self-hosting.
+
+3. Configure the bridge. The bridge's `pushServiceBaseUrl` must be a public HTTPS URL the phone can reach (your reverse tunnel / VPS / Cloudflare Tunnel). The action buttons POST to `${pushServiceBaseUrl}/approve/<callId>` with the single-use token in the `x-approval-token` header.
+
+   ```bash
+   curl -X POST https://<bridge-public-url>/settings \
+     -H "Authorization: Bearer $BRIDGE_TOKEN" \
+     -H "Content-Type: application/json" \
+     -d '{
+       "ntfyTopic": "patchwork-d1949fe75b5e",
+       "pushServiceBaseUrl": "https://<bridge-public-url>"
+     }'
+   ```
+
+   Self-hosted ntfy: also pass `"ntfyServer": "https://ntfy.your-domain.tld"`.
+
+4. Test it. Trigger any approval-gated tool call (e.g. a `gitPush` from a Claude Code session). Within seconds your phone buzzes with a notification carrying Approve / Reject buttons. Tap one. The bridge records the decision and unblocks the tool call.
+
+**Security model:** the `pushServiceBaseUrl` must be HTTPS — the bridge refuses to publish ntfy notifications when it's plaintext, because the action URLs would carry the single-use token over the wire. Topic names should be high-entropy (≥ 8 random hex bytes) and rotated if leaked. For multi-recipient or auth-gated topics, run [self-hosted ntfy](https://docs.ntfy.sh/install/) and point `ntfyServer` at it.
+
+**Trade-off vs the relay path:** ntfy is single-recipient (anyone with the topic name receives the push), no PWA, no custom branding. If you need team workflows or per-user device routing, use the relay path below.
 
 ---
 

--- a/src/__tests__/approvalHttp.test.ts
+++ b/src/__tests__/approvalHttp.test.ts
@@ -1042,6 +1042,150 @@ describe("push notification dispatch", () => {
     }
   });
 
+  it("ntfy publish includes Approve/Reject http actions with approvalToken header when ntfyTopic + bridgeCallbackBase configured", async () => {
+    const originalFetch = globalThis.fetch;
+    const ntfyCalls: Array<{ url: string; body: unknown }> = [];
+    globalThis.fetch = (async (url: string, init?: RequestInit) => {
+      ntfyCalls.push({
+        url,
+        body: JSON.parse((init?.body as string) ?? "{}"),
+      });
+      return new Response("{}", { status: 200 });
+    }) as typeof globalThis.fetch;
+    try {
+      const queue = new ApprovalQueue();
+      const pending = routeApprovalRequest(
+        { method: "POST", path: "/approvals", body: { toolName: "gitPush" } },
+        {
+          queue,
+          workspace: "/tmp",
+          ccLoader: emptyRules(),
+          approvalGate: "all",
+          ntfyTopic: "patchwork-test-topic",
+          ntfyServer: "https://ntfy.example.com",
+          pushServiceBaseUrl: "https://bridge.example.com",
+        },
+      );
+      await new Promise((r) => setTimeout(r, 50));
+      const item = queue.list()[0];
+      if (!item) throw new Error("no queued item");
+      queue.approve(item.callId);
+      await pending;
+
+      const ntfyCall = ntfyCalls.find(
+        (c) => new URL(c.url).hostname === "ntfy.example.com",
+      );
+      expect(ntfyCall).toBeDefined();
+      const body = ntfyCall!.body as {
+        topic: string;
+        actions: Array<{
+          action: string;
+          label: string;
+          method: string;
+          url: string;
+          headers: Record<string, string>;
+        }>;
+      };
+      expect(body.topic).toBe("patchwork-test-topic");
+      expect(body.actions).toHaveLength(2);
+      const approve = body.actions.find((a) => a.label === "Approve");
+      const reject = body.actions.find((a) => a.label === "Reject");
+      expect(approve).toBeDefined();
+      expect(reject).toBeDefined();
+      expect(approve!.action).toBe("http");
+      expect(approve!.method).toBe("POST");
+      expect(approve!.url).toBe(
+        `https://bridge.example.com/approve/${item.callId}`,
+      );
+      expect(reject!.url).toBe(
+        `https://bridge.example.com/reject/${item.callId}`,
+      );
+      // Single-use approval token must be in the header set, not the URL.
+      expect(typeof approve!.headers["x-approval-token"]).toBe("string");
+      expect(approve!.headers["x-approval-token"].length).toBeGreaterThan(16);
+      expect(approve!.url).not.toContain(approve!.headers["x-approval-token"]);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("ntfy publish skipped when bridgeCallbackBase missing (action URLs cannot be built)", async () => {
+    const originalFetch = globalThis.fetch;
+    const calls: string[] = [];
+    globalThis.fetch = (async (url: string) => {
+      calls.push(url);
+      return new Response("{}", { status: 200 });
+    }) as typeof globalThis.fetch;
+    try {
+      const queue = new ApprovalQueue();
+      const pending = routeApprovalRequest(
+        { method: "POST", path: "/approvals", body: { toolName: "gitPush" } },
+        {
+          queue,
+          workspace: "/tmp",
+          ccLoader: emptyRules(),
+          approvalGate: "all",
+          ntfyTopic: "patchwork-test-topic",
+          // pushServiceBaseUrl deliberately omitted
+        },
+      );
+      await new Promise((r) => setTimeout(r, 20));
+      const item = queue.list()[0];
+      if (item) queue.approve(item.callId);
+      await pending;
+      expect(
+        calls.filter((u) => {
+          try {
+            return new URL(u).hostname === "ntfy.sh";
+          } catch {
+            return false;
+          }
+        }),
+      ).toHaveLength(0);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("ntfy publish blocks non-HTTPS bridgeCallbackBase (would expose token over plaintext)", async () => {
+    const originalFetch = globalThis.fetch;
+    const calls: string[] = [];
+    globalThis.fetch = (async (url: string) => {
+      calls.push(url);
+      return new Response("{}", { status: 200 });
+    }) as typeof globalThis.fetch;
+    try {
+      const queue = new ApprovalQueue();
+      const pending = routeApprovalRequest(
+        { method: "POST", path: "/approvals", body: { toolName: "gitPush" } },
+        {
+          queue,
+          workspace: "/tmp",
+          ccLoader: emptyRules(),
+          approvalGate: "all",
+          ntfyTopic: "patchwork-test-topic",
+          ntfyServer: "https://ntfy.example.com",
+          pushServiceBaseUrl: "http://bridge.example.com",
+        },
+      );
+      await new Promise((r) => setTimeout(r, 20));
+      const item = queue.list()[0];
+      if (item) queue.approve(item.callId);
+      await pending;
+      expect(
+        calls.filter((u) => {
+          try {
+            return new URL(u).hostname === "ntfy.example.com";
+          } catch {
+            return false;
+          }
+        }),
+      ).toHaveLength(0);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   it("non-HTTPS push service URL is blocked", async () => {
     const originalFetch = globalThis.fetch;
     const calls: string[] = [];

--- a/src/__tests__/approvalHttp.test.ts
+++ b/src/__tests__/approvalHttp.test.ts
@@ -1109,6 +1109,56 @@ describe("push notification dispatch", () => {
     }
   });
 
+  it("ntfy publishes a confirmation notification after the approval is decided (visible feedback for silent http actions)", async () => {
+    const originalFetch = globalThis.fetch;
+    const ntfyCalls: Array<{ url: string; body: unknown }> = [];
+    globalThis.fetch = (async (url: string, init?: RequestInit) => {
+      ntfyCalls.push({
+        url,
+        body: JSON.parse((init?.body as string) ?? "{}"),
+      });
+      return new Response("{}", { status: 200 });
+    }) as typeof globalThis.fetch;
+    try {
+      const queue = new ApprovalQueue();
+      const pending = routeApprovalRequest(
+        { method: "POST", path: "/approvals", body: { toolName: "gitPush" } },
+        {
+          queue,
+          workspace: "/tmp",
+          ccLoader: emptyRules(),
+          approvalGate: "all",
+          ntfyTopic: "patchwork-test-topic",
+          ntfyServer: "https://ntfy.example.com",
+          pushServiceBaseUrl: "https://bridge.example.com",
+        },
+      );
+      await new Promise((r) => setTimeout(r, 50));
+      const item = queue.list()[0];
+      if (!item) throw new Error("no queued item");
+      queue.approve(item.callId);
+      await pending;
+
+      // Two ntfy publishes expected: the initial action prompt + the
+      // post-decision confirmation. Confirmation has no actions and a
+      // checkmark title.
+      const publishes = ntfyCalls.filter(
+        (c) => new URL(c.url).hostname === "ntfy.example.com",
+      );
+      expect(publishes.length).toBeGreaterThanOrEqual(2);
+      const confirmation = publishes.find((c) => {
+        const b = c.body as { title?: string; actions?: unknown[] };
+        return typeof b.title === "string" && b.title.startsWith("✓ Approved");
+      });
+      expect(confirmation).toBeDefined();
+      expect((confirmation!.body as { actions?: unknown[] }).actions).toBe(
+        undefined,
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   it("ntfy publish skipped when bridgeCallbackBase missing (action URLs cannot be built)", async () => {
     const originalFetch = globalThis.fetch;
     const calls: string[] = [];
@@ -1149,9 +1199,12 @@ describe("push notification dispatch", () => {
 
   it("ntfy publish blocks non-HTTPS bridgeCallbackBase (would expose token over plaintext)", async () => {
     const originalFetch = globalThis.fetch;
-    const calls: string[] = [];
-    globalThis.fetch = (async (url: string) => {
-      calls.push(url);
+    const calls: Array<{ url: string; body: unknown }> = [];
+    globalThis.fetch = (async (url: string, init?: RequestInit) => {
+      calls.push({
+        url,
+        body: JSON.parse((init?.body as string) ?? "{}"),
+      });
       return new Response("{}", { status: 200 });
     }) as typeof globalThis.fetch;
     try {
@@ -1172,15 +1225,16 @@ describe("push notification dispatch", () => {
       const item = queue.list()[0];
       if (item) queue.approve(item.callId);
       await pending;
-      expect(
-        calls.filter((u) => {
-          try {
-            return new URL(u).hostname === "ntfy.example.com";
-          } catch {
-            return false;
-          }
-        }),
-      ).toHaveLength(0);
+
+      // The confirmation publish (no actions) is fine even with a bogus
+      // bridgeCallbackBase — it doesn't carry the token. What MUST be
+      // suppressed is the prompt publish, which would put the token-
+      // bearing action URL on the wire pointing at a plaintext bridge.
+      const promptPublishes = calls.filter((c) => {
+        const b = c.body as { actions?: unknown[] };
+        return Array.isArray(b.actions) && b.actions.length > 0;
+      });
+      expect(promptPublishes).toHaveLength(0);
     } finally {
       globalThis.fetch = originalFetch;
     }

--- a/src/approvalHttp.ts
+++ b/src/approvalHttp.ts
@@ -65,6 +65,20 @@ export interface ApprovalHttpDeps {
   /** Public base URL of this bridge (e.g. https://mybridge.example.com). Embedded in push payload as callback base. */
   pushServiceBaseUrl?: string;
   /**
+   * ntfy.sh topic for direct phone-path approvals via action buttons. When set
+   * AND `pushServiceBaseUrl` is set (so the action URLs can reach the bridge),
+   * each queued approval is published to the topic with Approve / Reject HTTP
+   * action buttons that POST back to the bridge with the single-use approval
+   * token. Independent of `pushServiceUrl` — ntfy can be the sole phone path
+   * (no FCM/APNS relay needed) or run alongside it.
+   */
+  ntfyTopic?: string;
+  /**
+   * ntfy server. Defaults to `https://ntfy.sh`. Set to a self-hosted instance
+   * (e.g. `https://ntfy.your-domain.tld`) for auth/private-topic deployments.
+   */
+  ntfyServer?: string;
+  /**
    * Optional ActivityLog used to compute passive risk personalization
    * signals (`src/approvalSignals.ts`). When omitted, personalSignals are
    * not computed and the queue entry has the `personalSignals` field
@@ -428,6 +442,117 @@ async function dispatchPushNotification(
   }
 }
 
+/**
+ * Publish an approval prompt to ntfy.sh with Approve / Reject HTTP action
+ * buttons that POST back to the bridge using the single-use approval token.
+ * Reuses the same SSRF guard as the push relay path. Fire-and-forget.
+ *
+ * Action buttons embed the token in the `x-approval-token` header (not the
+ * URL), matching the existing relay → service-worker → bridge contract so the
+ * single-use token never appears in logs or referrer.
+ */
+async function dispatchNtfyApproval(
+  ntfyServer: string,
+  payload: {
+    topic: string;
+    toolName: string;
+    tier: string;
+    callId: string;
+    summary?: string;
+    approvalToken: string;
+    bridgeCallbackBase: string;
+  },
+): Promise<void> {
+  if (!ntfyServer.startsWith("https://")) {
+    console.warn(`[ntfy] Rejected non-HTTPS ntfy server URL`);
+    return;
+  }
+  if (!payload.bridgeCallbackBase.startsWith("https://")) {
+    console.warn(
+      `[ntfy] bridgeCallbackBase must be https:// for action buttons; skipping ntfy publish`,
+    );
+    return;
+  }
+  let hostname: string;
+  try {
+    hostname = new URL(ntfyServer).hostname;
+  } catch {
+    console.warn(`[ntfy] Malformed ntfy server URL — skipping`);
+    return;
+  }
+  if (hostname === "localhost") {
+    console.warn(`[ntfy] Blocked loopback ntfy server hostname`);
+    return;
+  }
+  try {
+    const resolved = await dns.lookup(hostname);
+    if (isBlockedIp(resolved.address)) {
+      console.warn(
+        `[ntfy] Blocked private/loopback IP for ntfy server: ${resolved.address}`,
+      );
+      return;
+    }
+  } catch (err) {
+    console.warn(
+      `[ntfy] DNS resolution failed for ${hostname}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return;
+  }
+
+  const callbackBase = payload.bridgeCallbackBase.replace(/\/+$/, "");
+  const headerSet = {
+    "x-approval-token": payload.approvalToken,
+    "Content-Type": "application/json",
+  };
+  const body = JSON.stringify({
+    topic: payload.topic,
+    title: `Approve ${payload.toolName}? (${payload.tier})`,
+    message: payload.summary ?? `Pending tool call ${payload.callId}`,
+    tags: ["lock", "warning"],
+    priority: payload.tier === "high" ? 5 : 4,
+    actions: [
+      {
+        action: "http",
+        label: "Approve",
+        method: "POST",
+        url: `${callbackBase}/approve/${payload.callId}`,
+        headers: headerSet,
+        clear: true,
+      },
+      {
+        action: "http",
+        label: "Reject",
+        method: "POST",
+        url: `${callbackBase}/reject/${payload.callId}`,
+        headers: headerSet,
+        clear: true,
+      },
+    ],
+  });
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 5_000);
+  try {
+    const res = await fetch(ntfyServer.replace(/\/+$/, "") + "/", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body,
+      signal: controller.signal,
+    });
+    if (!res.ok) {
+      console.warn(
+        `[ntfy] Non-2xx from ntfy server: ${res.status} ${res.statusText}`,
+      );
+    }
+  } catch (err) {
+    console.warn(
+      `[ntfy] Dispatch failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 function computeRiskSignals(
   toolName: string,
   params: Record<string, unknown>,
@@ -710,7 +835,7 @@ async function handleApprovalRequest(
       // field stays absent — that case still means "not configured."
       ...(personalSignals !== undefined && { personalSignals }),
     },
-    { withToken: !!deps.pushServiceUrl },
+    { withToken: !!deps.pushServiceUrl || !!deps.ntfyTopic },
   );
   recordApprovalPrompted();
 
@@ -738,6 +863,21 @@ async function handleApprovalRequest(
       riskSignals,
       approvalToken,
       bridgeCallbackBase: deps.pushServiceBaseUrl ?? "",
+    }).catch(() => {});
+  }
+
+  // ntfy.sh phone path — independent of the FCM/APNS relay above. Action
+  // buttons in the notification POST back to /approve|/reject with the
+  // single-use token. Requires a public bridgeCallbackBase (HTTPS).
+  if (deps.ntfyTopic && approvalToken && deps.pushServiceBaseUrl) {
+    dispatchNtfyApproval(deps.ntfyServer ?? "https://ntfy.sh", {
+      topic: deps.ntfyTopic,
+      toolName,
+      tier,
+      callId,
+      summary,
+      approvalToken,
+      bridgeCallbackBase: deps.pushServiceBaseUrl,
     }).catch(() => {});
   }
 

--- a/src/approvalHttp.ts
+++ b/src/approvalHttp.ts
@@ -553,6 +553,57 @@ async function dispatchNtfyApproval(
   }
 }
 
+/**
+ * Publish a confirmation to ntfy after an approval is decided. Gives the
+ * lock-screen tap visible feedback the iOS ntfy app does not produce on its
+ * own. Best-effort, fire-and-forget — never blocks decision lifecycle.
+ */
+async function dispatchNtfyConfirmation(
+  ntfyServer: string,
+  payload: { topic: string; toolName: string; outcome: string },
+): Promise<void> {
+  if (!ntfyServer.startsWith("https://")) return;
+  let hostname: string;
+  try {
+    hostname = new URL(ntfyServer).hostname;
+  } catch {
+    return;
+  }
+  if (hostname === "localhost") return;
+  try {
+    const resolved = await dns.lookup(hostname);
+    if (isBlockedIp(resolved.address)) return;
+  } catch {
+    return;
+  }
+  const approved = payload.outcome === "approved";
+  const body = JSON.stringify({
+    topic: payload.topic,
+    title: approved
+      ? `✓ Approved ${payload.toolName}`
+      : `✗ Rejected ${payload.toolName}`,
+    message: approved
+      ? "Tool call unblocked. Decision recorded."
+      : "Tool call rejected. Decision recorded.",
+    tags: [approved ? "white_check_mark" : "x"],
+    priority: 2,
+  });
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 5_000);
+  try {
+    await fetch(ntfyServer.replace(/\/+$/, "") + "/", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body,
+      signal: controller.signal,
+    });
+  } catch {
+    // best-effort
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 function computeRiskSignals(
   toolName: string,
   params: Record<string, unknown>,
@@ -886,6 +937,19 @@ async function handleApprovalRequest(
     recordApprovalCompleted();
   }
   emit(outcome === "approved" ? "allow" : "deny", outcome, { callId });
+
+  // Publish a confirmation back to the same ntfy topic so the lock-screen
+  // tap has visible feedback. The iOS ntfy app gives no UI signal when an
+  // http action fires successfully; without this follow-up the user can't
+  // tell whether their tap landed. Skip on "expired" — the approval ran
+  // out before any human input arrived, so there's nothing to confirm.
+  if (deps.ntfyTopic && deps.pushServiceBaseUrl && outcome !== "expired") {
+    dispatchNtfyConfirmation(deps.ntfyServer ?? "https://ntfy.sh", {
+      topic: deps.ntfyTopic,
+      toolName,
+      outcome,
+    }).catch(() => {});
+  }
   return {
     status: 200,
     body: {

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -1395,6 +1395,8 @@ export class Bridge {
             pushServiceUrl: this.server.pushServiceUrl ?? null,
             pushServiceToken: this.server.pushServiceToken ? "***" : null,
             pushServiceBaseUrl: this.server.pushServiceBaseUrl ?? null,
+            ntfyTopic: this.server.ntfyTopic ?? null,
+            ntfyServer: this.server.ntfyServer ?? null,
           };
         })(),
       };

--- a/src/server.ts
+++ b/src/server.ts
@@ -252,6 +252,10 @@ export class Server extends EventEmitter<ServerEvents> {
   public pushServiceToken: string | undefined = undefined;
   /** Patchwork: public base URL of this bridge, embedded in push payloads as callback base. */
   public pushServiceBaseUrl: string | undefined = undefined;
+  /** Patchwork: ntfy.sh topic for direct phone-path approvals via action buttons. */
+  public ntfyTopic: string | undefined = undefined;
+  /** Patchwork: ntfy server (default https://ntfy.sh; override for self-hosted). */
+  public ntfyServer: string | undefined = undefined;
   /** Patchwork: approval decision audit callback wired to activityLog.recordEvent. */
   public onApprovalDecision:
     | ((event: string, meta: Record<string, unknown>) => void)
@@ -1357,6 +1361,8 @@ export class Server extends EventEmitter<ServerEvents> {
           pushServiceUrl?: string;
           pushServiceToken?: string;
           pushServiceBaseUrl?: string;
+          ntfyTopic?: string;
+          ntfyServer?: string;
         }>(req, SETTINGS_BODY_CAP);
         if (!parsed.ok) {
           if (parsed.code === "too_large") {
@@ -1572,6 +1578,35 @@ export class Server extends EventEmitter<ServerEvents> {
               }
               this.pushServiceBaseUrl = baseUrl || undefined;
             }
+            if (body.ntfyTopic !== undefined) {
+              const topic = body.ntfyTopic.trim();
+              // Topic acts as a bearer token on the public ntfy.sh server —
+              // anyone subscribed sees the approval payload + single-use
+              // approvalToken. Reject empty / whitespace / control chars to
+              // avoid silent misconfiguration.
+              if (topic && !/^[A-Za-z0-9_-]{1,64}$/.test(topic)) {
+                res.writeHead(400, { "Content-Type": "application/json" });
+                res.end(
+                  JSON.stringify({
+                    error: "ntfyTopic must match [A-Za-z0-9_-]{1,64}",
+                  }),
+                );
+                return;
+              }
+              this.ntfyTopic = topic || undefined;
+            }
+            if (body.ntfyServer !== undefined) {
+              const server = body.ntfyServer.trim();
+              // Same reasoning as pushServiceBaseUrl — the bridge sends the
+              // single-use token to this URL. http:// would expose it on the
+              // wire; a malicious value would exfiltrate every approval.
+              if (server && !server.startsWith("https://")) {
+                res.writeHead(400, { "Content-Type": "application/json" });
+                res.end(JSON.stringify({ error: "ntfyServer must be HTTPS" }));
+                return;
+              }
+              this.ntfyServer = server || undefined;
+            }
             const restartRequired =
               driverRaw !== undefined ||
               body.apiKey !== undefined ||
@@ -1705,6 +1740,8 @@ export class Server extends EventEmitter<ServerEvents> {
               pushServiceUrl: this.pushServiceUrl,
               pushServiceToken: this.pushServiceToken,
               pushServiceBaseUrl: this.pushServiceBaseUrl,
+              ntfyTopic: this.ntfyTopic,
+              ntfyServer: this.ntfyServer,
               activityLog: this.activityLog,
               // RecipeRunLog satisfies RecipeRunQuerier structurally
               // — the cast bridges TS contravariance: RecipeRunQuerier's


### PR DESCRIPTION
## Summary

Adds `ntfyTopic` + `ntfyServer` settings that publish each pending approval to ntfy.sh with Approve / Reject HTTP action buttons. Tap a button on the lock screen, the bridge records the decision, the tool call unblocks. No FCM, no APNS, no service worker, no PWA install.

Independent of the existing FCM/APNS push relay — ntfy can be the sole phone path or run alongside it. Reuses the same `ApprovalQueue.validateToken` contract (single-use, 5-min TTL, max-failure replay defense), so the security model is identical to the existing service-worker path.

## Why

The push-relay path (services/push-relay) is great for teams: Firebase service account, APNS .p8, Node service, TLS reverse proxy, custom branded PWA, per-user device routing. It's also a lot of moving parts for one developer with one phone.

ntfy.sh collapses all of it into one HTTPS POST + an iOS/Android app from the App Store. Action buttons in 2026 iOS work natively from the lock screen — no app open, no PWA, no second tap. Hit this writing the daily-tweets recipe (PR #415): ntfy was the only phone-path that worked from a LaunchAgent-spawned subprocess context (TCC isolation kills AppleScript/iMessage there), and it became obvious the same pattern fits approval flow exactly.

## What changed

| File | Change |
|---|---|
| [src/approvalHttp.ts](src/approvalHttp.ts) | New `dispatchNtfyApproval()` parallel to `dispatchPushNotification()`. Wired into the request flow alongside the existing relay dispatch. Token still single-use, still in `x-approval-token` header (never URL). |
| [src/server.ts](src/server.ts) | New `ntfyTopic` / `ntfyServer` server fields. POST /settings handler validates: HTTPS-only ntfyServer, HTTPS-only `pushServiceBaseUrl` (refuses to publish otherwise — would leak token in transit), `[A-Za-z0-9_-]{1,64}` topic format. |
| [src/bridge.ts](src/bridge.ts) | GET /settings response surfaces `ntfyTopic` / `ntfyServer` so the dashboard can render them. |
| [src/__tests__/approvalHttp.test.ts](src/__tests__/approvalHttp.test.ts) | 3 new tests: happy path (action URLs correct, token in header not URL), skip when bridgeCallbackBase missing, refuse on plaintext bridgeCallbackBase. |
| [docs/mobile-oversight.md](docs/mobile-oversight.md) | New "Step 1B - ntfy.sh (no relay needed)" section. The existing FCM/APNS section is preserved unchanged. |

## Test plan

- [x] \`npx vitest run src/__tests__/approvalHttp.test.ts\` — 51/51 pass (3 new)
- [x] \`npx vitest run src/__tests__/\` — 1918/1918 pass
- [x] \`npm run build\` — clean
- [ ] Live test with the Patchwork iOS topic configured against the bridge — fire a high-tier tool call, confirm phone receives the action-button push, tap Approve, confirm bridge records the decision

## Security notes

- Topic name acts as a bearer-equivalent on public ntfy.sh (anyone subscribed sees the approval payload + token). Recommend ≥ 8 random hex bytes; rotate if leaked. For multi-recipient or auth, point \`ntfyServer\` at self-hosted ntfy.
- Single-use + 5-min TTL token means a leaked notification has a 5-minute / 1-approval blast radius even if the topic is compromised.
- Same SSRF guard chain as push relay (HTTPS-only, hostname allowlist, DNS pre-resolution, private-IP block). Direct port re-use means the same CodeQL coverage applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)