### PR TITLE
chore: clear three stale 'stub' comments referencing shipped work

### DIFF
--- a/src/recipes/yamlRunner.ts
+++ b/src/recipes/yamlRunner.ts
@@ -14,7 +14,10 @@
  *   file.read     — read file into `into` variable (optional: true ok)
  *   git.log_since — run git log --oneline --since=<since> (injected for tests)
  *   git.stale_branches — list branches with no activity in N days
- *   diagnostics.get — stub: returns empty string (bridge not required)
+ *   diagnostics.get — returns the bridge's LSP diagnostics; in CLI runs
+ *                     (no bridge available) returns a JSON {ok:false,error}
+ *                     payload that the step-error detector flags so the
+ *                     recipe halts rather than silently succeeding.
  *
  * Supported trigger types (for `patchwork recipe run`):
  *   manual, cron — both run immediately via CLI

--- a/src/server.ts
+++ b/src/server.ts
@@ -1788,8 +1788,11 @@ export class Server extends EventEmitter<ServerEvents> {
       //
       // GET → status. 200 {engaged, locked, lockedReason?, lockedValue?}
       //
-      // Audit emit is stubbed with this.logger.info — full plumbing
-      // (decisionTraceLog into Server) lands in step 5 of the #422 series.
+      // Audit emit: state transitions log to this.logger.info (always)
+      // AND record via this.recordKillSwitchTraceFn (when wired by the
+      // bridge — see src/bridge.ts where it threads decisionTraceLog
+      // through to ~/.patchwork/decision_traces.jsonl). Tests / headless
+      // contexts that don't wire the callback still get the log line.
       if (parsedUrl.pathname === "/kill-switch") {
         if (req.method === "GET") {
           const engaged = isWriteKillSwitchActive();
@@ -1888,11 +1891,11 @@ export class Server extends EventEmitter<ServerEvents> {
               throw err;
             }
             // v2-I6: audit emit on every state transition; no-ops skip.
-            // When the bridge wires recordKillSwitchTraceFn (step 5),
-            // this writes to ~/.patchwork/decision_traces.jsonl. The
-            // logger.info line stays as a secondary signal in the
-            // bridge log; it's the only output when the trace fn is
-            // unset (tests, headless contexts).
+            // The bridge wires recordKillSwitchTraceFn to write a
+            // DecisionTrace entry to ~/.patchwork/decision_traces.jsonl
+            // (see src/bridge.ts). The logger.info line stays as a
+            // secondary signal in the bridge log and is the only output
+            // when the trace fn is unset (tests, headless contexts).
             this.logger.info(
               `[kill-switch] ${next ? "ENGAGED" : "RELEASED"}${
                 reason ? ` (reason: ${reason})` : ""


### PR DESCRIPTION
## Summary

Code-truth pass found three doc comments that describe behaviour the implementation no longer matches. Misleading for anyone reading the file to learn what the surface does. **No code change** — comments only.

| File:line | Claim | Reality |
|---|---|---|
| \`src/recipes/yamlRunner.ts:17\` | \`diagnostics.get\` is a stub returning empty string | Returns a JSON \`{ok:false,error}\` payload that the step-error detector flags so the recipe halts |
| \`src/server.ts:1791\` | "Audit emit is stubbed … full plumbing lands in step 5" | Wired: logger.info + \`recordKillSwitchTraceFn\` set by \`src/bridge.ts\` from \`decisionTraceLog\` |
| \`src/server.ts:1891\` | "When the bridge wires recordKillSwitchTraceFn (step 5)…" | Drops conditional framing — bridge does wire it |

## Test plan

- [x] \`tsc --noEmit\` clean
- [x] \`biome check\` clean
- [ ] CI green (no code changes; should be a no-op)