### PR TITLE
feat(marketplace): surface missingConnectors[] notice on detail install panels

### DIFF
--- a/dashboard/src/app/marketplace/[...slug]/InstallPanel.tsx
+++ b/dashboard/src/app/marketplace/[...slug]/InstallPanel.tsx
@@ -5,10 +5,12 @@ import { useEffect, useState } from "react";
 import { apiPath } from "@/lib/api";
 import {
   assertValidInstallSource,
+  formatConnectorLabel,
   type RiskLevel,
   shortName,
 } from "@/lib/registry";
 import { InstallConfirmDialog } from "../_components/InstallConfirmDialog";
+import { MissingConnectorsNotice } from "../_components/MissingConnectorsNotice";
 
 interface Props {
   install: string;
@@ -49,6 +51,13 @@ export default function InstallPanel({
   const [done, setDone] = useState(false);
   const [copied, setCopied] = useState(false);
   const [confirmOpen, setConfirmOpen] = useState(false);
+  // Bridge ships `missingConnectors[]` on the install response when the
+  // recipe uses connectors that haven't been authorised yet (see
+  // connectorPreflight). Surfacing this on the detail panel matters more
+  // than on the browse view's transient toast — the detail page is
+  // where users land from a share link and where they'll come back to
+  // troubleshoot if the recipe never runs.
+  const [missingConnectors, setMissingConnectors] = useState<string[]>([]);
 
   const elevated =
     riskLevel === "medium" ||
@@ -98,6 +107,7 @@ export default function InstallPanel({
   async function runInstall() {
     setBusy(true);
     setErr(null);
+    setMissingConnectors([]);
     try {
       assertValidInstallSource(install);
       const res = await fetch(apiPath("/api/bridge/recipes/install"), {
@@ -105,20 +115,28 @@ export default function InstallPanel({
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ source: install }),
       });
+      let parsed: { error?: string; missingConnectors?: unknown } = {};
+      try {
+        parsed = (await res.json()) as typeof parsed;
+      } catch {
+        // ignore parse failure — fall back to status-only error below
+      }
       if (!res.ok) {
-        let msg = `Error ${res.status}`;
-        try {
-          const body = (await res.json()) as { error?: string };
-          if (body.error) msg = body.error;
-        } catch {
-          // ignore parse failure
-        }
         // Reflect transport-level failure into the status so the user
         // sees Log-in / Get-Patchwork on the next click instead of a
         // stuck Install button.
         if (res.status === 401) setBridgeStatus("unauth");
         else if (res.status >= 500) setBridgeStatus("offline");
-        throw new Error(msg);
+        throw new Error(parsed.error ?? `Error ${res.status}`);
+      }
+      // Capture missingConnectors[] before flipping `done` so the inline
+      // notice has the list to render on the same paint.
+      if (Array.isArray(parsed.missingConnectors)) {
+        setMissingConnectors(
+          parsed.missingConnectors.filter(
+            (c): c is string => typeof c === "string",
+          ),
+        );
       }
       setDone(true);
     } catch (e) {
@@ -218,6 +236,10 @@ export default function InstallPanel({
         <div className="alert-err" role="alert" style={{ fontSize: "var(--fs-s)" }}>
           {err}
         </div>
+      )}
+
+      {missingConnectors.length > 0 && (
+        <MissingConnectorsNotice connectors={missingConnectors} />
       )}
 
       <InstallConfirmDialog

--- a/dashboard/src/app/marketplace/[...slug]/__tests__/InstallPanel.test.tsx
+++ b/dashboard/src/app/marketplace/[...slug]/__tests__/InstallPanel.test.tsx
@@ -136,6 +136,35 @@ describe("InstallPanel — install-confirm dialog", () => {
     await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
   });
 
+  it("surfaces a missing-connectors notice when the bridge install response includes one", async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(200, { recipes: [] })) // status poll
+      .mockResolvedValueOnce(
+        jsonResponse(200, {
+          ok: true,
+          missingConnectors: ["gmail", "slack", "google-calendar"],
+        }),
+      );
+    render(
+      <InstallPanel install={INSTALL} name={NAME} riskLevel="low" />,
+    );
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: /^Install$/i }),
+      ).toBeInTheDocument(),
+    );
+    fireEvent.click(screen.getByRole("button", { name: /^Install$/i }));
+
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent(/Connect these services/i);
+    expect(alert).toHaveTextContent(/Gmail/);
+    expect(alert).toHaveTextContent(/Slack/);
+    expect(alert).toHaveTextContent(/Google Calendar/);
+    expect(
+      screen.getByRole("link", { name: /Open connections/i }),
+    ).toHaveAttribute("href", "/connections");
+  });
+
   it("Cancel button in the dialog does not POST", async () => {
     fetchMock.mockResolvedValueOnce(jsonResponse(200, { recipes: [] }));
     render(

--- a/dashboard/src/app/marketplace/_components/MissingConnectorsNotice.tsx
+++ b/dashboard/src/app/marketplace/_components/MissingConnectorsNotice.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import Link from "next/link";
+import { formatConnectorLabel } from "@/lib/registry";
+
+/**
+ * Post-install warning rendered on InstallPanel / BundleInstallPanel
+ * when the bridge's connectorPreflight ships back a non-empty
+ * `missingConnectors[]` on the install response.
+ *
+ * Why inline (not toast): the browse view fires a transient toast on
+ * the same event, but detail-page users typically land from a share
+ * link, install, and immediately try to run — they need a persistent
+ * notice that survives the page sitting open. Toast auto-dismisses
+ * after 8s and gives them nothing to come back to.
+ *
+ * Renders connectors as a comma-separated label list with a single
+ * action link to /connections. No "Dismiss" button — the notice
+ * disappears once the install state changes (e.g. on a successful
+ * re-install) or the page reloads.
+ */
+export function MissingConnectorsNotice({
+  connectors,
+}: {
+  connectors: string[];
+}) {
+  if (connectors.length === 0) return null;
+  const labels = connectors.map(formatConnectorLabel);
+  return (
+    <div
+      role="alert"
+      style={{
+        background: "var(--warn-soft)",
+        border: "1px solid var(--warn)",
+        borderRadius: "var(--r-2)",
+        padding: "var(--s-3) var(--s-4)",
+        fontSize: "var(--fs-s)",
+        color: "var(--ink-1)",
+        lineHeight: 1.55,
+        display: "flex",
+        flexDirection: "column",
+        gap: "var(--s-2)",
+      }}
+    >
+      <div>
+        <strong style={{ color: "var(--ink-0)" }}>
+          Connect {labels.length === 1 ? "this service" : "these services"}{" "}
+          before the recipe can run:
+        </strong>{" "}
+        {labels.join(", ")}.
+      </div>
+      <div>
+        <Link
+          href="/connections"
+          className="btn sm"
+          style={{ textDecoration: "none" }}
+        >
+          Open connections →
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/dashboard/src/app/marketplace/bundle/[...slug]/BundleInstallPanel.tsx
+++ b/dashboard/src/app/marketplace/bundle/[...slug]/BundleInstallPanel.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from "react";
 import { apiPath } from "@/lib/api";
 import { type RiskLevel, shortName } from "@/lib/registry";
 import { InstallConfirmDialog } from "../../_components/InstallConfirmDialog";
+import { MissingConnectorsNotice } from "../../_components/MissingConnectorsNotice";
 
 interface Props {
   /**
@@ -48,6 +49,9 @@ interface BundleInstallResponse {
     plugin?: string;
     policy_template?: string;
   };
+  /** Connectors the bundle's recipes need but the user hasn't
+   * authorised yet — surfaced as an inline notice after install. */
+  missingConnectors?: string[];
   error?: string;
   code?: string;
 }
@@ -311,6 +315,10 @@ export default function BundleInstallPanel({
             </div>
           )}
         </div>
+      )}
+
+      {result?.missingConnectors && result.missingConnectors.length > 0 && (
+        <MissingConnectorsNotice connectors={result.missingConnectors} />
       )}
 
       {(plugin || policyTemplate) && (

--- a/dashboard/src/app/marketplace/bundle/[...slug]/__tests__/BundleInstallPanel.test.tsx
+++ b/dashboard/src/app/marketplace/bundle/[...slug]/__tests__/BundleInstallPanel.test.tsx
@@ -253,6 +253,38 @@ describe("BundleInstallPanel — install action", () => {
       ).toHaveTextContent(/non-empty .recipes. array/i),
     );
   });
+
+  it("surfaces a missing-connectors notice when bundle install response includes one", async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(200, { recipes: [] }))
+      .mockResolvedValueOnce(
+        jsonResponse(200, {
+          ok: true,
+          kind: "bundle",
+          installed: [{ name: "a-recipe", action: "created" }],
+          failures: [],
+          missingConnectors: ["gmail", "linear"],
+        }),
+      );
+    render(<BundleInstallPanel installSource={SOURCE} recipes={RECIPES} name={NAME} />);
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: /Install bundle/i }),
+      ).toBeInTheDocument(),
+    );
+    fireEvent.click(screen.getByRole("button", { name: /Install bundle/i }));
+    // Confirm dialog opens; click the confirm button inside it.
+    const confirmBtns = screen.getAllByRole("button", { name: /Install bundle/i });
+    fireEvent.click(confirmBtns[confirmBtns.length - 1]);
+
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent(/Connect these services/i);
+    expect(alert).toHaveTextContent(/Gmail/);
+    expect(alert).toHaveTextContent(/Linear/);
+    expect(
+      screen.getByRole("link", { name: /Open connections/i }),
+    ).toHaveAttribute("href", "/connections");
+  });
 });
 
 describe("BundleInstallPanel — advisory rendering", () => {

--- a/dashboard/src/app/marketplace/page.tsx
+++ b/dashboard/src/app/marketplace/page.tsx
@@ -9,6 +9,7 @@ import { apiPath } from "@/lib/api";
 import {
   assertValidInstallSource,
   type ApprovalBehavior,
+  formatConnectorLabel,
   type RegistryBundle,
   type RegistryData,
   type RegistryRecipe,
@@ -150,23 +151,6 @@ function connectorColor(id: string): string {
   return PROVIDER_COLORS[norm] ?? "#4a5568";
 }
 
-/**
- * Render a connector id (e.g. "google-calendar", "slack") as a
- * user-facing label. Title-cases each hyphen segment; special-cases a
- * couple of acronyms that look wrong with vanilla title-case.
- * Used by the post-install missingConnectors toast — keep terse, no
- * marketing copy.
- */
-function formatConnectorLabel(id: string): string {
-  if (id === "github") return "GitHub";
-  if (id === "gitlab") return "GitLab";
-  if (id === "pagerduty") return "PagerDuty";
-  if (id === "hubspot") return "HubSpot";
-  return id
-    .split("-")
-    .map((part) => (part.length === 0 ? "" : part[0].toUpperCase() + part.slice(1)))
-    .join(" ");
-}
 
 // ------------------------------------------------------------------ card
 

--- a/dashboard/src/lib/registry.ts
+++ b/dashboard/src/lib/registry.ts
@@ -267,3 +267,25 @@ export async function fetchBundleManifest(
 export function shortName(name: string): string {
   return name.replace(/^@[^/]+\//, "");
 }
+
+/**
+ * Render a connector id (e.g. "google-calendar", "slack") as a
+ * user-facing label. Title-cases each hyphen segment; special-cases a
+ * couple of acronyms that look wrong with vanilla title-case.
+ *
+ * Shared between the browse-view RecipeCard's post-install
+ * missing-connectors toast and the detail-page InstallPanel /
+ * BundleInstallPanel inline notices. Keep terse — no marketing copy.
+ */
+export function formatConnectorLabel(id: string): string {
+  if (id === "github") return "GitHub";
+  if (id === "gitlab") return "GitLab";
+  if (id === "pagerduty") return "PagerDuty";
+  if (id === "hubspot") return "HubSpot";
+  return id
+    .split("-")
+    .map((part) =>
+      part.length === 0 ? "" : part[0].toUpperCase() + part.slice(1),
+    )
+    .join(" ");
+}


### PR DESCRIPTION
## Summary

P1 audit item. The browse-view RecipeCard fires a transient toast when the bridge install response includes \`missingConnectors[]\` (connectors the recipe needs but the user hasn't authorised yet) — but neither detail-page install panel did anything with the field. Users who land from a share link, install, and try to run hit a silent connector wall.

Now both panels surface the same data as an inline notice that persists until the next install attempt or page reload. Better fit than a toast for the detail-page flow where users actually linger and come back to troubleshoot.

## Changes

- **New** \`_components/MissingConnectorsNotice.tsx\` — alert-style card with formatted labels + Open-connections link
- **Hoist** \`formatConnectorLabel\` from \`page.tsx\` into \`lib/registry.ts\` so all three call sites (browse toast + 2 detail notices) share the GitHub / GitLab / PagerDuty / HubSpot acronym mappings
- **InstallPanel** — parse \`missingConnectors\` from install response, store in component state, render notice below the err line
- **BundleInstallPanel** — extend \`BundleInstallResponse\` with \`missingConnectors?: string[]\`, render notice below the installed/failures block

## Test plan

- [x] Dashboard suite 502/502 (was 500, +2):
  - InstallPanel: notice renders with labels + connections link
  - BundleInstallPanel: notice renders after dialog-confirmed install
- [x] \`tsc --noEmit\` clean
- [x] \`biome check\` clean
- [ ] CI green