### PR TITLE
fix(sse): correct event-type contract for shared-stream consumers

### DIFF
--- a/dashboard/src/hooks/__tests__/useApprovalPatterns.test.tsx
+++ b/dashboard/src/hooks/__tests__/useApprovalPatterns.test.tsx
@@ -84,10 +84,24 @@ describe("useApprovalPatterns — initial state", () => {
   });
 });
 
+// The bridge emits approval decisions as kind:"lifecycle" frames with
+// the decision payload nested in `metadata`. useBridgeStream forwards
+// `(kind, payload)` — so the hook sees type "lifecycle".
+function fireDecision(
+  toolName: unknown,
+  decision: unknown,
+): void {
+  fireEvent("lifecycle", {
+    kind: "lifecycle",
+    event: "approval_decision",
+    metadata: { toolName, decision },
+  });
+}
+
 describe("useApprovalPatterns — approval_decision stream events", () => {
   it("creates a new entry when toolName is unknown", () => {
     const { result } = renderHook(() => useApprovalPatterns());
-    fireEvent("approval_decision", { toolName: "Bash", decision: "approve" });
+    fireDecision("Bash", "approve");
     const got = result.current.patterns.get("Bash");
     expect(got).toBeDefined();
     expect(got!.approved).toBe(1);
@@ -104,15 +118,15 @@ describe("useApprovalPatterns — approval_decision stream events", () => {
       }),
     );
     const { result } = renderHook(() => useApprovalPatterns());
-    fireEvent("approval_decision", { toolName: "Bash", decision: "approve" });
+    fireDecision("Bash", "approve");
     expect(result.current.patterns.get("Bash")!.approved).toBe(6);
     expect(result.current.patterns.get("Bash")!.rejected).toBe(1);
   });
 
   it("increments the rejected counter on 'reject' decision", () => {
     const { result } = renderHook(() => useApprovalPatterns());
-    fireEvent("approval_decision", { toolName: "WebFetch", decision: "reject" });
-    fireEvent("approval_decision", { toolName: "WebFetch", decision: "reject" });
+    fireDecision("WebFetch", "reject");
+    fireDecision("WebFetch", "reject");
     expect(result.current.patterns.get("WebFetch")).toMatchObject({
       approved: 0,
       rejected: 2,
@@ -121,25 +135,32 @@ describe("useApprovalPatterns — approval_decision stream events", () => {
 
   it("persists updated patterns to localStorage", () => {
     renderHook(() => useApprovalPatterns());
-    fireEvent("approval_decision", { toolName: "Bash", decision: "approve" });
+    fireDecision("Bash", "approve");
     const stored = JSON.parse(localStorage.getItem(STORAGE_KEY)!);
     expect(stored.Bash).toMatchObject({ approved: 1, rejected: 0 });
   });
 
-  it("ignores non-approval_decision event types", () => {
+  it("ignores non-lifecycle frames and non-decision lifecycle events", () => {
     const { result } = renderHook(() => useApprovalPatterns());
-    fireEvent("connector_status", { toolName: "Bash", decision: "approve" });
-    fireEvent("ping", { x: 1 });
+    // wrong kind
+    fireEvent("tool", { kind: "tool", tool: "Bash" });
+    // lifecycle, but not an approval decision
+    fireEvent("lifecycle", {
+      kind: "lifecycle",
+      event: "recipe_done",
+      metadata: {},
+    });
     expect(result.current.patterns.size).toBe(0);
   });
 
-  it("ignores malformed event data (missing or wrong-shape fields)", () => {
+  it("ignores malformed decision payloads", () => {
     const { result } = renderHook(() => useApprovalPatterns());
-    fireEvent("approval_decision", null);
-    fireEvent("approval_decision", { toolName: "Bash" }); // missing decision
-    fireEvent("approval_decision", { decision: "approve" }); // missing toolName
-    fireEvent("approval_decision", { toolName: 7, decision: "approve" }); // wrong types
-    fireEvent("approval_decision", { toolName: "Bash", decision: "maybe" }); // bad enum
+    fireEvent("lifecycle", null);
+    fireEvent("lifecycle", { kind: "lifecycle", event: "approval_decision" }); // no metadata
+    fireDecision("Bash", undefined); // missing decision
+    fireDecision(undefined, "approve"); // missing toolName
+    fireDecision(7, "approve"); // wrong type
+    fireDecision("Bash", "maybe"); // bad enum
     expect(result.current.patterns.size).toBe(0);
   });
 });

--- a/dashboard/src/hooks/__tests__/useBridgeStream.test.tsx
+++ b/dashboard/src/hooks/__tests__/useBridgeStream.test.tsx
@@ -295,7 +295,7 @@ describe("useBridgeStream — shared /stream multiplex", () => {
     expect(subscribeStreamLiveness).toHaveBeenCalledTimes(1);
   });
 
-  it("forwards singleton messages to onEvent with the legacy 'message' type", () => {
+  it("forwards the singleton's derived event type to onEvent", () => {
     const onEvent = vi.fn();
     renderHook(() => useBridgeStream("/api/bridge/stream", onEvent));
     // Pull the message callback the hook registered, fire a payload.
@@ -303,9 +303,9 @@ describe("useBridgeStream — shared /stream multiplex", () => {
     act(() => {
       msgCb("lifecycle", { kind: "lifecycle", event: "recipe_done" });
     });
-    // Type is forced to "message" to preserve the legacy contract — the
-    // bridge emits default (unnamed) SSE frames.
-    expect(onEvent).toHaveBeenCalledWith("message", {
+    // Type is the payload `kind` (via subscribeStreamMessage) — what
+    // consumers guard on. Forwarded verbatim.
+    expect(onEvent).toHaveBeenCalledWith("lifecycle", {
       kind: "lifecycle",
       event: "recipe_done",
     });

--- a/dashboard/src/hooks/__tests__/useBridgeStream.test.tsx
+++ b/dashboard/src/hooks/__tests__/useBridgeStream.test.tsx
@@ -2,6 +2,19 @@
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+// The shared `/api/bridge/stream` path is multiplexed through the
+// streamLiveness singleton — mock it so the shared-path tests can drive
+// message + liveness callbacks deterministically. The direct-EventSource
+// tests below use a NON-shared path and never touch this mock.
+vi.mock("@/lib/streamLiveness", () => ({
+  subscribeStreamMessage: vi.fn(() => () => {}),
+  subscribeStreamLiveness: vi.fn(() => () => {}),
+}));
+
+import {
+  subscribeStreamLiveness,
+  subscribeStreamMessage,
+} from "@/lib/streamLiveness";
 import { useBridgeStream } from "../useBridgeStream";
 
 // Minimal EventSource shim — exposes the same surface jsdom doesn't
@@ -31,6 +44,8 @@ beforeEach(() => {
   FakeEventSource.instances = [];
   originalEventSource = (globalThis as { EventSource?: typeof EventSource }).EventSource;
   vi.stubGlobal("EventSource", FakeEventSource);
+  vi.mocked(subscribeStreamMessage).mockClear();
+  vi.mocked(subscribeStreamLiveness).mockClear();
 });
 
 afterEach(() => {
@@ -50,16 +65,16 @@ function latest(): FakeEventSource {
 describe("useBridgeStream — connect lifecycle", () => {
   it("constructs an EventSource at apiPath(path) on mount", () => {
     renderHook(() =>
-      useBridgeStream("/api/bridge/stream", () => {}),
+      useBridgeStream("/api/bridge/fallback-stream", () => {}),
     );
     expect(FakeEventSource.instances).toHaveLength(1);
     // apiPath is a passthrough in dev; just assert the trailing path made it in.
-    expect(latest().url).toContain("/api/bridge/stream");
+    expect(latest().url).toContain("/api/bridge/fallback-stream");
   });
 
   it("sets connected=true with no error after onopen", async () => {
     const { result } = renderHook(() =>
-      useBridgeStream("/api/bridge/stream", () => {}),
+      useBridgeStream("/api/bridge/fallback-stream", () => {}),
     );
 
     act(() => {
@@ -72,7 +87,7 @@ describe("useBridgeStream — connect lifecycle", () => {
 
   it("clears error on subsequent onopen (after a reconnect)", async () => {
     const { result } = renderHook(() =>
-      useBridgeStream("/api/bridge/stream", () => {}),
+      useBridgeStream("/api/bridge/fallback-stream", () => {}),
     );
     act(() => {
       latest().onerror?.(new Event("error"));
@@ -100,7 +115,7 @@ describe("useBridgeStream — connect lifecycle", () => {
 describe("useBridgeStream — error + reconnect", () => {
   it("onerror sets connected=false, error string, and closes the ES", async () => {
     const { result } = renderHook(() =>
-      useBridgeStream("/api/bridge/stream", () => {}),
+      useBridgeStream("/api/bridge/fallback-stream", () => {}),
     );
     const first = latest();
 
@@ -118,7 +133,7 @@ describe("useBridgeStream — error + reconnect", () => {
   it("schedules a reconnect 3s after onerror", async () => {
     vi.useFakeTimers();
     renderHook(() =>
-      useBridgeStream("/api/bridge/stream", () => {}),
+      useBridgeStream("/api/bridge/fallback-stream", () => {}),
     );
     const first = latest();
 
@@ -137,7 +152,7 @@ describe("useBridgeStream — error + reconnect", () => {
   it("cleanup cancels the pending reconnect timer", () => {
     vi.useFakeTimers();
     const { unmount } = renderHook(() =>
-      useBridgeStream("/api/bridge/stream", () => {}),
+      useBridgeStream("/api/bridge/fallback-stream", () => {}),
     );
     const first = latest();
 
@@ -159,7 +174,7 @@ describe("useBridgeStream — onmessage dispatch", () => {
   it("parses JSON and invokes onEvent with (type, data)", () => {
     const onEvent = vi.fn();
     renderHook(() =>
-      useBridgeStream("/api/bridge/stream", onEvent),
+      useBridgeStream("/api/bridge/fallback-stream", onEvent),
     );
 
     act(() => {
@@ -178,7 +193,7 @@ describe("useBridgeStream — onmessage dispatch", () => {
   it("falls back to type 'message' when msg.type is empty", () => {
     const onEvent = vi.fn();
     renderHook(() =>
-      useBridgeStream("/api/bridge/stream", onEvent),
+      useBridgeStream("/api/bridge/fallback-stream", onEvent),
     );
 
     act(() => {
@@ -194,7 +209,7 @@ describe("useBridgeStream — onmessage dispatch", () => {
   it("silently drops unparseable JSON without throwing", () => {
     const onEvent = vi.fn();
     renderHook(() =>
-      useBridgeStream("/api/bridge/stream", onEvent),
+      useBridgeStream("/api/bridge/fallback-stream", onEvent),
     );
 
     expect(() => {
@@ -211,7 +226,7 @@ describe("useBridgeStream — onmessage dispatch", () => {
     const second = vi.fn();
     const { rerender } = renderHook(
       ({ cb }: { cb: (t: string, d: unknown) => void }) =>
-        useBridgeStream("/api/bridge/stream", cb),
+        useBridgeStream("/api/bridge/fallback-stream", cb),
       { initialProps: { cb: first as (t: string, d: unknown) => void } },
     );
 
@@ -232,7 +247,7 @@ describe("useBridgeStream — onmessage dispatch", () => {
 describe("useBridgeStream — short-circuit guards", () => {
   it("does not construct an EventSource when enabled=false", () => {
     renderHook(() =>
-      useBridgeStream("/api/bridge/stream", () => {}, { enabled: false }),
+      useBridgeStream("/api/bridge/fallback-stream", () => {}, { enabled: false }),
     );
     expect(FakeEventSource.instances).toHaveLength(0);
   });
@@ -247,7 +262,7 @@ describe("useBridgeStream — short-circuit guards", () => {
 
     expect(() => {
       renderHook(() =>
-        useBridgeStream("/api/bridge/stream", () => {}),
+        useBridgeStream("/api/bridge/fallback-stream", () => {}),
       );
     }).not.toThrow();
   });
@@ -256,17 +271,83 @@ describe("useBridgeStream — short-circuit guards", () => {
 describe("useBridgeStream — initial + cleanup", () => {
   it("starts as { connected: false, error: undefined }", () => {
     const { result } = renderHook(() =>
-      useBridgeStream("/api/bridge/stream", () => {}),
+      useBridgeStream("/api/bridge/fallback-stream", () => {}),
     );
     expect(result.current).toEqual({ connected: false, error: undefined });
   });
 
   it("closes the EventSource on unmount", () => {
     const { unmount } = renderHook(() =>
-      useBridgeStream("/api/bridge/stream", () => {}),
+      useBridgeStream("/api/bridge/fallback-stream", () => {}),
     );
     const es = latest();
     unmount();
     expect(es.closed).toBe(true);
+  });
+});
+
+describe("useBridgeStream — shared /stream multiplex", () => {
+  it("rides the streamLiveness singleton instead of opening its own EventSource", () => {
+    renderHook(() => useBridgeStream("/api/bridge/stream", () => {}));
+    // No direct EventSource — the singleton owns the socket.
+    expect(FakeEventSource.instances).toHaveLength(0);
+    expect(subscribeStreamMessage).toHaveBeenCalledTimes(1);
+    expect(subscribeStreamLiveness).toHaveBeenCalledTimes(1);
+  });
+
+  it("forwards singleton messages to onEvent with the legacy 'message' type", () => {
+    const onEvent = vi.fn();
+    renderHook(() => useBridgeStream("/api/bridge/stream", onEvent));
+    // Pull the message callback the hook registered, fire a payload.
+    const msgCb = vi.mocked(subscribeStreamMessage).mock.calls[0]![0];
+    act(() => {
+      msgCb("lifecycle", { kind: "lifecycle", event: "recipe_done" });
+    });
+    // Type is forced to "message" to preserve the legacy contract — the
+    // bridge emits default (unnamed) SSE frames.
+    expect(onEvent).toHaveBeenCalledWith("message", {
+      kind: "lifecycle",
+      event: "recipe_done",
+    });
+  });
+
+  it("maps singleton liveness to connected + error", async () => {
+    const { result } = renderHook(() =>
+      useBridgeStream("/api/bridge/stream", () => {}),
+    );
+    const liveCb = vi.mocked(subscribeStreamLiveness).mock.calls[0]![0];
+
+    act(() => liveCb(true));
+    await waitFor(() => {
+      expect(result.current.connected).toBe(true);
+      expect(result.current.error).toBeUndefined();
+    });
+
+    act(() => liveCb(false));
+    await waitFor(() => {
+      expect(result.current.connected).toBe(false);
+      expect(result.current.error).toBe("Disconnected — reconnecting…");
+    });
+  });
+
+  it("unsubscribes from the singleton on unmount", () => {
+    const unsubMsg = vi.fn();
+    const unsubLive = vi.fn();
+    vi.mocked(subscribeStreamMessage).mockReturnValueOnce(unsubMsg);
+    vi.mocked(subscribeStreamLiveness).mockReturnValueOnce(unsubLive);
+    const { unmount } = renderHook(() =>
+      useBridgeStream("/api/bridge/stream", () => {}),
+    );
+    unmount();
+    expect(unsubMsg).toHaveBeenCalledTimes(1);
+    expect(unsubLive).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not subscribe when enabled=false", () => {
+    renderHook(() =>
+      useBridgeStream("/api/bridge/stream", () => {}, { enabled: false }),
+    );
+    expect(subscribeStreamMessage).not.toHaveBeenCalled();
+    expect(subscribeStreamLiveness).not.toHaveBeenCalled();
   });
 });

--- a/dashboard/src/hooks/useApprovalPatterns.ts
+++ b/dashboard/src/hooks/useApprovalPatterns.ts
@@ -41,18 +41,32 @@ function saveToStorage(map: Map<string, ToolPattern>): void {
   }
 }
 
-interface ApprovalDecisionEvent {
+interface ApprovalDecision {
   toolName: string;
   decision: "approve" | "reject";
 }
 
-function isApprovalDecisionEvent(data: unknown): data is ApprovalDecisionEvent {
-  if (!data || typeof data !== "object") return false;
+/**
+ * Extract `{toolName, decision}` from a bridge SSE frame, or null if
+ * it isn't an approval-decision event.
+ *
+ * The bridge emits `{kind:"lifecycle", event, metadata:{...}}`. The
+ * approval-decision payload carries `toolName` + `decision` inside
+ * `metadata` — NOT at the top level. The previous predicate checked
+ * the top level, so it never matched even when the event was the
+ * right kind. (Compounding bug: the consumer also guarded on the
+ * SSE frame type, which was always "message" — see useBridgeStream.)
+ */
+function readApprovalDecision(data: unknown): ApprovalDecision | null {
+  if (!data || typeof data !== "object") return null;
   const d = data as Record<string, unknown>;
-  return (
-    typeof d.toolName === "string" &&
-    (d.decision === "approve" || d.decision === "reject")
-  );
+  if (d.event !== "approval_decision") return null;
+  const md = d.metadata;
+  if (!md || typeof md !== "object") return null;
+  const m = md as Record<string, unknown>;
+  if (typeof m.toolName !== "string") return null;
+  if (m.decision !== "approve" && m.decision !== "reject") return null;
+  return { toolName: m.toolName, decision: m.decision };
 }
 
 export function useApprovalPatterns(): {
@@ -68,10 +82,14 @@ export function useApprovalPatterns(): {
   patternsRef.current = patterns;
 
   const onEvent = useCallback((type: string, data: unknown) => {
-    if (type !== "approval_decision") return;
-    if (!isApprovalDecisionEvent(data)) return;
+    // The shared stream tags frames by `kind` — approval decisions
+    // arrive as kind:"lifecycle". Filter to lifecycle, then pull the
+    // decision out of the metadata envelope.
+    if (type !== "lifecycle") return;
+    const decided = readApprovalDecision(data);
+    if (!decided) return;
 
-    const { toolName, decision } = data;
+    const { toolName, decision } = decided;
     const prev = patternsRef.current;
     const existing = prev.get(toolName) ?? {
       approved: 0,

--- a/dashboard/src/hooks/useBridgeStream.ts
+++ b/dashboard/src/hooks/useBridgeStream.ts
@@ -30,13 +30,15 @@ export function useBridgeStream(
 		if (!enabled) return;
 
 		// Shared lifecycle stream: ride the singleton instead of opening
-		// a second socket. The bridge emits default (unnamed) SSE frames,
-		// so the legacy direct-EventSource path always reported the event
-		// type as "message" — preserve that exactly here so consumers see
-		// no behavior change from the multiplex.
+		// a second socket. `subscribeStreamMessage` derives the event
+		// type from the payload's `kind` field (e.g. "lifecycle",
+		// "tool"), which is what stream consumers actually want to
+		// switch on — the legacy direct path forwarded the SSE frame's
+		// `.type` ("message" for the bridge's unnamed frames), which
+		// silently broke every consumer that guarded on `type`.
 		if (path === SHARED_STREAM_PATH) {
-			const unsubMsg = subscribeStreamMessage((_type, data) => {
-				onEventRef.current("message", data);
+			const unsubMsg = subscribeStreamMessage((type, data) => {
+				onEventRef.current(type, data);
 			});
 			const unsubLive = subscribeStreamLiveness((live) => {
 				setConnected(live);

--- a/dashboard/src/hooks/useBridgeStream.ts
+++ b/dashboard/src/hooks/useBridgeStream.ts
@@ -1,8 +1,18 @@
 "use client";
 import { useEffect, useRef, useState } from "react";
 import { apiPath } from "@/lib/api";
+import {
+  subscribeStreamLiveness,
+  subscribeStreamMessage,
+} from "@/lib/streamLiveness";
 
 const RECONNECT_DELAY_MS = 3_000;
+
+/** The shared lifecycle stream. Subscriptions to this path are
+ *  multiplexed through the `streamLiveness` singleton so a tab opens
+ *  exactly one EventSource for it regardless of how many components
+ *  consume it. Any other path falls back to a direct EventSource. */
+const SHARED_STREAM_PATH = "/api/bridge/stream";
 
 export function useBridgeStream(
 	path: string,
@@ -19,6 +29,26 @@ export function useBridgeStream(
 	useEffect(() => {
 		if (!enabled) return;
 
+		// Shared lifecycle stream: ride the singleton instead of opening
+		// a second socket. The bridge emits default (unnamed) SSE frames,
+		// so the legacy direct-EventSource path always reported the event
+		// type as "message" — preserve that exactly here so consumers see
+		// no behavior change from the multiplex.
+		if (path === SHARED_STREAM_PATH) {
+			const unsubMsg = subscribeStreamMessage((_type, data) => {
+				onEventRef.current("message", data);
+			});
+			const unsubLive = subscribeStreamLiveness((live) => {
+				setConnected(live);
+				setError(live ? undefined : "Disconnected — reconnecting…");
+			});
+			return () => {
+				unsubMsg();
+				unsubLive();
+			};
+		}
+
+		// Fallback: any other endpoint gets its own EventSource.
 		let es: EventSource | null = null;
 		let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 		let alive = true;


### PR DESCRIPTION
## Summary
Follow-up to #719 — fixes the latent type-guard bugs that PR deliberately left out of scope.

Three `/api/bridge/stream` consumers guarded on an event `type` that never matched (bridge sends unnamed SSE frames → `.type` always `"message"`), so their SSE paths silently no-op'd:
- `runs/page.tsx` — auto-reload on recipe events
- `runs/[seq]/page.tsx` — live step updates
- `useApprovalPatterns.ts` — approval-pattern tracking

**Fix:** the multiplex path now forwards the type `subscribeStreamMessage` derives from the payload `kind` (`"lifecycle"` / `"tool"`) — what the consumers were written against. `runs` + `runs/[seq]` work as designed with no change to their own code.

`useApprovalPatterns` had a second bug — it read `toolName`/`decision` from the top level, but the bridge nests them in `metadata`. Rewrote the predicate to filter `event === "approval_decision"` and read the metadata envelope.

## Stack
Targets `perf/usebridgestream-multiplex` (#719). Retarget to `main` after #719 merges.

## Test plan
- [ ] Trigger a recipe → /runs auto-reloads without waiting for the poll
- [ ] Open /runs/[seq] on a running recipe → steps update live
- [ ] Approve/reject a tool call → /insights approval patterns update
- [ ] 540 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)