### PR TITLE
feat(connectors): Wave 1b + 2-PAT — SendGrid / Twilio / Figma / Airtable / Webflow

### DIFF
--- a/dashboard/src/app/api/connections/[connector]/__tests__/registry.test.ts
+++ b/dashboard/src/app/api/connections/[connector]/__tests__/registry.test.ts
@@ -27,6 +27,10 @@ const EXPECTED_CONNECT = new Set([
   "zendesk", "pagerduty",
   // Wave 1a data-store connectors (PAT, lazy driver imports).
   "postgres", "mongodb", "redis", "elasticsearch",
+  // Wave 1b — PAT comms connectors.
+  "sendgrid", "twilio",
+  // Wave 2 — PAT SaaS connectors.
+  "figma", "airtable", "webflow",
 ]);
 const EXPECTED_TEST = new Set([
   "gmail", "github", "linear", "sentry", "google-calendar", "google-drive",
@@ -35,6 +39,10 @@ const EXPECTED_TEST = new Set([
   "pagerduty",
   // Wave 1a data-store connectors.
   "postgres", "mongodb", "redis", "elasticsearch",
+  // Wave 1b — PAT comms connectors.
+  "sendgrid", "twilio",
+  // Wave 2 — PAT SaaS connectors.
+  "figma", "airtable", "webflow",
 ]);
 const EXPECTED_DELETE = EXPECTED_TEST;
 

--- a/dashboard/src/app/connections/page.tsx
+++ b/dashboard/src/app/connections/page.tsx
@@ -325,6 +325,11 @@ const SUPPORTED_CONNECTORS = new Set([
   "mongodb",
   "redis",
   "elasticsearch",
+  "sendgrid",
+  "twilio",
+  "figma",
+  "airtable",
+  "webflow",
 ]);
 
 const TOKEN_MODAL_CONNECTORS: Record<string, TokenModalConfig> = {
@@ -515,6 +520,94 @@ const TOKEN_MODAL_CONNECTORS: Record<string, TokenModalConfig> = {
       { key: "apiKey", label: "API key (base64 id:secret)", placeholder: "VnVhQ2ZHY0JDZGJrUW0tZTVhT3g6...", type: "text", required: false },
       { key: "cloudId", label: "Elastic Cloud ID (alternative to node URL)", placeholder: "deployment:dXMtZWFzdC0xLmF3cy5l...", type: "text", required: false },
     ],
+  },
+  sendgrid: {
+    name: "SendGrid",
+    icon: <IconEnvelope />,
+    instructions: (
+      <>
+        Create an API key in{" "}
+        <a href="https://app.sendgrid.com/settings/api_keys" target="_blank" rel="noreferrer" style={{ color: "var(--info)" }}>
+          SendGrid → Settings → API Keys
+        </a>
+        . Restricted-access keys with Mail Send + Templates read are enough.
+        Optionally set a verified sender email so the <code>send</code> tool can
+        default the From address.
+      </>
+    ),
+    placeholder: "SendGrid API key (starts with SG.)",
+    tokenKey: "apiKey",
+    extraFields: [
+      { key: "fromEmail", label: "Default sender email (optional)", placeholder: "you@your-org.com", type: "email", required: false },
+    ],
+  },
+  twilio: {
+    name: "Twilio",
+    icon: <IconEnvelope />,
+    instructions: (
+      <>
+        Find your Account SID + Auth Token in{" "}
+        <a href="https://console.twilio.com/" target="_blank" rel="noreferrer" style={{ color: "var(--info)" }}>
+          Twilio Console
+        </a>
+        . Add a default From number (E.164, e.g. <code>+15551234567</code>) so
+        the <code>sendSms</code> tool can default it.
+      </>
+    ),
+    placeholder: "Twilio Account SID (starts with AC)",
+    tokenKey: "accountSid",
+    extraFields: [
+      { key: "authToken", label: "Auth token", placeholder: "Twilio auth token", type: "text", required: true },
+      { key: "defaultFrom", label: "Default From number (E.164, optional)", placeholder: "+15551234567", type: "text", required: false },
+    ],
+  },
+  figma: {
+    name: "Figma",
+    icon: <IconDatabase />,
+    instructions: (
+      <>
+        Generate a Personal Access Token at{" "}
+        <a href="https://www.figma.com/settings" target="_blank" rel="noreferrer" style={{ color: "var(--info)" }}>
+          Figma → Settings → Personal access tokens
+        </a>
+        . Read-only by default — Figma's API surface is mostly read.
+      </>
+    ),
+    placeholder: "Figma personal access token (starts with figd_)",
+    tokenKey: "accessToken",
+  },
+  airtable: {
+    name: "Airtable",
+    icon: <IconDatabase />,
+    instructions: (
+      <>
+        Create a Personal Access Token at{" "}
+        <a href="https://airtable.com/create/tokens" target="_blank" rel="noreferrer" style={{ color: "var(--info)" }}>
+          Airtable → Developer hub → Personal access tokens
+        </a>
+        . Grant <code>data.records:read</code> for read tools, plus
+        <code> data.records:write</code> if you want create/update tools.
+        Scope to specific bases for safety.
+      </>
+    ),
+    placeholder: "Airtable personal access token (starts with pat)",
+    tokenKey: "accessToken",
+  },
+  webflow: {
+    name: "Webflow",
+    icon: <IconDatabase />,
+    instructions: (
+      <>
+        Create a Site API Token in{" "}
+        <a href="https://webflow.com/dashboard/account/integrations" target="_blank" rel="noreferrer" style={{ color: "var(--info)" }}>
+          Webflow → Account → Integrations → API access
+        </a>
+        . Webflow v2 tokens are scoped to one site — the connector captures
+        the first site at connect time.
+      </>
+    ),
+    placeholder: "Webflow site API token",
+    tokenKey: "accessToken",
   },
 };
 

--- a/dashboard/src/app/connections/page.tsx
+++ b/dashboard/src/app/connections/page.tsx
@@ -570,7 +570,7 @@ const TOKEN_MODAL_CONNECTORS: Record<string, TokenModalConfig> = {
         <a href="https://www.figma.com/settings" target="_blank" rel="noreferrer" style={{ color: "var(--info)" }}>
           Figma → Settings → Personal access tokens
         </a>
-        . Read-only by default — Figma's API surface is mostly read.
+        . Read-only by default — Figma&apos;s API surface is mostly read.
       </>
     ),
     placeholder: "Figma personal access token (starts with figd_)",

--- a/src/connectorRoutes.ts
+++ b/src/connectorRoutes.ts
@@ -1509,6 +1509,248 @@ export function tryHandleConnectorRoute(
     return true;
   }
 
+  // ── SendGrid routes ─────────────────────────────────────────────
+  if (
+    parsedUrl.pathname === "/connections/sendgrid/connect" &&
+    req.method === "POST"
+  ) {
+    void dispatchConnectorConnect(req, res, async () => {
+      const m = await import("./connectors/sendgrid.js");
+      return m.handleSendGridConnect;
+    });
+    return true;
+  }
+  if (
+    parsedUrl.pathname === "/connections/sendgrid/test" &&
+    req.method === "POST"
+  ) {
+    void (async () => {
+      try {
+        const { handleSendGridTest } = await import("./connectors/sendgrid.js");
+        const result = await handleSendGridTest();
+        res.writeHead(result.status, {
+          "Content-Type": result.contentType ?? "application/json",
+        });
+        res.end(result.body);
+      } catch (err) {
+        respond500(res, err);
+      }
+    })();
+    return true;
+  }
+  if (
+    parsedUrl.pathname === "/connections/sendgrid" &&
+    req.method === "DELETE"
+  ) {
+    void (async () => {
+      try {
+        const { handleSendGridDisconnect } = await import(
+          "./connectors/sendgrid.js"
+        );
+        const result = handleSendGridDisconnect();
+        res.writeHead(result.status, {
+          "Content-Type": result.contentType ?? "application/json",
+        });
+        res.end(result.body);
+      } catch (err) {
+        respond500(res, err);
+      }
+    })();
+    return true;
+  }
+
+  // ── Twilio routes ───────────────────────────────────────────────
+  if (
+    parsedUrl.pathname === "/connections/twilio/connect" &&
+    req.method === "POST"
+  ) {
+    void dispatchConnectorConnect(req, res, async () => {
+      const m = await import("./connectors/twilio.js");
+      return m.handleTwilioConnect;
+    });
+    return true;
+  }
+  if (
+    parsedUrl.pathname === "/connections/twilio/test" &&
+    req.method === "POST"
+  ) {
+    void (async () => {
+      try {
+        const { handleTwilioTest } = await import("./connectors/twilio.js");
+        const result = await handleTwilioTest();
+        res.writeHead(result.status, {
+          "Content-Type": result.contentType ?? "application/json",
+        });
+        res.end(result.body);
+      } catch (err) {
+        respond500(res, err);
+      }
+    })();
+    return true;
+  }
+  if (parsedUrl.pathname === "/connections/twilio" && req.method === "DELETE") {
+    void (async () => {
+      try {
+        const { handleTwilioDisconnect } = await import(
+          "./connectors/twilio.js"
+        );
+        const result = handleTwilioDisconnect();
+        res.writeHead(result.status, {
+          "Content-Type": result.contentType ?? "application/json",
+        });
+        res.end(result.body);
+      } catch (err) {
+        respond500(res, err);
+      }
+    })();
+    return true;
+  }
+
+  // ── Figma routes ────────────────────────────────────────────────
+  if (
+    parsedUrl.pathname === "/connections/figma/connect" &&
+    req.method === "POST"
+  ) {
+    void dispatchConnectorConnect(req, res, async () => {
+      const m = await import("./connectors/figma.js");
+      return m.handleFigmaConnect;
+    });
+    return true;
+  }
+  if (
+    parsedUrl.pathname === "/connections/figma/test" &&
+    req.method === "POST"
+  ) {
+    void (async () => {
+      try {
+        const { handleFigmaTest } = await import("./connectors/figma.js");
+        const result = await handleFigmaTest();
+        res.writeHead(result.status, {
+          "Content-Type": result.contentType ?? "application/json",
+        });
+        res.end(result.body);
+      } catch (err) {
+        respond500(res, err);
+      }
+    })();
+    return true;
+  }
+  if (parsedUrl.pathname === "/connections/figma" && req.method === "DELETE") {
+    void (async () => {
+      try {
+        const { handleFigmaDisconnect } = await import("./connectors/figma.js");
+        const result = handleFigmaDisconnect();
+        res.writeHead(result.status, {
+          "Content-Type": result.contentType ?? "application/json",
+        });
+        res.end(result.body);
+      } catch (err) {
+        respond500(res, err);
+      }
+    })();
+    return true;
+  }
+
+  // ── Airtable routes ─────────────────────────────────────────────
+  if (
+    parsedUrl.pathname === "/connections/airtable/connect" &&
+    req.method === "POST"
+  ) {
+    void dispatchConnectorConnect(req, res, async () => {
+      const m = await import("./connectors/airtable.js");
+      return m.handleAirtableConnect;
+    });
+    return true;
+  }
+  if (
+    parsedUrl.pathname === "/connections/airtable/test" &&
+    req.method === "POST"
+  ) {
+    void (async () => {
+      try {
+        const { handleAirtableTest } = await import("./connectors/airtable.js");
+        const result = await handleAirtableTest();
+        res.writeHead(result.status, {
+          "Content-Type": result.contentType ?? "application/json",
+        });
+        res.end(result.body);
+      } catch (err) {
+        respond500(res, err);
+      }
+    })();
+    return true;
+  }
+  if (
+    parsedUrl.pathname === "/connections/airtable" &&
+    req.method === "DELETE"
+  ) {
+    void (async () => {
+      try {
+        const { handleAirtableDisconnect } = await import(
+          "./connectors/airtable.js"
+        );
+        const result = handleAirtableDisconnect();
+        res.writeHead(result.status, {
+          "Content-Type": result.contentType ?? "application/json",
+        });
+        res.end(result.body);
+      } catch (err) {
+        respond500(res, err);
+      }
+    })();
+    return true;
+  }
+
+  // ── Webflow routes ──────────────────────────────────────────────
+  if (
+    parsedUrl.pathname === "/connections/webflow/connect" &&
+    req.method === "POST"
+  ) {
+    void dispatchConnectorConnect(req, res, async () => {
+      const m = await import("./connectors/webflow.js");
+      return m.handleWebflowConnect;
+    });
+    return true;
+  }
+  if (
+    parsedUrl.pathname === "/connections/webflow/test" &&
+    req.method === "POST"
+  ) {
+    void (async () => {
+      try {
+        const { handleWebflowTest } = await import("./connectors/webflow.js");
+        const result = await handleWebflowTest();
+        res.writeHead(result.status, {
+          "Content-Type": result.contentType ?? "application/json",
+        });
+        res.end(result.body);
+      } catch (err) {
+        respond500(res, err);
+      }
+    })();
+    return true;
+  }
+  if (
+    parsedUrl.pathname === "/connections/webflow" &&
+    req.method === "DELETE"
+  ) {
+    void (async () => {
+      try {
+        const { handleWebflowDisconnect } = await import(
+          "./connectors/webflow.js"
+        );
+        const result = handleWebflowDisconnect();
+        res.writeHead(result.status, {
+          "Content-Type": result.contentType ?? "application/json",
+        });
+        res.end(result.body);
+      } catch (err) {
+        respond500(res, err);
+      }
+    })();
+    return true;
+  }
+
   // ── Google Calendar routes ──────────────────────────────────────
   if (
     parsedUrl.pathname === "/connections/google-calendar/auth" &&

--- a/src/connectors/__tests__/airtable.test.ts
+++ b/src/connectors/__tests__/airtable.test.ts
@@ -1,0 +1,352 @@
+import { existsSync, mkdirSync, rmSync } from "node:fs";
+import os from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ── Fetch mock helper ──────────────────────────────────────────────────────
+
+type FetchCall = { url: string; init?: RequestInit };
+
+function installFetchMock(
+  responder: (url: string, init?: RequestInit) => Response | Promise<Response>,
+) {
+  const calls: FetchCall[] = [];
+  const fn = vi.fn(async (url: string | URL, init?: RequestInit) => {
+    const u = typeof url === "string" ? url : url.toString();
+    calls.push({ url: u, init });
+    return responder(u, init);
+  });
+  // @ts-expect-error — override global fetch
+  globalThis.fetch = fn;
+  return { calls, fn };
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+// ── Test harness ───────────────────────────────────────────────────────────
+
+const tmpDir = join(os.tmpdir(), `patchwork-airtable-${Date.now()}`);
+const homeDir = join(tmpDir, "home");
+const patchworkHome = join(homeDir, ".patchwork");
+const tokensDir = join(patchworkHome, "tokens");
+
+beforeEach(() => {
+  process.env.HOME = homeDir;
+  process.env.PATCHWORK_HOME = patchworkHome;
+  process.env.PATCHWORK_TOKEN_STORAGE_BACKEND = "file";
+  delete process.env.AIRTABLE_ACCESS_TOKEN;
+  mkdirSync(tokensDir, { recursive: true });
+  vi.resetModules();
+});
+
+afterEach(() => {
+  delete process.env.HOME;
+  delete process.env.PATCHWORK_HOME;
+  delete process.env.PATCHWORK_TOKEN_STORAGE_BACKEND;
+  delete process.env.AIRTABLE_ACCESS_TOKEN;
+  if (existsSync(tmpDir)) {
+    rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+// ── normalizeError ─────────────────────────────────────────────────────────
+
+describe("normalizeError", () => {
+  it("maps HTTP status codes from Response", async () => {
+    const { AirtableConnector } = await import("../airtable.js");
+    const c = new AirtableConnector();
+    const make = (status: number) => new Response(null, { status });
+    expect(c.normalizeError(make(401)).code).toBe("auth_expired");
+    expect(c.normalizeError(make(403)).code).toBe("permission_denied");
+    expect(c.normalizeError(make(404)).code).toBe("not_found");
+    expect(c.normalizeError(make(422)).code).toBe("provider_error");
+    expect(c.normalizeError(make(429)).code).toBe("rate_limited");
+    expect(c.normalizeError(make(500)).code).toBe("provider_error");
+  });
+
+  it("marks 429 + 5xx retryable; 4xx non-retryable", async () => {
+    const { AirtableConnector } = await import("../airtable.js");
+    const c = new AirtableConnector();
+    const make = (status: number) => new Response(null, { status });
+    expect(c.normalizeError(make(429)).retryable).toBe(true);
+    expect(c.normalizeError(make(503)).retryable).toBe(true);
+    expect(c.normalizeError(make(401)).retryable).toBe(false);
+    expect(c.normalizeError(make(403)).retryable).toBe(false);
+    expect(c.normalizeError(make(404)).retryable).toBe(false);
+    expect(c.normalizeError(make(422)).retryable).toBe(false);
+  });
+
+  it("detects ENOTFOUND/ECONNREFUSED as network_error", async () => {
+    const { AirtableConnector } = await import("../airtable.js");
+    const c = new AirtableConnector();
+    expect(c.normalizeError(new Error("getaddrinfo ENOTFOUND x")).code).toBe(
+      "network_error",
+    );
+    expect(c.normalizeError(new Error("ECONNREFUSED")).code).toBe(
+      "network_error",
+    );
+  });
+
+  it("defaults to provider_error", async () => {
+    const { AirtableConnector } = await import("../airtable.js");
+    const c = new AirtableConnector();
+    expect(c.normalizeError(new Error("boom")).code).toBe("provider_error");
+    expect(c.normalizeError("plain string").code).toBe("provider_error");
+  });
+});
+
+// ── listRecords URL encoding + maxRecords cap ──────────────────────────────
+
+describe("listRecords", () => {
+  it("URL-encodes filterByFormula and caps maxRecords at 1000", async () => {
+    process.env.AIRTABLE_ACCESS_TOKEN = "pat_test_abc";
+    const { getAirtableConnector } = await import("../airtable.js");
+
+    const { calls } = installFetchMock(() =>
+      jsonResponse({ records: [], offset: undefined }),
+    );
+
+    const c = getAirtableConnector();
+    await c.listRecords("appXYZ", "Tasks", {
+      filterByFormula: "AND({Status}='Open', {Name}='A&B')",
+      maxRecords: 5000, // should be capped at 1000
+    });
+
+    expect(calls).toHaveLength(1);
+    const url = calls[0]!.url;
+    expect(url).toContain("/v0/appXYZ/Tasks?");
+    expect(url).toContain("maxRecords=1000");
+    // URLSearchParams encodes — verify the raw formula is NOT present
+    expect(url).not.toContain("{Status}='Open'");
+    // Verify the encoded form is present
+    expect(url).toMatch(/filterByFormula=AND/);
+    expect(url).toContain("%7BStatus%7D"); // {Status} encoded
+    expect(url).toContain("%26"); // & encoded
+  });
+
+  it("defaults maxRecords to 100 when omitted", async () => {
+    process.env.AIRTABLE_ACCESS_TOKEN = "pat_test_abc";
+    const { getAirtableConnector } = await import("../airtable.js");
+    const { calls } = installFetchMock(() => jsonResponse({ records: [] }));
+    const c = getAirtableConnector();
+    await c.listRecords("appXYZ", "Tasks");
+    expect(calls[0]!.url).toContain("maxRecords=100");
+  });
+
+  it("encodes baseId and table name with special chars", async () => {
+    process.env.AIRTABLE_ACCESS_TOKEN = "pat_test_abc";
+    const { getAirtableConnector } = await import("../airtable.js");
+    const { calls } = installFetchMock(() => jsonResponse({ records: [] }));
+    const c = getAirtableConnector();
+    await c.listRecords("appXYZ", "My Table/With Slash");
+    expect(calls[0]!.url).toContain("My%20Table%2FWith%20Slash");
+  });
+
+  it("serialises sort and fields params", async () => {
+    process.env.AIRTABLE_ACCESS_TOKEN = "pat_test_abc";
+    const { getAirtableConnector } = await import("../airtable.js");
+    const { calls } = installFetchMock(() => jsonResponse({ records: [] }));
+    const c = getAirtableConnector();
+    await c.listRecords("appXYZ", "Tasks", {
+      sort: [{ field: "Name", direction: "desc" }],
+      fields: ["Name", "Status"],
+      view: "Grid view",
+    });
+    const url = calls[0]!.url;
+    expect(url).toMatch(/sort%5B0%5D%5Bfield%5D=Name/);
+    expect(url).toMatch(/sort%5B0%5D%5Bdirection%5D=desc/);
+    expect(url).toMatch(/fields%5B%5D=Name/);
+    expect(url).toMatch(/fields%5B%5D=Status/);
+    expect(url).toMatch(/view=Grid\+view|view=Grid%20view/);
+  });
+});
+
+// ── createRecord wraps fields in records array ─────────────────────────────
+
+describe("createRecord", () => {
+  it("POSTs JSON with { records: [{ fields }] } shape", async () => {
+    process.env.AIRTABLE_ACCESS_TOKEN = "pat_test_abc";
+    const { getAirtableConnector } = await import("../airtable.js");
+
+    const { calls } = installFetchMock(() =>
+      jsonResponse({
+        records: [
+          {
+            id: "recNEW1",
+            createdTime: "2026-01-01T00:00:00.000Z",
+            fields: { Name: "Hello" },
+          },
+        ],
+      }),
+    );
+
+    const c = getAirtableConnector();
+    const out = await c.createRecord("appXYZ", "Tasks", { Name: "Hello" });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.init?.method).toBe("POST");
+    const body = JSON.parse(String(calls[0]!.init?.body));
+    expect(body).toEqual({ records: [{ fields: { Name: "Hello" } }] });
+    const headers = calls[0]!.init?.headers as Record<string, string>;
+    expect(headers["Content-Type"]).toBe("application/json");
+    expect(headers.Authorization).toBe("Bearer pat_test_abc");
+    expect(out.id).toBe("recNEW1");
+  });
+
+  it("throws when Airtable returns empty records array", async () => {
+    process.env.AIRTABLE_ACCESS_TOKEN = "pat_test_abc";
+    const { getAirtableConnector } = await import("../airtable.js");
+    installFetchMock(() => jsonResponse({ records: [] }));
+    const c = getAirtableConnector();
+    await expect(c.createRecord("appXYZ", "Tasks", {})).rejects.toThrow(
+      /no record/i,
+    );
+  });
+});
+
+// ── updateRecord ───────────────────────────────────────────────────────────
+
+describe("updateRecord", () => {
+  it("PATCHes with { fields } body (no records wrapper)", async () => {
+    process.env.AIRTABLE_ACCESS_TOKEN = "pat_test_abc";
+    const { getAirtableConnector } = await import("../airtable.js");
+    const { calls } = installFetchMock(() =>
+      jsonResponse({
+        id: "rec1",
+        createdTime: "2026-01-01T00:00:00.000Z",
+        fields: { Status: "Done" },
+      }),
+    );
+    const c = getAirtableConnector();
+    const out = await c.updateRecord("appXYZ", "Tasks", "rec1", {
+      Status: "Done",
+    });
+    expect(calls[0]!.init?.method).toBe("PATCH");
+    const body = JSON.parse(String(calls[0]!.init?.body));
+    expect(body).toEqual({ fields: { Status: "Done" } });
+    expect(out.fields.Status).toBe("Done");
+  });
+});
+
+// ── Connect handler captures user id + email ───────────────────────────────
+
+describe("handleAirtableConnect", () => {
+  it("rejects invalid JSON", async () => {
+    const { handleAirtableConnect } = await import("../airtable.js");
+    const r = await handleAirtableConnect("not json");
+    expect(r.status).toBe(400);
+    expect(r.body).toMatch(/Invalid JSON/);
+  });
+
+  it("requires accessToken field", async () => {
+    const { handleAirtableConnect } = await import("../airtable.js");
+    const r = await handleAirtableConnect(JSON.stringify({}));
+    expect(r.status).toBe(400);
+    expect(r.body).toMatch(/accessToken is required/);
+  });
+
+  it("validates via /v0/meta/whoami and captures user id + email", async () => {
+    const { handleAirtableConnect, loadTokens } = await import(
+      "../airtable.js"
+    );
+
+    const { calls } = installFetchMock(() =>
+      jsonResponse({ id: "usrAAA", email: "user@example.com" }),
+    );
+
+    const r = await handleAirtableConnect(
+      JSON.stringify({ accessToken: "patABC123" }),
+    );
+
+    expect(r.status).toBe(200);
+    expect(calls[0]!.url).toBe("https://api.airtable.com/v0/meta/whoami");
+    const headers = calls[0]!.init?.headers as Record<string, string>;
+    expect(headers.Authorization).toBe("Bearer patABC123");
+
+    const body = JSON.parse(r.body) as {
+      ok: boolean;
+      userId?: string;
+      email?: string;
+    };
+    expect(body.ok).toBe(true);
+    expect(body.userId).toBe("usrAAA");
+    expect(body.email).toBe("user@example.com");
+
+    const stored = loadTokens();
+    expect(stored?.userId).toBe("usrAAA");
+    expect(stored?.email).toBe("user@example.com");
+    expect(stored?.accessToken).toBe("patABC123");
+  });
+
+  it("captures user id when email scope absent", async () => {
+    const { handleAirtableConnect, loadTokens } = await import(
+      "../airtable.js"
+    );
+    installFetchMock(() => jsonResponse({ id: "usrBBB" })); // no email
+    const r = await handleAirtableConnect(
+      JSON.stringify({ accessToken: "patXYZ" }),
+    );
+    expect(r.status).toBe(200);
+    const stored = loadTokens();
+    expect(stored?.userId).toBe("usrBBB");
+    expect(stored?.email).toBeUndefined();
+  });
+
+  it("returns 401 when Airtable rejects token, without persisting", async () => {
+    const { handleAirtableConnect, loadTokens } = await import(
+      "../airtable.js"
+    );
+    installFetchMock(() => new Response("nope", { status: 401 }));
+    const r = await handleAirtableConnect(
+      JSON.stringify({ accessToken: "patBAD" }),
+    );
+    expect(r.status).toBe(401);
+    expect(loadTokens()).toBeNull();
+  });
+});
+
+// ── Disconnect ─────────────────────────────────────────────────────────────
+
+describe("handleAirtableDisconnect", () => {
+  it("clears stored tokens", async () => {
+    const { handleAirtableDisconnect, saveTokens, loadTokens } = await import(
+      "../airtable.js"
+    );
+    saveTokens({
+      accessToken: "patABC",
+      connected_at: new Date().toISOString(),
+    });
+    expect(loadTokens()).not.toBeNull();
+    const r = handleAirtableDisconnect();
+    expect(r.status).toBe(200);
+    expect(loadTokens()).toBeNull();
+  });
+});
+
+// ── getStatus ──────────────────────────────────────────────────────────────
+
+describe("getStatus", () => {
+  it("returns disconnected when no tokens", async () => {
+    const { getAirtableConnector } = await import("../airtable.js");
+    const s = getAirtableConnector().getStatus();
+    expect(s.status).toBe("disconnected");
+  });
+
+  it("returns connected + workspace label from email", async () => {
+    const { getAirtableConnector, saveTokens } = await import("../airtable.js");
+    saveTokens({
+      accessToken: "patABC",
+      userId: "usrAAA",
+      email: "u@x.com",
+      connected_at: new Date().toISOString(),
+    });
+    const s = getAirtableConnector().getStatus();
+    expect(s.status).toBe("connected");
+    expect(s.workspace).toContain("u@x.com");
+  });
+});

--- a/src/connectors/__tests__/figma.test.ts
+++ b/src/connectors/__tests__/figma.test.ts
@@ -1,0 +1,350 @@
+import { existsSync, mkdirSync, rmSync } from "node:fs";
+import os from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ── Test harness ────────────────────────────────────────────────────────────
+
+const tmpDir = join(os.tmpdir(), `patchwork-figma-${Date.now()}`);
+const homeDir = join(tmpDir, "home");
+const patchworkHome = join(homeDir, ".patchwork");
+const tokensDir = join(patchworkHome, "tokens");
+
+const originalFetch = globalThis.fetch;
+
+function mockFetch(handler: (url: string, init?: RequestInit) => Response) {
+  const fn = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.toString();
+    return handler(url, init);
+  });
+  // biome-ignore lint/suspicious/noExplicitAny: test seam
+  globalThis.fetch = fn as any;
+  return fn;
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+beforeEach(() => {
+  process.env.HOME = homeDir;
+  process.env.PATCHWORK_HOME = patchworkHome;
+  process.env.PATCHWORK_TOKEN_STORAGE_BACKEND = "file";
+  delete process.env.FIGMA_ACCESS_TOKEN;
+  mkdirSync(tokensDir, { recursive: true });
+  vi.resetModules();
+});
+
+afterEach(() => {
+  delete process.env.HOME;
+  delete process.env.PATCHWORK_HOME;
+  delete process.env.PATCHWORK_TOKEN_STORAGE_BACKEND;
+  delete process.env.FIGMA_ACCESS_TOKEN;
+  globalThis.fetch = originalFetch;
+  if (existsSync(tmpDir)) {
+    rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+// ── normalizeError ──────────────────────────────────────────────────────────
+
+describe("normalizeError", () => {
+  it("maps 401 to auth_expired", async () => {
+    const { FigmaConnector } = await import("../figma.js");
+    const c = new FigmaConnector();
+    const res = new Response("", { status: 401 });
+    const err = c.normalizeError(res);
+    expect(err.code).toBe("auth_expired");
+    expect(err.retryable).toBe(false);
+  });
+
+  it("maps 403 to auth_expired (Figma quirk)", async () => {
+    const { FigmaConnector } = await import("../figma.js");
+    const c = new FigmaConnector();
+    const res = new Response("", { status: 403 });
+    const err = c.normalizeError(res);
+    expect(err.code).toBe("auth_expired");
+    expect(err.retryable).toBe(false);
+  });
+
+  it("maps 404 to not_found", async () => {
+    const { FigmaConnector } = await import("../figma.js");
+    const c = new FigmaConnector();
+    expect(c.normalizeError(new Response("", { status: 404 })).code).toBe(
+      "not_found",
+    );
+  });
+
+  it("maps 429 to rate_limited (retryable)", async () => {
+    const { FigmaConnector } = await import("../figma.js");
+    const c = new FigmaConnector();
+    const err = c.normalizeError(new Response("", { status: 429 }));
+    expect(err.code).toBe("rate_limited");
+    expect(err.retryable).toBe(true);
+  });
+
+  it("maps 5xx to provider_error retryable", async () => {
+    const { FigmaConnector } = await import("../figma.js");
+    const c = new FigmaConnector();
+    const err = c.normalizeError(new Response("", { status: 503 }));
+    expect(err.code).toBe("provider_error");
+    expect(err.retryable).toBe(true);
+  });
+
+  it("maps non-retryable 4xx other to provider_error", async () => {
+    const { FigmaConnector } = await import("../figma.js");
+    const c = new FigmaConnector();
+    const err = c.normalizeError(new Response("", { status: 418 }));
+    expect(err.code).toBe("provider_error");
+    expect(err.retryable).toBe(false);
+  });
+
+  it("detects ENOTFOUND/ECONNREFUSED as network_error", async () => {
+    const { FigmaConnector } = await import("../figma.js");
+    const c = new FigmaConnector();
+    expect(
+      c.normalizeError(new Error("getaddrinfo ENOTFOUND api.figma.com")).code,
+    ).toBe("network_error");
+    expect(c.normalizeError(new Error("connect ECONNREFUSED")).code).toBe(
+      "network_error",
+    );
+  });
+
+  it("defaults to provider_error for unknown errors", async () => {
+    const { FigmaConnector } = await import("../figma.js");
+    const c = new FigmaConnector();
+    expect(c.normalizeError(new Error("boom")).code).toBe("provider_error");
+    expect(c.normalizeError("something").code).toBe("provider_error");
+  });
+});
+
+// ── getFile depth param ─────────────────────────────────────────────────────
+
+describe("getFile", () => {
+  it("applies default depth=2 query param", async () => {
+    process.env.FIGMA_ACCESS_TOKEN = "figd_test";
+    const fetchSpy = mockFetch(() =>
+      jsonResponse({
+        name: "f",
+        lastModified: "x",
+        version: "1",
+        document: {},
+      }),
+    );
+    const { getFigmaConnector } = await import("../figma.js");
+    const c = getFigmaConnector();
+    await c.getFile("ABC123");
+    const url = fetchSpy.mock.calls[0]![0] as string;
+    expect(url).toContain("/v1/files/ABC123");
+    expect(url).toContain("depth=2");
+  });
+
+  it("respects explicit depth and geometry", async () => {
+    process.env.FIGMA_ACCESS_TOKEN = "figd_test";
+    const fetchSpy = mockFetch(() =>
+      jsonResponse({
+        name: "f",
+        lastModified: "x",
+        version: "1",
+        document: {},
+      }),
+    );
+    const { getFigmaConnector } = await import("../figma.js");
+    const c = getFigmaConnector();
+    await c.getFile("KEY", { depth: 5, geometry: "paths" });
+    const url = fetchSpy.mock.calls[0]![0] as string;
+    expect(url).toContain("depth=5");
+    expect(url).toContain("geometry=paths");
+  });
+
+  it("rejects empty fileKey", async () => {
+    const { getFigmaConnector } = await import("../figma.js");
+    process.env.FIGMA_ACCESS_TOKEN = "figd_test";
+    const c = getFigmaConnector();
+    await expect(c.getFile("")).rejects.toThrow(/fileKey/);
+  });
+});
+
+// ── getImageUrls validation ─────────────────────────────────────────────────
+
+describe("getImageUrls", () => {
+  it("rejects empty ids array", async () => {
+    process.env.FIGMA_ACCESS_TOKEN = "figd_test";
+    const { getFigmaConnector } = await import("../figma.js");
+    const c = getFigmaConnector();
+    await expect(c.getImageUrls("KEY", { ids: [] })).rejects.toThrow(
+      /non-empty/,
+    );
+  });
+
+  it("rejects invalid format", async () => {
+    process.env.FIGMA_ACCESS_TOKEN = "figd_test";
+    const { getFigmaConnector } = await import("../figma.js");
+    const c = getFigmaConnector();
+    await expect(
+      // @ts-expect-error — testing runtime guard
+      c.getImageUrls("KEY", { ids: ["1:2"], format: "gif" }),
+    ).rejects.toThrow(/Invalid format/);
+  });
+
+  it("accepts png, jpg, svg, pdf", async () => {
+    process.env.FIGMA_ACCESS_TOKEN = "figd_test";
+    const fetchSpy = mockFetch(() =>
+      jsonResponse({ err: null, images: { "1:2": "https://s3/x" } }),
+    );
+    const { getFigmaConnector } = await import("../figma.js");
+    const c = getFigmaConnector();
+    for (const format of ["png", "jpg", "svg", "pdf"] as const) {
+      await c.getImageUrls("KEY", { ids: ["1:2"], format });
+    }
+    expect(fetchSpy).toHaveBeenCalledTimes(4);
+    const urls = fetchSpy.mock.calls.map((call) => call[0] as string);
+    expect(urls[0]).toContain("format=png");
+    expect(urls[1]).toContain("format=jpg");
+    expect(urls[2]).toContain("format=svg");
+    expect(urls[3]).toContain("format=pdf");
+  });
+
+  it("joins ids with comma and applies scale", async () => {
+    process.env.FIGMA_ACCESS_TOKEN = "figd_test";
+    const fetchSpy = mockFetch(() => jsonResponse({ err: null, images: {} }));
+    const { getFigmaConnector } = await import("../figma.js");
+    const c = getFigmaConnector();
+    await c.getImageUrls("KEY", { ids: ["1:2", "3:4"], scale: 2 });
+    const url = fetchSpy.mock.calls[0]![0] as string;
+    expect(url).toContain("ids=1%3A2%2C3%3A4");
+    expect(url).toContain("scale=2");
+  });
+});
+
+// ── getFileNodes ────────────────────────────────────────────────────────────
+
+describe("getFileNodes", () => {
+  it("rejects empty nodeIds", async () => {
+    process.env.FIGMA_ACCESS_TOKEN = "figd_test";
+    const { getFigmaConnector } = await import("../figma.js");
+    const c = getFigmaConnector();
+    await expect(c.getFileNodes("KEY", [])).rejects.toThrow(/non-empty/);
+  });
+
+  it("joins ids in query string", async () => {
+    process.env.FIGMA_ACCESS_TOKEN = "figd_test";
+    const fetchSpy = mockFetch(() =>
+      jsonResponse({ name: "f", lastModified: "x", version: "1", nodes: {} }),
+    );
+    const { getFigmaConnector } = await import("../figma.js");
+    const c = getFigmaConnector();
+    await c.getFileNodes("KEY", ["1:2", "3:4"]);
+    const url = fetchSpy.mock.calls[0]![0] as string;
+    expect(url).toContain("/nodes?");
+    expect(url).toContain("ids=1%3A2%2C3%3A4");
+  });
+});
+
+// ── Auth header ─────────────────────────────────────────────────────────────
+
+describe("X-Figma-Token header", () => {
+  it("sends the token from FIGMA_ACCESS_TOKEN env", async () => {
+    process.env.FIGMA_ACCESS_TOKEN = "figd_abcdef";
+    const fetchSpy = mockFetch(() =>
+      jsonResponse({ id: "u1", handle: "alice" }),
+    );
+    const { getFigmaConnector } = await import("../figma.js");
+    const c = getFigmaConnector();
+    await c.getMe();
+    const init = fetchSpy.mock.calls[0]![1] as RequestInit;
+    const headers = init.headers as Record<string, string>;
+    expect(headers["X-Figma-Token"]).toBe("figd_abcdef");
+  });
+});
+
+// ── HTTP connect handler ────────────────────────────────────────────────────
+
+describe("handleFigmaConnect", () => {
+  it("rejects invalid JSON", async () => {
+    const { handleFigmaConnect } = await import("../figma.js");
+    const r = await handleFigmaConnect("not json");
+    expect(r.status).toBe(400);
+    expect(r.body).toMatch(/Invalid JSON/);
+  });
+
+  it("requires accessToken", async () => {
+    const { handleFigmaConnect } = await import("../figma.js");
+    const r = await handleFigmaConnect(JSON.stringify({}));
+    expect(r.status).toBe(400);
+    expect(r.body).toMatch(/accessToken/);
+  });
+
+  it("validates via /v1/me + stores tokens", async () => {
+    mockFetch(() =>
+      jsonResponse({ id: "u1", handle: "alice", email: "a@x.io" }),
+    );
+    const { handleFigmaConnect, loadTokens } = await import("../figma.js");
+    const r = await handleFigmaConnect(
+      JSON.stringify({ accessToken: "figd_xyz" }),
+    );
+    expect(r.status).toBe(200);
+    const parsed = JSON.parse(r.body);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.userHandle).toBe("alice");
+    expect(parsed.email).toBe("a@x.io");
+    const tokens = loadTokens();
+    expect(tokens?.userHandle).toBe("alice");
+    expect(tokens?.accessToken).toBe("figd_xyz");
+  });
+
+  it("returns 401 on auth failure without storing tokens", async () => {
+    mockFetch(() => new Response("forbidden", { status: 403 }));
+    const { handleFigmaConnect, loadTokens } = await import("../figma.js");
+    const r = await handleFigmaConnect(
+      JSON.stringify({ accessToken: "figd_bad" }),
+    );
+    expect(r.status).toBe(401);
+    expect(loadTokens()).toBeNull();
+  });
+});
+
+// ── Disconnect ──────────────────────────────────────────────────────────────
+
+describe("handleFigmaDisconnect", () => {
+  it("clears stored tokens", async () => {
+    const { handleFigmaDisconnect, saveTokens, loadTokens } = await import(
+      "../figma.js"
+    );
+    saveTokens({
+      accessToken: "figd_x",
+      connected_at: new Date().toISOString(),
+    });
+    expect(loadTokens()).not.toBeNull();
+    const r = handleFigmaDisconnect();
+    expect(r.status).toBe(200);
+    expect(loadTokens()).toBeNull();
+  });
+});
+
+// ── getStatus ───────────────────────────────────────────────────────────────
+
+describe("getStatus", () => {
+  it("reports disconnected when no tokens", async () => {
+    const { getFigmaConnector } = await import("../figma.js");
+    const c = getFigmaConnector();
+    const status = c.getStatus();
+    expect(status.status).toBe("disconnected");
+  });
+
+  it("reports connected with handle from stored tokens", async () => {
+    const { getFigmaConnector, saveTokens } = await import("../figma.js");
+    saveTokens({
+      accessToken: "figd_stored",
+      userHandle: "bob",
+      connected_at: new Date().toISOString(),
+    });
+    const c = getFigmaConnector();
+    const status = c.getStatus();
+    expect(status.status).toBe("connected");
+    expect(status.workspace).toContain("bob");
+  });
+});

--- a/src/connectors/__tests__/sendgrid.test.ts
+++ b/src/connectors/__tests__/sendgrid.test.ts
@@ -1,0 +1,323 @@
+import { existsSync, mkdirSync, rmSync } from "node:fs";
+import os from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ── Fake fetch helpers ──────────────────────────────────────────────────────
+
+type FetchCall = { url: string; init?: RequestInit };
+
+function mockFetchResponse(opts: {
+  status?: number;
+  body?: unknown;
+  headers?: Record<string, string>;
+}): Response {
+  const status = opts.status ?? 200;
+  const headers = new Headers(opts.headers ?? {});
+  const bodyStr =
+    opts.body === undefined
+      ? ""
+      : typeof opts.body === "string"
+        ? opts.body
+        : JSON.stringify(opts.body);
+  return new Response(bodyStr, { status, headers });
+}
+
+function installFetchMock(
+  handler: (url: string, init?: RequestInit) => Response | Promise<Response>,
+): { calls: FetchCall[] } {
+  const calls: FetchCall[] = [];
+  const fn = vi.fn(async (url: string, init?: RequestInit) => {
+    calls.push({ url, init });
+    return handler(url, init);
+  });
+  // Cast — Node global fetch type.
+  (globalThis as unknown as { fetch: typeof fetch }).fetch =
+    fn as unknown as typeof fetch;
+  return { calls };
+}
+
+// ── Test harness ────────────────────────────────────────────────────────────
+
+const tmpDir = join(os.tmpdir(), `patchwork-sendgrid-${Date.now()}`);
+const homeDir = join(tmpDir, "home");
+const patchworkHome = join(homeDir, ".patchwork");
+const tokensDir = join(patchworkHome, "tokens");
+
+const originalFetch = globalThis.fetch;
+
+beforeEach(() => {
+  process.env.HOME = homeDir;
+  process.env.PATCHWORK_HOME = patchworkHome;
+  process.env.PATCHWORK_TOKEN_STORAGE_BACKEND = "file";
+  delete process.env.SENDGRID_API_KEY;
+  delete process.env.SENDGRID_FROM_EMAIL;
+  mkdirSync(tokensDir, { recursive: true });
+  vi.resetModules();
+});
+
+afterEach(() => {
+  delete process.env.HOME;
+  delete process.env.PATCHWORK_HOME;
+  delete process.env.PATCHWORK_TOKEN_STORAGE_BACKEND;
+  delete process.env.SENDGRID_API_KEY;
+  delete process.env.SENDGRID_FROM_EMAIL;
+  (globalThis as unknown as { fetch: typeof fetch }).fetch = originalFetch;
+  if (existsSync(tmpDir)) {
+    rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+// ── normalizeError status mapping ───────────────────────────────────────────
+
+describe("normalizeError", () => {
+  it("maps 401 → auth_expired", async () => {
+    const { SendGridConnector } = await import("../sendgrid.js");
+    const c = new SendGridConnector();
+    const err = c.normalizeError(new Response("", { status: 401 }));
+    expect(err.code).toBe("auth_expired");
+    expect(err.retryable).toBe(false);
+  });
+
+  it("maps 403 → permission_denied", async () => {
+    const { SendGridConnector } = await import("../sendgrid.js");
+    const c = new SendGridConnector();
+    expect(c.normalizeError(new Response("", { status: 403 })).code).toBe(
+      "permission_denied",
+    );
+  });
+
+  it("maps 404 → not_found", async () => {
+    const { SendGridConnector } = await import("../sendgrid.js");
+    const c = new SendGridConnector();
+    expect(c.normalizeError(new Response("", { status: 404 })).code).toBe(
+      "not_found",
+    );
+  });
+
+  it("maps 413 → provider_error (payload too large)", async () => {
+    const { SendGridConnector } = await import("../sendgrid.js");
+    const c = new SendGridConnector();
+    const e = c.normalizeError(new Response("", { status: 413 }));
+    expect(e.code).toBe("provider_error");
+    expect(e.message).toMatch(/too large/i);
+    expect(e.retryable).toBe(false);
+  });
+
+  it("maps 429 → rate_limited retryable", async () => {
+    const { SendGridConnector } = await import("../sendgrid.js");
+    const c = new SendGridConnector();
+    const e = c.normalizeError(new Response("", { status: 429 }));
+    expect(e.code).toBe("rate_limited");
+    expect(e.retryable).toBe(true);
+  });
+
+  it("maps 5xx → provider_error retryable", async () => {
+    const { SendGridConnector } = await import("../sendgrid.js");
+    const c = new SendGridConnector();
+    const e = c.normalizeError(new Response("", { status: 503 }));
+    expect(e.code).toBe("provider_error");
+    expect(e.retryable).toBe(true);
+  });
+
+  it("maps unexpected 4xx → provider_error non-retryable", async () => {
+    const { SendGridConnector } = await import("../sendgrid.js");
+    const c = new SendGridConnector();
+    const e = c.normalizeError(new Response("", { status: 418 }));
+    expect(e.code).toBe("provider_error");
+    expect(e.retryable).toBe(false);
+  });
+
+  it("detects ENOTFOUND/ECONNREFUSED as network_error", async () => {
+    const { SendGridConnector } = await import("../sendgrid.js");
+    const c = new SendGridConnector();
+    expect(
+      c.normalizeError(new Error("getaddrinfo ENOTFOUND api.sendgrid.com"))
+        .code,
+    ).toBe("network_error");
+    expect(c.normalizeError(new Error("connect ECONNREFUSED")).code).toBe(
+      "network_error",
+    );
+  });
+
+  it("defaults to provider_error", async () => {
+    const { SendGridConnector } = await import("../sendgrid.js");
+    const c = new SendGridConnector();
+    expect(c.normalizeError(new Error("boom")).code).toBe("provider_error");
+    expect(c.normalizeError("string err").code).toBe("provider_error");
+  });
+});
+
+// ── send() validation ───────────────────────────────────────────────────────
+
+describe("send()", () => {
+  it("rejects missing/invalid `to`", async () => {
+    const { getSendGridConnector, saveTokens } = await import("../sendgrid.js");
+    saveTokens({
+      apiKey: "SG.test",
+      fromEmail: "from@example.com",
+      connected_at: new Date().toISOString(),
+    });
+    const c = getSendGridConnector();
+    await expect(
+      c.send({ to: "not-an-email", subject: "hi", text: "x" }),
+    ).rejects.toThrow(/valid email/i);
+  });
+
+  it("rejects missing subject", async () => {
+    const { getSendGridConnector, saveTokens } = await import("../sendgrid.js");
+    saveTokens({
+      apiKey: "SG.test",
+      fromEmail: "from@example.com",
+      connected_at: new Date().toISOString(),
+    });
+    const c = getSendGridConnector();
+    await expect(
+      c.send({ to: "a@b.com", subject: "  ", text: "x" }),
+    ).rejects.toThrow(/subject/i);
+  });
+
+  it("rejects when neither text nor html provided", async () => {
+    const { getSendGridConnector, saveTokens } = await import("../sendgrid.js");
+    saveTokens({
+      apiKey: "SG.test",
+      fromEmail: "from@example.com",
+      connected_at: new Date().toISOString(),
+    });
+    const c = getSendGridConnector();
+    await expect(c.send({ to: "a@b.com", subject: "hi" })).rejects.toThrow(
+      /text.*html/i,
+    );
+  });
+
+  it("rejects when no `from` and no stored fromEmail", async () => {
+    const { getSendGridConnector, saveTokens } = await import("../sendgrid.js");
+    saveTokens({
+      apiKey: "SG.test",
+      // no fromEmail
+      connected_at: new Date().toISOString(),
+    });
+    const c = getSendGridConnector();
+    await expect(
+      c.send({ to: "a@b.com", subject: "hi", text: "x" }),
+    ).rejects.toThrow(/from/i);
+  });
+
+  it("happy path: POSTs to /v3/mail/send and returns message id", async () => {
+    const { getSendGridConnector, saveTokens } = await import("../sendgrid.js");
+    saveTokens({
+      apiKey: "SG.test",
+      fromEmail: "from@example.com",
+      connected_at: new Date().toISOString(),
+    });
+    const { calls } = installFetchMock(() =>
+      mockFetchResponse({
+        status: 202,
+        headers: { "x-message-id": "msg-abc-123" },
+      }),
+    );
+    const c = getSendGridConnector();
+    // Force authenticate first so apiCall has an auth context.
+    await c["authenticate"]();
+    const result = await c.send({
+      to: "a@b.com",
+      subject: "hi",
+      text: "hello",
+    });
+    expect(result.messageId).toBe("msg-abc-123");
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.url).toBe("https://api.sendgrid.com/v3/mail/send");
+    expect(calls[0]!.init?.method).toBe("POST");
+    const headers = calls[0]!.init?.headers as Record<string, string>;
+    expect(headers.Authorization).toBe("Bearer SG.test");
+    const body = JSON.parse(calls[0]!.init?.body as string);
+    expect(body.from.email).toBe("from@example.com");
+    expect(body.personalizations[0].to[0].email).toBe("a@b.com");
+    expect(body.subject).toBe("hi");
+    expect(body.content[0]).toEqual({ type: "text/plain", value: "hello" });
+  });
+});
+
+// ── HTTP connect handler ────────────────────────────────────────────────────
+
+describe("handleSendGridConnect", () => {
+  it("rejects invalid JSON", async () => {
+    const { handleSendGridConnect } = await import("../sendgrid.js");
+    const r = await handleSendGridConnect("not json");
+    expect(r.status).toBe(400);
+    expect(r.body).toMatch(/Invalid JSON/);
+  });
+
+  it("requires apiKey", async () => {
+    const { handleSendGridConnect } = await import("../sendgrid.js");
+    const r = await handleSendGridConnect(JSON.stringify({}));
+    expect(r.status).toBe(400);
+    expect(r.body).toMatch(/apiKey/);
+  });
+
+  it("rejects malformed fromEmail", async () => {
+    const { handleSendGridConnect } = await import("../sendgrid.js");
+    const r = await handleSendGridConnect(
+      JSON.stringify({ apiKey: "SG.test", fromEmail: "nope" }),
+    );
+    expect(r.status).toBe(400);
+    expect(r.body).toMatch(/fromEmail/);
+  });
+
+  it("validates by GET /v3/user/profile, captures username", async () => {
+    const { handleSendGridConnect, loadTokens } = await import(
+      "../sendgrid.js"
+    );
+    const { calls } = installFetchMock(() =>
+      mockFetchResponse({
+        status: 200,
+        body: { username: "acme-co", email: "ops@acme.test" },
+      }),
+    );
+    const r = await handleSendGridConnect(
+      JSON.stringify({ apiKey: "SG.test", fromEmail: "from@acme.test" }),
+    );
+    expect(r.status).toBe(200);
+    expect(calls[0]!.url).toBe("https://api.sendgrid.com/v3/user/profile");
+    const headers = calls[0]!.init?.headers as Record<string, string>;
+    expect(headers.Authorization).toBe("Bearer SG.test");
+    const tokens = loadTokens();
+    expect(tokens?.apiKey).toBe("SG.test");
+    expect(tokens?.accountName).toBe("acme-co");
+    expect(tokens?.fromEmail).toBe("from@acme.test");
+  });
+
+  it("returns 401 on profile fetch failure without storing tokens", async () => {
+    const { handleSendGridConnect, loadTokens } = await import(
+      "../sendgrid.js"
+    );
+    installFetchMock(() => mockFetchResponse({ status: 401 }));
+    const r = await handleSendGridConnect(JSON.stringify({ apiKey: "SG.bad" }));
+    expect(r.status).toBe(401);
+    expect(loadTokens()).toBeNull();
+  });
+});
+
+// ── getStatus ───────────────────────────────────────────────────────────────
+
+describe("getStatus", () => {
+  it("reports disconnected when no tokens", async () => {
+    const { SendGridConnector } = await import("../sendgrid.js");
+    const c = new SendGridConnector();
+    expect(c.getStatus().status).toBe("disconnected");
+  });
+
+  it("reports connected when tokens stored", async () => {
+    const { SendGridConnector, saveTokens } = await import("../sendgrid.js");
+    saveTokens({
+      apiKey: "SG.x",
+      fromEmail: "f@x.com",
+      accountName: "acme",
+      connected_at: new Date().toISOString(),
+    });
+    const c = new SendGridConnector();
+    const status = c.getStatus();
+    expect(status.status).toBe("connected");
+    expect(status.workspace).toMatch(/acme/);
+  });
+});

--- a/src/connectors/__tests__/twilio.test.ts
+++ b/src/connectors/__tests__/twilio.test.ts
@@ -186,8 +186,8 @@ describe("sendSms", () => {
     });
     const c = getTwilioConnector();
     await c.sendSms({ to: "+14155551234", body: "hi" });
-    const call = fetchMock.mock.calls[0]!;
-    const init = call[1] as RequestInit;
+    const call = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+    const init = call[1];
     expect(String(init.body)).toContain("From=%2B14155550100");
     expect(String(init.body)).toContain("To=%2B14155551234");
     expect(String(init.body)).toContain("Body=hi");
@@ -221,7 +221,7 @@ describe("listMessages", () => {
       dateSent: "2026-01-01",
       limit: 50,
     });
-    const url = fetchMock.mock.calls[0]![0] as string;
+    const url = (fetchMock.mock.calls[0] as unknown as [string])[0];
     expect(url).toContain("PageSize=50");
     expect(url).toContain("To=%2B14155551234");
     expect(url).toContain("From=%2B14155550100");
@@ -239,7 +239,7 @@ describe("listMessages", () => {
     });
     const c = getTwilioConnector();
     await c.listMessages();
-    const url = fetchMock.mock.calls[0]![0] as string;
+    const url = (fetchMock.mock.calls[0] as unknown as [string])[0];
     expect(url).toContain("PageSize=20");
   });
 });

--- a/src/connectors/__tests__/twilio.test.ts
+++ b/src/connectors/__tests__/twilio.test.ts
@@ -1,0 +1,348 @@
+import { existsSync, mkdirSync, rmSync } from "node:fs";
+import os from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const tmpDir = join(os.tmpdir(), `patchwork-twilio-${Date.now()}`);
+const homeDir = join(tmpDir, "home");
+const patchworkHome = join(homeDir, ".patchwork");
+const tokensDir = join(patchworkHome, "tokens");
+
+const ACCOUNT_SID = "ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
+const AUTH_TOKEN = "secret-auth-token";
+
+beforeEach(() => {
+  process.env.HOME = homeDir;
+  process.env.PATCHWORK_HOME = patchworkHome;
+  process.env.PATCHWORK_TOKEN_STORAGE_BACKEND = "file";
+  delete process.env.TWILIO_ACCOUNT_SID;
+  delete process.env.TWILIO_AUTH_TOKEN;
+  delete process.env.TWILIO_DEFAULT_FROM;
+  mkdirSync(tokensDir, { recursive: true });
+  vi.resetModules();
+  vi.restoreAllMocks();
+});
+
+afterEach(() => {
+  delete process.env.HOME;
+  delete process.env.PATCHWORK_HOME;
+  delete process.env.PATCHWORK_TOKEN_STORAGE_BACKEND;
+  delete process.env.TWILIO_ACCOUNT_SID;
+  delete process.env.TWILIO_AUTH_TOKEN;
+  delete process.env.TWILIO_DEFAULT_FROM;
+  if (existsSync(tmpDir)) {
+    rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+function mockFetchOnce(response: Partial<Response> & { json?: () => unknown }) {
+  const fn = vi.fn(async () =>
+    Object.assign(
+      {
+        ok: true,
+        status: 200,
+        json: async () => ({}),
+      },
+      response,
+    ),
+  );
+  // @ts-expect-error — global fetch mock
+  global.fetch = fn;
+  return fn;
+}
+
+function saveValidTokens(extra: Partial<Record<string, string>> = {}) {
+  return import("../twilio.js").then(({ saveTokens }) => {
+    saveTokens({
+      accountSid: ACCOUNT_SID,
+      authToken: AUTH_TOKEN,
+      defaultFrom: extra.defaultFrom,
+      connected_at: new Date().toISOString(),
+    });
+  });
+}
+
+// ── normalizeError ──────────────────────────────────────────────────────────
+
+describe("normalizeError", () => {
+  it("maps Response status codes to ConnectorError shapes", async () => {
+    const { TwilioConnector } = await import("../twilio.js");
+    const c = new TwilioConnector();
+    expect(c.normalizeError(new Response(null, { status: 401 })).code).toBe(
+      "auth_expired",
+    );
+    expect(c.normalizeError(new Response(null, { status: 403 })).code).toBe(
+      "permission_denied",
+    );
+    expect(c.normalizeError(new Response(null, { status: 404 })).code).toBe(
+      "not_found",
+    );
+    expect(c.normalizeError(new Response(null, { status: 429 })).code).toBe(
+      "rate_limited",
+    );
+    expect(c.normalizeError(new Response(null, { status: 500 })).code).toBe(
+      "provider_error",
+    );
+  });
+
+  it("marks 429 + 5xx retryable, 401/403/404 not retryable", async () => {
+    const { TwilioConnector } = await import("../twilio.js");
+    const c = new TwilioConnector();
+    expect(
+      c.normalizeError(new Response(null, { status: 429 })).retryable,
+    ).toBe(true);
+    expect(
+      c.normalizeError(new Response(null, { status: 503 })).retryable,
+    ).toBe(true);
+    expect(
+      c.normalizeError(new Response(null, { status: 401 })).retryable,
+    ).toBe(false);
+    expect(
+      c.normalizeError(new Response(null, { status: 404 })).retryable,
+    ).toBe(false);
+  });
+
+  it("extracts Twilio JSON {code, message} into provider_error text", async () => {
+    const { TwilioConnector } = await import("../twilio.js");
+    const c = new TwilioConnector();
+    const e = c.normalizeError({
+      code: 21211,
+      message: "Invalid 'To' Phone Number",
+      status: 400,
+    });
+    expect(e.code).toBe("provider_error");
+    expect(e.message).toContain("21211");
+    expect(e.message).toContain("Invalid 'To' Phone Number");
+  });
+
+  it("detects ENOTFOUND as network_error retryable", async () => {
+    const { TwilioConnector } = await import("../twilio.js");
+    const c = new TwilioConnector();
+    const e = c.normalizeError(
+      new Error("getaddrinfo ENOTFOUND api.twilio.com"),
+    );
+    expect(e.code).toBe("network_error");
+    expect(e.retryable).toBe(true);
+  });
+});
+
+// ── sendSms validation ──────────────────────────────────────────────────────
+
+describe("sendSms", () => {
+  it("rejects non-E.164 'to' numbers", async () => {
+    const { getTwilioConnector } = await import("../twilio.js");
+    await saveValidTokens({ defaultFrom: "+14155550100" });
+    const c = getTwilioConnector();
+    await expect(c.sendSms({ to: "5551234", body: "hi" })).rejects.toThrow(
+      /E\.164/,
+    );
+    await expect(c.sendSms({ to: "14155551234", body: "hi" })).rejects.toThrow(
+      /E\.164/,
+    );
+    await expect(c.sendSms({ to: "+1abc", body: "hi" })).rejects.toThrow(
+      /E\.164/,
+    );
+  });
+
+  it("accepts valid E.164 numbers", async () => {
+    const { getTwilioConnector } = await import("../twilio.js");
+    await saveValidTokens({ defaultFrom: "+14155550100" });
+    const fetchMock = mockFetchOnce({
+      ok: true,
+      status: 201,
+      json: async () => ({ sid: "SM123", to: "+14155551234" }),
+    });
+    const c = getTwilioConnector();
+    const result = await c.sendSms({ to: "+14155551234", body: "hi" });
+    expect(result.sid).toBe("SM123");
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
+  it("requires body", async () => {
+    const { getTwilioConnector } = await import("../twilio.js");
+    await saveValidTokens({ defaultFrom: "+14155550100" });
+    const c = getTwilioConnector();
+    await expect(c.sendSms({ to: "+14155551234", body: "" })).rejects.toThrow(
+      /body/,
+    );
+  });
+
+  it("throws when no 'from' provided and no defaultFrom", async () => {
+    const { getTwilioConnector } = await import("../twilio.js");
+    await saveValidTokens(); // no defaultFrom
+    const c = getTwilioConnector();
+    await expect(c.sendSms({ to: "+14155551234", body: "hi" })).rejects.toThrow(
+      /defaultFrom/,
+    );
+  });
+
+  it("uses stored defaultFrom when 'from' omitted", async () => {
+    const { getTwilioConnector } = await import("../twilio.js");
+    await saveValidTokens({ defaultFrom: "+14155550100" });
+    const fetchMock = mockFetchOnce({
+      ok: true,
+      status: 201,
+      json: async () => ({ sid: "SM999" }),
+    });
+    const c = getTwilioConnector();
+    await c.sendSms({ to: "+14155551234", body: "hi" });
+    const call = fetchMock.mock.calls[0]!;
+    const init = call[1] as RequestInit;
+    expect(String(init.body)).toContain("From=%2B14155550100");
+    expect(String(init.body)).toContain("To=%2B14155551234");
+    expect(String(init.body)).toContain("Body=hi");
+  });
+
+  it("rejects non-E.164 'from'", async () => {
+    const { getTwilioConnector } = await import("../twilio.js");
+    await saveValidTokens();
+    const c = getTwilioConnector();
+    await expect(
+      c.sendSms({ to: "+14155551234", body: "hi", from: "555-bad" }),
+    ).rejects.toThrow(/E\.164/);
+  });
+});
+
+// ── listMessages query params ───────────────────────────────────────────────
+
+describe("listMessages", () => {
+  it("builds correct query params with PageSize + filters", async () => {
+    const { getTwilioConnector } = await import("../twilio.js");
+    await saveValidTokens();
+    const fetchMock = mockFetchOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ messages: [], page: 0, page_size: 50 }),
+    });
+    const c = getTwilioConnector();
+    await c.listMessages({
+      to: "+14155551234",
+      from: "+14155550100",
+      dateSent: "2026-01-01",
+      limit: 50,
+    });
+    const url = fetchMock.mock.calls[0]![0] as string;
+    expect(url).toContain("PageSize=50");
+    expect(url).toContain("To=%2B14155551234");
+    expect(url).toContain("From=%2B14155550100");
+    expect(url).toContain("DateSent=2026-01-01");
+    expect(url).toContain(`/Accounts/${ACCOUNT_SID}/Messages.json`);
+  });
+
+  it("defaults PageSize to 20", async () => {
+    const { getTwilioConnector } = await import("../twilio.js");
+    await saveValidTokens();
+    const fetchMock = mockFetchOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ messages: [], page: 0, page_size: 20 }),
+    });
+    const c = getTwilioConnector();
+    await c.listMessages();
+    const url = fetchMock.mock.calls[0]![0] as string;
+    expect(url).toContain("PageSize=20");
+  });
+});
+
+// ── connect handler ─────────────────────────────────────────────────────────
+
+describe("handleTwilioConnect", () => {
+  it("rejects invalid JSON", async () => {
+    const { handleTwilioConnect } = await import("../twilio.js");
+    const r = await handleTwilioConnect("not json");
+    expect(r.status).toBe(400);
+    expect(r.body).toMatch(/Invalid JSON/);
+  });
+
+  it("requires accountSid + authToken", async () => {
+    const { handleTwilioConnect } = await import("../twilio.js");
+    const r1 = await handleTwilioConnect(JSON.stringify({}));
+    expect(r1.status).toBe(400);
+    const r2 = await handleTwilioConnect(
+      JSON.stringify({ accountSid: ACCOUNT_SID }),
+    );
+    expect(r2.status).toBe(400);
+    expect(r2.body).toMatch(/authToken/);
+  });
+
+  it("rejects accountSid that doesn't start with 'AC'", async () => {
+    const { handleTwilioConnect } = await import("../twilio.js");
+    const r = await handleTwilioConnect(
+      JSON.stringify({ accountSid: "XX123", authToken: AUTH_TOKEN }),
+    );
+    expect(r.status).toBe(400);
+    expect(r.body).toMatch(/AC/);
+  });
+
+  it("rejects non-E.164 defaultFrom", async () => {
+    const { handleTwilioConnect } = await import("../twilio.js");
+    const r = await handleTwilioConnect(
+      JSON.stringify({
+        accountSid: ACCOUNT_SID,
+        authToken: AUTH_TOKEN,
+        defaultFrom: "555-not-e164",
+      }),
+    );
+    expect(r.status).toBe(400);
+    expect(r.body).toMatch(/E\.164/);
+  });
+
+  it("captures friendly_name + sid on success and stores tokens", async () => {
+    mockFetchOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        sid: ACCOUNT_SID,
+        friendly_name: "Test Acme Account",
+      }),
+    });
+    const { handleTwilioConnect, loadTokens } = await import("../twilio.js");
+    const r = await handleTwilioConnect(
+      JSON.stringify({
+        accountSid: ACCOUNT_SID,
+        authToken: AUTH_TOKEN,
+        defaultFrom: "+14155550100",
+      }),
+    );
+    expect(r.status).toBe(200);
+    const parsed = JSON.parse(r.body) as {
+      ok: boolean;
+      friendlyName?: string;
+    };
+    expect(parsed.ok).toBe(true);
+    expect(parsed.friendlyName).toBe("Test Acme Account");
+    const tokens = loadTokens();
+    expect(tokens?.friendlyName).toBe("Test Acme Account");
+    expect(tokens?.defaultFrom).toBe("+14155550100");
+    expect(tokens?.accountSid).toBe(ACCOUNT_SID);
+  });
+
+  it("returns 401 on credentials rejected without storing tokens", async () => {
+    mockFetchOnce({
+      ok: false,
+      status: 401,
+      json: async () => ({ code: 20003, message: "Authenticate" }),
+    });
+    const { handleTwilioConnect, loadTokens } = await import("../twilio.js");
+    const r = await handleTwilioConnect(
+      JSON.stringify({ accountSid: ACCOUNT_SID, authToken: "wrong" }),
+    );
+    expect(r.status).toBe(401);
+    expect(loadTokens()).toBeNull();
+  });
+});
+
+// ── env override ────────────────────────────────────────────────────────────
+
+describe("env override", () => {
+  it("loadTokens reads from TWILIO_ACCOUNT_SID + TWILIO_AUTH_TOKEN", async () => {
+    process.env.TWILIO_ACCOUNT_SID = ACCOUNT_SID;
+    process.env.TWILIO_AUTH_TOKEN = AUTH_TOKEN;
+    process.env.TWILIO_DEFAULT_FROM = "+14155550100";
+    const { loadTokens } = await import("../twilio.js");
+    const t = loadTokens();
+    expect(t?.accountSid).toBe(ACCOUNT_SID);
+    expect(t?.authToken).toBe(AUTH_TOKEN);
+    expect(t?.defaultFrom).toBe("+14155550100");
+  });
+});

