### PR TITLE
chore(connections): remove radar (border-beam) effect on connector cards

### DIFF
--- a/dashboard/src/app/connections/page.tsx
+++ b/dashboard/src/app/connections/page.tsx
@@ -596,7 +596,7 @@ function ConnectorGridCard({ def, statusEntry, onConnect, onDisconnect, onTest, 
 
   return (
     <div
-      className="card beam"
+      className="card"
       style={{
         background: isDegraded ? "var(--warn-soft)" : undefined,
         borderColor: borderColor,

--- a/dashboard/src/app/globals.css
+++ b/dashboard/src/app/globals.css
@@ -783,41 +783,6 @@ button.topbar-search {
 [data-theme="dark"] .stat-card:hover::before,
 [data-theme="dark"] .glass-card:hover::before { opacity: 0.3; }
 
-/* Border beam animation on cards */
-.card.beam {
-  overflow: hidden;
-}
-.card.beam::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  border-radius: inherit;
-  background: conic-gradient(
-    from var(--beam-angle, 0deg) at 50% 50%,
-    transparent 0deg,
-    var(--orange) 60deg,
-    transparent 120deg
-  );
-  opacity: 0;
-  transition: opacity 400ms ease;
-  pointer-events: none;
-}
-.card.beam:hover::before {
-  opacity: 0.12;
-  animation: borderBeam 3s linear infinite;
-}
-[data-theme="dark"] .card.beam:hover::before {
-  opacity: 0.2;
-}
-@keyframes borderBeam {
-  to { --beam-angle: 360deg; }
-}
-@property --beam-angle {
-  syntax: "<angle>";
-  inherits: false;
-  initial-value: 0deg;
-}
-
 .glass-card {
   background: var(--glass-bg);
   border: 1px solid var(--glass-border);


### PR DESCRIPTION
## Summary
- Removed the rotating conic-gradient border-beam effect on /connections connector cards
- Dropped \`className="card beam"\` → \`className="card"\` on ConnectorGridCard
- Deleted the now-unused \`.card.beam\` CSS block + \`@keyframes borderBeam\` + \`@property --beam-angle\` (the only call site was this page)

Single biggest paint cost on /connections — 33 cards × per-frame conic-gradient rotation on hover. Also flagged by the CSS perf audit as paint-not-composite animation.

## Test plan
- [ ] /connections — hover a connector card; no rotating glow
- [ ] Card border still indicates connected/needs_reauth state via \`borderColor\`
- [ ] Grep confirms no \`card beam\` left in dashboard/src

🤖 Generated with [Claude Code](https://claude.com/claude-code)