### PR TITLE
fix(push): evict 404/410-Gone subscriptions from the relay store

### DIFF
--- a/dashboard/src/app/api/relay/push/__tests__/route.test.ts
+++ b/dashboard/src/app/api/relay/push/__tests__/route.test.ts
@@ -19,11 +19,12 @@ vi.mock("web-push", () => ({
 
 vi.mock("@/lib/pushStore", () => ({
   getSubscriptions: vi.fn(() => []),
+  removeSubscription: vi.fn(),
 }));
 
 import webpush from "web-push";
 import { POST } from "@/app/api/relay/push/route";
-import { getSubscriptions } from "@/lib/pushStore";
+import { getSubscriptions, removeSubscription } from "@/lib/pushStore";
 
 const TOKEN = "relay-test-token-1234567890abcdef";
 
@@ -68,6 +69,7 @@ beforeEach(() => {
   process.env.VAPID_PRIVATE_KEY = "test-vapid-private";
   process.env.VAPID_SUBJECT = "mailto:test@example.com";
   vi.mocked(getSubscriptions).mockReturnValue([validSub]);
+  vi.mocked(removeSubscription).mockClear();
   vi.mocked(webpush.sendNotification).mockClear();
   vi.mocked(webpush.setVapidDetails).mockClear();
 });
@@ -173,8 +175,72 @@ describe("POST /api/relay/push — fan-out", () => {
     const r = await POST(req({ authorization: `Bearer ${TOKEN}` }, validBody));
     expect(r.status).toBe(200);
     expect(webpush.sendNotification).toHaveBeenCalledTimes(3);
-    const body = (await r.json()) as { ok: boolean; sent: number; total: number };
-    expect(body).toEqual({ ok: true, sent: 2, total: 3 });
+    const body = (await r.json()) as {
+      ok: boolean;
+      sent: number;
+      total: number;
+      evicted: number;
+    };
+    expect(body).toEqual({ ok: true, sent: 2, total: 3, evicted: 0 });
+    // Plain Error has no statusCode → not evicted.
+    expect(removeSubscription).not.toHaveBeenCalled();
+  });
+
+  // ─── 410 Gone eviction — audit 2026-05-17 ─────────────────────────────────
+  it("evicts subscriptions that 410-Gone from the push service", async () => {
+    const subs = [
+      validSub,
+      { endpoint: "https://e2.com/p", keys: { p256dh: "k1", auth: "k2" } },
+      { endpoint: "https://e3.com/p", keys: { p256dh: "k3", auth: "k4" } },
+    ];
+    vi.mocked(getSubscriptions).mockReturnValue(subs);
+    vi.mocked(webpush.sendNotification).mockImplementation(async (sub) => {
+      if (sub.endpoint === subs[1].endpoint) {
+        // web-push throws WebPushError with statusCode 410 for expired
+        // subscriptions. Reproduce shape without importing the class.
+        const err = new Error("Gone") as Error & { statusCode: number };
+        err.statusCode = 410;
+        throw err;
+      }
+      return { statusCode: 201, body: "", headers: {} };
+    });
+
+    const r = await POST(req({ authorization: `Bearer ${TOKEN}` }, validBody));
+    expect(r.status).toBe(200);
+    const body = (await r.json()) as { evicted: number };
+    expect(body.evicted).toBe(1);
+    expect(removeSubscription).toHaveBeenCalledTimes(1);
+    expect(removeSubscription).toHaveBeenCalledWith(subs[1].endpoint);
+  });
+
+  it("evicts subscriptions that 404 from the push service", async () => {
+    vi.mocked(getSubscriptions).mockReturnValue([validSub]);
+    vi.mocked(webpush.sendNotification).mockImplementation(async () => {
+      const err = new Error("Not Found") as Error & { statusCode: number };
+      err.statusCode = 404;
+      throw err;
+    });
+    const r = await POST(req({ authorization: `Bearer ${TOKEN}` }, validBody));
+    expect(r.status).toBe(200);
+    const body = (await r.json()) as { evicted: number };
+    expect(body.evicted).toBe(1);
+    expect(removeSubscription).toHaveBeenCalledWith(validSub.endpoint);
+  });
+
+  it("does NOT evict on transient 5xx failures", async () => {
+    vi.mocked(getSubscriptions).mockReturnValue([validSub]);
+    vi.mocked(webpush.sendNotification).mockImplementation(async () => {
+      const err = new Error("Service Unavailable") as Error & {
+        statusCode: number;
+      };
+      err.statusCode = 503;
+      throw err;
+    });
+    const r = await POST(req({ authorization: `Bearer ${TOKEN}` }, validBody));
+    expect(r.status).toBe(200);
+    const body = (await r.json()) as { evicted: number };
+    expect(body.evicted).toBe(0);
+    expect(removeSubscription).not.toHaveBeenCalled();
   });
 
   it("forwarded payload includes computed approveUrl/rejectUrl from bridgeCallbackBase", async () => {

--- a/dashboard/src/app/api/relay/push/route.ts
+++ b/dashboard/src/app/api/relay/push/route.ts
@@ -1,7 +1,7 @@
 import crypto from "node:crypto";
 import { NextResponse } from "next/server";
 import webpush from "web-push";
-import { getSubscriptions } from "@/lib/pushStore";
+import { getSubscriptions, removeSubscription } from "@/lib/pushStore";
 import {
   DASHBOARD_API_BODY_CAPS,
   bodyTooLargeResponse,
@@ -157,5 +157,37 @@ export async function POST(req: Request) {
   );
   const sent = results.filter((r) => r.status === "fulfilled").length;
 
-  return NextResponse.json({ ok: true, sent, total: subs.length });
+  // Evict expired subscriptions. RFC 8030 mandates 404 / 410 when the
+  // push service has no record of the subscription (uninstalled SW,
+  // user disabled notifications, browser reset, device flashed). Pre-fix
+  // we kept re-fanning to those endpoints forever — each request
+  // carrying a live `approvalToken` to a service that no longer routes
+  // it. Audit 2026-05-17.
+  let evicted = 0;
+  for (let i = 0; i < results.length; i++) {
+    const r = results[i];
+    const sub = subs[i];
+    if (r.status !== "rejected" || !sub) continue;
+    const status = extractPushStatusCode(r.reason);
+    if (status === 404 || status === 410) {
+      removeSubscription(sub.endpoint);
+      evicted++;
+    }
+  }
+
+  return NextResponse.json({ ok: true, sent, total: subs.length, evicted });
+}
+
+/**
+ * Pluck the HTTP status code out of a web-push rejection. The library
+ * throws `WebPushError` instances with a `statusCode` field. Older
+ * versions of node-pushlib used `code`/`status`. Be defensive about
+ * shape so a future bump doesn't silently break the eviction path.
+ */
+function extractPushStatusCode(reason: unknown): number | undefined {
+  if (typeof reason !== "object" || reason === null) return undefined;
+  const r = reason as { statusCode?: unknown; status?: unknown };
+  if (typeof r.statusCode === "number") return r.statusCode;
+  if (typeof r.status === "number") return r.status;
+  return undefined;
 }


### PR DESCRIPTION
## Summary

Audit 2026-05-17: the push relay route fanned out to every stored subscription on every approval and **ignored push-service rejections**. RFC 8030 mandates 404 / 410 when the service has no record of the subscription (uninstalled SW, user disabled notifications, browser reset, device flashed) — but the relay kept re-fanning forever, each request carrying a live `approvalToken` to a dead endpoint.

## Failure modes prevented

- Live `approvalToken`s leaking to forever-orphan endpoints (a stale device that gets re-flashed could receive approval prompts again).
- The relay quietly carrying every dead device the user has ever subscribed from; the store grows monotonically.
- Operators reading the response `sent` count and wondering why deliveries don't match expectations.

## Fix

After `Promise.allSettled`, inspect each rejection's `statusCode` (WebPushError shape — the canonical `web-push` library throws those). On 404 / 410 call `removeSubscription(endpoint)` and bump an `evicted` counter returned in the response body alongside `sent` / `total`. Other status codes (5xx, network errors) are still tolerated as transient.

## Test plan

- [x] New: evicts on 410 (multi-sub setup, one returns 410, others succeed)
- [x] New: evicts on 404
- [x] New: does **not** evict on 503 (transient should not delete subscriptions)
- [x] Existing fan-out test updated: `evicted: 0` in body when rejection is a plain Error with no statusCode
- [x] 16/16 pass on the relay route test (was 13)
- [x] Full dashboard suite: **516 pass**
- [x] `npx tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)