--- a/src/connectors/__tests__/webflow.test.ts
+++ b/src/connectors/__tests__/webflow.test.ts
@@ -1,0 +1,399 @@
+import { existsSync, mkdirSync, rmSync } from "node:fs";
+import os from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ── fetch mock helpers ──────────────────────────────────────────────────────
+
+type FetchCall = { url: string; init?: RequestInit };
+
+function mockFetch(
+  responder: (call: FetchCall) => {
+    status?: number;
+    body?: unknown;
+    ok?: boolean;
+  },
+): { calls: FetchCall[]; restore: () => void } {
+  const calls: FetchCall[] = [];
+  const original = globalThis.fetch;
+  globalThis.fetch = vi.fn(
+    async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      calls.push({ url, init });
+      const r = responder({ url, init });
+      const status = r.status ?? 200;
+      const bodyStr = JSON.stringify(r.body ?? {});
+      return new Response(bodyStr, {
+        status,
+        headers: { "content-type": "application/json" },
+      });
+    },
+  ) as typeof fetch;
+  return {
+    calls,
+    restore: () => {
+      globalThis.fetch = original;
+    },
+  };
+}
+
+// ── Test harness (token storage on disk) ────────────────────────────────────
+
+const tmpDir = join(
+  os.tmpdir(),
+  `patchwork-webflow-${Date.now()}-${Math.random()}`,
+);
+const homeDir = join(tmpDir, "home");
+const patchworkHome = join(homeDir, ".patchwork");
+const tokensDir = join(patchworkHome, "tokens");
+
+beforeEach(() => {
+  process.env.HOME = homeDir;
+  process.env.PATCHWORK_HOME = patchworkHome;
+  process.env.PATCHWORK_TOKEN_STORAGE_BACKEND = "file";
+  delete process.env.WEBFLOW_API_TOKEN;
+  delete process.env.WEBFLOW_SITE_ID;
+  mkdirSync(tokensDir, { recursive: true });
+  vi.resetModules();
+});
+
+afterEach(() => {
+  delete process.env.HOME;
+  delete process.env.PATCHWORK_HOME;
+  delete process.env.PATCHWORK_TOKEN_STORAGE_BACKEND;
+  delete process.env.WEBFLOW_API_TOKEN;
+  delete process.env.WEBFLOW_SITE_ID;
+  if (existsSync(tmpDir)) {
+    rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+// ── normalizeError ──────────────────────────────────────────────────────────
+
+describe("normalizeError", () => {
+  it("maps HTTP status codes to ConnectorError shapes", async () => {
+    const { WebflowConnector } = await import("../webflow.js");
+    const c = new WebflowConnector();
+    const mk = (s: number) =>
+      new Response(null, { status: s }) as unknown as Response;
+    expect(c.normalizeError(mk(400)).code).toBe("provider_error");
+    expect(c.normalizeError(mk(401)).code).toBe("auth_expired");
+    expect(c.normalizeError(mk(403)).code).toBe("permission_denied");
+    expect(c.normalizeError(mk(404)).code).toBe("not_found");
+    expect(c.normalizeError(mk(429)).code).toBe("rate_limited");
+    expect(c.normalizeError(mk(429)).retryable).toBe(true);
+    expect(c.normalizeError(mk(500)).code).toBe("provider_error");
+    expect(c.normalizeError(mk(500)).retryable).toBe(true);
+    expect(c.normalizeError(mk(502)).retryable).toBe(true);
+  });
+
+  it("400 is not retryable", async () => {
+    const { WebflowConnector } = await import("../webflow.js");
+    const c = new WebflowConnector();
+    const r = c.normalizeError(
+      new Response(null, { status: 400 }) as unknown as Response,
+    );
+    expect(r.retryable).toBe(false);
+  });
+
+  it("detects ENOTFOUND/ECONNREFUSED as network_error", async () => {
+    const { WebflowConnector } = await import("../webflow.js");
+    const c = new WebflowConnector();
+    expect(
+      c.normalizeError(new Error("getaddrinfo ENOTFOUND api.webflow.com")).code,
+    ).toBe("network_error");
+    expect(c.normalizeError(new Error("ECONNREFUSED")).code).toBe(
+      "network_error",
+    );
+  });
+
+  it("defaults to provider_error", async () => {
+    const { WebflowConnector } = await import("../webflow.js");
+    const c = new WebflowConnector();
+    expect(c.normalizeError(new Error("boom")).code).toBe("provider_error");
+    expect(c.normalizeError("plain string").code).toBe("provider_error");
+  });
+});
+
+// ── handleWebflowConnect ────────────────────────────────────────────────────
+
+describe("handleWebflowConnect", () => {
+  it("rejects invalid JSON", async () => {
+    const { handleWebflowConnect } = await import("../webflow.js");
+    const r = await handleWebflowConnect("not json");
+    expect(r.status).toBe(400);
+    expect(r.body).toMatch(/Invalid JSON/);
+  });
+
+  it("requires accessToken", async () => {
+    const { handleWebflowConnect } = await import("../webflow.js");
+    const r = await handleWebflowConnect(JSON.stringify({}));
+    expect(r.status).toBe(400);
+    expect(r.body).toMatch(/accessToken/);
+  });
+
+  it("captures first site id + displayName + sends accept-version header", async () => {
+    const { handleWebflowConnect, loadTokens } = await import("../webflow.js");
+    const fetchMock = mockFetch(() => ({
+      status: 200,
+      body: {
+        sites: [
+          { id: "site_abc", displayName: "My Portfolio" },
+          { id: "site_def", displayName: "Other" },
+        ],
+      },
+    }));
+    try {
+      const r = await handleWebflowConnect(
+        JSON.stringify({ accessToken: "tok_123" }),
+      );
+      expect(r.status).toBe(200);
+      const parsed = JSON.parse(r.body) as {
+        siteId?: string;
+        siteName?: string;
+      };
+      expect(parsed.siteId).toBe("site_abc");
+      expect(parsed.siteName).toBe("My Portfolio");
+      const headers = (fetchMock.calls[0]?.init?.headers ?? {}) as Record<
+        string,
+        string
+      >;
+      expect(headers.Authorization).toBe("Bearer tok_123");
+      expect(headers["accept-version"]).toBe("2.0.0");
+      const tokens = loadTokens();
+      expect(tokens?.siteId).toBe("site_abc");
+      expect(tokens?.siteName).toBe("My Portfolio");
+    } finally {
+      fetchMock.restore();
+    }
+  });
+
+  it("returns 401 on auth failure + does not store tokens", async () => {
+    const { handleWebflowConnect, loadTokens } = await import("../webflow.js");
+    const fetchMock = mockFetch(() => ({ status: 401, body: {} }));
+    try {
+      const r = await handleWebflowConnect(
+        JSON.stringify({ accessToken: "bad" }),
+      );
+      expect(r.status).toBe(401);
+      expect(loadTokens()).toBeNull();
+    } finally {
+      fetchMock.restore();
+    }
+  });
+});
+
+// ── API methods ─────────────────────────────────────────────────────────────
+
+describe("listCollectionItems", () => {
+  it("caps limit at 100 even when caller passes higher", async () => {
+    const { getWebflowConnector, saveTokens } = await import("../webflow.js");
+    saveTokens({
+      accessToken: "tok_xyz",
+      connected_at: new Date().toISOString(),
+    });
+    const fetchMock = mockFetch(() => ({
+      status: 200,
+      body: { items: [], pagination: { limit: 100, offset: 0, total: 0 } },
+    }));
+    try {
+      const c = getWebflowConnector();
+      await c.listCollectionItems("col_1", { limit: 500 });
+      const url = fetchMock.calls[0]!.url;
+      expect(url).toContain("limit=100");
+      expect(url).not.toContain("limit=500");
+    } finally {
+      fetchMock.restore();
+    }
+  });
+
+  it("passes through offset + default limit 100 when none given", async () => {
+    const { getWebflowConnector, saveTokens } = await import("../webflow.js");
+    saveTokens({
+      accessToken: "tok_xyz",
+      connected_at: new Date().toISOString(),
+    });
+    const fetchMock = mockFetch(() => ({
+      status: 200,
+      body: { items: [{ id: "item_1" }], pagination: {} },
+    }));
+    try {
+      const c = getWebflowConnector();
+      const r = await c.listCollectionItems("col_1", { offset: 200 });
+      expect(r.items).toHaveLength(1);
+      const url = fetchMock.calls[0]!.url;
+      expect(url).toContain("limit=100");
+      expect(url).toContain("offset=200");
+    } finally {
+      fetchMock.restore();
+    }
+  });
+
+  it("always sets accept-version: 2.0.0 header", async () => {
+    const { getWebflowConnector, saveTokens } = await import("../webflow.js");
+    saveTokens({
+      accessToken: "tok_xyz",
+      connected_at: new Date().toISOString(),
+    });
+    const fetchMock = mockFetch(() => ({
+      status: 200,
+      body: { items: [] },
+    }));
+    try {
+      const c = getWebflowConnector();
+      await c.listCollectionItems("col_1");
+      const headers = (fetchMock.calls[0]?.init?.headers ?? {}) as Record<
+        string,
+        string
+      >;
+      expect(headers["accept-version"]).toBe("2.0.0");
+      expect(headers.Authorization).toBe("Bearer tok_xyz");
+    } finally {
+      fetchMock.restore();
+    }
+  });
+});
+
+describe("listFormSubmissions", () => {
+  it("caps limit at 100", async () => {
+    const { getWebflowConnector, saveTokens } = await import("../webflow.js");
+    saveTokens({
+      accessToken: "tok_xyz",
+      connected_at: new Date().toISOString(),
+    });
+    const fetchMock = mockFetch(() => ({
+      status: 200,
+      body: { formSubmissions: [], pagination: {} },
+    }));
+    try {
+      const c = getWebflowConnector();
+      await c.listFormSubmissions("form_1", { limit: 9999 });
+      const url = fetchMock.calls[0]!.url;
+      expect(url).toContain("limit=100");
+    } finally {
+      fetchMock.restore();
+    }
+  });
+});
+
+describe("listSites / listCollections / listForms", () => {
+  it("unwraps Webflow's named array fields into items[]", async () => {
+    const { getWebflowConnector, saveTokens } = await import("../webflow.js");
+    saveTokens({
+      accessToken: "tok_xyz",
+      connected_at: new Date().toISOString(),
+    });
+    const fetchMock = mockFetch(({ url }) => {
+      if (url.endsWith("/sites")) {
+        return { status: 200, body: { sites: [{ id: "s1" }, { id: "s2" }] } };
+      }
+      if (url.endsWith("/collections")) {
+        return { status: 200, body: { collections: [{ id: "c1" }] } };
+      }
+      if (url.endsWith("/forms")) {
+        return {
+          status: 200,
+          body: { forms: [{ id: "f1" }, { id: "f2" }, { id: "f3" }] },
+        };
+      }
+      return { status: 404, body: {} };
+    });
+    try {
+      const c = getWebflowConnector();
+      expect((await c.listSites()).items).toHaveLength(2);
+      expect((await c.listCollections("s1")).items).toHaveLength(1);
+      expect((await c.listForms("s1")).items).toHaveLength(3);
+    } finally {
+      fetchMock.restore();
+    }
+  });
+});
+
+// ── healthCheck ─────────────────────────────────────────────────────────────
+
+describe("healthCheck", () => {
+  it("returns ok:true on 200", async () => {
+    const { getWebflowConnector, saveTokens } = await import("../webflow.js");
+    saveTokens({
+      accessToken: "tok_xyz",
+      connected_at: new Date().toISOString(),
+    });
+    const fetchMock = mockFetch(() => ({ status: 200, body: { id: "u1" } }));
+    try {
+      const c = getWebflowConnector();
+      const r = await c.healthCheck();
+      expect(r.ok).toBe(true);
+      expect(fetchMock.calls[0]!.url).toContain("/token/authorized_by");
+    } finally {
+      fetchMock.restore();
+    }
+  });
+
+  it("returns auth_expired on 401", async () => {
+    const { getWebflowConnector, saveTokens } = await import("../webflow.js");
+    saveTokens({
+      accessToken: "tok_xyz",
+      connected_at: new Date().toISOString(),
+    });
+    const fetchMock = mockFetch(() => ({ status: 401, body: {} }));
+    try {
+      const c = getWebflowConnector();
+      const r = await c.healthCheck();
+      expect(r.ok).toBe(false);
+      expect(r.error?.code).toBe("auth_expired");
+    } finally {
+      fetchMock.restore();
+    }
+  });
+});
+
+// ── env var override ────────────────────────────────────────────────────────
+
+describe("env var override", () => {
+  it("WEBFLOW_API_TOKEN populates loadTokens()", async () => {
+    process.env.WEBFLOW_API_TOKEN = "env_tok";
+    process.env.WEBFLOW_SITE_ID = "env_site";
+    const { loadTokens } = await import("../webflow.js");
+    const tokens = loadTokens();
+    expect(tokens?.accessToken).toBe("env_tok");
+    expect(tokens?.siteId).toBe("env_site");
+  });
+});
+
+// ── getStatus ───────────────────────────────────────────────────────────────
+
+describe("getStatus", () => {
+  it("disconnected when no tokens", async () => {
+    const { getWebflowConnector } = await import("../webflow.js");
+    const c = getWebflowConnector();
+    expect(c.getStatus().status).toBe("disconnected");
+  });
+
+  it("connected + workspace label when tokens present", async () => {
+    const { getWebflowConnector, saveTokens } = await import("../webflow.js");
+    saveTokens({
+      accessToken: "t",
+      siteId: "s1",
+      siteName: "Portfolio",
+      connected_at: new Date().toISOString(),
+    });
+    const s = getWebflowConnector().getStatus();
+    expect(s.status).toBe("connected");
+    expect(s.workspace).toMatch(/Portfolio/);
+  });
+});
+
+// ── disconnect ──────────────────────────────────────────────────────────────
+
+describe("handleWebflowDisconnect", () => {
+  it("clears tokens", async () => {
+    const { handleWebflowDisconnect, saveTokens, loadTokens } = await import(
+      "../webflow.js"
+    );
+    saveTokens({ accessToken: "t", connected_at: new Date().toISOString() });
+    expect(loadTokens()).not.toBeNull();
+    const r = handleWebflowDisconnect();
+    expect(r.status).toBe(200);
+    expect(loadTokens()).toBeNull();
+  });
+});

--- a/src/connectors/airtable.ts
+++ b/src/connectors/airtable.ts
@@ -1,0 +1,515 @@
+/**
+ * Airtable connector — record access via the Airtable REST API v0.
+ *
+ * Auth: Personal Access Token (PAT) — `Authorization: Bearer <pat>`. PATs
+ *   start with `pat...`.
+ *   - Env var: AIRTABLE_ACCESS_TOKEN
+ *   - Stored: getSecretJsonSync("airtable") → AirtableTokens
+ *
+ * Tools: listBases, getBaseSchema, listRecords, getRecord, createRecord,
+ *   updateRecord. Write ops (create/update) are intentionally exposed — the
+ *   point of the integration is round-trip record manipulation.
+ *
+ * Extends BaseConnector for unified auth, retry, rate-limit, error handling.
+ */
+
+import {
+  type AuthContext,
+  BaseConnector,
+  type ConnectorError,
+  type ConnectorStatus,
+} from "./baseConnector.js";
+import {
+  deleteSecretJsonSync,
+  getSecretJsonSync,
+  storeSecretJsonSync,
+} from "./tokenStorage.js";
+
+export interface AirtableTokens {
+  accessToken: string; // pat...
+  userId?: string;
+  email?: string;
+  connected_at: string;
+}
+
+export interface AirtableBase {
+  id: string;
+  name: string;
+  permissionLevel?: string;
+}
+
+export interface AirtableField {
+  id: string;
+  name: string;
+  type: string;
+  description?: string;
+  options?: Record<string, unknown>;
+}
+
+export interface AirtableTable {
+  id: string;
+  name: string;
+  primaryFieldId?: string;
+  description?: string;
+  fields: AirtableField[];
+}
+
+export interface AirtableRecord {
+  id: string;
+  createdTime: string;
+  fields: Record<string, unknown>;
+}
+
+export interface AirtableListBasesResult {
+  bases: AirtableBase[];
+  offset?: string;
+}
+
+export interface AirtableSchemaResult {
+  tables: AirtableTable[];
+}
+
+export interface AirtableListRecordsResult {
+  records: AirtableRecord[];
+  offset?: string;
+}
+
+export interface AirtableListRecordsParams {
+  filterByFormula?: string;
+  sort?: Array<{ field: string; direction?: "asc" | "desc" }>;
+  view?: string;
+  fields?: string[];
+  maxRecords?: number;
+  pageSize?: number;
+}
+
+const BASE_URL = "https://api.airtable.com";
+const MAX_RECORDS_HARD_CAP = 1000;
+
+export class AirtableConnector extends BaseConnector {
+  readonly providerName = "airtable";
+  private tokens: AirtableTokens | null = null;
+
+  protected getOAuthConfig() {
+    return null;
+  }
+
+  async authenticate(): Promise<AuthContext> {
+    const tokens = loadTokens();
+    if (!tokens) {
+      throw new Error(
+        "Airtable not connected. Run: patchwork-os connect airtable or set AIRTABLE_ACCESS_TOKEN",
+      );
+    }
+    this.tokens = tokens;
+    return {
+      token: tokens.accessToken,
+      scopes: ["read", "write"],
+    };
+  }
+
+  async healthCheck(): Promise<{ ok: boolean; error?: ConnectorError }> {
+    try {
+      const result = await this.apiCall(async () => {
+        const res = await fetch(`${BASE_URL}/v0/meta/whoami`, {
+          headers: this.buildHeaders(),
+        });
+        if (!res.ok) throw res;
+        return res.json();
+      });
+      if ("error" in result) return { ok: false, error: result.error };
+      return { ok: true };
+    } catch (err) {
+      return { ok: false, error: this.normalizeError(err) };
+    }
+  }
+
+  normalizeError(error: unknown): ConnectorError {
+    if (error instanceof Response) {
+      const s = error.status;
+      if (s === 401)
+        return {
+          code: "auth_expired",
+          message: "Airtable authentication expired — reconnect",
+          retryable: false,
+          suggestedAction: "patchwork-os connect airtable",
+        };
+      if (s === 403)
+        return {
+          code: "permission_denied",
+          message: "Insufficient Airtable permissions for this base/table",
+          retryable: false,
+        };
+      if (s === 404)
+        return {
+          code: "not_found",
+          message: "Airtable resource not found",
+          retryable: false,
+        };
+      if (s === 422)
+        return {
+          code: "provider_error",
+          message: "Airtable validation error (invalid fields or formula)",
+          retryable: false,
+        };
+      if (s === 429)
+        return {
+          code: "rate_limited",
+          message: "Airtable API rate limit exceeded",
+          retryable: true,
+          suggestedAction: "Wait and retry",
+        };
+      return {
+        code: "provider_error",
+        message: `Airtable API error: HTTP ${s}`,
+        retryable: s >= 500,
+      };
+    }
+    if (error instanceof Error) {
+      if (
+        error.message.includes("ENOTFOUND") ||
+        error.message.includes("ECONNREFUSED")
+      ) {
+        return {
+          code: "network_error",
+          message: `Cannot connect to Airtable: ${error.message}`,
+          retryable: true,
+        };
+      }
+    }
+    return {
+      code: "provider_error",
+      message: error instanceof Error ? error.message : String(error),
+      retryable: false,
+    };
+  }
+
+  getStatus(): ConnectorStatus {
+    const tokens = loadTokens();
+    return {
+      id: "airtable",
+      status: tokens ? "connected" : "disconnected",
+      lastSync: tokens?.connected_at,
+      workspace: tokens?.email
+        ? `Airtable (${tokens.email})`
+        : tokens?.userId
+          ? `Airtable user ${tokens.userId}`
+          : undefined,
+    };
+  }
+
+  // ── API Methods ────────────────────────────────────────────────────────────
+
+  async listBases(): Promise<AirtableListBasesResult> {
+    const result = await this.apiCall(async () => {
+      const res = await fetch(`${BASE_URL}/v0/meta/bases`, {
+        headers: this.buildHeaders(),
+      });
+      if (!res.ok) throw res;
+      return res.json() as Promise<AirtableListBasesResult>;
+    });
+    if ("error" in result) throw new Error(result.error.message);
+    return result.data as AirtableListBasesResult;
+  }
+
+  async getBaseSchema(baseId: string): Promise<AirtableSchemaResult> {
+    const result = await this.apiCall(async () => {
+      const res = await fetch(
+        `${BASE_URL}/v0/meta/bases/${encodeURIComponent(baseId)}/tables`,
+        { headers: this.buildHeaders() },
+      );
+      if (!res.ok) throw res;
+      return res.json() as Promise<AirtableSchemaResult>;
+    });
+    if ("error" in result) throw new Error(result.error.message);
+    return result.data as AirtableSchemaResult;
+  }
+
+  async listRecords(
+    baseId: string,
+    tableIdOrName: string,
+    params: AirtableListRecordsParams = {},
+  ): Promise<AirtableListRecordsResult> {
+    const result = await this.apiCall(async () => {
+      const qs = new URLSearchParams();
+      if (params.filterByFormula)
+        qs.set("filterByFormula", params.filterByFormula);
+      if (params.view) qs.set("view", params.view);
+      if (params.pageSize) qs.set("pageSize", String(params.pageSize));
+
+      // Cap maxRecords at Airtable's 1000 hard limit. Default 100.
+      const maxRecords = Math.min(
+        params.maxRecords ?? 100,
+        MAX_RECORDS_HARD_CAP,
+      );
+      qs.set("maxRecords", String(maxRecords));
+
+      if (params.sort) {
+        params.sort.forEach((s, i) => {
+          qs.set(`sort[${i}][field]`, s.field);
+          if (s.direction) qs.set(`sort[${i}][direction]`, s.direction);
+        });
+      }
+      if (params.fields) {
+        for (const f of params.fields) qs.append("fields[]", f);
+      }
+
+      const url = `${BASE_URL}/v0/${encodeURIComponent(baseId)}/${encodeURIComponent(tableIdOrName)}?${qs}`;
+      const res = await fetch(url, { headers: this.buildHeaders() });
+      if (!res.ok) throw res;
+      return res.json() as Promise<AirtableListRecordsResult>;
+    });
+    if ("error" in result) throw new Error(result.error.message);
+    return result.data as AirtableListRecordsResult;
+  }
+
+  async getRecord(
+    baseId: string,
+    tableIdOrName: string,
+    recordId: string,
+  ): Promise<AirtableRecord> {
+    const result = await this.apiCall(async () => {
+      const url = `${BASE_URL}/v0/${encodeURIComponent(baseId)}/${encodeURIComponent(tableIdOrName)}/${encodeURIComponent(recordId)}`;
+      const res = await fetch(url, { headers: this.buildHeaders() });
+      if (!res.ok) throw res;
+      return res.json() as Promise<AirtableRecord>;
+    });
+    if ("error" in result) throw new Error(result.error.message);
+    return result.data as AirtableRecord;
+  }
+
+  async createRecord(
+    baseId: string,
+    tableIdOrName: string,
+    fields: Record<string, unknown>,
+  ): Promise<AirtableRecord> {
+    const result = await this.apiCall(async () => {
+      const url = `${BASE_URL}/v0/${encodeURIComponent(baseId)}/${encodeURIComponent(tableIdOrName)}`;
+      const res = await fetch(url, {
+        method: "POST",
+        headers: {
+          ...this.buildHeaders(),
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ records: [{ fields }] }),
+      });
+      if (!res.ok) throw res;
+      const json = (await res.json()) as { records: AirtableRecord[] };
+      const first = json.records?.[0];
+      if (!first) throw new Error("Airtable returned no record in response");
+      return first;
+    });
+    if ("error" in result) throw new Error(result.error.message);
+    return result.data as AirtableRecord;
+  }
+
+  async updateRecord(
+    baseId: string,
+    tableIdOrName: string,
+    recordId: string,
+    fields: Record<string, unknown>,
+  ): Promise<AirtableRecord> {
+    const result = await this.apiCall(async () => {
+      const url = `${BASE_URL}/v0/${encodeURIComponent(baseId)}/${encodeURIComponent(tableIdOrName)}/${encodeURIComponent(recordId)}`;
+      const res = await fetch(url, {
+        method: "PATCH",
+        headers: {
+          ...this.buildHeaders(),
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ fields }),
+      });
+      if (!res.ok) throw res;
+      return res.json() as Promise<AirtableRecord>;
+    });
+    if ("error" in result) throw new Error(result.error.message);
+    return result.data as AirtableRecord;
+  }
+
+  // ── Helpers ────────────────────────────────────────────────────────────────
+
+  private buildHeaders(): Record<string, string> {
+    const token = this.tokens?.accessToken ?? loadTokens()?.accessToken ?? "";
+    return {
+      Authorization: `Bearer ${token}`,
+      Accept: "application/json",
+    };
+  }
+}
+
+// ── Token persistence ────────────────────────────────────────────────────────
+
+export function loadTokens(): AirtableTokens | null {
+  const envKey = process.env.AIRTABLE_ACCESS_TOKEN;
+  if (envKey) {
+    return {
+      accessToken: envKey,
+      connected_at: new Date().toISOString(),
+    };
+  }
+  return getSecretJsonSync<AirtableTokens>("airtable");
+}
+
+export function saveTokens(tokens: AirtableTokens): void {
+  storeSecretJsonSync("airtable", tokens);
+}
+
+export function clearTokens(): void {
+  try {
+    deleteSecretJsonSync("airtable");
+  } catch {
+    // ignore
+  }
+}
+
+// ── Singleton instance ───────────────────────────────────────────────────────
+
+let _instance: AirtableConnector | null = null;
+
+function resetAirtableConnector(): void {
+  _instance = null;
+}
+
+export function getAirtableConnector(): AirtableConnector {
+  if (!_instance) {
+    _instance = new AirtableConnector();
+  }
+  return _instance;
+}
+
+export { getAirtableConnector as airtable };
+
+// ── HTTP Handlers ────────────────────────────────────────────────────────────
+// Wired in src/server.ts under /connections/airtable/*
+
+export interface ConnectorHandlerResult {
+  status: number;
+  body: string;
+  contentType?: string;
+}
+
+/**
+ * POST /connections/airtable/connect  { accessToken }
+ */
+export async function handleAirtableConnect(
+  body: string,
+): Promise<ConnectorHandlerResult> {
+  let accessToken: string;
+
+  try {
+    const parsed = JSON.parse(body) as { accessToken?: unknown };
+    if (typeof parsed.accessToken !== "string" || !parsed.accessToken) {
+      return {
+        status: 400,
+        contentType: "application/json",
+        body: JSON.stringify({ ok: false, error: "accessToken is required" }),
+      };
+    }
+    accessToken = parsed.accessToken;
+  } catch {
+    return {
+      status: 400,
+      contentType: "application/json",
+      body: JSON.stringify({ ok: false, error: "Invalid JSON body" }),
+    };
+  }
+
+  try {
+    const res = await fetch(`${BASE_URL}/v0/meta/whoami`, {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        Accept: "application/json",
+      },
+    });
+    if (!res.ok) {
+      return {
+        status: 401,
+        contentType: "application/json",
+        body: JSON.stringify({
+          ok: false,
+          error: `Credentials rejected by Airtable (HTTP ${res.status}) — check accessToken`,
+        }),
+      };
+    }
+    const who = (await res.json()) as { id?: string; email?: string };
+
+    const userId = who.id ?? undefined;
+    const email = who.email ?? undefined;
+
+    const tokens: AirtableTokens = {
+      accessToken,
+      userId,
+      email,
+      connected_at: new Date().toISOString(),
+    };
+    saveTokens(tokens);
+    resetAirtableConnector();
+
+    return {
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        ok: true,
+        userId,
+        email,
+        connectedAt: tokens.connected_at,
+      }),
+    };
+  } catch (err) {
+    return {
+      status: 500,
+      contentType: "application/json",
+      body: JSON.stringify({
+        ok: false,
+        error: err instanceof Error ? err.message : String(err),
+      }),
+    };
+  }
+}
+
+/**
+ * POST /connections/airtable/test
+ */
+export async function handleAirtableTest(): Promise<ConnectorHandlerResult> {
+  const tokens = loadTokens();
+  if (!tokens) {
+    return {
+      status: 400,
+      contentType: "application/json",
+      body: JSON.stringify({ ok: false, error: "Airtable not connected" }),
+    };
+  }
+  try {
+    const connector = getAirtableConnector();
+    const check = await connector.healthCheck();
+    return {
+      status: check.ok ? 200 : 401,
+      contentType: "application/json",
+      body: JSON.stringify(
+        check.ok ? { ok: true } : { ok: false, error: check.error?.message },
+      ),
+    };
+  } catch (err) {
+    return {
+      status: 500,
+      contentType: "application/json",
+      body: JSON.stringify({
+        ok: false,
+        error: err instanceof Error ? err.message : String(err),
+      }),
+    };
+  }
+}
+
+/**
+ * DELETE /connections/airtable
+ */
+export function handleAirtableDisconnect(): ConnectorHandlerResult {
+  clearTokens();
+  resetAirtableConnector();
+  return {
+    status: 200,
+    contentType: "application/json",
+    body: JSON.stringify({ ok: true }),
+  };
+}

