### PR TITLE
perf: rAF-throttle CardGlow + 5s relative-time tick on /activity

### DIFF
--- a/dashboard/src/app/activity/page.tsx
+++ b/dashboard/src/app/activity/page.tsx
@@ -203,9 +203,12 @@ export default function ActivityPage() {
     return () => es.close();
   }, []);
 
-  // tick for relative timestamps
+  // Tick for relative timestamps. Was 1Hz which forced 200-event
+  // table + histogram + HBarList to re-render every second. Bumped
+  // to 5s — "just now → 5s ago" still feels live without burning
+  // CPU on a stale-staring tab (perf audit 2026-05-19).
   useEffect(() => {
-    const id = setInterval(() => setTick((t) => t + 1), 1000);
+    const id = setInterval(() => setTick((t) => t + 1), 5000);
     return () => clearInterval(id);
   }, []);
 

--- a/dashboard/src/components/CardGlow.tsx
+++ b/dashboard/src/components/CardGlow.tsx
@@ -3,12 +3,25 @@ import { useEffect } from "react";
 
 const CARD_SELECTOR = ".card, .stat-card, .glass-card, .template-card";
 
+/**
+ * Hover-following gradient on cards. Was firing on every mousemove event
+ * (potentially 1000+/sec while moving the mouse), each call doing a DOM
+ * walk + getBoundingClientRect + two style writes. Now coalesced to one
+ * write per animation frame so the rest of the page can paint.
+ */
 export function CardGlow() {
   useEffect(() => {
     if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
 
-    function onMove(e: MouseEvent) {
-      const card = (e.target as Element).closest(CARD_SELECTOR) as HTMLElement | null;
+    let raf = 0;
+    let pendingEvent: MouseEvent | null = null;
+
+    function flush() {
+      raf = 0;
+      const e = pendingEvent;
+      pendingEvent = null;
+      if (!e) return;
+      const card = (e.target as Element | null)?.closest(CARD_SELECTOR) as HTMLElement | null;
       if (!card) return;
       const rect = card.getBoundingClientRect();
       const x = ((e.clientX - rect.left) / rect.width) * 100;
@@ -17,8 +30,16 @@ export function CardGlow() {
       card.style.setProperty("--mouse-y", `${y}%`);
     }
 
+    function onMove(e: MouseEvent) {
+      pendingEvent = e;
+      if (raf === 0) raf = requestAnimationFrame(flush);
+    }
+
     document.addEventListener("mousemove", onMove, { passive: true });
-    return () => document.removeEventListener("mousemove", onMove);
+    return () => {
+      document.removeEventListener("mousemove", onMove);
+      if (raf !== 0) cancelAnimationFrame(raf);
+    };
   }, []);
 
   return null;


### PR DESCRIPTION
## Summary
Two independent perf fixes flagged by the audit:

1. **CardGlow rAF-throttle** (\`dashboard/src/components/CardGlow.tsx\`) — document-level mousemove handler was firing 1000+/sec while moving the mouse, each call doing a DOM walk + \`getBoundingClientRect\` + two style writes. Now coalesces all events within one animation frame.
2. **/activity 1Hz → 5s tick** (\`dashboard/src/app/activity/page.tsx:206\`) — page re-rendered the 200-event table + histogram + HBarList every second purely to refresh relative-time strings. Bumped to 5s.

## Test plan
- [ ] Move mouse rapidly over a page with multiple cards — glow still tracks, no visible jank
- [ ] /activity left open in background tab — task manager / Activity Monitor shows reduced CPU
- [ ] Relative-times still update visibly within a few seconds

🤖 Generated with [Claude Code](https://claude.com/claude-code)