### PR TITLE
fix: critical + high-severity findings from codebase audit

### DIFF
--- a/dashboard/src/app/api/connections/[connector]/__tests__/registry.test.ts
+++ b/dashboard/src/app/api/connections/[connector]/__tests__/registry.test.ts
@@ -41,6 +41,8 @@ const EXPECTED_CONNECT = new Set([
   "resend", "obsidian", "todoist", "vercel", "paystack", "pipedrive",
   "caldiy", "grafana", "posthog", "cloudflare", "circleci", "woocommerce",
   "supabase",
+  // Jira (PAT) — bridge routes wired in src/connectorRoutes.ts.
+  "jira",
 ]);
 const EXPECTED_TEST = new Set([
   "gmail", "github", "linear", "sentry", "google-calendar", "google-drive",
@@ -61,6 +63,8 @@ const EXPECTED_TEST = new Set([
   "resend", "obsidian", "todoist", "vercel", "paystack", "pipedrive",
   "caldiy", "grafana", "posthog", "cloudflare", "circleci", "woocommerce",
   "supabase",
+  // Jira (PAT) — bridge routes wired in src/connectorRoutes.ts.
+  "jira",
 ]);
 const EXPECTED_DELETE = EXPECTED_TEST;
 

--- a/dashboard/src/middleware.test.ts
+++ b/dashboard/src/middleware.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import { SESSION_GATE_MATCHER } from "./middleware";
+
+/**
+ * Next.js consumes `config.matcher` at build time to decide which request
+ * paths the middleware runs on — the negative-lookahead is NOT evaluated
+ * inside `middleware()` itself. So the way to assert the OAuth-callback
+ * exemption is to compile the matcher string the same way Next does
+ * (anchored, full-path) and check which concrete paths it matches.
+ *
+ * A path that MATCHES → middleware runs → (no session) → 302 to /login.
+ * A path that does NOT match → middleware is skipped → request passes
+ * through with its OAuth `code`/`state` intact.
+ *
+ * Note: Next.js strips `basePath` before matching, so the internal pathname
+ * for the external `/dashboard/connections/github/callback` is
+ * `/connections/github/callback`.
+ */
+function matcherRunsOn(pathname: string): boolean {
+  // Mirror Next.js: each matcher entry is anchored as a full-path regex.
+  const re = new RegExp(`^${SESSION_GATE_MATCHER}$`);
+  return re.test(pathname);
+}
+
+describe("dashboard middleware session-gate matcher", () => {
+  it("does NOT run on OAuth callback page routes (cross-site redirect, no cookie)", () => {
+    // The bug: provider redirects browser to the callback as a cross-site
+    // top-level nav, SameSite=Strict cookie is dropped, and the old matcher
+    // ran the gate → 302 to /login → OAuth code/state lost.
+    expect(matcherRunsOn("/connections/github/callback")).toBe(false);
+  });
+
+  it("exempts callbacks for hyphenated connector names", () => {
+    // `[^/]+` must span a single segment including hyphens.
+    expect(matcherRunsOn("/connections/google-calendar/callback")).toBe(false);
+    expect(matcherRunsOn("/connections/google-drive/callback")).toBe(false);
+  });
+
+  it("exempts every shipped OAuth callback route", () => {
+    const connectors = [
+      "github",
+      "slack",
+      "gmail",
+      "asana",
+      "discord",
+      "gitlab",
+      "linear",
+      "sentry",
+      "google-calendar",
+      "google-drive",
+    ];
+    for (const c of connectors) {
+      expect(matcherRunsOn(`/connections/${c}/callback`)).toBe(false);
+    }
+  });
+
+  it("exempts the same-origin callback API route (defense-in-depth)", () => {
+    expect(matcherRunsOn("/api/connections/github/callback")).toBe(false);
+  });
+
+  it("STILL runs on the connections list page and connection detail pages", () => {
+    // The exemption must be narrow: only `.../callback`, not the whole
+    // connections area, which holds tokens and must stay gated.
+    expect(matcherRunsOn("/connections")).toBe(true);
+    expect(matcherRunsOn("/connections/github")).toBe(true);
+  });
+
+  it("still gates ordinary pages and mutating API routes", () => {
+    expect(matcherRunsOn("/analytics")).toBe(true);
+    expect(matcherRunsOn("/recipes")).toBe(true);
+    expect(matcherRunsOn("/api/push/subscribe")).toBe(true);
+    expect(matcherRunsOn("/api/logout")).toBe(true);
+  });
+
+  it("keeps the pre-existing public exemptions intact", () => {
+    expect(matcherRunsOn("/api/login")).toBe(false);
+    expect(matcherRunsOn("/sw.js")).toBe(false);
+    expect(matcherRunsOn("/marketplace")).toBe(false);
+    expect(matcherRunsOn("/api/relay/push")).toBe(false);
+    expect(matcherRunsOn("/api/relay/halt")).toBe(false);
+    expect(matcherRunsOn("/api/push/vapid-key")).toBe(false);
+  });
+});

--- a/dashboard/src/middleware.ts
+++ b/dashboard/src/middleware.ts
@@ -20,6 +20,28 @@ import { SESSION_COOKIE_NAME, verifySession } from "@/lib/session";
 const ALLOW_UNAUTHENTICATED =
   process.env.DASHBOARD_ALLOW_UNAUTHENTICATED === "1";
 
+/**
+ * The negative-lookahead matcher that decides which paths the session gate
+ * runs on. Exported so it can be unit-tested against concrete request paths
+ * (Next.js consumes `config.matcher` at build time, not at runtime, so the
+ * lookahead is not exercised inside `middleware()`).
+ *
+ * `connections/[^/]+/callback` exempts the OAuth callback PAGE routes
+ * (`/connections/<name>/callback`). On authenticated deployments
+ * (PATCHWORK_DASHBOARD_URL + DASHBOARD_PASSWORD) the provider redirects the
+ * browser to this path as a CROSS-SITE top-level navigation, so the
+ * SameSite=Strict session cookie is NOT sent on that hop. Without the
+ * exemption the middleware sees no session, treats it as an HTML nav, and
+ * 302s to /login — dropping the OAuth code/state and silently breaking every
+ * connector. The OAuth `state` parameter is the CSRF defense here, so
+ * skipping the session redirect is safe. `[^/]+` matches a single path
+ * segment, including hyphenated connector names (`google-calendar`,
+ * `google-drive`). The same-origin API route is also exempted for
+ * defense-in-depth.
+ */
+export const SESSION_GATE_MATCHER =
+  "/((?!_next/static|_next/image|favicon\\.ico|favicon\\.svg|manifest\\.json|robots\\.txt|schema/|marketplace|api/login|api/relay/push|api/relay/halt|sw\\.js|icons/|api/push/vapid-key|connections/[^/]+/callback|api/connections/[^/]+/callback).*)";
+
 function unauthenticated(req: NextRequest): NextResponse {
   // For HTML navigations: redirect to /dashboard/login with the original
   // path as `next` so the user can come back after authenticating.
@@ -115,10 +137,16 @@ export const config = {
     // mutation endpoints unauthenticated. Removed 2026-05-17 (#600).
     // Defense-in-depth: those handlers also re-check the session.
     //
+    // connections/<name>/callback: OAuth callback PAGE routes. The
+    // provider redirects the browser here cross-site, so the
+    // SameSite=Strict session cookie isn't sent; exempting them keeps
+    // the OAuth code/state from being dropped by a /login redirect.
+    // See SESSION_GATE_MATCHER above for the full rationale.
+    //
     // Root path (basePath bare) explicitly — the negative-lookahead
     // matcher below doesn't reliably catch `/` alone in Next.js, which
     // means the dashboard's overview page would otherwise be unprotected.
     "/",
-    "/((?!_next/static|_next/image|favicon\\.ico|favicon\\.svg|manifest\\.json|robots\\.txt|schema/|marketplace|api/login|api/relay/push|api/relay/halt|sw\\.js|icons/|api/push/vapid-key).*)",
+    SESSION_GATE_MATCHER,
   ],
 };

--- a/src/__tests__/connectorRoutes-registry-parity.test.ts
+++ b/src/__tests__/connectorRoutes-registry-parity.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Registry ⇄ route parity guard.
+ *
+ * The shared connector registry (`src/connectors/connectorRegistry.ts`) is
+ * the single source of truth the dashboard derives its connect / test /
+ * delete allowlists from. If a connector declares `supports.connect`,
+ * `supports.test`, or `supports.delete` but the bridge dispatcher
+ * (`src/connectorRoutes.ts`) has no matching route literal, the dashboard
+ * surfaces the connector and every call 404s end-to-end.
+ *
+ * That is exactly what happened to the 13 Wave 3/4 connectors (resend,
+ * obsidian, todoist, vercel, paystack, pipedrive, caldiy, grafana,
+ * posthog, cloudflare, circleci, woocommerce, supabase) and to jira (which
+ * had routes but an empty `supports`). This text-level assertion fails the
+ * build before that class of drift ships again.
+ *
+ * It is deliberately a string scan of the dispatcher source rather than a
+ * live HTTP probe: it catches a missing route block regardless of whether
+ * the connector module's handlers throw at runtime.
+ */
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { CONNECTORS } from "../connectors/connectorRegistry.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const routesSrc = readFileSync(join(here, "..", "connectorRoutes.ts"), "utf8");
+
+describe("connector registry ⇄ bridge route parity", () => {
+  for (const c of CONNECTORS) {
+    if (c.supports.connect === true) {
+      it(`${c.id}: registry declares connect → dispatcher has POST /connections/${c.id}/connect`, () => {
+        expect(
+          routesSrc,
+          `connectorRoutes.ts is missing the /connections/${c.id}/connect route`,
+        ).toContain(`/connections/${c.id}/connect`);
+      });
+    }
+    if (c.supports.test === true) {
+      it(`${c.id}: registry declares test → dispatcher has POST /connections/${c.id}/test`, () => {
+        expect(
+          routesSrc,
+          `connectorRoutes.ts is missing the /connections/${c.id}/test route`,
+        ).toContain(`/connections/${c.id}/test`);
+      });
+    }
+    if (c.supports.delete === true) {
+      it(`${c.id}: registry declares delete → dispatcher has DELETE /connections/${c.id}`, () => {
+        // The DELETE literal is the bare `/connections/<id>` path string.
+        // Assert it appears alongside a DELETE method guard so we don't
+        // match the longer /connect or /test literals by prefix.
+        const deletePattern = new RegExp(
+          `parsedUrl\\.pathname === "/connections/${c.id}"[\\s\\S]{0,80}req\\.method === "DELETE"`,
+        );
+        expect(
+          deletePattern.test(routesSrc),
+          `connectorRoutes.ts is missing the DELETE /connections/${c.id} route`,
+        ).toBe(true);
+      });
+    }
+  }
+});

--- a/src/__tests__/registration-coverage.test.ts
+++ b/src/__tests__/registration-coverage.test.ts
@@ -132,7 +132,7 @@ describe("registerAllTools — options-object overload", () => {
     expect(registered).toContain("ctxSaveTrace");
   });
 
-  it("does NOT register ctxSaveTrace when decisionTraceLog is missing", () => {
+  it("registers ctxSaveTrace even without an injected decisionTraceLog (falls back to a default ~/.patchwork store, so the ctx write path is available on a default driver=none bridge)", () => {
     const { transport, extensionClient, registered } = makeMinimalDeps();
     registerAllTools({
       transport: transport as never,
@@ -141,7 +141,7 @@ describe("registerAllTools — options-object overload", () => {
       probes: probes as never,
       extensionClient: extensionClient as never,
     });
-    expect(registered).not.toContain("ctxSaveTrace");
+    expect(registered).toContain("ctxSaveTrace");
   });
 
   it("registers getCommitsForIssue and enrichCommit when commitIssueLinkLog is provided", () => {

--- a/src/__tests__/yamlRunner-local-endpoint-guard.test.ts
+++ b/src/__tests__/yamlRunner-local-endpoint-guard.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { isLoopbackOrPrivateEndpoint } from "../localEndpointGuard.js";
+
+// Control what `loadConfig()` (dynamically imported inside defaultLocalFn)
+// returns, so we can inject an attacker-controlled `localEndpoint`.
+let mockLocalEndpoint: string | undefined;
+vi.mock("../patchworkConfig.js", async () => {
+  const actual = await vi.importActual<typeof import("../patchworkConfig.js")>(
+    "../patchworkConfig.js",
+  );
+  return {
+    ...actual,
+    loadConfig: vi.fn(() => ({ localEndpoint: mockLocalEndpoint })),
+  };
+});
+
+// Spy on the adapter factory. If the guard is working, a public endpoint must
+// short-circuit BEFORE the adapter is ever constructed (so no prompt is
+// streamed out). For loopback endpoints the adapter IS constructed and we
+// return a canned, network-free response.
+const createLocalAdapterSpy = vi.fn(() => ({
+  complete: vi.fn(async () => ({ text: "ok-from-local" })),
+}));
+vi.mock("../adapters/local.js", () => ({
+  createLocalAdapter: createLocalAdapterSpy,
+}));
+
+import { defaultLocalFn } from "../recipes/yamlRunner.js";
+
+describe("localEndpointGuard predicate", () => {
+  it("accepts loopback / private hosts", () => {
+    expect(isLoopbackOrPrivateEndpoint("http://127.0.0.1:11434/v1")).toBe(true);
+    expect(isLoopbackOrPrivateEndpoint("http://localhost:1234/v1")).toBe(true);
+    expect(isLoopbackOrPrivateEndpoint("http://10.0.0.5:8000/v1")).toBe(true);
+    expect(isLoopbackOrPrivateEndpoint("http://192.168.1.20:8080/v1")).toBe(
+      true,
+    );
+  });
+
+  it("rejects public hosts", () => {
+    expect(isLoopbackOrPrivateEndpoint("https://evil.example.com/v1")).toBe(
+      false,
+    );
+    expect(isLoopbackOrPrivateEndpoint("https://8.8.8.8/v1")).toBe(false);
+  });
+});
+
+describe("defaultLocalFn anti-SSRF guard (call-site)", () => {
+  let prevAllowRemote: string | undefined;
+
+  beforeEach(() => {
+    createLocalAdapterSpy.mockClear();
+    prevAllowRemote = process.env.LOCAL_ENDPOINT_ALLOW_REMOTE;
+    delete process.env.LOCAL_ENDPOINT_ALLOW_REMOTE;
+    mockLocalEndpoint = undefined;
+  });
+
+  afterEach(() => {
+    if (prevAllowRemote === undefined)
+      delete process.env.LOCAL_ENDPOINT_ALLOW_REMOTE;
+    else process.env.LOCAL_ENDPOINT_ALLOW_REMOTE = prevAllowRemote;
+  });
+
+  it("REJECTS a public localEndpoint when ALLOW_REMOTE is unset (no exfiltration)", async () => {
+    mockLocalEndpoint = "https://evil.example.com/v1";
+
+    const result = await defaultLocalFn("super secret prompt", "llama3");
+
+    expect(result.text).toBe(
+      "[agent step failed: localEndpoint is a public host; set LOCAL_ENDPOINT_ALLOW_REMOTE=1 to override]",
+    );
+    // Critical: the adapter must never be built, so the prompt is never
+    // streamed to the public host.
+    expect(createLocalAdapterSpy).not.toHaveBeenCalled();
+  });
+
+  it("ALLOWS a loopback localEndpoint (adapter is built, request proceeds)", async () => {
+    mockLocalEndpoint = "http://127.0.0.1:11434/v1";
+
+    const result = await defaultLocalFn("hello", "llama3");
+
+    expect(result.text).toBe("ok-from-local");
+    expect(createLocalAdapterSpy).toHaveBeenCalledTimes(1);
+    expect(createLocalAdapterSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ endpoint: "http://127.0.0.1:11434/v1" }),
+    );
+  });
+
+  it("ALLOWS a public localEndpoint when LOCAL_ENDPOINT_ALLOW_REMOTE=1 (explicit override)", async () => {
+    process.env.LOCAL_ENDPOINT_ALLOW_REMOTE = "1";
+    mockLocalEndpoint = "https://internal-cluster.example.com/v1";
+
+    const result = await defaultLocalFn("hello", "llama3");
+
+    expect(result.text).toBe("ok-from-local");
+    expect(createLocalAdapterSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -963,6 +963,24 @@ export class Bridge {
       `Available test runners: ${probeList(["vitest", "jest", "pytest", "cargo", "go"])}`,
     );
 
+    // Initialize Patchwork enrichment + decision-trace logs.
+    //
+    // These back the ctx tools (ctxQueryTraces / ctxGetTaskContext /
+    // ctxSaveTrace / getCommitsForIssue) which are advertised as standard
+    // full-mode tools regardless of orchestration. They MUST be created even
+    // on the default `driver: "none"` bridge — otherwise the decision-trace
+    // WRITE path and the enrichment reverse-lookup silently disappear and
+    // ctxSaveTrace returns tool-not-found.
+    const patchworkDir = path.join(os.homedir(), ".patchwork");
+    this.commitIssueLinkLog = new CommitIssueLinkLog({
+      dir: patchworkDir,
+      logger: this.logger,
+    });
+    this.decisionTraceLog = new DecisionTraceLog({
+      dir: patchworkDir,
+      logger: this.logger,
+    });
+
     // 2. Initialize Claude driver and orchestrator (if configured)
     if (this.config.driver !== "none") {
       const driver = createDriver(
@@ -984,16 +1002,6 @@ export class Bridge {
         },
         (msg) => this.logger.info(msg),
       );
-      // Patchwork: enrichment link log is useful regardless of orchestrator.
-      const patchworkDir = path.join(os.homedir(), ".patchwork");
-      this.commitIssueLinkLog = new CommitIssueLinkLog({
-        dir: patchworkDir,
-        logger: this.logger,
-      });
-      this.decisionTraceLog = new DecisionTraceLog({
-        dir: patchworkDir,
-        logger: this.logger,
-      });
       if (driver) {
         // Recipe run-history needs the orchestrator to produce anything.
         this.recipeRunLog = new RecipeRunLog({

--- a/src/commands/__tests__/taskFindLock.test.ts
+++ b/src/commands/__tests__/taskFindLock.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Tests for `findBridgeLockForTask()` — the lock-selection primitive behind
+ * `quick-task` / `start-task` / `continue-handoff`.
+ *
+ * Regression guard: the original `findLock()` in task.ts picked the most
+ * recently MODIFIED `~/.claude/ide/*.lock` with NO `isBridge:true` filter and
+ * NO PID-liveness check. That meant it could select an IDE-owned lock or a
+ * dead bridge and POST a Bearer token to the wrong port. These tests pin the
+ * fixed behaviour: only `isBridge:true` + live-PID locks are selectable, and
+ * an explicit `--port` override is verified the same way.
+ */
+
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { findBridgeLockForTask } from "../task.js";
+
+let dir: string;
+
+function writeLock(
+  port: number,
+  body: {
+    pid?: number;
+    authToken?: string;
+    workspace?: string;
+    isBridge?: boolean;
+  },
+): void {
+  writeFileSync(join(dir, `${port}.lock`), JSON.stringify(body));
+}
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "pw-task-findlock-"));
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("findBridgeLockForTask() — auto-discovery", () => {
+  it("selects an isBridge + live lock", () => {
+    writeLock(4100, {
+      pid: 5100,
+      authToken: "tok-bridge",
+      isBridge: true,
+    });
+    const lock = findBridgeLockForTask(undefined, {
+      lockDir: dir,
+      isLive: () => true,
+    });
+    expect(lock).toEqual({ port: 4100, authToken: "tok-bridge" });
+  });
+
+  it("ignores an IDE-owned (non-isBridge) lock even if it is newest", () => {
+    // A live bridge plus a newer IDE-owned lock — the old findLock would
+    // have picked the IDE lock by mtime. The fixed primitive must not.
+    writeLock(4100, {
+      pid: 5100,
+      authToken: "tok-bridge",
+      isBridge: true,
+    });
+    writeLock(4200, {
+      pid: 5200,
+      authToken: "tok-ide", // IDE-owned: must never be selected
+      isBridge: false,
+    });
+    const lock = findBridgeLockForTask(undefined, {
+      lockDir: dir,
+      isLive: () => true,
+    });
+    expect(lock?.port).toBe(4100);
+    expect(lock?.authToken).toBe("tok-bridge");
+  });
+
+  it("ignores a dead-PID bridge lock", () => {
+    writeLock(4100, {
+      pid: 5100,
+      authToken: "tok-dead",
+      isBridge: true,
+    });
+    writeLock(4200, {
+      pid: 5200,
+      authToken: "tok-live",
+      isBridge: true,
+    });
+    const lock = findBridgeLockForTask(undefined, {
+      lockDir: dir,
+      isLive: (pid) => pid === 5200, // only 4200's bridge is alive
+    });
+    expect(lock?.port).toBe(4200);
+    expect(lock?.authToken).toBe("tok-live");
+  });
+
+  it("returns null when only IDE-owned or dead locks exist", () => {
+    writeLock(4100, { pid: 5100, authToken: "tok", isBridge: false });
+    writeLock(4200, { pid: 5200, authToken: "tok", isBridge: true });
+    const lock = findBridgeLockForTask(undefined, {
+      lockDir: dir,
+      isLive: () => false, // bridge PID is dead
+    });
+    expect(lock).toBeNull();
+  });
+});
+
+describe("findBridgeLockForTask() — explicit --port override", () => {
+  it("returns the lock for the given port when it is a live bridge", () => {
+    writeLock(4300, {
+      pid: 5300,
+      authToken: "tok-port",
+      isBridge: true,
+    });
+    const lock = findBridgeLockForTask(4300, {
+      lockDir: dir,
+      isLive: () => true,
+    });
+    expect(lock).toEqual({ port: 4300, authToken: "tok-port" });
+  });
+
+  it("returns null for a --port that points at an IDE-owned lock", () => {
+    writeLock(4300, {
+      pid: 5300,
+      authToken: "tok-ide",
+      isBridge: false, // not a bridge
+    });
+    const lock = findBridgeLockForTask(4300, {
+      lockDir: dir,
+      isLive: () => true,
+    });
+    expect(lock).toBeNull();
+  });
+
+  it("returns null for a --port whose bridge PID is dead", () => {
+    writeLock(4300, {
+      pid: 5300,
+      authToken: "tok",
+      isBridge: true,
+    });
+    const lock = findBridgeLockForTask(4300, {
+      lockDir: dir,
+      isLive: () => false,
+    });
+    expect(lock).toBeNull();
+  });
+
+  it("returns null for a --port with no lock file", () => {
+    const lock = findBridgeLockForTask(9999, {
+      lockDir: dir,
+      isLive: () => true,
+    });
+    expect(lock).toBeNull();
+  });
+});

--- a/src/commands/__tests__/tracesExport.test.ts
+++ b/src/commands/__tests__/tracesExport.test.ts
@@ -2,6 +2,7 @@ import {
   createReadStream,
   existsSync,
   mkdirSync,
+  readFileSync,
   rmSync,
   statSync,
   writeFileSync,
@@ -11,6 +12,10 @@ import path from "node:path";
 import { createInterface } from "node:readline";
 import { createGunzip } from "node:zlib";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  decryptTraceBundle,
+  isEncryptedTraceBundle,
+} from "../../traceEncryption.js";
 import { runTracesExport, TRACES_EXPORT_VERSION } from "../tracesExport.js";
 
 interface ParsedBundle {
@@ -247,5 +252,98 @@ describe("runTracesExport", () => {
         result.outputPath,
       ),
     ).toBe(true);
+  });
+
+  describe("keyed (encrypted) mode", () => {
+    it("mode=keyed with a passphrase writes a .enc bundle that round-trips", async () => {
+      const decisionRows = [
+        { id: "d1", traceType: "approval", key: "Bash", decidedAt: 100 },
+        { id: "d2", traceType: "approval", key: "Read", decidedAt: 200 },
+      ];
+      writeFileSync(
+        path.join(patchworkDir, "decision_traces.jsonl"),
+        `${decisionRows.map((r) => JSON.stringify(r)).join("\n")}\n`,
+      );
+
+      const out = path.join(tmpRoot, "bundle.enc");
+      const result = await runTracesExport({
+        patchworkDir,
+        activityDir,
+        output: out,
+        mode: "keyed",
+        passphrase: "correct horse battery staple",
+      });
+
+      // The written file must be the encrypted bundle, not plain gzip.
+      expect(result.outputPath).toBe(out);
+      expect(existsSync(out)).toBe(true);
+      const raw = readFileSync(out);
+      expect(isEncryptedTraceBundle(raw)).toBe(true);
+
+      // No leftover intermediate plain bundle.
+      expect(existsSync(`${out}.jsonl.gz`)).toBe(false);
+
+      // Decrypt → gunzip → JSONL recovers the original rows.
+      const plainGz = decryptTraceBundle(raw, "correct horse battery staple");
+      const tmpGz = path.join(tmpRoot, "decrypted.jsonl.gz");
+      writeFileSync(tmpGz, plainGz);
+      const bundle = await readBundle(tmpGz);
+      expect(bundle.manifest.type).toBe("manifest");
+      expect(bundle.manifest.version).toBe(TRACES_EXPORT_VERSION);
+      const exported = bundle.rows
+        .filter((r) => r.source === "decision_traces")
+        .map((r) => r.entry);
+      expect(exported).toEqual(decisionRows);
+    });
+
+    it("default keyed output filename ends in .enc", async () => {
+      writeFileSync(
+        path.join(patchworkDir, "runs.jsonl"),
+        `${JSON.stringify({ seq: 1 })}\n`,
+      );
+      const result = await runTracesExport({
+        patchworkDir,
+        activityDir,
+        mode: "keyed",
+        passphrase: "pw",
+      });
+      expect(result.outputPath.endsWith(".enc")).toBe(true);
+      expect(isEncryptedTraceBundle(readFileSync(result.outputPath))).toBe(
+        true,
+      );
+    });
+
+    it("mode=keyed without a passphrase throws a clear error", async () => {
+      writeFileSync(
+        path.join(patchworkDir, "runs.jsonl"),
+        `${JSON.stringify({ seq: 1 })}\n`,
+      );
+      await expect(
+        runTracesExport({
+          patchworkDir,
+          activityDir,
+          output: path.join(tmpRoot, "bundle.enc"),
+          mode: "keyed",
+        }),
+      ).rejects.toThrow(/passphrase/i);
+    });
+
+    it("mode=public (default) still writes a plain gzip bundle", async () => {
+      writeFileSync(
+        path.join(patchworkDir, "runs.jsonl"),
+        `${JSON.stringify({ seq: 1 })}\n`,
+      );
+      const result = await runTracesExport({
+        patchworkDir,
+        activityDir,
+        output: path.join(tmpRoot, "plain.jsonl.gz"),
+        mode: "public",
+      });
+      const raw = readFileSync(result.outputPath);
+      expect(isEncryptedTraceBundle(raw)).toBe(false);
+      // gzip magic bytes
+      expect(raw[0]).toBe(0x1f);
+      expect(raw[1]).toBe(0x8b);
+    });
   });
 });

--- a/src/commands/task.ts
+++ b/src/commands/task.ts
@@ -7,9 +7,13 @@
  * identical across surfaces.
  */
 
-import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { readFileSync } from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import {
+  findBridgeLock,
+  type LockDiscoveryDeps,
+} from "../bridgeLockDiscovery.js";
 import { QUICK_TASK_PRESET_IDS } from "../quickTaskPresets.js";
 
 interface LockInfo {
@@ -17,61 +21,86 @@ interface LockInfo {
   authToken: string;
 }
 
-function findLock(overridePort?: number): LockInfo {
-  const lockDir = path.join(
+function defaultLockDir(): string {
+  return path.join(
     process.env.CLAUDE_CONFIG_DIR ?? path.join(os.homedir(), ".claude"),
     "ide",
   );
+}
 
-  let lockFile: string | undefined;
-  let port: number | undefined;
+function defaultIsLive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Resolve the running bridge to dispatch a task to.
+ *
+ * Auto-discovery delegates to the shared `findBridgeLock()` primitive
+ * (filters `isBridge:true` + live PID) — the same one used by `recipe run`,
+ * `halts`, `judgments`, and `kill-switch`. The previous local implementation
+ * picked the most recently MODIFIED `*.lock` with NO isBridge filter and NO
+ * liveness check, so it could select an IDE-owned lock or a dead bridge and
+ * POST a Bearer token to the wrong port.
+ *
+ * For an explicit `--port` override we read that single lock and verify it is
+ * a live `isBridge:true` lock before returning — same guarantees as the
+ * auto-discovery path. Returns `null` (rather than process.exit) so callers
+ * can attach their own usage messaging; the `findLock()` wrapper below handles
+ * the exit-on-failure behaviour the CLI surfaces expect.
+ *
+ * `deps` is a test-injection seam (temp dir + synthetic `isLive`).
+ */
+export function findBridgeLockForTask(
+  overridePort?: number,
+  deps: LockDiscoveryDeps = {},
+): LockInfo | null {
+  const lockDir = deps.lockDir ?? defaultLockDir();
+  const isLive = deps.isLive ?? defaultIsLive;
 
   if (overridePort !== undefined) {
-    port = overridePort;
-    lockFile = path.join(lockDir, `${port}.lock`);
-    if (!existsSync(lockFile)) {
-      process.stderr.write(`Error: No lock file for port ${port}\n`);
-      process.exit(1);
-    }
-  } else {
-    let bestMtime = 0;
+    const lockFile = path.join(lockDir, `${overridePort}.lock`);
     try {
-      for (const f of readdirSync(lockDir)) {
-        if (!f.endsWith(".lock")) continue;
-        const full = path.join(lockDir, f);
-        const mtime = statSync(full).mtimeMs;
-        if (mtime > bestMtime) {
-          bestMtime = mtime;
-          lockFile = full;
-          port = Number(path.basename(f, ".lock"));
-        }
-      }
+      const parsed = JSON.parse(readFileSync(lockFile, "utf-8")) as {
+        pid?: number;
+        authToken?: string;
+        isBridge?: boolean;
+      };
+      // Same gate as findBridgeLock: must be a live bridge, not an IDE lock.
+      if (!parsed.isBridge) return null;
+      if (!parsed.pid || !isLive(parsed.pid)) return null;
+      if (!parsed.authToken) return null;
+      return { port: overridePort, authToken: parsed.authToken };
     } catch {
-      // lock dir doesn't exist
+      return null;
     }
   }
 
-  if (!lockFile || !port) {
+  const found = findBridgeLock({ lockDir, isLive });
+  if (!found?.authToken) return null;
+  return { port: found.port, authToken: found.authToken };
+}
+
+function findLock(overridePort?: number): LockInfo {
+  const lock = findBridgeLockForTask(overridePort);
+  if (lock) return lock;
+
+  if (overridePort !== undefined) {
     process.stderr.write(
-      `Error: No bridge lock file found in ${lockDir}\n` +
-        "Start the bridge first: claude-ide-bridge --watch --full --driver subprocess\n",
+      `Error: No live bridge lock for port ${overridePort} ` +
+        "(missing, IDE-owned, or dead process).\n",
     );
     process.exit(1);
   }
-
-  try {
-    const data = JSON.parse(readFileSync(lockFile, "utf-8")) as {
-      authToken?: string;
-    };
-    if (!data.authToken) {
-      process.stderr.write("Error: Lock file has no authToken\n");
-      process.exit(1);
-    }
-    return { port, authToken: data.authToken };
-  } catch {
-    process.stderr.write(`Error: Could not read lock file ${lockFile}\n`);
-    process.exit(1);
-  }
+  process.stderr.write(
+    `Error: No live bridge found in ${defaultLockDir()}\n` +
+      "Start the bridge first: claude-ide-bridge --watch --full --driver subprocess\n",
+  );
+  process.exit(1);
 }
 
 interface QuickTaskResponse {

--- a/src/commands/tracesExport.ts
+++ b/src/commands/tracesExport.ts
@@ -31,7 +31,10 @@ import {
   existsSync,
   mkdirSync,
   readdirSync,
+  readFileSync,
   statSync,
+  unlinkSync,
+  writeFileSync,
 } from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -51,13 +54,28 @@ export type TraceSource =
   | "commit_issue_links"
   | "activity";
 
+/**
+ * Export confidentiality mode.
+ *
+ * - `public` (default): plain gzipped JSONL. Anyone with the file can read
+ *   it. Round-trips with `gunzip -c`.
+ * - `keyed`: the gzipped JSONL is wrapped in an AES-256-GCM envelope
+ *   (see `src/traceEncryption.ts`). Requires a `passphrase`. The output
+ *   defaults to a `.enc` filename and is auto-detected by `traces import`.
+ */
+export type TracesExportMode = "public" | "keyed";
+
 export interface TracesExportOptions {
-  /** Where to write the bundle. Default: `${patchworkDir}/traces-export-{ISO}.jsonl.gz`. */
+  /** Where to write the bundle. Default: `${patchworkDir}/traces-export-{ISO}.jsonl.gz` (or `.enc` for keyed mode). */
   output?: string;
   /** Directory containing runs.jsonl / decision_traces.jsonl / commit_issue_links.jsonl. Default: `~/.patchwork/`. */
   patchworkDir?: string;
   /** Directory containing `activity-{port}.jsonl` files. Default: `~/.claude/ide/`. */
   activityDir?: string;
+  /** Confidentiality mode. Default: `public` (plain gzip). `keyed` requires `passphrase`. */
+  mode?: TracesExportMode;
+  /** Passphrase for `keyed` mode. Required when `mode === "keyed"`; ignored otherwise. */
+  passphrase?: string;
 }
 
 export interface TracesExportSourceFile {
@@ -201,13 +219,25 @@ export async function runTracesExport(
   const exportedAt = new Date().toISOString();
   const patchworkDir = opts.patchworkDir ?? defaultPatchworkDir();
   const activityDir = opts.activityDir ?? defaultActivityDir();
+  const mode: TracesExportMode = opts.mode ?? "public";
 
-  // Default output: `<patchworkDir>/traces-export-<safeIso>.jsonl.gz`. ISO
-  // colons are filename-hostile on Windows so swap them for hyphens.
+  // Reject keyed mode without a passphrase up-front — before we touch the
+  // filesystem — so the caller gets a clear, actionable error and no
+  // half-written intermediate file is left behind.
+  if (mode === "keyed" && !opts.passphrase) {
+    throw new Error(
+      "traces export: --mode keyed requires a --passphrase (none provided)",
+    );
+  }
+
+  // Default output: `<patchworkDir>/traces-export-<safeIso>.jsonl.gz` (or
+  // `.enc` for keyed mode). ISO colons are filename-hostile on Windows so
+  // swap them for hyphens.
   const safeStamp = exportedAt.replace(/:/g, "-").replace(/\..+$/, "");
+  const defaultExt = mode === "keyed" ? "jsonl.gz.enc" : "jsonl.gz";
   const outputPath =
     opts.output ??
-    path.join(patchworkDir, `traces-export-${safeStamp}.jsonl.gz`);
+    path.join(patchworkDir, `traces-export-${safeStamp}.${defaultExt}`);
 
   // Discover sources.
   const files: Array<{
@@ -265,6 +295,12 @@ export async function runTracesExport(
   // Use a Readable source so pipeline() owns backpressure end-to-end —
   // writing directly to gzip outside the pipeline ignores the drain signal
   // and silently buffers everything in memory on large exports.
+  //
+  // For keyed mode we first write the plain gzip to an intermediate path,
+  // then read it back, AES-256-GCM-wrap it, write the `.enc` to the real
+  // outputPath, and unlink the intermediate. The encryption helper operates
+  // on a whole Buffer, so the intermediate file is the streaming boundary.
+  const gzipTarget = mode === "keyed" ? `${outputPath}.plain.tmp` : outputPath;
   const { Readable } = await import("node:stream");
   const source = Readable.from(
     (function* () {
@@ -279,8 +315,26 @@ export async function runTracesExport(
     })(),
     { objectMode: false },
   );
-  const sink = createWriteStream(outputPath, { mode: 0o600 });
+  const sink = createWriteStream(gzipTarget, { mode: 0o600 });
   await pipeline(source, createGzip(), sink);
+
+  if (mode === "keyed") {
+    // opts.passphrase is guaranteed non-empty by the early guard above.
+    const passphrase = opts.passphrase as string;
+    const { encryptTraceBundle } = await import("../traceEncryption.js");
+    try {
+      const plain = readFileSync(gzipTarget);
+      const encrypted = encryptTraceBundle(plain, passphrase);
+      writeFileSync(outputPath, encrypted, { mode: 0o600 });
+    } finally {
+      // Always remove the plaintext intermediate, even if encryption threw.
+      try {
+        unlinkSync(gzipTarget);
+      } catch {
+        // Intermediate already gone or never created — nothing to clean.
+      }
+    }
+  }
 
   return {
     outputPath,

--- a/src/connectorRoutes.ts
+++ b/src/connectorRoutes.ts
@@ -2361,5 +2361,652 @@ export function tryHandleConnectorRoute(
     return true;
   }
 
+  // ── Resend routes ───────────────────────────────────────────────
+  if (
+    parsedUrl.pathname === "/connections/resend/connect" &&
+    req.method === "POST"
+  ) {
+    void dispatchConnectorConnect(req, res, async () => {
+      const m = await import("./connectors/resend.js");
+      return m.handleResendConnect;
+    });
+    return true;
+  }
+  if (
+    parsedUrl.pathname === "/connections/resend/test" &&
+    req.method === "POST"
+  ) {
+    void (async () => {
+      try {
+        const { handleResendTest } = await import("./connectors/resend.js");
+        const result = await handleResendTest();
+        res.writeHead(result.status, {
+          "Content-Type": result.contentType ?? "application/json",
+        });
+        res.end(result.body);
+      } catch (err) {
+        respond500(res, err);
+      }
+    })();
+    return true;
+  }
+  if (parsedUrl.pathname === "/connections/resend" && req.method === "DELETE") {
+    void (async () => {
+      try {
+        const { handleResendDisconnect } = await import(
+          "./connectors/resend.js"
+        );
+        const result = handleResendDisconnect();
+        res.writeHead(result.status, {
+          "Content-Type": result.contentType ?? "application/json",
+        });
+        res.end(result.body);
+      } catch (err) {
+        respond500(res, err);
+      }
+    })();
+    return true;
+  }
+
+  // ── Obsidian routes ─────────────────────────────────────────────
+  if (
+    parsedUrl.pathname === "/connections/obsidian/connect" &&
+    req.method === "POST"
+  ) {
+    void dispatchConnectorConnect(req, res, async () => {
+      const m = await import("./connectors/obsidian.js");
+      return m.handleObsidianConnect;
+    });
+    return true;
+  }
+  if (
+    parsedUrl.pathname === "/connections/obsidian/test" &&
+    req.method === "POST"
+  ) {
+    void (async () => {
+      try {
+        const { handleObsidianTest } = await import("./connectors/obsidian.js");
+        const result = await handleObsidianTest();
+        res.writeHead(result.status, {
+          "Content-Type": result.contentType ?? "application/json",
+        });
+        res.end(result.body);
+      } catch (err) {
+        respond500(res, err);
+      }
+    })();
+    return true;
+  }
+  if (
+    parsedUrl.pathname === "/connections/obsidian" &&
+    req.method === "DELETE"
+  ) {
+    void (async () => {
+      try {
+        const { handleObsidianDisconnect } = await import(
+          "./connectors/obsidian.js"
+        );
+        const result = handleObsidianDisconnect();
+        res.writeHead(result.status, {
+          "Content-Type": result.contentType ?? "application/json",
+        });
+        res.end(result.body);
+      } catch (err) {
+        respond500(res, err);
+      }
+    })();
+    return true;
+  }
+
+  // ── Todoist routes ──────────────────────────────────────────────
+  if (
+    parsedUrl.pathname === "/connections/todoist/connect" &&
+    req.method === "POST"
+  ) {
+    void dispatchConnectorConnect(req, res, async () => {
+      const m = await import("./connectors/todoist.js");
+      return m.handleTodoistConnect;
+    });
+    return true;
+  }
+  if (
+    parsedUrl.pathname === "/connections/todoist/test" &&
+    req.method === "POST"
+  ) {
+    void (async () => {
+      try {
+        const { handleTodoistTest } = await import("./connectors/todoist.js");
+        const result = await handleTodoistTest();
+        res.writeHead(result.status, {
+          "Content-Type": result.contentType ?? "application/json",
+        });
+        res.end(result.body);
+      } catch (err) {
+        respond500(res, err);
+      }
+    })();
+    return true;
+  }
+  if (
+    parsedUrl.pathname === "/connections/todoist" &&
+    req.method === "DELETE"
+  ) {
+    void (async () => {
+      try {
+        const { handleTodoistDisconnect } = await import(
+          "./connectors/todoist.js"
+        );
+        const result = handleTodoistDisconnect();
+        res.writeHead(result.status, {
+          "Content-Type": result.contentType ?? "application/json",
+        });
+        res.end(result.body);
+      } catch (err) {
+        respond500(res, err);
+      }
+    })();
+    return true;
+  }
+
+  // ── Vercel routes ───────────────────────────────────────────────
+  if (
+    parsedUrl.pathname === "/connections/vercel/connect" &&
+    req.method === "POST"
+  ) {
+    void dispatchConnectorConnect(req, res, async () => {
+      const m = await import("./connectors/vercel.js");
+      return m.handleVercelConnect;
+    });
+    return true;
+  }
+  if (
+    parsedUrl.pathname === "/connections/vercel/test" &&
+    req.method === "POST"
+  ) {
+    void (async () => {
+      try {
+        const { handleVercelTest } = await import("./connectors/vercel.js");
+        const result = await handleVercelTest();
+        res.writeHead(result.status, {
+          "Content-Type": result.contentType ?? "application/json",
+        });
+        res.end(result.body);
+      } catch (err) {
+        respond500(res, err);
+      }
+    })();
+    return true;
+  }
+  if (parsedUrl.pathname === "/connections/vercel" && req.method === "DELETE") {
+    void (async () => {
+      try {
+        const { handleVercelDisconnect } = await import(
+          "./connectors/vercel.js"
+        );
+        const result = handleVercelDisconnect();
+        res.writeHead(result.status, {
+          "Content-Type": result.contentType ?? "application/json",
+        });
+        res.end(result.body);
+      } catch (err) {
+        respond500(res, err);
+      }
+    })();
+    return true;
+  }
+
+  // ── Paystack routes ─────────────────────────────────────────────
+  if (
+    parsedUrl.pathname === "/connections/paystack/connect" &&
+    req.method === "POST"
+  ) {
+    void dispatchConnectorConnect(req, res, async () => {
+      const m = await import("./connectors/paystack.js");
+      return m.handlePaystackConnect;
+    });
+    return true;
+  }
+  if (
+    parsedUrl.pathname === "/connections/paystack/test" &&
+    req.method === "POST"
+  ) {
+    void (async () => {
+      try {
+        const { handlePaystackTest } = await import("./connectors/paystack.js");
+        const result = await handlePaystackTest();
+        res.writeHead(result.status, {
+          "Content-Type": result.contentType ?? "application/json",
+        });
+        res.end(result.body);
+      } catch (err) {
+        respond500(res, err);
+      }
+    })();
+    return true;
+  }
+  if (
+    parsedUrl.pathname === "/connections/paystack" &&
+    req.method === "DELETE"
+  ) {
+    void (async () => {
+      try {
+        const { handlePaystackDisconnect } = await import(
+          "./connectors/paystack.js"
+        );
+        const result = handlePaystackDisconnect();
+        res.writeHead(result.status, {
+          "Content-Type": result.contentType ?? "application/json",
+        });
+        res.end(result.body);
+      } catch (err) {
+        respond500(res, err);
+      }
+    })();
+    return true;
+  }
+
+  // ── Pipedrive routes ────────────────────────────────────────────
+  if (
+    parsedUrl.pathname === "/connections/pipedrive/connect" &&
+    req.method === "POST"
+  ) {
+    void dispatchConnectorConnect(req, res, async () => {
+      const m = await import("./connectors/pipedrive.js");
+      return m.handlePipedriveConnect;
+    });
+    return true;
+  }
+  if (
+    parsedUrl.pathname === "/connections/pipedrive/test" &&
+    req.method === "POST"
+  ) {
+    void (async () => {
+      try {
+        const { handlePipedriveTest } = await import(
+          "./connectors/pipedrive.js"
+        );
+        const result = await handlePipedriveTest();
+        res.writeHead(result.status, {
+          "Content-Type": result.contentType ?? "application/json",
+        });
+        res.end(result.body);
+      } catch (err) {
+        respond500(res, err);
+      }
+    })();
+    return true;
+  }
+  if (
+    parsedUrl.pathname === "/connections/pipedrive" &&
+    req.method === "DELETE"
+  ) {
+    void (async () => {
+      try {
+        const { handlePipedriveDisconnect } = await import(
+          "./connectors/pipedrive.js"
+        );
+        const result = handlePipedriveDisconnect();
+        res.writeHead(result.status, {
+          "Content-Type": result.contentType ?? "application/json",
+        });
+        res.end(result.body);
+      } catch (err) {
+        respond500(res, err);
+      }
+    })();
+    return true;
+  }
+
+  // ── Cal.diy routes ──────────────────────────────────────────────
+  if (
+    parsedUrl.pathname === "/connections/caldiy/connect" &&
+    req.method === "POST"
+  ) {
+    void dispatchConnectorConnect(req, res, async () => {
+      const m = await import("./connectors/caldiy.js");
+      return m.handleCalDiyConnect;
+    });
+    return true;
+  }
+  if (
+    parsedUrl.pathname === "/connections/caldiy/test" &&
+    req.method === "POST"
+  ) {
+    void (async () => {
+      try {
+        const { handleCalDiyTest } = await import("./connectors/caldiy.js");
+        const result = await handleCalDiyTest();
+        res.writeHead(result.status, {
+          "Content-Type": result.contentType ?? "application/json",
+        });
+        res.end(result.body);
+      } catch (err) {
+        respond500(res, err);
+      }
+    })();
+    return true;
+  }
+  if (parsedUrl.pathname === "/connections/caldiy" && req.method === "DELETE") {
+    void (async () => {
+      try {
+        const { handleCalDiyDisconnect } = await import(
+          "./connectors/caldiy.js"
+        );
+        const result = handleCalDiyDisconnect();
+        res.writeHead(result.status, {
+          "Content-Type": result.contentType ?? "application/json",
+        });
+        res.end(result.body);
+      } catch (err) {
+        respond500(res, err);
+      }
+    })();
+    return true;
+  }
+
+  // ── Grafana routes ──────────────────────────────────────────────
+  if (
+    parsedUrl.pathname === "/connections/grafana/connect" &&
+    req.method === "POST"
+  ) {
+    void dispatchConnectorConnect(req, res, async () => {
+      const m = await import("./connectors/grafana.js");
+      return m.handleGrafanaConnect;
+    });
+    return true;
+  }
+  if (
+    parsedUrl.pathname === "/connections/grafana/test" &&
+    req.method === "POST"
+  ) {
+    void (async () => {
+      try {
+        const { handleGrafanaTest } = await import("./connectors/grafana.js");
+        const result = await handleGrafanaTest();
+        res.writeHead(result.status, {
+          "Content-Type": result.contentType ?? "application/json",
+        });
+        res.end(result.body);
+      } catch (err) {
+        respond500(res, err);
+      }
+    })();
+    return true;
+  }
+  if (
+    parsedUrl.pathname === "/connections/grafana" &&
+    req.method === "DELETE"
+  ) {
+    void (async () => {
+      try {
+        const { handleGrafanaDisconnect } = await import(
+          "./connectors/grafana.js"
+        );
+        const result = handleGrafanaDisconnect();
+        res.writeHead(result.status, {
+          "Content-Type": result.contentType ?? "application/json",
+        });
+        res.end(result.body);
+      } catch (err) {
+        respond500(res, err);
+      }
+    })();
+    return true;
+  }
+
+  // ── PostHog routes ──────────────────────────────────────────────
+  if (
+    parsedUrl.pathname === "/connections/posthog/connect" &&
+    req.method === "POST"
+  ) {
+    void dispatchConnectorConnect(req, res, async () => {
+      const m = await import("./connectors/posthog.js");
+      return m.handlePostHogConnect;
+    });
+    return true;
+  }
+  if (
+    parsedUrl.pathname === "/connections/posthog/test" &&
+    req.method === "POST"
+  ) {
+    void (async () => {
+      try {
+        const { handlePostHogTest } = await import("./connectors/posthog.js");
+        const result = await handlePostHogTest();
+        res.writeHead(result.status, {
+          "Content-Type": result.contentType ?? "application/json",
+        });
+        res.end(result.body);
+      } catch (err) {
+        respond500(res, err);
+      }
+    })();
+    return true;
+  }
+  if (
+    parsedUrl.pathname === "/connections/posthog" &&
+    req.method === "DELETE"
+  ) {
+    void (async () => {
+      try {
+        const { handlePostHogDisconnect } = await import(
+          "./connectors/posthog.js"
+        );
+        const result = handlePostHogDisconnect();
+        res.writeHead(result.status, {
+          "Content-Type": result.contentType ?? "application/json",
+        });
+        res.end(result.body);
+      } catch (err) {
+        respond500(res, err);
+      }
+    })();
+    return true;
+  }
+
+  // ── Cloudflare routes ───────────────────────────────────────────
+  if (
+    parsedUrl.pathname === "/connections/cloudflare/connect" &&
+    req.method === "POST"
+  ) {
+    void dispatchConnectorConnect(req, res, async () => {
+      const m = await import("./connectors/cloudflare.js");
+      return m.handleCloudflareConnect;
+    });
+    return true;
+  }
+  if (
+    parsedUrl.pathname === "/connections/cloudflare/test" &&
+    req.method === "POST"
+  ) {
+    void (async () => {
+      try {
+        const { handleCloudflareTest } = await import(
+          "./connectors/cloudflare.js"
+        );
+        const result = await handleCloudflareTest();
+        res.writeHead(result.status, {
+          "Content-Type": result.contentType ?? "application/json",
+        });
+        res.end(result.body);
+      } catch (err) {
+        respond500(res, err);
+      }
+    })();
+    return true;
+  }
+  if (
+    parsedUrl.pathname === "/connections/cloudflare" &&
+    req.method === "DELETE"
+  ) {
+    void (async () => {
+      try {
+        const { handleCloudflareDisconnect } = await import(
+          "./connectors/cloudflare.js"
+        );
+        const result = handleCloudflareDisconnect();
+        res.writeHead(result.status, {
+          "Content-Type": result.contentType ?? "application/json",
+        });
+        res.end(result.body);
+      } catch (err) {
+        respond500(res, err);
+      }
+    })();
+    return true;
+  }
+
+  // ── CircleCI routes ─────────────────────────────────────────────
+  if (
+    parsedUrl.pathname === "/connections/circleci/connect" &&
+    req.method === "POST"
+  ) {
+    void dispatchConnectorConnect(req, res, async () => {
+      const m = await import("./connectors/circleci.js");
+      return m.handleCircleCIConnect;
+    });
+    return true;
+  }
+  if (
+    parsedUrl.pathname === "/connections/circleci/test" &&
+    req.method === "POST"
+  ) {
+    void (async () => {
+      try {
+        const { handleCircleCITest } = await import("./connectors/circleci.js");
+        const result = await handleCircleCITest();
+        res.writeHead(result.status, {
+          "Content-Type": result.contentType ?? "application/json",
+        });
+        res.end(result.body);
+      } catch (err) {
+        respond500(res, err);
+      }
+    })();
+    return true;
+  }
+  if (
+    parsedUrl.pathname === "/connections/circleci" &&
+    req.method === "DELETE"
+  ) {
+    void (async () => {
+      try {
+        const { handleCircleCIDisconnect } = await import(
+          "./connectors/circleci.js"
+        );
+        const result = handleCircleCIDisconnect();
+        res.writeHead(result.status, {
+          "Content-Type": result.contentType ?? "application/json",
+        });
+        res.end(result.body);
+      } catch (err) {
+        respond500(res, err);
+      }
+    })();
+    return true;
+  }
+
+  // ── WooCommerce routes ──────────────────────────────────────────
+  if (
+    parsedUrl.pathname === "/connections/woocommerce/connect" &&
+    req.method === "POST"
+  ) {
+    void dispatchConnectorConnect(req, res, async () => {
+      const m = await import("./connectors/woocommerce.js");
+      return m.handleWooCommerceConnect;
+    });
+    return true;
+  }
+  if (
+    parsedUrl.pathname === "/connections/woocommerce/test" &&
+    req.method === "POST"
+  ) {
+    void (async () => {
+      try {
+        const { handleWooCommerceTest } = await import(
+          "./connectors/woocommerce.js"
+        );
+        const result = await handleWooCommerceTest();
+        res.writeHead(result.status, {
+          "Content-Type": result.contentType ?? "application/json",
+        });
+        res.end(result.body);
+      } catch (err) {
+        respond500(res, err);
+      }
+    })();
+    return true;
+  }
+  if (
+    parsedUrl.pathname === "/connections/woocommerce" &&
+    req.method === "DELETE"
+  ) {
+    void (async () => {
+      try {
+        const { handleWooCommerceDisconnect } = await import(
+          "./connectors/woocommerce.js"
+        );
+        const result = handleWooCommerceDisconnect();
+        res.writeHead(result.status, {
+          "Content-Type": result.contentType ?? "application/json",
+        });
+        res.end(result.body);
+      } catch (err) {
+        respond500(res, err);
+      }
+    })();
+    return true;
+  }
+
+  // ── Supabase routes ─────────────────────────────────────────────
+  if (
+    parsedUrl.pathname === "/connections/supabase/connect" &&
+    req.method === "POST"
+  ) {
+    void dispatchConnectorConnect(req, res, async () => {
+      const m = await import("./connectors/supabase.js");
+      return m.handleSupabaseConnect;
+    });
+    return true;
+  }
+  if (
+    parsedUrl.pathname === "/connections/supabase/test" &&
+    req.method === "POST"
+  ) {
+    void (async () => {
+      try {
+        const { handleSupabaseTest } = await import("./connectors/supabase.js");
+        const result = await handleSupabaseTest();
+        res.writeHead(result.status, {
+          "Content-Type": result.contentType ?? "application/json",
+        });
+        res.end(result.body);
+      } catch (err) {
+        respond500(res, err);
+      }
+    })();
+    return true;
+  }
+  if (
+    parsedUrl.pathname === "/connections/supabase" &&
+    req.method === "DELETE"
+  ) {
+    void (async () => {
+      try {
+        const { handleSupabaseDisconnect } = await import(
+          "./connectors/supabase.js"
+        );
+        const result = handleSupabaseDisconnect();
+        res.writeHead(result.status, {
+          "Content-Type": result.contentType ?? "application/json",
+        });
+        res.end(result.body);
+      } catch (err) {
+        respond500(res, err);
+      }
+    })();
+    return true;
+  }
+
   return false;
 }

--- a/src/connectors/__tests__/jira.test.ts
+++ b/src/connectors/__tests__/jira.test.ts
@@ -183,6 +183,82 @@ describe("handleJiraConnect", () => {
   });
 });
 
+describe("buildHeaders auth scheme (cloud + email API token)", () => {
+  const tmpDir = join(os.tmpdir(), `patchwork-jira-bh-${Date.now()}`);
+  const homeDir = join(tmpDir, "home");
+  const patchworkHome = join(homeDir, ".patchwork");
+  const tokensDir = join(patchworkHome, "tokens");
+
+  beforeEach(() => {
+    process.env.HOME = homeDir;
+    process.env.PATCHWORK_HOME = patchworkHome;
+    process.env.PATCHWORK_TOKEN_STORAGE_BACKEND = "file";
+    mkdirSync(tokensDir, { recursive: true });
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    delete process.env.HOME;
+    delete process.env.PATCHWORK_HOME;
+    delete process.env.PATCHWORK_TOKEN_STORAGE_BACKEND;
+    delete process.env.JIRA_API_TOKEN;
+    delete process.env.JIRA_INSTANCE_URL;
+    delete process.env.JIRA_EMAIL;
+    if (existsSync(tmpDir)) rmSync(tmpDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  function captureAuthHeader(): { current: string | undefined } {
+    const captured: { current: string | undefined } = { current: undefined };
+    global.fetch = vi.fn().mockImplementation((_url, init) => {
+      const headers = (init?.headers ?? {}) as Record<string, string>;
+      captured.current = headers.Authorization;
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        headers: { get: () => null },
+        json: async () => ({ id: "1", key: "ABC-1", fields: {} }),
+      });
+    }) as unknown as typeof fetch;
+    return captured;
+  }
+
+  it("uses Basic base64(email:token) for cloud + email API token (NOT Bearer)", async () => {
+    const { saveTokens, getJiraConnector } = await import("../jira.js");
+    saveTokens({
+      accessToken: "api-token-123",
+      email: "dev@acme.com",
+      instanceUrl: "https://acme.atlassian.net",
+      isCloud: true,
+      connected_at: "2026-06-02T00:00:00.000Z",
+    });
+
+    const captured = captureAuthHeader();
+    await getJiraConnector().fetchIssue("ABC-1");
+
+    const expectedBasic = Buffer.from("dev@acme.com:api-token-123").toString(
+      "base64",
+    );
+    expect(captured.current).toBe(`Basic ${expectedBasic}`);
+    expect(captured.current).not.toMatch(/^Bearer /);
+  });
+
+  it("uses Bearer for cloud token WITHOUT email (real OAuth access token)", async () => {
+    const { saveTokens, getJiraConnector } = await import("../jira.js");
+    saveTokens({
+      accessToken: "oauth-access-token",
+      instanceUrl: "https://acme.atlassian.net",
+      isCloud: true,
+      connected_at: "2026-06-02T00:00:00.000Z",
+    });
+
+    const captured = captureAuthHeader();
+    await getJiraConnector().fetchIssue("ABC-1");
+
+    expect(captured.current).toBe("Bearer oauth-access-token");
+  });
+});
+
 describe("connectorRoutes /connections/jira/connect wiring", () => {
   it("connectorRoutes.ts references handleJiraConnect (regression: was 404)", async () => {
     const { readFileSync } = await import("node:fs");

--- a/src/connectors/__tests__/notion.test.ts
+++ b/src/connectors/__tests__/notion.test.ts
@@ -216,3 +216,44 @@ describe("handleNotionDisconnect", () => {
     expect(JSON.parse(result.body).ok).toBe(true);
   });
 });
+
+describe("clearTokens deletes secure storage", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    delete process.env.NOTION_TOKEN;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.doUnmock("../tokenStorage.js");
+  });
+
+  it("calls deleteSecretJsonSync('notion') so the real token is removed", async () => {
+    const deleteSecretJsonSync = vi.fn();
+    vi.doMock("../tokenStorage.js", () => ({
+      getSecretJsonSync: vi.fn(() => null),
+      storeSecretJsonSync: vi.fn(),
+      deleteSecretJsonSync,
+    }));
+
+    const { clearTokens } = await import("../notion.js");
+    clearTokens();
+
+    expect(deleteSecretJsonSync).toHaveBeenCalledWith("notion");
+  });
+
+  it("still succeeds (does not throw) if deleteSecretJsonSync throws", async () => {
+    const deleteSecretJsonSync = vi.fn(() => {
+      throw new Error("keychain locked");
+    });
+    vi.doMock("../tokenStorage.js", () => ({
+      getSecretJsonSync: vi.fn(() => null),
+      storeSecretJsonSync: vi.fn(),
+      deleteSecretJsonSync,
+    }));
+
+    const { clearTokens } = await import("../notion.js");
+    expect(() => clearTokens()).not.toThrow();
+    expect(deleteSecretJsonSync).toHaveBeenCalledWith("notion");
+  });
+});

--- a/src/connectors/connectorRegistry.ts
+++ b/src/connectors/connectorRegistry.ts
@@ -46,9 +46,6 @@ export interface ConnectorDescriptor {
  * - `connect` allowlist is the narrow PAT-only set.
  * - `test` and `delete` allowlists are identical and cover every
  *   connector that has a corresponding bridge route.
- * - `jira` is intentionally absent from the dashboard surfaces today
- *   (concurrent work is wiring its bridge routes). When that lands,
- *   flip its `supports` flags here and the dashboard picks it up.
  */
 export const CONNECTORS: readonly ConnectorDescriptor[] = [
   // OAuth connectors
@@ -260,11 +257,14 @@ export const CONNECTORS: readonly ConnectorDescriptor[] = [
     authKind: "pat",
     supports: { connect: true, test: true, delete: true },
   },
-  // jira: PAT. Concurrent work is wiring the bridge routes. The
-  // `supports` capabilities here are deliberately empty until those
-  // routes exist; flipping them in this file is the one-line change
-  // that opens jira up to the dashboard surfaces.
-  { id: "jira", label: "Jira", authKind: "pat", supports: {} },
+  // jira: PAT. Bridge routes (connect / test / DELETE) live in
+  // src/connectorRoutes.ts.
+  {
+    id: "jira",
+    label: "Jira",
+    authKind: "pat",
+    supports: { connect: true, test: true, delete: true },
+  },
   // Wave 3 — new connectors (2026-05-31).
   {
     id: "resend",

--- a/src/connectors/jira.ts
+++ b/src/connectors/jira.ts
@@ -435,13 +435,18 @@ export class JiraConnector extends BaseConnector {
   }
 
   private buildHeaders(token: string): Record<string, string> {
-    if (this.tokens?.isCloud) {
+    // Bearer is only valid for a real OAuth 3LO access token, which has no
+    // associated email. Atlassian Cloud API tokens (the dashboard connect
+    // path) come with an email and require Basic base64(email:token) — Bearer
+    // 401s. Mirror the guard in handleJiraTest. Server/Data Center always
+    // uses Basic. See the cloud+email regression in jira.test.ts.
+    if (this.tokens?.isCloud && !this.tokens?.email) {
       return {
         Authorization: `Bearer ${token}`,
         Accept: "application/json",
       };
     } else {
-      // Server/Data Center uses Basic auth with email:token
+      // API token (cloud) or server/Data Center: Basic auth with email:token
       const email = this.tokens?.email ?? "api";
       const basic = Buffer.from(`${email}:${token}`).toString("base64");
       return {

--- a/src/connectors/notion.ts
+++ b/src/connectors/notion.ts
@@ -19,7 +19,11 @@ import {
   type ConnectorError,
   type ConnectorStatus,
 } from "./baseConnector.js";
-import { getSecretJsonSync, storeSecretJsonSync } from "./tokenStorage.js";
+import {
+  deleteSecretJsonSync,
+  getSecretJsonSync,
+  storeSecretJsonSync,
+} from "./tokenStorage.js";
 
 const NOTION_API = "https://api.notion.com/v1";
 const NOTION_VERSION = "2022-06-28";
@@ -135,6 +139,14 @@ export function saveTokens(tokens: NotionTokens): void {
 }
 
 export function clearTokens(): void {
+  // Primary: remove the token from secure storage (keychain or encrypted .enc).
+  // This is where saveTokens() actually persists the token.
+  try {
+    deleteSecretJsonSync("notion");
+  } catch {
+    /* ignore — best effort */
+  }
+  // Best-effort cleanup of any legacy plaintext token file.
   try {
     const p = path.join(homedir(), ".patchwork", "tokens", "notion.json");
     unlinkSync(p);

--- a/src/connectors/resend.ts
+++ b/src/connectors/resend.ts
@@ -515,7 +515,7 @@ export function getResendConnector(): ResendConnector {
 export { getResendConnector as resend };
 
 // ── HTTP Handlers ─────────────────────────────────────────────────────────────
-// Wired in src/server.ts under /connections/resend/*
+// Wired in src/connectorRoutes.ts under /connections/resend/*
 
 export interface ConnectorHandlerResult {
   status: number;

--- a/src/drivers/local/index.ts
+++ b/src/drivers/local/index.ts
@@ -1,91 +1,10 @@
+import { isLoopbackOrPrivateEndpoint } from "../../localEndpointGuard.js";
 import { OpenAIApiDriver } from "../openai/index.js";
 
-/**
- * Reject any LOCAL_ENDPOINT that doesn't resolve to loopback or RFC1918
- * private space. The local driver streams the user prompt + context-file
- * paths to whatever URL is set; if a malicious recipe (or a user pasting
- * a phishy "free local LLM" link) sets `LOCAL_ENDPOINT=https://attacker/v1`,
- * everything the local driver receives gets exfiltrated.
- *
- * Rule: hostname must be one of
- *   - localhost / 127.0.0.1 / ::1
- *   - RFC1918 private space (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16)
- *   - link-local (169.254.0.0/16, fe80::/10)
- *   - .local mDNS / .lan / .home / .internal suffixes
- *
- * To opt out (e.g. authorized remote inference cluster), the operator can
- * set LOCAL_ENDPOINT_ALLOW_REMOTE=1 — explicit override, audited via env.
- */
-export function isLoopbackOrPrivateEndpoint(rawUrl: string): boolean {
-  let host: string;
-  let wasBracketed = false;
-  try {
-    host = new URL(rawUrl).hostname.toLowerCase();
-  } catch {
-    return false;
-  }
-  if (!host) return false;
-  // Strip IPv6 brackets if any
-  if (host.startsWith("[") && host.endsWith("]")) {
-    host = host.slice(1, -1);
-    wasBracketed = true;
-  }
-  if (host === "localhost" || host === "127.0.0.1" || host === "::1") {
-    return true;
-  }
-  // IPv4 RFC1918 + link-local + 127/8 (check first — strict literal match)
-  const v4 = host.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
-  if (v4) {
-    const a = Number(v4[1]);
-    const b = Number(v4[2]);
-    if (a === 10) return true;
-    if (a === 127) return true;
-    if (a === 169 && b === 254) return true;
-    if (a === 172 && b >= 16 && b <= 31) return true;
-    if (a === 192 && b === 168) return true;
-    return false;
-  }
-  // IPv6 ranges — only when the input looked like an IPv6 literal (was
-  // bracketed in the URL, or matches an IPv6 syntactic shape). Without this
-  // gate, a hostname like `fc-services.example.com` or `fe8a-test` would
-  // match the legacy `startsWith("fc")` / `startsWith("fe8")` checks and
-  // bypass the validator. RFC3986 allows IPv6 literals only inside `[…]`,
-  // so requiring the brackets is the conservative path.
-  if (wasBracketed || /^[0-9a-f:]+$/.test(host)) {
-    if (
-      host.startsWith("fe8") ||
-      host.startsWith("fe9") ||
-      host.startsWith("fea") ||
-      host.startsWith("feb")
-    ) {
-      return true; // link-local fe80::/10
-    }
-    if (host.startsWith("fc") || host.startsWith("fd")) {
-      return true; // unique-local fc00::/7
-    }
-  }
-  // mDNS / common LAN suffixes — checked LAST and require a leading dot
-  // boundary so attacker-registered public domains like `evil.com.local`
-  // don't slip through (`.local` and `.lan` are not reserved TLDs at the
-  // DNS resolver level — only RFC6762 reserves them for mDNS, but public
-  // resolvers will happily look them up).
-  //
-  // The trade-off: a host literally named `printer.local` (single label
-  // before `.local`) is the legitimate mDNS form and matches; a host like
-  // `evil.com.local` (two-or-more labels before `.local`) is only the
-  // mDNS form by accident and is the bypass we're rejecting.
-  for (const suffix of [".local", ".lan", ".home", ".internal"]) {
-    if (host.endsWith(suffix)) {
-      const labels = host.split(".");
-      // 2 labels exactly: `<name>.local` — legitimate mDNS shape.
-      if (labels.length === 2) return true;
-      // More labels: ambiguous — refuse by default. Operator can opt out
-      // via LOCAL_ENDPOINT_ALLOW_REMOTE for legitimate multi-label
-      // internal DNS zones (e.g. `service.team.internal`).
-    }
-  }
-  return false;
-}
+// Re-export so existing importers (`import { isLoopbackOrPrivateEndpoint }
+// from ".../drivers/local/index.js"`) keep working after the predicate moved
+// to the shared `src/localEndpointGuard.ts` module.
+export { isLoopbackOrPrivateEndpoint };
 
 /**
  * Local LLM driver — Ollama, LM Studio, vLLM, llama.cpp server, and most

--- a/src/index.ts
+++ b/src/index.ts
@@ -1744,6 +1744,8 @@ if (process.argv[2] === "traces" && process.argv[3] === "export") {
       let output: string | undefined;
       let patchworkDir: string | undefined;
       let activityDir: string | undefined;
+      let mode: "public" | "keyed" | undefined;
+      let passphrase: string | undefined;
       for (let i = 0; i < args.length; i++) {
         const a = args[i];
         if (a === "--output" || a === "-o") {
@@ -1755,11 +1757,31 @@ if (process.argv[2] === "traces" && process.argv[3] === "export") {
         } else if (a === "--activity-dir") {
           activityDir = args[i + 1];
           i++;
+        } else if (a === "--mode") {
+          const m = args[i + 1];
+          if (m !== "public" && m !== "keyed") {
+            process.stderr.write(
+              `Error: --mode must be "public" or "keyed" (got: ${m})\n`,
+            );
+            process.exit(1);
+          }
+          mode = m;
+          i++;
+        } else if (a === "--passphrase") {
+          passphrase = args[i + 1];
+          i++;
         } else if (a === "--help" || a === "-h") {
           process.stdout.write(
-            "patchwork traces export [--output <path>] [--patchwork-dir <dir>] [--activity-dir <dir>]\n\n" +
+            "patchwork traces export [--output <path>] [--mode public|keyed]\n" +
+              "                        [--passphrase <phrase>]\n" +
+              "                        [--patchwork-dir <dir>] [--activity-dir <dir>]\n\n" +
               "Bundles ~/.patchwork/{runs,decision_traces,commit_issue_links}.jsonl\n" +
               "and ~/.claude/ide/activity-*.jsonl into a single gzipped JSONL file.\n\n" +
+              "Modes:\n" +
+              "  public  (default) Plain gzip bundle (.jsonl.gz). Anyone with the file\n" +
+              "          can read it.\n" +
+              "  keyed   AES-256-GCM encrypted bundle (.enc). Requires --passphrase;\n" +
+              "          auto-detected and decrypted by `traces import --passphrase`.\n\n" +
               "Output is a manifest line followed by one envelope per row:\n" +
               '  {"type":"manifest", ...}\n' +
               '  {"source":"runs", "entry":{...}}\n' +
@@ -1770,11 +1792,19 @@ if (process.argv[2] === "traces" && process.argv[3] === "export") {
           process.exit(0);
         }
       }
+      if (mode === "keyed" && !passphrase) {
+        process.stderr.write(
+          "Error: --mode keyed requires --passphrase <phrase>\n",
+        );
+        process.exit(1);
+      }
       const { runTracesExport } = await import("./commands/tracesExport.js");
       const result = await runTracesExport({
         ...(output !== undefined && { output }),
         ...(patchworkDir !== undefined && { patchworkDir }),
         ...(activityDir !== undefined && { activityDir }),
+        ...(mode !== undefined && { mode }),
+        ...(passphrase !== undefined && { passphrase }),
       });
       process.stdout.write(`  ✓ Wrote ${result.outputPath}\n`);
       process.stdout.write(

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,6 +51,11 @@ import { fileURLToPath } from "node:url";
 import { getAnalyticsPref, setAnalyticsPref } from "./analyticsPrefs.js";
 import { Bridge } from "./bridge.js";
 import {
+  type BridgeLockInfo,
+  findAllLiveBridges,
+  findBridgeLock,
+} from "./bridgeLockDiscovery.js";
+import {
   isBridgeToolsFileValid,
   repairBridgeToolsRulesIfStale,
 } from "./bridgeToolsRules.js";
@@ -618,57 +623,40 @@ Options:
     "ide",
   );
 
-  let lockFile: string | undefined;
-
+  // Select a *running bridge* lock (isBridge:true + live PID) rather than the
+  // most-recently-touched lock in ~/.claude/ide, which can be an IDE-owned
+  // lock or a dead bridge.
+  let bridgeLock: BridgeLockInfo | null;
   if (portArg) {
-    lockFile = path.join(lockDir, `${portArg}.lock`);
-    if (!existsSync(lockFile)) {
+    const port = Number(portArg);
+    bridgeLock = findAllLiveBridges().find((b) => b.port === port) ?? null;
+    if (!bridgeLock) {
       process.stderr.write(
-        `Error: No lock file found for port ${portArg} at ${lockFile}\n`,
+        `Error: No running bridge found for port ${portArg} (no lock file for that port, the lock is IDE-owned, or its process is not alive).\n`,
       );
       process.exit(1);
     }
   } else {
-    // Find the most recently modified lock file
-    let bestMtime = 0;
-    try {
-      for (const f of readdirSync(lockDir)) {
-        if (!f.endsWith(".lock")) continue;
-        const full = path.join(lockDir, f);
-        const mtime = statSync(full).mtimeMs;
-        if (mtime > bestMtime) {
-          bestMtime = mtime;
-          lockFile = full;
-        }
-      }
-    } catch {
-      // lock dir doesn't exist — handled below
-    }
+    bridgeLock = findBridgeLock();
   }
 
-  if (!lockFile) {
-    process.stderr.write(`Error: No bridge lock file found in ${lockDir}\n`);
+  if (!bridgeLock) {
+    process.stderr.write(
+      `Error: No running bridge lock file found in ${lockDir}\n`,
+    );
     process.stderr.write(
       "Make sure the bridge is running first, or pass --port <port>.\n",
     );
     process.exit(1);
   }
 
-  try {
-    const data = JSON.parse(readFileSync(lockFile, "utf-8")) as {
-      authToken?: string;
-    };
-    if (!data.authToken) {
-      process.stderr.write(
-        `Error: Lock file ${lockFile} has no authToken field\n`,
-      );
-      process.exit(1);
-    }
-    process.stdout.write(`${data.authToken}\n`);
-  } catch {
-    process.stderr.write(`Error: Could not read lock file ${lockFile}\n`);
+  if (!bridgeLock.authToken) {
+    process.stderr.write(
+      `Error: Bridge lock for port ${bridgeLock.port} has no authToken field\n`,
+    );
     process.exit(1);
   }
+  process.stdout.write(`${bridgeLock.authToken}\n`);
   process.exit(0);
 }
 
@@ -710,58 +698,37 @@ if (process.argv[2] === "notify") {
     "ide",
   );
 
-  let notifyLockFile: string | undefined;
+  // Select a *running bridge* lock (isBridge:true + live PID) rather than the
+  // most-recently-touched lock, which can be an IDE-owned or dead-bridge lock.
   let notifyPort: number | undefined;
+  let notifyToken: string | undefined;
 
   if (namedArgs.port) {
-    notifyPort = Number(namedArgs.port);
-    notifyLockFile = path.join(notifyLockDir, `${notifyPort}.lock`);
-    if (!existsSync(notifyLockFile)) {
+    const port = Number(namedArgs.port);
+    const lock = findAllLiveBridges().find((b) => b.port === port);
+    if (!lock) {
       process.stderr.write(
-        `Error: No lock file found for port ${notifyPort}\n`,
+        `Error: No running bridge found for port ${namedArgs.port} (no lock for that port, the lock is IDE-owned, or its process is not alive).\n`,
       );
       process.exit(1);
     }
+    notifyPort = lock.port;
+    notifyToken = lock.authToken;
   } else {
-    let bestMtime = 0;
-    try {
-      for (const f of readdirSync(notifyLockDir)) {
-        if (!f.endsWith(".lock")) continue;
-        const full = path.join(notifyLockDir, f);
-        const mtime = statSync(full).mtimeMs;
-        if (mtime > bestMtime) {
-          bestMtime = mtime;
-          notifyLockFile = full;
-          notifyPort = Number(path.basename(f, ".lock"));
-        }
-      }
-    } catch {
-      // lock dir doesn't exist
+    const lock = findBridgeLock();
+    if (lock) {
+      notifyPort = lock.port;
+      notifyToken = lock.authToken;
     }
   }
 
-  if (!notifyLockFile || !notifyPort) {
+  if (!notifyPort || !notifyToken) {
     process.stderr.write(
-      `Error: No bridge lock file found in ${notifyLockDir}\n`,
+      `Error: No running bridge lock file found in ${notifyLockDir}\n`,
     );
     process.stderr.write(
       "Make sure the bridge is running first (claude-ide-bridge --watch ...).\n",
     );
-    process.exit(1);
-  }
-
-  let notifyToken: string;
-  try {
-    const data = JSON.parse(readFileSync(notifyLockFile, "utf-8")) as {
-      authToken?: string;
-    };
-    if (!data.authToken) {
-      process.stderr.write(`Error: Lock file has no authToken field\n`);
-      process.exit(1);
-    }
-    notifyToken = data.authToken;
-  } catch {
-    process.stderr.write(`Error: Could not read lock file ${notifyLockFile}\n`);
     process.exit(1);
   }
 

--- a/src/localEndpointGuard.ts
+++ b/src/localEndpointGuard.ts
@@ -1,0 +1,94 @@
+/**
+ * Shared anti-SSRF guard for the "local" model driver / adapter.
+ *
+ * The local driver streams the user prompt + context-file paths to whatever
+ * URL is configured as the local endpoint. If a malicious recipe (or a user
+ * pasting a phishy "free local LLM" link) sets the endpoint to
+ * `https://attacker/v1`, everything the local driver receives gets
+ * exfiltrated.
+ *
+ * Two call sites share this predicate:
+ *   - `LocalApiDriver` (src/drivers/local/index.ts) — env-var `LOCAL_ENDPOINT`.
+ *   - `defaultLocalFn` (src/recipes/yamlRunner.ts) — dashboard/config-controlled
+ *     `localEndpoint` for `driver: local` recipe agent steps.
+ *
+ * Rule: hostname must be one of
+ *   - localhost / 127.0.0.1 / ::1
+ *   - RFC1918 private space (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16)
+ *   - link-local (169.254.0.0/16, fe80::/10)
+ *   - unique-local IPv6 (fc00::/7)
+ *   - .local mDNS / .lan / .home / .internal suffixes (single-label form only)
+ *
+ * To opt out (e.g. authorized remote inference cluster), the operator can
+ * set LOCAL_ENDPOINT_ALLOW_REMOTE=1 — explicit override, audited via env.
+ */
+export function isLoopbackOrPrivateEndpoint(rawUrl: string): boolean {
+  let host: string;
+  let wasBracketed = false;
+  try {
+    host = new URL(rawUrl).hostname.toLowerCase();
+  } catch {
+    return false;
+  }
+  if (!host) return false;
+  // Strip IPv6 brackets if any
+  if (host.startsWith("[") && host.endsWith("]")) {
+    host = host.slice(1, -1);
+    wasBracketed = true;
+  }
+  if (host === "localhost" || host === "127.0.0.1" || host === "::1") {
+    return true;
+  }
+  // IPv4 RFC1918 + link-local + 127/8 (check first — strict literal match)
+  const v4 = host.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
+  if (v4) {
+    const a = Number(v4[1]);
+    const b = Number(v4[2]);
+    if (a === 10) return true;
+    if (a === 127) return true;
+    if (a === 169 && b === 254) return true;
+    if (a === 172 && b >= 16 && b <= 31) return true;
+    if (a === 192 && b === 168) return true;
+    return false;
+  }
+  // IPv6 ranges — only when the input looked like an IPv6 literal (was
+  // bracketed in the URL, or matches an IPv6 syntactic shape). Without this
+  // gate, a hostname like `fc-services.example.com` or `fe8a-test` would
+  // match the legacy `startsWith("fc")` / `startsWith("fe8")` checks and
+  // bypass the validator. RFC3986 allows IPv6 literals only inside `[…]`,
+  // so requiring the brackets is the conservative path.
+  if (wasBracketed || /^[0-9a-f:]+$/.test(host)) {
+    if (
+      host.startsWith("fe8") ||
+      host.startsWith("fe9") ||
+      host.startsWith("fea") ||
+      host.startsWith("feb")
+    ) {
+      return true; // link-local fe80::/10
+    }
+    if (host.startsWith("fc") || host.startsWith("fd")) {
+      return true; // unique-local fc00::/7
+    }
+  }
+  // mDNS / common LAN suffixes — checked LAST and require a leading dot
+  // boundary so attacker-registered public domains like `evil.com.local`
+  // don't slip through (`.local` and `.lan` are not reserved TLDs at the
+  // DNS resolver level — only RFC6762 reserves them for mDNS, but public
+  // resolvers will happily look them up).
+  //
+  // The trade-off: a host literally named `printer.local` (single label
+  // before `.local`) is the legitimate mDNS form and matches; a host like
+  // `evil.com.local` (two-or-more labels before `.local`) is only the
+  // mDNS form by accident and is the bypass we're rejecting.
+  for (const suffix of [".local", ".lan", ".home", ".internal"]) {
+    if (host.endsWith(suffix)) {
+      const labels = host.split(".");
+      // 2 labels exactly: `<name>.local` — legitimate mDNS shape.
+      if (labels.length === 2) return true;
+      // More labels: ambiguous — refuse by default. Operator can opt out
+      // via LOCAL_ENDPOINT_ALLOW_REMOTE for legitimate multi-label
+      // internal DNS zones (e.g. `service.team.internal`).
+    }
+  }
+  return false;
+}

--- a/src/orchestrator/__tests__/childBridgeClient.test.ts
+++ b/src/orchestrator/__tests__/childBridgeClient.test.ts
@@ -300,3 +300,109 @@ describe("ChildBridgeClient 404 session-expiry recovery", () => {
     );
   });
 });
+
+// ── isError / structuredContent passthrough (ADR-0004) ────────────────────────
+
+describe("ChildBridgeClient isError passthrough", () => {
+  let server: http.Server;
+  let client: ChildBridgeClient;
+
+  afterEach(async () => {
+    client.destroy();
+    await closeServer(server);
+  });
+
+  it("propagates isError:true and structuredContent from the child tool result", async () => {
+    ({ server } = await startMockBridge((req, res) => {
+      const chunks: Buffer[] = [];
+      req.on("data", (c: Buffer) => chunks.push(c));
+      req.on("end", () => {
+        const body = JSON.parse(
+          Buffer.concat(chunks).toString("utf-8"),
+        ) as Record<string, unknown>;
+        const id = body.id;
+
+        if (body.method === "initialize") {
+          res.setHeader("mcp-session-id", "sess-err");
+          res.writeHead(200, { "content-type": "application/json" }).end(
+            JSON.stringify({
+              jsonrpc: "2.0",
+              id,
+              result: { protocolVersion: "2025-11-25", capabilities: {} },
+            }),
+          );
+        } else if (body.method === "notifications/initialized") {
+          res.writeHead(204).end();
+        } else if (body.method === "tools/call") {
+          // Child signals a tool-level failure per ADR-0004: isError:true in result.
+          res.writeHead(200, { "content-type": "application/json" }).end(
+            JSON.stringify({
+              jsonrpc: "2.0",
+              id,
+              result: {
+                content: [{ type: "text", text: "tool failed" }],
+                isError: true,
+                structuredContent: { code: "BOOM", detail: 42 },
+              },
+            }),
+          );
+        } else {
+          res.writeHead(200).end("{}");
+        }
+      });
+    }));
+
+    const { port } = server.address() as { port: number };
+    client = new ChildBridgeClient(port, AUTH_TOKEN);
+
+    const result = await client.callTool("myTool", {});
+    // Must NOT throw — isError is a tool-level signal carried in the result.
+    expect(result.content[0]?.text).toBe("tool failed");
+    expect(result.isError).toBe(true);
+    expect(result.structuredContent).toEqual({ code: "BOOM", detail: 42 });
+  });
+
+  it("leaves isError undefined for a normal successful result", async () => {
+    ({ server } = await startMockBridge((req, res) => {
+      const chunks: Buffer[] = [];
+      req.on("data", (c: Buffer) => chunks.push(c));
+      req.on("end", () => {
+        const body = JSON.parse(
+          Buffer.concat(chunks).toString("utf-8"),
+        ) as Record<string, unknown>;
+        const id = body.id;
+
+        if (body.method === "initialize") {
+          res.setHeader("mcp-session-id", "sess-ok");
+          res.writeHead(200, { "content-type": "application/json" }).end(
+            JSON.stringify({
+              jsonrpc: "2.0",
+              id,
+              result: { protocolVersion: "2025-11-25", capabilities: {} },
+            }),
+          );
+        } else if (body.method === "notifications/initialized") {
+          res.writeHead(204).end();
+        } else if (body.method === "tools/call") {
+          res.writeHead(200, { "content-type": "application/json" }).end(
+            JSON.stringify({
+              jsonrpc: "2.0",
+              id,
+              result: { content: [{ type: "text", text: "ok" }] },
+            }),
+          );
+        } else {
+          res.writeHead(200).end("{}");
+        }
+      });
+    }));
+
+    const { port } = server.address() as { port: number };
+    client = new ChildBridgeClient(port, AUTH_TOKEN);
+
+    const result = await client.callTool("myTool", {});
+    expect(result.content[0]?.text).toBe("ok");
+    expect(result.isError).toBeUndefined();
+    expect(result.structuredContent).toBeUndefined();
+  });
+});

--- a/src/orchestrator/__tests__/orchestratorBridge.integration.test.ts
+++ b/src/orchestrator/__tests__/orchestratorBridge.integration.test.ts
@@ -870,6 +870,104 @@ describe("OrchestratorBridge lazy tool exposure: switchWorkspace swaps tool list
   });
 });
 
+// ── reconcileClients: leak + stale-token guard ───────────────────────────────
+
+describe("OrchestratorBridge.reconcileClients", () => {
+  interface FakeClient {
+    port: number;
+    token: string;
+    destroyed: boolean;
+    destroy(): void;
+  }
+
+  function makeFakeClient(port: number, token: string): FakeClient {
+    return {
+      port,
+      token,
+      destroyed: false,
+      destroy() {
+        this.destroyed = true;
+      },
+    };
+  }
+
+  function makeBridge(port: number, authToken: string) {
+    return { port, authToken } as { port: number; authToken: string };
+  }
+
+  it("destroys and removes clients whose port left the registry", () => {
+    const clientMap = new Map<number, FakeClient>();
+    const stale = makeFakeClient(4001, "tok-a");
+    const kept = makeFakeClient(4002, "tok-b");
+    clientMap.set(4001, stale);
+    clientMap.set(4002, kept);
+
+    const created: number[] = [];
+    OrchestratorBridge.reconcileClients(
+      clientMap as unknown as Map<number, ChildBridgeClient>,
+      [makeBridge(4002, "tok-b")], // 4001 disappeared
+      (port, token) => {
+        created.push(port);
+        return makeFakeClient(port, token) as unknown as ChildBridgeClient;
+      },
+    );
+
+    // Stale client destroyed + removed
+    expect(stale.destroyed).toBe(true);
+    expect(clientMap.has(4001)).toBe(false);
+    // Surviving client untouched
+    expect(kept.destroyed).toBe(false);
+    expect(clientMap.get(4002)).toBe(kept as unknown as ChildBridgeClient);
+    // No recreation for the unchanged-token survivor
+    expect(created).toEqual([]);
+  });
+
+  it("destroys and recreates a client whose authToken changed (PID/port reuse)", () => {
+    const clientMap = new Map<number, FakeClient>();
+    const old = makeFakeClient(5001, "old-token");
+    clientMap.set(5001, old);
+
+    const created: Array<{ port: number; token: string }> = [];
+    OrchestratorBridge.reconcileClients(
+      clientMap as unknown as Map<number, ChildBridgeClient>,
+      [makeBridge(5001, "new-token")], // same port, different token
+      (port, token) => {
+        created.push({ port, token });
+        return makeFakeClient(port, token) as unknown as ChildBridgeClient;
+      },
+    );
+
+    // Old stale-token client destroyed
+    expect(old.destroyed).toBe(true);
+    // Recreated with the new token
+    expect(created).toEqual([{ port: 5001, token: "new-token" }]);
+    const replacement = clientMap.get(5001) as unknown as FakeClient;
+    expect(replacement).toBeDefined();
+    expect(replacement.token).toBe("new-token");
+    expect(replacement.destroyed).toBe(false);
+  });
+
+  it("leaves a client untouched when port and token are unchanged", () => {
+    const clientMap = new Map<number, FakeClient>();
+    const client = makeFakeClient(6001, "tok");
+    clientMap.set(6001, client);
+
+    const created: number[] = [];
+    OrchestratorBridge.reconcileClients(
+      clientMap as unknown as Map<number, ChildBridgeClient>,
+      [makeBridge(6001, "tok")],
+      (port, token) => {
+        created.push(port);
+        return makeFakeClient(port, token) as unknown as ChildBridgeClient;
+      },
+    );
+
+    expect(client.destroyed).toBe(false);
+    expect(clientMap.get(6001)).toBe(client as unknown as ChildBridgeClient);
+    expect(created).toEqual([]);
+  });
+});
+
 /**
  * Spin up a child bridge that serves a custom tool list (no echo fallback).
  */

--- a/src/orchestrator/childBridgeClient.ts
+++ b/src/orchestrator/childBridgeClient.ts
@@ -30,6 +30,12 @@ export class ChildBridgeClient {
     });
   }
 
+  /** The authToken this client was constructed with. Used by the orchestrator
+   *  to detect PID/port reuse with a rotated token and recreate the client. */
+  get token(): string {
+    return this.authToken;
+  }
+
   get isHealthy(): boolean {
     if (this.circuitState === "open") {
       if (Date.now() - this.circuitOpenedAt >= CIRCUIT_RESET_MS) {
@@ -116,7 +122,11 @@ export class ChildBridgeClient {
     name: string,
     args: Record<string, unknown>,
     signal?: AbortSignal,
-  ): Promise<{ content: Array<{ type: string; text: string }> }> {
+  ): Promise<{
+    content: Array<{ type: string; text: string }>;
+    isError?: boolean;
+    structuredContent?: unknown;
+  }> {
     if (!this.isHealthy) {
       throw bridgeUnavailableError(this.port, "circuit open");
     }
@@ -168,6 +178,7 @@ export class ChildBridgeClient {
         result?: {
           content?: Array<{ type: string; text: string }>;
           isError?: boolean;
+          structuredContent?: unknown;
         };
         error?: { code: number; message: string; data?: unknown };
       };
@@ -182,8 +193,18 @@ export class ChildBridgeClient {
       }
 
       this.onSuccess();
+      // Per ADR-0004, child bridges signal tool-level failures with
+      // `isError: true` in the result (NOT a JSON-RPC error). Propagate it —
+      // and any structuredContent — so a failed child tool call is not
+      // misreported to the MCP client as a success.
       return {
         content: json.result?.content ?? [{ type: "text", text: "" }],
+        ...(json.result?.isError !== undefined
+          ? { isError: json.result.isError }
+          : {}),
+        ...(json.result?.structuredContent !== undefined
+          ? { structuredContent: json.result.structuredContent }
+          : {}),
       };
     } catch (err) {
       if ((err as { bridgeError?: unknown }).bridgeError) throw err;

--- a/src/orchestrator/orchestratorBridge.ts
+++ b/src/orchestrator/orchestratorBridge.ts
@@ -109,8 +109,57 @@ export class OrchestratorBridge {
     );
   }
 
+  /**
+   * Reconcile a client map against the current registry bridges.
+   *
+   * Two leaks/correctness hazards are closed here:
+   *  1. Leaked clients — when a child's lock disappears, the registry drops it
+   *     but its ChildBridgeClient (with live keepAlive http.Agent sockets)
+   *     would otherwise linger in `clients` forever. Destroy + remove it.
+   *  2. Stale-token reuse — on PID/port reuse a child re-appears on the same
+   *     port with a NEW authToken. The cached client still holds the old token
+   *     and would authenticate wrong → the bridge is marked unhealthy forever.
+   *     Destroy + recreate the client with the fresh token.
+   *
+   * Static + dependency-injected (createClient factory) so it can be unit
+   * tested without standing up an OrchestratorBridge.
+   */
+  static reconcileClients(
+    clients: Map<number, ChildBridgeClient>,
+    bridges: Array<{ port: number; authToken: string }>,
+    createClient: (port: number, authToken: string) => ChildBridgeClient,
+  ): void {
+    const livePorts = new Set(bridges.map((b) => b.port));
+
+    // (1) Drop clients whose port left the registry.
+    for (const [port, client] of clients) {
+      if (!livePorts.has(port)) {
+        client.destroy();
+        clients.delete(port);
+      }
+    }
+
+    // (2) Recreate clients whose authToken changed (PID/port reuse).
+    for (const b of bridges) {
+      const existing = clients.get(b.port);
+      if (existing && existing.token !== b.authToken) {
+        existing.destroy();
+        clients.set(b.port, createClient(b.port, b.authToken));
+      }
+    }
+  }
+
   private async probeAll(): Promise<void> {
     const bridges = this.registry.getAll();
+
+    // Reconcile clients before probing: drop leaked clients for vanished
+    // bridges and recreate any whose authToken changed under PID/port reuse.
+    OrchestratorBridge.reconcileClients(
+      this.clients,
+      bridges,
+      (port, authToken) => new ChildBridgeClient(port, authToken),
+    );
+
     await Promise.all(
       bridges.map(async (b) => {
         let client = this.clients.get(b.port);
@@ -358,7 +407,11 @@ export class OrchestratorBridge {
     session: OrchestratorSession | null,
     signal?: AbortSignal,
     preferredPort?: number,
-  ): Promise<{ content: Array<{ type: string; text: string }> }> {
+  ): Promise<{
+    content: Array<{ type: string; text: string }>;
+    isError?: boolean;
+    structuredContent?: unknown;
+  }> {
     // Determine target bridge
     let targetPort = preferredPort ?? session?.stickyBridgePort ?? null;
 

--- a/src/recipes/__tests__/chainedRunner.test.ts
+++ b/src/recipes/__tests__/chainedRunner.test.ts
@@ -566,6 +566,24 @@ describe("runChainedRecipe", () => {
     expect(result.success).toBe(false);
     expect(result.errorMessage).toMatch(/circular/);
   });
+
+  // Regression: a step awaiting a non-existent target was silently dropped
+  // from the topological order (it AND its dependents never ran), but the
+  // run still reported success:true / failed:0. The runner must now reject
+  // the run with success:false and a descriptive error.
+  it("rejects a recipe whose awaits target does not exist", async () => {
+    const recipe: ChainedRecipe = {
+      name: "r",
+      steps: [
+        { id: "a", tool: "t" },
+        { id: "b", tool: "t", awaits: ["ghost"] },
+      ],
+    };
+    const result = await runChainedRecipe(recipe, baseOptions, noopDeps);
+    expect(result.success).toBe(false);
+    expect(result.errorMessage).toMatch(/ghost/);
+    expect(result.errorMessage).toMatch(/await/i);
+  });
 });
 
 describe("generateExecutionPlan", () => {

--- a/src/recipes/__tests__/compiler.test.ts
+++ b/src/recipes/__tests__/compiler.test.ts
@@ -165,6 +165,42 @@ describe("compileRecipe", () => {
     expect(compileRecipeFull(r).suggestedPermissions.allow).toEqual(["Read"]);
   });
 
+  // Regression: bucketForRisk returned 'allow' for EVERY value other than
+  // 'high'/'medium' — including typos like 'hgh'. That fails OPEN and
+  // defeats the documented "never auto-allow high-risk" guarantee. The
+  // fix makes it fail CLOSED: only 'low'/undefined → allow.
+  describe("bucketForRisk fails closed on unknown risk values", () => {
+    it("does NOT auto-allow a typo'd high risk ('hgh') — routes to ask", () => {
+      const r: Recipe = {
+        ...BASE,
+        steps: [
+          {
+            id: "danger",
+            agent: false,
+            tool: "Bash(rm -rf /)",
+            params: {},
+            risk: "hgh" as unknown as Recipe["steps"][number]["risk"],
+          },
+        ],
+      };
+      const result = compileRecipeFull(r);
+      expect(result.suggestedPermissions.allow).not.toContain("Bash(rm -rf /)");
+      expect(result.suggestedPermissions.ask).toContain("Bash(rm -rf /)");
+    });
+
+    it("still allows explicit low risk and undefined risk", () => {
+      const r: Recipe = {
+        ...BASE,
+        steps: [
+          { id: "a", agent: false, tool: "Read", params: {}, risk: "low" },
+          { id: "b", agent: false, tool: "Grep", params: {} },
+        ],
+      };
+      const result = compileRecipeFull(r);
+      expect(result.suggestedPermissions.allow).toEqual(["Grep", "Read"]);
+    });
+  });
+
   it("rejects cron + manual triggers", () => {
     expect(() =>
       compileRecipe({

--- a/src/recipes/__tests__/dependencyGraph.test.ts
+++ b/src/recipes/__tests__/dependencyGraph.test.ts
@@ -62,6 +62,40 @@ describe("buildDependencyGraph", () => {
     expect(order.indexOf("b")).toBeLessThan(order.indexOf("d"));
     expect(order.indexOf("c")).toBeLessThan(order.indexOf("d"));
   });
+
+  // Regression: a phantom `awaits:` target (one matching no real step) is
+  // skipped by the cycle-detection DFS (so hasCycles stays false) but is
+  // counted in Kahn's inDegree and never decremented — so the step that
+  // awaits it AND all its transitive dependents drop out of
+  // topologicalOrder silently and never run, while the run reports success.
+  describe("unknown awaits targets", () => {
+    it("reports unknownAwaitTargets when an awaits target does not exist", () => {
+      const g = buildDependencyGraph([
+        { id: "a" },
+        { id: "b", awaits: ["ghost"] },
+      ]);
+      expect(g.unknownAwaitTargets).toContain("ghost");
+    });
+
+    it("does NOT silently drop the awaiting step from topologicalOrder", () => {
+      // Before the fix `b` (inDegree 1, never decremented) was dropped.
+      const g = buildDependencyGraph([
+        { id: "a" },
+        { id: "b", awaits: ["ghost"] },
+        { id: "c", awaits: ["b"] },
+      ]);
+      // The graph is invalid (caller rejects the run), but the order must
+      // still include every declared step so the failure is visible rather
+      // than masquerading as a silent skip.
+      expect(g.topologicalOrder).toContain("b");
+      expect(g.topologicalOrder).toContain("c");
+    });
+
+    it("leaves unknownAwaitTargets empty for a valid graph", () => {
+      const g = buildDependencyGraph([{ id: "a" }, { id: "b", awaits: ["a"] }]);
+      expect(g.unknownAwaitTargets).toEqual([]);
+    });
+  });
 });
 
 describe("executeWithDependencies", () => {

--- a/src/recipes/__tests__/idempotencyKey.test.ts
+++ b/src/recipes/__tests__/idempotencyKey.test.ts
@@ -174,6 +174,81 @@ describe("WriteEffectLedger.getOrExecute", () => {
     expect(calls).toBe(2);
     expect(ledger.size()).toBe(1);
   });
+
+  it("does not cache a resolved {ok:false} result — retry re-executes", async () => {
+    // Connector write tools (e.g. asana.create_task) catch transient
+    // errors and RETURN `JSON.stringify({ok:false,error})` rather than
+    // throwing. A resolved {ok:false} must be treated as a failure: NOT
+    // cached, so the next retry re-executes instead of silently replaying
+    // the cached failure as a no-op.
+    const ledger = new WriteEffectLedger();
+    let calls = 0;
+    const fn = async () => {
+      calls++;
+      if (calls === 1) {
+        return JSON.stringify({ ok: false, error: "x" });
+      }
+      return JSON.stringify({ ok: true, id: "task_1" });
+    };
+
+    const first = await ledger.getOrExecute("k", fn);
+    expect(JSON.parse(first as string).ok).toBe(false);
+    // Failure must not have been cached.
+    expect(ledger.has("k")).toBe(false);
+    expect(ledger.size()).toBe(0);
+
+    // Retry: fn must run AGAIN (not serve the cached failure).
+    const second = await ledger.getOrExecute("k", fn);
+    expect(JSON.parse(second as string).ok).toBe(true);
+    expect(calls).toBe(2);
+    expect(ledger.has("k")).toBe(true);
+    expect(ledger.size()).toBe(1);
+  });
+
+  it("caches a genuine {ok:true} success — fn runs once", async () => {
+    const ledger = new WriteEffectLedger();
+    let calls = 0;
+    const fn = async () => {
+      calls++;
+      return JSON.stringify({ ok: true, id: "task_1" });
+    };
+    const first = await ledger.getOrExecute("k", fn);
+    const second = await ledger.getOrExecute("k", fn);
+    expect(first).toBe(second);
+    expect(calls).toBe(1);
+    expect(ledger.has("k")).toBe(true);
+  });
+
+  it("caches non-JSON string results (genuine successes) once", async () => {
+    // A bare string output (e.g. "Posted to #general") is a success, not
+    // a structured failure — JSON.parse throws (SyntaxError) and it must
+    // still cache as before.
+    const ledger = new WriteEffectLedger();
+    let calls = 0;
+    const fn = async () => {
+      calls++;
+      return "Posted to #general";
+    };
+    await ledger.getOrExecute("k", fn);
+    const second = await ledger.getOrExecute("k", fn);
+    expect(second).toBe("Posted to #general");
+    expect(calls).toBe(1);
+    expect(ledger.has("k")).toBe(true);
+  });
+
+  it("caches a null result (genuine success) once", async () => {
+    const ledger = new WriteEffectLedger();
+    let calls = 0;
+    const fn = async () => {
+      calls++;
+      return null;
+    };
+    await ledger.getOrExecute("k", fn);
+    const second = await ledger.getOrExecute("k", fn);
+    expect(second).toBeNull();
+    expect(calls).toBe(1);
+    expect(ledger.has("k")).toBe(true);
+  });
 });
 
 describe("WriteEffectLedger — disk-backed (PR5b)", () => {

--- a/src/recipes/__tests__/parser.test.ts
+++ b/src/recipes/__tests__/parser.test.ts
@@ -71,6 +71,38 @@ describe("parseRecipe", () => {
     }
   });
 
+  // Regression: parser.ts rejected `chained`, `on_file_save`, and
+  // `on_test_run` even though validateRecipeDefinition, the JSON schema,
+  // and the runtime (chainedRunner / dispatchRecipe / yamlRunner) all
+  // support them. A recipe that lints + runs could NOT be installed
+  // because the install path goes through parseRecipe.
+  describe("runtime trigger types accepted by parser (parity with validation/schema)", () => {
+    it("accepts a chained trigger", () => {
+      const r = parseRecipe({ ...VALID, trigger: { type: "chained" } });
+      expect(r.trigger.type).toBe("chained");
+    });
+
+    it("accepts an on_file_save trigger and preserves glob", () => {
+      const r = parseRecipe({
+        ...VALID,
+        trigger: { type: "on_file_save", glob: "**/*.ts" },
+      });
+      expect(r.trigger.type).toBe("on_file_save");
+      const serialized = JSON.parse(JSON.stringify(r));
+      expect(serialized.trigger.glob).toBe("**/*.ts");
+    });
+
+    it("accepts an on_test_run trigger and preserves filter", () => {
+      const r = parseRecipe({
+        ...VALID,
+        trigger: { type: "on_test_run", filter: "failure" },
+      });
+      expect(r.trigger.type).toBe("on_test_run");
+      const serialized = JSON.parse(JSON.stringify(r));
+      expect(serialized.trigger.filter).toBe("failure");
+    });
+  });
+
   // Regression: the marketplace install flow was broken because parser.ts
   // only accepted the legacy boolean discriminator (`agent: true | false`)
   // while the canonical schema, the runtime executor, every bundled

--- a/src/recipes/__tests__/recipeValidationConsistency.test.ts
+++ b/src/recipes/__tests__/recipeValidationConsistency.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Regression tests for recipe-validation consistency fixes:
+ *
+ *   Bug 2 — `risk` was never validated. The compiler bucketed unknown risk
+ *           values fail-OPEN (→ allow). `validateRecipeDefinition` now emits
+ *           an UNCONDITIONAL error for any risk outside low|medium|high,
+ *           not gated behind FLAG_SCHEMA_LINT.
+ *
+ *   Bug 3 — an `awaits:` target that matches no real step was silently
+ *           dropped from the topological order (the step AND its dependents
+ *           never ran, yet the run reported success). The static check now
+ *           flags unknown awaits targets at lint/doctor time.
+ */
+
+import { describe, expect, it } from "vitest";
+import { validateRecipeDefinition } from "../validation.js";
+
+const base = {
+  name: "consistency-test",
+  description: "test recipe",
+  trigger: { type: "manual" as const },
+  steps: [{ id: "s1", agent: { prompt: "hi" } }],
+};
+
+describe("risk enum validation (unconditional, not gated on FLAG_SCHEMA_LINT)", () => {
+  it("flags a typo'd risk value ('hgh') as an error", () => {
+    const result = validateRecipeDefinition({
+      ...base,
+      steps: [{ id: "s1", tool: "file.write", params: {}, risk: "hgh" }],
+    });
+    const errors = result.issues.filter((i) => i.level === "error");
+    expect(errors.some((e) => /risk/i.test(e.message))).toBe(true);
+    expect(result.valid).toBe(false);
+  });
+
+  it("accepts low | medium | high", () => {
+    for (const risk of ["low", "medium", "high"] as const) {
+      const result = validateRecipeDefinition({
+        ...base,
+        steps: [{ id: "s1", tool: "file.write", params: {}, risk }],
+      });
+      expect(
+        result.issues.filter(
+          (i) => i.level === "error" && /risk/i.test(i.message),
+        ),
+      ).toHaveLength(0);
+    }
+  });
+
+  it("reads risk from the nested agent object too", () => {
+    const result = validateRecipeDefinition({
+      ...base,
+      steps: [{ id: "s1", agent: { prompt: "hi", risk: "bogus" } }],
+    });
+    const errors = result.issues.filter(
+      (i) => i.level === "error" && /risk/i.test(i.message),
+    );
+    expect(errors.length).toBeGreaterThan(0);
+  });
+
+  it("does not flag steps without a risk field", () => {
+    const result = validateRecipeDefinition({
+      ...base,
+      steps: [{ id: "s1", tool: "file.write", params: {} }],
+    });
+    expect(
+      result.issues.filter(
+        (i) => i.level === "error" && /risk/i.test(i.message),
+      ),
+    ).toHaveLength(0);
+  });
+});
+
+describe("unknown awaits-target validation", () => {
+  it("flags an awaits target that matches no step id", () => {
+    const result = validateRecipeDefinition({
+      ...base,
+      trigger: { type: "chained" },
+      steps: [
+        { id: "a", tool: "file.read", params: {} },
+        { id: "b", tool: "file.write", params: {}, awaits: ["ghost"] },
+      ],
+    });
+    const errors = result.issues.filter((i) => i.level === "error");
+    expect(errors.some((e) => /awaits/i.test(e.message))).toBe(true);
+    expect(errors.some((e) => e.message.includes("ghost"))).toBe(true);
+    expect(result.valid).toBe(false);
+  });
+
+  it("does not flag a valid awaits chain", () => {
+    const result = validateRecipeDefinition({
+      ...base,
+      trigger: { type: "chained" },
+      steps: [
+        { id: "a", tool: "file.read", params: {} },
+        { id: "b", tool: "file.write", params: {}, awaits: ["a"] },
+      ],
+    });
+    expect(
+      result.issues.filter(
+        (i) => i.level === "error" && /awaits/i.test(i.message),
+      ),
+    ).toHaveLength(0);
+  });
+
+  // Regression: `awaits: [<parallel-group-id>]` is VALID at runtime —
+  // chainedRunner.expandParallelSteps rewrites a group-id await to the
+  // expanded child ids. But `flattenValidationSteps` hoists the children
+  // and DROPS the container id, so the naive (normalized-only) known-id
+  // collection produced a false positive on shipped templates
+  // (project-health-check.yaml, business-decision-brief.yaml). The fix
+  // also collects known ids from the RAW recipe steps.
+  it("does NOT flag a step that awaits a parallel-group container id", () => {
+    const result = validateRecipeDefinition({
+      ...base,
+      trigger: { type: "chained" },
+      steps: [
+        {
+          id: "gather",
+          parallel: [
+            { id: "commits", tool: "git.log_since" },
+            { id: "issues", tool: "github.list_issues" },
+          ],
+        },
+        { id: "summarize", agent: { prompt: "x" }, awaits: ["gather"] },
+      ],
+    });
+    expect(
+      result.issues.filter(
+        (i) => i.level === "error" && /awaits/i.test(i.message),
+      ),
+    ).toHaveLength(0);
+  });
+
+  // …but a genuine typo of a group id (present in neither the raw nor the
+  // flattened step list) MUST still error — detection isn't weakened.
+  it("still flags a typo'd parallel-group id (gather2)", () => {
+    const result = validateRecipeDefinition({
+      ...base,
+      trigger: { type: "chained" },
+      steps: [
+        {
+          id: "gather",
+          parallel: [{ id: "commits", tool: "git.log_since" }],
+        },
+        { id: "summarize", agent: { prompt: "x" }, awaits: ["gather2"] },
+      ],
+    });
+    const errors = result.issues.filter(
+      (i) => i.level === "error" && /awaits/i.test(i.message),
+    );
+    expect(errors.some((e) => e.message.includes("gather2"))).toBe(true);
+  });
+});

--- a/src/recipes/chainedRunner.ts
+++ b/src/recipes/chainedRunner.ts
@@ -759,7 +759,19 @@ export async function runChainedRecipe(
     }
   }
 
-  if (depGraph.hasCycles) {
+  // A phantom `awaits:` target (one matching no real step) is invisible to
+  // cycle detection but would silently drop the awaiting step and its
+  // dependents from execution while the run still reports success. Reject
+  // the run with a descriptive error BEFORE executing any step, mirroring
+  // the circular-dependency guard below.
+  const fatalGraphError =
+    depGraph.unknownAwaitTargets.length > 0
+      ? `Recipe has steps that await unknown step(s): ${depGraph.unknownAwaitTargets.join(", ")}`
+      : depGraph.hasCycles
+        ? "Recipe has circular dependencies"
+        : undefined;
+
+  if (fatalGraphError) {
     if (depth === 0) {
       const doneAt = Date.now();
       const durationMs = doneAt - runStartedAt;
@@ -770,7 +782,7 @@ export async function runChainedRecipe(
             doneAt,
             durationMs,
             stepResults: [],
-            errorMessage: "Recipe has circular dependencies",
+            errorMessage: fatalGraphError,
           });
         } else if (options.runLogDir) {
           const { RecipeRunLog } = await import("../runLog.js");
@@ -784,7 +796,7 @@ export async function runChainedRecipe(
             startedAt: runStartedAt,
             doneAt,
             durationMs,
-            errorMessage: "Recipe has circular dependencies",
+            errorMessage: fatalGraphError,
             stepResults: [],
           });
         }
@@ -796,7 +808,7 @@ export async function runChainedRecipe(
       success: false,
       stepResults: new Map(),
       summary: { total: 0, succeeded: 0, failed: 0, skipped: 0 },
-      errorMessage: "Recipe has circular dependencies",
+      errorMessage: fatalGraphError,
       context: {},
     };
   }

--- a/src/recipes/compiler.ts
+++ b/src/recipes/compiler.ts
@@ -106,9 +106,14 @@ function normalizeToolString(raw: string): string {
 function bucketForRisk(
   risk: Recipe["steps"][number]["risk"],
 ): "allow" | "ask" | "deny" {
-  if (risk === "high") return "ask";
-  if (risk === "medium") return "ask";
-  return "allow";
+  // Fail CLOSED: only an explicit `low` (or no risk declared, i.e. the
+  // author trusts it) auto-allows. EVERY other value — `medium`, `high`,
+  // and any typo like `hgh` — routes to `ask`. The previous fall-through
+  // to `allow` defeated the documented "never auto-allow high-risk"
+  // guarantee for unrecognised values. `validateRecipeDefinition` flags
+  // out-of-enum risk values so authors see the typo at lint time.
+  if (risk === undefined || risk === "low") return "allow";
+  return "ask";
 }
 
 export function compileRecipe(recipe: Recipe): AutomationProgram {

--- a/src/recipes/dependencyGraph.ts
+++ b/src/recipes/dependencyGraph.ts
@@ -18,6 +18,15 @@ export interface DependencyGraph {
   steps: StepDependency[];
   hasCycles: boolean;
   topologicalOrder: string[];
+  /**
+   * `awaits:` targets that reference a step id that does not exist. A
+   * phantom target is skipped by cycle-detection (so `hasCycles` stays
+   * false) but, if counted in Kahn's in-degree, would silently drop the
+   * awaiting step and its dependents from `topologicalOrder` — they'd
+   * never run, yet the run would report success. Callers MUST reject the
+   * run when this is non-empty. Sorted + de-duplicated.
+   */
+  unknownAwaitTargets: string[];
 }
 
 export interface ExecutionOptions {
@@ -37,6 +46,19 @@ export function buildDependencyGraph(
     awaits: s.awaits ?? [],
     index,
   }));
+
+  // Collect every declared step id so we can tell a real dependency edge
+  // from a phantom one. A phantom `awaits:` target (no matching step) must
+  // NOT be counted as an in-degree edge — otherwise Kahn's algorithm never
+  // decrements it and silently drops the awaiting step + its dependents
+  // from the topological order while the run still reports success.
+  const knownStepIds = new Set(nodes.map((n) => n.stepId));
+  const unknownTargets = new Set<string>();
+  for (const node of nodes) {
+    for (const depId of node.awaits) {
+      if (!knownStepIds.has(depId)) unknownTargets.add(depId);
+    }
+  }
 
   // Detect cycles using DFS
   const visited = new Set<string>();
@@ -76,8 +98,11 @@ export function buildDependencyGraph(
   const adjacency = new Map<string, string[]>();
 
   for (const node of nodes) {
-    inDegree.set(node.stepId, node.awaits.length);
-    for (const dep of node.awaits) {
+    // Only count edges to REAL steps. Counting phantom targets here is the
+    // root cause of the silent-drop bug — see `unknownTargets` above.
+    const realAwaits = node.awaits.filter((dep) => knownStepIds.has(dep));
+    inDegree.set(node.stepId, realAwaits.length);
+    for (const dep of realAwaits) {
       if (!adjacency.has(dep)) adjacency.set(dep, []);
       adjacency.get(dep)?.push(node.stepId);
     }
@@ -106,6 +131,7 @@ export function buildDependencyGraph(
     steps: nodes,
     hasCycles: cycles.length > 0,
     topologicalOrder,
+    unknownAwaitTargets: [...unknownTargets].sort(),
   };
 }
 

--- a/src/recipes/idempotencyKey.ts
+++ b/src/recipes/idempotencyKey.ts
@@ -23,9 +23,14 @@
  *
  * Scope of this PR (deliberately narrow):
  *   - In-run dedup only (Map lives for one recipe run, discarded after).
- *   - Records only on successful execution; errors don't pollute the
+ *   - Records only on successful execution; failures don't pollute the
  *     ledger, so retry-after-failure still re-executes (correct: if the
- *     tool errored, we can't assume the side effect happened).
+ *     tool failed, we can't assume the side effect happened). A failure
+ *     is EITHER a thrown/rejected error OR a resolved JSON `{ok:false}`
+ *     envelope — connector write tools (e.g. asana.create_task) catch
+ *     transient errors and RETURN `JSON.stringify({ok:false, error})`
+ *     rather than throwing, and that return-value failure must also skip
+ *     the cache (see `isReturnValueFailure` + `getOrExecute`).
  *   - No cross-run persistence — that's PR5b (disk-backed effect ledger).
  *   - No retry-time idempotency on partial-failure cases (Slack posted
  *     but HTTP timed out); that needs tool-side support and is a future
@@ -224,6 +229,35 @@ function assertSafeLedgerDir(dir: string): void {
   }
 }
 
+/**
+ * Detect a tool result that reports failure by return value rather than
+ * by throwing. Connector write tools wrap transient errors as
+ * `JSON.stringify({ok:false, error})`; such a result must NOT be cached
+ * in the effect ledger (the side effect didn't happen, so retry should
+ * re-execute).
+ *
+ * Robustness: only a JSON object literal with an explicit `ok === false`
+ * counts as a failure. `null`, non-JSON strings (`JSON.parse` throws),
+ * JSON primitives/arrays, and objects without `ok === false` (e.g.
+ * `{ok:true}`) are all treated as genuine successes and cache normally.
+ */
+function isReturnValueFailure(result: string | null): boolean {
+  if (result === null) return false;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(result);
+  } catch {
+    // Non-JSON string output — a genuine success (e.g. "Posted to #x").
+    return false;
+  }
+  return (
+    typeof parsed === "object" &&
+    parsed !== null &&
+    !Array.isArray(parsed) &&
+    (parsed as Record<string, unknown>).ok === false
+  );
+}
+
 export class WriteEffectLedger {
   private readonly cache = new Map<string, string | null>();
   private readonly inFlight = new Map<string, Promise<string | null>>();
@@ -285,7 +319,22 @@ export class WriteEffectLedger {
    * Atomically check cache + in-flight map, then execute `fn` at most once
    * per key. Concurrent callers with the same key share a single Promise —
    * fixing the TOCTOU window that existed between `has()` and `record()`.
-   * Failures are not cached so retry-after-failure still re-executes.
+   *
+   * Failures are not cached so retry-after-failure still re-executes. A
+   * failure is EITHER a rejected promise OR a resolved result that is a
+   * JSON-encoded `{ok:false, ...}` envelope. The latter case matters:
+   * connector write tools (e.g. `asana.create_task`) catch transient
+   * errors internally and RETURN `JSON.stringify({ok:false, error})`
+   * rather than throwing. If we cached that, the next retry would replay
+   * the cached failure as a silent no-op instead of re-executing — which
+   * is the entire class of "write tools that report failure by return
+   * value". So we parse the resolved result and treat `ok === false` as a
+   * failure: drop the in-flight entry, return the result to THIS caller,
+   * but do NOT record it, so a subsequent retry runs `fn` again.
+   *
+   * Genuine successes still cache: non-JSON strings (`JSON.parse` throws
+   * SyntaxError), `null`, and any JSON value without `ok === false` (e.g.
+   * `{ok:true}`) are recorded as before.
    */
   getOrExecute(
     key: string,
@@ -298,8 +347,13 @@ export class WriteEffectLedger {
     if (existing) return existing;
     const work = fn().then(
       (result) => {
-        this.record(key, result);
         this.inFlight.delete(key);
+        // Don't cache return-value failures — a resolved {ok:false}
+        // envelope means the side effect did NOT happen, so retry must
+        // re-execute. Return the result to this caller without recording.
+        if (!isReturnValueFailure(result)) {
+          this.record(key, result);
+        }
         return result;
       },
       (err: unknown) => {

--- a/src/recipes/installer.ts
+++ b/src/recipes/installer.ts
@@ -101,10 +101,19 @@ export function installRecipeFromFile(
   // they fire via the CLI, RecipeScheduler, and POST /hooks/* endpoint
   // respectively. Synthesize an empty CompiledRecipe stub so the caller API
   // stays uniform; file_watch and git_hook still run through compile.
+  //
+  // `chained`, `on_file_save`, and `on_test_run` are runtime-only triggers
+  // (ChainedRecipeRunner / yamlRunner + the bridge's automation hooks) that
+  // the recipe→AutomationProgram compiler does not model. They must bypass
+  // compile too — otherwise mapTrigger() throws "unknown trigger type" and
+  // a recipe that lints + runs cannot be installed (the original bug).
   const bypassCompile =
     recipe.trigger.type === "manual" ||
     recipe.trigger.type === "cron" ||
-    recipe.trigger.type === "webhook";
+    recipe.trigger.type === "webhook" ||
+    recipe.trigger.type === "chained" ||
+    recipe.trigger.type === "on_file_save" ||
+    recipe.trigger.type === "on_test_run";
   const compiled: CompiledRecipe = bypassCompile
     ? {
         program: {

--- a/src/recipes/parser.ts
+++ b/src/recipes/parser.ts
@@ -125,6 +125,28 @@ function parseTrigger(raw: unknown): Trigger {
       return { type: "git_hook", event: t.event };
     case "manual":
       return { type: "manual" };
+    case "chained":
+      // Chained recipes route to the ChainedRecipeRunner (dispatchRecipe).
+      // No required trigger fields — step-level awaits/parallel/vars drive
+      // execution. Parity with validateRecipeDefinition + the JSON schema
+      // so a recipe that lints + runs can also be installed.
+      return { type: "chained" };
+    case "on_file_save":
+      // Runtime file-save trigger. `glob`/`filter` are optional; preserve
+      // them when present so the on-disk JSON round-trip keeps the author's
+      // intent.
+      return {
+        type: "on_file_save",
+        ...(typeof t.glob === "string" ? { glob: t.glob } : {}),
+        ...(typeof t.filter === "string" ? { filter: t.filter } : {}),
+      };
+    case "on_test_run":
+      // Runtime test-run trigger. `filter` ("any" | "failure" |
+      // "pass-after-fail") is optional; preserve when present.
+      return {
+        type: "on_test_run",
+        ...(typeof t.filter === "string" ? { filter: t.filter } : {}),
+      };
     default:
       throw new RecipeParseError(`unknown trigger type '${String(t.type)}'`, [
         "trigger",

--- a/src/recipes/schema.ts
+++ b/src/recipes/schema.ts
@@ -13,7 +13,10 @@ export type TriggerType =
   | "cron"
   | "file_watch"
   | "git_hook"
-  | "manual";
+  | "manual"
+  | "chained"
+  | "on_file_save"
+  | "on_test_run";
 
 export interface WebhookTrigger {
   type: "webhook";
@@ -35,12 +38,44 @@ export interface ManualTrigger {
   type: "manual";
 }
 
+/**
+ * `chained` recipes route to the ChainedRecipeRunner (dispatchRecipe in
+ * yamlRunner.ts). They carry no required trigger fields of their own —
+ * step-level `awaits`/`parallel`/`vars` drive execution. Modeled here so
+ * the install path (parseRecipe) accepts them with parity to the JSON
+ * schema and validateRecipeDefinition. Extra trigger fields (vars/inputs)
+ * survive the JSON round-trip on install.
+ */
+export interface ChainedTrigger {
+  type: "chained";
+}
+
+/**
+ * `on_file_save` / `on_test_run` are the runtime-facing names for the
+ * file-save and test-run triggers (yamlRunner injects `{{file}}` /
+ * `{{runner}}`+`{{failed}}`+… context respectively). `glob`/`filter` are
+ * optional; the bridge wires these via its own automation hooks rather
+ * than the recipe compiler.
+ */
+export interface OnFileSaveTrigger {
+  type: "on_file_save";
+  glob?: string;
+  filter?: string;
+}
+export interface OnTestRunTrigger {
+  type: "on_test_run";
+  filter?: string;
+}
+
 export type Trigger =
   | WebhookTrigger
   | CronTrigger
   | FileWatchTrigger
   | GitHookTrigger
-  | ManualTrigger;
+  | ManualTrigger
+  | ChainedTrigger
+  | OnFileSaveTrigger
+  | OnTestRunTrigger;
 
 export interface FileContext {
   type: "file";

--- a/src/recipes/validation.ts
+++ b/src/recipes/validation.ts
@@ -161,7 +161,35 @@ export function validateRecipeDefinition(recipe: unknown): LintResult {
             });
           }
         }
+
+        // Unconditional risk-enum check. `risk` was previously never
+        // validated here (the parser casts it; the JSON-schema enum is
+        // gated behind FLAG_SCHEMA_LINT, which defaults off). A typo like
+        // `risk: "hgh"` silently fell through the compiler's risk bucketer
+        // to `allow` — fail-open. Flag any out-of-enum value as an error so
+        // `recipe lint` / `doctor` catch it before a run. Reads risk from
+        // the top-level step AND the nested agent object (both forms occur).
+        const stepAgent =
+          step.agent && typeof step.agent === "object"
+            ? (step.agent as Record<string, unknown>)
+            : undefined;
+        const riskValue = step.risk ?? stepAgent?.risk;
+        if (
+          riskValue !== undefined &&
+          riskValue !== "low" &&
+          riskValue !== "medium" &&
+          riskValue !== "high"
+        ) {
+          issues.push({
+            level: "error",
+            message: `Step ${i + 1}: invalid risk '${String(riskValue)}' — must be one of: low, medium, high`,
+            code: "risk-enum",
+            path: `steps.${i}.risk`,
+          });
+        }
       }
+
+      validateAwaitsTargets(r, recipe, issues);
 
       validateTemplateReferences(r, issues, collectParallelEachKeys(recipe));
     }
@@ -184,6 +212,121 @@ export function validateRecipeDefinition(recipe: unknown): LintResult {
     warnings,
     errors,
   };
+}
+
+/**
+ * Validate step `awaits:` targets against the set of declared step ids.
+ *
+ * An `awaits:` target that matches no real step is a recipe-authoring bug
+ * that the runtime can't recover from: the cycle-detection DFS skips the
+ * phantom edge (so `hasCycles` stays false), but Kahn's algorithm counts it
+ * in the awaiting step's in-degree and never decrements it — so the
+ * awaiting step AND all its transitive dependents silently drop out of the
+ * topological order, never run, and the run STILL reports success. Flag it
+ * statically so `recipe lint` / `doctor` catch it before any run.
+ *
+ * Known-id collection runs over BOTH:
+ *   - the NORMALIZED recipe (`normalizedRecipe.steps`) — `awaits:` clauses
+ *     live here, and `flattenValidationSteps` has already hoisted parallel
+ *     children to top level (so child ids are present), AND
+ *   - the RAW recipe (`rawRecipe.steps`) — still carries the `parallel:`
+ *     CONTAINER ids that flattening drops.
+ *
+ * The union matters because `awaits: [<parallel-group-id>]` is VALID at
+ * runtime: `chainedRunner.expandParallelSteps` rewrites a group-id await to
+ * the expanded child ids. Collecting from the raw steps keeps those
+ * container ids in `knownIds` so a legitimate group-await isn't flagged,
+ * while a genuine typo (`gather2`) — present in neither list — still errors.
+ */
+function validateAwaitsTargets(
+  normalizedRecipe: Record<string, unknown>,
+  rawRecipe: unknown,
+  issues: LintIssue[],
+): void {
+  const steps = Array.isArray(normalizedRecipe.steps)
+    ? (normalizedRecipe.steps as Array<Record<string, unknown>>)
+    : [];
+  if (steps.length === 0) return;
+
+  const knownIds = new Set<string>();
+  const collectIds = (list: Array<Record<string, unknown>>): void => {
+    for (const step of list) {
+      if (!step || typeof step !== "object") continue;
+      if (typeof step.id === "string") knownIds.add(step.id);
+      if (Array.isArray(step.parallel)) {
+        collectIds(step.parallel as Array<Record<string, unknown>>);
+      } else if (
+        step.parallel &&
+        typeof step.parallel === "object" &&
+        Array.isArray((step.parallel as Record<string, unknown>).steps)
+      ) {
+        collectIds(
+          (step.parallel as Record<string, unknown>).steps as Array<
+            Record<string, unknown>
+          >,
+        );
+      }
+    }
+  };
+  // Collect from the flattened (normalized) list first — child ids + any
+  // top-level ids.
+  collectIds(steps);
+  // Then collect from the RAW recipe steps so parallel-group CONTAINER ids
+  // (which `flattenValidationSteps` strips) are recognised as valid await
+  // targets. `collectIds` recurses into `parallel:` arrays / map-reduce
+  // `{steps}` blocks, picking up both the container id and its children.
+  if (
+    rawRecipe &&
+    typeof rawRecipe === "object" &&
+    !Array.isArray(rawRecipe) &&
+    Array.isArray((rawRecipe as Record<string, unknown>).steps)
+  ) {
+    collectIds(
+      (rawRecipe as Record<string, unknown>).steps as Array<
+        Record<string, unknown>
+      >,
+    );
+  }
+
+  const checkAwaits = (
+    list: Array<Record<string, unknown>>,
+    label: (i: number) => string,
+  ): void => {
+    for (let i = 0; i < list.length; i++) {
+      const step = list[i];
+      if (!step || typeof step !== "object") continue;
+      if (Array.isArray(step.awaits)) {
+        for (const target of step.awaits) {
+          if (typeof target === "string" && !knownIds.has(target)) {
+            issues.push({
+              level: "error",
+              message: `${label(i)}: awaits unknown step '${target}' — no step with that id exists. The step (and everything depending on it) would silently never run.`,
+              code: "unknown-awaits-target",
+              path: `steps.${i}.awaits`,
+            });
+          }
+        }
+      }
+      if (Array.isArray(step.parallel)) {
+        checkAwaits(
+          step.parallel as Array<Record<string, unknown>>,
+          (j) => `${label(i)}.parallel[${j}]`,
+        );
+      } else if (
+        step.parallel &&
+        typeof step.parallel === "object" &&
+        Array.isArray((step.parallel as Record<string, unknown>).steps)
+      ) {
+        checkAwaits(
+          (step.parallel as Record<string, unknown>).steps as Array<
+            Record<string, unknown>
+          >,
+          (j) => `${label(i)}.parallel.steps[${j}]`,
+        );
+      }
+    }
+  };
+  checkAwaits(steps, (i) => `Step ${i + 1}`);
 }
 
 /**

--- a/src/recipes/yamlRunner.ts
+++ b/src/recipes/yamlRunner.ts
@@ -39,6 +39,7 @@ import { fileURLToPath } from "node:url";
 import { parse as parseYaml } from "yaml";
 import { captureFixture } from "../connectors/fixtureRecorder.js";
 import { sanitizeEnv } from "../drivers/claude/envSanitizer.js";
+import { isLoopbackOrPrivateEndpoint } from "../localEndpointGuard.js";
 import { loadConfig as loadPatchworkConfigSync } from "../patchworkConfig.js";
 import { findYamlRecipePath } from "../recipesHttp.js";
 import type { RecipeRunLog } from "../runLog.js";
@@ -2137,7 +2138,7 @@ async function defaultClaudeFn(
   }
 }
 
-async function defaultLocalFn(
+export async function defaultLocalFn(
   prompt: string,
   model: string,
 ): Promise<AgentResult> {
@@ -2147,6 +2148,20 @@ async function defaultLocalFn(
       "../patchworkConfig.js"
     );
     const cfg = loadPatchworkConfig();
+    // Anti-SSRF: the local adapter streams the prompt to `cfg.localEndpoint`
+    // (dashboard/config-controlled). A `driver: local` recipe must not be
+    // able to POST the prompt to an arbitrary public host. Mirror the
+    // LocalApiDriver gate (src/drivers/local/index.ts): reject any non
+    // loopback/private endpoint unless LOCAL_ENDPOINT_ALLOW_REMOTE=1.
+    if (
+      cfg.localEndpoint &&
+      process.env.LOCAL_ENDPOINT_ALLOW_REMOTE !== "1" &&
+      !isLoopbackOrPrivateEndpoint(cfg.localEndpoint)
+    ) {
+      return {
+        text: "[agent step failed: localEndpoint is a public host; set LOCAL_ENDPOINT_ALLOW_REMOTE=1 to override]",
+      };
+    }
     const adapter = createLocalAdapter({
       endpoint: cfg.localEndpoint,
       defaultModel: cfg.localModel ?? model,

--- a/src/tools/__tests__/ctxToolsUnconditional.test.ts
+++ b/src/tools/__tests__/ctxToolsUnconditional.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi } from "vitest";
+import { makeConfig as buildConfig } from "../../__tests__/helpers/fixtures.js";
+import { registerAllTools } from "../index.js";
+
+/**
+ * Regression test for the "ctx WRITE/reverse-lookup tools missing on a stock
+ * bridge" bug.
+ *
+ * The four ctx tools — `ctxQueryTraces`, `ctxGetTaskContext`, `ctxSaveTrace`,
+ * `getCommitsForIssue` — are documented (CLAUDE.md) as standard full-mode
+ * tools. Two of them (`ctxSaveTrace`, `getCommitsForIssue`) were registered
+ * only when a `decisionTraceLog` / `commitIssueLinkLog` argument was supplied.
+ *
+ * On the default bridge (`driver: "none"`) those logs were never constructed,
+ * so the WRITE path and the enrichment reverse-lookup silently vanished and
+ * `ctxSaveTrace` returned tool-not-found.
+ *
+ * After the fix the four ctx tools must register unconditionally — even when
+ * the caller passes no log arguments at all.
+ *
+ * Test seam: full `Bridge.start()` is heavy (probes CLIs, binds a port, writes
+ * lock files), so we target the narrowest seam — `registerAllTools` with no log
+ * arguments, which is exactly the shape the stock `driver: "none"` bridge used
+ * to produce. The companion bridge.ts change guarantees the bridge now always
+ * constructs + passes real `commitIssueLinkLog` / `decisionTraceLog` stores.
+ */
+describe("ctx tools register unconditionally (no log args)", () => {
+  function makeDeps() {
+    const registered: string[] = [];
+    const transport = {
+      registerTool: vi.fn((schema: { name: string }) => {
+        registered.push(schema.name);
+      }),
+      applyToolCategories: vi.fn(),
+    };
+    const extensionClient = {
+      isConnected: () => false,
+      request: vi.fn(),
+      requestOrNull: vi.fn(),
+      latestAIComments: [],
+      onExtensionDisconnected: null,
+      onDiagnosticsChanged: null,
+    };
+    return { transport, extensionClient, registered };
+  }
+
+  const probes = {
+    gh: false,
+    rg: false,
+    fd: false,
+    eslint: false,
+    biome: false,
+    tsc: false,
+    pytest: false,
+    jest: false,
+    vitest: false,
+    cargo: false,
+    go: false,
+    pyright: false,
+    ruff: false,
+  };
+
+  const activityLog = {
+    query: vi.fn(() => []),
+    queryTimeline: vi.fn(() => []),
+    subscribe: vi.fn(() => () => {}),
+    stats: vi.fn(() => ({})),
+  };
+
+  it("registers all four ctx tools in full mode with NO log args supplied", () => {
+    const { transport, extensionClient, registered } = makeDeps();
+
+    // Full mode, default bridge: no commitIssueLinkLog / decisionTraceLog /
+    // recipeRunLog arguments — exactly the stock `driver: "none"` shape.
+    registerAllTools(
+      transport as never,
+      buildConfig({
+        workspace: "/tmp/test",
+        workspaceFolders: ["/tmp/test"],
+        fullMode: true,
+      }),
+      new Set(),
+      probes as never,
+      extensionClient as never,
+      activityLog as never,
+    );
+
+    const set = new Set(registered);
+    expect(set.has("ctxQueryTraces")).toBe(true);
+    expect(set.has("ctxGetTaskContext")).toBe(true);
+    expect(set.has("ctxSaveTrace")).toBe(true);
+    expect(set.has("getCommitsForIssue")).toBe(true);
+  });
+});

--- a/src/tools/__tests__/ctxToolsUnconditional.test.ts
+++ b/src/tools/__tests__/ctxToolsUnconditional.test.ts
@@ -1,6 +1,10 @@
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { makeConfig as buildConfig } from "../../__tests__/helpers/fixtures.js";
 import { registerAllTools } from "../index.js";
+
+const TEST_WORKSPACE = join(tmpdir(), "ctx-tools-test");
 
 /**
  * Regression test for the "ctx WRITE/reverse-lookup tools missing on a stock
@@ -75,8 +79,8 @@ describe("ctx tools register unconditionally (no log args)", () => {
     registerAllTools(
       transport as never,
       buildConfig({
-        workspace: "/tmp/test",
-        workspaceFolders: ["/tmp/test"],
+        workspace: TEST_WORKSPACE,
+        workspaceFolders: [TEST_WORKSPACE],
         fullMode: true,
       }),
       new Set(),

--- a/src/tools/__tests__/getProjectContext.test.ts
+++ b/src/tools/__tests__/getProjectContext.test.ts
@@ -124,6 +124,28 @@ describe("createGetProjectContextTool", () => {
     expect(result.brief.activeFile).toBe("/workspace/src/main.ts");
   });
 
+  // Regression for the two-shape getDiagnostics bug: the no-file branch of the
+  // extension handler now returns a FLAT Diagnostic[] (each entry has `file`).
+  // getProjectContext does `Array.isArray(diagnosticsResult.value)` + reads
+  // `d.file`/`d.severity`/`d.message`. With the old grouped wrapper this branch
+  // never ran and the tool reported "No errors or warnings".
+  it("counts errors/warnings from the flat getDiagnostics array", async () => {
+    const client = makeClient({
+      isConnected: () => true,
+      getDiagnostics: vi.fn().mockResolvedValue([
+        { file: "/ws/a.ts", severity: "error", message: "boom", line: 1 },
+        { file: "/ws/a.ts", severity: "warning", message: "meh", line: 2 },
+        { file: "/ws/b.ts", severity: "error", message: "kaboom", line: 3 },
+      ]),
+    });
+    const tool = createGetProjectContextTool(tmpDir, client, NO_PROBES);
+    const result = parse(await tool.handler({ force: true }));
+
+    expect(result.brief.diagnosticSummary).toBe("2 error(s), 1 warning(s)");
+    expect(result.brief.recentErrors).toHaveLength(3);
+    expect(result.brief.recentErrors[0].file).toBe("/ws/a.ts");
+  });
+
   it("includes suggestedPrompt string in output", async () => {
     const tool = createGetProjectContextTool(tmpDir, makeClient(), NO_PROBES);
     const result = parse(await tool.handler({}));

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,7 +1,11 @@
+import os from "node:os";
+import path from "node:path";
 import type { ActivityLog } from "../activityLog.js";
 import type { AutomationHooks } from "../automation.js";
 import type { ClaudeOrchestrator } from "../claudeOrchestrator.js";
+import { CommitIssueLinkLog } from "../commitIssueLinkLog.js";
 import type { Config } from "../config.js";
+import { DecisionTraceLog } from "../decisionTraceLog.js";
 import type { ExtensionClient } from "../extensionClient.js";
 import type { FileLock } from "../fileLock.js";
 import type { LoadedPluginTool } from "../pluginLoader.js";
@@ -425,9 +429,17 @@ export function registerAllTools(
   const getDisconnectInfo = getDisconnectInfoArg;
   const onContextCacheUpdated = onContextCacheUpdatedArg;
   const getExtensionDisconnectCount = getExtensionDisconnectCountArg;
-  const commitIssueLinkLog = commitIssueLinkLogArg;
   const recipeRunLog = recipeRunLogArg;
-  const decisionTraceLog = decisionTraceLogArg;
+  // The ctx WRITE / reverse-lookup tools (ctxSaveTrace, getCommitsForIssue)
+  // are advertised as standard full-mode tools (CLAUDE.md). They must register
+  // unconditionally, even on a stock `driver: "none"` bridge that doesn't wire
+  // these logs. Fall back to a default ~/.patchwork-backed store so the tools
+  // are always available — the bridge normally passes its own shared instances.
+  const patchworkDir = path.join(os.homedir(), ".patchwork");
+  const commitIssueLinkLog =
+    commitIssueLinkLogArg ?? new CommitIssueLinkLog({ dir: patchworkDir });
+  const decisionTraceLog =
+    decisionTraceLogArg ?? new DecisionTraceLog({ dir: patchworkDir });
 
   const workspace = config.workspace;
   const workspaceFolders = config.workspaceFolders;
@@ -776,18 +788,12 @@ export function registerAllTools(
       workspace,
       commitIssueLinkLog: commitIssueLinkLog ?? null,
     }),
-    ...(decisionTraceLog
-      ? [
-          createCtxSaveTraceTool(
-            workspace,
-            decisionTraceLog,
-            sessionId ? () => sessionId : undefined,
-          ),
-        ]
-      : []),
-    ...(commitIssueLinkLog
-      ? [createGetCommitsForIssueTool(workspace, commitIssueLinkLog)]
-      : []),
+    createCtxSaveTraceTool(
+      workspace,
+      decisionTraceLog,
+      sessionId ? () => sessionId : undefined,
+    ),
+    createGetCommitsForIssueTool(workspace, commitIssueLinkLog),
     createGetCodeCoverageTool(workspace),
     createGenerateTestsTool(workspace),
     ...(probes.gh

--- a/vscode-extension/src/__tests__/handlers/diagnostics.test.ts
+++ b/vscode-extension/src/__tests__/handlers/diagnostics.test.ts
@@ -118,7 +118,11 @@ describe("handleGetDiagnostics", () => {
     expect(vscode.languages.getDiagnostics).toHaveBeenCalled();
   });
 
-  it("returns all diagnostics grouped by file when no file param", async () => {
+  // Regression: the no-file branch MUST return a FLAT Diagnostic[] where each
+  // entry carries a `file` string. Returning a grouped { diagnostics } wrapper
+  // silently broke bridge consumers (contextBundle / getProjectContext /
+  // screenshotAndAnnotate) which do `Array.isArray(result)` + read `d.file`.
+  it("returns a FLAT array (not a wrapper object) when no file param", async () => {
     const uri1 = Uri.file("/a.ts");
     const uri2 = Uri.file("/b.ts");
     const allDiags = [
@@ -127,18 +131,28 @@ describe("handleGetDiagnostics", () => {
     ];
     vi.mocked(vscode.languages.getDiagnostics).mockReturnValue(allDiags as any);
 
-    const result = (await handleGetDiagnostics({})) as {
-      diagnostics: any[];
-      truncated: boolean;
-    };
-    expect(result.diagnostics).toHaveLength(2);
-    expect(result.diagnostics[0].file).toBe("/a.ts");
-    expect(result.diagnostics[0].diagnostics).toHaveLength(1);
-    expect(result.diagnostics[1].diagnostics).toHaveLength(2);
-    expect(result.truncated).toBe(false);
+    const result = await handleGetDiagnostics({});
+
+    // The crux of the bug fix: a flat array, not an object.
+    expect(Array.isArray(result)).toBe(true);
+    const arr = result as Array<Record<string, unknown>>;
+    expect(arr).toHaveLength(3); // 1 from a.ts + 2 from b.ts, flattened
+
+    // Every entry must include a `file` string (the inner grouped entries
+    // produced by diagnosticToJson did NOT have one).
+    for (const entry of arr) {
+      expect(typeof entry.file).toBe("string");
+      expect((entry.file as string).length).toBeGreaterThan(0);
+    }
+
+    // Files are preserved per-entry.
+    expect(arr[0].file).toBe("/a.ts");
+    expect(arr[0].message).toBe("a1");
+    expect(arr[1].file).toBe("/b.ts");
+    expect(arr[2].file).toBe("/b.ts");
   });
 
-  it("caps all-diagnostics at 500", async () => {
+  it("caps all-diagnostics at 500 (flat)", async () => {
     const uri = Uri.file("/big.ts");
     const manyDiags = Array.from({ length: 600 }, (_, i) =>
       makeDiag({ message: `err${i}` }),
@@ -147,12 +161,25 @@ describe("handleGetDiagnostics", () => {
       [uri, manyDiags],
     ] as any);
 
-    const result = (await handleGetDiagnostics({})) as {
-      diagnostics: any[];
-      truncated: boolean;
-    };
-    expect(result.diagnostics[0].diagnostics).toHaveLength(500);
-    expect(result.truncated).toBe(true);
+    const result = (await handleGetDiagnostics({})) as any[];
+    expect(Array.isArray(result)).toBe(true);
+    expect(result).toHaveLength(500);
+    expect(result[0].file).toBe("/big.ts");
+  });
+
+  it("caps across multiple files (flat)", async () => {
+    const uri1 = Uri.file("/one.ts");
+    const uri2 = Uri.file("/two.ts");
+    vi.mocked(vscode.languages.getDiagnostics).mockReturnValue([
+      [uri1, Array.from({ length: 400 }, () => makeDiag())],
+      [uri2, Array.from({ length: 400 }, () => makeDiag())],
+    ] as any);
+
+    const result = (await handleGetDiagnostics({})) as any[];
+    expect(result).toHaveLength(500);
+    // First 400 from /one.ts, then 100 from /two.ts.
+    expect(result[0].file).toBe("/one.ts");
+    expect(result[499].file).toBe("/two.ts");
   });
 
   it("skips files with zero diagnostics", async () => {
@@ -160,11 +187,8 @@ describe("handleGetDiagnostics", () => {
     vi.mocked(vscode.languages.getDiagnostics).mockReturnValue([
       [uri, []],
     ] as any);
-    const result = (await handleGetDiagnostics({})) as {
-      diagnostics: any[];
-      truncated: boolean;
-    };
-    expect(result.diagnostics).toHaveLength(0);
-    expect(result.truncated).toBe(false);
+    const result = (await handleGetDiagnostics({})) as any[];
+    expect(Array.isArray(result)).toBe(true);
+    expect(result).toHaveLength(0);
   });
 });

--- a/vscode-extension/src/handlers/diagnostics.ts
+++ b/vscode-extension/src/handlers/diagnostics.ts
@@ -35,23 +35,24 @@ export async function handleGetDiagnostics(
     const diags = vscode.languages.getDiagnostics(uri);
     return diags.map(diagnosticToJson);
   }
-  // Return all diagnostics (capped to prevent oversized payloads)
+  // Return all diagnostics as a FLAT list (capped to prevent oversized
+  // payloads). Each entry carries its own `file` field so it matches the
+  // `extensionClient.Diagnostic` shape that bridge consumers expect — they
+  // do `Array.isArray(result)` + read `d.file`/`d.severity`. Returning a
+  // grouped wrapper here silently broke contextBundle / getProjectContext /
+  // screenshotAndAnnotate (all reported zero diagnostics).
   const allDiags = vscode.languages.getDiagnostics();
-  const result: Array<{ file: string; diagnostics: unknown[] }> = [];
+  const result: Array<{ file: string } & ReturnType<typeof diagnosticToJson>> =
+    [];
   let totalCount = 0;
   for (const [uri, diags] of allDiags) {
-    if (diags.length > 0) {
-      const capped = diags.slice(0, MAX_ALL_DIAGNOSTICS - totalCount);
-      result.push({
-        file: uri.fsPath,
-        diagnostics: capped.map(diagnosticToJson),
-      });
-      totalCount += capped.length;
-      if (totalCount >= MAX_ALL_DIAGNOSTICS) break;
+    if (diags.length === 0) continue;
+    const capped = diags.slice(0, MAX_ALL_DIAGNOSTICS - totalCount);
+    for (const d of capped) {
+      result.push({ file: uri.fsPath, ...diagnosticToJson(d) });
     }
+    totalCount += capped.length;
+    if (totalCount >= MAX_ALL_DIAGNOSTICS) break;
   }
-  return {
-    diagnostics: result,
-    truncated: totalCount >= MAX_ALL_DIAGNOSTICS,
-  };
+  return result;
 }


### PR DESCRIPTION
## What

Fixes the **critical + high-severity** findings from a whole-codebase audit (2026-06-02). Each fix follows the repo's test-first Bug Fix Protocol (failing test → fix → passing test).

## Critical

- **Jira Cloud connector sent `Bearer` auth for API tokens** — Atlassian Cloud only accepts Bearer for OAuth 3LO tokens; API tokens need Basic `base64(email:token)`, so every Jira tool call 401'd. `buildHeaders` now uses the same Basic-vs-Bearer guard `handleJiraTest` already had. (Jira was doubly broken — see the registry-flags fix below.)

## High

- **13 Wave 3/4 connectors** (resend…supabase) were registry-declared + dashboard-surfaced but had **no bridge routes** → connect/test/delete 404'd end-to-end. Routes wired; misleading "wired in server.ts" comment fixed; **route↔registry parity regression test added** so this can't recur.
- **Jira registry `supports:{}`** hid working routes from the dashboard — flags flipped.
- **Recipes:** `chained`/`on_file_save`/`on_test_run` triggers were rejected at install despite linting/running fine; `bucketForRisk` failed **open** to auto-approve on an invalid `risk` value (now fail-closed + unconditional enum validation); a typo'd `awaits:` target silently dropped steps with a green run (now rejected at validate + run time).
- **Idempotency ledger cached `{ok:false}`** connector results, making step retries silent no-ops — now only genuine successes are cached.
- **Recipe `driver: local`** bypassed the loopback/`ALLOW_REMOTE` SSRF guard the bridge driver enforces (prompt/context exfil) — shared guard now applied.
- **Orchestrator:** child tool `isError`/`structuredContent` were dropped (failed proxied calls looked successful); leaked `ChildBridgeClient`s + reused stale tokens on port reuse — both fixed.
- **Notion disconnect** left the credential in secure storage (only deleted a never-written legacy file).
- **Dashboard OAuth callback** pages were caught by the `SameSite=Strict` session redirect, breaking **all** OAuth connector setup on password-gated deployments — callback routes now exempt.
- **Extension `getDiagnostics`** returned a wrapped object for the no-arg case while callers expected a flat `Diagnostic[]` → diagnostics silently dropped in `contextBundle`/`getProjectContext`/`screenshotAndAnnotate`.
- **CLI:** `traces export --passphrase/--mode keyed` was documented but unimplemented (now encrypts); `quick-task`/`start-task`/`continue-handoff` (and `print-token`/`notify`) picked locks by mtime with no `isBridge`/PID filter → now use `findBridgeLock`.
- **ctx-platform tools** (`ctxSaveTrace`, `getCommitsForIssue`, …) weren't registered on the default `driver=none` bridge, contradicting the docs — now always available in full mode.

## Verification

- `tsc` (main) + strict `tests.core` ratchet: **clean**
- Bridge **6950** · dashboard **754** · extension **575** tests pass

## Notes

- Rebased onto `main` (drops the unrelated release-bump that was in the working base).
- The medium-tier follow-up is in a stacked PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
