### PR TITLE
feat(activity): flash newest just-arrived row (uses existing keyframes)

### DIFF
--- a/dashboard/src/app/activity/page.tsx
+++ b/dashboard/src/app/activity/page.tsx
@@ -209,6 +209,26 @@ export default function ActivityPage() {
     return () => clearInterval(id);
   }, []);
 
+  // Flash the newest just-arrived event row with the existing
+  // .activity-row.is-fresh keyframes (globals.css:2061). Tracks the
+  // top-of-list event's identity; on change, marks it fresh for
+  // ~1.6s (matches the keyframe duration). Skipped during the
+  // initial history seed so we don't flash a hundred rows on mount.
+  const [freshKey, setFreshKey] = useState<string | null>(null);
+  const lastTopRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!seeded || events.length === 0) return;
+    const top = events[0];
+    const topKey = `${top.kind}-${top.id ?? ""}-${top.at ?? ""}`;
+    if (lastTopRef.current === topKey) return;
+    lastTopRef.current = topKey;
+    setFreshKey(topKey);
+    const id = setTimeout(() => {
+      setFreshKey((cur) => (cur === topKey ? null : cur));
+    }, 1700);
+    return () => clearTimeout(id);
+  }, [events, seeded]);
+
   const filtered = useMemo(() => {
     let out = events;
     if (tab === "tools") {
@@ -544,8 +564,19 @@ export default function ActivityPage() {
                         ? meta.summary
                         : "—";
 
+                const rowKey = `${e.kind}-${e.id ?? ""}-${e.at ?? ""}`;
+                const isFresh = freshKey === rowKey;
+                const isErr = e.kind === "tool" && e.status === "error";
                 return (
-                  <tr key={`${e.kind}-${e.id ?? i}-${i}`} style={{ cursor: "pointer" }}>
+                  <tr
+                    key={`${e.kind}-${e.id ?? i}-${i}`}
+                    className={
+                      isFresh
+                        ? `activity-row is-fresh${isErr ? " is-err" : ""}`
+                        : "activity-row"
+                    }
+                    style={{ cursor: "pointer" }}
+                  >
                     <td
                       className="muted"
                       title={e.at ? new Date(e.at).toISOString() : ""}


### PR DESCRIPTION
## Summary
- \`.activity-row.is-fresh\` keyframes existed in globals.css but were never applied
- New live event at top of list now gets \`.is-fresh\` for 1.7s (flash + slide-in)
- Errored tool events use the \`.is-err\` red-tint variant
- Initial history seed is skipped — no flash storm on mount

## Test plan
- [ ] Trigger a tool call — newest row tints + slides in
- [ ] Trigger a failing tool — newest row flashes red
- [ ] Hard refresh — history seeds without flashing every row
- [ ] System "Reduce motion" — keyframes still play (separate audit item)

🤖 Generated with [Claude Code](https://claude.com/claude-code)