### PR TITLE
fix(windows): P1 sweep — treeKill orphan pids, env whitelist, lockfile EPERM, isAbsolute

### DIFF
--- a/src/__tests__/lockfile.test.ts
+++ b/src/__tests__/lockfile.test.ts
@@ -196,4 +196,48 @@ describe("LockFileManager", () => {
     expect(fs.existsSync(freshPath)).toBe(true); // kept: 23h old
     expect(fs.existsSync(legacyPath)).toBe(true); // kept: no startedAt
   });
+
+  // ─── Foreign-PID EPERM (audit 2026-05-17) ──────────────────────────────────
+  // process.kill(foreignPid, 0) throws EPERM on Windows for live processes
+  // the bridge user lacks permission to signal (different user, higher
+  // integrity). Pre-fix code unconditionally unlinked on ANY kill failure
+  // → wrongly deleted a legitimate sibling's lock. Now: ESRCH unlinks,
+  // EPERM (and other errnos) preserve the lock.
+  it("cleanStale keeps foreign-PID lock when process.kill throws EPERM", () => {
+    const ideDir = path.join(tmpDir, "ide");
+    fs.mkdirSync(ideDir, { recursive: true, mode: 0o700 });
+
+    const foreignLockPath = path.join(ideDir, "33333.lock");
+    const foreignPid = 555555;
+    fs.writeFileSync(foreignLockPath, JSON.stringify({ pid: foreignPid }), {
+      mode: 0o600,
+    });
+
+    // Stub process.kill to throw EPERM for the foreign pid only.
+    const origKill = process.kill;
+    const killStub = ((pid: number, signal?: number | NodeJS.Signals) => {
+      if (pid === foreignPid) {
+        const err = new Error("kill EPERM") as NodeJS.ErrnoException;
+        err.code = "EPERM";
+        throw err;
+      }
+      return origKill(pid, signal);
+    }) as typeof process.kill;
+    // Assign via property descriptor since process.kill is read-only on
+    // some Node builds.
+    Object.defineProperty(process, "kill", {
+      value: killStub,
+      configurable: true,
+    });
+    try {
+      const mgr = new LockFileManager(logger);
+      mgr.cleanStale();
+      expect(fs.existsSync(foreignLockPath)).toBe(true);
+    } finally {
+      Object.defineProperty(process, "kill", {
+        value: origKill,
+        configurable: true,
+      });
+    }
+  });
 });

--- a/src/__tests__/processTree.test.ts
+++ b/src/__tests__/processTree.test.ts
@@ -7,7 +7,7 @@ vi.mock("node:child_process", async (importOriginal) => {
   return { ...original, execFileSync: execFileSyncMock };
 });
 
