### PR TITLE
fix(settings): validate localEndpoint URL + SSRF at the HTTP boundary

### DIFF
--- a/src/__tests__/server-settings.test.ts
+++ b/src/__tests__/server-settings.test.ts
@@ -611,6 +611,73 @@ describe("POST /settings — push/ntfy persistence", () => {
     expect(parsed.error).not.toContain("Invalid request body");
   });
 
+  it("rejects file:// scheme on localEndpoint", async () => {
+    const { status } = await makeRequest(
+      {
+        method: "POST",
+        path: "/settings",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${TOKEN}`,
+        },
+      },
+      JSON.stringify({ localEndpoint: "file:///etc/passwd" }),
+    );
+    expect(status).toBe(400);
+  });
+
+  it("rejects garbage / unparseable localEndpoint", async () => {
+    const { status } = await makeRequest(
+      {
+        method: "POST",
+        path: "/settings",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${TOKEN}`,
+        },
+      },
+      JSON.stringify({ localEndpoint: "not a url" }),
+    );
+    expect(status).toBe(400);
+  });
+
+  it("rejects public-IP localEndpoint without LOCAL_ENDPOINT_ALLOW_REMOTE", async () => {
+    const prev = process.env.LOCAL_ENDPOINT_ALLOW_REMOTE;
+    delete process.env.LOCAL_ENDPOINT_ALLOW_REMOTE;
+    try {
+      const { status, body } = await makeRequest(
+        {
+          method: "POST",
+          path: "/settings",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${TOKEN}`,
+          },
+        },
+        JSON.stringify({ localEndpoint: "http://8.8.8.8/v1" }),
+      );
+      expect(status).toBe(400);
+      expect(body).toContain("loopback or private");
+    } finally {
+      if (prev !== undefined) process.env.LOCAL_ENDPOINT_ALLOW_REMOTE = prev;
+    }
+  });
+
+  it("accepts loopback localEndpoint", async () => {
+    const { status } = await makeRequest(
+      {
+        method: "POST",
+        path: "/settings",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${TOKEN}`,
+        },
+      },
+      JSON.stringify({ localEndpoint: "http://localhost:11434/v1" }),
+    );
+    expect(status).toBe(200);
+  });
+
   it("persists pushServiceBaseUrl to patchwork config", async () => {
     const pw = await import("../patchworkConfig.js");
     const saveSpy = vi.mocked(pw.saveConfig);

--- a/src/server.ts
+++ b/src/server.ts
@@ -18,6 +18,7 @@ import {
 } from "./connectorRoutes.js";
 import { timingSafeStringEqual } from "./crypto.js";
 import { renderDashboardHtml } from "./dashboard.js";
+import { isLoopbackOrPrivateEndpoint } from "./drivers/local/index.js";
 import {
   EnvLockedFlagError,
   getEnvLockedValue,
@@ -1710,6 +1711,48 @@ export class Server extends EventEmitter<ServerEvents> {
             ) {
               respond400("ntfyServer must be HTTPS");
               return;
+            }
+
+            // localEndpoint — used by LocalApiDriver as the inference base
+            // URL. Must parse as http(s)://, be ≤2048 chars, and resolve to
+            // a loopback or private address. Otherwise prompts + context
+            // would stream to a public / metadata / file:// host. Same gate
+            // the driver enforces at construction, raised to the HTTP
+            // boundary so the bad value never reaches disk. Operator can
+            // opt out via LOCAL_ENDPOINT_ALLOW_REMOTE=1 for audited
+            // internal inference clusters.
+            const localEndpointTrimmed =
+              body.localEndpoint !== undefined
+                ? body.localEndpoint.trim()
+                : undefined;
+            if (
+              localEndpointTrimmed !== undefined &&
+              localEndpointTrimmed !== ""
+            ) {
+              if (localEndpointTrimmed.length > 2048) {
+                respond400("localEndpoint must be ≤2048 characters");
+                return;
+              }
+              let parsed: URL;
+              try {
+                parsed = new URL(localEndpointTrimmed);
+              } catch {
+                respond400("localEndpoint must be a valid http(s):// URL");
+                return;
+              }
+              if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+                respond400("localEndpoint must use http:// or https:// scheme");
+                return;
+              }
+              if (
+                process.env.LOCAL_ENDPOINT_ALLOW_REMOTE !== "1" &&
+                !isLoopbackOrPrivateEndpoint(localEndpointTrimmed)
+              ) {
+                respond400(
+                  "localEndpoint must be loopback or private (set LOCAL_ENDPOINT_ALLOW_REMOTE=1 to override)",
+                );
+                return;
+              }
             }
 
             // PHASE 2 — load config and apply all in-memory edits to `cfg`.


### PR DESCRIPTION
## Summary
- \`localEndpoint\` was accepted as any non-empty string and persisted directly. The driver-side guard fired only at next restart.
- Now validates at the HTTP boundary: length cap, \`new URL()\` parse, http(s):// scheme, loopback/private host (or LOCAL_ENDPOINT_ALLOW_REMOTE=1).

## Why
\`file:///etc/passwd\`, \`http://8.8.8.8/v1\`, or unparseable strings used to write to disk and crash LocalApiDriver on every subsequent boot.

## PR Stack
- Base: #624
- Stacks on: #620 → #621 → #622 → #623 → #624 → this

## Test plan
- [x] 4 new tests, 27/27 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)