### PR TITLE
fix(dashboard): UI polish batch 2 — OAuth timeout, poll gaps, a11y, dead code

### DIFF
--- a/dashboard/src/app/activity/page.tsx
+++ b/dashboard/src/app/activity/page.tsx
@@ -300,7 +300,9 @@ export default function ActivityPage() {
                   ? events.filter(
                       (e) => RECIPE_END_EVENTS.has(e.kind ?? "") || RECIPE_END_EVENTS.has(e.event ?? ""),
                     ).length
-                  : events.length;
+                  : events.filter(
+                      (e) => !(e.kind === "lifecycle" && ACTIVITY_NOISE_EVENTS.has(e.event ?? "")),
+                    ).length;
           return (
             <button
               key={t}

--- a/dashboard/src/app/decisions/page.tsx
+++ b/dashboard/src/app/decisions/page.tsx
@@ -73,6 +73,7 @@ function DecisionsContent() {
   const [showAllTags, setShowAllTags] = useState(false);
   const [keyQuery, setKeyQuery] = useState(searchParams.get("ref") ?? "");
   const [textQuery, setTextQuery] = useState(searchParams.get("q") ?? "");
+  const searchInputRef = useRef<HTMLInputElement>(null);
   const [since, setSince] = useState<SinceFilter>(() => {
     const sp = searchParams.get("since");
     return isSinceFilter(sp) ? sp : "30d";
@@ -107,6 +108,19 @@ function DecisionsContent() {
     params.set("limit", "200");
     return `?${params.toString()}`;
   }, [tag, debouncedKey, debouncedText, since]);
+
+  // Press "/" to focus the search input (GitHub / Linear convention).
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== "/" || e.metaKey || e.ctrlKey || e.altKey) return;
+      const active = document.activeElement;
+      if (active instanceof HTMLInputElement || active instanceof HTMLTextAreaElement) return;
+      e.preventDefault();
+      searchInputRef.current?.focus();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, []);
 
   const { data, error, loading, refetch } = useBridgeFetch<TracesResponse>(
     `/api/bridge/traces${qs}`,
@@ -168,12 +182,13 @@ function DecisionsContent() {
               Search decisions
             </span>
             <input
+              ref={searchInputRef}
               type="text"
               value={textQuery}
               onChange={(e) => setTextQuery(e.target.value)}
               placeholder="Search problems & solutions…"
               className="input"
-              aria-label="Search decisions"
+              aria-label="Search decisions (press / to focus)"
               style={{ minWidth: "min(240px, 100%)", width: 280, maxWidth: "100%" }}
             />
           </label>

--- a/dashboard/src/app/login/login-form.tsx
+++ b/dashboard/src/app/login/login-form.tsx
@@ -64,7 +64,6 @@ export function LoginForm({ next }: { next: string }) {
             fontSize: "var(--fs-m)",
             fontFamily: "var(--font-mono)",
             padding: "8px 10px",
-            outline: "none",
           }}
         />
       </label>

--- a/dashboard/src/app/runs/[seq]/page.tsx
+++ b/dashboard/src/app/runs/[seq]/page.tsx
@@ -46,7 +46,7 @@ interface RunDetail {
   taskId: string;
   recipeName: string;
   trigger: string;
-  status: "running" | "done" | "error" | "cancelled" | "interrupted";
+  status: "pending" | "running" | "done" | "error" | "cancelled" | "interrupted";
   createdAt: number;
   startedAt?: number;
   doneAt: number;
@@ -804,14 +804,19 @@ export default function RunDetailPage() {
           return null;
         });
 
+    const isInFlight = (r: RunDetail | null) =>
+      r?.status === "running" || r?.status === "pending";
+
     doFetch().then((initialRun) => {
-      if (!initialRun || initialRun.status !== "running") return;
+      if (!isInFlight(initialRun)) return;
       // Slower polling now that SSE delivers the live step deltas — polling
       // is just a backstop to canonicalize when the run transitions to
       // terminal (no `recipe_run_done` event yet; keep this until VD-1C).
+      // Also covers the pending → running transition so the page stays live
+      // when a queued run is picked up by the worker.
       intervalId = setInterval(() => {
         doFetch().then((r) => {
-          if (!r || r.status !== "running") {
+          if (!isInFlight(r)) {
             clearInterval(intervalId);
             intervalId = undefined;
           }

--- a/dashboard/src/components/OAuthCallback.tsx
+++ b/dashboard/src/components/OAuthCallback.tsx
@@ -23,6 +23,16 @@ function CallbackInner({ provider }: { provider: Provider }) {
     const state = params.get("state");
     const error = params.get("error");
 
+    // Strip OAuth params from the address bar so they don't linger in
+    // history or get accidentally shared via copy-paste.
+    if (code || state || error) {
+      const clean = new URL(window.location.href);
+      clean.searchParams.delete("code");
+      clean.searchParams.delete("state");
+      clean.searchParams.delete("error");
+      window.history.replaceState(null, "", clean.toString());
+    }
+
     const qs = new URLSearchParams();
     if (code) qs.set("code", code);
     if (state) qs.set("state", state);
@@ -46,8 +56,14 @@ function CallbackInner({ provider }: { provider: Provider }) {
       }
     };
 
-    fetch(apiPath(`/api/connections/${provider.id}/callback?${qs.toString()}`))
+    const abort = new AbortController();
+    const timeout = setTimeout(() => abort.abort(), 30_000);
+
+    fetch(apiPath(`/api/connections/${provider.id}/callback?${qs.toString()}`), {
+      signal: abort.signal,
+    })
       .then(async (r) => {
+        clearTimeout(timeout);
         let body: unknown = null;
         try {
           body = await r.json();
@@ -80,6 +96,11 @@ function CallbackInner({ provider }: { provider: Provider }) {
         }
       })
       .catch((err) => {
+        clearTimeout(timeout);
+        if (err instanceof DOMException && err.name === "AbortError") {
+          fail("connection_timeout");
+          return;
+        }
         fail(err instanceof Error ? err.message : "network_error");
       });
   }, [params, router, provider.id]);

--- a/dashboard/src/components/Shell.tsx
+++ b/dashboard/src/components/Shell.tsx
@@ -105,8 +105,6 @@ const NAV_SECTIONS: { title: string; items: NavItem[] }[] = [
   },
 ];
 
-const MORE_ITEMS: NavItem[] = [];
-
 // ------------------------------------------------------------------ approval count
 
 function useApprovalCount(): number {
@@ -301,7 +299,6 @@ export function Shell({ children }: { children: ReactNode }) {
   const { demo, toggle: toggleDemo } = useDemo();
   const identity = useIdentity(status);
   const [mobileOpen, setMobileOpen] = useState(false);
-  const [moreOpen, setMoreOpen] = useState(false);
   // Demo: replace with real notification count when available
   const hasNotifications = approvalCount > 0;
   const [paletteOpen, setPaletteOpen] = useState(false);
@@ -334,11 +331,6 @@ export function Shell({ children }: { children: ReactNode }) {
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
   }, []);
-
-  // Auto-expand More if we navigate into one of its routes
-  useEffect(() => {
-    if (MORE_ITEMS.some((it) => pathname?.startsWith(it.href))) setMoreOpen(true);
-  }, [pathname]);
 
   return (
     <div className={`app-shell${mobileOpen ? " mobile-open" : ""}`}>
@@ -542,48 +534,6 @@ export function Shell({ children }: { children: ReactNode }) {
             </div>
           ))}
 
-          {MORE_ITEMS.length > 0 && (
-            <div className="app-nav-more">
-              <button
-                type="button"
-                className="app-nav-link app-nav-more-toggle"
-                aria-expanded={moreOpen}
-                onClick={() => setMoreOpen((v) => !v)}
-              >
-                <span className="app-nav-link-icon" aria-hidden="true">
-                  <NavIcon path={PATHS.chevron} />
-                </span>
-                <span>More</span>
-                <span
-                  className="app-nav-more-caret"
-                  data-open={moreOpen ? "1" : "0"}
-                  aria-hidden="true"
-                >
-                  <NavIcon path={PATHS.chevron} />
-                </span>
-              </button>
-              {moreOpen && (
-                <div className="app-nav-more-items">
-                  {MORE_ITEMS.map((item) => {
-                    const isActive = pathname?.startsWith(item.href);
-                    return (
-                      <Link
-                        key={item.href}
-                        href={item.href}
-                        className={`app-nav-link${isActive ? " is-active" : ""}`}
-                        aria-current={isActive ? "page" : undefined}
-                      >
-                        <span className="app-nav-link-icon" aria-hidden="true">
-                          <NavIcon path={PATHS[item.icon]} />
-                        </span>
-                        <span>{item.label}</span>
-                      </Link>
-                    );
-                  })}
-                </div>
-              )}
-            </div>
-          )}
         </nav>
 
         <BridgeStatusBlock status={status} />


### PR DESCRIPTION
## Summary

- **OAuthCallback**: 30 s fetch timeout (was infinite hang with "Connecting…"); strip `code`/`state`/`error` from URL via `history.replaceState` after capture so OAuth params don't persist in browser history
- **LoginForm**: Remove `outline: none` from password input — keyboard focus ring was invisible (WCAG 2.4.7)
- **Shell**: Delete always-empty `MORE_ITEMS` array and the dead render branch + `moreOpen` state gated on it
- **runs/[seq]**: Extend in-flight poll to cover `pending` status — run detail page was staying stale when a queued run transitioned `pending → running` (poll only fired on `running`). Also adds `pending` to `RunDetail.status` union.
- **decisions**: Press `/` to focus the search input (GitHub/Linear convention). Guard skips when focus is already in an input/textarea.
- **activity**: "All" tab badge count now matches rendered rows — was showing `events.length` (all events including noise) while the table filtered out noise events

## Test plan

- [ ] OAuth: connect a provider, verify params stripped from URL after redirect; disconnect bridge to verify timeout fires after 30 s
- [ ] Login: tab to password field, verify focus ring visible
- [ ] Runs detail: navigate to a run in pending state, verify page polls and updates when it transitions to running
- [ ] Decisions: press `/` from the page body, verify search input is focused; press `/` while already in search, verify no double-focus
- [ ] Activity: switch to "All" tab, verify badge count ≤ total events (noise stripped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)