### PR TITLE
fix(logs): cross-process flock around JSONL appends (closes ADR-0007 write half)

### DIFF
--- a/src/__tests__/fileLockSync.test.ts
+++ b/src/__tests__/fileLockSync.test.ts
@@ -1,0 +1,114 @@
+import {
+  appendFileSync,
+  existsSync,
+  mkdtempSync,
+  openSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { withFileLockSync } from "../fileLockSync.js";
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(path.join(tmpdir(), "patchwork-flock-"));
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("withFileLockSync", () => {
+  it("runs the critical section and returns its value", () => {
+    const target = path.join(dir, "log.jsonl");
+    const result = withFileLockSync(target, () => "ok");
+    expect(result).toBe("ok");
+  });
+
+  it("creates and removes the sentinel lock file around the call", () => {
+    const target = path.join(dir, "log.jsonl");
+    const lockPath = `${target}.lock`;
+    let observedLockExists = false;
+    withFileLockSync(target, () => {
+      observedLockExists = existsSync(lockPath);
+    });
+    expect(observedLockExists).toBe(true);
+    expect(existsSync(lockPath)).toBe(false);
+  });
+
+  it("releases the lock even when the critical section throws", () => {
+    const target = path.join(dir, "log.jsonl");
+    const lockPath = `${target}.lock`;
+    expect(() =>
+      withFileLockSync(target, () => {
+        throw new Error("boom");
+      }),
+    ).toThrow(/boom/);
+    expect(existsSync(lockPath)).toBe(false);
+  });
+
+  it("blocks a held lock until timeoutMs and then throws", () => {
+    const target = path.join(dir, "log.jsonl");
+    const lockPath = `${target}.lock`;
+    // Simulate a stuck (live) lock by manually creating the sentinel.
+    closeSyncFd(openSync(lockPath, "wx", 0o600));
+    // Stamp it as recent so it doesn't trigger the stale-lock path.
+    writeFileSync(lockPath, ""); // mtime=now
+    const start = Date.now();
+    expect(() =>
+      withFileLockSync(target, () => "never", {
+        timeoutMs: 50,
+        staleLockMs: 60_000,
+      }),
+    ).toThrow(/timed out/);
+    const elapsed = Date.now() - start;
+    expect(elapsed).toBeGreaterThanOrEqual(40); // allow a bit of slack
+    // Lock file we manually created is still there (our timeout doesn't
+    // try to remove someone else's lock).
+    expect(existsSync(lockPath)).toBe(true);
+  });
+
+  it("force-unlinks a stale lock and then acquires it", () => {
+    const target = path.join(dir, "log.jsonl");
+    const lockPath = `${target}.lock`;
+    closeSyncFd(openSync(lockPath, "wx", 0o600));
+    // Age the file artificially via utimesSync-equivalent. Easiest:
+    // pass staleLockMs=0 so any existing lock is treated as stale.
+    const result = withFileLockSync(target, () => "acquired", {
+      staleLockMs: 0,
+      timeoutMs: 1_000,
+    });
+    expect(result).toBe("acquired");
+    expect(existsSync(lockPath)).toBe(false);
+  });
+
+  it("serializes interleaved sync appends from the same process", () => {
+    // Two synchronous callers under the same lock must produce a
+    // well-formed JSONL file. (Cross-process interleaving is what the
+    // helper actually defends against, but a sync test inside one
+    // process is the closest deterministic exercise we can write.)
+    const target = path.join(dir, "log.jsonl");
+    for (let i = 0; i < 50; i++) {
+      withFileLockSync(target, () => {
+        appendFileSync(target, `${JSON.stringify({ i })}\n`, { mode: 0o600 });
+      });
+    }
+    const raw = readFileSync(target, "utf-8").trim().split("\n");
+    expect(raw).toHaveLength(50);
+    for (let i = 0; i < 50; i++) {
+      expect(JSON.parse(raw[i] ?? "")).toEqual({ i });
+    }
+  });
+});
+
+// Helper — tiny shim so we don't need to import closeSync into the
+// top-level alongside openSync (keeps the imports list minimal).
+function closeSyncFd(fd: number): void {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { closeSync } = require("node:fs") as typeof import("node:fs");
+  closeSync(fd);
+}

--- a/src/commitIssueLinkLog.ts
+++ b/src/commitIssueLinkLog.ts
@@ -6,6 +6,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import path from "node:path";
+import { withFileLockSync } from "./fileLockSync.js";
 import type { Logger } from "./logger.js";
 
 /**
@@ -195,7 +196,12 @@ export class CommitIssueLinkLog {
         const code = (err as NodeJS.ErrnoException).code;
         if (code !== "ENOENT") throw err;
       }
-      appendFileSync(this.file, `${JSON.stringify(link)}\n`, { mode: 0o600 });
+      // Per-file lock — ADR-0007 multi-bridge concurrency. See the
+      // matching block in src/decisionTraceLog.ts for the full
+      // rationale; same pattern.
+      withFileLockSync(this.file, () => {
+        appendFileSync(this.file, `${JSON.stringify(link)}\n`, { mode: 0o600 });
+      });
     } catch (err) {
       this.opts.logger?.warn?.(
         `[linklog] append failed: ${err instanceof Error ? err.message : String(err)}`,

--- a/src/decisionTraceLog.ts
+++ b/src/decisionTraceLog.ts
@@ -7,6 +7,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import path from "node:path";
+import { withFileLockSync } from "./fileLockSync.js";
 import type { Logger } from "./logger.js";
 
 /**
@@ -187,7 +188,18 @@ export class DecisionTraceLog {
         const code = (err as NodeJS.ErrnoException).code;
         if (code !== "ENOENT") throw err;
       }
-      appendFileSync(this.file, `${JSON.stringify(trace)}\n`, { mode: 0o600 });
+      // Lock the file across the single appendFileSync call. ADR-0007:
+      // two bridges sharing $HOME can interleave bytes within a single
+      // JSONL row on apfs / ext4 (POSIX append-atomicity is not a
+      // contract for sub-page writes). The torn line then fails
+      // JSON.parse → row silently skipped on every reader. The lock
+      // bounds the critical section to <1ms in practice; contention at
+      // the bridge's write volume (≤ tens/min) is negligible.
+      withFileLockSync(this.file, () => {
+        appendFileSync(this.file, `${JSON.stringify(trace)}\n`, {
+          mode: 0o600,
+        });
+      });
     } catch (err) {
       this.opts.logger?.warn?.(
         `[dtrace-log] append failed: ${err instanceof Error ? err.message : String(err)}`,

--- a/src/fileLockSync.ts
+++ b/src/fileLockSync.ts
@@ -1,0 +1,128 @@
+import { closeSync, openSync, statSync, unlinkSync } from "node:fs";
+
+/**
+ * Tiny cross-process file mutex for synchronous critical sections.
+ *
+ * Used to wrap append-only JSONL writers (`decisionTraceLog`,
+ * `runLog`, `commitIssueLinkLog`) so two bridge processes sharing
+ * one `~/.claude/ide/` log directory can't interleave bytes within a
+ * single row.
+ *
+ * Why ad-hoc instead of `proper-lockfile`? proper-lockfile is the more
+ * featureful option (TTL refresh, retry jitter, async API) but adds a
+ * runtime dependency for a use case the bridge needs only synchronously
+ * in three call-sites. The pattern below — `openSync(file, "wx")` as
+ * the atomic lock primitive plus a stale-lock cleanup heuristic — is
+ * standard for shell-style flock without a native binding.
+ *
+ * ## Semantics
+ *
+ * `withFileLockSync(file, fn)`:
+ *
+ *   1. Attempts to create `${file}.lock` with `O_EXCL` (`flag: "wx"`).
+ *      First writer wins atomically — the kernel rejects EEXIST for
+ *      every other contender.
+ *   2. On EEXIST, polls with a short busy-wait (`Atomics.wait` would
+ *      need a shared SharedArrayBuffer across processes — out of scope;
+ *      hot-loop with `process.hrtime` instead, kernels schedule sleep
+ *      anyway under contention).
+ *   3. If the existing lock is older than `staleLockMs` (default 30s),
+ *      assumes the owner crashed and force-unlinks it before retrying.
+ *      The append-only JSONL writes the bridge does complete in <1ms in
+ *      practice, so 30s is generous.
+ *   4. Runs `fn()`, unlinks the lock in `finally`. Rethrows fn's
+ *      exception.
+ *
+ * Lock granularity is per-file (each log gets its own lock). At the
+ * bridge's write volume (≤ tens/min across all three logs) contention
+ * is effectively zero.
+ *
+ * ## Failure modes
+ *
+ * - **Deadlock-on-crash:** mitigated by the 30s stale-lock TTL. A bridge
+ *   that crashes mid-append leaves the lock until the next contender
+ *   notices it's stale and clears it. The first crash is invisible
+ *   (target file already written); subsequent contenders pay a 30s
+ *   penalty only if they happen to arrive within the window.
+ * - **TOCTOU on stale-lock unlink:** two processes both decide the lock
+ *   is stale and both `unlinkSync`. Second `unlinkSync` ENOENT is
+ *   swallowed. Both then race the `openSync("wx")` — one wins, the
+ *   other goes back to polling. No data corruption.
+ * - **NFS / non-POSIX FS:** O_EXCL is undefined on stale NFSv2; modern
+ *   NFS (≥ v3 with `noac`) and all local FS we ship on (apfs / ext4 /
+ *   ntfs) implement it correctly.
+ *
+ * @param file - The target file the caller is about to write. The lock
+ *   sentinel is `${file}.lock`.
+ * @param fn - Synchronous critical section. Holds the lock for its
+ *   entire duration.
+ * @param opts.timeoutMs - Max wait for the lock before throwing (default
+ *   5000). Use a small value — appends finish in <1ms in practice; a
+ *   timeout this far above the expected duration only fires if
+ *   something genuinely wrong happens.
+ * @param opts.staleLockMs - Age (ms) at which an existing lock is
+ *   considered abandoned and force-unlinked. Default 30000.
+ */
+export function withFileLockSync<T>(
+  file: string,
+  fn: () => T,
+  opts: { timeoutMs?: number; staleLockMs?: number } = {},
+): T {
+  const lockFile = `${file}.lock`;
+  const timeoutMs = opts.timeoutMs ?? 5000;
+  const staleLockMs = opts.staleLockMs ?? 30_000;
+  const deadline = Date.now() + timeoutMs;
+
+  let lockFd: number | null = null;
+  while (lockFd === null) {
+    try {
+      // O_EXCL — atomic create; first caller wins.
+      lockFd = openSync(lockFile, "wx", 0o600);
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code !== "EEXIST") throw err;
+      // Stale-lock cleanup. Best-effort: another contender may unlink
+      // ours simultaneously; that race resolves benignly (next openSync
+      // either wins or sees EEXIST again).
+      try {
+        const stat = statSync(lockFile);
+        if (Date.now() - stat.mtimeMs > staleLockMs) {
+          try {
+            unlinkSync(lockFile);
+          } catch {
+            /* already gone — another contender beat us to the cleanup */
+          }
+          continue;
+        }
+      } catch {
+        // statSync ENOENT — lock cleared between EEXIST and stat; retry
+        // immediately.
+        continue;
+      }
+      if (Date.now() > deadline) {
+        throw new Error(
+          `withFileLockSync: timed out after ${timeoutMs}ms waiting for ${lockFile}`,
+        );
+      }
+      // Busy-spin for ~5ms via hrtime. Node has no sync sleep; under
+      // contention the kernel preempts us, so this isn't actually a hot
+      // loop in practice (and tests can pass a 0ms timeout for the
+      // "already locked" case).
+      const spinUntil = process.hrtime.bigint() + 5_000_000n; // 5ms
+      while (process.hrtime.bigint() < spinUntil) {
+        /* yield */
+      }
+    }
+  }
+
+  try {
+    closeSync(lockFd);
+    return fn();
+  } finally {
+    try {
+      unlinkSync(lockFile);
+    } catch {
+      /* lock cleared by stale-lock cleanup in another process; ok */
+    }
+  }
+}

