### PR TITLE
feat(recipes): kill_switch halt category — distinguish blocked writes

### DIFF
--- a/dashboard/src/app/runs/page.tsx
+++ b/dashboard/src/app/runs/page.tsx
@@ -96,6 +96,7 @@ type HaltCategory =
   | "agent_threw"
   | "tool_threw"
   | "tool_error"
+  | "kill_switch"
   | "run_level"
   | "unknown";
 
@@ -111,6 +112,7 @@ const HALT_CATEGORY_LABEL: Record<HaltCategory, string> = {
   agent_threw: "agent threw",
   tool_threw: "tool threw",
   tool_error: "tool error",
+  kill_switch: "kill-switch blocked",
   run_level: "run-level halt",
   unknown: "uncategorised",
 };

--- a/src/__tests__/featureFlags.test.ts
+++ b/src/__tests__/featureFlags.test.ts
@@ -114,5 +114,19 @@ describe("featureFlags", () => {
 
       expect(() => assertWriteAllowed("file.write")).not.toThrow();
     });
+
+    it("attaches code: 'kill_switch_blocked' to the thrown error", () => {
+      setFlag(KILL_SWITCH_WRITES, true);
+
+      try {
+        assertWriteAllowed("file.write");
+        throw new Error("should have thrown");
+      } catch (err) {
+        expect(err).toBeInstanceOf(Error);
+        expect((err as Error & { code?: string }).code).toBe(
+          "kill_switch_blocked",
+        );
+      }
+    });
   });
 });

--- a/src/featureFlags.ts
+++ b/src/featureFlags.ts
@@ -375,12 +375,19 @@ export function isWriteKillSwitchActive(): boolean {
 
 /**
  * Assert write is allowed — throws if kill switch is active.
+ *
+ * The thrown error carries `code: "kill_switch_blocked"` so the recipe
+ * runner can categorise the resulting halt as `kill_switch` (rather than
+ * a generic `tool_threw`) and the dashboard pill row can flag it
+ * distinctly from real tool failures.
  */
 export function assertWriteAllowed(operation: string): void {
   if (isWriteKillSwitchActive()) {
-    throw new Error(
+    const err = new Error(
       `Write operation blocked by kill switch: ${operation}. ` +
         `Unset PATCHWORK_FLAG_KILL_SWITCH_WRITES or set kill-switch.writes=false to restore.`,
     );
+    (err as Error & { code?: string }).code = "kill_switch_blocked";
+    throw err;
   }
 }

--- a/src/recipes/__tests__/haltCategory.test.ts
+++ b/src/recipes/__tests__/haltCategory.test.ts
@@ -32,6 +32,14 @@ describe("categoriseHaltReason", () => {
     ).toBe("tool_error");
   });
 
+  it("recognises kill-switch-blocked writes before the generic tool_threw match", () => {
+    const reason =
+      'Tool "slack.postMessage" in step "post" threw: Write operation blocked by kill switch: slack.postMessage. Unset PATCHWORK_FLAG_KILL_SWITCH_WRITES or set kill-switch.writes=false to restore.';
+    expect(categoriseHaltReason(reason)).toBe("kill_switch");
+    expect(categoriseHaltReason("kill_switch_blocked")).toBe("kill_switch");
+    expect(categoriseHaltReason("kill-switch active")).toBe("kill_switch");
+  });
+
   it("returns 'unknown' for missing or unrecognised reasons", () => {
     expect(categoriseHaltReason(undefined)).toBe("unknown");
     expect(categoriseHaltReason("")).toBe("unknown");

--- a/src/recipes/haltCategory.ts
+++ b/src/recipes/haltCategory.ts
@@ -18,18 +18,23 @@ export type HaltCategory =
   | "agent_threw"
   | "tool_threw"
   | "tool_error"
+  /** Write blocked by the global kill-switch (#422). Distinct from a real tool failure. */
+  | "kill_switch"
   /** Whole-recipe failure (e.g. circular dependencies) — has no step row. */
   | "run_level"
   | "unknown";
 
 export function categoriseHaltReason(reason: string | undefined): HaltCategory {
   if (!reason) return "unknown";
-  // Order matters: more specific phrases (silent-fail, narration) must
-  // match before the general "Agent step ... threw" / "Tool ... threw"
-  // patterns. The phrases below mirror yamlRunner.ts:558-606,677-684,693-708.
+  // Order matters: more specific phrases (silent-fail, narration, kill
+  // switch) must match before the general "Agent step ... threw" /
+  // "Tool ... threw" patterns. The phrases below mirror
+  // yamlRunner.ts:558-606,677-684,693-708 and
+  // featureFlags.ts:assertWriteAllowed.
   if (/silent-fail/i.test(reason)) return "agent_silent_fail";
   if (/narration|whitespace|no content/i.test(reason))
     return "agent_narration_only";
+  if (/kill[- _]?switch/i.test(reason)) return "kill_switch";
   if (/^Agent step .* threw/i.test(reason)) return "agent_threw";
   if (/^Tool .* threw/i.test(reason)) return "tool_threw";
   if (/^Tool .* reported an error/i.test(reason)) return "tool_error";


### PR DESCRIPTION
## Summary

Closes the loop between the global write kill-switch landed in #422 and the halt-telemetry shipped in #441/#444. When the kill-switch is engaged and a recipe attempts a write, the resulting halt now categorises as \`kill_switch\` — distinguishable from a real tool failure in the dashboard.

Without this, an overnight kill-switch engagement looked the same as 3 tool failures in the morning dashboard: \`tool_threw · 3\`. Now it reads \`kill-switch blocked · 3\` and a glance tells you "everything paused because writes were off."

## What changed

### \`featureFlags.assertWriteAllowed\`
Attaches \`code: "kill_switch_blocked"\` to the thrown \`Error\`. The yamlRunner already propagates \`err.code\` into \`StepResult.errorCode\`, so this becomes a recognisable signal downstream without changing the throw shape.

### \`categoriseHaltReason\`
New regex \`/kill[- _]?switch/i\` ordered **before** the generic \`Tool ... threw\` pattern — so blocked writes never degrade into \`tool_threw\`.

### Dashboard
New \`HaltCategory: "kill_switch"\` variant with label \`"kill-switch blocked"\` on the pill row.

## Tests

2 new tests:
- \`featureFlags.test.ts\` — assertion carries \`code: "kill_switch_blocked"\`.
- \`haltCategory.test.ts\` — categoriser recognises the full thrown-error message AND the bare code string AND a "kill-switch" prose variant; order-sensitive (matches \`kill_switch\` before \`tool_threw\`).

## Test plan

- [x] 18 affected tests pass
- [x] bridge + dashboard typecheck clean
- [x] biome clean (2 pre-existing warnings on featureFlags.ts unrelated to this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)