### PR TITLE
feat: wire telemetry toggles to persistent backend

### DIFF
--- a/dashboard/src/app/api/bridge/telemetry-prefs/route.ts
+++ b/dashboard/src/app/api/bridge/telemetry-prefs/route.ts
@@ -1,0 +1,49 @@
+import { bridgeFetch } from "@/lib/bridge";
+import { NextResponse } from "next/server";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  try {
+    const res = await bridgeFetch("/telemetry-prefs");
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      return NextResponse.json(
+        { error: text || `Bridge returned ${res.status}` },
+        { status: res.status },
+      );
+    }
+    const data = await res.json();
+    return NextResponse.json(data);
+  } catch (err) {
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : "fetch failed" },
+      { status: 502 },
+    );
+  }
+}
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json().catch(() => ({}));
+    const res = await bridgeFetch("/telemetry-prefs", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      return NextResponse.json(
+        { error: text || `Bridge returned ${res.status}` },
+        { status: res.status },
+      );
+    }
+    const data = await res.json();
+    return NextResponse.json(data);
+  } catch (err) {
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : "fetch failed" },
+      { status: 502 },
+    );
+  }
+}

--- a/dashboard/src/app/settings/page.tsx
+++ b/dashboard/src/app/settings/page.tsx
@@ -215,10 +215,11 @@ export default function SettingsPage() {
   );
   const vapidPublicKey = process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY ?? "";
 
-  // Telemetry (local only — no backend yet)
+  // Telemetry — persisted via GET/POST /api/bridge/telemetry-prefs
   const [telCrash, setTelCrash] = useState(false);
   const [telUsage, setTelUsage] = useState(false);
   const [telDiag, setTelDiag] = useState(true);
+  const telInitialized = useRef(false);
 
   // Kill-switch state — fetched from /api/bridge/kill-switch (proxy to
   // bridge `GET /kill-switch`). Polls in tandem with /status below.
@@ -332,6 +333,35 @@ export default function SettingsPage() {
     };
   }, []);
 
