### PR TITLE
fix(tokenStorage): clear cross-backend orphans on store + delete

### DIFF
--- a/src/connectors/tokenStorage.ts
+++ b/src/connectors/tokenStorage.ts
@@ -57,6 +57,12 @@ export function storeSecretJsonSync(provider: string, value: unknown): void {
 
   if (resolveBackend() === "file") {
     setEncryptedFileSync(key, json);
+    // Cross-backend orphan guard: if a prior session wrote to the native
+    // keychain (auto-mode default), forcing PATCHWORK_TOKEN_STORAGE_BACKEND=file
+    // would leave that stale credential behind. A later session that unsets
+    // the env (back to auto) would resolve the stale keychain value first
+    // and skip the fresher file. Drop the keychain entry best-effort.
+    deleteKeychainItemSync(key);
     return;
   }
 
@@ -86,11 +92,10 @@ export function getSecretJsonSync<T>(provider: string): T | null {
 export function deleteSecretJsonSync(provider: string): void {
   const key = storageKey(provider);
 
-  if (resolveBackend() === "file") {
-    deleteEncryptedFileSync(key);
-    return;
-  }
-
+  // Always clear both backends. Even when the active backend is "file", a
+  // prior session may have stored the credential in the OS keychain; leaving
+  // it behind on delete is a credential-lifetime bug (revocation flow leaves
+  // a usable token in the keychain that auto-mode would surface later).
   deleteKeychainItemSync(key);
   deleteEncryptedFileSync(key);
 }


### PR DESCRIPTION
## Summary

- `storeSecretJsonSync(file)` now drops any stale keychain entry after writing the file.
- `deleteSecretJsonSync` always clears both file + keychain, regardless of resolved backend.

## Why

If a user stored tokens via the native keychain (default auto-mode), then later set \`PATCHWORK_TOKEN_STORAGE_BACKEND=file\`:

1. They store fresh tokens → file has v2, keychain still has v1.
2. They unset the env (back to auto).
3. Next read hits keychain first → **stale v1 returned**.

The delete path had the symmetric bug: revoking on file backend left a usable credential in the OS keychain. With this fix, both paths are symmetric to the existing native-store branch (which already deletes the file on keychain success).

## Test plan

- [x] Existing tokenStorage suite (7 tests) passes
- [x] \`tsc --noEmit\` + \`biome check\` clean