### PR TITLE
feat(dashboard): phase-2c action continuity

### DIFF
--- a/dashboard/src/app/approvals/page.tsx
+++ b/dashboard/src/app/approvals/page.tsx
@@ -215,6 +215,7 @@ const ApprovalCard = memo(function ApprovalCard({
     else setRejecting(true);
     try {
       await onDecide(p.callId, decision, reason);
+      toast.success(decision === "approve" ? "Approved" : "Denied");
     } catch (e) {
       toast.error(
         `${decision === "approve" ? "Approve" : "Reject"} failed: ${e instanceof Error ? e.message : String(e)}`,

--- a/dashboard/src/app/connections/page.tsx
+++ b/dashboard/src/app/connections/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+import Link from "next/link";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { apiPath } from "@/lib/api";
 import AddConnectionModal from "./AddConnectionModal";
@@ -567,9 +568,10 @@ interface GridCardProps {
   onDisconnect: () => void;
   onTest: () => Promise<{ ok: boolean; message?: string }>;
   loading: boolean;
+  recipeCount?: number;
 }
 
-function ConnectorGridCard({ def, statusEntry, onConnect, onDisconnect, onTest, loading }: GridCardProps) {
+function ConnectorGridCard({ def, statusEntry, onConnect, onDisconnect, onTest, loading, recipeCount }: GridCardProps) {
   const [testResult, setTestResult] = useState<{ ok: boolean; message?: string } | null>(null);
   const [testing, setTesting] = useState(false);
 
@@ -683,6 +685,30 @@ function ConnectorGridCard({ def, statusEntry, onConnect, onDisconnect, onTest, 
         ) : (
           <div style={{ fontSize: "var(--fs-s)", color: "var(--ink-3)", fontWeight: 400 }}>
             {def.tools} available tools
+          </div>
+        )}
+
+        {/* Recipe count badge */}
+        {recipeCount !== undefined && recipeCount > 0 && (
+          <div style={{ marginTop: 6 }}>
+            <Link
+              href={`/recipes?connector=${encodeURIComponent(def.id)}`}
+              style={{
+                display: "inline-flex",
+                alignItems: "center",
+                gap: 4,
+                fontSize: "var(--fs-2xs)",
+                color: "var(--accent)",
+                textDecoration: "none",
+                padding: "2px 7px",
+                borderRadius: 999,
+                background: "var(--accent-soft)",
+                border: "1px solid var(--accent-tint)",
+              }}
+              title={`${recipeCount} installed recipe${recipeCount === 1 ? "" : "s"} use this connector`}
+            >
+              {recipeCount} recipe{recipeCount === 1 ? "" : "s"}
+            </Link>
           </div>
         )}
 
@@ -878,6 +904,12 @@ function RecentCard({ def, lastSync }: { def: ConnectorDef; lastSync: string }) 
 
 export default function ConnectionsPage() {
   const [connectors, setConnectors] = useState<ConnectorStatus[]>([]);
+  // Connector id → number of installed recipes that reference it.
+  // Derived by fetching /api/bridge/recipes once on mount and scanning
+  // recipe names + descriptions for connector keywords (same heuristic
+  // as the Recipes page's detectConnectors). If the bridge is offline the
+  // map stays empty and no badges render — fail-soft.
+  const [connectorRecipeCounts, setConnectorRecipeCounts] = useState<Map<string, number>>(new Map());
   const [loading, setLoading] = useState(true);
   const [err, setErr] = useState<string>();
   const [bridgeOffline, setBridgeOffline] = useState(false);
@@ -922,6 +954,52 @@ export default function ConnectionsPage() {
 
   useEffect(() => {
     fetchConnectors();
+
+    // Fetch installed recipes and derive connector→recipe count map.
+    // Tool-prefix heuristic mirrors the Recipes page detectConnectors fn.
+    const TOOL_KEYWORD_TO_CONNECTOR_ID: Record<string, string> = {
+      slack: "slack",
+      github: "github",
+      jira: "jira",
+      linear: "linear",
+      gmail: "gmail",
+      calendar: "google-calendar",
+      googlecalendar: "google-calendar",
+      intercom: "intercom",
+      hubspot: "hubspot",
+      datadog: "datadog",
+      stripe: "stripe",
+      sentry: "sentry",
+      notion: "notion",
+      discord: "discord",
+      confluence: "confluence",
+      pagerduty: "pagerduty",
+      zendesk: "zendesk",
+      asana: "asana",
+      gitlab: "gitlab",
+    };
+    fetch(apiPath("/api/bridge/recipes"))
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data: { recipes?: Array<{ name: string; description?: string }>; } | Array<{ name: string; description?: string }> | null) => {
+        const list: Array<{ name: string; description?: string }> = Array.isArray(data)
+          ? data
+          : Array.isArray((data as { recipes?: unknown })?.recipes)
+            ? ((data as { recipes: Array<{ name: string; description?: string }> }).recipes)
+            : [];
+        const counts = new Map<string, number>();
+        for (const recipe of list) {
+          const haystack = `${recipe.name} ${recipe.description ?? ""}`.toLowerCase();
+          const seen = new Set<string>();
+          for (const [keyword, connId] of Object.entries(TOOL_KEYWORD_TO_CONNECTOR_ID)) {
+            if (!seen.has(connId) && haystack.includes(keyword)) {
+              counts.set(connId, (counts.get(connId) ?? 0) + 1);
+              seen.add(connId);
+            }
+          }
+        }
+        setConnectorRecipeCounts(counts);
+      })
+      .catch(() => {});
   }, []);
 
   function getConnector(id: string): ConnectorStatus {
@@ -1322,6 +1400,7 @@ export default function ConnectionsPage() {
                 onDisconnect={() => setConfirmDisconnectId(def.id)}
                 onTest={() => handleTest(def.id)}
                 loading={acting === def.id}
+                recipeCount={connectorRecipeCounts.get(def.id)}
               />
             ))}
           </div>

--- a/dashboard/src/app/marketplace/page.tsx
+++ b/dashboard/src/app/marketplace/page.tsx
@@ -648,7 +648,13 @@ export default function MarketplacePage() {
     // /recipes endpoint returns) — strip the `@scope/` prefix so the
     // Set lookup at the card-render sites matches.
     setInstalledNames((prev) => new Set([...prev, shortName(recipe.name)]));
-    toast.success("Recipe installed successfully");
+    const recipeKey = canonicalRecipeKey(recipe.name);
+    toast.success(`Installed ${shortName(recipe.name)}`, {
+      action: {
+        label: "View in Recipes",
+        onClick: () => router.push(`/recipes/${recipeKey}`),
+      },
+    });
     // Authoritative refresh from the bridge re-reads the unscoped names
     // from disk — keep the Set in sync in case the actual YAML `name:`
     // field differs from the slug the user clicked.

--- a/dashboard/src/app/recipes/[name]/page.tsx
+++ b/dashboard/src/app/recipes/[name]/page.tsx
@@ -353,9 +353,14 @@ export default function RecipeHubOverviewPage({
             body: JSON.stringify(body),
           },
         );
-        const data = (await res.json()) as { ok: boolean; taskId?: string; error?: string };
+        const data = (await res.json()) as { ok: boolean; taskId?: string; seq?: number; error?: string };
         if (data.ok) {
-          toast.success(`Started ${recipe.name}`);
+          const runHref = typeof data.seq === "number"
+            ? `/runs/${data.seq}`
+            : `/runs?recipe=${encodeURIComponent(recipe.name)}`;
+          toast.success("Run started", {
+            action: { label: "View run", onClick: () => router.push(runHref) },
+          });
           setRunModalOpen(false);
         } else {
           toast.error(`Run failed: ${data.error ?? "unknown"}`);
@@ -366,7 +371,7 @@ export default function RecipeHubOverviewPage({
         setRunStarting(false);
       }
     },
-    [recipe, toast],
+    [recipe, toast, router],
   );
 
   const handleToggle = useCallback(async () => {

--- a/dashboard/src/app/recipes/page.tsx
+++ b/dashboard/src/app/recipes/page.tsx
@@ -78,6 +78,45 @@ function detectConnectors(recipes: Recipe[]): string[] {
   return Array.from(found).sort();
 }
 
+// Keyword → connections-page connector id. Mirrors the heuristic the
+// /connections page uses to derive its "N recipes" badge — keeping both
+// in sync means the badge count and this filtered list agree. Maps to
+// the connections-page `def.id` values (e.g. `google-calendar`), which
+// is the id form the `?connector=` deep-link param carries.
+const CONNECTOR_KEYWORD_BY_ID: Record<string, string[]> = {
+  slack: ["slack"],
+  github: ["github"],
+  jira: ["jira"],
+  linear: ["linear"],
+  gmail: ["gmail"],
+  "google-calendar": ["calendar", "googlecalendar"],
+  intercom: ["intercom"],
+  hubspot: ["hubspot"],
+  datadog: ["datadog"],
+  stripe: ["stripe"],
+  sentry: ["sentry"],
+  notion: ["notion"],
+  discord: ["discord"],
+  confluence: ["confluence"],
+  pagerduty: ["pagerduty"],
+  zendesk: ["zendesk"],
+  asana: ["asana"],
+  gitlab: ["gitlab"],
+};
+
+/**
+ * True when a recipe references the given connector id, using the same
+ * name/description keyword scan as the /connections page badge. Returns
+ * false for unknown connector ids so an unrecognised `?connector=` param
+ * yields an empty (rather than full) list.
+ */
+function recipeMatchesConnector(recipe: Recipe, connectorId: string): boolean {
+  const keywords = CONNECTOR_KEYWORD_BY_ID[connectorId];
+  if (!keywords) return false;
+  const haystack = `${recipe.name} ${recipe.description ?? ""}`.toLowerCase();
+  return keywords.some((kw) => haystack.includes(kw));
+}
+
 function relTime(ms: number): string {
   const diff = Date.now() - ms;
   const sec = Math.floor(diff / 1000);
@@ -1034,10 +1073,18 @@ export default function RecipesPage() {
   // page re-renders on every SSE step event via LiveRunsContext, and
   // each rebuild was rebroadcasting a fresh array identity downstream,
   // breaking React.memo on row components. Perf audit 2026-05-19.
+  // #748 follow-up: /connections links here with ?connector=<id> when a
+  // user clicks the "N recipes" badge. Honour it as an additional filter
+  // so the deep-link actually narrows the list. Absent param → no-op.
+  const connectorFilter = searchParams.get("connector");
+
   const filteredRecipes = useMemo(() => {
     return (recipes ?? []).filter((r) => {
       if (statusFilter === "enabled" && r.enabled === false) return false;
       if (statusFilter === "paused" && r.enabled !== false) return false;
+      if (connectorFilter && !recipeMatchesConnector(r, connectorFilter)) {
+        return false;
+      }
       if (!search.trim()) return true;
       const q = search.toLowerCase();
       return (
@@ -1045,7 +1092,7 @@ export default function RecipesPage() {
         (r.description ?? "").toLowerCase().includes(q)
       );
     });
-  }, [recipes, statusFilter, search]);
+  }, [recipes, statusFilter, search, connectorFilter]);
 
   const { enabledCount, pausedCount, installedCount } = useMemo(() => {
     const list = recipes ?? [];
@@ -1254,6 +1301,51 @@ export default function RecipesPage() {
       </div>
 
       <HintCard id="recipes" />
+
+      {connectorFilter && (
+        <div
+          role="status"
+          style={{
+            display: "inline-flex",
+            alignItems: "center",
+            gap: 8,
+            margin: "0 0 var(--s-4)",
+            padding: "5px 6px 5px 12px",
+            borderRadius: 999,
+            fontSize: "var(--fs-s)",
+            background: "var(--accent-soft)",
+            border: "1px solid var(--accent-tint)",
+            color: "var(--accent)",
+          }}
+        >
+          <span>
+            Filtered by connector:{" "}
+            <strong style={{ fontWeight: 600 }}>{connectorFilter}</strong>
+          </span>
+          <button
+            type="button"
+            onClick={() => router.push("/recipes")}
+            aria-label="Clear connector filter"
+            title="Clear connector filter"
+            style={{
+              display: "inline-flex",
+              alignItems: "center",
+              justifyContent: "center",
+              width: 22,
+              height: 22,
+              borderRadius: "50%",
+              border: "none",
+              cursor: "pointer",
+              background: "transparent",
+              color: "var(--accent)",
+              fontSize: "var(--fs-m)",
+              lineHeight: 1,
+            }}
+          >
+            ✕
+          </button>
+        </div>
+      )}
 
       {err && (recipes === null || recipes.length === 0) && (
         <ErrorState


### PR DESCRIPTION
## Summary

- **Post-action toasts with follow-through links** (Piece 1)
  - Marketplace install: upgraded success toast to `Installed <name>` + "View in Recipes" action that navigates to `/recipes/<canonicalKey>`
  - Recipe hub run trigger: success toast now reads "Run started" with a "View run" action — links to `/runs/<seq>` when the bridge returns a seq, falls back to `/runs?recipe=<name>` filtered view
  - Approvals approve/deny: added `toast.success("Approved" / "Denied")` after the card fades out so the user gets feedback

- **Run-detail "Output → Inbox" link** (Piece 2)
  - The existing `InboxChip` already links each `inboxOutputs` entry to `/inbox?item=<key>` — already correct, no changes needed

- **"Recipes using this connector" badge on /connections** (Piece 3)
  - Fetches installed recipes on mount, derives a connector→count map via keyword heuristic (same as the Recipes page `detectConnectors`)
  - Renders a linked accent badge on each `ConnectorGridCard` with ≥1 matching recipe, linking to `/recipes?connector=<id>`
  - Fail-soft: badge doesn't render when bridge is offline or no matches

## Test plan

- [ ] Install a recipe from the marketplace → toast shows recipe name + "View in Recipes" action → clicking it navigates to `/recipes/<name>`
- [ ] Run a recipe from its hub page → toast shows "Run started" + "View run" → clicking navigates to the runs view
- [ ] Approve/deny an approval → success toast appears confirming the action
- [ ] On `/connections`, connectors referenced by installed recipes show an accent badge with count → clicking links to `/recipes?connector=<id>`
- [ ] With bridge offline, no recipe count badges appear on connections page

🤖 Generated with [Claude Code](https://claude.com/claude-code)