### PR TITLE
ci: switch npm publishing to OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -21,6 +21,12 @@ jobs:
   publish-alpha:
     if: startsWith(github.ref, 'refs/tags/') && contains(github.ref, '-alpha')
     runs-on: ubuntu-latest
+    # id-token: write is required for npm OIDC trusted publishing — npm
+    # exchanges the GitHub Actions OIDC token for a short-lived registry
+    # credential, so no NPM_TOKEN secret is stored or can expire.
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v4
 
@@ -29,6 +35,11 @@ jobs:
           node-version: '20'
           cache: npm
           registry-url: 'https://registry.npmjs.org'
+
+      # OIDC trusted publishing requires npm >= 11.5.1; node 20 ships
+      # npm 10.x. Upgrade in place.
+      - name: Upgrade npm for OIDC publishing
+        run: npm install -g npm@latest
 
       - run: npm ci
       - run: npm run build
@@ -48,11 +59,12 @@ jobs:
             echo "skip=true" >> "$GITHUB_OUTPUT"
           fi
 
+      # No NODE_AUTH_TOKEN — OIDC authenticates via the trusted-publisher
+      # config on npmjs.com. Provenance attestation is emitted automatically
+      # for trusted-publisher publishes.
       - name: Publish alpha to npm
         if: steps.npm_check.outputs.skip != 'true'
         run: npm publish --access public --tag alpha
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Create GitHub pre-release
         env:
@@ -74,6 +86,9 @@ jobs:
     # an emergency hotfix to the alpha line can still ship if needed.
     if: startsWith(github.ref, 'refs/tags/') && contains(github.ref, '-beta')
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v4
 
@@ -82,6 +97,9 @@ jobs:
           node-version: '20'
           cache: npm
           registry-url: 'https://registry.npmjs.org'
+
+      - name: Upgrade npm for OIDC publishing
+        run: npm install -g npm@latest
 
       - run: npm ci
       - run: npm run build
@@ -101,8 +119,6 @@ jobs:
       - name: Publish beta to npm
         if: steps.npm_check.outputs.skip != 'true'
         run: npm publish --access public --tag beta
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Create GitHub pre-release
         env:
@@ -127,6 +143,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -137,6 +154,9 @@ jobs:
           node-version: '20'
           cache: npm
           registry-url: 'https://registry.npmjs.org'
+
+      - name: Upgrade npm for OIDC publishing
+        run: npm install -g npm@latest
 
       - name: Install dependencies
         run: npm ci
@@ -172,8 +192,6 @@ jobs:
 
       - name: Publish to npm
         run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Create GitHub Release
         env:


### PR DESCRIPTION
## Why

`v0.2.0-beta.6` publish failed with `npm error 404 — PUT .../patchwork-os` — npm's auth-failure response (the package exists; 404 masks an invalid/insufficient token). Stored `NPM_TOKEN` secrets expire and require manual rotation. OIDC trusted publishing removes the secret entirely.

## What

All three publish jobs (`publish-alpha`, `publish-beta`, `publish`):
- `permissions: id-token: write` — GitHub issues the OIDC token npm exchanges for a short-lived registry credential
- `npm install -g npm@latest` after `setup-node` — OIDC publishing needs npm ≥ 11.5.1; node 20 ships npm 10.x
- removed `NODE_AUTH_TOKEN: secrets.NPM_TOKEN` from every `npm publish` step

Trusted-publisher publishes also emit npm **provenance attestation** automatically — no flag needed.

## ⚠️ Required one-time setup before this works

On npmjs.com → `patchwork-os` package → **Settings → Trusted Publishers** → add:
- Publisher: GitHub Actions
- Repository: `Oolab-labs/patchwork-os`
- Workflow: `publish-npm.yml`

The workflow changes are **inert until this is configured**. After it's set, `NPM_TOKEN` can be deleted from repo secrets.

## Shipping v0.2.0-beta.6 through this

After this PR merges + the npm trusted publisher is configured, the `v0.2.0-beta.6` tag will be deleted and re-pushed onto a commit that includes this workflow, so beta.6 publishes via OIDC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)