### PR TITLE
feat(dashboard): add EntityTimeline component + adopt on run/recipe pages

### DIFF
--- a/dashboard/src/app/recipes/[name]/page.tsx
+++ b/dashboard/src/app/recipes/[name]/page.tsx
@@ -26,11 +26,13 @@ import { Dialog } from "@/components/Dialog";
 import {
   ConnectorChip,
   EmptyState,
+  EntityTimeline,
   InboxChip,
   PatchCard,
   RunChip,
   StatusPill,
 } from "@/components/patchwork";
+import type { TimelineEvent } from "@/components/patchwork";
 import { detectConnectorsForRecipe } from "./layout";
 
 interface RecipeVar {
@@ -568,6 +570,24 @@ export default function RecipeHubOverviewPage({
             ))}
           </div>
         )}
+      </PatchCard>
+
+      {/* RECENT RUNS TIMELINE */}
+      <PatchCard style={{ padding: "var(--s-4)" }}>
+        <SectionHeader>Run timeline</SectionHeader>
+        <EntityTimeline
+          ariaLabel={`Recent run timeline for ${name}`}
+          events={recentRuns.map((r, i): TimelineEvent => ({
+            id: `run-${r.seq ?? r.startedAt}-${i}`,
+            kind: "run",
+            timestamp: r.startedAt,
+            label: `Run — ${r.status}`,
+            status: r.status,
+            meta: typeof r.seq === "number"
+              ? { seq: r.seq, recipeName: r.recipeName ?? r.recipe, hadStepErrors: r.hadStepErrors }
+              : undefined,
+          }))}
+        />
       </PatchCard>
 
       {/* HALT SUMMARY */}

--- a/dashboard/src/app/runs/[seq]/page.tsx
+++ b/dashboard/src/app/runs/[seq]/page.tsx
@@ -3,7 +3,8 @@ import Link from "next/link";
 import { useParams } from "next/navigation";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { apiPath } from "@/lib/api";
-import { RelationStrip } from "@/components/patchwork";
+import { EntityTimeline, RelationStrip } from "@/components/patchwork";
+import type { TimelineEvent } from "@/components/patchwork";
 import { RecipeChip, RunChip, ToolChip, InboxChip } from "@/components/patchwork/entity";
 import { StepDiffHover } from "@/components/StepDiffHover";
 import { Dialog } from "@/components/Dialog";
