### PR TITLE
fix(persistence): atomic rotate for decision/run logs + log silent checkpoint failures

### DIFF
--- a/src/__tests__/decisionTraceLog.test.ts
+++ b/src/__tests__/decisionTraceLog.test.ts
@@ -167,4 +167,35 @@ describe("DecisionTraceLog", () => {
     expect(text).not.toContain('"ref":"#huge"');
     expect(text).toContain('"ref":"#after-drop"');
   });
+
+  it("rotateDisk() leaves no orphaned `.tmp` file on success (atomic rename)", () => {
+    // Atomic-write contract: rotate must write to a sibling `.tmp` and
+    // renameSync it onto the target. If it instead used writeFileSync
+    // directly to the target, a crash / ENOSPC mid-write would truncate
+    // the whole audit log. Post-rotate, no `.tmp` file should linger.
+    //
+    // (Can't vi.spyOn the fs.* named imports — the source binds the
+    // refs at module load. Verify by observable side-effect instead.)
+    const file = path.join(dir, "decision_traces.jsonl");
+    const fs = require("node:fs") as typeof import("node:fs");
+    // Pre-seed > MAX_PERSIST_BYTES so the next append triggers rotate.
+    const filler = JSON.stringify({
+      seq: 0,
+      createdAt: 1,
+      ref: "#seed",
+      problem: "p",
+      solution: "s",
+      workspace: "/ws",
+      tags: ["x".repeat(64 * 1024)],
+    });
+    fs.writeFileSync(file, `${Array(50).fill(filler).join("\n")}\n`);
+
+    const log = new DecisionTraceLog({ dir });
+    log.record({ ...base(), ref: "#after-rotate" });
+
+    // Target file rotated, new record present, NO orphan .tmp left.
+    expect(fs.statSync(file).size).toBeLessThan(1024 * 1024);
+    expect(fs.readFileSync(file, "utf8")).toContain('"ref":"#after-rotate"');
+    expect(fs.existsSync(`${file}.tmp`)).toBe(false);
+  });
 });

--- a/src/__tests__/runLog.test.ts
+++ b/src/__tests__/runLog.test.ts
@@ -745,4 +745,50 @@ describe("RecipeRunLog.record", () => {
     expect(text).not.toContain('"taskId":"huge"');
     expect(text).toContain('"taskId":"after-drop"');
   });
+
+  it("rotateDisk() leaves no orphaned `.tmp` file on success (atomic rename)", () => {
+    // Atomic-write contract: rotate must write to a sibling `.tmp` and
+    // renameSync it onto the target. Pre-fix, a direct writeFileSync to
+    // the target meant a crash / ENOSPC mid-write truncated the whole
+    // run log. Verify by observable side-effect (no .tmp left behind).
+    const file = path.join(tmp, "runs.jsonl");
+    const fs = require("node:fs") as typeof import("node:fs");
+    // Pre-seed > MAX_PERSIST_BYTES with realistic rows so the next
+    // append triggers rotate. Use 64KB filler rows ×50 = ~3.2MB.
+    const filler = JSON.stringify({
+      seq: 0,
+      taskId: "seed",
+      recipeName: "r",
+      trigger: "recipe",
+      status: "done",
+      createdAt: 1,
+      doneAt: 2,
+      durationMs: 1,
+      stepResults: [
+        {
+          id: "filler",
+          status: "ok",
+          durationMs: 1,
+          registrySnapshot: { junk: "x".repeat(64 * 1024) },
+        },
+      ],
+    });
+    fs.writeFileSync(file, `${Array(50).fill(filler).join("\n")}\n`);
+
+    const log = new RecipeRunLog({ dir: tmp });
+    log.appendDirect({
+      taskId: "after-rotate",
+      recipeName: "r",
+      trigger: "recipe",
+      status: "done",
+      createdAt: 5,
+      startedAt: 5,
+      doneAt: 6,
+      durationMs: 1,
+    });
+
+    expect(fs.statSync(file).size).toBeLessThan(1024 * 1024);
+    expect(fs.readFileSync(file, "utf8")).toContain('"taskId":"after-rotate"');
+    expect(fs.existsSync(`${file}.tmp`)).toBe(false);
+  });
 });

--- a/src/decisionTraceLog.ts
+++ b/src/decisionTraceLog.ts
@@ -2,6 +2,7 @@ import {
   appendFileSync,
   mkdirSync,
   readFileSync,
+  renameSync,
   statSync,
   writeFileSync,
 } from "node:fs";
@@ -223,9 +224,14 @@ export class DecisionTraceLog {
         lines = [];
         joined = "";
       }
