### PR TITLE
fix(dashboard): a11y — palette ARIA, tap targets, live regions, drawer role, paper-theme sidebar

### DIFF
--- a/dashboard/src/app/globals.css
+++ b/dashboard/src/app/globals.css
@@ -2899,6 +2899,25 @@ button.topbar-search {
   .app-main {
     grid-column: 1 / 2;
   }
+  /* Tap targets: the mobile nav drawer renders `.app-nav-link` at ~35px
+     tall (7px padding + 21px content). Lift to the 44px WCAG 2.5.5 /
+     iOS HIG minimum so drawer links are comfortably tappable. */
+  .app-nav-link {
+    min-height: 44px;
+  }
+}
+
+/* Touch devices: the topbar icon buttons (`.theme-toggle` ~32px,
+   `.mobile-menu-btn` / `.topbar-bell` ~36px) are below the 44px minimum
+   tap target. Coarse-pointer / no-hover input is the reliable signal for
+   a touchscreen, independent of viewport width, so size up here. */
+@media (hover: none) and (pointer: coarse) {
+  .theme-toggle,
+  .mobile-menu-btn,
+  .app-header .topbar-icon-btn.topbar-bell {
+    min-width: 44px;
+    min-height: 44px;
+  }
 }
 
 /* ---- Identity pill (top bar) ---- */

