### PR TITLE
fix(dashboard): /traces honors ?recipe=/?q=, /runs honors ?session= — close broken deep-link contracts

### DIFF
--- a/dashboard/src/app/runs/page.tsx
+++ b/dashboard/src/app/runs/page.tsx
@@ -216,8 +216,14 @@ export default function RunsPage() {
   // share a manualRunId. Cleared via the same "clear filters" pill.
   const searchParams = useSearchParams();
   const [attemptFilter, setAttemptFilter] = useState<string>("");
+  // /sessions/[id] links to /runs?session=<id>; previously that param
+  // was silently ignored. Seed a client-side filter from it (the bridge
+  // /runs endpoint doesn't know about session yet, so we pass it through
+  // and filter defensively on any session-shaped field on the run).
+  const [sessionFilter, setSessionFilter] = useState<string>("");
   useEffect(() => {
     setAttemptFilter(searchParams?.get("attempt") ?? "");
+    setSessionFilter(searchParams?.get("session") ?? "");
     // RelationStrip on /runs and the dashboard hero link to ?recipe= and
     // ?halt=1 — seed the recipe filter and (for halt=1) flip status to
     // "error" so the page actually reflects the deep-link intent.
@@ -264,6 +270,11 @@ export default function RunsPage() {
         if (status !== "all") params.set("status", status);
         if (debouncedRecipeQuery) params.set("recipe", debouncedRecipeQuery);
         if (attemptFilter) params.set("manualRunId", attemptFilter);
+        // Forward `session` to the bridge — if/when /runs grows a
+        // session-axis filter the dashboard already speaks the contract.
+        // Today the bridge silently ignores unknown params, and we
+        // narrow client-side below.
+        if (sessionFilter) params.set("session", sessionFilter);
         const res = await fetch(apiPath(`/api/bridge/runs?${params}`), {
           signal: controller.signal,
         });
@@ -284,7 +295,7 @@ export default function RunsPage() {
       clearInterval(id);
       controller.abort();
     };
-  }, [trigger, status, debouncedRecipeQuery, limit, attemptFilter]);
+  }, [trigger, status, debouncedRecipeQuery, limit, attemptFilter, sessionFilter]);
 
   // Live SSE: subscribe to recipe lifecycle events (PR #642) so the list
   // updates immediately when a run starts/ends, instead of waiting up to
