### PR TITLE
feat(dashboard): new surfaces — first-run + live ticker + connector-requests read + vocab ratchet

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -12,6 +12,7 @@
     "test:watch": "vitest",
     "tokens:check": "node scripts/check-tokens.mjs",
     "lint:inline-fontsize": "node scripts/check-inline-fontsize.mjs",
+    "lint:vocabulary": "node scripts/check-vocabulary.mjs",
     "clean": "rm -rf .next tsconfig.tsbuildinfo"
   },
   "dependencies": {

--- a/dashboard/scripts/check-vocabulary.mjs
+++ b/dashboard/scripts/check-vocabulary.mjs
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+// Ratchet check: count user-facing uses of banned synonyms for Patchwork's
+// canonical vocabulary. Prevents drift like "Workflow" / "Job" / "Execution"
+// creeping into headings + microcopy while we have "Recipe" / "Run" / "Task"
+// already defined in src/lib/glossary.ts as canonical.
+//
+// Why monotonic ratchets, not strict zero: the codebase has legitimate uses
+// of these words (comment text, code identifiers, mock data). The baseline
+// captures the current count; new PRs can only bring it down.
+//
+// Banned words:
+//   Workflow / Workflows  -> use Recipe / Recipes
+//   Execution             -> use Run (the noun) or "executes" (verb)
+//
+// We deliberately DO NOT ban "automation" — Patchwork has a real --automation
+// feature (hooks) distinct from recipes. Linting that would conflate them.
+//
+// Skipped paths:
+//   - __tests__ (test fixtures often use synonyms intentionally)
+//   - mockData.ts (mock prose is not user-facing copy we control today)
+//   - any comment-only matches (the user never sees JSDoc / inline comments)
+//
+// Usage: node scripts/check-vocabulary.mjs
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { dirname, join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+const SRC = join(ROOT, "src");
+
+const BANNED = [
+  { pattern: /\b[Ww]orkflows?\b/g, suggest: "Recipe / Recipes" },
+  { pattern: /\bExecutions?\b/g, suggest: "Run / Runs (noun) or 'executes' (verb)" },
+];
+
+// Bump DOWN as drift gets normalized. Never bump UP.
+//
+// Execution=2: both are the "Execution Plan" heading on /runs/[seq]
+// (one in the live header, one in the modal title). That heading is
+// the runs-page-specific name for the dry-run plan view; keeping the
+// term here doesn't conflate with /runs's "run" noun. If the heading
+// gets renamed, drop this to 0.
+const BASELINE = {
+  Workflow: 0,
+  Execution: 2,
+};
+
+function* walkFiles(dir) {
+  for (const name of readdirSync(dir)) {
+    const full = join(dir, name);
+    const st = statSync(full);
+    if (st.isDirectory()) {
+      if (name === "node_modules" || name === ".next" || name === "__tests__") continue;
+      yield* walkFiles(full);
+    } else if (/\.(tsx?|jsx?)$/.test(name)) {
+      yield full;
+    }
+  }
+}
+
+/**
+ * Strip block comments + line comments + JSX comments so banned-word matches
+ * inside source-code commentary don't drive the ratchet. User-facing copy
+ * lives in string literals + JSX prose, which survive this scrub.
+ */
+function stripComments(text) {
+  return text
+    .replace(/\/\*[\s\S]*?\*\//g, " ")
+    .replace(/\/\/[^\n]*/g, " ")
+    .replace(/\{\/\*[\s\S]*?\*\/\}/g, " ");
+}
+
+function classify(word) {
+  if (/workflow/i.test(word)) return "Workflow";
+  if (/execution/i.test(word)) return "Execution";
+  return null;
+}
+
+const counts = { Workflow: 0, Execution: 0 };
+const hitsByFile = new Map();
+
+for (const file of walkFiles(SRC)) {
+  if (file.endsWith("mockData.ts")) continue;
+  const raw = readFileSync(file, "utf8");
+  const text = stripComments(raw);
+  for (const { pattern } of BANNED) {
+    const matches = text.match(pattern);
+    if (!matches) continue;
+    for (const m of matches) {
+      const bucket = classify(m);
+      if (!bucket) continue;
+      counts[bucket]++;
+      const key = relative(ROOT, file);
+      hitsByFile.set(key, (hitsByFile.get(key) ?? 0) + 1);
+    }
+  }
+}
+
+let failed = false;
+for (const [bucket, baseline] of Object.entries(BASELINE)) {
+  const got = counts[bucket];
+  if (got > baseline) {
+    console.error(
+      `\n✗ Vocabulary ratchet failed: ${got} '${bucket}' usages (baseline ${baseline}, +${got - baseline})`,
+    );
+    const suggest = BANNED.find((b) => classify(b.pattern.source) === bucket || b.pattern.source.toLowerCase().includes(bucket.toLowerCase()))?.suggest;
+    if (suggest) console.error(`  Prefer: ${suggest}`);
+    failed = true;
+  } else if (got < baseline) {
+    console.error(
+      `\n✗ Vocabulary ratchet drifted below baseline for '${bucket}': ${got} < ${baseline}.`,
+    );
+    console.error(
+      `  You removed ${baseline - got} usage(s) — thanks. Now lower BASELINE.${bucket} in scripts/check-vocabulary.mjs to ${got} and commit so the ratchet locks in the new floor.`,
+    );
+    failed = true;
+  }
+}
+
+if (failed) {
+  if (hitsByFile.size > 0) {
+    console.error("  Files with banned terms:");
+    for (const [file, n] of [...hitsByFile.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 10)) {
+      console.error(`    ${n.toString().padStart(3)}  ${file}`);
+    }
+    console.error("");
+  }
+  process.exit(1);
+}
+
+console.log(
+  `vocabulary ratchet ok (Workflow=${counts.Workflow}/${BASELINE.Workflow}, Execution=${counts.Execution}/${BASELINE.Execution})`,
+);

--- a/dashboard/src/app/api/connector-requests/__tests__/get-route.test.ts
+++ b/dashboard/src/app/api/connector-requests/__tests__/get-route.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Verifies the GET handler added to /api/connector-requests. Pairs
+ * with the existing POST suite (route.test.ts) — together they lock
+ * the full write-then-read contract that closes the plumbing-audit
+ * gap.
+ *
+ * Each test scopes HOME to a fresh tmpdir so the on-disk
+ * ~/.patchwork/connector-requests.json doesn't leak state between
+ * tests or read the user's real file.
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+let tmpHome: string;
+let originalHomedir: typeof os.homedir;
+
+async function callGet() {
+  const mod = await import("../route");
+  return mod.GET();
+}
+
+describe("GET /api/connector-requests", () => {
+  beforeEach(() => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "pw-connreq-"));
+    originalHomedir = os.homedir;
+    // Both the route handler and this test use os.homedir() to resolve
+    // ~/.patchwork — patch it so the GET reads from our scratch dir.
+    (os as { homedir: () => string }).homedir = () => tmpHome;
+    // Force route module re-evaluation so any cached imports stay clean
+    // across tests. Vitest re-imports per test file by default; this
+    // is belt-and-suspenders.
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    (os as { homedir: () => string }).homedir = originalHomedir;
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("returns an empty list when the file does not exist", async () => {
+    const res = await callGet();
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { requests: unknown };
+    expect(body.requests).toEqual([]);
+  });
+
+  it("returns saved requests sorted newest-first", async () => {
+    const dir = path.join(tmpHome, ".patchwork");
+    fs.mkdirSync(dir, { recursive: true });
+    const file = path.join(dir, "connector-requests.json");
+    fs.writeFileSync(
+      file,
+      JSON.stringify([
+        { name: "Older", requestedAt: "2026-01-01T00:00:00Z" },
+        { name: "Newest", requestedAt: "2026-05-12T10:00:00Z" },
+        { name: "Middle", notes: "with notes", requestedAt: "2026-03-15T00:00:00Z" },
+      ]),
+    );
+    const res = await callGet();
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { requests: Array<{ name: string }> };
+    expect(body.requests.map((r) => r.name)).toEqual(["Newest", "Middle", "Older"]);
+  });
+
+  it("caps the response at 50 entries", async () => {
+    const dir = path.join(tmpHome, ".patchwork");
+    fs.mkdirSync(dir, { recursive: true });
+    const file = path.join(dir, "connector-requests.json");
+    const many = Array.from({ length: 75 }, (_, i) => ({
+      name: `Req-${i}`,
+      requestedAt: new Date(2026, 0, 1, 0, 0, i).toISOString(),
+    }));
+    fs.writeFileSync(file, JSON.stringify(many));
+    const res = await callGet();
+    const body = (await res.json()) as { requests: Array<{ name: string }> };
+    expect(body.requests.length).toBe(50);
+  });
+
+  it("returns 500 when the file is malformed JSON", async () => {
+    const dir = path.join(tmpHome, ".patchwork");
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, "connector-requests.json"), "not json");
+    const res = await callGet();
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toMatch(/malformed/i);
+  });
+
+  it("returns 500 when the file is JSON but not an array", async () => {
+    const dir = path.join(tmpHome, ".patchwork");
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, "connector-requests.json"),
+      JSON.stringify({ requests: [] }),
+    );
+    const res = await callGet();
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toMatch(/unexpected format/i);
+  });
+});

