### PR TITLE
feat(bridge): inbox provenance + run→inbox + approval→run linkage data model

### DIFF
--- a/src/__tests__/inboxRoutes-provenance.test.ts
+++ b/src/__tests__/inboxRoutes-provenance.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Phase 0β — inbox provenance + `#`-line-strip bug fix.
+ *
+ * Two concerns:
+ *   1. Files written with YAML frontmatter (by yamlRunner v Phase 0β+)
+ *      should be parsed into a `provenance` field on both list and
+ *      single-item endpoints. Files without frontmatter degrade
+ *      gracefully (provenance: undefined).
+ *   2. The pre-existing `#`-line-strip on the list endpoint eats ANY
+ *      `#`-prefixed line, which strips heading lines from the file's
+ *      body AND would silently corrupt frontmatter delimiters / values
+ *      if `#` happened to lead a line. Fix: only strip headings AFTER
+ *      the frontmatter block is consumed.
+ */
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { tryHandleInboxRoute } from "../inboxRoutes.js";
+
+let fakeHome = "";
+let realHome: string | undefined;
+let realUserProfile: string | undefined;
+
+beforeEach(() => {
+  fakeHome = mkdtempSync(path.join(os.tmpdir(), "inbox-prov-"));
+  realHome = process.env.HOME;
+  realUserProfile = process.env.USERPROFILE;
+  process.env.HOME = fakeHome;
+  process.env.USERPROFILE = fakeHome;
+  mkdirSync(path.join(fakeHome, ".patchwork", "inbox"), { recursive: true });
+});
+
+afterEach(() => {
+  if (realHome === undefined) delete process.env.HOME;
+  else process.env.HOME = realHome;
+  if (realUserProfile === undefined) delete process.env.USERPROFILE;
+  else process.env.USERPROFILE = realUserProfile;
+  if (fakeHome && existsSync(fakeHome)) {
+    rmSync(fakeHome, { recursive: true, force: true });
+  }
+});
+
+type Captured = { status: number; body: string };
+function captureResponse(): { res: ServerResponse; result: Captured } {
+  const result: Captured = { status: 0, body: "" };
+  const chunks: string[] = [];
+  const res = {
+    writeHead: (status: number) => {
+      result.status = status;
+    },
+    end: (chunk?: string) => {
+      if (chunk) chunks.push(chunk);
+      result.body = chunks.join("");
+    },
+  } as unknown as ServerResponse;
+  return { res, result };
+}
+function fakeRequest(method: string): IncomingMessage {
+  return { method } as IncomingMessage;
+}
+async function flush(result: { status: number }): Promise<void> {
+  const deadline = Date.now() + 2000;
+  while (result.status === 0 && Date.now() < deadline) {
+    await new Promise((r) => setTimeout(r, 10));
+  }
+}
+
+describe("inboxRoutes — provenance + #-strip", () => {
+  it("parses frontmatter into provenance on the list endpoint", async () => {
+    writeFileSync(
+      path.join(fakeHome, ".patchwork", "inbox", "morning.md"),
+      `---\nrecipe: morning-brief\nrunSeq: 42\ntrigger: cron\ndeliveredAt: 2026-05-20T08:00:00.000Z\n---\n\n# Morning Brief\n\nbody content\n`,
+    );
+    const { res, result } = captureResponse();
+    expect(
+      tryHandleInboxRoute(fakeRequest("GET"), res, new URL("http://x/inbox")),
+    ).toBe(true);
+    await flush(result);
+    const body = JSON.parse(result.body) as {
+      items: Array<{ name: string; preview: string; provenance?: unknown }>;
+    };
+    const item = body.items.find((i) => i.name === "morning.md");
+    expect(item).toBeDefined();
+    expect(item?.provenance).toEqual({
+      recipe: "morning-brief",
+      runSeq: 42,
+      trigger: "cron",
+      deliveredAt: "2026-05-20T08:00:00.000Z",
+    });
+  });
+
+  it("returns provenance: undefined for files without frontmatter", async () => {
+    writeFileSync(
+      path.join(fakeHome, ".patchwork", "inbox", "legacy.md"),
+      "# legacy note\n\nno frontmatter here\n",
+    );
+    const { res, result } = captureResponse();
+    tryHandleInboxRoute(fakeRequest("GET"), res, new URL("http://x/inbox"));
+    await flush(result);
+    const body = JSON.parse(result.body) as {
+      items: Array<{ name: string; provenance?: unknown }>;
+    };
+    const item = body.items.find((i) => i.name === "legacy.md");
+    expect(item?.provenance).toBeUndefined();
+  });
+
+  it("BUG: today's list endpoint strips ALL #-prefixed lines from the body, including those after frontmatter — fixed so headings still survive in preview", async () => {
+    // Body has a `#` line that is NOT a frontmatter line. The old code
+    // dropped it entirely. After the fix, preview content still has it
+    // (or at least the non-`#` body lines are present and aren't blank).
+    writeFileSync(
+      path.join(fakeHome, ".patchwork", "inbox", "with-fm.md"),
+      `---\nrecipe: x\ntrigger: manual\ndeliveredAt: 2026-05-20T08:00:00.000Z\n---\n\n# Heading\n\nbodyline\n`,
+    );
+    const { res, result } = captureResponse();
+    tryHandleInboxRoute(fakeRequest("GET"), res, new URL("http://x/inbox"));
+    await flush(result);
+    const body = JSON.parse(result.body) as {
+      items: Array<{ name: string; preview: string }>;
+    };
+    const item = body.items.find((i) => i.name === "with-fm.md");
+    // The bug: with the old buggy code, the preview never includes
+    // frontmatter content (good) AND never includes the body's
+    // "# Heading" line. The fix consumes frontmatter explicitly first,
+    // and `#`-strip still drops the heading from the preview — but
+    // crucially the `bodyline` content survives.
+    expect(item?.preview).toContain("bodyline");
+    // The preview should NOT leak frontmatter content (the `---` lines
+    // or the `recipe: x` line).
+    expect(item?.preview).not.toContain("recipe: x");
+    expect(item?.preview).not.toContain("---");
+  });
+
+  it("single-item endpoint returns provenance", async () => {
+    writeFileSync(
+      path.join(fakeHome, ".patchwork", "inbox", "single.md"),
+      `---\nrecipe: r1\nrunSeq: 7\ntrigger: webhook\ndeliveredAt: 2026-05-20T08:00:00.000Z\n---\n\nhello\n`,
+    );
+    const { res, result } = captureResponse();
+    tryHandleInboxRoute(
+      fakeRequest("GET"),
+      res,
+      new URL("http://x/inbox/single.md"),
+    );
+    await flush(result);
+    const body = JSON.parse(result.body) as {
+      name: string;
+      content: string;
+      provenance?: unknown;
+    };
+    expect(body.provenance).toEqual({
+      recipe: "r1",
+      runSeq: 7,
+      trigger: "webhook",
+      deliveredAt: "2026-05-20T08:00:00.000Z",
+    });
+  });
+});

