### PR TITLE
fix(dashboard): 3 #600 MINOR polish items

### DIFF
--- a/dashboard/src/app/connections/page.tsx
+++ b/dashboard/src/app/connections/page.tsx
@@ -928,8 +928,11 @@ export default function ConnectionsPage() {
   }
 
   async function handleNotionConnect() {
-    if (!notionToken.startsWith("secret_")) {
-      setNotionErr('Token must start with "secret_" — find it in Notion → Settings → Connections → Your integrations');
+    // Audit 2026-05-17 (#600): Notion issues both legacy `secret_` and
+    // newer `ntn_` token prefixes. Rejecting `ntn_` was a false-negative
+    // that locked out valid users with current API keys.
+    if (!notionToken.startsWith("secret_") && !notionToken.startsWith("ntn_")) {
+      setNotionErr('Token must start with "secret_" or "ntn_" — find it in Notion → Settings → Connections → Your integrations');
       return;
     }
     setNotionConnecting(true);

--- a/dashboard/src/app/marketplace/page.tsx
+++ b/dashboard/src/app/marketplace/page.tsx
@@ -547,7 +547,13 @@ export default function MarketplacePage() {
         // bridge offline / timed out — try GitHub
       }
 
-      if (!recipes) {
+      // Audit 2026-05-17 (#600): bridge can return an empty registry
+      // (recipes: []) on a fresh install before any recipes are seeded.
+      // The original guard `if (!recipes)` short-circuited on truthy
+      // empty array → user saw "no recipes available" indefinitely
+      // even though GitHub has the seed set. Treat empty array as a
+      // miss too so the GitHub fallback runs.
+      if (!recipes || recipes.length === 0) {
         try {
           const res = await fetchWithTimeout(
             "https://raw.githubusercontent.com/patchworkos/recipes/main/index.json",
@@ -563,7 +569,7 @@ export default function MarketplacePage() {
         }
       }
 
-      if (recipes) {
+      if (recipes && recipes.length > 0) {
         setRegistry(recipes);
         setBundles(registryBundles);
       } else {

--- a/dashboard/src/app/settings/page.tsx
+++ b/dashboard/src/app/settings/page.tsx
@@ -196,6 +196,7 @@ export default function SettingsPage() {
 
   const [todayAnomaly, setTodayAnomaly] = useState(false);
   const [todayAnomalySaving, setTodayAnomalySaving] = useState(false);
+  const [todayAnomalyErr, setTodayAnomalyErr] = useState<string | null>(null);
   const todayAnomalyInitialized = useRef(false);
 
   // CC permission rules (loaded from approval insights)
@@ -670,10 +671,18 @@ export default function SettingsPage() {
       });
       if (res.ok) {
         setTodayAnomaly(value);
+        setTodayAnomalyErr(null);
         flashSaved();
+      } else {
+        // Audit 2026-05-17 (#600): previously swallowed all failures
+        // silently, including non-OK responses. Toggle would visually
+        // flip but persist nothing — silent data-loss class. Now surface
+        // via the same error-message slot the kill-switch row uses.
+        const body = (await res.json().catch(() => ({}))) as { error?: string };
+        setTodayAnomalyErr(body.error ?? `Save failed (HTTP ${res.status})`);
       }
-    } catch {
-      /* swallow */
+    } catch (e) {
+      setTodayAnomalyErr(e instanceof Error ? e.message : String(e));
     } finally {
       setTodayAnomalySaving(false);
     }
@@ -1255,6 +1264,11 @@ export default function SettingsPage() {
                 <p style={{ ...helpStyle, marginLeft: 24 }}>
                   Surfaces a chip on approvals when a tool runs outside your usual hours.
                 </p>
+                {todayAnomalyErr && (
+                  <p style={{ ...helpStyle, marginLeft: 24, color: "var(--err)" }}>
+                    {todayAnomalyErr}
+                  </p>
+                )}
               </div>
 
               <div style={{ padding: "16px 0" }}>


### PR DESCRIPTION
Three small fixes from the #600 audit backlog.

## connections — accept Notion ntn_ tokens
Validation rejected anything not starting with secret_. Notion's current API keys use the ntn_ prefix; this locked out valid users with a confusing error. Now accepts both.

## marketplace — empty registry falls through to GitHub
Bridge can return recipes: [] on a fresh install before any are seeded. The guard if (!recipes) short-circuited on truthy empty array, so users saw no recipes available indefinitely. Treat empty array as a miss so the GitHub fallback runs.

## settings — Time-of-day anomaly save no longer fails silently
saveTimeOfDayAnomaly swallowed both non-OK responses and thrown errors. Toggle would visually flip but persist nothing — silent data-loss class bug. Added an inline error message (same visual pattern as the kill-switch row) and clears on successful save.

## Closes
Three more #600 items. Cumulative across #597, #601, #602, #603, this PR: 3 BLOCKERs + 16 issues fixed.

## Test plan
- [ ] CI green
- [ ] Notion connect with an ntn_ token → accepted
- [ ] On fresh bridge with no recipes seeded, /marketplace populates from GitHub
- [ ] Settings → toggle Time-of-day anomaly while bridge is down → error message appears next to the toggle

🤖 Generated with [Claude Code](https://claude.com/claude-code)