### PR TITLE
feat(dashboard): "/" search hotkey on /tasks + /inbox

### DIFF
--- a/dashboard/src/app/inbox/page.tsx
+++ b/dashboard/src/app/inbox/page.tsx
@@ -6,6 +6,7 @@ import { apiPath } from "@/lib/api";
 import { EmptyState, HintCard } from "@/components/patchwork";
 import { InboxDeliveryCard } from "@/components/InboxDeliveryCard";
 import { useToast } from "@/components/Toast";
+import { useSearchHotkey } from "@/hooks/useSearchHotkey";
 
 function isFilterCategory(v: string | null): v is FilterCategory {
   return v === "All" || v === "Morning Briefs" || v === "Recipe Outputs" || v === "Agent Reports";
@@ -388,6 +389,7 @@ export default function InboxPage() {
   const [detailLoading, setDetailLoading] = useState(false);
   const [err, setErr] = useState<string | undefined>();
   const [sidebarOpen, setSidebarOpen] = useState(true);
+  const searchInputRef = useSearchHotkey();
   const router = useRouter();
   const searchParams = useSearchParams();
   const filterFromUrl = searchParams?.get("filter");
@@ -724,12 +726,13 @@ const filteredItems = items.filter((item) => {
                   {/* Search */}
                   <div style={{ padding: "10px 12px 8px" }}>
                     <input
+                      ref={searchInputRef}
                       type="search"
                       className="input"
-                      placeholder="Search…"
+                      placeholder="Search… ( / )"
                       value={search}
                       onChange={(e) => setSearch(e.target.value)}
-                      aria-label="Search inbox"
+                      aria-label="Search inbox (shortcut: /)"
                       style={{ width: "100%", fontSize: "var(--fs-s)" }}
                     />
                   </div>

--- a/dashboard/src/app/tasks/page.tsx
+++ b/dashboard/src/app/tasks/page.tsx
@@ -6,6 +6,7 @@ import { SkeletonList } from "@/components/Skeleton";
 import { EmptyState, ErrorState, RelationStrip } from "@/components/patchwork";
 import { ActivityTabs } from "@/components/ActivityTabs";
 import { useToast } from "@/components/Toast";
+import { useSearchHotkey } from "@/hooks/useSearchHotkey";
 
 interface Task {
   taskId: string;
@@ -290,6 +291,7 @@ export default function TasksPage() {
   const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
   const [search, setSearch] = useState("");
   const [statusFilter, setStatusFilter] = useState<"all" | "live" | "done" | "error">("all");
+  const searchInputRef = useSearchHotkey();
 
   const refetchRef = useRef<() => void>(() => {});
 
@@ -472,13 +474,14 @@ export default function TasksPage() {
           }}
         >
           <input
+            ref={searchInputRef}
             type="search"
             value={search}
             onChange={(e) => setSearch(e.target.value)}
-            placeholder="Search id, session, driver, output…"
+            placeholder="Search id, session, driver, output… ( / )"
             className="input"
             style={{ flex: "1 1 280px", maxWidth: 360, fontSize: "var(--fs-m)" }}
-            aria-label="Filter tasks"
+            aria-label="Filter tasks (shortcut: /)"
           />
           <div style={{ display: "flex", gap: 4 }} role="group" aria-label="Status filter">
             {([

--- a/dashboard/src/hooks/useSearchHotkey.ts
+++ b/dashboard/src/hooks/useSearchHotkey.ts
@@ -1,0 +1,31 @@
+"use client";
+import { useEffect, useRef } from "react";
+
+/**
+ * GitHub-style "/" hotkey that focuses the bound search input.
+ *
+ * Returns a ref to attach to the target input. While focused in another
+ * input/textarea/contenteditable, or when Cmd/Ctrl/Alt are held, the key
+ * is ignored — normal typing isn't hijacked and browser shortcuts still
+ * fire.
+ */
+export function useSearchHotkey(): React.MutableRefObject<HTMLInputElement | null> {
+	const ref = useRef<HTMLInputElement | null>(null);
+	useEffect(() => {
+		const onKey = (e: KeyboardEvent) => {
+			if (e.key !== "/" || e.metaKey || e.ctrlKey || e.altKey) return;
+			const t = e.target as HTMLElement | null;
+			if (t) {
+				const tag = t.tagName;
+				if (tag === "INPUT" || tag === "TEXTAREA" || t.isContentEditable) return;
+			}
+			if (!ref.current) return;
+			e.preventDefault();
+			ref.current.focus();
+			ref.current.select();
+		};
+		window.addEventListener("keydown", onKey);
+		return () => window.removeEventListener("keydown", onKey);
+	}, []);
+	return ref;
+}


### PR DESCRIPTION
## Summary

Extracts the GitHub-style \`/\` hotkey from /recipes (#650) into a reusable \`useSearchHotkey\` hook and applies it to /tasks and /inbox.

- Hook ignores the key while focused in another input/textarea/contenteditable, and on Cmd/Ctrl/Alt
- Placeholders show \"( / )\" hint; aria-labels mention the shortcut
- /recipes will be consolidated onto the shared hook in a follow-up to avoid conflict with #650

## Test plan

- [ ] /tasks: press / → search focuses
- [ ] /inbox: press / → search focuses (sidebar must be open)
- [ ] Both: typing / in a textarea inserts literally

🤖 Generated with [Claude Code](https://claude.com/claude-code)