### PR TITLE
feat(dashboard): recipe detail hub /recipes/[name] — definition + schedule + runs + outputs + controls

### DIFF
--- a/dashboard/src/app/activity/page.tsx
+++ b/dashboard/src/app/activity/page.tsx
@@ -3,6 +3,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { apiPath } from "@/lib/api";
+import { canonicalRecipeKey } from "@/lib/entityKey";
 import { relTime } from "@/components/time";
 import { ACTIVITY_NOISE_EVENTS } from "@/lib/activityNoise";
 import { subscribeStreamLiveness, subscribeStreamMessage } from "@/lib/streamLiveness";
@@ -66,7 +67,7 @@ function getLifecycleMeta(e: ActivityEvent) {
     sessionId:
       typeof m.sessionId === "string" ? m.sessionId.slice(0, 8) : undefined,
     summary: typeof m.summary === "string" ? m.summary : undefined,
-    recipeName: rawRecipe ? rawRecipe.replace(/:agent$/, "") : undefined,
+    recipeName: rawRecipe ? canonicalRecipeKey(rawRecipe) : undefined,
   };
 }
 

--- a/dashboard/src/app/inbox/page.tsx
+++ b/dashboard/src/app/inbox/page.tsx
@@ -4,6 +4,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import dynamic from "next/dynamic";
 import Link from "next/link";
 import { apiPath } from "@/lib/api";
+import { inboxItemKey } from "@/lib/entityKey";
 import { EmptyState, ErrorState, HintCard } from "@/components/patchwork";
 import { SkeletonList } from "@/components/Skeleton";
 import { InboxDeliveryCard } from "@/components/InboxDeliveryCard";
