### PR TITLE
fix(telemetry-prefs): reject non-boolean values instead of silently dropping

### DIFF
--- a/src/__tests__/httpBodyValidation-strict-keys.test.ts
+++ b/src/__tests__/httpBodyValidation-strict-keys.test.ts
@@ -171,6 +171,30 @@ describe("strict body-key validation — HTTP endpoints", () => {
     expect(parsed.unknownKeys).toContain("enabledZ");
   });
 
+  it("POST /telemetry-prefs rejects non-boolean known key (string 'true')", async () => {
+    const res = await request(
+      { method: "POST", path: "/telemetry-prefs", headers: authHeaders() },
+      JSON.stringify({ crashReports: "true" }),
+    );
+    expect(res.status).toBe(400);
+    const parsed = JSON.parse(res.body) as {
+      error: string;
+      reason: string;
+    };
+    expect(parsed.error).toBe("invalid_request");
+    expect(parsed.reason).toContain("crashReports");
+  });
+
+  it("POST /telemetry-prefs rejects numeric value for known key", async () => {
+    const res = await request(
+      { method: "POST", path: "/telemetry-prefs", headers: authHeaders() },
+      JSON.stringify({ usageStats: 1 }),
+    );
+    expect(res.status).toBe(400);
+    const parsed = JSON.parse(res.body) as { reason: string };
+    expect(parsed.reason).toContain("usageStats");
+  });
+
   it("POST /kill-switch rejects unknown key `bogus`", async () => {
     const res = await request(
       { method: "POST", path: "/kill-switch", headers: authHeaders() },

--- a/src/__tests__/server-settings.test.ts
+++ b/src/__tests__/server-settings.test.ts
@@ -527,6 +527,62 @@ describe("POST /settings — push/ntfy persistence", () => {
     expect(persisted.ntfyServer).toBe("https://ntfy.example.com");
   });
 
+  it("flags restartRequired when localEndpoint changes without model", async () => {
+    const { status, body } = await makeRequest(
+      {
+        method: "POST",
+        path: "/settings",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${TOKEN}`,
+        },
+      },
+      JSON.stringify({ localEndpoint: "http://localhost:8080" }),
+    );
+    expect(status).toBe(200);
+    expect(JSON.parse(body)).toMatchObject({ restartRequired: true });
+  });
+
+  it("persists localEndpoint without requiring model in the same POST", async () => {
+    const pw = await import("../patchworkConfig.js");
+    const saveSpy = vi.mocked(pw.saveConfig);
+    saveSpy.mockClear();
+
+    const { status } = await makeRequest(
+      {
+        method: "POST",
+        path: "/settings",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${TOKEN}`,
+        },
+      },
+      JSON.stringify({ localEndpoint: "http://localhost:9090" }),
+    );
+    expect(status).toBe(200);
+    const persisted = saveSpy.mock.calls[0]![0] as unknown as Record<
+      string,
+      unknown
+    >;
+    expect(persisted.localEndpoint).toBe("http://localhost:9090");
+  });
+
+  it("does NOT flag restartRequired for pure push/ntfy edits (live-mutated)", async () => {
+    const { status, body } = await makeRequest(
+      {
+        method: "POST",
+        path: "/settings",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${TOKEN}`,
+        },
+      },
+      JSON.stringify({ ntfyTopic: "patchwork-test" }),
+    );
+    expect(status).toBe(200);
+    expect(JSON.parse(body)).toMatchObject({ restartRequired: false });
+  });
+
   it("persists pushServiceBaseUrl to patchwork config", async () => {
     const pw = await import("../patchworkConfig.js");
     const saveSpy = vi.mocked(pw.saveConfig);

--- a/src/server.ts
+++ b/src/server.ts
@@ -2071,6 +2071,27 @@ export class Server extends EventEmitter<ServerEvents> {
             usageStats?: boolean;
             localDiagnostics?: boolean;
           } = {};
+          // Reject non-boolean values for known keys instead of silently
+          // dropping them. Previously `{"crashReports": "true"}` (string)
+          // got a 200 with no effect — caller never learned the toggle
+          // did nothing. Misrepresented consent is the worst-case
+          // outcome on the telemetry surface, so be strict here.
+          for (const key of [
+            "crashReports",
+            "usageStats",
+            "localDiagnostics",
+          ] as const) {
+            if (body[key] !== undefined && typeof body[key] !== "boolean") {
+              res.writeHead(400, { "Content-Type": "application/json" });
+              res.end(
+                JSON.stringify({
+                  error: "invalid_request",
+                  reason: `${key} must be a boolean`,
+                }),
+              );
+              return;
+            }
+          }
           if (typeof body.crashReports === "boolean") {
             update.crashReports = body.crashReports;
           }

--- a/src/server.ts
+++ b/src/server.ts
@@ -1736,12 +1736,18 @@ export class Server extends EventEmitter<ServerEvents> {
             }
             if (body.model !== undefined) {
               cfg.model = body.model as PatchworkConfig["model"];
-              if (body.model === "local") {
-                if (body.localEndpoint !== undefined)
-                  cfg.localEndpoint = body.localEndpoint.trim() || undefined;
-                if (body.localModel !== undefined)
-                  cfg.localModel = body.localModel.trim() || undefined;
-              }
+            }
+            // localEndpoint / localModel persist regardless of whether
+            // `model` is sent. Previously they were silently dropped when
+            // the dashboard updated only the endpoint of an already-local
+            // install, which left the running driver pointed at the old
+            // host until the user happened to re-pick "Local LLM" in the
+            // UI.
+            if (body.localEndpoint !== undefined) {
+              cfg.localEndpoint = body.localEndpoint.trim() || undefined;
+            }
+            if (body.localModel !== undefined) {
+              cfg.localModel = body.localModel.trim() || undefined;
             }
             // Push / ntfy fields used to be set only on `this.*` and were
             // lost on bridge restart. Persist alongside the rest.
@@ -1844,10 +1850,17 @@ export class Server extends EventEmitter<ServerEvents> {
               this.ntfyServer = ntfyServerTrimmed || undefined;
             }
 
+            // restartRequired covers fields the bridge only reads at boot:
+            // driver/model/apiKey (env injection + driver factory), plus
+            // localEndpoint/localModel which LocalApiDriver reads at
+            // construction time. Push/ntfy fields are live-mutated on
+            // `this.*` in PHASE 4 below, so they do not require restart.
             const restartRequired =
               driverRaw !== undefined ||
               body.apiKey !== undefined ||
-              body.model !== undefined;
+              body.model !== undefined ||
+              body.localEndpoint !== undefined ||
+              body.localModel !== undefined;
             res.writeHead(200, { "Content-Type": "application/json" });
             res.end(JSON.stringify({ ok: true, restartRequired }));
           }


### PR DESCRIPTION
## Summary
- `/telemetry-prefs` POST silently ignored non-boolean values for known keys (e.g. string \"true\", numeric 1) — returned 200 with no effect.
- Now returns 400 with a specific reason naming the offending key.

## Why
Misrepresented consent. A caller toggling a privacy preference deserves to know if their request was a no-op. The previous behavior made it impossible to debug \"why isn't my telemetry pref sticking?\" client-side.

## PR Stack
- Base: #622 (restart-required + local-endpoint persistence)
- Stacks on: #620 → #621 → #622 → this

## Test plan
- [x] 2 new tests in httpBodyValidation-strict-keys.test.ts (15/15 pass)
- [x] typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)