### PR TITLE
feat(recipes): disk-backed WriteEffectLedger (PR5b, opt-in)

### DIFF
--- a/src/recipes/__tests__/idempotencyKey.test.ts
+++ b/src/recipes/__tests__/idempotencyKey.test.ts
@@ -1,4 +1,7 @@
-import { describe, expect, it } from "vitest";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { deriveIdempotencyKey, WriteEffectLedger } from "../idempotencyKey.js";
 
 describe("deriveIdempotencyKey", () => {
@@ -101,5 +104,92 @@ describe("WriteEffectLedger", () => {
     ledger.record("b", "2");
     expect(ledger.size()).toBe(2);
     expect(ledger.keys().sort()).toEqual(["a", "b"]);
+  });
+});
+
+describe("WriteEffectLedger — disk-backed (PR5b)", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(path.join(os.tmpdir(), "effect-ledger-"));
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  it("persists records to effect_ledger.jsonl scoped by (recipeName, manualRunId)", () => {
+    const ledger = new WriteEffectLedger({
+      dir,
+      scopeKey: "post-notify:mr_abc",
+    });
+    ledger.record("k1", "ok");
+    ledger.record("k2", null);
+    const file = path.join(dir, "effect_ledger.jsonl");
+    const rows = readFileSync(file, "utf-8")
+      .trim()
+      .split("\n")
+      .map((l) => JSON.parse(l));
+    expect(rows).toHaveLength(2);
+    expect(rows[0].scopeKey).toBe("post-notify:mr_abc");
+    expect(rows[0].idemKey).toBe("k1");
+    expect(rows[0].output).toBe("ok");
+    expect(rows[1].output).toBeNull();
+  });
+
+  it("rehydrates only entries matching its scopeKey", () => {
+    // Pre-populate the ledger with three rows: two for our scope, one
+    // for a different attempt. A new ledger must only see its own.
+    const file = path.join(dir, "effect_ledger.jsonl");
+    const rows = [
+      {
+        scopeKey: "review:mr_a",
+        idemKey: "k1",
+        output: "first",
+        recordedAt: 1,
+      },
+      { scopeKey: "review:mr_a", idemKey: "k2", output: null, recordedAt: 2 },
+      {
+        scopeKey: "other:mr_b",
+        idemKey: "k1",
+        output: "off-scope",
+        recordedAt: 3,
+      },
+    ];
+    writeFileSync(file, `${rows.map((r) => JSON.stringify(r)).join("\n")}\n`);
+
+    const ledger = new WriteEffectLedger({ dir, scopeKey: "review:mr_a" });
+    expect(ledger.size()).toBe(2);
+    expect(ledger.has("k1")).toBe(true);
+    expect(ledger.get("k1")).toBe("first");
+    expect(ledger.get("k2")).toBeNull();
+
+    const offScope = new WriteEffectLedger({ dir, scopeKey: "review:mr_b" });
+    expect(offScope.size()).toBe(0);
+  });
+
+  it("retry of the same logical attempt sees prior records (resume semantics)", () => {
+    const opts = { dir, scopeKey: "deploy:mr_xyz" };
+    const first = new WriteEffectLedger(opts);
+    first.record("slack-post-hash", "sent");
+    // New process / new ledger constructed with same scope key.
+    const second = new WriteEffectLedger(opts);
+    expect(second.has("slack-post-hash")).toBe(true);
+    expect(second.get("slack-post-hash")).toBe("sent");
+  });
+
+  it("skips malformed rows without crashing", () => {
+    const file = path.join(dir, "effect_ledger.jsonl");
+    writeFileSync(
+      file,
+      `not-json\n${JSON.stringify({ scopeKey: "s:1", idemKey: "k", output: "v", recordedAt: 1 })}\n{}\n`,
+    );
+    const ledger = new WriteEffectLedger({ dir, scopeKey: "s:1" });
+    expect(ledger.size()).toBe(1);
+    expect(ledger.get("k")).toBe("v");
+  });
+
+  it("in-memory ledger (no disk option) writes no file", () => {
+    const ledger = new WriteEffectLedger();
+    ledger.record("k", "v");
+    // Nothing was passed for dir, so the temp dir should remain empty.
+    expect(() => readFileSync(path.join(dir, "effect_ledger.jsonl"))).toThrow();
+    expect(ledger.size()).toBe(1);
   });
 });

--- a/src/recipes/idempotencyKey.ts
+++ b/src/recipes/idempotencyKey.ts
@@ -40,6 +40,15 @@
  */
 
 import { createHash } from "node:crypto";
