### PR TITLE
fix(dashboard/settings): rAF-throttle scroll-spy measurement

### DIFF
--- a/dashboard/src/app/settings/page.tsx
+++ b/dashboard/src/app/settings/page.tsx
@@ -463,9 +463,15 @@ export default function SettingsPage() {
     };
   }, []);
 
-  // Scroll-spy active section
+  // Scroll-spy active section — rAF-throttled. Previously
+  // `getBoundingClientRect()` ×6 fired on every scroll event,
+  // forcing synchronous layout each tick and showing visible jank on
+  // long pages. Coalesce to at most one measurement per animation
+  // frame; the visual result is identical.
   useEffect(() => {
-    const handler = () => {
+    let pending = false;
+    const measure = () => {
+      pending = false;
       const offsets = NAV.map((n) => {
         const el = document.getElementById(n.id);
         if (!el) return { id: n.id, top: Number.POSITIVE_INFINITY };
@@ -474,8 +480,13 @@ export default function SettingsPage() {
       offsets.sort((a, b) => a.top - b.top);
       if (offsets[0]) setActive(offsets[0].id);
     };
+    const handler = () => {
+      if (pending) return;
+      pending = true;
+      requestAnimationFrame(measure);
+    };
     window.addEventListener("scroll", handler, { passive: true });
-    handler();
+    measure();
     return () => window.removeEventListener("scroll", handler);
   }, []);
 


### PR DESCRIPTION
## Summary
- Coalesce scroll-spy \`getBoundingClientRect()\` ×6 to one measurement per animation frame.
- No behavioural change; eliminates visible jank on long settings pages.

## Why
Audit P2. The previous handler did synchronous layout on every scroll event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)