### PR TITLE
fix(security): close CodeQL alerts #121 + #122

### DIFF
--- a/scripts/start-all.mjs
+++ b/scripts/start-all.mjs
@@ -98,9 +98,12 @@ function notify(msg, priority = "default") {
 const procs = new Map(); // name → ChildProcess
 
 function spawnProc(name, cmd, cmdArgs, opts = {}) {
+  // shell:false everywhere — on Windows we always invoke cmd.exe explicitly
+  // for .cmd shim resolution, so shell:true would only widen the attack
+  // surface by interpolating env-derived paths into a shell string.
   const child = spawn(cmd, cmdArgs, {
     stdio: ["ignore", "pipe", "pipe"],
-    shell: IS_WIN && (cmd.endsWith(".cmd") || cmd === "cmd.exe"),
+    shell: false,
     cwd: opts.cwd ?? BRIDGE_DIR,
     env: { ...process.env, ...opts.env },
   });

--- a/src/recipeRoutes.ts
+++ b/src/recipeRoutes.ts
@@ -1881,11 +1881,16 @@ export function tryHandleRecipeRoute(
           errName === "YAMLParseError" ||
           /yaml/i.test(errName);
         if (isParseError) {
+          // Return only the first line of the parser message — strips any
+          // embedded file path or stack frame that downstream parsers
+          // sometimes include (CodeQL: js/stack-trace-exposure).
+          const safeMsg =
+            errMsg.split("\n", 1)[0]?.slice(0, 500) ?? "invalid recipe";
           res.writeHead(400, { "Content-Type": "application/json" });
           res.end(
             JSON.stringify({
               ok: false,
-              error: errMsg,
+              error: safeMsg,
               code: "invalid_recipe",
             }),
           );


### PR DESCRIPTION
## Summary

Closes the two open CodeQL alerts on \`main\`:

- **#121** \`js/stack-trace-exposure\` in [src/recipeRoutes.ts:1886](src/recipeRoutes.ts#L1886) — sanitize the parser \`err.message\` echoed in the 400 response (first line + 500-char cap).
- **#122** \`js/shell-command-injection-from-environment\` in [scripts/start-all.mjs:101](scripts/start-all.mjs#L101) — drop \`shell: true\` from \`spawnProc\`; every Windows caller already invokes \`cmd.exe\` explicitly so it was dead defensive code.

## Test plan

- [ ] CodeQL re-scan shows both alerts auto-closed
- [ ] \`npm test\` passes
- [ ] Local \`npm run start-all:node\` still launches bridge + Claude + dashboard