### PR TITLE
feat(dashboard): dynamic landing — state-aware hero + quick-run buttons

### DIFF
--- a/dashboard/scripts/check-inline-fontsize.mjs
+++ b/dashboard/scripts/check-inline-fontsize.mjs
@@ -17,7 +17,7 @@ const SRC = join(ROOT, "src");
 
 // Bump DOWN as inline fontSize literals get migrated to var(--fs-*).
 // Never bump UP. CI reviewer should reject any PR raising this number.
-const BASELINE = 22;
+const BASELINE = 20;
 
 const PATTERN = /fontSize:\s*[0-9]+(?:\.[0-9]+)?/g;
 

--- a/dashboard/src/app/activity/page.tsx
+++ b/dashboard/src/app/activity/page.tsx
@@ -463,7 +463,7 @@ export default function ActivityPage() {
                     <td className="mono" style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", maxWidth: 160 }}>
                       {meta.recipeName ? (
                         <Link
-                          href={`/dashboard/recipes/${encodeURIComponent(meta.recipeName)}/edit`}
+                          href={`/recipes/${encodeURIComponent(meta.recipeName)}/edit`}
                           onClick={(ev) => ev.stopPropagation()}
                           style={{ color: "var(--accent)", textDecoration: "none" }}
                           title={`Recipe ${meta.recipeName}`}

--- a/dashboard/src/app/globals.css
+++ b/dashboard/src/app/globals.css
@@ -1828,6 +1828,123 @@ button.topbar-search {
   margin-right: 6px;
 }
 
+/* ---- Activity thread: filter chips + new-event flash ----
+   The thread used to render whatever came back from /activity in a
+   single take-it-or-leave-it list. Filter chips let users carve out
+   the slice they care about; the flash animation rewards a poll cycle
+   that introduces a new event by briefly tinting the row + sliding it
+   in from the rail. The page feels alive when the bridge is alive. */
+.activity-filter-row {
+  display: flex;
+  gap: 4px;
+  margin-bottom: 10px;
+  padding: 2px;
+  border-radius: var(--r-2);
+  background: var(--recess);
+  width: max-content;
+}
+.activity-filter-chip {
+  font-size: 11px;
+  font-family: var(--font-mono);
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  padding: 3px 10px;
+  border: none;
+  background: transparent;
+  color: var(--ink-3);
+  border-radius: var(--r-sm);
+  cursor: pointer;
+  transition: background 120ms ease, color 120ms ease;
+}
+.activity-filter-chip:hover { color: var(--ink-1); }
+.activity-filter-chip.is-active {
+  background: color-mix(in srgb, var(--accent) 14%, var(--surface));
+  color: var(--accent);
+}
+.activity-row {
+  position: relative;
+}
+.activity-row.is-fresh {
+  animation:
+    activity-row-flash 1.6s ease-out 1,
+    activity-row-slide 360ms cubic-bezier(.18,.7,.2,1) 1;
+}
+@keyframes activity-row-flash {
+  0% {
+    background: color-mix(in srgb, var(--accent) 18%, transparent);
+    box-shadow: inset 3px 0 0 var(--accent);
+  }
+  60% {
+    background: color-mix(in srgb, var(--accent) 6%, transparent);
+    box-shadow: inset 3px 0 0 color-mix(in srgb, var(--accent) 40%, transparent);
+  }
+  100% {
+    background: transparent;
+    box-shadow: inset 3px 0 0 transparent;
+  }
+}
+.activity-row.is-fresh.is-err {
+  animation:
+    activity-row-flash-err 1.6s ease-out 1,
+    activity-row-slide 360ms cubic-bezier(.18,.7,.2,1) 1;
+}
+@keyframes activity-row-flash-err {
+  0% {
+    background: color-mix(in srgb, var(--err) 18%, transparent);
+    box-shadow: inset 3px 0 0 var(--err);
+  }
+  60% {
+    background: color-mix(in srgb, var(--err) 6%, transparent);
+    box-shadow: inset 3px 0 0 color-mix(in srgb, var(--err) 40%, transparent);
+  }
+  100% {
+    background: transparent;
+    box-shadow: inset 3px 0 0 transparent;
+  }
+}
+@keyframes activity-row-slide {
+  from {
+    transform: translateY(-6px);
+    opacity: 0.4;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .activity-row.is-fresh,
+  .activity-row.is-fresh.is-err { animation: none; }
+}
+
+/* ---- Leaderboard: live-now dot on rows with a run in flight ---- */
+.leaderboard-live-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--ok);
+  flex-shrink: 0;
+  display: inline-block;
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--ok) 30%, transparent);
+  animation: leaderboard-live-pulse 1.6s ease-in-out infinite;
+}
+@keyframes leaderboard-live-pulse {
+  0%, 100% {
+    box-shadow:
+      0 0 0 2px color-mix(in srgb, var(--ok) 30%, transparent),
+      0 0 0 0 color-mix(in srgb, var(--ok) 55%, transparent);
+  }
+  50% {
+    box-shadow:
+      0 0 0 2px color-mix(in srgb, var(--ok) 30%, transparent),
+      0 0 0 8px color-mix(in srgb, var(--ok) 0%, transparent);
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .leaderboard-live-dot { animation: none; }
+}
+
 /* ---- Recipe leaderboard focal-card treatment ----
    Static accent presence (top stripe + subtle accent-tinted bg) so the
    card reads as "this is the protagonist section" without the rotating

--- a/dashboard/src/app/globals.css
+++ b/dashboard/src/app/globals.css
@@ -1810,6 +1810,126 @@ button.topbar-search {
   margin-right: 6px;
 }
 
+/* ---- Featured-recipe aside (replaces WeatherRing on hero) ---- */
+.quilt-aside-featured,
+.quilt-aside-empty {
+  position: relative;
+  z-index: 2;
+  align-self: stretch;
+  width: 280px;
+  padding: 22px 24px;
+  border-left: 1px solid var(--line-1);
+  background: color-mix(in srgb, var(--surface) 70%, transparent);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  justify-content: center;
+}
+.quilt-aside-eyebrow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-family: var(--font-mono);
+  font-size: var(--fs-2xs);
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  color: var(--ink-3);
+  text-transform: uppercase;
+}
+.quilt-aside-eyebrow-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--accent);
+  flex-shrink: 0;
+  display: inline-block;
+}
+.quilt-aside-eyebrow-dot[data-tone="err"] { background: var(--err); }
+.quilt-aside-eyebrow-dot[data-tone="accent"] { background: var(--accent); }
+.quilt-aside-eyebrow-dot[data-pulsing="1"] {
+  background: var(--ok);
+  animation: aside-eyebrow-pulse 1.6s ease-in-out infinite;
+  box-shadow: 0 0 0 0 color-mix(in srgb, var(--ok) 60%, transparent);
+}
+@keyframes aside-eyebrow-pulse {
+  0%, 100% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--ok) 55%, transparent); }
+  50% { box-shadow: 0 0 0 6px color-mix(in srgb, var(--ok) 0%, transparent); }
+}
+.quilt-aside-featured[data-mode="running"] .quilt-aside-eyebrow { color: var(--ok); }
+.quilt-aside-featured[data-mode="needs-retry"] .quilt-aside-eyebrow { color: var(--err); }
+.quilt-aside-name {
+  font-family: var(--font-mono);
+  font-size: var(--fs-l);
+  font-weight: 700;
+  color: var(--ink-0);
+  text-decoration: none;
+  line-height: 1.15;
+  word-break: break-all;
+  transition: color 120ms ease;
+}
+.quilt-aside-name:hover { color: var(--accent); }
+.quilt-aside-meta {
+  font-size: var(--fs-xs);
+  color: var(--ink-3);
+}
+.quilt-aside-spark {
+  margin: 4px 0 6px;
+}
+.quilt-aside-run {
+  align-self: flex-start;
+  font-size: var(--fs-s);
+  font-weight: 600;
+  padding: 6px 12px;
+  border-radius: var(--r-2);
+  border: 1px solid var(--accent);
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
+  color: var(--accent);
+  cursor: pointer;
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  transition: background 120ms ease, transform 80ms ease;
+}
+.quilt-aside-run:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--accent) 18%, transparent);
+}
+.quilt-aside-run:active:not(:disabled) { transform: translateY(1px); }
+.quilt-aside-run:disabled { cursor: wait; opacity: 0.7; }
+.quilt-aside-run[data-mode="needs-retry"] {
+  border-color: var(--err);
+  background: color-mix(in srgb, var(--err) 10%, transparent);
+  color: var(--err);
+}
+.quilt-aside-run[data-mode="needs-retry"]:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--err) 16%, transparent);
+}
+.quilt-aside-run[data-mode="running"] {
+  border-color: var(--ok);
+  background: color-mix(in srgb, var(--ok) 10%, transparent);
+  color: var(--ok);
+}
+.quilt-aside-run[data-mode="running"]:hover {
+  background: color-mix(in srgb, var(--ok) 16%, transparent);
+}
+.quilt-aside-empty-label {
+  font-family: var(--font-mono);
+  font-size: var(--fs-2xs);
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  color: var(--ink-3);
+  text-transform: uppercase;
+}
+.quilt-aside-empty-value {
+  font-family: var(--font-mono);
+  font-size: var(--fs-l);
+  font-weight: 700;
+  color: var(--ink-2);
+}
+.quilt-aside-empty-foot {
+  font-size: var(--fs-xs);
+}
+
 /* ---- Weather (stitched-seam gauge) ---- */
 .weather {
   position: relative;

--- a/dashboard/src/app/globals.css
+++ b/dashboard/src/app/globals.css
@@ -1828,6 +1828,28 @@ button.topbar-search {
   margin-right: 6px;
 }
 
+/* ---- Recipe leaderboard focal-card treatment ----
+   Static accent presence (top stripe + subtle accent-tinted bg) so the
+   card reads as "this is the protagonist section" without the rotating
+   conic-gradient beam we previously used — that radar sweep was a
+   gimmick and showed through even at rest. */
+.recipe-leaderboard-card {
+  position: relative;
+  border-top: 2px solid color-mix(in srgb, var(--accent) 80%, transparent);
+  background: linear-gradient(
+    to bottom,
+    color-mix(in srgb, var(--accent) 4%, var(--surface)) 0%,
+    var(--surface) 80px
+  );
+}
+[data-theme="dark"] .recipe-leaderboard-card {
+  background: linear-gradient(
+    to bottom,
+    color-mix(in srgb, var(--accent) 7%, var(--bg-2)) 0%,
+    var(--bg-2) 80px
+  );
+}
+
 /* ---- Featured-recipe aside (replaces WeatherRing on hero) ----
    Frosted-glass treatment over the quilt pattern. Earlier iteration
    used 70% surface mix with no blur — quilt squares bled through and

--- a/dashboard/src/app/globals.css
+++ b/dashboard/src/app/globals.css
@@ -1246,6 +1246,24 @@ button.topbar-search {
 .table .mono { font-family: var(--font-mono); font-size: 12px; color: var(--ink-1); }
 .table .muted { color: var(--ink-3); }
 
+/* /recipes table — readable, scannable row treatment. The default
+   .table row is dense (designed for log-like data); the recipes page
+   reads more like a product list, so it gets its own breathing room. */
+.recipes-table tbody td { padding: 12px 10px; }
+.recipes-table tr.recipe-row { transition: background 120ms ease; }
+.recipes-table tr.recipe-row:hover {
+  background: color-mix(in srgb, var(--accent) 5%, var(--recess));
+}
+.recipes-table tr.recipe-row.is-selected {
+  background: color-mix(in srgb, var(--accent) 9%, var(--bg-2));
+  box-shadow: inset 3px 0 0 var(--accent);
+}
+.recipes-table tr.recipe-row.is-selected:hover {
+  background: color-mix(in srgb, var(--accent) 12%, var(--bg-2));
+}
+.recipes-table tr.recipe-row.is-off { opacity: 0.55; }
+.recipes-table tr.recipe-row.is-off:hover { opacity: 0.85; }
+
 /* /recipes table on phone: 7-column desktop layout (%, RECIPE, TRIGGER,
    LAST 14 RUNS, AVG, LAST, Actions) is 700+ px wide. Below ≈768 px the
    declared widths plus padding push horizontal scroll to the point where
@@ -1810,7 +1828,11 @@ button.topbar-search {
   margin-right: 6px;
 }
 
-/* ---- Featured-recipe aside (replaces WeatherRing on hero) ---- */
+/* ---- Featured-recipe aside (replaces WeatherRing on hero) ----
+   Frosted-glass treatment over the quilt pattern. Earlier iteration
+   used 70% surface mix with no blur — quilt squares bled through and
+   ate the eyebrow contrast. Now: 92% surface + backdrop blur for a
+   crisp panel that reads against either theme. */
 .quilt-aside-featured,
 .quilt-aside-empty {
   position: relative;
@@ -1818,59 +1840,82 @@ button.topbar-search {
   align-self: stretch;
   width: 280px;
   padding: 22px 24px;
-  border-left: 1px solid var(--line-1);
-  background: color-mix(in srgb, var(--surface) 70%, transparent);
+  border-left: 1px solid var(--line-2);
+  background: color-mix(in srgb, var(--surface) 92%, transparent);
+  backdrop-filter: blur(6px) saturate(115%);
+  -webkit-backdrop-filter: blur(6px) saturate(115%);
   display: flex;
   flex-direction: column;
   gap: 8px;
   justify-content: center;
+  box-shadow: inset 1px 0 0 color-mix(in srgb, var(--ink-0) 4%, transparent);
 }
 .quilt-aside-eyebrow {
   display: flex;
   align-items: center;
   justify-content: space-between;
   font-family: var(--font-mono);
-  font-size: var(--fs-2xs);
+  font-size: 11px;
   font-weight: 700;
-  letter-spacing: 0.1em;
-  color: var(--ink-3);
+  letter-spacing: 0.12em;
+  color: var(--ink-2);
   text-transform: uppercase;
 }
 .quilt-aside-eyebrow-dot {
-  width: 7px;
-  height: 7px;
+  width: 8px;
+  height: 8px;
   border-radius: 50%;
   background: var(--accent);
   flex-shrink: 0;
   display: inline-block;
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 28%, transparent);
 }
-.quilt-aside-eyebrow-dot[data-tone="err"] { background: var(--err); }
-.quilt-aside-eyebrow-dot[data-tone="accent"] { background: var(--accent); }
+.quilt-aside-eyebrow-dot[data-tone="err"] {
+  background: var(--err);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--err) 28%, transparent);
+}
+.quilt-aside-eyebrow-dot[data-tone="accent"] {
+  background: var(--accent);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 28%, transparent);
+}
 .quilt-aside-eyebrow-dot[data-pulsing="1"] {
   background: var(--ok);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--ok) 30%, transparent);
   animation: aside-eyebrow-pulse 1.6s ease-in-out infinite;
