### PR TITLE
feat(observability): completion sweep + 30s GC fade on RecipeRunInline

### DIFF
--- a/dashboard/src/app/globals.css
+++ b/dashboard/src/app/globals.css
@@ -3693,3 +3693,50 @@ button.topbar-search {
   .pw-dialog-backdrop,
   .pw-dialog-panel { animation: none; }
 }
+
+/* ---- RecipeRunInline lifecycle motion ----
+   Two cues for terminal-state recipe runs:
+   1. Completion sweep: a brief accent flash across the progress bar
+      when status flips terminal (ok / halted / error). Makes "the bar
+      stopped — did anything happen?" legible.
+   2. GC fade: opacity transitions from 1 → 0.5 over the last 5s of
+      the 30s store hold so the card visibly winds down before unmount,
+      instead of vanishing without warning. Delay matches the store's
+      FINAL_HOLD_MS = 30_000 (LiveRunsContext.tsx). */
+.recipe-run-inline.is-terminal {
+  transition: opacity 5s ease;
+  transition-delay: 25s;
+  opacity: 0.5;
+}
+.recipe-run-inline.is-terminal .recipe-run-inline-bar::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(
+    90deg,
+    transparent 0%,
+    color-mix(in srgb, var(--accent) 50%, transparent) 50%,
+    transparent 100%
+  );
+  transform: translateX(-100%);
+  animation: recipe-run-completion-sweep 0.7s ease-out 1;
+  pointer-events: none;
+}
+@keyframes recipe-run-completion-sweep {
+  0%   { transform: translateX(-100%); }
+  100% { transform: translateX(100%); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .recipe-run-inline.is-terminal {
+    transition: none;
+    /* keep the final-fade endpoint so the visual end-state still says
+       "this is winding down" — just without the easing. */
+    opacity: 0.7;
+  }
+  .recipe-run-inline.is-terminal .recipe-run-inline-bar::after {
+    animation: none;
+  }
+}

--- a/dashboard/src/app/recipes/_components/RecipeRunInline.tsx
+++ b/dashboard/src/app/recipes/_components/RecipeRunInline.tsx
@@ -64,8 +64,17 @@ export function RecipeRunInline({
 	}
 
 	const p = pct(state);
+	// "Strip" density gets a one-shot completion sweep + opacity fade over
+	// the last 5s of the 30s store-GC window — makes the lifecycle legible
+	// instead of cards vanishing abruptly. Classes are no-ops while the
+	// run is "running"; flip on when status hits a terminal state.
+	const isTerminal = state.status !== "running";
+	const containerClass = isTerminal
+		? "recipe-run-inline is-terminal"
+		: "recipe-run-inline";
 	return (
 		<div
+			className={containerClass}
 			style={{ display: "flex", flexDirection: "column", gap: 6, marginTop: 4 }}
 			role="status"
 			aria-live="polite"
@@ -108,6 +117,7 @@ export function RecipeRunInline({
 			</div>
 			{state.totalSteps > 0 && (
 				<div
+					className="recipe-run-inline-bar"
 					aria-label={`Progress ${p}%`}
 					style={{
 						height: 4,
@@ -115,6 +125,7 @@ export function RecipeRunInline({
 						background: "var(--bg-2)",
 						borderRadius: 2,
 						overflow: "hidden",
+						position: "relative",
 					}}
 				>
 					<div


### PR DESCRIPTION
## Summary
Two CSS lifecycle cues for terminal recipe runs:
- **Completion sweep** — one-shot accent gradient sweeps across the progress bar when status flips terminal (ok / halted / error)
- **GC fade** — opacity transitions 1 → 0.5 over the last 5s of the 30s store-GC window (delay 25s, duration 5s). Matches \`LiveRunsContext.FINAL_HOLD_MS\` so timing stays consistent.

## Why
Recipe-run observability audit #5 (low impact, small effort). Cards used to vanish abruptly at 30s with no visual indication that they were about to be GC'd. Now there's a clear "winding down" pass before unmount.

## Test plan
- [ ] Trigger a recipe that completes → progress bar runs to 100%, accent sweeps across it once
- [ ] Card stays visible for ~25s after completion, then opacity fades to 0.5 over 5s
- [ ] Component unmounts at the 30s mark (store GC)
- [ ] Reduced-motion users see static 0.7 opacity, no sweep

🤖 Generated with [Claude Code](https://claude.com/claude-code)