### PR TITLE
fix(dashboard): marketplace honesty pass + install UX

### DIFF
--- a/dashboard/src/app/marketplace/page.tsx
+++ b/dashboard/src/app/marketplace/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 import Link from "next/link";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { Skeleton, SkeletonText } from "@/components/Skeleton";
 import { HintCard } from "@/components/patchwork";
 import { apiPath } from "@/lib/api";
@@ -437,26 +437,35 @@ export default function MarketplacePage() {
   const [searchOpen, setSearchOpen] = useState(false);
   const toast = useToast();
 
+  // Re-probe bridge + refresh the installed-names Set. Extracted so the
+  // post-install handler can call it to (a) catch the name-divergence
+  // bug where the dashboard tracks marketplace name but the bridge keys
+  // on the recipe's own YAML `name` field — without a refresh the
+  // "Installed" pill can lie — and (b) flip the offline banner if the
+  // bridge died mid-session.
+  const refreshInstalled = useCallback(async () => {
+    try {
+      const r = await fetch(apiPath("/api/bridge/recipes"));
+      if (!r.ok) {
+        setBridgeOnline(false);
+        return;
+      }
+      const data = await r.json();
+      const list = Array.isArray(data)
+        ? data
+        : Array.isArray(data?.recipes)
+          ? data.recipes
+          : [];
+      setBridgeOnline(true);
+      setInstalledNames(new Set(list.map((r: { name: string }) => r.name) as string[]));
+    } catch {
+      setBridgeOnline(false);
+    }
+  }, []);
+
   useEffect(() => {
     async function load() {
-      // Check bridge + fetch installed in parallel
-      const [installedResult] = await Promise.allSettled([
-        fetch(apiPath("/api/bridge/recipes")).then(async (r) => {
-          if (!r.ok) return { online: false, names: [] as string[] };
-          const data = await r.json();
-          const list = Array.isArray(data)
-            ? data
-            : Array.isArray(data?.recipes)
-              ? data.recipes
-              : [];
-          return { online: true, names: list.map((r: { name: string }) => r.name) as string[] };
-        }),
-      ]);
-
-      if (installedResult.status === "fulfilled") {
-        setBridgeOnline(installedResult.value.online);
-        setInstalledNames(new Set(installedResult.value.names));
-      }
+      await refreshInstalled();
 
       // Fetch registry: bridge → raw GitHub → hardcoded fallback. Each
       // hop has a 4s timeout so a slow CDN can't keep the user staring
@@ -535,6 +544,16 @@ export default function MarketplacePage() {
     }
 
     if (!res.ok) {
+      // 502 / 503 / 504 from our Next.js proxy means the bridge stopped
+      // responding to bridgeFetch — flip the offline banner so the next
+      // click renders "Get Patchwork" instead of another opaque retry,
+      // and surface a friendlier message than the raw upstream body.
+      if (res.status === 502 || res.status === 503 || res.status === 504) {
+        setBridgeOnline(false);
+        throw new Error(
+          "Bridge isn't responding. Start it with `patchwork start` and try again.",
+        );
+      }
       let msg = `Error ${res.status}`;
       try {
         const body = (await res.json()) as { error?: string };
@@ -545,8 +564,14 @@ export default function MarketplacePage() {
       throw new Error(msg);
     }
 
+    // Optimistic update so the card flips to "Installed" immediately.
     setInstalledNames((prev) => new Set([...prev, recipe.name]));
     toast.success("Recipe installed successfully");
+    // Authoritative refresh from the bridge — catches the name-
+    // divergence case where the dashboard tracks the marketplace name
+    // but the bridge writes the recipe under its own YAML `name` field.
+    // Without this, the green pill would lie until the next page load.
+    void refreshInstalled();
   }
 
   const filtered = (registry ?? []).filter((r) => {
@@ -611,12 +636,12 @@ export default function MarketplacePage() {
         <div>
           <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
             <h1 className="editorial-h1" style={{ margin: 0 }}>
-              Marketplace — <span className="accent">recipes built by the community.</span>
+              Marketplace — <span className="accent">open-source YAML, curated.</span>
             </h1>
             <HintCard.Toggle id="marketplace" />
           </div>
           <div className="editorial-sub">
-            {`${registry?.length ?? FALLBACK_REGISTRY.recipes.length} recipes · open-source YAML · audited weekly`}
+            {`${registry?.length ?? FALLBACK_REGISTRY.recipes.length} recipes · sourced from github.com/patchworkos/recipes`}
           </div>
         </div>
         <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
@@ -634,11 +659,12 @@ export default function MarketplacePage() {
             href="https://github.com/patchworkos/recipes/blob/main/CONTRIBUTING.md"
             target="_blank"
             rel="noopener noreferrer"
-            className="btn sm"
+            className="btn sm ghost"
             style={{ textDecoration: "none", fontSize: "var(--fs-s)" }}
-            aria-label="Submit a recipe to the marketplace"
+            aria-label="Propose a recipe by opening a pull request on GitHub"
+            title="Opens GitHub. Submissions are reviewed as PRs against patchworkos/recipes — there is no in-app submission flow."
           >
-            + Submit recipe
+            Propose via GitHub PR ↗
           </a>
         </div>
       </div>

--- a/dashboard/src/lib/hints.tsx
+++ b/dashboard/src/lib/hints.tsx
@@ -160,13 +160,13 @@ export const HINTS: Record<string, Hint> = {
     title: "What's the Marketplace?",
     body: (
       <>
-        <Glossary term="recipe">Recipes</Glossary> published by the Patchwork
-        community. Each card shows install count, required{" "}
-        <Glossary term="connection">connections</Glossary>, and the YAML
-        you&apos;d land in your project.
+        Curated <Glossary term="recipe">recipes</Glossary> from{" "}
+        <code>github.com/patchworkos/recipes</code>. Each card shows the
+        required <Glossary term="connection">connections</Glossary> and the
+        YAML that lands in your local recipe folder when you install.
       </>
     ),
-    tip: "Bundles install several related recipes at once.",
+    tip: "Bundles install several related recipes at once. Propose new entries via GitHub PR.",
   },
   transactions: {
     id: "transactions",


### PR DESCRIPTION
## Summary

Three agent-driven audits this morning surfaced that the marketplace UI overstates what the backend actually does. This PR is a focused honesty pass on the copy + the two highest-impact install UX gaps that don't require bridge-side changes.

## Honesty fixes
| Before | After | Why |
|---|---|---|
| "Marketplace — recipes built by the community" | "Marketplace — open-source YAML, curated." | Catalog has 8 recipes total, all authored by repo maintainer. Zero external contributors, 0 stars, 0 forks. "Community" was aspirational. |
| "8 recipes · open-source YAML · audited weekly" | "8 recipes · sourced from github.com/patchworkos/recipes" | The "audited weekly" claim was a flat-out untruth — recipes repo has no GitHub Actions, no scheduled scan, no audit pipeline. |
| primary "+ Submit recipe" | ghost-style "Propose via GitHub PR ↗" with disclosure tooltip | Button is just an `<a href>` to CONTRIBUTING.md. No in-app submission flow, no review queue, no auth surface. |
| HintCard "Recipes published by the Patchwork community" | "Curated recipes from `github.com/patchworkos/recipes`" | Matches the new tagline. |

## Install UX fixes
- **Friendlier error on bridge-die-mid-session.** When the Next.js proxy returns 502/503/504 (bridge stopped responding), surface `"Bridge isn't responding. Start it with `patchwork start` and try again."` and flip `bridgeOnline=false` so the next click renders "Get Patchwork" instead of another opaque retry. Previously the raw upstream body ("Internal server error") leaked into the card.
- **Name-divergence guard.** Dashboard tracked `installedNames` using the marketplace `recipe.name` optimistically. The bridge installer keys on the YAML's own `recipe.name` field — if those differ, the green "Installed" pill lied until the next page reload. Added a `refreshInstalled()` refetch after install so the Set reflects what the bridge actually persisted.

## Deferred (needs bridge-side work)
- Post-install hot-reload (today: bridge restart required to see new recipe)
- Connector preflight at install time (today: fails at first run)
- `parseRecipe` schema errors → 400 instead of opaque 500
- Hard-coded `patchworkos/recipes` org prefix in `src/recipeRoutes.ts:1506` (blocks third-party recipe hosts)
- Real downloads counter
- Live `index.json` doesn't carry `risk_level/network_access/approval_behavior` — trust pills only render from the FALLBACK_REGISTRY

## Test plan
- [x] tsc clean
- [x] vitest 395/395 passing
- [x] Playwright sanity: tagline + subhead updated; "Propose via GitHub PR" renders ghost-style; install button still works when bridge online

🤖 Generated with [Claude Code](https://claude.com/claude-code)