-  box-shadow: 0 0 0 0 color-mix(in srgb, var(--ok) 60%, transparent);
 }
 @keyframes aside-eyebrow-pulse {
-  0%, 100% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--ok) 55%, transparent); }
-  50% { box-shadow: 0 0 0 6px color-mix(in srgb, var(--ok) 0%, transparent); }
+  0%, 100% {
+    box-shadow:
+      0 0 0 2px color-mix(in srgb, var(--ok) 30%, transparent),
+      0 0 0 0 color-mix(in srgb, var(--ok) 55%, transparent);
+  }
+  50% {
+    box-shadow:
+      0 0 0 2px color-mix(in srgb, var(--ok) 30%, transparent),
+      0 0 0 7px color-mix(in srgb, var(--ok) 0%, transparent);
+  }
 }
 .quilt-aside-featured[data-mode="running"] .quilt-aside-eyebrow { color: var(--ok); }
 .quilt-aside-featured[data-mode="needs-retry"] .quilt-aside-eyebrow { color: var(--err); }
 .quilt-aside-name {
   font-family: var(--font-mono);
-  font-size: var(--fs-l);
+  font-size: 17px;
   font-weight: 700;
   color: var(--ink-0);
   text-decoration: none;
-  line-height: 1.15;
-  word-break: break-all;
+  line-height: 1.2;
+  /* Long recipe names need to wrap at the dash glyph, not mid-char.
+     `break-word` keeps "apple-watch-health-log" intact and breaks at
+     the next dash if it has to; `break-all` hyphenated mid-word. */
+  overflow-wrap: break-word;
+  word-break: normal;
+  hyphens: none;
   transition: color 120ms ease;
 }
 .quilt-aside-name:hover { color: var(--accent); }
 .quilt-aside-meta {
   font-size: var(--fs-xs);
-  color: var(--ink-3);
+  color: var(--ink-2);
 }
 .quilt-aside-spark {
   margin: 4px 0 6px;
@@ -1879,52 +1924,56 @@ button.topbar-search {
   align-self: flex-start;
   font-size: var(--fs-s);
   font-weight: 600;
-  padding: 6px 12px;
+  padding: 7px 14px;
   border-radius: var(--r-2);
   border: 1px solid var(--accent);
-  background: color-mix(in srgb, var(--accent) 12%, transparent);
-  color: var(--accent);
+  background: var(--accent);
+  color: var(--on-accent, #fff);
   cursor: pointer;
   text-decoration: none;
   display: inline-flex;
   align-items: center;
   gap: 4px;
-  transition: background 120ms ease, transform 80ms ease;
+  box-shadow: 0 1px 0 color-mix(in srgb, var(--ink-0) 8%, transparent);
+  transition: background 120ms ease, transform 80ms ease, box-shadow 120ms ease, filter 120ms ease;
 }
 .quilt-aside-run:hover:not(:disabled) {
-  background: color-mix(in srgb, var(--accent) 18%, transparent);
+  filter: brightness(1.06);
+  box-shadow: 0 3px 10px -4px color-mix(in srgb, var(--accent) 60%, transparent);
 }
 .quilt-aside-run:active:not(:disabled) { transform: translateY(1px); }
 .quilt-aside-run:disabled { cursor: wait; opacity: 0.7; }
 .quilt-aside-run[data-mode="needs-retry"] {
   border-color: var(--err);
-  background: color-mix(in srgb, var(--err) 10%, transparent);
-  color: var(--err);
+  background: var(--err);
+  color: var(--on-accent, #fff);
 }
 .quilt-aside-run[data-mode="needs-retry"]:hover:not(:disabled) {
-  background: color-mix(in srgb, var(--err) 16%, transparent);
+  filter: brightness(1.08);
+  box-shadow: 0 3px 10px -4px color-mix(in srgb, var(--err) 60%, transparent);
 }
 .quilt-aside-run[data-mode="running"] {
   border-color: var(--ok);
-  background: color-mix(in srgb, var(--ok) 10%, transparent);
-  color: var(--ok);
+  background: var(--ok);
+  color: var(--on-accent, #fff);
 }
 .quilt-aside-run[data-mode="running"]:hover {
-  background: color-mix(in srgb, var(--ok) 16%, transparent);
+  filter: brightness(1.06);
+  box-shadow: 0 3px 10px -4px color-mix(in srgb, var(--ok) 60%, transparent);
 }
 .quilt-aside-empty-label {
   font-family: var(--font-mono);
-  font-size: var(--fs-2xs);
+  font-size: 11px;
   font-weight: 700;
-  letter-spacing: 0.1em;
-  color: var(--ink-3);
+  letter-spacing: 0.12em;
+  color: var(--ink-2);
   text-transform: uppercase;
 }
 .quilt-aside-empty-value {
   font-family: var(--font-mono);
-  font-size: var(--fs-l);
+  font-size: 18px;
   font-weight: 700;
-  color: var(--ink-2);
+  color: var(--ink-1);
 }
 .quilt-aside-empty-foot {
   font-size: var(--fs-xs);

--- a/dashboard/src/app/globals.css
+++ b/dashboard/src/app/globals.css
@@ -1828,6 +1828,73 @@ button.topbar-search {
   margin-right: 6px;
 }
 
+/* ---- Telemetry-tile value-change flash ----
+   AnimatedNumber stamps a flash class + key on its inner span whenever
+   the upstream value changes (not on initial mount). Using `key`
+   forces React to mount a fresh element each change, which restarts
+   the CSS animation cleanly — without that, the class is added once
+   and the animation never replays on subsequent updates.
+   Tone-aware: +N gets accent up-flash, -N gets a muted down-flash. */
+.animated-number-flash {
+  display: inline-block;
+  animation: animated-number-flash-up 1.4s ease-out 1;
+}
+.animated-number-flash-down {
+  animation: animated-number-flash-down 1.4s ease-out 1;
+}
+@keyframes animated-number-flash-up {
+  0% {
+    color: var(--accent);
+    text-shadow: 0 0 14px color-mix(in srgb, var(--accent) 60%, transparent);
+  }
+  100% {
+    color: inherit;
+    text-shadow: none;
+  }
+}
+@keyframes animated-number-flash-down {
+  0% {
+    color: var(--ink-3);
+    text-shadow: 0 0 10px color-mix(in srgb, var(--ink-3) 40%, transparent);
+  }
+  100% {
+    color: inherit;
+    text-shadow: none;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .animated-number-flash { animation: none; }
+}
+
+/* ---- Leaderboard row stagger-in on first render ----
+   Rows fade up with a 50ms cascade so the leaderboard feels assembled
+   instead of plonked. Hard-cap the staggered delay at row 8 so really
+   long lists don't have a noticeable trailing reveal. */
+.leaderboard-row {
+  animation: leaderboard-row-in 360ms cubic-bezier(.18,.7,.2,1) both;
+}
+.leaderboard-row:nth-child(1) { animation-delay: 0ms; }
+.leaderboard-row:nth-child(2) { animation-delay: 60ms; }
+.leaderboard-row:nth-child(3) { animation-delay: 120ms; }
+.leaderboard-row:nth-child(4) { animation-delay: 180ms; }
+.leaderboard-row:nth-child(5) { animation-delay: 240ms; }
+.leaderboard-row:nth-child(6) { animation-delay: 300ms; }
+.leaderboard-row:nth-child(7) { animation-delay: 340ms; }
+.leaderboard-row:nth-child(n+8) { animation-delay: 380ms; }
+@keyframes leaderboard-row-in {
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .leaderboard-row { animation: none; }
+}
+
 /* ---- Activity thread: filter chips + new-event flash ----
    The thread used to render whatever came back from /activity in a
    single take-it-or-leave-it list. Filter chips let users carve out

--- a/dashboard/src/app/globals.css
+++ b/dashboard/src/app/globals.css
@@ -1828,6 +1828,83 @@ button.topbar-search {
   margin-right: 6px;
 }
 
+/* ---- Live-wire heartbeat above the telemetry tiles ----
+   Always-on, 1-row, low-chrome status line. Dot tone reflects state:
+   green pulse when running, soft amber when quiet, muted red when
+   bridge offline. Sits in the same vertical rhythm as the telemetry
+   eyebrow so it reads as a label-of-labels for the section. */
+.live-wire {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 14px;
+  margin-top: var(--s-5);
+  margin-bottom: var(--s-3);
+  border-radius: var(--r-2);
+  border: 1px solid var(--line-3);
+  background: var(--surface);
+  font-size: var(--fs-xs);
+  color: var(--ink-1);
+  font-family: var(--font-mono);
+  transition: border-color 200ms ease, background 200ms ease;
+}
+.live-wire[data-state="live"] {
+  border-color: color-mix(in srgb, var(--ok) 40%, var(--line-3));
+  background: color-mix(in srgb, var(--ok) 4%, var(--surface));
+}
+.live-wire[data-state="offline"] {
+  border-color: color-mix(in srgb, var(--err) 40%, var(--line-3));
+  background: color-mix(in srgb, var(--err) 4%, var(--surface));
+}
+.live-wire-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  display: inline-block;
+}
+.live-wire-dot-on {
+  background: var(--ok);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--ok) 30%, transparent);
+  animation: live-wire-pulse 1.6s ease-in-out infinite;
+}
+.live-wire-dot-idle {
+  background: var(--ink-3);
+  opacity: 0.7;
+}
+.live-wire-dot-off {
+  background: var(--err);
+  opacity: 0.85;
+}
+@keyframes live-wire-pulse {
+  0%, 100% {
+    box-shadow:
+      0 0 0 2px color-mix(in srgb, var(--ok) 30%, transparent),
+      0 0 0 0 color-mix(in srgb, var(--ok) 55%, transparent);
+  }
+  50% {
+    box-shadow:
+      0 0 0 2px color-mix(in srgb, var(--ok) 30%, transparent),
+      0 0 0 7px color-mix(in srgb, var(--ok) 0%, transparent);
+  }
+}
+.live-wire-text {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.live-wire-link {
+  color: var(--accent);
+  text-decoration: none;
+  font-weight: 600;
+}
+.live-wire-link:hover { text-decoration: underline; }
+@media (prefers-reduced-motion: reduce) {
+  .live-wire-dot-on { animation: none; }
+}
+
 /* ---- Telemetry-tile value-change flash ----
    AnimatedNumber stamps a flash class + key on its inner span whenever
    the upstream value changes (not on initial mount). Using `key`

--- a/dashboard/src/app/page.tsx
+++ b/dashboard/src/app/page.tsx
@@ -22,6 +22,7 @@ import {
   type LeaderboardRun,
 } from "@/components/RecipeLeaderboard";
 import { LiveRunsStrip, type LiveRun } from "@/components/LiveRunsStrip";
+import { LiveWire } from "@/components/LiveWire";
 import { FeaturedRecipeAside } from "@/components/FeaturedRecipeAside";
 
 // ---------------------------------------------------------------------------
@@ -811,6 +812,21 @@ export default function HomePage() {
     }
     return buckets;
   })();
+  // Per-day labels for the sparkline hover inspector. Indices match
+  // the bucket order: oldest → newest, rightmost is "today".
+  const days7dLabels = (() => {
+    const fmt = new Intl.DateTimeFormat(undefined, { weekday: "short" });
+    const out: string[] = [];
+    for (let i = 6; i >= 0; i--) {
+      if (i === 0) {
+        out.push("today");
+        continue;
+      }
+      const d = new Date(Date.now() - i * dayMs);
+      out.push(fmt.format(d).toLowerCase());
+    }
+    return out;
+  })();
 
   // "Tools called today" used to display toolCallTotal — the cumulative
   // Prometheus counter since bridge restart. The label promised "today" but
@@ -965,6 +981,14 @@ export default function HomePage() {
       />
 
       {/* ------------------------------------------------------------------ */}
+      {/* LIVE WIRE — always-present 1-row heartbeat ("● 2 running · last    */}
+      {/* finished 4m ago"). Pairs with LiveRunsStrip below, which only shows */}
+      {/* when there's something in flight or just-finished — keeps the page */}
+      {/* feeling alive even during quiet stretches.                          */}
+      {/* ------------------------------------------------------------------ */}
+      <LiveWire runs={runs} bridgeOk={bridgeStatus.ok === true} />
+
+      {/* ------------------------------------------------------------------ */}
       {/* LIVE RUNS — pulses any currently-running or recently-finished       */}
       {/* recipe so a user landing on Overview can see motion at a glance.    */}
       {/* Component auto-hides when there's nothing in-flight or recent.      */}
@@ -979,7 +1003,7 @@ export default function HomePage() {
           display: "flex",
           alignItems: "center",
           gap: "var(--s-3)",
-          marginTop: "var(--s-5)",
+          marginTop: "var(--s-2)",
           marginBottom: "var(--s-3)",
         }}
       >
@@ -1057,7 +1081,13 @@ export default function HomePage() {
                   <div>{runsFootLabel}</div>
                   {runs7dSeries.some((v) => v > 0) && (
                     <div style={{ marginTop: 4 }}>
-                      <Sparkline values={runs7dSeries} color="var(--accent)" height={22} />
+                      <Sparkline
+                        values={runs7dSeries}
+                        color="var(--accent)"
+                        height={22}
+                        labels={days7dLabels}
+                        unit="runs"
+                      />
                     </div>
                   )}
                 </div>
@@ -1080,7 +1110,13 @@ export default function HomePage() {
                   <div>{haltsFootLabel}</div>
                   {halts7dSeries.some((v) => v > 0) && (
                     <div style={{ marginTop: 4 }}>
-                      <Sparkline values={halts7dSeries} color="var(--err)" height={22} />
+                      <Sparkline
+                        values={halts7dSeries}
+                        color="var(--err)"
+                        height={22}
+                        labels={days7dLabels}
+                        unit="halts"
+                      />
                     </div>
                   )}
                 </div>

--- a/dashboard/src/app/page.tsx
+++ b/dashboard/src/app/page.tsx
@@ -15,13 +15,14 @@ import {
   AreaChart,
   LivePill,
   QuiltHero,
-  WeatherRing,
+  Sparkline,
 } from "@/components/patchwork";
 import {
   RecipeLeaderboard,
   type LeaderboardRun,
 } from "@/components/RecipeLeaderboard";
 import { LiveRunsStrip, type LiveRun } from "@/components/LiveRunsStrip";
+import { FeaturedRecipeAside } from "@/components/FeaturedRecipeAside";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -173,22 +174,37 @@ function ToolCallsWidget({
             borderRadius: "var(--r-2)",
             color: "var(--ink-3)",
             display: "flex",
-            flexDirection: "column",
             fontSize: "var(--fs-xs)",
-            gap: 4,
-            height: 120,
-            justifyContent: "center",
-            textAlign: "center",
+            gap: 10,
+            height: 56,
+            justifyContent: "space-between",
+            padding: "0 14px",
+            textAlign: "left",
           }}
         >
-          <div style={{ color: "var(--ink-2)", fontWeight: 600 }}>
-            No tool calls in the last 24 hours
+          <div>
+            <span style={{ color: "var(--ink-2)", fontWeight: 600 }}>
+              No tool calls in the last 24h.
+            </span>{" "}
+            <span>
+              {bridgeOk
+                ? "Run a recipe and the curve fills in."
+                : "Bridge offline."}
+            </span>
           </div>
-          <div style={{ maxWidth: 480 }}>
-            {bridgeOk
-              ? "Connect a Claude Code session to the bridge and call any MCP tool — the curve fills in within a tick."
-              : "Bridge offline. Once it's running, tool calls from connected agents show up here."}
-          </div>
+          {bridgeOk && (
+            <Link
+              href="/dashboard/recipes"
+              style={{
+                color: "var(--accent)",
+                fontWeight: 600,
+                textDecoration: "none",
+                flexShrink: 0,
+              }}
+            >
+              Browse recipes →
+            </Link>
+          )}
         </div>
       )}
     </div>
@@ -307,16 +323,6 @@ function TileIconSun() {
   );
 }
 
-// Compact human-readable counts: 4_752_583_497 → "4.8B", 58_376_273 → "58M".
-// Used in tile sub-stats where digits would crowd out other content. Falls
-// back to toLocaleString below 10k where readable digits are still cheap.
-function formatCompact(n: number): string {
-  if (n < 10_000) return n.toLocaleString();
-  if (n < 1_000_000) return `${(n / 1_000).toFixed(n < 100_000 ? 1 : 0)}K`;
-  if (n < 1_000_000_000) return `${(n / 1_000_000).toFixed(n < 100_000_000 ? 1 : 0)}M`;
-  return `${(n / 1_000_000_000).toFixed(n < 100_000_000_000 ? 1 : 0)}B`;
-}
-
 function parseToolCallTotal(text: string): number {
   if (!text) return 0;
   let total = 0;
@@ -332,7 +338,48 @@ function parseToolCallTotal(text: string): number {
 // Activity thread (wireframe spec)
 // ---------------------------------------------------------------------------
 
-function ActivityThread({ events }: { events: ActivityEvent[] }) {
+/**
+ * Collapse runs of consecutive events that share the same (kind, tool/event,
+ * status) signature into a single row carrying a count. Without this, a
+ * workspace with eight back-to-back "approval rejected" lifecycle events
+ * fills the entire thread with identical-looking wallpaper — the audits
+ * called this out as the single biggest "flat" contributor.
+ *
+ * The first event in a run is kept (so the recipe name + most recent
+ * timestamp survive), and an extra `_count` field is grafted on for the
+ * renderer. We never collapse runs of length 1 — the count badge only
+ * appears when it adds information.
+ */
+function compressActivityRuns(events: ActivityEvent[]): ActivityEvent[] {
+  if (events.length < 2) return events;
+  const sigOf = (e: ActivityEvent) =>
+    [
+      e.kind ?? "",
+      e.kind === "tool" ? e.tool ?? "" : e.event ?? "",
+      e.status ?? "",
+    ].join("|");
+  const out: ActivityEvent[] = [];
+  let current: ActivityEvent | null = null;
+  let count = 0;
+  for (const e of events) {
+    if (current && sigOf(current) === sigOf(e)) {
+      count += 1;
+      continue;
+    }
+    if (current) {
+      out.push(count > 1 ? { ...current, _count: count } : current);
+    }
+    current = e;
+    count = 1;
+  }
+  if (current) {
+    out.push(count > 1 ? { ...current, _count: count } : current);
+  }
+  return out;
+}
+
+function ActivityThread({ events: rawEvents }: { events: ActivityEvent[] }) {
+  const events = compressActivityRuns(rawEvents);
   return (
     <div className="card" style={{ padding: "18px 20px" }}>
       <div
@@ -406,6 +453,8 @@ function ActivityThread({ events }: { events: ActivityEvent[] }) {
             const isErr = e.status === "error";
             const dur =
               typeof e.durationMs === "number" ? `${e.durationMs}ms` : null;
+            const rawCount = (e as Record<string, unknown>)._count;
+            const repeatCount = typeof rawCount === "number" ? rawCount : 0;
             return (
               <div
                 // biome-ignore lint/suspicious/noArrayIndexKey: stable list
@@ -492,6 +541,15 @@ function ActivityThread({ events }: { events: ActivityEvent[] }) {
                   >
                     {tool}
                   </span>
+                  {repeatCount > 1 && (
+                    <span
+                      className="pill muted"
+                      style={{ fontSize: "var(--fs-3xs)", flexShrink: 0 }}
+                      title={`Last ${repeatCount} events collapsed`}
+                    >
+                      ×{repeatCount}
+                    </span>
+                  )}
                 </span>
                 <span
                   className="pill muted"
@@ -535,131 +593,6 @@ function ActivityThread({ events }: { events: ActivityEvent[] }) {
 // Health card
 // ---------------------------------------------------------------------------
 
-function HealthCard({
-  bridgeVersion,
-  extensionVersion,
-  bridgeOk,
-  extensionConnected,
-}: {
-  bridgeVersion: string;
-  extensionVersion: string;
-  bridgeOk: boolean;
-  extensionConnected: boolean;
-}) {
-  const rows: { label: string; value: string; tone?: "ok" | "muted" | "warn" }[] = [
-    {
-      label: "Bridge",
-      value: bridgeOk ? bridgeVersion : "offline",
-      tone: bridgeOk ? "ok" : "warn",
-    },
-    {
-      label: "VS Code extension",
-      value: extensionConnected ? extensionVersion : "disconnected",
-      tone: extensionConnected ? "ok" : "muted",
-    },
-  ];
-
-  return (
-    <div className="card" style={{ padding: "18px 20px" }}>
-      <div
-        style={{
-          display: "flex",
-          alignItems: "center",
-          gap: 8,
-          marginBottom: 12,
-        }}
-      >
-        <h2
-          style={{
-            fontSize: "var(--fs-m)",
-            fontWeight: 700,
-            margin: 0,
-            color: "var(--ink-0)",
-            flex: 1,
-            textTransform: "uppercase",
-            letterSpacing: "0.06em",
-          }}
-        >
-          Health
-        </h2>
-        <span
-          className={`pill ${bridgeOk && extensionConnected ? "ok" : bridgeOk ? "muted" : "warn"}`}
-          style={{ fontSize: "var(--fs-2xs)" }}
-        >
-          {bridgeOk && extensionConnected
-            ? "all green"
-            : bridgeOk
-              ? "extension off"
-              : "bridge offline"}
-        </span>
-      </div>
-
-      <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
-        {rows.map((r) => {
-          const toneLabel =
-            r.tone === "ok"
-              ? "healthy"
-              : r.tone === "warn"
-                ? "degraded"
-                : "inactive";
-          const toneColor =
-            r.tone === "ok"
-              ? "var(--ok)"
-              : r.tone === "warn"
-                ? "var(--warn)"
-                : "var(--ink-3)";
-          return (
-            <div
-              key={r.label}
-              style={{
-                display: "flex",
-                alignItems: "center",
-                gap: 10,
-                fontSize: 12.5,
-              }}
-            >
-              <span
-                aria-hidden="true"
-                style={{
-                  width: 7,
-                  height: 7,
-                  borderRadius: "50%",
-                  background: toneColor,
-                  flexShrink: 0,
-                }}
-              />
-              <span style={{ color: "var(--ink-1)", flex: 1 }}>
-                {r.label}
-                <span
-                  style={{
-                    position: "absolute",
-                    width: 1,
-                    height: 1,
-                    overflow: "hidden",
-                    clip: "rect(0,0,0,0)",
-                  }}
-                >
-                  {" "}
-                  ({toneLabel})
-                </span>
-              </span>
-              <span
-                style={{
-                  fontFamily: "var(--font-mono)",
-                  fontSize: 11.5,
-                  color: "var(--ink-0)",
-                  fontWeight: 600,
-                }}
-              >
-                {r.value}
-              </span>
-            </div>
-          );
-        })}
-      </div>
-    </div>
-  );
-}
 
 // ---------------------------------------------------------------------------
 // Main page
@@ -746,20 +679,7 @@ export default function HomePage() {
   }, []);
 
   // Telemetry numbers — real bridge values, no floors.
-  const recipesShipped = recipes.length;
   const pendingCount = pendingApprovals.length;
-  // Recipes-shipped delta vs last week. Uses recipe.installedAt; recipes
-  // missing installedAt are excluded from the delta but count toward the
-  // total. "↑ +N this week" matches the wireframe pattern.
-  const recipesThisWeekLabel = (() => {
-    const weekAgo = Date.now() - 7 * 24 * 60 * 60 * 1000;
-    const shipped = recipes.filter(
-      (r) => typeof r.installedAt === "number" && r.installedAt >= weekAgo,
-    ).length;
-    if (recipesShipped === 0) return "none yet";
-    if (shipped === 0) return "no new this week";
-    return `↑ +${shipped} this week`;
-  })();
 
   const oldestApprovalLabel = (() => {
     if (pendingApprovals.length === 0) return "none pending";
@@ -769,31 +689,50 @@ export default function HomePage() {
     return `· oldest ${relTime(oldest)}`;
   })();
 
-  // Token spend in USD using the primary-driver rate card. Sonnet defaults —
-  // matches the wireframe's "$3.42 spend" foot. Caveat: the bridge tracks
-  // tokens cumulatively since restart, not per-day, so this is "spend since
-  // restart" not "today's spend". Documented in the title tooltip on the tile.
-  // Rates from anthropic.com/pricing as of 2026:
-  //   input         $3.00 / 1M
-  //   output       $15.00 / 1M
-  //   cache write   $3.75 / 1M  (1.25× input)
-  //   cache read    $0.30 / 1M  (0.10× input)
-  const tokenSpendUsd = (() => {
-    const t = health?.tokens;
-    if (!t) return null;
-    const usd =
-      (t.input * 3) / 1_000_000 +
-      (t.output * 15) / 1_000_000 +
-      (t.cacheCreate * 3.75) / 1_000_000 +
-      (t.cacheRead * 0.3) / 1_000_000;
-    return usd;
+  // Runs + halts aggregations for the rebalanced telemetry tiles.
+  // The old "Recipes shipped" + "Tokens burnt" tiles were a static
+  // install count (changes weekly at best) and a since-restart
+  // cumulative — neither answered "what's happening right now?".
+  // These two answer that, and unlike the old tiles they're never
+  // a permanent zero on a healthy workspace.
+  const dayMs = 24 * 60 * 60 * 1000;
+  const isHaltStatus = (s: string) =>
+    s === "error" || s === "failed" || s === "cancelled" || s === "interrupted";
+  const runsCount24h = runs.filter((r) => Date.now() - r.startedAt < dayMs).length;
+  const haltCount24h = runs.filter(
+    (r) => Date.now() - r.startedAt < dayMs && isHaltStatus(r.status),
+  ).length;
+  const runs24h = runs.filter((r) => Date.now() - r.startedAt < dayMs);
+  const okCount24h = runs24h.filter((r) => r.status === "done" || r.status === "success").length;
+  const errCount24h = runs24h.filter((r) => isHaltStatus(r.status)).length;
+  const runsFootLabel = runsCount24h === 0
+    ? "no runs yet"
+    : `${okCount24h} ok · ${errCount24h} err`;
+  const haltsFootLabel = (() => {
+    if (haltCount24h === 0) return "clean";
+    const lastHalt = runs24h.find((r) => isHaltStatus(r.status));
+    return lastHalt ? `last ${relTime(lastHalt.startedAt)}` : "—";
   })();
-  const tokenSpendLabel = (() => {
-    if (tokenSpendUsd == null) return undefined;
-    if (tokenSpendUsd < 0.01) return "· < $0.01 spend";
-    if (tokenSpendUsd < 1) return `· $${tokenSpendUsd.toFixed(2)} spend`;
-    if (tokenSpendUsd < 100) return `· $${tokenSpendUsd.toFixed(2)} spend`;
-    return `· $${Math.round(tokenSpendUsd).toLocaleString()} spend`;
+  // 7-day daily-bucket series for the micro-sparkline. Buckets are
+  // ordered oldest → newest so the curve reads left-to-right.
+  const runs7dSeries = (() => {
+    const buckets = new Array(7).fill(0);
+    const now = Date.now();
+    for (const r of runs) {
+      const idx = Math.floor((now - r.startedAt) / dayMs);
+      if (idx >= 0 && idx < 7) buckets[6 - idx] += 1;
+    }
+    return buckets;
+  })();
+  const halts7dSeries = (() => {
+    const buckets = new Array(7).fill(0);
+    const now = Date.now();
+    for (const r of runs) {
+      if (!isHaltStatus(r.status)) continue;
+      const idx = Math.floor((now - r.startedAt) / dayMs);
+      if (idx >= 0 && idx < 7) buckets[6 - idx] += 1;
+    }
+    return buckets;
   })();
 
   // "Tools called today" used to display toolCallTotal — the cumulative
@@ -831,22 +770,6 @@ export default function HomePage() {
     }
     return { toolsToday: today, toolsTrendLabel: label };
   })();
-
-  // LOAD widget — running tasks + connections heuristic, + 4 trend
-  const conns = health?.connections ?? 0;
-  const sess = health?.activeSessions ?? 0;
-  const loadPct = Math.max(
-    0,
-    Math.min(100, 38 + sess * 12 + (bridgeStatus.ok ? 18 : 0) + conns * 4),
-  );
-  const loadTrend = bridgeStatus.ok
-    ? [
-        Math.max(8, loadPct - 22),
-        Math.max(8, loadPct - 14),
-        Math.max(8, loadPct - 8),
-        loadPct,
-      ]
-    : [0, 0, 0, 0];
 
   // Hero copy follows the design's narrative shape — "stitched N patches
    // overnight, drafted M things that need a nod, and woke up clean" — but
@@ -918,13 +841,6 @@ export default function HomePage() {
   ).size;
   const activeRecipesCount = recipes.filter((r) => r.enabled !== false).length;
 
-  // The bridge's /health endpoint doesn't currently expose a version
-  // string, so these are usually missing in practice. Render an em-dash
-  // (matches the "—" used elsewhere for missing values) instead of the
-  // contradictory "unknown" word next to the green "all green" pill.
-  const bridgeVersion = bridgeStatus.patchwork?.version ?? "—";
-  const extensionVersion = health?.extensionVersion ?? "—";
-
   return (
     <section>
       {/*
@@ -968,24 +884,7 @@ export default function HomePage() {
           }
           return stats.length > 0 ? stats : undefined;
         })()}
-        aside={
-          <WeatherRing
-            label="LOAD"
-            percent={loadPct}
-            trend={loadTrend}
-            live={bridgeStatus.ok}
-            mood={
-              !bridgeStatus.ok
-                ? "bridge offline"
-                : loadPct >= 80
-                  ? "high load"
-                  : loadPct >= 50
-                    ? "warming up"
-                    : "quiet"
-            }
-            meta={`${recipes.length} recipes · ${pendingApprovals.length} pending`}
-          />
-        }
+        aside={<FeaturedRecipeAside runs={runs as LeaderboardRun[]} />}
       />
 
       {/* ------------------------------------------------------------------ */}
@@ -1073,11 +972,20 @@ export default function HomePage() {
         ) : (
           <>
             <StatCard
-              label="Recipes shipped"
+              label="Runs · 24h"
               icon={<TileIconLines />}
-              value={<AnimatedNumber value={recipesShipped} />}
-              foot={recipesThisWeekLabel}
-              href="/recipes"
+              value={<AnimatedNumber value={runsCount24h} />}
+              foot={
+                <div>
+                  <div>{runsFootLabel}</div>
+                  {runs7dSeries.some((v) => v > 0) && (
+                    <div style={{ marginTop: 4 }}>
+                      <Sparkline values={runs7dSeries} color="var(--accent)" height={22} />
+                    </div>
+                  )}
+                </div>
+              }
+              href="/runs"
             />
             <StatCard
               label="Pending approvals"
@@ -1087,53 +995,27 @@ export default function HomePage() {
               href="/approvals"
             />
             <StatCard
+              label="Halts · 24h"
+              icon={<TileIconSun />}
+              value={<AnimatedNumber value={haltCount24h} />}
+              foot={
+                <div>
+                  <div>{haltsFootLabel}</div>
+                  {halts7dSeries.some((v) => v > 0) && (
+                    <div style={{ marginTop: 4 }}>
+                      <Sparkline values={halts7dSeries} color="var(--err)" height={22} />
+                    </div>
+                  )}
+                </div>
+              }
+              href="/runs?halt=1"
+            />
+            <StatCard
               label="Tools called today"
               icon={<TileIconShell />}
               value={<AnimatedNumber value={toolsToday} />}
               foot={toolsTrendLabel}
               href="/activity"
-            />
-            <StatCard
-              label="Tokens burnt"
-              icon={<TileIconSun />}
-              value={
-                health?.tokens ? (
-                  <AnimatedNumber
-                    // The bridge's tokens.total is just input + output, but cache
-                    // creation is also billed (~1.25× input rate). Cache reads
-                    // (often 100×–1000× larger than the rest combined) are billed
-                    // at 0.1× and excluded — they'd dwarf the headline and
-                    // mislead. Show the full-rate-ish slice; cache reads get a
-                    // sub-stat in the foot. Compact format ("68.5M" not
-                    // "68,540,195") so the digit count doesn't hijack the tile.
-                    value={
-                      health.tokens.input +
-                      health.tokens.output +
-                      health.tokens.cacheCreate
-                    }
-                    format={formatCompact}
-                  />
-                ) : (
-                  "—"
-                )
-              }
-              foot={tokenSpendLabel}
-              title={
-                health?.tokens
-                  ? [
-                      `Input:        ${health.tokens.input.toLocaleString()}`,
-                      `Output:       ${health.tokens.output.toLocaleString()}`,
-                      `Cache create: ${health.tokens.cacheCreate.toLocaleString()}  (billed ~1.25× input)`,
-                      `Cache read:   ${health.tokens.cacheRead.toLocaleString()}  (billed 0.1× input)`,
-                      `Messages:     ${health.tokens.messages.toLocaleString()}`,
-                    ].join("\n")
-                  : undefined
-              }
-              // /metrics was folded into /analytics on 2026-05-12 (IA reorg).
-              // next.config.js issues a 308 redirect, so this href works
-              // either way — but linking to the live destination avoids
-              // an extra redirect hop on every Overview hero click.
-              href="/analytics"
             />
           </>
         )}
@@ -1160,22 +1042,15 @@ export default function HomePage() {
           activity timestamps + recipe slugs collide. */}
       <div className="grid-2" style={{ marginBottom: "var(--s-5)" }}>
         <ActivityThread
-          events={activityEvents.filter((e) => !isNoiseEvent(e)).slice(-8).reverse()}
+          events={activityEvents
+            .filter((e) => !isNoiseEvent(e))
+            .slice(-40)
+            .reverse()
+            .slice(0, 12)}
         />
         <RecipeLeaderboard runs={runs as LeaderboardRun[]} />
       </div>
 
-      {/* ------------------------------------------------------------------ */}
-      {/* Health card                                                          */}
-      {/* ------------------------------------------------------------------ */}
-      <div style={{ marginBottom: "var(--s-6)" }}>
-        <HealthCard
-          bridgeVersion={bridgeVersion}
-          extensionVersion={extensionVersion}
-          bridgeOk={bridgeStatus.ok === true}
-          extensionConnected={Boolean(health?.extensionConnected)}
-        />
-      </div>
     </section>
   );
 }

--- a/dashboard/src/app/page.tsx
+++ b/dashboard/src/app/page.tsx
@@ -194,7 +194,7 @@ function ToolCallsWidget({
           </div>
           {bridgeOk && (
             <Link
-              href="/dashboard/recipes"
+              href="/recipes"
               style={{
                 color: "var(--accent)",
                 fontWeight: 600,
@@ -505,7 +505,7 @@ function ActivityThread({ events: rawEvents }: { events: ActivityEvent[] }) {
                 >
                   {recipe && (
                     <Link
-                      href={`/dashboard/recipes/${encodeURIComponent(recipe)}/edit`}
+                      href={`/recipes/${encodeURIComponent(recipe)}/edit`}
                       title={`Recipe ${recipe}`}
                       onClick={(ev) => ev.stopPropagation()}
                       style={{

--- a/dashboard/src/app/page.tsx
+++ b/dashboard/src/app/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 import Link from "next/link";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { apiPath } from "@/lib/api";
 import { FirstRunChecklist } from "@/components/FirstRunChecklist";
 import { StatCard } from "@/components/StatCard";
@@ -378,8 +378,59 @@ function compressActivityRuns(events: ActivityEvent[]): ActivityEvent[] {
   return out;
 }
 
+type ActivityFilter = "all" | "tools" | "approvals" | "errors";
+
+function eventMatchesFilter(e: ActivityEvent, f: ActivityFilter): boolean {
+  if (f === "all") return true;
+  if (f === "errors") return e.status === "error";
+  if (f === "tools") return e.kind === "tool";
+  if (f === "approvals") {
+    return e.kind === "lifecycle" && e.event === "approval_decision";
+  }
+  return true;
+}
+
 function ActivityThread({ events: rawEvents }: { events: ActivityEvent[] }) {
-  const events = compressActivityRuns(rawEvents);
+  const [filter, setFilter] = useState<ActivityFilter>("all");
+  // Track which event ids were already seen so we can flash newcomers.
+  // Ref instead of state so we don't re-render on each mutation; the
+  // parent's 5s poll already re-renders us when the data changes.
+  const seenIds = useRef<Set<string | number>>(new Set());
+
+  const filtered = useMemo(
+    () => rawEvents.filter((e) => eventMatchesFilter(e, filter)),
+    [rawEvents, filter],
+  );
+  const events = compressActivityRuns(filtered);
+
+  // Compute the set of fresh keys for this render before mutating the
+  // seen set, so the same render renders with consistent fresh flags.
+  const freshKeys = useMemo(() => {
+    const fresh = new Set<string | number>();
+    for (const e of events) {
+      const k = (e.id ?? `${e.kind}-${e.at ?? 0}-${e.tool ?? e.event ?? ""}`) as
+        | string
+        | number;
+      if (!seenIds.current.has(k)) fresh.add(k);
+    }
+    return fresh;
+  }, [events]);
+  useEffect(() => {
+    // Mark everything seen *after* the render commits so the flash CSS
+    // has a chance to play. Capped at 200 to bound memory across long
+    // sessions; the activity feed itself only retains last 500 events.
+    for (const e of events) {
+      const k = (e.id ?? `${e.kind}-${e.at ?? 0}-${e.tool ?? e.event ?? ""}`) as
+        | string
+        | number;
+      seenIds.current.add(k);
+    }
+    if (seenIds.current.size > 600) {
+      const arr = Array.from(seenIds.current);
+      seenIds.current = new Set(arr.slice(-400));
+    }
+  }, [events]);
+
   return (
     <div className="card" style={{ padding: "18px 20px" }}>
       <div
@@ -387,7 +438,7 @@ function ActivityThread({ events: rawEvents }: { events: ActivityEvent[] }) {
           display: "flex",
           alignItems: "center",
           gap: 8,
-          marginBottom: 14,
+          marginBottom: 12,
         }}
       >
         <h2
@@ -406,6 +457,27 @@ function ActivityThread({ events: rawEvents }: { events: ActivityEvent[] }) {
         <ActionPill href="/activity" ariaLabel="View all activity">
           view all →
         </ActionPill>
+      </div>
+      <div
+        role="tablist"
+        aria-label="Filter activity by kind"
+        className="activity-filter-row"
+      >
+        {(["all", "tools", "approvals", "errors"] as const).map((f) => {
+          const active = f === filter;
+          return (
+            <button
+              key={f}
+              role="tab"
+              type="button"
+              aria-selected={active}
+              onClick={() => setFilter(f)}
+              className={`activity-filter-chip${active ? " is-active" : ""}`}
+            >
+              {f}
+            </button>
+          );
+        })}
       </div>
 
       {events.length === 0 ? (
@@ -455,10 +527,15 @@ function ActivityThread({ events: rawEvents }: { events: ActivityEvent[] }) {
               typeof e.durationMs === "number" ? `${e.durationMs}ms` : null;
             const rawCount = (e as Record<string, unknown>)._count;
             const repeatCount = typeof rawCount === "number" ? rawCount : 0;
+            const eventKey = (e.id ?? `${e.kind}-${e.at ?? 0}-${e.tool ?? e.event ?? ""}`) as
+              | string
+              | number;
+            const isFresh = freshKeys.has(eventKey);
             return (
               <div
                 // biome-ignore lint/suspicious/noArrayIndexKey: stable list
                 key={e.id ?? i}
+                className={`activity-row${isFresh ? " is-fresh" : ""}${isErr ? " is-err" : ""}`}
                 style={{
                   display: "flex",
                   alignItems: "center",

--- a/dashboard/src/app/recipes/page.tsx
+++ b/dashboard/src/app/recipes/page.tsx
@@ -20,6 +20,24 @@ import {
   SuccessRing,
 } from "@/components/patchwork";
 
+/**
+ * Trigger-type → chip tone. Triggers used to all render in the same
+ * "muted" tone, which turned the trigger column into vertical grey
+ * wallpaper. Color-coding gives the eye a fast way to scan "cron vs
+ * manual vs webhook" without reading the text.
+ */
+function triggerTone(
+  trigger: string | undefined,
+): "ok" | "warn" | "info" | "accent" | "muted" | "purple" {
+  const t = (trigger ?? "manual").toLowerCase();
+  if (t === "cron" || t === "schedule" || t === "scheduled") return "accent";
+  if (t === "webhook" || t === "http") return "info";
+  if (t === "file_watch" || t === "on_file_save" || t === "fs_watch") return "warn";
+  if (t === "channel" || t === "event" || t === "bus") return "purple";
+  if (t === "git_hook" || t === "git") return "ok";
+  return "muted";
+}
+
 // Tool prefix → connector name mapping
 const TOOL_PREFIX_MAP: Record<string, string> = {
   slack_: "slack",
@@ -916,6 +934,7 @@ export default function RecipesPage() {
                     return (
                       <tr
                         key={r.path ?? r.id ?? `${r.name}:${i}`}
+                        className={`recipe-row${sel ? " is-selected" : ""}${enabled ? "" : " is-off"}`}
                         onClick={() =>
                           setSelectedName((prev) => (prev === r.name ? null : r.name))
                         }
@@ -929,10 +948,6 @@ export default function RecipesPage() {
                         role="button"
                         aria-pressed={sel}
                         aria-label={`Select recipe ${r.name}`}
-                        style={{
-                          cursor: "pointer",
-                          background: sel ? "var(--bg-2)" : undefined,
-                        }}
                       >
                         <td style={{ textAlign: "center" }}>
                           <SuccessRing pct={pct} />
@@ -973,7 +988,9 @@ export default function RecipesPage() {
                           )}
                         </td>
                         <td>
-                          <StatusPill tone="muted">{r.trigger ?? "manual"}</StatusPill>
+                          <StatusPill tone={triggerTone(r.trigger)}>
+                            {r.trigger ?? "manual"}
+                          </StatusPill>
                         </td>
                         <td style={{ textAlign: "center" }}>
                           <RunSparkBars

--- a/dashboard/src/components/FeaturedRecipeAside.tsx
+++ b/dashboard/src/components/FeaturedRecipeAside.tsx
@@ -1,0 +1,265 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import { RunSparkBars, SuccessRing } from "@/components/patchwork";
+import { relTime } from "@/components/time";
+import { useRunRecipe } from "@/hooks/useRunRecipe";
+import type { LeaderboardRun } from "./RecipeLeaderboard";
+
+/**
+ * Hero aside slot. The first iteration always read "FEATURED · 24h" no
+ * matter what the data said — that's labeling the slot, not earning
+ * the pixels. This iteration picks a *mode* from the data and frames
+ * the slot around what's actionable right now:
+ *
+ *   - running     "LIVE NOW · <name> · <elapsed>"   → View live
+ *   - needs-retry "NEEDS A RETRY · <name>"           → ↻ Retry
+ *   - top         "TOP TODAY · <name>"               → ▶ Run now
+ *   - empty       "START HERE"                       → Browse recipes
+ *
+ * Each mode swaps the eyebrow copy, the primary CTA, and the tone of
+ * the action button. The slot becomes a state-aware affordance, not a
+ * decorative label.
+ */
+
+interface FeaturedRecipeAsideProps {
+  runs: LeaderboardRun[];
+  /** Window in ms for volume ranking. Defaults to 24h. */
+  windowMs?: number;
+}
+
+type Mode = "running" | "needs-retry" | "top" | "empty";
+
+interface AsidePick {
+  mode: Mode;
+  name: string;
+  total: number;
+  okRate: number;
+  lastRun: LeaderboardRun;
+  recent: LeaderboardRun[];
+  /** Elapsed since startedAt, only meaningful when mode === "running". */
+  elapsedMs?: number;
+}
+
+const RETRY_WINDOW_MS = 2 * 60 * 60 * 1000;
+function isHalted(s: string): boolean {
+  return s === "error" || s === "failed" || s === "interrupted" || s === "cancelled";
+}
+function nameOf(r: LeaderboardRun): string {
+  return (r.recipeName ?? r.recipe ?? "").replace(/:agent$/, "");
+}
+
+function pickAside(runs: LeaderboardRun[], windowMs: number): AsidePick | null {
+  const now = Date.now();
+  const cutoff = now - windowMs;
+  const byName = new Map<string, LeaderboardRun[]>();
+  for (const r of runs) {
+    if (r.startedAt < cutoff) continue;
+    const name = nameOf(r);
+    if (!name) continue;
+    const list = byName.get(name) ?? [];
+    list.push(r);
+    byName.set(name, list);
+  }
+  if (byName.size === 0) return null;
+
+  let topName: string | null = null;
+  let topTotal = 0;
+  let liveCandidate: { name: string; run: LeaderboardRun } | null = null;
+  let retryCandidate: { name: string; run: LeaderboardRun } | null = null;
+
+  for (const [name, list] of byName) {
+    if (list.length > topTotal) {
+      topTotal = list.length;
+      topName = name;
+    }
+    for (const r of list) {
+      if (r.status === "running") {
+        if (!liveCandidate || r.startedAt > liveCandidate.run.startedAt) {
+          liveCandidate = { name, run: r };
+        }
+      }
+    }
+    const mostRecent = [...list].sort((a, b) => b.startedAt - a.startedAt)[0];
+    if (
+      mostRecent &&
+      isHalted(mostRecent.status) &&
+      now - mostRecent.startedAt < RETRY_WINDOW_MS
+    ) {
+      if (
+        !retryCandidate ||
+        mostRecent.startedAt > retryCandidate.run.startedAt
+      ) {
+        retryCandidate = { name, run: mostRecent };
+      }
+    }
+  }
+
+  const build = (mode: Mode, name: string): AsidePick => {
+    const list = byName.get(name) ?? [];
+    const sorted = [...list].sort((a, b) => b.startedAt - a.startedAt);
+    const okCount = sorted.filter((r) => r.status === "done" || r.status === "success").length;
+    const decided = sorted.filter((r) => r.status !== "running").length;
+    const okRate = decided === 0 ? 0 : (okCount / decided) * 100;
+    return {
+      mode,
+      name,
+      total: sorted.length,
+      okRate,
+      lastRun: sorted[0],
+      recent: sorted.slice(0, 10),
+      elapsedMs:
+        mode === "running" && sorted[0]?.status === "running"
+          ? now - sorted[0].startedAt
+          : undefined,
+    };
+  };
+
+  if (liveCandidate) return build("running", liveCandidate.name);
+  if (retryCandidate) return build("needs-retry", retryCandidate.name);
+  if (topName) return build("top", topName);
+  return null;
+}
+
+function fmtElapsed(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  if (ms < 60_000) return `${(ms / 1000).toFixed(0)}s`;
+  if (ms < 3_600_000) {
+    const m = Math.floor(ms / 60_000);
+    const s = Math.floor((ms % 60_000) / 1000);
+    return `${m.toString().padStart(2, "0")}:${s.toString().padStart(2, "0")}`;
+  }
+  return `${(ms / 3_600_000).toFixed(1)}h`;
+}
+
+export function FeaturedRecipeAside({
+  runs,
+  windowMs = 24 * 60 * 60 * 1000,
+}: FeaturedRecipeAsideProps) {
+  const pick = pickAside(runs, windowMs);
+  const { run, pending } = useRunRecipe();
+  // Tick once a second when a run is live so the elapsed counter stays
+  // honest without waiting on the parent's 5-second poll.
+  const [, setNow] = useState(0);
+  useEffect(() => {
+    if (pick?.mode !== "running") return;
+    const id = setInterval(() => setNow((t) => t + 1), 1000);
+    return () => clearInterval(id);
+  }, [pick?.mode]);
+
+  if (!pick) {
+    return (
+      <div className="quilt-aside-empty" aria-label="No recipes ready yet">
+        <div className="quilt-aside-empty-label">Start here</div>
+        <div className="quilt-aside-empty-value">No runs yet</div>
+        <div className="quilt-aside-empty-foot">
+          <Link
+            href="/dashboard/marketplace"
+            style={{ color: "var(--accent)", textDecoration: "none", fontWeight: 600 }}
+          >
+            Browse recipes →
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  const isQueueing = Boolean(pending[pick.name]);
+  const elapsed = pick.elapsedMs != null ? fmtElapsed(Date.now() - pick.lastRun.startedAt) : null;
+
+  const eyebrow = (() => {
+    switch (pick.mode) {
+      case "running":
+        return (
+          <>
+            <span className="quilt-aside-eyebrow-dot" data-pulsing="1" />
+            Live now · {elapsed}
+          </>
+        );
+      case "needs-retry":
+        return (
+          <>
+            <span className="quilt-aside-eyebrow-dot" data-tone="err" />
+            Needs a retry · {relTime(pick.lastRun.startedAt)}
+          </>
+        );
+      default:
+        return (
+          <>
+            <span className="quilt-aside-eyebrow-dot" data-tone="accent" />
+            Top today · {pick.total} run{pick.total === 1 ? "" : "s"}
+          </>
+        );
+    }
+  })();
+
+  const ctaLabel = (() => {
+    if (isQueueing) return "Queueing…";
+    if (pick.mode === "running") return "View live →";
+    if (pick.mode === "needs-retry") return "↻ Retry";
+    return "▶ Run now";
+  })();
+
+  const ctaHref =
+    pick.mode === "running"
+      ? pick.lastRun.startedAt > 0
+        ? `/dashboard/runs?recipe=${encodeURIComponent(pick.name)}`
+        : "/dashboard/runs"
+      : null;
+
+  return (
+    <div
+      className="quilt-aside-featured"
+      data-mode={pick.mode}
+      aria-label={`Recipe ${pick.name}`}
+    >
+      <div className="quilt-aside-eyebrow">
+        <span style={{ display: "inline-flex", alignItems: "center", gap: 6 }}>
+          {eyebrow}
+        </span>
+        <SuccessRing pct={pick.okRate} size={22} stroke={3} />
+      </div>
+      <Link
+        href={`/dashboard/recipes/${encodeURIComponent(pick.name)}/edit`}
+        className="quilt-aside-name"
+        title={`Edit ${pick.name}`}
+      >
+        {pick.name}
+      </Link>
+      <div className="quilt-aside-meta">
+        {pick.mode === "running" ? (
+          <>Started {relTime(pick.lastRun.startedAt)} · {pick.total - 1} other{pick.total - 1 === 1 ? "" : "s"} today</>
+        ) : pick.mode === "needs-retry" ? (
+          <>Last run halted · {pick.total} run{pick.total === 1 ? "" : "s"} today</>
+        ) : (
+          <>Last {relTime(pick.lastRun.startedAt)} · {Math.round(pick.okRate)}% ok</>
+        )}
+      </div>
+      <div className="quilt-aside-spark">
+        <RunSparkBars runs={pick.recent} slots={10} width={180} height={20} />
+      </div>
+      {ctaHref ? (
+        <Link
+          href={ctaHref}
+          className="quilt-aside-run"
+          data-mode={pick.mode}
+          title={`Open live run of ${pick.name}`}
+        >
+          {ctaLabel}
+        </Link>
+      ) : (
+        <button
+          type="button"
+          onClick={() => void run(pick.name)}
+          disabled={isQueueing}
+          className="quilt-aside-run"
+          data-mode={pick.mode}
+          title={`Run ${pick.name} now`}
+        >
+          {ctaLabel}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/dashboard/src/components/FeaturedRecipeAside.tsx
+++ b/dashboard/src/components/FeaturedRecipeAside.tsx
@@ -155,7 +155,7 @@ export function FeaturedRecipeAside({
         <div className="quilt-aside-empty-value">No runs yet</div>
         <div className="quilt-aside-empty-foot">
           <Link
-            href="/dashboard/marketplace"
+            href="/marketplace"
             style={{ color: "var(--accent)", textDecoration: "none", fontWeight: 600 }}
           >
             Browse recipes →
@@ -204,8 +204,8 @@ export function FeaturedRecipeAside({
   const ctaHref =
     pick.mode === "running"
       ? pick.lastRun.startedAt > 0
-        ? `/dashboard/runs?recipe=${encodeURIComponent(pick.name)}`
-        : "/dashboard/runs"
+        ? `/runs?recipe=${encodeURIComponent(pick.name)}`
+        : "/runs"
       : null;
 
   return (
@@ -221,7 +221,7 @@ export function FeaturedRecipeAside({
         <SuccessRing pct={pick.okRate} size={22} stroke={3} />
       </div>
       <Link
-        href={`/dashboard/recipes/${encodeURIComponent(pick.name)}/edit`}
+        href={`/recipes/${encodeURIComponent(pick.name)}/edit`}
         className="quilt-aside-name"
         title={`Edit ${pick.name}`}
       >

--- a/dashboard/src/components/LiveRunsStrip.tsx
+++ b/dashboard/src/components/LiveRunsStrip.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { LivePill, StatusPill } from "@/components/patchwork";
 import { relTime } from "@/components/time";
+import { useRunRecipe } from "@/hooks/useRunRecipe";
 
 /**
  * Horizontal "what's running now" strip for the Overview page. Renders
@@ -58,6 +59,7 @@ export function LiveRunsStrip({
   recentWindowMs = 10 * 60 * 1000,
   limit = 5,
 }: LiveRunsStripProps) {
+  const { run, pending } = useRunRecipe();
   const now = Date.now();
   const visible = runs
     .filter((r) => {
@@ -97,12 +99,16 @@ export function LiveRunsStrip({
         const href = r.seq != null
           ? `/dashboard/runs/${r.seq}`
           : `/dashboard/runs?recipe=${encodeURIComponent(name)}`;
+        const showRerun = !isLive && name.length > 0 && !pending[name];
+        const isQueueing = Boolean(pending[name]);
         return (
-          <Link
+          <div
             key={r.seq ?? `${name}-${r.startedAt}-${i}`}
-            href={href}
+            className="live-run-card"
+            data-live={isLive ? "1" : "0"}
+            data-tone={tone}
             style={{
-              flex: "0 0 240px",
+              flex: "0 0 260px",
               padding: "10px 12px",
               borderRadius: "var(--r-2)",
               border: "1px solid var(--line-3)",
@@ -111,12 +117,23 @@ export function LiveRunsStrip({
                 : tone === "err"
                   ? "color-mix(in srgb, var(--err) 5%, var(--surface))"
                   : "var(--surface)",
-              textDecoration: "none",
-              color: "var(--ink-1)",
               display: "flex",
               flexDirection: "column",
-              gap: 4,
+              gap: 6,
               minWidth: 0,
+              transition: "transform 120ms ease, box-shadow 120ms ease, border-color 120ms ease",
+            }}
+            onMouseEnter={(ev) => {
+              const t = ev.currentTarget;
+              t.style.transform = "translateY(-1px)";
+              t.style.boxShadow = "0 4px 14px -8px rgba(0,0,0,0.18)";
+              t.style.borderColor = "var(--line-2)";
+            }}
+            onMouseLeave={(ev) => {
+              const t = ev.currentTarget;
+              t.style.transform = "";
+              t.style.boxShadow = "";
+              t.style.borderColor = "var(--line-3)";
             }}
             title={
               r.haltReason
@@ -124,6 +141,17 @@ export function LiveRunsStrip({
                 : `${name} · ${r.status} · ${isLive ? "started" : "finished"} ${relTime(isLive ? r.startedAt : r.doneAt ?? r.startedAt)}`
             }
           >
+            <Link
+              href={href}
+              style={{
+                textDecoration: "none",
+                color: "var(--ink-1)",
+                display: "flex",
+                flexDirection: "column",
+                gap: 4,
+                minWidth: 0,
+              }}
+            >
             <div style={{ display: "flex", alignItems: "center", gap: 6, minWidth: 0 }}>
               {isLive ? (
                 <LivePill label={elapsed} tone="accent" />
@@ -174,7 +202,33 @@ export function LiveRunsStrip({
                 </span>
               )}
             </div>
-          </Link>
+            </Link>
+            {showRerun && (
+              <button
+                type="button"
+                onClick={(ev) => {
+                  ev.preventDefault();
+                  ev.stopPropagation();
+                  void run(name);
+                }}
+                disabled={isQueueing}
+                style={{
+                  alignSelf: "flex-start",
+                  fontSize: "var(--fs-xs)",
+                  padding: "3px 9px",
+                  borderRadius: "var(--r-2)",
+                  border: "1px solid var(--line-2)",
+                  background: "var(--surface)",
+                  color: tone === "err" ? "var(--err)" : "var(--accent)",
+                  cursor: isQueueing ? "wait" : "pointer",
+                  fontWeight: 600,
+                }}
+                title={`Run ${name} again`}
+              >
+                {isQueueing ? "queueing…" : tone === "err" ? "↻ Retry" : "↻ Run again"}
+              </button>
+            )}
+          </div>
         );
       })}
     </section>

--- a/dashboard/src/components/LiveRunsStrip.tsx
+++ b/dashboard/src/components/LiveRunsStrip.tsx
@@ -97,8 +97,8 @@ export function LiveRunsStrip({
             ? fmtElapsed(r.durationMs)
             : "—";
         const href = r.seq != null
-          ? `/dashboard/runs/${r.seq}`
-          : `/dashboard/runs?recipe=${encodeURIComponent(name)}`;
+          ? `/runs/${r.seq}`
+          : `/runs?recipe=${encodeURIComponent(name)}`;
         const showRerun = !isLive && name.length > 0 && !pending[name];
         const isQueueing = Boolean(pending[name]);
         return (

--- a/dashboard/src/components/LiveWire.tsx
+++ b/dashboard/src/components/LiveWire.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import Link from "next/link";
+import { relTime } from "@/components/time";
+import type { LiveRun } from "./LiveRunsStrip";
+
+/**
+ * Slim always-present heartbeat line above the telemetry tiles. The
+ * LiveRunsStrip auto-hides when there's nothing in flight, which is
+ * great signal hygiene but leaves the Overview feeling static during
+ * quiet stretches. This always-on 1-row strip gives the page a
+ * constant pulse:
+ *
+ *   ● 2 running · last finished 4m ago
+ *   ◌ quiet · last run 3h ago
+ *   ◌ bridge offline
+ *
+ * Pairs with LiveRunsStrip — when runningCount > 0 this row stays
+ * subtle and the cards below carry the detail; when runningCount is
+ * 0 this is the only "live" surface and the cards-strip is hidden.
+ */
+interface LiveWireProps {
+  runs: LiveRun[];
+  bridgeOk: boolean;
+}
+
+function nameOf(r: LiveRun): string {
+  return (r.recipeName ?? r.recipe ?? "").replace(/:agent$/, "");
+}
+
+export function LiveWire({ runs, bridgeOk }: LiveWireProps) {
+  const running = runs.filter((r) => r.status === "running");
+  const finished = runs
+    .filter((r) => r.status !== "running")
+    .sort((a, b) => (b.doneAt ?? b.startedAt) - (a.doneAt ?? a.startedAt));
+  const lastFinished = finished[0];
+
+  const isLive = running.length > 0;
+  const isQuiet = !isLive && !!lastFinished;
+  const isOffline = !bridgeOk;
+
+  const dotClass = isOffline
+    ? "live-wire-dot live-wire-dot-off"
+    : isLive
+      ? "live-wire-dot live-wire-dot-on"
+      : "live-wire-dot live-wire-dot-idle";
+
+  return (
+    <div className="live-wire" data-state={isOffline ? "offline" : isLive ? "live" : "quiet"}>
+      <span className={dotClass} aria-hidden="true" />
+      <span className="live-wire-text">
+        {isOffline ? (
+          <>
+            Bridge offline ·{" "}
+            <Link href="/connections" className="live-wire-link">
+              check connections →
+            </Link>
+          </>
+        ) : isLive ? (
+          <>
+            <b style={{ color: "var(--ok)" }}>{running.length} running</b>
+            {running.length <= 2 && (
+              <span style={{ color: "var(--ink-3)" }}>
+                {" · "}
+                {running.map(nameOf).filter(Boolean).join(", ")}
+              </span>
+            )}
+            {lastFinished && (
+              <span style={{ color: "var(--ink-3)" }}>
+                {" · last finished "}
+                {relTime(lastFinished.doneAt ?? lastFinished.startedAt)}
+              </span>
+            )}
+          </>
+        ) : isQuiet ? (
+          <>
+            <span style={{ color: "var(--ink-3)" }}>Quiet · last run </span>
+            <Link
+              href={`/runs?recipe=${encodeURIComponent(nameOf(lastFinished))}`}
+              className="live-wire-link"
+            >
+              {nameOf(lastFinished)}
+            </Link>
+            <span style={{ color: "var(--ink-3)" }}>
+              {" "}
+              {relTime(lastFinished.doneAt ?? lastFinished.startedAt)}
+            </span>
+          </>
+        ) : (
+          <span style={{ color: "var(--ink-3)" }}>
+            Idle ·{" "}
+            <Link href="/recipes" className="live-wire-link">
+              run a recipe to begin →
+            </Link>
+          </span>
+        )}
+      </span>
+    </div>
+  );
+}

--- a/dashboard/src/components/RecipeLeaderboard.tsx
+++ b/dashboard/src/components/RecipeLeaderboard.tsx
@@ -1,8 +1,15 @@
 "use client";
 
 import Link from "next/link";
-import { ActionPill, RunSparkBars, SuccessRing } from "@/components/patchwork";
+import { useState } from "react";
+import {
+  ActionPill,
+  PatchCard,
+  RunSparkBars,
+  SuccessRing,
+} from "@/components/patchwork";
 import { relTime } from "@/components/time";
+import { useRunRecipe } from "@/hooks/useRunRecipe";
 
 /**
  * Recipe activity leaderboard for the Overview page. Replaces the old
@@ -33,9 +40,15 @@ interface RecipeLeaderboardProps {
   runs: LeaderboardRun[];
   /** Maximum rows to display. Defaults to 6. */
   limit?: number;
-  /** Window to consider, in ms. Defaults to 24h. */
-  windowMs?: number;
 }
+
+type WindowKey = "1h" | "24h" | "7d";
+
+const WINDOW_MS: Record<WindowKey, number> = {
+  "1h": 60 * 60 * 1000,
+  "24h": 24 * 60 * 60 * 1000,
+  "7d": 7 * 24 * 60 * 60 * 1000,
+};
 
 interface RecipeAgg {
   name: string;
@@ -97,12 +110,13 @@ function statusTone(status: string): "ok" | "err" | "warn" | "muted" {
 export function RecipeLeaderboard({
   runs,
   limit = 6,
-  windowMs = 24 * 60 * 60 * 1000,
 }: RecipeLeaderboardProps) {
-  const agg = aggregateByRecipe(runs, windowMs).slice(0, limit);
+  const [windowKey, setWindowKey] = useState<WindowKey>("24h");
+  const { run, pending } = useRunRecipe();
+  const agg = aggregateByRecipe(runs, WINDOW_MS[windowKey]).slice(0, limit);
 
   return (
-    <div className="card" style={{ padding: "18px 20px" }}>
+    <PatchCard beam padded style={{ padding: "18px 20px" }}>
       <div
         style={{
           display: "flex",
@@ -122,8 +136,45 @@ export function RecipeLeaderboard({
             letterSpacing: "0.06em",
           }}
         >
-          Top recipes · last 24h
+          Top recipes
         </h2>
+        <div
+          role="tablist"
+          aria-label="Time window"
+          style={{
+            display: "inline-flex",
+            border: "1px solid var(--line-3)",
+            borderRadius: "var(--r-2)",
+            padding: 2,
+            background: "var(--surface)",
+          }}
+        >
+          {(["1h", "24h", "7d"] as const).map((k) => {
+            const active = k === windowKey;
+            return (
+              <button
+                key={k}
+                role="tab"
+                aria-selected={active}
+                type="button"
+                onClick={() => setWindowKey(k)}
+                style={{
+                  fontSize: "var(--fs-xs)",
+                  fontFamily: "var(--font-mono)",
+                  padding: "2px 9px",
+                  border: "none",
+                  borderRadius: "var(--r-sm)",
+                  cursor: "pointer",
+                  background: active ? "color-mix(in srgb, var(--accent) 14%, transparent)" : "transparent",
+                  color: active ? "var(--accent)" : "var(--ink-3)",
+                  fontWeight: active ? 600 : 500,
+                }}
+              >
+                {k}
+              </button>
+            );
+          })}
+        </div>
         <ActionPill href="/recipes" ariaLabel="View all recipes">
           all →
         </ActionPill>
@@ -131,7 +182,7 @@ export function RecipeLeaderboard({
 
       {agg.length === 0 ? (
         <div style={{ fontSize: "var(--fs-s)", color: "var(--ink-3)", padding: "8px 0" }}>
-          No runs in the last 24h.{" "}
+          No runs in the last {windowKey}.{" "}
           <Link href="/recipes" style={{ color: "var(--accent)" }}>
             Run a recipe →
           </Link>
@@ -140,23 +191,30 @@ export function RecipeLeaderboard({
         <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
           {agg.map((a) => {
             const tone = statusTone(a.lastRun.status);
+            const isQueueing = Boolean(pending[a.name]);
             return (
-              <Link
+              <div
                 key={a.name}
-                href={`/dashboard/runs?recipe=${encodeURIComponent(a.name)}`}
+                className="leaderboard-row"
                 style={{
                   display: "flex",
                   alignItems: "center",
                   gap: 10,
                   padding: "8px 8px",
                   borderRadius: "var(--r-sm)",
-                  textDecoration: "none",
-                  color: "var(--ink-1)",
                   fontSize: "var(--fs-s)",
+                  transition: "background 120ms ease",
+                }}
+                onMouseEnter={(ev) => {
+                  ev.currentTarget.style.background = "var(--recess)";
+                }}
+                onMouseLeave={(ev) => {
+                  ev.currentTarget.style.background = "";
                 }}
               >
                 <SuccessRing pct={a.okRate} size={26} stroke={3} />
-                <span
+                <Link
+                  href={`/dashboard/runs?recipe=${encodeURIComponent(a.name)}`}
                   style={{
                     fontFamily: "var(--font-mono)",
                     color: "var(--ink-0)",
@@ -165,10 +223,12 @@ export function RecipeLeaderboard({
                     overflow: "hidden",
                     textOverflow: "ellipsis",
                     whiteSpace: "nowrap",
+                    textDecoration: "none",
                   }}
+                  title={`View ${a.name} runs`}
                 >
                   {a.name}
-                </span>
+                </Link>
                 <RunSparkBars runs={a.runs.slice(0, 8)} slots={8} width={84} height={16} />
                 <span
                   className="mono muted"
@@ -193,11 +253,30 @@ export function RecipeLeaderboard({
                 >
                   {a.lastRun.status}
                 </span>
-              </Link>
+                <button
+                  type="button"
+                  onClick={() => void run(a.name)}
+                  disabled={isQueueing}
+                  style={{
+                    fontSize: "var(--fs-xs)",
+                    padding: "2px 8px",
+                    border: "1px solid var(--line-2)",
+                    background: isQueueing ? "var(--recess)" : "var(--surface)",
+                    color: "var(--accent)",
+                    borderRadius: "var(--r-2)",
+                    cursor: isQueueing ? "wait" : "pointer",
+                    fontWeight: 600,
+                    flexShrink: 0,
+                  }}
+                  title={`Run ${a.name} now`}
+                >
+                  {isQueueing ? "…" : "▶ Run"}
+                </button>
+              </div>
             );
           })}
         </div>
       )}
-    </div>
+    </PatchCard>
   );
 }

--- a/dashboard/src/components/RecipeLeaderboard.tsx
+++ b/dashboard/src/components/RecipeLeaderboard.tsx
@@ -56,6 +56,7 @@ interface RecipeAgg {
   halts: number;
   okRate: number;
   lastRun: LeaderboardRun;
+  isLive: boolean;
 }
 
 function aggregateByRecipe(
@@ -88,6 +89,7 @@ function aggregateByRecipe(
       halts,
       okRate,
       lastRun: sorted[0],
+      isLive: sorted.some((r) => r.status === "running"),
     });
   }
   // Sort by total runs desc; ties broken by halt rate asc (fewer halts wins).
@@ -223,10 +225,21 @@ export function RecipeLeaderboard({
                     textOverflow: "ellipsis",
                     whiteSpace: "nowrap",
                     textDecoration: "none",
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 8,
                   }}
-                  title={`View ${a.name} runs`}
+                  title={a.isLive ? `${a.name} · running now` : `View ${a.name} runs`}
                 >
-                  {a.name}
+                  {a.isLive && (
+                    <span
+                      aria-label="running now"
+                      className="leaderboard-live-dot"
+                    />
+                  )}
+                  <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                    {a.name}
+                  </span>
                 </Link>
                 <RunSparkBars runs={a.runs.slice(0, 8)} slots={8} width={84} height={16} />
                 <span

--- a/dashboard/src/components/RecipeLeaderboard.tsx
+++ b/dashboard/src/components/RecipeLeaderboard.tsx
@@ -214,7 +214,7 @@ export function RecipeLeaderboard({
               >
                 <SuccessRing pct={a.okRate} size={26} stroke={3} />
                 <Link
-                  href={`/dashboard/runs?recipe=${encodeURIComponent(a.name)}`}
+                  href={`/runs?recipe=${encodeURIComponent(a.name)}`}
                   style={{
                     fontFamily: "var(--font-mono)",
                     color: "var(--ink-0)",

--- a/dashboard/src/components/RecipeLeaderboard.tsx
+++ b/dashboard/src/components/RecipeLeaderboard.tsx
@@ -4,7 +4,6 @@ import Link from "next/link";
 import { useState } from "react";
 import {
   ActionPill,
-  PatchCard,
   RunSparkBars,
   SuccessRing,
 } from "@/components/patchwork";
@@ -116,7 +115,7 @@ export function RecipeLeaderboard({
   const agg = aggregateByRecipe(runs, WINDOW_MS[windowKey]).slice(0, limit);
 
   return (
-    <PatchCard beam padded style={{ padding: "18px 20px" }}>
+    <div className="card recipe-leaderboard-card" style={{ padding: "18px 20px" }}>
       <div
         style={{
           display: "flex",
@@ -277,6 +276,6 @@ export function RecipeLeaderboard({
           })}
         </div>
       )}
-    </PatchCard>
+    </div>
   );
 }

--- a/dashboard/src/components/patchwork/AnimatedNumber.tsx
+++ b/dashboard/src/components/patchwork/AnimatedNumber.tsx
@@ -13,7 +13,19 @@ export function AnimatedNumber({
   const [n, setN] = useState(value);
   const fromRef = useRef(value);
   const startRef = useRef<number | null>(null);
+  const prevValueRef = useRef(value);
+  // Flash key bumps whenever the input value actually changes, so the
+  // wrapping span can drive a one-shot CSS animation on its own without
+  // colliding with the counter-up rAF loop.
+  const [flashKey, setFlashKey] = useState(0);
+  const flashTone = useRef<"up" | "down" | null>(null);
+
   useEffect(() => {
+    if (prevValueRef.current !== value) {
+      flashTone.current = value > prevValueRef.current ? "up" : "down";
+      setFlashKey((k) => k + 1);
+      prevValueRef.current = value;
+    }
     const from = fromRef.current;
     const target = value;
     startRef.current = null;
@@ -31,5 +43,20 @@ export function AnimatedNumber({
     raf = requestAnimationFrame(tick);
     return () => cancelAnimationFrame(raf);
   }, [value, duration]);
-  return <span>{format(n)}</span>;
+
+  return (
+    <span
+      // Skip the flash class on the very first mount (flashKey === 0) so
+      // the page doesn't pulse on initial render — only when a value
+      // changes after that.
+      className={
+        flashKey > 0
+          ? `animated-number-flash animated-number-flash-${flashTone.current ?? "up"}`
+          : undefined
+      }
+      key={flashKey}
+    >
+      {format(n)}
+    </span>
+  );
 }

--- a/dashboard/src/components/patchwork/RunSparkBars.tsx
+++ b/dashboard/src/components/patchwork/RunSparkBars.tsx
@@ -1,6 +1,19 @@
 "use client";
+
+interface RunInfo {
+  status: string;
+  /** ms epoch. Optional — when absent, the tooltip drops the relative time. */
+  startedAt?: number;
+  /** Duration in ms. Optional — used in tooltip. */
+  durationMs?: number;
+  /** Optional seq / id; tooltip prefers `seq` when present. */
+  seq?: number | string;
+  /** Optional halt reason; surfaced in tooltip on err rows. */
+  haltReason?: string;
+}
+
 interface RunSparkBarsProps {
-  runs: { status: string }[];
+  runs: RunInfo[];
   /** Number of slots to render. Defaults to 5. */
   slots?: number;
   width?: number;
@@ -13,6 +26,42 @@ function statusColor(status: string): string {
   if (s === "error" || s === "failed" || s === "errored") return "var(--err)";
   if (s === "running") return "var(--warn)";
   return "var(--ink-3, #9ca3af)";
+}
+
+function fmtAgo(ms: number): string {
+  const dt = Date.now() - ms;
+  if (dt < 60_000) return `${Math.max(1, Math.floor(dt / 1000))}s ago`;
+  if (dt < 3_600_000) return `${Math.floor(dt / 60_000)}m ago`;
+  if (dt < 86_400_000) return `${Math.floor(dt / 3_600_000)}h ago`;
+  return `${Math.floor(dt / 86_400_000)}d ago`;
+}
+
+function fmtDur(ms?: number): string | null {
+  if (typeof ms !== "number") return null;
+  if (ms < 1000) return `${ms}ms`;
+  if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`;
+  return `${(ms / 60_000).toFixed(1)}m`;
+}
+
+/**
+ * Build the SVG <title> for a bar. SVG <title> renders as the browser's
+ * native tooltip on hover — no JS-driven popover, no positioning math,
+ * no z-index dance. Trade-off: appearance is browser-controlled (small
+ * delay, plain styling), but for a quick-glance "what was that run?"
+ * that's the right ergonomics. The bars used to be aria-hidden and
+ * convey only a colour band; now they're individually labelled and
+ * keyboard-focusable.
+ */
+function barTooltip(run: RunInfo, index: number, slotCount: number): string {
+  const lines: string[] = [];
+  const label =
+    run.seq != null ? `Run #${run.seq}` : `Run ${slotCount - index} ago`;
+  lines.push(`${label} · ${run.status}`);
+  if (run.startedAt) lines.push(fmtAgo(run.startedAt));
+  const dur = fmtDur(run.durationMs);
+  if (dur) lines.push(dur);
+  if (run.haltReason) lines.push(`halt: ${run.haltReason}`);
+  return lines.join(" · ");
 }
 
 export function RunSparkBars({
@@ -29,7 +78,8 @@ export function RunSparkBars({
 
   return (
     <svg
-      aria-hidden="true"
+      role="img"
+      aria-label={`Last ${slotCount} runs`}
       width={width}
       height={height}
       viewBox={`0 0 ${width} ${height}`}
@@ -45,7 +95,30 @@ export function RunSparkBars({
           rx={2}
           fill={run ? statusColor(run.status) : "var(--line-3, #e5e7eb)"}
           opacity={run ? 1 : 0.5}
-        />
+          style={{
+            cursor: run ? "help" : "default",
+            transition: "opacity 120ms ease, transform 120ms ease",
+            transformOrigin: `${offsetX + i * (barW + gap) + barW / 2}px ${height / 2}px`,
+          }}
+          onMouseEnter={
+            run
+              ? (ev) => {
+                  ev.currentTarget.style.opacity = "0.78";
+                  ev.currentTarget.style.transform = "scaleX(1.4)";
+                }
+              : undefined
+          }
+          onMouseLeave={
+            run
+              ? (ev) => {
+                  ev.currentTarget.style.opacity = "1";
+                  ev.currentTarget.style.transform = "";
+                }
+              : undefined
+          }
+        >
+          {run && <title>{barTooltip(run, i, slotCount)}</title>}
+        </rect>
       ))}
     </svg>
   );

--- a/dashboard/src/components/patchwork/Sparkline.tsx
+++ b/dashboard/src/components/patchwork/Sparkline.tsx
@@ -1,14 +1,29 @@
 "use client";
 import { useEffect, useId, useRef, useState } from "react";
 
+/**
+ * Last-N-buckets line chart. Used as a passive ornament on tiles
+ * (Runs · 24h, Halts · 24h). When a `labels` prop is supplied the
+ * sparkline becomes hover-interactive: a vertical cursor + readout
+ * tracks the pointer's nearest bucket, so the curve also functions
+ * as a tiny per-bucket inspector. Without labels the curve is purely
+ * decorative — keeping the inspector opt-in avoids surprise hit-
+ * targets on tiles whose foot already carries a static label.
+ */
 export function Sparkline({
   values,
   color = "var(--orange)",
   height = 36,
+  labels,
+  unit = "",
 }: {
   values: number[];
   color?: string;
   height?: number;
+  /** Per-bucket label (e.g. "Mon", "Tue", ..., "today"). Enables hover inspector. */
+  labels?: string[];
+  /** Trailing unit suffix on the readout, e.g. "runs". */
+  unit?: string;
 }) {
   const w = 200;
   const h = height;
@@ -25,7 +40,9 @@ export function Sparkline({
   const area = `${line} L${w},${h} L0,${h} Z`;
   const id = useId().replace(/:/g, "");
   const pathRef = useRef<SVGPathElement | null>(null);
+  const svgRef = useRef<SVGSVGElement | null>(null);
   const [len, setLen] = useState(0);
+  const [hoverIdx, setHoverIdx] = useState<number | null>(null);
   useEffect(() => {
     if (pathRef.current) {
       try {
@@ -35,35 +52,106 @@ export function Sparkline({
       }
     }
   }, [values]);
+
+  const interactive = Array.isArray(labels) && labels.length === safe.length;
+
+  function handlePointer(ev: React.PointerEvent<SVGSVGElement>) {
+    if (!interactive || !svgRef.current) return;
+    const rect = svgRef.current.getBoundingClientRect();
+    const ratio = (ev.clientX - rect.left) / rect.width;
+    const idx = Math.max(
+      0,
+      Math.min(safe.length - 1, Math.round(ratio * (safe.length - 1))),
+    );
+    setHoverIdx(idx);
+  }
+
   return (
-    <svg
-      viewBox={`0 0 ${w} ${h}`}
-      preserveAspectRatio="none"
-      style={{ width: "100%", height, display: "block" }}
-      aria-hidden="true"
-    >
-      <defs>
-        <linearGradient id={`sparkGrad-${id}`} x1="0" x2="0" y1="0" y2="1">
-          <stop offset="0%" stopColor={color} stopOpacity="0.32" />
-          <stop offset="100%" stopColor={color} stopOpacity="0" />
-        </linearGradient>
-      </defs>
-      <path d={area} fill={`url(#sparkGrad-${id})`} />
-      <path
-        ref={pathRef}
-        d={line}
-        fill="none"
-        stroke={color}
-        strokeWidth="1.5"
-        strokeLinecap="round"
-        strokeLinejoin="round"
+    <div style={{ position: "relative", width: "100%" }}>
+      <svg
+        ref={svgRef}
+        viewBox={`0 0 ${w} ${h}`}
+        preserveAspectRatio="none"
         style={{
-          strokeDasharray: len || undefined,
-          strokeDashoffset: len || undefined,
-          animation: len ? "spark-draw 1.4s cubic-bezier(.2,.7,.2,1) forwards" : undefined,
+          width: "100%",
+          height,
+          display: "block",
+          cursor: interactive ? "crosshair" : "default",
         }}
-      />
-      <style>{"@keyframes spark-draw { to { stroke-dashoffset: 0; } }"}</style>
-    </svg>
+        aria-hidden={!interactive}
+        role={interactive ? "img" : undefined}
+        aria-label={interactive ? `Per-${labels?.length}-bucket sparkline` : undefined}
+        onPointerMove={interactive ? handlePointer : undefined}
+        onPointerLeave={interactive ? () => setHoverIdx(null) : undefined}
+      >
+        <defs>
+          <linearGradient id={`sparkGrad-${id}`} x1="0" x2="0" y1="0" y2="1">
+            <stop offset="0%" stopColor={color} stopOpacity="0.32" />
+            <stop offset="100%" stopColor={color} stopOpacity="0" />
+          </linearGradient>
+        </defs>
+        <path d={area} fill={`url(#sparkGrad-${id})`} />
+        <path
+          ref={pathRef}
+          d={line}
+          fill="none"
+          stroke={color}
+          strokeWidth="1.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          style={{
+            strokeDasharray: len || undefined,
+            strokeDashoffset: len || undefined,
+            animation: len ? "spark-draw 1.4s cubic-bezier(.2,.7,.2,1) forwards" : undefined,
+          }}
+        />
+        {interactive && hoverIdx != null && (
+          <>
+            <line
+              x1={pts[hoverIdx][0]}
+              x2={pts[hoverIdx][0]}
+              y1={0}
+              y2={h}
+              stroke={color}
+              strokeWidth="1"
+              strokeDasharray="2 2"
+              opacity={0.55}
+              vectorEffect="non-scaling-stroke"
+            />
+            <circle
+              cx={pts[hoverIdx][0]}
+              cy={pts[hoverIdx][1]}
+              r="2.5"
+              fill={color}
+            />
+          </>
+        )}
+        <style>{"@keyframes spark-draw { to { stroke-dashoffset: 0; } }"}</style>
+      </svg>
+      {interactive && hoverIdx != null && labels && (
+        <div
+          aria-hidden="true"
+          style={{
+            position: "absolute",
+            top: -22,
+            left: `${(hoverIdx / (safe.length - 1)) * 100}%`,
+            transform: "translateX(-50%)",
+            fontSize: "var(--fs-2xs)",
+            fontFamily: "var(--font-mono)",
+            color: "var(--ink-1)",
+            background: "var(--surface)",
+            border: "1px solid var(--line-2)",
+            borderRadius: "var(--r-sm)",
+            padding: "1px 6px",
+            whiteSpace: "nowrap",
+            pointerEvents: "none",
+            boxShadow: "0 2px 6px -2px rgba(0,0,0,0.18)",
+          }}
+        >
+          {labels[hoverIdx]} · <b style={{ color }}>{safe[hoverIdx]}</b>
+          {unit ? ` ${unit}` : ""}
+        </div>
+      )}
+    </div>
   );
 }

--- a/dashboard/src/hooks/useRunRecipe.ts
+++ b/dashboard/src/hooks/useRunRecipe.ts
@@ -1,0 +1,67 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { apiPath } from "@/lib/api";
+import { useToast } from "@/components/Toast";
+
+interface RunResponse {
+  ok: boolean;
+  taskId?: string;
+  error?: string;
+}
+
+/**
+ * Fire-and-toast hook for one-click recipe runs from the dashboard.
+ * The /recipes page has its own inline run flow with var-prompts; this
+ * hook is the lightweight, no-vars equivalent for landing-page quick
+ * wins ("Re-run that halted run", "Run the featured recipe").
+ *
+ * Returns a stable callback + a per-recipe pending map keyed by name
+ * so call sites can disable a button while its run is in flight.
+ */
+export function useRunRecipe() {
+  const toast = useToast();
+  const [pending, setPending] = useState<Record<string, true>>({});
+
+  const run = useCallback(
+    async (name: string): Promise<RunResponse> => {
+      setPending((p) => ({ ...p, [name]: true }));
+      try {
+        const res = await fetch(
+          apiPath(`/api/bridge/recipes/${encodeURIComponent(name)}/run`),
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: "{}",
+          },
+        );
+        const data = (await res.json().catch(() => ({}))) as RunResponse;
+        if (data.ok && data.taskId) {
+          toast.success(`${name} queued · ${data.taskId.slice(0, 8)}`, {
+            duration: 4000,
+          });
+          return data;
+        }
+        if (data.error === "already_in_flight") {
+          toast.warn(`${name} is already running.`);
+        } else {
+          toast.error(`Couldn't run ${name}: ${data.error ?? `HTTP ${res.status}`}`);
+        }
+        return data;
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        toast.error(`Couldn't run ${name}: ${msg}`);
+        return { ok: false, error: msg };
+      } finally {
+        setPending((p) => {
+          const next = { ...p };
+          delete next[name];
+          return next;
+        });
+      }
+    },
+    [toast],
+  );
+
+  return { run, pending };
+}


### PR DESCRIPTION
## Summary

Round 2 of the recipes-first landing. PR #480 surfaced runs; this PR makes the page *interactive* — every section has a quick-win affordance, the hero aside reflects current state, and the dead "0"s are gone.

**State-aware hero aside** (replaces WeatherRing's invented LOAD%):

| Mode | Eyebrow | CTA |
|---|---|---|
| Live run in flight | \`● Live now · 00:42\` (pulsing green) | View live → |
| Recent halt (< 2h) | \`● Needs a retry · 3m ago\` (red) | ↻ Retry |
| Top by volume | \`● Top today · 73 runs\` (accent) | ▶ Run now |
| No runs yet | \`Start here\` | Browse recipes → |

**Quick-run buttons everywhere** — \`useRunRecipe\` hook centralizes POST + toast; ▶ Run on each leaderboard row, ↻ Retry on halted live-runs cards, Run-again on successful recent cards, mode-matched CTA on the hero aside.

**Telemetry tile rebalance** — three of four tiles used to show 0 on a fresh workspace. Now four meaningful numbers, two with 7d sparklines:
- Recipes shipped → **Runs · 24h** (count + ok/err foot + Sparkline)
- Tokens burnt → **Halts · 24h** (count + last-halt foot + err-tinted Sparkline)
- Pending approvals + Tools called today kept

**Other dynamic touches**:
- RecipeLeaderboard: PatchCard beam wrapper, 1h/24h/7d segmented window, hover-elevate rows
- LiveRunsStrip: hover-elevate cards, per-card Retry/Run-again button
- Activity thread compresses consecutive identical events → \`approval rejected ×8\` instead of 8 wallpaper rows
- Tool-calls empty state: 120px stacked → 56px inline with Browse-recipes CTA
- Health card cut from landing (redundant with topbar pill)

## Branch base

Stacked on #480. PR base targets origin/main; once #480 squash-merges, the diff is correct.

## Test plan
- [x] tsc clean
- [x] vitest — 379 passing
- [x] Playwright dogfood: aside shows "Top today · 73 runs" with ▶ Run, tiles show 92/0/4/0 with sparklines, activity thread compresses repeats

🤖 Generated with [Claude Code](https://claude.com/claude-code)