### PR TITLE
polish(runs): stat-card aria-labels + surface running count in subtitle

### DIFF
--- a/dashboard/src/app/runs/page.tsx
+++ b/dashboard/src/app/runs/page.tsx
@@ -368,11 +368,12 @@ export default function RunsPage() {
 
   const stats = useMemo(() => {
     const list = windowedRuns ?? [];
-    const s = { ok: 0, err: 0, other: 0, totalMs: 0 };
+    const s = { ok: 0, err: 0, running: 0, other: 0, totalMs: 0 };
     for (const r of list) {
       if (r.assertionFailures && r.assertionFailures.length > 0) s.err++;
       else if (r.status === "done") s.ok++;
       else if (r.status === "error") s.err++;
+      else if (r.status === "running") s.running++;
       else s.other++;
       s.totalMs += r.durationMs;
     }
@@ -395,6 +396,27 @@ export default function RunsPage() {
           </h1>
           <div className="editorial-sub">
             {runs ? `${runs.length} runs` : "— runs"} · last 24h · avg {fmtDur(stats.avgMs)}
+            {stats.running > 0 && (
+              <>
+                {" · "}
+                <button
+                  type="button"
+                  onClick={() => setStatus("running")}
+                  title="Filter to in-flight runs"
+                  style={{
+                    background: "transparent",
+                    border: "none",
+                    color: "var(--accent)",
+                    cursor: "pointer",
+                    font: "inherit",
+                    padding: 0,
+                    textDecoration: "underline",
+                  }}
+                >
+                  {stats.running} running
+                </button>
+              </>
+            )}
           </div>
           <RelationStrip
             items={[
@@ -626,6 +648,7 @@ export default function RunsPage() {
             background: "transparent",
           }}
           aria-pressed={status === "all"}
+          aria-label={`Filter: all runs (${stats.total})`}
         >
           <div style={{ fontSize: "var(--fs-xs)", fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.08em", color: "var(--ink-3)", marginBottom: 8 }}>All runs</div>
           <div style={{ fontFamily: "var(--font-mono)", fontSize: 36, fontWeight: 800, color: "var(--ink-0)", lineHeight: 1 }}>{stats.total}</div>
@@ -643,6 +666,7 @@ export default function RunsPage() {
             background: "transparent",
           }}
           aria-pressed={status === "done"}
+          aria-label={`Filter: successful runs (${stats.ok})`}
         >
           <div style={{ fontSize: "var(--fs-xs)", fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.08em", color: "var(--ok)", marginBottom: 8 }}>✓ Successful</div>
           <div style={{ fontFamily: "var(--font-mono)", fontSize: 36, fontWeight: 800, color: "var(--ink-0)", lineHeight: 1 }}>{stats.ok}</div>
@@ -660,6 +684,7 @@ export default function RunsPage() {
             background: "transparent",
           }}
           aria-pressed={status === "error"}
+          aria-label={`Filter: errored runs (${stats.err})`}
         >
           <div style={{ fontSize: "var(--fs-xs)", fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.08em", color: "var(--err)", marginBottom: 8 }}>⚠ Errored</div>
           <div style={{ fontFamily: "var(--font-mono)", fontSize: 36, fontWeight: 800, color: stats.err > 0 ? "var(--err)" : "var(--ink-0)", lineHeight: 1 }}>{stats.err}</div>


### PR DESCRIPTION
## Summary

Two audit P2 fixes for the /runs stats area:

- **aria-labels** on the three stat-card filter buttons. They were \`aria-pressed\` but unlabeled — screen reader users heard \"Successful, pressed\" with no count or filter context. Now: \`aria-label=\"Filter: successful runs (12)\"\`.
- **Running count surfaced**. Running/cancelled/interrupted statuses were lumped into a single \`other\` tally and unreachable from the UI (only via URL param). Split out \`running\` and, when > 0, show \"N running\" as an inline link in the subtitle that flips \`status=\"running\"\`.

Cancelled + interrupted still need their own affordance — deferred.

## Test plan

- [ ] AT user hears full filter label on each card + current count
- [ ] Start a long-running recipe → \"N running\" appears in subtitle
- [ ] Click \"N running\" → list filters to running, URL updates
- [ ] Other states unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)