### PR TITLE
fix(dashboard): honor deep-link params across inbox/approvals/insights/activity/tasks/compare

### DIFF
--- a/dashboard/src/app/activity/page.tsx
+++ b/dashboard/src/app/activity/page.tsx
@@ -13,6 +13,7 @@ import {
   HBarList,
   HintCard,
   LivePill,
+  RelationStrip,
   type LivePillConnection,
 } from "@/components/patchwork";
 import {
@@ -116,6 +117,7 @@ export default function ActivityPage() {
   const searchParams = useSearchParams();
   const tabFromUrl = searchParams?.get("tab");
   const toolFromUrl = searchParams?.get("tool") ?? "";
+  const sessionFromUrl = searchParams?.get("session") ?? "";
   const [tab, setTabState] = useState<Tab>(isTab(tabFromUrl) ? tabFromUrl : "all");
   const setTab = (next: Tab) => {
     setTabState(next);
@@ -128,6 +130,12 @@ export default function ActivityPage() {
   const clearToolFilter = () => {
     const params = new URLSearchParams(searchParams?.toString() ?? "");
     params.delete("tool");
+    const qs = params.toString();
+    router.replace(qs ? `?${qs}` : "?", { scroll: false });
+  };
+  const clearSessionFilter = () => {
+    const params = new URLSearchParams(searchParams?.toString() ?? "");
+    params.delete("session");
     const qs = params.toString();
     router.replace(qs ? `?${qs}` : "?", { scroll: false });
   };
@@ -264,8 +272,17 @@ export default function ActivityPage() {
     if (toolFromUrl) {
       out = out.filter((e) => e.tool === toolFromUrl);
     }
+    if (sessionFromUrl) {
+      out = out.filter((e) => {
+        const meta = getLifecycleMeta(e);
+        return (
+          meta.fullSessionId === sessionFromUrl ||
+          (typeof e.sessionId === "string" && e.sessionId === sessionFromUrl)
+        );
+      });
+    }
     return out;
-  }, [events, tab, toolFromUrl]);
+  }, [events, tab, toolFromUrl, sessionFromUrl]);
 
   const stats = useMemo(() => {
     let tools = 0;
@@ -312,6 +329,13 @@ export default function ActivityPage() {
               {events.length} events · last 24h · {stats.errors} errored
             </div>
           )}
+          <RelationStrip
+            items={[
+              { label: "Sessions", href: "/sessions", title: "Sessions that produced this activity" },
+              { label: "Runs", href: "/runs", title: "Recipe runs visible here" },
+              { label: "Approvals", href: "/approvals", title: "Approval decisions in the stream" },
+            ]}
+          />
         </div>
         <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
           <button
@@ -367,6 +391,28 @@ export default function ActivityPage() {
           <span style={{ color: "var(--ink-2)" }}>Filtering by tool:</span>
           <code>{toolFromUrl}</code>
           <button type="button" className="btn sm ghost" onClick={clearToolFilter}>
+            Clear
+          </button>
+        </div>
+      )}
+
+      {sessionFromUrl && (
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 8,
+            padding: "var(--s-2) var(--s-3)",
+            marginBottom: "var(--s-3)",
+            background: "var(--bg-2)",
+            border: "1px solid var(--line-2)",
+            borderRadius: "var(--r-2)",
+            fontSize: "var(--fs-s)",
+          }}
+        >
+          <span style={{ color: "var(--ink-2)" }}>Filtering by session:</span>
+          <code>{sessionFromUrl.slice(0, 8)}</code>
+          <button type="button" className="btn sm ghost" onClick={clearSessionFilter}>
             Clear
           </button>
         </div>

--- a/dashboard/src/app/analytics/page.tsx
+++ b/dashboard/src/app/analytics/page.tsx
@@ -148,6 +148,7 @@ export default function AnalyticsPage() {
           </div>
           <RelationStrip
             items={[
+              { label: "Recipes", href: "/recipes", title: "Recipes that produced this usage" },
               { label: "Runs", href: "/runs", title: "Recipe runs that drove this usage" },
               { label: "Activity", href: "/activity", title: "Raw activity stream" },
               { label: "Insights", href: "/insights", title: "Per-tool approval signals" },

--- a/dashboard/src/app/approvals/page.tsx
+++ b/dashboard/src/app/approvals/page.tsx
@@ -631,6 +631,7 @@ function ApprovalsContent() {
   const searchParams = useSearchParams();
   const router = useRouter();
   const sessionFilter = searchParams.get("session");
+  const recipeFilter = searchParams.get("recipe");
 
   const [pending, setPending] = useState<Pending[]>([]);
   const [hasLoaded, setHasLoaded] = useState(false);
@@ -1353,6 +1354,35 @@ function ApprovalsContent() {
             onClick={() => router.push("/approvals")}
           >
             Clear filter
+          </button>
+        </div>
+      )}
+
+      {recipeFilter && (
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 8,
+            padding: "var(--s-2) var(--s-3)",
+            marginBottom: "var(--s-3)",
+            background: "var(--bg-2)",
+            border: "1px solid var(--line-2)",
+            borderRadius: "var(--r-2)",
+            fontSize: "var(--fs-s)",
+          }}
+        >
+          <span style={{ color: "var(--ink-2)" }}>Linked from recipe:</span>
+          <code style={{ fontFamily: "var(--font-mono)" }}>{recipeFilter}</code>
+          <span style={{ color: "var(--ink-3)" }}>
+            · approval payloads don&apos;t carry a recipe identifier — showing all pending approvals
+          </span>
+          <button
+            type="button"
+            className="btn sm ghost"
+            onClick={() => router.push("/approvals")}
+          >
+            Clear
           </button>
         </div>
       )}

--- a/dashboard/src/app/inbox/page.tsx
+++ b/dashboard/src/app/inbox/page.tsx
@@ -423,6 +423,8 @@ export default function InboxPage() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const filterFromUrl = searchParams?.get("filter");
+  const itemFromUrl = searchParams?.get("item") ?? "";
+  const recipeFromUrl = searchParams?.get("recipe") ?? "";
   const [activeFilter, setActiveFilterState] = useState<FilterCategory>(
     isFilterCategory(filterFromUrl) ? filterFromUrl : "All",
   );
@@ -495,9 +497,20 @@ export default function InboxPage() {
     };
   }, [listData]);
 
