### PR TITLE
feat(dashboard): make suggestions + insights actionable with drill-down links

### DIFF
--- a/dashboard/src/app/insights/page.tsx
+++ b/dashboard/src/app/insights/page.tsx
@@ -259,19 +259,19 @@ export default function InsightsPage() {
                 {data.totalDecisions} decisions
               </Link>
               <Link
-                href="/approvals?decision=approved"
+                href="/traces"
                 className="pill ok"
                 style={{ textDecoration: "none" }}
-                title="See approved calls"
+                title="See trusted tool traces"
               >
                 {data.trustedToolCount} trusted
               </Link>
               {data.rejectedToolCount > 0 && (
                 <Link
-                  href="/approvals?decision=rejected"
+                  href="/approvals?risk=high"
                   className="pill err"
                   style={{ textDecoration: "none" }}
-                  title="See rejected calls"
+                  title="See high-risk pending approvals"
                 >
                   {data.rejectedToolCount} rejected
                 </Link>
@@ -477,7 +477,17 @@ export default function InsightsPage() {
                       fontVariantNumeric: "tabular-nums",
                     }}
                   >
-                    {t.approvals}
+                    {t.approvals > 0 ? (
+                      <Link
+                        href={`/activity?tool=${encodeURIComponent(t.toolName)}&tab=tools`}
+                        style={{ color: "inherit", textDecoration: "none" }}
+                        title={`${t.approvals} approvals for ${t.toolName}`}
+                      >
+                        {t.approvals}
+                      </Link>
+                    ) : (
+                      t.approvals
+                    )}
                   </td>
                   <td
                     style={{
@@ -491,7 +501,17 @@ export default function InsightsPage() {
                       fontVariantNumeric: "tabular-nums",
                     }}
                   >
-                    {t.rejections}
+                    {t.rejections > 0 ? (
+                      <Link
+                        href={`/activity?tool=${encodeURIComponent(t.toolName)}&tab=tools`}
+                        style={{ color: "inherit", textDecoration: "none" }}
+                        title={`${t.rejections} rejections for ${t.toolName}`}
+                      >
+                        {t.rejections}
+                      </Link>
+                    ) : (
+                      t.rejections
+                    )}
                   </td>
                   <td
                     style={{

--- a/dashboard/src/app/suggestions/page.tsx
+++ b/dashboard/src/app/suggestions/page.tsx
@@ -288,7 +288,17 @@ export default function SuggestionsPage() {
             if (!isTrustDetails(s.details)) return null;
             const { recipeName } = s.details;
             return (
-              <GraduateButton recipeName={recipeName} />
+              <span style={{ display: "inline-flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
+                <GraduateButton recipeName={recipeName} />
+                <Link
+                  href={`/recipes?selected=${encodeURIComponent(recipeName)}`}
+                  className="btn sm ghost"
+                  style={{ textDecoration: "none" }}
+                  title={`View ${recipeName} recipe`}
+                >
+                  View recipe
+                </Link>
+              </span>
             );
           }}
         />
@@ -299,7 +309,24 @@ export default function SuggestionsPage() {
           title="Installed tools you haven't called recently"
           subtitle={KIND_META.installed_but_unused.explanation}
           items={byKind.installed_but_unused}
-          renderAction={() => null}
+          renderAction={(s) => {
+            if (!isUnusedDetails(s.details) || s.details.examples.length === 0) return null;
+            return (
+              <span style={{ display: "inline-flex", alignItems: "center", gap: 6, flexWrap: "wrap" }}>
+                {s.details.examples.slice(0, 3).map((toolName) => (
+                  <Link
+                    key={toolName}
+                    href={`/activity?tool=${encodeURIComponent(toolName)}&tab=tools`}
+                    className="btn sm ghost"
+                    style={{ textDecoration: "none", fontFamily: "var(--font-mono, monospace)", fontSize: "var(--fs-xs)" }}
+                    title={`See activity for ${toolName}`}
+                  >
+                    {toolName}
+                  </Link>
+                ))}
+              </span>
+            );
+          }}
         />
       )}
 


### PR DESCRIPTION
## Summary

- **insights/page.tsx**: Fixed two broken deep-link contracts (`?decision=approved/rejected` on approvals page, which doesn't honor that param). KPI pills now link to `/traces` (trusted) and `/approvals?risk=high` (rejected, which `risk` IS honored by approvals). Per-row approval/rejection counts are now clickable links to `/activity?tool=<name>&tab=tools` (both `tool` and `tab` params verified honored).
- **suggestions/page.tsx**: `installed_but_unused` group now renders clickable tool buttons per example (up to 3) linking to `/activity?tool=<name>&tab=tools`. `recipe_trust_graduation` rows gain a "View recipe" link to `/recipes?selected=<name>` alongside the existing Graduate button (`selected` param verified honored by recipes page).

## Deep-link params verified
- `/activity?tool=` — honored (line 118 of activity/page.tsx)
- `/activity?tab=tools` — valid Tab value (line 33: `"all" | "tools" | "recipe_start" | "recipe_end"`)
- `/approvals?risk=high` — honored (line 643-648 of approvals/page.tsx)
- `/recipes?selected=` — honored (line 726 of recipes/page.tsx)
- `/traces` — plain link, no params, always valid

## Skipped / not invented
- No new bridge endpoints created
- `co_occurring_pair` "Draft a recipe" link to `/recipes/new?vars=` was already correct and verified honored
- Per-row `lastDecisionAt` timestamp left as plain text (no meaningful drill-down target)
- `heuristicLabel` and `matchedRule` cells left as plain text (no filter target for these on any page)

## Test plan
- [ ] Visit `/suggestions` with bridge running, verify "Installed tools" rows show tool name buttons
- [ ] Click a tool button — should land on `/activity?tool=<name>&tab=tools` filtered view
- [ ] Visit a recipe trust graduation row — "View recipe" link should navigate to recipe hub pre-selected
- [ ] Visit `/insights`, click the "trusted" pill → `/traces`
- [ ] Click the "rejected" pill → `/approvals?risk=high` (queue filtered to high-risk)
- [ ] Click an approval count cell → `/activity?tool=<name>&tab=tools`

🤖 Generated with [Claude Code](https://claude.com/claude-code)