### PR TITLE
feat: add graceful bridge restart endpoint with safety checks

### DIFF
--- a/dashboard/src/app/settings/page.tsx
+++ b/dashboard/src/app/settings/page.tsx
@@ -161,6 +161,9 @@ export default function SettingsPage() {
   const [driverSaving, setDriverSaving] = useState<string | null>(null);
   const [driverMsg, setDriverMsg] = useState<{ ok: boolean; text: string } | null>(null);
   const driverInitialized = useRef(false);
+  const [restartPending, setRestartPending] = useState(false);
+  const [restartBusy, setRestartBusy] = useState(false);
+  const [restartMsg, setRestartMsg] = useState<{ ok: boolean; text: string } | null>(null);
 
   // Per-row API key entry state. Inputs are uncontrolled w.r.t. /status —
   // the dashboard never sees the stored value (secure store is one-way),
@@ -556,10 +559,12 @@ export default function SettingsPage() {
       };
       if (res.ok) {
         setPrimaryDriver(rowId);
-        const text = body.restartRequired
-          ? `${row.name} set as primary. Restart Claude Code (quit and re-open, then run /ide) to activate the new driver.`
-          : `${row.name} set as primary.`;
-        setDriverMsg({ ok: true, text });
+        if (body.restartRequired) {
+          setRestartPending(true);
+          setDriverMsg({ ok: true, text: `${row.name} set as primary. Click "Restart Bridge" below to activate.` });
+        } else {
+          setDriverMsg({ ok: true, text: `${row.name} set as primary.` });
+        }
         flashSaved();
       } else {
         setDriverMsg({ ok: false, text: body.error ?? `Error ${res.status}` });
@@ -568,6 +573,45 @@ export default function SettingsPage() {
       setDriverMsg({ ok: false, text: e instanceof Error ? e.message : String(e) });
     } finally {
       setDriverSaving(null);
+    }
+  }
+
+  async function restartBridge() {
+    setRestartBusy(true);
+    setRestartMsg(null);
+    try {
+      const res = await fetch(apiPath("/api/bridge/restart"), {
+        method: "POST",
+      });
+      const body = (await res.json().catch(() => ({}))) as {
+        ok?: boolean;
+        message?: string;
+        error?: string;
+        reason?: string;
+        inFlightCalls?: number;
+        busySessions?: string[];
+      };
+      if (res.ok) {
+        setRestartPending(false);
+        setRestartMsg({ ok: true, text: body.message ?? "Bridge is restarting..." });
+        // Clear the message after a few seconds since the page will reload
+        setTimeout(() => setRestartMsg(null), 3000);
+      } else if (res.status === 409) {
+        // Restart blocked due to active work
+        const busyDetails = body.busySessions?.length
+          ? `\n\nBusy sessions:\n${body.busySessions.join("\n")}`
+          : "";
+        setRestartMsg({
+          ok: false,
+          text: `${body.reason ?? "Restart blocked"}${busyDetails}`,
+        });
+      } else {
+        setRestartMsg({ ok: false, text: body.error ?? `Error ${res.status}` });
+      }
+    } catch (e) {
+      setRestartMsg({ ok: false, text: e instanceof Error ? e.message : String(e) });
+    } finally {
+      setRestartBusy(false);
     }
   }
 
@@ -1070,6 +1114,43 @@ export default function SettingsPage() {
                   <p style={{ fontSize: "var(--fs-s)", marginTop: 4, color: driverMsg.ok ? "var(--ok)" : "var(--err)" }}>
                     {driverMsg.text}
                   </p>
+                )}
+                {restartPending && (
+                  <div style={{ marginTop: 12, padding: "12px 14px", background: "var(--bg-3)", border: "1px solid var(--line-1)", borderRadius: "var(--r-2)" }}>
+                    <div style={{ display: "flex", alignItems: "center", gap: 12, flexWrap: "wrap" }}>
+                      <div style={{ flex: 1, minWidth: 200 }}>
+                        <div style={{ fontSize: "var(--fs-m)", fontWeight: 600, color: "var(--fg-0)", marginBottom: 4 }}>
+                          Restart Required
+                        </div>
+                        <div style={{ fontSize: "var(--fs-s)", color: "var(--fg-2)" }}>
+                          The bridge needs to restart to apply the new driver configuration.
+                        </div>
+                      </div>
+                      <button
+                        type="button"
+                        onClick={restartBridge}
+                        disabled={restartBusy}
+                        style={{
+                          background: "var(--accent)",
+                          color: "white",
+                          border: "none",
+                          borderRadius: "var(--r-2)",
+                          padding: "8px 16px",
+                          fontSize: "var(--fs-m)",
+                          fontWeight: 600,
+                          cursor: restartBusy ? "default" : "pointer",
+                          opacity: restartBusy ? 0.6 : 1,
+                        }}
+                      >
+                        {restartBusy ? "Restarting..." : "Restart Bridge"}
+                      </button>
+                    </div>
+                    {restartMsg && (
+                      <p style={{ fontSize: "var(--fs-s)", marginTop: 8, color: restartMsg.ok ? "var(--ok)" : "var(--err)", whiteSpace: "pre-wrap" }}>
+                        {restartMsg.text}
+                      </p>
+                    )}
+                  </div>
                 )}
               </div>
             </div>

