### PR TITLE
fix(marketplace/submit): require Validate before submit + confirm before overwriting in-progress YAML

### DIFF
--- a/dashboard/src/app/marketplace/submit/__tests__/page.test.tsx
+++ b/dashboard/src/app/marketplace/submit/__tests__/page.test.tsx
@@ -102,6 +102,27 @@ async function fillRequiredFields() {
   });
 }
 
+/**
+ * Submit guard requires that Validate has been clicked at least once
+ * before the GitHub tab is opened — either a fresh successful lint or a
+ * recorded bridge-unreachable lintError counts. Most submit-flow tests
+ * mock fetch as all-503, so clicking Validate produces the unreachable
+ * branch which is sufficient. Helper consolidates the dance.
+ */
+async function runValidateAndWait() {
+  fireEvent.click(screen.getByRole("button", { name: /^Validate$/i }));
+  // Wait for the bridge-unreachable copy or the success badge to settle.
+  await waitFor(() =>
+    expect(
+      screen
+        .queryByText(/Lint passed/i)
+        // Bridge-unreachable text comes from the lint route.ts error path.
+        ?? screen.queryByText(/Bridge isn't responding/i)
+        ?? screen.queryByText(/Validation request failed/i),
+    ).not.toBeNull(),
+  );
+}
+
 // =====================================================================
 // Validation
 // =====================================================================
@@ -217,6 +238,7 @@ describe("MarketplaceSubmitPage — submit flow", () => {
   it("opens a GitHub create-file URL with the recipe.yaml prefilled", async () => {
     render(<MarketplaceSubmitPage />);
     await fillRequiredFields();
+    await runValidateAndWait();
 
     fireEvent.click(screen.getByRole("button", { name: /Open PR on GitHub/i }));
 
@@ -246,6 +268,7 @@ describe("MarketplaceSubmitPage — submit flow", () => {
   it("opens a second GitHub tab with recipe.json when manifest button is clicked", async () => {
     render(<MarketplaceSubmitPage />);
     await fillRequiredFields();
+    await runValidateAndWait();
     fireEvent.click(screen.getByRole("button", { name: /Open PR on GitHub/i }));
 
     // wait for transition
@@ -269,6 +292,7 @@ describe("MarketplaceSubmitPage — submit flow", () => {
   it("returns to compose view when Start over is clicked", async () => {
     render(<MarketplaceSubmitPage />);
     await fillRequiredFields();
+    await runValidateAndWait();
     fireEvent.click(screen.getByRole("button", { name: /Open PR on GitHub/i }));
     await screen.findByRole("heading", {
       name: /Recipe submission in progress/i,
@@ -450,6 +474,7 @@ describe("MarketplaceSubmitPage — sessionStorage draft", () => {
   it("clears the draft when Start over is clicked", async () => {
     render(<MarketplaceSubmitPage />);
     await fillRequiredFields();
+    await runValidateAndWait();
     fireEvent.click(screen.getByRole("button", { name: /Open PR on GitHub/i }));
     await screen.findByRole("heading", {
       name: /Recipe submission in progress/i,
@@ -500,6 +525,77 @@ describe("MarketplaceSubmitPage — preset picker", () => {
     ).map((o) => o.getAttribute("value"));
     // First entry is the empty placeholder.
     expect(optionValues).toEqual(["", "manual", "scheduled", "webhook"]);
+  });
+
+  it("prompts before overwriting YAML the user has customized", async () => {
+    render(<MarketplaceSubmitPage />);
+    // Customize the YAML so the guard fires.
+    fireEvent.change(screen.getByTestId("fake-yaml-editor"), {
+      target: { value: "name: hand-edited\n# user's work\n" },
+    });
+
+    fireEvent.change(
+      screen.getByLabelText(/Load a starter recipe preset/i),
+      { target: { value: "webhook" } },
+    );
+
+    // Dialog opens with the "Replace YAML?" prompt — the editor still
+    // holds the customized content.
+    expect(
+      await screen.findByRole("dialog", {
+        name: /Confirm overwrite of in-progress recipe YAML/i,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      (screen.getByTestId("fake-yaml-editor") as HTMLTextAreaElement).value,
+    ).toContain("hand-edited");
+
+    fireEvent.click(screen.getByRole("button", { name: /Keep my YAML/i }));
+    // After cancel, the editor still holds the user's work.
+    expect(
+      (screen.getByTestId("fake-yaml-editor") as HTMLTextAreaElement).value,
+    ).toContain("hand-edited");
+  });
+
+  it("swaps YAML without prompting when editor matches the starter recipe", async () => {
+    render(<MarketplaceSubmitPage />);
+    fireEvent.change(
+      screen.getByLabelText(/Load a starter recipe preset/i),
+      { target: { value: "webhook" } },
+    );
+    // No dialog — swap happens directly.
+    expect(
+      screen.queryByRole("dialog", {
+        name: /Confirm overwrite/i,
+      }),
+    ).not.toBeInTheDocument();
+    expect(
+      (screen.getByTestId("fake-yaml-editor") as HTMLTextAreaElement).value,
+    ).toContain("type: webhook");
+  });
+});
+
+// =====================================================================
+// Validate-before-submit guard
+// =====================================================================
+
+describe("MarketplaceSubmitPage — Validate-before-submit guard", () => {
+  beforeEach(() => {
+    fetchMock.mockResolvedValue(jsonResponse(503, {}));
+  });
+
+  it("blocks submit and surfaces an inline error when Validate has not been clicked", async () => {
+    render(<MarketplaceSubmitPage />);
+    await fillRequiredFields();
+    // Skip the runValidateAndWait() helper — that's the user mistake the
+    // guard is meant to catch.
+    fireEvent.click(screen.getByRole("button", { name: /Open PR on GitHub/i }));
+
+    expect(
+      await screen.findByText(/Click Validate first/i),
+    ).toBeInTheDocument();
+    // GitHub tab was NOT opened.
+    expect(openMock).not.toHaveBeenCalled();
   });
 });
 

--- a/dashboard/src/app/marketplace/submit/page.tsx
+++ b/dashboard/src/app/marketplace/submit/page.tsx
@@ -35,6 +35,7 @@ import {
   type SubmissionFormData,
 } from "@/lib/marketplaceSubmit";
 import { AutoGrowTextarea } from "@/components/AutoGrowTextarea";
+import { Dialog } from "@/components/Dialog";
 import type { ApprovalBehavior, RiskLevel } from "@/lib/registry";
 
 // CodeMirror touches `document` on mount — load it client-only.
@@ -215,6 +216,21 @@ export default function MarketplaceSubmitPage() {
   const [submitErrors, setSubmitErrors] = useState<
     Partial<Record<keyof SubmissionFormData | "yaml", string>>
   >({});
+
+  // ---- overwrite-confirm state ------------------------------------
+  // When the user picks a preset or "load installed recipe" while the
+  // YAML editor already holds non-trivial work, opening a confirm
+  // Dialog avoids silently nuking that work. Pre-fix both onChange
+  // handlers replaced the YAML directly. We only prompt when the
+  // current YAML differs from the starter — typing a slug or
+  // metadata doesn't trigger this, only actual YAML edits.
+  const [pendingOverwrite, setPendingOverwrite] = useState<{
+    label: string;
+    apply: () => void;
+  } | null>(null);
+  function yamlIsCustomized(): boolean {
+    return yaml.trim() !== STARTER_RECIPE_YAML.trim();
+  }
 
   // ---- derived data ------------------------------------------------
   const formData = useMemo<SubmissionFormData>(
@@ -459,8 +475,24 @@ export default function MarketplaceSubmitPage() {
       toast.error("Please fix the errors before submitting.");
       return;
     }
-    if (lintResult && lintResult.errors.length > 0) {
+    // Validate-before-submit guard. Pre-fix the submit handler accepted
+    // a null lintResult (user never clicked Validate) and forwarded the
+    // YAML straight to the GitHub create-file page — meaning a recipe
+    // with a syntax error could land in the PR with no warning. Now
+    // require either a fresh successful Validate OR a recorded bridge-
+    // unreachable lintError (the user opted into the soft-validate path
+    // explicitly by attempting Validate).
+    const lintIsFresh =
+      lintResult !== null && lintResult.forContent === yaml;
+    if (lintIsFresh && lintResult.errors.length > 0) {
       toast.error("Fix lint errors before submitting.");
+      return;
+    }
+    if (!lintIsFresh && lintError === null) {
+      errMap.yaml =
+        "Click Validate first — submit needs a fresh lint pass (or a recorded bridge-unreachable result).";
+      setSubmitErrors(errMap);
+      toast.error("Please Validate the YAML before submitting.");
       return;
     }
 
@@ -545,10 +577,20 @@ export default function MarketplaceSubmitPage() {
   function applyPreset(presetId: string) {
     const preset = RECIPE_PRESETS.find((p) => p.id === presetId);
     if (!preset) return;
-    // Only swap the YAML; metadata fields the user already filled stay
-    // intact. Lint result becomes stale by virtue of forContent mismatch.
-    setYaml(preset.yaml);
-    toast.info(`Loaded the ${preset.label} preset.`);
+    const doApply = () => {
+      // Only swap the YAML; metadata fields the user already filled stay
+      // intact. Lint result becomes stale by virtue of forContent mismatch.
+      setYaml(preset.yaml);
+      toast.info(`Loaded the ${preset.label} preset.`);
+    };
+    if (yamlIsCustomized()) {
+      setPendingOverwrite({
+        label: `the “${preset.label}” preset`,
+        apply: doApply,
+      });
+      return;
+    }
+    doApply();
   }
 
   function discardRestoredDraft() {
@@ -730,8 +772,17 @@ export default function MarketplaceSubmitPage() {
             <select
               defaultValue=""
               onChange={(e) => {
-                void loadFromInstalled(e.target.value);
+                const picked = e.target.value;
                 e.currentTarget.value = "";
+                if (!picked) return;
+                if (yamlIsCustomized()) {
+                  setPendingOverwrite({
+                    label: `“${picked}” (installed recipe)`,
+                    apply: () => void loadFromInstalled(picked),
+                  });
+                  return;
+                }
+                void loadFromInstalled(picked);
               }}
               style={{
                 background: "var(--bg-2)",
@@ -1232,6 +1283,65 @@ export default function MarketplaceSubmitPage() {
           }
         }
       `}</style>
+
+      <Dialog
+        open={pendingOverwrite !== null}
+        onClose={() => setPendingOverwrite(null)}
+        ariaLabel="Confirm overwrite of in-progress recipe YAML"
+      >
+        <h2
+          style={{
+            margin: 0,
+            marginBottom: "var(--s-3)",
+            fontSize: "var(--fs-l)",
+            color: "var(--ink-0)",
+          }}
+        >
+          Replace current YAML?
+        </h2>
+        <p
+          style={{
+            margin: 0,
+            marginBottom: "var(--s-5)",
+            fontSize: "var(--fs-s)",
+            color: "var(--fg-2)",
+            lineHeight: 1.5,
+          }}
+        >
+          You&apos;ve edited the recipe YAML. Loading {pendingOverwrite?.label}{" "}
+          will overwrite your work. Metadata fields (slug, author, tags…)
+          stay as-is.
+        </p>
+        <div
+          style={{
+            display: "flex",
+            gap: "var(--s-2)",
+            justifyContent: "flex-end",
+          }}
+        >
+          <button
+            type="button"
+            className="btn sm ghost"
+            onClick={() => setPendingOverwrite(null)}
+          >
+            Keep my YAML
+          </button>
+          <button
+            type="button"
+            className="btn sm primary"
+            onClick={() => {
+              const apply = pendingOverwrite?.apply;
+              setPendingOverwrite(null);
+              apply?.();
+            }}
+            // biome-ignore lint/a11y/noAutofocus: dialog-scoped — Enter
+            // should perform the primary (destructive) action explicitly.
+            autoFocus
+          >
+            Replace YAML
+          </button>
+        </div>
+      </Dialog>
     </section>
   );
 }


### PR DESCRIPTION
## Summary

Two P1 audit items, same submit-page surface:

### 1. Validate-before-submit guard
Pre-fix, the submit handler accepted a null \`lintResult\` (user never clicked Validate) and forwarded the YAML straight to GitHub's create-file page. A recipe with a syntax error could land in the PR with no warning. Now require either a fresh successful Validate **or** a recorded bridge-unreachable \`lintError\` before opening the GitHub tab — the user has to opt into the soft-validate path explicitly. Inline field error + toast on guard trip.

### 2. Confirm before overwrite on preset / installed-recipe pickers
Pre-fix, both onChange handlers replaced the YAML directly. Picking the wrong preset nuked work with no undo. Now: if the editor content differs from the starter template, picking either a preset or an installed-recipe opens a styled \`<Dialog>\` ("Replace YAML? / Keep my YAML / Replace YAML"). Untouched-from-starter content swaps in directly with no prompt.

## Test plan

- [x] Dashboard suite 500/500 (was 497, +3 regressions):
  - prompts on preset pick when editor is customized
  - swaps without prompting when editor matches starter
  - blocks submit + surfaces inline error when Validate skipped
- [x] Existing submit-flow tests updated to call a \`runValidateAndWait()\` helper that records a recoverable \`lintError\` (the soft-validate path)
- [x] \`tsc --noEmit\` clean
- [x] \`biome check\` clean
- [ ] CI green