### PR TITLE
fix(cli): register 'judgments' in KNOWN_SUBCOMMANDS

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -178,6 +178,7 @@ const KNOWN_SUBCOMMANDS = [
   "start",
   "kill-switch",
   "halts",
+  "judgments",
 ] as const;
 
 const __invokedSubcommand = (() => {


### PR DESCRIPTION
## Summary
PR #466 added the \`patchwork judgments\` IIFE block but forgot the subcommand name in \`KNOWN_SUBCOMMANDS\`. The unknown-command dispatcher runs first and exits with \`Unknown command: 'judgments'. Did you mean: suggest?\` before the IIFE is reached, leaving the whole subcommand unreachable from the built CLI.

Caught by a dogfooding agent exercising CLI parity with \`patchwork halts\`.

## Test plan
- [x] \`node dist/index.js judgments --help\` now prints the usage banner instead of unknown-command error

🤖 Generated with [Claude Code](https://claude.com/claude-code)