### PR TITLE
fix(test): increase beforeEach timeout in gitWrite tests for Windows CI

### DIFF
--- a/src/tools/__tests__/gitWrite.test.ts
+++ b/src/tools/__tests__/gitWrite.test.ts
@@ -85,7 +85,7 @@ describe("gitWrite tools", () => {
       cwd: tmpDir,
       stdio: "ignore",
     });
-  });
+  }, 30_000);
 
   afterEach(() => {
     fs.rmSync(tmpDir, { recursive: true, force: true });


### PR DESCRIPTION
## Problem

CI is red on `ci (windows-latest, 22)`. The `gitWrite tools > gitAdd > stages a specified file` test fails because the `beforeEach` hook times out at 10 000 ms.

The hook runs 5 synchronous git commands (`git init`, 2× `git config`, `git add`, `git commit`) which are slow on Windows runners and consistently exceed the global `hookTimeout` configured in `vitest.config.ts`.

## Fix

Pass `30_000` as the second argument to `beforeEach`, which vitest accepts as a per-hook timeout override. No global config change — all other tests are unaffected.

## Testing

- All other 389 tests continue to pass (as shown in the failing CI log itself)
- Fix is a one-line change with zero production-code impact