### PR TITLE
fix(dashboard): token driver badges + wrap marketplace tables for 375px (H8+H9)

### DIFF
--- a/dashboard/src/app/marketplace/[...slug]/page.tsx
+++ b/dashboard/src/app/marketplace/[...slug]/page.tsx
@@ -202,6 +202,9 @@ function Variables({ manifest }: { manifest: RecipeManifest | null }) {
   return (
     <div className="glass-card" style={{ padding: "var(--s-5)" }}>
       <h3 style={{ fontSize: "var(--fs-m)", marginTop: 0, marginBottom: "var(--s-3)" }}>Configuration</h3>
+      {/* Horizontal scroll wrapper — table has 4 columns + variable-width
+          description content, overflows at 375 px without this guard. */}
+      <div style={{ overflowX: "auto", WebkitOverflowScrolling: "touch" }}>
       <table style={{ width: "100%", fontSize: "var(--fs-s)", borderCollapse: "collapse" }}>
         <thead>
           <tr style={{ textAlign: "left", color: "var(--ink-2)" }}>
@@ -228,6 +231,7 @@ function Variables({ manifest }: { manifest: RecipeManifest | null }) {
           ))}
         </tbody>
       </table>
+      </div>
     </div>
   );
 }
@@ -365,6 +369,7 @@ function TrustMetadataCard({ recipe }: { recipe: RegistryRecipe }) {
   return (
     <div className="glass-card" style={{ padding: "var(--s-5)" }}>
       <h3 style={{ fontSize: "var(--fs-m)", marginTop: 0, marginBottom: "var(--s-3)" }}>Trust &amp; permissions</h3>
+      <div style={{ overflowX: "auto", WebkitOverflowScrolling: "touch" }}>
       <table style={{ width: "100%", fontSize: "var(--fs-s)", borderCollapse: "collapse" }}>
         <tbody>
           {rows.map(({ label, value }) => (
@@ -375,6 +380,7 @@ function TrustMetadataCard({ recipe }: { recipe: RegistryRecipe }) {
           ))}
         </tbody>
       </table>
+      </div>
     </div>
   );
 }

--- a/dashboard/src/app/marketplace/bundle/[...slug]/page.tsx
+++ b/dashboard/src/app/marketplace/bundle/[...slug]/page.tsx
@@ -260,6 +260,7 @@ function TrustCard({ bundle }: { bundle: RegistryBundle }) {
   return (
     <div className="glass-card" style={{ padding: "var(--s-5)" }}>
       <h3 style={{ fontSize: "var(--fs-m)", marginTop: 0, marginBottom: "var(--s-3)" }}>Trust &amp; permissions</h3>
+      <div style={{ overflowX: "auto", WebkitOverflowScrolling: "touch" }}>
       <table style={{ width: "100%", fontSize: "var(--fs-s)", borderCollapse: "collapse" }}>
         <tbody>
           {rows.map(({ label, value }) => (
@@ -270,6 +271,7 @@ function TrustCard({ bundle }: { bundle: RegistryBundle }) {
           ))}
         </tbody>
       </table>
+      </div>
     </div>
   );
 }

--- a/dashboard/src/app/tasks/page.tsx
+++ b/dashboard/src/app/tasks/page.tsx
@@ -37,11 +37,15 @@ interface Task {
 
 // ----------------------------------------------------------- driver badge
 
+// Token-backed driver badges. Each entry references CSS custom properties
+// from globals.css so the badges follow dark-mode + theme overrides instead
+// of pinning a fixed light-mode hex (audit H8: previous inline hex values
+// failed contrast in dark mode and bypassed the design-token system).
 const DRIVER_COLORS: Record<string, { bg: string; fg: string }> = {
-  claude: { bg: "rgba(217,119,87,0.14)", fg: "#c0562e" },
-  gemini: { bg: "rgba(66,133,244,0.14)", fg: "#2f6fe0" },
-  openai: { bg: "rgba(16,163,127,0.14)", fg: "#0d8a5e" },
-  grok: { bg: "rgba(120,120,120,0.14)", fg: "#555" },
+  claude: { bg: "var(--accent-soft)", fg: "var(--accent)" },
+  gemini: { bg: "var(--blue-soft)", fg: "var(--blue)" },
+  openai: { bg: "var(--green-soft)", fg: "var(--green)" },
+  grok: { bg: "var(--recess)", fg: "var(--ink-2)" },
 };
 
 function driverFromTask(t: Task): string {


### PR DESCRIPTION
## Summary
Two dashboard-audit follow-ups consolidated — both small UI fixes that clean up the last remaining audit findings in the polish tier.

### H8 — Tasks driver badge inline hex
\`/tasks\` rendered driver badges with hardcoded rgba/hex colors (claude \`#c0562e\`, gemini \`#2f6fe0\`, openai \`#0d8a5e\`, grok \`#555\`). No dark-mode adaptation — fixed light-mode hex would fail WCAG contrast on rgba dark backgrounds.

**Fix**: switch to CSS tokens that resolve to the right shade per theme.

### H9 — Marketplace tables overflow at 375px
Three tables in [\`marketplace/[...slug]/page.tsx\`](dashboard/src/app/marketplace/%5B...slug%5D/page.tsx) + [\`marketplace/bundle/[...slug]/page.tsx\`](dashboard/src/app/marketplace/bundle/%5B...slug%5D/page.tsx) rendered without horizontal-scroll wrappers. Four columns + variable description widths overflow the viewport on iPhone SE / Fold inner display.

**Fix**: wrap each in a \`<div style={{ overflowX: \"auto\", WebkitOverflowScrolling: \"touch\" }}>\`. Sessions and Transactions tables were already wrapped (\`.table-wrap\`) — no change needed there.

## Test plan
- [x] 733/733 dashboard tests pass
- [x] \`npx tsc --noEmit\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)