### PR TITLE
feat(dashboard): adopt entity chips on runs/inbox/activity/sessions + run→inbox provenance

### DIFF
--- a/dashboard/src/app/activity/page.tsx
+++ b/dashboard/src/app/activity/page.tsx
@@ -1,6 +1,5 @@
 "use client";
 import { useEffect, useMemo, useRef, useState } from "react";
-import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { apiPath } from "@/lib/api";
 import { canonicalRecipeKey } from "@/lib/entityKey";
@@ -16,6 +15,12 @@ import {
   LivePill,
   type LivePillConnection,
 } from "@/components/patchwork";
+import {
+  ApprovalChip,
+  RecipeChip,
+  SessionChip,
+  ToolChip,
+} from "@/components/patchwork/entity";
 import { SkeletonList } from "@/components/Skeleton";
 import { ActivityTabs } from "@/components/ActivityTabs";
 import { RecentHaltsPanel } from "@/components/RecentHaltsPanel";
@@ -66,6 +71,11 @@ function getLifecycleMeta(e: ActivityEvent) {
     specifier: typeof m.specifier === "string" ? m.specifier : undefined,
     sessionId:
       typeof m.sessionId === "string" ? m.sessionId.slice(0, 8) : undefined,
+    /** Full session id — kept separately for chip linking (the trimmed
+     *  one above is for label display in the legacy text path). */
+    fullSessionId:
+      typeof m.sessionId === "string" ? m.sessionId : undefined,
+    callId: typeof m.callId === "string" ? m.callId : undefined,
     summary: typeof m.summary === "string" ? m.summary : undefined,
     recipeName: rawRecipe ? canonicalRecipeKey(rawRecipe) : undefined,
   };
@@ -582,7 +592,9 @@ export default function ActivityPage() {
                         ? `activity-row is-fresh${isErr ? " is-err" : ""}`
                         : "activity-row"
                     }
-                    style={{ cursor: "pointer" }}
+                    /* Row had cursor:pointer but no onClick — deceptive
+                       affordance. Chips inside the row are now the real
+                       click targets. */
                   >
                     <td
                       className="muted"
