### PR TITLE
fix(dashboard): mask password, disable coming-soon connectors, fix truncation + chart axes

### DIFF
--- a/dashboard/src/app/approvals/page.tsx
+++ b/dashboard/src/app/approvals/page.tsx
@@ -1160,10 +1160,13 @@ function ApprovalsContent() {
 
       <HintCard id="approvals" />
 
-      {/* Hero status bar — counts by tier. When the queue is empty the
-          tier breakdown is all zeros — collapse it to avoid repeating
-          "0 pending" + "All clear" + four zero-tiles. The historical rate
-          strip (below) stays visible if there are past decisions. */}
+      {/* Hero status bar — counts by tier. When the queue is empty this
+          whole card is suppressed: the dedicated "All caught up!"
+          EmptyState below is the single empty state, so rendering a
+          "Queue — All clear" card here too was a redundant double
+          empty-state (UX audit 2026-05-20). The historical rate strip
+          still surfaces past decisions via the empty-state path. */}
+      {pending.length > 0 && (
       <div
         className="card"
         style={{
@@ -1189,7 +1192,7 @@ function ApprovalsContent() {
             Queue
           </div>
           <div style={{ fontSize: "var(--fs-3xl)", fontWeight: 800, color: "var(--ink-0)", lineHeight: 1.1 }}>
-            {pending.length === 0 ? "All clear" : `${pending.length} awaiting decision`}
+            {`${pending.length} awaiting decision`}
           </div>
         </div>
         {pending.length > 0 && (
@@ -1299,6 +1302,7 @@ function ApprovalsContent() {
           );
         })()}
       </div>
+      )}
 
       {/* Risk filter buttons — hidden when there's nothing to filter */}
       {pending.length > 0 && (

--- a/dashboard/src/app/inbox/page.tsx
+++ b/dashboard/src/app/inbox/page.tsx
@@ -125,6 +125,17 @@ function SenderAvatar({ name, size = 40 }: { name: string; size?: number }) {
 function stripMarkdown(text: string): string {
   return text
     .replace(/^#{1,6}\s+/gm, "")
+    // Drop GFM table delimiter rows ("| --- | :--: |") entirely — they
+    // carry no content, only render as "|---|---|" noise in the preview.
+    .replace(/^\s*\|?[\s:|-]*-[\s:|-]*\|?\s*$/gm, "")
+    // Flatten remaining table rows: split cells on pipes, keep the text.
+    .replace(/^\s*\|(.+)\|\s*$/gm, (_, row: string) =>
+      row
+        .split("|")
+        .map((c) => c.trim())
+        .filter(Boolean)
+        .join(" · "),
+    )
     .replace(/\*\*(.+?)\*\*/g, "$1")
     .replace(/\*(.+?)\*/g, "$1")
     .replace(/^[-*]\s+/gm, "")
@@ -796,7 +807,24 @@ const filteredItems = items.filter((item) => {
                               </div>
                               {/* Row 2: preview snippet (Gmail-style, 1 line on mobile) */}
                               {plainPreview && (
-                                <div className="inbox-item-preview" style={{ fontSize: "var(--fs-s)", color: "var(--ink-2)", lineHeight: 1.4 }}>
+                                <div
+                                  className="inbox-item-preview"
+                                  style={{
+                                    fontSize: "var(--fs-s)",
+                                    color: "var(--ink-2)",
+                                    lineHeight: 1.4,
+                                    // Clamp to 2 lines with an ellipsis so the
+                                    // snippet never cuts off mid-word. The
+                                    // .inbox-item-preview class only clamps
+                                    // inside the mobile media query — desktop
+                                    // had no clamp at all.
+                                    display: "-webkit-box",
+                                    WebkitLineClamp: 2,
+                                    WebkitBoxOrient: "vertical",
+                                    overflow: "hidden",
+                                    overflowWrap: "anywhere",
+                                  }}
+                                >
                                   {plainPreview}
                                 </div>
                               )}

--- a/dashboard/src/app/settings/_components/ConfigFileCard.tsx
+++ b/dashboard/src/app/settings/_components/ConfigFileCard.tsx
@@ -48,12 +48,18 @@ export function ConfigFileCard({ path }: { path: string }) {
       </div>
       <div
         className="mono"
+        title={path}
         style={{
           fontSize: "var(--fs-xs)",
           color: "var(--fg-1)",
           marginTop: 6,
-          wordBreak: "break-all",
           lineHeight: 1.4,
+          // Truncate cleanly with an ellipsis rather than breaking the
+          // path mid-word ("config.jso\nn"). Full path stays available
+          // via the title tooltip and the Copy button below.
+          overflow: "hidden",
+          textOverflow: "ellipsis",
+          whiteSpace: "nowrap",
         }}
       >
         {path}

--- a/dashboard/src/components/patchwork/AreaChart.tsx
+++ b/dashboard/src/components/patchwork/AreaChart.tsx
@@ -71,9 +71,34 @@ export function AreaChart({
     })
     .join("; ");
 
-  const xTicks = (xLabels ?? [])
-    .map((lbl, i) => ({ lbl, i }))
-    .filter(({ lbl }) => lbl.length > 0);
+  // Build x-axis ticks, then drop any tick that would render too close
+  // to the previously kept one. Without this, the first-bucket label and
+  // an adjacent N-hour tick collided (e.g. "11:00" overlapping "12:00").
+  // The last tick ("now") always wins — it's right-anchored, so we keep
+  // it and instead drop the prior tick if they'd overlap.
+  const MIN_TICK_GAP_PCT = 9; // ~one HH:MM label width at typical chart sizes
+  const xTicks = (() => {
+    const candidates = (xLabels ?? [])
+      .map((lbl, i) => ({ lbl, i, pct: (i / Math.max(n - 1, 1)) * 100 }))
+      .filter(({ lbl }) => lbl.length > 0);
+    if (candidates.length <= 1) return candidates;
+    const lastIdx = candidates.length - 1;
+    const kept: typeof candidates = [];
+    for (let c = 0; c < candidates.length; c++) {
+      const cur = candidates[c];
+      const isLast = c === lastIdx;
+      const prev = kept[kept.length - 1];
+      if (!prev || cur.pct - prev.pct >= MIN_TICK_GAP_PCT) {
+        kept.push(cur);
+        continue;
+      }
+      // Too close to the previously kept tick. The right-anchored final
+      // tick takes priority — replace the prior tick with it.
+      if (isLast) kept[kept.length - 1] = cur;
+      // otherwise: drop the current tick.
+    }
+    return kept;
+  })();
 
   return (
     <figure


### PR DESCRIPTION
## Summary

UX-audit nits in the dashboard, fixed in one PR. Two of the five reported items were already correct in `main` and needed no change.

- **Login password masking** — verified: the login field already renders `type="password"`. No change.
- **Coming-soon connector Connect button** — verified: coming-soon connector cards (e.g. "Docs") already render no Connect button at all (`!isComingSoon` guard). No change.
- **Truncation (LOW)** — Settings "Config file" path used `word-break: break-all` (broke mid-word, no ellipsis) → now single-line ellipsis truncation with a `title` tooltip + the existing Copy button for the full value. Inbox preview snippets had no clamp on desktop (the `.inbox-item-preview` clamp lived only inside a mobile media query) → added an inline 2-line `-webkit-line-clamp` with ellipsis. `stripMarkdown` now flattens GFM table rows (drops delimiter rows, joins cells with `·`) so previews no longer show raw `|---|` pipe syntax. Tasks summary already line-clamps correctly — left as-is.
- **Redundant double empty-state on Approvals (MED)** — `/approvals` rendered both a "Queue — All clear" hero card and a separate "All caught up!" empty-state panel. The hero card is now suppressed when the queue is empty; the dedicated EmptyState is the single empty state.
- **Analytics chart axis collision (MED)** — the "Calls — last 24h" x-axis collided adjacent ticks ("11:00" overlapping "12:00"). `AreaChart` now applies a minimum pixel-gap dedup to x-axis ticks, keeping the right-anchored "now" tick when a conflict occurs.

Scoping: no edits to `globals.css`, `Shell.tsx`, or shared shell components (owned by a sibling PR).

## Test plan

- [ ] `/login` — password field is masked (`type="password"`)
- [ ] `/connections` — "Docs" (Coming Soon) card has no Connect button
- [ ] `/settings` — Config file path truncates with an ellipsis; tooltip + Copy button give the full path
- [ ] `/inbox` — preview snippets clamp to 2 lines with an ellipsis; markdown tables render as plain text, not raw `|` syntax
- [ ] `/approvals` (empty queue) — only one empty state ("All caught up!"), no "Queue — All clear" card
- [ ] `/analytics` — "Calls — last 24h" x-axis ticks no longer overlap

Note: `npx tsc --noEmit` and `next lint` pass clean for the changed files. Browser verification was limited because the running dev server is bound to a different worktree's source tree; defect states were confirmed live against `main`, fixes verified at the source level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)