### PR TITLE
feat(dashboard): coherent first-run funnel with stateful onboarding steps

### DIFF
--- a/dashboard/src/app/inbox/page.tsx
+++ b/dashboard/src/app/inbox/page.tsx
@@ -686,6 +686,11 @@ const filteredItems = items.filter((item) => {
                 </div>
               </>
             }
+            action={
+              <Link href="/recipes" className="btn sm" style={{ textDecoration: "none" }}>
+                Run a recipe →
+              </Link>
+            }
           />
         ) : (
           <div

--- a/dashboard/src/app/runs/page.tsx
+++ b/dashboard/src/app/runs/page.tsx
@@ -867,7 +867,11 @@ export default function RunsPage() {
                   >
                     Clear filters
                   </button>
-                ) : undefined
+                ) : (
+                  <Link href="/recipes" className="btn sm" style={{ textDecoration: "none" }}>
+                    Go to recipes →
+                  </Link>
+                )
               }
             />
           );

--- a/dashboard/src/components/FirstRunChecklist.tsx
+++ b/dashboard/src/components/FirstRunChecklist.tsx
@@ -5,26 +5,22 @@ import { useCallback, useEffect, useState } from "react";
 import { apiPath } from "@/lib/api";
 
 /**
- * Four-step "first run" orchestration shown on /dashboard for users
- * whose workspace hasn't yet seen the full happy path. Each step
- * auto-checks against a real bridge endpoint:
+ * First-run funnel shown on /dashboard for users who haven't yet seen the
+ * full happy path. Steps are ordered by the natural onboarding sequence:
  *
- *   1. Connect a service        — `/api/bridge/connections` has any entry
- *   2. Install / create a recipe — `/api/bridge/recipes` returns >= 1
- *   3. Run it                    — `/api/bridge/runs` returns >= 1
- *   4. Approve when prompted     — `/api/bridge/approvals/history` has >= 1
+ *   1. Install or create a recipe  — `/api/bridge/recipes` returns >= 1
+ *   2. Run it                       — `/api/bridge/runs` returns >= 1
+ *   3. See a result in inbox        — `/api/bridge/inbox` returns >= 1 item
+ *   4. Connect a service            — `/api/bridge/connections` has any entry
  *
- * Strategic-critique gap: "What does a brand-new user see when /tasks,
- * /recipes, /activity are all empty? Today: 15 unstructured empty-
- * state divs, no orchestration." This component is the orchestration.
+ * The "next" step (first incomplete one) is visually emphasised so the
+ * user always knows what to do next.
  *
  * Collapses (renders null) when:
- *   - all 4 steps are complete (the happy path is established)
+ *   - all steps are complete (the happy path is established)
  *   - the user has dismissed it
  *
- * Dismissals persist in localStorage. A "Restore checklist" mechanic
- * is intentionally NOT here — Settings is the natural place for that,
- * filed for a follow-up commit.
+ * Dismissals persist in localStorage.
  */
 
 const STORAGE_KEY = "patchwork.firstRun.dismissed";
@@ -41,7 +37,7 @@ interface Status {
   connections: StepStatus;
   recipes: StepStatus;
   runs: StepStatus;
-  approvals: StepStatus;
+  inbox: StepStatus;
   loaded: boolean;
 }
 
@@ -50,7 +46,7 @@ function emptyStatus(): Status {
     connections: { done: false },
     recipes: { done: false },
     runs: { done: false },
-    approvals: { done: false },
+    inbox: { done: false },
     loaded: false,
   };
 }
