### PR TITLE
feat(analytics): allow self-hosted telemetry endpoint via env

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,6 +91,8 @@ Most users don't need to touch these — CLI flags cover the common cases. Liste
 | `PATCHWORK_FLAG_UI_SCHEMA_LINT` | Feature flag — strict UI-schema linting in the recipe editor. |
 | `LOCAL_MODEL` / `LOCAL_ENDPOINT` / `LOCAL_API_KEY` / `LOCAL_ENDPOINT_ALLOW_REMOTE` | Local-model driver config (Ollama / vLLM / OpenAI-compatible endpoint). |
 | `OTEL_SERVICE_NAME` | Override the OTel service name (default `claude-ide-bridge`). |
+| `PATCHWORK_ANALYTICS_ENDPOINT` | Override the opt-in telemetry collector URL (default `https://analytics.claude-ide-bridge.dev/v1/usage`). Must be `http(s)://`; invalid values fall back to default. Read once at startup, never from network — preserves the redirect-attack property. For self-hosted collectors. |
+| `PATCHWORK_ANALYTICS_KEY` | Shared-secret sent as `X-Analytics-Key` header on telemetry POSTs. Only meaningful when paired with a self-hosted endpoint that checks it. |
 
 ##### Connector credential env vars
 

--- a/src/__tests__/analyticsSend.test.ts
+++ b/src/__tests__/analyticsSend.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const ORIGINAL_ENV = { ...process.env };
+
+function makeFetchSpy(status = 204) {
+  return vi.fn<typeof fetch>(async () => new Response(null, { status }));
+}
+
+async function importFresh(env: Record<string, string | undefined>) {
+  for (const k of ["PATCHWORK_ANALYTICS_ENDPOINT", "PATCHWORK_ANALYTICS_KEY"]) {
+    delete process.env[k];
+  }
+  for (const [k, v] of Object.entries(env)) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+  vi.resetModules();
+  vi.doMock("../analyticsPrefs.js", () => ({ recordAnalyticsSent: vi.fn() }));
+  return await import("../analyticsSend.js");
+}
+
+describe("sendAnalytics endpoint resolution", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  it("defaults to the upstream endpoint when no override is set", async () => {
+    const fetchSpy = makeFetchSpy();
+    vi.stubGlobal("fetch", fetchSpy);
+    const mod = await importFresh({});
+    await mod.sendAnalytics({} as never);
+    expect(fetchSpy).toHaveBeenCalledOnce();
+    expect(fetchSpy.mock.calls[0]?.[0]).toBe(
+      "https://analytics.claude-ide-bridge.dev/v1/usage",
+    );
+    const init = fetchSpy.mock.calls[0]?.[1] as RequestInit | undefined;
+    expect(
+      (init?.headers as Record<string, string> | undefined)?.[
+        "X-Analytics-Key"
+      ],
+    ).toBeUndefined();
+  });
+
+  it("honors PATCHWORK_ANALYTICS_ENDPOINT and sends X-Analytics-Key when set", async () => {
+    const fetchSpy = makeFetchSpy();
+    vi.stubGlobal("fetch", fetchSpy);
+    const mod = await importFresh({
+      PATCHWORK_ANALYTICS_ENDPOINT:
+        "https://analytics.patchworkos.com/v1/usage",
+      PATCHWORK_ANALYTICS_KEY: "sekret",
+    });
+    await mod.sendAnalytics({} as never);
+    expect(fetchSpy.mock.calls[0]?.[0]).toBe(
+      "https://analytics.patchworkos.com/v1/usage",
+    );
+    const init = fetchSpy.mock.calls[0]?.[1] as RequestInit | undefined;
+    expect(
+      (init?.headers as Record<string, string> | undefined)?.[
+        "X-Analytics-Key"
+      ],
+    ).toBe("sekret");
+  });
+
+  it("falls back to default when override is not a valid URL", async () => {
+    const fetchSpy = makeFetchSpy();
+    vi.stubGlobal("fetch", fetchSpy);
+    const mod = await importFresh({
+      PATCHWORK_ANALYTICS_ENDPOINT: "not a url",
+    });
+    await mod.sendAnalytics({} as never);
+    expect(fetchSpy.mock.calls[0]?.[0]).toBe(
+      "https://analytics.claude-ide-bridge.dev/v1/usage",
+    );
+  });
+
+  it("falls back to default when override uses a non-http(s) scheme", async () => {
+    const fetchSpy = makeFetchSpy();
+    vi.stubGlobal("fetch", fetchSpy);
+    const mod = await importFresh({
+      PATCHWORK_ANALYTICS_ENDPOINT: "file:///etc/passwd",
+    });
+    await mod.sendAnalytics({} as never);
+    expect(fetchSpy.mock.calls[0]?.[0]).toBe(
+      "https://analytics.claude-ide-bridge.dev/v1/usage",
+    );
+  });
+
+  it("swallows fetch errors silently", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new Error("boom");
+      }),
+    );
+    const mod = await importFresh({});
+    await expect(mod.sendAnalytics({} as never)).resolves.toBeUndefined();
+  });
+});

