### PR TITLE
docs: refresh tool and prompt counts (177→180, 72→36)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,8 +4,8 @@
 
 Comply with all docs in `/documents/`. Consult before changes:
 
-- **[documents/platform-docs.md](documents/platform-docs.md)** — Full feature reference (177 tools registered). Consult before adding/modifying features. Authoritative count: `node scripts/audit-lsp-tools.mjs` Stats line.
-- **[documents/prompts-reference.md](documents/prompts-reference.md)** — All 72 MCP prompts reference.
+- **[documents/platform-docs.md](documents/platform-docs.md)** — Full feature reference (180 tools registered). Consult before adding/modifying features. Authoritative count: `node scripts/audit-lsp-tools.mjs` Stats line.
+- **[documents/prompts-reference.md](documents/prompts-reference.md)** — All 36 MCP prompts reference.
 - **[documents/styleguide.md](documents/styleguide.md)** — Code conventions, UI patterns, output formats. Follow for all new tools, handlers, responses.
 - **[documents/roadmap.md](documents/roadmap.md)** — Development direction. Check before exploratory work.
 - **[documents/data-reference.md](documents/data-reference.md)** — Data flows, state mgmt, protocol details. Consult before modifying connection/auth/state logic.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ You decide which model. You decide which actions need a human nod. You own the c
 
 **Five primitives, one runtime:**
 
-- **Tools** — 177 built-in (LSP, git, terminal, debugger, files) plus any plugin you write. Plugins hot-reload — Claude can author a tool mid-session and call it on the next turn. See [Live Toolsmithing](documents/live-toolsmithing.md).
+- **Tools** — 180 built-in (LSP, git, terminal, debugger, files) plus any plugin you write. Plugins hot-reload — Claude can author a tool mid-session and call it on the next turn. See [Live Toolsmithing](documents/live-toolsmithing.md).
 - **Recipes** — YAML automations triggered by cron, file save, git commit, test run, or webhook. Anything that can POST a JSON payload can fire a recipe.
 - **Delegation Policy** — three risk tiers, four-source precedence (managed → project-local → project → user). Auto-approve safe, require approval for risky, block dangerous.
 - **Trace memory** — every approval, every recipe run, every enrichment is durable JSONL. Past decisions are surfaced into future sessions automatically. Bundle and back up with [`patchwork traces export`](src/commands/tracesExport.ts).
@@ -27,7 +27,7 @@ The same codebase ships **two ways to use it.** Pick the layer you need.
 
 | | What you get | Install | Best for |
 |---|---|---|---|
-| **🔌 Claude IDE Bridge** | MCP bridge connecting Claude Code to your IDE. 177 tools — diagnostics, LSP, debugger, terminal, git, GitHub, file ops. | `npm i -g patchwork-os` then run `claude-ide-bridge` | Anyone who wants Claude Code to see and act on their editor state |
+| **🔌 Claude IDE Bridge** | MCP bridge connecting Claude Code to your IDE. 180 tools — diagnostics, LSP, debugger, terminal, git, GitHub, file ops. | `npm i -g patchwork-os` then run `claude-ide-bridge` | Anyone who wants Claude Code to see and act on their editor state |
 | **🤖 Patchwork OS** | Everything in the bridge **plus** YAML recipes, approval queue, oversight dashboard, mobile push approvals, multi-model providers, JetBrains companion. | Same package, run `patchwork init` | Power users running automation, agent workflows, or background tasks |
 
 Same codebase. Bridge is the foundation; Patchwork OS is the optional layer on top. **No vendor lock-in. Runs on your machine.**
