### PR TITLE
fix(recipes): atomic write in installRecipeFromFile (closes TOCTOU)

### DIFF
--- a/src/recipes/__tests__/installer.test.ts
+++ b/src/recipes/__tests__/installer.test.ts
@@ -196,4 +196,43 @@ steps:
       expect(result.action).toBe("created");
     });
   });
+
+  // ─── atomic write (audit 2026-05-17) ──────────────────────────────────────
+  // Default write path uses temp+rename. Two concurrent installs of the
+  // same recipe (cross-process) used to interleave bytes within the
+  // JSON payload (torn file → recipe invisible to the scheduler).
+  // Temp+rename guarantees the destination is either old content or
+  // new content, never partial.
+  describe("atomic write", () => {
+    it("leaves no .tmp.* sibling after a successful install", () => {
+      const src = writeRecipe("source", SIMPLE);
+      const recipesDir = path.join(dir, "recipes");
+      installRecipeFromFile(src, { recipesDir });
+      const { readdirSync } = require("node:fs") as typeof import("node:fs");
+      const entries = readdirSync(recipesDir);
+      expect(entries.filter((e: string) => e.includes(".tmp."))).toEqual([]);
+      expect(entries).toContain("sentry-autofix.json");
+    });
+
+    it("installed file is always valid JSON (no torn payload)", () => {
+      const src = writeRecipe("source", SIMPLE);
+      const recipesDir = path.join(dir, "recipes");
+      const result = installRecipeFromFile(src, { recipesDir });
+      // The file on disk parses to a recipe object — the temp+rename
+      // path can't observe a half-written JSON document.
+      const parsed = JSON.parse(readFileSync(result.installedPath, "utf-8"));
+      expect(parsed.name).toBe("sentry-autofix");
+    });
+
+    it("repeated installs converge to the latest payload (last writer wins)", () => {
+      const recipesDir = path.join(dir, "recipes");
+      const srcA = writeRecipe("source-a", { ...SIMPLE, version: "1.1" });
+      const srcB = writeRecipe("source-b", { ...SIMPLE, version: "2.0" });
+      installRecipeFromFile(srcA, { recipesDir });
+      const second = installRecipeFromFile(srcB, { recipesDir });
+      const parsed = JSON.parse(readFileSync(second.installedPath, "utf-8"));
+      expect(parsed.version).toBe("2.0");
+      expect(second.action).toBe("replaced");
+    });
+  });
 });

--- a/src/recipes/installer.ts
+++ b/src/recipes/installer.ts
@@ -1,9 +1,46 @@
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import crypto from "node:crypto";
+import {
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
 import path from "node:path";
 import { parse as parseYaml } from "yaml";
 import type { CompiledRecipe } from "./compiler.js";
 import { compileRecipeFull } from "./compiler.js";
 import { parseRecipe } from "./parser.js";
+
+/**
+ * Atomic temp+rename for the default install write. Audit 2026-05-17:
+ * two concurrent installs of the same recipe (cross-process, e.g.
+ * dashboard + CLI racing) used to interleave bytes within the JSON
+ * payload because the previous `writeFileSync(destPath, ...)` is not
+ * atomic for sub-page writes. A torn JSON file fails to parse and the
+ * recipe becomes invisible to the scheduler.
+ *
+ * `rename` is atomic at the FS layer on every platform we ship on
+ * (apfs / ext4 / ntfs / xfs). With temp+rename, two concurrent writers
+ * each end up with their own intact file → last `rename` wins, but
+ * the file on disk is ALWAYS a valid JSON document.
+ */
+function atomicWriteSync(target: string, content: string): void {
+  const tmp = `${target}.tmp.${process.pid}.${crypto
+    .randomBytes(6)
+    .toString("hex")}`;
+  try {
+    writeFileSync(tmp, content);
+    renameSync(tmp, target);
+  } catch (err) {
+    try {
+      unlinkSync(tmp);
+    } catch {
+      /* already gone or never created */
+    }
+    throw err;
+  }
+}
 
 /**
  * Recipe installer — loads a recipe file, validates, compiles, and copies it
@@ -44,8 +81,10 @@ export function installRecipeFromFile(
 
   const fs = opts.fs ?? {};
   const readFile = fs.readFile ?? ((p: string) => readFileSync(p, "utf-8"));
-  const writeFile =
-    fs.writeFile ?? ((p: string, c: string) => writeFileSync(p, c));
+  // Default writer is atomic (temp+rename). Callers may inject their
+  // own writeFile (tests, in-memory fs); they are responsible for
+  // their own atomicity guarantees.
+  const writeFile = fs.writeFile ?? atomicWriteSync;
   const mkdir = fs.mkdir ?? ((p: string) => mkdirSync(p, { recursive: true }));
 
   const text = readFile(sourcePath);


### PR DESCRIPTION
## Summary

[src/recipes/installer.ts:88](src/recipes/installer.ts#L88) previously wrote the installed recipe JSON via direct `writeFileSync(destPath, JSON.stringify(...))`. Two concurrent installs of the same recipe (cross-process: dashboard + CLI, or two bridges sharing `$HOME`) could interleave bytes within the payload — POSIX doesn't guarantee non-tearing writes for sub-page JSON. A torn file fails to parse and the recipe becomes invisible to the scheduler at the next load.

**Fix**: temp+rename. `rename` is atomic at the FS layer on every platform we ship on (apfs / ext4 / ntfs / xfs); concurrent writers each end up with their own intact temp file, the second `rename` wins, and the file on disk is always a valid JSON document. Caller-injected `opts.fs.writeFile` retains its existing contract.

Inlined the helper rather than depending on the shared `writeFileAtomic` helper from the open #576 — keeps this PR mergeable independently. When #576 lands the site can switch over in a follow-up cleanup.

## Test plan

- [x] 3 new atomic-write regression tests (no orphan `.tmp.*`, file is always valid JSON, last-writer-wins)
- [x] 9/9 pass on `src/recipes/__tests__/installer.test.ts` (was 6)
- [x] Full bridge suite: **5472 pass / 2 skipped** (pre-existing fs.watch flake)
- [x] `npx tsc -p tsconfig.json --noEmit` clean

## PR sequence

#572 → … → #584 → **this**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)