### PR TITLE
fix(marketplace): tier-0 cleanups from 2026-05-17 audit

### DIFF
--- a/dashboard/src/app/marketplace/[...slug]/InstallPanel.tsx
+++ b/dashboard/src/app/marketplace/[...slug]/InstallPanel.tsx
@@ -34,7 +34,10 @@ interface Props {
 // fixed this on the browse view; this panel was missed in that wave.
 type BridgeStatus = "checking" | "online" | "offline" | "unauth";
 
-const POLL_TIMEOUT_MS = 1500;
+// Browse view uses 4s for the registry probe; the install panel was
+// using 1.5s which produced false-negative "No local bridge detected"
+// banners on slow loopback / cold-start. Align with browse.
+const POLL_TIMEOUT_MS = 4000;
 
 export default function InstallPanel({
   install,
@@ -197,7 +200,7 @@ export default function InstallPanel({
         )}
         {!isInstalled && bridgeStatus === "unauth" && (
           <Link
-            href="/login?next=/dashboard/marketplace"
+            href={`/login?next=/dashboard/marketplace/${name}`}
             className="btn sm"
             style={{ textDecoration: "none", flexShrink: 0 }}
           >

--- a/dashboard/src/app/marketplace/bundle/[...slug]/BundleInstallPanel.tsx
+++ b/dashboard/src/app/marketplace/bundle/[...slug]/BundleInstallPanel.tsx
@@ -135,13 +135,23 @@ export default function BundleInstallPanel({
       });
       const body = (await res.json()) as BundleInstallResponse;
       setResult(body);
-      if (!res.ok && (!body.installed || body.installed.length === 0)) {
+      // Render the headline by partial-completion AND by HTTP status:
+      //   - !res.ok with no installed items → full failure (red banner).
+      //   - !res.ok with SOME installed items → partial (also surface
+      //     the bridge error message — pre-fix this branch silently fell
+      //     through to the green "Installed N" headline despite the 5xx).
+      //   - res.ok → success path; bump the counter.
+      const hasInstalled = !!body.installed && body.installed.length > 0;
+      if (!res.ok) {
         if (res.status === 401) setBridgeStatus("unauth");
         else if (res.status >= 500) setBridgeStatus("offline");
         setErr(body.error ?? `Install failed (HTTP ${res.status})`);
-      } else if (body.installed && body.installed.length > 0) {
-        // Refresh the installed-count headline so the "X of Y already
-        // installed" line catches up with the just-completed install.
+        // Still bump the count when partial — those recipes ARE
+        // installed even if the bundle as a whole errored.
+        if (hasInstalled) {
+          setInstalledCount((prev) => prev + body.installed!.length);
+        }
+      } else if (hasInstalled) {
         setInstalledCount((prev) => prev + body.installed!.length);
       }
     } catch (e) {
@@ -243,7 +253,7 @@ export default function BundleInstallPanel({
         )}
         {!allInstalled && bridgeStatus === "unauth" && (
           <Link
-            href="/login?next=/dashboard/marketplace"
+            href={`/login?next=/dashboard/marketplace/bundle/${name}`}
             className="btn sm"
             style={{ textDecoration: "none", flexShrink: 0 }}
           >

--- a/dashboard/src/app/marketplace/page.tsx
+++ b/dashboard/src/app/marketplace/page.tsx
@@ -348,14 +348,14 @@ function RecipeCard({
             </button>
           ) : bridgeStatus === "unauth" ? (
             <Link
-              href="/login?next=/dashboard/marketplace"
+              href={`/login?next=/dashboard/marketplace/${shortName(recipe.name)}`}
               className="btn sm"
               style={{ textDecoration: "none" }}
               aria-label={`Log in to install ${shortName(recipe.name)}`}
             >
               Log in
             </Link>
-          ) : (
+          ) : bridgeStatus === "offline" ? (
             <a
               href="https://patchworkos.com/#install"
               target="_blank"
@@ -366,6 +366,18 @@ function RecipeCard({
             >
               Get Patchwork
             </a>
+          ) : (
+            // bridgeStatus === "checking" — render no action while the
+            // first probe is in flight; switching to a real CTA happens
+            // when refreshInstalled resolves.
+            <span
+              aria-hidden="true"
+              style={{
+                display: "inline-block",
+                width: 84,
+                height: 28,
+              }}
+            />
           )}
         </div>
       </div>
@@ -450,7 +462,10 @@ function BundleCard({ bundle }: { bundle: RegistryBundle }) {
 
 // ------------------------------------------------------------------ page
 
-type BridgeStatus = "online" | "offline" | "unauth";
+// "checking" is the initial state before the first probe completes —
+// hides the "Install Patchwork OS" banner during page-load instead of
+// flashing it on slow networks (~4s+ on 3G). Matches InstallPanel.tsx.
+type BridgeStatus = "checking" | "online" | "offline" | "unauth";
 
 export default function MarketplacePage() {
   const [registry, setRegistry] = useState<RegistryRecipe[] | null>(null);
@@ -461,7 +476,7 @@ export default function MarketplacePage() {
   // Pre-fix users were told "bridge not connected — install Patchwork
   // OS" when they were just logged out of the dashboard.
   const [bridgeStatus, setBridgeStatus] =
-    useState<BridgeStatus>("offline");
+    useState<BridgeStatus>("checking");
   const [loadErr, setLoadErr] = useState<string | null>(null);
   const [search, setSearch] = useState("");
   const [searchOpen, setSearchOpen] = useState(false);
@@ -680,7 +695,7 @@ export default function MarketplacePage() {
           may be fine) vs "no bridge" (Install Patchwork). Pre-fix both
           collapsed into the "Install Patchwork" CTA, which told logged-
           out users to reinstall a thing they already had. */}
-      {bridgeStatus !== "online" && (
+      {bridgeStatus !== "online" && bridgeStatus !== "checking" && (
         <div
           style={{
             marginBottom: "var(--s-6)",

--- a/dashboard/src/lib/__tests__/installSourceValidation.test.ts
+++ b/dashboard/src/lib/__tests__/installSourceValidation.test.ts
@@ -77,4 +77,36 @@ describe("assertValidInstallSource — defence-in-depth at the call site", () =>
     expect(() => assertValidInstallSource(null as unknown as string)).toThrow();
     expect(() => assertValidInstallSource(42 as unknown as string)).toThrow();
   });
+
+  describe("path-traversal guard (audit 2026-05-17)", () => {
+    it("rejects `..` in the path segment", () => {
+      expect(() =>
+        assertValidInstallSource("github:owner/repo/recipes/../../foo@main"),
+      ).toThrow(/must not contain/);
+    });
+
+    it("rejects bare `..` path", () => {
+      expect(() =>
+        assertValidInstallSource("github:owner/repo/..@main"),
+      ).toThrow(/must not contain/);
+    });
+
+    it("rejects `.` segments", () => {
+      expect(() =>
+        assertValidInstallSource("github:owner/repo/./recipes@main"),
+      ).toThrow(/must not contain/);
+    });
+
+    it("rejects empty segments (double slash)", () => {
+      expect(() =>
+        assertValidInstallSource("github:owner/repo/recipes//foo@main"),
+      ).toThrow(/must not contain/);
+    });
+
+    it("accepts canonical multi-segment paths", () => {
+      expect(() =>
+        assertValidInstallSource("github:owner/repo/recipes/morning-brief@main"),
+      ).not.toThrow();
+    });
+  });
 });

--- a/dashboard/src/lib/__tests__/marketplaceSubmit.test.ts
+++ b/dashboard/src/lib/__tests__/marketplaceSubmit.test.ts
@@ -194,6 +194,38 @@ describe("validateSubmission", () => {
   });
 });
 
+describe("extractYamlName — trailing-comment tolerance (audit 2026-05-17)", () => {
+  it("extracts name with trailing space-comment", () => {
+    expect(extractYamlName("name: morning-brief # primary")).toBe(
+      "morning-brief",
+    );
+  });
+
+  it("extracts name with trailing tab-comment", () => {
+    expect(extractYamlName("name: foo\t# tabbed")).toBe("foo");
+  });
+
+  it("extracts double-quoted name with trailing comment", () => {
+    expect(extractYamlName('name: "morning-brief" # primary')).toBe(
+      "morning-brief",
+    );
+  });
+
+  it("extracts single-quoted name with trailing comment", () => {
+    expect(extractYamlName("name: 'morning-brief' # primary")).toBe(
+      "morning-brief",
+    );
+  });
+
+  it("still extracts a plain name without comment", () => {
+    expect(extractYamlName("name: morning-brief")).toBe("morning-brief");
+  });
+
+  it("returns null when name field is absent", () => {
+    expect(extractYamlName("version: '1.0'")).toBeNull();
+  });
+});
+
 describe("STARTER_RECIPE_YAML", () => {
   it("declares the apiVersion the registry expects", () => {
     expect(STARTER_RECIPE_YAML).toContain("apiVersion: patchwork.sh/v1");

--- a/dashboard/src/lib/marketplaceSubmit.ts
+++ b/dashboard/src/lib/marketplaceSubmit.ts
@@ -169,7 +169,13 @@ export interface ValidationIssue {
  * shape we don't unwrap (rare in practice for recipes).
  */
 export function extractYamlName(yaml: string): string | null {
-  const match = /^name:\s*("([^"]+)"|'([^']+)'|([^\s#]+))\s*$/m.exec(yaml);
+  // Trailing YAML comments (`name: foo # primary`) are valid and common
+  // in production recipes. The previous regex required `\s*$` directly
+  // after the value, so any `# comment` caused a silent null return
+  // (downstream treated as "no name in YAML" — misleading error).
+  // Now allow optional `[\s]*#.*` after the value, before EOL.
+  const match =
+    /^name:\s*("([^"]+)"|'([^']+)'|([^\s#]+))\s*(?:#.*)?$/m.exec(yaml);
   if (!match) return null;
   return match[2] ?? match[3] ?? match[4] ?? null;
 }

--- a/dashboard/src/lib/registry.ts
+++ b/dashboard/src/lib/registry.ts
@@ -172,6 +172,20 @@ export function assertValidInstallSource(install: string): ParsedInstallSource {
       "Invalid install source: must match `github:owner/repo[/path]@ref` (refusing to forward to bridge)",
     );
   }
+  // Reject path-traversal segments (audit 2026-05-17). The bridge's
+  // `parseGithubInstallSource` is strict-segment (charset `[a-z0-9_.-]`),
+  // so `..` would fail server-side anyway — but the dashboard's
+  // "defense-in-depth" promise should fail fast and visibly.
+  if (parsed.path.length > 0) {
+    const dangerousSegment = parsed.path
+      .split("/")
+      .some((seg) => seg === ".." || seg === "." || seg === "");
+    if (dangerousSegment) {
+      throw new Error(
+        "Invalid install source: path segments must not contain '.' or '..' (refusing to forward to bridge)",
+      );
+    }
+  }
   return parsed;
 }
 


### PR DESCRIPTION
## Summary

Six tier-0 findings on the marketplace surface, all small UX/security fixes. Each is independently safe.

| # | What | File |
|---|---|---|
| 1 | Browse-page bridgeStatus flickers \"offline\" during initial load (4s+ on 3G) → add \"checking\" state, hide banner during checking | [marketplace/page.tsx:463](dashboard/src/app/marketplace/page.tsx#L463) |
| 2 | Login `next=` lost recipe/bundle slug on 3 sites → include in URL | [page.tsx:351](dashboard/src/app/marketplace/page.tsx#L351), [InstallPanel.tsx:203](dashboard/src/app/marketplace/[...slug]/InstallPanel.tsx#L203), [BundleInstallPanel.tsx:246](dashboard/src/app/marketplace/bundle/[...slug]/BundleInstallPanel.tsx#L246) |
| 3 | InstallPanel poll timeout 1.5s → 4s (align with browse, fix false-negative \"no bridge\" on slow loopback) | [InstallPanel.tsx:37](dashboard/src/app/marketplace/[...slug]/InstallPanel.tsx#L37) |
| 4 | Bundle install 5xx + `installed[].length > 0` → green \"Installed N\" headline; now surfaces partial-failure correctly | [BundleInstallPanel.tsx:138](dashboard/src/app/marketplace/bundle/[...slug]/BundleInstallPanel.tsx#L138) |
| 5 | `extractYamlName` rejected `name: foo # comment` → downstream silently rendered as \"no name in YAML\" | [marketplaceSubmit.ts:172](dashboard/src/lib/marketplaceSubmit.ts#L172) |
| 6 | `assertValidInstallSource` allowed `..` in path segments — bridge would reject server-side, but the dashboard's defense-in-depth promise should fail fast | [registry.ts:163](dashboard/src/lib/registry.ts#L163) |

## Test plan

- [x] 5 new `extractYamlName` regression cases (4 comment variants + null path)
- [x] 5 new `assertValidInstallSource` traversal cases (`..` mid-path, bare `..`, `.`, empty segment, positive)
- [x] 93/93 pass on the three affected dashboard test files (was 84)
- [x] Full dashboard suite: **519/519** pass
- [x] `npx tsc --noEmit` clean

## PR sequence

#572 → #573 → #574 → #575 → #576 → #577 → #578 → **this**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)