### PR TITLE
feat(recipes): per-recipe token budget enforcement (PR2b)

### DIFF
--- a/src/recipes/__tests__/haltCategory.test.ts
+++ b/src/recipes/__tests__/haltCategory.test.ts
@@ -33,6 +33,16 @@ describe("categoriseHaltReason", () => {
     ).toBe("tool_error");
   });
 
+  it("recognises budget_exceeded halts from the RunBudget admission path", () => {
+    expect(
+      categoriseHaltReason(
+        "Run exceeded its token budget — budget_exceeded: total=1200 > tokensMax=1000.",
+      ),
+    ).toBe("budget_exceeded");
+    expect(categoriseHaltReason("budget_exceeded")).toBe("budget_exceeded");
+    expect(categoriseHaltReason("budget exceeded")).toBe("budget_exceeded");
+  });
+
   it("recognises kill-switch-blocked writes before the generic tool_threw match", () => {
     const reason =
       'Tool "slack.postMessage" in step "post" threw: Write operation blocked by kill switch: slack.postMessage. Unset PATCHWORK_FLAG_KILL_SWITCH_WRITES or set kill-switch.writes=false to restore.';

--- a/src/recipes/__tests__/runBudget.test.ts
+++ b/src/recipes/__tests__/runBudget.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import { RunBudget } from "../runBudget.js";
+
+describe("RunBudget — no policy", () => {
+  it("admits everything when no policy is set", () => {
+    const b = new RunBudget();
+    expect(b.admit().admitted).toBe(true);
+    b.reconcile("anthropic", { inputTokens: 100, outputTokens: 50 });
+    expect(b.admit().admitted).toBe(true);
+    expect(b.totals().total).toBe(0); // no-policy short-circuits reconcile
+  });
+});
+
+describe("RunBudget — tokensMax with default halt", () => {
+  it("admits while under cap and refuses when total >= tokensMax", () => {
+    const b = new RunBudget({ tokensMax: 1000 });
+    expect(b.admit().admitted).toBe(true);
+
+    b.reconcile("anthropic", { inputTokens: 400, outputTokens: 400 });
+    // total = 800, still under cap
+    expect(b.admit().admitted).toBe(true);
+
+    b.reconcile("anthropic", { inputTokens: 200, outputTokens: 100 });
+    // total = 1100, breached
+    const a = b.admit();
+    expect(a.admitted).toBe(false);
+    expect(a.reason).toMatch(/budget_exceeded/);
+    expect(a.reason).toMatch(/tokensMax=1000/);
+  });
+
+  it("totals() reports remaining and breached state", () => {
+    const b = new RunBudget({ tokensMax: 500 });
+    b.reconcile("anthropic", { inputTokens: 200, outputTokens: 150 });
+    expect(b.totals()).toMatchObject({
+      inputTokens: 200,
+      outputTokens: 150,
+      total: 350,
+      remaining: 150,
+      breached: false,
+      haltOnBreach: true,
+    });
+    b.reconcile("anthropic", { inputTokens: 200, outputTokens: 0 });
+    expect(b.totals().breached).toBe(true);
+    expect(b.totals().remaining).toBe(0);
+  });
+});
+
+describe("RunBudget — onBreach=warn", () => {
+  it("never refuses admission; emits one in-band warning on first breach", () => {
+    const b = new RunBudget({ tokensMax: 100, onBreach: "warn" });
+    b.reconcile("anthropic", { inputTokens: 60, outputTokens: 60 });
+    expect(b.admit().admitted).toBe(true);
+    expect(b.totals().breached).toBe(true);
+    expect(b.warnings().some((w) => /exceeded/i.test(w))).toBe(true);
+    // Subsequent reconciles don't duplicate the breach warning
+    b.reconcile("anthropic", { inputTokens: 50, outputTokens: 50 });
+    expect(b.warnings().filter((w) => /exceeded/i.test(w))).toHaveLength(1);
+  });
+});
+
+describe("RunBudget — subscription-driver fail-open", () => {
+  it("records a deduped warning per unmeasured driver, never blocks", () => {
+    const b = new RunBudget({ tokensMax: 100 });
+    b.reconcile("subprocess", undefined);
+    b.reconcile("subprocess", undefined);
+    b.reconcile("claude-code", undefined);
+    const warns = b.warnings();
+    expect(
+      warns.filter((w) => /subprocess.*does not report/i.test(w)),
+    ).toHaveLength(1);
+    expect(
+      warns.filter((w) => /claude-code.*does not report/i.test(w)),
+    ).toHaveLength(1);
+    expect(b.totals().total).toBe(0);
+    expect(b.admit().admitted).toBe(true);
+  });
+
+  it("does not record warnings when no tokensMax is configured", () => {
+    const b = new RunBudget();
+    b.reconcile("subprocess", undefined);
+    expect(b.warnings()).toHaveLength(0);
+  });
+});

--- a/src/recipes/__tests__/yamlRunner.test.ts
+++ b/src/recipes/__tests__/yamlRunner.test.ts
@@ -2506,6 +2506,142 @@ describe("resolveClaudeBinary — override precedence", async () => {
   });
 });
 
