### PR TITLE
feat(analytics): config file + `patchwork analytics` CLI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,7 @@ Comply with all docs in `/documents/`. Consult before changes:
 - `tools search <query> [--json]` — Filter the registered tools by name / description substring.
 - `install <companion>` — Install one of the bundled MCP-companion server registrations into Claude Desktop or Claude Code config. Use `--target cli|desktop` to choose, `--env KEY=VAL` to pass per-companion env vars. Companions: `memory`, `superpowers`, `devtools`, `database`, `slack`, `playwright`, `codebase-memory`. Each is a documented server config; the command writes it into `~/.claude.json` (CLI) or the Claude Desktop config (desktop) atomically.
 - `kill-switch engage|release|status [--reason <text>]` — Toggle the global write-disable gate (see ADR-0012).
+- `analytics show|configure|clear|test` — Manage the opt-in telemetry collector config (endpoint + shared secret) at `~/.claude/ide/analytics-config.json` (mode 0600). Replaces the brittle pattern of putting the secret in a launchd plist. `configure --endpoint URL --key KEY` writes both atomically; `test` sends a tiny synthetic payload and reports the HTTP status; `show` prints active values and resolution source (env / config / default). Env vars still win for headless/CI.
 - `panic` — Shortcut for `kill-switch engage --reason "manual panic"`.
 - `judgments [--window 1h|24h|overnight|7d|any] [--recipe <name>] [--json]` — Recent judge-step verdicts (from recipe steps with `agent.kind: judge`) across runs. Discovers the running bridge via lock file, queries `/runs/judge-summary`, prints per-verdict counts + 5 most-recent. Sibling of `halts`; same window/filter shape.
 - `suggest [--since-days N]` — Recipe co-occurrence + unused-tool suggestions from recent activity.
@@ -91,8 +92,8 @@ Most users don't need to touch these — CLI flags cover the common cases. Liste
 | `PATCHWORK_FLAG_UI_SCHEMA_LINT` | Feature flag — strict UI-schema linting in the recipe editor. |
 | `LOCAL_MODEL` / `LOCAL_ENDPOINT` / `LOCAL_API_KEY` / `LOCAL_ENDPOINT_ALLOW_REMOTE` | Local-model driver config (Ollama / vLLM / OpenAI-compatible endpoint). |
 | `OTEL_SERVICE_NAME` | Override the OTel service name (default `claude-ide-bridge`). |
-| `PATCHWORK_ANALYTICS_ENDPOINT` | Override the opt-in telemetry collector URL (default `https://analytics.claude-ide-bridge.dev/v1/usage`). Must be `http(s)://`; invalid values fall back to default. Read once at startup, never from network — preserves the redirect-attack property. For self-hosted collectors. |
-| `PATCHWORK_ANALYTICS_KEY` | Shared-secret sent as `X-Analytics-Key` header on telemetry POSTs. Only meaningful when paired with a self-hosted endpoint that checks it. |
+| `PATCHWORK_ANALYTICS_ENDPOINT` | Override the opt-in telemetry collector URL (default `https://analytics.claude-ide-bridge.dev/v1/usage`). Must be `http(s)://`; invalid values fall back to default. Per-call resolution; precedence: env > config file > default. For CI/headless. Prefer `patchwork analytics configure` for persistent setups — keeps the secret out of launchd plists. |
+| `PATCHWORK_ANALYTICS_KEY` | Shared-secret sent as `X-Analytics-Key` header on telemetry POSTs. Only meaningful when paired with a self-hosted endpoint that checks it. Same precedence as endpoint. |
 
 ##### Connector credential env vars
 

--- a/src/__tests__/analyticsConfig.test.ts
+++ b/src/__tests__/analyticsConfig.test.ts
@@ -44,8 +44,12 @@ describe("analyticsConfig", () => {
       key: "abc123",
     });
     const stat = fs.statSync(configPath());