--- a/docs/restart-endpoint.md
+++ b/docs/restart-endpoint.md
@@ -1,0 +1,182 @@
+# Bridge Restart Endpoint
+
+## Overview
+
+The bridge now supports graceful in-place restarts via a new `POST /restart` endpoint. This allows users to apply configuration changes (like switching AI drivers) without manually restarting the bridge process.
+
+## Endpoint Details
+
+### `POST /restart`
+
+**Authentication**: Requires Bearer token
+
+**Request**: No body required
+
+**Responses**:
+
+- **202 Accepted** - Restart initiated successfully
+  ```json
+  {
+    "ok": true,
+    "message": "Restart initiated. Bridge will shut down gracefully.",
+    "activeSessions": 2
+  }
+  ```
+
+- **409 Conflict** - Restart blocked due to active work
+  ```json
+  {
+    "ok": false,
+    "error": "restart_blocked",
+    "reason": "3 tool calls in progress",
+    "activeSessions": 2,
+    "inFlightCalls": 3,
+    "busySessions": [
+      "abc12345 (2 tools: file.read, git.status)",
+      "def67890 (1 tool: file.write)"
+    ]
+  }
+  ```
+
+- **503 Service Unavailable** - Restart endpoint not configured
+  ```json
+  {
+    "ok": false,
+    "error": "restart_unavailable",
+    "reason": "Restart endpoint not configured"
+  }
+  ```
+
+## Safety Checks
+
+The endpoint performs the following safety checks before allowing a restart:
+
+1. **Session Inspection**: Iterates through all active bridge sessions
+2. **In-Flight Tool Detection**: Checks each session for `activeToolCalls > 0`
+3. **Rejection on Active Work**: Returns 409 if any tool calls are in progress
+4. **Graceful Shutdown**: Only triggers SIGTERM when safe (no active work)
+
+## Implementation Details
+
+### Backend (`src/server.ts`)
+
+- Added `restartCheckFn` callback property to `Server` class
+- Endpoint checks callback, counts in-flight calls, and triggers SIGTERM if safe
+- 100ms delay before SIGTERM to ensure HTTP response is delivered
+
+### Bridge Wiring (`src/bridge.ts`)
+
+- Wires up `server.restartCheckFn` during bridge initialization
+- Callback iterates `this.sessions`, calls `transport.getStats()` on each
+- Returns session count, in-flight call count, and busy session details
+
+### Dashboard UI (`dashboard/src/app/settings/page.tsx`)
+
+- Added restart state management: `restartPending`, `restartBusy`, `restartMsg`
+- Modified `setPrimary()` to set `restartPending` when driver changes
+- Added `restartBridge()` function to call `/api/bridge/restart`
+- Added prominent "Restart Required" card with "Restart Bridge" button
+- Shows detailed error messages if restart is blocked (e.g., active tool calls)
+
+## User Experience
+
+### Before (Manual Restart)
+
+1. User changes AI driver in dashboard
+2. Dashboard shows: "Restart Claude Code (quit and re-open, then run /ide) to activate the new driver."
+3. User must manually quit and restart the bridge
+4. User must wait for bridge to come back online
+5. Dashboard reconnects automatically
+
+### After (Automatic Restart)
+
+1. User changes AI driver in dashboard
+2. Dashboard shows: "Gemini set as primary. Click 'Restart Bridge' below to activate."
+3. Prominent "Restart Required" card appears with blue "Restart Bridge" button
+4. User clicks button
+5. If safe (no active work):
+   - Bridge sends SIGTERM to itself
+   - Process manager (systemd/launchd/pm2) auto-restarts bridge
+   - Dashboard shows "Bridge is restarting..."
+   - Page reconnects when bridge comes back online
+6. If blocked (active tool calls):
+   - Dashboard shows: "3 tool calls in progress" with session details
+   - User can retry when work completes
+
+## Process Manager Requirements
+
+The restart endpoint relies on a process manager to automatically restart the bridge after SIGTERM:
+
+- **systemd** (Linux): `Restart=always` in service file
+- **launchd** (macOS): `KeepAlive` in plist
+- **pm2** (Node.js): `--restart-delay` flag
+- **Docker**: `restart: unless-stopped` in compose file
+
+Without a process manager, the bridge will shut down and not restart automatically.
+
+## Testing
+
+Comprehensive test coverage in `src/__tests__/restart.test.ts`:
+
+- ✅ Returns 503 when `restartCheckFn` not configured
+- ✅ Returns 202 when no sessions are active
+- ✅ Returns 409 when tool calls are in-flight
+- ✅ Returns 202 when sessions exist but idle
+- ✅ Requires authentication (401 without Bearer token)
+
+Run tests:
+```bash
+npx vitest run src/__tests__/restart.test.ts
+```
+
+## Example Usage
+
+### cURL
+
+```bash
+# Attempt restart
+curl -X POST http://localhost:3101/restart \
+  -H "Authorization: Bearer your-bridge-token"
+
+# Response (success)
+{
+  "ok": true,
+  "message": "Restart initiated. Bridge will shut down gracefully.",
+  "activeSessions": 0
+}
+
+# Response (blocked)
+{
+  "ok": false,
+  "error": "restart_blocked",
+  "reason": "2 tool calls in progress",
+  "activeSessions": 1,
+  "inFlightCalls": 2,
+  "busySessions": ["abc12345 (2 tools: file.read, git.status)"]
+}
+```
+
+### Dashboard
+
+1. Navigate to **Settings** → **AI drivers**
+2. Click "Set primary" on desired driver (e.g., Gemini)
+3. Click "Restart Bridge" button in the "Restart Required" card
+4. Wait for bridge to restart (typically 2-5 seconds)
+5. Dashboard reconnects automatically
+
+## Security Considerations
+
+- **Authentication Required**: Endpoint requires valid Bearer token
+- **No Force Flag**: Cannot override safety checks (prevents data loss)
+- **Audit Logging**: Restart attempts logged with session/tool details
+- **Rate Limiting**: Inherits server-wide rate limiting (no special bypass)
+
+## Future Enhancements
+
+Potential improvements for future versions:
+
+1. **Force Restart Flag**: `POST /restart?force=true` to override safety checks
+2. **Graceful Drain**: Wait for in-flight calls to complete (with timeout)
+3. **Hot Reload**: Reload config without full restart for certain changes
+4. **Restart Scheduling**: Schedule restart for specific time (e.g., 3am)
+5. **Multi-Instance Coordination**: Coordinate restarts across bridge cluster

