### PR TITLE
chore: add `npm run install:global` + macOS TCC guardrail

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,6 +159,8 @@ npm run package        # create .vsix
 
 **Extension versioning rule:** Windsurf caches `.vsix` files by version number and will silently reuse the old bundle if the version hasn't changed. **Always bump `vscode-extension/package.json` version before packaging** when the user will install the `.vsix` in Windsurf (or any VS Code fork). Patch bump (`1.4.2` → `1.4.3`) is sufficient. Never repackage without bumping — the user will install it and see no change.
 
+**Local global install rule (macOS):** Never run `npm install -g .` from a workspace under `~/Documents/`, `~/Desktop/`, or `~/Downloads/`. npm creates a symlink from `/opt/homebrew/lib/node_modules/<pkg>` into the workspace, and macOS TCC then silently blocks launchd-spawned processes from following that symlink (EPERM). The LaunchAgent will appear to install correctly but fail on first reload with `code: 'EPERM'`. Use `npm run install:global` (wraps `npm pack` + `npm install -g <tgz>`) instead — produces a real-copy install outside TCC's protected directory tree.
+
 Before staging, run `npx biome check --write <files>` on changed files. Fix before stage — don't wait for hook to fail.
 
 ## LSP Workflows

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
   },
   "scripts": {
     "build": "node -e \"require('fs').rmSync('dist',{recursive:true,force:true})\" && tsc && (node scripts/postinstall.mjs || true)",
+    "install:global": "node scripts/install-global.mjs",
     "dev": "tsx src/index.ts",
     "start": "node dist/index.js",
     "test": "vitest run",

--- a/scripts/install-global.mjs
+++ b/scripts/install-global.mjs
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+/**
+ * Install the current workspace globally as a real copy (not a symlink).
+ *
+ * Reason: `npm install -g .` from a workspace under ~/Documents/ on macOS
+ * makes /opt/homebrew/lib/node_modules/patchwork-os a symlink into Documents.
+ * macOS TCC then blocks launchd-spawned processes from reading it (EPERM),
+ * which silently breaks the LaunchAgent on first reload.
+ *
+ * This wrapper does `npm pack` → `npm install -g <tgz>` → cleanup. The result
+ * is a normal real-copy install under the global prefix, outside TCC's
+ * Documents/Desktop/Downloads protection.
+ *
+ * Use:  npm run install:global
+ */
+import { execSync } from "node:child_process";
+import { existsSync, rmSync } from "node:fs";
+import { join } from "node:path";
+
+const cwd = process.cwd();
+
+function run(cmd, opts = {}) {
+  return execSync(cmd, { stdio: "inherit", cwd, ...opts });
+}
+
+function capture(cmd) {
+  return execSync(cmd, { cwd, encoding: "utf-8" }).trim();
+}
+
+console.error("→ npm pack");
+const packOutput = capture("npm pack --silent");
+// `npm pack --silent` prints the tarball name on stdout (last non-empty line).
+const tarball = packOutput
+  .split("\n")
+  .map((s) => s.trim())
+  .filter(Boolean)
+  .pop();
+if (!tarball || !existsSync(join(cwd, tarball))) {
+  console.error(
+    `npm pack did not produce a tarball (got: ${tarball ?? "<empty>"})`,
+  );
+  process.exit(1);
+}
+console.error(`  packed: ${tarball}`);
+
+try {
+  console.error(`→ npm install -g ./${tarball}`);
+  run(`npm install -g "./${tarball}"`);
+} finally {
+  try {
+    rmSync(join(cwd, tarball));
+    console.error(`  cleaned: ${tarball}`);
+  } catch {
+    /* ignore */
+  }
+}
+
+console.error("✓ installed globally as a real copy");


### PR DESCRIPTION
## Summary

Adds `npm run install:global` (`scripts/install-global.mjs`) that wraps `npm pack` + `npm install -g <tgz>` for a real-copy global install, plus a CLAUDE.md note documenting why `npm install -g .` is a footgun on macOS.

## Why

`npm install -g .` from a workspace under `~/Documents/` (or `~/Desktop/`, `~/Downloads/`) makes `/opt/homebrew/lib/node_modules/patchwork-os` a **symlink** into the workspace. macOS TCC then silently blocks `launchd`-spawned processes from following that symlink — they get EPERM on first `open()`. The LaunchAgent installs without error but the bridge dies immediately on reload.

We hit this during analytics dogfooding (the session that produced #611 / #612). Took 20 minutes to diagnose. Future agents/contributors shouldn't have to figure this out from scratch.

## Test plan

- [x] `npm pack --dry-run --json` confirms tarball shape
- [x] Script handles cleanup on success and failure (try/finally)
- [ ] Reviewer: run `npm run install:global` locally, verify `/opt/homebrew/lib/node_modules/patchwork-os` is a real directory (not a symlink)

🤖 Generated with [Claude Code](https://claude.com/claude-code)