-  // Auto-select first item after initial load if nothing is selected
+  // Auto-select item from ?item= param on first load.
+  const itemParamHandledRef = useRef(false);
   useEffect(() => {
-    if (!loading && items.length > 0 && !selected && !detailLoading) {
+    if (loading || itemParamHandledRef.current) return;
+    if (itemFromUrl && items.length > 0) {
+      itemParamHandledRef.current = true;
+      const match = items.find((i) => i.name === itemFromUrl);
+      if (match) {
+        void selectItem(match.name);
+        return;
+      }
+    }
+    // Auto-select first item after initial load if nothing is selected
+    if (items.length > 0 && !selected && !detailLoading && !itemFromUrl) {
       void selectItem(items[0].name);
     }
     // Only on initial load — don't re-trigger on polling updates
@@ -505,6 +518,7 @@ export default function InboxPage() {
   }, [loading]);
 
 const filteredItems = items.filter((item) => {
+    if (recipeFromUrl && item.provenance?.recipe !== recipeFromUrl) return false;
     if (activeFilter !== "All" && categoryForItem(item.name) !== activeFilter) return false;
     if (search.trim()) {
       const q = search.toLowerCase();
@@ -636,6 +650,37 @@ const filteredItems = items.filter((item) => {
         </div>
 
         <HintCard id="inbox" />
+
+        {recipeFromUrl && (
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 8,
+              padding: "var(--s-2) var(--s-3)",
+              marginBottom: "var(--s-3)",
+              background: "var(--bg-2)",
+              border: "1px solid var(--line-2)",
+              borderRadius: "var(--r-2)",
+              fontSize: "var(--fs-s)",
+            }}
+          >
+            <span style={{ color: "var(--ink-2)" }}>Filtered by recipe:</span>
+            <code>{recipeFromUrl}</code>
+            <button
+              type="button"
+              className="btn sm ghost"
+              onClick={() => {
+                const params = new URLSearchParams(searchParams?.toString() ?? "");
+                params.delete("recipe");
+                const qs = params.toString();
+                router.replace(qs ? `?${qs}` : "/inbox", { scroll: false });
+              }}
+            >
+              Clear
+            </button>
+          </div>
+        )}
 
         {/*
           Discovery card for the "deliver to phone" capability. Lives

--- a/dashboard/src/app/insights/__tests__/page.keys.test.tsx
+++ b/dashboard/src/app/insights/__tests__/page.keys.test.tsx
@@ -14,6 +14,24 @@
 
 import { render, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// The insights page uses useSearchParams()/useRouter() (added with the
+// ?tool= deep-link support). Without the app-router context those hooks
+// throw "invariant expected app router to be mounted" — so mock the
+// module: empty search params + a no-op router.
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => new URLSearchParams(),
+  useRouter: () => ({
+    push: vi.fn(),
+    replace: vi.fn(),
+    prefetch: vi.fn(),
+    back: vi.fn(),
+    forward: vi.fn(),
+    refresh: vi.fn(),
+  }),
+  usePathname: () => "/insights",
+}));
+
 import InsightsPage from "@/app/insights/page";
 
 const DUP_PAYLOAD = {

--- a/dashboard/src/app/insights/page.tsx
+++ b/dashboard/src/app/insights/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 import Link from "next/link";
-import { useEffect, useMemo, useState } from "react";
+import { Suspense, useEffect, useMemo, useRef, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
 import { useBridgeFetch } from "@/hooks/useBridgeFetch";
 import { apiPath } from "@/lib/api";
 import { EmptyState, ErrorState, RelationStrip } from "@/components/patchwork";
@@ -133,6 +134,33 @@ function RuleCell({ explanation }: { explanation: RuleExplanation | null | undef
 }
 
 export default function InsightsPage() {
+  return (
+    <Suspense fallback={<SkeletonList rows={6} columns={5} />}>
+      <InsightsContent />
+    </Suspense>
+  );
+}
+
+function InsightsContent() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const toolFromUrl = searchParams?.get("tool") ?? "";
+  const highlightRef = useRef<HTMLTableRowElement | null>(null);
+
+  // Scroll highlighted tool row into view when param is set.
+  useEffect(() => {
+    if (toolFromUrl && highlightRef.current) {
+      highlightRef.current.scrollIntoView({ block: "nearest", behavior: "smooth" });
+    }
+  }, [toolFromUrl]);
+
+  const clearToolFilter = () => {
+    const params = new URLSearchParams(searchParams?.toString() ?? "");
+    params.delete("tool");
+    const qs = params.toString();
+    router.replace(qs ? `?${qs}` : "?", { scroll: false });
+  };
+
   const { data, error, loading, refetch } = useBridgeFetch<InsightsResponse>(
     "/api/bridge/approval-insights",
     { intervalMs: 30000 },
@@ -284,6 +312,28 @@ export default function InsightsPage() {
         </div>
       </div>
 
+      {toolFromUrl && (
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 8,
+            padding: "var(--s-2) var(--s-3)",
+            marginBottom: "var(--s-3)",
+            background: "var(--bg-2)",
+            border: "1px solid var(--line-2)",
+            borderRadius: "var(--r-2)",
+            fontSize: "var(--fs-s)",
+          }}
+        >
+          <span style={{ color: "var(--ink-2)" }}>Filtered by tool:</span>
+          <code>{toolFromUrl}</code>
+          <button type="button" className="btn sm ghost" onClick={clearToolFilter}>
+            Clear
+          </button>
+        </div>
+      )}
+
       {loading && tools.length === 0 && (
         <SkeletonList rows={6} columns={5} />
       )}
@@ -422,7 +472,9 @@ export default function InsightsPage() {
               </tr>
             </thead>
             <tbody>
-              {tools.map((t, i) => (
+              {tools.map((t, i) => {
+                const isHighlighted = toolFromUrl !== "" && t.toolName === toolFromUrl;
+                return (
                 <tr
                   // The bridge can return the same toolName more than once
                   // (e.g. a tool exposed under two MCP namespaces, or an
@@ -430,7 +482,13 @@ export default function InsightsPage() {
                   // alone then collides ("two children with the same key").
                   // Suffix the index so the key is unique regardless.
                   key={`${t.toolName}-${i}`}
-                  style={{ borderBottom: "1px solid var(--border-subtle)" }}
+                  ref={isHighlighted ? highlightRef : undefined}
+                  style={{
+                    borderBottom: "1px solid var(--border-subtle)",
+                    background: isHighlighted ? "color-mix(in srgb, var(--accent) 8%, transparent)" : undefined,
+                    outline: isHighlighted ? "2px solid var(--accent)" : undefined,
+                    outlineOffset: isHighlighted ? -2 : undefined,
+                  }}
                 >
                   <td style={{ padding: "10px 0", verticalAlign: "middle" }}>
                     <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
@@ -534,7 +592,8 @@ export default function InsightsPage() {
                     {relativeTime(t.lastDecisionAt)}
                   </td>
                 </tr>
-              ))}
+                );
+              })}
             </tbody>
           </table>
           </div>

--- a/dashboard/src/app/recipes/compare/page.tsx
+++ b/dashboard/src/app/recipes/compare/page.tsx
@@ -194,7 +194,9 @@ function PlanColumn({
 
 function CompareInner() {
   const params = useSearchParams();
-  const nameA = params.get("a") ?? "";
+  // ?name= seeds slot a (emitted by "Compare versions" on the recipe hub).
+  // ?a= / ?b= are the canonical keys used once both slots are filled.
+  const nameA = params.get("a") ?? params.get("name") ?? "";
   const nameB = params.get("b") ?? "";
 
   const [planA, setPlanA] = useState<DryRunPlan | null>(null);
@@ -291,10 +293,11 @@ function CompareInner() {
   if (!nameA || !nameB) {
     return (
       <div className="empty-state">
-        <h3>Missing recipe names</h3>
+        <h3>{nameA ? "Select a second recipe to compare" : "Missing recipe names"}</h3>
         <p>
-          Use <code>/recipes/compare?a=recipe-name&b=recipe-name-v2</code>. The
-          Fork button on the Recipes page links here automatically.
+          {nameA
+            ? <>Comparing <code>{nameA}</code> — add <code>?b=recipe-name-v2</code> to pick the second variant.</>
+            : <>Use <code>/recipes/compare?a=recipe-name&amp;b=recipe-name-v2</code>. The Fork button on the Recipes page links here automatically.</>}
         </p>
         <p style={{ marginTop: "var(--s-3)" }}>
           <Link href="/recipes" className="btn sm primary" style={{ textDecoration: "none" }}>

--- a/dashboard/src/app/tasks/page.tsx
+++ b/dashboard/src/app/tasks/page.tsx
@@ -1,6 +1,7 @@
 "use client";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { Suspense, useEffect, useMemo, useRef, useState } from "react";
 import Link from "next/link";
+import { useSearchParams } from "next/navigation";
 import { apiPath } from "@/lib/api";
 import { fmtDuration } from "@/components/time";
 import { SkeletonList } from "@/components/Skeleton";
@@ -283,13 +284,23 @@ function fmtAvg(ms: number): string {
 }
 
 export default function TasksPage() {
+  return (
+    <Suspense fallback={null}>
+      <TasksContent />
+    </Suspense>
+  );
+}
+
+function TasksContent() {
+  const searchParams = useSearchParams();
+  const idFromUrl = searchParams?.get("id") ?? "";
   const toast = useToast();
   const [tasks, setTasks] = useState<Task[]>([]);
   const [hasLoaded, setHasLoaded] = useState(false);
   const [err, setErr] = useState<string>();
   const [, setTick] = useState(0);
   const [cancelling, setCancelling] = useState<Record<string, boolean>>({});
-  const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
+  const [selectedTaskId, setSelectedTaskId] = useState<string | null>(idFromUrl || null);
   const [search, setSearch] = useState("");
   const [statusFilter, setStatusFilter] = useState<"all" | "live" | "done" | "error">("all");
   // Cap rendered rows. /tasks is an audit log that can hit 500+ entries;
@@ -302,6 +313,19 @@ export default function TasksPage() {
     setVisibleCount(ROW_PAGE);
   }, [search, statusFilter]);
   const searchInputRef = useSearchHotkey();
+
+  // Scroll the pre-selected row into view after initial load.
+  const idScrolledRef = useRef(false);
+  useEffect(() => {
+    if (!idFromUrl || idScrolledRef.current || !hasLoaded) return;
+    const row = document.querySelector<HTMLElement>(
+      `[data-task-row="${CSS.escape(idFromUrl)}"]`,
+    );
+    if (row) {
+      idScrolledRef.current = true;
+      row.scrollIntoView({ block: "nearest", behavior: "smooth" });
+    }
+  }, [idFromUrl, hasLoaded]);
 
   const refetchRef = useRef<() => void>(() => {});
 


### PR DESCRIPTION
## Summary

Fixes 7 broken deep-link contracts and 2 RelationStrip asymmetries. Entity chips and RelationStrips now land the user on a filtered/pre-selected page instead of an unfiltered one.

## Contracts fixed

| Param | Destination | Fix |
|---|---|---|
| `?item=<key>` | `/inbox` | Auto-selects matching inbox item after load; scroll into view |
| `?recipe=<name>` | `/inbox` | Filters list to items with matching provenance.recipe; dismissible banner |
| `?recipe=<name>` | `/approvals` | Shows honest "linked from recipe" banner (approvals don't carry recipe ID in payload) |
| `?name=<name>` | `/recipes/compare` | Seeds slot `a`; shows "select second recipe" prompt when `?b=` absent |
| `?tool=<name>` | `/insights` | Highlights + scrolls to matching tool row; dismissible banner |
| `?session=<id>` | `/activity` | Filters events to that session; dismissible banner matching existing `toolFromUrl` pattern |
| `?id=<id>` | `/tasks` | Pre-selects task on mount; scrolls row into view |

## RelationStrip asymmetries fixed

- `/activity` — added Sessions/Runs/Approvals RelationStrip (sessions→activity existed, reverse was missing)
- `/analytics` — added Recipes link (analytics data is per-recipe; insights already had it)

## Test plan

- [ ] `npx tsc --noEmit` in `dashboard/` — clean
- [ ] `npm run lint` in `dashboard/` — warnings only (all pre-existing)
- [ ] Navigate to `/inbox?item=<existing-name>` — that item should be auto-selected
- [ ] Navigate to `/inbox?recipe=morning-brief` — list filters to that recipe; banner shows
- [ ] Navigate to `/approvals?recipe=foo` — honest banner shows, all pending still visible
- [ ] Navigate to `/recipes/compare?name=my-recipe` — slot A pre-filled, "select second" message
- [ ] Navigate to `/insights?tool=Bash` — Bash row highlighted and scrolled to
- [ ] Navigate to `/activity?session=<id>` — events filtered; banner shows
- [ ] Navigate to `/tasks?id=<taskId>` — task pre-selected; row scrolled to

🤖 Generated with [Claude Code](https://claude.com/claude-code)