### PR TITLE
chore(readme): star nudge + daily clone-traffic snapshot

### DIFF
--- a/.github/workflows/clone-snapshot.yml
+++ b/.github/workflows/clone-snapshot.yml
@@ -1,0 +1,30 @@
+name: Daily clone-traffic snapshot
+
+# Runs scripts/analyze-clones.mjs daily and posts the result to the run's
+# Job Summary. Read-only: never writes to the repo. Used to test the
+# "are most clones bots?" hypothesis.
+
+on:
+  schedule:
+    - cron: '17 8 * * *'   # 08:17 UTC daily — off-peak, avoids the GH cron stampede
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  snapshot:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Snapshot clone traffic
+        run: node scripts/analyze-clones.mjs
+        env:
+          # Needs push perms on the repo (that's what gates /traffic/).
+          # Use OOLAB_PAT (already used by other workflows) rather than
+          # GITHUB_TOKEN, which doesn't have traffic-API scope by default.
+          GH_TOKEN: ${{ secrets.OOLAB_PAT }}
+          GH_REPO: ${{ github.repository }}

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 
 ### Your personal AI runtime, local-first.
 
+> ⭐ If this saves you a config file or a debug session, drop a star — it's the only signal I get that it's helping.
+
 > Patchwork OS is a local-first personal AI runtime: pluggable model providers, hot-reloadable tools, YAML recipes, a delegation policy with approval queue, and a durable trace memory — all running on your machine, all under your policy.
 
 You decide which model. You decide which actions need a human nod. You own the credentials, the logs, and the deployment. Nothing phones home unless you [opt in to anonymous analytics](#telemetry).

--- a/scripts/analyze-clones.mjs
+++ b/scripts/analyze-clones.mjs
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+/**
+ * Snapshot the bot-vs-human clone hypothesis using GitHub's free traffic APIs.
+ *
+ * Compares total clones to unique cloners — a low unique/total ratio
+ * (typically <0.15) suggests bot/CI/mirror traffic dominates. Cross-references
+ * with the page-view referrer list to see where actual humans came from.
+ *
+ * Outputs GitHub Actions job-summary markdown when GITHUB_STEP_SUMMARY is set,
+ * otherwise prints to stdout. Read-only — never writes back to the repo.
+ *
+ * Env:
+ *   GH_REPO   — owner/repo (default Oolab-labs/patchwork-os)
+ *   GH_TOKEN  — PAT with repo:read; required (the traffic API gates on push perms)
+ */
+import { appendFile } from "node:fs/promises";
+
+const REPO = process.env.GH_REPO ?? "Oolab-labs/patchwork-os";
+const TOKEN = process.env.GH_TOKEN;
+if (!TOKEN) {
+  console.error(
+    "GH_TOKEN required (needs push perms — that's what gates /traffic/)",
+  );
+  process.exit(2);
+}
+
+async function gh(path) {
+  const res = await fetch(`https://api.github.com${path}`, {
+    headers: {
+      Authorization: `Bearer ${TOKEN}`,
+      Accept: "application/vnd.github+json",
+      "X-GitHub-Api-Version": "2022-11-28",
+      "User-Agent": "patchwork-analyze-clones",
+    },
+  });
+  if (!res.ok)
+    throw new Error(`${path}: HTTP ${res.status} ${await res.text()}`);
+  return res.json();
+}
+
+const [clones, views, referrers] = await Promise.all([
+  gh(`/repos/${REPO}/traffic/clones`),
+  gh(`/repos/${REPO}/traffic/views`),
+  gh(`/repos/${REPO}/traffic/popular/referrers`),
+]);
+
+const totalClones = clones.count;
+const uniqueCloners = clones.uniques;
+const totalViews = views.count;
+const uniqueViewers = views.uniques;
+const ratio = totalClones > 0 ? uniqueCloners / totalClones : 0;
+
+const verdict =
+  totalClones === 0
+    ? "no data"
+    : ratio < 0.15
+      ? "**likely bot-dominated** (low unique/total ratio)"
+      : ratio < 0.4
+        ? "mixed bots + humans"
+        : "**likely human-dominated**";
+
+const lines = [];
+lines.push(`# Clone-traffic snapshot — ${REPO}`);
+lines.push("");
+lines.push(
+  `_Generated ${new Date().toISOString()}. GitHub /traffic API returns the last 14 days._`,
+);
+lines.push("");
+lines.push("| Metric | Value |");
+lines.push("|---|---|");
+lines.push(`| Total clones (14d) | ${totalClones} |`);
+lines.push(`| Unique cloners (14d) | ${uniqueCloners} |`);
+lines.push(`| unique / total | ${(ratio * 100).toFixed(1)}% — ${verdict} |`);
+lines.push(`| Total page views (14d) | ${totalViews} |`);
+lines.push(`| Unique viewers (14d) | ${uniqueViewers} |`);
+lines.push("");
+lines.push("## Top page-view referrers");
+lines.push("");
+if (referrers.length === 0) {
+  lines.push("_no referrers in window_");
+} else {
+  lines.push("| Referrer | Views | Unique |");
+  lines.push("|---|---|---|");
+  for (const r of referrers) {
+    lines.push(`| ${r.referrer} | ${r.count} | ${r.uniques} |`);
+  }
+}
+lines.push("");
+lines.push("## How to read this");
+lines.push("");
+lines.push(
+  "- **Unique cloners** counts distinct IPs cloning over 14d. Repeated CI / mirror crawlers from a tight IP range count as 1.",
+);
+lines.push(
+  "- A low **unique / total** ratio (<15%) usually means a handful of automated cloners are inflating the headline count.",
+);
+lines.push(
+  "- **Referrers** are for page views only — GitHub doesn't expose referrer on raw `git clone`. A low referrer-to-clone ratio is another bot signal.",
+);
+lines.push("");
+
+const out = lines.join("\n") + "\n";
+if (process.env.GITHUB_STEP_SUMMARY) {
+  await appendFile(process.env.GITHUB_STEP_SUMMARY, out);
+}
+process.stdout.write(out);


### PR DESCRIPTION
## Summary

Two small bundled changes, same goal — replace guesswork about real adoption with cheap signal:

### 1. README star nudge (1 line)

Adds one line under the hero, framed as feedback rather than an ask:

> ⭐ If this saves you a config file or a debug session, drop a star — it's the only signal I get that it's helping.

### 2. Daily clone-traffic snapshot

- `scripts/analyze-clones.mjs` pulls GitHub's `/traffic/clones`, `/traffic/views`, and `/traffic/popular/referrers`, computes the **unique-cloner / total-clones** ratio (low ratio ≈ bot/CI/mirror dominance), and emits Job-Summary markdown.
- `.github/workflows/clone-snapshot.yml` runs it daily at 08:17 UTC.
- Result lands on the Actions run page as a summary table — no commits, no external services.

## Why

GitHub already shows the clone counts in Insights → Traffic but doesn't surface the ratio or the bot-vs-human read. This makes the question answerable on a regular cadence. If the data shows the headline number is mostly bots, the star nudge has to do more work; if there's genuine human traffic, the nudge has real surface area.

## Out of scope (rejected alternatives)

- **Hosted `curl | sh` install endpoint** for referrer logging: bad security pattern, biases the sample, and Part A should answer the question first.
- **Per-install phone-home**: already covered by the opt-in telemetry from #611/#612 — different signal (installed AND running AND opted-in), not what we want here.

## Test plan

- [x] `node --check scripts/analyze-clones.mjs` clean
- [x] YAML lint clean
- [x] Script exits non-zero when GH_TOKEN is missing
- [ ] After merge: trigger workflow via `workflow_dispatch`, verify Job Summary renders with real data
- [ ] After merge: confirm `OOLAB_PAT` secret has traffic-API access (it should — already used by other workflows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)