### PR TITLE
fix(dashboard): UI-review nits — hydration, 404 link, stale title

### DIFF
--- a/dashboard/src/app/decisions/page.tsx
+++ b/dashboard/src/app/decisions/page.tsx
@@ -171,7 +171,7 @@ function DecisionsContent() {
         <div>
           <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
             <h1 className="editorial-h1" style={{ margin: 0 }}>
-              Decisions — <span className="accent">the knowledge base your agents wrote.</span>
+              Knowledge — <span className="accent">the knowledge base your agents wrote.</span>
             </h1>
             <HintCard.Toggle id="decisions" />
           </div>
@@ -282,7 +282,7 @@ function DecisionsContent() {
           description={
             error.startsWith("/traces")
               ? "The /traces response didn't match the schema this dashboard expects."
-              : "The bridge isn't responding. Decisions will reload on the next tick."
+              : "The bridge isn't responding. Knowledge will reload on the next tick."
           }
           error={error}
           onRetry={refetch}

--- a/dashboard/src/app/inbox/page.tsx
+++ b/dashboard/src/app/inbox/page.tsx
@@ -2,6 +2,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import dynamic from "next/dynamic";
+import Link from "next/link";
 import { apiPath } from "@/lib/api";
 import { EmptyState, HintCard } from "@/components/patchwork";
 import { InboxDeliveryCard } from "@/components/InboxDeliveryCard";
@@ -944,13 +945,16 @@ const filteredItems = items.filter((item) => {
                         >
                           Replay recipe
                         </button>
-                        <a
+                        <Link
+                          // next/link applies the `/dashboard` basePath
+                          // automatically — a raw <a href="/traces"> 404s
+                          // because it skips the prefix.
                           href={`/traces?q=${encodeURIComponent(recipeNameForSelected)}`}
                           className="btn sm ghost"
                           style={{ fontSize: "var(--fs-xs)", textDecoration: "none" }}
                         >
                           View trace
-                        </a>
+                        </Link>
                         <button
                           type="button"
                           className="btn sm ghost"

--- a/dashboard/src/app/layout.tsx
+++ b/dashboard/src/app/layout.tsx
@@ -81,7 +81,16 @@ export const dynamic = "force-dynamic";
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
-    <html lang="en" className={`${albertSans.variable} ${instrumentSerif.variable} ${jetbrainsMono.variable}`}>
+    <html
+      lang="en"
+      // The blocking inline script below sets `data-theme` on <html>
+      // before React hydrates. Server markup has no data-theme, so
+      // hydration would otherwise log a mismatch on every page.
+      // suppressHydrationWarning is exactly for this attribute-set-by-
+      // pre-hydration-script pattern — scoped to <html> only.
+      suppressHydrationWarning
+      className={`${albertSans.variable} ${instrumentSerif.variable} ${jetbrainsMono.variable}`}
+    >
       <head>
         {/* Blocking inline script: set data-theme before first paint to
             prevent the paper-theme flash on refresh. Must stay in sync


### PR DESCRIPTION
## Summary
Three small fixes from the Playwright UI walkthrough:

- **Hydration mismatch** — `suppressHydrationWarning` on `<html>`; the inline theme script sets `data-theme` pre-hydration, which logged a mismatch on every page.
- **Inbox "View trace" 404** — raw `<a href="/traces">` skipped the `/dashboard` basePath; converted to `next/link`.
- **/decisions stale title** — `<h1>` + an error line still said "Decisions" after the section→"Review" / item→"Knowledge" rename.

## Test plan
- [ ] No hydration-mismatch warning in console on page load
- [ ] Inbox → "View trace" navigates to /dashboard/traces (no 404)
- [ ] /decisions h1 reads "Knowledge"
- [ ] 540 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)