--- a/dashboard/src/app/recipes/page.tsx
+++ b/dashboard/src/app/recipes/page.tsx
@@ -1294,7 +1294,7 @@ export default function RecipesPage() {
         >
           <PatchCard padded={false} style={{ overflow: "hidden", minWidth: 0 }}>
             <div className="table-wrap" style={{ minWidth: 0, overflow: "auto" }}>
-              <table className="table recipes-table" style={{ width: "100%", tableLayout: "fixed" }}>
+              <table className="table recipes-table" aria-keyshortcuts="j k" style={{ width: "100%", tableLayout: "fixed" }}>
                 <caption className="sr-only">
                   Installed recipes with health, trigger, last 14 runs, average duration, last run time, and actions.
                 </caption>

--- a/dashboard/src/app/runs/page.tsx
+++ b/dashboard/src/app/runs/page.tsx
@@ -833,7 +833,7 @@ export default function RunsPage() {
         <>
         {/* Desktop / tablet: dense multi-column table. Hidden ≤768px. */}
         <div className="table-wrap runs-table-desktop">
-          <table className="table">
+          <table className="table" aria-keyshortcuts="j k">
             <thead>
               <tr>
                 <th style={{ width: 120 }}>When</th>
@@ -873,6 +873,7 @@ export default function RunsPage() {
                       tabIndex={0}
                       role="button"
                       aria-expanded={isExpanded}
+                      aria-label={`Run of ${formatRecipeName(r.recipeName, r.trigger)}, ${statusLabel(r)}, ${normaliseTrigger(r.trigger)} trigger`}
                       style={{
                         cursor: "pointer",
                         boxShadow:

--- a/dashboard/src/app/tasks/page.tsx
+++ b/dashboard/src/app/tasks/page.tsx
@@ -621,7 +621,17 @@ export default function TasksPage() {
                 pointerEvents: "none",
               }}
             />
-          <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+          {/* Tasks render as a button list (not a <table>); advertise the
+              j/k row-navigation shortcut on the group container so screen
+              readers announce it. Each task button already carries an
+              aria-label. `role="group"` (not `list`) keeps the existing
+              focusable <button> children valid as group members. */}
+          <div
+            role="group"
+            aria-label="Tasks — press j or k to move between tasks"
+            aria-keyshortcuts="j k"
+            style={{ display: "flex", flexDirection: "column", gap: 4 }}
+          >
             {filteredTasks.length === 0 && (
               <div style={{ padding: "var(--s-4)", color: "var(--ink-3)", fontSize: "var(--fs-m)" }}>
                 No tasks match this filter.

--- a/dashboard/src/components/ActivityTicker.tsx
+++ b/dashboard/src/components/ActivityTicker.tsx
@@ -128,9 +128,15 @@ export function ActivityTicker() {
   return (
     <div
       className="activity-ticker"
-      role="status"
+      // Decorative "feels alive" ticker — its three rows churn every few
+      // seconds. `aria-live="polite"` here produced continuous
+      // screen-reader chatter for no actionable benefit (the same events
+      // are reachable via the /activity page). Mark it `aria-live="off"`
+      // and drop `role="status"` so assistive tech ignores the churn;
+      // the rows stay individually focusable links for anyone who wants
+      // to explore them.
       aria-label="Live activity ticker"
-      aria-live="polite"
+      aria-live="off"
       style={{
         display: "flex",
         alignItems: "center",

--- a/dashboard/src/components/CommandPalette.tsx
+++ b/dashboard/src/components/CommandPalette.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { useRouter } from "next/navigation";
-import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { apiPath } from "@/lib/api";
 import { flatRoutes } from "@/lib/navRoutes";
 
@@ -237,6 +237,17 @@ export function CommandPalette({
     else grouped.push({ group: cmd.group, items: [{ cmd, idx }] });
   });
 
+  // Stable ids for the combobox/listbox ARIA wiring. `aria-activedescendant`
+  // on the input points at the currently-highlighted option so screen
+  // readers track keyboard navigation without moving DOM focus off the
+  // input.
+  const listId = "cmdk-listbox";
+  const rowId = (idx: number) => `cmdk-row-${idx}`;
+  const activeRowId =
+    filtered.length > 0 && activeIdx < filtered.length
+      ? rowId(activeIdx)
+      : undefined;
+
   return (
     <div
       className="cmdk-backdrop"
@@ -262,34 +273,51 @@ export function CommandPalette({
             onChange={(e) => setQuery(e.target.value)}
             placeholder="Jump to anything…"
             aria-label="Command palette query"
+            role="combobox"
+            aria-expanded={filtered.length > 0}
+            aria-controls={listId}
+            aria-autocomplete="list"
+            aria-activedescendant={activeRowId}
           />
           <span className="kbd">esc</span>
         </div>
-        <ul className="cmdk-list" ref={listRef} role="listbox">
+        <ul className="cmdk-list" ref={listRef} id={listId} role="listbox" aria-label="Results">
           {filtered.length === 0 && (
             <li className="cmdk-empty">No matches</li>
           )}
           {grouped.map((g) => (
-            <Fragment key={g.group}>
-              <li className="cmdk-group" aria-hidden="true">{g.group}</li>
-              {g.items.map(({ cmd, idx }) => (
-                <li
-                  key={cmd.id}
-                  data-idx={idx}
-                  role="option"
-                  aria-selected={idx === activeIdx}
-                  className={`cmdk-row${idx === activeIdx ? " is-active" : ""}`}
-                  onMouseEnter={() => setActiveIdx(idx)}
-                  onClick={() => {
-                    cmd.perform();
-                    onClose();
-                  }}
-                >
-                  <span className="cmdk-row-label">{cmd.label}</span>
-                  {cmd.hint && <span className="cmdk-row-hint">{cmd.hint}</span>}
-                </li>
-              ))}
-            </Fragment>
+            // Each group is a `role="group"` with an `aria-label` so the
+            // group name (Navigate / Recipes / …) is exposed as context
+            // for its options. The previous `<li aria-hidden>` header was
+            // both an invalid child of `role="listbox"` and silently
+            // dropped the grouping for assistive tech.
+            <li key={g.group} role="presentation">
+              <div role="group" aria-label={g.group}>
+                <div className="cmdk-group" aria-hidden="true">
+                  {g.group}
+                </div>
+                <ul role="presentation" style={{ listStyle: "none", margin: 0, padding: 0 }}>
+                  {g.items.map(({ cmd, idx }) => (
+                    <li
+                      key={cmd.id}
+                      id={rowId(idx)}
+                      data-idx={idx}
+                      role="option"
+                      aria-selected={idx === activeIdx}
+                      className={`cmdk-row${idx === activeIdx ? " is-active" : ""}`}
+                      onMouseEnter={() => setActiveIdx(idx)}
+                      onClick={() => {
+                        cmd.perform();
+                        onClose();
+                      }}
+                    >
+                      <span className="cmdk-row-label">{cmd.label}</span>
+                      {cmd.hint && <span className="cmdk-row-hint">{cmd.hint}</span>}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </li>
           ))}
         </ul>
       </div>

--- a/dashboard/src/components/GlobalLiveRunsStrip.tsx
+++ b/dashboard/src/components/GlobalLiveRunsStrip.tsx
@@ -1,5 +1,6 @@
 "use client";
 import Link from "next/link";
+import { useEffect, useRef, useState } from "react";
 import { useActiveRuns } from "@/hooks/LiveRunsContext";
 import { StatusPill } from "@/components/patchwork";
 
@@ -28,6 +29,23 @@ function tone(status: string): "ok" | "err" | "warn" | "muted" {
 
 const MAX_VISIBLE = 4;
 
+/**
+ * Builds a one-line summary of the current run set, used only to detect
+ * *meaningful* state transitions (a run finishing, halting, erroring, or
+ * a new run starting). The visual strip re-renders on every progress
+ * tick (`Step 3/7` → `Step 4/7`); announcing every tick floods screen
+ * readers, so the polite live-region carries this stable summary instead
+ * and only updates when a run changes lifecycle state.
+ */
+function transitionKey(
+  runs: { recipeName: string; status: string }[],
+): string {
+  return runs
+    .map((r) => `${r.recipeName}:${r.status}`)
+    .sort()
+    .join("|");
+}
+
 export function GlobalLiveRunsStrip() {
   const runs = useActiveRuns();
   // Order: running first, then most recent terminal first.
@@ -36,13 +54,45 @@ export function GlobalLiveRunsStrip() {
     if (b.status === "running" && a.status !== "running") return 1;
     return b.startedAt - a.startedAt;
   });
+
+  // Announce only lifecycle transitions, not per-step progress ticks.
+  const [announce, setAnnounce] = useState("");
+  const lastKeyRef = useRef("");
+  useEffect(() => {
+    const key = transitionKey(all);
+    if (key === lastKeyRef.current) return;
+    lastKeyRef.current = key;
+    const running = all.filter((r) => r.status === "running").length;
+    const halted = all.filter((r) => r.status === "halted").length;
+    const errored = all.filter(
+      (r) => r.status !== "running" && r.status !== "ok" && r.status !== "halted",
+    ).length;
+    const parts: string[] = [];
+    if (running > 0) parts.push(`${running} run${running === 1 ? "" : "s"} in progress`);
+    if (halted > 0) parts.push(`${halted} halted`);
+    if (errored > 0) parts.push(`${errored} errored`);
+    setAnnounce(parts.length > 0 ? parts.join(", ") : "");
+  }, [all]);
+
   if (all.length === 0) return null;
 
   const visible = all.slice(0, MAX_VISIBLE);
   const overflow = all.length - visible.length;
 
   return (
-    <div className="global-live-runs-strip" role="status" aria-live="polite">
+    <div className="global-live-runs-strip">
+      {/* Polite, atomic live region — carries a stable lifecycle summary
+          that only changes on real transitions, so screen readers are
+          not flooded by per-step progress updates from the visual rows
+          below (which are intentionally not in a live region). */}
+      <p
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+        className="sr-only"
+      >
+        {announce}
+      </p>
       {visible.map((r) => {
         const p = pct(r);
         const label =

--- a/dashboard/src/components/Shell.tsx
+++ b/dashboard/src/components/Shell.tsx
@@ -537,26 +537,24 @@ function AppShell({ children }: { children: ReactNode }) {
         </div>
       </header>
       {/*
-        Drawer ARIA: at desktop width the sidebar is just a navigation
-        landmark, but on mobile (≤768 px) it's a modal dialog —
-        useFocusTrap inerts the rest of the app + locks scroll while
-        it's open. Mirror that semantically with `role="dialog"` +
-        `aria-modal` so screen readers announce "Primary navigation
-        dialog" / "modal" instead of leaking it as just another
-        landmark. `tabIndex={-1}` is needed for the focus trap to
-        focus the container when there are no focusable children.
+        Drawer ARIA: at desktop width the sidebar is a permanent
+        navigation landmark — it has no dismiss path and is always
+        "open", so exposing it as a `role="dialog"` is wrong (a dialog
+        with no way to close confuses screen-reader users). On mobile
+        (≤768 px) it genuinely IS a modal dialog — useFocusTrap inerts
+        the rest of the app + locks scroll while it's open — so the
+        dialog role + `aria-modal` are correct THERE.
 
-        Desktop screen readers don't see the dialog role as wrong —
-        the drawer is always "open" at desktop, so behaving as a
-        dialog with no dismiss path is benign. The inertSelector
-        passed to useFocusTrap is `main, .app-header,
-        .mobile-bottom-nav` which only fires on mobile because none
-        of those targets actually go inert at desktop scope.
+        Render `role` conditionally: `dialog` only when `mobileOpen`,
+        otherwise `undefined` so the inner `<nav aria-label="Main
+        navigation">` is exposed as a plain navigation landmark.
+        `tabIndex={-1}` is needed for the focus trap to focus the
+        container when there are no focusable children.
       */}
       <aside
         ref={drawerRef}
         className="app-sidebar"
-        role="dialog"
+        role={mobileOpen ? "dialog" : undefined}
         aria-modal={mobileOpen ? "true" : undefined}
         aria-label="Primary navigation"
         tabIndex={-1}

--- a/dashboard/src/components/patchwork/RiskPill.tsx
+++ b/dashboard/src/components/patchwork/RiskPill.tsx
@@ -7,9 +7,15 @@ const TONE: Record<RiskLevel, string> = {
 };
 
 export function RiskPill({ level, label }: { level: RiskLevel; label?: string }) {
+  // The colored `.dot` is decorative (`aria-hidden`) — risk must never be
+  // conveyed by colour alone (WCAG 1.4.1). Always render the visible text
+  // label; `aria-label` spells out "risk" so the bare "LOW/MEDIUM/HIGH"
+  // text isn't ambiguous out of context for screen-reader users.
+  const text = label ?? level;
   return (
     <span
       className={`chip ${TONE[level]}`}
+      aria-label={`${level} risk`}
       style={{
         textTransform: "uppercase",
         letterSpacing: "0.06em",
@@ -19,7 +25,7 @@ export function RiskPill({ level, label }: { level: RiskLevel; label?: string })
       }}
     >
       <span className="dot" aria-hidden="true" />
-      {label ?? level}
+      {text}
     </span>
   );
 }

--- a/dashboard/src/components/patchwork/StatusPill.tsx
+++ b/dashboard/src/components/patchwork/StatusPill.tsx
@@ -25,18 +25,32 @@ export function StatusPill({
   children,
   className,
   title,
+  srLabel,
 }: {
   tone?: StatusTone;
   dot?: boolean;
-  children: ReactNode;
+  children?: ReactNode;
   className?: string;
   title?: string;
+  /**
+   * Screen-reader-only label. Use when the pill is icon-only (no visible
+   * text `children`) so status is never conveyed by the coloured `.dot`
+   * alone — WCAG 1.4.1 (use of colour).
+   */
+  srLabel?: string;
 }) {
   const cls = `chip ${TONE_CLASS[tone]}${className ? ` ${className}` : ""}`;
+  // The coloured `.dot` is decorative (`aria-hidden`). A pill must always
+  // carry a text label: either visible `children` or an `sr-only`
+  // fallback. Without one, an icon-only pill would communicate status
+  // purely through colour.
+  const hasVisibleText =
+    children !== undefined && children !== null && children !== false;
   return (
     <span className={cls} title={title}>
       {dot && <span className="dot" aria-hidden="true" />}
-      {children}
+      {hasVisibleText ? children : null}
+      {!hasVisibleText && srLabel && <span className="sr-only">{srLabel}</span>}
     </span>
   );
 }


### PR DESCRIPTION
## Summary

Fixes accessibility defects in shared dashboard shell/global files, found by a multi-agent UI audit. Scoped to shell/global files so it does not collide with sibling page-level PRs.

- **Tap targets (#1)** — `.app-nav-link` gets `min-height: 44px` in the mobile drawer; `.theme-toggle`, `.mobile-menu-btn`, `.topbar-bell` get a 44px minimum inside a `@media (hover:none) and (pointer:coarse)` block.
- **Command palette ARIA (#2)** — input is now `role="combobox"` with `aria-controls`, `aria-expanded`, `aria-autocomplete`, and `aria-activedescendant` referencing a stable per-row id. Group headers moved out of invalid `aria-hidden` `<li>` children of the listbox into `role="group"` wrappers with `aria-label`.
- **j/k shortcut advertised (#3)** — `aria-keyshortcuts="j k"` on the runs and recipes `<table>`s and on the tasks button-list container; runs rows get a summarizing `aria-label` (recipes/tasks rows already had one).
- **Live-region chatter (#4)** — ActivityTicker is decorative → `aria-live="off"`. GlobalLiveRunsStrip keeps a polite, `aria-atomic` live region but announces only lifecycle transitions (running/halted/errored counts), not per-step progress ticks; the visual rows are no longer inside a live region.
- **Status by colour (#5)** — RiskPill always renders its visible text label plus an `aria-label`; StatusPill gains an `srLabel` fallback so an icon-only pill never relies on the coloured dot alone.
- **Drawer role (#6)** — the nav `<aside>` only takes `role="dialog"` when the mobile drawer is open; at desktop it is exposed as a plain navigation landmark.

### Items already resolved on `main`

- **#7 (mobile bottom-nav overlap)** — `.app-main` and `.app-content` already carry bottom padding clearing the ~62px bottom nav (verified at 390px width via Playwright).
- **#8 (paper-theme sidebar)** — the sidebar already reads theme CSS tokens (`--canvas`, `--ink-*`) and renders light in the paper theme (verified via Playwright computed styles).

No code change was made for #7/#8 since they were not reproducible on current `main`.

## Test plan

- [x] `npx tsc --noEmit` in `dashboard/` — clean
- [x] `next lint` — no new warnings/errors from changed files
- [ ] Mobile drawer: nav links and topbar buttons are ≥44px tappable
- [ ] Command palette: screen reader announces active row + group context
- [ ] Runs/recipes tables + tasks list: j/k navigation advertised, rows have accessible names
- [ ] Screen reader: ActivityTicker silent; live-runs strip announces only on run lifecycle changes
- [ ] Risk/status pills convey state via text, not colour alone
- [ ] Desktop: nav landmark is not announced as a dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)