### PR TITLE
feat(dashboard): surface recipe Doctor from list + failed-run views

### DIFF
--- a/dashboard/src/app/recipes/[...name]/__tests__/DoctorPanel.test.tsx
+++ b/dashboard/src/app/recipes/[...name]/__tests__/DoctorPanel.test.tsx
@@ -66,6 +66,19 @@ describe("DoctorPanel", () => {
     expect(screen.getByText(/Reconnect from \/connections/)).toBeInTheDocument();
   });
 
+  it("auto-runs on mount when autoRun is set (deep-link)", async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => HEALTHY,
+    }));
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+    render(<DoctorPanel recipeName="demo" autoRun />);
+    // No click — the result should appear on its own.
+    await waitFor(() => expect(screen.getByText(/✓ healthy/)).toBeInTheDocument());
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
   it("surfaces a recipe_not_found error", async () => {
     mockFetchOnce({ error: "recipe_not_found", message: "recipe x not found" }, false, 404);
     render(<DoctorPanel recipeName="x" />);

--- a/dashboard/src/app/recipes/[...name]/_components/DoctorPanel.tsx
+++ b/dashboard/src/app/recipes/[...name]/_components/DoctorPanel.tsx
@@ -9,7 +9,7 @@
  * renders it.
  */
 
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { apiPath } from "@/lib/api";
 import {
   HALT_CATEGORY_HINT,
@@ -44,7 +44,15 @@ export interface DoctorResult {
   ok: boolean;
 }
 
-export function DoctorPanel({ recipeName }: { recipeName: string }) {
+export function DoctorPanel({
+  recipeName,
+  autoRun = false,
+}: {
+  recipeName: string;
+  /** Run the diagnosis immediately on mount — used by deep-links
+   *  (`?diagnose=1`) from the recipes list and failed-run views. */
+  autoRun?: boolean;
+}) {
   const [result, setResult] = useState<DoctorResult | null>(null);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -78,6 +86,16 @@ export function DoctorPanel({ recipeName }: { recipeName: string }) {
       setBusy(false);
     }
   }, [recipeName]);
+
+  // Auto-run once on mount when deep-linked (?diagnose=1). The ref guard
+  // keeps it to a single run even if React re-mounts in StrictMode dev.
+  const autoRanRef = useRef(false);
+  useEffect(() => {
+    if (autoRun && !autoRanRef.current) {
+      autoRanRef.current = true;
+      void runDoctor();
+    }
+  }, [autoRun, runDoctor]);
 
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: "var(--s-3)" }}>

--- a/dashboard/src/app/recipes/[...name]/page.tsx
+++ b/dashboard/src/app/recipes/[...name]/page.tsx
@@ -20,7 +20,7 @@ import { use, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { DoctorPanel } from "./_components/DoctorPanel";
 import RecipeEditPage from "./_edit/page";
 import RecipePlanPage from "./_plan/page";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { apiPath } from "@/lib/api";
 import { canonicalRecipeKey, inboxItemKey } from "@/lib/entityKey";
 import { useBridgeFetch } from "@/hooks/useBridgeFetch";
@@ -277,6 +277,9 @@ function RunModal({
 function RecipeHubOverviewPage({ name }: { name: string }) {
   const toast = useToast();
   const router = useRouter();
+  // Deep-link: `?diagnose=1` (from the recipes list / failed-run views)
+  // auto-runs the Doctor panel and scrolls to it.
+  const autoDiagnose = useSearchParams().get("diagnose") === "1";
 
   // Reusable list fetch for the recipe row (matches layout's data source).
   const { data: recipes, refetch: refetchRecipes } = useBridgeFetch<Recipe[]>(
@@ -856,11 +859,14 @@ function RecipeHubOverviewPage({ name }: { name: string }) {
         </div>
       </PatchCard>
 
-      {/* DOCTOR — composed health diagnosis (lint + policy + recent halts) */}
+      {/* DOCTOR — composed health diagnosis (lint + policy + recent halts).
+          The wrapping `#doctor` div is the scroll target for deep-links. */}
+      <div id="doctor">
       <PatchCard className="hub-card" style={{ padding: "var(--s-4)", animation: "hubCardIn 260ms 160ms ease both", animationFillMode: "both" }}>
         <SectionHeader>Doctor</SectionHeader>
-        <DoctorPanel recipeName={name} />
+        <DoctorPanel recipeName={name} autoRun={autoDiagnose} />
       </PatchCard>
+      </div>
       </div>{/* end main column */}
 
       {/* related panel column */}

--- a/dashboard/src/app/recipes/page.tsx
+++ b/dashboard/src/app/recipes/page.tsx
@@ -434,6 +434,14 @@ function RecipeDetailPanel({
         <span className="rdp-title" title={recipe.name}>{recipe.name}</span>
         {isLive && <LivePill tone="ok" />}
         <button type="button" onClick={onRun} className="btn sm primary">▶ Run</button>
+        <Link
+          href={`/recipes/${encodeURIComponent(recipe.name)}?diagnose=1#doctor`}
+          className="btn sm ghost"
+          style={{ textDecoration: "none" }}
+          title="Run the Doctor: lint + write-policy + recent halts, with fix hints"
+        >
+          Diagnose
+        </Link>
         <button
           type="button"
           onClick={onClose}

--- a/dashboard/src/app/runs/[seq]/page.tsx
+++ b/dashboard/src/app/runs/[seq]/page.tsx
@@ -1263,6 +1263,19 @@ export default function RunDetailPage() {
                   href: `/runs?recipe=${encodeURIComponent(run.recipeName)}`,
                   title: `Other runs of ${run.recipeName}`,
                 },
+                // Surface the recipe Doctor from a failed run — deep-link
+                // auto-runs the diagnosis (lint + policy + recent halts).
+                ...(run.status === "error" ||
+                (run.stepResults ?? []).some((s) => s.status === "error")
+                  ? [
+                      {
+                        label: "Diagnose",
+                        href: `/recipes/${encodeURIComponent(run.recipeName)}?diagnose=1#doctor`,
+                        tone: "accent" as const,
+                        title: `Run the Doctor on ${run.recipeName} — why it's failing + how to fix`,
+                      },
+                    ]
+                  : []),
                 {
                   label: "Activity",
                   href: "/activity",


### PR DESCRIPTION
Follow-up to #843. The Doctor panel was only reachable from a recipe's detail page; this adds discoverable entry points and deep-linking so users land on a diagnosis where they actually hit trouble.

## Changes
- **`DoctorPanel` `autoRun` prop** — runs the diagnosis on mount (single-run guarded), so a deep-link shows a result instead of just the button.
- **Recipe-detail page** — reads `?diagnose=1` → `autoRun`, with a `#doctor` scroll anchor.
- **Recipes list** (detail panel header) — a **Diagnose** link → `/recipes/<name>?diagnose=1#doctor`.
- **Run-detail** (`RelationStrip`) — a **Diagnose** link shown when the run errored or had step errors → same deep-link. A failing run is now one click from "why it's failing + how to fix".

## Tests
- Added `DoctorPanel` autoRun case.
- Dashboard `tsc` clean, full suite **740 pass**, eslint + inline-fontsize ratchet + tokens all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)