### PR TITLE
feat(recipes): Phase 2A.2 — dashboard 'Fix with AI' button + preview-diff modal

### DIFF
--- a/dashboard/src/app/api/bridge/recipes/repair/__tests__/route.test.ts
+++ b/dashboard/src/app/api/bridge/recipes/repair/__tests__/route.test.ts
@@ -1,0 +1,117 @@
+/** @vitest-environment node */
+/**
+ * Tests for the /api/bridge/recipes/repair proxy (Phase 2A.2).
+ *
+ * Covers: body cap (413), passthrough of bridge response shape
+ * (feature_disabled 503, rate-limited 429, ok 200), and
+ * Retry-After header passthrough.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import { POST } from "../route";
+
+let bridgeFetchMock = vi.fn(
+  async () =>
+    new Response(JSON.stringify({ ok: true, yaml: "name: fixed\n" }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    }),
+);
+
+vi.mock("@/lib/bridge", () => ({
+  bridgeFetch: (path: string, init: RequestInit) =>
+    bridgeFetchMock(path as never, init as never),
+}));
+
+function makeReq(body: string, contentLength?: string): Request {
+  const headers: Record<string, string> = {
+    "content-type": "application/json",
+    "sec-fetch-site": "same-origin",
+  };
+  if (contentLength !== undefined) headers["content-length"] = contentLength;
+  return new Request("https://dashboard.local/api/bridge/recipes/repair", {
+    method: "POST",
+    headers,
+    body,
+  });
+}
+
+describe("POST /api/bridge/recipes/repair", () => {
+  it("forwards a small body and returns the bridge's 200 result", async () => {
+    bridgeFetchMock = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ ok: true, yaml: "name: fixed\n" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+    const body = JSON.stringify({
+      currentYaml: "name: broken\n",
+      lintIssues: [{ level: "error", message: "Missing trigger" }],
+    });
+    const res = await POST(makeReq(body));
+    expect(res.status).toBe(200);
+    const parsed = await res.json();
+    expect(parsed.ok).toBe(true);
+    expect(parsed.yaml).toBe("name: fixed\n");
+  });
+
+  it("passes through the bridge's 503 feature_disabled without rewriting", async () => {
+    bridgeFetchMock = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            ok: false,
+            code: "feature_disabled",
+            error: "off",
+            unavailable: true,
+          }),
+          { status: 503, headers: { "content-type": "application/json" } },
+        ),
+    );
+    const res = await POST(
+      makeReq(JSON.stringify({ currentYaml: "name: x\n", lintIssues: [] })),
+    );
+    expect(res.status).toBe(503);
+    const parsed = await res.json();
+    expect(parsed.code).toBe("feature_disabled");
+  });
+
+  it("passes through 429 with Retry-After header preserved", async () => {
+    bridgeFetchMock = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({ ok: false, retryAfterSeconds: 30 }),
+          {
+            status: 429,
+            headers: {
+              "content-type": "application/json",
+              "retry-after": "30",
+            },
+          },
+        ),
+    );
+    const res = await POST(
+      makeReq(JSON.stringify({ currentYaml: "name: x\n", lintIssues: [] })),
+    );
+    expect(res.status).toBe(429);
+    expect(res.headers.get("retry-after")).toBe("30");
+  });
+
+  it("rejects oversized request via Content-Length with 413", async () => {
+    const res = await POST(makeReq("x", "9999999999"));
+    expect(res.status).toBe(413);
+  });
+
+  it("returns 502 when bridge is unreachable", async () => {
+    bridgeFetchMock = vi.fn(async () => {
+      throw new Error("ECONNREFUSED");
+    });
+    const res = await POST(
+      makeReq(JSON.stringify({ currentYaml: "name: x\n", lintIssues: [] })),
+    );
+    expect(res.status).toBe(502);
+    const parsed = await res.json();
+    expect(parsed.error).toMatch(/unreachable/i);
+  });
+});

--- a/dashboard/src/app/api/bridge/recipes/repair/__tests__/route.test.ts
+++ b/dashboard/src/app/api/bridge/recipes/repair/__tests__/route.test.ts
@@ -10,7 +10,13 @@ import { describe, expect, it, vi } from "vitest";
 
 import { POST } from "../route";
 
-let bridgeFetchMock = vi.fn(
+// Typed signature so the per-test reassignment of `bridgeFetchMock`
+// doesn't lose its arg shape — strict tsc rejected `vi.fn(async () => …)`
+// as zero-arg.
+let bridgeFetchMock: (
+  path: string,
+  init: RequestInit,
+) => Promise<Response> = vi.fn(
   async () =>
     new Response(JSON.stringify({ ok: true, yaml: "name: fixed\n" }), {
       status: 200,
@@ -19,8 +25,7 @@ let bridgeFetchMock = vi.fn(
 );
 
 vi.mock("@/lib/bridge", () => ({
-  bridgeFetch: (path: string, init: RequestInit) =>
-    bridgeFetchMock(path as never, init as never),
+  bridgeFetch: (path: string, init: RequestInit) => bridgeFetchMock(path, init),
 }));
 
 function makeReq(body: string, contentLength?: string): Request {

--- a/dashboard/src/app/api/bridge/recipes/repair/route.ts
+++ b/dashboard/src/app/api/bridge/recipes/repair/route.ts
@@ -10,7 +10,6 @@
  * no" message.
  */
 
