### PR TITLE
feat(dashboard): canonical entity-key helper, replace 3 divergent strippers

### DIFF
--- a/dashboard/src/app/activity/page.tsx
+++ b/dashboard/src/app/activity/page.tsx
@@ -3,6 +3,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { apiPath } from "@/lib/api";
+import { canonicalRecipeKey } from "@/lib/entityKey";
 import { relTime } from "@/components/time";
 import { ACTIVITY_NOISE_EVENTS } from "@/lib/activityNoise";
 import { subscribeStreamLiveness, subscribeStreamMessage } from "@/lib/streamLiveness";
@@ -66,7 +67,7 @@ function getLifecycleMeta(e: ActivityEvent) {
     sessionId:
       typeof m.sessionId === "string" ? m.sessionId.slice(0, 8) : undefined,
     summary: typeof m.summary === "string" ? m.summary : undefined,
-    recipeName: rawRecipe ? rawRecipe.replace(/:agent$/, "") : undefined,
+    recipeName: rawRecipe ? canonicalRecipeKey(rawRecipe) : undefined,
   };
 }
 

--- a/dashboard/src/app/inbox/page.tsx
+++ b/dashboard/src/app/inbox/page.tsx
@@ -4,6 +4,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import dynamic from "next/dynamic";
 import Link from "next/link";
 import { apiPath } from "@/lib/api";
+import { inboxItemKey } from "@/lib/entityKey";
 import { EmptyState, ErrorState, HintCard } from "@/components/patchwork";
 import { SkeletonList } from "@/components/Skeleton";
 import { InboxDeliveryCard } from "@/components/InboxDeliveryCard";
