### PR TITLE
feat(recipes): haltReason in chainedRunner + run_level halt category

### DIFF
--- a/dashboard/src/app/runs/page.tsx
+++ b/dashboard/src/app/runs/page.tsx
@@ -96,6 +96,7 @@ type HaltCategory =
   | "agent_threw"
   | "tool_threw"
   | "tool_error"
+  | "run_level"
   | "unknown";
 
 interface HaltSummary {
@@ -110,6 +111,7 @@ const HALT_CATEGORY_LABEL: Record<HaltCategory, string> = {
   agent_threw: "agent threw",
   tool_threw: "tool threw",
   tool_error: "tool error",
+  run_level: "run-level halt",
   unknown: "uncategorised",
 };
 
@@ -281,6 +283,11 @@ export default function RunsPage() {
                   fontSize: "var(--fs-2xs)",
                   background: cat === "unknown" ? "var(--bg-1)" : undefined,
                   color: cat === "unknown" ? "var(--fg-2)" : "var(--err)",
+                  // light-mode visibility: var(--bg-1) on a pill can blend
+                  // into the panel, so add a subtle border on the muted variant.
+                  ...(cat === "unknown" && {
+                    border: "1px solid var(--border-subtle)",
+                  }),
                 }}
               >
                 {HALT_CATEGORY_LABEL[cat]} · {count}

--- a/src/recipes/__tests__/chainedRunner.runLog.test.ts
+++ b/src/recipes/__tests__/chainedRunner.runLog.test.ts
@@ -481,4 +481,29 @@ describe("runChainedRecipe — ActivityLog step event broadcast", () => {
       expect(e.metadata.recipeName).toBe("outer");
     }
   });
+
+  it("derives haltReason on failing chained steps so they categorise", async () => {
+    const { RecipeRunLog } = await import("../../runLog.js");
+    const { summariseHalts } = await import("../haltCategory.js");
+    const log = new RecipeRunLog({ dir: tmpDir });
+    const failingDeps: ExecutionDeps = {
+      executeTool: vi.fn().mockRejectedValue(new Error("remote unreachable")),
+      executeAgent: vi.fn(),
+      loadNestedRecipe: vi.fn().mockResolvedValue(null),
+    };
+    await runChainedRecipe(
+      chainedRecipe(),
+      optsWithLog({ runLog: log, runLogDir: undefined }),
+      failingDeps,
+    );
+    const run = log.query()[0];
+    const step = run?.stepResults?.[0];
+    expect(step?.status).toBe("error");
+    expect(step?.haltReason).toBeDefined();
+    expect(step?.haltReason).toContain("remote unreachable");
+    // And the run feeds summariseHalts as a non-`unknown` category.
+    const summary = summariseHalts(log.query());
+    expect(summary.total).toBeGreaterThan(0);
+    expect(summary.byCategory.unknown ?? 0).toBe(0);
+  });
 });

