### PR TITLE
feat(recipes): mobile sticky Run bar when a recipe is selected

### DIFF
--- a/dashboard/src/app/globals.css
+++ b/dashboard/src/app/globals.css
@@ -3036,6 +3036,33 @@ button.topbar-search {
   }
 }
 
+/* Mobile-only sticky Run bar — gives a guaranteed-visible 44pt
+   primary action while the desktop inline Run button stays cramped
+   in a horizontally-scrolling table on phones. */
+.recipes-mobile-run-bar {
+  display: none;
+}
+@media (max-width: 768px) {
+  .recipes-mobile-run-bar {
+    position: fixed;
+    left: 0;
+    right: 0;
+    bottom: calc(var(--bottom-nav-h, 62px) + env(safe-area-inset-bottom, 0px));
+    z-index: 27;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 8px 12px;
+    background: var(--surface);
+    border-top: 1px solid var(--line-2);
+    box-shadow: 0 -2px 12px rgba(0, 0, 0, 0.08);
+  }
+  /* Pad bottom of recipes content so the bar never overlaps the last row. */
+  .recipes-grid {
+    padding-bottom: 70px;
+  }
+}
+
 /* ---- Mobile bottom nav --------------------------------------------- */
 .cmdk-backdrop {
   position: fixed;

--- a/dashboard/src/app/recipes/page.tsx
+++ b/dashboard/src/app/recipes/page.tsx
@@ -584,6 +584,74 @@ function RecipeDetailPanel({
   );
 }
 
+/**
+ * Sticky run bar shown on mobile (≤ 768px) when a recipe is selected.
+ * The inline row Run button is hidden in a horizontally-scrolling 7-column
+ * table on phones; this bar gives a guaranteed-visible 44pt-tall primary
+ * action without forcing the detail panel into a full-screen sheet.
+ *
+ * Sits above the MobileBottomNav (z 27 vs nav's 28) so the nav stays on
+ * top of taps that miss the bar. CSS class `.recipes-mobile-run-bar` is
+ * display:none on desktop via @media.
+ */
+function MobileRunBar({
+  recipe,
+  onRun,
+  onClose,
+  disabled,
+}: {
+  recipe: Recipe;
+  onRun: () => void;
+  onClose: () => void;
+  disabled: boolean;
+}) {
+  return (
+    <div className="recipes-mobile-run-bar" role="region" aria-label="Selected recipe quick actions">
+      <button
+        type="button"
+        onClick={onClose}
+        aria-label="Deselect recipe"
+        style={{
+          background: "transparent",
+          border: "1px solid var(--line-2)",
+          borderRadius: 6,
+          minWidth: 36,
+          minHeight: 36,
+          cursor: "pointer",
+          color: "var(--ink-3)",
+        }}
+      >
+        ×
+      </button>
+      <div
+        style={{
+          flex: 1,
+          minWidth: 0,
+          fontFamily: "var(--font-mono)",
+          fontWeight: 600,
+          fontSize: "var(--fs-s)",
+          overflow: "hidden",
+          textOverflow: "ellipsis",
+          whiteSpace: "nowrap",
+        }}
+        title={recipe.name}
+      >
+        {recipe.name}
+      </div>
+      <button
+        type="button"
+        className="btn primary"
+        onClick={onRun}
+        disabled={disabled}
+        style={{ minHeight: 44, paddingInline: 16, fontWeight: 600 }}
+        aria-label={`Run ${recipe.name}`}
+      >
+        ▶ Run{recipe.vars && recipe.vars.length > 0 ? "…" : ""}
+      </button>
+    </div>
+  );
+}
+
 export default function RecipesPage() {
   const [recipes, setRecipes] = useState<Recipe[] | null>(null);
   const [runMap, setRunMap] = useState<Map<string, RunRecord>>(new Map());
@@ -1367,6 +1435,14 @@ export default function RecipesPage() {
             />
           )}
         </div>
+      )}
+      {selectedRecipe && (
+        <MobileRunBar
+          recipe={selectedRecipe}
+          onRun={() => handleRunClick(selectedRecipe)}
+          onClose={() => setSelectedName(null)}
+          disabled={selectedRecipe.enabled === false}
+        />
       )}
 
       {recipes && recipes.length > 0 && (


### PR DESCRIPTION
## Summary

The inline row Run button is 8px-font inside a 7-column horizontally-scrolling table on phones — primary action effectively invisible on ~390px viewports. P1 from the dashboard audit.

Adds a sticky bottom bar (≤ 768px only) that appears when a recipe is selected, containing:
- × close (deselects, returns to list)
- recipe name (truncated to fit)
- **44pt-tall \"▶ Run\" button** (full primary, ellipsis if vars exist)

## Implementation

- Sits at z 27, above content but **below** \`.mobile-bottom-nav\` (z 28), with \`bottom\` offset computed from \`--bottom-nav-h\` + \`env(safe-area-inset-bottom, 0px)\`.
- \`.recipes-grid\` gets 70px bottom padding so the last row never sits under the bar.
- Reuses existing \`handleRunClick\` → modal opens for var-bearing recipes, one-tap after the session confirm gate otherwise. No new modal infra.

## Test plan

- [ ] Mobile (≤ 768px): select a recipe → sticky bar appears with Run button at thumb level
- [ ] Tap × → recipe deselects, bar disappears
- [ ] Tap Run → run flow (modal for var-bearing, immediate for confirmed-session)
- [ ] Desktop > 768px: bar hidden (display: none)
- [ ] Bar respects safe-area on notched phones
- [ ] Disabled recipes show disabled Run button

🤖 Generated with [Claude Code](https://claude.com/claude-code)