### PR TITLE
feat(dashboard): shared entity-chip components (RunChip/RecipeChip/ToolChip/etc.)

### DIFF
--- a/dashboard/src/app/activity/page.tsx
+++ b/dashboard/src/app/activity/page.tsx
@@ -3,6 +3,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { apiPath } from "@/lib/api";
+import { canonicalRecipeKey } from "@/lib/entityKey";
 import { relTime } from "@/components/time";
 import { ACTIVITY_NOISE_EVENTS } from "@/lib/activityNoise";
 import { subscribeStreamLiveness, subscribeStreamMessage } from "@/lib/streamLiveness";
@@ -66,7 +67,7 @@ function getLifecycleMeta(e: ActivityEvent) {
     sessionId:
       typeof m.sessionId === "string" ? m.sessionId.slice(0, 8) : undefined,
     summary: typeof m.summary === "string" ? m.summary : undefined,
-    recipeName: rawRecipe ? rawRecipe.replace(/:agent$/, "") : undefined,
+    recipeName: rawRecipe ? canonicalRecipeKey(rawRecipe) : undefined,
   };
 }
 

--- a/dashboard/src/app/inbox/page.tsx
+++ b/dashboard/src/app/inbox/page.tsx
@@ -4,6 +4,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import dynamic from "next/dynamic";
 import Link from "next/link";
 import { apiPath } from "@/lib/api";
+import { inboxItemKey } from "@/lib/entityKey";
 import { EmptyState, ErrorState, HintCard } from "@/components/patchwork";
 import { SkeletonList } from "@/components/Skeleton";
 import { InboxDeliveryCard } from "@/components/InboxDeliveryCard";
