### PR TITLE
fix: atomic writes for 10 critical state files

### DIFF
--- a/dashboard/src/lib/pushStore.ts
+++ b/dashboard/src/lib/pushStore.ts
@@ -1,3 +1,4 @@
+import crypto from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -16,9 +17,20 @@ function load(): Map<string, PushSubscription> {
 }
 
 function persist(store: Map<string, PushSubscription>): void {
+  // Atomic write — temp + rename — so a crash mid-write can't truncate
+  // the subscription store (which would silently wipe every push
+  // subscription on next boot; load() catches parse errors and resets
+  // to an empty Map). Audit 2026-05-17.
+  const tmp = `${STORE_PATH}.tmp.${process.pid}.${crypto.randomBytes(6).toString("hex")}`;
   try {
-    fs.writeFileSync(STORE_PATH, JSON.stringify([...store.entries()]), "utf8");
+    fs.writeFileSync(tmp, JSON.stringify([...store.entries()]), "utf8");
+    fs.renameSync(tmp, STORE_PATH);
   } catch (err) {
+    try {
+      fs.unlinkSync(tmp);
+    } catch {
+      /* already gone or never created */
+    }
     console.warn("[pushStore] Failed to persist subscriptions:", err);
   }
 }

--- a/src/__tests__/claudeOrchestrator.test.ts
+++ b/src/__tests__/claudeOrchestrator.test.ts
@@ -267,31 +267,47 @@ describe("ClaudeOrchestrator", () => {
 
 // ── Persistence tests ─────────────────────────────────────────────────────────
 
+// Atomic write helper (writeFileAtomic / writeFileAtomicSync) writes to a
+// temp path then renames. The persistence tests below mock writeFile* to
+// capture content without touching disk, so rename* must also be mocked
+// (otherwise the helper's rename step ENOENTs on the un-created temp).
 vi.mock("node:fs/promises", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:fs/promises")>();
   return {
     ...actual,
     readFile: vi.fn(),
     writeFile: vi.fn().mockResolvedValue(undefined),
+    rename: vi.fn().mockResolvedValue(undefined),
+    unlink: vi.fn().mockResolvedValue(undefined),
+    chmod: vi.fn().mockResolvedValue(undefined),
   };
 });
 
 vi.mock("node:fs", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:fs")>();
+  const mockedPromises = {
+    ...(actual.promises ?? {}),
+    writeFile: vi.fn().mockResolvedValue(undefined),
+    rename: vi.fn().mockResolvedValue(undefined),
+    unlink: vi.fn().mockResolvedValue(undefined),
+    chmod: vi.fn().mockResolvedValue(undefined),
+  };
   return {
     ...actual,
     default: {
       ...actual,
       writeFileSync: vi.fn(),
+      renameSync: vi.fn(),
+      unlinkSync: vi.fn(),
       chmodSync: vi.fn(),
-      promises: {
-        ...(actual.promises ?? {}),
-        chmod: vi.fn().mockResolvedValue(undefined),
-      },
+      promises: mockedPromises,
       lstatSync: vi.fn().mockReturnValue({ isFile: () => true }),
     },
     writeFileSync: vi.fn(),
+    renameSync: vi.fn(),
+    unlinkSync: vi.fn(),
     chmodSync: vi.fn(),
+    promises: mockedPromises,
     lstatSync: vi.fn().mockReturnValue({ isFile: () => true }),
   };
 });
