### PR TITLE
feat(approvals): redact secret-shaped param values from display

### DIFF
--- a/dashboard/src/app/approvals/page.tsx
+++ b/dashboard/src/app/approvals/page.tsx
@@ -1466,9 +1466,37 @@ function ruleClass(kind: "deny" | "ask" | "allow"): string {
   return kind === "deny" ? "err" : kind === "ask" ? "warn" : "ok";
 }
 
+/**
+ * Keys matched here (case-insensitive, substring) have their values
+ * redacted to "***" when serialised for display. Audit caught that
+ * tool params (e.g. `runHttpRequest` with an Authorization header,
+ * connector configs) were rendered verbatim — anyone shoulder-surfing
+ * an approval card could read out a live bearer token.
+ *
+ * Conservative: a key has to look secret-shaped. Adding noise (e.g. an
+ * api `key` field that's just a category id) is far less bad than
+ * leaking a real secret.
+ */
+const REDACT_KEY_PATTERN = /(token|secret|password|api[_-]?key|auth(orization)?|bearer|cookie|session[_-]?id|private[_-]?key)/i;
+
+function redactValue(v: unknown): unknown {
+  if (v === null || v === undefined) return v;
+  if (typeof v !== "object") return v;
+  if (Array.isArray(v)) return v.map(redactValue);
+  const out: Record<string, unknown> = {};
+  for (const [k, val] of Object.entries(v as Record<string, unknown>)) {
+    if (REDACT_KEY_PATTERN.test(k) && typeof val === "string" && val.length > 0) {
+      out[k] = "***";
+    } else {
+      out[k] = redactValue(val);
+    }
+  }
+  return out;
+}
+
 function safeStringify(v: unknown): string {
   try {
-    return JSON.stringify(v, null, 2);
+    return JSON.stringify(redactValue(v), null, 2);
   } catch {
     return String(v);
   }


### PR DESCRIPTION
## Summary

Tool params on approval cards were JSON-stringified verbatim — anyone shoulder-surfing could read out live bearer tokens, API keys, session ids etc. from \`runHttpRequest\` / connector-config approvals.

Walks the params object and redacts string values to \`\"***\"\` when the key matches:

\`\`\`
/(token|secret|password|api[_-]?key|auth(orization)?|bearer|cookie|session[_-]?id|private[_-]?key)/i
\`\`\`

Case-insensitive substring match. Conservative by design — a key has to look secret-shaped. False positive (an \"api key\" that's a category id) is much less bad than a false negative.

Applies to both the expanded card body and the \"copy params\" button so copying a redacted blob avoids accidental paste of a real secret into Slack/issue tracker.

Display-only: bridge keeps the real params for the actual tool call; approval flow only signals approve/reject via callId.

## Test plan

- [ ] Approval card with \`{Authorization: \"Bearer abc123\"}\` → renders \`***\`
- [ ] \`{api_key, apiKey, API-KEY, secretToken}\` all redacted
- [ ] \`{recipient, message}\` rendered verbatim
- [ ] Nested: \`{headers: {Authorization: \"…\"}}\` → redacted in nested object
- [ ] Copy params → clipboard contains redacted JSON, not real secret

🤖 Generated with [Claude Code](https://claude.com/claude-code)