### PR TITLE
fix(marketplace): three-state bridge status + confirm dialog on detail-page install panels

### DIFF
--- a/dashboard/src/app/marketplace/[...slug]/InstallPanel.tsx
+++ b/dashboard/src/app/marketplace/[...slug]/InstallPanel.tsx
@@ -1,27 +1,60 @@
 "use client";
 
+import Link from "next/link";
 import { useEffect, useState } from "react";
 import { apiPath } from "@/lib/api";
-import { assertValidInstallSource, shortName } from "@/lib/registry";
+import {
+  assertValidInstallSource,
+  type RiskLevel,
+  shortName,
+} from "@/lib/registry";
+import { InstallConfirmDialog } from "../_components/InstallConfirmDialog";
 
 interface Props {
   install: string;
   name: string;
+  /**
+   * Optional risk metadata. When `riskLevel` is medium/high OR
+   * `networkAccess`/`fileAccess` is true, clicking Install opens the
+   * confirm dialog instead of installing one-tap — same gating as the
+   * browse-view RecipeCard. Pre-fix, the detail page skipped the
+   * confirm step entirely so installing a high-risk recipe from a
+   * share link was one click.
+   */
+  riskLevel?: RiskLevel;
+  connectors?: string[];
+  networkAccess?: boolean;
+  fileAccess?: boolean;
 }
 
-interface BridgeStatus {
-  online: boolean;
-  installed: boolean;
-}
+// Three-state instead of boolean — distinguishes 401 (logged-out
+// dashboard, bridge IS reachable) from 503 (bridge truly down). PR #552
+// fixed this on the browse view; this panel was missed in that wave.
+type BridgeStatus = "checking" | "online" | "offline" | "unauth";
 
 const POLL_TIMEOUT_MS = 1500;
 