-const { treeKill } = await import("../processTree.js");
+const { treeKill, treeKillPid } = await import("../processTree.js");
 
 const ORIG_PLATFORM = process.platform;
 function setPlatform(p: NodeJS.Platform) {
@@ -112,6 +112,50 @@ describe("treeKill", () => {
 
     it("no-ops when child already signalled", () => {
       treeKill(fakeChild({ pid: 1234, signalCode: "SIGTERM" }));
+      expect(execFileSyncMock).not.toHaveBeenCalled();
+    });
+  });
+
+  // ─── treeKillPid — bare-pid overload (audit 2026-05-17) ──────────────────
+  describe("treeKillPid", () => {
+    afterEach(() => {
+      setPlatform(ORIG_PLATFORM);
+      execFileSyncMock.mockReset();
+    });
+
+    it("on win32 — invokes taskkill /F /T /PID <pid>", () => {
+      setPlatform("win32");
+      execFileSyncMock.mockImplementationOnce(() => Buffer.from(""));
+      treeKillPid(4242);
+      expect(execFileSyncMock).toHaveBeenCalledWith(
+        "taskkill",
+        ["/F", "/T", "/PID", "4242"],
+        expect.objectContaining({ stdio: "ignore", windowsHide: true }),
+      );
+    });
+
+    it("on win32 — swallows taskkill failure (process already exited)", () => {
+      setPlatform("win32");
+      execFileSyncMock.mockImplementationOnce(() => {
+        throw new Error("not found");
+      });
+      // Must not throw — best-effort semantics.
+      expect(() => treeKillPid(4242)).not.toThrow();
+    });
+
+    it("no-ops on invalid pid (0, NaN, negative)", () => {
+      setPlatform("win32");
+      treeKillPid(0);
+      treeKillPid(-1);
+      treeKillPid(Number.NaN);
+      expect(execFileSyncMock).not.toHaveBeenCalled();
+    });
+
+    it("on posix — does not call taskkill (process.kill is used)", () => {
+      setPlatform("darwin");
+      // process.kill(-pid) on an invalid pid throws; the helper swallows
+      // so the call must complete without error.
+      expect(() => treeKillPid(999_999_999)).not.toThrow();
       expect(execFileSyncMock).not.toHaveBeenCalled();
     });
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,6 +60,7 @@ import {
   PATCHWORK_PACKAGE_NAME,
   SYMLINK_INSTALL_FIX,
 } from "./installGuard.js";
+import { treeKill } from "./processTree.js";
 import { PACKAGE_VERSION, semverGt } from "./version.js";
 import { ensureCmdShim } from "./winShim.js";
 
@@ -4139,7 +4140,12 @@ if (__subcommandWillRun) {
       for (const sig of ["SIGTERM", "SIGINT"] as const) {
         process.once(sig, () => {
           stopping = true;
-          child.kill(sig);
+          // Use treeKill so grandchildren (recipe runners, claude
+          // subprocesses, extension watchers) are reaped on Windows.
+          // Bare `child.kill(sig)` maps to TerminateProcess on win32
+          // and skips descendants → orphaned processes survive a
+          // supervisor SIGTERM. Audit 2026-05-17.
+          treeKill(child, sig);
         });
       }
 

--- a/src/lockfile.ts
+++ b/src/lockfile.ts
@@ -182,11 +182,37 @@ export class LockFileManager {
               }
               // Different live PID → legitimate sibling bridge instance;
               // never delete based on age or nonce alone.
-            } catch {
-              this.logger.warn(
-                `Removing stale lock file: ${file} (PID ${content.pid} not running)`,
-              );
-              fs.unlinkSync(filePath);
+            } catch (killErr) {
+              // On Windows `process.kill(foreignPid, 0)` can throw EPERM
+              // for a LIVE process the bridge user lacks permission to
+              // signal (e.g. lock owned by a different OS user or by a
+              // higher-integrity process). Unconditionally unlinking on
+              // any kill failure would WRONGLY delete a legitimate
+              // foreign sibling's lock. Distinguish:
+              //   - ESRCH → process is gone, remove the lock
+              //   - EPERM on Windows → permission-only, do NOT delete
+              //   - EPERM on POSIX → could be either (kernel doesn't
+              //     distinguish for our pid). Conservative: do nothing
+              //     for foreign pids, only act on our own pid via the
+              //     nonce/age branch above. Audit 2026-05-17.
+              const code = (killErr as NodeJS.ErrnoException).code;
+              if (code === "ESRCH") {
+                this.logger.warn(
+                  `Removing stale lock file: ${file} (PID ${content.pid} not running)`,
+                );
+                fs.unlinkSync(filePath);
+              } else if (code === "EPERM") {
+                this.logger.warn(
+                  `Keeping lock file ${file} — PID ${content.pid} returned EPERM (permission denied; assuming legitimate foreign sibling)`,
+                );
+              } else {
+                // Other errno (rare). Preserve the lock — better to let
+                // a stale-but-foreign lock linger than to wrongly delete
+                // a live sibling's coordination file.
+                this.logger.warn(
+                  `Keeping lock file ${file} — process.kill(${content.pid}, 0) failed with ${code ?? "unknown"}: ${killErr instanceof Error ? killErr.message : String(killErr)}`,
+                );
+              }
             }
           }
         } catch (err) {

--- a/src/processTree.ts
+++ b/src/processTree.ts
@@ -59,3 +59,48 @@ export function treeKill(
     /* already exited */
   }
 }
+
+/**
+ * Kill a process tree by bare pid. Same semantics as `treeKill` but for
+ * callers that only hold a numeric pid (e.g. a child the bridge spawned
+ * with `detached: true; unref()` and let go of the ChildProcess handle).
+ *
+ * On Windows this is the only correct way to reap grandchildren — bare
+ * `process.kill(pid, sig)` maps to `TerminateProcess` which skips them.
+ * On POSIX it best-effort signals the process group (`-pid`) when the
+ * target is a group leader, then falls back to single-pid signal.
+ *
+ * Audit 2026-05-17: spawnWorkspace.ts and the `--watch` supervisor in
+ * src/index.ts both held a foreign-pid handle (no ChildProcess) and
+ * fell back to `process.kill(pid, sig)`. Use this helper instead.
+ */
+export function treeKillPid(
+  pid: number,
+  signal: NodeJS.Signals = "SIGTERM",
+): void {
+  if (!Number.isInteger(pid) || pid <= 0) return;
+
+  if (process.platform === "win32") {
+    try {
+      execFileSync("taskkill", ["/F", "/T", "/PID", String(pid)], {
+        stdio: "ignore",
+        windowsHide: true,
+      });
+    } catch {
+      // Already exited / permission denied / taskkill missing — best-effort.
+    }
+    return;
+  }
+  // POSIX: try process-group kill first (works when target was spawned
+  // detached → setsid → group leader). Fall back to single-pid signal.
+  try {
+    process.kill(-pid, signal);
+  } catch {
+    /* not a group leader */
+  }
+  try {
+    process.kill(pid, signal);
+  } catch {
+    /* already exited */
+  }
+}

--- a/src/tools/__tests__/spawnWorkspace.test.ts
+++ b/src/tools/__tests__/spawnWorkspace.test.ts
@@ -242,7 +242,13 @@ describe("spawnWorkspace handler", () => {
     const parsed = parseText(result);
     expect(parsed.code).toBe("timeout");
     expect(parsed.error).toMatch(/extension did not connect/);
-    expect(killSpy).toHaveBeenCalledWith(pid, "SIGTERM");
+    // POSIX-only: `treeKillPid` calls `process.kill(-pid, sig)` (process
+    // group) and `process.kill(pid, sig)` (single child). On Windows it
+    // shells out to `taskkill /F /T /PID <pid>` and `process.kill`
+    // is never invoked. Covered by `src/__tests__/processTree.test.ts`.
+    if (process.platform !== "win32") {
+      expect(killSpy).toHaveBeenCalledWith(pid, "SIGTERM");
+    }
   });
 
   it("waitForExtension unset: returns without extensionConnected field (back-compat)", async () => {
@@ -365,7 +371,10 @@ describe("spawnWorkspace handler", () => {
     expect(parsed.code).toBe("code_server_missing");
     expect(parsed.error).toMatch(/code-server/);
     // Bridge must be cleaned up when code-server spawn fails.
-    expect(killSpy).toHaveBeenCalledWith(bridgePid, "SIGTERM");
+    // POSIX-only kill-spy check (see treeKillPid Windows note above).
+    if (process.platform !== "win32") {
+      expect(killSpy).toHaveBeenCalledWith(bridgePid, "SIGTERM");
+    }
   });
 
   it("codeServer: honors codeServerBin override", async () => {

--- a/src/tools/detectUnusedCode.ts
+++ b/src/tools/detectUnusedCode.ts
@@ -1,5 +1,5 @@
 import { existsSync } from "node:fs";
-import { join, relative } from "node:path";
+import { isAbsolute, join, relative } from "node:path";
 import type { ProbeResults } from "../probe.js";
 import {
   execSafe,
@@ -189,9 +189,10 @@ function parseTsPruneOutput(output: string, workspace: string): UnusedItem[] {
     const line = Number.parseInt(m[2] ?? "0", 10);
     const symbol = m[3]?.trim() ?? "";
     if (!filePath || !symbol) continue;
-    const rel = filePath.startsWith("/")
-      ? relative(workspace, filePath)
-      : filePath;
+    // Use path.isAbsolute so Windows absolute paths (`C:\...`) take the
+    // relative-to-workspace branch — pre-fix `startsWith("/")` only
+    // matched POSIX absolute paths. Audit 2026-05-17.
+    const rel = isAbsolute(filePath) ? relative(workspace, filePath) : filePath;
     items.push({ file: rel, line, symbol, kind: "export" });
   }
   return items;
@@ -212,9 +213,10 @@ function parseTscOutput(output: string, workspace: string): UnusedItem[] {
     // TS6133 has a quoted symbol (m[4]); TS6192/TS6196 may not (use m[5] as fallback)
     const symbol = (m[4] ?? m[5] ?? "").trim();
     if (!filePath || !symbol) continue;
-    const rel = filePath.startsWith("/")
-      ? relative(workspace, filePath)
-      : filePath;
+    // Use path.isAbsolute so Windows absolute paths (`C:\...`) take the
+    // relative-to-workspace branch — pre-fix `startsWith("/")` only
+    // matched POSIX absolute paths. Audit 2026-05-17.
+    const rel = isAbsolute(filePath) ? relative(workspace, filePath) : filePath;
     const kind: "export" | "local" | "parameter" =
       code === "TS6192" || code === "TS6196" ? "parameter" : "local";
     items.push({ file: rel, line, symbol, kind });

--- a/src/tools/fileWatcher.ts
+++ b/src/tools/fileWatcher.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import {
   type ExtensionClient,
   ExtensionTimeoutError,
@@ -52,8 +53,13 @@ export function createWatchFilesTool(extensionClient: ExtensionClient) {
       if (/[\x00-\x1f]/.test(id) || /[\x00-\x1f]/.test(pattern)) {
         return error("id and pattern must not contain control characters");
       }
-      // Reject patterns that could escape the workspace
+      // Reject patterns that could escape the workspace. Pre-fix only
+      // caught a leading `/` or `\\`, which missed Windows drive-letter
+      // absolutes like `C:\Windows\System32\*.dll`. Use `path.isAbsolute`
+      // (handles both POSIX and Windows shapes) plus the legacy `..` /
+      // backslash-prefix guard for explicit clarity. Audit 2026-05-17.
       if (
+        path.isAbsolute(pattern) ||
         pattern.startsWith("/") ||
         pattern.startsWith("\\") ||
         pattern.includes("..")

--- a/src/tools/previewEdit.ts
+++ b/src/tools/previewEdit.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import path from "node:path";
 import {
   error,
   optionalBool,
@@ -321,8 +322,12 @@ export function createPreviewEditTool(workspace: string) {
       const originalLines = originalContent.split("\n");
       const newLines = newContent.split("\n");
 
-      const relativePath = rawPath.startsWith("/")
-        ? rawPath.slice(workspace.length + 1)
+      // Use path.relative + isAbsolute so Windows absolute paths
+      // (`C:\...`) are handled. Pre-fix `startsWith("/")` only matched
+      // POSIX absolute paths; on Windows the slice produced corrupt
+      // output (separator mismatch). Audit 2026-05-17.
+      const relativePath = path.isAbsolute(rawPath)
+        ? path.relative(workspace, rawPath)
         : rawPath;
 
       const { diff, linesAdded, linesRemoved } = computeUnifiedDiff(

--- a/src/tools/spawnWorkspace.ts
+++ b/src/tools/spawnWorkspace.ts
@@ -5,6 +5,7 @@ import { homedir } from "node:os";
 import path from "node:path";
 import type { ToolResult } from "../fp/result.js";
 import { err, okS, toCallToolResult } from "../fp/result.js";
+import { treeKillPid } from "../processTree.js";
 import { ensureCmdShim } from "../winShim.js";
 
 export interface SpawnWorkspaceResult {
@@ -298,7 +299,7 @@ async function spawnWorkspace(
         } catch (e) {
           // Clean up the bridge we just spawned before reporting.
           try {
-            process.kill(pid, "SIGTERM");
+            treeKillPid(pid, "SIGTERM");
           } catch {
             /* ignore */
           }
@@ -334,13 +335,13 @@ async function spawnWorkspace(
 
       // Lock appeared but extension never connected — kill child + timeout.
       try {
-        process.kill(pid, "SIGTERM");
+        treeKillPid(pid, "SIGTERM");
       } catch {
         // already exited
       }
       if (codeServerPid !== undefined) {
         try {
-          process.kill(codeServerPid, "SIGTERM");
+          treeKillPid(codeServerPid, "SIGTERM");
         } catch {
           // already exited
         }
@@ -359,7 +360,7 @@ async function spawnWorkspace(
 
   // Timed out — kill the child
   try {
-    process.kill(pid, "SIGTERM");
+    treeKillPid(pid, "SIGTERM");
   } catch {
     // ignore — already exited
   }

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -495,6 +495,19 @@ export async function execSafe(
       RUSTUP_HOME: process.env.RUSTUP_HOME,
       GOPATH: process.env.GOPATH,
       GOROOT: process.env.GOROOT,
+      // Windows-essential env vars (audit 2026-05-17). Without these,
+      // git can't find ~/.gitconfig (uses %USERPROFILE%), gh can't find
+      // its config (uses %APPDATA%), executables can't be resolved
+      // without %PATHEXT%, and many `.exe` invocations fail without
+      // %SYSTEMROOT% for DLL search. No-op on POSIX (all undefined).
+      USERPROFILE: process.env.USERPROFILE,
+      APPDATA: process.env.APPDATA,
+      LOCALAPPDATA: process.env.LOCALAPPDATA,
+      USERNAME: process.env.USERNAME,
+      SYSTEMROOT: process.env.SYSTEMROOT,
+      PATHEXT: process.env.PATHEXT,
+      COMSPEC: process.env.COMSPEC,
+      WINDIR: process.env.WINDIR,
       // Allow caller to extend with additional vars
       ...opts.env,
     };
@@ -598,6 +611,15 @@ export async function execSafeStreaming(
     RUSTUP_HOME: process.env.RUSTUP_HOME,
     GOPATH: process.env.GOPATH,
     GOROOT: process.env.GOROOT,
+    // Windows-essential env (audit 2026-05-17 — see execSafe above)
+    USERPROFILE: process.env.USERPROFILE,
+    APPDATA: process.env.APPDATA,
+    LOCALAPPDATA: process.env.LOCALAPPDATA,
+    USERNAME: process.env.USERNAME,
+    SYSTEMROOT: process.env.SYSTEMROOT,
+    PATHEXT: process.env.PATHEXT,
+    COMSPEC: process.env.COMSPEC,
+    WINDIR: process.env.WINDIR,
     ...opts.env,
   };
   for (const k of Object.keys(minimalEnv)) {


### PR DESCRIPTION
## Summary

Six Windows-affecting bugs from the 2026-05-17 P1 audit.

### Tree-kill for bare-pid callers
[src/processTree.ts](src/processTree.ts) adds `treeKillPid(pid, sig)` — same semantics as `treeKill(child, sig)` but accepts a numeric pid. Bare `process.kill(pid, sig)` on Windows maps to `TerminateProcess` which skips descendants. Sites converted:

- [spawnWorkspace.ts](src/tools/spawnWorkspace.ts) ×4 (bridge + code-server pids; timeout / no-extension / cleanup paths)
- [index.ts](src/index.ts) — `--watch` supervisor uses `treeKill(child, sig)`

### execSafe env whitelist missing Windows essentials
[utils.ts](src/tools/utils.ts) `execSafe` + `execSafeStreaming` — added `USERPROFILE`, `APPDATA`, `LOCALAPPDATA`, `USERNAME`, `SYSTEMROOT`, `PATHEXT`, `COMSPEC`, `WINDIR`. Without these git couldn't find `~/.gitconfig` (uses `%USERPROFILE%`), gh couldn't find its config (`%APPDATA%`), and many `.exe` invocations failed without `%PATHEXT%` / `%SYSTEMROOT%`.

### lockfile.cleanStale wrongly deleted live foreign locks on EPERM
[lockfile.ts](src/lockfile.ts) — `process.kill(foreignPid, 0)` on Windows throws EPERM for live processes the bridge user lacks permission to signal. Pre-fix catch unconditionally unlinked on ANY kill failure → wrongly deleted a legitimate sibling's coordination file. Now distinguishes:
- ESRCH → process gone, unlink
- EPERM → permission-only, keep
- other → conservatively keep + log

### path.isAbsolute() replaces startsWith("/")
Three tools used `startsWith("/")` to detect absolute paths — only matches POSIX, falls through for `C:\...`:
- [detectUnusedCode.ts](src/tools/detectUnusedCode.ts) ×2 (parseEslintOutput + parseTscOutput)
- [previewEdit.ts](src/tools/previewEdit.ts) — also fixed broken `slice(workspace.length+1)` (separator mismatch on Windows); replaced with `path.relative`
- [fileWatcher.ts](src/tools/fileWatcher.ts) — escape-guard missed drive-letter absolutes, bypassing workspace-confine (security-adjacent)

## Test plan

- [x] 4 new `treeKillPid` cases (win32 taskkill argv shape, swallow on failure, invalid-pid guard, posix path)
- [x] 1 new lockfile case (foreign-PID + EPERM → lock preserved)
- [x] 66 pass on the 6 affected test files
- [x] Full bridge suite: **5474 pass / 2 skipped** (one pre-existing fs.watch flake; passes on re-run)
- [x] `npx tsc -p tsconfig.json --noEmit` clean

## PR sequence

#572 → #573 → #574 → #575 → #576 → #577 → #578 → #579 → #580 → #581 → **this**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)