### PR TITLE
revert: remove CC Routines tools — overlaps with recipe scheduling

### DIFF
--- a/documents/roadmap.md
+++ b/documents/roadmap.md
@@ -774,7 +774,7 @@ Research (2026-03-17) against current Claude Code docs revealed gaps between the
 ### Remaining (deferred)
 - Verify Tool Search compatibility — with 135+ tools active; low priority (automatic, no bridge changes needed)
 - Agent Teams — when Claude Code's multi-session Teams feature ships; plan session namespacing then
-- **Claude Code Routines integration** — revisit when API exits research preview (`experimental-cc-routine-2026-04-01`). Immediate value: thin `runRoutine`/`getRoutineStatus`/`listRoutines` MCP tools (Phase 3 only — ~1 file, no driver changes). Full `RoutinesDriver` (`--driver routines`) deferred until auth is stable (currently claude.ai accounts only, not open API). Policy-layer `routineId` on automation hooks also deferred. See: https://claude.ai/code/routines
+- **Claude Code Routines** — Closed. Routines overlaps with Patchwork's recipe scheduling system (cron triggers, connector steps, run history, dashboard visibility). Not worth integrating as a parallel scheduling layer. Revisit only if Routines adds something recipes genuinely can't do (e.g. stateful multi-step agents with persistent memory).
 
 ---
 


### PR DESCRIPTION
## Summary

- PR #510 added `listRoutines`, `runRoutine`, and `getRoutineStatus` MCP tools as stubs for the Claude Code Routines research-preview API — but was never merged to `main`
- This PR formally closes out that line of work and updates the roadmap with the decision rationale
- No code to delete (PR #510 files never landed on `main`); the only change is `documents/roadmap.md`

## Decision

CC Routines overlaps with Patchwork's recipe scheduling system (cron triggers, connector steps, run history, dashboard visibility). Integrating it as a parallel scheduling layer adds maintenance cost with no unique capability. The roadmap entry is updated to **Closed** with a clear revisit condition: only if Routines adds something recipes genuinely cannot do (e.g. stateful multi-step agents with persistent memory).

## Test plan

- [x] `node scripts/audit-lsp-tools.mjs` — confirms 177 tools (unchanged from before #510)
- [x] `npm run build` — passes
- [x] `npx tsc --noEmit -p tsconfig.tests.core.json` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)