### PR TITLE
feat(telemetry): destination visibility + right-to-erasure

### DIFF
--- a/dashboard/src/app/api/bridge/telemetry-prefs/route.ts
+++ b/dashboard/src/app/api/bridge/telemetry-prefs/route.ts
@@ -35,6 +35,32 @@ export async function GET() {
   }
 }
 
+export async function DELETE(request: Request) {
+  const guard = requireSameOrigin(request);
+  if (guard) return guard;
+  try {
+    const res = await bridgeFetch("/telemetry-prefs", { method: "DELETE" });
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      console.error(
+        `[bridge/telemetry-prefs DELETE] bridge returned ${res.status}:`,
+        text,
+      );
+      return NextResponse.json(
+        { error: `Bridge returned ${res.status}` },
+        { status: res.status },
+      );
+    }
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    console.error(
+      "[bridge/telemetry-prefs DELETE] bridge fetch failed:",
+      err,
+    );
+    return NextResponse.json({ error: "Bridge unreachable" }, { status: 502 });
+  }
+}
+
 export async function POST(request: Request) {
   const guard = requireSameOrigin(request);
   if (guard) return guard;

--- a/dashboard/src/app/settings/page.tsx
+++ b/dashboard/src/app/settings/page.tsx
@@ -253,17 +253,37 @@ export default function SettingsPage() {
   const [telDiag, setTelDiag] = useState(true);
   const telInitialized = useRef(false);
   const [telLastSentAt, setTelLastSentAt] = useState<string | null>(null);
+  const [telEndpoint, setTelEndpoint] = useState<string | null>(null);
+  const [telEndpointSource, setTelEndpointSource] = useState<string | null>(
+    null,
+  );
+  const [telResetBusy, setTelResetBusy] = useState(false);
+  const [telResetMsg, setTelResetMsg] = useState<{
+    ok: boolean;
+    text: string;
+  } | null>(null);
 
-  // Fetch analytics prefs (including lastSentAt) from bridge
+  // Fetch analytics prefs (including lastSentAt + endpoint info) from bridge
   useEffect(() => {
     let alive = true;
     const fetch_ = async () => {
       try {
         const res = await fetch(apiPath("/api/bridge/telemetry-prefs"));
         if (res.ok) {
-          const data = (await res.json()) as { lastSentAt?: string };
-          if (alive && typeof data.lastSentAt === "string") {
+          const data = (await res.json()) as {
+            lastSentAt?: string;
+            endpoint?: string;
+            endpointSource?: string;
+          };
+          if (!alive) return;
+          if (typeof data.lastSentAt === "string") {
             setTelLastSentAt(data.lastSentAt);
+          }
+          if (typeof data.endpoint === "string") {
+            setTelEndpoint(data.endpoint);
+          }
+          if (typeof data.endpointSource === "string") {
+            setTelEndpointSource(data.endpointSource);
           }
         }
       } catch {
@@ -275,6 +295,46 @@ export default function SettingsPage() {
       alive = false;
     };
   }, []);
+
+  async function resetTelemetryData() {
+    if (
+      !confirm(
+        "Delete all local telemetry data?\n\nThis clears your saved preferences, the analytics endpoint config, and the install-identifying salt. Equivalent to a fresh install for telemetry purposes.",
+      )
+    ) {
+      return;
+    }
+    setTelResetBusy(true);
+    setTelResetMsg(null);
+    try {
+      const res = await fetch(apiPath("/api/bridge/telemetry-prefs"), {
+        method: "DELETE",
+      });
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as {
+          error?: string;
+        };
+        setTelResetMsg({
+          ok: false,
+          text: body.error ?? `Error ${res.status}`,
+        });
+      } else {
+        // Local state reset — server salt is gone, prefs reset to false.
+        setTelCrash(false);
+        setTelUsage(false);
+        setTelDiag(false);
+        setTelLastSentAt(null);
+        setTelResetMsg({ ok: true, text: "Local telemetry data cleared." });
+      }
+    } catch (e) {
+      setTelResetMsg({
+        ok: false,
+        text: e instanceof Error ? e.message : String(e),
+      });
+    } finally {
+      setTelResetBusy(false);
+    }
+  }
 
   // Kill-switch state — fetched from /api/bridge/kill-switch (proxy to
   // bridge `GET /kill-switch`). Polls in tandem with /status below.
@@ -1756,6 +1816,72 @@ export default function SettingsPage() {
                     })}
                   </div>
                 )}
