### PR TITLE
fix(marketplace): Wave 0 trust gaps — kill-switch on install, default-deny confirmation, honest enable-copy

### DIFF
--- a/dashboard/src/app/marketplace/[...slug]/InstallPanel.tsx
+++ b/dashboard/src/app/marketplace/[...slug]/InstallPanel.tsx
@@ -62,11 +62,25 @@ export default function InstallPanel({
   // troubleshoot if the recipe never runs.
   const [missingConnectors, setMissingConnectors] = useState<string[]>([]);
 
-  const elevated =
-    riskLevel === "medium" ||
-    riskLevel === "high" ||
-    networkAccess === true ||
-    fileAccess === true;
+  // Marketplace trust Wave 0 (#782 follow-up): default-deny semantics.
+  //
+  // Previously the confirmation dialog ONLY appeared when one of
+  // {riskLevel >= medium, networkAccess === true, fileAccess === true}
+  // was set, which meant a registry author who forgot to flag a
+  // file-writing recipe gave users a silent one-tap install. The live
+  // marketplace registry has NO trust metadata on any recipe today
+  // (`risk_level`/`network_access`/`file_access` are absent), so every
+  // live install bypassed confirmation.
+  //
+  // New rule: only bypass confirmation if the recipe EXPLICITLY claims
+  // low risk AND explicitly disclaims network + file access. Anything
+  // missing those flags is treated as elevated — same as if the author
+  // explicitly marked it high-risk. Honest fail-closed.
+  const elevated = !(
+    riskLevel === "low" &&
+    networkAccess === false &&
+    fileAccess === false
+  );
 
   useEffect(() => {
     let cancelled = false;
@@ -177,10 +191,12 @@ export default function InstallPanel({
           {isInstalled ? (
             <>
               <span style={{ color: "var(--ok)", marginRight: 6 }}>✓</span>
-              Installed locally — enable with{" "}
+              Installed locally — runs on its trigger immediately. To
+              pause it later, use{" "}
               <code style={{ background: "var(--recess)", padding: "2px 6px", borderRadius: 4 }}>
-                patchwork recipe enable {shortName(name)}
+                patchwork recipe disable {shortName(name)}
               </code>
+              .
             </>
           ) : bridgeStatus === "online" ? (
             "Bridge connected — install with one click."

--- a/dashboard/src/app/marketplace/[...slug]/__tests__/InstallPanel.test.tsx
+++ b/dashboard/src/app/marketplace/[...slug]/__tests__/InstallPanel.test.tsx
@@ -96,6 +96,26 @@ describe("InstallPanel — install-confirm dialog", () => {
     await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
   });
 
+  it("opens the confirm dialog when trust metadata is missing (live-registry case)", async () => {
+    // Marketplace trust Wave 0 — the live registry doesn't carry
+    // risk_level / network_access / file_access on any recipe today.
+    // The old gate ("show dialog only if elevated === true") would
+    // silent-install every live recipe. The new gate requires the
+    // recipe to EXPLICITLY claim {risk: low, networkAccess: false,
+    // fileAccess: false} to bypass — missing fields fail closed.
+    fetchMock.mockResolvedValueOnce(jsonResponse(200, { recipes: [] }));
+    render(<InstallPanel install={INSTALL} name={NAME} />);
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: /^Install$/i }),
+      ).toBeInTheDocument(),
+    );
+    fireEvent.click(screen.getByRole("button", { name: /^Install$/i }));
+    // Dialog opens — install POST does NOT fire yet.
+    await screen.findByRole("dialog");
+    expect(fetchMock).toHaveBeenCalledTimes(1); // status poll only
+  });
+
   it("opens the confirm dialog before installing a high-risk recipe", async () => {
     fetchMock
       .mockResolvedValueOnce(jsonResponse(200, { recipes: [] })) // status poll
@@ -146,7 +166,13 @@ describe("InstallPanel — install-confirm dialog", () => {
         }),
       );
     render(
-      <InstallPanel install={INSTALL} name={NAME} riskLevel="low" />,
+      <InstallPanel
+        install={INSTALL}
+        name={NAME}
+        riskLevel="low"
+        networkAccess={false}
+        fileAccess={false}
+      />,
     );
     await waitFor(() =>
       expect(

--- a/dashboard/src/app/marketplace/bundle/[...slug]/BundleInstallPanel.tsx
+++ b/dashboard/src/app/marketplace/bundle/[...slug]/BundleInstallPanel.tsx
@@ -218,8 +218,9 @@ export default function BundleInstallPanel({
           {allInstalled ? (
             <>
               <span style={{ color: "var(--ok)", marginRight: 6 }}>✓</span>
-              All {recipes.length} recipes installed locally — enable each
-              with <code>patchwork recipe enable &lt;name&gt;</code>.
+              All {recipes.length} recipes installed locally — they run on
+              their triggers immediately. To pause one, use{" "}
+              <code>patchwork recipe disable &lt;name&gt;</code>.
             </>
           ) : partialInstalled ? (
             <>

--- a/src/__tests__/recipeRoutes-install.test.ts
+++ b/src/__tests__/recipeRoutes-install.test.ts
@@ -693,4 +693,37 @@ describe("Server /recipes/:name/run — A-PR2 body cap (32 KB)", () => {
     );
     expect(status).toBe(503);
   });
+
+  // ── Marketplace trust Wave 0 — kill-switch gate ───────────────────────
+  it("install-kill-switch: PATCHWORK_FLAG_KILL_SWITCH_WRITES=1 → 503 kill_switch_blocked", async () => {
+    // Engage kill-switch dynamically via the in-process flag setter so
+    // the test doesn't need a bridge restart. `kill-switch.writes` reads
+    // from the env-lock snapshot, so flip it via setFlag at runtime.
+    const { setFlag, KILL_SWITCH_WRITES, _resetEnvLockForTesting } =
+      await import("../featureFlags.js");
+    _resetEnvLockForTesting();
+    setFlag(KILL_SWITCH_WRITES, true, false);
+    try {
+      const { status, body } = await makeRequest(
+        {
+          method: "POST",
+          path: "/recipes/install",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${TOKEN}`,
+          },
+        },
+        JSON.stringify({
+          source: "github:patchworkos/recipes/recipes/morning-brief",
+        }),
+      );
+      expect(status).toBe(503);
+      const parsed = JSON.parse(body);
+      expect(parsed.ok).toBe(false);
+      expect(parsed.code).toBe("kill_switch_blocked");
+      expect(parsed.error).toMatch(/kill switch/i);
+    } finally {
+      setFlag(KILL_SWITCH_WRITES, false, false);
+    }
+  });
 });

--- a/src/recipeRoutes.ts
+++ b/src/recipeRoutes.ts
@@ -34,6 +34,7 @@ import {
   computeSummary as computeActivationSummary,
   loadMetrics as loadActivationMetrics,
 } from "./activationMetrics.js";
+import { isWriteKillSwitchActive } from "./featureFlags.js";
 import {
   consumeToken,
   refillBucket,
@@ -1398,6 +1399,26 @@ export function tryHandleRecipeRoute(
     // an explicitly-allowlisted hostname STILL has to clear the SSRF check
     // (so an admin can't accidentally allowlist `localhost`).
     // ---------------------------------------------------------------------
+    //
+    // Marketplace trust Wave 0 (#782 follow-up): gate the route on the
+    // global write kill-switch. Install writes recipe files to disk;
+    // when an operator engages `PATCHWORK_FLAG_KILL_SWITCH_WRITES` or
+    // flips the `kill-switch.writes` flag, this previously kept writing
+    // anyway — a latent trust gap. Returns 503 with a code the
+    // dashboard can match against to render the right banner.
+    if (isWriteKillSwitchActive()) {
+      res.writeHead(503, { "Content-Type": "application/json" });
+      res.end(
+        JSON.stringify({
+          ok: false,
+          code: "kill_switch_blocked",
+          error:
+            "Recipe install blocked by kill switch (PATCHWORK_FLAG_KILL_SWITCH_WRITES / kill-switch.writes). " +
+            "Unset the env var or POST /kill-switch with {engaged:false} to restore.",
+        }),
+      );
+      return true;
+    }
     void (async () => {
       const parsedBody = await readJsonBody<{ source?: string }>(
         req,


### PR DESCRIPTION
## Summary

Three trust/correctness gaps surfaced by the marketplace investigation (Phase 1A dogfood follow-up). All small surgical fixes; none invent new infrastructure.

| Fix | Where | Before | After |
|---|---|---|---|
| 1 | `src/recipeRoutes.ts:/recipes/install` | Install writes to disk even when kill-switch.writes is engaged | Returns `503 {code:"kill_switch_blocked"}` |
| 2+3 | `dashboard/.../InstallPanel.tsx` | Recipes with missing trust metadata (the **entire live registry** today) installed in one tap | Default-deny: dialog opens unless recipe **explicitly** claims `{risk:low, networkAccess:false, fileAccess:false}` |
| 5 | `InstallPanel.tsx` + `BundleInstallPanel.tsx` | "Installed locally — enable with `patchwork recipe enable <name>`" (a lie; recipes are live on install) | "Installed locally — runs on its trigger immediately. To pause it later, use `patchwork recipe disable <name>`" |

## Why this matters

The live marketplace registry today carries **zero** trust metadata — `curl raw.githubusercontent.com/patchworkos/recipes/main/index.json` returns 8 recipes with no `risk_level` / `network_access` / `file_access` / `approval_behavior` fields. The old confirmation gate (`elevated === true`) therefore silently installed **every live recipe** with no preview. Users on the live marketplace path (which is 99% of users — the fallback registry only fires when both bridge AND GitHub are unreachable) had no idea what was landing on their disk.

Kill-switch was even more latent: an operator engages writes-disable, the user installs anyway. No tests, no enforcement.

## Stats

- +107 / −10 across 5 files
- Bridge vitest 6132/6134 (1 new test: `install-kill-switch`)
- Dashboard vitest 665/665 (1 new test: live-registry-shape confirmation gate)
- `tsc --noEmit` clean (regular + tests.core.json strict)
- biome clean

## Test plan

- [ ] `PATCHWORK_FLAG_KILL_SWITCH_WRITES=1 patchwork start` → try installing from dashboard → `503 kill_switch_blocked`
- [ ] Install `morning-brief` from the live marketplace (no metadata) → confirmation dialog opens with risk pill + connectors list, even though the registry doesn't claim risk
- [ ] Install a recipe that EXPLICITLY sets `risk_level: "low", network_access: false, file_access: false` → one-tap install (no dialog)
- [ ] Verify the post-install banner reads "runs on its trigger immediately" not "enable with `patchwork recipe enable`"

## What's queued next

**Wave 1** (broken UX): Google Calendar connector-id drift (3 spellings), bundle install skips connector preflight, MissingConnectorsNotice dead-end link, partial-bundle-200-with-misleading-success.

**Wave 2** (moderate UX): Submit two-tab GitHub footgun, draft persistence (sessionStorage → localStorage), stale-tab registry revalidation, FALLBACK_REGISTRY refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)