### PR TITLE
fix(recipes): resolve workspace root before spawning agent steps

### DIFF
--- a/src/recipes/__tests__/defaultClaudeCodeFn.cwd.test.ts
+++ b/src/recipes/__tests__/defaultClaudeCodeFn.cwd.test.ts
@@ -65,12 +65,22 @@ afterEach(() => {
 });
 
 describe("defaultClaudeCodeFn — workspace cwd threading", () => {
-  it("spawns the agent subprocess with cwd = PATCHWORK_WORKSPACE", async () => {
-    process.env.PATCHWORK_WORKSPACE = workspace;
-    const out = await defaultClaudeCodeFn("ignored — fake binary");
-    // `pwd` on macOS may resolve /var → /private/var; compare via realpath.
-    expect(realpathSync(out)).toBe(realpathSync(workspace));
-  });
+  // The fake `claude` is a `#!/bin/sh` script — POSIX-only. Windows
+  // `spawnSync` can't execute it, so the spawn fails, `defaultClaudeCodeFn`
+  // returns the `[agent step failed: claude CLI not found]` placeholder,
+  // and `realpathSync` on that string throws an unrelated ENOENT. The
+  // resolver logic itself is covered platform-agnostically by
+  // `resolveWorkspaceRoot.test.ts`; skip this end-to-end spawn assertion
+  // on Windows.
+  it.skipIf(process.platform === "win32")(
+    "spawns the agent subprocess with cwd = PATCHWORK_WORKSPACE",
+    async () => {
+      process.env.PATCHWORK_WORKSPACE = workspace;
+      const out = await defaultClaudeCodeFn("ignored — fake binary");
+      // `pwd` on macOS may resolve /var → /private/var; compare via realpath.
+      expect(realpathSync(out)).toBe(realpathSync(workspace));
+    },
+  );
 
   it("returns the typed recipe_no_workspace error when no workspace resolves", async () => {
     // No env var, no .git ancestor of a deeply-nested tmpdir.

--- a/src/recipes/__tests__/defaultClaudeCodeFn.cwd.test.ts
+++ b/src/recipes/__tests__/defaultClaudeCodeFn.cwd.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Integration test: `defaultClaudeCodeFn` threads the resolved workspace
+ * root into `spawnSync` as `cwd`, instead of inheriting `$HOME` from the
+ * bridge LaunchAgent.
+ *
+ * Unit tests for `resolveWorkspaceRoot` prove the helper logic; this test
+ * proves the wiring — a real subprocess launched by `defaultClaudeCodeFn`
+ * lands in the workspace dir, not in whatever cwd the test runner happens
+ * to use. Uses a fake `claude` shell script (via `PATCHWORK_CLAUDE_BINARY`)
+ * that prints its own `pwd`, so the assertion is end-to-end through the
+ * real spawn — no mocks of `node:child_process`.
+ *
+ * Bug context: P2 of the 2026-05-20 improvement-research run — the bridge
+ * LaunchAgent sets WorkingDirectory=$HOME, so agent steps shelling out to
+ * git/npm/project scripts failed with "fatal: not a git repository"
+ * (231/232 silent-fail halts).
+ */
+
+import { execSync } from "node:child_process";
+import {
+  chmodSync,
+  mkdtempSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { defaultClaudeCodeFn } from "../yamlRunner.js";
+
+let workspace: string;
+let fakeBinDir: string;
+let savedBinary: string | undefined;
+let savedWorkspace: string | undefined;
+
+beforeEach(() => {
+  // Real git repo so resolveWorkspaceRoot's git-ancestor walk could find
+  // it if needed. Tests below set PATCHWORK_WORKSPACE explicitly so the
+  // path through the resolver is deterministic regardless of where the
+  // test runner is launched from.
+  workspace = mkdtempSync(path.join(os.tmpdir(), "pw-cwd-ws-"));
+  execSync("git init -q -b main", { cwd: workspace });
+
+  // Fake `claude` binary: prints its cwd. Mirrors how a real run would
+  // behave when `harvest_internal` shells out — but for the spawn path
+  // itself, not the LLM behaviour.
+  fakeBinDir = mkdtempSync(path.join(os.tmpdir(), "pw-cwd-bin-"));
+  const fakeClaude = path.join(fakeBinDir, "claude");
+  writeFileSync(fakeClaude, "#!/bin/sh\npwd\n");
+  chmodSync(fakeClaude, 0o755);
+
+  savedBinary = process.env.PATCHWORK_CLAUDE_BINARY;
+  savedWorkspace = process.env.PATCHWORK_WORKSPACE;
+  process.env.PATCHWORK_CLAUDE_BINARY = fakeClaude;
+});
+
+afterEach(() => {
+  rmSync(workspace, { recursive: true, force: true });
+  rmSync(fakeBinDir, { recursive: true, force: true });
+  if (savedBinary === undefined) delete process.env.PATCHWORK_CLAUDE_BINARY;
+  else process.env.PATCHWORK_CLAUDE_BINARY = savedBinary;
+  if (savedWorkspace === undefined) delete process.env.PATCHWORK_WORKSPACE;
+  else process.env.PATCHWORK_WORKSPACE = savedWorkspace;
+});
+
+describe("defaultClaudeCodeFn — workspace cwd threading", () => {
+  it("spawns the agent subprocess with cwd = PATCHWORK_WORKSPACE", async () => {
+    process.env.PATCHWORK_WORKSPACE = workspace;
+    const out = await defaultClaudeCodeFn("ignored — fake binary");
+    // `pwd` on macOS may resolve /var → /private/var; compare via realpath.
+    expect(realpathSync(out)).toBe(realpathSync(workspace));
+  });
+
+  it("returns the typed recipe_no_workspace error when no workspace resolves", async () => {
+    // No env var, no .git ancestor of a deeply-nested tmpdir.
+    const isolated = mkdtempSync(path.join(os.tmpdir(), "pw-cwd-isolated-"));
+    const originalCwd = process.cwd();
+    try {
+      process.chdir(isolated);
+      const out = await defaultClaudeCodeFn("ignored");
+      expect(out).toMatch(/^\[agent step failed: recipe_no_workspace\b/);
+      // Must mention how to fix it — operators reading the halt log need
+      // the env var name + the recipe field as actionable info.
+      expect(out).toMatch(/PATCHWORK_WORKSPACE/);
+      expect(out).toMatch(/workspace:/);
+    } finally {
+      process.chdir(originalCwd);
+      rmSync(isolated, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/recipes/__tests__/resolveWorkspaceRoot.test.ts
+++ b/src/recipes/__tests__/resolveWorkspaceRoot.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Tests for `resolveWorkspaceRoot` — recipe workspace-root resolution.
+ *
+ * Diagnosed by the 2026-05-20 `improvement-research` run (top HIGH proposal
+ * P2): the bridge LaunchAgent sets `WorkingDirectory: __HOME__`, so recipe
+ * agent-step subprocesses inherit `$HOME` as cwd. Steps that shell out to
+ * `git log` / `npm audit` / project scripts then fail with
+ * `fatal: not a git repository` — recorded as the catch-all
+ * `agent_silent_fail` (231/232 halts on 2026-05-20). The fix is a workspace
+ * resolver the runner uses before spawning, plus a `recipe_no_workspace`
+ * halt reason when nothing usable is found.
+ *
+ * Resolution precedence (highest first):
+ *   1. `explicitPath` — from a recipe-level `workspace:` field
+ *   2. `PATCHWORK_WORKSPACE` env var
+ *   3. Walk up from `startDir` (default `process.cwd()`) looking for `.git`
+ *   4. null — caller halts with `recipe_no_workspace`
+ */
+
+import { execSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { resolveWorkspaceRoot } from "../workspaceRoot.js";
+
+let tmp: string;
+let savedEnv: string | undefined;
+
+beforeEach(() => {
+  tmp = mkdtempSync(path.join(os.tmpdir(), "pw-workspace-"));
+  savedEnv = process.env.PATCHWORK_WORKSPACE;
+  delete process.env.PATCHWORK_WORKSPACE;
+});
+
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true });
+  if (savedEnv === undefined) delete process.env.PATCHWORK_WORKSPACE;
+  else process.env.PATCHWORK_WORKSPACE = savedEnv;
+});
+
+describe("resolveWorkspaceRoot", () => {
+  it("walks up to find the nearest ancestor with .git", () => {
+    execSync("git init -q -b main", { cwd: tmp });
+    const nested = path.join(tmp, "a", "b", "c");
+    mkdirSync(nested, { recursive: true });
+
+    const got = resolveWorkspaceRoot({ startDir: nested });
+
+    expect(got).not.toBeNull();
+    expect(got?.path).toBe(tmp);
+    expect(got?.source).toBe("git-ancestor");
+  });
+
+  it("returns null when no .git ancestor exists and no env/explicit is set", () => {
+    // Mimics the bug: cwd is `$HOME` with no git ancestor → recipe must
+    // refuse to run steps that need a workspace.
+    const got = resolveWorkspaceRoot({ startDir: tmp });
+    expect(got).toBeNull();
+  });
+
+  it("honors PATCHWORK_WORKSPACE env var above the git walk", () => {
+    execSync("git init -q -b main", { cwd: tmp });
+    const other = mkdtempSync(path.join(os.tmpdir(), "pw-workspace-env-"));
+    try {
+      process.env.PATCHWORK_WORKSPACE = other;
+      const got = resolveWorkspaceRoot({ startDir: tmp });
+      expect(got?.path).toBe(path.resolve(other));
+      expect(got?.source).toBe("env");
+    } finally {
+      rmSync(other, { recursive: true, force: true });
+    }
+  });
+
+  it("honors explicitPath above PATCHWORK_WORKSPACE and the git walk", () => {
+    execSync("git init -q -b main", { cwd: tmp });
+    const explicit = mkdtempSync(path.join(os.tmpdir(), "pw-workspace-x-"));
+    try {
+      process.env.PATCHWORK_WORKSPACE = tmp;
+      const got = resolveWorkspaceRoot({
+        startDir: tmp,
+        explicitPath: explicit,
+      });
+      expect(got?.path).toBe(path.resolve(explicit));
+      expect(got?.source).toBe("explicit");
+    } finally {
+      rmSync(explicit, { recursive: true, force: true });
+    }
+  });
+
+  it("returns an absolute path even when input is relative", () => {
+    execSync("git init -q -b main", { cwd: tmp });
+    const got = resolveWorkspaceRoot({ explicitPath: tmp });
+    expect(got).not.toBeNull();
+    expect(path.isAbsolute(got!.path)).toBe(true);
+  });
+
+  it("rejects non-existent explicit paths (caller must halt loudly)", () => {
+    const missing = path.join(tmp, "does", "not", "exist");
+    const got = resolveWorkspaceRoot({ explicitPath: missing });
+    expect(got).toBeNull();
+  });
+});

--- a/src/recipes/__tests__/stepObservation.test.ts
+++ b/src/recipes/__tests__/stepObservation.test.ts
@@ -85,6 +85,22 @@ describe("detectSilentFail — agent-step placeholders", () => {
     expect(detectSilentFail("[step skipped: missing dep]")).not.toBeNull();
   });
 
+  it("gives recipe_no_workspace its own typed reason, not the generic bucket", () => {
+    // Regression: P7 of the 2026-05-20 improvement-research run. With the
+    // workspace-root fix shipped in P2, this string is now emitted whenever
+    // a recipe step can't resolve a workspace. Without a dedicated pattern
+    // it collapses into the generic "agent step skipped or failed" bucket,
+    // hiding the actual cause — defeating the point of P2's typed error.
+    const m = detectSilentFail(
+      '[agent step failed: recipe_no_workspace — no .git ancestor of "/Users/wesh" and PATCHWORK_WORKSPACE not set]',
+    );
+    expect(m).not.toBeNull();
+    expect(m?.reason).toBe("recipe_no_workspace");
+    // The generic agent-step pattern (which matches the same prefix) must
+    // NOT have fired first.
+    expect(m?.reason).not.toMatch(/agent step skipped or failed/);
+  });
+
   it("does NOT flag bracketed text that isn't the placeholder shape", () => {
     expect(detectSilentFail("[INFO] some log line")).toBeNull();
     expect(detectSilentFail("[error] handled gracefully")).toBeNull();

--- a/src/recipes/stepObservation.ts
+++ b/src/recipes/stepObservation.ts
@@ -66,6 +66,15 @@ const SILENT_FAIL_PATTERNS: Array<{ regex: RegExp; reason: string }> = [
       /^\s*\(([^()]*?)(unavailable|not available|not configured|no data|error|failed)\)/i,
     reason: "tool returned a parens-wrapped placeholder",
   },
+  // Typed reason: recipe step ran with no workspace root resolved. Emitted
+  // by `defaultClaudeCodeFn` when `resolveWorkspaceRoot()` returns null —
+  // first fix in the halt-taxonomy refinement (P7 of the 2026-05-20
+  // research run). MUST match before the generic agent-step pattern below
+  // so the typed reason isn't swallowed by the catch-all.
+  {
+    regex: /^\s*\[agent step failed:\s*recipe_no_workspace\b/i,
+    reason: "recipe_no_workspace",
+  },
   // Agent-step short-circuit: agentExecutor's own error/skip strings.
   // Used by `executeAgent` when an API key is missing or the LLM
   // returns nothing. Not surfaced as JSON, so the runner never saw it.

--- a/src/recipes/workspaceRoot.ts
+++ b/src/recipes/workspaceRoot.ts
@@ -1,0 +1,92 @@
+/**
+ * Recipe workspace-root resolution.
+ *
+ * The bridge LaunchAgent sets `WorkingDirectory: __HOME__`, so recipe
+ * agent-step subprocesses spawned by the bridge inherit `$HOME` as cwd.
+ * Steps that shell out to `git log` / `npm audit` / project scripts then
+ * fail with `fatal: not a git repository` and the recipe runner records
+ * the catch-all `agent_silent_fail` halt — diagnosed by the 2026-05-20
+ * `improvement-research` run (231/232 halts) as proposal P2.
+ *
+ * This module returns a resolved workspace root the runner can use as
+ * `cwd:` on spawn. When nothing is resolvable the caller must halt with a
+ * typed reason (`recipe_no_workspace`) — never run steps against `$HOME`.
+ *
+ * Resolution precedence (highest first):
+ *   1. `explicitPath`         — from a recipe-level `workspace:` field
+ *   2. `PATCHWORK_WORKSPACE`  — env var
+ *   3. Walk up from `startDir` (default `process.cwd()`) for `.git`
+ *   4. `null`
+ *
+ * Each candidate must exist on disk; a non-existent explicit/env path
+ * returns null so the caller halts loudly instead of silently spawning
+ * against a missing directory.
+ */
+
+import { statSync } from "node:fs";
+import path from "node:path";
+
+export interface WorkspaceRoot {
+  /** Absolute path. */
+  path: string;
+  /** Which resolution rule fired — for logging and halt-reason context. */
+  source: "explicit" | "env" | "git-ancestor";
+}
+
+export interface ResolveWorkspaceRootOptions {
+  /** Directory to begin the `.git` ancestor walk from. Default: `process.cwd()`. */
+  startDir?: string;
+  /** Recipe-level `workspace:` field, if any. */
+  explicitPath?: string;
+}
+
+function dirExists(p: string): boolean {
+  try {
+    return statSync(p).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function gitMarkerExists(dir: string): boolean {
+  // `.git` is a directory in normal clones and a file in git-worktrees.
+  try {
+    statSync(path.join(dir, ".git"));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function walkUpForGit(startDir: string): string | null {
+  let current = path.resolve(startDir);
+  // Bounded walk: stop at filesystem root (`path.dirname(root) === root`).
+  for (;;) {
+    if (gitMarkerExists(current)) return current;
+    const parent = path.dirname(current);
+    if (parent === current) return null;
+    current = parent;
+  }
+}
+
+export function resolveWorkspaceRoot(
+  options: ResolveWorkspaceRootOptions = {},
+): WorkspaceRoot | null {
+  const { explicitPath, startDir = process.cwd() } = options;
+
+  if (explicitPath && explicitPath.length > 0) {
+    const resolved = path.resolve(explicitPath);
+    return dirExists(resolved) ? { path: resolved, source: "explicit" } : null;
+  }
+
+  const envPath = process.env.PATCHWORK_WORKSPACE;
+  if (envPath && envPath.length > 0) {
+    const resolved = path.resolve(envPath);
+    return dirExists(resolved) ? { path: resolved, source: "env" } : null;
+  }
+
+  const gitRoot = walkUpForGit(startDir);
+  if (gitRoot) return { path: gitRoot, source: "git-ancestor" };
+
+  return null;
+}

--- a/src/recipes/yamlRunner.ts
+++ b/src/recipes/yamlRunner.ts
@@ -1917,7 +1917,7 @@ export function resolveClaudeBinary(): string {
   return ensureCmdShim("claude");
 }
 
-function defaultClaudeCodeFn(
+export function defaultClaudeCodeFn(
   prompt: string,
   _opts?: { mcpAccess?: boolean },
 ): Promise<string> {

--- a/src/recipes/yamlRunner.ts
+++ b/src/recipes/yamlRunner.ts
@@ -74,7 +74,6 @@ import { resolveRecipePath } from "./resolveRecipePath.js";
 import { RunBudget } from "./runBudget.js";
 import type { ErrorPolicy } from "./schema.js";
 import { detectSilentFail } from "./stepObservation.js";
-
 // Import tool registry and trigger tool self-registration
 import {
   applyToolOutputContext,
@@ -83,6 +82,7 @@ import {
   hasTool,
   registerPluginTools,
 } from "./toolRegistry.js";
+import { resolveWorkspaceRoot } from "./workspaceRoot.js";
 import "./tools/index.js";
 
 /**
@@ -1922,6 +1922,16 @@ function defaultClaudeCodeFn(
   _opts?: { mcpAccess?: boolean },
 ): Promise<string> {
   const binary = resolveClaudeBinary();
+  // Resolve a workspace cwd so the spawned `claude -p` doesn't inherit the
+  // bridge LaunchAgent's `$HOME` (P2 from the 2026-05-20 research run).
+  // When nothing resolves, surface a typed reason instead of silently
+  // shelling out from the wrong directory.
+  const workspace = resolveWorkspaceRoot();
+  if (!workspace) {
+    return Promise.resolve(
+      `[agent step failed: recipe_no_workspace — no .git ancestor of "${process.cwd()}" and PATCHWORK_WORKSPACE not set. Set PATCHWORK_WORKSPACE in the bridge environment or add a 'workspace:' field to the recipe.]`,
+    );
+  }
   try {
     const result = spawnSync(
       binary,
@@ -1933,6 +1943,7 @@ function defaultClaudeCodeFn(
         "--no-session-persistence",
       ],
       {
+        cwd: workspace.path,
         encoding: "utf-8",
         timeout: 120_000,
         maxBuffer: 10 * 1024 * 1024,


### PR DESCRIPTION
## Summary

Recipes that spawn `claude -p` agent steps inherited `process.cwd()` as the workspace. When the bridge runs under a LaunchAgent (`WorkingDirectory: $HOME`), every shell-out (`git log`, `npm audit`, project scripts) ran from `$HOME` — producing `fatal: not a git repository` and a cascade of `agent_silent_fail` halts. The 2026-05-20 `improvement-research` run halted **231/232** steps this way.

## What this does

- **`src/recipes/workspaceRoot.ts`** (new) — `resolveWorkspaceRoot()`: explicit arg → `PATCHWORK_WORKSPACE` env → `.git`-ancestor walk → null. Bounded walk, disk-existence guards.
- **`src/recipes/yamlRunner.ts`** — `defaultClaudeCodeFn` resolves the workspace before spawn; a null result fails fast with a clear `recipe_no_workspace` reason rather than silently running from `$HOME`.
- **`src/recipes/stepObservation.ts`** — `recipe_no_workspace` gets its own silent-fail pattern.
- Halt taxonomy gets `recipe_no_workspace` as a distinct reason (commit `fb995901`).
- Tests: `resolveWorkspaceRoot.test.ts` (unset/relative/nonexistent root), spawn-cwd end-to-end coverage.

## Provenance

This work existed complete on branch `fix/recipe-workspace-root` but never reached main — it briefly rode a PR branch and was rebased out during PR #760 cleanup. This PR is that branch, rebased cleanly onto current main (no conflicts) and re-verified.

## Known follow-up (NOT in this PR)

There is a **second** agent-spawn path — `ClaudeOrchestrator.driver.run({ workspace: this.workspace })` ([claudeOrchestrator.ts:411](src/claudeOrchestrator.ts#L411)) — used for bridge-orchestrated tasks. It takes `workspace` from the orchestrator constructor, which the bridge populates from its own (possibly `$HOME`) cwd. That path needs the same `resolveWorkspaceRoot()` treatment — filed as a follow-up; it touches an unrelated WIP stash so it is deliberately out of scope here.

## Test plan

- [x] `resolveWorkspaceRoot.test.ts` + `stepObservation.test.ts` + `defaultClaudeCodeFn.cwd.test.ts` — 42 pass
- [x] Full recipe suite — 876 pass (1 local-only failure is an untracked WIP recipe, not on this branch / not on CI)
- [x] `tsc -p tsconfig.tests.core.json` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)