### PR TITLE
fix(bridge): map parser/YAML errors on /recipes/install to 400, not opaque 500

### DIFF
--- a/src/__tests__/recipeRoutes-install.test.ts
+++ b/src/__tests__/recipeRoutes-install.test.ts
@@ -257,10 +257,13 @@ describe("Server /recipes/install — A-PR2 (dogfood F-05 / H-routes Bug 2)", ()
       },
       JSON.stringify({ source: "https://example.org/foo.yaml" }),
     );
-    // Either the install completes (200) or the installer fails because we
-    // didn't actually populate ~/.patchwork/recipes — both prove the
-    // allowlist gate passed (the body is no longer 403).
-    expect([200, 500]).toContain(status);
+    // Either the install completes (200), the recipe parses but doesn't
+    // satisfy the schema (400 invalid_recipe), or the installer itself
+    // crashes (500). All three prove the allowlist gate passed (status
+    // is no longer 403). 400 is the post-2026-05-13 baseline — parser
+    // errors used to come back as 500 indistinguishably from installer
+    // crashes.
+    expect([200, 400, 500]).toContain(status);
   });
 
   it("install-bad-source: rejects non-https / non-github source → 400", async () => {
@@ -297,6 +300,74 @@ describe("Server /recipes/install — A-PR2 (dogfood F-05 / H-routes Bug 2)", ()
     const parsed = JSON.parse(body);
     expect(parsed.ok).toBe(false);
     expect(parsed.error).toMatch(/invalid recipe name/i);
+  });
+
+  it("install-malformed-yaml: invalid YAML body → 400 invalid_recipe (was 500)", async () => {
+    // Body that successfully fetches but won't parse as YAML. The previous
+    // behaviour was to bubble the parser/yaml exception up to the generic
+    // 500 catch-all — dashboards then surfaced "Internal server error"
+    // with no signal that the recipe itself was the problem. Now the
+    // handler distinguishes parser failures and returns 400 with the
+    // actual error message.
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        fakeResponse(200, "this: is: not: valid: yaml: ::"),
+      ) as unknown as typeof fetch;
+    const { status, body } = await makeRequest(
+      {
+        method: "POST",
+        path: "/recipes/install",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${TOKEN}`,
+        },
+      },
+      JSON.stringify({
+        source: "github:patchworkos/recipes/recipes/malformed-recipe",
+      }),
+    );
+    expect(status).toBe(400);
+    const parsed = JSON.parse(body);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.code).toBe("invalid_recipe");
+    // Error should carry the parser's message, not the generic
+    // "Internal server error" string.
+    expect(parsed.error).not.toBe("Internal server error");
+    expect(typeof parsed.error).toBe("string");
+    expect(parsed.error.length).toBeGreaterThan(0);
+  });
+
+  it("install-schema-violation: well-formed YAML missing required fields → 400 invalid_recipe", async () => {
+    // YAML parses fine but parseRecipe throws RecipeParseError because
+    // `steps` is missing. Same 400 + message-passthrough behaviour as
+    // the malformed-yaml case.
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        fakeResponse(
+          200,
+          "name: malformed-recipe\nversion: 1.0.0\ntrigger:\n  type: manual\n",
+        ),
+      ) as unknown as typeof fetch;
+    const { status, body } = await makeRequest(
+      {
+        method: "POST",
+        path: "/recipes/install",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${TOKEN}`,
+        },
+      },
+      JSON.stringify({
+        source: "github:patchworkos/recipes/recipes/malformed-recipe",
+      }),
+    );
+    expect(status).toBe(400);
+    const parsed = JSON.parse(body);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.code).toBe("invalid_recipe");
+    expect(parsed.error).toMatch(/steps/i);
   });
 });
 

--- a/src/recipeRoutes.ts
+++ b/src/recipeRoutes.ts
@@ -1714,7 +1714,29 @@ export function tryHandleRecipeRoute(
         res.writeHead(200, { "Content-Type": "application/json" });
         res.end(JSON.stringify({ ok: true, ...result }));
       } catch (err) {
-        // Truly unexpected — installer crash, manifest validation throw, etc.
+        // Distinguish "the recipe YAML is malformed" (user-actionable, 400)
+        // from "the installer itself crashed" (server bug, 500). Before this
+        // every parser error came back as the same opaque 500 — dashboards
+        // surfaced "Internal server error" with no way to know what was wrong.
+        const errName = err instanceof Error ? err.name : "";
+        const errMsg = err instanceof Error ? err.message : String(err);
+        const isParseError =
+          errName === "RecipeParseError" ||
+          // js-yaml / the `yaml` package both throw YAMLException / YAMLParseError.
+          errName === "YAMLException" ||
+          errName === "YAMLParseError" ||
+          /yaml/i.test(errName);
+        if (isParseError) {
+          res.writeHead(400, { "Content-Type": "application/json" });
+          res.end(
+            JSON.stringify({
+              ok: false,
+              error: errMsg,
+              code: "invalid_recipe",
+            }),
+          );
+          return;
+        }
         console.error(`[recipes/install] internal install error:`, err);
         res.writeHead(500, { "Content-Type": "application/json" });
         res.end(


### PR DESCRIPTION
## Summary

Continuing the marketplace audit follow-ups from #485. The bridge install handler caught all errors with a single generic 500 — including parser errors that are entirely user-fixable. Dashboards then surfaced *"Internal server error"* with no actionable signal.

This PR distinguishes parser failures from genuine installer crashes:

| Error class | Before | After |
|---|---|---|
| Malformed YAML body | 500 `install_internal_error` | **400** `invalid_recipe` with the YAML parser's message |
| Schema violation (e.g. missing `steps`) | 500 `install_internal_error` | **400** `invalid_recipe` with the `RecipeParseError` message |
| mkdir / writeFile / unexpected crash | 500 `install_internal_error` | unchanged (those ARE server bugs) |

Detected by checking the thrown error's `name`: `RecipeParseError` (from `src/recipes/parser.ts`), `YAMLException` / `YAMLParseError` (from the `yaml` package), or any `name` matching `/yaml/i` as a defensive fallback.

## Tests

- **`install-malformed-yaml`** — `"this: is: not: valid: yaml: ::"` body → 400 `invalid_recipe`, error message is non-empty and non-generic
- **`install-schema-violation`** — well-formed YAML missing `steps` → 400 `invalid_recipe`, error message matches `/steps/i`
- **`install-allowlist-env`** updated — its intent is "post-allowlist outcome != 403"; 400 is now a legitimate post-allowlist outcome

## Out of scope (next swing in this audit thread)

- **Cron-scheduler hot-reload after install** — today the recipe lands on disk and `GET /recipes` sees it immediately, but cron-trigger recipes don't fire until next bridge restart. Wants a `deps.refreshScheduler?: () => void` hook in the deps chain; more surface area than this PR.
- Connector preflight, hard-coded `patchworkos/recipes` org prefix, real downloads counter, missing `risk_level/network_access/approval_behavior` in live `index.json` — all need bridge OR registry-repo changes.

## Test plan
- [x] tsc clean
- [x] `recipeRoutes-install.test.ts` 11/11 passing including 2 new + 1 updated
- [x] No behavior change for non-parser failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)