### PR TITLE
fix(a11y): j/k nav moves DOM focus + AnimatedNumber honors reduced-motion

### DIFF
--- a/dashboard/src/app/recipes/page.tsx
+++ b/dashboard/src/app/recipes/page.tsx
@@ -1104,10 +1104,13 @@ export default function RecipesPage() {
       // Scroll the newly-selected row into view (centered) so j/k feels
       // like a cursor walk rather than a silent state change off-screen.
       requestAnimationFrame(() => {
-        const row = document.querySelector(
+        const row = document.querySelector<HTMLElement>(
           `[data-recipe-row="${CSS.escape(nextName)}"]`,
         );
         row?.scrollIntoView({ block: "nearest", behavior: "smooth" });
+        // Move real DOM focus so keyboard + screen-reader users get
+        // feedback from j/k, not just a visual selection change.
+        row?.focus();
       });
     };
     window.addEventListener("keydown", onKey);

--- a/dashboard/src/app/runs/page.tsx
+++ b/dashboard/src/app/runs/page.tsx
@@ -417,8 +417,13 @@ export default function RunsPage() {
       const nextKey = `${list[next].taskId}-${list[next].seq}`;
       setExpanded(nextKey);
       requestAnimationFrame(() => {
-        const row = document.querySelector(`[data-run-row="${CSS.escape(nextKey)}"]`);
+        const row = document.querySelector<HTMLElement>(
+          `[data-run-row="${CSS.escape(nextKey)}"]`,
+        );
         row?.scrollIntoView({ block: "nearest", behavior: "smooth" });
+        // Move real DOM focus so keyboard + screen-reader users get
+        // feedback from j/k, not just a visual selection change.
+        row?.focus();
       });
     };
     globalThis.addEventListener("keydown", onKey);

--- a/dashboard/src/app/tasks/page.tsx
+++ b/dashboard/src/app/tasks/page.tsx
@@ -447,8 +447,13 @@ export default function TasksPage() {
       const nextId = visible[next].taskId;
       setSelectedTaskId(nextId);
       requestAnimationFrame(() => {
-        const row = document.querySelector(`[data-task-row="${CSS.escape(nextId)}"]`);
+        const row = document.querySelector<HTMLElement>(
+          `[data-task-row="${CSS.escape(nextId)}"]`,
+        );
         row?.scrollIntoView({ block: "nearest", behavior: "smooth" });
+        // Move real DOM focus, not just visual selection — otherwise
+        // keyboard + screen-reader users get no feedback from j/k.
+        row?.focus();
       });
     };
     window.addEventListener("keydown", onKey);

--- a/dashboard/src/components/patchwork/AnimatedNumber.tsx
+++ b/dashboard/src/components/patchwork/AnimatedNumber.tsx
@@ -29,6 +29,17 @@ export function AnimatedNumber({
     if (fromRef.current === value && prevValueRef.current === value) {
       return;
     }
+    // Reduced-motion: a CSS rule can't stop a JS rAF loop, so honour
+    // the preference here — snap straight to the target, no count-up.
+    if (
+      typeof window !== "undefined" &&
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches
+    ) {
+      prevValueRef.current = value;
+      fromRef.current = value;
+      setN(value);
+      return;
+    }
     if (prevValueRef.current !== value) {
       flashTone.current = value > prevValueRef.current ? "up" : "down";
       setFlashKey((k) => k + 1);


### PR DESCRIPTION
## Summary
Two a11y fixes from the multi-agent audit.

1. **j/k row navigation never moved DOM focus** — /tasks, /runs, /recipes set selection state + `scrollIntoView` + `aria-pressed` but never `.focus()`. Keyboard/screen-reader users got zero feedback. Rows are already focusable (`<button>` or `tabIndex=0 role="button"`), so it's a one-line `.focus()` ×3.
2. **`AnimatedNumber` ignored `prefers-reduced-motion`** — a JS rAF count-up loop the global reduced-motion CSS block can't stop. Now snaps to the target value when the media query matches (mirrors `CardGlow`).

## Test plan
- [ ] /tasks: Tab to the list, press j/k → focus visibly moves row to row, SR announces each
- [ ] Same on /runs, /recipes
- [ ] With OS "reduce motion" on → stat numbers appear at final value instantly, no count-up
- [ ] 540 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)