### PR TITLE
feat(push): dedup repeat halt pushes per runSeq

### DIFF
--- a/src/__tests__/wireHaltPushDispatch.test.ts
+++ b/src/__tests__/wireHaltPushDispatch.test.ts
@@ -139,3 +139,77 @@ describe("wireHaltPushDispatch", () => {
     );
   });
 });
+
+describe("wireHaltPushDispatch — dedup", () => {
+  it("collapses repeat recipe_done for the same runSeq inside the window", () => {
+    let clock = 1_000;
+    wireHaltPushDispatch({
+      activityLog,
+      getPushConfig: () => CFG,
+      dedupWindowMs: 60_000,
+      now: () => clock,
+    });
+
+    activityLog.recordEvent("recipe_done", {
+      runSeq: 7,
+      recipeName: "x",
+      status: "error",
+    });
+    clock += 30_000; // still inside the 60s window
+    activityLog.recordEvent("recipe_done", {
+      runSeq: 7,
+      recipeName: "x",
+      status: "error",
+    });
+
+    expect(dispatchHaltPushNotification).toHaveBeenCalledTimes(1);
+  });
+
+  it("dispatches again once the dedup window has elapsed", () => {
+    let clock = 1_000;
+    wireHaltPushDispatch({
+      activityLog,
+      getPushConfig: () => CFG,
+      dedupWindowMs: 60_000,
+      now: () => clock,
+    });
+
+    activityLog.recordEvent("recipe_done", {
+      runSeq: 7,
+      recipeName: "x",
+      status: "error",
+    });
+    clock += 61_000; // past the window
+    activityLog.recordEvent("recipe_done", {
+      runSeq: 7,
+      recipeName: "x",
+      status: "error",
+    });
+
+    expect(dispatchHaltPushNotification).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not dedup distinct runSeqs", () => {
+    wireHaltPushDispatch({ activityLog, getPushConfig: () => CFG });
+    activityLog.recordEvent("recipe_done", {
+      runSeq: 1,
+      recipeName: "x",
+      status: "error",
+    });
+    activityLog.recordEvent("recipe_done", {
+      runSeq: 2,
+      recipeName: "y",
+      status: "error",
+    });
+    expect(dispatchHaltPushNotification).toHaveBeenCalledTimes(2);
+  });
+
+  it("never dedups the runSeq=0 unknown sentinel", () => {
+    wireHaltPushDispatch({ activityLog, getPushConfig: () => CFG });
+    // Two distinct unknown-seq runs must both fire — collapsing them
+    // would silently drop a real halt.
+    activityLog.recordEvent("recipe_done", { status: "error" });
+    activityLog.recordEvent("recipe_done", { status: "error" });
+    expect(dispatchHaltPushNotification).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/wireHaltPushDispatch.ts
+++ b/src/wireHaltPushDispatch.ts
@@ -10,6 +10,10 @@
  * Reads `pushServiceUrl` / `pushServiceToken` from a getter callback
  * (not a captured value) so config edits through `/settings` take
  * effect immediately without a bridge restart.
+ *
+ * Dedup: a run that is retried / resumed can emit `recipe_done` more
+ * than once. A short-window per-runSeq guard collapses those into a
+ * single push so a flapping run can't spam every subscribed device.
  */
 
 import type { ActivityLog } from "./activityLog.js";
@@ -22,16 +26,30 @@ interface WireHaltPushDispatchDeps {
    *  captured value picks up runtime config changes. */
   getPushConfig: () => { url: string; token: string } | null;
   logger?: { warn?: (msg: string) => void };
+  /** Override the dedup window. Default 60_000 ms. Tests pass a small
+   *  value; production never sets it. */
+  dedupWindowMs?: number;
+  /** Injectable clock for deterministic tests. Default `Date.now`. */
+  now?: () => number;
 }
 
-/**
- * Returns an unsubscribe function. Caller is responsible for
- * cleanup on shutdown (the bridge doesn't typically need to —
- * process exit drops the listener regardless).
- */
+const DEFAULT_DEDUP_WINDOW_MS = 60_000;
+
 export function wireHaltPushDispatch(
   deps: WireHaltPushDispatchDeps,
 ): () => void {
+  const dedupWindowMs = deps.dedupWindowMs ?? DEFAULT_DEDUP_WINDOW_MS;
+  const now = deps.now ?? Date.now;
+  // runSeq → last-dispatched epoch ms. Pruned opportunistically on
+  // each event so the Map can't grow unbounded on a long-lived bridge.
+  const lastDispatched = new Map<number, number>();
+
+  function prune(cutoff: number): void {
+    for (const [seq, at] of lastDispatched) {
+      if (at < cutoff) lastDispatched.delete(seq);
+    }
+  }
+
   return deps.activityLog.subscribe((kind, entry) => {
     if (kind !== "lifecycle") return;
     const lifecycle = entry as {
@@ -50,6 +68,18 @@ export function wireHaltPushDispatch(
     const runSeq = typeof md.runSeq === "number" ? md.runSeq : 0;
     const errorMessage =
       typeof md.errorMessage === "string" ? md.errorMessage : undefined;
+
+    // Dedup: skip if this runSeq fired a push within the window.
+    // runSeq 0 is the "unknown" sentinel — never dedup it, since two
+    // genuinely distinct unknown-seq runs would otherwise collide.
+    const at = now();
+    prune(at - dedupWindowMs);
+    if (runSeq !== 0) {
+      const last = lastDispatched.get(runSeq);
+      if (last !== undefined && at - last < dedupWindowMs) return;
+      lastDispatched.set(runSeq, at);
+    }
+
     // Best-effort: dispatchHaltPushNotification swallows errors, but
     // a synchronously-thrown URL parse error would still surface here.
     dispatchHaltPushNotification(cfg.url, cfg.token, {
@@ -57,7 +87,7 @@ export function wireHaltPushDispatch(
       runSeq,
       status: "error",
       errorMessage,
-      occurredAt: Date.now(),
+      occurredAt: at,
     }).catch((err) => {
       deps.logger?.warn?.(
         `[halt-push] unexpected dispatcher error: ${err instanceof Error ? err.message : String(err)}`,


### PR DESCRIPTION
## Summary
Web Push PR 5 — final PR of the halt-push series. A retried / resumed run can emit `recipe_done` with `status=error` more than once; without dedup each emission fans out a push to every device.

`wireHaltPushDispatch` now keeps a `runSeq → last-dispatched` Map and skips a dispatch if the same runSeq fired within the window (default 60s). Map pruned opportunistically per event — no unbounded growth.

`runSeq=0` (unknown sentinel) is never deduped — two distinct unknown-seq runs would otherwise collide and drop a real halt.

## Test plan
- [ ] Same runSeq emits recipe_done twice within 60s → one push
- [ ] Same runSeq after 60s → second push fires
- [ ] Distinct runSeqs → both fire
- [ ] runSeq=0 events → never deduped
- [ ] 11 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)