### PR TITLE
fix(logs): tail-on-read for decisionTraceLog + commitIssueLinkLog (closes ADR-0007 read half)

### DIFF
--- a/src/__tests__/commitIssueLinkLog.test.ts
+++ b/src/__tests__/commitIssueLinkLog.test.ts
@@ -143,4 +143,42 @@ describe("CommitIssueLinkLog", () => {
     expect(log.query({ limit: 3 })).toHaveLength(3);
     expect(log.query({ limit: 0 })).toHaveLength(1); // clamped to min 1
   });
+
+  // ─── Tail-on-read (ADR-0007) ───────────────────────────────────────────
+  it("tail-on-read: query() picks up rows appended by a sibling bridge", () => {
+    const file = path.join(dir, "commit_issue_links.jsonl");
+    const fs = require("node:fs") as typeof import("node:fs");
+
+    const a = new CommitIssueLinkLog({ dir });
+    a.record({ ...base(), sha: "sha-self-1" });
+
+    // Simulate a sibling bridge appending directly. Higher seq so the
+    // dedup guard (`seq > this.seq`) accepts the row.
+    const externalRow = JSON.stringify({
+      seq: 999,
+      createdAt: 1,
+      sha: "sha-sibling",
+      ref: "#sibling",
+      linkType: "fixes",
+      resolved: true,
+      workspace: "/ws/sibling",
+      subject: "from sibling",
+    });
+    fs.appendFileSync(file, `${externalRow}\n`);
+
+    const shas = a.query({}).map((r) => r.sha);
+    expect(shas).toContain("sha-sibling");
+    expect(shas).toContain("sha-self-1");
+  });
+
+  it("tail-on-read: self-appends don't get re-loaded as duplicates", () => {
+    const log = new CommitIssueLinkLog({ dir });
+    log.record({ ...base(), sha: "sha-x" });
+    log.record({ ...base(), sha: "sha-y" });
+    const first = log.query({}).map((r) => r.sha);
+    const second = log.query({}).map((r) => r.sha);
+    expect(first).toEqual(second);
+    expect(first.filter((s) => s === "sha-x")).toHaveLength(1);
+    expect(first.filter((s) => s === "sha-y")).toHaveLength(1);
+  });
 });

--- a/src/__tests__/decisionTraceLog.test.ts
+++ b/src/__tests__/decisionTraceLog.test.ts
@@ -198,4 +198,46 @@ describe("DecisionTraceLog", () => {
     expect(fs.readFileSync(file, "utf8")).toContain('"ref":"#after-rotate"');
     expect(fs.existsSync(`${file}.tmp`)).toBe(false);
   });
+
+  // ─── Tail-on-read (ADR-0007) ───────────────────────────────────────────
+  it("tail-on-read: query() picks up rows appended by a sibling bridge", () => {
+    const file = path.join(dir, "decision_traces.jsonl");
+    const fs = require("node:fs") as typeof import("node:fs");
+
+    const a = new DecisionTraceLog({ dir });
+    a.record({ ...base(), ref: "#a-1" });
+    expect(a.query().map((t) => t.ref)).toEqual(["#a-1"]);
+
+    // Simulate sibling bridge appending directly to disk. Higher seq
+    // so the dedup guard (`seq > this.seq`) accepts the row.
+    const externalRow = JSON.stringify({
+      seq: 999,
+      createdAt: 2,
+      ref: "#sibling-write",
+      problem: "p",
+      solution: "s",
+      workspace: "/ws",
+    });
+    fs.appendFileSync(file, `${externalRow}\n`);
+
+    const refs = a.query().map((t) => t.ref);
+    expect(refs).toContain("#sibling-write");
+    expect(refs).toContain("#a-1");
+  });
+
+  it("tail-on-read: self-appends don't get re-loaded as duplicates", () => {
+    const a = new DecisionTraceLog({ dir });
+    a.record({ ...base(), ref: "#one" });
+    a.record({ ...base(), ref: "#two" });
+    // Two queries back-to-back with no intervening write must return
+    // identical results — the tail-read short-circuits when file size
+    // hasn't grown past `lastReadOffset`.
+    const first = a.query().map((t) => t.ref);
+    const second = a.query().map((t) => t.ref);
+    expect(first).toEqual(second);
+    expect(first).toContain("#one");
+    expect(first).toContain("#two");
+    expect(first.filter((r) => r === "#one")).toHaveLength(1);
+    expect(first.filter((r) => r === "#two")).toHaveLength(1);
+  });
 });

