### PR TITLE
fix(recipes): close 4 #605 MAJORs (kill-switch gate + var injection + webhook name + err leak)

### DIFF
--- a/src/recipeOrchestration.ts
+++ b/src/recipeOrchestration.ts
@@ -341,16 +341,29 @@ export class RecipeOrchestration {
           ...(result.error !== undefined && { error: result.error }),
         };
       } catch (err) {
-        return {
-          ok: false,
-          error: err instanceof Error ? err.message : String(err),
-        };
+        // #605: don't leak err.message (file paths, stack details) to
+        // the HTTP caller — same fix shape as the dashboard recipe
+        // routes in #601. Server-side log retains the detail.
+        this.deps.logger?.warn?.(
+          `[runReplayFn] replay failed for seq=${seq}: ${err instanceof Error ? err.message : String(err)}`,
+        );
+        return { ok: false, error: "replay_internal_error" };
       }
     };
 
     this.wireGenerateFn();
 
     server.webhookFn = async (hookPath: string, payload: unknown) => {
+      // #605: same kill-switch gate as runRecipeFn — webhook trigger
+      // is just another path into recipe execution.
+      try {
+        const { isWriteKillSwitchActive } = await import("./featureFlags.js");
+        if (isWriteKillSwitchActive()) {
+          return { ok: false, error: "kill_switch_blocked" };
+        }
+      } catch {
+        /* featureFlags module unavailable — fail open. */
+      }
       if (!this.deps.getOrchestrator()) {
         return {
           ok: false,
@@ -364,6 +377,16 @@ export class RecipeOrchestration {
       const match = findWebhookRecipe(recipesDir, hookPath);
       if (!match) {
         return { ok: false, error: "not_found" };
+      }
+      // #605: defense-in-depth — webhookFn previously trusted whatever
+      // name the on-disk recipe declared. A legacy/tampered recipe
+      // with a slashy or oversized name would propagate into
+      // triggerSource and log keys. The parser enforces RECIPE_NAME_RE
+      // at install time; re-check at the webhook boundary for any
+      // recipe that predates that check or was hand-edited later.
+      const { RECIPE_NAME_RE } = await import("./recipes/names.js");
+      if (!RECIPE_NAME_RE.test(match.name)) {
+        return { ok: false, error: "invalid_recipe_name" };
       }
       if (match.format === "yaml") {
         let payloadText: string | undefined;
@@ -418,6 +441,22 @@ export class RecipeOrchestration {
       name: string,
       vars?: Record<string, string>,
     ) => {
+      // #605: kill-switch gate. Recipe execution is the largest write
+      // surface the bridge exposes (Claude subprocess + tool calls);
+      // the kill switch was designed for exactly this case but the
+      // recipe entry point never consulted it.
+      try {
+        const { isWriteKillSwitchActive } = await import("./featureFlags.js");
+        if (isWriteKillSwitchActive()) {
+          return {
+            ok: false,
+            error: "kill_switch_blocked",
+          };
+        }
+      } catch {
+        /* featureFlags module unavailable — fail open, same as
+           every other site that imports it dynamically. */
+      }
       if (!this.deps.getOrchestrator()) {
         return {
           ok: false,
@@ -434,6 +473,18 @@ export class RecipeOrchestration {
       const loaded = loadRecipePrompt(recipesDir, name);
       if (loaded) {
         try {
+          // #605: validate vars BEFORE interpolating into the prompt.
+          // The HTTP boundary already calls validateRecipeVars, but
+          // runRecipeFn is also reachable from webhookFn/scheduler with
+          // unvalidated payloads. A var value containing newlines or
+          // backticks could bias the prompt (prompt-injection-by-var).
+          if (vars && Object.keys(vars).length > 0) {
+            const { validateRecipeVars } = await import("./recipeRoutes.js");
+            const varsErr = validateRecipeVars(vars);
+            if (varsErr) {
+              return { ok: false, error: `invalid_vars:${varsErr.field}` };
+            }
+          }
           let prompt = loaded.prompt;
           if (vars && Object.keys(vars).length > 0) {
             const varLines = Object.entries(vars)
@@ -447,10 +498,11 @@ export class RecipeOrchestration {
           });
           return { ok: true, taskId };
         } catch (err) {
-          return {
-            ok: false,
-            error: err instanceof Error ? err.message : String(err),
-          };
+          // #605: don't leak err.message (file paths, stack details).
+          this.deps.logger?.warn?.(
+            `[runRecipeFn] enqueue failed for '${name}': ${err instanceof Error ? err.message : String(err)}`,
+          );
+          return { ok: false, error: "enqueue_failed" };
         }
       }
 


### PR DESCRIPTION
Four security-relevant MAJORs from [#605](https://github.com/Oolab-labs/issues/605) — all in src/recipeOrchestration.ts.

## kill-switch gate on recipe execution
`runRecipeFn` + `webhookFn` never consulted the kill switch. Recipe execution (Claude subprocess + tool calls) is the largest write surface the bridge exposes and was the kill switchs primary target per #422. Both entry points now check `isWriteKillSwitchActive()` and return `kill_switch_blocked` before enqueue.

## var interpolation prompt-injection
`runRecipeFn` JSON path interpolated `vars` k=v into the prompt with no escaping. `validateRecipeVars` was enforced at the HTTP boundary but `runRecipeFn` is also reachable from `webhookFn` and the scheduler with unvalidated payloads — a value containing newlines or backticks could bias the prompt. Now: `validateRecipeVars` at the `runRecipeFn` boundary itself.

## webhookFn name validation (defense-in-depth)
`findWebhookRecipe` trusted whatever `name` the on-disk recipe declared. A legacy/tampered/hand-edited recipe with a slashy or oversized name propagated into `triggerSource` and log keys. Now: re-check `match.name` against `RECIPE_NAME_RE` at the webhook boundary.

## runReplayFn err.message leak
Caught error returned via response body verbatim — file paths and stack details leaked to the dashboard. Same fix shape as the dashboard recipe routes in #601: log full detail server-side, return a stable `replay_internal_error` string. Same fix applied to `runRecipeFn`'s catch (was returning err.message too).

## Tests
727/727 recipe tests pass locally.

## Test plan
- [ ] CI green
- [ ] Engage kill switch (`patchwork kill-switch engage`), POST /recipes/<name>/run → `{error: kill_switch_blocked}`
- [ ] POST /recipes/<name>/run with `{vars: {x: "a\nb"}}` → 400-ish `invalid_vars:value`
- [ ] On-disk recipe with slashy webhookPath name → /hooks/<path> returns `invalid_recipe_name`
- [ ] runReplayFn failure → response body is `replay_internal_error`, bridge log carries the detail

🤖 Generated with [Claude Code](https://claude.com/claude-code)