### PR TITLE
fix(dashboard): close 3 BLOCKERs + 3 MAJORs from audit #600

### DIFF
--- a/dashboard/src/app/api/bridge/recipes/[name]/route.ts
+++ b/dashboard/src/app/api/bridge/recipes/[name]/route.ts
@@ -40,8 +40,12 @@ export async function GET(
       headers: { "content-type": "application/json" },
     });
   } catch (err) {
+    // Audit 2026-05-17 (#600): don't leak err.message (file paths,
+    // ECONNREFUSED detail). Generic proxy was fixed in #120; these
+    // per-route handlers were missed.
+    console.error("[recipes/:name] bridge fetch failed:", err);
     return new Response(
-      JSON.stringify({ error: err instanceof Error ? err.message : "fetch failed" }),
+      JSON.stringify({ error: "Bridge unreachable" }),
       { status: 502, headers: { "content-type": "application/json" } },
     );
   }
@@ -71,8 +75,12 @@ async function forwardWithMethod(
       headers: { "content-type": "application/json" },
     });
   } catch (err) {
+    // Audit 2026-05-17 (#600): don't leak err.message (file paths,
+    // ECONNREFUSED detail). Generic proxy was fixed in #120; these
+    // per-route handlers were missed.
+    console.error("[recipes/:name] bridge fetch failed:", err);
     return new Response(
-      JSON.stringify({ error: err instanceof Error ? err.message : "fetch failed" }),
+      JSON.stringify({ error: "Bridge unreachable" }),
       { status: 502, headers: { "content-type": "application/json" } },
     );
   }
@@ -111,8 +119,12 @@ export async function DELETE(
       headers: { "content-type": "application/json" },
     });
   } catch (err) {
+    // Audit 2026-05-17 (#600): don't leak err.message (file paths,
+    // ECONNREFUSED detail). Generic proxy was fixed in #120; these
+    // per-route handlers were missed.
+    console.error("[recipes/:name] bridge fetch failed:", err);
     return new Response(
-      JSON.stringify({ error: err instanceof Error ? err.message : "fetch failed" }),
+      JSON.stringify({ error: "Bridge unreachable" }),
       { status: 502, headers: { "content-type": "application/json" } },
     );
   }

--- a/dashboard/src/app/api/bridge/recipes/[name]/run/route.ts
+++ b/dashboard/src/app/api/bridge/recipes/[name]/run/route.ts
@@ -47,8 +47,10 @@ export async function POST(
       headers: { "content-type": "application/json" },
     });
   } catch (err) {
+    // #600: don't leak err.message detail; see [name]/route.ts.
+    console.error("[recipes/:name/run] bridge fetch failed:", err);
     return new Response(
-      JSON.stringify({ error: err instanceof Error ? err.message : "fetch failed" }),
+      JSON.stringify({ error: "Bridge unreachable" }),
       { status: 502, headers: { "content-type": "application/json" } },
     );
   }

--- a/dashboard/src/app/api/bridge/recipes/generate/route.ts
+++ b/dashboard/src/app/api/bridge/recipes/generate/route.ts
@@ -37,10 +37,10 @@ export async function POST(req: Request): Promise<Response> {
       headers: { "content-type": "application/json" },
     });
   } catch (err) {
+    // #600: don't leak err.message detail; see [name]/route.ts.
+    console.error("[recipes/generate] bridge fetch failed:", err);
     return new Response(
-      JSON.stringify({
-        error: err instanceof Error ? err.message : "fetch failed",
-      }),
+      JSON.stringify({ error: "Bridge unreachable" }),
       { status: 502, headers: { "content-type": "application/json" } },
     );
   }

--- a/dashboard/src/app/api/bridge/recipes/install/route.ts
+++ b/dashboard/src/app/api/bridge/recipes/install/route.ts
@@ -84,9 +84,8 @@ export async function POST(req: Request): Promise<Response> {
       headers: { "content-type": "application/json" },
     });
   } catch (err) {
-    return jsonError(
-      502,
-      err instanceof Error ? err.message : "fetch failed",
-    );
+    // #600: don't leak err.message detail; see [name]/route.ts.
+    console.error("[recipes/install] bridge fetch failed:", err);
+    return jsonError(502, "Bridge unreachable");
   }
 }