-import type { NextRequest } from "next/server";
 import { bridgeFetch } from "@/lib/bridge";
 import { requireSameOrigin } from "@/lib/csrf";
 import {
@@ -22,7 +21,10 @@ import {
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
-export async function POST(req: NextRequest): Promise<Response> {
+// Signature uses bare `Request` (not `NextRequest`) to match the
+// existing /api/bridge/recipes/generate proxy so the test file can
+// pass `new Request(...)` directly without a NextRequest cast.
+export async function POST(req: Request): Promise<Response> {
   const guard = requireSameOrigin(req);
   if (guard) return guard;
   // Same cap as `/recipes/lint` since the body carries the full YAML

--- a/dashboard/src/app/api/bridge/recipes/repair/route.ts
+++ b/dashboard/src/app/api/bridge/recipes/repair/route.ts
@@ -1,0 +1,59 @@
+/**
+ * Phase 2A.2 proxy for the bridge's `/recipes/repair` LLM-driven fix
+ * endpoint. Same shape as `/recipes/lint` proxy — same-origin guard,
+ * body cap, bridgeFetch passthrough, structured error mapping.
+ *
+ * The bridge gates this behind the `recipe.repair-ai` feature flag —
+ * returns 503 `{code:"feature_disabled"}` when off. Surface that
+ * through the proxy unchanged so the dashboard can render the
+ * "enable the flag" toast inline rather than a generic "bridge said
+ * no" message.
+ */
+
+import type { NextRequest } from "next/server";
+import { bridgeFetch } from "@/lib/bridge";
+import { requireSameOrigin } from "@/lib/csrf";
+import {
+  BRIDGE_BODY_CAPS,
+  bodyTooLargeResponse,
+  readBodyWithCap,
+} from "@/lib/readBodyWithCap";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function POST(req: NextRequest): Promise<Response> {
+  const guard = requireSameOrigin(req);
+  if (guard) return guard;
+  // Same cap as `/recipes/lint` since the body carries the full YAML
+  // plus a small `lintIssues[]` array (cap on bridge side matches).
+  const read = await readBodyWithCap(req, BRIDGE_BODY_CAPS.content);
+  if (!read.ok) return bodyTooLargeResponse(BRIDGE_BODY_CAPS.content);
+  try {
+    const res = await bridgeFetch("/recipes/repair", {
+      method: "POST",
+      headers: {
+        "content-type": req.headers.get("content-type") ?? "application/json",
+      },
+      body: read.body,
+    });
+    const text = await res.text();
+    return new Response(text, {
+      status: res.status,
+      headers: {
+        "content-type": "application/json",
+        // Pass through Retry-After so the dashboard toast can show
+        // "wait N seconds" on 429 without re-parsing the body.
+        ...(res.headers.get("retry-after") && {
+          "retry-after": res.headers.get("retry-after") as string,
+        }),
+      },
+    });
+  } catch (err) {
+    console.error("[recipes/repair] bridge fetch failed:", err);
+    return new Response(JSON.stringify({ error: "Bridge unreachable" }), {
+      status: 502,
+      headers: { "content-type": "application/json" },
+    });
+  }
+}

--- a/dashboard/src/app/recipes/[name]/edit/page.tsx
+++ b/dashboard/src/app/recipes/[name]/edit/page.tsx
@@ -60,6 +60,17 @@ export default function RecipeEditPage({
   // the lint banner; this state carries the line/column/code/path
   // fields needed for inline diagnostics.
   const [lintIssues, setLintIssues] = useState<YamlLintIssue[]>([]);
+  // Phase 2A.2: "Fix with AI" — proposes a repaired YAML via the
+  // bridge's /recipes/repair endpoint and shows the result in a
+  // preview modal so the user can apply or discard. Gated behind the
+  // `recipe.repair-ai` flag on the bridge side; when off the bridge
+  // returns 503 feature_disabled and the dashboard renders a toast
+  // pointing at Settings → Feature flags.
+  const [repairBusy, setRepairBusy] = useState(false);
+  const [repairProposal, setRepairProposal] = useState<{
+    yaml: string;
+    warnings: string[];
+  } | null>(null);
   const [linting, setLinting] = useState(false);
   const toast = useToast();
 
@@ -432,6 +443,72 @@ export default function RecipeEditPage({
     }
   }
 
+  async function handleFixWithAi() {
+    if (repairBusy) return;
+    setRepairBusy(true);
+    try {
+      const res = await fetch(apiPath("/api/bridge/recipes/repair"), {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ currentYaml: content, lintIssues }),
+      });
+      const data = (await res.json().catch(() => ({}))) as {
+        ok?: boolean;
+        yaml?: string;
+        warnings?: string[];
+        error?: string;
+        code?: string;
+        unavailable?: boolean;
+        retryAfterSeconds?: number;
+      };
+      if (res.status === 503 && data.code === "feature_disabled") {
+        toast.info(
+          "Recipe AI repair is off by default. Enable the `recipe.repair-ai` flag in Settings → Feature flags.",
+        );
+        return;
+      }
+      if (res.status === 503) {
+        toast.error(
+          "Recipe AI repair unavailable — needs `patchwork --driver subprocess` running.",
+        );
+        return;
+      }
+      if (res.status === 429) {
+        toast.error(
+          `Rate-limited. Try again in ${data.retryAfterSeconds ?? 60}s.`,
+        );
+        return;
+      }
+      if (!res.ok || !data.ok || !data.yaml) {
+        toast.error(
+          `AI repair failed: ${data.error ?? `HTTP ${res.status}`}`,
+        );
+        return;
+      }
+      setRepairProposal({
+        yaml: data.yaml,
+        warnings: data.warnings ?? [],
+      });
+    } catch (e) {
+      toast.error(
+        `AI repair request failed: ${e instanceof Error ? e.message : String(e)}`,
+      );
+    } finally {
+      setRepairBusy(false);
+    }
+  }
+
+  function applyRepair() {
+    if (!repairProposal) return;
+    setContent(repairProposal.yaml);
+    setRepairProposal(null);
+    toast.success("Applied AI proposal. Review + save to commit.");
+  }
+
+  function discardRepair() {
+    setRepairProposal(null);
+  }
+
   return (
     <section>
       {/* The layout at recipes/[name]/layout.tsx already renders
@@ -562,14 +639,157 @@ export default function RecipeEditPage({
             fontSize: "var(--fs-m)",
           }}
         >
-          <strong style={{ display: "block", marginBottom: 4 }}>
-            {lintErrors.length} lint error{lintErrors.length === 1 ? "" : "s"}
-          </strong>
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+              gap: "var(--s-3)",
+              marginBottom: 4,
+            }}
+          >
+            <strong>
+              {lintErrors.length} lint error
+              {lintErrors.length === 1 ? "" : "s"}
+            </strong>
+            {/* Phase 2A.2: Fix with AI — posts to /recipes/repair (the
+                bridge gates this behind the `recipe.repair-ai` flag;
+                503 + feature_disabled → toast pointing at Settings). */}
+            <button
+              type="button"
+              onClick={() => void handleFixWithAi()}
+              disabled={repairBusy}
+              className="btn sm"
+              style={{ flexShrink: 0 }}
+              aria-label="Propose an AI fix for the lint errors"
+            >
+              {repairBusy ? "Asking AI…" : "Fix with AI"}
+            </button>
+          </div>
           <ul style={{ margin: 0, paddingLeft: 18, fontFamily: "var(--font-mono)", fontSize: "var(--fs-s)" }}>
             {lintErrors.map((msg, idx) => (
               <li key={`lint-err-${idx}`}>{msg}</li>
             ))}
           </ul>
+        </div>
+      )}
+
+      {/* Phase 2A.2: AI repair preview modal. Renders the proposed
+          YAML; user applies (overwrites editor content) or discards. */}
+      {repairProposal !== null && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-label="AI-proposed recipe fix"
+          style={{
+            position: "fixed",
+            inset: 0,
+            zIndex: 80,
+            background: "rgba(0,0,0,0.55)",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            padding: "var(--s-4)",
+          }}
+          onClick={(e) => {
+            // Backdrop click discards.
+            if (e.target === e.currentTarget) discardRepair();
+          }}
+        >
+          <div
+            style={{
+              background: "var(--bg-0)",
+              borderRadius: "var(--r-3)",
+              border: "1px solid var(--line-2)",
+              maxWidth: 880,
+              width: "100%",
+              maxHeight: "85vh",
+              display: "flex",
+              flexDirection: "column",
+              gap: "var(--s-3)",
+              padding: "var(--s-5)",
+              overflow: "hidden",
+            }}
+          >
+            <div>
+              <h2 style={{ margin: 0, fontSize: "var(--fs-l)" }}>
+                AI proposed a fix
+              </h2>
+              <p
+                style={{
+                  margin: "var(--s-2) 0 0",
+                  color: "var(--ink-2)",
+                  fontSize: "var(--fs-s)",
+                }}
+              >
+                Review the proposed YAML below. Apply will replace your
+                editor content — save afterwards to commit. Discard
+                throws this proposal away (your buffer is unchanged).
+              </p>
+            </div>
+            {repairProposal.warnings.length > 0 && (
+              <div
+                style={{
+                  background: "var(--warn-soft)",
+                  border: "1px solid var(--warn)",
+                  borderRadius: "var(--r-2)",
+                  padding: "var(--s-2) var(--s-3)",
+                  fontSize: "var(--fs-s)",
+                  color: "var(--warn)",
+                }}
+              >
+                <strong>
+                  {repairProposal.warnings.length} warning
+                  {repairProposal.warnings.length === 1 ? "" : "s"}:
+                </strong>
+                <ul style={{ margin: "4px 0 0 18px", padding: 0 }}>
+                  {repairProposal.warnings.map((w, idx) => (
+                    <li key={`repair-warn-${idx}`}>{w}</li>
+                  ))}
+                </ul>
+              </div>
+            )}
+            <pre
+              style={{
+                flex: 1,
+                overflow: "auto",
+                background: "var(--recess)",
+                border: "1px solid var(--line-2)",
+                borderRadius: "var(--r-2)",
+                padding: "var(--s-3)",
+                fontFamily: "var(--font-mono)",
+                fontSize: "var(--fs-s)",
+                color: "var(--ink-0)",
+                margin: 0,
+                whiteSpace: "pre-wrap",
+                wordBreak: "break-word",
+              }}
+            >
+              {repairProposal.yaml}
+            </pre>
+            <div
+              style={{
+                display: "flex",
+                gap: "var(--s-3)",
+                justifyContent: "flex-end",
+              }}
+            >
+              <button
+                type="button"
+                className="btn ghost"
+                onClick={discardRepair}
+              >
+                Discard
+              </button>
+              <button
+                type="button"
+                className="btn primary"
+                onClick={applyRepair}
+              >
+                Apply proposal
+              </button>
+            </div>
+          </div>
         </div>
       )}
 


### PR DESCRIPTION
## Summary

Dashboard half of Phase 2A. Wires to the bridge `/recipes/repair` endpoint shipped in #787 with a button + preview-diff modal + clear failure-mode toasts.

| Where | Change |
|---|---|
| `dashboard/.../api/bridge/recipes/repair/route.ts` | New Next proxy, same shape as `/recipes/lint` proxy (same-origin guard, body cap, bridgeFetch passthrough, Retry-After preserved on 429) |
| `recipes/[name]/edit/page.tsx` | "Fix with AI" button inside the lint-error banner + state for in-flight request + preview modal with Apply/Discard |

## Failure-mode toasts

| Bridge response | Toast |
|---|---|
| 200 ok | modal opens with proposed YAML |
| 503 `feature_disabled` | info toast: "Enable the `recipe.repair-ai` flag in Settings → Feature flags." |
| 503 unavailable | error: "needs `patchwork --driver subprocess` running" |
| 429 | error: "Rate-limited. Try again in N seconds." (uses `retryAfterSeconds` from body) |
| any other 4xx/5xx | error with the bridge's `error` field |
| network error | generic "request failed" |

## Stats

- +399 / −3 across 3 files
- dashboard vitest 670/670 (5 new in proxy `__tests__/route.test.ts`)
- `tsc --noEmit` clean

## Test plan

- [ ] Enable `recipe.repair-ai` flag, edit a broken recipe → "Fix with AI" button appears in the red lint banner
- [ ] Click → "Asking AI…" busy state → modal opens with proposed YAML
- [ ] Apply → editor content replaced, modal closes, banner clears on next lint pass
- [ ] Discard → modal closes, editor buffer unchanged
- [ ] Backdrop click → discard (same as Discard button)
- [ ] Flag off → 503 `feature_disabled` → info toast with the enable instructions

## Campaign closeout

This closes Phase 2A. Remaining:
- **Phase 2B** — form-mode toggle on existing recipes (AI-free fallback)
- **Phase 3** — `HaltCategory` expansion + per-recipe failure-pattern detection + real retry-from-step

🤖 Generated with [Claude Code](https://claude.com/claude-code)