### PR TITLE
feat(push): per-subscription halt-notification toggle on Settings

### DIFF
--- a/dashboard/src/app/api/push/prefs/route.ts
+++ b/dashboard/src/app/api/push/prefs/route.ts
@@ -1,0 +1,88 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireSameOrigin } from "@/lib/csrf";
+import { getPrefs, setPrefs } from "@/lib/pushStore";
+import {
+  DASHBOARD_API_BODY_CAPS,
+  bodyTooLargeResponse,
+  readJsonWithCap,
+} from "@/lib/readBodyWithCap";
+import { SESSION_COOKIE_NAME, verifySession } from "@/lib/session";
+
+/**
+ * Per-subscription push preferences.
+ *
+ *   GET  /api/push/prefs?endpoint=<url>  → { prefs: { approvals, halts } }
+ *   POST /api/push/prefs { endpoint, halts? , approvals? } → { ok, prefs }
+ *
+ * Same auth posture as /api/push/subscribe — same-origin + session.
+ * Unknown endpoints: GET returns the defaults; POST 404s (you can't
+ * set prefs for a subscription that was never registered).
+ */
+
+async function authed(req: NextRequest): Promise<NextResponse | null> {
+  const guard = requireSameOrigin(req);
+  if (guard) return guard;
+  const session = await verifySession(
+    req.cookies.get(SESSION_COOKIE_NAME)?.value,
+  );
+  if (!session.valid) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  return null;
+}
+
+export async function GET(req: NextRequest) {
+  const fail = await authed(req);
+  if (fail) return fail;
+
+  const endpoint = req.nextUrl.searchParams.get("endpoint");
+  if (!endpoint) {
+    return NextResponse.json(
+      { error: "endpoint query param required" },
+      { status: 400 },
+    );
+  }
+  return NextResponse.json({ prefs: getPrefs(endpoint) });
+}
+
+export async function POST(req: NextRequest) {
+  const fail = await authed(req);
+  if (fail) return fail;
+
+  const parsed = await readJsonWithCap<{
+    endpoint?: string;
+    halts?: boolean;
+    approvals?: boolean;
+  }>(req, DASHBOARD_API_BODY_CAPS.push);
+  if (!parsed.ok) {
+    if (parsed.reason === "too_large")
+      return bodyTooLargeResponse(parsed.maxBytes);
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+  const body = parsed.value;
+  if (!body?.endpoint) {
+    return NextResponse.json(
+      { error: "endpoint required" },
+      { status: 400 },
+    );
+  }
+
+  const next: { halts?: boolean; approvals?: boolean } = {};
+  if (typeof body.halts === "boolean") next.halts = body.halts;
+  if (typeof body.approvals === "boolean") next.approvals = body.approvals;
+  if (Object.keys(next).length === 0) {
+    return NextResponse.json(
+      { error: "no preference fields to update" },
+      { status: 400 },
+    );
+  }
+
+  const ok = setPrefs(body.endpoint, next);
+  if (!ok) {
+    return NextResponse.json(
+      { error: "unknown subscription endpoint" },
+      { status: 404 },
+    );
+  }
+  return NextResponse.json({ ok: true, prefs: getPrefs(body.endpoint) });
+}

--- a/dashboard/src/app/settings/page.tsx
+++ b/dashboard/src/app/settings/page.tsx
@@ -5,6 +5,7 @@ import { apiPath } from "@/lib/api";
 import { subscribeStreamMessage } from "@/lib/streamLiveness";
 import { EmptyState, StatusPill } from "@/components/patchwork";
 import {
+  getPushSubscriptionEndpoint,
   getPushSubscriptionStatus,
   registerServiceWorker,
   subscribeToPush,
@@ -246,6 +247,10 @@ export default function SettingsPage() {
   const [pushMsg, setPushMsg] = useState<{ ok: boolean; text: string } | null>(
     null,
   );
+  // Per-subscription "notify me when runs halt" preference. Defaults
+  // on; loaded from /api/push/prefs once a subscription exists.
+  const [haltsPref, setHaltsPref] = useState(true);
+  const [haltsPrefBusy, setHaltsPrefBusy] = useState(false);
   const vapidPublicKey = process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY ?? "";
 
   // Telemetry — persisted via GET/POST /api/bridge/telemetry-prefs
@@ -529,6 +534,33 @@ export default function SettingsPage() {
       cancel = true;
     };
   }, []);
+
+  // Load the per-subscription halt-notification preference once a
+  // subscription exists. Defaults on (DEFAULT_PREFS) so a missing
+  // record reads as enabled.
+  useEffect(() => {
+    if (pushStatus !== "subscribed") return;
+    let cancel = false;
+    (async () => {
+      try {
+        const endpoint = await getPushSubscriptionEndpoint();
+        if (!endpoint || cancel) return;
+        const res = await fetch(
+          apiPath(`/api/push/prefs?endpoint=${encodeURIComponent(endpoint)}`),
+        );
+        if (!res.ok || cancel) return;
+        const data = (await res.json()) as { prefs?: { halts?: boolean } };
+        if (!cancel && typeof data.prefs?.halts === "boolean") {
+          setHaltsPref(data.prefs.halts);
+        }
+      } catch {
+        // fail-soft — leave the default
+      }
+    })();
+    return () => {
+      cancel = true;
+    };
+  }, [pushStatus]);
 
   // Scroll-spy active section — rAF-throttled. Previously
   // `getBoundingClientRect()` ×6 fired on every scroll event,
@@ -855,6 +887,35 @@ export default function SettingsPage() {
       });
     } finally {
       setPushBusy(false);
+    }
+  }
+
+  async function handleHaltsPrefToggle(next: boolean) {
+    setHaltsPrefBusy(true);
+    // Optimistic — revert on failure.
+    const prev = haltsPref;
+    setHaltsPref(next);
+    try {
+      const endpoint = await getPushSubscriptionEndpoint();
+      if (!endpoint) throw new Error("no active push subscription");
+      const res = await fetch(apiPath("/api/push/prefs"), {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ endpoint, halts: next }),
+      });
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as { error?: string };
+        throw new Error(body.error ?? `HTTP ${res.status}`);
+      }
+      flashSaved();
+    } catch (e) {
+      setHaltsPref(prev);
+      setPushMsg({
+        ok: false,
+        text: `Couldn't update halt-notification preference: ${e instanceof Error ? e.message : String(e)}`,
+      });
+    } finally {
+      setHaltsPrefBusy(false);
     }
   }
 
