### PR TITLE
feat(server): --webhook-secret + HMAC auth for /hooks/*

### DIFF
--- a/src/__tests__/server-webhook-hmac.test.ts
+++ b/src/__tests__/server-webhook-hmac.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Tests for HMAC-SHA256 webhook authentication at POST /hooks/*.
+ *
+ * When `webhookSecret` is configured, requests carrying the
+ * `X-Hub-Signature-256: sha256=<hex>` header are authenticated via HMAC
+ * over the raw request body, bypassing the bearer-token gate. Bearer
+ * access continues to work — HMAC is additive, not a replacement.
+ */
+import { createHmac } from "node:crypto";
+import http from "node:http";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { Logger } from "../logger.js";
+import { Server } from "../server.js";
+
+const logger = new Logger(false);
+const TOKEN = "test-hmac-bearer-token-000000000000";
+const SECRET =
+  "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"; // 64 hex chars
+
+let server: Server | null = null;
+let port = 0;
+let calls: Array<{ path: string; payload: unknown }>;
+
+async function startServer(opts: { secret: string | null }): Promise<void> {
+  calls = [];
+  server = new Server(TOKEN, logger);
+  server.webhookSecret = opts.secret;
+  server.webhookFn = async (path, payload) => {
+    calls.push({ path, payload });
+    return { ok: true, name: "stub-recipe", taskId: "task-1" };
+  };
+  port = await server.findAndListen(null);
+}
+
+afterEach(async () => {
+  await server?.close();
+  server = null;
+  port = 0;
+});
+
+function sign(body: string, secret: string): string {
+  return `sha256=${createHmac("sha256", secret).update(body).digest("hex")}`;
+}
+
+function postHooks(
+  body: string,
+  headers: Record<string, string>,
+): Promise<{ status: number; body: string }> {
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      {
+        hostname: "127.0.0.1",
+        port,
+        method: "POST",
+        path: "/hooks/test-recipe",
+        headers: {
+          "Content-Type": "application/json",
+          "Content-Length": String(Buffer.byteLength(body, "utf-8")),
+          ...headers,
+        },
+      },
+      (res) => {
+        let data = "";
+        res.on("data", (chunk) => (data += chunk));
+        res.on("end", () =>
+          resolve({ status: res.statusCode ?? 0, body: data }),
+        );
+      },
+    );
+    req.on("error", reject);
+    req.write(body);
+    req.end();
+  });
+}
+
+describe("POST /hooks/* — HMAC-SHA256 webhook auth", () => {
+  beforeEach(() => {
+    calls = [];
+  });
+
+  it("accepts a valid X-Hub-Signature-256 (no bearer needed)", async () => {
+    await startServer({ secret: SECRET });
+    const body = JSON.stringify({ action: "opened", number: 42 });
+    const { status } = await postHooks(body, {
+      "X-Hub-Signature-256": sign(body, SECRET),
+    });
+    expect(status).toBe(200);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].path).toBe("/test-recipe");
+    expect(calls[0].payload).toEqual({ action: "opened", number: 42 });
+  });
+
+  it("rejects an invalid signature with 401 invalid_signature", async () => {
+    await startServer({ secret: SECRET });
+    const body = JSON.stringify({ action: "opened" });
+    const bogus = sign(body, "0".repeat(64));
+    const { status, body: respBody } = await postHooks(body, {
+      "X-Hub-Signature-256": bogus,
+    });
+    expect(status).toBe(401);
+    expect(JSON.parse(respBody)).toEqual({ error: "invalid_signature" });
+    expect(calls).toHaveLength(0);
+  });
+
+  it("rejects a tampered signature (one char off) — constant-time compare", async () => {
+    await startServer({ secret: SECRET });
+    const body = JSON.stringify({ action: "opened" });
+    const good = sign(body, SECRET);
+    // Flip the final hex char to its neighbor — same length, off by one.
+    const last = good[good.length - 1];
+    const flipped = last === "0" ? "1" : "0";
+    const tampered = good.slice(0, -1) + flipped;
+    const { status } = await postHooks(body, {
+      "X-Hub-Signature-256": tampered,
+    });
+    expect(status).toBe(401);
+    expect(calls).toHaveLength(0);
+  });
+
+  it("returns 401 webhook_secret_not_configured when signature presented but no secret set", async () => {
+    await startServer({ secret: null });
+    const body = JSON.stringify({ action: "opened" });
+    // Use any valid-shaped signature — server has no secret to compare against
+    const sig = sign(body, SECRET);
+    // Need a bearer to pass the outer gate, otherwise we never reach the
+    // /hooks handler. (No secret means no HMAC bypass.)
+    const { status, body: respBody } = await postHooks(body, {
+      "X-Hub-Signature-256": sig,
+      Authorization: `Bearer ${TOKEN}`,
+    });
+    expect(status).toBe(401);
+    expect(JSON.parse(respBody)).toEqual({
+      error: "webhook_secret_not_configured",
+    });
+    expect(calls).toHaveLength(0);
+  });
+
+  it("falls back to Bearer auth when no signature header (backwards compat)", async () => {
+    await startServer({ secret: SECRET });
+    const body = JSON.stringify({ source: "internal-automation" });
+    const { status } = await postHooks(body, {
+      Authorization: `Bearer ${TOKEN}`,
+    });
+    expect(status).toBe(200);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].payload).toEqual({ source: "internal-automation" });
+  });
+
+  it("returns 401 when neither signature nor Bearer is provided", async () => {
+    await startServer({ secret: SECRET });
+    const body = JSON.stringify({ action: "opened" });
+    const { status } = await postHooks(body, {});
+    expect(status).toBe(401);
+    expect(calls).toHaveLength(0);
+  });
+
+  it("accepts empty body with a valid signature (GitHub ping edge case)", async () => {
+    await startServer({ secret: SECRET });
+    const body = "";
+    const { status } = await postHooks(body, {
+      "X-Hub-Signature-256": sign(body, SECRET),
+    });
+    expect(status).toBe(200);
+    expect(calls).toHaveLength(1);
+    // Empty body — payload is undefined (no JSON parse attempted on empty input)
+    expect(calls[0].payload).toBeUndefined();
+  });
+});

