### PR TITLE
fix(recipes): connectorPreflight namespace match — accept dot-form tool IDs

### DIFF
--- a/src/recipes/__tests__/connectorPreflight.test.ts
+++ b/src/recipes/__tests__/connectorPreflight.test.ts
@@ -93,6 +93,39 @@ describe("detectRequiredConnectors", () => {
     ).toEqual([]);
   });
 
+  // Regression: every connector tool registered today uses dot-form IDs
+  // (`slack.post_message`, `gmail.fetch_unread`, ...). The pre-fix prefix
+  // map keyed by `slack_` etc. and used `tool.startsWith(prefix)` →
+  // never matched dot-form → every YAML recipe install reported
+  // "no connectors needed" regardless of what the recipe actually used.
+  it("detects connectors from canonical dot-form tool IDs (registry shape)", () => {
+    expect(
+      detectRequiredConnectors(
+        recipe([
+          { id: "s1", agent: false, tool: "slack.post_message", params: {} },
+          { id: "s2", agent: false, tool: "gmail.fetch_unread", params: {} },
+          { id: "s3", agent: false, tool: "linear.list_issues", params: {} },
+          { id: "s4", agent: false, tool: "github.list_prs", params: {} },
+        ] as Recipe["steps"]),
+      ),
+    ).toEqual(["github", "gmail", "linear", "slack"]);
+  });
+
+  it("detects connectors from dot-form in agent tools[] arrays", () => {
+    expect(
+      detectRequiredConnectors(
+        recipe([
+          {
+            id: "s1",
+            agent: true,
+            prompt: "compose",
+            tools: ["hubspot.listContacts", "calendar.list_events"],
+          },
+        ] as Recipe["steps"]),
+      ),
+    ).toEqual(["google-calendar", "hubspot"]);
+  });
+
   it("matches every entry in the public prefix map", () => {
     // Sanity: every prefix in the map should match a tool we synthesize
     // from it. Guards against typos that would silently break the map.

--- a/src/recipes/connectorPreflight.ts
+++ b/src/recipes/connectorPreflight.ts
@@ -23,33 +23,65 @@
 import type { Recipe, Step } from "./schema.js";
 
 /**
- * Tool-name prefix → connector id (matching the IDs returned by
+ * Tool-namespace → connector id (matching the IDs returned by
  * `/connections` — see src/connectors/gmail.ts handleConnectionsList).
  * Both `google-calendar` and the dashboard's `googleCalendar` spelling
  * are accepted on the caller side; this map is authoritative for the
  * bridge.
+ *
+ * Keys are BARE namespace names (no separator). The matcher accepts BOTH
+ * dot-form (`slack.post_message`) and underscore-form (`slack_post_message`)
+ * tool IDs. Real registry tools use dot-form
+ * (e.g. `src/recipes/tools/slack.ts` registers `slack.post_message`); the
+ * previous map keyed by `slack_` etc. silently failed every YAML recipe
+ * install because `tool.startsWith("slack_")` never matched `slack.post_message`.
  */
-export const TOOL_PREFIX_TO_CONNECTOR: Record<string, string> = {
-  slack_: "slack",
-  github_: "github",
-  jira_: "jira",
-  linear_: "linear",
-  gmail_: "gmail",
-  calendar_: "google-calendar",
-  drive_: "google-drive",
-  intercom_: "intercom",
-  hubspot_: "hubspot",
-  datadog_: "datadog",
-  stripe_: "stripe",
-  sentry_: "sentry",
-  zendesk_: "zendesk",
-  asana_: "asana",
-  notion_: "notion",
-  confluence_: "confluence",
-  discord_: "discord",
-  gitlab_: "gitlab",
-  pagerduty_: "pagerduty",
+export const TOOL_NAMESPACE_TO_CONNECTOR: Record<string, string> = {
+  slack: "slack",
+  github: "github",
+  jira: "jira",
+  linear: "linear",
+  gmail: "gmail",
+  calendar: "google-calendar",
+  drive: "google-drive",
+  intercom: "intercom",
+  hubspot: "hubspot",
+  datadog: "datadog",
+  stripe: "stripe",
+  sentry: "sentry",
+  zendesk: "zendesk",
+  asana: "asana",
+  notion: "notion",
+  confluence: "confluence",
+  discord: "discord",
+  gitlab: "gitlab",
+  pagerduty: "pagerduty",
 };
+
+/**
+ * @deprecated Use `TOOL_NAMESPACE_TO_CONNECTOR` instead. Kept as a thin
+ * alias derived from the canonical map so legacy callers (and the
+ * underscore-suffix tool-name shape) keep working until they migrate.
+ */
+export const TOOL_PREFIX_TO_CONNECTOR: Record<string, string> =
+  Object.fromEntries(
+    Object.entries(TOOL_NAMESPACE_TO_CONNECTOR).map(([ns, connector]) => [
+      `${ns}_`,
+      connector,
+    ]),
+  );
+
+/**
+ * Extract the namespace prefix from a registered tool ID. Tool IDs land
+ * in either `namespace.tool_name` (the canonical dot-form used by every
+ * registry entry today — see `src/recipes/tools/*.ts`) or the older
+ * `namespace_tool_name` underscore-form some tests use. Either form
+ * resolves to the bare namespace, lowercased.
+ */
+function extractNamespace(toolId: string): string | undefined {
+  const m = toolId.match(/^([a-z][a-z0-9-]*)[_.]/i);
+  return m?.[1]?.toLowerCase();
+}
 
 function toolsOfStep(step: Step): string[] {
   // agent: false steps carry a single `tool` field. agent: true steps
@@ -73,13 +105,8 @@ function toolsOfStep(step: Step): string[] {
 const PROMPT_PREFIX_PATTERNS: ReadonlyArray<{
   prefix: string;
   connector: string;
-}> = Object.entries(TOOL_PREFIX_TO_CONNECTOR).map(([prefix, connector]) => ({
-  // Strip trailing underscore — when the prompt mentions a tool name like
-  // `slack_post_message` the underscore is part of the literal we look
-  // for, but when an agent prompt is more conversational ("post to slack
-  // using slack.post_message"), we want to match the prefix without the
-  // separator too.
-  prefix: prefix.replace(/_$/, ""),
+}> = Object.entries(TOOL_NAMESPACE_TO_CONNECTOR).map(([prefix, connector]) => ({
+  prefix,
   connector,
 }));
 
@@ -131,13 +158,14 @@ export function detectRequiredConnectors(recipe: Recipe): string[] {
   const required = new Set<string>();
   for (const step of recipe.steps) {
     // Explicit `tool` / `tools[]` fields (canonical detection path).
+    // Pull the namespace out of the tool ID — works for both dot-form
+    // (the registry's canonical `slack.post_message`) and the legacy
+    // underscore-form some tests use (`slack_post_message`).
     for (const tool of toolsOfStep(step)) {
-      for (const [prefix, connector] of Object.entries(
-        TOOL_PREFIX_TO_CONNECTOR,
-      )) {
-        if (tool.startsWith(prefix)) {
-          required.add(connector);
-        }
+      const ns = extractNamespace(tool);
+      if (ns) {
+        const connector = TOOL_NAMESPACE_TO_CONNECTOR[ns];
+        if (connector) required.add(connector);
       }
     }
     // Prompt body scan for agent-mode steps — catches recipes that


### PR DESCRIPTION
## Summary
\`detectRequiredConnectors\` keyed off \`TOOL_PREFIX_TO_CONNECTOR\` with underscore-suffix keys (\`slack_\`, \`gmail_\`, …) and tested via \`tool.startsWith(prefix)\`. Every connector tool registered today uses **dot-form** IDs (\`slack.post_message\`, \`gmail.fetch_unread\`, …) → \`startsWith(\"slack_\")\` never matched \`slack.post_message\` → canonical detection returned \`[]\` for every YAML recipe install.

The \`/recipes/install\` + \`/recipes/install/bundle\` routes wire the result into \`missingConnectors\` (non-blocking warning). **Symptom**: install panel claimed \"no connectors needed\" regardless of what the recipe actually called — first run discovered missing auth at runtime.

## Why the bug was hidden
Existing unit tests synthesized fictional underscore-form tool IDs (\`slack_chat\`) that DID match the broken prefix map. Production never sees those IDs — they're test-only.

## Fix
- Restructure map keys to bare namespaces (no separator): \`TOOL_NAMESPACE_TO_CONNECTOR\`
- Add \`extractNamespace(toolId)\` that pulls the first \`[a-z][a-z0-9-]*\` segment from either dot-form OR underscore-form IDs
- Keep \`TOOL_PREFIX_TO_CONNECTOR\` as a derived deprecated alias so the single external test consumer keeps working without churn

## Test plan
- [x] 19/19 connectorPreflight tests pass (2 new regression tests for real-world dot-form IDs)
- [x] **New regression**: \`detectRequiredConnectors\` correctly identifies \`slack.post_message\`, \`gmail.fetch_unread\`, \`linear.list_issues\`, \`github.list_prs\` as needing the right connectors
- [x] **New regression**: dot-form in \`tools[]\` arrays (\`hubspot.listContacts\`, \`calendar.list_events\`) resolves correctly
- [x] All existing underscore-form tests still green via the same namespace extractor
- [x] \`npx tsc --noEmit\` clean
- [x] \`npx biome check\` clean
- [x] \`node scripts/audit-lsp-tools.mjs\` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)