### PR TITLE
fix(runs): mobile layout + honest partial-failure status

### DIFF
--- a/dashboard/src/app/globals.css
+++ b/dashboard/src/app/globals.css
@@ -1274,6 +1274,76 @@ button.topbar-search {
     border-bottom-right-radius: var(--r-l);
   }
 }
+/* Overview "Live and recent runs" strip — horizontal scroll-snap carousel.
+   Hide the scrollbar chrome on desktop (the cards themselves are the cue)
+   while keeping the track scrollable via wheel / trackpad / touch. */
+.live-runs-strip {
+  scrollbar-width: thin;
+}
+.live-runs-strip::-webkit-scrollbar {
+  height: 6px;
+}
+.live-runs-strip::-webkit-scrollbar-thumb {
+  background: var(--line-2);
+  border-radius: 3px;
+}
+
+/* /runs responsive layout — dense table on desktop, stacked cards on
+   phones. The 6-column run table is unreadable crammed into a 390px
+   viewport, so below 768px the table is swapped for a tappable card
+   list (matching the stacked pattern other list pages use). */
+.runs-card-list {
+  display: none;
+}
+@media (max-width: 768px) {
+  .runs-table-desktop {
+    display: none;
+  }
+  .runs-card-list {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+}
+.run-card {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px 14px;
+  border: 1px solid var(--line-1);
+  border-radius: var(--r-m);
+  background: var(--card-bg);
+  cursor: pointer;
+}
+.run-card[data-status="running"] {
+  box-shadow: inset 3px 0 0 var(--blue);
+}
+.run-card:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+.run-card-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  min-width: 0;
+}
+.run-card-meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px 12px;
+  font-size: var(--fs-xs);
+}
+.run-card-detail {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding-top: 8px;
+  border-top: 1px solid var(--line-1);
+}
+
 .table {
   width: 100%;
   border-collapse: collapse;

--- a/dashboard/src/app/runs/[seq]/page.tsx
+++ b/dashboard/src/app/runs/[seq]/page.tsx
@@ -63,6 +63,9 @@ interface RunDetail {
   childSeqs?: number[];
   /** PR5c — stable id shared across resumed retries of the same attempt. */
   manualRunId?: string;
+  /** Run finished `done` but ≥1 step ended in error — "completed with
+   *  errors". Set by the bridge run log (see runLog.hadStepErrors). */
+  hadStepErrors?: boolean;
 }
 
 interface PlanStep {
@@ -1219,13 +1222,37 @@ export default function RunDetailPage() {
         {run && (
           <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
             <span className="pill muted" style={{ fontSize: "var(--fs-xs)" }}>{run.trigger}</span>
-            <span
-              className={`pill ${run.assertionFailures?.length ? "err" : statusPillClass(run.status)}`}
-              style={{ fontSize: "var(--fs-xs)" }}
-            >
-              {run.status !== "running" && <span className="pill-dot" />}
-              {run.status}
-            </span>
+            {(() => {
+              // Honest partial-failure: a run can finish `done` while a step
+              // errored. The bridge run log carries `hadStepErrors`; older
+              // runs without the field fall back to scanning stepResults.
+              const hadStepErrors =
+                run.hadStepErrors ??
+                (run.stepResults ?? []).some((s) => s.status === "error");
+              const partialFail =
+                run.status === "done" &&
+                hadStepErrors &&
+                !run.assertionFailures?.length;
+              const cls = run.assertionFailures?.length
+                ? "err"
+                : partialFail
+                  ? "warn"
+                  : statusPillClass(run.status);
+              return (
+                <span
+                  className={`pill ${cls}`}
+                  style={{ fontSize: "var(--fs-xs)" }}
+                  title={
+                    partialFail
+                      ? "Run finished but one or more steps errored"
+                      : undefined
+                  }
+                >
+                  {run.status !== "running" && <span className="pill-dot" />}
+                  {partialFail ? "completed with errors" : run.status}
+                </span>
+              );
+            })()}
             <span className="pill muted" style={{ fontSize: "var(--fs-xs)" }}>
               {fmtDur(run.durationMs)}
             </span>

--- a/dashboard/src/app/runs/page.tsx
+++ b/dashboard/src/app/runs/page.tsx
@@ -59,6 +59,9 @@ interface Run {
   assertionFailures?: AssertionFailure[];
   /** PR5c — stable id for one logical retry-attempt; ties resumed runs together. */
   manualRunId?: string;
+  /** Run finished `done` but ≥1 step ended in error — "completed with
+   *  errors". Set by the bridge run log (see runLog.hadStepErrors). */
+  hadStepErrors?: boolean;
 }
 
 type TriggerFilter = "all" | "cron" | "webhook" | "recipe" | "manual" | "git_hook";
@@ -88,9 +91,20 @@ function fmtDur(ms: number): string {
 function statusPill(r: Run): "ok" | "err" | "warn" | "muted" | "running" {
   if (r.status === "running") return "running";
   if (r.assertionFailures && r.assertionFailures.length > 0) return "err";
+  // Honest partial-failure: a run can finish `done` while a step errored.
+  // Render amber "completed with errors" instead of a clean green "done".
+  if (r.status === "done" && r.hadStepErrors) return "warn";
   if (r.status === "done") return "ok";
   if (r.status === "error") return "err";
   return "warn";
+}
+
+/** Display label for the status cell — honest about partial failure. */
+function statusLabel(r: Run): string {
+  if (r.status === "done" && r.hadStepErrors && !r.assertionFailures?.length) {
+    return "completed with errors";
+  }
+  return r.status;
 }
 
 const RUNS_PAGE_SIZE = 100;
@@ -816,7 +830,9 @@ export default function RunsPage() {
           );
         })()
       ) : (
-        <div className="table-wrap">
+        <>
+        {/* Desktop / tablet: dense multi-column table. Hidden ≤768px. */}
+        <div className="table-wrap runs-table-desktop">
           <table className="table">
             <thead>
               <tr>
@@ -907,7 +923,7 @@ export default function RunsPage() {
                           {sClass !== "running" && (
                             <span className="pill-dot" />
                           )}
-                          {r.status}
+                          {statusLabel(r)}
                           {r.assertionFailures &&
                             r.assertionFailures.length > 0 &&
                             ` · ${r.assertionFailures.length} fail`}
@@ -1120,6 +1136,112 @@ export default function RunsPage() {
             </div>
           )}
         </div>
+
+        {/* Mobile (≤768px): stacked card layout. The dense table is
+            unreadable crammed into a phone viewport, so each run becomes
+            a tappable card. Shown only ≤768px via .runs-card-list CSS. */}
+        <div className="runs-card-list">
+          {windowedRuns.map((r) => {
+            const key = `${r.taskId}-${r.seq}`;
+            const isExpanded = expanded === key;
+            const sClass = statusPill(r);
+            return (
+              <div
+                key={key}
+                data-run-row={key}
+                className="run-card"
+                data-status={r.status}
+                onClick={() => setExpanded(isExpanded ? null : key)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    setExpanded(isExpanded ? null : key);
+                  }
+                }}
+                tabIndex={0}
+                role="button"
+                aria-expanded={isExpanded}
+              >
+                <div className="run-card-head">
+                  <Link
+                    href={`/runs/${r.seq}`}
+                    onClick={(e) => e.stopPropagation()}
+                    className="mono"
+                    style={{ fontWeight: 600, minWidth: 0, overflow: "hidden", textOverflow: "ellipsis" }}
+                  >
+                    {formatRecipeName(r.recipeName, r.trigger)}
+                  </Link>
+                  <span
+                    className={`pill ${sClass}`}
+                    style={{ fontSize: "var(--fs-2xs)", flexShrink: 0 }}
+                  >
+                    {sClass !== "running" && <span className="pill-dot" />}
+                    {statusLabel(r)}
+                    {r.assertionFailures &&
+                      r.assertionFailures.length > 0 &&
+                      ` · ${r.assertionFailures.length} fail`}
+                  </span>
+                </div>
+                <div className="run-card-meta">
+                  <span className="pill muted" style={{ fontSize: "var(--fs-2xs)" }}>
+                    {normaliseTrigger(r.trigger)}
+                  </span>
+                  <span className="mono muted">
+                    {fmtWhen(
+                      r.status === "running"
+                        ? r.startedAt ?? r.createdAt
+                        : r.doneAt,
+                    )}
+                  </span>
+                  <span className="mono muted">
+                    {r.status === "running"
+                      ? fmtDur(Date.now() - (r.startedAt ?? r.createdAt))
+                      : fmtDur(r.durationMs)}
+                  </span>
+                  {r.taskId && (
+                    <span className="mono muted" title={r.taskId}>
+                      {r.taskId.slice(0, 8)}
+                    </span>
+                  )}
+                </div>
+                {isExpanded && (
+                  <div className="run-card-detail">
+                    {r.errorMessage && (
+                      <pre className="task-output" style={{ color: "var(--red)" }}>
+                        {r.errorMessage}
+                      </pre>
+                    )}
+                    {r.outputTail && (
+                      <pre className="task-output">{r.outputTail}</pre>
+                    )}
+                    <Link
+                      href={`/runs/${r.seq}`}
+                      className="btn sm ghost"
+                      style={{ textDecoration: "none" }}
+                      onClick={(e) => e.stopPropagation()}
+                    >
+                      Open full run →
+                    </Link>
+                  </div>
+                )}
+              </div>
+            );
+          })}
+          {runs != null &&
+            runs.length >= limit &&
+            (windowedRuns == null ||
+              windowedRuns.length === runs.length) && (
+              <button
+                type="button"
+                className="btn ghost"
+                style={{ alignSelf: "center", marginTop: "var(--s-3)" }}
+                onClick={() => setLimit((n) => n + RUNS_PAGE_SIZE)}
+              >
+                Load more (+{RUNS_PAGE_SIZE})
+              </button>
+            )}
+        </div>
+        </>
       )}
     </section>
   );

