### PR TITLE
docs(examples): add SchemaStore $schema pragma to recipe examples

### DIFF
--- a/examples/recipes/chained-followup-child.yaml
+++ b/examples/recipes/chained-followup-child.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/patchworkos/recipes/main/schema/recipe.v1.json
 version: 1.0.0
 name: chained-followup-child
 description: Child chained recipe used by the canonical chained follow-up demo.

--- a/examples/recipes/chained-followup-demo.yaml
+++ b/examples/recipes/chained-followup-demo.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/patchworkos/recipes/main/schema/recipe.v1.json
 version: 1.0.0
 name: chained-followup-demo
 description: Demonstrate chained dependencies, gating, optional steps, and nested recipe calls.

--- a/examples/recipes/google-meet-debrief-single.yaml
+++ b/examples/recipes/google-meet-debrief-single.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/patchworkos/recipes/main/schema/recipe.v1.json
 version: 1.0.0
 name: google-meet-debrief-single
 description: >

--- a/examples/recipes/google-meet-debrief.yaml
+++ b/examples/recipes/google-meet-debrief.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/patchworkos/recipes/main/schema/recipe.v1.json
 version: 1.0.0
 name: google-meet-debrief
 description: >

--- a/examples/recipes/morning-inbox-triage.yaml
+++ b/examples/recipes/morning-inbox-triage.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/patchworkos/recipes/main/schema/recipe.v1.json
 version: 1.0.0
 name: morning-inbox-triage
 description: >

--- a/examples/recipes/oolabs-daily-tweets.yaml
+++ b/examples/recipes/oolabs-daily-tweets.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/patchworkos/recipes/main/schema/recipe.v1.json
 apiVersion: patchwork.sh/v1
 name: daily-tweets-from-prs
 description: |


### PR DESCRIPTION
## Summary

- Prepend the SchemaStore `# yaml-language-server: $schema=...` pragma to the 6 top-level recipe examples
- Canonical schema URL: `https://raw.githubusercontent.com/patchworkos/recipes/main/schema/recipe.v1.json` (matches `$id` in `schemas/recipe.v1.json` and the URL submitted to SchemaStore PR schemastore/json#5608)
- Subdir examples (`advanced-patterns/`, `starter-pack/`) get the same treatment in a follow-up PR

## Why

Closes the autocomplete loop for editors that already support the SchemaStore catalog — even before the catalog PR lands, the pragma alone makes `vscode-yaml`, `nvim-lspconfig`, IntelliJ etc. resolve the schema directly from the raw URL.

## Verification

- All 6 files previously had no schema pragma (verified pre-edit)
- Schema URL returns HTTP 200 (verified)
- Files start with valid YAML; pragma is a comment and does not affect runtime parsing

## Test plan

- [ ] Open one of the modified examples in VS Code with `redhat.vscode-yaml`; confirm autocomplete on `trigger.type`, step `tool:` etc.
- [ ] CI green (no parser changes — pragma is a comment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)