### PR TITLE
feat(runs): blue left-edge accent on running step rows

### DIFF
--- a/dashboard/src/app/runs/[seq]/page.tsx
+++ b/dashboard/src/app/runs/[seq]/page.tsx
@@ -448,6 +448,9 @@ function StepRow({
       style={{
         position: "relative",
         borderBottom: "1px solid var(--border-subtle)",
+        borderLeft: step.status === "running"
+          ? "3px solid var(--blue)"
+          : "3px solid transparent",
         cursor: step.error ? "pointer" : "default",
       }}
       onClick={() => step.error && toggleOpen()}


### PR DESCRIPTION
## Summary
- StepRow on /runs/[seq] previously had identical chrome for running / queued / ok / error / skipped steps
- Adds 3px var(--blue) left border when step.status === "running"; transparent placeholder otherwise (no layout jitter on transition)
- Pairs with the existing .pill.running ::before pulse so eye lands on the same row

## Test plan
- [ ] Run a multi-step recipe and open /runs/<seq> while running — the in-flight step has a visible left bar
- [ ] After completion, all rows have transparent placeholder (uniform left edge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)