### PR TITLE
docs: complete --claude-driver → --driver sweep

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -155,7 +155,7 @@ A dedicated WebSocket connection (separate from the Claude Code connection) runs
 | `onPermissionDenied` | Claude Code PermissionDenied hook (CC 2.1.89+) |
 | `onDebugSessionEnd` | VS Code debug session terminates |
 
-**Event flow**: lifecycle event fires (tool call completes or `/notify` POST received) → `handle*()` method checks policy enabled + per-file/event cooldown (min 5s) + loop guard (prevents re-entrant triggers) → `_evaluateWhen()` checks `AutomationCondition` (minDiagnosticCount, diagnosticsMinSeverity, testRunnerLastStatus) → `_enqueueAutomationTask()` → `SubprocessDriver` spawns `claude --verbose` subprocess with the resolved prompt. Rolling 60-minute rate limit window caps tasks per hour (default 20). Requires `--claude-driver subprocess`.
+**Event flow**: lifecycle event fires (tool call completes or `/notify` POST received) → `handle*()` method checks policy enabled + per-file/event cooldown (min 5s) + loop guard (prevents re-entrant triggers) → `_evaluateWhen()` checks `AutomationCondition` (minDiagnosticCount, diagnosticsMinSeverity, testRunnerLastStatus) → `_enqueueAutomationTask()` → `SubprocessDriver` spawns `claude --verbose` subprocess with the resolved prompt. Rolling 60-minute rate limit window caps tasks per hour (default 20). Requires `--driver subprocess`.
 
 ---
 

--- a/README.bridge.md
+++ b/README.bridge.md
@@ -192,7 +192,7 @@ claude-ide-bridge start-task "Refactor the auth module for clarity, keep behavio
 claude-ide-bridge continue-handoff
 ```
 
-Requires `--claude-driver subprocess` on the running bridge. All three subcommands accept `--json`, `--port`, `--source`. Enforces a 5s bridge-global cooldown per preset (shared with the sidebar).
+Requires `--driver subprocess` on the running bridge. All three subcommands accept `--json`, `--port`, `--source`. Enforces a 5s bridge-global cooldown per preset (shared with the sidebar).
 
 ---
 
@@ -223,7 +223,7 @@ Event-driven hooks that trigger Claude tasks automatically — no polling, no ma
 
 Start with:
 ```bash
-claude-ide-bridge --watch --automation --automation-policy ./policy.json --claude-driver subprocess
+claude-ide-bridge --watch --automation --automation-policy ./policy.json --driver subprocess
 ```
 
 **18 hook events:** `onFileSave`, `onFileChanged`, `onDiagnosticsError`, `onDiagnosticsCleared`, `onGitCommit`, `onGitPush`, `onGitPull`, `onBranchCheckout`, `onPullRequest`, `onTestRun`, `onTestPassAfterFailure`, `onPostCompact`, `onInstructionsLoaded`, `onTaskCreated`, `onTaskSuccess`, `onPermissionDenied`, `onCwdChanged`, `onDebugSessionEnd`
@@ -299,7 +299,7 @@ claude-ide-bridge install claude-mem
 | `--fixed-token <uuid>` | — | Stable auth token across restarts |
 | `--automation` | off | Enable automation hooks |
 | `--automation-policy <path>` | — | Path to policy JSON |
-| `--claude-driver subprocess` | none | Enable Claude subprocess orchestration |
+| `--driver subprocess` | none | Enable Claude subprocess orchestration |
 | `--plugin <path>` | — | Load a plugin (repeatable) |
 | `--plugin-watch` | off | Hot-reload plugins on change |
 | `--issuer-url <url>` | — | Activate OAuth 2.0 mode |

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ The package ships these in `templates/recipes/`. Recipes that need API keys are 
 
 ### Automation hooks
 
-Event-driven hooks trigger Claude tasks automatically. Activate with `--automation --automation-policy <path.json> --claude-driver subprocess`.
+Event-driven hooks trigger Claude tasks automatically. Activate with `--automation --automation-policy <path.json> --driver subprocess`.
 
 Key hooks:
 

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -12,7 +12,7 @@ Automation hooks let Claude act autonomously on IDE and git events without user 
 
 - `--automation` — enables hook evaluation in the bridge
 - Full mode (the default since v2.43.0) — most hooks invoke tools like `runTests`, `gitCommit`, `getDiagnostics` that are hidden in slim mode; do NOT pass `--slim` alongside `--automation`
-- `--claude-driver subprocess` — required to spawn Claude Code subprocesses; without this, hooks are evaluated but never dispatched
+- `--driver subprocess` — required to spawn Claude Code subprocesses; without this, hooks are evaluated but never dispatched
 - `--automation-policy <path>` — path to your policy JSON file; if omitted, the bridge looks for `automation-policy.json` in the workspace root
 
 **Claude Code version minimums for CC-wired hooks:**
@@ -37,7 +37,7 @@ claude-ide-bridge \
   --watch \
   --automation \
   --automation-policy /path/to/automation-policy.json \
-  --claude-driver subprocess
+  --driver subprocess
 ```
 
 The policy file lives wherever you point `--automation-policy`. A common location is the workspace root:

