### PR TITLE
test(connectors): per-provider OAuth refresh coverage

### DIFF
--- a/src/connectors/__tests__/asanaOAuthConfig.test.ts
+++ b/src/connectors/__tests__/asanaOAuthConfig.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Contract lock for Asana's OAuth config wiring.
+ *
+ * Asana is one of the three BaseConnector subclasses that ship with a
+ * real `tokenEndpoint` (others: Discord, GitLab). The Wave-2 plan's
+ * "remaining gap" was lack of per-provider coverage beyond the generic
+ * BaseConnector tests — this file locks the provider-specific surface
+ * for Asana.
+ *
+ * What's tested:
+ *   1. Returns null when neither env nor stored credentials are present
+ *      (the refresh path must be unreachable in that case).
+ *   2. Returns the canonical Asana token URL + scope set when env
+ *      credentials are present (pins the constants so a refactor can't
+ *      silently change them).
+ *
+ * Generic refresh-flow behavior (401 → clear, 5xx → preserve, etc.) is
+ * covered by baseConnector.test.ts against a TestConnector subclass.
+ */
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { AsanaConnector } from "../asana.js";
+
+type WithGetOAuthConfig = {
+  getOAuthConfig(): {
+    clientId: string;
+    tokenEndpoint: string;
+    scopes?: string[];
+  } | null;
+};
+
+const ASANA_CANONICAL_TOKEN_URL = "https://app.asana.com/-/oauth_token";
+
+describe("AsanaConnector.getOAuthConfig()", () => {
+  let tmpHome: string;
+
+  beforeEach(() => {
+    tmpHome = mkdtempSync(join(tmpdir(), "patchwork-asana-oauth-"));
+    process.env.PATCHWORK_HOME = tmpHome;
+    process.env.PATCHWORK_TOKEN_STORAGE_BACKEND = "file";
+    delete process.env.ASANA_CLIENT_ID;
+    delete process.env.ASANA_CLIENT_SECRET;
+  });
+
+  afterEach(() => {
+    delete process.env.PATCHWORK_HOME;
+    delete process.env.PATCHWORK_TOKEN_STORAGE_BACKEND;
+    delete process.env.ASANA_CLIENT_ID;
+    delete process.env.ASANA_CLIENT_SECRET;
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("returns null when neither env nor stored credentials are present", () => {
+    const config = (
+      new AsanaConnector() as unknown as WithGetOAuthConfig
+    ).getOAuthConfig();
+    expect(config).toBeNull();
+  });
+
+  it("returns canonical token URL + scopes when env credentials are present", () => {
+    process.env.ASANA_CLIENT_ID = "test_client_id";
+    process.env.ASANA_CLIENT_SECRET = "test_client_secret";
+
+    const config = (
+      new AsanaConnector() as unknown as WithGetOAuthConfig
+    ).getOAuthConfig();
+
+    expect(config).not.toBeNull();
+    expect(config?.tokenEndpoint).toBe(ASANA_CANONICAL_TOKEN_URL);
+    expect(config?.scopes).toEqual(["default"]);
+    expect(config?.clientId).toBe("test_client_id");
+  });
+});

--- a/src/connectors/__tests__/discordOAuthConfig.test.ts
+++ b/src/connectors/__tests__/discordOAuthConfig.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Contract lock for Discord's OAuth config wiring.
+ *
+ * Discord is one of the three BaseConnector subclasses with a real
+ * `tokenEndpoint`. See asanaOAuthConfig.test.ts for the rationale.
+ */
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { DiscordConnector } from "../discord.js";
+
+type WithGetOAuthConfig = {
+  getOAuthConfig(): {
+    clientId: string;
+    tokenEndpoint: string;
+    scopes?: string[];
+  } | null;
+};
+
+const DISCORD_CANONICAL_TOKEN_URL = "https://discord.com/api/oauth2/token";
+
+describe("DiscordConnector.getOAuthConfig()", () => {
+  let tmpHome: string;
+
+  beforeEach(() => {
+    tmpHome = mkdtempSync(join(tmpdir(), "patchwork-discord-oauth-"));
+    process.env.PATCHWORK_HOME = tmpHome;
+    process.env.PATCHWORK_TOKEN_STORAGE_BACKEND = "file";
+    delete process.env.DISCORD_CLIENT_ID;
+    delete process.env.DISCORD_CLIENT_SECRET;
+  });
+
+  afterEach(() => {
+    delete process.env.PATCHWORK_HOME;
+    delete process.env.PATCHWORK_TOKEN_STORAGE_BACKEND;
+    delete process.env.DISCORD_CLIENT_ID;
+    delete process.env.DISCORD_CLIENT_SECRET;
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("returns null when neither env nor stored credentials are present", () => {
+    const config = (
+      new DiscordConnector() as unknown as WithGetOAuthConfig
+    ).getOAuthConfig();
+    expect(config).toBeNull();
+  });
+
+  it("returns canonical token URL + scopes when env credentials are present", () => {
+    process.env.DISCORD_CLIENT_ID = "test_client_id";
+    process.env.DISCORD_CLIENT_SECRET = "test_client_secret";
+
+    const config = (
+      new DiscordConnector() as unknown as WithGetOAuthConfig
+    ).getOAuthConfig();
+
+    expect(config).not.toBeNull();
+    expect(config?.tokenEndpoint).toBe(DISCORD_CANONICAL_TOKEN_URL);
+    expect(config?.scopes).toEqual(["identify", "guilds", "messages.read"]);
+    expect(config?.clientId).toBe("test_client_id");
+  });
+});

--- a/src/connectors/__tests__/gitlabOAuthConfig.test.ts
+++ b/src/connectors/__tests__/gitlabOAuthConfig.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Contract lock for GitLab's OAuth config wiring.
+ *
+ * GitLab is the third BaseConnector subclass with a real `tokenEndpoint`.
+ * Unlike Asana/Discord, GitLab's tokenEndpoint is dynamic — it derives
+ * from the configured GitLab instance URL (defaults to gitlab.com,
+ * configurable via GITLAB_BASE_URL for self-hosted instances).
+ *
+ * This test pins both the default-instance URL and the self-hosted
+ * override path, so a refactor of the base-URL logic can't silently
+ * break refresh against self-hosted GitLab.
+ */
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { GitLabConnector } from "../gitlab.js";
+
+type WithGetOAuthConfig = {
+  getOAuthConfig(): {
+    clientId: string;
+    tokenEndpoint: string;
+    scopes?: string[];
+  } | null;
+};
+
+describe("GitLabConnector.getOAuthConfig()", () => {
+  let tmpHome: string;
+
+  beforeEach(() => {
+    tmpHome = mkdtempSync(join(tmpdir(), "patchwork-gitlab-oauth-"));
+    process.env.PATCHWORK_HOME = tmpHome;
+    process.env.PATCHWORK_TOKEN_STORAGE_BACKEND = "file";
+    delete process.env.GITLAB_CLIENT_ID;
+    delete process.env.GITLAB_CLIENT_SECRET;
+    delete process.env.GITLAB_BASE_URL;
+  });
+
+  afterEach(() => {
+    delete process.env.PATCHWORK_HOME;
+    delete process.env.PATCHWORK_TOKEN_STORAGE_BACKEND;
+    delete process.env.GITLAB_CLIENT_ID;
+    delete process.env.GITLAB_CLIENT_SECRET;
+    delete process.env.GITLAB_BASE_URL;
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("returns null when neither env nor stored credentials are present", () => {
+    const config = (
+      new GitLabConnector() as unknown as WithGetOAuthConfig
+    ).getOAuthConfig();
+    expect(config).toBeNull();
+  });
+
+  it("returns gitlab.com token URL + scopes by default", () => {
+    process.env.GITLAB_CLIENT_ID = "test_client_id";
+    process.env.GITLAB_CLIENT_SECRET = "test_client_secret";
+
+    const config = (
+      new GitLabConnector() as unknown as WithGetOAuthConfig
+    ).getOAuthConfig();
+
+    expect(config).not.toBeNull();
+    expect(config?.tokenEndpoint).toBe("https://gitlab.com/oauth/token");
+    expect(config?.scopes).toEqual([
+      "read_user",
+      "read_api",
+      "read_repository",
+    ]);
+  });
+
+  it("respects GITLAB_BASE_URL for self-hosted instances", () => {
+    process.env.GITLAB_CLIENT_ID = "test_client_id";
+    process.env.GITLAB_CLIENT_SECRET = "test_client_secret";
+    process.env.GITLAB_BASE_URL = "https://gitlab.example.com";
+
+    const config = (
+      new GitLabConnector() as unknown as WithGetOAuthConfig
+    ).getOAuthConfig();
+
+    expect(config?.tokenEndpoint).toBe(
+      "https://gitlab.example.com/oauth/token",
+    );
+  });
+});

--- a/src/connectors/__tests__/googleCalendarRefresh.test.ts
+++ b/src/connectors/__tests__/googleCalendarRefresh.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Tests that Google Calendar token refresh works using stored
+ * _client_id/_client_secret when env vars are absent — same production
+ * bug shape as gmailRefresh.test.ts (silent refresh failure after a
+ * bridge restart with no credentials in env).
+ */
+
+import os from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return {
+    ...actual,
+    existsSync: vi.fn().mockReturnValue(false),
+    readFileSync: vi.fn().mockReturnValue("{}"),
+    writeFileSync: vi.fn(),
+    renameSync: vi.fn(),
+    chmodSync: vi.fn(),
+    unlinkSync: vi.fn(),
+    mkdirSync: vi.fn(),
+  };
+});
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+import * as fs from "node:fs";
+import { getValidAccessToken } from "../googleCalendar.js";
+
+function mockConnected(overrides: Record<string, unknown> = {}) {
+  vi.mocked(fs.existsSync).mockReturnValue(true);
+  vi.mocked(fs.readFileSync).mockReturnValue(
+    JSON.stringify({
+      access_token: "at_test",
+      refresh_token: "rt_test",
+      expiry_date: Date.now() + 60 * 60 * 1000,
+      ...overrides,
+    }),
+  );
+}
+
+beforeEach(() => {
+  vi.mocked(fs.existsSync).mockReturnValue(false);
+  mockFetch.mockReset();
+  process.env.GOOGLE_CALENDAR_CLIENT_ID = "env_cid";
+  process.env.GOOGLE_CALENDAR_CLIENT_SECRET = "env_csecret";
+  process.env.PATCHWORK_HOME = join(
+    os.tmpdir(),
+    `patchwork-gcal-refresh-${Date.now()}`,
+  );
+  process.env.PATCHWORK_TOKEN_STORAGE_BACKEND = "file";
+});
+
+afterEach(() => {
+  delete process.env.GOOGLE_CALENDAR_CLIENT_ID;
+  delete process.env.GOOGLE_CALENDAR_CLIENT_SECRET;
+  delete process.env.PATCHWORK_HOME;
+  delete process.env.PATCHWORK_TOKEN_STORAGE_BACKEND;
+  vi.restoreAllMocks();
+});
+
+describe("googleCalendar.getValidAccessToken — credential fallback", () => {
+  it("uses stored _client_id/_client_secret when env vars absent at refresh time", async () => {
+    delete process.env.GOOGLE_CALENDAR_CLIENT_ID;
+    delete process.env.GOOGLE_CALENDAR_CLIENT_SECRET;
+
+    mockConnected({
+      expiry_date: Date.now() - 1000,
+      _client_id: "stored_cid",
+      _client_secret: "stored_csecret",
+    });
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ access_token: "at_refreshed", expires_in: 3600 }),
+      text: async () => "{}",
+    } as unknown as Response);
+
+    const token = await getValidAccessToken();
+    expect(token).toBe("at_refreshed");
+
+    const body = new URLSearchParams(
+      mockFetch.mock.calls[0]![1]!.body as string,
+    );
+    expect(body.get("client_id")).toBe("stored_cid");
+    expect(body.get("client_secret")).toBe("stored_csecret");
+    expect(body.get("refresh_token")).toBe("rt_test");
+  });
+
+  it("throws a clear error when token expired and no credentials anywhere", async () => {
+    delete process.env.GOOGLE_CALENDAR_CLIENT_ID;
+    delete process.env.GOOGLE_CALENDAR_CLIENT_SECRET;
+    mockConnected({ expiry_date: Date.now() - 1000 });
+    await expect(getValidAccessToken()).rejects.toThrow(
+      /reconnect|credentials/i,
+    );
+  });
+
+  it("prefers env vars over stored credentials when both present", async () => {
+    mockConnected({
+      expiry_date: Date.now() - 1000,
+      _client_id: "stored_cid",
+      _client_secret: "stored_csecret",
+    });
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ access_token: "at_refreshed", expires_in: 3600 }),
+      text: async () => "{}",
+    } as unknown as Response);
+
+    await getValidAccessToken();
+
+    const body = new URLSearchParams(
+      mockFetch.mock.calls[0]![1]!.body as string,
+    );
+    expect(body.get("client_id")).toBe("env_cid");
+  });
+});

