### PR TITLE
fix(dashboard): mobile tap targets + raise overlays above bottom-nav

### DIFF
--- a/dashboard/src/app/approvals/page.tsx
+++ b/dashboard/src/app/approvals/page.tsx
@@ -437,7 +437,9 @@ function BatchActionBar({
     <div
       style={{
         position: "sticky",
-        bottom: "calc(var(--s-6) + env(safe-area-inset-bottom, 0px))",
+        // Lift above the mobile bottom-nav (--bottom-nav-h is 0 on desktop,
+        // 62px on phones); env() adds the iPhone safe-area inset.
+        bottom: "calc(var(--s-6) + var(--bottom-nav-h, 0px) + env(safe-area-inset-bottom, 0px))",
         zIndex: 10,
         display: "flex",
         gap: "var(--s-3)",

--- a/dashboard/src/app/globals.css
+++ b/dashboard/src/app/globals.css
@@ -2564,6 +2564,19 @@ button.topbar-search {
   text-decoration: none;
 }
 
+/*
+  Toast viewport positioning. Inline-style version used to hard-code
+  bottom: 16px which collided with the mobile bottom-nav (62px tall) on
+  phones — toasts rendered behind the nav and were invisible. The viewport
+  now lifts itself above the nav whenever --bottom-nav-h is set.
+*/
+.toast-viewport {
+  position: fixed;
+  bottom: calc(16px + var(--bottom-nav-h, 0px) + env(safe-area-inset-bottom, 0px));
+  right: 16px;
+  z-index: 1100;
+}
+
 /* Settings page layout — desktop has a sticky 200px in-page nav next to
    cards; on mobile (≤768px) the nav stacks above the cards instead of
    eating half the viewport width. */
@@ -3104,10 +3117,23 @@ button.topbar-search {
   text-transform: none;
 }
 
+/*
+  Mobile bottom-nav height is exposed as a CSS variable so other fixed /
+  sticky overlays (toast viewport, BatchActionBar, mobile reader pane) can
+  raise themselves above it instead of getting hidden behind. ~62px is the
+  measured height of the rendered nav (6px + 36px icon-row + 6px + safe-area).
+*/
+:root {
+  --bottom-nav-h: 0px;
+}
+
 .mobile-bottom-nav {
   display: none;
 }
 @media (max-width: 768px) {
+  :root {
+    --bottom-nav-h: 62px;
+  }
   .mobile-bottom-nav {
     display: grid;
     position: fixed;

--- a/dashboard/src/app/inbox/page.tsx
+++ b/dashboard/src/app/inbox/page.tsx
@@ -567,8 +567,12 @@ const filteredItems = items.filter((item) => {
               style={{
                 display: "flex",
                 alignItems: "center",
+                justifyContent: "center",
                 gap: 5,
-                padding: "5px 12px",
+                // 32px min hit target meets WCAG 2.5.5 (24×24); 9px vertical
+                // padding around the 12px icon lands at exactly 32 + border.
+                padding: "9px 14px",
+                minHeight: 32,
                 borderRadius: "var(--r-full)",
                 border: "1px solid var(--line-2)",
                 background: "transparent",
@@ -671,7 +675,7 @@ const filteredItems = items.filter((item) => {
                       onClick={() => setSidebarOpen(false)}
                       title="Collapse sidebar"
                       aria-label="Collapse message sidebar"
-                      style={{ background: "none", border: "none", cursor: "pointer", color: "var(--ink-3)", padding: "3px 5px", borderRadius: "var(--r-s)", fontSize: "var(--fs-xs)", lineHeight: 1 }}
+                      style={{ background: "none", border: "none", cursor: "pointer", color: "var(--ink-3)", padding: "8px 10px", minWidth: 32, minHeight: 32, display: "inline-flex", alignItems: "center", justifyContent: "center", borderRadius: "var(--r-s)", fontSize: "var(--fs-xs)", lineHeight: 1 }}
                     >
                       <span aria-hidden="true">◀</span>
                     </button>

--- a/dashboard/src/components/Toast.tsx
+++ b/dashboard/src/components/Toast.tsx
@@ -180,11 +180,8 @@ function ToastViewport({
       role="region"
       aria-label="Toast notifications"
       data-toast-viewport
+      className="toast-viewport"
       style={{
-        position: "fixed",
-        bottom: 16,
-        right: 16,
-        zIndex: 1100,
         display: "flex",
         flexDirection: "column",
         gap: 8,
@@ -265,8 +262,18 @@ function ToastViewport({
                 border: "none",
                 color: "var(--ink-2)",
                 cursor: "pointer",
-                fontSize: 16,
+                fontSize: 18,
                 lineHeight: 1,
+                // 32×32 hit area meets WCAG 2.5.5 (24×24 min) and gets close
+                // to Apple HIG's 44×44. Glyph stays small via font-size.
+                width: 32,
+                height: 32,
+                minWidth: 32,
+                minHeight: 32,
+                display: "inline-flex",
+                alignItems: "center",
+                justifyContent: "center",
+                borderRadius: 6,
                 padding: 0,
                 marginLeft: 2,
               }}


### PR DESCRIPTION
## Summary

Three mobile-only issues from the UX audit, all invisible to anyone testing on desktop:

1. **Toast notifications rendered behind the bottom-nav.** Hardcoded `bottom: 16px` + 62px-tall `MobileBottomNav` = success / error confirmations were invisible to phone-first users.
2. **Sub-WCAG tap targets**: Toast `×` was 14×14, inbox Refresh was 40×17, inbox sidebar collapse was ~22×18. WCAG 2.5.5 minimum is 24×24.
3. **`/approvals` BatchActionBar landed under the nav** — its sticky `bottom` only accounted for `--s-6 + safe-area`, not the bottom-nav.

This PR introduces a single CSS variable `--bottom-nav-h` (0px on desktop, 62px ≤768px) that any fixed/sticky overlay can add to its bottom offset to lift cleanly above the nav.

**PR 4 of the recalibrated UX-audit sequence.**

### Changes

- **`globals.css`**: declare `--bottom-nav-h: 0px` in `:root`; bump to `62px` inside `@media (max-width: 768px)`. New `.toast-viewport` rule with `bottom: calc(16px + var(--bottom-nav-h, 0px) + env(safe-area-inset-bottom, 0px))`.
- **`Toast.tsx`**: add `className=\"toast-viewport\"` and remove `position`/`bottom`/`right`/`zIndex` from inline style. Bump dismiss `×` to 32×32 with proper flex centering.
- **`inbox/page.tsx`**: Refresh button padding `5px → 9px` (height `17 → 35`); sidebar collapse arrow padding `3px → 8px` + `min-width/min-height: 32`.
- **`approvals/page.tsx`** BatchActionBar: sticky `bottom` now adds `var(--bottom-nav-h, 0px)` — no-op on desktop, lifts above nav on mobile.

### Verified locally with Playwright (390×844 viewport)

| Element | Before | After |
|---|---|---|
| Toast viewport `bottom` | 16px | 78px |
| Probe toast position | y=828 (inside nav 782–844) | y=704–766 (above nav) |
| Toast dismiss × size | 14×14 | 32×32 |
| Inbox Refresh button | ~40×17 | 89×35 |
| `--bottom-nav-h` var | (didn't exist) | 0px desktop / 62px mobile |

Dashboard test suite: 395/395 pass. `tsc --noEmit` + `biome check` clean.

## Test plan

- [ ] Open dashboard at iPhone-width (390px) → trigger any toast (e.g. cancel a task) → verify toast renders above the bottom-nav
- [ ] Tap the toast `×` on phone → easier to hit than before
- [ ] Open `/approvals` on mobile, select 2+ approvals → BatchActionBar appears above the bottom-nav (not under)
- [ ] Tap inbox Refresh on phone → button is comfortable (not a 17px sliver)
- [ ] On desktop (>768px) → no visible change anywhere; `--bottom-nav-h` resolves to 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)