### PR TITLE
fix(cli): kill-switch + judgments dogfood — panic --help, --help discoverability, stale-lock walk

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2220,37 +2220,43 @@ if (process.argv[2] === "halts") {
         );
         process.exit(2);
       }
-      // Single-bridge default: query the first. Multi-bridge users will
-      // typically have one orchestrator anyway; expanding to fan-out is a
-      // follow-up if needed.
-      const lock = liveLocks[0];
-      if (!lock) {
-        process.stderr.write("No running bridge found.\n");
-        process.exit(2);
-      }
       const sinceMs = windowSinceMs(window);
       const params: string[] = [];
       if (sinceMs != null) params.push(`sinceMs=${sinceMs}`);
       if (recipeFilter)
         params.push(`recipe=${encodeURIComponent(recipeFilter)}`);
       const qs = params.length > 0 ? `?${params.join("&")}` : "";
-      const controller = new AbortController();
-      const timer = setTimeout(() => controller.abort(), 10_000);
-      let res: Response;
-      try {
-        res = await fetch(
-          `http://127.0.0.1:${lock.port}/runs/halt-summary${qs}`,
-          {
-            headers: { Authorization: `Bearer ${lock.authToken}` },
-            signal: controller.signal,
-          },
-        );
-      } finally {
-        clearTimeout(timer);
+      // Walk live bridges in order; first responsive one wins. See the
+      // matching block in the `judgments` handler — findAllLiveBridges
+      // can include stale entries when a recycled PID still answers
+      // `kill(pid, 0)` but the lock points at a dead bridge.
+      let res: Response | null = null;
+      let lastStatus = 0;
+      for (const lock of liveLocks) {
+        const controller = new AbortController();
+        const timer = setTimeout(() => controller.abort(), 10_000);
+        try {
+          const candidate = await fetch(
+            `http://127.0.0.1:${lock.port}/runs/halt-summary${qs}`,
+            {
+              headers: { Authorization: `Bearer ${lock.authToken}` },
+              signal: controller.signal,
+            },
+          );
+          if (candidate.ok) {
+            res = candidate;
+            break;
+          }
+          lastStatus = candidate.status;
+        } catch {
+          /* unreachable lock — try next */
+        } finally {
+          clearTimeout(timer);
+        }
       }
-      if (!res.ok) {
+      if (!res) {
         process.stderr.write(
-          `Bridge returned ${res.status} for /runs/halt-summary\n`,
+          `No live bridge served /runs/halt-summary (last status: ${lastStatus || "unreachable"}).\n`,
         );
         process.exit(1);
       }
@@ -2382,34 +2388,45 @@ if (process.argv[2] === "judgments") {
         );
         process.exit(2);
       }
-      const lock = liveLocks[0];
-      if (!lock) {
-        process.stderr.write("No running bridge found.\n");
-        process.exit(2);
-      }
       const sinceMs = windowSinceMs(window);
       const params: string[] = [];
       if (sinceMs != null) params.push(`sinceMs=${sinceMs}`);
       if (recipeFilter)
         params.push(`recipe=${encodeURIComponent(recipeFilter)}`);
       const qs = params.length > 0 ? `?${params.join("&")}` : "";
-      const controller = new AbortController();
-      const timer = setTimeout(() => controller.abort(), 10_000);
-      let res: Response;
-      try {
-        res = await fetch(
-          `http://127.0.0.1:${lock.port}/runs/judge-summary${qs}`,
-          {
-            headers: { Authorization: `Bearer ${lock.authToken}` },
-            signal: controller.signal,
-          },
-        );
-      } finally {
-        clearTimeout(timer);
+      // Walk live bridges in order; the first responsive one wins.
+      // findAllLiveBridges uses `kill(pid, 0)` for liveness, which
+      // returns true for any recycled PID — so liveLocks can contain
+      // stale entries from dead bridges. Previously we picked [0]
+      // unconditionally and surfaced a confusing 404; now we try each
+      // and only fall through to the error path when *all* fail.
+      let res: Response | null = null;
+      let lastStatus = 0;
+      for (const lock of liveLocks) {
+        const controller = new AbortController();
+        const timer = setTimeout(() => controller.abort(), 10_000);
+        try {
+          const candidate = await fetch(
+            `http://127.0.0.1:${lock.port}/runs/judge-summary${qs}`,
+            {
+              headers: { Authorization: `Bearer ${lock.authToken}` },
+              signal: controller.signal,
+            },
+          );
+          if (candidate.ok) {
+            res = candidate;
+            break;
+          }
+          lastStatus = candidate.status;
+        } catch {
+          /* unreachable lock — try next */
+        } finally {
+          clearTimeout(timer);
+        }
       }
-      if (!res.ok) {
+      if (!res) {
         process.stderr.write(
-          `Bridge returned ${res.status} for /runs/judge-summary\n`,
+          `No live bridge served /runs/judge-summary (last status: ${lastStatus || "unreachable"}).\n`,
         );
         process.exit(1);
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -251,8 +251,12 @@ if (
       `  recipe --help                             Full recipe subcommand index\n\n` +
       `Diagnose\n` +
       `  halts [--window 1h|24h|overnight|7d]      Morning summary of recent recipe halts\n` +
+      `  judgments [--window ...] [--recipe N]     Recent judge-step verdicts across runs\n` +
       `  traces export                             Bundle approval / recipe / decision traces\n` +
       `  print-token [--port N]                    Print the active bridge auth token\n\n` +
+      `Safety\n` +
+      `  kill-switch <engage|release|status>       Block / resume write-tier tools across bridges\n` +
+      `  panic [--reason "..."]                    Shorthand for kill-switch engage\n\n` +
       `Daemon (no subcommand)\n` +
       `  --workspace <dir>                         Start the bridge in foreground\n` +
       `  --watch                                   Auto-restart supervisor\n` +
@@ -2123,11 +2127,24 @@ if (process.argv[2] === "kill-switch") {
 // form is `kill-switch engage`; this alias matches it so shell history six
 // months later still makes sense. Does not accept sub-verbs — just runs engage.
 if (process.argv[2] === "panic") {
+  const extra = process.argv.slice(3); // e.g. --reason "..." --force-local
+  // Guard against `panic --help` engaging the kill switch — a real
+  // footgun if you tab-completed the verb to confirm syntax before
+  // committing to the action. `panic` is an alias, so we honor --help
+  // here ourselves rather than forwarding to kill-switch engage.
+  if (extra.includes("--help") || extra.includes("-h")) {
+    console.log(
+      'Usage: patchwork panic [--reason "..."] [--force-local]\n\n' +
+        "  Alias for `patchwork kill-switch engage` — blocks all write-tier\n" +
+        "  tool calls across every running bridge. Use --reason to leave a\n" +
+        "  note in the audit trail. Release with `patchwork kill-switch release`.\n",
+    );
+    process.exit(0);
+  }
   // Spawn self with kill-switch engage to reuse the full handler without
   // duplicating 200+ LOC. Passes through any flags (--reason, --force-local).
   import("node:child_process").then(({ spawnSync }) => {
     const self = process.argv[1] ?? process.execPath;
-    const extra = process.argv.slice(3); // e.g. --reason "..." --force-local
     const result = spawnSync(
       process.execPath,
       [self, "kill-switch", "engage", ...extra],


### PR DESCRIPTION
## Summary

Four CLI gaps surfaced by dogfooding the kill-switch and judge features end-to-end.

### 1. 🚨 Critical: \`patchwork panic --help\` engaged the kill switch

\`panic\` forwarded \`--help\` straight to \`kill-switch engage\`, which doesn't recognize it as a help flag and runs as normal. Typing \`panic --help\` to confirm syntax — exactly the cautious thing a user would do — engaged the kill switch on every running bridge. Fix: intercept \`--help\` / \`-h\` at the panic dispatcher before forwarding.

### 2. kill-switch / panic / judgments not in --help

All three were registered as \`KNOWN_SUBCOMMANDS\` but never listed in the top-level \`--help\` output. Users had no way to discover them short of reading source.
- New **Safety** section with kill-switch + panic
- \`judgments\` added to the existing **Diagnose** section next to its sibling \`halts\`

### 3. \`judgments\` + \`halts\` failed on the first stale lock

\`findAllLiveBridges\` uses \`process.kill(pid, 0)\` for liveness — which returns true for any recycled PID even when the bridge itself is dead. When the lock dir had stale bridge lock files before the live one (alphanumerical order), \`judgments\` / \`halts\` picked \`liveLocks[0]\`, got a 404 from the now-different process at that port, and exited with a confusing \"Bridge returned 404\" message. The live bridge was reachable the whole time. Fix: iterate over \`liveLocks\` and fall through per-lock failures — same fan-out shape \`kill-switch status\` already uses.

## Other dogfood findings (not in this PR)

- **Judge step undocumented for recipe authors.** The runtime supports \`agent: { kind: \"judge\", reviews: <stepId> }\` (PR3a / #457), but it's not in \`schemas/recipe.v1.json\`, not in CLAUDE.md, not in \`documents/platform-docs.md\`, and there's no example recipe. Filing as a separate issue — the schema + docs + example are their own PR.
- **Stale lock garbage-collection.** \`findAllLiveBridges\` should probe each lock with an HTTP \`/status\` ping (not just \`kill(pid, 0)\`) and prune locks that fail. This PR works around it at the CLI layer; the proper fix is one level down.

## Test plan

- [ ] \`patchwork panic --help\` → prints help, does NOT engage
- [ ] \`patchwork panic -h\` → same
- [ ] \`patchwork panic\` (no flags) → engages (unchanged behavior)
- [ ] \`patchwork --help\` → shows Safety + Diagnose sections with the new entries
- [ ] \`patchwork judgments\` succeeds when a stale lock exists in front of the live bridge
- [ ] \`patchwork halts\` same
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)