### PR TITLE
fix(smoke): 2× waitForBridge timeout on win32 to stop flaky cold-starts

### DIFF
--- a/scripts/smoke/helpers.mjs
+++ b/scripts/smoke/helpers.mjs
@@ -115,11 +115,19 @@ export function httpDelete(url, headers = {}) {
 }
 
 // ── Bridge readiness ──────────────────────────────────────────────────────────
+// Default Windows multiplier: cmd.exe shim cold-start on GH runners is slow
+// enough that 10s isn't always enough — especially when two bridges spawn in
+// parallel (cat4). Bump the floor to 2× on win32 unless a caller explicitly
+// overrides. Saw transient CAT-4 / CAT-6 / CAT-7 timeouts in the first post-
+// advisory CI run (main, b121a98b).
+const WIN_TIMEOUT_MULTIPLIER = process.platform === "win32" ? 2 : 1;
+
 export async function waitForBridge(port, timeoutMs = 10_000, claudeConfigDir) {
   // Wait for lock file — written just before bridge accepts WS connections.
   const dir = claudeConfigDir ? path.join(claudeConfigDir, "ide") : lockDir();
   const lockPath = path.join(dir, `${port}.lock`);
-  const deadline = Date.now() + timeoutMs;
+  const effectiveTimeout = timeoutMs * WIN_TIMEOUT_MULTIPLIER;
+  const deadline = Date.now() + effectiveTimeout;
   while (Date.now() < deadline) {
     if (fs.existsSync(lockPath)) {
       await sleep(200); // tiny buffer for WS listener to bind after lock write
@@ -128,7 +136,7 @@ export async function waitForBridge(port, timeoutMs = 10_000, claudeConfigDir) {
     await sleep(100);
   }
   throw new Error(
-    `Bridge lock file for port ${port} not found after ${timeoutMs}ms`,
+    `Bridge lock file for port ${port} not found after ${effectiveTimeout}ms`,
   );
 }
 


### PR DESCRIPTION
## Summary
- First post-advisory main run (b121a98b, right after #537 flipped windows-latest to blocking) failed CAT-4 with `Bridge lock file for port 37220 not found after 10000ms`
- Root cause: two bridges spawning in parallel via `cmd.exe` shim on a GH runner can exceed 10s before the first lock write
- Promote a `WIN_TIMEOUT_MULTIPLIER=2` into `waitForBridge` itself — every smoke script gets the doubled budget on Windows without per-site bumps

## Failing run
- Run 25933459419, job 76233915369: CAT-4 `Promise.all([waitForBridge(SLIM), waitForBridge(FULL)])` index 0 timed out
- All other categories (1-3, 5-12) passed on the same run, so the issue is specifically the parallel-spawn cold-start case

## Why not revert #537
The flip is correct — Windows IS green on its own merits, this is one bridge-spawn-budget tuning issue. Reverting would hide the real problem and we'd be back to advisory mode where the next regression doesn't surface.

## Test plan
- [x] POSIX path unchanged (`WIN_TIMEOUT_MULTIPLIER` is 1 off-win32)
- [ ] Watch windows-latest CI on this PR — must pass to validate the bump is enough

🤖 Generated with [Claude Code](https://claude.com/claude-code)