### PR TITLE
chore(release): sync main to v0.2.0-beta.10

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -131,19 +131,6 @@ jobs:
         if: steps.npm_check.outputs.skip != 'true'
         run: npm publish --access public --tag beta
 
-      # Beta is the active release line; keep `latest` in sync so
-      # `npm i patchwork-os` and the npmjs.com page stay current.
-      # When a stable (non-prerelease) version ships, remove this step.
-      # Note: OIDC trusted publishing only covers `npm publish`; dist-tag
-      # operations require a real token (NPM_TOKEN secret).
-      - name: Point latest dist-tag to this beta
-        if: steps.npm_check.outputs.skip != 'true'
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: |
-          npm config set //registry.npmjs.org/:_authToken "$NODE_AUTH_TOKEN"
-          V=$(node -p "require('./package.json').version")
-          npm dist-tag add patchwork-os@$V latest
 
       - name: Create GitHub pre-release
         env:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "patchwork-os",
-  "version": "0.2.0-beta.6",
+  "version": "0.2.0-beta.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "patchwork-os",
-      "version": "0.2.0-beta.6",
+      "version": "0.2.0-beta.10",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "patchwork-os",
-  "version": "0.2.0-beta.9",
+  "version": "0.2.0-beta.10",
   "description": "Your personal AI runtime, local-first. Patchwork OS gives any AI model a consistent set of tools, YAML recipes, a delegation policy with approval queue, and a durable trace memory — all on your machine, all under your policy.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

`main` was left at `0.2.0-beta.9` even though **`v0.2.0-beta.10` is tagged and published to npm** (`latest` + `beta` dist-tags). The beta.10 release commit only ever lived on `feat/connectors-wave3` (now pruned) and the tag — it never merged back to `main`.

This cherry-picks that exact release commit (`2c5d4763`) so the repo matches what's published. Without it, the next release PR would bump from beta.9 and the working tree wouldn't reflect the shipped version.

## Changes (identical to the published release)
- `package.json`: `0.2.0-beta.9` → `0.2.0-beta.10`
- `package-lock.json`: `0.2.0-beta.6` → `0.2.0-beta.10` (lock was stale)
- `.github/workflows/publish-npm.yml`: removed the dead NPM_TOKEN dist-tag step (the `latest` dist-tag is managed manually — this step was already retired in the published release)

## Verification
- Cherry-pick of `2c5d4763` applied cleanly (3 files, +3/-16 — matches the tagged commit)
- `git diff` vs the tag is empty for these files

🤖 Generated with [Claude Code](https://claude.com/claude-code)