### PR TITLE
polish(runs): subtitle reflects window + attempt-id deep-link back

### DIFF
--- a/dashboard/src/app/runs/[seq]/page.tsx
+++ b/dashboard/src/app/runs/[seq]/page.tsx
@@ -1427,7 +1427,26 @@ export default function RunDetailPage() {
               {run.manualRunId && (
                 <div style={{ minWidth: 0 }}>
                   <div style={{ fontSize: "var(--fs-2xs)", color: "var(--fg-2)", marginBottom: 2 }}>ATTEMPT</div>
-                  <CopyableMono value={run.manualRunId} ariaLabel="Copy attempt id" />
+                  <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+                    <CopyableMono value={run.manualRunId} ariaLabel="Copy attempt id" />
+                    <Link
+                      href={`/runs?attempt=${encodeURIComponent(run.manualRunId)}`}
+                      title="Show all runs sharing this attempt id"
+                      style={{
+                        fontSize: "var(--fs-2xs)",
+                        color: "var(--ink-3)",
+                        textDecoration: "none",
+                        border: "1px solid var(--line-2)",
+                        borderRadius: 4,
+                        padding: "2px 6px",
+                        minHeight: 24,
+                        display: "inline-flex",
+                        alignItems: "center",
+                      }}
+                    >
+                      see all →
+                    </Link>
+                  </div>
                 </div>
               )}
             </div>

--- a/dashboard/src/app/runs/page.tsx
+++ b/dashboard/src/app/runs/page.tsx
@@ -394,7 +394,7 @@ export default function RunsPage() {
             Runs — <span className="accent">every patch your agents stitched.</span>
           </h1>
           <div className="editorial-sub">
-            {runs ? `${runs.length} runs` : "— runs"} · last 24h · avg {fmtDur(stats.avgMs)}
+            {runs ? `${runs.length} runs` : "— runs"} · {TIME_WINDOW_LABEL[window].toLowerCase()} · avg {fmtDur(stats.avgMs)}
           </div>
           <RelationStrip
             items={[


### PR DESCRIPTION
## Summary

Two small audit follow-ups:

- **/runs subtitle**: hardcoded \"last 24h\" regardless of selected window. Now reads from \`TIME_WINDOW_LABEL\` so stats line agrees with the filter (\"any time\", \"last hour\", \"since 6pm yesterday\", etc.).
- **/runs/[seq] attempt-id**: adds \"see all →\" link to \`/runs?attempt=<id>\` so users can jump from a resumed attempt back to its siblings without copy-pasting into the URL bar. Composes with the existing \`CopyableMono\` (Copy button still works).

## Test plan

- [ ] Change time window → subtitle updates to match
- [ ] Open a run with manualRunId → \"see all →\" link routes to /runs?attempt=…
- [ ] /runs page receives the attempt param and filters

🤖 Generated with [Claude Code](https://claude.com/claude-code)