### PR TITLE
feat(recipe): multi-step loop + paramsSchema-driven prompts in recipe new -i

### DIFF
--- a/src/commands/__tests__/recipe-new-interactive.test.ts
+++ b/src/commands/__tests__/recipe-new-interactive.test.ts
@@ -3,14 +3,16 @@
  * behind `patchwork recipe new --interactive`.
  *
  * The prompt deps are injected so the test drives a fixed sequence
- * of answers and asserts the generated YAML shape. Two paths covered:
- *   1. Manual trigger + agent step + tail write
- *   2. Cron trigger + connector tool + agent step + tail write
+ * of answers and asserts the generated YAML shape. Each kind=N constant
+ * matches the step-kind-choice index from runNewInteractive:
+ *   KIND_TOOL  = 1  ("Add a tool step")
+ *   KIND_AGENT = 2  ("Add an agent step")
+ *   KIND_DONE  = 3  ("Done — preview and write")
  *
  * Schema-drift firewall: `validateRecipeDefinition` is invoked inside
  * the function, so a real schema change that the generator violates
- * will surface here as a `result.warnings` entry — the test asserts
- * no errors among warnings so a regression breaks the build.
+ * will surface here as a `result.warnings` entry of level "error" —
+ * the tests assert that array is empty so a regression breaks the build.
  */
 
 import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
@@ -19,6 +21,10 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import "../../recipes/tools/index.js";
 import { type InteractivePromptDeps, runNewInteractive } from "../recipe.js";
