### PR TITLE
feat(dashboard): PWA install prompt via beforeinstallprompt

### DIFF
--- a/dashboard/src/components/PWAInstallPrompt.tsx
+++ b/dashboard/src/components/PWAInstallPrompt.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+// `beforeinstallprompt` is a non-standard but widely-supported event on
+// Chromium browsers (Chrome, Edge, Brave, Android Chrome). Safari doesn't
+// fire it — iOS users still install via Share → Add to Home Screen, and
+// Safari hides the prompt entirely. We feature-detect and no-op elsewhere.
+interface BeforeInstallPromptEvent extends Event {
+	readonly platforms: string[];
+	prompt(): Promise<void>;
+	readonly userChoice: Promise<{ outcome: "accepted" | "dismissed" }>;
+}
+
+const DISMISSED_KEY = "patchwork:pwa-install-dismissed";
+
+function isStandalone(): boolean {
+	if (typeof window === "undefined") return false;
+	// iOS Safari uses navigator.standalone; Chromium uses display-mode.
+	if (window.matchMedia("(display-mode: standalone)").matches) return true;
+	const nav = window.navigator as Navigator & { standalone?: boolean };
+	return nav.standalone === true;
+}
+
+function wasDismissed(): boolean {
+	if (typeof window === "undefined") return false;
+	try {
+		return window.localStorage.getItem(DISMISSED_KEY) === "1";
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * One-time "Install Patchwork" prompt for Chromium browsers. Surfaces
+ * the native `beforeinstallprompt` event as a small bottom-anchored
+ * bar — install or dismiss-forever. No-ops on iOS Safari (event
+ * unavailable; iOS install path is the Share menu).
+ *
+ * Persists dismissal in localStorage so we don't re-prompt on every
+ * page load.
+ */
+export function PWAInstallPrompt() {
+	const [deferred, setDeferred] = useState<BeforeInstallPromptEvent | null>(null);
+	const [visible, setVisible] = useState(false);
+
+	useEffect(() => {
+		if (isStandalone() || wasDismissed()) return;
+		const onPrompt = (e: Event) => {
+			e.preventDefault();
+			setDeferred(e as BeforeInstallPromptEvent);
+			setVisible(true);
+		};
+		const onInstalled = () => {
+			setVisible(false);
+			setDeferred(null);
+		};
+		window.addEventListener("beforeinstallprompt", onPrompt);
+		window.addEventListener("appinstalled", onInstalled);
+		return () => {
+			window.removeEventListener("beforeinstallprompt", onPrompt);
+			window.removeEventListener("appinstalled", onInstalled);
+		};
+	}, []);
+
+	if (!visible || !deferred) return null;
+
+	const onInstall = async () => {
+		try {
+			await deferred.prompt();
+			await deferred.userChoice; // resolves once user picks
+		} catch {
+			// browser refused — fail silent
+		} finally {
+			setVisible(false);
+			setDeferred(null);
+		}
+	};
+
+	const onDismiss = () => {
+		try {
+			window.localStorage.setItem(DISMISSED_KEY, "1");
+		} catch {
+			/* private mode */
+		}
+		setVisible(false);
+		setDeferred(null);
+	};
+
+	return (
+		<div
+			role="dialog"
+			aria-label="Install Patchwork as an app"
+			style={{
+				position: "fixed",
+				left: 12,
+				right: 12,
+				bottom: 12,
+				zIndex: 100,
+				padding: "10px 14px",
+				background: "var(--bg-1)",
+				border: "1px solid var(--line-2)",
+				borderRadius: 10,
+				boxShadow: "0 4px 16px rgba(0,0,0,0.18)",
+				display: "flex",
+				alignItems: "center",
+				gap: 10,
+				flexWrap: "wrap",
+				maxWidth: 480,
+				margin: "0 auto",
+			}}
+		>
+			<span style={{ fontSize: "var(--fs-s)", flex: 1, minWidth: 180 }}>
+				Install Patchwork as an app for faster access + push notifications.
+			</span>
+			<button
+				type="button"
+				onClick={onDismiss}
+				className="btn sm ghost"
+				style={{ minHeight: 32 }}
+			>
+				Not now
+			</button>
+			<button
+				type="button"
+				onClick={onInstall}
+				className="btn sm primary"
+				style={{ minHeight: 32 }}
+			>
+				Install
+			</button>
+		</div>
+	);
+}

--- a/dashboard/src/components/Shell.tsx
+++ b/dashboard/src/components/Shell.tsx
@@ -13,6 +13,7 @@ import { NAV_SECTIONS } from "@/lib/navRoutes";
 import { ActivityTicker } from "./ActivityTicker";
 import { BridgeOfflineBanner } from "./BridgeOfflineBanner";
 import { KillSwitchBanner } from "./KillSwitchBanner";
+import { PWAInstallPrompt } from "./PWAInstallPrompt";
 import { CardGlow } from "./CardGlow";
 import { CommandPalette } from "./CommandPalette";
 
@@ -592,6 +593,7 @@ export function Shell({ children }: { children: ReactNode }) {
         <div className="app-content">{children}</div>
       </main>
       <CommandPalette open={paletteOpen} onClose={() => setPaletteOpen(false)} />
+      <PWAInstallPrompt />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Manifest + icons were already wired (\`start_url: /dashboard/approvals\`, \`display: standalone\`), but the install affordance has been invisible — Chromium only surfaces it when the page handles \`beforeinstallprompt\`.

Adds a small bottom-anchored prompt that:
- Captures \`beforeinstallprompt\` and triggers the native install dialog
- Persists \"Not now\" in localStorage — no re-prompt loops
- No-ops when already standalone or previously dismissed
- No-ops on iOS Safari (event unavailable; iOS users install via Share → Add to Home Screen)

## Mobile

- 32pt min-height buttons
- \`flex-wrap\` + \`max-width: 480\` + auto-center so it doesn't span tablet/desktop viewports
- 12px insets — clears iOS bottom nav and Android system bar

## Test plan

- [ ] Open dashboard in Chrome (desktop or Android) — prompt appears after engagement criteria met
- [ ] Click Install — native picker opens; on accept, app installs
- [ ] Click Not now — prompt disappears; reload doesn't re-show
- [ ] Open in iOS Safari — no prompt (correct)
- [ ] Open already-installed PWA — no prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)