### PR TITLE
feat(dashboard): admin /telemetry view of self-hosted analytics receiver

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,6 +130,7 @@ The dashboard reads these from `dashboard/.env.local` / `.env` at startup. Most 
 | `DASHBOARD_SESSION_SECRET` | Cookie-signing secret (random hex ≥ 32 chars). |
 | `DASHBOARD_ALLOW_UNAUTHENTICATED` | `1` to bypass the password gate (local dev only). |
 | `DASHBOARD_AUTH_FAILURE_WINDOW_MS` / `DASHBOARD_AUTH_MAX_FAILURES` / `DASHBOARD_AUTH_LOCKOUT_MS` | Brute-force lockout tuning for the login form. |
+| `DASHBOARD_TELEMETRY_DIR` | Directory the `/telemetry` page reads JSONL files from. Default `/var/lib/analytics` — matches the self-hosted analytics receiver. Gated by the same single-user session auth as the rest of the dashboard, so effectively admin-only. |
 | `PATCHWORK_BRIDGE_TOKEN` | Bearer token the dashboard uses when forwarding to a remote bridge (paired with `PATCHWORK_BRIDGE_URL`). |
 | `NEXT_PUBLIC_BASE_PATH` | basePath for mounted-prefix deployments (`/dashboard` under nginx, etc.). |
 | `NEXT_PUBLIC_DEMO_MODE` | Read-only demo mode for the public marketing site. |

--- a/dashboard/src/app/api/telemetry/route.ts
+++ b/dashboard/src/app/api/telemetry/route.ts
@@ -1,0 +1,177 @@
+/**
+ * Reads the self-hosted analytics receiver's JSONL files and returns an
+ * aggregated summary. Reads files in DASHBOARD_TELEMETRY_DIR (default
+ * /var/lib/analytics). Gated by the dashboard's existing session auth
+ * via middleware — single-user password = effectively admin-only.
+ *
+ * Query params:
+ *   days   — how many days back to include (default 7, max 90)
+ */
+
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { NextResponse } from "next/server";
+
+export const dynamic = "force-dynamic";
+
+const DEFAULT_DIR = "/var/lib/analytics";
+const MAX_DAYS = 90;
+const MAX_BYTES_PER_FILE = 16 * 1024 * 1024; // 16 MB safety cap
+
+interface ToolStat {
+  tool: string;
+  calls: number;
+  errors: number;
+  p50Ms: number;
+  p95Ms: number;
+}
+
+interface Summary {
+  bridgeVersion?: string;
+  sessionDurationMs?: number;
+  toolStats?: ToolStat[];
+  installSalt?: string;
+  nodeVersion?: string;
+  osFamily?: string;
+}
+
+interface Event extends Summary {
+  receivedAt: string; // derived from filename (UTC date)
+}
+
+function listDays(days: number): string[] {
+  const out: string[] = [];
+  const now = new Date();
+  for (let i = 0; i < days; i++) {
+    const d = new Date(now);
+    d.setUTCDate(d.getUTCDate() - i);
+    out.push(d.toISOString().slice(0, 10));
+  }
+  return out;
+}
+
+async function readDay(dir: string, day: string): Promise<Event[]> {
+  const file = path.join(dir, `${day}.jsonl`);
+  let raw: string;
+  try {
+    const stat = await fs.stat(file);
+    if (stat.size > MAX_BYTES_PER_FILE) return [];
+    raw = await fs.readFile(file, "utf-8");
+  } catch {
+    return [];
+  }
+  const out: Event[] = [];
+  for (const line of raw.split("\n")) {
+    if (!line.trim()) continue;
+    try {
+      const obj = JSON.parse(line) as Summary;
+      out.push({ ...obj, receivedAt: day });
+    } catch {
+      // skip malformed line
+    }
+  }
+  return out;
+}
+
+function aggregate(events: Event[]) {
+  const totalEvents = events.length;
+  const totalSessionMs = events.reduce(
+    (a, e) => a + (typeof e.sessionDurationMs === "number" ? e.sessionDurationMs : 0),
+    0,
+  );
+
+  // by-tool
+  const byTool = new Map<string, { calls: number; errors: number; p95Max: number }>();
+  for (const e of events) {
+    for (const t of e.toolStats ?? []) {
+      const cur = byTool.get(t.tool) ?? { calls: 0, errors: 0, p95Max: 0 };
+      cur.calls += t.calls;
+      cur.errors += t.errors;
+      cur.p95Max = Math.max(cur.p95Max, t.p95Ms);
+      byTool.set(t.tool, cur);
+    }
+  }
+  const tools = Array.from(byTool.entries())
+    .map(([tool, s]) => ({ tool, ...s }))
+    .sort((a, b) => b.calls - a.calls);
+
+  // by-day
+  const byDay = new Map<string, number>();
+  for (const e of events) {
+    byDay.set(e.receivedAt, (byDay.get(e.receivedAt) ?? 0) + 1);
+  }
+  const days = Array.from(byDay.entries())
+    .map(([day, count]) => ({ day, count }))
+    .sort((a, b) => a.day.localeCompare(b.day));
+
+  // by-install (salt — dedupes repeated installs from same machine)
+  const byInstall = new Map<string, number>();
+  for (const e of events) {
+    if (typeof e.installSalt === "string") {
+      byInstall.set(e.installSalt, (byInstall.get(e.installSalt) ?? 0) + 1);
+    }
+  }
+  const installs = byInstall.size;
+
+  // by-version
+  const byVersion = new Map<string, number>();
+  for (const e of events) {
+    const v = e.bridgeVersion ?? "<unknown>";
+    byVersion.set(v, (byVersion.get(v) ?? 0) + 1);
+  }
+  const versions = Array.from(byVersion.entries())
+    .map(([version, count]) => ({ version, count }))
+    .sort((a, b) => b.count - a.count);
+
+  // recent (last 20)
+  const recent = events.slice(-20).reverse().map((e) => ({
+    receivedAt: e.receivedAt,
+    bridgeVersion: e.bridgeVersion,
+    sessionDurationMs: e.sessionDurationMs,
+    toolCount: e.toolStats?.reduce((a, t) => a + t.calls, 0) ?? 0,
+    installSalt: e.installSalt ? `${e.installSalt.slice(0, 6)}…` : undefined,
+  }));
+
+  return { totalEvents, totalSessionMs, installs, tools, days, versions, recent };
+}
+
+export async function GET(req: Request) {
+  const url = new URL(req.url);
+  const daysParam = Number.parseInt(url.searchParams.get("days") ?? "7", 10);
+  const days = Math.min(Math.max(Number.isFinite(daysParam) ? daysParam : 7, 1), MAX_DAYS);
+  const dir = process.env.DASHBOARD_TELEMETRY_DIR ?? DEFAULT_DIR;
+
+  let directoryExists = true;
+  try {
+    const stat = await fs.stat(dir);
+    if (!stat.isDirectory()) directoryExists = false;
+  } catch {
+    directoryExists = false;
+  }
+
+  if (!directoryExists) {
+    return NextResponse.json(
+      {
+        directory: dir,
+        directoryExists: false,
+        message:
+          "Telemetry directory not found. Set DASHBOARD_TELEMETRY_DIR to the JSONL output dir of the analytics receiver (default /var/lib/analytics).",
+      },
+      { status: 200 },
+    );
+  }
+
+  const dayList = listDays(days);
+  const allEvents: Event[] = [];
+  for (const d of dayList) {
+    allEvents.push(...(await readDay(dir, d)));
+  }
+
+  const summary = aggregate(allEvents);
+  return NextResponse.json({
+    directory: dir,
+    directoryExists: true,
+    windowDays: days,
+    ...summary,
+  });
+}

