### PR TITLE
feat(push): one-time Enable-push offer in the halt watcher

### DIFF
--- a/dashboard/src/components/HaltToastWatcher.tsx
+++ b/dashboard/src/components/HaltToastWatcher.tsx
@@ -2,6 +2,11 @@
 import { useEffect, useRef } from "react";
 import { useActiveRuns } from "@/hooks/LiveRunsContext";
 import { useToast } from "@/components/Toast";
+import {
+  getPushSubscriptionStatus,
+  registerServiceWorker,
+  subscribeToPush,
+} from "@/lib/pushSubscription";
 import type { ActiveRunState } from "@/hooks/useRecipeRunStream";
 
 /**
@@ -10,14 +15,40 @@ import type { ActiveRunState } from "@/hooks/useRecipeRunStream";
  * terminal failure state (halted or error). The toast carries a
  * deep-link to the failing step on /runs/:seq when stepId is known.
  *
- * Web Push (background) is a separate follow-up — VAPID + service
- * worker need wiring. This component covers the foreground case.
+ * The first time a halt fires while the user is NOT subscribed to
+ * Web Push, it also offers a one-time "Enable push" toast so they
+ * can opt in to background notifications — clicking it runs the
+ * subscribe flow (the click is the user gesture the Notification
+ * permission prompt requires). Dismissal is remembered so the offer
+ * never repeats.
  */
+
+const PROMPTED_KEY = "patchwork:halt-push-prompted";
+
+function alreadyPrompted(): boolean {
+  try {
+    return localStorage.getItem(PROMPTED_KEY) === "1";
+  } catch {
+    return true; // localStorage unavailable — treat as prompted, never nag
+  }
+}
+
+function markPrompted(): void {
+  try {
+    localStorage.setItem(PROMPTED_KEY, "1");
+  } catch {
+    // ignore
+  }
+}
+
 export function HaltToastWatcher() {
   const runs = useActiveRuns();
   const toast = useToast();
   const prevRef = useRef<Map<string, ActiveRunState>>(new Map());
   const initialMountRef = useRef(true);
+  // Guards the one-time push-opt-in offer within this tab's lifetime,
+  // independent of the localStorage flag (which also survives reloads).
+  const offeredPushRef = useRef(false);
 
   useEffect(() => {
     // On the very first render we get whatever state the store
@@ -58,10 +89,58 @@ export function HaltToastWatcher() {
             }
           : undefined,
       });
+
+      maybeOfferPush();
     }
 
     prevRef.current = runs;
   }, [runs, toast]);
+
+  // Fire the one-time "Enable push" offer if the user isn't already
+  // subscribed and hasn't been asked before. Separate toast (not an
+  // extra action on the halt toast — Toast supports a single action).
+  function maybeOfferPush() {
+    if (offeredPushRef.current || alreadyPrompted()) return;
+    offeredPushRef.current = true;
+    void (async () => {
+      let status: Awaited<ReturnType<typeof getPushSubscriptionStatus>>;
+      try {
+        status = await getPushSubscriptionStatus();
+      } catch {
+        return;
+      }
+      // Only worth offering when push is genuinely available + off.
+      if (status !== "unsubscribed") return;
+      markPrompted();
+      toast.info("Get notified about halts even when this tab is closed.", {
+        id: "halt-push-offer",
+        duration: 0, // sticky — needs an explicit decision
+        action: {
+          label: "Enable push",
+          onClick: () => {
+            void enablePush();
+          },
+        },
+      });
+    })();
+  }
+
+  async function enablePush() {
+    const vapid = process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY ?? "";
+    if (!vapid) {
+      toast.error("Push isn't configured on this server.");
+      return;
+    }
+    try {
+      await registerServiceWorker();
+      await subscribeToPush(vapid);
+      toast.success("Push enabled — you'll be notified when runs halt.");
+    } catch (e) {
+      toast.error(
+        `Couldn't enable push: ${e instanceof Error ? e.message : String(e)}`,
+      );
+    }
+  }
 
   return null;
 }


### PR DESCRIPTION
## Summary
Web Push PR 4. First time a recipe halts while the user isn't subscribed to Web Push, `HaltToastWatcher` fires a one-time sticky toast offering to enable background notifications.

- Clicking "Enable push" runs `registerServiceWorker` + `subscribeToPush` — the click is the user gesture the permission prompt needs.
- Shown at most once: tab-lifetime ref + `localStorage` flag (`patchwork:halt-push-prompted`).
- Only fires when push is available and off (`status === "unsubscribed"`) — never for denied / unsupported / already-subscribed.
- Separate toast, not a second action on the halt toast (Toast supports one action; "Open run" stays primary).

## Test plan
- [ ] Halt a recipe while unsubscribed + never-prompted → halt toast + separate "Enable push" offer
- [ ] Click "Enable push" → permission prompt → on grant, success toast
- [ ] Halt again → no repeat offer (localStorage flag set)
- [ ] Already-subscribed user → no offer ever
- [ ] Permission denied → no offer

🤖 Generated with [Claude Code](https://claude.com/claude-code)