### PR TITLE
security: validate ledgerDir + reject symlinks (HIGH/MEDIUM)

### DIFF
--- a/src/recipes/__tests__/idempotencyKey.test.ts
+++ b/src/recipes/__tests__/idempotencyKey.test.ts
@@ -1,4 +1,10 @@
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -243,5 +249,71 @@ describe("assertValidManualRunId", () => {
     expect(() => assertValidManualRunId("null\x00byte")).toThrow();
     expect(() => assertValidManualRunId("../etc/passwd")).toThrow();
     expect(() => assertValidManualRunId("path/traversal")).toThrow();
+  });
+});
+
+describe("WriteEffectLedger — ledgerDir validation (security hardening)", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(path.join(os.tmpdir(), "effect-ledger-sec-"));
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  it("rejects empty string", () => {
+    expect(() => new WriteEffectLedger({ dir: "", scopeKey: "s" })).toThrow(
+      /non-empty/,
+    );
+  });
+
+  it("rejects null bytes", () => {
+    expect(
+      () => new WriteEffectLedger({ dir: "/tmp/foo\0bar", scopeKey: "s" }),
+    ).toThrow(/null bytes/);
+  });
+
+  it("rejects relative paths", () => {
+    expect(
+      () => new WriteEffectLedger({ dir: "relative/path", scopeKey: "s" }),
+    ).toThrow(/absolute/);
+  });
+
+  it("rejects a directory that is a symlink", () => {
+    const realDir = path.join(dir, "real");
+    const linkDir = path.join(dir, "link");
+    writeFileSync(path.join(dir, "marker"), "x");
+    symlinkSync(realDir, linkDir);
+    expect(
+      () => new WriteEffectLedger({ dir: linkDir, scopeKey: "s" }),
+    ).toThrow(/symlink/);
+  });
+
+  it("accepts a fresh non-existent absolute path (will be mkdir'd)", () => {
+    const fresh = path.join(dir, "fresh");
+    expect(
+      () => new WriteEffectLedger({ dir: fresh, scopeKey: "s" }),
+    ).not.toThrow();
+  });
+
+  it("refuses to load a symlinked JSONL file", () => {
+    // Pre-populate a sibling file with foreign data, then symlink the
+    // ledger filename to it. Constructor should NOT pick up the foreign
+    // contents.
+    const realLedger = path.join(dir, "real-ledger");
+    writeFileSync(
+      realLedger,
+      `${JSON.stringify({ scopeKey: "victim", idemKey: "leaked", output: "secret", recordedAt: 1 })}\n`,
+    );
+    symlinkSync(realLedger, path.join(dir, "effect_ledger.jsonl"));
+    const warnings: string[] = [];
+    const ledger = new WriteEffectLedger({
+      dir,
+      scopeKey: "victim",
+      logger: {
+        warn: (msg: string) => warnings.push(msg),
+        // biome-ignore lint/suspicious/noExplicitAny: minimal Logger shape
+      } as any,
+    });
+    expect(ledger.has("leaked")).toBe(false);
+    expect(warnings.some((w) => /symlink/.test(w))).toBe(true);
   });
 });

