### PR TITLE
fix(cli): readable tool errors + complete --help + aligned list output

### DIFF
--- a/src/commands/recipeInstall.ts
+++ b/src/commands/recipeInstall.ts
@@ -874,9 +874,14 @@ export function printInstalledList(entries: InstalledRecipeEntry[]): void {
   for (const entry of entries) {
     const version = (entry.version ?? "—").padEnd(maxVersion);
     const status = (entry.enabled ? "enabled" : "disabled").padEnd(8);
-    const detail = entry.hasManifest
+    const rawDetail = entry.hasManifest
       ? (entry.description ?? "")
       : `[${(entry.yamlFiles ?? []).join(", ")}]`;
+    // Truncate the description/files column so a long value can't wrap and
+    // destroy column alignment on 80-col terminals. Matches the 120-char
+    // cap used by the `halts` command for recent reasons.
+    const detail =
+      rawDetail.length > 120 ? `${rawDetail.slice(0, 117)}…` : rawDetail;
     console.log(
       `${entry.name.padEnd(maxName)}  ${version}  ${status}  ${detail}`,
     );

--- a/src/commands/tools.ts
+++ b/src/commands/tools.ts
@@ -8,6 +8,9 @@
  * No bridge connection required — reads static registry at import time.
  */
 
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { TOOL_CATEGORIES } from "../tools/index.js";
 
 // ---------------------------------------------------------------------------
@@ -221,11 +224,115 @@ export interface ToolEntry {
   categories: string[];
 }
 
-/** Build the full tool catalog from TOOL_CATEGORIES + TOOL_DESCRIPTIONS. */
+/**
+ * Scan a single tool module source for every `schema: { ... name: "x" ... }`
+ * block and return the tool names it registers. Works on both compiled JS
+ * (shipped in dist/) and TypeScript source — the schema object literal shape
+ * is identical after compilation.
+ *
+ * Ported from scripts/audit-lsp-tools.mjs so the CLI catalog is derived from
+ * the same registry-of-truth the audit gate enforces.
+ */
+function extractToolNamesFromModule(src: string): string[] {
+  const out: string[] = [];
+  let i = 0;
+  while (i < src.length) {
+    const schemaIdx = src.indexOf("schema: {", i);
+    if (schemaIdx === -1) break;
+    let depth = 0;
+    let blockStart = -1;
+    for (let j = schemaIdx + 8; j < src.length; j++) {
+      if (src[j] === "{") {
+        depth++;
+        if (depth === 1) blockStart = j;
+      } else if (src[j] === "}") {
+        if (depth === 1) {
+          const block = src.slice(blockStart, j + 1);
+          const m = block.match(/\bname:\s*"([a-zA-Z][a-zA-Z0-9_]+)"/);
+          if (m?.[1]) out.push(m[1]);
+          break;
+        }
+        depth--;
+      }
+    }
+    i = schemaIdx + 9;
+  }
+  return out;
+}
+
+/**
+ * Enumerate every registered tool name by scanning the tool modules on disk.
+ *
+ * This is the registry-of-truth: it scans the actual `dist/tools/*.js` (or
+ * `src/tools/*.ts` in dev) modules that `registerAllTools` loads, so the
+ * count and catalog cannot drift from the hand-maintained `TOOL_CATEGORIES` /
+ * `TOOL_DESCRIPTIONS` metadata maps. Returns `null` if the tool directory
+ * cannot be located (e.g. an unusual install layout) so callers can fall
+ * back to the metadata maps.
+ */
+export function discoverRegisteredToolNames(): Set<string> | null {
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  // Compiled: dist/commands/tools.js → dist/tools. Dev (tsx): src/commands → src/tools.
+  const candidates = [
+    path.resolve(here, "..", "tools"),
+    path.resolve(here, "..", "..", "src", "tools"),
+  ];
+  for (const dir of candidates) {
+    let files: string[];
+    try {
+      files = readdirSync(dir);
+    } catch {
+      continue;
+    }
+    const mods = files.filter(
+      (f) =>
+        (f.endsWith(".js") || f.endsWith(".ts")) &&
+        !f.endsWith(".d.ts") &&
+        !f.endsWith(".map"),
+    );
+    if (mods.length === 0) continue;
+    const names = new Set<string>();
+    for (const f of mods) {
+      let src: string;
+      try {
+        src = readFileSync(path.join(dir, f), "utf8");
+      } catch {
+        continue;
+      }
+      for (const n of extractToolNamesFromModule(src)) names.add(n);
+    }
+    if (names.size > 0) return names;
+  }
+  return null;
+}
+
+/**
+ * Build the full tool catalog.
+ *
+ * The set of tools is derived from the actual registered tool modules
+ * (`discoverRegisteredToolNames`) so the printed count never drifts. The
+ * `TOOL_CATEGORIES` / `TOOL_DESCRIPTIONS` maps supply categories and
+ * human-readable descriptions as metadata overlays. If module discovery
+ * fails, falls back to the union of the two metadata maps.
+ */
 export function buildToolCatalog(): ToolEntry[] {
-  const seen = new Set<string>();
+  const registered = discoverRegisteredToolNames();
   const entries: ToolEntry[] = [];
 
+  if (registered) {
+    for (const name of registered) {
+      entries.push({
+        name,
+        description: TOOL_DESCRIPTIONS[name] ?? "",
+        categories: TOOL_CATEGORIES[name] ?? [],
+      });
+    }
+    return entries.sort((a, b) => a.name.localeCompare(b.name));
+  }
+
+  // Fallback: union of the metadata maps (drift-prone, used only when the
+  // tool modules can't be located on disk).
+  const seen = new Set<string>();
   for (const [name, cats] of Object.entries(TOOL_CATEGORIES)) {
     seen.add(name);
     entries.push({
@@ -234,14 +341,11 @@ export function buildToolCatalog(): ToolEntry[] {
       categories: cats,
     });
   }
-
-  // Also include tools in the description map that have no category entry.
   for (const [name, desc] of Object.entries(TOOL_DESCRIPTIONS)) {
     if (!seen.has(name)) {
       entries.push({ name, description: desc, categories: [] });
     }
   }
-
   return entries.sort((a, b) => a.name.localeCompare(b.name));
 }
 

--- a/src/fp/__tests__/result.test.ts
+++ b/src/fp/__tests__/result.test.ts
@@ -97,12 +97,14 @@ describe("toCallToolResult", () => {
   it("error case → isError:true", () => {
     const result = toCallToolResult(err("timeout", "timed out"));
     expect((result as { isError?: boolean }).isError).toBe(true);
-    const parsed = JSON.parse(result.content[0]!.text) as Record<
-      string,
-      unknown
-    >;
-    expect(parsed.error).toBe("timed out");
-    expect(parsed.code).toBe("timeout");
+    // text content is the plain message; machine-readable fields are in
+    // structuredContent (ADR-0004).
+    expect(result.content[0]!.text).toBe("timed out");
+    const structured = (
+      result as { structuredContent?: Record<string, unknown> }
+    ).structuredContent;
+    expect(structured?.error).toBe("timed out");
+    expect(structured?.code).toBe("timeout");
   });
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -250,9 +250,17 @@ if (
       `  recipe run <name> [--vars k=v]            Run a recipe by name\n` +
       `  recipe install <source>                   Install from a path or GitHub source\n` +
       `  recipe --help                             Full recipe subcommand index\n\n` +
+      `Operate\n` +
+      `  start [--port N] [--workspace <dir>]      Start a single bridge (no tmux)\n` +
+      `  status                                    One-line bridge status (port, uptime)\n` +
+      `  tools [list|search <q>] [--slim] [--json] List tools the bridge would register\n` +
+      `  analytics <show|configure|clear|test>     Manage opt-in telemetry config\n` +
+      `  launchd <install|uninstall|status>        Manage the macOS auto-start LaunchAgent\n\n` +
       `Diagnose\n` +
       `  halts [--window 1h|24h|overnight|7d]      Morning summary of recent recipe halts\n` +
       `  judgments [--window ...] [--recipe N]     Recent judge-step verdicts across runs\n` +
+      `  suggest [--since-days N]                  Recipe + unused-tool suggestions\n` +
+      `  token-efficiency benchmark                Measure token cost across tool sets\n` +
       `  traces export                             Bundle approval / recipe / decision traces\n` +
       `  print-token [--port N]                    Print the active bridge auth token\n\n` +
       `Safety\n` +

--- a/src/tools/__tests__/claudeTasks.test.ts
+++ b/src/tools/__tests__/claudeTasks.test.ts
@@ -9,7 +9,16 @@ import { createGetClaudeTaskStatusTool } from "../getClaudeTaskStatus.js";
 import { createListClaudeTasksTool } from "../listClaudeTasks.js";
 import { createRunClaudeTaskTool } from "../runClaudeTask.js";
 
-function parse(r: { content: Array<{ type: string; text: string }> }) {
+function parse(r: {
+  content: Array<{ type: string; text: string }>;
+  isError?: boolean;
+  structuredContent?: unknown;
+}) {
+  // Error results carry the plain message in `text` and machine-readable
+  // fields in `structuredContent` (ADR-0004). Success results keep the
+  // JSON-stringified payload in `text`.
+  if (r.isError && r.structuredContent !== undefined)
+    return r.structuredContent as any;
   return JSON.parse(r.content[0]?.text ?? "{}");
 }
 

--- a/src/tools/__tests__/clipboard.test.ts
+++ b/src/tools/__tests__/clipboard.test.ts
@@ -9,7 +9,16 @@ import {
   createWriteClipboardTool,
 } from "../clipboard.js";
 
-function parse(r: { content: Array<{ type: string; text: string }> }) {
+function parse(r: {
+  content: Array<{ type: string; text: string }>;
+  isError?: boolean;
+  structuredContent?: unknown;
+}) {
+  // Error results carry the plain message in `text` and machine-readable
+  // fields in `structuredContent` (ADR-0004). Success results keep the
+  // JSON-stringified payload in `text`.
+  if (r.isError && r.structuredContent !== undefined)
+    return r.structuredContent as any;
   return JSON.parse(r.content[0]?.text ?? "{}");
 }
 

--- a/src/tools/__tests__/editText.test.ts
+++ b/src/tools/__tests__/editText.test.ts
@@ -9,7 +9,16 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { applyEditsToContent, createEditTextTool } from "../editText.js";
 
-function parse(r: { content: Array<{ type: string; text: string }> }) {
+function parse(r: {
+  content: Array<{ type: string; text: string }>;
+  isError?: boolean;
+  structuredContent?: unknown;
+}) {
+  // Error results carry the plain message in `text` and machine-readable
+  // fields in `structuredContent` (ADR-0004). Success results keep the
+  // JSON-stringified payload in `text`.
+  if (r.isError && r.structuredContent !== undefined)
+    return r.structuredContent as any;
   return JSON.parse(r.content[0]?.text ?? "{}");
 }
 

--- a/src/tools/__tests__/fileOperations.test.ts
+++ b/src/tools/__tests__/fileOperations.test.ts
@@ -13,7 +13,16 @@ import {
   createRenameFileTool,
 } from "../fileOperations.js";
 
-function parse(r: { content: Array<{ type: string; text: string }> }) {
+function parse(r: {
+  content: Array<{ type: string; text: string }>;
+  isError?: boolean;
+  structuredContent?: unknown;
+}) {
+  // Error results carry the plain message in `text` and machine-readable
+  // fields in `structuredContent` (ADR-0004). Success results keep the
+  // JSON-stringified payload in `text`.
+  if (r.isError && r.structuredContent !== undefined)
+    return r.structuredContent as any;
   return JSON.parse(r.content[0]?.text ?? "{}");
 }
 

--- a/src/tools/__tests__/findFiles.test.ts
+++ b/src/tools/__tests__/findFiles.test.ts
@@ -19,7 +19,16 @@ const ok = (stdout: string) => ({
   durationMs: 10,
 });
 
-function parse(r: { content: Array<{ type: string; text: string }> }) {
+function parse(r: {
+  content: Array<{ type: string; text: string }>;
+  isError?: boolean;
+  structuredContent?: unknown;
+}) {
+  // Error results carry the plain message in `text` and machine-readable
+  // fields in `structuredContent` (ADR-0004). Success results keep the
+  // JSON-stringified payload in `text`.
+  if (r.isError && r.structuredContent !== undefined)
+    return r.structuredContent as any;
   return JSON.parse(r.content[0]?.text ?? "{}");
 }
 

--- a/src/tools/__tests__/fixAllLintErrors.test.ts
+++ b/src/tools/__tests__/fixAllLintErrors.test.ts
@@ -45,6 +45,11 @@ function makeProbes(overrides: Record<string, boolean> = {}) {
 }
 
 function parse(result: any) {
+  // Error results carry the plain message in `text` and machine-readable
+  // fields in `structuredContent` (ADR-0004).
+  if (result.isError && result.structuredContent !== undefined) {
+    return result.structuredContent;
+  }
   return JSON.parse(result.content[0].text);
 }
 

--- a/src/tools/__tests__/formatDocument.test.ts
+++ b/src/tools/__tests__/formatDocument.test.ts
@@ -47,6 +47,11 @@ function makeProbes(overrides: Record<string, boolean> = {}) {
 }
 
 function parse(result: any) {
+  // Error results carry the plain message in `text` and machine-readable
+  // fields in `structuredContent` (ADR-0004).
+  if (result.isError && result.structuredContent !== undefined) {
+    return result.structuredContent;
+  }
   return JSON.parse(result.content[0].text);
 }
 

--- a/src/tools/__tests__/getBufferContent.test.ts
+++ b/src/tools/__tests__/getBufferContent.test.ts
@@ -4,7 +4,15 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createGetBufferContentTool } from "../getBufferContent.js";
 
-function parse(result: { content: Array<{ type: string; text: string }> }) {
+function parse(result: {
+  content: Array<{ type: string; text: string }>;
+  isError?: boolean;
+  structuredContent?: unknown;
+}) {
+  // Error results carry the plain message in `text` and machine-readable
+  // fields in `structuredContent` (ADR-0004).
+  if (result.isError && result.structuredContent !== undefined)
+    return result.structuredContent as any;
   return JSON.parse(result.content.at(0)?.text ?? "{}");
 }
 

--- a/src/tools/__tests__/gitWrite.test.ts
+++ b/src/tools/__tests__/gitWrite.test.ts
@@ -64,7 +64,15 @@ describe("isValidRef", () => {
   });
 });
 
-function parse(result: { content: Array<{ type: string; text: string }> }) {
+function parse(result: {
+  content: Array<{ type: string; text: string }>;
+  isError?: boolean;
+  structuredContent?: unknown;
+}) {
+  // Error results carry the plain message in `text` and machine-readable
+  // fields in `structuredContent` (ADR-0004).
+  if (result.isError && result.structuredContent !== undefined)
+    return result.structuredContent as any;
   return JSON.parse(result.content.at(0)?.text ?? "{}");
 }
 

--- a/src/tools/__tests__/githubComposite.test.ts
+++ b/src/tools/__tests__/githubComposite.test.ts
@@ -19,17 +19,13 @@ function parse(r: {
   content: Array<{ type: string; text: string }>;
   isError?: true;
 }) {
-  const raw = JSON.parse(r.content.at(0)?.text ?? "{}") as unknown;
-  if (
-    r.isError &&
-    typeof raw === "object" &&
-    raw !== null &&
-    "error" in (raw as object) &&
-    typeof (raw as Record<string, unknown>).error === "string"
-  ) {
-    return (raw as Record<string, unknown>).error as string;
+  // Error results (ADR-0004): `text` is the plain message string — return it
+  // directly so callers can assert on the error text. Success results carry
+  // a JSON-stringified payload in `text`.
+  if (r.isError) {
+    return r.content.at(0)?.text ?? "";
   }
-  return raw;
+  return JSON.parse(r.content.at(0)?.text ?? "{}") as unknown;
 }
 
 const ok = (stdout: string, stderr = "") => ({

--- a/src/tools/__tests__/githubReview.test.ts
+++ b/src/tools/__tests__/githubReview.test.ts
@@ -24,18 +24,12 @@ function parse(result: {
   content: Array<{ type: string; text: string }>;
   isError?: true;
 }): any {
-  const raw = JSON.parse(result.content.at(0)?.text ?? "{}") as unknown;
-  // New error format: { error: "...", code?: "..." } — unwrap to the error string for backward-compat
-  if (
-    result.isError &&
-    typeof raw === "object" &&
-    raw !== null &&
-    "error" in (raw as object) &&
-    typeof (raw as Record<string, unknown>).error === "string"
-  ) {
-    return (raw as Record<string, unknown>).error as string;
+  // Error results (ADR-0004): `text` is the plain message string — return it
+  // directly. Success results carry a JSON-stringified payload in `text`.
+  if (result.isError) {
+    return result.content.at(0)?.text ?? "";
   }
-  return raw;
+  return JSON.parse(result.content.at(0)?.text ?? "{}") as unknown;
 }
 
 const workspace = "/fake/workspace";

--- a/src/tools/__tests__/httpClient.test.ts
+++ b/src/tools/__tests__/httpClient.test.ts
@@ -8,7 +8,15 @@ import { createSendHttpRequestTool } from "../httpClient.js";
 
 const tool = createSendHttpRequestTool();
 
-function parse(result: { content: Array<{ type: string; text: string }> }) {
+function parse(result: {
+  content: Array<{ type: string; text: string }>;
+  isError?: boolean;
+  structuredContent?: unknown;
+}) {
+  // Error results carry the plain message in `text` and machine-readable
+  // fields in `structuredContent` (ADR-0004).
+  if (result.isError && result.structuredContent !== undefined)
+    return result.structuredContent as any;
   return JSON.parse(result.content.at(0)?.text ?? "{}");
 }
 
@@ -228,8 +236,7 @@ describe("sendHttpRequest — Host header SSRF bypass prevention", () => {
       headers: { Host: "evil.com\r\nX-Injected: yes" },
     });
     expect(result.isError).toBe(true);
-    expect(JSON.parse(result.content[0]?.text ?? "{}").error).toMatch(
-      /invalid characters/i,
-    );
+    // Error `text` is the plain message (ADR-0004).
+    expect(result.content[0]?.text ?? "").toMatch(/invalid characters/i);
   });
 });

--- a/src/tools/__tests__/openFile.test.ts
+++ b/src/tools/__tests__/openFile.test.ts
@@ -9,7 +9,16 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createOpenFileTool } from "../openFile.js";
 
-function parse(r: { content: Array<{ type: string; text: string }> }) {
+function parse(r: {
+  content: Array<{ type: string; text: string }>;
+  isError?: boolean;
+  structuredContent?: unknown;
+}) {
+  // Error results carry the plain message in `text` and machine-readable
+  // fields in `structuredContent` (ADR-0004). Success results keep the
+  // JSON-stringified payload in `text`.
+  if (r.isError && r.structuredContent !== undefined)
+    return r.structuredContent as any;
   return JSON.parse(r.content[0]?.text ?? "{}");
 }
 

--- a/src/tools/__tests__/organizeImports.test.ts
+++ b/src/tools/__tests__/organizeImports.test.ts
@@ -20,7 +20,13 @@ const mockExecSafe = vi.mocked(execSafe);
 function parse(result: {
   content: Array<{ type: string; text: string }>;
   isError?: true;
+  structuredContent?: unknown;
 }) {
+  // Error results carry the plain message in `text` and machine-readable
+  // fields in `structuredContent` (ADR-0004).
+  if (result.isError && result.structuredContent !== undefined) {
+    return result.structuredContent as any;
+  }
   return JSON.parse(result.content.at(0)?.text ?? "{}");
 }
 

--- a/src/tools/__tests__/previewCodeAction.test.ts
+++ b/src/tools/__tests__/previewCodeAction.test.ts
@@ -45,7 +45,8 @@ describe("previewCodeAction", () => {
       actionTitle: "Add missing import",
     });
     expect(result.isError).toBe(true);
-    expect(JSON.parse(result.content[0]!.text).code).toBe("extension_required");
+    // Machine-readable error code lives in structuredContent (ADR-0004).
+    expect((result as any).structuredContent.code).toBe("extension_required");
   });
 
   it("returns preview data on success", async () => {

--- a/src/tools/__tests__/refactorExtractFunction.test.ts
+++ b/src/tools/__tests__/refactorExtractFunction.test.ts
@@ -15,7 +15,16 @@ function makeExtensionClient(overrides: Record<string, unknown> = {}) {
   } as unknown as import("../../extensionClient.js").ExtensionClient;
 }
 
-function parse(r: { content: Array<{ type: string; text: string }> }) {
+function parse(r: {
+  content: Array<{ type: string; text: string }>;
+  isError?: boolean;
+  structuredContent?: unknown;
+}) {
+  // Error results carry the plain message in `text` and machine-readable
+  // fields in `structuredContent` (ADR-0004). Success results keep the
+  // JSON-stringified payload in `text`.
+  if (r.isError && r.structuredContent !== undefined)
+    return r.structuredContent as any;
   return JSON.parse(r.content[0]?.text ?? "{}");
 }
 

--- a/src/tools/__tests__/refactorPreview.test.ts
+++ b/src/tools/__tests__/refactorPreview.test.ts
@@ -53,7 +53,8 @@ describe("refactorPreview", () => {
       actionTitle: "Extract function",
     });
     expect(result.isError).toBe(true);
-    expect(JSON.parse(result.content[0]!.text).code).toBe("extension_required");
+    // Machine-readable error code lives in structuredContent (ADR-0004).
+    expect((result as any).structuredContent.code).toBe("extension_required");
   });
 
   it("returns preview data on success", async () => {

--- a/src/tools/__tests__/remainingTools.test.ts
+++ b/src/tools/__tests__/remainingTools.test.ts
@@ -24,7 +24,16 @@ import { createSetActiveWorkspaceFolderTool } from "../setActiveWorkspaceFolder.
 import { createGetTypeHierarchyTool } from "../typeHierarchy.js";
 import { createSetWorkspaceSettingTool } from "../workspaceSettings.js";
 
-function parse(r: { content: Array<{ type: string; text: string }> }) {
+function parse(r: {
+  content: Array<{ type: string; text: string }>;
+  isError?: boolean;
+  structuredContent?: unknown;
+}) {
+  // Error results carry the plain message in `text` and machine-readable
+  // fields in `structuredContent` (ADR-0004). Success results keep the
+  // JSON-stringified payload in `text`.
+  if (r.isError && r.structuredContent !== undefined)
+    return r.structuredContent as any;
   return JSON.parse(r.content[0]?.text ?? "{}");
 }
 

--- a/src/tools/__tests__/replaceBlock.test.ts
+++ b/src/tools/__tests__/replaceBlock.test.ts
@@ -9,17 +9,12 @@ function parse(result: {
   content: Array<{ type: string; text: string }>;
   isError?: boolean;
 }) {
-  const raw = JSON.parse(result.content.at(0)?.text ?? "{}") as unknown;
-  if (
-    result.isError &&
-    typeof raw === "object" &&
-    raw !== null &&
-    "error" in (raw as object) &&
-    typeof (raw as Record<string, unknown>).error === "string"
-  ) {
-    return (raw as Record<string, unknown>).error as string;
+  // Error results (ADR-0004): `text` is the plain message string — return it
+  // directly. Success results carry a JSON-stringified payload in `text`.
+  if (result.isError) {
+    return result.content.at(0)?.text ?? "";
   }
-  return raw;
+  return JSON.parse(result.content.at(0)?.text ?? "{}") as unknown;
 }
 
 describe("replaceBlock TOCTOU bug", () => {

--- a/src/tools/__tests__/resumeClaudeTask.test.ts
+++ b/src/tools/__tests__/resumeClaudeTask.test.ts
@@ -27,7 +27,15 @@ function makeOrchestrator(task?: ClaudeTask) {
   } as unknown as ClaudeOrchestrator;
 }
 
-function parse(result: { content: Array<{ type: string; text: string }> }) {
+function parse(result: {
+  content: Array<{ type: string; text: string }>;
+  isError?: boolean;
+  structuredContent?: unknown;
+}) {
+  // Error results carry the plain message in `text` and machine-readable
+  // fields in `structuredContent` (ADR-0004).
+  if (result.isError && result.structuredContent !== undefined)
+    return result.structuredContent as any;
   return JSON.parse(result.content.at(0)?.text ?? "{}");
 }
 

--- a/src/tools/__tests__/runClaudeTask.test.ts
+++ b/src/tools/__tests__/runClaudeTask.test.ts
@@ -18,11 +18,16 @@ function makeOrchestrator(driver?: ProviderDriver) {
 }
 
 function resultText(result: any): string {
-  return result.content[0]?.text ?? "";
+  // For error results (ADR-0004) `text` is the plain message; the machine
+  // code lives in `structuredContent.code`. Combine both so callers can
+  // assert against either the message text or the error code.
+  const text = result.content[0]?.text ?? "";
+  const code = result.structuredContent?.code;
+  return typeof code === "string" ? `${text} ${code}` : text;
 }
 
 function resultData(result: any): unknown {
-  return JSON.parse(resultText(result));
+  return JSON.parse(result.content[0]?.text ?? "");
 }
 
 describe("runClaudeTask", () => {

--- a/src/tools/__tests__/search.test.ts
+++ b/src/tools/__tests__/search.test.ts
@@ -8,7 +8,15 @@ import { createFindFilesTool } from "../findFiles.js";
 import { createGetFileTreeTool } from "../getFileTree.js";
 import { createSearchWorkspaceTool } from "../searchWorkspace.js";
 
-function parse(result: { content: Array<{ type: string; text: string }> }) {
+function parse(result: {
+  content: Array<{ type: string; text: string }>;
+  isError?: boolean;
+  structuredContent?: unknown;
+}) {
+  // Error results carry the plain message in `text` and machine-readable
+  // fields in `structuredContent` (ADR-0004).
+  if (result.isError && result.structuredContent !== undefined)
+    return result.structuredContent as any;
   return JSON.parse(result.content.at(0)?.text ?? "{}");
 }
 

--- a/src/tools/__tests__/searchAndReplace.logic.test.ts
+++ b/src/tools/__tests__/searchAndReplace.logic.test.ts
@@ -24,7 +24,15 @@ import { execSafe } from "../utils.js";
 
 const mockedExecSafe = execSafe as ReturnType<typeof vi.fn>;
 
-function parse(result: { content: Array<{ type: string; text: string }> }) {
+function parse(result: {
+  content: Array<{ type: string; text: string }>;
+  isError?: boolean;
+  structuredContent?: unknown;
+}) {
+  // Error results carry the plain message in `text` and machine-readable
+  // fields in `structuredContent` (ADR-0004).
+  if (result.isError && result.structuredContent !== undefined)
+    return result.structuredContent as any;
   return JSON.parse(result.content.at(0)?.text ?? "{}");
 }
 

--- a/src/tools/__tests__/spawnWorkspace.test.ts
+++ b/src/tools/__tests__/spawnWorkspace.test.ts
@@ -7,7 +7,13 @@ import { createSpawnWorkspaceTool } from "../spawnWorkspace.js";
 
 // ---- helpers ---------------------------------------------------------------
 
-function parseText(result: { content: Array<{ type: string; text: string }> }) {
+function parseText(result: {
+  content: Array<{ type: string; text: string }>;
+  isError?: boolean;
+  structuredContent?: unknown;
+}) {
+  if (result.isError && result.structuredContent !== undefined)
+    return result.structuredContent as any;
   return JSON.parse(result.content[0]?.text ?? "{}");
 }
 

--- a/src/tools/__tests__/utils-security.test.ts
+++ b/src/tools/__tests__/utils-security.test.ts
@@ -18,29 +18,33 @@ describe("success() and error() format", () => {
     expect(result.isError).toBeUndefined();
   });
 
-  it("error returns compact JSON with isError: true", () => {
+  it("error returns the plain message as text with isError: true", () => {
     const result = error("something failed");
     expect(result.isError).toBe(true);
-    const parsed = JSON.parse(result.content.at(0)?.text ?? "{}");
-    expect(parsed.error).toBe("something failed");
-    expect(parsed.code).toBeUndefined();
+    // text content is the plain, human/LLM-readable message — not JSON.
+    expect(result.content.at(0)?.text).toBe("something failed");
+    // machine-readable fields live in structuredContent.
+    expect(result.structuredContent.error).toBe("something failed");
+    expect(result.structuredContent.code).toBeUndefined();
   });
 
   it("error with optional code field (string message)", () => {
     const result = error("not found", "file_not_found");
     expect(result.isError).toBe(true);
-    const parsed = JSON.parse(result.content.at(0)?.text ?? "{}");
-    expect(parsed.error).toBe("not found");
-    expect(parsed.code).toBe("file_not_found");
+    expect(result.content.at(0)?.text).toBe("not found");
+    expect(result.structuredContent.error).toBe("not found");
+    expect(result.structuredContent.code).toBe("file_not_found");
   });
 
-  it("error with object payload (legacy structured errors)", () => {
+  it("error with object payload surfaces fields in structuredContent", () => {
     const result = error({ fixed: false, source: "cli", error: "lint failed" });
     expect(result.isError).toBe(true);
-    const parsed = JSON.parse(result.content.at(0)?.text ?? "{}");
-    expect(parsed.fixed).toBe(false);
-    expect(parsed.error).toBe("lint failed");
-    expect(parsed.code).toBeUndefined();
+    // text is the human-readable message extracted from the `error` field.
+    expect(result.content.at(0)?.text).toBe("lint failed");
+    expect(result.structuredContent.fixed).toBe(false);
+    expect(result.structuredContent.source).toBe("cli");
+    expect(result.structuredContent.error).toBe("lint failed");
+    expect(result.structuredContent.code).toBeUndefined();
   });
 
   it("error with object payload plus code", () => {
@@ -48,8 +52,8 @@ describe("success() and error() format", () => {
       { fixed: false, error: "lint failed" },
       "external_command_failed",
     );
-    const parsed = JSON.parse(result.content.at(0)?.text ?? "{}");
-    expect(parsed.code).toBe("external_command_failed");
+    expect(result.content.at(0)?.text).toBe("lint failed");
+    expect(result.structuredContent.code).toBe("external_command_failed");
   });
 
   it("success with null", () => {

--- a/src/tools/__tests__/vscodeTasks.test.ts
+++ b/src/tools/__tests__/vscodeTasks.test.ts
@@ -4,7 +4,16 @@ import {
   createRunVSCodeTaskTool,
 } from "../vscodeTasks.js";
 
-function parse(r: { content: Array<{ type: string; text: string }> }) {
+function parse(r: {
+  content: Array<{ type: string; text: string }>;
+  isError?: boolean;
+  structuredContent?: unknown;
+}) {
+  // Error results carry the plain message in `text` and machine-readable
+  // fields in `structuredContent` (ADR-0004). Success results keep the
+  // JSON-stringified payload in `text`.
+  if (r.isError && r.structuredContent !== undefined)
+    return r.structuredContent as any;
   return JSON.parse(r.content[0]?.text ?? "{}");
 }
 

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -301,28 +301,51 @@ export function successStructuredLarge(data: unknown): {
   };
 }
 
+/**
+ * Build a tool-error result (ADR-0004 Tier 2).
+ *
+ * The `text` content block carries the plain, human/LLM-readable error
+ * message — never a JSON blob. An LLM consuming a failed tool call should be
+ * able to read the message directly without JSON-parsing it.
+ *
+ * Machine-readable fields (`code` and any extra fields passed via the object
+ * form) are surfaced in `structuredContent` for non-LLM clients that want a
+ * stable, parseable shape. `structuredContent.error` always holds the same
+ * message string as the text block.
+ *
+ * Accepts either a plain message string or an object. For the object form the
+ * human-readable message is taken from `error` / `message`, falling back to a
+ * JSON rendering only when neither is present.
+ */
 export function error(
   data: string | Record<string, unknown>,
   code?: string,
 ): {
   content: Array<{ type: string; text: string }>;
+  structuredContent: Record<string, unknown>;
   isError: true;
 } {
-  let payload: Record<string, unknown>;
+  let message: string;
+  let structured: Record<string, unknown>;
   if (typeof data === "string") {
-    payload = { error: data };
+    message = data;
+    structured = { error: data };
   } else {
-    payload = { ...data };
+    structured = { ...data };
+    const m = data.error ?? data.message;
+    message = typeof m === "string" ? m : JSON.stringify(data);
+    structured.error = message;
   }
-  if (code !== undefined) payload.code = code;
+  if (code !== undefined) structured.code = code;
   return {
-    content: [{ type: "text", text: JSON.stringify(payload) }],
+    content: [{ type: "text", text: message }],
+    structuredContent: structured,
     isError: true,
   };
 }
 
 export function extensionRequired(feature: string, alternatives?: string[]) {
-  let msg = `VS Code extension not connected — ${feature} requires the extension.\n\nTo reconnect: Cmd+Shift+P → "Claude IDE Bridge: Reconnect"`;
+  let msg = `VS Code extension not connected — ${feature} requires the extension.\n\nTo reconnect: open the Command Palette → "Claude IDE Bridge: Reconnect"`;
   if (alternatives?.length) {
     msg += `\n\nAlternatives that work without the extension:\n${alternatives.map((a) => `  • ${a}`).join("\n")}`;
   }


### PR DESCRIPTION
## Summary

Five CLI / tool-response UX defects found by a UX audit, fixed in one PR.

1. **(HIGH) Tool errors no longer return raw JSON.** `error()` in `src/tools/utils.ts` previously wrapped every message as `JSON.stringify({error, code})` in the `text` content block, forcing an LLM to JSON-parse a failed tool call. Per the styleguide and ADR-0004, error `text` is now the plain human/LLM-readable message; machine-readable fields (`code` plus any extra object fields) go in `structuredContent`. `structuredContent.error` always mirrors the message string.
2. **(HIGH) `patchwork --help` completeness.** Added the previously omitted subcommands: `start`, `status`, `tools`, `analytics`, `launchd`, `suggest`, `token-efficiency` (grouped under new "Operate" / extended "Diagnose" sections).
3. **(MED) `recipe list` column alignment.** `printInstalledList` in `src/commands/recipeInstall.ts` now truncates the Description/Files column to 120 chars (matching the `halts` command's reason truncation) so long values can't wrap and break alignment on 80-col terminals.
4. **(MED) `tools list` drift-proof count.** `buildToolCatalog` in `src/commands/tools.ts` now derives the tool set by scanning the actual registered tool modules on disk (`dist/tools/*.js`, falling back to `src/tools/*.ts` in dev) — the same registry-of-truth `scripts/audit-lsp-tools.mjs` enforces — instead of a hand-maintained `TOOL_CATEGORIES` + `TOOL_DESCRIPTIONS` union. Count now reports **177**, matching the authoritative audit count. `TOOL_CATEGORIES`/`TOOL_DESCRIPTIONS` remain as metadata overlays; a metadata-union fallback covers unusual install layouts.
5. **(LOW) Mac-only keybind.** `extensionRequired()` no longer hard-codes `Cmd+Shift+P`; it says "open the Command Palette".

### `doctor` subcommand verdict

The task asked whether a `doctor` CLI subcommand should exist. **No stale reference found** — neither `CLAUDE.md` nor `src/index.ts` references a `doctor` subcommand, and no such subcommand exists. The `bridgeDoctor` capability is intentionally an MCP tool (run by the connected agent), not a CLI subcommand. Nothing to add or remove; no doc edit needed.

### Item 1 blast radius

The new error contract broke **27 test files** that asserted the old JSON-blob shape (`JSON.parse(content[0].text).error/.code`). All 27 were updated to the new contract — shared `parse()` test helpers now return `structuredContent` for error results / the plain `text` for the message; direct assertions check `structuredContent.code` or the plain message text. The contract was updated, not reverted.

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — only 4 pre-existing environmental failures remain (shim-*/recipe-cli suites that spawn `tsx`, which isn't installed in this env; confirmed failing on clean `origin/main` too). All 27 updated test files pass.
- [x] `npx tsc -p tsconfig.tests.core.json --noEmit` — passes (strict core typecheck)
- [x] `node scripts/audit-lsp-tools.mjs` — all checks pass; 177 total registered
- [x] `npx biome check --write` on all changed files
- [x] `node dist/index.js tools list` → `claude-ide-bridge — 177 tools`
- [x] `node dist/index.js --help` shows all new subcommands

🤖 Generated with [Claude Code](https://claude.com/claude-code)