### PR TITLE
feat(recipes): idempotency keys for write tools — in-run dedup

### DIFF
--- a/src/recipes/__tests__/idempotencyKey.test.ts
+++ b/src/recipes/__tests__/idempotencyKey.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+import { deriveIdempotencyKey, WriteEffectLedger } from "../idempotencyKey.js";
+
+describe("deriveIdempotencyKey", () => {
+  it("produces the same key for identical (toolId, params)", () => {
+    const a = deriveIdempotencyKey("slack.postMessage", {
+      channel: "#general",
+      text: "hello",
+    });
+    const b = deriveIdempotencyKey("slack.postMessage", {
+      channel: "#general",
+      text: "hello",
+    });
+    expect(a).toBe(b);
+  });
+
+  it("produces the same key regardless of param key order", () => {
+    const a = deriveIdempotencyKey("slack.postMessage", {
+      channel: "#a",
+      text: "hi",
+      threadTs: "1.0",
+    });
+    const b = deriveIdempotencyKey("slack.postMessage", {
+      threadTs: "1.0",
+      text: "hi",
+      channel: "#a",
+    });
+    expect(a).toBe(b);
+  });
+
+  it("differs when toolId differs", () => {
+    const params = { channel: "#general", text: "hello" };
+    expect(deriveIdempotencyKey("slack.postMessage", params)).not.toBe(
+      deriveIdempotencyKey("slack.updateMessage", params),
+    );
+  });
+
+  it("differs when any param value differs", () => {
+    const a = deriveIdempotencyKey("slack.postMessage", {
+      channel: "#general",
+      text: "hello",
+    });
+    const b = deriveIdempotencyKey("slack.postMessage", {
+      channel: "#general",
+      text: "hello!",
+    });
+    expect(a).not.toBe(b);
+  });
+
+  it("canonicalises nested object key order", () => {
+    const a = deriveIdempotencyKey("http.request", {
+      headers: { Authorization: "Bearer x", "X-Idem": "1" },
+      url: "https://api.example.com",
+    });
+    const b = deriveIdempotencyKey("http.request", {
+      url: "https://api.example.com",
+      headers: { "X-Idem": "1", Authorization: "Bearer x" },
+    });
+    expect(a).toBe(b);
+  });
+
+  it("preserves array element order (arrays are ordered by definition)", () => {
+    const a = deriveIdempotencyKey("github.requestReviewers", {
+      pr: 42,
+      reviewers: ["alice", "bob"],
+    });
+    const b = deriveIdempotencyKey("github.requestReviewers", {
+      pr: 42,
+      reviewers: ["bob", "alice"],
+    });
+    expect(a).not.toBe(b);
+  });
+
+  it("returns 16 hex chars", () => {
+    const key = deriveIdempotencyKey("x", {});
+    expect(key).toMatch(/^[0-9a-f]{16}$/);
+  });
+});
+
+describe("WriteEffectLedger", () => {
+  it("records and retrieves outputs by key", () => {
+    const ledger = new WriteEffectLedger();
+    expect(ledger.has("k1")).toBe(false);
+    ledger.record("k1", "result-1");
+    expect(ledger.has("k1")).toBe(true);
+    expect(ledger.get("k1")).toBe("result-1");
+  });
+
+  it("distinguishes 'not present' from 'cached null' via has()", () => {
+    const ledger = new WriteEffectLedger();
+    ledger.record("k", null);
+    expect(ledger.has("k")).toBe(true);
+    expect(ledger.get("k")).toBe(null);
+    expect(ledger.has("missing")).toBe(false);
+    expect(ledger.get("missing")).toBeUndefined();
+  });
+
+  it("tracks size + key set for inspection", () => {
+    const ledger = new WriteEffectLedger();
+    ledger.record("a", "1");
+    ledger.record("b", "2");
+    expect(ledger.size()).toBe(2);
+    expect(ledger.keys().sort()).toEqual(["a", "b"]);
+  });
+});

