### PR TITLE
feat: kill-switch v2 — /kill-switch endpoint + CLI panic alias + SSE broadcast + EnvLockedFlagError

### DIFF
--- a/dashboard/src/app/settings/page.tsx
+++ b/dashboard/src/app/settings/page.tsx
@@ -309,6 +309,27 @@ export default function SettingsPage() {
     return () => clearInterval(id);
   }, []);
 
+  // v2-I8 (#422): SSE consumer for kind:"kill-switch" events from /stream.
+  // When the bridge emits a state-change event the toggle updates in <1s
+  // without waiting for the next 5-second poll cycle.
+  useEffect(() => {
+    const es = new EventSource(apiPath("/api/bridge/stream"));
+    es.onmessage = (msg) => {
+      try {
+        const evt = JSON.parse(msg.data) as {
+          kind?: string;
+          engaged?: boolean;
+        };
+        if (evt.kind === "kill-switch" && typeof evt.engaged === "boolean") {
+          setKsEngaged(evt.engaged);
+        }
+      } catch {
+        // ignore malformed events
+      }
+    };
+    return () => es.close();
+  }, []);
+
   // Load CC permission rules for the approval policy section
   useEffect(() => {
     let cancel = false;

--- a/src/__tests__/server-kill-switch.test.ts
+++ b/src/__tests__/server-kill-switch.test.ts
@@ -21,6 +21,7 @@ import http from "node:http";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   _resetEnvLockForTesting,
+  EnvLockedFlagError,
   isWriteKillSwitchActive,
   KILL_SWITCH_WRITES,
   lockKillSwitchEnv,
@@ -355,5 +356,114 @@ describe("POST /kill-switch — audit emit (step 5)", () => {
     expect(status).toBe(200);
     // No assertion on side effect — verifying the optional-callback
     // pattern doesn't crash the handler.
+  });
+});
+
+describe("POST /kill-switch — SSE broadcast (v2-I8)", () => {
+  it("calls broadcastKillSwitchEventFn with engaged:true on engage", async () => {
+    const broadcasts: Array<{ engaged: boolean; reason?: string }> = [];
+    server!.broadcastKillSwitchEventFn = (engaged, reason) =>
+      broadcasts.push({ engaged, reason });
+
+    const { status } = await request(
+      "POST",
+      JSON.stringify({ engage: true, reason: "test-broadcast" }),
+    );
+    expect(status).toBe(200);
+    expect(broadcasts).toHaveLength(1);
+    expect(broadcasts[0]?.engaged).toBe(true);
+    expect(broadcasts[0]?.reason).toBe("test-broadcast");
+  });
+
+  it("calls broadcastKillSwitchEventFn with engaged:false on release", async () => {
+    setFlag(KILL_SWITCH_WRITES, true, false);
+    const broadcasts: Array<{ engaged: boolean }> = [];
+    server!.broadcastKillSwitchEventFn = (engaged) =>
+      broadcasts.push({ engaged });
+
+    await request("POST", JSON.stringify({ engage: false }));
+    expect(broadcasts).toHaveLength(1);
+    expect(broadcasts[0]?.engaged).toBe(false);
+  });
+
+  it("does NOT call broadcastKillSwitchEventFn on no-op (already-engaged)", async () => {
+    setFlag(KILL_SWITCH_WRITES, true, false);
+    const broadcasts: Array<unknown> = [];
+    server!.broadcastKillSwitchEventFn = (engaged) => broadcasts.push(engaged);
+
+    const { body } = await request("POST", JSON.stringify({ engage: true }));
+    expect(JSON.parse(body).changed).toBe(false);
+    expect(broadcasts).toHaveLength(0);
+  });
+
+  it("does NOT call broadcastKillSwitchEventFn on 409 env-locked", async () => {
+    process.env[KILL_SWITCH_ENV] = "1";
+    lockKillSwitchEnv();
+    const broadcasts: Array<unknown> = [];
+    server!.broadcastKillSwitchEventFn = (engaged) => broadcasts.push(engaged);
+
+    const { status } = await request("POST", JSON.stringify({ engage: false }));
+    expect(status).toBe(409);
+    expect(broadcasts).toHaveLength(0);
+  });
+
+  it("does not throw when broadcastKillSwitchEventFn is unset", async () => {
+    server!.broadcastKillSwitchEventFn = null;
+    const { status } = await request("POST", JSON.stringify({ engage: true }));
+    expect(status).toBe(200);
+  });
+});
+
+describe("EnvLockedFlagError — setFlag throws when env-locked (v2-I9)", () => {
+  it("setFlag throws EnvLockedFlagError when kill-switch flag is env-locked to true", () => {
+    process.env[KILL_SWITCH_ENV] = "1";
+    lockKillSwitchEnv();
+
+    expect(() => setFlag(KILL_SWITCH_WRITES, false)).toThrow(
+      EnvLockedFlagError,
+    );
+  });
+
+  it("setFlag throws EnvLockedFlagError when kill-switch flag is env-locked to false", () => {
+    process.env[KILL_SWITCH_ENV] = "0";
+    lockKillSwitchEnv();
+
+    expect(() => setFlag(KILL_SWITCH_WRITES, true)).toThrow(EnvLockedFlagError);
+  });
+
+  it("EnvLockedFlagError carries correct frozenValue when locked to true", () => {
+    process.env[KILL_SWITCH_ENV] = "1";
+    lockKillSwitchEnv();
+
+    let err: EnvLockedFlagError | null = null;
+    try {
+      setFlag(KILL_SWITCH_WRITES, false);
+    } catch (e) {
+      err = e as EnvLockedFlagError;
+    }
+    expect(err).toBeInstanceOf(EnvLockedFlagError);
+    expect(err?.frozenValue).toBe(true);
+    expect(err?.flagId).toBe(KILL_SWITCH_WRITES);
+    expect(err?.name).toBe("EnvLockedFlagError");
+  });
+
+  it("EnvLockedFlagError carries correct frozenValue when locked to false", () => {
+    process.env[KILL_SWITCH_ENV] = "0";
+    lockKillSwitchEnv();
+
+    let err: EnvLockedFlagError | null = null;
+    try {
+      setFlag(KILL_SWITCH_WRITES, true);
+    } catch (e) {
+      err = e as EnvLockedFlagError;
+    }
+    expect(err?.frozenValue).toBe(false);
+  });
+
+  it("setFlag does NOT throw when env var is absent (env lock exists but no freeze)", () => {
+    // lockKillSwitchEnv with no env var → FROZEN_KILL_SWITCH_ENV.get() returns
+    // undefined → isEnvLockedFor returns false → no throw.
+    lockKillSwitchEnv();
+    expect(() => setFlag(KILL_SWITCH_WRITES, true)).not.toThrow();
   });
 });