--- a/src/commitIssueLinkLog.ts
+++ b/src/commitIssueLinkLog.ts
@@ -81,6 +81,14 @@ export class CommitIssueLinkLog {
   private readonly file: string;
   private readonly memoryCap: number;
   private readonly now: () => number;
+  /**
+   * Highest file size seen so far. ADR-0007 tail-on-read: every
+   * `query()` re-stats the file; if it grew, we re-parse and merge
+   * any rows with `seq > this.seq` (so a sibling bridge's appends
+   * become visible without holding a separate offset cursor). Matches
+   * the pattern already in `src/runLog.ts:syncFromDisk`.
+   */
+  private lastFileSize = 0;
 
   constructor(private readonly opts: LinkLogOptions) {
     this.file = path.join(opts.dir, "commit_issue_links.jsonl");
@@ -138,6 +146,9 @@ export class CommitIssueLinkLog {
   }
 
   query(q: LinkQuery = {}): CommitIssueLink[] {
+    // ADR-0007 tail-on-read: pick up any rows a sibling bridge appended
+    // since our last query / load. statSync-only when no growth.
+    this.syncFromDisk();
     let out = this.links;
     if (q.sha) {
       const needle = q.sha;
@@ -196,6 +207,17 @@ export class CommitIssueLinkLog {
       // rationale; same pattern.
       withFileLockSync(this.file, () => {
         appendFileSync(this.file, `${JSON.stringify(link)}\n`, { mode: 0o600 });
+        // Advance the tail-on-read cursor past our own write so the next
+        // query() doesn't re-read the row from disk (we already pushed it
+        // to this.links in `record`). The seq-gt guard in syncFromDisk
+        // would also defend, but bumping the size cursor lets that path
+        // short-circuit on `size <= lastFileSize` and skip a readFileSync.
+        try {
+          this.lastFileSize = statSync(this.file).size;
+        } catch {
+          /* ENOENT after a successful append is very unlikely; if it
+             happens the next syncFromDisk re-tries cleanly. */
+        }
       });
     } catch (err) {
       this.opts.logger?.warn?.(
@@ -233,6 +255,15 @@ export class CommitIssueLinkLog {
       writeFileAtomicSync(this.file, joined.length > 0 ? `${joined}\n` : "", {
         mode: 0o600,
       });
+      // Refresh the tail-on-read cursor to the post-rotation file size.
+      // Without this, the next syncFromDisk() would see `size <
+      // lastFileSize`, skip the read entirely, and miss every row a
+      // sibling bridge has appended since.
+      try {
+        this.lastFileSize = statSync(this.file).size;
+      } catch {
+        this.lastFileSize = 0;
+      }
     } catch (err) {
       this.opts.logger?.warn?.(
         `[linklog] rotate failed: ${err instanceof Error ? err.message : String(err)}`,
@@ -240,10 +271,50 @@ export class CommitIssueLinkLog {
     }
   }
 
-  private loadExisting(): void {
+  /**
+   * Incrementally read any new lines appended to the file since last
+   * load. Matches the runLog `syncFromDisk` pattern: re-read whole
+   * file, but use the `seq > this.seq` guard so existing rows aren't
+   * re-pushed. Tail-on-read (ADR-0007) — sibling-bridge appends are
+   * picked up at the next `query()`.
+   */
+  private syncFromDisk(): void {
     try {
-      statSync(this.file);
+      const size = statSync(this.file).size;
+      if (size <= this.lastFileSize) return;
+      const raw = readFileSync(this.file, "utf-8");
+      for (const line of raw.split("\n")) {
+        if (!line) continue;
+        try {
+          const parsed = JSON.parse(line) as CommitIssueLink;
+          if (
+            typeof parsed.seq !== "number" ||
+            typeof parsed.sha !== "string" ||
+            typeof parsed.ref !== "string"
+          ) {
+            continue;
+          }
+          if (parsed.seq > this.seq) {
+            this.seq = parsed.seq;
+            this.links.push(parsed);
+            if (this.links.length > this.memoryCap) this.links.shift();
+          }
+        } catch {
+          /* skip malformed */
+        }
+      }
+      this.lastFileSize = size;
     } catch {
+      /* file may not exist yet */
+    }
+  }
+
+  private loadExisting(): void {
+    let size: number;
+    try {
+      size = statSync(this.file).size;
+    } catch {
+      this.lastFileSize = 0;
       return;
     }
     let raw: string;
@@ -272,6 +343,7 @@ export class CommitIssueLinkLog {
         // skip malformed line
       }
     }
+    this.lastFileSize = size;
     if (this.links.length > this.memoryCap) {
       this.links.splice(0, this.links.length - this.memoryCap);
     }

--- a/src/decisionTraceLog.ts
+++ b/src/decisionTraceLog.ts
@@ -1,7 +1,10 @@
 import {
   appendFileSync,
+  closeSync,
   mkdirSync,
+  openSync,
   readFileSync,
+  readSync,
   renameSync,
   statSync,
   writeFileSync,
@@ -92,6 +95,16 @@ export class DecisionTraceLog {
   private readonly file: string;
   private readonly memoryCap: number;
   private readonly now: () => number;
+  /**
+   * Byte offset into `file` up to which we've already loaded rows into
+   * `this.traces`. ADR-0007 tail-on-read: every `query()` re-stats the
+   * file and reads the delta `[lastReadOffset, size)`, so a sibling
+   * bridge's appends become visible to this process within one query
+   * — without holding the whole log in memory or paying read cost on
+   * every append. Single-process operation is unaffected (offset is
+   * always at EOF so the stat → no-grow path short-circuits).
+   */
+  private lastReadOffset = 0;
 
   constructor(private readonly opts: DecisionTraceLogOptions) {
     this.file = path.join(opts.dir, "decision_traces.jsonl");
@@ -151,6 +164,10 @@ export class DecisionTraceLog {
   }
 
   query(q: DecisionQuery = {}): DecisionTrace[] {
+    // ADR-0007 tail-on-read: pick up any rows a sibling bridge appended
+    // since our last query / load. Single-process operation pays only a
+    // `statSync` per query — read-delta is empty when `size === offset`.
+    this.tailDisk();
     let out = this.traces;
     if (q.ref) {
       const needle = q.ref;
@@ -199,6 +216,17 @@ export class DecisionTraceLog {
         appendFileSync(this.file, `${JSON.stringify(trace)}\n`, {
           mode: 0o600,
         });
+        // Advance the tail-on-read offset past our own write so the next
+        // query() doesn't re-read this row from disk and add a duplicate
+        // to this.traces (we already pushed it in `record` above).
+        // ADR-0007 tail-on-read.
+        try {
+          this.lastReadOffset = statSync(this.file).size;
+        } catch {
+          /* statSync ENOENT after a successful append would be very
+             strange; the next tailDisk() will fall into the
+             shrank-or-missing path and reload cleanly. */
+        }
       });
     } catch (err) {
       this.opts.logger?.warn?.(
@@ -252,9 +280,12 @@ export class DecisionTraceLog {
   }
 
   private loadExisting(): void {
+    let size: number;
     try {
-      statSync(this.file);
+      size = statSync(this.file).size;
     } catch {
+      // File doesn't exist yet — first call will create it.
+      this.lastReadOffset = 0;
       return;
     }
     let raw: string;
@@ -266,6 +297,71 @@ export class DecisionTraceLog {
       );
       return;
     }
+    this.consumeRawJsonl(raw);
+    this.lastReadOffset = size;
+    if (this.traces.length > this.memoryCap) {
+      this.traces.splice(0, this.traces.length - this.memoryCap);
+    }
+  }
+
+  /**
+   * Tail-on-read (ADR-0007). Read any rows appended to the file since
+   * `lastReadOffset` and merge them into the in-memory ring. Cheap when
+   * nothing changed (one `statSync`); on a fresh sibling write we read
+   * just the delta. Torn rows (mid-write race) JSON.parse-fail and are
+   * skipped — but the cross-process flock around appends (`#584`)
+   * eliminates that failure mode in practice.
+   */
+  private tailDisk(): void {
+    let size: number;
+    try {
+      size = statSync(this.file).size;
+    } catch {
+      // File doesn't exist (yet) — nothing to tail.
+      return;
+    }
+    if (size === this.lastReadOffset) return;
+    if (size < this.lastReadOffset) {
+      // File shrank — rotated or truncated by a sibling. Fall back to a
+      // full reload so we pick up the post-rotate state cleanly.
+      this.traces.length = 0;
+      this.lastReadOffset = 0;
+      this.loadExisting();
+      return;
+    }
+    // Read only the new bytes.
+    let buf: Buffer;
+    try {
+      const fd = openSync(this.file, "r");
+      try {
+        const len = size - this.lastReadOffset;
+        buf = Buffer.alloc(len);
+        readSync(fd, buf, 0, len, this.lastReadOffset);
+      } finally {
+        closeSync(fd);
+      }
+    } catch (err) {
+      this.opts.logger?.warn?.(
+        `[dtrace-log] tail read failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      return;
+    }
+    this.consumeRawJsonl(buf.toString("utf-8"));
+    this.lastReadOffset = size;
+    if (this.traces.length > this.memoryCap) {
+      this.traces.splice(0, this.traces.length - this.memoryCap);
+    }
+  }
+
+  /**
+   * Parse a JSONL chunk and append each well-formed trace into the
+   * in-memory ring. Shared between `loadExisting` (initial load) and
+   * `tailDisk` (incremental merges). Skips malformed rows silently —
+   * the cross-process flock around appends (#584) makes those rare,
+   * and the alternative (throwing) would lose every later row in the
+   * chunk on one bad line.
+   */
+  private consumeRawJsonl(raw: string): void {
     for (const line of raw.split("\n")) {
       if (!line) continue;
       try {
@@ -283,9 +379,6 @@ export class DecisionTraceLog {
       } catch {
         // skip malformed row
       }
-    }
-    if (this.traces.length > this.memoryCap) {
-      this.traces.splice(0, this.traces.length - this.memoryCap);
     }
   }
 }


### PR DESCRIPTION
## Summary

ADR-0007 has two pillars:
- **Write-side flock** — shipped in #584
- **Read-side tail-on-read** — this PR

`runLog.ts` already had `syncFromDisk()` + `lastFileSize` (predates ADR-0007). The other two logs were missing the read half — sibling bridges' writes stayed invisible until a restart. \"Durable cross-session memory\" silently became \"durable to each individual bridge only\".

## decisionTraceLog

- Added `lastReadOffset` field
- Refactored `loadExisting` to set offset to file size after read
- Added `tailDisk()` that re-stats and reads only `[lastReadOffset, size)` on growth (true delta read, not re-parse-whole-file)
- `query()` calls `tailDisk()` first
- `append()` advances offset past our own write so we don't re-read our own rows
- File-shrink (sibling rotated) → full `loadExisting()` to pick up post-rotation state
- Shared parse loop factored into `consumeRawJsonl()`

## commitIssueLinkLog

Mirrors runLog's pattern: `lastFileSize` + `syncFromDisk()`. Uses the `seq > this.seq` guard rather than a byte offset. `append()` and `rotateDisk()` both refresh `lastFileSize`.

## Test plan

- [x] 4 new tail-on-read regression tests (2 per file): sibling bridge appends → query() sees them, self-appends don't get re-loaded as duplicates
- [x] 51 → 55 log tests pass
- [x] Full bridge suite: **5473 pass / 2 skipped** (pre-existing fs.watch flake)
- [x] `npx tsc -p tsconfig.json --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)