--- a/src/recipes/__tests__/toolRegistry.idempotency.test.ts
+++ b/src/recipes/__tests__/toolRegistry.idempotency.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Integration test for PR5a — idempotency dedup at the `executeTool`
+ * dispatch boundary.
+ *
+ * Verifies that a write tool invoked twice in the same run with the same
+ * params executes exactly once and returns the cached output on the
+ * second call. Read tools and tools without a ledger are unaffected.
+ */
+
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  type MockInstance,
+  vi,
+} from "vitest";
+import { WriteEffectLedger } from "../idempotencyKey.js";
+import {
+  clearRegistry,
+  executeTool,
+  type RegisteredTool,
+  registerTool,
+} from "../toolRegistry.js";
+import type { RunContext, StepDeps } from "../yamlRunner.js";
+
+type Exec = RegisteredTool["execute"];
+
+function makeDeps(ledger?: WriteEffectLedger): StepDeps {
+  return { writeEffectLedger: ledger } as unknown as StepDeps;
+}
+
+describe("executeTool — idempotency dedup (PR5a)", () => {
+  let writeExec: MockInstance;
+  let readExec: MockInstance;
+
+  beforeEach(() => {
+    clearRegistry();
+    writeExec = vi.fn().mockResolvedValue("wrote");
+    readExec = vi.fn().mockResolvedValue("read");
+    registerTool({
+      id: "test.write",
+      namespace: "test",
+      description: "test write tool",
+      paramsSchema: { type: "object" },
+      outputSchema: { type: "string" },
+      riskDefault: "high",
+      isWrite: true,
+      execute: writeExec as unknown as Exec,
+    });
+    registerTool({
+      id: "test.read",
+      namespace: "test",
+      description: "test read tool",
+      paramsSchema: { type: "object" },
+      outputSchema: { type: "string" },
+      riskDefault: "low",
+      isWrite: false,
+      execute: readExec as unknown as Exec,
+    });
+  });
+
+  afterEach(() => {
+    clearRegistry();
+  });
+
+  it("dedupes a duplicate write-tool call with identical params in the same run", async () => {
+    const ledger = new WriteEffectLedger();
+    const ctx: RunContext = { env: {}, steps: {} } as unknown as RunContext;
+    const params = { channel: "#general", text: "hello" };
+
+    const first = await executeTool("test.write", {
+      params,
+      step: {},
+      ctx,
+      deps: makeDeps(ledger),
+    });
+    const second = await executeTool("test.write", {
+      params,
+      step: {},
+      ctx,
+      deps: makeDeps(ledger),
+    });
+
+    expect(first).toBe("wrote");
+    expect(second).toBe("wrote");
+    expect(writeExec).toHaveBeenCalledTimes(1); // dedup'd the second
+    expect(ledger.size()).toBe(1);
+  });
+
+  it("does NOT dedup when params differ (different idempotency key)", async () => {
+    const ledger = new WriteEffectLedger();
+    const ctx: RunContext = { env: {}, steps: {} } as unknown as RunContext;
+
+    await executeTool("test.write", {
+      params: { text: "first" },
+      step: {},
+      ctx,
+      deps: makeDeps(ledger),
+    });
+    await executeTool("test.write", {
+      params: { text: "second" },
+      step: {},
+      ctx,
+      deps: makeDeps(ledger),
+    });
+
+    expect(writeExec).toHaveBeenCalledTimes(2);
+    expect(ledger.size()).toBe(2);
+  });
+
+  it("ignores ledger entirely for read tools", async () => {
+    const ledger = new WriteEffectLedger();
+    const ctx: RunContext = { env: {}, steps: {} } as unknown as RunContext;
+    const params = { path: "x.txt" };
+
+    await executeTool("test.read", {
+      params,
+      step: {},
+      ctx,
+      deps: makeDeps(ledger),
+    });
+    await executeTool("test.read", {
+      params,
+      step: {},
+      ctx,
+      deps: makeDeps(ledger),
+    });
+
+    expect(readExec).toHaveBeenCalledTimes(2);
+    expect(ledger.size()).toBe(0); // read tools never write to the ledger
+  });
+
+  it("falls through to a normal execute when no ledger is provided", async () => {
+    const ctx: RunContext = { env: {}, steps: {} } as unknown as RunContext;
+    await executeTool("test.write", {
+      params: { x: 1 },
+      step: {},
+      ctx,
+      deps: makeDeps(undefined),
+    });
+    await executeTool("test.write", {
+      params: { x: 1 },
+      step: {},
+      ctx,
+      deps: makeDeps(undefined),
+    });
+    // Without a ledger, dedup can't happen — both calls run.
+    expect(writeExec).toHaveBeenCalledTimes(2);
+  });
+
+  it("does NOT record errors — retry after failure re-executes", async () => {
+    clearRegistry();
+    let attempts = 0;
+    const failingExec = vi.fn().mockImplementation(async () => {
+      attempts++;
+      if (attempts === 1) throw new Error("transient");
+      return "succeeded";
+    });
+    registerTool({
+      id: "test.flaky",
+      namespace: "test",
+      description: "flaky write tool",
+      paramsSchema: { type: "object" },
+      outputSchema: { type: "string" },
+      riskDefault: "high",
+      isWrite: true,
+      execute: failingExec as unknown as Exec,
+    });
+
+    const ledger = new WriteEffectLedger();
+    const ctx: RunContext = { env: {}, steps: {} } as unknown as RunContext;
+    const params = { x: 1 };
+
+    await expect(
+      executeTool("test.flaky", {
+        params,
+        step: {},
+        ctx,
+        deps: makeDeps(ledger),
+      }),
+    ).rejects.toThrow(/transient/);
+    expect(ledger.size()).toBe(0); // failure NOT recorded
+
+    const second = await executeTool("test.flaky", {
+      params,
+      step: {},
+      ctx,
+      deps: makeDeps(ledger),
+    });
+    expect(second).toBe("succeeded");
+    expect(failingExec).toHaveBeenCalledTimes(2);
+    expect(ledger.size()).toBe(1); // now recorded
+  });
+});

