### PR TITLE
fix(slack): upstream auth.revoke on disconnect + 32-byte OAuth state

### DIFF
--- a/src/connectorRoutes.ts
+++ b/src/connectorRoutes.ts
@@ -604,7 +604,7 @@ export function tryHandleConnectorRoute(
     void (async () => {
       try {
         const { handleSlackDisconnect } = await import("./connectors/slack.js");
-        const result = handleSlackDisconnect();
+        const result = await handleSlackDisconnect();
         res.writeHead(result.status, {
           "Content-Type": result.contentType ?? "application/json",
         });

--- a/src/connectors/__tests__/slack.test.ts
+++ b/src/connectors/__tests__/slack.test.ts
@@ -97,9 +97,74 @@ describe("slack token storage", () => {
 
     const { handleSlackDisconnect } = await import("../slack.js");
 
-    const result = handleSlackDisconnect();
+    const result = await handleSlackDisconnect();
 
     expect(result.status).toBe(200);
     expect(existsSync(join(tokensDir, "slack-state.json"))).toBe(false);
+  });
+
+  // ─── auth.revoke upstream (audit 2026-05-17) ────────────────────────────
+  // Pre-fix, disconnect was local-only — a leaked token kept working.
+  // Now the bot token is revoked at Slack before the local delete.
+  it("posts to auth.revoke before deleting tokens, with the bearer", async () => {
+    // Plant a real token-file so loadTokens returns access_token.
+    const { storeSecretJsonSync } = await import("../tokenStorage.js");
+    storeSecretJsonSync("slack", {
+      access_token: "xoxb-test-token-abc",
+      bot_user_id: "U0",
+      team_id: "T0",
+    });
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response('{"ok":true}', { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    vi.resetModules();
+    const { handleSlackDisconnect } = await import("../slack.js");
+    const result = await handleSlackDisconnect();
+
+    expect(result.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [
+      string,
+      RequestInit & { headers: Record<string, string> },
+    ];
+    expect(url).toBe("https://slack.com/api/auth.revoke");
+    expect(init.method).toBe("POST");
+    expect(init.headers.Authorization).toBe("Bearer xoxb-test-token-abc");
+  });
+
+  it("still deletes local tokens when auth.revoke fails (best-effort)", async () => {
+    const { storeSecretJsonSync } = await import("../tokenStorage.js");
+    storeSecretJsonSync("slack", {
+      access_token: "xoxb-test-token-fail",
+      bot_user_id: "U0",
+      team_id: "T0",
+    });
+
+    const fetchMock = vi.fn().mockRejectedValueOnce(new Error("network down"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    vi.resetModules();
+    const { handleSlackDisconnect, isConnected } = await import("../slack.js");
+    const result = await handleSlackDisconnect();
+
+    expect(result.status).toBe(200);
+    // Local delete must still happen — disconnect should never leave
+    // the user "stuck connected" because the vendor was unreachable.
+    expect(isConnected()).toBe(false);
+  });
+
+  it("skips auth.revoke when there is no stored token", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    vi.resetModules();
+    const { handleSlackDisconnect } = await import("../slack.js");
+    const result = await handleSlackDisconnect();
+
+    expect(result.status).toBe(200);
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/src/connectors/slack.ts
+++ b/src/connectors/slack.ts
@@ -357,7 +357,11 @@ export function handleSlackAuthorize(): ConnectorHandlerResult {
       }),
     };
   }
-  const state = crypto.randomBytes(16).toString("hex");
+  // 256-bit (32 random bytes) → 64 hex chars. Previously 16 bytes = 128 bits,
+  // which is fine for CSRF but every other connector (Asana, Discord, GitLab,
+  // Gmail, Google Calendar/Drive) uses 32 bytes via crypto.randomBytes(32) +
+  // base64url. Standardise on the higher entropy. Audit 2026-05-17.
+  const state = crypto.randomBytes(32).toString("hex");
   saveState(state);
   const params = new URLSearchParams({
     client_id: clientId(),
@@ -473,7 +477,53 @@ export async function handleSlackTest(): Promise<ConnectorHandlerResult> {
   }
 }
 
-export function handleSlackDisconnect(): ConnectorHandlerResult {
+/**
+ * Best-effort revoke of the bot token at Slack's `auth.revoke` endpoint
+ * before deleting the local copy. If revoke fails (network error,
+ * vendor returns invalid_auth, token already revoked) we proceed with
+ * the local delete — Slack's revoke is non-idempotent-but-safe: a
+ * second revoke on the same token returns `{ok: false, error:
+ * "token_revoked"}` which is the desired terminal state.
+ *
+ * Why upstream revoke matters (audit 2026-05-17): pre-fix, clicking
+ * "Disconnect" in the dashboard only deleted the token file locally.
+ * Anyone with an exfiltrated copy of `~/.patchwork/tokens/slack-...`
+ * could keep using the bot token until it was rotated or revoked at
+ * Slack's side — months or years later. Every other connector
+ * (Discord, Google*, mcpOAuth) already calls the vendor's revoke;
+ * Slack was the outlier (called out in discord.ts's comment).
+ */
+async function revokeUpstream(accessToken: string): Promise<void> {
+  // 3-second timeout — disconnect must not hang the dashboard request.
+  const ac = new AbortController();
+  const timer = setTimeout(() => ac.abort(), 3_000);
+  try {
+    await fetch("https://slack.com/api/auth.revoke", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      signal: ac.signal,
+    });
+    // Discard the response body — Slack returns `{ok: true|false}` but
+    // we don't gate on it. Either way the next step is to delete the
+    // local token; logging the result risks emitting the bearer token
+    // into bridge logs.
+  } catch {
+    // Best-effort: network errors, timeout, fetch abort — fall through.
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export async function handleSlackDisconnect(): Promise<ConnectorHandlerResult> {
+  // Capture the token BEFORE deleting it locally — auth.revoke needs
+  // the bearer to identify the install to revoke.
+  const tokens = loadTokens();
+  if (tokens?.access_token) {
+    await revokeUpstream(tokens.access_token);
+  }
   deleteTokens();
   return {
     status: 200,


### PR DESCRIPTION
## Summary

Two Slack-connector audit findings from 2026-05-17.

### 1. Disconnect was local-only — leaked tokens kept working
Pre-fix, clicking \"Disconnect\" in the dashboard only deleted `~/.patchwork/tokens/slack-*.enc`. The bot token stayed valid at Slack until manual rotation (often never). Anyone with an exfiltrated copy kept posting / reading. Every other OAuth connector in the bridge (Discord, Gmail, Google*, mcpOAuth for Linear/Sentry/GitHub-MCP) already calls the vendor's revoke — Slack was the outlier, called out in discord.ts comments.

`handleSlackDisconnect` now POSTs to `https://slack.com/api/auth.revoke` with the bearer before the local delete. **Best-effort**: 3s timeout, any error still falls through to the local delete — disconnect must never leave the user \"stuck connected\" because Slack was unreachable. auth.revoke is idempotent-safe.

### 2. OAuth state was 128-bit (`randomBytes(16)`), everyone else is 256-bit
Slack was the outlier in entropy. 128 bits is fine for CSRF in absolute terms, but standardising on `randomBytes(32)` removes a \"why is this connector different\" gotcha.

## Test plan
- [x] 3 new tests: auth.revoke called with correct URL + bearer, network failure still deletes local tokens, skip when no stored token
- [x] `handleSlackDisconnect` is now async; caller in `connectorRoutes.ts` + existing test updated to await
- [x] 3 → 6 slack.test.ts tests pass
- [x] Full bridge suite: **5472 pass**
- [x] `npx tsc -p tsconfig.json --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)