### PR TITLE
feat(recipes): Phase 1B — YAML positions + CodeMirror inline gutter linter

### DIFF
--- a/dashboard/src/app/recipes/[name]/edit/_components/YamlEditor.tsx
+++ b/dashboard/src/app/recipes/[name]/edit/_components/YamlEditor.tsx
@@ -2,10 +2,46 @@
 
 import { useEffect, useRef } from "react";
 import { EditorView, keymap, lineNumbers, highlightActiveLineGutter, drawSelection, dropCursor, rectangularSelection, crosshairCursor, highlightActiveLine } from "@codemirror/view";
-import { EditorState, type Extension } from "@codemirror/state";
+import { EditorState, StateEffect, StateField, type Extension } from "@codemirror/state";
 import { defaultKeymap, history, historyKeymap, indentWithTab } from "@codemirror/commands";
 import { foldGutter, indentOnInput, syntaxHighlighting, defaultHighlightStyle, bracketMatching, foldKeymap } from "@codemirror/language";
 import { yaml } from "@codemirror/lang-yaml";
+import { linter, type Diagnostic } from "@codemirror/lint";
+
+/**
+ * Lint issue shape mirrored from `src/recipes/validation.ts`. Kept
+ * local so the editor component has no cross-package import; the
+ * dashboard route fetches `LintIssue[]` from `/api/bridge/recipes/lint`
+ * and forwards via the `lintIssues` prop.
+ */
+export interface YamlLintIssue {
+  level: "error" | "warning";
+  message: string;
+  /** 1-indexed line; when present, drives the gutter marker position. */
+  line?: number;
+  /** 1-indexed column; optional — when absent, the marker spans the line. */
+  column?: number;
+  code?: string;
+  path?: string;
+}
+
+/**
+ * State effect + field used to push lint diagnostics into the editor
+ * imperatively. CodeMirror's `linter()` is normally for async
+ * source-based lint passes; since our diagnostics come from a
+ * debounced server-side `/recipes/lint` fetch upstream, we shove them
+ * in via a StateField + effect instead.
+ */
+const setLintDiagnostics = StateEffect.define<readonly Diagnostic[]>();
+const lintDiagnosticsField = StateField.define<readonly Diagnostic[]>({
+  create: () => [],
+  update(value, tr) {
+    for (const effect of tr.effects) {
+      if (effect.is(setLintDiagnostics)) return effect.value;
+    }
+    return value;
+  },
+});
 
 // Minimal theme matching patchwork design tokens (both light/dark via CSS vars).
 // CM themes use static strings, so we inject a <style> for var() mappings.
