### PR TITLE
feat!: remove deprecated --claude-driver / claudeDriver alias

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ Comply with all docs in `/documents/`. Consult before changes:
 - `gen-claude-md` — Generate starter CLAUDE.md for current workspace
 - `print-token [--port N]` — Print auth token from active lock file
 - `gen-plugin-stub <dir> --name <org/name> --prefix <prefix> [--ts]` — Scaffold new plugin (add `--ts` for TypeScript variant)
-- `quick-task <preset>` — Launch a context-aware Claude task from a preset (fixErrors, refactorFile, addTests, explainCode, optimizePerf, runTests, resumeLastCancelled). Same dispatch path as the sidebar. Requires `--claude-driver subprocess`.
+- `quick-task <preset>` — Launch a context-aware Claude task from a preset (fixErrors, refactorFile, addTests, explainCode, optimizePerf, runTests, resumeLastCancelled). Same dispatch path as the sidebar. Requires `--driver subprocess`.
 - `start-task "<description>"` — Enqueue a free-form Claude task; Claude gathers its own workspace context.
 - `continue-handoff` — Resume from the stored handoff note (skips auto-snapshots).
 - `--watch` — Auto-restart supervisor with exponential backoff (2s → 30s). Safe for production.
@@ -171,7 +171,7 @@ For remote deployments where claude.ai custom connectors need authenticated acce
 
 Bridge spawns Claude Code subprocesses as background tasks.
 
-- **Activation**: `--claude-driver subprocess` (or `api`). Default `none` (disabled).
+- **Activation**: `--driver subprocess` (or `api`). Default `none` (disabled).
 - **Tools**: `runClaudeTask` (enqueue prompt), `getClaudeTaskStatus`, `cancelClaudeTask`, `listClaudeTasks`, `resumeClaudeTask`.
 - **Task lifecycle**: `pending` → `running` → `done | error | cancelled | interrupted`. Output streams to VS Code output channel, capped at 50KB.
 - **Binary**: `--claude-binary <path>` overrides Claude CLI path (default: `claude` on PATH).
@@ -182,7 +182,7 @@ Full reference: [documents/platform-docs.md](documents/platform-docs.md) (Claude
 
 Event-driven hooks that trigger Claude tasks automatically.
 
-- **Activation**: `--automation --automation-policy <path.json> --claude-driver subprocess`
+- **Activation**: `--automation --automation-policy <path.json> --driver subprocess`
 - **Hooks**:
   - `onDiagnosticsStateChange` (v2.43.0+) — unified diagnostics hook. `state: "error"` fires on new error/warning diagnostics (`{{file}}`, `{{diagnostics}}`, severity filter). `state: "cleared"` fires when errors/warnings drop to zero (`{{file}}`). Replaces deprecated `onDiagnosticsError` + `onDiagnosticsCleared`.
   - `onFileSave` — matching files saved. Minimatch glob patterns. Placeholder: `{{file}}`.

--- a/dashboard/src/app/recipes/new/page.tsx
+++ b/dashboard/src/app/recipes/new/page.tsx
@@ -564,7 +564,7 @@ function NewRecipePageInner() {
         setAiResult({
           error:
             data.error ??
-            "AI generation is not available — start the bridge with --claude-driver subprocess.",
+            "AI generation is not available — start the bridge with --driver subprocess.",
         });
       } else if (data.ok && data.yaml) {
         setAiResult({ yaml: data.yaml, warnings: data.warnings });

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "vps:stop": "bash scripts/start-vps.sh --stop",
     "start-all": "bash scripts/start-all.sh",
     "start-orchestrator": "bash scripts/start-orchestrator.sh",
-    "start:automation": "claude-ide-bridge --workspace . --automation --automation-policy automation-policy.json --claude-driver subprocess --full",
+    "start:automation": "claude-ide-bridge --workspace . --automation --automation-policy automation-policy.json --driver subprocess --full",
     "prepare": "husky"
   },
   "dependencies": {

--- a/scripts/audit-schema-changes.mjs
+++ b/scripts/audit-schema-changes.mjs
@@ -51,7 +51,7 @@ const config = {
   maxHttpSessions: 5,
   auditLogPath: undefined,
   automation: false,
-  claudeDriver: "none",
+  driver: "none",
   vps: false,
   db: false,
   linters: [],

--- a/scripts/smoke/cat12-automation.mjs
+++ b/scripts/smoke/cat12-automation.mjs
@@ -44,7 +44,7 @@ fs.writeFileSync(POLICY_PATH, JSON.stringify(validPolicy, null, 2));
       "--automation",
       "--automation-policy",
       POLICY_PATH,
-      "--claude-driver",
+      "--driver",
       "subprocess", // required by --automation; actual claude binary not invoked until a task fires
     ],
     { env: ENV, stdio: ["ignore", "ignore", "pipe"] },
@@ -118,7 +118,7 @@ fs.writeFileSync(POLICY_PATH, JSON.stringify(validPolicy, null, 2));
       "--automation",
       "--automation-policy",
       badPolicyPath,
-      "--claude-driver",
+      "--driver",
       "subprocess",
     ],
     { env: ENV, stdio: ["ignore", "ignore", "ignore"] },

--- a/scripts/start-all.sh
+++ b/scripts/start-all.sh
@@ -55,7 +55,7 @@ NO_DASHBOARD=""
 DASHBOARD_PORT="3200"
 BRIDGE_PORT_FLAG=""
 AUTOMATION_POLICY=""
-CLAUDE_DRIVER="subprocess"
+DRIVER="subprocess"
 BRIDGE_READY_TIMEOUT="${BRIDGE_READY_TIMEOUT:-30}"
 LAST_CLAUDE_RESTART=0
 RESTART_COUNT=0
@@ -74,7 +74,7 @@ while [[ $# -gt 0 ]]; do
     --dashboard-port)    DASHBOARD_PORT="$2"; shift 2 ;;
     --bridge-port)       BRIDGE_PORT_FLAG="--port $2"; shift 2 ;;
     --automation-policy) AUTOMATION_POLICY="$2"; shift 2 ;;
