### PR TITLE
feat: surface kill-switch state + audit filter + telemetry last-sent in dashboard

### DIFF
--- a/dashboard/src/app/page.tsx
+++ b/dashboard/src/app/page.tsx
@@ -8,6 +8,7 @@ import { SkeletonStatCard } from "@/components/Skeleton";
 import { relTime } from "@/components/time";
 import { useBridgeFetch } from "@/hooks/useBridgeFetch";
 import { useBridgeStatus } from "@/hooks/useBridgeStatus";
+import { KillSwitchBanner } from "@/components/KillSwitchBanner";
 import { isNoiseEvent } from "@/lib/activityNoise";
 import { isHaltStatus } from "@/lib/runStatus";
 import {
@@ -935,6 +936,12 @@ export default function HomePage() {
 
   return (
     <section>
+      {bridgeStatus.killSwitch?.engaged && (
+        <KillSwitchBanner
+          engaged={bridgeStatus.killSwitch.engaged}
+          locked={bridgeStatus.killSwitch.locked}
+        />
+      )}
       {/*
         First-run checklist: orchestrates the 4-step happy path for
         brand-new workspaces (connect → install recipe → run → approve).

--- a/dashboard/src/app/settings/page.tsx
+++ b/dashboard/src/app/settings/page.tsx
@@ -220,6 +220,29 @@ export default function SettingsPage() {
   const [telUsage, setTelUsage] = useState(false);
   const [telDiag, setTelDiag] = useState(true);
   const telInitialized = useRef(false);
+  const [telLastSentAt, setTelLastSentAt] = useState<string | null>(null);
+
+  // Fetch analytics prefs (including lastSentAt) from bridge
+  useEffect(() => {
+    let alive = true;
+    const fetch_ = async () => {
+      try {
+        const res = await fetch(apiPath("/api/bridge/telemetry-prefs"));
+        if (res.ok) {
+          const data = (await res.json()) as { lastSentAt?: string };
+          if (alive && typeof data.lastSentAt === "string") {
+            setTelLastSentAt(data.lastSentAt);
+          }
+        }
+      } catch {
+        // Bridge offline — no-op
+      }
+    };
+    fetch_();
+    return () => {
+      alive = false;
+    };
+  }, []);
 
   // Kill-switch state — fetched from /api/bridge/kill-switch (proxy to
   // bridge `GET /kill-switch`). Polls in tandem with /status below.
@@ -1446,6 +1469,24 @@ export default function SettingsPage() {
                     void saveTelemetryPref("localDiagnostics", v);
                   }}
                 />
+                {telLastSentAt && (
+                  <div
+                    style={{
+                      fontSize: "var(--fs-s)",
+                      color: "var(--ink-2)",
+                      paddingTop: 4,
+                    }}
+                  >
+                    Last sent:{" "}
+                    {new Date(telLastSentAt).toLocaleDateString(undefined, {
+                      year: "numeric",
+                      month: "short",
+                      day: "numeric",
+                      hour: "2-digit",
+                      minute: "2-digit",
+                    })}
+                  </div>
+                )}
               </div>
             </div>
           </div>

--- a/dashboard/src/app/traces/page.tsx
+++ b/dashboard/src/app/traces/page.tsx
@@ -16,6 +16,7 @@ interface DecisionTrace {
   key: string;
   summary: string;
   body: Record<string, unknown>;
+  tags?: string[];
 }
 
 interface TracesResponse {
@@ -574,6 +575,7 @@ export default function TracesPage() {
   const [since, setSince] = useState<SinceFilter>("24h");
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
   const [view, setView] = useState<"flat" | "tree">("tree");
+  const [ksOnly, setKsOnly] = useState(false);
 
   const qs = useMemo(() => {
     const params = new URLSearchParams();
@@ -586,9 +588,12 @@ export default function TracesPage() {
       params.set("since", String(Date.now() - sinceMs));
     }
     params.set("limit", "50");
+    if (ksOnly) {
+      params.set("tag", "kill-switch");
+    }
     const s = params.toString();
     return s ? `?${s}` : "";
-  }, [debouncedSearch, since]);
+  }, [debouncedSearch, since, ksOnly]);
 
   const { data, error, loading, refetch } = useBridgeFetch<TracesResponse>(
     `/api/bridge/traces${qs}`,
@@ -697,6 +702,21 @@ export default function TracesPage() {
               {k === "all" ? `All (${traces.length})` : k === "done" ? `Done (${doneCount})` : `Errors (${errorCount})`}
             </button>
           ))}
+          <button
+            type="button"
+            onClick={() => setKsOnly((v) => !v)}
+            className={ksOnly ? "pill accent" : "pill muted"}
+            style={{
+              cursor: "pointer",
+              border: "none",
+              fontSize: "var(--fs-s)",
+              ...(ksOnly
+                ? { background: "var(--err-soft)", color: "var(--err)" }
+                : {}),
+            }}
+          >
+            Kill-switch
+          </button>
         </div>
         <label style={{ display: "inline-flex", alignItems: "center", gap: 6, fontSize: "var(--fs-s)", color: "var(--ink-2)" }}>
           <span>since</span>
@@ -774,8 +794,17 @@ export default function TracesPage() {
             const statusColor = status === "done" ? "var(--ok)" : status === "error" ? "var(--err)" : "var(--ink-3)";
             const statusBg = status === "done" ? "var(--ok-soft)" : status === "error" ? "var(--err-soft)" : "var(--recess)";
             const statusLabel = status === "done" ? "done" : status === "error" ? "error" : "running";
+            const isKillSwitch = Array.isArray(t.tags) && t.tags.includes("kill-switch");
             return (
-              <div key={rowKey} style={{ borderBottom: "1px solid var(--line-3)" }}>
+              <div
+                key={rowKey}
+                style={{
+                  borderBottom: "1px solid var(--line-3)",
+                  ...(isKillSwitch
+                    ? { borderLeft: "3px solid var(--err)" }
+                    : {}),
+                }}
+              >
                 <div
                   style={{
                     display: "grid",

--- a/dashboard/src/components/KillSwitchBanner.tsx
+++ b/dashboard/src/components/KillSwitchBanner.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { useState } from "react";
+import { apiPath } from "@/lib/api";
+
+interface KillSwitchBannerProps {
+  engaged: boolean;
+  locked: boolean;
+}
+
+/**
+ * Displays a prominent warning banner when the write kill-switch is engaged.
+ * Renders nothing when engaged=false.
+ */
+export function KillSwitchBanner({ engaged, locked }: KillSwitchBannerProps) {
+  const [releasing, setReleasing] = useState(false);
+  const [releaseError, setReleaseError] = useState<string | null>(null);
+
+  if (!engaged) return null;
+
+  const handleRelease = async () => {
+    if (releasing || locked) return;
+    setReleasing(true);
+    setReleaseError(null);
+    try {
+      const res = await fetch(apiPath("/api/bridge/kill-switch"), {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ engage: false }),
+      });
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as {
+          error?: string;
+          lockedReason?: string;
+        };
+        setReleaseError(
+          body.lockedReason ?? body.error ?? `Request failed (${res.status})`,
+        );
+      }
+    } catch {
+      setReleaseError("Network error — bridge may be offline.");
+    } finally {
+      setReleasing(false);
+    }
+  };
+
+  return (
+    <div
+      role="alert"
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: "var(--s-3)",
+        padding: "10px 16px",
+        background: "var(--err-soft)",
+        borderLeft: "4px solid var(--err)",
+        borderRadius: "var(--r-s)",
+        marginBottom: "var(--s-4)",
+        flexWrap: "wrap",
+      }}
+    >
+      <span
+        style={{
+          flex: 1,
+          fontSize: "var(--fs-s)",
+          color: "var(--ink-0)",
+          fontWeight: 500,
+        }}
+      >
+        ⚠ Write kill-switch is ENGAGED — all recipe writes are blocked.
+      </span>
+
+      {releaseError && (
+        <span
+          style={{
+            fontSize: "var(--fs-xs, var(--fs-s))",
+            color: "var(--err)",
+            flexBasis: "100%",
+          }}
+        >
+          {releaseError}
+        </span>
+      )}
+
+      <button
+        type="button"
+        className="btn"
+        disabled={locked || releasing}
+        onClick={handleRelease}
+        title={locked ? "(env-locked) Cannot release — set by environment variable at startup." : undefined}
+        style={{ fontSize: "var(--fs-s)", whiteSpace: "nowrap" }}
+      >
+        {releasing ? "Releasing…" : "Release"}
+        {locked && (
+          <span
+            style={{
+              marginLeft: 6,
+              fontSize: "var(--fs-xs, var(--fs-s))",
+              opacity: 0.7,
+            }}
+          >
+            (env-locked)
+          </span>
+        )}
+      </button>
+    </div>
+  );
+}

