### PR TITLE
docs(extension): per-step walkthrough pages

### DIFF
--- a/vscode-extension/docs/walkthrough-check-connection.md
+++ b/vscode-extension/docs/walkthrough-check-connection.md
@@ -1,0 +1,27 @@
+## Verify the bridge is running
+
+The bridge is the background process that connects Claude to VS Code. The extension auto-starts it on first open, but if you see "Bridge disconnected" in the status bar you can start it manually.
+
+### Manual start
+
+```bash
+# macOS / Linux
+claude-ide-bridge start-all
+
+# Windows (PowerShell or cmd)
+claude-ide-bridge start-all
+```
+
+`start-all` launches the bridge plus the dashboard, then keeps them alive.
+
+### How to tell it's working
+
+- Status bar shows "Connected to bridge"
+- The Analytics panel under the Claude icon in the activity bar opens without a "no bridge found" message
+- A lock file appears at `~/.claude/ide/<port>.lock` (Windows: `%USERPROFILE%\.claude\ide\<port>.lock`)
+
+### Troubleshooting
+
+- **Port already in use** — another bridge instance is running. `claude-ide-bridge halts --window 1h` shows recent activity.
+- **`claude-ide-bridge: command not found`** — install with `npm i -g patchwork-os`. Restart your shell after install.
+- **Extension still shows disconnected** — click **Reconnect** above. The extension polls `~/.claude/ide/` and reconnects within ~2s of the lock file appearing.

--- a/vscode-extension/docs/walkthrough-first-task.md
+++ b/vscode-extension/docs/walkthrough-first-task.md
@@ -1,0 +1,33 @@
+## Run your first Claude task
+
+The bridge exposes a queue for background Claude tasks: prompts you fire-and-forget while continuing other work. They show up in the Analytics panel and notify on completion.
+
+### Two ways to start one
+
+**From the sidebar:** click **+ New Task** in the Claude panel, type your prompt, hit Enter.
+
+**From the CLI:**
+
+```bash
+claude-ide-bridge start-task "explain the architecture of src/bridge.ts"
+```
+
+### Preset tasks
+
+For common workflows, use a preset instead of typing the prompt every time:
+
+```bash
+claude-ide-bridge quick-task explainCode    # uses the active editor
+claude-ide-bridge quick-task fixErrors      # acts on current diagnostics
+claude-ide-bridge quick-task addTests       # generates tests for active file
+```
+
+`claude-ide-bridge quick-task --help` lists all presets (`fixErrors`, `refactorFile`, `addTests`, `explainCode`, `optimizePerf`, `runTests`, `resumeLastCancelled`).
+
+### Where the output goes
+
+- Streaming text shows in the **Output → Claude IDE Bridge** channel
+- Final answer is written to the Analytics panel
+- If you want it in chat, switch to the regular Claude chat panel after the task completes and ask "what did that task return?"
+
+Tasks are queued, not exclusive — fire multiple at once.

--- a/vscode-extension/docs/walkthrough-open-panel.md
+++ b/vscode-extension/docs/walkthrough-open-panel.md
@@ -1,0 +1,20 @@
+## The Analytics Panel
+
+The Analytics panel surfaces what the bridge is doing in real time. Open it from the Claude icon in the activity bar (left sidebar) or with the **Claude IDE Bridge: Open Panel** command.
+
+### What it shows
+
+- **Connection health** — bridge status, extension protocol version, current session ID
+- **Tool calls** — the last N MCP tool invocations Claude has made, with timing and outcome
+- **Active tasks** — any in-flight Claude subprocess tasks queued via `runClaudeTask`
+- **Recent decisions** — approvals, recipe runs, and ctx-trace saves from the last 12 hours
+
+### When to look at it
+
+- After a slow turn — was Claude bottlenecked on a tool call or waiting on an extension response?
+- During a recipe run — every step's tool calls are visible
+- Before reporting an issue — the connection-health row tells maintainers what to investigate first
+
+### Keyboard shortcut
+
+The panel doesn't bind a shortcut by default. Add one via **Keyboard Shortcuts** → search for `Open Panel`.

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "claude-ide-bridge-extension",
   "displayName": "Claude IDE Bridge",
   "description": "MCP bridge between Claude Code and your IDE. 170+ tools — diagnostics, LSP, debugger, terminal, git. Optional Patchwork OS layer adds recipes, oversight, and approval queue.",
-  "version": "1.4.14",
+  "version": "1.4.15",
   "extensionKind": [
     "workspace"
   ],
@@ -69,7 +69,7 @@
               "onCommand:claudeIdeBridge.reconnect"
             ],
             "media": {
-              "markdown": "docs/walkthrough-hooks.md"
+              "markdown": "docs/walkthrough-check-connection.md"
             }
           },
           {
@@ -80,7 +80,7 @@
               "onView:claudeIdeBridgeAnalytics"
             ],
             "media": {
-              "markdown": "docs/walkthrough-hooks.md"
+              "markdown": "docs/walkthrough-open-panel.md"
             }
           },
           {
@@ -91,7 +91,7 @@
               "onCommand:claudeIdeBridge.startTask"
             ],
             "media": {
-              "markdown": "docs/walkthrough-hooks.md"
+              "markdown": "docs/walkthrough-first-task.md"
             }
           },
           {


### PR DESCRIPTION
## Summary

Last code/content item from the Windows audit. All 4 walkthrough steps in \`vscode-extension/package.json\` pointed at the same \`docs/walkthrough-hooks.md\` — a 17-line file describing only the automation-hook config step. First-time users opening the *Verify bridge is running*, *Open the Analytics Panel*, or *Run your first task* steps saw misaligned content that didn't match the step they were on.

### Three new step-specific pages

- **walkthrough-check-connection.md** — \`start-all\` command, lock file location (with Windows \`%USERPROFILE%\` form), troubleshooting common failures
- **walkthrough-open-panel.md** — what the Analytics panel shows, when to consult it, how to add a keyboard shortcut
- **walkthrough-first-task.md** — \`start-task\` + \`quick-task\` presets, where output goes, multi-task queueing

\`walkthrough-hooks.md\` stays as-is for the \`configureHook\` step.

Extension version bumped 1.4.14 → 1.4.15 per the project's "always bump on .vsix repackage" rule.

## Test plan

- [x] \`npm run build\` (extension) clean
- [x] \`package.json\` valid JSON
- [x] No code paths changed; just doc routing
- [ ] Install the new .vsix in VS Code, open the walkthrough, verify each step shows its own page

## Closes from the audit

| Audit finding | Status |
|---|---|
| Walkthrough doc is 17 lines × 4 steps point to same file | **fixed** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)