### PR TITLE
chore: migrate 5 inline fontSize literals + lower ratchet to 14

### DIFF
--- a/dashboard/scripts/check-inline-fontsize.mjs
+++ b/dashboard/scripts/check-inline-fontsize.mjs
@@ -17,7 +17,7 @@ const SRC = join(ROOT, "src");
 
 // Bump DOWN as inline fontSize literals get migrated to var(--fs-*).
 // Never bump UP. CI reviewer should reject any PR raising this number.
-const BASELINE = 19;
+const BASELINE = 14;
 
 const PATTERN = /fontSize:\s*[0-9]+(?:\.[0-9]+)?/g;
 

--- a/dashboard/src/app/analytics/page.tsx
+++ b/dashboard/src/app/analytics/page.tsx
@@ -262,16 +262,16 @@ export default function AnalyticsPage() {
                 <tbody>
                   {topTools.map((t) => (
                     <tr key={t.tool} style={{ borderBottom: "1px solid var(--line-3)" }}>
-                      <td style={{ padding: "7px 8px", fontFamily: "var(--font-mono)", fontSize: 11.5, color: "var(--ink-0)", whiteSpace: "nowrap" }}>{t.tool}</td>
+                      <td style={{ padding: "7px 8px", fontFamily: "var(--font-mono)", fontSize: "var(--fs-xs)", color: "var(--ink-0)", whiteSpace: "nowrap" }}>{t.tool}</td>
                       <td style={{ padding: "7px 8px", width: "100%" }}>
                         <div style={{ background: "var(--line-3)", borderRadius: 2, height: 5, width: "100%" }}>
                           <div style={{ background: "var(--orange)", borderRadius: 2, height: 5, width: `${(t.calls / maxCalls) * 100}%` }} />
                         </div>
                       </td>
-                      <td style={{ textAlign: "right", padding: "7px 8px", fontFamily: "var(--font-mono)", fontSize: 11.5, whiteSpace: "nowrap" }}>{t.calls}</td>
-                      <td style={{ textAlign: "right", padding: "7px 8px", fontFamily: "var(--font-mono)", fontSize: 11.5, color: t.errors > 0 ? "var(--err)" : "var(--ink-3)", whiteSpace: "nowrap" }}>{t.errors} err</td>
-                      <td style={{ textAlign: "right", padding: "7px 8px", fontFamily: "var(--font-mono)", fontSize: 11.5, color: "var(--ink-3)", whiteSpace: "nowrap" }} title="p50 latency">{fmtDuration(t.p50Ms)}</td>
-                      <td style={{ textAlign: "right", padding: "7px 8px", fontFamily: "var(--font-mono)", fontSize: 11.5, color: "var(--ink-3)", whiteSpace: "nowrap" }} title="p95 latency">{fmtDuration(t.p95Ms)}</td>
+                      <td style={{ textAlign: "right", padding: "7px 8px", fontFamily: "var(--font-mono)", fontSize: "var(--fs-xs)", whiteSpace: "nowrap" }}>{t.calls}</td>
+                      <td style={{ textAlign: "right", padding: "7px 8px", fontFamily: "var(--font-mono)", fontSize: "var(--fs-xs)", color: t.errors > 0 ? "var(--err)" : "var(--ink-3)", whiteSpace: "nowrap" }}>{t.errors} err</td>
+                      <td style={{ textAlign: "right", padding: "7px 8px", fontFamily: "var(--font-mono)", fontSize: "var(--fs-xs)", color: "var(--ink-3)", whiteSpace: "nowrap" }} title="p50 latency">{fmtDuration(t.p50Ms)}</td>
+                      <td style={{ textAlign: "right", padding: "7px 8px", fontFamily: "var(--font-mono)", fontSize: "var(--fs-xs)", color: "var(--ink-3)", whiteSpace: "nowrap" }} title="p95 latency">{fmtDuration(t.p95Ms)}</td>
                     </tr>
                   ))}
                 </tbody>


### PR DESCRIPTION
## Summary
- Replace 5 \`fontSize: 11.5\` in /analytics tool-history table with \`var(--fs-xs)\` (11px)
- Lower \`check-inline-fontsize.mjs\` BASELINE from 19 → 14

## Why
Audit recommendation #8: ratchet was at-ceiling (19/19). Any new feature PR adding a single inline fontSize literal would tip the ratchet without a paired migration. This bank 5 headroom.

The 0.5px shrink (11.5 → 11) is intentional — design-token coherence beats fractional pixel precision in a mono column.

## Test plan
- [ ] /analytics tool history renders normally; no visible regression
- [ ] \`node scripts/check-inline-fontsize.mjs\` reports 14/14

🤖 Generated with [Claude Code](https://claude.com/claude-code)