### PR TITLE
feat(runs): surface mid-run step errors + step anchor on halt

### DIFF
--- a/dashboard/src/app/recipes/_components/RecipeRunInline.tsx
+++ b/dashboard/src/app/recipes/_components/RecipeRunInline.tsx
@@ -134,19 +134,34 @@ export function RecipeRunInline({
 					/>
 				</div>
 			)}
-			{(state.haltReason || state.lastError) && state.status !== "running" && (
+			{(state.haltReason || state.lastError) && (
+				// Mid-run step errors used to be hidden until the run ended —
+				// the gate `status !== "running"` swallowed any in-flight
+				// failure breadcrumb. Surface them inline with a softer
+				// "step failed, continuing" tone; post-run halts keep the
+				// stronger err background.
 				<div
 					className="mono"
 					style={{
 						fontSize: "var(--fs-2xs)",
-						color: "var(--ink-3)",
-						background: "var(--bg-2)",
+						color: state.status === "running" ? "var(--warn)" : "var(--ink-3)",
+						background:
+							state.status === "running"
+								? "color-mix(in srgb, var(--warn) 10%, transparent)"
+								: "var(--bg-2)",
 						padding: "4px 6px",
 						borderRadius: 4,
 						wordBreak: "break-word",
 					}}
 				>
-					{state.haltReason ?? state.lastError}
+					{state.status === "running" && state.lastError ? (
+						<>
+							<span style={{ fontWeight: 600 }}>Step failed — </span>
+							{state.lastError}
+						</>
+					) : (
+						state.haltReason ?? state.lastError
+					)}
 				</div>
 			)}
 		</div>

--- a/dashboard/src/app/runs/[seq]/page.tsx
+++ b/dashboard/src/app/runs/[seq]/page.tsx
@@ -445,12 +445,17 @@ function StepRow({
   return (
     <div
       ref={wrapperRef}
+      // Anchor for halt breadcrumb deep-links. When a run ends with
+      // a haltReason that names a stepId, links can land on
+      // /runs/:seq#step-<id> and scroll the failing row into view.
+      id={`step-${step.id}`}
       style={{
         position: "relative",
         borderBottom: "1px solid var(--border-subtle)",
         borderLeft: step.status === "running"
           ? "3px solid var(--blue)"
           : "3px solid transparent",
+        scrollMarginTop: 80,
         cursor: step.error ? "pointer" : "default",
       }}
       onClick={() => step.error && toggleOpen()}


### PR DESCRIPTION
## Summary
- **RecipeRunInline**: drop the \`status !== "running"\` gate on the \`lastError\` block. Mid-run step errors now show inline with a warn-tone background ("Step failed — …"); post-run halts keep the stronger err background.
- **StepRow** in \`/runs/[seq]\`: add \`id="step-<stepId>"\` + \`scrollMarginTop: 80\` so halt breadcrumbs can deep-link to specific steps.

Wires up the foundation for halt-toast click-through (separate PR).

## Test plan
- [ ] Recipe with a failing step but successful overall run → row shows yellow "Step failed — <msg>" inline while still running
- [ ] Halted run → row keeps the strong err tone with halt reason
- [ ] Navigate to \`/runs/<seq>#step-<id>\` → page scrolls to that step, header doesn't overlap

🤖 Generated with [Claude Code](https://claude.com/claude-code)