@@ -305,7 +321,11 @@ describe("ClaudeOrchestrator — persistence", () => {
     vi.clearAllMocks();
     const fsp = await import("node:fs/promises");
     const fsm = await import("node:fs");
-    mockWriteFile = fsp.writeFile as unknown as MockInstance;
+    // writeFileAtomic helper uses `fs.promises.writeFile` (via the
+    // namespace import of node:fs), not the standalone node:fs/promises
+    // module — so read the mock from the `node:fs` namespace's promises.
+    mockWriteFile = ((fsm.default as { promises: Record<string, MockInstance> })
+      .promises.writeFile ?? fsp.writeFile) as MockInstance;
     mockReadFile = fsp.readFile as unknown as MockInstance;
     mockWriteFileSync = (fsm.default as unknown as Record<string, MockInstance>)
       .writeFileSync;

--- a/src/__tests__/claudeOrchestrator.test.ts
+++ b/src/__tests__/claudeOrchestrator.test.ts
@@ -324,8 +324,9 @@ describe("ClaudeOrchestrator — persistence", () => {
     // writeFileAtomic helper uses `fs.promises.writeFile` (via the
     // namespace import of node:fs), not the standalone node:fs/promises
     // module — so read the mock from the `node:fs` namespace's promises.
-    mockWriteFile = ((fsm.default as { promises: Record<string, MockInstance> })
-      .promises.writeFile ?? fsp.writeFile) as MockInstance;
+    mockWriteFile = ((
+      fsm.default as unknown as { promises: Record<string, MockInstance> }
+    ).promises.writeFile ?? fsp.writeFile) as MockInstance;
     mockReadFile = fsp.readFile as unknown as MockInstance;
     mockWriteFileSync = (fsm.default as unknown as Record<string, MockInstance>)
       .writeFileSync;

--- a/src/activityLog.ts
+++ b/src/activityLog.ts
@@ -19,6 +19,7 @@ import {
   computeStats,
   computeWindowedStats,
 } from "./fp/activityAnalytics.js";
+import { writeFileAtomic } from "./writeFileAtomic.js";
 
 function escapeLabelValue(s: string): string {
   return s.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\n/g, "\\n");
@@ -183,7 +184,7 @@ export class ActivityLog {
         lines = lines.slice(-Math.max(1, Math.floor(lines.length / 2)));
         joined = lines.join("\n");
       }
-      await fs.promises.writeFile(this.persistPath, `${lines.join("\n")}\n`, {
+      await writeFileAtomic(this.persistPath, `${lines.join("\n")}\n`, {
         mode: 0o600,
       });
     } catch (err) {

--- a/src/claudeOrchestrator.ts
+++ b/src/claudeOrchestrator.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import fs from "node:fs";
-import { readFile, writeFile } from "node:fs/promises";
+import { readFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import {
   isAbsolute as isAbsolutePath,
@@ -14,6 +14,7 @@ function getConfigDir(): string {
 }
 
 import type { IClaudeDriver } from "./drivers/types.js";
+import { writeFileAtomic, writeFileAtomicSync } from "./writeFileAtomic.js";
 
 export type TaskStatus =
   | "pending"
@@ -559,9 +560,13 @@ export class ClaudeOrchestrator {
       savedAt: Date.now(),
       tasks: this._buildTasksPayload(),
     };
-    await writeFile(filePath, JSON.stringify(payload, null, 2), "utf-8");
-    // Restrict to owner-only — prompts may contain sensitive code or secrets
-    await fs.promises.chmod(filePath, 0o600);
+    // Atomic write — temp+rename — so a crash mid-write can't truncate
+    // tasks file and lose the re-enqueue contract. mode 0o600 owner-only
+    // (prompts may contain sensitive code or secrets).
+    await writeFileAtomic(filePath, JSON.stringify(payload, null, 2), {
+      encoding: "utf-8",
+      mode: 0o600,
+    });
   }
 
   /** Synchronous flush called during shutdown — captures tasks at their true
@@ -575,8 +580,13 @@ export class ClaudeOrchestrator {
         savedAt: Date.now(),
         tasks: this._buildTasksPayload(),
       };
-      fs.writeFileSync(filePath, JSON.stringify(payload, null, 2), "utf-8");
-      fs.chmodSync(filePath, 0o600);
+      // SIGTERM mid-write was the worst-case for non-atomic write — a
+      // truncated tasks file means loadPersistedTasks silently swallows
+      // the parse error and all interrupted-run tasks are lost.
+      writeFileAtomicSync(filePath, JSON.stringify(payload, null, 2), {
+        encoding: "utf-8",
+        mode: 0o600,
+      });
     } catch {
       /* best-effort */
     }

--- a/src/commitIssueLinkLog.ts
+++ b/src/commitIssueLinkLog.ts
@@ -1,12 +1,7 @@
-import {
-  appendFileSync,
-  mkdirSync,
-  readFileSync,
-  statSync,
-  writeFileSync,
-} from "node:fs";
+import { appendFileSync, mkdirSync, readFileSync, statSync } from "node:fs";
 import path from "node:path";
 import type { Logger } from "./logger.js";
+import { writeFileAtomicSync } from "./writeFileAtomic.js";
 
 /**
  * CommitIssueLinkLog — persistent audit trail of every commit→issue link
@@ -229,7 +224,7 @@ export class CommitIssueLinkLog {
         lines = [];
         joined = "";
       }
-      writeFileSync(this.file, joined.length > 0 ? `${joined}\n` : "", {
+      writeFileAtomicSync(this.file, joined.length > 0 ? `${joined}\n` : "", {
         mode: 0o600,
       });
     } catch (err) {

--- a/src/connectors/slack.ts
+++ b/src/connectors/slack.ts
@@ -13,15 +13,10 @@
  */
 
 import crypto from "node:crypto";
-import {
-  existsSync,
-  mkdirSync,
-  readFileSync,
-  unlinkSync,
-  writeFileSync,
-} from "node:fs";
+import { existsSync, mkdirSync, readFileSync, unlinkSync } from "node:fs";
 import { homedir } from "node:os";
 import path from "node:path";
+import { writeFileAtomicSync } from "../writeFileAtomic.js";
 import { escHtml } from "./htmlEscape.js";
 import {
   deleteSecretJsonSync,
@@ -142,7 +137,7 @@ export function isConnected(): boolean {
 function saveState(state: string): void {
   const statePath = getStatePath();
   mkdirSync(path.dirname(statePath), { recursive: true, mode: 0o700 });
-  writeFileSync(statePath, JSON.stringify({ state, ts: Date.now() }), {
+  writeFileAtomicSync(statePath, JSON.stringify({ state, ts: Date.now() }), {
     mode: 0o600,
   });
 }

--- a/src/featureFlags.ts
+++ b/src/featureFlags.ts
@@ -8,10 +8,11 @@
  *   - Per-feature opt-in with default-off safety
  */
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync } from "node:fs";
 import os from "node:os";
 import { join } from "node:path";
 import { watchDirectoryWithFallback } from "./fsWatchWithFallback.js";
+import { writeFileAtomicSync } from "./writeFileAtomic.js";
 
 /** Flag definition */
 export interface FeatureFlag {
@@ -277,7 +278,7 @@ function persistFlags(): void {
     }
   }
 
-  writeFileSync(path, JSON.stringify(toSave, null, 2));
+  writeFileAtomicSync(path, JSON.stringify(toSave, null, 2));
 }
 
 // ============================================================================

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,6 +62,7 @@ import {
 } from "./installGuard.js";
 import { PACKAGE_VERSION, semverGt } from "./version.js";
 import { ensureCmdShim } from "./winShim.js";
+import { writeFileAtomicSync } from "./writeFileAtomic.js";
 
 const __dirnameTop = path.dirname(fileURLToPath(import.meta.url));
 
@@ -3345,7 +3346,12 @@ Steps performed:
         type: "stdio",
       };
       claudeJson.mcpServers = mcpServers;
-      writeFileSync(claudeJsonAbs, `${JSON.stringify(claudeJson, null, 2)}\n`);
+      // Atomic — `~/.claude.json` holds every MCP server registration on
+      // the machine. A crash mid-write would brick Claude Code globally.
+      writeFileAtomicSync(
+        claudeJsonAbs,
+        `${JSON.stringify(claudeJson, null, 2)}\n`,
+      );
       process.stderr.write(
         `  ✓ MCP shim — registered in ${claudeJsonAbs}\n     Note: bridge tools are wired via ~/.claude.json (global), not .mcp.json.\n     This is intentional — when VS Code/Windsurf/Cursor launches Claude Code it\n     injects --mcp-config which overrides any project .mcp.json. Only ~/.claude.json\n     is always loaded. You do not need to add anything to .mcp.json.\n\n`,
       );
@@ -3417,7 +3423,12 @@ Steps performed:
     }
     if (added.length > 0 || migrated.length > 0) {
       ccSettings.hooks = ccHooks;
-      writeFileSync(ccSettingsPath, `${JSON.stringify(ccSettings, null, 2)}\n`);
+      // Atomic — `~/.claude/settings.json` holds every CC hook entry; a
+      // crash mid-write loses the user's full hook configuration.
+      writeFileAtomicSync(
+        ccSettingsPath,
+        `${JSON.stringify(ccSettings, null, 2)}\n`,
+      );
       const addMsg =
         added.length > 0
           ? `  ✓ CC hooks — wired ${added.length} automation hook(s) in ${ccSettingsPath}\n     Added: ${added.join(", ")}\n`

--- a/src/patchworkConfig.ts
+++ b/src/patchworkConfig.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import type { ModelChoice } from "./adapters/index.js";
@@ -7,6 +7,7 @@ import {
   getSecretJsonSync,
   storeSecretJsonSync,
 } from "./connectors/tokenStorage.js";
+import { writeFileAtomicSync } from "./writeFileAtomic.js";
 
 export interface PatchworkConfig {
   model: ModelChoice;
@@ -183,7 +184,9 @@ export function loadConfig(path = defaultConfigPath()): PatchworkConfig {
       const stripped = { ...parsed };
       delete (stripped as Partial<PatchworkConfig>).apiKeys;
       try {
-        writeFileSync(path, JSON.stringify(stripped, null, 2), { mode: 0o600 });
+        writeFileAtomicSync(path, JSON.stringify(stripped, null, 2), {
+          mode: 0o600,
+        });
       } catch {
         // Read-only filesystem or permissions error — non-fatal; secure
         // store now holds a copy, plaintext stays on disk until next save.
@@ -211,7 +214,9 @@ export function saveConfig(
   // we won't round-trip it back to plaintext JSON.
   const stripped: PatchworkConfig = { ...config };
   delete stripped.apiKeys;
-  writeFileSync(path, JSON.stringify(stripped, null, 2), { mode: 0o600 });
+  writeFileAtomicSync(path, JSON.stringify(stripped, null, 2), {
+    mode: 0o600,
+  });
 }
 
 export function validateModelChoice(value: string): value is ModelChoice {

--- a/src/preToolUseHook.ts
+++ b/src/preToolUseHook.ts
@@ -1,6 +1,7 @@
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { writeFileAtomicSync } from "./writeFileAtomic.js";
 
 /**
  * Register the Patchwork PreToolUse approval hook in Claude Code's
@@ -64,7 +65,10 @@ export function registerPreToolUseHook(
     });
     allHooks[HOOK_EVENT] = entries;
     ccSettings.hooks = allHooks;
-    writeFileSync(ccSettingsPath, `${JSON.stringify(ccSettings, null, 2)}\n`);
+    writeFileAtomicSync(
+      ccSettingsPath,
+      `${JSON.stringify(ccSettings, null, 2)}\n`,
+    );
     return { action: "added", path: ccSettingsPath, hookCommand };
   } catch (err) {
     return {

--- a/src/recipes/idempotencyKey.ts
+++ b/src/recipes/idempotencyKey.ts
@@ -46,10 +46,10 @@ import {
   mkdirSync,
   readFileSync,
   statSync,
-  writeFileSync,
 } from "node:fs";
 import path from "node:path";
 import type { Logger } from "../logger.js";
+import { writeFileAtomicSync } from "../writeFileAtomic.js";
 
 /**
  * Stable canonical-JSON serialiser. Recursively sorts object keys so two
@@ -364,12 +364,10 @@ export class WriteEffectLedger {
       if (lines.length > MAX_PERSIST_LINES) {
         lines = lines.slice(-MAX_PERSIST_LINES);
       }
-      writeFileSync(
+      writeFileAtomicSync(
         this.file,
         lines.length > 0 ? `${lines.join("\n")}\n` : "",
-        {
-          mode: 0o600,
-        },
+        { mode: 0o600 },
       );
     } catch (err) {
       this.disk.logger?.warn?.(

--- a/src/tools/handoffNote.ts
+++ b/src/tools/handoffNote.ts
@@ -2,6 +2,7 @@ import crypto from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { writeFileAtomicSync } from "../writeFileAtomic.js";
 import { error, successStructured } from "./utils.js";
 
 function getGlobalNotePath(configDir: string): string {
@@ -151,7 +152,7 @@ export async function writeNote(
     : getGlobalNotePath(dir);
 
   fs.mkdirSync(path.dirname(primaryPath), { recursive: true, mode: 0o700 });
-  fs.writeFileSync(primaryPath, contentJson, { mode: 0o600 });
+  writeFileAtomicSync(primaryPath, contentJson, { mode: 0o600 });
 
   // Invalidate cache so next read reflects the new value immediately.
   invalidateCachedNote(primaryPath);


### PR DESCRIPTION
## Summary

Generalizes the `writeFileAtomic` helper from #576 across the state-file writers flagged in the 2026-05-17 audit. Same pattern (temp + rename); each site was using direct `writeFile` / `writeFileSync`.

**Stacked on #576.** Merge that first; this PR's base is `fix/atomic-write-edit-tools`.

### Bridge sites (10)

| File | What it persists | Worst case if torn |
|---|---|---|
| `src/commitIssueLinkLog.ts` | commit↔issue audit trail | history loss (sibling of decisionTraceLog/runLog fixed in #567 — missed) |
| `src/recipes/idempotencyKey.ts` | WriteEffectLedger | **recipe side-effect replay** (resend emails, repost Slack, double-charge) |
| `src/featureFlags.ts` | kill-switch state | silent disengage (loadFlags returns defaults on parse fail) |
| `src/claudeOrchestrator.ts` (×2) | orchestrator tasks | **SIGTERM-during-shutdown loses every queued + interrupted task** |
| `src/index.ts` (×2) | `~/.claude.json` + `~/.claude/settings.json` | brick every MCP integration / CC hook entry on the machine |
| `src/preToolUseHook.ts` | `~/.claude/settings.json` | same as above |
| `src/tools/handoffNote.ts` | cross-session memory | next session has no context |
| `src/patchworkConfig.ts` (×2) | user config + apiKey migration | L186 case: crash post-migration leaves both secure-store AND plaintext |
| `src/activityLog.ts` | rotated activity log | history loss |
| `src/connectors/slack.ts` | Slack OAuth CSRF state | callback fails (UX hiccup) |

### Dashboard site

- `dashboard/src/lib/pushStore.ts` — torn store + `load()`'s catch-all = **every push subscription silently wiped on next boot**. Inlined temp+rename here rather than reaching back into bridge `src/` (separate package).

## Test plan

- [x] `claudeOrchestrator.test.ts` mocks extended (`rename` + nested `promises` namespace) so atomic helper's temp-then-rename flow completes under mock.
- [x] Full bridge suite: **5480 pass / 2 skipped** (unchanged from #576).
- [x] `pushStore.test.ts`: 9/9 pass.
- [x] `npx tsc -p tsconfig.json --noEmit` clean.
- [x] Dashboard `npx tsc --noEmit` clean.

## PR sequence

#572 → #573 → #574 → #575 → #576 → #577 → **this**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)