### PR TITLE
feat(settings): emit settings.change audit event on every config write

### DIFF
--- a/src/__tests__/server-settings.test.ts
+++ b/src/__tests__/server-settings.test.ts
@@ -463,6 +463,111 @@ describe("POST /settings — validate-before-write", () => {
   });
 });
 
+describe("POST /settings — audit-log emission", () => {
+  it("emits settings.change with fields list", async () => {
+    const { ActivityLog } = await import("../activityLog.js");
+    const log = new ActivityLog();
+    server!.activityLog = log;
+    const events: Array<{
+      event: string;
+      metadata?: Record<string, unknown>;
+    }> = [];
+    log.subscribe((_kind, entry) => {
+      if ("event" in entry) {
+        events.push({
+          event: entry.event,
+          metadata: entry.metadata,
+        });
+      }
+    });
+
+    const { status } = await makeRequest(
+      {
+        method: "POST",
+        path: "/settings",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${TOKEN}`,
+        },
+      },
+      JSON.stringify({ approvalGate: "all", enableTimeOfDayAnomaly: true }),
+    );
+    expect(status).toBe(200);
+    const change = events.find((e) => e.event === "settings.change");
+    expect(change).toBeDefined();
+    const fields = change!.metadata?.fields as string[];
+    expect(fields).toContain("approvalGate");
+    expect(fields).toContain("enableTimeOfDayAnomaly");
+  });
+
+  it("redacts apiKey, pushServiceToken, and ntfyTopic in the audit entry", async () => {
+    const { ActivityLog } = await import("../activityLog.js");
+    const log = new ActivityLog();
+    server!.activityLog = log;
+    const events: Array<Record<string, unknown>> = [];
+    log.subscribe((_kind, entry) => {
+      if ("metadata" in entry && entry.metadata) {
+        events.push(entry.metadata as Record<string, unknown>);
+      }
+    });
+
+    await makeRequest(
+      {
+        method: "POST",
+        path: "/settings",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${TOKEN}`,
+        },
+      },
+      JSON.stringify({
+        apiKey: { provider: "openai", key: "sk-supersecret" },
+        pushServiceToken: "tok-supersecret",
+        ntfyTopic: "patchwork-secret-topic-abc",
+      }),
+    );
+
+    const last = events.at(-1)!;
+    const changes = last.changes as Record<string, unknown>;
+    expect(JSON.stringify(changes)).not.toContain("sk-supersecret");
+    expect(JSON.stringify(changes)).not.toContain("tok-supersecret");
+    expect(JSON.stringify(changes)).not.toContain("patchwork-secret-topic-abc");
+    expect((changes.apiKey as { key: string }).key).toBe("***");
+    expect(changes.pushServiceToken).toBe("***");
+    expect(changes.ntfyTopic).toBe("***");
+  });
+
+  it("does not emit when kill-switch blocks the write", async () => {
+    const { ActivityLog } = await import("../activityLog.js");
+    const log = new ActivityLog();
+    server!.activityLog = log;
+    const events: string[] = [];
+    log.subscribe((_kind, entry) => {
+      if ("event" in entry) events.push(entry.event);
+    });
+
+    const flags = await import("../featureFlags.js");
+    const { setFlag, KILL_SWITCH_WRITES } = flags;
+    setFlag(KILL_SWITCH_WRITES, true);
+    try {
+      await makeRequest(
+        {
+          method: "POST",
+          path: "/settings",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${TOKEN}`,
+          },
+        },
+        JSON.stringify({ driver: "gemini" }),
+      );
+      expect(events).not.toContain("settings.change");
+    } finally {
+      setFlag(KILL_SWITCH_WRITES, false);
+    }
+  });
+});
+
 describe("POST /settings — kill-switch gate", () => {
   // Regression: engaging the kill-switch must block config mutations,
   // not just tool dispatch. Otherwise a panicked operator who engages

--- a/src/server.ts
+++ b/src/server.ts
@@ -1922,6 +1922,51 @@ export class Server extends EventEmitter<ServerEvents> {
               body.model !== undefined ||
               body.localEndpoint !== undefined ||
               body.localModel !== undefined;
+
+            // Audit-log emission — forensic record of every config mutation
+            // so an operator can answer "who changed what, when?" after an
+            // incident. Bearer-token auth doesn't carry an actor identity
+            // (no user JWT) so we attribute to "http" with the request IP.
+            // Secrets are redacted to the shape `"***"` — value presence
+            // is recorded, value content is never logged.
+            if (this.activityLog) {
+              const changes: Record<string, unknown> = {};
+              if (hasWebhookUpdate) changes.webhookUrl = webhookRaw || "";
+              if (gateRaw !== undefined) changes.approvalGate = gateRaw;
+              if (body.enableTimeOfDayAnomaly !== undefined)
+                changes.enableTimeOfDayAnomaly = body.enableTimeOfDayAnomaly;
+              if (driverRaw !== undefined) changes.driver = driverRaw;
+              if (body.model !== undefined) changes.model = body.model;
+              if (body.localEndpoint !== undefined)
+                changes.localEndpoint = body.localEndpoint;
+              if (body.localModel !== undefined)
+                changes.localModel = body.localModel;
+              if (body.apiKey)
+                changes.apiKey = { provider: body.apiKey.provider, key: "***" };
+              if (pushUrlTrimmed !== undefined)
+                changes.pushServiceUrl = pushUrlTrimmed || "";
+              if (body.pushServiceToken !== undefined)
+                changes.pushServiceToken = body.pushServiceToken ? "***" : "";
+              if (pushBaseTrimmed !== undefined)
+                changes.pushServiceBaseUrl = pushBaseTrimmed || "";
+              if (ntfyTopicTrimmed !== undefined)
+                changes.ntfyTopic = ntfyTopicTrimmed ? "***" : "";
+              if (ntfyServerTrimmed !== undefined)
+                changes.ntfyServer = ntfyServerTrimmed || "";
+              const remoteAddr =
+                (req.headers["x-forwarded-for"] as string | undefined)
+                  ?.split(",")[0]
+                  ?.trim() ||
+                req.socket.remoteAddress ||
+                "unknown";
+              this.activityLog.recordEvent("settings.change", {
+                actor: "http",
+                ip: remoteAddr,
+                fields: Object.keys(changes),
+                changes,
+              });
+            }
+
             res.writeHead(200, { "Content-Type": "application/json" });
             res.end(JSON.stringify({ ok: true, restartRequired }));
           }


### PR DESCRIPTION
## Summary
- Every /settings POST that reaches PHASE 4 records a \`settings.change\` lifecycle event with actor, IP, mutated fields, and per-field values (secrets redacted to \`\"***\"\`).
- Kill-switch-blocked requests do NOT emit.

## PR Stack
- Base: #626
- Stacks on: #620 → … → #626 → this

## Test plan
- [x] 3 new tests, 33/33 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)