### PR TITLE
feat(recipes): resume via --attempt id (PR5c, closes PR5 trilogy)

### DIFF
--- a/src/commands/__tests__/recipe.test.ts
+++ b/src/commands/__tests__/recipe.test.ts
@@ -1,6 +1,7 @@
 import {
   existsSync,
   mkdirSync,
+  mkdtempSync,
   readdirSync,
   readFileSync,
   rmSync,
@@ -3036,6 +3037,97 @@ trigger:
       } finally {
         vi.useRealTimers();
       }
+    });
+  });
+
+  // ── PR5c — resume support via --attempt / manualRunId ──────────────────────
+  describe("runRecipe — manualRunId + ledgerDir resume semantics", () => {
+    it("a second runRecipe call with the same (manualRunId, ledgerDir) short-circuits the duplicate write tool", async () => {
+      const ledgerDir = mkdtempSync(join(os.tmpdir(), "resume-ledger-"));
+      const outPath = join(tmpDir, "resume-out.txt");
+      const recipePath = join(tmpDir, "resume-recipe.yaml");
+      writeFileSync(
+        recipePath,
+        `name: resume-test
+description: PR5c resume scope
+trigger:
+  type: manual
+steps:
+  - id: write_once
+    tool: file.write
+    path: ${JSON.stringify(outPath)}
+    content: "first-call"
+`,
+      );
+
+      const attempt = "mr_resume_test_1";
+
+      // First call: file.write runs the side effect AND records its
+      // idempotency key in the disk ledger.
+      const first = await runRecipe(recipePath, {
+        manualRunId: attempt,
+        ledgerDir,
+      });
+      expect("stepsRun" in first.result && first.result.stepsRun).toBe(1);
+      expect(readFileSync(outPath, "utf-8")).toBe("first-call");
+
+      // Overwrite the file behind the runner's back. If the second
+      // runRecipe re-executes file.write, this content will be replaced
+      // back to "first-call". If short-circuit works, the marker stays.
+      writeFileSync(outPath, "tampered");
+
+      // Second call: same attempt id, same ledger dir → the disk-backed
+      // ledger rehydrates from the JSONL on construction, sees the
+      // matching idempotency key, and short-circuits the call.
+      const second = await runRecipe(recipePath, {
+        manualRunId: attempt,
+        ledgerDir,
+      });
+      expect("stepsRun" in second.result && second.result.stepsRun).toBe(1);
+      expect(readFileSync(outPath, "utf-8")).toBe("tampered");
+
+      // Sanity: ledger file written and contains our scope key.
+      const ledgerFile = join(ledgerDir, "effect_ledger.jsonl");
+      const rows = readFileSync(ledgerFile, "utf-8")
+        .trim()
+        .split("\n")
+        .map((l) => JSON.parse(l));
+      expect(rows.length).toBeGreaterThanOrEqual(1);
+      expect(rows[0].scopeKey).toBe(`resume-test:${attempt}`);
+      rmSync(ledgerDir, { recursive: true, force: true });
+    });
+
+    it("a different manualRunId on the second call re-executes (different scope)", async () => {
+      const ledgerDir = mkdtempSync(join(os.tmpdir(), "resume-ledger-"));
+      const outPath = join(tmpDir, "rescope-out.txt");
+      const recipePath = join(tmpDir, "rescope-recipe.yaml");
+      writeFileSync(
+        recipePath,
+        `name: rescope-test
+description: PR5c scope isolation
+trigger:
+  type: manual
+steps:
+  - id: write_once
+    tool: file.write
+    path: ${JSON.stringify(outPath)}
+    content: "from-attempt"
+`,
+      );
+
+      await runRecipe(recipePath, {
+        manualRunId: "mr_a",
+        ledgerDir,
+      });
+      writeFileSync(outPath, "tampered");
+
+      // Different attempt id → different scope → re-executes.
+      await runRecipe(recipePath, {
+        manualRunId: "mr_b",
+        ledgerDir,
+      });
+      expect(readFileSync(outPath, "utf-8")).toBe("from-attempt");
+      rmSync(ledgerDir, { recursive: true, force: true });
     });
   });
 });