-      writeFileSync(this.file, joined.length > 0 ? `${joined}\n` : "", {
+      // Atomic write: temp file + rename. A crash / ENOSPC mid-write
+      // would otherwise truncate the entire audit history at the source
+      // path. Matches the pattern used in sessionCheckpoint.write().
+      const tmp = `${this.file}.tmp`;
+      writeFileSync(tmp, joined.length > 0 ? `${joined}\n` : "", {
         mode: 0o600,
       });
+      renameSync(tmp, this.file);
     } catch (err) {
       this.opts.logger?.warn?.(
         `[dtrace-log] rotate failed: ${err instanceof Error ? err.message : String(err)}`,

--- a/src/runLog.ts
+++ b/src/runLog.ts
@@ -2,6 +2,7 @@ import {
   appendFileSync,
   mkdirSync,
   readFileSync,
+  renameSync,
   statSync,
   writeFileSync,
 } from "node:fs";
@@ -479,9 +480,14 @@ export class RecipeRunLog {
         lines = [];
         joined = "";
       }
-      writeFileSync(this.file, joined.length > 0 ? `${joined}\n` : "", {
+      // Atomic write: temp file + rename. Crash / ENOSPC mid-write
+      // would otherwise truncate the entire run-log file at the source
+      // path. Matches the pattern used in sessionCheckpoint.write().
+      const tmp = `${this.file}.tmp`;
+      writeFileSync(tmp, joined.length > 0 ? `${joined}\n` : "", {
         mode: 0o600,
       });
+      renameSync(tmp, this.file);
       // Refresh `lastFileSize` so the next syncFromDisk() doesn't see
       // `size <= lastFileSize` (stale pre-rotation value) and silently
       // skip freshly-appended rows.

--- a/src/sessionCheckpoint.ts
+++ b/src/sessionCheckpoint.ts
@@ -25,6 +25,14 @@ export class SessionCheckpoint {
   private checkpointPath: string;
   private intervalHandle: ReturnType<typeof setInterval> | null = null;
   private readonly workspace: string | undefined;
+  /**
+   * Surface checkpoint-write failures exactly once per instance. Silent
+   * fail defeats the whole restore feature (disk-full / permission flip
+   * → no checkpoint ever written → restore has no data on crash). One
+   * warn line is enough; spamming on every 30s interval would drown the
+   * log.
+   */
+  private writeFailureLogged = false;
 
   constructor(port: number, workspace?: string) {
     const configDir =
@@ -74,8 +82,18 @@ export class SessionCheckpoint {
       fs.renameSync(tmpPath, this.checkpointPath);
       // Ensure restrictive permissions even if the file pre-existed with a wider mode.
       fs.chmodSync(this.checkpointPath, 0o600);
-    } catch {
-      // Best-effort — never block bridge operation
+    } catch (err) {
+      // Best-effort — never block bridge operation. Log once per instance
+      // so the operator sees something on disk-full / EACCES instead of
+      // a silently-broken restore feature.
+      if (!this.writeFailureLogged) {
+        this.writeFailureLogged = true;
+        const msg = err instanceof Error ? err.message : String(err);
+        // eslint-disable-next-line no-console
+        console.warn(
+          `[sessionCheckpoint] write failed (${msg}). Further failures from this instance will be silenced.`,
+        );
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

Bug-sweep found three disk-IO durability gaps in long-lived audit log paths. None bite on the happy path; all bite on crash / ENOSPC / EACCES — exactly when an audit trail matters most.

### 1. Non-atomic rotate (\`decisionTraceLog.ts\`, \`runLog.ts\`)
\`rotateDisk()\` in both call sites used a single \`writeFileSync()\` straight to the target path. A crash / ENOSPC / power-loss mid-write truncates the entire JSONL file → loss of audit history (~10 000 decision traces / runs).

Switched to the temp-file + \`renameSync\` pattern already used by \`sessionCheckpoint.write()\`. On crash mid-write the temp file gets orphaned; the target stays intact.

### 2. Silent checkpoint write failure (\`sessionCheckpoint.ts\`)
\`write()\` swallowed all errors silently. Disk-full / permission flip → no checkpoint ever written → restore feature is silently non-functional, operator never knows. Added a **once-per-instance** \`console.warn\` so the first failure surfaces; subsequent failures stay quiet to avoid spamming the log every 30s.

## Test plan

- [x] Bridge suite **5467/5469** (was 5466, +2):
  - decisionTraceLog: post-rotate file under cap, target valid, no orphan \`.tmp\`
  - runLog: same shape
- [x] \`tsc --noEmit\` clean
- [x] \`biome check\` clean
- [ ] CI green