### PR TITLE
security: scrub __proto__ at remaining untrusted JSON.parse boundaries

### DIFF
--- a/src/__tests__/sanitizeParsedJson.test.ts
+++ b/src/__tests__/sanitizeParsedJson.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseJsonSanitized,
+  sanitizeParsedJson,
+} from "../sanitizeParsedJson.js";
+
+describe("sanitizeParsedJson", () => {
+  it("returns primitives unchanged", () => {
+    expect(sanitizeParsedJson("hello")).toBe("hello");
+    expect(sanitizeParsedJson(42)).toBe(42);
+    expect(sanitizeParsedJson(true)).toBe(true);
+    expect(sanitizeParsedJson(null)).toBe(null);
+    expect(sanitizeParsedJson(undefined)).toBe(undefined);
+  });
+
+  it("preserves benign object keys", () => {
+    expect(sanitizeParsedJson({ a: 1, b: "two", c: null })).toEqual({
+      a: 1,
+      b: "two",
+      c: null,
+    });
+  });
+
+  it("strips top-level __proto__ key", () => {
+    // JSON.parse stores __proto__ as an own property via defineProperty;
+    // it does NOT pollute Object.prototype at parse time. The risk is
+    // downstream Object.assign / spread re-introducing it.
+    const raw = JSON.parse('{"__proto__":{"polluted":true},"safe":1}');
+    const sanitized = sanitizeParsedJson(raw) as Record<string, unknown>;
+    expect(sanitized).toEqual({ safe: 1 });
+    expect(Object.hasOwn(sanitized, "__proto__")).toBe(false);
+  });
+
+  it("strips top-level constructor key", () => {
+    const raw = JSON.parse('{"constructor":"evil","safe":1}');
+    expect(sanitizeParsedJson(raw)).toEqual({ safe: 1 });
+  });
+
+  it("strips top-level prototype key", () => {
+    const raw = JSON.parse('{"prototype":"evil","safe":1}');
+    expect(sanitizeParsedJson(raw)).toEqual({ safe: 1 });
+  });
+
+  it("strips dangerous keys at every depth (object children)", () => {
+    const raw = JSON.parse('{"nested":{"__proto__":{"x":1},"a":2},"a":3}');
+    expect(sanitizeParsedJson(raw)).toEqual({
+      nested: { a: 2 },
+      a: 3,
+    });
+  });
+
+  it("strips dangerous keys at every depth (array children)", () => {
+    const raw = JSON.parse(
+      '[{"__proto__":{"x":1},"a":2},{"constructor":"y","b":3}]',
+    );
+    expect(sanitizeParsedJson(raw)).toEqual([{ a: 2 }, { b: 3 }]);
+  });
+
+  it("does not mutate the input", () => {
+    const raw = JSON.parse('{"__proto__":{"x":1},"a":2}');
+    sanitizeParsedJson(raw);
+    // Input still has the dangerous own property — sanitize is a clone.
+    expect(Object.hasOwn(raw as object, "__proto__")).toBe(true);
+  });
+
+  it("preserves arrays of primitives", () => {
+    expect(sanitizeParsedJson([1, "two", null, true])).toEqual([
+      1,
+      "two",
+      null,
+      true,
+    ]);
+  });
+
+  it("preserves nested objects with no dangerous keys", () => {
+    expect(sanitizeParsedJson({ a: { b: { c: [{ d: 1 }] } } })).toEqual({
+      a: { b: { c: [{ d: 1 }] } },
+    });
+  });
+});
+
+describe("parseJsonSanitized", () => {
+  it("parses + sanitizes in one call", () => {
+    expect(parseJsonSanitized('{"__proto__":{"x":1},"a":2}')).toEqual({
+      a: 2,
+    });
+  });
+
+  it("throws on invalid JSON (same as JSON.parse)", () => {
+    expect(() => parseJsonSanitized("not-json")).toThrow(SyntaxError);
+  });
+});

