### PR TITLE
feat(cli): patchwork halts — morning summary from the terminal

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,7 @@ Comply with all docs in `/documents/`. Consult before changes:
 - `quick-task <preset>` — Launch a context-aware Claude task from a preset (fixErrors, refactorFile, addTests, explainCode, optimizePerf, runTests, resumeLastCancelled). Same dispatch path as the sidebar. Requires `--driver subprocess`.
 - `start-task "<description>"` — Enqueue a free-form Claude task; Claude gathers its own workspace context.
 - `continue-handoff` — Resume from the stored handoff note (skips auto-snapshots).
+- `halts [--window 1h|24h|overnight|7d|any] [--json]` — One-screen morning summary of recent recipe halts. Discovers the running bridge via lock file, queries `/runs/halt-summary`, formats per category + 5 most-recent reasons. Default window is `overnight` (since 6pm yesterday local). Composes the haltReason field + category aggregator shipped in #441/#444.
 - `recipe new <name>` — Scaffold a recipe from a template (`minimal` | `daily` | `inbox`). Add `--interactive` (or `-i`) to drop into the connector-aware prompt tree instead: mode pick (Guided / Template / AI-suggest), then step-by-step build. Generated YAML includes the SchemaStore pragma and runs `validateRecipeDefinition` post-hoc as warnings. AI-suggest discovers the running bridge via `~/.claude/ide/*.lock` and POSTs the goal to `/recipes/generate`; raw response written to disk (no form normalization).
 - `--watch` — Auto-restart supervisor with exponential backoff (2s → 30s). Safe for production.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -177,6 +177,7 @@ const KNOWN_SUBCOMMANDS = [
   "launchd",
   "start",
   "kill-switch",
+  "halts",
 ] as const;
 
 const __invokedSubcommand = (() => {
@@ -1895,6 +1896,162 @@ if (process.argv[2] === "kill-switch") {
         process.stdout.write(
           `\n  Kill-switch ${engage ? "engaged" : "released"} on ${liveLocks.length} bridge${liveLocks.length === 1 ? "" : "s"}.\n`,
         );
+      }
+      process.exit(0);
+    } catch (err) {
+      process.stderr.write(
+        `Error: ${err instanceof Error ? err.message : String(err)}\n`,
+      );
+      process.exit(1);
+    }
+  })();
+}
+
+// `patchwork halts` — one-screen morning summary of recent recipe halts.
+//
+// Composes the haltReason field (#441), category aggregator + endpoint
+// (#444), and dashboard pill conventions: queries the live bridge's
+// /runs/halt-summary endpoint over the chosen window and prints a
+// per-category breakdown plus the 5 most-recent halt reasons. Default
+// window is "overnight" (since 6pm yesterday local) so it lines up with
+// "what halted while I was asleep?".
+if (process.argv[2] === "halts") {
+  const args = process.argv.slice(3);
+  const wantHelp = args.includes("--help") || args.includes("-h");
+  if (wantHelp) {
+    process.stdout.write(
+      "Usage: patchwork halts [--window <name>] [--json]\n" +
+        "\n" +
+        "  --window 1h | 24h | overnight | 7d | any   (default: overnight)\n" +
+        "  --json                                     emit raw JSON (for scripting)\n" +
+        "\n" +
+        '"overnight" = since 6pm yesterday local time.\n',
+    );
+    process.exit(0);
+  }
+  type Win = "1h" | "24h" | "overnight" | "7d" | "any";
+  function parseWindow(): Win {
+    const idx = args.findIndex((a) => a === "--window" || a === "-w");
+    const raw = idx >= 0 && idx + 1 < args.length ? args[idx + 1] : "overnight";
+    if (
+      raw === "1h" ||
+      raw === "24h" ||
+      raw === "overnight" ||
+      raw === "7d" ||
+      raw === "any"
+    )
+      return raw;
+    process.stderr.write(`Unknown --window value: "${raw}"\n`);
+    process.exit(1);
+  }
+  function windowSinceMs(w: Win): number | null {
+    if (w === "any") return null;
+    if (w === "1h") return 60 * 60 * 1000;
+    if (w === "24h") return 24 * 60 * 60 * 1000;
+    if (w === "7d") return 7 * 24 * 60 * 60 * 1000;
+    const d = new Date();
+    d.setHours(18, 0, 0, 0);
+    if (d.getTime() > Date.now()) d.setDate(d.getDate() - 1);
+    return Date.now() - d.getTime();
+  }
+  const window = parseWindow();
+  const wantJson = args.includes("--json");
+
+  (async () => {
+    try {
+      const { findAllLiveBridges } = await import("./bridgeLockDiscovery.js");
+      const liveLocks = findAllLiveBridges();
+      if (liveLocks.length === 0) {
+        process.stderr.write(
+          "No running bridge found. Start one with `patchwork start` (or `--driver subprocess`).\n",
+        );
+        process.exit(2);
+      }
+      // Single-bridge default: query the first. Multi-bridge users will
+      // typically have one orchestrator anyway; expanding to fan-out is a
+      // follow-up if needed.
+      const lock = liveLocks[0];
+      if (!lock) {
+        process.stderr.write("No running bridge found.\n");
+        process.exit(2);
+      }
+      const sinceMs = windowSinceMs(window);
+      const qs = sinceMs != null ? `?sinceMs=${sinceMs}` : "";
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), 10_000);
+      let res: Response;
+      try {
+        res = await fetch(
+          `http://127.0.0.1:${lock.port}/runs/halt-summary${qs}`,
+          {
+            headers: { Authorization: `Bearer ${lock.authToken}` },
+            signal: controller.signal,
+          },
+        );
+      } finally {
+        clearTimeout(timer);
+      }
+      if (!res.ok) {
+        process.stderr.write(
+          `Bridge returned ${res.status} for /runs/halt-summary\n`,
+        );
+        process.exit(1);
+      }
+      const summary = (await res.json()) as {
+        total: number;
+        byCategory: Record<string, number>;
+        recent: Array<{ reason: string; category: string; runSeq: number }>;
+      };
+
+      if (wantJson) {
+        process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);
+        process.exit(0);
+      }
+
+      const labels: Record<string, string> = {
+        agent_silent_fail: "agent silent-fail",
+        agent_narration_only: "agent narration-only",
+        agent_threw: "agent threw",
+        tool_threw: "tool threw",
+        tool_error: "tool error",
+        kill_switch: "kill-switch blocked",
+        run_level: "run-level halt",
+        unknown: "uncategorised",
+      };
+
+      const windowLabel: Record<Win, string> = {
+        "1h": "last hour",
+        "24h": "last 24h",
+        overnight: "since 6pm yesterday",
+        "7d": "last 7 days",
+        any: "all time",
+      };
+
+      process.stdout.write(`Halts — ${windowLabel[window]}\n`);
+      process.stdout.write(`Total: ${summary.total}\n`);
+      if (summary.total === 0) {
+        process.stdout.write("\n  (nothing halted in this window)\n");
+        process.exit(0);
+      }
+
+      const entries = Object.entries(summary.byCategory).sort(
+        ([, a], [, b]) => b - a,
+      );
+      process.stdout.write("\nBy category:\n");
+      for (const [cat, count] of entries) {
+        const label = labels[cat] ?? cat;
+        process.stdout.write(`  ${String(count).padStart(3)}  ${label}\n`);
+      }
+
+      if (summary.recent.length > 0) {
+        process.stdout.write("\nMost recent:\n");
+        for (const r of summary.recent) {
+          // Truncate the reason to ~120 chars so a wide stack trace
+          // can't blow up the terminal width on phones / narrow panes.
+          const reason =
+            r.reason.length > 120 ? `${r.reason.slice(0, 117)}…` : r.reason;
+          process.stdout.write(`  #${r.runSeq}  [${r.category}]  ${reason}\n`);
+        }
       }
       process.exit(0);
     } catch (err) {


### PR DESCRIPTION
## Summary

One-screen halt summary for the CLI workflow. Composes the \`haltReason\` field (#441), the category aggregator + \`/runs/halt-summary\` endpoint (#444), and the \`kill_switch\` category (#447).

For users who live in the terminal, no need to open the dashboard to read last night's halts — pairs naturally with the cron-triggered overnight workflow.

## Example output

\`\`\`
$ patchwork halts
Halts — since 6pm yesterday
Total: 4

By category:
    2  tool threw
    1  kill-switch blocked
    1  agent silent-fail

Most recent:
  #182  [tool_threw]  Tool "slack.postMessage" in step "post" threw…
  #181  [kill_switch]  Tool "github.createPR" in step "open" threw: …
\`\`\`

## What changed

- **\`src/index.ts\`** — new \`halts\` subcommand. Discovers the running bridge via \`findAllLiveBridges()\` (same pattern as \`kill-switch\`), queries \`/runs/halt-summary\` with Bearer auth + 10s deadline, formats per category + 5 most-recent reasons (truncated to 120 chars to keep narrow terminals readable).
- **\`CLAUDE.md\`** — documented under CLI Subcommands.

## Flags

- \`--window 1h | 24h | overnight | 7d | any\` (default: \`overnight\` = since 6pm yesterday local; same windows as the dashboard).
- \`--json\` — emit the raw \`/runs/halt-summary\` payload (for scripting / further processing).

## Why no new tests

\`/runs/halt-summary\` is already covered by \`server-halt-summary.test.ts\` (3 integration tests). The CLI dispatcher is a thin formatter on top with no extractable units; testing it as a subprocess shell-out would be theatre. Manually verified:

- \`--help\` prints usage and exits 0
- No-bridge path prints stderr error + exits 2
- 404 path (bridge predates #444) prints error + exits 1
- Successful path against a live bridge formats correctly

## Test plan

- [x] \`npx tsc -p tsconfig.json --noEmit\` clean
- [x] biome clean
- [x] \`node dist/index.js halts --help\` prints usage
- [x] \`node dist/index.js halts --window 24h\` against a live bridge formats correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)