### PR TITLE
fix(dashboard): 4 #605 hooks + components + pushStore MAJORs

### DIFF
--- a/dashboard/src/components/CommandPalette.tsx
+++ b/dashboard/src/components/CommandPalette.tsx
@@ -65,17 +65,21 @@ export function CommandPalette({
   // offline) so we don't need to gate on bridge status here.
   useEffect(() => {
     if (!open) return;
+    // #605: AbortController per open so closing the palette mid-fetch
+    // cancels both requests — late responses won't overwrite fresh
+    // state if the user reopens quickly with different bridge data.
+    const controller = new AbortController();
     // Refetch on every open. Approvals especially go stale fast — a user
     // approving via the queue then re-opening the palette should not see
     // already-decided calls. Recipes change rarely but it's cheap.
-    fetch(apiPath("/api/bridge/recipes"))
+    fetch(apiPath("/api/bridge/recipes"), { signal: controller.signal })
       .then((r) => (r.ok ? r.json() : null))
       .then((d) => {
         const list = (d?.recipes ?? d ?? []) as { name?: string }[];
         setRecipes(list.filter((r) => r.name).map((r) => ({ name: r.name as string })));
       })
       .catch(() => {});
-    fetch(apiPath("/api/bridge/approvals"))
+    fetch(apiPath("/api/bridge/approvals"), { signal: controller.signal })
       .then((r) => (r.ok ? r.json() : null))
       .then((d) => {
         const list = (d?.pending ?? d ?? []) as { callId?: string; toolName?: string }[];
@@ -87,6 +91,7 @@ export function CommandPalette({
         );
       })
       .catch(() => {});
+    return () => controller.abort();
   }, [open]);
 
   const commands = useMemo<Command[]>(() => {

--- a/dashboard/src/components/ConnectorHealthPanel.tsx
+++ b/dashboard/src/components/ConnectorHealthPanel.tsx
@@ -54,10 +54,11 @@ export function ConnectorHealthPanel({ connectors, marginTop }: Props) {
   const [statusMap, setStatusMap] = useState<StatusMap | null>(null);
   const [fetchErr, setFetchErr] = useState<string>();
 
-  async function load() {
+  async function load(signal?: AbortSignal) {
     try {
       const res = await fetch(apiPath("/api/bridge/connectors/status"), {
         cache: "no-store",
+        ...(signal && { signal }),
       });
       if (!res.ok) {
         const body = (await res.json().catch(() => ({}))) as {
@@ -89,14 +90,22 @@ export function ConnectorHealthPanel({ connectors, marginTop }: Props) {
       setStatusMap(map);
       setFetchErr(undefined);
     } catch (e) {
+      // #605: don't surface AbortError as a UI failure.
+      if (e instanceof DOMException && e.name === "AbortError") return;
       setFetchErr(e instanceof Error ? e.message : String(e));
     }
   }
 
   useEffect(() => {
-    void load();
-    const id = setInterval(() => void load(), 30_000);
-    return () => clearInterval(id);
+    // #605: AbortController per effect; aborts in-flight fetch on
+    // unmount so setStatusMap doesn't fire on dead tree.
+    const controller = new AbortController();
+    void load(controller.signal);
+    const id = setInterval(() => void load(controller.signal), 30_000);
+    return () => {
+      clearInterval(id);
+      controller.abort();
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/dashboard/src/components/FirstRunChecklist.tsx
+++ b/dashboard/src/components/FirstRunChecklist.tsx
@@ -55,9 +55,13 @@ function emptyStatus(): Status {
   };
 }
 
-async function probeArray(path: string, key?: string): Promise<number> {
+async function probeArray(
+  path: string,
+  key?: string,
+  signal?: AbortSignal,
+): Promise<number> {
   try {
-    const res = await fetch(apiPath(path));
+    const res = await fetch(apiPath(path), { ...(signal && { signal }) });
     if (!res.ok) return 0;
     const data = (await res.json()) as unknown;
     const arr = key
@@ -94,7 +98,7 @@ export function FirstRunChecklist() {
     setDismissed(readDismissed());
   }, []);
 
-  const probe = useCallback(async () => {
+  const probe = useCallback(async (signal?: AbortSignal) => {
     // Probe all 5 endpoints in parallel — cheap reads, brand-new
     // workspace is the hot path. Endpoint shapes (verified against
     // the live bridge):
@@ -108,12 +112,13 @@ export function FirstRunChecklist() {
     // user has been through the flow at least once).
     const [conn, recipes, runs, pendingApprovals, approvalTraces] =
       await Promise.all([
-        probeArray("/api/bridge/connections", "connectors"),
-        probeArray("/api/bridge/recipes", "recipes"),
-        probeArray("/api/bridge/runs", "runs"),
-        probeArray("/api/bridge/approvals"),
-        probeArray("/api/bridge/traces?traceType=approval", "traces"),
+        probeArray("/api/bridge/connections", "connectors", signal),
+        probeArray("/api/bridge/recipes", "recipes", signal),
+        probeArray("/api/bridge/runs", "runs", signal),
+        probeArray("/api/bridge/approvals", undefined, signal),
+        probeArray("/api/bridge/traces?traceType=approval", "traces", signal),
       ]);
+    if (signal?.aborted) return;
     setStatus({
       connections: {
         done: conn > 0,
@@ -140,12 +145,22 @@ export function FirstRunChecklist() {
   }, []);
 
   useEffect(() => {
-    void probe();
+    // #605: own per-tick AbortController so unmount cancels in-flight
+    // probes (and the 5 parallel probeArray fetches inside).
+    const controller = new AbortController();
+    void probe(controller.signal);
     // Refresh every 30s — the checklist auto-completes as the user
     // works through it, so polling makes the green checkmarks appear
-    // without a reload.
-    const id = setInterval(probe, 30_000);
-    return () => clearInterval(id);
+    // without a reload. Each tick gets its own controller so per-tick
+    // abort doesn't kill all future ticks.
+    const id = setInterval(() => {
+      const tickCtrl = new AbortController();
+      void probe(tickCtrl.signal);
+    }, 30_000);
+    return () => {
+      clearInterval(id);
+      controller.abort();
+    };
   }, [probe]);
 
   if (dismissed) return null;

--- a/dashboard/src/hooks/useBridgeStatus.ts
+++ b/dashboard/src/hooks/useBridgeStatus.ts
@@ -139,10 +139,14 @@ export function useBridgeStatus(): BridgeStatus {
   useEffect(() => {
     let alive = true;
     let timerId: ReturnType<typeof setTimeout> | null = null;
+    let failures = 0;
+    const controller = new AbortController();
 
     const poll = async () => {
       try {
-        const res = await fetch(apiPath("/api/bridge/kill-switch"));
+        const res = await fetch(apiPath("/api/bridge/kill-switch"), {
+          signal: controller.signal,
+        });
         if (res.ok) {
           const data = (await res.json()) as {
             engaged: boolean;
@@ -151,16 +155,34 @@ export function useBridgeStatus(): BridgeStatus {
           if (alive) {
             setStatus((prev) => ({ ...prev, killSwitch: data }));
           }
+          failures = 0;
+        } else {
+          failures++;
         }
-      } catch {
+      } catch (e) {
+        // AbortError on unmount is expected — don't bump the failure counter.
+        if (!(e instanceof DOMException && e.name === "AbortError")) {
+          failures++;
+        }
         // Bridge offline — leave killSwitch as-is
       }
-      if (alive) timerId = setTimeout(poll, KILL_SWITCH_POLL_MS);
+      // #605: exponential backoff on persistent failure. Previously
+      // fired every 10s regardless — 360 req/hour per open tab while
+      // the bridge is offline. Reuse the same backoff curve as the
+      // status poll above.
+      if (alive) {
+        const delay =
+          failures === 0
+            ? KILL_SWITCH_POLL_MS
+            : Math.min(KILL_SWITCH_POLL_MS * 2 ** failures, MAX_BACKOFF_MS);
+        timerId = setTimeout(poll, delay);
+      }
     };
 
     poll();
     return () => {
       alive = false;
+      controller.abort();
       if (timerId !== null) clearTimeout(timerId);
     };
   }, []);

--- a/dashboard/src/lib/pushStore.ts
+++ b/dashboard/src/lib/pushStore.ts
@@ -20,12 +20,28 @@ function persist(store: Map<string, PushSubscription>): void {
   // Atomic write — temp + rename — so a crash mid-write can't truncate
   // the subscription store (which would silently wipe every push
   // subscription on next boot; load() catches parse errors and resets
-  // to an empty Map). Audit 2026-05-17.
+  // to an empty Map).
+  //
+  // #605: explicit fsync of the temp file before rename. Without it,
+  // ext4 (`data=writeback`) and APFS edge cases let the rename
+  // complete while the temp file's data is still in the page cache —
+  // a crash between rename and flush can leave the destination with
+  // zero bytes despite the atomic-rename promise. Pattern matches the
+  // bridge's `writeFileAtomicSync` (src/writeFileAtomic.ts).
   const tmp = `${STORE_PATH}.tmp.${process.pid}.${crypto.randomBytes(6).toString("hex")}`;
+  let fd: number | null = null;
   try {
-    fs.writeFileSync(tmp, JSON.stringify([...store.entries()]), "utf8");
+    const body = JSON.stringify([...store.entries()]);
+    fd = fs.openSync(tmp, "w");
+    fs.writeSync(fd, body);
+    fs.fsyncSync(fd);
+    fs.closeSync(fd);
+    fd = null;
     fs.renameSync(tmp, STORE_PATH);
   } catch (err) {
+    if (fd !== null) {
+      try { fs.closeSync(fd); } catch { /* already closed */ }
+    }
     try {
       fs.unlinkSync(tmp);
     } catch {


### PR DESCRIPTION
Four more #605 MAJORs.

## useBridgeStatus kill-switch poll backoff
Polled `/kill-switch` every 10s regardless of failure — 360 req/hour per open tab while the bridge is offline. Added exponential backoff on failure (same curve as the status poll) + AbortController for unmount.

## FirstRunChecklist AbortController + per-tick controllers
`probe()` ran 5 parallel fetches every 30s forever with no cancellation. setState fired on dead tree after navigation. Now: mount-scoped controller for first probe, per-tick controller inside setInterval so abort doesnt poison future ticks.

## ConnectorHealthPanel AbortController
30s poll without cancellation. Same fix shape.

## CommandPalette AbortController on open
Two parallel fetches fired on every palette open with no cleanup. Closing mid-fetch let late responses overwrite stale state. Per-open controller aborted on close.

## pushStore explicit fsync before rename
Atomic write was `temp + rename` without `fsync`. ext4 (`data=writeback`) and APFS edge cases let the rename complete while the temp data is still in the page cache — a crash between rename and flush can leave the destination zero-bytes despite the atomic-rename promise. Now: `openSync + writeSync + fsyncSync + closeSync + rename`. Matches the bridges `writeFileAtomicSync`.

## Tests
353/353 dashboard tests pass.

## Test plan
- [ ] CI green
- [ ] Stop the bridge; open dashboard tab; observe /kill-switch fetch rate drops on every failure (not constant 10s)
- [ ] Open + close CommandPalette rapidly; no late state overwrites
- [ ] Run dashboard, kill -9 the Next process; restart; push subscription store is intact (or empty — never garbage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)