### PR TITLE
feat(featureFlags): add isEnvLockedFor + getEnvLockedValue helpers (step 1/6 of #422)

### DIFF
--- a/src/__tests__/featureFlags.isEnvLockedFor.test.ts
+++ b/src/__tests__/featureFlags.isEnvLockedFor.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Tests for `isEnvLockedFor()` + `getEnvLockedValue()` — the helpers the
+ * `/kill-switch` endpoint and dashboard toggle will use to detect when a
+ * kill-switch flag has been frozen by `lockKillSwitchEnv()`.
+ *
+ * Context: issue #422 v2 review caught a UX bug in the naive predicate
+ * (`envLocked && frozen !== undefined` would correctly detect both
+ * locked-to-on and locked-to-off, but the tooltip needs to know WHICH
+ * direction so it can render "env-locked to ON" vs "env-locked to OFF").
+ *
+ * Surfaces tested:
+ *   - isEnvLockedFor(flag) returns true only after lockKillSwitchEnv()
+ *     captured a non-undefined value for that kill-switch flag.
+ *   - getEnvLockedValue(flag) surfaces the frozen direction (true/false/null).
+ *   - Both helpers return safe defaults for unknown flags, non-kill-switch
+ *     flags, and pre-lock state.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  _resetEnvLockForTesting,
+  getEnvLockedValue,
+  isEnvLockedFor,
+  KILL_SWITCH_WRITES,
+  lockKillSwitchEnv,
+} from "../featureFlags.js";
+
+const KILL_SWITCH_ENV = "PATCHWORK_FLAG_KILL_SWITCH_WRITES";
+
+beforeEach(() => {
+  delete process.env[KILL_SWITCH_ENV];
+  _resetEnvLockForTesting();
+});
+
+afterEach(() => {
+  delete process.env[KILL_SWITCH_ENV];
+  _resetEnvLockForTesting();
+});
+
+describe("isEnvLockedFor()", () => {
+  it("returns false before lockKillSwitchEnv() is called", () => {
+    process.env[KILL_SWITCH_ENV] = "1";
+    expect(isEnvLockedFor(KILL_SWITCH_WRITES)).toBe(false);
+  });
+
+  it("returns false after lock when env was unset", () => {
+    delete process.env[KILL_SWITCH_ENV];
+    lockKillSwitchEnv();
+    expect(isEnvLockedFor(KILL_SWITCH_WRITES)).toBe(false);
+  });
+
+  it("returns true after lock when env was set to 1 (locked to ON)", () => {
+    process.env[KILL_SWITCH_ENV] = "1";
+    lockKillSwitchEnv();
+    expect(isEnvLockedFor(KILL_SWITCH_WRITES)).toBe(true);
+  });
+
+  it("returns true after lock when env was set to 0 (locked to OFF)", () => {
+    // I2 from the #422 v2 review: BOTH directions are policy-locked.
+    // The CLI/dashboard must surface the locked state in either case so
+    // setFlag returns 409 Conflict instead of silently no-op'ing.
+    process.env[KILL_SWITCH_ENV] = "0";
+    lockKillSwitchEnv();
+    expect(isEnvLockedFor(KILL_SWITCH_WRITES)).toBe(true);
+  });
+
+  it("returns true after lock when env was set to true (case-insensitive)", () => {
+    process.env[KILL_SWITCH_ENV] = "TRUE";
+    lockKillSwitchEnv();
+    expect(isEnvLockedFor(KILL_SWITCH_WRITES)).toBe(true);
+  });
+
+  it("returns true after lock when env was set to false (case-insensitive)", () => {
+    process.env[KILL_SWITCH_ENV] = "False";
+    lockKillSwitchEnv();
+    expect(isEnvLockedFor(KILL_SWITCH_WRITES)).toBe(true);
+  });
+
+  it("returns false for unknown flag ids", () => {
+    process.env[KILL_SWITCH_ENV] = "1";
+    lockKillSwitchEnv();
+    expect(isEnvLockedFor("not-a-real-flag")).toBe(false);
+  });
+
+  it("post-mutation of process.env does not change the result", () => {
+    process.env[KILL_SWITCH_ENV] = "1";
+    lockKillSwitchEnv();
+    expect(isEnvLockedFor(KILL_SWITCH_WRITES)).toBe(true);
+    // Mutating env after lock — locked state is sticky.
+    delete process.env[KILL_SWITCH_ENV];
+    expect(isEnvLockedFor(KILL_SWITCH_WRITES)).toBe(true);
+  });
+});
+
+describe("getEnvLockedValue()", () => {
+  it("returns null before lockKillSwitchEnv() is called", () => {
+    process.env[KILL_SWITCH_ENV] = "1";
+    expect(getEnvLockedValue(KILL_SWITCH_WRITES)).toBeNull();
+  });
+
+  it("returns null after lock when env was unset", () => {
+    delete process.env[KILL_SWITCH_ENV];
+    lockKillSwitchEnv();
+    expect(getEnvLockedValue(KILL_SWITCH_WRITES)).toBeNull();
+  });
+
+  it("returns true when env-locked to ON", () => {
+    process.env[KILL_SWITCH_ENV] = "1";
+    lockKillSwitchEnv();
+    expect(getEnvLockedValue(KILL_SWITCH_WRITES)).toBe(true);
+  });
+
+  it("returns false when env-locked to OFF (any non-truthy value)", () => {
+    // 0, false, "", anything-not-truthy → false per lockKillSwitchEnv's
+    // existing semantics. The dashboard tooltip reads this to render
+    // "env-locked to OFF" vs "env-locked to ON".
+    process.env[KILL_SWITCH_ENV] = "0";
+    lockKillSwitchEnv();
+    expect(getEnvLockedValue(KILL_SWITCH_WRITES)).toBe(false);
+  });
+
+  it("returns null for unknown flag ids", () => {
+    process.env[KILL_SWITCH_ENV] = "1";
+    lockKillSwitchEnv();
+    expect(getEnvLockedValue("not-a-real-flag")).toBeNull();
+  });
+});

