### PR TITLE
perf(settings): subscribe to shared SSE singleton

### DIFF
--- a/dashboard/src/app/activity/page.tsx
+++ b/dashboard/src/app/activity/page.tsx
@@ -5,6 +5,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { apiPath } from "@/lib/api";
 import { relTime } from "@/components/time";
 import { ACTIVITY_NOISE_EVENTS } from "@/lib/activityNoise";
+import { subscribeStreamLiveness, subscribeStreamMessage } from "@/lib/streamLiveness";
 import { markHaltsSeen } from "@/lib/haltsSeen";
 import {
   EmptyState,
@@ -120,7 +121,6 @@ export default function ActivityPage() {
     router.replace(qs ? `?${qs}` : "?", { scroll: false });
   };
   const [, setTick] = useState(0);
-  const esRef = useRef<EventSource | null>(null);
   // Pause/resume — events that arrive while paused are buffered so the
   // user doesn't lose context while inspecting a row. Counter drives the
   // resume button label so the user knows what's accumulating.
@@ -154,52 +154,54 @@ export default function ActivityPage() {
     };
   }, []);
 
+  // Subscribe to the shared singleton SSE stream — one socket per tab
+  // serves /activity, the LiveRuns store, and the header liveness pip.
+  // Tri-state: streamLiveness reports a boolean; if it stays false for
+  // OFFLINE_AFTER_MS the page downgrades "reconnecting" → "offline".
   useEffect(() => {
-    // Browser EventSource auto-retries forever on error. We give up on
-    // showing "reconnecting" and downgrade to "offline" after this many
-    // consecutive errors without a successful open in between.
-    const MAX_SSE_FAILURES = 5;
-    let consecutiveErrors = 0;
-    const es = new EventSource(apiPath("/api/bridge/stream"));
-    esRef.current = es;
-    es.onopen = () => {
-      consecutiveErrors = 0;
-      setConnection("live");
-      setErr(undefined);
-    };
-    es.onerror = () => {
-      consecutiveErrors += 1;
-      if (consecutiveErrors >= MAX_SSE_FAILURES) {
-        setConnection("offline");
+    const OFFLINE_AFTER_MS = 30_000;
+    let offlineTimer: ReturnType<typeof setTimeout> | null = null;
+
+    const unMsg = subscribeStreamMessage((_type, raw) => {
+      const entry = withAt(raw as ActivityEvent);
+      if (pausedRef.current) {
+        pendingBufRef.current = [entry, ...pendingBufRef.current].slice(0, MAX_EVENTS);
+        setPendingCount(pendingBufRef.current.length);
+        return;
+      }
+      setEvents((prev) => {
+        if (
+          entry.id !== undefined &&
+          prev.some((p) => p.id === entry.id && p.kind === entry.kind)
+        ) {
+          return prev;
+        }
+        return [entry, ...prev].slice(0, MAX_EVENTS);
+      });
+    });
+
+    const unLive = subscribeStreamLiveness((live) => {
+      if (offlineTimer) {
+        clearTimeout(offlineTimer);
+        offlineTimer = null;
+      }
+      if (live) {
+        setConnection("live");
+        setErr(undefined);
       } else {
         setConnection("reconnecting");
+        setErr("Disconnected — reconnecting…");
+        offlineTimer = setTimeout(() => {
+          setConnection("offline");
+        }, OFFLINE_AFTER_MS);
       }
-      setErr("Disconnected — reconnecting…");
+    });
+
+    return () => {
+      unMsg();
+      unLive();
+      if (offlineTimer) clearTimeout(offlineTimer);
     };
-    es.onmessage = (msg) => {
-      try {
-        const entry = withAt(JSON.parse(msg.data) as ActivityEvent);
-        if (pausedRef.current) {
-          pendingBufRef.current = [entry, ...pendingBufRef.current].slice(0, MAX_EVENTS);
-          setPendingCount(pendingBufRef.current.length);
-          return;
-        }
-        setEvents((prev) => {
-          // Dedup by (id, kind) so the first live event doesn't duplicate
-          // the most recent history row.
-          if (
-            entry.id !== undefined &&
-            prev.some((p) => p.id === entry.id && p.kind === entry.kind)
-          ) {
-            return prev;
-          }
-          return [entry, ...prev].slice(0, MAX_EVENTS);
-        });
-      } catch {
-        // ignore
-      }
-    };
-    return () => es.close();
   }, []);
 
   // Tick for relative timestamps. Was 1Hz which forced 200-event

--- a/dashboard/src/app/settings/page.tsx
+++ b/dashboard/src/app/settings/page.tsx
@@ -2,6 +2,7 @@
 import { useEffect, useRef, useState } from "react";
 import { fmtDuration } from "@/components/time";
 import { apiPath } from "@/lib/api";
+import { subscribeStreamMessage } from "@/lib/streamLiveness";
 import { EmptyState, StatusPill } from "@/components/patchwork";
 import {
   getPushSubscriptionStatus,
@@ -445,65 +446,17 @@ export default function SettingsPage() {
   }, []);
 
   // v2-I8 (#422): SSE consumer for kind:"kill-switch" events from /stream.
-  // When the bridge emits a state-change event the toggle updates in <1s
-  // without waiting for the next 5-second poll cycle.
+  // Subscribes via the shared singleton (#700) — one socket per tab
+  // serves the kill-switch listener, /activity, the LiveRuns store,
+  // and the header liveness pip. Singleton owns reconnect/backoff.
   useEffect(() => {
-    // #600 + audit 2026-05-18: cap reconnect attempts AND fix the
-    // counter race. Native EventSource fires `onerror` on every
-    // reconnect blip (readyState=CONNECTING) *and* on terminal close
-    // (readyState=CLOSED). Bumping a counter on every fire used to
-    // close the stream inside seconds on flaky links because the
-    // browser tried to reconnect faster than `onopen` reset the
-    // counter. Now we only count when the browser has given up
-    // (readyState=CLOSED), and we schedule a manual reconnect with
-    // exponential backoff after that. The 5s settings poll provides
-    // a fallback while the stream is paused.
-    const MAX_FAILURES = 5;
-    const BACKOFF_MS = [5_000, 10_000, 30_000, 60_000, 60_000];
-    let failures = 0;
-    let es: EventSource | null = null;
-    let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
-    let cancelled = false;
-
-    const connect = () => {
-      if (cancelled) return;
-      es = new EventSource(apiPath("/api/bridge/stream"));
-      es.onopen = () => {
-        failures = 0;
-      };
-      es.onmessage = (msg) => {
-        try {
-          const evt = JSON.parse(msg.data) as {
-            kind?: string;
-            engaged?: boolean;
-          };
-          if (
-            evt.kind === "kill-switch" &&
-            typeof evt.engaged === "boolean"
-          ) {
-            setKsEngaged(evt.engaged);
-          }
-        } catch {
-          // ignore malformed events
-        }
-      };
-      es.onerror = () => {
-        // Transient (browser is auto-reconnecting): no-op, let it.
-        if (es?.readyState !== EventSource.CLOSED) return;
-        // Terminal close — counts as one failure.
-        failures += 1;
-        if (failures >= MAX_FAILURES) return;
-        const delay = BACKOFF_MS[Math.min(failures - 1, BACKOFF_MS.length - 1)];
-        reconnectTimer = setTimeout(connect, delay);
-      };
-    };
-    connect();
-
-    return () => {
-      cancelled = true;
-      if (reconnectTimer) clearTimeout(reconnectTimer);
-      es?.close();
-    };
+    return subscribeStreamMessage((type, raw) => {
+      if (type !== "kill-switch") return;
+      const evt = raw as { engaged?: boolean } | null;
+      if (evt && typeof evt.engaged === "boolean") {
+        setKsEngaged(evt.engaged);
+      }
+    });
   }, []);
 
   // Load CC permission rules for the approval policy section

--- a/dashboard/src/hooks/LiveRunsContext.tsx
+++ b/dashboard/src/hooks/LiveRunsContext.tsx
@@ -1,6 +1,6 @@
 "use client";
-import { useEffect, useRef, useSyncExternalStore, type ReactNode } from "react";
-import { useBridgeStream } from "./useBridgeStream";
+import { useEffect, useSyncExternalStore, type ReactNode } from "react";
+import { subscribeStreamLiveness, subscribeStreamMessage } from "@/lib/streamLiveness";
 import type { ActiveRunState } from "./useRecipeRunStream";
 
 /**
@@ -177,18 +177,20 @@ function isBrowser() {
 }
 
 export function LiveRunsProvider({ children }: { children: ReactNode }) {
-  // Stable callback ref so useBridgeStream doesn't churn.
-  const onEvent = useRef((type: string, raw: unknown) => {
-    store.applyEvent(type, raw);
-  }).current;
-  const { connected } = useBridgeStream("/api/bridge/stream", onEvent);
-
+  // Subscribe to the shared singleton SSE stream rather than opening
+  // a second EventSource. Both subscriptions are idempotent; the
+  // stream opens lazily on first subscriber and tears down when the
+  // last unsubscribes.
   useEffect(() => {
-    store.setConnected(connected);
-  }, [connected]);
-
-  useEffect(() => {
+    const unMsg = subscribeStreamMessage((type, data) => {
+      store.applyEvent(type, data);
+    });
+    const unLive = subscribeStreamLiveness((live) => {
+      store.setConnected(live);
+    });
     return () => {
+      unMsg();
+      unLive();
       store.clearGcTimers();
     };
   }, []);

--- a/dashboard/src/lib/streamLiveness.ts
+++ b/dashboard/src/lib/streamLiveness.ts
@@ -25,6 +25,7 @@ import { apiPath } from "@/lib/api";
  */
 
 const listeners = new Set<(live: boolean) => void>();
+const messageListeners = new Set<(type: string, data: unknown) => void>();
 let es: EventSource | null = null;
 let isLive = false;
 let lastHeartbeatAt = 0;
@@ -57,9 +58,28 @@ function ensureStream() {
     setLive(true);
   };
 
-  es.onmessage = () => {
+  es.onmessage = (msg) => {
     lastHeartbeatAt = Date.now();
     if (!isLive) setLive(true);
+    if (messageListeners.size === 0) return;
+    // Parse + dispatch to message subscribers. Wrapped in try so a
+    // malformed payload doesn't break the heartbeat path above.
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(msg.data);
+    } catch {
+      return;
+    }
+    const obj = parsed as { kind?: string; type?: string } | null;
+    const type =
+      (obj && typeof obj === "object" && (obj.kind ?? obj.type)) || "message";
+    for (const cb of messageListeners) {
+      try {
+        cb(type, parsed);
+      } catch {
+        // isolate one bad subscriber from the rest
+      }
+    }
   };
 
   es.onerror = () => {
@@ -75,6 +95,33 @@ function teardownStream() {
   es.close();
   es = null;
   isLive = false;
+}
+
+function streamHasSubscribers(): boolean {
+  return listeners.size > 0 || messageListeners.size > 0;
+}
+
+/**
+ * Subscribe to parsed SSE messages from the shared stream. Returns
+ * unsubscribe. The callback receives `(type, data)` where `type` is
+ * pulled from `data.kind` (preferred) or `data.type`, falling back
+ * to `"message"`. Malformed JSON payloads are dropped silently.
+ *
+ * Consumers that previously opened their own EventSource on
+ * `/api/bridge/stream` should subscribe here instead — same stream,
+ * one socket per tab.
+ */
+export function subscribeStreamMessage(
+  cb: (type: string, data: unknown) => void,
+): () => void {
+  messageListeners.add(cb);
+  ensureStream();
+  return () => {
+    messageListeners.delete(cb);
+    if (!streamHasSubscribers()) {
+      teardownStream();
+    }
+  };
 }
 
 /**
@@ -101,7 +148,7 @@ export function subscribeStreamLiveness(
   return () => {
     listeners.delete(cb);
     clearInterval(sweepId);
-    if (listeners.size === 0) {
+    if (!streamHasSubscribers()) {
       teardownStream();
     }
   };


### PR DESCRIPTION
## Summary
- /settings drops 60 lines of bespoke EventSource + exponential-backoff reconnect logic
- Consumes \`kind === "kill-switch"\` events via \`subscribeStreamMessage\` (from #700)
- Singleton handles reconnect; kill-switch toggle still updates in <1s of bridge state change

## Stack
- Targets \`perf/activity-shared-sse\` (#701). Retarget after #700/#701 squash-merge.

## Test plan
- [ ] Engage kill switch via CLI → /settings toggle flips within ~1s
- [ ] Disengage → toggle flips back
- [ ] No regression in the 5s polling fallback (still in place)

🤖 Generated with [Claude Code](https://claude.com/claude-code)