+                {telEndpoint && (
+                  <div
+                    style={{
+                      fontSize: "var(--fs-s)",
+                      color: "var(--ink-2)",
+                      paddingTop: 4,
+                    }}
+                    aria-label="Telemetry destination"
+                  >
+                    Sending to{" "}
+                    <span className="mono">{telEndpoint}</span>
+                    {telEndpointSource && (
+                      <span style={{ color: "var(--ink-3)" }}>
+                        {" "}
+                        (source: {telEndpointSource})
+                      </span>
+                    )}
+                  </div>
+                )}
+                <div
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 8,
+                    flexWrap: "wrap",
+                    paddingTop: 8,
+                    borderTop: "1px solid var(--border-default)",
+                    marginTop: 4,
+                  }}
+                >
+                  <button
+                    type="button"
+                    onClick={() => void resetTelemetryData()}
+                    disabled={telResetBusy}
+                    aria-label="Delete local telemetry data"
+                    style={{
+                      background: "transparent",
+                      color: "var(--fg-2)",
+                      border: "1px solid var(--border-default)",
+                      borderRadius: "var(--r-2)",
+                      padding: "5px 10px",
+                      fontSize: "var(--fs-s)",
+                      cursor: telResetBusy ? "default" : "pointer",
+                      opacity: telResetBusy ? 0.5 : 1,
+                    }}
+                  >
+                    {telResetBusy
+                      ? "Clearing…"
+                      : "Delete local telemetry data"}
+                  </button>
+                  <span
+                    style={{ fontSize: "var(--fs-s)", color: "var(--ink-3)" }}
+                  >
+                    Clears prefs, endpoint config, and the install salt.
+                  </span>
+                  {telResetMsg && (
+                    <span
+                      style={{
+                        fontSize: "var(--fs-s)",
+                        color: telResetMsg.ok ? "var(--ok)" : "var(--err)",
+                      }}
+                    >
+                      {telResetMsg.text}
+                    </span>
+                  )}
+                </div>
               </div>
             </div>
           </div>

--- a/src/__tests__/server-settings.test.ts
+++ b/src/__tests__/server-settings.test.ts
@@ -617,6 +617,70 @@ describe("POST /settings — pushServiceToken charset cap", () => {
   });
 });
 
