### PR TITLE
feat(approvals): collect rejection reason for high-tier denials

### DIFF
--- a/dashboard/src/app/approvals/page.tsx
+++ b/dashboard/src/app/approvals/page.tsx
@@ -121,7 +121,11 @@ interface ApprovalCardProps {
   rules: CcRules | null;
   isExpanded: boolean;
   onToggleExpand: (callId: string) => void;
-  onDecide: (callId: string, decision: "approve" | "reject") => Promise<void>;
+  onDecide: (
+    callId: string,
+    decision: "approve" | "reject",
+    reason?: string,
+  ) => Promise<void>;
   isSelected: boolean;
   onToggleSelect: (callId: string) => void;
   fadingOut: boolean;
@@ -189,10 +193,22 @@ function ApprovalCard({
       );
       if (!proceed) return;
     }
+    // Collect a rejection reason for high-tier denials so the audit log
+    // has provenance for "why was this blocked?" investigations. Empty
+    // string cancels (matches window.prompt's null-on-cancel semantics).
+    let reason: string | undefined;
+    if (decision === "reject" && p.tier === "high") {
+      const entered = window.prompt(
+        `Why are you rejecting ${p.toolName}? (logged for audit; max 500 chars)`,
+        "",
+      );
+      if (entered === null) return; // user hit cancel
+      reason = entered.trim() || undefined;
+    }
     if (decision === "approve") setApproving(true);
     else setRejecting(true);
     try {
-      await onDecide(p.callId, decision);
+      await onDecide(p.callId, decision, reason);
     } catch (e) {
       toast.error(
         `${decision === "approve" ? "Approve" : "Reject"} failed: ${e instanceof Error ? e.message : String(e)}`,
@@ -719,8 +735,17 @@ function ApprovalsContent() {
     fadeTimersRef.current.add(timer);
   }
 
-  async function decide(callId: string, decision: "approve" | "reject") {
-    const res = await fetch(`${API}/${decision}/${callId}`, { method: "POST" });
+  async function decide(
+    callId: string,
+    decision: "approve" | "reject",
+    reason?: string,
+  ) {
+    const init: RequestInit = { method: "POST" };
+    if (reason && reason.trim().length > 0) {
+      init.headers = { "Content-Type": "application/json" };
+      init.body = JSON.stringify({ reason: reason.trim().slice(0, 500) });
+    }
+    const res = await fetch(`${API}/${decision}/${callId}`, init);
     if (!res.ok) {
       const text = await res.text().catch(() => res.statusText);
       throw new Error(`${decision} failed: ${text || res.status}`);
@@ -855,9 +880,18 @@ function ApprovalsContent() {
           );
           if (!proceed) return;
         }
+        let kbdReason: string | undefined;
+        if (choice === "reject" && target.tier === "high") {
+          const entered = window.prompt(
+            `Why are you rejecting ${target.toolName}? (logged for audit; max 500 chars)`,
+            "",
+          );
+          if (entered === null) return;
+          kbdReason = entered.trim() || undefined;
+        }
         inFlightRef.current.add(target.callId);
         setKbdInFlight((prev) => ({ ...prev, [target.callId]: choice }));
-        decide(target.callId, choice)
+        decide(target.callId, choice, kbdReason)
           .then(() => setAnnouncement(`${verb} ${target.toolName}`))
           .catch((err: unknown) =>
             setAnnouncement(

--- a/src/approvalHttp.ts
+++ b/src/approvalHttp.ts
@@ -263,8 +263,22 @@ export async function routeApprovalRequest(
         };
       }
     }
+    // Optional rejection reason — surfaced on the audit decision event so
+    // operators have provenance for high-tier denials. Capped at 500 chars
+    // and trimmed; non-strings or empties drop to undefined.
+    let reason: string | undefined;
+    const raw = (req.body as Record<string, unknown> | undefined)?.reason;
+    if (typeof raw === "string") {
+      const trimmed = raw.trim().slice(0, 500);
+      if (trimmed.length > 0) reason = trimmed;
+    }
     const ok = deps.queue.reject(callId);
     if (ok) {
+      deps.onDecision?.("approval_decision", {
+        callId,
+        decision: "deny",
+        ...(reason !== undefined && { reason }),
+      });
       return { status: 200, body: { decision: "deny", callId } };
     }
     const prior = deps.queue.getRecentDecision(callId);


### PR DESCRIPTION
## Summary

Audit gap: rejecting a high-tier tool call was a single click with no required justification — even for destructive Bash, raw HTTP writes, etc. Incident investigations had no provenance.

**Dashboard** (\`approvals/page.tsx\`):
- \`handleDecide\` + keyboard X paths prompt via \`window.prompt\` when \`p.tier === \"high\"\`. Cancel returns \`null\` → no POST.
- \`decide()\` forwards the reason as a JSON body on \`POST /reject/:id\`.

**Bridge** (\`src/approvalHttp.ts\`):
- \`/reject\` route extracts optional \`body.reason\` (trim + 500-char cap), passes it on \`onDecision\` meta as \`reason\`. The existing \`approval_decision\` audit-log schema already carries \`reason\` for auto-decisions, so this surfaces without new fields.
- Body parsing was already wired (32 KB \`APPROVALS_BODY_CAP\` in server.ts); change is just reading \`body.reason\`.

Low-tier rejects are unchanged — one-click stays the default to avoid prompt fatigue. Tier-policy server-side enforcement (\`reasonRequired\` policy header) is a follow-up.

## Test plan

- [ ] Reject a high-tier item via mouse → prompt appears; submit reason → POST body contains \`{reason: \"...\"}\`
- [ ] Cancel prompt → no POST, card stays
- [ ] Reject low-tier → no prompt, immediate POST
- [ ] Keyboard X on focused high-tier → prompt; submit → reject + audit row carries reason
- [ ] Bridge \`approval_decision\` audit event includes \`reason\` field
- [ ] Existing 55 approvalHttp tests pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)