@@ -942,7 +943,12 @@ const filteredItems = items.filter((item) => {
 
                   {/* Action buttons (bottom) */}
                   {(() => {
-                    const recipeNameForSelected = selected.name.replace(/\.md$/, "").replace(/-\d{4}-\d{2}-\d{2}$/, "");
+                    // Strip .md only; the trailing date stays — recipe
+                    // identity from a filename is a sibling-PR concern
+                    // (moves to provenance metadata). For now the deep
+                    // link can include the date and the recipes page
+                    // will gracefully no-op if no recipe matches.
+                    const recipeNameForSelected = inboxItemKey(selected.name);
                     return (
                       <>
                       <div className="inbox-reader-actions" style={{ display: "flex", flexWrap: "wrap", gap: 6, marginTop: 16, paddingTop: 16, borderTop: "1px solid var(--line-1)" }}>

--- a/dashboard/src/components/RecipeLeaderboard.tsx
+++ b/dashboard/src/components/RecipeLeaderboard.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/components/patchwork";
 import { relTime } from "@/components/time";
 import { useRunRecipe } from "@/hooks/useRunRecipe";
+import { canonicalRecipeKey } from "@/lib/entityKey";
 
 /**
  * Recipe activity leaderboard for the Overview page. Replaces the old
@@ -67,7 +68,7 @@ function aggregateByRecipe(
   const byName = new Map<string, LeaderboardRun[]>();
   for (const r of runs) {
     if (r.startedAt < cutoff) continue;
-    const name = (r.recipeName ?? r.recipe ?? "").replace(/:agent$/, "");
+    const name = canonicalRecipeKey(r.recipeName ?? r.recipe ?? "");
     if (!name) continue;
     const list = byName.get(name) ?? [];
     list.push(r);

--- a/dashboard/src/components/patchwork/entity/ApprovalChip.tsx
+++ b/dashboard/src/components/patchwork/entity/ApprovalChip.tsx
@@ -1,0 +1,56 @@
+import Link from "next/link";
+import {
+  StatusPill,
+  type StatusTone,
+} from "@/components/patchwork/StatusPill";
+import { type EntityVariant, variantStyle } from "./types";
+
+export type ApprovalDecision = "pending" | "approved" | "rejected";
+
+export interface ApprovalChipProps {
+  callId: string;
+  tier?: string;
+  decision?: ApprovalDecision;
+  variant?: EntityVariant;
+}
+
+const DECISION_TONE: Record<ApprovalDecision, StatusTone> = {
+  pending: "warn",
+  approved: "ok",
+  rejected: "err",
+};
+
+/**
+ * <ApprovalChip> — linked identity chip for a single approval call.
+ *
+ * Labels with the tier (if known) and the decision verdict; status tone
+ * comes from a StatusPill so colour is never the sole signal.
+ */
+export function ApprovalChip({
+  callId,
+  tier,
+  decision,
+  variant = "chip",
+}: ApprovalChipProps) {
+  const { className, style } = variantStyle(variant);
+  const label = tier ? tier : callId.slice(0, 10);
+  const ariaLabel = `Approval ${callId}${tier ? ` (${tier})` : ""}${
+    decision ? `, ${decision}` : ""
+  }`;
+  return (
+    <Link
+      href={`/approvals/${callId}`}
+      className={className}
+      style={style}
+      aria-label={ariaLabel}
+      title={ariaLabel}
+    >
+      <span style={{ fontFamily: "var(--font-mono)" }}>{label}</span>
+      {decision && (
+        <StatusPill tone={DECISION_TONE[decision]} srLabel={decision}>
+          {decision}
+        </StatusPill>
+      )}
+    </Link>
+  );
+}

--- a/dashboard/src/components/patchwork/entity/ConnectorChip.tsx
+++ b/dashboard/src/components/patchwork/entity/ConnectorChip.tsx
@@ -1,0 +1,58 @@
+import { type EntityVariant, variantStyle } from "./types";
+
+export interface ConnectorChipProps {
+  id: string;
+  healthy?: boolean;
+  variant?: EntityVariant;
+}
+
+/**
+ * <ConnectorChip> — linked identity chip for a connector.
+ *
+ * Target is a hash anchor on `/connections` (the connections page
+ * scrolls to the matching row), so this renders a plain `<a>` instead
+ * of a Next `<Link>` — Next's router would strip the fragment.
+ *
+ * Health is signalled by a coloured dot AND an explicit text label on
+ * aria so colour is never the sole signal.
+ */
+export function ConnectorChip({
+  id,
+  healthy,
+  variant = "chip",
+}: ConnectorChipProps) {
+  const { className, style } = variantStyle(variant);
+  const dotColor =
+    healthy === undefined
+      ? "var(--muted, #888)"
+      : healthy
+        ? "var(--green, #2ea44f)"
+        : "var(--red, #d1242f)";
+  const healthLabel =
+    healthy === undefined ? "" : healthy ? ", healthy" : ", unhealthy";
+  const ariaLabel = `Connector ${id}${healthLabel}`;
+  return (
+    <a
+      href={`/connections#${id}`}
+      className={className}
+      style={style}
+      aria-label={ariaLabel}
+      title={ariaLabel}
+    >
+      <span
+        aria-hidden="true"
+        style={{
+          width: 8,
+          height: 8,
+          borderRadius: "50%",
+          background: dotColor,
+          display: "inline-block",
+        }}
+      />
+      <span>{id}</span>
+      {healthy !== undefined && (
+        <span className="sr-only">{healthy ? "healthy" : "unhealthy"}</span>
+      )}
+    </a>
+  );
+}

--- a/dashboard/src/components/patchwork/entity/EntityLink.tsx
+++ b/dashboard/src/components/patchwork/entity/EntityLink.tsx
@@ -1,0 +1,127 @@
+import Link from "next/link";
+import { canonicalRecipeKey, inboxItemKey } from "@/lib/entityKey";
+import { ApprovalChip } from "./ApprovalChip";
+import { ConnectorChip } from "./ConnectorChip";
+import { InboxChip } from "./InboxChip";
+import { RecipeChip } from "./RecipeChip";
+import { RunChip } from "./RunChip";
+import { SessionChip } from "./SessionChip";
+import { ToolChip } from "./ToolChip";
+import { TraceChip } from "./TraceChip";
+import { type EntityKind, type EntityVariant, variantStyle } from "./types";
+
+export interface EntityLinkProps {
+  kind: EntityKind;
+  id: string;
+  label?: string;
+  variant?: EntityVariant;
+}
+
+/**
+ * <EntityLink> — kind-dispatched chip.
+ *
+ * Lets callers render any entity by `(kind, id)` without importing the
+ * specific chip. The visual / link contract matches the kind-specific
+ * chip exactly. `task` and `decision` are minimal-chip variants that
+ * the dedicated chips don't (yet) cover — they share the same generic
+ * shape.
+ */
+export function EntityLink({
+  kind,
+  id,
+  label,
+  variant = "chip",
+}: EntityLinkProps) {
+  switch (kind) {
+    case "run": {
+      const seq = Number.parseInt(id, 10);
+      return <RunChip seq={Number.isFinite(seq) ? seq : 0} variant={variant} />;
+    }
+    case "recipe":
+      return <RecipeChip name={id} variant={variant} />;
+    case "tool":
+      return <ToolChip name={id} variant={variant} />;
+    case "session":
+      return <SessionChip id={id} variant={variant} />;
+    case "approval":
+      return <ApprovalChip callId={id} variant={variant} />;
+    case "trace":
+      return (
+        <TraceChip
+          traceKey={id}
+          traceType={label ?? "decision"}
+          variant={variant}
+        />
+      );
+    case "connector":
+      return <ConnectorChip id={id} variant={variant} />;
+    case "inbox":
+      return <InboxChip name={id} variant={variant} />;
+    case "task":
+      return <GenericChip kind="task" id={id} label={label} variant={variant} />;
+    case "decision":
+      return (
+        <GenericChip kind="decision" id={id} label={label} variant={variant} />
+      );
+  }
+}
+
+/**
+ * Hook returning the canonical href for an entity (kind, id).
+ *
+ * Exposed so `RelationStrip` items can later be built from the same
+ * resolver — keeps URLs in lockstep with the chips.
+ */
+export function useEntityHref(kind: EntityKind, id: string): string {
+  switch (kind) {
+    case "run":
+      return `/runs/${id}`;
+    case "recipe":
+      return `/recipes/${canonicalRecipeKey(id)}`;
+    case "tool":
+      return `/insights?tool=${encodeURIComponent(id)}`;
+    case "session":
+      return `/sessions/${encodeURIComponent(id)}`;
+    case "approval":
+      return `/approvals/${id}`;
+    case "trace":
+      return `/traces?q=${encodeURIComponent(id)}`;
+    case "connector":
+      return `/connections#${id}`;
+    case "inbox":
+      return `/inbox?item=${encodeURIComponent(inboxItemKey(id))}`;
+    case "task":
+      return `/tasks?id=${encodeURIComponent(id)}`;
+    case "decision":
+      return `/decisions?ref=${encodeURIComponent(id)}`;
+  }
+}
+
+function GenericChip({
+  kind,
+  id,
+  label,
+  variant = "chip",
+}: {
+  kind: "task" | "decision";
+  id: string;
+  label?: string;
+  variant?: EntityVariant;
+}) {
+  const { className, style } = variantStyle(variant);
+  const href = useEntityHref(kind, id);
+  const text = label ?? id;
+  const kindLabel = kind === "task" ? "Task" : "Decision";
+  const ariaLabel = `${kindLabel} ${text}`;
+  return (
+    <Link
+      href={href}
+      className={className}
+      style={style}
+      aria-label={ariaLabel}
+      title={ariaLabel}
+    >
+      <span style={{ fontFamily: "var(--font-mono)" }}>{text}</span>
+    </Link>
+  );
+}

--- a/dashboard/src/components/patchwork/entity/InboxChip.tsx
+++ b/dashboard/src/components/patchwork/entity/InboxChip.tsx
@@ -1,0 +1,37 @@
+import Link from "next/link";
+import { inboxItemKey } from "@/lib/entityKey";
+import { type EntityVariant, variantStyle } from "./types";
+
+export interface InboxChipProps {
+  name: string;
+  recipeName?: string;
+  variant?: EntityVariant;
+}
+
+/**
+ * <InboxChip> — linked identity chip for an inbox item.
+ *
+ * The visible label keeps the date in it (inbox identity includes the
+ * date — see `inboxItemKey`); only the `.md` suffix is stripped for
+ * the link target.
+ */
+export function InboxChip({
+  name,
+  recipeName,
+  variant = "chip",
+}: InboxChipProps) {
+  const { className, style } = variantStyle(variant);
+  const key = inboxItemKey(name);
+  const ariaLabel = `Inbox ${key}${recipeName ? ` (${recipeName})` : ""}`;
+  return (
+    <Link
+      href={`/inbox?item=${encodeURIComponent(key)}`}
+      className={className}
+      style={style}
+      aria-label={ariaLabel}
+      title={ariaLabel}
+    >
+      <span>{key}</span>
+    </Link>
+  );
+}

--- a/dashboard/src/components/patchwork/entity/RecipeChip.tsx
+++ b/dashboard/src/components/patchwork/entity/RecipeChip.tsx
@@ -1,0 +1,43 @@
+import Link from "next/link";
+import { LivePill } from "@/components/patchwork/LivePill";
+import { canonicalRecipeKey } from "@/lib/entityKey";
+import { type EntityVariant, variantStyle } from "./types";
+
+export interface RecipeChipProps {
+  name: string;
+  trigger?: string;
+  live?: boolean;
+  variant?: EntityVariant;
+}
+
+/**
+ * <RecipeChip> — linked identity chip for a recipe.
+ *
+ * Always routes through `canonicalRecipeKey()` so the same recipe lands
+ * on the same URL regardless of whether the source string carried a
+ * trailing agent-axis suffix.
+ */
+export function RecipeChip({
+  name,
+  trigger,
+  live,
+  variant = "chip",
+}: RecipeChipProps) {
+  const { className, style } = variantStyle(variant);
+  const key = canonicalRecipeKey(name);
+  const ariaLabel = `Recipe ${key}${trigger ? ` (${trigger})` : ""}${
+    live ? ", live" : ""
+  }`;
+  return (
+    <Link
+      href={`/recipes/${key}`}
+      className={className}
+      style={style}
+      aria-label={ariaLabel}
+      title={ariaLabel}
+    >
+      <span>{key}</span>
+      {live && <LivePill connection="live" />}
+    </Link>
+  );
+}

--- a/dashboard/src/components/patchwork/entity/RunChip.tsx
+++ b/dashboard/src/components/patchwork/entity/RunChip.tsx
@@ -1,0 +1,54 @@
+import Link from "next/link";
+import { StatusPill, deriveRunStatus } from "@/components/patchwork/StatusPill";
+import { type EntityVariant, variantStyle } from "./types";
+
+export type RunStatus = "running" | "done" | "error" | string;
+
+export interface RunChipProps {
+  seq: number;
+  status?: RunStatus;
+  hadStepErrors?: boolean;
+  recipeName?: string;
+  variant?: EntityVariant;
+}
+
+/**
+ * <RunChip> — linked identity chip for a single recipe run.
+ *
+ * Renders `#<seq>` and, when `status` is provided, an inner StatusPill
+ * derived via `deriveRunStatus()` so the same verdict shows up wherever
+ * a run is referenced. Always a real <Link>, so keyboard nav + middle-
+ * click open in tab work without extra wiring at the call site.
+ */
+export function RunChip({
+  seq,
+  status,
+  hadStepErrors,
+  recipeName,
+  variant = "chip",
+}: RunChipProps) {
+  const { className, style } = variantStyle(variant);
+  const derived = status
+    ? deriveRunStatus(status, { hadStepErrors })
+    : undefined;
+  const label = `#${seq}`;
+  const ariaLabel = derived
+    ? `Run ${label}${recipeName ? ` (${recipeName})` : ""}, ${derived.label}`
+    : `Run ${label}${recipeName ? ` (${recipeName})` : ""}`;
+  return (
+    <Link
+      href={`/runs/${seq}`}
+      className={className}
+      style={style}
+      aria-label={ariaLabel}
+      title={ariaLabel}
+    >
+      <span style={{ fontFamily: "var(--font-mono)" }}>{label}</span>
+      {derived && (
+        <StatusPill tone={derived.tone} srLabel={derived.label}>
+          {derived.label}
+        </StatusPill>
+      )}
+    </Link>
+  );
+}

--- a/dashboard/src/components/patchwork/entity/SessionChip.tsx
+++ b/dashboard/src/components/patchwork/entity/SessionChip.tsx
@@ -1,0 +1,37 @@
+import Link from "next/link";
+import { LivePill } from "@/components/patchwork/LivePill";
+import { type EntityVariant, variantStyle } from "./types";
+
+export interface SessionChipProps {
+  id: string;
+  active?: boolean;
+  variant?: EntityVariant;
+}
+
+/**
+ * <SessionChip> — linked identity chip for a Claude session.
+ *
+ * Renders only the first 8 chars of the id to keep the chip compact;
+ * full id remains in the link target + aria-label.
+ */
+export function SessionChip({
+  id,
+  active,
+  variant = "chip",
+}: SessionChipProps) {
+  const { className, style } = variantStyle(variant);
+  const short = id.slice(0, 8);
+  const ariaLabel = `Session ${id}${active ? ", active" : ""}`;
+  return (
+    <Link
+      href={`/sessions/${encodeURIComponent(id)}`}
+      className={className}
+      style={style}
+      aria-label={ariaLabel}
+      title={ariaLabel}
+    >
+      <span style={{ fontFamily: "var(--font-mono)" }}>{short}</span>
+      {active && <LivePill connection="live" />}
+    </Link>
+  );
+}

--- a/dashboard/src/components/patchwork/entity/ToolChip.tsx
+++ b/dashboard/src/components/patchwork/entity/ToolChip.tsx
@@ -1,0 +1,32 @@
+import Link from "next/link";
+import { RiskPill, type RiskLevel } from "@/components/patchwork/RiskPill";
+import { type EntityVariant, variantStyle } from "./types";
+
+export interface ToolChipProps {
+  name: string;
+  tier?: RiskLevel;
+  variant?: EntityVariant;
+}
+
+/**
+ * <ToolChip> — linked identity chip for a tool name.
+ *
+ * Optional risk-tier pill (low / medium / high). Links into the insights
+ * page filtered by tool so click-through lands on usage context.
+ */
+export function ToolChip({ name, tier, variant = "chip" }: ToolChipProps) {
+  const { className, style } = variantStyle(variant);
+  const ariaLabel = `Tool ${name}${tier ? `, ${tier} risk` : ""}`;
+  return (
+    <Link
+      href={`/insights?tool=${encodeURIComponent(name)}`}
+      className={className}
+      style={style}
+      aria-label={ariaLabel}
+      title={ariaLabel}
+    >
+      <span style={{ fontFamily: "var(--font-mono)" }}>{name}</span>
+      {tier && <RiskPill level={tier} />}
+    </Link>
+  );
+}

--- a/dashboard/src/components/patchwork/entity/TraceChip.tsx
+++ b/dashboard/src/components/patchwork/entity/TraceChip.tsx
@@ -1,0 +1,58 @@
+import Link from "next/link";
+import { type EntityVariant, variantStyle } from "./types";
+
+export interface TraceChipProps {
+  /**
+   * Trace identity key. Named `traceKey` (not `key`) because React
+   * silently consumes any prop literally called `key` — passing it
+   * through would arrive as `undefined`.
+   */
+  traceKey: string;
+  traceType: string;
+  variant?: EntityVariant;
+}
+
+/**
+ * Glyph per trace-type so each kind has a single-character visual hook
+ * — keeps the chip compact in dense lists. Unknown types fall back to a
+ * generic dot.
+ */
+const TYPE_GLYPH: Record<string, string> = {
+  approval: "✓",
+  enrichment: "✎",
+  recipe: "▶",
+  agent: "◆",
+  decision: "●",
+};
+
+function glyphFor(traceType: string): string {
+  return TYPE_GLYPH[traceType] ?? "·";
+}
+
+/**
+ * <TraceChip> — linked identity chip for a stored decision trace.
+ *
+ * Renders a type glyph + short key. Click-through lands on the traces
+ * page filtered by the trace's key.
+ */
+export function TraceChip({
+  traceKey,
+  traceType,
+  variant = "chip",
+}: TraceChipProps) {
+  const { className, style } = variantStyle(variant);
+  const short = traceKey.length > 24 ? `${traceKey.slice(0, 24)}…` : traceKey;
+  const ariaLabel = `Trace ${traceType} ${traceKey}`;
+  return (
+    <Link
+      href={`/traces?q=${encodeURIComponent(traceKey)}`}
+      className={className}
+      style={style}
+      aria-label={ariaLabel}
+      title={ariaLabel}
+    >
+      <span aria-hidden="true">{glyphFor(traceType)}</span>
+      <span style={{ fontFamily: "var(--font-mono)" }}>{short}</span>
+    </Link>
+  );
+}

--- a/dashboard/src/components/patchwork/entity/__tests__/entity.test.tsx
+++ b/dashboard/src/components/patchwork/entity/__tests__/entity.test.tsx
@@ -1,0 +1,202 @@
+/**
+ * Behaviour contract for the entity-chip family (Phase 0γ).
+ *
+ * One file covers every chip — variant + aria + href + dispatcher routing —
+ * because the surface they share is bigger than what each individually adds.
+ * If a chip grows substantially, split it back out.
+ */
+
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import {
+  ApprovalChip,
+  ConnectorChip,
+  EntityLink,
+  InboxChip,
+  RecipeChip,
+  RunChip,
+  SessionChip,
+  ToolChip,
+  TraceChip,
+  useEntityHref,
+} from "@/components/patchwork/entity";
+
+function hrefOf(container: HTMLElement): string | null {
+  const a = container.querySelector("a");
+  return a ? a.getAttribute("href") : null;
+}
+
+function ariaOf(container: HTMLElement): string | null {
+  const a = container.querySelector("a");
+  return a ? a.getAttribute("aria-label") : null;
+}
+
+describe("<RunChip/>", () => {
+  it("links to /runs/<seq>", () => {
+    const { container } = render(<RunChip seq={42} />);
+    expect(hrefOf(container)).toBe("/runs/42");
+  });
+
+  it("exposes aria-label with run seq and status", () => {
+    const { container } = render(<RunChip seq={7} status="done" />);
+    expect(ariaOf(container)).toContain("Run #7");
+    expect(ariaOf(container)).toContain("done");
+  });
+
+  it("renders without throwing for every variant", () => {
+    for (const v of ["chip", "row", "link"] as const) {
+      const { container } = render(<RunChip seq={1} variant={v} />);
+      expect(container.querySelector("a")).not.toBeNull();
+    }
+  });
+});
+
+describe("<RecipeChip/>", () => {
+  it("routes :agent suffix through canonicalRecipeKey", () => {
+    const { container } = render(<RecipeChip name="morning-pulse:agent" />);
+    expect(hrefOf(container)).toBe("/recipes/morning-pulse");
+  });
+
+  it("links a bare recipe name directly", () => {
+    const { container } = render(<RecipeChip name="inbox-summary" />);
+    expect(hrefOf(container)).toBe("/recipes/inbox-summary");
+  });
+
+  it("aria-label uses the canonical key", () => {
+    const { container } = render(<RecipeChip name="x:cron" />);
+    expect(ariaOf(container)).toBe("Recipe x");
+  });
+});
+
+describe("<ToolChip/>", () => {
+  it("encodes special chars in the tool name", () => {
+    const { container } = render(<ToolChip name="my tool/run" />);
+    expect(hrefOf(container)).toBe("/insights?tool=my%20tool%2Frun");
+  });
+
+  it("exposes the risk tier in aria-label", () => {
+    const { container } = render(<ToolChip name="curl" tier="high" />);
+    expect(ariaOf(container)).toContain("high risk");
+  });
+});
+
+describe("<SessionChip/>", () => {
+  it("links to /sessions/<full-id>", () => {
+    const { container } = render(<SessionChip id="01h89-abcdef-uuid" />);
+    expect(hrefOf(container)).toBe("/sessions/01h89-abcdef-uuid");
+  });
+
+  it("renders only first 8 chars visibly", () => {
+    const { container } = render(<SessionChip id="01h89XYZQRS" />);
+    const span = container.querySelector("a span");
+    expect(span?.textContent).toBe("01h89XYZ");
+  });
+});
+
+describe("<ApprovalChip/>", () => {
+  it("links to /approvals/<callId>", () => {
+    const { container } = render(<ApprovalChip callId="call_abc123" />);
+    expect(hrefOf(container)).toBe("/approvals/call_abc123");
+  });
+
+  it("aria-label includes decision verdict", () => {
+    const { container } = render(
+      <ApprovalChip callId="x" decision="rejected" />,
+    );
+    expect(ariaOf(container)).toContain("rejected");
+  });
+});
+
+describe("<TraceChip/>", () => {
+  it("links to /traces filtered by the trace key", () => {
+    const { container } = render(
+      <TraceChip traceKey="trace-1" traceType="approval" />,
+    );
+    expect(hrefOf(container)).toBe("/traces?q=trace-1");
+  });
+});
+
+describe("<ConnectorChip/>", () => {
+  it("uses a hash-anchor target (plain <a>, not Next Link)", () => {
+    const { container } = render(<ConnectorChip id="github" />);
+    const a = container.querySelector("a");
+    expect(a?.getAttribute("href")).toBe("/connections#github");
+  });
+
+  it("labels health for screen readers", () => {
+    const { container } = render(
+      <ConnectorChip id="slack" healthy={false} />,
+    );
+    expect(ariaOf(container)).toContain("unhealthy");
+  });
+});
+
+describe("<InboxChip/>", () => {
+  it("strips .md for the link target but keeps the date in the visible label", () => {
+    const { container } = render(
+      <InboxChip name="morning-brief-2026-05-20.md" />,
+    );
+    expect(hrefOf(container)).toBe(
+      "/inbox?item=morning-brief-2026-05-20",
+    );
+    const span = container.querySelector("a span");
+    expect(span?.textContent).toBe("morning-brief-2026-05-20");
+  });
+});
+
+describe("<EntityLink/> dispatcher", () => {
+  it.each([
+    ["run", "12", "/runs/12"],
+    ["recipe", "foo:agent", "/recipes/foo"],
+    ["tool", "curl", "/insights?tool=curl"],
+    ["session", "abc", "/sessions/abc"],
+    ["approval", "call_1", "/approvals/call_1"],
+    ["trace", "k", "/traces?q=k"],
+    ["connector", "gh", "/connections#gh"],
+    ["inbox", "x.md", "/inbox?item=x"],
+    ["task", "t1", "/tasks?id=t1"],
+    ["decision", "d1", "/decisions?ref=d1"],
+  ] as const)("kind=%s routes to %s", (kind, id, expectedHref) => {
+    const { container } = render(<EntityLink kind={kind} id={id} />);
+    const a = container.querySelector("a");
+    expect(a?.getAttribute("href")).toBe(expectedHref);
+  });
+});
+
+describe("useEntityHref()", () => {
+  // Pure function — call directly outside a component to lock behaviour.
+  it("matches every chip's link target", () => {
+    expect(useEntityHref("run", "9")).toBe("/runs/9");
+    expect(useEntityHref("recipe", "foo:cron")).toBe("/recipes/foo");
+    expect(useEntityHref("tool", "a/b")).toBe("/insights?tool=a%2Fb");
+    expect(useEntityHref("session", "s1")).toBe("/sessions/s1");
+    expect(useEntityHref("approval", "c1")).toBe("/approvals/c1");
+    expect(useEntityHref("trace", "t")).toBe("/traces?q=t");
+    expect(useEntityHref("connector", "gh")).toBe("/connections#gh");
+    expect(useEntityHref("inbox", "x.md")).toBe("/inbox?item=x");
+    expect(useEntityHref("task", "t1")).toBe("/tasks?id=t1");
+    expect(useEntityHref("decision", "d1")).toBe("/decisions?ref=d1");
+  });
+});
+
+describe("keyboard focusability", () => {
+  it("every chip renders a real <a> (focusable by default)", () => {
+    const cases = [
+      <RunChip key="r" seq={1} />,
+      <RecipeChip key="re" name="x" />,
+      <ToolChip key="t" name="x" />,
+      <SessionChip key="s" id="x" />,
+      <ApprovalChip key="a" callId="x" />,
+      <TraceChip key="tr" traceKey="trace-1" traceType="x" />,
+      <ConnectorChip key="c" id="x" />,
+      <InboxChip key="i" name="x.md" />,
+    ];
+    for (const node of cases) {
+      const { container } = render(node);
+      const a = container.querySelector("a");
+      expect(a).not.toBeNull();
+      // <a href=…> is focusable; absent href would drop tab order.
+      expect(a?.getAttribute("href")).toBeTruthy();
+    }
+  });
+});

--- a/dashboard/src/components/patchwork/entity/index.ts
+++ b/dashboard/src/components/patchwork/entity/index.ts
@@ -1,0 +1,29 @@
+/**
+ * Shared entity-component layer (Phase 0γ).
+ *
+ * Chips own identity + link + label; pills (StatusPill / RiskPill /
+ * LivePill) own status tone. Every chip in here renders a real link
+ * so keyboard-nav + middle-click come free at the call site.
+ *
+ * Page adoption (replacing hand-rolled chips on existing pages) is
+ * Phase 2 and lives in a separate PR — this barrel is purely additive.
+ */
+
+export { RunChip, type RunChipProps, type RunStatus } from "./RunChip";
+export { RecipeChip, type RecipeChipProps } from "./RecipeChip";
+export { ToolChip, type ToolChipProps } from "./ToolChip";
+export { SessionChip, type SessionChipProps } from "./SessionChip";
+export {
+  ApprovalChip,
+  type ApprovalChipProps,
+  type ApprovalDecision,
+} from "./ApprovalChip";
+export { TraceChip, type TraceChipProps } from "./TraceChip";
+export { ConnectorChip, type ConnectorChipProps } from "./ConnectorChip";
+export { InboxChip, type InboxChipProps } from "./InboxChip";
+export {
+  EntityLink,
+  useEntityHref,
+  type EntityLinkProps,
+} from "./EntityLink";
+export { type EntityKind, type EntityVariant } from "./types";

--- a/dashboard/src/components/patchwork/entity/types.ts
+++ b/dashboard/src/components/patchwork/entity/types.ts
@@ -1,0 +1,72 @@
+/**
+ * Shared types + helpers for the entity-chip family.
+ *
+ * Chips own identity + link + label; pills (StatusPill / RiskPill /
+ * LivePill) own status tone. These types are the small contract the
+ * whole family shares — `EntityVariant` is the visual register and
+ * `EntityKind` is the dispatcher's discriminator.
+ */
+
+import type { CSSProperties } from "react";
+
+export type EntityVariant = "chip" | "row" | "link";
+
+export type EntityKind =
+  | "run"
+  | "recipe"
+  | "tool"
+  | "session"
+  | "approval"
+  | "trace"
+  | "connector"
+  | "inbox"
+  | "task"
+  | "decision";
+
+/** Inline style + className applied based on the requested variant. */
+export function variantStyle(variant: EntityVariant = "chip"): {
+  className: string;
+  style: CSSProperties;
+} {
+  if (variant === "link") {
+    return {
+      className: "entity-link entity-link--link",
+      style: {
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 6,
+        textDecoration: "underline",
+        color: "inherit",
+      },
+    };
+  }
+  if (variant === "row") {
+    return {
+      className: "entity-link entity-link--row",
+      style: {
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 6,
+        textDecoration: "none",
+        color: "inherit",
+      },
+    };
+  }
+  // "chip" — default
+  return {
+    className: "entity-link entity-link--chip",
+    style: {
+      display: "inline-flex",
+      alignItems: "center",
+      gap: 6,
+      padding: "2px 8px",
+      borderRadius: 999,
+      border: "1px solid color-mix(in srgb, currentColor 18%, transparent)",
+      background: "color-mix(in srgb, currentColor 6%, transparent)",
+      textDecoration: "none",
+      color: "inherit",
+      fontSize: "var(--fs-xs)",
+      lineHeight: 1.2,
+    },
+  };
+}

--- a/dashboard/src/components/patchwork/index.ts
+++ b/dashboard/src/components/patchwork/index.ts
@@ -26,3 +26,4 @@ export { MetricsDonut, type DonutSegment } from "./MetricsDonut";
 export { AreaChart, type AreaChartSeries } from "./AreaChart";
 export { RunSparkBars } from "./RunSparkBars";
 export { SuccessRing, type SuccessRingProps } from "./SuccessRing";
+export * from "./entity";

--- a/dashboard/src/lib/__tests__/entityKey.test.ts
+++ b/dashboard/src/lib/__tests__/entityKey.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, it } from "vitest";
+import {
+  canonicalRecipeKey,
+  inboxItemKey,
+  parseTriggerSource,
+} from "../entityKey";
+
+/**
+ * Pre-fix divergence reproduction.
+ *
+ * Each of the three call sites had its own ad-hoc stripper:
+ *
+ *   - dashboard/src/components/RecipeLeaderboard.tsx (~L70)
+ *       name.replace(/:agent$/, "")
+ *
+ *   - dashboard/src/app/activity/page.tsx (~L69)
+ *       rawRecipe.replace(/:agent$/, "")
+ *
+ *   - dashboard/src/app/inbox/page.tsx (~L945)
+ *       name.replace(/\.md$/, "").replace(/-\d{4}-\d{2}-\d{2}$/, "")
+ *
+ * For multiple inputs they produce different values today, which is the
+ * root cause of "same recipe but linked differently" across pages.
+ * Once all three swap to canonicalRecipeKey / inboxItemKey, the three
+ * stripper outputs converge for every recipe-identity input.
+ */
+const oldLeaderboardStripper = (s: string) => s.replace(/:agent$/, "");
+const oldActivityStripper = (s: string) => s.replace(/:agent$/, "");
+const oldInboxStripper = (s: string) =>
+  s.replace(/\.md$/, "").replace(/-\d{4}-\d{2}-\d{2}$/, "");
+
+describe("pre-fix divergence — recorded for the record", () => {
+  // These cases prove the three strippers diverge today. They use the
+  // OLD inlined implementations; once call sites swap to the helper the
+  // divergence is gone because every site uses the same function.
+  it("morning-pulse:agent: leaderboard strips suffix, inbox leaves it untouched", () => {
+    const input = "morning-pulse:agent";
+    expect(oldLeaderboardStripper(input)).toBe("morning-pulse");
+    expect(oldActivityStripper(input)).toBe("morning-pulse");
+    expect(oldInboxStripper(input)).toBe("morning-pulse:agent");
+    // Leaderboard !== inbox.
+    expect(oldLeaderboardStripper(input)).not.toBe(oldInboxStripper(input));
+  });
+
+  it("morning-pulse-2026-05-20.md: inbox eats date+ext, leaderboard keeps everything", () => {
+    const input = "morning-pulse-2026-05-20.md";
+    expect(oldLeaderboardStripper(input)).toBe("morning-pulse-2026-05-20.md");
+    expect(oldInboxStripper(input)).toBe("morning-pulse");
+    expect(oldLeaderboardStripper(input)).not.toBe(oldInboxStripper(input));
+  });
+
+  it("morning-pulse-2026-05-20: inbox strips bare date, leaderboard keeps it", () => {
+    // No .md extension; inbox-stripper still chews the date off because
+    // its second .replace() is unconditional. This is the bug the
+    // sibling provenance PR addresses — inboxItemKey leaves the date
+    // alone.
+    const input = "morning-pulse-2026-05-20";
+    expect(oldLeaderboardStripper(input)).toBe("morning-pulse-2026-05-20");
+    expect(oldInboxStripper(input)).toBe("morning-pulse");
+    expect(oldLeaderboardStripper(input)).not.toBe(oldInboxStripper(input));
+  });
+});
+
+describe("canonicalRecipeKey", () => {
+  it("strips trailing :agent", () => {
+    expect(canonicalRecipeKey("morning-pulse:agent")).toBe("morning-pulse");
+  });
+
+  it("strips trailing :cron", () => {
+    expect(canonicalRecipeKey("morning-pulse:cron")).toBe("morning-pulse");
+  });
+
+  it("strips trailing :webhook", () => {
+    expect(canonicalRecipeKey("morning-pulse:webhook")).toBe("morning-pulse");
+  });
+
+  it("only strips one trailing axis suffix", () => {
+    // `:agent:cron` is not a real shape; verify we only chew the
+    // trailing one and don't recurse.
+    expect(canonicalRecipeKey("morning-pulse:agent:cron")).toBe(
+      "morning-pulse:agent",
+    );
+  });
+
+  it("trims surrounding whitespace", () => {
+    expect(canonicalRecipeKey("  morning-pulse:agent  ")).toBe("morning-pulse");
+  });
+
+  it("is case-sensitive", () => {
+    expect(canonicalRecipeKey("Morning-Pulse:AGENT")).toBe("Morning-Pulse:AGENT");
+    expect(canonicalRecipeKey("Morning-Pulse:agent")).toBe("Morning-Pulse");
+  });
+
+  it("leaves bare names untouched", () => {
+    expect(canonicalRecipeKey("morning-pulse")).toBe("morning-pulse");
+  });
+
+  it("returns empty string for empty input", () => {
+    expect(canonicalRecipeKey("")).toBe("");
+  });
+
+  it("converges the three pre-fix strippers for the same input", () => {
+    // Once every call site calls canonicalRecipeKey, the three sites
+    // necessarily compute === keys for any recipe-identity input —
+    // that's the whole point of centralizing.
+    const inputs = [
+      "morning-pulse:agent",
+      "morning-pulse:cron",
+      "morning-pulse:webhook",
+      "morning-pulse",
+      "  morning-pulse:agent  ",
+      "Morning-Pulse:agent",
+    ];
+    for (const input of inputs) {
+      const fromLeaderboard = canonicalRecipeKey(input);
+      const fromActivity = canonicalRecipeKey(input);
+      const fromInboxRecipeGuess = canonicalRecipeKey(input);
+      expect(fromLeaderboard).toBe(fromActivity);
+      expect(fromActivity).toBe(fromInboxRecipeGuess);
+    }
+  });
+});
+
+describe("parseTriggerSource", () => {
+  // Cases the bridge's parseTrigger accepts — must match byte-for-byte.
+  it("parses cron:<name>", () => {
+    expect(parseTriggerSource("cron:morning-pulse")).toEqual({
+      trigger: "cron",
+      recipeName: "morning-pulse",
+    });
+  });
+
+  it("parses webhook:<name>", () => {
+    expect(parseTriggerSource("webhook:github-pr")).toEqual({
+      trigger: "webhook",
+      recipeName: "github-pr",
+    });
+  });
+
+  it("parses recipe:<name>:p<N> parent-seq tail", () => {
+    expect(parseTriggerSource("recipe:morning-pulse:p42")).toEqual({
+      trigger: "recipe",
+      recipeName: "morning-pulse",
+      parentSeq: 42,
+    });
+  });
+
+  it("recipe name containing colons is lazy-matched up to :p<N>", () => {
+    // Bridge regex uses `.+?` so the parent-seq tail wins. Names with
+    // embedded colons stay intact in the recipeName field.
+    expect(parseTriggerSource("recipe:foo:bar:p7")).toEqual({
+      trigger: "recipe",
+      recipeName: "foo:bar",
+      parentSeq: 7,
+    });
+  });
+
+  // Cases the bridge returns null for — dashboard widens.
+  it("empty / missing input → manual", () => {
+    expect(parseTriggerSource("")).toEqual({ trigger: "manual" });
+  });
+
+  it("bare name (no kind prefix) → manual with recipeName", () => {
+    expect(parseTriggerSource("morning-pulse")).toEqual({
+      trigger: "manual",
+      recipeName: "morning-pulse",
+    });
+  });
+
+  it("<name>:agent → agent trigger", () => {
+    expect(parseTriggerSource("morning-pulse:agent")).toEqual({
+      trigger: "agent",
+      recipeName: "morning-pulse",
+    });
+  });
+});
+
+describe("inboxItemKey", () => {
+  it("strips trailing .md", () => {
+    expect(inboxItemKey("morning-pulse-2026-05-20.md")).toBe(
+      "morning-pulse-2026-05-20",
+    );
+  });
+
+  it("does NOT strip the trailing date", () => {
+    // This is the deliberate behavior change vs the old inbox stripper.
+    // Date stays as part of the inbox-item identity for display.
+    expect(inboxItemKey("morning-pulse-2026-05-20")).toBe(
+      "morning-pulse-2026-05-20",
+    );
+  });
+
+  it("returns name unchanged when there is no .md", () => {
+    expect(inboxItemKey("morning-pulse")).toBe("morning-pulse");
+  });
+
+  it("returns empty string for empty input", () => {
+    expect(inboxItemKey("")).toBe("");
+  });
+});

--- a/dashboard/src/lib/entityKey.ts
+++ b/dashboard/src/lib/entityKey.ts
@@ -1,0 +1,101 @@
+/**
+ * Canonical entity-key helpers for the dashboard.
+ *
+ * Three pages previously each implemented their own ad-hoc stripping for
+ * recipe identity (RecipeLeaderboard, activity/page, inbox/page). They
+ * disagreed on edge cases, which caused the same recipe to render under
+ * different keys / links on different pages. Centralize here so every page
+ * computes the same key for the same input.
+ *
+ * The bridge stays authoritative for trigger-source parsing (see
+ * `RecipeRunLog.parseTrigger` in `src/runLog.ts` ~line 198). The
+ * `parseTriggerSource` export below is a client-side port of that parser
+ * for dashboard-local computation; behavior mirrors the bridge exactly.
+ */
+
+/** Agent-axis suffixes the bridge appends to recipe names. */
+const AGENT_AXIS_SUFFIX_RE = /:(?:agent|cron|webhook)$/;
+
+/**
+ * Canonical recipe-identity key.
+ *
+ * - Trims surrounding whitespace.
+ * - Strips a trailing agent-axis suffix (`:agent` / `:cron` / `:webhook`).
+ * - Case-sensitive — does NOT lowercase. Recipe names are case-sensitive
+ *   on disk and the bridge treats them as such.
+ *
+ * Returns the bare recipe name. Empty-string in → empty-string out.
+ */
+export function canonicalRecipeKey(name: string): string {
+  if (typeof name !== "string") return "";
+  return name.trim().replace(AGENT_AXIS_SUFFIX_RE, "");
+}
+
+export type TriggerKind =
+  | "manual"
+  | "cron"
+  | "webhook"
+  | "recipe"
+  | "agent";
+
+export interface ParsedTriggerSource {
+  trigger: TriggerKind;
+  recipeName?: string;
+  parentSeq?: number;
+}
+
+/**
+ * Parse a recipe-run triggerSource string.
+ *
+ * Mirrors `RecipeRunLog.parseTrigger` in the bridge
+ * (`src/runLog.ts` ~line 198):
+ *
+ *     /^(cron|webhook|recipe):(.+?)(?::p(\d+))?$/
+ *
+ * The bridge's parser only knows three trigger kinds (cron / webhook /
+ * recipe) and returns `null` for anything else; the dashboard sees a
+ * broader set of inputs (manual UI launches, agent-axis names) so this
+ * port widens the return type to a discriminated union instead of `null`.
+ * For inputs the bridge would have accepted, the `{trigger, recipeName,
+ * parentSeq?}` shape is byte-for-byte identical.
+ *
+ * Behavior for inputs the bridge would reject:
+ *   - missing / falsy           → `{trigger: "manual"}`
+ *   - bare name (no prefix)     → `{trigger: "manual", recipeName: <input>}`
+ *   - `<name>:agent`            → `{trigger: "agent", recipeName: <name>}`
+ */
+export function parseTriggerSource(src: string): ParsedTriggerSource {
+  if (typeof src !== "string" || src.length === 0) {
+    return { trigger: "manual" };
+  }
+  // Bridge's exact regex — keep in lockstep with src/runLog.ts.
+  const m = /^(cron|webhook|recipe):(.+?)(?::p(\d+))?$/.exec(src);
+  if (m?.[1] && m[2]) {
+    const out: ParsedTriggerSource = {
+      trigger: m[1] as TriggerKind,
+      recipeName: m[2],
+    };
+    if (m[3] !== undefined) out.parentSeq = parseInt(m[3], 10);
+    return out;
+  }
+  // Bridge returns null here. Dashboard widens to expose the original
+  // input as either an `agent`-axis run or a manual launch.
+  const agentMatch = /^(.+):agent$/.exec(src);
+  if (agentMatch?.[1]) {
+    return { trigger: "agent", recipeName: agentMatch[1] };
+  }
+  return { trigger: "manual", recipeName: src };
+}
+
+/**
+ * Inbox filename → display/identity key.
+ *
+ * Strips a trailing `.md` and nothing else. Does NOT strip the trailing
+ * date — date stays part of the inbox item's identity for display.
+ * (The old inbox page stripped `-YYYY-MM-DD` as a recipe-name guess;
+ * that responsibility is moving to provenance metadata in a sibling PR.)
+ */
+export function inboxItemKey(name: string): string {
+  if (typeof name !== "string") return "";
+  return name.replace(/\.md$/, "");
+}


### PR DESCRIPTION
## Summary
- Adds `dashboard/src/components/patchwork/entity/` — shared chips for run / recipe / tool / session / approval / trace / connector / inbox, plus an `EntityLink` dispatcher and a `useEntityHref(kind,id)` resolver that future `RelationStrip` items can reuse.
- Chips own identity + link + label; existing `StatusPill` / `RiskPill` / `LivePill` keep status-tone duty (reused, not duplicated). Recipe + inbox links route through the canonical-key helper introduced in #740.
- Every chip renders a real anchor (`<Link>` for path targets, `<a>` for `/connections#`-style hash targets) so keyboard nav and middle-click open work without per-call-site wiring. ARIA labels + `srLabel` on inner pills keep status off-colour for AT users.
- Purely additive — no existing pages touched. Page adoption is Phase 2 and ships separately.

Base is `feat/entity-key-helper` (PR #740) because that helper isn't merged yet. When #740 lands, GitHub will retarget this PR to `main` automatically.

## Test plan
- [x] `cd dashboard && npx tsc --noEmit` clean
- [x] `cd dashboard && npx vitest run src/components/patchwork/entity` — 28 / 28 passing (variant rendering, href targets, aria-labels, dispatcher routing across all kinds, keyboard focusability via real `<a>` elements, `:agent` suffix routed through `canonicalRecipeKey`).
- [ ] Spot-check that no current page imports broke (none should — additive only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)