--- a/src/__tests__/server-webhook-hmac.test.ts
+++ b/src/__tests__/server-webhook-hmac.test.ts
@@ -86,8 +86,8 @@ describe("POST /hooks/* — HMAC-SHA256 webhook auth", () => {
     });
     expect(status).toBe(200);
     expect(calls).toHaveLength(1);
-    expect(calls[0].path).toBe("/test-recipe");
-    expect(calls[0].payload).toEqual({ action: "opened", number: 42 });
+    expect(calls[0]!.path).toBe("/test-recipe");
+    expect(calls[0]!.payload).toEqual({ action: "opened", number: 42 });
   });
 
   it("rejects an invalid signature with 401 invalid_signature", async () => {
@@ -143,7 +143,7 @@ describe("POST /hooks/* — HMAC-SHA256 webhook auth", () => {
     });
     expect(status).toBe(200);
     expect(calls).toHaveLength(1);
-    expect(calls[0].payload).toEqual({ source: "internal-automation" });
+    expect(calls[0]!.payload).toEqual({ source: "internal-automation" });
   });
 
   it("returns 401 when neither signature nor Bearer is provided", async () => {
@@ -163,6 +163,6 @@ describe("POST /hooks/* — HMAC-SHA256 webhook auth", () => {
     expect(status).toBe(200);
     expect(calls).toHaveLength(1);
     // Empty body — payload is undefined (no JSON parse attempted on empty input)
-    expect(calls[0].payload).toBeUndefined();
+    expect(calls[0]!.payload).toBeUndefined();
   });
 });

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -179,6 +179,7 @@ export class Bridge {
       config.trustedProxies,
     );
     this.server.bridgeConfigPath = config.configFilePath ?? undefined;
