### PR TITLE
feat(metrics): bridge_recipe_halts Prometheus gauge

### DIFF
--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -35,6 +35,10 @@ import { isPreToolUseHookRegistered } from "./preToolUseHook.js";
 import type { ProbeResults } from "./probe.js";
 import { probeAll } from "./probe.js";
 import { RecipeOrchestration } from "./recipeOrchestration.js";
+import {
+  haltSummaryToPrometheus,
+  summariseHalts,
+} from "./recipes/haltCategory.js";
 import { warnAboutLegacyPermissionsSidecars } from "./recipes/migrationWarnings.js";
 import { RecipeOrchestrator } from "./recipes/RecipeOrchestrator.js";
 import { classifyTool } from "./riskTier.js";
@@ -1105,11 +1109,30 @@ export class Bridge {
         tokens: this.tokenUsageTracker.getTotals(),
       };
     };
-    this.server.metricsFn = () =>
-      this.activityLog.toPrometheus({
+    this.server.metricsFn = () => {
+      const base = this.activityLog.toPrometheus({
         rateLimitRejected: this.activityLog.getRateLimitRejections(),
         extensionDisconnects: this.extensionDisconnectCount,
       });
+      // Append per-category halt gauges from the runLog so users with
+      // their own Prometheus stack can dashboard halts without using
+      // Patchwork's UI. Reads everything currently in the in-memory ring
+      // (bounded by runLog memoryCap); rotation may cause the values to
+      // decrease, so we expose this as a `gauge` rather than a `counter`.
+      // Composes #441/#444/#447 — same data shape as /runs/halt-summary
+      // and `patchwork halts`, surfaced through the existing /metrics
+      // route.
+      let haltLines: string[] = [];
+      try {
+        if (this.recipeRunLog) {
+          const runs = this.recipeRunLog.query({ limit: 500 });
+          haltLines = haltSummaryToPrometheus(summariseHalts(runs));
+        }
+      } catch {
+        /* fail-open: prometheus must never break on log read */
+      }
+      return haltLines.length > 0 ? `${base}\n${haltLines.join("\n")}\n` : base;
+    };
     this.server.perfDataFn = () => {
       const windowMs = 60 * 60_000; // 1h window for dashboard
       const windowedS = this.activityLog.windowedStats(windowMs);

--- a/src/recipes/__tests__/haltCategory.test.ts
+++ b/src/recipes/__tests__/haltCategory.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   categoriseHaltReason,
   deriveHaltReasonFromError,
+  haltSummaryToPrometheus,
   summariseHalts,
 } from "../haltCategory.js";
 
@@ -194,5 +195,44 @@ describe("deriveHaltReasonFromError", () => {
     });
     expect(r).toBeDefined();
     expect(categoriseHaltReason(r)).toBe("agent_threw");
+  });
+});
+
+describe("haltSummaryToPrometheus", () => {
+  it("returns empty array for an empty summary (no orphan HELP/TYPE)", () => {
+    expect(
+      haltSummaryToPrometheus({ total: 0, byCategory: {}, recent: [] }),
+    ).toEqual([]);
+  });
+
+  it("emits HELP + TYPE + one line per category", () => {
+    const lines = haltSummaryToPrometheus({
+      total: 5,
+      byCategory: { tool_threw: 3, kill_switch: 1, agent_silent_fail: 1 },
+      recent: [],
+    });
+    expect(lines).toContain(
+      "# HELP bridge_recipe_halts Recipe halts in the in-memory run-log window, by category",
+    );
+    expect(lines).toContain("# TYPE bridge_recipe_halts gauge");
+    expect(lines).toContain('bridge_recipe_halts{category="tool_threw"} 3');
+    expect(lines).toContain('bridge_recipe_halts{category="kill_switch"} 1');
+    expect(lines).toContain(
+      'bridge_recipe_halts{category="agent_silent_fail"} 1',
+    );
+    // 2 meta lines + 3 sample lines
+    expect(lines).toHaveLength(5);
+  });
+
+  it("produces lines that parse as well-formed Prometheus text-exposition", () => {
+    const lines = haltSummaryToPrometheus({
+      total: 1,
+      byCategory: { unknown: 1 },
+      recent: [],
+    });
+    const sampleLines = lines.filter((l) => !l.startsWith("#"));
+    expect(sampleLines).toHaveLength(1);
+    // Match `metric{labels} value` per Prometheus exposition format.
+    expect(sampleLines[0]).toMatch(/^[a-z_][a-z0-9_]*\{[a-z_]+="[^"]+"\} \d+$/);
   });
 });

--- a/src/recipes/haltCategory.ts
+++ b/src/recipes/haltCategory.ts
@@ -107,6 +107,27 @@ export function summariseHalts(runs: HaltSummaryInputRun[]): HaltSummary {
 }
 
 /**
+ * Format a `HaltSummary` as Prometheus text-exposition lines for the
+ * `bridge_recipe_halts{category="..."} N` gauge. Returns an empty array
+ * when the summary is empty (no HELP/TYPE block emitted in that case so
+ * Prom scrapers don't see an orphan declaration).
+ *
+ * Surfaced via `/metrics` so users with their own observability stack
+ * can dashboard halts without using Patchwork's UI.
+ */
+export function haltSummaryToPrometheus(summary: HaltSummary): string[] {
+  if (summary.total === 0) return [];
+  const lines: string[] = [
+    "# HELP bridge_recipe_halts Recipe halts in the in-memory run-log window, by category",
+    "# TYPE bridge_recipe_halts gauge",
+  ];
+  for (const [category, count] of Object.entries(summary.byCategory)) {
+    lines.push(`bridge_recipe_halts{category="${category}"} ${count}`);
+  }
+  return lines;
+}
+
+/**
  * Derive a one-sentence haltReason from a step's error-status + raw error
  * string. Used by `chainedRunner` to mirror the convention emitted by
  * `yamlRunner`. Returns `undefined` for non-error rows or missing error.


### PR DESCRIPTION
## Summary

Surfaces halt counts by category via the existing \`/metrics\` endpoint so users with their own Prometheus / Grafana stacks can dashboard halts without using Patchwork's UI.

Composes #441 (haltReason) + #444 (category aggregator) + #447 (kill_switch). Same data, new surface.

## What gets exposed

\`\`\`
# HELP bridge_recipe_halts Recipe halts in the in-memory run-log window, by category
# TYPE bridge_recipe_halts gauge
bridge_recipe_halts{category="tool_threw"} 3
bridge_recipe_halts{category="kill_switch"} 1
bridge_recipe_halts{category="agent_silent_fail"} 1
\`\`\`

## Design notes

- **\`gauge\` not \`counter\`** — the runLog rotates at 10 k lines / 1 MB so values can decrease. Honest naming over technically-wrong-counter.
- **HELP/TYPE omitted when zero halts** — no orphan declarations leaking to scrapers.
- **Fail-open** — any read error is swallowed; base metrics still emit.

## Refactor

Extracted \`haltSummaryToPrometheus(summary)\` into \`haltCategory.ts\` so the formatter is unit-testable without instantiating a real Bridge.

## Tests

3 new tests:
- Empty summary → empty array (no orphan HELP/TYPE)
- Non-empty → HELP + TYPE + one sample per category
- Output matches the Prometheus text-exposition grammar regex

## Test plan

- [x] 12 halt-category tests pass
- [x] \`npx tsc -p tsconfig.json --noEmit\` clean
- [x] biome clean (autofix applied)

🤖 Generated with [Claude Code](https://claude.com/claude-code)