-export default function InstallPanel({ install, name }: Props) {
-  const [status, setStatus] = useState<BridgeStatus | null>(null);
+export default function InstallPanel({
+  install,
+  name,
+  riskLevel,
+  connectors,
+  networkAccess,
+  fileAccess,
+}: Props) {
+  const [bridgeStatus, setBridgeStatus] = useState<BridgeStatus>("checking");
+  const [installed, setInstalled] = useState(false);
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState<string | null>(null);
   const [done, setDone] = useState(false);
   const [copied, setCopied] = useState(false);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+
+  const elevated =
+    riskLevel === "medium" ||
+    riskLevel === "high" ||
+    networkAccess === true ||
+    fileAccess === true;
 
   useEffect(() => {
     let cancelled = false;
@@ -32,20 +65,26 @@ export default function InstallPanel({ install, name }: Props) {
       .then(async (r) => {
         if (cancelled) return;
         if (!r.ok) {
-          setStatus({ online: false, installed: false });
+          setBridgeStatus(r.status === 401 ? "unauth" : "offline");
           return;
         }
         const data = await r.json();
-        const list = Array.isArray(data) ? data : Array.isArray(data?.recipes) ? data.recipes : [];
-        // Registry names are scoped (e.g. "@patchworkos/morning-brief") but
-        // the bridge writes recipes under their YAML `name:` field (unscoped,
-        // e.g. "morning-brief"). Compare against the short form.
+        const list = Array.isArray(data)
+          ? data
+          : Array.isArray(data?.recipes)
+            ? data.recipes
+            : [];
+        // Bridge stores recipes under the unscoped YAML `name:`; the
+        // detail page receives the scoped registry name.
         const target = shortName(name);
-        const installed = list.some((x: { name: string }) => x.name === target);
-        setStatus({ online: true, installed });
+        const isInstalled = list.some(
+          (x: { name: string }) => x.name === target,
+        );
+        setBridgeStatus("online");
+        setInstalled(isInstalled);
       })
       .catch(() => {
-        if (!cancelled) setStatus({ online: false, installed: false });
+        if (!cancelled) setBridgeStatus("offline");
       })
       .finally(() => clearTimeout(timer));
 
@@ -56,13 +95,10 @@ export default function InstallPanel({ install, name }: Props) {
     };
   }, [name]);
 
-  async function handleInstall() {
+  async function runInstall() {
     setBusy(true);
     setErr(null);
     try {
-      // Defense in depth: refuse to forward anything that isn't a
-      // github:owner/repo[/path]@ref shape. Tampered registry indexes
-      // could otherwise pass opaque strings (https://, file://, etc).
       assertValidInstallSource(install);
       const res = await fetch(apiPath("/api/bridge/recipes/install"), {
         method: "POST",
@@ -77,6 +113,11 @@ export default function InstallPanel({ install, name }: Props) {
         } catch {
           // ignore parse failure
         }
+        // Reflect transport-level failure into the status so the user
+        // sees Log-in / Get-Patchwork on the next click instead of a
+        // stuck Install button.
+        if (res.status === 401) setBridgeStatus("unauth");
+        else if (res.status >= 500) setBridgeStatus("offline");
         throw new Error(msg);
       }
       setDone(true);
@@ -85,6 +126,14 @@ export default function InstallPanel({ install, name }: Props) {
     } finally {
       setBusy(false);
     }
+  }
+
+  function handleInstall() {
+    if (elevated) {
+      setConfirmOpen(true);
+      return;
+    }
+    void runInstall();
   }
 
   const cliCmd = `patchwork recipe install ${install}`;
@@ -98,33 +147,44 @@ export default function InstallPanel({ install, name }: Props) {
     }
   }
 
-  const installed = status?.installed === true || done;
+  const isInstalled = installed || done;
 
   return (
     <div className="glass-card" style={{ padding: "var(--s-5)", display: "flex", flexDirection: "column", gap: 12 }}>
       <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 12, flexWrap: "wrap" }}>
         <div style={{ fontSize: "var(--fs-m)", color: "var(--ink-1)" }}>
-          {installed ? (
+          {isInstalled ? (
             <>
               <span style={{ color: "var(--ok)", marginRight: 6 }}>✓</span>
               Installed locally — enable with{" "}
               <code style={{ background: "var(--recess)", padding: "2px 6px", borderRadius: 4 }}>
-                patchwork recipe enable {name.replace(/^@[^/]+\//, "")}
+                patchwork recipe enable {shortName(name)}
               </code>
             </>
-          ) : status?.online ? (
+          ) : bridgeStatus === "online" ? (
             "Bridge connected — install with one click."
-          ) : status === null ? (
+          ) : bridgeStatus === "checking" ? (
             "Checking for local bridge…"
+          ) : bridgeStatus === "unauth" ? (
+            "Bridge reachable but the dashboard is logged out. Sign in to install in one click, or use the CLI below."
           ) : (
             "No local bridge detected. Install via CLI below."
           )}
         </div>
 
-        {!installed && status?.online && (
+        {!isInstalled && bridgeStatus === "online" && (
           <button type="button" className="btn sm" onClick={handleInstall} disabled={busy}>
             {busy ? "Installing…" : "Install"}
           </button>
+        )}
+        {!isInstalled && bridgeStatus === "unauth" && (
+          <Link
+            href="/login?next=/dashboard/marketplace"
+            className="btn sm"
+            style={{ textDecoration: "none", flexShrink: 0 }}
+          >
+            Log in
+          </Link>
         )}
       </div>
 
@@ -159,6 +219,18 @@ export default function InstallPanel({ install, name }: Props) {
           {err}
         </div>
       )}
+
+      <InstallConfirmDialog
+        open={confirmOpen}
+        onClose={() => setConfirmOpen(false)}
+        onConfirm={() => void runInstall()}
+        name={shortName(name)}
+        source={install}
+        riskLevel={riskLevel}
+        connectors={connectors}
+        networkAccess={networkAccess}
+        fileAccess={fileAccess}
+      />
     </div>
   );
 }

--- a/dashboard/src/app/marketplace/[...slug]/__tests__/InstallPanel.test.tsx
+++ b/dashboard/src/app/marketplace/[...slug]/__tests__/InstallPanel.test.tsx
@@ -1,0 +1,158 @@
+/**
+ * InstallPanel (single recipe, detail page) regression coverage.
+ *
+ * Focus: the gaps that the dogfood audit found on the detail page even
+ * after PR #552 fixed them on the browse view —
+ *   - three-state bridge status (401 vs 503/offline conflation)
+ *   - install-confirm dialog gated by elevated risk metadata
+ *   - Log-in CTA when unauth
+ */
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  type Mock,
+  vi,
+} from "vitest";
+import InstallPanel from "../InstallPanel";
+
+let fetchMock: Mock;
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+beforeEach(() => {
+  fetchMock = vi.fn();
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+const INSTALL = "github:patchworkos/recipes/recipes/morning-brief";
+const NAME = "@patchworkos/morning-brief";
+
+describe("InstallPanel — three-state bridge status", () => {
+  it("shows the 'logged out' copy + Log in CTA when /api/bridge/recipes returns 401", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(401, {}));
+    render(<InstallPanel install={INSTALL} name={NAME} />);
+    await waitFor(() =>
+      expect(
+        screen.getByText(/dashboard is logged out/i),
+      ).toBeInTheDocument(),
+    );
+    expect(
+      screen.getByRole("link", { name: /Log in/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /^Install$/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows the offline copy when /api/bridge/recipes returns 503", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(503, {}));
+    render(<InstallPanel install={INSTALL} name={NAME} />);
+    await waitFor(() =>
+      expect(
+        screen.getByText(/No local bridge detected/i),
+      ).toBeInTheDocument(),
+    );
+    expect(
+      screen.queryByRole("link", { name: /Log in/i }),
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe("InstallPanel — install-confirm dialog", () => {
+  it("installs in one tap when the recipe is low-risk (no confirm dialog)", async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(200, { recipes: [] })) // status poll
+      .mockResolvedValueOnce(jsonResponse(200, { ok: true })); // install
+    render(
+      <InstallPanel
+        install={INSTALL}
+        name={NAME}
+        riskLevel="low"
+        networkAccess={false}
+        fileAccess={false}
+      />,
+    );
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: /^Install$/i }),
+      ).toBeInTheDocument(),
+    );
+    fireEvent.click(screen.getByRole("button", { name: /^Install$/i }));
+    // Install POST fires immediately, no dialog interception.
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+  });
+
+  it("opens the confirm dialog before installing a high-risk recipe", async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(200, { recipes: [] })) // status poll
+      .mockResolvedValueOnce(jsonResponse(200, { ok: true })); // install
+    render(
+      <InstallPanel
+        install={INSTALL}
+        name={NAME}
+        riskLevel="high"
+        connectors={["gmail", "slack"]}
+        networkAccess
+        fileAccess
+      />,
+    );
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: /^Install$/i }),
+      ).toBeInTheDocument(),
+    );
+    fireEvent.click(screen.getByRole("button", { name: /^Install$/i }));
+
+    // Dialog has rendered, install POST NOT yet sent.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(
+      await screen.findByRole("dialog", {
+        name: /Confirm install of morning-brief/i,
+      }),
+    ).toBeInTheDocument();
+    // Risk + connectors + network/file bullets visible.
+    expect(screen.getByText(/Risk:/i)).toBeInTheDocument();
+    expect(screen.getByText(/gmail, slack/i)).toBeInTheDocument();
+    expect(screen.getByText(/Network access/i)).toBeInTheDocument();
+    expect(screen.getByText(/File access/i)).toBeInTheDocument();
+
+    // Confirm fires the POST.
+    const confirms = screen.getAllByRole("button", { name: /^Install$/i });
+    fireEvent.click(confirms[confirms.length - 1]);
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+  });
+
+  it("Cancel button in the dialog does not POST", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(200, { recipes: [] }));
+    render(
+      <InstallPanel
+        install={INSTALL}
+        name={NAME}
+        riskLevel="high"
+      />,
+    );
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: /^Install$/i }),
+      ).toBeInTheDocument(),
+    );
+    fireEvent.click(screen.getByRole("button", { name: /^Install$/i }));
+    fireEvent.click(await screen.findByRole("button", { name: /Cancel/i }));
+    // Only the status-poll call; no install POST.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/dashboard/src/app/marketplace/[...slug]/page.tsx
+++ b/dashboard/src/app/marketplace/[...slug]/page.tsx
@@ -95,7 +95,14 @@ export default async function RecipeDetailPage({ params }: PageProps) {
 
       <Description recipe={recipe} manifest={manifest} />
 
-      <InstallPanel install={recipe.install} name={recipe.name} />
+      <InstallPanel
+        install={recipe.install}
+        name={recipe.name}
+        riskLevel={recipe.risk_level}
+        connectors={recipe.connectors}
+        networkAccess={recipe.network_access}
+        fileAccess={recipe.file_access}
+      />
 
       <ConnectorHealthPanel connectors={recipe.connectors} marginTop={0} />
 

--- a/dashboard/src/app/marketplace/_components/InstallConfirmDialog.tsx
+++ b/dashboard/src/app/marketplace/_components/InstallConfirmDialog.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import { Dialog } from "@/components/Dialog";
+import type { RiskLevel } from "@/lib/registry";
+
+/**
+ * Shared install-confirmation dialog used by:
+ *   - browse view RecipeCard (single recipe, gated by `elevated`)
+ *   - detail-page InstallPanel (single recipe, gated by `elevated`)
+ *   - bundle detail panel (always shown — bundles are inherently elevated
+ *     because they install multiple recipes + may pull plugins / policies)
+ *
+ * Renders nothing when `open=false`; consumers control open/close via state.
+ */
+export interface InstallConfirmDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+  /** Heading + dialog ariaLabel suffix — e.g. "morning-brief" or "morning bundle". */
+  name: string;
+  /** Verbatim install source (`github:owner/repo[/path]`), shown inline. */
+  source: string;
+  /** Optional risk level — drives the colour-coded pill. */
+  riskLevel?: RiskLevel;
+  /** Optional connector list shown as a comma-separated row. */
+  connectors?: string[];
+  /** Adds a "Network access" bullet when truthy. */
+  networkAccess?: boolean;
+  /** Adds a "File access" bullet when truthy. */
+  fileAccess?: boolean;
+  /** Optional extra bullets (e.g. bundle plugin / policy advisory). */
+  extraBullets?: string[];
+  /** Confirm button label, default "Install". Bundles use "Install bundle". */
+  confirmLabel?: string;
+}
+
+const RISK_COLOUR: Record<RiskLevel, string> = {
+  low: "var(--ok)",
+  medium: "var(--warn)",
+  high: "var(--err)",
+};
+
+export function InstallConfirmDialog({
+  open,
+  onClose,
+  onConfirm,
+  name,
+  source,
+  riskLevel,
+  connectors,
+  networkAccess,
+  fileAccess,
+  extraBullets,
+  confirmLabel = "Install",
+}: InstallConfirmDialogProps) {
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      ariaLabel={`Confirm install of ${name}`}
+    >
+      <h2
+        style={{
+          margin: 0,
+          marginBottom: "var(--s-3)",
+          fontSize: "var(--fs-l)",
+          color: "var(--ink-0)",
+        }}
+      >
+        Install {name}?
+      </h2>
+      <p
+        style={{
+          margin: 0,
+          marginBottom: "var(--s-4)",
+          fontSize: "var(--fs-s)",
+          color: "var(--fg-2)",
+          lineHeight: 1.5,
+        }}
+      >
+        The recipe YAML will be fetched from{" "}
+        <code
+          style={{
+            background: "var(--recess)",
+            padding: "1px 5px",
+            borderRadius: 4,
+            fontSize: "var(--fs-xs)",
+            wordBreak: "break-all",
+          }}
+        >
+          {source}
+        </code>{" "}
+        and stored locally.
+      </p>
+      <ul
+        style={{
+          margin: 0,
+          marginBottom: "var(--s-5)",
+          paddingLeft: "var(--s-4)",
+          fontSize: "var(--fs-s)",
+          color: "var(--ink-1)",
+          lineHeight: 1.7,
+        }}
+      >
+        {riskLevel && (
+          <li>
+            <strong>Risk:</strong>{" "}
+            <span style={{ color: RISK_COLOUR[riskLevel] }}>{riskLevel}</span>
+          </li>
+        )}
+        {connectors && connectors.length > 0 && (
+          <li>
+            <strong>Connectors:</strong> {connectors.join(", ")}
+          </li>
+        )}
+        {networkAccess && <li>Network access</li>}
+        {fileAccess && <li>File access</li>}
+        {extraBullets?.map((b) => (
+          <li key={b}>{b}</li>
+        ))}
+      </ul>
+      <div
+        style={{
+          display: "flex",
+          gap: "var(--s-2)",
+          justifyContent: "flex-end",
+        }}
+      >
+        <button type="button" className="btn sm ghost" onClick={onClose}>
+          Cancel
+        </button>
+        <button
+          type="button"
+          className="btn sm primary"
+          onClick={() => {
+            onClose();
+            onConfirm();
+          }}
+          // biome-ignore lint/a11y/noAutofocus: dialog-scoped — focus moves
+          // into the panel anyway and Enter should confirm the primary action.
+          autoFocus
+        >
+          {confirmLabel}
+        </button>
+      </div>
+    </Dialog>
+  );
+}

