### PR TITLE
feat(dashboard): render kill-switch banner site-wide via Shell

### DIFF
--- a/dashboard/src/app/page.tsx
+++ b/dashboard/src/app/page.tsx
@@ -8,7 +8,6 @@ import { SkeletonStatCard } from "@/components/Skeleton";
 import { relTime } from "@/components/time";
 import { useBridgeFetch } from "@/hooks/useBridgeFetch";
 import { useBridgeStatus } from "@/hooks/useBridgeStatus";
-import { KillSwitchBanner } from "@/components/KillSwitchBanner";
 import { isNoiseEvent } from "@/lib/activityNoise";
 import { isHaltStatus } from "@/lib/runStatus";
 import {
@@ -929,12 +928,7 @@ export default function HomePage() {
 
   return (
     <section>
-      {bridgeStatus.killSwitch?.engaged && (
-        <KillSwitchBanner
-          engaged={bridgeStatus.killSwitch.engaged}
-          locked={bridgeStatus.killSwitch.locked}
-        />
-      )}
+      {/* Kill-switch banner rendered globally by Shell — was duplicated here. */}
       {/*
         First-run checklist: orchestrates the 4-step happy path for
         brand-new workspaces (connect → install recipe → run → approve).

--- a/dashboard/src/components/Shell.tsx
+++ b/dashboard/src/components/Shell.tsx
@@ -12,6 +12,7 @@ import { getHaltsLookbackMs, subscribeHaltsSeen } from "@/lib/haltsSeen";
 import { NAV_SECTIONS } from "@/lib/navRoutes";
 import { ActivityTicker } from "./ActivityTicker";
 import { BridgeOfflineBanner } from "./BridgeOfflineBanner";
+import { KillSwitchBanner } from "./KillSwitchBanner";
 import { CardGlow } from "./CardGlow";
 import { CommandPalette } from "./CommandPalette";
 
@@ -582,6 +583,12 @@ export function Shell({ children }: { children: ReactNode }) {
 
       <main id="main-content" className="app-main" tabIndex={-1}>
         <BridgeOfflineBanner status={status} />
+        {status.killSwitch?.engaged && (
+          <KillSwitchBanner
+            engaged={status.killSwitch.engaged}
+            locked={status.killSwitch.locked}
+          />
+        )}
         <div className="app-content">{children}</div>
       </main>
       <CommandPalette open={paletteOpen} onClose={() => setPaletteOpen(false)} />


### PR DESCRIPTION
## Summary

The \`KillSwitchBanner\` was only rendered on the home page. When writes are blocked, the operator is likely on \`/recipes\`, \`/runs\`, or \`/approvals\` trying to act — and they currently see opaque \"blocked\" errors with no indication why.

Moves the banner into \`Shell\` so it sits at the top of \`<main>\` on every route. Removes the duplicate render + import from \`app/page.tsx\`.

No new state — reuses the existing \`useBridgeStatus().killSwitch\` already polled by Shell.

## Test plan

- [ ] Engage kill-switch from /settings; navigate to /recipes, /runs, /activity, /traces — banner visible on each
- [ ] Release from banner; disappears on all pages
- [ ] Home page no longer renders duplicate banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)