### PR TITLE
feat(push): bridge halt dispatch — completes the halt-push pipeline

### DIFF
--- a/src/__tests__/wireHaltPushDispatch.test.ts
+++ b/src/__tests__/wireHaltPushDispatch.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Tests for the bridge-side halt-push wiring. The actual dispatcher
+ * (dispatchHaltPushNotification — SSRF / fetch / abort) is exercised
+ * indirectly via vi.mock so we can assert *when* and *with what* the
+ * dispatch is invoked.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../haltPushDispatch.js", () => ({
+  dispatchHaltPushNotification: vi.fn(async () => undefined),
+}));
+
+import { ActivityLog } from "../activityLog.js";
+import { dispatchHaltPushNotification } from "../haltPushDispatch.js";
+import { wireHaltPushDispatch } from "../wireHaltPushDispatch.js";
+
+const CFG = { url: "https://relay.example.com/relay", token: "tok-1234567890" };
+
+let activityLog: ActivityLog;
+
+beforeEach(() => {
+  activityLog = new ActivityLog();
+  vi.mocked(dispatchHaltPushNotification).mockClear();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("wireHaltPushDispatch", () => {
+  it("dispatches on recipe_done with status=error", () => {
+    wireHaltPushDispatch({
+      activityLog,
+      getPushConfig: () => CFG,
+    });
+
+    activityLog.recordEvent("recipe_done", {
+      runSeq: 42,
+      recipeName: "morning-brief",
+      status: "error",
+      errorMessage: "Agent silent-fail in step summarize",
+    });
+
+    expect(dispatchHaltPushNotification).toHaveBeenCalledTimes(1);
+    expect(dispatchHaltPushNotification).toHaveBeenCalledWith(
+      CFG.url,
+      CFG.token,
+      expect.objectContaining({
+        recipeName: "morning-brief",
+        runSeq: 42,
+        status: "error",
+        errorMessage: "Agent silent-fail in step summarize",
+      }),
+    );
+  });
+
+  it("skips recipe_done with status=done (successful runs)", () => {
+    wireHaltPushDispatch({ activityLog, getPushConfig: () => CFG });
+    activityLog.recordEvent("recipe_done", {
+      runSeq: 1,
+      recipeName: "x",
+      status: "done",
+    });
+    expect(dispatchHaltPushNotification).not.toHaveBeenCalled();
+  });
+
+  it("skips non-recipe_done lifecycle events", () => {
+    wireHaltPushDispatch({ activityLog, getPushConfig: () => CFG });
+    activityLog.recordEvent("recipe_started", { runSeq: 1, recipeName: "x" });
+    activityLog.recordEvent("recipe_step_done", {
+      runSeq: 1,
+      stepId: "s1",
+      status: "error",
+      error: "step blew up",
+    });
+    expect(dispatchHaltPushNotification).not.toHaveBeenCalled();
+  });
+
+  it("no-ops when push relay config is not set", () => {
+    wireHaltPushDispatch({ activityLog, getPushConfig: () => null });
+    activityLog.recordEvent("recipe_done", {
+      runSeq: 1,
+      recipeName: "x",
+      status: "error",
+    });
+    expect(dispatchHaltPushNotification).not.toHaveBeenCalled();
+  });
+
+  it("reads config per-event so /settings changes take effect immediately", () => {
+    let cfg: typeof CFG | null = null;
+    wireHaltPushDispatch({ activityLog, getPushConfig: () => cfg });
+
+    // First fire: no config → no dispatch.
+    activityLog.recordEvent("recipe_done", {
+      runSeq: 1,
+      recipeName: "x",
+      status: "error",
+    });
+    expect(dispatchHaltPushNotification).not.toHaveBeenCalled();
+
+    // Config arrives, second fire dispatches.
+    cfg = CFG;
+    activityLog.recordEvent("recipe_done", {
+      runSeq: 2,
+      recipeName: "x",
+      status: "error",
+    });
+    expect(dispatchHaltPushNotification).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns an unsubscribe that detaches the listener", () => {
+    const unsubscribe = wireHaltPushDispatch({
+      activityLog,
+      getPushConfig: () => CFG,
+    });
+
+    unsubscribe();
+
+    activityLog.recordEvent("recipe_done", {
+      runSeq: 1,
+      recipeName: "x",
+      status: "error",
+    });
+    expect(dispatchHaltPushNotification).not.toHaveBeenCalled();
+  });
+
+  it("defaults missing recipeName / runSeq to safe values without throwing", () => {
+    wireHaltPushDispatch({ activityLog, getPushConfig: () => CFG });
+    activityLog.recordEvent("recipe_done", { status: "error" });
+    expect(dispatchHaltPushNotification).toHaveBeenCalledWith(
+      CFG.url,
+      CFG.token,
+      expect.objectContaining({
+        recipeName: "recipe",
+        runSeq: 0,
+        status: "error",
+      }),
+    );
+  });
+});

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -60,6 +60,7 @@ import { buildRecentTracesDigest } from "./tools/recentTracesDigest.js";
 import { resolveFilePath } from "./tools/utils.js";
 import { McpTransport } from "./transport.js";
 import { PACKAGE_VERSION } from "./version.js";
+import { wireHaltPushDispatch } from "./wireHaltPushDispatch.js";
 
 const SHUTDOWN_TIMEOUT_MS = 5000;
 let globalHandlersRegistered = false;
@@ -1447,6 +1448,21 @@ export class Bridge {
       this.config.pushServiceBaseUrl ?? undefined;
     this.server.ntfyTopic = this.config.ntfyTopic ?? undefined;
     this.server.ntfyServer = this.config.ntfyServer ?? undefined;
+
+    // Wire recipe-halt → Web Push dispatch. The listener reads
+    // pushServiceUrl/Token via getter each fire, so config edits
+    // through /settings take effect without a restart. Push request
+    // is fire-and-forget; runner is never blocked on a relay outage.
+    wireHaltPushDispatch({
+      activityLog: this.activityLog,
+      getPushConfig: () => {
+        const url = this.server.pushServiceUrl;
+        const token = this.server.pushServiceToken;
+        if (!url || !token) return null;
+        return { url, token };
+      },
+      logger: this.logger,
+    });
     this.server.readyFn = () => {
       // Count tools from the first active session (all sessions share the same tool set)
       const anySession = [...this.sessions.values()][0];

--- a/src/haltPushDispatch.ts
+++ b/src/haltPushDispatch.ts
@@ -1,0 +1,120 @@
+/**
+ * Bridge → push relay dispatch for recipe halt events.
+ *
+ * Sibling of `dispatchPushNotification` in [src/approvalHttp.ts](./approvalHttp.ts).
+ * The bridge POSTs a halt payload to `${pushServiceUrl}/halt`; the relay
+ * (a hosted push service or the dashboard's `/api/relay/halt` route)
+ * fans it out to every subscribed browser via Web Push.
+ *
+ * SSRF guard mirrors the approval dispatcher: HTTPS-only, hostname
+ * blocklist (localhost / loopback / private IPs after DNS resolve),
+ * 5s abort timeout, fire-and-forget so the recipe runner is never
+ * blocked on a push relay outage.
+ *
+ * Wired via `wireHaltPushDispatch` (subscribes to ActivityLog) — keeps
+ * the runner itself ignorant of push transport.
+ */
+
+import dns from "node:dns/promises";
+
+/**
+ * Same SSRF blocklist as `dispatchPushNotification` in approvalHttp.ts.
+ * Duplicated inline to keep this dispatcher self-contained (the
+ * approvalHttp version is module-private and the file is already
+ * dense). If a third dispatcher ever lands, extract to a shared
+ * `src/sanitizeIp.ts`.
+ */
+function isBlockedIp(ip: string): boolean {
+  if (ip === "::1" || ip === "0:0:0:0:0:0:0:1") return true;
+  const parts = ip.split(".").map(Number);
+  if (parts.length !== 4) return false;
+  const [a, b] = parts as [number, number, number, number];
+  if (a === 127) return true;
+  if (a === 10) return true;
+  if (a === 172 && b >= 16 && b <= 31) return true;
+  if (a === 192 && b === 168) return true;
+  if (a === 169 && b === 254) return true;
+  return false;
+}
+
+export interface HaltPushPayload {
+  recipeName: string;
+  runSeq: number;
+  /** Always "error" or "halted" — the runner emits "error" today; the
+   *  shape leaves room for the dashboard's halted/error distinction. */
+  status: "error" | "halted";
+  haltReason?: string;
+  haltCategory?: string;
+  stepId?: string;
+  errorMessage?: string;
+  occurredAt?: number;
+}
+
+/**
+ * Fire-and-forget dispatch. Never throws — caller cannot recover from a
+ * push relay outage. Logged via console.warn for ops visibility.
+ */
+export async function dispatchHaltPushNotification(
+  pushServiceUrl: string,
+  pushServiceToken: string,
+  payload: HaltPushPayload,
+): Promise<void> {
+  if (!pushServiceUrl.startsWith("https://")) {
+    console.warn(`[halt-push] Rejected non-HTTPS push service URL`);
+    return;
+  }
+  let hostname: string;
+  try {
+    hostname = new URL(pushServiceUrl).hostname;
+  } catch {
+    console.warn(`[halt-push] Malformed push service URL — skipping`);
+    return;
+  }
+  if (hostname === "localhost") {
+    console.warn(`[halt-push] Blocked loopback push service hostname`);
+    return;
+  }
+  try {
+    const resolved = await dns.lookup(hostname);
+    if (isBlockedIp(resolved.address)) {
+      console.warn(
+        `[halt-push] Blocked private/loopback IP for push service: ${resolved.address}`,
+      );
+      return;
+    }
+  } catch (err) {
+    console.warn(
+      `[halt-push] DNS resolution failed for ${hostname}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return;
+  }
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 5_000);
+  try {
+    const res = await fetch(`${pushServiceUrl}/halt`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${pushServiceToken}`,
+      },
+      body: JSON.stringify(payload),
+      signal: controller.signal,
+    });
+    if (!res.ok) {
+      // 404 is informational ("no subscribers yet") — same relay
+      // contract as the approval path. Anything else is worth a warn.
+      if (res.status !== 404) {
+        console.warn(
+          `[halt-push] Non-2xx from push relay: ${res.status} ${res.statusText}`,
+        );
+      }
+    }
+  } catch (err) {
+    console.warn(
+      `[halt-push] Dispatch failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/src/wireHaltPushDispatch.ts
+++ b/src/wireHaltPushDispatch.ts
@@ -1,0 +1,67 @@
+/**
+ * Subscribe to ActivityLog and dispatch a Web Push notification
+ * whenever a recipe run completes with status=error.
+ *
+ * Lives outside the recipe runner so the runner stays push-agnostic
+ * (`yamlRunner.ts` already emits `recipe_done` lifecycle events —
+ * we just listen). Pushes are fire-and-forget; runner is never
+ * blocked or affected by a relay outage.
+ *
+ * Reads `pushServiceUrl` / `pushServiceToken` from a getter callback
+ * (not a captured value) so config edits through `/settings` take
+ * effect immediately without a bridge restart.
+ */
+
+import type { ActivityLog } from "./activityLog.js";
+import { dispatchHaltPushNotification } from "./haltPushDispatch.js";
+
+interface WireHaltPushDispatchDeps {
+  activityLog: ActivityLog;
+  /** Called per event — returns the current push relay config or null
+   *  if push isn't configured. Reading from a getter rather than a
+   *  captured value picks up runtime config changes. */
+  getPushConfig: () => { url: string; token: string } | null;
+  logger?: { warn?: (msg: string) => void };
+}
+
+/**
+ * Returns an unsubscribe function. Caller is responsible for
+ * cleanup on shutdown (the bridge doesn't typically need to —
+ * process exit drops the listener regardless).
+ */
+export function wireHaltPushDispatch(
+  deps: WireHaltPushDispatchDeps,
+): () => void {
+  return deps.activityLog.subscribe((kind, entry) => {
+    if (kind !== "lifecycle") return;
+    const lifecycle = entry as {
+      event?: string;
+      metadata?: Record<string, unknown>;
+    };
+    if (lifecycle.event !== "recipe_done") return;
+    const md = lifecycle.metadata ?? {};
+    if (md.status !== "error") return;
+
+    const cfg = deps.getPushConfig();
+    if (!cfg) return;
+
+    const recipeName =
+      typeof md.recipeName === "string" ? md.recipeName : "recipe";
+    const runSeq = typeof md.runSeq === "number" ? md.runSeq : 0;
+    const errorMessage =
+      typeof md.errorMessage === "string" ? md.errorMessage : undefined;
+    // Best-effort: dispatchHaltPushNotification swallows errors, but
+    // a synchronously-thrown URL parse error would still surface here.
+    dispatchHaltPushNotification(cfg.url, cfg.token, {
+      recipeName,
+      runSeq,
+      status: "error",
+      errorMessage,
+      occurredAt: Date.now(),
+    }).catch((err) => {
+      deps.logger?.warn?.(
+        `[halt-push] unexpected dispatcher error: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary
Bridge end of the halt-push chain. The dashboard side shipped in #712 was sitting idle without this; merging #712 + this PR delivers halt notifications end-to-end.

- New \`src/haltPushDispatch.ts\` — \`dispatchHaltPushNotification\` mirroring \`dispatchPushNotification\` (SSRF guard, 5s abort, fire-and-forget).
- New \`src/wireHaltPushDispatch.ts\` — \`activityLog.subscribe\` listener filtering \`recipe_done\` + \`status === "error"\`.
- \`src/bridge.ts\` — one call to \`wireHaltPushDispatch\` after the push config block. Reads pushServiceUrl / pushServiceToken per-event via getter so /settings changes apply without restart.

## Why this shape
The runner stays push-agnostic. \`yamlRunner.ts\` already emits the \`recipe_done\` lifecycle event with \`status\` / \`runSeq\` / \`recipeName\` / \`errorMessage\`; we just listen instead of threading a new RunnerDeps field through the orchestrator.

\`isBlockedIp\` is duplicated inline (17 lines) — extraction hint left in a comment if a third dispatcher ever lands.

## Test plan
- [ ] Run a recipe that errors with push relay configured → relay receives a POST with the halt payload
- [ ] Same recipe succeeds → no POST fires
- [ ] /settings updates push config mid-session → next halt uses new config (no restart needed)
- [ ] No push relay configured → listener wired but never dispatches
- [ ] 7 new unit tests pass

## Pre-existing flake
\`src/__tests__/fsWatchWithFallback.test.ts:113\` (file-watch polling timing) — unrelated to this PR.

## Follow-ups
- PR 3: Settings toggle for per-subscription \`prefs.halts\`
- PR 4: In-toast "Enable push" CTA in HaltToastWatcher (#708)
- PR 5: 60s dedupe LRU keyed by \`(runSeq, stepId)\` if flapping becomes a problem

🤖 Generated with [Claude Code](https://claude.com/claude-code)