### PR TITLE
fix(dashboard): inbox Replay opens Recipes RunModal via deep-link (closes last #600 UX gap)

### DIFF
--- a/dashboard/src/app/inbox/page.tsx
+++ b/dashboard/src/app/inbox/page.tsx
@@ -405,7 +405,6 @@ export default function InboxPage() {
   const [search, setSearch] = useState("");
   const [refreshing, setRefreshing] = useState(false);
   const [seenNames] = useState<Set<string>>(() => new Set());
-  const [replayingFor, setReplayingFor] = useState<string | null>(null);
   const toast = useToast();
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const detailRef = useRef<HTMLDivElement | null>(null);
@@ -928,49 +927,19 @@ const filteredItems = items.filter((item) => {
                           type="button"
                           className="btn sm primary"
                           style={{ background: "var(--orange)", border: "none", fontSize: "var(--fs-xs)" }}
-                          disabled={replayingFor === selected.name}
-                          onClick={async () => {
-                            const itemName = selected.name;
-                            setReplayingFor(itemName);
-                            try {
-                              const res = await fetch(
-                                apiPath(`/api/bridge/recipes/${encodeURIComponent(recipeNameForSelected)}/run`),
-                                { method: "POST" },
-                              );
-                              if (!res.ok) {
-                                const text = await res.text().catch(() => res.statusText);
-                                // Audit 2026-05-17 (#600): the bridge
-                                // returns 400 with a 'vars' / 'required'
-                                // message when the recipe declares vars
-                                // that the empty body didn't supply.
-                                // Route the user to the Recipes page Run
-                                // button (which has the vars-input modal)
-                                // instead of a generic "Replay failed"
-                                // toast. Restoring full inline vars input
-                                // here is tracked separately.
-                                const looksLikeMissingVars =
-                                  res.status === 400 &&
-                                  /\bvars?\b|required/i.test(text);
-                                if (looksLikeMissingVars) {
-                                  toast.error(
-                                    `Recipe needs vars — open from /recipes to fill them in.`,
-                                  );
-                                } else {
-                                  toast.error(`Replay failed: ${text || res.status}`);
-                                }
-                              } else {
-                                toast.success(`Replayed “${recipeNameForSelected}”`);
-                              }
-                            } catch (e) {
-                              toast.error(e instanceof Error ? e.message : String(e));
-                            } finally {
-                              setTimeout(() => {
-                                setReplayingFor((cur) => (cur === itemName ? null : cur));
-                              }, 2000);
-                            }
+                          // #600: route to /recipes?run=<name> so the user
+                          // lands on the recipe with its vars-input modal
+                          // already open. Previously this POSTed directly
+                          // and silently 400'd on any recipe with required
+                          // vars (which is most of them). Deep-link is
+                          // consumed by the recipes page useEffect on load.
+                          onClick={() => {
+                            router.push(
+                              `/recipes?run=${encodeURIComponent(recipeNameForSelected)}`,
+                            );
                           }}
                         >
-                          {replayingFor === selected.name ? "Running…" : "Replay recipe"}
+                          Replay recipe
                         </button>
                         <a
                           href={`/traces?q=${encodeURIComponent(recipeNameForSelected)}`}

--- a/dashboard/src/app/recipes/page.tsx
+++ b/dashboard/src/app/recipes/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 import React from "react";
 import Link from "next/link";
+import { useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Dialog } from "@/components/Dialog";
 import { apiPath } from "@/lib/api";
@@ -578,6 +579,13 @@ export default function RecipesPage() {
   const [modalRunning, setModalRunning] = useState(false);
   const [search, setSearch] = useState("");
   const toast = useToast();
+  // #600: deep-link support so /recipes?run=<name> auto-opens the
+  // RunModal once recipes are loaded. Used by the Inbox Replay
+  // button so users land on the recipe with its vars-input modal
+  // already open instead of getting a silent 400 for missing vars.
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const deepLinkConsumedRef = useRef(false);
 
   const load = React.useCallback(async () => {
     try {
@@ -675,6 +683,28 @@ export default function RecipesPage() {
       document.removeEventListener("visibilitychange", onVisibility);
     };
   }, [load]);
+
+  // #600: deep-link consumer. Fires once after recipes load if the URL
+  // has ?run=<name>. Looks up the recipe, opens the RunModal, then
+  // strips the param so a back-navigation doesn't re-open the modal.
+  // Silent no-op if the named recipe isn't installed — the user lands
+  // on /recipes and can see the empty state / search for it.
+  useEffect(() => {
+    if (deepLinkConsumedRef.current) return;
+    const wantRun = searchParams.get("run");
+    if (!wantRun) return;
+    if (!recipes) return; // wait for first load
+    const match = recipes.find((r) => r.name === wantRun);
+    if (match) {
+      setModal({ recipe: match });
+      setModalRunning(false);
+    } else {
+      toast.error(`Recipe '${wantRun}' is not installed.`);
+    }
+    deepLinkConsumedRef.current = true;
+    // Drop the param so refresh / back-nav doesn't re-trigger.
+    router.replace(window.location.pathname);
+  }, [recipes, searchParams, router, toast]);
 
   async function executeRun(name: string, vars?: Record<string, string>) {
     setRunning((p) => ({ ...p, [name]: "running…" }));


### PR DESCRIPTION
Closes the last #600 BLOCKER-adjacent item. Companion to #601 + #602.

## What changed

Inbox Replay button silently 400'd on any recipe that declared required vars (most of them). #602 added a stopgap toast (\"Recipe needs vars — open from /recipes\"). This PR ships the actual flow.

- **recipes/page.tsx** — consumes \`?run=<name>\` query param. After recipes load, looks up the named recipe and opens the RunModal (vars-input form). Strips the param via \`router.replace\` so back-nav doesn't re-trigger. Toasts a clear error if the recipe isn't installed.
- **inbox/page.tsx** — Replay button now \`router.push('/recipes?run=<name>')\`. Removed old 30-line fetch handler + \`replayingFor\` state.

## UX before vs. after

**Before:** click Replay → recipe with vars → 400 → \"Recipe needs vars, open /recipes\" toast → user manually navigates and re-finds the recipe.

**After:** click Replay → land on /recipes with the modal already open and recipe selected → fill vars → Run.

Same vars-input modal as the Recipes-page Run button — consistent UX from both entry points.

## Test plan

- [ ] CI green
- [ ] Local: open an inbox message that was produced by a vars-required recipe; click Replay → /recipes opens with modal pre-populated
- [ ] Refresh /recipes (without ?run= param) → modal stays closed (param was stripped)
- [ ] Click Replay for a recipe that's no longer installed → toast \"Recipe '<name>' is not installed\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)