+import {
+  appendFileSync,
+  mkdirSync,
+  readFileSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import path from "node:path";
+import type { Logger } from "../logger.js";
 
 /**
  * Stable canonical-JSON serialiser. Recursively sorts object keys so two
@@ -87,8 +96,63 @@ export function deriveIdempotencyKey(
  * with no shared params hash by construction); the ledger catches
  * accidental same-params calls.
  */
+/**
+ * Optional disk-backed persistence for the ledger.
+ *
+ * PR5b — extends in-memory dedup so a *retry* of the same logical
+ * `(recipeName, manualRunId)` attempt won't replay side effects. The
+ * ledger stays per-attempt; cron/webhook runs and recipes without a
+ * manualRunId stay purely in memory (no scope key = nothing to write).
+ *
+ * File layout: a single JSONL at `${dir}/effect_ledger.jsonl`. Each row
+ * is `{scopeKey, idemKey, output, recordedAt}`. On construction, the
+ * ledger streams the file and rehydrates entries whose `scopeKey`
+ * matches the configured scope; everything else is left alone for the
+ * other attempts' ledgers to pick up.
+ *
+ * Failure mode: any IO error falls back to in-memory operation and logs
+ * a warning. A partially-replayed attempt with an unreadable ledger
+ * degrades to "re-execute side effects" — louder than "silently dedup
+ * something we can't audit".
+ */
+export interface DiskLedgerOptions {
+  /** Directory holding `effect_ledger.jsonl`. Created if missing. */
+  dir: string;
+  /** `${recipeName}:${manualRunId}` — composed by the caller. */
+  scopeKey: string;
+  logger?: Logger;
+}
+
+interface LedgerRow {
+  scopeKey: string;
+  idemKey: string;
+  output: string | null;
+  recordedAt: number;
+}
+
+const LEDGER_FILENAME = "effect_ledger.jsonl";
+const MAX_PERSIST_BYTES = 1024 * 1024; // 1 MB — same posture as runLog
+const MAX_PERSIST_LINES = 10_000;
+
 export class WriteEffectLedger {
   private readonly cache = new Map<string, string | null>();
+  private readonly disk: DiskLedgerOptions | null;
+  private readonly file: string | null;
+
+  constructor(disk?: DiskLedgerOptions) {
+    this.disk = disk ?? null;
+    this.file = disk ? path.join(disk.dir, LEDGER_FILENAME) : null;
+    if (this.disk && this.file) {
+      try {
+        mkdirSync(this.disk.dir, { recursive: true, mode: 0o700 });
+      } catch (err) {
+        this.disk.logger?.warn?.(
+          `[effect-ledger] could not create ${this.disk.dir}: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+      this.loadExisting();
+    }
+  }
 
   has(key: string): boolean {
     return this.cache.has(key);
@@ -106,6 +170,14 @@ export class WriteEffectLedger {
 
   record(key: string, output: string | null): void {
     this.cache.set(key, output);
+    if (this.disk && this.file) {
+      this.append({
+        scopeKey: this.disk.scopeKey,
+        idemKey: key,
+        output,
+        recordedAt: Date.now(),
+      });
+    }
   }
 
   /** Test-only inspection of the current key set. */
@@ -115,5 +187,84 @@ export class WriteEffectLedger {
 
   size(): number {
     return this.cache.size;
+  }
+
+  private loadExisting(): void {
+    if (!this.disk || !this.file) return;
+    let raw: string;
+    try {
+      statSync(this.file);
+      raw = readFileSync(this.file, "utf-8");
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code !== "ENOENT") {
+        this.disk.logger?.warn?.(
+          `[effect-ledger] read failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+      return;
+    }
+    for (const line of raw.split("\n")) {
+      if (!line) continue;
+      try {
+        const row = JSON.parse(line) as LedgerRow;
+        if (
+          typeof row.scopeKey !== "string" ||
+          typeof row.idemKey !== "string"
+        ) {
+          continue;
+        }
+        if (row.scopeKey === this.disk.scopeKey) {
+          this.cache.set(row.idemKey, row.output ?? null);
+        }
+      } catch {
+        /* skip malformed row */
+      }
+    }
+  }
+
+  private append(row: LedgerRow): void {
+    if (!this.disk || !this.file) return;
+    try {
+      try {
+        const st = statSync(this.file);
+        if (st.size > MAX_PERSIST_BYTES) this.rotate();
+      } catch (err) {
+        const code = (err as NodeJS.ErrnoException).code;
+        if (code !== "ENOENT") throw err;
+      }
+      appendFileSync(this.file, `${JSON.stringify(row)}\n`, { mode: 0o600 });
+    } catch (err) {
+      this.disk.logger?.warn?.(
+        `[effect-ledger] append failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  /**
+   * Trim `effect_ledger.jsonl` to the most recent MAX_PERSIST_LINES.
+   * Best-effort — failure logs and the next append proceeds against the
+   * un-rotated file. Same pattern as RecipeRunLog / DecisionTraceLog.
+   */
+  private rotate(): void {
+    if (!this.file || !this.disk) return;
+    try {
+      const raw = readFileSync(this.file, "utf-8");
+      let lines = raw.split("\n").filter((l) => l.trim());
+      if (lines.length > MAX_PERSIST_LINES) {
+        lines = lines.slice(-MAX_PERSIST_LINES);
+      }
+      writeFileSync(
+        this.file,
+        lines.length > 0 ? `${lines.join("\n")}\n` : "",
+        {
+          mode: 0o600,
+        },
+      );
+    } catch (err) {
+      this.disk.logger?.warn?.(
+        `[effect-ledger] rotate failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
   }
 }


### PR DESCRIPTION
## Summary
- \`WriteEffectLedger\` now accepts an optional \`DiskLedgerOptions { dir, scopeKey, logger? }\` constructor arg. When provided, records persist to \`\${dir}/effect_ledger.jsonl\` and are rehydrated on construction — but only the rows matching the configured \`scopeKey\` (\`\${recipeName}:\${manualRunId}\`, from PR #459).
- Existing callers (no argument) keep pure in-memory dedup — cron / webhook / nested-recipe runs have no manualRunId and shouldn't share a scope.
- 5 new tests: round-trip, scope-key isolation, resume semantics, malformed-row tolerance, no-disk = no file.

## Test plan
- [x] \`idempotencyKey.test.ts\` 15/15 pass (5 new)
- [x] Full suite: 5299 tests pass
- [x] \`npm run typecheck\` clean

Composes on #459 (manualRunId field). Next: wire orchestrator to construct the ledger with the proper scope (small follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)