--- a/dashboard/src/app/telemetry/loading.tsx
+++ b/dashboard/src/app/telemetry/loading.tsx
@@ -1,0 +1,3 @@
+export default function Loading() {
+  return <div style={{ padding: 24 }} aria-busy="true">Loading…</div>;
+}

--- a/dashboard/src/app/telemetry/page.tsx
+++ b/dashboard/src/app/telemetry/page.tsx
@@ -1,0 +1,266 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { apiPath } from "@/lib/api";
+import { StatCard } from "@/components/StatCard";
+import { EmptyState } from "@/components/patchwork";
+
+interface ToolRow {
+  tool: string;
+  calls: number;
+  errors: number;
+  p95Max: number;
+}
+
+interface RecentRow {
+  receivedAt: string;
+  bridgeVersion?: string;
+  sessionDurationMs?: number;
+  toolCount: number;
+  installSalt?: string;
+}
+
+interface TelemetryResponse {
+  directory: string;
+  directoryExists: boolean;
+  message?: string;
+  windowDays?: number;
+  totalEvents?: number;
+  totalSessionMs?: number;
+  installs?: number;
+  tools?: ToolRow[];
+  days?: { day: string; count: number }[];
+  versions?: { version: string; count: number }[];
+  recent?: RecentRow[];
+}
+
+const WINDOWS = [
+  { label: "7d", value: 7 },
+  { label: "30d", value: 30 },
+  { label: "90d", value: 90 },
+];
+
+function fmtMs(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`;
+  if (ms < 3_600_000) return `${(ms / 60_000).toFixed(1)}m`;
+  return `${(ms / 3_600_000).toFixed(1)}h`;
+}
+
+export default function TelemetryPage() {
+  const [days, setDays] = useState<number>(7);
+  const [data, setData] = useState<TelemetryResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    fetch(apiPath(`/api/telemetry?days=${days}`))
+      .then(async (r) => {
+        if (!r.ok) throw new Error(`HTTP ${r.status}`);
+        return r.json() as Promise<TelemetryResponse>;
+      })
+      .then((d) => {
+        if (!cancelled) setData(d);
+      })
+      .catch((e) => {
+        if (!cancelled) setError(e instanceof Error ? e.message : String(e));
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [days]);
+
+  const topVersion = useMemo(() => data?.versions?.[0]?.version ?? "—", [data]);
+
+  if (loading && !data) {
+    return <div style={{ padding: 24 }} aria-busy="true">Loading…</div>;
+  }
+  if (error) {
+    return (
+      <div style={{ padding: 24 }}>
+        <h1>Telemetry</h1>
+        <EmptyState title="Failed to load telemetry" description={error} />
+      </div>
+    );
+  }
+  if (!data) {
+    return null;
+  }
+  if (!data.directoryExists) {
+    return (
+      <div style={{ padding: 24 }}>
+        <h1>Telemetry</h1>
+        <EmptyState
+          title="Telemetry directory not found"
+          description={
+            <>
+              Looked for JSONL files in <code>{data.directory}</code>.
+              Set <code>DASHBOARD_TELEMETRY_DIR</code> to the receiver's output
+              directory (default <code>/var/lib/analytics</code>) and restart
+              the dashboard.
+            </>
+          }
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ padding: 24, display: "flex", flexDirection: "column", gap: 24 }}>
+      <header style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+        <div>
+          <h1 style={{ margin: 0 }}>Telemetry</h1>
+          <p style={{ margin: "4px 0 0", color: "var(--fg-2)", fontSize: 14 }}>
+            Self-hosted analytics receiver — events from opted-in bridge installs.
+            Reading from <code>{data.directory}</code>.
+          </p>
+        </div>
+        <div role="tablist" aria-label="Time window" style={{ display: "flex", gap: 4 }}>
+          {WINDOWS.map((w) => (
+            <button
+              type="button"
+              key={w.value}
+              role="tab"
+              aria-selected={w.value === days}
+              onClick={() => setDays(w.value)}
+              style={{
+                padding: "6px 12px",
+                borderRadius: 6,
+                border: "1px solid var(--border)",
+                background: w.value === days ? "var(--accent)" : "transparent",
+                color: w.value === days ? "var(--accent-fg)" : "var(--fg)",
+                cursor: "pointer",
+              }}
+            >
+              {w.label}
+            </button>
+          ))}
+        </div>
+      </header>
+
+      <section
+        style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))",
+          gap: 12,
+        }}
+      >
+        <StatCard label="Events" value={data.totalEvents ?? 0} foot={`window: ${data.windowDays}d`} />
+        <StatCard label="Unique installs" value={data.installs ?? 0} foot="dedup by install salt" />
+        <StatCard
+          label="Total session time"
+          value={fmtMs(data.totalSessionMs ?? 0)}
+          foot="sum of sessionDurationMs"
+        />
+        <StatCard label="Top version" value={topVersion} foot="most events" />
+      </section>
+
+      <section>
+        <h2 style={{ marginBottom: 8 }}>Tools (by total calls)</h2>
+        {(data.tools ?? []).length === 0 ? (
+          <EmptyState title="No tool calls in window" description="Either no installs are opted in or no sessions completed." />
+        ) : (
+          <div style={{ overflowX: "auto" }}>
+            <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 14 }}>
+              <thead>
+                <tr style={{ textAlign: "left", borderBottom: "1px solid var(--border)" }}>
+                  <th style={{ padding: 8 }}>Tool</th>
+                  <th style={{ padding: 8, textAlign: "right" }}>Calls</th>
+                  <th style={{ padding: 8, textAlign: "right" }}>Errors</th>
+                  <th style={{ padding: 8, textAlign: "right" }}>p95 (max)</th>
+                </tr>
+              </thead>
+              <tbody>
+                {(data.tools ?? []).map((t) => (
+                  <tr key={t.tool} style={{ borderBottom: "1px solid var(--border-subtle)" }}>
+                    <td style={{ padding: 8, fontFamily: "var(--font-mono)" }}>{t.tool}</td>
+                    <td style={{ padding: 8, textAlign: "right" }}>{t.calls.toLocaleString()}</td>
+                    <td
+                      style={{
+                        padding: 8,
+                        textAlign: "right",
+                        color: t.errors > 0 ? "var(--err)" : "var(--fg-2)",
+                      }}
+                    >
+                      {t.errors}
+                    </td>
+                    <td style={{ padding: 8, textAlign: "right" }}>{t.p95Max}ms</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+
+      <section style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 24 }}>
+        <div>
+          <h2 style={{ marginBottom: 8 }}>By version</h2>
+          <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 14 }}>
+            <tbody>
+              {(data.versions ?? []).map((v) => (
+                <tr key={v.version} style={{ borderBottom: "1px solid var(--border-subtle)" }}>
+                  <td style={{ padding: 6, fontFamily: "var(--font-mono)" }}>{v.version}</td>
+                  <td style={{ padding: 6, textAlign: "right" }}>{v.count}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+        <div>
+          <h2 style={{ marginBottom: 8 }}>By day</h2>
+          <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 14 }}>
+            <tbody>
+              {(data.days ?? []).map((d) => (
+                <tr key={d.day} style={{ borderBottom: "1px solid var(--border-subtle)" }}>
+                  <td style={{ padding: 6, fontFamily: "var(--font-mono)" }}>{d.day}</td>
+                  <td style={{ padding: 6, textAlign: "right" }}>{d.count}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section>
+        <h2 style={{ marginBottom: 8 }}>Recent (last 20)</h2>
+        {(data.recent ?? []).length === 0 ? (
+          <EmptyState title="No recent events" description="" />
+        ) : (
+          <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 13 }}>
+            <thead>
+              <tr style={{ textAlign: "left", borderBottom: "1px solid var(--border)" }}>
+                <th style={{ padding: 6 }}>Received (UTC date)</th>
+                <th style={{ padding: 6 }}>Version</th>
+                <th style={{ padding: 6, textAlign: "right" }}>Tool calls</th>
+                <th style={{ padding: 6, textAlign: "right" }}>Session</th>
+                <th style={{ padding: 6 }}>Install</th>
+              </tr>
+            </thead>
+            <tbody>
+              {(data.recent ?? []).map((r, i) => (
+                <tr key={`${r.receivedAt}-${i}`} style={{ borderBottom: "1px solid var(--border-subtle)" }}>
+                  <td style={{ padding: 6, fontFamily: "var(--font-mono)" }}>{r.receivedAt}</td>
+                  <td style={{ padding: 6, fontFamily: "var(--font-mono)" }}>{r.bridgeVersion ?? "—"}</td>
+                  <td style={{ padding: 6, textAlign: "right" }}>{r.toolCount}</td>
+                  <td style={{ padding: 6, textAlign: "right" }}>
+                    {typeof r.sessionDurationMs === "number" ? fmtMs(r.sessionDurationMs) : "—"}
+                  </td>
+                  <td style={{ padding: 6, fontFamily: "var(--font-mono)", color: "var(--fg-2)" }}>
+                    {r.installSalt ?? "—"}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/dashboard/src/lib/navRoutes.ts
+++ b/dashboard/src/lib/navRoutes.ts
@@ -118,6 +118,13 @@ export const NAV_SECTIONS: NavSection[] = [
         icon: "monitor",
       },
       { href: "/transactions", label: "Transactions", icon: "diff" },
+      {
+        href: "/telemetry",
+        label: "Telemetry",
+        paletteLabel: "Insights — Telemetry (admin)",
+        paletteHint: "self-hosted collector",
+        icon: "trending",
+      },
     ],
   },
   {


### PR DESCRIPTION
## Summary

New dashboard page at `/telemetry` that reads JSONL files from the self-hosted analytics receiver (the one introduced in #611/#612 wiring) and renders aggregated views:

- Totals: events, unique installs (deduped by install salt), total session time, top version
- Tools table: calls, errors, max p95 across the window
- By-version + by-day breakdowns
- Recent 20 events table

Time window selector: 7d / 30d / 90d.

## Auth

Gated by the dashboard's existing session auth (single-user `DASHBOARD_PASSWORD`). Effectively admin-only by construction — no new auth model added.

## New env

| Var | Effect |
|---|---|
| `DASHBOARD_TELEMETRY_DIR` | Path to JSONL files. Default `/var/lib/analytics`. |

## Honest scope

Only events written to the configured directory are visible. Today that means only installs that:
1. Opted in to telemetry, AND
2. Have `PATCHWORK_ANALYTICS_ENDPOINT` pointing at this VPS, AND
3. Send the matching `PATCHWORK_ANALYTICS_KEY`

I.e. for now, just my own laptop. A public/community collector (where any opted-in install in the wild lands here) would require dropping the shared secret, adding strong rate limiting + abuse protection, and a privacy policy. That's a real product call, not a tiny PR — explicitly out of scope.

## Test plan

- [x] `dashboard$ npx tsc --noEmit` → clean
- [x] `dashboard$ npx next build --no-lint` → clean
- [ ] Reviewer: deploy + visit `/telemetry`, verify empty-state when `/var/lib/analytics` doesn't exist
- [ ] Reviewer: with seeded JSONL, verify totals + sort order

🤖 Generated with [Claude Code](https://claude.com/claude-code)