### PR TITLE
chore(release): v0.2.0-beta.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [0.2.0-beta.6] — 2026-05-20
+
+Reliability + correctness batch (#763–#766).
+
+### Fixed
+
+- **Recipe agent steps ran from `$HOME`, not the project.** The bridge LaunchAgent sets `WorkingDirectory: $HOME`, so recipe agent-step subprocesses inherited `$HOME` as cwd — shell-outs (`git log`, `npm audit`, project scripts) failed with `fatal: not a git repository` and the run recorded catch-all `agent_silent_fail` halts. The 2026-05-20 `improvement-research` run halted 231/232 steps this way. New `resolveWorkspaceRoot()` (explicit `workspace:` → `PATCHWORK_WORKSPACE` env → `.git`-ancestor walk) resolves the real project root before spawn; an unresolvable workspace now fails fast with a typed `recipe_no_workspace` reason instead of silently running against `$HOME` (#765).
+- **Marketplace recipe install was broken.** GitHub host fallback + scoped-name handling fixed so `recipe install` works (#763).
+
+### Changed
+
+- AJV validation (transport-layer tool-arg checks, recipe lint, recipe `step.expect`) pinned to the JSON Schema **2020-12** dialect per MCP SEP-1613. Additive — the draft-07 meta-schema stays registered so existing schemas validate unchanged (#766).
+
+### Docs
+
+- Corrected the RFC citation for `/.well-known/oauth-protected-resource` — it implements **RFC 9728** (OAuth 2.0 Protected Resource Metadata), not RFC 9396 (#764).
+
+---
+
 ## [0.2.0-beta.5] — 2026-05-18
 
 Second-day audit batch: 14 PRs (#596–#609) closing **7 BLOCKERs** + **25+ MAJOR/MINOR** items surfaced by two rounds of structured dogfooding (issues #600 and #605). Security-relevant — recommended upgrade for every beta.4 user.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "patchwork-os",
-  "version": "0.2.0-beta.5",
+  "version": "0.2.0-beta.6",
   "description": "Your personal AI runtime, local-first. Patchwork OS gives any AI model a consistent set of tools, YAML recipes, a delegation policy with approval queue, and a durable trace memory — all on your machine, all under your policy.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Release v0.2.0-beta.6

Reliability + correctness batch. Bumps `package.json` 0.2.0-beta.5 → 0.2.0-beta.6 + CHANGELOG.

### Included (merged since beta.5)

- **#765** — resolve workspace root before spawning agent steps. Fixes recipes running from `$HOME` (231/232-halt root cause).
- **#763** — marketplace recipe install fix (GitHub host fallback + scoped names).
- **#766** — AJV pinned to JSON Schema 2020-12 dialect (MCP SEP-1613).
- **#764** — RFC 9728 citation correction for the OAuth protected-resource endpoint.

### Publish

On merge, push tag `v0.2.0-beta.6` → `publish-npm.yml` runs `npm publish --access public --tag beta`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)