### PR TITLE
security(recipes): enforce RECIPE_NAME_RE on parseRecipe + assert resolved write path

### DIFF
--- a/src/recipes/__tests__/installer.test.ts
+++ b/src/recipes/__tests__/installer.test.ts
@@ -127,4 +127,73 @@ steps:
     const src = writeRecipe("bad", { name: "x" }); // missing required fields
     expect(() => installRecipeFromFile(src, { recipesDir: dir })).toThrow();
   });
+
+  describe("path-traversal defence (audit 2026-05-17)", () => {
+    it("rejects recipe.name with .. segments at the parser boundary", () => {
+      const src = writeRecipe("attacker", {
+        ...SIMPLE,
+        name: "../../../etc/cron.d/pwn",
+      });
+      const recipesDir = path.join(dir, "recipes");
+      expect(() => installRecipeFromFile(src, { recipesDir })).toThrow(
+        /name must match/,
+      );
+    });
+
+    it("rejects recipe.name with forward-slash separator", () => {
+      const src = writeRecipe("attacker", { ...SIMPLE, name: "foo/bar" });
+      expect(() =>
+        installRecipeFromFile(src, { recipesDir: path.join(dir, "recipes") }),
+      ).toThrow(/name must match/);
+    });
+
+    it("rejects recipe.name with backslash separator (Windows)", () => {
+      const src = writeRecipe("attacker", {
+        ...SIMPLE,
+        name: "foo\\..\\..\\evil",
+      });
+      expect(() =>
+        installRecipeFromFile(src, { recipesDir: path.join(dir, "recipes") }),
+      ).toThrow(/name must match/);
+    });
+
+    it("rejects recipe.name with uppercase chars (kebab-case enforced)", () => {
+      const src = writeRecipe("attacker", { ...SIMPLE, name: "ABC" });
+      expect(() =>
+        installRecipeFromFile(src, { recipesDir: path.join(dir, "recipes") }),
+      ).toThrow(/name must match/);
+    });
+
+    it("rejects recipe.name with underscore (kebab-case enforced)", () => {
+      const src = writeRecipe("attacker", { ...SIMPLE, name: "with_under" });
+      expect(() =>
+        installRecipeFromFile(src, { recipesDir: path.join(dir, "recipes") }),
+      ).toThrow(/name must match/);
+    });
+
+    it("rejects recipe.name starting with hyphen", () => {
+      const src = writeRecipe("attacker", { ...SIMPLE, name: "-leading-dash" });
+      expect(() =>
+        installRecipeFromFile(src, { recipesDir: path.join(dir, "recipes") }),
+      ).toThrow(/name must match/);
+    });
+
+    it("rejects recipe.name longer than 64 chars", () => {
+      const src = writeRecipe("attacker", {
+        ...SIMPLE,
+        name: "a".repeat(65),
+      });
+      expect(() =>
+        installRecipeFromFile(src, { recipesDir: path.join(dir, "recipes") }),
+      ).toThrow(/name must match/);
+    });
+
+    it("accepts canonical kebab-case names", () => {
+      const src = writeRecipe("ok", { ...SIMPLE, name: "morning-brief" });
+      const result = installRecipeFromFile(src, {
+        recipesDir: path.join(dir, "recipes"),
+      });
+      expect(result.action).toBe("created");
+    });
+  });
 });

--- a/src/recipes/installer.ts
+++ b/src/recipes/installer.ts
@@ -78,6 +78,21 @@ export function installRecipeFromFile(
 
   mkdir(opts.recipesDir);
   const destPath = path.join(opts.recipesDir, `${recipe.name}.json`);
+  // Belt-and-braces: parseRecipe already constrains `name` to the
+  // RECIPE_NAME_RE charset, but assert the resolved path stays inside
+  // recipesDir before writing. Defends against any future parser bypass
+  // and against callers reaching this function with a pre-parsed object
+  // that skipped parseRecipe.
+  const resolvedDir = path.resolve(opts.recipesDir);
+  const resolvedDest = path.resolve(destPath);
+  if (
+    resolvedDest !== resolvedDir &&
+    !resolvedDest.startsWith(resolvedDir + path.sep)
+  ) {
+    throw new Error(
+      `installRecipeFromFile: refusing to write outside recipesDir (dest=${resolvedDest} dir=${resolvedDir})`,
+    );
+  }
   let action: "created" | "replaced" = "created";
   try {
     readFile(destPath);

--- a/src/recipes/parser.ts
+++ b/src/recipes/parser.ts
@@ -1,3 +1,4 @@
+import { RECIPE_NAME_RE } from "./names.js";
 import type { Recipe, Step, Trigger } from "./schema.js";
 
 /**
@@ -23,6 +24,18 @@ export function parseRecipe(raw: unknown): Recipe {
   }
   const r = raw as Record<string, unknown>;
   const name = requireString(r, "name");
+  // Enforce the canonical recipe-name shape at the parse boundary. Without
+  // this, `installRecipeFromFile` would `path.join(recipesDir, ${name}.json)`
+  // with attacker-controlled `name` (registry recipe / bundle install path)
+  // and `../../../etc/cron.d/pwn` would escape the recipes dir. Audit 2026-05-17.
+  // `recipesHttp` already enforces this regex at its own boundaries; this
+  // closes the gap on the install path used by `recipes/install` + bundle install.
+  if (!RECIPE_NAME_RE.test(name)) {
+    throw new RecipeParseError(
+      `name must match ${RECIPE_NAME_RE} (kebab-case, 1-64 chars, alphanumeric or hyphen, starts with [a-z0-9])`,
+      ["name"],
+    );
+  }
   const version = requireString(r, "version");
   const trigger = parseTrigger(r.trigger);
   const stepsRaw = r.steps;


### PR DESCRIPTION
## Summary

A registry recipe or bundle with `name: \"../../../etc/cron.d/pwn\"` could escape `recipesDir` via the `path.join` at [src/recipes/installer.ts:80](src/recipes/installer.ts#L80). `parseRecipe`/`requireString` only checked non-empty; `validateRecipeDefinition` is only a *warning* AND isn't called by `installRecipeFromFile`. Both [recipeRoutes.ts:1531](src/recipeRoutes.ts#L1531) (bundle install) and `:1804` (YAML install) reach the installer.

`recipesHttp` already gates its routes on `RECIPE_NAME_RE` via [src/recipes/names.ts](src/recipes/names.ts); the install path was the straggler.

### Fix
- **parser.ts** — enforce `RECIPE_NAME_RE` on `name` at the parse boundary. Every install path goes through `parseRecipe` so this catches all reachable callers.
- **installer.ts** — belt-and-braces: assert `path.resolve(destPath)` stays inside `path.resolve(opts.recipesDir)` before writing. Defends against any future parser bypass or pre-parsed-object caller.

## Test plan

- [x] 8 new regression tests in `installer.test.ts` cover: `..` traversal, forward + backslash separators, uppercase, underscore, leading-hyphen, > 64 chars, and the positive case.
- [x] `npx vitest run src/recipes` — **711/711 pass** (703 + 8 new).
- [x] `npx vitest run src/__tests__ src/recipes` — **2763 pass / 2 skipped** (pre-existing).
- [x] `npx tsc -p tsconfig.json --noEmit` clean.
- [x] Survey of all 13 template recipe names in `templates/recipes/*.yaml` confirms they match `RECIPE_NAME_RE`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)