### PR TITLE
fix(dashboard): mobile responsive layout

### DIFF
--- a/dashboard/src/app/globals.css
+++ b/dashboard/src/app/globals.css
@@ -5362,7 +5362,7 @@ a.btn { text-decoration: none; }
 /* -- page header / toolbar -- */
 .traces-heading-em { font-style: italic; }
 .traces-sub { display: flex; align-items: center; gap: var(--s-3); font-size: var(--fs-m); color: var(--ink-2); margin-bottom: var(--s-3); }
-.traces-toolbar { display: flex; align-items: center; gap: var(--s-2); margin-top: var(--s-2); }
+.traces-toolbar { display: flex; align-items: center; gap: var(--s-2); margin-top: var(--s-2); flex-wrap: wrap; }
 .traces-search-input { flex: 1; padding: 6px 10px; border-radius: 6px; border: 1px solid var(--border-subtle); background: var(--bg-0); color: var(--ink-1); font-size: var(--fs-m); outline: none; min-width: 0; }
 .traces-search-input:focus { border-color: var(--orange); }
 
@@ -6775,6 +6775,13 @@ details[open] .traces-detail-arrow { transform: rotate(90deg); }
   gap: 16px;
   align-items: stretch;
   animation: compareIn 220ms ease both;
+  flex-wrap: wrap;
+}
+@media (max-width: 768px) {
+  .compare-columns > * {
+    flex: 1 1 100%;
+    min-width: 0;
+  }
 }
 .compare-legend {
   display: flex;
@@ -6997,3 +7004,32 @@ details[open] .traces-detail-arrow { transform: rotate(90deg); }
 }
 .recipe-relation-strip a { transition: color 120ms, text-decoration-color 120ms; }
 .recipe-relation-strip a:hover { text-decoration-color: currentColor; }
+
+.recipe-hub-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 240px);
+  gap: var(--s-4);
+  align-items: start;
+}
+@media (max-width: 768px) {
+  .recipe-hub-layout {
+    grid-template-columns: 1fr;
+  }
+  .recipe-hub-layout aside {
+    position: static !important;
+  }
+}
+
+@media (max-width: 640px) {
+  .app-content {
+    padding-left: 12px;
+    padding-right: 12px;
+  }
+}
+
+@media (hover: none) and (pointer: coarse) {
+  .runs-halt-pill {
+    min-height: 44px;
+    padding: 8px 12px;
+  }
+}

--- a/dashboard/src/app/recipes/[...name]/page.tsx
+++ b/dashboard/src/app/recipes/[...name]/page.tsx
@@ -592,14 +592,7 @@ function RecipeHubOverviewPage({ name }: { name: string }) {
   ];
 
   return (
-    <div
-      style={{
-        display: "grid",
-        gridTemplateColumns: "minmax(0, 1fr) minmax(0, 240px)",
-        gap: "var(--s-4, 16px)",
-        alignItems: "start",
-      }}
-    >
+    <div className="recipe-hub-layout">
       {/* main column */}
       <div className="recipe-hub-main" style={{ display: "flex", flexDirection: "column", gap: "var(--s-5)", minWidth: 0 }}>
       <RunModal

--- a/dashboard/src/app/tasks/page.tsx
+++ b/dashboard/src/app/tasks/page.tsx
@@ -581,7 +581,7 @@ function TasksContent() {
             onChange={(e) => setSearch(e.target.value)}
             placeholder="Search id, session, driver, output… ( / )"
             className="input"
-            style={{ flex: "1 1 280px", maxWidth: 360, fontSize: "var(--fs-m)" }}
+            style={{ flex: "1 1 min(280px, 100%)", maxWidth: 360, fontSize: "var(--fs-m)" }}
             aria-label="Filter tasks (shortcut: /)"
           />
           <div style={{ display: "flex", gap: 4 }} role="group" aria-label="Status filter">

--- a/dashboard/src/app/traces/page.tsx
+++ b/dashboard/src/app/traces/page.tsx
@@ -614,7 +614,7 @@ export default function TracesPage() {
             ]}
           />
         </div>
-        <div className="traces-toolbar" style={{ display: "flex", alignItems: "center", gap: 8 }}>
+        <div className="traces-toolbar" style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
           <div style={{ position: "relative", display: "flex", alignItems: "center" }}>
             <input
               type="text"


### PR DESCRIPTION
## Summary

- **Recipe hub layout**: moved inline `gridTemplateColumns` style to `.recipe-hub-layout` CSS class; collapses to single column at ≤768px and unsticks the aside on mobile
- **Compare page**: added `flex-wrap: wrap` + `@media (max-width: 768px)` to `.compare-columns` so panels stack vertically on phones
- **Traces toolbar**: added `flex-wrap: wrap` so search input + export button wrap on narrow viewports
- **Tasks search input**: changed `flex: "1 1 280px"` → `flex: "1 1 min(280px, 100%)"` so it doesn't overflow 320px phones
- **App content**: tightened horizontal padding to 12px at ≤640px
- **Touch targets**: raised `.runs-halt-pill` to `min-height: 44px` on touch devices

Already responsive (confirmed by reading existing CSS):
- App shell nav collapse (line 3232)
- Inbox two-pane (`.inbox-twopane`, line 3994)
- Settings grid (line 3183)
- Sessions two-pane (line 1950)
- Tasks layout (line 1927)
- Traces card overflow (line 5386)
- Recipe form grid (correctly 2-col at ≥900px)

## Test plan
- [ ] Open dashboard on a 390px-wide viewport (Chrome DevTools mobile preset)
- [ ] Recipe hub page: sidebar should stack below main content
- [ ] Recipe compare page: panels should stack vertically
- [ ] Traces page: toolbar wraps instead of clips
- [ ] Tasks page: search input doesn't overflow on 320px
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)