--- a/src/recipes/idempotencyKey.ts
+++ b/src/recipes/idempotencyKey.ts
@@ -42,6 +42,7 @@
 import { createHash } from "node:crypto";
 import {
   appendFileSync,
+  lstatSync,
   mkdirSync,
   readFileSync,
   statSync,
@@ -180,12 +181,65 @@ const LEDGER_FILENAME = "effect_ledger.jsonl";
 const MAX_PERSIST_BYTES = 1024 * 1024; // 1 MB — same posture as runLog
 const MAX_PERSIST_LINES = 10_000;
 
+/**
+ * Validate a caller-supplied ledger directory before any filesystem IO.
+ *
+ * The dir argument flows from the CLI (`--ledger-dir`) and (if/when
+ * exposed) HTTP-runner inputs; we'd rather fail loudly than write JSONL
+ * to whatever path is handed in. Three checks:
+ *
+ *  - **No null bytes** — would short-circuit C string handling in older
+ *    libc paths and confuse logs / audit tooling.
+ *  - **Absolute** — relative paths resolve against `process.cwd()`,
+ *    which for recipe runs is the workspace; an `--ledger-dir foo`
+ *    silently scattering ledger files under recipe sources is the
+ *    wrong default. Caller can pass `path.resolve(...)` explicitly if
+ *    they want relative resolution.
+ *  - **Not a symlink** — if the directory already exists and is a
+ *    symlink, an attacker who can write to the symlink's owning dir
+ *    can swap the target and redirect appends. Rejecting up front
+ *    means a fresh dir is created (via mkdirSync) or an existing real
+ *    dir is used; symlink-replacement on the JSONL file itself is
+ *    handled separately on each read in `loadExisting`.
+ */
+function assertSafeLedgerDir(dir: string): void {
+  if (typeof dir !== "string" || dir.length === 0) {
+    throw new Error("ledgerDir must be a non-empty string");
+  }
+  if (dir.includes("\0")) {
+    throw new Error("ledgerDir must not contain null bytes");
+  }
+  if (!path.isAbsolute(dir)) {
+    throw new Error(`ledgerDir must be an absolute path; got: ${dir}`);
+  }
+  try {
+    const st = lstatSync(dir);
+    if (st.isSymbolicLink()) {
+      throw new Error(`ledgerDir must not be a symlink: ${dir}`);
+    }
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === "ENOENT") return; // dir will be created later — fine
+    throw err;
+  }
+}
+
 export class WriteEffectLedger {
   private readonly cache = new Map<string, string | null>();
   private readonly disk: DiskLedgerOptions | null;
   private readonly file: string | null;
 
   constructor(disk?: DiskLedgerOptions) {
+    if (disk) {
+      // Validate + normalise the directory before any IO. Rejects null
+      // bytes (would short-circuit C string handling in libc paths),
+      // requires absolute paths (relative paths resolve against cwd
+      // which is the recipe workspace — surprising and racy), and
+      // refuses symlinks (a symlink swap on the ledger directory after
+      // construction could redirect appends to an attacker-chosen
+      // path).
+      assertSafeLedgerDir(disk.dir);
+    }
     this.disk = disk ?? null;
     this.file = disk ? path.join(disk.dir, LEDGER_FILENAME) : null;
     if (this.disk && this.file) {
@@ -239,7 +293,17 @@ export class WriteEffectLedger {
     if (!this.disk || !this.file) return;
     let raw: string;
     try {
-      statSync(this.file);
+      // `lstat` (not `stat`) so we see the symlink, not its target.
+      // A swapped symlink at `${dir}/effect_ledger.jsonl` would
+      // otherwise let an attacker substitute another file's contents
+      // as cached tool outputs.
+      const st = lstatSync(this.file);
+      if (st.isSymbolicLink()) {
+        this.disk.logger?.warn?.(
+          `[effect-ledger] refusing to load ${this.file}: file is a symlink`,
+        );
+        return;
+      }
       raw = readFileSync(this.file, "utf-8");
     } catch (err) {
       const code = (err as NodeJS.ErrnoException).code;


### PR DESCRIPTION
## Summary

Closes two security findings from today's audit:

### 1. HIGH — \`--ledger-dir\` path-traversal write primitive
Flag value flowed straight to \`WriteEffectLedger\` which would \`mkdirSync\` + \`appendFileSync\` wherever told. CLI is local-trusted today but \`ledgerDir\` is on \`RunRecipeOptions\` — any future HTTP runner path picks up the same surface.

**Fix:** \`assertSafeLedgerDir\` before any IO. Rejects empty string, null bytes, relative paths, and existing-symlinked dirs. Permits ENOENT (mkdir creates fresh).

### 2. MEDIUM — symlink swap on the JSONL file
\`loadExisting\` followed symlinks via \`statSync\`. Attacker who could write to the ledger directory could substitute foreign cached outputs.

**Fix:** \`lstatSync\` + refuse-to-load with warn-log when \`isSymbolicLink()\`.

## Test plan
- [x] 6 new tests: empty/null-byte/relative/symlink-dir rejected; ENOENT accepted; symlinked JSONL refused-to-load (with foreign data behind it that doesn't poison the cache)
- [x] Full suite: 5314 tests pass
- [x] \`npm run typecheck\` clean

## Remaining audit findings (follow-ups)
- MEDIUM \`parseJudgeVerdict\` brace-counter doesn't respect strings
- MEDIUM \`buildJudgeArtefactBlock\` unhandled-throws on circular/BigInt
- BUG \`updateRunSteps\` never called from production

🤖 Generated with [Claude Code](https://claude.com/claude-code)