### PR TITLE
a11y(runs): aria-labels on stat-card filter buttons

### DIFF
--- a/dashboard/src/app/runs/page.tsx
+++ b/dashboard/src/app/runs/page.tsx
@@ -626,6 +626,7 @@ export default function RunsPage() {
             background: "transparent",
           }}
           aria-pressed={status === "all"}
+          aria-label={`Filter: all runs (${stats.total})`}
         >
           <div style={{ fontSize: "var(--fs-xs)", fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.08em", color: "var(--ink-3)", marginBottom: 8 }}>All runs</div>
           <div style={{ fontFamily: "var(--font-mono)", fontSize: 36, fontWeight: 800, color: "var(--ink-0)", lineHeight: 1 }}>{stats.total}</div>
@@ -643,6 +644,7 @@ export default function RunsPage() {
             background: "transparent",
           }}
           aria-pressed={status === "done"}
+          aria-label={`Filter: successful runs (${stats.ok})`}
         >
           <div style={{ fontSize: "var(--fs-xs)", fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.08em", color: "var(--ok)", marginBottom: 8 }}>✓ Successful</div>
           <div style={{ fontFamily: "var(--font-mono)", fontSize: 36, fontWeight: 800, color: "var(--ink-0)", lineHeight: 1 }}>{stats.ok}</div>
@@ -660,6 +662,7 @@ export default function RunsPage() {
             background: "transparent",
           }}
           aria-pressed={status === "error"}
+          aria-label={`Filter: errored runs (${stats.err})`}
         >
           <div style={{ fontSize: "var(--fs-xs)", fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.08em", color: "var(--err)", marginBottom: 8 }}>⚠ Errored</div>
           <div style={{ fontFamily: "var(--font-mono)", fontSize: 36, fontWeight: 800, color: stats.err > 0 ? "var(--err)" : "var(--ink-0)", lineHeight: 1 }}>{stats.err}</div>


### PR DESCRIPTION
## Summary

Each \`/runs\` stat-card had \`aria-pressed\` but no \`aria-label\` — screen-reader users heard just \"Successful, pressed\" with no count or filter context.

Adds explicit \`aria-label=\"Filter: <kind> runs (<count>)\"\` to all three cards.

Originally part of #666 (closed because #671 supersedes its running-count work); porting the a11y bit forward so it doesn't get lost.

## Test plan

- [ ] DevTools / AT reads full filter label + current count on each card
- [ ] Visual appearance unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)