### PR TITLE
Windows audit v4: tree-kill cancelled/timed-out tasks

### DIFF
--- a/src/__tests__/processTree.test.ts
+++ b/src/__tests__/processTree.test.ts
@@ -46,13 +46,18 @@ describe("treeKill", () => {
   describe("on win32", () => {
     beforeEach(() => setPlatform("win32"));
 
-    it("invokes taskkill /F /T /PID for live children", () => {
-      treeKill(fakeChild({ pid: 1234 }));
+    it("invokes taskkill /F /T /PID AND child.kill backstop", () => {
+      const kill = vi.fn(() => true);
+      treeKill(fakeChild({ pid: 1234, kill }));
       expect(execFileSyncMock).toHaveBeenCalledWith(
         "taskkill",
         ["/F", "/T", "/PID", "1234"],
         expect.objectContaining({ stdio: "ignore", windowsHide: true }),
       );
+      // Backstop fires the `close` event for test stubs that override
+      // child.kill, and is a no-op on real Windows since taskkill already
+      // killed the immediate child.
+      expect(kill).toHaveBeenCalledWith("SIGTERM");
       expect(processKillSpy).not.toHaveBeenCalled();
     });
 

--- a/src/__tests__/processTree.test.ts
+++ b/src/__tests__/processTree.test.ts
@@ -1,0 +1,113 @@
+import type { ChildProcess } from "node:child_process";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const execFileSyncMock = vi.fn();
+vi.mock("node:child_process", async (importOriginal) => {
+  const original = await importOriginal<typeof import("node:child_process")>();
+  return { ...original, execFileSync: execFileSyncMock };
+});
+
+const { treeKill } = await import("../processTree.js");
+
+const ORIG_PLATFORM = process.platform;
+function setPlatform(p: NodeJS.Platform) {
+  Object.defineProperty(process, "platform", { value: p, configurable: true });
+}
+
+function fakeChild(opts: {
+  pid?: number;
+  exitCode?: number | null;
+  signalCode?: NodeJS.Signals | null;
+  kill?: ReturnType<typeof vi.fn>;
+}): ChildProcess {
+  return {
+    pid: opts.pid,
+    exitCode: opts.exitCode ?? null,
+    signalCode: opts.signalCode ?? null,
+    kill: opts.kill ?? vi.fn(() => true),
+  } as unknown as ChildProcess;
+}
+
+describe("treeKill", () => {
+  // biome-ignore lint/suspicious/noExplicitAny: vi.spyOn return type is tricky to express across vitest versions
+  let processKillSpy: any;
+
+  beforeEach(() => {
+    execFileSyncMock.mockReset();
+    execFileSyncMock.mockReturnValue(Buffer.from(""));
+    processKillSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    setPlatform(ORIG_PLATFORM);
+  });
+
+  describe("on win32", () => {
+    beforeEach(() => setPlatform("win32"));
+
+    it("invokes taskkill /F /T /PID for live children", () => {
+      treeKill(fakeChild({ pid: 1234 }));
+      expect(execFileSyncMock).toHaveBeenCalledWith(
+        "taskkill",
+        ["/F", "/T", "/PID", "1234"],
+        expect.objectContaining({ stdio: "ignore", windowsHide: true }),
+      );
+      expect(processKillSpy).not.toHaveBeenCalled();
+    });
+
+    it("swallows taskkill failures (process already gone)", () => {
+      execFileSyncMock.mockImplementation(() => {
+        throw new Error("not found");
+      });
+      expect(() => treeKill(fakeChild({ pid: 1234 }))).not.toThrow();
+    });
+  });
+
+  describe("on posix", () => {
+    beforeEach(() => setPlatform("linux"));
+
+    it("signals the negative pid (process group) AND calls child.kill", () => {
+      const kill = vi.fn(() => true);
+      treeKill(fakeChild({ pid: 5678, kill }));
+      expect(processKillSpy).toHaveBeenCalledWith(-5678, "SIGTERM");
+      expect(kill).toHaveBeenCalledWith("SIGTERM");
+      expect(execFileSyncMock).not.toHaveBeenCalled();
+    });
+
+    it("respects the signal argument on both kill paths", () => {
+      const kill = vi.fn(() => true);
+      treeKill(fakeChild({ pid: 5678, kill }), "SIGKILL");
+      expect(processKillSpy).toHaveBeenCalledWith(-5678, "SIGKILL");
+      expect(kill).toHaveBeenCalledWith("SIGKILL");
+    });
+
+    it("falls back to child.kill when process-group kill ESRCHes (non-detached)", () => {
+      processKillSpy.mockImplementation(() => {
+        throw new Error("ESRCH");
+      });
+      const kill = vi.fn(() => true);
+      expect(() => treeKill(fakeChild({ pid: 5678, kill }))).not.toThrow();
+      expect(kill).toHaveBeenCalled();
+    });
+  });
+
+  describe("guards", () => {
+    beforeEach(() => setPlatform("win32"));
+
+    it("no-ops when pid is undefined (spawn error)", () => {
+      treeKill(fakeChild({ pid: undefined }));
+      expect(execFileSyncMock).not.toHaveBeenCalled();
+    });
+
+    it("no-ops when child already exited", () => {
+      treeKill(fakeChild({ pid: 1234, exitCode: 0 }));
+      expect(execFileSyncMock).not.toHaveBeenCalled();
+    });
+
+    it("no-ops when child already signalled", () => {
+      treeKill(fakeChild({ pid: 1234, signalCode: "SIGTERM" }));
+      expect(execFileSyncMock).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/drivers/claude/subprocess.ts
+++ b/src/drivers/claude/subprocess.ts
@@ -2,6 +2,7 @@ import { spawn } from "node:child_process";
 import { mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { treeKill } from "../../processTree.js";
 import { ensureCmdShim } from "../../winShim.js";
 import type {
   ProviderDriver,
@@ -186,6 +187,16 @@ export class SubprocessDriver implements ProviderDriver {
       // setsid() — prevents subprocess from opening /dev/tty for interactive prompts.
       detached: true,
     });
+    // Node's `signal` option calls `child.kill()` on abort, which only signals
+    // the immediate child. claude -p may itself spawn children (MCP shims,
+    // tools); without tree-kill those orphan when the task is cancelled.
+    // On POSIX this kills the process group (setsid above); on Windows it
+    // runs `taskkill /F /T /PID`. Idempotent with Node's auto-kill.
+    const onAbort = () => treeKill(child);
+    input.signal.addEventListener("abort", onAbort, { once: true });
+    child.once("close", () => {
+      input.signal.removeEventListener("abort", onAbort);
+    });
 
     let lineBuf = "";
     let accumulated = "";
@@ -257,7 +268,7 @@ export class SubprocessDriver implements ProviderDriver {
       ? setTimeout(() => {
           if (firstAssistantAt === undefined && !doneFromResult) {
             startupTimedOut = true;
-            child.kill();
+            treeKill(child);
           }
         }, input.startupTimeoutMs)
       : null;

--- a/src/drivers/gemini/index.ts
+++ b/src/drivers/gemini/index.ts
@@ -8,6 +8,7 @@ import {
 } from "node:fs";
 import { homedir } from "node:os";
 import { isAbsolute, join, resolve } from "node:path";
+import { treeKill } from "../../processTree.js";
 import { ensureCmdShim } from "../../winShim.js";
 import { sanitizeEnv } from "../claude/envSanitizer.js";
 import { splitLines } from "../claude/streamParser.js";
@@ -256,6 +257,16 @@ export class GeminiSubprocessDriver implements ProviderDriver {
       // but keep detached=false so the subprocess dies cleanly with the bridge
       // rather than getting SIGPIPE when the pipe closes mid-run.
       child.unref();
+      // Tree-kill on abort. Node's signal-driven auto-kill only signals the
+      // immediate child; gemini may spawn tool subprocesses that orphan on
+      // cancellation. On Windows this runs `taskkill /F /T /PID`; on POSIX
+      // (non-detached) it's effectively a no-op since there's no process
+      // group, leaving Node's auto-kill to handle the child.
+      const onAbort = () => treeKill(child);
+      input.signal.addEventListener("abort", onAbort, { once: true });
+      child.once("close", () => {
+        input.signal.removeEventListener("abort", onAbort);
+      });
 
       let lineBuf = "";
       let accumulated = "";
@@ -321,7 +332,7 @@ export class GeminiSubprocessDriver implements ProviderDriver {
         ? setTimeout(() => {
             if (firstAssistantAt === undefined && !doneFromResult) {
               startupTimedOut = true;
-              child.kill();
+              treeKill(child);
             }
           }, input.startupTimeoutMs)
         : null;

--- a/src/processTree.ts
+++ b/src/processTree.ts
@@ -38,18 +38,21 @@ export function treeKill(
       // Best-effort. Common reasons: child already exited, permission denied,
       // taskkill not on PATH (locked-down Windows installs).
     }
-    return;
+  } else {
+    // POSIX: process-group kill (works when child was spawned detached:true →
+    // setsid → process-group leader). ESRCH for non-detached children is
+    // expected; child.kill() below handles the single-child case.
+    try {
+      process.kill(-pid, signal);
+    } catch {
+      /* not a group leader */
+    }
   }
 
-  // POSIX: try process-group kill first (works when child was spawned
-  // detached:true → setsid → process-group leader). ESRCH for non-detached
-  // children is expected and swallowed; child.kill() below handles the
-  // single-child case so the immediate child always gets signaled.
-  try {
-    process.kill(-pid, signal);
-  } catch {
-    /* not a group leader */
-  }
+  // Single-child backstop on every platform. On Windows, taskkill /T should
+  // have killed the immediate child already, making this a no-op; but it
+  // ensures the ChildProcess fires its `close` event in test stubs that
+  // override `child.kill` and short-circuits the spawn/auto-kill flow.
   try {
     child.kill(signal);
   } catch {

--- a/src/processTree.ts
+++ b/src/processTree.ts
@@ -1,0 +1,58 @@
+import type { ChildProcess } from "node:child_process";
+import { execFileSync } from "node:child_process";
+
+/**
+ * Kill a child process and all its descendants.
+ *
+ * Node's `child.kill()` and the AbortSignal-driven kill that `spawn({ signal })`
+ * wires up both only signal the immediate child. That leaves grandchildren
+ * orphaned when a Claude task is cancelled or times out.
+ *
+ * On POSIX, a process spawned with `detached: true` is its own process-group
+ * leader (`setsid()`); signalling the negative PID kills the whole group.
+ *
+ * On Windows there's no process-group concept, so the canonical way to kill
+ * a tree is `taskkill /F /T /PID <pid>` — `/F` force, `/T` includes children.
+ *
+ * Best-effort: a process that already exited (or that we lack permission to
+ * signal) is not an error. Callers may invoke this from abort handlers that
+ * fire after the child has already closed.
+ */
+export function treeKill(
+  child: ChildProcess,
+  signal: NodeJS.Signals = "SIGTERM",
+): void {
+  const pid = child.pid;
+  if (pid === undefined) return;
+  // != null covers both `null` (live) and `undefined` (test mocks that omit
+  // the field). A real ChildProcess has these as `number|null` / `Signals|null`.
+  if (child.exitCode != null || child.signalCode != null) return;
+
+  if (process.platform === "win32") {
+    try {
+      execFileSync("taskkill", ["/F", "/T", "/PID", String(pid)], {
+        stdio: "ignore",
+        windowsHide: true,
+      });
+    } catch {
+      // Best-effort. Common reasons: child already exited, permission denied,
+      // taskkill not on PATH (locked-down Windows installs).
+    }
+    return;
+  }
+
+  // POSIX: try process-group kill first (works when child was spawned
+  // detached:true → setsid → process-group leader). ESRCH for non-detached
+  // children is expected and swallowed; child.kill() below handles the
+  // single-child case so the immediate child always gets signaled.
+  try {
+    process.kill(-pid, signal);
+  } catch {
+    /* not a group leader */
+  }
+  try {
+    child.kill(signal);
+  } catch {
+    /* already exited */
+  }
+}


### PR DESCRIPTION
## Summary

Follow-up to #527 (Windows audit v3). Fixes the remaining confirmed-shipping orphan-process bug from the audit.

The Claude and Gemini subprocess drivers call \`child.kill()\` on cancellation/startup-timeout. That only signals the immediate child — when \`claude -p\` (or \`gemini -p\`) has spawned its own children (MCP shims, tool subprocesses, Bash), those orphan.

- **POSIX**: subprocess driver spawns \`detached: true\` (setsid), but \`child.kill()\` doesn't reach the process group. Negative-PID kill is the correct call.
- **Windows**: no process-group concept; \`child.kill()\` only calls \`TerminateProcess\` on the immediate child. The documented way to kill a tree is \`taskkill /F /T /PID <pid>\`.

Adds \`src/processTree.ts\` \`treeKill(child, signal?)\` helper:
- **win32**: shells out to \`taskkill /F /T /PID\` (stdio:ignore, windowsHide).
- **POSIX**: tries \`process.kill(-pid, signal)\` (group-kill for detached children) then \`child.kill(signal)\` (single-child fallback for non-detached). Both best-effort.

Wires it into:
- \`src/drivers/claude/subprocess.ts\` — replaces \`child.kill()\` at startup-timeout site; adds abort-listener that fires \`treeKill\` (idempotent with Node's auto-kill on the spawn \`signal\` option).
- \`src/drivers/gemini/index.ts\` — same two changes.

\`src/claudeDriver.ts\` (deprecated per its file header — only consumed by legacy tests) intentionally NOT touched.

## Test plan

- [x] \`npm run typecheck\` + \`typecheck:tests:core\` clean
- [x] \`npm test\` — **5415 passed | 2 skipped (+8 new)**
- [x] \`npm run build\` clean
- [x] \`biome check --write\` clean
- [x] 8 \`treeKill\` unit tests cover: win32 taskkill shape, POSIX dual-kill, signal arg respected, guards (undefined pid, already-exited, already-signalled), best-effort swallows.

## Audit follow-ups remaining

From the original audit, still open:
- \`automationInterpreter.ts\` minimatch path-separator mismatch on win32 (silently breaks \`onFileSave\` glob patterns).
- \`config.ts INTERPRETER_COMMANDS\` missing Windows variants (\`node.exe\`, \`cmd\`, \`powershell\`).
- \`pluginWatcher.ts\` / \`featureFlags.ts\` \`fs.watch\` with no polling fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)