### PR TITLE
ci: diagnostic step for OIDC publish (ENEEDAUTH)

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -118,6 +118,15 @@ jobs:
             echo "skip=true" >> "$GITHUB_OUTPUT"
           fi
 
+      # Temporary diagnostic — confirms npm is >= 11.5.1 and the GitHub
+      # OIDC token endpoint is exposed to the job before the publish.
+      - name: Diagnose OIDC publish prerequisites
+        run: |
+          echo "npm version : $(npm -v)"
+          echo "node version: $(node -v)"
+          echo "registry    : $(npm config get registry)"
+          echo "OIDC token URL present: ${ACTIONS_ID_TOKEN_REQUEST_URL:+yes}"
+
       - name: Publish beta to npm
         if: steps.npm_check.outputs.skip != 'true'
         run: npm publish --access public --tag beta


### PR DESCRIPTION
## Why

OIDC publish of v0.2.0-beta.6 now fails with `ENEEDAUTH` — npm has no credential and isn't attempting the OIDC token exchange at all. The remaining unknowns: is npm actually ≥ 11.5.1 on the publish step, and is the GitHub OIDC token endpoint (`ACTIONS_ID_TOKEN_REQUEST_URL`) exposed to the job?

Adds a temporary diagnostic step before `npm publish` that prints npm/node version, registry, and OIDC-env presence — so the next tagged run shows the exact missing prerequisite instead of another guess. Removed once publish succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)