### PR TITLE
fix(settings): decouple local-endpoint persistence from model + flag restart

### DIFF
--- a/src/__tests__/server-settings.test.ts
+++ b/src/__tests__/server-settings.test.ts
@@ -527,6 +527,62 @@ describe("POST /settings — push/ntfy persistence", () => {
     expect(persisted.ntfyServer).toBe("https://ntfy.example.com");
   });
 
+  it("flags restartRequired when localEndpoint changes without model", async () => {
+    const { status, body } = await makeRequest(
+      {
+        method: "POST",
+        path: "/settings",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${TOKEN}`,
+        },
+      },
+      JSON.stringify({ localEndpoint: "http://localhost:8080" }),
+    );
+    expect(status).toBe(200);
+    expect(JSON.parse(body)).toMatchObject({ restartRequired: true });
+  });
+
+  it("persists localEndpoint without requiring model in the same POST", async () => {
+    const pw = await import("../patchworkConfig.js");
+    const saveSpy = vi.mocked(pw.saveConfig);
+    saveSpy.mockClear();
+
+    const { status } = await makeRequest(
+      {
+        method: "POST",
+        path: "/settings",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${TOKEN}`,
+        },
+      },
+      JSON.stringify({ localEndpoint: "http://localhost:9090" }),
+    );
+    expect(status).toBe(200);
+    const persisted = saveSpy.mock.calls[0]![0] as unknown as Record<
+      string,
+      unknown
+    >;
+    expect(persisted.localEndpoint).toBe("http://localhost:9090");
+  });
+
+  it("does NOT flag restartRequired for pure push/ntfy edits (live-mutated)", async () => {
+    const { status, body } = await makeRequest(
+      {
+        method: "POST",
+        path: "/settings",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${TOKEN}`,
+        },
+      },
+      JSON.stringify({ ntfyTopic: "patchwork-test" }),
+    );
+    expect(status).toBe(200);
+    expect(JSON.parse(body)).toMatchObject({ restartRequired: false });
+  });
+
   it("persists pushServiceBaseUrl to patchwork config", async () => {
     const pw = await import("../patchworkConfig.js");
     const saveSpy = vi.mocked(pw.saveConfig);

--- a/src/server.ts
+++ b/src/server.ts
@@ -1736,12 +1736,18 @@ export class Server extends EventEmitter<ServerEvents> {
             }
             if (body.model !== undefined) {
               cfg.model = body.model as PatchworkConfig["model"];
-              if (body.model === "local") {
-                if (body.localEndpoint !== undefined)
-                  cfg.localEndpoint = body.localEndpoint.trim() || undefined;
-                if (body.localModel !== undefined)
-                  cfg.localModel = body.localModel.trim() || undefined;
-              }
+            }
+            // localEndpoint / localModel persist regardless of whether
+            // `model` is sent. Previously they were silently dropped when
+            // the dashboard updated only the endpoint of an already-local
+            // install, which left the running driver pointed at the old
+            // host until the user happened to re-pick "Local LLM" in the
+            // UI.
+            if (body.localEndpoint !== undefined) {
+              cfg.localEndpoint = body.localEndpoint.trim() || undefined;
+            }
+            if (body.localModel !== undefined) {
+              cfg.localModel = body.localModel.trim() || undefined;
             }
             // Push / ntfy fields used to be set only on `this.*` and were
             // lost on bridge restart. Persist alongside the rest.
@@ -1844,10 +1850,17 @@ export class Server extends EventEmitter<ServerEvents> {
               this.ntfyServer = ntfyServerTrimmed || undefined;
             }
 
+            // restartRequired covers fields the bridge only reads at boot:
+            // driver/model/apiKey (env injection + driver factory), plus
+            // localEndpoint/localModel which LocalApiDriver reads at
+            // construction time. Push/ntfy fields are live-mutated on
+            // `this.*` in PHASE 4 below, so they do not require restart.
             const restartRequired =
               driverRaw !== undefined ||
               body.apiKey !== undefined ||
-              body.model !== undefined;
+              body.model !== undefined ||
+              body.localEndpoint !== undefined ||
+              body.localModel !== undefined;
             res.writeHead(200, { "Content-Type": "application/json" });
             res.end(JSON.stringify({ ok: true, restartRequired }));
           }


### PR DESCRIPTION
## Summary
- `localEndpoint` / `localModel` were silently dropped when sent without `model` → dashboard endpoint edits no-op'd after first save.
- `restartRequired` now correctly flags localEndpoint/localModel changes (read at boot only).
- Asserts push/ntfy do NOT require restart (live-mutated on `this.*`).

## PR Stack
- Base: #621 (push/ntfy persistence)
- Stacks on: #620 → #621 → this

## Test plan
- [x] 3 new tests in server-settings.test.ts (22/22 pass)
- [x] typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)