### PR TITLE
feat(dashboard): recipe flow editor SVG components + design overhaul spec

### DIFF
--- a/dashboard/src/app/recipes/[...name]/_edit/page.tsx
+++ b/dashboard/src/app/recipes/[...name]/_edit/page.tsx
@@ -129,16 +129,34 @@ export default function RecipeEditPage({ name }: { name: string }) {
         }
       }
 
+      // Flatten a single raw step (or parallel: wrapper) into FlowSvgStep[].
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      return (rawSteps as any[]).map((s: any, idx: number): FlowSvgStep => {
+      function mapStep(s: any, idx: number, idPrefix = ""): FlowSvgStep[] {
+        // W2 — Handle parallel: wrapper — flatten inner steps as top-level nodes
+        // so they appear in the DAG. Each inner step gets a generated ID prefixed
+        // with the wrapper index to avoid collisions.
+        if (s && typeof s === "object" && Array.isArray(s.parallel?.steps)) {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          return (s.parallel.steps as any[]).flatMap((inner: any, innerIdx: number) => {
+            const innerIdSuffix =
+              typeof inner?.id === "string"
+                ? inner.id
+                : typeof inner?.tool === "string"
+                  ? inner.tool
+                  : String(innerIdx);
+            return mapStep(inner, innerIdx, `${idx}_${innerIdSuffix}_`);
+          });
+        }
+
         const id =
-          typeof s?.id === "string"
+          idPrefix +
+          (typeof s?.id === "string"
             ? s.id
             : typeof s?.tool === "string"
               ? s.tool
               : typeof s?.into === "string"
                 ? s.into
-                : `step_${idx + 1}`;
+                : `step_${idx + 1}`);
 
         // Determine type
         const type: FlowSvgStep["type"] =
@@ -148,28 +166,64 @@ export default function RecipeEditPage({ name }: { name: string }) {
               ? "agent"
               : "tool";
 
-        // Resolve implicit deps from {{}} refs in the entire step body,
+        // Pass 1 — resolve implicit deps from {{}} template refs in the step body,
         // mapped through the intoToId table. Exclude self-references.
         const refs = new Set<string>();
         collectRefs(s, refs);
-        const dependencies = Array.from(refs)
+        const implicitDeps = Array.from(refs)
           .map((r) => intoToId.get(r))
           .filter((depId): depId is string => depId !== undefined && depId !== id);
 
-        return {
-          id,
-          type,
-          tool: typeof s?.tool === "string" ? s.tool : undefined,
-          namespace: typeof s?.namespace === "string" ? s.namespace : undefined,
-          prompt: s?.agent?.prompt ?? (typeof s?.prompt === "string" ? s.prompt : undefined),
-          recipe: typeof s?.recipe === "string" ? s.recipe : undefined,
-          dependencies: dependencies.length > 0 ? dependencies : undefined,
-        };
-      });
+        // Pass 2 (W1) — honour explicit `dependencies:` arrays. These carry step
+        // IDs directly; no intoToId lookup needed.
+        const explicitDeps: string[] = [];
+        if (Array.isArray(s?.dependencies)) {
+          for (const dep of s.dependencies as unknown[]) {
+            if (typeof dep === "string" && dep !== id) {
+              explicitDeps.push(dep);
+            }
+          }
+        }
+
+        // Merge and dedup — implicit first (preserves existing behaviour),
+        // then any explicit IDs not already covered.
+        const seen = new Set<string>(implicitDeps);
+        const dependencies: string[] = [...implicitDeps];
+        for (const dep of explicitDeps) {
+          if (!seen.has(dep)) {
+            seen.add(dep);
+            dependencies.push(dep);
+          }
+        }
+
+        return [
+          {
+            id,
+            type,
+            tool: typeof s?.tool === "string" ? s.tool : undefined,
+            namespace: typeof s?.namespace === "string" ? s.namespace : undefined,
+            prompt: s?.agent?.prompt ?? (typeof s?.prompt === "string" ? s.prompt : undefined),
+            recipe: typeof s?.recipe === "string" ? s.recipe : undefined,
+            dependencies: dependencies.length > 0 ? dependencies : undefined,
+          },
+        ];
+      }
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return (rawSteps as any[]).flatMap((s: any, idx: number) => mapStep(s, idx));
     } catch {
       return [];
     }
   }, [content]);
+
+  // W3 — Prefetch the YamlEditor dynamic-import chunk whenever flow mode is
+  // active. This ensures the chunk is already loaded before onStepClick calls
+  // switchEditMode("yaml"), eliminating the loading state flash on transition.
+  useEffect(() => {
+    if (editMode === "flow") {
+      void import("./_components/YamlEditor");
+    }
+  }, [editMode]);
 
   // Connector preflight surfaced on the edit page (Phase 1A item 5,
   // upgraded by Phase 1A.1).


### PR DESCRIPTION
## Summary

- **`FlowSvg.tsx`** — Read-only SVG-based visual flow diagram component for the recipe editor. Renders step nodes with status-aware `color-mix()` fills (ok/error/running/pending/halted/skipped), connector arrows between dependent steps, and step-type labels (tool/agent/recipe). Clickable nodes via `onStepClick` callback.
- **`flowLayout.ts`** — Pure layout engine backing `FlowSvg`. `computeFlowLayout()` performs topological rank assignment (Kahn's algorithm), grid-positions nodes within ranks, and computes total canvas dimensions. Exports `NODE_W`/`NODE_H` constants so the SVG component and any future consumers stay in sync.
- **`docs/design-overhaul.md`** — UI/UX overhaul design specification for the current dashboard polish sprint. Defines token primitives (`--accent-cool`, `color-mix()` status composition), five highest-leverage implementation targets in dependency order, and cross-wave findings from the design audit (flat recipe table, home page tightening, marketplace simplification, motion policy, single-accent focus).

## Implementation notes

- `FlowSvg` is ~250 LOC, read-only — no node-canvas dependency. Mounts in the recipe plan and run pages.
- `computeFlowLayout` handles cycles/orphans gracefully; out-of-graph dependency refs are filtered before rank computation.
- Design spec establishes `--accent-cool: #0787ff` as the secondary accent (running state, focused indicators, sparkline strokes) alongside the existing orange. Rejects framer-motion; uses existing CSS keyframes.

## Test plan

- [ ] Render `<FlowSvg>` with a multi-step recipe (with dependencies) and verify nodes appear in correct rank columns
- [ ] Verify status fills apply correctly for each `StepStatus` variant
- [ ] Verify `onStepClick` fires with the correct step id
- [ ] Verify `computeFlowLayout` returns correct `width`/`height` for 0-step, 1-step, and multi-step inputs
- [ ] Review `docs/design-overhaul.md` for accuracy against current dashboard state

🤖 Generated with [Claude Code](https://claude.com/claude-code)