@@ -595,21 +607,38 @@ export default function ActivityPage() {
                     </td>
                     <td className="mono" style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", maxWidth: 160 }}>
                       {meta.recipeName ? (
-                        <Link
-                          href={`/recipes/${encodeURIComponent(meta.recipeName)}/edit`}
-                          onClick={(ev) => ev.stopPropagation()}
-                          style={{ color: "var(--accent)", textDecoration: "none" }}
-                          title={`Recipe ${meta.recipeName}`}
-                        >
-                          {meta.recipeName}
-                        </Link>
+                        <RecipeChip
+                          name={meta.recipeName}
+                          variant="row"
+                        />
                       ) : (
                         <span className="muted">—</span>
                       )}
                     </td>
                     <td className="mono" style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", maxWidth: 300 }}>
-                      {mainLabel}
-                      {subLabel && <span className="muted">{subLabel}</span>}
+                      {isTool && e.tool ? (
+                        <ToolChip name={e.tool} variant="row" />
+                      ) : isApproval && meta.callId ? (
+                        <ApprovalChip
+                          callId={meta.callId}
+                          tier={meta.toolName}
+                          decision={
+                            meta.decision === "allow"
+                              ? "approved"
+                              : meta.decision === "deny"
+                                ? "rejected"
+                                : undefined
+                          }
+                          variant="row"
+                        />
+                      ) : isLifecycle && meta.fullSessionId ? (
+                        <SessionChip id={meta.fullSessionId} variant="row" />
+                      ) : (
+                        <>
+                          {mainLabel}
+                          {subLabel && <span className="muted">{subLabel}</span>}
+                        </>
+                      )}
                     </td>
                     <td className="mono muted">{durationCell}</td>
                     <td>

--- a/dashboard/src/app/inbox/page.tsx
+++ b/dashboard/src/app/inbox/page.tsx
@@ -6,6 +6,7 @@ import Link from "next/link";
 import { apiPath } from "@/lib/api";
 import { inboxItemKey } from "@/lib/entityKey";
 import { EmptyState, ErrorState, HintCard, RelationStrip } from "@/components/patchwork";
+import { RecipeChip, RunChip } from "@/components/patchwork/entity";
 import { SkeletonList } from "@/components/Skeleton";
 import { InboxDeliveryCard } from "@/components/InboxDeliveryCard";
 import { useToast } from "@/components/Toast";
@@ -29,17 +30,29 @@ type FilterCategory = "All" | "Morning Briefs" | "Recipe Outputs" | "Agent Repor
 
 // ------------------------------------------------------------------ types
 
+/** Provenance frontmatter the bridge writes onto inbox files (PR #742).
+ *  Optional + additive — older files without frontmatter have no
+ *  `provenance` and the UI suppresses the header strip. */
+interface InboxProvenance {
+  recipe?: string;
+  runSeq?: number;
+  trigger?: string;
+  deliveredAt?: number;
+}
+
 interface InboxItem {
   name: string;
   path: string;
   modifiedAt: string;
   preview: string;
+  provenance?: InboxProvenance;
 }
 
 interface InboxDetail {
   name: string;
   content: string;
   modifiedAt: string;
+  provenance?: InboxProvenance;
 }
 
 // ------------------------------------------------------------------ slug helpers
@@ -900,13 +913,43 @@ const filteredItems = items.filter((item) => {
                     {slugToTitle(selected.name)}
                   </h2>
 
-                  {/* Sender row: avatar + name + time */}
+                  {/* Sender row: avatar + provenance (when present) + time.
+                      With provenance frontmatter (PR #742) we render a
+                      truthful "Produced by <recipe> · run <#seq>" strip.
+                      Without it we suppress the legacy "Local agent" guess
+                      — silence is more honest than a generic label. */}
                   <div style={{ display: "flex", alignItems: "center", gap: 12, marginBottom: 20, paddingBottom: 14, borderBottom: "1px solid var(--line-1)" }}>
                     <SenderAvatar name={selected.name} size={40} />
                     <div style={{ flex: 1, minWidth: 0 }}>
-                      <div style={{ fontSize: "var(--fs-m)", fontWeight: 600, color: "var(--ink-0)", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>
-                        Local agent
-                      </div>
+                      {selected.provenance?.recipe && (
+                        <div
+                          style={{
+                            fontSize: "var(--fs-m)",
+                            color: "var(--ink-0)",
+                            display: "flex",
+                            alignItems: "center",
+                            flexWrap: "wrap",
+                            gap: 6,
+                          }}
+                        >
+                          <span style={{ color: "var(--ink-3)" }}>Produced by</span>
+                          <RecipeChip
+                            name={selected.provenance.recipe}
+                            trigger={selected.provenance.trigger}
+                            variant="link"
+                          />
+                          {selected.provenance.runSeq !== undefined && (
+                            <>
+                              <span style={{ color: "var(--ink-3)" }}>· run</span>
+                              <RunChip
+                                seq={selected.provenance.runSeq}
+                                recipeName={selected.provenance.recipe}
+                                variant="link"
+                              />
+                            </>
+                          )}
+                        </div>
+                      )}
                       <div style={{ fontSize: "var(--fs-xs)", color: "var(--ink-3)", marginTop: 2 }}>
                         {new Date(selected.modifiedAt).toLocaleString()}
                       </div>
@@ -951,12 +994,12 @@ const filteredItems = items.filter((item) => {
 
                   {/* Action buttons (bottom) */}
                   {(() => {
-                    // Strip .md only; the trailing date stays — recipe
-                    // identity from a filename is a sibling-PR concern
-                    // (moves to provenance metadata). For now the deep
-                    // link can include the date and the recipes page
-                    // will gracefully no-op if no recipe matches.
-                    const recipeNameForSelected = inboxItemKey(selected.name);
+                    // Prefer provenance.recipe (PR #742 frontmatter) over
+                    // a filename-regex guess. Older files without
+                    // provenance fall back to the .md-stripped filename
+                    // — the recipes page no-ops gracefully on a miss.
+                    const recipeNameForSelected =
+                      selected.provenance?.recipe ?? inboxItemKey(selected.name);
                     return (
                       <>
                       <div className="inbox-reader-actions" style={{ display: "flex", flexWrap: "wrap", gap: 6, marginTop: 16, paddingTop: 16, borderTop: "1px solid var(--line-1)" }}>

--- a/dashboard/src/app/page.tsx
+++ b/dashboard/src/app/page.tsx
@@ -18,6 +18,7 @@ import {
   QuiltHero,
   Sparkline,
 } from "@/components/patchwork";
+import { RecipeChip, ToolChip } from "@/components/patchwork/entity";
 import {
   RecipeLeaderboard,
   type LeaderboardRun,
@@ -576,43 +577,33 @@ function ActivityThread({ events: rawEvents }: { events: ActivityEvent[] }) {
                   }}
                 >
                   {recipe && (
-                    <Link
-                      href={`/recipes/${encodeURIComponent(recipe)}/edit`}
-                      title={`Recipe ${recipe}`}
-                      onClick={(ev) => ev.stopPropagation()}
+                    <RecipeChip
+                      name={recipe}
+                      variant="row"
+                    />
+                  )}
+                  {recipe && (
+                    <span aria-hidden="true" style={{ color: "var(--ink-3)" }}>·</span>
+                  )}
+                  {e.kind === "tool" && e.tool ? (
+                    <ToolChip name={e.tool} variant="row" />
+                  ) : (
+                    <span
                       style={{
                         fontFamily: "var(--font-mono)",
-                        fontSize: "var(--fs-xs)",
-                        color: "var(--accent)",
-                        textDecoration: "none",
-                        flexShrink: 0,
-                        maxWidth: 140,
+                        fontSize: "var(--fs-s)",
+                        color: "var(--ink-0)",
+                        fontWeight: 600,
+                        flex: 1,
+                        minWidth: 0,
                         overflow: "hidden",
                         textOverflow: "ellipsis",
                         whiteSpace: "nowrap",
                       }}
                     >
-                      {recipe}
-                    </Link>
+                      {tool}
+                    </span>
                   )}
-                  {recipe && (
-                    <span aria-hidden="true" style={{ color: "var(--ink-3)" }}>·</span>
-                  )}
-                  <span
-                    style={{
-                      fontFamily: "var(--font-mono)",
-                      fontSize: "var(--fs-s)",
-                      color: "var(--ink-0)",
-                      fontWeight: 600,
-                      flex: 1,
-                      minWidth: 0,
-                      overflow: "hidden",
-                      textOverflow: "ellipsis",
-                      whiteSpace: "nowrap",
-                    }}
-                  >
-                    {tool}
-                  </span>
                   {repeatCount > 1 && (
                     <span
                       className="pill muted"

--- a/dashboard/src/app/recipes/page.tsx
+++ b/dashboard/src/app/recipes/page.tsx
@@ -25,6 +25,7 @@ import {
   StatusPill,
   SuccessRing,
 } from "@/components/patchwork";
+import { RunChip } from "@/components/patchwork/entity";
 
 /**
  * Trigger-type → chip tone. Triggers used to all render in the same
@@ -142,6 +143,10 @@ interface Recipe {
 interface RunRecord {
   recipe: string;
   recipeName?: string;
+  /** Bridge run sequence — required for /runs/[seq] deep-link. The bridge
+   *  /runs API already returns this; the field was simply missing from
+   *  the dashboard-side type. */
+  seq?: number;
   startedAt: number;
   status: string;
   durationMs?: number;
@@ -542,7 +547,16 @@ function RecipeDetailPanel({
                     fontFamily: "var(--font-mono)",
                   }}
                 >
-                  <StatusPill tone={tone}>{ok ? "ok" : run.status}</StatusPill>
+                  {typeof run.seq === "number" ? (
+                    <RunChip
+                      seq={run.seq}
+                      status={run.status}
+                      recipeName={run.recipeName ?? run.recipe}
+                      variant="row"
+                    />
+                  ) : (
+                    <StatusPill tone={tone}>{ok ? "ok" : run.status}</StatusPill>
+                  )}
                   <span style={{ color: "var(--ink-3)", flex: 1 }}>{relTime(run.startedAt)}</span>
                   <span style={{ color: "var(--ink-2)" }}>{formatDuration(run.durationMs)}</span>
                   {typeof run.toolCount === "number" && (

--- a/dashboard/src/app/runs/[seq]/page.tsx
+++ b/dashboard/src/app/runs/[seq]/page.tsx
@@ -4,6 +4,7 @@ import { useParams } from "next/navigation";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { apiPath } from "@/lib/api";
 import { RelationStrip } from "@/components/patchwork";
+import { RecipeChip, RunChip, ToolChip, InboxChip } from "@/components/patchwork/entity";
 import { StepDiffHover } from "@/components/StepDiffHover";
 import { Dialog } from "@/components/Dialog";
 import { useBridgeStream } from "@/hooks/useBridgeStream";
@@ -66,6 +67,10 @@ interface RunDetail {
   /** Run finished `done` but ≥1 step ended in error — "completed with
    *  errors". Set by the bridge run log (see runLog.hadStepErrors). */
   hadStepErrors?: boolean;
+  /** Bridge-provided list of inbox files this run produced (see
+   *  RecipeRun.inboxOutputs in src/runLog.ts). Forwarded straight
+   *  through the dashboard's bridge pass-through proxy. */
+  inboxOutputs?: Array<{ filename: string; deliveredAt: number }>;
 }
 
 interface PlanStep {
@@ -487,7 +492,17 @@ function StepRow({
               whiteSpace: "nowrap",
             }}
           >
-            {step.tool ?? step.id}
+            {step.tool ? (
+              <span
+                onClick={(e) => e.stopPropagation()}
+                onKeyDown={(e) => e.stopPropagation()}
+                style={{ display: "inline-flex" }}
+              >
+                <ToolChip name={step.tool} variant="link" />
+              </span>
+            ) : (
+              step.id
+            )}
           </div>
           {step.tool && step.tool !== step.id && (
             <div className="mono muted" style={{ fontSize: "var(--fs-xs)", marginTop: 2 }}>
@@ -810,33 +825,30 @@ function CausalChainCard({ run }: { run: RunDetail }) {
       </div>
       <div style={{ padding: "8px 0" }}>
         {hasParent && (
-          <Link
-            href={`/runs/${run.parentSeq}`}
+          <div
             style={{
               display: "flex",
               alignItems: "center",
               gap: 10,
               padding: "6px 16px",
-              textDecoration: "none",
-              color: "inherit",
             }}
           >
             <span style={{ fontSize: "var(--fs-xs)", color: "var(--ink-3)", minWidth: 56 }}>triggered by</span>
-            <span className="pill muted" style={{ fontSize: "var(--fs-xs)" }}>#{run.parentSeq}</span>
-            <span style={{ fontSize: "var(--fs-m)" }}>
-              {parent ? parent.recipeName : <span style={{ color: "var(--ink-3)" }}>…</span>}
-            </span>
+            <RunChip
+              seq={run.parentSeq as number}
+              status={parent?.status}
+              recipeName={parent?.recipeName}
+              variant="row"
+            />
             {parent && (
-              <>
-                <span className={`pill ${statusPillClass(parent.status)}`} style={{ fontSize: "var(--fs-2xs)" }}>
-                  {parent.status}
-                </span>
-                <span className="mono muted" style={{ fontSize: "var(--fs-xs)", marginLeft: "auto" }}>
-                  {fmtDur(parent.durationMs)}
-                </span>
-              </>
+              <RecipeChip name={parent.recipeName} variant="link" />
             )}
-          </Link>
+            {parent && (
+              <span className="mono muted" style={{ fontSize: "var(--fs-xs)", marginLeft: "auto" }}>
+                {fmtDur(parent.durationMs)}
+              </span>
+            )}
+          </div>
         )}
         {hasParent && hasChildren && (
           <div style={{ margin: "2px 16px", borderTop: "1px solid var(--border-subtle)" }} />
@@ -844,35 +856,32 @@ function CausalChainCard({ run }: { run: RunDetail }) {
         {(run.childSeqs ?? []).map((childSeq, i) => {
           const child = children.find((c) => c.seq === childSeq);
           return (
-            <Link
+            <div
               key={childSeq}
-              href={`/runs/${childSeq}`}
               style={{
                 display: "flex",
                 alignItems: "center",
                 gap: 10,
                 padding: "6px 16px",
-                textDecoration: "none",
-                color: "inherit",
                 borderTop: i > 0 ? "1px solid var(--border-subtle)" : undefined,
               }}
             >
               <span style={{ fontSize: "var(--fs-xs)", color: "var(--ink-3)", minWidth: 56 }}>triggered</span>
-              <span className="pill muted" style={{ fontSize: "var(--fs-xs)" }}>#{childSeq}</span>
-              <span style={{ fontSize: "var(--fs-m)" }}>
-                {child ? child.recipeName : <span style={{ color: "var(--ink-3)" }}>…</span>}
-              </span>
+              <RunChip
+                seq={childSeq}
+                status={child?.status}
+                recipeName={child?.recipeName}
+                variant="row"
+              />
               {child && (
-                <>
-                  <span className={`pill ${statusPillClass(child.status)}`} style={{ fontSize: "var(--fs-2xs)" }}>
-                    {child.status}
-                  </span>
-                  <span className="mono muted" style={{ fontSize: "var(--fs-xs)", marginLeft: "auto" }}>
-                    {fmtDur(child.durationMs)}
-                  </span>
-                </>
+                <RecipeChip name={child.recipeName} variant="link" />
               )}
-            </Link>
+              {child && (
+                <span className="mono muted" style={{ fontSize: "var(--fs-xs)", marginLeft: "auto" }}>
+                  {fmtDur(child.durationMs)}
+                </span>
+              )}
+            </div>
           );
         })}
       </div>
@@ -1170,7 +1179,11 @@ export default function RunDetailPage() {
             <span className="mono">#{seq}</span>
           </div>
           <h1 style={{ margin: 0, fontSize: 22 }}>
-            {run ? run.recipeName : <span style={{ color: "var(--ink-3)" }}>…</span>}
+            {run ? (
+              <RecipeChip name={run.recipeName} variant="link" />
+            ) : (
+              <span style={{ color: "var(--ink-3)" }}>…</span>
+            )}
           </h1>
           {/*
             "Feels connected" strip for the run detail. Runs are the
@@ -1382,6 +1395,38 @@ export default function RunDetailPage() {
           {tab === "steps" && (
             <>
               <CausalChainCard run={run} />
+              {run.inboxOutputs && run.inboxOutputs.length > 0 && (
+                <div
+                  className="card"
+                  style={{
+                    marginBottom: 20,
+                    padding: "10px 16px",
+                    display: "flex",
+                    flexWrap: "wrap",
+                    alignItems: "center",
+                    gap: 8,
+                  }}
+                >
+                  <span
+                    style={{
+                      fontSize: "var(--fs-xs)",
+                      color: "var(--ink-3)",
+                      fontWeight: 600,
+                      textTransform: "uppercase",
+                      letterSpacing: "0.06em",
+                    }}
+                  >
+                    Delivered to inbox
+                  </span>
+                  {run.inboxOutputs.map((out) => (
+                    <InboxChip
+                      key={out.filename}
+                      name={out.filename}
+                      recipeName={run.recipeName}
+                    />
+                  ))}
+                </div>
+              )}
               {run.assertionFailures && run.assertionFailures.length > 0 && (
                 <AssertionFailuresPanel failures={run.assertionFailures} />
               )}

--- a/dashboard/src/app/runs/page.tsx
+++ b/dashboard/src/app/runs/page.tsx
@@ -6,6 +6,7 @@ import { useSearchParams } from "next/navigation";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { LivePill } from "@/components/patchwork/LivePill";
 import { AnimatedNumber, EmptyState, ErrorState, RelationStrip } from "@/components/patchwork";
+import { RecipeChip } from "@/components/patchwork/entity";
 import { SkeletonList } from "@/components/Skeleton";
 import { ActivityTabs } from "@/components/ActivityTabs";
 import { useDebounced } from "@/hooks/useDebounced";
@@ -932,13 +933,20 @@ export default function RunsPage() {
                         )}
                       </td>
                       <td className="mono">
-                        <Link
-                          href={`/runs/${r.seq}`}
+                        {/* Chip links to the recipe hub; row click still
+                            expands; row-level "Open full run →" in the
+                            drawer handles the run navigation. */}
+                        <span
                           onClick={(e) => e.stopPropagation()}
-                          style={{ fontWeight: 600 }}
+                          onKeyDown={(e) => e.stopPropagation()}
+                          style={{ display: "inline-flex" }}
                         >
-                          {formatRecipeName(r.recipeName, r.trigger)}
-                        </Link>
+                          <RecipeChip
+                            name={r.recipeName}
+                            trigger={normaliseTrigger(r.trigger)}
+                            variant="row"
+                          />
+                        </span>
                       </td>
                       <td>
                         <span className="pill muted">{normaliseTrigger(r.trigger)}</span>
@@ -1206,14 +1214,17 @@ export default function RunsPage() {
                 aria-expanded={isExpanded}
               >
                 <div className="run-card-head">
-                  <Link
-                    href={`/runs/${r.seq}`}
+                  <span
                     onClick={(e) => e.stopPropagation()}
-                    className="mono"
-                    style={{ fontWeight: 600, minWidth: 0, overflow: "hidden", textOverflow: "ellipsis" }}
+                    onKeyDown={(e) => e.stopPropagation()}
+                    style={{ display: "inline-flex", minWidth: 0 }}
                   >
-                    {formatRecipeName(r.recipeName, r.trigger)}
-                  </Link>
+                    <RecipeChip
+                      name={r.recipeName}
+                      trigger={normaliseTrigger(r.trigger)}
+                      variant="row"
+                    />
+                  </span>
                   <span
                     className={`pill ${sClass}`}
                     style={{ fontSize: "var(--fs-2xs)", flexShrink: 0 }}

--- a/dashboard/src/app/sessions/[id]/page.tsx
+++ b/dashboard/src/app/sessions/[id]/page.tsx
@@ -227,8 +227,13 @@ export default function SessionDetailPage() {
               },
               {
                 label: "Activity stream",
-                href: "/activity",
-                title: "Live event firehose",
+                href: `/activity?session=${encodeURIComponent(id)}`,
+                title: `Events emitted by session ${id}`,
+              },
+              {
+                label: "Approvals",
+                href: `/approvals?session=${encodeURIComponent(id)}`,
+                title: `Approvals waiting on session ${id}`,
               },
               {
                 label: "All sessions",

--- a/dashboard/src/app/sessions/page.tsx
+++ b/dashboard/src/app/sessions/page.tsx
@@ -4,6 +4,8 @@ import { relTime } from "@/components/time";
 import { useBridgeFetch } from "@/hooks/useBridgeFetch";
 import { apiPath } from "@/lib/api";
 import { EmptyState, ErrorState, RelationStrip } from "@/components/patchwork";
+import { ToolChip } from "@/components/patchwork/entity";
+import Link from "next/link";
 import { SkeletonList } from "@/components/Skeleton";
 import { ActivityTabs } from "@/components/ActivityTabs";
 import { useToast } from "@/components/Toast";
@@ -20,13 +22,8 @@ interface SessionSummary {
   clientType?: string;
 }
 
-function recipeFor(s: SessionSummary): string {
+function firstToolFor(s: SessionSummary): string {
   return s.firstTool ?? "session";
-}
-
-function descriptionFor(recipe: string, hasRealRecipe: boolean): string {
-  if (!hasRealRecipe) return "no first tool reported";
-  return `first tool · ${recipe}`;
 }
 
 function activityState(
@@ -230,14 +227,21 @@ export default function SessionsPage() {
               const act = activityState(lastMs);
               const toolCount = s.toolCount ?? 0;
               const isSelected = selectedId === s.id;
-              const recipe = recipeFor(s);
-              const description = descriptionFor(recipe, Boolean(s.firstTool));
+              const firstTool = firstToolFor(s);
+              const hasRealTool = Boolean(s.firstTool);
 
               return (
-                <button
+                <div
                   key={s.id}
-                  type="button"
+                  role="button"
+                  tabIndex={0}
                   onClick={() => setSelectedId(isSelected ? null : s.id)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.preventDefault();
+                      setSelectedId(isSelected ? null : s.id);
+                    }
+                  }}
                   className="glass-card glass-card--hover"
                   style={{
                     textAlign: "left",
@@ -274,7 +278,7 @@ export default function SessionsPage() {
                           whiteSpace: "nowrap",
                         }}
                       >
-                        s{idx + 1} · {recipe}
+                        s{idx + 1}
                       </div>
                     </div>
                     <span
@@ -298,17 +302,26 @@ export default function SessionsPage() {
                     </span>
                   </div>
 
-                  {/* description */}
+                  {/* description — First tool, surfaced as a ToolChip when
+                      one was actually reported. */}
                   <div
                     style={{
                       fontSize: "var(--fs-s)",
                       color: "var(--ink-2)",
-                      overflow: "hidden",
-                      textOverflow: "ellipsis",
-                      whiteSpace: "nowrap",
+                      display: "flex",
+                      alignItems: "center",
+                      gap: 6,
+                      flexWrap: "wrap",
                     }}
                   >
-                    {description}
+                    <span style={{ color: "var(--ink-3)" }}>First tool:</span>
+                    {hasRealTool ? (
+                      <span onClick={(e) => e.stopPropagation()}>
+                        <ToolChip name={firstTool} variant="row" />
+                      </span>
+                    ) : (
+                      <span className="muted">none reported</span>
+                    )}
                   </div>
 
                   {/* metrics row */}
@@ -321,7 +334,12 @@ export default function SessionsPage() {
                       borderTop: "1px solid var(--line-3)",
                     }}
                   >
-                    <div>
+                    <Link
+                      href={`/activity?session=${encodeURIComponent(s.id)}`}
+                      onClick={(e) => e.stopPropagation()}
+                      title={`Activity for session ${s.id.slice(0, 8)}`}
+                      style={{ textDecoration: "none", color: "inherit" }}
+                    >
                       <div
                         style={{
                           fontSize: "var(--fs-stat)",
@@ -345,8 +363,13 @@ export default function SessionsPage() {
                       >
                         Tools
                       </div>
-                    </div>
-                    <div>
+                    </Link>
+                    <Link
+                      href={`/sessions/${encodeURIComponent(s.id)}`}
+                      onClick={(e) => e.stopPropagation()}
+                      title="Open session detail"
+                      style={{ textDecoration: "none", color: "inherit" }}
+                    >
                       <div
                         style={{
                           fontSize: "var(--fs-stat)",
@@ -370,8 +393,13 @@ export default function SessionsPage() {
                       >
                         Files
                       </div>
-                    </div>
-                    <div>
+                    </Link>
+                    <Link
+                      href={`/approvals?session=${encodeURIComponent(s.id)}`}
+                      onClick={(e) => e.stopPropagation()}
+                      title="Approvals for this session"
+                      style={{ textDecoration: "none", color: "inherit" }}
+                    >
                       <div
                         style={{
                           fontSize: "var(--fs-stat)",
@@ -396,7 +424,7 @@ export default function SessionsPage() {
                       >
                         Pending
                       </div>
-                    </div>
+                    </Link>
                   </div>
 
                   {/* footer */}
@@ -413,7 +441,7 @@ export default function SessionsPage() {
                       <span className="mono">{s.remoteAddr}</span>
                     )}
                   </div>
-                </button>
+                </div>
               );
             })}
           </div>

--- a/dashboard/src/app/traces/page.tsx
+++ b/dashboard/src/app/traces/page.tsx
@@ -9,6 +9,7 @@ import { useBridgeFetch } from "@/hooks/useBridgeFetch";
 import { useDebounced } from "@/hooks/useDebounced";
 import { arr, isRecord, shape, type ShapeCheck } from "@/lib/validate";
 import { EmptyState, ErrorState, HintCard, LivePill, RelationStrip } from "@/components/patchwork";
+import { ApprovalChip, RecipeChip } from "@/components/patchwork/entity";
 import { ActivityTabs } from "@/components/ActivityTabs";
 import { SkeletonList } from "@/components/Skeleton";
 
@@ -965,31 +966,51 @@ export default function TracesPage() {
                   >
                     {t.key}
                   </button>
-                  <button
-                    type="button"
-                    onClick={() => toggle(rowKey)}
+                  <div
                     style={{
-                      fontSize: "var(--fs-m)",
-                      // Anonymous traces (no body.recipeName) used to fall back to
-                      // t.key here, which was already rendered in the prior column
-                      // — every "anon:Bash" row showed "anon:Bash anon:Bash". Mute
-                      // and em-dash when the recipe name would just duplicate.
-                      color:
-                        typeof t.body?.recipeName === "string"
-                          ? "var(--ink-1)"
-                          : "var(--ink-3)",
-                      background: "transparent",
-                      border: "none",
-                      padding: 0,
-                      cursor: "pointer",
-                      textAlign: "left",
+                      display: "flex",
+                      alignItems: "center",
+                      gap: 6,
+                      minWidth: 0,
                       overflow: "hidden",
-                      textOverflow: "ellipsis",
-                      whiteSpace: "nowrap",
                     }}
                   >
-                    {typeof t.body?.recipeName === "string" ? t.body.recipeName : "—"}
-                  </button>
+                    <button
+                      type="button"
+                      onClick={() => toggle(rowKey)}
+                      aria-label={isOpen ? "Collapse details" : "Expand details"}
+                      style={{
+                        fontSize: "var(--fs-m)",
+                        color:
+                          typeof t.body?.recipeName === "string"
+                            ? "var(--ink-1)"
+                            : "var(--ink-3)",
+                        background: "transparent",
+                        border: "none",
+                        padding: 0,
+                        cursor: "pointer",
+                        textAlign: "left",
+                        overflow: "hidden",
+                        textOverflow: "ellipsis",
+                        whiteSpace: "nowrap",
+                      }}
+                    >
+                      {typeof t.body?.recipeName === "string" ? t.body.recipeName : "—"}
+                    </button>
+                    {typeof t.body?.recipeName === "string" && (
+                      <RecipeChip
+                        name={t.body.recipeName}
+                        variant="link"
+                      />
+                    )}
+                    {t.traceType === "approval" &&
+                      typeof t.body?.callId === "string" && (
+                        <ApprovalChip
+                          callId={t.body.callId}
+                          variant="link"
+                        />
+                      )}
+                  </div>
                   <span style={{ fontSize: "var(--fs-xs)", color: "var(--ink-3)", textAlign: "right" }}>
                     {relTime(t.ts)}
                   </span>


### PR DESCRIPTION
## Summary

Phase 2b follow-through to PR #746. The earlier PR shipped the structural
additions (RelationStrips, low-risk chip swaps) but deferred the higher-payoff
adoptions on the journey spine. This PR pushes them through.

Per numbered item from the task:

1. **/runs list** — recipe cell now `RecipeChip(variant="row")` linking to `/recipes/<key>` via `canonicalRecipeKey`. Row click still toggles expand; chip uses `stopPropagation`. Same swap on the mobile run-card head.
2. **/runs/[seq] detail** — H1 → `RecipeChip(variant="link")`. Per-step rows render `ToolChip` when `step.tool` is set; agent steps stay plain text. `CausalChainCard` rebuilt around `RunChip` + `RecipeChip`. Session-id-on-run: not present in the run record on the bridge side (`RecipeRun` has no `sessionId` field in `src/runLog.ts`), so the SessionChip in the header is a no-op for now — documented in the commit and left as a follow-up if the bridge starts populating it.
3. **/inbox provenance header** — confirmed `provenance` is returned by `/inbox` and `/inbox/[filename]` in `src/inboxRoutes.ts` (PR #742). When `selected.provenance` is set: "Produced by `<RecipeChip />` · run `<RunChip />`". When unset: header strip suppressed AND the legacy "Local agent" sender label is dropped (silence beats a generic guess). The action-row recipe-name guess now prefers `provenance.recipe` and falls back to `inboxItemKey()` only when provenance is missing.
4. **/activity rows** — removed deceptive `cursor:pointer` (no row handler existed). Recipe → `RecipeChip(row)`, tool → `ToolChip(row)`, approval-decision → `ApprovalChip(row)`, lifecycle-with-sessionId → `SessionChip(row)`. Surfaced `callId` and full `sessionId` from metadata for the chips.
5. **/sessions list + /sessions/[id]** — Session card converted from `<button>` to `role="button" div` so nested `<a>` Links are legal. Mislabel "recipe" (it was `firstTool`) fixed to "First tool" rendered with `ToolChip`. Tool/Files/Pending stats are now drill-down Links to `/activity?session=`, `/sessions/[id]`, `/approvals?session=` respectively. On detail page, `RelationStrip` Activity + Approvals items now session-scoped.
6. **/recipes detail panel "Recent runs"** — `RunRecord` gains `seq?: number` (bridge `/runs` already returns it). When present, rows render `RunChip(row)` linking `/runs/[seq]`; fallback to `StatusPill` keeps older data working.
7. **/traces recipe column** — picked option (a): kept the existing expand button + added a `RecipeChip(link)` next to it. Approval-trace rows additionally render `ApprovalChip(link)` when `body.callId` is present.
8. **Overview ActivityThread** — recipe → `RecipeChip(row)`, tool kind → `ToolChip(row)`. Chip is the click target; row is no longer a link.
9. **Run-detail "Output → Inbox"** — added `inboxOutputs?: Array<{filename, deliveredAt}>` to the local `RunDetail` type (bridge already writes it via `RecipeRun.inboxOutputs`) and rendered a "Delivered to inbox" card with `InboxChip` per filename, sitting between `CausalChainCard` and the steps panel.

## Test plan

- [ ] Type-check: `npx tsc --noEmit` in `dashboard/` (✅ verified locally, clean exit)
- [ ] Visual walkthrough — dev server not running in this agent's sandbox, so the walkthrough below is the recommended manual verification:
  - [ ] `/runs`: recipe cell links to `/recipes/<name>`, row click still expands, "Open full run →" still in drawer
  - [ ] `/runs/[seq]`: H1 chip-links to recipe; step rows show ToolChip; CausalChainCard parent/child are clickable RunChips; runs with inbox outputs show the "Delivered to inbox" strip
  - [ ] `/inbox`: pick an item produced by a recent recipe run (frontmatter present) and confirm the "Produced by … · run #N" header; pick an older file without frontmatter and confirm header is suppressed
  - [ ] `/activity`: rows no longer show pointer cursor; click recipe/tool/approval chip lands on the right page
  - [ ] `/sessions`: card stat numbers are Links to the session-scoped variant pages; first-tool renders as a ToolChip
  - [ ] `/sessions/[id]`: Activity/Approvals strip targets are `?session=<id>`
  - [ ] `/recipes` detail panel: recent runs are clickable RunChips
  - [ ] `/traces`: recipe-name button still expands the row; the small RecipeChip next to it lands on `/recipes/<name>`
  - [ ] `/`: ActivityThread rows show inline chips; row containers are not links

🤖 Generated with [Claude Code](https://claude.com/claude-code)