### PR TITLE
feat(mobile-nav): surface halt count badge on "More" button

### DIFF
--- a/dashboard/src/components/MobileBottomNav.tsx
+++ b/dashboard/src/components/MobileBottomNav.tsx
@@ -142,7 +142,7 @@ export function MobileBottomNav() {
                 borderRadius: 8,
                 background: "var(--err)",
                 color: "#fff",
-                fontSize: 10,
+                fontSize: "var(--fs-2xs)",
                 fontWeight: 700,
                 lineHeight: "16px",
                 textAlign: "center",

--- a/dashboard/src/components/MobileBottomNav.tsx
+++ b/dashboard/src/components/MobileBottomNav.tsx
@@ -4,6 +4,7 @@ import { usePathname } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 import { useFocusTrap } from "@/lib/useFocusTrap";
 import { MOBILE_PRIMARY_HREFS, findRoute, moreRoutes } from "@/lib/navRoutes";
+import { useHaltCount } from "./Shell";
 
 interface BottomNavItem {
   href: string;
@@ -68,6 +69,10 @@ export function MobileBottomNav() {
   });
 
   const moreActive = MORE_LINKS.some((l) => pathname.startsWith(l.href));
+  // Surface halt count on the More button — the /activity route lives
+  // under More on mobile, so without this the badge is invisible
+  // exactly when oncall needs it.
+  const haltCount = useHaltCount();
 
   return (
     <>
@@ -106,6 +111,8 @@ export function MobileBottomNav() {
           onClick={() => setSheetOpen((v) => !v)}
           aria-expanded={sheetOpen}
           aria-controls="mobile-more-sheet"
+          aria-label={haltCount > 0 ? `More (${haltCount} halt${haltCount === 1 ? "" : "s"})` : "More"}
+          style={{ position: "relative" }}
         >
           <svg
             width="20"
@@ -121,6 +128,30 @@ export function MobileBottomNav() {
             <path d={MORE_ICON} />
           </svg>
           <span>More</span>
+          {haltCount > 0 && (
+            <span
+              aria-hidden="true"
+              title={`${haltCount} recent halt${haltCount === 1 ? "" : "s"}`}
+              style={{
+                position: "absolute",
+                top: 4,
+                right: "calc(50% - 16px)",
+                minWidth: 16,
+                height: 16,
+                padding: "0 4px",
+                borderRadius: 8,
+                background: "var(--err)",
+                color: "#fff",
+                fontSize: 10,
+                fontWeight: 700,
+                lineHeight: "16px",
+                textAlign: "center",
+                pointerEvents: "none",
+              }}
+            >
+              {haltCount > 9 ? "9+" : haltCount}
+            </span>
+          )}
         </button>
       </nav>
 

--- a/dashboard/src/components/Shell.tsx
+++ b/dashboard/src/components/Shell.tsx
@@ -180,7 +180,7 @@ function useApprovalCount(): number {
  * Re-fetches immediately on `markHaltsSeen()` so the badge clears on
  * visit instead of waiting for the next 60s tick.
  */
-function useHaltCount(): number {
+export function useHaltCount(): number {
   const [count, setCount] = useState(0);
   useEffect(() => {
     let alive = true;


### PR DESCRIPTION
## Summary

\`/activity\` carries the \"halts\" badge on desktop, but on mobile it lives under the \"More\" sheet — so the badge was invisible exactly when on-call would want one-tap access to triage.

Reads halt count via \`useHaltCount\` (now re-exported from Shell) and renders a small red dot with the count on the More button when > 0. \`aria-label\` updates to \"More (N halts)\".

## Test plan

- [ ] Simulate halts (or force a non-zero halt-summary response) → red dot with count appears on More
- [ ] Acknowledge halts → dot disappears within 60s (poll period)
- [ ] AT user hears \"More, 3 halts\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)