### PR TITLE
fix(connectors): unify OAuth state TTL to 10 min across asana/discord/gitlab

### DIFF
--- a/src/connectors/asana.ts
+++ b/src/connectors/asana.ts
@@ -177,12 +177,13 @@ export function isConnected(): boolean {
 }
 
 // ── State (CSRF) ─────────────────────────────────────────────────────────────
-// In-memory map keyed by hex random — short-lived (5 min). Mirrors discord's
-// approach (Set + setTimeout).
+// In-memory map keyed by hex random — short-lived (10 min). Standardised
+// across every OAuth connector in the bridge (gmail / google* / slack /
+// mcpOAuth all use 10 min). Audit 2026-05-17.
 
 import { createOAuthStateStore } from "./oauthStateStore.js";
 
-const STATE_TTL_MS = 5 * 60 * 1000;
+const STATE_TTL_MS = 10 * 60 * 1000;
 const pendingStates = createOAuthStateStore({ ttlMs: STATE_TTL_MS });
 
 function generateState(): string {

--- a/src/connectors/discord.ts
+++ b/src/connectors/discord.ts
@@ -149,13 +149,14 @@ export function isConnected(): boolean {
 }
 
 // ── State (CSRF) ─────────────────────────────────────────────────────────────
-// In-memory map keyed by hex random — short-lived (5 min). Mirrors gmail's
-// approach (Set + setTimeout) rather than slack's on-disk file because we
-// don't need cross-process resumption for an OAuth round-trip.
+// In-memory map keyed by hex random — short-lived (10 min). Standardised
+// across every OAuth connector (gmail / google* / asana / mcpOAuth all
+// use 10 min). Audit 2026-05-17. We don't need cross-process resumption
+// for an OAuth round-trip.
 
 import { createOAuthStateStore } from "./oauthStateStore.js";
 
-const STATE_TTL_MS = 5 * 60 * 1000;
+const STATE_TTL_MS = 10 * 60 * 1000;
 const pendingStates = createOAuthStateStore({ ttlMs: STATE_TTL_MS });
 
 function generateState(): string {

--- a/src/connectors/gitlab.ts
+++ b/src/connectors/gitlab.ts
@@ -192,7 +192,13 @@ export function isConnected(): boolean {
 // ── State (CSRF) ─────────────────────────────────────────────────────────────
 
 const pendingStates = new Set<string>();
-const STATE_TTL_MS = 5 * 60 * 1000;
+// 10-minute TTL — standardised across every OAuth connector in the
+// bridge (gmail / google* / asana / discord / mcpOAuth). Audit
+// 2026-05-17. The unbounded `Set<string>` shape here is pre-#119 and
+// is tracked separately as a follow-up migration to the shared
+// `createOAuthStateStore` (which adds a hard size cap on top of the
+// TTL); this change unifies only the TTL value.
+const STATE_TTL_MS = 10 * 60 * 1000;
 
 function generateState(): string {
   const state = crypto.randomBytes(32).toString("hex");


### PR DESCRIPTION
## Summary

Audit 2026-05-17: three connectors used 5 min for OAuth state TTL while every other connector in the bridge (gmail / google-calendar / google-drive / slack / mcpOAuth) used 10 min. The shared `createOAuthStateStore` default is 10 min — asana / discord explicitly overrode it; gitlab uses a pre-#119 raw `Set<string>` + `setTimeout`.

5 min is enough for the happy case, but a slow network / captcha / MFA / tab-switch can push past 5 min and the user sees \"invalid state\" — confusing for one connector when every other one tolerates it.

Unified on 10 min:
- [asana.ts:185](src/connectors/asana.ts#L185)
- [discord.ts:158](src/connectors/discord.ts#L158)
- [gitlab.ts:195](src/connectors/gitlab.ts#L195) (TTL only; the unbounded `Set<string>` data structure is a separate pre-#119 migration tracked separately)

## Test plan

- [x] 67/67 connector tests pass (asana 29 + discord 32 + gitlab 6)
- [x] `npx tsc -p tsconfig.json --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)