### PR TITLE
docs: surface judge step for recipe authors (closes #598)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ Comply with all docs in `/documents/`. Consult before changes:
 - `install <companion>` — Install one of the bundled MCP-companion server registrations into Claude Desktop or Claude Code config. Use `--target cli|desktop` to choose, `--env KEY=VAL` to pass per-companion env vars. Companions: `memory`, `superpowers`, `devtools`, `database`, `slack`, `playwright`, `codebase-memory`. Each is a documented server config; the command writes it into `~/.claude.json` (CLI) or the Claude Desktop config (desktop) atomically.
 - `kill-switch engage|release|status [--reason <text>]` — Toggle the global write-disable gate (see ADR-0012).
 - `panic` — Shortcut for `kill-switch engage --reason "manual panic"`.
-- `judgments [--since <duration>] [--limit N] [--json]` — Recent approval decisions across all sessions.
+- `judgments [--window 1h|24h|overnight|7d|any] [--recipe <name>] [--json]` — Recent judge-step verdicts (from recipe steps with `agent.kind: judge`) across runs. Discovers the running bridge via lock file, queries `/runs/judge-summary`, prints per-verdict counts + 5 most-recent. Sibling of `halts`; same window/filter shape.
 - `suggest [--since-days N]` — Recipe co-occurrence + unused-tool suggestions from recent activity.
 - `traces export [--passphrase <p>] [--mode keyed|public] > file.jsonl` — Export decision traces; `--mode keyed` encrypts with the passphrase.
 - `traces import [--passphrase <p>] [--dry-run] < file.jsonl` — Restore traces from an export.

--- a/dashboard/public/schema/recipe.v1.json
+++ b/dashboard/public/schema/recipe.v1.json
@@ -215,6 +215,15 @@
                     "type": "string",
                     "description": "Model to use for the agent step"
                   },
+                  "kind": {
+                    "type": "string",
+                    "enum": ["agent", "judge"],
+                    "description": "Step kind. 'agent' (default) runs the prompt as a normal agent step. 'judge' runs a cold-eyes review of another step's output and attaches a structured verdict (approve / request_changes / unparseable). Augment-only: a 'request_changes' verdict adds signal but does not halt the run. Pair with 'reviews: <stepId>'."
+                  },
+                  "reviews": {
+                    "type": "string",
+                    "description": "Step id whose output the judge should review. Required when kind = 'judge'."
+                  },
                   "driver": {
                     "type": "string",
                     "enum": [
@@ -426,6 +435,15 @@
                             "model": {
                               "type": "string"
                             },
+                            "kind": {
+                              "type": "string",
+                              "enum": ["agent", "judge"],
+                              "description": "Step kind. 'agent' (default) runs the prompt as a normal agent step. 'judge' runs a cold-eyes review of another step's output. Pair with 'reviews: <stepId>'."
+                            },
+                            "reviews": {
+                              "type": "string",
+                              "description": "Step id whose output the judge should review. Required when kind = 'judge'."
+                            },
                             "driver": {
                               "type": "string",
                               "enum": [
@@ -609,6 +627,15 @@
           "description": "Path to write final output"
         }
       }
+    },
+    "allowWrites": {
+      "type": "array",
+      "description": "Acknowledge write-tool steps so preflight does not flag them. Each entry is a tool id (e.g. \"file.write\") or a namespace (e.g. \"slack\" to acknowledge every slack.* tool). Equivalent to passing --allow-write on the CLI; the recipe-level list and the CLI list are merged.",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "uniqueItems": true
     },
     "on_error": {
       "type": "object",

--- a/documents/platform-docs.md
+++ b/documents/platform-docs.md
@@ -668,6 +668,15 @@ Recipes live in `~/.patchwork/recipes/` (JSON or YAML). Supported triggers:
 
 Install with `patchwork recipe install <path-to-recipe.yaml>`. Run history persists as JSONL at `~/.patchwork/runs.jsonl` via `RecipeRunLog` (append-only file + bounded in-memory ring); surfaced in the dashboard `/recipes` and `/runs` pages.
 
+### Recipe step kinds
+
+A `steps[]` entry is one of: `agent`, `tool`, or `recipe` (sub-call). Agent steps additionally support a `kind` field that swaps execution semantics.
+
+| `agent.kind` | When | Behavior |
+|---|---|---|
+| `agent` _(default)_ | Most steps | Run the prompt as a normal agent step; result goes into `into` / `agent_output`. |
+| `judge` | Quality gate on another step's output | Cold-eyes review of the step named in `reviews:`. Returns a structured verdict (`approve` / `request_changes` / `unparseable`). **Augment-only — the verdict never halts the run**; it adds signal you can inspect via `patchwork judgments` or the dashboard `/runs` judge widget. Useful for catching borderline output in recipes whose results go somewhere visible (PR comment, inbox draft, ticket update) without breaking the pipeline. See `examples/recipes/judge-cold-eyes-review.yaml`. |
+
 ### Webhook SSRF defenses
 
 `webhookUrl` (approval-queued notification) enforces:

--- a/examples/recipes/judge-cold-eyes-review.yaml
+++ b/examples/recipes/judge-cold-eyes-review.yaml
@@ -1,0 +1,44 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/patchworkos/recipes/main/schema/recipe.v1.json
+apiVersion: patchwork.sh/v1
+version: 1.0.0
+name: judge-cold-eyes-review
+description: |
+  Demonstrates the judge step — a cold-eyes review of another step's output.
+  The judge attaches a structured verdict (approve / request_changes /
+  unparseable) to the run, but does NOT halt the run. Augment-only: the
+  verdict adds signal you can inspect via `patchwork judgments` or the
+  dashboard /runs widget; downstream steps still execute regardless.
+
+  Useful when the first agent's output goes somewhere visible (PR comment,
+  inbox draft, ticket update) and you want a second opinion on quality
+  before a human reads it — request_changes verdicts surface in the
+  judge-summary so you can spot recipes that consistently produce
+  borderline output without breaking them.
+
+trigger:
+  type: manual
+
+steps:
+  - id: draft_summary
+    agent:
+      prompt: |
+        Write a 3-bullet summary of yesterday's git activity in this repo.
+        Each bullet ≤ 14 words. No headings. No preamble.
+    risk: low
+
+  - id: judge_summary
+    awaits:
+      - draft_summary
+    agent:
+      kind: judge
+      reviews: draft_summary
+      prompt: |
+        Review the summary below for:
+        - factual accuracy against the actual git log
+        - bullet-count compliance (exactly 3)
+        - each bullet ≤ 14 words
+        - no headings or preamble
+
+        Return a verdict: approve | request_changes | unparseable
+        Include a one-line reason.
+    risk: low

--- a/schemas/recipe.v1.json
+++ b/schemas/recipe.v1.json
@@ -215,6 +215,15 @@
                     "type": "string",
                     "description": "Model to use for the agent step"
                   },
