### PR TITLE
chore(ci): drop Node 20 — EOL April 2026, runner removal Sept 2026

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,12 +18,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Node 20 reached EOL April 2026; removed from GitHub-hosted runners Sept 2026.
         os: [ubuntu-latest, windows-latest]
-        node-version: [20, 22]
-        exclude:
-          # Run Windows on Node 22 only to keep matrix lean while coverage is new
-          - os: windows-latest
-            node-version: 20
+        node-version: [22]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -295,12 +292,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Node 20 reached EOL April 2026; removed from GitHub-hosted runners Sept 2026.
         os: [ubuntu-latest, windows-latest]
-        node-version: [20, 22]
-        exclude:
-          # Match the bridge `ci` job: Windows on Node 22 only.
-          - os: windows-latest
-            node-version: 20
+        node-version: [22]
     defaults:
       run:
         working-directory: vscode-extension


### PR DESCRIPTION
## Summary

- Removes `node-version: 20` from the `ci` and `extension` job matrices
- Drops the `exclude` blocks that existed solely to prevent `windows-latest × Node 20`
- Adds a one-line comment explaining the removal rationale

## Why now

Node 20 reached EOL in **April 2026**. GitHub-hosted runners will **remove Node 20 on September 16, 2026** and have been forcing all action-script runtimes to Node 24 since June 2, 2026. Every CI run on the previous PR (`#827`) emitted three deprecation warnings per job:

```
Node.js 20 actions are deprecated … will be forced to run with Node.js 24 starting June 2nd, 2026.
Node.js 20 will be removed from the runner on September 16, 2026.
```

Node 22 (current LTS, supported until April 2027) remains the single test target on ubuntu-latest and windows-latest.

## Test plan

- [ ] CI passes on this PR (only `node-version: [22]` runs)
- [ ] No deprecation warnings about Node 20 in job logs

🤖 Generated with [Claude Code](https://claude.ai/claude-code)