--- a/dashboard/src/app/marketplace/bundle/[...slug]/BundleInstallPanel.tsx
+++ b/dashboard/src/app/marketplace/bundle/[...slug]/BundleInstallPanel.tsx
@@ -1,8 +1,10 @@
 "use client";
 
+import Link from "next/link";
 import { useEffect, useState } from "react";
 import { apiPath } from "@/lib/api";
-import { shortName } from "@/lib/registry";
+import { type RiskLevel, shortName } from "@/lib/registry";
+import { InstallConfirmDialog } from "../../_components/InstallConfirmDialog";
 
 interface Props {
   /**
@@ -19,13 +21,22 @@ interface Props {
   plugin?: string;
   /** Optional advisory surface for `manifest.policy_template`. */
   policyTemplate?: string;
+  // ── Confirm-dialog metadata (RegistryBundle.* via TrustMetadata) ──────
+  /** Display name for the confirm dialog heading. */
+  name: string;
+  /** Optional risk metadata for the confirm dialog. Bundles always
+   * trigger the confirm step (multi-recipe install + possible plugin),
+   * but the metadata enriches what the user sees. */
+  riskLevel?: RiskLevel;
+  connectors?: string[];
+  networkAccess?: boolean;
+  fileAccess?: boolean;
 }
 
