### PR TITLE
perf(live-runs): vanilla store + useSyncExternalStore per-key selectors

### DIFF
--- a/dashboard/src/hooks/LiveRunsContext.tsx
+++ b/dashboard/src/hooks/LiveRunsContext.tsx
@@ -1,62 +1,235 @@
 "use client";
-import { createContext, useContext, useMemo, type ReactNode } from "react";
-import { useRecipeRunStream, type ActiveRunState } from "./useRecipeRunStream";
+import { useEffect, useRef, useSyncExternalStore, type ReactNode } from "react";
+import { useBridgeStream } from "./useBridgeStream";
+import type { ActiveRunState } from "./useRecipeRunStream";
 
 /**
- * Shell-level provider that holds ONE SSE subscription to the bridge's
- * lifecycle stream and exposes the live "what's running right now" map
- * to every page. Before this, each page that wanted the data opened its
- * own EventSource — /recipes opened one, /runs opened another, and any
- * page that wanted a sidebar badge would have opened a third.
+ * Shell-level live-runs store backed by a vanilla pub-sub + a single
+ * shared SSE subscription. Selectors use `useSyncExternalStore` with
+ * per-key subscriptions, so a row consumer only re-renders when ITS
+ * recipe's slice changes — not on every step event from every recipe.
  *
- * Mount once in `Shell.tsx`; consumers call `useActiveRuns()`,
- * `useRecipeRun(name)`, or `useActiveRunCount()`. The selector hooks
- * memoize so a row consumer only sees a re-render when ITS recipe
- * changes, not on every step event.
+ * The previous shape (useState<Map> behind a Context value) emitted a
+ * fresh Map identity on every event, which made every page mounted
+ * under Shell re-render unconditionally.
  */
 
