### PR TITLE
fix(dashboard): close real-time-feedback and navigation gaps

### DIFF
--- a/dashboard/src/app/connections/page.tsx
+++ b/dashboard/src/app/connections/page.tsx
@@ -955,6 +955,12 @@ export default function ConnectionsPage() {
   useEffect(() => {
     fetchConnectors();
 
+    // Background poll every 30s so expired/degraded OAuth tokens show
+    // an up-to-date badge instead of a stale "Connected" forever.
+    const pollId = setInterval(() => {
+      void fetchConnectors();
+    }, 30_000);
+
     // Fetch installed recipes and derive connector→recipe count map.
     // Tool-prefix heuristic mirrors the Recipes page detectConnectors fn.
     const TOOL_KEYWORD_TO_CONNECTOR_ID: Record<string, string> = {
@@ -1000,6 +1006,10 @@ export default function ConnectionsPage() {
         setConnectorRecipeCounts(counts);
       })
       .catch(() => {});
+
+    return () => {
+      clearInterval(pollId);
+    };
   }, []);
 
   function getConnector(id: string): ConnectorStatus {

--- a/dashboard/src/app/marketplace/page.tsx
+++ b/dashboard/src/app/marketplace/page.tsx
@@ -587,6 +587,16 @@ export default function MarketplacePage() {
     }
 
     load().catch((e) => setLoadErr(e instanceof Error ? e.message : String(e)));
+
+    // Refresh the installed set every 30s so recipes installed via CLI or
+    // another tab show the "Installed" badge without a manual reload.
+    const pollId = setInterval(() => {
+      void refreshInstalled();
+    }, 30_000);
+
+    return () => clearInterval(pollId);
+  // refreshInstalled is stable (useCallback with no deps)
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   async function handleInstall(recipe: RegistryRecipe) {

--- a/dashboard/src/app/recipes/[name]/edit/page.tsx
+++ b/dashboard/src/app/recipes/[name]/edit/page.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { use, useEffect, useRef, useState } from "react";
 import { apiPath } from "@/lib/api";
-import { BackLink, RelationStrip } from "@/components/patchwork";
+// BackLink and RelationStrip are rendered by the shared recipes/[name]/layout.tsx
 import { useToast } from "@/components/Toast";
 import dynamic from "next/dynamic";
 
@@ -308,66 +308,10 @@ export default function RecipeEditPage({
 
   return (
     <section>
-      {/* Header */}
-      <div className="page-head">
-        <div>
-          <BackLink href="/recipes" label="Recipes" />
-          <h1 style={{ marginTop: 0 }}>
-            Edit{" "}
-            <code
-              style={{
-                fontFamily: "var(--font-mono)",
-                fontSize: "0.85em",
-                background: "var(--bg-2)",
-                padding: "2px 8px",
-                borderRadius: "var(--r-1)",
-              }}
-            >
-              {name}
-            </code>
-          </h1>
-          <div className="page-head-sub">Edit recipe YAML and save or run.</div>
-          {/*
-            "Feels connected" strip for the recipe detail. Lets users
-            jump from editing the YAML straight to: the runs this
-            recipe has produced (filtered by name), the live activity
-            stream (where its events show up in real time), and the
-            marketplace (to see published variants). Each chip is a
-            link to a filtered list — the recipe detail used to dead-
-            end into the editor with no outbound context.
-          */}
-          <RelationStrip
-            items={[
-              {
-                label: "Recent runs",
-                href: `/runs?recipe=${encodeURIComponent(name)}`,
-                title: `Recent runs of ${name}`,
-              },
-              {
-                label: "Halts",
-                href: `/runs?recipe=${encodeURIComponent(name)}&halt=1`,
-                tone: "warn",
-                title: `Runs of ${name} that hit a halt reason`,
-              },
-              {
-                label: "Traces",
-                href: `/traces?recipe=${encodeURIComponent(name)}`,
-                title: `Decision logs for ${name}`,
-              },
-              {
-                label: "Live activity",
-                href: "/activity",
-                title: "Stream of every event from this and other recipes",
-              },
-              {
-                label: "Marketplace",
-                href: "/marketplace",
-                title: "Community-published recipes",
-              },
-            ]}
-          />
-        </div>
-        <div style={{ display: "flex", gap: "var(--s-3)", alignItems: "center" }}>
+      {/* The layout at recipes/[name]/layout.tsx already renders
+          breadcrumb, H1, StatusPill, RelationStrip, and TabBar.
+          Only edit-specific actions live here. */}
+      <div style={{ display: "flex", gap: "var(--s-3)", alignItems: "center", marginBottom: "var(--s-4)" }}>
           <Link
             href={`/recipes/${encodeURIComponent(name)}/plan`}
             className="btn"
@@ -392,7 +336,6 @@ export default function RecipeEditPage({
           >
             {saving ? "Saving…" : dirty ? "Save •" : "Save"}
           </button>
-        </div>
       </div>
 
       {/* Recipe-not-found banner — fires when /api/bridge/recipes/:name 404'd

--- a/dashboard/src/app/recipes/page.tsx
+++ b/dashboard/src/app/recipes/page.tsx
@@ -717,9 +717,10 @@ export default function RecipesPage() {
   const [err, setErr] = useState<string>();
   const [unsupported, setUnsupported] = useState(false);
   const [running, setRunning] = useState<Record<string, string>>({});
-  // Initial selection read from ?selected=<name> on first render, then
-  // kept in sync via replaceState so refresh / share-link works without
-  // bloating history.
+  // ?selected=<name> deep-link (e.g. from suggestions/page.tsx) — redirect
+  // immediately to the hub so keyboard and mouse behave identically.
+  // We keep the state initialiser below reading the param so the redirect
+  // useEffect fires once after mount (when router is available).
   const [selectedName, setSelectedName] = useState<string | null>(() => {
     if (typeof window === "undefined") return null;
     const sp = new URLSearchParams(window.location.search);
@@ -777,6 +778,19 @@ export default function RecipesPage() {
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
   }, [selectedName, modal]);
+  // ?selected=<name> deep-link redirect: navigate to hub so the user
+  // always lands on the full recipe hub page regardless of entry point.
+  // This keeps links from suggestions/page.tsx working while ensuring
+  // keyboard and mouse navigation are identical (both go to the hub).
+  useEffect(() => {
+    if (!selectedName) return;
+    router.replace(
+      `/recipes/${encodeURIComponent(canonicalRecipeKey(selectedName))}`,
+    );
+  // Run once on mount (when selectedName comes from ?selected= param).
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   const deepLinkConsumedRef = useRef(false);
 
   // Mirror selectedName → URL `?selected=<name>` via replaceState so the
@@ -928,21 +942,31 @@ export default function RecipesPage() {
           body: JSON.stringify(body),
         },
       );
-      const data = (await res.json()) as { ok: boolean; taskId?: string; error?: string };
+      const data = (await res.json()) as { ok: boolean; taskId?: string; seq?: number; error?: string };
       if (data.ok && data.taskId) {
         setRunning((p) => ({ ...p, [name]: `queued ${data.taskId?.slice(0, 8)}` }));
+        const runsHref = data.seq != null
+          ? `/runs/${data.seq}`
+          : `/runs?recipe=${encodeURIComponent(name)}`;
+        toast.success("Run started", {
+          action: { label: "View run", onClick: () => router.push(runsHref) },
+        });
+        void load();
       } else {
         const errMsg =
           data.error === "already_in_flight"
             ? "Already running"
             : `error: ${data.error ?? "unknown"}`;
         setRunning((p) => ({ ...p, [name]: errMsg }));
+        toast.error(`Run failed: ${data.error ?? "unknown"}`);
       }
     } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
       setRunning((p) => ({
         ...p,
-        [name]: `error: ${e instanceof Error ? e.message : String(e)}`,
+        [name]: `error: ${msg}`,
       }));
+      toast.error(`Run failed: ${msg}`);
     }
   }
 
@@ -1161,23 +1185,27 @@ export default function RecipesPage() {
             ? 0
             : filteredRecipes.length - 1
           : (idx + delta + filteredRecipes.length) % filteredRecipes.length;
-      const nextName = filteredRecipes[next].name;
-      setSelectedName(nextName);
-      // Scroll the newly-selected row into view (centered) so j/k feels
-      // like a cursor walk rather than a silent state change off-screen.
+      const nextRecipe = filteredRecipes[next];
+      const nextName = nextRecipe.name;
+      // Scroll the newly-focused row into view and move DOM focus so j/k
+      // feels like a cursor walk rather than a silent state change off-screen.
       requestAnimationFrame(() => {
         const row = document.querySelector<HTMLElement>(
           `[data-recipe-row="${CSS.escape(nextName)}"]`,
         );
         row?.scrollIntoView({ block: "nearest", behavior: "smooth" });
-        // Move real DOM focus so keyboard + screen-reader users get
-        // feedback from j/k, not just a visual selection change.
         row?.focus();
       });
+      // If Enter is pressed after j/k movement the row's onKeyDown handler
+      // calls router.push — same as a click. We no longer open the inline
+      // RecipeDetailPanel from j/k; both input methods navigate to the hub.
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [filteredRecipes, selectedName, modal]);
+  // selectedName intentionally removed from deps — j/k no longer drives
+  // the side panel; it only moves DOM focus so the row can handle Enter.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [filteredRecipes, modal]);
 
   return (
     <section>

--- a/dashboard/src/app/transactions/page.tsx
+++ b/dashboard/src/app/transactions/page.tsx
@@ -3,6 +3,7 @@ import { useEffect, useMemo, useState } from "react";
 import { apiPath } from "@/lib/api";
 import { useBridgeFetch } from "@/hooks/useBridgeFetch";
 import { SkeletonList } from "@/components/Skeleton";
+import { useToast } from "@/components/Toast";
 import { EmptyState, ErrorState, HintCard, RelationStrip } from "@/components/patchwork";
 
 interface TransactionEdit {
@@ -97,12 +98,13 @@ function formatBytes(n: number): string {
 }
 
 export default function TransactionsPage() {
-  const { data, error, loading } = useBridgeFetch<TransactionsResponse>(
+  const { data, error, loading, refetch } = useBridgeFetch<TransactionsResponse>(
     "/api/bridge/transactions",
     { intervalMs: 3000 },
   );
   const [busy, setBusy] = useState<Record<string, "rolling-back" | string>>({});
   const transactions = data?.transactions ?? [];
+  const toast = useToast();
 
   async function rollback(id: string) {
     setBusy((p) => ({ ...p, [id]: "rolling-back" }));
@@ -111,15 +113,19 @@ export default function TransactionsPage() {
         method: "POST",
       });
       const body = (await res.json().catch(() => ({}))) as { ok?: boolean; error?: string };
-      setBusy((p) => ({
-        ...p,
-        [id]: res.ok && body.ok !== false ? "discarded" : `error: ${body.error ?? res.status}`,
-      }));
+      if (res.ok && body.ok !== false) {
+        setBusy((p) => ({ ...p, [id]: "discarded" }));
+        toast.success("Transaction discarded");
+        refetch();
+      } else {
+        const errMsg = body.error ?? String(res.status);
+        setBusy((p) => ({ ...p, [id]: `error: ${errMsg}` }));
+        toast.error(`Discard failed: ${errMsg}`);
+      }
     } catch (e) {
-      setBusy((p) => ({
-        ...p,
-        [id]: `error: ${e instanceof Error ? e.message : String(e)}`,
-      }));
+      const msg = e instanceof Error ? e.message : String(e);
+      setBusy((p) => ({ ...p, [id]: `error: ${msg}` }));
+      toast.error(`Discard failed: ${msg}`);
     }
   }
 


### PR DESCRIPTION
## Summary

- **Fix 1 — Recipe LIST run trigger**: `executeRun()` now calls `toast.success("Run started", { action: { label: "View run", onClick } })` linking to `/runs/<seq>` (or `/runs?recipe=<name>` if no seq), calls `void load()` for immediate sparkbar refresh, and shows `toast.error(...)` on failure.
- **Fix 2 — Keyboard/mouse navigation parity**: j/k navigation now moves DOM focus to the recipe row (not `setSelectedName`). Since the row's `onKeyDown` already calls `router.push` on Enter (same as click), both input methods now go to the hub. Decision: `?selected=<name>` deep-links (from `suggestions/page.tsx`) redirect immediately to the hub via a mount-time `useEffect` — keeps the inbound links working without opening the divergent inline panel. The `RecipeDetailPanel` remains for now but is no longer reachable via keyboard j/k.
- **Fix 3 — Recipe EDIT duplicate header**: Removed the edit page's duplicate `<div class="page-head">` containing `<BackLink>`, `<h1>Edit {name}</h1>`, and `<RelationStrip>`. The shared `recipes/[name]/layout.tsx` already renders all of those. Removed unused `BackLink` and `RelationStrip` imports.
- **Fix 4 — /connections background polling**: Added `setInterval(fetchConnectors, 30_000)` inside the mount `useEffect`, cleared on unmount, so expired/degraded OAuth tokens show updated badge status without a manual reload.
- **Fix 5 — /transactions discard toast + refetch**: `rollback()` now calls `toast.success("Transaction discarded")` / `toast.error(...)` and `refetch()` on success to re-sync the list. Added `useToast` import.
- **Fix 6 — /marketplace installedNames poll**: Added `setInterval(refreshInstalled, 30_000)` (cleared on unmount) in the load `useEffect` so recipes installed via CLI or another tab surface the "Installed" badge within 30s.

## Test plan

- [ ] Trigger a recipe run from `/recipes` list — confirm toast appears with "View run" action link
- [ ] Use j/k then Enter on `/recipes` — confirm navigation goes to hub (same as mouse click)
- [ ] Navigate to `/recipes?selected=morning-brief` — confirm redirect to hub page
- [ ] Open `/recipes/<name>/edit` — confirm single H1 (no duplicate heading)
- [ ] Open `/connections`, revoke an OAuth token externally, wait 30s — confirm badge updates
- [ ] Discard a transaction on `/transactions` — confirm toast and list refresh
- [ ] Install a recipe via CLI, open `/marketplace` within 30s — confirm "Installed" badge appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)