### PR TITLE
fix(ci): unblock main — export runAndWait so it isn't flagged unused

### DIFF
--- a/examples/recipe-api/client.mjs
+++ b/examples/recipe-api/client.mjs
@@ -94,7 +94,7 @@ if (approvals.length > 0) {
 
 // ── Poll until a recipe run completes ────────────────────────────────────────
 
-async function runAndWait(name, vars, timeoutMs = 60_000) {
+export async function runAndWait(name, vars, timeoutMs = 60_000) {
   const { seq } = await bridgeFetch("/recipes/run", {
     method: "POST",
     body: JSON.stringify({ name, vars }),
@@ -115,6 +115,7 @@ async function runAndWait(name, vars, timeoutMs = 60_000) {
   throw new Error(`Timed out waiting for run #${seq}`);
 }
 
-// Uncomment to use:
+// Example usage (run with: node examples/recipe-api/client.mjs):
+// import { runAndWait } from "./client.mjs";
 // const result = await runAndWait("morning-brief");
 // console.log("Output:", result.output);


### PR DESCRIPTION
## Summary
biome's \`noUnusedVariables\` fires on \`examples/recipe-api/client.mjs:97\` because the demo at the bottom is commented out and nothing else references \`runAndWait\`. CI lint step on main has been red since the last merge → all in-flight PRs (#818, #819, #820, #821, #822) inherit the broken lint gate.

## Fix
Export the function (matches the file's intent as a reusable client / example) and update the demo comment to use the new import shape. Zero runtime change.

## Test plan
- [x] \`npx biome check examples/recipe-api/client.mjs\` → no warnings
- [x] No runtime behavior change — top-level calls still run when the file is executed as a script