### PR TITLE
fix(marketplace): Wave 1 — connector id drift, bundle preflight, deep-link notices, partial-bundle UI

### DIFF
--- a/dashboard/src/app/marketplace/[...slug]/__tests__/InstallPanel.test.tsx
+++ b/dashboard/src/app/marketplace/[...slug]/__tests__/InstallPanel.test.tsx
@@ -183,12 +183,18 @@ describe("InstallPanel — install-confirm dialog", () => {
 
     const alert = await screen.findByRole("alert");
     expect(alert).toHaveTextContent(/Connect these services/i);
-    expect(alert).toHaveTextContent(/Gmail/);
-    expect(alert).toHaveTextContent(/Slack/);
-    expect(alert).toHaveTextContent(/Google Calendar/);
+    // Wave 1: per-connector deep-links replace the single "Open
+    // connections" button. Each link reads "Connect <Label> →" and
+    // points at `/connections#<connector-id>` for direct landing.
     expect(
-      screen.getByRole("link", { name: /Open connections/i }),
-    ).toHaveAttribute("href", "/connections");
+      screen.getByRole("link", { name: /Connect Gmail/i }),
+    ).toHaveAttribute("href", "/connections#gmail");
+    expect(
+      screen.getByRole("link", { name: /Connect Slack/i }),
+    ).toHaveAttribute("href", "/connections#slack");
+    expect(
+      screen.getByRole("link", { name: /Connect Google Calendar/i }),
+    ).toHaveAttribute("href", "/connections#google-calendar");
   });
 
   it("Cancel button in the dialog does not POST", async () => {

--- a/dashboard/src/app/marketplace/_components/MissingConnectorsNotice.tsx
+++ b/dashboard/src/app/marketplace/_components/MissingConnectorsNotice.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import Link from "next/link";
-import { formatConnectorLabel } from "@/lib/registry";
+import { formatConnectorLabel, normalizeConnectorId } from "@/lib/registry";
 
 /**
  * Post-install warning rendered on InstallPanel / BundleInstallPanel
@@ -14,10 +13,18 @@ import { formatConnectorLabel } from "@/lib/registry";
  * notice that survives the page sitting open. Toast auto-dismisses
  * after 8s and gives them nothing to come back to.
  *
- * Renders connectors as a comma-separated label list with a single
- * action link to /connections. No "Dismiss" button — the notice
- * disappears once the install state changes (e.g. on a successful
- * re-install) or the page reloads.
+ * Wave 1 fix: each connector now gets its OWN row with a deep-link
+ * straight to `/connections#<connector-id>` (the connections page
+ * scrolls to the anchor, so the user lands on the right row). The old
+ * version was a single comma-joined label list with one generic
+ * "Open connections →" button that dumped every user on the same
+ * index — a textbook dead-end. The `<a>` is intentionally raw (not
+ * Next `<Link>`) because Next's router strips hash fragments on
+ * client-side navigation.
+ *
+ * Renders as a `role="alert"` block so screen readers announce the
+ * full list. Each link reads "Connect Gmail" → screen readers say
+ * "Connect Gmail, link".
  */
 export function MissingConnectorsNotice({
   connectors,
@@ -25,7 +32,13 @@ export function MissingConnectorsNotice({
   connectors: string[];
 }) {
   if (connectors.length === 0) return null;
-  const labels = connectors.map(formatConnectorLabel);
+  // Normalise display ids so a recipe that imported as `googleCalendar`
+  // still lands on `/connections#google-calendar`, matching the
+  // canonical id used on that page's anchor targets.
+  const items = connectors.map((raw) => {
+    const id = normalizeConnectorId(raw);
+    return { id, label: formatConnectorLabel(id) };
+  });
   return (
     <div
       role="alert"
@@ -44,20 +57,35 @@ export function MissingConnectorsNotice({
     >
       <div>
         <strong style={{ color: "var(--ink-0)" }}>
-          Connect {labels.length === 1 ? "this service" : "these services"}{" "}
+          Connect {items.length === 1 ? "this service" : "these services"}{" "}
           before the recipe can run:
-        </strong>{" "}
-        {labels.join(", ")}.
+        </strong>
       </div>
-      <div>
-        <Link
-          href="/connections"
-          className="btn sm"
-          style={{ textDecoration: "none" }}
-        >
-          Open connections →
-        </Link>
-      </div>
+      <ul
+        style={{
+          listStyle: "none",
+          padding: 0,
+          margin: 0,
+          display: "flex",
+          flexDirection: "column",
+          gap: "var(--s-1)",
+        }}
+      >
+        {items.map(({ id, label }) => (
+          <li key={id}>
+            <a
+              href={`/connections#${id}`}
+              className="btn sm"
+              style={{
+                textDecoration: "none",
+                display: "inline-block",
+              }}
+            >
+              Connect {label} →
+            </a>
+          </li>
+        ))}
+      </ul>
     </div>
   );
 }

--- a/dashboard/src/app/marketplace/bundle/[...slug]/BundleInstallPanel.tsx
+++ b/dashboard/src/app/marketplace/bundle/[...slug]/BundleInstallPanel.tsx
@@ -299,32 +299,58 @@ export default function BundleInstallPanel({
             borderTop: "1px solid var(--line-1)",
           }}
         >
-          {result.installed && result.installed.length > 0 && (
-            <div style={{ fontSize: "var(--fs-s)", color: "var(--ink-1)" }}>
-              <span style={{ color: "var(--ok)", marginRight: 6 }}>✓</span>
-              Installed {result.installed.length} recipe
-              {result.installed.length === 1 ? "" : "s"}:{" "}
-              <span style={{ fontFamily: "var(--font-mono)" }}>
-                {result.installed.map((r) => r.name).join(", ")}
-              </span>
-            </div>
-          )}
-          {result.failures && result.failures.length > 0 && (
-            <div style={{ fontSize: "var(--fs-s)", color: "var(--err)" }}>
-              <strong>{result.failures.length} failed:</strong>
-              <ul style={{ margin: "4px 0 0 16px", padding: 0 }}>
-                {result.failures.map((f) => (
-                  <li key={f.name}>
-                    <span style={{ fontFamily: "var(--font-mono)" }}>
-                      {f.name}
+          {(() => {
+            // Wave 1 fix: when failures dominate (more recipes failed
+            // than installed), demote the green "✓ Installed N recipes"
+            // headline to yellow "Installed with errors" so the user
+            // doesn't miss the red failure list sitting underneath.
+            // Previously a 1-of-5-installed result still showed a
+            // green checkmark + downplayed failures.
+            const installedCount = result.installed?.length ?? 0;
+            const failureCount = result.failures?.length ?? 0;
+            const failuresDominate = failureCount > installedCount;
+            return (
+              <>
+                {installedCount > 0 && (
+                  <div
+                    style={{ fontSize: "var(--fs-s)", color: "var(--ink-1)" }}
+                  >
+                    <span
+                      style={{
+                        color: failuresDominate ? "var(--warn)" : "var(--ok)",
+                        marginRight: 6,
+                      }}
+                    >
+                      {failuresDominate ? "⚠" : "✓"}
                     </span>
-                    {" — "}
-                    {f.error}
-                  </li>
-                ))}
-              </ul>
-            </div>
-          )}
+                    {failuresDominate
+                      ? `Only ${installedCount} of ${installedCount + failureCount} recipes installed`
+                      : `Installed ${installedCount} recipe${installedCount === 1 ? "" : "s"}`}
+                    :{" "}
+                    <span style={{ fontFamily: "var(--font-mono)" }}>
+                      {result.installed?.map((r) => r.name).join(", ")}
+                    </span>
+                  </div>
+                )}
+                {failureCount > 0 && (
+                  <div style={{ fontSize: "var(--fs-s)", color: "var(--err)" }}>
+                    <strong>{failureCount} failed:</strong>
+                    <ul style={{ margin: "4px 0 0 16px", padding: 0 }}>
+                      {result.failures?.map((f) => (
+                        <li key={f.name}>
+                          <span style={{ fontFamily: "var(--font-mono)" }}>
+                            {f.name}
+                          </span>
+                          {" — "}
+                          {f.error}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+              </>
+            );
+          })()}
         </div>
       )}
 

--- a/dashboard/src/app/marketplace/bundle/[...slug]/__tests__/BundleInstallPanel.test.tsx
+++ b/dashboard/src/app/marketplace/bundle/[...slug]/__tests__/BundleInstallPanel.test.tsx
@@ -219,7 +219,14 @@ describe("BundleInstallPanel — install action", () => {
     fireEvent.click(confirmBtns[confirmBtns.length - 1]);
 
     await waitFor(() => expect(screen.getByText(/2 failed:/i)).toBeInTheDocument());
-    expect(screen.getByText(/Installed 1 recipe:/i)).toBeInTheDocument();
+    // Wave 1: when failures dominate (here 2 failed vs 1 installed),
+    // the green "Installed N recipes" headline is demoted to a yellow
+    // "Only N of M recipes installed" line so the user can't miss the
+    // failure list underneath. Old assertion looked for "Installed 1
+    // recipe:" which no longer renders in this state.
+    expect(
+      screen.getByText(/Only 1 of 3 recipes installed/i),
+    ).toBeInTheDocument();
     expect(screen.getByText(/Upstream returned 404/i)).toBeInTheDocument();
     expect(
       screen.getByText(/Recipe body exceeded 1 MB cap/i),
@@ -279,11 +286,15 @@ describe("BundleInstallPanel — install action", () => {
 
     const alert = await screen.findByRole("alert");
     expect(alert).toHaveTextContent(/Connect these services/i);
-    expect(alert).toHaveTextContent(/Gmail/);
-    expect(alert).toHaveTextContent(/Linear/);
+    // Wave 1: per-connector deep-links replace the single
+    // "Open connections" button (which was a dead-end dropping the
+    // user on the connections index with no anchor).
     expect(
-      screen.getByRole("link", { name: /Open connections/i }),
-    ).toHaveAttribute("href", "/connections");
+      screen.getByRole("link", { name: /Connect Gmail/i }),
+    ).toHaveAttribute("href", "/connections#gmail");
+    expect(
+      screen.getByRole("link", { name: /Connect Linear/i }),
+    ).toHaveAttribute("href", "/connections#linear");
   });
 });
 

--- a/dashboard/src/app/marketplace/page.tsx
+++ b/dashboard/src/app/marketplace/page.tsx
@@ -11,6 +11,7 @@ import {
   assertValidInstallSource,
   type ApprovalBehavior,
   formatConnectorLabel,
+  normalizeConnectorId,
   type RegistryBundle,
   type RegistryData,
   type RegistryRecipe,
@@ -31,7 +32,7 @@ const FALLBACK_REGISTRY: RegistryData = {
       description:
         "Daily 6am digest: Gmail unread, Linear assigned issues, Slack DMs, and today's calendar — composed into one Slack message.",
       tags: ["productivity", "morning", "daily"],
-      connectors: ["gmail", "linear", "slack", "calendar"],
+      connectors: ["gmail", "linear", "slack", "google-calendar"],
       install: "github:patchworkos/recipes/recipes/morning-brief",
       downloads: 0,
       risk_level: "low",
@@ -297,7 +298,13 @@ function RecipeCard({
         }}
       >
         <div style={{ display: "flex", gap: 6, alignItems: "center", flexWrap: "wrap" }}>
-          {recipe.connectors.map((c) => (
+          {recipe.connectors.map((rawId) => {
+            // Wave 1: normalize legacy connector-id spellings (the live
+            // registry uses `googleCalendar`; older fallback data uses
+            // `calendar`; canonical is `google-calendar`). Without this
+            // the chip dot rendered grey with garbage initials.
+            const c = normalizeConnectorId(rawId);
+            return (
             <span
               key={c}
               className="connector-dot"
@@ -307,7 +314,8 @@ function RecipeCard({
             >
               {connectorInitials(c)}
             </span>
-          ))}
+            );
+          })}
           {recipe.downloads > 0 && (
             <span
               style={{

--- a/dashboard/src/lib/registry.ts
+++ b/dashboard/src/lib/registry.ts
@@ -381,6 +381,37 @@ export function shortName(name: string): string {
 }
 
 /**
+ * Canonical connector ids match the bridge's `connectorRegistry.ts` —
+ * kebab-case, no namespace. Recipes in the wild use three spellings of
+ * the Google Calendar one (`googleCalendar` in the live registry,
+ * `calendar` in the old fallback data, `google-calendar` everywhere
+ * else). Map all known aliases to the canonical id at the dashboard
+ * boundary so chip rendering, install dialogs, and the deep-link target
+ * on `/connections#<id>` are consistent.
+ *
+ * Adding a new alias is cheaper than fixing every consumer. The bridge
+ * `KNOWN_CONNECTOR_IDS` set in `app/recipes/[name]/layout.tsx` is the
+ * authoritative target — entries here must resolve into that set.
+ */
+const CONNECTOR_ID_ALIASES: Record<string, string> = {
+  googlecalendar: "google-calendar",
+  calendar: "google-calendar",
+  gcal: "google-calendar",
+  googledrive: "google-drive",
+  gdrive: "google-drive",
+  googledocs: "google-docs",
+  gdocs: "google-docs",
+  docs: "google-docs",
+  mongo: "mongodb",
+  es: "elasticsearch",
+};
+
+export function normalizeConnectorId(raw: string): string {
+  const lower = raw.toLowerCase();
+  return CONNECTOR_ID_ALIASES[lower] ?? lower;
+}
+
+/**
  * Render a connector id (e.g. "google-calendar", "slack") as a
  * user-facing label. Title-cases each hyphen segment; special-cases a
  * couple of acronyms that look wrong with vanilla title-case.
@@ -389,11 +420,14 @@ export function shortName(name: string): string {
  * missing-connectors toast and the detail-page InstallPanel /
  * BundleInstallPanel inline notices. Keep terse — no marketing copy.
  */
-export function formatConnectorLabel(id: string): string {
+export function formatConnectorLabel(rawId: string): string {
+  const id = normalizeConnectorId(rawId);
   if (id === "github") return "GitHub";
   if (id === "gitlab") return "GitLab";
   if (id === "pagerduty") return "PagerDuty";
   if (id === "hubspot") return "HubSpot";
+  if (id === "sendgrid") return "SendGrid";
+  if (id === "mongodb") return "MongoDB";
   return id
     .split("-")
     .map((part) =>

--- a/src/recipeRoutes.ts
+++ b/src/recipeRoutes.ts
@@ -1581,9 +1581,16 @@ export function tryHandleRecipeRoute(
             action: "created" | "replaced";
           }> = [];
           const failures: Array<{ name: string; error: string }> = [];
-          const { writeFileSync, mkdirSync, unlinkSync } = await import(
-            "node:fs"
-          );
+          // Wave 1 fix: aggregate connector preflight across every
+          // bundle-installed recipe so the dashboard can surface a
+          // single "you need to connect Gmail + Slack + Calendar before
+          // running these" notice, matching the single-recipe install's
+          // missingConnectors behaviour. Previously bundle installs
+          // returned no preflight hint → users hit first-run "no Slack
+          // token" surprise on every recipe.
+          const aggregatedMissingConnectors = new Set<string>();
+          const { writeFileSync, mkdirSync, unlinkSync, readFileSync } =
+            await import("node:fs");
           const { installRecipeFromFile } = await import(
             "./recipes/installer.js"
           );
@@ -1657,6 +1664,60 @@ export function tryHandleRecipeRoute(
                   recipesDir,
                 });
                 installed.push({ name: r, action: installResult.action });
+                // Per-recipe connector preflight — same shape as the
+                // single-recipe path (lines ~2005+). Defensive: any
+                // failure must not roll back the install.
+                try {
+                  const installedJson = readFileSync(
+                    installResult.installedPath,
+                    "utf-8",
+                  );
+                  const recipeForPreflight = JSON.parse(installedJson) as {
+                    steps?: unknown[];
+                  };
+                  if (Array.isArray(recipeForPreflight.steps)) {
+                    const { detectRequiredConnectors, findMissingConnectors } =
+                      await import("./recipes/connectorPreflight.js");
+                    const required = detectRequiredConnectors(
+                      recipeForPreflight as Parameters<
+                        typeof detectRequiredConnectors
+                      >[0],
+                    );
+                    if (required.length > 0) {
+                      const { handleConnectionsList } = await import(
+                        "./connectors/gmail.js"
+                      );
+                      const connsResult = await handleConnectionsList();
+                      let connections: Array<{
+                        id?: string;
+                        status?: string;
+                      }> = [];
+                      try {
+                        const body = JSON.parse(connsResult.body) as {
+                          connectors?: Array<{
+                            id?: string;
+                            status?: string;
+                          }>;
+                        };
+                        connections = body.connectors ?? [];
+                      } catch {
+                        /* malformed body — treat as no connections */
+                      }
+                      const missing = findMissingConnectors(
+                        required,
+                        connections,
+                      );
+                      for (const id of missing) {
+                        aggregatedMissingConnectors.add(id);
+                      }
+                    }
+                  }
+                } catch (preflightErr) {
+                  console.warn(
+                    `[recipes/install] bundle preflight for "${r}" failed (non-blocking):`,
+                    preflightErr,
+                  );
+                }
               } finally {
                 try {
                   unlinkSync(tmpFile);
@@ -1700,6 +1761,9 @@ export function tryHandleRecipeRoute(
               bundleName,
               installed,
               failures,
+              ...(aggregatedMissingConnectors.size > 0 && {
+                missingConnectors: Array.from(aggregatedMissingConnectors),
+              }),
               ...(Object.keys(advisory).length > 0 && { advisory }),
             }),
           );


### PR DESCRIPTION
## Summary

Wave 1 follow-up to PR #783 (kill-switch + default-deny dialog). Four items, all focused on the install flow's silent-failure surface area.

| Item | Fix |
|---|---|
| 4 | `normalizeConnectorId()` collapses 3 spellings (`googleCalendar` / `calendar` / `google-calendar`) at the display boundary |
| 6 | Bundle install runs preflight per-recipe + aggregates `missingConnectors` (previously zero hint for bundle users) |
| 7 | `MissingConnectorsNotice` deep-links `/connections#<id>` per connector instead of dropping users on the index |
| 8 | `BundleInstallPanel` demotes the green "✓ Installed N recipes" headline to yellow "Only N of M installed" when failures dominate |

## Stats

- +237 / −60 across 7 files
- Bridge vitest 6143/6145, dashboard vitest 665/665 (3 tests updated for new shapes)
- `tsc --noEmit` clean (regular + tests.core.json strict)
- biome clean

## Test plan

- [ ] Install `morning-brief` (live registry) → calendar chip now reads "google-calendar" everywhere (label, aria, deep-link)
- [ ] Install a bundle of 5 recipes with missing connectors → notice shows aggregated set + one deep-link per connector
- [ ] Click "Connect Gmail" inside the notice → lands on `/connections#gmail` directly (page scrolls to row)
- [ ] Trigger a bundle install where 2 of 3 fail → headline reads "Only 1 of 3 recipes installed" in yellow

## What's next

**Wave 2** (queued): submit two-tab GitHub footgun, draft persistence (sessionStorage → localStorage), stale-tab revalidation interval, FALLBACK_REGISTRY refresh from live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)