### PR TITLE
feat(dashboard): surface manualRunId on /runs and /runs/[seq]

### DIFF
--- a/dashboard/src/app/runs/[seq]/page.tsx
+++ b/dashboard/src/app/runs/[seq]/page.tsx
@@ -60,6 +60,8 @@ interface RunDetail {
   parentSeq?: number;
   /** seqs of runs triggered by this run. */
   childSeqs?: number[];
+  /** PR5c — stable id shared across resumed retries of the same attempt. */
+  manualRunId?: string;
 }
 
 interface PlanStep {
@@ -1191,6 +1193,18 @@ export default function RunDetailPage() {
                 <div>
                   <div style={{ fontSize: "var(--fs-2xs)", color: "var(--fg-2)", marginBottom: 2 }}>MODEL</div>
                   <span className="mono" style={{ fontSize: "var(--fs-s)" }}>{run.model}</span>
+                </div>
+              )}
+              {run.manualRunId && (
+                <div>
+                  <div style={{ fontSize: "var(--fs-2xs)", color: "var(--fg-2)", marginBottom: 2 }}>ATTEMPT</div>
+                  <span
+                    className="mono"
+                    style={{ fontSize: "var(--fs-s)" }}
+                    title="Stable id across resumed retries of the same logical attempt (PR5c)"
+                  >
+                    {run.manualRunId}
+                  </span>
                 </div>
               )}
             </div>

--- a/dashboard/src/app/runs/page.tsx
+++ b/dashboard/src/app/runs/page.tsx
@@ -54,6 +54,8 @@ interface Run {
   outputTail?: string;
   errorMessage?: string;
   assertionFailures?: AssertionFailure[];
+  /** PR5c — stable id for one logical retry-attempt; ties resumed runs together. */
+  manualRunId?: string;
 }
 
 type TriggerFilter = "all" | "cron" | "webhook" | "recipe" | "manual" | "git_hook";
@@ -509,6 +511,18 @@ export default function RunsPage() {
                       </td>
                       <td>
                         <span className="pill muted">{normaliseTrigger(r.trigger)}</span>
+                        {r.manualRunId && (
+                          <span
+                            className="pill muted mono"
+                            style={{
+                              marginLeft: 6,
+                              fontSize: "var(--fs-2xs)",
+                            }}
+                            title={`Attempt id ${r.manualRunId} — same id across runs = a resumed retry`}
+                          >
+                            attempt:{r.manualRunId.slice(-6)}
+                          </span>
+                        )}
                       </td>
                       <td>
                         <span


### PR DESCRIPTION
## Summary
- \`/runs\` row: small \`attempt:<last6>\` pill rendered next to the trigger pill when a run has a \`manualRunId\`. Lets users spot resumed-retry pairs without clicking through.
- \`/runs/[seq]\` header: full \`ATTEMPT\` field rendered in the metadata strip.
- Purely cosmetic, additive; runs without \`manualRunId\` are unchanged.

Composes on #463 (PR5c resume CLI). Closes the PR5 visibility loop — every channel that surfaces halts now also surfaces attempts.

## Test plan
- [x] Dashboard \`tsc --noEmit\` clean
- [x] Pre-PR5c runs (no \`manualRunId\`) render exactly as before
- [ ] Manual: trigger two resumed runs with same \`--attempt\` id; both rows show matching pills

🤖 Generated with [Claude Code](https://claude.com/claude-code)