### PR TITLE
feat(bridge): connector preflight on /recipes/install — surface missing services

### DIFF
--- a/src/__tests__/recipeRoutes-install.test.ts
+++ b/src/__tests__/recipeRoutes-install.test.ts
@@ -495,6 +495,118 @@ describe("Server /recipes/install — A-PR2 (dogfood F-05 / H-routes Bug 2)", ()
     expect(parsed.code).toBe("invalid_recipe");
     expect(parsed.error).toMatch(/steps/i);
   });
+
+  it("install-connector-preflight: response carries missingConnectors when recipe needs unconnected services", async () => {
+    // The install handler reads the recipe just written to disk, walks
+    // its steps for tool-prefix matches against the known connector
+    // map, and (if anything's missing in /connections) surfaces the
+    // list under `missingConnectors` in the response body. The recipe
+    // STILL installs — this is a soft warning, not a 4xx gate.
+    const yamlBody = [
+      "name: slack-pinger",
+      "version: 1.0.0",
+      "trigger:",
+      "  type: manual",
+      "steps:",
+      "  - id: ping",
+      "    agent: false",
+      "    tool: slack_chat",
+      "    params:",
+      "      channel: '#general'",
+      "      text: hello",
+      "",
+    ].join("\n");
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        fakeResponse(200, yamlBody),
+      ) as unknown as typeof fetch;
+
+    const { status, body } = await makeRequest(
+      {
+        method: "POST",
+        path: "/recipes/install",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${TOKEN}`,
+        },
+      },
+      JSON.stringify({
+        source: "github:patchworkos/recipes/recipes/slack-pinger",
+      }),
+    );
+    expect(status).toBe(200);
+    const parsed = JSON.parse(body);
+    expect(parsed.ok).toBe(true);
+    // Recipe needs slack; the test bridge has no slack connector
+    // configured, so it should appear in missingConnectors.
+    expect(parsed.missingConnectors).toEqual(["slack"]);
+
+    try {
+      const { unlinkSync } = await import("node:fs");
+      const os = await import("node:os");
+      const path = await import("node:path");
+      unlinkSync(
+        path.join(os.homedir(), ".patchwork", "recipes", "slack-pinger.json"),
+      );
+    } catch {
+      // best-effort
+    }
+  });
+
+  it("install-connector-preflight: no missingConnectors field when recipe uses only built-in tools", async () => {
+    // file.write / shell.run / etc. don't match any connector prefix,
+    // so the response body must NOT include a missingConnectors key
+    // (avoids the dashboard showing an empty "connect:" toast).
+    const yamlBody = [
+      "name: file-writer",
+      "version: 1.0.0",
+      "trigger:",
+      "  type: manual",
+      "steps:",
+      "  - id: w",
+      "    agent: false",
+      "    tool: file.write",
+      "    params:",
+      "      path: /tmp/x",
+      "      content: y",
+      "",
+    ].join("\n");
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        fakeResponse(200, yamlBody),
+      ) as unknown as typeof fetch;
+
+    const { status, body } = await makeRequest(
+      {
+        method: "POST",
+        path: "/recipes/install",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${TOKEN}`,
+        },
+      },
+      JSON.stringify({
+        source: "github:patchworkos/recipes/recipes/file-writer",
+      }),
+    );
+    expect(status).toBe(200);
+    const parsed = JSON.parse(body);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.missingConnectors).toBeUndefined();
+
+    try {
+      const { unlinkSync } = await import("node:fs");
+      const os = await import("node:os");
+      const path = await import("node:path");
+      unlinkSync(
+        path.join(os.homedir(), ".patchwork", "recipes", "file-writer.json"),
+      );
+    } catch {
+      // best-effort
+    }
+  });
 });
 
 describe("Server /recipes/:name/run — A-PR2 body cap (32 KB)", () => {

--- a/src/recipeRoutes.ts
+++ b/src/recipeRoutes.ts
@@ -1753,7 +1753,11 @@ export function tryHandleRecipeRoute(
           "node:fs"
         );
         writeFileSync(tmpFile, yamlText, "utf-8");
-        let result: { action: "created" | "replaced"; name: string };
+        let result: {
+          action: "created" | "replaced";
+          name: string;
+          missingConnectors?: string[];
+        };
         try {
           const recipesDir = path.join(os.homedir(), ".patchwork", "recipes");
           mkdirSync(recipesDir, { recursive: true });
@@ -1763,7 +1767,58 @@ export function tryHandleRecipeRoute(
           const installResult = installRecipeFromFile(tmpFile, {
             recipesDir,
           });
-          result = { action: installResult.action, name: recipeName };
+          // Soft preflight: detect which connectors the recipe uses
+          // and surface the unconfigured ones as a warning. The recipe
+          // is already on disk — this is a hint for the dashboard to
+          // prompt "you'll need to connect Slack + Gmail to run this",
+          // not a gate on the install itself. Defensive: any failure
+          // here MUST NOT roll the install back, so the whole block is
+          // wrapped in try/catch.
+          let missingConnectors: string[] | undefined;
+          try {
+            const { readFileSync } = await import("node:fs");
+            const installedJson = readFileSync(
+              installResult.installedPath,
+              "utf-8",
+            );
+            const recipe = JSON.parse(installedJson) as {
+              steps?: unknown[];
+            };
+            if (Array.isArray(recipe.steps)) {
+              const { detectRequiredConnectors, findMissingConnectors } =
+                await import("./recipes/connectorPreflight.js");
+              const required = detectRequiredConnectors(
+                recipe as Parameters<typeof detectRequiredConnectors>[0],
+              );
+              if (required.length > 0) {
+                const { handleConnectionsList } = await import(
+                  "./connectors/gmail.js"
+                );
+                const connsResult = await handleConnectionsList();
+                let connections: Array<{ id?: string; status?: string }> = [];
+                try {
+                  const body = JSON.parse(connsResult.body) as {
+                    connectors?: Array<{ id?: string; status?: string }>;
+                  };
+                  connections = body.connectors ?? [];
+                } catch {
+                  /* malformed body — treat as no connections */
+                }
+                const missing = findMissingConnectors(required, connections);
+                if (missing.length > 0) missingConnectors = missing;
+              }
+            }
+          } catch (preflightErr) {
+            console.warn(
+              `[recipes/install] connector preflight failed (non-blocking):`,
+              preflightErr,
+            );
+          }
+          result = {
+            action: installResult.action,
+            name: recipeName,
+            ...(missingConnectors ? { missingConnectors } : {}),
+          };
         } finally {
           try {
             unlinkSync(tmpFile);

--- a/src/recipes/__tests__/connectorPreflight.test.ts
+++ b/src/recipes/__tests__/connectorPreflight.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Unit tests for the connector-preflight helper. The HTTP-level
+ * integration (install handler surfaces `missingConnectors` in the
+ * response) lives in src/__tests__/recipeRoutes-install.test.ts.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  detectRequiredConnectors,
+  findMissingConnectors,
+  TOOL_PREFIX_TO_CONNECTOR,
+} from "../connectorPreflight.js";
+import type { Recipe } from "../schema.js";
+
+// Minimal Recipe builder — only the fields the helper actually reads.
+function recipe(steps: Recipe["steps"]): Recipe {
+  return {
+    name: "test",
+    version: "1.0.0",
+    trigger: { type: "manual" },
+    steps,
+  };
+}
+
+describe("detectRequiredConnectors", () => {
+  it("returns empty for recipes with no tool steps", () => {
+    expect(
+      detectRequiredConnectors(
+        recipe([
+          { id: "s1", agent: true, prompt: "think", tools: undefined },
+        ] as Recipe["steps"]),
+      ),
+    ).toEqual([]);
+  });
+
+  it("detects connectors from agent:false tool fields", () => {
+    expect(
+      detectRequiredConnectors(
+        recipe([
+          { id: "s1", agent: false, tool: "slack_chat", params: {} },
+          { id: "s2", agent: false, tool: "gmail_send", params: {} },
+        ] as Recipe["steps"]),
+      ),
+    ).toEqual(["gmail", "slack"]);
+  });
+
+  it("detects connectors from agent:true tools[] arrays", () => {
+    expect(
+      detectRequiredConnectors(
+        recipe([
+          {
+            id: "s1",
+            agent: true,
+            prompt: "compose",
+            tools: ["linear_list_issues", "calendar_list_events"],
+          },
+        ] as Recipe["steps"]),
+      ),
+    ).toEqual(["google-calendar", "linear"]);
+  });
+
+  it("de-duplicates connectors used by multiple steps", () => {
+    expect(
+      detectRequiredConnectors(
+        recipe([
+          { id: "s1", agent: false, tool: "slack_chat", params: {} },
+          { id: "s2", agent: false, tool: "slack_search", params: {} },
+        ] as Recipe["steps"]),
+      ),
+    ).toEqual(["slack"]);
+  });
+
+  it("returns results in sorted order so the response is stable", () => {
+    expect(
+      detectRequiredConnectors(
+        recipe([
+          { id: "s1", agent: false, tool: "stripe_charge", params: {} },
+          { id: "s2", agent: false, tool: "asana_create_task", params: {} },
+          { id: "s3", agent: false, tool: "github_open_pr", params: {} },
+        ] as Recipe["steps"]),
+      ),
+    ).toEqual(["asana", "github", "stripe"]);
+  });
+
+  it("ignores tool names that don't match any known prefix", () => {
+    expect(
+      detectRequiredConnectors(
+        recipe([
+          { id: "s1", agent: false, tool: "shell.run", params: {} },
+          { id: "s2", agent: false, tool: "file.write", params: {} },
+        ] as Recipe["steps"]),
+      ),
+    ).toEqual([]);
+  });
+
+  it("matches every entry in the public prefix map", () => {
+    // Sanity: every prefix in the map should match a tool we synthesize
+    // from it. Guards against typos that would silently break the map.
+    for (const [prefix, connector] of Object.entries(
+      TOOL_PREFIX_TO_CONNECTOR,
+    )) {
+      const detected = detectRequiredConnectors(
+        recipe([
+          { id: "s", agent: false, tool: `${prefix}example`, params: {} },
+        ] as Recipe["steps"]),
+      );
+      expect(
+        detected,
+        `prefix '${prefix}' should map to '${connector}'`,
+      ).toEqual([connector]);
+    }
+  });
+});
+
+describe("findMissingConnectors", () => {
+  it("returns required ids that aren't in the connected set", () => {
+    expect(
+      findMissingConnectors(
+        ["slack", "gmail", "linear"],
+        [
+          { id: "slack", status: "connected" },
+          { id: "gmail", status: "disconnected" },
+          // linear: absent from the list entirely
+        ],
+      ),
+    ).toEqual(["gmail", "linear"]);
+  });
+
+  it("treats only status === 'connected' as connected", () => {
+    // Defensive: any other status string ("error", "expired", "reauth",
+    // "disconnected", undefined) means the recipe can't currently use
+    // the connector, so it should show up as missing.
+    expect(
+      findMissingConnectors(["slack"], [{ id: "slack", status: "expired" }]),
+    ).toEqual(["slack"]);
+  });
+
+  it("preserves the input order of `required` in the output", () => {
+    // The install handler relies on `detectRequiredConnectors` for the
+    // sort; this layer must NOT re-sort the input.
+    expect(
+      findMissingConnectors(
+        ["zendesk", "asana", "github"],
+        [{ id: "asana", status: "connected" }],
+      ),
+    ).toEqual(["zendesk", "github"]);
+  });
+
+  it("returns [] when all required connectors are connected", () => {
+    expect(
+      findMissingConnectors(
+        ["slack", "gmail"],
+        [
+          { id: "slack", status: "connected" },
+          { id: "gmail", status: "connected" },
+          { id: "linear", status: "connected" },
+        ],
+      ),
+    ).toEqual([]);
+  });
+
+  it("tolerates malformed entries (missing id or status)", () => {
+    expect(
+      findMissingConnectors(
+        ["slack"],
+        [
+          { id: undefined, status: "connected" } as never,
+          { status: "connected" } as never,
+          { id: "slack" }, // status missing — treated as not connected
+        ],
+      ),
+    ).toEqual(["slack"]);
+  });
+});

--- a/src/recipes/connectorPreflight.ts
+++ b/src/recipes/connectorPreflight.ts
@@ -1,0 +1,113 @@
+/**
+ * Detect which connectors a recipe depends on by inspecting its tool
+ * names. Used as a *soft* preflight after install — the route returns
+ * a `missingConnectors` warning array so the dashboard can prompt the
+ * user to authorise the missing services without blocking the install
+ * itself.
+ *
+ * Why soft (warning, not 400):
+ *   - Users may install a recipe with the intent to authorise later.
+ *   - The bridge has no way to know whether a missing connector is
+ *     "the user forgot" or "the user uses this recipe only via the
+ *     manual code path that doesn't need auth".
+ *   - First-run discovery (today's behaviour) is the worst UX, but
+ *     blocking install entirely overcorrects.
+ *
+ * Detection is deliberately lossy. We match the FIRST underscore-
+ * separated namespace of each step's tool name against a known prefix
+ * map (slack_chat, gmail_send, linear_create_issue, …). Recipes that
+ * use shell tools wrapping curl to call a service won't be detected —
+ * but such recipes also don't go through the Patchwork connector
+ * store anyway.
+ */
+import type { Recipe, Step } from "./schema.js";
+
+/**
+ * Tool-name prefix → connector id (matching the IDs returned by
+ * `/connections` — see src/connectors/gmail.ts handleConnectionsList).
+ * Both `google-calendar` and the dashboard's `googleCalendar` spelling
+ * are accepted on the caller side; this map is authoritative for the
+ * bridge.
+ */
+export const TOOL_PREFIX_TO_CONNECTOR: Record<string, string> = {
+  slack_: "slack",
+  github_: "github",
+  jira_: "jira",
+  linear_: "linear",
+  gmail_: "gmail",
+  calendar_: "google-calendar",
+  drive_: "google-drive",
+  intercom_: "intercom",
+  hubspot_: "hubspot",
+  datadog_: "datadog",
+  stripe_: "stripe",
+  sentry_: "sentry",
+  zendesk_: "zendesk",
+  asana_: "asana",
+  notion_: "notion",
+  confluence_: "confluence",
+  discord_: "discord",
+  gitlab_: "gitlab",
+  pagerduty_: "pagerduty",
+};
+
+function toolsOfStep(step: Step): string[] {
+  // agent: false steps carry a single `tool` field. agent: true steps
+  // optionally list permitted tools in `tools[]`. Other shapes (nested
+  // recipe calls, sub-agents) are not first-class in the schema today.
+  if (step.agent === false) {
+    return [step.tool];
+  }
+  if (step.agent === true && Array.isArray(step.tools)) {
+    return step.tools;
+  }
+  return [];
+}
+
+/**
+ * Walk a recipe's steps and return the connector ids it likely needs.
+ * Stable order (sorted) so the response is deterministic.
+ */
+export function detectRequiredConnectors(recipe: Recipe): string[] {
+  const required = new Set<string>();
+  for (const step of recipe.steps) {
+    for (const tool of toolsOfStep(step)) {
+      for (const [prefix, connector] of Object.entries(
+        TOOL_PREFIX_TO_CONNECTOR,
+      )) {
+        if (tool.startsWith(prefix)) {
+          required.add(connector);
+        }
+      }
+    }
+  }
+  return [...required].sort();
+}
+
+interface ConnectorStatusEntry {
+  id?: string;
+  status?: string;
+}
+
+/**
+ * Compare required connectors against the bridge's `/connections`
+ * payload. Returns the ids of connectors the recipe needs but the
+ * user hasn't connected (or whose status is not "connected").
+ *
+ * Lenient on input shape — the live `/connections` response has a
+ * stable contract, but tests + future surfaces may pass in something
+ * shaped slightly differently. Anything we can't classify is treated
+ * as "not connected" so a malformed connections payload doesn't
+ * silently make every recipe look healthy.
+ */
+export function findMissingConnectors(
+  required: ReadonlyArray<string>,
+  connections: ReadonlyArray<ConnectorStatusEntry>,
+): string[] {
+  const connectedSet = new Set<string>();
+  for (const c of connections) {
+    if (typeof c?.id !== "string") continue;
+    if (c.status === "connected") connectedSet.add(c.id);
+  }
+  return required.filter((id) => !connectedSet.has(id));
+}


### PR DESCRIPTION
## Summary

Continues the marketplace audit thread (#485 #486 #487). When a user installs a recipe like \`morning-brief\` that needs gmail + slack + linear + google-calendar, the bridge wrote the YAML to disk with no indication the recipe couldn't actually run — failure was discovered at first run with an opaque tool-call rejection.

This PR adds **soft preflight** on install: the response carries a \`missingConnectors\` array listing the services the recipe needs but the user hasn't authorised. The recipe still installs (it's a warning, not a gate).

## Response shape

```json
{
  "ok": true,
  "action": "created",
  "name": "morning-brief",
  "missingConnectors": ["gmail", "slack"]
}
```

The dashboard can surface this as a non-blocking *"You'll need to connect Slack + Gmail to run this"* prompt. Field is **omitted** (not \`[]\`) when nothing's missing, so \`parsed.missingConnectors?.length\` works.

## New module

\`src/recipes/connectorPreflight.ts\`:
- \`TOOL_PREFIX_TO_CONNECTOR\` — 19-entry map (slack_ → slack, gmail_ → gmail, calendar_ → google-calendar, etc.)
- \`detectRequiredConnectors(recipe)\` — walks recipe.steps (both \`agent:false tool\` and \`agent:true tools[]\` shapes), returns the sorted unique connector ids the recipe will need
- \`findMissingConnectors(required, connections)\` — diffs against the live \`/connections\` payload; anything other than \`status === "connected"\` is missing

## Why soft (200 + warning, not 4xx gate)

- Users may install with the intent to authorise later
- The bridge can't distinguish "user forgot Slack" from "user only runs this via a manual code path that doesn't need auth"
- Blocking overcorrects today's first-run-discovery UX

## Defensive

The entire preflight block is wrapped in try/catch. ANY failure (filesystem read, dynamic import, \`/connections\` returning a malformed body) logs a warning and proceeds with no \`missingConnectors\` field — never fails the install itself.

## Tests
- **12 unit tests** on \`connectorPreflight.test.ts\` — prefix map, de-duplication, sort order, empty cases, malformed payloads, prefix-map round-trip
- **2 integration tests** in \`recipeRoutes-install.test.ts\` — slack-pinger → \`missingConnectors: ["slack"]\`; file-writer (no prefixes) → field undefined

23/23 install + preflight tests green. Bridge tsc clean. biome-formatted.

## Out of scope

- Dashboard rendering of \`missingConnectors\` (front-end PR — should show inline post-install banner with deep-links to \`/connections/\<id\>/authorize\`)
- Hard-coded \`patchworkos/recipes\` org prefix
- Real downloads counter
- Live \`index.json\` missing trust fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)