### PR TITLE
fix(marketplace): mobile-friendly action bars on browse + submit pages

### DIFF
--- a/dashboard/src/app/marketplace/page.tsx
+++ b/dashboard/src/app/marketplace/page.tsx
@@ -768,12 +768,23 @@ export default function MarketplacePage() {
             {`${registry?.length ?? FALLBACK_REGISTRY.recipes.length} recipes · sourced from github.com/patchworkos/recipes`}
           </div>
         </div>
-        <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+        {/* flex-wrap so Search + Submit drop below the title on narrow
+            viewports instead of squeezing the heading; flex-shrink:0 on
+            the action chips so they don't compress past their text width. */}
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 8,
+            flexWrap: "wrap",
+            flexShrink: 0,
+          }}
+        >
           <button
             type="button"
             onClick={() => setSearchOpen((v) => !v)}
             className="btn sm ghost"
-            style={{ fontSize: "var(--fs-s)" }}
+            style={{ fontSize: "var(--fs-s)", flexShrink: 0 }}
             aria-label="Toggle search"
             aria-expanded={searchOpen}
           >
@@ -782,7 +793,11 @@ export default function MarketplacePage() {
           <Link
             href="/marketplace/submit"
             className="btn sm primary"
-            style={{ textDecoration: "none", fontSize: "var(--fs-s)" }}
+            style={{
+              textDecoration: "none",
+              fontSize: "var(--fs-s)",
+              flexShrink: 0,
+            }}
             title="Compose a recipe and open a PR against patchworkos/recipes via GitHub's web flow."
           >
             Submit a recipe

--- a/dashboard/src/app/marketplace/submit/page.tsx
+++ b/dashboard/src/app/marketplace/submit/page.tsx
@@ -1230,6 +1230,11 @@ export default function MarketplaceSubmitPage() {
             display: "flex",
             gap: "var(--s-3)",
             alignItems: "center",
+            // flex-wrap so the URL-size readout drops below the buttons on
+            // narrow viewports instead of squeezing into them. Without
+            // this the readout text gets clipped or overlaps the Cancel
+            // link on phones.
+            flexWrap: "wrap",
             marginTop: "var(--s-6)",
             gridColumn: "1 / -1",
           }}
@@ -1244,9 +1249,16 @@ export default function MarketplaceSubmitPage() {
             style={{
               color: "var(--fg-3)",
               fontSize: "var(--fs-s)",
+              // `marginLeft: auto` pushes the readout to the right edge on
+              // wide rows AND keeps it left-aligned on its own row after
+              // wrap (the parent's `gap` already provides vertical spacing).
               marginLeft: "auto",
               textAlign: "right",
               lineHeight: 1.4,
+              // Block stays full-width on small viewports so the "URL ≈ X KB"
+              // line doesn't get hyphenated awkwardly. Cap so on desktop it
+              // doesn't grow past content.
+              minWidth: 0,
             }}
           >
             <div>


### PR DESCRIPTION
## Summary

Audit P1 — two action bars assumed enough horizontal space and clipped or overlapped on phone viewports:

- **Browse page-head** (Search + Submit-a-recipe) — bare flex next to a long h1. On a 390px viewport the action chips got pushed under the title with no wrap, then compressed past their text. Added \`flexWrap: "wrap"\` on the container + \`flexShrink: 0\` on the chips.
- **Submit form footer** (Open-PR + Cancel + "URL ≈ X KB" readout) — flex row with no wrap. The readout collided with Cancel on narrow viewports. Added \`flexWrap: "wrap"\` and \`minWidth: 0\` on the readout so it drops cleanly to its own row below the buttons. \`marginLeft: auto\` stays — pushes right on desktop, no-op when alone on its row.

No functional change; pure layout.

## Test plan

- [x] Dashboard suite 500/500 (no test deltas — layout only)
- [x] \`tsc --noEmit\` clean
- [x] \`biome check\` clean
- [ ] CI green