### PR TITLE
ci: auto-publish canary on every green merge to main

### DIFF
--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -1,0 +1,91 @@
+name: Publish canary on merge to main
+
+# Fires after CI succeeds on a main push (i.e. a PR merge). Publishes a
+# `<version>.canary.<run_number>` build to npm under the `canary` dist-tag,
+# so `npm install -g patchwork-os@canary` always tracks main. Stable users
+# on `latest` / `beta` are untouched.
+#
+# Why: prior to this, the only way to dogfood a freshly-merged change was to
+# wait for the next manual `chore(release):` PR. Canary closes that gap
+# without lowering the bar for tagged releases (which still go through the
+# existing publish-npm.yml workflow).
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+    branches: [main]
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  publish-canary:
+    # Only proceed when the upstream CI run succeeded. workflow_run fires
+    # on every completion, including failures.
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.head_branch == 'main')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Pin to the exact commit CI validated, not whatever main is now.
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+          registry-url: 'https://registry.npmjs.org'
+
+      - run: npm ci
+      - run: npm run build
+
+      # Compute canary version. Shape: <current>.canary.<runNumber>
+      # Example: 0.2.0-beta.5  →  0.2.0-beta.5.canary.42
+      # Always sorts above the base version and below the next base bump.
+      - name: Compute canary version
+        id: ver
+        run: |
+          BASE=$(node -p "require('./package.json').version")
+          CANARY="${BASE}.canary.${{ github.run_number }}"
+          echo "version=$CANARY" >> "$GITHUB_OUTPUT"
+          echo "Canary version: $CANARY"
+
+      # Idempotency: re-running the workflow (manual or workflow_run retry)
+      # would otherwise fail loudly with npm E403 — skip cleanly.
+      - name: Check if version already published
+        id: npm_check
+        run: |
+          if npm view "patchwork-os@${{ steps.ver.outputs.version }}" version > /dev/null 2>&1; then
+            echo "Already published — skipping"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Write canary version into package.json
+        if: steps.npm_check.outputs.skip != 'true'
+        run: |
+          node -e "
+            const fs = require('fs');
+            const pkg = JSON.parse(fs.readFileSync('package.json','utf-8'));
+            pkg.version = '${{ steps.ver.outputs.version }}';
+            fs.writeFileSync('package.json', JSON.stringify(pkg,null,2)+'\n');
+          "
+
+      - name: Publish canary to npm
+        if: steps.npm_check.outputs.skip != 'true'
+        run: npm publish --access public --tag canary
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Summary
+        if: always()
+        run: |
+          echo "### Canary publish" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Version: \`${{ steps.ver.outputs.version }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Skipped: \`${{ steps.npm_check.outputs.skip == 'true' }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Install: \`npm install -g patchwork-os@canary\`" >> "$GITHUB_STEP_SUMMARY"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,6 +161,10 @@ npm run package        # create .vsix
 
 Before staging, run `npx biome check --write <files>` on changed files. Fix before stage — don't wait for hook to fail.
 
+**Release channels:**
+- `latest` / `beta` — manual via `chore(release):` PRs, tagged `v*-beta*` → `publish-npm.yml`. Stable / human-curated.
+- `canary` — automatic on every green main merge via `publish-canary.yml`. Version shape `<base>.canary.<runNumber>` (e.g. `0.2.0-beta.5.canary.42`). `npm install -g patchwork-os@canary` always tracks main. Use for dogfooding freshly-merged changes without waiting for the next release PR. Never default-installed.
+
 ## LSP Workflows
 
 All LSP tools available in both slim and full mode (full is the default since v2.43.0).


### PR DESCRIPTION
## Summary

Adds `.github/workflows/publish-canary.yml`. Fires after CI succeeds on a main push (PR merge), publishes `<version>.canary.<run_number>` to npm under the `canary` dist-tag.

`latest` / `beta` channels untouched — existing `chore(release):` flow keeps working unchanged.

## Why

Right now the gap between "PR merged" and "I can dogfood the merged change" is bounded by how often a manual `chore(release):` PR gets cut. This session's analytics work hit that gap painfully: PR #611 merged, but the published bridge was beta.0, so I had to overlay the built file into the homebrew install just to test the new env override end-to-end. That side path corrupted the npm install and ate ~30 min of recovery.

With canary, the flow becomes:

```bash
npm install -g patchwork-os@canary    # latest green main
patchwork analytics test              # dogfood the actual production binary
```

## Design

- **Trigger**: `workflow_run` on CI completion, branches `[main]`, only proceeds when `conclusion == 'success'`. Never publishes a red build.
- **Pinning**: checks out `workflow_run.head_sha` — the exact commit CI validated, not whatever main moved to.
- **Version shape**: `<package.json version>.canary.<run_number>`, e.g. `0.2.0-beta.5.canary.42`. Semver-prerelease-compares above the base and below the next bump.
- **Dist-tag**: `canary`. `npm install -g patchwork-os` continues to install whatever's on `latest`.
- **Idempotency**: `npm view` pre-check skips cleanly if already published (re-running the workflow is safe).
- **No git writes**: package.json bump is local to the runner; nothing pushed back. Avoids loops and "release commits" cluttering history.

## Risks

- Every merge → one npm publish → npm storage grows. Negligible (~2 MB per canary; unpublish via `npm dist-tag rm` if needed).
- Bad commits that slip past CI ship to canary users immediately. Mitigation: existing coverage + lint + typecheck gates, plus canary is opt-in (`@canary` tag).
- Doesn't auto-prune old canaries. Future improvement: scheduled job to `npm dist-tag rm` canaries older than 30 days. Not blocking.

## Test plan

- [x] YAML syntax validates (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] After merge: trigger via `workflow_dispatch` once to verify happy path (NPM_TOKEN, version shape, dist-tag)
- [ ] Verify `npm view patchwork-os@canary version` returns the published canary
- [ ] Verify `npm install -g patchwork-os@canary` works
- [ ] Verify a subsequent main merge auto-publishes the next canary

🤖 Generated with [Claude Code](https://claude.com/claude-code)