### PR TITLE
feat(loading): standardize page-level loading on SkeletonList across 7 pages

### DIFF
--- a/dashboard/src/app/analytics/page.tsx
+++ b/dashboard/src/app/analytics/page.tsx
@@ -4,6 +4,7 @@ import { StatCard } from "@/components/StatCard";
 import { useBridgeFetch } from "@/hooks/useBridgeFetch";
 import { AreaChart, ErrorState } from "@/components/patchwork";
 import type { AreaChartSeries } from "@/components/patchwork";
+import { SkeletonList } from "@/components/Skeleton";
 import { isHaltStatus } from "@/lib/runStatus";
 
 interface ToolStat {
@@ -246,12 +247,7 @@ export default function AnalyticsPage() {
           </div>
 
           {loading ? (
-            <div
-              className="card"
-              style={{ color: "var(--fg-3)", fontSize: "var(--fs-m)" }}
-            >
-              Loading…
-            </div>
+            <SkeletonList rows={5} columns={3} />
           ) : topTools.length === 0 ? (
             <div className="empty-state">
               <h3>No tool call data yet</h3>

--- a/dashboard/src/app/decisions/page.tsx
+++ b/dashboard/src/app/decisions/page.tsx
@@ -8,6 +8,7 @@ import { useDebounced } from "@/hooks/useDebounced";
 import { arr, isRecord, shape, type ShapeCheck } from "@/lib/validate";
 import { DecisionsTabs } from "@/components/DecisionsTabs";
 import { ErrorState, Glossary, HintCard, LivePill } from "@/components/patchwork";
+import { SkeletonList } from "@/components/Skeleton";
 
 interface DecisionTrace {
   traceType: "decision";
@@ -272,7 +273,7 @@ function DecisionsContent() {
       )}
 
       {loading && traces.length === 0 && (
-        <p style={{ color: "var(--fg-2)" }}>Loading…</p>
+        <SkeletonList rows={5} columns={4} />
       )}
 
       {error && traces.length === 0 && (

--- a/dashboard/src/app/insights/page.tsx
+++ b/dashboard/src/app/insights/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from "react";
 import { useBridgeFetch } from "@/hooks/useBridgeFetch";
 import { apiPath } from "@/lib/api";
 import { EmptyState, ErrorState } from "@/components/patchwork";
+import { SkeletonList } from "@/components/Skeleton";
 
 interface ToolInsight {
   toolName: string;
@@ -257,7 +258,7 @@ export default function InsightsPage() {
       </div>
 
       {loading && tools.length === 0 && (
-        <p style={{ color: "var(--fg-2)" }}>Loading…</p>
+        <SkeletonList rows={6} columns={5} />
       )}
       {error && tools.length === 0 && (
         <ErrorState

--- a/dashboard/src/app/insights/replay/page.tsx
+++ b/dashboard/src/app/insights/replay/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { useState } from "react";
 import { useBridgeFetch } from "@/hooks/useBridgeFetch";
 import { BackLink, EmptyState } from "@/components/patchwork";
+import { SkeletonList } from "@/components/Skeleton";
 
 type ReplayDecision = "allow" | "deny" | "ask" | "none";
 type ChangeKind = "now_allowed" | "now_denied" | "now_asked";
@@ -122,7 +123,7 @@ export default function ReplayPage() {
       </div>
 
       {loading && rows.length === 0 && (
-        <p style={{ color: "var(--fg-2)" }}>Loading…</p>
+        <SkeletonList rows={6} columns={4} />
       )}
       {error && <div className="alert-err">Unreachable: {error}</div>}
 

--- a/dashboard/src/app/suggestions/page.tsx
+++ b/dashboard/src/app/suggestions/page.tsx
@@ -6,6 +6,7 @@ import { apiPath } from "@/lib/api";
 import { useBridgeFetch } from "@/hooks/useBridgeFetch";
 import { DecisionsTabs } from "@/components/DecisionsTabs";
 import { ErrorState, HintCard } from "@/components/patchwork";
+import { SkeletonList } from "@/components/Skeleton";
 
 const SINCE_DAYS_OPTIONS = [1, 7, 30, 90] as const;
 type SinceDays = (typeof SINCE_DAYS_OPTIONS)[number];
@@ -222,7 +223,7 @@ export default function SuggestionsPage() {
       <HintCard id="suggestions" />
 
       {loading && suggestions.length === 0 && (
-        <p style={{ color: "var(--fg-2)" }}>Loading…</p>
+        <SkeletonList rows={5} columns={3} />
       )}
       {error && suggestions.length === 0 && (
         <ErrorState

--- a/dashboard/src/app/traces/page.tsx
+++ b/dashboard/src/app/traces/page.tsx
@@ -7,6 +7,7 @@ import { useDebounced } from "@/hooks/useDebounced";
 import { arr, isRecord, shape, type ShapeCheck } from "@/lib/validate";
 import { EmptyState, ErrorState, HintCard, LivePill, RelationStrip } from "@/components/patchwork";
 import { ActivityTabs } from "@/components/ActivityTabs";
+import { SkeletonList } from "@/components/Skeleton";
 
 type TraceType = "approval" | "enrichment" | "recipe_run" | "decision";
 
@@ -756,7 +757,7 @@ export default function TracesPage() {
       </div>
 
       {loading && traces.length === 0 && (
-        <p style={{ color: "var(--fg-2)" }}>Loading…</p>
+        <SkeletonList rows={6} columns={4} />
       )}
 
       {error && traces.length === 0 && (

--- a/dashboard/src/app/transactions/page.tsx
+++ b/dashboard/src/app/transactions/page.tsx
@@ -2,6 +2,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { apiPath } from "@/lib/api";
 import { useBridgeFetch } from "@/hooks/useBridgeFetch";
+import { SkeletonList } from "@/components/Skeleton";
 import { ErrorState, HintCard, RelationStrip } from "@/components/patchwork";
 
 interface TransactionEdit {
@@ -215,7 +216,7 @@ export default function TransactionsPage() {
       <HintCard id="transactions" />
 
       {loading && transactions.length === 0 && (
-        <p style={{ color: "var(--fg-2)" }}>Loading…</p>
+        <SkeletonList rows={6} columns={5} />
       )}
       {error && transactions.length === 0 && (
         <ErrorState


### PR DESCRIPTION
## Summary
- Now that .skeleton CSS is present (PR #679), the SkeletonList component actually shimmers
- Replaced bare \`<p>Loading…</p>\` with \`<SkeletonList rows columns>\` on:
  - /transactions, /decisions, /suggestions, /insights, /insights/replay, /traces, /analytics
- All other page-level loaders already used SkeletonList — consistent now

Net: 7 lines of "Loading…" replaced with the shared skeleton component + 7 imports added.

## Test plan
- [ ] Hard refresh each page — skeleton shimmer renders instead of text
- [ ] System "Reduce motion" — skeleton renders static (animation handled by #679's CSS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)