### PR TITLE
security: close 3 input-validation gaps (init exec injection + Confluence/Datadog SSRF)

### DIFF
--- a/src/connectors/__tests__/confluence.test.ts
+++ b/src/connectors/__tests__/confluence.test.ts
@@ -152,6 +152,30 @@ describe("handleConfluenceConnect", () => {
   });
 
   describe("SSRF guard on instanceUrl (audit 2026-05-17)", () => {
+    // Isolated PATCHWORK_HOME so the positive case ("accepts
+    // atlassian.net") doesn't leak tokens onto the runner's real $HOME
+    // and break `handleConfluenceTest("returns 400 when not
+    // connected")`. CI repro: PR #577.
+    const ssrfTmpDir = join(
+      os.tmpdir(),
+      `patchwork-confluence-ssrf-${Date.now()}`,
+    );
+    const ssrfHome = join(ssrfTmpDir, ".patchwork");
+
+    beforeEach(() => {
+      mkdirSync(join(ssrfHome, "tokens"), { recursive: true });
+      process.env.PATCHWORK_HOME = ssrfHome;
+      process.env.PATCHWORK_TOKEN_STORAGE_BACKEND = "file";
+    });
+
+    afterEach(() => {
+      delete process.env.PATCHWORK_HOME;
+      delete process.env.PATCHWORK_TOKEN_STORAGE_BACKEND;
+      if (existsSync(ssrfTmpDir)) {
+        rmSync(ssrfTmpDir, { recursive: true, force: true });
+      }
+    });
+
     it("rejects http://169.254.169.254 metadata service without hitting fetch", async () => {
       const fetchMock = vi.fn();
       global.fetch = fetchMock as unknown as typeof fetch;

--- a/src/connectors/__tests__/confluence.test.ts
+++ b/src/connectors/__tests__/confluence.test.ts
@@ -151,6 +151,91 @@ describe("handleConfluenceConnect", () => {
     expect(result.status).toBe(400);
   });
 
+  describe("SSRF guard on instanceUrl (audit 2026-05-17)", () => {
+    it("rejects http://169.254.169.254 metadata service without hitting fetch", async () => {
+      const fetchMock = vi.fn();
+      global.fetch = fetchMock as unknown as typeof fetch;
+      vi.resetModules();
+      const { handleConfluenceConnect } = await import("../confluence.js");
+      const result = await handleConfluenceConnect(
+        JSON.stringify({
+          token: "x",
+          email: "u@e.com",
+          instanceUrl: "http://169.254.169.254/admin",
+        }),
+      );
+      expect(result.status).toBe(400);
+      expect(JSON.parse(result.body).error).toMatch(/atlassian\.net/);
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it("rejects http://127.0.0.1", async () => {
+      const fetchMock = vi.fn();
+      global.fetch = fetchMock as unknown as typeof fetch;
+      vi.resetModules();
+      const { handleConfluenceConnect } = await import("../confluence.js");
+      const result = await handleConfluenceConnect(
+        JSON.stringify({
+          token: "x",
+          email: "u@e.com",
+          instanceUrl: "http://127.0.0.1/wiki",
+        }),
+      );
+      expect(result.status).toBe(400);
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it("rejects https on non-Atlassian host", async () => {
+      const fetchMock = vi.fn();
+      global.fetch = fetchMock as unknown as typeof fetch;
+      vi.resetModules();
+      const { handleConfluenceConnect } = await import("../confluence.js");
+      const result = await handleConfluenceConnect(
+        JSON.stringify({
+          token: "x",
+          email: "u@e.com",
+          instanceUrl: "https://attacker.example.com",
+        }),
+      );
+      expect(result.status).toBe(400);
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it("rejects subdomain-confusion (attacker.atlassian.net.evil.com)", async () => {
+      const fetchMock = vi.fn();
+      global.fetch = fetchMock as unknown as typeof fetch;
+      vi.resetModules();
+      const { handleConfluenceConnect } = await import("../confluence.js");
+      const result = await handleConfluenceConnect(
+        JSON.stringify({
+          token: "x",
+          email: "u@e.com",
+          instanceUrl: "https://atlassian.net.evil.com",
+        }),
+      );
+      expect(result.status).toBe(400);
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it("accepts https://<workspace>.atlassian.net", async () => {
+      global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+      }) as unknown as typeof fetch;
+      vi.resetModules();
+      const { handleConfluenceConnect } = await import("../confluence.js");
+      const result = await handleConfluenceConnect(
+        JSON.stringify({
+          token: "x",
+          email: "u@e.com",
+          instanceUrl: "https://acme.atlassian.net",
+        }),
+      );
+      // NOT 400 — would be 200 (success) or 500 (token storage mock failure)
+      expect(result.status).not.toBe(400);
+    });
+  });
+
   it("returns 401 when Confluence rejects credentials", async () => {
     global.fetch = vi.fn().mockResolvedValueOnce({
       ok: false,

--- a/src/connectors/__tests__/datadog.test.ts
+++ b/src/connectors/__tests__/datadog.test.ts
@@ -151,6 +151,77 @@ describe("handleDatadogConnect", () => {
     expect(result.status).toBe(400);
   });
 
+  describe("SSRF guard on site (audit 2026-05-17)", () => {
+    it("rejects internal-IP-as-site without hitting fetch", async () => {
+      const fetchMock = vi.fn();
+      global.fetch = fetchMock as unknown as typeof fetch;
+      vi.resetModules();
+      const { handleDatadogConnect } = await import("../datadog.js");
+      const result = await handleDatadogConnect(
+        JSON.stringify({ apiKey: "x", appKey: "y", site: "127.0.0.1:9091/x" }),
+      );
+      expect(result.status).toBe(400);
+      expect(JSON.parse(result.body).error).toMatch(/site must be one of/);
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it("rejects metadata-service-as-site", async () => {
+      const fetchMock = vi.fn();
+      global.fetch = fetchMock as unknown as typeof fetch;
+      vi.resetModules();
+      const { handleDatadogConnect } = await import("../datadog.js");
+      const result = await handleDatadogConnect(
+        JSON.stringify({
+          apiKey: "x",
+          appKey: "y",
+          site: "169.254.169.254",
+        }),
+      );
+      expect(result.status).toBe(400);
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it("rejects subdomain-of-datadoghq trick", async () => {
+      const fetchMock = vi.fn();
+      global.fetch = fetchMock as unknown as typeof fetch;
+      vi.resetModules();
+      const { handleDatadogConnect } = await import("../datadog.js");
+      const result = await handleDatadogConnect(
+        JSON.stringify({
+          apiKey: "x",
+          appKey: "y",
+          site: "evil.com/datadoghq.com",
+        }),
+      );
+      expect(result.status).toBe(400);
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it("accepts all 6 canonical sites", async () => {
+      const sites = [
+        "datadoghq.com",
+        "us3.datadoghq.com",
+        "us5.datadoghq.com",
+        "datadoghq.eu",
+        "ap1.datadoghq.com",
+        "ddog-gov.com",
+      ];
+      for (const site of sites) {
+        global.fetch = vi.fn().mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+        }) as unknown as typeof fetch;
+        vi.resetModules();
+        const { handleDatadogConnect } = await import("../datadog.js");
+        const result = await handleDatadogConnect(
+          JSON.stringify({ apiKey: "x", appKey: "y", site }),
+        );
+        // 200 (success) or 500 (token storage mock), but NOT 400 from site guard
+        expect(result.status).not.toBe(400);
+      }
+    });
+  });
+
   it("returns 401 when Datadog rejects credentials", async () => {
     global.fetch = vi.fn().mockResolvedValueOnce({
       ok: false,

--- a/src/connectors/__tests__/datadog.test.ts
+++ b/src/connectors/__tests__/datadog.test.ts
@@ -152,6 +152,30 @@ describe("handleDatadogConnect", () => {
   });
 
   describe("SSRF guard on site (audit 2026-05-17)", () => {
+    // Isolated PATCHWORK_HOME so the success path of `accepts all 6`
+    // doesn't leak tokens onto the runner's real $HOME, which would
+    // make `handleDatadogTest("returns 400 when not connected")`
+    // observe stored tokens it doesn't expect. CI repro: PR #577.
+    const ssrfTmpDir = join(
+      os.tmpdir(),
+      `patchwork-datadog-ssrf-${Date.now()}`,
+    );
+    const ssrfHome = join(ssrfTmpDir, ".patchwork");
+
+    beforeEach(() => {
+      mkdirSync(join(ssrfHome, "tokens"), { recursive: true });
+      process.env.PATCHWORK_HOME = ssrfHome;
+      process.env.PATCHWORK_TOKEN_STORAGE_BACKEND = "file";
+    });
+
+    afterEach(() => {
+      delete process.env.PATCHWORK_HOME;
+      delete process.env.PATCHWORK_TOKEN_STORAGE_BACKEND;
+      if (existsSync(ssrfTmpDir)) {
+        rmSync(ssrfTmpDir, { recursive: true, force: true });
+      }
+    });
+
     it("rejects internal-IP-as-site without hitting fetch", async () => {
       const fetchMock = vi.fn();
       global.fetch = fetchMock as unknown as typeof fetch;

--- a/src/connectors/confluence.ts
+++ b/src/connectors/confluence.ts
@@ -25,6 +25,27 @@ import {
 // Confluence Cloud REST API v2
 const CONFLUENCE_API_V2 = "/wiki/api/v2";
 
+/**
+ * Accept only https Atlassian-cloud hostnames for the `instanceUrl` that the
+ * dashboard hands to `handleConfluenceConnect`. Without this, an
+ * authenticated caller could submit `http://169.254.169.254/...` or
+ * `http://127.0.0.1/admin` and the bridge would POST Basic auth credentials
+ * to it. On-prem deployments override via the CONFLUENCE_INSTANCE_URL env
+ * (which is operator-trusted, not caller-controlled).
+ */
+function isAllowedConfluenceUrl(rawUrl: string): boolean {
+  try {
+    const parsed = new URL(rawUrl);
+    if (parsed.protocol !== "https:") return false;
+    return (
+      parsed.hostname === "atlassian.net" ||
+      parsed.hostname.endsWith(".atlassian.net")
+    );
+  } catch {
+    return false;
+  }
+}
+
 export interface ConfluenceTokens {
   accessToken: string; // API token
   email: string; // Atlassian account email for Basic auth
@@ -402,6 +423,22 @@ export async function handleConfluenceConnect(
         body: JSON.stringify({
           ok: false,
           error: "instanceUrl is required (e.g. https://myteam.atlassian.net)",
+        }),
+      };
+    }
+    // Defend against authenticated SSRF: a caller-supplied `instanceUrl`
+    // like `http://169.254.169.254/...` or `http://127.0.0.1/admin` would
+    // otherwise be interpolated into `fetch()` with Basic auth attached.
+    // Require https + an Atlassian cloud hostname. On-prem deployments can
+    // override via CONFLUENCE_INSTANCE_URL env. Audit 2026-05-17.
+    if (!isAllowedConfluenceUrl(parsed.instanceUrl)) {
+      return {
+        status: 400,
+        contentType: "application/json",
+        body: JSON.stringify({
+          ok: false,
+          error:
+            "instanceUrl must be https and on atlassian.net (e.g. https://myteam.atlassian.net)",
         }),
       };
     }

--- a/src/connectors/datadog.ts
+++ b/src/connectors/datadog.ts
@@ -23,6 +23,21 @@ import {
   storeSecretJsonSync,
 } from "./tokenStorage.js";
 
+/**
+ * Datadog's full public-site list. The `site` field is interpolated into
+ * `https://api.${site}/...` so any caller-supplied value flows into a
+ * fetch URL — enum-validate to prevent SSRF / credential redirection.
+ * Source: https://docs.datadoghq.com/getting_started/site/
+ */
+const DATADOG_ALLOWED_SITES: ReadonlySet<string> = new Set([
+  "datadoghq.com",
+  "us3.datadoghq.com",
+  "us5.datadoghq.com",
+  "datadoghq.eu",
+  "ap1.datadoghq.com",
+  "ddog-gov.com",
+]);
+
 export interface DatadogTokens {
   apiKey: string;
   appKey: string;
@@ -388,10 +403,26 @@ export async function handleDatadogConnect(
     }
     apiKey = parsed.apiKey;
     appKey = parsed.appKey;
-    site =
+    const submittedSite =
       typeof parsed.site === "string" && parsed.site
         ? parsed.site
         : "datadoghq.com";
+    // Defend against authenticated SSRF: site is interpolated into
+    // `https://api.${site}/api/v1/validate`. Inputs like `evil.com/x`,
+    // `127.0.0.1:9091/x?`, or `internal-svc..corp` would otherwise route
+    // Datadog credentials to attacker-chosen hosts. Datadog has a fixed
+    // public list of sites — enum-validate. Audit 2026-05-17.
+    if (!DATADOG_ALLOWED_SITES.has(submittedSite)) {
+      return {
+        status: 400,
+        contentType: "application/json",
+        body: JSON.stringify({
+          ok: false,
+          error: `site must be one of: ${[...DATADOG_ALLOWED_SITES].join(", ")}`,
+        }),
+      };
+    }
+    site = submittedSite;
   } catch {
     return {
       status: 400,

--- a/src/index.ts
+++ b/src/index.ts
@@ -3577,8 +3577,11 @@ Steps performed:
         ? fallbackDocs
         : null;
     if (target) {
-      const { exec } = await import("node:child_process");
-      exec(`code "${target}"`, { timeout: 3000 }, () => {});
+      // Use execFile with argv (no shell) — exec(`code "${target}"`) was
+      // shell-evaluated and could be injected via `--workspace '"; ...'`
+      // since path.resolve preserves shell metachars. Audit 2026-05-17.
+      const { execFile } = await import("node:child_process");
+      execFile("code", [target], { timeout: 3000 }, () => {});
     }
   }
 


### PR DESCRIPTION
## Summary

Three audit findings (2026-05-17), one PR — all "untrusted string flows into a privileged operation":

### 1. `patchwork init --workspace` command injection
[src/index.ts:3580](src/index.ts#L3580) — `exec(\`code \"\${target}\"\`)` where `target = path.join(workspace, ...)`. `path.resolve` preserves shell metachars, so `--workspace '\"; id; #'` shell-evaluates. Same class as PR #516. **Fix**: `execFile(\"code\", [target])` — no shell, argv only.

### 2. Confluence `instanceUrl` SSRF
[src/connectors/confluence.ts:398](src/connectors/confluence.ts#L398) — caller-supplied `instanceUrl` was only stripped of trailing slash, then interpolated into a Basic-auth `fetch()`. An authenticated bridge caller could submit `http://169.254.169.254/latest/...` (AWS metadata) or `http://127.0.0.1/admin` and the bridge would POST `email:token` credentials to it. **Fix**: require `https:` + `atlassian.net` hostname (matches Jira's existing `isAtlassianCloudHost` shape). On-prem deployments override via operator-controlled `CONFLUENCE_INSTANCE_URL` env, not the dashboard.

### 3. Datadog `site` SSRF
[src/connectors/datadog.ts:391](src/connectors/datadog.ts#L391) — `site` interpolated into `https://api.${site}/api/v1/validate`. Inputs like `evil.com/x`, `127.0.0.1:9091/x?`, `internal-svc..corp` would route `DD-API-KEY` + `DD-APPLICATION-KEY` headers to attacker hosts. **Fix**: enum allowlist of Datadog's 6 public sites (`datadoghq.com`, `us3/us5.datadoghq.com`, `datadoghq.eu`, `ap1.datadoghq.com`, `ddog-gov.com`).

## Test plan

- [x] 9 regression tests added: 4 Confluence SSRF cases (metadata, loopback, non-Atlassian, subdomain-confusion) + positive case; 4 Datadog SSRF cases (loopback, metadata, subdomain trick) + positive case across all 6 sites.
- [x] 35/35 pass on the two affected test files (was 26).
- [x] `npx tsc -p tsconfig.json --noEmit` clean.

## PR sequence

#572 → #573 → #574 → #575 → #576 → **this**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)