### PR TITLE
fix(runs): wire updateRunSteps for live in-progress visibility

### DIFF
--- a/src/recipes/__tests__/yamlRunner.test.ts
+++ b/src/recipes/__tests__/yamlRunner.test.ts
@@ -2955,3 +2955,51 @@ describe("haltReason population on error StepResults", () => {
     expect(step.haltReason).toBeUndefined();
   });
 });
+
+describe("live step persistence via updateRunSteps", () => {
+  it("each completed step is visible on the running run before completeRun fires", async () => {
+    // Captures the in-memory runLog state observed at step-2 dispatch
+    // time. If updateRunSteps is wired, step 1's result must be present.
+    const { RecipeRunLog } = await import("../../runLog.js");
+    const tmp = mkdtempSync(path.join(os.tmpdir(), "yamlrunner-live-"));
+    try {
+      const runLog = new RecipeRunLog({ dir: tmp });
+      let snapshotAtStep2: unknown[] | undefined;
+      const recipe = makeRecipe({
+        name: "live-tail-test",
+        steps: [
+          {
+            agent: { prompt: "first", into: "a" },
+          },
+          {
+            agent: { prompt: "second", into: "b" },
+          },
+        ],
+      });
+      const claudeFn = vi
+        .fn()
+        .mockImplementationOnce(async () => "first-result")
+        .mockImplementationOnce(async () => {
+          // At this point step 1 has finished and pushed; the runLog
+          // entry must already reflect it.
+          const runs = runLog.query({ limit: 10 });
+          snapshotAtStep2 = runs[0]?.stepResults;
+          return "second-result";
+        });
+      await runYamlRecipe(recipe, {
+        ...noop(),
+        runLog,
+        claudeFn,
+        claudeCodeFn: claudeFn,
+        localFn: claudeFn,
+        providerDriverFn: claudeFn,
+      });
+      expect(Array.isArray(snapshotAtStep2)).toBe(true);
+      expect(snapshotAtStep2).toHaveLength(1);
+      // biome-ignore lint/suspicious/noExplicitAny: snapshot is unknown[]
+      expect((snapshotAtStep2 as any)[0].status).toBe("ok");
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/recipes/yamlRunner.ts
+++ b/src/recipes/yamlRunner.ts
@@ -583,6 +583,21 @@ export async function runYamlRecipe(
   let stepsRun = 0;
   let runError: string | undefined;
 
+  // Push live step results into the run-log ring so the dashboard's
+  // `/runs/[seq]` page surfaces verdicts + haltReasons mid-flight,
+  // instead of waiting for the whole recipe to finish via
+  // `completeRun`. The runLog ignores non-running entries; cron/webhook
+  // runs through the orchestrator path (where `runSeq` is undefined)
+  // skip this entirely.
+  const persistLiveStepResults = (): void => {
+    if (!deps.runLog || runSeq === undefined || stepDeps.testMode) return;
+    try {
+      deps.runLog.updateRunSteps(runSeq, stepResults);
+    } catch {
+      /* live-tail is best-effort; never break a recipe run for it */
+    }
+  };
+
   for (const step of recipe.steps) {
     // Evaluate `when` guard before running anything. Mirrors
     // chainedRunner.ts:248-266 — render the template, then truthy-check the
@@ -607,6 +622,7 @@ export async function runYamlRecipe(
           durationMs: 0,
         });
         stepsRun++;
+        persistLiveStepResults();
         continue;
       }
     }
@@ -649,6 +665,7 @@ export async function runYamlRecipe(
           durationMs: 0,
         });
         stepsRun++;
+        persistLiveStepResults();
         continue;
       }
       try {
@@ -744,6 +761,7 @@ export async function runYamlRecipe(
         });
       }
       stepsRun++;
+      persistLiveStepResults();
       continue;
     }
 
@@ -890,6 +908,7 @@ export async function runYamlRecipe(
         );
       }
     }
+    persistLiveStepResults();
   }
 
   // Evaluate expect block before persisting so failures are stored in the run log


### PR DESCRIPTION
## Summary
\`RecipeRunLog.updateRunSteps\` was defined but had zero production callers — yamlRunner only persisted via \`completeRun\` at the end. A long recipe's per-step verdicts, haltReasons, and skip flags were invisible on \`/runs/[seq]\` until the whole run finished. Audit caught it.

**Fix:** new \`persistLiveStepResults()\` helper called at each loop tail and at every early \`continue\` (skipped-by-when, budget-exceeded, agent-threw). Best-effort — IO errors don't break the recipe.

Integration test: 2-step recipe; the stub \`claudeFn\` on call #2 reads the runLog and captures step 1's persisted state. Asserts the snapshot has step 1's \`status: "ok"\` row before step 2 begins.

## Test plan
- [x] New integration test passes
- [x] Full suite: 5331 tests pass / typecheck clean
- [x] biome clean

## Audit complete
Last MEDIUM/BUG finding from the security + logic sweep. The full audit batch (#468–#471 + this) is now shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)