### PR TITLE
fix(settings): cancel pending approvals when gate downgrades to off

### DIFF
--- a/src/__tests__/approvalQueue.test.ts
+++ b/src/__tests__/approvalQueue.test.ts
@@ -215,6 +215,25 @@ describe("ApprovalQueue — cancellation", () => {
     expect(q.cancel("not-a-real-id")).toBe(false);
   });
 
+  it("cancelAll resolves every pending promise with 'cancelled' and returns the count", async () => {
+    const q = new ApprovalQueue();
+    const a = q.request({ toolName: "x", params: { i: 1 }, tier: "high" });
+    const b = q.request({ toolName: "y", params: { i: 2 }, tier: "high" });
+    const c = q.request({ toolName: "z", params: { i: 3 }, tier: "high" });
+    expect(q.size()).toBe(3);
+    const n = q.cancelAll();
+    expect(n).toBe(3);
+    expect(q.size()).toBe(0);
+    await expect(a.promise).resolves.toBe("cancelled");
+    await expect(b.promise).resolves.toBe("cancelled");
+    await expect(c.promise).resolves.toBe("cancelled");
+  });
+
+  it("cancelAll on an empty queue is a no-op returning 0", () => {
+    const q = new ApprovalQueue();
+    expect(q.cancelAll()).toBe(0);
+  });
+
   it("AbortSignal on request() resolves the promise with 'cancelled'", async () => {
     const q = new ApprovalQueue();
     const ac = new AbortController();

--- a/src/__tests__/server-settings.test.ts
+++ b/src/__tests__/server-settings.test.ts
@@ -568,6 +568,57 @@ describe("POST /settings — audit-log emission", () => {
   });
 });
 
+describe("POST /settings — gate downgrade cancels pending approvals", () => {
+  it("cancels every pending entry when approvalGate transitions to off", async () => {
+    const { getApprovalQueue } = await import("../approvalQueue.js");
+    const q = getApprovalQueue();
+    q.cancelAll();
+    server!.approvalGate = "high";
+    const a = q.request({ toolName: "x", params: { i: 1 }, tier: "high" });
+    const b = q.request({ toolName: "y", params: { i: 2 }, tier: "high" });
+    expect(q.size()).toBe(2);
+
+    const { status } = await makeRequest(
+      {
+        method: "POST",
+        path: "/settings",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${TOKEN}`,
+        },
+      },
+      JSON.stringify({ approvalGate: "off" }),
+    );
+    expect(status).toBe(200);
+    expect(q.size()).toBe(0);
+    await expect(a.promise).resolves.toBe("cancelled");
+    await expect(b.promise).resolves.toBe("cancelled");
+  });
+
+  it("does NOT cancel entries on a no-op off → off transition", async () => {
+    const { getApprovalQueue } = await import("../approvalQueue.js");
+    const q = getApprovalQueue();
+    q.cancelAll();
+    server!.approvalGate = "off";
+    const a = q.request({ toolName: "x", params: { i: 1 }, tier: "high" });
+    expect(q.size()).toBe(1);
+
+    await makeRequest(
+      {
+        method: "POST",
+        path: "/settings",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${TOKEN}`,
+        },
+      },
+      JSON.stringify({ approvalGate: "off" }),
+    );
+    expect(q.size()).toBe(1);
+    q.cancel(a.callId);
+  });
+});
+
 describe("POST /settings — kill-switch gate", () => {
   // Regression: engaging the kill-switch must block config mutations,
   // not just tool dispatch. Otherwise a panicked operator who engages

--- a/src/approvalQueue.ts
+++ b/src/approvalQueue.ts
@@ -366,6 +366,23 @@ export class ApprovalQueue {
     return this.resolveEntry(callId, "rejected");
   }
 
+  /**
+   * Cancel every still-pending entry, resolving each with "cancelled".
+   * Used when the operator downgrades the approval gate to "off" so
+   * phone approvers don't see "Approve" buttons whose token is now
+   * meaningless (the originating tool dispatch already short-circuited
+   * to bypass on the new gate). Returns the number of entries that
+   * were cancelled.
+   */
+  cancelAll(): number {
+    const callIds = [...this.entries.keys()];
+    let n = 0;
+    for (const id of callIds) {
+      if (this.resolveEntry(id, "cancelled")) n++;
+    }
+    return n;
+  }
+
   list(): PendingApproval[] {
     return [...this.entries.values()].map((e) => ({
       callId: e.callId,

--- a/src/server.ts
+++ b/src/server.ts
@@ -1887,7 +1887,22 @@ export class Server extends EventEmitter<ServerEvents> {
             // PHASE 4 — live state. Only after every persistence step
             // succeeded; ensures live state never diverges from disk.
             if (gateRaw !== undefined) {
+              const prevGate = this.approvalGate;
               this.approvalGate = gateRaw as "off" | "high" | "all";
+              // When the operator downgrades to "off", every pending
+              // queue entry becomes moot — the originating tool dispatch
+              // now bypasses, and a phone approver who hits "Approve"
+              // five seconds later would get a 404. Cancel them
+              // server-side so the dashboard /approvals list clears
+              // and any pending phone notification reflects reality.
+              if (gateRaw === "off" && prevGate !== "off") {
+                const cancelled = getApprovalQueue().cancelAll();
+                if (cancelled > 0) {
+                  this.logger.info(
+                    `[/settings] approvalGate → off; cancelled ${cancelled} pending entr${cancelled === 1 ? "y" : "ies"}`,
+                  );
+                }
+              }
             }
             if (body.enableTimeOfDayAnomaly !== undefined) {
               this.enableTimeOfDayAnomaly = body.enableTimeOfDayAnomaly;


### PR DESCRIPTION
## Summary
- New \`ApprovalQueue.cancelAll()\` resolves every pending entry as \`cancelled\`.
- \`/settings\` PHASE 4 detects \`approvalGate\` transitions to \`off\` and invokes it.
- No-op transitions (off → off) leave the queue alone.

## Why
Audit P1 #12. After a gate downgrade to off, pending approvalTokens kept their bearer state. Phone approvers could press "Approve" against entries the dispatcher had already bypassed — wrong from a trust + UX angle and a future replay risk.

## Test plan
- [x] 2 new approvalQueue tests + 2 new server-settings tests (77/77 pass)
- [x] strict tsc clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)