--- a/docs/dogfood/recipe-dogfood-2026-05-01/F-tools.md
+++ b/docs/dogfood/recipe-dogfood-2026-05-01/F-tools.md
@@ -1,6 +1,6 @@
 # F — Recipe Tool Registry Dogfood (Round 2, alpha.35 fresh)
 
-Bridge: PID 68045, started 1777627477261 (2026-05-01 ~12:24 local), `node dist/index.js --port 3101 --automation --automation-policy automation-policy.json --claude-driver subprocess --full`. Code path: `dist/recipes/...` re-imported live. Round 1 left ~6 of 60 tools tested; this run hit all 67 read-tier tools end-to-end and source-audited every write-tier tool.
+Bridge: PID 68045, started 1777627477261 (2026-05-01 ~12:24 local), `node dist/index.js --port 3101 --automation --automation-policy automation-policy.json --driver subprocess --full`. Code path: `dist/recipes/...` re-imported live. Round 1 left ~6 of 60 tools tested; this run hit all 67 read-tier tools end-to-end and source-audited every write-tier tool.
 
 Inventory done two ways:
 1. `listTools()` against the live registry (`dist/recipes/toolRegistry.js`).

--- a/docs/self-healing-quickstart.md
+++ b/docs/self-healing-quickstart.md
@@ -50,7 +50,7 @@ claude-ide-bridge \
   --full \
   --automation \
   --automation-policy ./automation-policy.json \
-  --claude-driver subprocess
+  --driver subprocess
 ```
 
 Leave this running. You'll see something like:

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -272,10 +272,10 @@ docker run \
 
 Automation requires the flag to be present at startup:
 ```bash
-claude-ide-bridge --watch --automation --automation-policy /path/to/policy.json --claude-driver subprocess
+claude-ide-bridge --watch --automation --automation-policy /path/to/policy.json --driver subprocess
 ```
 
-All three flags are required: `--automation`, `--automation-policy`, and `--claude-driver subprocess`.
+All three flags are required: `--automation`, `--automation-policy`, and `--driver subprocess`.
 
 ### Claude Code version too old
 

--- a/documents/headless-quickstart.md
+++ b/documents/headless-quickstart.md
@@ -93,13 +93,13 @@ Call `getBridgeStatus` after connecting to see which probes passed and which too
 | `auditDependencies` | Checks for outdated packages |
 | `getSecurityAdvisories` | CVE scan |
 | `runTests` | vitest / jest / pytest / cargo / go test |
-| `runClaudeTask` | Requires `--claude-driver subprocess` or `api` |
-| `listClaudeTasks` | Requires `--claude-driver` |
-| `getClaudeTaskStatus` | Requires `--claude-driver` |
+| `runClaudeTask` | Requires `--driver subprocess` or `api` |
+| `listClaudeTasks` | Requires `--driver` |
+| `getClaudeTaskStatus` | Requires `--driver` |
 
 ### Task Launcher CLI (v2.42.0+)
 
-Headless parity with the VS Code sidebar — launch context-aware Claude tasks from a terminal. Same prompt-building logic as the sidebar, same dispatch path. Requires a running bridge with `--claude-driver subprocess`.
+Headless parity with the VS Code sidebar — launch context-aware Claude tasks from a terminal. Same prompt-building logic as the sidebar, same dispatch path. Requires a running bridge with `--driver subprocess`.
 
 ```bash
 # 7 presets: fixErrors · refactorFile · addTests · explainCode · optimizePerf · runTests · resumeLastCancelled