--- a/src/connectors/connectorRegistry.ts
+++ b/src/connectors/connectorRegistry.ts
@@ -195,6 +195,38 @@ export const CONNECTORS: readonly ConnectorDescriptor[] = [
     authKind: "pat",
     supports: { connect: true, test: true, delete: true },
   },
+  // Wave 1b — PAT comms connectors.
+  {
+    id: "sendgrid",
+    label: "SendGrid",
+    authKind: "pat",
+    supports: { connect: true, test: true, delete: true },
+  },
+  {
+    id: "twilio",
+    label: "Twilio",
+    authKind: "pat",
+    supports: { connect: true, test: true, delete: true },
+  },
+  // Wave 2 — PAT SaaS connectors (skip Wave 3 OAuth-app connectors for now).
+  {
+    id: "figma",
+    label: "Figma",
+    authKind: "pat",
+    supports: { connect: true, test: true, delete: true },
+  },
+  {
+    id: "airtable",
+    label: "Airtable",
+    authKind: "pat",
+    supports: { connect: true, test: true, delete: true },
+  },
+  {
+    id: "webflow",
+    label: "Webflow",
+    authKind: "pat",
+    supports: { connect: true, test: true, delete: true },
+  },
   // jira: PAT. Concurrent work is wiring the bridge routes. The
   // `supports` capabilities here are deliberately empty until those
   // routes exist; flipping them in this file is the one-line change

