### PR TITLE
fix(dashboard): wrong path "templates/recipes" → "~/.patchwork/recipes"

### DIFF
--- a/dashboard/src/app/recipes/page.tsx
+++ b/dashboard/src/app/recipes/page.tsx
@@ -796,7 +796,7 @@ export default function RecipesPage() {
           </div>
           <div className="editorial-sub">
             {recipes
-              ? `templates/recipes · ${installedCount} installed · ${enabledCount} enabled`
+              ? `~/.patchwork/recipes · ${installedCount} installed · ${enabledCount} enabled`
               : "Loading…"}
           </div>
           <RelationStrip

--- a/dashboard/src/components/FirstRunChecklist.tsx
+++ b/dashboard/src/components/FirstRunChecklist.tsx
@@ -123,7 +123,7 @@ export function FirstRunChecklist() {
       recipes: {
         done: recipes > 0,
         hint: "Browse the marketplace or scaffold one with patchwork recipe new.",
-        doneHint: "YAML lives in templates/recipes. Tweak triggers and steps in /recipes.",
+        doneHint: "YAML lives in ~/.patchwork/recipes. Tweak triggers and steps in /recipes.",
       },
       runs: {
         done: runs > 0,


### PR DESCRIPTION
## Summary

Dogfooding the first-run checklist's step 2 ("Install or create a recipe") surfaced a copy bug visible to every dashboard user.

Both the **checklist's step-2 doneHint** and the **/recipes page editorial-sub** claim recipes live in \`templates/recipes\`. But that path is just the bundled-with-product set in the repo (13 yamls). Actual user installs — including anything created via /recipes/new — land in \`~/.patchwork/recipes/\` (38 yamls on a healthy workspace).

Confirmed via end-to-end dogfood:
- Filled /recipes/new with a test recipe → clicked Create YAML draft
- Page navigated to /recipes/dogfood-test-recipe/edit
- File appeared at \`~/.patchwork/recipes/dogfood-test-recipe.yaml\` (373 chars)
- \`templates/recipes\` directory was untouched

Both copy strings updated. No behavior change beyond the text.

## Out of scope (separate bug)

The same dogfood session also surfaced **Marketplace Install silently 500s when the bridge is offline** — the Install button stays clickable and only renders a tiny red "Internal server error" string under the card with no guidance that the bridge needs to be running. Needs a bridge-status guard on the button. Punted to a follow-up since the fix is more involved (UX states + maybe a tooltip).

## Test plan
- [x] tsc clean
- [x] vitest 395/395 passing
- [x] Verified bug live before fix; copy reads correctly after

🤖 Generated with [Claude Code](https://claude.com/claude-code)