--- a/dashboard/src/app/api/bridge/recipes/lint/route.ts
+++ b/dashboard/src/app/api/bridge/recipes/lint/route.ts
@@ -36,8 +36,10 @@ export async function POST(req: NextRequest): Promise<Response> {
       headers: { "content-type": "application/json" },
     });
   } catch (err) {
+    // #600: don't leak err.message detail; see [name]/route.ts.
+    console.error("[recipes/lint] bridge fetch failed:", err);
     return new Response(
-      JSON.stringify({ error: err instanceof Error ? err.message : "fetch failed" }),
+      JSON.stringify({ error: "Bridge unreachable" }),
       { status: 502, headers: { "content-type": "application/json" } },
     );
   }

--- a/dashboard/src/app/api/push/subscribe/__tests__/route.test.ts
+++ b/dashboard/src/app/api/push/subscribe/__tests__/route.test.ts
@@ -15,16 +15,33 @@ vi.mock("@/lib/pushStore", () => ({
   addSubscription: vi.fn(),
 }));
 
+// Audit 2026-05-17 (#600): subscribe now requires a valid session
+// (defense-in-depth on top of CSRF) — see route.ts comment. Mock
+// verifySession so existing CSRF tests still exercise the same-origin
+// path with a valid session by default; the new session-required test
+// makes verifySession return invalid.
+vi.mock("@/lib/session", () => ({
+  SESSION_COOKIE_NAME: "patchwork_session",
+  verifySession: vi.fn(),
+}));
+
 import { POST } from "@/app/api/push/subscribe/route";
 import { addSubscription } from "@/lib/pushStore";
+import { verifySession } from "@/lib/session";
 
 beforeEach(() => {
   vi.mocked(addSubscription).mockReset();
+  vi.mocked(verifySession).mockResolvedValue({ valid: true, expiresAt: Date.now() + 60_000 });
 });
 
