### PR TITLE
fix(recipes): don't echo error message in /recipes/doctor 404 (js/stack-trace-exposure)

### DIFF
--- a/src/recipeRoutes.ts
+++ b/src/recipeRoutes.ts
@@ -771,11 +771,19 @@ export function tryHandleRecipeRoute(
         res.end(JSON.stringify(result));
       } catch (err) {
         // resolveRecipePath throws "recipe ... not found" for unknown
-        // names — map that to 404; anything else is a real 500.
+        // names — map that to 404; anything else is a real 500. Never echo
+        // err.message back to the client: it embeds the absolute recipes
+        // path (info-exposure / js/stack-trace-exposure). Return a static
+        // message; respond500 handles logging the detail server-side.
         const msg = err instanceof Error ? err.message : String(err);
         if (/not found/i.test(msg)) {
           res.writeHead(404, { "Content-Type": "application/json" });
-          res.end(JSON.stringify({ error: "recipe_not_found", message: msg }));
+          res.end(
+            JSON.stringify({
+              error: "recipe_not_found",
+              message: "recipe not found",
+            }),
+          );
           return;
         }
         respond500(res, err);


### PR DESCRIPTION
Fixes CodeQL alert #128 — `js/stack-trace-exposure` (medium) at `src/recipeRoutes.ts:778`.

## Problem
The `/recipes/doctor` not-found branch returned the caught `err.message` to the client. For an unknown recipe, that message is `recipe "<name>" not found in /Users/<user>/.patchwork/recipes` — leaking the absolute recipes path (local-path / info exposure).

## Fix
Return a static `"recipe not found"` message; don't echo the exception. The full error remains available server-side. The 500 branch already used `respond500` (logs the stack, sends a generic body), so no change there.

Per the project's CodeQL note (pattern-matches the data flow, not intent), this restructures the sink — the tainted `err.message → response` flow is removed, so the alert clears rather than being suppressed.

## Tests
`recipeRoutes-doctor.test.ts` still green (the 404 test asserts on `error: "recipe_not_found"`, unchanged). Bridge typecheck + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)