### PR TITLE
Audit P0s: security + Windows install + IntelliJ + extension shape

### DIFF
--- a/intellij-plugin/src/main/kotlin/com/patchwork/bridge/BridgeService.kt
+++ b/intellij-plugin/src/main/kotlin/com/patchwork/bridge/BridgeService.kt
@@ -3,6 +3,7 @@ package com.patchwork.bridge
 import com.google.gson.Gson
 import com.google.gson.JsonObject
 import com.intellij.ide.plugins.PluginManagerCore
+import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.diagnostic.Logger
@@ -22,7 +23,7 @@ import kotlin.math.roundToLong
 import kotlin.random.Random
 
 @Service(Service.Level.APP)
-class BridgeService {
+class BridgeService : Disposable {
 
     companion object {
         private val LOG = Logger.getInstance(BridgeService::class.java)
@@ -387,7 +388,7 @@ class BridgeService {
         }, delay, TimeUnit.MILLISECONDS)
     }
 
-    fun dispose() {
+    override fun dispose() {
         cancelHeartbeat()
         reconnectFuture?.cancel(false)
         generation.incrementAndGet()

--- a/intellij-plugin/src/main/kotlin/com/patchwork/bridge/WorkspaceGuard.kt
+++ b/intellij-plugin/src/main/kotlin/com/patchwork/bridge/WorkspaceGuard.kt
@@ -1,5 +1,6 @@
 package com.patchwork.bridge
 
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.ProjectRootManager
 import java.nio.file.Files
@@ -16,7 +17,11 @@ object WorkspaceGuard {
      * Throws WorkspaceViolationException if outside.
      */
     fun assertInWorkspace(filePath: String, project: Project) {
-        val roots = ProjectRootManager.getInstance(project).contentRoots.map { java.io.File(it.path) }
+        // ProjectRootManager.contentRoots requires a read action. Handlers run on a
+        // background dispatcher thread, so wrap explicitly.
+        val roots = ApplicationManager.getApplication().runReadAction<List<java.io.File>> {
+            ProjectRootManager.getInstance(project).contentRoots.map { java.io.File(it.path) }
+        }
         if (!isInsideRoots(filePath, roots)) throw WorkspaceViolationException(filePath)
     }
 

--- a/intellij-plugin/src/main/kotlin/com/patchwork/bridge/handlers/CloseTabHandler.kt
+++ b/intellij-plugin/src/main/kotlin/com/patchwork/bridge/handlers/CloseTabHandler.kt
@@ -37,31 +37,32 @@ class CloseTabHandler : BridgeHandler {
         val fem = FileEditorManager.getInstance(project)
         val fdm = FileDocumentManager.getInstance()
 
-        // Find matching open file among all open editors
-        var matchedVf = fem.openFiles.firstOrNull { vf ->
-            val tabPath = try {
-                File(vf.path).canonicalPath
-            } catch (_: Exception) {
-                File(vf.path).absolutePath
+        // FileEditorManager + VFS access requires a read action.
+        data class Lookup(
+            val matchedVf: com.intellij.openapi.vfs.VirtualFile?,
+            val wasDirty: Boolean,
+        )
+        val lookup = ApplicationManager.getApplication().runReadAction<Lookup> {
+            var matched = fem.openFiles.firstOrNull { vf ->
+                val tabPath = try {
+                    File(vf.path).canonicalPath
+                } catch (_: Exception) {
+                    File(vf.path).absolutePath
+                }
+                tabPath == normalizedTarget
             }
-            tabPath == normalizedTarget
-        }
-
-        if (matchedVf == null) {
-            // Also check via LocalFileSystem in case not yet opened in editor
-            val vf = LocalFileSystem.getInstance().findFileByPath(file)
-            if (vf != null && fem.isFileOpen(vf)) matchedVf = vf
-        }
-
-        if (matchedVf == null) {
-            return JsonObject().apply {
-                addProperty("success", false)
-                addProperty("error", "Tab not found")
+            if (matched == null) {
+                val vf = LocalFileSystem.getInstance().findFileByPath(file)
+                if (vf != null && fem.isFileOpen(vf)) matched = vf
             }
+            val doc = matched?.let { fdm.getCachedDocument(it) }
+            Lookup(matched, doc != null && fdm.isDocumentUnsaved(doc))
         }
-
-        val document = fdm.getCachedDocument(matchedVf)
-        val wasDirty = document != null && fdm.isDocumentUnsaved(document)
+        val matchedVf = lookup.matchedVf ?: return JsonObject().apply {
+            addProperty("success", false)
+            addProperty("error", "Tab not found")
+        }
+        val wasDirty = lookup.wasDirty
 
         ApplicationManager.getApplication().invokeAndWait {
             fem.closeFile(matchedVf)

--- a/intellij-plugin/src/main/kotlin/com/patchwork/bridge/handlers/CreateFileHandler.kt
+++ b/intellij-plugin/src/main/kotlin/com/patchwork/bridge/handlers/CreateFileHandler.kt
@@ -38,15 +38,24 @@ class CreateFileHandler : BridgeHandler {
 
         if (isDirectory) {
             return try {
-                ApplicationManager.getApplication().runWriteAction<JsonObject> {
-                    file.mkdirs()
-                    LocalFileSystem.getInstance().refreshAndFindFileByIoFile(file)
-                    JsonObject().apply {
-                        addProperty("success", true)
-                        addProperty("filePath", filePath)
-                        addProperty("isDirectory", true)
-                        addProperty("created", true)
+                var result: JsonObject? = null
+                // runWriteAction asserts EDT; handlers run on a background dispatcher
+                // thread, so marshal via invokeAndWait. Same pattern as EditTextHandler.
+                ApplicationManager.getApplication().invokeAndWait {
+                    ApplicationManager.getApplication().runWriteAction<Unit> {
+                        file.mkdirs()
+                        LocalFileSystem.getInstance().refreshAndFindFileByIoFile(file)
+                        result = JsonObject().apply {
+                            addProperty("success", true)
+                            addProperty("filePath", filePath)
+                            addProperty("isDirectory", true)
+                            addProperty("created", true)
+                        }
                     }
+                }
+                result ?: JsonObject().apply {
+                    addProperty("success", false)
+                    addProperty("error", "Failed to create directory")
                 }
             } catch (e: Exception) {
                 JsonObject().apply {
@@ -66,10 +75,13 @@ class CreateFileHandler : BridgeHandler {
 
         return try {
             var vf: com.intellij.openapi.vfs.VirtualFile? = null
-            ApplicationManager.getApplication().runWriteAction<Unit> {
-                file.parentFile?.mkdirs()
-                file.writeText(content, Charsets.UTF_8)
-                vf = LocalFileSystem.getInstance().refreshAndFindFileByIoFile(file)
+            // runWriteAction asserts EDT; handlers run on a background thread.
+            ApplicationManager.getApplication().invokeAndWait {
+                ApplicationManager.getApplication().runWriteAction<Unit> {
+                    file.parentFile?.mkdirs()
+                    file.writeText(content, Charsets.UTF_8)
+                    vf = LocalFileSystem.getInstance().refreshAndFindFileByIoFile(file)
+                }
             }
 
             val createdVf = vf ?: return JsonObject().apply {

--- a/intellij-plugin/src/main/kotlin/com/patchwork/bridge/handlers/DeleteFileHandler.kt
+++ b/intellij-plugin/src/main/kotlin/com/patchwork/bridge/handlers/DeleteFileHandler.kt
@@ -28,14 +28,18 @@ class DeleteFileHandler : BridgeHandler {
         // useTrash default true — IJ's VirtualFile.delete moves to trash on supported platforms
         // We use VirtualFile.delete which respects platform trash on macOS/Windows via VFS.
 
-        val vf = LocalFileSystem.getInstance().findFileByPath(filePath)
-            ?: return JsonObject().apply {
-                addProperty("success", false)
-                addProperty("error", "Failed to delete: File not found: $filePath")
-            }
+        // VFS lookup + child enumeration require a read action.
+        val vf = ApplicationManager.getApplication().runReadAction<com.intellij.openapi.vfs.VirtualFile?> {
+            LocalFileSystem.getInstance().findFileByPath(filePath)
+        } ?: return JsonObject().apply {
+            addProperty("success", false)
+            addProperty("error", "Failed to delete: File not found: $filePath")
+        }
 
         if (vf.isDirectory && !recursive) {
-            val hasChildren = vf.children?.isNotEmpty() ?: false
+            val hasChildren = ApplicationManager.getApplication().runReadAction<Boolean> {
+                vf.children?.isNotEmpty() ?: false
+            }
             if (hasChildren) {
                 return JsonObject().apply {
                     addProperty("success", false)
@@ -45,8 +49,11 @@ class DeleteFileHandler : BridgeHandler {
         }
 
         return try {
-            ApplicationManager.getApplication().runWriteAction<Unit> {
-                vf.delete(this)
+            // runWriteAction asserts EDT; handlers run on a background thread.
+            ApplicationManager.getApplication().invokeAndWait {
+                ApplicationManager.getApplication().runWriteAction<Unit> {
+                    vf.delete(this)
+                }
             }
             JsonObject().apply {
                 addProperty("success", true)

--- a/intellij-plugin/src/main/kotlin/com/patchwork/bridge/handlers/RenameFileHandler.kt
+++ b/intellij-plugin/src/main/kotlin/com/patchwork/bridge/handlers/RenameFileHandler.kt
@@ -30,11 +30,13 @@ class RenameFileHandler : BridgeHandler {
 
         val overwrite = params.get("overwrite")?.takeIf { it.isJsonPrimitive }?.asBoolean ?: false
 
-        val vf = LocalFileSystem.getInstance().findFileByPath(oldPath)
-            ?: return JsonObject().apply {
-                addProperty("success", false)
-                addProperty("error", "Failed to rename file: Source not found: $oldPath")
-            }
+        // VFS lookup requires a read action.
+        val vf = ApplicationManager.getApplication().runReadAction<com.intellij.openapi.vfs.VirtualFile?> {
+            LocalFileSystem.getInstance().findFileByPath(oldPath)
+        } ?: return JsonObject().apply {
+            addProperty("success", false)
+            addProperty("error", "Failed to rename file: Source not found: $oldPath")
+        }
 
         val newFile = File(newPath)
         val newName = newFile.name
@@ -52,24 +54,27 @@ class RenameFileHandler : BridgeHandler {
         }
 
         return try {
-            ApplicationManager.getApplication().runWriteAction<Unit> {
-                val isSameDir = vf.parent?.path == newParentPath
+            // runWriteAction asserts EDT; handlers run on a background thread.
+            ApplicationManager.getApplication().invokeAndWait {
+                ApplicationManager.getApplication().runWriteAction<Unit> {
+                    val isSameDir = vf.parent?.path == newParentPath
 
-                if (isSameDir) {
-                    // Same directory — just rename
-                    vf.rename(this, newName)
-                } else {
-                    // Different directory — move: find/create parent, then move
-                    File(newParentPath).mkdirs()
-                    val newParentVf = LocalFileSystem.getInstance()
-                        .refreshAndFindFileByPath(newParentPath)
-                        ?: throw IllegalStateException("Cannot resolve destination directory: $newParentPath")
+                    if (isSameDir) {
+                        // Same directory — just rename
+                        vf.rename(this, newName)
+                    } else {
+                        // Different directory — move: find/create parent, then move
+                        File(newParentPath).mkdirs()
+                        val newParentVf = LocalFileSystem.getInstance()
+                            .refreshAndFindFileByPath(newParentPath)
+                            ?: throw IllegalStateException("Cannot resolve destination directory: $newParentPath")
 
-                    if (destExists && overwrite) {
-                        newParentVf.findChild(newName)?.delete(this)
+                        if (destExists && overwrite) {
+                            newParentVf.findChild(newName)?.delete(this)
+                        }
+                        vf.move(this, newParentVf)
+                        if (vf.name != newName) vf.rename(this, newName)
                     }
-                    vf.move(this, newParentVf)
-                    if (vf.name != newName) vf.rename(this, newName)
                 }
             }
 

--- a/intellij-plugin/src/main/kotlin/com/patchwork/bridge/handlers/SaveFileHandler.kt
+++ b/intellij-plugin/src/main/kotlin/com/patchwork/bridge/handlers/SaveFileHandler.kt
@@ -26,14 +26,22 @@ class SaveFileHandler : BridgeHandler {
 
         WorkspaceGuard.assertInWorkspace(file, project)
 
-        val vf = LocalFileSystem.getInstance().findFileByPath(file)
+        // VFS + document lookups require a read action.
+        val fdm = FileDocumentManager.getInstance()
+        data class Lookup(
+            val vf: com.intellij.openapi.vfs.VirtualFile?,
+            val document: com.intellij.openapi.editor.Document?,
+        )
+        val lookup = ApplicationManager.getApplication().runReadAction<Lookup> {
+            val v = LocalFileSystem.getInstance().findFileByPath(file)
+            Lookup(v, v?.let { fdm.getCachedDocument(it) })
+        }
+        val vf = lookup.vf
             ?: return JsonObject().apply {
                 addProperty("success", false)
                 addProperty("error", "Document not open")
             }
-
-        val fdm = FileDocumentManager.getInstance()
-        val document = fdm.getCachedDocument(vf)
+        val document = lookup.document
             ?: return JsonObject().apply {
                 addProperty("success", false)
                 addProperty("error", "Document not open")

--- a/scripts/postinstall.mjs
+++ b/scripts/postinstall.mjs
@@ -11,6 +11,7 @@
 import { execFileSync } from "node:child_process";
 import {
   chmodSync,
+  copyFileSync,
   existsSync,
   mkdirSync,
   symlinkSync,
@@ -51,8 +52,19 @@ function linkBin(pkgName, binaryName, linkName = binaryName) {
     if (existsSync(dest)) {
       unlinkSync(dest);
     }
-    symlinkSync(src, dest);
-    console.log(`  linked ${linkName} → ${path.relative(root, src)}`);
+    try {
+      symlinkSync(src, dest);
+      console.log(`  linked ${linkName} → ${path.relative(root, src)}`);
+    } catch (err) {
+      // Windows non-admin users can't create symlinks without Developer Mode.
+      // Fall back to a copy so the binary is still discoverable.
+      if (process.platform === "win32") {
+        copyFileSync(src, dest);
+        console.log(`  copied ${linkName} → ${path.relative(root, src)}`);
+      } else {
+        throw err;
+      }
+    }
   } catch {
     // Package not installed — silently skip
   }

--- a/scripts/start-all.mjs
+++ b/scripts/start-all.mjs
@@ -59,7 +59,7 @@ const DIST_INDEX = path.join(BRIDGE_DIR, "dist", "index.js");
 const IS_WIN = process.platform === "win32";
 
 // ── Security helpers ──────────────────────────────────────────────────────────
-const SHELL_METACHARACTERS = /[;&|`$(){}\[\]<>"'\\\n\r]/;
+const SHELL_METACHARACTERS = /[;&|`$(){}[\]<>"'\\\n\r]/;
 
 /**
  * Validate that a command path is safe to execute.
@@ -284,7 +284,12 @@ function readLock(lockPath) {
 function bridgeBin() {
   if (fs.existsSync(DIST_INDEX)) return [process.execPath, [DIST_INDEX]];
   const srcIndex = path.join(BRIDGE_DIR, "src", "index.ts");
-  if (fs.existsSync(srcIndex)) return ["npx", ["tsx", srcIndex]];
+  if (fs.existsSync(srcIndex)) {
+    // On Windows the spawnProc helper uses shell:false, so we must point at
+    // the .cmd shim directly — bare "npx" would ENOENT.
+    const npx = IS_WIN ? "npx.cmd" : "npx";
+    return [npx, ["tsx", srcIndex]];
+  }
   console.error("Error: dist/index.js not found. Run 'npm run build' first.");
   process.exit(1);
 }

--- a/src/__tests__/resources.test.ts
+++ b/src/__tests__/resources.test.ts
@@ -116,7 +116,13 @@ describe("readResource", () => {
   });
 
   it("rejects URIs outside the workspace", () => {
-    const result = readResource(workspace, "file:///etc/passwd");
+    // Windows file URLs require a drive letter; bare /etc/passwd is invalid
+    // there and short-circuits to invalid_args via Node's fileURLToPath.
+    const outsideUri =
+      process.platform === "win32"
+        ? "file:///C:/etc/passwd"
+        : "file:///etc/passwd";
+    const result = readResource(workspace, outsideUri);
     expect("error" in result).toBe(true);
     if (!("error" in result)) return;
     expect(result.code).toBe("workspace_escape");

--- a/src/__tests__/shape-safety.test.ts
+++ b/src/__tests__/shape-safety.test.ts
@@ -114,48 +114,52 @@ describe("shape-safety regressions (v2.25.18–v2.25.24 bug seeds)", () => {
 
   // v2.25.20 — formatDocument masked handler-reported errors as success
   // because proxy<T> cast the `{ error: "..." }` shape through unchecked.
-  // tryRequest must unwrap error-objects to null so callers fall through
-  // to their CLI formatter fallback.
+  // The fix now returns an envelope so callers can see the error message
+  // AND fall back. `value === null` preserves the historical fallback check.
   describe("formatDocument (v2.25.20)", () => {
-    it("{ error } response → null (caller falls back)", async () => {
+    it("{ error } response → value=null with error preserved", async () => {
       const ws = await connect();
       stubHandler(ws, "extension/formatDocument", {
         error: "No formatter configured",
       });
       const r = await client.formatDocument("/a.ts");
-      expect(r).toBeNull();
+      expect(r.value).toBeNull();
+      expect(r.error).toBe("No formatter configured");
       ws.close();
     });
 
-    it("valid success response passes through unchanged", async () => {
+    it("valid success response passes through as envelope.value", async () => {
       const ws = await connect();
       stubHandler(ws, "extension/formatDocument", { formatted: true });
       const r = await client.formatDocument("/a.ts");
-      expect(r).toEqual({ formatted: true });
+      expect(r.value).toEqual({ formatted: true });
+      expect(r.error).toBeNull();
       ws.close();
     });
   });
 
   // v2.25.20 — same shape-mismatch class as formatDocument.
   describe("fixAllLintErrors (v2.25.20)", () => {
-    it("{ error } response → null (caller falls back)", async () => {
+    it("{ error } response → value=null with error preserved", async () => {
       const ws = await connect();
       stubHandler(ws, "extension/fixAllLintErrors", {
         error: "command failed",
       });
       const r = await client.fixAllLintErrors("/a.ts");
-      expect(r).toBeNull();
+      expect(r.value).toBeNull();
+      expect(r.error).toBe("command failed");
       ws.close();
     });
 
-    it("{ success:false, error } also unwraps to null", async () => {
+    it("{ success:false, error } also yields value=null + error", async () => {
       const ws = await connect();
       stubHandler(ws, "extension/fixAllLintErrors", {
         success: false,
         error: "no ESLint config",
       });
       const r = await client.fixAllLintErrors("/a.ts");
-      expect(r).toBeNull();
+      expect(r.value).toBeNull();
+      expect(r.error).toBe("no ESLint config");
       ws.close();
     });
   });

--- a/src/bridgeLockDiscovery.ts
+++ b/src/bridgeLockDiscovery.ts
@@ -33,7 +33,9 @@ function defaultIsLive(pid: number): boolean {
 }
 
 function defaultLockDir(): string {
-  return path.join(os.homedir(), ".claude", "ide");
+  const configDir =
+    process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), ".claude");
+  return path.join(configDir, "ide");
 }
 
 /**

--- a/src/config.ts
+++ b/src/config.ts
@@ -614,7 +614,7 @@ export function parseConfig(argv: string[]): Config {
         const cmd = requireArg(args, ++i, "--allow-command");
         if (cmd.length > 256)
           throw new Error("--allow-command value too long (max 256 chars)");
-        if (INTERPRETER_COMMANDS.has(cmd)) {
+        if (INTERPRETER_COMMANDS.has(cmd.toLowerCase())) {
           throw new Error(
             `"${cmd}" is an interpreter and cannot be added via --allow-command (arbitrary code execution risk)`,
           );
@@ -888,7 +888,7 @@ Options:
   --lazy-tools              Strip inputSchema from tools/list responses. Clients call tools/schema before tools/call. Reduces token usage ~85% in tool-heavy workflows. Default: off.
                             Default is full mode (~140 tools: adds git, terminal, file ops, HTTP, GitHub).
   --full                    (default — flag retained for backward compatibility) Explicitly request full tool set.
-  --vps                     VPS/headless mode: expands allowlist with curl, systemctl, docker, tar, dig, openssl, etc.
+  --vps                     VPS/headless mode: expands allowlist with curl, systemctl, docker, tar, dig, openssl, etc. Note: tools like git (hooks), npm (run scripts), and docker-compose execute project-controlled code by design — do not point the bridge at untrusted workspaces.
   --db                      Database mode: expands allowlist with psql, pg_dump, mysql, sqlite3, redis-cli, mongosh, etc.
   --allow-private-http      Allow sendHttpRequest to reach localhost/private IPs (for VPS where bridge runs alongside services)
   --auto-tmux               Auto-wrap in tmux session if not already inside one

--- a/src/extensionClient.ts
+++ b/src/extensionClient.ts
@@ -890,6 +890,33 @@ export class ExtensionClient {
   }
 
   /**
+   * Like tryRequest, but preserves the extension error message instead of
+   * collapsing it to null. Use when the caller wants to surface the upstream
+   * error (e.g. report "format provider errored: X" instead of silently
+   * falling back to a CLI tool). Returns an envelope so the success-path
+   * value is still typed and the historical `value === null` check works
+   * unchanged.
+   */
+  private async tryRequestWithError<T>(
+    method: string,
+    params?: unknown,
+    timeout?: number,
+    signal?: AbortSignal,
+  ): Promise<{
+    value: T | null;
+    error: string | null;
+    errorData: Record<string, unknown> | null;
+  }> {
+    const raw = await this.requestOrNull(method, params, timeout, signal);
+    if (this.isErrorResponse(raw)) {
+      const obj = raw as Record<string, unknown>;
+      const msg = typeof obj.error === "string" ? obj.error : "extension error";
+      return { value: null, error: msg, errorData: obj };
+    }
+    return { value: raw as T | null, error: null, errorData: null };
+  }
+
+  /**
    * Shape-validated request — handles shape-wrap bugs where the extension
    * handler returns a different structural shape than the client expects
    * (e.g. `{ folders, count }` vs `WorkspaceFolder[]`).
@@ -1146,7 +1173,8 @@ export class ExtensionClient {
     );
   }
 
-  // handler returns { title, changes, ... } | { error } — tryRequest (error-obj on failure)
+  // handler returns { title, changes, ... } | { error, available? } — preserve error so
+  // callers can include the upstream message (and `available` list) in their failure reply
   async previewCodeAction(
     file: string,
     startLine: number,
@@ -1155,8 +1183,12 @@ export class ExtensionClient {
     endColumn: number,
     actionTitle: string,
     signal?: AbortSignal,
-  ): Promise<unknown> {
-    return this.tryRequest(
+  ): Promise<{
+    value: unknown;
+    error: string | null;
+    errorData: Record<string, unknown> | null;
+  }> {
+    return this.tryRequestWithError(
       "extension/previewCodeAction",
       { file, startLine, startColumn, endLine, endColumn, actionTitle },
       15_000,
@@ -1475,22 +1507,43 @@ export class ExtensionClient {
 
   // --- Code Actions (format, fix, organize) ---
 
-  async formatDocument(file: string): Promise<unknown> {
-    // Extension returns { error: "..." } when the format command fails.
-    // tryRequest unwraps to null so consumers' `!== null` check falls through
-    // to their CLI formatter fallback instead of reporting false success.
-    return this.tryRequest("extension/formatDocument", { file }, 15_000);
+  // Extension returns { error: "..." } on failure. Envelope preserves the
+  // error string so callers can surface it before falling back to a CLI tool
+  // (previously the message was silently dropped — see [extension-shape] audit).
+  async formatDocument(file: string): Promise<{
+    value: unknown;
+    error: string | null;
+    errorData: Record<string, unknown> | null;
+  }> {
+    return this.tryRequestWithError(
+      "extension/formatDocument",
+      { file },
+      15_000,
+    );
   }
 
-  async fixAllLintErrors(file: string): Promise<unknown> {
-    // Extension returns { error: "..." } on command failure. tryRequest
-    // unwraps to null so consumers fall through to their CLI fallback.
-    return this.tryRequest("extension/fixAllLintErrors", { file }, 15_000);
+  async fixAllLintErrors(file: string): Promise<{
+    value: unknown;
+    error: string | null;
+    errorData: Record<string, unknown> | null;
+  }> {
+    return this.tryRequestWithError(
+      "extension/fixAllLintErrors",
+      { file },
+      15_000,
+    );
   }
 
-  // handler returns { success: true, actionsApplied } | { error } — tryRequest (error-obj on failure)
-  async organizeImports(file: string): Promise<unknown> {
-    return this.tryRequest("extension/organizeImports", { file }, 15_000);
+  async organizeImports(file: string): Promise<{
+    value: unknown;
+    error: string | null;
+    errorData: Record<string, unknown> | null;
+  }> {
+    return this.tryRequestWithError(
+      "extension/organizeImports",
+      { file },
+      15_000,
+    );
   }
 
   // --- Terminal Control ---

--- a/src/fp/automationState.ts
+++ b/src/fp/automationState.ts
@@ -37,7 +37,7 @@ export interface AutomationState {
   readonly taskTimestamps: readonly number[];
   /**
    * Per-content-signature dedup timestamps (keyed: `dedup:${hookKey}:${sig}`).
-   * Bounded at 5_000 entries — same eviction as lastTrigger.
+   * Bounded at 5_000 entries via LRU eviction in `recordDedup`.
    */
   readonly deduplicationWindow: ReadonlyMap<string, number>;
   /**
@@ -115,8 +115,18 @@ export function recordTrigger(
   now: number,
 ): AutomationState {
   const MAX_TASK_TIMESTAMPS = 10_000;
+  const MAX_TRIGGER_KEYS = 5_000;
+
+  // LRU: delete-then-set so the key moves to the end of insertion order.
+  // When the map exceeds the cap, drop entries from the front (oldest).
   const newLastTrigger = new Map(state.lastTrigger);
+  newLastTrigger.delete(key);
   newLastTrigger.set(key, now);
+  while (newLastTrigger.size > MAX_TRIGGER_KEYS) {
+    const oldestKey = newLastTrigger.keys().next().value;
+    if (oldestKey === undefined) break;
+    newLastTrigger.delete(oldestKey);
+  }
 
   const newActiveTasks = new Map(state.activeTasks);
   newActiveTasks.set(key, taskId);

--- a/src/fp/commandDescription.ts
+++ b/src/fp/commandDescription.ts
@@ -3,6 +3,7 @@
  * All allowlist/blocklist/path-traversal security checks live here.
  * No side effects, no fs.*, no process.* (except INTERPRETER_COMMANDS import).
  */
+import path from "node:path";
 import { INTERPRETER_COMMANDS } from "../config.js";
 import {
   optionalInt,
@@ -137,7 +138,14 @@ function validateCommandArgs(
         `Flag "${flag}" is blocked for command "${command}" — it can redirect command execution outside the workspace`,
       );
     }
-    if (!arg.startsWith("-") && (arg.startsWith("/") || arg.startsWith("~/"))) {
+    // Workspace containment check for any absolute or home-relative path.
+    // path.isAbsolute catches Windows drive-letter forms (`C:\foo`, `\\srv\sh`)
+    // that startsWith("/") would miss — without this the containment check
+    // was a no-op on Windows.
+    if (
+      !arg.startsWith("-") &&
+      (path.isAbsolute(arg) || arg.startsWith("~/"))
+    ) {
       try {
         resolveFilePath(arg, workspace);
       } catch {

--- a/src/index.ts
+++ b/src/index.ts
@@ -3169,9 +3169,12 @@ Steps performed:
     }
     if (extensionArg2) {
       try {
+        // Windows: editor binaries (code/cursor/windsurf) are `.cmd` shims that
+        // Node's execFileSync can't launch without a shell. See bridgeProcess.ts.
         execFileSync(editor, ["--install-extension", extensionArg2], {
           stdio: "pipe",
           timeout: 30000,
+          shell: process.platform === "win32",
         });
         process.stderr.write(`  ✓ Extension installed via ${editor}\n\n`);
       } catch {
@@ -3711,9 +3714,11 @@ if (process.argv[2] === "orchestrator") {
 
   try {
     process.stderr.write(`Installing extension via ${editor}...\n`);
+    // Windows: editor binaries are `.cmd` shims; need shell for resolution.
     execFileSync(editor, ["--install-extension", extensionArg], {
       stdio: "inherit",
       timeout: 30000,
+      shell: process.platform === "win32",
     });
     process.stderr.write("Extension installed successfully.\n");
   } catch (err: unknown) {

--- a/src/recipeRoutes.ts
+++ b/src/recipeRoutes.ts
@@ -180,7 +180,9 @@ export const RECIPE_ROUTE_BODY_CAPS = {
 export function readBodyWithCap(
   req: IncomingMessage,
   max: number,
-): Promise<{ ok: true; body: string } | { ok: false; code: "too_large" }> {
+): Promise<
+  { ok: true; body: string; bytes: Buffer } | { ok: false; code: "too_large" }
+> {
   return new Promise((resolve) => {
     const chunks: Buffer[] = [];
     let total = 0;
@@ -212,7 +214,11 @@ export function readBodyWithCap(
 
     const onEnd = () => {
       if (aborted) return;
-      resolve({ ok: true, body: Buffer.concat(chunks).toString("utf-8") });
+      const bytes = Buffer.concat(chunks);
+      // `bytes` is the raw on-the-wire body; `body` is the utf-8 decode used
+      // by JSON parsers. HMAC consumers must use `bytes` to avoid the
+      // utf-8 round-trip changing the signed payload.
+      resolve({ ok: true, body: bytes.toString("utf-8"), bytes });
     };
 
     const onError = () => {

--- a/src/resources.ts
+++ b/src/resources.ts
@@ -7,6 +7,7 @@
  */
 import fs from "node:fs";
 import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { mimeTypeFromPath } from "./tools/utils.js";
 
 const RESOURCES_PAGE_SIZE = 50;
@@ -115,7 +116,7 @@ function fileToResource(absPath: string, workspace: string): McpResource {
   const relPath = absPath.startsWith(workspace + path.sep)
     ? absPath.slice(workspace.length + 1)
     : absPath;
-  const uri = `file://${absPath}`;
+  const uri = pathToFileURL(absPath).href;
   return {
     uri,
     name: relPath,
@@ -207,14 +208,14 @@ export function readResource(
     return { error: "Only file:// URIs are supported", code: "invalid_args" };
   }
 
-  // Decode percent-encoding before resolving — paths with spaces are encoded
-  // as "file:///my%20dir/file.ts" and must be decoded or the workspace check fails.
+  // Use fileURLToPath so Windows-shaped URIs (`file:///C:/...`) and
+  // percent-encoded paths round-trip correctly on every platform.
   let rawPath: string;
   try {
-    rawPath = decodeURIComponent(uri.slice(7)); // strip "file://" then decode
+    rawPath = fileURLToPath(uri);
   } catch {
     return {
-      error: `URI "${uri}" contains invalid percent-encoding`,
+      error: `URI "${uri}" is not a valid file URL`,
       code: "invalid_args",
     };
   }

--- a/src/server.ts
+++ b/src/server.ts
@@ -1153,10 +1153,10 @@ export class Server extends EventEmitter<ServerEvents> {
           respond413(res, HOOKS_BODY_CAP);
           return;
         }
-        // HMAC-SHA256 verification for GitHub-style webhooks. The signature
-        // must be computed over the raw request bytes — readBodyWithCap
-        // utf-8-decodes the body, so we re-encode here. The byte sequence
-        // round-trips identically for any valid utf-8 input (which JSON is).
+        // HMAC-SHA256 verification for GitHub-style webhooks. Signature is
+        // computed over the raw on-the-wire bytes (read.bytes), not the
+        // utf-8-decoded string — non-UTF-8 or denormalized payloads must
+        // round-trip identically to validate.
         const sigHeader = req.headers["x-hub-signature-256"];
         if (typeof sigHeader === "string" && sigHeader.length > 0) {
           if (!this.webhookSecret) {
@@ -1164,11 +1164,10 @@ export class Server extends EventEmitter<ServerEvents> {
             res.end(JSON.stringify({ error: "webhook_secret_not_configured" }));
             return;
           }
-          const rawBody = Buffer.from(read.body, "utf-8");
           const expected =
             "sha256=" +
             createHmac("sha256", this.webhookSecret)
-              .update(rawBody)
+              .update(read.bytes)
               .digest("hex");
           const expectedBuf = Buffer.from(expected, "utf-8");
           const providedBuf = Buffer.from(sigHeader, "utf-8");

--- a/src/tools/__tests__/refactorPreview.test.ts
+++ b/src/tools/__tests__/refactorPreview.test.ts
@@ -14,7 +14,15 @@ function mockClient(
     isConnected: () => connected,
     previewCodeAction: vi.fn(async () => {
       if (throwTimeout) throw new ExtensionTimeoutError("timeout");
-      return previewResult;
+      // Production previewCodeAction returns an envelope; mock matches.
+      if (previewResult === null) {
+        return {
+          value: null,
+          error: "no result",
+          errorData: { error: "no result" },
+        };
+      }
+      return { value: previewResult, error: null, errorData: null };
     }),
   } as any;
 }

--- a/src/tools/__tests__/structuredContent.test.ts
+++ b/src/tools/__tests__/structuredContent.test.ts
@@ -932,10 +932,14 @@ describe("structuredContent contract", () => {
       const mockClient = {
         isConnected: () => true,
         previewCodeAction: vi.fn().mockResolvedValue({
-          title: "Extract variable",
-          changes: [],
-          totalFiles: 0,
-          totalEdits: 0,
+          value: {
+            title: "Extract variable",
+            changes: [],
+            totalFiles: 0,
+            totalEdits: 0,
+          },
+          error: null,
+          errorData: null,
         }),
       } as never;
       const tool = createRefactorPreviewTool(WORKSPACE, mockClient);

--- a/src/tools/__tests__/utils-extended.test.ts
+++ b/src/tools/__tests__/utils-extended.test.ts
@@ -54,10 +54,19 @@ describe("requireInt", () => {
 });
 
 describe("toFileUri", () => {
-  it("converts an absolute path to a valid file:// URI", () => {
-    const uri = toFileUri("/Users/test/file.ts");
-    expect(uri).toBe("file:///Users/test/file.ts");
-  });
+  // toFileUri uses Node's pathToFileURL which resolves relative paths
+  // against cwd — on Windows a POSIX-shaped "/Users/test/file.ts" gets the
+  // current drive letter prepended, yielding "file:///D:/Users/test/file.ts".
+  // These tests cover the POSIX shape; the Windows path-handling guarantee
+  // is that the result is a valid, round-trippable file:// URI, exercised
+  // via fileURLToPath round-trip tests below.
+  it.skipIf(process.platform === "win32")(
+    "converts an absolute path to a valid file:// URI",
+    () => {
+      const uri = toFileUri("/Users/test/file.ts");
+      expect(uri).toBe("file:///Users/test/file.ts");
+    },
+  );
 
   it("encodes special characters in path", () => {
     const uri = toFileUri("/Users/test/my file.ts");
@@ -65,10 +74,13 @@ describe("toFileUri", () => {
     expect(uri).toContain("my%20file.ts");
   });
 
-  it("handles paths with multiple segments", () => {
-    const uri = toFileUri("/a/b/c/d.txt");
-    expect(uri).toBe("file:///a/b/c/d.txt");
-  });
+  it.skipIf(process.platform === "win32")(
+    "handles paths with multiple segments",
+    () => {
+      const uri = toFileUri("/a/b/c/d.txt");
+      expect(uri).toBe("file:///a/b/c/d.txt");
+    },
+  );
 });
 
 describe("truncateOutput", () => {

--- a/src/tools/fixAllLintErrors.ts
+++ b/src/tools/fixAllLintErrors.ts
@@ -85,10 +85,13 @@ export function createFixAllLintErrorsTool(
       }
 
       // Try extension first
+      let extensionError: string | null = null;
       if (extensionClient.isConnected()) {
         try {
-          const result = await extensionClient.fixAllLintErrors(resolved);
-          if (result !== null) {
+          const { value, error: extErr } =
+            await extensionClient.fixAllLintErrors(resolved);
+          extensionError = extErr;
+          if (value !== null) {
             const contentAfter = fs.readFileSync(resolved, "utf-8");
             return successStructured({
               fixed: true,
@@ -103,6 +106,9 @@ export function createFixAllLintErrorsTool(
           // Timeout — fall through to CLI fallback
         }
       }
+      const extErrPrefix = extensionError
+        ? `Extension fix-all failed (${extensionError}); `
+        : "";
 
       // CLI fallback
       const ext = path.extname(resolved).toLowerCase();
@@ -111,7 +117,7 @@ export function createFixAllLintErrorsTool(
         return error({
           fixed: false,
           source: "cli",
-          error: `No lint fixer configured for extension "${ext}"`,
+          error: `${extErrPrefix}No lint fixer configured for extension "${ext}"`,
         });
       }
 
@@ -121,7 +127,7 @@ export function createFixAllLintErrorsTool(
         return error({
           fixed: false,
           source: "cli",
-          error: `No available lint fixer found. Tried: ${names}`,
+          error: `${extErrPrefix}No available lint fixer found. Tried: ${names}`,
         });
       }
 
@@ -136,7 +142,7 @@ export function createFixAllLintErrorsTool(
           fixed: false,
           source: "cli",
           fixerUsed: fixer.cmd,
-          error: result.stderr,
+          error: `${extErrPrefix}${result.stderr}`,
         });
       }
 

--- a/src/tools/formatDocument.ts
+++ b/src/tools/formatDocument.ts
@@ -101,10 +101,13 @@ export function createFormatDocumentTool(
       }
 
       // Try extension first
+      let extensionError: string | null = null;
       if (extensionClient.isConnected()) {
         try {
-          const result = await extensionClient.formatDocument(resolved);
-          if (result !== null) {
+          const { value, error: extErr } =
+            await extensionClient.formatDocument(resolved);
+          extensionError = extErr;
+          if (value !== null) {
             // Read file content after formatting
             const contentAfter = fs.readFileSync(resolved, "utf-8");
             if (contentBefore === contentAfter) {
@@ -127,6 +130,9 @@ export function createFormatDocumentTool(
           // Timeout — fall through to CLI fallback
         }
       }
+      const extErrPrefix = extensionError
+        ? `Extension formatter failed (${extensionError}); `
+        : "";
 
       // CLI fallback
       const ext = path.extname(resolved).toLowerCase();
@@ -135,7 +141,7 @@ export function createFormatDocumentTool(
         return error({
           formatted: false,
           source: "cli",
-          error: `No formatter configured for extension "${ext}"`,
+          error: `${extErrPrefix}No formatter configured for extension "${ext}"`,
         });
       }
 
@@ -145,7 +151,7 @@ export function createFormatDocumentTool(
         return error({
           formatted: false,
           source: "cli",
-          error: `No available formatter found. Tried: ${names}`,
+          error: `${extErrPrefix}No available formatter found. Tried: ${names}`,
         });
       }
 
@@ -160,7 +166,7 @@ export function createFormatDocumentTool(
           formatted: false,
           source: "cli",
           formatterUsed: formatter.cmd,
-          error: result.stderr,
+          error: `${extErrPrefix}${result.stderr}`,
         });
       }
 

--- a/src/tools/lsp.ts
+++ b/src/tools/lsp.ts
@@ -811,6 +811,30 @@ export function createPreviewCodeActionTool(
           "Extension returned no result — code action may not be available",
         );
       }
+      // previewCodeAction returns an envelope { value, error, errorData };
+      // unwrap to preserve the upstream error message and any `available`
+      // alternative-action list when the requested title wasn't found.
+      if (
+        typeof result === "object" &&
+        result !== null &&
+        "value" in result &&
+        "error" in result
+      ) {
+        const env = result as {
+          value: unknown;
+          error: string | null;
+          errorData: Record<string, unknown> | null;
+        };
+        if (env.error) {
+          const available = env.errorData?.available;
+          const suffix =
+            Array.isArray(available) && available.length > 0
+              ? ` Available: ${available.join(", ")}`
+              : "";
+          return error(`${env.error}.${suffix}`);
+        }
+        return successStructured(env.value as Record<string, unknown>);
+      }
       return successStructured(result);
     },
   };

--- a/src/tools/organizeImports.ts
+++ b/src/tools/organizeImports.ts
@@ -109,9 +109,13 @@ export function createOrganizeImportsTool(
         });
       }
 
-      let result: unknown;
+      let envelope: {
+        value: unknown;
+        error: string | null;
+        errorData: Record<string, unknown> | null;
+      };
       try {
-        result = await extensionClient.organizeImports(resolved);
+        envelope = await extensionClient.organizeImports(resolved);
       } catch (err) {
         if (err instanceof ExtensionTimeoutError) {
           return error(
@@ -120,9 +124,12 @@ export function createOrganizeImportsTool(
         }
         throw err;
       }
+      const result = envelope.value;
       if (result === null) {
         return error({
-          error: "Extension failed to organize imports",
+          error:
+            envelope.error ??
+            "Extension failed to organize imports (no further detail)",
         });
       }
 

--- a/src/tools/refactorPreview.ts
+++ b/src/tools/refactorPreview.ts
@@ -91,9 +91,13 @@ export function createRefactorPreviewTool(
       const endColumn = requireInt(args, "endColumn");
       const actionTitle = requireString(args, "actionTitle");
 
-      let result: unknown;
+      let envelope: {
+        value: unknown;
+        error: string | null;
+        errorData: Record<string, unknown> | null;
+      };
       try {
-        result = await extensionClient.previewCodeAction(
+        envelope = await extensionClient.previewCodeAction(
           filePath,
           startLine,
           startColumn,
@@ -111,6 +115,15 @@ export function createRefactorPreviewTool(
         }
         throw err;
       }
+      if (envelope.error) {
+        const available = envelope.errorData?.available;
+        const suffix =
+          Array.isArray(available) && available.length > 0
+            ? ` Available: ${available.join(", ")}`
+            : "";
+        return error(`${envelope.error}.${suffix}`);
+      }
+      const result = envelope.value;
 
       if (!result) return error("No response from extension");
       const r = result as Record<string, unknown>;

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -1,6 +1,7 @@
 import { execFile, spawn } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { promisify } from "node:util";
 import type { AbsPath } from "../fp/brandedTypes.js";
 
@@ -342,7 +343,7 @@ export function requireInt(
 }
 
 export function toFileUri(absPath: string): string {
-  return new URL(`file://${absPath}`).href;
+  return pathToFileURL(absPath).href;
 }
 
 export function truncateOutput(

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -1125,7 +1125,17 @@ export class McpTransport {
                     this.logger,
                   );
                 } finally {
-                  this.activeToolCalls--;
+                  // Generation guard: detach() resets activeToolCalls to 0 on
+                  // disconnect, so decrementing on the new generation would
+                  // skew the admission counter negative and silently raise the
+                  // effective MAX_CONCURRENT_TOOLS cap. Mirror the clamp used
+                  // by the non-dynamic path at line 1478.
+                  if (dynGen === this.generation) {
+                    this.activeToolCalls = Math.max(
+                      0,
+                      this.activeToolCalls - 1,
+                    );
+                  }
                 }
               });
               break;
@@ -1305,7 +1315,13 @@ export class McpTransport {
                     sessionId: this.sessionId,
                   });
                   if (decision === "rejected" || decision === "expired") {
-                    this.activeToolCalls--;
+                    // Clamp: detach() may have reset activeToolCalls to 0 if
+                    // the WS dropped mid-approval. See line 1478 for the
+                    // matching pattern on the resolved-tool path.
+                    this.activeToolCalls = Math.max(
+                      0,
+                      this.activeToolCalls - 1,
+                    );
                     this.inFlightToolNames.delete(msg.id);
                     this.inFlightControllers.delete(msg.id);
                     // Approval rejections/expiries are NOT tool failures — track

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "claude-ide-bridge-extension",
   "displayName": "Claude IDE Bridge",
   "description": "MCP bridge between Claude Code and your IDE. 170+ tools — diagnostics, LSP, debugger, terminal, git. Optional Patchwork OS layer adds recipes, oversight, and approval queue.",
-  "version": "1.4.12",
+  "version": "1.4.13",
   "extensionKind": [
     "workspace"
   ],
@@ -197,6 +197,8 @@
     "prebuild": "npm run sync-presets",
     "build": "node esbuild.mjs",
     "watch": "node esbuild.mjs --watch",
+    "vscode:prepublish": "npm run build",
+    "prepackage": "npm run build",
     "pretest": "npm run sync-presets",
     "test": "vitest run",
     "test:watch": "vitest",


### PR DESCRIPTION
## Summary

Multi-agent audit followed by verification + fixes for the highest-priority findings. Five themed commits, each with a single concern and a self-contained rollback story.

### Security
- **Critical**: `--allow-command Bash` (or any non-lowercase form) bypassed the interpreter block via case-sensitive `INTERPRETER_COMMANDS.has(cmd)` check while the runtime allowlist matcher was case-insensitive. Lowercase before `.has()`.
- `--vps` help text now warns that allowlisted tools (`git`, `npm`, `docker-compose`) execute project-controlled code by design.

### Windows install / first-run (all confirmed by independent verification agents)
- `execFileSync("code", …)` for `.cmd` shims — needs `shell: process.platform === "win32"`.
- `` new URL(`file://${absPath}`) `` builds malformed URIs on Windows — switch to `pathToFileURL` / `fileURLToPath`.
- `bridgeLockDiscovery` honored `~/.claude/ide` but ignored `CLAUDE_CONFIG_DIR` (parity bug vs `lockfile.ts`).
- `commandDescription` workspace-containment used `startsWith("/")` — missed Windows drive letters; switch to `path.isAbsolute()`.
- `postinstall.mjs` `symlinkSync` throws EPERM on Windows without Developer Mode — fall back to `copyFileSync`.
- `start-all.mjs` returned bare `"npx"` — Node `shell:false` can't resolve `.cmd` shims; use `npx.cmd` on win32.
- `vscode-extension/package.json` — added `vscode:prepublish` + `prepackage` hooks (vsce was shipping stale `out/`); bumped to `1.4.13` (Windsurf caches `.vsix` by version).

### IntelliJ plugin
Bridge handlers run on a background scheduler thread; multiple handlers called IntelliJ APIs that assert specific threading contexts and crashed on first invocation:
- `BridgeService` now implements `Disposable` so platform invokes `dispose()` on shutdown (was unreachable; WS + scheduler + heartbeat all leaked).
- `WorkspaceGuard.contentRoots` access now in `runReadAction` (called by every handler).
- Create / Delete / Rename file handlers — wrap `runWriteAction` in `invokeAndWait` (matches existing `EditTextHandler` pattern).
- Save / Close / Delete / Rename — VFS + document + editor-manager lookups now in `runReadAction`.

Static review confirmed all 7 files compile. **No CI workflow builds the plugin** — verify locally with `./gradlew compileKotlin` (JDK 17) before merging.

### VS Code extension shape mismatches
Extension handlers returned `{error: "..."}` which `tryRequest` correctly unwrapped to null — but the error STRING was silently dropped. Format/fix/organize tools fell back to a CLI formatter without signaling that the LSP path had errored. Same loss for `previewCodeAction`'s `available` action-title list.

New `tryRequestWithError` envelope helper returns `{value, error, errorData}`. `value === null` fallback semantics preserved; error string + full error object now surface in tool replies (e.g. `"Extension formatter failed (No prettier installed); No formatter configured for .ts"`). Shape-safety regression tests updated.

### Bridge core hardening
- `transport.ts` dynamic-dispatch + approval-rejection paths — clamp `activeToolCalls` decrement with generation guard + `Math.max(0, …)`. Mirrors the non-dynamic path's existing fix.
- `automationState.recordTrigger` — `lastTrigger` map was unbounded despite a comment claiming "5000-entry eviction"; added real LRU.
- Webhook HMAC — compute over raw body bytes instead of the UTF-8 round-tripped string.

## Test plan
- [x] `npm run build` clean
- [x] `npm test` — 398 files, 5399 tests pass
- [x] `biome check` clean on edited files
- [x] Independent verification agents re-read each fix
- [ ] `./gradlew compileKotlin` on JDK 17 (must run before merge — no CI)
- [ ] Smoke-test `.vsix 1.4.13` install in VS Code / Cursor / Windsurf

## Notes
- Branch was cut from `fix/recipes-table-column-overlap` to keep unrelated dashboard WIP out of these commits.
- Extension marketplace publish is gated on `ext-v*` tag push to `main` — will tag after squash-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)