### PR TITLE
test(ext/bridgeProcess): fix Windows stderr-reset flake (200→1000ms timeout)

### DIFF
--- a/vscode-extension/src/__tests__/bridgeProcess.test.ts
+++ b/vscode-extension/src/__tests__/bridgeProcess.test.ts
@@ -331,7 +331,11 @@ describe("BridgeProcess — stderr captured in failure message", () => {
 
   it("resets stale stderr between spawn attempts", async () => {
     const ws = "/home/user/project-stderr-reset";
-    const proc = makeProc(ws, 200);
+    // 1000ms (was 200ms): Windows CI runners can take >200ms between
+    // proc.spawn() and the setTimeout(30) callback firing, racing the
+    // lock-poll deadline before the stderr emit lands. 1s gives slack
+    // without meaningfully slowing the suite (test timeout is 5s).
+    const proc = makeProc(ws, 1_000);
     const failedMessages: string[] = [];
     proc.onStartupFailed = (msg) => failedMessages.push(msg);
 


### PR DESCRIPTION
## Summary

- Windows CI flake on PR #552 (run 25965086160) — `bridgeProcess.test.ts > resets stale stderr between spawn attempts`.
- Test used a 200ms lock-poll timeout. Windows runners can take >200ms between `proc.spawn()` and the `setTimeout(30)` callback firing, so the lock-poll deadline fires before the new stderr is emitted. The failure message then defaults instead of containing `"NEW ERROR from attempt 2"`.
- Bumped to 1000ms — enough slack on Windows, no meaningful slowdown (test timeout is 5s; local run 2.0s).

## Test plan

- [x] `npx vitest run src/__tests__/bridgeProcess.test.ts` — 16/16 pass locally
- [ ] CI: extension job on windows-latest passes