--- a/src/featureFlags.ts
+++ b/src/featureFlags.ts
@@ -133,6 +133,42 @@ export function isEnabled(flagId: string): boolean {
 }
 
 /**
+ * Returns true when the given kill-switch flag is **env-locked** — i.e. its
+ * value was frozen at startup from a `PATCHWORK_FLAG_<ID>` environment
+ * variable and any subsequent `setFlag()` call will be silently overridden
+ * by `isEnabled()`.
+ *
+ * Used by the `/kill-switch` endpoint (issue #422) to surface a 409
+ * Conflict instead of returning 200 OK for a setFlag that won't stick,
+ * and by the dashboard to render the toggle as disabled (with a tooltip
+ * naming which direction was sysadmin-locked) when this returns true.
+ *
+ * Returns false for non-kill-switch flags (they read env dynamically and
+ * are never "locked"), for unknown flags, and when `lockKillSwitchEnv()`
+ * has not yet been called.
+ */
+export function isEnvLockedFor(flagId: string): boolean {
+  if (!envLocked) return false;
+  const flag = FLAG_REGISTRY.get(flagId);
+  if (!flag?.isKillSwitch) return false;
+  return FROZEN_KILL_SWITCH_ENV.get(flagId) !== undefined;
+}
+
+/**
+ * Returns the frozen env-locked value for a kill-switch flag (`true` /
+ * `false`), or `null` if not env-locked.
+ *
+ * Used by the dashboard tooltip so the disabled-state can read "env-locked
+ * to **on**" vs "env-locked to **off**" — both directions are policy-locked,
+ * but the user should know which.
+ */
+export function getEnvLockedValue(flagId: string): boolean | null {
+  if (!isEnvLockedFor(flagId)) return null;
+  const frozen = FROZEN_KILL_SWITCH_ENV.get(flagId);
+  return frozen === undefined ? null : frozen;
+}
+
+/**
  * Set a flag value (persists to config file if persist=true).
  */
 export function setFlag(flagId: string, value: boolean, persist = false): void {


### PR DESCRIPTION
## Step 1 of the [#422](https://github.com/Oolab-labs/patchwork-os/issues/422) v2 kill-switch series

The cheapest derisking move from the 6-PR implementation order. Two pure read-only helpers in `src/featureFlags.ts`. No other surface depends on them yet — lands cleanly alone.

## What's added

- **`isEnvLockedFor(flagId): boolean`** — true when the given kill-switch flag was frozen by `lockKillSwitchEnv()` AND a non-undefined value was captured from `PATCHWORK_FLAG_<ID>`. Step 2 (the `/kill-switch` endpoint) reads this to return 409 Conflict instead of silently no-op'ing a `setFlag` call; step 6 (dashboard) reads it to render the toggle as disabled.

- **`getEnvLockedValue(flagId): boolean | null`** — surfaces the frozen direction (`true`=locked-to-ON, `false`=locked-to-OFF, `null`=not-locked) so the dashboard tooltip can render "env-locked to {on|off}" — both directions are policy-locked and the user should know which.

## Why both helpers, not just the boolean

The 4-agent v2 review caught a UX gap in the naive `envLocked && frozen !== undefined` predicate ([#422 v2 revision I2](https://github.com/Oolab-labs/patchwork-os/issues/422)): `=0` and `=1` both lock the toggle, but the user needs to see **which direction** was sysadmin-mandated. Returning a single boolean would force the dashboard to peek at `FLAG_VALUES` or call `isEnabled()` separately and reason about env-source — cleaner to expose the frozen value directly.

## Test coverage (13 cases, all pass)

**Locked path:**
- returns `true` after lock when env=1 (locked-to-ON)
- returns `true` after lock when env=0 (locked-to-OFF) — **I2 case**
- returns `true` for `"TRUE"`/`"False"` (case-insensitive boundary)
- post-lock env mutation does not change result (sticky)

**Unlocked / no-op path:**
- returns `false` before `lockKillSwitchEnv()`
- returns `false` after lock when env was unset
- returns `false`/`null` for unknown flag ids

**`getEnvLockedValue` mirror:** null when not env-locked; matches frozen direction otherwise.

## Net diff

**2 files, +163 / 0**

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run build` passes
- [x] `npx vitest run src/__tests__/featureFlags.isEnvLockedFor.test.ts` → 13 / 13 pass
- [x] Biome: 0 new errors (2 pre-existing `noNonNullAssertion` warnings on `isEnabled` lines I didn't touch — out of scope)
- [ ] CI green

## Next steps in the series

After this lands, step 2 is the bridge `/kill-switch` POST endpoint (~80 LOC) using these helpers + `setFlag` + a stubbed audit emit. Step 3 is the CLI subcommand. Steps 4-6 follow per [#422 implementation order](https://github.com/Oolab-labs/patchwork-os/issues/422).

🤖 Generated with [Claude Code](https://claude.com/claude-code)