### PR TITLE
ci(win): tighten windows-latest from advisory to blocking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,11 +172,10 @@ jobs:
     name: Smoke tests (live bridge)
     runs-on: ${{ matrix.os }}
     needs: ci
-    # Windows starts advisory (continue-on-error) — the smoke harness has
-    # never run on win32 before. Tighten to blocking once green for ~5
-    # consecutive runs, same pattern PRs #497–#501 used for the bridge
-    # test matrix. ubuntu remains the blocking gate.
-    continue-on-error: ${{ matrix.os == 'windows-latest' }}
+    # windows-latest is blocking. Was advisory through PRs #527–#536 while
+    # the smoke harness was being ported (.cmd shims, CRLF batch files,
+    # tree-kill, HTTP /shutdown for clean exit). Five consecutive green
+    # runs across #533-#536; advisory mode no longer needed.
     strategy:
       fail-fast: false
       matrix:
@@ -286,10 +285,9 @@ jobs:
   extension:
     runs-on: ${{ matrix.os }}
     needs: ci
-    # Windows starts advisory — the extension build + test suite has never
-    # exercised win32 in CI. Tighten to blocking once green for ~5
-    # consecutive runs (same playbook the bridge matrix used in #497–#501).
-    continue-on-error: ${{ matrix.os == 'windows-latest' }}
+    # windows-latest is blocking. Was advisory through PRs #527–#536; with
+    # the five extension test suites un-skipped (#535) and four green PR
+    # runs in a row, advisory mode is no longer needed.
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary
- Drop `continue-on-error: \${{ matrix.os == 'windows-latest' }}` from the smoke + extension jobs in `.github/workflows/ci.yml`
- Windows regressions will now block merge, same as ubuntu

## Why now
windows-latest has been running as advisory since #527 while the Windows port was being landed: `.cmd` shim spawn fixes, tree-kill, fs.watch polling fallback, CRLF batch-file overrides, smoke harness `shell:true` audit, HTTP `/shutdown` for clean exit. With #533-#536 all 18/18 green across both jobs (including the un-skipped extension suites from #535 and CAT-11.5/11.6 from #534), advisory mode is no longer earning its keep.

## Test plan
- [ ] Watch this PR's own windows-latest run — must pass on its own merits, not advisory
- [ ] If it goes red, that's a real signal to fix before flipping (the whole point of the advisory→blocking move)

🤖 Generated with [Claude Code](https://claude.com/claude-code)