### PR TITLE
fix(dashboard): first-time confirm + warn-style on Run button

### DIFF
--- a/dashboard/src/app/recipes/[name]/edit/page.tsx
+++ b/dashboard/src/app/recipes/[name]/edit/page.tsx
@@ -329,9 +329,10 @@ export default function RecipeEditPage({
           </Link>
           <button
             type="button"
-            className="btn"
+            className="btn warn"
             onClick={() => void handleRun()}
             disabled={running || loading}
+            title="Run the saved recipe immediately. May use API credits or call external services."
           >
             {running ? "Starting…" : "Run"}
           </button>

--- a/dashboard/src/app/recipes/page.tsx
+++ b/dashboard/src/app/recipes/page.tsx
@@ -146,6 +146,30 @@ interface RunModalState {
   recipe: Recipe;
 }
 
+// Per-session confirmation gate for the Run button. The audit critique was that
+// confirming on EVERY Run trains users to dismiss the dialog. Confirming once
+// per browser session keeps the "you're about to spend money" signal at first
+// touch without becoming friction noise on iteration.
+const SESSION_RUN_CONFIRMED_KEY = "patchwork:run-confirmed";
+
+function hasConfirmedRunThisSession(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.sessionStorage.getItem(SESSION_RUN_CONFIRMED_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+function markRunConfirmedThisSession(): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.sessionStorage.setItem(SESSION_RUN_CONFIRMED_KEY, "1");
+  } catch {
+    /* sessionStorage may be unavailable (private mode); fail open. */
+  }
+}
+
 interface RecipeContentResponse {
   name?: string;
   content?: string;
@@ -216,6 +240,32 @@ function RunModal({
               onConfirm(values);
             }}
           >
+            {vars.length === 0 && (
+              <div
+                style={{
+                  marginBottom: "var(--s-4)",
+                  padding: "var(--s-3) var(--s-4)",
+                  border: "1px solid var(--line-2)",
+                  borderRadius: "var(--r-1)",
+                  background: "var(--bg-2)",
+                  fontSize: "var(--fs-m)",
+                  color: "var(--fg-2)",
+                }}
+              >
+                Running this recipe will execute its steps immediately and may
+                use API credits or call external services.
+                {state.recipe.trigger && state.recipe.trigger !== "manual" && (
+                  <>
+                    {" "}
+                    Trigger:{" "}
+                    <code style={{ fontFamily: "var(--font-mono)" }}>
+                      {state.recipe.trigger}
+                    </code>
+                    .
+                  </>
+                )}
+              </div>
+            )}
             <div style={{ display: "flex", flexDirection: "column", gap: "var(--s-4)" }}>
               {vars.map((v) => (
                 <div key={v.name}>
@@ -256,7 +306,7 @@ function RunModal({
               <button type="button" className="btn ghost" onClick={onClose} disabled={running}>
                 Cancel
               </button>
-              <button type="submit" className="btn" disabled={running}>
+              <button type="submit" className="btn warn" disabled={running}>
                 {running ? "Starting…" : "Run recipe"}
               </button>
             </div>
@@ -659,7 +709,11 @@ export default function RecipesPage() {
 
   function handleRunClick(recipe: Recipe) {
     const vars = recipe.vars ?? [];
-    if (vars.length === 0) {
+    // Vars-less recipes used to fire on first click with no confirm. We open
+    // the same RunModal (which has zero fields when there are no vars, so it
+    // becomes a pure confirm dialog) UNLESS the user has already acknowledged
+    // a Run this session.
+    if (vars.length === 0 && hasConfirmedRunThisSession()) {
       void executeRun(recipe.name);
       return;
     }
@@ -769,6 +823,7 @@ export default function RecipesPage() {
     setModalRunning(true);
     try {
       await executeRun(name, vars);
+      markRunConfirmedThisSession();
     } finally {
       setModal(null);
       setModalRunning(false);


### PR DESCRIPTION
## Summary

Two issues from the dashboard UX audit:

1. The Run button on `/recipes` and `/recipes/[name]/edit` was visually indistinguishable from Save (same color, same size). On the recipes list, vars-less recipes also fired on first click with no confirm at all.
2. A naive fix ("confirm on every Run") would just train users to dismiss the dialog.

This PR splits the difference: **first Run of any browser session opens a confirm dialog; subsequent Runs in the same session fire instantly.** Stored in `sessionStorage` under `patchwork:run-confirmed` (fails open if storage is unavailable).

This is **PR 2 of the recalibrated UX-audit sequence** — "style the danger".

### Changes

**`dashboard/src/app/recipes/page.tsx`**
- `handleRunClick` now opens the existing `RunModal` for vars-less recipes too — unless the user already confirmed a Run this session.
- `RunModal` renders an explainer block when `vars.length === 0` ("Running this recipe will execute its steps immediately and may use API credits or call external services") plus the recipe's trigger.
- Modal submit button changed from `btn` to `btn warn` so it visually reads as "this does something" rather than "this saves something."
- `handleModalConfirm` calls `markRunConfirmedThisSession()` on success.

**`dashboard/src/app/recipes/[name]/edit/page.tsx`**
- Run button changed from `btn` (looks identical to Save's `btn primary`) to `btn warn`.
- Added `title` attr: "Run the saved recipe immediately. May use API credits or call external services."
- Existing dirty-buffer confirm preserved.

### Out of scope (deferred to follow-up)

- "Estimated cost: $X" pill from prior runs — needs aggregation work.
- Per-recipe confirm-once (this PR is per-session, applies to all recipes). Could revisit if users complain about confirming for trusted recipes after switching tabs.

## Test plan

- [ ] Open a fresh browser tab, navigate to `/recipes`, click Run on a vars-less recipe → confirm modal appears with explainer block + warn-styled Run button
- [ ] Click "Run recipe" → recipe fires, modal closes
- [ ] Click Run on another vars-less recipe → fires immediately (no modal — already confirmed this session)
- [ ] Open a new tab → click Run on a vars-less recipe → modal appears again (sessionStorage is per-tab)
- [ ] Run a vars-ful recipe → modal still has fields + warn-styled Run button
- [ ] Visit `/recipes/[name]/edit` → Run button is visually distinct from Save (warn vs primary)
- [ ] Hover Run on edit page → tooltip shows "Run the saved recipe immediately…"
- [ ] `tsc --noEmit` clean (verified locally)
- [ ] `biome check` clean (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)