### PR TITLE
feat(dashboard): unify user-facing terminology across the dashboard

### DIFF
--- a/dashboard/src/app/analytics/page.tsx
+++ b/dashboard/src/app/analytics/page.tsx
@@ -144,7 +144,7 @@ export default function AnalyticsPage() {
             Analytics — <span className="accent">what your agents actually do.</span>
           </h1>
           <div className="editorial-sub">
-            tool usage · hook activity · automation history
+            tool usage · hook activity · recipe history
           </div>
           <RelationStrip
             items={[
@@ -295,7 +295,7 @@ export default function AnalyticsPage() {
                 style={{ marginTop: "var(--s-8)", marginBottom: "var(--s-4)" }}
               >
                 <div>
-                  <h2>Recent automation tasks</h2>
+                  <h2>Recent recipe tasks</h2>
                 </div>
               </div>
 

--- a/dashboard/src/app/sessions/[id]/page.tsx
+++ b/dashboard/src/app/sessions/[id]/page.tsx
@@ -447,7 +447,7 @@ export default function SessionDetailPage() {
       {decisions.length > 0 && (
         <div className="card" style={{ marginTop: "var(--s-4)" }}>
           <div className="card-head">
-            <h2>Decisions saved</h2>
+            <h2>Knowledge saved</h2>
             <span className="pill muted">{decisions.length}</span>
           </div>
           <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>


### PR DESCRIPTION
## Summary

Phase 4 (piece B) — conservative terminology sweep based on a full audit of `dashboard/src/`.

### Concept → Canonical-term inventory

| Concept | Variants found | Canonical term chosen | Action |
|---|---|---|---|
| Recipe automation concept | "automation history" (`analytics/page.tsx:147`), "Recent automation tasks" (`analytics/page.tsx:298`), vs "recipe" everywhere else | **recipe** (matches route, nav label, glossary, all other pages) | Fixed 2 strings in analytics |
| The `/decisions` knowledge-base page | "Decisions saved" (`sessions/[id]/page.tsx:450`) vs "Knowledge" (nav label, page heading, DecisionsTabs, hints) | **Knowledge** (matches nav label, route rename comment in `navRoutes.ts`) | Fixed 1 string in session detail |
| Run that stopped early | "halt/halted" (dominant), also "halts" in labels/badges/tooltips | **halt/halts** — already canonical and consistent throughout | No change needed |
| Recipe enabled/disabled toggle | "paused" (intentional, distinct from a run halting) | **paused** — correctly distinct concept | No change |
| Recipe / run / connector / connection | All used consistently matching their routes and glossary | All consistent | No change |

### What was changed

- `dashboard/src/app/analytics/page.tsx` — subtitle "automation history" → "recipe history"; heading "Recent automation tasks" → "Recent recipe tasks"
- `dashboard/src/app/sessions/[id]/page.tsx` — section heading "Decisions saved" → "Knowledge saved"

### What was deliberately left alone

- All TypeScript identifiers, route paths, query params, API field names, CSS classes (`data-*`, component names, internal state values like `status === "halted"`)
- `"paused"` for the recipe disable toggle — intentionally distinct from a run halting
- `"halt"` everywhere else — already the canonical and consistent term for a run that stopped early
- `failingCount24h` / "runs failed · 24h" on the overview — this is a **separate** metric from `haltCount24h`, not a synonym

### Verification

- `npx tsc --noEmit` — clean
- `npm run lint` — only pre-existing warnings (none from touched files)
- `npm test` — 643/643 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)