### PR TITLE
perf(approvals): single setTimeout per card instead of 1Hz setInterval

### DIFF
--- a/dashboard/src/app/approvals/page.tsx
+++ b/dashboard/src/app/approvals/page.tsx
@@ -161,16 +161,22 @@ function ApprovalCard({
   const hasParams = p.params && Object.keys(p.params).length > 0;
   const match = matchRule(p.toolName, rules);
 
-  // Tick once per second so we can flip to "expired" UI when `expires`
-  // passes without depending on the parent re-rendering. Only runs while
-  // not yet expired — once `now >= expires` the interval clears itself.
-  const [now, setNow] = useState(() => Date.now());
-  const expired = now >= expires;
+  // Flip to "expired" UI exactly once when `expires` passes. Previously
+  // ticked Date.now() at 1Hz per card, which forced every visible card
+  // to re-render every second even though the countdown UI is owned by
+  // a leaf <CountdownTimer> that ticks itself. Now a single setTimeout
+  // schedules the boolean flip and unmounts. Perf audit 2026-05-19.
+  const [expired, setExpired] = useState(() => Date.now() >= expires);
   useEffect(() => {
     if (expired) return;
-    const id = setInterval(() => setNow(Date.now()), 1000);
-    return () => clearInterval(id);
-  }, [expired]);
+    const remaining = expires - Date.now();
+    if (remaining <= 0) {
+      setExpired(true);
+      return;
+    }
+    const id = setTimeout(() => setExpired(true), remaining);
+    return () => clearTimeout(id);
+  }, [expires, expired]);
 
   // Merge external (keyboard-path) in-flight state with the card's own.
   // The button visuals respect either source so users see a spinner


### PR DESCRIPTION
## Summary
- ApprovalCard ran a 1Hz \`setInterval\` per instance purely to flip an \`expired\` boolean
- With 50 pending approvals that's 50 timers + 50 component re-renders/sec
- Replaced with a single \`setTimeout\` scheduled for the exact expiry moment; card re-renders exactly once (Countdown pill → Expired pill)
- Countdown display itself ticks inside the leaf \`<CountdownTimer>\` component — unchanged

## Test plan
- [ ] Approval near expiry shows countdown ticking down (CountdownTimer owns this)
- [ ] At T=0 the pill flips to "Expired"
- [ ] Card mounted with already-expired \`expires\` shows Expired immediately, no timer scheduled
- [ ] React DevTools profiler: ApprovalCard no longer re-renders 1/sec

🤖 Generated with [Claude Code](https://claude.com/claude-code)