### PR TITLE
fix(insights): wrap tool-history table in horizontal-overflow container

### DIFF
--- a/dashboard/src/app/insights/page.tsx
+++ b/dashboard/src/app/insights/page.tsx
@@ -285,6 +285,7 @@ export default function InsightsPage() {
             <h2>Tool history</h2>
             <span className="pill muted">{tools.length}</span>
           </div>
+          <div style={{ overflowX: "auto" }}>
           <table
             style={{ width: "100%", borderCollapse: "collapse", fontSize: "var(--fs-m)" }}
           >
@@ -484,6 +485,7 @@ export default function InsightsPage() {
               ))}
             </tbody>
           </table>
+          </div>
         </div>
       )}
 


### PR DESCRIPTION
## Summary
- Wrap the Tool-history table in \`/insights\` with \`<div style={{ overflowX: "auto" }}>\` so wide columns scroll within the card instead of pushing the page horizontally on narrow viewports.

## Why
Dashboard-quality audit recommendation #4. Same pattern already proven on /traces.

## Out of scope
The audit also flagged \`whiteSpace:"nowrap"\` cells on \`/page.tsx\` (L592, L611). On inspection those are bounded with \`maxWidth + overflow: hidden + textOverflow: ellipsis\` — they truncate correctly. No fix needed there.

## Test plan
- [ ] /insights on a narrow viewport (≤480px) → table scrolls horizontally within its card; surrounding content stays put

🤖 Generated with [Claude Code](https://claude.com/claude-code)