@@ -74,6 +110,12 @@ function makeExtensions(onSave: () => void): Extension[] {
     crosshairCursor(),
     highlightActiveLine(),
     yaml(),
+    // Phase 1B: lint extension reads diagnostics from a StateField
+    // populated imperatively by the parent component when `/recipes/lint`
+    // returns structured `LintIssue[]`. The linter() call provides the
+    // gutter markers, hover messages, and inline squiggles for free.
+    lintDiagnosticsField,
+    linter((view) => Array.from(view.state.field(lintDiagnosticsField))),
     keymap.of([
       ...defaultKeymap,
       ...historyKeymap,
@@ -91,6 +133,7 @@ export default function YamlEditor({
   onSave,
   minHeight = 400,
   highlightLine,
+  lintIssues,
 }: {
   value: string;
   onChange: (value: string) => void;
@@ -102,6 +145,14 @@ export default function YamlEditor({
    * exact step that broke.
    */
   highlightLine?: number;
+  /**
+   * Phase 1B: structured lint issues to render as inline gutter
+   * diagnostics + squiggles. The route page fetches `/recipes/lint` and
+   * forwards the response; issues without a `line` field are dropped
+   * here (no gutter marker possible without a position — the lint
+   * banner still shows them as text).
+   */
+  lintIssues?: YamlLintIssue[];
 }) {
   const containerRef = useRef<HTMLDivElement>(null);
   const viewRef = useRef<EditorView | null>(null);
@@ -150,6 +201,33 @@ export default function YamlEditor({
       });
     }
   }, [value]);
+
+  // Phase 1B: sync lint issues → CodeMirror diagnostics. Re-fires when
+  // the parent fetches a new lint result. Issues without a `line` field
+  // are dropped (no source position → can't render a gutter marker —
+  // the route-level banner still shows them as text). One line per
+  // issue: span the whole line so the gutter marker + hover are
+  // unambiguous, even when `column` is set.
+  useEffect(() => {
+    const view = viewRef.current;
+    if (!view) return;
+    const issues = lintIssues ?? [];
+    const doc = view.state.doc;
+    const diagnostics: Diagnostic[] = [];
+    for (const issue of issues) {
+      if (typeof issue.line !== "number") continue;
+      const lineNum = Math.max(1, Math.min(issue.line, doc.lines));
+      const line = doc.line(lineNum);
+      diagnostics.push({
+        from: line.from,
+        to: line.to,
+        severity: issue.level === "error" ? "error" : "warning",
+        message: issue.message,
+        source: issue.code,
+      });
+    }
+    view.dispatch({ effects: setLintDiagnostics.of(diagnostics) });
+  }, [lintIssues]);
 
   // Scroll-to-line for the failed-run → YAML deep-link. Re-fires whenever
   // `highlightLine` or `value` changes — covers both the "land here on

--- a/dashboard/src/app/recipes/[name]/edit/page.tsx
+++ b/dashboard/src/app/recipes/[name]/edit/page.tsx
@@ -11,6 +11,7 @@ import {
   detectConnectorsForRecipe,
   detectConnectorsFromYaml,
 } from "../layout";
+import type { YamlLintIssue } from "./_components/YamlEditor";
 import dynamic from "next/dynamic";
 
 /** Minimal shape we need from `/api/bridge/connectors/status` to drive
@@ -54,6 +55,11 @@ export default function RecipeEditPage({
   const [saveError, setSaveError] = useState<string | null>(null);
   const [lintErrors, setLintErrors] = useState<string[]>([]);
   const [lintWarnings, setLintWarnings] = useState<string[]>([]);
+  // Phase 1B: structured issues drive the CodeMirror gutter linter.
+  // The display lists above continue to use plain message strings for
+  // the lint banner; this state carries the line/column/code/path
+  // fields needed for inline diagnostics.
+  const [lintIssues, setLintIssues] = useState<YamlLintIssue[]>([]);
   const [linting, setLinting] = useState(false);
   const toast = useToast();
 
@@ -234,6 +240,7 @@ export default function RecipeEditPage({
     if (!content.trim()) {
       setLintErrors([]);
       setLintWarnings([]);
+      setLintIssues([]);
       setLinting(false);
       return;
     }
@@ -277,6 +284,42 @@ export default function RecipeEditPage({
             : [];
           setLintErrors(errors);
           setLintWarnings(warnings);
+          // Phase 1B: collect structured issues (with line/column where
+          // resolvable) to drive CodeMirror gutter diagnostics. Filters
+          // raw items that lack the required `level` + `message` shape.
+          const toIssue = (raw: unknown, level: "error" | "warning"): YamlLintIssue | null => {
+            if (
+              raw &&
+              typeof raw === "object" &&
+              typeof (raw as { message?: unknown }).message === "string"
+            ) {
+              const r = raw as Partial<YamlLintIssue>;
+              return {
+                level,
+                message: r.message as string,
+                ...(typeof r.line === "number" && { line: r.line }),
+                ...(typeof r.column === "number" && { column: r.column }),
+                ...(typeof r.code === "string" && { code: r.code }),
+                ...(typeof r.path === "string" && { path: r.path }),
+              };
+            }
+            return null;
+          };
+          const structuredErrors = Array.isArray(
+            (data as { errors?: unknown }).errors,
+          )
+            ? (data as { errors: unknown[] }).errors
+                .map((r) => toIssue(r, "error"))
+                .filter((i): i is YamlLintIssue => i !== null)
+            : [];
+          const structuredWarnings = Array.isArray(
+            (data as { warnings?: unknown }).warnings,
+          )
+            ? (data as { warnings: unknown[] }).warnings
+                .map((r) => toIssue(r, "warning"))
+                .filter((i): i is YamlLintIssue => i !== null)
+            : [];
+          setLintIssues([...structuredErrors, ...structuredWarnings]);
         })
         .catch(() => {
           // ignore lint failures; server may be unavailable
@@ -686,6 +729,7 @@ export default function RecipeEditPage({
             onSave={() => void handleSave()}
             minHeight={400}
             highlightLine={highlightLine}
+            lintIssues={lintIssues}
           />
         )}
         <div

--- a/src/__tests__/webhookRecipes.test.ts
+++ b/src/__tests__/webhookRecipes.test.ts
@@ -336,8 +336,16 @@ describe("lintRecipeContent", () => {
 
     expect(lintRecipeContent(content)).toEqual({
       ok: false,
+      // Phase 1B: lint issues now carry `line`/`column` from
+      // `enrichIssuesWithPositions` — Step 1's `agent:` row in the
+      // sample YAML lives at line 5 col 5.
       errors: [
-        { level: "error", message: "Step 1: Agent step missing 'prompt'" },
+        {
+          level: "error",
+          message: "Step 1: Agent step missing 'prompt'",
+          line: 5,
+          column: 5,
+        },
       ],
       warnings: [{ level: "warning", message: "Missing 'description' field" }],
     });

--- a/src/recipes/__tests__/yamlPositions.test.ts
+++ b/src/recipes/__tests__/yamlPositions.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Tests for `resolveYamlPositions` + `enrichIssuesWithPositions`
+ * (Phase 1B). Pinning the wire shape so CodeMirror diagnostics land
+ * on the right lines.
+ */
+
+import { describe, expect, it } from "vitest";
+import type { LintIssue } from "../validation.js";
+import {
+  enrichIssuesWithPositions,
+  resolveYamlPositions,
+} from "../yamlPositions.js";
+
+const SAMPLE = `name: my-recipe
+description: x
+trigger:
+  type: cron
+  at: "0 6 * * *"
+steps:
+  - id: first
+    tool: file.read
+    path: /tmp/x
+  - id: second
+    agent: {}
+`;
+
+describe("resolveYamlPositions", () => {
+  it("indexes every top-level key", () => {
+    const idx = resolveYamlPositions(SAMPLE);
+    expect(idx.byPath.get("name")?.line).toBe(1);
+    expect(idx.byPath.get("description")?.line).toBe(2);
+    expect(idx.byPath.get("trigger")?.line).toBe(3);
+    expect(idx.byPath.get("steps")?.line).toBe(6);
+  });
+
+  it("indexes trigger sub-fields", () => {
+    const idx = resolveYamlPositions(SAMPLE);
+    expect(idx.byPath.get("trigger.type")?.line).toBe(4);
+    expect(idx.byPath.get("trigger.at")?.line).toBe(5);
+  });
+
+  it("indexes each step by zero-based index + step-level fields", () => {
+    const idx = resolveYamlPositions(SAMPLE);
+    expect(idx.byPath.get("steps.0")?.line).toBe(7);
+    expect(idx.byPath.get("steps.0.tool")?.line).toBe(8);
+    expect(idx.byPath.get("steps.0.path")?.line).toBe(9);
+    expect(idx.byPath.get("steps.1")?.line).toBe(10);
+    expect(idx.byPath.get("steps.1.agent")?.line).toBe(11);
+  });
+
+  it("returns an empty index for malformed YAML (no throw)", () => {
+    const idx = resolveYamlPositions("name: x\n  bad: indent\nfoo: [unclosed");
+    // Either parses partially or returns empty — either way no exception.
+    expect(idx.byPath instanceof Map).toBe(true);
+  });
+
+  it("returns an empty index when the root isn't an object", () => {
+    const idx = resolveYamlPositions("- just\n- a\n- list\n");
+    expect(idx.byPath.size).toBe(0);
+  });
+});
+
+describe("enrichIssuesWithPositions", () => {
+  it("attaches line/column for 'Step N:' messages", () => {
+    const issues: LintIssue[] = [
+      { level: "error", message: "Step 2: Agent step missing 'prompt'" },
+    ];
+    const out = enrichIssuesWithPositions(SAMPLE, issues);
+    // Step 2 (1-indexed) → steps[1] in the AST → line 10.
+    expect(out[0]?.line).toBe(10);
+  });
+
+  it("attaches line/column for AJV-style path issues (Phase 1A `path` field)", () => {
+    const issues: LintIssue[] = [
+      {
+        level: "error",
+        message: "Schema validation: trigger.at must match pattern",
+        code: "pattern",
+        path: "trigger.at",
+      },
+    ];
+    const out = enrichIssuesWithPositions(SAMPLE, issues);
+    expect(out[0]?.line).toBe(5);
+    expect(out[0]?.column).toBeGreaterThanOrEqual(1);
+  });
+
+  it("falls back to parent path when the deep schema key isn't indexed", () => {
+    const issues: LintIssue[] = [
+      {
+        level: "error",
+        message: "Schema validation: steps.0.params.0.nested oops",
+        path: "steps.0.params.0.nested",
+      },
+    ];
+    const out = enrichIssuesWithPositions(SAMPLE, issues);
+    // No exact match; walks up to `steps.0.tool` parent? No — it walks
+    // segment-by-segment until match. `steps.0` is the deepest known.
+    expect(out[0]?.line).toBe(7);
+  });
+
+  it("matches 'Missing or invalid X field' messages on a root key", () => {
+    const issues: LintIssue[] = [
+      { level: "error", message: "Missing or invalid 'trigger' field" },
+    ];
+    const out = enrichIssuesWithPositions(SAMPLE, issues);
+    expect(out[0]?.line).toBe(3);
+  });
+
+  it("passes issues through unchanged when no path resolves", () => {
+    const issues: LintIssue[] = [
+      {
+        level: "warning",
+        message: "Unspecific generic warning that doesn't reference any path",
+      },
+    ];
+    const out = enrichIssuesWithPositions(SAMPLE, issues);
+    expect(out[0]?.line).toBeUndefined();
+    expect(out[0]?.column).toBeUndefined();
+  });
+
+  it("preserves an already-populated line/column (validator-set positions win)", () => {
+    const issues: LintIssue[] = [
+      { level: "error", message: "Step 1: ...", line: 999, column: 1 },
+    ];
+    const out = enrichIssuesWithPositions(SAMPLE, issues);
+    expect(out[0]?.line).toBe(999);
+  });
+
+  it("returns the original array for empty input (no parse work)", () => {
+    const issues: LintIssue[] = [];
+    const out = enrichIssuesWithPositions(SAMPLE, issues);
+    expect(out).toBe(issues);
+  });
+});

--- a/src/recipes/yamlPositions.ts
+++ b/src/recipes/yamlPositions.ts
@@ -1,0 +1,208 @@
+/**
+ * YAML source-position resolver for lint diagnostics (Phase 1B).
+ *
+ * `validateRecipeDefinition` (validation.ts) emits `LintIssue` records
+ * keyed by logical paths — "Step 3", "trigger.at", "name" — but operates
+ * on a parsed JS object that has no source-position information. This
+ * module re-parses the YAML text into a CST-aware Document and produces
+ * a lookup table mapping logical-path strings to `{line, column}` pairs.
+ *
+ * `enrichIssuesWithPositions(yamlText, issues)` consults that map and
+ * adds `line` / `column` fields to each issue. Issues whose path can't
+ * be resolved are returned unchanged — the editor renders them at the
+ * top of the file or just in the lint banner.
+ *
+ * Used by `lintRecipeContent` in recipesHttp.ts. The pure mapping is
+ * exported separately so the Phase 1B follow-up (CodeMirror linter
+ * extension in YamlEditor.tsx) can also key off it client-side without
+ * re-running the validator.
+ */
+
+import { isMap, isPair, isScalar, isSeq, parseDocument } from "yaml";
+import type { LintIssue } from "./validation.js";
+
+interface Position {
+  /** 1-indexed line in the source YAML. */
+  line: number;
+  /** 1-indexed column. */
+  column: number;
+}
+
+/**
+ * Map of "logical path" → source position. Keys take one of two shapes:
+ *
+ *   - `<key>` for top-level scalar/object fields (`name`, `description`,
+ *     `trigger`, `steps`, ...).
+ *   - `<key>.<sub...>` for nested mapping fields — e.g. `trigger.at`,
+ *     `trigger.type`. Only the leaves we know the validator looks at are
+ *     populated; deeper nesting is best-effort.
+ *
+ *   - `steps.<n>` for the Nth step (zero-indexed to match AJV
+ *     `instancePath`). Maps to the line of the step's `id:` / `tool:` /
+ *     `agent:` key.
+ *
+ *   - `steps.<n>.<field>` for step-level fields (`steps.0.prompt`).
+ *
+ * Construction is best-effort; a malformed YAML buffer produces an
+ * empty map and falls through to top-of-file positions.
+ */
+export interface YamlPositionIndex {
+  byPath: Map<string, Position>;
+}
+
+export function resolveYamlPositions(yamlText: string): YamlPositionIndex {
+  const byPath = new Map<string, Position>();
+  let doc: ReturnType<typeof parseDocument>;
+  try {
+    doc = parseDocument(yamlText, { keepSourceTokens: false });
+  } catch {
+    return { byPath };
+  }
+
+  const contents = doc.contents;
+  if (!isMap(contents)) return { byPath };
+
+  // Pre-compute a (offset → {line, column}) translator. `lineCounter`
+  // would be more correct but adds a yaml-package option requirement —
+  // do the math ourselves from a single pass over the source.
+  const positionAt = (offset: number): Position => {
+    let line = 1;
+    let col = 1;
+    for (let i = 0; i < offset && i < yamlText.length; i++) {
+      if (yamlText.charCodeAt(i) === 0x0a) {
+        line++;
+        col = 1;
+      } else {
+        col++;
+      }
+    }
+    return { line, column: col };
+  };
+
+  // Record positions for every top-level key.
+  for (const pair of contents.items) {
+    if (!isPair(pair)) continue;
+    const key = pair.key;
+    if (!isScalar(key) || typeof key.value !== "string") continue;
+    const offset = key.range?.[0];
+    if (typeof offset === "number") {
+      byPath.set(key.value, positionAt(offset));
+    }
+    // Special-case the two most commonly-referenced root keys:
+    // `steps` (sequence) and `trigger` (mapping). Walk one level deeper.
+    if (key.value === "steps" && isSeq(pair.value)) {
+      pair.value.items.forEach((stepNode, idx) => {
+        if (!isMap(stepNode)) return;
+        // Use the line of the FIRST key in the step mapping as the
+        // step's source line — that's the line a user editing the
+        // recipe sees as the "start" of step N.
+        const firstKey = stepNode.items[0];
+        if (
+          !firstKey ||
+          !isPair(firstKey) ||
+          !isScalar(firstKey.key) ||
+          typeof firstKey.key.value !== "string"
+        ) {
+          return;
+        }
+        const stepOffset = firstKey.key.range?.[0];
+        if (typeof stepOffset !== "number") return;
+        const stepPos = positionAt(stepOffset);
+        byPath.set(`steps.${idx}`, stepPos);
+        // Also index each step-level field for the more precise
+        // schema-error cases (`steps.0.prompt`, `steps.0.tool`, ...).
+        for (const subPair of stepNode.items) {
+          if (!isPair(subPair)) continue;
+          const subKey = subPair.key;
+          if (!isScalar(subKey) || typeof subKey.value !== "string") continue;
+          const subOffset = subKey.range?.[0];
+          if (typeof subOffset !== "number") continue;
+          byPath.set(`steps.${idx}.${subKey.value}`, positionAt(subOffset));
+        }
+      });
+    }
+    if (key.value === "trigger" && isMap(pair.value)) {
+      for (const subPair of pair.value.items) {
+        if (!isPair(subPair)) continue;
+        const subKey = subPair.key;
+        if (!isScalar(subKey) || typeof subKey.value !== "string") continue;
+        const subOffset = subKey.range?.[0];
+        if (typeof subOffset !== "number") continue;
+        byPath.set(`trigger.${subKey.value}`, positionAt(subOffset));
+      }
+    }
+  }
+
+  return { byPath };
+}
+
+/**
+ * Step-message regex: matches the "Step N:" prefix the hand-rolled
+ * validator emits. N is 1-indexed in the message; we convert to
+ * 0-indexed to match the AJV `instancePath` convention used in the
+ * position index.
+ */
+const STEP_MSG_RE = /^Step (\d+):/;
+
+/**
+ * Resolve a LintIssue's logical position. Returns null when no match —
+ * caller leaves the issue unannotated and the editor renders it without
+ * a gutter marker.
+ */
+function resolveIssuePosition(
+  issue: LintIssue,
+  index: YamlPositionIndex,
+): Position | null {
+  // 1. Explicit `path` field set by Phase 1A `toSchemaLintIssue` —
+  //    matches AJV `instancePath` shape (`steps.0.prompt`, `trigger.at`).
+  if (issue.path && issue.path !== "recipe") {
+    const exact = index.byPath.get(issue.path);
+    if (exact) return exact;
+    // Fall back to the parent: a deep schema error like `steps.0.params.0`
+    // resolves to `steps.0` when the deeper position isn't known.
+    const segments = issue.path.split(".");
+    while (segments.length > 1) {
+      segments.pop();
+      const ancestor = index.byPath.get(segments.join("."));
+      if (ancestor) return ancestor;
+    }
+  }
+  // 2. "Step N:" prefix in the message — hand-rolled validator path.
+  const stepMatch = STEP_MSG_RE.exec(issue.message);
+  if (stepMatch?.[1]) {
+    const n = Number.parseInt(stepMatch[1], 10) - 1;
+    const stepPos = index.byPath.get(`steps.${n}`);
+    if (stepPos) return stepPos;
+  }
+  // 3. "Missing or invalid 'X' field" — match the field name and look it
+  //    up at the root.
+  const missingFieldMatch = /'([a-zA-Z_][a-zA-Z0-9_]*)'/.exec(issue.message);
+  if (missingFieldMatch?.[1]) {
+    const fieldPos = index.byPath.get(missingFieldMatch[1]);
+    if (fieldPos) return fieldPos;
+  }
+  return null;
+}
+
+/**
+ * Return a copy of `issues` with `line` / `column` populated where the
+ * logical path can be resolved against the source YAML. Issues whose
+ * path doesn't match anything in the index are passed through unchanged
+ * — callers must tolerate missing positions.
+ */
+export function enrichIssuesWithPositions(
+  yamlText: string,
+  issues: LintIssue[],
+): LintIssue[] {
+  if (issues.length === 0) return issues;
+  const index = resolveYamlPositions(yamlText);
+  if (index.byPath.size === 0) return issues;
+  return issues.map((issue) => {
+    // Preserve any line/column already set by the validator (future-
+    // proofing — validators may grow source-aware emit paths).
+    if (typeof issue.line === "number") return issue;
+    const pos = resolveIssuePosition(issue, index);
+    if (!pos) return issue;
+    return { ...issue, line: pos.line, column: pos.column };
+  });
+}

--- a/src/recipesHttp.ts
+++ b/src/recipesHttp.ts
@@ -27,6 +27,7 @@ import {
   type LintIssue,
   validateRecipeDefinition,
 } from "./recipes/validation.js";
+import { enrichIssuesWithPositions } from "./recipes/yamlPositions.js";
 
 /**
  * Returns true unless `filePath` lives inside an install dir whose
@@ -936,9 +937,17 @@ export function lintRecipeContent(content: string): {
   }
 
   const validation = validateRecipeDefinition(parsed);
+  // Phase 1B: enrich with source positions. The validator operates on
+  // the parsed JS object and has no line/column info; this pass
+  // re-parses the YAML AST to map logical paths (`steps.0.prompt`,
+  // `trigger.at`, "Step 3:" prefixes) → 1-indexed line/column. The
+  // CodeMirror linter extension in the editor keys off these to render
+  // inline gutter diagnostics. Issues whose path doesn't match anything
+  // in the index pass through unannotated.
+  const enriched = enrichIssuesWithPositions(content, validation.issues);
   const errors: LintIssue[] = [];
   const warnings: LintIssue[] = [];
-  for (const issue of validation.issues) {
+  for (const issue of enriched) {
     if (issue.level === "error") errors.push(issue);
     else warnings.push(issue);
   }


### PR DESCRIPTION
## Summary

Phase 1B of the recipe-fix-UX campaign. Threads source positions through the lint pipeline so the editor renders inline gutter markers + squiggles + hover messages, not just a flat error banner.

Phase 1A.1 (#782) shipped structured `path` / `code` fields on `LintIssue` — this PR wires the missing `line` / `column` resolution from YAML AST to CodeMirror's `@codemirror/lint` extension.

## What it does

```yaml
name: x
trigger:
  type: cron
steps:
  - agent: {}              # ← red squiggle: "Step 1: Agent step missing 'prompt'"
```

Click the gutter marker → hover shows the message. Source-position resolver maps:
- AJV `instancePath` (Phase 1A) → exact AST position with ancestor fallback
- "Step N:" message prefix → step N's `id:` / first-key line
- "'X' field" message → root-level X position

Issues without a resolvable position pass through unannotated — they still appear in the lint banner above the editor.

## Stats

- +484 / −3 across 6 files (bridge resolver + tests + dashboard editor + page wiring)
- bridge vitest 6155/6157 (1 fsWatch flake unrelated, passes in isolation)
- dashboard vitest 665/665
- `tsc --noEmit` clean (regular + tests.core.json strict)
- 12 new tests pinning resolver + enrichment behavior

## Architecture

```
YAML buffer → /recipes/lint
              → validateRecipeDefinition (operates on parsed object)
              → enrichIssuesWithPositions (re-parses CST, maps paths)
              → LintIssue[] with line/column
            → dashboard fetch
            → lintIssues state
            → YamlEditor (StateField + setLintDiagnostics effect)
            → @codemirror/lint linter()
```

The position resolver lives in a separate `yamlPositions.ts` module so the Phase 2A "Fix with AI" repair flow can reuse it for "click the squiggle to ask Claude to fix this step" UX.

## Test plan

- [ ] Open a broken recipe — verify red squiggle on the offending step row
- [ ] Hover gutter marker → tooltip shows the lint message
- [ ] Edit the offending row → squiggle clears on next lint pass
- [ ] Lint issue without a resolvable path → still appears in the top-of-editor banner (not lost)
- [ ] AJV schema error with `path: "trigger.at"` → squiggle lands on the `at:` line

## What's next

**Phase 2A**: "Fix with AI" button — pipes current YAML + structured `LintIssue[]` to a `/recipes/repair` endpoint that wraps `runClaudeTask`. Position resolver in this PR is reused to land Claude's proposed-diff at the offending line for the preview UX.

🤖 Generated with [Claude Code](https://claude.com/claude-code)