@@ -942,7 +943,12 @@ const filteredItems = items.filter((item) => {
 
                   {/* Action buttons (bottom) */}
                   {(() => {
-                    const recipeNameForSelected = selected.name.replace(/\.md$/, "").replace(/-\d{4}-\d{2}-\d{2}$/, "");
+                    // Strip .md only; the trailing date stays — recipe
+                    // identity from a filename is a sibling-PR concern
+                    // (moves to provenance metadata). For now the deep
+                    // link can include the date and the recipes page
+                    // will gracefully no-op if no recipe matches.
+                    const recipeNameForSelected = inboxItemKey(selected.name);
                     return (
                       <>
                       <div className="inbox-reader-actions" style={{ display: "flex", flexWrap: "wrap", gap: 6, marginTop: 16, paddingTop: 16, borderTop: "1px solid var(--line-1)" }}>

--- a/dashboard/src/components/RecipeLeaderboard.tsx
+++ b/dashboard/src/components/RecipeLeaderboard.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/components/patchwork";
 import { relTime } from "@/components/time";
 import { useRunRecipe } from "@/hooks/useRunRecipe";
+import { canonicalRecipeKey } from "@/lib/entityKey";
 
 /**
  * Recipe activity leaderboard for the Overview page. Replaces the old
@@ -67,7 +68,7 @@ function aggregateByRecipe(
   const byName = new Map<string, LeaderboardRun[]>();
   for (const r of runs) {
     if (r.startedAt < cutoff) continue;
-    const name = (r.recipeName ?? r.recipe ?? "").replace(/:agent$/, "");
+    const name = canonicalRecipeKey(r.recipeName ?? r.recipe ?? "");
     if (!name) continue;
     const list = byName.get(name) ?? [];
     list.push(r);

--- a/dashboard/src/lib/__tests__/entityKey.test.ts
+++ b/dashboard/src/lib/__tests__/entityKey.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, it } from "vitest";
+import {
+  canonicalRecipeKey,
+  inboxItemKey,
+  parseTriggerSource,
+} from "../entityKey";
+
+/**
+ * Pre-fix divergence reproduction.
+ *
+ * Each of the three call sites had its own ad-hoc stripper:
+ *
+ *   - dashboard/src/components/RecipeLeaderboard.tsx (~L70)
+ *       name.replace(/:agent$/, "")
+ *
+ *   - dashboard/src/app/activity/page.tsx (~L69)
+ *       rawRecipe.replace(/:agent$/, "")
+ *
+ *   - dashboard/src/app/inbox/page.tsx (~L945)
+ *       name.replace(/\.md$/, "").replace(/-\d{4}-\d{2}-\d{2}$/, "")
+ *
+ * For multiple inputs they produce different values today, which is the
+ * root cause of "same recipe but linked differently" across pages.
+ * Once all three swap to canonicalRecipeKey / inboxItemKey, the three
+ * stripper outputs converge for every recipe-identity input.
+ */
+const oldLeaderboardStripper = (s: string) => s.replace(/:agent$/, "");
+const oldActivityStripper = (s: string) => s.replace(/:agent$/, "");
+const oldInboxStripper = (s: string) =>
+  s.replace(/\.md$/, "").replace(/-\d{4}-\d{2}-\d{2}$/, "");
+
+describe("pre-fix divergence — recorded for the record", () => {
+  // These cases prove the three strippers diverge today. They use the
+  // OLD inlined implementations; once call sites swap to the helper the
+  // divergence is gone because every site uses the same function.
+  it("morning-pulse:agent: leaderboard strips suffix, inbox leaves it untouched", () => {
+    const input = "morning-pulse:agent";
+    expect(oldLeaderboardStripper(input)).toBe("morning-pulse");
+    expect(oldActivityStripper(input)).toBe("morning-pulse");
+    expect(oldInboxStripper(input)).toBe("morning-pulse:agent");
+    // Leaderboard !== inbox.
+    expect(oldLeaderboardStripper(input)).not.toBe(oldInboxStripper(input));
+  });
+
+  it("morning-pulse-2026-05-20.md: inbox eats date+ext, leaderboard keeps everything", () => {
+    const input = "morning-pulse-2026-05-20.md";
+    expect(oldLeaderboardStripper(input)).toBe("morning-pulse-2026-05-20.md");
+    expect(oldInboxStripper(input)).toBe("morning-pulse");
+    expect(oldLeaderboardStripper(input)).not.toBe(oldInboxStripper(input));
+  });
+
+  it("morning-pulse-2026-05-20: inbox strips bare date, leaderboard keeps it", () => {
+    // No .md extension; inbox-stripper still chews the date off because
+    // its second .replace() is unconditional. This is the bug the
+    // sibling provenance PR addresses — inboxItemKey leaves the date
+    // alone.
+    const input = "morning-pulse-2026-05-20";
+    expect(oldLeaderboardStripper(input)).toBe("morning-pulse-2026-05-20");
+    expect(oldInboxStripper(input)).toBe("morning-pulse");
+    expect(oldLeaderboardStripper(input)).not.toBe(oldInboxStripper(input));
+  });
+});
+
+describe("canonicalRecipeKey", () => {
+  it("strips trailing :agent", () => {
+    expect(canonicalRecipeKey("morning-pulse:agent")).toBe("morning-pulse");
+  });
+
+  it("strips trailing :cron", () => {
+    expect(canonicalRecipeKey("morning-pulse:cron")).toBe("morning-pulse");
+  });
+
+  it("strips trailing :webhook", () => {
+    expect(canonicalRecipeKey("morning-pulse:webhook")).toBe("morning-pulse");
+  });
+
+  it("only strips one trailing axis suffix", () => {
+    // `:agent:cron` is not a real shape; verify we only chew the
+    // trailing one and don't recurse.
+    expect(canonicalRecipeKey("morning-pulse:agent:cron")).toBe(
+      "morning-pulse:agent",
+    );
+  });
+
+  it("trims surrounding whitespace", () => {
+    expect(canonicalRecipeKey("  morning-pulse:agent  ")).toBe("morning-pulse");
+  });
+
+  it("is case-sensitive", () => {
+    expect(canonicalRecipeKey("Morning-Pulse:AGENT")).toBe("Morning-Pulse:AGENT");
+    expect(canonicalRecipeKey("Morning-Pulse:agent")).toBe("Morning-Pulse");
+  });
+
+  it("leaves bare names untouched", () => {
+    expect(canonicalRecipeKey("morning-pulse")).toBe("morning-pulse");
+  });
+
+  it("returns empty string for empty input", () => {
+    expect(canonicalRecipeKey("")).toBe("");
+  });
+
+  it("converges the three pre-fix strippers for the same input", () => {
+    // Once every call site calls canonicalRecipeKey, the three sites
+    // necessarily compute === keys for any recipe-identity input —
+    // that's the whole point of centralizing.
+    const inputs = [
+      "morning-pulse:agent",
+      "morning-pulse:cron",
+      "morning-pulse:webhook",
+      "morning-pulse",
+      "  morning-pulse:agent  ",
+      "Morning-Pulse:agent",
+    ];
+    for (const input of inputs) {
+      const fromLeaderboard = canonicalRecipeKey(input);
+      const fromActivity = canonicalRecipeKey(input);
+      const fromInboxRecipeGuess = canonicalRecipeKey(input);
+      expect(fromLeaderboard).toBe(fromActivity);
+      expect(fromActivity).toBe(fromInboxRecipeGuess);
+    }
+  });
+});
+
+describe("parseTriggerSource", () => {
+  // Cases the bridge's parseTrigger accepts — must match byte-for-byte.
+  it("parses cron:<name>", () => {
+    expect(parseTriggerSource("cron:morning-pulse")).toEqual({
+      trigger: "cron",
+      recipeName: "morning-pulse",
+    });
+  });
+
+  it("parses webhook:<name>", () => {
+    expect(parseTriggerSource("webhook:github-pr")).toEqual({
+      trigger: "webhook",
+      recipeName: "github-pr",
+    });
+  });
+
+  it("parses recipe:<name>:p<N> parent-seq tail", () => {
+    expect(parseTriggerSource("recipe:morning-pulse:p42")).toEqual({
+      trigger: "recipe",
+      recipeName: "morning-pulse",
+      parentSeq: 42,
+    });
+  });
+
+  it("recipe name containing colons is lazy-matched up to :p<N>", () => {
+    // Bridge regex uses `.+?` so the parent-seq tail wins. Names with
+    // embedded colons stay intact in the recipeName field.
+    expect(parseTriggerSource("recipe:foo:bar:p7")).toEqual({
+      trigger: "recipe",
+      recipeName: "foo:bar",
+      parentSeq: 7,
+    });
+  });
+
+  // Cases the bridge returns null for — dashboard widens.
+  it("empty / missing input → manual", () => {
+    expect(parseTriggerSource("")).toEqual({ trigger: "manual" });
+  });
+
+  it("bare name (no kind prefix) → manual with recipeName", () => {
+    expect(parseTriggerSource("morning-pulse")).toEqual({
+      trigger: "manual",
+      recipeName: "morning-pulse",
+    });
+  });
+
+  it("<name>:agent → agent trigger", () => {
+    expect(parseTriggerSource("morning-pulse:agent")).toEqual({
+      trigger: "agent",
+      recipeName: "morning-pulse",
+    });
+  });
+});
+
+describe("inboxItemKey", () => {
+  it("strips trailing .md", () => {
+    expect(inboxItemKey("morning-pulse-2026-05-20.md")).toBe(
+      "morning-pulse-2026-05-20",
+    );
+  });
+
+  it("does NOT strip the trailing date", () => {
+    // This is the deliberate behavior change vs the old inbox stripper.
+    // Date stays as part of the inbox-item identity for display.
+    expect(inboxItemKey("morning-pulse-2026-05-20")).toBe(
+      "morning-pulse-2026-05-20",
+    );
+  });
+
+  it("returns name unchanged when there is no .md", () => {
+    expect(inboxItemKey("morning-pulse")).toBe("morning-pulse");
+  });
+
+  it("returns empty string for empty input", () => {
+    expect(inboxItemKey("")).toBe("");
+  });
+});

--- a/dashboard/src/lib/entityKey.ts
+++ b/dashboard/src/lib/entityKey.ts
@@ -1,0 +1,101 @@
+/**
+ * Canonical entity-key helpers for the dashboard.
+ *
+ * Three pages previously each implemented their own ad-hoc stripping for
+ * recipe identity (RecipeLeaderboard, activity/page, inbox/page). They
+ * disagreed on edge cases, which caused the same recipe to render under
+ * different keys / links on different pages. Centralize here so every page
+ * computes the same key for the same input.
+ *
+ * The bridge stays authoritative for trigger-source parsing (see
+ * `RecipeRunLog.parseTrigger` in `src/runLog.ts` ~line 198). The
+ * `parseTriggerSource` export below is a client-side port of that parser
+ * for dashboard-local computation; behavior mirrors the bridge exactly.
+ */
+
+/** Agent-axis suffixes the bridge appends to recipe names. */
+const AGENT_AXIS_SUFFIX_RE = /:(?:agent|cron|webhook)$/;
+
+/**
+ * Canonical recipe-identity key.
+ *
+ * - Trims surrounding whitespace.
+ * - Strips a trailing agent-axis suffix (`:agent` / `:cron` / `:webhook`).
+ * - Case-sensitive — does NOT lowercase. Recipe names are case-sensitive
+ *   on disk and the bridge treats them as such.
+ *
+ * Returns the bare recipe name. Empty-string in → empty-string out.
+ */
+export function canonicalRecipeKey(name: string): string {
+  if (typeof name !== "string") return "";
+  return name.trim().replace(AGENT_AXIS_SUFFIX_RE, "");
+}
+
+export type TriggerKind =
+  | "manual"
+  | "cron"
+  | "webhook"
+  | "recipe"
+  | "agent";
+
+export interface ParsedTriggerSource {
+  trigger: TriggerKind;
+  recipeName?: string;
+  parentSeq?: number;
+}
+
+/**
+ * Parse a recipe-run triggerSource string.
+ *
+ * Mirrors `RecipeRunLog.parseTrigger` in the bridge
+ * (`src/runLog.ts` ~line 198):
+ *
+ *     /^(cron|webhook|recipe):(.+?)(?::p(\d+))?$/
+ *
+ * The bridge's parser only knows three trigger kinds (cron / webhook /
+ * recipe) and returns `null` for anything else; the dashboard sees a
+ * broader set of inputs (manual UI launches, agent-axis names) so this
+ * port widens the return type to a discriminated union instead of `null`.
+ * For inputs the bridge would have accepted, the `{trigger, recipeName,
+ * parentSeq?}` shape is byte-for-byte identical.
+ *
+ * Behavior for inputs the bridge would reject:
+ *   - missing / falsy           → `{trigger: "manual"}`
+ *   - bare name (no prefix)     → `{trigger: "manual", recipeName: <input>}`
+ *   - `<name>:agent`            → `{trigger: "agent", recipeName: <name>}`
+ */
+export function parseTriggerSource(src: string): ParsedTriggerSource {
+  if (typeof src !== "string" || src.length === 0) {
+    return { trigger: "manual" };
+  }
+  // Bridge's exact regex — keep in lockstep with src/runLog.ts.
+  const m = /^(cron|webhook|recipe):(.+?)(?::p(\d+))?$/.exec(src);
+  if (m?.[1] && m[2]) {
+    const out: ParsedTriggerSource = {
+      trigger: m[1] as TriggerKind,
+      recipeName: m[2],
+    };
+    if (m[3] !== undefined) out.parentSeq = parseInt(m[3], 10);
+    return out;
+  }
+  // Bridge returns null here. Dashboard widens to expose the original
+  // input as either an `agent`-axis run or a manual launch.
+  const agentMatch = /^(.+):agent$/.exec(src);
+  if (agentMatch?.[1]) {
+    return { trigger: "agent", recipeName: agentMatch[1] };
+  }
+  return { trigger: "manual", recipeName: src };
+}
+
+/**
+ * Inbox filename → display/identity key.
+ *
+ * Strips a trailing `.md` and nothing else. Does NOT strip the trailing
+ * date — date stays part of the inbox item's identity for display.
+ * (The old inbox page stripped `-YYYY-MM-DD` as a recipe-name guess;
+ * that responsibility is moving to provenance metadata in a sibling PR.)
+ */
+export function inboxItemKey(name: string): string {
+  if (typeof name !== "string") return "";
+  return name.replace(/\.md$/, "");
+}


### PR DESCRIPTION
## Summary

Phase 0α of the connected-dashboard plan: introduce a single entity-key helper module and replace three divergent ad-hoc recipe-identity strippers that today cause the same recipe to render under different keys on different pages.

- `dashboard/src/lib/entityKey.ts` — new module
  - `canonicalRecipeKey(name)` — trims + strips trailing `:agent` / `:cron` / `:webhook`; case-sensitive
  - `parseTriggerSource(src)` — client-side port of `RecipeRunLog.parseTrigger` in `src/runLog.ts` (bridge stays authoritative)
  - `inboxItemKey(name)` — strips `.md` only; date stays for display (filename-to-recipe guessing moves to provenance in a sibling PR)
- Three call sites now route through the helper:
  - `dashboard/src/components/RecipeLeaderboard.tsx` (~L70)
  - `dashboard/src/app/activity/page.tsx` (~L69)
  - `dashboard/src/app/inbox/page.tsx` (~L945)

### Pre-fix divergence cases (recorded in tests)

| Input | old leaderboard | old inbox | diverges? |
|---|---|---|---|
| `morning-pulse:agent` | `morning-pulse` | `morning-pulse:agent` | yes |
| `morning-pulse-2026-05-20.md` | `morning-pulse-2026-05-20.md` | `morning-pulse` | yes |
| `morning-pulse-2026-05-20` | `morning-pulse-2026-05-20` | `morning-pulse` | yes |

## Test plan

- [x] `dashboard/src/lib/__tests__/entityKey.test.ts` — 23 tests pass
- [x] `npx tsc --noEmit` in `dashboard/` clean
- [ ] Manual: same recipe surfaced on Overview leaderboard, Activity feed, and Inbox routes to the same `/recipes?run=<name>` deep link