### PR TITLE
fix(dashboard): abort upstream SSE fetch on client disconnect — stop leaking bridge subscribers

### DIFF
--- a/dashboard/src/app/api/bridge/[...path]/__tests__/route.test.ts
+++ b/dashboard/src/app/api/bridge/[...path]/__tests__/route.test.ts
@@ -142,6 +142,97 @@ describe("catch-all bridge proxy — SSE /stream non-OK passthrough", () => {
   });
 });
 
+describe("catch-all bridge proxy — SSE /stream aborts upstream on disconnect", () => {
+  const ctx = { params: Promise.resolve({ path: ["stream"] }) };
+
+  function makeStreamReqWithSignal(): {
+    req: NextRequest;
+    abortClient: () => void;
+  } {
+    const clientAbort = new AbortController();
+    const req = new Request("https://dashboard.local/api/bridge/stream", {
+      method: "GET",
+      headers: { "sec-fetch-site": "same-origin" },
+    });
+    Object.defineProperty(req, "nextUrl", {
+      value: { search: "" },
+      configurable: true,
+    });
+    // NextRequest exposes `.signal` that aborts when the client disconnects.
+    Object.defineProperty(req, "signal", {
+      value: clientAbort.signal,
+      configurable: true,
+    });
+    return {
+      req: req as unknown as NextRequest,
+      abortClient: () => clientAbort.abort(),
+    };
+  }
+
+  it("aborts the upstream bridge fetch when the response stream is cancelled", async () => {
+    mockFindBridge.mockReturnValueOnce({ authToken: "t", port: 9999 });
+    let upstreamSignal: AbortSignal | undefined;
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementationOnce(async (_url, init) => {
+        upstreamSignal = (init as RequestInit | undefined)?.signal ?? undefined;
+        // A body that never completes — mimics a held-open SSE connection.
+        return new Response(
+          new ReadableStream<Uint8Array>({
+            start() {
+              /* never enqueue, never close */
+            },
+          }),
+          { status: 200, headers: { "content-type": "text/event-stream" } },
+        );
+      });
+    try {
+      const { req } = makeStreamReqWithSignal();
+      const res = await GET(req, ctx);
+      expect(res.status).toBe(200);
+      // The upstream fetch must have been given an abort signal.
+      expect(upstreamSignal).toBeInstanceOf(AbortSignal);
+      expect(upstreamSignal?.aborted).toBe(false);
+      // Simulate the browser closing its EventSource: Next.js cancels the
+      // response stream. This must abort the upstream fetch so the bridge
+      // sees the socket close and decrements its subscriber count.
+      await res.body?.cancel();
+      expect(upstreamSignal?.aborted).toBe(true);
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it("aborts the upstream bridge fetch when the incoming request is aborted", async () => {
+    mockFindBridge.mockReturnValueOnce({ authToken: "t", port: 9999 });
+    let upstreamSignal: AbortSignal | undefined;
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementationOnce(async (_url, init) => {
+        upstreamSignal = (init as RequestInit | undefined)?.signal ?? undefined;
+        return new Response(
+          new ReadableStream<Uint8Array>({
+            start() {
+              /* never enqueue, never close */
+            },
+          }),
+          { status: 200, headers: { "content-type": "text/event-stream" } },
+        );
+      });
+    try {
+      const { req, abortClient } = makeStreamReqWithSignal();
+      const res = await GET(req, ctx);
+      expect(res.status).toBe(200);
+      expect(upstreamSignal?.aborted).toBe(false);
+      // Client disconnects (tab close / navigation) → req.signal aborts.
+      abortClient();
+      expect(upstreamSignal?.aborted).toBe(true);
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+});
+
 describe("catch-all bridge proxy — error body does not leak internals", () => {
   const ctx = { params: Promise.resolve({ path: ["some", "path"] }) };
 

--- a/dashboard/src/app/api/bridge/[...path]/route.ts
+++ b/dashboard/src/app/api/bridge/[...path]/route.ts
@@ -31,10 +31,29 @@ async function proxy(req: NextRequest, segments: string[]): Promise<Response> {
         { status: 503 },
       );
     }
+    // Abort the upstream bridge fetch when the browser disconnects.
+    // Without this, closing an EventSource (tab close, page reload,
+    // navigation) cancels the downstream response but leaves the upstream
+    // fetch reader looping forever. The bridge keeps the subscriber
+    // registered, its 15s keep-alive ping keeps succeeding into the
+    // orphaned proxy socket, and its cleanup() never runs — every reload
+    // leaks one subscriber until the bridge's 20-cap saturates and
+    // /stream returns 503 forever (kill-switch + activity ticker die).
+    const upstreamAbort = new AbortController();
+    const abortUpstream = () => {
+      if (!upstreamAbort.signal.aborted) upstreamAbort.abort();
+    };
+    // Propagate client disconnect: req.signal aborts when the browser
+    // goes away. If it's already aborted, abort the upstream immediately.
+    if (req.signal) {
+      if (req.signal.aborted) abortUpstream();
+      else req.signal.addEventListener("abort", abortUpstream, { once: true });
+    }
     let upstream: Response;
     try {
       upstream = await fetch(resolveBridgeUrl(lock, target), {
         headers: { Authorization: `Bearer ${lock.authToken}` },
+        signal: upstreamAbort.signal,
       });
     } catch (err) {
       console.error("[dashboard /api/bridge] upstream fetch failed:", err);
@@ -66,6 +85,7 @@ async function proxy(req: NextRequest, segments: string[]): Promise<Response> {
     // immediately. Without this, the browser's EventSource.onopen never fires
     // until the first real event arrives (the bridge holds /stream idle).
     const encoder = new TextEncoder();
+    let upstreamReader: ReadableStreamDefaultReader<Uint8Array> | undefined;
     const out = new ReadableStream({
       async start(controller) {
         controller.enqueue(encoder.encode(": connected\n\n"));
@@ -74,6 +94,7 @@ async function proxy(req: NextRequest, segments: string[]): Promise<Response> {
           controller.close();
           return;
         }
+        upstreamReader = reader;
         try {
           while (true) {
             const { done, value } = await reader.read();
@@ -85,6 +106,14 @@ async function proxy(req: NextRequest, segments: string[]): Promise<Response> {
         } finally {
           controller.close();
         }
+      },
+      // Fires when the downstream consumer goes away (Next.js cancels the
+      // response when the browser closes the connection). Abort the
+      // upstream fetch and cancel its reader so the bridge sees the socket
+      // close and runs cleanup() — decrementing sseSubscriberCount.
+      cancel() {
+        abortUpstream();
+        upstreamReader?.cancel().catch(() => {});
       },
     });
     return new Response(out, {

--- a/src/__tests__/stream.test.ts
+++ b/src/__tests__/stream.test.ts
@@ -120,6 +120,44 @@ describe("GET /stream SSE endpoint", () => {
     expect(body).toContain('"kind":"lifecycle"');
   });
 
+  it("decrements subscriber count back to 0 after client disconnect", async () => {
+    expect(server.sseSubscribers_count).toBe(0);
+    const { status, close } = await sseGet(port, TEST_TOKEN);
+    expect(status).toBe(200);
+    // Wait for the connection to fully register.
+    await new Promise((r) => setTimeout(r, 20));
+    expect(server.sseSubscribers_count).toBe(1);
+
+    // Simulate the browser closing its EventSource.
+    close();
+    // Give the server's req.close handler time to run cleanup().
+    await new Promise((r) => setTimeout(r, 50));
+    expect(server.sseSubscribers_count).toBe(0);
+  });
+
+  it("evicts the oldest subscriber when a new one arrives at the cap", async () => {
+    // Open MAX_SSE_SUBSCRIBERS (20) connections to saturate the cap.
+    const conns: Array<{ status: number; close: () => void }> = [];
+    for (let i = 0; i < 20; i++) {
+      conns.push(await sseGet(port, TEST_TOKEN));
+    }
+    await new Promise((r) => setTimeout(r, 30));
+    expect(server.sseSubscribers_count).toBe(20);
+
+    // A 21st request must NOT 503 — the oldest subscriber is evicted and
+    // the new one takes its slot. Pre-fix this returned 503 forever.
+    const extra = await sseGet(port, TEST_TOKEN);
+    expect(extra.status).toBe(200);
+    await new Promise((r) => setTimeout(r, 30));
+    // Still capped at 20 (one evicted, one added).
+    expect(server.sseSubscribers_count).toBe(20);
+
+    for (const c of conns) c.close();
+    extra.close();
+    await new Promise((r) => setTimeout(r, 50));
+    expect(server.sseSubscribers_count).toBe(0);
+  });
+
   it("multiple subscribers receive independent event streams", async () => {
     const { chunks: chunks1, close: close1 } = await sseGet(port, TEST_TOKEN);
     const { chunks: chunks2, close: close2 } = await sseGet(port, TEST_TOKEN);

--- a/src/server.ts
+++ b/src/server.ts
@@ -127,12 +127,29 @@ export class Server extends EventEmitter<ServerEvents> {
   private oauthServer: OAuthServer | null = null;
   private oauthIssuerUrl: string | null = null;
   private sseSubscriberCount = 0;
+  /**
+   * Registered SSE subscribers on `/stream`, oldest-first by insertion
+   * order. Used as a defense-in-depth backstop: if a subscriber's peer is
+   * a dead-but-not-erroring socket (e.g. an orphaned proxy connection),
+   * the ping-write cleanup can fail to fire and the subscriber leaks. To
+   * guarantee a leak can never *permanently* brick `/stream`, a new
+   * request arriving at the cap evicts the oldest subscriber instead of
+   * returning 503 — mirroring the HTTP-session eviction in ADR-0005.
+   * The real cure for the known leak is the dashboard proxy aborting its
+   * upstream fetch on client disconnect; this is the backstop.
+   */
+  private sseSubscribers = new Set<{ close: () => void }>();
   /** Cache for CC permission rules (30s TTL) to avoid filesystem walks on each dashboard poll */
   private _explainRulesCache: {
     at: number;
     rules: AttributedPermissionRules;
   } | null = null;
   private static readonly MAX_SSE_SUBSCRIBERS = 20;
+
+  /** Number of currently-registered `/stream` SSE subscribers. Read-only. */
+  public get sseSubscribers_count(): number {
+    return this.sseSubscriberCount;
+  }
 
   /** Set by bridge to provide health data */
   public healthDataFn: (() => Record<string, unknown>) | null = null;
@@ -1081,6 +1098,17 @@ export class Server extends EventEmitter<ServerEvents> {
         return;
       }
       if (req.url === "/stream" && req.method === "GET") {
+        // Backstop (ADR-0005 pattern): at the cap, evict the oldest
+        // subscriber rather than returning 503 forever. A leaked
+        // subscriber whose socket is dead-but-not-erroring can otherwise
+        // permanently brick /stream. The dashboard proxy abort-on-disconnect
+        // fix is the real cure; this guarantees recovery either way.
+        if (this.sseSubscriberCount >= Server.MAX_SSE_SUBSCRIBERS) {
+          const oldest = this.sseSubscribers.values().next().value;
+          if (oldest) oldest.close();
+        }
+        // If eviction somehow didn't free a slot (no registered
+        // subscribers but counter still pinned), fail closed with 503.
         if (this.sseSubscriberCount >= Server.MAX_SSE_SUBSCRIBERS) {
           res.writeHead(503, { "Content-Type": "application/json" });
           res.end(
@@ -1110,13 +1138,23 @@ export class Server extends EventEmitter<ServerEvents> {
         let cleanedUp = false;
         let pingHandle: ReturnType<typeof setInterval> | null = null;
         let unsub: () => void = () => {};
+        const subscriber = { close: () => {} };
         const cleanup = () => {
           if (cleanedUp) return;
           cleanedUp = true;
           this.sseSubscriberCount--;
+          this.sseSubscribers.delete(subscriber);
           if (pingHandle) clearInterval(pingHandle);
           unsub();
         };
+        // Eviction path: tear down state AND destroy the socket so the
+        // peer (and any orphaned proxy in between) observes the close.
+        subscriber.close = () => {
+          cleanup();
+          res.end();
+          res.socket?.destroy();
+        };
+        this.sseSubscribers.add(subscriber);
 
         unsub =
           this.streamFn?.((kind, entry) => {

--- a/src/server.ts
+++ b/src/server.ts
@@ -138,7 +138,7 @@ export class Server extends EventEmitter<ServerEvents> {
    * The real cure for the known leak is the dashboard proxy aborting its
    * upstream fetch on client disconnect; this is the backstop.
    */
-  private sseSubscribers = new Set<{ close: () => void }>();
+  private sseSubscribers = new Set<() => void>();
   /** Cache for CC permission rules (30s TTL) to avoid filesystem walks on each dashboard poll */
   private _explainRulesCache: {
     at: number;
@@ -1103,18 +1103,13 @@ export class Server extends EventEmitter<ServerEvents> {
         // subscriber whose socket is dead-but-not-erroring can otherwise
         // permanently brick /stream. The dashboard proxy abort-on-disconnect
         // fix is the real cure; this guarantees recovery either way.
+        // sseSubscriberCount and sseSubscribers.size stay in lockstep
+        // (both mutated together below + in cleanup()), so when the
+        // counter is at the cap there is always an evictable subscriber —
+        // eviction always frees the slot.
         if (this.sseSubscriberCount >= Server.MAX_SSE_SUBSCRIBERS) {
           const oldest = this.sseSubscribers.values().next().value;
-          if (oldest) oldest.close();
-        }
-        // If eviction somehow didn't free a slot (no registered
-        // subscribers but counter still pinned), fail closed with 503.
-        if (this.sseSubscriberCount >= Server.MAX_SSE_SUBSCRIBERS) {
-          res.writeHead(503, { "Content-Type": "application/json" });
-          res.end(
-            JSON.stringify({ error: "Too many SSE subscribers (max 20)" }),
-          );
-          return;
+          oldest?.();
         }
         this.sseSubscriberCount++;
         // Disable socket timeout — SSE connections are long-lived by design
@@ -1138,23 +1133,22 @@ export class Server extends EventEmitter<ServerEvents> {
         let cleanedUp = false;
         let pingHandle: ReturnType<typeof setInterval> | null = null;
         let unsub: () => void = () => {};
-        const subscriber = { close: () => {} };
+        // Single teardown closure, also stored directly in the registry
+        // as this subscriber's eviction handler — it tears down state AND
+        // destroys the socket so the peer (and any orphaned proxy in
+        // between) observes the close. It removes this exact function
+        // from the Set, so no placeholder/no-op function is ever created.
         const cleanup = () => {
           if (cleanedUp) return;
           cleanedUp = true;
           this.sseSubscriberCount--;
-          this.sseSubscribers.delete(subscriber);
+          this.sseSubscribers.delete(cleanup);
           if (pingHandle) clearInterval(pingHandle);
           unsub();
-        };
-        // Eviction path: tear down state AND destroy the socket so the
-        // peer (and any orphaned proxy in between) observes the close.
-        subscriber.close = () => {
-          cleanup();
           res.end();
           res.socket?.destroy();
         };
-        this.sseSubscribers.add(subscriber);
+        this.sseSubscribers.add(cleanup);
 
         unsub =
           this.streamFn?.((kind, entry) => {


### PR DESCRIPTION
## Summary

The bridge's SSE `/stream` endpoint was saturating its 20-subscriber cap and then returning `503` forever, killing the dashboard's live activity ticker and kill-switch UI.

**Root cause:** The dashboard SSE proxy (`dashboard/src/app/api/bridge/[...path]/route.ts`, the `if (segments[0] === "stream")` branch) called `fetch()` to the bridge with **no abort signal**, and the wrapper `ReadableStream` had **no `cancel()` method**. When the browser closed its `EventSource` (tab close, page reload, navigation), Next.js cancelled the downstream response stream — but nothing aborted the upstream `fetch` to the bridge. The upstream reader loop kept `await reader.read()`-ing, the bridge kept the subscriber registered, and the bridge's 15s keep-alive ping `res.write()` kept succeeding (writing into the now-orphaned proxy connection), so the bridge's `cleanup()` never ran. Every dev reload / extra tab leaked one subscriber until `sseSubscriberCount` hit `MAX_SSE_SUBSCRIBERS` (20) and `/stream` returned `503` permanently.

### Primary fix — dashboard proxy (the real cure)
- Create an `AbortController` and pass its `.signal` to the upstream `fetch(...)`.
- Propagate the incoming request's cancellation: forward `req.signal` so the upstream aborts when the client disconnects (abort immediately if already aborted).
- Add a `cancel()` method to the wrapper `ReadableStream` that aborts the controller and cancels the upstream reader — fires when the downstream consumer goes away.

When the browser disconnects, the upstream bridge fetch is now aborted, the bridge sees the socket close, and `cleanup()` decrements `sseSubscriberCount`.

### Backstop — bridge defense-in-depth (`src/server.ts`)
Following the HTTP-session eviction pattern in **ADR-0005**: `/stream` subscribers are now tracked in an insertion-ordered `Set`. When a new request arrives at the cap, the **oldest subscriber is evicted** (its socket closed) instead of returning `503`. This guarantees a dead-but-not-erroring peer can never *permanently* brick the endpoint. The proxy fix is the cure; this is the safety net.

## Test plan

- [x] Dashboard: new tests in `route.test.ts` assert the upstream `fetch` receives an `AbortSignal`, and that it aborts both when the response stream's `cancel()` is called and when the incoming request is aborted. Both **failed before the fix, pass after**.
- [x] Bridge: new test in `stream.test.ts` asserts a 21st `/stream` request at the cap gets `200` (oldest evicted) instead of `503`. **Failed before the eviction backstop, passes after.**
- [x] `npm run build` + `npx tsc -p tsconfig.tests.core.json --noEmit` — clean.
- [x] `cd dashboard && npx tsc --noEmit` — clean.
- [x] `npx vitest run src/__tests__/stream.test.ts` — 7/7 pass.
- [x] `cd dashboard && npx vitest run src/app/api/bridge` — 29/29 pass.

Note: 5 unrelated bridge test files (`shim-*`, `recipe-cli.integration`) fail in this worktree because the `tsx` binary is absent from `node_modules/.bin` — a pre-existing environment gap, unrelated to this change (none touch SSE).

🤖 Generated with [Claude Code](https://claude.com/claude-code)