### PR TITLE
fix(dashboard): guard localStorage, lock pushStore 0600, fix liveness teardown

### DIFF
--- a/dashboard/src/components/CommandPalette.tsx
+++ b/dashboard/src/components/CommandPalette.tsx
@@ -122,10 +122,24 @@ export function CommandPalette({
         label: "Toggle theme (paper / dark)",
         group: "Actions",
         perform: () => {
-          const current = localStorage.getItem("patchwork.theme") === "paper" ? "paper" : "dark";
-          const next = current === "dark" ? "paper" : "dark";
-          localStorage.setItem("patchwork.theme", next);
-          window.dispatchEvent(new StorageEvent("storage", { key: "patchwork.theme", newValue: next }));
+          // localStorage throws in private mode / cookies-blocked —
+          // guard so the command palette can't crash the app.
+          try {
+            const current =
+              localStorage.getItem("patchwork.theme") === "paper"
+                ? "paper"
+                : "dark";
+            const next = current === "dark" ? "paper" : "dark";
+            localStorage.setItem("patchwork.theme", next);
+            window.dispatchEvent(
+              new StorageEvent("storage", {
+                key: "patchwork.theme",
+                newValue: next,
+              }),
+            );
+          } catch {
+            // private mode — theme toggle unavailable, non-fatal
+          }
         },
       },
       {

--- a/dashboard/src/components/Shell.tsx
+++ b/dashboard/src/components/Shell.tsx
@@ -275,12 +275,35 @@ function applyTheme(theme: ThemePref) {
   document.body.dataset.theme = theme;
 }
 
+// localStorage access throws (not returns null) in Firefox/Safari
+// private mode and when cookies are blocked. `useTheme` runs inside
+// `Shell`, which wraps every route — an unguarded throw here unmounts
+// the whole app to a white screen. The blocking inline script in
+// layout.tsx is already try-caught; these guards keep the React copy
+// consistent.
+function readStoredTheme(): string | null {
+  try {
+    return (
+      localStorage.getItem("patchwork.theme") ??
+      localStorage.getItem("pw-theme")
+    );
+  } catch {
+    return null;
+  }
+}
+
+function writeStoredTheme(value: string): void {
+  try {
+    localStorage.setItem("patchwork.theme", value);
+  } catch {
+    // private mode / quota — theme still applies for this session
+  }
+}
+
 function useTheme() {
   const [active, setActive] = useState<ThemePref>("dark");
   useEffect(() => {
-    const stored = normalizeTheme(
-      localStorage.getItem("patchwork.theme") ?? localStorage.getItem("pw-theme"),
-    );
+    const stored = normalizeTheme(readStoredTheme());
     setActive(stored);
     applyTheme(stored);
     const onStorage = (e: StorageEvent) => {
@@ -298,7 +321,7 @@ function useTheme() {
     const next: ThemePref = active === "dark" ? "paper" : "dark";
     setActive(next);
     applyTheme(next);
-    localStorage.setItem("patchwork.theme", next);
+    writeStoredTheme(next);
   };
   return { active, toggle };
 }

--- a/dashboard/src/lib/pushStore.ts
+++ b/dashboard/src/lib/pushStore.ts
@@ -81,7 +81,12 @@ function persist(store: Map<string, PushEntry>): void {
   let fd: number | null = null;
   try {
     const body = JSON.stringify([...store.entries()]);
-    fd = fs.openSync(tmp, "w");
+    // Mode 0600 — the store holds every push endpoint + the
+    // `keys.auth` / `keys.p256dh` secrets that authorize sending Web
+    // Push to those browsers. Default open mode (0666 minus umask)
+    // would leave them group/world-readable. Set it on the temp fd
+    // so the file is never briefly world-readable before the rename.
+    fd = fs.openSync(tmp, "w", 0o600);
     fs.writeSync(fd, body);
     fs.fsyncSync(fd);
     fs.closeSync(fd);

--- a/dashboard/src/lib/streamLiveness.ts
+++ b/dashboard/src/lib/streamLiveness.ts
@@ -94,7 +94,11 @@ function teardownStream() {
   if (!es) return;
   es.close();
   es = null;
-  isLive = false;
+  lastHeartbeatAt = 0;
+  // Route through setLive so getStreamLiveness() (and any future
+  // listener) sees a consistent value — a bare `isLive = false`
+  // bypassed notify() and left non-React readers stale.
+  setLive(false);
 }
 
 function streamHasSubscribers(): boolean {


### PR DESCRIPTION
## Summary
Three fixes from the multi-agent UI/UX + security audit.

1. **White-screen in private mode (HIGH)** — `useTheme` (Shell.tsx) + the CommandPalette theme toggle read/write `localStorage` unguarded. It *throws* (not returns null) in Firefox/Safari private mode / cookies-blocked. Shell wraps every route → the throw blank-screens the whole app. The layout.tsx inline script was already guarded; the React copies weren't.
2. **pushStore 0600 (MED)** — the subscription store holds push endpoints + `keys.auth`/`keys.p256dh` secrets. The atomic write used default file mode (~0644). Now opens the temp fd `0o600`.
3. **streamLiveness teardown (LOW)** — `teardownStream` set `isLive` directly, bypassing `setLive`/`notify()`. Routed through `setLive`.

## Test plan
- [ ] Dashboard loads in a private/incognito window (localStorage blocked) — no white screen, theme falls back to dark
- [ ] `~/.claude/patchwork-push-subscriptions.json` is mode 600 after a subscribe
- [ ] 540 dashboard tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)