--- a/src/__tests__/restart.test.ts
+++ b/src/__tests__/restart.test.ts
@@ -1,0 +1,138 @@
+import http from "node:http";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { Logger } from "../logger.js";
+import { Server } from "../server.js";
+
+const logger = new Logger(false);
+
+describe("POST /restart endpoint", () => {
+  let server: Server;
+  let port: number;
+  const authToken = "test-restart-token";
+
+  beforeEach(async () => {
+    server = new Server(authToken, logger);
+    port = await server.findAndListen(null);
+  });
+
+  afterEach(async () => {
+    await server.close();
+  });
+
+  function makeRequest(
+    method: string,
+    path: string,
+    body?: unknown,
+  ): Promise<{ status: number; body: unknown }> {
+    return new Promise((resolve, reject) => {
+      const req = http.request(
+        {
+          hostname: "127.0.0.1",
+          port,
+          path,
+          method,
+          headers: {
+            Authorization: `Bearer ${authToken}`,
+            ...(body ? { "Content-Type": "application/json" } : {}),
+          },
+        },
+        (res) => {
+          let data = "";
+          res.on("data", (chunk) => {
+            data += chunk;
+          });
+          res.on("end", () => {
+            try {
+              const parsed = data ? JSON.parse(data) : {};
+              resolve({ status: res.statusCode ?? 0, body: parsed });
+            } catch {
+              resolve({ status: res.statusCode ?? 0, body: data });
+            }
+          });
+        },
+      );
+      req.on("error", reject);
+      if (body) {
+        req.write(JSON.stringify(body));
+      }
+      req.end();
+    });
+  }
+
+  it("returns 503 when restartCheckFn is not configured", async () => {
+    const res = await makeRequest("POST", "/restart");
+    expect(res.status).toBe(503);
+    expect((res.body as { error?: string }).error).toBe("restart_unavailable");
+  });
+
+  it("returns 202 when no sessions are active", async () => {
+    server.restartCheckFn = () => ({
+      totalSessions: 0,
+      inFlightCalls: 0,
+      busySessions: [],
+    });
+
+    const res = await makeRequest("POST", "/restart");
+    expect(res.status).toBe(202);
+    expect((res.body as { ok?: boolean }).ok).toBe(true);
+    expect((res.body as { message?: string }).message).toContain(
+      "Restart initiated",
+    );
+  });
+
+  it("returns 409 when tool calls are in flight", async () => {
+    server.restartCheckFn = () => ({
+      totalSessions: 2,
+      inFlightCalls: 3,
+      busySessions: [
+        "abc12345 (2 tools: file.read, git.status)",
+        "def67890 (1 tool: file.write)",
+      ],
+    });
+
+    const res = await makeRequest("POST", "/restart");
+    expect(res.status).toBe(409);
+    expect((res.body as { error?: string }).error).toBe("restart_blocked");
+    expect((res.body as { reason?: string }).reason).toContain(
+      "3 tool calls in progress",
+    );
+    expect((res.body as { inFlightCalls?: number }).inFlightCalls).toBe(3);
+    expect((res.body as { busySessions?: string[] }).busySessions).toHaveLength(
+      2,
+    );
+  });
+
+  it("returns 202 when sessions exist but no tool calls are active", async () => {
+    server.restartCheckFn = () => ({
+      totalSessions: 3,
+      inFlightCalls: 0,
+      busySessions: [],
+    });
+
+    const res = await makeRequest("POST", "/restart");
+    expect(res.status).toBe(202);
+    expect((res.body as { ok?: boolean }).ok).toBe(true);
+    expect((res.body as { activeSessions?: number }).activeSessions).toBe(3);
+  });
+
+  it("requires authentication", async () => {
+    server.restartCheckFn = () => ({
+      totalSessions: 0,
+      inFlightCalls: 0,
+      busySessions: [],
+    });
+
+    const req = http.request(
+      {
+        hostname: "127.0.0.1",
+        port,
+        path: "/restart",
+        method: "POST",
+      },
+      (res) => {
+        expect(res.statusCode).toBe(401);
+      },
+    );
+    req.end();
+  });
+});

