### PR TITLE
Windows audit v6: block .exe/.cmd interpreters + Windows shells

### DIFF
--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -105,6 +105,47 @@ describe("parseConfig --allow-command interpreter guard", () => {
     ]);
     expect(config.commandAllowlist).toContain("prettier");
   });
+
+  // Regression: before isInterpreterCommand(), a Windows attacker could
+  // bypass the interpreter block with `--allow-command node.exe` since the
+  // set only contained bare names. Extensions, casing, and path prefixes
+  // are now normalised.
+  it("blocks Windows .exe / .cmd / .bat extensions", () => {
+    for (const cmd of ["node.exe", "Node.EXE", "python.exe", "make.cmd"]) {
+      expect(() =>
+        parseConfig(["--workspace", "/tmp", "--allow-command", cmd]),
+      ).toThrow(/interpreter/);
+    }
+  });
+
+  it("blocks Windows shells (cmd, powershell, pwsh)", () => {
+    for (const cmd of [
+      "cmd",
+      "cmd.exe",
+      "powershell",
+      "powershell.exe",
+      "pwsh",
+      "pwsh.exe",
+      "wscript.exe",
+      "cscript.exe",
+    ]) {
+      expect(() =>
+        parseConfig(["--workspace", "/tmp", "--allow-command", cmd]),
+      ).toThrow(/interpreter/);
+    }
+  });
+
+  it("blocks interpreters supplied with an absolute path", () => {
+    for (const cmd of [
+      "/usr/local/bin/node",
+      "C:\\Windows\\System32\\cmd.exe",
+      "C:/Windows/System32/powershell.exe",
+    ]) {
+      expect(() =>
+        parseConfig(["--workspace", "/tmp", "--allow-command", cmd]),
+      ).toThrow(/interpreter/);
+    }
+  });
 });
 
 // Helper: parseConfig slices argv at index 2, so prefix with two dummy entries

--- a/src/config.ts
+++ b/src/config.ts
@@ -157,7 +157,10 @@ export const DB_ALLOWLIST_EXTRAS = [
 ];
 
 /** Commands that can execute arbitrary code via flags like -e, -c, --eval.
- *  These are blocked from the default allowlist but can be added via --allow-command. */
+ *  These are blocked from the default allowlist and from --allow-command /
+ *  commandAllowlist additions. Entries are bare names; Windows extensions
+ *  (`.exe` / `.cmd` / `.bat` / `.com` / `.ps1`) are stripped before lookup
+ *  by `isInterpreterCommand()`. */
 export const INTERPRETER_COMMANDS = new Set([
   "node",
   "python",
@@ -175,7 +178,33 @@ export const INTERPRETER_COMMANDS = new Set([
   "perl",
   "lua",
   "php",
+  // Windows shells & interpreters. cmd.exe `/c` and PowerShell `-Command`
+  // both accept arbitrary command strings; `pwsh` is PowerShell 7+.
+  "cmd",
+  "powershell",
+  "pwsh",
+  "wscript",
+  "cscript",
 ]);
+
+/**
+ * Case-insensitive interpreter check that also strips Windows executable
+ * extensions and any leading path. Defends against bypass attempts like:
+ *   --allow-command node.exe
+ *   --allow-command C:\\Windows\\System32\\cmd.exe
+ *   --allow-command Powershell.EXE
+ */
+export function isInterpreterCommand(cmd: string): boolean {
+  // Strip any directory prefix — `C:\Windows\System32\cmd.exe` → `cmd.exe`.
+  // Handle both POSIX and Windows separators since the input is user-supplied
+  // and may be authored on either platform.
+  let base = cmd;
+  const lastSep = Math.max(base.lastIndexOf("/"), base.lastIndexOf("\\"));
+  if (lastSep >= 0) base = base.slice(lastSep + 1);
+  // Lowercase, then strip a single trailing executable extension.
+  base = base.toLowerCase().replace(/\.(exe|cmd|bat|com|ps1)$/i, "");
+  return INTERPRETER_COMMANDS.has(base);
+}
 
 const EDITOR_IDE_NAMES: Record<string, string> = {
   windsurf: "Windsurf",
@@ -424,7 +453,7 @@ export function parseConfig(argv: string[]): Config {
   let jsonl = false;
   let linters: string[] = fileConfig.linters ?? [];
   for (const cmd of fileConfig.commandAllowlist ?? []) {
-    if (INTERPRETER_COMMANDS.has(cmd)) {
+    if (isInterpreterCommand(cmd)) {
       throw new Error(
         `"${cmd}" is an interpreter and cannot be added via commandAllowlist in config file (arbitrary code execution risk)`,
       );
@@ -614,7 +643,7 @@ export function parseConfig(argv: string[]): Config {
         const cmd = requireArg(args, ++i, "--allow-command");
         if (cmd.length > 256)
           throw new Error("--allow-command value too long (max 256 chars)");
-        if (INTERPRETER_COMMANDS.has(cmd.toLowerCase())) {
+        if (isInterpreterCommand(cmd)) {
           throw new Error(
             `"${cmd}" is an interpreter and cannot be added via --allow-command (arbitrary code execution risk)`,
           );


### PR DESCRIPTION
## Summary

Follow-up to #527, #528, #529. Closes the defense-in-depth gap in the interpreter blocklist.

\`INTERPRETER_COMMANDS\` (\`src/config.ts\`) blocked bare names (\`node\`, \`bash\`, \`python\`, …) from being added to the command allowlist on the documented "arbitrary code execution risk" grounds. The Windows variants slipped through:

- \`--allow-command node.exe\` — set lookup only had bare names; \`node.exe\` is a different string.
- \`commandAllowlist\` in the config file didn't even \`.toLowerCase()\` — \`Node\` slipped through.
- Windows shells (\`cmd\`, \`powershell\`, \`pwsh\`, \`wscript\`, \`cscript\`) weren't in the set at all.
- Absolute paths like \`C:\\Windows\\System32\\cmd.exe\` weren't normalised.

### Fix

New \`isInterpreterCommand(cmd)\` helper:
- strips any leading path (POSIX or Windows separator)
- lowercases
- strips a single trailing \`.exe\` / \`.cmd\` / \`.bat\` / \`.com\` / \`.ps1\` extension
- then checks the set

Applied at both call sites (config-file \`commandAllowlist\` AND \`--allow-command\` CLI). \`cmd\`, \`powershell\`, \`pwsh\`, \`wscript\`, \`cscript\` added to the set.

## Test plan

- [x] \`npm run typecheck\` + \`typecheck:tests:core\` clean
- [x] \`npm test\` — **5410 passed | 2 skipped** (+3 new regression tests)
- [x] 3 new tests cover: extension stripping (mixed case), Windows shells, absolute-path normalisation.

## Audit follow-ups remaining

Only one left from the original Windows audit:
- \`pluginWatcher.ts\` / \`featureFlags.ts\` \`fs.watch\` with no polling fallback — affects plugin hot-reload + kill-switch flag changes on flaky Windows mounts (network drives, WSL bind mounts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)