### PR TITLE
feat(connectors): Google Docs — read-only, extends Google OAuth cluster

### DIFF
--- a/dashboard/src/app/api/connections/[connector]/__tests__/registry.test.ts
+++ b/dashboard/src/app/api/connections/[connector]/__tests__/registry.test.ts
@@ -21,6 +21,8 @@ const EXPECTED_AUTH = new Set([
   "gmail", "google-calendar", "google-drive", "github", "linear", "sentry",
   "slack", "asana", "discord", "gitlab",
   "notion", "confluence", "datadog", "hubspot", "intercom", "stripe", "zendesk",
+  // Wave 3 — Google Docs (extends Google cluster).
+  "google-docs",
 ]);
 const EXPECTED_CONNECT = new Set([
   "notion", "confluence", "datadog", "hubspot", "intercom", "stripe",
@@ -43,6 +45,8 @@ const EXPECTED_TEST = new Set([
   "sendgrid", "twilio",
   // Wave 2 — PAT SaaS connectors.
   "figma", "airtable", "webflow",
+  // Wave 3 — Google Docs (OAuth).
+  "google-docs",
 ]);
 const EXPECTED_DELETE = EXPECTED_TEST;
 

--- a/dashboard/src/app/connections/page.tsx
+++ b/dashboard/src/app/connections/page.tsx
@@ -46,7 +46,7 @@ const CATALOG: ConnectorDef[] = [
   { id: "jira",             name: "Jira",             initials: "JI", category: "Project",    wave: 1, tools: 8,  bg: "#0052CC" },
   { id: "notion",           name: "Notion",           initials: "NO", category: "Docs",       wave: 1, tools: 6,  bg: "#000000" },
   { id: "pagerduty",        name: "PagerDuty",        initials: "PD", category: "Ops",        wave: 1, tools: 7,  bg: "#06AC38" },
-  { id: "docs",             name: "Docs",             initials: "DO", category: "Docs",       wave: 1, tools: 3,  bg: "#4285F4" },
+  { id: "google-docs",      name: "Google Docs",      initials: "DO", category: "Docs",       wave: 1, tools: 2,  bg: "#4285F4" },
   { id: "confluence",       name: "Confluence",       initials: "CF", category: "Docs",       wave: 1, tools: 5,  bg: "#0052CC" },
   { id: "linear",           name: "Linear",           initials: "LI", category: "Project",    wave: 1, tools: 6,  bg: "#5E6AD2" },
   { id: "slack",            name: "Slack",            initials: "SL", category: "Comms",      wave: 1, tools: 7,  bg: "#4A154B" },
@@ -330,6 +330,7 @@ const SUPPORTED_CONNECTORS = new Set([
   "figma",
   "airtable",
   "webflow",
+  "google-docs",
 ]);
 
 const TOKEN_MODAL_CONNECTORS: Record<string, TokenModalConfig> = {

--- a/src/connectorRoutes.ts
+++ b/src/connectorRoutes.ts
@@ -196,6 +196,29 @@ export function tryHandlePublicConnectorRoute(
     return true;
   }
   if (
+    parsedUrl.pathname === "/connections/google-docs/callback" &&
+    req.method === "GET"
+  ) {
+    void (async () => {
+      try {
+        const { handleDocsCallback } = await import(
+          "./connectors/googleDocs.js"
+        );
+        const code = parsedUrl.searchParams.get("code");
+        const state = parsedUrl.searchParams.get("state");
+        const error = parsedUrl.searchParams.get("error");
+        const result = await handleDocsCallback(code, state, error);
+        res.writeHead(result.status, {
+          "Content-Type": result.contentType ?? "application/json",
+        });
+        res.end(result.body);
+      } catch (err) {
+        respond500(res, err);
+      }
+    })();
+    return true;
+  }
+  if (
     parsedUrl.pathname === "/connections/slack/callback" &&
     req.method === "GET"
   ) {
@@ -1918,6 +1941,71 @@ export function tryHandleConnectorRoute(
           "./connectors/googleDrive.js"
         );
         const result = await handleDriveDisconnect();
+        res.writeHead(result.status, {
+          "Content-Type": result.contentType ?? "application/json",
+        });
+        res.end(result.body);
+      } catch (err) {
+        respond500(res, err);
+      }
+    })();
+    return true;
+  }
+
+  // ── Google Docs routes ──────────────────────────────────────────
+  if (
+    parsedUrl.pathname === "/connections/google-docs/auth" &&
+    req.method === "GET"
+  ) {
+    void (async () => {
+      try {
+        const { handleDocsAuthRedirect } = await import(
+          "./connectors/googleDocs.js"
+        );
+        const result = handleDocsAuthRedirect();
+        if (result.redirect) {
+          res.writeHead(302, { Location: result.redirect });
+          res.end();
+        } else {
+          res.writeHead(result.status, {
+            "Content-Type": result.contentType ?? "application/json",
+          });
+          res.end(result.body);
+        }
+      } catch (err) {
+        respond500(res, err);
+      }
+    })();
+    return true;
+  }
+  if (
+    parsedUrl.pathname === "/connections/google-docs/test" &&
+    req.method === "POST"
+  ) {
+    void (async () => {
+      try {
+        const { handleDocsTest } = await import("./connectors/googleDocs.js");
+        const result = await handleDocsTest();
+        res.writeHead(result.status, {
+          "Content-Type": result.contentType ?? "application/json",
+        });
+        res.end(result.body);
+      } catch (err) {
+        respond500(res, err);
+      }
+    })();
+    return true;
+  }
+  if (
+    parsedUrl.pathname === "/connections/google-docs" &&
+    req.method === "DELETE"
+  ) {
+    void (async () => {
+      try {
+        const { handleDocsDisconnect } = await import(
+          "./connectors/googleDocs.js"
+        );
+        const result = await handleDocsDisconnect();
         res.writeHead(result.status, {
           "Content-Type": result.contentType ?? "application/json",
         });

--- a/src/connectors/__tests__/googleDocs.test.ts
+++ b/src/connectors/__tests__/googleDocs.test.ts
@@ -1,0 +1,529 @@
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return {
+    ...actual,
+    existsSync: vi.fn().mockReturnValue(false),
+    readFileSync: vi.fn().mockReturnValue("{}"),
+    writeFileSync: vi.fn(),
+    renameSync: vi.fn(),
+    chmodSync: vi.fn(),
+    unlinkSync: vi.fn(),
+    mkdirSync: vi.fn(),
+  };
+});
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+import * as fs from "node:fs";
+import {
+  extractDocumentId,
+  getDocument,
+  getDocumentText,
+  getStatus,
+  getValidAccessToken,
+  handleDocsAuthRedirect,
+  handleDocsCallback,
+  handleDocsDisconnect,
+  handleDocsTest,
+  loadTokens,
+  normalizeError,
+} from "../googleDocs.js";
+
+const ONE_HOUR = 60 * 60 * 1000;
+
+function mockTokens(overrides: Record<string, unknown> = {}) {
+  vi.mocked(fs.existsSync).mockReturnValue(true);
+  vi.mocked(fs.readFileSync).mockReturnValue(
+    JSON.stringify({
+      access_token: "at_test",
+      refresh_token: "rt_test",
+      expiry_date: Date.now() + ONE_HOUR,
+      connected_at: "2026-05-22T00:00:00.000Z",
+      ...overrides,
+    }),
+  );
+}
+
+function jsonResponse(body: unknown, ok = true, status = 200): Response {
+  return {
+    ok,
+    status,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as unknown as Response;
+}
+
+function textResponse(text: string, ok = true, status = 200): Response {
+  return {
+    ok,
+    status,
+    text: async () => text,
+    json: async () => ({}),
+  } as unknown as Response;
+}
+
+beforeEach(() => {
+  vi.mocked(fs.existsSync).mockReturnValue(false);
+  vi.mocked(fs.readFileSync).mockReturnValue("{}");
+  mockFetch.mockReset();
+  process.env.GOOGLE_DOCS_CLIENT_ID = "env_cid";
+  process.env.GOOGLE_DOCS_CLIENT_SECRET = "env_csecret";
+  process.env.PATCHWORK_TOKEN_DIR = path.join(
+    os.tmpdir(),
+    `patchwork-docs-test-${Date.now()}`,
+  );
+  process.env.PATCHWORK_HOME = process.env.PATCHWORK_TOKEN_DIR;
+  process.env.PATCHWORK_TOKEN_STORAGE_BACKEND = "file";
+});
+
+afterEach(() => {
+  delete process.env.GOOGLE_DOCS_CLIENT_ID;
+  delete process.env.GOOGLE_DOCS_CLIENT_SECRET;
+  delete process.env.PATCHWORK_TOKEN_DIR;
+  delete process.env.PATCHWORK_HOME;
+  delete process.env.PATCHWORK_TOKEN_STORAGE_BACKEND;
+  vi.restoreAllMocks();
+});
+
+describe("extractDocumentId", () => {
+  it("extracts ID from /document/d/<id> URL", () => {
+    expect(
+      extractDocumentId("https://docs.google.com/document/d/abc123_-XYZ/edit"),
+    ).toBe("abc123_-XYZ");
+  });
+
+  it("returns input unchanged when already a bare ID", () => {
+    expect(extractDocumentId("abc123_-XYZ")).toBe("abc123_-XYZ");
+  });
+});
+
+describe("normalizeError", () => {
+  it("401 → auth_expired (non-retryable)", () => {
+    const n = normalizeError(401, "expired");
+    expect(n.kind).toBe("auth_expired");
+    expect(n.retryable).toBe(false);
+  });
+
+  it("403 → permission_denied (non-retryable)", () => {
+    expect(normalizeError(403, "nope").kind).toBe("permission_denied");
+  });
+
+  it("404 → not_found (non-retryable)", () => {
+    const n = normalizeError(404, "gone");
+    expect(n.kind).toBe("not_found");
+    expect(n.retryable).toBe(false);
+  });
+
+  it("429 → rate_limited (retryable)", () => {
+    const n = normalizeError(429, "");
+    expect(n.kind).toBe("rate_limited");
+    expect(n.retryable).toBe(true);
+  });
+
+  it("500 → provider_error (retryable)", () => {
+    const n = normalizeError(503, "");
+    expect(n.kind).toBe("provider_error");
+    expect(n.retryable).toBe(true);
+  });
+
+  it("unmatched status → unknown_error", () => {
+    expect(normalizeError(418, "tea").kind).toBe("unknown_error");
+  });
+});
+
+describe("loadTokens", () => {
+  it("returns null when no file present", () => {
+    expect(loadTokens()).toBeNull();
+  });
+
+  it("returns parsed tokens when legacy file exists", () => {
+    mockTokens({ email: "u@example.com" });
+    const tokens = loadTokens();
+    expect(tokens).toMatchObject({
+      access_token: "at_test",
+      refresh_token: "rt_test",
+      email: "u@example.com",
+    });
+  });
+
+  it("returns null when file content is invalid JSON", () => {
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.readFileSync).mockReturnValue("{ not json");
+    expect(loadTokens()).toBeNull();
+  });
+});
+
+describe("getStatus", () => {
+  it("returns disconnected when no tokens", () => {
+    expect(getStatus()).toMatchObject({
+      id: "google-docs",
+      status: "disconnected",
+    });
+  });
+
+  it("returns connected when token still valid", () => {
+    mockTokens({ email: "u@example.com" });
+    const s = getStatus();
+    expect(s.status).toBe("connected");
+    expect(s.email).toBe("u@example.com");
+  });
+
+  it("returns connected when expired but refresh available", () => {
+    mockTokens({ expiry_date: Date.now() - 1000 });
+    expect(getStatus().status).toBe("connected");
+  });
+
+  it("returns needs_reauth when expired and no refresh token", () => {
+    mockTokens({ expiry_date: Date.now() - 1000, refresh_token: undefined });
+    expect(getStatus().status).toBe("needs_reauth");
+  });
+
+  it("returns needs_reauth when expired, refresh present, but creds gone", () => {
+    delete process.env.GOOGLE_DOCS_CLIENT_ID;
+    delete process.env.GOOGLE_DOCS_CLIENT_SECRET;
+    mockTokens({
+      expiry_date: Date.now() - 1000,
+      _client_id: undefined,
+      _client_secret: undefined,
+    });
+    expect(getStatus().status).toBe("needs_reauth");
+  });
+});
+
+describe("getValidAccessToken", () => {
+  it("throws when not connected", async () => {
+    await expect(getValidAccessToken()).rejects.toThrow(
+      /Google Docs not connected/,
+    );
+  });
+
+  it("returns token without refresh when not near expiry", async () => {
+    mockTokens();
+    expect(await getValidAccessToken()).toBe("at_test");
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("refreshes within 60s expiry buffer", async () => {
+    mockTokens({ expiry_date: Date.now() + 30_000 });
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({ access_token: "at_refreshed", expires_in: 3600 }),
+    );
+    expect(await getValidAccessToken()).toBe("at_refreshed");
+    const [, init] = mockFetch.mock.calls[0] as unknown as [
+      string,
+      RequestInit,
+    ];
+    const body = new URLSearchParams(init.body as string);
+    expect(body.get("grant_type")).toBe("refresh_token");
+    expect(body.get("client_id")).toBe("env_cid");
+  });
+
+  it("throws when refresh fails with 400", async () => {
+    mockTokens({ expiry_date: Date.now() - 1000 });
+    mockFetch.mockResolvedValueOnce(textResponse("invalid_grant", false, 400));
+    await expect(getValidAccessToken()).rejects.toThrow(
+      /Token refresh failed.*400/,
+    );
+  });
+});
+
+describe("getDocument", () => {
+  it("fetches doc tree from /v1/documents/{id}", async () => {
+    mockTokens();
+    const docPayload = {
+      documentId: "doc-1",
+      title: "Hello",
+      body: { content: [] },
+    };
+    mockFetch.mockResolvedValueOnce(jsonResponse(docPayload));
+    const out = await getDocument("doc-1");
+    expect(out).toEqual(docPayload);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const [url, init] = mockFetch.mock.calls[0] as unknown as [
+      string,
+      RequestInit,
+    ];
+    expect(url).toBe("https://docs.googleapis.com/v1/documents/doc-1");
+    expect((init.headers as Record<string, string>).Authorization).toBe(
+      "Bearer at_test",
+    );
+  });
+
+  it("extracts ID from URL form", async () => {
+    mockTokens();
+    mockFetch.mockResolvedValueOnce(jsonResponse({ documentId: "abc" }));
+    await getDocument("https://docs.google.com/document/d/abc/edit");
+    const [url] = mockFetch.mock.calls[0] as unknown as [string];
+    expect(url).toContain("/v1/documents/abc");
+  });
+
+  it("refreshes once on 401 then retries", async () => {
+    mockTokens();
+    mockFetch
+      .mockResolvedValueOnce(textResponse("unauthorized", false, 401))
+      .mockResolvedValueOnce(
+        jsonResponse({ access_token: "at_refreshed", expires_in: 3600 }),
+      )
+      .mockResolvedValueOnce(jsonResponse({ documentId: "doc-1" }));
+    const out = await getDocument("doc-1");
+    expect(out).toEqual({ documentId: "doc-1" });
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+    // call[1] is the refresh; call[2] is the retry with the new token
+    const [, retryInit] = mockFetch.mock.calls[2] as unknown as [
+      string,
+      RequestInit,
+    ];
+    expect((retryInit.headers as Record<string, string>).Authorization).toBe(
+      "Bearer at_refreshed",
+    );
+  });
+
+  it("throws normalized message on non-2xx", async () => {
+    mockTokens();
+    mockFetch.mockResolvedValueOnce(textResponse("nope", false, 403));
+    await expect(getDocument("doc-1")).rejects.toThrow(
+      /Google Docs API error 403/,
+    );
+  });
+});
+
+describe("getDocumentText", () => {
+  it("walks body.content paragraphs and joins textRun content", async () => {
+    mockTokens();
+    const docPayload = {
+      documentId: "doc-1",
+      body: {
+        content: [
+          {
+            paragraph: {
+              elements: [
+                { textRun: { content: "Hello " } },
+                { textRun: { content: "world\n" } },
+              ],
+            },
+          },
+          {
+            paragraph: {
+              elements: [{ textRun: { content: "Second line\n" } }],
+            },
+          },
+        ],
+      },
+    };
+    mockFetch.mockResolvedValueOnce(jsonResponse(docPayload));
+    expect(await getDocumentText("doc-1")).toBe("Hello world\nSecond line\n");
+  });
+
+  it("returns '' when body content is empty", async () => {
+    mockTokens();
+    mockFetch.mockResolvedValueOnce(jsonResponse({ documentId: "x" }));
+    expect(await getDocumentText("x")).toBe("");
+  });
+
+  it("recurses into table cells", async () => {
+    mockTokens();
+    const docPayload = {
+      documentId: "doc-1",
+      body: {
+        content: [
+          {
+            table: {
+              tableRows: [
+                {
+                  tableCells: [
+                    {
+                      content: [
+                        {
+                          paragraph: {
+                            elements: [{ textRun: { content: "cell1 " } }],
+                          },
+                        },
+                      ],
+                    },
+                    {
+                      content: [
+                        {
+                          paragraph: {
+                            elements: [{ textRun: { content: "cell2" } }],
+                          },
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+        ],
+      },
+    };
+    mockFetch.mockResolvedValueOnce(jsonResponse(docPayload));
+    expect(await getDocumentText("doc-1")).toBe("cell1 cell2");
+  });
+
+  it("ignores paragraph elements without textRun", async () => {
+    mockTokens();
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({
+        documentId: "x",
+        body: {
+          content: [
+            {
+              paragraph: {
+                elements: [
+                  { textRun: { content: "kept" } },
+                  { startIndex: 1, endIndex: 2 },
+                ],
+              },
+            },
+          ],
+        },
+      }),
+    );
+    expect(await getDocumentText("x")).toBe("kept");
+  });
+});
+
+describe("handleDocsAuthRedirect", () => {
+  it("returns 400 when client creds not configured", () => {
+    delete process.env.GOOGLE_DOCS_CLIENT_ID;
+    delete process.env.GOOGLE_DOCS_CLIENT_SECRET;
+    const result = handleDocsAuthRedirect();
+    expect(result.status).toBe(400);
+    expect(JSON.parse(result.body)).toMatchObject({
+      ok: false,
+      error: expect.stringMatching(/CLIENT_ID/),
+    });
+  });
+
+  it("returns 302 redirect with correct OAuth params + documents.readonly scope", () => {
+    const result = handleDocsAuthRedirect();
+    expect(result.status).toBe(302);
+    expect(result.redirect).toContain("accounts.google.com/o/oauth2/v2/auth");
+    expect(result.redirect).toContain("client_id=env_cid");
+    expect(result.redirect).toContain("access_type=offline");
+    expect(result.redirect).toContain("prompt=consent");
+    expect(result.redirect).toMatch(/state=[a-f0-9]{64}/);
+    expect(decodeURIComponent(result.redirect ?? "")).toContain(
+      "https://www.googleapis.com/auth/documents.readonly",
+    );
+  });
+});
+
+describe("handleDocsCallback", () => {
+  it("returns 400 when error param present", async () => {
+    const result = await handleDocsCallback(null, null, "access_denied");
+    expect(result.status).toBe(400);
+    expect(JSON.parse(result.body)).toMatchObject({
+      ok: false,
+      error: "access_denied",
+    });
+  });
+
+  it("returns 400 when state missing", async () => {
+    const result = await handleDocsCallback("code", null, null);
+    expect(result.status).toBe(400);
+    expect(JSON.parse(result.body).error).toMatch(/Invalid OAuth state/);
+  });
+
+  it("returns 400 when state not pending (replay/forgery)", async () => {
+    const result = await handleDocsCallback("code", "unknown-state", null);
+    expect(result.status).toBe(400);
+    expect(JSON.parse(result.body).error).toMatch(/Invalid OAuth state/);
+  });
+
+  it("completes auth flow with valid state from redirect", async () => {
+    const auth = handleDocsAuthRedirect();
+    const state = /state=([a-f0-9]+)/.exec(auth.redirect ?? "")?.[1] ?? "";
+    expect(state).not.toBe("");
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({
+        access_token: "at_new",
+        refresh_token: "rt_new",
+        expires_in: 3600,
+        token_type: "Bearer",
+        scope: "documents.readonly",
+      }),
+    );
+    const result = await handleDocsCallback("code", state, null);
+    expect(result.status).toBe(200);
+    expect(JSON.parse(result.body)).toMatchObject({ ok: true });
+  });
+
+  it("invalidates state after first use", async () => {
+    const auth = handleDocsAuthRedirect();
+    const state = /state=([a-f0-9]+)/.exec(auth.redirect ?? "")?.[1] ?? "";
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({ access_token: "at_new", expires_in: 3600 }),
+    );
+    await handleDocsCallback("code", state, null);
+    const replay = await handleDocsCallback("code", state, null);
+    expect(replay.status).toBe(400);
+    expect(JSON.parse(replay.body).error).toMatch(/Invalid OAuth state/);
+  });
+});
+
+describe("handleDocsTest", () => {
+  it("returns 400 when not connected", async () => {
+    const result = await handleDocsTest();
+    expect(result.status).toBe(400);
+    expect(JSON.parse(result.body).ok).toBe(false);
+  });
+
+  it("returns 200 with email on tokeninfo success", async () => {
+    mockTokens();
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({
+        email: "u@example.com",
+        scope: "https://www.googleapis.com/auth/documents.readonly",
+      }),
+    );
+    const result = await handleDocsTest();
+    expect(result.status).toBe(200);
+    expect(JSON.parse(result.body)).toMatchObject({
+      ok: true,
+      email: "u@example.com",
+    });
+  });
+
+  it("returns 400 when tokeninfo errors", async () => {
+    mockTokens();
+    mockFetch.mockResolvedValueOnce(jsonResponse({}, false, 401));
+    const result = await handleDocsTest();
+    expect(result.status).toBe(400);
+    expect(JSON.parse(result.body).ok).toBe(false);
+  });
+});
+
+describe("handleDocsDisconnect", () => {
+  it("returns 200 even when no tokens", async () => {
+    const result = await handleDocsDisconnect();
+    expect(result.status).toBe(200);
+    expect(JSON.parse(result.body)).toEqual({ ok: true });
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("calls Google revoke endpoint when access_token present", async () => {
+    mockTokens();
+    mockFetch.mockResolvedValueOnce(jsonResponse({}));
+    const result = await handleDocsDisconnect();
+    expect(result.status).toBe(200);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const [url] = mockFetch.mock.calls[0] as unknown as [string];
+    expect(url).toContain("oauth2.googleapis.com/revoke");
+    expect(url).toContain("token=at_test");
+  });
+
+  it("still returns ok when revoke throws", async () => {
+    mockTokens();
+    mockFetch.mockRejectedValueOnce(new Error("network"));
+    const result = await handleDocsDisconnect();
+    expect(result.status).toBe(200);
+    expect(JSON.parse(result.body)).toEqual({ ok: true });
+  });
+});

--- a/src/connectors/connectorRegistry.ts
+++ b/src/connectors/connectorRegistry.ts
@@ -71,6 +71,12 @@ export const CONNECTORS: readonly ConnectorDescriptor[] = [
     supports: { auth: true, test: true, delete: true },
   },
   {
+    id: "google-docs",
+    label: "Google Docs",
+    authKind: "oauth",
+    supports: { auth: true, test: true, delete: true },
+  },
+  {
     id: "github",
     label: "GitHub",
     authKind: "oauth",

--- a/src/connectors/gmail.ts
+++ b/src/connectors/gmail.ts
@@ -338,6 +338,7 @@ export async function handleConnectionsList(): Promise<ConnectorHandlerResult> {
     figma: () => import("./figma.js"),
     airtable: () => import("./airtable.js"),
     webflow: () => import("./webflow.js"),
+    "google-docs": () => import("./googleDocs.js"),
   };
   const tokenPasteProbes = CONNECTORS.filter(
     (c) => !EXPLICIT_IDS.has(c.id),

--- a/src/connectors/googleDocs.ts
+++ b/src/connectors/googleDocs.ts
@@ -1,0 +1,553 @@
+import crypto from "node:crypto";
+import { existsSync, readFileSync, unlinkSync } from "node:fs";
+import { homedir } from "node:os";
+import path from "node:path";
+import { connectorRedirectUri } from "./connectorRedirectUri.js";
+import {
+  deleteSecretJsonSync,
+  getSecretJsonSync,
+  storeSecretJsonSync,
+} from "./tokenStorage.js";
+
+const SCOPES = ["https://www.googleapis.com/auth/documents.readonly"];
+const REDIRECT_URI = connectorRedirectUri("google-docs");
+const DOCS_API = "https://docs.googleapis.com";
+
+function getTokenPath() {
+  const dir =
+    process.env.PATCHWORK_TOKEN_DIR ??
+    path.join(homedir(), ".patchwork", "tokens");
+  return path.join(dir, "google-docs.json");
+}
+
+export interface DocsTokens {
+  access_token: string;
+  refresh_token?: string;
+  expiry_date?: number;
+  token_type?: string;
+  scope?: string;
+  email?: string;
+  connected_at: string;
+  _client_id?: string;
+  _client_secret?: string;
+}
+
+export interface ConnectorStatus {
+  id: string;
+  status: "connected" | "disconnected" | "needs_reauth";
+  lastSync?: string;
+  email?: string;
+}
+
+export interface ConnectorHandlerResult {
+  status: number;
+  body: string;
+  contentType?: string;
+  redirect?: string;
+}
+
+/**
+ * Normalized error categories returned by Google Docs API.
+ * Mirrors the Drive/Calendar cluster's error-classification posture.
+ */
+export type NormalizedErrorKind =
+  | "auth_expired"
+  | "permission_denied"
+  | "not_found"
+  | "rate_limited"
+  | "provider_error"
+  | "unknown_error";
+
+export interface NormalizedError {
+  kind: NormalizedErrorKind;
+  status: number;
+  message: string;
+  retryable: boolean;
+}
+
+export function normalizeError(status: number, body: string): NormalizedError {
+  if (status === 401) {
+    return {
+      kind: "auth_expired",
+      status,
+      message: body || "Authentication expired",
+      retryable: false,
+    };
+  }
+  if (status === 403) {
+    return {
+      kind: "permission_denied",
+      status,
+      message: body || "Permission denied (scope may be too narrow)",
+      retryable: false,
+    };
+  }
+  if (status === 404) {
+    return {
+      kind: "not_found",
+      status,
+      message: body || "Document not found",
+      retryable: false,
+    };
+  }
+  if (status === 429) {
+    return {
+      kind: "rate_limited",
+      status,
+      message: body || "Rate limited",
+      retryable: true,
+    };
+  }
+  if (status >= 500) {
+    return {
+      kind: "provider_error",
+      status,
+      message: body || "Provider error",
+      retryable: true,
+    };
+  }
+  return {
+    kind: "unknown_error",
+    status,
+    message: body || `HTTP ${status}`,
+    retryable: false,
+  };
+}
+
+function clientId(): string {
+  return process.env.GOOGLE_DOCS_CLIENT_ID ?? "";
+}
+
+function clientSecret(): string {
+  return process.env.GOOGLE_DOCS_CLIENT_SECRET ?? "";
+}
+
+function isConfigured(): boolean {
+  return Boolean(clientId() && clientSecret());
+}
+
+export function loadTokens(): DocsTokens | null {
+  const secureTokens = getSecretJsonSync<DocsTokens>("google-docs");
+  if (secureTokens) return secureTokens;
+
+  const tokenPath = getTokenPath();
+  if (!existsSync(tokenPath)) return null;
+  try {
+    const tokens = JSON.parse(readFileSync(tokenPath, "utf-8")) as DocsTokens;
+    saveTokens(tokens);
+    return tokens;
+  } catch {
+    return null;
+  }
+}
+
+function saveTokens(tokens: DocsTokens): void {
+  storeSecretJsonSync("google-docs", tokens);
+  const tokenPath = getTokenPath();
+  if (existsSync(tokenPath)) {
+    try {
+      unlinkSync(tokenPath);
+    } catch {}
+  }
+}
+
+function deleteTokens(): void {
+  deleteSecretJsonSync("google-docs");
+  const tokenPath = getTokenPath();
+  if (existsSync(tokenPath)) {
+    try {
+      unlinkSync(tokenPath);
+    } catch {}
+  }
+}
+
+export function getStatus(): ConnectorStatus {
+  const tokens = loadTokens();
+  if (!tokens) return { id: "google-docs", status: "disconnected" };
+  const expired = !tokens.expiry_date || Date.now() > tokens.expiry_date;
+  const hasCredentials = Boolean(
+    (process.env.GOOGLE_DOCS_CLIENT_ID || tokens._client_id) &&
+      (process.env.GOOGLE_DOCS_CLIENT_SECRET || tokens._client_secret),
+  );
+  const canRefresh = Boolean(tokens.refresh_token) && hasCredentials;
+  const status = expired && !canRefresh ? "needs_reauth" : "connected";
+  return {
+    id: "google-docs",
+    status,
+    lastSync: tokens.connected_at,
+    email: tokens.email,
+  };
+}
+
+function buildAuthUrl(state: string): string {
+  const params = new URLSearchParams({
+    client_id: clientId(),
+    redirect_uri: REDIRECT_URI,
+    response_type: "code",
+    scope: SCOPES.join(" "),
+    access_type: "offline",
+    prompt: "consent",
+    state,
+  });
+  return `https://accounts.google.com/o/oauth2/v2/auth?${params.toString()}`;
+}
+
+async function exchangeCode(
+  code: string,
+): Promise<Omit<DocsTokens, "connected_at">> {
+  const res = await fetch("https://oauth2.googleapis.com/token", {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      code,
+      client_id: clientId(),
+      client_secret: clientSecret(),
+      redirect_uri: REDIRECT_URI,
+      grant_type: "authorization_code",
+    }).toString(),
+  });
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`Token exchange failed: ${res.status} ${body}`);
+  }
+  const json = (await res.json()) as {
+    access_token: string;
+    refresh_token?: string;
+    expires_in?: number;
+    token_type?: string;
+    scope?: string;
+  };
+  return {
+    access_token: json.access_token,
+    refresh_token: json.refresh_token,
+    expiry_date: json.expires_in
+      ? Date.now() + json.expires_in * 1000
+      : undefined,
+    token_type: json.token_type,
+    scope: json.scope,
+    _client_id: clientId() || undefined,
+    _client_secret: clientSecret() || undefined,
+  };
+}
+
+async function refreshAccessToken(tokens: DocsTokens): Promise<DocsTokens> {
+  if (!tokens.refresh_token) throw new Error("No refresh token available");
+  const id = clientId() || tokens._client_id || "";
+  const secret = clientSecret() || tokens._client_secret || "";
+  if (!id || !secret)
+    throw new Error(
+      "Google Docs client credentials not available — reconnect the Google Docs connector",
+    );
+  const res = await fetch("https://oauth2.googleapis.com/token", {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      refresh_token: tokens.refresh_token,
+      client_id: id,
+      client_secret: secret,
+      grant_type: "refresh_token",
+    }).toString(),
+  });
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`Token refresh failed: ${res.status} ${body}`);
+  }
+  const json = (await res.json()) as {
+    access_token: string;
+    expires_in?: number;
+    token_type?: string;
+  };
+  const updated: DocsTokens = {
+    ...tokens,
+    access_token: json.access_token,
+    expiry_date: json.expires_in
+      ? Date.now() + json.expires_in * 1000
+      : tokens.expiry_date,
+  };
+  saveTokens(updated);
+  return updated;
+}
+
+/**
+ * In-flight refresh promise. Prevents concurrent expired-token callers from
+ * both burning the same refresh token (Google rotates on use).
+ */
+let refreshInflight: Promise<DocsTokens> | null = null;
+
+export async function getValidAccessToken(): Promise<string> {
+  let tokens = loadTokens();
+  if (!tokens) throw new Error("Google Docs not connected");
+  const bufferMs = 60_000;
+  if (!tokens.expiry_date || Date.now() > tokens.expiry_date - bufferMs) {
+    if (!refreshInflight) {
+      refreshInflight = (async () => {
+        try {
+          return await refreshAccessToken(tokens as DocsTokens);
+        } finally {
+          refreshInflight = null;
+        }
+      })();
+    }
+    tokens = await refreshInflight;
+  }
+  return tokens.access_token;
+}
+
+async function revokeToken(token: string): Promise<void> {
+  await fetch(
+    `https://oauth2.googleapis.com/revoke?token=${encodeURIComponent(token)}`,
+    { method: "POST" },
+  ).catch(() => {});
+}
+
+/** Extract a Doc ID from a Google Docs URL or pass-through a bare ID. */
+export function extractDocumentId(urlOrId: string): string {
+  const match = /\/document\/d\/([a-zA-Z0-9_-]+)/.exec(urlOrId);
+  return match ? (match[1] as string) : urlOrId;
+}
+
+// ── Document types (subset of the Docs API response we care about) ───────────
+
+export interface DocsTextRun {
+  content?: string;
+  textStyle?: Record<string, unknown>;
+}
+
+export interface DocsParagraphElement {
+  startIndex?: number;
+  endIndex?: number;
+  textRun?: DocsTextRun;
+}
+
+export interface DocsParagraph {
+  elements?: DocsParagraphElement[];
+  paragraphStyle?: Record<string, unknown>;
+}
+
+export interface DocsStructuralElement {
+  startIndex?: number;
+  endIndex?: number;
+  paragraph?: DocsParagraph;
+  table?: {
+    tableRows?: Array<{
+      tableCells?: Array<{ content?: DocsStructuralElement[] }>;
+    }>;
+  };
+  sectionBreak?: Record<string, unknown>;
+  tableOfContents?: { content?: DocsStructuralElement[] };
+}
+
+export interface DocsDocument {
+  documentId: string;
+  title?: string;
+  body?: { content?: DocsStructuralElement[] };
+  headers?: Record<string, { content?: DocsStructuralElement[] }>;
+  footers?: Record<string, { content?: DocsStructuralElement[] }>;
+  revisionId?: string;
+}
+
+/**
+ * Authenticated GET against a Docs API endpoint. Refreshes on 401 exactly
+ * once and retries the original request. Other non-2xx → throws with the
+ * normalized error message.
+ */
+async function docsGet(
+  endpoint: string,
+  fetchFn: typeof fetch = globalThis.fetch,
+): Promise<unknown> {
+  const doOnce = async (token: string): Promise<Response> =>
+    fetchFn(`${DOCS_API}${endpoint}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+
+  let token = await getValidAccessToken();
+  let res = await doOnce(token);
+  if (res.status === 401) {
+    // Force a refresh by clearing expiry on disk, then retry once.
+    const tokens = loadTokens();
+    if (tokens?.refresh_token) {
+      const refreshed = await refreshAccessToken({
+        ...tokens,
+        expiry_date: 0,
+      });
+      token = refreshed.access_token;
+      res = await doOnce(token);
+    }
+  }
+  if (!res.ok) {
+    const body = await res.text();
+    const norm = normalizeError(res.status, body.slice(0, 200));
+    throw new Error(`Google Docs API error ${norm.status}: ${norm.message}`);
+  }
+  return res.json();
+}
+
+/**
+ * Fetch the structured document tree by ID. Returns the raw Docs API
+ * response (body + headers + footers + styles).
+ */
+export async function getDocument(
+  documentId: string,
+  fetchFn: typeof fetch = globalThis.fetch,
+): Promise<DocsDocument> {
+  const id = extractDocumentId(documentId);
+  return (await docsGet(
+    `/v1/documents/${encodeURIComponent(id)}`,
+    fetchFn,
+  )) as DocsDocument;
+}
+
+/**
+ * Walk a list of StructuralElements and emit their text. Recurses into
+ * tables and table-of-contents entries.
+ */
+function extractTextFromElements(elements: DocsStructuralElement[]): string {
+  const parts: string[] = [];
+  for (const el of elements) {
+    if (el.paragraph?.elements) {
+      for (const pe of el.paragraph.elements) {
+        const text = pe.textRun?.content;
+        if (typeof text === "string") parts.push(text);
+      }
+    }
+    if (el.table?.tableRows) {
+      for (const row of el.table.tableRows) {
+        for (const cell of row.tableCells ?? []) {
+          if (cell.content) parts.push(extractTextFromElements(cell.content));
+        }
+      }
+    }
+    if (el.tableOfContents?.content) {
+      parts.push(extractTextFromElements(el.tableOfContents.content));
+    }
+  }
+  return parts.join("");
+}
+
+/**
+ * Convenience helper: fetch the doc and return a flat plain-text string
+ * by walking the body's StructuralElement[] and extracting text from
+ * paragraph.elements[].textRun.content.
+ */
+export async function getDocumentText(
+  documentId: string,
+  fetchFn: typeof fetch = globalThis.fetch,
+): Promise<string> {
+  const doc = await getDocument(documentId, fetchFn);
+  const content = doc.body?.content ?? [];
+  return extractTextFromElements(content);
+}
+
+import { createOAuthStateStore } from "./oauthStateStore.js";
+
+const pendingStates = createOAuthStateStore({ namespace: "googleDocs" });
+
+function generateState(): string {
+  const state = crypto.randomBytes(32).toString("hex");
+  if (!pendingStates.add(state)) {
+    throw new Error(
+      "OAuth state store full — too many concurrent authorize requests",
+    );
+  }
+  return state;
+}
+
+export function handleDocsAuthRedirect(): ConnectorHandlerResult {
+  if (!isConfigured()) {
+    return {
+      status: 400,
+      contentType: "application/json",
+      body: JSON.stringify({
+        ok: false,
+        error:
+          "GOOGLE_DOCS_CLIENT_ID and GOOGLE_DOCS_CLIENT_SECRET env vars not set",
+      }),
+    };
+  }
+  const state = generateState();
+  return { status: 302, body: "", redirect: buildAuthUrl(state) };
+}
+
+export async function handleDocsCallback(
+  code: string | null,
+  state: string | null,
+  error: string | null,
+): Promise<ConnectorHandlerResult> {
+  if (error) {
+    return {
+      status: 400,
+      contentType: "application/json",
+      body: JSON.stringify({ ok: false, error }),
+    };
+  }
+  if (!code || !state || !pendingStates.consume(state)) {
+    return {
+      status: 400,
+      contentType: "application/json",
+      body: JSON.stringify({ ok: false, error: "Invalid OAuth state" }),
+    };
+  }
+  try {
+    const oauthTokens = await exchangeCode(code);
+    const tokens: DocsTokens = {
+      ...oauthTokens,
+      connected_at: new Date().toISOString(),
+    };
+    saveTokens(tokens);
+    return {
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ ok: true }),
+    };
+  } catch (err) {
+    return {
+      status: 400,
+      contentType: "application/json",
+      body: JSON.stringify({
+        ok: false,
+        error: err instanceof Error ? err.message : String(err),
+      }),
+    };
+  }
+}
+
+/**
+ * Health check: verifies the stored access token is still valid by
+ * issuing a tokeninfo introspection call (same shape Drive/Calendar
+ * cluster use elsewhere). Returns ok=true with email on success.
+ */
+export async function handleDocsTest(): Promise<ConnectorHandlerResult> {
+  try {
+    const accessToken = await getValidAccessToken();
+    const res = await fetch(
+      `https://oauth2.googleapis.com/tokeninfo?access_token=${encodeURIComponent(accessToken)}`,
+    );
+    if (!res.ok) throw new Error(`Token introspection error ${res.status}`);
+    const json = (await res.json()) as { email?: string; scope?: string };
+    return {
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ ok: true, email: json.email, scope: json.scope }),
+    };
+  } catch (err) {
+    return {
+      status: 400,
+      contentType: "application/json",
+      body: JSON.stringify({
+        ok: false,
+        error: err instanceof Error ? err.message : String(err),
+      }),
+    };
+  }
+}
+
+export async function handleDocsDisconnect(): Promise<ConnectorHandlerResult> {
+  const tokens = loadTokens();
+  if (tokens?.access_token) await revokeToken(tokens.access_token);
+  deleteTokens();
+  return {
+    status: 200,
+    contentType: "application/json",
+    body: JSON.stringify({ ok: true }),
+  };
+}


### PR DESCRIPTION
## Summary

Adds the **Google Docs** connector — OAuth 2.0, read-only, parallel to `googleDrive.ts` / `googleCalendar.ts`. Follow-up to #778 (Wave 1a data stores) and #779 (Wave 1b/2 PAT comms+SaaS).

| Tool | API |
|---|---|
| `getDocument(id)` | full structured doc tree |
| `getDocumentText(id)` | walks body/tables/TOC, returns flat plain text |

OAuth env vars: `GOOGLE_DOCS_CLIENT_ID` + `GOOGLE_DOCS_CLIENT_SECRET`. Scope: `documents.readonly`. Health check uses tokeninfo introspection.

## Stats

- +1,183 LOC across 7 files (482 connector + 437 tests + wiring)
- **41/41 new tests pass**, bridge full suite 5986/5988 (2 skipped, unrelated), dashboard 664/664
- `tsc --noEmit` clean (regular + `tsconfig.tests.core.json` strict)
- biome clean, all files report UTF-8 text
- All Wave 1a/1b CI traps applied pre-push

## Catalog id rename

Catalog id `docs` → `google-docs`. Display label stays "Google Docs". This makes the catalog ↔ registry ↔ loader-map ↔ routes ↔ test snapshot all share one id, matching the existing `google-calendar` / `google-drive` convention.

## Test plan

- [ ] Set `GOOGLE_DOCS_CLIENT_ID` + `GOOGLE_DOCS_CLIENT_SECRET` in bridge env
- [ ] Click "Google Docs" in `/connections` → redirects to Google consent
- [ ] Verify `/connections/google-docs/test` returns 200 after callback
- [ ] Call `getDocumentText(<known-doc-id>)` from a recipe — verify flat text matches doc body
- [ ] Disconnect — token cleared

## What's left (deferred)

- Monday, Salesforce, Shopify, Snowflake — each needs you to register the vendor OAuth app and set env vars. Currently "Coming Soon" in catalog. Worth a separate "connector enablement" PR once those credentials exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)