### PR TITLE
feat(judgments): /runs/judge-summary endpoint + patchwork judgments CLI

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2124,6 +2124,169 @@ if (process.argv[2] === "halts") {
   })();
 }
 
+// `patchwork judgments` — PR3b sibling of `patchwork halts`. Same window
+// + recipe filter shape; queries /runs/judge-summary and prints a
+// per-verdict breakdown plus the 5 most-recent verdicts.
+if (process.argv[2] === "judgments") {
+  const args = process.argv.slice(3);
+  const wantHelp = args.includes("--help") || args.includes("-h");
+  if (wantHelp) {
+    process.stdout.write(
+      "Usage: patchwork judgments [--window <name>] [--recipe <name>] [--json]\n" +
+        "\n" +
+        "  --window 1h | 24h | overnight | 7d | any   (default: overnight)\n" +
+        "  --recipe <name>                            filter to one recipe by name\n" +
+        "  --json                                     emit raw JSON (for scripting)\n" +
+        "\n" +
+        '"overnight" = since 6pm yesterday local time.\n',
+    );
+    process.exit(0);
+  }
+  type Win = "1h" | "24h" | "overnight" | "7d" | "any";
+  function parseWindow(): Win {
+    const idx = args.findIndex((a) => a === "--window" || a === "-w");
+    const raw = idx >= 0 && idx + 1 < args.length ? args[idx + 1] : "overnight";
+    if (
+      raw === "1h" ||
+      raw === "24h" ||
+      raw === "overnight" ||
+      raw === "7d" ||
+      raw === "any"
+    )
+      return raw;
+    process.stderr.write(`Unknown --window value: "${raw}"\n`);
+    process.exit(1);
+  }
+  function windowSinceMs(w: Win): number | null {
+    if (w === "any") return null;
+    if (w === "1h") return 60 * 60 * 1000;
+    if (w === "24h") return 24 * 60 * 60 * 1000;
+    if (w === "7d") return 7 * 24 * 60 * 60 * 1000;
+    const d = new Date();
+    d.setHours(18, 0, 0, 0);
+    if (d.getTime() > Date.now()) d.setDate(d.getDate() - 1);
+    return Date.now() - d.getTime();
+  }
+  const window = parseWindow();
+  const wantJson = args.includes("--json");
+  const recipeIdx = args.findIndex((a) => a === "--recipe" || a === "-r");
+  const recipeFilter =
+    recipeIdx >= 0 && recipeIdx + 1 < args.length
+      ? args[recipeIdx + 1]
+      : undefined;
+
+  (async () => {
+    try {
+      const { findAllLiveBridges } = await import("./bridgeLockDiscovery.js");
+      const liveLocks = findAllLiveBridges();
+      if (liveLocks.length === 0) {
+        process.stderr.write(
+          "No running bridge found. Start one with `patchwork start` (or `--driver subprocess`).\n",
+        );
+        process.exit(2);
+      }
+      const lock = liveLocks[0];
+      if (!lock) {
+        process.stderr.write("No running bridge found.\n");
+        process.exit(2);
+      }
+      const sinceMs = windowSinceMs(window);
+      const params: string[] = [];
+      if (sinceMs != null) params.push(`sinceMs=${sinceMs}`);
+      if (recipeFilter)
+        params.push(`recipe=${encodeURIComponent(recipeFilter)}`);
+      const qs = params.length > 0 ? `?${params.join("&")}` : "";
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), 10_000);
+      let res: Response;
+      try {
+        res = await fetch(
+          `http://127.0.0.1:${lock.port}/runs/judge-summary${qs}`,
+          {
+            headers: { Authorization: `Bearer ${lock.authToken}` },
+            signal: controller.signal,
+          },
+        );
+      } finally {
+        clearTimeout(timer);
+      }
+      if (!res.ok) {
+        process.stderr.write(
+          `Bridge returned ${res.status} for /runs/judge-summary\n`,
+        );
+        process.exit(1);
+      }
+      const summary = (await res.json()) as {
+        total: number;
+        byVerdict: Record<string, number>;
+        recent: Array<{
+          verdict: string;
+          firstReason?: string;
+          runSeq: number;
+          stepId: string;
+        }>;
+      };
+
+      if (wantJson) {
+        process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);
+        process.exit(0);
+      }
+
+      const labels: Record<string, string> = {
+        approve: "approve",
+        request_changes: "request changes",
+        unparseable: "unparseable",
+      };
+      const windowLabel: Record<Win, string> = {
+        "1h": "last hour",
+        "24h": "last 24h",
+        overnight: "since 6pm yesterday",
+        "7d": "last 7 days",
+        any: "all time",
+      };
+
+      const recipeSuffix = recipeFilter ? ` · recipe="${recipeFilter}"` : "";
+      process.stdout.write(
+        `Judgments — ${windowLabel[window]}${recipeSuffix}\n`,
+      );
+      process.stdout.write(`Total: ${summary.total}\n`);
+      if (summary.total === 0) {
+        process.stdout.write("\n  (no judge steps fired in this window)\n");
+        process.exit(0);
+      }
+
+      const entries = Object.entries(summary.byVerdict).sort(
+        ([, a], [, b]) => b - a,
+      );
+      process.stdout.write("\nBy verdict:\n");
+      for (const [verdict, count] of entries) {
+        const label = labels[verdict] ?? verdict;
+        process.stdout.write(`  ${String(count).padStart(3)}  ${label}\n`);
+      }
+
+      if (summary.recent.length > 0) {
+        process.stdout.write("\nMost recent:\n");
+        for (const r of summary.recent) {
+          const reason = r.firstReason
+            ? r.firstReason.length > 120
+              ? `${r.firstReason.slice(0, 117)}…`
+              : r.firstReason
+            : "(no reason)";
+          process.stdout.write(
+            `  #${r.runSeq}  [${r.verdict}]  ${r.stepId}: ${reason}\n`,
+          );
+        }
+      }
+      process.exit(0);
+    } catch (err) {
+      process.stderr.write(
+        `Error: ${err instanceof Error ? err.message : String(err)}\n`,
+      );
+      process.exit(1);
+    }
+  })();
+}
+
 if (process.argv[2] === "recipe" && process.argv[3] === "schema") {
   const outputDir = process.argv[4] ?? path.join(process.cwd(), "schemas");
   (async () => {

--- a/src/recipeOrchestration.ts
+++ b/src/recipeOrchestration.ts
@@ -11,6 +11,7 @@ import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
 import { recordRecipeRun } from "./activationMetrics.js";
 import type { ClaudeOrchestrator } from "./claudeOrchestrator.js";
 import { summariseHalts } from "./recipes/haltCategory.js";
+import { summariseJudgments } from "./recipes/judgeSummary.js";
 import type { RecipeOrchestrator } from "./recipes/RecipeOrchestrator.js";
 import type {
   SchedulerEnqueue,
@@ -227,6 +228,28 @@ export class RecipeOrchestration {
         })
         .filter((r) => r.createdAt >= cutoff);
       return summariseHalts(runs);
+    };
+
+    // PR3b — judge verdicts use the same windowing/recipe filter shape
+    // as halts. Verdicts intentionally live on a *separate* aggregate
+    // channel to preserve the augment-only invariant.
+    server.judgeSummaryFn = (opts?: {
+      sinceMs?: number;
+      limit?: number;
+      recipe?: string;
+    }) => {
+      if (!this.deps.recipeRunLog)
+        return { total: 0, byVerdict: {}, recent: [] };
+      const sinceMs = opts?.sinceMs ?? 7 * 24 * 60 * 60 * 1000;
+      const limit = opts?.limit ?? 500;
+      const cutoff = Date.now() - sinceMs;
+      const runs = this.deps.recipeRunLog
+        .query({
+          limit,
+          ...(opts?.recipe !== undefined && { recipe: opts.recipe }),
+        })
+        .filter((r) => r.createdAt >= cutoff);
+      return summariseJudgments(runs);
     };
 
     server.runPlanFn = async (recipeName: string) => {

--- a/src/recipeRoutes.ts
+++ b/src/recipeRoutes.ts
@@ -379,6 +379,18 @@ export interface RecipeRouteDeps {
         recipe?: string;
       }) => import("./recipes/haltCategory.js").HaltSummary)
     | null;
+  /**
+   * PR3b sibling of haltSummaryFn — same windowing shape but aggregates
+   * judge-step verdicts instead. Returns the `JudgeSummary` shape from
+   * src/recipes/judgeSummary.ts.
+   */
+  judgeSummaryFn:
+    | ((opts?: {
+        sinceMs?: number;
+        limit?: number;
+        recipe?: string;
+      }) => import("./recipes/judgeSummary.js").JudgeSummary)
+    | null;
   runPlanFn: ((recipeName: string) => Promise<Record<string, unknown>>) | null;
   runReplayFn:
     | ((seq: number) => Promise<{
@@ -579,6 +591,29 @@ export function tryHandleRecipeRoute(
         ...(Number.isFinite(limit) && { limit }),
         ...(recipe && { recipe }),
       }) ?? { total: 0, byCategory: {}, recent: [] };
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(summary));
+    } catch (err) {
+      respond500(res, err);
+    }
+    return true;
+  }
+
+  // GET /runs/judge-summary — PR3b sibling of /runs/halt-summary.
+  // Same query shape (sinceMs, limit, recipe), returns JudgeSummary.
+  if (parsedUrl.pathname === "/runs/judge-summary" && req.method === "GET") {
+    try {
+      const sp = parsedUrl.searchParams;
+      const sinceMsRaw = sp.get("sinceMs");
+      const limitRaw = sp.get("limit");
+      const recipe = sp.get("recipe");
+      const sinceMs = sinceMsRaw ? Number.parseInt(sinceMsRaw, 10) : Number.NaN;
+      const limit = limitRaw ? Number.parseInt(limitRaw, 10) : Number.NaN;
+      const summary = deps.judgeSummaryFn?.({
+        ...(Number.isFinite(sinceMs) && { sinceMs }),
+        ...(Number.isFinite(limit) && { limit }),
+        ...(recipe && { recipe }),
+      }) ?? { total: 0, byVerdict: {}, recent: [] };
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify(summary));
     } catch (err) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -234,6 +234,14 @@ export class Server extends EventEmitter<ServerEvents> {
         recipe?: string;
       }) => import("./recipes/haltCategory.js").HaltSummary)
     | null = null;