--- a/src/connectors/figma.ts
+++ b/src/connectors/figma.ts
@@ -1,0 +1,524 @@
+/**
+ * Figma connector — read-only access to Figma files, comments, and team
+ * projects via the Figma REST API.
+ *
+ * Auth: Personal Access Token sent as `X-Figma-Token: <token>`.
+ *   - Env var: FIGMA_ACCESS_TOKEN
+ *   - Stored: getSecretJsonSync("figma") → FigmaTokens
+ *
+ * Tools: getMe, getFile, getFileNodes, getImageUrls, getFileComments,
+ *        listTeamProjects, listProjectFiles
+ *
+ * Extends BaseConnector for unified auth, retry, rate-limit, error handling.
+ */
+
+import {
+  type AuthContext,
+  BaseConnector,
+  type ConnectorError,
+  type ConnectorStatus,
+} from "./baseConnector.js";
+import {
+  deleteSecretJsonSync,
+  getSecretJsonSync,
+  storeSecretJsonSync,
+} from "./tokenStorage.js";
+
+export interface FigmaTokens {
+  accessToken: string;
+  userHandle?: string;
+  email?: string;
+  connected_at: string;
+}
+
+export interface FigmaUser {
+  id: string;
+  handle: string;
+  img_url?: string;
+  email?: string;
+}
+
+export interface FigmaFile {
+  name: string;
+  lastModified: string;
+  version: string;
+  document: unknown;
+  components?: Record<string, unknown>;
+  styles?: Record<string, unknown>;
+  schemaVersion?: number;
+  thumbnailUrl?: string;
+}
+
+export interface FigmaFileNodes {
+  name: string;
+  lastModified: string;
+  version: string;
+  nodes: Record<string, { document: unknown } | null>;
+}
+
+export interface FigmaImageResult {
+  err: string | null;
+  images: Record<string, string | null>;
+}
+
+export interface FigmaComment {
+  id: string;
+  file_key: string;
+  message: string;
+  user: { id: string; handle: string };
+  created_at: string;
+  resolved_at?: string | null;
+}
+
+export interface FigmaCommentsResult {
+  comments: FigmaComment[];
+}
+
+export interface FigmaProject {
+  id: string;
+  name: string;
+}
+
+export interface FigmaTeamProjectsResult {
+  name: string;
+  projects: FigmaProject[];
+}
+
+export interface FigmaProjectFile {
+  key: string;
+  name: string;
+  thumbnail_url?: string;
+  last_modified: string;
+}
+
+export interface FigmaProjectFilesResult {
+  name: string;
+  files: FigmaProjectFile[];
+}
+
+export type FigmaImageFormat = "png" | "jpg" | "svg" | "pdf";
+
+const BASE_URL = "https://api.figma.com";
+const VALID_IMAGE_FORMATS: ReadonlySet<FigmaImageFormat> = new Set([
+  "png",
+  "jpg",
+  "svg",
+  "pdf",
+]);
+
+export class FigmaConnector extends BaseConnector {
+  readonly providerName = "figma";
+  private tokens: FigmaTokens | null = null;
+
+  protected getOAuthConfig() {
+    return null;
+  }
+
+  async authenticate(): Promise<AuthContext> {
+    const tokens = loadTokens();
+    if (!tokens) {
+      throw new Error(
+        "Figma not connected. Run: patchwork-os connect figma or set FIGMA_ACCESS_TOKEN",
+      );
+    }
+    this.tokens = tokens;
+    return {
+      token: tokens.accessToken,
+      scopes: ["read"],
+    };
+  }
+
+  async healthCheck(): Promise<{ ok: boolean; error?: ConnectorError }> {
+    try {
+      const result = await this.apiCall(async () => {
+        const res = await fetch(`${BASE_URL}/v1/me`, {
+          headers: this.buildHeaders(),
+        });
+        if (!res.ok) throw res;
+        return res.json();
+      });
+      if ("error" in result) return { ok: false, error: result.error };
+      return { ok: true };
+    } catch (err) {
+      return { ok: false, error: this.normalizeError(err) };
+    }
+  }
+
+  normalizeError(error: unknown): ConnectorError {
+    if (error instanceof Response) {
+      const s = error.status;
+      // Figma uses 403 for invalid/expired tokens, not 401.
+      if (s === 401 || s === 403)
+        return {
+          code: "auth_expired",
+          message: "Figma authentication expired or invalid — reconnect",
+          retryable: false,
+          suggestedAction: "patchwork-os connect figma",
+        };
+      if (s === 404)
+        return {
+          code: "not_found",
+          message: "Figma resource not found",
+          retryable: false,
+        };
+      if (s === 429)
+        return {
+          code: "rate_limited",
+          message: "Figma API rate limit exceeded",
+          retryable: true,
+          suggestedAction: "Wait and retry",
+        };
+      return {
+        code: "provider_error",
+        message: `Figma API error: HTTP ${s}`,
+        retryable: s >= 500,
+      };
+    }
+    if (error instanceof Error) {
+      if (
+        error.message.includes("ENOTFOUND") ||
+        error.message.includes("ECONNREFUSED")
+      ) {
+        return {
+          code: "network_error",
+          message: `Cannot connect to Figma: ${error.message}`,
+          retryable: true,
+        };
+      }
+    }
+    return {
+      code: "provider_error",
+      message: error instanceof Error ? error.message : String(error),
+      retryable: false,
+    };
+  }
+
+  getStatus(): ConnectorStatus {
+    const tokens = loadTokens();
+    return {
+      id: "figma",
+      status: tokens ? "connected" : "disconnected",
+      lastSync: tokens?.connected_at,
+      workspace: tokens?.userHandle
+        ? `Figma user @${tokens.userHandle}`
+        : undefined,
+    };
+  }
+
+  // ── API Methods ────────────────────────────────────────────────────────────
+
+  async getMe(): Promise<FigmaUser> {
+    const result = await this.apiCall(async () => {
+      const res = await fetch(`${BASE_URL}/v1/me`, {
+        headers: this.buildHeaders(),
+      });
+      if (!res.ok) throw res;
+      return res.json() as Promise<FigmaUser>;
+    });
+    if ("error" in result) throw new Error(result.error.message);
+    return result.data as FigmaUser;
+  }
+
+  async getFile(
+    fileKey: string,
+    params: { depth?: number; geometry?: "paths" } = {},
+  ): Promise<FigmaFile> {
+    if (!fileKey) throw new Error("fileKey is required");
+    const depth = params.depth ?? 2;
+    const result = await this.apiCall(async () => {
+      const qs = new URLSearchParams();
+      qs.set("depth", String(depth));
+      if (params.geometry) qs.set("geometry", params.geometry);
+      const res = await fetch(
+        `${BASE_URL}/v1/files/${encodeURIComponent(fileKey)}?${qs}`,
+        { headers: this.buildHeaders() },
+      );
+      if (!res.ok) throw res;
+      return res.json() as Promise<FigmaFile>;
+    });
+    if ("error" in result) throw new Error(result.error.message);
+    return result.data as FigmaFile;
+  }
+
+  async getFileNodes(
+    fileKey: string,
+    nodeIds: string[],
+  ): Promise<FigmaFileNodes> {
+    if (!fileKey) throw new Error("fileKey is required");
+    if (!Array.isArray(nodeIds) || nodeIds.length === 0) {
+      throw new Error("nodeIds must be a non-empty array");
+    }
+    const result = await this.apiCall(async () => {
+      const qs = new URLSearchParams();
+      qs.set("ids", nodeIds.join(","));
+      const res = await fetch(
+        `${BASE_URL}/v1/files/${encodeURIComponent(fileKey)}/nodes?${qs}`,
+        { headers: this.buildHeaders() },
+      );
+      if (!res.ok) throw res;
+      return res.json() as Promise<FigmaFileNodes>;
+    });
+    if ("error" in result) throw new Error(result.error.message);
+    return result.data as FigmaFileNodes;
+  }
+
+  async getImageUrls(
+    fileKey: string,
+    params: { ids: string[]; format?: FigmaImageFormat; scale?: number },
+  ): Promise<FigmaImageResult> {
+    if (!fileKey) throw new Error("fileKey is required");
+    if (!params || !Array.isArray(params.ids) || params.ids.length === 0) {
+      throw new Error("ids must be a non-empty array");
+    }
+    const format = params.format ?? "png";
+    if (!VALID_IMAGE_FORMATS.has(format)) {
+      throw new Error(
+        `Invalid format '${format}'. Must be one of: png, jpg, svg, pdf`,
+      );
+    }
+    const scale = params.scale ?? 1;
+    const result = await this.apiCall(async () => {
+      const qs = new URLSearchParams();
+      qs.set("ids", params.ids.join(","));
+      qs.set("format", format);
+      qs.set("scale", String(scale));
+      const res = await fetch(
+        `${BASE_URL}/v1/images/${encodeURIComponent(fileKey)}?${qs}`,
+        { headers: this.buildHeaders() },
+      );
+      if (!res.ok) throw res;
+      return res.json() as Promise<FigmaImageResult>;
+    });
+    if ("error" in result) throw new Error(result.error.message);
+    return result.data as FigmaImageResult;
+  }
+
+  async getFileComments(fileKey: string): Promise<FigmaCommentsResult> {
+    if (!fileKey) throw new Error("fileKey is required");
+    const result = await this.apiCall(async () => {
+      const res = await fetch(
+        `${BASE_URL}/v1/files/${encodeURIComponent(fileKey)}/comments`,
+        { headers: this.buildHeaders() },
+      );
+      if (!res.ok) throw res;
+      return res.json() as Promise<FigmaCommentsResult>;
+    });
+    if ("error" in result) throw new Error(result.error.message);
+    return result.data as FigmaCommentsResult;
+  }
+
+  async listTeamProjects(teamId: string): Promise<FigmaTeamProjectsResult> {
+    if (!teamId) throw new Error("teamId is required");
+    const result = await this.apiCall(async () => {
+      const res = await fetch(
+        `${BASE_URL}/v1/teams/${encodeURIComponent(teamId)}/projects`,
+        { headers: this.buildHeaders() },
+      );
+      if (!res.ok) throw res;
+      return res.json() as Promise<FigmaTeamProjectsResult>;
+    });
+    if ("error" in result) throw new Error(result.error.message);
+    return result.data as FigmaTeamProjectsResult;
+  }
+
+  async listProjectFiles(projectId: string): Promise<FigmaProjectFilesResult> {
+    if (!projectId) throw new Error("projectId is required");
+    const result = await this.apiCall(async () => {
+      const res = await fetch(
+        `${BASE_URL}/v1/projects/${encodeURIComponent(projectId)}/files`,
+        { headers: this.buildHeaders() },
+      );
+      if (!res.ok) throw res;
+      return res.json() as Promise<FigmaProjectFilesResult>;
+    });
+    if ("error" in result) throw new Error(result.error.message);
+    return result.data as FigmaProjectFilesResult;
+  }
+
+  // ── Helpers ────────────────────────────────────────────────────────────────
+
+  private buildHeaders(): Record<string, string> {
+    const token = this.tokens?.accessToken ?? loadTokens()?.accessToken ?? "";
+    return {
+      "X-Figma-Token": token,
+      Accept: "application/json",
+    };
+  }
+}
+
+// ── Token persistence ────────────────────────────────────────────────────────
+
+export function loadTokens(): FigmaTokens | null {
+  const envToken = process.env.FIGMA_ACCESS_TOKEN;
+  if (envToken) {
+    return {
+      accessToken: envToken,
+      connected_at: new Date().toISOString(),
+    };
+  }
+  return getSecretJsonSync<FigmaTokens>("figma");
+}
+
+export function saveTokens(tokens: FigmaTokens): void {
+  storeSecretJsonSync("figma", tokens);
+}
+
+export function clearTokens(): void {
+  try {
+    deleteSecretJsonSync("figma");
+  } catch {
+    // ignore
+  }
+}
+
+// ── Singleton instance ───────────────────────────────────────────────────────
+
+let _instance: FigmaConnector | null = null;
+
+function resetFigmaConnector(): void {
+  _instance = null;
+}
+
+export function getFigmaConnector(): FigmaConnector {
+  if (!_instance) {
+    _instance = new FigmaConnector();
+  }
+  return _instance;
+}
+
+export { getFigmaConnector as figma };
+
+// ── HTTP Handlers ────────────────────────────────────────────────────────────
+// Wired in src/server.ts under /connections/figma/*
+
+export interface ConnectorHandlerResult {
+  status: number;
+  body: string;
+  contentType?: string;
+}
+
+/**
+ * POST /connections/figma/connect  { accessToken }
+ */
+export async function handleFigmaConnect(
+  body: string,
+): Promise<ConnectorHandlerResult> {
+  let accessToken: string;
+
+  try {
+    const parsed = JSON.parse(body) as { accessToken?: unknown };
+    if (typeof parsed.accessToken !== "string" || !parsed.accessToken) {
+      return {
+        status: 400,
+        contentType: "application/json",
+        body: JSON.stringify({ ok: false, error: "accessToken is required" }),
+      };
+    }
+    accessToken = parsed.accessToken;
+  } catch {
+    return {
+      status: 400,
+      contentType: "application/json",
+      body: JSON.stringify({ ok: false, error: "Invalid JSON body" }),
+    };
+  }
+
+  try {
+    const res = await fetch(`${BASE_URL}/v1/me`, {
+      headers: {
+        "X-Figma-Token": accessToken,
+        Accept: "application/json",
+      },
+    });
+    if (!res.ok) {
+      return {
+        status: 401,
+        contentType: "application/json",
+        body: JSON.stringify({
+          ok: false,
+          error: `Credentials rejected by Figma (HTTP ${res.status}) — check accessToken`,
+        }),
+      };
+    }
+    const user = (await res.json()) as {
+      handle?: string;
+      email?: string;
+    };
+
+    const tokens: FigmaTokens = {
+      accessToken,
+      userHandle: user.handle,
+      email: user.email,
+      connected_at: new Date().toISOString(),
+    };
+    saveTokens(tokens);
+    resetFigmaConnector();
+
+    return {
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        ok: true,
+        userHandle: tokens.userHandle,
+        email: tokens.email,
+        connectedAt: tokens.connected_at,
+      }),
+    };
+  } catch (err) {
+    return {
+      status: 500,
+      contentType: "application/json",
+      body: JSON.stringify({
+        ok: false,
+        error: err instanceof Error ? err.message : String(err),
+      }),
+    };
+  }
+}
+
+/**
+ * POST /connections/figma/test
+ */
+export async function handleFigmaTest(): Promise<ConnectorHandlerResult> {
+  const tokens = loadTokens();
+  if (!tokens) {
+    return {
+      status: 400,
+      contentType: "application/json",
+      body: JSON.stringify({ ok: false, error: "Figma not connected" }),
+    };
+  }
+  try {
+    const connector = getFigmaConnector();
+    const check = await connector.healthCheck();
+    return {
+      status: check.ok ? 200 : 401,
+      contentType: "application/json",
+      body: JSON.stringify(
+        check.ok ? { ok: true } : { ok: false, error: check.error?.message },
+      ),
+    };
+  } catch (err) {
+    return {
+      status: 500,
+      contentType: "application/json",
+      body: JSON.stringify({
+        ok: false,
+        error: err instanceof Error ? err.message : String(err),
+      }),
+    };
+  }
+}
+
+/**
+ * DELETE /connections/figma
+ */
+export function handleFigmaDisconnect(): ConnectorHandlerResult {
+  clearTokens();
+  resetFigmaConnector();
+  return {
+    status: 200,
+    contentType: "application/json",
+    body: JSON.stringify({ ok: true }),
+  };
+}

