### PR TITLE
Windows audit v7: polling fallback for plugin + flag watchers

### DIFF
--- a/src/__tests__/fsWatchWithFallback.test.ts
+++ b/src/__tests__/fsWatchWithFallback.test.ts
@@ -1,0 +1,115 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { watchDirectoryWithFallback } from "../fsWatchWithFallback.js";
+
+/**
+ * These tests cover the polling fallback path because that's the brittle
+ * surface area the audit flagged. The fs.watch happy path is exercised
+ * implicitly across the rest of the suite (pluginWatcher tests, etc.) so
+ * we focus here on:
+ *   - fs.watch throwing → polling starts
+ *   - directory created later → polling sees it
+ *   - file mtime advances → onChange fires
+ *   - stop() releases timer
+ */
+
+describe("watchDirectoryWithFallback — polling fallback", () => {
+  let tmp: string;
+  let stops: Array<() => void> = [];
+
+  beforeEach(() => {
+    tmp = mkdtempSync(path.join(os.tmpdir(), "fs-watch-fallback-"));
+    stops = [];
+  });
+
+  afterEach(() => {
+    for (const stop of stops) {
+      try {
+        stop();
+      } catch {
+        /* ignore */
+      }
+    }
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("falls back to polling when fs.watch throws (non-existent dir)", async () => {
+    const missing = path.join(tmp, "does-not-exist-yet");
+    const onChange = vi.fn();
+    const warn = vi.fn();
+    const stop = watchDirectoryWithFallback(missing, onChange, {
+      pollIntervalMs: 20,
+      logger: { warn },
+    });
+    stops.push(stop);
+    // Polling must have started — logger.warn called with "fs.watch threw".
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0]?.[0]).toMatch(/fs\.watch threw/);
+
+    // Create the directory + a file. Polling should detect on its next tick.
+    require("node:fs").mkdirSync(missing);
+    writeFileSync(path.join(missing, "a.txt"), "hi");
+    await new Promise((r) => setTimeout(r, 80));
+    expect(onChange).toHaveBeenCalled();
+  });
+
+  it("polling fires onChange when a file's mtime advances", async () => {
+    const onChange = vi.fn();
+    // Force the polling path by pointing fs.watch at a directory it can't
+    // watch — actually easier: just always-polling via fs.watch mock isn't
+    // available here, so use the missing-dir trigger.
+    const dir = path.join(tmp, "p");
+    require("node:fs").mkdirSync(dir);
+    const file = path.join(dir, "f.txt");
+    writeFileSync(file, "v1");
+
+    // Watch a sibling missing dir to force polling, then mkdir it pointing
+    // at the same `dir`. Simpler: just point at a path that fs.watch
+    // refuses. On macOS/Linux, fs.watch on a regular file works, on a
+    // missing path throws. Use missing then mkdir to it.
+    const watchPath = path.join(tmp, "watched");
+    const stop = watchDirectoryWithFallback(watchPath, onChange, {
+      pollIntervalMs: 20,
+    });
+    stops.push(stop);
+
+    require("node:fs").mkdirSync(watchPath);
+    writeFileSync(path.join(watchPath, "g.txt"), "v1");
+    await new Promise((r) => setTimeout(r, 60));
+    expect(onChange).toHaveBeenCalled();
+    onChange.mockClear();
+
+    // Bump mtime on an existing file.
+    await new Promise((r) => setTimeout(r, 20)); // ensure mtime resolution
+    writeFileSync(path.join(watchPath, "g.txt"), "v2");
+    await new Promise((r) => setTimeout(r, 60));
+    expect(onChange).toHaveBeenCalled();
+  });
+
+  it("stop() halts polling — onChange not fired after stop", async () => {
+    const onChange = vi.fn();
+    const watchPath = path.join(tmp, "watched");
+    const stop = watchDirectoryWithFallback(watchPath, onChange, {
+      pollIntervalMs: 20,
+    });
+    stop();
+    require("node:fs").mkdirSync(watchPath);
+    writeFileSync(path.join(watchPath, "x.txt"), "v");
+    await new Promise((r) => setTimeout(r, 60));
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("happy path: fs.watch succeeds and fires onChange", async () => {
+    const onChange = vi.fn();
+    const stop = watchDirectoryWithFallback(tmp, onChange, {
+      pollIntervalMs: 20,
+    });
+    stops.push(stop);
+    writeFileSync(path.join(tmp, "new.txt"), "x");
+    // fs.watch fires within ~10ms on local filesystems
+    await new Promise((r) => setTimeout(r, 50));
+    expect(onChange).toHaveBeenCalled();
+  });
+});

--- a/src/featureFlags.ts
+++ b/src/featureFlags.ts
@@ -8,16 +8,10 @@
  *   - Per-feature opt-in with default-off safety
  */
 
-import {
-  existsSync,
-  type FSWatcher,
-  mkdirSync,
-  readFileSync,
-  watch,
-  writeFileSync,
-} from "node:fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import { join } from "node:path";
+import { watchDirectoryWithFallback } from "./fsWatchWithFallback.js";
 
 /** Flag definition */
 export interface FeatureFlag {
@@ -346,10 +340,8 @@ loadFlags();
 export function watchFlags(): () => void {
   const flagsPath = getFlagsPath();
   const flagsDir = join(flagsPath, "..");
-  const flagsFile = "flags.json";
 
   let debounceTimer: ReturnType<typeof setTimeout> | null = null;
-  let watcher: FSWatcher | null = null;
   let stopped = false;
 
   const reload = (): void => {
@@ -366,24 +358,14 @@ export function watchFlags(): () => void {
     }, 100);
   };
 
-  try {
-    // Watch the directory rather than the file directly — flags.json
-    // may not exist yet when watch is established, and editors / atomic
-    // writes (rename-into-place) lose direct file watches.
-    watcher = watch(flagsDir, { recursive: false }, (_event, filename) => {
-      if (stopped) return;
-      // filename may be null on some platforms; reload on null to be safe.
-      if (!filename || filename === flagsFile) {
-        reload();
-      }
-    });
-  } catch {
-    // Directory doesn't exist yet — the user hasn't engaged any flags.
-    // No-op; first `persistFlags()` creates the dir and from then on
-    // the watcher won't fire. This is acceptable for an emergency-stop
-    // flag because the file will exist as soon as anyone toggles via
-    // /kill-switch (which calls setFlag(..., persist=true)).
-  }
+  // Watch the directory rather than the file directly — flags.json may not
+  // exist yet when watch is established, and editors / atomic writes
+  // (rename-into-place) lose direct file watches. The helper falls back to
+  // mtime polling when the dir is missing or fs.watch fails (Windows
+  // network drives, WSL bind mounts), and notices when the dir later appears.
+  const stopWatcher = watchDirectoryWithFallback(flagsDir, () => {
+    if (!stopped) reload();
+  });
 
   return (): void => {
     stopped = true;
@@ -391,13 +373,10 @@ export function watchFlags(): () => void {
       clearTimeout(debounceTimer);
       debounceTimer = null;
     }
-    if (watcher) {
-      try {
-        watcher.close();
-      } catch {
-        /* ignore */
-      }
-      watcher = null;
+    try {
+      stopWatcher();
+    } catch {
+      /* ignore */
     }
   };
 }

--- a/src/fsWatchWithFallback.ts
+++ b/src/fsWatchWithFallback.ts
@@ -1,0 +1,129 @@
+import fs from "node:fs";
+
+/**
+ * Watch a directory for any change, falling back to mtime polling when
+ * `fs.watch` is unavailable or fails.
+ *
+ * Motivation: `fs.watch` is unreliable on several real-world filesystems —
+ * Windows network drives (SMB/CIFS), WSL bind mounts, and macOS volumes
+ * mounted from a Linux host all either throw at watch time or stop firing
+ * events silently mid-session. The bridge's plugin hot-reload and kill-
+ * switch flag watcher silently went dead on those mounts.
+ *
+ * Behaviour:
+ *   - First try `fs.watch(dir, { recursive: false })`. If it succeeds, also
+ *     listen for the watcher's `error` event so a mid-session breakdown
+ *     swaps to polling without losing change notifications.
+ *   - If `fs.watch` throws (e.g. ENOENT — the directory doesn't exist yet,
+ *     or EPERM — the filesystem doesn't support watching), start polling
+ *     immediately.
+ *   - Polling: stat the directory every `pollIntervalMs` (default 2000ms)
+ *     and stat each non-dot file in it. Fire `onChange` if any file's
+ *     mtime advanced, a file appeared, or a file disappeared. If the
+ *     directory itself is missing, keep polling — it may appear later.
+ *
+ * Caller filters changes by re-reading the file(s) of interest. The helper
+ * deliberately does NOT expose the changed filename: polling can't reliably
+ * provide that, and fs.watch filenames are already null on some platforms
+ * (Windows rename events, atomic saves). One source of truth keeps callers
+ * platform-agnostic.
+ *
+ * Returns a `stop()` function that releases both the watcher and the timer.
+ */
+export function watchDirectoryWithFallback(
+  dir: string,
+  onChange: () => void,
+  opts: {
+    pollIntervalMs?: number;
+    logger?: { warn: (msg: string) => void } | undefined;
+  } = {},
+): () => void {
+  const pollIntervalMs = opts.pollIntervalMs ?? 2000;
+  const logger = opts.logger;
+
+  let watcher: fs.FSWatcher | null = null;
+  let pollTimer: ReturnType<typeof setInterval> | null = null;
+  let stopped = false;
+  // Snapshot: filename → mtimeMs. Empty Map when directory doesn't exist.
+  let snapshot = new Map<string, number>();
+
+  const snapshotDir = (): Map<string, number> => {
+    const out = new Map<string, number>();
+    try {
+      const entries = fs.readdirSync(dir, { withFileTypes: true });
+      for (const ent of entries) {
+        if (!ent.isFile()) continue;
+        if (ent.name.startsWith(".")) continue;
+        try {
+          const st = fs.statSync(`${dir}/${ent.name}`);
+          out.set(ent.name, st.mtimeMs);
+        } catch {
+          /* file disappeared between readdir and stat — ignore */
+        }
+      }
+    } catch {
+      /* dir missing — empty snapshot */
+    }
+    return out;
+  };
+
+  const startPolling = (reason: string): void => {
+    if (pollTimer || stopped) return;
+    if (logger) logger.warn(`[fs-watch] falling back to polling: ${reason}`);
+    snapshot = snapshotDir();
+    pollTimer = setInterval(() => {
+      if (stopped) return;
+      const next = snapshotDir();
+      let changed = next.size !== snapshot.size;
+      if (!changed) {
+        for (const [name, mtime] of next) {
+          const prev = snapshot.get(name);
+          if (prev === undefined || prev !== mtime) {
+            changed = true;
+            break;
+          }
+        }
+      }
+      snapshot = next;
+      if (changed) onChange();
+    }, pollIntervalMs);
+    // Don't keep the event loop alive solely for polling.
+    pollTimer.unref?.();
+  };
+
+  try {
+    watcher = fs.watch(dir, { recursive: false }, () => {
+      if (!stopped) onChange();
+    });
+    watcher.on("error", (err) => {
+      // Watcher broke mid-session. Tear it down, start polling.
+      try {
+        watcher?.close();
+      } catch {
+        /* ignore */
+      }
+      watcher = null;
+      startPolling(`watcher error: ${err.message}`);
+    });
+  } catch (err) {
+    startPolling(
+      `fs.watch threw: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  return (): void => {
+    stopped = true;
+    if (watcher) {
+      try {
+        watcher.close();
+      } catch {
+        /* ignore */
+      }
+      watcher = null;
+    }
+    if (pollTimer) {
+      clearInterval(pollTimer);
+      pollTimer = null;
+    }
+  };
+}

--- a/src/pluginWatcher.ts
+++ b/src/pluginWatcher.ts
@@ -1,5 +1,5 @@
-import fs from "node:fs";
 import type { Config } from "./config.js";
+import { watchDirectoryWithFallback } from "./fsWatchWithFallback.js";
 import type { Logger } from "./logger.js";
 import {
   getBuiltInToolNames,
@@ -12,7 +12,7 @@ import type { McpTransport } from "./transport.js";
 const DEBOUNCE_MS = 300;
 
 export class PluginWatcher {
-  private watchers = new Map<string, fs.FSWatcher>();
+  private watchers = new Map<string, () => void>(); // spec → stop function
   private debounceTimers = new Map<string, ReturnType<typeof setTimeout>>();
   private loadedPlugins = new Map<string, LoadedPlugin>(); // keyed by spec
   private transports = new Set<McpTransport>();
@@ -28,20 +28,12 @@ export class PluginWatcher {
   start(plugins: LoadedPlugin[]): void {
     for (const plugin of plugins) {
       this.loadedPlugins.set(plugin.spec, plugin);
-      try {
-        const watcher = fs.watch(
-          plugin.pluginDir,
-          { recursive: false },
-          (_event, _filename) => {
-            this.scheduleReload(plugin.spec);
-          },
-        );
-        this.watchers.set(plugin.spec, watcher);
-      } catch (err) {
-        this.logger.warn(
-          `[plugin-watch] Could not watch "${plugin.pluginDir}": ${err instanceof Error ? err.message : String(err)}`,
-        );
-      }
+      const stop = watchDirectoryWithFallback(
+        plugin.pluginDir,
+        () => this.scheduleReload(plugin.spec),
+        { logger: this.logger },
+      );
+      this.watchers.set(plugin.spec, stop);
     }
   }
 
@@ -61,9 +53,9 @@ export class PluginWatcher {
     this.stopped = true;
     for (const timer of this.debounceTimers.values()) clearTimeout(timer);
     this.debounceTimers.clear();
-    for (const watcher of this.watchers.values()) {
+    for (const stopWatcher of this.watchers.values()) {
       try {
-        watcher.close();
+        stopWatcher();
       } catch {
         /* ignore */
       }


### PR DESCRIPTION
## Summary

Closes the last code-fix item from the original Windows audit.

\`fs.watch\` is unreliable on several real-world filesystems — Windows network drives (SMB/CIFS) and WSL bind mounts often throw at watch time or stop emitting events silently; Linux can hit \`ENOSPC\` when the inotify limit is exhausted. Both \`pluginWatcher.ts\` and \`featureFlags.ts watchFlags()\` wrapped \`fs.watch\` in try/catch but the catch only logged and swallowed — no fallback. **Plugin hot-reload and kill-switch flag changes silently went dead on those mounts.**

### Helper

New \`src/fsWatchWithFallback.ts watchDirectoryWithFallback(dir, onChange, opts)\`:
- First tries \`fs.watch\`. On success, also listens for the watcher's \`error\` event so a mid-session breakdown swaps to polling without losing notifications.
- On throw or runtime error, falls back to a **2s mtime poll** of the directory. Snapshot is a \`Map<filename, mtimeMs>\`; \`onChange\` fires when sizes differ, files appear/disappear, or any mtime advances.
- If the directory doesn't exist yet, polling continues and notices when it's created.
- Returns a \`stop()\` function that releases watcher + timer.

### Applied at

- \`src/pluginWatcher.ts\` — stores a stop-function per plugin instead of an \`FSWatcher\`.
- \`src/featureFlags.ts watchFlags\` — loses the filename filter (polling can't supply one) but \`loadFlags()\` already debounces 100ms and is cheap; spurious reloads on a sibling-file edit are harmless.

## Test plan

- [x] \`npm run typecheck\` + \`typecheck:tests:core\` clean
- [x] \`npm test\` — **5427 passed | 2 skipped** (+4 new)
- [x] 4 new tests cover: fs.watch throws on missing dir → polling kicks in, mtime advance detected via polling, \`stop()\` halts polling, fs.watch happy path fires \`onChange\`. Real fs ops against \`mkdtemp\` dirs — no platform mocking needed because the polling path is identical on every OS.

## Original audit — closed

Code-level fixes from the audit are all shipped or in-flight:

| PR | Bug class | Status |
|---|---|---|
| #527 | \`.cmd\` shim fixes (start-all, yamlRunner, gemini, MCP config) | merged |
| #528 | Tree-kill cancelled/timed-out tasks | merged |
| #529 | Minimatch path normalisation for automation hooks | merged |
| #530 | Interpreter blocklist Windows variants | merged |
| #531 (this) | fs.watch polling fallback | open |

Remaining audit items are out of scope for code fixes:
- Lockfile auth-token confidentiality on NTFS — trust-model decision (chmod is a no-op on Windows); same-user trust is the IDE-tooling norm.
- CI gaps (extension never builds on Windows; smoke suite never runs on Windows; walkthrough doc is 17 lines × 4 steps) — separate work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)