### PR TITLE
fix: SSRF 6to4 block, ReDoS guard, cron UTC default, Windows atomic rename

### DIFF
--- a/src/patchworkConfig.ts
+++ b/src/patchworkConfig.ts
@@ -58,6 +58,8 @@ export interface PatchworkConfig {
   managedSettingsPath?: string;
   recipes?: {
     disabled?: string[];
+    /** IANA timezone name for cron schedules, e.g. "America/New_York". Defaults to "UTC". */
+    timezone?: string;
   };
   /** AI driver mode — persisted so dashboard changes survive restart. */
   driver?: Driver;

--- a/src/recipes/scheduler.ts
+++ b/src/recipes/scheduler.ts
@@ -55,6 +55,12 @@ export interface SchedulerOptions {
    * silently make the scheduler skip a freshly-fixtured recipe.
    */
   disabledRecipes?: ReadonlyArray<string>;
+  /**
+   * IANA timezone for cron expressions, e.g. "America/New_York". Defaults to
+   * `loadConfig().recipes?.timezone ?? "UTC"` at start time. Tests can inject
+   * this to avoid depending on the dev machine's config.
+   */
+  timezone?: string;
 }
 
 export class RecipeScheduler {
@@ -254,9 +260,15 @@ export class RecipeScheduler {
           );
         } else {
           // cron5
-          const cronJob = cron.schedule(parsed2.expression, () => {
-            this.fire(name);
-          });
+          const timezone =
+            this.opts.timezone ?? loadConfig().recipes?.timezone ?? "UTC";
+          const cronJob = cron.schedule(
+            parsed2.expression,
+            () => {
+              this.fire(name);
+            },
+            { timezone },
+          );
           // Store a sentinel timer so the ScheduledRecipe shape stays stable
           const dummyTimer = this.setIntervalFn(() => {}, 2_147_483_647);
           if (typeof dummyTimer === "object" && "unref" in dummyTimer)

--- a/src/recipes/yamlRunner.ts
+++ b/src/recipes/yamlRunner.ts
@@ -349,6 +349,16 @@ export async function evaluateStepExpect(
   }
 
   if (expect.matches !== undefined) {
+    // Guard against ReDoS: limit pattern and input string length before
+    // compiling / executing user-supplied regex.
+    const MAX_PATTERN = 500;
+    const MAX_INPUT = 65_536; // 64 KB
+    if (expect.matches.length > MAX_PATTERN) {
+      failures.push(
+        `matches: regex pattern too long (${expect.matches.length} chars, max ${MAX_PATTERN})`,
+      );
+      return failures;
+    }
     let re: RegExp;
     try {
       re = new RegExp(expect.matches);
@@ -358,7 +368,9 @@ export async function evaluateStepExpect(
       );
       return failures;
     }
-    if (!re.test(asString)) {
+    const testInput =
+      asString.length > MAX_INPUT ? asString.slice(0, MAX_INPUT) : asString;
+    if (!re.test(testInput)) {
       failures.push(
         `matches: ${JSON.stringify(expect.matches)} did not match output`,
       );

--- a/src/ssrfGuard.ts
+++ b/src/ssrfGuard.ts
@@ -78,6 +78,9 @@ export function isPrivateHost(hostname: string): boolean {
   if (host === "::1") return true; // loopback
   if (host.startsWith("fe80:")) return true; // link-local
   if (host.startsWith("fc") || host.startsWith("fd")) return true; // ULA (RFC 4193)
+  if (host.startsWith("2002:")) return true; // 6to4 (RFC 3056) — embeds IPv4 in bits 16-47;
+  // a 6to4 address for a private IPv4 (e.g. 2002:c0a8:0101:: → 192.168.1.1) bypasses
+  // the IPv4 checks above unless we block the entire /16 here.
   if (host.startsWith("::ffff:")) return isPrivateHost(host.slice(7));
   if (host.startsWith("::ffff:0:")) return isPrivateHost(host.slice(9));
 

--- a/src/writeFileAtomic.ts
+++ b/src/writeFileAtomic.ts
@@ -71,7 +71,21 @@ export function writeFileAtomicSync(
     } else {
       fs.writeFileSync(tmp, data, { mode });
     }
-    fs.renameSync(tmp, target);
+    try {
+      fs.renameSync(tmp, target);
+    } catch (renameErr) {
+      // On Windows, renameSync throws EEXIST when the target already exists
+      // (unlike POSIX which atomically replaces). Unlink the target and retry.
+      if (
+        process.platform === "win32" &&
+        (renameErr as NodeJS.ErrnoException).code === "EEXIST"
+      ) {
+        fs.unlinkSync(target);
+        fs.renameSync(tmp, target);
+      } else {
+        throw renameErr;
+      }
+    }
   } catch (err) {
     try {
       fs.unlinkSync(tmp);
@@ -103,7 +117,20 @@ export async function writeFileAtomic(
     } else {
       await fs.promises.writeFile(tmp, data, { mode, signal: opts.signal });
     }
-    await fs.promises.rename(tmp, target);
+    try {
+      await fs.promises.rename(tmp, target);
+    } catch (renameErr) {
+      // Windows: rename throws EEXIST when target exists (unlike POSIX atomic replace).
+      if (
+        process.platform === "win32" &&
+        (renameErr as NodeJS.ErrnoException).code === "EEXIST"
+      ) {
+        await fs.promises.unlink(target);
+        await fs.promises.rename(tmp, target);
+      } else {
+        throw renameErr;
+      }
+    }
   } catch (err) {
     try {
       await fs.promises.unlink(tmp);


### PR DESCRIPTION
## Summary

Second batch from the codebase audit — security and correctness fixes.

### Security

**SSRF guard — 6to4 range missing** (`src/ssrfGuard.ts`)
The `2002::/16` IPv6 prefix (6to4, RFC 3056) was not blocked. A 6to4 address embeds a private IPv4 in bits 16–47 — e.g. `2002:c0a8:0101::` maps to `192.168.1.1` — so an attacker could reach private hosts that the existing IPv4 checks block. Added `host.startsWith("2002:")` to the IPv6 guard block.

**ReDoS in `step.expect.matches`** (`src/recipes/yamlRunner.ts`)
`new RegExp(userPattern)` compiled and executed against arbitrary tool output with no bounds. Added a 500-char cap on the pattern (returns a failure instead of compiling) and a 64 KB cap on the input string tested against it, limiting catastrophic-backtracking exposure without adding a dependency.

### Correctness

**Cron runs in server local time** (`src/recipes/scheduler.ts`, `src/patchworkConfig.ts`)
`cron.schedule(expression, callback)` was called without a `timezone` option. On a non-UTC host all cron recipes fire at the wrong local time. Now reads `recipes.timezone` from `~/.patchwork/config.json`, defaults to `"UTC"`. Added `recipes.timezone?: string` to `PatchworkConfig`.

**Windows atomic rename** (`src/writeFileAtomic.ts`)
`fs.renameSync` / `fs.promises.rename` throw `EEXIST` on Windows when the target file already exists (unlike POSIX, which replaces atomically). Both the sync and async paths now catch `EEXIST` on `win32`, unlink the target, and retry the rename.

**node-cron v3 → v4 disk sync**
`npm ci` was run to align `node_modules` with the lockfile (v3.0.3 on disk vs v4.2.1 in `package-lock.json`). No API changes needed — v4 `schedule()` / `validate()` / `task.stop()` are backward-compatible; timezone option is additive.

## Test plan

- [ ] `npm run build` + `npm test` — 442 files, 6217 tests pass (verified locally)
- [ ] Verify cron recipes fire at correct UTC time on a non-UTC host after deploying
- [ ] Verify `step.expect.matches` with a >500-char pattern returns a descriptive failure (not a hang)
- [ ] Verify SSRF guard rejects `2002:c0a8:0101::` (maps to 192.168.1.1)
- [ ] Windows CI leg covers the EEXIST rename path

🤖 Generated with [Claude Code](https://claude.com/claude-code)