### PR TITLE
fix(recipes): connectorPreflight scans agent prompts for tool mentions

### DIFF
--- a/src/recipes/__tests__/connectorPreflight.test.ts
+++ b/src/recipes/__tests__/connectorPreflight.test.ts
@@ -110,6 +110,90 @@ describe("detectRequiredConnectors", () => {
       ).toEqual([connector]);
     }
   });
+
+  // ─── Prompt-body scan (audit 2026-05-17) ───────────────────────────────
+  // Agent steps that name a tool inside the `prompt` body without
+  // listing it in `tools[]` used to be invisible to the preflight.
+  // Now we scan the prompt for known tool prefixes too. Detection is
+  // lossy by design — false positives are tolerable, false negatives
+  // (silent miss → install panel claims "no connectors needed") are not.
+  describe("prompt-body scan", () => {
+    it("detects connector named via underscored tool in agent prompt", () => {
+      expect(
+        detectRequiredConnectors(
+          recipe([
+            {
+              id: "notify",
+              agent: true,
+              prompt: "Use slack_post_message to send the summary.",
+            },
+          ] as Recipe["steps"]),
+        ),
+      ).toEqual(["slack"]);
+    });
+
+    it("detects connector named via dotted prose in agent prompt", () => {
+      expect(
+        detectRequiredConnectors(
+          recipe([
+            {
+              id: "fetch",
+              agent: true,
+              prompt: "Pull recent issues with linear.search and triage them.",
+            },
+          ] as Recipe["steps"]),
+        ),
+      ).toEqual(["linear"]);
+    });
+
+    it("merges prompt-named connectors with tools[] entries", () => {
+      expect(
+        detectRequiredConnectors(
+          recipe([
+            {
+              id: "compose",
+              agent: true,
+              prompt: "Send the digest via gmail_send_message.",
+              tools: ["slack_post_message"],
+            },
+          ] as Recipe["steps"]),
+        ),
+      ).toEqual(["gmail", "slack"]);
+    });
+
+    it("ignores random words that happen to start with a prefix string", () => {
+      // "slacks" is NOT a tool; "calendaring" is NOT a tool. The
+      // detector should not flag either.
+      expect(
+        detectRequiredConnectors(
+          recipe([
+            {
+              id: "x",
+              agent: true,
+              prompt: "Update the slacks in calendaring documentation.",
+            },
+          ] as Recipe["steps"]),
+        ),
+      ).toEqual([]);
+    });
+
+    it("ignores prompt of agent:false tool steps (only `tool` field counts)", () => {
+      // Tool steps have a strict `tool` field — they don't get the
+      // permissive prompt scan.
+      expect(
+        detectRequiredConnectors(
+          recipe([
+            {
+              id: "x",
+              agent: false,
+              tool: "Read",
+              params: { _comment: "this would mention slack_post but doesn't" },
+            },
+          ] as Recipe["steps"]),
+        ),
+      ).toEqual([]);
+    });
+  });
 });
 
 describe("findMissingConnectors", () => {

--- a/src/recipes/connectorPreflight.ts
+++ b/src/recipes/connectorPreflight.ts
@@ -65,12 +65,72 @@ function toolsOfStep(step: Step): string[] {
 }
 
 /**
+ * Compiled list of tool-name prefixes (without the trailing underscore)
+ * used by `promptMentionsConnector`. Built once at module load — the
+ * source map is small and stable, so caching this avoids regex churn
+ * inside the per-step loop.
+ */
+const PROMPT_PREFIX_PATTERNS: ReadonlyArray<{
+  prefix: string;
+  connector: string;
+}> = Object.entries(TOOL_PREFIX_TO_CONNECTOR).map(([prefix, connector]) => ({
+  // Strip trailing underscore — when the prompt mentions a tool name like
+  // `slack_post_message` the underscore is part of the literal we look
+  // for, but when an agent prompt is more conversational ("post to slack
+  // using slack.post_message"), we want to match the prefix without the
+  // separator too.
+  prefix: prefix.replace(/_$/, ""),
+  connector,
+}));
+
+/**
+ * Inspect an agent step's `prompt` for references to tool names from
+ * known connectors. Catches the common case where the LLM is told
+ * which tool to call inside the prompt body rather than via the
+ * `tools[]` allowlist — e.g.:
+ *
+ *   - id: notify
+ *     agent:
+ *       prompt: Use slack_post_message to send "{{summary}}" to #ops.
+ *
+ * That prompt previously fell through `toolsOfStep` entirely (no
+ * `tool`, empty `tools[]`) and the install panel told the user "no
+ * connectors needed" despite the recipe relying on Slack at runtime.
+ *
+ * Detection is deliberately lossy — we match `<prefix>_` followed by a
+ * word char (the literal tool-name shape `slack_post_message`) and we
+ * also match `<prefix>.` to catch prose like "use slack.fetch". False
+ * positives are tolerable: surfacing one extra "you may want to
+ * authorise X" hint is strictly better than the pre-fix silent miss.
+ *
+ * Audit 2026-05-17.
+ */
+function promptMentionsConnectors(prompt: string): string[] {
+  const found = new Set<string>();
+  // Only look at the prompt body — vars / outputs / context refs go
+  // through `{{...}}` interpolation which the runtime resolves later.
+  for (const { prefix, connector } of PROMPT_PREFIX_PATTERNS) {
+    // Anchor on a word boundary so `unrelated_slack_word` doesn't
+    // match (\\bslack[_.]\\w would also match `slack_alert`, which is
+    // the intended target).
+    const re = new RegExp(`\\b${escapeForRegex(prefix)}[_.]\\w`, "i");
+    if (re.test(prompt)) found.add(connector);
+  }
+  return [...found];
+}
+
+function escapeForRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
  * Walk a recipe's steps and return the connector ids it likely needs.
  * Stable order (sorted) so the response is deterministic.
  */
 export function detectRequiredConnectors(recipe: Recipe): string[] {
   const required = new Set<string>();
   for (const step of recipe.steps) {
+    // Explicit `tool` / `tools[]` fields (canonical detection path).
     for (const tool of toolsOfStep(step)) {
       for (const [prefix, connector] of Object.entries(
         TOOL_PREFIX_TO_CONNECTOR,
@@ -78,6 +138,15 @@ export function detectRequiredConnectors(recipe: Recipe): string[] {
         if (tool.startsWith(prefix)) {
           required.add(connector);
         }
+      }
+    }
+    // Prompt body scan for agent-mode steps — catches recipes that
+    // tell the LLM which tool to call inline (e.g. "Use slack_post_message
+    // to ...") without listing it in `tools[]`. See
+    // `promptMentionsConnectors` above for the rationale.
+    if (step.agent === true && typeof step.prompt === "string") {
+      for (const connector of promptMentionsConnectors(step.prompt)) {
+        required.add(connector);
       }
     }
   }


### PR DESCRIPTION
## Summary

Audit 2026-05-17: [`toolsOfStep`](src/recipes/connectorPreflight.ts) only inspected `step.tool` (agent:false) and `step.tools[]` (agent:true). Agent recipes that named a tool inside the `prompt:` body **without** listing it in `tools[]` fell through the preflight silently — the dashboard install panel told the user \"no connectors needed\" despite the recipe relying on Slack / Gmail / Linear / etc. at runtime.

The header comment already admitted detection was \"deliberately lossy\" but the prompt-body gap was the most common miss in practice.

## Fix

Adds `promptMentionsConnectors(prompt)` — for each known tool prefix, test `\b<prefix>[_.]\w` (matches `slack_post_message` and prose like `slack.fetch`). Word-boundary anchor avoids false positives like `unrelated_slack_word`; trailing `[_.]` separator avoids matching bare nouns like \"slacks\" / \"calendaring\". Detection stays lossy by design — false positives surface one extra \"authorise X\" hint, which is strictly better than the silent miss.

Wired into `detectRequiredConnectors`: agent steps now contribute their `tools[]` AND any connector named in `prompt:`. agent:false steps unchanged.

## Test plan

- [x] 5 new prompt-scan cases: underscored tool in prompt, dotted prose, prompt + tools[] dedup-merge, false-positive avoidance (`slacks`, `calendaring`), agent:false ignored
- [x] 12 → 17 connectorPreflight tests pass
- [x] Full bridge suite: **5474 pass**
- [x] `npx tsc -p tsconfig.json --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)