### PR TITLE
perf(sse): multiplex bridge stream through the shared singleton

### DIFF
--- a/dashboard/src/hooks/LiveRunsContext.tsx
+++ b/dashboard/src/hooks/LiveRunsContext.tsx
@@ -1,6 +1,6 @@
 "use client";
-import { useEffect, useRef, useSyncExternalStore, type ReactNode } from "react";
-import { useBridgeStream } from "./useBridgeStream";
+import { useEffect, useSyncExternalStore, type ReactNode } from "react";
+import { subscribeStreamLiveness, subscribeStreamMessage } from "@/lib/streamLiveness";
 import type { ActiveRunState } from "./useRecipeRunStream";
 
 /**
@@ -177,18 +177,20 @@ function isBrowser() {
 }
 
 export function LiveRunsProvider({ children }: { children: ReactNode }) {
-  // Stable callback ref so useBridgeStream doesn't churn.
-  const onEvent = useRef((type: string, raw: unknown) => {
-    store.applyEvent(type, raw);
-  }).current;
-  const { connected } = useBridgeStream("/api/bridge/stream", onEvent);
-
+  // Subscribe to the shared singleton SSE stream rather than opening
+  // a second EventSource. Both subscriptions are idempotent; the
+  // stream opens lazily on first subscriber and tears down when the
+  // last unsubscribes.
   useEffect(() => {
-    store.setConnected(connected);
-  }, [connected]);
-
-  useEffect(() => {
+    const unMsg = subscribeStreamMessage((type, data) => {
+      store.applyEvent(type, data);
+    });
+    const unLive = subscribeStreamLiveness((live) => {
+      store.setConnected(live);
+    });
     return () => {
+      unMsg();
+      unLive();
       store.clearGcTimers();
     };
   }, []);

--- a/dashboard/src/lib/streamLiveness.ts
+++ b/dashboard/src/lib/streamLiveness.ts
@@ -25,6 +25,7 @@ import { apiPath } from "@/lib/api";
  */
 
 const listeners = new Set<(live: boolean) => void>();
+const messageListeners = new Set<(type: string, data: unknown) => void>();
 let es: EventSource | null = null;
 let isLive = false;
 let lastHeartbeatAt = 0;
@@ -57,9 +58,28 @@ function ensureStream() {
     setLive(true);
   };
 
-  es.onmessage = () => {
+  es.onmessage = (msg) => {
     lastHeartbeatAt = Date.now();
     if (!isLive) setLive(true);
+    if (messageListeners.size === 0) return;
+    // Parse + dispatch to message subscribers. Wrapped in try so a
+    // malformed payload doesn't break the heartbeat path above.
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(msg.data);
+    } catch {
+      return;
+    }
+    const obj = parsed as { kind?: string; type?: string } | null;
+    const type =
+      (obj && typeof obj === "object" && (obj.kind ?? obj.type)) || "message";
+    for (const cb of messageListeners) {
+      try {
+        cb(type, parsed);
+      } catch {
+        // isolate one bad subscriber from the rest
+      }
+    }
   };
 
   es.onerror = () => {
@@ -75,6 +95,33 @@ function teardownStream() {
   es.close();
   es = null;
   isLive = false;
+}
+
+function streamHasSubscribers(): boolean {
+  return listeners.size > 0 || messageListeners.size > 0;
+}
+
+/**
+ * Subscribe to parsed SSE messages from the shared stream. Returns
+ * unsubscribe. The callback receives `(type, data)` where `type` is
+ * pulled from `data.kind` (preferred) or `data.type`, falling back
+ * to `"message"`. Malformed JSON payloads are dropped silently.
+ *
+ * Consumers that previously opened their own EventSource on
+ * `/api/bridge/stream` should subscribe here instead — same stream,
+ * one socket per tab.
+ */
+export function subscribeStreamMessage(
+  cb: (type: string, data: unknown) => void,
+): () => void {
+  messageListeners.add(cb);
+  ensureStream();
+  return () => {
+    messageListeners.delete(cb);
+    if (!streamHasSubscribers()) {
+      teardownStream();
+    }
+  };
 }
 
 /**
@@ -101,7 +148,7 @@ export function subscribeStreamLiveness(
   return () => {
     listeners.delete(cb);
     clearInterval(sweepId);
-    if (listeners.size === 0) {
+    if (!streamHasSubscribers()) {
       teardownStream();
     }
   };


### PR DESCRIPTION
## Summary
- Extend \`streamLiveness\` with \`subscribeStreamMessage(cb)\` — parses each SSE payload once and fans out
- \`LiveRunsProvider\` subscribes there instead of opening a second EventSource via \`useBridgeStream\`
- One socket per tab for \`/api/bridge/stream\` (down from 2)

## Why
LiveRuns + streamLiveness were both holding sockets to the same endpoint. The shared singleton already handles open/teardown / heartbeat sweep — this PR just lets non-liveness consumers ride the same connection.

## Test plan
- [ ] /recipes still shows live RecipeRunInline chips when a recipe runs
- [ ] Sidebar liveness pip still flips on bridge disconnect
- [ ] 281 hook + lib tests pass

Follow-ups (separate PRs): migrate /activity, /approvals, /settings off their direct \`new EventSource\` calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)