### PR TITLE
fix: close 4 #605 round-2 BLOCKERs (SSE leak + temp-race + auth storm + CSRF bypass)

### DIFF
--- a/dashboard/src/app/api/connector-requests/__tests__/route.test.ts
+++ b/dashboard/src/app/api/connector-requests/__tests__/route.test.ts
@@ -58,9 +58,23 @@ describe("POST /api/connector-requests — CSRF guard", () => {
     expect(res.status).toBe(200);
   });
 
-  it("allows requests with no sec-fetch-site header (server-to-server)", async () => {
-    const res = await POST(makeReq({ name: "ok" }, {}));
+  it("allows requests with no sec-fetch-site header when Origin matches Host (legacy browser)", async () => {
+    // #605: requireSameOrigin now falls back to Origin/Host check
+    // when sec-fetch-site is absent. The test makeReq's Request URL is
+    // dashboard.local so Origin must match.
+    const res = await POST(
+      makeReq(
+        { name: "ok" },
+        { origin: "https://dashboard.local", host: "dashboard.local" },
+      ),
+    );
     expect(res.status).toBe(200);
+  });
+
+  it("rejects requests with no sec-fetch-site AND no Origin (curl with cookies)", async () => {
+    // #605: curl --cookie session=... with no headers used to bypass CSRF.
+    const res = await POST(makeReq({ name: "ok" }, {}));
+    expect(res.status).toBe(403);
   });
 });
 

--- a/dashboard/src/hooks/useBridgeFetch.ts
+++ b/dashboard/src/hooks/useBridgeFetch.ts
@@ -83,6 +83,18 @@ export function useBridgeFetch<T>(
           return;
         }
 