+                  "kind": {
+                    "type": "string",
+                    "enum": ["agent", "judge"],
+                    "description": "Step kind. 'agent' (default) runs the prompt as a normal agent step. 'judge' runs a cold-eyes review of another step's output and attaches a structured verdict (approve / request_changes / unparseable). Augment-only: a 'request_changes' verdict adds signal but does not halt the run. Pair with 'reviews: <stepId>'."
+                  },
+                  "reviews": {
+                    "type": "string",
+                    "description": "Step id whose output the judge should review. Required when kind = 'judge'."
+                  },
                   "driver": {
                     "type": "string",
                     "enum": [
@@ -425,6 +434,15 @@
                             },
                             "model": {
                               "type": "string"
+                            },
+                            "kind": {
+                              "type": "string",
+                              "enum": ["agent", "judge"],
+                              "description": "Step kind. 'agent' (default) runs the prompt as a normal agent step. 'judge' runs a cold-eyes review of another step's output. Pair with 'reviews: <stepId>'."
+                            },
+                            "reviews": {
+                              "type": "string",
+                              "description": "Step id whose output the judge should review. Required when kind = 'judge'."
                             },
                             "driver": {
                               "type": "string",


### PR DESCRIPTION
## Summary

Closes #598. The judge step (PR3a / #457) was fully wired at runtime and surfaced in the CLI (\`patchwork judgments\`) and dashboard \`/runs\` widget, but recipe authors had no way to discover it without reading source.

## Changes

- **\`schemas/recipe.v1.json\`** + **\`dashboard/public/schema/recipe.v1.json\`**: add \`kind\` enum (\`'agent'\` | \`'judge'\`) and \`reviews\` field to both agent step schema blocks (top-level + the nested copy inside chained-followup). Editors using the SchemaStore pragma now autocomplete + validate judge recipes.
- **\`examples/recipes/judge-cold-eyes-review.yaml\`**: minimal recipe demonstrating the agent → judge pattern.
- **\`CLAUDE.md\`**: corrected the \`judgments\` CLI description — it said \"approval decisions\" but it's actually judge-step verdicts.
- **\`documents/platform-docs.md\`**: new \"Recipe step kinds\" subsection in the Recipes section with a table covering agent + judge.

## Compat

Non-breaking. \`kind\` defaults to \`'agent'\` when absent — every existing recipe validates unchanged against the updated schema.

## Test plan

- [ ] CI green
- [ ] \`patchwork recipe lint examples/recipes/judge-cold-eyes-review.yaml\` → valid
- [ ] Schema additions are present in both files (canonical + dashboard mirror)
- [ ] Spot-check that an editor with the SchemaStore pragma autocompletes \`kind:\` to \`agent\` / \`judge\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)