### PR TITLE
feat(digest): HALTS line in session-start digest

### DIFF
--- a/src/tools/__tests__/recentTracesDigest.test.ts
+++ b/src/tools/__tests__/recentTracesDigest.test.ts
@@ -134,7 +134,12 @@ describe("buildRecentTracesDigest", () => {
       errorMessage: "x".repeat(200),
     });
     const lines = await buildRecentTracesDigest({ recipeRunLog: runLog });
-    const bullet = lines[1] ?? "";
+    // PR #449 prepends a HALTS line when run_level halts are present; the
+    // error recorded above qualifies. Find the bullet after the
+    // "RECENT DECISIONS" heading instead of hardcoding lines[1].
+    const headingIdx = lines.findIndex((l) => l.startsWith("RECENT DECISIONS"));
+    expect(headingIdx).toBeGreaterThanOrEqual(0);
+    const bullet = lines[headingIdx + 1] ?? "";
     expect(bullet).toContain("…"); // truncation marker present
     // The rendered summary (between icon and "— Ns ago") must be ≤80 chars.
     const summaryMatch = bullet.match(/^ {2}. (.+) — \d+[smhd] ago$/);
@@ -276,5 +281,95 @@ describe("buildRecentTracesDigest — decision formatting", () => {
     const summaryMatch = bullet.match(/^ {2}. (.+) — \d+[smhd] ago$/);
     expect(summaryMatch).not.toBeNull();
     expect((summaryMatch?.[1] ?? "").length).toBeLessThanOrEqual(80);
+  });
+
+  // ── PR #449 — HALTS one-liner ────────────────────────────────────────────
+  describe("HALTS line", () => {
+    it("prepends a halt summary when recent runs include error stepResults", async () => {
+      const now = Date.now();
+      // Record two error runs in the last 12h via appendDirect so we can
+      // attach stepResults with haltReason inline.
+      runLog.appendDirect({
+        taskId: "t-1",
+        recipeName: "post-notify",
+        trigger: "cron",
+        status: "error",
+        createdAt: now - 60_000,
+        startedAt: now - 60_000,
+        doneAt: now - 30_000,
+        durationMs: 30_000,
+        stepResults: [
+          {
+            id: "post",
+            status: "error",
+            haltReason: 'Tool "slack.postMessage" in step "post" threw: 500',
+            durationMs: 100,
+          },
+        ],
+      });
+      runLog.appendDirect({
+        taskId: "t-2",
+        recipeName: "weekly-report",
+        trigger: "cron",
+        status: "error",
+        createdAt: now - 120_000,
+        startedAt: now - 120_000,
+        doneAt: now - 90_000,
+        durationMs: 30_000,
+        stepResults: [
+          {
+            id: "fetch",
+            status: "error",
+            haltReason:
+              'Tool "jira.searchIssues" in step "fetch" reported an error: 401',
+            durationMs: 100,
+          },
+        ],
+      });
+
+      const lines = await buildRecentTracesDigest({ recipeRunLog: runLog });
+      const haltLine = lines.find((l) => l.startsWith("HALTS"));
+      expect(haltLine).toBeDefined();
+      expect(haltLine).toContain("HALTS (last 12h): 2");
+      expect(haltLine).toContain("tool_threw·1");
+      expect(haltLine).toContain("tool_error·1");
+    });
+
+    it("emits halt summary even when there are no decision traces (halts alone are signal)", async () => {
+      const now = Date.now();
+      // run_level halt — no stepResults, just an errorMessage.
+      runLog.appendDirect({
+        taskId: "t-cycle",
+        recipeName: "broken",
+        trigger: "cron",
+        status: "error",
+        createdAt: now - 1000,
+        startedAt: now - 1000,
+        doneAt: now - 500,
+        durationMs: 500,
+        errorMessage: "Recipe has circular dependencies",
+        stepResults: [],
+      });
+      const lines = await buildRecentTracesDigest({ recipeRunLog: runLog });
+      expect(lines.length).toBeGreaterThan(0);
+      expect(lines[0]).toContain("HALTS");
+      expect(lines[0]).toContain("run_level·1");
+    });
+
+    it("omits the HALTS line when nothing halted in the window", async () => {
+      runLog.appendDirect({
+        taskId: "t-ok",
+        recipeName: "happy",
+        trigger: "cron",
+        status: "done",
+        createdAt: Date.now() - 1000,
+        startedAt: Date.now() - 1000,
+        doneAt: Date.now() - 500,
+        durationMs: 500,
+        stepResults: [],
+      });
+      const lines = await buildRecentTracesDigest({ recipeRunLog: runLog });
+      expect(lines.every((l) => !l.startsWith("HALTS"))).toBe(true);
+    });
   });
 });

--- a/src/tools/recentTracesDigest.ts
+++ b/src/tools/recentTracesDigest.ts
@@ -1,6 +1,7 @@
 import type { ActivityLog } from "../activityLog.js";
 import type { CommitIssueLinkLog } from "../commitIssueLinkLog.js";
 import type { DecisionTraceLog } from "../decisionTraceLog.js";