+// ── PR2b — recipe.budget enforcement ─────────────────────────────────────────
+
+describe("recipe.budget — tokensMax enforcement (PR2b)", () => {
+  it("halts on the next agent step after budget is breached", async () => {
+    const recipe = makeRecipe({
+      budget: { tokensMax: 100 },
+      steps: [
+        {
+          agent: {
+            prompt: "step 1",
+            model: "claude-haiku-4-5-20251001",
+            into: "out1",
+          },
+        },
+        {
+          agent: {
+            prompt: "step 2",
+            model: "claude-haiku-4-5-20251001",
+            into: "out2",
+          },
+        },
+      ],
+    });
+    // First call consumes 120 tokens (over the 100-token cap); second
+    // call must be denied admission before it ever dispatches.
+    let calls = 0;
+    const result = await runYamlRecipe(recipe, {
+      ...noop(),
+      claudeFn: async () => {
+        calls++;
+        return {
+          text: `output ${calls}`,
+          usage: { inputTokens: 60, outputTokens: 60 },
+        };
+      },
+    });
+    expect(calls).toBe(1); // second admission refused
+    expect(result.stepResults).toHaveLength(2);
+    expect(result.stepResults[0]?.status).toBe("ok");
+    expect(result.stepResults[1]?.status).toBe("error");
+    expect(result.stepResults[1]?.haltReason).toMatch(/budget_exceeded/);
+  });
+
+  it("does not enforce when recipe.budget is absent (no overhead)", async () => {
+    const recipe = makeRecipe({
+      steps: [
+        {
+          agent: {
+            prompt: "step",
+            model: "claude-haiku-4-5-20251001",
+            into: "out",
+          },
+        },
+      ],
+    });
+    const result = await runYamlRecipe(recipe, {
+      ...noop(),
+      claudeFn: async () => ({
+        text: "ok",
+        usage: { inputTokens: 1_000_000, outputTokens: 1_000_000 },
+      }),
+    });
+    expect(result.stepResults[0]?.status).toBe("ok");
+  });
+
+  it("onBreach='warn' lets the run continue past the cap", async () => {
+    const recipe = makeRecipe({
+      budget: { tokensMax: 100, onBreach: "warn" },
+      steps: [
+        {
+          agent: {
+            prompt: "step 1",
+            model: "claude-haiku-4-5-20251001",
+            into: "out1",
+          },
+        },
+        {
+          agent: {
+            prompt: "step 2",
+            model: "claude-haiku-4-5-20251001",
+            into: "out2",
+          },
+        },
+      ],
+    });
+    let calls = 0;
+    const result = await runYamlRecipe(recipe, {
+      ...noop(),
+      claudeFn: async () => {
+        calls++;
+        return {
+          text: `output ${calls}`,
+          usage: { inputTokens: 200, outputTokens: 200 },
+        };
+      },
+    });
+    expect(calls).toBe(2);
+    expect(result.stepResults[0]?.status).toBe("ok");
+    expect(result.stepResults[1]?.status).toBe("ok");
+  });
+
+  it("subscription-driver fail-open: no usage = no enforcement", async () => {
+    const recipe = makeRecipe({
+      budget: { tokensMax: 50 },
+      steps: [
+        {
+          agent: {
+            prompt: "step 1",
+            model: "claude-haiku-4-5-20251001",
+            into: "out1",
+          },
+        },
+        {
+          agent: {
+            prompt: "step 2",
+            model: "claude-haiku-4-5-20251001",
+            into: "out2",
+          },
+        },
+      ],
+    });
+    // claudeFn returns plain strings — usage is undefined → fail-open.
+    let calls = 0;
+    const result = await runYamlRecipe(recipe, {
+      ...noop(),
+      claudeFn: async () => {
+        calls++;
+        return `output ${calls}`;
+      },
+    });
+    expect(calls).toBe(2);
+    expect(result.stepResults[0]?.status).toBe("ok");
+    expect(result.stepResults[1]?.status).toBe("ok");
+  });
+});
+
 // ── PR2a — executeAgent return shape (AgentResult union normalization) ───────
 // The runner's claudeFn dep accepts `Promise<string | AgentResult>`. Test
 // mocks return strings (legacy/cheap); bridge wrappers + real adapters