-interface LiveRunsValue {
-  active: Map<string, ActiveRunState>;
-  connected: boolean;
+const FINAL_HOLD_MS = 30_000;
+
+interface LifecycleEvent {
+  event?: string;
+  metadata?: {
+    runSeq?: number;
+    recipeName?: string;
+    stepId?: string;
+    tool?: string;
+    status?: "ok" | "error" | "skipped";
+    error?: string;
+    durationMs?: number;
+    totalSteps?: number;
+    haltReason?: string;
+    haltCategory?: string;
+  };
+  ts?: number;
 }
 
-const LiveRunsContext = createContext<LiveRunsValue | null>(null);
+type Listener = () => void;
+
+function createStore() {
+  let active = new Map<string, ActiveRunState>();
+  let connected = false;
+  const allListeners = new Set<Listener>();
+  const rowListeners = new Map<string, Set<Listener>>();
+  const connectedListeners = new Set<Listener>();
+  const gcTimers = new Map<string, ReturnType<typeof setTimeout>>();
+
+  function notifyRow(name: string) {
+    const set = rowListeners.get(name);
+    if (set) for (const cb of set) cb();
+  }
+  function notifyAll() {
+    for (const cb of allListeners) cb();
+  }
+
+  function setRow(name: string, next: ActiveRunState | undefined) {
+    const fresh = new Map(active);
+    if (next) fresh.set(name, next);
+    else fresh.delete(name);
+    active = fresh;
+    notifyRow(name);
+    notifyAll();
+  }
+
+  return {
+    applyEvent(type: string, raw: unknown) {
+      if (type !== "lifecycle") return;
+      const data = raw as LifecycleEvent | undefined;
+      const md = data?.metadata;
+      if (!data?.event || !md) return;
+      const name = md.recipeName;
+      if (!name) return;
+
+      if (data.event === "recipe_started") {
+        setRow(name, {
+          runSeq: md.runSeq ?? 0,
+          recipeName: name,
+          totalSteps: md.totalSteps ?? 0,
+          doneSteps: 0,
+          startedAt: data.ts ?? Date.now(),
+          status: "running",
+        });
+        const t = gcTimers.get(name);
+        if (t) {
+          clearTimeout(t);
+          gcTimers.delete(name);
+        }
+      } else if (data.event === "recipe_step_start") {
+        const cur = active.get(name);
+        if (!cur) return;
+        setRow(name, { ...cur, currentStepId: md.stepId, currentTool: md.tool });
+      } else if (data.event === "recipe_step_done") {
+        const cur = active.get(name);
+        if (!cur) return;
+        setRow(name, {
+          ...cur,
+          doneSteps: cur.doneSteps + 1,
+          lastError: md.status === "error" ? md.error : cur.lastError,
+        });
+      } else if (data.event === "recipe_done") {
+        const cur = active.get(name);
+        if (!cur) return;
+        const status: ActiveRunState["status"] = md.haltReason
+          ? "halted"
+          : md.status === "error"
+            ? "error"
+            : "ok";
+        setRow(name, {
+          ...cur,
+          endedAt: data.ts ?? Date.now(),
+          status,
+          haltReason: md.haltReason,
+          haltCategory: md.haltCategory,
+        });
+        const t = gcTimers.get(name);
+        if (t) clearTimeout(t);
+        const timer = setTimeout(() => {
+          if (active.has(name)) setRow(name, undefined);
+          gcTimers.delete(name);
+        }, FINAL_HOLD_MS);
+        gcTimers.set(name, timer);
+      }
+    },
+    setConnected(next: boolean) {
+      if (connected === next) return;
+      connected = next;
+      for (const cb of connectedListeners) cb();
+    },
+    getAll: () => active,
+    getRow: (name: string | undefined) => (name ? active.get(name) : undefined),
+    getConnected: () => connected,
+    getActiveCount: () => {
+      let n = 0;
+      for (const v of active.values()) if (v.status === "running") n++;
+      return n;
+    },
+    subscribeAll(cb: Listener) {
+      allListeners.add(cb);
+      return () => {
+        allListeners.delete(cb);
+      };
+    },
+    subscribeRow(name: string, cb: Listener) {
+      let set = rowListeners.get(name);
+      if (!set) {
+        set = new Set();
+        rowListeners.set(name, set);
+      }
+      set.add(cb);
+      return () => {
+        const cur = rowListeners.get(name);
+        if (!cur) return;
+        cur.delete(cb);
+        if (cur.size === 0) rowListeners.delete(name);
+      };
+    },
+    subscribeConnected(cb: Listener) {
+      connectedListeners.add(cb);
+      return () => {
+        connectedListeners.delete(cb);
+      };
+    },
+    clearGcTimers() {
+      for (const t of gcTimers.values()) clearTimeout(t);
+      gcTimers.clear();
+    },
+  };
+}
+
+// Module-singleton. One store per browser tab; safe because the
+// provider mounts once at Shell.
+const store = createStore();
+
+const EMPTY_MAP: Map<string, ActiveRunState> = new Map();
+const subscribeEmpty = () => () => {};
+
+function isBrowser() {
+  return typeof window !== "undefined";
+}
 
 export function LiveRunsProvider({ children }: { children: ReactNode }) {
-  const { active, connected } = useRecipeRunStream();
-  const value = useMemo(() => ({ active, connected }), [active, connected]);
-  return <LiveRunsContext.Provider value={value}>{children}</LiveRunsContext.Provider>;
-}
+  // Stable callback ref so useBridgeStream doesn't churn.
+  const onEvent = useRef((type: string, raw: unknown) => {
+    store.applyEvent(type, raw);
+  }).current;
+  const { connected } = useBridgeStream("/api/bridge/stream", onEvent);
 
-function useLiveRunsValue(): LiveRunsValue {
-  const v = useContext(LiveRunsContext);
-  // When a consumer renders outside the provider (e.g. tests, storybook),
-  // return an empty Map rather than throwing — graceful no-op.
-  return v ?? EMPTY_VALUE;
+  useEffect(() => {
+    store.setConnected(connected);
+  }, [connected]);
+
+  useEffect(() => {
+    return () => {
+      store.clearGcTimers();
+    };
+  }, []);
+
+  return <>{children}</>;
 }
-const EMPTY_VALUE: LiveRunsValue = { active: new Map(), connected: false };
 
 /** Full live-runs Map keyed by recipeName. */
 export function useActiveRuns(): Map<string, ActiveRunState> {
-  return useLiveRunsValue().active;
+  return useSyncExternalStore(
+    isBrowser() ? store.subscribeAll : subscribeEmpty,
+    store.getAll,
+    () => EMPTY_MAP,
+  );
 }
 
-/** Lookup a single recipe's live state; undefined if none. */
+/**
+ * Per-recipe selector — only fires when THIS recipe's slice changes.
+ * `name` may be undefined for callers behind conditional data.
+ */
 export function useRecipeRun(name: string | undefined): ActiveRunState | undefined {
-  const { active } = useLiveRunsValue();
-  if (!name) return undefined;
-  return active.get(name);
+  const subscribe =
+    name && isBrowser() ? (cb: Listener) => store.subscribeRow(name, cb) : subscribeEmpty;
+  const getSnapshot = () => store.getRow(name);
+  return useSyncExternalStore(subscribe, getSnapshot, () => undefined);
 }
 
 /** Count of currently-running (status === "running") recipes. */
 export function useActiveRunCount(): number {
-  const { active } = useLiveRunsValue();
-  let n = 0;
-  for (const v of active.values()) if (v.status === "running") n++;
-  return n;
+  return useSyncExternalStore(
+    isBrowser() ? store.subscribeAll : subscribeEmpty,
+    store.getActiveCount,
+    () => 0,
+  );
 }
 
 /** Bridge-stream connection state (boolean). */
 export function useLiveRunsConnected(): boolean {
-  return useLiveRunsValue().connected;
+  return useSyncExternalStore(
+    isBrowser() ? store.subscribeConnected : subscribeEmpty,
+    store.getConnected,
+    () => false,
+  );
 }


### PR DESCRIPTION
## Summary
- Replace \`useState<Map>\` inside the LiveRuns provider with a module-level pub-sub store
- Selectors now use \`useSyncExternalStore\` with **per-recipe-name** subscriptions
- A consumer of \`useRecipeRun(name)\` only re-renders when *that* recipe's slice changes — not on every SSE step event for every recipe

Hot path: when 5+ recipes are running concurrently, /recipes used to reconcile the entire page on every step. Now only the row whose name changed reconciles.

## Test plan
- [ ] /recipes still shows live RecipeRunInline chips
- [ ] LivePill still updates connection state
- [ ] Tests pass (\`npx vitest run src/hooks\` — 44/44 green locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)