--- a/src/runLog.ts
+++ b/src/runLog.ts
@@ -7,6 +7,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import path from "node:path";
+import { withFileLockSync } from "./fileLockSync.js";
 import type { Logger } from "./logger.js";
 
 /**
@@ -441,7 +442,12 @@ export class RecipeRunLog {
         const code = (err as NodeJS.ErrnoException).code;
         if (code !== "ENOENT") throw err;
       }
-      appendFileSync(this.file, `${JSON.stringify(run)}\n`, { mode: 0o600 });
+      // Per-file lock — ADR-0007 multi-bridge concurrency. See the
+      // matching block in src/decisionTraceLog.ts for the full
+      // rationale; same pattern.
+      withFileLockSync(this.file, () => {
+        appendFileSync(this.file, `${JSON.stringify(run)}\n`, { mode: 0o600 });
+      });
     } catch (err) {
       this.opts.logger?.warn?.(
         `[runlog] append failed: ${err instanceof Error ? err.message : String(err)}`,


### PR DESCRIPTION
## Summary

ADR-0007 (Proposed, 2026-04-18) prescribes \"wrap each append in proper-lockfile (or fs.flockSync via a native binding)\" around the three append-only logs:

- [src/decisionTraceLog.ts](src/decisionTraceLog.ts) — decision_traces.jsonl
- [src/runLog.ts](src/runLog.ts) — recipe_runs.jsonl
- [src/commitIssueLinkLog.ts](src/commitIssueLinkLog.ts) — commit_issue_links.jsonl

Without a cross-process mutex, two bridges sharing one `$HOME` could interleave bytes within a single JSONL row — POSIX does not guarantee non-tearing concurrent appends for sub-page writes, and macOS APFS has been empirically observed to tear at ~256 bytes (well under typical row size). A torn row fails `JSON.parse` → silently skipped on every reader → \"durable cross-session memory\" promise quietly broken.

### Approach
Adds [src/fileLockSync.ts](src/fileLockSync.ts) — a tiny synchronous file mutex. `O_EXCL` create of `${file}.lock` as the atomic primitive, 30s stale-lock heuristic for crashed owners, 5s default timeout. No new dependency (proper-lockfile is the alternative, but the bridge needs the sync API in only three call-sites — ad-hoc is the lighter footprint).

Lock granularity is per-file. Each log gets its own sentinel. At the bridge's write volume (≤ tens/min across all three combined) contention is effectively zero.

### Scope note
This PR closes the **write half** of ADR-0007. The complementary tail-on-read piece (each `query()` re-stats the file and merges new rows since `lastReadOffset`) is deferred to a follow-up. Without tail-on-read, queries are still single-bridge local; but the data on disk is now correct.

## Test plan

- [x] 6 new `fileLockSync` regression tests: critical-section run + return value, sentinel lifecycle, throw-releases-lock, timeout when held, stale-lock force-unlink, 50-iter serialized-append integrity.
- [x] 51 pass on the three affected log test files (no behaviour change in the wrappers).
- [x] Full bridge suite: **5475 pass / 2 skipped** (one pre-existing fs.watch flake; passes on re-run).
- [x] `npx tsc -p tsconfig.json --noEmit` clean.

## PR sequence

#572 → ... → #583 → **this**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)