### PR TITLE
fix(marketplace): strip scope when checking if a recipe is installed

### DIFF
--- a/dashboard/src/app/marketplace/[...slug]/InstallPanel.tsx
+++ b/dashboard/src/app/marketplace/[...slug]/InstallPanel.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { apiPath } from "@/lib/api";
-import { assertValidInstallSource } from "@/lib/registry";
+import { assertValidInstallSource, shortName } from "@/lib/registry";
 
 interface Props {
   install: string;
@@ -37,7 +37,11 @@ export default function InstallPanel({ install, name }: Props) {
         }
         const data = await r.json();
         const list = Array.isArray(data) ? data : Array.isArray(data?.recipes) ? data.recipes : [];
-        const installed = list.some((x: { name: string }) => x.name === name);
+        // Registry names are scoped (e.g. "@patchworkos/morning-brief") but
+        // the bridge writes recipes under their YAML `name:` field (unscoped,
+        // e.g. "morning-brief"). Compare against the short form.
+        const target = shortName(name);
+        const installed = list.some((x: { name: string }) => x.name === target);
         setStatus({ online: true, installed });
       })
       .catch(() => {

--- a/dashboard/src/app/marketplace/bundle/[...slug]/BundleInstallPanel.tsx
+++ b/dashboard/src/app/marketplace/bundle/[...slug]/BundleInstallPanel.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { apiPath } from "@/lib/api";
+import { shortName } from "@/lib/registry";
 
 interface Props {
   /**
@@ -74,11 +75,17 @@ export default function BundleInstallPanel({
           : Array.isArray(data?.recipes)
             ? data.recipes
             : [];
-        const installedNames = new Set(
-          list.map((x: { name?: string }) => x.name).filter(Boolean),
+        const installedNames = new Set<string>(
+          list
+            .map((x: { name?: string }) => x.name)
+            .filter((n: string | undefined): n is string => Boolean(n)),
         );
+        // Bundle manifest entries may be scoped (`@scope/name`); the bridge
+        // writes recipes under their unscoped YAML `name:` field. Strip the
+        // scope before comparing so a bundle ships with consistent display
+        // names but still finds locally-installed recipes.
         const installedCount = recipes.filter((r) =>
-          installedNames.has(r),
+          installedNames.has(shortName(r)),
         ).length;
         setStatus({ online: true, installedCount });
       })

--- a/dashboard/src/app/marketplace/bundle/[...slug]/__tests__/BundleInstallPanel.test.tsx
+++ b/dashboard/src/app/marketplace/bundle/[...slug]/__tests__/BundleInstallPanel.test.tsx
@@ -61,6 +61,27 @@ describe("BundleInstallPanel — status polling", () => {
     ).toBeInTheDocument();
   });
 
+  it("counts scoped manifest entries as installed when bridge returns unscoped names (regression)", async () => {
+    // Regression: bundle manifests may declare recipes as scoped names
+    // ("@patchworkos/morning-brief") but the bridge writes them under the
+    // unscoped YAML `name:` ("morning-brief"). Without shortName() the
+    // installed-count was always 0 for scoped bundles.
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse(200, { recipes: [{ name: "a-recipe" }, { name: "b-recipe" }] }),
+    );
+    render(
+      <BundleInstallPanel
+        installSource={SOURCE}
+        recipes={["@patchworkos/a-recipe", "@patchworkos/b-recipe", "@patchworkos/c-recipe"]}
+      />,
+    );
+    await waitFor(() =>
+      expect(
+        screen.getByText(/2 of 3 recipes already installed/i),
+      ).toBeInTheDocument(),
+    );
+  });
+
   it("shows partial-installed copy when some recipes already exist", async () => {
     fetchMock.mockResolvedValueOnce(
       jsonResponse(200, { recipes: [{ name: "a-recipe" }] }),

--- a/dashboard/src/app/marketplace/page.tsx
+++ b/dashboard/src/app/marketplace/page.tsx
@@ -598,12 +598,14 @@ export default function MarketplacePage() {
     }
 
     // Optimistic update so the card flips to "Installed" immediately.
-    setInstalledNames((prev) => new Set([...prev, recipe.name]));
+    // installedNames is keyed by the unscoped name (what the bridge's
+    // /recipes endpoint returns) — strip the `@scope/` prefix so the
+    // Set lookup at the card-render sites matches.
+    setInstalledNames((prev) => new Set([...prev, shortName(recipe.name)]));
     toast.success("Recipe installed successfully");
-    // Authoritative refresh from the bridge — catches the name-
-    // divergence case where the dashboard tracks the marketplace name
-    // but the bridge writes the recipe under its own YAML `name` field.
-    // Without this, the green pill would lie until the next page load.
+    // Authoritative refresh from the bridge re-reads the unscoped names
+    // from disk — keep the Set in sync in case the actual YAML `name:`
+    // field differs from the slug the user clicked.
     void refreshInstalled();
 
     // Bridge-side connector preflight (#488) ships a `missingConnectors`
@@ -830,7 +832,7 @@ export default function MarketplacePage() {
                   <RecipeCard
                     key={featured.name}
                     recipe={featured}
-                    installed={installedNames.has(featured.name)}
+                    installed={installedNames.has(shortName(featured.name))}
                     bridgeOnline={bridgeOnline}
                     onInstall={handleInstall}
                   />
@@ -849,7 +851,7 @@ export default function MarketplacePage() {
                   <RecipeCard
                     key={recipe.name}
                     recipe={recipe}
-                    installed={installedNames.has(recipe.name)}
+                    installed={installedNames.has(shortName(recipe.name))}
                     bridgeOnline={bridgeOnline}
                     onInstall={handleInstall}
                   />


### PR DESCRIPTION
## Summary

Dogfood found the green **"Installed"** pill never appeared on marketplace cards, even when the user had the recipe installed. Repro: `morning-brief` was in `~/.patchwork/recipes/` (bridge `/recipes` returned it under that name), but the card for `@patchworkos/morning-brief` still rendered **"Install"**.

**Root cause** — name divergence:
- Registry index.json: **scoped** (`@patchworkos/morning-brief`)
- Bridge `/recipes`: **unscoped** YAML `name:` (`morning-brief`)
- `installedNames.has(recipe.name)` compares scoped against unscoped → never matches

The existing code comment at `page.tsx:603-606` *acknowledged* a "name-divergence case" but misdiagnosed it (said "marketplace name vs YAML name field"; real divergence is scoped vs unscoped) and the existing refresh didn't fix it.

## What this fixes

`shortName()` from `lib/registry.ts:267` already strips the `@scope/` prefix and is already imported. Wrap the four call sites:

| File:line | Before | After |
|---|---|---|
| `marketplace/page.tsx:601` (optimistic install update) | `recipe.name` | `shortName(recipe.name)` |
| `marketplace/page.tsx:835` (featured card) | `installedNames.has(featured.name)` | `installedNames.has(shortName(featured.name))` |
| `marketplace/page.tsx:854` (rest cards) | `installedNames.has(recipe.name)` | `installedNames.has(shortName(recipe.name))` |
| `marketplace/[...slug]/InstallPanel.tsx:40` (detail page) | `x.name === name` | `x.name === shortName(name)` |
| `marketplace/bundle/[...slug]/BundleInstallPanel.tsx:80` (latent, never observable today because registry has zero bundles) | `installedNames.has(r)` | `installedNames.has(shortName(r))` |

Also rewrote the misleading comment at `page.tsx:603-606`.

## Verification

- New `BundleInstallPanel.test.tsx` regression: scoped manifest entries + unscoped bridge response → asserts the correct "2 of 3 installed" count. Fails without `shortName`.
- Full dashboard suite: 479/479 passing.
- `tsc --noEmit` clean.

## Why scope-strip and not the other directions

- (a) ~~Bridge returns scoped names~~ — bridge has no concept of scope (scope is publisher identity in the registry, not a filesystem name).
- (b) ~~Registry drops scopes~~ — loses publisher attribution.
- (c) **Dashboard normalizes on read.** Cleanest; one helper that already exists, smallest blast radius.

🤖 Generated with [Claude Code](https://claude.com/claude-code)