-    // mode 0o600 — owner rw only
-    expect(stat.mode & 0o777).toBe(0o600);
+    // POSIX file modes don't apply on Windows (NTFS reports 0o666 for any
+    // writable file regardless of the mode passed to writeFileSync). Skip
+    // the perms assertion there; the 0o600 still takes effect on macOS/Linux.
+    if (process.platform !== "win32") {
+      expect(stat.mode & 0o777).toBe(0o600);
+    }
   });
 
   it("rejects an invalid endpoint URL", async () => {

--- a/src/__tests__/analyticsConfig.test.ts
+++ b/src/__tests__/analyticsConfig.test.ts
@@ -1,0 +1,110 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const ORIGINAL_ENV = { ...process.env };
+
+let tmpRoot: string;
+
+beforeEach(() => {
+  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "analytics-cfg-"));
+  process.env.CLAUDE_CONFIG_DIR = tmpRoot;
+});
+
+afterEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+  try {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  } catch {
+    /* ignore */
+  }
+});
+
+async function importFresh() {
+  vi.resetModules();
+  return await import("../analyticsConfig.js");
+}
+
+describe("analyticsConfig", () => {
+  it("returns empty config when file is missing", async () => {
+    const { getAnalyticsConfig } = await importFresh();
+    expect(getAnalyticsConfig()).toEqual({});
+  });
+
+  it("round-trips endpoint + key", async () => {
+    const { setAnalyticsConfig, getAnalyticsConfig, configPath } =
+      await importFresh();
+    setAnalyticsConfig({
+      endpoint: "https://collector.example.com/v1/usage",
+      key: "abc123",
+    });
+    expect(getAnalyticsConfig()).toEqual({
+      endpoint: "https://collector.example.com/v1/usage",
+      key: "abc123",
+    });
+    const stat = fs.statSync(configPath());
+    // mode 0o600 — owner rw only
+    expect(stat.mode & 0o777).toBe(0o600);
+  });
+
+  it("rejects an invalid endpoint URL", async () => {
+    const { setAnalyticsConfig } = await importFresh();
+    expect(() => setAnalyticsConfig({ endpoint: "not a url" })).toThrow(
+      /invalid endpoint/,
+    );
+  });
+
+  it("rejects a non-http(s) scheme", async () => {
+    const { setAnalyticsConfig } = await importFresh();
+    expect(() =>
+      setAnalyticsConfig({ endpoint: "file:///etc/passwd" }),
+    ).toThrow(/invalid endpoint/);
+  });
+
+  it("ignores invalid endpoints already on disk (read-side guard)", async () => {
+    const { configPath, getAnalyticsConfig } = await importFresh();
+    fs.mkdirSync(path.dirname(configPath()), { recursive: true });
+    fs.writeFileSync(
+      configPath(),
+      JSON.stringify({ endpoint: "ftp://nope", key: "k" }),
+    );
+    expect(getAnalyticsConfig()).toEqual({ key: "k" });
+  });
+
+  it("merges updates rather than overwriting unspecified fields", async () => {
+    const { setAnalyticsConfig, getAnalyticsConfig } = await importFresh();
+    setAnalyticsConfig({
+      endpoint: "https://a.example.com/u",
+      key: "k1",
+    });
+    setAnalyticsConfig({ key: "k2" });
+    expect(getAnalyticsConfig()).toEqual({
+      endpoint: "https://a.example.com/u",
+      key: "k2",
+    });
+  });
+
+  it("clears a field when passed undefined explicitly", async () => {
+    const { setAnalyticsConfig, getAnalyticsConfig } = await importFresh();
+    setAnalyticsConfig({
+      endpoint: "https://a.example.com/u",
+      key: "k1",
+    });
+    setAnalyticsConfig({ key: undefined });
+    expect(getAnalyticsConfig()).toEqual({
+      endpoint: "https://a.example.com/u",
+    });
+  });
+
+  it("clearAnalyticsConfig removes the file", async () => {
+    const { setAnalyticsConfig, clearAnalyticsConfig, configPath } =
+      await importFresh();
+    setAnalyticsConfig({ endpoint: "https://a.example.com/u" });
+    expect(fs.existsSync(configPath())).toBe(true);
+    clearAnalyticsConfig();
+    expect(fs.existsSync(configPath())).toBe(false);
+    // idempotent
+    expect(() => clearAnalyticsConfig()).not.toThrow();
+  });
+});

--- a/src/__tests__/analyticsSend.test.ts
+++ b/src/__tests__/analyticsSend.test.ts
@@ -1,18 +1,37 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const ORIGINAL_ENV = { ...process.env };
+
+let tmpRoot: string;
 
 function makeFetchSpy(status = 204) {
   return vi.fn<typeof fetch>(async () => new Response(null, { status }));
 }
 
