### PR TITLE
perf(activity): subscribe to shared SSE singleton

### DIFF
--- a/dashboard/src/app/activity/page.tsx
+++ b/dashboard/src/app/activity/page.tsx
@@ -5,6 +5,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { apiPath } from "@/lib/api";
 import { relTime } from "@/components/time";
 import { ACTIVITY_NOISE_EVENTS } from "@/lib/activityNoise";
+import { subscribeStreamLiveness, subscribeStreamMessage } from "@/lib/streamLiveness";
 import { markHaltsSeen } from "@/lib/haltsSeen";
 import {
   EmptyState,
@@ -120,7 +121,6 @@ export default function ActivityPage() {
     router.replace(qs ? `?${qs}` : "?", { scroll: false });
   };
   const [, setTick] = useState(0);
-  const esRef = useRef<EventSource | null>(null);
   // Pause/resume — events that arrive while paused are buffered so the
   // user doesn't lose context while inspecting a row. Counter drives the
   // resume button label so the user knows what's accumulating.
@@ -154,52 +154,54 @@ export default function ActivityPage() {
     };
   }, []);
 
+  // Subscribe to the shared singleton SSE stream — one socket per tab
+  // serves /activity, the LiveRuns store, and the header liveness pip.
+  // Tri-state: streamLiveness reports a boolean; if it stays false for
+  // OFFLINE_AFTER_MS the page downgrades "reconnecting" → "offline".
   useEffect(() => {
-    // Browser EventSource auto-retries forever on error. We give up on
-    // showing "reconnecting" and downgrade to "offline" after this many
-    // consecutive errors without a successful open in between.
-    const MAX_SSE_FAILURES = 5;
-    let consecutiveErrors = 0;
-    const es = new EventSource(apiPath("/api/bridge/stream"));
-    esRef.current = es;
-    es.onopen = () => {
-      consecutiveErrors = 0;
-      setConnection("live");
-      setErr(undefined);
-    };
-    es.onerror = () => {
-      consecutiveErrors += 1;
-      if (consecutiveErrors >= MAX_SSE_FAILURES) {
-        setConnection("offline");
+    const OFFLINE_AFTER_MS = 30_000;
+    let offlineTimer: ReturnType<typeof setTimeout> | null = null;
+
+    const unMsg = subscribeStreamMessage((_type, raw) => {
+      const entry = withAt(raw as ActivityEvent);
+      if (pausedRef.current) {
+        pendingBufRef.current = [entry, ...pendingBufRef.current].slice(0, MAX_EVENTS);
+        setPendingCount(pendingBufRef.current.length);
+        return;
+      }
+      setEvents((prev) => {
+        if (
+          entry.id !== undefined &&
+          prev.some((p) => p.id === entry.id && p.kind === entry.kind)
+        ) {
+          return prev;
+        }
+        return [entry, ...prev].slice(0, MAX_EVENTS);
+      });
+    });
+
+    const unLive = subscribeStreamLiveness((live) => {
+      if (offlineTimer) {
+        clearTimeout(offlineTimer);
+        offlineTimer = null;
+      }
+      if (live) {
+        setConnection("live");
+        setErr(undefined);
       } else {
         setConnection("reconnecting");
+        setErr("Disconnected — reconnecting…");
+        offlineTimer = setTimeout(() => {
+          setConnection("offline");
+        }, OFFLINE_AFTER_MS);
       }
-      setErr("Disconnected — reconnecting…");
+    });
+
+    return () => {
+      unMsg();
+      unLive();
+      if (offlineTimer) clearTimeout(offlineTimer);
     };
-    es.onmessage = (msg) => {
-      try {
-        const entry = withAt(JSON.parse(msg.data) as ActivityEvent);
-        if (pausedRef.current) {
-          pendingBufRef.current = [entry, ...pendingBufRef.current].slice(0, MAX_EVENTS);
-          setPendingCount(pendingBufRef.current.length);
-          return;
-        }
-        setEvents((prev) => {
-          // Dedup by (id, kind) so the first live event doesn't duplicate
-          // the most recent history row.
-          if (
-            entry.id !== undefined &&
-            prev.some((p) => p.id === entry.id && p.kind === entry.kind)
-          ) {
-            return prev;
-          }
-          return [entry, ...prev].slice(0, MAX_EVENTS);
-        });
-      } catch {
-        // ignore
-      }
-    };
-    return () => es.close();
   }, []);
 
   // Tick for relative timestamps. Was 1Hz which forced 200-event

--- a/dashboard/src/hooks/LiveRunsContext.tsx
+++ b/dashboard/src/hooks/LiveRunsContext.tsx
@@ -1,6 +1,6 @@
 "use client";
-import { useEffect, useRef, useSyncExternalStore, type ReactNode } from "react";
-import { useBridgeStream } from "./useBridgeStream";
+import { useEffect, useSyncExternalStore, type ReactNode } from "react";
+import { subscribeStreamLiveness, subscribeStreamMessage } from "@/lib/streamLiveness";
 import type { ActiveRunState } from "./useRecipeRunStream";
 
 /**
@@ -177,18 +177,20 @@ function isBrowser() {
 }
 
 export function LiveRunsProvider({ children }: { children: ReactNode }) {
-  // Stable callback ref so useBridgeStream doesn't churn.
-  const onEvent = useRef((type: string, raw: unknown) => {
-    store.applyEvent(type, raw);
-  }).current;
-  const { connected } = useBridgeStream("/api/bridge/stream", onEvent);
-
+  // Subscribe to the shared singleton SSE stream rather than opening
+  // a second EventSource. Both subscriptions are idempotent; the
+  // stream opens lazily on first subscriber and tears down when the
+  // last unsubscribes.
   useEffect(() => {
-    store.setConnected(connected);
-  }, [connected]);
-
-  useEffect(() => {
+    const unMsg = subscribeStreamMessage((type, data) => {
+      store.applyEvent(type, data);
+    });
+    const unLive = subscribeStreamLiveness((live) => {
+      store.setConnected(live);
+    });
     return () => {
+      unMsg();
+      unLive();
       store.clearGcTimers();
     };
   }, []);

--- a/dashboard/src/lib/streamLiveness.ts
+++ b/dashboard/src/lib/streamLiveness.ts
@@ -25,6 +25,7 @@ import { apiPath } from "@/lib/api";
  */
 
 const listeners = new Set<(live: boolean) => void>();
+const messageListeners = new Set<(type: string, data: unknown) => void>();
 let es: EventSource | null = null;
 let isLive = false;
 let lastHeartbeatAt = 0;
@@ -57,9 +58,28 @@ function ensureStream() {
     setLive(true);
   };
 
-  es.onmessage = () => {
+  es.onmessage = (msg) => {
     lastHeartbeatAt = Date.now();
     if (!isLive) setLive(true);
+    if (messageListeners.size === 0) return;
+    // Parse + dispatch to message subscribers. Wrapped in try so a
+    // malformed payload doesn't break the heartbeat path above.
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(msg.data);
+    } catch {
+      return;
+    }
+    const obj = parsed as { kind?: string; type?: string } | null;
+    const type =
+      (obj && typeof obj === "object" && (obj.kind ?? obj.type)) || "message";
+    for (const cb of messageListeners) {
+      try {
+        cb(type, parsed);
+      } catch {
+        // isolate one bad subscriber from the rest
+      }
+    }
   };
 
   es.onerror = () => {
@@ -75,6 +95,33 @@ function teardownStream() {
   es.close();
   es = null;
   isLive = false;
+}
+
+function streamHasSubscribers(): boolean {
+  return listeners.size > 0 || messageListeners.size > 0;
+}
+
+/**
+ * Subscribe to parsed SSE messages from the shared stream. Returns
+ * unsubscribe. The callback receives `(type, data)` where `type` is
+ * pulled from `data.kind` (preferred) or `data.type`, falling back
+ * to `"message"`. Malformed JSON payloads are dropped silently.
+ *
+ * Consumers that previously opened their own EventSource on
+ * `/api/bridge/stream` should subscribe here instead — same stream,
+ * one socket per tab.
+ */
+export function subscribeStreamMessage(
+  cb: (type: string, data: unknown) => void,
+): () => void {
+  messageListeners.add(cb);
+  ensureStream();
+  return () => {
+    messageListeners.delete(cb);
+    if (!streamHasSubscribers()) {
+      teardownStream();
+    }
+  };
 }
 
 /**
@@ -101,7 +148,7 @@ export function subscribeStreamLiveness(
   return () => {
     listeners.delete(cb);
     clearInterval(sweepId);
-    if (listeners.size === 0) {
+    if (!streamHasSubscribers()) {
       teardownStream();
     }
   };


### PR DESCRIPTION
## Summary
- /activity drops its direct \`new EventSource("/api/bridge/stream")\` and consumes parsed messages via \`subscribeStreamMessage\` (from #700)
- Connection tri-state preserved with a local 30s settle timer: live → reconnecting (immediate) → offline (after 30s of staying false)

## Stack
- Targets \`perf/sse-multiplex\` (#700). Retarget to \`main\` after #700 squash-merges.

## Test plan
- [ ] /activity still shows new events arriving live
- [ ] Pause/resume buffer still works (events queue while paused, flush on resume)
- [ ] Tri-state LivePill on /activity still flips live → reconnecting → offline correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)