### PR TITLE
feat: add listRoutines/runRoutine/getRoutineStatus MCP tools (CC Routines Phase 3)

### DIFF
--- a/src/tools/__tests__/ccRoutines.test.ts
+++ b/src/tools/__tests__/ccRoutines.test.ts
@@ -1,0 +1,238 @@
+import { describe, expect, it } from "vitest";
+import type { RoutinesExecutor } from "../ccRoutines.js";
+import {
+  createGetRoutineStatusTool,
+  createListRoutinesTool,
+  createRunRoutineTool,
+} from "../ccRoutines.js";
+
+// ---------------------------------------------------------------------------
+// Executor helpers
+// ---------------------------------------------------------------------------
+
+function okExec(stdout: string): RoutinesExecutor {
+  return async () => ({ stdout });
+}
+
+function errExec(msg: string): RoutinesExecutor {
+  return async () => {
+    throw new Error(msg);
+  };
+}
+
+function parseResult(result: unknown) {
+  const r = result as { content: Array<{ text: string }>; isError?: boolean };
+  return { isError: r.isError, data: JSON.parse(r.content[0]!.text) };
+}
+
+// ---------------------------------------------------------------------------
+// listRoutines
+// ---------------------------------------------------------------------------
+
+describe("listRoutines", () => {
+  it("returns routines array on success", async () => {
+    const routines = [
+      {
+        id: "r1",
+        name: "nightly-review",
+        schedule: "0 2 * * *",
+        status: "idle",
+      },
+      {
+        id: "r2",
+        name: "health-check",
+        schedule: "0 * * * *",
+        status: "running",
+      },
+    ];
+    const tool = createListRoutinesTool(
+      "claude",
+      okExec(JSON.stringify(routines)),
+    );
+
+    const { isError, data } = parseResult(await tool.handler({}));
+    expect(isError).toBeFalsy();
+    expect(data.routines).toHaveLength(2);
+    expect(data.routines[0].id).toBe("r1");
+  });
+
+  it("returns cc_routines_unavailable when command not found", async () => {
+    const tool = createListRoutinesTool(
+      "claude",
+      errExec("unknown command: routines"),
+    );
+
+    const { isError, data } = parseResult(await tool.handler({}));
+    expect(isError).toBe(true);
+    expect(data.error).toBe("cc_routines_unavailable");
+  });
+
+  it("wraps object payload with .routines key", async () => {
+    const payload = { routines: [{ id: "r3", name: "inbox" }] };
+    const tool = createListRoutinesTool(
+      "claude",
+      okExec(JSON.stringify(payload)),
+    );
+
+    const { isError, data } = parseResult(await tool.handler({}));
+    expect(isError).toBeFalsy();
+    expect(data.routines[0].id).toBe("r3");
+  });
+
+  it("falls back to line-split when output is not JSON", async () => {
+    const tool = createListRoutinesTool(
+      "claude",
+      okExec("nightly-review\nhealth-check\n"),
+    );
+
+    const { isError, data } = parseResult(await tool.handler({}));
+    expect(isError).toBeFalsy();
+    expect(data.routines).toHaveLength(2);
+  });
+
+  it("returns error on unexpected exec failure", async () => {
+    const tool = createListRoutinesTool("claude", errExec("permission denied"));
+
+    const { isError } = parseResult(await tool.handler({}));
+    expect(isError).toBe(true);
+  });
+
+  it("matches outputSchema shape — routines is array", async () => {
+    const tool = createListRoutinesTool(
+      "claude",
+      okExec(JSON.stringify([{ id: "r1", name: "daily" }])),
+    );
+
+    const { data } = parseResult(await tool.handler({}));
+    expect(Array.isArray(data.routines)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runRoutine
+// ---------------------------------------------------------------------------
+
+describe("runRoutine", () => {
+  it("returns taskId and status on success", async () => {
+    const tool = createRunRoutineTool(
+      "claude",
+      okExec(JSON.stringify({ taskId: "task-abc", status: "running" })),
+    );
+
+    const { isError, data } = parseResult(await tool.handler({ id: "r1" }));
+    expect(isError).toBeFalsy();
+    expect(data.taskId).toBe("task-abc");
+    expect(data.status).toBe("running");
+  });
+
+  it("rejects empty id", async () => {
+    const tool = createRunRoutineTool("claude", okExec("{}"));
+    const { isError } = parseResult(await tool.handler({ id: "" }));
+    expect(isError).toBe(true);
+  });
+
+  it("rejects missing id", async () => {
+    const tool = createRunRoutineTool("claude", okExec("{}"));
+    const { isError } = parseResult(await tool.handler({}));
+    expect(isError).toBe(true);
+  });
+
+  it("returns cc_routines_unavailable when command not found", async () => {
+    const tool = createRunRoutineTool("claude", errExec("not found"));
+
+    const { isError, data } = parseResult(await tool.handler({ id: "r1" }));
+    expect(isError).toBe(true);
+    expect(data.error).toBe("cc_routines_unavailable");
+  });
+
+  it("falls back to id+running on non-JSON output", async () => {
+    const tool = createRunRoutineTool("claude", okExec("started"));
+
+    const { isError, data } = parseResult(await tool.handler({ id: "r1" }));
+    expect(isError).toBeFalsy();
+    expect(data.taskId).toBe("r1");
+    expect(data.status).toBe("running");
+  });
+
+  it("uses parsed taskId when JSON contains it", async () => {
+    const tool = createRunRoutineTool(
+      "claude",
+      okExec(JSON.stringify({ taskId: "t2", status: "pending" })),
+    );
+
+    const { isError, data } = parseResult(
+      await tool.handler({ id: "r2", input: '{"key":"val"}' }),
+    );
+    expect(isError).toBeFalsy();
+    expect(data.taskId).toBe("t2");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getRoutineStatus
+// ---------------------------------------------------------------------------
+
+describe("getRoutineStatus", () => {
+  it("returns status fields on success", async () => {
+    const payload = {
+      id: "r1",
+      status: "idle",
+      lastRun: "2026-05-13T02:00:00Z",
+      nextRun: "2026-05-14T02:00:00Z",
+      output: "All checks passed",
+    };
+    const tool = createGetRoutineStatusTool(
+      "claude",
+      okExec(JSON.stringify(payload)),
+    );
+
+    const { isError, data } = parseResult(await tool.handler({ id: "r1" }));
+    expect(isError).toBeFalsy();
+    expect(data.id).toBe("r1");
+    expect(data.status).toBe("idle");
+    expect(data.lastRun).toBe("2026-05-13T02:00:00Z");
+    expect(data.output).toBe("All checks passed");
+  });
+
+  it("rejects whitespace-only id", async () => {
+    const tool = createGetRoutineStatusTool("claude", okExec("{}"));
+    const { isError } = parseResult(await tool.handler({ id: "  " }));
+    expect(isError).toBe(true);
+  });
+
+  it("returns cc_routines_unavailable when subcommand unknown", async () => {
+    const tool = createGetRoutineStatusTool(
+      "claude",
+      errExec("Unknown argument: routines"),
+    );
+
+    const { isError, data } = parseResult(await tool.handler({ id: "r1" }));
+    expect(isError).toBe(true);
+    expect(data.error).toBe("cc_routines_unavailable");
+  });
+
+  it("falls back to id+unknown on non-JSON output", async () => {
+    const tool = createGetRoutineStatusTool("claude", okExec("no json here"));
+
+    const { isError, data } = parseResult(await tool.handler({ id: "r1" }));
+    expect(isError).toBeFalsy();
+    expect(data.id).toBe("r1");
+    expect(data.status).toBe("unknown");
+  });
+
+  it("handles snake_case keys from CLI", async () => {
+    const tool = createGetRoutineStatusTool(
+      "claude",
+      okExec(
+        JSON.stringify({
+          id: "r1",
+          status: "running",
+          last_run: "2026-05-14T01:00:00Z",
+        }),
+      ),
+    );
+
+    const { data } = parseResult(await tool.handler({ id: "r1" }));
+    expect(data.lastRun).toBe("2026-05-14T01:00:00Z");
+  });
+});

--- a/src/tools/ccRoutines.ts
+++ b/src/tools/ccRoutines.ts
@@ -1,0 +1,333 @@
+/**
+ * CC Routines Phase 3 — thin MCP tools for Claude Code Routines API.
+ *
+ * The `claude routines` subcommand is part of a research preview
+ * (API identifier: experimental-cc-routine-2026-04-01) gated on
+ * claude.ai accounts. These tools are registered unconditionally so
+ * they appear in the MCP handshake and fail gracefully when the API
+ * is not yet available on the host account.
+ *
+ * TODO: ungate when API exits research preview
+ */
+
+import { execFile } from "node:child_process";
+import { ToolErrorCodes } from "../errors.js";
+import { error, successStructured } from "./utils.js";
+
+const UNAVAILABLE_ERROR = {
+  error: "cc_routines_unavailable",
+  message:
+    "Claude Code Routines API not yet available on this account. See https://claude.ai/code/routines",
+} as const;
+
+export type RoutinesExecutor = (
+  binary: string,
+  args: string[],
+) => Promise<{ stdout: string }>;
+
+/** Default executor using node:child_process execFile. */
+export const defaultExecutor: RoutinesExecutor = (binary, args) =>
+  new Promise((resolve, reject) => {
+    execFile(
+      binary,
+      args,
+      { timeout: 30_000, env: process.env },
+      (err, stdout) => {
+        if (err) reject(err);
+        else resolve({ stdout });
+      },
+    );
+  });
+
+/** Run `claude routines <args>` and return stdout, or null if unavailable. */
+async function runRoutinesCli(
+  args: string[],
+  claudeBinary: string,
+  executor: RoutinesExecutor,
+): Promise<{ stdout: string } | { unavailable: true } | { execError: string }> {
+  try {
+    const { stdout } = await executor(claudeBinary, ["routines", ...args]);
+    return { stdout };
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
+    // Detect "unknown command" / "not found" variants that indicate the
+    // routines subcommand is not available on this build/account.
+    if (
+      msg.includes("unknown command") ||
+      msg.includes("is not a claude command") ||
+      msg.includes("not found") ||
+      msg.includes("Unknown argument: routines")
+    ) {
+      return { unavailable: true };
+    }
+    return { execError: msg };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// listRoutines
+// ---------------------------------------------------------------------------
+
+export function createListRoutinesTool(
+  claudeBinary = "claude",
+  executor: RoutinesExecutor = defaultExecutor,
+) {
+  return {
+    schema: {
+      name: "listRoutines",
+      description:
+        "List all Claude Code Routines configured on this account. Returns an array of routine summaries including id, name, schedule, lastRun, and status. Requires the CC Routines research-preview feature.",
+      annotations: {
+        title: "List CC Routines",
+        readOnlyHint: true,
+        destructiveHint: false,
+        openWorldHint: true,
+      },
+      inputSchema: {
+        type: "object" as const,
+        properties: {},
+        additionalProperties: false as const,
+      },
+      outputSchema: {
+        type: "object",
+        properties: {
+          routines: {
+            type: "array",
+            items: {
+              type: "object",
+              properties: {
+                id: { type: "string" },
+                name: { type: "string" },
+                schedule: { type: "string" },
+                lastRun: { type: "string" },
+                status: { type: "string" },
+              },
+              required: ["id", "name"],
+            },
+          },
+          error: { type: "string" },
+          message: { type: "string" },
+        },
+      },
+    },
+    handler: async (_args: Record<string, unknown>) => {
+      const result = await runRoutinesCli(
+        ["list", "--json"],
+        claudeBinary,
+        executor,
+      );
+
+      if ("unavailable" in result) {
+        return {
+          content: [
+            { type: "text" as const, text: JSON.stringify(UNAVAILABLE_ERROR) },
+          ],
+          isError: true,
+        };
+      }
+
+      if ("execError" in result) {
+        return error(
+          `Failed to list routines: ${result.execError}`,
+          ToolErrorCodes.EXTERNAL_COMMAND_FAILED,
+        );
+      }
+
+      try {
+        const parsed = JSON.parse(result.stdout.trim() || "[]");
+        const routines = Array.isArray(parsed)
+          ? parsed
+          : (parsed.routines ?? []);
+        return successStructured({ routines });
+      } catch {
+        // Non-JSON output — surface as raw text in a best-effort parse
+        const lines = result.stdout.trim().split("\n").filter(Boolean);
+        const routines = lines.map((line, i) => ({
+          id: String(i),
+          name: line,
+        }));
+        return successStructured({ routines });
+      }
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// runRoutine
+// ---------------------------------------------------------------------------
+
+export function createRunRoutineTool(
+  claudeBinary = "claude",
+  executor: RoutinesExecutor = defaultExecutor,
+) {
+  return {
+    schema: {
+      name: "runRoutine",
+      description:
+        "Trigger a Claude Code Routine by ID. Optionally pass an input JSON string. Returns a taskId and initial status. Requires the CC Routines research-preview feature.",
+      annotations: {
+        title: "Run CC Routine",
+        readOnlyHint: false,
+        destructiveHint: false,
+        openWorldHint: true,
+      },
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          id: {
+            type: "string",
+            description: "Routine ID to run.",
+          },
+          input: {
+            type: "string",
+            description:
+              "Optional JSON string passed as --input to the routine.",
+          },
+        },
+        required: ["id"] as const,
+        additionalProperties: false as const,
+      },
+      outputSchema: {
+        type: "object",
+        properties: {
+          taskId: { type: "string" },
+          status: { type: "string" },
+          error: { type: "string" },
+          message: { type: "string" },
+        },
+      },
+    },
+    handler: async (args: Record<string, unknown>) => {
+      const id = args.id;
+      if (typeof id !== "string" || id.trim() === "") {
+        return error(
+          "id must be a non-empty string",
+          ToolErrorCodes.INVALID_ARGS,
+        );
+      }
+
+      const cliArgs = ["run", id.trim(), "--json"];
+      if (typeof args.input === "string" && args.input.trim() !== "") {
+        cliArgs.push("--input", args.input.trim());
+      }
+
+      const result = await runRoutinesCli(cliArgs, claudeBinary, executor);
+
+      if ("unavailable" in result) {
+        return {
+          content: [
+            { type: "text" as const, text: JSON.stringify(UNAVAILABLE_ERROR) },
+          ],
+          isError: true,
+        };
+      }
+
+      if ("execError" in result) {
+        return error(
+          `Failed to run routine: ${result.execError}`,
+          ToolErrorCodes.EXTERNAL_COMMAND_FAILED,
+        );
+      }
+
+      try {
+        const parsed = JSON.parse(result.stdout.trim() || "{}");
+        return successStructured({
+          taskId: parsed.taskId ?? parsed.id ?? id,
+          status: parsed.status ?? "running",
+        });
+      } catch {
+        return successStructured({ taskId: id, status: "running" });
+      }
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// getRoutineStatus
+// ---------------------------------------------------------------------------
+
+export function createGetRoutineStatusTool(
+  claudeBinary = "claude",
+  executor: RoutinesExecutor = defaultExecutor,
+) {
+  return {
+    schema: {
+      name: "getRoutineStatus",
+      description:
+        "Get the current status, last run time, next scheduled run, and most recent output for a Claude Code Routine. Requires the CC Routines research-preview feature.",
+      annotations: {
+        title: "Get CC Routine Status",
+        readOnlyHint: true,
+        destructiveHint: false,
+        openWorldHint: true,
+      },
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          id: {
+            type: "string",
+            description: "Routine ID to query.",
+          },
+        },
+        required: ["id"] as const,
+        additionalProperties: false as const,
+      },
+      outputSchema: {
+        type: "object",
+        properties: {
+          id: { type: "string" },
+          status: { type: "string" },
+          lastRun: { type: "string" },
+          nextRun: { type: "string" },
+          output: { type: "string" },
+          error: { type: "string" },
+          message: { type: "string" },
+        },
+      },
+    },
+    handler: async (args: Record<string, unknown>) => {
+      const id = args.id;
+      if (typeof id !== "string" || id.trim() === "") {
+        return error(
+          "id must be a non-empty string",
+          ToolErrorCodes.INVALID_ARGS,
+        );
+      }
+
+      const result = await runRoutinesCli(
+        ["status", id.trim(), "--json"],
+        claudeBinary,
+        executor,
+      );
+
+      if ("unavailable" in result) {
+        return {
+          content: [
+            { type: "text" as const, text: JSON.stringify(UNAVAILABLE_ERROR) },
+          ],
+          isError: true,
+        };
+      }
+
+      if ("execError" in result) {
+        return error(
+          `Failed to get routine status: ${result.execError}`,
+          ToolErrorCodes.EXTERNAL_COMMAND_FAILED,
+        );
+      }
+
+      try {
+        const parsed = JSON.parse(result.stdout.trim() || "{}");
+        return successStructured({
+          id: parsed.id ?? id.trim(),
+          status: parsed.status ?? "unknown",
+          lastRun: parsed.lastRun ?? parsed.last_run ?? undefined,
+          nextRun: parsed.nextRun ?? parsed.next_run ?? undefined,
+          output: parsed.output ?? undefined,
+        });
+      } catch {
+        return successStructured({ id: id.trim(), status: "unknown" });
+      }
+    },
+  };
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -21,6 +21,11 @@ import {
 import { createBridgeDoctorTool } from "./bridgeDoctor.js";
 import { createBridgeStatusTool, type DisconnectInfo } from "./bridgeStatus.js";
 import { createCancelClaudeTaskTool } from "./cancelClaudeTask.js";
+import {
+  createGetRoutineStatusTool,
+  createListRoutinesTool,
+  createRunRoutineTool,
+} from "./ccRoutines.js";
 import { createCheckDocumentDirtyTool } from "./checkDocumentDirty.js";
 import {
   createReadClipboardTool,
@@ -839,6 +844,11 @@ export function registerAllTools(
           ...(launchQuickTaskToolInstance ? [launchQuickTaskToolInstance] : []),
         ]
       : []),
+    // CC Routines — registered unconditionally; stub returns graceful error
+    // when the routines API is not yet available on the host account.
+    createListRoutinesTool(config.claudeBinary),
+    createRunRoutineTool(config.claudeBinary),
+    createGetRoutineStatusTool(config.claudeBinary),
   ];
 
   const activeTools = config.fullMode


### PR DESCRIPTION
## Summary

- Adds three MCP tools (`listRoutines`, `runRoutine`, `getRoutineStatus`) for the Claude Code Routines research-preview API (`experimental-cc-routine-2026-04-01`)
- The `claude routines` subcommand is **not yet available** on this machine — all three tools are registered as graceful stubs returning `{error: "cc_routines_unavailable", isError: true}` so they appear in the MCP handshake without crashing
- Uses an injectable `RoutinesExecutor` type for clean unit testing without child_process mocks; 17 tests covering success, unavailable, exec-error, and JSON-fallback paths
- Tool count: 177 → 180 (confirmed by `node scripts/audit-lsp-tools.mjs`)

## Files changed

- `src/tools/ccRoutines.ts` — new file with all three tool factories + `RoutinesExecutor` type
- `src/tools/__tests__/ccRoutines.test.ts` — 17 unit tests
- `src/tools/index.ts` — import + unconditional registration of all three tools

## Test plan

- [x] `npm run build` — passes
- [x] `npx tsc --noEmit -p tsconfig.tests.core.json` — passes
- [x] `npx vitest run src/tools/__tests__/ccRoutines.test.ts` — 17/17 pass
- [x] `node scripts/audit-lsp-tools.mjs` — 180 total tools (was 177)
- [x] `npx biome check --write` — no remaining issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)