--- a/dashboard/src/app/api/connector-requests/route.ts
+++ b/dashboard/src/app/api/connector-requests/route.ts
@@ -18,6 +18,55 @@ interface ConnectorRequest {
   requestedAt: string;
 }
 
+/**
+ * Returns the list of connector requests the user has submitted via
+ * this endpoint. Plumbing audit flagged the route as write-only —
+ * users filled out the request form and the result vanished into
+ * ~/.patchwork/connector-requests.json. The GET handler closes that
+ * loop so the dashboard can surface "Your requests" inline on the
+ * connections page.
+ */
+export async function GET(): Promise<Response> {
+  try {
+    const file = path.join(os.homedir(), ".patchwork", "connector-requests.json");
+    if (!fs.existsSync(file)) {
+      return NextResponse.json({ requests: [] });
+    }
+    const raw = fs.readFileSync(file, "utf8");
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      // Same defensive handling as POST — surface a clear 500 rather
+      // than silently returning an empty list when the file is
+      // malformed (which would mask a real disk problem).
+      return NextResponse.json(
+        { error: "connector-requests.json is malformed — fix or delete it and retry" },
+        { status: 500 },
+      );
+    }
+    if (!Array.isArray(parsed)) {
+      return NextResponse.json(
+        { error: "connector-requests.json has unexpected format — expected an array" },
+        { status: 500 },
+      );
+    }
+    // Newest first; cap at a sensible window so the dashboard panel
+    // doesn't render hundreds of historical requests.
+    const requests = (parsed as ConnectorRequest[])
+      .slice()
+      .sort((a, b) => (a.requestedAt < b.requestedAt ? 1 : -1))
+      .slice(0, 50);
+    return NextResponse.json({ requests });
+  } catch (e) {
+    console.error("[connector-requests] read error", e);
+    return NextResponse.json(
+      { error: "Failed to read connector requests" },
+      { status: 500 },
+    );
+  }
+}
+
 export async function POST(req: Request): Promise<Response> {
   const guard = requireSameOrigin(req);
   if (guard) return guard;

--- a/dashboard/src/app/connections/YourConnectorRequests.tsx
+++ b/dashboard/src/app/connections/YourConnectorRequests.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { apiPath } from "@/lib/api";
+
+/**
+ * Lists the user's previously-submitted connector requests on
+ * /connections. Plumbing audit (2026-05-12) found the request form
+ * was write-only — submitted requests vanished into
+ * ~/.patchwork/connector-requests.json with no way to see them again.
+ *
+ * Pairs with the GET handler added to /api/connector-requests:
+ *   - empty list -> render nothing (no noise for fresh installs)
+ *   - non-empty -> compact list, newest first, with relative time
+ *   - fetch error -> render nothing (best-effort; the connections
+ *     page is the primary surface and we don't want a sub-panel
+ *     fail to break the page)
+ */
+
+interface ConnectorRequest {
+  name: string;
+  notes?: string;
+  requestedAt: string;
+}
+
+function relTime(iso: string): string {
+  const at = Date.parse(iso);
+  if (Number.isNaN(at)) return iso;
+  const s = Math.max(0, Math.floor((Date.now() - at) / 1000));
+  if (s < 60) return `${s}s ago`;
+  if (s < 3600) return `${Math.floor(s / 60)}m ago`;
+  if (s < 86_400) return `${Math.floor(s / 3600)}h ago`;
+  return `${Math.floor(s / 86_400)}d ago`;
+}
+
+export function YourConnectorRequests() {
+  const [requests, setRequests] = useState<ConnectorRequest[]>([]);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch(apiPath("/api/connector-requests"));
+        if (!res.ok) return;
+        const data = (await res.json()) as { requests?: ConnectorRequest[] };
+        if (cancelled) return;
+        setRequests(Array.isArray(data.requests) ? data.requests : []);
+      } catch {
+        /* read is best-effort */
+      } finally {
+        if (!cancelled) setLoaded(true);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (!loaded || requests.length === 0) return null;
+
+  return (
+    <section
+      aria-labelledby="your-requests-heading"
+      style={{
+        marginBottom: "var(--s-4)",
+        padding: "12px 16px",
+        borderRadius: "var(--r-2)",
+        border: "1px solid var(--line-2)",
+        background: "var(--recess)",
+      }}
+    >
+      <h2
+        id="your-requests-heading"
+        style={{
+          margin: 0,
+          fontSize: "var(--fs-s)",
+          fontWeight: 600,
+          color: "var(--ink-2)",
+          textTransform: "uppercase",
+          letterSpacing: "0.05em",
+        }}
+      >
+        Your connector requests{" "}
+        <span style={{ color: "var(--ink-3)", fontWeight: 400, textTransform: "none", letterSpacing: 0 }}>
+          · {requests.length}
+        </span>
+      </h2>
+      <ul
+        style={{
+          listStyle: "none",
+          padding: 0,
+          margin: "8px 0 0",
+          display: "flex",
+          flexDirection: "column",
+          gap: 4,
+        }}
+      >
+        {requests.map((r, i) => (
+          <li
+            key={`${r.requestedAt}-${i}`}
+            style={{
+              display: "flex",
+              alignItems: "baseline",
+              gap: 10,
+              fontSize: "var(--fs-s)",
+              color: "var(--ink-2)",
+            }}
+          >
+            <strong style={{ color: "var(--ink-1)", fontWeight: 600 }}>{r.name}</strong>
+            {r.notes && (
+              <span
+                style={{
+                  color: "var(--ink-3)",
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                  whiteSpace: "nowrap",
+                  flex: 1,
+                  minWidth: 0,
+                }}
+                title={r.notes}
+              >
+                — {r.notes}
+              </span>
+            )}
+            <span
+              style={{
+                color: "var(--ink-3)",
+                fontSize: "var(--fs-xs)",
+                flexShrink: 0,
+                marginLeft: "auto",
+              }}
+            >
+              {relTime(r.requestedAt)}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/dashboard/src/app/connections/page.tsx
+++ b/dashboard/src/app/connections/page.tsx
@@ -2,6 +2,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { apiPath } from "@/lib/api";
 import AddConnectionModal from "./AddConnectionModal";
+import { YourConnectorRequests } from "./YourConnectorRequests";
 import { Dialog } from "@/components/Dialog";
 import { HintCard } from "@/components/patchwork";
 import { useToast } from "@/components/Toast";
@@ -1218,6 +1219,14 @@ export default function ConnectionsPage() {
       </div>
 
       <HintCard id="connections" />
+
+      {/*
+        Plumbing-audit fix: the connector-request form used to be
+        write-only — submitted requests vanished into
+        ~/.patchwork/connector-requests.json. This panel reads from
+        the new GET handler so users can see what they've asked for.
+      */}
+      <YourConnectorRequests />
 
       {err && <div className="alert-err" role="alert">{err}</div>}
 

--- a/dashboard/src/app/connections/page.tsx
+++ b/dashboard/src/app/connections/page.tsx
@@ -1493,7 +1493,7 @@ export default function ConnectionsPage() {
                 Disconnect {displayName}?
               </strong>
               <p style={{ fontSize: "var(--fs-m)", color: "var(--fg-2)", margin: 0, lineHeight: 1.5 }}>
-                Recipes and automations that use {displayName} will fail until you reconnect.
+                Recipes that use {displayName} will fail until you reconnect.
                 Patchwork will keep your existing recipe definitions; only the auth token is removed.
               </p>
               <div style={{ display: "flex", gap: 8, justifyContent: "flex-end", marginTop: 4 }}>

--- a/dashboard/src/app/globals.css
+++ b/dashboard/src/app/globals.css
@@ -649,6 +649,18 @@ button.topbar-search {
   cursor: pointer;
   font-family: inherit;
 }
+
+/*
+ * Live activity ticker — mounted between the palette button and the
+ * action cluster in the topbar. Hide on narrow viewports where the
+ * topbar already has to drop the brand suffix; mobile users have the
+ * /activity page for the full firehose.
+ */
+@media (max-width: 900px) {
+  .activity-ticker {
+    display: none !important;
+  }
+}
 .kbd {
   /* Keyboard-shortcut hint chip (⌘K, J, K, E, X). On touch devices
      there's no physical keyboard so the chip is misleading — the

--- a/dashboard/src/app/page.tsx
+++ b/dashboard/src/app/page.tsx
@@ -2,6 +2,7 @@
 import Link from "next/link";
 import { useEffect, useRef, useState } from "react";
 import { apiPath } from "@/lib/api";
+import { FirstRunChecklist } from "@/components/FirstRunChecklist";
 import { StatCard } from "@/components/StatCard";
 import { SkeletonStatCard } from "@/components/Skeleton";
 import { relTime } from "@/components/time";
@@ -930,6 +931,14 @@ export default function HomePage() {
 
   return (
     <section>
+      {/*
+        First-run checklist: orchestrates the 4-step happy path for
+        brand-new workspaces (connect → install recipe → run → approve).
+        Auto-collapses once all four steps are complete; user-dismissable
+        any time. Lives above the hero so a new user can't miss it.
+      */}
+      <FirstRunChecklist />
+
       {/* ------------------------------------------------------------------ */}
       {/* Quilt hero with LOAD widget                                          */}
       {/* ------------------------------------------------------------------ */}

--- a/dashboard/src/app/transactions/page.tsx
+++ b/dashboard/src/app/transactions/page.tsx
@@ -161,7 +161,7 @@ export default function TransactionsPage() {
             >
               the speculative-refactoring doc
             </a>{" "}
-            for the workflow.
+            for the full flow.
           </div>
         </div>
         <div>

--- a/dashboard/src/components/ActivityTicker.tsx
+++ b/dashboard/src/components/ActivityTicker.tsx
@@ -1,0 +1,230 @@
+"use client";
+
+import Link from "next/link";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useBridgeStream } from "@/hooks/useBridgeStream";
+
+/**
+ * Compact live-event ticker for the topbar.
+ *
+ * Surfaces the three most-recent events the bridge has emitted, so the
+ * dashboard feels alive on every page (not just /activity). Reuses the
+ * existing useBridgeStream hook so we share one SSE connection with the
+ * /activity page rather than opening a second EventSource per tab.
+ *
+ * Hidden when:
+ *   - mobile breakpoint (CSS handles this — the topbar already collapses)
+ *   - bridge is unreachable (no events to show; degrades to nothing)
+ *   - user dismissed the ticker (localStorage, since this is a topbar
+ *     element the user has to look at every page; respect that choice)
+ *
+ * Each event is clickable → /activity?focus=<id> so the user can pivot
+ * from a glimpse on any page to the full thread.
+ */
+
+const STORAGE_KEY = "patchwork.activityTicker.dismissed";
+const MAX_VISIBLE = 3;
+const MAX_KEPT = 20;
+
+interface TickerEvent {
+  id?: number;
+  kind: string;
+  tool?: string;
+  event?: string;
+  status?: "success" | "error";
+  durationMs?: number;
+  timestamp?: string;
+  at?: number;
+  metadata?: Record<string, unknown>;
+}
+
+function readDismissed(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.localStorage.getItem(STORAGE_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+function writeDismissed() {
+  try {
+    window.localStorage.setItem(STORAGE_KEY, "1");
+  } catch {
+    /* private mode */
+  }
+}
+
+/**
+ * Pull a 1-line human label out of the event. Tools render their name +
+ * outcome; lifecycle events render the event name + the most-meaningful
+ * piece of metadata (tool name for approvals, summary for recipe ends).
+ */
+function describe(e: TickerEvent): string {
+  if (e.kind === "tool" && typeof e.tool === "string") {
+    const status = e.status === "error" ? " · error" : "";
+    const dur =
+      typeof e.durationMs === "number" && e.durationMs > 0
+        ? ` (${e.durationMs}ms)`
+        : "";
+    return `${e.tool}${status}${dur}`;
+  }
+  if (typeof e.event === "string") {
+    const meta = e.metadata ?? {};
+    const toolName = typeof meta.toolName === "string" ? meta.toolName : "";
+    const decision = typeof meta.decision === "string" ? meta.decision : "";
+    if (e.event === "approval_decision" && toolName)
+      return `${decision || "decided"} · ${toolName}`;
+    if (e.event === "approval_request" && toolName) return `approval · ${toolName}`;
+    return e.event;
+  }
+  return e.kind;
+}
+
+function tone(e: TickerEvent): "ok" | "err" | "muted" {
+  if (e.kind === "tool" && e.status === "error") return "err";
+  if (e.kind === "tool") return "ok";
+  if (e.event === "approval_request") return "muted";
+  return "muted";
+}
+
+const TONE_COLORS: Record<"ok" | "err" | "muted", string> = {
+  ok: "var(--green)",
+  err: "var(--red)",
+  muted: "var(--ink-3)",
+};
+
+export function ActivityTicker() {
+  const [events, setEvents] = useState<TickerEvent[]>([]);
+  const [dismissed, setDismissed] = useState(false);
+  const lastIdRef = useRef<number | undefined>(undefined);
+
+  useEffect(() => {
+    setDismissed(readDismissed());
+  }, []);
+
+  const onEvent = useCallback((_type: string, data: unknown) => {
+    if (!data || typeof data !== "object") return;
+    const e = data as TickerEvent;
+    // Dedup by id (the bridge emits monotonic IDs); ignore the rare
+    // case where the SSE replay sends an event we already have.
+    if (e.id !== undefined && lastIdRef.current === e.id) return;
+    if (e.id !== undefined) lastIdRef.current = e.id;
+    setEvents((prev) => {
+      const next: TickerEvent[] = [e, ...prev];
+      // Keep a small window — older events leave the ticker quickly.
+      return next.slice(0, MAX_KEPT);
+    });
+  }, []);
+
+  const { connected } = useBridgeStream("/api/bridge/stream", onEvent, {
+    enabled: !dismissed,
+  });
+
+  if (dismissed) return null;
+
+  const visible = events.slice(0, MAX_VISIBLE);
+
+  return (
+    <div
+      className="activity-ticker"
+      role="status"
+      aria-label="Live activity ticker"
+      aria-live="polite"
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 10,
+        minHeight: 24,
+        padding: "0 10px",
+        fontSize: "var(--fs-xs)",
+        color: "var(--ink-2)",
+        overflow: "hidden",
+        maxWidth: 520,
+        flex: "0 1 520px",
+      }}
+    >
+      <span
+        aria-hidden="true"
+        style={{
+          width: 6,
+          height: 6,
+          borderRadius: "50%",
+          background: connected ? "var(--green)" : "var(--ink-3)",
+          flexShrink: 0,
+          boxShadow: connected
+            ? "0 0 6px color-mix(in srgb, var(--green) 60%, transparent)"
+            : "none",
+        }}
+      />
+      {visible.length === 0 ? (
+        <span style={{ color: "var(--ink-3)", whiteSpace: "nowrap" }}>
+          {connected ? "Listening for events…" : "Bridge stream offline"}
+        </span>
+      ) : (
+        <ul
+          style={{
+            listStyle: "none",
+            padding: 0,
+            margin: 0,
+            display: "flex",
+            gap: 8,
+            overflow: "hidden",
+            minWidth: 0,
+          }}
+        >
+          {visible.map((e, i) => {
+            const label = describe(e);
+            const t = tone(e);
+            const href = `/activity${e.id !== undefined ? `?focus=${e.id}` : ""}`;
+            return (
+              <li
+                key={`${e.id ?? "x"}-${i}`}
+                style={{
+                  minWidth: 0,
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                  whiteSpace: "nowrap",
+                  flex: i === 0 ? "1 1 auto" : "0 1 auto",
+                  maxWidth: i === 0 ? 260 : 140,
+                }}
+              >
+                <Link
+                  href={href}
+                  title={label}
+                  style={{
+                    color: TONE_COLORS[t],
+                    textDecoration: "none",
+                    fontFamily: "var(--font-mono)",
+                  }}
+                >
+                  {label}
+                </Link>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+      <button
+        type="button"
+        onClick={() => {
+          writeDismissed();
+          setDismissed(true);
+        }}
+        aria-label="Hide activity ticker"
+        title="Hide ticker"
+        style={{
+          background: "transparent",
+          border: "none",
+          color: "var(--ink-3)",
+          padding: "0 4px",
+          cursor: "pointer",
+          fontSize: "var(--fs-xs)",
+          flexShrink: 0,
+        }}
+      >
+        ✕
+      </button>
+    </div>
+  );
+}

--- a/dashboard/src/components/FirstRunChecklist.tsx
+++ b/dashboard/src/components/FirstRunChecklist.tsx
@@ -1,0 +1,321 @@
+"use client";
+
+import Link from "next/link";
+import { useCallback, useEffect, useState } from "react";
+import { apiPath } from "@/lib/api";
+
+/**
+ * Four-step "first run" orchestration shown on /dashboard for users
+ * whose workspace hasn't yet seen the full happy path. Each step
+ * auto-checks against a real bridge endpoint:
+ *
+ *   1. Connect a service        — `/api/bridge/connections` has any entry
+ *   2. Install / create a recipe — `/api/bridge/recipes` returns >= 1
+ *   3. Run it                    — `/api/bridge/runs` returns >= 1
+ *   4. Approve when prompted     — `/api/bridge/approvals/history` has >= 1
+ *
+ * Strategic-critique gap: "What does a brand-new user see when /tasks,
+ * /recipes, /activity are all empty? Today: 15 unstructured empty-
+ * state divs, no orchestration." This component is the orchestration.
+ *
+ * Collapses (renders null) when:
+ *   - all 4 steps are complete (the happy path is established)
+ *   - the user has dismissed it
+ *
+ * Dismissals persist in localStorage. A "Restore checklist" mechanic
+ * is intentionally NOT here — Settings is the natural place for that,
+ * filed for a follow-up commit.
+ */
+
+const STORAGE_KEY = "patchwork.firstRun.dismissed";
+
+interface StepStatus {
+  done: boolean;
+  /** Optional 1-line detail surfaced when the step is incomplete. */
+  hint?: string;
+}
+
+interface Status {
+  connections: StepStatus;
+  recipes: StepStatus;
+  runs: StepStatus;
+  approvals: StepStatus;
+  loaded: boolean;
+}
+
+function emptyStatus(): Status {
+  return {
+    connections: { done: false },
+    recipes: { done: false },
+    runs: { done: false },
+    approvals: { done: false },
+    loaded: false,
+  };
+}
+
+async function probeArray(path: string, key?: string): Promise<number> {
+  try {
+    const res = await fetch(apiPath(path));
+    if (!res.ok) return 0;
+    const data = (await res.json()) as unknown;
+    const arr = key
+      ? ((data as Record<string, unknown>)?.[key] as unknown[] | undefined)
+      : (data as unknown[]);
+    return Array.isArray(arr) ? arr.length : 0;
+  } catch {
+    return 0;
+  }
+}
+
+function readDismissed(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.localStorage.getItem(STORAGE_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+function writeDismissed() {
+  try {
+    window.localStorage.setItem(STORAGE_KEY, "1");
+  } catch {
+    /* private mode */
+  }
+}
+
+export function FirstRunChecklist() {
+  const [status, setStatus] = useState<Status>(emptyStatus);
+  const [dismissed, setDismissed] = useState(false);
+
+  useEffect(() => {
+    setDismissed(readDismissed());
+  }, []);
+
+  const probe = useCallback(async () => {
+    // Probe all 5 endpoints in parallel — cheap reads, brand-new
+    // workspace is the hot path. Endpoint shapes (verified against
+    // the live bridge):
+    //   /connections                       -> { connectors: [...] }
+    //   /recipes                           -> { recipes: [...] }
+    //   /runs                              -> { runs: [...] }
+    //   /approvals                         -> [...] (pending queue)
+    //   /traces?traceType=approval         -> { traces: [...] }
+    // Step 4 is satisfied if EITHER an approval is currently pending
+    // (the user is mid-flow) OR an approval trace was ever saved (the
+    // user has been through the flow at least once).
+    const [conn, recipes, runs, pendingApprovals, approvalTraces] =
+      await Promise.all([
+        probeArray("/api/bridge/connections", "connectors"),
+        probeArray("/api/bridge/recipes", "recipes"),
+        probeArray("/api/bridge/runs", "runs"),
+        probeArray("/api/bridge/approvals"),
+        probeArray("/api/bridge/traces?traceType=approval", "traces"),
+      ]);
+    setStatus({
+      connections: { done: conn > 0, hint: "Pick Gmail, Slack, or another service to start." },
+      recipes: {
+        done: recipes > 0,
+        hint: "Install one from Marketplace or scaffold a new one.",
+      },
+      runs: { done: runs > 0, hint: "Run a recipe by hand or wait for a trigger." },
+      approvals: {
+        done: pendingApprovals > 0 || approvalTraces > 0,
+        hint: "Approvals appear here when a recipe asks to run a gated tool.",
+      },
+      loaded: true,
+    });
+  }, []);
+
+  useEffect(() => {
+    void probe();
+    // Refresh every 30s — the checklist auto-completes as the user
+    // works through it, so polling makes the green checkmarks appear
+    // without a reload.
+    const id = setInterval(probe, 30_000);
+    return () => clearInterval(id);
+  }, [probe]);
+
+  if (dismissed) return null;
+  if (!status.loaded) return null;
+  const allDone =
+    status.connections.done &&
+    status.recipes.done &&
+    status.runs.done &&
+    status.approvals.done;
+  if (allDone) return null;
+
+  const steps: Array<{
+    n: number;
+    label: string;
+    cta: { href: string; label: string };
+    step: StepStatus;
+  }> = [
+    {
+      n: 1,
+      label: "Connect a service",
+      cta: { href: "/connections", label: "Connect →" },
+      step: status.connections,
+    },
+    {
+      n: 2,
+      label: "Install or create a recipe",
+      cta: { href: "/marketplace", label: "Browse marketplace →" },
+      step: status.recipes,
+    },
+    {
+      n: 3,
+      label: "Run it",
+      cta: { href: "/recipes", label: "Open recipes →" },
+      step: status.runs,
+    },
+    {
+      n: 4,
+      label: "Approve when prompted",
+      cta: { href: "/approvals", label: "See queue →" },
+      step: status.approvals,
+    },
+  ];
+
+  return (
+    <section
+      aria-labelledby="first-run-heading"
+      style={{
+        marginBottom: "var(--s-5)",
+        padding: "16px 20px",
+        borderRadius: "var(--r-3)",
+        border: "1px solid color-mix(in srgb, var(--accent) 22%, transparent)",
+        background: "color-mix(in srgb, var(--accent) 5%, var(--surface))",
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          alignItems: "baseline",
+          justifyContent: "space-between",
+          gap: 12,
+          flexWrap: "wrap",
+        }}
+      >
+        <h2
+          id="first-run-heading"
+          style={{
+            margin: 0,
+            fontSize: "var(--fs-m)",
+            fontWeight: 600,
+            color: "var(--ink-1)",
+          }}
+        >
+          Get started <span style={{ color: "var(--ink-3)", fontWeight: 400 }}>· 4 steps</span>
+        </h2>
+        <button
+          type="button"
+          onClick={() => {
+            writeDismissed();
+            setDismissed(true);
+          }}
+          aria-label="Dismiss first-run checklist"
+          style={{
+            background: "transparent",
+            border: "1px solid var(--line-2)",
+            color: "var(--ink-3)",
+            padding: "3px 10px",
+            borderRadius: "var(--r-2)",
+            fontSize: "var(--fs-xs)",
+            cursor: "pointer",
+          }}
+        >
+          Dismiss
+        </button>
+      </div>
+
+      <ol
+        style={{
+          listStyle: "none",
+          padding: 0,
+          margin: "12px 0 0",
+          display: "flex",
+          flexDirection: "column",
+          gap: 8,
+        }}
+      >
+        {steps.map((s) => (
+          <li
+            key={s.n}
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 12,
+              padding: "8px 12px",
+              borderRadius: "var(--r-2)",
+              background: s.step.done
+                ? "color-mix(in srgb, var(--green) 7%, transparent)"
+                : "var(--recess)",
+              opacity: s.step.done ? 0.65 : 1,
+              transition: "opacity 180ms, background 180ms",
+            }}
+          >
+            <span
+              aria-hidden="true"
+              style={{
+                width: 22,
+                height: 22,
+                borderRadius: "50%",
+                background: s.step.done ? "var(--green)" : "transparent",
+                border: s.step.done
+                  ? "1px solid var(--green)"
+                  : "1px solid var(--line-2)",
+                color: s.step.done ? "var(--on-accent, #fff)" : "var(--ink-3)",
+                display: "inline-flex",
+                alignItems: "center",
+                justifyContent: "center",
+                fontSize: "var(--fs-xs)",
+                fontWeight: 700,
+                flexShrink: 0,
+              }}
+            >
+              {s.step.done ? "✓" : s.n}
+            </span>
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <div
+                style={{
+                  fontSize: "var(--fs-s)",
+                  fontWeight: 500,
+                  color: "var(--ink-1)",
+                  textDecoration: s.step.done ? "line-through" : "none",
+                }}
+              >
+                {s.label}
+              </div>
+              {!s.step.done && s.step.hint && (
+                <div
+                  style={{
+                    fontSize: "var(--fs-xs)",
+                    color: "var(--ink-3)",
+                    marginTop: 2,
+                  }}
+                >
+                  {s.step.hint}
+                </div>
+              )}
+            </div>
+            {!s.step.done && (
+              <Link
+                href={s.cta.href}
+                style={{
+                  fontSize: "var(--fs-xs)",
+                  fontWeight: 600,
+                  color: "var(--accent)",
+                  textDecoration: "none",
+                  flexShrink: 0,
+                }}
+              >
+                {s.cta.label}
+              </Link>
+            )}
+          </li>
+        ))}
+      </ol>
+    </section>
+  );
+}

--- a/dashboard/src/components/FirstRunChecklist.tsx
+++ b/dashboard/src/components/FirstRunChecklist.tsx
@@ -31,8 +31,10 @@ const STORAGE_KEY = "patchwork.firstRun.dismissed";
 
 interface StepStatus {
   done: boolean;
-  /** Optional 1-line detail surfaced when the step is incomplete. */
+  /** One-line nudge surfaced when the step is incomplete — "do this next". */
   hint?: string;
+  /** One-line follow-on surfaced when the step is done — "what good looks like". */
+  doneHint?: string;
 }
 
 interface Status {
@@ -113,15 +115,25 @@ export function FirstRunChecklist() {
         probeArray("/api/bridge/traces?traceType=approval", "traces"),
       ]);
     setStatus({
-      connections: { done: conn > 0, hint: "Pick Gmail, Slack, or another service to start." },
+      connections: {
+        done: conn > 0,
+        hint: "Gmail, Slack, or any HTTP API. Credentials stay in ~/.patchwork.",
+        doneHint: "Add more in /connections — one recipe can fan across services.",
+      },
       recipes: {
         done: recipes > 0,
-        hint: "Install one from Marketplace or scaffold a new one.",
+        hint: "Browse the marketplace or scaffold one with patchwork recipe new.",
+        doneHint: "YAML lives in templates/recipes. Tweak triggers and steps in /recipes.",
       },
-      runs: { done: runs > 0, hint: "Run a recipe by hand or wait for a trigger." },
+      runs: {
+        done: runs > 0,
+        hint: "Hit Run on any recipe, or wait for a scheduled trigger.",
+        doneHint: "Watch live in /activity. Halts and errors land in /runs.",
+      },
       approvals: {
         done: pendingApprovals > 0 || approvalTraces > 0,
-        hint: "Approvals appear here when a recipe asks to run a gated tool.",
+        hint: "Nothing leaves your machine without a nod. The queue is in /approvals.",
+        doneHint: "Approval patterns in /insights surface what's safe to auto-approve.",
       },
       loaded: true,
     });
@@ -144,6 +156,11 @@ export function FirstRunChecklist() {
     status.runs.done &&
     status.approvals.done;
   if (allDone) return null;
+  const doneCount =
+    (status.connections.done ? 1 : 0) +
+    (status.recipes.done ? 1 : 0) +
+    (status.runs.done ? 1 : 0) +
+    (status.approvals.done ? 1 : 0);
 
   const steps: Array<{
     n: number;
@@ -206,7 +223,10 @@ export function FirstRunChecklist() {
             color: "var(--ink-1)",
           }}
         >
-          Get started <span style={{ color: "var(--ink-3)", fontWeight: 400 }}>· 4 steps</span>
+          Get started{" "}
+          <span style={{ color: "var(--ink-3)", fontWeight: 400 }}>
+            · {doneCount} of 4 done
+          </span>
         </h2>
         <button
           type="button"
@@ -287,17 +307,21 @@ export function FirstRunChecklist() {
               >
                 {s.label}
               </div>
-              {!s.step.done && s.step.hint && (
-                <div
-                  style={{
-                    fontSize: "var(--fs-xs)",
-                    color: "var(--ink-3)",
-                    marginTop: 2,
-                  }}
-                >
-                  {s.step.hint}
-                </div>
-              )}
+              {(() => {
+                const tip = s.step.done ? s.step.doneHint : s.step.hint;
+                if (!tip) return null;
+                return (
+                  <div
+                    style={{
+                      fontSize: "var(--fs-xs)",
+                      color: "var(--ink-3)",
+                      marginTop: 2,
+                    }}
+                  >
+                    {tip}
+                  </div>
+                );
+              })()}
             </div>
             {!s.step.done && (
               <Link

--- a/dashboard/src/components/Shell.tsx
+++ b/dashboard/src/components/Shell.tsx
@@ -9,6 +9,7 @@ import { isDemoMode, onDemoModeChange, setDemoMode } from "@/lib/demoMode";
 import { useFocusTrap } from "@/lib/useFocusTrap";
 import { subscribeStreamLiveness } from "@/lib/streamLiveness";
 import { NAV_SECTIONS } from "@/lib/navRoutes";
+import { ActivityTicker } from "./ActivityTicker";
 import { BridgeOfflineBanner } from "./BridgeOfflineBanner";
 import { CardGlow } from "./CardGlow";
 import { CommandPalette } from "./CommandPalette";
@@ -374,6 +375,15 @@ export function Shell({ children }: { children: ReactNode }) {
           <span className="topbar-search-placeholder">Jump to anything…</span>
           <span className="kbd">⌘K</span>
         </button>
+        {/*
+          Live activity ticker. Sits between the command-palette button
+          and the right-side action cluster. Renders the last 3 events
+          the bridge has emitted (tool calls, approval decisions,
+          lifecycle events) with a live green pulse — gives the
+          dashboard a "feels alive" axis on every page, not just on
+          /activity. Hidden below the desktop breakpoint via CSS.
+        */}
+        <ActivityTicker />
         <div className="app-header-actions">
           <IdentityPill ok={status.ok} host={identity.host} port={identity.port} />
           {/*

--- a/dashboard/src/components/__tests__/ActivityTicker.test.tsx
+++ b/dashboard/src/components/__tests__/ActivityTicker.test.tsx
@@ -1,0 +1,132 @@
+/**
+ * Verifies the topbar live-event ticker:
+ *   - renders an "idle" message before any event arrives
+ *   - renders up to 3 most-recent events with the right tone + label
+ *   - tool events render with the tool name + optional duration
+ *   - lifecycle approval_decision events render decision + tool name
+ *   - error tool calls render in the err tone (red)
+ *   - dismissal hides the ticker + persists across remounts
+ *   - clicking an event with id routes to /activity?focus=<id>
+ *
+ * The component uses useBridgeStream under the hood. Rather than mock
+ * the hook directly (which would couple tests to its internals), we
+ * mock useBridgeStream's transport by stubbing EventSource and
+ * dispatching messages on it.
+ */
+
+import { act, fireEvent, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { ActivityTicker } from "@/components/ActivityTicker";
+
+class MockEventSource {
+  static instances: MockEventSource[] = [];
+  url: string;
+  onopen: ((ev: Event) => void) | null = null;
+  onerror: ((ev: Event) => void) | null = null;
+  onmessage: ((ev: MessageEvent) => void) | null = null;
+  closed = false;
+  constructor(url: string) {
+    this.url = url;
+    MockEventSource.instances.push(this);
+    // Defer onopen so the first render is "connecting" — production
+    // EventSource also opens asynchronously.
+    queueMicrotask(() => this.onopen?.(new Event("open")));
+  }
+  close() {
+    this.closed = true;
+  }
+  emit(data: unknown) {
+    this.onmessage?.(
+      new MessageEvent("message", { data: JSON.stringify(data) }),
+    );
+  }
+}
+
+const originalES = global.EventSource;
+
+describe("<ActivityTicker/>", () => {
+  beforeEach(() => {
+    MockEventSource.instances = [];
+    window.localStorage.clear();
+    (global as unknown as { EventSource: typeof MockEventSource }).EventSource =
+      MockEventSource;
+  });
+  afterEach(() => {
+    window.localStorage.clear();
+    global.EventSource = originalES;
+  });
+
+  it("shows a placeholder while idle", () => {
+    const { getByText } = render(<ActivityTicker />);
+    expect(getByText(/Listening for events|Bridge stream offline/)).toBeInTheDocument();
+  });
+
+  it("renders the most-recent tool event with its name + duration", async () => {
+    const { findByText } = render(<ActivityTicker />);
+    const es = MockEventSource.instances[0]!;
+    await act(async () => {
+      es.emit({ kind: "tool", tool: "Bash", status: "success", durationMs: 42, id: 1 });
+    });
+    expect(await findByText(/Bash \(42ms\)/)).toBeInTheDocument();
+  });
+
+  it("colours errored tool calls red and successful ones green (via inline style)", async () => {
+    const { findByText } = render(<ActivityTicker />);
+    const es = MockEventSource.instances[0]!;
+    await act(async () => {
+      es.emit({ kind: "tool", tool: "ToolA", status: "error", id: 1 });
+    });
+    const link = (await findByText(/ToolA · error/)).closest("a")!;
+    expect(link.getAttribute("style") ?? "").toMatch(/var\(--red\)/);
+  });
+
+  it("renders approval_decision lifecycle with decision + tool name", async () => {
+    const { findByText } = render(<ActivityTicker />);
+    const es = MockEventSource.instances[0]!;
+    await act(async () => {
+      es.emit({
+        kind: "lifecycle",
+        event: "approval_decision",
+        metadata: { decision: "approved", toolName: "Bash" },
+        id: 7,
+      });
+    });
+    expect(await findByText(/approved · Bash/)).toBeInTheDocument();
+  });
+
+  it("keeps only the 3 most-recent events visible", async () => {
+    const { container } = render(<ActivityTicker />);
+    const es = MockEventSource.instances[0]!;
+    await act(async () => {
+      es.emit({ kind: "tool", tool: "A", status: "success", id: 1 });
+      es.emit({ kind: "tool", tool: "B", status: "success", id: 2 });
+      es.emit({ kind: "tool", tool: "C", status: "success", id: 3 });
+      es.emit({ kind: "tool", tool: "D", status: "success", id: 4 });
+      es.emit({ kind: "tool", tool: "E", status: "success", id: 5 });
+    });
+    const items = container.querySelectorAll("li");
+    expect(items.length).toBe(3);
+    // Newest first.
+    expect(items[0]!.textContent).toMatch(/^E/);
+    expect(items[2]!.textContent).toMatch(/^C/);
+  });
+
+  it("each event with an id links to /activity?focus=<id>", async () => {
+    const { findByText } = render(<ActivityTicker />);
+    const es = MockEventSource.instances[0]!;
+    await act(async () => {
+      es.emit({ kind: "tool", tool: "X", status: "success", id: 91 });
+    });
+    const link = (await findByText(/X/)).closest("a")!;
+    expect(link.getAttribute("href")).toBe("/activity?focus=91");
+  });
+
+  it("dismissal hides the ticker + persists across remounts", async () => {
+    const { container, getByRole, unmount } = render(<ActivityTicker />);
+    fireEvent.click(getByRole("button", { name: /hide activity ticker/i }));
+    expect(container.firstChild).toBeNull();
+    unmount();
+    const { container: c2 } = render(<ActivityTicker />);
+    expect(c2.firstChild).toBeNull();
+  });
+});

--- a/dashboard/src/components/__tests__/FirstRunChecklist.test.tsx
+++ b/dashboard/src/components/__tests__/FirstRunChecklist.test.tsx
@@ -1,0 +1,117 @@
+/**
+ * Verifies the first-run orchestrator on /dashboard:
+ *   - probes 4 endpoints and auto-checks steps that have data
+ *   - hides when all 4 are complete (the happy path is established)
+ *   - hides when the user dismisses + persists across remounts
+ *   - shows incomplete steps with a CTA + hint
+ *   - completed steps render with a check mark and line-through
+ */
+
+import { fireEvent, render, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { FirstRunChecklist } from "@/components/FirstRunChecklist";
+
+const originalFetch = global.fetch;
+
+type Probe =
+  | { kind: "arr"; arr: unknown[] }
+  | { kind: "wrap"; key: string; arr: unknown[] };
+
+function makeFetch(perPath: Record<string, Probe>): typeof fetch {
+  // Order keys longest-first so a URL like /api/bridge/approvals/history
+  // matches its specific entry instead of the shorter /api/bridge/approvals.
+  const keysByLength = Object.keys(perPath).sort((a, b) => b.length - a.length);
+  const spy = vi.fn(async (input: RequestInfo | URL): Promise<Response> => {
+    const url = typeof input === "string" ? input : input.toString();
+    const match = keysByLength.find((p) => url.includes(p));
+    if (!match) return new Response("[]", { headers: { "content-type": "application/json" } });
+    const probe = perPath[match]!;
+    const body = probe.kind === "arr" ? probe.arr : { [probe.key]: probe.arr };
+    return new Response(JSON.stringify(body), {
+      headers: { "content-type": "application/json" },
+    });
+  });
+  return spy as unknown as typeof fetch;
+}
+
+describe("<FirstRunChecklist/>", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+  afterEach(() => {
+    window.localStorage.clear();
+    global.fetch = originalFetch;
+  });
+
+  it("renders four steps with the right completion state from the probes", async () => {
+    global.fetch = makeFetch({
+      "/api/bridge/connections": { kind: "wrap", key: "connectors", arr: [{ id: "gmail" }] },
+      "/api/bridge/recipes": { kind: "wrap", key: "recipes", arr: [] },
+      "/api/bridge/runs": { kind: "wrap", key: "runs", arr: [] },
+      "/api/bridge/approvals": { kind: "arr", arr: [] },
+      "/api/bridge/traces?traceType=approval": { kind: "wrap", key: "traces", arr: [] },
+    });
+    const { findByText, container } = render(<FirstRunChecklist />);
+    expect(await findByText(/Get started/)).toBeInTheDocument();
+    // Step 1 (connections) is done — check mark renders, line-through.
+    expect(container.textContent).toMatch(/Connect a service/);
+    // Step 4 (approvals) is incomplete — its CTA link is in the DOM.
+    expect(container.querySelector('a[href="/approvals"]')).not.toBeNull();
+  });
+
+  it("collapses entirely when all four steps are complete", async () => {
+    global.fetch = makeFetch({
+      "/api/bridge/connections": { kind: "wrap", key: "connectors", arr: [{ id: "gmail" }] },
+      "/api/bridge/recipes": { kind: "wrap", key: "recipes", arr: [{ name: "x" }] },
+      "/api/bridge/runs": { kind: "wrap", key: "runs", arr: [{ seq: 1 }] },
+      "/api/bridge/approvals": { kind: "arr", arr: [{ callId: "a" }] },
+      "/api/bridge/traces?traceType=approval": { kind: "wrap", key: "traces", arr: [] },
+    });
+    const { container } = render(<FirstRunChecklist />);
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalled();
+    });
+    await waitFor(() => {
+      expect(container.firstChild).toBeNull();
+    });
+  });
+
+  it("renders nothing on first paint (waits for probes) — no skeleton flash", () => {
+    global.fetch = makeFetch({
+      "/api/bridge/connections": { kind: "wrap", key: "connectors", arr: [] },
+      "/api/bridge/recipes": { kind: "wrap", key: "recipes", arr: [] },
+      "/api/bridge/runs": { kind: "wrap", key: "runs", arr: [] },
+      "/api/bridge/approvals": { kind: "arr", arr: [] },
+      "/api/bridge/traces?traceType=approval": { kind: "wrap", key: "traces", arr: [] },
+    });
+    const { container } = render(<FirstRunChecklist />);
+    // Pre-fetch, container is empty (no skeleton because a fresh user
+    // would see a flicker every Overview load).
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("dismissal persists across remounts via localStorage", async () => {
+    global.fetch = makeFetch({
+      "/api/bridge/connections": { kind: "wrap", key: "connectors", arr: [] },
+      "/api/bridge/recipes": { kind: "wrap", key: "recipes", arr: [] },
+      "/api/bridge/runs": { kind: "wrap", key: "runs", arr: [] },
+      "/api/bridge/approvals": { kind: "arr", arr: [] },
+      "/api/bridge/traces?traceType=approval": { kind: "wrap", key: "traces", arr: [] },
+    });
+    const { findByRole, container, unmount } = render(<FirstRunChecklist />);
+    const dismiss = await findByRole("button", {
+      name: /dismiss first-run checklist/i,
+    });
+    fireEvent.click(dismiss);
+    expect(container.firstChild).toBeNull();
+    unmount();
+    const { container: c2 } = render(<FirstRunChecklist />);
+    // Even after the new mount's probes settle, the checklist stays
+    // hidden because of the persisted dismissal.
+    await waitFor(() => {
+      // No assertion needed mid-await — we just want probes to fire.
+      expect(global.fetch).toHaveBeenCalled();
+    });
+    expect(c2.firstChild).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Fourth and final in the dashboard polish series, on top of #475 + #476 + #477. Four small features that close out the original goals: orchestrated first-run, live "feels alive" pulse, a plumbing-audit P0 gap, and a lint ratchet to prevent vocabulary drift.

## What lands

**`<FirstRunChecklist>` on `/dashboard`** — 4-step orchestrator above the QuiltHero:
  1. Connect a service       — probes `/api/bridge/connections` (key: connectors)
  2. Install / create a recipe — probes `/api/bridge/recipes` (key: recipes)
  3. Run it                    — probes `/api/bridge/runs` (key: runs)
  4. Approve when prompted     — probes `/api/bridge/approvals` OR `/api/bridge/traces?traceType=approval`

Each step auto-checks as the user works through it (30s poll). Completed steps render with ✓ on a green background and line-through; incomplete steps render the count number, a 1-line hint, and a CTA link. Collapses entirely when all four are complete OR the user dismisses (localStorage). Closes the "no orchestrated onboarding" gap the strategic critique flagged.

**Live `<ActivityTicker>` in the topbar** — sits between the command-palette button and the right-side action cluster. Renders the 3 most-recent events the bridge has emitted (tool calls, approval decisions, recipe lifecycle) with a live green-pulse dot. Reuses the existing `useBridgeStream` hook so we share one SSE connection with `/activity` rather than opening a second EventSource per tab.

- Each visible event is clickable → `/activity?focus=<id>`.
- Errored tool calls render in red; lifecycle events get a 1-line decision + tool-name description.
- Dismissable; persists via localStorage. Hidden below 900 px via a `.activity-ticker` rule in `globals.css`.

**"Your connector requests" read view** — closes a plumbing-audit P0 gap. The `/api/connector-requests` endpoint was write-only: users filled out the request form and the result vanished into `~/.patchwork/connector-requests.json` with no way to see what they'd asked for.
- New GET handler on the route: reads the saved JSON, sorts newest-first, caps at 50 entries. Defensive errors on malformed JSON / non-array shape.
- New `YourConnectorRequests` component mounted on `/connections` below the HintCard. Renders nothing on empty installs.

**`check-vocabulary.mjs` lint ratchet** — strategic-critique flagged "Recipes / Workflows / Automations / Tasks / Runs all live in nav, headings, and toasts" as bigger felt-disjointedness than two pill systems.
- Bans `Workflow / Workflows` (use Recipe / Recipes); bans `Execution / Executions` (use Run / Runs noun or "executes" verb).
- Strips comments before counting; skips `__tests__` and `mockData.ts`.
- Explicitly DOES NOT ban "automation" — Patchwork has a real `--automation` feature distinct from recipes.
- Wired as `npm run lint:vocabulary`. Baseline today: `Workflow=0, Execution=2` (the two are "Execution Plan" headings on `/runs/[seq]`, intentional).

Plus 2 microcopy drift fixes that close the Workflow baseline to zero:
- `/transactions`: "for the workflow." → "for the full flow."
- `/connections`: "Recipes and automations that use X" → "Recipes that use X" (redundant — "automations" was the synonym).

## Test plan

- [ ] `npm test` — 395/395 pass (+16 new in this PR)
- [ ] `npx tsc --noEmit` — clean
- [ ] `npm run lint:vocabulary` — passes (Workflow=0/0, Execution=2/2)
- [ ] Visit `/dashboard` on a fresh workspace and confirm the FirstRunChecklist renders with the right completion state
- [ ] Connect a service and confirm step 1 auto-checks (within the 30s poll window)
- [ ] Dismiss the checklist; confirm localStorage persists across reload
- [ ] On any page, confirm the topbar ActivityTicker shows "Listening for events…" (when bridge live but quiet) or events when active
- [ ] Trigger an event (run a recipe, approve a call) — confirm it appears in the ticker
- [ ] Submit a connector request via the existing form; reload `/connections`; confirm it appears in the "Your connector requests" panel
- [ ] On `/transactions`, confirm the copy says "for the full flow" (not "workflow")

## Blast radius

Small. FirstRunChecklist auto-collapses when complete; ActivityTicker is dismissable; YourConnectorRequests renders null on empty. Lint ratchet is opt-in via `npm run`; not yet wired into CI gate (follow-up).

## Depends on

#475 + #476 + #477. Must merge after all three.

## End of series

This is the last of the dashboard polish series. Cumulative across all four PRs:
- 5 new design-system primitives (`BackLink`, `RelationStrip`, `HintCard`, `Glossary`, plus `<BridgeOfflineBanner>` / `<RecentHaltsPanel>` / `<FirstRunChecklist>` / `<ActivityTicker>` / `<YourConnectorRequests>` as page components)
- 6-section sidebar reorg; all 17 dashboard pages reachable
- `/decisions` correctly labelled "Knowledge" everywhere
- Bridge-offline state explains itself; Demo chip auto-hides; Insights label fixed
- HintCard on all 10 main pages; Glossary woven through every domain term
- Live event pulse in topbar; first-run orchestration on Overview
- Vocabulary lint ratchet; ~50 new tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)