### PR TITLE
feat(dashboard): list-page RelationStrips + detail-page fixes

### DIFF
--- a/dashboard/src/app/approvals/[callId]/page.tsx
+++ b/dashboard/src/app/approvals/[callId]/page.tsx
@@ -234,6 +234,16 @@ export default function ApprovalDetailPage() {
           */}
           <RelationStrip
             items={[
+              ...(sessionId
+                ? [
+                    {
+                      label: "Session",
+                      href: `/sessions/${encodeURIComponent(sessionId)}`,
+                      tone: "accent" as const,
+                      title: `Session ${sessionId} that requested this approval`,
+                    },
+                  ]
+                : []),
               {
                 label: "Approval patterns",
                 href: "/insights",

--- a/dashboard/src/app/approvals/page.tsx
+++ b/dashboard/src/app/approvals/page.tsx
@@ -4,7 +4,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { Suspense, useCallback, useEffect, useRef, useState } from "react";
 import { useApprovalPatterns } from "../../hooks/useApprovalPatterns";
 import { apiPath } from "@/lib/api";
-import { CodeBlock, EmptyState, HintCard, KeyChip } from "@/components/patchwork";
+import { CodeBlock, EmptyState, HintCard, KeyChip, RelationStrip } from "@/components/patchwork";
 import { SkeletonList } from "@/components/Skeleton";
 import { DecisionsTabs } from "@/components/DecisionsTabs";
 import { useToast } from "@/components/Toast";
@@ -885,6 +885,19 @@ function ApprovalsContent() {
               return `~/.patchwork/inbox · ${pending.length} pending${oldestTs ? ` · oldest ${relTime(oldestTs)}` : ""}`;
             })()}
           </div>
+          <RelationStrip
+            items={[
+              { label: "Insights", href: "/insights", title: "Approve/reject patterns across tools" },
+              {
+                label: "Suggestions",
+                href: "/suggestions",
+                tone: pending.length > 0 ? "accent" : "neutral",
+                title: "Policy tweaks the system suggests",
+              },
+              { label: "Settings", href: "/settings#approvals", title: "Configure approval rules" },
+              { label: "Knowledge", href: "/decisions", title: "Saved reasoning your agents wrote down" },
+            ]}
+          />
           <div
             className="kbd-hint-row"
             style={{

--- a/dashboard/src/app/recipes/[name]/edit/page.tsx
+++ b/dashboard/src/app/recipes/[name]/edit/page.tsx
@@ -297,6 +297,17 @@ export default function RecipeEditPage({
                 title: `Recent runs of ${name}`,
               },
               {
+                label: "Halts",
+                href: `/runs?recipe=${encodeURIComponent(name)}&halt=1`,
+                tone: "warn",
+                title: `Runs of ${name} that hit a halt reason`,
+              },
+              {
+                label: "Traces",
+                href: `/traces?recipe=${encodeURIComponent(name)}`,
+                title: `Decision logs for ${name}`,
+              },
+              {
                 label: "Live activity",
                 href: "/activity",
                 title: "Stream of every event from this and other recipes",

--- a/dashboard/src/app/recipes/page.tsx
+++ b/dashboard/src/app/recipes/page.tsx
@@ -14,6 +14,7 @@ import {
   highlightYaml,
   LivePill,
   PatchCard,
+  RelationStrip,
   RunSparkBars,
   StatusPill,
 } from "@/components/patchwork";
@@ -867,6 +868,14 @@ export default function RecipesPage() {
               ? `templates/recipes · ${installedCount} installed · ${enabledCount} enabled`
               : "Loading…"}
           </div>
+          <RelationStrip
+            items={[
+              { label: "Runs", href: "/runs", title: "Runs produced by these recipes" },
+              { label: "Halts", href: "/runs?halt=1", tone: "warn", title: "Runs that hit a halt reason" },
+              { label: "Marketplace", href: "/marketplace", title: "Community-published recipes" },
+              { label: "New recipe", href: "/recipes/new", tone: "accent", title: "Author a new recipe" },
+            ]}
+          />
         </div>
         <div style={{ display: "flex", alignItems: "center", gap: "var(--s-2)" }}>
           <button

--- a/dashboard/src/app/runs/[seq]/page.tsx
+++ b/dashboard/src/app/runs/[seq]/page.tsx
@@ -984,6 +984,16 @@ export default function RunDetailPage() {
                   href: `/traces?recipe=${encodeURIComponent(run.recipeName)}`,
                   title: "Saved reasoning + enrichment for this recipe",
                 },
+                ...((run.stepResults ?? []).some((s) => s.haltReason)
+                  ? [
+                      {
+                        label: "Halts",
+                        href: `/runs?recipe=${encodeURIComponent(run.recipeName)}&halt=1`,
+                        tone: "warn" as const,
+                        title: "Other halted runs of this recipe",
+                      },
+                    ]
+                  : []),
               ]}
             />
           )}

--- a/dashboard/src/app/runs/page.tsx
+++ b/dashboard/src/app/runs/page.tsx
@@ -5,7 +5,7 @@ import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { LivePill } from "@/components/patchwork/LivePill";
-import { ErrorState } from "@/components/patchwork";
+import { ErrorState, RelationStrip } from "@/components/patchwork";
 import { ActivityTabs } from "@/components/ActivityTabs";
 import { useDebounced } from "@/hooks/useDebounced";
 
@@ -301,6 +301,14 @@ export default function RunsPage() {
           <div className="editorial-sub">
             {runs ? `${runs.length} runs` : "— runs"} · last 24h · avg {fmtDur(stats.avgMs)}
           </div>
+          <RelationStrip
+            items={[
+              { label: "Recipes", href: "/recipes", title: "The YAML that produced these runs" },
+              { label: "Halts", href: "/runs?halt=1", tone: "warn", title: "Runs that hit a halt reason" },
+              { label: "Traces", href: "/traces", title: "Decision logs for these runs" },
+              { label: "Activity", href: "/activity", title: "Live event firehose" },
+            ]}
+          />
         </div>
         <LivePill label="5s" />
       </div>

--- a/dashboard/src/app/sessions/[id]/page.tsx
+++ b/dashboard/src/app/sessions/[id]/page.tsx
@@ -209,8 +209,8 @@ export default function SessionDetailPage() {
             items={[
               {
                 label: "Recent runs",
-                href: "/runs",
-                title: "Recipe runs across all sessions",
+                href: `/runs?session=${encodeURIComponent(id)}`,
+                title: `Recipe runs from session ${id}`,
               },
               {
                 label: "Activity stream",

--- a/dashboard/src/app/sessions/page.tsx
+++ b/dashboard/src/app/sessions/page.tsx
@@ -3,7 +3,7 @@ import { Fragment, useState } from "react";
 import { relTime } from "@/components/time";
 import { useBridgeFetch } from "@/hooks/useBridgeFetch";
 import { apiPath } from "@/lib/api";
-import { ErrorState } from "@/components/patchwork";
+import { ErrorState, RelationStrip } from "@/components/patchwork";
 import { SkeletonList } from "@/components/Skeleton";
 import { ActivityTabs } from "@/components/ActivityTabs";
 
@@ -156,6 +156,14 @@ export default function SessionsPage() {
           <div className="editorial-sub">
             {liveCount} live · {idleCount} idle
           </div>
+          <RelationStrip
+            items={[
+              { label: "Tasks", href: "/tasks", title: "Subprocess invocations from these sessions" },
+              { label: "Activity", href: "/activity", title: "Events emitted by these sessions" },
+              { label: "Approvals", href: "/approvals", title: "Approvals these sessions are waiting on" },
+              { label: "Connections", href: "/connections", title: "Configured services these sessions can call" },
+            ]}
+          />
         </div>
         <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
           <button

--- a/dashboard/src/app/tasks/page.tsx
+++ b/dashboard/src/app/tasks/page.tsx
@@ -3,7 +3,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { apiPath } from "@/lib/api";
 import { fmtDuration } from "@/components/time";
 import { SkeletonList } from "@/components/Skeleton";
-import { EmptyState, ErrorState } from "@/components/patchwork";
+import { EmptyState, ErrorState, RelationStrip } from "@/components/patchwork";
 import { ActivityTabs } from "@/components/ActivityTabs";
 
 interface Task {
@@ -429,6 +429,14 @@ export default function TasksPage() {
           <div className="editorial-sub">
             {tasks.length} task{tasks.length !== 1 ? "s" : ""} · avg {fmtAvg(avgMs)} · driver: {driverLabel}
           </div>
+          <RelationStrip
+            items={[
+              { label: "Sessions", href: "/sessions", title: "Clients that spawned these tasks" },
+              { label: "Runs", href: "/runs", title: "Recipe runs that enqueued tasks" },
+              { label: "Activity", href: "/activity", title: "Tool calls emitted by tasks" },
+              { label: "Approvals", href: "/approvals", title: "Tasks waiting on a human nod" },
+            ]}
+          />
         </div>
         <div style={{ display: "flex", gap: 6, alignItems: "center" }}>
           <button

--- a/dashboard/src/app/traces/page.tsx
+++ b/dashboard/src/app/traces/page.tsx
@@ -5,7 +5,7 @@ import { apiPath } from "@/lib/api";
 import { useBridgeFetch } from "@/hooks/useBridgeFetch";
 import { useDebounced } from "@/hooks/useDebounced";
 import { arr, isRecord, shape, type ShapeCheck } from "@/lib/validate";
-import { EmptyState, ErrorState, HintCard, LivePill } from "@/components/patchwork";
+import { EmptyState, ErrorState, HintCard, LivePill, RelationStrip } from "@/components/patchwork";
 import { ActivityTabs } from "@/components/ActivityTabs";
 
 type TraceType = "approval" | "enrichment" | "recipe_run" | "decision";
@@ -643,6 +643,14 @@ export default function TracesPage() {
             </span>
             <LivePill label="3s" tone="muted" />
           </div>
+          <RelationStrip
+            items={[
+              { label: "Knowledge", href: "/decisions", title: "Saved reasoning your agents wrote down" },
+              { label: "Approvals", href: "/approvals", title: "Approvals these traces touched" },
+              { label: "Runs", href: "/runs", title: "Recipe runs these traces came from" },
+              { label: "Insights", href: "/insights", title: "Cross-tool approval patterns" },
+            ]}
+          />
         </div>
         <div style={{ display: "flex", gap: "var(--s-3)", alignItems: "center" }}>
           <input

--- a/dashboard/src/app/transactions/page.tsx
+++ b/dashboard/src/app/transactions/page.tsx
@@ -2,7 +2,7 @@
 import { useEffect, useState } from "react";
 import { apiPath } from "@/lib/api";
 import { useBridgeFetch } from "@/hooks/useBridgeFetch";
-import { ErrorState, HintCard } from "@/components/patchwork";
+import { ErrorState, HintCard, RelationStrip } from "@/components/patchwork";
 
 interface TransactionEdit {
   filePath: string;
@@ -163,6 +163,14 @@ export default function TransactionsPage() {
             </a>{" "}
             for the workflow.
           </div>
+          <RelationStrip
+            items={[
+              { label: "Approvals", href: "/approvals", title: "Approval queue gating commit" },
+              { label: "Recipes", href: "/recipes", title: "Recipes that stage edits" },
+              { label: "Activity", href: "/activity", title: "Live event firehose" },
+              { label: "Runs", href: "/runs", title: "Runs that produced these edits" },
+            ]}
+          />
         </div>
         <div>
           <span className="pill muted">


### PR DESCRIPTION
## Summary

PR A1 of the Round 2 connectivity track. Adds `<RelationStrip>` to seven main list pages and fixes four existing detail-page strips that were too generic.

**List-page strips (under each H1 subhead):**
- `/tasks` → Sessions · Runs · Activity · Approvals
- `/runs` → Recipes · Halts (warn) · Traces · Activity
- `/sessions` → Tasks · Activity · Approvals · Connections
- `/recipes` → Runs · Halts (warn) · Marketplace · New recipe (accent)
- `/transactions` → Approvals · Recipes · Activity · Runs
- `/approvals` → Insights · Suggestions (accent when pending>0) · Settings · Knowledge
- `/traces` → Knowledge · Approvals · Runs · Insights

**Detail-page strip fixes:**
- `/sessions/[id]` — "Recent runs" now filters to `?session=<id>`
- `/approvals/[callId]` — adds Session chip (accent) when `sessionId` known
- `/runs/[seq]` — adds Halts chip (warn) when any step has a `haltReason`
- `/recipes/[name]/edit` — adds Halts (warn) + Traces chips

Pure surface wiring — no behaviour, fetching, or state changes.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — 379 passing
- [x] Playwright sanity: strips render on `/tasks` and `/approvals`
- [ ] Visual smoke on each list page after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)