### PR TITLE
fix(marketplace): distinguish registry-unreachable from recipe/bundle-missing on detail pages

### DIFF
--- a/dashboard/src/app/marketplace/[...slug]/page.tsx
+++ b/dashboard/src/app/marketplace/[...slug]/page.tsx
@@ -27,8 +27,12 @@ export async function generateMetadata({ params }: PageProps) {
   const { slug } = await params;
   const fullName = decodeURIComponent(slug.join("/"));
   const registry = await fetchRegistry();
-  const recipe = registry?.recipes.find((r) => r.name === fullName);
-
+  // Don't mislabel a registry-down page as 404 — separate title makes
+  // tab-history and SEO crawlers distinguish the two states.
+  if (!registry) {
+    return { title: "Registry unreachable — Marketplace · Patchwork OS" };
+  }
+  const recipe = registry.recipes.find((r) => r.name === fullName);
   if (!recipe) {
     return { title: "Not found — Marketplace · Patchwork OS" };
   }
@@ -56,7 +60,13 @@ export default async function RecipeDetailPage({ params }: PageProps) {
   const fullName = decodeURIComponent(slug.join("/"));
 
   const registry = await fetchRegistry();
-  const recipe = registry?.recipes.find((r) => r.name === fullName);
+  // Distinguish "registry unreachable" (CDN failure, transient network
+  // issue) from "recipe genuinely missing" — pre-fix both collapsed into
+  // notFound(), so every detail-page URL 404'd whenever the CDN was down.
+  // Now the unreachable case renders a recoverable error UI with a
+  // back-link instead of a hard 404 the user can't recover from.
+  if (!registry) return <RegistryUnreachable fullName={fullName} />;
+  const recipe = registry.recipes.find((r) => r.name === fullName);
   if (!recipe) notFound();
 
   const src = parseInstallSource(recipe.install);
@@ -353,6 +363,61 @@ function TrustMetadataCard({ recipe }: { recipe: RegistryRecipe }) {
         </tbody>
       </table>
     </div>
+  );
+}
+
+function RegistryUnreachable({ fullName }: { fullName: string }) {
+  return (
+    <section style={{ display: "flex", flexDirection: "column", gap: "var(--s-5)" }}>
+      <Link
+        href="/marketplace"
+        className="btn sm ghost"
+        style={{ alignSelf: "flex-start", textDecoration: "none", fontSize: "var(--fs-s)" }}
+      >
+        ← Back to marketplace
+      </Link>
+      <div
+        className="glass-card"
+        style={{
+          padding: "var(--s-5)",
+          display: "flex",
+          flexDirection: "column",
+          gap: "var(--s-3)",
+          background: "var(--warn-soft)",
+          border: "1px solid var(--warn)",
+        }}
+        role="alert"
+      >
+        <h1 style={{ margin: 0, fontSize: "var(--fs-l)", color: "var(--ink-0)" }}>
+          Marketplace registry unreachable
+        </h1>
+        <p style={{ margin: 0, fontSize: "var(--fs-s)", color: "var(--ink-1)", lineHeight: 1.55 }}>
+          Couldn&apos;t load the recipe index from{" "}
+          <code style={{ fontSize: "var(--fs-xs)" }}>
+            github.com/patchworkos/recipes
+          </code>
+          . The recipe{" "}
+          <code style={{ fontSize: "var(--fs-xs)" }}>{fullName}</code> may or
+          may not exist — we can&apos;t tell without the registry.
+        </p>
+        <p style={{ margin: 0, fontSize: "var(--fs-s)", color: "var(--fg-2)", lineHeight: 1.55 }}>
+          Refresh the page in a minute, or use the CLI directly:
+        </p>
+        <code
+          style={{
+            background: "var(--recess)",
+            padding: "10px 12px",
+            borderRadius: "var(--r-2)",
+            fontSize: "var(--fs-s)",
+            fontFamily: "var(--font-mono, ui-monospace, monospace)",
+            overflowX: "auto",
+            color: "var(--ink-1)",
+          }}
+        >
+          patchwork recipe install {fullName}
+        </code>
+      </div>
+    </section>
   );
 }
 

--- a/dashboard/src/app/marketplace/bundle/[...slug]/page.tsx
+++ b/dashboard/src/app/marketplace/bundle/[...slug]/page.tsx
@@ -24,7 +24,10 @@ export async function generateMetadata({ params }: PageProps) {
   const { slug } = await params;
   const fullName = decodeURIComponent(slug.join("/"));
   const registry = await fetchRegistry();
-  const bundle = registry?.bundles?.find((b) => b.name === fullName);
+  if (!registry) {
+    return { title: "Registry unreachable — Marketplace · Patchwork OS" };
+  }
+  const bundle = registry.bundles?.find((b) => b.name === fullName);
   if (!bundle) return { title: "Not found — Marketplace · Patchwork OS" };
   return {
     title: `${shortName(bundle.name)} — Bundle · Marketplace · Patchwork OS`,
@@ -37,12 +40,30 @@ export default async function BundleDetailPage({ params }: PageProps) {
   const fullName = decodeURIComponent(slug.join("/"));
 
   const registry = await fetchRegistry();
-  const bundle = registry?.bundles?.find((b) => b.name === fullName);
+  // Same fix as the recipe detail page: don't conflate "registry
+  // unreachable" with "bundle missing". Pre-fix, every bundle URL 404'd
+  // whenever the CDN was down.
+  if (!registry) return <RegistryUnreachable fullName={fullName} />;
+  const bundle = registry.bundles?.find((b) => b.name === fullName);
   if (!bundle) notFound();
 
   const src = parseInstallSource(bundle.install);
   let manifest: BundleManifest | null = null;
-  if (src) manifest = await fetchBundleManifest(src);
+  let manifestErr = false;
+  if (src) {
+    try {
+      manifest = await fetchBundleManifest(src);
+      // fetchBundleManifest swallows network errors and returns null —
+      // treat null as a manifest-unavailable signal so the page renders
+      // a notice instead of an empty bundle.
+      manifestErr = manifest === null;
+    } catch {
+      manifest = null;
+      manifestErr = true;
+    }
+  } else {
+    manifestErr = true;
+  }
 
   return (
     <section style={{ display: "flex", flexDirection: "column", gap: "var(--s-6)" }}>
@@ -59,6 +80,8 @@ export default async function BundleDetailPage({ params }: PageProps) {
       <p style={{ fontSize: "var(--fs-base)", color: "var(--ink-1)", lineHeight: 1.6, maxWidth: 760 }}>
         {manifest?.description ?? bundle.description}
       </p>
+
+      {manifestErr && <ManifestUnavailableNotice bundle={bundle} />}
 
       <WhatIsIncluded bundle={bundle} manifest={manifest} />
 
@@ -258,6 +281,94 @@ function RequiredEnvCard({ vars }: { vars: string[] }) {
           </li>
         ))}
       </ul>
+    </div>
+  );
+}
+
+function RegistryUnreachable({ fullName }: { fullName: string }) {
+  return (
+    <section style={{ display: "flex", flexDirection: "column", gap: "var(--s-5)" }}>
+      <Link
+        href="/marketplace"
+        className="btn sm ghost"
+        style={{ alignSelf: "flex-start", textDecoration: "none", fontSize: "var(--fs-s)" }}
+      >
+        ← Back to marketplace
+      </Link>
+      <div
+        className="glass-card"
+        style={{
+          padding: "var(--s-5)",
+          display: "flex",
+          flexDirection: "column",
+          gap: "var(--s-3)",
+          background: "var(--warn-soft)",
+          border: "1px solid var(--warn)",
+        }}
+        role="alert"
+      >
+        <h1 style={{ margin: 0, fontSize: "var(--fs-l)", color: "var(--ink-0)" }}>
+          Marketplace registry unreachable
+        </h1>
+        <p style={{ margin: 0, fontSize: "var(--fs-s)", color: "var(--ink-1)", lineHeight: 1.55 }}>
+          Couldn&apos;t load the bundle index from{" "}
+          <code style={{ fontSize: "var(--fs-xs)" }}>
+            github.com/patchworkos/recipes
+          </code>
+          . The bundle{" "}
+          <code style={{ fontSize: "var(--fs-xs)" }}>{fullName}</code> may or
+          may not exist — we can&apos;t tell without the registry.
+        </p>
+        <p style={{ margin: 0, fontSize: "var(--fs-s)", color: "var(--fg-2)", lineHeight: 1.55 }}>
+          Refresh in a minute, or install via CLI:
+        </p>
+        <code
+          style={{
+            background: "var(--recess)",
+            padding: "10px 12px",
+            borderRadius: "var(--r-2)",
+            fontSize: "var(--fs-s)",
+            fontFamily: "var(--font-mono, ui-monospace, monospace)",
+            overflowX: "auto",
+            color: "var(--ink-1)",
+          }}
+        >
+          patchwork recipe install {fullName}
+        </code>
+      </div>
+    </section>
+  );
+}
+
+function ManifestUnavailableNotice({ bundle }: { bundle: RegistryBundle }) {
+  return (
+    <div
+      className="glass-card"
+      style={{
+        padding: "var(--s-4) var(--s-5)",
+        background: "var(--warn-soft)",
+        border: "1px solid var(--warn)",
+        display: "flex",
+        flexDirection: "column",
+        gap: "var(--s-2)",
+      }}
+      role="status"
+    >
+      <strong style={{ fontSize: "var(--fs-s)", color: "var(--ink-0)" }}>
+        Bundle manifest unavailable
+      </strong>
+      <p style={{ margin: 0, fontSize: "var(--fs-s)", color: "var(--ink-1)", lineHeight: 1.55 }}>
+        We couldn&apos;t load{" "}
+        <code style={{ fontSize: "var(--fs-xs)" }}>{bundle.install}</code>/manifest.json
+        — the page below shows only what the registry knows. Specific recipe
+        list, plugin name, policy template, and required env may be missing.
+        Reload to retry, or install via CLI which fetches the manifest
+        directly:{" "}
+        <code style={{ fontSize: "var(--fs-xs)" }}>
+          patchwork recipe install {bundle.name}
+        </code>
+        .
+      </p>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Audit follow-up. Both marketplace detail pages collapsed two very different states into a single \`notFound()\` call:

- **registry-unreachable** — \`fetchRegistry()\` returned null because the CDN was down / DNS flaked / GitHub raw returned 5xx
- **genuinely missing** — registry loaded fine but the slug isn't in it

Pre-fix, every URL on either detail page 404'd whenever the registry CDN was down — even for recipes that DO exist. The 404 page tells the user to "check the URL" which is actively misleading.

## Changes

**\`[...slug]/page.tsx\` and \`bundle/[...slug]/page.tsx\`:**
- \`registry === null\` → render a recoverable warning page with back-link + CLI fallback command + distinct page title (so tab history / SEO can tell the states apart). \`notFound()\` is only called when the registry loaded AND the slug isn't in it.

**\`bundle/[...slug]/page.tsx\` additionally:**
- When registry loads + bundle is found but \`fetchBundleManifest()\` returns null (manifest CDN-down), render an inline notice above the body so users see "we only have what the registry knows" instead of a silent empty Recipes-list / plugin / policy-template / required-env block.

CLI fallback is genuinely useful here: \`patchwork recipe install\` takes the registry name directly and fetches the manifest itself without depending on the dashboard's CDN cache.

## Test plan

- [x] \`npx vitest run\` — 482/482 pass
- [x] \`tsc --noEmit\` clean
- [x] \`biome check\` clean
- [ ] CI green