### PR TITLE
fix(marketplace): parser-based summarizeRisk + shorter ISR window on detail pages

### DIFF
--- a/dashboard/src/app/marketplace/[...slug]/page.tsx
+++ b/dashboard/src/app/marketplace/[...slug]/page.tsx
@@ -16,7 +16,13 @@ import {
 } from "@/lib/registry";
 import InstallPanel from "./InstallPanel";
 
-export const revalidate = 300;
+// 60s ISR (was 300s). A 5-minute cache hides freshly merged recipes
+// from the dashboard for an awkwardly long window after the registry
+// PR lands — the audit flagged this as the longest-tail user-visible
+// staleness in the marketplace flow. 60s keeps the CDN benefit
+// (single fetch per minute per recipe slug) without the "merged 4
+// minutes ago but still 404" surprise.
+export const revalidate = 60;
 
 interface PageProps {
   // Next 15: dynamic route params are Promise-typed.

--- a/dashboard/src/app/marketplace/bundle/[...slug]/page.tsx
+++ b/dashboard/src/app/marketplace/bundle/[...slug]/page.tsx
@@ -13,7 +13,9 @@ import {
 } from "@/lib/registry";
 import BundleInstallPanel from "./BundleInstallPanel";
 
-export const revalidate = 300;
+// 60s (was 300s) — match the recipe detail page; freshly merged
+// bundles shouldn't 404 for 5 min after the registry PR lands.
+export const revalidate = 60;
 
 interface PageProps {
   // Next 15: dynamic route params are Promise-typed.

--- a/dashboard/src/lib/__tests__/registry.test.ts
+++ b/dashboard/src/lib/__tests__/registry.test.ts
@@ -105,26 +105,37 @@ steps:
     expect(got.steps).toBe(1);
   });
 
