### PR TITLE
fix(dashboard): surface VAPID rotation in push test results

### DIFF
--- a/dashboard/src/app/api/push/test/route.ts
+++ b/dashboard/src/app/api/push/test/route.ts
@@ -35,5 +35,20 @@ export async function POST(req: Request) {
   );
 
   const sent = results.filter((r) => r.status === "fulfilled").length;
-  return NextResponse.json({ ok: true, sent, total: subs.length });
+  // 404 / 410 = subscription is gone (browser unsubscribed, VAPID
+  // rotated, push service evicted). Count separately so the UI can
+  // distinguish a legitimate "nobody subscribed" failure from "all
+  // subs are stale" — when invalid === total, the most likely cause
+  // is a VAPID-key change since the existing subs were created.
+  const invalid = results.filter((r) => {
+    if (r.status !== "rejected") return false;
+    const err = r.reason as { statusCode?: number } | null;
+    return err?.statusCode === 404 || err?.statusCode === 410;
+  }).length;
+  return NextResponse.json({
+    ok: true,
+    sent,
+    total: subs.length,
+    invalid,
+  });
 }

--- a/dashboard/src/app/settings/page.tsx
+++ b/dashboard/src/app/settings/page.tsx
@@ -751,13 +751,33 @@ export default function SettingsPage() {
         ok?: boolean;
         sent?: number;
         total?: number;
+        invalid?: number;
         error?: string;
       };
       if (res.ok) {
-        setPushMsg({
-          ok: true,
-          text: `Sent ${body.sent ?? 0} of ${body.total ?? 0} subscribers.`,
-        });
+        const sent = body.sent ?? 0;
+        const total = body.total ?? 0;
+        const invalid = body.invalid ?? 0;
+        // All subs returned 404/410 → most likely VAPID key rotated
+        // since the existing subs were created. Surface explicitly so
+        // the user knows what to do (re-subscribe everyone) instead of
+        // staring at "Sent 0 of N" forever.
+        if (invalid > 0 && invalid === total && sent === 0) {
+          setPushMsg({
+            ok: false,
+            text: `Sent 0 of ${total} — every subscription returned 410/404. Likely VAPID key changed since subscribing; have devices re-subscribe.`,
+          });
+        } else if (invalid > 0) {
+          setPushMsg({
+            ok: true,
+            text: `Sent ${sent} of ${total} subscribers (${invalid} stale, pruning recommended).`,
+          });
+        } else {
+          setPushMsg({
+            ok: true,
+            text: `Sent ${sent} of ${total} subscribers.`,
+          });
+        }
       } else {
         setPushMsg({
           ok: false,


### PR DESCRIPTION
## Summary
- Classify 410/404 results from \`webpush.sendNotification\` as \`invalid\` server-side.
- Client distinguishes three states: all-stale (likely VAPID rotation), partial-stale (pruning hint), and clean.

## Why
Audit P2: \"Sent 0 of N\" success-style message hid a real config problem after VAPID rotation. Users had no signal pointing at the root cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)