### PR TITLE
ci: remove temporary OIDC publish diagnostic step

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -118,15 +118,6 @@ jobs:
             echo "skip=true" >> "$GITHUB_OUTPUT"
           fi
 
-      # Temporary diagnostic — confirms npm is >= 11.5.1 and the GitHub
-      # OIDC token endpoint is exposed to the job before the publish.
-      - name: Diagnose OIDC publish prerequisites
-        run: |
-          echo "npm version : $(npm -v)"
-          echo "node version: $(node -v)"
-          echo "registry    : $(npm config get registry)"
-          echo "OIDC token URL present: ${ACTIONS_ID_TOKEN_REQUEST_URL:+yes}"
-
       - name: Publish beta to npm
         if: steps.npm_check.outputs.skip != 'true'
         run: npm publish --access public --tag beta


### PR DESCRIPTION
Removes the diagnostic step added in #770. It did its job — confirmed npm 11.15.0 + OIDC env were correct, isolating the `ENEEDAUTH` to a wrong workflow filename in the npmjs.com trusted-publisher config (`publish-canary.yml` instead of `publish-npm.yml`), now corrected.

`v0.2.0-beta.6` published successfully via OIDC trusted publishing — `beta` dist-tag updated. Workflow-only revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)