### PR TITLE
security(transport): defer global rate-limit slot past AJV (H2)

### DIFF
--- a/src/__tests__/transport.test.ts
+++ b/src/__tests__/transport.test.ts
@@ -520,6 +520,64 @@ describe("McpTransport", () => {
     expect(err.message).toMatch(/rate limit/i);
   });
 
+  it("malformed tools/call payloads (AJV fail) do NOT consume the per-session rate-limit window", async () => {
+    // Audit finding H2: the per-session ring buffer used to record the
+    // request timestamp BEFORE AJV validation ran, so 200 INVALID_PARAMS
+    // payloads would saturate the window and lock out legitimate calls
+    // for 60 s. The per-tool token bucket (consumeToolRateLimitToken)
+    // already skipped on AJV failure; this test pins the same behavior
+    // for the global ring buffer.
+    const { ws } = await setup("rate-limit-ajv-rollback", (t) => {
+      t.registerTool(
+        {
+          name: "strictTool",
+          description:
+            "Requires a string `must` arg — used to trigger AJV fail.",
+          inputSchema: {
+            type: "object",
+            properties: { must: { type: "string" } },
+            required: ["must"],
+            additionalProperties: false,
+          },
+        },
+        async (args) => ({
+          content: [{ type: "text", text: String(args.must) }],
+        }),
+      );
+    });
+
+    // Fire 250 AJV-failing calls (250 > 200 = RATE_LIMIT_MAX). Each one
+    // should be rejected with INVALID_PARAMS and should NOT consume a
+    // slot in the global ring buffer.
+    for (let i = 1; i <= 250; i++) {
+      send(ws, {
+        jsonrpc: "2.0",
+        id: i,
+        method: "tools/call",
+        // Empty args object → AJV rejects (missing required `must`).
+        params: { name: "strictTool", arguments: {} },
+      });
+    }
+    // Wait for all 250 INVALID_PARAMS responses.
+    const last = await waitFor(ws, (m) => m.id === 250, 15000);
+    expect(last.error?.code).toBe(ErrorCodes.INVALID_PARAMS);
+
+    // A VALID 251st call should succeed — NOT rate-limited. Pre-fix
+    // behavior: this call would return RATE_LIMIT_EXCEEDED because the
+    // ring buffer was saturated by the 250 malformed payloads.
+    send(ws, {
+      jsonrpc: "2.0",
+      id: 251,
+      method: "tools/call",
+      params: { name: "strictTool", arguments: { must: "ok" } },
+    });
+    const valid = await waitFor(ws, (m) => m.id === 251, 5000);
+    expect(valid.error).toBeUndefined();
+    expect(valid.result).toMatchObject({
+      content: [{ type: "text", text: "ok" }],
+    });
+  });
+
   it("notification rate limit: exactly the 500th notification is dropped (>= off-by-one fix)", async () => {
     // NOTIFICATION_RATE_LIMIT = 500. After setup, notifCount = 1
     // (notifications/initialized). We send 498 dummy notifications/cancelled

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -816,9 +816,18 @@ export class McpTransport {
           );
           return;
         }
-        // Record this timestamp and advance the head pointer
-        this.rateLimitBuf[this.rateLimitHead] = now;
-        this.rateLimitHead = (this.rateLimitHead + 1) % RATE_LIMIT_MAX;
+        // Defer the ring-buffer WRITE until after the request is known to
+        // not be malformed. A flood of AJV-failing payloads should NOT
+        // consume the per-session sliding window — that's symmetrical
+        // with the per-tool token bucket which already skips on AJV
+        // failure (consumeToolRateLimitToken runs only after validation
+        // passes). Rollback-after-write was the original fix, but
+        // concurrent message handlers race between write and rollback
+        // and can momentarily fill the buffer.
+        //
+        // Default: count the request. AJV-fail branches below set
+        // `countRequestInRateLimit = false` to skip the write.
+        let countRequestInRateLimit = true;
 
         let response: JsonRpcResponse = {
           jsonrpc: "2.0",
@@ -1229,6 +1238,7 @@ export class McpTransport {
                 ) {
                   this.callCount++;
                   this.errorCount++;
+                  countRequestInRateLimit = false; // malformed → don't consume window slot
                   response = {
                     jsonrpc: "2.0",
                     id: msg.id,
@@ -1244,6 +1254,7 @@ export class McpTransport {
                 if (JSON.stringify(rawArgs).length > 1_048_576) {
                   this.callCount++;
                   this.errorCount++;
+                  countRequestInRateLimit = false; // malformed → don't consume window slot
                   response = {
                     jsonrpc: "2.0",
                     id: msg.id,
@@ -1268,6 +1279,7 @@ export class McpTransport {
                 if (validate && !validate(toolArgs)) {
                   this.callCount++;
                   this.errorCount++;
+                  countRequestInRateLimit = false; // AJV-fail → don't consume window slot
                   const messages = (validate.errors ?? [])
                     .map((e) => `${e.instancePath || "."} ${e.message}`)
                     .join("; ");
@@ -1718,6 +1730,16 @@ export class McpTransport {
                 message: `Method not found: ${safeMethod(msg.method)}`,
               },
             };
+        }
+
+        // Deferred rate-limit accounting: write the slot only after the
+        // dispatch path has decided the request is well-formed. AJV-fail
+        // branches in tools/call clear `countRequestInRateLimit` above so
+        // a flood of malformed payloads can't saturate the per-session
+        // 200/min sliding window.
+        if (countRequestInRateLimit) {
+          this.rateLimitBuf[this.rateLimitHead] = now;
+          this.rateLimitHead = (this.rateLimitHead + 1) % RATE_LIMIT_MAX;
         }
 
         this.logger.debug(`--> response for ${safeMethod(msg.method)}`);


### PR DESCRIPTION
## Summary
The per-session ring-buffer rate limit (200 req/min) wrote the timestamp at request ENTRY, before AJV validation. A flood of \`INVALID_PARAMS\` payloads saturated the window → 60 s lockout of legitimate calls on the attacker's own session.

The per-tool token bucket already skipped on AJV failure (per #800–#803). This change makes the global ring buffer symmetrical.

## Implementation
- Keep the entry peek (oldest-slot read). This still protects against a true 200/min flood whether requests succeed or not — the peek is cheap and stateless.
- Defer the WRITE until after the switch dispatch. AJV-fail branches in tools/call set \`countRequestInRateLimit = false\` to skip the write entirely.
- A prior rollback-after-write approach raced between concurrent message handlers (handler A writes slot X, yields at \`safeSend\`; handler B's entry peek sees slot X occupied before A's rollback runs). Deferring past the switch closes the race because the write only happens once the handler runs synchronously past all validation gates.

## Test plan
- [x] **New regression test** in [transport.test.ts](src/__tests__/transport.test.ts): sends 250 AJV-failing \`tools/call\` payloads followed by a valid call, asserts the valid call is NOT rate-limited. Pre-fix this returned \`-32004 RATE_LIMIT_EXCEEDED\`; post-fix returns the valid result.
- [x] 58/58 transport tests pass (transport.test.ts + transport-ajv.test.ts + transport-rate-limit.test.ts + transport-edge-cases.test.ts)
- [x] \`npx tsc --noEmit\` clean
- [x] \`npx biome check\` clean
- [x] The existing 200-ping rate-limit test still passes — the entry peek still rejects a flood of well-formed requests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)