--- a/src/__tests__/runLog.test.ts
+++ b/src/__tests__/runLog.test.ts
@@ -854,3 +854,74 @@ describe("RecipeRunLog.record", () => {
     expect(fs.existsSync(`${file}.tmp`)).toBe(false);
   });
 });
+
+describe("RecipeRunLog — inboxOutputs (Phase 0β provenance)", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(path.join(os.tmpdir(), "runlog-inbox-"));
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("appendDirect round-trips inboxOutputs through query()", () => {
+    const log = new RecipeRunLog({ dir });
+    log.appendDirect({
+      taskId: "t1",
+      recipeName: "morning-brief",
+      trigger: "cron",
+      status: "done",
+      createdAt: 1,
+      startedAt: 1,
+      doneAt: 2,
+      durationMs: 1,
+      inboxOutputs: [{ filename: "brief.md", deliveredAt: 12345 }],
+    });
+    const found = log.query()[0];
+    expect(found?.inboxOutputs).toEqual([
+      { filename: "brief.md", deliveredAt: 12345 },
+    ]);
+  });
+
+  it("completeRun persists inboxOutputs into the JSONL row", () => {
+    const log = new RecipeRunLog({ dir });
+    const seq = log.startRun({
+      taskId: "t2",
+      recipeName: "morning",
+      trigger: "cron",
+      createdAt: 1,
+      startedAt: 1,
+    });
+    log.completeRun(seq, {
+      status: "done",
+      doneAt: 2,
+      durationMs: 1,
+      stepResults: [],
+      inboxOutputs: [{ filename: "a.md", deliveredAt: 999 }],
+    });
+    const found = log.query().find((r) => r.seq === seq);
+    expect(found?.inboxOutputs).toEqual([
+      { filename: "a.md", deliveredAt: 999 },
+    ]);
+  });
+
+  it("omits inboxOutputs when empty", () => {
+    const log = new RecipeRunLog({ dir });
+    const seq = log.startRun({
+      taskId: "t3",
+      recipeName: "morning",
+      trigger: "cron",
+      createdAt: 1,
+      startedAt: 1,
+    });
+    log.completeRun(seq, {
+      status: "done",
+      doneAt: 2,
+      durationMs: 1,
+      stepResults: [],
+      inboxOutputs: [],
+    });
+    const found = log.query().find((r) => r.seq === seq);
+    expect(found?.inboxOutputs).toBeUndefined();
+  });
+});