-  it("treats hyphenated suffixes as the base level (regex \\b is letter↔hyphen boundary)", () => {
-    // Documents existing behavior: `risk: medium-aggressive` matches the
-    // `risk: medium\b` regex because \b finds a word boundary at the
-    // letter→hyphen transition. If we want to forbid suffixes we'd need
-    // `[^\w-]` instead of `\b`. Pinned here so a future regex tightening
-    // is a deliberate, test-noticed change.
-    const yaml = "  risk: medium-aggressive\n  risk: medium\n";
-    expect(summarizeRisk(yaml).medium).toBe(2);
+  it("ignores unrecognised risk values (hyphenated suffix etc) under the parser-based impl", () => {
+    // The old regex used `\b` and counted `risk: medium-aggressive` as
+    // medium. The new parser-based impl uses strict equality and treats
+    // anything outside {low, medium, high} as not-a-risk-level — much
+    // better, since the registry's risk enum is exactly those three.
+    const yaml = `steps:
+  - id: a
+    risk: medium-aggressive
+  - id: b
+    risk: medium
+`;
+    expect(summarizeRisk(yaml).medium).toBe(1);
   });
 
-  it("counts only step rows that match `- id: <non-space>`", () => {
-    // Continuation-of-prior-list lines that don't start with `- id:` shouldn't count.
-    const yaml = `
-steps:
+  it("counts every map entry under `steps:` as a step (matches YAML semantics, not the legacy `- id:` heuristic)", () => {
+    // The pre-fix regex required `^- id:` rows. The parser sees every
+    // array entry under `steps:` as a step regardless of which keys it
+    // declares — closer to the recipe runtime's actual behaviour, where
+    // an id-less step is still a step (it just gets an auto-id).
+    const yaml = `steps:
   - id: real-step
     risk: low
-  - name: not-a-step
+  - name: also-a-step
     risk: high
 `;
-    expect(summarizeRisk(yaml).steps).toBe(1);
+    expect(summarizeRisk(yaml)).toEqual({
+      low: 1,
+      medium: 0,
+      high: 1,
+      steps: 2,
+    });
   });
 });
 

--- a/dashboard/src/lib/__tests__/summarizeRisk.test.ts
+++ b/dashboard/src/lib/__tests__/summarizeRisk.test.ts
@@ -1,0 +1,94 @@
+/**
+ * summarizeRisk — counts step-level risk values from a recipe YAML.
+ *
+ * Pre-fix used a regex against `^\s*risk:` which over-counted any
+ * `risk:` substring inside multi-line block scalars (prompts that
+ * mention the word) and nested non-step objects with a risk key.
+ * The audit found morning-brief's narration prompt produces a false
+ * "1 high risk" reading.
+ */
+import { describe, expect, it } from "vitest";
+import { summarizeRisk } from "../registry";
+
+describe("summarizeRisk", () => {
+  it("counts step-level risk values correctly", () => {
+    const yaml = `name: demo
+steps:
+  - id: a
+    risk: low
+  - id: b
+    risk: medium
+  - id: c
+    risk: high
+  - id: d
+    risk: high
+`;
+    expect(summarizeRisk(yaml)).toEqual({
+      low: 1,
+      medium: 1,
+      high: 2,
+      steps: 4,
+    });
+  });
+
+  it("does NOT count `risk:` strings that appear inside a block scalar prompt (regression)", () => {
+    // Pre-fix this YAML returned high: 1 because the regex caught the
+    // word in the prompt body. The real recipe has zero step risk.
+    const yaml = `name: morning-brief
+steps:
+  - id: narrate
+    agent:
+      prompt: |
+        Write a daily brief in plain prose.
+        risk: high — this is the worst-case scenario phrasing.
+      into: brief
+`;
+    expect(summarizeRisk(yaml)).toEqual({
+      low: 0,
+      medium: 0,
+      high: 0,
+      steps: 1,
+    });
+  });
+
+  it("returns zeros on a recipe with no risk declarations", () => {
+    const yaml = `name: bare
+steps:
+  - id: only
+    agent:
+      prompt: do thing
+      into: out
+`;
+    expect(summarizeRisk(yaml)).toEqual({
+      low: 0,
+      medium: 0,
+      high: 0,
+      steps: 1,
+    });
+  });
+
+  it("returns zeros on a parse error rather than throwing", () => {
+    expect(summarizeRisk("not: valid: yaml: :")).toEqual({
+      low: 0,
+      medium: 0,
+      high: 0,
+      steps: 0,
+    });
+  });
+
+  it("ignores non-recognised risk values", () => {
+    const yaml = `name: weird
+steps:
+  - id: a
+    risk: spicy
+  - id: b
+    risk: low
+`;
+    expect(summarizeRisk(yaml)).toEqual({
+      low: 1,
+      medium: 0,
+      high: 0,
+      steps: 2,
+    });
+  });
+});

--- a/dashboard/src/lib/registry.ts
+++ b/dashboard/src/lib/registry.ts
@@ -4,6 +4,8 @@
  * Sources data from `https://raw.githubusercontent.com/patchworkos/recipes/main/`.
  */
 
+import { parse as parseYaml } from "yaml";
+
 export type RiskLevel = "low" | "medium" | "high";
 export type ApprovalBehavior = "always_ask" | "ask_on_novel" | "auto_approve";
 
@@ -232,8 +234,19 @@ export async function fetchRecipeYaml(
 }
 
 /**
- * Crude risk-level extractor — counts `risk: low|medium|high` occurrences in YAML.
- * Avoids a full YAML parser dependency for what's just a UI summary.
+ * Risk-level summary for the detail-page "Steps & risk" card.
+ *
+ * Walks `steps[].risk` via a real YAML parse, then counts low / medium /
+ * high values. Pre-fix used regex against `^\s*risk:` which over-counted
+ * any `risk:` substring inside multi-line block scalars (e.g.
+ * `prompt: |` followed by indented prose containing the word) and any
+ * nested object with a `risk:` key in a non-step position. False
+ * positives showed up in real recipes (morning-brief's narration
+ * prompt contains "risk: high").
+ *
+ * Parser is `yaml` (already in deps for the recipe-editor). Returns
+ * zeros on parse failure rather than throwing — the panel is a hint,
+ * not a gate.
  */
 export function summarizeRisk(yaml: string): {
   low: number;
@@ -241,11 +254,29 @@ export function summarizeRisk(yaml: string): {
   high: number;
   steps: number;
 } {
-  const low = (yaml.match(/^\s*risk:\s*low\b/gm) ?? []).length;
-  const medium = (yaml.match(/^\s*risk:\s*medium\b/gm) ?? []).length;
-  const high = (yaml.match(/^\s*risk:\s*high\b/gm) ?? []).length;
-  const steps = (yaml.match(/^\s*-\s*id:\s+\S/gm) ?? []).length;
-  return { low, medium, high, steps };
+  let doc: unknown;
+  try {
+    doc = parseYaml(yaml);
+  } catch {
+    return { low: 0, medium: 0, high: 0, steps: 0 };
+  }
+  const steps =
+    doc !== null &&
+    typeof doc === "object" &&
+    Array.isArray((doc as { steps?: unknown }).steps)
+      ? ((doc as { steps: unknown[] }).steps)
+      : [];
+  let low = 0;
+  let medium = 0;
+  let high = 0;
+  for (const step of steps) {
+    if (step === null || typeof step !== "object") continue;
+    const r = (step as { risk?: unknown }).risk;
+    if (r === "low") low++;
+    else if (r === "medium") medium++;
+    else if (r === "high") high++;
+  }
+  return { low, medium, high, steps: steps.length };
 }
 
 export async function fetchBundleManifest(


### PR DESCRIPTION
## Summary

Two small P2 audit items, same blast radius:

### \`summarizeRisk\`: parser, not regex
Pre-fix used \`^\s*risk:\` against the YAML text. Two false-positive classes:
1. **Block scalars** — a step's \`prompt: |\` body that mentions the word "risk:" got counted as a risk-level. Real example: morning-brief's narration prompt contains "risk: high" as prose and reported a spurious 1-high step.
2. **Nested objects** — any non-step map with a \`risk:\` key (e.g. inside \`vars:\`) counted toward the total.

Now parses the YAML and walks \`steps[].risk\` strictly:
- \`r === "low" | "medium" | "high"\` (was \`\b\`-bounded — counted \`medium-aggressive\` as medium)
- every array entry under \`steps:\` counts as a step (was: only rows matching \`^- id:\` — id-less steps were missed)

Parse failures return zeros — the card is a hint, not a gate.

### Detail-page ISR: 300s → 60s
Pre-fix \`revalidate = 300\` meant a freshly merged recipe was invisible from the dashboard for up to **5 min** after the registry PR landed. 60s keeps the per-slug CDN benefit (one fetch per minute) without the "merged 4 min ago but still 404" surprise. Applied to both \`[...slug]/page.tsx\` and \`bundle/[...slug]/page.tsx\`.

## Test plan

- [x] Dashboard suite 505/505 (was 500, +5 regressions):
  - new `summarizeRisk.test.ts`: step counts, block-scalar false-positive, parse-failure, unrecognised values
  - existing `registry.test.ts` behaviour pins updated to reflect new stricter semantics
- [x] \`tsc --noEmit\` clean
- [x] \`biome check\` clean
- [ ] CI green