### PR TITLE
feat(recipes): surface cron schedule expression in trigger column

### DIFF
--- a/dashboard/src/app/recipes/page.tsx
+++ b/dashboard/src/app/recipes/page.tsx
@@ -121,6 +121,7 @@ interface Recipe {
   source?: string;
   trigger?: string;
   webhookPath?: string;
+  schedule?: string;
   stepCount?: number;
   path?: string;
   enabled?: boolean;
@@ -1324,9 +1325,41 @@ export default function RecipesPage() {
                           )}
                         </td>
                         <td>
-                          <StatusPill tone={triggerTone(r.trigger)}>
-                            {r.trigger ?? "manual"}
-                          </StatusPill>
+                          <div style={{ display: "flex", flexDirection: "column", gap: 2 }}>
+                            <StatusPill tone={triggerTone(r.trigger)}>
+                              {r.trigger ?? "manual"}
+                            </StatusPill>
+                            {r.schedule && (
+                              <span
+                                className="mono muted"
+                                title={`Cron expression: ${r.schedule}`}
+                                style={{
+                                  fontSize: "var(--fs-2xs)",
+                                  whiteSpace: "nowrap",
+                                  overflow: "hidden",
+                                  textOverflow: "ellipsis",
+                                  maxWidth: 140,
+                                }}
+                              >
+                                {r.schedule}
+                              </span>
+                            )}
+                            {r.trigger === "webhook" && r.webhookPath && (
+                              <span
+                                className="mono muted"
+                                title={`Webhook path: ${r.webhookPath}`}
+                                style={{
+                                  fontSize: "var(--fs-2xs)",
+                                  whiteSpace: "nowrap",
+                                  overflow: "hidden",
+                                  textOverflow: "ellipsis",
+                                  maxWidth: 140,
+                                }}
+                              >
+                                {r.webhookPath}
+                              </span>
+                            )}
+                          </div>
                         </td>
                         <td style={{ textAlign: "center" }}>
                           <RunSparkBars

--- a/src/recipesHttp.ts
+++ b/src/recipesHttp.ts
@@ -993,6 +993,8 @@ export interface RecipeSummary {
   trigger?: string;
   /** For webhook triggers, the configured path (e.g. "/github-pr"). */
   webhookPath?: string;
+  /** For cron/schedule triggers, the configured expression (e.g. "0 9 * * *"). */
+  schedule?: string;
   stepCount: number;
   path: string;
   installedAt: number;
@@ -1059,7 +1061,12 @@ export function listInstalledRecipes(
       const parsed = (isYaml ? parseYaml(raw) : JSON.parse(raw)) as {
         name?: string;
         description?: string;
-        trigger?: { type?: string; path?: string };
+        trigger?: {
+          type?: string;
+          path?: string;
+          schedule?: string;
+          cron?: string;
+        };
         steps?: unknown[];
         vars?: Array<{
           name: string;
@@ -1100,11 +1107,22 @@ export function listInstalledRecipes(
         typeof parsed.trigger?.path === "string"
           ? parsed.trigger.path
           : undefined;
+      // Cron/schedule expression for the trigger column. Surfaces `0 9 * * *`
+      // in the UI without forcing a YAML fetch. Either field shape is valid.
+      const schedule =
+        parsed.trigger?.type === "cron" || parsed.trigger?.type === "schedule"
+          ? typeof parsed.trigger?.schedule === "string"
+            ? parsed.trigger.schedule
+            : typeof parsed.trigger?.cron === "string"
+              ? parsed.trigger.cron
+              : undefined
+          : undefined;
       recipes.push({
         name: parsedName,
         description: parsed.description,
         trigger: parsed.trigger?.type,
         ...(webhookPath ? { webhookPath } : {}),
+        ...(schedule ? { schedule } : {}),
         stepCount: Array.isArray(parsed.steps) ? parsed.steps.length : 0,
         path: fullPath,
         installedAt: stat.mtimeMs,
@@ -1147,7 +1165,12 @@ export function listInstalledRecipes(
       const parsed = (isYaml ? parseYaml(raw) : JSON.parse(raw)) as {
         name?: string;
         description?: string;
-        trigger?: { type?: string; path?: string };
+        trigger?: {
+          type?: string;
+          path?: string;
+          schedule?: string;
+          cron?: string;
+        };
         steps?: unknown[];
         vars?: Array<{
           name: string;
@@ -1177,11 +1200,22 @@ export function listInstalledRecipes(
         typeof parsed.trigger?.path === "string"
           ? parsed.trigger.path
           : undefined;
+      // Cron/schedule expression for the trigger column. Surfaces `0 9 * * *`
+      // in the UI without forcing a YAML fetch. Either field shape is valid.
+      const schedule =
+        parsed.trigger?.type === "cron" || parsed.trigger?.type === "schedule"
+          ? typeof parsed.trigger?.schedule === "string"
+            ? parsed.trigger.schedule
+            : typeof parsed.trigger?.cron === "string"
+              ? parsed.trigger.cron
+              : undefined
+          : undefined;
       recipes.push({
         name: parsedName,
         description: parsed.description,
         trigger: parsed.trigger?.type,
         ...(webhookPath ? { webhookPath } : {}),
+        ...(schedule ? { schedule } : {}),
         stepCount: Array.isArray(parsed.steps) ? parsed.steps.length : 0,
         path: entrypointPath,
         installedAt: stat.mtimeMs,


### PR DESCRIPTION
## Summary

Cron-triggered recipes showed only the \"cron\" pill — users had to open the YAML to see if a recipe fires hourly, nightly, or weekly. Audit P1.

Cheaper alternative to a full next-fire computation: surface the expression itself. Adding a real next-fire timestamp would need \`cron-parser\` (new dep) or a hand-rolled tick computer.

## Changes

**Bridge** (\`src/recipesHttp.ts\`):
- Parse \`trigger.schedule\` / \`trigger.cron\` on cron/schedule triggers in \`listInstalledRecipes\`; emit as \`RecipeSummary.schedule\`.
- Applied to both top-level and install-dir parse paths.

**Dashboard** (\`recipes/page.tsx\`):
- \`Recipe.schedule?: string\`.
- Renders under the trigger pill as mono 2xs (\`0 9 * * *\`), full expression in the hover title. Same treatment for webhook paths so the column composition is consistent.

## Test plan

- [ ] Cron recipe → trigger column shows \"cron\" pill + \"0 9 * * *\" line below
- [ ] Hovering the line shows full expression (in case of truncation)
- [ ] Webhook recipe → \"webhook\" pill + path below
- [ ] Manual recipe → just the pill, no extra line
- [ ] Existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)