### PR TITLE
fix(nav): rename "Decisions" section to "Review" to avoid Knowledge sibling clash

### DIFF
--- a/dashboard/src/lib/__tests__/navRoutes.test.ts
+++ b/dashboard/src/lib/__tests__/navRoutes.test.ts
@@ -20,7 +20,7 @@ describe("navRoutes contract", () => {
     const titles = NAV_SECTIONS.map((s) => s.title);
     expect(titles).toEqual([
       "Today",
-      "Decisions",
+      "Review",
       "Activity",
       "Build",
       "Insights",

--- a/dashboard/src/lib/navRoutes.ts
+++ b/dashboard/src/lib/navRoutes.ts
@@ -42,7 +42,7 @@ export interface NavSection {
  *
  * IA conventions:
  *   - "Today" = the morning-routine destinations.
- *   - "Decisions" = the trio Approvals/Suggestions/Knowledge.
+ *   - "Review" = the trio Approvals/Suggestions/Knowledge.
  *     "Knowledge" is the renamed /decisions page (which renders the
  *     ctxSaveTrace knowledge base, NOT approval history — the previous
  *     "History" label was actively wrong).
@@ -65,25 +65,33 @@ export const NAV_SECTIONS: NavSection[] = [
     ],
   },
   {
-    title: "Decisions",
+    // Section was titled "Decisions" but contained an item also called
+    // "Knowledge" (the /decisions route — the past-decision archive).
+    // Sibling-naming clash made it unclear that all three are decision
+    // surfaces with different time horizons:
+    //   Approvals   — pending now
+    //   Suggestions — queued rule changes
+    //   Knowledge   — archived decision traces
+    // Rename section so the heading describes the cluster, not one sub-item.
+    title: "Review",
     routes: [
       {
         href: "/approvals",
         label: "Approvals",
-        paletteLabel: "Decisions — Approvals",
+        paletteLabel: "Review — Approvals",
         icon: "check",
         badge: "approvals",
       },
       {
         href: "/suggestions",
         label: "Suggestions",
-        paletteLabel: "Decisions — Suggestions",
+        paletteLabel: "Review — Suggestions",
         icon: "lightbulb",
       },
       {
         href: "/decisions",
         label: "Knowledge",
-        paletteLabel: "Decisions — Knowledge",
+        paletteLabel: "Review — Knowledge",
         icon: "bookmark",
       },
     ],


### PR DESCRIPTION
## Summary

Audit caught the sibling-naming clash: \"Decisions\" section header contained an item also labeled \"Knowledge\" (the /decisions route — past-decision archive). Reading the sidebar showed \"Decisions → Knowledge\" with no obvious link between the terms.

Rename section to **\"Review\"** so the heading describes the cluster (things you review) rather than reusing the name of one sub-item. Palette labels updated to \"Review — <item>\".

Routes, badges, icons unchanged — pure labeling fix.

## Test plan

- [ ] Sidebar shows \"Review\" header above Approvals / Suggestions / Knowledge
- [ ] ⌘K \"Review — Approvals\" / \"Review — Suggestions\" / \"Review — Knowledge\" entries
- [ ] Routes still navigate correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)