### PR TITLE
feat(dashboard/recipes): inline live run observability

### DIFF
--- a/dashboard/src/app/recipes/_components/RecipeRunInline.tsx
+++ b/dashboard/src/app/recipes/_components/RecipeRunInline.tsx
@@ -1,0 +1,154 @@
+"use client";
+import Link from "next/link";
+import { StatusPill } from "@/components/patchwork";
+import type { ActiveRunState } from "@/hooks/useRecipeRunStream";
+
+function pct(state: ActiveRunState): number {
+	if (state.totalSteps <= 0) return 0;
+	return Math.min(100, Math.round((state.doneSteps / state.totalSteps) * 100));
+}
+
+function durSec(state: ActiveRunState): string {
+	const end = state.endedAt ?? Date.now();
+	const s = Math.max(0, Math.round((end - state.startedAt) / 1000));
+	if (s < 60) return `${s}s`;
+	const m = Math.floor(s / 60);
+	return `${m}m ${s % 60}s`;
+}
+
+/**
+ * Inline live indicator for a recipe's active or just-finished run.
+ * Three density levels:
+ *   "chip"     — compact "Step 2/5 · 3s" pill for the recipes-list row
+ *   "strip"    — progress bar + current step + status, for the detail panel
+ *   "outcome"  — terminal state with halt reason / open-run link
+ */
+export function RecipeRunInline({
+	state,
+	density = "strip",
+}: {
+	state: ActiveRunState;
+	density?: "chip" | "strip" | "outcome";
+}) {
+	const tone: "ok" | "warn" | "err" | "muted" =
+		state.status === "running"
+			? "warn"
+			: state.status === "ok"
+				? "ok"
+				: state.status === "halted"
+					? "muted"
+					: "err";
+	const label =
+		state.status === "running"
+			? state.totalSteps > 0
+				? `Step ${state.doneSteps}/${state.totalSteps}`
+				: "Running"
+			: state.status === "ok"
+				? "Done"
+				: state.status === "halted"
+					? "Halted"
+					: "Error";
+
+	if (density === "chip") {
+		return (
+			<span
+				style={{ display: "inline-flex", alignItems: "center", gap: 6, fontSize: "var(--fs-xs)" }}
+				aria-label={`Run ${label.toLowerCase()}`}
+			>
+				<StatusPill tone={tone}>{label}</StatusPill>
+				<span className="mono muted" style={{ fontVariantNumeric: "tabular-nums" }}>
+					{durSec(state)}
+				</span>
+			</span>
+		);
+	}
+
+	const p = pct(state);
+	return (
+		<div
+			style={{ display: "flex", flexDirection: "column", gap: 6, marginTop: 4 }}
+			role="status"
+			aria-live="polite"
+		>
+			<div
+				style={{
+					display: "flex",
+					alignItems: "center",
+					gap: 8,
+					fontSize: "var(--fs-xs)",
+					flexWrap: "wrap",
+				}}
+			>
+				<StatusPill tone={tone}>{label}</StatusPill>
+				{state.currentTool && state.status === "running" && (
+					<span className="mono" style={{ color: "var(--ink-2)" }}>
+						{state.currentTool}
+					</span>
+				)}
+				<span className="mono muted" style={{ fontVariantNumeric: "tabular-nums" }}>
+					{durSec(state)}
+				</span>
+				<span style={{ flex: 1 }} />
+				{state.runSeq > 0 && (
+					<Link
+						href={`/runs/${state.runSeq}`}
+						style={{
+							fontSize: "var(--fs-xs)",
+							color: "var(--ink-3)",
+							textDecoration: "none",
+							minHeight: 28,
+							display: "inline-flex",
+							alignItems: "center",
+							padding: "0 6px",
+						}}
+					>
+						open run →
+					</Link>
+				)}
+			</div>
+			{state.totalSteps > 0 && (
+				<div
+					aria-label={`Progress ${p}%`}
+					style={{
+						height: 4,
+						width: "100%",
+						background: "var(--bg-2)",
+						borderRadius: 2,
+						overflow: "hidden",
+					}}
+				>
+					<div
+						style={{
+							width: `${p}%`,
+							height: "100%",
+							background:
+								state.status === "error"
+									? "var(--err)"
+									: state.status === "halted"
+										? "var(--warn)"
+										: state.status === "ok"
+											? "var(--ok)"
+											: "var(--accent)",
+							transition: "width 0.25s ease",
+						}}
+					/>
+				</div>
+			)}
+			{(state.haltReason || state.lastError) && state.status !== "running" && (
+				<div
+					className="mono"
+					style={{
+						fontSize: "var(--fs-2xs)",
+						color: "var(--ink-3)",
+						background: "var(--bg-2)",
+						padding: "4px 6px",
+						borderRadius: 4,
+						wordBreak: "break-word",
+					}}
+				>
+					{state.haltReason ?? state.lastError}
+				</div>
+			)}
+		</div>
+	);
+}