--- a/dashboard/src/hooks/useBridgeStatus.ts
+++ b/dashboard/src/hooks/useBridgeStatus.ts
@@ -31,6 +31,7 @@ export interface BridgeStatus {
     model?: string;
     version?: string;
   };
+  killSwitch?: { engaged: boolean; locked: boolean } | null;
 }
 
 const BASE_INTERVAL_MS = 5000;
@@ -44,6 +45,8 @@ function nextDelay(failures: number): number {
   const exp = Math.min(BASE_INTERVAL_MS * 2 ** failures, MAX_BACKOFF_MS);
   return exp * (0.8 + Math.random() * 0.4); // ±20% jitter
 }
+
+const KILL_SWITCH_POLL_MS = 10_000;
 
 export function useBridgeStatus(): BridgeStatus {
   const [status, setStatus] = useState<BridgeStatus>({ ok: false });
@@ -130,5 +133,37 @@ export function useBridgeStatus(): BridgeStatus {
       unsubLiveness();
     };
   }, []);
+
+  // Poll kill-switch state independently — it can change at any time and
+  // the status endpoint doesn't include it.
+  useEffect(() => {
+    let alive = true;
+    let timerId: ReturnType<typeof setTimeout> | null = null;
+
+    const poll = async () => {
+      try {
+        const res = await fetch(apiPath("/api/bridge/kill-switch"));
+        if (res.ok) {
+          const data = (await res.json()) as {
+            engaged: boolean;
+            locked: boolean;
+          };
+          if (alive) {
+            setStatus((prev) => ({ ...prev, killSwitch: data }));
+          }
+        }
+      } catch {
+        // Bridge offline — leave killSwitch as-is
+      }
+      if (alive) timerId = setTimeout(poll, KILL_SWITCH_POLL_MS);
+    };
+
+    poll();
+    return () => {
+      alive = false;
+      if (timerId !== null) clearTimeout(timerId);
+    };
+  }, []);
+
   return status;
 }