--- a/src/recipes/idempotencyKey.ts
+++ b/src/recipes/idempotencyKey.ts
@@ -1,0 +1,119 @@
+/**
+ * Idempotency keys for write-tool calls.
+ *
+ * PR5a of the Val-inspired plan. Foundation for safe retry + safe resume.
+ *
+ * Two pieces:
+ *
+ *   `deriveIdempotencyKey(toolId, params)`
+ *     A stable, deterministic hash over `(toolId, canonicalised params)`.
+ *     Canonicalisation = JSON.stringify with sorted keys, recursive — so
+ *     `{ a: 1, b: 2 }` and `{ b: 2, a: 1 }` hash identically. Returns a
+ *     hex SHA-256 prefix (first 16 chars; collisions vanishingly small
+ *     within a single run scope).
+ *
+ *   `WriteEffectLedger`
+ *     Per-run in-memory map of key → cached output. The runner constructs
+ *     one per recipe run and threads it through `StepDeps` / `ToolContext`.
+ *     `toolRegistry.executeTool` checks the ledger before invoking write
+ *     tools; if the key is present, returns the cached output instead of
+ *     re-executing — preventing duplicate side effects when two parallel
+ *     branches of a chained recipe both call the same write tool with the
+ *     same params.
+ *
+ * Scope of this PR (deliberately narrow):
+ *   - In-run dedup only (Map lives for one recipe run, discarded after).
+ *   - Records only on successful execution; errors don't pollute the
+ *     ledger, so retry-after-failure still re-executes (correct: if the
+ *     tool errored, we can't assume the side effect happened).
+ *   - No cross-run persistence — that's PR5b (disk-backed effect ledger).
+ *   - No retry-time idempotency on partial-failure cases (Slack posted
+ *     but HTTP timed out); that needs tool-side support and is a future
+ *     PR.
+ *
+ * The protection this DOES provide today: a `parallel:` block (or a
+ * recipe that calls a write tool from two different chained steps with
+ * identical params) cannot duplicate the side effect. Concretely, this
+ * was a footgun that pre-dated PR5a: `chainedRunner.ts` schedules steps
+ * with dependency-graph parallelism; if two branches happen to call
+ * `slack.postMessage` with the same payload, the message went twice.
+ */
+
+import { createHash } from "node:crypto";
+
+/**
+ * Stable canonical-JSON serialiser. Recursively sorts object keys so two
+ * params records with the same shape but different key order produce the
+ * same string. Plain objects only — falls back to `JSON.stringify` for
+ * arrays / primitives / null.
+ */
+function canonicalise(value: unknown): string {
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map(canonicalise).join(",")}]`;
+  }
+  const entries = Object.entries(value as Record<string, unknown>).sort(
+    ([a], [b]) => (a < b ? -1 : a > b ? 1 : 0),
+  );
+  const body = entries
+    .map(([k, v]) => `${JSON.stringify(k)}:${canonicalise(v)}`)
+    .join(",");
+  return `{${body}}`;
+}
+
+/**
+ * Derive a stable idempotency key for a write-tool invocation. 16 hex
+ * chars is 64 bits of entropy — far more than enough for in-run dedup
+ * (a single recipe with even 10⁵ steps has ~5×10⁻¹⁰ collision risk).
+ */
+export function deriveIdempotencyKey(
+  toolId: string,
+  params: Record<string, unknown>,
+): string {
+  const payload = `${toolId}|${canonicalise(params)}`;
+  return createHash("sha256").update(payload).digest("hex").slice(0, 16);
+}
+
+/**
+ * In-memory per-run ledger of executed write-tool calls. Maps idempotency
+ * keys to the cached output the tool returned, so a duplicate call can
+ * be short-circuited to the same result the first call produced.
+ *
+ * The ledger is single-threaded by design — runners are single-process
+ * and a per-run ledger has no cross-thread access. Concurrency safety
+ * within a run is provided by the dependency graph (parallel-only steps
+ * with no shared params hash by construction); the ledger catches
+ * accidental same-params calls.
+ */
+export class WriteEffectLedger {
+  private readonly cache = new Map<string, string | null>();
+
+  has(key: string): boolean {
+    return this.cache.has(key);
+  }
+
+  /**
+   * Return the previously-cached output for `key`, or `undefined` if not
+   * recorded. `null` is a legitimate cached value (= the tool returned
+   * `null` originally), so callers must use `has()` to distinguish "not
+   * present" from "present and null".
+   */
+  get(key: string): string | null | undefined {
+    return this.cache.get(key);
+  }
+
+  record(key: string, output: string | null): void {
+    this.cache.set(key, output);
+  }
+
+  /** Test-only inspection of the current key set. */
+  keys(): string[] {
+    return Array.from(this.cache.keys());
+  }
+
+  size(): number {
+    return this.cache.size;
+  }
+}

--- a/src/recipes/toolRegistry.ts
+++ b/src/recipes/toolRegistry.ts
@@ -10,6 +10,7 @@
  */
 
 import { assertWriteAllowed } from "../featureFlags.js";
+import { deriveIdempotencyKey } from "./idempotencyKey.js";
 import type { RunContext, StepDeps } from "./yamlRunner.js";
 
 export interface ToolMetadata {
@@ -116,6 +117,25 @@ export async function executeTool(
   }
   if (tool.isWrite) {
     assertWriteAllowed(id);
+
+    // PR5a — idempotency dedup. Within a single recipe run, the same
+    // write tool with the same params must execute exactly once. If a
+    // parallel branch (chained recipe) or a re-dispatch reaches this
+    // function with a key already in the ledger, return the cached
+    // output so downstream `{{steps.x.data}}` references stay coherent.
+    // Errors are NOT recorded — retry-after-failure still re-executes
+    // (correct: a failed call may not have completed its side effect).
+    const ledger = context.deps.writeEffectLedger;
+    if (ledger) {
+      const key = deriveIdempotencyKey(id, context.params);
+      if (ledger.has(key)) {
+        const cached = ledger.get(key);
+        return cached ?? null;
+      }
+      const result = await tool.execute(context);
+      ledger.record(key, result);
+      return result;
+    }
   }
   return tool.execute(context);
 }

--- a/src/recipes/yamlRunner.ts
+++ b/src/recipes/yamlRunner.ts
@@ -42,6 +42,7 @@ import {
   executeAgent as _executeAgent,
   type AgentExecutorDeps,
 } from "./agentExecutor.js";
+import { WriteEffectLedger } from "./idempotencyKey.js";
 import {
   defaultDeprecationWarn,
   normalizeRecipeForRuntime,
@@ -330,6 +331,14 @@ export type StepDeps = Required<
   recordFixturesDir?: string;
   runLog?: RecipeRunLog;
   testMode: boolean;
+  /**
+   * PR5a — per-run idempotency ledger. When present, `executeTool`
+   * short-circuits duplicate write-tool calls (same toolId + params)
+   * within the run, returning the cached output instead of re-invoking
+   * the tool. Constructed at run start in `runYamlRecipe` /
+   * `runChainedRecipe`; discarded when the run completes.
+   */
+  writeEffectLedger?: WriteEffectLedger;
 };
 
 // Strip tool-call narration some models (e.g. Gemini) prepend before the markdown block.
@@ -1166,6 +1175,9 @@ function resolveStepDeps(deps: RunnerDeps): StepDeps {
       }),
     logDir: deps.logDir,
     testMode: deps.testMode ?? false,
+    // PR5a: per-run idempotency ledger. Each call to `resolveStepDeps`
+    // produces a fresh ledger, so the scope is one recipe run.
+    writeEffectLedger: new WriteEffectLedger(),
   };
 }
 


### PR DESCRIPTION
## Summary

Foundation for safe retry and safe resume (the PR5 series in the Val-inspired roadmap). Closes the duplicate-side-effect footgun where a chained recipe with a \`parallel:\` block — or any two steps calling the same write tool with the same params — would post Slack messages, commit, or push twice.

This is **PR5a** of three: the primitive + in-run dedup. **PR5b** adds disk-backed cross-run persistence; **PR5c** uses both to enable safe resume-from-step.

## What changed

### \`src/recipes/idempotencyKey.ts\`
- \`deriveIdempotencyKey(toolId, params)\` — stable hash via canonical JSON (recursive key sort). Returns 16 hex chars (~5×10⁻¹⁰ collision risk at 10⁵ keys, plenty for a single-run scope).
- \`WriteEffectLedger\` — in-memory \`Map<key, cached output>\` with \`has\` / \`get\` / \`record\` API. The \`null\`-vs-missing distinction is preserved via \`has()\` because \`null\` is a legitimate cached value.

### Wiring (\`toolRegistry.executeTool\`)
When the tool's \`isWrite\` is true AND a \`writeEffectLedger\` is on the \`StepDeps\`:
- Derive the key; if already present, return the cached output (no re-execute).
- After a successful execute, record the output.
- **Errors are NOT recorded** — retry after failure re-executes, which is correct: a failed call may not have completed its side effect.

Read tools and runs without a ledger are unaffected; the change is additive.

### Per-run construction (\`resolveStepDeps\` in yamlRunner.ts)
Each call to \`runYamlRecipe\` / \`runChainedRecipe\` (via \`buildChainedDeps\`) gets a fresh ledger. Scope = one recipe run, discarded when the run completes.

## Concrete protection delivered

Before this PR, the following recipe would post **two** Slack messages:
\`\`\`yaml
steps:
  parallel:
    - tool: slack.postMessage
      channel: "#general"
      text: "deploy complete"
    - tool: slack.postMessage
      channel: "#general"
      text: "deploy complete"
\`\`\`

After this PR, the second call hits the ledger and returns the cached first result. One message goes to Slack.

## Out of scope (PR5b / PR5c will land these)

- **Cross-run persistence** — disk-backed effect ledger so a re-run of a recipe that already posted to Slack doesn't post again.
- **Retry-time idempotency for partial failures** — Slack posted but HTTP response timed out. Requires tool-side idempotency-key passing (Slack/Stripe APIs support this natively).
- **Resume-from-step semantics** — fork \`replayRun.ts\` into a real-mode resume variant gated on the ledger.

## Tests

15 tests across 2 files:
- 10 unit tests for derivation (key-order invariance, nested objects, array order preserved, tool-ID and value diff) + ledger API
- 5 integration tests at the \`executeTool\` boundary: dedup happy path, different-params no-dedup, read-tool ignore, no-ledger fallthrough, error-not-recorded

## Test plan

- [x] \`npx vitest run src/recipes/__tests__/\` — 582 tests pass (15 new + all existing)
- [x] \`npx tsc -p tsconfig.json --noEmit\` clean
- [x] biome clean (autofix applied)

🤖 Generated with [Claude Code](https://claude.com/claude-code)