-interface BridgeStatus {
-  online: boolean;
-  /** Count of bundle recipes already installed (matched by name). */
-  installedCount: number;
-}
+// Three-state instead of boolean: distinguishes 401 (logged-out
+// dashboard) from 503 (no bridge). Matches the fix PR #552 made on the
+// browse view; PR #549 extended it to the single-recipe detail panel.
+type BridgeStatus = "checking" | "online" | "offline" | "unauth";
 
 interface BundleInstallResponse {
   ok: boolean;
@@ -48,12 +59,19 @@ export default function BundleInstallPanel({
   recipes,
   plugin,
   policyTemplate,
+  name,
+  riskLevel,
+  connectors,
+  networkAccess,
+  fileAccess,
 }: Props) {
-  const [status, setStatus] = useState<BridgeStatus | null>(null);
+  const [bridgeStatus, setBridgeStatus] = useState<BridgeStatus>("checking");
+  const [installedCount, setInstalledCount] = useState(0);
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState<string | null>(null);
   const [result, setResult] = useState<BundleInstallResponse | null>(null);
   const [copied, setCopied] = useState(false);
+  const [confirmOpen, setConfirmOpen] = useState(false);
 
   const cliCmd = `patchwork recipe install ${installSource}`;
 
@@ -66,7 +84,7 @@ export default function BundleInstallPanel({
       .then(async (r) => {
         if (cancelled) return;
         if (!r.ok) {
-          setStatus({ online: false, installedCount: 0 });
+          setBridgeStatus(r.status === 401 ? "unauth" : "offline");
           return;
         }
         const data = await r.json();
@@ -80,17 +98,17 @@ export default function BundleInstallPanel({
             .map((x: { name?: string }) => x.name)
             .filter((n: string | undefined): n is string => Boolean(n)),
         );
-        // Bundle manifest entries may be scoped (`@scope/name`); the bridge
-        // writes recipes under their unscoped YAML `name:` field. Strip the
-        // scope before comparing so a bundle ships with consistent display
-        // names but still finds locally-installed recipes.
-        const installedCount = recipes.filter((r) =>
+        // Bundle manifest entries may be scoped (`@scope/name`); the
+        // bridge writes recipes under their unscoped YAML `name:`. Strip
+        // the scope before comparing.
+        const count = recipes.filter((r) =>
           installedNames.has(shortName(r)),
         ).length;
-        setStatus({ online: true, installedCount });
+        setBridgeStatus("online");
+        setInstalledCount(count);
       })
       .catch(() => {
-        if (!cancelled) setStatus({ online: false, installedCount: 0 });
+        if (!cancelled) setBridgeStatus("offline");
       })
       .finally(() => clearTimeout(timer));
 
@@ -101,7 +119,7 @@ export default function BundleInstallPanel({
     };
   }, [recipes]);
 
-  async function handleInstall() {
+  async function runInstall() {
     setBusy(true);
     setErr(null);
     setResult(null);
@@ -112,13 +130,15 @@ export default function BundleInstallPanel({
         body: JSON.stringify({ source: installSource }),
       });
       const body = (await res.json()) as BundleInstallResponse;
-      // Bridge returns 200 on partial success (any installed) and 5xx on
-      // full failure — both shapes carry `installed[]` + `failures[]`,
-      // so render the result either way and surface a top-level error
-      // banner only if there's no structured payload.
       setResult(body);
       if (!res.ok && (!body.installed || body.installed.length === 0)) {
+        if (res.status === 401) setBridgeStatus("unauth");
+        else if (res.status >= 500) setBridgeStatus("offline");
         setErr(body.error ?? `Install failed (HTTP ${res.status})`);
+      } else if (body.installed && body.installed.length > 0) {
+        // Refresh the installed-count headline so the "X of Y already
+        // installed" line catches up with the just-completed install.
+        setInstalledCount((prev) => prev + body.installed!.length);
       }
     } catch (e) {
       setErr(e instanceof Error ? e.message : String(e));
@@ -137,12 +157,25 @@ export default function BundleInstallPanel({
     }
   }
 
-  const allInstalled =
-    status?.installedCount === recipes.length && recipes.length > 0;
-  const partialInstalled =
-    status !== null &&
-    status.installedCount > 0 &&
-    status.installedCount < recipes.length;
+  const allInstalled = installedCount === recipes.length && recipes.length > 0;
+  const partialInstalled = installedCount > 0 && installedCount < recipes.length;
+
+  // Build the extra bullets for the confirm dialog. Bundles inherently
+  // span N recipes, so always surface that count; plugin / policy-template
+  // get their own line so users see them BEFORE confirming, not as a
+  // post-install advisory surprise.
+  const extraBullets: string[] = [];
+  extraBullets.push(
+    `Installs ${recipes.length} recipe${recipes.length === 1 ? "" : "s"}`,
+  );
+  if (plugin) {
+    extraBullets.push(
+      `Recommends installing companion plugin "${plugin}" via npm`,
+    );
+  }
+  if (policyTemplate) {
+    extraBullets.push(`Includes a policy template (${policyTemplate})`);
+  }
 
   return (
     <div
@@ -176,28 +209,42 @@ export default function BundleInstallPanel({
             </>
           ) : partialInstalled ? (
             <>
-              {status.installedCount} of {recipes.length} recipes already
-              installed. Install button will pull the missing{" "}
-              {recipes.length - status.installedCount}.
+              {installedCount} of {recipes.length} recipes already installed.
+              Install button will pull the missing{" "}
+              {recipes.length - installedCount}.
             </>
-          ) : status?.online ? (
+          ) : bridgeStatus === "online" ? (
             `Bridge connected — install all ${recipes.length} recipe${recipes.length === 1 ? "" : "s"} with one click.`
-          ) : status === null ? (
+          ) : bridgeStatus === "checking" ? (
             "Checking for local bridge…"
+          ) : bridgeStatus === "unauth" ? (
+            "Bridge reachable but the dashboard is logged out. Sign in to install in one click, or use the CLI below."
           ) : (
             "No local bridge detected. Install via CLI below."
           )}
         </div>
 
-        {!allInstalled && status?.online && (
+        {!allInstalled && bridgeStatus === "online" && (
           <button
             type="button"
             className="btn sm"
-            onClick={handleInstall}
+            // Bundles always go through the confirm step — pulling N
+            // recipes and possibly a plugin is too high-impact for
+            // one-tap install regardless of declared risk level.
+            onClick={() => setConfirmOpen(true)}
             disabled={busy}
           >
             {busy ? "Installing…" : "Install bundle"}
           </button>
+        )}
+        {!allInstalled && bridgeStatus === "unauth" && (
+          <Link
+            href="/login?next=/dashboard/marketplace"
+            className="btn sm"
+            style={{ textDecoration: "none", flexShrink: 0 }}
+          >
+            Log in
+          </Link>
         )}
       </div>
 
@@ -266,10 +313,6 @@ export default function BundleInstallPanel({
         </div>
       )}
 
-      {/* Plugin / policy template advisory — surface even before install
-          so users know what additional manual steps are required.
-          Mirrors the bridge response's `advisory.{plugin,policy_template}`
-          fields when those are declared in the bundle manifest. */}
       {(plugin || policyTemplate) && (
         <div
           style={{
@@ -317,6 +360,20 @@ export default function BundleInstallPanel({
           {err}
         </div>
       )}
+
+      <InstallConfirmDialog
+        open={confirmOpen}
+        onClose={() => setConfirmOpen(false)}
+        onConfirm={() => void runInstall()}
+        name={`${shortName(name)} bundle`}
+        source={installSource}
+        riskLevel={riskLevel}
+        connectors={connectors}
+        networkAccess={networkAccess}
+        fileAccess={fileAccess}
+        extraBullets={extraBullets}
+        confirmLabel="Install bundle"
+      />
     </div>
   );
 }

--- a/dashboard/src/app/marketplace/bundle/[...slug]/__tests__/BundleInstallPanel.test.tsx
+++ b/dashboard/src/app/marketplace/bundle/[...slug]/__tests__/BundleInstallPanel.test.tsx
@@ -44,12 +44,13 @@ afterEach(() => {
 
 const SOURCE = "github:patchworkos/recipes/bundles/morning";
 const RECIPES = ["a-recipe", "b-recipe", "c-recipe"];
+const NAME = "morning";
 
 describe("BundleInstallPanel — status polling", () => {
   it("shows 'Bridge connected' copy when none of the bundle's recipes are installed", async () => {
     // First (and only) call fetches /api/bridge/recipes; return empty.
     fetchMock.mockResolvedValueOnce(jsonResponse(200, { recipes: [] }));
-    render(<BundleInstallPanel installSource={SOURCE} recipes={RECIPES} />);
+    render(<BundleInstallPanel installSource={SOURCE} recipes={RECIPES} name={NAME} />);
     await waitFor(() =>
       expect(
         screen.getByText(/Bridge connected — install all 3 recipes/i),
@@ -73,6 +74,7 @@ describe("BundleInstallPanel — status polling", () => {
       <BundleInstallPanel
         installSource={SOURCE}
         recipes={["@patchworkos/a-recipe", "@patchworkos/b-recipe", "@patchworkos/c-recipe"]}
+        name={NAME}
       />,
     );
     await waitFor(() =>
@@ -86,7 +88,7 @@ describe("BundleInstallPanel — status polling", () => {
     fetchMock.mockResolvedValueOnce(
       jsonResponse(200, { recipes: [{ name: "a-recipe" }] }),
     );
-    render(<BundleInstallPanel installSource={SOURCE} recipes={RECIPES} />);
+    render(<BundleInstallPanel installSource={SOURCE} recipes={RECIPES} name={NAME} />);
     await waitFor(() =>
       expect(
         screen.getByText(/1 of 3 recipes already installed/i),
@@ -103,7 +105,7 @@ describe("BundleInstallPanel — status polling", () => {
         recipes: RECIPES.map((name) => ({ name })),
       }),
     );
-    render(<BundleInstallPanel installSource={SOURCE} recipes={RECIPES} />);
+    render(<BundleInstallPanel installSource={SOURCE} recipes={RECIPES} name={NAME} />);
     await waitFor(() =>
       expect(
         screen.getByText(/All 3 recipes installed locally/i),
@@ -116,13 +118,34 @@ describe("BundleInstallPanel — status polling", () => {
 
   it("falls back to 'No local bridge' copy when /api/bridge/recipes errors", async () => {
     fetchMock.mockResolvedValueOnce(jsonResponse(503, {}));
-    render(<BundleInstallPanel installSource={SOURCE} recipes={RECIPES} />);
+    render(<BundleInstallPanel installSource={SOURCE} recipes={RECIPES} name={NAME} />);
     await waitFor(() =>
       expect(
         screen.getByText(/No local bridge detected/i),
       ).toBeInTheDocument(),
     );
     // No install button when bridge is offline — only the CLI copy box.
+    expect(
+      screen.queryByRole("button", { name: /Install bundle/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows the 'logged out' copy + Log in CTA when /api/bridge/recipes returns 401", async () => {
+    // Three-state bridge status: 401 must NOT be conflated with 503/offline.
+    // Pre-fix the bundle panel said "No local bridge detected" when the
+    // dashboard was logged out, even though the bridge was reachable.
+    fetchMock.mockResolvedValueOnce(jsonResponse(401, {}));
+    render(<BundleInstallPanel installSource={SOURCE} recipes={RECIPES} name={NAME} />);
+    await waitFor(() =>
+      expect(
+        screen.getByText(/dashboard is logged out/i),
+      ).toBeInTheDocument(),
+    );
+    expect(
+      screen.getByRole("link", { name: /Log in/i }),
+    ).toBeInTheDocument();
+    // Install button is hidden in the unauth state — the Log-in CTA takes
+    // its slot.
     expect(
       screen.queryByRole("button", { name: /Install bundle/i }),
     ).not.toBeInTheDocument();
@@ -146,13 +169,16 @@ describe("BundleInstallPanel — install action", () => {
           failures: [],
         }),
       );
-    render(<BundleInstallPanel installSource={SOURCE} recipes={RECIPES} />);
+    render(<BundleInstallPanel installSource={SOURCE} recipes={RECIPES} name={NAME} />);
     await waitFor(() =>
       expect(
         screen.getByRole("button", { name: /Install bundle/i }),
       ).toBeInTheDocument(),
     );
     fireEvent.click(screen.getByRole("button", { name: /Install bundle/i }));
+    // Confirm dialog opens; click the confirm button inside it.
+    const confirmBtns = screen.getAllByRole("button", { name: /Install bundle/i });
+    fireEvent.click(confirmBtns[confirmBtns.length - 1]);
 
     await waitFor(() =>
       expect(screen.getByText(/Installed 3 recipes:/i)).toBeInTheDocument(),
@@ -181,13 +207,16 @@ describe("BundleInstallPanel — install action", () => {
           ],
         }),
       );
-    render(<BundleInstallPanel installSource={SOURCE} recipes={RECIPES} />);
+    render(<BundleInstallPanel installSource={SOURCE} recipes={RECIPES} name={NAME} />);
     await waitFor(() =>
       expect(
         screen.getByRole("button", { name: /Install bundle/i }),
       ).toBeInTheDocument(),
     );
     fireEvent.click(screen.getByRole("button", { name: /Install bundle/i }));
+    // Confirm dialog opens; click the confirm button inside it.
+    const confirmBtns = screen.getAllByRole("button", { name: /Install bundle/i });
+    fireEvent.click(confirmBtns[confirmBtns.length - 1]);
 
     await waitFor(() => expect(screen.getByText(/2 failed:/i)).toBeInTheDocument());
     expect(screen.getByText(/Installed 1 recipe:/i)).toBeInTheDocument();
@@ -207,13 +236,16 @@ describe("BundleInstallPanel — install action", () => {
           code: "bundle_manifest_invalid_recipes",
         }),
       );
-    render(<BundleInstallPanel installSource={SOURCE} recipes={RECIPES} />);
+    render(<BundleInstallPanel installSource={SOURCE} recipes={RECIPES} name={NAME} />);
     await waitFor(() =>
       expect(
         screen.getByRole("button", { name: /Install bundle/i }),
       ).toBeInTheDocument(),
     );
     fireEvent.click(screen.getByRole("button", { name: /Install bundle/i }));
+    // Confirm dialog opens; click the confirm button inside it.
+    const confirmBtns = screen.getAllByRole("button", { name: /Install bundle/i });
+    fireEvent.click(confirmBtns[confirmBtns.length - 1]);
 
     await waitFor(() =>
       expect(
@@ -230,6 +262,7 @@ describe("BundleInstallPanel — advisory rendering", () => {
       <BundleInstallPanel
         installSource={SOURCE}
         recipes={RECIPES}
+        name={NAME}
         plugin="@example/plugin"
       />,
     );
@@ -250,6 +283,7 @@ describe("BundleInstallPanel — advisory rendering", () => {
       <BundleInstallPanel
         installSource={SOURCE}
         recipes={RECIPES}
+        name={NAME}
         policyTemplate="policies/strict.json"
       />,
     );
@@ -266,7 +300,7 @@ describe("BundleInstallPanel — advisory rendering", () => {
 
   it("does not render the manual-followup section when no advisory is present", async () => {
     fetchMock.mockResolvedValueOnce(jsonResponse(200, { recipes: [] }));
-    render(<BundleInstallPanel installSource={SOURCE} recipes={RECIPES} />);
+    render(<BundleInstallPanel installSource={SOURCE} recipes={RECIPES} name={NAME} />);
     await waitFor(() =>
       expect(
         screen.getByRole("button", { name: /Install bundle/i }),

--- a/dashboard/src/app/marketplace/bundle/[...slug]/page.tsx
+++ b/dashboard/src/app/marketplace/bundle/[...slug]/page.tsx
@@ -73,6 +73,11 @@ export default async function BundleDetailPage({ params }: PageProps) {
       <BundleInstallPanel
         installSource={bundle.install}
         recipes={manifest?.recipes ?? []}
+        name={bundle.name}
+        riskLevel={bundle.risk_level ?? manifest?.risk_level}
+        connectors={bundle.connectors}
+        networkAccess={bundle.network_access ?? manifest?.network_access}
+        fileAccess={bundle.file_access ?? manifest?.file_access}
         {...(manifest?.plugin && { plugin: manifest.plugin })}
         {...(manifest?.policy_template && {
           policyTemplate: manifest.policy_template,

--- a/dashboard/src/app/marketplace/page.tsx
+++ b/dashboard/src/app/marketplace/page.tsx
@@ -2,9 +2,9 @@
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
-import { Dialog } from "@/components/Dialog";
 import { Skeleton, SkeletonText } from "@/components/Skeleton";
 import { HintCard } from "@/components/patchwork";
+import { InstallConfirmDialog } from "./_components/InstallConfirmDialog";
 import { apiPath } from "@/lib/api";
 import {
   assertValidInstallSource,
@@ -401,106 +401,17 @@ function RecipeCard({
         </div>
       )}
 
-      <Dialog
+      <InstallConfirmDialog
         open={confirmOpen}
         onClose={() => setConfirmOpen(false)}
-        ariaLabel={`Confirm install of ${shortName(recipe.name)}`}
-      >
-        <h2
-          style={{
-            margin: 0,
-            marginBottom: "var(--s-3)",
-            fontSize: "var(--fs-l)",
-            color: "var(--ink-0)",
-          }}
-        >
-          Install {shortName(recipe.name)}?
-        </h2>
-        <p
-          style={{
-            margin: 0,
-            marginBottom: "var(--s-4)",
-            fontSize: "var(--fs-s)",
-            color: "var(--fg-2)",
-            lineHeight: 1.5,
-          }}
-        >
-          The recipe YAML will be fetched from{" "}
-          <code
-            style={{
-              background: "var(--recess)",
-              padding: "1px 5px",
-              borderRadius: 4,
-              fontSize: "var(--fs-xs)",
-              wordBreak: "break-all",
-            }}
-          >
-            {recipe.install}
-          </code>{" "}
-          and stored locally.
-        </p>
-        <ul
-          style={{
-            margin: 0,
-            marginBottom: "var(--s-5)",
-            paddingLeft: "var(--s-4)",
-            fontSize: "var(--fs-s)",
-            color: "var(--ink-1)",
-            lineHeight: 1.7,
-          }}
-        >
-          {recipe.risk_level && (
-            <li>
-              <strong>Risk:</strong>{" "}
-              <span
-                style={{
-                  color:
-                    recipe.risk_level === "high"
-                      ? "var(--err)"
-                      : recipe.risk_level === "medium"
-                        ? "var(--warn)"
-                        : "var(--ok)",
-                }}
-              >
-                {recipe.risk_level}
-              </span>
-            </li>
-          )}
-          {recipe.connectors?.length ? (
-            <li>
-              <strong>Connectors:</strong> {recipe.connectors.join(", ")}
-            </li>
-          ) : null}
-          {recipe.network_access && <li>Network access</li>}
-          {recipe.file_access && <li>File access</li>}
-        </ul>
-        <div
-          style={{
-            display: "flex",
-            gap: "var(--s-2)",
-            justifyContent: "flex-end",
-          }}
-        >
-          <button
-            type="button"
-            className="btn sm ghost"
-            onClick={() => setConfirmOpen(false)}
-          >
-            Cancel
-          </button>
-          <button
-            type="button"
-            className="btn sm primary"
-            onClick={() => {
-              setConfirmOpen(false);
-              void runInstall();
-            }}
-            autoFocus
-          >
-            Install
-          </button>
-        </div>
-      </Dialog>
+        onConfirm={() => void runInstall()}
+        name={shortName(recipe.name)}
+        source={recipe.install}
+        riskLevel={recipe.risk_level}
+        connectors={recipe.connectors}
+        networkAccess={recipe.network_access}
+        fileAccess={recipe.file_access}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

The dogfood audit found that PR #552's three-state bridge-status fix and PR #554's install-confirm Dialog landed on the **browse view** but neither was replicated onto the two detail-page install panels:

- Clicking Install on a high-risk recipe (or bundle) from a shared detail URL skipped the confirm step entirely.
- Both panels said "no local bridge detected" when the dashboard was merely logged out (401 conflated with 503/offline).

This PR extracts the confirm dialog into a shared component and wires both detail panels onto the same three-state status / log-in branch the browse view already has.

## Changes

- **New** `_components/InstallConfirmDialog.tsx` — single source of truth (risk pill, connectors, network/file bullets, extra-bullets slot for bundle-only lines).
- **RecipeCard (browse)** — swap inline `<Dialog>` for shared component (no behaviour change, just dedup).
- **InstallPanel (single recipe, detail)**
  - boolean `BridgeStatus.online` → three-state `"checking" | "online" | "offline" | "unauth"`
  - 401 surfaces "logged out" copy + Log-in CTA
  - confirm dialog opens when `riskLevel ∈ {medium, high}` or `network_access`/`file_access` is true
  - on 401/5xx during install, flip status so the next click routes to log-in / get-Patchwork
- **BundleInstallPanel**
  - same three-state + Log-in CTA
  - **always** shows the confirm dialog (bundles install N recipes + maybe a plugin — too high-impact for one-tap regardless of declared risk_level)
  - dialog enumerates "Installs N recipes", plugin advisory, policy-template advisory BEFORE confirming (previously only post-install)
  - on successful install, bump local `installedCount` so the "X of Y installed" headline catches up

Detail pages forward the risk metadata from the already-fetched `RegistryRecipe` / `RegistryBundle`.

## Test plan

- [x] Dashboard suite 488/488 (was 482). +6 regression tests:
  - BundleInstallPanel: 401 → log-out copy + Log-in CTA
  - InstallPanel: 401/503 split, low-risk skips dialog, high-risk opens dialog, Cancel doesn't POST
  - Existing bundle install tests updated to click the dialog's confirm button
- [x] `tsc --noEmit` clean
- [x] `biome check` clean
- [ ] CI green