### PR TITLE
feat(runs): filter by manualRunId end-to-end

### DIFF
--- a/dashboard/src/app/runs/page.tsx
+++ b/dashboard/src/app/runs/page.tsx
@@ -2,6 +2,7 @@
 import React from "react";
 import { apiPath } from "@/lib/api";
 import Link from "next/link";
+import { useSearchParams } from "next/navigation";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { LivePill } from "@/components/patchwork/LivePill";
 import { ErrorState } from "@/components/patchwork";
@@ -150,6 +151,13 @@ export default function RunsPage() {
   const [haltSummary, setHaltSummary] = useState<HaltSummary | null>(null);
   const [recipeQuery, setRecipeQuery] = useState("");
   const debouncedRecipeQuery = useDebounced(recipeQuery, 250);
+  // PR5c follow-up: read `?attempt=<id>` from URL to deep-link runs that
+  // share a manualRunId. Cleared via the same "clear filters" pill.
+  const searchParams = useSearchParams();
+  const [attemptFilter, setAttemptFilter] = useState<string>("");
+  useEffect(() => {
+    setAttemptFilter(searchParams?.get("attempt") ?? "");
+  }, [searchParams]);
   const [limit, setLimit] = useState(RUNS_PAGE_SIZE);
   const [expanded, setExpanded] = useState<string | null>(null);
 
@@ -162,6 +170,7 @@ export default function RunsPage() {
         if (trigger !== "all") params.set("trigger", trigger);
         if (status !== "all") params.set("status", status);
         if (debouncedRecipeQuery) params.set("recipe", debouncedRecipeQuery);
+        if (attemptFilter) params.set("manualRunId", attemptFilter);
         const res = await fetch(apiPath(`/api/bridge/runs?${params}`));
         if (!res.ok) throw new Error(`/runs ${res.status}`);
         const data = (await res.json()) as { runs?: Run[] };
@@ -175,7 +184,7 @@ export default function RunsPage() {
     load();
     const id = setInterval(load, 5000);
     return () => clearInterval(id);
-  }, [trigger, status, debouncedRecipeQuery, limit]);
+  }, [trigger, status, debouncedRecipeQuery, limit, attemptFilter]);
 
   // PR1c: poll halt-summary independently (cheaper payload, fixed cadence).
   // PR4: window selector feeds the same sinceMs into the summary so the
@@ -346,7 +355,19 @@ export default function RunsPage() {
             </option>
           ))}
         </select>
