### PR TITLE
fix(settings): outer catch returns 500, not 400

### DIFF
--- a/src/__tests__/server-settings.test.ts
+++ b/src/__tests__/server-settings.test.ts
@@ -583,6 +583,34 @@ describe("POST /settings — push/ntfy persistence", () => {
     expect(JSON.parse(body)).toMatchObject({ restartRequired: false });
   });
 
+  it("returns 500 (not 400) when an unexpected error escapes the handler", async () => {
+    // loadConfig is the first thing PHASE 2 calls. Make it throw to
+    // simulate any non-validation error — disk corruption, schema parse
+    // crash, etc. The outer catch should classify this as a server
+    // error, not "Invalid request body".
+    const pw = await import("../patchworkConfig.js");
+    const loadSpy = vi.mocked(pw.loadConfig);
+    loadSpy.mockImplementationOnce(() => {
+      throw new Error("boom — simulated disk corruption");
+    });
+
+    const { status, body } = await makeRequest(
+      {
+        method: "POST",
+        path: "/settings",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${TOKEN}`,
+        },
+      },
+      JSON.stringify({ approvalGate: "all" }),
+    );
+
+    expect(status).toBe(500);
+    const parsed = JSON.parse(body) as { error: string };
+    expect(parsed.error).not.toContain("Invalid request body");
+  });
+
   it("persists pushServiceBaseUrl to patchwork config", async () => {
     const pw = await import("../patchworkConfig.js");
     const saveSpy = vi.mocked(pw.saveConfig);

--- a/src/server.ts
+++ b/src/server.ts
@@ -1865,11 +1865,17 @@ export class Server extends EventEmitter<ServerEvents> {
             res.end(JSON.stringify({ ok: true, restartRequired }));
           }
         } catch (err) {
+          // Any error reaching this outer catch is unexpected — all caller
+          // validation errors already returned their own 400 inline, and all
+          // expected disk-write errors return their own 500. So this is a
+          // server bug, not a client one. Returning 400 here misled clients
+          // into believing they had sent a bad body when in fact something
+          // crashed serverside.
           this.logger.error(
-            `[/config/patchwork] error: ${err instanceof Error ? (err.stack ?? err.message) : String(err)}`,
+            `[/config/patchwork] unhandled error: ${err instanceof Error ? (err.stack ?? err.message) : String(err)}`,
           );
-          res.writeHead(400, { "Content-Type": "application/json" });
-          res.end(JSON.stringify({ error: "Invalid request body" }));
+          res.writeHead(500, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ error: "Internal server error" }));
         }
         return;
       }


### PR DESCRIPTION
## Summary
- Unexpected serverside errors in /settings were misclassified as 400 \"Invalid request body\", misleading clients.
- Now returns 500 \"Internal server error\" with full stack in bridge log.

## PR Stack
- Base: #623
- Stacks on: #620 → #621 → #622 → #623 → this

## Test plan
- [x] New test stubs loadConfig to throw, asserts 500 + body not containing \"Invalid request body\"
- [x] 23/23 server-settings tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)