### PR TITLE
fix(ext): pin-note ReferenceError + add prod typecheck CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -309,6 +309,8 @@ jobs:
           cache-dependency-path: vscode-extension/package-lock.json
       - name: Install dependencies
         run: npm ci
+      - name: Type check
+        run: npm run typecheck
       - name: Test
         run: npm test
       - name: Build

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-ide-bridge-extension",
-  "version": "1.4.12",
+  "version": "1.4.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-ide-bridge-extension",
-      "version": "1.4.12",
+      "version": "1.4.16",
       "license": "MIT",
       "dependencies": {
         "ws": "^8.18.0"
@@ -16,6 +16,7 @@
         "@types/ws": "^8.5.10",
         "@vscode/codicons": "^0.0.45",
         "esbuild": "^0.27.4",
+        "typescript": "^5.9.3",
         "vitest": "^3.0.0"
       },
       "engines": {
@@ -1436,6 +1437,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/undici-types": {

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -205,6 +205,7 @@
     "prebuild": "npm run sync-presets",
     "build": "node esbuild.mjs",
     "watch": "node esbuild.mjs --watch",
+    "pretypecheck": "npm run sync-presets",
     "typecheck": "tsc -p tsconfig.prod.json --noEmit",
     "vscode:prepublish": "npm run build",
     "prepackage": "npm run build",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -205,6 +205,7 @@
     "prebuild": "npm run sync-presets",
     "build": "node esbuild.mjs",
     "watch": "node esbuild.mjs --watch",
+    "typecheck": "tsc -p tsconfig.prod.json --noEmit",
     "vscode:prepublish": "npm run build",
     "prepackage": "npm run build",
     "pretest": "npm run sync-presets",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -222,6 +222,7 @@
     "@types/ws": "^8.5.10",
     "@vscode/codicons": "^0.0.45",
     "esbuild": "^0.27.4",
+    "typescript": "^5.9.3",
     "vitest": "^3.0.0"
   }
 }

--- a/vscode-extension/src/analyticsPanel.ts
+++ b/vscode-extension/src/analyticsPanel.ts
@@ -672,7 +672,7 @@ export class AnalyticsViewProvider implements vscode.WebviewViewProvider {
   }
 
   private async _handlePinNote(
-    _view: vscode.WebviewView,
+    view: vscode.WebviewView,
     refresh: () => Promise<void>,
   ): Promise<void> {
     try {

--- a/vscode-extension/src/bridgeInstaller.ts
+++ b/vscode-extension/src/bridgeInstaller.ts
@@ -68,7 +68,9 @@ export class BridgeInstaller {
         timeout: 10_000,
       });
       const match = stdout.trim().match(/(\d+\.\d+\.\d+[^\s]*)/);
-      return match ? match[1] : null;
+      // match[1] is the captured version string; coalesce to null to satisfy
+      // the function's `string | null` return type under noUncheckedIndexedAccess.
+      return match?.[1] ?? null;
     } catch {
       return null;
     }

--- a/vscode-extension/src/bridgeProcess.ts
+++ b/vscode-extension/src/bridgeProcess.ts
@@ -129,8 +129,10 @@ export class BridgeProcess {
         timeout: 5_000,
       });
       // split on \r?\n so a trailing \r from Windows `where` output doesn't