--- a/dashboard/src/components/LiveRunsStrip.tsx
+++ b/dashboard/src/components/LiveRunsStrip.tsx
@@ -82,12 +82,21 @@ export function LiveRunsStrip({
   return (
     <section
       aria-label="Live and recent recipe runs"
+      className="live-runs-strip"
       style={{
         marginBottom: "var(--s-4)",
         display: "flex",
         gap: 10,
         overflowX: "auto",
+        // Scroll-snap carousel: each card snaps to the start edge so a
+        // phone user can flick through them without a card half-clipped.
+        scrollSnapType: "x proximity",
+        // Right padding + scroll-padding keep the last card fully visible
+        // and reachable instead of bleeding past the viewport edge.
+        paddingRight: 12,
+        scrollPaddingInline: 4,
         paddingBottom: 4,
+        WebkitOverflowScrolling: "touch",
       }}
     >
       {visible.map((r, i) => {
@@ -111,7 +120,10 @@ export function LiveRunsStrip({
             data-live={isLive ? "1" : "0"}
             data-tone={tone}
             style={{
-              flex: "0 0 260px",
+              // Cap at 260px but allow the card to shrink on narrow phones
+              // so it never bleeds past the viewport edge with no scroll cue.
+              flex: "0 0 clamp(220px, 78vw, 260px)",
+              scrollSnapAlign: "start",
               padding: "10px 12px",
               borderRadius: "var(--r-2)",
               border: "1px solid var(--line-3)",

--- a/dashboard/src/components/patchwork/StatusPill.tsx
+++ b/dashboard/src/components/patchwork/StatusPill.tsx
@@ -40,3 +40,29 @@ export function StatusPill({
     </span>
   );
 }
+
+/**
+ * Honest run-status derivation. A run that finished `status: "done"` while
+ * one or more steps errored is NOT a clean success — the bridge run log
+ * carries `hadStepErrors` (see runLog.ts) for exactly this case. Surface it
+ * as an amber "completed with errors" state instead of a green "done".
+ *
+ * Returns the chip tone + display label so the runs list cell and the
+ * run-detail header render the same verdict from one place.
+ */
+export function deriveRunStatus(
+  status: string,
+  opts?: { hadStepErrors?: boolean; assertionFailures?: number },
+): { tone: StatusTone; label: string } {
+  const assertionFails = opts?.assertionFailures ?? 0;
+  if (status === "running") return { tone: "info", label: "running" };
+  if (assertionFails > 0) {
+    return { tone: "err", label: `error · ${assertionFails} fail` };
+  }
+  if (status === "done" && opts?.hadStepErrors) {
+    return { tone: "warn", label: "completed with errors" };
+  }
+  if (status === "done") return { tone: "ok", label: "done" };
+  if (status === "error") return { tone: "err", label: "error" };
+  return { tone: "warn", label: status };
+}

--- a/dashboard/src/components/patchwork/index.ts
+++ b/dashboard/src/components/patchwork/index.ts
@@ -8,7 +8,7 @@ export {
 } from "./RelationStrip";
 export { HintCard } from "./HintCard";
 export { Glossary, type GlossaryProps } from "./Glossary";
-export { StatusPill, type StatusTone } from "./StatusPill";
+export { StatusPill, deriveRunStatus, type StatusTone } from "./StatusPill";
 export { RiskPill, type RiskLevel } from "./RiskPill";
 export { ActionPill } from "./ActionPill";
 export { LivePill, type LivePillConnection } from "./LivePill";


### PR DESCRIPTION
## Summary

Fixes three independently-confirmed UI audit defects in the dashboard, in one PR.

- **`/runs` mobile layout (HIGH)** — the 6-column run table was crammed into a 390px viewport and unreadable. Added a stacked, tappable card layout (`.runs-card-list`) shown ≤768px; the dense table (`.runs-table-desktop`) stays on larger screens. Cards keep tap-to-expand (error/output tail) and the "Load more" pager.
- **Overview live-runs row overflow (MED)** — `LiveRunsStrip` clipped its second card past the right edge on mobile with no scroll affordance. Converted to a scroll-snap carousel: cards shrink (`clamp(220px, 78vw, 260px)`), snap to the start edge, and the strip shows a thin scrollbar.
- **Dishonest "done" badge (HIGH)** — a run that finished `status: "done"` while a step errored showed a plain green "done" pill. Now renders an amber **"completed with errors"** state in both the runs-list status cell and the run-detail header. `hadStepErrors` was already plumbed from the bridge run log (`src/runLog.ts`) through `runsFn` / `runDetailFn` to the dashboard — no API change needed; the dashboard simply wasn't rendering it. Added `deriveRunStatus` to `StatusPill.tsx` for the shared verdict logic; run-detail also falls back to scanning `stepResults` for older runs missing the field.

## Test plan

- [ ] `cd dashboard && npx tsc --noEmit` — clean (verified)
- [ ] `cd dashboard && npm run lint` — clean for changed files (verified)
- [ ] At 390px: `/runs` shows stacked cards, no horizontal table scroll
- [ ] At 390px: Overview live-runs row snaps card-to-card, last card fully reachable
- [ ] At ~1440px: `/runs` shows the dense table unchanged
- [ ] A `done` run with a failed step shows an amber "completed with errors" badge in both the runs list and the run-detail header