--- a/src/__tests__/yamlRunner-inbox-provenance.test.ts
+++ b/src/__tests__/yamlRunner-inbox-provenance.test.ts
@@ -19,7 +19,11 @@ vi.mock("../patchworkConfig.js", async () => {
   return { ...actual, loadConfig: vi.fn(() => ({})) };
 });
 
-import { runYamlRecipe, type YamlRecipe } from "../recipes/yamlRunner.js";
+import {
+  isInboxPathFor,
+  runYamlRecipe,
+  type YamlRecipe,
+} from "../recipes/yamlRunner.js";
 
 let fakeHome = "";
 let realHome: string | undefined;
@@ -33,6 +37,75 @@ afterEach(() => {
   if (realHome === undefined) delete process.env.HOME;
   else process.env.HOME = realHome;
   if (fakeHome) rmSync(fakeHome, { recursive: true, force: true });
+});
+
+describe("isInboxPathFor — separator-agnostic detection (Windows regression)", () => {
+  // PR #742 follow-up: the original literal-`/` prefix never matched on
+  // Windows because `os.homedir()` returns `C:\Users\…` and resolved
+  // recipe paths use `\` separators. This unit drives both POSIX and
+  // Win32 path semantics by injecting the path module — no real
+  // filesystem touched, so the test is cross-platform.
+  it("matches a direct child under the POSIX inbox dir", () => {
+    expect(
+      isInboxPathFor(
+        "/home/u/.patchwork/inbox/brief.md",
+        "/home/u/.patchwork/inbox",
+        path.posix,
+      ),
+    ).toBe(true);
+  });
+  it("matches a direct child under a Win32 inbox dir with `\\` separators", () => {
+    expect(
+      isInboxPathFor(
+        "C:\\Users\\u\\.patchwork\\inbox\\brief.md",
+        "C:\\Users\\u\\.patchwork\\inbox",
+        path.win32,
+      ),
+    ).toBe(true);
+  });
+  it("rejects dotfiles + the .archive subnamespace", () => {
+    expect(
+      isInboxPathFor(
+        "/home/u/.patchwork/inbox/.archive",
+        "/home/u/.patchwork/inbox",
+        path.posix,
+      ),
+    ).toBe(false);
+  });
+  it("rejects nested children (inbox/sub/foo.md)", () => {
+    expect(
+      isInboxPathFor(
+        "/home/u/.patchwork/inbox/sub/foo.md",
+        "/home/u/.patchwork/inbox",
+        path.posix,
+      ),
+    ).toBe(false);
+    expect(
+      isInboxPathFor(
+        "C:\\Users\\u\\.patchwork\\inbox\\sub\\foo.md",
+        "C:\\Users\\u\\.patchwork\\inbox",
+        path.win32,
+      ),
+    ).toBe(false);
+  });
+  it("rejects paths outside the inbox dir (`..` escape)", () => {
+    expect(
+      isInboxPathFor(
+        "/home/u/.patchwork/other/foo.md",
+        "/home/u/.patchwork/inbox",
+        path.posix,
+      ),
+    ).toBe(false);
+  });
+  it("rejects the inbox dir itself", () => {
+    expect(
+      isInboxPathFor(
+        "/home/u/.patchwork/inbox",
+        "/home/u/.patchwork/inbox",
+        path.posix,
+      ),
+    ).toBe(false);
+  });
 });
 
 describe("yamlRunner — inbox provenance", () => {

--- a/src/__tests__/yamlRunner-inbox-provenance.test.ts
+++ b/src/__tests__/yamlRunner-inbox-provenance.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Phase 0β — yamlRunner inbox provenance.
+ *
+ * A recipe whose `file.write` targets `~/.patchwork/inbox/<name>.md` must:
+ *   1. Prepend a YAML frontmatter block to the written content (recipe
+ *      name, trigger, deliveredAt — plus runSeq when set).
+ *   2. Record the delivered filename onto an `inboxOutputs` array
+ *      surfaced via the result + the run-log row.
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../patchworkConfig.js", async () => {
+  const actual = await vi.importActual<typeof import("../patchworkConfig.js")>(
+    "../patchworkConfig.js",
+  );
+  return { ...actual, loadConfig: vi.fn(() => ({})) };
+});
+
+import { runYamlRecipe, type YamlRecipe } from "../recipes/yamlRunner.js";
+
+let fakeHome = "";
+let realHome: string | undefined;
+
+beforeEach(() => {
+  fakeHome = mkdtempSync(path.join(os.tmpdir(), "yaml-inbox-prov-"));
+  realHome = process.env.HOME;
+  process.env.HOME = fakeHome;
+});
+afterEach(() => {
+  if (realHome === undefined) delete process.env.HOME;
+  else process.env.HOME = realHome;
+  if (fakeHome) rmSync(fakeHome, { recursive: true, force: true });
+});
+
+describe("yamlRunner — inbox provenance", () => {
+  it("prepends frontmatter on file.write to ~/.patchwork/inbox/ and records inboxOutputs", async () => {
+    const written: Record<string, string> = {};
+    const recipe: YamlRecipe = {
+      name: "morning-brief",
+      trigger: { type: "manual" },
+      steps: [
+        {
+          tool: "file.write",
+          path: "~/.patchwork/inbox/brief.md",
+          content: "# Brief\n\nbody\n",
+        },
+      ],
+    } as YamlRecipe;
+
+    const result = await runYamlRecipe(recipe, {
+      now: () => new Date("2026-05-20T08:00:00Z"),
+      logDir: fakeHome,
+      readFile: () => {
+        throw new Error("not found");
+      },
+      writeFile: (p, c) => {
+        written[p] = c;
+      },
+      appendFile: () => {},
+      mkdir: () => {},
+      gitLogSince: () => "",
+      gitStaleBranches: () => "",
+      getDiagnostics: () => "",
+    });
+
+    expect(result.stepsRun).toBe(1);
+    const writtenPaths = Object.keys(written);
+    expect(writtenPaths).toHaveLength(1);
+    const content = written[writtenPaths[0] as string] as string;
+    expect(content).toMatch(/^---\nrecipe: morning-brief\n/);
+    // yamlRunner normalises trigger kinds outside {cron,webhook,recipe}
+    // to "recipe" for the run-log; the frontmatter mirrors that.
+    expect(content).toContain("trigger: recipe");
+    expect(content).toContain("deliveredAt:");
+    expect(content).toContain("# Brief");
+    // Closing delimiter present + a blank line before body.
+    expect(content).toMatch(/---\n\n/);
+  });
+
+  it("non-inbox paths pass through unchanged", async () => {
+    const written: Record<string, string> = {};
+    const tmp = mkdtempSync(path.join(os.tmpdir(), "non-inbox-"));
+    const target = path.join(tmp, "out.md");
+    const recipe: YamlRecipe = {
+      name: "plain",
+      trigger: { type: "manual" },
+      steps: [{ tool: "file.write", path: target, content: "raw\n" }],
+    } as YamlRecipe;
+
+    await runYamlRecipe(recipe, {
+      now: () => new Date("2026-05-20T08:00:00Z"),
+      logDir: fakeHome,
+      readFile: () => "",
+      writeFile: (p, c) => {
+        written[p] = c;
+      },
+      appendFile: () => {},
+      mkdir: () => {},
+      gitLogSince: () => "",
+      gitStaleBranches: () => "",
+      getDiagnostics: () => "",
+    });
+    expect(written[target]).toBe("raw\n");
+    rmSync(tmp, { recursive: true, force: true });
+  });
+});

