### PR TITLE
fix(dashboard): close 13 #600 audit items (re-fetch + AbortControllers + mobile + UX + security)

### DIFF
--- a/dashboard/src/app/activity/page.tsx
+++ b/dashboard/src/app/activity/page.tsx
@@ -340,12 +340,9 @@ export default function ActivityPage() {
 
       {/* Charts row: histogram + top tools */}
       <div
-        style={{
-          display: "grid",
-          gridTemplateColumns: "1fr minmax(0, 340px)",
-          gap: "var(--s-4)",
-          marginBottom: "var(--s-4)",
-        }}
+        // #600: .two-pane-340-rev collapses to single column at ≤768px.
+        className="two-pane-340-rev"
+        style={{ marginBottom: "var(--s-4)" }}
       >
         <div className="card" style={{ padding: "14px 18px 10px" }}>
           <div

--- a/dashboard/src/app/api/login/route.ts
+++ b/dashboard/src/app/api/login/route.ts
@@ -76,14 +76,22 @@ export async function POST(req: NextRequest) {
 
   const a = Buffer.from(password, "utf8");
   const b = Buffer.from(expected, "utf8");
-  // timingSafeEqual requires equal-length buffers; pad the shorter one
-  // so a length-only timing leak doesn't bypass the loop.
-  const len = Math.max(a.length, b.length);
-  const pa = Buffer.alloc(len);
-  const pb = Buffer.alloc(len);
-  a.copy(pa);
-  b.copy(pb);
-  const equal = a.length === b.length && crypto.timingSafeEqual(pa, pb);
+  // Constant-time compare. Pad BOTH inputs to the same fixed buffer
+  // (PAD = 256) every call so the loop cost is identical regardless of
+  // either input's length, then AND with a length-equality check that
+  // runs AFTER timingSafeEqual (not before — short-circuiting on
+  // length is the same leak as not padding at all).
+  // Audit 2026-05-17 (#600): previous version padded to
+  // `max(a.length, b.length)` and short-circuited on `a.length ===
+  // b.length` BEFORE timingSafeEqual, leaking expected-password length
+  // via response time.
+  const PAD = 256;
+  const pa = Buffer.alloc(PAD);
+  const pb = Buffer.alloc(PAD);
+  if (a.length <= PAD) a.copy(pa);
+  if (b.length <= PAD) b.copy(pb);
+  const bytesEqual = crypto.timingSafeEqual(pa, pb);
+  const equal = bytesEqual && a.length === b.length;
 
   if (!equal) {
     const result = recordFailure(ip);

--- a/dashboard/src/app/connections/page.tsx
+++ b/dashboard/src/app/connections/page.tsx
@@ -1009,6 +1009,13 @@ export default function ConnectionsPage() {
     }
     const popup = window.open(apiPath(`/api/connections/${id}/auth`), "_blank");
     if (!popup) {
+      // Audit 2026-05-17 (#600): blocked-popup state was silently
+      // returned to runReAuthAll but ignored by per-card Connect clicks,
+      // so single-card connects looked like the button did nothing.
+      // Surface here so every caller benefits.
+      toast.error(
+        `Browser blocked the ${id} popup. Allow popups for this site and try again.`,
+      );
       return Promise.resolve("blocked");
     }
     return new Promise((resolve) => {

--- a/dashboard/src/app/globals.css
+++ b/dashboard/src/app/globals.css
@@ -1521,6 +1521,30 @@ button.topbar-search {
   }
 }
 
+/* /sessions + /activity two-pane layout (340 px rail + detail).
+   Audit 2026-05-17 (#600): both pages used inline grid-template-columns
+   with no media query, so the 340 px column overflowed phone viewports
+   and forced a horizontal scroll. Collapse to single column under 768 px,
+   matching .tasks-layout. */
+.two-pane-340 {
+  display: grid;
+  grid-template-columns: 340px minmax(0, 1fr);
+  gap: var(--s-4);
+  align-items: start;
+}
+.two-pane-340-rev {
+  display: grid;
+  grid-template-columns: 1fr minmax(0, 340px);
+  gap: var(--s-4);
+  align-items: start;
+}
+@media (max-width: 768px) {
+  .two-pane-340,
+  .two-pane-340-rev {
+    grid-template-columns: 1fr;
+  }
+}
+
 
 /* ---- Decision rows ---- */
 

--- a/dashboard/src/app/inbox/page.tsx
+++ b/dashboard/src/app/inbox/page.tsx
@@ -939,7 +939,25 @@ const filteredItems = items.filter((item) => {
                               );
                               if (!res.ok) {
                                 const text = await res.text().catch(() => res.statusText);
-                                toast.error(`Replay failed: ${text || res.status}`);
+                                // Audit 2026-05-17 (#600): the bridge
+                                // returns 400 with a 'vars' / 'required'
+                                // message when the recipe declares vars
+                                // that the empty body didn't supply.
+                                // Route the user to the Recipes page Run
+                                // button (which has the vars-input modal)
+                                // instead of a generic "Replay failed"
+                                // toast. Restoring full inline vars input
+                                // here is tracked separately.
+                                const looksLikeMissingVars =
+                                  res.status === 400 &&
+                                  /\bvars?\b|required/i.test(text);
+                                if (looksLikeMissingVars) {
+                                  toast.error(
+                                    `Recipe needs vars — open from /recipes to fill them in.`,
+                                  );
+                                } else {
+                                  toast.error(`Replay failed: ${text || res.status}`);
+                                }
                               } else {
                                 toast.success(`Replayed “${recipeNameForSelected}”`);
                               }

--- a/dashboard/src/app/inbox/page.tsx
+++ b/dashboard/src/app/inbox/page.tsx
@@ -411,11 +411,18 @@ export default function InboxPage() {
   const detailRef = useRef<HTMLDivElement | null>(null);
   const selectedRef = useRef<InboxDetail | null>(null);
   selectedRef.current = selected;
+  // #600: track in-flight list fetch so we can abort on unmount /
+  // visibilitychange. Previously the response could land after the
+  // user navigated away → setItems() on a dead tree.
+  const listAbortRef = useRef<AbortController | null>(null);
 
   const fetchList = useCallback(async (manual = false) => {
+    listAbortRef.current?.abort();
+    const controller = new AbortController();
+    listAbortRef.current = controller;
     if (manual) setRefreshing(true);
     try {
-      const res = await fetch(apiPath("/api/inbox"));
+      const res = await fetch(apiPath("/api/inbox"), { signal: controller.signal });
       if (!res.ok) throw new Error(`/api/inbox ${res.status}`);
       const data = (await res.json()) as { items: InboxItem[] };
       const incoming = data.items ?? [];
@@ -436,15 +443,22 @@ export default function InboxPage() {
       if (cur) {
         const updated = incoming.find((i) => i.name === cur.name);
         if (updated && updated.modifiedAt !== cur.modifiedAt) {
-          const detailRes = await fetch(apiPath(`/api/inbox/${encodeURIComponent(cur.name)}`));
+          const detailRes = await fetch(
+            apiPath(`/api/inbox/${encodeURIComponent(cur.name)}`),
+            { signal: controller.signal },
+          );
           if (detailRes.ok) setSelected((await detailRes.json()) as InboxDetail);
         }
       }
     } catch (e) {
+      if (e instanceof DOMException && e.name === "AbortError") return;
       setErr(e instanceof Error ? e.message : String(e));
     } finally {
-      setLoading(false);
-      if (manual) setRefreshing(false);
+      if (listAbortRef.current === controller) {
+        setLoading(false);
+        if (manual) setRefreshing(false);
+        listAbortRef.current = null;
+      }
     }
   }, [seenNames]);
 
@@ -463,6 +477,8 @@ export default function InboxPage() {
     return () => {
       if (pollRef.current) clearInterval(pollRef.current);
       document.removeEventListener("visibilitychange", onVisible);
+      // #600: abort any in-flight list fetch on unmount.
+      listAbortRef.current?.abort();
     };
   }, [fetchList]);
 

--- a/dashboard/src/app/login/login-form.tsx
+++ b/dashboard/src/app/login/login-form.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useState } from "react";
+import { apiPath } from "@/lib/api";
 
 /**
  * Single-password login form. Posts to /api/login, follows the JSON
@@ -17,7 +18,12 @@ export function LoginForm({ next }: { next: string }) {
     setBusy(true);
     setErr("");
     try {
-      const res = await fetch("/dashboard/api/login", {
+      // Audit 2026-05-17 (#600): use apiPath() so the form works when
+      // NEXT_PUBLIC_BASE_PATH is anything other than the literal
+      // "/dashboard" (root mount, custom prefix, etc.). The hardcoded
+      // path 404'd on non-default deploys and showed a generic "Error
+      // 404" to the user with no hint why.
+      const res = await fetch(apiPath("/api/login"), {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ password: pw, next }),

--- a/dashboard/src/app/marketplace/submit/page.tsx
+++ b/dashboard/src/app/marketplace/submit/page.tsx
@@ -178,6 +178,10 @@ export default function MarketplaceSubmitPage() {
   const [lintResult, setLintResult] = useState<LintResult | null>(null);
   const [lintError, setLintError] = useState<string | null>(null);
   const [linting, setLinting] = useState(false);
+  // #600: in-flight lint controller. Rapid clicks → stale response can
+  // overwrite a newer result. Aborting the previous request before
+  // firing a new one keeps the latest-click semantics intact.
+  const lintAbortRef = useRef<AbortController | null>(null);
 
   // ---- starter recipes (load from bridge if running) ---------------
   const [installedNames, setInstalledNames] = useState<string[]>([]);
@@ -401,6 +405,11 @@ export default function MarketplaceSubmitPage() {
 
   // ---- validation --------------------------------------------------
   async function runLint() {
+    // #600: cancel any in-flight lint before starting a new one so the
+    // latest click always wins.
+    lintAbortRef.current?.abort();
+    const controller = new AbortController();
+    lintAbortRef.current = controller;
     setLinting(true);
     setLintError(null);
     try {
@@ -408,6 +417,7 @@ export default function MarketplaceSubmitPage() {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ content: yaml }),
+        signal: controller.signal,
       });
       if (!res.ok) {
         if (res.status === 502 || res.status === 503 || res.status === 504) {
@@ -442,9 +452,17 @@ export default function MarketplaceSubmitPage() {
         );
       }
     } catch (err) {
+      // Aborts from a newer click are expected — don't surface them.
+      if (err instanceof DOMException && err.name === "AbortError") return;
       setLintError(err instanceof Error ? err.message : String(err));
     } finally {
-      setLinting(false);
+      // Only clear the loading flag if THIS controller is still the
+      // current one — a newer click already kicked off and will manage
+      // its own setLinting(false).
+      if (lintAbortRef.current === controller) {
+        setLinting(false);
+        lintAbortRef.current = null;
+      }
     }
   }
 

--- a/dashboard/src/app/page.tsx
+++ b/dashboard/src/app/page.tsx
@@ -273,13 +273,6 @@ function formatUptime(ms: number): string {
   return `${sec}s`;
 }
 
-function parseUptimeMs(text: string): number | null {
-  if (!text) return null;
-  const m = text.match(/^bridge_uptime_seconds\s+(\d+(?:\.\d+)?)/m);
-  if (m) return Math.round(Number.parseFloat(m[1]) * 1000);
-  return null;
-}
-
 // Telemetry-tile icons. Match the wireframe glyphs (≡ recipes, 🔒 approvals,
 // >_ tools, ☉ tokens) but rendered as 12×12 inline SVGs at --ink-3 so they
 // read as muted decoration next to the uppercase tile labels.
@@ -1176,6 +1169,3 @@ export default function HomePage() {
 
 // (kept for upstream typing imports / no-op reference)
 export type { BridgeHealth };
-
-// Suppress unused-import false positives for parsing helper retained intentionally.
-void parseUptimeMs;

--- a/dashboard/src/app/runs/[seq]/page.tsx
+++ b/dashboard/src/app/runs/[seq]/page.tsx
@@ -564,10 +564,18 @@ function statusPillClass(status: RunDetail["status"]): string {
 function CausalChainCard({ run }: { run: RunDetail }) {
   const [parent, setParent] = useState<RunSummary | null>(null);
   const [children, setChildren] = useState<RunSummary[]>([]);
+  // Serialize childSeqs for the dep array. Using the array reference
+  // directly re-fires this effect on every 5s polling tick (the parent
+  // returns a fresh RunDetail object → fresh childSeqs reference,
+  // even when contents are identical), which means full N+1 re-fetch
+  // every 5s while the page is open. Audit 2026-05-17 (#600). Serialize
+  // to a string so identity equality holds across stable contents.
+  const childSeqsKey = run.childSeqs?.join(",") ?? "";
 
   useEffect(() => {
+    const controller = new AbortController();
     if (run.parentSeq) {
-      fetch(apiPath(`/api/bridge/runs/${run.parentSeq}`))
+      fetch(apiPath(`/api/bridge/runs/${run.parentSeq}`), { signal: controller.signal })
         .then((r) => r.ok ? r.json() : null)
         .then((d: { run?: RunSummary } | null) => {
           if (d?.run) setParent(d.run);
@@ -577,7 +585,7 @@ function CausalChainCard({ run }: { run: RunDetail }) {
     if (run.childSeqs && run.childSeqs.length > 0) {
       Promise.all(
         run.childSeqs.map((seq) =>
-          fetch(apiPath(`/api/bridge/runs/${seq}`))
+          fetch(apiPath(`/api/bridge/runs/${seq}`), { signal: controller.signal })
             .then((r) => r.ok ? r.json() : null)
             .then((d: { run?: RunSummary } | null) => d?.run ?? null)
             .catch(() => null),
@@ -586,7 +594,12 @@ function CausalChainCard({ run }: { run: RunDetail }) {
         setChildren(results.filter((r): r is RunSummary => r !== null));
       });
     }
-  }, [run.parentSeq, run.childSeqs]);
+    return () => controller.abort();
+    // childSeqsKey is the serialized form of run.childSeqs — using the
+    // array directly would re-run every poll tick. eslint can't see
+    // the equivalence; this is intentional.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [run.parentSeq, childSeqsKey]);
 
   const hasParent = !!run.parentSeq;
   const hasChildren = (run.childSeqs ?? []).length > 0;

--- a/dashboard/src/app/runs/page.tsx
+++ b/dashboard/src/app/runs/page.tsx
@@ -190,6 +190,13 @@ export default function RunsPage() {
   const reloadRef = useRef<() => void>(() => {});
 
   useEffect(() => {
+    // Audit 2026-05-17 (#600): one AbortController per effect run,
+    // aborted in cleanup. Without this, rapid filter changes could
+    // race-overwrite the latest result with stale responses from the
+    // previous filter set — user flips trigger to 'cron', sees old
+    // 'manual' results blink in. The interval handle is independent;
+    // the controller only cancels in-flight requests.
+    const controller = new AbortController();
     const load = async () => {
       try {
         const params = new URLSearchParams({ limit: String(limit) });
@@ -197,36 +204,48 @@ export default function RunsPage() {
         if (status !== "all") params.set("status", status);
         if (debouncedRecipeQuery) params.set("recipe", debouncedRecipeQuery);
         if (attemptFilter) params.set("manualRunId", attemptFilter);
-        const res = await fetch(apiPath(`/api/bridge/runs?${params}`));
+        const res = await fetch(apiPath(`/api/bridge/runs?${params}`), {
+          signal: controller.signal,
+        });
         if (!res.ok) throw new Error(`/runs ${res.status}`);
         const data = (await res.json()) as { runs?: Run[] };
         setRuns(data.runs ?? []);
         setErr(undefined);
       } catch (e) {
+        // AbortError on unmount / dep change is expected — don't surface.
+        if (e instanceof DOMException && e.name === "AbortError") return;
         setErr(e instanceof Error ? e.message : String(e));
       }
     };
     reloadRef.current = () => void load();
     load();
     const id = setInterval(load, 5000);
-    return () => clearInterval(id);
+    return () => {
+      clearInterval(id);
+      controller.abort();
+    };
   }, [trigger, status, debouncedRecipeQuery, limit, attemptFilter]);
 
   // PR1c: poll halt-summary independently (cheaper payload, fixed cadence).
   // PR4: window selector feeds the same sinceMs into the summary so the
   // pills always reflect the same window as the displayed run list.
   useEffect(() => {
-    let cancelled = false;
+    // #600: replace the `cancelled` flag with an AbortController so we
+    // actually cancel the network request on unmount / window change,
+    // not just suppress the setState (which would still parse the JSON
+    // and burn the bridge response).
+    const controller = new AbortController();
     const load = async () => {
       try {
         const sinceMs = windowCutoffMs(window);
         const qs = sinceMs != null ? `?sinceMs=${sinceMs}` : "";
         const res = await fetch(
           apiPath(`/api/bridge/runs/halt-summary${qs}`),
+          { signal: controller.signal },
         );
         if (!res.ok) return;
         const data = (await res.json()) as HaltSummary;
-        if (!cancelled) setHaltSummary(data);
+        setHaltSummary(data);
       } catch {
         /* halt summary is best-effort; ignore */
       }
@@ -234,24 +253,26 @@ export default function RunsPage() {
     void load();
     const id = setInterval(load, 30_000);
     return () => {
-      cancelled = true;
       clearInterval(id);
+      controller.abort();
     };
   }, [window]);
 
   // PR3b sibling poller — judge-summary on the same cadence + window.
   useEffect(() => {
-    let cancelled = false;
+    // #600: same AbortController pattern as halt-summary above.
+    const controller = new AbortController();
     const load = async () => {
       try {
         const sinceMs = windowCutoffMs(window);
         const qs = sinceMs != null ? `?sinceMs=${sinceMs}` : "";
         const res = await fetch(
           apiPath(`/api/bridge/runs/judge-summary${qs}`),
+          { signal: controller.signal },
         );
         if (!res.ok) return;
         const data = (await res.json()) as JudgeSummary;
-        if (!cancelled) setJudgeSummary(data);
+        setJudgeSummary(data);
       } catch {
         /* judge summary is best-effort; ignore */
       }
@@ -259,8 +280,8 @@ export default function RunsPage() {
     void load();
     const id = setInterval(load, 30_000);
     return () => {
-      cancelled = true;
       clearInterval(id);
+      controller.abort();
     };
   }, [window]);
 

--- a/dashboard/src/app/sessions/page.tsx
+++ b/dashboard/src/app/sessions/page.tsx
@@ -240,12 +240,10 @@ export default function SessionsPage() {
         </div>
       ) : (
         <div
-          style={{
-            display: "grid",
-            gridTemplateColumns: sessions.length > 0 ? "340px minmax(0,1fr)" : "1fr",
-            gap: "var(--s-4)",
-            alignItems: "start",
-          }}
+          // #600: .two-pane-340 collapses to single column at ≤768px so
+          // the 340 px rail doesn't overflow phone viewports.
+          className={sessions.length > 0 ? "two-pane-340" : undefined}
+          style={sessions.length > 0 ? undefined : { display: "block" }}
         >
           {/* left: session card list */}
           <div style={{ display: "flex", flexDirection: "column", gap: "var(--s-3)" }}>

--- a/dashboard/src/app/settings/page.tsx
+++ b/dashboard/src/app/settings/page.tsx
@@ -340,7 +340,17 @@ export default function SettingsPage() {
   // When the bridge emits a state-change event the toggle updates in <1s
   // without waiting for the next 5-second poll cycle.
   useEffect(() => {
+    // #600: cap reconnect attempts. EventSource auto-reconnects forever
+    // if the endpoint 404s — burns bridge resources and pollutes the
+    // network panel with retries that will never succeed. After 5
+    // failures we give up; the 5s settings poll still picks up state
+    // changes (just at a slower cadence).
+    let failures = 0;
+    const MAX_FAILURES = 5;
     const es = new EventSource(apiPath("/api/bridge/stream"));
+    es.onopen = () => {
+      failures = 0;
+    };
     es.onmessage = (msg) => {
       try {
         const evt = JSON.parse(msg.data) as {
@@ -352,6 +362,12 @@ export default function SettingsPage() {
         }
       } catch {
         // ignore malformed events
+      }
+    };
+    es.onerror = () => {
+      failures += 1;
+      if (failures >= MAX_FAILURES) {
+        es.close();
       }
     };
     return () => es.close();

--- a/dashboard/src/app/traces/page.tsx
+++ b/dashboard/src/app/traces/page.tsx
@@ -785,7 +785,13 @@ export default function TracesPage() {
           description="Traces appear as recipes run and approvals are processed."
         />
       ) : view === "flat" ? (
-        <div className="card" style={{ padding: 0, overflow: "hidden", marginBottom: "var(--s-5)" }}>
+        // #600: switch `overflow: hidden` → `overflow-x: auto` so the
+        // wide 7-col table can horizontally scroll INSIDE the card on
+        // phones instead of pushing the whole page wider than the
+        // viewport. Each row keeps its columnar layout (the alternative
+        // — stacking cells vertically per row — destroys the table
+        // affordance, which is the whole point of this view).
+        <div className="card" style={{ padding: 0, overflowX: "auto", overflowY: "hidden", marginBottom: "var(--s-5)" }}>
           {visible.map(t => {
             const rowKey = `${t.traceType}:${t.ts}:${t.key}`;
             const isOpen = expanded.has(rowKey);
@@ -934,7 +940,8 @@ export default function TracesPage() {
         </div>
       ) : (
         // Tree view
-        <div className="card" style={{ padding: 0, overflow: "hidden", marginBottom: "var(--s-5)" }}>
+        // #600: same overflow-x: auto pattern as the flat view above.
+        <div className="card" style={{ padding: 0, overflowX: "auto", overflowY: "hidden", marginBottom: "var(--s-5)" }}>
           {buildSpanGroups(visible).map((group) => {
             const { root, children } = group;
             const rootKey = `${root.traceType}:${root.ts}:${root.key}`;


### PR DESCRIPTION
13 #600 audit fixes in one branch. Companion to #601 (BLOCKERs + first MAJOR batch).

## Re-fetch + basePath (2)
1. **runs/[seq] CausalChainCard** — \`childSeqs\` array dep caused full N+1 child re-fetch every 5s. Serialize for dep + AbortController.
2. **login-form** — hardcoded \`/dashboard/api/login\` ignored \`NEXT_PUBLIC_BASE_PATH\`. Routed through \`apiPath()\`.

## AbortController sweep (4)
3. **runs/page.tsx** — three polling effects had no cancellation; rapid filter flips overwrote newer state with stale responses. Per-effect AbortController.
4. **marketplace/submit runLint** — rapid clicks → SECOND-to-finish wins. Ref-held controller aborts previous.
5. **inbox fetchList** — 30s poll had no cancellation. Shared abort ref.
6. **settings EventSource** — no \`onerror\` → auto-reconnect forever. Cap at 5 failures.

## Mobile responsiveness (3)
7. **sessions/page.tsx** — 340px rail overflowed phones. New \`.two-pane-340\` utility.
8. **activity/page.tsx** — same issue, reversed. \`.two-pane-340-rev\`.
9. **traces/page.tsx** — 7-col grid pushed page > viewport. Containers switched to \`overflow-x: auto\` so the table scrolls inside the card.

## UX dead-ends + clarity (2)
10. **inbox Replay 'silently fails' on vars-required recipes** — bridge returns 400 with vars/required message; we now detect that shape and toast the user to use Recipes page Run modal.
11. **connections single-card Connect popup-blocked silent no-op** — \`handleConnect\` returned \"blocked\" but only \`runReAuthAll\` surfaced it. Per-card toast added.

## Security (1)
12. **login length-leak** — constant-time compare short-circuited on \`a.length === b.length\` BEFORE \`timingSafeEqual\` ran, leaking expected-password length via response time. Now pads both inputs to fixed PAD=256 and ANDs length check AFTER.

## Cleanup (1)
13. **dead \`parseUptimeMs\`** — function + accompanying \`void parseUptimeMs\` suppression removed.

## Verified false positives (no fix needed)
- **inbox \`/api/inbox\` vs \`/api/bridge/inbox\` mismatch** — both paths work via the generic \`[...path]\` proxy.
- **approvals list \`approvalToken\`** — mobile push always opens detail page (which has the token in URL), never list.

## Closes
From #600: 9 MAJORs + 1 MINOR + 1 security MINOR. **Cumulative across #597 + #601 + #602: 3 BLOCKERs + 12 issues fixed.**

## Test plan
- [ ] CI green
- [ ] Run detail page: child fetches fire once on mount (not every 5s)
- [ ] Deploy with NEXT_PUBLIC_BASE_PATH=/ → login form POSTs correct URL
- [ ] Runs page rapid filter flips → final list matches final filter
- [ ] Submit page rapid Validate clicks → only latest response renders
- [ ] Inbox: navigate mid-poll → no unmount warnings
- [ ] Settings: stop bridge → /stream retries 5x then stops
- [ ] DevTools 375 px viewport: sessions/activity/traces no horizontal page scroll
- [ ] Inbox Replay on a vars-required recipe → clear toast routing to /recipes
- [ ] Connect a service with popups blocked → toast appears
- [ ] Login attempts with very short vs. long passwords → no measurable timing difference

🤖 Generated with [Claude Code](https://claude.com/claude-code) — surfaced by structured dogfood session.