@@ -1395,6 +1396,70 @@ export default function RunDetailPage() {
           {tab === "steps" && (
             <>
               <CausalChainCard run={run} />
+
+              {/* ── Timeline card ── */}
+              {(() => {
+                const events: TimelineEvent[] = [];
+                // trigger event
+                events.push({
+                  id: `trigger-${run.seq}`,
+                  kind: "trigger",
+                  timestamp: run.createdAt,
+                  label: `Triggered by: ${run.trigger}`,
+                });
+                // the run itself
+                events.push({
+                  id: `run-${run.seq}`,
+                  kind: "run",
+                  timestamp: run.startedAt ?? run.createdAt,
+                  label: `Run #${run.seq} — ${run.status}`,
+                  status: run.status,
+                  meta: {
+                    seq: run.seq,
+                    recipeName: run.recipeName,
+                    hadStepErrors: run.hadStepErrors,
+                  },
+                });
+                // step events
+                for (const step of run.stepResults ?? []) {
+                  events.push({
+                    id: `step-${run.seq}-${step.id}`,
+                    kind: "step",
+                    timestamp: step.startedAt ?? run.startedAt ?? run.createdAt,
+                    label: step.tool ? `${step.tool} (${step.id})` : step.id,
+                    status: step.status,
+                    href: `#step-${step.id}`,
+                  });
+                }
+                // inbox outputs
+                for (const out of run.inboxOutputs ?? []) {
+                  events.push({
+                    id: `inbox-${run.seq}-${out.filename}`,
+                    kind: "inbox",
+                    timestamp: out.deliveredAt,
+                    label: out.filename,
+                    meta: { name: out.filename, recipeName: run.recipeName },
+                  });
+                }
+                return (
+                  <div className="card" style={{ marginBottom: 20, padding: 0, overflow: "hidden" }}>
+                    <div
+                      style={{
+                        padding: "10px 16px",
+                        borderBottom: "1px solid var(--border-subtle)",
+                        fontSize: "var(--fs-s)",
+                        fontWeight: 600,
+                        color: "var(--ink-2)",
+                      }}
+                    >
+                      Timeline
+                    </div>
+                    <div style={{ padding: "12px 16px" }}>
+                      <EntityTimeline events={events} ariaLabel={`Timeline for run #${run.seq}`} />
+                    </div>
+                  </div>
+                );
+              })()}
               {run.inboxOutputs && run.inboxOutputs.length > 0 && (
                 <div
                   className="card"

--- a/dashboard/src/components/patchwork/EntityTimeline.tsx
+++ b/dashboard/src/components/patchwork/EntityTimeline.tsx
@@ -1,0 +1,300 @@
+import Link from "next/link";
+import { EmptyState } from "./EmptyState";
+import { RunChip } from "./entity/RunChip";
+import { InboxChip } from "./entity/InboxChip";
+import { ApprovalChip, type ApprovalDecision } from "./entity/ApprovalChip";
+import { TraceChip } from "./entity/TraceChip";
+
+/**
+ * Discriminated event in an entity timeline.
+ *
+ * `kind` drives which entity chip (if any) to render alongside the label.
+ * Keep `id` on event-level data — the chips use it when present.
+ */
+export interface TimelineEvent {
+  /** Stable key for React. */
+  id: string;
+  kind: "run" | "inbox" | "approval" | "trace" | "step" | "trigger";
+  /** Unix ms timestamp — timeline is sorted newest-first. */
+  timestamp: number;
+  /** Human-readable description of this event. */
+  label: string;
+  /** Optional navigation target (used for plain links on step / trigger rows). */
+  href?: string;
+  /** Optional status string passed through to RunChip and shown as a badge. */
+  status?: string;
+  /**
+   * Entity-specific context bag.
+   *
+   * run       → { seq: number; recipeName?: string; hadStepErrors?: boolean }
+   * inbox     → { name: string; recipeName?: string }
+   * approval  → { callId: string; decision?: string }
+   * trace     → { traceKey: string; traceType?: string }
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  meta?: Record<string, unknown>;
+}
+
+// ------------------------------------------------------------------ helpers
+
+function relTime(ms: number): string {
+  const diff = Date.now() - ms;
+  const sec = Math.floor(diff / 1000);
+  if (sec < 5) return "just now";
+  if (sec < 60) return `${sec}s ago`;
+  const min = Math.floor(sec / 60);
+  if (min < 60) return `${min}m ago`;
+  const hrs = Math.floor(min / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  const days = Math.floor(hrs / 24);
+  if (days < 7) return `${days}d ago`;
+  return new Date(ms).toLocaleDateString("en-US", { month: "short", day: "numeric" });
+}
+
+/** Map each kind to a small colour dot on the spine. */
+function kindDotColor(kind: TimelineEvent["kind"]): string {
+  switch (kind) {
+    case "run":      return "var(--blue, #4a90d9)";
+    case "inbox":    return "var(--green, #4caf50)";
+    case "approval": return "var(--amber, #d49a3a)";
+    case "trace":    return "var(--accent, #7c6ff7)";
+    case "step":     return "var(--ink-3, #9ca3af)";
+    case "trigger":  return "var(--ink-2, #6b7280)";
+    default:         return "var(--line-2)";
+  }
+}
+
+/** Render the entity chip for a row, or null when the kind has no chip. */
+function EntityChip({ event }: { event: TimelineEvent }) {
+  const { kind, meta = {} } = event;
+
+  if (kind === "run" && typeof meta.seq === "number") {
+    return (
+      <RunChip
+        seq={meta.seq as number}
+        status={event.status}
+        hadStepErrors={meta.hadStepErrors as boolean | undefined}
+        recipeName={meta.recipeName as string | undefined}
+        variant="chip"
+      />
+    );
+  }
+
+  if (kind === "inbox" && typeof meta.name === "string") {
+    return (
+      <InboxChip
+        name={meta.name as string}
+        recipeName={meta.recipeName as string | undefined}
+        variant="chip"
+      />
+    );
+  }
+
+  if (kind === "approval" && typeof meta.callId === "string") {
+    const approvalDecisions: ApprovalDecision[] = ["pending", "approved", "rejected"];
+    const rawDecision = meta.decision as string | undefined;
+    const decision = rawDecision && approvalDecisions.includes(rawDecision as ApprovalDecision)
+      ? rawDecision as ApprovalDecision
+      : undefined;
+    return (
+      <ApprovalChip
+        callId={meta.callId as string}
+        decision={decision}
+        variant="chip"
+      />
+    );
+  }
+
+  if (kind === "trace" && typeof meta.traceKey === "string") {
+    return (
+      <TraceChip
+        traceKey={meta.traceKey as string}
+        traceType={(meta.traceType as string | undefined) ?? "decision"}
+        variant="chip"
+      />
+    );
+  }
+
+  // step / trigger with href → plain Link
+  if (event.href) {
+    return (
+      <Link
+        href={event.href}
+        style={{
+          fontSize: "var(--fs-xs)",
+          color: "var(--accent)",
+          textDecoration: "none",
+        }}
+      >
+        {event.label}
+      </Link>
+    );
+  }
+
+  return null;
+}
+
+// ------------------------------------------------------------------ component
+
+export interface EntityTimelineProps {
+  events: TimelineEvent[];
+  /** Accessible label for the wrapping <ol>. Defaults to "Timeline". */
+  ariaLabel?: string;
+}
+
+/**
+ * EntityTimeline — vertical chronological (newest-first) event list.
+ *
+ * Presentational only: pass pre-shaped TimelineEvent[]; no fetching inside.
+ * Accessible: the list is an <ol> with <li> rows; the spine is aria-hidden.
+ */
+export function EntityTimeline({
+  events,
+  ariaLabel = "Timeline",
+}: EntityTimelineProps) {
+  if (events.length === 0) {
+    return <EmptyState title="No timeline events" description="Events will appear here as this entity accumulates activity." />;
+  }
+
+  const sorted = [...events].sort((a, b) => b.timestamp - a.timestamp);
+  const isLast = (i: number) => i === sorted.length - 1;
+
+  return (
+    <ol
+      aria-label={ariaLabel}
+      style={{
+        listStyle: "none",
+        margin: 0,
+        padding: 0,
+      }}
+    >
+      {sorted.map((event, i) => {
+        const dotColor = kindDotColor(event.kind);
+        // Call as a function so we can check for null synchronously.
+        // Using JSX here would always produce a React element (never null).
+        const chip = EntityChip({ event });
+
+        return (
+          <li
+            key={event.id}
+            style={{
+              display: "grid",
+              gridTemplateColumns: "24px 1fr",
+              gap: "0 10px",
+              position: "relative",
+            }}
+          >
+            {/* ── spine ── */}
+            <div
+              aria-hidden="true"
+              style={{
+                display: "flex",
+                flexDirection: "column",
+                alignItems: "center",
+              }}
+            >
+              {/* dot */}
+              <div
+                style={{
+                  width: 10,
+                  height: 10,
+                  borderRadius: "50%",
+                  background: dotColor,
+                  flexShrink: 0,
+                  marginTop: 5,
+                  zIndex: 1,
+                }}
+              />
+              {/* connector line to next item */}
+              {!isLast(i) && (
+                <div
+                  style={{
+                    flex: 1,
+                    width: 1,
+                    background: "var(--border-subtle, var(--line-2))",
+                    minHeight: 16,
+                    marginTop: 2,
+                  }}
+                />
+              )}
+            </div>
+
+            {/* ── row body ── */}
+            <div
+              style={{
+                paddingBottom: isLast(i) ? 0 : 16,
+                minWidth: 0,
+              }}
+            >
+              {/* kind badge + time */}
+              <div
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 6,
+                  marginBottom: chip ? 4 : 0,
+                }}
+              >
+                <span
+                  className="mono"
+                  style={{
+                    fontSize: "var(--fs-2xs)",
+                    color: "var(--ink-3)",
+                    textTransform: "uppercase",
+                    letterSpacing: "0.05em",
+                  }}
+                >
+                  {event.kind}
+                </span>
+                <span
+                  style={{
+                    fontSize: "var(--fs-2xs)",
+                    color: "var(--ink-3)",
+                  }}
+                >
+                  {relTime(event.timestamp)}
+                </span>
+              </div>
+
+              {/* chip or label */}
+              {chip ? (
+                <div style={{ display: "inline-flex", alignItems: "center", gap: 6, flexWrap: "wrap" }}>
+                  {chip}
+                  {/* Only show label separately when chip doesn't already encode it (step/trigger chips render the label themselves) */}
+                  {event.kind !== "step" && event.kind !== "trigger" && event.href == null && (
+                    <span
+                      style={{
+                        fontSize: "var(--fs-s)",
+                        color: "var(--ink-1)",
+                        overflow: "hidden",
+                        textOverflow: "ellipsis",
+                        whiteSpace: "nowrap",
+                        maxWidth: "100%",
+                      }}
+                    >
+                      {event.label}
+                    </span>
+                  )}
+                </div>
+              ) : (
+                <span
+                  style={{
+                    fontSize: "var(--fs-s)",
+                    color: "var(--ink-2)",
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                    whiteSpace: "nowrap",
+                    display: "block",
+                    maxWidth: "100%",
+                  }}
+                >
+                  {event.label}
+                </span>
+              )}
+            </div>
+          </li>
+        );
+      })}
+    </ol>
+  );
+}

--- a/dashboard/src/components/patchwork/__tests__/EntityTimeline.test.tsx
+++ b/dashboard/src/components/patchwork/__tests__/EntityTimeline.test.tsx
@@ -1,0 +1,127 @@
+/**
+ * EntityTimeline — unit tests.
+ *
+ * Covers: empty state, sort (newest first), chip rendering, spine,
+ * and accessible list structure.
+ */
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { EntityTimeline } from "@/components/patchwork/EntityTimeline";
+import type { TimelineEvent } from "@/components/patchwork/EntityTimeline";
+
+// ---------- fixtures
+
+const NOW = 1_700_000_000_000; // stable epoch so relTime never flickers
+
+const runEvent: TimelineEvent = {
+  id: "run-1",
+  kind: "run",
+  timestamp: NOW - 1000,
+  label: "Run #1 — done",
+  status: "done",
+  meta: { seq: 1, recipeName: "morning-pulse" },
+};
+
+const triggerEvent: TimelineEvent = {
+  id: "trigger-1",
+  kind: "trigger",
+  timestamp: NOW - 5000,
+  label: "Triggered by: cron",
+};
+
+const inboxEvent: TimelineEvent = {
+  id: "inbox-1",
+  kind: "inbox",
+  timestamp: NOW - 500,
+  label: "morning-brief-2026-05-20.md",
+  meta: { name: "morning-brief-2026-05-20.md", recipeName: "morning-pulse" },
+};
+
+const stepEvent: TimelineEvent = {
+  id: "step-1",
+  kind: "step",
+  timestamp: NOW - 2000,
+  label: "sendEmail (step-1)",
+  href: "#step-step-1",
+};
+
+// ---------- tests
+
+describe("<EntityTimeline />", () => {
+  it("renders EmptyState when events array is empty", () => {
+    render(<EntityTimeline events={[]} />);
+    expect(screen.getByText("No timeline events")).toBeTruthy();
+  });
+
+  it("renders an <ol> list with correct aria-label", () => {
+    const { container } = render(
+      <EntityTimeline events={[runEvent]} ariaLabel="Run #1 timeline" />,
+    );
+    const ol = container.querySelector("ol");
+    expect(ol).not.toBeNull();
+    expect(ol?.getAttribute("aria-label")).toBe("Run #1 timeline");
+  });
+
+  it("renders one <li> per event", () => {
+    const { container } = render(
+      <EntityTimeline events={[runEvent, triggerEvent, inboxEvent]} />,
+    );
+    const items = container.querySelectorAll("li");
+    expect(items).toHaveLength(3);
+  });
+
+  it("sorts events newest first (descending by timestamp)", () => {
+    const { container } = render(
+      <EntityTimeline events={[triggerEvent, inboxEvent, runEvent]} />,
+    );
+    const items = container.querySelectorAll("li");
+    // inboxEvent has the highest timestamp (NOW - 500), should be first
+    expect(items[0].textContent).toContain("inbox");
+    // triggerEvent has the lowest (NOW - 5000), should be last
+    expect(items[2].textContent).toContain("trigger");
+  });
+
+  it("renders a RunChip <a> for run-kind events that have a seq", () => {
+    const { container } = render(<EntityTimeline events={[runEvent]} />);
+    const link = container.querySelector("a");
+    expect(link?.getAttribute("href")).toBe("/runs/1");
+  });
+
+  it("renders an InboxChip <a> for inbox-kind events", () => {
+    const { container } = render(<EntityTimeline events={[inboxEvent]} />);
+    const link = container.querySelector("a");
+    expect(link?.getAttribute("href")).toContain("/inbox?item=");
+  });
+
+  it("renders a plain next/link for step events that have an href", () => {
+    const { container } = render(<EntityTimeline events={[stepEvent]} />);
+    const link = container.querySelector("a");
+    expect(link?.getAttribute("href")).toBe("#step-step-1");
+  });
+
+  it("renders trigger event as plain text when no chip/href", () => {
+    render(<EntityTimeline events={[triggerEvent]} />);
+    expect(screen.getByText("Triggered by: cron")).toBeTruthy();
+  });
+
+  it("spine dots are aria-hidden", () => {
+    const { container } = render(<EntityTimeline events={[runEvent]} />);
+    // The spine wrapper div has aria-hidden="true"
+    const hidden = container.querySelectorAll('[aria-hidden="true"]');
+    expect(hidden.length).toBeGreaterThan(0);
+  });
+
+  it("defaults ariaLabel to 'Timeline'", () => {
+    const { container } = render(<EntityTimeline events={[runEvent]} />);
+    const ol = container.querySelector("ol");
+    expect(ol?.getAttribute("aria-label")).toBe("Timeline");
+  });
+
+  it("does not mutate the input events array", () => {
+    const events = [triggerEvent, inboxEvent, runEvent];
+    const before = events.map((e) => e.id);
+    render(<EntityTimeline events={events} />);
+    expect(events.map((e) => e.id)).toEqual(before);
+  });
+});

--- a/dashboard/src/components/patchwork/index.ts
+++ b/dashboard/src/components/patchwork/index.ts
@@ -27,3 +27,4 @@ export { AreaChart, type AreaChartSeries } from "./AreaChart";
 export { RunSparkBars } from "./RunSparkBars";
 export { SuccessRing, type SuccessRingProps } from "./SuccessRing";
 export * from "./entity";
+export { EntityTimeline, type EntityTimelineProps, type TimelineEvent } from "./EntityTimeline";


### PR DESCRIPTION
## Summary

- Adds `EntityTimeline` component at `dashboard/src/components/patchwork/EntityTimeline.tsx` — a presentational vertical spine-and-dot timeline that accepts `TimelineEvent[]` and renders newest-first
- Reuses existing entity chips (`RunChip`, `InboxChip`, `ApprovalChip`, `TraceChip`) for linked rows; plain `next/link` for step/trigger rows that have an `href`; empty state via shared `EmptyState`
- Exported from the `@/components/patchwork` barrel alongside `TimelineEvent` type
- Adopted on **run detail** (`/runs/[seq]`): trigger → run → step events → inbox deliveries
- Adopted on **recipe hub** (`/recipes/[name]`): one event per recent run, newest-first
- 11 unit tests (sort order, empty state, chip href/aria, spine aria-hidden, immutability)

## Test plan

- [ ] `npx vitest run` in `dashboard/` — 607 tests pass (11 new)
- [ ] `npm run lint -- --file src/components/patchwork/EntityTimeline.tsx` — clean
- [ ] Run detail page: Timeline card appears in Steps tab with trigger/run/step/inbox rows
- [ ] Recipe hub: Run timeline card lists recent runs newest-first with RunChip links
- [ ] Empty state renders when no events present

🤖 Generated with [Claude Code](https://claude.com/claude-code)