### PR TITLE
fix(oauth): correct RFC 9396 → 9728 citation for protected-resource endpoint

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -78,7 +78,7 @@ Two independent WebSocket connections run simultaneously. The **Claude Code ↔ 
 
 | File | Purpose |
 |---|---|
-| `src/oauth.ts` | `OAuthServerImpl`: RFC 8414/7591/9396 endpoints; PKCE S256; 24h opaque access tokens; timing-safe comparisons |
+| `src/oauth.ts` | `OAuthServerImpl`: RFC 8414/7591/9728 endpoints; PKCE S256; 24h opaque access tokens; timing-safe comparisons |
 | `src/probe.ts` | `probeAll()`: detects available CLI tools (ctags, typescript-language-server, rg, git, gh); results drive `getToolCapabilities` |
 | `src/activityLog.ts` | Bounded ring buffer (500 entries); percentiles; co-occurrence; JSONL persistence |
 | `src/errors.ts` | `ErrorCodes` (JSON-RPC -32xxx) and `ToolErrorCodes` (string codes for `isError: true` content) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -265,7 +265,7 @@ Full reference: [documents/plugin-authoring.md](documents/plugin-authoring.md)
 For remote deployments where claude.ai custom connectors need authenticated access.
 
 - **Activation**: `--issuer-url <public-https-url>` activates OAuth 2.0. `--cors-origin <origin>` (repeatable) sets `Access-Control-Allow-Origin` on all responses.
-- **Endpoints**: `/.well-known/oauth-authorization-server` (RFC 8414), `/.well-known/oauth-protected-resource` (RFC 9396), `/oauth/register` (RFC 7591 dynamic client registration), `/oauth/authorize` (approval page), `/oauth/token`, `/oauth/revoke` (RFC 7009).
+- **Endpoints**: `/.well-known/oauth-authorization-server` (RFC 8414), `/.well-known/oauth-protected-resource` (RFC 9728), `/oauth/register` (RFC 7591 dynamic client registration), `/oauth/authorize` (approval page), `/oauth/token`, `/oauth/revoke` (RFC 7009).
 - **Design**: PKCE S256 mandatory. Auth codes single-use, 5-min TTL. Access tokens opaque base64url, 24-hour TTL. No refresh tokens — clients connecting TO the bridge re-authorize on expiry. Note: connector tokens (bridge connecting OUT to external services) DO use refresh tokens and auto-refresh on 401 via `baseConnector.refreshToken()`.
 - **CIMD**: if `client_id` is an `https://` URL, bridge fetches the Client ID Metadata Document (RFC draft) to discover `redirect_uris`; 5-min cache, 8 KB max, SSRF-guarded.
 - **Bridge token**: resource owner credential. Entered in `/oauth/authorize` approval page. All string comparisons timing-safe.

--- a/docs/protocol-spec.md
+++ b/docs/protocol-spec.md
@@ -502,7 +502,7 @@ When the bridge is started with `--issuer-url <public-https-url>`, it activates 
 | Path | Standard |
 |---|---|
 | `GET /.well-known/oauth-authorization-server` | RFC 8414 discovery |
-| `GET /.well-known/oauth-protected-resource` | RFC 9396 resource metadata |
+| `GET /.well-known/oauth-protected-resource` | RFC 9728 resource metadata |
 | `POST /oauth/register` | RFC 7591 dynamic client registration |
 | `GET /oauth/authorize` | Authorization code flow (PKCE S256 required) |
 | `POST /oauth/token` | Token exchange |

--- a/docs/remote-access.md
+++ b/docs/remote-access.md
@@ -143,7 +143,7 @@ claude-ide-bridge \
 | Endpoint | Purpose |
 |---|---|
 | `/.well-known/oauth-authorization-server` | RFC 8414 server metadata discovery |
-| `/.well-known/oauth-protected-resource` | RFC 9396 protected resource metadata |
+| `/.well-known/oauth-protected-resource` | RFC 9728 protected resource metadata |
 | `/oauth/register` | Dynamic client registration (RFC 7591) |
 | `/oauth/authorize` | Authorization approval page — enter bridge token here |
 | `/oauth/token` | Token exchange |

--- a/documents/platform-docs.md
+++ b/documents/platform-docs.md
@@ -916,7 +916,7 @@ Once `--issuer-url` is set the bridge activates its full OAuth 2.0 server:
 | Endpoint | RFC | Purpose |
 |---|---|---|
 | `/.well-known/oauth-authorization-server` | RFC 8414 | Metadata discovery |
