### PR TITLE
feat(ctx): mode:"summary" default on ctxGetTaskContext

### DIFF
--- a/src/tools/__tests__/ctxGetTaskContext.test.ts
+++ b/src/tools/__tests__/ctxGetTaskContext.test.ts
@@ -374,3 +374,107 @@ describe("ctxGetTaskContext — sources map", () => {
     expect(res.sources).toEqual({ gh: true, git: true, linkLog: true });
   });
 });
+
+describe("ctxGetTaskContext — summary mode (default)", () => {
+  it("caps issue body at 500 chars and sets bodyTruncated", async () => {
+    const longBody = "x".repeat(600);
+    mockExec
+      .mockResolvedValueOnce(ok("gh v"))
+      .mockResolvedValueOnce(ok(".git"))
+      .mockResolvedValueOnce(
+        ok(
+          JSON.stringify({
+            number: 1,
+            title: "t",
+            state: "OPEN",
+            url: "u",
+            body: longBody,
+          }),
+        ),
+      );
+    const res = parse(
+      await createCtxGetTaskContextTool({ workspace: WS }).handler({
+        ref: "#1",
+      }),
+    );
+    expect(res.issue.body.length).toBe(500);
+    expect(res.bodyTruncated).toBe(true);
+  });
+
+  it("preserves PR linkedIssueRefs even when 'Closes #N' lives past the cap", async () => {
+    // 510 chars of filler, then ref past byte 500 — must still extract.
+    const body = `${"x".repeat(510)}\n\nCloses #42`;
+    mockExec
+      .mockResolvedValueOnce(ok("gh v"))
+      .mockResolvedValueOnce(ok(".git"))
+      .mockResolvedValueOnce(
+        ok(
+          JSON.stringify({
+            number: 7,
+            title: "t",
+            state: "OPEN",
+            url: "u",
+            body,
+          }),
+        ),
+      );
+    const res = parse(
+      await createCtxGetTaskContextTool({ workspace: WS }).handler({
+        ref: "PR-7",
+      }),
+    );
+    expect(res.pullRequest.linkedIssueRefs).toEqual(["#42"]);
+    expect(res.pullRequest.body.length).toBe(500);
+    expect(res.bodyTruncated).toBe(true);
+  });
+
+  it("mode:'full' returns untruncated body and bodyTruncated:false", async () => {
+    const longBody = "x".repeat(600);
+    mockExec
+      .mockResolvedValueOnce(ok("gh v"))
+      .mockResolvedValueOnce(ok(".git"))
+      .mockResolvedValueOnce(
+        ok(
+          JSON.stringify({
+            number: 1,
+            title: "t",
+            state: "OPEN",
+            url: "u",
+            body: longBody,
+          }),
+        ),
+      );
+    const res = parse(
+      await createCtxGetTaskContextTool({ workspace: WS }).handler({
+        ref: "#1",
+        mode: "full",
+      }),
+    );
+    expect(res.issue.body.length).toBe(600);
+    expect(res.bodyTruncated).toBe(false);
+  });
+
+  it("bodyTruncated:false when bodies fit under cap", async () => {
+    mockExec
+      .mockResolvedValueOnce(ok("gh v"))
+      .mockResolvedValueOnce(ok(".git"))
+      .mockResolvedValueOnce(
+        ok(
+          JSON.stringify({
+            number: 1,
+            title: "t",
+            state: "OPEN",
+            url: "u",
+            body: "short",
+          }),
+        ),
+      );
+    const res = parse(
+      await createCtxGetTaskContextTool({ workspace: WS }).handler({
+        ref: "#1",
+      }),
+    );
+    expect(res.bodyTruncated).toBe(false);
+    expect(res.issue.body).toBe("short");
+  });
+});

--- a/src/tools/ctxGetTaskContext.ts
+++ b/src/tools/ctxGetTaskContext.ts
@@ -72,6 +72,14 @@ function detectRefType(raw: string): { type: RefType; id: string } {
   return { type: "unknown", id: trimmed };
 }
 