-      // get appended to the binary path and cause ENOENT at spawn time
-      return stdout.trim().split(/\r?\n/)[0].trim();
+      // get appended to the binary path and cause ENOENT at spawn time.
+      // String#split is documented to always return at least one element, so
+      // `?? ""` is just to satisfy TS noUncheckedIndexedAccess.
+      return (stdout.trim().split(/\r?\n/)[0] ?? "").trim();
     } catch {
       // Fall back to a bare name that the OS can resolve at spawn time. On
       // Windows that means the `.cmd` shim — bare "claude-ide-bridge" would

--- a/vscode-extension/src/handlers/lsp.ts
+++ b/vscode-extension/src/handlers/lsp.ts
@@ -526,7 +526,9 @@ export function createLspHandlers(
 
     if (!items || items.length === 0) return null;
 
-    const item = items[0];
+    // Non-null assertion: length>0 just checked, but TS can't narrow array indexing
+    // under noUncheckedIndexedAccess.
+    const item = items[0]!;
     const symbol = {
       name: item.name,
       kind: vscode.SymbolKind[item.kind],

--- a/vscode-extension/src/handlers/typeHierarchy.ts
+++ b/vscode-extension/src/handlers/typeHierarchy.ts
@@ -37,7 +37,9 @@ export async function handleGetTypeHierarchy(
     };
   }
 
-  const rootItem = items[0];
+  // Non-null assertion: length>0 just checked above; TS can't narrow array
+  // indexing under noUncheckedIndexedAccess.
+  const rootItem = items[0]!;
 
   function serializeItem(item: vscode.TypeHierarchyItem) {
     return {

--- a/vscode-extension/tsconfig.prod.json
+++ b/vscode-extension/tsconfig.prod.json
@@ -1,0 +1,5 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "src/__tests__/**/*", "**/*.test.ts"]
+}


### PR DESCRIPTION
## Summary

Two changes that go together — the bug, and the guard that would have caught it.

## The bug

`vscode-extension/src/analyticsPanel.ts:702` referenced an undeclared `view` while the enclosing method `_handlePinNote(_view: WebviewView, …)` had only `_view` in scope. When a user clicked **Pin note** on an auto-snapshot, the function threw `ReferenceError: view is not defined`, which the outer `catch {}` at line 716 silently swallowed — user saw no toast and no pin, just nothing.

Fix: rename param `_view` → `view`. The `_` prefix is a project convention for *intentionally unused* params; this one IS used, so the underscore was the mistake.

## Why this shipped

The extension's `npm run build` is `node esbuild.mjs` — esbuild strips types without checking them. Root `tsc --noEmit` doesn't include `vscode-extension/`. CI ran nothing that would have failed on the bad reference, even though all other workspaces (`dashboard`, `push-relay`) get an explicit `Type check` step.

This PR closes the gap.

## New CI gate

- `vscode-extension/tsconfig.prod.json` (new) — extends the main tsconfig, excludes `__tests__/**` so the gate runs against production code only. The test files have pre-existing strict-mode errors (readonly assigns on `vscode.*` mocks, `Object is possibly undefined` in `MockInstance` casts) that don't surface at runtime and are out of scope for this PR. Tracked for a future cleanup; not worth blocking the bug fix on.
- `vscode-extension/package.json` — new `typecheck` script: `\"tsc -p tsconfig.prod.json --noEmit\"`
- `.github/workflows/ci.yml` — `npm run typecheck` step added to the extension job, runs on both ubuntu-latest and windows-latest in the existing matrix.

## Other production errors found and fixed

Enabling the gate against existing code surfaced four other real strict-mode violations:

| File:line | Issue | Fix |
|---|---|---|
| `bridgeInstaller.ts:71` | `match?.[1]` is `string \| undefined`, sig says `string \| null` | `?? null` |
| `bridgeProcess.ts:133` | `split(...)[0]` possibly undefined under noUncheckedIndexedAccess | `?? \"\"` (split returns ≥1 — type narrowing nit) |
| `handlers/lsp.ts:529` | `items[0]` after `length === 0` guard | `items[0]!` |
| `handlers/typeHierarchy.ts:40` | same pattern | `items[0]!` |

## Test plan

- [x] `cd vscode-extension && npm run typecheck` → exit 0
- [x] `npm test` → 569/569 passing
- [x] Root `tsc --noEmit` → still clean (unaffected)
- [x] Bridge suite → 5,436/5,436 passing (unaffected)
- [ ] Windows CI to confirm the extension typecheck step passes on win32 too

🤖 Generated with [Claude Code](https://claude.com/claude-code)