--- a/src/commands/recipe.ts
+++ b/src/commands/recipe.ts
@@ -1043,6 +1043,20 @@ export interface RunRecipeOptions {
   vars?: Record<string, string>;
   workdir?: string;
   deps?: Partial<RunnerDeps>;
+  /**
+   * PR5c — stable id for one *logical* execution attempt. Forwarded to
+   * RunnerDeps so the runner constructs a disk-backed WriteEffectLedger
+   * scoped by `${recipe.name}:${manualRunId}`. Re-using the same id on
+   * a retry replays prior dedup records and skips already-completed
+   * write tools (resume semantics).
+   */
+  manualRunId?: string;
+  /**
+   * PR5c — directory holding `effect_ledger.jsonl`. Required for the
+   * disk-backed ledger; without it the ledger stays in-memory even
+   * when manualRunId is set.
+   */
+  ledgerDir?: string;
 }
 
 export interface RunRecipeStepSelection {
@@ -1098,6 +1112,8 @@ export async function runRecipe(
   const runnerDeps: RunnerDeps = {
     ...options.deps,
     workdir: options.workdir ?? options.deps?.workdir ?? process.cwd(),
+    ...(options.manualRunId && { manualRunId: options.manualRunId }),
+    ...(options.ledgerDir && { ledgerDir: options.ledgerDir }),
   };
   if (options.dryRun) {
     throw new Error("runRecipeDryPlan must be used for dry-run execution");

--- a/src/index.ts
+++ b/src/index.ts
@@ -1178,11 +1178,13 @@ if (process.argv[2] === "recipe" && process.argv[3] === "uninstall") {
 if (process.argv[2] === "recipe" && process.argv[3] === "run") {
   const args = process.argv.slice(4);
   const usage =
-    "Usage: patchwork recipe run <name-or-file> [--local] [--dry-run] [--step <id>] [--var KEY=VALUE]\n";
+    "Usage: patchwork recipe run <name-or-file> [--local] [--dry-run] [--step <id>] [--var KEY=VALUE] [--attempt <id>] [--ledger-dir <path>]\n";
   let localFlag = false;
   let dryRun = false;
   let recipeRef: string | undefined;
   let step: string | undefined;
+  let attemptId: string | undefined;
+  let ledgerDir: string | undefined;
   const vars: Record<string, string> = {};
 
   for (let i = 0; i < args.length; i++) {
@@ -1211,6 +1213,35 @@ if (process.argv[2] === "recipe" && process.argv[3] === "run") {
         process.exit(1);
       }
       step = value;
+      continue;
+    }
+
+    if (currentArg === "--attempt" || currentArg.startsWith("--attempt=")) {
+      const value =
+        currentArg === "--attempt"
+          ? args[++i]
+          : currentArg.slice("--attempt=".length);
+      if (!value) {
+        process.stderr.write(`Error: --attempt requires a value\n${usage}`);
+        process.exit(1);
+      }
+      attemptId = value;
+      continue;
+    }
+
+    if (
+      currentArg === "--ledger-dir" ||
+      currentArg.startsWith("--ledger-dir=")
+    ) {
+      const value =
+        currentArg === "--ledger-dir"
+          ? args[++i]
+          : currentArg.slice("--ledger-dir=".length);
+      if (!value) {
+        process.stderr.write(`Error: --ledger-dir requires a value\n${usage}`);
+        process.exit(1);
+      }
+      ledgerDir = value;
       continue;
     }
 
@@ -1266,7 +1297,7 @@ if (process.argv[2] === "recipe" && process.argv[3] === "run") {
       })();
       const { findBridgeLock } = await import("./bridgeLockDiscovery.js");
       const lock = localFlag ? null : findBridgeLock();
-      if (lock && !dryRun && !step && !explicitFile) {
+      if (lock && !dryRun && !step && !explicitFile && !attemptId) {
         const res = await fetch(`http://127.0.0.1:${lock.port}/recipes/run`, {
           method: "POST",
           headers: {
@@ -1323,9 +1354,28 @@ if (process.argv[2] === "recipe" && process.argv[3] === "run") {
           : `  Running recipe "${recipeArg}" locally…\n`,
       );
       const workdir = lock?.workspace || process.cwd();
+      // PR5c — resume support: when --attempt is given, mint or reuse a
+      // stable id and point the runner at a disk-backed effect ledger.
+      // `--attempt new` always mints a fresh id; any other value is
+      // taken verbatim (so the user can re-run the same attempt and
+      // skip already-completed write tools).
+      let resolvedAttempt: string | undefined;
+      let resolvedLedgerDir: string | undefined;
+      if (attemptId !== undefined) {
+        resolvedAttempt =
+          attemptId === "new"
+            ? `mr_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`
+            : attemptId;
+        resolvedLedgerDir = ledgerDir ?? path.join(os.homedir(), ".patchwork");
+        process.stdout.write(
+          `  Attempt id: ${resolvedAttempt} (ledger: ${resolvedLedgerDir})\n`,
+        );
+      }
       const run = await runRecipe(recipeArg, {
         ...(step ? { step } : {}),
         ...(seedVars ? { vars: seedVars } : {}),
+        ...(resolvedAttempt && { manualRunId: resolvedAttempt }),
+        ...(resolvedLedgerDir && { ledgerDir: resolvedLedgerDir }),
         workdir,
       });
       if (run.stepSelection) {


### PR DESCRIPTION
## Summary
- New CLI flags: \`--attempt <id>\` (or \`--attempt new\` to mint one) and \`--ledger-dir <path>\` (defaults to \`~/.patchwork\`) on \`patchwork recipe run\`.
- New \`runRecipe\` options: \`manualRunId\` + \`ledgerDir\` forward through to \`RunnerDeps\` so SDK callers can drive resume programmatically.
- Re-running the same \`(recipeName, manualRunId)\` short-circuits already-completed write tools instead of replaying side effects.
- Bridge fast-path bypassed when \`--attempt\` is set (resume needs the local runner to construct the disk-backed ledger).

Composes #459 (\`manualRunId\` field) + #461 (disk-backed ledger class) + #462 (orchestrator wiring). End of the PR5 trilogy.

## Test plan
- [x] 2 end-to-end tests in \`recipe.test.ts\` verify scope isolation + short-circuit via \`file.write\`
- [x] Full suite: 5301 tests pass
- [x] \`npm run typecheck\` clean
- [x] biome clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)