### PR TITLE
fix(yamlRunner): scrub __proto__ from agent JSON output before stashing in ctx

### DIFF
--- a/src/recipes/__tests__/yamlRunner.test.ts
+++ b/src/recipes/__tests__/yamlRunner.test.ts
@@ -106,6 +106,22 @@ describe("render", () => {
     expect(render("{{ obj.constructor }}", { obj: json })).toBe("");
     expect(render("{{ obj.valueOf }}", { obj: json })).toBe("");
   });
+  it("strips __proto__/constructor/prototype from JSON-parsed intermediates", () => {
+    // Attacker-controlled JSON in a ctx string must not survive dotted-path
+    // resolution with these keys intact (downstream Object.assign / merge
+    // would pollute Object.prototype). sanitizeParsed should drop them at
+    // parse time.
+    const evil = JSON.stringify({
+      __proto__: { polluted: true },
+      constructor: { evil: 1 },
+      ok: "fine",
+    });
+    expect(render("{{ obj.ok }}", { obj: evil })).toBe("fine");
+    expect(render("{{ obj.__proto__ }}", { obj: evil })).toBe("");
+    expect(render("{{ obj.constructor }}", { obj: evil })).toBe("");
+    // Confirm no actual pollution slipped through.
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+  });
 });
 
 // ── validateYamlRecipe ────────────────────────────────────────────────────────
@@ -431,6 +447,40 @@ describe("runYamlRecipe — silent-fail detection (P1)", () => {
     });
     expect(result.stepResults[0]?.status).toBe("error");
     expect(result.stepResults[0]?.error).toMatch(/agent step skipped/);
+  });
+
+  it("strips prototype-pollution keys from agent JSON output before stashing in ctx", async () => {
+    // A jailbroken agent could return `{"__proto__":{"polluted":true}}`; the
+    // parsed object lands in ctx and gets spread/merged downstream. Scrub
+    // the dangerous keys at the parse boundary.
+    const recipe = makeRecipe({
+      steps: [
+        {
+          agent: {
+            prompt: "produce",
+            model: "claude-haiku-4-5-20251001",
+            into: "result",
+          },
+        },
+        {
+          tool: "file.write",
+          path: path.join(TMP, "out.txt"),
+          content: "ok={{result.ok}} proto={{result.__proto__}}",
+        },
+      ],
+    });
+    const written: Record<string, string> = {};
+    const result = await runYamlRecipe(recipe, {
+      ...noop(),
+      claudeFn: async () =>
+        '```json\n{"__proto__":{"polluted":true},"ok":"yes"}\n```',
+      writeFile: (p, c) => {
+        written[p] = c;
+      },
+    });
+    expect(result.stepResults[0]?.status).toBe("ok");
+    expect(Object.values(written)[0]).toBe("ok=yes proto=");
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
   });
 
   it("does NOT flag legitimate output that contains 'unavailable' as prose", async () => {

--- a/src/recipes/yamlRunner.ts
+++ b/src/recipes/yamlRunner.ts
@@ -63,6 +63,26 @@ import { RunBudget } from "./runBudget.js";
 import type { ErrorPolicy } from "./schema.js";
 import { detectSilentFail } from "./stepObservation.js";
 
+/**
+ * Recursively strip prototype-pollution keys from a JSON.parse result before
+ * it lands in the recipe ctx. JSON.parse itself doesn't mutate Object.prototype
+ * (V8 uses defineProperty), but a `__proto__` own-property survives and will
+ * pollute via downstream `Object.assign` / deep-merge operations. Agent step
+ * output is attacker-controllable (jailbroken model), so scrub at the parse
+ * boundary. See feedback_record_string_prototype_walk.md.
+ */
+const DANGEROUS_KEYS = new Set(["__proto__", "constructor", "prototype"]);
+function sanitizeParsed(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sanitizeParsed);
+  if (value === null || typeof value !== "object") return value;
+  const out: Record<string, unknown> = {};
+  for (const key of Object.keys(value)) {
+    if (DANGEROUS_KEYS.has(key)) continue;
+    out[key] = sanitizeParsed((value as Record<string, unknown>)[key]);
+  }
+  return out;
+}
+
 // Import tool registry and trigger tool self-registration
 import {
   applyToolOutputContext,
@@ -727,7 +747,9 @@ export async function runYamlRecipe(
               const jsonMatch = /```(?:json)?\s*([\s\S]*?)```/.exec(
                 stripped,
               ) ?? [null, stripped];
-              const parsed = JSON.parse((jsonMatch[1] ?? "").trim());
+              const parsed = sanitizeParsed(
+                JSON.parse((jsonMatch[1] ?? "").trim()),
+              ) as RunContext[string];
               ctx[intoKey] = parsed;
             } catch {
               ctx[intoKey] = stripped;
@@ -1094,7 +1116,7 @@ export function render(template: string, ctx: RunContext): string {
       if (val == null) return "";
       if (typeof val === "string") {
         try {
-          val = JSON.parse(val);
+          val = sanitizeParsed(JSON.parse(val));
         } catch {
           return "";
         }


### PR DESCRIPTION
## Summary

- Add `sanitizeParsed()` helper that recursively drops `__proto__` / `constructor` / `prototype` own-keys.
- Apply it to both `JSON.parse` sites in `yamlRunner.ts` that write into the recipe ctx:
  - agent-step result stash (line 750)
  - dotted-path render intermediate (line 1115)
- 2 regression tests: render dotted-path + full agent-step round-trip with malicious JSON envelope.

## Why

Agent step output is attacker-controllable (jailbroken model). `JSON.parse` doesn't pollute `Object.prototype` itself (V8 uses defineProperty), but a `__proto__` own-property survives and will pollute via any downstream `Object.assign` / deep-merge of the ctx value. Matches the pattern from `feedback_record_string_prototype_walk.md` (Object.hasOwn over bracket access) — this PR closes the parse-boundary version.

## Test plan

- [x] `npx vitest run src/recipes/__tests__/yamlRunner.test.ts` — 140 pass (was 138)
- [x] `npx tsc --noEmit` clean
- [x] `npx biome check` clean