### PR TITLE
feat(connectors): complete catalog — Monday, Salesforce, Shopify, Snowflake + driver + docs fixes

### DIFF
--- a/dashboard/src/app/connections/page.tsx
+++ b/dashboard/src/app/connections/page.tsx
@@ -620,7 +620,7 @@ const TOKEN_MODAL_CONNECTORS: Record<string, TokenModalConfig> = {
     instructions: (
       <>
         Create a Custom App in your Shopify admin under{" "}
-        <a href="https://admin.shopify.com/settings/apps/development" target="_blank" rel="noreferrer" className="conn-modal-link">
+        <a href="https://admin.shopify.com/settings/apps/development" target="_blank" rel="noreferrer" style={{ color: "var(--info)" }}>
           Settings → Apps and sales channels → Develop apps
         </a>
         . Grant <code>read_products</code>, <code>read_orders</code>, and
@@ -640,7 +640,7 @@ const TOKEN_MODAL_CONNECTORS: Record<string, TokenModalConfig> = {
     instructions: (
       <>
         Create a Personal Access Token in{" "}
-        <a href="https://docs.snowflake.com/en/user-guide/programmatic-access-tokens" target="_blank" rel="noreferrer" className="conn-modal-link">
+        <a href="https://docs.snowflake.com/en/user-guide/programmatic-access-tokens" target="_blank" rel="noreferrer" style={{ color: "var(--info)" }}>
           Snowflake → User → Personal access tokens
         </a>
         . Read-only role recommended — only SELECT/SHOW/DESC/EXPLAIN

--- a/src/connectorRoutes.ts
+++ b/src/connectorRoutes.ts
@@ -2228,7 +2228,7 @@ export function tryHandleConnectorRoute(
         const { handleShopifyDisconnect } = await import(
           "./connectors/shopify.js"
         );
-        const result = handleShopifyDisconnect();
+        const result = await handleShopifyDisconnect();
         res.writeHead(result.status, {
           "Content-Type": result.contentType ?? "application/json",
         });

--- a/src/connectors/__tests__/shopify.test.ts
+++ b/src/connectors/__tests__/shopify.test.ts
@@ -500,7 +500,7 @@ describe("handleShopifyDisconnect", () => {
   it("returns 200 always", async () => {
     vi.resetModules();
     const { handleShopifyDisconnect } = await import("../shopify.js");
-    const result = handleShopifyDisconnect();
+    const result = await handleShopifyDisconnect();
     expect(result.status).toBe(200);
     expect(JSON.parse(result.body).ok).toBe(true);
   });

--- a/src/connectors/__tests__/shopify.test.ts
+++ b/src/connectors/__tests__/shopify.test.ts
@@ -18,7 +18,6 @@ describe("shopify token helpers", () => {
   });
 
   afterEach(() => {
-    vi.restoreAllMocks();
     delete process.env.HOME;
     delete process.env.PATCHWORK_HOME;
     delete process.env.PATCHWORK_TOKEN_STORAGE_BACKEND;

--- a/src/connectors/shopify.ts
+++ b/src/connectors/shopify.ts
@@ -631,7 +631,7 @@ export async function handleShopifyTest(): Promise<ConnectorHandlerResult> {
 /**
  * DELETE /connections/shopify
  */
-export function handleShopifyDisconnect(): ConnectorHandlerResult {
+export async function handleShopifyDisconnect(): Promise<ConnectorHandlerResult> {
   clearTokens();
   resetShopifyConnector();
   return {


### PR DESCRIPTION
## Summary

- **feat(connectors):** Ships the final four connectors (Monday, Salesforce, Shopify, Snowflake) to complete the full connector catalog. All four were previously blocked on vendor OAuth-app registration; code is now aligned with the six call-site pattern established in Waves 1a/1b (#778, #779, #780): registry, routes, gmail.ts loader-map, dashboard SUPPORTED set, modal config, and registry.test.ts snapshot.
- **fix(drivers):** Re-applies the `CLAUDE_CODE_OAUTH_TOKEN` env-var preservation patch in the env sanitizer — the fix was inadvertently dropped during a prior rebase. Without this, OAuth-token users hitting the subprocess driver receive 401s from the Console endpoint rather than the expected auth flow.
- **docs(recipes):** Captures template-resolution gotchas discovered in production debugging: top-level `vars:` is silently dropped (must nest under `trigger`), `driver: claude` routes to the API path (needs `ANTHROPIC_API_KEY`), and `claude -p` MCP must use the stdio shim form.

## Test plan

- [ ] Connector registry snapshot in `registry.test.ts` passes with all four new entries
- [ ] OAuth flows for Monday, Salesforce, Shopify, Snowflake complete without redirect-URI errors
- [ ] Dashboard `/connections` modal shows all four new connectors with correct icons and config fields
- [ ] Subprocess driver subprocess spawned with `CLAUDE_CODE_OAUTH_TOKEN` present in env (regression check)
- [ ] Recipe using `trigger.vars` resolves correctly; top-level `vars:` emits validator warning
- [ ] `npm test` green; `npm run typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)