### PR TITLE
docs: add recipe marketplace section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,6 +371,12 @@ Bridge, VS Code extension, smoke harness, and CI are all green on native Windows
 
 `patchwork halts --window overnight` prints a one-screen digest of recipe halts (categorised, 5 most recent reasons). Pair with `patchwork judgments` to review what Claude decided overnight before approving anything.
 
+### 🛒 Recipe marketplace — install + submit from the dashboard
+
+Browse the curated registry at [github.com/patchworkos/recipes](https://github.com/patchworkos/recipes) at **`/marketplace`** in the dashboard. One-click install if the bridge is running, with risk + connector preview before fetch.
+
+Contributing a recipe? **`/marketplace/submit`** is a full in-app submission flow: starter YAML presets (manual / scheduled / webhook), live `recipe.json` manifest preview, auto-save draft in `sessionStorage`, lint via the bridge before submit, and a "Submit to GitHub" button that opens a prefilled create-file PR on the registry repo. GitHub auto-forks for users without push access — no extra accounts needed.
+
 ---
 
 ## Architecture


### PR DESCRIPTION
## Summary

PR #543 shipped the in-app marketplace submission flow at `/marketplace/submit` but README still had zero mention of the recipe marketplace as a feature.

This adds a section under **More features** covering both halves:
- `/marketplace` — browse + one-click install from the curated registry
- `/marketplace/submit` — full in-app submission flow (presets, manifest preview, sessionStorage draft, lint via bridge, prefilled GitHub create-file PR)

## Risk
None — docs only, 6 lines added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)