### PR TITLE
test(extension): un-skip 5 win32-gated suites with cross-platform paths

### DIFF
--- a/vscode-extension/src/__tests__/__mocks__/vscode.ts
+++ b/vscode-extension/src/__tests__/__mocks__/vscode.ts
@@ -3,7 +3,12 @@
  * Only mocks what the extension handlers actually use.
  * Resolved via vitest alias so handler source code needs zero changes.
  */
+import * as path from "node:path";
 import { vi } from "vitest";
+
+/** Platform-aware workspace root used by __reset defaults and exported for tests. */
+export const MOCK_WORKSPACE_ROOT = path.resolve("/workspace");
+export const MOCK_TEST_ROOT = path.resolve("/test-root");
 
 // ── Constructors ──────────────────────────────────────────────
 
@@ -432,8 +437,8 @@ export function _mockTerminal(
 export function __reset() {
   workspace.isTrusted = true;
   workspace.workspaceFolders = [
-    { uri: { fsPath: "/workspace" } },
-    { uri: { fsPath: "/test-root" } },
+    { uri: { fsPath: MOCK_WORKSPACE_ROOT } },
+    { uri: { fsPath: MOCK_TEST_ROOT } },
   ] as any;
   workspace.textDocuments = [];
   workspace.openTextDocument

--- a/vscode-extension/src/__tests__/bridgeInstaller.test.ts
+++ b/vscode-extension/src/__tests__/bridgeInstaller.test.ts
@@ -1,9 +1,7 @@
-// TODO(windows): test fixtures use POSIX-only literal paths (e.g. fsPath: "/workspace")
-// that path.resolve() on win32 rewrites to drive-prefixed absolute paths, breaking
-// the workspace-containment + lockfile lookups the handlers do. Migrate to
-// platform-aware fixtures before flipping windows-latest extension CI from advisory.
-
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const BRIDGE_BIN =
+  process.platform === "win32" ? "claude-ide-bridge.cmd" : "claude-ide-bridge";
 
 // Mock vscode
 vi.mock("vscode", () => ({
@@ -59,94 +57,85 @@ afterEach(() => {
   vi.clearAllMocks();
 });
 
-describe.skipIf(process.platform === "win32")(
-  "BridgeInstaller.getInstalledVersion",
-  () => {
-    it("returns semver from claude-ide-bridge --version output", async () => {
-      mockExec("claude-ide-bridge 2.0.0\n");
-      const v = await installer.getInstalledVersion();
-      expect(v).toBe("2.0.0");
-    });
+describe("BridgeInstaller.getInstalledVersion", () => {
+  it("returns semver from claude-ide-bridge --version output", async () => {
+    mockExec("claude-ide-bridge 2.0.0\n");
+    const v = await installer.getInstalledVersion();
+    expect(v).toBe("2.0.0");
+  });
 
-    it("returns null when binary not found", async () => {
-      mockedExecFile.mockImplementationOnce(
-        (_bin: string, _args: string[], _opts: unknown, cb: Function) => {
-          cb(new Error("ENOENT"));
-        },
-      );
-      const v = await installer.getInstalledVersion();
-      expect(v).toBeNull();
-    });
-  },
-);
+  it("returns null when binary not found", async () => {
+    mockedExecFile.mockImplementationOnce(
+      (_bin: string, _args: string[], _opts: unknown, cb: Function) => {
+        cb(new Error("ENOENT"));
+      },
+    );
+    const v = await installer.getInstalledVersion();
+    expect(v).toBeNull();
+  });
+});
 
-describe.skipIf(process.platform === "win32")(
-  "BridgeInstaller.getRequiredVersion",
-  () => {
-    it("returns the injected BRIDGE_VERSION", () => {
-      expect(installer.getRequiredVersion()).toBe("2.0.1");
-    });
-  },
-);
+describe("BridgeInstaller.getRequiredVersion", () => {
+  it("returns the injected BRIDGE_VERSION", () => {
+    expect(installer.getRequiredVersion()).toBe("2.0.1");
+  });
+});
 
-describe.skipIf(process.platform === "win32")(
-  "BridgeInstaller.ensureInstalled",
-  () => {
-    it("is a no-op when installed version matches required", async () => {
-      // getInstalledVersion returns 2.0.1 (matches BRIDGE_VERSION)
-      mockExec("2.0.1\n");
-      await installer.ensureInstalled();
-      // npm install should NOT have been called
-      expect(mockedExecFile).toHaveBeenCalledTimes(1);
-      expect(mockedExecFile.mock.calls[0][0]).toBe("claude-ide-bridge");
-    });
+describe("BridgeInstaller.ensureInstalled", () => {
+  it("is a no-op when installed version matches required", async () => {
+    // getInstalledVersion returns 2.0.1 (matches BRIDGE_VERSION)
+    mockExec("2.0.1\n");
+    await installer.ensureInstalled();
+    // npm install should NOT have been called
+    expect(mockedExecFile).toHaveBeenCalledTimes(1);
+    expect(mockedExecFile.mock.calls[0][0]).toBe(BRIDGE_BIN);
+  });
 
-    it("calls npm install when bridge is not installed", async () => {
-      // getInstalledVersion → null (not found)
-      mockedExecFile.mockImplementationOnce(
-        (_bin: string, _args: string[], _opts: unknown, cb: Function) => {
-          cb(new Error("ENOENT"));
-        },
-      );
-      // npm install succeeds
-      mockExec("", "", 0);
+  it("calls npm install when bridge is not installed", async () => {
+    // getInstalledVersion → null (not found)
+    mockedExecFile.mockImplementationOnce(
+      (_bin: string, _args: string[], _opts: unknown, cb: Function) => {
+        cb(new Error("ENOENT"));
+      },
+    );
+    // npm install succeeds
+    mockExec("", "", 0);
 
-      await installer.ensureInstalled();
+    await installer.ensureInstalled();
 
-      expect(mockedExecFile).toHaveBeenCalledTimes(2);
-      const npmCall = mockedExecFile.mock.calls[1];
-      expect(npmCall[0]).toMatch(/npm/);
-      expect(npmCall[1]).toContain("install");
-      expect(npmCall[1]).toContain("-g");
-      expect(npmCall[1].some((a: string) => a.includes("2.0.1"))).toBe(true);
-    });
+    expect(mockedExecFile).toHaveBeenCalledTimes(2);
+    const npmCall = mockedExecFile.mock.calls[1];
+    expect(npmCall[0]).toMatch(/npm/);
+    expect(npmCall[1]).toContain("install");
+    expect(npmCall[1]).toContain("-g");
+    expect(npmCall[1].some((a: string) => a.includes("2.0.1"))).toBe(true);
+  });
 
-    it("calls npm install when installed version is outdated", async () => {
-      mockExec("1.9.0\n"); // outdated
-      mockExec("", "", 0); // npm install succeeds
+  it("calls npm install when installed version is outdated", async () => {
+    mockExec("1.9.0\n"); // outdated
+    mockExec("", "", 0); // npm install succeeds
 
-      await installer.ensureInstalled();
+    await installer.ensureInstalled();
 
-      expect(mockedExecFile).toHaveBeenCalledTimes(2);
-    });
+    expect(mockedExecFile).toHaveBeenCalledTimes(2);
+  });
 
-    it("shows warning when npm is not found", async () => {
-      // getInstalledVersion → null
-      mockedExecFile.mockImplementationOnce(
-        (_bin: string, _args: string[], _opts: unknown, cb: Function) => {
-          cb(new Error("ENOENT"));
-        },
-      );
-      // npm install → ENOENT
-      mockedExecFile.mockImplementationOnce(
-        (_bin: string, _args: string[], _opts: unknown, cb: Function) => {
-          const err = new Error("ENOENT: npm not found");
-          cb(err, { stdout: "", stderr: "" });
-        },
-      );
+  it("shows warning when npm is not found", async () => {
+    // getInstalledVersion → null
+    mockedExecFile.mockImplementationOnce(
+      (_bin: string, _args: string[], _opts: unknown, cb: Function) => {
+        cb(new Error("ENOENT"));
+      },
+    );
+    // npm install → ENOENT
+    mockedExecFile.mockImplementationOnce(
+      (_bin: string, _args: string[], _opts: unknown, cb: Function) => {
+        const err = new Error("ENOENT: npm not found");
+        cb(err, { stdout: "", stderr: "" });
+      },
+    );
 
-      await expect(installer.ensureInstalled()).rejects.toThrow();
-      expect(vscode.window.showWarningMessage).toHaveBeenCalled();
-    });
-  },
-);
+    await expect(installer.ensureInstalled()).rejects.toThrow();
+    expect(vscode.window.showWarningMessage).toHaveBeenCalled();
+  });
+});

--- a/vscode-extension/src/__tests__/handlers/codeActions.test.ts
+++ b/vscode-extension/src/__tests__/handlers/codeActions.test.ts
@@ -1,8 +1,4 @@
-// TODO(windows): test fixtures use POSIX-only literal paths (e.g. fsPath: "/workspace")
-// that path.resolve() on win32 rewrites to drive-prefixed absolute paths, breaking
-// the workspace-containment + lockfile lookups the handlers do. Migrate to
-// platform-aware fixtures before flipping windows-latest extension CI from advisory.
-
+import * as path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import * as vscode from "vscode";
 import {
@@ -16,10 +12,13 @@ import {
   _mockTextEditor,
 } from "../__mocks__/vscode";
 
+const WORKSPACE = path.resolve("/workspace");
+const TEST_FILE = path.join(WORKSPACE, "file.ts");
+
 function setupEditorMock() {
   const save = vi.fn(async () => true);
   const doc = _mockTextDocument({
-    fsPath: "/workspace/file.ts",
+    fsPath: TEST_FILE,
     lineCount: 20,
     save,
   });
@@ -33,7 +32,7 @@ beforeEach(() => {
   __reset();
 });
 
-describe.skipIf(process.platform === "win32")("handleFormatDocument", () => {
+describe("handleFormatDocument", () => {
   it("applies formatting edits and saves", async () => {
     const { save } = setupEditorMock();
     const textEdit = {
@@ -46,7 +45,7 @@ describe.skipIf(process.platform === "win32")("handleFormatDocument", () => {
     vi.mocked(vscode.commands.executeCommand).mockResolvedValue([textEdit]);
 
     const result = (await handleFormatDocument({
-      file: "/workspace/file.ts",
+      file: TEST_FILE,
     })) as any;
     expect(result.success).toBe(true);
     expect(result.editsApplied).toBe(1);
@@ -59,7 +58,7 @@ describe.skipIf(process.platform === "win32")("handleFormatDocument", () => {
     vi.mocked(vscode.commands.executeCommand).mockResolvedValue([]);
 
     const result = (await handleFormatDocument({
-      file: "/workspace/file.ts",
+      file: TEST_FILE,
     })) as any;
     expect(result.success).toBe(true);
     expect(result.editsApplied).toBe(0);
@@ -77,14 +76,14 @@ describe.skipIf(process.platform === "win32")("handleFormatDocument", () => {
     );
 
     const result = (await handleFormatDocument({
-      file: "/workspace/file.ts",
+      file: TEST_FILE,
     })) as any;
     expect(result.error).toBe("provider failed");
     expect(result.success).toBeUndefined();
   });
 });
 
-describe.skipIf(process.platform === "win32")("handleFixAllLintErrors", () => {
+describe("handleFixAllLintErrors", () => {
   it("applies code actions with edits", async () => {
     const { save } = setupEditorMock();
     const wsEdit = new vscode.WorkspaceEdit();
@@ -92,7 +91,7 @@ describe.skipIf(process.platform === "win32")("handleFixAllLintErrors", () => {
     vi.mocked(vscode.commands.executeCommand).mockResolvedValue([action]);
 
     const result = (await handleFixAllLintErrors({
-      file: "/workspace/file.ts",
+      file: TEST_FILE,
     })) as any;
     expect(result.success).toBe(true);
     expect(result.actionsApplied).toBe(1);
@@ -110,7 +109,7 @@ describe.skipIf(process.platform === "win32")("handleFixAllLintErrors", () => {
       .mockResolvedValueOnce(undefined); // execute command
 
     const result = (await handleFixAllLintErrors({
-      file: "/workspace/file.ts",
+      file: TEST_FILE,
     })) as any;
     expect(result.actionsApplied).toBe(1);
   });
@@ -120,7 +119,7 @@ describe.skipIf(process.platform === "win32")("handleFixAllLintErrors", () => {
     vi.mocked(vscode.commands.executeCommand).mockResolvedValue([]);
 
     const result = (await handleFixAllLintErrors({
-      file: "/workspace/file.ts",
+      file: TEST_FILE,
     })) as any;
     expect(result.success).toBe(true);
     expect(result.actionsApplied).toBe(0);
@@ -133,13 +132,13 @@ describe.skipIf(process.platform === "win32")("handleFixAllLintErrors", () => {
     );
 
     const result = (await handleFixAllLintErrors({
-      file: "/workspace/file.ts",
+      file: TEST_FILE,
     })) as any;
     expect(result.error).toBe("lint provider crashed");
   });
 });
 
-describe.skipIf(process.platform === "win32")("handleOrganizeImports", () => {
+describe("handleOrganizeImports", () => {
   it("applies organize imports action", async () => {
     const { save } = setupEditorMock();
     const wsEdit = new vscode.WorkspaceEdit();
@@ -147,7 +146,7 @@ describe.skipIf(process.platform === "win32")("handleOrganizeImports", () => {
     vi.mocked(vscode.commands.executeCommand).mockResolvedValue([action]);
 
     const result = (await handleOrganizeImports({
-      file: "/workspace/file.ts",
+      file: TEST_FILE,
     })) as any;
     expect(result.success).toBe(true);
     expect(result.actionsApplied).toBe(1);

--- a/vscode-extension/src/__tests__/handlers/editText.test.ts
+++ b/vscode-extension/src/__tests__/handlers/editText.test.ts
@@ -1,21 +1,20 @@
-// TODO(windows): test fixtures use POSIX-only literal paths (e.g. fsPath: "/workspace")
-// that path.resolve() on win32 rewrites to drive-prefixed absolutes, breaking the
-// workspace-containment check in handleEditText. Migrate to platform-aware fixtures
-// before flipping windows-latest extension CI from advisory to blocking.
-
+import * as path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import * as vscode from "vscode";
 import { handleEditText } from "../../handlers/editText";
 import { __reset, _mockTextDocument } from "../__mocks__/vscode";
 
+const WORKSPACE = path.resolve("/workspace");
+const TEST_FILE = path.join(WORKSPACE, "test.ts");
+
 beforeEach(() => {
   __reset();
 });
 
-describe.skipIf(process.platform === "win32")("handleEditText", () => {
+describe("handleEditText", () => {
   it("applies an insert edit", async () => {
     const result = (await handleEditText({
-      filePath: "/workspace/test.ts",
+      filePath: TEST_FILE,
       edits: [{ type: "insert", line: 1, column: 1, text: "hello" }],
     })) as any;
     expect(result.success).toBe(true);
@@ -25,7 +24,7 @@ describe.skipIf(process.platform === "win32")("handleEditText", () => {
 
   it("applies a delete edit", async () => {
     const result = (await handleEditText({
-      filePath: "/workspace/test.ts",
+      filePath: TEST_FILE,
       edits: [{ type: "delete", line: 1, column: 1, endLine: 1, endColumn: 5 }],
     })) as any;
     expect(result.success).toBe(true);
@@ -33,7 +32,7 @@ describe.skipIf(process.platform === "win32")("handleEditText", () => {
 
   it("applies a replace edit", async () => {
     const result = (await handleEditText({
-      filePath: "/workspace/test.ts",
+      filePath: TEST_FILE,
       edits: [
         {
           type: "replace",
@@ -50,7 +49,7 @@ describe.skipIf(process.platform === "win32")("handleEditText", () => {
 
   it("applies multiple edits", async () => {
     const result = (await handleEditText({
-      filePath: "/workspace/test.ts",
+      filePath: TEST_FILE,
       edits: [
         { type: "insert", line: 1, column: 1, text: "a" },
         { type: "insert", line: 2, column: 1, text: "b" },
@@ -62,7 +61,7 @@ describe.skipIf(process.platform === "win32")("handleEditText", () => {
 
   it("throws when edits is not an array", async () => {
     await expect(
-      handleEditText({ filePath: "/workspace/test.ts", edits: "bad" }),
+      handleEditText({ filePath: TEST_FILE, edits: "bad" }),
     ).rejects.toThrow("must be an array");
   });
 
@@ -74,14 +73,14 @@ describe.skipIf(process.platform === "win32")("handleEditText", () => {
       text: "x",
     }));
     await expect(
-      handleEditText({ filePath: "/workspace/test.ts", edits }),
+      handleEditText({ filePath: TEST_FILE, edits }),
     ).rejects.toThrow("Maximum 1000");
   });
 
   it("throws on unknown edit type", async () => {
     await expect(
       handleEditText({
-        filePath: "/workspace/test.ts",
+        filePath: TEST_FILE,
         edits: [{ type: "unknown", line: 1, column: 1 }],
       }),
     ).rejects.toThrow("Unknown edit type");
@@ -89,14 +88,14 @@ describe.skipIf(process.platform === "win32")("handleEditText", () => {
 
   it("throws when edit is not an object", async () => {
     await expect(
-      handleEditText({ filePath: "/workspace/test.ts", edits: ["bad"] }),
+      handleEditText({ filePath: TEST_FILE, edits: ["bad"] }),
     ).rejects.toThrow("must be an object");
   });
 
   it("returns error when applyEdit fails", async () => {
     vi.mocked(vscode.workspace.applyEdit).mockResolvedValue(false);
     const result = (await handleEditText({
-      filePath: "/workspace/test.ts",
+      filePath: TEST_FILE,
       edits: [{ type: "insert", line: 1, column: 1, text: "x" }],
     })) as any;
     expect(result.success).toBe(false);
@@ -104,11 +103,11 @@ describe.skipIf(process.platform === "win32")("handleEditText", () => {
 
   it("saves document when save=true", async () => {
     const save = vi.fn(async () => true);
-    const doc = _mockTextDocument({ fsPath: "/workspace/test.ts", save });
+    const doc = _mockTextDocument({ fsPath: TEST_FILE, save });
     vscode.workspace.textDocuments = [doc];
 
     const result = (await handleEditText({
-      filePath: "/workspace/test.ts",
+      filePath: TEST_FILE,
       edits: [{ type: "insert", line: 1, column: 1, text: "x" }],
       save: true,
     })) as any;
@@ -118,7 +117,7 @@ describe.skipIf(process.platform === "win32")("handleEditText", () => {
 
   it("does not save when save is not set", async () => {
     const result = (await handleEditText({
-      filePath: "/workspace/test.ts",
+      filePath: TEST_FILE,
       edits: [{ type: "insert", line: 1, column: 1, text: "x" }],
     })) as any;
     expect(result.saved).toBe(false);

--- a/vscode-extension/src/__tests__/handlers/files.test.ts
+++ b/vscode-extension/src/__tests__/handlers/files.test.ts
@@ -1,8 +1,4 @@
-// TODO(windows): test fixtures use POSIX-only literal paths (e.g. fsPath: "/workspace")
-// that path.resolve() on win32 rewrites to drive-prefixed absolute paths, breaking
-// the workspace-containment + lockfile lookups the handlers do. Migrate to
-// platform-aware fixtures before flipping windows-latest extension CI from advisory.
-
+import * as path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import * as vscode from "vscode";
 import {
@@ -22,67 +18,64 @@ import {
   Uri,
 } from "../__mocks__/vscode";
 
+const WORKSPACE = path.resolve("/workspace");
+const OTHER_ROOT = path.resolve("/other");
+const ANYWHERE = path.resolve("/anywhere");
+const wsFile = (...parts: string[]) => path.join(WORKSPACE, ...parts);
+const otherFile = (...parts: string[]) => path.join(OTHER_ROOT, ...parts);
+
 beforeEach(() => {
   __reset();
 });
 
 // ── Workspace boundary (tested through handlers) ──────────────
 
-describe.skipIf(process.platform === "win32")(
-  "workspace boundary checks",
-  () => {
-    it("rejects all paths when no workspace folders", async () => {
-      vscode.workspace.workspaceFolders = undefined;
-      await expect(
-        handleOpenFile({ file: "/anywhere/file.ts" }),
-      ).rejects.toThrow("No workspace is open");
-    });
+describe("workspace boundary checks", () => {
+  it("rejects all paths when no workspace folders", async () => {
+    vscode.workspace.workspaceFolders = undefined;
+    await expect(
+      handleOpenFile({ file: path.join(ANYWHERE, "file.ts") }),
+    ).rejects.toThrow("No workspace is open");
+  });
 
-    it("allows paths inside workspace", async () => {
-      vscode.workspace.workspaceFolders = [
-        { uri: { fsPath: "/workspace" } },
-      ] as any;
-      await expect(
-        handleOpenFile({ file: "/workspace/src/file.ts" }),
-      ).resolves.not.toThrow();
-    });
+  it("allows paths inside workspace", async () => {
+    vscode.workspace.workspaceFolders = [{ uri: { fsPath: WORKSPACE } }] as any;
+    await expect(
+      handleOpenFile({ file: wsFile("src", "file.ts") }),
+    ).resolves.not.toThrow();
+  });
 
-    it("allows exact workspace root", async () => {
-      vscode.workspace.workspaceFolders = [
-        { uri: { fsPath: "/workspace" } },
-      ] as any;
-      await expect(
-        handleIsDirty({ file: "/workspace" }),
-      ).resolves.not.toThrow();
-    });
+  it("allows exact workspace root", async () => {
+    vscode.workspace.workspaceFolders = [{ uri: { fsPath: WORKSPACE } }] as any;
+    await expect(handleIsDirty({ file: WORKSPACE })).resolves.not.toThrow();
+  });
 
-    it("rejects paths outside workspace", async () => {
-      vscode.workspace.workspaceFolders = [
-        { uri: { fsPath: "/workspace" } },
-      ] as any;
-      await expect(handleOpenFile({ file: "/other/file.ts" })).rejects.toThrow(
-        "outside the workspace",
-      );
-    });
-  },
-);
+  it("rejects paths outside workspace", async () => {
+    vscode.workspace.workspaceFolders = [{ uri: { fsPath: WORKSPACE } }] as any;
+    await expect(
+      handleOpenFile({ file: otherFile("file.ts") }),
+    ).rejects.toThrow("outside the workspace");
+  });
+});
 
 // ── handleGetOpenFiles ────────────────────────────────────────
 
-describe.skipIf(process.platform === "win32")("handleGetOpenFiles", () => {
+describe("handleGetOpenFiles", () => {
   it("returns empty array when no tabs", async () => {
     vscode.window.tabGroups.all = [];
     expect(await handleGetOpenFiles()).toEqual([]);
   });
 
   it("returns file info for TabInputText tabs", async () => {
-    const uri = Uri.file("/workspace/test.ts");
+    const fileA = wsFile("test.ts");
+    const fileB = wsFile("other.ts");
+    const uri = Uri.file(fileA);
     vscode.window.tabGroups.all = [
       {
         tabs: [
           { input: new TabInputText(uri), isActive: true, isDirty: false },
           {
-            input: new TabInputText(Uri.file("/workspace/other.ts")),
+            input: new TabInputText(Uri.file(fileB)),
             isActive: false,
             isDirty: true,
           },
@@ -93,12 +86,12 @@ describe.skipIf(process.platform === "win32")("handleGetOpenFiles", () => {
     const result = (await handleGetOpenFiles()) as any[];
     expect(result).toHaveLength(2);
     expect(result[0]).toEqual({
-      filePath: "/workspace/test.ts",
+      filePath: fileA,
       isActive: true,
       isDirty: false,
     });
     expect(result[1]).toEqual({
-      filePath: "/workspace/other.ts",
+      filePath: fileB,
       isActive: false,
       isDirty: true,
     });
@@ -122,7 +115,7 @@ describe.skipIf(process.platform === "win32")("handleGetOpenFiles", () => {
 
 // ── handleIsDirty ─────────────────────────────────────────────
 
-describe.skipIf(process.platform === "win32")("handleIsDirty", () => {
+describe("handleIsDirty", () => {
   it("throws on non-string file param", async () => {
     await expect(handleIsDirty({ file: 123 } as any)).rejects.toThrow(
       "must be a non-empty string",
@@ -130,34 +123,34 @@ describe.skipIf(process.platform === "win32")("handleIsDirty", () => {
   });
 
   it("returns true for dirty document", async () => {
-    const doc = _mockTextDocument({ fsPath: "/workspace/f.ts", isDirty: true });
+    const doc = _mockTextDocument({ fsPath: wsFile("f.ts"), isDirty: true });
     vscode.workspace.textDocuments = [doc];
-    expect(await handleIsDirty({ file: "/workspace/f.ts" })).toBe(true);
+    expect(await handleIsDirty({ file: wsFile("f.ts") })).toBe(true);
   });
 
   it("returns false for clean document", async () => {
     const doc = _mockTextDocument({
-      fsPath: "/workspace/f.ts",
+      fsPath: wsFile("f.ts"),
       isDirty: false,
     });
     vscode.workspace.textDocuments = [doc];
-    expect(await handleIsDirty({ file: "/workspace/f.ts" })).toBe(false);
+    expect(await handleIsDirty({ file: wsFile("f.ts") })).toBe(false);
   });
 
   it("returns false when document not found", async () => {
     vscode.workspace.textDocuments = [];
-    expect(await handleIsDirty({ file: "/workspace/missing.ts" })).toBe(false);
+    expect(await handleIsDirty({ file: wsFile("missing.ts") })).toBe(false);
   });
 });
 
 // ── handleOpenFile ────────────────────────────────────────────
 
-describe.skipIf(process.platform === "win32")("handleOpenFile", () => {
+describe("handleOpenFile", () => {
   it("opens document and shows with position", async () => {
-    const doc = _mockTextDocument({ fsPath: "/workspace/f.ts" });
+    const doc = _mockTextDocument({ fsPath: wsFile("f.ts") });
     vi.mocked(vscode.workspace.openTextDocument).mockResolvedValue(doc);
 
-    const result = await handleOpenFile({ file: "/workspace/f.ts", line: 10 });
+    const result = await handleOpenFile({ file: wsFile("f.ts"), line: 10 });
     expect(result).toBe(true);
     expect(vscode.workspace.openTextDocument).toHaveBeenCalled();
     expect(vscode.window.showTextDocument).toHaveBeenCalledWith(
@@ -167,9 +160,9 @@ describe.skipIf(process.platform === "win32")("handleOpenFile", () => {
   });
 
   it("defaults to line 1", async () => {
-    const doc = _mockTextDocument({ fsPath: "/workspace/f.ts" });
+    const doc = _mockTextDocument({ fsPath: wsFile("f.ts") });
     vi.mocked(vscode.workspace.openTextDocument).mockResolvedValue(doc);
-    await handleOpenFile({ file: "/workspace/f.ts" });
+    await handleOpenFile({ file: wsFile("f.ts") });
     // Position should be (0, 0) since line defaults to 1, converted to 0-based
     expect(vscode.window.showTextDocument).toHaveBeenCalled();
   });
@@ -177,38 +170,38 @@ describe.skipIf(process.platform === "win32")("handleOpenFile", () => {
 
 // ── handleSaveFile ────────────────────────────────────────────
 
-describe.skipIf(process.platform === "win32")("handleSaveFile", () => {
+describe("handleSaveFile", () => {
   it("saves an open document", async () => {
     const save = vi.fn(async () => true);
-    const doc = _mockTextDocument({ fsPath: "/workspace/f.ts", save });
+    const doc = _mockTextDocument({ fsPath: wsFile("f.ts"), save });
     vscode.workspace.textDocuments = [doc];
-    expect(await handleSaveFile({ file: "/workspace/f.ts" })).toBe(true);
+    expect(await handleSaveFile({ file: wsFile("f.ts") })).toBe(true);
     expect(save).toHaveBeenCalled();
   });
 
   it("returns error for untitled document", async () => {
     const doc = _mockTextDocument({
-      fsPath: "/workspace/f.ts",
+      fsPath: wsFile("f.ts"),
       isUntitled: true,
     });
     vscode.workspace.textDocuments = [doc];
-    const result = (await handleSaveFile({ file: "/workspace/f.ts" })) as any;
+    const result = (await handleSaveFile({ file: wsFile("f.ts") })) as any;
     expect(result.success).toBe(false);
     expect(result.error).toContain("untitled");
   });
 
   it("returns error when document not open", async () => {
     vscode.workspace.textDocuments = [];
-    const result = (await handleSaveFile({ file: "/workspace/f.ts" })) as any;
+    const result = (await handleSaveFile({ file: wsFile("f.ts") })) as any;
     expect(result.success).toBe(false);
   });
 });
 
 // ── handleCloseTab ────────────────────────────────────────────
 
-describe.skipIf(process.platform === "win32")("handleCloseTab", () => {
+describe("handleCloseTab", () => {
   it("closes a matching tab", async () => {
-    const uri = Uri.file("/workspace/f.ts");
+    const uri = Uri.file(wsFile("f.ts"));
     const tab = {
       input: new TabInputText(uri),
       isActive: true,
@@ -217,14 +210,14 @@ describe.skipIf(process.platform === "win32")("handleCloseTab", () => {
     vscode.window.tabGroups.all = [{ tabs: [tab] }] as any;
     vi.mocked(vscode.window.tabGroups.close).mockResolvedValue(true);
 
-    const result = (await handleCloseTab({ file: "/workspace/f.ts" })) as any;
+    const result = (await handleCloseTab({ file: wsFile("f.ts") })) as any;
     expect(result.success).toBe(true);
     expect(result.promptedToSave).toBe(false);
   });
 
   it("returns error when tab not found", async () => {
     vscode.window.tabGroups.all = [];
-    const result = (await handleCloseTab({ file: "/workspace/f.ts" })) as any;
+    const result = (await handleCloseTab({ file: wsFile("f.ts") })) as any;
     expect(result.success).toBe(false);
     expect(result.error).toContain("not found");
   });
@@ -232,10 +225,10 @@ describe.skipIf(process.platform === "win32")("handleCloseTab", () => {
 
 // ── handleCreateFile ──────────────────────────────────────────
 
-describe.skipIf(process.platform === "win32")("handleCreateFile", () => {
+describe("handleCreateFile", () => {
   it("creates a file and opens it", async () => {
     const result = (await handleCreateFile({
-      filePath: "/workspace/new.ts",
+      filePath: wsFile("new.ts"),
       content: "hello",
     })) as any;
     expect(result.success).toBe(true);
@@ -246,7 +239,7 @@ describe.skipIf(process.platform === "win32")("handleCreateFile", () => {
 
   it("creates a directory", async () => {
     const result = (await handleCreateFile({
-      filePath: "/workspace/dir",
+      filePath: wsFile("dir"),
       isDirectory: true,
     })) as any;
     expect(result.success).toBe(true);
@@ -256,7 +249,7 @@ describe.skipIf(process.platform === "win32")("handleCreateFile", () => {
 
   it("skips opening when openAfterCreate=false", async () => {
     await handleCreateFile({
-      filePath: "/workspace/new.ts",
+      filePath: wsFile("new.ts"),
       openAfterCreate: false,
     });
     expect(vscode.window.showTextDocument).not.toHaveBeenCalled();
@@ -265,7 +258,7 @@ describe.skipIf(process.platform === "win32")("handleCreateFile", () => {
   it("returns error when applyEdit fails", async () => {
     vi.mocked(vscode.workspace.applyEdit).mockResolvedValue(false);
     const result = (await handleCreateFile({
-      filePath: "/workspace/new.ts",
+      filePath: wsFile("new.ts"),
     })) as any;
     expect(result.success).toBe(false);
   });
@@ -273,14 +266,14 @@ describe.skipIf(process.platform === "win32")("handleCreateFile", () => {
 
 // ── handleDeleteFile ──────────────────────────────────────────
 
-describe.skipIf(process.platform === "win32")("handleDeleteFile", () => {
+describe("handleDeleteFile", () => {
   it("deletes a file with defaults", async () => {
     const result = (await handleDeleteFile({
-      filePath: "/workspace/f.ts",
+      filePath: wsFile("f.ts"),
     })) as any;
     expect(result.success).toBe(true);
     expect(vscode.workspace.fs.delete).toHaveBeenCalledWith(
-      expect.objectContaining({ fsPath: "/workspace/f.ts" }),
+      expect.objectContaining({ fsPath: wsFile("f.ts") }),
       { recursive: false, useTrash: true },
     );
   });
@@ -290,7 +283,7 @@ describe.skipIf(process.platform === "win32")("handleDeleteFile", () => {
       new Error("ENOENT"),
     );
     const result = (await handleDeleteFile({
-      filePath: "/workspace/f.ts",
+      filePath: wsFile("f.ts"),
     })) as any;
     expect(result.success).toBe(false);
     expect(result.error).toContain("ENOENT");
@@ -299,11 +292,11 @@ describe.skipIf(process.platform === "win32")("handleDeleteFile", () => {
 
 // ── handleRenameFile ──────────────────────────────────────────
 
-describe.skipIf(process.platform === "win32")("handleRenameFile", () => {
+describe("handleRenameFile", () => {
   it("renames a file", async () => {
     const result = (await handleRenameFile({
-      oldPath: "/workspace/a.ts",
-      newPath: "/workspace/b.ts",
+      oldPath: wsFile("a.ts"),
+      newPath: wsFile("b.ts"),
     })) as any;
     expect(result.success).toBe(true);
     expect(result.renamed).toBe(true);
@@ -313,18 +306,19 @@ describe.skipIf(process.platform === "win32")("handleRenameFile", () => {
   it("returns error when applyEdit fails", async () => {
     vi.mocked(vscode.workspace.applyEdit).mockResolvedValue(false);
     const result = (await handleRenameFile({
-      oldPath: "/workspace/a.ts",
-      newPath: "/workspace/b.ts",
+      oldPath: wsFile("a.ts"),
+      newPath: wsFile("b.ts"),
     })) as any;
     expect(result.success).toBe(false);
   });
 
   it("checks both paths against workspace", async () => {
-    vscode.workspace.workspaceFolders = [
-      { uri: { fsPath: "/workspace" } },
-    ] as any;
+    vscode.workspace.workspaceFolders = [{ uri: { fsPath: WORKSPACE } }] as any;
     await expect(
-      handleRenameFile({ oldPath: "/workspace/a.ts", newPath: "/other/b.ts" }),
+      handleRenameFile({
+        oldPath: wsFile("a.ts"),
+        newPath: otherFile("b.ts"),
+      }),
     ).rejects.toThrow("outside the workspace");
   });
 });

--- a/vscode-extension/src/__tests__/lockfiles-multiworkspace.test.ts
+++ b/vscode-extension/src/__tests__/lockfiles-multiworkspace.test.ts
@@ -3,6 +3,7 @@
  * - readLockFileForWorkspace
  * - readAllMatchingLockFiles
  */
+import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("vscode", async () => {
@@ -17,9 +18,12 @@ vi.mock("fs/promises", () => ({
   readFile: vi.fn(),
 }));
 
-vi.mock("../constants", () => ({
-  LOCK_DIR: "/mock/lock/dir",
-}));
+vi.mock("../constants", () => {
+  const p = require("node:path") as typeof import("node:path");
+  return { LOCK_DIR: p.resolve("/mock/lock/dir") };
+});
+
+const CUSTOM_LOCK_DIR = path.resolve("/custom/lock");
 
 import * as fsp from "node:fs/promises";
 import * as vscode from "vscode";
@@ -29,6 +33,12 @@ import {
 } from "../lockfiles";
 
 const NOW = 1_700_000_000_000;
+
+const WS_A = path.resolve("/project/a");
+const WS_B = path.resolve("/project/b");
+const WS_C = path.resolve("/project/c");
+const WS_UNKNOWN = path.resolve("/project/unknown");
+const WS_SOME = path.resolve("/some/ws");
 
 function makeLockContent(
   workspace: string,
@@ -54,7 +64,7 @@ function setupLocks(
   vi.mocked(fsp.readdir).mockResolvedValue(locks.map((l) => l.file) as any);
   vi.mocked(fsp.stat).mockResolvedValue({ mtimeMs: NOW } as any);
   vi.mocked(fsp.readFile).mockImplementation(async (p: unknown) => {
-    const file = String(p).split("/").pop()!;
+    const file = path.basename(String(p));
     const lock = locks.find((l) => l.file === file);
     if (!lock) throw new Error(`ENOENT: ${String(p)}`);
     return makeLockContent(lock.workspace, lock.overrides ?? {}) as any;
@@ -75,114 +85,107 @@ afterEach(() => {
 
 // ── readLockFileForWorkspace ──────────────────────────────────────────────────
 
-describe.skipIf(process.platform === "win32")(
-  "readLockFileForWorkspace",
-  () => {
-    it("returns the lock file matching the specified workspace", async () => {
-      setupLocks([
-        { file: "10001.lock", workspace: "/project/a" },
-        { file: "10002.lock", workspace: "/project/b" },
-      ]);
-      const result = await readLockFileForWorkspace("/project/b");
-      expect(result).not.toBeNull();
-      expect(result!.port).toBe(10002);
-      expect(result!.workspace).toBe("/project/b");
-    });
+describe("readLockFileForWorkspace", () => {
+  it("returns the lock file matching the specified workspace", async () => {
+    setupLocks([
+      { file: "10001.lock", workspace: WS_A },
+      { file: "10002.lock", workspace: WS_B },
+    ]);
+    const result = await readLockFileForWorkspace(WS_B);
+    expect(result).not.toBeNull();
+    expect(result!.port).toBe(10002);
+    expect(result!.workspace).toBe(WS_B);
+  });
 
-    it("returns null when no lock file matches", async () => {
-      setupLocks([{ file: "10001.lock", workspace: "/project/a" }]);
-      const result = await readLockFileForWorkspace("/project/unknown");
-      expect(result).toBeNull();
-    });
+  it("returns null when no lock file matches", async () => {
+    setupLocks([{ file: "10001.lock", workspace: WS_A }]);
+    const result = await readLockFileForWorkspace(WS_UNKNOWN);
+    expect(result).toBeNull();
+  });
 
-    it("resolves symlink-style paths correctly (both resolved)", async () => {
-      setupLocks([{ file: "10001.lock", workspace: "/project/a" }]);
-      // The function uses path.resolve() on both sides
-      const result = await readLockFileForWorkspace("/project/./a");
-      expect(result).not.toBeNull();
-      expect(result!.port).toBe(10001);
-    });
+  it("resolves symlink-style paths correctly (both resolved)", async () => {
+    setupLocks([{ file: "10001.lock", workspace: WS_A }]);
+    // The function uses path.resolve() on both sides
+    const result = await readLockFileForWorkspace(
+      path.join(path.resolve("/project"), ".", "a"),
+    );
+    expect(result).not.toBeNull();
+    expect(result!.port).toBe(10001);
+  });
 
-    it("skips expired lock files", async () => {
-      setupLocks([
-        {
-          file: "10001.lock",
-          workspace: "/project/a",
-          overrides: { startedAt: NOW - 25 * 60 * 60 * 1000 }, // 25h ago — beyond 24h threshold
-        },
-      ]);
-      const result = await readLockFileForWorkspace("/project/a");
-      expect(result).toBeNull();
-    });
+  it("skips expired lock files", async () => {
+    setupLocks([
+      {
+        file: "10001.lock",
+        workspace: WS_A,
+        overrides: { startedAt: NOW - 25 * 60 * 60 * 1000 }, // 25h ago — beyond 24h threshold
+      },
+    ]);
+    const result = await readLockFileForWorkspace(WS_A);
+    expect(result).toBeNull();
+  });
 
-    it("uses the provided lockDir override", async () => {
-      vi.mocked(fsp.access).mockImplementation(async (p) => {
-        if (String(p) !== "/custom/lock") throw new Error("ENOENT");
-      });
-      setupLocks([{ file: "10001.lock", workspace: "/project/a" }]);
-      const result = await readLockFileForWorkspace(
-        "/project/a",
-        "/custom/lock",
-      );
-      // Access check passes for /custom/lock; file lookup succeeds
-      expect(result).not.toBeNull();
+  it("uses the provided lockDir override", async () => {
+    vi.mocked(fsp.access).mockImplementation(async (p) => {
+      if (String(p) !== CUSTOM_LOCK_DIR) throw new Error("ENOENT");
     });
-  },
-);
+    setupLocks([{ file: "10001.lock", workspace: WS_A }]);
+    const result = await readLockFileForWorkspace(WS_A, CUSTOM_LOCK_DIR);
+    // Access check passes for CUSTOM_LOCK_DIR; file lookup succeeds
+    expect(result).not.toBeNull();
+  });
+});
 
 // ── readAllMatchingLockFiles ──────────────────────────────────────────────────
 
-describe.skipIf(process.platform === "win32")(
-  "readAllMatchingLockFiles",
-  () => {
-    it("returns one lock per workspace folder", async () => {
-      (vscode.workspace as any).workspaceFolders = [
-        { uri: { fsPath: "/project/a" } },
-        { uri: { fsPath: "/project/b" } },
-      ];
-      setupLocks([
-        { file: "10001.lock", workspace: "/project/a" },
-        { file: "10002.lock", workspace: "/project/b" },
-      ]);
-      const results = await readAllMatchingLockFiles();
-      expect(results).toHaveLength(2);
-      expect(results.map((r) => r.port).sort()).toEqual([10001, 10002]);
-    });
+describe("readAllMatchingLockFiles", () => {
+  it("returns one lock per workspace folder", async () => {
+    (vscode.workspace as any).workspaceFolders = [
+      { uri: { fsPath: WS_A } },
+      { uri: { fsPath: WS_B } },
+    ];
+    setupLocks([
+      { file: "10001.lock", workspace: WS_A },
+      { file: "10002.lock", workspace: WS_B },
+    ]);
+    const results = await readAllMatchingLockFiles();
+    expect(results).toHaveLength(2);
+    expect(results.map((r) => r.port).sort()).toEqual([10001, 10002]);
+  });
 
-    it("omits workspace folders with no matching bridge", async () => {
-      (vscode.workspace as any).workspaceFolders = [
-        { uri: { fsPath: "/project/a" } },
-        { uri: { fsPath: "/project/c" } }, // no bridge
-      ];
-      setupLocks([{ file: "10001.lock", workspace: "/project/a" }]);
-      const results = await readAllMatchingLockFiles();
-      expect(results).toHaveLength(1);
-      expect(results[0].port).toBe(10001);
-    });
+  it("omits workspace folders with no matching bridge", async () => {
+    (vscode.workspace as any).workspaceFolders = [
+      { uri: { fsPath: WS_A } },
+      { uri: { fsPath: WS_C } }, // no bridge
+    ];
+    setupLocks([{ file: "10001.lock", workspace: WS_A }]);
+    const results = await readAllMatchingLockFiles();
+    expect(results).toHaveLength(1);
+    expect(results[0].port).toBe(10001);
+  });
 
-    it("deduplicates: same port appears only once even if matched by two folders", async () => {
-      (vscode.workspace as any).workspaceFolders = [
-        { uri: { fsPath: "/project/a" } },
-        { uri: { fsPath: "/project/a" } }, // duplicate
-      ];
-      setupLocks([{ file: "10001.lock", workspace: "/project/a" }]);
-      const results = await readAllMatchingLockFiles();
-      expect(results).toHaveLength(1);
-    });
+  it("deduplicates: same port appears only once even if matched by two folders", async () => {
+    (vscode.workspace as any).workspaceFolders = [
+      { uri: { fsPath: WS_A } },
+      { uri: { fsPath: WS_A } }, // duplicate
+    ];
+    setupLocks([{ file: "10001.lock", workspace: WS_A }]);
+    const results = await readAllMatchingLockFiles();
+    expect(results).toHaveLength(1);
+  });
 
-    it("returns the newest available lock when no workspace folders are open", async () => {
-      (vscode.workspace as any).workspaceFolders = undefined;
-      setupLocks([{ file: "10001.lock", workspace: "/some/ws" }]);
-      const results = await readAllMatchingLockFiles();
-      expect(results).toHaveLength(1);
-      expect(results[0].port).toBe(10001);
-    });
+  it("returns the newest available lock when no workspace folders are open", async () => {
+    (vscode.workspace as any).workspaceFolders = undefined;
+    setupLocks([{ file: "10001.lock", workspace: WS_SOME }]);
+    const results = await readAllMatchingLockFiles();
+    expect(results).toHaveLength(1);
+    expect(results[0].port).toBe(10001);
+  });
 
-    it("returns empty array when no workspace folders and no lock files", async () => {
-      (vscode.workspace as any).workspaceFolders = [];
-      vi.mocked(fsp.readdir).mockResolvedValue([] as any);
-      const results = await readAllMatchingLockFiles();
-      expect(results).toHaveLength(0);
-    });
-  },
-);
+  it("returns empty array when no workspace folders and no lock files", async () => {
+    (vscode.workspace as any).workspaceFolders = [];
+    vi.mocked(fsp.readdir).mockResolvedValue([] as any);
+    const results = await readAllMatchingLockFiles();
+    expect(results).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Five extension vitest files were skipped on Windows because fixtures hardcoded POSIX paths (`fsPath: "/workspace/file.ts"`)
- Migrated to `path.resolve()` / `path.join()` helpers; removed every `describe.skipIf(process.platform === "win32")` wrapper and the `// TODO(windows)` headers
- Mock `vscode.workspaceFolders` now exports `MOCK_WORKSPACE_ROOT` so handler containment checks pass on both platforms

## Why
Tail-end of the Windows audit campaign (#525, #527-#533). These suites covered files / editText / codeActions / bridgeInstaller / lockfiles — the heart of the extension handler surface. Having them dark on Windows meant Windows regressions in those paths wouldn't surface in CI.

## Test plan
- [x] Local `npm test -- --run` in vscode-extension: 36 files, 569/569 tests pass
- [x] biome check clean
- [x] No handler source under `src/handlers` modified
- [ ] Watch windows-latest extension CI job — should still pass with the suites now active

🤖 Generated with [Claude Code](https://claude.com/claude-code)