### PR TITLE
docs: refresh plugin.xml counts + surface plugin agents/skills/hooks

### DIFF
--- a/documents/plugin-authoring.md
+++ b/documents/plugin-authoring.md
@@ -412,3 +412,47 @@ npm search keywords:claude-ide-bridge-plugin
 ```
 
 > **Note:** The earlier `claude-ide-bridge marketplace list/search/install` subcommand was removed (issue #279). For non-plugin community content (recipe bundles), use `patchwork recipe install github:<org>/<repo>`.
+
+## Bundled companion plugin (`claude-ide-bridge-plugin/`)
+
+The repo ships a reference plugin at `claude-ide-bridge-plugin/` that demonstrates the Claude Code **agent / skill / hook** surfaces in addition to MCP tools. These are separate from the MCP-tool surface this doc focuses on — they target the Claude Code session itself, not the bridge's tool registry — but a plugin can register any combination of the four.
+
+### Agents (`claude-ide-bridge-plugin/agents/*.md`)
+
+Markdown files Claude Code surfaces as named sub-agents in the user's session. The bundled plugin ships four, each tuned for a specific IDE-workflow lane:
+
+| File | Surface |
+|---|---|
+| `ide-architect.md` | High-level codebase exploration: call hierarchies, type relationships, dependency graphs. |
+| `ide-code-reviewer.md` | Code review with inline diagnostics, blast-radius reasoning, refactor-safety analysis. |
+| `ide-debugger.md` | Breakpoint setup, expression evaluation, debug-state inspection. |
+| `ide-test-runner.md` | Test discovery, failure triage, coverage analysis. |
+
+An agent file is a plain markdown prompt; Claude Code reads it lazily when the user invokes the agent by name.
+
+### Skills (`claude-ide-bridge-plugin/skills/*/`)
+
+Per-directory skills that bundle a `SKILL.md` + supporting assets. Claude Code makes these available to any session that loads the plugin. The bundled plugin ships twelve:
+
+| Skill | What it does |
+|---|---|
+| `ide-api-deprecation-tracker` | Surface `@deprecated` usages across the workspace. |
+| `ide-coverage` | Render an HTML coverage heatmap from lcov / JSON coverage data. |
+| `ide-dead-code-hunter` | Find unused exports, unreferenced functions. |
+| `ide-debug` | Guided XDebugger / debugpy session setup. |
+| `ide-deps` | Build a force-directed dependency graph for a symbol. |
+| `ide-diagnostics-board` | Workspace-wide diagnostics dashboard (HTML). |
+| `ide-explore` | LSP-driven codebase tour for unfamiliar repos. |
+| `ide-monitor` | Long-running diagnostics watcher, surfaces regressions. |
+| `ide-quality` | Lint / format / fix-all-issues sweep on changed files. |
+| `ide-refactor` | Safe-refactor protocol: analyze → preview → execute. |
+| `ide-review` | Composite PR review (diff + diagnostics + churn + risk). |
+| `ide-type-mismatch-fix` | Targeted fix for TS / type-error categories. |
+
+### Hooks (`claude-ide-bridge-plugin/hooks/hooks.json`)
+
+JSON map of Claude Code hook events → shell commands. The bundled plugin wires `PreToolUse` / `PostToolUse` to the bridge's automation hooks so that tool calls Claude Code makes from the agent surface flow through the same approval queue as recipe tool calls, and `decisionTraceLog` captures every Claude-side call alongside recipe-side calls.
+
+### Authoring your own
+
+The four surfaces are independent — a plugin that only wants to ship MCP tools (the focus of the rest of this doc) does **not** need to ship agents, skills, or hooks. Conversely, a plugin can ship one or more of these without registering any MCP tool. The `claude-ide-bridge-plugin/` directory in the repo is the canonical example combining all four.

--- a/intellij-plugin/src/main/resources/META-INF/plugin.xml
+++ b/intellij-plugin/src/main/resources/META-INF/plugin.xml
@@ -8,7 +8,7 @@
 
 <p><b>MCP bridge between Claude Code and your JetBrains IDE.</b> Gives Claude Code real-time
 visibility into your editor — open files, diagnostics, terminal output, debug state — and
-lets it act on all of it through 170+ MCP tools.</p>
+lets it act on all of it through 180 MCP tools.</p>
 
 <p>Fix a bug from your phone. Let Claude run your tests and commit the result. Ask Claude
 what lint errors are in your workspace without copy-pasting anything. This plugin makes all
@@ -19,7 +19,7 @@ and other JetBrains IDEs — wire-compatible with the
 <h3>Two ways to use it</h3>
 
 <ul>
-  <li><b>Bridge only (default).</b> 170 MCP tools — LSP, diagnostics, debugger, terminal, git, GitHub, file ops. For anyone who wants Claude Code to see and act on their IDE.</li>
+  <li><b>Bridge only (default).</b> 180 MCP tools — LSP, diagnostics, debugger, terminal, git, GitHub, file ops. For anyone who wants Claude Code to see and act on their IDE.</li>
   <li><b>Patchwork OS layer (opt-in).</b> All bridge tools plus YAML recipes, an approval queue, oversight dashboard, mobile push approvals, and multi-model orchestration. For automation, agent workflows, and background tasks.</li>
 </ul>
 
@@ -54,7 +54,7 @@ machine. No cloud accounts required.</p>
   <li><b>Environment health</b> — <code>bridgeDoctor</code> verifies plugin connection, git, linter, test runner, lock file, GitHub CLI.</li>
 </ul>
 
-<p>This plugin contributes 49 IDE-side handlers (core, LSP, debugger, terminal, code style).
+<p>This plugin contributes 67 IDE-side wire methods (50 real handler implementations + 17 documented stubs for forward compatibility with the VS Code surface — captureScreenshot, watchFiles, executeVSCodeCommand, etc., which the bridge tolerates as "not implemented in this IDE").
 The bridge ships an additional ~120 transport-level tools (git, GitHub, search, formatting,
 project info, Claude orchestration, etc.) that work the moment the bridge is running — even
 without the IDE plugin connected.</p>


### PR DESCRIPTION
## Summary

Two audit findings from 2026-05-17.

### plugin.xml stale counts
Three sites baked the v1.0.0 launch counts into the marketplace listing copy:
- \"170+ MCP tools\" → **180 MCP tools** (matches README/CLAUDE.md; `audit-lsp-tools.mjs` is authoritative)
- \"170 MCP tools\" in two-modes block → 180
- \"49 IDE-side handlers\" → **67 IDE-side wire methods** (50 real + 17 documented stubs for VS Code parity — `audit-intellij-parity.mjs` is authoritative)

The `change-notes` block under \"1.0.0 — 2026-04-22\" is a historical record of what shipped at v1.0.0; left as-is.

### plugin-authoring.md missed the agent/skill/hook surfaces
The bundled `claude-ide-bridge-plugin/` ships **4 agents + 12 skills + a hooks.json** — none of which were documented in the canonical authoring guide. Added a \"Bundled companion plugin\" section enumerating each:
- Agents table (architect / code-reviewer / debugger / test-runner)
- Skills table (all 12: api-deprecation-tracker, coverage, dead-code-hunter, debug, deps, diagnostics-board, explore, monitor, quality, refactor, review, type-mismatch-fix)
- Hooks section (PreToolUse / PostToolUse → bridge approval queue)
- Authoring note: surfaces are independent

🤖 Generated with [Claude Code](https://claude.com/claude-code)