### PR TITLE
feat(bridge): HTTP /shutdown endpoint for clean exit on Windows

### DIFF
--- a/scripts/smoke/cat11-shutdown.mjs
+++ b/scripts/smoke/cat11-shutdown.mjs
@@ -78,8 +78,20 @@ try {
     "11.2 lock file present before SIGTERM",
   );
 
-  // Send SIGTERM
-  proc.kill("SIGTERM");
+  const BASE = `http://127.0.0.1:${PORT}`;
+
+  // Trigger shutdown. POSIX: SIGTERM hits the signal handler. Windows:
+  // SIGTERM is TerminateProcess (no handlers fire), so POST /shutdown
+  // which calls the bridge's internal shutdown sequence directly.
+  if (process.platform === "win32") {
+    await httpPost(
+      `${BASE}/shutdown`,
+      {},
+      { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+    ).catch(() => ({ status: 0 }));
+  } else {
+    proc.kill("SIGTERM");
+  }
 
   // Wait up to 5s for clean shutdown
   const deadline = Date.now() + 5_000;
@@ -88,7 +100,7 @@ try {
   }
 
   // 11.3 Exited within 5s
-  assert(exitCode !== null, "11.3 bridge exited within 5s of SIGTERM");
+  assert(exitCode !== null, "11.3 bridge exited within 5s of shutdown");
 
   // 11.4 Exit code is 143 or 0 (some bridges exit 0 on graceful SIGTERM)
   assert(
@@ -96,32 +108,23 @@ try {
     `11.4 exit code is 0 or 143 (got ${exitCode})`,
   );
 
-  // 11.5 / 11.6 — clean-shutdown invariants. On POSIX SIGTERM hits the
-  // bridge's signal handlers, which unlink the lock file + close the HTTP
-  // server. Windows `process.kill('SIGTERM')` is documented as
-  // TerminateProcess (no clean-shutdown handlers fire), so the lockfile
-  // cleanup + HTTP-server close paths aren't exercised by SIGTERM here.
-  // Skip these two on win32 until the harness uses a Windows-clean exit
-  // path (HTTP /shutdown endpoint, CTRL_BREAK_EVENT, etc).
-  if (process.platform !== "win32") {
-    // Give OS a brief moment to flush — lock removal happens before process exit
-    await sleep(300);
-    assert(
-      !lockExistsIn(PORT, ENV.CLAUDE_CONFIG_DIR),
-      "11.5 lock file removed after shutdown",
-    );
+  // 11.5 / 11.6 — clean-shutdown invariants. Both POSIX (SIGTERM handler)
+  // and Windows (HTTP /shutdown) now exercise the same cleanup path.
+  await sleep(300);
+  assert(
+    !lockExistsIn(PORT, ENV.CLAUDE_CONFIG_DIR),
+    "11.5 lock file removed after shutdown",
+  );
 
-    const BASE = `http://127.0.0.1:${PORT}`;
-    const r = await httpPost(
-      `${BASE}/mcp`,
-      { jsonrpc: "2.0", id: 2, method: "tools/list", params: {} },
-      { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
-    ).catch(() => ({ status: 0 }));
-    assert(
-      r.status === 0 || r.status === 503 || r.status === 404,
-      `11.6 HTTP endpoint closed after shutdown (got ${r.status})`,
-    );
-  }
+  const r = await httpPost(
+    `${BASE}/mcp`,
+    { jsonrpc: "2.0", id: 2, method: "tools/list", params: {} },
+    { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+  ).catch(() => ({ status: 0 }));
+  assert(
+    r.status === 0 || r.status === 503 || r.status === 404,
+    `11.6 HTTP endpoint closed after shutdown (got ${r.status})`,
+  );
 } finally {
   // Ensure bridge is dead even if test throws
   try {

--- a/src/__tests__/shutdown.test.ts
+++ b/src/__tests__/shutdown.test.ts
@@ -1,0 +1,131 @@
+import http from "node:http";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { Logger } from "../logger.js";
+import { Server } from "../server.js";
+
+const logger = new Logger(false);
+
+describe("POST /shutdown endpoint", () => {
+  let server: Server;
+  let port: number;
+  const authToken = "test-shutdown-token";
+
+  beforeEach(async () => {
+    server = new Server(authToken, logger);
+    port = await server.findAndListen(null);
+    // Prevent the default SIGTERM-to-self from firing during tests.
+    server.shutdownFn = () => {};
+  });
+
+  afterEach(async () => {
+    await server.close();
+  });
+
+  function makeRequest(
+    method: string,
+    path: string,
+  ): Promise<{ status: number; body: unknown }> {
+    return new Promise((resolve, reject) => {
+      const req = http.request(
+        {
+          hostname: "127.0.0.1",
+          port,
+          path,
+          method,
+          headers: { Authorization: `Bearer ${authToken}` },
+        },
+        (res) => {
+          let data = "";
+          res.on("data", (chunk) => {
+            data += chunk;
+          });
+          res.on("end", () => {
+            try {
+              const parsed = data ? JSON.parse(data) : {};
+              resolve({ status: res.statusCode ?? 0, body: parsed });
+            } catch {
+              resolve({ status: res.statusCode ?? 0, body: data });
+            }
+          });
+        },
+      );
+      req.on("error", reject);
+      req.end();
+    });
+  }
+
+  it("returns 202 when no work is in flight", async () => {
+    server.restartCheckFn = () => ({
+      totalSessions: 0,
+      inFlightCalls: 0,
+      busySessions: [],
+    });
+
+    const res = await makeRequest("POST", "/shutdown");
+    expect(res.status).toBe(202);
+    expect((res.body as { ok?: boolean }).ok).toBe(true);
+  });
+
+  it("returns 409 when tool calls are in flight", async () => {
+    server.restartCheckFn = () => ({
+      totalSessions: 1,
+      inFlightCalls: 2,
+      busySessions: ["abc12345 (2 tools: file.read, git.status)"],
+    });
+
+    const res = await makeRequest("POST", "/shutdown");
+    expect(res.status).toBe(409);
+    expect((res.body as { error?: string }).error).toBe("shutdown_blocked");
+    expect((res.body as { inFlightCalls?: number }).inFlightCalls).toBe(2);
+  });
+
+  it("force=1 overrides the in-flight check", async () => {
+    server.restartCheckFn = () => ({
+      totalSessions: 1,
+      inFlightCalls: 5,
+      busySessions: ["abc"],
+    });
+
+    const res = await makeRequest("POST", "/shutdown?force=1");
+    expect(res.status).toBe(202);
+    expect((res.body as { ok?: boolean }).ok).toBe(true);
+  });
+
+  it("calls shutdownFn after responding", async () => {
+    let called = false;
+    server.shutdownFn = () => {
+      called = true;
+    };
+    server.restartCheckFn = () => ({
+      totalSessions: 0,
+      inFlightCalls: 0,
+      busySessions: [],
+    });
+
+    const res = await makeRequest("POST", "/shutdown");
+    expect(res.status).toBe(202);
+    // shutdownFn is invoked via setTimeout(100); wait it out.
+    await new Promise((r) => setTimeout(r, 200));
+    expect(called).toBe(true);
+  });
+
+  it("requires authentication", async () => {
+    const res = await new Promise<{ status: number }>((resolve, reject) => {
+      const req = http.request(
+        {
+          hostname: "127.0.0.1",
+          port,
+          path: "/shutdown",
+          method: "POST",
+        },
+        (r) => {
+          r.resume();
+          resolve({ status: r.statusCode ?? 0 });
+        },
+      );
+      req.on("error", reject);
+      req.end();
+    });
+    expect(res.status).toBe(401);
+  });
+});

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -1787,6 +1787,17 @@ export class Bridge {
     // All process-level signal handlers are guarded by globalHandlersRegistered so
     // that repeated start() calls (e.g. in tests or --watch restarts) don't
     // accumulate process.once listeners and trigger MaxListenersExceededWarning.
+    // Wire server callbacks so /restart and /shutdown invoke the bridge's
+    // shutdown sequence directly. This is the only path that works on
+    // Windows, where `process.kill(pid, 'SIGTERM')` is TerminateProcess
+    // and registered handlers never fire.
+    this.server.restartKillFn = () => {
+      void shutdown("SIGTERM", 143);
+    };
+    this.server.shutdownFn = () => {
+      void shutdown("SIGTERM", 0);
+    };
+
     if (!globalHandlersRegistered) {
       globalHandlersRegistered = true;
       process.once("SIGINT", () => shutdown("SIGINT", 130));

--- a/src/server.ts
+++ b/src/server.ts
@@ -515,6 +515,15 @@ export class Server extends EventEmitter<ServerEvents> {
   public restartKillFn: () => void = () => process.kill(process.pid, "SIGTERM");
 
   /**
+   * Called when /shutdown decides it is safe to exit. Defaults to
+   * `process.kill(process.pid, 'SIGTERM')`. Bridge overrides this to run its
+   * internal shutdown sequence directly — necessary on Windows where
+   * `process.kill(pid, 'SIGTERM')` is TerminateProcess and cleanup handlers
+   * never fire.
+   */
+  public shutdownFn: () => void = () => process.kill(process.pid, "SIGTERM");
+
+  /**
    * Attach an OAuth 2.0 Authorization Server.
    * When set, the bridge exposes:
    *   GET  /.well-known/oauth-authorization-server
@@ -2022,6 +2031,51 @@ export class Server extends EventEmitter<ServerEvents> {
         setTimeout(() => {
           this.logger.info("[/restart] Sending SIGTERM to self");
           killFn();
+        }, 100);
+        return;
+      }
+
+      // /shutdown — graceful exit endpoint. POST → triggers the bridge's
+      // internal shutdown sequence (lockfile unlink, HTTP close, telemetry
+      // flush). Same in-flight safety check as /restart; pass `?force=1` to
+      // skip it. Necessary on Windows where `process.kill(pid, 'SIGTERM')`
+      // is TerminateProcess and cleanup handlers never fire — the bridge
+      // wires `shutdownFn` to call the shutdown sequence directly.
+      if (parsedUrl.pathname === "/shutdown" && req.method === "POST") {
+        const force = parsedUrl.searchParams.get("force") === "1";
+        if (!force && this.restartCheckFn) {
+          const check = this.restartCheckFn();
+          if (check.inFlightCalls > 0) {
+            this.logger.warn(
+              `[/shutdown] Rejected — ${check.inFlightCalls} in-flight tool call${check.inFlightCalls === 1 ? "" : "s"}`,
+            );
+            res.writeHead(409, { "Content-Type": "application/json" });
+            res.end(
+              JSON.stringify({
+                ok: false,
+                error: "shutdown_blocked",
+                reason: `${check.inFlightCalls} tool call${check.inFlightCalls === 1 ? "" : "s"} in progress`,
+                inFlightCalls: check.inFlightCalls,
+                busySessions: check.busySessions,
+              }),
+            );
+            return;
+          }
+        }
+
+        this.logger.info("[/shutdown] Initiating graceful shutdown");
+        res.writeHead(202, { "Content-Type": "application/json" });
+        res.end(
+          JSON.stringify({
+            ok: true,
+            message: "Shutdown initiated.",
+          }),
+        );
+
+        const shutdownFn = this.shutdownFn;
+        setTimeout(() => {
+          this.logger.info("[/shutdown] Calling bridge shutdown sequence");
+          shutdownFn();
         }, 100);
         return;
       }


### PR DESCRIPTION
## Summary
- Adds Bearer-authenticated `POST /shutdown` that invokes the bridge's internal shutdown sequence directly (lockfile unlink, HTTP close, telemetry flush)
- Bridge wires `server.shutdownFn` and `server.restartKillFn` to call the local shutdown closure — works on both POSIX and Windows
- `cat11-shutdown` smoke now POSTs `/shutdown` on win32, re-enabling the previously-skipped 11.5/11.6 invariants

## Why
On Windows, `process.kill(pid, 'SIGTERM')` is `TerminateProcess`: registered signal handlers never run. Neither `/restart` nor `SIGTERM` previously exercised the cleanup path on Windows — `/restart` was effectively a hard kill, and CAT-11.5/11.6 were skipped on win32. With the new endpoint both platforms hit the same code path.

## Test plan
- [x] New `src/__tests__/shutdown.test.ts` covers 202 / 409 / `?force=1` / auth / `shutdownFn` invocation (5 tests, all pass)
- [x] Existing `src/__tests__/restart.test.ts` unaffected (5 tests pass)
- [x] `cat11-shutdown.mjs` POSIX run: 6/6 pass locally
- [ ] Watch windows-latest smoke job — 11.5/11.6 should now be exercised on Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)