--- a/documents/platform-docs.md
+++ b/documents/platform-docs.md
@@ -430,7 +430,7 @@ All plan tools are full-only.
 
 ### Orchestrator / Claude Subprocesses
 
-These tools require `--claude-driver subprocess` (or `api`) at startup. They are not registered otherwise.
+These tools require `--driver subprocess` (or `api`) at startup. They are not registered otherwise.
 
 | Tool | Mode | Description |
 |------|------|-------------|
@@ -838,7 +838,7 @@ No. Patchwork is model-agnostic by design — that's one of its core differentia
 
 ### Provider drivers
 
-The `--claude-driver` flag selects the provider backend for subprocess orchestration tasks:
+The `--driver` flag selects the provider backend for subprocess orchestration tasks:
 
 | Flag value | Provider | Auth | Subscription support |
 |---|---|---|---|

--- a/documents/roadmap.md
+++ b/documents/roadmap.md
@@ -71,9 +71,9 @@ All four "phantom tools" previously advertised in the MCP handshake (`ctxGetTask
 
 ## Remaining Patchwork work
 
-1. **Dogfood the agent-read loop — CONFIRMED CLOSED (2026-04-22).** Live run of `ctx-loop-test` recipe via `/recipes/run` HTTP endpoint with `--claude-driver subprocess` active. Agent called `ctxSaveTrace` (seq 14 written to `~/.patchwork/decision_traces.jsonl`), called `ctxQueryTraces` (returned 5 traces, test trace found), wrote report to `~/.patchwork/inbox/ctx-loop-test-2026-04-22.md` with `Result: PASS`. Fix shipped: `runRecipeFn` in `bridge.ts` now falls through to YAML runner when JSON recipe not found — YAML recipes are runnable via HTTP endpoint for the first time.
+1. **Dogfood the agent-read loop — CONFIRMED CLOSED (2026-04-22).** Live run of `ctx-loop-test` recipe via `/recipes/run` HTTP endpoint with `--driver subprocess` active. Agent called `ctxSaveTrace` (seq 14 written to `~/.patchwork/decision_traces.jsonl`), called `ctxQueryTraces` (returned 5 traces, test trace found), wrote report to `~/.patchwork/inbox/ctx-loop-test-2026-04-22.md` with `Result: PASS`. Fix shipped: `runRecipeFn` in `bridge.ts` now falls through to YAML runner when JSON recipe not found — YAML recipes are runnable via HTTP endpoint for the first time.
 2. **Freshness scoring + dedup across context sources.** Deferred; wait until real duplication pain appears in `contextBundle` / `getCommitsForIssue` output.
-3. **Slack connector** — dogfooded 2026-04-22. `handleSlackTest` → 200, `slackListChannels` returns channels, `slackPostMessage` posts successfully to #all-massappealdesigns. `morning-brief-slack` tool steps (github.list_prs, linear.list_issues, slack.post_message) all run end-to-end. Agent step requires `--claude-driver subprocess` (by design). Google Calendar token refresh error is unrelated — OAuth tokens need re-auth. **Slack is production-ready.**
+3. **Slack connector** — dogfooded 2026-04-22. `handleSlackTest` → 200, `slackListChannels` returns channels, `slackPostMessage` posts successfully to #all-massappealdesigns. `morning-brief-slack` tool steps (github.list_prs, linear.list_issues, slack.post_message) all run end-to-end. Agent step requires `--driver subprocess` (by design). Google Calendar token refresh error is unrelated — OAuth tokens need re-auth. **Slack is production-ready.**
 4. **Gemini driver parity — CLOSED (2026-04-22).** Full end-to-end validation: `ctx-loop-test` (tool-use, ctxSaveTrace + ctxQueryTraces, PASS in 32s) and `morning-brief` (7-step recipe, 26s, correct sections, no narration leak, written to inbox + visible in dashboard). Fixes shipped: MCP injection via `~/.gemini/settings.json`; `cwd: homedir()` (workspace `.gemini/settings.json` was loading shim → hang); removed `model: gemini-2.0-flash` (not available on this account); `stripLeadingNarration()` for tool-call narration prefix; snippet cleanup (200-char cap, Unicode noise stripped); 300s timeout. **Scheduler YAML bug fixed (2026-04-22):** cron scheduler was silently dropping YAML recipes — `RecipeScheduler.fire()` now routes YAML recipes through `runYaml` → `runRecipeFn` → YAML runner. Root cause of degraded Apr 20–21 morning briefs.
 
 ---
@@ -733,10 +733,10 @@ The bridge can now spawn Claude subprocesses, queue tasks, and drive event-drive
 - `src/claudeDriver.ts`: `IClaudeDriver` interface + `SubprocessDriver` (spawns `claude -p`) + `ApiDriver` stub
 - `src/claudeOrchestrator.ts`: Task queue with `MAX_CONCURRENT=10`, `MAX_QUEUE=20`, `MAX_HISTORY=100`. Exposes `enqueue()`, `runAndWait()`, `cancel()`, `list()`, `getTask()`
 - `src/automation.ts`: `AutomationHooks` + `loadPolicy()` — handles `onDiagnosticsError` and `onFileSave` with cooldown and loop guard
-- 4 new MCP tools: `runClaudeTask`, `getClaudeTaskStatus`, `cancelClaudeTask`, `listClaudeTasks` (session-scoped; only visible when `--claude-driver != none`)
+- 4 new MCP tools: `runClaudeTask`, `getClaudeTaskStatus`, `cancelClaudeTask`, `listClaudeTasks` (session-scoped; only visible when `--driver != none`)
 - `GET /tasks` HTTP endpoint (Bearer-auth) for external monitoring
 - VS Code output channel receives streamed Claude output in real time (`bridge/claudeTaskOutput` push notification)
-- New CLI flags: `--claude-driver`, `--claude-binary`, `--automation`, `--automation-policy`
+- New CLI flags: `--driver`, `--claude-binary`, `--automation`, `--automation-policy`
 - Security: 32 KB prompt cap, `CLAUDECODE` env stripped from subprocess, workspace path confinement on context files, diagnostic message sanitization with delimiters
 - **Bug fixes (2026-03-14 live test)**: Removed bogus `--workspace` flag from `claude -p` spawn args (flag doesn't exist in the CLI); added `stdio: ['ignore', 'pipe', 'pipe']` to prevent subprocess blocking on open stdin pipe; stripped all `CLAUDE_CODE_*` + `MCP_*` env vars from subprocess to prevent attaching to parent session ingress; added `--strict-mcp-config` to suppress `.mcp.json` auto-discovery in the workspace
 
@@ -774,7 +774,7 @@ Research (2026-03-17) against current Claude Code docs revealed gaps between the
 ### Remaining (deferred)
 - Verify Tool Search compatibility — with 135+ tools active; low priority (automatic, no bridge changes needed)
 - Agent Teams — when Claude Code's multi-session Teams feature ships; plan session namespacing then
-- **Claude Code Routines integration** — revisit when API exits research preview (`experimental-cc-routine-2026-04-01`). Immediate value: thin `runRoutine`/`getRoutineStatus`/`listRoutines` MCP tools (Phase 3 only — ~1 file, no driver changes). Full `RoutinesDriver` (`--claude-driver routines`) deferred until auth is stable (currently claude.ai accounts only, not open API). Policy-layer `routineId` on automation hooks also deferred. See: https://claude.ai/code/routines
+- **Claude Code Routines integration** — revisit when API exits research preview (`experimental-cc-routine-2026-04-01`). Immediate value: thin `runRoutine`/`getRoutineStatus`/`listRoutines` MCP tools (Phase 3 only — ~1 file, no driver changes). Full `RoutinesDriver` (`--driver routines`) deferred until auth is stable (currently claude.ai accounts only, not open API). Policy-layer `routineId` on automation hooks also deferred. See: https://claude.ai/code/routines
 
 ---
 

--- a/documents/triggers.md
+++ b/documents/triggers.md
@@ -43,7 +43,7 @@ Returns:
 | 200 | recipe accepted (the run itself is async — check the dashboard for outcome) |
 | 401 | missing or wrong `Authorization: Bearer` header |
 | 404 | no recipe matches that hook path |
-| 503 | bridge running without `--claude-driver subprocess` (orchestrator unavailable) |
+| 503 | bridge running without `--driver subprocess` (orchestrator unavailable) |
 
 **Get your token:**
 

--- a/documents/use-cases.md
+++ b/documents/use-cases.md
@@ -488,7 +488,7 @@ The `claude remote-control` pane in tmux receives your message and relays it to 
 
 ### Step 2: Claude hands off to a subprocess
 
-With Claude server mode enabled (`--claude-driver subprocess`), Claude does one thing:
+With Claude server mode enabled (`--driver subprocess`), Claude does one thing:
 
 **Tool**: `runClaudeTask`
 ```json

--- a/examples/recipes/advanced-patterns/README.md
+++ b/examples/recipes/advanced-patterns/README.md
@@ -24,7 +24,7 @@ Claude subagent per thread via `runClaudeTask`, then merges all results into a
 single structured document. The canonical reference for parent→child agent
 topologies in Patchwork.
 
-Requires: `--claude-driver subprocess` (or `api`), `file-mcp`, `notify-mcp`.
+Requires: `--driver subprocess` (or `api`), `file-mcp`, `notify-mcp`.
 
 ```bash
 patchwork run multi-agent-research --question "What are the main failure modes of solo founder companies?"
@@ -123,7 +123,7 @@ Two recipes in one file:
         into: "result_{{thread.id}}"
 ```
 
-Requires `--claude-driver subprocess` or `--claude-driver api`.
+Requires `--driver subprocess` or `--driver api`.
 
 ### Per-step model routing
 
@@ -166,10 +166,10 @@ trigger:
 
 | Recipe | Integrations needed |
 |---|---|
-| `multi-agent-research` | `claude-driver`, `file-mcp`, `notify-mcp` |
+| `multi-agent-research` | `driver`, `file-mcp`, `notify-mcp` |
 | `voice-memo-router` | `transcription-mcp`, `file-mcp`, `notify-mcp` |
 | `mixed-provider-pipeline` | `file-mcp`, multi-provider model support |
-| `writer-feedback-loop` | `claude-driver`, `file-mcp`, `dashboard-mcp`, `notify-mcp` |
+| `writer-feedback-loop` | `driver`, `file-mcp`, `dashboard-mcp`, `notify-mcp` |
 | `relationship-memory` | `gmail-mcp`, `file-mcp`, `notify-mcp` |
 | `small-business-brain` | `gmail-mcp`, `file-mcp`, `notify-mcp`, `scheduler-mcp` |
 

--- a/examples/recipes/advanced-patterns/mixed-provider-pipeline.yaml
+++ b/examples/recipes/advanced-patterns/mixed-provider-pipeline.yaml
@@ -3,7 +3,7 @@
 # Economics: GPT-4o-mini for classification (fast+cheap), Claude for drafting (quality),
 #            local Ollama for bulk summarization.
 # requires: file-mcp, notify-mcp
-# requires: claude-driver with multi-provider support (--claude-driver subprocess | api)
+# requires: driver with multi-provider support (--driver subprocess | api)
 version: 1.0.0
 name: mixed-provider-pipeline
 description: >

--- a/examples/recipes/advanced-patterns/multi-agent-research.yaml
+++ b/examples/recipes/advanced-patterns/multi-agent-research.yaml
@@ -1,7 +1,7 @@
 # vision-tier — demonstrates the runClaudeTask parent→child spawn pattern.
-# Works today if --claude-driver subprocess is active.
+# Works today if --driver subprocess is active.
 # Each topic gets its own Claude subprocess; parent merges results.
-# requires: file-mcp (read/write), claude-driver (subprocess or api)
+# requires: file-mcp (read/write), driver (subprocess or api)
 version: 1.0.0
 name: multi-agent-research
 description: >

--- a/examples/recipes/advanced-patterns/writer-feedback-loop.yaml
+++ b/examples/recipes/advanced-patterns/writer-feedback-loop.yaml
@@ -2,7 +2,7 @@
 # Spawns parallel subagents with distinct critical personas.
 # The approval trace log accumulates over time — which lens you act on teaches
 # the system which feedback style helps you most per project type.
-# requires: file-mcp, notify-mcp, claude-driver (subprocess or api)
+# requires: file-mcp, notify-mcp, driver (subprocess or api)
 version: 1.0.0
 name: writer-feedback-loop
 description: >

--- a/examples/self-healing-demo/README.md
+++ b/examples/self-healing-demo/README.md
@@ -33,7 +33,7 @@ claude-ide-bridge \
   --full \
   --automation \
   --automation-policy ./automation-policy.json \
-  --claude-driver subprocess
+  --driver subprocess
 ```
 
 Then open `src/broken.ts` in your IDE. The TypeScript language server will surface the error; the bridge's `onDiagnosticsError` hook fires; `runClaudeTask` spawns a Claude subprocess with the diagnostic contents already embedded; Claude is instructed to call `getDiagnostics` + `getHover` + propose a patch and return its reasoning.

--- a/examples/self-healing-demo/automation-policy.json
+++ b/examples/self-healing-demo/automation-policy.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Self-healing demo policy. When TS language server reports a new error, Claude is spawned to diagnose it. Response is surface-only — the fix is NOT auto-applied.",
-  "_usage": "claude-ide-bridge --workspace $PWD --full --automation --automation-policy ./automation-policy.json --claude-driver subprocess",
+  "_usage": "claude-ide-bridge --workspace $PWD --full --automation --automation-policy ./automation-policy.json --driver subprocess",
 
   "defaultModel": "claude-haiku-4-5-20251001",
   "defaultEffort": "low",

--- a/templates/automation-policies/recipe-authoring.json
+++ b/templates/automation-policies/recipe-authoring.json
@@ -1,6 +1,6 @@
 {
   "_comment": "recipe-authoring — runs preflight automatically when a .yaml recipe file is saved. Closes the authoring inner loop: edit → save → instant validation feedback via Claude task.",
-  "_usage": "Copy to automation-policy.json. Requires --automation --automation-policy <path> --claude-driver subprocess",
+  "_usage": "Copy to automation-policy.json. Requires --automation --automation-policy <path> --driver subprocess",
 
   "automationSystemPrompt": "Recipe lint bot. ≤10 lines. No preamble. List issues with file:line if available. End with 'Recipe OK' when clean.",
 

--- a/templates/automation-policies/security-first.json
+++ b/templates/automation-policies/security-first.json
@@ -1,6 +1,6 @@
 {
   "_comment": "security-first — monitors auth, payment, and API surface for vulnerabilities on every relevant change.",
-  "_usage": "Copy to automation-policy.json. Requires --automation --automation-policy <path> --claude-driver subprocess",
+  "_usage": "Copy to automation-policy.json. Requires --automation --automation-policy <path> --driver subprocess",
 
   "automationSystemPrompt": "Automation bot. Drop articles/filler. Fragments OK. Abbreviate: DB/auth/config/req/res/fn. X→Y arrows. ≤5 lines. No preamble. Call tools → report results only.",
 

--- a/templates/automation-policies/strict-lint.json
+++ b/templates/automation-policies/strict-lint.json
@@ -1,6 +1,6 @@
 {
   "_comment": "strict-lint — triggers on every save and error, enforces zero-warning policy.",
-  "_usage": "Copy to automation-policy.json. Requires --automation --automation-policy <path> --claude-driver subprocess",
+  "_usage": "Copy to automation-policy.json. Requires --automation --automation-policy <path> --driver subprocess",
 
   "automationSystemPrompt": "Automation bot. Drop articles/filler. Fragments OK. Abbreviate: DB/auth/config/req/res/fn. X→Y arrows. ≤5 lines. No preamble. Call tools → report results only.",
 

--- a/templates/automation-policies/test-driven.json
+++ b/templates/automation-policies/test-driven.json
@@ -1,6 +1,6 @@
 {
   "_comment": "test-driven — enforces test coverage and runs tests automatically on every relevant change.",
-  "_usage": "Copy to automation-policy.json. Requires --automation --automation-policy <path> --claude-driver subprocess",
+  "_usage": "Copy to automation-policy.json. Requires --automation --automation-policy <path> --driver subprocess",
 
   "automationSystemPrompt": "Automation bot. Drop articles/filler. Fragments OK. Abbreviate: DB/auth/config/req/res/fn. X→Y arrows. ≤5 lines. No preamble. Call tools → report results only.",
 

--- a/templates/automation-policy.example.json
+++ b/templates/automation-policy.example.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Example automation policy with LSP-aware prompts. Copy to automation-policy.json and adjust as needed.",
-  "_usage": "Start bridge with: claude-ide-bridge --automation --automation-policy ./automation-policy.json --claude-driver subprocess",
+  "_usage": "Start bridge with: claude-ide-bridge --automation --automation-policy ./automation-policy.json --driver subprocess",
 
   "onFileChanged": {
     "enabled": true,

--- a/templates/co.patchwork-os.bridge.plist
+++ b/templates/co.patchwork-os.bridge.plist
@@ -8,7 +8,7 @@
   <key>ProgramArguments</key>
   <array>
     <string>__BINARY_PATH__</string>
-    <string>--claude-driver</string>
+    <string>--driver</string>
     <string>subprocess</string>
   </array>
   <key>RunAtLoad</key>

--- a/templates/recipes/approval-queue-ui-test.yaml
+++ b/templates/recipes/approval-queue-ui-test.yaml
@@ -19,7 +19,7 @@ description: |
     Keyboard — J / K (focus), E / X (decide)
 
   PREREQUISITES
-    1. Bridge running with --claude-driver subprocess so the agent has MCP
+    1. Bridge running with --driver subprocess so the agent has MCP
        access to the Playwright server.
     2. Dashboard reachable at DASHBOARD_URL (defaults to localhost:3000;
        Patchwork's Next.js dev typically mounts under /dashboard, so the

--- a/templates/recipes/ctx-loop-test.yaml
+++ b/templates/recipes/ctx-loop-test.yaml
@@ -5,7 +5,7 @@ description: |
   appears in the result. Output lands in ~/.patchwork/inbox/ for manual inspection.
   Run this after deploying a new bridge build to confirm the memory moat is live.
 
-  NOTE: requires --claude-driver subprocess and a running bridge with HTTP port
+  NOTE: requires --driver subprocess and a running bridge with HTTP port
   so the agent subprocess has MCP access. Running via `patchwork recipe run`
   (local yamlRunner) will fail at Step 1 — the local claude -p subprocess has
   no bridge MCP context. Trigger from the dashboard Recipes page instead.

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -15,7 +15,7 @@ Fix a bug from your phone. Let Claude run your tests and commit the result. Ask 
 | **Bridge only** _(default)_ | 170 MCP tools: LSP, diagnostics, debugger, terminal, git, GitHub, file ops | Anyone who wants Claude Code to see and act on their IDE |
 | **Patchwork OS layer** _(opt-in)_ | All bridge tools + recipes, approval queue, oversight dashboard, mobile push approvals, multi-model | Power users running automation, agent workflows, or background tasks |
 
-The bridge runs without any flags. Add `--automation --claude-driver subprocess` to enable the Patchwork OS layer when you want it.
+The bridge runs without any flags. Add `--automation --driver subprocess` to enable the Patchwork OS layer when you want it.
 
 ---
 
@@ -155,7 +155,7 @@ In untrusted workspaces, bridge auto-install and auto-start are disabled. The ex
 Everything below is opt-in. The bridge works fine without any of it. Enable when you want a background agent that watches your workspace, runs YAML recipes on events, and routes risky actions through an approval queue.
 
 ```bash
-claude-ide-bridge --automation --automation-policy automation-policy.json --claude-driver subprocess
+claude-ide-bridge --automation --automation-policy automation-policy.json --driver subprocess
 # or use the patchwork CLI which sets these defaults
 patchwork start-all
 ```
@@ -202,7 +202,7 @@ Recipes run via `patchwork recipe run <name>` or fire automatically from automat
 
 ### Claude Orchestration
 
-When started with `--claude-driver subprocess`, the bridge can spawn Claude Code subprocesses as background tasks. Tools: `runClaudeTask`, `getClaudeTaskStatus`, `cancelClaudeTask`, `listClaudeTasks`, `resumeClaudeTask`. Output streams to the **Claude IDE Bridge** output channel in real time.
+When started with `--driver subprocess`, the bridge can spawn Claude Code subprocesses as background tasks. Tools: `runClaudeTask`, `getClaudeTaskStatus`, `cancelClaudeTask`, `listClaudeTasks`, `resumeClaudeTask`. Output streams to the **Claude IDE Bridge** output channel in real time.
 
 The headless CLI also exposes `start-task "<description>"`, `quick-task <preset>`, and `continue-handoff` as subcommands, sharing the same dispatch path as MCP clients and the sidebar.
 


### PR DESCRIPTION
## Summary

Follow-up to **#420** (alias removal). The original rip kept the diff reviewable by scoping to code + CLAUDE.md; this PR finishes the job across the user-facing surface: `docs/`, `documents/`, `examples/`, `templates/`, README files.

## Critical runtime fix

- **`templates/co.patchwork-os.bridge.plist`** — the macOS launchd plist was passing the now-removed flag as a `ProgramArgument`. Anyone who ran `launchctl load ~/Library/LaunchAgents/co.patchwork-os.bridge.plist` after #420 merged would get a bridge that failed at startup. This file is generated by `patchwork launchd install` from this template.

## Critical-but-not-runtime

- `templates/automation-policy.example.json` — `_usage` comment that users copy verbatim
- `templates/automation-policies/{recipe-authoring,strict-lint,test-driven,security-first}.json` — `_usage` comments in policy presets users install via `patchwork install`

## Prose / examples / comments

`README.md`, `README.bridge.md`, `ARCHITECTURE.md`, `vscode-extension/README.md`, `docs/{automation,troubleshooting,self-healing-quickstart}.md`, `documents/{headless-quickstart,platform-docs,triggers,use-cases,roadmap}.md`, the 4 advanced-patterns examples, both self-healing-demo files, two template recipe comment blocks, and the dogfood historical artifact updated for forward-reader consistency.

Also normalized bare `claude-driver` (no dashes) to `driver` in recipe `# requires:` comment blocks and the capability column of `examples/recipes/advanced-patterns/README.md` so the prose matches the canonical flag name.

## Left alone (intentional)

- All `claudeDriver.ts` references in code/docs — that's the driver-implementation source file ([src/claudeDriver.ts](src/claudeDriver.ts)), not the CLI flag (a different concept that survives).
- `CHANGELOG.md` historical alpha.21 entries (preserve fact-of-history — the alias did exist between alpha.21 and beta.2).

## Net diff

**27 files changed, +45 / −45** (line-for-line substitutions, zero logic changes).

## Test plan

- [x] `grep -rn 'claude-driver\\|claudeDriver' . --include='*.md' --include='*.json' --include='*.plist' --include='*.yaml' --include='*.sh' --include='*.ts' --include='*.mjs'` returns only file-name references to `claudeDriver.ts` (driver impl) and a CHANGELOG entry — both intentional.
- [ ] CI green
- [ ] Smoke: `launchctl load ~/Library/LaunchAgents/co.patchwork-os.bridge.plist` (after re-running `patchwork launchd install`) starts cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)