### PR TITLE
feat(empty-states): adopt shared EmptyState on 4 ad-hoc pages

### DIFF
--- a/dashboard/src/app/decisions/page.tsx
+++ b/dashboard/src/app/decisions/page.tsx
@@ -7,7 +7,7 @@ import { useBridgeFetch } from "@/hooks/useBridgeFetch";
 import { useDebounced } from "@/hooks/useDebounced";
 import { arr, isRecord, shape, type ShapeCheck } from "@/lib/validate";
 import { DecisionsTabs } from "@/components/DecisionsTabs";
-import { ErrorState, Glossary, HintCard, LivePill } from "@/components/patchwork";
+import { EmptyState, ErrorState, Glossary, HintCard, LivePill } from "@/components/patchwork";
 import { SkeletonList } from "@/components/Skeleton";
 
 interface DecisionTrace {
@@ -293,33 +293,34 @@ function DecisionsContent() {
       )}
 
       {!loading && traces.length === 0 && !error ? (
-        <div className="empty-state">
-          <h3>
-            {!tag && !keyQuery && !textQuery
+        <EmptyState
+          title={
+            !tag && !keyQuery && !textQuery
               ? "No decisions yet"
-              : "No matching decisions"}
-          </h3>
-          <p>
-            {!tag && !keyQuery && !textQuery
+              : "No matching decisions"
+          }
+          description={
+            !tag && !keyQuery && !textQuery
               ? "When an agent resolves a task it can save a short problem/solution note here. New decisions also show up in the next session's start-of-task digest, so the next agent starts with the context."
-              : `No decisions${tag ? ` tagged "${tag}"` : ""}${keyQuery ? ` with ref matching "${keyQuery}"` : ""}${textQuery ? ` containing "${textQuery}"` : ""}.`}
-          </p>
-          {(tag || keyQuery || textQuery) && (
-            <button
-              type="button"
-              onClick={() => {
-                setTag("");
-                setKeyQuery("");
-                setTextQuery("");
-                setSince("30d");
-              }}
-              className="pill muted"
-              style={{ cursor: "pointer", marginTop: "var(--s-3)" }}
-            >
-              Clear filters
-            </button>
-          )}
-        </div>
+              : `No decisions${tag ? ` tagged "${tag}"` : ""}${keyQuery ? ` with ref matching "${keyQuery}"` : ""}${textQuery ? ` containing "${textQuery}"` : ""}.`
+          }
+          action={
+            (tag || keyQuery || textQuery) ? (
+              <button
+                type="button"
+                onClick={() => {
+                  setTag("");
+                  setKeyQuery("");
+                  setTextQuery("");
+                  setSince("30d");
+                }}
+                className="btn sm ghost"
+              >
+                Clear filters
+              </button>
+            ) : undefined
+          }
+        />
       ) : (
         <div
           style={{ display: "flex", flexDirection: "column", gap: "var(--s-2)" }}

--- a/dashboard/src/app/sessions/page.tsx
+++ b/dashboard/src/app/sessions/page.tsx
@@ -3,7 +3,7 @@ import { Fragment, useState } from "react";
 import { relTime } from "@/components/time";
 import { useBridgeFetch } from "@/hooks/useBridgeFetch";
 import { apiPath } from "@/lib/api";
-import { ErrorState, RelationStrip } from "@/components/patchwork";
+import { EmptyState, ErrorState, RelationStrip } from "@/components/patchwork";
 import { SkeletonList } from "@/components/Skeleton";
 import { ActivityTabs } from "@/components/ActivityTabs";
 import { useToast } from "@/components/Toast";
@@ -189,25 +189,28 @@ export default function SessionsPage() {
       )}
 
       {!loading && sessions.length === 0 && !error ? (
-        <div className="empty">
-          <h3 style={{ color: "var(--ink-1)", marginBottom: 8 }}>No active sessions</h3>
-          <p style={{ color: "var(--ink-2)", fontSize: "var(--fs-m)", maxWidth: 420, margin: "0 auto 12px" }}>
-            No Claude Code agents are currently connected to the bridge.
-          </p>
-          <p style={{ color: "var(--ink-3)", fontSize: "var(--fs-m)", maxWidth: 420, margin: "0 auto 16px" }}>
-            Connect a Claude Code session to the bridge to see live activity here.{" "}
-            <a href="https://docs.anthropic.com/claude-code" target="_blank" rel="noreferrer" style={{ color: "var(--accent)" }}>
-              Learn more →
-            </a>
-          </p>
-          <button
-            type="button"
-            className="btn sm ghost"
-            onClick={refetch}
-          >
-            Refresh
-          </button>
-        </div>
+        <EmptyState
+          title="No active sessions"
+          description={
+            <>
+              No Claude Code agents are currently connected to the bridge. Connect
+              one to see live activity here.{" "}
+              <a
+                href="https://docs.anthropic.com/claude-code"
+                target="_blank"
+                rel="noreferrer"
+                style={{ color: "var(--accent)" }}
+              >
+                Learn more →
+              </a>
+            </>
+          }
+          action={
+            <button type="button" className="btn sm ghost" onClick={refetch}>
+              Refresh
+            </button>
+          }
+        />
       ) : (
         <div
           // #600: .two-pane-340 collapses to single column at ≤768px so

--- a/dashboard/src/app/suggestions/page.tsx
+++ b/dashboard/src/app/suggestions/page.tsx
@@ -5,7 +5,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { apiPath } from "@/lib/api";
 import { useBridgeFetch } from "@/hooks/useBridgeFetch";
 import { DecisionsTabs } from "@/components/DecisionsTabs";
-import { ErrorState, HintCard } from "@/components/patchwork";
+import { EmptyState, ErrorState, HintCard } from "@/components/patchwork";
 import { SkeletonList } from "@/components/Skeleton";
 
 const SINCE_DAYS_OPTIONS = [1, 7, 30, 90] as const;
@@ -238,15 +238,17 @@ export default function SuggestionsPage() {
       )}
 
       {!loading && !error && suggestions.length === 0 && (
-        <div className="empty-state">
-          <h3>No suggestions right now</h3>
-          <p>
-            Either the lookback window is too short, your activity log doesn&apos;t
-            have enough variety yet, or every co-occurring pair is already in a
-            recipe. Try widening the lookback above, or come back after a few
-            more days of normal use.
-          </p>
-        </div>
+        <EmptyState
+          title="No suggestions right now"
+          description={
+            <>
+              Either the lookback window is too short, your activity log doesn&apos;t
+              have enough variety yet, or every co-occurring pair is already in a
+              recipe. Try widening the lookback above, or come back after a few
+              more days of normal use.
+            </>
+          }
+        />
       )}
 
       {byKind.co_occurring_pair.length > 0 && (

--- a/dashboard/src/app/transactions/page.tsx
+++ b/dashboard/src/app/transactions/page.tsx
@@ -3,7 +3,7 @@ import { useEffect, useMemo, useState } from "react";
 import { apiPath } from "@/lib/api";
 import { useBridgeFetch } from "@/hooks/useBridgeFetch";
 import { SkeletonList } from "@/components/Skeleton";
-import { ErrorState, HintCard, RelationStrip } from "@/components/patchwork";
+import { EmptyState, ErrorState, HintCard, RelationStrip } from "@/components/patchwork";
 
 interface TransactionEdit {
   filePath: string;
@@ -230,14 +230,16 @@ export default function TransactionsPage() {
       )}
 
       {!loading && transactions.length === 0 && (
-        <div className="empty-state">
-          <h3>No active transactions</h3>
-          <p>
-            When an agent calls <code>beginTransaction</code> + <code>stageEdit</code>,
-            the staged edits appear here. Until <code>commitTransaction</code> fires,
-            nothing has touched disk.
-          </p>
-        </div>
+        <EmptyState
+          title="No active transactions"
+          description={
+            <>
+              When an agent calls <code>beginTransaction</code> +{" "}
+              <code>stageEdit</code>, the staged edits appear here. Until{" "}
+              <code>commitTransaction</code> fires, nothing has touched disk.
+            </>
+          }
+        />
       )}
 
       {transactions.map((tx) => {


### PR DESCRIPTION
## Summary
- Convert ad-hoc \`<h3>\`/\`<p>\`/\`<button>\` empty-state blocks to the shared \`EmptyState\` component on:
  - /sessions
  - /transactions
  - /suggestions
  - /decisions

## Why
Dashboard-quality audit recommendation #1 — 7 pages were hand-rolling their own empty states while 5 shared `EmptyState`. Inconsistent visual treatment, no shared first-run pattern.

## Stack
- Remaining 3 pages (/recipes, /runs, /connections) deferred — they touch row-loop code with PRs #703 / #704 / #705 in flight.

## Test plan
- [ ] Each of the 4 pages renders correctly when empty (title + description + optional action)
- [ ] /decisions "Clear filters" CTA still resets filters when present
- [ ] /sessions Refresh button still triggers refetch

🤖 Generated with [Claude Code](https://claude.com/claude-code)