--- a/src/recipes/haltCategory.ts
+++ b/src/recipes/haltCategory.ts
@@ -20,6 +20,8 @@ export type HaltCategory =
   | "tool_error"
   /** Write blocked by the global kill-switch (#422). Distinct from a real tool failure. */
   | "kill_switch"
+  /** Recipe's `tokensMax` budget breached (PR2b). */
+  | "budget_exceeded"
   /** Whole-recipe failure (e.g. circular dependencies) — has no step row. */
   | "run_level"
   | "unknown";
@@ -35,6 +37,8 @@ export function categoriseHaltReason(reason: string | undefined): HaltCategory {
   if (/narration|whitespace|no content/i.test(reason))
     return "agent_narration_only";
   if (/kill[- _]?switch/i.test(reason)) return "kill_switch";
+  if (/budget[_ ]?exceeded|exceeded its token budget/i.test(reason))
+    return "budget_exceeded";
   if (/^Agent step .* threw/i.test(reason)) return "agent_threw";
   if (/^Tool .* threw/i.test(reason)) return "tool_threw";
   if (/^Tool .* reported an error/i.test(reason)) return "tool_error";

--- a/src/recipes/runBudget.ts
+++ b/src/recipes/runBudget.ts
@@ -1,0 +1,140 @@
+/**
+ * Per-recipe token budget — PR2b.
+ *
+ * Built on PR2a's `AgentResult.usage` plumbing. The runner constructs
+ * one `RunBudget` per recipe execution; agent steps consult it before
+ * dispatch (admission) and reconcile actual consumption after the call
+ * returns. On breach the run halts at the *next* admission check (we
+ * never retroactively fail a step that succeeded — the user's tokens
+ * are already spent, halting after-the-fact would just confuse the
+ * audit trail).
+ *
+ * Subscription drivers (Claude CLI, provider subprocess CLIs) don't
+ * surface per-call token counts. `RunBudget` tracks which drivers were
+ * unmeasured and exposes a deduped warnings list — fail-open with a
+ * single notice per driver per run, never block.
+ *
+ * Scope (PR2b only):
+ *   - cumulative token enforcement (input + output)
+ *   - halt-on-breach OR warn-on-breach via `BudgetPolicy.onBreach`
+ *   - subscription-driver fail-open with warning
+ *
+ * Out of scope (future):
+ *   - per-step caps (extend `BudgetPolicy` or add `AgentStep.tokensMax`)
+ *   - `usdMax` (needs a price table; subscription drivers complicate)
+ *   - `wallClockMs` (orthogonal to tokens, separate accounting)
+ */
+
+import type { AgentUsage } from "./agentExecutor.js";
+import type { BudgetPolicy } from "./schema.js";
+
+export interface BudgetAdmission {
+  /** True = step may proceed. False = budget exhausted. */
+  admitted: boolean;
+  /** When `admitted: false`, a one-sentence reason fit for haltReason. */
+  reason?: string;
+}
+
+export interface BudgetTotals {
+  inputTokens: number;
+  outputTokens: number;
+  total: number;
+  /** Remaining tokens before breach. Undefined when no limit is set. */
+  remaining?: number;
+  /** True once total >= tokensMax. */
+  breached: boolean;
+  /** Whether the configured policy halts on breach (vs warn). */
+  haltOnBreach: boolean;
+}
+
+export class RunBudget {
+  private readonly tokensMax?: number;
+  private readonly haltOnBreach: boolean;
+  private inputTokens = 0;
+  private outputTokens = 0;
+  /** Drivers that returned `usage: undefined` during this run, deduped. */
+  private readonly unmeasuredDrivers = new Set<string>();
+  /** Free-form warnings surfaced via the run log. */
+  private readonly warningList: string[] = [];
+
+  constructor(policy?: BudgetPolicy) {
+    this.tokensMax = policy?.tokensMax;
+    this.haltOnBreach = (policy?.onBreach ?? "halt") === "halt";
+  }
+
+  /** Cheap admission check before dispatching an agent step. */
+  admit(): BudgetAdmission {
+    if (this.tokensMax === undefined) return { admitted: true };
+    if (this.breached()) {
+      if (!this.haltOnBreach) {
+        // warn-mode: never block, just keep going. The warning was
+        // already emitted on the post-call reconcile that breached.
+        return { admitted: true };
+      }
+      return {
+        admitted: false,
+        reason: `Run exceeded its token budget — budget_exceeded: total=${this.totalTokens()} > tokensMax=${this.tokensMax}.`,
+      };
+    }
+    return { admitted: true };
+  }
+
+  /**
+   * Record the actual usage reported by an agent call. `usage` may be
+   * undefined when the driver doesn't surface token counts — we record
+   * the driver name once per run and continue (fail-open).
+   */
+  reconcile(driver: string, usage: AgentUsage | undefined): void {
+    if (this.tokensMax === undefined) return;
+    if (!usage) {
+      if (!this.unmeasuredDrivers.has(driver)) {
+        this.unmeasuredDrivers.add(driver);
+        this.warningList.push(
+          `Driver "${driver}" does not report token usage — budget enforcement skipped for its calls. Set recipe.budget.onBreach="warn" or move to an API driver to fix.`,
+        );
+      }
+      return;
+    }
+    this.inputTokens += usage.inputTokens;
+    this.outputTokens += usage.outputTokens;
+    if (this.breached() && !this.haltOnBreach) {
+      // warn-mode: emit a single in-band warning the first time we
+      // cross the line. Subsequent steps continue running.
+      const breachKey = "warn-breach-emitted";
+      if (!this.unmeasuredDrivers.has(breachKey)) {
+        this.unmeasuredDrivers.add(breachKey);
+        this.warningList.push(
+          `Token budget exceeded (total=${this.totalTokens()}, tokensMax=${this.tokensMax}) but onBreach="warn" — continuing.`,
+        );
+      }
+    }
+  }
+
+  /** Snapshot of current totals + breach state. */
+  totals(): BudgetTotals {
+    const total = this.totalTokens();
+    return {
+      inputTokens: this.inputTokens,
+      outputTokens: this.outputTokens,
+      total,
+      ...(this.tokensMax !== undefined && {
+        remaining: Math.max(0, this.tokensMax - total),
+      }),
+      breached: this.breached(),
+      haltOnBreach: this.haltOnBreach,
+    };
+  }
+
+  /** Warnings collected so the runner can surface them in the run log. */
+  warnings(): string[] {
+    return [...this.warningList];
+  }
+
+  private totalTokens(): number {
+    return this.inputTokens + this.outputTokens;
+  }
+
+  private breached(): boolean {
+    return this.tokensMax !== undefined && this.totalTokens() >= this.tokensMax;
+  }
+}

--- a/src/recipes/schema.ts
+++ b/src/recipes/schema.ts
@@ -95,6 +95,35 @@ export interface ErrorPolicy {
   notify?: boolean;
 }
 
+/**
+ * PR2b — per-recipe token budget. When `tokensMax` is set, the runner
+ * tracks cumulative input + output tokens from API drivers across the
+ * run; on breach the run halts with a `budget_exceeded` haltReason
+ * (composes with the existing halt-summary / dashboard / CLI / Prom
+ * surfaces from #441/#444/#451/#452/#453).
+ *
+ * Subscription drivers (Claude CLI, provider subprocess CLIs) don't
+ * report token counts — the runner emits a one-time warning per driver
+ * per run and skips enforcement for those calls (fail-open). API
+ * drivers (Anthropic API, OpenAI/Gemini/Grok subprocess that surfaces
+ * usage, local LLM adapters) get full enforcement.
+ *
+ * Nested object (not flat `tokensMax`) so future siblings — `usdMax`,
+ * `wallClockMs`, `stepsMax` — don't churn the schema again.
+ */
+export interface BudgetPolicy {
+  /** Cumulative input + output tokens allowed across the whole run. */
+  tokensMax?: number;
+  /**
+   * What to do when the budget is breached. `halt` (default) stops the
+   * run on the next admission check with a `budget_exceeded` halt
+   * reason. `warn` continues the run but emits a warning + records the
+   * breach in the run log; useful for tuning budgets without breaking
+   * production cron recipes.
+   */
+  onBreach?: "halt" | "warn";
+}
+
 export interface Recipe {
   name: string;
   version: string;
@@ -109,4 +138,6 @@ export interface Recipe {
    */
   allowWrites?: string[];
   on_error?: ErrorPolicy;
+  /** PR2b — see `BudgetPolicy` above. Absent = no enforcement. */
+  budget?: BudgetPolicy;
 }

--- a/src/recipes/yamlRunner.ts
+++ b/src/recipes/yamlRunner.ts
@@ -49,6 +49,7 @@ import {
   normalizeRecipeForRuntime,
 } from "./legacyRecipeCompat.js";
 import { resolveRecipePath } from "./resolveRecipePath.js";
+import { RunBudget } from "./runBudget.js";
 import type { ErrorPolicy } from "./schema.js";
 import { detectSilentFail } from "./stepObservation.js";
 
@@ -220,6 +221,8 @@ export interface YamlRecipe {
    */
   allowWrites?: string[];
   on_error?: ErrorPolicy;
+  /** PR2b — per-recipe token budget (see `BudgetPolicy` in schema.ts). */
+  budget?: import("./schema.js").BudgetPolicy;
 }
 
 export type RunContext = Record<string, string>;
@@ -486,6 +489,9 @@ export async function runYamlRecipe(
   };
 
   const stepDeps = resolveStepDeps(deps);
+  // PR2b: one per-run budget shared across all agent steps. Absent
+  // `recipe.budget` → no enforcement, no overhead.
+  const runBudget = new RunBudget(recipe.budget);
 
   // Open a `running`-state run-log entry so the dashboard sees the recipe
   // as in flight. Only when a long-lived `runLog` is provided (bridge path);
@@ -555,10 +561,28 @@ export async function runYamlRecipe(
       const stepId = intoKey;
       const stepStart = Date.now();
       let agentResult: string;
-      // PR2a foundation: the executor now returns `{text, usage?}` so
-      // downstream PR2b can enforce per-recipe tokensMax. This call site
-      // discards `.usage` for now — wiring lands in PR2b along with the
-      // RunBudget admission/reconcile path.
+      // PR2b: per-recipe token budget. Admission check before dispatch;
+      // reconcile actual consumption after. Subscription drivers
+      // (Claude CLI, provider subprocess) report `usage === undefined`
+      // — `RunBudget.reconcile` records a fail-open warning per driver
+      // per run and continues.
+      const admission = runBudget.admit();
+      if (!admission.admitted) {
+        const reason =
+          admission.reason ??
+          "Run exceeded its token budget — budget_exceeded.";
+        runError = runError ?? reason;
+        stepResults.push({
+          id: stepId,
+          tool: "agent",
+          status: "error",
+          error: reason,
+          haltReason: reason,
+          durationMs: 0,
+        });
+        stepsRun++;
+        continue;
+      }
       try {
         const agentReturn = await _executeAgent(
           {
@@ -572,6 +596,10 @@ export async function runYamlRecipe(
           buildAgentExecutorDeps(stepDeps, deps),
         );
         agentResult = agentReturn.text;
+        runBudget.reconcile(
+          agentCfg.driver === "api" ? "anthropic" : (agentCfg.driver ?? "auto"),
+          agentReturn.usage,
+        );
         // Catch both `[agent step failed: ...]` (existing) and the
         // silent-fail patterns `[agent step skipped: ...]` etc. via the
         // shared detector. Per-step opt-out via `silentFailDetection: false`.


### PR DESCRIPTION
## Summary

Builds on PR2a's \`AgentResult.usage\` plumbing (#454) to give recipes a hard or soft cap on cumulative agent-step token consumption. Halts on breach by default; opt into warn-only mode with \`onBreach: "warn"\`.

## Recipe schema

\`\`\`yaml
budget:
  tokensMax: 100000        # cumulative input + output
  onBreach: halt           # or "warn" — default halt
\`\`\`

Nested under \`budget:\` (not flat \`tokensMax\`) so future siblings — \`usdMax\`, \`wallClockMs\`, \`stepsMax\` — don't churn the schema again. Field is optional; absent = no enforcement.

## Runtime

New \`src/recipes/runBudget.ts\` — \`RunBudget\` class with \`admit()\` / \`reconcile()\` / \`totals()\` / \`warnings()\`. Runner constructs one per recipe execution; agent steps admit before dispatch, reconcile after.

**Architectural decision from the planning round:** halt happens on the *next* admission check, not retroactively. The tokens are already spent — failing a just-completed step would confuse the audit trail.

## Subscription-driver fail-open

| Driver | Behaviour |
|---|---|
| Anthropic API (\`defaultClaudeFn\`) | Reports usage → full enforcement |
| Local adapters that surface usage | Reports usage → full enforcement |
| Claude CLI (\`claude -p\`) | \`usage === undefined\` → fail-open warning |
| openai/grok/gemini subprocess CLIs | Same — fail-open warning |

Per the architectural plan: CLI drivers can't surface tokens, but we don't want them to silently break budgeted recipes. RunBudget records a **deduped warning per driver per run** and continues. Never blocks.

## Halt-category integration

New \`budget_exceeded\` category in \`haltCategory.ts\` — regex matches "budget_exceeded" / "budget exceeded" / "exceeded its token budget".

**Composes free** with every halt surface shipped today:
- \`/runs/halt-summary\` endpoint (#444) ✅
- Dashboard pill row (#444) ✅
- \`patchwork halts\` CLI (#448) ✅
- Session-start digest HALTS line (#450) ✅
- \`--recipe\` filter (#451) ✅
- Sidebar badge (#452) ✅
- \`bridge_recipe_halts\` Prom gauge (#453) ✅

No new surfaces needed — the new category lights up on every channel because of the convention work already shipped.

## Tests — 10 new across 3 files

- **6 unit tests** for \`RunBudget\` (no-policy, halt-mode breach, warn-mode breach, totals accounting, subscription fail-open dedup, no-warnings-when-no-policy)
- **4 integration tests** in \`yamlRunner.test.ts\` (halt on next step after breach, no enforcement when budget absent, warn-mode lets run continue, subscription fail-open path)
- **1 category test** in \`haltCategory.test.ts\`

## Out of scope (future)

- Per-step \`tokensMax\` cap (would extend \`AgentStep\`)
- \`usdMax\` (needs a price table; subscription drivers complicate honest accounting)
- \`wallClockMs\` (orthogonal — separate accounting)

## Test plan

- [x] 149 affected tests pass
- [x] \`npx tsc -p tsconfig.json --noEmit\` clean
- [x] biome clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)