### PR TITLE
feat(runs): record hadStepErrors — a done run can still have failed steps

### DIFF
--- a/src/__tests__/runLog.test.ts
+++ b/src/__tests__/runLog.test.ts
@@ -336,6 +336,68 @@ describe("RecipeRunLog.record", () => {
     expect(parsed.status).toBe("done");
   });
 
+  it("completeRun sets hadStepErrors=true when a step ended in error but the run is done", () => {
+    const log = new RecipeRunLog({ dir: tmp });
+    const seq = log.startRun({
+      taskId: "chained:partial:1",
+      recipeName: "partial",
+      trigger: "recipe",
+      createdAt: 1_000,
+    });
+    log.completeRun(seq, {
+      status: "done",
+      doneAt: 2_000,
+      durationMs: 1_000,
+      stepResults: [
+        { id: "a", status: "ok", durationMs: 100 },
+        {
+          id: "b",
+          status: "error",
+          durationMs: 200,
+          haltReason: "tool x failed",
+        },
+        { id: "c", status: "ok", durationMs: 100 },
+      ],
+    });
+    const run = log.getBySeq(seq);
+    expect(run?.status).toBe("done");
+    expect(run?.hadStepErrors).toBe(true);
+  });
+
+  it("completeRun sets hadStepErrors=false for a clean run", () => {
+    const log = new RecipeRunLog({ dir: tmp });
+    const seq = log.startRun({
+      taskId: "chained:clean:1",
+      recipeName: "clean",
+      trigger: "recipe",
+      createdAt: 1_000,
+    });
+    log.completeRun(seq, {
+      status: "done",
+      doneAt: 2_000,
+      durationMs: 1_000,
+      stepResults: [{ id: "a", status: "ok", durationMs: 100 }],
+    });
+    expect(log.getBySeq(seq)?.hadStepErrors).toBe(false);
+  });
+
+  it("appendDirect derives hadStepErrors the same way", () => {
+    const log = new RecipeRunLog({ dir: tmp });
+    log.appendDirect({
+      taskId: "yaml:partial:1",
+      recipeName: "partial",
+      trigger: "manual",
+      status: "done",
+      createdAt: 1_000,
+      doneAt: 2_000,
+      durationMs: 1_000,
+      stepResults: [
+        { id: "a", status: "error", durationMs: 50, haltReason: "boom" },
+      ],
+    });
+    expect(log.query({ limit: 1 })[0]?.hadStepErrors).toBe(true);
+  });
+
   it("query() returns running entries alongside terminal ones", () => {
     const log = new RecipeRunLog({ dir: tmp });
     log.appendDirect({

--- a/src/__tests__/runLog.test.ts
+++ b/src/__tests__/runLog.test.ts
@@ -386,7 +386,7 @@ describe("RecipeRunLog.record", () => {
     log.appendDirect({
       taskId: "yaml:partial:1",
       recipeName: "partial",
-      trigger: "manual",
+      trigger: "recipe",
       status: "done",
       createdAt: 1_000,
       doneAt: 2_000,

--- a/src/recipes/yamlRunner.ts
+++ b/src/recipes/yamlRunner.ts
@@ -1059,6 +1059,10 @@ export async function runYamlRecipe(
           status: runError ? "error" : "done",
           durationMs: doneAt - recipeStartedAt,
           stepCount: finalStepResults.length,
+          // A `done` run can still carry step errors — the runner
+          // continues past a non-fatal step failure. Surface it so
+          // live consumers can show "completed with errors".
+          hadStepErrors: finalStepResults.some((s) => s.status === "error"),
           ...(runError !== undefined && { errorMessage: runError }),
           ...(assertionFailures.length > 0 && {
             assertionFailureCount: assertionFailures.length,

--- a/src/runLog.ts
+++ b/src/runLog.ts
@@ -94,6 +94,15 @@ export interface RecipeRun {
   durationMs: number;
   /** Per-step execution results — present when run via yamlRunner or chainedRunner. */
   stepResults?: RunStepResult[];
+  /**
+   * True when the run finished `done` but at least one step ended with
+   * `status: "error"`. The runner continues past a non-fatal step
+   * error, so such a run is legitimately `done` — but flat-green
+   * "success" hides that a step failed. Consumers (the dashboard
+   * Overview) use this to render an honest "completed with errors"
+   * state. Absent / false = a clean run.
+   */
+  hadStepErrors?: boolean;
   /** seq of the parent run that triggered this one, if trigger === "recipe". */
   parentSeq?: number;
   /** Assertion failures from the recipe's expect block — present when assertions fail. */
@@ -329,7 +338,12 @@ export class RecipeRunLog {
   /** Write a run directly (e.g. from yamlRunner which has no orchestrator task). */
   appendDirect(run: Omit<RecipeRun, "seq">): void {
     const seq = ++this.seq;
-    const full: RecipeRun = { ...run, seq };
+    // Derive hadStepErrors the same way completeRun does, so the
+    // CLI / no-orchestrator path stays consistent with the bridge path.
+    const hadStepErrors = (run.stepResults ?? []).some(
+      (s) => s.status === "error",
+    );
+    const full: RecipeRun = { ...run, seq, hadStepErrors };
     mkdirSync(path.dirname(this.file), { recursive: true, mode: 0o700 });
     this.append(full);
     this.runs.push(full);
@@ -418,6 +432,10 @@ export class RecipeRunLog {
       doneAt: opts.doneAt,
       durationMs: opts.durationMs,
       stepResults: opts.stepResults,
+      // Derived, single source of truth: a run with any error-status
+      // step "completed with errors" even if its terminal status is
+      // `done` (the runner continues past non-fatal step errors).
+      hadStepErrors: opts.stepResults.some((s) => s.status === "error"),
       ...(opts.outputTail !== undefined && { outputTail: opts.outputTail }),
       ...(opts.errorMessage !== undefined && {
         errorMessage: opts.errorMessage,


### PR DESCRIPTION
## Summary
Part 1 of the halt-count fix surfaced by the UI review.

**Diagnostic** (run against the live run log, 1,979 runs): 108 runs finished `status: "done"` while containing a step with `status: "error"` + a `haltReason`. Only 1 of 108 errored on its final step — the rest errored mid-recipe and the runner continued to completion. So those runs are *legitimately* `done`, but:
- Overview shows them as flat "100% success" — hides 108 step failures
- the halt-summary aggregator counts each errored step → /runs shows "107 halts"

Two dashboards, two honest-but-contradictory numbers.

**This PR** adds a derived `hadStepErrors` boolean to the run record:
- `completeRun` (bridge) + `appendDirect` (CLI) derive it from `stepResults` — single source of truth, no caller changes
- `recipe_done` lifecycle event carries it for live consumers

## Why a flag, not a new status
Adding a `partial` status would ripple through every `status === "done"` / `isHaltStatus` check in bridge + dashboard. A boolean flag is non-breaking — existing status logic untouched; new consumers opt in.

## Follow-up (part 2, dashboard)
Consume `hadStepErrors` on Overview to render "N completed with errors", and relabel the /runs + /activity "halts" counters as "step errors" — so the two views stop contradicting each other.

## Test plan
- [ ] 3 new runLog tests pass (done-with-error-step, clean, appendDirect)
- [ ] Full bridge suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)