### PR TITLE
feat(recipe): add template mode to 'recipe new --interactive'

### DIFF
--- a/src/commands/__tests__/recipe-new-interactive.test.ts
+++ b/src/commands/__tests__/recipe-new-interactive.test.ts
@@ -22,6 +22,8 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import "../../recipes/tools/index.js";
 import { type InteractivePromptDeps, runNewInteractive } from "../recipe.js";
 
+const MODE_GUIDED = 1;
+const MODE_TEMPLATE = 2;
 const KIND_TOOL = 1;
 const KIND_AGENT = 2;
 const KIND_DONE = 3;
@@ -74,6 +76,7 @@ describe("runNewInteractive", () => {
     const deps = makeStubDeps({
       ask: ["my-test-recipe", "Test description", "Summarize the input"],
       pickFromList: [
+        MODE_GUIDED, // mode: guided
         1, // trigger type: manual
         KIND_AGENT, // step 1: agent
         KIND_DONE, // step 2: done
@@ -140,6 +143,7 @@ describe("runNewInteractive", () => {
     const deps = makeStubDeps({
       ask: ["my-cron-recipe", "Daily cron test", "0 8 * * *"],
       pickFromList: [
+        MODE_GUIDED, // mode: guided
         2, // trigger type: cron
         KIND_TOOL, // step 1: tool
         chosenNsIdx, // pick connector
@@ -196,6 +200,7 @@ describe("runNewInteractive", () => {
     const deps = makeStubDeps({
       ask: ["multi-step", "Two tool steps + agent", "Summarize results"],
       pickFromList: [
+        MODE_GUIDED, // mode: guided
         1, // trigger: manual
         KIND_TOOL,
         picks[0]!.ns,
@@ -269,6 +274,7 @@ describe("runNewInteractive", () => {
     const deps = makeStubDeps({
       ask: ["needs-params", "Test required params", ...stubAnswers],
       pickFromList: [
+        MODE_GUIDED, // mode: guided
         1, // manual
         KIND_TOOL,
         chosenNsIdx,
@@ -296,6 +302,7 @@ describe("runNewInteractive", () => {
     const deps = makeStubDeps({
       ask: ["INVALID-Name", "valid-name", "desc", "prompt"],
       pickFromList: [
+        MODE_GUIDED, // mode: guided
         1, // manual
         KIND_AGENT, // agent step
         KIND_DONE,
@@ -311,6 +318,7 @@ describe("runNewInteractive", () => {
     const deps = makeStubDeps({
       ask: ["cancel-test", "desc"],
       pickFromList: [
+        MODE_GUIDED, // mode: guided
         1, // manual
         KIND_DONE, // no steps
       ],
@@ -322,5 +330,47 @@ describe("runNewInteractive", () => {
     await expect(
       runNewInteractive({ outputDir: tmpDir, deps }),
     ).rejects.toThrow(/Cancelled/);
+  });
+
+  it("template mode writes a starter recipe from the named template", async () => {
+    const deps = makeStubDeps({
+      ask: ["from-template", "Built from a template"],
+      pickFromList: [
+        MODE_TEMPLATE, // mode: template
+        1, // template index: first in listTemplates() — "minimal"
+      ],
+      confirm: [
+        true, // keep the recipe
+      ],
+    });
+
+    const result = await runNewInteractive({ outputDir: tmpDir, deps });
+    expect(existsSync(result.path)).toBe(true);
+    expect(result.path.endsWith("from-template.yaml")).toBe(true);
+
+    const content = readFileSync(result.path, "utf-8");
+    expect(content).toContain("name: from-template");
+    expect(content).toContain("description: Built from a template");
+    // "minimal" template writes a single file.write step.
+    expect(content).toContain("tool: file.write");
+  });
+
+  it("template mode declines write and cleans up the file", async () => {
+    const deps = makeStubDeps({
+      ask: ["template-cancel", "Will be discarded"],
+      pickFromList: [
+        MODE_TEMPLATE,
+        1, // first template
+      ],
+      confirm: [
+        false, // decline keep
+      ],
+    });
+
+    await expect(
+      runNewInteractive({ outputDir: tmpDir, deps }),
+    ).rejects.toThrow(/Cancelled/);
+    // Ensure the runNew-written file was cleaned up.
+    expect(existsSync(join(tmpDir, "template-cancel.yaml"))).toBe(false);
   });
 });

--- a/src/commands/recipe.ts
+++ b/src/commands/recipe.ts
@@ -279,6 +279,61 @@ export async function runNewInteractive(
 ): Promise<InteractiveNewResult> {
   const { deps } = options;
 
+  // Mode pick — Guided (full prompt tree) vs Template (existing
+  // runNew templates: minimal | daily | inbox). The AI-suggest mode
+  // is still deferred (per memory project_recipe_audit_2026_05_06_part2:
+  // AI YAML must skip the form normalizer; needs design work for the
+  // bridge-discovery + auth path).
+  const templates = listTemplates();
+  const modeChoices = [
+    "Guided — full prompt tree (recommended)",
+    `Template — pick from ${templates.length} starters (${templates.join(", ")})`,
+  ];
+  const modeIdx = await deps.pickFromList(
+    "How do you want to start?",
+    modeChoices,
+  );
+
+  // Template mode: re-use the existing runNew() flow with the picked template.
+  if (modeIdx === 2) {
+    const name = await askWithValidation(deps, "Recipe name", (a) =>
+      RECIPE_NAME_RE.test(a)
+        ? null
+        : 'must match /^[a-z0-9][a-z0-9_-]{1,63}$/ (e.g. "morning-brief").',
+    );
+    const description = await askWithValidation(
+      deps,
+      "One-line description",
+      (a) => (a.trim().length > 0 ? null : "cannot be empty."),
+    );
+    const templateIdx = await deps.pickFromList("Pick a template", templates);
+    const template = templates[templateIdx - 1];
+    if (!template) throw new Error("Invalid template selection");
+
+    const result = runNew({
+      name,
+      description,
+      template,
+      ...(options.outputDir ? { outputDir: options.outputDir } : {}),
+    });
+    if (deps.preview) deps.preview(result.content);
+    const shouldWrite = await deps.confirm("Keep this recipe?");
+    if (!shouldWrite) {
+      // runNew already wrote the file — clean up to honor "cancel."
+      try {
+        if (existsSync(result.path)) {
+          const { unlinkSync } = await import("node:fs");
+          unlinkSync(result.path);
+        }
+      } catch {
+        // best effort
+      }
+      throw new Error("Cancelled by user");
+    }
+    return { path: result.path, content: result.content, warnings: [] };
+  }
+
+  // Guided mode (default — modeIdx === 1).
   const name = await askWithValidation(deps, "Recipe name", (a) =>
     RECIPE_NAME_RE.test(a)
       ? null


### PR DESCRIPTION
## Summary

Closes the third planner-spec mode for the interactive scaffolder. The top-level prompt now offers:

1. **Guided** — full prompt tree (recommended)
2. **Template** — pick from `{minimal, daily, inbox}`

Template mode delegates to the existing `runNew()` flow with the picked template, surfaces a preview, and asks for a keep/discard confirmation. On decline, the just-written file is unlinked to honor the cancel semantics tests already expect from guided mode.

## Deferred

AI-suggest mode stays deferred — per memory `project_recipe_audit_2026_05_06_part2`, AI-generated YAML must skip the form normalizer, and bridge-discovery from the CLI is the same shape as the [#422](https://github.com/Oolab-labs/patchwork-os/issues/422) kill-switch redesign. Both should land together once that design is signed off.

## Tests — 8 total, 2 new

- Existing 6 tests prefixed with `MODE_GUIDED` selection (no semantic change — pure prompt-sequence addition)
- **NEW**: template mode writes a starter from the named template
- **NEW**: template mode decline cleans up the file (no orphan YAML)

## Net diff

**2 files, +105 / 0**

## Test plan

- [x] `npm run typecheck` passes
- [x] `npx vitest run src/commands/__tests__/recipe-new-interactive.test.ts` → 8 / 8 pass
- [x] Biome clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)