### PR TITLE
fix(win): three .cmd-shim spawn stragglers missed in the audit sweep

### DIFF
--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -144,6 +144,9 @@ export async function runInstall(argv: string[]): Promise<void> {
     try {
       execFileSync("npm", ["install", "-g", entry.npmPackage], {
         stdio: "inherit",
+        // Windows: `npm` is `npm.cmd` and Node's execFileSync can't launch
+        // a .cmd shim without a shell.
+        shell: process.platform === "win32",
       });
     } catch {
       process.stderr.write(

--- a/src/index.ts
+++ b/src/index.ts
@@ -3469,6 +3469,9 @@ Steps performed:
     execFileSync("claude-ide-bridge", ["--version"], {
       stdio: "pipe",
       timeout: 5000,
+      // Windows: global npm bin is a `.cmd` shim that Node's execFileSync
+      // can't launch without a shell. See bridgeProcess.ts for context.
+      shell: process.platform === "win32",
     });
     shimOnPath = true;
   } catch {

--- a/src/tools/headless/lspClient.ts
+++ b/src/tools/headless/lspClient.ts
@@ -64,6 +64,9 @@ export class HeadlessLspClient {
     try {
       proc = spawn("typescript-language-server", ["--stdio"], {
         stdio: ["pipe", "pipe", "pipe"],
+        // Windows: typescript-language-server is a `.cmd` shim; Node's
+        // spawn can't launch a .cmd without a shell.
+        shell: process.platform === "win32",
       });
     } catch (err) {
       this.initPromise = null;


### PR DESCRIPTION
## Summary
- Sweep after PRs #527-#532 turned up three production spawn sites that launch `.cmd` shims on Windows without `shell:true`, so they ENOENT on real Windows
- All fixed with the same `shell: process.platform === "win32"` pattern already used elsewhere in the tree

## Sites
1. `src/index.ts` — post-install probe `claude-ide-bridge --version` (gates the 'shim on PATH' detection)
2. `src/commands/install.ts` — `npm install -g <pkg>` for companion packages
3. `src/tools/headless/lspClient.ts` — `typescript-language-server --stdio` (headless LSP in --slim mode)

## Why these slipped through
The original audit focused on smoke harness + driver subprocess paths. These three are tucked into less-trafficked code paths (post-install probe, recipe install, headless LSP) and weren't exercised by the CI smoke matrix.

## Test plan
- [x] `npm run build` clean
- [x] biome check clean
- [ ] Watch windows-latest CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)