--- a/src/connectors/gmail.ts
+++ b/src/connectors/gmail.ts
@@ -333,6 +333,11 @@ export async function handleConnectionsList(): Promise<ConnectorHandlerResult> {
     mongodb: () => import("./mongodb.js"),
     redis: () => import("./redis.js"),
     elasticsearch: () => import("./elasticsearch.js"),
+    sendgrid: () => import("./sendgrid.js"),
+    twilio: () => import("./twilio.js"),
+    figma: () => import("./figma.js"),
+    airtable: () => import("./airtable.js"),
+    webflow: () => import("./webflow.js"),
   };
   const tokenPasteProbes = CONNECTORS.filter(
     (c) => !EXPLICIT_IDS.has(c.id),

--- a/src/connectors/sendgrid.ts
+++ b/src/connectors/sendgrid.ts
@@ -1,0 +1,531 @@
+/**
+ * SendGrid connector — outbound transactional email via SendGrid v3 REST API.
+ *
+ * Auth: Bearer API key (`SG.*`).
+ *   - Env var: SENDGRID_API_KEY (+ optional SENDGRID_FROM_EMAIL)
+ *   - Stored: getSecretJsonSync("sendgrid") → SendGridTokens
+ *
+ * Tools: send, listTemplates, getTemplate, listSenders, getStats
+ *
+ * Extends BaseConnector for unified auth, retry, rate-limit, error handling.
+ */
+
+import {
+  type AuthContext,
+  BaseConnector,
+  type ConnectorError,
+  type ConnectorStatus,
+} from "./baseConnector.js";
+import {
+  deleteSecretJsonSync,
+  getSecretJsonSync,
+  storeSecretJsonSync,
+} from "./tokenStorage.js";
+
+export interface SendGridTokens {
+  apiKey: string; // SG.xxxx
+  fromEmail?: string;
+  accountName?: string;
+  connected_at: string;
+}
+
+export interface SendGridTemplate {
+  id: string;
+  name: string;
+  generation: "legacy" | "dynamic";
+  updated_at?: string;
+}
+
+export interface SendGridTemplateListResult {
+  result: SendGridTemplate[];
+}
+
+export interface SendGridVerifiedSender {
+  id: number;
+  from_email: string;
+  from_name?: string;
+  verified: boolean;
+}
+
+export interface SendGridSenderListResult {
+  results: SendGridVerifiedSender[];
+}
+
+export interface SendGridStatsBucket {
+  date: string;
+  stats: Array<{
+    metrics: Record<string, number>;
+    name?: string;
+    type?: string;
+  }>;
+}
+
+export interface SendGridSendResult {
+  messageId: string;
+}
+
+const BASE_URL = "https://api.sendgrid.com";
+
+// Loose RFC 5322-ish email check — good enough to reject obvious garbage.
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+function isValidEmail(s: unknown): s is string {
+  return typeof s === "string" && EMAIL_RE.test(s);
+}
+
+export class SendGridConnector extends BaseConnector {
+  readonly providerName = "sendgrid";
+  private tokens: SendGridTokens | null = null;
+
+  protected getOAuthConfig() {
+    return null;
+  }
+
+  async authenticate(): Promise<AuthContext> {
+    const tokens = loadTokens();
+    if (!tokens) {
+      throw new Error(
+        "SendGrid not connected. Run: patchwork-os connect sendgrid or set SENDGRID_API_KEY",
+      );
+    }
+    this.tokens = tokens;
+    return {
+      token: tokens.apiKey,
+      scopes: ["mail.send"],
+    };
+  }
+
+  async healthCheck(): Promise<{ ok: boolean; error?: ConnectorError }> {
+    try {
+      const result = await this.apiCall(async () => {
+        const res = await fetch(`${BASE_URL}/v3/scopes`, {
+          headers: this.buildHeaders(),
+        });
+        if (!res.ok) throw res;
+        return res.json();
+      });
+      if ("error" in result) return { ok: false, error: result.error };
+      return { ok: true };
+    } catch (err) {
+      return { ok: false, error: this.normalizeError(err) };
+    }
+  }
+
+  normalizeError(error: unknown): ConnectorError {
+    if (error instanceof Response) {
+      const s = error.status;
+      if (s === 401)
+        return {
+          code: "auth_expired",
+          message: "SendGrid authentication expired — reconnect",
+          retryable: false,
+          suggestedAction: "patchwork-os connect sendgrid",
+        };
+      if (s === 403)
+        return {
+          code: "permission_denied",
+          message: "Insufficient SendGrid permissions",
+          retryable: false,
+        };
+      if (s === 404)
+        return {
+          code: "not_found",
+          message: "SendGrid resource not found",
+          retryable: false,
+        };
+      if (s === 413)
+        return {
+          code: "provider_error",
+          message: "SendGrid payload too large",
+          retryable: false,
+        };
+      if (s === 429)
+        return {
+          code: "rate_limited",
+          message: "SendGrid API rate limit exceeded",
+          retryable: true,
+          suggestedAction: "Wait and retry",
+        };
+      if (s >= 500)
+        return {
+          code: "provider_error",
+          message: `SendGrid API error: HTTP ${s}`,
+          retryable: true,
+        };
+      return {
+        code: "provider_error",
+        message: `SendGrid API error: HTTP ${s}`,
+        retryable: false,
+      };
+    }
+    if (error instanceof Error) {
+      if (
+        error.message.includes("ENOTFOUND") ||
+        error.message.includes("ECONNREFUSED")
+      ) {
+        return {
+          code: "network_error",
+          message: `Cannot connect to SendGrid: ${error.message}`,
+          retryable: true,
+        };
+      }
+    }
+    return {
+      code: "provider_error",
+      message: error instanceof Error ? error.message : String(error),
+      retryable: false,
+    };
+  }
+
+  getStatus(): ConnectorStatus {
+    const tokens = loadTokens();
+    return {
+      id: "sendgrid",
+      status: tokens ? "connected" : "disconnected",
+      lastSync: tokens?.connected_at,
+      workspace: tokens?.accountName
+        ? `SendGrid (${tokens.accountName})`
+        : tokens?.fromEmail
+          ? `SendGrid <${tokens.fromEmail}>`
+          : undefined,
+    };
+  }
+
+  // ── API Methods ────────────────────────────────────────────────────────────
+
+  async send(params: {
+    to: string;
+    subject: string;
+    text?: string;
+    html?: string;
+    from?: string;
+  }): Promise<SendGridSendResult> {
+    if (!isValidEmail(params.to)) {
+      throw new Error("send: `to` must be a valid email address");
+    }
+    if (typeof params.subject !== "string" || !params.subject.trim()) {
+      throw new Error("send: `subject` is required");
+    }
+    if (!params.text && !params.html) {
+      throw new Error("send: one of `text` or `html` is required");
+    }
+    const tokens = this.tokens ?? loadTokens();
+    const from = params.from ?? tokens?.fromEmail;
+    if (!from) {
+      throw new Error(
+        "send: no `from` provided and no fromEmail stored — pass `from` or reconnect with a verified sender",
+      );
+    }
+    if (!isValidEmail(from)) {
+      throw new Error("send: `from` must be a valid email address");
+    }
+
+    const content: Array<{ type: string; value: string }> = [];
+    if (params.text) content.push({ type: "text/plain", value: params.text });
+    if (params.html) content.push({ type: "text/html", value: params.html });
+
+    const body = {
+      personalizations: [{ to: [{ email: params.to }] }],
+      from: { email: from },
+      subject: params.subject,
+      content,
+    };
+
+    const result = await this.apiCall(async () => {
+      const res = await fetch(`${BASE_URL}/v3/mail/send`, {
+        method: "POST",
+        headers: {
+          ...this.buildHeaders(),
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(body),
+      });
+      if (!res.ok) throw res;
+      // SendGrid returns 202 + X-Message-Id header on success, empty body.
+      const messageId = res.headers.get("x-message-id") ?? "";
+      return { messageId };
+    });
+    if ("error" in result) throw new Error(result.error.message);
+    return result.data;
+  }
+
+  async listTemplates(
+    params: { limit?: number; generations?: "legacy" | "dynamic" } = {},
+  ): Promise<SendGridTemplateListResult> {
+    const result = await this.apiCall(async () => {
+      const qs = new URLSearchParams();
+      if (params.limit) qs.set("page_size", String(params.limit));
+      if (params.generations) qs.set("generations", params.generations);
+      const url = `${BASE_URL}/v3/templates${qs.toString() ? `?${qs}` : ""}`;
+      const res = await fetch(url, { headers: this.buildHeaders() });
+      if (!res.ok) throw res;
+      return res.json() as Promise<SendGridTemplateListResult>;
+    });
+    if ("error" in result) throw new Error(result.error.message);
+    return result.data;
+  }
+
+  async getTemplate(templateId: string): Promise<SendGridTemplate> {
+    if (!templateId || typeof templateId !== "string") {
+      throw new Error("getTemplate: templateId is required");
+    }
+    const result = await this.apiCall(async () => {
+      const res = await fetch(
+        `${BASE_URL}/v3/templates/${encodeURIComponent(templateId)}`,
+        { headers: this.buildHeaders() },
+      );
+      if (!res.ok) throw res;
+      return res.json() as Promise<SendGridTemplate>;
+    });
+    if ("error" in result) throw new Error(result.error.message);
+    return result.data;
+  }
+
+  async listSenders(
+    params: { limit?: number } = {},
+  ): Promise<SendGridSenderListResult> {
+    const result = await this.apiCall(async () => {
+      const qs = new URLSearchParams();
+      if (params.limit) qs.set("limit", String(params.limit));
+      const url = `${BASE_URL}/v3/verified_senders${qs.toString() ? `?${qs}` : ""}`;
+      const res = await fetch(url, { headers: this.buildHeaders() });
+      if (!res.ok) throw res;
+      return res.json() as Promise<SendGridSenderListResult>;
+    });
+    if ("error" in result) throw new Error(result.error.message);
+    return result.data;
+  }
+
+  async getStats(params: {
+    startDate: string;
+    endDate?: string;
+    aggregatedBy?: "day" | "week" | "month";
+  }): Promise<SendGridStatsBucket[]> {
+    if (!params.startDate) {
+      throw new Error("getStats: startDate is required (YYYY-MM-DD)");
+    }
+    const result = await this.apiCall(async () => {
+      const qs = new URLSearchParams();
+      qs.set("start_date", params.startDate);
+      if (params.endDate) qs.set("end_date", params.endDate);
+      if (params.aggregatedBy) qs.set("aggregated_by", params.aggregatedBy);
+      const res = await fetch(`${BASE_URL}/v3/stats?${qs}`, {
+        headers: this.buildHeaders(),
+      });
+      if (!res.ok) throw res;
+      return res.json() as Promise<SendGridStatsBucket[]>;
+    });
+    if ("error" in result) throw new Error(result.error.message);
+    return result.data;
+  }
+
+  // ── Helpers ────────────────────────────────────────────────────────────────
+
+  private buildHeaders(): Record<string, string> {
+    const key = this.tokens?.apiKey ?? loadTokens()?.apiKey ?? "";
+    return {
+      Authorization: `Bearer ${key}`,
+      Accept: "application/json",
+    };
+  }
+}
+
+// ── Token persistence ────────────────────────────────────────────────────────
+
+export function loadTokens(): SendGridTokens | null {
+  const envKey = process.env.SENDGRID_API_KEY;
+  if (envKey) {
+    return {
+      apiKey: envKey,
+      fromEmail: process.env.SENDGRID_FROM_EMAIL,
+      connected_at: new Date().toISOString(),
+    };
+  }
+  return getSecretJsonSync<SendGridTokens>("sendgrid");
+}
+
+export function saveTokens(tokens: SendGridTokens): void {
+  storeSecretJsonSync("sendgrid", tokens);
+}
+
+export function clearTokens(): void {
+  try {
+    deleteSecretJsonSync("sendgrid");
+  } catch {
+    // ignore
+  }
+}
+
+// ── Singleton instance ───────────────────────────────────────────────────────
+
+let _instance: SendGridConnector | null = null;
+
+function resetSendGridConnector(): void {
+  _instance = null;
+}
+
+export function getSendGridConnector(): SendGridConnector {
+  if (!_instance) {
+    _instance = new SendGridConnector();
+  }
+  return _instance;
+}
+
+export { getSendGridConnector as sendgrid };
+
+// ── HTTP Handlers ────────────────────────────────────────────────────────────
+// Wired in src/connectorRoutes.ts under /connections/sendgrid/*
+
+export interface ConnectorHandlerResult {
+  status: number;
+  body: string;
+  contentType?: string;
+}
+
+/**
+ * POST /connections/sendgrid/connect  { apiKey, fromEmail? }
+ */
+export async function handleSendGridConnect(
+  body: string,
+): Promise<ConnectorHandlerResult> {
+  let apiKey: string;
+  let fromEmail: string | undefined;
+
+  try {
+    const parsed = JSON.parse(body) as {
+      apiKey?: unknown;
+      fromEmail?: unknown;
+    };
+    if (typeof parsed.apiKey !== "string" || !parsed.apiKey) {
+      return {
+        status: 400,
+        contentType: "application/json",
+        body: JSON.stringify({ ok: false, error: "apiKey is required" }),
+      };
+    }
+    apiKey = parsed.apiKey;
+    if (parsed.fromEmail !== undefined) {
+      if (
+        typeof parsed.fromEmail !== "string" ||
+        !isValidEmail(parsed.fromEmail)
+      ) {
+        return {
+          status: 400,
+          contentType: "application/json",
+          body: JSON.stringify({
+            ok: false,
+            error: "fromEmail must be a valid email address",
+          }),
+        };
+      }
+      fromEmail = parsed.fromEmail;
+    }
+  } catch {
+    return {
+      status: 400,
+      contentType: "application/json",
+      body: JSON.stringify({ ok: false, error: "Invalid JSON body" }),
+    };
+  }
+
+  try {
+    const res = await fetch(`${BASE_URL}/v3/user/profile`, {
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        Accept: "application/json",
+      },
+    });
+    if (!res.ok) {
+      return {
+        status: 401,
+        contentType: "application/json",
+        body: JSON.stringify({
+          ok: false,
+          error: `Credentials rejected by SendGrid (HTTP ${res.status}) — check apiKey`,
+        }),
+      };
+    }
+    const profile = (await res.json()) as {
+      username?: string;
+      email?: string;
+    };
+
+    const accountName = profile.username ?? undefined;
+
+    const tokens: SendGridTokens = {
+      apiKey,
+      fromEmail,
+      accountName,
+      connected_at: new Date().toISOString(),
+    };
+    saveTokens(tokens);
+    resetSendGridConnector();
+
+    return {
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        ok: true,
+        accountName,
+        fromEmail,
+        connectedAt: tokens.connected_at,
+      }),
+    };
+  } catch (err) {
+    return {
+      status: 500,
+      contentType: "application/json",
+      body: JSON.stringify({
+        ok: false,
+        error: err instanceof Error ? err.message : String(err),
+      }),
+    };
+  }
+}
+
+/**
+ * POST /connections/sendgrid/test
+ */
+export async function handleSendGridTest(): Promise<ConnectorHandlerResult> {
+  const tokens = loadTokens();
+  if (!tokens) {
+    return {
+      status: 400,
+      contentType: "application/json",
+      body: JSON.stringify({ ok: false, error: "SendGrid not connected" }),
+    };
+  }
+  try {
+    const connector = getSendGridConnector();
+    const check = await connector.healthCheck();
+    return {
+      status: check.ok ? 200 : 401,
+      contentType: "application/json",
+      body: JSON.stringify(
+        check.ok ? { ok: true } : { ok: false, error: check.error?.message },
+      ),
+    };
+  } catch (err) {
+    return {
+      status: 500,
+      contentType: "application/json",
+      body: JSON.stringify({
+        ok: false,
+        error: err instanceof Error ? err.message : String(err),
+      }),
+    };
+  }
+}
+
+/**
+ * DELETE /connections/sendgrid
+ */
+export function handleSendGridDisconnect(): ConnectorHandlerResult {
+  clearTokens();
+  resetSendGridConnector();
+  return {
+    status: 200,
+    contentType: "application/json",
+    body: JSON.stringify({ ok: true }),
+  };
+}