+  // Load telemetry prefs on mount (once). Fail-soft — if bridge is offline
+  // the toggles remain at their default values.
+  useEffect(() => {
+    if (telInitialized.current) return;
+    let cancel = false;
+    (async () => {
+      try {
+        const res = await fetch(apiPath("/api/bridge/telemetry-prefs"));
+        if (!res.ok) return;
+        const data = (await res.json()) as {
+          crashReports?: boolean;
+          usageStats?: boolean;
+          localDiagnostics?: boolean;
+        };
+        if (cancel) return;
+        if (typeof data.crashReports === "boolean") setTelCrash(data.crashReports);
+        if (typeof data.usageStats === "boolean") setTelUsage(data.usageStats);
+        if (typeof data.localDiagnostics === "boolean") setTelDiag(data.localDiagnostics);
+        telInitialized.current = true;
+      } catch {
+        /* fail-soft — bridge may not be running */
+      }
+    })();
+    return () => {
+      cancel = true;
+    };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   // Read current Web Push subscription status on mount. Idempotently
   // register the SW so a fresh visit can later subscribe without a reload —
   // pushManager.subscribe() requires an active registration.
@@ -371,6 +401,23 @@ export default function SettingsPage() {
     setSaveState("saving");
     setTimeout(() => setSaveState("saved"), 600);
     setTimeout(() => setSaveState("idle"), 2400);
+  }
+
+  async function saveTelemetryPref(
+    field: "crashReports" | "usageStats" | "localDiagnostics",
+    value: boolean,
+  ) {
+    // Optimistic local update already applied by the caller via setter.
+    try {
+      await fetch(apiPath("/api/bridge/telemetry-prefs"), {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ [field]: value }),
+      });
+      flashSaved();
+    } catch {
+      /* fail-soft — UI already shows the optimistic value */
+    }
   }
 
   async function saveApiKey(provider: ApiKeyProvider) {
@@ -1348,29 +1395,35 @@ export default function SettingsPage() {
               </div>
 
               <div style={{ padding: "16px 0", display: "flex", flexDirection: "column", gap: 14 }}>
-                <div role="status" style={{ fontSize: "var(--fs-s)", color: "var(--fg-3)", marginBottom: 4 }}>
-                  Preview only — toggles do not yet persist between reloads.
-                </div>
                 <ToggleRow
                   id="tel-crash"
                   label="Crash reports"
                   help="Send anonymized stack traces to help diagnose bridge crashes. No source files, no env vars."
                   checked={telCrash}
-                  onChange={setTelCrash}
+                  onChange={(v) => {
+                    setTelCrash(v);
+                    void saveTelemetryPref("crashReports", v);
+                  }}
                 />
                 <ToggleRow
                   id="tel-usage"
                   label="Anonymous usage stats"
                   help="Tool-call counts and feature flag usage. No prompts, no file paths, no identifiers."
                   checked={telUsage}
-                  onChange={setTelUsage}
+                  onChange={(v) => {
+                    setTelUsage(v);
+                    void saveTelemetryPref("usageStats", v);
+                  }}
                 />
                 <ToggleRow
                   id="tel-diag"
                   label="Local diagnostics retention"
                   help="Keep last 7 days of bridge logs on this machine for debugging. Never leaves your computer."
                   checked={telDiag}
-                  onChange={setTelDiag}
+                  onChange={(v) => {
+                    setTelDiag(v);
+                    void saveTelemetryPref("localDiagnostics", v);
+                  }}
                 />
               </div>
             </div>

--- a/src/__tests__/telemetryPrefs.test.ts
+++ b/src/__tests__/telemetryPrefs.test.ts
@@ -1,0 +1,122 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  getAnalyticsPref,
+  getTelemetryPrefs,
+  setAnalyticsPref,
+  setTelemetryPrefs,
+} from "../analyticsPrefs.js";
+
+// Each test runs in its own isolated CLAUDE_CONFIG_DIR so writes don't
+// bleed into the real ~/.claude/ide/analytics.json.
+let tmpDir: string;
+
+function ideDir() {
+  return path.join(tmpDir, "ide");
+}
+function prefsFile() {
+  return path.join(ideDir(), "analytics.json");
+}
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "tel-prefs-test-"));
+  process.env.CLAUDE_CONFIG_DIR = tmpDir;
+});
+
+afterEach(() => {
+  delete process.env.CLAUDE_CONFIG_DIR;
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("getTelemetryPrefs — fresh install (no file)", () => {
+  it("returns all false when no file exists", () => {
+    expect(getTelemetryPrefs()).toEqual({
+      crashReports: false,
+      usageStats: false,
+      localDiagnostics: false,
+    });
+  });
+});
+
+describe("getTelemetryPrefs — v1 migration (enabled-only file)", () => {
+  it("maps enabled:true → crashReports:true, usageStats:true, localDiagnostics:false", () => {
+    fs.mkdirSync(ideDir(), { recursive: true });
+    fs.writeFileSync(
+      prefsFile(),
+      JSON.stringify({ enabled: true, decidedAt: "2025-01-01T00:00:00.000Z" }),
+    );
+    expect(getTelemetryPrefs()).toEqual({
+      crashReports: true,
+      usageStats: true,
+      localDiagnostics: false,
+    });
+  });
+
+  it("maps enabled:false → all false", () => {
+    fs.mkdirSync(ideDir(), { recursive: true });
+    fs.writeFileSync(
+      prefsFile(),
+      JSON.stringify({ enabled: false, decidedAt: "2025-01-01T00:00:00.000Z" }),
+    );
+    expect(getTelemetryPrefs()).toEqual({
+      crashReports: false,
+      usageStats: false,
+      localDiagnostics: false,
+    });
+  });
+});
+
+describe("setTelemetryPrefs — full and partial update", () => {
+  it("writes and reads back full prefs", () => {
+    setTelemetryPrefs({
+      crashReports: true,
+      usageStats: false,
+      localDiagnostics: true,
+    });
+    expect(getTelemetryPrefs()).toEqual({
+      crashReports: true,
+      usageStats: false,
+      localDiagnostics: true,
+    });
+  });
+
+  it("partial update only changes supplied fields", () => {
+    setTelemetryPrefs({
+      crashReports: true,
+      usageStats: true,
+      localDiagnostics: true,
+    });
+    setTelemetryPrefs({ usageStats: false });
+    expect(getTelemetryPrefs()).toEqual({
+      crashReports: true,
+      usageStats: false,
+      localDiagnostics: true,
+    });
+  });
+});
+
+describe("legacy getAnalyticsPref / setAnalyticsPref", () => {
+  it("returns null when no file exists", () => {
+    expect(getAnalyticsPref()).toBeNull();
+  });
+
+  it("setAnalyticsPref(true) makes getAnalyticsPref() return true", () => {
+    setAnalyticsPref(true);
+    expect(getAnalyticsPref()).toBe(true);
+  });
+
+  it("setAnalyticsPref(true) sets crashReports + usageStats true", () => {
+    setAnalyticsPref(true);
+    const p = getTelemetryPrefs();
+    expect(p.crashReports).toBe(true);
+    expect(p.usageStats).toBe(true);
+  });
+
+  it("setAnalyticsPref(false) makes getAnalyticsPref() return false", () => {
+    setAnalyticsPref(true);
+    setAnalyticsPref(false);
+    expect(getAnalyticsPref()).toBe(false);
+  });
+});

--- a/src/analyticsPrefs.ts
+++ b/src/analyticsPrefs.ts
@@ -1,5 +1,5 @@
 /**
- * Reads and writes the opt-in analytics preference.
+ * Reads and writes the opt-in telemetry preferences.
  * Stored in ~/.claude/ide/analytics.json (respects CLAUDE_CONFIG_DIR).
  * File created with 0o600 permissions (owner read/write only).
  */
@@ -9,8 +9,16 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-interface PrefsFile {
-  enabled: boolean;
+export interface TelemetryPrefs {
+  crashReports: boolean;
+  usageStats: boolean;
+  localDiagnostics: boolean;
+}
+
+interface PrefsFileV2 {
+  crashReports: boolean;
+  usageStats: boolean;
+  localDiagnostics: boolean;
   decidedAt: string; // ISO8601
 }
 
@@ -26,43 +34,103 @@ function saltPath(): string {
   return path.join(claudeDir, "ide", "analytics-salt");
 }
 
-/** Returns the current opt-in state, or null if no preference has been set. */
-export function getAnalyticsPref(): boolean | null {
+/**
+ * Read and migrate the on-disk prefs to the v2 shape.
+ * Old files with only `enabled` map to:
+ *   { crashReports: enabled, usageStats: enabled, localDiagnostics: false }
+ */
+export function getTelemetryPrefs(): TelemetryPrefs {
   const p = prefsPath();
   try {
     const raw = fs.readFileSync(p, "utf-8");
     const obj = JSON.parse(raw) as unknown;
-    if (
-      typeof obj === "object" &&
-      obj !== null &&
-      "enabled" in obj &&
-      typeof (obj as PrefsFile).enabled === "boolean"
-    ) {
-      return (obj as PrefsFile).enabled;
+    if (typeof obj !== "object" || obj === null) {
+      return {
+        crashReports: false,
+        usageStats: false,
+        localDiagnostics: false,
+      };
     }
-    return null;
-  } catch (err) {
-    const code = (err as NodeJS.ErrnoException).code;
-    if (code === "ENOENT") return null;
-    return null;
+    const rec = obj as Record<string, unknown>;
+
+    // v2 shape
+    if (typeof rec.crashReports === "boolean") {
+      return {
+        crashReports: rec.crashReports,
+        usageStats:
+          typeof rec.usageStats === "boolean" ? rec.usageStats : false,
+        localDiagnostics:
+          typeof rec.localDiagnostics === "boolean"
+            ? rec.localDiagnostics
+            : false,
+      };
+    }
+
+    // v1 migration — `enabled` only
+    if (typeof rec.enabled === "boolean") {
+      return {
+        crashReports: rec.enabled,
+        usageStats: rec.enabled,
+        localDiagnostics: false,
+      };
+    }
+
+    return { crashReports: false, usageStats: false, localDiagnostics: false };
+  } catch (_err) {
+    return { crashReports: false, usageStats: false, localDiagnostics: false };
   }
 }
 
-/** Persists the opt-in preference. Creates file with 0o600 permissions. */
-export function setAnalyticsPref(enabled: boolean): void {
+/** Partial-merge update. Reads current prefs, applies supplied fields, writes back. */
+export function setTelemetryPrefs(prefs: Partial<TelemetryPrefs>): void {
+  const current = getTelemetryPrefs();
+  const next: PrefsFileV2 = {
+    crashReports:
+      prefs.crashReports !== undefined
+        ? prefs.crashReports
+        : current.crashReports,
+    usageStats:
+      prefs.usageStats !== undefined ? prefs.usageStats : current.usageStats,
+    localDiagnostics:
+      prefs.localDiagnostics !== undefined
+        ? prefs.localDiagnostics
+        : current.localDiagnostics,
+    decidedAt: new Date().toISOString(),
+  };
+  writePrefs(next);
+}
+
+function writePrefs(content: PrefsFileV2): void {
   const p = prefsPath();
   const dir = path.dirname(p);
   fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
-  const content: PrefsFile = {
-    enabled,
-    decidedAt: new Date().toISOString(),
-  };
-  // Write to temp file then rename for atomicity
   const tmp = `${p}.tmp`;
   fs.writeFileSync(tmp, `${JSON.stringify(content, null, 2)}\n`, {
     mode: 0o600,
   });
   fs.renameSync(tmp, p);
+}
+
+// ---------------------------------------------------------------------------
+// Legacy API — kept for callers that predate the three-flag shape.
+// Derived from usageStats so existing analytics collection doesn't change.
+// ---------------------------------------------------------------------------
+
+/** Returns the current opt-in state, or null if no preference has been set. */
+export function getAnalyticsPref(): boolean | null {
+  const p = prefsPath();
+  try {
+    fs.accessSync(p);
+  } catch {
+    return null;
+  }
+  const prefs = getTelemetryPrefs();
+  return prefs.usageStats;
+}
+
+/** Persists the opt-in preference (legacy single-boolean form). */
+export function setAnalyticsPref(enabled: boolean): void {
+  setTelemetryPrefs({ usageStats: enabled, crashReports: enabled });
 }
 
 /**

--- a/src/analyticsPrefs.ts
+++ b/src/analyticsPrefs.ts
@@ -120,7 +120,8 @@ function writePrefs(content: PrefsFileV2): void {
 export function getAnalyticsPref(): boolean | null {
   const p = prefsPath();
   try {
-    fs.accessSync(p);
+    const raw = fs.readFileSync(p, "utf-8");
+    JSON.parse(raw);
   } catch {
     return null;
   }

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,6 +3,7 @@ import { EventEmitter } from "node:events";
 import http from "node:http";
 import { WebSocket, WebSocketServer as WsServer } from "ws";
 import type { ActivityListener } from "./activityTypes.js";
+import { getTelemetryPrefs, setTelemetryPrefs } from "./analyticsPrefs.js";
 import { handleApprovalsStream, routeApprovalRequest } from "./approvalHttp.js";
 import { getApprovalQueue } from "./approvalQueue.js";
 import type { AttributedPermissionRules } from "./ccPermissions.js";
@@ -1852,6 +1853,57 @@ export class Server extends EventEmitter<ServerEvents> {
               locked: false,
             }),
           );
+          return;
+        }
+      }
+
+      // /telemetry-prefs — read/write per-flag telemetry preferences.
+      // GET  → {crashReports, usageStats, localDiagnostics}
+      // POST {crashReports?, usageStats?, localDiagnostics?} → same shape (partial update)
+      if (parsedUrl.pathname === "/telemetry-prefs") {
+        if (req.method === "GET") {
+          const prefs = getTelemetryPrefs();
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(JSON.stringify(prefs));
+          return;
+        }
+        if (req.method === "POST") {
+          const TP_BODY_CAP = 1 * 1024;
+          const parsed = await readJsonBody<{
+            crashReports?: unknown;
+            usageStats?: unknown;
+            localDiagnostics?: unknown;
+          }>(req, TP_BODY_CAP);
+          if (!parsed.ok) {
+            if (parsed.code === "too_large") {
+              respond413(res, TP_BODY_CAP);
+              return;
+            }
+            res.writeHead(400, { "Content-Type": "application/json" });
+            res.end(
+              JSON.stringify({ error: "invalid_request", reason: "bad_json" }),
+            );
+            return;
+          }
+          const body = parsed.value ?? {};
+          const update: {
+            crashReports?: boolean;
+            usageStats?: boolean;
+            localDiagnostics?: boolean;
+          } = {};
+          if (typeof body.crashReports === "boolean") {
+            update.crashReports = body.crashReports;
+          }
+          if (typeof body.usageStats === "boolean") {
+            update.usageStats = body.usageStats;
+          }
+          if (typeof body.localDiagnostics === "boolean") {
+            update.localDiagnostics = body.localDiagnostics;
+          }
+          setTelemetryPrefs(update);
+          const prefs = getTelemetryPrefs();
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(JSON.stringify(prefs));
           return;
         }
       }


### PR DESCRIPTION
## Summary

- Extends `analyticsPrefs.ts` to three separate boolean flags (`crashReports`, `usageStats`, `localDiagnostics`) replacing the single `enabled` field; v1→v2 migration reads old files transparently
- Adds `GET /telemetry-prefs` and `POST /telemetry-prefs` to `src/server.ts` (same auth pattern as `/kill-switch`; POST accepts partial updates)
- Adds Next.js proxy route at `dashboard/src/app/api/bridge/telemetry-prefs/route.ts` (GET + POST)
- Wires settings page toggles: hydrated on mount from the bridge, each change POSTs immediately; removes "Preview only — toggles do not yet persist between reloads" notice
- Legacy `getAnalyticsPref()` / `setAnalyticsPref()` still work (derived from `usageStats`+`crashReports`); no other callers break

## Migration strategy

Old files with `{enabled: boolean}` are read and mapped to `{crashReports: enabled, usageStats: enabled, localDiagnostics: false}`. The file is rewritten to v2 shape on the first write (toggle or `setAnalyticsPref` call).

## Test plan

- [ ] `npx vitest run src/__tests__/telemetryPrefs.test.ts` — 9 tests pass (fresh file, v1 migration, partial update, legacy API)
- [ ] `npm run build` (bridge) — clean
- [ ] `npx tsc --noEmit -p tsconfig.tests.core.json` — clean
- [ ] Toggle each switch in the dashboard Settings → Telemetry section; reload — state persists
- [ ] Verify `~/.claude/ide/analytics.json` is created with correct three-flag shape after first toggle

🤖 Generated with [Claude Code](https://claude.com/claude-code)