--- a/src/automation.ts
+++ b/src/automation.ts
@@ -15,6 +15,7 @@ import {
 import type { InterpreterContext } from "./fp/interpreterContext.js";
 import { VsCodeBackend } from "./fp/interpreterContext.js";
 import { parsePolicy } from "./fp/policyParser.js";
+import { parseJsonSanitized } from "./sanitizeParsedJson.js";
 
 /** Maximum length (chars) of an automation policy prompt template (matches runClaudeTask cap) */
 const MAX_POLICY_PROMPT_CHARS = 32_768;
@@ -807,7 +808,15 @@ export function loadPolicy(filePath: string): AutomationPolicy {
 
   let parsed: unknown;
   try {
-    parsed = JSON.parse(raw);
+    // Strip `__proto__` / `constructor` / `prototype` own-property keys
+    // at the parse boundary. Automation policy is operator-supplied via
+    // `--automation-policy <file>`, so it's trusted in normal flows —
+    // but the file ships untrusted in shared-host setups (CI runners,
+    // multi-tenant relays) where any user with write access to the
+    // policy file could otherwise inject prototype properties that
+    // surface in downstream Object.assign / spread merges. Audit
+    // 2026-05-17.
+    parsed = parseJsonSanitized(raw);
   } catch (err) {
     throw new Error(
       `Failed to parse automation policy file "${filePath}": ${err instanceof Error ? err.message : String(err)}`,

--- a/src/pluginLoader.ts
+++ b/src/pluginLoader.ts
@@ -18,6 +18,7 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 import type { Config } from "./config.js";
 import type { Logger } from "./logger.js";
+import { parseJsonSanitized } from "./sanitizeParsedJson.js";
 import { TOOL_CATEGORIES } from "./tools/index.js";
 
 /**
@@ -298,7 +299,15 @@ export async function loadOnePluginFull(
 
   let rawManifest: unknown;
   try {
-    rawManifest = JSON.parse(fs.readFileSync(manifestPath, "utf-8"));
+    // Scrub `__proto__` / `constructor` / `prototype` own-property keys
+    // before the manifest is validated and stashed in the plugin
+    // registry. Manifests are operator-trusted today (only loaded via
+    // explicit --plugin flag or the gen-plugin-stub flow), but the
+    // operator may install plugins from arbitrary npm and a hostile
+    // manifest could still inject prototype properties into the
+    // process via downstream Object.assign / spread. Defense-in-depth
+    // at the JSON.parse boundary. Audit 2026-05-17.
+    rawManifest = parseJsonSanitized(fs.readFileSync(manifestPath, "utf-8"));
   } catch (err) {
     logger.warn(
       `Plugin "${spec}" — failed to parse ${MANIFEST_FILE}: ${err instanceof Error ? err.message : String(err)}`,

--- a/src/recipes/yamlRunner.ts
+++ b/src/recipes/yamlRunner.ts
@@ -41,6 +41,14 @@ import { captureFixture } from "../connectors/fixtureRecorder.js";
 import { loadConfig as loadPatchworkConfigSync } from "../patchworkConfig.js";
 import { findYamlRecipePath } from "../recipesHttp.js";
 import type { RecipeRunLog } from "../runLog.js";
+/**
+ * Local alias for `sanitizeParsedJson` from `src/sanitizeParsedJson.ts`.
+ * Kept under the old name so the existing callsites in this file don't
+ * need to be renamed. The shared module is the canonical home for the
+ * prototype-pollution scrub — see PR #568 + audit 2026-05-17 + the
+ * comment in that file for full rationale.
+ */
+import { sanitizeParsedJson as sanitizeParsed } from "../sanitizeParsedJson.js";
 import { ensureCmdShim } from "../winShim.js";
 import {
   executeAgent as _executeAgent,
@@ -65,26 +73,6 @@ import { resolveRecipePath } from "./resolveRecipePath.js";
 import { RunBudget } from "./runBudget.js";
 import type { ErrorPolicy } from "./schema.js";
 import { detectSilentFail } from "./stepObservation.js";
-
-/**
- * Recursively strip prototype-pollution keys from a JSON.parse result before
- * it lands in the recipe ctx. JSON.parse itself doesn't mutate Object.prototype
- * (V8 uses defineProperty), but a `__proto__` own-property survives and will
- * pollute via downstream `Object.assign` / deep-merge operations. Agent step
- * output is attacker-controllable (jailbroken model), so scrub at the parse
- * boundary. See feedback_record_string_prototype_walk.md.
- */
-const DANGEROUS_KEYS = new Set(["__proto__", "constructor", "prototype"]);
-function sanitizeParsed(value: unknown): unknown {
-  if (Array.isArray(value)) return value.map(sanitizeParsed);
-  if (value === null || typeof value !== "object") return value;
-  const out: Record<string, unknown> = {};
-  for (const key of Object.keys(value)) {
-    if (DANGEROUS_KEYS.has(key)) continue;
-    out[key] = sanitizeParsed((value as Record<string, unknown>)[key]);
-  }
-  return out;
-}
 
 // Import tool registry and trigger tool self-registration
 import {

--- a/src/sanitizeParsedJson.ts
+++ b/src/sanitizeParsedJson.ts
@@ -1,0 +1,54 @@
+/**
+ * Recursively strip prototype-pollution keys from a `JSON.parse` result
+ * before it lands in a shared map / merge target / runtime context.
+ *
+ * Why this is needed even though `JSON.parse` doesn't mutate
+ * `Object.prototype`:
+ *   V8 uses `Object.defineProperty(obj, "__proto__", { value, ... })` for
+ *   `JSON.parse('{"__proto__": {...}}')`, so the prototype chain itself
+ *   is unaffected at parse time. But the *own property* survives — and
+ *   any downstream `Object.assign(target, parsed)`, deep-merge, spread,
+ *   or `for...in` traversal that writes via bracket assignment will
+ *   re-introduce the pollution.
+ *
+ * The conservative move at every untrusted-JSON ingest boundary is to
+ * walk the parse result and drop the three dangerous keys
+ * (`__proto__`, `constructor`, `prototype`) recursively.
+ *
+ * See PR #568 + `feedback_record_string_prototype_walk.md` for the
+ * underlying class of bugs. Originally local to
+ * `src/recipes/yamlRunner.ts`; this module is the shared home.
+ */
+
+const DANGEROUS_KEYS = new Set(["__proto__", "constructor", "prototype"]);
+
+/**
+ * Strip `__proto__` / `constructor` / `prototype` own-property keys
+ * recursively from `value`. Returns a plain JSON-safe shape (objects
+ * become `Record<string, unknown>` with the dangerous keys absent;
+ * arrays mapped element-wise; primitives returned as-is).
+ *
+ * This is a clone, not an in-place mutation. The original parse result
+ * is left untouched, so callers can apply this lazily and the eager
+ * shape (e.g. when the parse result is also used for fast-path
+ * comparison) still sees the original.
+ */
+export function sanitizeParsedJson(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sanitizeParsedJson);
+  if (value === null || typeof value !== "object") return value;
+  const out: Record<string, unknown> = {};
+  for (const key of Object.keys(value)) {
+    if (DANGEROUS_KEYS.has(key)) continue;
+    out[key] = sanitizeParsedJson((value as Record<string, unknown>)[key]);
+  }
+  return out;
+}
+
+/**
+ * `JSON.parse` + `sanitizeParsedJson` in one call. Use at any
+ * untrusted-JSON ingest site (agent step output, plugin manifest,
+ * automation policy from disk, connector tokens after store-fetch).
+ */
+export function parseJsonSanitized(raw: string): unknown {
+  return sanitizeParsedJson(JSON.parse(raw));
+}


### PR DESCRIPTION
## Summary

Audit 2026-05-17: PR #568 added a `sanitizeParsed` helper inside [src/recipes/yamlRunner.ts](src/recipes/yamlRunner.ts) to defang `__proto__` / `constructor` / `prototype` keys in agent step JSON output. Two other JSON.parse boundaries had the same risk shape but no scrub:

- [pluginLoader.ts:301](src/pluginLoader.ts#L301) — plugin manifest JSON. Plugins load via `--plugin <path-or-pkg>`; an operator install from arbitrary npm could ship a hostile manifest that introduces prototype properties into the bridge process via downstream Object.assign / spread. **Defense-in-depth, not a current exploit.**
- [automation.ts:810](src/automation.ts#L810) — automation policy JSON loaded from `--automation-policy <file>`. Operator-supplied in normal flows but shared-host setups (CI runners, multi-tenant relays) where any user with write access to the policy file is a real surface.

### Approach

Extracted the scrub helper to [src/sanitizeParsedJson.ts](src/sanitizeParsedJson.ts) as the canonical shared module. Two exports:
- `sanitizeParsedJson(value)` — recursive clone with dangerous keys dropped. Pure; doesn't mutate input.
- `parseJsonSanitized(raw)` — `JSON.parse(raw)` + sanitize in one call.

[src/recipes/yamlRunner.ts](src/recipes/yamlRunner.ts) keeps a local `sanitizeParsed` alias (re-exported from the shared module) so existing callsites don't need to be renamed.

## Test plan

- [x] 12 new tests for the helper: primitives passthrough, top-level / nested stripping (object + array children), non-mutation guarantee, JSON.parse error passthrough
- [x] Full bridge suite: **5481 pass / 2 skipped**
- [x] `npx tsc -p tsconfig.json --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)