--- a/src/analyticsSend.ts
+++ b/src/analyticsSend.ts
@@ -2,14 +2,31 @@
  * Sends an anonymized analytics summary to the usage endpoint.
  * - Fire-and-forget is NOT used: callers must await this with a timeout race.
  * - All errors are caught and swallowed — telemetry must never affect bridge operation.
- * - Endpoint is hardcoded (not runtime-configurable) to prevent redirect attacks.
+ * - Endpoint defaults to the upstream collector; self-hosters may override at startup
+ *   via PATCHWORK_ANALYTICS_ENDPOINT. The value is read once at module load (never
+ *   from the network or the summary payload) to preserve the redirect-attack property.
  */
 
 import type { AnalyticsSummary } from "./analyticsAggregator.js";
 import { recordAnalyticsSent } from "./analyticsPrefs.js";
 
-/** Hardcoded endpoint — not configurable at runtime. */
-const ANALYTICS_ENDPOINT = "https://analytics.claude-ide-bridge.dev/v1/usage";
+const DEFAULT_ENDPOINT = "https://analytics.claude-ide-bridge.dev/v1/usage";
+
+function resolveEndpoint(): string {
+  const override = process.env.PATCHWORK_ANALYTICS_ENDPOINT;
+  if (!override) return DEFAULT_ENDPOINT;
+  try {
+    const u = new URL(override);
+    if (u.protocol !== "https:" && u.protocol !== "http:")
+      return DEFAULT_ENDPOINT;
+    return u.toString();
+  } catch {
+    return DEFAULT_ENDPOINT;
+  }
+}
+
+const ANALYTICS_ENDPOINT = resolveEndpoint();
+const ANALYTICS_KEY = process.env.PATCHWORK_ANALYTICS_KEY;
 
 const SEND_TIMEOUT_MS = 3000;
 
@@ -22,9 +39,13 @@ export async function sendAnalytics(summary: AnalyticsSummary): Promise<void> {
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), SEND_TIMEOUT_MS);
     try {
+      const headers: Record<string, string> = {
+        "Content-Type": "application/json",
+      };
+      if (ANALYTICS_KEY) headers["X-Analytics-Key"] = ANALYTICS_KEY;
       const res = await fetch(ANALYTICS_ENDPOINT, {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers,
         body: JSON.stringify(summary),
         signal: controller.signal,
       });


### PR DESCRIPTION
## Summary
- Adds optional `PATCHWORK_ANALYTICS_ENDPOINT` to override the opt-in telemetry collector URL; default unchanged.
- Adds optional `PATCHWORK_ANALYTICS_KEY` that, when set, is sent as the `X-Analytics-Key` header.
- Endpoint is read **once at module load** (never from the network or summary payload), so the redirect-attack property the hardcoded constant was protecting is preserved.
- Invalid URLs and non-`http(s):` schemes fall back to the default upstream collector.

## Why
Self-hosters had no path to redirect opt-in telemetry at their own collector. An env override read at process start keeps the security property intact while unblocking that use case.

## Changes
- `src/analyticsSend.ts` — env override + optional auth header
- `src/__tests__/analyticsSend.test.ts` — 5 cases: default, override+key, bad URL fallback, bad scheme fallback, fetch error swallow
- `CLAUDE.md` — env-vars table entries for both new vars

## Test plan
- [x] `npx vitest run src/__tests__/analyticsSend.test.ts` — 5/5 pass
- [x] `npx tsc -p tsconfig.tests.core.json --noEmit` — clean
- [x] `npx biome check --write` on touched files — clean
- [ ] Reviewer: confirm the env-only override doesn't violate the design intent documented at the top of the file

🤖 Generated with [Claude Code](https://claude.com/claude-code)