### PR TITLE
feat(judge): verdict pill on step row + JUDGMENTS digest line (PR3c)

### DIFF
--- a/dashboard/src/app/runs/[seq]/page.tsx
+++ b/dashboard/src/app/runs/[seq]/page.tsx
@@ -10,6 +10,13 @@ import { diffForStep, previewMockedReplay } from "@/lib/registryDiff";
 
 // ------------------------------------------------------------------ types
 
+interface JudgeVerdict {
+  verdict: "approve" | "request_changes" | "unparseable";
+  reasons: string[];
+  fixList?: string[];
+  raw?: string;
+}
+
 interface StepResult {
   id: string;
   tool?: string;
@@ -17,6 +24,8 @@ interface StepResult {
   error?: string;
   /** One-sentence human-actionable halt reason for error rows. */
   haltReason?: string;
+  /** PR3a — cold-eyes judge verdict. Augment-only: never affects status. */
+  judgeVerdict?: JudgeVerdict;
   durationMs: number;
   // VD-2 capture (all optional — pre-VD-2 runs don't have these).
   resolvedParams?: unknown;
@@ -162,6 +171,72 @@ function stepStatusLabel(status: StepResult["status"]): string {
   return "skipped";
 }
 
+function verdictPalette(
+  verdict: JudgeVerdict["verdict"],
+): { bg: string; fg: string; label: string } {
+  if (verdict === "approve") {
+    return { bg: "var(--ok-bg, #1b3a1b)", fg: "var(--ok)", label: "approve" };
+  }
+  if (verdict === "request_changes") {
+    return {
+      bg: "var(--warn-bg, #3a2a1b)",
+      fg: "var(--warn, #d49a3a)",
+      label: "request_changes",
+    };
+  }
+  return {
+    bg: "var(--bg-2)",
+    fg: "var(--fg-2)",
+    label: "unparseable",
+  };
+}
+
+function JudgeVerdictPill({ verdict }: { verdict: JudgeVerdict }) {
+  const { bg, fg, label } = verdictPalette(verdict.verdict);
+  const firstReason = verdict.reasons[0];
+  return (
+    <div
+      style={{
+        marginTop: 4,
+        display: "flex",
+        gap: 6,
+        flexWrap: "wrap",
+        alignItems: "center",
+      }}
+    >
+      <span
+        className="mono"
+        style={{
+          fontSize: "var(--fs-xs)",
+          padding: "1px 6px",
+          borderRadius: 3,
+          background: bg,
+          color: fg,
+          letterSpacing: "0.02em",
+        }}
+        title="cold-eyes judge verdict (augment-only — never gates the run)"
+      >
+        judge: {label}
+      </span>
+      {firstReason && (
+        <span
+          className="muted"
+          style={{
+            fontSize: "var(--fs-xs)",
+            whiteSpace: "normal",
+            wordBreak: "break-word",
+          }}
+        >
+          {firstReason}
+          {verdict.reasons.length > 1 && (
+            <> +{verdict.reasons.length - 1} more</>
+          )}
+        </span>
+      )}
+    </div>
+  );
+}
+
 function StepRow({
   step,
   index,
@@ -275,6 +350,9 @@ function StepRow({
             >
               {step.haltReason}
             </div>
+          )}
+          {step.judgeVerdict && (
+            <JudgeVerdictPill verdict={step.judgeVerdict} />
           )}
           <div
             style={{

--- a/src/tools/__tests__/recentTracesDigest.test.ts
+++ b/src/tools/__tests__/recentTracesDigest.test.ts
@@ -372,4 +372,76 @@ describe("buildRecentTracesDigest — decision formatting", () => {
       expect(lines.every((l) => !l.startsWith("HALTS"))).toBe(true);
     });
   });
+
+  // ── PR3c — JUDGMENTS one-liner ───────────────────────────────────────────
+  describe("JUDGMENTS line", () => {
+    it("prepends a verdict summary when recent runs include judgeVerdicts", async () => {
+      const now = Date.now();
+      runLog.appendDirect({
+        taskId: "t-j1",
+        recipeName: "review",
+        trigger: "recipe",
+        status: "done",
+        createdAt: now - 60_000,
+        startedAt: now - 60_000,
+        doneAt: now - 30_000,
+        durationMs: 30_000,
+        stepResults: [
+          {
+            id: "review",
+            status: "ok",
+            durationMs: 800,
+            judgeVerdict: {
+              verdict: "approve",
+              reasons: ["small diff"],
+            },
+          },
+        ],
+      });
+      runLog.appendDirect({
+        taskId: "t-j2",
+        recipeName: "review",
+        trigger: "recipe",
+        status: "done",
+        createdAt: now - 120_000,
+        startedAt: now - 120_000,
+        doneAt: now - 90_000,
+        durationMs: 30_000,
+        stepResults: [
+          {
+            id: "review",
+            status: "ok",
+            durationMs: 800,
+            judgeVerdict: {
+              verdict: "request_changes",
+              reasons: ["missing tests"],
+            },
+          },
+        ],
+      });
+
+      const lines = await buildRecentTracesDigest({ recipeRunLog: runLog });
+      const judgeLine = lines.find((l) => l.startsWith("JUDGMENTS"));
+      expect(judgeLine).toBeDefined();
+      expect(judgeLine).toContain("JUDGMENTS (last 12h): 2");
+      expect(judgeLine).toContain("approve·1");
+      expect(judgeLine).toContain("request_changes·1");
+    });
+
+    it("omits the JUDGMENTS line when no recent runs carry a verdict", async () => {
+      runLog.appendDirect({
+        taskId: "t-ok",
+        recipeName: "happy",
+        trigger: "cron",
+        status: "done",
+        createdAt: Date.now() - 1000,
+        startedAt: Date.now() - 1000,
+        doneAt: Date.now() - 500,
+        durationMs: 500,
+        stepResults: [],
+      });
+      const lines = await buildRecentTracesDigest({ recipeRunLog: runLog });
+      expect(lines.every((l) => !l.startsWith("JUDGMENTS"))).toBe(true);
+    });
+  });
 });

--- a/src/tools/recentTracesDigest.ts
+++ b/src/tools/recentTracesDigest.ts
@@ -2,6 +2,7 @@ import type { ActivityLog } from "../activityLog.js";
 import type { CommitIssueLinkLog } from "../commitIssueLinkLog.js";
 import type { DecisionTraceLog } from "../decisionTraceLog.js";
 import { summariseHalts } from "../recipes/haltCategory.js";
+import { summariseJudgments } from "../recipes/judgeSummary.js";
 import type { RecipeRunLog } from "../runLog.js";
 import { createCtxQueryTracesTool } from "./ctxQueryTraces.js";
 
@@ -150,6 +151,7 @@ export async function buildRecentTracesDigest(
   // even when there are no decision traces — halts are signal on their
   // own.
   let haltLine: string | null = null;
+  let judgeLine: string | null = null;
   if (deps.recipeRunLog) {
     const cutoff = now - windowMs;
     const recentRuns = deps.recipeRunLog
@@ -163,12 +165,25 @@ export async function buildRecentTracesDigest(
         .join(" ");
       haltLine = `HALTS (last 12h): ${halts.total} — ${breakdown}`;
     }
+    // PR3c — same window, parallel channel. Surfaced separately from
+    // halts to preserve the augment-only invariant (a request_changes
+    // verdict is not a failure). Useful for "the judge has been
+    // asking for changes a lot lately".
+    const judgments = summariseJudgments(recentRuns);
+    if (judgments.total > 0) {
+      const breakdown = Object.entries(judgments.byVerdict)
+        .sort(([, a], [, b]) => b - a)
+        .map(([v, count]) => `${v}·${count}`)
+        .join(" ");
+      judgeLine = `JUDGMENTS (last 12h): ${judgments.total} — ${breakdown}`;
+    }
   }
 
-  // If there's nothing on either axis, skip the section entirely.
-  if (!haltLine && top.length === 0) return [];
+  // If there's nothing on any axis, skip the section entirely.
+  if (!haltLine && !judgeLine && top.length === 0) return [];
 
   if (haltLine) lines.push(haltLine);
+  if (judgeLine) lines.push(judgeLine);
   if (top.length > 0) {
     lines.push("RECENT DECISIONS (last 12h):");
     for (const t of top) {
@@ -180,7 +195,8 @@ export async function buildRecentTracesDigest(
   // Hard byte cap — keep dropping oldest decision entries until under budget.
   // The halt line + DECISIONS heading are the floor (length 2 when both
   // present, 1 when only one). Don't pop past the floor.
-  const floor = (haltLine ? 1 : 0) + (top.length > 0 ? 1 : 0);
+  const floor =
+    (haltLine ? 1 : 0) + (judgeLine ? 1 : 0) + (top.length > 0 ? 1 : 0);
   while (lines.join("\n").length > MAX_BYTES && lines.length > floor) {
     lines.pop();
   }


### PR DESCRIPTION
## Summary
- Dashboard \`/runs/[seq]\` step row renders a colour-coded \`judge: approve|request_changes|unparseable\` pill + first reason when the step carries a \`judgeVerdict\`. Augment-only — never affects the step/run status pill.
- Session-start digest gains a \`JUDGMENTS (last 12h)\` one-liner with per-verdict counts, sibling to the existing \`HALTS\` line. Floor calculation updated so the byte cap doesn't drop either summary line.
- 2 new tests for the digest line.

Composes #457 (judge step) + #458 (judgeSummary aggregate). Closes out PR3 trilogy.

## Test plan
- [x] \`recentTracesDigest.test.ts\` 19/19 pass (2 new for JUDGMENTS line)
- [x] bridge \`npm run typecheck\` clean
- [x] dashboard \`tsc --noEmit\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)