+import { summariseHalts } from "../recipes/haltCategory.js";
 import type { RecipeRunLog } from "../runLog.js";
 import { createCtxQueryTracesTool } from "./ctxQueryTraces.js";
 
@@ -138,20 +139,50 @@ export async function buildRecentTracesDigest(
       }
     | undefined;
   const traces = structured?.traces ?? [];
-  if (traces.length === 0) return [];
-
   const top = traces.slice(0, topN);
-  const lines: string[] = ["RECENT DECISIONS (last 12h):"];
-  for (const t of top) {
-    const icon = TYPE_ICON[t.traceType] ?? "·";
-    lines.push(`  ${icon} ${formatTraceLine(t, now)}`);
+  const lines: string[] = [];
+
+  // PR #449: prepend a one-line halt summary when the runLog reports any
+  // halts in the same 12h window. Lets a fresh-context agent see "3
+  // recipes halted overnight (2 tool_threw, 1 kill_switch)" without
+  // querying ctxQueryTraces. Composes with the haltReason field (#441),
+  // category aggregator (#444), and kill_switch category (#447). Emitted
+  // even when there are no decision traces — halts are signal on their
+  // own.
+  let haltLine: string | null = null;
+  if (deps.recipeRunLog) {
+    const cutoff = now - windowMs;
+    const recentRuns = deps.recipeRunLog
+      .query({ limit: 500 })
+      .filter((r) => r.createdAt >= cutoff);
+    const halts = summariseHalts(recentRuns);
+    if (halts.total > 0) {
+      const breakdown = Object.entries(halts.byCategory)
+        .sort(([, a], [, b]) => b - a)
+        .map(([cat, count]) => `${cat}·${count}`)
+        .join(" ");
+      haltLine = `HALTS (last 12h): ${halts.total} — ${breakdown}`;
+    }
   }
 
-  // Hard byte cap — keep dropping oldest entries until under budget.
-  while (lines.join("\n").length > MAX_BYTES && lines.length > 1) {
+  // If there's nothing on either axis, skip the section entirely.
+  if (!haltLine && top.length === 0) return [];
+
+  if (haltLine) lines.push(haltLine);
+  if (top.length > 0) {
+    lines.push("RECENT DECISIONS (last 12h):");
+    for (const t of top) {
+      const icon = TYPE_ICON[t.traceType] ?? "·";
+      lines.push(`  ${icon} ${formatTraceLine(t, now)}`);
+    }
+  }
+
+  // Hard byte cap — keep dropping oldest decision entries until under budget.
+  // The halt line + DECISIONS heading are the floor (length 2 when both
+  // present, 1 when only one). Don't pop past the floor.
+  const floor = (haltLine ? 1 : 0) + (top.length > 0 ? 1 : 0);
+  while (lines.join("\n").length > MAX_BYTES && lines.length > floor) {
     lines.pop();
   }
-  // If only the heading survived, drop it too (nothing useful to say).
-  if (lines.length <= 1) return [];
   return lines;
 }


### PR DESCRIPTION
## Summary

Closes another loop. The bridge's session-start digest already injects a \`RECENT DECISIONS (last 12h)\` block into every Claude Code session's system prompt. This PR prepends a one-line halt summary when the runLog reports any halts in the same window — so a fresh-context agent sees "3 recipes halted overnight (2 tool_threw, 1 kill_switch)" without having to call \`ctxQueryTraces\` first.

Composes everything shipped: #441 (haltReason), #444 (category aggregator), #447 (kill_switch category).

## Example output

\`\`\`
HALTS (last 12h): 3 — tool_threw·2 kill_switch·1
RECENT DECISIONS (last 12h):
  ▸ recipe:post-notify — 5m ago
  ★ #482 [perf] cached duplicate slack post — 1h ago
\`\`\`

## Design notes

- **Emitted independently** of the trace section. Halts alone are signal — if you wake up to 0 decisions but 5 halts, that's the morning headline.
- **Skipped when nothing applies**. No halts AND no traces → the digest section is dropped (same as before this PR).
- **Bounded length**. The breakdown is \`cat·count\` pairs — short. Stays well inside the existing 2 KB digest budget regardless of how many categories show up.
- **No new schema, no new endpoint** — pure consumer of \`summariseHalts()\` + \`recipeRunLog.query()\` that already exist.

## Tests

3 new tests + 1 updated index assertion (the HALTS line shifts trace bullets by one):
- Halt line appears with per-step error halts
- Halt line emitted even when there are zero decision traces (halts alone are signal)
- Halt line omitted when nothing halted in the window

## Test plan

- [x] 17 digest tests pass (14 existing + 3 new)
- [x] digestFreshness + digestIntegration integration suites pass
- [x] \`npx tsc -p tsconfig.json --noEmit\` clean
- [x] biome clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)