### PR TITLE
fix(login): render /login bare, without the authenticated app shell

### DIFF
--- a/dashboard/src/app/decisions/page.tsx
+++ b/dashboard/src/app/decisions/page.tsx
@@ -171,7 +171,7 @@ function DecisionsContent() {
         <div>
           <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
             <h1 className="editorial-h1" style={{ margin: 0 }}>
-              Decisions — <span className="accent">the knowledge base your agents wrote.</span>
+              Knowledge — <span className="accent">the knowledge base your agents wrote.</span>
             </h1>
             <HintCard.Toggle id="decisions" />
           </div>
@@ -282,7 +282,7 @@ function DecisionsContent() {
           description={
             error.startsWith("/traces")
               ? "The /traces response didn't match the schema this dashboard expects."
-              : "The bridge isn't responding. Decisions will reload on the next tick."
+              : "The bridge isn't responding. Knowledge will reload on the next tick."
           }
           error={error}
           onRetry={refetch}

--- a/dashboard/src/app/inbox/page.tsx
+++ b/dashboard/src/app/inbox/page.tsx
@@ -2,6 +2,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import dynamic from "next/dynamic";
+import Link from "next/link";
 import { apiPath } from "@/lib/api";
 import { EmptyState, HintCard } from "@/components/patchwork";
 import { InboxDeliveryCard } from "@/components/InboxDeliveryCard";
@@ -944,13 +945,16 @@ const filteredItems = items.filter((item) => {
                         >
                           Replay recipe
                         </button>
-                        <a
+                        <Link
+                          // next/link applies the `/dashboard` basePath
+                          // automatically — a raw <a href="/traces"> 404s
+                          // because it skips the prefix.
                           href={`/traces?q=${encodeURIComponent(recipeNameForSelected)}`}
                           className="btn sm ghost"
                           style={{ fontSize: "var(--fs-xs)", textDecoration: "none" }}
                         >
                           View trace
-                        </a>
+                        </Link>
                         <button
                           type="button"
                           className="btn sm ghost"

--- a/dashboard/src/app/layout.tsx
+++ b/dashboard/src/app/layout.tsx
@@ -81,7 +81,16 @@ export const dynamic = "force-dynamic";
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
-    <html lang="en" className={`${albertSans.variable} ${instrumentSerif.variable} ${jetbrainsMono.variable}`}>
+    <html
+      lang="en"
+      // The blocking inline script below sets `data-theme` on <html>
+      // before React hydrates. Server markup has no data-theme, so
+      // hydration would otherwise log a mismatch on every page.
+      // suppressHydrationWarning is exactly for this attribute-set-by-
+      // pre-hydration-script pattern — scoped to <html> only.
+      suppressHydrationWarning
+      className={`${albertSans.variable} ${instrumentSerif.variable} ${jetbrainsMono.variable}`}
+    >
       <head>
         {/* Blocking inline script: set data-theme before first paint to
             prevent the paper-theme flash on refresh. Must stay in sync

--- a/dashboard/src/components/MobileBottomNav.tsx
+++ b/dashboard/src/components/MobileBottomNav.tsx
@@ -74,6 +74,10 @@ export function MobileBottomNav() {
   // exactly when oncall needs it.
   const haltCount = useHaltCount();
 
+  // /login is pre-auth — no app chrome. Early return after all hooks
+  // so hook order stays stable (rules-of-hooks).
+  if (pathname === "/login") return null;
+
   return (
     <>
       <nav className="mobile-bottom-nav" aria-label="Primary">

--- a/dashboard/src/components/Shell.tsx
+++ b/dashboard/src/components/Shell.tsx
@@ -305,7 +305,20 @@ function useTheme() {
 
 // ------------------------------------------------------------------ shell
 
+/**
+ * Route-aware shell wrapper. The root layout renders <Shell> for every
+ * route, but /login is pre-auth and must NOT show the app chrome
+ * (sidebar, bridge-status widgets, banners). Short-circuit there and
+ * render the page bare. Bonus: AppShell's hooks (bridge pollers, SSE)
+ * don't even run on the login page.
+ */
 export function Shell({ children }: { children: ReactNode }) {
+  const pathname = usePathname();
+  if (pathname === "/login") return <>{children}</>;
+  return <AppShell>{children}</AppShell>;
+}
+
+function AppShell({ children }: { children: ReactNode }) {
   const pathname = usePathname();
   const status = useBridgeStatus();
   const approvalCount = useApprovalCount();


### PR DESCRIPTION
## Summary
Playwright UI review found the full app chrome (sidebar, bridge-status widgets, offline banners, PWA dialog) rendering around the `/login` password form for unauthenticated visitors.

The root layout renders `<Shell>` + `<MobileBottomNav>` for every route. Fix without a `(app)` route-group restructure:
- `Shell` is now a thin route-aware wrapper — `/login` → children bare; else → `AppShell` (former Shell body, renamed). AppShell's bridge pollers / SSE don't run on /login.
- `MobileBottomNav` early-returns `null` on `/login` (after hooks — rules-of-hooks safe).

## Test plan
- [ ] /dashboard/login → only the password card, no sidebar/banners/bottom-nav
- [ ] After login → full app shell renders normally
- [ ] No bridge-status network calls fire on the login page

🤖 Generated with [Claude Code](https://claude.com/claude-code)