### PR TITLE
feat(runLog): manualRunId field on RecipeRun (PR5b prereq)

### DIFF
--- a/src/__tests__/runLog.test.ts
+++ b/src/__tests__/runLog.test.ts
@@ -419,6 +419,28 @@ describe("RecipeRunLog.record", () => {
     expect(log.getChildSeqs(99)).toEqual([]);
   });
 
+  it("startRun round-trips manualRunId for one logical attempt", () => {
+    const log = new RecipeRunLog({ dir: tmp });
+    const attempt = "mr_2026-05-11_abc123";
+    const seq = log.startRun({
+      taskId: "manual:review:1",
+      recipeName: "review",
+      trigger: "recipe",
+      createdAt: 1_000,
+      manualRunId: attempt,
+    });
+    expect(log.getBySeq(seq)?.manualRunId).toBe(attempt);
+
+    // Omitting the field leaves it unset (cron / webhook runs).
+    const seq2 = log.startRun({
+      taskId: "cron:nightly:2",
+      recipeName: "nightly",
+      trigger: "cron",
+      createdAt: 2_000,
+    });
+    expect(log.getBySeq(seq2)?.manualRunId).toBeUndefined();
+  });
+
   it("record() stores parentSeq from :p<N> triggerSource suffix", () => {
     const log = new RecipeRunLog({ dir: tmp });
     const rec = log.record({

--- a/src/runLog.ts
+++ b/src/runLog.ts
@@ -101,6 +101,18 @@ export interface RecipeRun {
     actual: unknown;
     message: string;
   }>;
+  /**
+   * Stable id for one *logical* user-initiated execution attempt (PR5b
+   * prereq). Distinct from `seq` (which is per *physical* run row): a
+   * retry-after-failure of the same logical attempt re-uses the same
+   * `manualRunId` so the disk-backed WriteEffectLedger can scope dedup
+   * by `(recipeName, manualRunId)` and avoid replaying side effects.
+   *
+   * Optional — cron / webhook / nested-recipe trigger runs leave it
+   * unset. Caller-supplied (the CLI / dashboard mints it); the run log
+   * just round-trips the value.
+   */
+  manualRunId?: string;
 }
 
 const MAX_OUTPUT_TAIL = 2_000;
@@ -332,6 +344,7 @@ export class RecipeRunLog {
     startedAt?: number;
     model?: string;
     parentSeq?: number;
+    manualRunId?: string;
   }): number {
     const seq = ++this.seq;
     const run: RecipeRun = {
@@ -349,6 +362,7 @@ export class RecipeRunLog {
       durationMs: 0,
       stepResults: [],
       ...(opts.parentSeq !== undefined && { parentSeq: opts.parentSeq }),
+      ...(opts.manualRunId !== undefined && { manualRunId: opts.manualRunId }),
     };
     this.runs.push(run);
     if (this.runs.length > this.memoryCap) this.runs.shift();


### PR DESCRIPTION
## Summary
- Adds optional \`manualRunId?: string\` to \`RecipeRun\` and \`startRun(opts)\`.
- Stable id for one *logical* user-initiated execution attempt — re-used across retries so the disk-backed \`WriteEffectLedger\` (PR5b) can scope dedup by \`(recipeName, manualRunId)\`.
- Purely additive; cron / webhook / nested-recipe runs leave the field unset.

## Test plan
- [x] New test covers round-trip + omitted-field default
- [x] \`runLog.test.ts\` 25/25 pass
- [x] \`npm run typecheck\` clean

Independent of #458. Unblocks PR5b (disk-backed effect ledger) and PR5c (resume-from-step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)