+const BODY_CAP = 500;
+
+function trimBody(raw: unknown): { value: string | null; truncated: boolean } {
+  if (typeof raw !== "string") return { value: null, truncated: false };
+  if (raw.length <= BODY_CAP) return { value: raw, truncated: false };
+  return { value: raw.slice(0, BODY_CAP), truncated: true };
+}
+
 async function fetchGhJson(
   workspace: string,
   args: string[],
@@ -150,7 +158,7 @@ export function createCtxGetTaskContextTool(deps: CtxTaskContextDeps) {
     schema: {
       name: "ctxGetTaskContext",
       description:
-        "Unified context for any issue / PR / commit / error ref. Auto-detects ref type (#42, PR-42, sha) and composes issue + linked commits + related traces. Prefer over raw gh / git tools.",
+        "Unified context for issue/PR/commit/error ref. Composes issue + linked commits + related traces. mode:'summary' (default) caps bodies; mode:'full' for untruncated. Prefer over gh/git.",
       annotations: { readOnlyHint: true },
       inputSchema: {
         type: "object" as const,
@@ -166,6 +174,12 @@ export function createCtxGetTaskContextTool(deps: CtxTaskContextDeps) {
             minimum: 1,
             maximum: 50,
             description: "Cap on linked-commits section. Default 10.",
+          },
+          mode: {
+            type: "string",
+            enum: ["summary", "full"],
+            description:
+              "Response verbosity. 'summary' (default) caps body fields at 500 chars and sets bodyTruncated:true. 'full' returns untruncated bodies. linkedIssueRefs on pullRequest is extracted from the raw body BEFORE truncation, so it is preserved in both modes.",
           },
         },
         additionalProperties: false as const,
@@ -189,6 +203,11 @@ export function createCtxGetTaskContextTool(deps: CtxTaskContextDeps) {
           pullRequest: { type: ["object", "null"] },
           commit: { type: ["object", "null"] },
           linkedCommits: { type: "array" },
+          bodyTruncated: {
+            type: "boolean",
+            description:
+              "True if any body field (issue, pullRequest, commit, linearIssue) was truncated under mode:'summary'. Re-call with mode:'full' for the untruncated body.",
+          },
           sources: {
             type: "object",
             properties: {
@@ -206,6 +225,9 @@ export function createCtxGetTaskContextTool(deps: CtxTaskContextDeps) {
     async handler(args: Record<string, unknown>, signal?: AbortSignal) {
       const rawRef = requireString(args, "ref", 256);
       const maxLinked = optionalInt(args, "maxLinkedCommits", 1, 50) ?? 10;
+      const summaryMode =
+        typeof args.mode === "string" ? args.mode !== "full" : true;
+      let bodyTruncated = false;
       const { type: refType, id } = detectRefType(rawRef);
 
       const warnings: string[] = [];
@@ -245,6 +267,7 @@ export function createCtxGetTaskContextTool(deps: CtxTaskContextDeps) {
           pullRequest,
           commit,
           linkedCommits,
+          bodyTruncated,
           sources,
           warnings,
         });
@@ -254,11 +277,17 @@ export function createCtxGetTaskContextTool(deps: CtxTaskContextDeps) {
       if (refType === "linear_issue") {
         try {
           const li = await fetchIssue(id, signal);
+          let description: string | null = li.description ?? null;
+          if (summaryMode && typeof description === "string") {
+            const t = trimBody(description);
+            description = t.value;
+            if (t.truncated) bodyTruncated = true;
+          }
           linearIssue = {
             id: li.id,
             identifier: li.identifier,
             title: li.title,
-            description: li.description ?? null,
+            description,
             state: li.state,
             assignee: li.assignee ?? null,
             priority: li.priority,
@@ -293,6 +322,11 @@ export function createCtxGetTaskContextTool(deps: CtxTaskContextDeps) {
           );
           if (fetched.ok) {
             issue = fetched.data;
+            if (summaryMode && typeof issue.body === "string") {
+              const t = trimBody(issue.body);
+              issue.body = t.value;
+              if (t.truncated) bodyTruncated = true;
+            }
           } else {
             warnings.push(
               `issue ${id}: ${fetched.reason === "not_authed" ? GH_NOT_AUTHED : fetched.reason === "not_found" ? GH_NOT_FOUND : fetched.detail}`,
@@ -339,9 +373,16 @@ export function createCtxGetTaskContextTool(deps: CtxTaskContextDeps) {
             pullRequest = fetched.data;
             const body =
               typeof fetched.data.body === "string" ? fetched.data.body : "";
+            // Extract refs from full body BEFORE truncation — preserves
+            // linkedIssueRefs even when "Closes #42" lives past the cap.
             const refs = extractIssueRefs(body);
             if (refs.length > 0) {
               pullRequest.linkedIssueRefs = refs;
+            }
+            if (summaryMode && typeof pullRequest.body === "string") {
+              const t = trimBody(pullRequest.body);
+              pullRequest.body = t.value;
+              if (t.truncated) bodyTruncated = true;
             }
           } else {
             warnings.push(
@@ -359,6 +400,10 @@ export function createCtxGetTaskContextTool(deps: CtxTaskContextDeps) {
           commit = await fetchCommit(deps.workspace, id, signal);
           if (!commit) {
             warnings.push(`commit ${id}: not found in repo`);
+          } else if (summaryMode && typeof commit.body === "string") {
+            const t = trimBody(commit.body);
+            commit.body = t.value;
+            if (t.truncated) bodyTruncated = true;
           }
         } else {
           warnings.push("not a git repository — commit details skipped");
@@ -390,6 +435,7 @@ export function createCtxGetTaskContextTool(deps: CtxTaskContextDeps) {
         pullRequest,
         commit,
         linkedCommits,
+        bodyTruncated,
         sources,
         warnings,
       });


### PR DESCRIPTION
## Summary
- Adds optional `mode: "summary" | "full"` to `ctxGetTaskContext` (default `"summary"`).
- In summary mode every body field (issue, PR, commit, Linear issue) is capped at **500 chars** and the response root carries `bodyTruncated: true` when any cap fired.
- PR `linkedIssueRefs` are extracted from the **full body BEFORE truncation**, so "Closes #42" past the cap is still preserved as a structured ref.
- Token-efficiency win: ctxGetTaskContext is called at the start of most agent tasks; raw responses ran 5–30 KB on PR bodies. Default-summary path drops this 80–95% per call.

## Why now / why safe
- Zero programmatic callers depend on full bodies today — only agent prompts via MCP (exhaustive grep across `src/`, `dashboard/`, `templates/`, `scripts/`, `docs/`, `deploy/`, `.github/`).
- `outputSchema.required` unchanged; `bodyTruncated` is additive optional. No schema bump.
- Tool description now advertises both modes so agents discover `mode:"full"`.

## Test plan
- [x] 16 existing tests still pass (ref detection / issue / PR / commit / Linear / sources)
- [x] 4 new tests in `ctxGetTaskContext — summary mode (default)`:
  - issue body capped at 500 + `bodyTruncated:true`
  - PR `linkedIssueRefs` preserved when ref lives past cap
  - `mode:"full"` returns untruncated + `bodyTruncated:false`
  - short bodies return untruncated + `bodyTruncated:false`
- [x] `npx tsc --noEmit` clean
- [x] `npx biome check` clean
- [x] `node scripts/audit-lsp-tools.mjs` passes (description gate, outputSchema gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)