### PR TITLE
feat(dashboard): adopt entity chips + add missing RelationStrips across all surfaces

### DIFF
--- a/dashboard/src/app/analytics/page.tsx
+++ b/dashboard/src/app/analytics/page.tsx
@@ -2,7 +2,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { StatCard } from "@/components/StatCard";
 import { useBridgeFetch } from "@/hooks/useBridgeFetch";
-import { AreaChart, EmptyState, ErrorState } from "@/components/patchwork";
+import { AreaChart, EmptyState, ErrorState, RelationStrip, ToolChip } from "@/components/patchwork";
 import type { AreaChartSeries } from "@/components/patchwork";
 import { SkeletonList } from "@/components/Skeleton";
 import { isHaltStatus } from "@/lib/runStatus";
@@ -146,6 +146,13 @@ export default function AnalyticsPage() {
           <div className="editorial-sub">
             tool usage · hook activity · automation history
           </div>
+          <RelationStrip
+            items={[
+              { label: "Runs", href: "/runs", title: "Recipe runs that drove this usage" },
+              { label: "Activity", href: "/activity", title: "Raw activity stream" },
+              { label: "Insights", href: "/insights", title: "Per-tool approval signals" },
+            ]}
+          />
         </div>
       </div>
 
@@ -262,7 +269,9 @@ export default function AnalyticsPage() {
                     // unique (same tool across MCP namespaces / aggregation
                     // dupes). Suffix the index to avoid React key collisions.
                     <tr key={`${t.tool}-${i}`} style={{ borderBottom: "1px solid var(--line-3)" }}>
-                      <td style={{ padding: "7px 8px", fontFamily: "var(--font-mono)", fontSize: "var(--fs-xs)", color: "var(--ink-0)", whiteSpace: "nowrap" }}>{t.tool}</td>
+                      <td style={{ padding: "7px 8px", fontSize: "var(--fs-xs)", color: "var(--ink-0)", whiteSpace: "nowrap" }}>
+                        <ToolChip name={t.tool} variant="link" />
+                      </td>
                       <td style={{ padding: "7px 8px", width: "100%" }}>
                         <div style={{ background: "var(--line-3)", borderRadius: 2, height: 5, width: "100%" }}>
                           <div style={{ background: "var(--orange)", borderRadius: 2, height: 5, width: `${(t.calls / maxCalls) * 100}%` }} />

--- a/dashboard/src/app/connections/page.tsx
+++ b/dashboard/src/app/connections/page.tsx
@@ -4,7 +4,7 @@ import { apiPath } from "@/lib/api";
 import AddConnectionModal from "./AddConnectionModal";
 import { YourConnectorRequests } from "./YourConnectorRequests";
 import { Dialog } from "@/components/Dialog";
-import { EmptyState, HintCard } from "@/components/patchwork";
+import { EmptyState, HintCard, RelationStrip } from "@/components/patchwork";
 import { SkeletonList } from "@/components/Skeleton";
 import { useToast } from "@/components/Toast";
 import type { ConnectorStatus } from "./types";
@@ -1203,6 +1203,13 @@ export default function ConnectionsPage() {
           <div className="editorial-sub">
             oauth · scoped to your machine · tokens in ~/.patchwork/secrets
           </div>
+          <RelationStrip
+            items={[
+              { label: "Recipes", href: "/recipes", title: "Recipes that use these connectors" },
+              { label: "Inbox", href: "/inbox", title: "Outputs produced via these connectors" },
+              { label: "Marketplace", href: "/marketplace", title: "Find recipes for these providers" },
+            ]}
+          />
         </div>
         {!loading && !bridgeOffline && (
           <div style={{ display: "flex", gap: 8, alignItems: "center" }}>

--- a/dashboard/src/app/decisions/page.tsx
+++ b/dashboard/src/app/decisions/page.tsx
@@ -7,7 +7,8 @@ import { useBridgeFetch } from "@/hooks/useBridgeFetch";
 import { useDebounced } from "@/hooks/useDebounced";
 import { arr, isRecord, shape, type ShapeCheck } from "@/lib/validate";
 import { DecisionsTabs } from "@/components/DecisionsTabs";
-import { EmptyState, ErrorState, Glossary, HintCard, LivePill } from "@/components/patchwork";
+import { EmptyState, ErrorState, Glossary, HintCard, LivePill, RelationStrip } from "@/components/patchwork";
+import { EntityLink } from "@/components/patchwork/entity";
 import { SkeletonList } from "@/components/Skeleton";
 
 interface DecisionTrace {
@@ -183,6 +184,14 @@ function DecisionsContent() {
             </span>
             <LivePill label="5s" tone="muted" />
           </div>
+          <RelationStrip
+            items={[
+              { label: "Traces", href: "/traces", title: "Underlying decision-trace stream" },
+              { label: "Approvals", href: "/approvals", title: "Per-call approvals" },
+              { label: "Insights", href: "/insights", title: "Per-tool approval aggregates" },
+              { label: "Recipes", href: "/recipes", title: "Recipes whose decisions are saved here" },
+            ]}
+          />
         </div>
         <div style={{ display: "flex", gap: 8, flexWrap: "wrap", alignItems: "center" }}>
           <label style={{ display: "flex", flexDirection: "column", gap: 2 }}>
@@ -364,7 +373,18 @@ function DecisionsContent() {
                       flexShrink: 0,
                     }}
                   >
-                    {b.ref ?? t.key}
+                    {(() => {
+                      const refStr = String(b.ref ?? t.key ?? "");
+                      const prMatch = refStr.match(/^PR[-#](\d+)$/i);
+                      const hashMatch = refStr.match(/^#(\d+)$/);
+                      if (prMatch) {
+                        return <EntityLink kind="run" id={prMatch[1]} variant="link" />;
+                      }
+                      if (hashMatch) {
+                        return <EntityLink kind="run" id={hashMatch[1]} variant="link" />;
+                      }
+                      return refStr;
+                    })()}
                   </span>
                   <span style={{ flex: 1 }} />
                   {typeof b.sessionId === "string" && b.sessionId.length > 0 && (

--- a/dashboard/src/app/inbox/page.tsx
+++ b/dashboard/src/app/inbox/page.tsx
@@ -5,7 +5,7 @@ import dynamic from "next/dynamic";
 import Link from "next/link";
 import { apiPath } from "@/lib/api";
 import { inboxItemKey } from "@/lib/entityKey";
-import { EmptyState, ErrorState, HintCard } from "@/components/patchwork";
+import { EmptyState, ErrorState, HintCard, RelationStrip } from "@/components/patchwork";
 import { SkeletonList } from "@/components/Skeleton";
 import { InboxDeliveryCard } from "@/components/InboxDeliveryCard";
 import { useToast } from "@/components/Toast";
@@ -566,6 +566,14 @@ const filteredItems = items.filter((item) => {
               <HintCard.Toggle id="inbox" />
             </div>
             <div className="editorial-sub">~/.patchwork/inbox · briefs · summaries · agent reports</div>
+            <RelationStrip
+              items={[
+                { label: "Recipes", href: "/recipes", title: "Recipes that produce inbox items" },
+                { label: "Runs", href: "/runs", title: "Runs that generated these messages" },
+                { label: "Traces", href: "/traces", title: "Decisions tied to these outputs" },
+                { label: "Connections", href: "/connections", title: "Connectors used to source content" },
+              ]}
+            />
           </div>
           <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
             {unseen > 0 && (

--- a/dashboard/src/app/insights/page.tsx
+++ b/dashboard/src/app/insights/page.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
 import { useBridgeFetch } from "@/hooks/useBridgeFetch";
 import { apiPath } from "@/lib/api";
-import { EmptyState, ErrorState } from "@/components/patchwork";
+import { EmptyState, ErrorState, RelationStrip } from "@/components/patchwork";
 import { SkeletonList } from "@/components/Skeleton";
 
 interface ToolInsight {
@@ -231,6 +231,14 @@ export default function InsightsPage() {
           <div className="editorial-sub" style={{ fontFamily: "inherit" }}>
             Your personal approval history in aggregate. Same signals shown per-call in the approval modal. Read-only.
           </div>
+          <RelationStrip
+            items={[
+              { label: "Approvals", href: "/approvals", title: "Individual approval calls" },
+              { label: "Traces", href: "/traces", title: "Decision traces" },
+              { label: "Knowledge", href: "/decisions", title: "Saved decisions" },
+              { label: "Suggestions", href: "/suggestions", title: "Patterns mined from runs" },
+            ]}
+          />
         </div>
         <div
           style={{
@@ -242,12 +250,31 @@ export default function InsightsPage() {
         >
           {data && (
             <>
-              <span className="pill muted">{data.totalDecisions} decisions</span>
-              <span className="pill ok">{data.trustedToolCount} trusted</span>
+              <Link
+                href="/activity"
+                className="pill muted"
+                style={{ textDecoration: "none" }}
+                title="See activity stream"
+              >
+                {data.totalDecisions} decisions
+              </Link>
+              <Link
+                href="/approvals?decision=approved"
+                className="pill ok"
+                style={{ textDecoration: "none" }}
+                title="See approved calls"
+              >
+                {data.trustedToolCount} trusted
+              </Link>
               {data.rejectedToolCount > 0 && (
-                <span className="pill err">
+                <Link
+                  href="/approvals?decision=rejected"
+                  className="pill err"
+                  style={{ textDecoration: "none" }}
+                  title="See rejected calls"
+                >
                   {data.rejectedToolCount} rejected
-                </span>
+                </Link>
               )}
             </>
           )}

--- a/dashboard/src/app/marketplace/page.tsx
+++ b/dashboard/src/app/marketplace/page.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
 import { Skeleton, SkeletonText } from "@/components/Skeleton";
 import { EmptyState, HintCard } from "@/components/patchwork";
+import { canonicalRecipeKey } from "@/lib/entityKey";
 import { InstallConfirmDialog } from "./_components/InstallConfirmDialog";
 import { apiPath } from "@/lib/api";
 import {
@@ -325,17 +326,20 @@ function RecipeCard({
 
         <div style={{ flexShrink: 0 }}>
           {isInstalled ? (
-            <span
+            <Link
+              href={`/recipes/${canonicalRecipeKey(recipe.name)}`}
               className="pill"
               style={{
                 background: "var(--ok-soft)",
                 color: "var(--ok)",
                 border: "1px solid var(--ok)",
                 fontSize: "var(--fs-xs)",
+                textDecoration: "none",
               }}
+              title="Open installed recipe"
             >
               &#10003; Installed
-            </span>
+            </Link>
           ) : bridgeStatus === "online" ? (
             <button
               type="button"

--- a/dashboard/src/app/suggestions/page.tsx
+++ b/dashboard/src/app/suggestions/page.tsx
@@ -5,7 +5,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { apiPath } from "@/lib/api";
 import { useBridgeFetch } from "@/hooks/useBridgeFetch";
 import { DecisionsTabs } from "@/components/DecisionsTabs";
-import { EmptyState, ErrorState, HintCard } from "@/components/patchwork";
+import { EmptyState, ErrorState, HintCard, RelationStrip } from "@/components/patchwork";
 import { SkeletonList } from "@/components/Skeleton";
 
 const SINCE_DAYS_OPTIONS = [1, 7, 30, 90] as const;
@@ -190,6 +190,13 @@ export default function SuggestionsPage() {
           <div className="editorial-sub" style={{ fontFamily: "inherit" }}>
             Read-only — nothing on this page changes policy. Same data <code>patchwork suggest</code> prints.
           </div>
+          <RelationStrip
+            items={[
+              { label: "Approvals", href: "/approvals", title: "Approval calls these suggestions touch" },
+              { label: "Insights", href: "/insights", title: "Per-tool approval aggregates" },
+              { label: "Knowledge", href: "/decisions", title: "Saved decisions" },
+            ]}
+          />
         </div>
         <div style={{ display: "flex", gap: 6, alignItems: "center" }}>
           <label htmlFor="since-days" style={{ fontSize: "var(--fs-s)", color: "var(--fg-2)" }}>

--- a/dashboard/src/app/tasks/page.tsx
+++ b/dashboard/src/app/tasks/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useEffect, useMemo, useRef, useState } from "react";
+import Link from "next/link";
 import { apiPath } from "@/lib/api";
 import { fmtDuration } from "@/components/time";
 import { SkeletonList } from "@/components/Skeleton";
@@ -591,9 +592,9 @@ export default function TasksPage() {
               </>
             }
             action={
-              <a href="/recipes" className="btn sm">
+              <Link href="/recipes" className="btn sm">
                 Browse recipes
-              </a>
+              </Link>
             }
           />
         ) : (

--- a/dashboard/src/app/traces/page.tsx
+++ b/dashboard/src/app/traces/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useSearchParams } from "next/navigation";
+import Link from "next/link";
 import { relTime } from "@/components/time";
 import { apiPath } from "@/lib/api";
 import { canonicalRecipeKey } from "@/lib/entityKey";
@@ -875,9 +876,9 @@ export default function TracesPage() {
           title="No traces yet"
           description="Decision traces (approvals, enrichment, recipe runs) accumulate here as the bridge operates. Run a recipe or process an approval to start the log."
           action={
-            <a href="/recipes" className="btn sm">
+            <Link href="/recipes" className="btn sm">
               Browse recipes
-            </a>
+            </Link>
           }
         />
       ) : view === "flat" ? (


### PR DESCRIPTION
## Summary

Phase 2b of the connected-dashboard plan. Wires the shared entity-chip family into pages that still rendered entities as plain text, and adds RelationStrips to surfaces that were missing the cross-page fan-out strip.

**RelationStrip additions (6 pages)**

- `/inbox` — Recipes, Runs, Traces, Connections
- `/connections` — Recipes, Inbox, Marketplace
- `/analytics` — Runs, Activity, Insights
- `/insights` — Approvals, Traces, Knowledge, Suggestions
- `/suggestions` — Approvals, Insights, Knowledge
- `/decisions` (Knowledge) — Traces, Approvals, Insights, Recipes

**Chip swaps**

- `/analytics` "Top tools" table: tool name renders as `ToolChip` linking to `/insights?tool=<name>`.
- `/marketplace`: "Installed" pill is now a `Link` to the recipe hub (`/recipes/<canonicalKey>`).
- `/insights` header KPI pills (decisions / trusted / rejected): now `Link`s to `/activity` and `/approvals?decision=…` instead of inert spans.
- `/decisions` ref column: `PR-###` and `####` refs route through `EntityLink kind="run"` (RunChip); other refs stay as text.

**Deferred (tracked for follow-up PRs)**

These were genuinely risky in a "broad mechanical" PR — each needs targeted thought:

- `/runs` and `/runs/[seq]` heavy row/detail chip swap — row-click navigation + multi-suffix recipe-name formatting need a dedicated pass.
- `/activity` row chips — table rows already carry `cursor:pointer` with no `href`; swap deferred until row-vs-chip click target is decided.
- `/sessions` and `/sessions/[id]` drill-down link retargeting + `firstTool` label fix.
- `/traces` recipe column — currently a `<button>` (expand-toggle), so wrapping in a chip would steal the click. Needs co-design with the expand affordance.
- `/inbox` provenance-driven header (requires inbox API `provenance` field — not visible in this branch).
- `/approvals` row recipe/run chips (gated on bridge populating `runSeq` / `recipeName`).
- `/recipes` recent-runs rows → `RunChip` (already a Phase 1 row).
- Overview `/` ActivityThread chip-wrapping.
- `/connections` connector-name → `ConnectorChip` (page is 1.5k lines; needs careful read).

## Test plan

- [ ] Dashboard typecheck (note: worktree has no `node_modules`; existing reported errors are all pre-existing module-resolution failures unrelated to this change).
- [ ] Visual: log in, walk /inbox, /connections, /analytics, /insights, /suggestions, /decisions — confirm RelationStrip renders under each H1 and chips link to the named destinations.
- [ ] Visual: /marketplace — confirm "Installed" pill on an already-installed card opens `/recipes/<name>`.
- [ ] Visual: /analytics "Top tools" — confirm tool name renders as ToolChip, hover shows tool label, click goes to `/insights?tool=<name>`.
- [ ] Visual: /insights — confirm header pills link to `/activity` and `/approvals?decision=…`.
- [ ] Visual: /decisions — confirm a card with `body.ref = PR-123` (or `#123`) renders a clickable RunChip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)