--- a/src/activityLog.ts
+++ b/src/activityLog.ts
@@ -62,6 +62,15 @@ export class ActivityLog {
     return () => this.listeners.delete(listener);
   }
 
+  /**
+   * Returns all current listeners. Used by bridge to broadcast custom
+   * SSE kinds (e.g. `kind: "kill-switch"`) that don't go through
+   * `recordEvent` (which would emit them as `kind: "lifecycle"`).
+   */
+  getListeners(): ReadonlySet<ActivityListener> {
+    return this.listeners;
+  }
+
   setPersistPath(p: string): void {
     this.persistPath = p;
     this._loadFromDisk();

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -1306,6 +1306,22 @@ export class Bridge {
       };
     };
     this.server.streamFn = (listener) => this.activityLog.subscribe(listener);
+    // v2-I8 (#422): broadcast kind:"kill-switch" SSE when state changes.
+    // The activityLog subscriber list fans out to all open /stream clients.
+    this.server.broadcastKillSwitchEventFn = (engaged, reason) => {
+      for (const listener of this.activityLog.getListeners()) {
+        try {
+          listener("kill-switch", {
+            id: 0,
+            timestamp: new Date().toISOString(),
+            event: engaged ? "engage" : "release",
+            metadata: { engaged, ...(reason ? { reason } : {}) },
+          });
+        } catch {
+          /* listener must not crash broadcast */
+        }
+      }
+    };
     this.server.cancelTaskFn = (id: string) =>
       this.orchestrator?.cancel(id, "user") ?? false;
     // Wire `/sessions` for the dashboard's Sessions page. The same Map is