--- a/src/connectors/twilio.ts
+++ b/src/connectors/twilio.ts
@@ -1,0 +1,616 @@
+/**
+ * Twilio connector — SMS + account access via the Twilio REST API (2010-04-01).
+ *
+ * Auth: HTTP Basic where username=Account SID (AC...), password=Auth Token.
+ *   - Env vars: TWILIO_ACCOUNT_SID + TWILIO_AUTH_TOKEN (+ optional TWILIO_DEFAULT_FROM)
+ *   - Stored: getSecretJsonSync("twilio") → TwilioTokens
+ *
+ * Tools: sendSms, listMessages, getMessage, listPhoneNumbers, getAccountBalance
+ *
+ * Extends BaseConnector for unified auth, retry, rate-limit, error handling.
+ */
+
+import {
+  type AuthContext,
+  BaseConnector,
+  type ConnectorError,
+  type ConnectorStatus,
+} from "./baseConnector.js";
+import {
+  deleteSecretJsonSync,
+  getSecretJsonSync,
+  storeSecretJsonSync,
+} from "./tokenStorage.js";
+
+export interface TwilioTokens {
+  accountSid: string; // AC...
+  authToken: string;
+  defaultFrom?: string;
+  friendlyName?: string;
+  connected_at: string;
+}
+
+export interface TwilioMessage {
+  sid: string;
+  account_sid: string;
+  to: string;
+  from: string;
+  body: string;
+  status: string;
+  direction: string;
+  date_sent: string | null;
+  date_created: string;
+  date_updated: string;
+  price: string | null;
+  price_unit: string | null;
+  error_code: number | null;
+  error_message: string | null;
+  num_segments: string;
+  num_media: string;
+  uri: string;
+}
+
+export interface TwilioMessageListResult {
+  messages: TwilioMessage[];
+  page: number;
+  page_size: number;
+  next_page_uri: string | null;
+}
+
+export interface TwilioPhoneNumber {
+  sid: string;
+  account_sid: string;
+  phone_number: string;
+  friendly_name: string;
+  capabilities: { voice?: boolean; sms?: boolean; mms?: boolean };
+  date_created: string;
+}
+
+export interface TwilioPhoneNumberListResult {
+  incoming_phone_numbers: TwilioPhoneNumber[];
+  page: number;
+  page_size: number;
+  next_page_uri: string | null;
+}
+
+export interface TwilioBalance {
+  account_sid: string;
+  balance: string;
+  currency: string;
+}
+
+const BASE_URL = "https://api.twilio.com";
+const E164_RE = /^\+\d{8,15}$/;
+
+export class TwilioConnector extends BaseConnector {
+  readonly providerName = "twilio";
+  private tokens: TwilioTokens | null = null;
+
+  protected getOAuthConfig() {
+    return null;
+  }
+
+  async authenticate(): Promise<AuthContext> {
+    const tokens = loadTokens();
+    if (!tokens) {
+      throw new Error(
+        "Twilio not connected. Run: patchwork-os connect twilio or set TWILIO_ACCOUNT_SID + TWILIO_AUTH_TOKEN",
+      );
+    }
+    this.tokens = tokens;
+    return {
+      token: tokens.authToken,
+      scopes: ["read", "write"],
+    };
+  }
+
+  async healthCheck(): Promise<{ ok: boolean; error?: ConnectorError }> {
+    try {
+      const tokens = this.tokens ?? loadTokens();
+      if (!tokens) {
+        return {
+          ok: false,
+          error: {
+            code: "auth_expired",
+            message: "Twilio not connected",
+            retryable: false,
+          },
+        };
+      }
+      this.tokens = tokens;
+      const result = await this.apiCall(async () => {
+        const res = await fetch(
+          `${BASE_URL}/2010-04-01/Accounts/${tokens.accountSid}.json`,
+          { headers: this.buildHeaders() },
+        );
+        if (!res.ok) throw res;
+        return res.json();
+      });
+      if ("error" in result) return { ok: false, error: result.error };
+      return { ok: true };
+    } catch (err) {
+      return { ok: false, error: this.normalizeError(err) };
+    }
+  }
+
+  normalizeError(error: unknown): ConnectorError {
+    if (error instanceof Response) {
+      const s = error.status;
+      if (s === 401)
+        return {
+          code: "auth_expired",
+          message: "Twilio authentication expired — reconnect",
+          retryable: false,
+          suggestedAction: "patchwork-os connect twilio",
+        };
+      if (s === 403)
+        return {
+          code: "permission_denied",
+          message: "Insufficient Twilio permissions",
+          retryable: false,
+        };
+      if (s === 404)
+        return {
+          code: "not_found",
+          message: "Twilio resource not found",
+          retryable: false,
+        };
+      if (s === 429)
+        return {
+          code: "rate_limited",
+          message: "Twilio API rate limit exceeded",
+          retryable: true,
+          suggestedAction: "Wait and retry",
+        };
+      return {
+        code: "provider_error",
+        message: `Twilio API error: HTTP ${s}`,
+        retryable: s >= 500,
+      };
+    }
+    if (
+      error &&
+      typeof error === "object" &&
+      "code" in error &&
+      "message" in error &&
+      typeof (error as { message: unknown }).message === "string"
+    ) {
+      // Twilio JSON error shape: { code, message, status, more_info }
+      const e = error as { code: unknown; message: string; status?: number };
+      const s = typeof e.status === "number" ? e.status : 0;
+      if (s === 401)
+        return {
+          code: "auth_expired",
+          message: `Twilio auth failed: ${e.message}`,
+          retryable: false,
+          suggestedAction: "patchwork-os connect twilio",
+        };
+      if (s === 403)
+        return {
+          code: "permission_denied",
+          message: `Twilio: ${e.message}`,
+          retryable: false,
+        };
+      if (s === 404)
+        return {
+          code: "not_found",
+          message: `Twilio: ${e.message}`,
+          retryable: false,
+        };
+      if (s === 429)
+        return {
+          code: "rate_limited",
+          message: `Twilio: ${e.message}`,
+          retryable: true,
+        };
+      return {
+        code: "provider_error",
+        message: `Twilio [${e.code}]: ${e.message}`,
+        retryable: s >= 500,
+      };
+    }
+    if (error instanceof Error) {
+      if (
+        error.message.includes("ENOTFOUND") ||
+        error.message.includes("ECONNREFUSED")
+      ) {
+        return {
+          code: "network_error",
+          message: `Cannot connect to Twilio: ${error.message}`,
+          retryable: true,
+        };
+      }
+    }
+    return {
+      code: "provider_error",
+      message: error instanceof Error ? error.message : String(error),
+      retryable: false,
+    };
+  }
+
+  getStatus(): ConnectorStatus {
+    const tokens = loadTokens();
+    return {
+      id: "twilio",
+      status: tokens ? "connected" : "disconnected",
+      lastSync: tokens?.connected_at,
+      workspace: tokens?.friendlyName
+        ? `Twilio: ${tokens.friendlyName}`
+        : tokens?.accountSid
+          ? `Twilio account ${tokens.accountSid}`
+          : undefined,
+    };
+  }
+
+  // ── API Methods ────────────────────────────────────────────────────────────
+
+  async sendSms(params: {
+    to: string;
+    body: string;
+    from?: string;
+  }): Promise<TwilioMessage> {
+    if (!params.to || !E164_RE.test(params.to)) {
+      throw new Error(
+        `Invalid 'to' phone number: must be E.164 format (e.g. +14155551234), got: ${params.to}`,
+      );
+    }
+    if (!params.body) {
+      throw new Error("sendSms: 'body' is required");
+    }
+    const tokens = this.tokens ?? loadTokens();
+    if (!tokens) throw new Error("Twilio not connected");
+    this.tokens = tokens;
+    const from = params.from ?? tokens.defaultFrom;
+    if (!from) {
+      throw new Error(
+        "sendSms: no 'from' number provided and no defaultFrom configured",
+      );
+    }
+    if (!E164_RE.test(from)) {
+      throw new Error(
+        `Invalid 'from' phone number: must be E.164 format, got: ${from}`,
+      );
+    }
+    const formBody = new URLSearchParams();
+    formBody.set("To", params.to);
+    formBody.set("From", from);
+    formBody.set("Body", params.body);
+
+    const result = await this.apiCall(async () => {
+      const res = await fetch(
+        `${BASE_URL}/2010-04-01/Accounts/${tokens.accountSid}/Messages.json`,
+        {
+          method: "POST",
+          headers: {
+            ...this.buildHeaders(),
+            "Content-Type": "application/x-www-form-urlencoded",
+          },
+          body: formBody.toString(),
+        },
+      );
+      if (!res.ok) throw res;
+      return res.json() as Promise<TwilioMessage>;
+    });
+    if ("error" in result) throw new Error(result.error.message);
+    return result.data as TwilioMessage;
+  }
+
+  async listMessages(
+    params: {
+      to?: string;
+      from?: string;
+      dateSent?: string;
+      limit?: number;
+    } = {},
+  ): Promise<TwilioMessageListResult> {
+    const tokens = this.tokens ?? loadTokens();
+    if (!tokens) throw new Error("Twilio not connected");
+    this.tokens = tokens;
+    const qs = new URLSearchParams();
+    qs.set("PageSize", String(params.limit ?? 20));
+    if (params.to) qs.set("To", params.to);
+    if (params.from) qs.set("From", params.from);
+    if (params.dateSent) qs.set("DateSent", params.dateSent);
+
+    const result = await this.apiCall(async () => {
+      const res = await fetch(
+        `${BASE_URL}/2010-04-01/Accounts/${tokens.accountSid}/Messages.json?${qs}`,
+        { headers: this.buildHeaders() },
+      );
+      if (!res.ok) throw res;
+      return res.json() as Promise<TwilioMessageListResult>;
+    });
+    if ("error" in result) throw new Error(result.error.message);
+    return result.data as TwilioMessageListResult;
+  }
+
+  async getMessage(messageSid: string): Promise<TwilioMessage> {
+    const tokens = this.tokens ?? loadTokens();
+    if (!tokens) throw new Error("Twilio not connected");
+    this.tokens = tokens;
+    const result = await this.apiCall(async () => {
+      const res = await fetch(
+        `${BASE_URL}/2010-04-01/Accounts/${tokens.accountSid}/Messages/${messageSid}.json`,
+        { headers: this.buildHeaders() },
+      );
+      if (!res.ok) throw res;
+      return res.json() as Promise<TwilioMessage>;
+    });
+    if ("error" in result) throw new Error(result.error.message);
+    return result.data as TwilioMessage;
+  }
+
+  async listPhoneNumbers(
+    params: { limit?: number } = {},
+  ): Promise<TwilioPhoneNumberListResult> {
+    const tokens = this.tokens ?? loadTokens();
+    if (!tokens) throw new Error("Twilio not connected");
+    this.tokens = tokens;
+    const qs = new URLSearchParams();
+    qs.set("PageSize", String(params.limit ?? 20));
+    const result = await this.apiCall(async () => {
+      const res = await fetch(
+        `${BASE_URL}/2010-04-01/Accounts/${tokens.accountSid}/IncomingPhoneNumbers.json?${qs}`,
+        { headers: this.buildHeaders() },
+      );
+      if (!res.ok) throw res;
+      return res.json() as Promise<TwilioPhoneNumberListResult>;
+    });
+    if ("error" in result) throw new Error(result.error.message);
+    return result.data as TwilioPhoneNumberListResult;
+  }
+
+  async getAccountBalance(): Promise<TwilioBalance> {
+    const tokens = this.tokens ?? loadTokens();
+    if (!tokens) throw new Error("Twilio not connected");
+    this.tokens = tokens;
+    const result = await this.apiCall(async () => {
+      const res = await fetch(
+        `${BASE_URL}/2010-04-01/Accounts/${tokens.accountSid}/Balance.json`,
+        { headers: this.buildHeaders() },
+      );
+      if (!res.ok) throw res;
+      return res.json() as Promise<TwilioBalance>;
+    });
+    if ("error" in result) throw new Error(result.error.message);
+    return result.data as TwilioBalance;
+  }
+
+  // ── Helpers ────────────────────────────────────────────────────────────────
+
+  private buildHeaders(): Record<string, string> {
+    const sid = this.tokens?.accountSid ?? "";
+    const tok = this.tokens?.authToken ?? "";
+    const basic = Buffer.from(`${sid}:${tok}`).toString("base64");
+    return {
+      Authorization: `Basic ${basic}`,
+      Accept: "application/json",
+    };
+  }
+}
+
+// ── Token persistence ────────────────────────────────────────────────────────
+
+export function loadTokens(): TwilioTokens | null {
+  const envSid = process.env.TWILIO_ACCOUNT_SID;
+  const envTok = process.env.TWILIO_AUTH_TOKEN;
+  if (envSid && envTok) {
+    return {
+      accountSid: envSid,
+      authToken: envTok,
+      defaultFrom: process.env.TWILIO_DEFAULT_FROM,
+      connected_at: new Date().toISOString(),
+    };
+  }
+  return getSecretJsonSync<TwilioTokens>("twilio");
+}
+
+export function saveTokens(tokens: TwilioTokens): void {
+  storeSecretJsonSync("twilio", tokens);
+}
+
+export function clearTokens(): void {
+  try {
+    deleteSecretJsonSync("twilio");
+  } catch {
+    // ignore
+  }
+}
+
+// ── Singleton instance ───────────────────────────────────────────────────────
+
+let _instance: TwilioConnector | null = null;
+
+function resetTwilioConnector(): void {
+  _instance = null;
+}
+
+export function getTwilioConnector(): TwilioConnector {
+  if (!_instance) {
+    _instance = new TwilioConnector();
+  }
+  return _instance;
+}
+
+export { getTwilioConnector as twilio };
+
+// ── HTTP Handlers ────────────────────────────────────────────────────────────
+// Wired in src/server.ts under /connections/twilio/*
+
+export interface ConnectorHandlerResult {
+  status: number;
+  body: string;
+  contentType?: string;
+}
+
+/**
+ * POST /connections/twilio/connect  { accountSid, authToken, defaultFrom? }
+ */
+export async function handleTwilioConnect(
+  body: string,
+): Promise<ConnectorHandlerResult> {
+  let accountSid: string;
+  let authToken: string;
+  let defaultFrom: string | undefined;
+
+  try {
+    const parsed = JSON.parse(body) as {
+      accountSid?: unknown;
+      authToken?: unknown;
+      defaultFrom?: unknown;
+    };
+    if (typeof parsed.accountSid !== "string" || !parsed.accountSid) {
+      return {
+        status: 400,
+        contentType: "application/json",
+        body: JSON.stringify({ ok: false, error: "accountSid is required" }),
+      };
+    }
+    if (typeof parsed.authToken !== "string" || !parsed.authToken) {
+      return {
+        status: 400,
+        contentType: "application/json",
+        body: JSON.stringify({ ok: false, error: "authToken is required" }),
+      };
+    }
+    if (!parsed.accountSid.startsWith("AC")) {
+      return {
+        status: 400,
+        contentType: "application/json",
+        body: JSON.stringify({
+          ok: false,
+          error: "accountSid must start with 'AC'",
+        }),
+      };
+    }
+    accountSid = parsed.accountSid;
+    authToken = parsed.authToken;
+    if (typeof parsed.defaultFrom === "string" && parsed.defaultFrom) {
+      if (!E164_RE.test(parsed.defaultFrom)) {
+        return {
+          status: 400,
+          contentType: "application/json",
+          body: JSON.stringify({
+            ok: false,
+            error: "defaultFrom must be E.164 format (e.g. +14155551234)",
+          }),
+        };
+      }
+      defaultFrom = parsed.defaultFrom;
+    }
+  } catch {
+    return {
+      status: 400,
+      contentType: "application/json",
+      body: JSON.stringify({ ok: false, error: "Invalid JSON body" }),
+    };
+  }
+
+  try {
+    const basic = Buffer.from(`${accountSid}:${authToken}`).toString("base64");
+    const res = await fetch(
+      `${BASE_URL}/2010-04-01/Accounts/${accountSid}.json`,
+      {
+        headers: {
+          Authorization: `Basic ${basic}`,
+          Accept: "application/json",
+        },
+      },
+    );
+    if (!res.ok) {
+      return {
+        status: 401,
+        contentType: "application/json",
+        body: JSON.stringify({
+          ok: false,
+          error: `Credentials rejected by Twilio (HTTP ${res.status}) — check accountSid + authToken`,
+        }),
+      };
+    }
+    const account = (await res.json()) as {
+      sid?: string;
+      friendly_name?: string;
+    };
+
+    const friendlyName = account.friendly_name ?? undefined;
+    const sid = account.sid ?? accountSid;
+
+    const tokens: TwilioTokens = {
+      accountSid: sid,
+      authToken,
+      defaultFrom,
+      friendlyName,
+      connected_at: new Date().toISOString(),
+    };
+    saveTokens(tokens);
+    resetTwilioConnector();
+
+    return {
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        ok: true,
+        accountSid: sid,
+        friendlyName,
+        defaultFrom,
+        connectedAt: tokens.connected_at,
+      }),
+    };
+  } catch (err) {
+    return {
+      status: 500,
+      contentType: "application/json",
+      body: JSON.stringify({
+        ok: false,
+        error: err instanceof Error ? err.message : String(err),
+      }),
+    };
+  }
+}
+
+/**
+ * POST /connections/twilio/test
+ */
+export async function handleTwilioTest(): Promise<ConnectorHandlerResult> {
+  const tokens = loadTokens();
+  if (!tokens) {
+    return {
+      status: 400,
+      contentType: "application/json",
+      body: JSON.stringify({ ok: false, error: "Twilio not connected" }),
+    };
+  }
+  try {
+    const connector = getTwilioConnector();
+    const check = await connector.healthCheck();
+    return {
+      status: check.ok ? 200 : 401,
+      contentType: "application/json",
+      body: JSON.stringify(
+        check.ok ? { ok: true } : { ok: false, error: check.error?.message },
+      ),
+    };
+  } catch (err) {
+    return {
+      status: 500,
+      contentType: "application/json",
+      body: JSON.stringify({
+        ok: false,
+        error: err instanceof Error ? err.message : String(err),
+      }),
+    };
+  }
+}
+
+/**
+ * DELETE /connections/twilio
+ */
+export function handleTwilioDisconnect(): ConnectorHandlerResult {
+  clearTokens();
+  resetTwilioConnector();
+  return {
+    status: 200,
+    contentType: "application/json",
+    body: JSON.stringify({ ok: true }),
+  };
+}