+  /** Patchwork (PR3b): aggregate judge-step verdicts across recent runs. */
+  public judgeSummaryFn:
+    | ((opts?: {
+        sinceMs?: number;
+        limit?: number;
+        recipe?: string;
+      }) => import("./recipes/judgeSummary.js").JudgeSummary)
+    | null = null;
   /** Patchwork: set by bridge to generate a dry-run plan for a recipe by name. */
   public runPlanFn:
     | ((recipeName: string) => Promise<Record<string, unknown>>)
@@ -1398,6 +1406,7 @@ export class Server extends EventEmitter<ServerEvents> {
           runsFn: this.runsFn,
           runDetailFn: this.runDetailFn,
           haltSummaryFn: this.haltSummaryFn,
+          judgeSummaryFn: this.judgeSummaryFn,
           runPlanFn: this.runPlanFn,
           runReplayFn: this.runReplayFn,
           runRecipeFn: this.runRecipeFn,


### PR DESCRIPTION
## Summary
- New HTTP endpoint \`GET /runs/judge-summary?sinceMs&limit&recipe\` returns the \`JudgeSummary\` shape — same query parameters and fail-open posture as \`/runs/halt-summary\`.
- New CLI \`patchwork judgments\` mirrors \`patchwork halts\`: same \`--window\` / \`--recipe\` / \`--json\` flags, same bridge-discovery + 10s fetch timeout convention.
- Backed by a new \`judgeSummaryFn\` on \`Server\` bound in \`recipeOrchestration\`.

Closes the verdict-visibility loop: dashboard pill (#460) + Prom gauge (#458) + session digest line (#460) + on-demand CLI/endpoint (this PR).

## Test plan
- [x] Full suite: 5302 tests pass
- [x] \`npm run typecheck\` clean
- [x] biome clean
- [ ] Manual: \`patchwork judgments --window 24h\` returns the same byVerdict counts as a manually-summed query on /runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)