-        {(recipeQuery || trigger !== "all" || window !== "any") && (
+        {attemptFilter && (
+          <span
+            className="pill mono"
+            style={{ fontSize: "var(--fs-xs)" }}
+            title="Filtering by attempt id"
+          >
+            attempt:{attemptFilter}
+          </span>
+        )}
+        {(recipeQuery ||
+          trigger !== "all" ||
+          window !== "any" ||
+          attemptFilter) && (
           <button
             type="button"
             className="btn sm ghost"
@@ -354,6 +375,19 @@ export default function RunsPage() {
               setRecipeQuery("");
               setTrigger("all");
               setWindow("any");
+              setAttemptFilter("");
+              // Strip the ?attempt= from the URL so the filter doesn't
+              // re-apply on next render via the useSearchParams effect.
+              // `window` is shadowed by a state variable in this file —
+              // reach the global through `globalThis`.
+              const g = globalThis as typeof globalThis & {
+                window?: Window;
+              };
+              if (g.window && attemptFilter) {
+                const url = new URL(g.window.location.href);
+                url.searchParams.delete("attempt");
+                g.window.history.replaceState({}, "", url.toString());
+              }
             }}
           >
             Clear
@@ -512,16 +546,19 @@ export default function RunsPage() {
                       <td>
                         <span className="pill muted">{normaliseTrigger(r.trigger)}</span>
                         {r.manualRunId && (
-                          <span
+                          <Link
+                            href={`/runs?attempt=${encodeURIComponent(r.manualRunId)}`}
+                            onClick={(e) => e.stopPropagation()}
                             className="pill muted mono"
                             style={{
                               marginLeft: 6,
                               fontSize: "var(--fs-2xs)",
+                              textDecoration: "none",
                             }}
-                            title={`Attempt id ${r.manualRunId} — same id across runs = a resumed retry`}
+                            title={`Attempt id ${r.manualRunId} — click to filter to all runs sharing this attempt`}
                           >
                             attempt:{r.manualRunId.slice(-6)}
-                          </span>
+                          </Link>
                         )}
                       </td>
                       <td>

--- a/src/__tests__/runLog.test.ts
+++ b/src/__tests__/runLog.test.ts
@@ -441,6 +441,55 @@ describe("RecipeRunLog.record", () => {
     expect(log.getBySeq(seq2)?.manualRunId).toBeUndefined();
   });
 
+  it("query({ manualRunId }) returns only runs from that attempt", () => {
+    const log = new RecipeRunLog({ dir: tmp });
+    const attempt = "mr_resume_42";
+    log.appendDirect({
+      taskId: "t1",
+      recipeName: "review",
+      trigger: "recipe",
+      status: "error",
+      createdAt: 1_000,
+      doneAt: 1_500,
+      durationMs: 500,
+      manualRunId: attempt,
+    });
+    log.appendDirect({
+      taskId: "t2",
+      recipeName: "review",
+      trigger: "recipe",
+      status: "done",
+      createdAt: 2_000,
+      doneAt: 2_500,
+      durationMs: 500,
+      manualRunId: attempt,
+    });
+    log.appendDirect({
+      taskId: "t3",
+      recipeName: "review",
+      trigger: "recipe",
+      status: "done",
+      createdAt: 3_000,
+      doneAt: 3_500,
+      durationMs: 500,
+      manualRunId: "mr_other",
+    });
+    log.appendDirect({
+      taskId: "t4",
+      recipeName: "nightly",
+      trigger: "cron",
+      status: "done",
+      createdAt: 4_000,
+      doneAt: 4_500,
+      durationMs: 500,
+    });
+
+    const matched = log.query({ manualRunId: attempt });
+    expect(matched.map((r) => r.taskId).sort()).toEqual(["t1", "t2"]);
+    // Empty result for unknown ids — not a partial match.
+    expect(log.query({ manualRunId: "mr_does_not_exist" })).toEqual([]);
+  });
+
   it("record() stores parentSeq from :p<N> triggerSource suffix", () => {
     const log = new RecipeRunLog({ dir: tmp });
     const rec = log.record({

--- a/src/recipeOrchestration.ts
+++ b/src/recipeOrchestration.ts
@@ -177,6 +177,7 @@ export class RecipeOrchestration {
       status?: string;
       recipe?: string;
       after?: number;
+      manualRunId?: string;
     }) => {
       if (!this.deps.recipeRunLog) return [];
       return this.deps.recipeRunLog.query({
@@ -194,6 +195,7 @@ export class RecipeOrchestration {
         }),
         ...(q.recipe !== undefined && { recipe: q.recipe }),
         ...(q.after !== undefined && { after: q.after }),
+        ...(q.manualRunId !== undefined && { manualRunId: q.manualRunId }),
       }) as unknown as Record<string, unknown>[];
     };
 

--- a/src/recipeRoutes.ts
+++ b/src/recipeRoutes.ts
@@ -543,6 +543,7 @@ export function tryHandleRecipeRoute(
       const trigger = sp.get("trigger");
       const status = sp.get("status");
       const recipe = sp.get("recipe");
+      const manualRunId = sp.get("manualRunId");
       const limit = limitRaw ? Number.parseInt(limitRaw, 10) : Number.NaN;
       const after = afterRaw ? Number.parseInt(afterRaw, 10) : Number.NaN;
       const runs =
@@ -551,6 +552,7 @@ export function tryHandleRecipeRoute(
           ...(trigger && { trigger }),
           ...(status && { status }),
           ...(recipe && { recipe }),
+          ...(manualRunId && { manualRunId }),
           ...(Number.isFinite(after) && { after }),
         }) ?? [];
       res.writeHead(200, { "Content-Type": "application/json" });

--- a/src/runLog.ts
+++ b/src/runLog.ts
@@ -145,6 +145,8 @@ export interface RunQuery {
   recipe?: string;
   /** Runs with seq > after. */
   after?: number;
+  /** PR5c — exact-match on manualRunId. Yields all retries of one attempt. */
+  manualRunId?: string;
 }
 
 export class RecipeRunLog {
@@ -256,6 +258,10 @@ export class RecipeRunLog {
     if (q.trigger) out = out.filter((r) => r.trigger === q.trigger);
     if (q.status) out = out.filter((r) => r.status === q.status);
     if (q.recipe) out = out.filter((r) => r.recipeName === q.recipe);
+    if (q.manualRunId) {
+      const id = q.manualRunId;
+      out = out.filter((r) => r.manualRunId === id);
+    }
     if (q.after !== undefined) {
       const after = q.after;
       out = out.filter((r) => r.seq > after);

--- a/src/server.ts
+++ b/src/server.ts
@@ -220,6 +220,7 @@ export class Server extends EventEmitter<ServerEvents> {
         status?: string;
         recipe?: string;
         after?: number;
+        manualRunId?: string;
       }) => Record<string, unknown>[])
     | null = null;
   /** Patchwork: set by bridge to fetch a single run by seq for the detail page. */


### PR DESCRIPTION
## Summary
- \`RunLog.query({ manualRunId })\` — exact-match filter on the attempt id.
- \`GET /runs?manualRunId=<id>\` — reads + forwards the new param.
- Dashboard \`/runs?attempt=<id>\` — deep-link is read from the URL on mount, populates a filter pill, and the \`attempt:\` pill on each row is now a clickable \`<Link>\` that drops the user into the filtered view. Clearing strips both state and \`?attempt=\` from the URL.

Closes the visibility loop opened by #463 / #464 — a user who hits a failure can click the attempt pill and see every run that participated in that retry.

## Test plan
- [x] New runLog test covers exact-match + miss
- [x] Full suite: 5302 tests pass
- [x] Bridge \`npm run typecheck\` + dashboard \`tsc --noEmit\` both clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)