### PR TITLE
Windows audit v3: extend #525 .cmd-shim fixes to remaining spawn sites

### DIFF
--- a/scripts/start-all.mjs
+++ b/scripts/start-all.mjs
@@ -59,7 +59,15 @@ const DIST_INDEX = path.join(BRIDGE_DIR, "dist", "index.js");
 const IS_WIN = process.platform === "win32";
 
 // ── Security helpers ──────────────────────────────────────────────────────────
-const SHELL_METACHARACTERS = /[;&|`$(){}[\]<>"'\\\n\r]/;
+// On Windows `\` is the path separator (e.g. `C:\Program Files\nodejs\node.exe`),
+// not a shell-injection vector. cmd.exe's actual metacharacters are
+// `^ & < > | ( )` — `\` does not need escaping. Including it in the regex
+// would reject every legitimate Windows path that spawnProc validates
+// (process.execPath, npm.cmd, npx.cmd, etc.) and fail-stop the whole script.
+// Same fix that PR #525 applied to vscode-extension/src/bridgeProcess.ts.
+const SHELL_METACHARACTERS = IS_WIN
+  ? /[;&|`$(){}[\]<>"'\n\r]/
+  : /[;&|`$(){}[\]<>"'\\\n\r]/;
 
 /**
  * Validate that a command path is safe to execute.

--- a/src/__tests__/winShim.test.ts
+++ b/src/__tests__/winShim.test.ts
@@ -1,0 +1,55 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { ensureCmdShim } from "../winShim.js";
+
+const ORIG_PLATFORM = process.platform;
+
+function setPlatform(p: NodeJS.Platform) {
+  Object.defineProperty(process, "platform", { value: p, configurable: true });
+}
+
+describe("ensureCmdShim", () => {
+  describe("on non-win32", () => {
+    beforeAll(() => setPlatform("linux"));
+    afterAll(() => setPlatform(ORIG_PLATFORM));
+
+    it("returns binary unchanged regardless of shape", () => {
+      expect(ensureCmdShim("claude")).toBe("claude");
+      expect(ensureCmdShim("/usr/local/bin/claude")).toBe(
+        "/usr/local/bin/claude",
+      );
+      expect(ensureCmdShim("./scripts/foo.sh")).toBe("./scripts/foo.sh");
+    });
+  });
+
+  describe("on win32", () => {
+    beforeAll(() => setPlatform("win32"));
+    afterAll(() => setPlatform(ORIG_PLATFORM));
+
+    it("appends .cmd to bare binary names", () => {
+      expect(ensureCmdShim("claude")).toBe("claude.cmd");
+      expect(ensureCmdShim("claude-ide-bridge")).toBe("claude-ide-bridge.cmd");
+      expect(ensureCmdShim("gemini")).toBe("gemini.cmd");
+    });
+
+    it("leaves names that already have an extension alone", () => {
+      expect(ensureCmdShim("claude.exe")).toBe("claude.exe");
+      expect(ensureCmdShim("claude.cmd")).toBe("claude.cmd");
+      expect(ensureCmdShim("claude.bat")).toBe("claude.bat");
+    });
+
+    it("leaves absolute Windows paths alone", () => {
+      // path.sep on win32 is '\'; on the host (darwin/linux) it's '/'. Both
+      // backslash-containing and forward-slash-containing paths must be left
+      // untouched regardless of host so cross-platform tests stay green.
+      expect(ensureCmdShim("C:\\Program Files\\nodejs\\claude")).toBe(
+        "C:\\Program Files\\nodejs\\claude",
+      );
+      expect(ensureCmdShim("C:/Users/foo/claude")).toBe("C:/Users/foo/claude");
+    });
+
+    it("leaves relative paths alone", () => {
+      expect(ensureCmdShim("./bin/claude")).toBe("./bin/claude");
+      expect(ensureCmdShim(".\\bin\\claude")).toBe(".\\bin\\claude");
+    });
+  });
+});

--- a/src/drivers/claude/__tests__/subprocess.mcp-access.test.ts
+++ b/src/drivers/claude/__tests__/subprocess.mcp-access.test.ts
@@ -99,9 +99,15 @@ describe("SubprocessDriver mcpAccess opt-in", () => {
     };
     // Stdio shim — auto-discovers the bridge from ~/.claude/ide/*.lock at
     // runtime, so url/authToken from bridgeMcp() aren't echoed into the file.
+    // On Windows the command is suffixed with `.cmd` so claude -p's own
+    // spawn(shell:false) can resolve the npm-installed bridge shim.
+    const expectedCommand =
+      process.platform === "win32"
+        ? "claude-ide-bridge.cmd"
+        : "claude-ide-bridge";
     expect(cfg.mcpServers.patchwork).toEqual({
       type: "stdio",
-      command: "claude-ide-bridge",
+      command: expectedCommand,
       args: ["shim"],
     });
   });

--- a/src/drivers/claude/__tests__/subprocess.mcp-access.test.ts
+++ b/src/drivers/claude/__tests__/subprocess.mcp-access.test.ts
@@ -125,6 +125,40 @@ describe("SubprocessDriver mcpAccess opt-in", () => {
     ).toBe(true);
   });
 
+  // Regression: PR #525 fixed `effectiveBinary` resolution for claude -p's
+  // own spawn, but `claude -p` then re-spawns the bridge via the stdio MCP
+  // config — and that spawn ALSO can't resolve a bare `.cmd` on Windows.
+  // Before this fix, the config wrote `command: "claude-ide-bridge"`, so
+  // MCP-over-claude-CLI silently failed on Windows.
+  it("writes .cmd shim into MCP stdio config on win32", async () => {
+    const ORIG_PLATFORM = process.platform;
+    Object.defineProperty(process, "platform", {
+      value: "win32",
+      configurable: true,
+    });
+    try {
+      const driver = new SubprocessDriver("claude", "ant", vi.fn(), () => ({
+        url: "http://127.0.0.1:3101/mcp",
+        authToken: "tkn-abc",
+      }));
+      await finishRun(
+        driver.run(makeInput({ providerOptions: { mcpAccess: true } })),
+      );
+      const args = spawnMock.mock.calls[0]![1] as string[];
+      const idx = args.indexOf("--mcp-config");
+      const cfgPath = args[idx + 1]!;
+      const cfg = JSON.parse(readFileSync(cfgPath, "utf-8")) as {
+        mcpServers: { patchwork: { command: string } };
+      };
+      expect(cfg.mcpServers.patchwork.command).toBe("claude-ide-bridge.cmd");
+    } finally {
+      Object.defineProperty(process, "platform", {
+        value: ORIG_PLATFORM,
+        configurable: true,
+      });
+    }
+  });
+
   it("logs a warning when mcpAccess: true but no bridgeMcp accessor wired", async () => {
     const log = vi.fn();
     const driver = new SubprocessDriver("claude", "ant", log);

--- a/src/drivers/claude/subprocess.ts
+++ b/src/drivers/claude/subprocess.ts
@@ -1,7 +1,8 @@
 import { spawn } from "node:child_process";
 import { mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import path, { join } from "node:path";
+import { join } from "node:path";
+import { ensureCmdShim } from "../../winShim.js";
 import type {
   ProviderDriver,
   ProviderTaskInput,
@@ -38,11 +39,15 @@ const OUTPUT_CAP = 50 * 1024; // 50KB
 function writeMcpConfigFile(_mcp: { url: string; authToken: string }): string {
   const dir = mkdtempSync(join(tmpdir(), "patchwork-mcp-"));
   const path = join(dir, "mcp.json");
+  // claude -p spawns the stdio command itself via Node's child_process, which
+  // can't resolve a bare `.cmd` shim on Windows (shell:false; only PATHEXT-
+  // listed `.exe` files auto-resolve). Record the `.cmd` form on win32 so
+  // claude -p can find the bridge binary that npm installed.
   const config = {
     mcpServers: {
       patchwork: {
         type: "stdio",
-        command: "claude-ide-bridge",
+        command: ensureCmdShim("claude-ide-bridge"),
         args: ["shim"],
       },
     },
@@ -96,17 +101,12 @@ export class SubprocessDriver implements ProviderDriver {
     const maxBudgetUsd =
       typeof opts.maxBudgetUsd === "number" ? opts.maxBudgetUsd : undefined;
 
-    let effectiveBinary = useAnt ? this.antBinary : this.binary;
     // npm-installed shims on Windows are `.cmd` files. Node's spawn with
     // shell:false can't launch them via a bare name — without the explicit
     // extension every Claude subprocess spawn ENOENTs on Windows.
-    if (
-      process.platform === "win32" &&
-      !path.extname(effectiveBinary) &&
-      !effectiveBinary.includes(path.sep)
-    ) {
-      effectiveBinary = `${effectiveBinary}.cmd`;
-    }
+    const effectiveBinary = ensureCmdShim(
+      useAnt ? this.antBinary : this.binary,
+    );
     // Re-write before each run — /tmp may be cleared on long-running servers.
     this.settings.write();
 

--- a/src/drivers/gemini/index.ts
+++ b/src/drivers/gemini/index.ts
@@ -8,6 +8,7 @@ import {
 } from "node:fs";
 import { homedir } from "node:os";
 import { isAbsolute, join, resolve } from "node:path";
+import { ensureCmdShim } from "../../winShim.js";
 import { sanitizeEnv } from "../claude/envSanitizer.js";
 import { splitLines } from "../claude/streamParser.js";
 import type {
@@ -236,11 +237,16 @@ export class GeminiSubprocessDriver implements ProviderDriver {
         }
       }
 
+      // On Windows, npm-installed gemini is a `.cmd` shim that spawn(shell:false)
+      // can't launch by bare name (Node only auto-resolves `.exe` via PATHEXT).
+      // Same fix that PR #525 applied to the Claude subprocess driver.
+      const spawnBinary = ensureCmdShim(this.binary);
+
       this.log(
-        `[GeminiSubprocessDriver] spawning: ${this.binary} -p <prompt> (workspace: ${input.workspace})`,
+        `[GeminiSubprocessDriver] spawning: ${spawnBinary} -p <prompt> (workspace: ${input.workspace})`,
       );
 
-      const child = spawn(this.binary, args, {
+      const child = spawn(spawnBinary, args, {
         cwd: homedir(),
         env,
         signal: input.signal,

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,6 +61,7 @@ import {
   SYMLINK_INSTALL_FIX,
 } from "./installGuard.js";
 import { PACKAGE_VERSION, semverGt } from "./version.js";
+import { ensureCmdShim } from "./winShim.js";
 
 const __dirnameTop = path.dirname(fileURLToPath(import.meta.url));
 
@@ -3335,8 +3336,11 @@ Steps performed:
         `  ✓ MCP shim — already registered in ${claudeJsonAbs}\n\n`,
       );
     } else {
+      // claude -p spawns the stdio command via Node's child_process, which
+      // can't resolve a bare `.cmd` shim on Windows. Record the `.cmd` form
+      // on win32 so the bridge binary is findable by the spawned process.
       mcpServers["claude-ide-bridge"] = {
-        command: "claude-ide-bridge",
+        command: ensureCmdShim("claude-ide-bridge"),
         args: ["shim"],
         type: "stdio",
       };

--- a/src/recipes/__tests__/yamlRunner.test.ts
+++ b/src/recipes/__tests__/yamlRunner.test.ts
@@ -1,7 +1,7 @@
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 // Isolate from the developer's real ~/.patchwork/config.json — agent steps
 // now read it via a static import (was a broken `require()` under ESM that
@@ -2560,6 +2560,51 @@ describe("resolveClaudeBinary — override precedence", async () => {
       const result = resolveClaudeBinary();
       expect(typeof result).toBe("string");
       expect(result.length).toBeGreaterThan(0);
+    });
+  });
+
+  // Regression: PR #525 fixed the parallel resolver in
+  // src/drivers/claude/subprocess.ts but missed this one. Before the fix,
+  // every recipe `agent` step on Windows ENOENT'd because npm installs
+  // `claude` as a `.cmd` shim and spawn(shell:false) won't auto-resolve.
+  describe("Windows .cmd shim resolution", () => {
+    const ORIG_PLATFORM = process.platform;
+    afterEach(() => {
+      Object.defineProperty(process, "platform", {
+        value: ORIG_PLATFORM,
+        configurable: true,
+      });
+    });
+
+    it("appends .cmd to bare 'claude' default on win32", () => {
+      Object.defineProperty(process, "platform", {
+        value: "win32",
+        configurable: true,
+      });
+      withEnv(undefined, () => {
+        const result = resolveClaudeBinary();
+        // Either the default `claude` was found (→ `claude.cmd`) or the
+        // dev's ~/.patchwork/config.json sets `claudeBinary` to an absolute
+        // path (which we leave alone). Both endings are acceptable; bare
+        // `claude` with no extension is the regression.
+        expect(
+          result === "claude.cmd" ||
+            result.includes("\\") ||
+            result.includes("/"),
+        ).toBe(true);
+      });
+    });
+
+    it("leaves env-provided absolute paths alone on win32", () => {
+      Object.defineProperty(process, "platform", {
+        value: "win32",
+        configurable: true,
+      });
+      withEnv("C:\\Program Files\\nodejs\\claude.cmd", () => {
+        expect(resolveClaudeBinary()).toBe(
+          "C:\\Program Files\\nodejs\\claude.cmd",
+        );
+      });
     });
   });
 });

--- a/src/recipes/__tests__/yamlRunner.test.ts
+++ b/src/recipes/__tests__/yamlRunner.test.ts
@@ -2544,8 +2544,10 @@ describe("resolveClaudeBinary — override precedence", async () => {
     withEnv("", () => {
       // No PatchworkConfig.claudeBinary mocked here, so this falls through
       // to the literal "claude" default. The point is: empty string in
-      // env shouldn't mean "spawn empty-string-binary".
-      expect(resolveClaudeBinary()).toBe("claude");
+      // env shouldn't mean "spawn empty-string-binary". On Windows the
+      // default is suffixed with `.cmd` so spawn(shell:false) can resolve it.
+      const expected = process.platform === "win32" ? "claude.cmd" : "claude";
+      expect(resolveClaudeBinary()).toBe(expected);
     });
   });
 

--- a/src/recipes/yamlRunner.ts
+++ b/src/recipes/yamlRunner.ts
@@ -38,6 +38,7 @@ import { captureFixture } from "../connectors/fixtureRecorder.js";
 import { loadConfig as loadPatchworkConfigSync } from "../patchworkConfig.js";
 import { findYamlRecipePath } from "../recipesHttp.js";
 import type { RecipeRunLog } from "../runLog.js";
+import { ensureCmdShim } from "../winShim.js";
 import {
   executeAgent as _executeAgent,
   type AgentExecutorDeps,
@@ -1397,15 +1398,15 @@ function buildAgentExecutorDeps(
  */
 export function resolveClaudeBinary(): string {
   const envOverride = process.env.PATCHWORK_CLAUDE_BINARY;
-  if (envOverride && envOverride.length > 0) return envOverride;
+  if (envOverride && envOverride.length > 0) return ensureCmdShim(envOverride);
   try {
     const cfg = loadPatchworkConfigSync();
     if (cfg.claudeBinary && cfg.claudeBinary.length > 0)
-      return cfg.claudeBinary;
+      return ensureCmdShim(cfg.claudeBinary);
   } catch {
     // ignore — fall through to the "claude" default
   }
-  return "claude";
+  return ensureCmdShim("claude");
 }
 
 function defaultClaudeCodeFn(

--- a/src/winShim.ts
+++ b/src/winShim.ts
@@ -1,0 +1,31 @@
+import path from "node:path";
+
+/**
+ * Resolve a binary name to its `.cmd` shim on Windows when needed.
+ *
+ * npm-installed binaries on Windows are `.cmd` files in `node_modules/.bin/`
+ * (or under `%APPDATA%\npm` for `-g` installs). Node's `child_process.spawn`
+ * with `shell:false` does NOT auto-resolve `.cmd` shims — only `.exe` via
+ * `PATHEXT`. Calling `spawn("claude", …)` on Windows therefore ENOENTs even
+ * though `claude --version` works fine in any terminal.
+ *
+ * This helper appends `.cmd` to bare binary names on win32, leaving:
+ *   - absolute / relative paths (anything with a separator) alone
+ *   - names that already have an extension alone
+ *   - non-Windows platforms untouched
+ *
+ * This was the fix pattern established in PR #525 for the Claude subprocess
+ * driver; centralising it here keeps the four other spawn sites consistent.
+ *
+ * Also used when *writing* an MCP stdio config that another process will
+ * spawn — that spawning process inherits the same shell:false limitation,
+ * so the config must record the `.cmd` form on Windows.
+ */
+export function ensureCmdShim(binary: string): string {
+  if (process.platform !== "win32") return binary;
+  // Use path.win32 explicitly so the check behaves identically when tests
+  // mock process.platform on a POSIX host (where path.sep would still be '/').
+  if (path.win32.extname(binary)) return binary;
+  if (binary.includes("\\") || binary.includes("/")) return binary;
+  return `${binary}.cmd`;
+}


### PR DESCRIPTION
## Summary

Follow-up to #525. A four-agent Windows audit found four classes of spawn bugs #525 didn't reach. All share the root cause it identified — Node's `spawn(shell:false)` on Windows can't resolve npm-installed `.cmd` shims by bare name. Every confirmed-shipping-bug from the audit is fixed here.

- **`scripts/start-all.mjs:62`** — `SHELL_METACHARACTERS` regex contained `\`, so `validateCommandPath()` rejected `process.execPath` (`C:\Program Files\nodejs\node.exe`) on every Windows run. **Bridge refused to start via `start-all` / `patchwork start`.** Same fix #525 applied to `vscode-extension/src/bridgeProcess.ts`.
- **`src/recipes/yamlRunner.ts`** — parallel `resolveClaudeBinary()` returned bare `"claude"` on Windows. **Every recipe `agent` step ENOENT'd.**
- **`src/drivers/gemini/index.ts`** — bare `gemini` binary on Windows. Gemini driver broken when used.
- **MCP stdio configs (`src/drivers/claude/subprocess.ts:45` + `src/index.ts:3338`)** — wrote `command: "claude-ide-bridge"`. `claude -p` then re-spawns the bridge with the bare name and ENOENTs. **MCP-over-claude-CLI silently broken on Windows.**

Extracted the established `.cmd`-append pattern into a shared `ensureCmdShim()` helper (`src/winShim.ts`) and applied it everywhere — including refactoring the inline block #525 introduced in `subprocess.ts`.

## Test plan

- [x] `npm run typecheck` + `npm run typecheck:tests:core` clean
- [x] `npm test` — **5407 passed | 2 skipped (+3 new regression tests)**
- [x] `npm run build` clean
- [x] `npx biome check --write` clean on all changed files
- [x] Regression tests mock `process.platform=win32` on the macOS runner:
  - `ensureCmdShim` unit tests (bare names, absolute paths both `\` and `/`, extensions, non-win32 passthrough)
  - `resolveClaudeBinary` returns `.cmd` form on win32
  - MCP stdio config writes `claude-ide-bridge.cmd` on win32

## Deferred to follow-up

Audit also found two more bugs that are deliberately not in this PR — they need separate review:

- `detached:true` + `process.kill(-pid, signal)` orphan-leak on Windows (`claudeDriver.ts:338`, `drivers/claude/subprocess.ts:260`) — POSIX process-group cancellation doesn't work on Windows; needs `taskkill /F /T /PID` branch.
- `automationInterpreter.ts:65` minimatch path-separator mismatch — Windows-format file paths (`C:\…\bar.ts`) silently don't match POSIX glob patterns; needs normalisation + `nocase: true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)