### PR TITLE
fix(dashboard): surface silent failures in Cancel / Replay / Pause-all

### DIFF
--- a/dashboard/src/app/sessions/page.tsx
+++ b/dashboard/src/app/sessions/page.tsx
@@ -6,6 +6,7 @@ import { apiPath } from "@/lib/api";
 import { ErrorState, RelationStrip } from "@/components/patchwork";
 import { SkeletonList } from "@/components/Skeleton";
 import { ActivityTabs } from "@/components/ActivityTabs";
+import { useToast } from "@/components/Toast";
 
 interface SessionSummary {
   id: string;
@@ -119,14 +120,36 @@ function SessionSummaryPanel({
 // ----------------------------------------------------------- page
 
 export default function SessionsPage() {
+  const toast = useToast();
   const { data, error, loading, refetch } = useBridgeFetch<SessionSummary[]>(
     "/api/bridge/sessions",
     { intervalMs: 3000 },
   );
 
   const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [pausing, setPausing] = useState(false);
 
   const sessions = data ?? [];
+
+  async function handlePauseAll() {
+    if (sessions.length === 0 || pausing) return;
+    setPausing(true);
+    try {
+      const res = await fetch(apiPath("/api/bridge/sessions/pause-all"), { method: "POST" });
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as { error?: string };
+        throw new Error(body.error ?? `Server returned ${res.status}`);
+      }
+      toast.success(`Paused ${sessions.length} session${sessions.length === 1 ? "" : "s"}`);
+      refetch();
+    } catch (e) {
+      toast.error(
+        `Couldn't pause sessions — ${e instanceof Error ? e.message : String(e)}`,
+      );
+    } finally {
+      setPausing(false);
+    }
+  }
 
   const liveCount = sessions.filter((s) => {
     const lastMs =
@@ -169,15 +192,12 @@ export default function SessionsPage() {
           <button
             type="button"
             className="btn sm ghost"
-            disabled={sessions.length === 0}
+            disabled={sessions.length === 0 || pausing}
             style={sessions.length === 0 ? { opacity: 0.4, cursor: "default" } : undefined}
-            onClick={() => {
-              if (sessions.length === 0) return;
-              void fetch(apiPath("/api/bridge/sessions/pause-all"), { method: "POST" });
-            }}
+            onClick={() => void handlePauseAll()}
           >
             <span aria-hidden style={{ marginRight: 6 }}>❚❚</span>
-            Pause all
+            {pausing ? "Pausing…" : "Pause all"}
           </button>
         </div>
       </div>

--- a/dashboard/src/app/tasks/page.tsx
+++ b/dashboard/src/app/tasks/page.tsx
@@ -5,6 +5,7 @@ import { fmtDuration } from "@/components/time";
 import { SkeletonList } from "@/components/Skeleton";
 import { EmptyState, ErrorState, RelationStrip } from "@/components/patchwork";
 import { ActivityTabs } from "@/components/ActivityTabs";
+import { useToast } from "@/components/Toast";
 
 interface Task {
   taskId: string;
@@ -90,6 +91,7 @@ function TaskDetail({ task, onCancel, cancelling }: {
   onCancel: (id: string) => void;
   cancelling: Record<string, boolean>;
 }) {
+  const toast = useToast();
   const [copied, setCopied] = useState<"id" | "term" | "replay" | null>(null);
   function flash(kind: "id" | "term" | "replay") {
     setCopied(kind);
@@ -235,9 +237,15 @@ function TaskDetail({ task, onCancel, cancelling }: {
                 apiPath(`/api/bridge/tasks/${task.taskId}/replay`),
                 { method: "POST" },
               );
-              if (res.ok) flash("replay");
-            } catch {
-              /* swallow — surfaced via next poll */
+              if (!res.ok) {
+                const body = (await res.json().catch(() => ({}))) as { error?: string };
+                throw new Error(body.error ?? `Server returned ${res.status}`);
+              }
+              flash("replay");
+            } catch (e) {
+              toast.error(
+                `Couldn't replay — ${e instanceof Error ? e.message : String(e)}`,
+              );
             }
           }}
         >
@@ -278,7 +286,11 @@ function TaskDetail({ task, onCancel, cancelling }: {
 // ----------------------------------------------------------- page
 
 async function cancelTask(id: string): Promise<void> {
-  await fetch(apiPath(`/api/bridge/tasks/${id}/cancel`), { method: "POST" });
+  const res = await fetch(apiPath(`/api/bridge/tasks/${id}/cancel`), { method: "POST" });
+  if (!res.ok) {
+    const body = (await res.json().catch(() => ({}))) as { error?: string };
+    throw new Error(body.error ?? `Server returned ${res.status}`);
+  }
 }
 
 function fmtAvg(ms: number): string {
@@ -288,6 +300,7 @@ function fmtAvg(ms: number): string {
 }
 
 export default function TasksPage() {
+  const toast = useToast();
   const [tasks, setTasks] = useState<Task[]>([]);
   const [hasLoaded, setHasLoaded] = useState(false);
   const [err, setErr] = useState<string>();
@@ -413,6 +426,11 @@ export default function TasksPage() {
     setCancelling((p) => ({ ...p, [id]: true }));
     try {
       await cancelTask(id);
+      toast.success("Task cancelled");
+    } catch (e) {
+      toast.error(
+        `Couldn't cancel — ${e instanceof Error ? e.message : String(e)}`,
+      );
     } finally {
       setCancelling((p) => ({ ...p, [id]: false }));
     }


### PR DESCRIPTION
## Summary

Three destructive POSTs in `tasks` + `sessions` were fire-and-forget — the server could return 500 and the buttons would flip back to their idle label with no error feedback. On a money-spending live agent process, "did my Cancel actually cancel?" was unanswerable.

This is **PR 1 of the recalibrated UX-audit sequence** — the silent-failure pass. Identified as the highest-leverage fix because it benefits every audience (engineers, marketplace installers, and PWA-only users equally).

### Changes
- **`tasks/page.tsx` Cancel**: `cancelTask` now throws on non-OK; `handleCancel` wraps it in try/catch and surfaces success + error via `toast`.
- **`tasks/page.tsx` Replay**: drop the `/* swallow — surfaced via next poll */` comment; surface error via `toast` on both non-OK responses and network failures (the next poll won't show a 500 from a POST that already returned).
- **`sessions/page.tsx` Pause all**: convert from `void fetch()` to an async handler with `.ok` check, busy state ("Pausing…"), success + error toasts, and a `refetch()` on success.

No UI change on the happy path. Same buttons, same labels (with "Pausing…" added during the in-flight POST).

## Test plan

- [ ] Manual: in dev mode, kill the bridge, click Cancel on a running task → expect error toast (not silent button reset)
- [ ] Manual: click Pause all with bridge stopped → expect error toast + button returns to "Pause all"
- [ ] Manual: click Cancel against a real running task → expect "Task cancelled" toast + status flips to cancelled on next poll
- [ ] Manual: click Pause all against real sessions → expect "Paused N sessions" toast + sessions list refreshes
- [ ] `tsc --noEmit` clean (verified locally)
- [ ] `biome check` clean (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)