--- a/src/connectors/webflow.ts
+++ b/src/connectors/webflow.ts
@@ -1,0 +1,538 @@
+/**
+ * Webflow connector — read-only access to Webflow CMS via the Webflow v2 API.
+ *
+ * Auth: Site API Token via `Authorization: Bearer <token>` + `accept-version: 2.0.0`.
+ *   - Env var: WEBFLOW_API_TOKEN (+ optional WEBFLOW_SITE_ID)
+ *   - Stored: getSecretJsonSync("webflow") → WebflowTokens
+ *
+ * Tools: listSites, getSite, listCollections, getCollection, listCollectionItems,
+ *        getCollectionItem, listForms, listFormSubmissions
+ *
+ * Extends BaseConnector for unified auth, retry, rate-limit, error handling.
+ */
+
+import {
+  type AuthContext,
+  BaseConnector,
+  type ConnectorError,
+  type ConnectorStatus,
+} from "./baseConnector.js";
+import {
+  deleteSecretJsonSync,
+  getSecretJsonSync,
+  storeSecretJsonSync,
+} from "./tokenStorage.js";
+
+export interface WebflowTokens {
+  accessToken: string;
+  siteId?: string;
+  siteName?: string;
+  connected_at: string;
+}
+
+export interface WebflowSite {
+  id: string;
+  displayName?: string;
+  shortName?: string;
+  workspaceId?: string;
+  createdOn?: string;
+  lastPublished?: string;
+}
+
+export interface WebflowCollection {
+  id: string;
+  displayName?: string;
+  singularName?: string;
+  slug?: string;
+  createdOn?: string;
+  lastUpdated?: string;
+}
+
+export interface WebflowCollectionItem {
+  id: string;
+  cmsLocaleId?: string;
+  lastPublished?: string | null;
+  lastUpdated?: string;
+  createdOn?: string;
+  isArchived?: boolean;
+  isDraft?: boolean;
+  fieldData?: Record<string, unknown>;
+}
+
+export interface WebflowForm {
+  id: string;
+  displayName?: string;
+  createdOn?: string;
+  lastUpdated?: string;
+  fields?: Record<string, unknown>;
+}
+
+export interface WebflowFormSubmission {
+  id: string;
+  displayName?: string;
+  siteId?: string;
+  formId?: string;
+  dateSubmitted?: string;
+  formResponse?: Record<string, unknown>;
+}
+
+export interface WebflowListResult<T> {
+  items: T[];
+  pagination?: {
+    limit?: number;
+    offset?: number;
+    total?: number;
+  };
+}
+
+const BASE_URL = "https://api.webflow.com/v2";
+const MAX_LIMIT = 100;
+
+export class WebflowConnector extends BaseConnector {
+  readonly providerName = "webflow";
+  private tokens: WebflowTokens | null = null;
+
+  protected getOAuthConfig() {
+    return null;
+  }
+
+  async authenticate(): Promise<AuthContext> {
+    const tokens = loadTokens();
+    if (!tokens) {
+      throw new Error(
+        "Webflow not connected. Run: patchwork-os connect webflow or set WEBFLOW_API_TOKEN",
+      );
+    }
+    this.tokens = tokens;
+    return {
+      token: tokens.accessToken,
+      scopes: ["read"],
+    };
+  }
+
+  async healthCheck(): Promise<{ ok: boolean; error?: ConnectorError }> {
+    try {
+      const result = await this.apiCall(async () => {
+        const res = await fetch(`${BASE_URL}/token/authorized_by`, {
+          headers: this.buildHeaders(),
+        });
+        if (!res.ok) throw res;
+        return res.json();
+      });
+      if ("error" in result) return { ok: false, error: result.error };
+      return { ok: true };
+    } catch (err) {
+      return { ok: false, error: this.normalizeError(err) };
+    }
+  }
+
+  normalizeError(error: unknown): ConnectorError {
+    if (error instanceof Response) {
+      const s = error.status;
+      if (s === 400)
+        return {
+          code: "provider_error",
+          message: `Webflow API bad request (HTTP 400)`,
+          retryable: false,
+        };
+      if (s === 401)
+        return {
+          code: "auth_expired",
+          message: "Webflow authentication expired — reconnect",
+          retryable: false,
+          suggestedAction: "patchwork-os connect webflow",
+        };
+      if (s === 403)
+        return {
+          code: "permission_denied",
+          message: "Insufficient Webflow permissions",
+          retryable: false,
+        };
+      if (s === 404)
+        return {
+          code: "not_found",
+          message: "Webflow resource not found",
+          retryable: false,
+        };
+      if (s === 429)
+        return {
+          code: "rate_limited",
+          message: "Webflow API rate limit exceeded",
+          retryable: true,
+          suggestedAction: "Wait and retry",
+        };
+      return {
+        code: "provider_error",
+        message: `Webflow API error: HTTP ${s}`,
+        retryable: s >= 500,
+      };
+    }
+    if (error instanceof Error) {
+      if (
+        error.message.includes("ENOTFOUND") ||
+        error.message.includes("ECONNREFUSED")
+      ) {
+        return {
+          code: "network_error",
+          message: `Cannot connect to Webflow: ${error.message}`,
+          retryable: true,
+        };
+      }
+    }
+    return {
+      code: "provider_error",
+      message: error instanceof Error ? error.message : String(error),
+      retryable: false,
+    };
+  }
+
+  getStatus(): ConnectorStatus {
+    const tokens = loadTokens();
+    return {
+      id: "webflow",
+      status: tokens ? "connected" : "disconnected",
+      lastSync: tokens?.connected_at,
+      workspace: tokens?.siteName
+        ? `Webflow site ${tokens.siteName}`
+        : tokens?.siteId
+          ? `Webflow site ${tokens.siteId}`
+          : undefined,
+    };
+  }
+
+  // ── API Methods ────────────────────────────────────────────────────────────
+
+  async listSites(): Promise<WebflowListResult<WebflowSite>> {
+    const result = await this.apiCall(async () => {
+      const res = await fetch(`${BASE_URL}/sites`, {
+        headers: this.buildHeaders(),
+      });
+      if (!res.ok) throw res;
+      return res.json() as Promise<{ sites?: WebflowSite[] }>;
+    });
+    if ("error" in result) throw new Error(result.error.message);
+    const data = result.data as { sites?: WebflowSite[] };
+    return { items: data.sites ?? [] };
+  }
+
+  async getSite(siteId: string): Promise<WebflowSite> {
+    const result = await this.apiCall(async () => {
+      const res = await fetch(
+        `${BASE_URL}/sites/${encodeURIComponent(siteId)}`,
+        { headers: this.buildHeaders() },
+      );
+      if (!res.ok) throw res;
+      return res.json() as Promise<WebflowSite>;
+    });
+    if ("error" in result) throw new Error(result.error.message);
+    return result.data as WebflowSite;
+  }
+
+  async listCollections(
+    siteId: string,
+  ): Promise<WebflowListResult<WebflowCollection>> {
+    const result = await this.apiCall(async () => {
+      const res = await fetch(
+        `${BASE_URL}/sites/${encodeURIComponent(siteId)}/collections`,
+        { headers: this.buildHeaders() },
+      );
+      if (!res.ok) throw res;
+      return res.json() as Promise<{ collections?: WebflowCollection[] }>;
+    });
+    if ("error" in result) throw new Error(result.error.message);
+    const data = result.data as { collections?: WebflowCollection[] };
+    return { items: data.collections ?? [] };
+  }
+
+  async getCollection(collectionId: string): Promise<WebflowCollection> {
+    const result = await this.apiCall(async () => {
+      const res = await fetch(
+        `${BASE_URL}/collections/${encodeURIComponent(collectionId)}`,
+        { headers: this.buildHeaders() },
+      );
+      if (!res.ok) throw res;
+      return res.json() as Promise<WebflowCollection>;
+    });
+    if ("error" in result) throw new Error(result.error.message);
+    return result.data as WebflowCollection;
+  }
+
+  async listCollectionItems(
+    collectionId: string,
+    params: { limit?: number; offset?: number } = {},
+  ): Promise<WebflowListResult<WebflowCollectionItem>> {
+    const limit = Math.min(params.limit ?? MAX_LIMIT, MAX_LIMIT);
+    const offset = params.offset ?? 0;
+    const result = await this.apiCall(async () => {
+      const qs = new URLSearchParams();
+      qs.set("limit", String(limit));
+      qs.set("offset", String(offset));
+      const res = await fetch(
+        `${BASE_URL}/collections/${encodeURIComponent(collectionId)}/items?${qs}`,
+        { headers: this.buildHeaders() },
+      );
+      if (!res.ok) throw res;
+      return res.json() as Promise<{
+        items?: WebflowCollectionItem[];
+        pagination?: WebflowListResult<WebflowCollectionItem>["pagination"];
+      }>;
+    });
+    if ("error" in result) throw new Error(result.error.message);
+    const data = result.data as {
+      items?: WebflowCollectionItem[];
+      pagination?: WebflowListResult<WebflowCollectionItem>["pagination"];
+    };
+    return { items: data.items ?? [], pagination: data.pagination };
+  }
+
+  async getCollectionItem(
+    collectionId: string,
+    itemId: string,
+  ): Promise<WebflowCollectionItem> {
+    const result = await this.apiCall(async () => {
+      const res = await fetch(
+        `${BASE_URL}/collections/${encodeURIComponent(
+          collectionId,
+        )}/items/${encodeURIComponent(itemId)}`,
+        { headers: this.buildHeaders() },
+      );
+      if (!res.ok) throw res;
+      return res.json() as Promise<WebflowCollectionItem>;
+    });
+    if ("error" in result) throw new Error(result.error.message);
+    return result.data as WebflowCollectionItem;
+  }
+
+  async listForms(siteId: string): Promise<WebflowListResult<WebflowForm>> {
+    const result = await this.apiCall(async () => {
+      const res = await fetch(
+        `${BASE_URL}/sites/${encodeURIComponent(siteId)}/forms`,
+        { headers: this.buildHeaders() },
+      );
+      if (!res.ok) throw res;
+      return res.json() as Promise<{ forms?: WebflowForm[] }>;
+    });
+    if ("error" in result) throw new Error(result.error.message);
+    const data = result.data as { forms?: WebflowForm[] };
+    return { items: data.forms ?? [] };
+  }
+
+  async listFormSubmissions(
+    formId: string,
+    params: { limit?: number; offset?: number } = {},
+  ): Promise<WebflowListResult<WebflowFormSubmission>> {
+    const limit = Math.min(params.limit ?? MAX_LIMIT, MAX_LIMIT);
+    const offset = params.offset ?? 0;
+    const result = await this.apiCall(async () => {
+      const qs = new URLSearchParams();
+      qs.set("limit", String(limit));
+      qs.set("offset", String(offset));
+      const res = await fetch(
+        `${BASE_URL}/forms/${encodeURIComponent(formId)}/submissions?${qs}`,
+        { headers: this.buildHeaders() },
+      );
+      if (!res.ok) throw res;
+      return res.json() as Promise<{
+        formSubmissions?: WebflowFormSubmission[];
+        pagination?: WebflowListResult<WebflowFormSubmission>["pagination"];
+      }>;
+    });
+    if ("error" in result) throw new Error(result.error.message);
+    const data = result.data as {
+      formSubmissions?: WebflowFormSubmission[];
+      pagination?: WebflowListResult<WebflowFormSubmission>["pagination"];
+    };
+    return { items: data.formSubmissions ?? [], pagination: data.pagination };
+  }
+
+  // ── Helpers ────────────────────────────────────────────────────────────────
+
+  private buildHeaders(): Record<string, string> {
+    const token = this.tokens?.accessToken ?? "";
+    return {
+      Authorization: `Bearer ${token}`,
+      Accept: "application/json",
+      "accept-version": "2.0.0",
+    };
+  }
+}
+
+// ── Token persistence ────────────────────────────────────────────────────────
+
+export function loadTokens(): WebflowTokens | null {
+  const envToken = process.env.WEBFLOW_API_TOKEN;
+  if (envToken) {
+    return {
+      accessToken: envToken,
+      siteId: process.env.WEBFLOW_SITE_ID,
+      connected_at: new Date().toISOString(),
+    };
+  }
+  return getSecretJsonSync<WebflowTokens>("webflow");
+}
+
+export function saveTokens(tokens: WebflowTokens): void {
+  storeSecretJsonSync("webflow", tokens);
+}
+
+export function clearTokens(): void {
+  try {
+    deleteSecretJsonSync("webflow");
+  } catch {
+    // ignore
+  }
+}
+
+// ── Singleton instance ───────────────────────────────────────────────────────
+
+let _instance: WebflowConnector | null = null;
+
+function resetWebflowConnector(): void {
+  _instance = null;
+}
+
+export function getWebflowConnector(): WebflowConnector {
+  if (!_instance) {
+    _instance = new WebflowConnector();
+  }
+  return _instance;
+}
+
+export { getWebflowConnector as webflow };
+
+// ── HTTP Handlers ────────────────────────────────────────────────────────────
+// Wired in src/server.ts under /connections/webflow/*
+
+export interface ConnectorHandlerResult {
+  status: number;
+  body: string;
+  contentType?: string;
+}
+
+/**
+ * POST /connections/webflow/connect  { accessToken }
+ * Validates by GET /v2/sites; captures first site's id + displayName.
+ */
+export async function handleWebflowConnect(
+  body: string,
+): Promise<ConnectorHandlerResult> {
+  let accessToken: string;
+
+  try {
+    const parsed = JSON.parse(body) as { accessToken?: unknown };
+    if (typeof parsed.accessToken !== "string" || !parsed.accessToken) {
+      return {
+        status: 400,
+        contentType: "application/json",
+        body: JSON.stringify({ ok: false, error: "accessToken is required" }),
+      };
+    }
+    accessToken = parsed.accessToken;
+  } catch {
+    return {
+      status: 400,
+      contentType: "application/json",
+      body: JSON.stringify({ ok: false, error: "Invalid JSON body" }),
+    };
+  }
+
+  try {
+    const res = await fetch(`${BASE_URL}/sites`, {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        Accept: "application/json",
+        "accept-version": "2.0.0",
+      },
+    });
+    if (!res.ok) {
+      return {
+        status: 401,
+        contentType: "application/json",
+        body: JSON.stringify({
+          ok: false,
+          error: `Credentials rejected by Webflow (HTTP ${res.status}) — check accessToken`,
+        }),
+      };
+    }
+    const data = (await res.json()) as { sites?: WebflowSite[] };
+    const firstSite = data.sites?.[0];
+    const siteId = firstSite?.id;
+    const siteName = firstSite?.displayName;
+
+    const tokens: WebflowTokens = {
+      accessToken,
+      siteId,
+      siteName,
+      connected_at: new Date().toISOString(),
+    };
+    saveTokens(tokens);
+    resetWebflowConnector();
+
+    return {
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        ok: true,
+        siteId,
+        siteName,
+        connectedAt: tokens.connected_at,
+      }),
+    };
+  } catch (err) {
+    return {
+      status: 500,
+      contentType: "application/json",
+      body: JSON.stringify({
+        ok: false,
+        error: err instanceof Error ? err.message : String(err),
+      }),
+    };
+  }
+}
+
+/**
+ * POST /connections/webflow/test
+ */
+export async function handleWebflowTest(): Promise<ConnectorHandlerResult> {
+  const tokens = loadTokens();
+  if (!tokens) {
+    return {
+      status: 400,
+      contentType: "application/json",
+      body: JSON.stringify({ ok: false, error: "Webflow not connected" }),
+    };
+  }
+  try {
+    const connector = getWebflowConnector();
+    const check = await connector.healthCheck();
+    return {
+      status: check.ok ? 200 : 401,
+      contentType: "application/json",
+      body: JSON.stringify(
+        check.ok ? { ok: true } : { ok: false, error: check.error?.message },
+      ),
+    };
+  } catch (err) {
+    return {
+      status: 500,
+      contentType: "application/json",
+      body: JSON.stringify({
+        ok: false,
+        error: err instanceof Error ? err.message : String(err),
+      }),
+    };
+  }
+}
+
+/**
+ * DELETE /connections/webflow
+ */
+export function handleWebflowDisconnect(): ConnectorHandlerResult {
+  clearTokens();
+  resetWebflowConnector();
+  return {
+    status: 200,
+    contentType: "application/json",
+    body: JSON.stringify({ ok: true }),
+  };
+}