--- a/src/featureFlags.ts
+++ b/src/featureFlags.ts
@@ -176,11 +176,51 @@ export function getEnvLockedValue(flagId: string): boolean | null {
 }
 
 /**
+ * Thrown by `setFlag` when a kill-switch flag is env-locked (its value was
+ * frozen at startup via `PATCHWORK_FLAG_<ID>`) and the caller attempts to
+ * mutate it. The `/kill-switch` POST handler catches this and returns a
+ * structured 409 Conflict so the CLI / dashboard can distinguish
+ * "policy-locked" from "bad request" (issue #422, pitfall I9).
+ *
+ * `frozenValue` is the locked direction — callers can surface
+ * "env-locked to on" vs "env-locked to off" in error messages.
+ */
+export class EnvLockedFlagError extends Error {
+  public readonly flagId: string;
+  public readonly frozenValue: boolean;
+
+  constructor(flagId: string, frozenValue: boolean) {
+    super(
+      `Feature flag "${flagId}" is env-locked to ${frozenValue ? "true" : "false"} ` +
+        `(set at startup via PATCHWORK_FLAG_${flagId.replace(/[.-]/g, "_").toUpperCase()}). ` +
+        `Unset the environment variable to allow runtime mutation.`,
+    );
+    this.name = "EnvLockedFlagError";
+    this.flagId = flagId;
+    this.frozenValue = frozenValue;
+  }
+}
+
+/**
  * Set a flag value (persists to config file if persist=true).
+ *
+ * Throws `EnvLockedFlagError` if the flag is a kill-switch flag that has been
+ * frozen by `lockKillSwitchEnv()` — a sysadmin env-var override takes
+ * precedence over runtime mutation. The `/kill-switch` POST handler catches
+ * this and returns 409 (pitfall I9 from issue #422).
  */
 export function setFlag(flagId: string, value: boolean, persist = false): void {
   if (!FLAG_REGISTRY.has(flagId)) {
     throw new Error(`Unknown feature flag: "${flagId}"`);
+  }
+
+  // v2-I9: kill-switch flags that were env-locked at startup must not be
+  // silently overridden — throw so callers (the /kill-switch handler) can
+  // surface a structured 409 instead of returning 200 for a mutation that
+  // won't take effect.
+  if (isEnvLockedFor(flagId)) {
+    const frozen = FROZEN_KILL_SWITCH_ENV.get(flagId);
+    throw new EnvLockedFlagError(flagId, frozen === true);
   }
 
   FLAG_VALUES.set(flagId, value);

--- a/src/index.ts
+++ b/src/index.ts
@@ -177,6 +177,7 @@ const KNOWN_SUBCOMMANDS = [
   "launchd",
   "start",
   "kill-switch",
+  "panic",
   "halts",
   "judgments",
 ] as const;
@@ -1819,28 +1820,67 @@ if (process.argv[2] === "kill-switch") {
   }
   (async () => {
     try {
-      // v2-B2: enumerate ALL live bridge locks (not just the first).
-      const { findAllLiveBridges } = await import("./bridgeLockDiscovery.js");
-      const liveLocks = findAllLiveBridges();
-      type BridgeLockInfo = (typeof liveLocks)[number];
-
-      if (liveLocks.length === 0) {
-        process.stderr.write(
-          "No running bridge found.\n" +
-            "  - For `engage`/`release`, kill-switch has no live target to update.\n" +
-            "  - Restart the bridge with `--driver subprocess` to enable orchestration,\n" +
-            "    then re-run this command.\n",
-        );
-        process.exit(2);
-      }
-
-      // Parse optional --reason.
+      // Parse optional flags early so --force-local can be used without a bridge.
       const args = process.argv.slice(4);
       const reasonIdx = args.findIndex((a) => a === "--reason" || a === "-m");
       const reason =
         reasonIdx >= 0 && reasonIdx + 1 < args.length
           ? args[reasonIdx + 1]
           : undefined;
+      // v2-I4: --force-local writes flags.json directly when no live bridge
+      // is reachable. The running bridge's fs.watch (v2-S1) picks up the
+      // change within ~100ms; without a running bridge this is "effective
+      // next boot" — which is still better than a silent noop.
+      const forceLocal = args.includes("--force-local");
+
+      // v2-B2: enumerate ALL live bridge locks (not just the first).
+      const { findAllLiveBridges } = await import("./bridgeLockDiscovery.js");
+      const liveLocks = findAllLiveBridges();
+      type BridgeLockInfo = (typeof liveLocks)[number];
+
+      if (liveLocks.length === 0) {
+        if (forceLocal && (sub === "engage" || sub === "release")) {
+          // --force-local: write flags.json directly. The running bridge's
+          // fs.watch picks this up within ~100ms; if the bridge is wedged
+          // or not started, this is effective on next start.
+          const { setFlag, KILL_SWITCH_WRITES } = await import(
+            "./featureFlags.js"
+          );
+          const engage = sub === "engage";
+          setFlag(KILL_SWITCH_WRITES, engage, true);
+          // Audit in a sibling CLI-only JSONL (v2-I10: bridge-only writes
+          // go to decision_traces.jsonl; CLI fallback is distinct).
+          const os = await import("node:os");
+          const path = await import("node:path");
+          const fs = await import("node:fs");
+          const cliTraceFile = path.join(
+            process.env.PATCHWORK_HOME ??
+              path.join(os.default.homedir(), ".patchwork"),
+            "decision_traces.cli.jsonl",
+          );
+          const dir = path.dirname(cliTraceFile);
+          if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+          const entry = JSON.stringify({
+            ts: new Date().toISOString(),
+            event: engage ? "engage" : "release",
+            actor: "cli-force-local",
+            ...(reason ? { reason } : {}),
+          });
+          fs.appendFileSync(cliTraceFile, `${entry}\n`);
+          process.stdout.write(
+            `  ✓ kill-switch ${engage ? "ENGAGED" : "released"} via --force-local (flags.json written directly).\n` +
+              "    Running bridges will pick this up via fs.watch within ~100ms.\n",
+          );
+          process.exit(0);
+        }
+        process.stderr.write(
+          "No running bridge found.\n" +
+            "  - For `engage`/`release`, kill-switch has no live target to update.\n" +
+            "  - Use --force-local to write flags.json directly (bridge fs.watch picks it up).\n" +
+            "  - Or restart the bridge and re-run this command.\n",
+        );
+        process.exit(2);
+      }
 
       // v2-I4: 10s per-request deadline. AbortController per call.
       async function callBridge(
@@ -1970,6 +2010,26 @@ if (process.argv[2] === "kill-switch") {
       process.exit(1);
     }
   })();
+}
+
+// `patchwork panic` — alias for `patchwork kill-switch engage` (v2-Strong-2).
+//
+// Discoverable under stress (short command, obvious intent). Canonical noun
+// form is `kill-switch engage`; this alias matches it so shell history six
+// months later still makes sense. Does not accept sub-verbs — just runs engage.
+if (process.argv[2] === "panic") {
+  // Spawn self with kill-switch engage to reuse the full handler without
+  // duplicating 200+ LOC. Passes through any flags (--reason, --force-local).
+  import("node:child_process").then(({ spawnSync }) => {
+    const self = process.argv[1] ?? process.execPath;
+    const extra = process.argv.slice(3); // e.g. --reason "..." --force-local
+    const result = spawnSync(
+      process.execPath,
+      [self, "kill-switch", "engage", ...extra],
+      { stdio: "inherit" },
+    );
+    process.exit(result.status ?? 1);
+  });
 }
 
 // `patchwork halts` — one-screen morning summary of recent recipe halts.

--- a/src/server.ts
+++ b/src/server.ts
@@ -14,6 +14,7 @@ import {
 import { timingSafeStringEqual } from "./crypto.js";
 import { renderDashboardHtml } from "./dashboard.js";
 import {
+  EnvLockedFlagError,
   getEnvLockedValue,
   isEnvLockedFor,
   isWriteKillSwitchActive,
@@ -339,6 +340,15 @@ export class Server extends EventEmitter<ServerEvents> {
         reason: string | undefined;
         ts: number;
       }) => void)
+    | null = null;
+  /**
+   * Set by bridge to broadcast a `kind: "kill-switch"` SSE event from
+   * `/stream` when the kill-switch state changes (issue #422 v2, pitfall I8).
+   * Bridge wires this to `activityLog.broadcastKillSwitch()` or an equivalent
+   * that notifies all active SSE listeners so the dashboard updates in <1s.
+   */
+  public broadcastKillSwitchEventFn:
+    | ((engaged: boolean, reason?: string) => void)
     | null = null;
   /** Patchwork: set by bridge to match + fire webhook-triggered recipes. */
   public webhookFn:
@@ -1817,7 +1827,28 @@ export class Server extends EventEmitter<ServerEvents> {
           const next = body.engage;
           const changed = prev !== next;
           if (changed) {
-            setFlag(KILL_SWITCH_WRITES, next, true);
+            try {
+              setFlag(KILL_SWITCH_WRITES, next, true);
+            } catch (err) {
+              // Belt-and-suspenders: setFlag now throws EnvLockedFlagError if
+              // the flag was env-locked (we already checked isEnvLockedFor above,
+              // but a race with lockKillSwitchEnv() in tests warrants this).
+              if (err instanceof EnvLockedFlagError) {
+                res.writeHead(409, { "Content-Type": "application/json" });
+                res.end(
+                  JSON.stringify({
+                    error: "env_locked",
+                    flag: KILL_SWITCH_WRITES,
+                    frozenValue: err.frozenValue,
+                    lockedReason: `PATCHWORK_FLAG_KILL_SWITCH_WRITES=${
+                      err.frozenValue ? "1" : "0"
+                    } at bridge startup`,
+                  }),
+                );
+                return;
+              }
+              throw err;
+            }
             // v2-I6: audit emit on every state transition; no-ops skip.
             // When the bridge wires recordKillSwitchTraceFn (step 5),
             // this writes to ~/.patchwork/decision_traces.jsonl. The
@@ -1834,6 +1865,9 @@ export class Server extends EventEmitter<ServerEvents> {
               reason,
               ts: Date.now(),
             });
+            // v2-I8: broadcast SSE kind:"kill-switch" so dashboard updates
+            // in <1s without changing the poll cadence.
+            this.broadcastKillSwitchEventFn?.(next, reason);
           }
           res.writeHead(200, { "Content-Type": "application/json" });
           res.end(


### PR DESCRIPTION
## Summary

Implements the remaining pieces of the kill-switch v2 spec from issue #422 (closed design-only, this is the implementation PR).

**What was already on `main`:**
- `featureFlags.ts`: `isEnvLockedFor`, `getEnvLockedValue`, `watchFlags` (v2-S1)
- `server.ts`: `/kill-switch` GET/POST endpoint with 409 env-locked, idempotency, audit stub
- `index.ts`: `kill-switch engage|release|status` CLI with multi-bridge fan-out (v2-B2)
- Dashboard: kill-switch toggle with `disabled`/`disabledReason` on `ToggleRow`
- Tests: `featureFlags.*test.ts`, `server-kill-switch.test.ts`

**Added in this PR:**

| Spec item | What changed |
|---|---|
| v2-I9 `EnvLockedFlagError` | Added class to `featureFlags.ts`; `setFlag` throws it when env-locked kill-switch flag is mutated. Server catches it belt-and-suspenders on top of pre-check. |
| v2-I8 SSE `kind:"kill-switch"` | Added `broadcastKillSwitchEventFn` on `Server`; bridge wires it via `activityLog.getListeners()`. Dashboard settings page adds `EventSource` consumer that updates toggle in <1s. |
| v2-Strong-2 `panic` alias | `patchwork panic` spawns self with `kill-switch engage` + forwarded flags. Added to `KNOWN_SUBCOMMANDS`. |
| v2-I4 `--force-local` | When no live bridge found: writes `flags.json` directly + logs to sibling `decision_traces.cli.jsonl`. Running bridges pick it up via fs.watch (~100ms). |
| Tests | SSE broadcast suite (5 cases) + `EnvLockedFlagError` suite (5 cases) in `server-kill-switch.test.ts`. |

**Skipped (noted in issue as sibling PR):**
- I5: plumbing `decisionTraceLog` through `Server` constructor — `TODO` comment left in server.ts; the audit currently uses `logger.info` as stub.

## Test plan

- [x] `npm run build` passes
- [x] `npx tsc --noEmit -p tsconfig.tests.core.json` passes
- [x] `npx vitest run src/__tests__/server-kill-switch.test.ts src/__tests__/featureFlags` — 63 tests pass
- [x] `npx biome check --write` on changed files — only pre-existing warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)