### PR TITLE
feat(nav): live-runs badge on the /runs sidebar entry

### DIFF
--- a/dashboard/src/app/globals.css
+++ b/dashboard/src/app/globals.css
@@ -500,6 +500,21 @@ button { font-family: inherit; }
   line-height: 1;
 }
 
+/* "Live now" variant — blue tone + soft pulse to signal motion
+   (active recipe runs). Distinct from .nav-badge (orange, static
+   counter for pending/queued things). */
+.nav-badge.is-live {
+  background: var(--blue);
+  animation: nav-badge-live-pulse 1.8s ease-in-out infinite;
+}
+@keyframes nav-badge-live-pulse {
+  0%, 100% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--blue) 45%, transparent); }
+  50%      { box-shadow: 0 0 0 4px color-mix(in srgb, var(--blue) 0%, transparent); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .nav-badge.is-live { animation: none; }
+}
+
 
 /* ---- Header / Topbar ---- */
 

--- a/dashboard/src/components/Shell.tsx
+++ b/dashboard/src/components/Shell.tsx
@@ -15,7 +15,7 @@ import { KillSwitchBanner } from "./KillSwitchBanner";
 import { PWAInstallPrompt } from "./PWAInstallPrompt";
 import { CardGlow } from "./CardGlow";
 import { CommandPalette } from "./CommandPalette";
-import { LiveRunsProvider } from "@/hooks/LiveRunsContext";
+import { LiveRunsProvider, useActiveRunCount } from "@/hooks/LiveRunsContext";
 
 // ------------------------------------------------------------------ icons
 
@@ -81,7 +81,7 @@ type NavItem = {
   href: string;
   label: string;
   icon: string;
-  badge?: "approvals" | "halts";
+  badge?: "approvals" | "halts" | "runs";
 };
 
 const SECTIONS: { title: string; items: NavItem[] }[] = NAV_SECTIONS.map((s) => ({
@@ -307,6 +307,7 @@ export function Shell({ children }: { children: ReactNode }) {
   const status = useBridgeStatus();
   const approvalCount = useApprovalCount();
   const haltCount = useHaltCount();
+  const runCount = useActiveRunCount();
   const { active, toggle } = useTheme();
   const identity = useIdentity(status);
   const [mobileOpen, setMobileOpen] = useState(false);
@@ -358,11 +359,15 @@ export function Shell({ children }: { children: ReactNode }) {
                 ? approvalCount
                 : item.badge === "halts"
                   ? haltCount
-                  : 0;
+                  : item.badge === "runs"
+                    ? runCount
+                    : 0;
             const badgeLabel =
               item.badge === "approvals"
                 ? `${badgeCount} pending`
-                : `${badgeCount} new halt${badgeCount === 1 ? "" : "s"} since last visit`;
+                : item.badge === "runs"
+                  ? `${badgeCount} run${badgeCount === 1 ? "" : "s"} live now`
+                  : `${badgeCount} new halt${badgeCount === 1 ? "" : "s"} since last visit`;
             const showBadge = !!item.badge && badgeCount > 0;
             return (
               <Link
@@ -376,7 +381,10 @@ export function Shell({ children }: { children: ReactNode }) {
                 </span>
                 <span>{item.label}</span>
                 {showBadge && (
-                  <span className="nav-badge" aria-label={badgeLabel}>
+                  <span
+                    className={`nav-badge${item.badge === "runs" ? " is-live" : ""}`}
+                    aria-label={badgeLabel}
+                  >
                     {badgeCount > 99 ? "99+" : badgeCount}
                   </span>
                 )}
@@ -385,7 +393,7 @@ export function Shell({ children }: { children: ReactNode }) {
           })}
         </div>
       )),
-    [pathname, approvalCount, haltCount],
+    [pathname, approvalCount, haltCount, runCount],
   );
 
   return (

--- a/dashboard/src/lib/navRoutes.ts
+++ b/dashboard/src/lib/navRoutes.ts
@@ -9,7 +9,7 @@
  * Adding a page? Add it here and only here.
  */
 
-export type NavBadge = "approvals" | "halts";
+export type NavBadge = "approvals" | "halts" | "runs";
 
 export interface NavRoute {
   /** Path under the dashboard basePath (no `/dashboard` prefix). */
@@ -117,7 +117,7 @@ export const NAV_SECTIONS: NavSection[] = [
         icon: "activity",
         badge: "halts",
       },
-      { href: "/runs",         label: "Runs",         paletteLabel: "Activity — Runs",         icon: "play" },
+      { href: "/runs",         label: "Runs",         paletteLabel: "Activity — Runs",         icon: "play", badge: "runs" },
       { href: "/tasks",        label: "Tasks",        paletteLabel: "Activity — Tasks",        icon: "tasks" },
       { href: "/sessions",     label: "Sessions",     paletteLabel: "Activity — Sessions",     icon: "person" },
       { href: "/traces",       label: "Traces",       paletteLabel: "Activity — Traces",       icon: "git" },


### PR DESCRIPTION
## Summary
- Wire \`useActiveRunCount()\` (already exported from LiveRunsContext) into the sidebar
- Blue \`.nav-badge.is-live\` variant with a soft pulse — distinct from the orange "pending" badge used for approvals + halts
- Honors \`prefers-reduced-motion\`

## Why
Top recommendation from the recipe-run observability audit: the global "something is running right now" signal was completely missing from the sidebar even though the store already tracked it.

## Test plan
- [ ] Kick off a recipe → sidebar /runs entry shows a blue badge with count
- [ ] Pulse animates smoothly
- [ ] Badge disappears 30s after run completes (matches store GC)
- [ ] Reduced-motion users see static badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)