-function makeReq(secFetchSite: string | null, body: unknown): NextRequest {
+function makeReq(
+  secFetchSite: string | null,
+  body: unknown,
+  cookie: string = "patchwork_session=valid",
+): NextRequest {
   const headers = new Headers({ "content-type": "application/json" });
   if (secFetchSite !== null) headers.set("sec-fetch-site", secFetchSite);
+  if (cookie) headers.set("cookie", cookie);
   return new NextRequest("http://localhost:3200/api/push/subscribe", {
     method: "POST",
     headers,
@@ -50,9 +67,16 @@ describe("POST /api/push/subscribe — CSRF guard", () => {
     expect(addSubscription).not.toHaveBeenCalled();
   });
 
-  it("accepts same-origin requests", async () => {
+  it("accepts same-origin requests with valid session", async () => {
     const res = await POST(makeReq("same-origin", validSub));
     expect(res.status).toBe(200);
     expect(addSubscription).toHaveBeenCalledOnce();
+  });
+
+  it("rejects same-origin requests without a valid session (401)", async () => {
+    vi.mocked(verifySession).mockResolvedValue({ valid: false });
+    const res = await POST(makeReq("same-origin", validSub));
+    expect(res.status).toBe(401);
+    expect(addSubscription).not.toHaveBeenCalled();
   });
 });

--- a/dashboard/src/app/api/push/subscribe/route.ts
+++ b/dashboard/src/app/api/push/subscribe/route.ts
@@ -6,11 +6,25 @@ import {
   bodyTooLargeResponse,
   readJsonWithCap,
 } from "@/lib/readBodyWithCap";
+import { SESSION_COOKIE_NAME, verifySession } from "@/lib/session";
 import type { PushSubscription } from "web-push";
 
 export async function POST(req: NextRequest) {
   const guard = requireSameOrigin(req);
   if (guard) return guard;
+
+  // Audit 2026-05-17 (#600 BLOCKER #4): the route was exempt from the
+  // middleware session gate to let the SW re-subscribe via
+  // pushsubscriptionchange, but SW fetches default to
+  // credentials: "same-origin" and DO carry the session cookie. The
+  // exemption left an unauthenticated addSubscription that any visitor
+  // (or attacker faking Origin) could spam, polluting the push store.
+  // Re-protect at the handler layer and trim the middleware exempt
+  // list to match.
+  const session = await verifySession(req.cookies.get(SESSION_COOKIE_NAME)?.value);
+  if (!session.valid) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
 
   const parsed = await readJsonWithCap<unknown>(req, DASHBOARD_API_BODY_CAPS.push);
   if (!parsed.ok) {

--- a/dashboard/src/app/api/push/unsubscribe/route.ts
+++ b/dashboard/src/app/api/push/unsubscribe/route.ts
@@ -6,10 +6,20 @@ import {
   bodyTooLargeResponse,
   readJsonWithCap,
 } from "@/lib/readBodyWithCap";
+import { SESSION_COOKIE_NAME, verifySession } from "@/lib/session";
 
 export async function POST(req: NextRequest) {
   const guard = requireSameOrigin(req);
   if (guard) return guard;
+
+  // Audit 2026-05-17 (#600 BLOCKER #4): unauthenticated unsubscribe
+  // would let an attacker silently de-register real devices. Same
+  // exemption story as subscribe — see that file.
+  const session = await verifySession(req.cookies.get(SESSION_COOKIE_NAME)?.value);
+  if (!session.valid) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
   const parsed = await readJsonWithCap<Record<string, unknown>>(
     req,
     DASHBOARD_API_BODY_CAPS.push,

--- a/dashboard/src/app/connections/page.tsx
+++ b/dashboard/src/app/connections/page.tsx
@@ -957,8 +957,10 @@ export default function ConnectionsPage() {
 
   async function handleTokenConnect() {
     if (!tokenModal) return;
-    setTokenConnecting(true);
-    setTokenErr(null);
+    // Audit 2026-05-17 (#600): validate BEFORE flipping the spinner.
+    // The previous order set tokenConnecting=true then early-returned
+    // on missing fields without resetting it — the Save button got
+    // stuck on "Connecting…" forever until the modal was reopened.
     const cfg = TOKEN_MODAL_CONNECTORS[tokenModal];
     const missing = (cfg.extraFields ?? [])
       .filter((f) => f.required && !tokenExtras[f.key]?.trim())
@@ -967,6 +969,8 @@ export default function ConnectionsPage() {
       setTokenErr(`Missing required field${missing.length === 1 ? "" : "s"}: ${missing.join(", ")}`);
       return;
     }
+    setTokenConnecting(true);
+    setTokenErr(null);
     const payload: Record<string, string> = { [cfg.tokenKey]: tokenValue };
     for (const f of cfg.extraFields ?? []) {
       const v = tokenExtras[f.key]?.trim();

--- a/dashboard/src/app/sessions/page.tsx
+++ b/dashboard/src/app/sessions/page.tsx
@@ -127,29 +127,7 @@ export default function SessionsPage() {
   );
 
   const [selectedId, setSelectedId] = useState<string | null>(null);
-  const [pausing, setPausing] = useState(false);
-
   const sessions = data ?? [];
-
-  async function handlePauseAll() {
-    if (sessions.length === 0 || pausing) return;
-    setPausing(true);
-    try {
-      const res = await fetch(apiPath("/api/bridge/sessions/pause-all"), { method: "POST" });
-      if (!res.ok) {
-        const body = (await res.json().catch(() => ({}))) as { error?: string };
-        throw new Error(body.error ?? `Server returned ${res.status}`);
-      }
-      toast.success(`Paused ${sessions.length} session${sessions.length === 1 ? "" : "s"}`);
-      refetch();
-    } catch (e) {
-      toast.error(
-        `Couldn't pause sessions — ${e instanceof Error ? e.message : String(e)}`,
-      );
-    } finally {
-      setPausing(false);
-    }
-  }
 
   const liveCount = sessions.filter((s) => {
     const lastMs =
@@ -188,18 +166,10 @@ export default function SessionsPage() {
             ]}
           />
         </div>
-        <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
-          <button
-            type="button"
-            className="btn sm ghost"
-            disabled={sessions.length === 0 || pausing}
-            style={sessions.length === 0 ? { opacity: 0.4, cursor: "default" } : undefined}
-            onClick={() => void handlePauseAll()}
-          >
-            <span aria-hidden style={{ marginRight: 6 }}>❚❚</span>
-            {pausing ? "Pausing…" : "Pause all"}
-          </button>
-        </div>
+        {/* Pause-all button removed 2026-05-17 (#600 BLOCKER #3):
+            POST /api/bridge/sessions/pause-all has no bridge route — the
+            button always 404'd. Restore when the bridge ships a
+            sessions pause-all endpoint. */}
       </div>
 
       {error && sessions.length === 0 && (

--- a/dashboard/src/app/settings/page.tsx
+++ b/dashboard/src/app/settings/page.tsx
@@ -467,8 +467,13 @@ export default function SettingsPage() {
     }
   }
 
-  async function saveApiKey(provider: ApiKeyProvider) {
-    const key = keyDrafts[provider];
+  async function saveApiKey(provider: ApiKeyProvider, explicitKey?: string) {
+    // Audit 2026-05-17 (#600): reading keyDrafts[provider] from closure
+    // is stale when the Clear button queues setKeyDrafts("") immediately
+    // before calling this — React batches state updates, so the OLD key
+    // gets re-saved instead of cleared. Accept an explicit value to
+    // bypass the closure for callers that already know the intended key.
+    const key = explicitKey !== undefined ? explicitKey : keyDrafts[provider];
     setKeySaving(provider);
     setKeyMsg(null);
     try {
@@ -1035,7 +1040,9 @@ export default function SettingsPage() {
                               onClick={() => {
                                 setKeyDrafts((d) => ({ ...d, [provider]: "" }));
                                 // Empty string deletes from secure store.
-                                void saveApiKey(provider);
+                                // Pass "" explicitly — saveApiKey would
+                                // otherwise read the stale closure key.
+                                void saveApiKey(provider, "");
                               }}
                               disabled={keySaving === provider}
                               title="Remove the stored key from the secure store"

--- a/dashboard/src/app/tasks/page.tsx
+++ b/dashboard/src/app/tasks/page.tsx
@@ -92,8 +92,8 @@ function TaskDetail({ task, onCancel, cancelling }: {
   cancelling: Record<string, boolean>;
 }) {
   const toast = useToast();
-  const [copied, setCopied] = useState<"id" | "term" | "replay" | null>(null);
-  function flash(kind: "id" | "term" | "replay") {
+  const [copied, setCopied] = useState<"id" | "term" | null>(null);
+  function flash(kind: "id" | "term") {
     setCopied(kind);
     setTimeout(() => setCopied((c) => (c === kind ? null : c)), 1500);
   }
@@ -227,30 +227,11 @@ function TaskDetail({ task, onCancel, cancelling }: {
         >
           {copied === "term" ? "✓ Copied" : "> Open in terminal"}
         </button>
-        <button
-          type="button"
-          className="btn sm ghost"
-          style={{ fontSize: "var(--fs-s)" }}
-          onClick={async () => {
-            try {
-              const res = await fetch(
-                apiPath(`/api/bridge/tasks/${task.taskId}/replay`),
-                { method: "POST" },
-              );
-              if (!res.ok) {
-                const body = (await res.json().catch(() => ({}))) as { error?: string };
-                throw new Error(body.error ?? `Server returned ${res.status}`);
-              }
-              flash("replay");
-            } catch (e) {
-              toast.error(
-                `Couldn't replay — ${e instanceof Error ? e.message : String(e)}`,
-              );
-            }
-          }}
-        >
-          {copied === "replay" ? "✓ Queued" : "↻ Replay"}
-        </button>
+        {/* Replay button removed 2026-05-17 (#600 BLOCKER #2): targeted
+            POST /api/bridge/tasks/:id/replay which the bridge never
+            implemented (only POST /runs/:seq/replay exists, for recipe
+            runs). Every click 404'd with a confusing "Couldn't replay"
+            toast. Restore once the bridge ships a tasks replay route. */}
         <button
           type="button"
           className="btn sm ghost"

--- a/dashboard/src/middleware.ts
+++ b/dashboard/src/middleware.ts
@@ -103,18 +103,24 @@ export const config = {
     //
     // PWA + SW machinery exemptions (these paths must be reachable
     // without a session so the PWA can install and the service worker
-    // can re-subscribe in the background):
+    // can register before login):
     //   - sw.js: registered by `navigator.serviceWorker.register` on
     //     page load; must be cacheable by the browser before login.
     //   - icons/: PWA icons referenced from manifest.json.
     //   - api/push/vapid-key: SW context fetches this on
-    //     pushsubscriptionchange; SW doesn't always carry the cookie.
-    //   - api/push/{subscribe,unsubscribe}: same SW context limitation;
-    //     they have their own same-origin CSRF guard.
+    //     pushsubscriptionchange. Read-only, public; safe to expose.
+    //
+    // api/push/{subscribe,unsubscribe} used to be exempt here too on
+    // the theory that the SW couldn't carry the session cookie. In
+    // practice SW fetches default to `credentials: "same-origin"` and
+    // DO send the cookie, so the exemption was wrong — it left two
+    // mutation endpoints unauthenticated. Removed 2026-05-17 (#600).
+    // Defense-in-depth: those handlers also re-check the session.
+    //
     // Root path (basePath bare) explicitly — the negative-lookahead
     // matcher below doesn't reliably catch `/` alone in Next.js, which
     // means the dashboard's overview page would otherwise be unprotected.
     "/",
-    "/((?!_next/static|_next/image|favicon\\.ico|favicon\\.svg|manifest\\.json|robots\\.txt|schema/|marketplace|api/login|api/relay/push|sw\\.js|icons/|api/push/vapid-key|api/push/subscribe|api/push/unsubscribe).*)",
+    "/((?!_next/static|_next/image|favicon\\.ico|favicon\\.svg|manifest\\.json|robots\\.txt|schema/|marketplace|api/login|api/relay/push|sw\\.js|icons/|api/push/vapid-key).*)",
   ],
 };


### PR DESCRIPTION
Closes the highest-impact findings from [#600](https://github.com/Oolab-labs/patchwork-os/issues/600) — the 2026-05-17 dogfood audit.

## Security (BLOCKER)
**\`api/push/{subscribe,unsubscribe}\`** were exempt from middleware session auth on the (incorrect) assumption that SW fetches couldn't carry the session cookie. SW fetches default to \`credentials: \"same-origin\"\` and DO send the cookie — the exemption left two unauthenticated mutation endpoints that any visitor could spam to pollute \`~/.claude/patchwork-push-subscriptions.json\` or silently unsubscribe real devices. Now: handler-level \`verifySession()\` (defense-in-depth) plus the middleware exempt list trimmed to match.

## Dead UI (BLOCKER)
- **Tasks page \`↻ Replay\` button** removed. Targeted \`POST /api/bridge/tasks/:id/replay\` which the bridge never shipped (only \`/runs/:seq/replay\` exists, for recipes). Every click 404'd.
- **Sessions page \`❚❚ Pause all\` button** removed. \`POST /api/bridge/sessions/pause-all\` has no bridge route.
Both can be restored when the bridge ships the endpoints.

## Data integrity (MAJOR)
**Settings \"Clear\" API key sent the OLD key.** \`setKeyDrafts(empty)\` batches with React state; \`saveApiKey()\` then read \`keyDrafts[provider]\` from a stale closure → saved the unchanged key. Fix: \`saveApiKey\` accepts an explicit value; Clear calls with \`\"\"\`.

## UX dead-end (MAJOR)
**Connections \`Save\` stuck on \"Connecting…\".** \`handleTokenConnect\` flipped \`setTokenConnecting(true)\` then early-returned on missing-field validation without resetting it. Moved validation BEFORE the spinner flip.

## Info disclosure (MAJOR)
**5 recipe routes** (\`lint\`, \`install\`, \`generate\`, \`[name]\`, \`[name]/run\`) returned \`err.message\` in 502 bodies, leaking file paths + ECONNREFUSED detail. The generic \`[...path]\` proxy was fixed in #120; these per-route handlers were missed. Now return \`\"Bridge unreachable\"\` and \`console.error\` the detail server-side.

## Closes
From #600: BLOCKERs #2, #3, #4 and three MAJORs.
Remaining #600 work (race conditions, mobile audit gaps, login basePath, etc.) will follow in separate PRs.

## Test plan

- [ ] CI green
- [ ] Local: unauthenticated POST to \`/dashboard/api/push/subscribe\` returns 401
- [ ] Local: tasks page no longer shows Replay button; sessions page no longer shows Pause-all
- [ ] Local: Settings Clear sends an empty body (verify in network tab) and badge updates to 'key cleared'
- [ ] Local: open Confluence (or any token connector) modal with required field empty; click Save with no value → error message AND Save button re-enables
- [ ] Stop the bridge, hit \`/api/bridge/recipes/foo\` from the dashboard; response body is \`{\"error\":\"Bridge unreachable\"}\` (no path detail); server logs carry the full error

🤖 Generated with [Claude Code](https://claude.com/claude-code) — surfaced by structured dogfood session.