--- a/src/approvalQueue.ts
+++ b/src/approvalQueue.ts
@@ -44,6 +44,23 @@ export interface PendingApproval {
   personalSignals?: import("./approvalSignals.js").PersonalSignal[];
   /** 256-bit hex token for phone-path approve/reject. Only present when push is configured. */
   approvalToken?: string;
+  /**
+   * Phase 0β provenance — recipe run that originated this approval.
+   * Populated when the bridge can correlate the approval call to a
+   * recipe-step context (the `personalSignals` pipeline already
+   * sources from `recipe_run_log`, but that's read-only signal data;
+   * these two fields surface the link itself on the wire so the
+   * dashboard approval detail page can render an "originating run"
+   * chip without re-deriving it from filenames or sessionId.
+   *
+   * TODO(phase-0β-pop): population is deferred — the immediate goal
+   * is unblocking the dashboard schema. Computing the link without a
+   * deeper refactor requires sessionId→runSeq mapping that today
+   * lives behind `personalSignals.source: "recipe_run_log"`. Wiring
+   * that explicitly into `handleApprovalRequest` is the follow-up.
+   */
+  runSeq?: number;
+  recipeName?: string;
 }
 
 /**

--- a/src/inboxRoutes.ts
+++ b/src/inboxRoutes.ts
@@ -21,6 +21,67 @@ import path from "node:path";
 import { respond500 } from "./httpErrorResponse.js";
 
 /**
+ * Phase 0β provenance shape. Optional + additive — files without
+ * frontmatter return `provenance: undefined`.
+ */
+export interface InboxProvenance {
+  recipe?: string;
+  runSeq?: number;
+  trigger?: string;
+  deliveredAt?: string;
+}
+
+/**
+ * Split a markdown file into its YAML-frontmatter block (parsed as a flat
+ * `key: value` map) and the remaining body. Frontmatter is recognised
+ * only when the file begins with `---\n` and a closing `---` line is
+ * found within the first 30 lines (cap to bound the scan). Returns
+ * `{ provenance: undefined, body: content }` for files without
+ * frontmatter so callers degrade gracefully on legacy inbox items.
+ */
+export function parseInboxFile(content: string): {
+  provenance: InboxProvenance | undefined;
+  body: string;
+} {
+  if (!content.startsWith("---\n")) {
+    return { provenance: undefined, body: content };
+  }
+  const lines = content.split("\n");
+  // lines[0] === "---". Find the next "---" delimiter.
+  let endIdx = -1;
+  const maxScan = Math.min(lines.length, 30);
+  for (let i = 1; i < maxScan; i++) {
+    if (lines[i] === "---") {
+      endIdx = i;
+      break;
+    }
+  }
+  if (endIdx === -1) {
+    // Malformed — no closing delimiter. Treat as body-only.
+    return { provenance: undefined, body: content };
+  }
+  const fm: InboxProvenance = {};
+  for (let i = 1; i < endIdx; i++) {
+    const line = lines[i] ?? "";
+    const m = /^([a-zA-Z][a-zA-Z0-9_]*):\s*(.*)$/.exec(line);
+    if (!m) continue;
+    const key = m[1] as string;
+    const rawVal = (m[2] ?? "").trim();
+    if (key === "runSeq") {
+      const n = Number.parseInt(rawVal, 10);
+      if (Number.isFinite(n)) fm.runSeq = n;
+    } else if (key === "recipe" || key === "trigger" || key === "deliveredAt") {
+      (fm as Record<string, string>)[key] = rawVal;
+    }
+  }
+  const body = lines.slice(endIdx + 1).join("\n");
+  // Strip a single leading blank line if present (frontmatter writers
+  // emit a trailing blank line by convention).
+  const trimmedBody = body.startsWith("\n") ? body.slice(1) : body;
+  return { provenance: fm, body: trimmedBody };
+}
+
+/**
  * Filename guard shared by every inbox sub-route. Rejects directory
  * separators and `..` segments so the request can never escape the inbox
  * directory. Returns the joined absolute path on success, or null with the
@@ -64,7 +125,15 @@ export function tryHandleInboxRoute(
               readFile(filePath, "utf8"),
               stat(filePath),
             ]);
-            const stripped = content
+            // Phase 0β — consume frontmatter FIRST, then strip
+            // heading-`#` lines from the body only. Previously the
+            // `#`-strip ran over the whole file, which meant any
+            // pre-existing `#`-prefixed body line was eaten AND, more
+            // subtly, frontmatter values (lines like `recipe: x`,
+            // `---`) leaked into the preview because they weren't
+            // `#`-prefixed. Splitting the two passes fixes both.
+            const { provenance, body } = parseInboxFile(content);
+            const stripped = body
               .split("\n")
               .filter((l) => !l.startsWith("#"))
               .join("\n")
@@ -79,6 +148,7 @@ export function tryHandleInboxRoute(
               name,
               modifiedAt: stats.mtime.toISOString(),
               preview: stripped.slice(0, 200),
+              ...(provenance && { provenance }),
             };
           }),
         );
@@ -112,11 +182,13 @@ export function tryHandleInboxRoute(
           stat(filePath),
         ]);
         res.writeHead(200, { "Content-Type": "application/json" });
+        const { provenance } = parseInboxFile(content);
         res.end(
           JSON.stringify({
             name: filename,
             content,
             modifiedAt: stats.mtime.toISOString(),
+            ...(provenance && { provenance }),
           }),
         );
       } catch (err: unknown) {

--- a/src/recipes/yamlRunner.ts
+++ b/src/recipes/yamlRunner.ts
@@ -568,6 +568,74 @@ export async function runYamlRecipe(
   };
 
   const stepDeps = resolveStepDeps(deps, { recipeName: recipe.name });
+
+  // Phase 0β — inbox provenance. When a recipe `file.write` / `file.append`
+  // step targets `~/.patchwork/inbox/`, prepend a YAML frontmatter block
+  // (first write only) recording recipe + run + trigger, and accumulate the
+  // delivered filename onto the run record's `inboxOutputs`. Old recipes /
+  // non-inbox paths pass through unchanged.
+  const inboxDir = `${os.homedir()}/.patchwork/inbox/`;
+  const inboxOutputs: Array<{ filename: string; deliveredAt: number }> = [];
+  const isInboxPath = (abs: string): boolean =>
+    abs.startsWith(inboxDir) && !path.basename(abs).startsWith(".");
+  const buildFrontmatter = (): string => {
+    const triggerKindAtWrite = yamlTriggerKind;
+    const lines = ["---", `recipe: ${recipe.name}`];
+    if (runSeq !== undefined) lines.push(`runSeq: ${runSeq}`);
+    lines.push(
+      `trigger: ${triggerKindAtWrite}`,
+      `deliveredAt: ${new Date().toISOString()}`,
+      "---",
+      "",
+      "",
+    );
+    return lines.join("\n");
+  };
+  const recordInboxDelivery = (abs: string): void => {
+    inboxOutputs.push({
+      filename: path.basename(abs),
+      deliveredAt: Date.now(),
+    });
+  };
+  const fileAlreadyHasFrontmatter = (abs: string): boolean => {
+    try {
+      if (!existsSync(abs)) return false;
+      const fd = readFileSync(abs, "utf-8");
+      return fd.startsWith("---\n");
+    } catch {
+      return false;
+    }
+  };
+  const originalWrite = stepDeps.writeFile;
+  const originalAppend = stepDeps.appendFile;
+  stepDeps.writeFile = (p: string, content: string) => {
+    if (isInboxPath(p)) {
+      const needsFm = !fileAlreadyHasFrontmatter(p);
+      const final = needsFm ? buildFrontmatter() + content : content;
+      originalWrite(p, final);
+      recordInboxDelivery(p);
+      return;
+    }
+    originalWrite(p, content);
+  };
+  stepDeps.appendFile = (p: string, content: string) => {
+    if (isInboxPath(p)) {
+      // file.append: never re-prepend. If file is brand-new (no existing
+      // frontmatter), seed one so a recipe that only ever uses append still
+      // gets provenance — without this, a recipe using append-only would
+      // produce frontmatter-less inbox items and the UI would degrade.
+      const exists = existsSync(p);
+      if (!exists) {
+        originalWrite(p, buildFrontmatter() + content);
+      } else {
+        originalAppend(p, content);
+      }
+      recordInboxDelivery(p);
+      return;
+    }
+    originalAppend(p, content);
+  };
+
   // PR2b: one per-run budget shared across all agent steps. Absent
   // `recipe.budget` → no enforcement, no overhead.
   const runBudget = new RunBudget(recipe.budget);
@@ -1082,6 +1150,7 @@ export async function runYamlRecipe(
           outputTail,
           ...(runError !== undefined && { errorMessage: runError }),
           ...(assertionFailures.length > 0 ? { assertionFailures } : {}),
+          ...(inboxOutputs.length > 0 ? { inboxOutputs } : {}),
         });
         emit("recipe_done", {
           runSeq,
@@ -1118,6 +1187,7 @@ export async function runYamlRecipe(
           errorMessage: runError,
           stepResults: finalStepResults,
           ...(assertionFailures.length > 0 ? { assertionFailures } : {}),
+          ...(inboxOutputs.length > 0 ? { inboxOutputs } : {}),
         });
       }
     } catch {

--- a/src/recipes/yamlRunner.ts
+++ b/src/recipes/yamlRunner.ts
@@ -430,6 +430,29 @@ export type StepDeps = Required<
 };
 
 // Strip tool-call narration some models (e.g. Gemini) prepend before the markdown block.
+/**
+ * Phase 0β — separator-agnostic inbox-path detector. Extracted so the
+ * Windows path-separator behaviour can be unit-tested by injecting
+ * `path.win32` / `path.posix` without booting a real recipe runner.
+ *
+ * Returns true when `candidate` resolves to a direct child of
+ * `inboxDirAbs`, isn't a dotfile, and lives in (not above) the inbox
+ * dir. Both arguments must already be platform-appropriate absolute
+ * paths (resolve them with the same path module before calling).
+ */
+export function isInboxPathFor(
+  candidate: string,
+  inboxDirAbs: string,
+  pathMod: typeof path,
+): boolean {
+  const target = pathMod.resolve(candidate);
+  const rel = pathMod.relative(inboxDirAbs, target);
+  if (!rel || rel.startsWith("..") || pathMod.isAbsolute(rel)) return false;
+  if (pathMod.basename(target).startsWith(".")) return false;
+  // Only direct children — `~/.patchwork/inbox/foo.md`, not nested.
+  return !rel.includes(pathMod.sep);
+}
+
 function stripLeadingNarration(text: string): string {
   const lines = text.split("\n");
   const firstMarkdown = lines.findIndex((l) =>
@@ -574,10 +597,20 @@ export async function runYamlRecipe(
   // (first write only) recording recipe + run + trigger, and accumulate the
   // delivered filename onto the run record's `inboxOutputs`. Old recipes /
   // non-inbox paths pass through unchanged.
-  const inboxDir = `${os.homedir()}/.patchwork/inbox/`;
+  //
+  // Windows path-separator fix (CI repro 2026-05-20): the original
+  // implementation built the prefix as `${os.homedir()}/.patchwork/inbox/`
+  // and compared with `startsWith`, which failed on Windows where
+  // resolved absolute paths use `\` separators and `os.homedir()` returns
+  // `C:\Users\...`. Now we resolve both sides through `path.resolve()`
+  // and use `path.relative()` to detect containment so the comparison is
+  // separator-agnostic. Also case-insensitive on Win32 (NTFS).
+  const inboxDirAbs = path.resolve(
+    path.join(os.homedir(), ".patchwork", "inbox"),
+  );
   const inboxOutputs: Array<{ filename: string; deliveredAt: number }> = [];
   const isInboxPath = (abs: string): boolean =>
-    abs.startsWith(inboxDir) && !path.basename(abs).startsWith(".");
+    isInboxPathFor(abs, inboxDirAbs, path);
   const buildFrontmatter = (): string => {
     const triggerKindAtWrite = yamlTriggerKind;
     const lines = ["---", `recipe: ${recipe.name}`];
@@ -597,21 +630,30 @@ export async function runYamlRecipe(
       deliveredAt: Date.now(),
     });
   };
-  const fileAlreadyHasFrontmatter = (abs: string): boolean => {
+  // Atomic read-or-default: a single `readFileSync` in a try/catch. No
+  // `existsSync`/`statSync` probe around the write — on Windows a stat
+  // immediately before write can race a concurrent fd holder and surface
+  // `EBUSY`/`EPERM`. The read either succeeds (file present) or throws
+  // ENOENT (treated as new file). Either way we never stat the same path
+  // we're about to write.
+  const readExistingOrEmpty = (abs: string): string => {
     try {
-      if (!existsSync(abs)) return false;
-      const fd = readFileSync(abs, "utf-8");
-      return fd.startsWith("---\n");
+      return readFileSync(abs, "utf-8");
     } catch {
-      return false;
+      return "";
     }
   };
   const originalWrite = stepDeps.writeFile;
   const originalAppend = stepDeps.appendFile;
   stepDeps.writeFile = (p: string, content: string) => {
     if (isInboxPath(p)) {
-      const needsFm = !fileAlreadyHasFrontmatter(p);
-      const final = needsFm ? buildFrontmatter() + content : content;
+      // First-write detection by content shape, not by stat. Empty string
+      // (ENOENT) and any file that does NOT already begin with `---\n`
+      // gets frontmatter; pre-frontmattered files are overwritten as-is
+      // so consumers can replay a recipe without doubling the header.
+      const existing = readExistingOrEmpty(p);
+      const hasFm = existing.startsWith("---\n");
+      const final = hasFm ? content : buildFrontmatter() + content;
       originalWrite(p, final);
       recordInboxDelivery(p);
       return;
@@ -620,12 +662,11 @@ export async function runYamlRecipe(
   };
   stepDeps.appendFile = (p: string, content: string) => {
     if (isInboxPath(p)) {
-      // file.append: never re-prepend. If file is brand-new (no existing
-      // frontmatter), seed one so a recipe that only ever uses append still
-      // gets provenance — without this, a recipe using append-only would
-      // produce frontmatter-less inbox items and the UI would degrade.
-      const exists = existsSync(p);
-      if (!exists) {
+      // file.append: never re-prepend. If file is brand-new, seed one
+      // frontmatter block so an append-only recipe still gets
+      // provenance. Same atomic read-or-default — no stat probe.
+      const existing = readExistingOrEmpty(p);
+      if (existing.length === 0) {
         originalWrite(p, buildFrontmatter() + content);
       } else {
         originalAppend(p, content);

--- a/src/runLog.ts
+++ b/src/runLog.ts
@@ -124,6 +124,15 @@ export interface RecipeRun {
    * just round-trips the value.
    */
   manualRunId?: string;
+  /**
+   * Phase 0β provenance — files this run delivered to the inbox
+   * (`~/.patchwork/inbox/`). One entry per `file.write` step whose
+   * resolved path is inside the inbox dir; populated by yamlRunner.
+   * Lets the dashboard link a run to its produced inbox items
+   * without filename-string-munging. Optional + additive: pre-Phase-0β
+   * runs simply omit it.
+   */
+  inboxOutputs?: Array<{ filename: string; deliveredAt: number }>;
 }
 
 const MAX_OUTPUT_TAIL = 2_000;
@@ -420,6 +429,7 @@ export class RecipeRunLog {
       outputTail?: string;
       errorMessage?: string;
       assertionFailures?: RecipeRun["assertionFailures"];
+      inboxOutputs?: RecipeRun["inboxOutputs"];
     },
   ): void {
     const idx = this.runs.findIndex((r) => r.seq === seq);
@@ -443,6 +453,10 @@ export class RecipeRunLog {
       ...(opts.assertionFailures !== undefined && {
         assertionFailures: opts.assertionFailures,
       }),
+      ...(opts.inboxOutputs !== undefined &&
+        opts.inboxOutputs.length > 0 && {
+          inboxOutputs: opts.inboxOutputs,
+        }),
     };
     this.runs[idx] = finalized;
     mkdirSync(path.dirname(this.file), { recursive: true, mode: 0o700 });


### PR DESCRIPTION
## Summary

Phase 0β of the connected-dashboard plan. Adds the provenance fields the dashboard needs to link Inbox items back to their originating recipe runs and approvals back to their runs — fields that simply didn't exist before, forcing the inbox UI to guess recipe names by string-munging filenames.

- **`src/runLog.ts`** — adds optional `RecipeRun.inboxOutputs?: Array<{filename, deliveredAt}>` threaded through `completeRun` and `appendDirect`. Additive; pre-Phase-0β rows round-trip unchanged.
- **`src/recipes/yamlRunner.ts`** — when a `file.write` / `file.append` step targets `~/.patchwork/inbox/`, prepends a YAML frontmatter block (recipe, runSeq when set, trigger, deliveredAt) on first write and records the delivered filename onto the run's `inboxOutputs`. Non-inbox paths unchanged. `file.append` seeds frontmatter only when the file is brand-new; subsequent appends never re-prepend.
- **`src/inboxRoutes.ts`** — parses frontmatter into a `provenance` field on both list + single-item endpoints. Fixes a pre-existing bug where the `#`-prefixed-line strip ran over the whole file, which let frontmatter lines (`---`, `recipe: x`) leak into the preview because they weren't `#`-prefixed. Now consumes frontmatter first, then strips headings from the body only.
- **`src/approvalQueue.ts`** — adds optional `PendingApproval.runSeq?` + `recipeName?` so the approval detail page can show an originating-run chip. Schema bump only — population is deferred (TODO comment) per the plan, to unblock dashboard work without a deeper refactor of `handleApprovalRequest`.

Back-compat: old runs without `inboxOutputs`, old inbox files without frontmatter, and old approvals without `runSeq`/`recipeName` all degrade silently (field absent → UI skips the chip / link).

## Test plan

- [x] Bug-fix protocol followed: `src/__tests__/inboxRoutes-provenance.test.ts` includes a failing-first repro for the `#`-strip bug (frontmatter leaking into preview), now fixed
- [x] `RecipeRun.inboxOutputs` round-trips through `appendDirect` + `completeRun` + `query` (`src/__tests__/runLog.test.ts`)
- [x] yamlRunner writes frontmatter to inbox paths and records `inboxOutputs`; non-inbox paths untouched (`src/__tests__/yamlRunner-inbox-provenance.test.ts`)
- [x] `inboxRoutes`: frontmatter file → `provenance` populated; legacy file → `provenance: undefined`; single-item endpoint also returns `provenance`
- [x] `npm run build` clean
- [x] `npx tsc -p tsconfig.tests.core.json --noEmit` clean
- [x] `npx biome check --write` applied to all changed files
- [ ] Pre-existing `shim-*` / `recipe-cli.integration` test failures are environmental (missing `tsx` binary in `node_modules/.bin`) and unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)