### PR TITLE
perf(tasks): only tick at 1Hz when a task is actually live

### DIFF
--- a/dashboard/src/app/tasks/page.tsx
+++ b/dashboard/src/app/tasks/page.tsx
@@ -344,10 +344,20 @@ export default function TasksPage() {
     };
   }, []);
 
+  // Tick only when there's at least one running/pending task — relative
+  // timestamps for terminal tasks ("3m ago") move at human scale, so we
+  // don't need a 1Hz re-render of all 485 rows. Without this guard the
+  // entire table re-rendered every second purely to refresh the live
+  // duration counter on running rows (perf audit 2026-05-19).
+  const hasLiveTask = useMemo(
+    () => tasks.some((t) => t.status === "running" || t.status === "pending"),
+    [tasks],
+  );
   useEffect(() => {
+    if (!hasLiveTask) return;
     const id = setInterval(() => setTick((t) => t + 1), 1000);
     return () => clearInterval(id);
-  }, []);
+  }, [hasLiveTask]);
 
   // live-computed subtitle stats
   const { avgMs, driverLabel } = useMemo(() => {


### PR DESCRIPTION
## Summary
- /tasks re-rendered all 485 rows every second purely to refresh the relative-time on running rows
- Guard the 1Hz \`setTick\` interval behind \`tasks.some(running||pending)\` — terminal-only tables no longer rerender
- Perf audit flagged this as the single biggest visible source of sluggishness on the page

## Test plan
- [ ] /tasks with all-terminal tasks — no per-second rerender (verify via React DevTools profiler)
- [ ] /tasks with a running task — duration still ticks up live
- [ ] Recipe finishes — interval auto-unmounts on next tasks update

🤖 Generated with [Claude Code](https://claude.com/claude-code)