### PR TITLE
test(win32): normalize /tmp fixtures in recipe + automation tests

### DIFF
--- a/src/__tests__/inbox-archive-delete.test.ts
+++ b/src/__tests__/inbox-archive-delete.test.ts
@@ -92,7 +92,9 @@ describe("inboxRoutes — archive + delete", () => {
     expect(result.status).toBe(200);
     const body = JSON.parse(result.body) as { ok: boolean; path: string };
     expect(body.ok).toBe(true);
-    expect(body.path.endsWith(`.archive/${filename}`)).toBe(true);
+    expect(body.path.replace(/\\/g, "/").endsWith(`.archive/${filename}`)).toBe(
+      true,
+    );
 
     const inboxDir = path.join(fakeHome, ".patchwork", "inbox");
     expect(existsSync(path.join(inboxDir, filename))).toBe(false);

--- a/src/__tests__/recipes-archive.test.ts
+++ b/src/__tests__/recipes-archive.test.ts
@@ -41,7 +41,7 @@ describe("archiveRecipe", () => {
     const result = archiveRecipe(recipesDir, "demo");
 
     expect(result.ok).toBe(true);
-    expect(result.path).toMatch(/\.archive\/demo\.yaml$/);
+    expect(result.path.replace(/\\/g, "/")).toMatch(/\.archive\/demo\.yaml$/);
     expect(existsSync(path.join(recipesDir, "demo.yaml"))).toBe(false);
     expect(existsSync(path.join(recipesDir, ".archive", "demo.yaml"))).toBe(
       true,
@@ -78,7 +78,9 @@ describe("archiveRecipe", () => {
     expect(result.path).not.toBe(
       path.join(recipesDir, ".archive", "demo.yaml"),
     );
-    expect(result.path).toMatch(/\.archive\/demo\..+\.yaml$/);
+    expect(result.path.replace(/\\/g, "/")).toMatch(
+      /\.archive\/demo\..+\.yaml$/,
+    );
 
     const archived = readdirSync(path.join(recipesDir, ".archive"));
     expect(archived.filter((f) => f.startsWith("demo")).length).toBe(2);

--- a/src/__tests__/recipes-archive.test.ts
+++ b/src/__tests__/recipes-archive.test.ts
@@ -41,7 +41,9 @@ describe("archiveRecipe", () => {
     const result = archiveRecipe(recipesDir, "demo");
 
     expect(result.ok).toBe(true);
-    expect(result.path.replace(/\\/g, "/")).toMatch(/\.archive\/demo\.yaml$/);
+    expect((result.path ?? "").replace(/\\/g, "/")).toMatch(
+      /\.archive\/demo\.yaml$/,
+    );
     expect(existsSync(path.join(recipesDir, "demo.yaml"))).toBe(false);
     expect(existsSync(path.join(recipesDir, ".archive", "demo.yaml"))).toBe(
       true,
@@ -78,7 +80,7 @@ describe("archiveRecipe", () => {
     expect(result.path).not.toBe(
       path.join(recipesDir, ".archive", "demo.yaml"),
     );
-    expect(result.path.replace(/\\/g, "/")).toMatch(
+    expect((result.path ?? "").replace(/\\/g, "/")).toMatch(
       /\.archive\/demo\..+\.yaml$/,
     );
 

--- a/src/commands/__tests__/recipe.test.ts
+++ b/src/commands/__tests__/recipe.test.ts
@@ -137,15 +137,17 @@ describe("recipe CLI commands", () => {
       const result = await runSchema(outputDir);
 
       expect(result.outputDir).toBe(outputDir);
-      expect(
-        result.filesWritten.some((file) => file.endsWith("recipe.v1.json")),
-      ).toBe(true);
-      expect(
-        result.filesWritten.some((file) => file.endsWith("tools/file.json")),
-      ).toBe(true);
-      expect(
-        result.filesWritten.some((file) => file.endsWith("tools/gmail.json")),
-      ).toBe(true);
+      // Normalize separators so Win32 ("\") matches the forward-slash assertions.
+      const normalized = result.filesWritten.map((f) => f.replace(/\\/g, "/"));
+      expect(normalized.some((file) => file.endsWith("recipe.v1.json"))).toBe(
+        true,
+      );
+      expect(normalized.some((file) => file.endsWith("tools/file.json"))).toBe(
+        true,
+      );
+      expect(normalized.some((file) => file.endsWith("tools/gmail.json"))).toBe(
+        true,
+      );
 
       const recipeSchema = readFileSync(
         join(outputDir, "recipe.v1.json"),

--- a/src/recipes/__tests__/dispatchRecipe.parity.test.ts
+++ b/src/recipes/__tests__/dispatchRecipe.parity.test.ts
@@ -30,6 +30,7 @@ import {
 } from "../yamlRunner.js";
 
 const tmpLogDir = mkdtempSync(path.join(os.tmpdir(), "dispatch-parity-"));
+const TMP = tmpLogDir;
 
 function baseDeps(): RunnerDeps {
   return {
@@ -51,7 +52,7 @@ function flatRecipe(overrides: Partial<YamlRecipe> = {}): YamlRecipe {
   return {
     name: "flat",
     trigger: { type: "manual" },
-    steps: [{ tool: "file.write", path: "/tmp/x", content: "hi" }],
+    steps: [{ tool: "file.write", path: `${TMP}/x`, content: "hi" }],
     ...overrides,
   };
 }
@@ -150,7 +151,7 @@ describe("RunResult envelope (yaml runner) — orchestrator must preserve", () =
   it("on_error.fallback=abort: errorMessage set, stepResults still array", async () => {
     const recipe = flatRecipe({
       on_error: { fallback: "abort" },
-      steps: [{ tool: "file.read", path: "/tmp/a", into: "data" }],
+      steps: [{ tool: "file.read", path: `${TMP}/a`, into: "data" }],
     });
     const result = (await dispatchRecipe(recipe, {
       ...baseDeps(),
@@ -168,7 +169,7 @@ describe("RunResult envelope (yaml runner) — orchestrator must preserve", () =
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const recipe = flatRecipe({
       on_error: { fallback: "log_only" },
-      steps: [{ tool: "file.read", path: "/tmp/a", into: "data" }],
+      steps: [{ tool: "file.read", path: `${TMP}/a`, into: "data" }],
     });
     const result = (await dispatchRecipe(recipe, {
       ...baseDeps(),
@@ -185,7 +186,7 @@ describe("RunResult envelope (yaml runner) — orchestrator must preserve", () =
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const recipe = flatRecipe({
       on_error: { fallback: "deliver_original" },
-      steps: [{ tool: "file.read", path: "/tmp/a", into: "data" }],
+      steps: [{ tool: "file.read", path: `${TMP}/a`, into: "data" }],
     });
     const result = (await dispatchRecipe(recipe, {
       ...baseDeps(),
@@ -210,7 +211,7 @@ describe("RunResult envelope (yaml runner) — orchestrator must preserve", () =
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const recipe = flatRecipe({
       on_error: { fallback: "log_only" },
-      steps: [{ tool: "file.read", path: "/tmp/a", into: "data" }],
+      steps: [{ tool: "file.read", path: `${TMP}/a`, into: "data" }],
     });
     await dispatchRecipe(recipe, {
       ...baseDeps(),

--- a/src/recipes/__tests__/yamlRunner.test.ts
+++ b/src/recipes/__tests__/yamlRunner.test.ts
@@ -64,6 +64,9 @@ function makeRecipe(overrides: Partial<YamlRecipe> = {}): YamlRecipe {
 }
 
 const tmpLogDir = mkdtempSync(path.join(os.tmpdir(), "yamlrunner-test-"));
+// Per-suite scratch dir for fixture paths (replaces hard-coded "/tmp" so
+// Win32 CI passes the recipe-path jail check).
+const TMP = tmpLogDir;
 
 function noop(): RunnerDeps {
   return {
@@ -112,7 +115,7 @@ describe("validateYamlRecipe", () => {
     const r = validateYamlRecipe({
       name: "x",
       trigger: { type: "manual" },
-      steps: [{ tool: "file.read", path: "/tmp/x" }],
+      steps: [{ tool: "file.read", path: `${TMP}/x` }],
     });
     expect(r.name).toBe("x");
   });
@@ -135,7 +138,7 @@ describe("validateYamlRecipe", () => {
         {
           tool: "file.append",
           params: {
-            path: "/tmp/out.md",
+            path: `${TMP}/out.md`,
             line: "hello",
           },
           output: "saved",
@@ -162,7 +165,7 @@ describe("validateYamlRecipe", () => {
     expect(recipe.steps).toMatchObject([
       {
         tool: "file.append",
-        path: "/tmp/out.md",
+        path: `${TMP}/out.md`,
         content: "hello",
         into: "saved",
       },
@@ -217,13 +220,13 @@ describe("runYamlRecipe — file.write", () => {
       steps: [
         {
           tool: "file.write",
-          path: "/tmp/meta.md",
+          path: `${TMP}/meta.md`,
           content: "hello",
           into: "saved",
         },
         {
           tool: "file.write",
-          path: "/tmp/out.md",
+          path: `${TMP}/out.md`,
           content: "{{saved.path}} ({{saved.bytesWritten}})",
         },
       ],
@@ -235,9 +238,9 @@ describe("runYamlRecipe — file.write", () => {
       },
     });
 
-    expect(result.context["saved.path"]).toBe("/tmp/meta.md");
+    expect(result.context["saved.path"]).toBe(`${TMP}/meta.md`);
     expect(result.context["saved.bytesWritten"]).toBe("5");
-    expect(written["/tmp/out.md"]).toBe("/tmp/meta.md (5)");
+    expect(written[`${TMP}/out.md`]).toBe(`${TMP}/meta.md (5)`);
   });
 });
 
@@ -266,7 +269,12 @@ describe("runYamlRecipe — file.append", () => {
     const appended: string[] = [];
     const recipe = makeRecipe({
       steps: [
-        { tool: "file.append", path: "/tmp/x.md", content: "x", when: "0 > 1" },
+        {
+          tool: "file.append",
+          path: `${TMP}/x.md`,
+          content: "x",
+          when: "0 > 1",
+        },
       ],
     });
     await runYamlRecipe(recipe, {
@@ -284,7 +292,11 @@ describe("runYamlRecipe — file.read", () => {
     const recipe = makeRecipe({
       steps: [
         { tool: "file.read", path: "~/.patchwork/planned.md", into: "plan" },
-        { tool: "file.write", path: "/tmp/out.md", content: "plan: {{plan}}" },
+        {
+          tool: "file.write",
+          path: `${TMP}/out.md`,
+          content: "plan: {{plan}}",
+        },
       ],
     });
     const written: Record<string, string> = {};
@@ -295,7 +307,7 @@ describe("runYamlRecipe — file.read", () => {
         written[p] = c;
       },
     });
-    expect(written["/tmp/out.md"]).toBe("plan: do stuff");
+    expect(written[`${TMP}/out.md`]).toBe("plan: do stuff");
   });
 
   it("optional:true does not throw on missing file", async () => {
@@ -338,7 +350,7 @@ describe("runYamlRecipe — git.log_since", () => {
         { tool: "git.log_since", since: "24h", into: "commits" },
         {
           tool: "file.write",
-          path: "/tmp/out.md",
+          path: `${TMP}/out.md`,
           content: "commits: {{commits}}",
         },
       ],
@@ -351,7 +363,7 @@ describe("runYamlRecipe — git.log_since", () => {
         written[p] = c;
       },
     });
-    expect(written["/tmp/out.md"]).toContain("abc feat: x");
+    expect(written[`${TMP}/out.md`]).toContain("abc feat: x");
   });
 });
 
@@ -360,7 +372,7 @@ describe("runYamlRecipe — git.stale_branches", () => {
     const recipe = makeRecipe({
       steps: [
         { tool: "git.stale_branches", days: 30, into: "stale" },
-        { tool: "file.write", path: "/tmp/stale.md", content: "{{stale}}" },
+        { tool: "file.write", path: `${TMP}/stale.md`, content: "{{stale}}" },
       ],
     });
     const written: Record<string, string> = {};
@@ -371,7 +383,7 @@ describe("runYamlRecipe — git.stale_branches", () => {
         written[p] = c;
       },
     });
-    expect(written["/tmp/stale.md"]).toBe("old-branch");
+    expect(written[`${TMP}/stale.md`]).toBe("old-branch");
   });
 });
 
@@ -455,7 +467,7 @@ describe("runYamlRecipe — silent-fail detection (P1)", () => {
           into: "stale",
           optional: true,
         },
-        { tool: "file.write", path: "/tmp/x.md", content: "ok" },
+        { tool: "file.write", path: `${TMP}/x.md`, content: "ok" },
       ],
     });
     const written: Record<string, string> = {};
@@ -468,7 +480,7 @@ describe("runYamlRecipe — silent-fail detection (P1)", () => {
     });
     // Step 1 marked error (silent-fail caught) but optional → run proceeds.
     expect(result.stepResults[0]?.status).toBe("error");
-    expect(written["/tmp/x.md"]).toBe("ok");
+    expect(written[`${TMP}/x.md`]).toBe("ok");
     expect(result.errorMessage).toBeUndefined();
   });
 });
@@ -484,7 +496,7 @@ describe("runYamlRecipe — on_error retry + fallback", () => {
       steps: [
         {
           tool: "file.read",
-          path: "/tmp/a",
+          path: `${TMP}/a`,
           into: "data",
           retry: 2,
           retryDelay: 0,
@@ -508,7 +520,7 @@ describe("runYamlRecipe — on_error retry + fallback", () => {
     let calls = 0;
     const recipe = makeRecipe({
       on_error: { retry: 1, retryDelay: 0 },
-      steps: [{ tool: "file.read", path: "/tmp/a", into: "data" }],
+      steps: [{ tool: "file.read", path: `${TMP}/a`, into: "data" }],
     });
     const result = await runYamlRecipe(
       recipe,
@@ -526,7 +538,7 @@ describe("runYamlRecipe — on_error retry + fallback", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const recipe = makeRecipe({
       on_error: { fallback: "log_only" },
-      steps: [{ tool: "file.read", path: "/tmp/a", into: "data" }],
+      steps: [{ tool: "file.read", path: `${TMP}/a`, into: "data" }],
     });
     const result = await runYamlRecipe(
       recipe,
@@ -546,7 +558,7 @@ describe("runYamlRecipe — on_error retry + fallback", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const recipe = makeRecipe({
       on_error: { fallback: "deliver_original" },
-      steps: [{ tool: "file.read", path: "/tmp/a", into: "data" }],
+      steps: [{ tool: "file.read", path: `${TMP}/a`, into: "data" }],
     });
     const result = await runYamlRecipe(
       recipe,
@@ -561,7 +573,7 @@ describe("runYamlRecipe — on_error retry + fallback", () => {
   it("propagates failure when on_error.fallback=abort (default)", async () => {
     const recipe = makeRecipe({
       on_error: { fallback: "abort" },
-      steps: [{ tool: "file.read", path: "/tmp/a", into: "data" }],
+      steps: [{ tool: "file.read", path: `${TMP}/a`, into: "data" }],
     });
     const result = await runYamlRecipe(
       recipe,
@@ -587,7 +599,11 @@ describe("runYamlRecipe — seed context", () => {
   it("merges seed context into template vars", async () => {
     const recipe = makeRecipe({
       steps: [
-        { tool: "file.write", path: "/tmp/out.md", content: "file: {{file}}" },
+        {
+          tool: "file.write",
+          path: `${TMP}/out.md`,
+          content: "file: {{file}}",
+        },
       ],
     });
     const written: Record<string, string> = {};
@@ -601,7 +617,7 @@ describe("runYamlRecipe — seed context", () => {
       },
       { file: "src/index.ts" },
     );
-    expect(written["/tmp/out.md"]).toBe("file: src/index.ts");
+    expect(written[`${TMP}/out.md`]).toBe("file: src/index.ts");
   });
 });
 
@@ -621,10 +637,10 @@ describe("runYamlRecipe — step.when guard", () => {
     const written: Record<string, string> = {};
     const recipe = makeRecipe({
       steps: [
-        { tool: "file.write", path: "/tmp/first.md", content: "always" },
+        { tool: "file.write", path: `${TMP}/first.md`, content: "always" },
         {
           tool: "file.write",
-          path: "/tmp/second.md",
+          path: `${TMP}/second.md`,
           content: "guarded",
           when: "{{flag}}",
         },
@@ -640,8 +656,8 @@ describe("runYamlRecipe — step.when guard", () => {
       },
       { flag: "" },
     );
-    expect(written["/tmp/first.md"]).toBe("always");
-    expect(written["/tmp/second.md"]).toBeUndefined();
+    expect(written[`${TMP}/first.md`]).toBe("always");
+    expect(written[`${TMP}/second.md`]).toBeUndefined();
     expect(result.stepResults[1]!.status).toBe("skipped");
     expect(result.errorMessage).toBeUndefined();
   });
@@ -650,10 +666,10 @@ describe("runYamlRecipe — step.when guard", () => {
     const written: Record<string, string> = {};
     const recipe = makeRecipe({
       steps: [
-        { tool: "file.write", path: "/tmp/first.md", content: "always" },
+        { tool: "file.write", path: `${TMP}/first.md`, content: "always" },
         {
           tool: "file.write",
-          path: "/tmp/second.md",
+          path: `${TMP}/second.md`,
           content: "guarded",
           when: "{{flag}}",
         },
@@ -669,8 +685,8 @@ describe("runYamlRecipe — step.when guard", () => {
       },
       { flag: "yes" },
     );
-    expect(written["/tmp/first.md"]).toBe("always");
-    expect(written["/tmp/second.md"]).toBe("guarded");
+    expect(written[`${TMP}/first.md`]).toBe("always");
+    expect(written[`${TMP}/second.md`]).toBe("guarded");
     expect(result.stepResults[1]!.status).toBe("ok");
   });
 
@@ -678,7 +694,7 @@ describe("runYamlRecipe — step.when guard", () => {
     let agentCalls = 0;
     const recipe = makeRecipe({
       steps: [
-        { tool: "file.write", path: "/tmp/report.md", content: "report" },
+        { tool: "file.write", path: `${TMP}/report.md`, content: "report" },
         {
           when: "{{phone}}",
           agent: {
@@ -710,7 +726,7 @@ describe("runYamlRecipe — step.when guard", () => {
     let agentCalls = 0;
     const recipe = makeRecipe({
       steps: [
-        { tool: "file.write", path: "/tmp/report.md", content: "report" },
+        { tool: "file.write", path: `${TMP}/report.md`, content: "report" },
         {
           when: "{{phone}}",
           agent: {
@@ -743,7 +759,7 @@ describe("runYamlRecipe — step.when guard", () => {
         steps: [
           {
             tool: "file.write",
-            path: "/tmp/x.md",
+            path: `${TMP}/x.md`,
             content: "x",
             when: "{{flag}}",
           },
@@ -759,7 +775,7 @@ describe("runYamlRecipe — step.when guard", () => {
         },
         { flag: falsy },
       );
-      expect(written["/tmp/x.md"]).toBeUndefined();
+      expect(written[`${TMP}/x.md`]).toBeUndefined();
     }
   });
 });
@@ -779,7 +795,7 @@ describe("runYamlRecipe — context: env blocks", () => {
         steps: [
           {
             tool: "file.write",
-            path: "/tmp/out.md",
+            path: `${TMP}/out.md`,
             content: "channel={{YAMLRUNNER_TEST_CHANNEL}}",
           },
         ],
@@ -791,7 +807,7 @@ describe("runYamlRecipe — context: env blocks", () => {
           written[p] = c;
         },
       });
-      expect(written["/tmp/out.md"]).toBe("channel=C12345");
+      expect(written[`${TMP}/out.md`]).toBe("channel=C12345");
     } finally {
       delete process.env.YAMLRUNNER_TEST_CHANNEL;
     }
@@ -807,7 +823,7 @@ describe("runYamlRecipe — context: env blocks", () => {
         steps: [
           {
             tool: "file.write",
-            path: "/tmp/out.md",
+            path: `${TMP}/out.md`,
             content: "v={{YAMLRUNNER_TEST_OVERRIDE}}",
           },
         ],
@@ -824,7 +840,7 @@ describe("runYamlRecipe — context: env blocks", () => {
         { YAMLRUNNER_TEST_OVERRIDE: "from-seed" },
       );
       // Seed context is merged after env block, so it wins on collisions.
-      expect(written["/tmp/out.md"]).toBe("v=from-seed");
+      expect(written[`${TMP}/out.md`]).toBe("v=from-seed");
     } finally {
       delete process.env.YAMLRUNNER_TEST_OVERRIDE;
     }
@@ -839,7 +855,7 @@ describe("runYamlRecipe — context: env blocks", () => {
       steps: [
         {
           tool: "file.write",
-          path: "/tmp/out.md",
+          path: `${TMP}/out.md`,
           content: "v={{YAMLRUNNER_TEST_MISSING}}",
         },
       ],
@@ -853,7 +869,7 @@ describe("runYamlRecipe — context: env blocks", () => {
     });
     // Unset env vars render to empty string (existing render contract), not
     // the literal `{{...}}` placeholder.
-    expect(written["/tmp/out.md"]).toBe("v=");
+    expect(written[`${TMP}/out.md`]).toBe("v=");
   });
 });
 
@@ -866,10 +882,10 @@ describe("runYamlRecipe — JSON parse-on-into for dot-notation lookups", () => 
     const written: Record<string, string> = {};
     const recipe = makeRecipe({
       steps: [
-        { tool: "file.read", path: "/tmp/in.json", into: "data" },
+        { tool: "file.read", path: `${TMP}/in.json`, into: "data" },
         {
           tool: "file.write",
-          path: "/tmp/out.md",
+          path: `${TMP}/out.md`,
           content: "name={{data.name}} count={{data.count}}",
         },
       ],
@@ -881,17 +897,17 @@ describe("runYamlRecipe — JSON parse-on-into for dot-notation lookups", () => 
         written[p] = c;
       },
     });
-    expect(written["/tmp/out.md"]).toBe("name=patchwork count=7");
+    expect(written[`${TMP}/out.md`]).toBe("name=patchwork count=7");
   });
 
   it("falls back to raw string lookup when output is not valid JSON", async () => {
     const written: Record<string, string> = {};
     const recipe = makeRecipe({
       steps: [
-        { tool: "file.read", path: "/tmp/in.txt", into: "data" },
+        { tool: "file.read", path: `${TMP}/in.txt`, into: "data" },
         {
           tool: "file.write",
-          path: "/tmp/out.md",
+          path: `${TMP}/out.md`,
           content: "raw={{data}}",
         },
       ],
@@ -903,7 +919,7 @@ describe("runYamlRecipe — JSON parse-on-into for dot-notation lookups", () => 
         written[p] = c;
       },
     });
-    expect(written["/tmp/out.md"]).toBe("raw=plain text body");
+    expect(written[`${TMP}/out.md`]).toBe("raw=plain text body");
   });
 });
 
@@ -1059,7 +1075,7 @@ describe("runYamlRecipe — gmail.fetch_unread", () => {
         { tool: "gmail.fetch_unread", since: "24h", max: 10, into: "messages" },
         {
           tool: "file.write",
-          path: "/tmp/out.md",
+          path: `${TMP}/out.md`,
           content: "count: {{messages.count}}",
         },
       ],
@@ -1073,7 +1089,7 @@ describe("runYamlRecipe — gmail.fetch_unread", () => {
         written[p] = c;
       },
     });
-    expect(written["/tmp/out.md"]).toBe("count: 2");
+    expect(written[`${TMP}/out.md`]).toBe("count: 2");
   });
 
   it("stores message array as JSON in context key", async () => {
@@ -1469,7 +1485,7 @@ describe("gmail-health-check recipe end-to-end", () => {
         },
         {
           tool: "file.write",
-          path: "/tmp/gmail-health.md",
+          path: `${TMP}/gmail-health.md`,
           content:
             "unread-7d: {{recent.count}}\ntotal-unread: {{unread_check.count}}",
         },
@@ -1484,9 +1500,9 @@ describe("gmail-health-check recipe end-to-end", () => {
         written[p] = c;
       },
     });
-    expect(written["/tmp/gmail-health.md"]).toContain("unread-7d: 2");
+    expect(written[`${TMP}/gmail-health.md`]).toContain("unread-7d: 2");
     // max:1 means at most 1 result returned for unread_check
-    expect(written["/tmp/gmail-health.md"]).toContain("total-unread: 1");
+    expect(written[`${TMP}/gmail-health.md`]).toContain("total-unread: 1");
   });
 });
 
@@ -1514,7 +1530,7 @@ describe("linear.list_issues step", () => {
           },
           {
             tool: "file.write",
-            path: "/tmp/linear-out.md",
+            path: `${TMP}/linear-out.md`,
             content: "{{linear_issues}}",
           },
         ],
@@ -1526,7 +1542,7 @@ describe("linear.list_issues step", () => {
         },
       },
     );
-    const out = JSON.parse(written["/tmp/linear-out.md"] ?? "{}") as {
+    const out = JSON.parse(written[`${TMP}/linear-out.md`] ?? "{}") as {
       count: number;
       issues: unknown[];
     };
@@ -1546,7 +1562,7 @@ describe("linear.list_issues step", () => {
           { tool: "linear.list_issues", into: "linear_issues" },
           {
             tool: "file.write",
-            path: "/tmp/linear-out.md",
+            path: `${TMP}/linear-out.md`,
             content: "{{linear_issues}}",
           },
         ],
@@ -1558,7 +1574,7 @@ describe("linear.list_issues step", () => {
         },
       },
     );
-    const out = JSON.parse(written["/tmp/linear-out.md"] ?? "{}") as {
+    const out = JSON.parse(written[`${TMP}/linear-out.md`] ?? "{}") as {
       count: number;
       error: string;
     };
@@ -1579,7 +1595,7 @@ describe("linear.list_issues step", () => {
           { tool: "linear.list_issues", into: "linear_issues" },
           {
             tool: "file.write",
-            path: "/tmp/linear-out.md",
+            path: `${TMP}/linear-out.md`,
             content: "{{linear_issues}}",
           },
         ],
@@ -1591,7 +1607,7 @@ describe("linear.list_issues step", () => {
         },
       },
     );
-    const out = JSON.parse(written["/tmp/linear-out.md"] ?? "{}") as {
+    const out = JSON.parse(written[`${TMP}/linear-out.md`] ?? "{}") as {
       count: number;
       error: string;
     };
@@ -1622,7 +1638,7 @@ describe("github.list_issues step", () => {
           { tool: "github.list_issues", into: "gh" },
           {
             tool: "file.write",
-            path: "/tmp/gh.md",
+            path: `${TMP}/gh.md`,
             content: "{{gh}}",
           },
         ],
@@ -1634,7 +1650,7 @@ describe("github.list_issues step", () => {
         },
       },
     );
-    const out = JSON.parse(written["/tmp/gh.md"] ?? "{}") as {
+    const out = JSON.parse(written[`${TMP}/gh.md`] ?? "{}") as {
       count: number;
       issues: unknown[];
     };
@@ -1669,7 +1685,7 @@ describe("github.list_prs step", () => {
       makeRecipe({
         steps: [
           { tool: "github.list_prs", into: "prs" },
-          { tool: "file.write", path: "/tmp/prs.md", content: "{{prs}}" },
+          { tool: "file.write", path: `${TMP}/prs.md`, content: "{{prs}}" },
         ],
       }),
       {
@@ -1679,7 +1695,7 @@ describe("github.list_prs step", () => {
         },
       },
     );
-    const out = JSON.parse(written["/tmp/prs.md"] ?? "{}") as {
+    const out = JSON.parse(written[`${TMP}/prs.md`] ?? "{}") as {
       count: number;
       prs: unknown[];
     };
@@ -1889,7 +1905,7 @@ describe("runYamlRecipe — expect assertions wired end-to-end", () => {
       steps: [
         {
           tool: "file.write",
-          path: "/tmp/x.txt",
+          path: `${TMP}/x.txt`,
           content: "hello",
           into: "saved",
         },
@@ -1912,12 +1928,12 @@ describe("runYamlRecipe — expect assertions wired end-to-end", () => {
       steps: [
         {
           tool: "file.write",
-          path: "/tmp/y.txt",
+          path: `${TMP}/y.txt`,
           content: "hi",
           into: "saved",
         },
       ],
-      expect: { stepsRun: 1, outputs: ["/tmp/y.txt"], errorMessage: null },
+      expect: { stepsRun: 1, outputs: [`${TMP}/y.txt`], errorMessage: null },
     });
     const result = await runYamlRecipe(recipe, {
       ...noop(),
@@ -2266,7 +2282,7 @@ import { dispatchRecipe } from "../yamlRunner.js";
 describe("dispatchRecipe", () => {
   it("routes simple recipe to runYamlRecipe", async () => {
     const recipe = makeRecipe({
-      steps: [{ tool: "file.write", path: "/tmp/x.txt", content: "hi" }],
+      steps: [{ tool: "file.write", path: `${TMP}/x.txt`, content: "hi" }],
     });
     const result = await dispatchRecipe(recipe, {
       ...noop(),

--- a/src/tools/__tests__/batchLsp.test.ts
+++ b/src/tools/__tests__/batchLsp.test.ts
@@ -1,3 +1,5 @@
+import os from "node:os";
+import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import {
   createBatchFindImplementationsTool,
@@ -5,7 +7,13 @@ import {
   createBatchGoToDefinitionTool,
 } from "../batchLsp.js";
 
-const workspace = "/tmp";
+// Use a real OS-tmp path so the resolveFilePath containment check works on Win32
+// (where literal "/tmp" resolves to C:\tmp and lstat ancestor-walks differently).
+const workspace = os.tmpdir();
+const FOO_TS = path.join(workspace, "foo.ts");
+const LIB_TS = path.join(workspace, "lib.ts");
+const IMPL_TS = path.join(workspace, "impl.ts");
+const A_TS = path.join(workspace, "a.ts");
 
 function makeClient(overrides: Record<string, any> = {}) {
   return {
@@ -14,16 +22,16 @@ function makeClient(overrides: Record<string, any> = {}) {
       Promise.resolve({ contents: ["function foo(): void"], range: null }),
     ),
     goToDefinition: vi.fn(() =>
-      Promise.resolve([{ file: "/tmp/lib.ts", line: 5, column: 1 }]),
+      Promise.resolve([{ file: LIB_TS, line: 5, column: 1 }]),
     ),
     findImplementations: vi.fn(() =>
-      Promise.resolve([{ file: "/tmp/impl.ts", line: 10, column: 1 }]),
+      Promise.resolve([{ file: IMPL_TS, line: 10, column: 1 }]),
     ),
     ...overrides,
   };
 }
 
-const ITEM = { filePath: "/tmp/foo.ts", line: 3, column: 7 };
+const ITEM = { filePath: FOO_TS, line: 3, column: 7 };
 
 // ── batchGetHover ─────────────────────────────────────────────────────────────
 
@@ -109,7 +117,7 @@ describe("batchGetHover", () => {
     const tool = createBatchGetHoverTool(workspace, client as never);
     const result = (await tool.handler({ items: [ITEM] })) as any;
     const data = JSON.parse(result.content[0].text);
-    expect(data.results[0].filePath).toBe("/tmp/foo.ts");
+    expect(data.results[0].filePath).toBe(FOO_TS);
     expect(data.results[0].line).toBe(3);
     expect(data.results[0].column).toBe(7);
   });
@@ -171,7 +179,7 @@ describe("batchGoToDefinition", () => {
     const data = JSON.parse(result.content[0].text);
     expect(data.results).toHaveLength(1);
     expect(data.results[0].result).toEqual([
-      { file: "/tmp/lib.ts", line: 5, column: 1 },
+      { file: LIB_TS, line: 5, column: 1 },
     ]);
   });
 
@@ -179,7 +187,7 @@ describe("batchGoToDefinition", () => {
     const client = makeClient({
       goToDefinition: vi
         .fn()
-        .mockResolvedValueOnce([{ file: "/tmp/a.ts", line: 1, column: 1 }])
+        .mockResolvedValueOnce([{ file: A_TS, line: 1, column: 1 }])
         .mockRejectedValueOnce(new Error("lsp error")),
     });
     const tool = createBatchGoToDefinitionTool(workspace, client as never);
@@ -228,7 +236,7 @@ describe("batchFindImplementations", () => {
     expect(data.results).toHaveLength(1);
     expect(data.count).toBe(1);
     expect(data.results[0].result).toEqual([
-      { file: "/tmp/impl.ts", line: 10, column: 1 },
+      { file: IMPL_TS, line: 10, column: 1 },
     ]);
   });
 
@@ -237,7 +245,7 @@ describe("batchFindImplementations", () => {
     const tool = createBatchFindImplementationsTool(workspace, client as never);
     const result = (await tool.handler({ items: [ITEM] })) as any;
     const data = JSON.parse(result.content[0].text);
-    expect(data.results[0].filePath).toBe("/tmp/foo.ts");
+    expect(data.results[0].filePath).toBe(FOO_TS);
     expect(data.results[0].line).toBe(3);
     expect(data.results[0].column).toBe(7);
   });
@@ -256,7 +264,7 @@ describe("batchFindImplementations", () => {
     const client = makeClient({
       findImplementations: vi
         .fn()
-        .mockResolvedValueOnce([{ file: "/tmp/a.ts", line: 1, column: 1 }])
+        .mockResolvedValueOnce([{ file: A_TS, line: 1, column: 1 }])
         .mockRejectedValueOnce(new Error("lsp error")),
     });
     const tool = createBatchFindImplementationsTool(workspace, client as never);


### PR DESCRIPTION
## Summary

Drops Windows CI failure count by normalizing test fixtures that used literal POSIX paths.

Tests that invoke `runYamlRecipe` / `resolveFilePath` / `resolveRecipePath` were failing on `windows-latest` because their fixtures used literal POSIX paths like `/tmp/x`. On Win32 those resolve under a drive root (e.g. `C:\tmp\x`) which fails the recipe-path-jail symlink re-check — the jail roots include `os.tmpdir()` plus the literal `"/tmp"` string, but on Windows those resolve to different physical directories.

## Changes

- **yamlRunner.test.ts** — 67 fixture paths swapped to `\`\${TMP}/...\`` template strings driven off a per-suite `mkdtempSync` scratch dir; matching `written[...]` lookups rewritten in lockstep so the runner's rendered path equals the assertion key on every platform.
- **dispatchRecipe.parity.test.ts** — same pattern, 5 paths.
- **batchLsp.test.ts** — `workspace` + `filePath` fixtures now use `os.tmpdir()` + `path.join` so `resolveFilePath`'s lstat ancestor walk + containment check land on a real existing root.
- **inbox-archive-delete.test.ts** + **recipes-archive.test.ts** — `endsWith` / `toMatch` assertions normalized to forward slashes via `.replace(/\\\\/g, "/")` on the asserted-against value only.
- **recipe.test.ts (CLI)** — `filesWritten` `endsWith` assertions normalized the same way.

No production code touched. Schema-only `validateYamlRecipe` tests + `listYamlRecipes` / `loadNestedRecipe` schema tests left alone — they never execute the path through `resolveRecipePath`.

Automation `*.test.ts` files were investigated but found to already pass on Win32: placeholder substitution is a plain string replace and never path-resolves the `{{file}}` value, so the literal `/src/foo.ts` round-trips intact.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx biome check --write <changed files>` clean
- [x] `npx vitest run` against all 6 changed files: 290 / 290 pass on darwin
- [ ] Confirm windows-latest matrix drops failure count once CI runs