### PR TITLE
perf(AnimatedNumber): skip rAF loop when value already matches target

### DIFF
--- a/dashboard/src/components/patchwork/AnimatedNumber.tsx
+++ b/dashboard/src/components/patchwork/AnimatedNumber.tsx
@@ -21,6 +21,14 @@ export function AnimatedNumber({
   const flashTone = useRef<"up" | "down" | null>(null);
 
   useEffect(() => {
+    // Effect deps are [value, duration] — but a parent re-render that
+    // hands us an identical number still re-runs the effect when the
+    // component itself re-renders (not when deps change). Guard against
+    // that: if `value` already matches both the animation target and
+    // the displayed number, skip the rAF loop entirely.
+    if (fromRef.current === value && prevValueRef.current === value) {
+      return;
+    }
     if (prevValueRef.current !== value) {
       flashTone.current = value > prevValueRef.current ? "up" : "down";
       setFlashKey((k) => k + 1);


### PR DESCRIPTION
## Summary
- AnimatedNumber's effect schedules a 1200ms rAF on first mount even when \`fromRef.current\` already equals \`value\` (both initialize from the same value via useState/useRef)
- 3 stat cards on /runs × 1200ms wasted rAF tick on every page load
- Guards effect to bail when displayed value + animation start-point already match target

## Test plan
- [ ] /runs cold load — stat numbers display immediately, no nearly-imperceptible count from N to N
- [ ] When a stat changes (e.g., new run completes), AnimatedNumber still counts up + flashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)