### PR TITLE
fix(orchestrator): resolve workspace root before handing tasks to the driver

### DIFF
--- a/src/__tests__/claudeOrchestrator.test.ts
+++ b/src/__tests__/claudeOrchestrator.test.ts
@@ -1,3 +1,7 @@
+import { execSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import {
   afterEach,
   beforeEach,
@@ -958,5 +962,82 @@ describe("ClaudeOrchestrator._drain does not loop forever when all tasks exceed 
     // Cleanup
     releaseBlocker?.();
     await new Promise((r) => setTimeout(r, 50));
+  });
+});
+
+// ── Workspace resolution ──────────────────────────────────────────────────────
+//
+// The bridge LaunchAgent defaults WorkingDirectory to $HOME, so the
+// orchestrator's constructor `workspace` is typically $HOME. The orchestrator
+// must resolve a real workspace (PATCHWORK_WORKSPACE env, then a .git-ancestor
+// walk) before handing it to the driver as cwd — otherwise agent steps shell
+// out from $HOME and fail with `fatal: not a git repository`.
+
+function makeCapturingDriver(): {
+  driver: ProviderDriver;
+  lastWorkspace: () => string | undefined;
+} {
+  let seen: string | undefined;
+  return {
+    driver: {
+      name: "capturing",
+      async run(input: ProviderTaskInput) {
+        seen = input.workspace;
+        return { text: "ok", exitCode: 0, durationMs: 1 };
+      },
+    },
+    lastWorkspace: () => seen,
+  };
+}
+
+describe("ClaudeOrchestrator — workspace resolution", () => {
+  let savedEnv: string | undefined;
+  let tmp: string;
+
+  beforeEach(() => {
+    savedEnv = process.env.PATCHWORK_WORKSPACE;
+    delete process.env.PATCHWORK_WORKSPACE;
+    tmp = mkdtempSync(path.join(os.tmpdir(), "orch-ws-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+    if (savedEnv === undefined) delete process.env.PATCHWORK_WORKSPACE;
+    else process.env.PATCHWORK_WORKSPACE = savedEnv;
+  });
+
+  it("PATCHWORK_WORKSPACE overrides a non-repo constructor workspace", async () => {
+    const wsRepo = mkdtempSync(path.join(os.tmpdir(), "orch-ws-env-"));
+    try {
+      execSync("git init -q -b main", { cwd: wsRepo });
+      process.env.PATCHWORK_WORKSPACE = wsRepo;
+      // Constructor workspace is a non-repo dir — stands in for $HOME.
+      const cap = makeCapturingDriver();
+      const orch = new ClaudeOrchestrator(cap.driver, tmp, noop);
+      orch.enqueue({ prompt: "hello" });
+      await new Promise((r) => setImmediate(r));
+      expect(cap.lastWorkspace()).toBe(path.resolve(wsRepo));
+    } finally {
+      rmSync(wsRepo, { recursive: true, force: true });
+    }
+  });
+
+  it("resolves a .git-ancestor when the constructor workspace is a repo", async () => {
+    execSync("git init -q -b main", { cwd: tmp });
+    const cap = makeCapturingDriver();
+    const orch = new ClaudeOrchestrator(cap.driver, tmp, noop);
+    orch.enqueue({ prompt: "hello" });
+    await new Promise((r) => setImmediate(r));
+    expect(cap.lastWorkspace()).toBe(tmp);
+  });
+
+  it("falls back to the constructor workspace when nothing resolves", async () => {
+    // tmp has no .git ancestor and no env var — must not crash, just pass
+    // the original workspace through unchanged.
+    const cap = makeCapturingDriver();
+    const orch = new ClaudeOrchestrator(cap.driver, tmp, noop);
+    orch.enqueue({ prompt: "hello" });
+    await new Promise((r) => setImmediate(r));
+    expect(cap.lastWorkspace()).toBe(tmp);
   });
 });

--- a/src/claudeOrchestrator.ts
+++ b/src/claudeOrchestrator.ts
@@ -14,6 +14,7 @@ function getConfigDir(): string {
 }
 
 import type { IClaudeDriver } from "./drivers/types.js";
+import { resolveWorkspaceRoot } from "./recipes/workspaceRoot.js";
 import { writeFileAtomic, writeFileAtomicSync } from "./writeFileAtomic.js";
 
 export type TaskStatus =
@@ -407,11 +408,23 @@ export class ClaudeOrchestrator {
       controller.abort();
     }, task.timeoutMs);
 
+    // The bridge LaunchAgent defaults its WorkingDirectory to $HOME, so
+    // `this.workspace` is typically $HOME unless the bridge was started
+    // with an explicit --workspace. Resolve a real workspace per task
+    // (PATCHWORK_WORKSPACE env, then a .git-ancestor walk) so agent steps
+    // don't shell out from $HOME and fail with `fatal: not a git
+    // repository` — the dominant `agent_silent_fail` halt cause. #765
+    // fixed the --local path (defaultClaudeCodeFn); this closes the
+    // bridge-orchestrated path.
+    const resolvedWorkspace =
+      resolveWorkspaceRoot({ startDir: this.workspace })?.path ??
+      this.workspace;
+
     try {
       const result = await this.driver.run({
         prompt: task.prompt,
         contextFiles: task.contextFiles,
-        workspace: this.workspace,
+        workspace: resolvedWorkspace,
         timeoutMs: task.timeoutMs,
         signal: controller.signal,
         model: task.model,


### PR DESCRIPTION
## Problem

PR #765 fixed the workspace-root bug on the **`--local`** recipe path (`defaultClaudeCodeFn`) — agent steps now spawn in the real repo instead of the bridge LaunchAgent's `$HOME`. But the **bridge-orchestrated** path was left unfixed:

`ClaudeOrchestrator` passed its constructor `workspace` (typically `$HOME`, because the LaunchAgent defaults `WorkingDirectory` to it) straight to `driver.run()` as the subprocess cwd. So recipe agent steps run *through the bridge* still shelled out from `$HOME` and failed with `fatal: not a git repository` — the dominant cause of the `agent_silent_fail` halt cluster.

## Fix

Resolve a real workspace **per task** via `resolveWorkspaceRoot` (already in `main`, landed by #765) before the `driver.run()` call:

1. `PATCHWORK_WORKSPACE` env var, then
2. a `.git`-ancestor walk from the configured workspace, then
3. fall back to the configured workspace unchanged when nothing resolves (no crash, no behavior change for correctly-configured bridges).

This completes the workspace-root fix end-to-end — **both** the `--local` and bridge-orchestrated paths now spawn agent steps in the repo.

## Testing

- 3 new tests in `claudeOrchestrator.test.ts` via a capturing fake driver: `PATCHWORK_WORKSPACE` overrides a non-repo workspace; a `.git`-ancestor is resolved; graceful fallback when nothing resolves.
- Full file: **43 tests** pass · strict typecheck (`tsconfig.tests.core.json`) + biome clean.

Small, contained change — one import + ~10 lines, no new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)