### PR TITLE
feat(runs): blue left-edge accent on running list rows

### DIFF
--- a/dashboard/src/app/runs/page.tsx
+++ b/dashboard/src/app/runs/page.tsx
@@ -773,7 +773,13 @@ export default function RunsPage() {
                       tabIndex={0}
                       role="button"
                       aria-expanded={isExpanded}
-                      style={{ cursor: "pointer" }}
+                      style={{
+                        cursor: "pointer",
+                        boxShadow:
+                          r.status === "running"
+                            ? "inset 3px 0 0 var(--blue)"
+                            : undefined,
+                      }}
                     >
                       <td className="mono muted">
                         {fmtWhen(


### PR DESCRIPTION
## Summary
- Single row pulsing pill among 100 finished rows was easy to miss
- Adds 3px var(--blue) inset shadow on the row's left edge when status === "running"
- Mirrors #681 (same affordance on /runs/[seq] step rows)

## Test plan
- [ ] Trigger a long recipe — its row in /runs has a visible blue strip
- [ ] After completion, the strip disappears (no layout shift since inset-shadow doesn't reserve space)

🤖 Generated with [Claude Code](https://claude.com/claude-code)