--- a/src/connectors/__tests__/googleDriveRefresh.test.ts
+++ b/src/connectors/__tests__/googleDriveRefresh.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Tests that Google Drive token refresh works using stored
+ * _client_id/_client_secret when env vars are absent — same production
+ * bug shape as gmailRefresh.test.ts.
+ */
+
+import os from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return {
+    ...actual,
+    existsSync: vi.fn().mockReturnValue(false),
+    readFileSync: vi.fn().mockReturnValue("{}"),
+    writeFileSync: vi.fn(),
+    renameSync: vi.fn(),
+    chmodSync: vi.fn(),
+    unlinkSync: vi.fn(),
+    mkdirSync: vi.fn(),
+  };
+});
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+import * as fs from "node:fs";
+import { getValidAccessToken } from "../googleDrive.js";
+
+function mockConnected(overrides: Record<string, unknown> = {}) {
+  vi.mocked(fs.existsSync).mockReturnValue(true);
+  vi.mocked(fs.readFileSync).mockReturnValue(
+    JSON.stringify({
+      access_token: "at_test",
+      refresh_token: "rt_test",
+      expiry_date: Date.now() + 60 * 60 * 1000,
+      ...overrides,
+    }),
+  );
+}
+
+beforeEach(() => {
+  vi.mocked(fs.existsSync).mockReturnValue(false);
+  mockFetch.mockReset();
+  process.env.GOOGLE_DRIVE_CLIENT_ID = "env_cid";
+  process.env.GOOGLE_DRIVE_CLIENT_SECRET = "env_csecret";
+  process.env.PATCHWORK_HOME = join(
+    os.tmpdir(),
+    `patchwork-gdrive-refresh-${Date.now()}`,
+  );
+  process.env.PATCHWORK_TOKEN_STORAGE_BACKEND = "file";
+});
+
+afterEach(() => {
+  delete process.env.GOOGLE_DRIVE_CLIENT_ID;
+  delete process.env.GOOGLE_DRIVE_CLIENT_SECRET;
+  delete process.env.PATCHWORK_HOME;
+  delete process.env.PATCHWORK_TOKEN_STORAGE_BACKEND;
+  vi.restoreAllMocks();
+});
+
+describe("googleDrive.getValidAccessToken — credential fallback", () => {
+  it("uses stored _client_id/_client_secret when env vars absent at refresh time", async () => {
+    delete process.env.GOOGLE_DRIVE_CLIENT_ID;
+    delete process.env.GOOGLE_DRIVE_CLIENT_SECRET;
+
+    mockConnected({
+      expiry_date: Date.now() - 1000,
+      _client_id: "stored_cid",
+      _client_secret: "stored_csecret",
+    });
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ access_token: "at_refreshed", expires_in: 3600 }),
+      text: async () => "{}",
+    } as unknown as Response);
+
+    const token = await getValidAccessToken();
+    expect(token).toBe("at_refreshed");
+
+    const body = new URLSearchParams(
+      mockFetch.mock.calls[0]![1]!.body as string,
+    );
+    expect(body.get("client_id")).toBe("stored_cid");
+    expect(body.get("client_secret")).toBe("stored_csecret");
+    expect(body.get("refresh_token")).toBe("rt_test");
+  });
+
+  it("throws a clear error when token expired and no credentials anywhere", async () => {
+    delete process.env.GOOGLE_DRIVE_CLIENT_ID;
+    delete process.env.GOOGLE_DRIVE_CLIENT_SECRET;
+    mockConnected({ expiry_date: Date.now() - 1000 });
+    await expect(getValidAccessToken()).rejects.toThrow(
+      /reconnect|credentials/i,
+    );
+  });
+
+  it("prefers env vars over stored credentials when both present", async () => {
+    mockConnected({
+      expiry_date: Date.now() - 1000,
+      _client_id: "stored_cid",
+      _client_secret: "stored_csecret",
+    });
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ access_token: "at_refreshed", expires_in: 3600 }),
+      text: async () => "{}",
+    } as unknown as Response);
+
+    await getValidAccessToken();
+
+    const body = new URLSearchParams(
+      mockFetch.mock.calls[0]![1]!.body as string,
+    );
+    expect(body.get("client_id")).toBe("env_cid");
+  });
+});