--- a/src/__tests__/telemetryPrefs.test.ts
+++ b/src/__tests__/telemetryPrefs.test.ts
@@ -4,7 +4,9 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   getAnalyticsPref,
+  getAnalyticsPrefsAll,
   getTelemetryPrefs,
+  recordAnalyticsSent,
   setAnalyticsPref,
   setTelemetryPrefs,
 } from "../analyticsPrefs.js";
@@ -118,5 +120,58 @@ describe("legacy getAnalyticsPref / setAnalyticsPref", () => {
     setAnalyticsPref(true);
     setAnalyticsPref(false);
     expect(getAnalyticsPref()).toBe(false);
+  });
+});
+
+describe("recordAnalyticsSent", () => {
+  it("is a no-op when no prefs file exists", () => {
+    // Should not throw
+    expect(() => recordAnalyticsSent()).not.toThrow();
+  });
+
+  it("writes lastSentAt after setAnalyticsPref(true)", () => {
+    setAnalyticsPref(true);
+
+    const before = Date.now();
+    recordAnalyticsSent();
+    const after = Date.now();
+
+    const prefs = getAnalyticsPrefsAll();
+    expect(prefs).not.toBeNull();
+    expect(typeof prefs!.lastSentAt).toBe("string");
+
+    const ts = new Date(prefs!.lastSentAt!).getTime();
+    expect(ts).toBeGreaterThanOrEqual(before);
+    expect(ts).toBeLessThanOrEqual(after);
+  });
+
+  it("preserves enabled state when recording lastSentAt", () => {
+    setAnalyticsPref(false);
+    recordAnalyticsSent();
+
+    expect(getAnalyticsPref()).toBe(false);
+    const prefs = getAnalyticsPrefsAll();
+    expect(typeof prefs!.lastSentAt).toBe("string");
+  });
+
+  it("updates lastSentAt on repeated calls", () => {
+    setAnalyticsPref(true);
+    recordAnalyticsSent();
+    const prefs1 = getAnalyticsPrefsAll();
+
+    // Small delay to ensure timestamp advances
+    const ts1 = new Date(prefs1!.lastSentAt!).getTime();
+
+    // Force clock to advance by at least 1 ms
+    const spin = Date.now() + 1;
+    while (Date.now() < spin) {
+      /* busy wait */
+    }
+
+    recordAnalyticsSent();
+    const prefs2 = getAnalyticsPrefsAll();
+    const ts2 = new Date(prefs2!.lastSentAt!).getTime();
+
+    expect(ts2).toBeGreaterThanOrEqual(ts1);
   });
 });

