### PR TITLE
fix(readme): npm version badge tracks @beta tag, not @latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Patchwork OS
 
-[![npm version](https://img.shields.io/npm/v/patchwork-os.svg)](https://www.npmjs.com/package/patchwork-os)
+[![npm beta](https://img.shields.io/npm/v/patchwork-os/beta.svg?label=npm%20%40beta)](https://www.npmjs.com/package/patchwork-os)
 [![license](https://img.shields.io/npm/l/patchwork-os.svg)](LICENSE)
 
 ### Your personal AI runtime, local-first.


### PR DESCRIPTION
## Summary

The shields.io \`npm/v/patchwork-os\` badge defaults to the \`latest\` dist-tag, which on npm is currently pinned to **0.2.0-beta.0** (the first beta, never moved). Every install command in the README uses \`patchwork-os@beta\` → currently **0.2.0-beta.5**. The badge has been five betas stale.

Switch the URL to \`/npm/v/patchwork-os/beta\` so it tracks the tag we actually point users to. Label \`npm @beta\` makes the channel explicit.

Current dist-tags on npm for reference:
- \`latest\`: 0.2.0-beta.0
- \`beta\`: 0.2.0-beta.5
- \`canary\`: 0.2.0-beta.5.canary.32
- \`alpha\`: 0.2.0-alpha.37
- \`next\`: 0.2.0-alpha.32

## Test plan

- [ ] Verify badge URL resolves to a valid SVG showing 0.2.0-beta.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)