@@ -942,7 +943,12 @@ const filteredItems = items.filter((item) => {
 
                   {/* Action buttons (bottom) */}
                   {(() => {
-                    const recipeNameForSelected = selected.name.replace(/\.md$/, "").replace(/-\d{4}-\d{2}-\d{2}$/, "");
+                    // Strip .md only; the trailing date stays — recipe
+                    // identity from a filename is a sibling-PR concern
+                    // (moves to provenance metadata). For now the deep
+                    // link can include the date and the recipes page
+                    // will gracefully no-op if no recipe matches.
+                    const recipeNameForSelected = inboxItemKey(selected.name);
                     return (
                       <>
                       <div className="inbox-reader-actions" style={{ display: "flex", flexWrap: "wrap", gap: 6, marginTop: 16, paddingTop: 16, borderTop: "1px solid var(--line-1)" }}>

--- a/dashboard/src/app/recipes/[name]/layout.tsx
+++ b/dashboard/src/app/recipes/[name]/layout.tsx
@@ -1,0 +1,312 @@
+"use client";
+
+/**
+ * Recipe detail hub — shared layout.
+ *
+ * Wraps `/recipes/[name]` (Overview), `/edit`, and `/plan` so the recipe
+ * is the anchor of the journey instead of three independent pages. The
+ * Overview hub is the new landing point from the recipes list (PR
+ * `feat/recipe-detail-hub`, Phase 1). Edit + Plan still render their
+ * own bodies below this header — Phase 4 will retire their duplicate
+ * page-heads.
+ */
+
+import Link from "next/link";
+import { usePathname, useRouter } from "next/navigation";
+import { use, useEffect, useMemo, useRef } from "react";
+import { canonicalRecipeKey } from "@/lib/entityKey";
+import { RelationStrip, StatusPill } from "@/components/patchwork";
+import { useBridgeFetch } from "@/hooks/useBridgeFetch";
+
+interface RecipeSummary {
+  name: string;
+  description?: string;
+  trigger?: string;
+  enabled?: boolean;
+  lint?: { ok: boolean; errorCount: number; warningCount: number };
+}
+
+interface RecipesListResponse {
+  recipes?: RecipeSummary[];
+}
+
+// Tool prefix → connector name. Copy of detectConnectors() from the list
+// page, narrowed to a single recipe. Kept inline to avoid a cross-file
+// refactor in Phase 1 (task explicitly defers that).
+const TOOL_PREFIX_MAP: Record<string, string> = {
+  slack_: "slack",
+  github_: "github",
+  jira_: "jira",
+  linear_: "linear",
+  gmail_: "gmail",
+  calendar_: "googleCalendar",
+  intercom_: "intercom",
+  hubspot_: "hubspot",
+  datadog_: "datadog",
+  stripe_: "stripe",
+  sentry_: "sentry",
+};
+
+export function detectConnectorsForRecipe(recipe: RecipeSummary): string[] {
+  const haystack = `${recipe.name} ${recipe.description ?? ""}`.toLowerCase();
+  const found = new Set<string>();
+  for (const [prefix, connector] of Object.entries(TOOL_PREFIX_MAP)) {
+    const keyword = prefix.replace(/_$/, "");
+    if (haystack.includes(prefix) || haystack.includes(keyword)) {
+      found.add(connector);
+    }
+  }
+  return Array.from(found).sort();
+}
+
+type TabKey = "overview" | "edit" | "plan";
+
+interface TabSpec {
+  key: TabKey;
+  label: string;
+  href: (name: string) => string;
+  match: (pathname: string, name: string) => boolean;
+}
+
+function basePath(name: string): string {
+  return `/recipes/${encodeURIComponent(name)}`;
+}
+
+const TABS: TabSpec[] = [
+  {
+    key: "overview",
+    label: "Overview",
+    href: (n) => basePath(n),
+    match: (p, n) => p === basePath(n) || p === `${basePath(n)}/`,
+  },
+  {
+    key: "edit",
+    label: "Edit",
+    href: (n) => `${basePath(n)}/edit`,
+    match: (p, n) => p.startsWith(`${basePath(n)}/edit`),
+  },
+  {
+    key: "plan",
+    label: "Plan",
+    href: (n) => `${basePath(n)}/plan`,
+    match: (p, n) => p.startsWith(`${basePath(n)}/plan`),
+  },
+];
+
+function TabBar({ name }: { name: string }) {
+  const pathname = usePathname() ?? "";
+  const router = useRouter();
+  const tabRefs = useRef<Array<HTMLAnchorElement | null>>([]);
+  const activeIdx = useMemo(() => {
+    const i = TABS.findIndex((t) => t.match(pathname, name));
+    return i < 0 ? 0 : i;
+  }, [pathname, name]);
+
+  function onKey(e: React.KeyboardEvent<HTMLAnchorElement>, idx: number) {
+    let next = idx;
+    if (e.key === "ArrowLeft") next = (idx - 1 + TABS.length) % TABS.length;
+    else if (e.key === "ArrowRight") next = (idx + 1) % TABS.length;
+    else if (e.key === "Home") next = 0;
+    else if (e.key === "End") next = TABS.length - 1;
+    else if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      router.push(TABS[idx].href(name));
+      return;
+    } else return;
+    e.preventDefault();
+    tabRefs.current[next]?.focus();
+  }
+
+  return (
+    <div
+      role="tablist"
+      aria-label="Recipe sections"
+      style={{
+        display: "flex",
+        gap: 4,
+        marginTop: 12,
+        borderBottom: "1px solid var(--line-2)",
+      }}
+    >
+      {TABS.map((t, i) => {
+        const isActive = i === activeIdx;
+        return (
+          <Link
+            key={t.key}
+            ref={(el) => {
+              tabRefs.current[i] = el;
+            }}
+            href={t.href(name)}
+            role="tab"
+            aria-selected={isActive}
+            aria-current={isActive ? "page" : undefined}
+            tabIndex={isActive ? 0 : -1}
+            onKeyDown={(e) => onKey(e, i)}
+            style={{
+              padding: "8px 14px",
+              fontSize: "var(--fs-s)",
+              fontWeight: isActive ? 600 : 500,
+              color: isActive ? "var(--accent)" : "var(--ink-2)",
+              textDecoration: "none",
+              borderBottom: `2px solid ${isActive ? "var(--accent)" : "transparent"}`,
+              marginBottom: -1,
+              transition: "color 120ms, border-color 120ms",
+            }}
+          >
+            {t.label}
+          </Link>
+        );
+      })}
+    </div>
+  );
+}
+
+function Breadcrumb({ name }: { name: string }) {
+  return (
+    <nav aria-label="Breadcrumb" style={{ fontSize: "var(--fs-xs)", color: "var(--ink-3)" }}>
+      <ol
+        style={{
+          display: "flex",
+          gap: 6,
+          alignItems: "center",
+          listStyle: "none",
+          padding: 0,
+          margin: 0,
+        }}
+      >
+        <li>
+          <Link href="/recipes" style={{ color: "var(--ink-3)", textDecoration: "none" }}>
+            Recipes
+          </Link>
+        </li>
+        <li aria-hidden="true" style={{ color: "var(--ink-4, var(--ink-3))" }}>
+          /
+        </li>
+        <li aria-current="page" style={{ color: "var(--ink-2)", fontFamily: "var(--font-mono)" }}>
+          {name}
+        </li>
+      </ol>
+    </nav>
+  );
+}
+
+function statusPillFor(recipe: RecipeSummary | undefined): {
+  tone: "ok" | "warn" | "err" | "muted";
+  label: string;
+} {
+  if (!recipe) return { tone: "muted", label: "loading" };
+  if (recipe.lint && recipe.lint.ok === false) return { tone: "err", label: "lint error" };
+  if (recipe.enabled === false) return { tone: "muted", label: "disabled" };
+  return { tone: "ok", label: "enabled" };
+}
+
+export default function RecipeDetailLayout({
+  children,
+  params,
+}: {
+  children: React.ReactNode;
+  params: Promise<{ name: string }>;
+}) {
+  const { name: rawName } = use(params);
+  const name = canonicalRecipeKey(decodeURIComponent(rawName));
+
+  // Resolve the recipe from the list endpoint. Cheap, cached, and the
+  // single-recipe `/api/bridge/recipes/[name]` returns raw YAML rather
+  // than the structured Recipe row we need for the header.
+  const { data: recipes } = useBridgeFetch<RecipeSummary[]>(
+    "/api/bridge/recipes",
+    {
+      intervalMs: 30_000,
+      transform: (raw) => {
+        if (Array.isArray(raw)) return raw as RecipeSummary[];
+        const obj = raw as RecipesListResponse;
+        return obj?.recipes ?? [];
+      },
+    },
+  );
+
+  const recipe = useMemo(
+    () => recipes?.find((r) => canonicalRecipeKey(r.name) === name),
+    [recipes, name],
+  );
+
+  // Set document title so browser tabs reflect the recipe.
+  useEffect(() => {
+    if (typeof document === "undefined") return;
+    const prev = document.title;
+    document.title = `${name} · Recipes · Patchwork`;
+    return () => {
+      document.title = prev;
+    };
+  }, [name]);
+
+  const { tone, label } = statusPillFor(recipe);
+  const connectors = useMemo(
+    () => (recipe ? detectConnectorsForRecipe(recipe) : []),
+    [recipe],
+  );
+
+  const relationItems = useMemo(() => {
+    const enc = encodeURIComponent(name);
+    const items = [
+      { label: "Runs", href: `/runs?recipe=${enc}`, title: `Runs of ${name}` },
+      {
+        label: "Halts",
+        href: `/runs?recipe=${enc}&halt=1`,
+        tone: "warn" as const,
+        title: `Halted runs of ${name}`,
+      },
+      { label: "Traces", href: `/traces?recipe=${enc}`, title: `Decision traces for ${name}` },
+      { label: "Inbox", href: `/inbox?recipe=${enc}`, title: `Inbox outputs from ${name}` },
+      { label: "Approvals", href: `/approvals?recipe=${enc}`, title: `Approvals for ${name}` },
+    ];
+    for (const c of connectors) {
+      items.push({ label: c, href: `/connections#${c}`, title: `Connector: ${c}` });
+    }
+    items.push({ label: "Edit", href: `/recipes/${enc}/edit`, title: "Edit YAML" });
+    items.push({ label: "Plan", href: `/recipes/${enc}/plan`, title: "Dry-run plan" });
+    return items;
+  }, [name, connectors]);
+
+  return (
+    <section>
+      <div style={{ marginBottom: 16 }}>
+        <Breadcrumb name={name} />
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 12,
+            marginTop: 8,
+            flexWrap: "wrap",
+          }}
+        >
+          <h1
+            style={{
+              margin: 0,
+              fontFamily: "var(--font-mono)",
+              fontSize: "var(--fs-2xl, 1.5rem)",
+            }}
+          >
+            {name}
+          </h1>
+          <StatusPill tone={tone}>{label}</StatusPill>
+        </div>
+        {recipe?.description && (
+          <div
+            style={{
+              marginTop: 6,
+              color: "var(--ink-3)",
+              fontSize: "var(--fs-s)",
+            }}
+          >
+            {recipe.description}
+          </div>
+        )}
+        <RelationStrip items={relationItems} />
+        <TabBar name={name} />
+      </div>
+      {children}
+    </section>
+  );
+}

--- a/dashboard/src/app/recipes/[name]/page.tsx
+++ b/dashboard/src/app/recipes/[name]/page.tsx
@@ -1,0 +1,689 @@
+"use client";
+
+/**
+ * Recipe detail hub — Overview tab.
+ *
+ * Lands when the user clicks a row on `/recipes`. Surfaces:
+ *  - Summary card (trigger, schedule, last-run outcome, success rate, avg duration)
+ *  - Recent runs (last 5-10, RunChip rows; "View all runs" link)
+ *  - Halt summary (categorised; "View halts" link) — only when halts exist
+ *  - Connectors required (ConnectorChip + health dot)
+ *  - Latest inbox output (when bridge surfaces `inboxOutputs`; PR #742+)
+ *  - Controls: Run now, Enable/Disable, Edit, Plan, Compare, Uninstall
+ *
+ * The shared `layout.tsx` owns the breadcrumb, H1, status pill, RelationStrip,
+ * and tab bar — this file is just the body.
+ */
+
+import Link from "next/link";
+import { use, useCallback, useEffect, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import { apiPath } from "@/lib/api";
+import { canonicalRecipeKey } from "@/lib/entityKey";
+import { useBridgeFetch } from "@/hooks/useBridgeFetch";
+import { useToast } from "@/components/Toast";
+import { Dialog } from "@/components/Dialog";
+import {
+  ConnectorChip,
+  EmptyState,
+  InboxChip,
+  PatchCard,
+  RunChip,
+  StatusPill,
+} from "@/components/patchwork";
+import { detectConnectorsForRecipe } from "./layout";
+
+interface RecipeVar {
+  name: string;
+  description?: string;
+  required?: boolean;
+  default?: string;
+}
+
+interface Recipe {
+  name: string;
+  description?: string;
+  version?: string;
+  trigger?: string;
+  schedule?: string;
+  webhookPath?: string;
+  stepCount?: number;
+  enabled?: boolean;
+  vars?: RecipeVar[];
+  path?: string;
+}
+
+interface RunRecord {
+  seq?: number;
+  recipe: string;
+  recipeName?: string;
+  startedAt: number;
+  status: string;
+  durationMs?: number;
+  hadStepErrors?: boolean;
+  inboxOutputs?: Array<{ filename: string; deliveredAt: number }>;
+}
+
+type HaltCategory =
+  | "agent_silent_fail"
+  | "agent_narration_only"
+  | "agent_threw"
+  | "tool_threw"
+  | "tool_error"
+  | "kill_switch"
+  | "run_level"
+  | "unknown";
+
+interface HaltSummary {
+  total: number;
+  byCategory: Partial<Record<HaltCategory, number>>;
+  recent: Array<{ reason: string; category: HaltCategory; runSeq: number }>;
+}
+
+interface ConnectorStatus {
+  id: string;
+  healthy?: boolean;
+}
+
+const HALT_CATEGORY_LABEL: Record<HaltCategory, string> = {
+  agent_silent_fail: "agent silent-fail",
+  agent_narration_only: "agent narration-only",
+  agent_threw: "agent threw",
+  tool_threw: "tool threw",
+  tool_error: "tool error",
+  kill_switch: "kill switch",
+  run_level: "run-level",
+  unknown: "unknown",
+};
+
+function relTime(ms: number): string {
+  const diff = Date.now() - ms;
+  const sec = Math.floor(diff / 1000);
+  if (sec < 60) return "just now";
+  const min = Math.floor(sec / 60);
+  if (min < 60) return `${min}m ago`;
+  const hrs = Math.floor(min / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  const days = Math.floor(hrs / 24);
+  if (days < 7) return `${days}d ago`;
+  return new Date(ms).toLocaleDateString("en-US", { month: "short", day: "numeric" });
+}
+
+function formatDuration(ms: number | undefined): string {
+  if (typeof ms !== "number" || !Number.isFinite(ms) || ms <= 0) return "—";
+  if (ms < 1000) return `${Math.round(ms)}ms`;
+  if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`;
+  const m = Math.floor(ms / 60_000);
+  const s = Math.round((ms % 60_000) / 1000);
+  return `${m}m ${s}s`;
+}
+
+function SectionHeader({ children }: { children: React.ReactNode }) {
+  return (
+    <h2
+      style={{
+        fontSize: "var(--fs-xs)",
+        fontWeight: 700,
+        textTransform: "uppercase",
+        letterSpacing: "0.08em",
+        color: "var(--ink-3)",
+        margin: "0 0 10px",
+      }}
+    >
+      {children}
+    </h2>
+  );
+}
+
+function RunModal({
+  open,
+  recipe,
+  onClose,
+  onConfirm,
+  running,
+}: {
+  open: boolean;
+  recipe: Recipe | null;
+  onClose: () => void;
+  onConfirm: (vars: Record<string, string>) => void;
+  running: boolean;
+}) {
+  const [values, setValues] = useState<Record<string, string>>({});
+  useEffect(() => {
+    if (!open || !recipe) return;
+    const init: Record<string, string> = {};
+    for (const v of recipe.vars ?? []) init[v.name] = v.default ?? "";
+    setValues(init);
+  }, [open, recipe]);
+  const vars = recipe?.vars ?? [];
+  return (
+    <Dialog open={open} onClose={onClose} ariaLabelledBy="hub-run-modal-title" maxWidth={480}>
+      {recipe && (
+        <>
+          <div style={{ display: "flex", justifyContent: "space-between", marginBottom: "var(--s-4)" }}>
+            <h2 id="hub-run-modal-title" style={{ margin: 0, fontSize: "var(--fs-xl)", fontWeight: 600 }}>
+              Run <code>{recipe.name}</code>
+            </h2>
+            <button type="button" className="btn sm ghost" onClick={onClose} aria-label="Close">×</button>
+          </div>
+          <form
+            onSubmit={(e) => {
+              e.preventDefault();
+              onConfirm(values);
+            }}
+          >
+            {vars.length === 0 && (
+              <div
+                style={{
+                  marginBottom: "var(--s-4)",
+                  padding: "var(--s-3) var(--s-4)",
+                  border: "1px solid var(--line-2)",
+                  borderRadius: "var(--r-1)",
+                  background: "var(--bg-2)",
+                  fontSize: "var(--fs-m)",
+                  color: "var(--fg-2)",
+                }}
+              >
+                Running this recipe will execute its steps immediately and may use API credits or
+                call external services.
+              </div>
+            )}
+            <div style={{ display: "flex", flexDirection: "column", gap: "var(--s-4)" }}>
+              {vars.map((v) => (
+                <div key={v.name}>
+                  <label
+                    htmlFor={`hub-run-${v.name}`}
+                    style={{
+                      display: "block",
+                      marginBottom: 4,
+                      fontSize: "var(--fs-m)",
+                      fontFamily: "var(--font-mono)",
+                    }}
+                  >
+                    {v.name}
+                    {v.required && <span style={{ color: "var(--err)", marginLeft: 4 }}>*</span>}
+                  </label>
+                  {v.description && (
+                    <div style={{ fontSize: "var(--fs-s)", color: "var(--fg-3)", marginBottom: 4 }}>
+                      {v.description}
+                    </div>
+                  )}
+                  <input
+                    id={`hub-run-${v.name}`}
+                    type="text"
+                    required={v.required}
+                    value={values[v.name] ?? ""}
+                    onChange={(e) => setValues((prev) => ({ ...prev, [v.name]: e.target.value }))}
+                    className="input"
+                    style={{ width: "100%" }}
+                  />
+                </div>
+              ))}
+            </div>
+            <div style={{ display: "flex", gap: "var(--s-3)", marginTop: "var(--s-5)", justifyContent: "flex-end" }}>
+              <button type="button" className="btn ghost" onClick={onClose} disabled={running}>
+                Cancel
+              </button>
+              <button type="submit" className="btn warn" disabled={running}>
+                {running ? "Starting…" : "Run recipe"}
+              </button>
+            </div>
+          </form>
+        </>
+      )}
+    </Dialog>
+  );
+}
+
+export default function RecipeHubOverviewPage({
+  params,
+}: {
+  params: Promise<{ name: string }>;
+}) {
+  const { name: rawName } = use(params);
+  const name = canonicalRecipeKey(decodeURIComponent(rawName));
+  const toast = useToast();
+  const router = useRouter();
+
+  // Reusable list fetch for the recipe row (matches layout's data source).
+  const { data: recipes, refetch: refetchRecipes } = useBridgeFetch<Recipe[]>(
+    "/api/bridge/recipes",
+    {
+      intervalMs: 30_000,
+      transform: (raw) => {
+        if (Array.isArray(raw)) return raw as Recipe[];
+        const obj = raw as { recipes?: Recipe[] };
+        return obj?.recipes ?? [];
+      },
+    },
+  );
+  const recipe = useMemo(
+    () => recipes?.find((r) => canonicalRecipeKey(r.name) === name) ?? null,
+    [recipes, name],
+  );
+
+  // Runs filtered by recipe — bridge supports ?recipe= filter.
+  const { data: runsResp } = useBridgeFetch<{ runs: RunRecord[] }>(
+    `/api/bridge/runs?recipe=${encodeURIComponent(name)}&limit=50`,
+    { intervalMs: 10_000 },
+  );
+  const runs: RunRecord[] = useMemo(() => {
+    const raw = runsResp?.runs ?? [];
+    // Client-side guard in case the bridge ignores the param.
+    return raw
+      .filter((r) => canonicalRecipeKey(r.recipeName ?? r.recipe ?? "") === name)
+      .sort((a, b) => b.startedAt - a.startedAt);
+  }, [runsResp, name]);
+
+  // Halt summary filtered by recipe.
+  const { data: haltSummary } = useBridgeFetch<HaltSummary>(
+    `/api/bridge/runs/halt-summary?recipe=${encodeURIComponent(name)}`,
+    { intervalMs: 30_000 },
+  );
+
+  // Connector health — best-effort.
+  const { data: connectorStatuses } = useBridgeFetch<ConnectorStatus[]>(
+    "/api/bridge/connectors/status",
+    {
+      intervalMs: 60_000,
+      transform: (raw) => {
+        if (Array.isArray(raw)) return raw as ConnectorStatus[];
+        const obj = raw as { connectors?: ConnectorStatus[] };
+        return obj?.connectors ?? [];
+      },
+    },
+  );
+
+  const requiredConnectors = useMemo(
+    () => (recipe ? detectConnectorsForRecipe(recipe) : []),
+    [recipe],
+  );
+
+  const connectorHealthMap = useMemo(() => {
+    const m = new Map<string, boolean | undefined>();
+    for (const c of connectorStatuses ?? []) m.set(c.id, c.healthy);
+    return m;
+  }, [connectorStatuses]);
+
+  // Derived run metrics.
+  const lastRun = runs[0];
+  const recentRuns = runs.slice(0, 10);
+  const successPct = useMemo(() => {
+    const settled = runs.filter(
+      (r) => r.status !== "running" && r.status !== "queued" && r.status !== "pending",
+    );
+    if (settled.length === 0) return null;
+    const ok = settled.filter((r) => r.status === "done" || r.status === "success").length;
+    return (ok / settled.length) * 100;
+  }, [runs]);
+  const avgDurationMs = useMemo(() => {
+    const ds = runs.map((r) => r.durationMs).filter((d): d is number => typeof d === "number" && d > 0);
+    if (ds.length === 0) return undefined;
+    return ds.reduce((s, d) => s + d, 0) / ds.length;
+  }, [runs]);
+
+  // Latest inbox output — PR #742 attaches inboxOutputs to RecipeRun.
+  const latestInboxOutput = useMemo(() => {
+    for (const r of runs) {
+      if (Array.isArray(r.inboxOutputs) && r.inboxOutputs.length > 0) {
+        const sorted = [...r.inboxOutputs].sort((a, b) => b.deliveredAt - a.deliveredAt);
+        return sorted[0];
+      }
+    }
+    return null;
+  }, [runs]);
+
+  // Controls state.
+  const [runModalOpen, setRunModalOpen] = useState(false);
+  const [runStarting, setRunStarting] = useState(false);
+  const [toggling, setToggling] = useState(false);
+
+  const handleRunConfirm = useCallback(
+    async (vars: Record<string, string>) => {
+      if (!recipe) return;
+      setRunStarting(true);
+      try {
+        const body: Record<string, unknown> = {};
+        if (Object.keys(vars).length > 0) body.vars = vars;
+        const res = await fetch(
+          apiPath(`/api/bridge/recipes/${encodeURIComponent(recipe.name)}/run`),
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(body),
+          },
+        );
+        const data = (await res.json()) as { ok: boolean; taskId?: string; error?: string };
+        if (data.ok) {
+          toast.success(`Started ${recipe.name}`);
+          setRunModalOpen(false);
+        } else {
+          toast.error(`Run failed: ${data.error ?? "unknown"}`);
+        }
+      } catch (e) {
+        toast.error(`Run failed: ${e instanceof Error ? e.message : String(e)}`);
+      } finally {
+        setRunStarting(false);
+      }
+    },
+    [recipe, toast],
+  );
+
+  const handleToggle = useCallback(async () => {
+    if (!recipe || toggling) return;
+    const target = recipe.enabled === false;
+    const trigger = recipe.trigger ?? "manual";
+    if (!target && trigger !== "manual") {
+      const proceed = window.confirm(
+        `Disable "${recipe.name}"? Trigger "${trigger}" will stop firing until you re-enable.`,
+      );
+      if (!proceed) return;
+    }
+    setToggling(true);
+    try {
+      const res = await fetch(
+        apiPath(`/api/bridge/recipes/${encodeURIComponent(recipe.name)}`),
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ enabled: target }),
+        },
+      );
+      if (!res.ok) throw new Error(`PATCH /recipes ${res.status}`);
+      toast.success(target ? "Enabled" : "Disabled");
+      refetchRecipes();
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : String(e));
+    } finally {
+      setToggling(false);
+    }
+  }, [recipe, toggling, toast, refetchRecipes]);
+
+  const handleUninstall = useCallback(async () => {
+    if (!recipe) return;
+    const proceed = window.confirm(
+      `Permanently delete "${recipe.name}"? This removes the YAML file. Cannot be undone.`,
+    );
+    if (!proceed) return;
+    try {
+      const res = await fetch(
+        apiPath(`/api/bridge/recipes/${encodeURIComponent(recipe.name)}`),
+        { method: "DELETE" },
+      );
+      if (!res.ok) {
+        const text = await res.text().catch(() => res.statusText);
+        toast.error(`Delete failed: ${text || res.status}`);
+        return;
+      }
+      toast.success(`Deleted ${recipe.name}`);
+      router.push("/recipes");
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : String(e));
+    }
+  }, [recipe, router, toast]);
+
+  const scheduleString = useMemo(() => {
+    if (!recipe) return "—";
+    const trig = recipe.trigger ?? "manual";
+    if (trig === "cron" || trig === "schedule") return recipe.schedule ?? "cron (unknown)";
+    if (trig === "webhook") return recipe.webhookPath ?? "webhook";
+    return trig;
+  }, [recipe]);
+
+  const lastRunDerived = useMemo(() => {
+    if (!lastRun) return null;
+    const ok = lastRun.status === "done" || lastRun.status === "success";
+    const fail = lastRun.status === "error" || lastRun.status === "failed";
+    const tone: "ok" | "warn" | "err" | "info" | "muted" = ok
+      ? "ok"
+      : fail
+        ? "err"
+        : lastRun.status === "running"
+          ? "info"
+          : "warn";
+    return { tone, label: lastRun.status, when: relTime(lastRun.startedAt) };
+  }, [lastRun]);
+
+  if (recipes && !recipe) {
+    return (
+      <EmptyState
+        title="Recipe not found"
+        description={`No recipe named "${name}" is installed.`}
+        action={
+          <Link href="/recipes" className="btn primary" style={{ textDecoration: "none" }}>
+            Back to recipes
+          </Link>
+        }
+      />
+    );
+  }
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "var(--s-5)" }}>
+      <RunModal
+        open={runModalOpen}
+        recipe={recipe}
+        onClose={() => setRunModalOpen(false)}
+        onConfirm={handleRunConfirm}
+        running={runStarting}
+      />
+
+      {/* SUMMARY */}
+      <PatchCard style={{ padding: "var(--s-4)" }}>
+        <SectionHeader>Summary</SectionHeader>
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "repeat(auto-fit, minmax(160px, 1fr))",
+            gap: "var(--s-4)",
+            fontSize: "var(--fs-s)",
+          }}
+        >
+          <div>
+            <div style={{ color: "var(--ink-3)", fontSize: "var(--fs-xs)" }}>Trigger</div>
+            <div style={{ fontFamily: "var(--font-mono)", marginTop: 2 }}>{recipe?.trigger ?? "manual"}</div>
+          </div>
+          <div>
+            <div style={{ color: "var(--ink-3)", fontSize: "var(--fs-xs)" }}>Schedule</div>
+            <div style={{ fontFamily: "var(--font-mono)", marginTop: 2 }}>{scheduleString}</div>
+          </div>
+          <div>
+            <div style={{ color: "var(--ink-3)", fontSize: "var(--fs-xs)" }}>Last run</div>
+            <div style={{ marginTop: 2, display: "flex", alignItems: "center", gap: 6 }}>
+              {lastRunDerived ? (
+                <>
+                  <StatusPill tone={lastRunDerived.tone}>{lastRunDerived.label}</StatusPill>
+                  <span style={{ color: "var(--ink-3)" }}>{lastRunDerived.when}</span>
+                </>
+              ) : (
+                <span style={{ color: "var(--ink-3)" }}>never</span>
+              )}
+            </div>
+          </div>
+          <div>
+            <div style={{ color: "var(--ink-3)", fontSize: "var(--fs-xs)" }}>Success rate</div>
+            <div style={{ fontFamily: "var(--font-mono)", marginTop: 2, fontVariantNumeric: "tabular-nums" }}>
+              {successPct == null ? "—" : `${successPct.toFixed(0)}%`}
+              {runs.length > 0 && (
+                <span style={{ color: "var(--ink-3)", marginLeft: 4, fontSize: "var(--fs-xs)" }}>
+                  over {runs.length}
+                </span>
+              )}
+            </div>
+          </div>
+          <div>
+            <div style={{ color: "var(--ink-3)", fontSize: "var(--fs-xs)" }}>Avg duration</div>
+            <div style={{ fontFamily: "var(--font-mono)", marginTop: 2, fontVariantNumeric: "tabular-nums" }}>
+              {formatDuration(avgDurationMs)}
+            </div>
+          </div>
+        </div>
+      </PatchCard>
+
+      {/* RECENT RUNS */}
+      <PatchCard style={{ padding: "var(--s-4)" }}>
+        <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+          <SectionHeader>Recent runs</SectionHeader>
+          <Link
+            href={`/runs?recipe=${encodeURIComponent(name)}`}
+            style={{ fontSize: "var(--fs-xs)", color: "var(--accent)", textDecoration: "none" }}
+          >
+            View all runs →
+          </Link>
+        </div>
+        {recentRuns.length === 0 ? (
+          <div style={{ color: "var(--ink-3)", fontSize: "var(--fs-s)" }}>
+            No runs yet. Use Run now below to start one.
+          </div>
+        ) : (
+          <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+            {recentRuns.map((r, i) => (
+              <div
+                key={`${r.seq ?? r.startedAt}-${i}`}
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 10,
+                  fontSize: "var(--fs-xs)",
+                  padding: "6px 8px",
+                  borderRadius: "var(--r-1)",
+                  background: "var(--bg-2)",
+                }}
+              >
+                {typeof r.seq === "number" ? (
+                  <RunChip seq={r.seq} status={r.status} hadStepErrors={r.hadStepErrors} variant="row" />
+                ) : (
+                  <span style={{ fontFamily: "var(--font-mono)" }}>{r.status}</span>
+                )}
+                <span style={{ flex: 1, color: "var(--ink-3)" }}>{relTime(r.startedAt)}</span>
+                <span style={{ color: "var(--ink-2)", fontFamily: "var(--font-mono)" }}>
+                  {formatDuration(r.durationMs)}
+                </span>
+              </div>
+            ))}
+          </div>
+        )}
+      </PatchCard>
+
+      {/* HALT SUMMARY */}
+      {haltSummary && haltSummary.total > 0 && (
+        <PatchCard style={{ padding: "var(--s-4)" }}>
+          <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+            <SectionHeader>Halts</SectionHeader>
+            <Link
+              href={`/runs?recipe=${encodeURIComponent(name)}&halt=1`}
+              style={{ fontSize: "var(--fs-xs)", color: "var(--accent)", textDecoration: "none" }}
+            >
+              View halts →
+            </Link>
+          </div>
+          <div style={{ display: "flex", flexWrap: "wrap", gap: 8 }}>
+            {(Object.entries(haltSummary.byCategory) as Array<[HaltCategory, number]>).map(
+              ([cat, count]) => (
+                <div
+                  key={cat}
+                  style={{
+                    display: "inline-flex",
+                    alignItems: "center",
+                    gap: 6,
+                    padding: "4px 10px",
+                    borderRadius: 999,
+                    background: "color-mix(in srgb, var(--amber) 8%, transparent)",
+                    border: "1px solid color-mix(in srgb, var(--amber) 35%, transparent)",
+                    fontSize: "var(--fs-xs)",
+                    color: "var(--amber)",
+                  }}
+                >
+                  <span style={{ fontFamily: "var(--font-mono)" }}>
+                    {HALT_CATEGORY_LABEL[cat] ?? cat}
+                  </span>
+                  <span style={{ fontWeight: 600 }}>{count}</span>
+                </div>
+              ),
+            )}
+          </div>
+        </PatchCard>
+      )}
+
+      {/* CONNECTORS */}
+      {requiredConnectors.length > 0 && (
+        <PatchCard style={{ padding: "var(--s-4)" }}>
+          <SectionHeader>Connectors required</SectionHeader>
+          <div style={{ display: "flex", flexWrap: "wrap", gap: 8 }}>
+            {requiredConnectors.map((id) => (
+              <ConnectorChip key={id} id={id} healthy={connectorHealthMap.get(id)} />
+            ))}
+          </div>
+        </PatchCard>
+      )}
+
+      {/* LATEST INBOX OUTPUT */}
+      {latestInboxOutput && (
+        <PatchCard style={{ padding: "var(--s-4)" }}>
+          <SectionHeader>Latest inbox output</SectionHeader>
+          <div style={{ display: "flex", alignItems: "center", gap: 8, fontSize: "var(--fs-s)" }}>
+            <InboxChip name={latestInboxOutput.filename} recipeName={name} />
+            <span style={{ color: "var(--ink-3)", fontSize: "var(--fs-xs)" }}>
+              {relTime(latestInboxOutput.deliveredAt)}
+            </span>
+          </div>
+        </PatchCard>
+      )}
+
+      {/* CONTROLS */}
+      <PatchCard style={{ padding: "var(--s-4)" }}>
+        <SectionHeader>Controls</SectionHeader>
+        <div style={{ display: "flex", flexWrap: "wrap", gap: "var(--s-3)" }}>
+          <button
+            type="button"
+            className="btn warn"
+            onClick={() => setRunModalOpen(true)}
+            disabled={!recipe || recipe.enabled === false}
+            title="Execute this recipe now"
+          >
+            ▶ Run now
+          </button>
+          <button
+            type="button"
+            className="btn"
+            onClick={() => void handleToggle()}
+            disabled={!recipe || toggling}
+            aria-pressed={recipe?.enabled !== false}
+          >
+            {recipe?.enabled === false ? "Enable" : "Disable"}
+          </button>
+          <Link
+            href={`/recipes/${encodeURIComponent(name)}/edit`}
+            className="btn"
+            style={{ textDecoration: "none" }}
+          >
+            Edit
+          </Link>
+          <Link
+            href={`/recipes/${encodeURIComponent(name)}/plan`}
+            className="btn"
+            style={{ textDecoration: "none" }}
+          >
+            Plan
+          </Link>
+          <Link
+            href={`/recipes/compare?name=${encodeURIComponent(name)}`}
+            className="btn ghost"
+            style={{ textDecoration: "none" }}
+          >
+            Compare versions
+          </Link>
+          <button
+            type="button"
+            className="btn ghost"
+            style={{ color: "var(--err)", marginLeft: "auto" }}
+            onClick={() => void handleUninstall()}
+            disabled={!recipe}
+          >
+            Uninstall
+          </button>
+        </div>
+      </PatchCard>
+    </div>
+  );
+}

--- a/dashboard/src/app/recipes/page.tsx
+++ b/dashboard/src/app/recipes/page.tsx
@@ -5,6 +5,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Dialog } from "@/components/Dialog";
 import { apiPath } from "@/lib/api";
+import { canonicalRecipeKey } from "@/lib/entityKey";
 import { ConnectorHealthPanel } from "@/components/ConnectorHealthPanel";
 import { SkeletonList } from "@/components/Skeleton";
 import { useToast } from "@/components/Toast";
@@ -1360,19 +1361,18 @@ export default function RecipesPage() {
                         key={r.path ?? r.id ?? `${r.name}:${i}`}
                         className={`recipe-row${sel ? " is-selected" : ""}${enabled ? "" : " is-off"}`}
                         data-recipe-row={r.name}
-                        onClick={() =>
-                          setSelectedName((prev) => (prev === r.name ? null : r.name))
-                        }
+                        onClick={() => {
+                          router.push(`/recipes/${encodeURIComponent(canonicalRecipeKey(r.name))}`);
+                        }}
                         onKeyDown={(e) => {
                           if (e.key === "Enter" || e.key === " ") {
                             e.preventDefault();
-                            setSelectedName((prev) => (prev === r.name ? null : r.name));
+                            router.push(`/recipes/${encodeURIComponent(canonicalRecipeKey(r.name))}`);
                           }
                         }}
                         tabIndex={0}
-                        role="button"
-                        aria-pressed={sel}
-                        aria-label={`Select recipe ${r.name}`}
+                        role="link"
+                        aria-label={`Open recipe ${r.name}`}
                       >
                         <td style={{ textAlign: "center" }}>
                           <SuccessRing pct={pct} />
@@ -1380,7 +1380,7 @@ export default function RecipesPage() {
                         <td className="mono" style={{ overflow: "hidden" }}>
                           <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
                             <Link
-                              href={`/recipes/${encodeURIComponent(r.name)}/edit`}
+                              href={`/recipes/${encodeURIComponent(canonicalRecipeKey(r.name))}`}
                               onClick={(e) => e.stopPropagation()}
                               style={{
                                 whiteSpace: "nowrap",

--- a/dashboard/src/components/RecipeLeaderboard.tsx
+++ b/dashboard/src/components/RecipeLeaderboard.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/components/patchwork";
 import { relTime } from "@/components/time";
 import { useRunRecipe } from "@/hooks/useRunRecipe";
+import { canonicalRecipeKey } from "@/lib/entityKey";
 
 /**
  * Recipe activity leaderboard for the Overview page. Replaces the old
@@ -67,7 +68,7 @@ function aggregateByRecipe(
   const byName = new Map<string, LeaderboardRun[]>();
   for (const r of runs) {
     if (r.startedAt < cutoff) continue;
-    const name = (r.recipeName ?? r.recipe ?? "").replace(/:agent$/, "");
+    const name = canonicalRecipeKey(r.recipeName ?? r.recipe ?? "");
     if (!name) continue;
     const list = byName.get(name) ?? [];
     list.push(r);

--- a/dashboard/src/components/patchwork/entity/ApprovalChip.tsx
+++ b/dashboard/src/components/patchwork/entity/ApprovalChip.tsx
@@ -1,0 +1,56 @@
+import Link from "next/link";
+import {
+  StatusPill,
+  type StatusTone,
+} from "@/components/patchwork/StatusPill";
+import { type EntityVariant, variantStyle } from "./types";
+
+export type ApprovalDecision = "pending" | "approved" | "rejected";
+
+export interface ApprovalChipProps {
+  callId: string;
+  tier?: string;
+  decision?: ApprovalDecision;
+  variant?: EntityVariant;
+}
+
+const DECISION_TONE: Record<ApprovalDecision, StatusTone> = {
+  pending: "warn",
+  approved: "ok",
+  rejected: "err",
+};
+
+/**
+ * <ApprovalChip> — linked identity chip for a single approval call.
+ *
+ * Labels with the tier (if known) and the decision verdict; status tone
+ * comes from a StatusPill so colour is never the sole signal.
+ */
+export function ApprovalChip({
+  callId,
+  tier,
+  decision,
+  variant = "chip",
+}: ApprovalChipProps) {
+  const { className, style } = variantStyle(variant);
+  const label = tier ? tier : callId.slice(0, 10);
+  const ariaLabel = `Approval ${callId}${tier ? ` (${tier})` : ""}${
+    decision ? `, ${decision}` : ""
+  }`;
+  return (
+    <Link
+      href={`/approvals/${callId}`}
+      className={className}
+      style={style}
+      aria-label={ariaLabel}
+      title={ariaLabel}
+    >
+      <span style={{ fontFamily: "var(--font-mono)" }}>{label}</span>
+      {decision && (
+        <StatusPill tone={DECISION_TONE[decision]} srLabel={decision}>
+          {decision}
+        </StatusPill>
+      )}
+    </Link>
+  );
+}

--- a/dashboard/src/components/patchwork/entity/ConnectorChip.tsx
+++ b/dashboard/src/components/patchwork/entity/ConnectorChip.tsx
@@ -1,0 +1,58 @@
+import { type EntityVariant, variantStyle } from "./types";
+
+export interface ConnectorChipProps {
+  id: string;
+  healthy?: boolean;
+  variant?: EntityVariant;
+}
+
+/**
+ * <ConnectorChip> — linked identity chip for a connector.
+ *
+ * Target is a hash anchor on `/connections` (the connections page
+ * scrolls to the matching row), so this renders a plain `<a>` instead
+ * of a Next `<Link>` — Next's router would strip the fragment.
+ *
+ * Health is signalled by a coloured dot AND an explicit text label on
+ * aria so colour is never the sole signal.
+ */
+export function ConnectorChip({
+  id,
+  healthy,
+  variant = "chip",
+}: ConnectorChipProps) {
+  const { className, style } = variantStyle(variant);
+  const dotColor =
+    healthy === undefined
+      ? "var(--muted, #888)"
+      : healthy
+        ? "var(--green, #2ea44f)"
+        : "var(--red, #d1242f)";
+  const healthLabel =
+    healthy === undefined ? "" : healthy ? ", healthy" : ", unhealthy";
+  const ariaLabel = `Connector ${id}${healthLabel}`;
+  return (
+    <a
+      href={`/connections#${id}`}
+      className={className}
+      style={style}
+      aria-label={ariaLabel}
+      title={ariaLabel}
+    >
+      <span
+        aria-hidden="true"
+        style={{
+          width: 8,
+          height: 8,
+          borderRadius: "50%",
+          background: dotColor,
+          display: "inline-block",
+        }}
+      />
+      <span>{id}</span>
+      {healthy !== undefined && (
+        <span className="sr-only">{healthy ? "healthy" : "unhealthy"}</span>
+      )}
+    </a>
+  );
+}

--- a/dashboard/src/components/patchwork/entity/EntityLink.tsx
+++ b/dashboard/src/components/patchwork/entity/EntityLink.tsx
@@ -1,0 +1,127 @@
+import Link from "next/link";
+import { canonicalRecipeKey, inboxItemKey } from "@/lib/entityKey";
+import { ApprovalChip } from "./ApprovalChip";
+import { ConnectorChip } from "./ConnectorChip";
+import { InboxChip } from "./InboxChip";
+import { RecipeChip } from "./RecipeChip";
+import { RunChip } from "./RunChip";
+import { SessionChip } from "./SessionChip";
+import { ToolChip } from "./ToolChip";
+import { TraceChip } from "./TraceChip";
+import { type EntityKind, type EntityVariant, variantStyle } from "./types";
+
+export interface EntityLinkProps {
+  kind: EntityKind;
+  id: string;
+  label?: string;
+  variant?: EntityVariant;
+}
+
+/**
+ * <EntityLink> — kind-dispatched chip.
+ *
+ * Lets callers render any entity by `(kind, id)` without importing the
+ * specific chip. The visual / link contract matches the kind-specific
+ * chip exactly. `task` and `decision` are minimal-chip variants that
+ * the dedicated chips don't (yet) cover — they share the same generic
+ * shape.
+ */
+export function EntityLink({
+  kind,
+  id,
+  label,
+  variant = "chip",
+}: EntityLinkProps) {
+  switch (kind) {
+    case "run": {
+      const seq = Number.parseInt(id, 10);
+      return <RunChip seq={Number.isFinite(seq) ? seq : 0} variant={variant} />;
+    }
+    case "recipe":
+      return <RecipeChip name={id} variant={variant} />;
+    case "tool":
+      return <ToolChip name={id} variant={variant} />;
+    case "session":
+      return <SessionChip id={id} variant={variant} />;
+    case "approval":
+      return <ApprovalChip callId={id} variant={variant} />;
+    case "trace":
+      return (
+        <TraceChip
+          traceKey={id}
+          traceType={label ?? "decision"}
+          variant={variant}
+        />
+      );
+    case "connector":
+      return <ConnectorChip id={id} variant={variant} />;
+    case "inbox":
+      return <InboxChip name={id} variant={variant} />;
+    case "task":
+      return <GenericChip kind="task" id={id} label={label} variant={variant} />;
+    case "decision":
+      return (
+        <GenericChip kind="decision" id={id} label={label} variant={variant} />
+      );
+  }
+}
+
+/**
+ * Hook returning the canonical href for an entity (kind, id).
+ *
+ * Exposed so `RelationStrip` items can later be built from the same
+ * resolver — keeps URLs in lockstep with the chips.
+ */
+export function useEntityHref(kind: EntityKind, id: string): string {
+  switch (kind) {
+    case "run":
+      return `/runs/${id}`;
+    case "recipe":
+      return `/recipes/${canonicalRecipeKey(id)}`;
+    case "tool":
+      return `/insights?tool=${encodeURIComponent(id)}`;
+    case "session":
+      return `/sessions/${encodeURIComponent(id)}`;
+    case "approval":
+      return `/approvals/${id}`;
+    case "trace":
+      return `/traces?q=${encodeURIComponent(id)}`;
+    case "connector":
+      return `/connections#${id}`;
+    case "inbox":
+      return `/inbox?item=${encodeURIComponent(inboxItemKey(id))}`;
+    case "task":
+      return `/tasks?id=${encodeURIComponent(id)}`;
+    case "decision":
+      return `/decisions?ref=${encodeURIComponent(id)}`;
+  }
+}
+
+function GenericChip({
+  kind,
+  id,
+  label,
+  variant = "chip",
+}: {
+  kind: "task" | "decision";
+  id: string;
+  label?: string;
+  variant?: EntityVariant;
+}) {
+  const { className, style } = variantStyle(variant);
+  const href = useEntityHref(kind, id);
+  const text = label ?? id;
+  const kindLabel = kind === "task" ? "Task" : "Decision";
+  const ariaLabel = `${kindLabel} ${text}`;
+  return (
+    <Link
+      href={href}
+      className={className}
+      style={style}
+      aria-label={ariaLabel}
+      title={ariaLabel}
+    >
+      <span style={{ fontFamily: "var(--font-mono)" }}>{text}</span>
+    </Link>
+  );
+}

--- a/dashboard/src/components/patchwork/entity/InboxChip.tsx
+++ b/dashboard/src/components/patchwork/entity/InboxChip.tsx
@@ -1,0 +1,37 @@
+import Link from "next/link";
+import { inboxItemKey } from "@/lib/entityKey";
+import { type EntityVariant, variantStyle } from "./types";
+
+export interface InboxChipProps {
+  name: string;
+  recipeName?: string;
+  variant?: EntityVariant;
+}
+
+/**
+ * <InboxChip> — linked identity chip for an inbox item.
+ *
+ * The visible label keeps the date in it (inbox identity includes the
+ * date — see `inboxItemKey`); only the `.md` suffix is stripped for
+ * the link target.
+ */
+export function InboxChip({
+  name,
+  recipeName,
+  variant = "chip",
+}: InboxChipProps) {
+  const { className, style } = variantStyle(variant);
+  const key = inboxItemKey(name);
+  const ariaLabel = `Inbox ${key}${recipeName ? ` (${recipeName})` : ""}`;
+  return (
+    <Link
+      href={`/inbox?item=${encodeURIComponent(key)}`}
+      className={className}
+      style={style}
+      aria-label={ariaLabel}
+      title={ariaLabel}
+    >
+      <span>{key}</span>
+    </Link>
+  );
+}

--- a/dashboard/src/components/patchwork/entity/RecipeChip.tsx
+++ b/dashboard/src/components/patchwork/entity/RecipeChip.tsx
@@ -1,0 +1,43 @@
+import Link from "next/link";
+import { LivePill } from "@/components/patchwork/LivePill";
+import { canonicalRecipeKey } from "@/lib/entityKey";
+import { type EntityVariant, variantStyle } from "./types";
+
+export interface RecipeChipProps {
+  name: string;
+  trigger?: string;
+  live?: boolean;
+  variant?: EntityVariant;
+}
+
+/**
+ * <RecipeChip> — linked identity chip for a recipe.
+ *
+ * Always routes through `canonicalRecipeKey()` so the same recipe lands
+ * on the same URL regardless of whether the source string carried a
+ * trailing agent-axis suffix.
+ */
+export function RecipeChip({
+  name,
+  trigger,
+  live,
+  variant = "chip",
+}: RecipeChipProps) {
+  const { className, style } = variantStyle(variant);
+  const key = canonicalRecipeKey(name);
+  const ariaLabel = `Recipe ${key}${trigger ? ` (${trigger})` : ""}${
+    live ? ", live" : ""
+  }`;
+  return (
+    <Link
+      href={`/recipes/${key}`}
+      className={className}
+      style={style}
+      aria-label={ariaLabel}
+      title={ariaLabel}
+    >
+      <span>{key}</span>
+      {live && <LivePill connection="live" />}
+    </Link>
+  );
+}

--- a/dashboard/src/components/patchwork/entity/RunChip.tsx
+++ b/dashboard/src/components/patchwork/entity/RunChip.tsx
@@ -1,0 +1,54 @@
+import Link from "next/link";
+import { StatusPill, deriveRunStatus } from "@/components/patchwork/StatusPill";
+import { type EntityVariant, variantStyle } from "./types";
+
+export type RunStatus = "running" | "done" | "error" | string;
+
+export interface RunChipProps {
+  seq: number;
+  status?: RunStatus;
+  hadStepErrors?: boolean;
+  recipeName?: string;
+  variant?: EntityVariant;
+}
+
+/**
+ * <RunChip> — linked identity chip for a single recipe run.
+ *
+ * Renders `#<seq>` and, when `status` is provided, an inner StatusPill
+ * derived via `deriveRunStatus()` so the same verdict shows up wherever
+ * a run is referenced. Always a real <Link>, so keyboard nav + middle-
+ * click open in tab work without extra wiring at the call site.
+ */
+export function RunChip({
+  seq,
+  status,
+  hadStepErrors,
+  recipeName,
+  variant = "chip",
+}: RunChipProps) {
+  const { className, style } = variantStyle(variant);
+  const derived = status
+    ? deriveRunStatus(status, { hadStepErrors })
+    : undefined;
+  const label = `#${seq}`;
+  const ariaLabel = derived
+    ? `Run ${label}${recipeName ? ` (${recipeName})` : ""}, ${derived.label}`
+    : `Run ${label}${recipeName ? ` (${recipeName})` : ""}`;
+  return (
+    <Link
+      href={`/runs/${seq}`}
+      className={className}
+      style={style}
+      aria-label={ariaLabel}
+      title={ariaLabel}
+    >
+      <span style={{ fontFamily: "var(--font-mono)" }}>{label}</span>
+      {derived && (
+        <StatusPill tone={derived.tone} srLabel={derived.label}>
+          {derived.label}
+        </StatusPill>
+      )}
+    </Link>
+  );
+}

--- a/dashboard/src/components/patchwork/entity/SessionChip.tsx
+++ b/dashboard/src/components/patchwork/entity/SessionChip.tsx
@@ -1,0 +1,37 @@
+import Link from "next/link";
+import { LivePill } from "@/components/patchwork/LivePill";
+import { type EntityVariant, variantStyle } from "./types";
+
+export interface SessionChipProps {
+  id: string;
+  active?: boolean;
+  variant?: EntityVariant;
+}
+
+/**
+ * <SessionChip> — linked identity chip for a Claude session.
+ *
+ * Renders only the first 8 chars of the id to keep the chip compact;
+ * full id remains in the link target + aria-label.
+ */
+export function SessionChip({
+  id,
+  active,
+  variant = "chip",
+}: SessionChipProps) {
+  const { className, style } = variantStyle(variant);
+  const short = id.slice(0, 8);
+  const ariaLabel = `Session ${id}${active ? ", active" : ""}`;
+  return (
+    <Link
+      href={`/sessions/${encodeURIComponent(id)}`}
+      className={className}
+      style={style}
+      aria-label={ariaLabel}
+      title={ariaLabel}
+    >
+      <span style={{ fontFamily: "var(--font-mono)" }}>{short}</span>
+      {active && <LivePill connection="live" />}
+    </Link>
+  );
+}

--- a/dashboard/src/components/patchwork/entity/ToolChip.tsx
+++ b/dashboard/src/components/patchwork/entity/ToolChip.tsx
@@ -1,0 +1,32 @@
+import Link from "next/link";
+import { RiskPill, type RiskLevel } from "@/components/patchwork/RiskPill";
+import { type EntityVariant, variantStyle } from "./types";
+
+export interface ToolChipProps {
+  name: string;
+  tier?: RiskLevel;
+  variant?: EntityVariant;
+}
+
+/**
+ * <ToolChip> — linked identity chip for a tool name.
+ *
+ * Optional risk-tier pill (low / medium / high). Links into the insights
+ * page filtered by tool so click-through lands on usage context.
+ */
+export function ToolChip({ name, tier, variant = "chip" }: ToolChipProps) {
+  const { className, style } = variantStyle(variant);
+  const ariaLabel = `Tool ${name}${tier ? `, ${tier} risk` : ""}`;
+  return (
+    <Link
+      href={`/insights?tool=${encodeURIComponent(name)}`}
+      className={className}
+      style={style}
+      aria-label={ariaLabel}
+      title={ariaLabel}
+    >
+      <span style={{ fontFamily: "var(--font-mono)" }}>{name}</span>
+      {tier && <RiskPill level={tier} />}
+    </Link>
+  );
+}

--- a/dashboard/src/components/patchwork/entity/TraceChip.tsx
+++ b/dashboard/src/components/patchwork/entity/TraceChip.tsx
@@ -1,0 +1,58 @@
+import Link from "next/link";
+import { type EntityVariant, variantStyle } from "./types";
+
+export interface TraceChipProps {
+  /**
+   * Trace identity key. Named `traceKey` (not `key`) because React
+   * silently consumes any prop literally called `key` — passing it
+   * through would arrive as `undefined`.
+   */
+  traceKey: string;
+  traceType: string;
+  variant?: EntityVariant;
+}
+
+/**
+ * Glyph per trace-type so each kind has a single-character visual hook
+ * — keeps the chip compact in dense lists. Unknown types fall back to a
+ * generic dot.
+ */
+const TYPE_GLYPH: Record<string, string> = {
+  approval: "✓",
+  enrichment: "✎",
+  recipe: "▶",
+  agent: "◆",
+  decision: "●",
+};
+
+function glyphFor(traceType: string): string {
+  return TYPE_GLYPH[traceType] ?? "·";
+}
+
+/**
+ * <TraceChip> — linked identity chip for a stored decision trace.
+ *
+ * Renders a type glyph + short key. Click-through lands on the traces
+ * page filtered by the trace's key.
+ */
+export function TraceChip({
+  traceKey,
+  traceType,
+  variant = "chip",
+}: TraceChipProps) {
+  const { className, style } = variantStyle(variant);
+  const short = traceKey.length > 24 ? `${traceKey.slice(0, 24)}…` : traceKey;
+  const ariaLabel = `Trace ${traceType} ${traceKey}`;
+  return (
+    <Link
+      href={`/traces?q=${encodeURIComponent(traceKey)}`}
+      className={className}
+      style={style}
+      aria-label={ariaLabel}
+      title={ariaLabel}
+    >
+      <span aria-hidden="true">{glyphFor(traceType)}</span>
+      <span style={{ fontFamily: "var(--font-mono)" }}>{short}</span>
+    </Link>
+  );
+}

--- a/dashboard/src/components/patchwork/entity/__tests__/entity.test.tsx
+++ b/dashboard/src/components/patchwork/entity/__tests__/entity.test.tsx
@@ -1,0 +1,202 @@
+/**
+ * Behaviour contract for the entity-chip family (Phase 0γ).
+ *
+ * One file covers every chip — variant + aria + href + dispatcher routing —
+ * because the surface they share is bigger than what each individually adds.
+ * If a chip grows substantially, split it back out.
+ */
+
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import {
+  ApprovalChip,
+  ConnectorChip,
+  EntityLink,
+  InboxChip,
+  RecipeChip,
+  RunChip,
+  SessionChip,
+  ToolChip,
+  TraceChip,
+  useEntityHref,
+} from "@/components/patchwork/entity";
+
+function hrefOf(container: HTMLElement): string | null {
+  const a = container.querySelector("a");
+  return a ? a.getAttribute("href") : null;
+}
+
+function ariaOf(container: HTMLElement): string | null {
+  const a = container.querySelector("a");
+  return a ? a.getAttribute("aria-label") : null;
+}
+
+describe("<RunChip/>", () => {
+  it("links to /runs/<seq>", () => {
+    const { container } = render(<RunChip seq={42} />);
+    expect(hrefOf(container)).toBe("/runs/42");
+  });
+
+  it("exposes aria-label with run seq and status", () => {
+    const { container } = render(<RunChip seq={7} status="done" />);
+    expect(ariaOf(container)).toContain("Run #7");
+    expect(ariaOf(container)).toContain("done");
+  });
+
+  it("renders without throwing for every variant", () => {
+    for (const v of ["chip", "row", "link"] as const) {
+      const { container } = render(<RunChip seq={1} variant={v} />);
+      expect(container.querySelector("a")).not.toBeNull();
+    }
+  });
+});
+
+describe("<RecipeChip/>", () => {
+  it("routes :agent suffix through canonicalRecipeKey", () => {
+    const { container } = render(<RecipeChip name="morning-pulse:agent" />);
+    expect(hrefOf(container)).toBe("/recipes/morning-pulse");
+  });
+
+  it("links a bare recipe name directly", () => {
+    const { container } = render(<RecipeChip name="inbox-summary" />);
+    expect(hrefOf(container)).toBe("/recipes/inbox-summary");
+  });
+
+  it("aria-label uses the canonical key", () => {
+    const { container } = render(<RecipeChip name="x:cron" />);
+    expect(ariaOf(container)).toBe("Recipe x");
+  });
+});
+
+describe("<ToolChip/>", () => {
+  it("encodes special chars in the tool name", () => {
+    const { container } = render(<ToolChip name="my tool/run" />);
+    expect(hrefOf(container)).toBe("/insights?tool=my%20tool%2Frun");
+  });
+
+  it("exposes the risk tier in aria-label", () => {
+    const { container } = render(<ToolChip name="curl" tier="high" />);
+    expect(ariaOf(container)).toContain("high risk");
+  });
+});
+
+describe("<SessionChip/>", () => {
+  it("links to /sessions/<full-id>", () => {
+    const { container } = render(<SessionChip id="01h89-abcdef-uuid" />);
+    expect(hrefOf(container)).toBe("/sessions/01h89-abcdef-uuid");
+  });
+
+  it("renders only first 8 chars visibly", () => {
+    const { container } = render(<SessionChip id="01h89XYZQRS" />);
+    const span = container.querySelector("a span");
+    expect(span?.textContent).toBe("01h89XYZ");
+  });
+});
+
+describe("<ApprovalChip/>", () => {
+  it("links to /approvals/<callId>", () => {
+    const { container } = render(<ApprovalChip callId="call_abc123" />);
+    expect(hrefOf(container)).toBe("/approvals/call_abc123");
+  });
+
+  it("aria-label includes decision verdict", () => {
+    const { container } = render(
+      <ApprovalChip callId="x" decision="rejected" />,
+    );
+    expect(ariaOf(container)).toContain("rejected");
+  });
+});
+
+describe("<TraceChip/>", () => {
+  it("links to /traces filtered by the trace key", () => {
+    const { container } = render(
+      <TraceChip traceKey="trace-1" traceType="approval" />,
+    );
+    expect(hrefOf(container)).toBe("/traces?q=trace-1");
+  });
+});
+
+describe("<ConnectorChip/>", () => {
+  it("uses a hash-anchor target (plain <a>, not Next Link)", () => {
+    const { container } = render(<ConnectorChip id="github" />);
+    const a = container.querySelector("a");
+    expect(a?.getAttribute("href")).toBe("/connections#github");
+  });
+
+  it("labels health for screen readers", () => {
+    const { container } = render(
+      <ConnectorChip id="slack" healthy={false} />,
+    );
+    expect(ariaOf(container)).toContain("unhealthy");
+  });
+});
+
+describe("<InboxChip/>", () => {
+  it("strips .md for the link target but keeps the date in the visible label", () => {
+    const { container } = render(
+      <InboxChip name="morning-brief-2026-05-20.md" />,
+    );
+    expect(hrefOf(container)).toBe(
+      "/inbox?item=morning-brief-2026-05-20",
+    );
+    const span = container.querySelector("a span");
+    expect(span?.textContent).toBe("morning-brief-2026-05-20");
+  });
+});
+
+describe("<EntityLink/> dispatcher", () => {
+  it.each([
+    ["run", "12", "/runs/12"],
+    ["recipe", "foo:agent", "/recipes/foo"],
+    ["tool", "curl", "/insights?tool=curl"],
+    ["session", "abc", "/sessions/abc"],
+    ["approval", "call_1", "/approvals/call_1"],
+    ["trace", "k", "/traces?q=k"],
+    ["connector", "gh", "/connections#gh"],
+    ["inbox", "x.md", "/inbox?item=x"],
+    ["task", "t1", "/tasks?id=t1"],
+    ["decision", "d1", "/decisions?ref=d1"],
+  ] as const)("kind=%s routes to %s", (kind, id, expectedHref) => {
+    const { container } = render(<EntityLink kind={kind} id={id} />);
+    const a = container.querySelector("a");
+    expect(a?.getAttribute("href")).toBe(expectedHref);
+  });
+});
+
+describe("useEntityHref()", () => {
+  // Pure function — call directly outside a component to lock behaviour.
+  it("matches every chip's link target", () => {
+    expect(useEntityHref("run", "9")).toBe("/runs/9");
+    expect(useEntityHref("recipe", "foo:cron")).toBe("/recipes/foo");
+    expect(useEntityHref("tool", "a/b")).toBe("/insights?tool=a%2Fb");
+    expect(useEntityHref("session", "s1")).toBe("/sessions/s1");
+    expect(useEntityHref("approval", "c1")).toBe("/approvals/c1");
+    expect(useEntityHref("trace", "t")).toBe("/traces?q=t");
+    expect(useEntityHref("connector", "gh")).toBe("/connections#gh");
+    expect(useEntityHref("inbox", "x.md")).toBe("/inbox?item=x");
+    expect(useEntityHref("task", "t1")).toBe("/tasks?id=t1");
+    expect(useEntityHref("decision", "d1")).toBe("/decisions?ref=d1");
+  });
+});
+
+describe("keyboard focusability", () => {
+  it("every chip renders a real <a> (focusable by default)", () => {
+    const cases = [
+      <RunChip key="r" seq={1} />,
+      <RecipeChip key="re" name="x" />,
+      <ToolChip key="t" name="x" />,
+      <SessionChip key="s" id="x" />,
+      <ApprovalChip key="a" callId="x" />,
+      <TraceChip key="tr" traceKey="trace-1" traceType="x" />,
+      <ConnectorChip key="c" id="x" />,
+      <InboxChip key="i" name="x.md" />,
+    ];
+    for (const node of cases) {
+      const { container } = render(node);
+      const a = container.querySelector("a");
+      expect(a).not.toBeNull();
+      // <a href=…> is focusable; absent href would drop tab order.
+      expect(a?.getAttribute("href")).toBeTruthy();
+    }
+  });
+});

--- a/dashboard/src/components/patchwork/entity/index.ts
+++ b/dashboard/src/components/patchwork/entity/index.ts
@@ -1,0 +1,29 @@
+/**
+ * Shared entity-component layer (Phase 0γ).
+ *
+ * Chips own identity + link + label; pills (StatusPill / RiskPill /
+ * LivePill) own status tone. Every chip in here renders a real link
+ * so keyboard-nav + middle-click come free at the call site.
+ *
+ * Page adoption (replacing hand-rolled chips on existing pages) is
+ * Phase 2 and lives in a separate PR — this barrel is purely additive.
+ */
+
+export { RunChip, type RunChipProps, type RunStatus } from "./RunChip";
+export { RecipeChip, type RecipeChipProps } from "./RecipeChip";
+export { ToolChip, type ToolChipProps } from "./ToolChip";
+export { SessionChip, type SessionChipProps } from "./SessionChip";
+export {
+  ApprovalChip,
+  type ApprovalChipProps,
+  type ApprovalDecision,
+} from "./ApprovalChip";
+export { TraceChip, type TraceChipProps } from "./TraceChip";
+export { ConnectorChip, type ConnectorChipProps } from "./ConnectorChip";
+export { InboxChip, type InboxChipProps } from "./InboxChip";
+export {
+  EntityLink,
+  useEntityHref,
+  type EntityLinkProps,
+} from "./EntityLink";
+export { type EntityKind, type EntityVariant } from "./types";

--- a/dashboard/src/components/patchwork/entity/types.ts
+++ b/dashboard/src/components/patchwork/entity/types.ts
@@ -1,0 +1,72 @@
+/**
+ * Shared types + helpers for the entity-chip family.
+ *
+ * Chips own identity + link + label; pills (StatusPill / RiskPill /
+ * LivePill) own status tone. These types are the small contract the
+ * whole family shares — `EntityVariant` is the visual register and
+ * `EntityKind` is the dispatcher's discriminator.
+ */
+
+import type { CSSProperties } from "react";
+
+export type EntityVariant = "chip" | "row" | "link";
+
+export type EntityKind =
+  | "run"
+  | "recipe"
+  | "tool"
+  | "session"
+  | "approval"
+  | "trace"
+  | "connector"
+  | "inbox"
+  | "task"
+  | "decision";
+
+/** Inline style + className applied based on the requested variant. */
+export function variantStyle(variant: EntityVariant = "chip"): {
+  className: string;
+  style: CSSProperties;
+} {
+  if (variant === "link") {
+    return {
+      className: "entity-link entity-link--link",
+      style: {
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 6,
+        textDecoration: "underline",
+        color: "inherit",
+      },
+    };
+  }
+  if (variant === "row") {
+    return {
+      className: "entity-link entity-link--row",
+      style: {
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 6,
+        textDecoration: "none",
+        color: "inherit",
+      },
+    };
+  }
+  // "chip" — default
+  return {
+    className: "entity-link entity-link--chip",
+    style: {
+      display: "inline-flex",
+      alignItems: "center",
+      gap: 6,
+      padding: "2px 8px",
+      borderRadius: 999,
+      border: "1px solid color-mix(in srgb, currentColor 18%, transparent)",
+      background: "color-mix(in srgb, currentColor 6%, transparent)",
+      textDecoration: "none",
+      color: "inherit",
+      fontSize: "var(--fs-xs)",
+      lineHeight: 1.2,
+    },
+  };
+}

--- a/dashboard/src/components/patchwork/index.ts
+++ b/dashboard/src/components/patchwork/index.ts
@@ -26,3 +26,4 @@ export { MetricsDonut, type DonutSegment } from "./MetricsDonut";
 export { AreaChart, type AreaChartSeries } from "./AreaChart";
 export { RunSparkBars } from "./RunSparkBars";
 export { SuccessRing, type SuccessRingProps } from "./SuccessRing";
+export * from "./entity";

--- a/dashboard/src/lib/__tests__/entityKey.test.ts
+++ b/dashboard/src/lib/__tests__/entityKey.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, it } from "vitest";
+import {
+  canonicalRecipeKey,
+  inboxItemKey,
+  parseTriggerSource,
+} from "../entityKey";
+
+/**
+ * Pre-fix divergence reproduction.
+ *
+ * Each of the three call sites had its own ad-hoc stripper:
+ *
+ *   - dashboard/src/components/RecipeLeaderboard.tsx (~L70)
+ *       name.replace(/:agent$/, "")
+ *
+ *   - dashboard/src/app/activity/page.tsx (~L69)
+ *       rawRecipe.replace(/:agent$/, "")
+ *
+ *   - dashboard/src/app/inbox/page.tsx (~L945)
+ *       name.replace(/\.md$/, "").replace(/-\d{4}-\d{2}-\d{2}$/, "")
+ *
+ * For multiple inputs they produce different values today, which is the
+ * root cause of "same recipe but linked differently" across pages.
+ * Once all three swap to canonicalRecipeKey / inboxItemKey, the three
+ * stripper outputs converge for every recipe-identity input.
+ */
+const oldLeaderboardStripper = (s: string) => s.replace(/:agent$/, "");
+const oldActivityStripper = (s: string) => s.replace(/:agent$/, "");
+const oldInboxStripper = (s: string) =>
+  s.replace(/\.md$/, "").replace(/-\d{4}-\d{2}-\d{2}$/, "");
+
+describe("pre-fix divergence — recorded for the record", () => {
+  // These cases prove the three strippers diverge today. They use the
+  // OLD inlined implementations; once call sites swap to the helper the
+  // divergence is gone because every site uses the same function.
+  it("morning-pulse:agent: leaderboard strips suffix, inbox leaves it untouched", () => {
+    const input = "morning-pulse:agent";
+    expect(oldLeaderboardStripper(input)).toBe("morning-pulse");
+    expect(oldActivityStripper(input)).toBe("morning-pulse");
+    expect(oldInboxStripper(input)).toBe("morning-pulse:agent");
+    // Leaderboard !== inbox.
+    expect(oldLeaderboardStripper(input)).not.toBe(oldInboxStripper(input));
+  });
+
+  it("morning-pulse-2026-05-20.md: inbox eats date+ext, leaderboard keeps everything", () => {
+    const input = "morning-pulse-2026-05-20.md";
+    expect(oldLeaderboardStripper(input)).toBe("morning-pulse-2026-05-20.md");
+    expect(oldInboxStripper(input)).toBe("morning-pulse");
+    expect(oldLeaderboardStripper(input)).not.toBe(oldInboxStripper(input));
+  });
+
+  it("morning-pulse-2026-05-20: inbox strips bare date, leaderboard keeps it", () => {
+    // No .md extension; inbox-stripper still chews the date off because
+    // its second .replace() is unconditional. This is the bug the
+    // sibling provenance PR addresses — inboxItemKey leaves the date
+    // alone.
+    const input = "morning-pulse-2026-05-20";
+    expect(oldLeaderboardStripper(input)).toBe("morning-pulse-2026-05-20");
+    expect(oldInboxStripper(input)).toBe("morning-pulse");
+    expect(oldLeaderboardStripper(input)).not.toBe(oldInboxStripper(input));
+  });
+});
+
+describe("canonicalRecipeKey", () => {
+  it("strips trailing :agent", () => {
+    expect(canonicalRecipeKey("morning-pulse:agent")).toBe("morning-pulse");
+  });
+
+  it("strips trailing :cron", () => {
+    expect(canonicalRecipeKey("morning-pulse:cron")).toBe("morning-pulse");
+  });
+
+  it("strips trailing :webhook", () => {
+    expect(canonicalRecipeKey("morning-pulse:webhook")).toBe("morning-pulse");
+  });
+
+  it("only strips one trailing axis suffix", () => {
+    // `:agent:cron` is not a real shape; verify we only chew the
+    // trailing one and don't recurse.
+    expect(canonicalRecipeKey("morning-pulse:agent:cron")).toBe(
+      "morning-pulse:agent",
+    );
+  });
+
+  it("trims surrounding whitespace", () => {
+    expect(canonicalRecipeKey("  morning-pulse:agent  ")).toBe("morning-pulse");
+  });
+
+  it("is case-sensitive", () => {
+    expect(canonicalRecipeKey("Morning-Pulse:AGENT")).toBe("Morning-Pulse:AGENT");
+    expect(canonicalRecipeKey("Morning-Pulse:agent")).toBe("Morning-Pulse");
+  });
+
+  it("leaves bare names untouched", () => {
+    expect(canonicalRecipeKey("morning-pulse")).toBe("morning-pulse");
+  });
+
+  it("returns empty string for empty input", () => {
+    expect(canonicalRecipeKey("")).toBe("");
+  });
+
+  it("converges the three pre-fix strippers for the same input", () => {
+    // Once every call site calls canonicalRecipeKey, the three sites
+    // necessarily compute === keys for any recipe-identity input —
+    // that's the whole point of centralizing.
+    const inputs = [
+      "morning-pulse:agent",
+      "morning-pulse:cron",
+      "morning-pulse:webhook",
+      "morning-pulse",
+      "  morning-pulse:agent  ",
+      "Morning-Pulse:agent",
+    ];
+    for (const input of inputs) {
+      const fromLeaderboard = canonicalRecipeKey(input);
+      const fromActivity = canonicalRecipeKey(input);
+      const fromInboxRecipeGuess = canonicalRecipeKey(input);
+      expect(fromLeaderboard).toBe(fromActivity);
+      expect(fromActivity).toBe(fromInboxRecipeGuess);
+    }
+  });
+});
+
+describe("parseTriggerSource", () => {
+  // Cases the bridge's parseTrigger accepts — must match byte-for-byte.
+  it("parses cron:<name>", () => {
+    expect(parseTriggerSource("cron:morning-pulse")).toEqual({
+      trigger: "cron",
+      recipeName: "morning-pulse",
+    });
+  });
+
+  it("parses webhook:<name>", () => {
+    expect(parseTriggerSource("webhook:github-pr")).toEqual({
+      trigger: "webhook",
+      recipeName: "github-pr",
+    });
+  });
+
+  it("parses recipe:<name>:p<N> parent-seq tail", () => {
+    expect(parseTriggerSource("recipe:morning-pulse:p42")).toEqual({
+      trigger: "recipe",
+      recipeName: "morning-pulse",
+      parentSeq: 42,
+    });
+  });
+
+  it("recipe name containing colons is lazy-matched up to :p<N>", () => {
+    // Bridge regex uses `.+?` so the parent-seq tail wins. Names with
+    // embedded colons stay intact in the recipeName field.
+    expect(parseTriggerSource("recipe:foo:bar:p7")).toEqual({
+      trigger: "recipe",
+      recipeName: "foo:bar",
+      parentSeq: 7,
+    });
+  });
+
+  // Cases the bridge returns null for — dashboard widens.
+  it("empty / missing input → manual", () => {
+    expect(parseTriggerSource("")).toEqual({ trigger: "manual" });
+  });
+
+  it("bare name (no kind prefix) → manual with recipeName", () => {
+    expect(parseTriggerSource("morning-pulse")).toEqual({
+      trigger: "manual",
+      recipeName: "morning-pulse",
+    });
+  });
+
+  it("<name>:agent → agent trigger", () => {
+    expect(parseTriggerSource("morning-pulse:agent")).toEqual({
+      trigger: "agent",
+      recipeName: "morning-pulse",
+    });
+  });
+});
+
+describe("inboxItemKey", () => {
+  it("strips trailing .md", () => {
+    expect(inboxItemKey("morning-pulse-2026-05-20.md")).toBe(
+      "morning-pulse-2026-05-20",
+    );
+  });
+
+  it("does NOT strip the trailing date", () => {
+    // This is the deliberate behavior change vs the old inbox stripper.
+    // Date stays as part of the inbox-item identity for display.
+    expect(inboxItemKey("morning-pulse-2026-05-20")).toBe(
+      "morning-pulse-2026-05-20",
+    );
+  });
+
+  it("returns name unchanged when there is no .md", () => {
+    expect(inboxItemKey("morning-pulse")).toBe("morning-pulse");
+  });
+
+  it("returns empty string for empty input", () => {
+    expect(inboxItemKey("")).toBe("");
+  });
+});

--- a/dashboard/src/lib/entityKey.ts
+++ b/dashboard/src/lib/entityKey.ts
@@ -1,0 +1,101 @@
+/**
+ * Canonical entity-key helpers for the dashboard.
+ *
+ * Three pages previously each implemented their own ad-hoc stripping for
+ * recipe identity (RecipeLeaderboard, activity/page, inbox/page). They
+ * disagreed on edge cases, which caused the same recipe to render under
+ * different keys / links on different pages. Centralize here so every page
+ * computes the same key for the same input.
+ *
+ * The bridge stays authoritative for trigger-source parsing (see
+ * `RecipeRunLog.parseTrigger` in `src/runLog.ts` ~line 198). The
+ * `parseTriggerSource` export below is a client-side port of that parser
+ * for dashboard-local computation; behavior mirrors the bridge exactly.
+ */
+
+/** Agent-axis suffixes the bridge appends to recipe names. */
+const AGENT_AXIS_SUFFIX_RE = /:(?:agent|cron|webhook)$/;
+
+/**
+ * Canonical recipe-identity key.
+ *
+ * - Trims surrounding whitespace.
+ * - Strips a trailing agent-axis suffix (`:agent` / `:cron` / `:webhook`).
+ * - Case-sensitive — does NOT lowercase. Recipe names are case-sensitive
+ *   on disk and the bridge treats them as such.
+ *
+ * Returns the bare recipe name. Empty-string in → empty-string out.
+ */
+export function canonicalRecipeKey(name: string): string {
+  if (typeof name !== "string") return "";
+  return name.trim().replace(AGENT_AXIS_SUFFIX_RE, "");
+}
+
+export type TriggerKind =
+  | "manual"
+  | "cron"
+  | "webhook"
+  | "recipe"
+  | "agent";
+
+export interface ParsedTriggerSource {
+  trigger: TriggerKind;
+  recipeName?: string;
+  parentSeq?: number;
+}
+
+/**
+ * Parse a recipe-run triggerSource string.
+ *
+ * Mirrors `RecipeRunLog.parseTrigger` in the bridge
+ * (`src/runLog.ts` ~line 198):
+ *
+ *     /^(cron|webhook|recipe):(.+?)(?::p(\d+))?$/
+ *
+ * The bridge's parser only knows three trigger kinds (cron / webhook /
+ * recipe) and returns `null` for anything else; the dashboard sees a
+ * broader set of inputs (manual UI launches, agent-axis names) so this
+ * port widens the return type to a discriminated union instead of `null`.
+ * For inputs the bridge would have accepted, the `{trigger, recipeName,
+ * parentSeq?}` shape is byte-for-byte identical.
+ *
+ * Behavior for inputs the bridge would reject:
+ *   - missing / falsy           → `{trigger: "manual"}`
+ *   - bare name (no prefix)     → `{trigger: "manual", recipeName: <input>}`
+ *   - `<name>:agent`            → `{trigger: "agent", recipeName: <name>}`
+ */
+export function parseTriggerSource(src: string): ParsedTriggerSource {
+  if (typeof src !== "string" || src.length === 0) {
+    return { trigger: "manual" };
+  }
+  // Bridge's exact regex — keep in lockstep with src/runLog.ts.
+  const m = /^(cron|webhook|recipe):(.+?)(?::p(\d+))?$/.exec(src);
+  if (m?.[1] && m[2]) {
+    const out: ParsedTriggerSource = {
+      trigger: m[1] as TriggerKind,
+      recipeName: m[2],
+    };
+    if (m[3] !== undefined) out.parentSeq = parseInt(m[3], 10);
+    return out;
+  }
+  // Bridge returns null here. Dashboard widens to expose the original
+  // input as either an `agent`-axis run or a manual launch.
+  const agentMatch = /^(.+):agent$/.exec(src);
+  if (agentMatch?.[1]) {
+    return { trigger: "agent", recipeName: agentMatch[1] };
+  }
+  return { trigger: "manual", recipeName: src };
+}
+
+/**
+ * Inbox filename → display/identity key.
+ *
+ * Strips a trailing `.md` and nothing else. Does NOT strip the trailing
+ * date — date stays part of the inbox item's identity for display.
+ * (The old inbox page stripped `-YYYY-MM-DD` as a recipe-name guess;
+ * that responsibility is moving to provenance metadata in a sibling PR.)
+ */
+export function inboxItemKey(name: string): string {
+  if (typeof name !== "string") return "";
+  return name.replace(/\.md$/, "");
+}


### PR DESCRIPTION
## Summary

Phase 1 of the connected-dashboard plan. The recipe is now the anchor of the user journey instead of a dead-end YAML editor.

- New `/recipes/[name]` Overview hub: Summary card (trigger, schedule, last-run, success rate, avg duration), Recent runs (RunChip rows + "view all runs"), Halt summary (categorised, conditional), Connectors required (ConnectorChip + health), Latest inbox output (uses `RecipeRun.inboxOutputs` when present — degrades gracefully when absent, per #742), Controls (Run now, Enable/Disable, Edit, Plan, Compare, Uninstall).
- New shared `layout.tsx` wraps Overview / Edit / Plan with a breadcrumb (`Recipes / {name}`), H1 + status pill, `RelationStrip` (Runs / Halts / Traces / Inbox / Approvals / required connectors / Edit / Plan), and a `role="tablist"` tab bar with arrow-key roving tabindex, Home/End, Enter activation.
- `/recipes` row click + inner name `<Link>` now navigate to `/recipes/{canonicalRecipeKey(name)}` instead of toggling the side panel + landing on `/edit`. Fixes the a11y "two focusable targets per row" trap. The side detail panel is no longer auto-opened by row click (left in place for now; full removal is Phase 2).

Confined to three files per task scope: `layout.tsx`, `page.tsx`, and `recipes/page.tsx`. Edit + Plan keep their own existing page-heads underneath the layout header for now — Phase 4 will retire the duplicates.

## Dependencies

Must merge after:
- **#743** `feat/entity-components` (base of this PR — provides `RunChip`, `ConnectorChip`, `InboxChip`)
- **#740** `feat/entity-key-helper` (`canonicalRecipeKey`)

When those merge, GitHub will auto-retarget this PR's base to `main`. `#742` (`inboxOutputs` provenance) is optional — the "Latest inbox output" section is omitted entirely when the field is absent.

## Test plan

- [ ] `cd dashboard && npx tsc --noEmit` clean (verified locally)
- [ ] `cd dashboard && npm run lint -- --file …` clean (verified locally)
- [ ] Visit `/recipes`, click a recipe row → lands on `/recipes/[name]` Overview hub
- [ ] Inner name link is also a Link to the hub (no longer `/edit`)
- [ ] Tab bar: Left/Right cycles tabs, Home/End jump to first/last, Enter activates, `aria-selected`/`aria-current` correct on the active tab
- [ ] Overview sections render: Summary card, Recent runs (with RunChip), Connectors required, Controls
- [ ] When recipe has halts: Halt summary section renders with category pills + count
- [ ] When recipe has runs with `inboxOutputs`: Latest inbox output section renders (InboxChip + delivery time); otherwise omitted
- [ ] Empty state when recipe name in URL is unknown
- [ ] Visit `/recipes/[name]/edit` and `/plan` — same hub header above, tab bar reflects current tab
- [ ] Click "Run now" → RunModal opens with vars (or zero-field confirm body); enqueue works
- [ ] Enable/Disable toggle flips `recipe.enabled` via `PATCH /api/bridge/recipes/[name]`
- [ ] Uninstall → confirm dialog → `DELETE /api/bridge/recipes/[name]` → redirect to `/recipes`
- [ ] Compare versions button links `/recipes/compare?name={name}` (entry point only — compare page itself untouched per scope)

🤖 Generated with [Claude Code](https://claude.com/claude-code)