-| `/.well-known/oauth-protected-resource` | RFC 9396 | Resource server metadata |
+| `/.well-known/oauth-protected-resource` | RFC 9728 | Resource server metadata |
 | `/oauth/register` | RFC 7591 | Dynamic client registration |
 | `/oauth/authorize` | RFC 6749 | Authorization code grant (PKCE S256 mandatory) |
 | `/oauth/token` | RFC 6749 | Token exchange |

--- a/documents/roadmap.md
+++ b/documents/roadmap.md
@@ -417,7 +417,7 @@ FileLock `tryAcquire` (non-blocking); `watchActivityLog` + `contextBundle` slim-
 **v2.4.10 shipped (2026-03-19) — Full OAuth 2.0 for claude.ai custom connectors:**
 - `--issuer-url <url>` flag: activates OAuth 2.0 mode; sets issuer in all discovery documents
 - `--cors-origin <url>` flag (repeatable): adds `Access-Control-Allow-Origin` for specific origin on ALL responses (including 401s); env var `CLAUDE_IDE_BRIDGE_CORS_ORIGINS` (comma-separated)
-- RFC 9396 `/.well-known/oauth-protected-resource` endpoint (claude.ai probes this before OAuth)
+- RFC 9728 `/.well-known/oauth-protected-resource` endpoint (claude.ai probes this before OAuth)
 - RFC 7591 `POST /oauth/register` dynamic client registration (claude.ai registers client_id before PKCE)
 - Approval page: bridge token entered in browser at `/oauth/authorize` (no more `?token=` URL)
 - POST `/oauth/authorize` route fixed (was GET-only; form submission fell through to 401)

--- a/src/oauthRoutes.ts
+++ b/src/oauthRoutes.ts
@@ -1,7 +1,7 @@
 /**
  * OAuth 2.0 route dispatcher — extracted from src/server.ts.
  *
- * Owns the public OAuth endpoints (RFC 8414 discovery, RFC 9396 protected-
+ * Owns the public OAuth endpoints (RFC 8414 discovery, RFC 9728 protected-
  * resource metadata, RFC 7591 dynamic client registration, authorize,
  * token, RFC 7009 revoke). All routes are unauthenticated — they MUST
  * run before the bearer-auth gate.
@@ -53,7 +53,7 @@ export function tryHandleOAuthRoute(
     return true;
   }
 
-  // RFC 9396 Protected Resource Metadata — Claude.ai probes this to discover
+  // RFC 9728 Protected Resource Metadata — Claude.ai probes this to discover
   // which authorization server protects this resource. Both the bare and
   // resource-path variants are handled.
   if (


### PR DESCRIPTION
## Summary

`/.well-known/oauth-protected-resource` was cited as **RFC 9396** in 8 places. RFC 9396 is OAuth *Rich Authorization Requests* — unrelated. The protected-resource metadata endpoint is **RFC 9728** (OAuth 2.0 Protected Resource Metadata).

Pure citation correction — 7 tracked files (1 code comment block in `src/oauthRoutes.ts`, plus `ARCHITECTURE.md`, `CLAUDE.md`, `docs/remote-access.md`, `docs/protocol-spec.md`, `documents/platform-docs.md`, `documents/roadmap.md`). The endpoint implementation is **already RFC 9728-compliant** (returns `resource` + `authorization_servers`) — no behavior change.

## Provenance

Surfaced by a three-layer multi-agent review of the 2026-05-20 `improvement-research` report (proposal #5). Of that report's 8 ranked proposals, independent verification found:

- **#1** (deterministic agent_silent_fail gate) — **already done**: `detectSilentFail` is wired at both runner sites, and empty/whitespace agent output is already caught at `yamlRunner.ts:1092` (`agent_narration_only` halt). Nothing to ship.
- **#5** (this PR) — real, trivial.
- **#3** (MCP Tasks), **#7b** (snippet-edit guard in `vscode-extension/src/handlers/lsp.ts`), **#6** (AJV → JSON Schema 2020-12 dialect), **#8** (Elicitation observe-only hooks) — real but larger / riskier; deferred to their own PRs.
- **#2** (`recipe_no_workspace`) — already built on branch `fix/recipe-workspace-root`; needs recovery, not rebuild.
- **#4** (403 on invalid Origin) — rejected: WS already 403s bad Origin; HTTP path uses Host-header DNS-rebinding defense by design.

## Test plan

- [x] `src/__tests__/oauth*` — 68 tests pass (no behavior change)
- [x] Biome clean
- [x] `grep -rn 9396` — zero remaining references repo-wide

🤖 Generated with [Claude Code](https://claude.com/claude-code)