### PR TITLE
feat(tools): trim aggregator prose in bridgeStatus + getToolCapabilities

### DIFF
--- a/src/tools/bridgeStatus.ts
+++ b/src/tools/bridgeStatus.ts
@@ -121,7 +121,6 @@ export function createBridgeStatusTool(
           tier: { type: "string", enum: ["full", "basic"] },
           tierDescription: { type: "string" },
           hint: { type: "string" },
-          suggestedActions: { type: "array", items: { type: "string" } },
           lastDisconnect: {
             type: "object",
             properties: {
@@ -167,25 +166,6 @@ export function createBridgeStatusTool(
               : ("poor" as const);
 
       const automationStatus = automationHooks?.getStatus() ?? null;
-      const unwired = automationStatus?.unwiredEnabledHooks ?? [];
-
-      const baseSuggestedActions = extensionConnected
-        ? [
-            "Use explainSymbol to understand any function in one call",
-            "Use refactorPreview to see what a refactoring would change before applying",
-            "Use setEditorDecorations to highlight code review findings inline",
-          ]
-        : [
-            "Connect the VS Code extension for LSP, debugger, and terminal tools",
-            "File operations, Git, GitHub, and CLI tools are available without the extension",
-          ];
-
-      if (unwired.length > 0) {
-        baseSuggestedActions.push(
-          `Automation hooks enabled but not wired in settings.json: ${unwired.join(", ")}. ` +
-            `Add CC hook entries calling the bridge notify tools (see CLAUDE.md Automation Policy section).`,
-        );
-      }
 
       // Compute tool availability: answers "why can't Claude call X?" without
       // requiring the caller to try the tool first and parse the error.
@@ -268,14 +248,11 @@ export function createBridgeStatusTool(
         }),
         tier: extensionConnected ? "full" : "basic",
         tierDescription: extensionConnected
-          ? "All tools available including LSP, debugger, and terminal integration"
-          : "File operations, Git, GitHub, and CLI tools available. Connect the VS Code extension for LSP, debugger, and terminal tools.",
-        suggestedActions: baseSuggestedActions,
+          ? "All tools available (LSP, debugger, terminal)"
+          : "Basic tools available. Connect the VS Code extension for LSP/debugger/terminal.",
         hint: extensionConnected
           ? "All tools available."
-          : "Extension disconnected — extension-dependent tools (LSP, terminal, debugging, etc.) are temporarily unavailable. " +
-            "Native tools (file search, git, GitHub) still work. " +
-            "The extension will auto-reconnect, or the user can run the 'Claude IDE Bridge: Reconnect' command.",
+          : "Extension disconnected — LSP/terminal/debugger unavailable. Will auto-reconnect.",
         ...(getDisconnectInfo && {
           lastDisconnect: getDisconnectInfo(),
         }),

--- a/src/tools/getToolCapabilities.ts
+++ b/src/tools/getToolCapabilities.ts
@@ -54,8 +54,8 @@ export function createGetToolCapabilitiesTool(
         extensionConnected: extensionClient.isConnected(),
         tier: extensionClient.isConnected() ? "full" : "basic",
         tierDescription: extensionClient.isConnected()
-          ? "All tools available including LSP, debugger, and terminal integration"
-          : "File operations, Git, GitHub, and CLI tools available. Connect the VS Code extension for LSP, debugger, and terminal tools.",
+          ? "All tools available (LSP, debugger, terminal)"
+          : "Basic tools available. Connect the VS Code extension for LSP/debugger/terminal.",
         editor: config.editorCommand ?? "none",
         cliTools: {
           rg: probes.rg,


### PR DESCRIPTION
## Summary
- Drop \`suggestedActions\` array from \`getBridgeStatus\` response (3 onboarding strings, not asserted by any caller).
- Shorten \`tierDescription\` + disconnected \`hint\` in \`getBridgeStatus\` while preserving the substrings tests assert on (\`"All tools available"\`, \`"Connect the VS Code extension"\`, \`"auto-reconnect"\`).
- Shorten \`tierDescription\` in \`getToolCapabilities\` the same way.
- Structured fields (\`automation.unwiredEnabledHooks\`, \`toolAvailability\`, \`features\`, \`availableTools\`) keep the actionable signal — agents still learn what's unwired or missing, just without the prose paragraph.

## Why
\`getBridgeStatus\` is often the first tool called when an agent attaches to the bridge, and \`getToolCapabilities\` runs alongside it. Their responses carried ~600 B of human-targeted prose every call, repeated for every session.

## Test plan
- [x] 20 \`bridgeStatus\` tests still pass (substring assertions on \`hint\`/\`tierDescription\` preserved)
- [x] 21 \`getToolCapabilities\` tests still pass (drift-guard for \`availableTools.lsp ↔ SLIM_TOOL_NAMES\` intact)
- [x] \`npx tsc --noEmit\` clean
- [x] \`npx biome check\` clean
- [x] \`node scripts/audit-lsp-tools.mjs\` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)