--- a/src/recipes/tools/gmail.ts
+++ b/src/recipes/tools/gmail.ts
@@ -477,8 +477,15 @@ registerTool({
 
     for (const msg of messages) {
       const subject = msg.subject ?? "";
+      // Gemini's notification email format changed at least once. Earlier
+      // emails said "Notes by Gemini" in the subject; the current format
+      // (as of 2026) is `Notes: "<meeting title>" <date>` from
+      // gemini-notes@google.com — no "by Gemini" anywhere. Match both, plus
+      // the generic Drive-share variants Drive uses when the Doc is shared
+      // separately. Also accept any subject that already references a
+      // docs.google.com URL via the snippet.
       const isGemini =
-        /notes by gemini|document shared with you|shared a document|invited you to (?:edit|view|comment)/i.test(
+        /notes by gemini|^notes:\s|document shared with you|shared a document|invited you to (?:edit|view|comment)/i.test(
           subject,
         ) ||
         /notes by gemini|docs\.google\.com\/document/i.test(msg.snippet ?? "");

--- a/src/recipes/tools/gmail.ts
+++ b/src/recipes/tools/gmail.ts
@@ -507,20 +507,25 @@ registerTool({
         continue;
       }
 
-      // Gemini notes — fetch full message to get Drive URL
+      // Gemini notes — fetch full message and look for either a Doc URL OR
+      // an inlined-body. Newer Gemini emails (2026+) inline the full notes
+      // directly in the email body and DON'T include a docs.google.com URL.
+      // Older Gemini / Meet emails just link to a Drive doc.
       let driveUrl = "";
+      let emailBody = "";
       try {
         const fullMsg = await gmailGetMessage(msg.id, deps);
         const parsed = JSON.parse(fullMsg) as {
           links?: string[];
           body?: string;
         };
+        emailBody = parsed.body ?? "";
         const links = parsed.links ?? [];
         driveUrl = links.find(isDocsGoogleHost) ?? "";
         if (!driveUrl) {
           // Try extracting from body text
           const bodyMatch = /https?:\/\/docs\.google\.com\/[^\s"'<>]+/.exec(
-            parsed.body ?? "",
+            emailBody,
           );
           driveUrl = bodyMatch?.[0] ?? "";
         }
@@ -535,11 +540,15 @@ registerTool({
       }
 
       if (!driveUrl) {
+        // No linked Doc — use the email body itself as the meeting content.
+        // Gemini's inlined-notes format is what the parser already expects:
+        // a "Summary" section, topical sections, etc. Fall back to snippet
+        // only when even the body is empty (rare).
         results.push({
           emailId: msg.id,
           subject,
           source: "email",
-          content: msg.snippet ?? "",
+          content: emailBody.length > 0 ? emailBody : (msg.snippet ?? ""),
         });
         continue;
       }

--- a/src/recipes/tools/gmail.ts
+++ b/src/recipes/tools/gmail.ts
@@ -69,7 +69,13 @@ async function gmailSearch(
     // 2. Fetch details for each message
     const messages = await Promise.all(
       ids.slice(0, max).map(async (m) => {
-        const detailUrl = `https://www.googleapis.com/gmail/v1/users/me/messages/${m.id}?format=metadata&metadataHeaders=Subject,From,Date`;
+        // Gmail's metadataHeaders param must be REPEATED per header, not
+        // comma-joined. `metadataHeaders=Subject,From,Date` is silently
+        // dropped server-side — the response then carries an empty
+        // headers array and every {subject,from,date} field returns "",
+        // which made downstream tools that branch on the subject (e.g.
+        // resolveMeetingNotes) silently no-op against real emails.
+        const detailUrl = `https://www.googleapis.com/gmail/v1/users/me/messages/${m.id}?format=metadata&metadataHeaders=Subject&metadataHeaders=From&metadataHeaders=Date`;
         const detailRes = await fetch(detailUrl, {
           headers: { Authorization: `Bearer ${token}` },
         });


### PR DESCRIPTION
## Summary

Five PAT-only HTTP connectors (no new deps, global `fetch`). Follow-up to #778.

| Connector | Auth | Key tools |
|---|---|---|
| SendGrid | Bearer `SG.…` | `send`, `listTemplates`, `getStats` |
| Twilio | Basic (SID + auth token) | `sendSms`, `listMessages`, `getAccountBalance` |
| Figma | `X-Figma-Token` | `getFile`, `getImageUrls`, `getFileComments` |
| Airtable | Bearer PAT | `listRecords`, `createRecord`, `updateRecord` |
| Webflow | Bearer + `accept-version: 2.0.0` | `listCollectionItems`, `listFormSubmissions` |

## Stats

- **+5,082 LOC** across 15 files
- **103/103 new tests passing**, full bridge suite 5945 ✓, dashboard 664 ✓
- `tsc --noEmit` clean unfiltered, all files report UTF-8 text, biome clean

## Wave 1a lessons applied (no CI traps this time)

1. ✅ Ran `npm run typecheck` UNFILTERED before push (Wave 1a missed `@ts-expect-error`)
2. ✅ Ran `file src/connectors/*.ts` — all UTF-8 (Wave 1a had a literal NUL byte)
3. ✅ Updated `gmail.ts` `handleConnectionsList` loader map in the same commit
4. ✅ Updated dashboard `registry.test.ts` EXPECTED snapshot in the same commit
5. ✅ Scrubbed realistic-looking token-shape placeholders so GitHub secret scanner doesn't reject the push

## Test plan

- [ ] Connect SendGrid via dashboard with a real API key; verify `/connections/sendgrid/test` returns 200
- [ ] Connect Twilio (SID + auth token + From number); `sendSms` to a verified number
- [ ] Connect Figma with a PAT scoped to file_read; `getFile` returns truncated tree at depth=2
- [ ] Connect Airtable with PAT scoped to one base; `listRecords` honours `maxRecords` cap at 1000
- [ ] Connect Webflow with site token; `listCollectionItems` honours limit cap at 100

## Follow-ups (not in this PR)

- **Docs**: extend the existing Google connector cluster with Google Docs API (different shape from PAT pattern, deserves its own PR)
- **Wave 3 stubs**: Monday, Salesforce, Shopify, Snowflake — these need YOU to register vendor OAuth apps before code can ship. Stub UI showing "Configure OAuth app" will land next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)