### PR TITLE
feat(dashboard): recipes-first landing — leaderboard + live runs + recipe attribution

### DIFF
--- a/dashboard/src/app/activity/page.tsx
+++ b/dashboard/src/app/activity/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useEffect, useMemo, useRef, useState } from "react";
+import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { apiPath } from "@/lib/api";
 import { relTime } from "@/components/time";
@@ -46,6 +47,16 @@ interface ActivityEvent {
 
 function getLifecycleMeta(e: ActivityEvent) {
   const m = e.metadata ?? {};
+  // recipeName lives in metadata for both lifecycle rows AND tool-call
+  // rows the bridge emits inside a recipe step. Surfacing it on the row
+  // lets users trace tool calls back to the recipe that produced them
+  // without bouncing through /runs.
+  const rawRecipe =
+    typeof m.recipeName === "string"
+      ? m.recipeName
+      : typeof m.recipe === "string"
+        ? m.recipe
+        : undefined;
   return {
     toolName: typeof m.toolName === "string" ? m.toolName : undefined,
     decision: typeof m.decision === "string" ? m.decision : undefined,
@@ -54,6 +65,7 @@ function getLifecycleMeta(e: ActivityEvent) {
     sessionId:
       typeof m.sessionId === "string" ? m.sessionId.slice(0, 8) : undefined,
     summary: typeof m.summary === "string" ? m.summary : undefined,
+    recipeName: rawRecipe ? rawRecipe.replace(/:agent$/, "") : undefined,
   };
 }
 
@@ -389,6 +401,7 @@ export default function ActivityPage() {
               <tr>
                 <th style={{ width: 140 }}>Time</th>
                 <th style={{ width: 110 }}>Kind</th>
+                <th style={{ width: 160 }}>Recipe</th>
                 <th>Tool / Event</th>
                 <th style={{ width: 110 }}>Duration</th>
                 <th style={{ width: 130 }}>Status / Decision</th>
@@ -446,6 +459,20 @@ export default function ActivityPage() {
                     </td>
                     <td>
                       <span className={`pill ${kindClass}`}>{kindLabel}</span>
+                    </td>
+                    <td className="mono" style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", maxWidth: 160 }}>
+                      {meta.recipeName ? (
+                        <Link
+                          href={`/dashboard/recipes/${encodeURIComponent(meta.recipeName)}/edit`}
+                          onClick={(ev) => ev.stopPropagation()}
+                          style={{ color: "var(--accent)", textDecoration: "none" }}
+                          title={`Recipe ${meta.recipeName}`}
+                        >
+                          {meta.recipeName}
+                        </Link>
+                      ) : (
+                        <span className="muted">—</span>
+                      )}
                     </td>
                     <td className="mono" style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", maxWidth: 300 }}>
                       {mainLabel}

--- a/dashboard/src/app/page.tsx
+++ b/dashboard/src/app/page.tsx
@@ -16,6 +16,11 @@ import {
   QuiltHero,
   WeatherRing,
 } from "@/components/patchwork";
+import {
+  RecipeLeaderboard,
+  type LeaderboardRun,
+} from "@/components/RecipeLeaderboard";
+import { LiveRunsStrip, type LiveRun } from "@/components/LiveRunsStrip";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -203,6 +208,23 @@ function activityKind(e: ActivityEvent): string {
   return e.kind ?? "event";
 }
 
+/**
+ * Extract the recipe a row belongs to. Every step/recipe event the
+ * bridge emits carries metadata.recipeName, but pre-2026-05-13 the
+ * Overview activity thread dropped it on the floor. Surfacing it makes
+ * recipes feel like the protagonist of the activity stream instead of
+ * a hidden parent of disconnected tool calls.
+ */
+function activityRecipe(e: ActivityEvent): string | undefined {
+  const m = e.metadata;
+  if (!m || typeof m !== "object") return undefined;
+  const direct = (m as Record<string, unknown>).recipeName ?? (m as Record<string, unknown>).recipe;
+  if (typeof direct === "string" && direct.length > 0) {
+    return direct.replace(/:agent$/, "");
+  }
+  return undefined;
+}
+
 function greetingFromHour(h: number): string {
   if (h < 12) return "Good morning";
   if (h < 18) return "Good afternoon";
@@ -379,6 +401,7 @@ function ActivityThread({ events }: { events: ActivityEvent[] }) {
             const ts = e.at ?? Date.now();
             const tool = activityLabel(e);
             const kind = activityKind(e);
+            const recipe = activityRecipe(e);
             const isErr = e.status === "error";
             const dur =
               typeof e.durationMs === "number" ? `${e.durationMs}ms` : null;
@@ -423,18 +446,51 @@ function ActivityThread({ events }: { events: ActivityEvent[] }) {
                 </span>
                 <span
                   style={{
-                    fontFamily: "var(--font-mono)",
-                    fontSize: "var(--fs-s)",
-                    color: "var(--ink-0)",
-                    fontWeight: 600,
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 6,
                     flex: 1,
                     minWidth: 0,
-                    overflow: "hidden",
-                    textOverflow: "ellipsis",
-                    whiteSpace: "nowrap",
                   }}
                 >
-                  {tool}
+                  {recipe && (
+                    <Link
+                      href={`/dashboard/recipes/${encodeURIComponent(recipe)}/edit`}
+                      title={`Recipe ${recipe}`}
+                      onClick={(ev) => ev.stopPropagation()}
+                      style={{
+                        fontFamily: "var(--font-mono)",
+                        fontSize: "var(--fs-xs)",
+                        color: "var(--accent)",
+                        textDecoration: "none",
+                        flexShrink: 0,
+                        maxWidth: 140,
+                        overflow: "hidden",
+                        textOverflow: "ellipsis",
+                        whiteSpace: "nowrap",
+                      }}
+                    >
+                      {recipe}
+                    </Link>
+                  )}
+                  {recipe && (
+                    <span aria-hidden="true" style={{ color: "var(--ink-3)" }}>·</span>
+                  )}
+                  <span
+                    style={{
+                      fontFamily: "var(--font-mono)",
+                      fontSize: "var(--fs-s)",
+                      color: "var(--ink-0)",
+                      fontWeight: 600,
+                      flex: 1,
+                      minWidth: 0,
+                      overflow: "hidden",
+                      textOverflow: "ellipsis",
+                      whiteSpace: "nowrap",
+                    }}
+                  >
+                    {tool}
+                  </span>
                 </span>
                 <span
                   className="pill muted"
@@ -473,76 +529,6 @@ function ActivityThread({ events }: { events: ActivityEvent[] }) {
 // Active recipe (live YAML + spinner)
 // ---------------------------------------------------------------------------
 
-function RecentRecipesCard({ recipes }: { recipes: Recipe[] }) {
-  const top = [...recipes]
-    .filter((r) => r.enabled !== false)
-    .sort((a, b) => (b.lastRun ?? 0) - (a.lastRun ?? 0))
-    .slice(0, 6);
-  return (
-    <div className="card" style={{ padding: "18px 20px" }}>
-      <div
-        style={{
-          display: "flex",
-          alignItems: "center",
-          gap: 8,
-          marginBottom: 14,
-        }}
-      >
-        <h2
-          style={{
-            fontSize: "var(--fs-m)",
-            fontWeight: 700,
-            margin: 0,
-            color: "var(--ink-0)",
-            flex: 1,
-            textTransform: "uppercase",
-            letterSpacing: "0.06em",
-          }}
-        >
-          Recent recipes
-        </h2>
-        <ActionPill href="/recipes" ariaLabel="View all recipes">
-          all →
-        </ActionPill>
-      </div>
-
-      {top.length === 0 ? (
-        <div style={{ fontSize: "var(--fs-s)", color: "var(--ink-3)", padding: "8px 0" }}>
-          No enabled recipes yet.{" "}
-          <Link href="/recipes/new" style={{ color: "var(--accent)" }}>
-            Create one →
-          </Link>
-        </div>
-      ) : (
-        <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
-          {top.map((r) => (
-            <Link
-              key={r.id ?? r.name}
-              href={`/recipes/${encodeURIComponent(r.name)}/edit`}
-              style={{
-                display: "flex",
-                alignItems: "center",
-                gap: 10,
-                padding: "6px 8px",
-                borderRadius: "var(--r-sm)",
-                textDecoration: "none",
-                color: "var(--ink-1)",
-                fontSize: "var(--fs-s)",
-              }}
-            >
-              <span style={{ fontFamily: "var(--font-mono)", color: "var(--ink-0)", flex: 1, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
-                {r.name}
-              </span>
-              <span style={{ fontSize: "var(--fs-xs)", color: "var(--ink-3)" }}>
-                {r.lastRun ? relTime(r.lastRun) : "never run"}
-              </span>
-            </Link>
-          ))}
-        </div>
-      )}
-    </div>
-  );
-}
 
 // ---------------------------------------------------------------------------
 // Health card
@@ -687,6 +673,7 @@ export default function HomePage() {
 
   const [pendingApprovals, setPendingApprovals] = useState<Pending[]>([]);
   const [recipes, setRecipes] = useState<Recipe[]>([]);
+  const [runs, setRuns] = useState<LiveRun[]>([]);
   const [toolCallTotal, setToolCallTotal] = useState(0);
   const [activityEvents, setActivityEvents] = useState<ActivityEvent[]>([]);
   const tickRef = useRef<() => void>(() => {});
@@ -696,7 +683,7 @@ export default function HomePage() {
     let alive = true;
     const tick = async () => {
       try {
-        const [approvalsRes, metricsRes, recipesRes, activityRes] =
+        const [approvalsRes, metricsRes, recipesRes, activityRes, runsRes] =
           await Promise.all([
             fetch(apiPath("/api/bridge/approvals")),
             fetch(apiPath("/api/bridge/metrics")),
@@ -708,6 +695,10 @@ export default function HomePage() {
             // simply shows the most recent N events bucketed into 24
             // hours, which still beats showing nothing.
             fetch(apiPath("/api/bridge/activity?last=500")),
+            // Recipe-runs power the new LiveRunsStrip + RecipeLeaderboard.
+            // catch() so an older bridge missing the endpoint just shows
+            // empty surfaces — the rest of Overview keeps working.
+            fetch(apiPath("/api/bridge/runs")).catch(() => null),
           ]);
         if (!alive) return;
 
@@ -729,9 +720,14 @@ export default function HomePage() {
           ? recipesData
           : (recipesData as { recipes?: Recipe[] }).recipes ?? [];
 
+        const runsData = runsRes?.ok
+          ? ((await runsRes.json()) as { runs?: LiveRun[] })
+          : { runs: [] };
+
         setToolCallTotal(total);
         setPendingApprovals(Array.isArray(approvalsData) ? approvalsData : []);
         setRecipes(list);
+        setRuns(Array.isArray(runsData.runs) ? runsData.runs : []);
         setActivityEvents(
           (activityData.events ?? []).map(withAt),
         );
@@ -984,6 +980,13 @@ export default function HomePage() {
       />
 
       {/* ------------------------------------------------------------------ */}
+      {/* LIVE RUNS — pulses any currently-running or recently-finished       */}
+      {/* recipe so a user landing on Overview can see motion at a glance.    */}
+      {/* Component auto-hides when there's nothing in-flight or recent.      */}
+      {/* ------------------------------------------------------------------ */}
+      <LiveRunsStrip runs={runs} />
+
+      {/* ------------------------------------------------------------------ */}
       {/* TELEMETRY eyebrow                                                    */}
       {/* ------------------------------------------------------------------ */}
       <div
@@ -1150,7 +1153,7 @@ export default function HomePage() {
         <ActivityThread
           events={activityEvents.filter((e) => !isNoiseEvent(e)).slice(-8).reverse()}
         />
-        <RecentRecipesCard recipes={recipes} />
+        <RecipeLeaderboard runs={runs as LeaderboardRun[]} />
       </div>
 
       {/* ------------------------------------------------------------------ */}

--- a/dashboard/src/app/recipes/page.tsx
+++ b/dashboard/src/app/recipes/page.tsx
@@ -16,6 +16,7 @@ import {
   PatchCard,
   RunSparkBars,
   StatusPill,
+  SuccessRing,
 } from "@/components/patchwork";
 
 // Tool prefix → connector name mapping
@@ -244,76 +245,6 @@ function RunModal({
         </>
       )}
     </Dialog>
-  );
-}
-
-/** Small donut ring showing success rate (0-100). */
-function SuccessRing({
-  pct,
-  size = 28,
-  stroke = 4,
-}: {
-  pct: number | null;
-  size?: number;
-  stroke?: number;
-}) {
-  const r = (size - stroke) / 2;
-  const c = 2 * Math.PI * r;
-  const safePct = pct == null ? 0 : Math.max(0, Math.min(100, pct));
-  const dash = (safePct / 100) * c;
-  const color =
-    pct == null
-      ? "var(--line-3)"
-      : safePct >= 90
-        ? "var(--ok)"
-        : safePct >= 60
-          ? "var(--warn)"
-          : "var(--err)";
-  return (
-    <svg
-      width={size}
-      height={size}
-      viewBox={`0 0 ${size} ${size}`}
-      style={{ display: "block", flexShrink: 0 }}
-      aria-label={pct == null ? "no run data" : `${Math.round(safePct)}% success`}
-    >
-      <circle
-        cx={size / 2}
-        cy={size / 2}
-        r={r}
-        fill="none"
-        stroke="var(--line-3)"
-        strokeWidth={stroke}
-      />
-      {pct != null && (
-        <circle
-          cx={size / 2}
-          cy={size / 2}
-          r={r}
-          fill="none"
-          stroke={color}
-          strokeWidth={stroke}
-          strokeDasharray={`${dash} ${c - dash}`}
-          strokeDashoffset={c / 4}
-          strokeLinecap="round"
-          transform={`rotate(-90 ${size / 2} ${size / 2})`}
-        />
-      )}
-      <text
-        x="50%"
-        y="50%"
-        textAnchor="middle"
-        dominantBaseline="central"
-        style={{
-          fontFamily: "var(--font-mono)",
-          fontSize: size <= 28 ? 8 : 10,
-          fontWeight: 700,
-          fill: "var(--ink-1)",
-        }}
-      >
-        {pct == null ? "—" : `${Math.round(safePct)}`}
-      </text>
-    </svg>
   );
 }
 
@@ -1038,7 +969,8 @@ export default function RecipesPage() {
                         <td style={{ textAlign: "center" }}>
                           <RunSparkBars
                             runs={(allRunsMap.get(r.name) ?? []).slice(0, 14)}
-                            width={90}
+                            slots={14}
+                            width={140}
                             height={20}
                           />
                         </td>

--- a/dashboard/src/components/LiveRunsStrip.tsx
+++ b/dashboard/src/components/LiveRunsStrip.tsx
@@ -1,0 +1,182 @@
+"use client";
+
+import Link from "next/link";
+import { LivePill, StatusPill } from "@/components/patchwork";
+import { relTime } from "@/components/time";
+
+/**
+ * Horizontal "what's running now" strip for the Overview page. Renders
+ * runs in flight + runs that finished in the last 10 minutes, so a user
+ * landing on /dashboard can immediately see "is anything alive, did
+ * anything just halt?" without clicking through to /runs.
+ *
+ * Auto-hides when there's nothing to show. The empty state on Overview
+ * is silence, not an empty card — this surface earns its pixels only
+ * when there's signal.
+ */
+
+export interface LiveRun {
+  seq?: number;
+  recipe: string;
+  recipeName?: string;
+  startedAt: number;
+  doneAt?: number;
+  status: string;
+  durationMs?: number;
+  haltReason?: string;
+}
+
+interface LiveRunsStripProps {
+  runs: LiveRun[];
+  /** Window in ms for "recently finished". Defaults to 10 min. */
+  recentWindowMs?: number;
+  /** Maximum cards. Defaults to 5. */
+  limit?: number;
+}
+
+function recipeNameOf(r: LiveRun): string {
+  return (r.recipeName ?? r.recipe ?? "").replace(/:agent$/, "");
+}
+
+function statusTone(status: string): "ok" | "err" | "warn" | "muted" {
+  const s = status.toLowerCase();
+  if (s === "running") return "warn";
+  if (s === "done" || s === "success") return "ok";
+  if (s === "error" || s === "failed" || s === "interrupted") return "err";
+  return "muted";
+}
+
+function fmtElapsed(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`;
+  if (ms < 3_600_000) return `${Math.floor(ms / 60_000)}m ${Math.floor((ms % 60_000) / 1000)}s`;
+  return `${Math.floor(ms / 3_600_000)}h ${Math.floor((ms % 3_600_000) / 60_000)}m`;
+}
+
+export function LiveRunsStrip({
+  runs,
+  recentWindowMs = 10 * 60 * 1000,
+  limit = 5,
+}: LiveRunsStripProps) {
+  const now = Date.now();
+  const visible = runs
+    .filter((r) => {
+      if (r.status === "running") return true;
+      const endedAt = r.doneAt ?? r.startedAt + (r.durationMs ?? 0);
+      return now - endedAt < recentWindowMs;
+    })
+    .sort((a, b) => {
+      if (a.status === "running" && b.status !== "running") return -1;
+      if (b.status === "running" && a.status !== "running") return 1;
+      return b.startedAt - a.startedAt;
+    })
+    .slice(0, limit);
+
+  if (visible.length === 0) return null;
+
+  return (
+    <section
+      aria-label="Live and recent recipe runs"
+      style={{
+        marginBottom: "var(--s-4)",
+        display: "flex",
+        gap: 10,
+        overflowX: "auto",
+        paddingBottom: 4,
+      }}
+    >
+      {visible.map((r, i) => {
+        const name = recipeNameOf(r);
+        const tone = statusTone(r.status);
+        const isLive = r.status === "running";
+        const elapsed = isLive
+          ? fmtElapsed(now - r.startedAt)
+          : r.durationMs
+            ? fmtElapsed(r.durationMs)
+            : "—";
+        const href = r.seq != null
+          ? `/dashboard/runs/${r.seq}`
+          : `/dashboard/runs?recipe=${encodeURIComponent(name)}`;
+        return (
+          <Link
+            key={r.seq ?? `${name}-${r.startedAt}-${i}`}
+            href={href}
+            style={{
+              flex: "0 0 240px",
+              padding: "10px 12px",
+              borderRadius: "var(--r-2)",
+              border: "1px solid var(--line-3)",
+              background: isLive
+                ? "color-mix(in srgb, var(--warn) 6%, var(--surface))"
+                : tone === "err"
+                  ? "color-mix(in srgb, var(--err) 5%, var(--surface))"
+                  : "var(--surface)",
+              textDecoration: "none",
+              color: "var(--ink-1)",
+              display: "flex",
+              flexDirection: "column",
+              gap: 4,
+              minWidth: 0,
+            }}
+            title={
+              r.haltReason
+                ? `Halt: ${r.haltReason}`
+                : `${name} · ${r.status} · ${isLive ? "started" : "finished"} ${relTime(isLive ? r.startedAt : r.doneAt ?? r.startedAt)}`
+            }
+          >
+            <div style={{ display: "flex", alignItems: "center", gap: 6, minWidth: 0 }}>
+              {isLive ? (
+                <LivePill label={elapsed} tone="accent" />
+              ) : (
+                <StatusPill tone={tone}>{r.status}</StatusPill>
+              )}
+              <span
+                style={{
+                  fontFamily: "var(--font-mono)",
+                  color: "var(--ink-0)",
+                  fontSize: "var(--fs-s)",
+                  fontWeight: 600,
+                  flex: 1,
+                  minWidth: 0,
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                  whiteSpace: "nowrap",
+                }}
+              >
+                {name}
+              </span>
+            </div>
+            <div
+              style={{
+                fontSize: "var(--fs-xs)",
+                color: "var(--ink-3)",
+                display: "flex",
+                gap: 6,
+              }}
+            >
+              {isLive ? (
+                <span>running · {elapsed}</span>
+              ) : (
+                <span>{relTime(r.doneAt ?? r.startedAt)} · {elapsed}</span>
+              )}
+              {r.haltReason && (
+                <span
+                  style={{
+                    color: "var(--err)",
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                    whiteSpace: "nowrap",
+                    minWidth: 0,
+                    flex: 1,
+                  }}
+                >
+                  · {r.haltReason}
+                </span>
+              )}
+            </div>
+          </Link>
+        );
+      })}
+    </section>
+  );
+}

--- a/dashboard/src/components/RecipeLeaderboard.tsx
+++ b/dashboard/src/components/RecipeLeaderboard.tsx
@@ -1,0 +1,203 @@
+"use client";
+
+import Link from "next/link";
+import { ActionPill, RunSparkBars, SuccessRing } from "@/components/patchwork";
+import { relTime } from "@/components/time";
+
+/**
+ * Recipe activity leaderboard for the Overview page. Replaces the old
+ * "Recent recipes" card, which sorted by lastRun timestamp but rendered
+ * only name + relTime — no run shape, no halt signal, no status.
+ *
+ * Three audits in 2026-05-13 converged: recipes are the unit of work,
+ * yet every aggregate surface (tool-calls chart, ActivityThread,
+ * tokens-burnt tile) keys on tools or events, not recipes. This card is
+ * the "Top recipes — last 24h" answer to "what's actually running, and
+ * how healthy?" — at the same screen position as the old card.
+ *
+ * Each row:
+ *   [SuccessRing] recipe-name  ▮▮▮▮▮  N runs · K halts · last <status> Xm ago
+ * Click → /runs?recipe=<name>.
+ */
+
+export interface LeaderboardRun {
+  recipe: string;
+  recipeName?: string;
+  startedAt: number;
+  status: string;
+  durationMs?: number;
+}
+
+interface RecipeLeaderboardProps {
+  /** All runs from /api/bridge/runs (will be filtered + grouped here). */
+  runs: LeaderboardRun[];
+  /** Maximum rows to display. Defaults to 6. */
+  limit?: number;
+  /** Window to consider, in ms. Defaults to 24h. */
+  windowMs?: number;
+}
+
+interface RecipeAgg {
+  name: string;
+  runs: LeaderboardRun[];
+  total: number;
+  halts: number;
+  okRate: number;
+  lastRun: LeaderboardRun;
+}
+
+function aggregateByRecipe(
+  runs: LeaderboardRun[],
+  windowMs: number,
+): RecipeAgg[] {
+  const cutoff = Date.now() - windowMs;
+  const byName = new Map<string, LeaderboardRun[]>();
+  for (const r of runs) {
+    if (r.startedAt < cutoff) continue;
+    const name = (r.recipeName ?? r.recipe ?? "").replace(/:agent$/, "");
+    if (!name) continue;
+    const list = byName.get(name) ?? [];
+    list.push(r);
+    byName.set(name, list);
+  }
+  const out: RecipeAgg[] = [];
+  for (const [name, list] of byName) {
+    const sorted = [...list].sort((a, b) => b.startedAt - a.startedAt);
+    const halts = sorted.filter(
+      (r) => r.status === "error" || r.status === "cancelled" || r.status === "interrupted",
+    ).length;
+    const okCount = sorted.filter((r) => r.status === "done" || r.status === "success").length;
+    const decided = sorted.filter((r) => r.status !== "running").length;
+    const okRate = decided === 0 ? 0 : (okCount / decided) * 100;
+    out.push({
+      name,
+      runs: sorted,
+      total: sorted.length,
+      halts,
+      okRate,
+      lastRun: sorted[0],
+    });
+  }
+  // Sort by total runs desc; ties broken by halt rate asc (fewer halts wins).
+  out.sort((a, b) => {
+    if (b.total !== a.total) return b.total - a.total;
+    return a.halts / Math.max(a.total, 1) - b.halts / Math.max(b.total, 1);
+  });
+  return out;
+}
+
+function statusTone(status: string): "ok" | "err" | "warn" | "muted" {
+  const s = status.toLowerCase();
+  if (s === "done" || s === "success") return "ok";
+  if (s === "error" || s === "failed") return "err";
+  if (s === "running") return "warn";
+  return "muted";
+}
+
+export function RecipeLeaderboard({
+  runs,
+  limit = 6,
+  windowMs = 24 * 60 * 60 * 1000,
+}: RecipeLeaderboardProps) {
+  const agg = aggregateByRecipe(runs, windowMs).slice(0, limit);
+
+  return (
+    <div className="card" style={{ padding: "18px 20px" }}>
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 8,
+          marginBottom: 14,
+        }}
+      >
+        <h2
+          style={{
+            fontSize: "var(--fs-m)",
+            fontWeight: 700,
+            margin: 0,
+            color: "var(--ink-0)",
+            flex: 1,
+            textTransform: "uppercase",
+            letterSpacing: "0.06em",
+          }}
+        >
+          Top recipes · last 24h
+        </h2>
+        <ActionPill href="/recipes" ariaLabel="View all recipes">
+          all →
+        </ActionPill>
+      </div>
+
+      {agg.length === 0 ? (
+        <div style={{ fontSize: "var(--fs-s)", color: "var(--ink-3)", padding: "8px 0" }}>
+          No runs in the last 24h.{" "}
+          <Link href="/recipes" style={{ color: "var(--accent)" }}>
+            Run a recipe →
+          </Link>
+        </div>
+      ) : (
+        <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+          {agg.map((a) => {
+            const tone = statusTone(a.lastRun.status);
+            return (
+              <Link
+                key={a.name}
+                href={`/dashboard/runs?recipe=${encodeURIComponent(a.name)}`}
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 10,
+                  padding: "8px 8px",
+                  borderRadius: "var(--r-sm)",
+                  textDecoration: "none",
+                  color: "var(--ink-1)",
+                  fontSize: "var(--fs-s)",
+                }}
+              >
+                <SuccessRing pct={a.okRate} size={26} stroke={3} />
+                <span
+                  style={{
+                    fontFamily: "var(--font-mono)",
+                    color: "var(--ink-0)",
+                    flex: 1,
+                    minWidth: 0,
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                    whiteSpace: "nowrap",
+                  }}
+                >
+                  {a.name}
+                </span>
+                <RunSparkBars runs={a.runs.slice(0, 8)} slots={8} width={84} height={16} />
+                <span
+                  className="mono muted"
+                  style={{ fontSize: "var(--fs-xs)", minWidth: 56, textAlign: "right" }}
+                  title={`${a.total} run${a.total === 1 ? "" : "s"}`}
+                >
+                  {a.total} run{a.total === 1 ? "" : "s"}
+                </span>
+                {a.halts > 0 && (
+                  <span
+                    className="pill warn"
+                    style={{ fontSize: "var(--fs-3xs)", flexShrink: 0 }}
+                    title={`${a.halts} halted run${a.halts === 1 ? "" : "s"}`}
+                  >
+                    {a.halts} halt{a.halts === 1 ? "" : "s"}
+                  </span>
+                )}
+                <span
+                  className={`pill ${tone}`}
+                  style={{ fontSize: "var(--fs-3xs)", flexShrink: 0, minWidth: 64, textAlign: "center" }}
+                  title={`Last run ${relTime(a.lastRun.startedAt)} · ${a.lastRun.status}`}
+                >
+                  {a.lastRun.status}
+                </span>
+              </Link>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/dashboard/src/components/patchwork/RunSparkBars.tsx
+++ b/dashboard/src/components/patchwork/RunSparkBars.tsx
@@ -1,6 +1,8 @@
 "use client";
 interface RunSparkBarsProps {
   runs: { status: string }[];
+  /** Number of slots to render. Defaults to 5. */
+  slots?: number;
   width?: number;
   height?: number;
 }
@@ -13,11 +15,16 @@ function statusColor(status: string): string {
   return "var(--ink-3, #9ca3af)";
 }
 
-export function RunSparkBars({ runs, width = 56, height = 18 }: RunSparkBarsProps) {
-  const slots = Array.from({ length: 5 }, (_, i) => runs[i] ?? null);
+export function RunSparkBars({
+  runs,
+  slots: slotCount = 5,
+  width = 56,
+  height = 18,
+}: RunSparkBarsProps) {
+  const slots = Array.from({ length: slotCount }, (_, i) => runs[i] ?? null);
   const barW = 6;
   const gap = 4;
-  const totalW = 5 * barW + 4 * gap; // 46
+  const totalW = slotCount * barW + (slotCount - 1) * gap;
   const offsetX = (width - totalW) / 2;
 
   return (

--- a/dashboard/src/components/patchwork/SuccessRing.tsx
+++ b/dashboard/src/components/patchwork/SuccessRing.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+/**
+ * Small donut ring showing success rate (0-100). Promoted from
+ * recipes/page.tsx so Overview's RecipeLeaderboard and other surfaces
+ * can render per-recipe health without duplicating the SVG.
+ */
+
+export interface SuccessRingProps {
+  pct: number | null;
+  size?: number;
+  stroke?: number;
+}
+
+export function SuccessRing({ pct, size = 28, stroke = 4 }: SuccessRingProps) {
+  const r = (size - stroke) / 2;
+  const c = 2 * Math.PI * r;
+  const safePct = pct == null ? 0 : Math.max(0, Math.min(100, pct));
+  const dash = (safePct / 100) * c;
+  const color =
+    pct == null
+      ? "var(--line-3)"
+      : safePct >= 90
+        ? "var(--ok)"
+        : safePct >= 60
+          ? "var(--warn)"
+          : "var(--err)";
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox={`0 0 ${size} ${size}`}
+      style={{ display: "block", flexShrink: 0 }}
+      aria-label={pct == null ? "no run data" : `${Math.round(safePct)}% success`}
+    >
+      <circle
+        cx={size / 2}
+        cy={size / 2}
+        r={r}
+        fill="none"
+        stroke="var(--line-3)"
+        strokeWidth={stroke}
+      />
+      {pct != null && (
+        <circle
+          cx={size / 2}
+          cy={size / 2}
+          r={r}
+          fill="none"
+          stroke={color}
+          strokeWidth={stroke}
+          strokeDasharray={`${dash} ${c - dash}`}
+          strokeDashoffset={c / 4}
+          strokeLinecap="round"
+          transform={`rotate(-90 ${size / 2} ${size / 2})`}
+        />
+      )}
+      <text
+        x="50%"
+        y="50%"
+        textAnchor="middle"
+        dominantBaseline="central"
+        style={{
+          fontFamily: "var(--font-mono)",
+          fontSize: size <= 28 ? 8 : 10,
+          fontWeight: 700,
+          fill: "var(--ink-1)",
+        }}
+      >
+        {pct == null ? "—" : `${Math.round(safePct)}`}
+      </text>
+    </svg>
+  );
+}

--- a/dashboard/src/components/patchwork/index.ts
+++ b/dashboard/src/components/patchwork/index.ts
@@ -32,3 +32,4 @@ export { EventsHistogram } from "./EventsHistogram";
 export { MetricsDonut, type DonutSegment } from "./MetricsDonut";
 export { AreaChart, type AreaChartSeries } from "./AreaChart";
 export { RunSparkBars } from "./RunSparkBars";
+export { SuccessRing, type SuccessRingProps } from "./SuccessRing";


### PR DESCRIPTION
## Summary

Three parallel audits in 2026-05-13 converged: recipes are the unit of work in Patchwork, but every aggregate surface keys on tools or events. This PR is the first cut at making recipes the protagonist of the landing page and the activity firehose.

**Six changes:**

1. **Recipe leaderboard replaces Recent recipes** on Overview. Top-N recipes by 24h run volume, each row a `SuccessRing` + 8-bar `RunSparkBars` + halt-count pill + last-status pill. Click → `/runs?recipe=<name>`. The old card showed only name + lastRun timestamp; it answered "which recipes exist" but not "which are working".

2. **`<LiveRunsStrip>`** above the telemetry tiles. Pulses running + recently-finished recipes with `LivePill` and elapsed time. Auto-hides when nothing is in flight or recent — this surface earns its pixels only when there's signal.

3. **Activity thread surfaces `metadata.recipeName`**. Every step event the bridge emits carries recipeName; Overview's thread dropped it. Rows now show `recipe · tool` with the recipe as an accent-coloured chip → recipe editor.

4. **`/activity` table gets a Recipe column** between Kind and Tool/Event. Accent chip → recipe editor.

5. **`SuccessRing` promoted** to `@/components/patchwork`. Was inline in `recipes/page.tsx`; the new leaderboard needed it.

6. **`RunSparkBars` bug fix.** Header on `/recipes` table said "LAST 14 RUNS" but the component hardcoded 5 bars. Now takes a `slots` prop; recipes table passes `slots={14}`.

## Audit findings deferred to follow-ups

- Cut `QuiltHero`'s `WeatherRing` LOAD% (invented number, no decision attached) — replace with a featured-recipe aside
- Cut "Recipes shipped" + "Tokens burnt" tiles → new "Runs (24h)" tile with ok/err counts
- Stack the Tool-calls 24h chart by recipe (top-5 + other) with clickable legend
- "Used by N recipes" panels on each connector page
- `ActivityTicker.describe()` should also surface recipeName (waiting for #478 to merge)

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — 379 passing
- [x] Playwright sanity: leaderboard renders, /activity Recipe column renders, LiveRunsStrip auto-hides when no runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)