--- a/src/analyticsPrefs.ts
+++ b/src/analyticsPrefs.ts
@@ -20,6 +20,7 @@ interface PrefsFileV2 {
   usageStats: boolean;
   localDiagnostics: boolean;
   decidedAt: string; // ISO8601
+  lastSentAt?: string; // ISO8601 — updated after each successful analytics send
 }
 
 function prefsPath(): string {
@@ -109,6 +110,53 @@ function writePrefs(content: PrefsFileV2): void {
     mode: 0o600,
   });
   fs.renameSync(tmp, p);
+}
+
+/**
+ * Returns the raw prefs file contents including optional `lastSentAt` timestamp.
+ * Returns null when no prefs file exists yet.
+ */
+export function getAnalyticsPrefsAll(): (PrefsFileV2 & { lastSentAt?: string }) | null {
+  const p = prefsPath();
+  try {
+    const raw = fs.readFileSync(p, "utf-8");
+    const obj = JSON.parse(raw) as unknown;
+    if (typeof obj === "object" && obj !== null) {
+      return obj as PrefsFileV2 & { lastSentAt?: string };
+    }
+    return null;
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === "ENOENT") return null;
+    return null;
+  }
+}
+
+/**
+ * Records the current time as `lastSentAt` in the prefs file.
+ * No-op if no prefs file exists yet (user never opted in, nothing to record).
+ */
+export function recordAnalyticsSent(): void {
+  const p = prefsPath();
+  try {
+    const raw = fs.readFileSync(p, "utf-8");
+    const obj = JSON.parse(raw) as unknown;
+    if (typeof obj === "object" && obj !== null) {
+      const updated = {
+        ...(obj as PrefsFileV2),
+        lastSentAt: new Date().toISOString(),
+      };
+      const dir = path.dirname(p);
+      fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+      const tmp = `${p}.tmp`;
+      fs.writeFileSync(tmp, `${JSON.stringify(updated, null, 2)}\n`, {
+        mode: 0o600,
+      });
+      fs.renameSync(tmp, p);
+    }
+  } catch {
+    // No prefs file or unreadable — nothing to update
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/analyticsPrefs.ts
+++ b/src/analyticsPrefs.ts
@@ -116,7 +116,9 @@ function writePrefs(content: PrefsFileV2): void {
  * Returns the raw prefs file contents including optional `lastSentAt` timestamp.
  * Returns null when no prefs file exists yet.
  */
-export function getAnalyticsPrefsAll(): (PrefsFileV2 & { lastSentAt?: string }) | null {
+export function getAnalyticsPrefsAll():
+  | (PrefsFileV2 & { lastSentAt?: string })
+  | null {
   const p = prefsPath();
   try {
     const raw = fs.readFileSync(p, "utf-8");

--- a/src/analyticsSend.ts
+++ b/src/analyticsSend.ts
@@ -6,6 +6,7 @@
  */
 
 import type { AnalyticsSummary } from "./analyticsAggregator.js";
+import { recordAnalyticsSent } from "./analyticsPrefs.js";
 
 /** Hardcoded endpoint — not configurable at runtime. */
 const ANALYTICS_ENDPOINT = "https://analytics.claude-ide-bridge.dev/v1/usage";
@@ -21,12 +22,15 @@ export async function sendAnalytics(summary: AnalyticsSummary): Promise<void> {
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), SEND_TIMEOUT_MS);
     try {
-      await fetch(ANALYTICS_ENDPOINT, {
+      const res = await fetch(ANALYTICS_ENDPOINT, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(summary),
         signal: controller.signal,
       });
+      if (res.ok) {
+        recordAnalyticsSent();
+      }
     } finally {
       clearTimeout(timer);
     }

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,7 +3,11 @@ import { EventEmitter } from "node:events";
 import http from "node:http";
 import { WebSocket, WebSocketServer as WsServer } from "ws";
 import type { ActivityListener } from "./activityTypes.js";
-import { getAnalyticsPrefsAll, getTelemetryPrefs, setTelemetryPrefs } from "./analyticsPrefs.js";
+import {
+  getAnalyticsPrefsAll,
+  getTelemetryPrefs,
+  setTelemetryPrefs,
+} from "./analyticsPrefs.js";
 import { handleApprovalsStream, routeApprovalRequest } from "./approvalHttp.js";
 import { getApprovalQueue } from "./approvalQueue.js";
 import type { AttributedPermissionRules } from "./ccPermissions.js";

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,7 +3,7 @@ import { EventEmitter } from "node:events";
 import http from "node:http";
 import { WebSocket, WebSocketServer as WsServer } from "ws";
 import type { ActivityListener } from "./activityTypes.js";
-import { getTelemetryPrefs, setTelemetryPrefs } from "./analyticsPrefs.js";
+import { getAnalyticsPrefsAll, getTelemetryPrefs, setTelemetryPrefs } from "./analyticsPrefs.js";
 import { handleApprovalsStream, routeApprovalRequest } from "./approvalHttp.js";
 import { getApprovalQueue } from "./approvalQueue.js";
 import type { AttributedPermissionRules } from "./ccPermissions.js";
@@ -1897,8 +1897,13 @@ export class Server extends EventEmitter<ServerEvents> {
       if (parsedUrl.pathname === "/telemetry-prefs") {
         if (req.method === "GET") {
           const prefs = getTelemetryPrefs();
+          const all = getAnalyticsPrefsAll();
+          const response: Record<string, unknown> = { ...prefs };
+          if (all?.lastSentAt !== undefined) {
+            response.lastSentAt = all.lastSentAt;
+          }
           res.writeHead(200, { "Content-Type": "application/json" });
-          res.end(JSON.stringify(prefs));
+          res.end(JSON.stringify(response));
           return;
         }
         if (req.method === "POST") {


### PR DESCRIPTION
## Summary

- **Gap 1 — Kill-switch banner (home page):** New `KillSwitchBanner` component renders a red left-bordered alert when `GET /kill-switch` reports `engaged: true`. `useBridgeStatus` now polls `/kill-switch` every 10 s in a separate `useEffect` and merges `killSwitch: {engaged, locked}` into the returned status. Release button calls `POST /api/bridge/kill-switch {engage: false}` and is disabled + annotated "(env-locked)" when the bridge flag is frozen by environment variable.
- **Gap 2 — Kill-switch filter on /traces:** Added `ksOnly` boolean state and a "Kill-switch" chip in the filter bar. When active it appends `&tag=kill-switch` to the fetch query. Kill-switch rows (those with `tags` containing `"kill-switch"`) get a subtle red left-border accent. `DecisionTrace` interface extended with optional `tags?: string[]`.
- **Gap 3 — Telemetry last-sent timestamp:** `analyticsPrefs.ts` gains `getAnalyticsPrefsAll()` (returns full prefs including `lastSentAt`) and `recordAnalyticsSent()` (writes current ISO timestamp back to file). `analyticsSend.ts` calls `recordAnalyticsSent()` on `response.ok`. New `GET /telemetry-prefs` bridge endpoint returns the prefs object. Settings page fetches it on mount and shows "Last sent: <date>" below the telemetry toggles when present.

## Test plan

- [ ] Bridge builds: `npm run build` passes
- [ ] Next.js dashboard builds: `cd dashboard && npm run build` passes
- [ ] Type check: `npx tsc --noEmit -p tsconfig.tests.core.json` passes
- [ ] Unit tests: `npx vitest run src/__tests__/telemetryPrefs.test.ts` — 4 tests pass
- [ ] Home page with kill-switch engaged shows the red banner; Release button works
- [ ] Home page with kill-switch disengaged shows no banner
- [ ] /traces Kill-switch chip filters to tagged rows only; engaged rows have red left-border
- [ ] Settings page shows "Last sent: <date>" after `recordAnalyticsSent()` has been called

Generated with [Claude Code](https://claude.com/claude-code)