@@ -76,7 +76,7 @@ claude-ide-bridge --workspace .
 CLAUDE_CODE_IDE_SKIP_VALID_CHECK=true claude --ide
 ```
 
-Type `/ide` in Claude Code to confirm the connection. That's it — Claude now sees your diagnostics, open files, and editor state, and can call 177 tools to act on them.
+Type `/ide` in Claude Code to confirm the connection. That's it — Claude now sees your diagnostics, open files, and editor state, and can call 180 tools to act on them.
 
 **What the bridge gives Claude:**
 
@@ -117,7 +117,7 @@ The bridge auto-responds to the GET probe Gemini sends before initializing, so i
 
 | Mode | Tools | When to use |
 |---|---|---|
-| Full _(default)_ | 177 | All git, GitHub, terminal, file ops, orchestration |
+| Full _(default)_ | 180 | All git, GitHub, terminal, file ops, orchestration |
 | Slim (`--slim`) | ~60 | LSP + debugger + editor state only |
 
 Bridge-only docs: [documents/platform-docs.md](documents/platform-docs.md)
@@ -175,7 +175,7 @@ Both start the bridge, wait for the lock file, launch `claude --ide` and `remote
 
 ```powershell
 # Node orchestrator options (--key value form)
-npm run start-all:node -- --full               # all 177 tools
+npm run start-all:node -- --full               # all 180 tools
 npm run start-all:node -- --no-dashboard       # skip dashboard
 npm run start-all:node -- --dashboard-port 3300
 npm run start-all:node -- --no-remote          # skip remote-control
@@ -379,7 +379,7 @@ Bridge, VS Code extension, smoke harness, and CI are all green on native Windows
 patchwork-os (npm package)
 │
 ├── claude-ide-bridge          ← run alone for bridge-only mode
-│   ├── MCP server             177 tools over WebSocket / HTTP / stdio
+│   ├── MCP server             180 tools over WebSocket / HTTP / stdio
 │   ├── VS Code extension      LSP, debugger, editor state, live diagnostics
 │   ├── Git / GitHub           gitCommit, gitPush, githubCreatePR, …
 │   ├── Terminal               runInTerminal, getTerminalOutput, …
@@ -407,7 +407,7 @@ Use whichever fits your mental model.
 
 ## Tool surface
 
-177 MCP tools across 15 categories. Highlights:
+180 MCP tools across 15 categories. Highlights:
 
 | Category | Tools |
 |---|---|
@@ -473,7 +473,7 @@ Systemd service and deploy scripts in [`deploy/`](deploy/). Full guide: [docs/re
 
 | Feature | Status |
 |---|---|
-| 177 MCP tools (LSP, git, tests, debugger, diagnostics) | **shipped** |
+| 180 MCP tools (LSP, git, tests, debugger, diagnostics) | **shipped** |
 | VS Code / Cursor / Windsurf / Antigravity extension | **shipped** |
 | JetBrains plugin (49 handlers) | **shipped** |
 | `patchwork init` — one-command setup | **shipped** |
@@ -530,8 +530,8 @@ Patchwork ships an **opt-in** anonymous usage summary. It is **disabled by defau
 
 | Doc | Contents |
 |---|---|
-| [documents/platform-docs.md](documents/platform-docs.md) | Full tool reference (177 tools), automation hooks, connectors |
-| [documents/prompts-reference.md](documents/prompts-reference.md) | All 72 MCP prompts |
+| [documents/platform-docs.md](documents/platform-docs.md) | Full tool reference (180 tools), automation hooks, connectors |
+| [documents/prompts-reference.md](documents/prompts-reference.md) | All 36 MCP prompts |
 | [documents/styleguide.md](documents/styleguide.md) | Code conventions, UI patterns |
 | [documents/roadmap.md](documents/roadmap.md) | Development direction |
 | [documents/data-reference.md](documents/data-reference.md) | Data flows, state management, protocol details |

--- a/documents/platform-docs.md
+++ b/documents/platform-docs.md
@@ -1,6 +1,6 @@
 # Claude IDE Bridge — Platform Documentation
 
-177 tools · 72 MCP prompts · 20 automation hooks · 19 connectors (Slack, GitHub, Linear, Gmail, Google Calendar, Google Drive, Sentry, Notion, Confluence, Datadog, HubSpot, Intercom, Stripe, Zendesk, Jira, PagerDuty, Discord, Asana, GitLab — see [README](../README.md) for canonical list) — current version in [package.json](../package.json)
+180 tools · 36 MCP prompts · 20 automation hooks · 19 connectors (Slack, GitHub, Linear, Gmail, Google Calendar, Google Drive, Sentry, Notion, Confluence, Datadog, HubSpot, Intercom, Stripe, Zendesk, Jira, PagerDuty, Discord, Asana, GitLab — see [README](../README.md) for canonical list) — current version in [package.json](../package.json)
 
 > **Deployment model:** Remote deployment (VPS + reverse proxy, systemd service, `--bind 0.0.0.0 --issuer-url <https-url>`) is a first-class, production-ready pattern and is the recommended architecture for team or cloud access. Local mode (`127.0.0.1`, no `--issuer-url`) is for individual development.
 
@@ -464,7 +464,7 @@ Task lifecycle: `pending → running → done | error | cancelled`.
 
 ## MCP Prompts
 
-The bridge serves **72 built-in prompts** via `prompts/list` and `prompts/get`. They appear as `/mcp__bridge__<name>` in any MCP client supporting the MCP prompts protocol.
+The bridge serves **36 built-in prompts** via `prompts/list` and `prompts/get`. They appear as `/mcp__bridge__<name>` in any MCP client supporting the MCP prompts protocol.
 
 ### Core Prompts
 


### PR DESCRIPTION
## Summary

Three docs claimed counts that drifted from reality. The most embarrassing drift is the **prompt count** — three separate docs claimed "72 MCP prompts" when the actual `PROMPTS.length` from [src/prompts.ts](src/prompts.ts) is **36**. The number that ended up in the prompt row was probably copy-pasted from the tool count (which was 177, now 180).

## Authoritative counts (re-confirmed)

| Surface | Source | Value |
|---|---|---|
| Tool count | `node scripts/audit-lsp-tools.mjs` Stats line | **180 total registered** |
| Prompt count | `PROMPTS.length` from compiled `dist/prompts.js` | **36** |

## Files updated

| File | What changed |
|---|---|
| `CLAUDE.md` | "177 tools" → "180 tools"; "72 MCP prompts" → "36 MCP prompts" |
| `README.md` | 9 sites referencing "177" → "180"; "72 MCP prompts" → "36 MCP prompts" |
| `documents/platform-docs.md` | header tagline + the "72 built-in prompts" copy in the MCP Prompts section |

[`documents/prompts-reference.md`](documents/prompts-reference.md) already says "ships **36** prompts" and is the only doc that was correct all along — left untouched.

## How this happened

An audit pass earlier today reported "73 prompts" using `grep -c "^\s*name:" src/prompts.ts`, which matches both top-level prompt entries AND nested `name:` fields under each prompt's `arguments`. The independent verifier evaluated `PROMPTS.length` at runtime and confirmed the true count is 36. Adjusting heuristic counts to `PROMPTS.length` for any future doc refresh.

## Risk

None — docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)