### PR TITLE
ci(win32): close last failure + flip windows-latest to blocking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,9 @@ permissions:
 jobs:
   ci:
     runs-on: ${{ matrix.os }}
-    # windows-latest is advisory until the pre-existing POSIX-only test gaps
-    # (mode-bit asserts, bash-script tests, symlink fixtures, hardcoded
-    # /src paths) are closed. Tracked as follow-up work to PR #495.
-    continue-on-error: ${{ matrix.os == 'windows-latest' }}
+    # windows-latest was advisory through PRs #497–#501 while the
+    # pre-existing POSIX-only test gaps were closed (126 → 0 failures).
+    # Now a real blocking check.
     strategy:
       fail-fast: false
       matrix:

--- a/src/__tests__/inbox-archive-delete.test.ts
+++ b/src/__tests__/inbox-archive-delete.test.ts
@@ -65,11 +65,19 @@ function fakeRequest(method: string): IncomingMessage {
   return { method } as IncomingMessage;
 }
 
-async function flush(): Promise<void> {
+async function flush(result?: { status: number }): Promise<void> {
   // Route handlers are dispatched via `void (async () => {...})()` and may
-  // call `await import("node:fs/promises")` internally, so we need a real
-  // tick (not just the microtask queue) before asserting.
-  await new Promise((r) => setTimeout(r, 30));
+  // call `await import("node:fs/promises")` internally. A fixed 30ms wait
+  // is enough on a warm darwin laptop but flakes on slow Windows CI
+  // runners — poll until status is set (or 2s cap) when a result is passed.
+  if (!result) {
+    await new Promise((r) => setTimeout(r, 30));
+    return;
+  }
+  const deadline = Date.now() + 2000;
+  while (result.status === 0 && Date.now() < deadline) {
+    await new Promise((r) => setTimeout(r, 10));
+  }
 }
 
 describe("inboxRoutes — archive + delete", () => {
@@ -87,7 +95,7 @@ describe("inboxRoutes — archive + delete", () => {
       new URL(`http://x/inbox/${filename}/archive`),
     );
     expect(handled).toBe(true);
-    await flush();
+    await flush(result);
 
     expect(result.status).toBe(200);
     const body = JSON.parse(result.body) as { ok: boolean; path: string };
@@ -113,7 +121,7 @@ describe("inboxRoutes — archive + delete", () => {
       new URL(`http://x/inbox/${filename}`),
     );
     expect(handled).toBe(true);
-    await flush();
+    await flush(result);
 
     expect(result.status).toBe(200);
     expect(JSON.parse(result.body).ok).toBe(true);
@@ -129,7 +137,7 @@ describe("inboxRoutes — archive + delete", () => {
       res,
       new URL("http://x/inbox/nope.md/archive"),
     );
-    await flush();
+    await flush(result);
     expect(result.status).toBe(404);
     expect(JSON.parse(result.body).ok).toBe(false);
   });
@@ -141,7 +149,7 @@ describe("inboxRoutes — archive + delete", () => {
       res,
       new URL("http://x/inbox/nope.md"),
     );
-    await flush();
+    await flush(result);
     expect(result.status).toBe(404);
   });
 
@@ -154,7 +162,7 @@ describe("inboxRoutes — archive + delete", () => {
       // slash decodes back to `/` — must still be rejected.
       new URL("http://x/inbox/%2E%2E%2Fpasswd.md/archive"),
     );
-    await flush();
+    await flush(result);
     expect(result.status).toBe(400);
   });
 
@@ -169,7 +177,7 @@ describe("inboxRoutes — archive + delete", () => {
       r1.res,
       new URL(`http://x/inbox/${filename}/archive`),
     );
-    await flush();
+    await flush(r1.result);
     expect(r1.result.status).toBe(200);
 
     // Re-create at the same name and archive again.
@@ -180,7 +188,7 @@ describe("inboxRoutes — archive + delete", () => {
       r2.res,
       new URL(`http://x/inbox/${filename}/archive`),
     );
-    await flush();
+    await flush(r2.result);
     expect(r2.result.status).toBe(200);
 
     const archived = readdirSync(path.join(inboxDir, ".archive"));
@@ -201,11 +209,11 @@ describe("inboxRoutes — archive + delete", () => {
       arch.res,
       new URL(`http://x/inbox/${filename}/archive`),
     );
-    await flush();
+    await flush(arch.result);
 
     const { res, result } = captureResponse();
     tryHandleInboxRoute(fakeRequest("GET"), res, new URL("http://x/inbox"));
-    await flush();
+    await flush(result);
     expect(result.status).toBe(200);
     const body = JSON.parse(result.body) as { items: { name: string }[] };
     expect(body.items.find((i) => i.name === filename)).toBeUndefined();

--- a/src/__tests__/install.test.ts
+++ b/src/__tests__/install.test.ts
@@ -208,8 +208,10 @@ describe("runInstall", () => {
   });
 
   describe("--target cli", () => {
-    // CLAUDE_CONFIG_DIR overrides the home dir base for the CLI config path
-    const testHomeDir = "/tmp/test-home";
+    // CLAUDE_CONFIG_DIR overrides the home dir base for the CLI config path.
+    // Normalize so production's path.join() doesn't rewrite forward slashes
+    // to backslashes on Win32 — otherwise startsWith() below mismatches.
+    const testHomeDir = path.normalize("/tmp/test-home");
 
     beforeEach(() => {
       process.env.CLAUDE_CONFIG_DIR = testHomeDir;


### PR DESCRIPTION
## Summary

Final piece of the Windows compatibility work (PRs #495 → #501). Closes the last remaining failure and makes Windows CI a real blocking check.

- **`src/__tests__/install.test.ts`** — \`testHomeDir = "/tmp/test-home"\` literal. On Win32 production's \`path.join()\` rewrites all separators, so the actual write path becomes \`\\tmp\\test-home\\.claude.json\` while the test's \`expectedBase\` stayed \`/tmp/test-home\\.claude.json\`. \`startsWith()\` mismatched. Wrap in \`path.normalize()\` so the base matches whatever \`path.join\` produces.
- **`.github/workflows/ci.yml`** — drop \`continue-on-error: ${{ matrix.os == 'windows-latest' }}\` added in PR #495. Windows is now blocking.

## End state

0 Windows failures on main. The full journey:

| Stage | Failures |
|---|---|
| PR #495 (initial windows-latest matrix entry) | 126 |
| After PR #497 (skipIfs) | ~109 |
| After PR #498 (/tmp fixtures) | ~50 |
| After PR #499 (long tail) | ~30 |
| After PR #500 (yamlRunner + LSP) | 18 |
| After PR #501 (final cleanup) | 1 |
| **After this PR** | **0** |

Production bugs found and fixed along the way:
- vscode-extension CRLF / .cmd / SIGTERM
- \`makeRelative\` path.sep prefix stripping
- \`parseCoverageSummary\` path.sep same bug
- \`bridgeDoctor\` execSync shell injection
- \`resolvePs\` spawnSync exit-status check
- \`vitestJest\` path.relative backslash output in MCP tool result
- \`recipeInstall\` startsWith("/") rejected Win32 abs paths