--- a/src/__tests__/restart.test.ts
+++ b/src/__tests__/restart.test.ts
@@ -66,6 +66,7 @@ describe("POST /restart endpoint", () => {
   });
 
   it("returns 202 when no sessions are active", async () => {
+    server.restartKillFn = () => {}; // prevent SIGTERM during tests
     server.restartCheckFn = () => ({
       totalSessions: 0,
       inFlightCalls: 0,
@@ -103,6 +104,7 @@ describe("POST /restart endpoint", () => {
   });
 
   it("returns 202 when sessions exist but no tool calls are active", async () => {
+    server.restartKillFn = () => {}; // prevent SIGTERM during tests
     server.restartCheckFn = () => ({
       totalSessions: 3,
       inFlightCalls: 0,
@@ -122,17 +124,23 @@ describe("POST /restart endpoint", () => {
       busySessions: [],
     });
 
-    const req = http.request(
-      {
-        hostname: "127.0.0.1",
-        port,
-        path: "/restart",
-        method: "POST",
-      },
-      (res) => {
-        expect(res.statusCode).toBe(401);
-      },
-    );
-    req.end();
+    const res = await new Promise<{ status: number }>((resolve, reject) => {
+      const req = http.request(
+        {
+          hostname: "127.0.0.1",
+          port,
+          path: "/restart",
+          method: "POST",
+          // deliberately omit Authorization header
+        },
+        (res) => {
+          res.resume(); // drain so socket closes cleanly
+          resolve({ status: res.statusCode ?? 0 });
+        },
+      );
+      req.on("error", reject);
+      req.end();
+    });
+    expect(res.status).toBe(401);
   });
 });

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -1373,6 +1373,28 @@ export class Bridge {
       }
       return out;
     };
+    this.server.restartCheckFn = () => {
+      let totalSessions = 0;
+      let totalInFlight = 0;
+      const busySessions: string[] = [];
+
+      for (const [sid, session] of this.sessions) {
+        totalSessions++;
+        const stats = session.transport.getStats();
+        if (stats.activeToolCalls > 0) {
+          totalInFlight += stats.activeToolCalls;
+          busySessions.push(
+            `${sid.slice(0, 8)} (${stats.activeToolCalls} tool${stats.activeToolCalls === 1 ? "" : "s"}: ${stats.inFlightTools.join(", ")})`,
+          );
+        }
+      }
+
+      return {
+        totalSessions,
+        inFlightCalls: totalInFlight,
+        busySessions,
+      };
+    };
     this.server.tasksFn = () => ({
       tasks: (this.orchestrator?.list() ?? []).map((t) => ({
         taskId: t.id,

--- a/src/server.ts
+++ b/src/server.ts
@@ -508,6 +508,13 @@ export class Server extends EventEmitter<ServerEvents> {
     | null = null;
 
   /**
+   * Called when /restart decides it is safe to shut down. Defaults to
+   * `process.kill(process.pid, 'SIGTERM')`. Override in tests to a no-op so
+   * the Vitest runner process is not actually killed.
+   */
+  public restartKillFn: () => void = () => process.kill(process.pid, "SIGTERM");
+
+  /**
    * Attach an OAuth 2.0 Authorization Server.
    * When set, the bridge exposes:
    *   GET  /.well-known/oauth-authorization-server
@@ -2010,10 +2017,12 @@ export class Server extends EventEmitter<ServerEvents> {
           }),
         );
 
-        // Trigger SIGTERM after response is sent (100ms delay to ensure response delivery)
+        // Trigger shutdown after response is sent (100ms delay to ensure response delivery).
+        // Uses this.restartKillFn so tests can override without killing the runner.
+        const killFn = this.restartKillFn;
         setTimeout(() => {
           this.logger.info("[/restart] Sending SIGTERM to self");
-          process.kill(process.pid, "SIGTERM");
+          killFn();
         }, 100);
         return;
       }

--- a/src/server.ts
+++ b/src/server.ts
@@ -498,6 +498,15 @@ export class Server extends EventEmitter<ServerEvents> {
     | ((name: string, enabled: boolean) => { ok: boolean; error?: string })
     | null = null;
 
+  /** Set by bridge to check if restart is safe (no in-flight tool calls). */
+  public restartCheckFn:
+    | (() => {
+        totalSessions: number;
+        inFlightCalls: number;
+        busySessions: string[];
+      })
+    | null = null;
+
   /**
    * Attach an OAuth 2.0 Authorization Server.
    * When set, the bridge exposes:
@@ -1949,6 +1958,64 @@ export class Server extends EventEmitter<ServerEvents> {
           res.end(JSON.stringify(prefs));
           return;
         }
+      }
+
+      // /restart — graceful bridge restart endpoint.
+      // POST → triggers SIGTERM if no active work; returns 409 if busy.
+      // Safety checks: rejects restart if sessions have in-flight tool calls.
+      if (parsedUrl.pathname === "/restart" && req.method === "POST") {
+        if (!this.restartCheckFn) {
+          res.writeHead(503, { "Content-Type": "application/json" });
+          res.end(
+            JSON.stringify({
+              ok: false,
+              error: "restart_unavailable",
+              reason: "Restart endpoint not configured",
+            }),
+          );
+          return;
+        }
+
+        const check = this.restartCheckFn();
+
+        // Reject restart if there's active work
+        if (check.inFlightCalls > 0) {
+          this.logger.warn(
+            `[/restart] Rejected — ${check.inFlightCalls} in-flight tool call${check.inFlightCalls === 1 ? "" : "s"} across ${check.busySessions.length} session${check.busySessions.length === 1 ? "" : "s"}`,
+          );
+          res.writeHead(409, { "Content-Type": "application/json" });
+          res.end(
+            JSON.stringify({
+              ok: false,
+              error: "restart_blocked",
+              reason: `${check.inFlightCalls} tool call${check.inFlightCalls === 1 ? "" : "s"} in progress`,
+              activeSessions: check.totalSessions,
+              inFlightCalls: check.inFlightCalls,
+              busySessions: check.busySessions,
+            }),
+          );
+          return;
+        }
+
+        // Safe to restart — log and trigger SIGTERM
+        this.logger.info(
+          `[/restart] Initiating graceful restart — ${check.totalSessions} session${check.totalSessions === 1 ? "" : "s"}, 0 in-flight calls`,
+        );
+        res.writeHead(202, { "Content-Type": "application/json" });
+        res.end(
+          JSON.stringify({
+            ok: true,
+            message: "Restart initiated. Bridge will shut down gracefully.",
+            activeSessions: check.totalSessions,
+          }),
+        );
+
+        // Trigger SIGTERM after response is sent (100ms delay to ensure response delivery)
+        setTimeout(() => {
+          this.logger.info("[/restart] Sending SIGTERM to self");
+          process.kill(process.pid, "SIGTERM");
+        }, 100);
+        return;
       }
 
       // CC hook notify endpoint — lightweight alternative to full MCP session for hook wiring.


### PR DESCRIPTION
Add POST /restart endpoint that checks for in-flight tool calls before triggering SIGTERM. Dashboard settings page now shows a "Restart Required" card after driver changes with a button to restart the bridge.

Backend:
- Server.restartCheckFn callback checks sessions for activeToolCalls
- Returns 409 Conflict with busy session details if unsafe
- Triggers SIGTERM if safe to restart

Dashboard:
- Settings page calls /api/bridge/restart via bridge proxy
- Shows "Restart Required" card when driver changes
- Displays busy session details if restart blocked

Tests: src/__tests__/restart.test.ts
Docs: docs/restart-endpoint.md