### PR TITLE
fix(win): use path.relative for contextFile workspace-confine check

### DIFF
--- a/src/__tests__/claudeOrchestrator.test.ts
+++ b/src/__tests__/claudeOrchestrator.test.ts
@@ -562,6 +562,98 @@ describe("ClaudeOrchestrator — persistence", () => {
     expect(task?.createdAt).toBe(originalCreatedAt);
   });
 
+  // ── contextFiles workspace-confine (Windows path-prefix regression) ──────
+
+  it("loadPersistedTasks — contextFiles inside the workspace are kept", async () => {
+    const id = "ffffffff-0000-0000-0000-000000000010";
+    const v1Payload = {
+      version: 1,
+      savedAt: Date.now(),
+      tasks: [
+        {
+          id,
+          sessionId: "",
+          prompt: "p",
+          contextFiles: ["/tmp/inside.txt", "/tmp/subdir/nested.md"],
+          status: "pending",
+          createdAt: Date.now(),
+          timeoutMs: 120_000,
+          tokenEstimate: 1,
+        },
+      ],
+    };
+    mockReadFile.mockResolvedValueOnce(JSON.stringify(v1Payload));
+
+    const orch = new ClaudeOrchestrator(makeSlowDriver(60_000), "/tmp", noop);
+    await orch.loadPersistedTasks(9999);
+
+    const task = orch.getTask(id);
+    expect(task?.contextFiles).toEqual([
+      "/tmp/inside.txt",
+      "/tmp/subdir/nested.md",
+    ]);
+  });
+
+  it("loadPersistedTasks — contextFiles outside the workspace are dropped", async () => {
+    const id = "ffffffff-0000-0000-0000-000000000011";
+    const v1Payload = {
+      version: 1,
+      savedAt: Date.now(),
+      tasks: [
+        {
+          id,
+          sessionId: "",
+          prompt: "p",
+          contextFiles: [
+            "/tmp/inside.txt",
+            "/etc/passwd", // escapes workspace
+            "../sibling.md", // resolves outside /tmp
+          ],
+          status: "pending",
+          createdAt: Date.now(),
+          timeoutMs: 120_000,
+          tokenEstimate: 1,
+        },
+      ],
+    };
+    mockReadFile.mockResolvedValueOnce(JSON.stringify(v1Payload));
+
+    const orch = new ClaudeOrchestrator(makeSlowDriver(60_000), "/tmp", noop);
+    await orch.loadPersistedTasks(9999);
+
+    const task = orch.getTask(id);
+    expect(task?.contextFiles).toEqual(["/tmp/inside.txt"]);
+  });
+
+  it("loadPersistedTasks — the workspace root itself is accepted (rel === '')", async () => {
+    const id = "ffffffff-0000-0000-0000-000000000012";
+    const v1Payload = {
+      version: 1,
+      savedAt: Date.now(),
+      tasks: [
+        {
+          id,
+          sessionId: "",
+          prompt: "p",
+          // Workspace root passes the relative('') check; whether it survives
+          // lstatSync(isFile()) depends on the mock — here lstatSync is stubbed
+          // to return isFile: true so we isolate the path-confine logic.
+          contextFiles: ["/tmp"],
+          status: "pending",
+          createdAt: Date.now(),
+          timeoutMs: 120_000,
+          tokenEstimate: 1,
+        },
+      ],
+    };
+    mockReadFile.mockResolvedValueOnce(JSON.stringify(v1Payload));
+
+    const orch = new ClaudeOrchestrator(makeSlowDriver(60_000), "/tmp", noop);
+    await orch.loadPersistedTasks(9999);
+
+    expect(orch.getTask(id)?.contextFiles).toEqual(["/tmp"]);
+  });
+
   // ── persistTasks ─────────────────────────────────────────────────────────
 
   it("persistTasks — uses v1 envelope and includes all task statuses", async () => {

--- a/src/claudeOrchestrator.ts
+++ b/src/claudeOrchestrator.ts
@@ -2,7 +2,12 @@ import { randomUUID } from "node:crypto";
 import fs from "node:fs";
 import { readFile, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
-import { join, resolve as resolvePath } from "node:path";
+import {
+  isAbsolute as isAbsolutePath,
+  join,
+  relative as relativePath,
+  resolve as resolvePath,
+} from "node:path";
 
 function getConfigDir(): string {
   return process.env.CLAUDE_CONFIG_DIR || join(homedir(), ".claude");
@@ -636,16 +641,20 @@ export class ClaudeOrchestrator {
         if (this.tasks.has(t.id)) continue;
 
         const prompt: string = typeof t.prompt === "string" ? t.prompt : "";
-        // Only restore context files that are workspace-confined regular files
+        // Only restore context files that are workspace-confined regular files.
+        // The previous check used `abs.startsWith(\`${normalizedWorkspace}/\`)`
+        // — hardcoded POSIX separator silently dropped every contextFile on
+        // Windows where resolvePath returns backslash paths. Use path.relative
+        // so the check is OS-correct.
         const contextFiles: string[] = Array.isArray(t.contextFiles)
           ? t.contextFiles.filter((f: unknown) => {
               if (typeof f !== "string") return false;
               const abs = resolvePath(f);
-              if (
-                abs !== normalizedWorkspace &&
-                !abs.startsWith(`${normalizedWorkspace}/`)
-              )
-                return false;
+              const rel = relativePath(normalizedWorkspace, abs);
+              // rel === "" means abs IS the workspace root (acceptable).
+              // Any segment starting with ".." or an absolute drive-prefixed
+              // remainder means abs escaped the workspace.
+              if (rel.startsWith("..") || isAbsolutePath(rel)) return false;
               try {
                 return fs.lstatSync(abs).isFile();
               } catch {


### PR DESCRIPTION
## Summary

The contextFile workspace-confine check at `src/claudeOrchestrator.ts:646` hardcoded the POSIX separator:

\`\`\`ts
if (abs !== normalizedWorkspace && !abs.startsWith(\`\${normalizedWorkspace}/\`)) return false;
\`\`\`

On Windows, `node:path.resolve` returns backslash paths — both sides of the comparison were backslashes, so the literal `/` never matched and **every contextFile was silently dropped** on bridge restart / task replay.

## The fix

Replace the hardcoded `/` startsWith with `path.relative`:

\`\`\`ts
const rel = relativePath(normalizedWorkspace, abs);
if (rel.startsWith("..") || isAbsolutePath(rel)) return false;
\`\`\`

`path.relative` is OS-aware and returns:
- `""` when abs is the workspace root → accepted
- `"subdir/file"` or `"subdir\\file"` per platform → accepted
- `"../escape"` when abs is outside the workspace → rejected
- A drive-prefixed absolute path on Windows when abs is on a different volume → rejected via `isAbsolutePath`

## User-visible impact

**Windows:** tasks that included contextFiles now actually restore those files on bridge restart / replay. Before this fix, every contextFile was dropped on Windows, so resumed tasks started with an empty context array — silently degraded behavior.

**Mac / Linux:** no behavior change. `path.relative` on POSIX hosts produces the same accept/reject decisions the old code did. All 5,435 existing tests pass unchanged.

## Test plan

- [x] New tests in `src/__tests__/claudeOrchestrator.test.ts`:
  - contextFiles inside workspace → kept
  - contextFiles outside (`/etc/passwd`, `../sibling.md`) → dropped
  - workspace root itself (`rel === \"\"`) → accepted
- [x] Existing `loadPersistedTasks` suite: 40/40 passing
- [x] Full bridge suite: 5,435/5,435 passing
- [x] `tsc --noEmit` clean
- [ ] Windows CI to confirm the symptom is resolved end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)