+
+const KIND_TOOL = 1;
+const KIND_AGENT = 2;
+const KIND_DONE = 3;
 
 /**
  * Build a prompt-deps stub that returns a fixed sequence of answers.
@@ -64,130 +70,237 @@ describe("runNewInteractive", () => {
     rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  it("manual trigger + skip connector + agent step writes valid YAML", async () => {
+  it("manual trigger + single agent step writes valid YAML", async () => {
     const deps = makeStubDeps({
       ask: ["my-test-recipe", "Test description", "Summarize the input"],
       pickFromList: [
         1, // trigger type: manual
-        99, // connector pick: out-of-range to force "skip" (last option)
+        KIND_AGENT, // step 1: agent
+        KIND_DONE, // step 2: done
       ],
       confirm: [
-        true, // add agent step
         true, // write to disk
       ],
     });
 
-    // pickFromList=99 is invalid; the test deps don't validate, but the
-    // runNewInteractive flow does (it treats "out of namespaces range"
-    // as the "skip" branch). Recompute with a valid skip index.
-    // The "skip" option is appended after the namespaces, so a stable
-    // sentinel is: pick the largest valid index by counting registered
-    // namespaces first.
-    // For simplicity, rebuild deps with the right skip index.
-    const { listConnectorNamespaces } = await import(
-      "../../recipes/toolRegistry.js"
-    );
-    const skipIdx = listConnectorNamespaces().length + 1;
-    const deps2 = makeStubDeps({
-      ask: ["my-test-recipe", "Test description", "Summarize the input"],
-      pickFromList: [1, skipIdx],
-      confirm: [true, true],
-    });
-    void deps; // first build was a no-op for skipIdx discovery
-
-    const result = await runNewInteractive({
-      outputDir: tmpDir,
-      deps: deps2,
-    });
+    const result = await runNewInteractive({ outputDir: tmpDir, deps });
 
     expect(existsSync(result.path)).toBe(true);
     expect(result.path.endsWith("my-test-recipe.yaml")).toBe(true);
 
     const content = readFileSync(result.path, "utf-8");
     expect(content).toContain("name: my-test-recipe");
-    expect(content).toContain("description: ");
     expect(content).toContain("type: manual");
     expect(content).toContain("agent: true");
     expect(content).toContain("Summarize the input");
     expect(content).toContain("tool: file.write");
-    // Skipped connector — no tool step before the file.write tail.
-    // The only `- tool:` line should be the tail.
+    // No connector tool steps — only the file.write tail.
     const toolLines = content
       .split("\n")
       .filter((line) => line.trim().startsWith("- tool:"));
     expect(toolLines.length).toBe(1);
+    // Tail file.write references the agent output.
+    expect(content).toContain("{{agent_output}}");
 
-    // No schema-drift errors should be present in warnings (warnings of
-    // level "warning" are tolerated — this gate is for real errors).
     const errors = result.warnings.filter((w) => w.level === "error");
     expect(errors).toEqual([]);
   });
 
-  it("cron trigger + connector + no agent writes valid YAML with cron line", async () => {
-    const { listConnectorNamespaces } = await import(
+  it("cron trigger + tool step (no agent) writes valid YAML with cron line", async () => {
+    const { listConnectorNamespaces, listTools } = await import(
       "../../recipes/toolRegistry.js"
     );
     const namespaces = listConnectorNamespaces();
-    expect(namespaces.length).toBeGreaterThan(0); // sanity — registry is hydrated
+    expect(namespaces.length).toBeGreaterThan(0); // sanity
 
-    const firstNsIdx = 1;
+    // Walk the registry deterministically to find the first connector
+    // whose first tool has zero required params — keeps the test from
+    // breaking when a new connector lands with required fields.
+    let chosenNsIdx = -1;
+    let chosenToolIdx = -1;
+    outer: for (let i = 0; i < namespaces.length; i++) {
+      const ns = namespaces[i];
+      if (!ns) continue;
+      const tools = listTools(ns);
+      for (let j = 0; j < tools.length; j++) {
+        const schema = tools[j]?.paramsSchema as { required?: unknown } | null;
+        const required = Array.isArray(schema?.required)
+          ? (schema?.required as unknown[])
+          : [];
+        if (required.length === 0) {
+          chosenNsIdx = i + 1;
+          chosenToolIdx = j + 1;
+          break outer;
+        }
+      }
+    }
+    expect(chosenNsIdx).toBeGreaterThan(0);
+    expect(chosenToolIdx).toBeGreaterThan(0);
+
     const deps = makeStubDeps({
-      ask: [
-        "my-cron-recipe",
-        "Daily cron test",
-        "0 8 * * *", // cron expression
-      ],
+      ask: ["my-cron-recipe", "Daily cron test", "0 8 * * *"],
       pickFromList: [
         2, // trigger type: cron
-        firstNsIdx, // pick first connector namespace
-        1, // pick first tool from that namespace
+        KIND_TOOL, // step 1: tool
+        chosenNsIdx, // pick connector
+        chosenToolIdx, // pick tool (zero-required-params)
+        KIND_DONE, // step 2: done
       ],
       confirm: [
-        false, // skip agent step
-        true, // write to disk
+        true, // write
       ],
     });
 
-    const result = await runNewInteractive({
-      outputDir: tmpDir,
-      deps,
-    });
+    const result = await runNewInteractive({ outputDir: tmpDir, deps });
 
     const content = readFileSync(result.path, "utf-8");
     expect(content).toContain("name: my-cron-recipe");
     expect(content).toContain("type: cron");
-    expect(content).toContain("at: ");
     expect(content).toContain("0 8 * * *");
-    // Connector tool step landed before the file.write tail.
+    // Two tool steps: the connector + the file.write tail.
     const toolLines = content
       .split("\n")
       .filter((line) => line.trim().startsWith("- tool:"));
-    expect(toolLines.length).toBe(2); // connector + file.write tail
-    // No agent step.
+    expect(toolLines.length).toBe(2);
     expect(content).not.toContain("agent: true");
 
     const errors = result.warnings.filter((w) => w.level === "error");
     expect(errors).toEqual([]);
   });
 
-  it("rejects invalid recipe names with the validation hint", async () => {
-    // First answer is invalid (uppercase), second is valid. The
-    // generator re-asks; askWithValidation surfaces the rule in the
-    // re-asked question. We just confirm the eventual valid answer
-    // produces the recipe rather than crashing.
-    const { listConnectorNamespaces } = await import(
+  it("multi-step recipe: 2 tool steps + 1 agent step", async () => {
+    const { listConnectorNamespaces, listTools } = await import(
       "../../recipes/toolRegistry.js"
     );
-    const skipIdx = listConnectorNamespaces().length + 1;
+    const namespaces = listConnectorNamespaces();
+
+    // Find two zero-required-param tools (may be in the same ns or different).
+    const picks: Array<{ ns: number; tool: number }> = [];
+    outer: for (let i = 0; i < namespaces.length && picks.length < 2; i++) {
+      const ns = namespaces[i];
+      if (!ns) continue;
+      const tools = listTools(ns);
+      for (let j = 0; j < tools.length && picks.length < 2; j++) {
+        const schema = tools[j]?.paramsSchema as { required?: unknown } | null;
+        const required = Array.isArray(schema?.required)
+          ? (schema?.required as unknown[])
+          : [];
+        if (required.length === 0) {
+          picks.push({ ns: i + 1, tool: j + 1 });
+          if (picks.length >= 2) break outer;
+        }
+      }
+    }
+    expect(picks.length).toBe(2);
+
     const deps = makeStubDeps({
-      ask: [
-        "INVALID-Name", // rejected — uppercase
-        "valid-name", // accepted
-        "desc",
-        "prompt",
+      ask: ["multi-step", "Two tool steps + agent", "Summarize results"],
+      pickFromList: [
+        1, // trigger: manual
+        KIND_TOOL,
+        picks[0]!.ns,
+        picks[0]!.tool,
+        KIND_TOOL,
+        picks[1]!.ns,
+        picks[1]!.tool,
+        KIND_AGENT,
+        KIND_DONE,
       ],
-      pickFromList: [1, skipIdx],
-      confirm: [true, true],
+      confirm: [true],
+    });
+
+    const result = await runNewInteractive({ outputDir: tmpDir, deps });
+    const content = readFileSync(result.path, "utf-8");
+
+    // Three tool steps in steps[] (2 connectors) + file.write tail = 3 lines
+    const toolLines = content
+      .split("\n")
+      .filter((line) => line.trim().startsWith("- tool:"));
+    expect(toolLines.length).toBe(3);
+    expect(content).toContain("agent: true");
+    // Tail references the agent_output (most recent).
+    expect(content).toContain("{{agent_output}}");
+
+    const errors = result.warnings.filter((w) => w.level === "error");
+    expect(errors).toEqual([]);
+  });
+
+  it("prompts for the tool's required params from paramsSchema", async () => {
+    const { listConnectorNamespaces, listTools } = await import(
+      "../../recipes/toolRegistry.js"
+    );
+    const namespaces = listConnectorNamespaces();
+
+    // Find the first tool with >=1 required param.
+    let chosenNsIdx = -1;
+    let chosenToolIdx = -1;
+    let requiredKeys: string[] = [];
+    outer: for (let i = 0; i < namespaces.length; i++) {
+      const ns = namespaces[i];
+      if (!ns) continue;
+      const tools = listTools(ns);
+      for (let j = 0; j < tools.length; j++) {
+        const schema = tools[j]?.paramsSchema as { required?: unknown } | null;
+        const reqArr = Array.isArray(schema?.required)
+          ? (schema?.required as unknown[])
+          : [];
+        const filtered = reqArr.filter(
+          (k): k is string => typeof k === "string" && k !== "into",
+        );
+        if (filtered.length > 0) {
+          chosenNsIdx = i + 1;
+          chosenToolIdx = j + 1;
+          requiredKeys = filtered;
+          break outer;
+        }
+      }
+    }
+    // If no connector tool exposes a required param, skip with a clear note.
+    if (chosenNsIdx === -1) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        "No connector tool with required params found — skipping required-params test",
+      );
+      return;
+    }
+
+    const stubAnswers = requiredKeys.map((k) => `value_for_${k}`);
+
+    const deps = makeStubDeps({
+      ask: ["needs-params", "Test required params", ...stubAnswers],
+      pickFromList: [
+        1, // manual
+        KIND_TOOL,
+        chosenNsIdx,
+        chosenToolIdx,
+        KIND_DONE,
+      ],
+      confirm: [true],
+    });
+
+    const result = await runNewInteractive({ outputDir: tmpDir, deps });
+    const content = readFileSync(result.path, "utf-8");
+
+    // Each required key + its stub value should appear in the YAML.
+    for (let i = 0; i < requiredKeys.length; i++) {
+      const key = requiredKeys[i]!;
+      const value = stubAnswers[i]!;
+      expect(content).toContain(`    ${key}: ${value}`);
+    }
+
+    const errors = result.warnings.filter((w) => w.level === "error");
+    expect(errors).toEqual([]);
+  });
+
+  it("rejects invalid recipe names with the validation hint", async () => {
+    const deps = makeStubDeps({
+      ask: ["INVALID-Name", "valid-name", "desc", "prompt"],
+      pickFromList: [
+        1, // manual
+        KIND_AGENT, // agent step
+        KIND_DONE,
+      ],
+      confirm: [true],
     });
 
     const result = await runNewInteractive({ outputDir: tmpDir, deps });
@@ -195,15 +308,13 @@ describe("runNewInteractive", () => {
   });
 
   it("cancels cleanly when user declines the final write", async () => {
-    const { listConnectorNamespaces } = await import(
-      "../../recipes/toolRegistry.js"
-    );
-    const skipIdx = listConnectorNamespaces().length + 1;
     const deps = makeStubDeps({
       ask: ["cancel-test", "desc"],
-      pickFromList: [1, skipIdx],
+      pickFromList: [
+        1, // manual
+        KIND_DONE, // no steps
+      ],
       confirm: [
-        false, // no agent step
         false, // decline write
       ],
     });

--- a/src/commands/recipe.ts
+++ b/src/commands/recipe.ts
@@ -229,6 +229,51 @@ function yamlScalar(value: string): string {
   return JSON.stringify(value);
 }
 
+/**
+ * Prompt the user for the tool's required JSON Schema fields. Optional
+ * properties are skipped — the user can hand-edit the YAML afterwards
+ * if they want to set defaults. `into` is excluded since the generator
+ * supplies its own name.
+ *
+ * Returns an ordered list of `[key, value]` pairs so the YAML output is
+ * stable across runs (insertion order of object keys is sufficient in
+ * V8 for string keys, but an array makes the contract explicit).
+ */
+async function collectRequiredParams(
+  deps: InteractivePromptDeps,
+  tool: { id: string; paramsSchema: unknown },
+): Promise<Array<[string, string]>> {
+  const schema = tool.paramsSchema as
+    | {
+        required?: unknown;
+        properties?: Record<string, { description?: string }> | undefined;
+      }
+    | null
+    | undefined;
+  if (!schema || typeof schema !== "object") return [];
+
+  const required = Array.isArray(schema.required)
+    ? (schema.required.filter(
+        (k): k is string => typeof k === "string" && k !== "into",
+      ) as string[])
+    : [];
+  if (required.length === 0) return [];
+
+  const out: Array<[string, string]> = [];
+  const properties = schema.properties ?? {};
+  for (const key of required) {
+    const propMeta = properties[key];
+    const hint = propMeta?.description ? ` — ${propMeta.description}` : "";
+    const value = await askWithValidation(
+      deps,
+      `${tool.id} → ${key}${hint}`,
+      (a) => (a.trim().length > 0 ? null : "required, cannot be empty."),
+    );
+    out.push([key, value.trim()]);
+  }
+  return out;
+}
+
 export async function runNewInteractive(
   options: InteractiveNewOptions,
 ): Promise<InteractiveNewResult> {
@@ -267,49 +312,88 @@ export async function runNewInteractive(
     triggerLines.push(`  at: ${yamlScalar(cron.trim())}`);
   }
 
-  // Tool-step pick (connector or skip)
+  // Step loop. The user adds tool / agent steps until they pick "done".
+  // Each tool pick reads its paramsSchema and prompts for required fields,
+  // so the generated recipe is closer to runnable than the MVP slice.
   const namespaces = listConnectorNamespaces();
-  const choices = [...namespaces, "(skip — no tool step)"];
-  const nsIdx = await deps.pickFromList("Pick a connector (or skip)", choices);
-
   const stepLines: string[] = ["steps:"];
-  const pickedNs = namespaces[nsIdx - 1];
-  if (nsIdx >= 1 && nsIdx <= namespaces.length && pickedNs) {
-    const ns = pickedNs;
-    const tools = listTools(ns);
-    const labels = tools.map((t) => `${t.id} — ${t.description}`);
-    const toolIdx = await deps.pickFromList(`Pick a ${ns} tool`, labels);
-    const tool = tools[toolIdx - 1];
-    if (!tool) throw new Error(`Invalid tool selection for ${ns}`);
-    stepLines.push(`  - tool: ${tool.id}`);
-    stepLines.push(`    into: ${ns}_result`);
-  }
+  const intoNames: string[] = [];
+  let lastAgentInto: string | null = null;
+  let toolStepCount = 0;
+  let agentStepCount = 0;
 
-  const wantsAgent = await deps.confirm("Add an agent (LLM) step?");
-  if (wantsAgent) {
-    const prompt = await askWithValidation(deps, "Agent prompt", (a) =>
-      a.trim().length > 0 ? null : "cannot be empty.",
+  const stepKindChoices = [
+    "Add a tool step (calls a registered tool — gmail.fetch_unread, github.list_issues, …)",
+    "Add an agent step (LLM prompt — drafts, classifies, summarizes)",
+    "Done — preview and write",
+  ];
+
+  for (let stepIdx = 0; stepIdx < 20; stepIdx++) {
+    const kind = await deps.pickFromList(
+      stepIdx === 0
+        ? "Build steps — what's next?"
+        : "Add another step? (or pick Done)",
+      stepKindChoices,
     );
-    stepLines.push(`  - agent: true`);
-    stepLines.push(`    prompt: |`);
-    for (const line of prompt.split("\n")) {
-      stepLines.push(`      ${line}`);
+    if (kind === 3) break;
+
+    if (kind === 1) {
+      // Tool step
+      const nsIdx = await deps.pickFromList(
+        "Pick a connector",
+        namespaces.slice(),
+      );
+      const ns = namespaces[nsIdx - 1];
+      if (!ns) throw new Error("Invalid connector selection");
+      const tools = listTools(ns);
+      const labels = tools.map((t) => `${t.id} — ${t.description}`);
+      const toolIdx = await deps.pickFromList(`Pick a ${ns} tool`, labels);
+      const tool = tools[toolIdx - 1];
+      if (!tool) throw new Error(`Invalid tool selection for ${ns}`);
+      toolStepCount += 1;
+      const intoName =
+        toolStepCount === 1 ? `${ns}_result` : `${ns}_result_${toolStepCount}`;
+      intoNames.push(intoName);
+      stepLines.push(`  - tool: ${tool.id}`);
+      // Prompt for required params from the tool's JSON schema.
+      const params = await collectRequiredParams(deps, tool);
+      for (const [key, value] of params) {
+        stepLines.push(`    ${key}: ${yamlScalar(value)}`);
+      }
+      stepLines.push(`    into: ${intoName}`);
+    } else if (kind === 2) {
+      // Agent step
+      const prompt = await askWithValidation(deps, "Agent prompt", (a) =>
+        a.trim().length > 0 ? null : "cannot be empty.",
+      );
+      agentStepCount += 1;
+      const intoName =
+        agentStepCount === 1
+          ? "agent_output"
+          : `agent_output_${agentStepCount}`;
+      lastAgentInto = intoName;
+      stepLines.push(`  - agent: true`);
+      stepLines.push(`    prompt: |`);
+      for (const line of prompt.split("\n")) {
+        stepLines.push(`      ${line}`);
+      }
+      stepLines.push(`    into: ${intoName}`);
     }
-    stepLines.push(`    into: agent_output`);
   }
 
   // Always tail with file.write to inbox so the user sees output somewhere.
+  // Reference the most recent agent output when one exists, otherwise fall
+  // back to the most recent tool result (or a TODO comment if neither).
+  const tailRef = lastAgentInto ?? intoNames[intoNames.length - 1] ?? null;
   stepLines.push(`  - tool: file.write`);
   stepLines.push(`    path: "~/.patchwork/inbox/${name}-{{date}}.md"`);
   stepLines.push(`    content: |`);
-  if (wantsAgent) {
-    stepLines.push(`      # ${name} — {{date}}`);
-    stepLines.push(``);
-    stepLines.push(`      {{agent_output}}`);
+  stepLines.push(`      # ${name} — {{date}}`);
+  stepLines.push(``);
+  if (tailRef) {
+    stepLines.push(`      {{${tailRef}}}`);
   } else {
-    stepLines.push(`      # ${name} — {{date}}`);
-    stepLines.push(``);
-    stepLines.push(`      (no agent step configured — fill in)`);
+    stepLines.push(`      (no steps configured — fill in)`);
   }
 
   const content =


### PR DESCRIPTION
## Summary

Extends the interactive scaffolder (#427) from a single-step toy into something users can actually build real recipes with. Two pieces:

### 1. Step loop

Instead of "pick a connector → optional agent", the user now picks step kind at each iteration:
- **1.** Add a tool step
- **2.** Add an agent step
- **3.** Done — preview and write

Up to 20 steps allowed (safety cap; real recipes top out at ~10). Each tool step gets a unique `into:` name (first one keeps the `<ns>_result` shape, subsequent ones append `_2`, `_3`, …). Agent steps get `agent_output`, `agent_output_2`, …

The `file.write` tail references the most recent agent output when one exists, otherwise the most recent tool result, otherwise emits a TODO comment.

### 2. Required-params prompting

When a tool step is picked, the generator reads the tool's `paramsSchema.required` array and prompts for each required field — surfacing the schema's `description` as inline hint text. Skips `into` (the generator provides its own) and skips optional fields (user hand-edits if they want defaults).

This turns recipes generated by `recipe new -i` from "fill in the blanks" stubs into runnable starting points. e.g. picking `github.create_issue` now prompts for `repo` and `title`; the generated YAML lints clean and the recipe is one `--local` away from being usable.

## Tests — 6 cases, all green

- Manual + single agent step (unchanged contract)
- Cron + tool step, with deterministic walk-the-registry to find the first zero-required-params tool (test no longer breaks when a new connector ships with required fields)
- **NEW**: Multi-step — 2 tool steps + 1 agent step in one recipe. Asserts tool-line count (3 = 2 connectors + `file.write`) and agent block present.
- **NEW**: Required-params — walks the registry to find a tool with ≥1 required param, asserts each `key: value` pair lands in the generated YAML.
- Invalid name retry (unchanged)
- Decline-write cancellation (unchanged)

## Net diff

**2 files changed, +302 / −107.**

## Test plan

- [x] `npm run typecheck` passes
- [x] `npx vitest run src/commands/__tests__/recipe-new-interactive.test.ts` → 6 / 6 pass
- [x] Biome clean
- [ ] CI green
- [ ] Smoke: `patchwork recipe new --interactive --out /tmp` — pick `github` → `create_issue`, supply `owner/repo` + title, confirm recipe writes with both fields in YAML

🤖 Generated with [Claude Code](https://claude.com/claude-code)