+describe("/telemetry-prefs — endpoint visibility + right-to-erasure", () => {
+  it("GET returns the resolved endpoint + source", async () => {
+    const prevEnv = process.env.PATCHWORK_ANALYTICS_ENDPOINT;
+    delete process.env.PATCHWORK_ANALYTICS_ENDPOINT;
+    try {
+      const { status, body } = await makeRequest(
+        {
+          method: "GET",
+          path: "/telemetry-prefs",
+          headers: { Authorization: `Bearer ${TOKEN}` },
+        },
+        "",
+      );
+      expect(status).toBe(200);
+      const parsed = JSON.parse(body) as {
+        endpoint?: string;
+        endpointSource?: string;
+      };
+      expect(parsed.endpoint).toBeTruthy();
+      expect(["env", "config", "default"]).toContain(parsed.endpointSource);
+    } finally {
+      if (prevEnv !== undefined)
+        process.env.PATCHWORK_ANALYTICS_ENDPOINT = prevEnv;
+    }
+  });
+
+  it("GET reports endpointSource='env' when PATCHWORK_ANALYTICS_ENDPOINT is set", async () => {
+    const prev = process.env.PATCHWORK_ANALYTICS_ENDPOINT;
+    process.env.PATCHWORK_ANALYTICS_ENDPOINT = "https://example.com/v1/usage";
+    try {
+      const { body } = await makeRequest(
+        {
+          method: "GET",
+          path: "/telemetry-prefs",
+          headers: { Authorization: `Bearer ${TOKEN}` },
+        },
+        "",
+      );
+      const parsed = JSON.parse(body) as {
+        endpoint?: string;
+        endpointSource?: string;
+      };
+      expect(parsed.endpointSource).toBe("env");
+      expect(parsed.endpoint).toBe("https://example.com/v1/usage");
+    } finally {
+      if (prev === undefined) delete process.env.PATCHWORK_ANALYTICS_ENDPOINT;
+      else process.env.PATCHWORK_ANALYTICS_ENDPOINT = prev;
+    }
+  });
+
+  it("DELETE returns 200 ok:true (idempotent on missing files)", async () => {
+    const { status, body } = await makeRequest(
+      {
+        method: "DELETE",
+        path: "/telemetry-prefs",
+        headers: { Authorization: `Bearer ${TOKEN}` },
+      },
+      "",
+    );
+    expect(status).toBe(200);
+    expect(JSON.parse(body)).toMatchObject({ ok: true });
+  });
+});
+
 describe("POST /settings — kill-switch gate", () => {
   // Regression: engaging the kill-switch must block config mutations,
   // not just tool dispatch. Otherwise a panicked operator who engages

--- a/src/analyticsPrefs.ts
+++ b/src/analyticsPrefs.ts
@@ -35,6 +35,14 @@ function saltPath(): string {
   return path.join(claudeDir, "ide", "analytics-salt");
 }
 
+/** Public paths for the /telemetry-prefs DELETE handler. */
+export function getAnalyticsPrefsPath(): string {
+  return prefsPath();
+}
+export function getAnalyticsSaltPath(): string {
+  return saltPath();
+}
+
 /**
  * Read and migrate the on-disk prefs to the v2 shape.
  * Old files with only `enabled` map to:

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,10 +1,14 @@
 import { createHmac, timingSafeEqual } from "node:crypto";
 import { EventEmitter } from "node:events";
+import { unlinkSync } from "node:fs";
 import http from "node:http";
 import { WebSocket, WebSocketServer as WsServer } from "ws";
 import type { ActivityListener } from "./activityTypes.js";
+import { clearAnalyticsConfig, getAnalyticsConfig } from "./analyticsConfig.js";
 import {
   getAnalyticsPrefsAll,
+  getAnalyticsPrefsPath,
+  getAnalyticsSaltPath,
   getTelemetryPrefs,
   setTelemetryPrefs,
 } from "./analyticsPrefs.js";
@@ -2184,8 +2188,10 @@ export class Server extends EventEmitter<ServerEvents> {
       }
 
       // /telemetry-prefs — read/write per-flag telemetry preferences.
-      // GET  → {crashReports, usageStats, localDiagnostics}
-      // POST {crashReports?, usageStats?, localDiagnostics?} → same shape (partial update)
+      // GET    → {crashReports, usageStats, localDiagnostics, endpoint, endpointSource}
+      // POST   {crashReports?, usageStats?, localDiagnostics?} → same shape (partial update)
+      // DELETE → clears prefs file + analytics-config + install salt
+      //          (right-to-erasure affordance).
       if (parsedUrl.pathname === "/telemetry-prefs") {
         if (req.method === "GET") {
           const prefs = getTelemetryPrefs();
@@ -2194,8 +2200,58 @@ export class Server extends EventEmitter<ServerEvents> {
           if (all?.lastSentAt !== undefined) {
             response.lastSentAt = all.lastSentAt;
           }
+          // Destination visibility — consent baseline. Caller can see
+          // where their data would go and whether the destination came
+          // from env (CI/headless) or the on-disk config file.
+          const envEndpoint = process.env.PATCHWORK_ANALYTICS_ENDPOINT;
+          const cfgEndpoint = getAnalyticsConfig().endpoint;
+          const defaultEndpoint =
+            "https://analytics.claude-ide-bridge.dev/v1/usage";
+          if (envEndpoint) {
+            response.endpoint = envEndpoint;
+            response.endpointSource = "env";
+          } else if (cfgEndpoint) {
+            response.endpoint = cfgEndpoint;
+            response.endpointSource = "config";
+          } else {
+            response.endpoint = defaultEndpoint;
+            response.endpointSource = "default";
+          }
           res.writeHead(200, { "Content-Type": "application/json" });
           res.end(JSON.stringify(response));
+          return;
+        }
+        if (req.method === "DELETE") {
+          // Right-to-erasure: drop prefs, analytics-config (endpoint /
+          // shared secret), and the install salt. Next outbound send
+          // (if any) will mint a fresh salt and treat this as a new
+          // install. Kill-switch is honored here too — incident-mode
+          // operators may still want to scrub local state, so allow
+          // it; flip if the threat model changes.
+          try {
+            unlinkSync(getAnalyticsPrefsPath());
+          } catch {
+            /* missing is fine */
+          }
+          try {
+            unlinkSync(getAnalyticsSaltPath());
+          } catch {
+            /* missing is fine */
+          }
+          clearAnalyticsConfig();
+          if (this.activityLog) {
+            this.activityLog.recordEvent("telemetry.reset", {
+              actor: "http",
+              ip:
+                (req.headers["x-forwarded-for"] as string | undefined)
+                  ?.split(",")[0]
+                  ?.trim() ||
+                req.socket.remoteAddress ||
+                "unknown",
+            });
+          }
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ ok: true }));
           return;
         }
         if (req.method === "POST") {


### PR DESCRIPTION
## Summary
- GET /telemetry-prefs returns \`endpoint\` + \`endpointSource\` (env / config / default).
- DELETE /telemetry-prefs clears prefs, analytics-config, install salt. Idempotent.
- Dashboard surfaces \"Sending to <url> (source: …)\" and a \"Delete local telemetry data\" button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)