### PR TITLE
fix(connectors): apply BaseConnector hardening to mcpOAuth refresh + revoke

### DIFF
--- a/src/connectors/__tests__/mcpOAuth-hardening.test.ts
+++ b/src/connectors/__tests__/mcpOAuth-hardening.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Regression tests for mcpOAuth refresh + revoke hardening.
+ *
+ * Pre-fix mcpOAuth.doRefresh (#37/#104 in BaseConnector) was missing four
+ * guards that the canonical BaseConnector.refreshToken enforces, and
+ * mcpOAuth.revoke posted the access_token to /token even when a refresh
+ * token existed. Audit 2026-05-17.
+ *
+ *   - HTTPS protocol check on tokenEndpoint
+ *   - access_token type/length validation on success body
+ *   - expires_in bounds check (positive finite ≤ 1 year)
+ *   - 401 / 400+invalid_grant → deleteTokenFile (permanent failure)
+ *   - revoke prefers refresh_token + sets token_type_hint
+ */
+
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("mcpOAuth hardening", () => {
+  const tmpDir = join(
+    os.tmpdir(),
+    `patchwork-mcp-oauth-hardening-${Date.now()}`,
+  );
+  const homeDir = join(tmpDir, "home");
+  const patchworkHome = join(homeDir, ".patchwork");
+  const tokensDir = join(patchworkHome, "tokens");
+
+  function stageExpiredLinearToken(refreshToken: string = "rt_v1"): void {
+    const legacy = {
+      vendor: "linear" as const,
+      client_id: "linear-client-id",
+      access_token: "stale-access-token",
+      refresh_token: refreshToken,
+      expires_at: Date.now() - 60_000,
+      connected_at: "2026-04-23T00:00:00.000Z",
+    };
+    writeFileSync(
+      join(tokensDir, "linear-mcp.json"),
+      JSON.stringify(legacy, null, 2),
+    );
+  }
+
+  beforeEach(() => {
+    process.env.HOME = homeDir;
+    process.env.USERPROFILE = homeDir;
+    process.env.PATCHWORK_HOME = patchworkHome;
+    process.env.PATCHWORK_TOKEN_STORAGE_BACKEND = "file";
+    mkdirSync(tokensDir, { recursive: true });
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    delete process.env.HOME;
+    delete process.env.USERPROFILE;
+    delete process.env.PATCHWORK_HOME;
+    delete process.env.PATCHWORK_TOKEN_STORAGE_BACKEND;
+    vi.unstubAllGlobals();
+    if (existsSync(tmpDir)) {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  // HTTPS-only check on tokenEndpoint is exercised at code-review level:
+  // linear/sentry/github vendor configs all hardcode `https://` and
+  // `vendorConfig` is not user-overridable at runtime. The guard catches
+  // the future case where discovery / env override could supply http://.
+
+  it("treats 401 as permanent → deletes token file", async () => {
+    stageExpiredLinearToken();
+    const fetchMock = vi.fn().mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: "invalid_token" }), {
+        status: 401,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { getAccessToken, isConnected } = await import("../mcpOAuth.js");
+
+    await expect(getAccessToken("linear")).rejects.toThrow(/refresh failed/);
+
+    // Token file should be gone — next call surfaces "not connected".
+    expect(isConnected("linear")).toBe(false);
+  });
+
+  it("treats 400 invalid_grant as permanent → deletes token file", async () => {
+    stageExpiredLinearToken();
+    const fetchMock = vi.fn().mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: "invalid_grant" }), {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { getAccessToken, isConnected } = await import("../mcpOAuth.js");
+
+    await expect(getAccessToken("linear")).rejects.toThrow(/refresh failed/);
+    expect(isConnected("linear")).toBe(false);
+  });
+
+  it("treats 500 / other failures as transient → keeps token file", async () => {
+    stageExpiredLinearToken();
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response("server down", { status: 503 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { getAccessToken, isConnected } = await import("../mcpOAuth.js");
+
+    await expect(getAccessToken("linear")).rejects.toThrow(/refresh failed/);
+    // Token file MUST survive transient failures — flaky wifi shouldn't
+    // force a full re-OAuth.
+    expect(isConnected("linear")).toBe(true);
+  });
+
+  it("rejects empty access_token in success body (no `Bearer undefined` persist)", async () => {
+    stageExpiredLinearToken();
+    const fetchMock = vi.fn().mockResolvedValueOnce(
+      new Response(JSON.stringify({}), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { getAccessToken } = await import("../mcpOAuth.js");
+    await expect(getAccessToken("linear")).rejects.toThrow(/no access_token/);
+  });
+
+  it("rejects absurd expires_in (> 1 year)", async () => {
+    stageExpiredLinearToken();
+    const fetchMock = vi.fn().mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          access_token: "fresh",
+          expires_in: 60 * 60 * 24 * 400, // 400 days
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { getAccessToken } = await import("../mcpOAuth.js");
+    await expect(getAccessToken("linear")).rejects.toThrow(
+      /invalid expires_in/,
+    );
+  });
+
+  it("rejects negative / zero expires_in", async () => {
+    stageExpiredLinearToken();
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ access_token: "fresh", expires_in: -10 }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { getAccessToken } = await import("../mcpOAuth.js");
+    await expect(getAccessToken("linear")).rejects.toThrow(
+      /invalid expires_in/,
+    );
+  });
+
+  it("revoke prefers refresh_token + sets token_type_hint", async () => {
+    // Stage a fresh (non-expired) Linear token with both access + refresh.
+    const file = {
+      vendor: "linear" as const,
+      client_id: "linear-client-id",
+      access_token: "live-access-token",
+      refresh_token: "live-refresh-token",
+      expires_at: Date.now() + 3_600_000,
+      connected_at: "2026-04-23T00:00:00.000Z",
+    };
+    writeFileSync(
+      join(tokensDir, "linear-mcp.json"),
+      JSON.stringify(file, null, 2),
+    );
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response("", { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { revoke } = await import("../mcpOAuth.js");
+    await revoke("linear");
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const body = new URLSearchParams(String(init.body));
+    expect(body.get("token")).toBe("live-refresh-token");
+    expect(body.get("token_type_hint")).toBe("refresh_token");
+  });
+
+  it("revoke falls back to access_token when no refresh exists", async () => {
+    const file = {
+      vendor: "linear" as const,
+      client_id: "linear-client-id",
+      access_token: "only-access-token",
+      // no refresh_token
+      expires_at: Date.now() + 3_600_000,
+      connected_at: "2026-04-23T00:00:00.000Z",
+    };
+    writeFileSync(
+      join(tokensDir, "linear-mcp.json"),
+      JSON.stringify(file, null, 2),
+    );
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response("", { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { revoke } = await import("../mcpOAuth.js");
+    await revoke("linear");
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const body = new URLSearchParams(String(init.body));
+    expect(body.get("token")).toBe("only-access-token");
+    expect(body.get("token_type_hint")).toBe(null);
+  });
+});

--- a/src/connectors/mcpOAuth.ts
+++ b/src/connectors/mcpOAuth.ts
@@ -214,6 +214,7 @@ interface PendingAuth {
 }
 
 const pending = new Map<string, PendingAuth>();
+const PENDING_MAX_ENTRIES = 1000;
 
 function gcPending(): void {
   const now = Date.now();
@@ -304,6 +305,11 @@ export async function startAuthorize(
 
   const verifier = config.skipPkce ? undefined : genVerifier();
   const state = base64url(crypto.randomBytes(24));
+  if (pending.size >= PENDING_MAX_ENTRIES) {
+    throw new Error(
+      `${config.vendor}: pending-auth store full (cap=${PENDING_MAX_ENTRIES}); retry later`,
+    );
+  }
   pending.set(state, {
     vendor: config.vendor,
     verifier,
@@ -485,6 +491,23 @@ async function doRefresh(
   const tokenEndpoint = config.tokenEndpoint;
   if (!refreshToken || !tokenEndpoint) return file;
 
+  // Refuse to send the refresh token to a non-HTTPS endpoint. A vendor
+  // config that derives tokenEndpoint from environment / discovery could
+  // otherwise be tricked into POSTing the secret to an attacker.
+  let endpointUrl: URL;
+  try {
+    endpointUrl = new URL(tokenEndpoint);
+  } catch {
+    throw new Error(
+      `${file.vendor}: token refresh failed (invalid token_endpoint). Re-authorize via GET /connections/${file.vendor}/authorize`,
+    );
+  }
+  if (endpointUrl.protocol !== "https:") {
+    throw new Error(
+      `${file.vendor}: token refresh refused — token_endpoint must be https`,
+    );
+  }
+
   const body = new URLSearchParams({
     grant_type: "refresh_token",
     refresh_token: refreshToken,
@@ -501,22 +524,69 @@ async function doRefresh(
     body: body.toString(),
   });
   if (!res.ok) {
+    // Distinguish permanent (refresh token revoked) from transient failures.
+    // Permanent → drop the stored token so the next call surfaces a clean
+    // "not connected" error and the user is prompted to re-auth.
+    let errorBody: { error?: string } = {};
+    try {
+      errorBody = (await res.json()) as { error?: string };
+    } catch {
+      // non-JSON error body — fall through
+    }
+    const refreshTokenIsInvalid =
+      res.status === 401 ||
+      (res.status === 400 && errorBody.error === "invalid_grant");
+    if (refreshTokenIsInvalid) {
+      deleteTokenFile(file.vendor);
+    }
     throw new Error(
       `${file.vendor}: token refresh failed (${res.status}). Re-authorize via GET /connections/${file.vendor}/authorize`,
     );
   }
-  const json = (await res.json()) as {
-    access_token: string;
-    refresh_token?: string;
-    expires_in?: number;
+  let json: {
+    access_token?: unknown;
+    refresh_token?: unknown;
+    expires_in?: unknown;
   };
+  try {
+    json = (await res.json()) as typeof json;
+  } catch {
+    // Malformed success body — treat as transient
+    throw new Error(
+      `${file.vendor}: token refresh returned malformed JSON; keeping existing token`,
+    );
+  }
+  // Validate the success body before adopting. A 200 with `{}` or
+  // `{access_token: null}` would otherwise persist `Bearer undefined`.
+  if (typeof json.access_token !== "string" || json.access_token.length === 0) {
+    throw new Error(
+      `${file.vendor}: token refresh returned no access_token; keeping existing token`,
+    );
+  }
+  let expiresAt: number | undefined;
+  if (json.expires_in !== undefined) {
+    const ONE_YEAR_S = 60 * 60 * 24 * 365;
+    if (
+      typeof json.expires_in !== "number" ||
+      !Number.isFinite(json.expires_in) ||
+      json.expires_in <= 0 ||
+      json.expires_in > ONE_YEAR_S
+    ) {
+      throw new Error(
+        `${file.vendor}: token refresh returned invalid expires_in; keeping existing token`,
+      );
+    }
+    expiresAt = Date.now() + json.expires_in * 1000;
+  }
+  const newRefreshToken =
+    typeof json.refresh_token === "string" && json.refresh_token.length > 0
+      ? json.refresh_token
+      : file.refresh_token;
   const updated: McpTokenFile = {
     ...file,
     access_token: json.access_token,
-    refresh_token: json.refresh_token ?? file.refresh_token,
-    expires_at: json.expires_in
-      ? Date.now() + json.expires_in * 1000
-      : undefined,
+    refresh_token: newRefreshToken,
+    expires_at: expiresAt,
   };
   saveTokenFile(updated);
   return updated;
@@ -568,10 +638,19 @@ export async function revoke(vendor: VendorId): Promise<void> {
   const file = loadTokenFile(vendor);
   const config = vendorConfig(vendor);
   if (file && config.revocationEndpoint) {
+    // RFC 7009 §2.1: revoking a refresh_token also revokes the access_token
+    // it minted. Sending the access_token only leaves the refresh_token live
+    // at the IdP — anyone with an exfiltrated copy of the token file can
+    // mint fresh access tokens forever. Always prefer refresh_token; fall
+    // back to access_token only when no refresh exists.
+    const tokenToRevoke = file.refresh_token ?? file.access_token;
     const body = new URLSearchParams({
-      token: file.access_token,
+      token: tokenToRevoke,
       client_id: file.client_id,
     });
+    if (file.refresh_token) {
+      body.set("token_type_hint", "refresh_token");
+    }
     if (file.client_secret) body.set("client_secret", file.client_secret);
     await fetch(config.revocationEndpoint, {
       method: "POST",


### PR DESCRIPTION
## Summary

mcpOAuth (Linear, Sentry, GitHub-MCP) was forked from the BaseConnector OAuth shape and missed three hardening passes (#37, #104, #119) that landed on the canonical path. This brings it in line.

### Refresh (`doRefresh`)
- Rejects non-HTTPS `tokenEndpoint` — refuses to POST `refresh_token` over plain HTTP even if a future discovery/env supplies it.
- Validates `access_token` is a non-empty string on the success body (no more `Bearer undefined` persisted on `{}`).
- Bounds `expires_in` to `(0s, 1y]`.
- Distinguishes **permanent** (`401` OR `400 + error: invalid_grant`) — deletes token file so next call surfaces "not connected" — from **transient** (`5xx`, network error, non-JSON body) — keeps token, retries next call.

### Revoke
RFC 7009 §2.1: revoking the `refresh_token` cascades and kills the access tokens it minted. We were posting the access_token only — an exfiltrated token file kept minting forever. Now sends `refresh_token` (with `token_type_hint: refresh_token`) when present; falls back to access_token when no refresh exists.

### Pending-auth Map cap
The `pending` Map was unbounded — an authenticated caller looping `/authorize` was a heap-amplification surface. PR #119 fixed this for other connectors via `oauthStateStore`; mcpOAuth carries `PendingAuth` payload so it doesn't slot into the shared store. Cap = 1000 entries (same shape as the shared store).

## Test plan

- [x] `npx vitest run src/connectors/__tests__/mcpOAuth*.test.ts` — 12/12 pass (4 existing + 8 new).
- [x] `npx tsc -p tsconfig.json --noEmit` clean.
- [x] New tests cover: 401 permanent, 400+invalid_grant permanent, 503 transient (keeps token), empty `access_token`, `expires_in > 1y`, negative `expires_in`, revoke prefers refresh_token, revoke fallback to access_token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)