### PR TITLE
feat(metrics): bridge_recipe_judgments Prometheus gauge (PR3b)

### DIFF
--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -39,6 +39,10 @@ import {
   haltSummaryToPrometheus,
   summariseHalts,
 } from "./recipes/haltCategory.js";
+import {
+  judgeSummaryToPrometheus,
+  summariseJudgments,
+} from "./recipes/judgeSummary.js";
 import { warnAboutLegacyPermissionsSidecars } from "./recipes/migrationWarnings.js";
 import { RecipeOrchestrator } from "./recipes/RecipeOrchestrator.js";
 import { classifyTool } from "./riskTier.js";
@@ -1123,15 +1127,21 @@ export class Bridge {
       // and `patchwork halts`, surfaced through the existing /metrics
       // route.
       let haltLines: string[] = [];
+      let judgeLines: string[] = [];
       try {
         if (this.recipeRunLog) {
           const runs = this.recipeRunLog.query({ limit: 500 });
           haltLines = haltSummaryToPrometheus(summariseHalts(runs));
+          // PR3b — judge verdicts are a separate channel from halts
+          // (augment-only invariant; see judgeVerdict.ts). Same window,
+          // same fail-open posture.
+          judgeLines = judgeSummaryToPrometheus(summariseJudgments(runs));
         }
       } catch {
         /* fail-open: prometheus must never break on log read */
       }
-      return haltLines.length > 0 ? `${base}\n${haltLines.join("\n")}\n` : base;
+      const extras = [...haltLines, ...judgeLines];
+      return extras.length > 0 ? `${base}\n${extras.join("\n")}\n` : base;
     };
     this.server.perfDataFn = () => {
       const windowMs = 60 * 60_000; // 1h window for dashboard

--- a/src/recipes/__tests__/judgeSummary.test.ts
+++ b/src/recipes/__tests__/judgeSummary.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import {
+  judgeSummaryToPrometheus,
+  summariseJudgments,
+} from "../judgeSummary.js";
+import type { JudgeVerdict } from "../judgeVerdict.js";
+
+function v(
+  kind: JudgeVerdict["verdict"],
+  reasons: string[] = [],
+): JudgeVerdict {
+  return { verdict: kind, reasons };
+}
+
+describe("summariseJudgments", () => {
+  it("returns an empty summary for no runs", () => {
+    expect(summariseJudgments([])).toEqual({
+      total: 0,
+      byVerdict: {},
+      recent: [],
+    });
+  });
+
+  it("ignores steps with no judgeVerdict", () => {
+    const summary = summariseJudgments([
+      {
+        seq: 1,
+        stepResults: [{ id: "build" }, { id: "test" }],
+      },
+    ]);
+    expect(summary.total).toBe(0);
+  });
+
+  it("counts verdicts across runs and bucketises by kind", () => {
+    const summary = summariseJudgments([
+      {
+        seq: 3,
+        stepResults: [{ id: "review", judgeVerdict: v("approve", ["lgtm"]) }],
+      },
+      {
+        seq: 2,
+        stepResults: [
+          {
+            id: "review",
+            judgeVerdict: v("request_changes", ["missing tests"]),
+          },
+          { id: "second_pass", judgeVerdict: v("approve") },
+        ],
+      },
+      {
+        seq: 1,
+        stepResults: [{ id: "review", judgeVerdict: v("unparseable") }],
+      },
+    ]);
+    expect(summary.total).toBe(4);
+    expect(summary.byVerdict).toEqual({
+      approve: 2,
+      request_changes: 1,
+      unparseable: 1,
+    });
+  });
+
+  it("caps recent at 5 with newest first (caller-provided order)", () => {
+    const runs = Array.from({ length: 10 }, (_, i) => ({
+      seq: 10 - i,
+      stepResults: [
+        { id: "review", judgeVerdict: v("approve", [`reason ${10 - i}`]) },
+      ],
+    }));
+    const summary = summariseJudgments(runs);
+    expect(summary.recent).toHaveLength(5);
+    expect(summary.recent[0]?.runSeq).toBe(10);
+    expect(summary.recent[0]?.firstReason).toBe("reason 10");
+    expect(summary.recent[0]?.stepId).toBe("review");
+  });
+
+  it("omits firstReason when reasons is empty", () => {
+    const summary = summariseJudgments([
+      {
+        seq: 1,
+        stepResults: [{ id: "r", judgeVerdict: v("approve", []) }],
+      },
+    ]);
+    expect(summary.recent[0]?.firstReason).toBeUndefined();
+  });
+});
+
+describe("judgeSummaryToPrometheus", () => {
+  it("emits no lines on empty summary (no orphan HELP/TYPE)", () => {
+    expect(
+      judgeSummaryToPrometheus({ total: 0, byVerdict: {}, recent: [] }),
+    ).toEqual([]);
+  });
+
+  it("emits HELP, TYPE, and one line per verdict", () => {
+    const lines = judgeSummaryToPrometheus({
+      total: 3,
+      byVerdict: { approve: 2, request_changes: 1 },
+      recent: [],
+    });
+    expect(lines[0]).toContain("# HELP bridge_recipe_judgments");
+    expect(lines[1]).toBe("# TYPE bridge_recipe_judgments gauge");
+    expect(lines).toContain('bridge_recipe_judgments{verdict="approve"} 2');
+    expect(lines).toContain(
+      'bridge_recipe_judgments{verdict="request_changes"} 1',
+    );
+  });
+});

--- a/src/recipes/judgeSummary.ts
+++ b/src/recipes/judgeSummary.ts
@@ -1,0 +1,84 @@
+/**
+ * Judge-verdict aggregation — PR3b.
+ *
+ * Parallel to haltCategory.summariseHalts: walks a window of runs and
+ * counts judge-step verdicts (`approve` / `request_changes` /
+ * `unparseable`). Surfaces through:
+ *
+ *  - `/metrics` as `bridge_recipe_judgments{verdict="..."}` gauge
+ *  - (later) dashboard panel + session-start digest in PR3c
+ *
+ * Augment-only invariant (see judgeVerdict.ts): a `request_changes`
+ * verdict never appears as a HaltCategory and never causes
+ * `status: "error"`. This module is the *separate* channel that makes
+ * cold-eyes review visible without re-introducing gate semantics.
+ */
+import type { JudgeVerdict, JudgeVerdictKind } from "./judgeVerdict.js";
+
+export interface JudgeSummary {
+  /** Total step results scanned that carry a `judgeVerdict`. */
+  total: number;
+  /** Per-verdict counts; verdicts with zero hits are omitted. */
+  byVerdict: Partial<Record<JudgeVerdictKind, number>>;
+  /** Most recent 5 verdicts (with first reason) for UI surfacing. */
+  recent: Array<{
+    verdict: JudgeVerdictKind;
+    firstReason?: string;
+    runSeq: number;
+    stepId: string;
+  }>;
+}
+
+interface JudgeSummaryInputRun {
+  seq: number;
+  stepResults?: Array<{
+    id: string;
+    judgeVerdict?: JudgeVerdict;
+  }>;
+}
+
+/**
+ * Aggregate judge verdicts across a set of runs. Runs are expected to
+ * be sorted newest-first so `recent` reflects the most recent
+ * verdicts.
+ */
+export function summariseJudgments(runs: JudgeSummaryInputRun[]): JudgeSummary {
+  const byVerdict: Partial<Record<JudgeVerdictKind, number>> = {};
+  const recent: JudgeSummary["recent"] = [];
+  let total = 0;
+  for (const run of runs) {
+    for (const step of run.stepResults ?? []) {
+      const v = step.judgeVerdict;
+      if (!v) continue;
+      total++;
+      byVerdict[v.verdict] = (byVerdict[v.verdict] ?? 0) + 1;
+      if (recent.length < 5) {
+        recent.push({
+          verdict: v.verdict,
+          ...(v.reasons[0] !== undefined && { firstReason: v.reasons[0] }),
+          runSeq: run.seq,
+          stepId: step.id,
+        });
+      }
+    }
+  }
+  return { total, byVerdict, recent };
+}
+
+/**
+ * Format a `JudgeSummary` as Prometheus text-exposition lines for the
+ * `bridge_recipe_judgments{verdict="..."} N` gauge. Returns an empty
+ * array when the summary is empty (no HELP/TYPE block so Prom scrapers
+ * don't see an orphan declaration).
+ */
+export function judgeSummaryToPrometheus(summary: JudgeSummary): string[] {
+  if (summary.total === 0) return [];
+  const lines: string[] = [
+    "# HELP bridge_recipe_judgments Recipe judge-step verdicts in the in-memory run-log window, by verdict",
+    "# TYPE bridge_recipe_judgments gauge",
+  ];
+  for (const [verdict, count] of Object.entries(summary.byVerdict)) {
+    lines.push(`bridge_recipe_judgments{verdict="${verdict}"} ${count}`);
+  }
+  return lines;
+}


### PR DESCRIPTION
## Summary
- New module \`src/recipes/judgeSummary.ts\` mirrors \`haltCategory.summariseHalts\` for judge-step verdicts; aggregates \`approve\` / \`request_changes\` / \`unparseable\` counts across the run-log window.
- \`/metrics\` now emits \`bridge_recipe_judgments{verdict="..."}\` gauge lines alongside the existing halt gauge, behind the same fail-open guard.
- Verdicts are a **separate channel** from halts — folding them into \`HaltCategory\` would re-introduce gate semantics and break the PR3a augment-only invariant.

## Test plan
- [x] 7 unit tests in \`judgeSummary.test.ts\`
- [x] Full suite: 5291 tests pass
- [x] \`npm run typecheck\` clean

Composes on #457 (PR3a). Next: PR3c adds the dashboard panel + session-digest line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)