--- a/src/recipes/__tests__/haltCategory.test.ts
+++ b/src/recipes/__tests__/haltCategory.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { categoriseHaltReason, summariseHalts } from "../haltCategory.js";
+import {
+  categoriseHaltReason,
+  deriveHaltReasonFromError,
+  summariseHalts,
+} from "../haltCategory.js";
 
 describe("categoriseHaltReason", () => {
   it("maps each of the 5 yamlRunner phrases to its own category", () => {
@@ -96,5 +100,91 @@ describe("summariseHalts", () => {
     expect(summary.total).toBe(0);
     expect(summary.byCategory).toEqual({});
     expect(summary.recent).toEqual([]);
+  });
+
+  it("counts run-level errorMessage as run_level when no per-step halts cover it", () => {
+    const runs = [
+      {
+        seq: 4,
+        status: "error" as const,
+        errorMessage: "Recipe has circular dependencies",
+        stepResults: [],
+      },
+      {
+        seq: 3,
+        status: "error" as const,
+        errorMessage: "this should NOT be counted (step halt already covers)",
+        stepResults: [
+          {
+            status: "error" as const,
+            haltReason: 'Tool "a" in step "s" threw: x',
+          },
+        ],
+      },
+    ];
+    const summary = summariseHalts(runs);
+    expect(summary.total).toBe(2);
+    expect(summary.byCategory).toEqual({
+      tool_threw: 1,
+      run_level: 1,
+    });
+    expect(summary.recent.find((r) => r.category === "run_level")?.runSeq).toBe(
+      4,
+    );
+  });
+});
+
+describe("deriveHaltReasonFromError", () => {
+  it("returns undefined for non-error or missing error", () => {
+    expect(
+      deriveHaltReasonFromError({ stepId: "s", status: "ok" }),
+    ).toBeUndefined();
+    expect(
+      deriveHaltReasonFromError({ stepId: "s", status: "error" }),
+    ).toBeUndefined();
+  });
+
+  it("derives silent-fail / narration / agent-threw / tool-error in that order", () => {
+    expect(
+      deriveHaltReasonFromError({
+        stepId: "s",
+        status: "error",
+        error: "silent-fail detected: (...)",
+      }),
+    ).toMatch(/silent-fail/);
+    expect(
+      deriveHaltReasonFromError({
+        stepId: "s",
+        status: "error",
+        error: "only narration here",
+      }),
+    ).toMatch(/narration/);
+    expect(
+      deriveHaltReasonFromError({
+        stepId: "s",
+        isAgent: true,
+        status: "error",
+        error: "kaboom",
+      }),
+    ).toMatch(/Agent step .* threw/);
+    expect(
+      deriveHaltReasonFromError({
+        stepId: "s",
+        toolName: "git.x",
+        status: "error",
+        error: "remote unreachable",
+      }),
+    ).toMatch(/Tool "git\.x" .* reported an error/);
+  });
+
+  it("output round-trips through categoriseHaltReason to the expected category", () => {
+    const r = deriveHaltReasonFromError({
+      stepId: "s",
+      isAgent: true,
+      status: "error",
+      error: "kaboom",
+    });
+    expect(r).toBeDefined();
+    expect(categoriseHaltReason(r)).toBe("agent_threw");
   });
 });

--- a/src/recipes/chainedRunner.ts
+++ b/src/recipes/chainedRunner.ts
@@ -12,6 +12,7 @@ import {
   buildDependencyGraph,
   executeWithDependencies,
 } from "./dependencyGraph.js";
+import { deriveHaltReasonFromError } from "./haltCategory.js";
 import type {
   NestedRecipeConfig,
   NestedRecipeContext,
@@ -944,6 +945,8 @@ export async function runChainedRecipe(
         tool?: string;
         status: "ok" | "skipped" | "error";
         error?: string;
+        /** One-sentence human-actionable halt reason — see StepResult in yamlRunner.ts. */
+        haltReason?: string;
         durationMs: number;
         // VD-2 capture (only attached when present in `capturedStepData`).
         resolvedParams?: unknown;
@@ -954,11 +957,24 @@ export async function runChainedRecipe(
       for (const [id, r] of enrichedResults) {
         const step = stepMap.get(id);
         const captured = capturedStepData.get(id);
+        const status = r.skipped ? "skipped" : r.success ? "ok" : "error";
+        const errorMsg = r.error?.message;
+        // Mirror the haltReason convention from yamlRunner.ts so chained
+        // runs surface on the same dashboard pills + morning summary as
+        // top-level runs.
+        const haltReason = deriveHaltReasonFromError({
+          stepId: id,
+          toolName: step?.tool,
+          isAgent: !!step?.agent,
+          status,
+          error: errorMsg,
+        });
         stepResultsList.push({
           id,
           tool: step?.tool,
-          status: r.skipped ? "skipped" : r.success ? "ok" : "error",
-          error: r.error?.message,
+          status,
+          error: errorMsg,
+          ...(haltReason !== undefined && { haltReason }),
           durationMs: r.durationMs ?? 0,
           ...(captured?.resolvedParams !== undefined && {
             resolvedParams: captured.resolvedParams,

--- a/src/recipes/haltCategory.ts
+++ b/src/recipes/haltCategory.ts
@@ -18,6 +18,8 @@ export type HaltCategory =
   | "agent_threw"
   | "tool_threw"
   | "tool_error"
+  /** Whole-recipe failure (e.g. circular dependencies) — has no step row. */
+  | "run_level"
   | "unknown";
 
 export function categoriseHaltReason(reason: string | undefined): HaltCategory {
@@ -45,6 +47,10 @@ export interface HaltSummary {
 
 interface HaltSummaryInputRun {
   seq: number;
+  /** Top-level run status — `run_level` halts are runs with status === "error" but no error stepResults (e.g. circular-dep failure before any step ran). */
+  status?: "running" | "done" | "error" | "cancelled" | "interrupted";
+  /** Top-level errorMessage — surfaced as a `run_level` halt when no per-step halts cover it. */
+  errorMessage?: string;
   stepResults?: Array<{
     status: "ok" | "skipped" | "error";
     haltReason?: string;
@@ -54,14 +60,21 @@ interface HaltSummaryInputRun {
 /**
  * Aggregate halt categories across a set of runs. Runs are expected to be
  * sorted newest-first so `recent` reflects the most recent halts.
+ *
+ * A run contributes:
+ * - one entry per error-status stepResult that has a `haltReason`
+ * - plus one `run_level` entry if `status === "error"` and there were no
+ *   per-step halts that already explained it (avoids double-counting).
  */
 export function summariseHalts(runs: HaltSummaryInputRun[]): HaltSummary {
   const byCategory: Partial<Record<HaltCategory, number>> = {};
   const recent: HaltSummary["recent"] = [];
   let total = 0;
   for (const run of runs) {
+    let stepHaltsForRun = 0;
     for (const step of run.stepResults ?? []) {
       if (step.status !== "error" || !step.haltReason) continue;
+      stepHaltsForRun++;
       total++;
       const cat = categoriseHaltReason(step.haltReason);
       byCategory[cat] = (byCategory[cat] ?? 0) + 1;
@@ -73,6 +86,45 @@ export function summariseHalts(runs: HaltSummaryInputRun[]): HaltSummary {
         });
       }
     }
+    if (stepHaltsForRun === 0 && run.status === "error" && run.errorMessage) {
+      total++;
+      byCategory.run_level = (byCategory.run_level ?? 0) + 1;
+      if (recent.length < 5) {
+        recent.push({
+          reason: run.errorMessage,
+          category: "run_level",
+          runSeq: run.seq,
+        });
+      }
+    }
   }
   return { total, byCategory, recent };
+}
+
+/**
+ * Derive a one-sentence haltReason from a step's error-status + raw error
+ * string. Used by `chainedRunner` to mirror the convention emitted by
+ * `yamlRunner`. Returns `undefined` for non-error rows or missing error.
+ *
+ * Pattern-matches the same phrases `categoriseHaltReason` knows about,
+ * so chained-run haltReasons categorise into the same buckets.
+ */
+export function deriveHaltReasonFromError(opts: {
+  stepId: string;
+  toolName?: string;
+  isAgent?: boolean;
+  status: "ok" | "skipped" | "error";
+  error?: string;
+}): string | undefined {
+  if (opts.status !== "error" || !opts.error) return undefined;
+  if (/silent-fail/i.test(opts.error)) {
+    return `Step "${opts.stepId}" returned no usable output (silent-fail).`;
+  }
+  if (/narration|whitespace|no content/i.test(opts.error)) {
+    return `Step "${opts.stepId}" returned only narration or whitespace — no content.`;
+  }
+  if (opts.isAgent) {
+    return `Agent step "${opts.stepId}" threw before completing: ${opts.error}`;
+  }
+  return `Tool "${opts.toolName ?? "?"}" in step "${opts.stepId}" reported an error: ${opts.error}`;
 }


### PR DESCRIPTION
## Summary

Three follow-ups to #441 / #442, all surfacing real gaps that only become visible once you look at the dashboard pill row end-to-end.

> **Stacked PR** — targets [feat/halt-summary-and-window](https://github.com/Oolab-labs/patchwork-os/pull/442). After #441 → #442 merge sequence, retarget this to \`main\`.

## What changed

### 1. chainedRunner now emits \`haltReason\` on failing steps
The chainedRunner builds its own \`stepResultsList\` (\`chainedRunner.ts:942-973\`) — independent of yamlRunner — and silently dropped \`haltReason\` because the inline type didn't include the field. **Most modern recipes run through chainedRunner**, so the halt-summary pills shipped in #442 were undercounting.

Extracted the convention into a shared \`deriveHaltReasonFromError\` helper in \`haltCategory.ts\` so the two runners can't drift. Categorises the same way as yamlRunner phrases (silent-fail / narration / agent-threw / tool-error).

### 2. \`run_level\` halt category for whole-recipe failures
A recipe that fails its circular-dependency check produces a top-level \`errorMessage\` but no error \`stepResults\` — so #442's \`summariseHalts\` reported 0 even though the run halted. New \`run_level\` category counted when \`status === "error"\` AND no per-step halt already explained the failure (avoids double-counting).

\`HaltSummaryInputRun\` gained optional \`status\` and \`errorMessage\` fields; \`RecipeRun\` is structurally compatible so the recipeOrchestration binding picks it up automatically without further changes.

### 3. Dashboard polish
- New \`run-level halt\` label in the pill row.
- \`uncategorised\` pill gets a subtle border so it's reliably visible in light mode (reviewer nit from #442).

## Tests

5 new tests:
- 3 for \`deriveHaltReasonFromError\` (each category + round-trip through \`categoriseHaltReason\`)
- 1 for run-level summarisation (incl. double-count avoidance)
- 1 chainedRunner integration test asserting a failing step both gets a haltReason AND categorises (\`byCategory.unknown === 0\`)

## Test plan

- [x] \`npx vitest run src/recipes/__tests__/haltCategory.test.ts src/recipes/__tests__/chainedRunner.runLog.test.ts\` — 23 tests pass
- [x] bridge + dashboard typecheck clean
- [x] biome clean (autofix applied)

🤖 Generated with [Claude Code](https://claude.com/claude-code)