### PR TITLE
feat(empty-states): finish EmptyState rollout on the last 3 pages

### DIFF
--- a/dashboard/src/app/connections/page.tsx
+++ b/dashboard/src/app/connections/page.tsx
@@ -4,7 +4,8 @@ import { apiPath } from "@/lib/api";
 import AddConnectionModal from "./AddConnectionModal";
 import { YourConnectorRequests } from "./YourConnectorRequests";
 import { Dialog } from "@/components/Dialog";
-import { HintCard } from "@/components/patchwork";
+import { EmptyState, HintCard } from "@/components/patchwork";
+import { SkeletonList } from "@/components/Skeleton";
 import { useToast } from "@/components/Toast";
 import type { ConnectorStatus } from "./types";
 
@@ -1245,14 +1246,17 @@ export default function ConnectionsPage() {
       {err && <div className="alert-err" role="alert">{err}</div>}
 
       {bridgeOffline ? (
-        <div className="empty-state" role="status">
-          <h3>Bridge offline</h3>
-          <p>The bridge is not running. Start it with <code>patchwork start-all</code> then reload this page.</p>
-        </div>
+        <EmptyState
+          title="Bridge offline"
+          description={
+            <>
+              The bridge is not running. Start it with{" "}
+              <code>patchwork start-all</code> then reload this page.
+            </>
+          }
+        />
       ) : loading ? (
-        <div className="empty-state" role="status" aria-busy="true">
-          <p>Loading…</p>
-        </div>
+        <SkeletonList rows={3} columns={2} />
       ) : (
         <>
           {/* Recently used strip */}

--- a/dashboard/src/app/recipes/page.tsx
+++ b/dashboard/src/app/recipes/page.tsx
@@ -13,6 +13,7 @@ import type { ActiveRunState } from "@/hooks/useRecipeRunStream";
 import { RecipeRunInline } from "./_components/RecipeRunInline";
 import {
   CodeBlock,
+  EmptyState,
   ErrorState,
   HintCard,
   highlightYaml,
@@ -1251,23 +1252,32 @@ export default function RecipesPage() {
       {recipes === null && !err ? (
         <SkeletonList rows={4} columns={3} />
       ) : recipes === null && err ? null : recipes === null || recipes.length === 0 ? (
-        <div className="empty-state">
-          <h3>No recipes installed</h3>
-          <p>Browse the marketplace or author your own.</p>
-          <div style={{ display: "flex", gap: "var(--s-2)", marginTop: "var(--s-3)" }}>
-            <Link href="/marketplace" className="btn primary" style={{ textDecoration: "none" }}>
-              Browse marketplace
-            </Link>
-            <Link href="/recipes/new" className="btn ghost" style={{ textDecoration: "none" }}>
-              New recipe
-            </Link>
-          </div>
-          {unsupported && (
-            <p style={{ marginTop: 12, fontSize: "var(--fs-s)" }}>
-              Recipe listing endpoint not available on this bridge version.
-            </p>
-          )}
-        </div>
+        <EmptyState
+          title="No recipes installed"
+          description={
+            unsupported
+              ? "Recipe listing endpoint not available on this bridge version."
+              : "Browse the marketplace or author your own."
+          }
+          action={
+            <>
+              <Link
+                href="/marketplace"
+                className="btn primary"
+                style={{ textDecoration: "none" }}
+              >
+                Browse marketplace
+              </Link>
+              <Link
+                href="/recipes/new"
+                className="btn ghost"
+                style={{ textDecoration: "none" }}
+              >
+                New recipe
+              </Link>
+            </>
+          }
+        />
       ) : (
         <div
           className={`recipes-grid${selectedRecipe ? " has-detail" : ""}`}

--- a/dashboard/src/app/runs/page.tsx
+++ b/dashboard/src/app/runs/page.tsx
@@ -5,7 +5,7 @@ import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { LivePill } from "@/components/patchwork/LivePill";
-import { AnimatedNumber, ErrorState, RelationStrip } from "@/components/patchwork";
+import { AnimatedNumber, EmptyState, ErrorState, RelationStrip } from "@/components/patchwork";
 import { SkeletonList } from "@/components/Skeleton";
 import { ActivityTabs } from "@/components/ActivityTabs";
 import { useDebounced } from "@/hooks/useDebounced";
@@ -748,66 +748,68 @@ export default function RunsPage() {
       {windowedRuns === null && !err ? (
         <SkeletonList rows={6} columns={6} />
       ) : !windowedRuns || windowedRuns.length === 0 ? (
-        <div className="empty-state">
-          <h3>
-            {(trigger !== "all" ||
-              status !== "all" ||
-              debouncedRecipeQuery ||
-              attemptFilter)
-              ? "No runs match current filters"
-              : window === "any"
-                ? "No runs yet"
-                : "No runs in this window"}
-          </h3>
-          <p>
-            {(trigger !== "all" ||
-              status !== "all" ||
-              debouncedRecipeQuery ||
-              attemptFilter) ? (
-              <>
-                Active:{" "}
-                {[
-                  trigger !== "all" && `trigger=${trigger}`,
-                  status !== "all" && `status=${status}`,
-                  debouncedRecipeQuery && `recipe=${debouncedRecipeQuery}`,
-                  attemptFilter && `attempt=${attemptFilter}`,
-                  window !== "any" && `window=${TIME_WINDOW_LABEL[window].toLowerCase()}`,
-                ]
-                  .filter(Boolean)
-                  .join(" · ")}
-              </>
-            ) : window === "any" ? (
-              <>
-                Recipe executions (cron, webhook, or{" "}
-                <code>patchwork recipe run</code>) will appear here once they
-                complete.
-              </>
-            ) : (
-              <>
-                No runs in “{TIME_WINDOW_LABEL[window]}”. Try widening the
-                window.
-              </>
-            )}
-          </p>
-          {(trigger !== "all" ||
+        (() => {
+          const filtered =
+            trigger !== "all" ||
             status !== "all" ||
-            debouncedRecipeQuery ||
-            attemptFilter) && (
-            <button
-              type="button"
-              className="btn sm ghost"
-              style={{ marginTop: "var(--s-3)" }}
-              onClick={() => {
-                setTrigger("all");
-                setStatus("all");
-                setRecipeQuery("");
-                setAttemptFilter("");
-              }}
-            >
-              Clear filters
-            </button>
-          )}
-        </div>
+            !!debouncedRecipeQuery ||
+            !!attemptFilter;
+          return (
+            <EmptyState
+              title={
+                filtered
+                  ? "No runs match current filters"
+                  : window === "any"
+                    ? "No runs yet"
+                    : "No runs in this window"
+              }
+              description={
+                filtered ? (
+                  <>
+                    Active:{" "}
+                    {[
+                      trigger !== "all" && `trigger=${trigger}`,
+                      status !== "all" && `status=${status}`,
+                      debouncedRecipeQuery && `recipe=${debouncedRecipeQuery}`,
+                      attemptFilter && `attempt=${attemptFilter}`,
+                      window !== "any" &&
+                        `window=${TIME_WINDOW_LABEL[window].toLowerCase()}`,
+                    ]
+                      .filter(Boolean)
+                      .join(" · ")}
+                  </>
+                ) : window === "any" ? (
+                  <>
+                    Recipe executions (cron, webhook, or{" "}
+                    <code>patchwork recipe run</code>) will appear here once
+                    they complete.
+                  </>
+                ) : (
+                  <>
+                    No runs in “{TIME_WINDOW_LABEL[window]}”. Try widening
+                    the window.
+                  </>
+                )
+              }
+              action={
+                filtered ? (
+                  <button
+                    type="button"
+                    className="btn sm ghost"
+                    onClick={() => {
+                      setTrigger("all");
+                      setStatus("all");
+                      setRecipeQuery("");
+                      setAttemptFilter("");
+                    }}
+                  >
+                    Clear filters
+                  </button>
+                ) : undefined
+              }
+            />
+          );
+        })()
       ) : (
         <div className="table-wrap">
           <table className="table">


### PR DESCRIPTION
## Summary
- /recipes, /runs, /connections — convert remaining ad-hoc empty-state \`<div>\`/\`<h3>\` blocks to the shared \`<EmptyState>\` component
- /connections loading fork now uses \`SkeletonList\` instead of a bare "Loading…" string

## Why
Closes audit recommendation #1 — started in #706, finishes here. All 7 pages flagged by the dashboard-quality audit now use the shared component.

## Test plan
- [ ] /recipes empty → shows Marketplace + New CTAs
- [ ] /runs with active filters → shows filter list + "Clear filters" action
- [ ] /runs with no filters + empty → shows window-aware description
- [ ] /connections with bridge offline → EmptyState with start-all hint
- [ ] /connections loading → SkeletonList instead of "Loading…"

🤖 Generated with [Claude Code](https://claude.com/claude-code)