### PR TITLE
feat(approvals): tier-weighted batch confirm + cap long primary value

### DIFF
--- a/dashboard/src/app/approvals/page.tsx
+++ b/dashboard/src/app/approvals/page.tsx
@@ -798,10 +798,19 @@ function ApprovalsContent() {
 
   async function batchDecide(decision: "approve" | "reject") {
     const ids = selectedInView.map((p) => p.callId);
-    if (ids.length >= 3) {
+    // Confirm gate is tier-weighted: any high-risk selection demands a
+    // confirm even for a batch of 1; non-high batches keep the historical
+    // ≥3 threshold so the prompt doesn't become noise for tidy reviews.
+    const highCount = selectedInView.filter((p) => p.tier === "high").length;
+    const needsConfirm = highCount > 0 || ids.length >= 3;
+    if (needsConfirm) {
       const verb = decision === "approve" ? "Approve" : "Reject";
+      const highNote =
+        highCount > 0
+          ? ` (${highCount} high-risk)`
+          : "";
       const proceed = window.confirm(
-        `${verb} ${ids.length} approvals at once? This action can't be undone.`,
+        `${verb} ${ids.length} approval${ids.length === 1 ? "" : "s"}${highNote}? This action can't be undone.`,
       );
       if (!proceed) return;
     }

--- a/dashboard/src/app/globals.css
+++ b/dashboard/src/app/globals.css
@@ -1443,6 +1443,12 @@ button.topbar-search {
   color: var(--ink-0);
   word-break: break-all;
   white-space: pre-wrap;
+  /* Long URLs / commands could exceed the card height on mobile and
+     push the Approve/Reject buttons below the fold. Cap at ~6 lines
+     with a scrollbar; full text remains accessible via expand or
+     scroll. Reviewers can always click "Full params" for the raw view. */
+  max-height: 9.5em;
+  overflow-y: auto;
 }
 .approval-params-wrap { margin: 12px 0; }
 .approval-params-toggle {


### PR DESCRIPTION
## Summary

Two small approval-card audit fixes:

**Batch confirm: tier-weighted**
- Was: hardcoded \`ids.length >= 3\` → selecting a single high-tier via select-all + Approve skipped confirm.
- Now: any high-risk selection triggers confirm even at count 1; non-high batches keep the ≥3 threshold to avoid prompt noise on tidy reviews.
- Confirm copy names the high-risk subset count.

**Long primary value cap**
- The orange-left-border strip rendering the URL/command had no height limit. Long URLs on a phone pushed Approve/Reject below the fold.
- Cap at ~6 lines (9.5em) with internal \`overflow-y: auto\`. \"Full params\" remains the path to raw text.

## Test plan

- [ ] Select one high-risk approval → click Approve in batch bar → confirm
- [ ] Select two medium-risk → click Approve → no confirm
- [ ] Select three low → click Approve → confirm
- [ ] Approval with 600-char URL primary → strip scrolls internally; buttons stay visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)