@@ -1675,6 +1736,28 @@ export default function SettingsPage() {
                     </>
                   )}
                 </div>
+                {pushStatus === "subscribed" && (
+                  <label
+                    style={{
+                      display: "flex",
+                      alignItems: "center",
+                      gap: 8,
+                      marginTop: 12,
+                      fontSize: "var(--fs-s)",
+                      color: "var(--ink-1)",
+                      cursor: haltsPrefBusy ? "default" : "pointer",
+                      opacity: haltsPrefBusy ? 0.6 : 1,
+                    }}
+                  >
+                    <input
+                      type="checkbox"
+                      checked={haltsPref}
+                      disabled={haltsPrefBusy}
+                      onChange={(e) => handleHaltsPrefToggle(e.target.checked)}
+                    />
+                    Notify me when a recipe run halts or errors
+                  </label>
+                )}
                 {pushMsg && (
                   <p
                     style={{

--- a/dashboard/src/lib/pushSubscription.ts
+++ b/dashboard/src/lib/pushSubscription.ts
@@ -125,6 +125,21 @@ export async function getPushSubscriptionStatus(): Promise<"subscribed" | "denie
   return sub ? "subscribed" : "unsubscribed";
 }
 
+/**
+ * Endpoint URL of the current browser's push subscription, or null if
+ * not subscribed. The endpoint is the stable key the bridge / dashboard
+ * push store uses, so callers need it to read or update per-subscription
+ * preferences (see /api/push/prefs).
+ */
+export async function getPushSubscriptionEndpoint(): Promise<string | null> {
+  if (!("serviceWorker" in navigator) || !("PushManager" in window))
+    return null;
+  const reg = await navigator.serviceWorker.getRegistration("/dashboard/");
+  if (!reg) return null;
+  const sub = await reg.pushManager.getSubscription();
+  return sub?.endpoint ?? null;
+}
+
 function urlBase64ToUint8Array(base64String: string): Uint8Array {
   const padding = "=".repeat((4 - (base64String.length % 4)) % 4);
   const base64 = (base64String + padding).replace(/-/g, "+").replace(/_/g, "/");


### PR DESCRIPTION
## Summary
Web Push PR 3. Exposes the per-subscription `prefs.halts` flag (store API shipped in #712, now on main) to the user.

- **`/api/push/prefs`** — GET (read by endpoint) + POST (update). Same-origin + session auth, mirrors `/api/push/subscribe`.
- **`getPushSubscriptionEndpoint()`** — new helper resolving the current browser's subscription endpoint.
- **Settings → Mobile** — "Notify me when a recipe run halts or errors" checkbox, shown once subscribed. Loads current pref on mount; optimistic toggle with revert-on-failure.

Lets a user keep approval pushes but mute halt pushes (or vice versa) without unsubscribing. `/api/relay/halt` already filters fan-out on `prefs.halts`.

## Test plan
- [ ] Subscribe to push → checkbox appears, checked (default)
- [ ] Uncheck → POST persists; reload Settings → still unchecked
- [ ] Halt a recipe while unchecked → no push to that browser; approval pushes still arrive
- [ ] Toggle failure → checkbox reverts, error shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)