### PR TITLE
ci(canary): switch to npm trusted publishing (OIDC)

### DIFF
--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -19,6 +19,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write  # required for npm trusted publishing (OIDC)
 
 jobs:
   publish-canary:
@@ -40,6 +41,10 @@ jobs:
           node-version: '20'
           cache: npm
           registry-url: 'https://registry.npmjs.org'
+
+      # Trusted publishing (OIDC) requires npm >= 11.5.1. Node 20 ships with npm 10.x.
+      - name: Upgrade npm for trusted publishing
+        run: npm install -g npm@latest
 
       - run: npm ci
       - run: npm run build
@@ -78,8 +83,6 @@ jobs:
       - name: Publish canary to npm
         if: steps.npm_check.outputs.skip != 'true'
         run: npm publish --access public --tag canary
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Summary
         if: always()


### PR DESCRIPTION
## Summary

- Add `id-token: write` permission for OIDC token issuance
- Upgrade npm to >=11.5.1 (Node 20 ships npm 10.x; trusted publishing needs 11.5.1+)
- Drop `NODE_AUTH_TOKEN` / `NPM_TOKEN` dependency for canary

## Why

Canary fires on every main merge. When `NPM_TOKEN` expired/scope-narrowed, ~32 consecutive canary publishes silently failed → red checks on every merge → Glama maintenance score docked, listing page shows failing CI.

Trusted publishing removes the rotation footgun entirely for the noisy path. Stable releases (\`publish-npm.yml\`) keep \`NPM_TOKEN\` for now — those are rare + human-watched, so rotate-on-failure is acceptable; npm has multi-publisher UI on the roadmap so we can switch later without restructuring.

## Prereqs (already done)

Trusted publisher added on npmjs.com for \`patchwork-os\` → \`publish-canary.yml\`.

## Test plan

- [ ] Merge → next CI success → canary workflow runs
- [ ] Verify run publishes successfully (no NPM_TOKEN in env)
- [ ] Confirm \`npm view patchwork-os@canary\` advances