### PR TITLE
feat(push): halt-event relay end-to-end (dashboard side)

### DIFF
--- a/dashboard/public/sw.js
+++ b/dashboard/public/sw.js
@@ -123,6 +123,31 @@ self.addEventListener("push", (event) => {
     return;
   }
 
+  // Branch on payload kind. Approval pushes (no kind, legacy shape)
+  // and halt pushes (kind === "halt") render different notifications
+  // and have different click targets.
+  if (data.kind === "halt") {
+    const { recipeName, runSeq, status, haltReason, stepId, errorMessage } =
+      data;
+    const isError = status === "error";
+    const title = `${isError ? "⚠️ Run errored" : "Run halted"}: ${recipeName ?? "recipe"}`;
+    const body = haltReason || errorMessage || (isError ? "Run errored" : "Run halted");
+    // Coalesce repeat fires for the same run so flapping doesn't spam.
+    const tag = `halt-${runSeq ?? recipeName ?? "unknown"}`;
+    event.waitUntil(
+      self.registration.showNotification(title, {
+        body,
+        tag,
+        icon: "/icons/icon-192.png",
+        badge: "/icons/icon-192.png",
+        requireInteraction: false,
+        data: { kind: "halt", runSeq, stepId },
+      }),
+    );
+    return;
+  }
+
+  // Default path: approval push.
   const {
     callId,
     toolName,
@@ -161,8 +186,31 @@ self.addEventListener("push", (event) => {
 
 self.addEventListener("notificationclick", (event) => {
   event.notification.close();
-  const { callId, approveUrl, rejectUrl, approvalToken, expiresAt } =
-    event.notification.data ?? {};
+  const notifData = event.notification.data ?? {};
+
+  // Halt notifications deep-link to the failing run/step. No inline
+  // actions — the user inspects the run in the dashboard.
+  if (notifData.kind === "halt") {
+    const { runSeq, stepId } = notifData;
+    if (!runSeq) return;
+    const targetUrl = stepId
+      ? `./runs/${runSeq}#step-${encodeURIComponent(stepId)}`
+      : `./runs/${runSeq}`;
+    event.waitUntil(
+      self.clients
+        .matchAll({ type: "window", includeUncontrolled: true })
+        .then((clients) => {
+          const existing = clients.find((c) => c.url.includes("/runs/"));
+          if (existing) {
+            return existing.focus().then((c) => c.navigate(targetUrl));
+          }
+          return self.clients.openWindow(targetUrl);
+        }),
+    );
+    return;
+  }
+
+  const { callId, approveUrl, rejectUrl, approvalToken, expiresAt } = notifData;
 
   // Stale notification: token-clearing path on the bridge runs single-use,
   // so a click after expiry would 401 anyway, but we short-circuit to avoid

--- a/dashboard/src/app/api/relay/halt/__tests__/route.test.ts
+++ b/dashboard/src/app/api/relay/halt/__tests__/route.test.ts
@@ -143,12 +143,17 @@ describe("POST /api/relay/halt", () => {
   it("evicts subscriptions that respond 404 / 410", async () => {
     const dead410 = { ...validSub, endpoint: "https://dead.example/410" };
     vi.mocked(getSubscriptionsFor).mockReturnValueOnce([validSub, dead410]);
-    vi.mocked(webpush.sendNotification).mockImplementation(async (sub) => {
-      if ((sub as { endpoint: string }).endpoint.endsWith("/410")) {
+    // Cast to the web-push impl signature loosely — the real lib returns
+    // a SendResult shape, but we only care about success vs the
+    // 404/410-shaped thrown error eviction path.
+    vi.mocked(webpush.sendNotification).mockImplementation((async (
+      sub: { endpoint: string },
+    ) => {
+      if (sub.endpoint.endsWith("/410")) {
         throw { statusCode: 410 };
       }
-      return { statusCode: 201 } as unknown as undefined;
-    });
+      return { statusCode: 201 };
+    }) as unknown as typeof webpush.sendNotification);
     const r = await POST(req({ authorization: `Bearer ${TOKEN}` }, validBody));
     const body = (await r.json()) as { sent: number; evicted: number };
     expect(body.sent).toBe(1);

--- a/dashboard/src/app/api/relay/halt/__tests__/route.test.ts
+++ b/dashboard/src/app/api/relay/halt/__tests__/route.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Tests for the bridge → dashboard halt-event relay
+ * (`POST /api/relay/halt`). Sibling of /api/relay/push; same auth and
+ * fan-out shape, different payload + the consumer set is filtered by
+ * `pushStore.getSubscriptionsFor("halts")`.
+ */
+
+import { NextRequest } from "next/server";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("web-push", () => ({
+  default: {
+    setVapidDetails: vi.fn(),
+    sendNotification: vi.fn(async () => ({ statusCode: 201 })),
+  },
+}));
+
+vi.mock("@/lib/pushStore", () => ({
+  getSubscriptionsFor: vi.fn(() => []),
+  removeSubscription: vi.fn(),
+}));
+
+import webpush from "web-push";
+import { POST } from "@/app/api/relay/halt/route";
+import { getSubscriptionsFor, removeSubscription } from "@/lib/pushStore";
+
+const TOKEN = "relay-test-token-1234567890abcdef";
+
+const validSub = {
+  endpoint: "https://example.com/push/abc",
+  keys: { p256dh: "p256dh-key", auth: "auth-key" },
+};
+
+const validBody = {
+  recipeName: "morning-brief",
+  runSeq: 42,
+  status: "halted" as const,
+  haltReason: "Agent step 'summarize' returned only narration",
+  haltCategory: "agent_narration_only",
+  stepId: "summarize",
+};
+
+function req(headers: Record<string, string>, body: unknown): NextRequest {
+  return new NextRequest("http://localhost:3200/api/relay/halt", {
+    method: "POST",
+    headers: { "content-type": "application/json", ...headers },
+    body: JSON.stringify(body),
+  });
+}
+
+const ENV_KEYS = [
+  "PATCHWORK_PUSH_TOKEN",
+  "NEXT_PUBLIC_VAPID_PUBLIC_KEY",
+  "VAPID_PRIVATE_KEY",
+  "VAPID_SUBJECT",
+] as const;
+
+let originalEnv: Record<string, string | undefined>;
+
+beforeEach(() => {
+  originalEnv = Object.fromEntries(ENV_KEYS.map((k) => [k, process.env[k]]));
+  process.env.PATCHWORK_PUSH_TOKEN = TOKEN;
+  process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY = "test-vapid-public";
+  process.env.VAPID_PRIVATE_KEY = "test-vapid-private";
+  process.env.VAPID_SUBJECT = "mailto:test@example.com";
+  vi.mocked(getSubscriptionsFor).mockReturnValue([validSub]);
+  vi.mocked(removeSubscription).mockClear();
+  vi.mocked(webpush.sendNotification).mockClear();
+  vi.mocked(webpush.setVapidDetails).mockClear();
+});
+
+afterEach(() => {
+  for (const k of ENV_KEYS) {
+    if (originalEnv[k] === undefined) delete process.env[k];
+    else process.env[k] = originalEnv[k];
+  }
+});
+
+describe("POST /api/relay/halt", () => {
+  it("401 without Bearer token", async () => {
+    const r = await POST(req({}, validBody));
+    expect(r.status).toBe(401);
+    expect(webpush.sendNotification).not.toHaveBeenCalled();
+  });
+
+  it("401 with wrong Bearer token", async () => {
+    const r = await POST(req({ authorization: "Bearer wrong" }, validBody));
+    expect(r.status).toBe(401);
+  });
+
+  it("503 when VAPID keys are unset", async () => {
+    delete process.env.VAPID_PRIVATE_KEY;
+    const r = await POST(req({ authorization: `Bearer ${TOKEN}` }, validBody));
+    expect(r.status).toBe(503);
+  });
+
+  it("400 on missing recipeName / runSeq / status", async () => {
+    const r = await POST(
+      req({ authorization: `Bearer ${TOKEN}` }, {
+        ...validBody,
+        recipeName: undefined,
+      }),
+    );
+    expect(r.status).toBe(400);
+  });
+
+  it("400 on invalid status value", async () => {
+    const r = await POST(
+      req({ authorization: `Bearer ${TOKEN}` }, {
+        ...validBody,
+        status: "running",
+      }),
+    );
+    expect(r.status).toBe(400);
+  });
+
+  it("404 when no halt-opted-in subscriptions exist", async () => {
+    vi.mocked(getSubscriptionsFor).mockReturnValueOnce([]);
+    const r = await POST(req({ authorization: `Bearer ${TOKEN}` }, validBody));
+    expect(r.status).toBe(404);
+    expect(webpush.sendNotification).not.toHaveBeenCalled();
+  });
+
+  it("fans out to halt-opted-in subscriptions and returns count", async () => {
+    const r = await POST(req({ authorization: `Bearer ${TOKEN}` }, validBody));
+    expect(r.status).toBe(200);
+    const body = (await r.json()) as { ok: boolean; sent: number; total: number };
+    expect(body).toEqual({ ok: true, sent: 1, total: 1, evicted: 0 });
+    expect(webpush.sendNotification).toHaveBeenCalledTimes(1);
+    // Payload shape: kind="halt" + run + step
+    const payload = JSON.parse(
+      vi.mocked(webpush.sendNotification).mock.calls[0]![1] as string,
+    );
+    expect(payload).toMatchObject({
+      kind: "halt",
+      recipeName: "morning-brief",
+      runSeq: 42,
+      status: "halted",
+      stepId: "summarize",
+    });
+  });
+
+  it("evicts subscriptions that respond 404 / 410", async () => {
+    const dead410 = { ...validSub, endpoint: "https://dead.example/410" };
+    vi.mocked(getSubscriptionsFor).mockReturnValueOnce([validSub, dead410]);
+    vi.mocked(webpush.sendNotification).mockImplementation(async (sub) => {
+      if ((sub as { endpoint: string }).endpoint.endsWith("/410")) {
+        throw { statusCode: 410 };
+      }
+      return { statusCode: 201 } as unknown as undefined;
+    });
+    const r = await POST(req({ authorization: `Bearer ${TOKEN}` }, validBody));
+    const body = (await r.json()) as { sent: number; evicted: number };
+    expect(body.sent).toBe(1);
+    expect(body.evicted).toBe(1);
+    expect(removeSubscription).toHaveBeenCalledWith(dead410.endpoint);
+  });
+
+  it("only consults halt-opted-in subscriptions (separate from approval set)", async () => {
+    await POST(req({ authorization: `Bearer ${TOKEN}` }, validBody));
+    expect(getSubscriptionsFor).toHaveBeenCalledWith("halts");
+  });
+});

--- a/dashboard/src/app/api/relay/halt/route.ts
+++ b/dashboard/src/app/api/relay/halt/route.ts
@@ -1,0 +1,157 @@
+import crypto from "node:crypto";
+import { NextResponse } from "next/server";
+import webpush from "web-push";
+import { getSubscriptionsFor, removeSubscription } from "@/lib/pushStore";
+import {
+  DASHBOARD_API_BODY_CAPS,
+  bodyTooLargeResponse,
+  readJsonWithCap,
+} from "@/lib/readBodyWithCap";
+
+/**
+ * Bridge → dashboard halt-event relay.
+ *
+ * Sibling of /api/relay/push (approval-call relay). The bridge POSTs
+ * here whenever a recipe transitions to a terminal failure state
+ * (halted / errored). The route fans out a Web Push notification to
+ * every subscription that opted in to halt events via
+ * `pushStore` prefs.
+ *
+ * Wire-shape matches the approval relay so an operator can point a
+ * single `pushServiceUrl` at the dashboard and have it serve both:
+ *   POST /api/relay/push  — approvals
+ *   POST /api/relay/halt  — halts
+ *
+ * Auth: Bearer token compared timing-safe against PATCHWORK_PUSH_TOKEN
+ * (shared with the approval relay).
+ */
+
+function readVapidConfig(): { publicKey: string; privateKey: string; subject: string } {
+  return {
+    publicKey: process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY ?? "",
+    privateKey: process.env.VAPID_PRIVATE_KEY ?? "",
+    subject: process.env.VAPID_SUBJECT ?? "mailto:admin@example.com",
+  };
+}
+
+interface RelayHaltBody {
+  recipeName?: string;
+  runSeq?: number;
+  status?: "halted" | "error";
+  haltReason?: string;
+  haltCategory?: string;
+  stepId?: string;
+  errorMessage?: string;
+  occurredAt?: number;
+}
+
+function unauthorized(): NextResponse {
+  return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+}
+
+function verifyBearer(req: Request): boolean {
+  const expected = process.env.PATCHWORK_PUSH_TOKEN ?? "";
+  if (!expected) return false;
+  const header = req.headers.get("authorization") ?? "";
+  if (!header.startsWith("Bearer ")) return false;
+  const presented = header.slice(7);
+  if (presented.length !== expected.length) return false;
+  try {
+    return crypto.timingSafeEqual(
+      Buffer.from(presented, "utf8"),
+      Buffer.from(expected, "utf8"),
+    );
+  } catch {
+    return false;
+  }
+}
+
+export async function POST(req: Request) {
+  if (!verifyBearer(req)) return unauthorized();
+
+  const vapid = readVapidConfig();
+  if (!vapid.publicKey || !vapid.privateKey) {
+    return NextResponse.json(
+      { error: "VAPID keys not configured" },
+      { status: 503 },
+    );
+  }
+
+  const parsed = await readJsonWithCap<RelayHaltBody>(
+    req,
+    DASHBOARD_API_BODY_CAPS.relayHalt,
+  );
+  if (!parsed.ok) {
+    if (parsed.reason === "too_large")
+      return bodyTooLargeResponse(parsed.maxBytes);
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+  const body = parsed.value;
+
+  const { recipeName, runSeq, status } = body;
+  if (!recipeName || typeof runSeq !== "number" || !status) {
+    return NextResponse.json(
+      { error: "missing required fields: recipeName, runSeq, status" },
+      { status: 400 },
+    );
+  }
+  if (status !== "halted" && status !== "error") {
+    return NextResponse.json(
+      { error: "status must be 'halted' or 'error'" },
+      { status: 400 },
+    );
+  }
+
+  const subs = getSubscriptionsFor("halts");
+  if (subs.length === 0) {
+    // Bridge fires fire-and-forget so this 404 is informational only.
+    return NextResponse.json(
+      { ok: false, sent: 0, total: 0, error: "no halt subscribers" },
+      { status: 404 },
+    );
+  }
+
+  const now = Date.now();
+  const payload = JSON.stringify({
+    kind: "halt",
+    recipeName,
+    runSeq,
+    status,
+    haltReason: body.haltReason,
+    haltCategory: body.haltCategory,
+    stepId: body.stepId,
+    errorMessage: body.errorMessage,
+    occurredAt: body.occurredAt ?? now,
+  });
+
+  webpush.setVapidDetails(vapid.subject, vapid.publicKey, vapid.privateKey);
+
+  const results = await Promise.allSettled(
+    subs.map((sub) => webpush.sendNotification(sub, payload)),
+  );
+  const sent = results.filter((r) => r.status === "fulfilled").length;
+
+  // Same 404/410 eviction logic as /api/relay/push — RFC 8030 endpoint
+  // teardown. Without it we keep fanning forever to dead subscriptions.
+  let evicted = 0;
+  for (let i = 0; i < results.length; i++) {
+    const r = results[i];
+    const sub = subs[i];
+    if (r.status !== "rejected" || !sub) continue;
+    const status = extractPushStatusCode(r.reason);
+    if (status === 404 || status === 410) {
+      removeSubscription(sub.endpoint);
+      evicted++;
+    }
+  }
+
+  return NextResponse.json({ ok: true, sent, total: subs.length, evicted });
+}
+
+function extractPushStatusCode(reason: unknown): number | undefined {
+  if (typeof reason !== "object" || reason === null) return undefined;
+  const r = reason as { statusCode?: unknown; status?: unknown };
+  if (typeof r.statusCode === "number") return r.statusCode;
+  if (typeof r.status === "number") return r.status;
+  return undefined;
+}

--- a/dashboard/src/lib/__tests__/pushStore.test.ts
+++ b/dashboard/src/lib/__tests__/pushStore.test.ts
@@ -73,11 +73,14 @@ describe("pushStore — add/remove/get", () => {
 
     expect(getSubscriptions()).toEqual([sub]);
     expect(fs.existsSync(storePath)).toBe(true);
+    // v2 on-disk shape: [endpoint, { sub, prefs }]
     const onDisk = JSON.parse(fs.readFileSync(storePath, "utf8")) as [
       string,
-      PushSubscription,
+      { sub: PushSubscription; prefs: { approvals: boolean; halts: boolean } },
     ][];
-    expect(onDisk).toEqual([[sub.endpoint, sub]]);
+    expect(onDisk).toEqual([
+      [sub.endpoint, { sub, prefs: { approvals: true, halts: true } }],
+    ]);
   });
 
   it("add is idempotent on repeated endpoint (replaces, no duplicate)", async () => {
@@ -109,9 +112,11 @@ describe("pushStore — add/remove/get", () => {
     expect(getSubscriptions()).toEqual([b]);
     const onDisk = JSON.parse(fs.readFileSync(storePath, "utf8")) as [
       string,
-      PushSubscription,
+      { sub: PushSubscription; prefs: { approvals: boolean; halts: boolean } },
     ][];
-    expect(onDisk).toEqual([[b.endpoint, b]]);
+    expect(onDisk).toEqual([
+      [b.endpoint, { sub: b, prefs: { approvals: true, halts: true } }],
+    ]);
   });
 
   it("remove on an unknown endpoint is a no-op", async () => {

--- a/dashboard/src/lib/pushStore.ts
+++ b/dashboard/src/lib/pushStore.ts
@@ -6,17 +6,66 @@ import type { PushSubscription } from "web-push";
 
 const STORE_PATH = path.join(os.homedir(), ".claude", "patchwork-push-subscriptions.json");
 
-function load(): Map<string, PushSubscription> {
+/**
+ * Per-subscription preferences. Both default `true` so existing
+ * subscriptions keep firing every event class until the user opts out
+ * (e.g. via a future Settings toggle). Adding new event classes here
+ * needs the same default to preserve back-compat.
+ */
+export interface PushPrefs {
+  approvals: boolean;
+  halts: boolean;
+}
+
+const DEFAULT_PREFS: PushPrefs = { approvals: true, halts: true };
+
+export interface PushEntry {
+  sub: PushSubscription;
+  prefs: PushPrefs;
+}
+
+/**
+ * Backwards-compatible loader. The on-disk format is one of two shapes
+ * depending on what wrote it:
+ *
+ *   - legacy: `[endpoint, PushSubscription][]`
+ *   - v2:     `[endpoint, { sub, prefs }][]`
+ *
+ * Detect per-entry (not file-level) so a partial in-place migration on
+ * a tab that came back online doesn't blank the rest of the store.
+ */
+function load(): Map<string, PushEntry> {
   try {
     const raw = fs.readFileSync(STORE_PATH, "utf8");
-    const entries = JSON.parse(raw) as [string, PushSubscription][];
-    return new Map(entries);
+    const entries = JSON.parse(raw) as [string, unknown][];
+    const out = new Map<string, PushEntry>();
+    for (const [endpoint, value] of entries) {
+      if (
+        value &&
+        typeof value === "object" &&
+        "sub" in (value as object) &&
+        "prefs" in (value as object)
+      ) {
+        const v = value as { sub: PushSubscription; prefs: Partial<PushPrefs> };
+        out.set(endpoint, {
+          sub: v.sub,
+          prefs: { ...DEFAULT_PREFS, ...v.prefs },
+        });
+      } else {
+        // legacy shape: the raw subscription
+        out.set(endpoint, {
+          sub: value as PushSubscription,
+          prefs: { ...DEFAULT_PREFS },
+        });
+      }
+    }
+    return out;
   } catch {
     return new Map();
   }
 }
 
-function persist(store: Map<string, PushSubscription>): void {
+function persist(store: Map<string, PushEntry>): void {
   // Atomic write — temp + rename — so a crash mid-write can't truncate
   // the subscription store (which would silently wipe every push
   // subscription on next boot; load() catches parse errors and resets
@@ -54,7 +103,14 @@ function persist(store: Map<string, PushSubscription>): void {
 const store = load();
 
 export function addSubscription(sub: PushSubscription): void {
-  store.set(sub.endpoint, sub);
+  const existing = store.get(sub.endpoint);
+  store.set(sub.endpoint, {
+    sub,
+    // Preserve prefs on resubscribe (pushsubscriptionchange path) so a
+    // user who opted out of halts stays opted out across browser
+    // restarts. New endpoints inherit DEFAULT_PREFS.
+    prefs: existing?.prefs ?? { ...DEFAULT_PREFS },
+  });
   persist(store);
 }
 
@@ -63,6 +119,30 @@ export function removeSubscription(endpoint: string): void {
   persist(store);
 }
 
+/** All subscriptions, regardless of preference. Callers filter. */
 export function getSubscriptions(): PushSubscription[] {
-  return [...store.values()];
+  return [...store.values()].map((e) => e.sub);
+}
+
+/**
+ * Subscriptions opted in to a specific event class. Use this from the
+ * relay routes so a user who toggled off halt notifications doesn't
+ * keep getting them.
+ */
+export function getSubscriptionsFor(kind: keyof PushPrefs): PushSubscription[] {
+  return [...store.values()].filter((e) => e.prefs[kind]).map((e) => e.sub);
+}
+
+/** Read a subscription's prefs (defaults if unknown). */
+export function getPrefs(endpoint: string): PushPrefs {
+  return store.get(endpoint)?.prefs ?? { ...DEFAULT_PREFS };
+}
+
+/** Update prefs for an existing subscription. No-op for unknown endpoints. */
+export function setPrefs(endpoint: string, prefs: Partial<PushPrefs>): boolean {
+  const entry = store.get(endpoint);
+  if (!entry) return false;
+  store.set(endpoint, { sub: entry.sub, prefs: { ...entry.prefs, ...prefs } });
+  persist(store);
+  return true;
 }

--- a/dashboard/src/lib/readBodyWithCap.ts
+++ b/dashboard/src/lib/readBodyWithCap.ts
@@ -58,6 +58,8 @@ export const DASHBOARD_API_BODY_CAPS = {
   push: 16 * 1024,
   /** /api/relay/push — bridge → dashboard relay (callId/toolName/tier/approvalToken/bridgeCallbackBase + optional summary, riskSignals). 8 KB is generous. */
   relayPush: 8 * 1024,
+  /** /api/relay/halt — bridge → dashboard halt-event relay (recipeName/runSeq/status/haltReason/stepId). 4 KB caps long stack traces in haltReason. */
+  relayHalt: 4 * 1024,
   /** /api/connections/[connector]/connect — OAuth start: redirect target + provider state. */
   connectionsConnect: 32 * 1024,
 } as const;


### PR DESCRIPTION
## Summary

PR 1 of the halt-push campaign — dashboard-side plumbing complete; bridge dispatch in a follow-up.

- **\`pushStore\`** — extend value to \`{ sub, prefs }\` with backwards-compatible loader. New API: \`getSubscriptionsFor(kind)\`, \`getPrefs\`, \`setPrefs\`. Defaults opt every existing subscription in to every event class.
- **\`/api/relay/halt\`** — sibling of \`/api/relay/push\`. Same Bearer auth + 404/410 eviction. Filters to halt-opted-in subs via \`getSubscriptionsFor("halts")\`.
- **\`sw.js\`** — push + notificationclick branch on \`data.kind === "halt"\`. Tag coalesces flapping (\`halt-<runSeq>\`); click deep-links to \`./runs/:seq#step-:id\` (anchor shipped in #705).
- Tests: 9 new for \`/api/relay/halt\`; existing pushStore tests updated for v2 on-disk shape. 535 tests pass.

## Why
Top recommendation from the recipe-run observability audit. Foreground halt toast already shipped (#708) — this adds the background-tab / browser-closed path. Reuses the entire existing approval-push pipeline (SW + VAPID + store + relay route shape).

## Operator smoke test
\`\`\`
curl -X POST https://your.dash/api/relay/halt \\
     -H "Authorization: Bearer $PATCHWORK_PUSH_TOKEN" \\
     -H "Content-Type: application/json" \\
     -d '{"recipeName":"smoke","runSeq":1,"status":"halted","haltReason":"manual smoke"}'
\`\`\`

## Follow-ups
- **PR 2**: bridge \`dispatchHaltNotification()\` at \`recipe_done\` emit sites with haltReason / error status
- **PR 3**: Settings toggle for \`prefs.halts\` per-subscription
- **PR 4**: In-toast "Enable push for halts" CTA wired to \`HaltToastWatcher\` (#708)
- **PR 5**: Bridge-side 60s dedupe by \`(runSeq, stepId)\`

## Test plan
- [ ] curl smoke (above) → notification fires on any subscribed browser
- [ ] Click notification → opens `/runs/<seq>#step-<id>` (or `/runs/<seq>` if no stepId)
- [ ] Existing approval-push notification still works (no regression on the legacy code path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)