### PR TITLE
feat(bridge): wire decisionTraceLog into /kill-switch (step 5/6 of #422)

### DIFF
--- a/src/__tests__/server-kill-switch.test.ts
+++ b/src/__tests__/server-kill-switch.test.ts
@@ -273,3 +273,87 @@ describe("POST /kill-switch", () => {
     expect(status).toBe(413);
   });
 });
+
+describe("POST /kill-switch — audit emit (step 5)", () => {
+  it("calls recordKillSwitchTraceFn with engage event on state transition", async () => {
+    const events: Array<{
+      engaged: boolean;
+      reason: string | undefined;
+      ts: number;
+    }> = [];
+    server!.recordKillSwitchTraceFn = (e) => events.push(e);
+
+    const { status } = await request(
+      "POST",
+      JSON.stringify({ engage: true, reason: "runaway recipe loop" }),
+    );
+    expect(status).toBe(200);
+    expect(events).toHaveLength(1);
+    expect(events[0]?.engaged).toBe(true);
+    expect(events[0]?.reason).toBe("runaway recipe loop");
+    expect(typeof events[0]?.ts).toBe("number");
+  });
+
+  it("does NOT emit audit on no-op (already-engaged) transitions", async () => {
+    // Engage first so the second call is a no-op.
+    setFlag(KILL_SWITCH_WRITES, true, false);
+    const events: Array<unknown> = [];
+    server!.recordKillSwitchTraceFn = (e) => events.push(e);
+
+    const { status, body } = await request(
+      "POST",
+      JSON.stringify({ engage: true }),
+    );
+    expect(status).toBe(200);
+    expect(JSON.parse(body).changed).toBe(false);
+    // Audit log should remain empty — no real state change happened.
+    expect(events).toHaveLength(0);
+  });
+
+  it("emits release with reason undefined when no reason is supplied", async () => {
+    setFlag(KILL_SWITCH_WRITES, true, false);
+    const events: Array<{
+      engaged: boolean;
+      reason: string | undefined;
+    }> = [];
+    server!.recordKillSwitchTraceFn = (e) => events.push(e);
+
+    await request("POST", JSON.stringify({ engage: false }));
+    expect(events).toHaveLength(1);
+    expect(events[0]?.engaged).toBe(false);
+    expect(events[0]?.reason).toBeUndefined();
+  });
+
+  it("does NOT emit audit when env-locked (409 path)", async () => {
+    process.env[KILL_SWITCH_ENV] = "1";
+    lockKillSwitchEnv();
+    const events: Array<unknown> = [];
+    server!.recordKillSwitchTraceFn = (e) => events.push(e);
+
+    const { status } = await request("POST", JSON.stringify({ engage: false }));
+    expect(status).toBe(409);
+    expect(events).toHaveLength(0);
+  });
+
+  it("trims reason to 500 chars before emit", async () => {
+    const events: Array<{
+      reason: string | undefined;
+    }> = [];
+    server!.recordKillSwitchTraceFn = (e) => events.push(e);
+
+    // 600-char reason fits inside the 1 KB body cap but exceeds the
+    // 500-char trim. After trim, reason should be exactly 500.
+    const reason = "a".repeat(600);
+    await request("POST", JSON.stringify({ engage: true, reason }));
+    expect(events).toHaveLength(1);
+    expect(events[0]?.reason?.length).toBe(500);
+  });
+
+  it("does not throw when recordKillSwitchTraceFn is unset (logger-only path)", async () => {
+    server!.recordKillSwitchTraceFn = null;
+    const { status } = await request("POST", JSON.stringify({ engage: true }));
+    expect(status).toBe(200);
+    // No assertion on side effect — verifying the optional-callback
+    // pattern doesn't crash the handler.
+  });
+});

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -1355,6 +1355,34 @@ export class Bridge {
         extensionConnected: this.extensionClient.isConnected(),
       };
     };
