### PR TITLE
Windows audit v5: normalise paths for minimatch in automation hooks

### DIFF
--- a/src/fp/__tests__/automationInterpreter.test.ts
+++ b/src/fp/__tests__/automationInterpreter.test.ts
@@ -1,5 +1,5 @@
 import fc from "fast-check";
-import { describe, expect, it, test } from "vitest";
+import { afterEach, describe, expect, it, test } from "vitest";
 import {
   evaluateWhen,
   executeAutomationPolicy,
@@ -62,6 +62,64 @@ describe("matchesCondition", () => {
   it("returns false on invalid glob", () => {
     // Extremely malformed pattern — just ensure no throw
     expect(() => matchesCondition("[invalid", "value")).not.toThrow();
+  });
+
+  // Regression: before this normalisation, every onFileSave/onFileChanged
+  // hook with a POSIX-style glob silently never fired on Windows because
+  // VS Code's Uri.fsPath surfaces paths with backslashes (C:\Users\…) and
+  // minimatch is strict on `/`.
+  describe("Windows path normalisation", () => {
+    const ORIG_PLATFORM = process.platform;
+    afterEach(() => {
+      Object.defineProperty(process, "platform", {
+        value: ORIG_PLATFORM,
+        configurable: true,
+      });
+    });
+
+    function setWin() {
+      Object.defineProperty(process, "platform", {
+        value: "win32",
+        configurable: true,
+      });
+    }
+
+    it("matches POSIX glob against backslash-separated Windows path", () => {
+      setWin();
+      expect(matchesCondition("**/*.ts", "C:\\repo\\src\\foo.ts")).toBe(true);
+      expect(matchesCondition("**/*.ts", "C:\\repo\\src\\foo.js")).toBe(false);
+    });
+
+    it("respects nocase on Windows (NTFS is case-insensitive)", () => {
+      setWin();
+      expect(matchesCondition("**/*.ts", "C:\\repo\\SRC\\Foo.TS")).toBe(true);
+    });
+
+    it("normalises backslashes in the user-supplied pattern too", () => {
+      setWin();
+      // A Windows user writing the glob with native separators should still
+      // match — minimatch ordinarily treats `\` as an escape character.
+      expect(matchesCondition("**\\*.ts", "C:\\repo\\src\\foo.ts")).toBe(true);
+    });
+
+    it("negation pattern still works on Windows", () => {
+      setWin();
+      expect(matchesCondition("!**/*.test.ts", "C:\\repo\\src\\foo.ts")).toBe(
+        true,
+      );
+      expect(
+        matchesCondition("!**/*.test.ts", "C:\\repo\\src\\foo.test.ts"),
+      ).toBe(false);
+    });
+
+    it("POSIX nocase is OFF (Linux/macOS case-sensitive filesystems)", () => {
+      Object.defineProperty(process, "platform", {
+        value: "linux",
+        configurable: true,
+      });
+      // POSIX path with mismatched case should not match without nocase.
+      expect(matchesCondition("**/foo.ts", "/repo/src/FOO.TS")).toBe(false);
+    });
   });
 });
 

--- a/src/fp/automationInterpreter.ts
+++ b/src/fp/automationInterpreter.ts
@@ -52,17 +52,30 @@ function emptyAcc(state: AutomationState): Acc {
 /**
  * Returns true if `value` matches the condition pattern.
  * Negation via "!" prefix. Missing pattern → always true.
+ *
+ * On Windows, file paths arrive as `C:\Users\foo\src\bar.ts` while users
+ * write POSIX-style globs (`src/**\/*.ts`). minimatch is strict on `/` and
+ * NTFS is case-insensitive, so without normalisation onFileSave/onFileChanged
+ * hooks silently never fire on Windows. Normalise backslashes to forward
+ * slashes on both sides and pass `nocase` on win32.
  */
 export function matchesCondition(
   pattern: string | undefined,
   value: string,
 ): boolean {
   if (pattern === undefined || pattern === "") return true;
+  const isWin = process.platform === "win32";
+  const normValue = isWin ? value.replace(/\\/g, "/") : value;
+  const opts = isWin ? { dot: true, nocase: true } : { dot: true };
   try {
     if (pattern.startsWith("!")) {
-      return !minimatch(value, pattern.slice(1), { dot: true });
+      const inner = isWin
+        ? pattern.slice(1).replace(/\\/g, "/")
+        : pattern.slice(1);
+      return !minimatch(normValue, inner, opts);
     }
-    return minimatch(value, pattern, { dot: true });
+    const normPattern = isWin ? pattern.replace(/\\/g, "/") : pattern;
+    return minimatch(normValue, normPattern, opts);
   } catch {
     return false;
   }


### PR DESCRIPTION
## Summary

Follow-up to #527 + #528. Fixes the next confirmed-shipping Windows bug from the audit.

\`matchesCondition\` (the entry point for \`onFileSave\` / \`onFileChanged\` glob conditions in \`src/fp/automationInterpreter.ts\`) called minimatch with the raw \`eventData.file\` value. On Windows the value arrives from VS Code's \`Uri.fsPath\` as \`C:\\Users\\foo\\src\\bar.ts\`. minimatch is strict on \`/\` and NTFS is case-insensitive, so:

- \`onFileSave: { condition: "**/*.ts" }\` silently never fired on any Windows file save (backslash mismatch).
- \`Src/Foo.TS\` did not match \`src/**/*.ts\` on case-insensitive NTFS volumes.

Both made the entire automation-hooks feature appear broken on Windows with no error.

### Fix

In \`matchesCondition\`, on win32 only:
- Replace \`\\\` with \`/\` in both the value and the user-supplied pattern before minimatch.
- Pass \`{ nocase: true }\` so NTFS case-insensitivity is respected.
- POSIX behaviour unchanged.

## Test plan

- [x] \`npm run typecheck\` + \`typecheck:tests:core\` clean
- [x] \`npm test\` — **5412 passed | 2 skipped** (+5 new)
- [x] 5 new regression tests cover: slash-direction mismatch, NTFS case-insensitivity, backslash in user pattern, negation prefix on Windows, POSIX nocase-OFF guard. \`process.platform\` mocked per-test on the host.

## Audit follow-ups remaining

- \`config.ts INTERPRETER_COMMANDS\` missing Windows variants (\`node.exe\`, \`cmd\`, \`powershell\`, \`pwsh\`) — defense-in-depth.
- \`pluginWatcher.ts\` / \`featureFlags.ts\` \`fs.watch\` with no polling fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)