### PR DESCRIPTION
## Summary

Closes the test-coverage gap that originally motivated the "~1 day of test work" Wave-2 announce-blocker line in [docs/recipe-authoring-wave2-plan.md:75-79](docs/recipe-authoring-wave2-plan.md#L75-L79).

Companion to **#424** (lock-tests for the 8 API-token Wave-2 connectors). This PR covers the connectors that actually have a real OAuth `tokenEndpoint`.

## Two layers

### 1. Config-shape locks (Asana, Discord, GitLab)

For each `BaseConnector` subclass with a real `tokenEndpoint`:

- Asserts `getOAuthConfig()` returns `null` when no credentials (env or stored) are present — refresh path must be unreachable in that state.
- Pins canonical token URL + scope set so a refactor can't silently change them.

GitLab gets a third test for the `GITLAB_BASE_URL` self-hosted override.

Generic refresh-flow behavior (401 → clear, 5xx → preserve, transient errors, refresh-token rotation) stays covered by [baseConnector.test.ts:114-358](src/connectors/__tests__/baseConnector.test.ts#L114-L358) against a `TestConnector` subclass.

### 2. gmailRefresh.test.ts pattern copies (googleCalendar, googleDrive)

Both modules export `getValidAccessToken` (the same standalone-function pattern as Gmail), so they get the same three tests:

- Stored `_client_id` / `_client_secret` fallback when env vars absent (the production bug Gmail had)
- Clean error when token expired + no credentials anywhere
- Env vars beat stored credentials when both present

## Provider matrix

| Connector | File | Token URL | Scopes / env vars |
|---|---|---|---|
| Asana | [asana.ts:207](src/connectors/asana.ts#L207) | `https://app.asana.com/-/oauth_token` | `["default"]` |
| Discord | [discord.ts:180](src/connectors/discord.ts#L180) | `https://discord.com/api/oauth2/token` | `["identify", "guilds", "messages.read"]` |
| GitLab | [gitlab.ts:215](src/connectors/gitlab.ts#L215) | `<base>/oauth/token` (default `gitlab.com`, override via `GITLAB_BASE_URL`) | `["read_user", "read_api", "read_repository"]` |
| Google Calendar | [googleCalendar.ts:256](src/connectors/googleCalendar.ts#L256) | (standalone module) | `GOOGLE_CALENDAR_CLIENT_ID/SECRET` |
| Google Drive | [googleDrive.ts:209](src/connectors/googleDrive.ts#L209) | (standalone module) | `GOOGLE_DRIVE_CLIENT_ID/SECRET` |

## Net diff

**5 new files, +434 LOC, 13 new tests, 0 lines touched in existing code.**

## Test plan

- [x] `npx vitest run src/connectors/__tests__/{asanaOAuthConfig,discordOAuthConfig,gitlabOAuthConfig,googleCalendarRefresh,googleDriveRefresh}.test.ts` → 13 / 13 pass
- [x] `npm run typecheck` passes
- [x] Biome formatting clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)