### PR TITLE
refactor(dashboard): unify CSRF guards on requireSameOrigin helper

### DIFF
--- a/dashboard/src/app/api/bridge/[...path]/route.ts
+++ b/dashboard/src/app/api/bridge/[...path]/route.ts
@@ -1,5 +1,6 @@
 import type { NextRequest } from "next/server";
 import { bridgeFetch, findBridge, resolveBridgeUrl } from "@/lib/bridge";
+import { requireSameOrigin } from "@/lib/csrf";
 import { isDemoModeServer } from "@/lib/demoModeServer";
 import { mockBridgeResponse } from "@/lib/mockData";
 import {
@@ -119,13 +120,8 @@ async function proxy(req: NextRequest, segments: string[]): Promise<Response> {
   }
 
   if (req.method !== "GET" && req.method !== "HEAD") {
-    const sfs = req.headers.get("sec-fetch-site");
-    if (sfs && sfs !== "same-origin" && sfs !== "none") {
-      return new Response(JSON.stringify({ error: "CSRF check failed" }), {
-        status: 403,
-        headers: { "Content-Type": "application/json" },
-      });
-    }
+    const guard = requireSameOrigin(req);
+    if (guard) return guard;
   }
 
   // In demo mode short-circuit to fixture data instead of hitting a bridge

--- a/dashboard/src/app/api/bridge/recipes/[name]/route.ts
+++ b/dashboard/src/app/api/bridge/recipes/[name]/route.ts
@@ -1,5 +1,6 @@
 import type { NextRequest } from "next/server";
 import { bridgeFetch } from "@/lib/bridge";
+import { requireSameOrigin } from "@/lib/csrf";
 import { isDemoModeServer } from "@/lib/demoModeServer";
 import {
   BRIDGE_BODY_CAPS,
@@ -51,13 +52,8 @@ async function forwardWithMethod(
   ctx: RouteContext,
   method: "PUT" | "PATCH",
 ): Promise<Response> {
-  const sfs = req.headers.get("sec-fetch-site");
-  if (sfs && sfs !== "same-origin" && sfs !== "none") {
-    return new Response(JSON.stringify({ error: "CSRF check failed" }), {
-      status: 403,
-      headers: { "content-type": "application/json" },
-    });
-  }
+  const guard = requireSameOrigin(req);
+  if (guard) return guard;
   if (await isDemoModeServer()) return demoOk();
   const read = await readBodyWithCap(req, BRIDGE_BODY_CAPS.content);
   if (!read.ok) return bodyTooLargeResponse(BRIDGE_BODY_CAPS.content);
@@ -100,13 +96,8 @@ export async function DELETE(
   req: NextRequest,
   ctx: RouteContext,
 ): Promise<Response> {
-  const sfs = req.headers.get("sec-fetch-site");
-  if (sfs && sfs !== "same-origin" && sfs !== "none") {
-    return new Response(JSON.stringify({ error: "CSRF check failed" }), {
-      status: 403,
-      headers: { "content-type": "application/json" },
-    });
-  }
+  const guard = requireSameOrigin(req);
+  if (guard) return guard;
   if (await isDemoModeServer()) return demoOk();
   try {
     const { name } = await ctx.params;

--- a/dashboard/src/app/api/bridge/recipes/[name]/run/route.ts
+++ b/dashboard/src/app/api/bridge/recipes/[name]/run/route.ts
@@ -1,5 +1,6 @@
 import type { NextRequest } from "next/server";
 import { bridgeFetch } from "@/lib/bridge";
+import { requireSameOrigin } from "@/lib/csrf";
 import { isDemoModeServer } from "@/lib/demoModeServer";
 import {
   BRIDGE_BODY_CAPS,
@@ -17,13 +18,8 @@ export async function POST(
   req: NextRequest,
   ctx: RouteContext,
 ): Promise<Response> {
-  const sfs = req.headers.get("sec-fetch-site");
-  if (sfs && sfs !== "same-origin" && sfs !== "none") {
-    return new Response(JSON.stringify({ error: "CSRF check failed" }), {
-      status: 403,
-      headers: { "content-type": "application/json" },
-    });
-  }
+  const guard = requireSameOrigin(req);
+  if (guard) return guard;
   const { name } = await ctx.params;
   if (await isDemoModeServer()) {
     return new Response(

--- a/dashboard/src/app/api/bridge/recipes/generate/route.ts
+++ b/dashboard/src/app/api/bridge/recipes/generate/route.ts
@@ -1,4 +1,5 @@
 import { bridgeFetch } from "@/lib/bridge";
+import { requireSameOrigin } from "@/lib/csrf";
 import { isDemoModeServer } from "@/lib/demoModeServer";
 import {
   BRIDGE_BODY_CAPS,
@@ -10,13 +11,8 @@ export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
 export async function POST(req: Request): Promise<Response> {
-  const sfs = req.headers.get("sec-fetch-site");
-  if (sfs && sfs !== "same-origin" && sfs !== "none") {
-    return new Response(JSON.stringify({ error: "CSRF check failed" }), {
-      status: 403,
-      headers: { "content-type": "application/json" },
-    });
-  }
+  const guard = requireSameOrigin(req);
+  if (guard) return guard;
   if (await isDemoModeServer()) {
     return new Response(
       JSON.stringify({

--- a/dashboard/src/app/api/bridge/recipes/install/route.ts
+++ b/dashboard/src/app/api/bridge/recipes/install/route.ts
@@ -1,4 +1,5 @@
 import { bridgeFetch } from "@/lib/bridge";
+import { requireSameOrigin } from "@/lib/csrf";
 import { isDemoModeServer } from "@/lib/demoModeServer";
 import {
   BRIDGE_BODY_CAPS,
@@ -22,10 +23,8 @@ function jsonError(
 }
 
 export async function POST(req: Request): Promise<Response> {
-  const sfs = req.headers.get("sec-fetch-site");
-  if (sfs && sfs !== "same-origin" && sfs !== "none") {
-    return jsonError(403, "CSRF check failed");
-  }
+  const guard = requireSameOrigin(req);
+  if (guard) return guard;
 
   if (await isDemoModeServer()) {
     return jsonError(

--- a/dashboard/src/app/api/bridge/recipes/lint/route.ts
+++ b/dashboard/src/app/api/bridge/recipes/lint/route.ts
@@ -1,5 +1,6 @@
 import type { NextRequest } from "next/server";
 import { bridgeFetch } from "@/lib/bridge";
+import { requireSameOrigin } from "@/lib/csrf";
 import { isDemoModeServer } from "@/lib/demoModeServer";
 import {
   BRIDGE_BODY_CAPS,
@@ -11,13 +12,8 @@ export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
 export async function POST(req: NextRequest): Promise<Response> {
-  const sfs = req.headers.get("sec-fetch-site");
-  if (sfs && sfs !== "same-origin" && sfs !== "none") {
-    return new Response(JSON.stringify({ error: "CSRF check failed" }), {
-      status: 403,
-      headers: { "content-type": "application/json" },
-    });
-  }
+  const guard = requireSameOrigin(req);
+  if (guard) return guard;
   if (await isDemoModeServer()) {
     return new Response(
       JSON.stringify({ ok: true, demo: true, errors: [], warnings: [] }),


### PR DESCRIPTION
## Summary

Six bridge proxy routes each inlined the same \`sec-fetch-site\` check with subtly different error-body shapes. Replaced all with the existing \`requireSameOrigin\` helper from \`@/lib/csrf\` (previously only used by \`connector-requests\`).

Files:
- \`bridge/[...path]/route.ts\`
- \`bridge/recipes/lint/route.ts\`
- \`bridge/recipes/install/route.ts\`
- \`bridge/recipes/[name]/route.ts\` (PUT/PATCH + DELETE)
- \`bridge/recipes/[name]/run/route.ts\`
- \`bridge/recipes/generate/route.ts\`

Net: +20 / -46.

## Why

Six divergent copies of one policy is a CSRF maintenance hazard — last security sweep already nudged people in this direction. Now one helper to evolve.

## Behaviour

Unchanged. Same accept set (\`same-origin\` / \`none\` / absent), same 403, same \`{ error: \"CSRF check failed\" }\` body.

## Test plan

- [x] \`vitest run src/app/api/bridge/\` — 21/21 pass
- [x] \`tsc --noEmit\` clean