@@ -99,60 +95,44 @@ export function FirstRunChecklist() {
   }, []);
 
   const probe = useCallback(async (signal?: AbortSignal) => {
-    // Probe all 5 endpoints in parallel — cheap reads, brand-new
-    // workspace is the hot path. Endpoint shapes (verified against
-    // the live bridge):
-    //   /connections                       -> { connectors: [...] }
-    //   /recipes                           -> { recipes: [...] }
-    //   /runs                              -> { runs: [...] }
-    //   /approvals                         -> [...] (pending queue)
-    //   /traces?traceType=approval         -> { traces: [...] }
-    // Step 4 is satisfied if EITHER an approval is currently pending
-    // (the user is mid-flow) OR an approval trace was ever saved (the
-    // user has been through the flow at least once).
-    const [conn, recipes, runs, pendingApprovals, approvalTraces] =
-      await Promise.all([
-        probeArray("/api/bridge/connections", "connectors", signal),
-        probeArray("/api/bridge/recipes", "recipes", signal),
-        probeArray("/api/bridge/runs", "runs", signal),
-        probeArray("/api/bridge/approvals", undefined, signal),
-        probeArray("/api/bridge/traces?traceType=approval", "traces", signal),
-      ]);
+    const [recipes, runs, inboxItems, conn] = await Promise.all([
+      probeArray("/api/bridge/recipes", "recipes", signal),
+      probeArray("/api/bridge/runs", "runs", signal),
+      probeArray("/api/bridge/inbox", "items", signal),
+      probeArray("/api/bridge/connections", "connectors", signal),
+    ]);
     if (signal?.aborted) return;
     setStatus({
-      connections: {
-        done: conn > 0,
-        hint: "Gmail, Slack, or any HTTP API. Credentials stay in ~/.patchwork.",
-        doneHint: "Add more in /connections — one recipe can fan across services.",
-      },
       recipes: {
         done: recipes > 0,
         hint: "Browse the marketplace or scaffold one with patchwork recipe new.",
-        doneHint: "YAML lives in ~/.patchwork/recipes. Tweak triggers and steps in /recipes.",
+        doneHint:
+          "YAML lives in ~/.patchwork/recipes. Tweak triggers and steps in /recipes.",
       },
       runs: {
         done: runs > 0,
         hint: "Hit Run on any recipe, or wait for a scheduled trigger.",
-        doneHint: "Watch live in /activity. Halts and errors land in /runs.",
+        doneHint: "Watch live in /runs. Halts and errors appear there too.",
       },
-      approvals: {
-        done: pendingApprovals > 0 || approvalTraces > 0,
-        hint: "Nothing leaves your machine without a nod. The queue is in /approvals.",
-        doneHint: "Approval patterns in /insights surface what's safe to auto-approve.",
+      inbox: {
+        done: inboxItems > 0,
+        hint: "After a recipe run, results land here as inbox items.",
+        doneHint:
+          "Inbox delivers briefs. Set up phone delivery so results reach you anywhere.",
+      },
+      connections: {
+        done: conn > 0,
+        hint: "Gmail, Slack, or any HTTP API. Credentials stay in ~/.patchwork.",
+        doneHint:
+          "Add more in /connections — one recipe can fan across services.",
       },
       loaded: true,
     });
   }, []);
 
   useEffect(() => {
-    // #605: own per-tick AbortController so unmount cancels in-flight
-    // probes (and the 5 parallel probeArray fetches inside).
     const controller = new AbortController();
     void probe(controller.signal);
-    // Refresh every 30s — the checklist auto-completes as the user
-    // works through it, so polling makes the green checkmarks appear
-    // without a reload. Each tick gets its own controller so per-tick
-    // abort doesn't kill all future ticks.
     const id = setInterval(() => {
       const tickCtrl = new AbortController();
       void probe(tickCtrl.signal);
@@ -165,17 +145,19 @@ export function FirstRunChecklist() {
 
   if (dismissed) return null;
   if (!status.loaded) return null;
+
   const allDone =
-    status.connections.done &&
     status.recipes.done &&
     status.runs.done &&
-    status.approvals.done;
+    status.inbox.done &&
+    status.connections.done;
   if (allDone) return null;
+
   const doneCount =
-    (status.connections.done ? 1 : 0) +
     (status.recipes.done ? 1 : 0) +
     (status.runs.done ? 1 : 0) +
-    (status.approvals.done ? 1 : 0);
+    (status.inbox.done ? 1 : 0) +
+    (status.connections.done ? 1 : 0);
 
   const steps: Array<{
     n: number;
@@ -185,29 +167,32 @@ export function FirstRunChecklist() {
   }> = [
     {
       n: 1,
-      label: "Connect a service",
-      cta: { href: "/connections", label: "Connect →" },
-      step: status.connections,
-    },
-    {
-      n: 2,
       label: "Install or create a recipe",
       cta: { href: "/marketplace", label: "Browse marketplace →" },
       step: status.recipes,
     },
     {
-      n: 3,
-      label: "Run it",
+      n: 2,
+      label: "Run a recipe",
       cta: { href: "/recipes", label: "Open recipes →" },
       step: status.runs,
     },
     {
+      n: 3,
+      label: "See a result in your inbox",
+      cta: { href: "/inbox", label: "Open inbox →" },
+      step: status.inbox,
+    },
+    {
       n: 4,
-      label: "Approve when prompted",
-      cta: { href: "/approvals", label: "See queue →" },
-      step: status.approvals,
+      label: "Connect a service",
+      cta: { href: "/connections", label: "Connect →" },
+      step: status.connections,
     },
   ];
+
+  // Index of the first incomplete step — this is the "next" step.
+  const nextIdx = steps.findIndex((s) => !s.step.done);
 
   return (
     <section
@@ -274,86 +259,117 @@ export function FirstRunChecklist() {
           gap: 8,
         }}
       >
-        {steps.map((s) => (
-          <li
-            key={s.n}
-            style={{
-              display: "flex",
-              alignItems: "center",
-              gap: 12,
-              padding: "8px 12px",
-              borderRadius: "var(--r-2)",
-              background: s.step.done
-                ? "color-mix(in srgb, var(--green) 7%, transparent)"
-                : "var(--recess)",
-              opacity: s.step.done ? 0.65 : 1,
-              transition: "opacity 180ms, background 180ms",
-            }}
-          >
-            <span
-              aria-hidden="true"
+        {steps.map((s, idx) => {
+          const isNext = idx === nextIdx;
+          return (
+            <li
+              key={s.n}
+              data-next={isNext ? "true" : undefined}
               style={{
-                width: 22,
-                height: 22,
-                borderRadius: "50%",
-                background: s.step.done ? "var(--green)" : "transparent",
-                border: s.step.done
-                  ? "1px solid var(--green)"
-                  : "1px solid var(--line-2)",
-                color: s.step.done ? "var(--on-accent, #fff)" : "var(--ink-3)",
-                display: "inline-flex",
+                display: "flex",
                 alignItems: "center",
-                justifyContent: "center",
-                fontSize: "var(--fs-xs)",
-                fontWeight: 700,
-                flexShrink: 0,
+                gap: 12,
+                padding: "8px 12px",
+                borderRadius: "var(--r-2)",
+                background: s.step.done
+                  ? "color-mix(in srgb, var(--green) 7%, transparent)"
+                  : isNext
+                    ? "color-mix(in srgb, var(--accent) 8%, var(--recess))"
+                    : "var(--recess)",
+                opacity: s.step.done ? 0.65 : 1,
+                outline: isNext
+                  ? "1.5px solid color-mix(in srgb, var(--accent) 35%, transparent)"
+                  : "none",
+                transition: "opacity 180ms, background 180ms",
               }}
             >
-              {s.step.done ? "✓" : s.n}
-            </span>
-            <div style={{ flex: 1, minWidth: 0 }}>
-              <div
+              <span
+                aria-hidden="true"
                 style={{
-                  fontSize: "var(--fs-s)",
-                  fontWeight: 500,
-                  color: "var(--ink-1)",
-                  textDecoration: s.step.done ? "line-through" : "none",
-                }}
-              >
-                {s.label}
-              </div>
-              {(() => {
-                const tip = s.step.done ? s.step.doneHint : s.step.hint;
-                if (!tip) return null;
-                return (
-                  <div
-                    style={{
-                      fontSize: "var(--fs-xs)",
-                      color: "var(--ink-3)",
-                      marginTop: 2,
-                    }}
-                  >
-                    {tip}
-                  </div>
-                );
-              })()}
-            </div>
-            {!s.step.done && (
-              <Link
-                href={s.cta.href}
-                style={{
+                  width: 22,
+                  height: 22,
+                  borderRadius: "50%",
+                  background: s.step.done
+                    ? "var(--green)"
+                    : isNext
+                      ? "var(--accent)"
+                      : "transparent",
+                  border: s.step.done
+                    ? "1px solid var(--green)"
+                    : isNext
+                      ? "1px solid var(--accent)"
+                      : "1px solid var(--line-2)",
+                  color:
+                    s.step.done || isNext
+                      ? "var(--on-accent, #fff)"
+                      : "var(--ink-3)",
+                  display: "inline-flex",
+                  alignItems: "center",
+                  justifyContent: "center",
                   fontSize: "var(--fs-xs)",
-                  fontWeight: 600,
-                  color: "var(--accent)",
-                  textDecoration: "none",
+                  fontWeight: 700,
                   flexShrink: 0,
                 }}
               >
-                {s.cta.label}
-              </Link>
-            )}
-          </li>
-        ))}
+                {s.step.done ? "✓" : s.n}
+              </span>
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div
+                  style={{
+                    fontSize: "var(--fs-s)",
+                    fontWeight: isNext ? 600 : 500,
+                    color: "var(--ink-1)",
+                    textDecoration: s.step.done ? "line-through" : "none",
+                  }}
+                >
+                  {s.label}
+                  {isNext && (
+                    <span
+                      style={{
+                        marginLeft: 8,
+                        fontSize: "var(--fs-xs)",
+                        fontWeight: 600,
+                        color: "var(--accent)",
+                        verticalAlign: "middle",
+                      }}
+                    >
+                      ← next
+                    </span>
+                  )}
+                </div>
+                {(() => {
+                  const tip = s.step.done ? s.step.doneHint : s.step.hint;
+                  if (!tip) return null;
+                  return (
+                    <div
+                      style={{
+                        fontSize: "var(--fs-xs)",
+                        color: "var(--ink-3)",
+                        marginTop: 2,
+                      }}
+                    >
+                      {tip}
+                    </div>
+                  );
+                })()}
+              </div>
+              {!s.step.done && (
+                <Link
+                  href={s.cta.href}
+                  style={{
+                    fontSize: "var(--fs-xs)",
+                    fontWeight: 600,
+                    color: "var(--accent)",
+                    textDecoration: "none",
+                    flexShrink: 0,
+                  }}
+                >
+                  {s.cta.label}
+                </Link>
+              )}
+            </li>
+          );
+        })}
       </ol>
     </section>
   );

--- a/dashboard/src/components/__tests__/FirstRunChecklist.test.tsx
+++ b/dashboard/src/components/__tests__/FirstRunChecklist.test.tsx
@@ -1,10 +1,9 @@
 /**
- * Verifies the first-run orchestrator on /dashboard:
- *   - probes 4 endpoints and auto-checks steps that have data
- *   - hides when all 4 are complete (the happy path is established)
- *   - hides when the user dismisses + persists across remounts
- *   - shows incomplete steps with a CTA + hint
- *   - completed steps render with a check mark and line-through
+ * Verifies the first-run funnel on /dashboard:
+ *   - step ordering: recipe → run → inbox → connect
+ *   - first incomplete step is marked as "next" (data-next="true")
+ *   - collapses when all 4 steps are complete
+ *   - collapses when the user dismisses + persists across remounts
  */
 
 import { fireEvent, render, waitFor } from "@testing-library/react";
@@ -18,8 +17,7 @@ type Probe =
   | { kind: "wrap"; key: string; arr: unknown[] };
 
 function makeFetch(perPath: Record<string, Probe>): typeof fetch {
-  // Order keys longest-first so a URL like /api/bridge/approvals/history
-  // matches its specific entry instead of the shorter /api/bridge/approvals.
+  // Order keys longest-first so more-specific paths match first.
   const keysByLength = Object.keys(perPath).sort((a, b) => b.length - a.length);
   const spy = vi.fn(async (input: RequestInfo | URL): Promise<Response> => {
     const url = typeof input === "string" ? input : input.toString();
@@ -43,29 +41,57 @@ describe("<FirstRunChecklist/>", () => {
     global.fetch = originalFetch;
   });
 
-  it("renders four steps with the right completion state from the probes", async () => {
+  it("step 1 (recipe) is active/next when no data exists", async () => {
     global.fetch = makeFetch({
-      "/api/bridge/connections": { kind: "wrap", key: "connectors", arr: [{ id: "gmail" }] },
       "/api/bridge/recipes": { kind: "wrap", key: "recipes", arr: [] },
       "/api/bridge/runs": { kind: "wrap", key: "runs", arr: [] },
-      "/api/bridge/approvals": { kind: "arr", arr: [] },
-      "/api/bridge/traces?traceType=approval": { kind: "wrap", key: "traces", arr: [] },
+      "/api/bridge/inbox": { kind: "wrap", key: "items", arr: [] },
+      "/api/bridge/connections": { kind: "wrap", key: "connectors", arr: [] },
     });
     const { findByText, container } = render(<FirstRunChecklist />);
     expect(await findByText(/Get started/)).toBeInTheDocument();
-    // Step 1 (connections) is done — check mark renders, line-through.
-    expect(container.textContent).toMatch(/Connect a service/);
-    // Step 4 (approvals) is incomplete — its CTA link is in the DOM.
-    expect(container.querySelector('a[href="/approvals"]')).not.toBeNull();
+    // Step 1 label is present
+    expect(container.textContent).toMatch(/Install or create a recipe/);
+    // First item should have data-next="true"
+    const items = container.querySelectorAll("li");
+    expect(items[0]?.getAttribute("data-next")).toBe("true");
+    expect(items[1]?.getAttribute("data-next")).toBeNull();
+  });
+
+  it("step 2 (run) is next when recipes are installed but no runs", async () => {
+    global.fetch = makeFetch({
+      "/api/bridge/recipes": { kind: "wrap", key: "recipes", arr: [{ name: "x" }] },
+      "/api/bridge/runs": { kind: "wrap", key: "runs", arr: [] },
+      "/api/bridge/inbox": { kind: "wrap", key: "items", arr: [] },
+      "/api/bridge/connections": { kind: "wrap", key: "connectors", arr: [] },
+    });
+    const { findByText, container } = render(<FirstRunChecklist />);
+    await findByText(/Get started/);
+    const items = container.querySelectorAll("li");
+    // Step 1 done (no data-next), step 2 is next
+    expect(items[0]?.getAttribute("data-next")).toBeNull();
+    expect(items[1]?.getAttribute("data-next")).toBe("true");
+  });
+
+  it("step 3 (inbox) is next when recipes + runs exist but inbox empty", async () => {
+    global.fetch = makeFetch({
+      "/api/bridge/recipes": { kind: "wrap", key: "recipes", arr: [{ name: "x" }] },
+      "/api/bridge/runs": { kind: "wrap", key: "runs", arr: [{ seq: 1 }] },
+      "/api/bridge/inbox": { kind: "wrap", key: "items", arr: [] },
+      "/api/bridge/connections": { kind: "wrap", key: "connectors", arr: [] },
+    });
+    const { findByText, container } = render(<FirstRunChecklist />);
+    await findByText(/Get started/);
+    const items = container.querySelectorAll("li");
+    expect(items[2]?.getAttribute("data-next")).toBe("true");
   });
 
   it("collapses entirely when all four steps are complete", async () => {
     global.fetch = makeFetch({
-      "/api/bridge/connections": { kind: "wrap", key: "connectors", arr: [{ id: "gmail" }] },
       "/api/bridge/recipes": { kind: "wrap", key: "recipes", arr: [{ name: "x" }] },
       "/api/bridge/runs": { kind: "wrap", key: "runs", arr: [{ seq: 1 }] },
-      "/api/bridge/approvals": { kind: "arr", arr: [{ callId: "a" }] },
-      "/api/bridge/traces?traceType=approval": { kind: "wrap", key: "traces", arr: [] },
+      "/api/bridge/inbox": { kind: "wrap", key: "items", arr: [{ id: "i1" }] },
+      "/api/bridge/connections": { kind: "wrap", key: "connectors", arr: [{ id: "gmail" }] },
     });
     const { container } = render(<FirstRunChecklist />);
     await waitFor(() => {
@@ -78,25 +104,21 @@ describe("<FirstRunChecklist/>", () => {
 
   it("renders nothing on first paint (waits for probes) — no skeleton flash", () => {
     global.fetch = makeFetch({
-      "/api/bridge/connections": { kind: "wrap", key: "connectors", arr: [] },
       "/api/bridge/recipes": { kind: "wrap", key: "recipes", arr: [] },
       "/api/bridge/runs": { kind: "wrap", key: "runs", arr: [] },
-      "/api/bridge/approvals": { kind: "arr", arr: [] },
-      "/api/bridge/traces?traceType=approval": { kind: "wrap", key: "traces", arr: [] },
+      "/api/bridge/inbox": { kind: "wrap", key: "items", arr: [] },
+      "/api/bridge/connections": { kind: "wrap", key: "connectors", arr: [] },
     });
     const { container } = render(<FirstRunChecklist />);
-    // Pre-fetch, container is empty (no skeleton because a fresh user
-    // would see a flicker every Overview load).
     expect(container.firstChild).toBeNull();
   });
 
   it("dismissal persists across remounts via localStorage", async () => {
     global.fetch = makeFetch({
-      "/api/bridge/connections": { kind: "wrap", key: "connectors", arr: [] },
       "/api/bridge/recipes": { kind: "wrap", key: "recipes", arr: [] },
       "/api/bridge/runs": { kind: "wrap", key: "runs", arr: [] },
-      "/api/bridge/approvals": { kind: "arr", arr: [] },
-      "/api/bridge/traces?traceType=approval": { kind: "wrap", key: "traces", arr: [] },
+      "/api/bridge/inbox": { kind: "wrap", key: "items", arr: [] },
+      "/api/bridge/connections": { kind: "wrap", key: "connectors", arr: [] },
     });
     const { findByRole, container, unmount } = render(<FirstRunChecklist />);
     const dismiss = await findByRole("button", {
@@ -106,12 +128,25 @@ describe("<FirstRunChecklist/>", () => {
     expect(container.firstChild).toBeNull();
     unmount();
     const { container: c2 } = render(<FirstRunChecklist />);
-    // Even after the new mount's probes settle, the checklist stays
-    // hidden because of the persisted dismissal.
     await waitFor(() => {
-      // No assertion needed mid-await — we just want probes to fire.
       expect(global.fetch).toHaveBeenCalled();
     });
     expect(c2.firstChild).toBeNull();
+  });
+
+  it("step CTAs link to the correct pages", async () => {
+    global.fetch = makeFetch({
+      "/api/bridge/recipes": { kind: "wrap", key: "recipes", arr: [] },
+      "/api/bridge/runs": { kind: "wrap", key: "runs", arr: [] },
+      "/api/bridge/inbox": { kind: "wrap", key: "items", arr: [] },
+      "/api/bridge/connections": { kind: "wrap", key: "connectors", arr: [] },
+    });
+    const { findByText, container } = render(<FirstRunChecklist />);
+    await findByText(/Get started/);
+    // All 4 steps have CTAs since nothing is done
+    expect(container.querySelector('a[href="/marketplace"]')).not.toBeNull();
+    expect(container.querySelector('a[href="/recipes"]')).not.toBeNull();
+    expect(container.querySelector('a[href="/inbox"]')).not.toBeNull();
+    expect(container.querySelector('a[href="/connections"]')).not.toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

- Upgrades `FirstRunChecklist` to an ordered 4-step funnel (recipe → run → inbox → connect) matching the natural onboarding path; replaces the old "connect first" ordering
- First incomplete step is visually emphasised as "next" with an accent-colored ring, bold label, and `← next` badge so new users always know what to do
- Funnel auto-hides when all steps complete; dismissal persists in `localStorage`
- Empty states on `/runs` and `/inbox` gain a "Go to recipes →" / "Run a recipe →" CTA pointing back to the funnel's next action
- Rewrites the test suite with 7 cases covering: step-1-active (no data), step-2-active (recipes only), step-3-active (recipes+runs, no inbox), all-complete → hidden, no-flash on first paint, dismissal persistence, CTA hrefs

## Test plan

- [ ] All 7 unit tests pass: `npx vitest run src/components/__tests__/FirstRunChecklist.test.tsx`
- [ ] TypeScript clean for changed files: `npx tsc --noEmit` (no new errors)
- [ ] Lint clean: `npm run lint` (no new errors)
- [ ] Fresh browser session: Overview shows funnel; completing step 1 auto-advances the "next" highlight
- [ ] Dismiss button hides the funnel and survives page reload
- [ ] `/runs` empty state shows "Go to recipes →" link
- [ ] `/inbox` empty state shows "Run a recipe →" link

🤖 Generated with [Claude Code](https://claude.com/claude-code)