### PR TITLE
feat(halts): expand HaltCategory — auth/rate-limit/network/missing-connector sub-categories

### DIFF
--- a/dashboard/src/app/recipes/[name]/page.tsx
+++ b/dashboard/src/app/recipes/[name]/page.tsx
@@ -74,6 +74,13 @@ type HaltCategory =
   | "tool_threw"
   | "tool_error"
   | "kill_switch"
+  | "budget_exceeded"
+  | "expect_failed"
+  | "step_timeout"
+  | "auth_failure"
+  | "rate_limited"
+  | "network_error"
+  | "missing_connector"
   | "run_level"
   | "unknown";
 
@@ -99,6 +106,13 @@ const HALT_CATEGORY_LABEL: Record<HaltCategory, string> = {
   tool_threw: "tool threw",
   tool_error: "tool error",
   kill_switch: "kill switch",
+  budget_exceeded: "budget exceeded",
+  expect_failed: "expect failed",
+  step_timeout: "step timeout",
+  auth_failure: "auth failure",
+  rate_limited: "rate limited",
+  network_error: "network error",
+  missing_connector: "missing connector",
   run_level: "run-level",
   unknown: "unknown",
 };

--- a/dashboard/src/app/runs/page.tsx
+++ b/dashboard/src/app/runs/page.tsx
@@ -117,6 +117,13 @@ type HaltCategory =
   | "tool_threw"
   | "tool_error"
   | "kill_switch"
+  | "budget_exceeded"
+  | "expect_failed"
+  | "step_timeout"
+  | "auth_failure"
+  | "rate_limited"
+  | "network_error"
+  | "missing_connector"
   | "run_level"
   | "unknown";
 