+
+    // Wire kill-switch audit-trace emit to decisionTraceLog. State
+    // transitions become DecisionTrace entries with tags=["kill-switch",
+    // "engage"|"release", "actor:http"]; query via ctxQueryTraces. See
+    // step 5 of #422.
+    if (this.decisionTraceLog) {
+      const traceLog = this.decisionTraceLog;
+      const workspace = this.config.workspace;
+      this.server.recordKillSwitchTraceFn = (event): void => {
+        const direction = event.engaged ? "engage" : "release";
+        const isoTs = new Date(event.ts).toISOString();
+        try {
+          traceLog.record({
+            ref: "kill-switch.writes",
+            problem: event.reason ?? direction,
+            solution: `${event.engaged ? "ENGAGED" : "RELEASED"} at ${isoTs}`,
+            workspace,
+            tags: ["kill-switch", direction, "actor:http"],
+          });
+        } catch (err) {
+          this.logger.warn(
+            `[kill-switch] failed to record audit trace: ${
+              err instanceof Error ? err.message : String(err)
+            }`,
+          );
+        }
+      };
+    }
     this.server.statusFn = () => {
       let sessionsInGrace = 0;
       const sessionList: Record<string, unknown>[] = [];

--- a/src/server.ts
+++ b/src/server.ts
@@ -289,6 +289,32 @@ export class Server extends EventEmitter<ServerEvents> {
    * the user's preference.
    */
   public enableTimeOfDayAnomaly = false;
+  /**
+   * Patchwork: set by bridge to record a kill-switch audit trace.
+   * `/kill-switch` POST emits one entry on every state transition (no-op
+   * toggles do not emit). When unset, the handler logs via this.logger
+   * instead — see step 5 of issue #422.
+   *
+   * Trace encoding (v2-I6 from #422): we encode kill-switch events via
+   * the existing `DecisionTrace` schema rather than extending its
+   * `traceType` union, to keep schema migration off the kill-switch
+   * critical path. Fields used:
+   *   ref       = "kill-switch.writes"
+   *   problem   = "<short reason>" or "engage" / "release" if no reason
+   *   solution  = "ENGAGED at <ts>" or "RELEASED at <ts>"
+   *   tags      = ["kill-switch", "engage" | "release", "actor:http"]
+   *
+   * `ctxQueryTraces({tag: "kill-switch"})` returns the full audit
+   * history; pair with `tag: "engage"` / `tag: "release"` to filter
+   * direction.
+   */
+  public recordKillSwitchTraceFn:
+    | ((event: {
+        engaged: boolean;
+        reason: string | undefined;
+        ts: number;
+      }) => void)
+    | null = null;
   /** Patchwork: set by bridge to match + fire webhook-triggered recipes. */
   public webhookFn:
     | ((
@@ -1721,13 +1747,22 @@ export class Server extends EventEmitter<ServerEvents> {
           const changed = prev !== next;
           if (changed) {
             setFlag(KILL_SWITCH_WRITES, next, true);
-            // Audit-emit stub. Step 5 (decisionTraceLog plumbing into
-            // Server) replaces this console line with a real trace write.
+            // v2-I6: audit emit on every state transition; no-ops skip.
+            // When the bridge wires recordKillSwitchTraceFn (step 5),
+            // this writes to ~/.patchwork/decision_traces.jsonl. The
+            // logger.info line stays as a secondary signal in the
+            // bridge log; it's the only output when the trace fn is
+            // unset (tests, headless contexts).
             this.logger.info(
               `[kill-switch] ${next ? "ENGAGED" : "RELEASED"}${
                 reason ? ` (reason: ${reason})` : ""
               } — actor=http`,
             );
+            this.recordKillSwitchTraceFn?.({
+              engaged: next,
+              reason,
+              ts: Date.now(),
+            });
           }
           res.writeHead(200, { "Content-Type": "application/json" });
           res.end(


### PR DESCRIPTION
## Step 5 of the [#422](https://github.com/Oolab-labs/patchwork-os/issues/422) v2 kill-switch series

Plumbs the existing `DecisionTraceLog` into `Server` so the `/kill-switch` endpoint emits real audit traces to `~/.patchwork/decision_traces.jsonl` instead of the logger-only stub from step 2.

## Pattern

Adds a typed callback `recordKillSwitchTraceFn` on `Server` (mirrors existing `statusFn` / `webhookFn` / `metricsFn` injection points). Bridge wires it from `this.decisionTraceLog` after the `Server` is constructed.

```ts
// src/server.ts
public recordKillSwitchTraceFn:
  | ((event: { engaged, reason, ts }) => void)
  | null = null;

// src/bridge.ts (after server construction)
if (this.decisionTraceLog) {
  this.server.recordKillSwitchTraceFn = (event) => {
    this.decisionTraceLog!.record({
      ref: "kill-switch.writes",
      problem: event.reason ?? direction,
      solution: `${ENGAGED|RELEASED} at ${isoTs}`,
      workspace: this.config.workspace,
      tags: ["kill-switch", "engage"|"release", "actor:http"],
    });
  };
}
```

## v2-I6 — schema encoding

`DecisionTrace` has no `traceType` field. Per the v2 review's I6 recommendation, kill-switch events ride on the existing schema:

| Field | Value |
|---|---|
| `ref` | `"kill-switch.writes"` |
| `problem` | user-supplied reason, or `"engage"`/`"release"` sentinel |
| `solution` | `"ENGAGED at <iso8601>"` or `"RELEASED at <iso8601>"` |
| `workspace` | `bridge.config.workspace` |
| `tags` | `["kill-switch", "engage"\|"release", "actor:http"]` |

Query history with `ctxQueryTraces({tag: "kill-switch"})`; filter direction with `tag: "engage"` / `tag: "release"`. **No schema migration required** — the change is purely additive.

## Behavior on emit

- **Only state transitions emit** — no-op toggles skip the emit per v2-I12 idempotency, keeping the audit log meaningful
- **env-locked 409 path skips emit** (no state change happened)
- **Reason is trimmed to 500 chars** before storage (matches the endpoint's existing trim)
- **When `recordKillSwitchTraceFn` is null** (test contexts, headless bridges without DecisionTraceLog wired), the handler falls back to the `logger.info` line — no crash, no extra branching

## Test coverage — 6 new cases on top of step 2's 14

- engage state transition → audit emit with reason captured
- no-op toggle → no audit emit
- release emits with reason undefined when not supplied
- env-locked 409 → no audit emit (no transition happened)
- reason trimmed to 500 chars before emit
- `recordKillSwitchTraceFn` null → handler does not throw

## Net diff

**3 files, +149 / −2** (server.ts +39, bridge.ts +28, test +84)

## Test plan

- [x] `npm run typecheck` passes
- [x] `npx vitest run src/__tests__/server-kill-switch.test.ts` → 20 / 20 pass
- [x] Biome clean
- [ ] CI green
- [ ] Smoke: with bridge running, POST `/kill-switch {engage: true, reason: "test"}` then `ctxQueryTraces({tag: "kill-switch"})` returns the entry

## What's next

Step 6/6 (~160 LOC) — dashboard toggle in `/settings` page consuming `GET /kill-switch` + posting to `POST /kill-switch` + SSE event for fast updates. Last step in the series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)