### PR TITLE
fix(approvals): keep Approve/Reject in their own row, +44pt min-height

### DIFF
--- a/dashboard/src/app/approvals/page.tsx
+++ b/dashboard/src/app/approvals/page.tsx
@@ -423,11 +423,17 @@ function ApprovalCard({
         </CodeBlock>
       </div>
 
-      <div style={{ display: "flex", alignItems: "center", gap: 8, marginTop: 12, marginLeft: 52, flexWrap: "wrap" }}>
+      {/* Decision cluster kept on its own row so Approve and Reject stay
+          together at all viewport widths. Audit caught that the previous
+          single flex-wrap row could split the destructive button onto
+          a different line from "Edit & approve", increasing fat-finger
+          risk on phones. Secondary actions (copy commands) live below in
+          a separate flex group. */}
+      <div style={{ display: "flex", alignItems: "center", gap: 12, marginTop: 12, marginLeft: 52, flexWrap: "wrap" }}>
         <button
           type="button"
           className="btn primary"
-          style={{ background: "var(--green)", borderColor: "var(--green)", color: "var(--on-accent)", display: "inline-flex", alignItems: "center", gap: 6 }}
+          style={{ background: "var(--green)", borderColor: "var(--green)", color: "var(--on-accent)", display: "inline-flex", alignItems: "center", gap: 6, minHeight: 44 }}
           onClick={() => handleDecide("approve")}
           disabled={isApproving || isRejecting || expired}
           title={expired ? "Expired — the agent has moved on" : undefined}
@@ -440,7 +446,7 @@ function ApprovalCard({
         <button
           type="button"
           className="btn danger"
-          style={{ display: "inline-flex", alignItems: "center", gap: 6 }}
+          style={{ display: "inline-flex", alignItems: "center", gap: 6, minHeight: 44 }}
           onClick={() => handleDecide("reject")}
           disabled={isApproving || isRejecting || expired}
           title={expired ? "Expired — the agent has moved on" : undefined}
@@ -450,6 +456,8 @@ function ApprovalCard({
           {isRejecting ? " Rejecting…" : " Reject"}
           <KeyChip>X</KeyChip>
         </button>
+      </div>
+      <div style={{ display: "flex", alignItems: "center", gap: 8, marginTop: 8, marginLeft: 52, flexWrap: "wrap" }}>
         <button
           type="button"
           className="btn sm ghost"


### PR DESCRIPTION
## Summary

Single flex-wrap action row could split the destructive **Reject** button onto a different line from \"Edit & approve\" / \"Open in terminal\" at narrow widths — fat-finger risk on phones where a misclick on Reject is unrecoverable. Audit finding.

- Approve + Reject get their own flex group at the top of the action area: 12px gap, 44pt min-height (WCAG 2.5.5).
- Secondary actions (Edit & approve, Open in terminal) move into a separate flex group below — keeps 8px gap and ghost styling, but no longer shares a wrap boundary with the decision buttons.

## Test plan

- [ ] Mobile (≤ 480px): Approve + Reject stay on the same row; copy buttons drop below
- [ ] Desktop: Approve + Reject + copy buttons land on two clean rows
- [ ] Tap target on phone is ≥ 44pt for both decision buttons
- [ ] Expired/in-flight states still disable both correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)