-    --claude-driver)     CLAUDE_DRIVER="$2"; shift 2 ;;
+    --driver)            DRIVER="$2"; shift 2 ;;
     *)                   echo "Unknown option: $1" >&2; exit 1 ;;
   esac
 done
@@ -168,7 +168,7 @@ if [[ -z "$FULL_MODE" ]]; then
 fi
 if [[ -n "$AUTOMATION_POLICY" ]]; then
   echo ""
-  echo "  ⚡ Automation: enabled (driver: $CLAUDE_DRIVER)"
+  echo "  ⚡ Automation: enabled (driver: $DRIVER)"
   echo "     Policy: $AUTOMATION_POLICY"
 fi
 echo ""
@@ -207,7 +207,7 @@ if [[ -n "$IDE_NAME" ]]; then
 fi
 BRIDGE_AUTOMATION_FLAGS=""
 if [[ -n "$AUTOMATION_POLICY" ]]; then
-  BRIDGE_AUTOMATION_FLAGS="--automation --automation-policy $(printf '%q' "$AUTOMATION_POLICY") --claude-driver $(printf '%q' "$CLAUDE_DRIVER")"
+  BRIDGE_AUTOMATION_FLAGS="--automation --automation-policy $(printf '%q' "$AUTOMATION_POLICY") --driver $(printf '%q' "$DRIVER")"
 fi
 # Use compiled dist when src/ is absent (npm install), tsx during local development
 if [[ -f "$BRIDGE_DIR/src/index.ts" ]]; then

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -462,7 +462,7 @@ describe("saveBridgeConfigDriver", () => {
     mkdirSync(path.dirname(target), { recursive: true });
     writeFileSync(
       target,
-      JSON.stringify({ port: 4747, claudeDriver: "subprocess" }, null, 2),
+      JSON.stringify({ port: 4747, driver: "subprocess" }, null, 2),
     );
     process.chdir(workspace);
     process.env.CLAUDE_CONFIG_DIR = claudeDir;
@@ -483,7 +483,7 @@ describe("saveBridgeConfigDriver", () => {
     writeFileSync(
       customPath,
       JSON.stringify(
-        { bindAddress: "127.0.0.1", claudeDriver: "subprocess" },
+        { bindAddress: "127.0.0.1", driver: "subprocess" },
         null,
         2,
       ),

--- a/src/__tests__/digestIntegration.test.ts
+++ b/src/__tests__/digestIntegration.test.ts
@@ -47,7 +47,7 @@ function makeDeps() {
       noReady: false,
       configFile: null,
       noLockFile: false,
-      claudeDriver: "subprocess" as const,
+      driver: "subprocess" as const,
       claudeBinary: "claude",
       automationPolicy: null,
     },

--- a/src/__tests__/integration-e2e.test.ts
+++ b/src/__tests__/integration-e2e.test.ts
@@ -48,7 +48,7 @@ function makeConfig(workspace: string): Config {
     activeWorkspaceFolder: workspace,
     gracePeriodMs: 30_000,
     autoTmux: false,
-    claudeDriver: "none",
+    driver: "none",
     claudeBinary: "claude",
     automationEnabled: false,
     automationPolicyPath: null,

--- a/src/__tests__/pluginWatcher-shadow.test.ts
+++ b/src/__tests__/pluginWatcher-shadow.test.ts
@@ -53,7 +53,7 @@ function makeConfig(overrides: Partial<Config> = {}): Config {
     activeWorkspaceFolder: process.cwd(),
     gracePeriodMs: 30_000,
     autoTmux: false,
-    claudeDriver: "none",
+    driver: "none",
     claudeBinary: "claude",
     automationEnabled: false,
     automationPolicyPath: null,

--- a/src/__tests__/pluginWatcher.test.ts
+++ b/src/__tests__/pluginWatcher.test.ts
@@ -52,7 +52,7 @@ function makeConfig(overrides: Partial<Config> = {}): Config {
     activeWorkspaceFolder: process.cwd(),
     gracePeriodMs: 30_000,
     autoTmux: false,
-    claudeDriver: "none",
+    driver: "none",
     claudeBinary: "claude",
     automationEnabled: false,
     automationPolicyPath: null,

--- a/src/__tests__/recipeRoutes-generate-rate-limit.test.ts
+++ b/src/__tests__/recipeRoutes-generate-rate-limit.test.ts
@@ -8,7 +8,7 @@
  * bucket at 10 req/min.
  *
  * The Claude orchestrator isn't wired in these tests (Server is
- * default-constructed without `--claude-driver subprocess`), so the
+ * default-constructed without `--driver subprocess`), so the
  * route returns 503 `unavailable:true` after the rate-limit check
  * passes. That's fine for testing the limiter in isolation: tokens get
  * consumed regardless of the downstream branch, so the 11th request

--- a/src/__tests__/registration-coverage.test.ts
+++ b/src/__tests__/registration-coverage.test.ts
@@ -56,7 +56,7 @@ function baseConfig(overrides: Partial<{ fullMode: boolean }> = {}) {
     activeWorkspaceFolder: "/tmp/test",
     gracePeriodMs: 30_000,
     autoTmux: false,
-    claudeDriver: "none" as const,
+    driver: "none" as const,
     claudeBinary: "claude",
     automationEnabled: false,
     automationPolicyPath: null,

--- a/src/__tests__/server-settings.test.ts
+++ b/src/__tests__/server-settings.test.ts
@@ -7,8 +7,7 @@
  * driver was still loaded on restart.
  *
  * These tests prove that POST /settings writes driver to the authoritative
- * bridge config file (server.bridgeConfigPath), preserves unrelated keys, and
- * strips the deprecated claudeDriver field.
+ * bridge config file (server.bridgeConfigPath) and preserves unrelated keys.
  */
 
 import {
@@ -147,34 +146,6 @@ describe("POST /settings — driver persistence to bridge config file", () => {
     expect(saved.port).toBe(4747);
     expect(saved.fullMode).toBe(true);
     expect(saved.automationEnabled).toBe(false);
-  });
-
-  it("strips deprecated claudeDriver key when saving driver", async () => {
-    const bridgeCfgPath = path.join(tempDir!, "bridge.json");
-    writeFileSync(
-      bridgeCfgPath,
-      JSON.stringify({ claudeDriver: "subprocess", port: 3101 }, null, 2),
-    );
-    server!.bridgeConfigPath = bridgeCfgPath;
-
-    await makeRequest(
-      {
-        method: "POST",
-        path: "/settings",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${TOKEN}`,
-        },
-      },
-      JSON.stringify({ driver: "gemini" }),
-    );
-
-    const saved = JSON.parse(readFileSync(bridgeCfgPath, "utf-8")) as Record<
-      string,
-      unknown
-    >;
-    expect(saved.driver).toBe("gemini");
-    expect(saved).not.toHaveProperty("claudeDriver");
   });
 
   it("creates bridge config file if it does not exist yet", async () => {

--- a/src/__tests__/streamableHttp.test.ts
+++ b/src/__tests__/streamableHttp.test.ts
@@ -29,7 +29,7 @@ function makeDeps() {
     noReady: false,
     configFile: null,
     noLockFile: false,
-    claudeDriver: "subprocess" as const,
+    driver: "subprocess" as const,
     claudeBinary: "claude",
     automationPolicy: null,
   };

--- a/src/__tests__/streamableHttpToolRegistration.test.ts
+++ b/src/__tests__/streamableHttpToolRegistration.test.ts
@@ -46,7 +46,7 @@ function makeDeps() {
     noReady: false,
     configFile: null,
     noLockFile: false,
-    claudeDriver: "subprocess" as const,
+    driver: "subprocess" as const,
     claudeBinary: "claude",
     automationPolicy: null,
   };

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -1057,7 +1057,7 @@ export class Bridge {
 
     if (this.config.automationEnabled) {
       if (!this.orchestrator) {
-        throw new Error("--automation requires --claude-driver != none");
+        throw new Error("--automation requires --driver != none");
       }
       if (!this.config.automationPolicyPath) {
         throw new Error("--automation requires --automation-policy <path>");
@@ -1463,7 +1463,7 @@ export class Bridge {
         return {
           ok: false,
           error:
-            "launchQuickTask not registered — requires --claude-driver subprocess",
+            "launchQuickTask not registered — requires --driver subprocess",
         };
       }
       const r = result as {

--- a/src/commands/task.ts
+++ b/src/commands/task.ts
@@ -54,7 +54,7 @@ function findLock(overridePort?: number): LockInfo {
   if (!lockFile || !port) {
     process.stderr.write(
       `Error: No bridge lock file found in ${lockDir}\n` +
-        "Start the bridge first: claude-ide-bridge --watch --full --claude-driver subprocess\n",
+        "Start the bridge first: claude-ide-bridge --watch --full --driver subprocess\n",
     );
     process.exit(1);
   }
@@ -119,7 +119,7 @@ function usageQuickTask(): never {
     `Usage: claude-ide-bridge quick-task <preset> [--json] [--port N] [--source NAME]\n\n` +
       `Presets: ${QUICK_TASK_PRESET_IDS.join(", ")}\n\n` +
       "Runs a context-aware Claude task using the same preset logic as the VS Code sidebar.\n" +
-      "Requires bridge running with --claude-driver subprocess.\n",
+      "Requires bridge running with --driver subprocess.\n",
   );
   process.exit(2);
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -219,16 +219,6 @@ interface ConfigFile {
     | "gemini-api"
     | "local"
     | "none";
-  /** @deprecated Use driver instead. */
-  claudeDriver?:
-    | "subprocess"
-    | "api"
-    | "openai"
-    | "grok"
-    | "gemini"
-    | "gemini-api"
-    | "local"
-    | "none";
   claudeBinary?: string;
   antBinary?: string;
   automationEnabled?: boolean;
@@ -261,7 +251,6 @@ const KNOWN_CONFIG_FILE_KEYS = new Set<string>([
   "ideName",
   "autoTmux",
   "driver",
-  "claudeDriver", // deprecated alias — still accepted for backward compat
   "claudeBinary",
   "antBinary",
   "automationEnabled",
@@ -379,7 +368,6 @@ export function saveBridgeConfigDriver(
     }
     parsed = candidate as Record<string, unknown>;
   }
-  delete parsed.claudeDriver;
   parsed.driver = driver;
   fs.mkdirSync(path.dirname(targetPath), { recursive: true });
   fs.writeFileSync(targetPath, JSON.stringify(parsed, null, 2), {
@@ -458,12 +446,6 @@ export function parseConfig(argv: string[]): Config {
       : 24 * 60 * 60 * 1_000; // default 24h
   let corsOrigins: string[] = fileConfig.corsOrigins ?? [];
   let trustedProxies: string[] = fileConfig.trustedProxies ?? [];
-  // "driver" is the canonical field; "claudeDriver" is the deprecated alias.
-  if (fileConfig.claudeDriver && !fileConfig.driver) {
-    console.warn(
-      '[patchwork-os] Warning: "claudeDriver" in config is deprecated — rename to "driver".',
-    );
-  }
   const VALID_DRIVER_MODES = [
     "subprocess",
     "api",
@@ -493,7 +475,7 @@ export function parseConfig(argv: string[]): Config {
     | "gemini"
     | "gemini-api"
     | "local"
-    | "none" = fileConfig.driver ?? fileConfig.claudeDriver ?? "none";
+    | "none" = fileConfig.driver ?? "none";
   let claudeBinary = fileConfig.claudeBinary ?? "claude";
   let antBinary = fileConfig.antBinary ?? "ant";
   let automationEnabled = fileConfig.automationEnabled ?? false;
@@ -664,15 +646,8 @@ export function parseConfig(argv: string[]): Config {
       case "--auto-tmux":
         autoTmux = true;
         break;
-      case "--driver":
-      case "--claude-driver": {
-        const flagName = args[i] as string;
-        if (flagName === "--claude-driver") {
-          console.warn(
-            "[patchwork-os] Warning: --claude-driver is deprecated — use --driver instead.",
-          );
-        }
-        const driverVal = requireArg(args, ++i, flagName);
+      case "--driver": {
+        const driverVal = requireArg(args, ++i, "--driver");
         if (
           driverVal !== "subprocess" &&
           driverVal !== "api" &&
@@ -684,7 +659,7 @@ export function parseConfig(argv: string[]): Config {
           driverVal !== "none"
         ) {
           throw new Error(
-            `Invalid ${flagName} value: "${driverVal}". Must be "subprocess", "api", "openai", "grok", "gemini", "gemini-api", "local", or "none".`,
+            `Invalid --driver value: "${driverVal}". Must be "subprocess", "api", "openai", "grok", "gemini", "gemini-api", "local", or "none".`,
           );
         }
         driver = driverVal;
@@ -900,9 +875,8 @@ Patchwork:
 
 Automation:
   --driver <mode>           AI driver: "subprocess" | "api" | "openai" | "grok" | "gemini" | "gemini-api" | "local" | "none" (default: "none")
-  --claude-driver <mode>    Deprecated alias for --driver
   --claude-binary <path>    Path to claude binary (default: "claude")
-  --automation              Enable event-driven automation hooks (requires --claude-driver != none and --automation-policy)
+  --automation              Enable event-driven automation hooks (requires --driver != none and --automation-policy)
   --automation-policy <path>  Path to JSON automation policy file
 
 Plugins:

--- a/src/recipeOrchestration.ts
+++ b/src/recipeOrchestration.ts
@@ -377,7 +377,7 @@ export class RecipeOrchestration {
         return {
           ok: false,
           error:
-            "Orchestrator unavailable — start bridge with --claude-driver subprocess",
+            "Orchestrator unavailable — start bridge with --driver subprocess",
         };
       }
       const orchestrator = this.deps.getOrchestrator();

--- a/src/recipeRoutes.ts
+++ b/src/recipeRoutes.ts
@@ -435,7 +435,7 @@ export function tryHandleRecipeRoute(
             JSON.stringify({
               ok: false,
               error:
-                "Recipe execution unavailable — requires --claude-driver subprocess",
+                "Recipe execution unavailable — requires --driver subprocess",
             }),
           );
           return;
@@ -493,7 +493,7 @@ export function tryHandleRecipeRoute(
             JSON.stringify({
               ok: false,
               error:
-                "Recipe execution unavailable — requires --claude-driver subprocess",
+                "Recipe execution unavailable — requires --driver subprocess",
             }),
           );
           return;
@@ -702,7 +702,7 @@ export function tryHandleRecipeRoute(
           JSON.stringify({
             ok: false,
             error:
-              "Recipe generation unavailable — requires --claude-driver subprocess",
+              "Recipe generation unavailable — requires --driver subprocess",
             unavailable: true,
           }),
         );

--- a/src/recipes/scheduler.ts
+++ b/src/recipes/scheduler.ts
@@ -336,7 +336,7 @@ export class RecipeScheduler {
     if (yamlPath) {
       if (!this.opts.runYaml) {
         this.opts.logger?.warn?.(
-          `[scheduler] skipped "${name}" — YAML recipe requires runYaml callback (start bridge with --claude-driver)`,
+          `[scheduler] skipped "${name}" — YAML recipe requires runYaml callback (start bridge with --driver)`,
         );
         return;
       }

--- a/src/server.ts
+++ b/src/server.ts
@@ -1056,7 +1056,7 @@ export class Server extends EventEmitter<ServerEvents> {
             JSON.stringify({
               ok: false,
               error:
-                "Webhooks unavailable — start bridge with --claude-driver subprocess",
+                "Webhooks unavailable — start bridge with --driver subprocess",
             }),
           );
           return;
@@ -1802,8 +1802,7 @@ export class Server extends EventEmitter<ServerEvents> {
           res.end(
             JSON.stringify({
               ok: false,
-              error:
-                "Quick tasks unavailable — requires --claude-driver subprocess",
+              error: "Quick tasks unavailable — requires --driver subprocess",
             }),
           );
           return;

--- a/src/tools/__tests__/bridgeDoctor.test.ts
+++ b/src/tools/__tests__/bridgeDoctor.test.ts
@@ -39,7 +39,7 @@ const BASE_CONFIG = {
   automationEnabled: false,
   automationPolicyPath: null,
   issuerUrl: null,
-  claudeDriver: "none" as const,
+  driver: "none" as const,
   claudeBinary: "claude",
   port: 0,
 } as unknown as import("../../config.js").Config;

--- a/src/tools/__tests__/slimMode.test.ts
+++ b/src/tools/__tests__/slimMode.test.ts
@@ -110,7 +110,7 @@ describe("registerAllTools tool set filtering", () => {
       activeWorkspaceFolder: "/tmp/test",
       gracePeriodMs: 30_000,
       autoTmux: false,
-      claudeDriver: "none" as const,
+      driver: "none" as const,
       claudeBinary: "claude",
       automationEnabled: false,
       automationPolicyPath: null,


### PR DESCRIPTION
## BREAKING CHANGE

Use `--driver` / `"driver"` instead. The alias was added in 00ae4d7 (2026-04-21, alpha.21) as a transitional rename and has been emitting a deprecation warning ever since. **beta.2 is the cutover moment.**

```
--claude-driver subprocess   →  --driver subprocess
"claudeDriver": "..."        →  "driver": "..."   (in config JSON)
```

## Summary

- **Rip in `src/config.ts`** (7 spots, ~25 LOC removed):
  - Drop the deprecated `claudeDriver?` field from `ConfigFile`
  - Drop `"claudeDriver"` from `KNOWN_CONFIG_FILE_KEYS`
  - Drop the `delete parsed.claudeDriver` cleanup in `saveBridgeConfigDriver`
  - Drop the deprecation-warning block and the `?? fileConfig.claudeDriver` fallback
  - Collapse `case "--driver": case "--claude-driver":` into a single `case "--driver":`
  - Drop `--claude-driver` from `--help`; update the `--automation` help line

- **Test cleanups** (9 fixtures had been quietly using the dead alias via `as Partial<Config>` casts):
  - Rename `claudeDriver` → `driver` in: `bridgeDoctor`, `slimMode`, `digestIntegration`, `pluginWatcher`, `pluginWatcher-shadow`, `streamableHttp`, `streamableHttpToolRegistration`, `registration-coverage`, `integration-e2e`
  - `server-settings.test.ts`: delete the `"strips deprecated claudeDriver key"` test (its premise is gone)
  - `config.test.ts`: rename two JSON input fixtures to the canonical field
  - `recipeRoutes-generate-rate-limit.test.ts`: comment update

- **Error-string updates** so user-facing messages match the canonical flag:
  - `recipeRoutes.ts`, `bridge.ts`, `server.ts`, `recipeOrchestration.ts`, `recipes/scheduler.ts`, `commands/task.ts`
  - `dashboard/src/app/recipes/new/page.tsx` ("AI generation unavailable")

- **CLAUDE.md**: 3 references updated.

## Scope kept tight intentionally

A doc-sweep across `docs/`, `documents/`, `examples/`, `vscode-extension/README.md`, `README.bridge.md`, `README.md`, `ARCHITECTURE.md` (~20 files, ~40 prose substitutions) is deferred to a follow-up PR. Until then, users may see `--claude-driver` mentioned in docs — that flag no longer works after this PR ships.

## Net diff

**21 files changed, +33 / −89 (−56 LOC).**

## Test plan

- [x] `npm run typecheck` passes
- [x] `npx tsc -p tsconfig.tests.core.json` passes (strict gate)
- [x] `npm run build` passes
- [x] `npx vitest run src/__tests__ src/tools/__tests__` — **3578 / 3578 pass**
- [x] `grep -rn "claudeDriver\|claude-driver" src/ CLAUDE.md dashboard/src` returns 0 functional hits (only `src/claudeDriver.ts` driver-implementation file remains, which is intentional)
- [ ] CI green
- [ ] Smoke: `claude-ide-bridge --claude-driver subprocess` now exits with a clear error (was: deprecation warning + still worked)

## Migration

Users on alpha.21+ already see the deprecation warning. After this lands:

```bash
# Before
claude-ide-bridge --claude-driver subprocess
# After
claude-ide-bridge --driver subprocess
```

Config files (`~/.claude/ide/config.json`, `~/.patchwork/config.json`):

```json
// Before
{ "claudeDriver": "subprocess" }
// After
{ "driver": "subprocess" }
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)