### PR TITLE
ci: drop registry-url from publish-canary so OIDC publish works

### DIFF
--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -36,11 +36,14 @@ jobs:
           # Pin to the exact commit CI validated, not whatever main is now.
           ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
+      # Deliberately NO `registry-url:` — setup-node would write an .npmrc
+      # with a placeholder `_authToken`, and `npm publish` would then attempt
+      # (failing, E404) token auth instead of OIDC. OIDC requires npm see no
+      # auth token. Default registry is registry.npmjs.org. (Mirrors #769.)
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: npm
-          registry-url: 'https://registry.npmjs.org'
 
       # Trusted publishing (OIDC) requires npm >= 11.5.1. Node 20 ships with npm 10.x.
       - name: Upgrade npm for trusted publishing


### PR DESCRIPTION
## Why

`Publish canary on merge to main` fails on **every** main merge with `E404`.

Same defect #769 fixed in `publish-npm.yml`: `actions/setup-node` with `registry-url:` writes an `.npmrc` with a placeholder `_authToken`, so `npm publish` attempts token auth (→ E404) instead of OIDC trusted publishing. I fixed `publish-npm.yml` but missed its sibling `publish-canary.yml`.

## Fix

Removed `registry-url` from the canary job's `setup-node`. npm publishes to the default registry; the OIDC path engages.

## ⚠️ Also required — a second trusted publisher on npmjs.com

The npmjs.com trusted-publisher entry currently covers only workflow `publish-npm.yml`. Canary publishes from `publish-canary.yml`, a different workflow file — npm matches trusted publishers by exact workflow filename.

`patchwork-os` → Settings → Trusted Publishers → **add a second entry**:
- Publisher: GitHub Actions
- Organization: `Oolab-labs`
- Repository: `patchwork-os`
- Workflow filename: `publish-canary.yml`
- Environment: blank

Until that entry exists, canary OIDC will still fail auth even with this PR merged.

## Note

`publish-canary.yml` already has `id-token: write` and the npm-upgrade step — only `registry-url` was wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)