### PR TITLE
fix(connector-requests): atomic write to prevent truncation on crash

### DIFF
--- a/dashboard/src/app/api/connector-requests/__tests__/route.test.ts
+++ b/dashboard/src/app/api/connector-requests/__tests__/route.test.ts
@@ -186,6 +186,19 @@ describe("POST /api/connector-requests — persistence", () => {
     expect((await res.json()).error).toMatch(/expected an array/);
   });
 
+  it("writes atomically — no .tmp orphan after a successful POST", async () => {
+    // Atomic-write contract: writes to a sibling .tmp then renames onto the
+    // target. A crash / ENOSPC mid-write must never truncate the audit file.
+    await POST(makeReq({ name: "AtomicTest" }));
+
+    const dir = path.dirname(storeFile);
+    const orphans = fs
+      .readdirSync(dir)
+      .filter((f) => f.startsWith("connector-requests.json.tmp"));
+    expect(orphans).toEqual([]);
+    expect(fs.existsSync(storeFile)).toBe(true);
+  });
+
   it("500s with 'Failed to save request' on write error (with console.error)", async () => {
     // Force fs.writeFileSync to throw.
     const writeSpy = vi.spyOn(fs, "writeFileSync").mockImplementation(() => {

--- a/dashboard/src/app/api/connector-requests/route.ts
+++ b/dashboard/src/app/api/connector-requests/route.ts
@@ -135,7 +135,13 @@ export async function POST(req: Request): Promise<Response> {
     }
 
     existing.push(entry);
-    fs.writeFileSync(file, JSON.stringify(existing, null, 2), "utf8");
+    // Atomic write: temp file + rename. A crash / ENOSPC during direct
+    // writeFileSync would truncate connector-requests.json and wipe every
+    // prior request. Matches the rotate pattern in src/decisionTraceLog.ts
+    // and src/sessionCheckpoint.ts.
+    const tmp = `${file}.tmp.${process.pid}.${Date.now()}`;
+    fs.writeFileSync(tmp, JSON.stringify(existing, null, 2), "utf8");
+    fs.renameSync(tmp, file);
   } catch (e) {
     console.error("[connector-requests] write error", e);
     return NextResponse.json(


### PR DESCRIPTION
## Summary

- POST handler now writes \`connector-requests.json\` to a sibling \`.tmp\` file and \`renameSync\`s onto the target.
- Regression test asserts no \`.tmp\` orphan remains after a successful POST.

## Why

A crash / ENOSPC during direct \`fs.writeFileSync\` would truncate the file and wipe every prior connector request. Matches the temp+rename pattern already used in \`src/decisionTraceLog.ts\`, \`src/runLog.ts\`, and \`src/sessionCheckpoint.ts\`.

## Scope notes

- Did NOT add cross-process locking. Read-modify-write is fully synchronous within a single Node tick (no \`await\` between read and write), so single-process Next.js can't lose updates. Multi-worker deployments would need file locking, but the dashboard is a local-loopback endpoint.

## Test plan

- [x] \`npx vitest run\` on the route — 20/20 pass (was 19, +1 atomic-write regression)