### PR TITLE
fix(marketplace/submit): persist flow stage so reload doesn't lose the second-file button

### DIFF
--- a/dashboard/src/app/marketplace/submit/__tests__/page.test.tsx
+++ b/dashboard/src/app/marketplace/submit/__tests__/page.test.tsx
@@ -352,6 +352,74 @@ describe("MarketplaceSubmitPage — sessionStorage draft", () => {
     ).toBe("Restored description.");
   });
 
+  it("restores 'submitted' stage from sessionStorage (regression — refresh after submit must stay on success view)", () => {
+    // Reproduces dogfood Bug #5: user clicked Submit (which transitioned
+    // to the success view with the "Open recipe.json on GitHub" button),
+    // then refreshed the page. Pre-fix the user landed back on compose
+    // view with the draft restored — losing access to the second-file
+    // button, and a Submit-again would open a duplicate prefilled tab.
+    sessionStorage.setItem(
+      "patchwork.marketplaceSubmit.draft.v1",
+      JSON.stringify({
+        slugRaw: "my-recipe",
+        authorRaw: "myhandle",
+        version: "1.0.0",
+        description: "test",
+        tagsInput: "test",
+        connectorsInput: "",
+        license: "MIT",
+        homepage: "",
+        riskLevel: "low",
+        networkAccess: false,
+        fileAccess: false,
+        approvalBehavior: "ask_on_novel",
+        yaml: "name: my-recipe\n",
+        stage: "submitted",
+      }),
+    );
+
+    render(<MarketplaceSubmitPage />);
+
+    expect(
+      screen.getByRole("heading", { name: /Recipe submission in progress/i }),
+    ).toBeInTheDocument();
+    // The second-step button must be reachable.
+    expect(
+      screen.getByRole("button", { name: /Open recipe\.json on GitHub/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("defaults stage to 'compose' when the persisted draft omits it (older drafts)", () => {
+    // Drafts saved before the stage field shipped won't have it.
+    // Don't accidentally land users on a never-submitted "submitted"
+    // view.
+    sessionStorage.setItem(
+      "patchwork.marketplaceSubmit.draft.v1",
+      JSON.stringify({
+        slugRaw: "from-v1",
+        authorRaw: "",
+        version: "1.0.0",
+        description: "",
+        tagsInput: "",
+        connectorsInput: "",
+        license: "MIT",
+        homepage: "",
+        riskLevel: "low",
+        networkAccess: false,
+        fileAccess: false,
+        approvalBehavior: "ask_on_novel",
+        yaml: "name: from-v1\n",
+        // intentionally no `stage`
+      }),
+    );
+
+    render(<MarketplaceSubmitPage />);
+
+    expect(
+      screen.getByRole("heading", { name: /^Submit a recipe$/i }),
+    ).toBeInTheDocument();
+  });
+
   it("falls back to defaults when sessionStorage contains malformed data", () => {
     sessionStorage.setItem(
       "patchwork.marketplaceSubmit.draft.v1",

--- a/dashboard/src/app/marketplace/submit/page.tsx
+++ b/dashboard/src/app/marketplace/submit/page.tsx
@@ -50,6 +50,8 @@ interface LintResult {
   warnings: string[];
 }
 
+type Stage = "compose" | "submitted";
+
 interface DraftState {
   slugRaw: string;
   authorRaw: string;
@@ -64,6 +66,14 @@ interface DraftState {
   fileAccess: boolean;
   approvalBehavior: ApprovalBehavior;
   yaml: string;
+  /**
+   * Which flow stage the user was on when the draft was last saved.
+   * Persisted so that refreshing the page after Submit doesn't bounce
+   * the user back to compose view — they'd lose access to the "Open
+   * recipe.json on GitHub" button needed for the second commit, and a
+   * Submit-again would open a duplicate prefilled tab.
+   */
+  stage: Stage;
 }
 
 function readDraft(): DraftState | null {
@@ -101,6 +111,10 @@ function readDraft(): DraftState | null {
           ? parsed.approvalBehavior
           : "ask_on_novel",
       yaml: parsed.yaml,
+      // Older drafts (pre-PR550-followup) won't have `stage` — default to
+      // compose so a v1 draft restored under v2 lands the user on the
+      // form, not a stale submitted view.
+      stage: parsed.stage === "submitted" ? "submitted" : "compose",
     };
   } catch {
     return null;
@@ -115,8 +129,6 @@ function clearDraft(): void {
     /* storage unavailable / quota — non-fatal */
   }
 }
-
-type Stage = "compose" | "submitted";
 
 export default function MarketplaceSubmitPage() {
   const toast = useToast();
@@ -199,7 +211,7 @@ export default function MarketplaceSubmitPage() {
   }, []);
 
   // ---- submit / errors --------------------------------------------
-  const [stage, setStage] = useState<Stage>("compose");
+  const [stage, setStage] = useState<Stage>(draft?.stage ?? "compose");
   const [submitErrors, setSubmitErrors] = useState<
     Partial<Record<keyof SubmissionFormData | "yaml", string>>
   >({});
@@ -270,7 +282,12 @@ export default function MarketplaceSubmitPage() {
   // for users who land on the page and immediately leave).
   useEffect(() => {
     if (typeof window === "undefined") return;
+    // Always persist when stage === "submitted" so a refresh keeps the
+    // user on the post-submit view (the "Open recipe.json on GitHub"
+    // button lives there). Otherwise only persist when fields are dirty
+    // — avoids polluting storage for users who land + leave immediately.
     const isDirty =
+      stage === "submitted" ||
       slugRaw !== "" ||
       authorRaw !== "" ||
       description !== "" ||
@@ -294,6 +311,7 @@ export default function MarketplaceSubmitPage() {
         fileAccess,
         approvalBehavior,
         yaml,
+        stage,
       };
       window.sessionStorage.setItem(
         SUBMIT_DRAFT_STORAGE_KEY,
@@ -316,6 +334,7 @@ export default function MarketplaceSubmitPage() {
     fileAccess,
     approvalBehavior,
     yaml,
+    stage,
   ]);
 
   // ---- load starter from installed recipe --------------------------
@@ -490,28 +509,10 @@ export default function MarketplaceSubmitPage() {
     }
   }
 
-  function startOver() {
-    setStage("compose");
-    setSubmitErrors({});
-    setLintResult(null);
-    setLintError(null);
-    // The submission flow is done — drop the auto-save so the next visit
-    // doesn't surprise the user with their previous form contents.
-    clearDraft();
-  }
-
-  function applyPreset(presetId: string) {
-    const preset = RECIPE_PRESETS.find((p) => p.id === presetId);
-    if (!preset) return;
-    // Only swap the YAML; metadata fields the user already filled stay
-    // intact. Lint result becomes stale by virtue of forContent mismatch.
-    setYaml(preset.yaml);
-    toast.info(`Loaded the ${preset.label} preset.`);
-  }
-
-  function discardRestoredDraft() {
-    // Restore defaults across the board AND drop sessionStorage so the
-    // auto-save effect's next pass doesn't immediately rewrite it.
+  // Reset every form field + transient state to its initial value, then
+  // drop the persisted draft. Stage stays the caller's responsibility
+  // (Start Over goes to "compose"; nobody else uses this currently).
+  function resetToDefaults() {
     setSlugRaw("");
     setAuthorRaw("");
     setVersion("1.0.0");
@@ -529,6 +530,29 @@ export default function MarketplaceSubmitPage() {
     setLintError(null);
     setSubmitErrors({});
     clearDraft();
+  }
+
+  function startOver() {
+    // After submit, "Start over" should produce a fresh form. Pre-PR550-
+    // followup this only flipped stage + cleared transient errors and
+    // called clearDraft — but now that `stage` is in the auto-save
+    // effect's deps, the very next render would re-save the still-
+    // populated fields, defeating the clear. Wipe the fields too.
+    resetToDefaults();
+    setStage("compose");
+  }
+
+  function applyPreset(presetId: string) {
+    const preset = RECIPE_PRESETS.find((p) => p.id === presetId);
+    if (!preset) return;
+    // Only swap the YAML; metadata fields the user already filled stay
+    // intact. Lint result becomes stale by virtue of forContent mismatch.
+    setYaml(preset.yaml);
+    toast.info(`Loaded the ${preset.label} preset.`);
+  }
+
+  function discardRestoredDraft() {
+    resetToDefaults();
     setShowRestoredBanner(false);
     toast.info("Draft discarded — starting fresh.");
   }


### PR DESCRIPTION
## Summary

Dogfood **Bug #5**: after clicking "Submit to GitHub" (which opens the GitHub create-file tab AND transitions the page to the post-submit view with the "Open recipe.json on GitHub" button for the second file), **refreshing the page bounced the user back to compose view** with the draft restored. They lost access to the second-file button. Worse, clicking Submit again opened a duplicate `recipe.yaml` tab — duplicate-PR risk.

**Root cause:** `stage` was a `useState` that never round-tripped through sessionStorage. The auto-save effect persisted the draft fields but not the stage. On reload, `useState` always initialised to `"compose"`.

## What this fixes

- `DraftState` gains a `stage: Stage` field
- `readDraft()` validates + defaults: any value other than `"submitted"` becomes `"compose"` (covers older drafts pre-dating this field)
- `useState` reads `draft.stage` at mount
- Auto-save snapshot includes stage; effect dep array includes stage
- `isDirty` short-circuits to true whenever `stage === "submitted"` so we always persist the post-submit view even if the form is otherwise pristine

## Knock-on: `startOver` had to grow form-field resets

Because `stage` is now in the auto-save deps, calling `setStage("compose")` triggers the effect on the next render. With form fields still populated post-submit, `isDirty` becomes true and the draft gets re-saved immediately after `clearDraft()` — defeating the clear.

Fix: extract a shared `resetToDefaults()` helper that both `startOver` and `discardRestoredDraft` use. The semantic of "Start over" is "fresh form" — matches user mental model.

## Test plan

- [x] New regression: `stage: "submitted"` in draft → mount lands on the post-submit view, "Open recipe.json on GitHub" button reachable
- [x] New defensive: draft without a `stage` field → mount lands on compose (older draft compat)
- [x] Existing "Start over clears the draft" test still passes (now via `resetToDefaults`)
- [x] 480/480 dashboard suite passing
- [x] `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)