### PR TITLE
fix(init): default driver to subprocess so recipe-run works post-init

### DIFF
--- a/scripts/start-all.mjs
+++ b/scripts/start-all.mjs
@@ -308,10 +308,12 @@ function buildBridgeArgs() {
   const extra = [
     "--workspace",
     WORKSPACE,
+    "--driver",
+    DRIVER,
     ...(BRIDGE_PORT > 0 ? ["--port", String(BRIDGE_PORT)] : []),
     ...(FULL_MODE ? ["--full"] : []),
     ...(AUTO_POLICY
-      ? ["--automation", "--automation-policy", AUTO_POLICY, "--driver", DRIVER]
+      ? ["--automation", "--automation-policy", AUTO_POLICY]
       : []),
   ];
   return { bin, args: [...prefix, ...extra] };

--- a/src/patchworkConfig.ts
+++ b/src/patchworkConfig.ts
@@ -80,6 +80,11 @@ const DEFAULTS: PatchworkConfig = {
     pushNotifications: false,
   },
   recipesDir: join(homedir(), ".patchwork", "recipes"),
+  // Default driver so `patchwork-os recipe run X` and dashboard task launches
+  // work immediately after `patchwork init`. Without this the bridge defaults
+  // to "none" and recipe execution returns "Recipe execution unavailable —
+  // requires --driver subprocess", silently breaking the init "Next:" flow.
+  driver: "subprocess",
 };
 
 export function defaultConfigPath(): string {


### PR DESCRIPTION
## Summary

Audit reviewer flagged a P0 the original audit missed: init's "Next:" instructions tell new users to run \`patchwork-os recipe run daily-status\`, but on a fresh install **every recipe run fails** with:

> Recipe execution unavailable — requires --driver subprocess

### Root cause chain

1. \`src/patchworkConfig.ts\` DEFAULTS had no \`driver\` field, so a freshly \`patchwork init\`-ed config.json omits it.
2. \`src/config.ts:498\` reads the field and falls back to \`"none"\`.
3. \`src/recipeRoutes.ts:495\` short-circuits all recipe execution when \`driver === "none"\`.
4. \`scripts/start-all.mjs\` only passed \`--driver\` to the bridge when \`--automation-policy\` was also set.

So whether the user reached the bridge via \`patchwork start\` OR direct invocation, the driver was \`"none"\`.

### Fix

Two-pronged so both paths work after a clean init:

- \`DEFAULTS\` in \`patchworkConfig.ts\` now sets \`driver: "subprocess"\`. Bridge picks this up on every start via \`config.ts:498\` fallback.
- \`start-all.mjs\` always passes \`--driver\` (defaulting to \`"subprocess"\`, same as the script's documented default).

No behavior change for users who explicitly set \`driver\` in their config. CLI \`--driver\` flag still wins per existing precedence.

## Test plan

- [x] \`tsc --noEmit\` clean
- [x] \`vitest\` 5369/5369 pass
- [ ] CI green
- [ ] Manual: after \`patchwork init && patchwork-os recipe run daily-status\` — runs (not "execution unavailable")