### PR TITLE
docs: hygiene cleanup — URL normalization, version refs, support section

### DIFF
--- a/README.bridge.md
+++ b/README.bridge.md
@@ -5,7 +5,7 @@
 [![Docker](https://img.shields.io/badge/docker-ghcr.io%2FOolab--labs%2Fclaude--ide--bridge-blue)](https://github.com/Oolab-labs/claude-ide-bridge/pkgs/container/claude-ide-bridge)
 [![License: MIT](https://img.shields.io/npm/l/claude-ide-bridge)](https://opensource.org/licenses/MIT)
 
-**MCP bridge giving Claude Code IDE superpowers: 141 tools for LSP, debugging, git, GitHub, terminals, and more.**
+**MCP bridge giving Claude Code IDE superpowers — 170+ tools for LSP, debugging, git, GitHub, terminals, and more (see [platform-docs](documents/platform-docs.md) for the full list).**
 
 A WebSocket bridge between Claude Code CLI and your VS Code extension. Claude sees what your IDE sees — live diagnostics, go-to-definition, call hierarchies, hover types, breakpoints, debugger state — and can act on it: edit files, run tests, commit, open PRs, all without you copy-pasting anything.
 
@@ -314,7 +314,7 @@ claude-ide-bridge install claude-mem
 | File | Description |
 |---|---|
 | [ARCHITECTURE.md](ARCHITECTURE.md) | System topology, request lifecycle, component map, design decisions |
-| [documents/platform-docs.md](documents/platform-docs.md) | Full tool reference — all 141 tools with parameters and examples |
+| [documents/platform-docs.md](documents/platform-docs.md) | Full tool reference — all 170+ tools with parameters and examples |
 | [documents/prompts-reference.md](documents/prompts-reference.md) | All MCP prompts (31 prompts, 12 plugin skills, 4 subagents) |
 | [docs/automation.md](docs/automation.md) | Automation hooks reference — all 18 events, policy schema, condition filters |
 | [docs/troubleshooting.md](docs/troubleshooting.md) | Diagnostics, common errors, and fixes |

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ Use whichever fits your mental model.
 
 ---
 
-## Tool surface (v0.2.0-beta.0)
+## Tool surface
 
 170+ MCP tools across 15 categories. Highlights:
 
@@ -342,6 +342,13 @@ patchwork init
 | [documents/comparison.md](documents/comparison.md) | Patchwork vs MCP server / Zapier / hosted assistants / agent frameworks — honest tradeoffs |
 | [docs/adr/](docs/adr/) | Architecture Decision Records |
 | [docs/remote-access.md](docs/remote-access.md) | VPS deployment guide |
+
+---
+
+## Support
+
+- **Bugs & feature requests:** [GitHub Issues](https://github.com/Oolab-labs/patchwork-os/issues)
+- **Questions & community:** [GitHub Discussions](https://github.com/Oolab-labs/patchwork-os/discussions)
 
 ---
 

--- a/docs/self-healing-quickstart.md
+++ b/docs/self-healing-quickstart.md
@@ -35,8 +35,8 @@ The command detects your IDE and installs the VSIX. Restart the IDE once after.
 ## 3. Grab the demo
 
 ```bash
-git clone https://github.com/Oolab-labs/claude-ide-bridge.git
-cd claude-ide-bridge/examples/self-healing-demo
+git clone https://github.com/Oolab-labs/patchwork-os.git
+cd patchwork-os/examples/self-healing-demo
 npm install
 ```
 

--- a/documents/platform-docs.md
+++ b/documents/platform-docs.md
@@ -1,6 +1,6 @@
 # Claude IDE Bridge — Platform Documentation
 
-Version **0.2.0-alpha.35** · 170+ tools · 72 MCP prompts · 20 automation hooks · 19 connectors (Slack, GitHub, Linear, Gmail, Google Calendar, Google Drive, Sentry, Notion, Confluence, Datadog, HubSpot, Intercom, Stripe, Zendesk, Jira, PagerDuty, Discord, Asana, GitLab — see [README](../README.md) for canonical list)
+170+ tools · 72 MCP prompts · 20 automation hooks · 19 connectors (Slack, GitHub, Linear, Gmail, Google Calendar, Google Drive, Sentry, Notion, Confluence, Datadog, HubSpot, Intercom, Stripe, Zendesk, Jira, PagerDuty, Discord, Asana, GitLab — see [README](../README.md) for canonical list) — current version in [package.json](../package.json)
 
 > **Deployment model:** Remote deployment (VPS + reverse proxy, systemd service, `--bind 0.0.0.0 --issuer-url <https-url>`) is a first-class, production-ready pattern and is the recommended architecture for team or cloud access. Local mode (`127.0.0.1`, no `--issuer-url`) is for individual development.
 


### PR DESCRIPTION
## Summary

- **URL split-brain fix:** `docs/self-healing-quickstart.md` clone URL pointed at the old `Oolab-labs/claude-ide-bridge` repo; corrected to `Oolab-labs/patchwork-os`
- **Version number drift:** removed hardcoded `v0.2.0-beta.0` from the "Tool surface" heading in `README.md` and replaced the pinned `Version 0.2.0-alpha.35` line in `documents/platform-docs.md` with a pointer to `package.json`; updated stale tool count (141 → 170+) in `README.bridge.md` tagline and docs table row
- **Support section:** added a minimal Support section to `README.md` with links to GitHub Issues and GitHub Discussions

## What was NOT changed

- No production code (`src/`, `vscode-extension/src/`, test files)
- No real domain names, tokens, or email addresses introduced
- `Oolab-labs/patchwork-os` GitHub URLs already present in docs were left as-is (they are correct and intentional)

## Test plan

- [ ] Spot-check that clone URL in `self-healing-quickstart.md` resolves to a valid path
- [ ] Confirm README renders cleanly on GitHub (support section, no pinned version in heading)

🤖 Generated with [Claude Code](https://claude.com/claude-code)