### PR TITLE
feat(runs): surface running / cancelled / interrupted counts in subtitle

### DIFF
--- a/dashboard/src/app/runs/page.tsx
+++ b/dashboard/src/app/runs/page.tsx
@@ -368,12 +368,14 @@ export default function RunsPage() {
 
   const stats = useMemo(() => {
     const list = windowedRuns ?? [];
-    const s = { ok: 0, err: 0, other: 0, totalMs: 0 };
+    const s = { ok: 0, err: 0, running: 0, cancelled: 0, interrupted: 0, totalMs: 0 };
     for (const r of list) {
       if (r.assertionFailures && r.assertionFailures.length > 0) s.err++;
       else if (r.status === "done") s.ok++;
       else if (r.status === "error") s.err++;
-      else s.other++;
+      else if (r.status === "running") s.running++;
+      else if (r.status === "cancelled") s.cancelled++;
+      else if (r.status === "interrupted") s.interrupted++;
       s.totalMs += r.durationMs;
     }
     const avgMs = list.length ? Math.round(s.totalMs / list.length) : 0;
@@ -395,6 +397,32 @@ export default function RunsPage() {
           </h1>
           <div className="editorial-sub">
             {runs ? `${runs.length} runs` : "— runs"} · {TIME_WINDOW_LABEL[window].toLowerCase()} · avg {fmtDur(stats.avgMs)}
+            {/* Statuses without dedicated stat cards (running / cancelled /
+                interrupted) surface here as inline filter links so they're
+                still reachable from the UI. Hidden when zero. */}
+            {(["running", "cancelled", "interrupted"] as const).map((k) =>
+              stats[k] > 0 ? (
+                <span key={k}>
+                  {" · "}
+                  <button
+                    type="button"
+                    onClick={() => setStatus(k)}
+                    title={`Filter to ${k} runs`}
+                    style={{
+                      background: "transparent",
+                      border: "none",
+                      color: "var(--accent)",
+                      cursor: "pointer",
+                      font: "inherit",
+                      padding: 0,
+                      textDecoration: "underline",
+                    }}
+                  >
+                    {stats[k]} {k}
+                  </button>
+                </span>
+              ) : null,
+            )}
           </div>
           <RelationStrip
             items={[


### PR DESCRIPTION
## Summary

Audit P2: the three stat cards cover only **All / Successful / Errored**. \`running\`, \`cancelled\`, \`interrupted\` were lumped into a single \`other\` tally — unreachable from the UI, only by typing \`?status=running\` into the URL.

- Stats memo splits all three into their own counts.
- Subtitle gets an inline clickable filter link per non-zero non-card status. Hidden when zero so the line stays clean on idle dashboards.

This **supersedes #666** (running-only). When #666 lands first, the conflict is take-this-PR-version of the stats hook + subtitle.

## Test plan

- [ ] Trigger long-running recipe → \"N running\" link in subtitle, filters to running on click
- [ ] Cancel a run → \"N cancelled\" link appears
- [ ] Idle dashboard → no extra links
- [ ] aria-pressed on the corresponding status filter (if rendered) lights up

🤖 Generated with [Claude Code](https://claude.com/claude-code)