-async function importFresh(env: Record<string, string | undefined>) {
+async function importFresh(
+  env: Record<string, string | undefined>,
+  configFile?: { endpoint?: string; key?: string },
+) {
   for (const k of ["PATCHWORK_ANALYTICS_ENDPOINT", "PATCHWORK_ANALYTICS_KEY"]) {
     delete process.env[k];
   }
+  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "asend-"));
+  process.env.CLAUDE_CONFIG_DIR = tmpRoot;
   for (const [k, v] of Object.entries(env)) {
     if (v === undefined) delete process.env[k];
     else process.env[k] = v;
+  }
+  if (configFile) {
+    const dir = path.join(tmpRoot, "ide");
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, "analytics-config.json"),
+      JSON.stringify(configFile),
+      { mode: 0o600 },
+    );
   }
   vi.resetModules();
   vi.doMock("../analyticsPrefs.js", () => ({ recordAnalyticsSent: vi.fn() }));
@@ -28,6 +47,13 @@ describe("sendAnalytics endpoint resolution", () => {
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
     process.env = { ...ORIGINAL_ENV };
+    if (tmpRoot) {
+      try {
+        fs.rmSync(tmpRoot, { recursive: true, force: true });
+      } catch {
+        /* ignore */
+      }
+    }
   });
 
   it("defaults to the upstream endpoint when no override is set", async () => {
@@ -89,6 +115,60 @@ describe("sendAnalytics endpoint resolution", () => {
     expect(fetchSpy.mock.calls[0]?.[0]).toBe(
       "https://analytics.claude-ide-bridge.dev/v1/usage",
     );
+  });
+
+  it("reads endpoint and key from config file when env is unset", async () => {
+    const fetchSpy = makeFetchSpy();
+    vi.stubGlobal("fetch", fetchSpy);
+    const mod = await importFresh(
+      {},
+      { endpoint: "https://collector.example.com/u", key: "from-file" },
+    );
+    await mod.sendAnalytics({} as never);
+    expect(fetchSpy.mock.calls[0]?.[0]).toBe("https://collector.example.com/u");
+    const init = fetchSpy.mock.calls[0]?.[1] as RequestInit | undefined;
+    expect(
+      (init?.headers as Record<string, string> | undefined)?.[
+        "X-Analytics-Key"
+      ],
+    ).toBe("from-file");
+  });
+
+  it("env overrides the config file (env > file > default)", async () => {
+    const fetchSpy = makeFetchSpy();
+    vi.stubGlobal("fetch", fetchSpy);
+    const mod = await importFresh(
+      {
+        PATCHWORK_ANALYTICS_ENDPOINT: "https://env.example.com/u",
+        PATCHWORK_ANALYTICS_KEY: "from-env",
+      },
+      { endpoint: "https://collector.example.com/u", key: "from-file" },
+    );
+    await mod.sendAnalytics({} as never);
+    expect(fetchSpy.mock.calls[0]?.[0]).toBe("https://env.example.com/u");
+    const init = fetchSpy.mock.calls[0]?.[1] as RequestInit | undefined;
+    expect(
+      (init?.headers as Record<string, string> | undefined)?.[
+        "X-Analytics-Key"
+      ],
+    ).toBe("from-env");
+  });
+
+  it("env endpoint + file key compose when each is set separately", async () => {
+    const fetchSpy = makeFetchSpy();
+    vi.stubGlobal("fetch", fetchSpy);
+    const mod = await importFresh(
+      { PATCHWORK_ANALYTICS_ENDPOINT: "https://env.example.com/u" },
+      { key: "from-file" },
+    );
+    await mod.sendAnalytics({} as never);
+    expect(fetchSpy.mock.calls[0]?.[0]).toBe("https://env.example.com/u");
+    const init = fetchSpy.mock.calls[0]?.[1] as RequestInit | undefined;
+    expect(
+      (init?.headers as Record<string, string> | undefined)?.[
+        "X-Analytics-Key"
+      ],
+    ).toBe("from-file");
   });
 
   it("swallows fetch errors silently", async () => {

--- a/src/analyticsConfig.ts
+++ b/src/analyticsConfig.ts
@@ -1,0 +1,91 @@
+/**
+ * On-disk config for the opt-in telemetry collector (endpoint + shared secret).
+ *
+ * Lives at ~/.claude/ide/analytics-config.json (respects CLAUDE_CONFIG_DIR).
+ * Mode 0600. Atomic writes via temp + rename.
+ *
+ * Resolution order in analyticsSend.ts:
+ *   1. process.env.PATCHWORK_ANALYTICS_ENDPOINT / _KEY  (highest)
+ *   2. this file
+ *   3. upstream default (no key)
+ *
+ * Reason for the file: keeps the shared secret out of launchd plists
+ * (which are Time-Machine backed, iCloud synced, and survive reinstalls
+ * in an inconsistent way) and gives operators a single source of truth
+ * managed by the `patchwork analytics configure` CLI.
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+export interface AnalyticsConfig {
+  endpoint?: string;
+  key?: string;
+}
+
+export function configPath(): string {
+  const claudeDir =
+    process.env.CLAUDE_CONFIG_DIR ?? path.join(os.homedir(), ".claude");
+  return path.join(claudeDir, "ide", "analytics-config.json");
+}
+
+function isValidEndpoint(value: unknown): value is string {
+  if (typeof value !== "string" || value.length === 0) return false;
+  try {
+    const u = new URL(value);
+    return u.protocol === "http:" || u.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+/** Read the config file. Returns empty object on missing/invalid file. */
+export function getAnalyticsConfig(): AnalyticsConfig {
+  try {
+    const raw = fs.readFileSync(configPath(), "utf-8");
+    const obj = JSON.parse(raw) as unknown;
+    if (typeof obj !== "object" || obj === null) return {};
+    const rec = obj as Record<string, unknown>;
+    const out: AnalyticsConfig = {};
+    if (isValidEndpoint(rec.endpoint)) out.endpoint = rec.endpoint;
+    if (typeof rec.key === "string" && rec.key.length > 0) out.key = rec.key;
+    return out;
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Atomic write with mode 0600. Merges with existing config — pass
+ * `{ endpoint: undefined }` to clear a field explicitly.
+ */
+export function setAnalyticsConfig(update: AnalyticsConfig): void {
+  const current = getAnalyticsConfig();
+  const next: AnalyticsConfig = { ...current };
+  if ("endpoint" in update) {
+    if (update.endpoint === undefined) delete next.endpoint;
+    else if (isValidEndpoint(update.endpoint)) next.endpoint = update.endpoint;
+    else
+      throw new Error(
+        `invalid endpoint (must be http(s) URL): ${update.endpoint}`,
+      );
+  }
+  if ("key" in update) {
+    if (update.key === undefined) delete next.key;
+    else next.key = update.key;
+  }
+  const p = configPath();
+  fs.mkdirSync(path.dirname(p), { recursive: true });
+  const tmp = `${p}.tmp.${process.pid}`;
+  fs.writeFileSync(tmp, JSON.stringify(next, null, 2) + "\n", { mode: 0o600 });
+  fs.renameSync(tmp, p);
+}
+
+export function clearAnalyticsConfig(): void {
+  try {
+    fs.unlinkSync(configPath());
+  } catch {
+    /* file may not exist */
+  }
+}

--- a/src/analyticsSend.ts
+++ b/src/analyticsSend.ts
@@ -2,31 +2,73 @@
  * Sends an anonymized analytics summary to the usage endpoint.
  * - Fire-and-forget is NOT used: callers must await this with a timeout race.
  * - All errors are caught and swallowed — telemetry must never affect bridge operation.
- * - Endpoint defaults to the upstream collector; self-hosters may override at startup
- *   via PATCHWORK_ANALYTICS_ENDPOINT. The value is read once at module load (never
- *   from the network or the summary payload) to preserve the redirect-attack property.
+ * - Endpoint defaults to the upstream collector. Operators may override via:
+ *     1. env: PATCHWORK_ANALYTICS_ENDPOINT  (highest precedence; for CI/headless)
+ *     2. config file: ~/.claude/ide/analytics-config.json  (preferred — managed by
+ *        `patchwork analytics configure`, keeps secrets out of launchd plists)
+ *     3. default upstream collector
+ *   Endpoint is resolved per-call (cheap fs read) so live config changes take
+ *   effect on the next send without restart. Invalid values fall back through.
+ *   Never read from the network or summary payload — preserves the
+ *   redirect-attack property the original hardcoded constant was protecting.
  */
 
 import type { AnalyticsSummary } from "./analyticsAggregator.js";
+import { getAnalyticsConfig } from "./analyticsConfig.js";
 import { recordAnalyticsSent } from "./analyticsPrefs.js";
 
 const DEFAULT_ENDPOINT = "https://analytics.claude-ide-bridge.dev/v1/usage";
 
-function resolveEndpoint(): string {
-  const override = process.env.PATCHWORK_ANALYTICS_ENDPOINT;
-  if (!override) return DEFAULT_ENDPOINT;
+function validUrl(value: string | undefined): string | undefined {
+  if (!value) return undefined;
   try {
-    const u = new URL(override);
-    if (u.protocol !== "https:" && u.protocol !== "http:")
-      return DEFAULT_ENDPOINT;
+    const u = new URL(value);
+    if (u.protocol !== "https:" && u.protocol !== "http:") return undefined;
     return u.toString();
   } catch {
-    return DEFAULT_ENDPOINT;
+    return undefined;
   }
 }
 
-const ANALYTICS_ENDPOINT = resolveEndpoint();
-const ANALYTICS_KEY = process.env.PATCHWORK_ANALYTICS_KEY;
+export function resolveAnalyticsTarget(): {
+  endpoint: string;
+  key: string | undefined;
+  source: {
+    endpoint: "env" | "config" | "default";
+    key: "env" | "config" | "none";
+  };
+} {
+  const envEndpoint = validUrl(process.env.PATCHWORK_ANALYTICS_ENDPOINT);
+  const envKey = process.env.PATCHWORK_ANALYTICS_KEY;
+  const cfg = getAnalyticsConfig();
+  const cfgEndpoint = validUrl(cfg.endpoint);
+
+  let endpoint = DEFAULT_ENDPOINT;
+  let endpointSource: "env" | "config" | "default" = "default";
+  if (envEndpoint) {
+    endpoint = envEndpoint;
+    endpointSource = "env";
+  } else if (cfgEndpoint) {
+    endpoint = cfgEndpoint;
+    endpointSource = "config";
+  }
+
+  let key: string | undefined;
+  let keySource: "env" | "config" | "none" = "none";
+  if (envKey) {
+    key = envKey;
+    keySource = "env";
+  } else if (cfg.key) {
+    key = cfg.key;
+    keySource = "config";
+  }
+
+  return {
+    endpoint,
+    key,
+    source: { endpoint: endpointSource, key: keySource },
+  };
+}
 
 const SEND_TIMEOUT_MS = 3000;
 
@@ -36,14 +78,15 @@ const SEND_TIMEOUT_MS = 3000;
  */
 export async function sendAnalytics(summary: AnalyticsSummary): Promise<void> {
   try {
+    const { endpoint, key } = resolveAnalyticsTarget();
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), SEND_TIMEOUT_MS);
     try {
       const headers: Record<string, string> = {
         "Content-Type": "application/json",
       };
-      if (ANALYTICS_KEY) headers["X-Analytics-Key"] = ANALYTICS_KEY;
-      const res = await fetch(ANALYTICS_ENDPOINT, {
+      if (key) headers["X-Analytics-Key"] = key;
+      const res = await fetch(endpoint, {
         method: "POST",
         headers,
         body: JSON.stringify(summary),

--- a/src/commands/analytics.ts
+++ b/src/commands/analytics.ts
@@ -1,0 +1,149 @@
+/**
+ * `patchwork analytics` CLI — manage the self-hosted telemetry collector config.
+ *
+ * Replaces the brittle pattern of putting endpoint + secret in a launchd plist.
+ * Config lives at ~/.claude/ide/analytics-config.json (mode 0600), read on every
+ * send. Env vars still win for headless / CI use.
+ */
+
+import {
+  clearAnalyticsConfig,
+  configPath,
+  getAnalyticsConfig,
+  setAnalyticsConfig,
+} from "../analyticsConfig.js";
+import { resolveAnalyticsTarget, sendAnalytics } from "../analyticsSend.js";
+
+const USAGE =
+  "Usage: patchwork analytics <subcommand>\n\n" +
+  "  show                                  Print active endpoint, key (masked), and source\n" +
+  "  configure --endpoint URL [--key KEY]  Write endpoint and/or key to the config file\n" +
+  "  clear                                 Remove the config file\n" +
+  "  test                                  Send a tiny synthetic payload and report HTTP status\n" +
+  "\n" +
+  "Resolution order: env (PATCHWORK_ANALYTICS_ENDPOINT/_KEY) > config file > upstream default.\n";
+
+function maskKey(key: string | undefined): string {
+  if (!key) return "<unset>";
+  if (key.length <= 8) return "***";
+  return `${key.slice(0, 4)}…${key.slice(-4)} (len=${key.length})`;
+}
+
+function parseFlags(args: string[]): Record<string, string | true> {
+  const out: Record<string, string | true> = {};
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (!a || !a.startsWith("--")) continue;
+    const name = a.slice(2);
+    const next = args[i + 1];
+    if (next && !next.startsWith("--")) {
+      out[name] = next;
+      i++;
+    } else {
+      out[name] = true;
+    }
+  }
+  return out;
+}
+
+export async function runAnalyticsCommand(argv: string[]): Promise<number> {
+  const sub = argv[0];
+  if (!sub || sub === "--help" || sub === "-h") {
+    process.stdout.write(USAGE);
+    return sub ? 0 : 1;
+  }
+
+  if (sub === "show") {
+    const target = resolveAnalyticsTarget();
+    const cfg = getAnalyticsConfig();
+    process.stdout.write(
+      `Active endpoint:  ${target.endpoint}  (source: ${target.source.endpoint})\n` +
+        `Active key:       ${maskKey(target.key)}  (source: ${target.source.key})\n` +
+        `Config file:      ${configPath()}\n` +
+        `  endpoint:       ${cfg.endpoint ?? "<unset>"}\n` +
+        `  key:            ${maskKey(cfg.key)}\n` +
+        `Env:\n` +
+        `  PATCHWORK_ANALYTICS_ENDPOINT: ${process.env.PATCHWORK_ANALYTICS_ENDPOINT ?? "<unset>"}\n` +
+        `  PATCHWORK_ANALYTICS_KEY:      ${maskKey(process.env.PATCHWORK_ANALYTICS_KEY)}\n`,
+    );
+    return 0;
+  }
+
+  if (sub === "configure") {
+    const flags = parseFlags(argv.slice(1));
+    const update: { endpoint?: string; key?: string } = {};
+    if (typeof flags.endpoint === "string") update.endpoint = flags.endpoint;
+    if (typeof flags.key === "string") update.key = flags.key;
+    if (Object.keys(update).length === 0) {
+      process.stderr.write(
+        "configure requires at least --endpoint URL or --key KEY\n",
+      );
+      return 1;
+    }
+    try {
+      setAnalyticsConfig(update);
+    } catch (err) {
+      process.stderr.write(
+        `configure failed: ${err instanceof Error ? err.message : String(err)}\n`,
+      );
+      return 1;
+    }
+    process.stdout.write(`wrote ${configPath()}\n`);
+    return 0;
+  }
+
+  if (sub === "clear") {
+    clearAnalyticsConfig();
+    process.stdout.write(`removed ${configPath()}\n`);
+    return 0;
+  }
+
+  if (sub === "test") {
+    const target = resolveAnalyticsTarget();
+    process.stdout.write(
+      `sending synthetic summary to ${target.endpoint} (key source: ${target.source.key})…\n`,
+    );
+    // Build minimal real-shaped summary
+    const summary = {
+      bridgeVersion: "cli-test",
+      sessionDurationMs: 1,
+      toolStats: [
+        { tool: "getDiagnostics", calls: 1, errors: 0, p50Ms: 1, p95Ms: 1 },
+      ],
+    };
+    // sendAnalytics swallows errors, so we shadow it with a direct fetch
+    // to surface the actual HTTP status to the operator.
+    try {
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), 5000);
+      const headers: Record<string, string> = {
+        "Content-Type": "application/json",
+      };
+      if (target.key) headers["X-Analytics-Key"] = target.key;
+      const res = await fetch(target.endpoint, {
+        method: "POST",
+        headers,
+        body: JSON.stringify(summary),
+        signal: controller.signal,
+      });
+      clearTimeout(timer);
+      process.stdout.write(`HTTP ${res.status}\n`);
+      if (!res.ok) {
+        const body = await res.text().catch(() => "");
+        if (body) process.stdout.write(`body: ${body.slice(0, 500)}\n`);
+        return 1;
+      }
+      // Also exercise the real send path so prefs.lastSentAt updates.
+      await sendAnalytics(summary);
+      return 0;
+    } catch (err) {
+      process.stderr.write(
+        `test failed: ${err instanceof Error ? err.message : String(err)}\n`,
+      );
+      return 1;
+    }
+  }
+
+  process.stderr.write(`unknown subcommand: ${sub}\n\n${USAGE}`);
+  return 1;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -183,6 +183,7 @@ const KNOWN_SUBCOMMANDS = [
   "panic",
   "halts",
   "judgments",
+  "analytics",
 ] as const;
 
 const __invokedSubcommand = (() => {
@@ -2324,6 +2325,17 @@ if (process.argv[2] === "halts") {
       );
       process.exit(1);
     }
+  })();
+}
+
+// `patchwork analytics` — manage the self-hosted telemetry collector config.
+// Replaces the brittle "endpoint+secret in launchd plist" pattern with a
+// proper config file the bridge reads at startup.
+if (process.argv[2] === "analytics") {
+  (async () => {
+    const { runAnalyticsCommand } = await import("./commands/analytics.js");
+    const code = await runAnalyticsCommand(process.argv.slice(3));
+    process.exit(code);
   })();
 }
 


### PR DESCRIPTION
## Summary

Adds `~/.claude/ide/analytics-config.json` (mode 0600, atomic writes) and a `patchwork analytics` CLI to manage the self-hosted telemetry collector config.

Replaces the brittle pattern of putting the endpoint + secret in launchd plists (Time-Machine backed, iCloud synced, survive reinstalls inconsistently, no rotation story).

## Resolution order

1. env (`PATCHWORK_ANALYTICS_ENDPOINT` / `_KEY`) — highest, for CI/headless
2. `~/.claude/ide/analytics-config.json` — preferred for persistent setups
3. upstream default — unchanged

Per-call resolution (cheap fs read), so live config changes take effect on the next send without restart. Endpoint validation (http(s) only) preserves the redirect-attack property the hardcoded constant was protecting in #611.

## New CLI

```
patchwork analytics show                                   # mask key, show resolution source
patchwork analytics configure --endpoint URL [--key KEY]   # atomic write
patchwork analytics clear                                  # remove config file
patchwork analytics test                                   # send synthetic payload, report HTTP
```

## Tests

- `analyticsConfig.test.ts` — 8 cases: round-trip, mode 0600, invalid-URL rejection, non-http(s) rejection, read-side guard on stale files, merge semantics, clear-via-`undefined`, idempotent `clear()`.
- `analyticsSend.test.ts` — 3 new cases: config-file fallback, env > file precedence, env-endpoint + file-key composition. Existing 5 cases unchanged.

All 16 pass; `tsc -p tsconfig.tests.core.json` clean; `npm run build` clean.

## Live dogfood

Against the production VPS:

```
$ analytics configure --endpoint https://analytics.patchworkos.com/v1/usage --key <secret>
wrote /Users/.../analytics-config.json
$ analytics test
sending synthetic summary to https://analytics.patchworkos.com/v1/usage (key source: config)…
HTTP 204
$ analytics test   # with wrong key
HTTP 401
exit-code=1
```

Payload landed on VPS receiver intact.

## Migration

No breaking changes. The env-var path from #611 is unchanged. Operators currently using plist env vars can switch with:

```
patchwork analytics configure --endpoint URL --key KEY
# then remove PATCHWORK_ANALYTICS_* keys from the plist
```

## Test plan

- [x] `npx vitest run src/__tests__/analyticsConfig.test.ts src/__tests__/analyticsSend.test.ts` → 16/16
- [x] `npx tsc -p tsconfig.tests.core.json --noEmit` → clean
- [x] `npx tsc --noEmit` → clean
- [x] `npm run build` → clean
- [x] Live round-trip against analytics.patchworkos.com → HTTP 204
- [ ] Reviewer: confirm config-file path doesn't violate the redirect-attack design intent (file-only, never network-sourced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)