### PR TITLE
polish(marketplace): styled install dialog + slug warn + clearer submit label

### DIFF
--- a/dashboard/src/app/marketplace/page.tsx
+++ b/dashboard/src/app/marketplace/page.tsx
@@ -2,6 +2,7 @@
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
+import { Dialog } from "@/components/Dialog";
 import { Skeleton, SkeletonText } from "@/components/Skeleton";
 import { HintCard } from "@/components/patchwork";
 import { apiPath } from "@/lib/api";
@@ -183,30 +184,21 @@ function RecipeCard({
   const [loading, setLoading] = useState(false);
   const [err, setErr] = useState<string | null>(null);
   const [justInstalled, setJustInstalled] = useState(false);
+  const [confirmOpen, setConfirmOpen] = useState(false);
 
   const isInstalled = installed || justInstalled;
 
-  async function handleInstall() {
-    // Risk-aware confirmation. Low-risk recipes can install on a single click
-    // (preserves the existing one-click flow); medium/high or any recipe that
-    // requests network/file access shows a summary dialog so the operator
-    // sees what they're agreeing to before the bridge fetches it.
-    const elevated =
-      recipe.risk_level === "medium" ||
-      recipe.risk_level === "high" ||
-      recipe.network_access ||
-      recipe.file_access;
-    if (elevated) {
-      const summary: string[] = [];
-      if (recipe.risk_level) summary.push(`Risk: ${recipe.risk_level}`);
-      if (recipe.connectors?.length) summary.push(`Connectors: ${recipe.connectors.join(", ")}`);
-      if (recipe.network_access) summary.push("Network access");
-      if (recipe.file_access) summary.push("File access");
-      const proceed = window.confirm(
-        `Install ${shortName(recipe.name)}?\n\n${summary.join("\n")}\n\nThe recipe YAML will be fetched from ${recipe.install} and stored locally.`,
-      );
-      if (!proceed) return;
-    }
+  // Risk-aware confirmation. Low-risk recipes install on a single click
+  // (preserves the existing one-click flow); medium/high or any recipe
+  // that requests network/file access opens a styled summary dialog so
+  // the operator sees what they're agreeing to before the bridge fetches it.
+  const elevated =
+    recipe.risk_level === "medium" ||
+    recipe.risk_level === "high" ||
+    recipe.network_access ||
+    recipe.file_access;
+
+  async function runInstall() {
     setLoading(true);
     setErr(null);
     try {
@@ -217,6 +209,14 @@ function RecipeCard({
     } finally {
       setLoading(false);
     }
+  }
+
+  function handleInstall() {
+    if (elevated) {
+      setConfirmOpen(true);
+      return;
+    }
+    void runInstall();
   }
 
   return (
@@ -391,6 +391,107 @@ function RecipeCard({
           {err}
         </div>
       )}
+
+      <Dialog
+        open={confirmOpen}
+        onClose={() => setConfirmOpen(false)}
+        ariaLabel={`Confirm install of ${shortName(recipe.name)}`}
+      >
+        <h2
+          style={{
+            margin: 0,
+            marginBottom: "var(--s-3)",
+            fontSize: "var(--fs-l)",
+            color: "var(--ink-0)",
+          }}
+        >
+          Install {shortName(recipe.name)}?
+        </h2>
+        <p
+          style={{
+            margin: 0,
+            marginBottom: "var(--s-4)",
+            fontSize: "var(--fs-s)",
+            color: "var(--fg-2)",
+            lineHeight: 1.5,
+          }}
+        >
+          The recipe YAML will be fetched from{" "}
+          <code
+            style={{
+              background: "var(--recess)",
+              padding: "1px 5px",
+              borderRadius: 4,
+              fontSize: "var(--fs-xs)",
+              wordBreak: "break-all",
+            }}
+          >
+            {recipe.install}
+          </code>{" "}
+          and stored locally.
+        </p>
+        <ul
+          style={{
+            margin: 0,
+            marginBottom: "var(--s-5)",
+            paddingLeft: "var(--s-4)",
+            fontSize: "var(--fs-s)",
+            color: "var(--ink-1)",
+            lineHeight: 1.7,
+          }}
+        >
+          {recipe.risk_level && (
+            <li>
+              <strong>Risk:</strong>{" "}
+              <span
+                style={{
+                  color:
+                    recipe.risk_level === "high"
+                      ? "var(--err)"
+                      : recipe.risk_level === "medium"
+                        ? "var(--warn)"
+                        : "var(--ok)",
+                }}
+              >
+                {recipe.risk_level}
+              </span>
+            </li>
+          )}
+          {recipe.connectors?.length ? (
+            <li>
+              <strong>Connectors:</strong> {recipe.connectors.join(", ")}
+            </li>
+          ) : null}
+          {recipe.network_access && <li>Network access</li>}
+          {recipe.file_access && <li>File access</li>}
+        </ul>
+        <div
+          style={{
+            display: "flex",
+            gap: "var(--s-2)",
+            justifyContent: "flex-end",
+          }}
+        >
+          <button
+            type="button"
+            className="btn sm ghost"
+            onClick={() => setConfirmOpen(false)}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            className="btn sm primary"
+            onClick={() => {
+              setConfirmOpen(false);
+              void runInstall();
+            }}
+            autoFocus
+          >
+            Install
+          </button>
+        </div>
+      </Dialog>
     </div>
   );
 }

--- a/dashboard/src/app/marketplace/submit/__tests__/page.test.tsx
+++ b/dashboard/src/app/marketplace/submit/__tests__/page.test.tsx
@@ -116,7 +116,7 @@ describe("MarketplaceSubmitPage — validation", () => {
   it("renders field-level errors when submitted empty", async () => {
     render(<MarketplaceSubmitPage />);
     fireEvent.click(
-      screen.getByRole("button", { name: /Submit to GitHub/i }),
+      screen.getByRole("button", { name: /Open PR on GitHub/i }),
     );
 
     expect(await screen.findByText(/Slug must start with/i)).toBeInTheDocument();
@@ -128,6 +128,18 @@ describe("MarketplaceSubmitPage — validation", () => {
     expect(openMock).not.toHaveBeenCalled();
   });
 
+  it("shows a normalization warning when the slug input contains unicode/uppercase", async () => {
+    render(<MarketplaceSubmitPage />);
+    fireEvent.change(screen.getByLabelText(/^Slug/i), {
+      target: { value: "Café Daily" },
+    });
+    expect(
+      await screen.findByText(
+        /Will be saved as ["“]caf-daily["”] — only lowercase letters, digits, and hyphens are allowed\./i,
+      ),
+    ).toBeInTheDocument();
+  });
+
   it("blocks submit when YAML name doesn't match the slug", async () => {
     render(<MarketplaceSubmitPage />);
     await fillRequiredFields();
@@ -135,7 +147,7 @@ describe("MarketplaceSubmitPage — validation", () => {
       target: { value: "name: completely-different-name\n" },
     });
 
-    fireEvent.click(screen.getByRole("button", { name: /Submit to GitHub/i }));
+    fireEvent.click(screen.getByRole("button", { name: /Open PR on GitHub/i }));
 
     expect(
       await screen.findByText(
@@ -206,7 +218,7 @@ describe("MarketplaceSubmitPage — submit flow", () => {
     render(<MarketplaceSubmitPage />);
     await fillRequiredFields();
 
-    fireEvent.click(screen.getByRole("button", { name: /Submit to GitHub/i }));
+    fireEvent.click(screen.getByRole("button", { name: /Open PR on GitHub/i }));
 
     await waitFor(() => expect(openMock).toHaveBeenCalledTimes(1));
     const [url, target, features] = openMock.mock.calls[0] as [
@@ -234,7 +246,7 @@ describe("MarketplaceSubmitPage — submit flow", () => {
   it("opens a second GitHub tab with recipe.json when manifest button is clicked", async () => {
     render(<MarketplaceSubmitPage />);
     await fillRequiredFields();
-    fireEvent.click(screen.getByRole("button", { name: /Submit to GitHub/i }));
+    fireEvent.click(screen.getByRole("button", { name: /Open PR on GitHub/i }));
 
     // wait for transition
     await screen.findByRole("button", {
@@ -257,7 +269,7 @@ describe("MarketplaceSubmitPage — submit flow", () => {
   it("returns to compose view when Start over is clicked", async () => {
     render(<MarketplaceSubmitPage />);
     await fillRequiredFields();
-    fireEvent.click(screen.getByRole("button", { name: /Submit to GitHub/i }));
+    fireEvent.click(screen.getByRole("button", { name: /Open PR on GitHub/i }));
     await screen.findByRole("heading", {
       name: /Recipe submission in progress/i,
     });
@@ -370,7 +382,7 @@ describe("MarketplaceSubmitPage — sessionStorage draft", () => {
   it("clears the draft when Start over is clicked", async () => {
     render(<MarketplaceSubmitPage />);
     await fillRequiredFields();
-    fireEvent.click(screen.getByRole("button", { name: /Submit to GitHub/i }));
+    fireEvent.click(screen.getByRole("button", { name: /Open PR on GitHub/i }));
     await screen.findByRole("heading", {
       name: /Recipe submission in progress/i,
     });

--- a/dashboard/src/app/marketplace/submit/page.tsx
+++ b/dashboard/src/app/marketplace/submit/page.tsx
@@ -590,7 +590,7 @@ export default function MarketplaceSubmitPage() {
       >
         <strong style={{ color: "var(--fg-1)" }}>How this works:</strong> fill
         the form below, validate the YAML, then click{" "}
-        <strong>Submit to GitHub</strong>. We open a prefilled "create new
+        <strong>Open PR on GitHub</strong>. We open a prefilled "create new
         file" page on the registry repo. GitHub will fork it for you if
         needed, then you click <em>Propose new file</em> to open a PR. You
         then add the manifest file the same way — full instructions appear on
@@ -753,9 +753,14 @@ export default function MarketplaceSubmitPage() {
               htmlFor="ms-slug"
               required
               hint={
-                formData.slug
-                  ? `Becomes ${recipeYamlPath(formData)} on GitHub.`
-                  : "Lowercase kebab-case (e.g. my-daily-report). Becomes the directory name in the registry."
+                // Three states: warn if the raw input normalised to something
+                // different (unicode/uppercase/whitespace stripped), preview the
+                // resulting path once it's clean, or show the initial how-to copy.
+                slugRaw && slugRaw.trim() !== formData.slug
+                  ? `Will be saved as “${formData.slug || "(empty)"}” — only lowercase letters, digits, and hyphens are allowed.`
+                  : formData.slug
+                    ? `Becomes ${recipeYamlPath(formData)} on GitHub.`
+                    : "Lowercase kebab-case (e.g. my-daily-report). Becomes the directory name in the registry."
               }
               error={submitErrors.slug}
             >
@@ -1155,7 +1160,7 @@ export default function MarketplaceSubmitPage() {
           }}
         >
           <button type="submit" className="btn primary">
-            Submit to GitHub →
+            Open PR on GitHub →
           </button>
           <Link href="/marketplace" className="btn ghost">
             Cancel


### PR DESCRIPTION
## Summary

The polish trio held back from the dogfood backlog. Three small UX fixes:

- **Bug #6** — RecipeCard's elevated-risk install confirm uses the styled `<Dialog/>` instead of `window.confirm`. Same gating (medium/high risk OR network/file access). Shows the install source URL inline, colour-coded risk pill, auto-focused Install button.
- **Bug #4** — Slug field warns when raw input contains characters that get stripped (unicode, uppercase, whitespace). Typing "Café Daily" now shows _"Will be saved as 'caf-daily' — only lowercase letters, digits, and hyphens are allowed."_ instead of silently saving.
- **Bug #7** — Primary submit button: _"Submit to GitHub →"_ → _"Open PR on GitHub →"_. We don't push for the user — we open the create-file form that becomes a PR. Tests + body copy updated.

## Test plan

- [x] `npx vitest run` — dashboard suite 479/479 (was 478; +1 slug-warn regression)
- [ ] CI green