--- a/dashboard/src/app/recipes/page.tsx
+++ b/dashboard/src/app/recipes/page.tsx
@@ -8,6 +8,8 @@ import { apiPath } from "@/lib/api";
 import { ConnectorHealthPanel } from "@/components/ConnectorHealthPanel";
 import { SkeletonList } from "@/components/Skeleton";
 import { useToast } from "@/components/Toast";
+import { useRecipeRunStream, type ActiveRunState } from "@/hooks/useRecipeRunStream";
+import { RecipeRunInline } from "./_components/RecipeRunInline";
 import {
   CodeBlock,
   ErrorState,
@@ -417,6 +419,7 @@ function RecipeDetailPanel({
   onDelete,
   running,
   isLive,
+  activeRun,
 }: {
   recipe: Recipe;
   recentRuns: RunRecord[];
@@ -426,6 +429,7 @@ function RecipeDetailPanel({
   onDelete: () => void;
   running: Record<string, string>;
   isLive: boolean;
+  activeRun: ActiveRunState | undefined;
 }) {
   return (
     <PatchCard
@@ -474,10 +478,16 @@ function RecipeDetailPanel({
         </button>
       </div>
 
-      {running[recipe.name] && (
+      {activeRun ? (
         <div style={{ marginBottom: 10 }}>
-          <StatusPill tone="warn">{running[recipe.name]}</StatusPill>
+          <RecipeRunInline state={activeRun} density="strip" />
         </div>
+      ) : (
+        running[recipe.name] && (
+          <div style={{ marginBottom: 10 }}>
+            <StatusPill tone="warn">{running[recipe.name]}</StatusPill>
+          </div>
+        )
       )}
 
       <div style={{ marginBottom: 14 }}>
@@ -587,6 +597,9 @@ export default function RecipesPage() {
   const [modalRunning, setModalRunning] = useState(false);
   const [search, setSearch] = useState("");
   const toast = useToast();
+  // Live SSE-driven run state, keyed by recipe name. Foundation for inline
+  // run observability — see PR #642 (bridge lifecycle emit) + RecipeRunInline.
+  const { active: activeRunsByName } = useRecipeRunStream();
   // #600: deep-link support so /recipes?run=<name> auto-opens the
   // RunModal once recipes are loaded. Used by the Inbox Replay
   // button so users land on the recipe with its vars-input modal
@@ -1104,6 +1117,12 @@ export default function RecipesPage() {
                               {r.name}
                             </Link>
                             {live && <LivePill tone="ok" />}
+                            {activeRunsByName.get(r.name) && (
+                              <RecipeRunInline
+                                state={activeRunsByName.get(r.name) as ActiveRunState}
+                                density="chip"
+                              />
+                            )}
                             {!enabled && <StatusPill tone="muted">off</StatusPill>}
                             {r.lint && r.lint.ok === false && (
                               <StatusPill
@@ -1237,6 +1256,7 @@ export default function RecipesPage() {
               onDelete={() => void handleDeleteRecipe(selectedRecipe)}
               running={running}
               isLive={isLive(selectedRecipe.name)}
+              activeRun={activeRunsByName.get(selectedRecipe.name)}
             />
           )}
         </div>

--- a/dashboard/src/hooks/useRecipeRunStream.ts
+++ b/dashboard/src/hooks/useRecipeRunStream.ts
@@ -1,0 +1,146 @@
+"use client";
+import { useEffect, useRef, useState } from "react";
+import { useBridgeStream } from "./useBridgeStream";
+
+export interface ActiveRunState {
+	runSeq: number;
+	recipeName: string;
+	totalSteps: number;
+	doneSteps: number;
+	currentStepId?: string;
+	currentTool?: string;
+	startedAt: number;
+	endedAt?: number;
+	status: "running" | "ok" | "error" | "halted";
+	haltReason?: string;
+	haltCategory?: string;
+	lastError?: string;
+}
+
+interface LifecycleEvent {
+	event?: string;
+	metadata?: {
+		runSeq?: number;
+		recipeName?: string;
+		stepId?: string;
+		tool?: string;
+		status?: "ok" | "error" | "skipped";
+		error?: string;
+		durationMs?: number;
+		totalSteps?: number;
+		haltReason?: string;
+		haltCategory?: string;
+	};
+	ts?: number;
+}
+
+const FINAL_HOLD_MS = 30_000; // keep terminal state visible 30s, then GC
+
+/**
+ * Subscribe to ActivityLog SSE and aggregate per-recipe live run state.
+ * Foundation for inline run observability on /recipes — emits the events
+ * shipped by yamlRunner / chainedRunner (recipe_started, recipe_step_start,
+ * recipe_step_done, recipe_done).
+ *
+ * Keyed by recipeName, not runSeq, so the recipes-list row knows whether
+ * "its" run is live without needing to discover the runSeq first.
+ */
+export function useRecipeRunStream(): {
+	active: Map<string, ActiveRunState>;
+	connected: boolean;
+} {
+	const [active, setActive] = useState<Map<string, ActiveRunState>>(new Map());
+	const gcTimers = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
+
+	useEffect(() => {
+		const timers = gcTimers.current;
+		return () => {
+			for (const t of timers.values()) clearTimeout(t);
+			timers.clear();
+		};
+	}, []);
+
+	const onEvent = (type: string, raw: unknown) => {
+		if (type !== "lifecycle") return;
+		const data = raw as LifecycleEvent | undefined;
+		const md = data?.metadata;
+		if (!data?.event || !md) return;
+		const name = md.recipeName;
+		if (!name) return;
+
+		if (data.event === "recipe_started") {
+			setActive((prev) => {
+				const next = new Map(prev);
+				next.set(name, {
+					runSeq: md.runSeq ?? 0,
+					recipeName: name,
+					totalSteps: md.totalSteps ?? 0,
+					doneSteps: 0,
+					startedAt: data.ts ?? Date.now(),
+					status: "running",
+				});
+				return next;
+			});
+			const existing = gcTimers.current.get(name);
+			if (existing) {
+				clearTimeout(existing);
+				gcTimers.current.delete(name);
+			}
+		} else if (data.event === "recipe_step_start") {
+			setActive((prev) => {
+				const cur = prev.get(name);
+				if (!cur) return prev;
+				const next = new Map(prev);
+				next.set(name, { ...cur, currentStepId: md.stepId, currentTool: md.tool });
+				return next;
+			});
+		} else if (data.event === "recipe_step_done") {
+			setActive((prev) => {
+				const cur = prev.get(name);
+				if (!cur) return prev;
+				const next = new Map(prev);
+				next.set(name, {
+					...cur,
+					doneSteps: cur.doneSteps + 1,
+					lastError: md.status === "error" ? md.error : cur.lastError,
+				});
+				return next;
+			});
+		} else if (data.event === "recipe_done") {
+			setActive((prev) => {
+				const cur = prev.get(name);
+				if (!cur) return prev;
+				const next = new Map(prev);
+				const status: ActiveRunState["status"] = md.haltReason
+					? "halted"
+					: md.status === "error"
+						? "error"
+						: "ok";
+				next.set(name, {
+					...cur,
+					endedAt: data.ts ?? Date.now(),
+					status,
+					haltReason: md.haltReason,
+					haltCategory: md.haltCategory,
+				});
+				return next;
+			});
+			// Schedule GC so terminal state lingers briefly then drops.
+			const existing = gcTimers.current.get(name);
+			if (existing) clearTimeout(existing);
+			const timer = setTimeout(() => {
+				setActive((prev) => {
+					if (!prev.has(name)) return prev;
+					const next = new Map(prev);
+					next.delete(name);
+					return next;
+				});
+				gcTimers.current.delete(name);
+			}, FINAL_HOLD_MS);
+			gcTimers.current.set(name, timer);
+		}
+	};
+
+	const { connected } = useBridgeStream("/api/bridge/stream", onEvent);
+	return { active, connected };
+}

--- a/src/recipes/__tests__/yamlRunner.test.ts
+++ b/src/recipes/__tests__/yamlRunner.test.ts
@@ -3158,3 +3158,75 @@ describe("live step persistence via updateRunSteps", () => {
     }
   });
 });
+
+// ── live-tail SSE emission (PR #2: recipe lifecycle events) ──────────────────
+describe("runYamlRecipe — SSE lifecycle emissions", () => {
+  it("emits recipe_started, recipe_step_start/done, and recipe_done with haltCategory", async () => {
+    const tmp = mkdtempSync(path.join(os.tmpdir(), "yaml-sse-"));
+    try {
+      const { ActivityLog } = await import("../../activityLog.js");
+      const { RecipeRunLog } = await import("../../runLog.js");
+      const activityLog = new ActivityLog();
+      const runLog = new RecipeRunLog({ dir: tmp });
+      const events: Array<{
+        event: string;
+        metadata?: Record<string, unknown>;
+      }> = [];
+      activityLog.subscribe((_kind, entry) => {
+        if ("event" in entry) {
+          events.push({
+            event: entry.event,
+            metadata: entry.metadata as Record<string, unknown>,
+          });
+        }
+      });
+
+      const recipe = makeRecipe({
+        name: "live-tail-test",
+        steps: [{ tool: "diagnostics", uri: "file:///nope.ts", into: "diag" }],
+      });
+
+      await runYamlRecipe(recipe, {
+        ...noop(),
+        runLog,
+        activityLog,
+      });
+
+      const recipeStarted = events.find((e) => e.event === "recipe_started");
+      const stepStart = events.find((e) => e.event === "recipe_step_start");
+      const stepDone = events.find((e) => e.event === "recipe_step_done");
+      const recipeDone = events.find((e) => e.event === "recipe_done");
+
+      expect(recipeStarted).toBeDefined();
+      expect(recipeStarted?.metadata?.recipeName).toBe("live-tail-test");
+      expect(recipeStarted?.metadata?.totalSteps).toBe(1);
+      expect(stepStart).toBeDefined();
+      expect(stepStart?.metadata?.stepId).toBe("diag");
+      expect(stepDone).toBeDefined();
+      // step might be "ok" or "skipped" depending on stub return; both
+      // prove the lifecycle wiring fired exactly once.
+      expect(["ok", "skipped"]).toContain(stepDone?.metadata?.status);
+      expect(recipeDone).toBeDefined();
+      expect(recipeDone?.metadata?.status).toBe("done");
+      expect(recipeDone?.metadata?.stepCount).toBe(1);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("does not emit when activityLog is absent (no-op safety)", async () => {
+    const tmp = mkdtempSync(path.join(os.tmpdir(), "yaml-sse-noop-"));
+    try {
+      const { RecipeRunLog } = await import("../../runLog.js");
+      const runLog = new RecipeRunLog({ dir: tmp });
+      const recipe = makeRecipe({
+        name: "no-activity",
+        steps: [{ tool: "diagnostics", uri: "file:///x.ts", into: "diag" }],
+      });
+      // Should not throw; activityLog omitted entirely.
+      await runYamlRecipe(recipe, { ...noop(), runLog });
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/recipes/chainedRunner.ts
+++ b/src/recipes/chainedRunner.ts
@@ -12,7 +12,10 @@ import {
   buildDependencyGraph,
   executeWithDependencies,
 } from "./dependencyGraph.js";
-import { deriveHaltReasonFromError } from "./haltCategory.js";
+import {
+  categoriseHaltReason,
+  deriveHaltReasonFromError,
+} from "./haltCategory.js";
 import type {
   NestedRecipeConfig,
   NestedRecipeContext,
@@ -750,6 +753,23 @@ export async function runChainedRecipe(
   const broadcastSeq = runSeq;
   const broadcastName = recipe.name;
   const stepStartTimes = new Map<string, number>();
+  const broadcastRunStartedAt = Date.now();
+
+  // Emit recipe_started immediately. Dashboard RecipeRunInline watches
+  // this event to flip a row from "queued" to "running" before the
+  // first step lands.
+  if (broadcastActivity && broadcastSeq !== undefined) {
+    try {
+      broadcastActivity.recordEvent("recipe_started", {
+        runSeq: broadcastSeq,
+        recipeName: broadcastName,
+        totalSteps: recipe.steps?.length ?? 0,
+        ts: broadcastRunStartedAt,
+      });
+    } catch {
+      /* live-tail must not break a recipe run */
+    }
+  }
 
   const wrappedOnStepStart =
     broadcastActivity && broadcastSeq !== undefined
@@ -777,15 +797,30 @@ export async function runChainedRecipe(
           const ts = Date.now();
           const startedAt = stepStartTimes.get(stepId);
           try {
+            const stepDef = stepMap.get(stepId);
+            const haltReason =
+              error?.message !== undefined
+                ? deriveHaltReasonFromError({
+                    stepId,
+                    toolName: stepDef?.tool,
+                    isAgent: !!stepDef?.agent,
+                    status: "error",
+                    error: error.message,
+                  })
+                : undefined;
             broadcastActivity.recordEvent("recipe_step_done", {
               runSeq: broadcastSeq,
               recipeName: broadcastName,
               stepId,
-              tool: stepMap.get(stepId)?.tool,
+              tool: stepDef?.tool,
               status: error ? "error" : "ok",
               ...(error?.message !== undefined && { error: error.message }),
               ...(startedAt !== undefined && {
                 durationMs: ts - startedAt,
+              }),
+              ...(haltReason !== undefined && {
+                haltReason,
+                haltCategory: categoriseHaltReason(haltReason),
               }),
               ts,
             });
@@ -1006,6 +1041,23 @@ export async function runChainedRecipe(
             errorMessage: result.errorMessage,
           }),
         });
+        if (broadcastActivity && broadcastSeq !== undefined) {
+          try {
+            broadcastActivity.recordEvent("recipe_done", {
+              runSeq: broadcastSeq,
+              recipeName: broadcastName,
+              status: result.success ? "done" : "error",
+              durationMs: doneAt - runStartedAt,
+              stepCount: stepResultsList.length,
+              ...(result.errorMessage !== undefined && {
+                errorMessage: result.errorMessage,
+              }),
+              ts: doneAt,
+            });
+          } catch {
+            /* live-tail must not break a recipe run */
+          }
+        }
       } else if (options.runLogDir) {
         const { RecipeRunLog } = await import("../runLog.js");
         const log = new RecipeRunLog({ dir: options.runLogDir });

--- a/src/recipes/yamlRunner.ts
+++ b/src/recipes/yamlRunner.ts
@@ -55,6 +55,7 @@ import {
   type AgentExecutorDeps,
   type AgentResult,
 } from "./agentExecutor.js";
+import { categoriseHaltReason } from "./haltCategory.js";
 import {
   assertValidManualRunId,
   deriveScopeKey,
@@ -305,6 +306,16 @@ export interface RunnerDeps {
    */
   runLog?: RecipeRunLog;
   /**
+   * Live-tail broadcaster for recipe + step lifecycle events. When
+   * supplied, the runner emits `recipe_started`, `recipe_step_start`,
+   * `recipe_step_done`, and `recipe_done` lifecycle events to the
+   * activity log, which the bridge proxies to dashboard SSE
+   * subscribers via /stream. Previously only `chainedRunner` emitted
+   * step events; flat YAML recipes (the common case) ran silent.
+   * Pass `bridge.activityLog`.
+   */
+  activityLog?: import("../activityLog.js").ActivityLog;
+  /**
    * Optional Anthropic API caller for agent steps. Defaults to fetch-based
    * impl. May return either a raw string (legacy / tests) or `AgentResult`
    * carrying usage tokens (bridge wrappers, real adapters). The runner
@@ -400,6 +411,7 @@ export type StepDeps = Required<
     | "runLog"
     | "ledgerDir"
     | "manualRunId"
+    | "activityLog"
   >
 > & {
   workdir: string;
@@ -595,6 +607,36 @@ export async function runYamlRecipe(
   let stepsRun = 0;
   let runError: string | undefined;
 
+  // Live-tail SSE broadcaster. Wrapped in a try/catch on every call so a
+  // misbehaving listener can never break the run (mirrors chainedRunner).
+  // No-ops when `activityLog` isn't wired (CLI runs, tests, mocks).
+  const broadcast = deps.activityLog;
+  const emit = (
+    event:
+      | "recipe_started"
+      | "recipe_step_start"
+      | "recipe_step_done"
+      | "recipe_done",
+    metadata: Record<string, unknown>,
+  ): void => {
+    if (!broadcast || runSeq === undefined || stepDeps.testMode) return;
+    try {
+      broadcast.recordEvent(event, metadata);
+    } catch {
+      /* live-tail must not break a recipe run */
+    }
+  };
+  // Emit recipe_started as soon as we have a runSeq. The dashboard
+  // RecipeRunInline component watches for this event to flip a row
+  // from "queued" to "running" without waiting for the first step.
+  emit("recipe_started", {
+    runSeq,
+    recipeName: recipe.name,
+    trigger: yamlTriggerKind,
+    totalSteps: recipe.steps.length,
+    ts: recipeStartedAt,
+  });
+
   // Push live step results into the run-log ring so the dashboard's
   // `/runs/[seq]` page surfaces verdicts + haltReasons mid-flight,
   // instead of waiting for the whole recipe to finish via
@@ -609,8 +651,21 @@ export async function runYamlRecipe(
       /* live-tail is best-effort; never break a recipe run for it */
     }
   };
+  // Track per-step start timestamps so done events carry durationMs
+  // without a second roundtrip.
+  const stepStartTs = new Map<string, number>();
 
   for (const step of recipe.steps) {
+    const stepIdForEmit = step.into ?? step.agent?.into ?? `step_${stepsRun}`;
+    const stepTs = Date.now();
+    stepStartTs.set(stepIdForEmit, stepTs);
+    emit("recipe_step_start", {
+      runSeq,
+      recipeName: recipe.name,
+      stepId: stepIdForEmit,
+      tool: step.agent ? "agent" : step.tool,
+      ts: stepTs,
+    });
     // Evaluate `when` guard before running anything. Mirrors
     // chainedRunner.ts:248-266 — render the template, then truthy-check the
     // result (empty string, "0", "false", "null", "undefined" are falsy).
@@ -635,6 +690,15 @@ export async function runYamlRecipe(
         });
         stepsRun++;
         persistLiveStepResults();
+        emit("recipe_step_done", {
+          runSeq,
+          recipeName: recipe.name,
+          stepId: skipId,
+          tool: step.agent ? "agent" : step.tool,
+          status: "skipped",
+          durationMs: 0,
+          ts: Date.now(),
+        });
         continue;
       }
     }
@@ -923,6 +987,30 @@ export async function runYamlRecipe(
       }
     }
     persistLiveStepResults();
+    // Emit recipe_step_done for live-tail SSE. Look up the matching
+    // entry in stepResults (the loop pushed at most one with this id);
+    // payload mirrors chainedRunner's done event plus haltCategory.
+    const justPushed = stepResults
+      .slice()
+      .reverse()
+      .find((r) => r.id === stepIdForEmit);
+    if (justPushed) {
+      const haltReason = justPushed.haltReason;
+      emit("recipe_step_done", {
+        runSeq,
+        recipeName: recipe.name,
+        stepId: justPushed.id,
+        tool: justPushed.tool,
+        status: justPushed.status,
+        durationMs: justPushed.durationMs,
+        ...(justPushed.error !== undefined && { error: justPushed.error }),
+        ...(haltReason !== undefined && {
+          haltReason,
+          haltCategory: categoriseHaltReason(haltReason),
+        }),
+        ts: Date.now(),
+      });
+    }
   }
 
   // Evaluate expect block before persisting so failures are stored in the run log
@@ -964,6 +1052,18 @@ export async function runYamlRecipe(
           outputTail,
           ...(runError !== undefined && { errorMessage: runError }),
           ...(assertionFailures.length > 0 ? { assertionFailures } : {}),
+        });
+        emit("recipe_done", {
+          runSeq,
+          recipeName: recipe.name,
+          status: runError ? "error" : "done",
+          durationMs: doneAt - recipeStartedAt,
+          stepCount: finalStepResults.length,
+          ...(runError !== undefined && { errorMessage: runError }),
+          ...(assertionFailures.length > 0 && {
+            assertionFailureCount: assertionFailures.length,
+          }),
+          ts: doneAt,
         });
       } else {
         const { RecipeRunLog } = await import("../runLog.js");
@@ -1854,15 +1954,16 @@ export async function dispatchRecipe(
     }
     return runChainedRecipe(chainedRecipe, options, deps.chainedDeps);
   }
-  // For non-chained recipes, lift `runLog` from chainedOptions onto the
-  // RunnerDeps so runYamlRecipe gets the bridge's singleton too.
-  return runYamlRecipe(
-    recipe,
-    deps.chainedOptions?.runLog
-      ? { ...deps, runLog: deps.chainedOptions.runLog }
-      : deps,
-    seedContext,
-  );
+  // For non-chained recipes, lift `runLog` AND `activityLog` from
+  // chainedOptions onto the RunnerDeps so runYamlRecipe gets the
+  // bridge's singletons too. The activityLog is what powers
+  // recipe_started / recipe_step_start / recipe_step_done /
+  // recipe_done SSE emission to dashboard subscribers.
+  const lifted: RunnerDeps = { ...deps };
+  if (deps.chainedOptions?.runLog) lifted.runLog = deps.chainedOptions.runLog;
+  if (deps.chainedOptions?.activityLog)
+    lifted.activityLog = deps.chainedOptions.activityLog;
+  return runYamlRecipe(recipe, lifted, seedContext);
 }
 
 /** List all YAML recipes in a directory. Returns names. */


### PR DESCRIPTION
## Summary

PR #3 of the dashboard polish stack — consumes the recipe lifecycle SSE events from #642 to surface live run progress directly on /recipes.

- New \`useRecipeRunStream\` hook: subscribes to \`/api/bridge/stream\`, aggregates \`recipe_started\` / \`recipe_step_start\` / \`recipe_step_done\` / \`recipe_done\` events keyed by recipe name, holds terminal state 30s before GC.
- New \`RecipeRunInline\` component with three density levels:
  - **chip** — \`[Step 2/5] 3s\` pill on the list row when a run is live
  - **strip** — progress bar + current tool + \"open run →\" link in the detail panel
  - **outcome** — terminal halt-reason / error card (terminal states reuse strip)
- Detail panel: replaces the static \`StatusPill\` for \`running[name]\` with the live strip; falls back to the old pill for queued/error pre-SSE states.

## Mobile

- chip + strip use \`flex-wrap\` so they reflow at narrow widths
- \"open run →\" link is 28pt min-height (tap-friendly)
- progress bar transitions at 250ms — visible without being distracting

## Test plan

- [ ] Trigger a recipe with multiple steps; chip should appear in list row with step counter incrementing
- [ ] Open detail panel mid-run; progress bar fills, current tool shown
- [ ] On halt: halt reason surfaces in strip; terminal state holds 30s then drops
- [ ] On success: \"Done\" + duration; terminal hold then GC

Stacks on #642. Will retarget to main once #642 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)