### PR TITLE
feat(runs): list view subscribes to recipe lifecycle SSE

### DIFF
--- a/dashboard/src/app/runs/page.tsx
+++ b/dashboard/src/app/runs/page.tsx
@@ -8,6 +8,7 @@ import { LivePill } from "@/components/patchwork/LivePill";
 import { ErrorState, RelationStrip } from "@/components/patchwork";
 import { ActivityTabs } from "@/components/ActivityTabs";
 import { useDebounced } from "@/hooks/useDebounced";
+import { useBridgeStream } from "@/hooks/useBridgeStream";
 
 interface AssertionFailure {
   assertion: string;
@@ -270,6 +271,29 @@ export default function RunsPage() {
     };
   }, [trigger, status, debouncedRecipeQuery, limit, attemptFilter]);
 
+  // Live SSE: subscribe to recipe lifecycle events (PR #642) so the list
+  // updates immediately when a run starts/ends, instead of waiting up to
+  // 5 s for the next poll tick. Debounced 500 ms so a burst of step events
+  // from a chained recipe only triggers one reload.
+  const reloadDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const onLifecycle = (type: string, raw: unknown) => {
+    if (type !== "lifecycle") return;
+    const ev = (raw as { event?: string } | undefined)?.event;
+    if (ev !== "recipe_started" && ev !== "recipe_done") return;
+    if (reloadDebounceRef.current) clearTimeout(reloadDebounceRef.current);
+    reloadDebounceRef.current = setTimeout(() => reloadRef.current(), 500);
+  };
+  const { connected: streamConnected } = useBridgeStream(
+    "/api/bridge/stream",
+    onLifecycle,
+  );
+  useEffect(
+    () => () => {
+      if (reloadDebounceRef.current) clearTimeout(reloadDebounceRef.current);
+    },
+    [],
+  );
+
   // PR1c: poll halt-summary independently (cheaper payload, fixed cadence).
   // PR4: window selector feeds the same sinceMs into the summary so the
   // pills always reflect the same window as the displayed run list.
@@ -381,7 +405,10 @@ export default function RunsPage() {
             ]}
           />
         </div>
-        <LivePill label="5s" />
+        <LivePill
+          tone={streamConnected ? "ok" : "muted"}
+          label={streamConnected ? "live" : "5s"}
+        />
       </div>
 
       {haltSummary && haltSummary.total > 0 && (


### PR DESCRIPTION
## Summary

Audit P0: \`/runs\` list view polled every 5 s, while \`/runs/[seq]\` already used \`/api/bridge/stream\`. The \"Live · 5s\" pill was misleading — runs appeared up to 5 s after they started, and a fast recipe could finish before the pill even ticked.

## Changes

- Subscribe to lifecycle events via \`useBridgeStream\` (same hook the detail page uses)
- On \`recipe_started\` / \`recipe_done\` (PR #642), debounce 500 ms then trigger a reload via \`reloadRef\` — a burst of step events from a chained recipe only fires one fetch
- \`LivePill\` flips to \`tone=\"ok\"\` + \`label=\"live\"\` while SSE is connected, falls back to \`muted\" + \"5s\"\` on disconnect — actual liveness, not poll cadence

The 5 s poll stays as a safety net for any event the bridge fails to emit (truncation, hook misconfig, etc.).

## Test plan

- [ ] Trigger a recipe → list updates within ~500 ms (not 5 s)
- [ ] Pill reads \"live\" while bridge SSE is up
- [ ] Stop bridge → pill flips to muted \"5s\" within a few seconds
- [ ] Burst of step events from chained recipe → single reload (debounce)

🤖 Generated with [Claude Code](https://claude.com/claude-code)