### PR TITLE
fix(approvals): surface Sync inbox failures via toast

### DIFF
--- a/dashboard/src/app/approvals/page.tsx
+++ b/dashboard/src/app/approvals/page.tsx
@@ -568,6 +568,7 @@ function ApprovalsContent() {
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
   const [dismissed, setDismissed] = useState<Set<string>>(new Set());
   const [copied, setCopied] = useState<string | null>(null);
+  const toast = useToast();
   const riskFromUrl = searchParams.get("risk");
   const [riskFilter, setRiskFilterState] = useState<RiskFilter>(
     riskFromUrl === "low" || riskFromUrl === "medium" || riskFromUrl === "high"
@@ -1057,9 +1058,22 @@ function ApprovalsContent() {
           onClick={() => {
             const approvalsUrl = `${API}/approvals${sessionFilter ? `?session=${sessionFilter}` : ""}`;
             fetch(approvalsUrl)
-              .then((r) => r.ok ? r.json() : null)
-              .then((d) => { if (d) setPending(d as Pending[]); })
-              .catch(() => {});
+              .then(async (r) => {
+                if (!r.ok) {
+                  const detail = await r.text().catch(() => r.statusText);
+                  throw new Error(detail || `${r.status}`);
+                }
+                return r.json();
+              })
+              .then((d) => {
+                if (d) setPending(d as Pending[]);
+                toast.info("Inbox synced");
+              })
+              .catch((e: unknown) => {
+                toast.error(
+                  `Sync failed: ${e instanceof Error ? e.message : String(e)}`,
+                );
+              });
           }}
         >
           Sync inbox


### PR DESCRIPTION
## Summary

\"Sync inbox\" silently swallowed both fetch errors and non-OK HTTP responses (\`.catch(() => {})\`). A user retrying after a bridge crash got no feedback whether the second click succeeded — they just kept clicking.

- Throw on non-2xx with the response body / statusText as the message
- Catch pushes \`toast.error\` with the message
- On success: \`toast.info(\"Inbox synced\")\` — positive confirmation so users stop clicking
- Hoist \`useToast()\` into \`ApprovalsContent\` (already in \`ApprovalCard\`)

## Test plan

- [ ] Click Sync inbox with bridge online → \"Inbox synced\" toast
- [ ] Stop bridge → toast.error with message
- [ ] Bridge returns 500 → toast.error with body text

🤖 Generated with [Claude Code](https://claude.com/claude-code)