### PR TITLE
feat(recipes): no-match empty state with clear-filter shortcuts

### DIFF
--- a/dashboard/src/app/recipes/page.tsx
+++ b/dashboard/src/app/recipes/page.tsx
@@ -1287,6 +1287,39 @@ export default function RecipesPage() {
                   </tr>
                 </thead>
                 <tbody>
+                  {filteredRecipes.length === 0 && (
+                    <tr>
+                      <td colSpan={7} style={{ padding: "var(--s-5) var(--s-4)", textAlign: "center" }}>
+                        <div className="muted" style={{ fontSize: "var(--fs-m)", marginBottom: "var(--s-2)" }}>
+                          {search.trim()
+                            ? `No recipes match "${search.trim()}"`
+                            : statusFilter === "paused"
+                              ? "No paused recipes"
+                              : "No enabled recipes"}
+                        </div>
+                        <div style={{ display: "flex", gap: "var(--s-2)", justifyContent: "center", flexWrap: "wrap" }}>
+                          {search.trim() && (
+                            <button
+                              type="button"
+                              className="btn sm ghost"
+                              onClick={() => setSearch("")}
+                            >
+                              Clear search
+                            </button>
+                          )}
+                          {statusFilter !== "all" && (
+                            <button
+                              type="button"
+                              className="btn sm ghost"
+                              onClick={() => setStatusFilter("all")}
+                            >
+                              Show all
+                            </button>
+                          )}
+                        </div>
+                      </td>
+                    </tr>
+                  )}
                   {filteredRecipes.map((r, i) => {
                     const live = isLive(r.name);
                     const last = runMap.get(r.name);


### PR DESCRIPTION
## Summary
- When current search / status filter excludes every recipe, render an inline empty-state row instead of a bare table
- Offers one-click "Clear search" / "Show all" so users don't get stranded staring at a header
- Wording adapts to which filter is responsible

## Test plan
- [ ] Type a nonsense search query — empty row appears with Clear search button
- [ ] Switch to "Paused only" with no paused recipes — empty row says "No paused recipes"
- [ ] Clear search button restores the list

🤖 Generated with [Claude Code](https://claude.com/claude-code)