### PR TITLE
feat(dashboard/recipes): Escape closes the detail panel

### DIFF
--- a/dashboard/src/app/recipes/page.tsx
+++ b/dashboard/src/app/recipes/page.tsx
@@ -607,6 +607,24 @@ export default function RecipesPage() {
   // already open instead of getting a silent 400 for missing vars.
   const searchParams = useSearchParams();
   const router = useRouter();
+
+  // Escape closes the detail panel (when no modal is open — modal owns
+  // its own Escape handling via Dialog). Skipped while typing in an
+  // input so it doesn't fight the browser's clear-search behavior.
+  useEffect(() => {
+    if (!selectedName) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== "Escape" || modal) return;
+      const t = e.target as HTMLElement | null;
+      if (t) {
+        const tag = t.tagName;
+        if (tag === "INPUT" || tag === "TEXTAREA" || t.isContentEditable) return;
+      }
+      setSelectedName(null);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [selectedName, modal]);
   const deepLinkConsumedRef = useRef(false);
 
   const load = React.useCallback(async () => {


### PR DESCRIPTION
## Summary

Detail panel had no keyboard close — × button or re-click on the row only. Escape now closes it.

- Only listens while panel is open
- Yields to RunModal's own Dialog Escape so modal closes first if both open
- Skipped while focused in an input/textarea/contenteditable

## Test plan

- [ ] Select recipe → press Escape → panel closes
- [ ] Open Run modal → press Escape → only modal closes; panel stays
- [ ] Focus search → press Escape → browser clears search; panel stays

🤖 Generated with [Claude Code](https://claude.com/claude-code)