@@ -369,12 +380,29 @@ export default function RunsPage() {
   }, [window]);
 
   const windowedRuns = useMemo(() => {
-    const cutoffMs = windowCutoffMs(window);
-    if (cutoffMs == null) return runs;
     if (runs == null) return null;
-    const threshold = Date.now() - cutoffMs;
-    return runs.filter((r) => r.createdAt >= threshold);
-  }, [runs, window]);
+    const cutoffMs = windowCutoffMs(window);
+    const threshold = cutoffMs == null ? null : Date.now() - cutoffMs;
+    // Defensive client-side session match: the bridge run record may
+    // carry the session id under one of a few field names depending on
+    // version. Check all of them — typed as Run but read loosely.
+    const matchesSession = (r: Run): boolean => {
+      if (!sessionFilter) return true;
+      const rec = r as unknown as Record<string, unknown>;
+      const candidates = [
+        rec.sessionId,
+        rec.session,
+        rec.claudeSessionId,
+      ];
+      return candidates.some(
+        (v) => typeof v === "string" && v === sessionFilter,
+      );
+    };
+    return runs.filter(
+      (r) =>
+        (threshold == null || r.createdAt >= threshold) && matchesSession(r),
+    );
+  }, [runs, window, sessionFilter]);
 
   // Reset page size when filters change so we don't accidentally hold a giant fetch.
   useEffect(() => {
@@ -657,10 +685,20 @@ export default function RunsPage() {
             attempt:{attemptFilter}
           </span>
         )}
+        {sessionFilter && (
+          <span
+            className="pill mono"
+            style={{ fontSize: "var(--fs-xs)" }}
+            title={`Filtering to runs in session ${sessionFilter}`}
+          >
+            session:{sessionFilter.slice(0, 8)}
+          </span>
+        )}
         {(recipeQuery ||
           trigger !== "all" ||
           window !== "any" ||
-          attemptFilter) && (
+          attemptFilter ||
+          sessionFilter) && (
           <button
             type="button"
             className="btn sm ghost"
@@ -669,6 +707,7 @@ export default function RunsPage() {
               setTrigger("all");
               setWindow("any");
               setAttemptFilter("");
+              setSessionFilter("");
               // Strip the ?attempt= from the URL so the filter doesn't
               // re-apply on next render via the useSearchParams effect.
               // `window` is shadowed by a state variable in this file —
@@ -679,7 +718,7 @@ export default function RunsPage() {
               if (g.window) {
                 const url = new URL(g.window.location.href);
                 let dirty = false;
-                for (const k of ["attempt", "recipe", "halt"]) {
+                for (const k of ["attempt", "recipe", "halt", "session"]) {
                   if (url.searchParams.has(k)) {
                     url.searchParams.delete(k);
                     dirty = true;
@@ -772,7 +811,8 @@ export default function RunsPage() {
             trigger !== "all" ||
             status !== "all" ||
             !!debouncedRecipeQuery ||
-            !!attemptFilter;
+            !!attemptFilter ||
+            !!sessionFilter;
           return (
             <EmptyState
               title={
@@ -791,6 +831,7 @@ export default function RunsPage() {
                       status !== "all" && `status=${status}`,
                       debouncedRecipeQuery && `recipe=${debouncedRecipeQuery}`,
                       attemptFilter && `attempt=${attemptFilter}`,
+                      sessionFilter && `session=${sessionFilter}`,
                       window !== "any" &&
                         `window=${TIME_WINDOW_LABEL[window].toLowerCase()}`,
                     ]
@@ -820,6 +861,7 @@ export default function RunsPage() {
                       setStatus("all");
                       setRecipeQuery("");
                       setAttemptFilter("");
+                      setSessionFilter("");
                     }}
                   >
                     Clear filters

--- a/dashboard/src/app/traces/page.tsx
+++ b/dashboard/src/app/traces/page.tsx
@@ -1,7 +1,9 @@
 "use client";
 import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useSearchParams } from "next/navigation";
 import { relTime } from "@/components/time";
 import { apiPath } from "@/lib/api";
+import { canonicalRecipeKey } from "@/lib/entityKey";
 import { useBridgeFetch } from "@/hooks/useBridgeFetch";
 import { useDebounced } from "@/hooks/useDebounced";
 import { arr, isRecord, shape, type ShapeCheck } from "@/lib/validate";
@@ -569,14 +571,70 @@ function ExportButton({ disabled: outerDisabled }: { disabled?: boolean }) {
   );
 }
 
+function isSinceFilter(v: string | null): v is SinceFilter {
+  return v === "1h" || v === "24h" || v === "7d" || v === "30d" || v === "all";
+}
+
 export default function TracesPage() {
+  const searchParams = useSearchParams();
   const [statusFilter, setStatusFilter] = useState<"all" | "done" | "errors">("all");
-  const [searchQuery, setSearchQuery] = useState("");
+  // Inbound deep-links: /traces?recipe=<name> (from /runs, /recipes, etc.)
+  // and /traces?q=<free-text> previously landed on an unfiltered page —
+  // the destination ignored the param entirely. Seed the search box from
+  // either, preferring ?recipe= (canonicalised via canonicalRecipeKey so
+  // a "foo:agent" axis variant resolves to the bare recipe). Also honor
+  // ?since= when it's a known bucket key.
+  const initialRecipe = useMemo(() => {
+    const r = searchParams?.get("recipe");
+    return r ? canonicalRecipeKey(r) : "";
+  }, [searchParams]);
+  const initialQ = searchParams?.get("q") ?? "";
+  const initialSince = searchParams?.get("since");
+  const [searchQuery, setSearchQuery] = useState<string>(initialRecipe || initialQ);
+  const [recipeFilter, setRecipeFilter] = useState<string>(initialRecipe);
   const debouncedSearch = useDebounced(searchQuery, 250);
-  const [since, setSince] = useState<SinceFilter>("24h");
+  const [since, setSince] = useState<SinceFilter>(
+    isSinceFilter(initialSince) ? initialSince : "24h",
+  );
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
   const [view, setView] = useState<"flat" | "tree">("tree");
   const [ksOnly, setKsOnly] = useState(false);
+
+  // Re-seed on URL change (e.g. user clicks another ?recipe= chip without
+  // a full page nav). Keep this minimal — only re-apply when the inbound
+  // param differs from current state, so user typing isn't trampled.
+  useEffect(() => {
+    const r = searchParams?.get("recipe");
+    const canon = r ? canonicalRecipeKey(r) : "";
+    if (canon && canon !== recipeFilter) {
+      setRecipeFilter(canon);
+      setSearchQuery(canon);
+    } else if (!r && recipeFilter) {
+      // ?recipe= was cleared from the URL externally — drop the filter.
+      setRecipeFilter("");
+    }
+    const q = searchParams?.get("q");
+    if (q && q !== searchQuery && !canon) {
+      setSearchQuery(q);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchParams]);
+
+  const clearRecipeFilter = useCallback(() => {
+    setRecipeFilter("");
+    setSearchQuery("");
+    if (typeof globalThis !== "undefined" && globalThis.location) {
+      const url = new URL(globalThis.location.href);
+      let dirty = false;
+      for (const k of ["recipe", "q"]) {
+        if (url.searchParams.has(k)) {
+          url.searchParams.delete(k);
+          dirty = true;
+        }
+      }
+      if (dirty) globalThis.history.replaceState(null, "", url.toString());
+    }
+  }, []);
 
   const qs = useMemo(() => {
     const params = new URLSearchParams();
@@ -680,6 +738,38 @@ export default function TracesPage() {
       </div>
 
       <HintCard id="traces" />
+
+      {recipeFilter && (
+        <div
+          style={{
+            display: "flex",
+            gap: 8,
+            alignItems: "center",
+            marginBottom: "var(--s-3)",
+            padding: "6px 10px",
+            border: "1px solid var(--border-subtle)",
+            borderRadius: 6,
+            background: "var(--bg-0)",
+            fontSize: "var(--fs-s)",
+          }}
+        >
+          <span style={{ color: "var(--ink-2)" }}>Filtered by recipe:</span>
+          <span
+            className="mono"
+            style={{ color: "var(--ink-0)", fontWeight: 600 }}
+          >
+            {recipeFilter}
+          </span>
+          <button
+            type="button"
+            className="btn sm ghost"
+            onClick={clearRecipeFilter}
+            style={{ marginLeft: "auto" }}
+          >
+            Clear
+          </button>
+        </div>
+      )}
 
       {/* filter bar */}
       <div


### PR DESCRIPTION
## Summary

Phase 2a of the connected-dashboard plan: two surgical deep-link contract fixes. Multiple pages link TO query params that the destination page silently ignored — every "Traces for this recipe" chip landed on an unfiltered Traces page; every "Runs in this session" chip landed on an unfiltered Runs page. This wires the contracts so inbound links actually filter.

- `/traces`: read `?recipe=` (canonicalised via `canonicalRecipeKey`) and `?q=` from `useSearchParams()`, seed the existing search box, and render a dismissable "Filtered by recipe: …" banner with a Clear button. Also honor `?since=` when it's a known bucket.
- `/runs`: read `?session=` from `useSearchParams()`, forward to `/api/bridge/runs` (bridge ignores unknown params today; contract is ready when the field lands), and narrow client-side on `sessionId` / `session` / `claudeSessionId` candidate fields. Surface a `session:<short>` pill next to the existing `attempt:` pill; plumb through Clear button + empty-state detector + URL-strip set.

No entity-component adoption, no data-model changes, no other pages touched.

## Test plan

- [ ] From `/sessions/<id>`, click "Recent runs" → `/runs?session=<id>` shows the session pill and (when bridge gains the field) only runs in that session; Clear button removes the param.
- [ ] From a RelationStrip / chip pointing at `/traces?recipe=<name>`, page lands with search prefilled and "Filtered by recipe" banner; Clear strips `?recipe=` and `?q=` from URL.
- [ ] `/traces?q=foo` seeds the search box.
- [ ] `/traces?since=7d` opens with the 7d bucket selected.
- [ ] `npx tsc --noEmit` clean in `dashboard/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)