+        // #605 BLOCKER: 401/403 used to fall through to the generic
+        // !res.ok branch and re-schedule indefinitely — persistent auth
+        // failure (cookie expired, password rotated) became a forever
+        // poll at the backoff cap. Treat as terminal like 404; the
+        // dashboard's session-required middleware redirects html navs
+        // to /login on its own, and refetch() can resume after re-auth.
+        if (res.status === 401 || res.status === 403) {
+          setError(res.status === 401 ? "Not signed in" : "Forbidden");
+          setLoading(false);
+          return;
+        }
+
         if (!res.ok) {
           setError(`Request failed: ${res.status}`);
           setLoading(false);

--- a/dashboard/src/lib/__tests__/csrf.test.ts
+++ b/dashboard/src/lib/__tests__/csrf.test.ts
@@ -12,9 +12,15 @@ import { describe, expect, it } from "vitest";
 import { NextRequest } from "next/server";
 import { requireSameOrigin } from "@/lib/csrf";
 
-function makeReq(secFetchSite: string | null): NextRequest {
+function makeReq(
+  secFetchSite: string | null,
+  opts: { origin?: string | null; host?: string | null } = {},
+): NextRequest {
   const headers = new Headers();
   if (secFetchSite !== null) headers.set("sec-fetch-site", secFetchSite);
+  // Default host is what NextRequest uses; opts can override or null.
+  if (opts.origin !== null && opts.origin !== undefined) headers.set("origin", opts.origin);
+  if (opts.host !== null && opts.host !== undefined) headers.set("host", opts.host);
   return new NextRequest("http://localhost:3200/api/test", {
     method: "POST",
     headers,
@@ -30,11 +36,28 @@ describe("requireSameOrigin", () => {
     expect(requireSameOrigin(makeReq("none"))).toBeNull();
   });
 
-  it("returns null when sec-fetch-site header is absent (older browsers)", () => {
-    // Matches the existing bridge proxy behaviour — header missing → allow.
-    // sec-fetch-site is universally supported in modern browsers, but legacy
-    // automation tools may omit it.
-    expect(requireSameOrigin(makeReq(null))).toBeNull();
+  it("returns null when sec-fetch-site is absent but Origin matches Host (legacy browser)", () => {
+    // #605 fix: tightened. Header absent → fall back to Origin/Host
+    // equality check. This still works for legacy clients (Origin has
+    // been universal on mutating verbs since ~2020) but blocks curl/
+    // script with cookies that present no Origin at all.
+    expect(
+      requireSameOrigin(
+        makeReq(null, { origin: "http://localhost:3200", host: "localhost:3200" }),
+      ),
+    ).toBeNull();
+  });
+
+  it("returns 403 when sec-fetch-site is absent and Origin is missing entirely (curl with cookies)", () => {
+    const res = requireSameOrigin(makeReq(null, { origin: null, host: "localhost:3200" }));
+    expect(res?.status).toBe(403);
+  });
+
+  it("returns 403 when sec-fetch-site is absent and Origin host differs from Host", () => {
+    const res = requireSameOrigin(
+      makeReq(null, { origin: "http://evil.example.com", host: "localhost:3200" }),
+    );
+    expect(res?.status).toBe(403);
   });
 
   it("returns 403 when sec-fetch-site is cross-site", () => {

--- a/dashboard/src/lib/csrf.ts
+++ b/dashboard/src/lib/csrf.ts
@@ -1,18 +1,20 @@
 /**
  * Centralised CSRF guard for dashboard mutation routes.
  *
- * Mirrors the inline check that previously lived in the bridge proxy and a
- * handful of recipe routes: rely on the browser-issued `sec-fetch-site`
- * Fetch Metadata header, accept only `same-origin` / `none` (the latter for
- * direct address-bar navigation in the dashboard's same-origin XHR flow),
- * reject anything else with 403.
+ * Primary check is the browser-issued `sec-fetch-site` Fetch Metadata
+ * header — accept only `same-origin` / `none` (the latter for direct
+ * address-bar navigation), reject anything else with 403.
  *
- * `sec-fetch-site` is forgeable from a non-browser client, but it can NOT be
- * set by JavaScript inside a page — which is exactly the threat model
+ * `sec-fetch-site` is forgeable from a non-browser client, but it CAN NOT
+ * be set by JavaScript inside a page — which is exactly the threat model
  * (cross-origin page submitting a form / fetch with the user's cookies).
- * For server-to-server callers there is no header at all, which we allow:
- * those callers either present a Bearer token, hit a separate auth path, or
- * are blocked by the bridge itself.
+ *
+ * Audit 2026-05-17 (#605): when `sec-fetch-site` is absent (server-to-
+ * server, very-old browsers, `curl --cookie session=…`), the previous
+ * implementation allowed the request. That bypassed CSRF for any
+ * cookie-bearing script on the same machine targeting a mutating route.
+ * Now: if the header is absent, fall back to an Origin/Host equality
+ * check. Requests with neither header are rejected.
  *
  * Returns `null` when the request is allowed, or a 403 NextResponse to be
  * returned directly to the client otherwise.
@@ -24,11 +26,31 @@ export function requireSameOrigin(
   req: { headers: { get(name: string): string | null } },
 ): NextResponse | null {
   const sfs = req.headers.get("sec-fetch-site");
-  if (sfs && sfs !== "same-origin" && sfs !== "none") {
+  if (sfs) {
+    if (sfs !== "same-origin" && sfs !== "none") {
+      return NextResponse.json({ error: "CSRF check failed" }, { status: 403 });
+    }
+    return null;
+  }
+  // Header absent — defense-in-depth fallback. Require Origin to match
+  // Host (a same-origin browser request always sends Origin on
+  // mutating verbs since 2020-ish). Server-side / curl callers that
+  // need to hit mutating routes must set Origin explicitly.
+  const origin = req.headers.get("origin");
+  const host = req.headers.get("host");
+  if (!origin || !host) {
     return NextResponse.json(
-      { error: "CSRF check failed" },
+      { error: "CSRF check failed (missing Origin)" },
       { status: 403 },
     );
+  }
+  try {
+    const originHost = new URL(origin).host;
+    if (originHost !== host) {
+      return NextResponse.json({ error: "CSRF check failed" }, { status: 403 });
+    }
+  } catch {
+    return NextResponse.json({ error: "CSRF check failed" }, { status: 403 });
   }
   return null;
 }

--- a/src/recipeRoutes.ts
+++ b/src/recipeRoutes.ts
@@ -1522,9 +1522,15 @@ export function tryHandleRecipeRoute(
                 continue;
               }
               const yamlText = Buffer.from(recipeBuf).toString("utf-8");
+              // #605: same race-fix as /recipes/install — embed pid +
+              // randomBytes so concurrent bundle installs of the same
+              // recipe inside one millisecond don't collide.
+              const { randomBytes: randomBytesFn } = await import(
+                "node:crypto"
+              );
               const tmpFile = path.join(
                 os.tmpdir(),
-                `patchwork-bundle-install-${Date.now()}-${r}.yaml`,
+                `patchwork-bundle-install-${process.pid}-${Date.now()}-${randomBytesFn(6).toString("hex")}-${r}.yaml`,
               );
               writeFileSync(tmpFile, yamlText, "utf-8");
               try {
@@ -1782,9 +1788,15 @@ export function tryHandleRecipeRoute(
           chunks.map((c) => Buffer.from(c)),
         ).toString("utf-8");
 
+        // #605: temp path must be unique per process+request. Previous
+        // form was `Date.now()-${recipeName}` — two concurrent installs
+        // of the same recipe inside one millisecond produced identical
+        // paths → writeFileSync interleaved bytes, and the first finally
+        // block unlinked the file the second still needed.
+        const { randomBytes } = await import("node:crypto");
         const tmpFile = path.join(
           os.tmpdir(),
-          `patchwork-install-${Date.now()}-${recipeName}.yaml`,
+          `patchwork-install-${process.pid}-${Date.now()}-${randomBytes(6).toString("hex")}-${recipeName}.yaml`,
         );
         const { writeFileSync, mkdirSync, unlinkSync } = await import(
           "node:fs"

--- a/src/server.ts
+++ b/src/server.ts
@@ -1092,32 +1092,48 @@ export class Server extends EventEmitter<ServerEvents> {
         });
         res.flushHeaders();
 
-        const unsub =
+        // Idempotent teardown — every disconnect path (write error,
+        // ping error, req.close) funnels through here. Without this the
+        // counter could be decremented twice for a single subscriber
+        // (req.close fires AFTER write error in some Node versions) or
+        // not at all (write error never escalates to req.close on
+        // certain proxy intermediaries). Audit 2026-05-17 (#605
+        // BLOCKER): observed in production — subscribers hit cap of 20
+        // after enough page reloads, every new SSE returns 503 and
+        // kill-switch / activity ticker silently die.
+        let cleanedUp = false;
+        let pingHandle: ReturnType<typeof setInterval> | null = null;
+        let unsub: () => void = () => {};
+        const cleanup = () => {
+          if (cleanedUp) return;
+          cleanedUp = true;
+          this.sseSubscriberCount--;
+          if (pingHandle) clearInterval(pingHandle);
+          unsub();
+        };
+
+        unsub =
           this.streamFn?.((kind, entry) => {
             try {
               res.write(`data: ${JSON.stringify({ kind, ...entry })}\n\n`);
             } catch {
-              // Client disconnected — unsubscribe on next tick
-              unsub?.();
+              cleanup();
             }
           }) ?? (() => {});
 
         // Keep-alive comment ping every 15s so proxies don't close idle connections
-        const ping = setInterval(() => {
+        pingHandle = setInterval(() => {
           try {
             res.write(": ping\n\n");
           } catch {
-            clearInterval(ping);
-            unsub();
+            cleanup();
           }
         }, 15_000);
-        ping.unref();
+        pingHandle.unref();
 
-        req.on("close", () => {
-          this.sseSubscriberCount--;
-          clearInterval(ping);
-          unsub();
-        });
+        req.on("close", cleanup);
+        req.on("error", cleanup);
+        res.on("error", cleanup);
         return;
       }
       if (req.url === "/tasks" && req.method === "GET") {


### PR DESCRIPTION
Closes the 4 BLOCKERs from [#605](https://github.com/Oolab-labs/patchwork-os/issues/605). Two were actively breaking the live workspace bridge; two were exploitable bypasses.

## 1. bridge: SSE subscriber leak (LIVE breakage)
`/stream` decremented its counter only in `req.on('close')`, but the close handler doesnt fire on every disconnect path (write errors, ping interval errors, proxy teardowns). Once the count creeps to MAX_SSE_SUBSCRIBERS=20 the bridge returns 503 to every new SSE — kill-switch live updates, activity ticker, future SSE consumers all silently die. **Reproduced on the live workspace bridge during the audit.**

Fix: idempotent `cleanup()` funnel called from every disconnect path.

## 2. bridge: /recipes/install temp-file race
Temp path was `patchwork-install-${Date.now()}-${recipeName}.yaml` — two concurrent installs of the same recipe within one ms collided, the first finishers `finally unlinkSync` deleted the file the second still needed. Same bug in the bundle path.

Fix: embed `process.pid + randomBytes(6)` in both temp paths.

## 3. dashboard: useBridgeFetch 401/403 storm
Hook treated auth failures as generic non-OK and re-scheduled forever. Cookie expiry → indefinite poll at backoff cap hammering the bridge.

Fix: treat 401/403 as terminal (like 404). Sessions middleware redirects html navs to /login on its own; refetch() resumes after re-auth.

## 4. dashboard: CSRF helper bypass on missing sec-fetch-site
`requireSameOrigin` allowed any request with no `sec-fetch-site` header. curl/script with cookies on the same machine bypassed CSRF entirely on every mutating route.

Fix: defense-in-depth fallback — when header is absent, require Origin to match Host. Requests with neither header are rejected. **4 new tests + 8 existing pass (12 green total).**

## Test plan
- [ ] CI green
- [ ] Restart bridge, reload dashboard 30+ times — SSE never returns 503
- [ ] Concurrent `patchwork recipe install` of the same source from two terminals — both succeed
- [ ] Expire dashboard cookie (delete patchwork_session), reload — useBridgeFetch errors stop after one tick instead of looping
- [ ] `curl -X POST -H 'Cookie: patchwork_session=…' http://localhost:3200/dashboard/api/push/subscribe` → 403 CSRF (no sec-fetch-site, no Origin)

🤖 Generated with [Claude Code](https://claude.com/claude-code) — round-2 dogfood session.