+    this.server.webhookSecret = config.webhookSecret ?? null;
     if (config.issuerUrl) {
       this.oauthServer = new OAuthServerImpl(this.authToken, config.issuerUrl, {
         configDir,

--- a/src/config.ts
+++ b/src/config.ts
@@ -60,6 +60,14 @@ export interface Config {
   db: boolean;
   allowPrivateHttp: boolean;
   fixedToken: string | null;
+  /**
+   * Shared secret for HMAC-SHA256 verification of GitHub-style webhooks
+   * at POST /hooks/*. When set, requests presenting a valid
+   * `X-Hub-Signature-256: sha256=<hex>` header are authenticated via HMAC
+   * instead of Bearer token. Bearer-token access to /hooks/* still works
+   * (additive, backwards-compatible). null when feature disabled.
+   */
+  webhookSecret: string | null;
   issuerUrl: string | null;
   /** Access token TTL in milliseconds (derived from oauthTokenTtlDays config; default 24h). */
   oauthTokenTtlMs: number;
@@ -226,6 +234,7 @@ interface ConfigFile {
   plugins?: string[];
   pluginWatch?: boolean;
   fixedToken?: string;
+  webhookSecret?: string;
   issuerUrl?: string;
   oauthTokenTtlDays?: number;
   corsOrigins?: string[];
@@ -258,6 +267,7 @@ const KNOWN_CONFIG_FILE_KEYS = new Set<string>([
   "plugins",
   "pluginWatch",
   "fixedToken",
+  "webhookSecret",
   "issuerUrl",
   "oauthTokenTtlDays",
   "corsOrigins",
@@ -438,6 +448,16 @@ export function parseConfig(argv: string[]): Config {
   let allowPrivateHttp = false;
   let pluginWatch = fileConfig.pluginWatch ?? false;
   let fixedToken: string | null = fileConfig.fixedToken ?? null;
+  let webhookSecret: string | null = fileConfig.webhookSecret ?? null;
+  // Validate config-file value early so a malformed value fails loud rather
+  // than silently disabling webhook auth.
+  if (webhookSecret !== null) {
+    if (!/^[0-9a-fA-F]+$/.test(webhookSecret) || webhookSecret.length < 32) {
+      throw new Error(
+        "webhookSecret in config file must be a hex string of length >= 32 (16 bytes)",
+      );
+    }
+  }
   let issuerUrl: string | null = fileConfig.issuerUrl ?? null;
   const rawTtlDays = fileConfig.oauthTokenTtlDays;
   const oauthTokenTtlMs =
@@ -721,6 +741,16 @@ export function parseConfig(argv: string[]): Config {
         fixedToken = tok;
         break;
       }
+      case "--webhook-secret": {
+        const sec = requireArg(args, ++i, "--webhook-secret");
+        if (!/^[0-9a-fA-F]+$/.test(sec) || sec.length < 32) {
+          throw new Error(
+            "--webhook-secret must be a hex string of length >= 32 (16 bytes); generate with `openssl rand -hex 32`",
+          );
+        }
+        webhookSecret = sec;
+        break;
+      }
       case "--issuer-url": {
         issuerUrl = requireArg(args, ++i, "--issuer-url");
         if (!/^https?:\/\/.+/.test(issuerUrl))
@@ -872,6 +902,9 @@ Options:
 Patchwork:
   --approval-gate <level>   Delegation policy: gate tool calls via oversight dashboard: "off" | "high" | "all" (default: "off")
   --managed-settings <path> Admin-controlled settings file (highest rule precedence, cannot be overridden by users)
+  --webhook-secret <hex>    Shared secret (hex, >=32 chars) for HMAC-SHA256 verification of POST /hooks/*
+                            via the X-Hub-Signature-256 header (GitHub-style webhooks). Bearer-token
+                            access to /hooks/* still works. Env: BRIDGE_WEBHOOK_SECRET
 
 Automation:
   --driver <mode>           AI driver: "subprocess" | "api" | "openai" | "grok" | "gemini" | "gemini-api" | "local" | "none" (default: "none")
@@ -956,6 +989,16 @@ Environment Variables:
     } else {
       console.warn(
         "Warning: CLAUDE_IDE_BRIDGE_TOKEN is not a valid UUID — ignored.",
+      );
+    }
+  }
+  if (process.env.BRIDGE_WEBHOOK_SECRET) {
+    const envSec = process.env.BRIDGE_WEBHOOK_SECRET;
+    if (/^[0-9a-fA-F]+$/.test(envSec) && envSec.length >= 32) {
+      webhookSecret = envSec;
+    } else {
+      console.warn(
+        "Warning: BRIDGE_WEBHOOK_SECRET must be a hex string of length >= 32 — ignored.",
       );
     }
   }
@@ -1062,6 +1105,7 @@ Environment Variables:
     plugins,
     pluginWatch,
     fixedToken,
+    webhookSecret,
     issuerUrl,
     oauthTokenTtlMs,
     corsOrigins,

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,3 +1,4 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
 import { EventEmitter } from "node:events";
 import http from "node:http";
 import { WebSocket, WebSocketServer as WsServer } from "ws";
@@ -249,6 +250,13 @@ export class Server extends EventEmitter<ServerEvents> {
   public managedSettingsPath: string | undefined = undefined;
   /** Effective bridge config path to update when dashboard saves driver changes. */
   public bridgeConfigPath: string | undefined = undefined;
+  /**
+   * Shared secret for HMAC-SHA256 verification of POST /hooks/* requests
+   * carrying `X-Hub-Signature-256`. When null (default), HMAC auth is
+   * disabled and /hooks/* requires the bridge bearer token like every
+   * other route. Set by Bridge constructor from `config.webhookSecret`.
+   */
+  public webhookSecret: string | null = null;
   /** Patchwork: live approval gate level — mutated by POST /settings, read by bridge per-session setup. */
   public approvalGate: "off" | "high" | "all" = "off";
   /** Patchwork: outbound webhook URL for approval notifications (from dashboard.webhookUrl in config). */
@@ -692,6 +700,15 @@ export class Server extends EventEmitter<ServerEvents> {
         req.method === "POST" &&
         /^\/(approve|reject)\/[A-Za-z0-9-]+$/.test(parsedUrl.pathname) &&
         !!req.headers["x-approval-token"];
+      // GitHub-style webhook bypass: when --webhook-secret is configured,
+      // POST /hooks/* requests carrying X-Hub-Signature-256 bypass the
+      // bearer-token gate. Signature itself is verified inside the
+      // /hooks/* handler after the body has been read.
+      const isHmacWebhookCandidate =
+        req.method === "POST" &&
+        parsedUrl.pathname.startsWith("/hooks/") &&
+        !!req.headers["x-hub-signature-256"] &&
+        this.webhookSecret !== null;
       // Rate-limit the phone bypass surface. Only applies when this is
       // actually a phone-path request that's relying on the bypass — a
       // properly-authenticated bearer caller is unaffected. Counted +
@@ -742,7 +759,12 @@ export class Server extends EventEmitter<ServerEvents> {
         }
       }
       // oauthResolved is the bridge token if the OAuth token is valid; null otherwise
-      if (!isStaticToken && !oauthResolved && !isPhoneApprovalPath) {
+      if (
+        !isStaticToken &&
+        !oauthResolved &&
+        !isPhoneApprovalPath &&
+        !isHmacWebhookCandidate
+      ) {
         // RFC 6750: only include error= when a token was actually presented but invalid
         const tokenPresented = bearer.length > 0;
         const wwwAuth =
@@ -1074,6 +1096,36 @@ export class Server extends EventEmitter<ServerEvents> {
         if (!read.ok) {
           respond413(res, HOOKS_BODY_CAP);
           return;
+        }
+        // HMAC-SHA256 verification for GitHub-style webhooks. The signature
+        // must be computed over the raw request bytes — readBodyWithCap
+        // utf-8-decodes the body, so we re-encode here. The byte sequence
+        // round-trips identically for any valid utf-8 input (which JSON is).
+        const sigHeader = req.headers["x-hub-signature-256"];
+        if (typeof sigHeader === "string" && sigHeader.length > 0) {
+          if (!this.webhookSecret) {
+            res.writeHead(401, { "Content-Type": "application/json" });
+            res.end(JSON.stringify({ error: "webhook_secret_not_configured" }));
+            return;
+          }
+          const rawBody = Buffer.from(read.body, "utf-8");
+          const expected =
+            "sha256=" +
+            createHmac("sha256", this.webhookSecret)
+              .update(rawBody)
+              .digest("hex");
+          const expectedBuf = Buffer.from(expected, "utf-8");
+          const providedBuf = Buffer.from(sigHeader, "utf-8");
+          // timingSafeEqual throws on length mismatch — length-check first
+          // so the constant-time path is only taken on equal-length inputs.
+          const sigOk =
+            expectedBuf.length === providedBuf.length &&
+            timingSafeEqual(expectedBuf, providedBuf);
+          if (!sigOk) {
+            res.writeHead(401, { "Content-Type": "application/json" });
+            res.end(JSON.stringify({ error: "invalid_signature" }));
+            return;
+          }
         }
         let payload: unknown;
         if (read.body.trim()) {


### PR DESCRIPTION
## Summary

Enables GitHub-style webhooks at `POST /hooks/*` to authenticate via HMAC-SHA256 (`X-Hub-Signature-256`) instead of requiring a Bearer token. Backwards compatible: Bearer access still works; HMAC is additive, only active when `--webhook-secret <hex>` (or `BRIDGE_WEBHOOK_SECRET` env) is set.

Live on `bridge.massappealdesigns.co.ke` for ~6 hours powering the ci-red-fixer recipe; this PR brings the implementation back upstream before the next `git pull` on the VPS clobbers the rsync-d code.

## Implementation

- `src/config.ts` — CLI flag `--webhook-secret <hex>`, `BRIDGE_WEBHOOK_SECRET` env, file-config key (≥32 hex chars).
- `src/server.ts` — `isHmacWebhookCandidate` bypass alongside existing `isPhoneApprovalPath` bypass; inside the handler, signature recomputed over raw body, `timingSafeEqual` compare.
- `src/bridge.ts` — pass `webhookSecret` to `Server` via existing setter pattern (matches `bridgeConfigPath`).
- `src/__tests__/server-webhook-hmac.test.ts` — 7 new tests: valid / invalid / missing / no-secret-configured / tampered / empty-body / bearer-backwards-compat.

Documentation entry already on main at `CLAUDE.md` Security Model section.

## Test plan

- [x] \`npm test -- src/__tests__/server-webhook-hmac.test.ts\` — 7/7 pass locally
- [x] \`npm run build\` — clean
- [x] End-to-end smoke: GitHub webhook → bridge → recipe → ntfy push (verified 6h in production on Oolab-labs/patchwork-os)
- [ ] Existing server tests in CI still pass (was 121/121 during dev)

🤖 Generated with [Claude Code](https://claude.com/claude-code)