### PR TITLE
feat(dialog): fade-in backdrop + pop-in panel on modal open

### DIFF
--- a/dashboard/src/app/globals.css
+++ b/dashboard/src/app/globals.css
@@ -3734,3 +3734,26 @@ button.topbar-search {
     left: -100%;
   }
 }
+
+/* ---- Dialog open animation (components/Dialog.tsx) ---------------
+ * Backdrop fades; panel pops with a small upward translate so users
+ * notice the modal mounting. Reduced-motion users get instant
+ * placement. */
+.pw-dialog-backdrop {
+  animation: pw-dialog-fade-in 140ms ease-out;
+}
+.pw-dialog-panel {
+  animation: pw-dialog-pop-in 180ms cubic-bezier(0.18, 0.7, 0.2, 1);
+}
+@keyframes pw-dialog-fade-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+@keyframes pw-dialog-pop-in {
+  from { opacity: 0; transform: translateY(8px) scale(0.98); }
+  to   { opacity: 1; transform: none; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .pw-dialog-backdrop,
+  .pw-dialog-panel { animation: none; }
+}

--- a/dashboard/src/components/Dialog.tsx
+++ b/dashboard/src/components/Dialog.tsx
@@ -145,6 +145,7 @@ export function Dialog({
   return createPortal(
     <div
       role="presentation"
+      className="pw-dialog-backdrop"
       onClick={(e) => {
         if (dismissOnBackdrop && e.target === e.currentTarget) onClose();
       }}
@@ -168,6 +169,7 @@ export function Dialog({
         tabIndex={-1}
         onKeyDown={handleKeyDown}
         id={fallbackId}
+        className="pw-dialog-panel"
         style={{
           background: "var(--surface)",
           color: "var(--ink-0)",


### PR DESCRIPTION
## Summary
- Modals snap on without animation today
- Backdrop fades (140ms); panel pops in (180ms, slight translateY + scale)
- Respects \`prefers-reduced-motion\`

Affects every Dialog instance (Run modal, Recipe install, Replay confirm, tier-gated confirm).

## Test plan
- [ ] Click Run on a recipe — modal eases in (was instant)
- [ ] Close + reopen — animation replays
- [ ] System "Reduce motion" — instant placement

🤖 Generated with [Claude Code](https://claude.com/claude-code)