@@ -152,6 +159,13 @@ const HALT_CATEGORY_LABEL: Record<HaltCategory, string> = {
   tool_threw: "tool threw",
   tool_error: "tool error",
   kill_switch: "kill-switch blocked",
+  budget_exceeded: "budget exceeded",
+  expect_failed: "expect failed",
+  step_timeout: "step timeout",
+  auth_failure: "auth failure",
+  rate_limited: "rate limited",
+  network_error: "network error",
+  missing_connector: "missing connector",
   run_level: "run-level halt",
   unknown: "uncategorised",
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -2287,6 +2287,13 @@ if (process.argv[2] === "halts") {
         tool_threw: "tool threw",
         tool_error: "tool error",
         kill_switch: "kill-switch blocked",
+        budget_exceeded: "budget exceeded",
+        expect_failed: "expect failed",
+        step_timeout: "step timeout",
+        auth_failure: "auth failure",
+        rate_limited: "rate limited",
+        network_error: "network error",
+        missing_connector: "missing connector",
         run_level: "run-level halt",
         unknown: "uncategorised",
       };

--- a/src/recipes/__tests__/haltCategory.test.ts
+++ b/src/recipes/__tests__/haltCategory.test.ts
@@ -51,6 +51,66 @@ describe("categoriseHaltReason", () => {
     expect(categoriseHaltReason("kill-switch active")).toBe("kill_switch");
   });
 
+  it("recognises auth_failure inside wrapped tool envelopes", () => {
+    expect(
+      categoriseHaltReason(
+        'Tool "github.createIssue" in step "open" threw: 401 Unauthorized',
+      ),
+    ).toBe("auth_failure");
+    expect(
+      categoriseHaltReason(
+        'Tool "slack.post" in step "n" reported an error: token_expired',
+      ),
+    ).toBe("auth_failure");
+    expect(categoriseHaltReason("403 Forbidden")).toBe("auth_failure");
+  });
+
+  it("recognises rate_limited halts", () => {
+    expect(
+      categoriseHaltReason(
+        'Tool "github.search" in step "s" threw: 429 Too Many Requests',
+      ),
+    ).toBe("rate_limited");
+    expect(categoriseHaltReason("rate-limit exceeded")).toBe("rate_limited");
+  });
+
+  it("recognises network_error halts (transport-level)", () => {
+    expect(
+      categoriseHaltReason(
+        'Tool "http.get" in step "s" threw: connect ECONNREFUSED 127.0.0.1:443',
+      ),
+    ).toBe("network_error");
+    expect(
+      categoriseHaltReason(
+        'Tool "x" threw: getaddrinfo ENOTFOUND api.example.com',
+      ),
+    ).toBe("network_error");
+    expect(categoriseHaltReason("fetch failed")).toBe("network_error");
+  });
+
+  it("recognises missing_connector halts", () => {
+    expect(
+      categoriseHaltReason(
+        'Tool "gmail.send" in step "s" threw: connector_not_configured',
+      ),
+    ).toBe("missing_connector");
+    expect(
+      categoriseHaltReason(
+        'Tool "x" reported an error: no connector token for slack',
+      ),
+    ).toBe("missing_connector");
+  });
+
+  it("leaves the existing 'remote unreachable' phrase in tool_error (network match is narrow)", () => {
+    // Regression guard: too many tools use "unreachable" as a generic
+    // phrase — keep it in tool_error, not network_error.
+    expect(
+      categoriseHaltReason(
+        'Tool "git.x" in step "y" reported an error: remote unreachable',
+      ),
+    ).toBe("tool_error");
+  });
+
   it("returns 'unknown' for missing or unrecognised reasons", () => {
     expect(categoriseHaltReason(undefined)).toBe("unknown");
     expect(categoriseHaltReason("")).toBe("unknown");

--- a/src/recipes/haltCategory.ts
+++ b/src/recipes/haltCategory.ts
@@ -26,6 +26,27 @@ export type HaltCategory =
   | "expect_failed"
   /** Per-step wall-clock `timeout_ms` exceeded (sandbox-alternative slice). */
   | "step_timeout"
+  /**
+   * Connector returned 401/403 — token expired or scopes insufficient.
+   * Actionable: user should reconnect from /connections.
+   */
+  | "auth_failure"
+  /**
+   * External service returned 429 / rate limit. Actionable: retry later
+   * or back off the cron cadence.
+   */
+  | "rate_limited"
+  /**
+   * Transport failed before the request reached the service
+   * (ECONNREFUSED, ENOTFOUND, fetch failed). Distinct from a 4xx/5xx
+   * from the service itself — usually a local network / DNS issue.
+   */
+  | "network_error"
+  /**
+   * Tool needed a connector that isn't configured for this workspace.
+   * Actionable: install/connect from /connections.
+   */
+  | "missing_connector"
   /** Whole-recipe failure (e.g. circular dependencies) — has no step row. */
   | "run_level"
   | "unknown";
@@ -47,6 +68,31 @@ export function categoriseHaltReason(reason: string | undefined): HaltCategory {
   // Must precede the `^Tool ... threw` matcher: timeouts surface wrapped
   // inside the tool-threw envelope (`Tool "x" in step "y" threw: step_timeout: ...`).
   if (/step_timeout/i.test(reason)) return "step_timeout";
+  // Sub-categories that peek inside the wrapped `Tool "x" threw: <inner>` /
+  // `Tool "x" reported an error: <inner>` envelope. Must precede the
+  // generic `tool_threw` / `tool_error` matchers below. Patterns are
+  // deliberately narrow — e.g. "unreachable" alone stays in `tool_error`
+  // because too many tools use it as a generic phrase.
+  if (
+    /\b(401|403)\b|unauthori[sz]ed|forbidden|invalid[_ -]?token|token[_ -]?expired|authentication[_ -]?failed/i.test(
+      reason,
+    )
+  )
+    return "auth_failure";
+  if (/\b429\b|rate[_ -]?limit|too many requests/i.test(reason))
+    return "rate_limited";
+  if (
+    /ECONNREFUSED|ENOTFOUND|ECONNRESET|ETIMEDOUT|EAI_AGAIN|fetch failed|network[_ -]?error|getaddrinfo/i.test(
+      reason,
+    )
+  )
+    return "network_error";
+  if (
+    /connector[_ -]?not[_ -]?configured|no[_ -]?(connector[_ -]?)?token|not[_ -]?connected|missing[_ -]?connector/i.test(
+      reason,
+    )
+  )
+    return "missing_connector";
   if (/^Agent step .* threw/i.test(reason)) return "agent_threw";
   if (/^Tool .* threw/i.test(reason)) return "tool_threw";
   if (/^Tool .* reported an error/i.test(reason)) return "tool_error";

--- a/src/tools/__tests__/recentTracesDigest.test.ts
+++ b/src/tools/__tests__/recentTracesDigest.test.ts
@@ -332,7 +332,9 @@ describe("buildRecentTracesDigest — decision formatting", () => {
       expect(haltLine).toBeDefined();
       expect(haltLine).toContain("HALTS (last 12h): 2");
       expect(haltLine).toContain("tool_threw·1");
-      expect(haltLine).toContain("tool_error·1");
+      // "401" in the wrapped envelope now categorises as auth_failure
+      // (PR #789 — sub-category split out of tool_error/tool_threw).
+      expect(haltLine).toContain("auth_failure·1");
     });
 
     it("emits halt summary even when there are no decision traces (halts alone are signal)", async () => {


### PR DESCRIPTION
## Summary

- Splits `auth_failure` / `rate_limited` / `network_error` / `missing_connector` out of the generic `tool_threw` bucket so the dashboard halts panel + `patchwork halts` CLI can surface actionable phrasing ("token expired — reconnect Slack") instead of opaque "tool threw".
- Patterns are narrow: peek inside the `Tool "x" in step "y" threw: <inner>` envelope for literal errno phrases (`ECONNREFUSED`, `401`, `429`, `connector_not_configured`). "Remote unreachable" stays in `tool_error` — too many tools use it generically (regression-guarded by test).
- Fixes a dashboard divergence: the two `HaltCategory` union types were missing `budget_exceeded` / `expect_failed` / `step_timeout` that already existed in the bridge — they were rendering with raw enum keys. Added the 3 pre-existing ones along with the 4 new categories so `HALT_CATEGORY_LABEL: Record<HaltCategory, string>` is exhaustive again.
- CLI `halts` label table updated to match.

## Test plan

- [x] `npx vitest run src/recipes/__tests__/haltCategory.test.ts` — 18 pass (5 new + regression guard for "remote unreachable")
- [x] `npx vitest run src/__tests__/server-halt-summary.test.ts` — 5 pass
- [x] `dashboard/ tsc --noEmit` clean
- [x] `tsc -p tsconfig.tests.core.json` clean
- [x] `npm run build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)