### PR TITLE
fix: medium-severity findings from codebase audit (stacked on #848)

### DIFF
--- a/dashboard/src/app/api/login/__tests__/route.test.ts
+++ b/dashboard/src/app/api/login/__tests__/route.test.ts
@@ -1,0 +1,110 @@
+/** @vitest-environment node */
+/**
+ * Tests for the dashboard login route (`POST /api/login`).
+ *
+ * Focus: the brute-force lockout must not turn into a global denial of
+ * service when no trusted reverse proxy is configured. Without
+ * BRIDGE_TRUST_PROXY=true, clientKey() returns the literal "unknown" for
+ * EVERY request, so a shared lockout keyed on that string would lock out
+ * all users after MAX_FAILURES bad passwords (the common local / direct
+ * deploy case). With a trusted proxy + distinct client IPs, per-IP lockout
+ * must still work. Audit 2026-06-02.
+ */
+
+import { NextRequest } from "next/server";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { POST } from "@/app/api/login/route";
+import { _config, _resetForTests } from "@/lib/authRateLimit";
+
+const PASSWORD = "correct-horse-battery-staple";
+const SECRET = "0123456789abcdef0123456789abcdef";
+
+const ENV_KEYS = [
+  "DASHBOARD_PASSWORD",
+  "DASHBOARD_SESSION_SECRET",
+  "BRIDGE_TRUST_PROXY",
+] as const;
+
+let originalEnv: Record<string, string | undefined>;
+
+beforeEach(() => {
+  originalEnv = Object.fromEntries(ENV_KEYS.map((k) => [k, process.env[k]]));
+  process.env.DASHBOARD_PASSWORD = PASSWORD;
+  process.env.DASHBOARD_SESSION_SECRET = SECRET;
+  delete process.env.BRIDGE_TRUST_PROXY;
+  _resetForTests();
+});
+
+afterEach(() => {
+  for (const k of ENV_KEYS) {
+    if (originalEnv[k] === undefined) delete process.env[k];
+    else process.env[k] = originalEnv[k];
+  }
+  _resetForTests();
+});
+
+function req(body: unknown, headers: Record<string, string> = {}): NextRequest {
+  return new NextRequest("http://localhost:3200/api/login", {
+    method: "POST",
+    headers: { "content-type": "application/json", ...headers },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/login — no trusted proxy (BRIDGE_TRUST_PROXY unset)", () => {
+  it("does NOT lock out a subsequent correct login after many bad attempts", async () => {
+    // Hammer the endpoint with more than MAX_FAILURES wrong passwords. All
+    // requests bucket into "unknown" because there's no trusted proxy.
+    for (let i = 0; i < _config.MAX_FAILURES + 3; i++) {
+      const r = await POST(req({ password: "wrong" }));
+      // Each wrong attempt is a 401, never a 429 shared lockout.
+      expect(r.status).toBe(401);
+    }
+
+    // A legitimate user with the right password must still get in — the
+    // shared "unknown" bucket must NOT have locked everyone out.
+    const ok = await POST(req({ password: PASSWORD }));
+    expect(ok.status).toBe(200);
+    const body = (await ok.json()) as { ok: boolean };
+    expect(body.ok).toBe(true);
+  });
+
+  it("never returns 429 for the shared 'unknown' bucket", async () => {
+    for (let i = 0; i < _config.MAX_FAILURES + 5; i++) {
+      const r = await POST(req({ password: "nope" }));
+      expect(r.status).not.toBe(429);
+    }
+  });
+});
+
+describe("POST /api/login — trusted proxy (BRIDGE_TRUST_PROXY=true)", () => {
+  beforeEach(() => {
+    process.env.BRIDGE_TRUST_PROXY = "true";
+  });
+
+  it("locks out a single abusive IP after MAX_FAILURES, returning 429", async () => {
+    const attacker = { "x-forwarded-for": "203.0.113.7" };
+    let last: Response | undefined;
+    for (let i = 0; i < _config.MAX_FAILURES; i++) {
+      last = await POST(req({ password: "wrong" }, attacker));
+    }
+    // The MAX_FAILURES-th failure trips the lockout.
+    expect(last?.status).toBe(429);
+    // And a follow-up attempt from the same IP is still locked, even with
+    // the correct password.
+    const blocked = await POST(req({ password: PASSWORD }, attacker));
+    expect(blocked.status).toBe(429);
+  });
+
+  it("does not lock a different IP just because another IP was locked", async () => {
+    const attacker = { "x-forwarded-for": "203.0.113.7" };
+    for (let i = 0; i < _config.MAX_FAILURES; i++) {
+      await POST(req({ password: "wrong" }, attacker));
+    }
+    // A distinct, well-behaved IP logging in correctly must succeed.
+    const legit = { "x-forwarded-for": "198.51.100.9" };
+    const ok = await POST(req({ password: PASSWORD }, legit));
+    expect(ok.status).toBe(200);
+  });
+});

--- a/dashboard/src/app/api/login/route.ts
+++ b/dashboard/src/app/api/login/route.ts
@@ -50,12 +50,22 @@ export async function POST(req: NextRequest) {
   }
 
   const ip = clientKey(req.headers);
-  const lock = checkLocked(ip);
-  if (lock.locked) {
-    return NextResponse.json(
-      { error: "too many attempts" },
-      { status: 429, headers: { "Retry-After": String(lock.retryAfterSec) } },
-    );
+  // When no trusted reverse proxy is configured, clientKey() returns the
+  // literal "unknown" for EVERY request — so a shared lockout keyed on it
+  // would let 5 bad passwords from anyone lock out ALL users for the
+  // lockout window (the common local / direct-deploy case). Only apply the
+  // per-IP brute-force lockout when we have a real, attributable client key
+  // (i.e. BRIDGE_TRUST_PROXY=true + a forwarded IP). Without it we rely on
+  // the timing-safe password compare below as the sole gate. Audit 2026-06-02.
+  const trackable = ip !== "unknown";
+  if (trackable) {
+    const lock = checkLocked(ip);
+    if (lock.locked) {
+      return NextResponse.json(
+        { error: "too many attempts" },
+        { status: 429, headers: { "Retry-After": String(lock.retryAfterSec) } },
+      );
+    }
   }
 
   const parsed = await readJsonWithCap<LoginBody>(
@@ -70,7 +80,7 @@ export async function POST(req: NextRequest) {
   const next = parsed.value?.next;
 
   if (typeof password !== "string") {
-    recordFailure(ip);
+    if (trackable) recordFailure(ip);
     return NextResponse.json({ error: "missing password" }, { status: 400 });
   }
 
@@ -94,20 +104,25 @@ export async function POST(req: NextRequest) {
   const equal = bytesEqual && a.length === b.length;
 
   if (!equal) {
-    const result = recordFailure(ip);
-    if (result.locked) {
-      return NextResponse.json(
-        { error: "too many attempts" },
-        {
-          status: 429,
-          headers: { "Retry-After": String(result.retryAfterSec) },
-        },
-      );
+    // Only track failures against a real, attributable client key. The
+    // "unknown" bucket (no trusted proxy) must not accumulate a shared
+    // lockout — see the trackable guard above.
+    if (trackable) {
+      const result = recordFailure(ip);
+      if (result.locked) {
+        return NextResponse.json(
+          { error: "too many attempts" },
+          {
+            status: 429,
+            headers: { "Retry-After": String(result.retryAfterSec) },
+          },
+        );
+      }
     }
     return NextResponse.json({ error: "invalid password" }, { status: 401 });
   }
 
-  recordSuccess(ip);
+  if (trackable) recordSuccess(ip);
   const cookie = await signSession();
   const redirect = isSafeRedirect(next) ? next : "/dashboard";
   return NextResponse.json(

--- a/dashboard/src/app/api/relay/push/__tests__/route.test.ts
+++ b/dashboard/src/app/api/relay/push/__tests__/route.test.ts
@@ -19,12 +19,17 @@ vi.mock("web-push", () => ({
 
 vi.mock("@/lib/pushStore", () => ({
   getSubscriptions: vi.fn(() => []),
+  getSubscriptionsFor: vi.fn(() => []),
   removeSubscription: vi.fn(),
 }));
 
 import webpush from "web-push";
 import { POST } from "@/app/api/relay/push/route";
-import { getSubscriptions, removeSubscription } from "@/lib/pushStore";
+import {
+  getSubscriptions,
+  getSubscriptionsFor,
+  removeSubscription,
+} from "@/lib/pushStore";
 
 const TOKEN = "relay-test-token-1234567890abcdef";
 
@@ -69,6 +74,7 @@ beforeEach(() => {
   process.env.VAPID_PRIVATE_KEY = "test-vapid-private";
   process.env.VAPID_SUBJECT = "mailto:test@example.com";
   vi.mocked(getSubscriptions).mockReturnValue([validSub]);
+  vi.mocked(getSubscriptionsFor).mockReturnValue([validSub]);
   vi.mocked(removeSubscription).mockClear();
   vi.mocked(webpush.sendNotification).mockClear();
   vi.mocked(webpush.setVapidDetails).mockClear();
@@ -153,7 +159,7 @@ describe("POST /api/relay/push — payload validation", () => {
 
 describe("POST /api/relay/push — fan-out", () => {
   it("404 when no subscriptions registered (informational, not an error)", async () => {
-    vi.mocked(getSubscriptions).mockReturnValue([]);
+    vi.mocked(getSubscriptionsFor).mockReturnValue([]);
     const r = await POST(req({ authorization: `Bearer ${TOKEN}` }, validBody));
     expect(r.status).toBe(404);
     expect(webpush.sendNotification).not.toHaveBeenCalled();
@@ -165,7 +171,7 @@ describe("POST /api/relay/push — fan-out", () => {
       { endpoint: "https://e2.com/p", keys: { p256dh: "k1", auth: "k2" } },
       { endpoint: "https://e3.com/p", keys: { p256dh: "k3", auth: "k4" } },
     ];
-    vi.mocked(getSubscriptions).mockReturnValue(subs);
+    vi.mocked(getSubscriptionsFor).mockReturnValue(subs);
     // Make the 2nd subscription fail — sent should be 2/3.
     vi.mocked(webpush.sendNotification).mockImplementation(async (sub) => {
       if (sub.endpoint === subs[1].endpoint) throw new Error("410 gone");
@@ -193,7 +199,7 @@ describe("POST /api/relay/push — fan-out", () => {
       { endpoint: "https://e2.com/p", keys: { p256dh: "k1", auth: "k2" } },
       { endpoint: "https://e3.com/p", keys: { p256dh: "k3", auth: "k4" } },
     ];
-    vi.mocked(getSubscriptions).mockReturnValue(subs);
+    vi.mocked(getSubscriptionsFor).mockReturnValue(subs);
     vi.mocked(webpush.sendNotification).mockImplementation(async (sub) => {
       if (sub.endpoint === subs[1].endpoint) {
         // web-push throws WebPushError with statusCode 410 for expired
@@ -214,7 +220,7 @@ describe("POST /api/relay/push — fan-out", () => {
   });
 
   it("evicts subscriptions that 404 from the push service", async () => {
-    vi.mocked(getSubscriptions).mockReturnValue([validSub]);
+    vi.mocked(getSubscriptionsFor).mockReturnValue([validSub]);
     vi.mocked(webpush.sendNotification).mockImplementation(async () => {
       const err = new Error("Not Found") as Error & { statusCode: number };
       err.statusCode = 404;
@@ -228,7 +234,7 @@ describe("POST /api/relay/push — fan-out", () => {
   });
 
   it("does NOT evict on transient 5xx failures", async () => {
-    vi.mocked(getSubscriptions).mockReturnValue([validSub]);
+    vi.mocked(getSubscriptionsFor).mockReturnValue([validSub]);
     vi.mocked(webpush.sendNotification).mockImplementation(async () => {
       const err = new Error("Service Unavailable") as Error & {
         statusCode: number;
@@ -269,5 +275,51 @@ describe("POST /api/relay/push — fan-out", () => {
     const [, payloadStr] = vi.mocked(webpush.sendNotification).mock.calls[0]!;
     const payload = JSON.parse(payloadStr as string) as { approveUrl: string };
     expect(payload.approveUrl).toBe("https://bridge.example.com/approve/call-123");
+  });
+});
+
+// ─── per-subscription `approvals` opt-out — audit 2026-06-02 ────────────────
+// Pre-fix the approval relay fanned out via the unfiltered getSubscriptions(),
+// so a subscription that set approvals:false (persisted by /api/push/prefs)
+// still received every approval push. The halt relay already filtered via
+// getSubscriptionsFor("halts"); this asserts the approval relay does the same
+// with the "approvals" event class.
+describe("POST /api/relay/push — respects approvals opt-out", () => {
+  it("filters via getSubscriptionsFor('approvals'), not the unfiltered getSubscriptions()", async () => {
+    await POST(req({ authorization: `Bearer ${TOKEN}` }, validBody));
+    expect(getSubscriptionsFor).toHaveBeenCalledWith("approvals");
+    expect(getSubscriptions).not.toHaveBeenCalled();
+  });
+
+  it("excludes a subscription with approvals:false from the recipient set", async () => {
+    const optedIn = validSub;
+    const optedOut = {
+      endpoint: "https://opted-out.example.com/p",
+      keys: { p256dh: "k1", auth: "k2" },
+    };
+    // getSubscriptionsFor('approvals') is the store-level filter: it only
+    // returns the opted-in subscription. The opted-out one must never be
+    // sent to.
+    vi.mocked(getSubscriptionsFor).mockImplementation((kind) =>
+      kind === "approvals" ? [optedIn] : [optedIn, optedOut],
+    );
+
+    const r = await POST(req({ authorization: `Bearer ${TOKEN}` }, validBody));
+    expect(r.status).toBe(200);
+    expect(webpush.sendNotification).toHaveBeenCalledTimes(1);
+    const sentEndpoints = vi
+      .mocked(webpush.sendNotification)
+      .mock.calls.map((c) => (c[0] as { endpoint: string }).endpoint);
+    expect(sentEndpoints).toEqual([optedIn.endpoint]);
+    expect(sentEndpoints).not.toContain(optedOut.endpoint);
+  });
+
+  it("404 'no approval subscribers' when no subscription opted in to approvals", async () => {
+    vi.mocked(getSubscriptionsFor).mockReturnValue([]);
+    const r = await POST(req({ authorization: `Bearer ${TOKEN}` }, validBody));
+    expect(r.status).toBe(404);
+    const body = (await r.json()) as { error: string; total: number };
+    expect(body.error).toMatch(/approval subscribers/i);
+    expect(webpush.sendNotification).not.toHaveBeenCalled();
   });
 });

--- a/dashboard/src/app/api/relay/push/route.ts
+++ b/dashboard/src/app/api/relay/push/route.ts
@@ -1,7 +1,7 @@
 import crypto from "node:crypto";
 import { NextResponse } from "next/server";
 import webpush from "web-push";
-import { getSubscriptions, removeSubscription } from "@/lib/pushStore";
+import { getSubscriptionsFor, removeSubscription } from "@/lib/pushStore";
 import {
   DASHBOARD_API_BODY_CAPS,
   bodyTooLargeResponse,
@@ -126,12 +126,16 @@ export async function POST(req: Request) {
     );
   }
 
-  const subs = getSubscriptions();
+  // Filter to subscriptions opted in to approval pushes. A user who set
+  // approvals:false via /api/push/prefs must NOT receive these — pre-fix
+  // this used the unfiltered getSubscriptions() and ignored the opt-out
+  // (the halt relay already filtered via getSubscriptionsFor("halts")).
+  const subs = getSubscriptionsFor("approvals");
   if (subs.length === 0) {
     // Bridge fires fire-and-forget so this 404 is informational only —
     // the ok:false form lets curl-based debugging see the empty state.
     return NextResponse.json(
-      { ok: false, sent: 0, total: 0, error: "no subscriptions" },
+      { ok: false, sent: 0, total: 0, error: "no approval subscribers" },
       { status: 404 },
     );
   }

--- a/src/__tests__/decisionReplay.test.ts
+++ b/src/__tests__/decisionReplay.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from "vitest";
+import type { ActivityLog } from "../activityLog.js";
+import type { LifecycleEntry } from "../activityTypes.js";
+import type { PermissionRules } from "../ccPermissions.js";
+import { computeDecisionReplay } from "../decisionReplay.js";
+
+/**
+ * Build a minimal ActivityLog stub that only implements queryApprovalDecisions
+ * (the single method computeDecisionReplay depends on).
+ */
+function fakeLog(entries: LifecycleEntry[]): ActivityLog {
+  return {
+    queryApprovalDecisions: () => entries,
+  } as unknown as ActivityLog;
+}
+
+let nextId = 1;
+function row(
+  toolName: string,
+  decision: string,
+  specifier?: string,
+): LifecycleEntry {
+  return {
+    id: nextId++,
+    timestamp: new Date(2026, 0, 1, 0, 0, nextId).toISOString(),
+    event: "approval_decision",
+    metadata: {
+      toolName,
+      decision,
+      ...(specifier !== undefined && { specifier }),
+    },
+  };
+}
+
+describe("computeDecisionReplay — change bucketing", () => {
+  it("buckets ask→deny and ask→allow correctly and counts sum to changedCount", () => {
+    // Current policy: deny ToolDeny, allow ToolAllow.
+    const rules: PermissionRules = {
+      allow: ["ToolAllow"],
+      ask: [],
+      deny: ["ToolDeny"],
+    };
+
+    const entries = [
+      // originally "ask", current policy denies it → now_denied
+      row("ToolDeny", "ask"),
+      // originally "ask", current policy allows it → now_allowed
+      row("ToolAllow", "ask"),
+    ];
+
+    const result = computeDecisionReplay(fakeLog(entries), {
+      workspace: "/ws",
+      loadRulesFn: () => rules,
+    });
+
+    const askToDeny = result.rows.find((r) => r.toolName === "ToolDeny");
+    const askToAllow = result.rows.find((r) => r.toolName === "ToolAllow");
+
+    expect(askToDeny?.replayDecision).toBe("deny");
+    expect(askToDeny?.unchanged).toBe(false);
+    expect(askToDeny?.changeKind).toBe("now_denied");
+
+    expect(askToAllow?.replayDecision).toBe("allow");
+    expect(askToAllow?.unchanged).toBe(false);
+    expect(askToAllow?.changeKind).toBe("now_allowed");
+
+    // Both rows changed.
+    expect(result.changedCount).toBe(2);
+    expect(result.nowDeniedCount).toBe(1);
+    expect(result.nowAllowedCount).toBe(1);
+    expect(result.nowAskedCount).toBe(0);
+
+    // Buckets must sum exactly to changedCount — the core invariant.
+    expect(
+      result.nowAllowedCount + result.nowDeniedCount + result.nowAskedCount,
+    ).toBe(result.changedCount);
+  });
+
+  it("ask→none (no current rule matches) is now_denied and counted, not an orphan", () => {
+    // Empty policy → every tool evaluates to "none".
+    const rules: PermissionRules = { allow: [], ask: [], deny: [] };
+    const entries = [row("SomeTool", "ask")];
+
+    const result = computeDecisionReplay(fakeLog(entries), {
+      workspace: "/ws",
+      loadRulesFn: () => rules,
+    });
+
+    const r = result.rows[0];
+    expect(r?.replayDecision).toBe("none");
+    // ask → none is a real flip (previously gated, now effectively unmatched).
+    expect(r?.unchanged).toBe(false);
+    expect(r?.changeKind).toBe("now_denied");
+
+    expect(result.changedCount).toBe(1);
+    expect(result.nowDeniedCount).toBe(1);
+    expect(
+      result.nowAllowedCount + result.nowDeniedCount + result.nowAskedCount,
+    ).toBe(result.changedCount);
+  });
+
+  it("exposes a nowAskedCount field and counts *→ask transitions", () => {
+    const rules: PermissionRules = {
+      allow: [],
+      ask: ["ToolAsk"],
+      deny: [],
+    };
+    const entries = [
+      // originally allow, current policy asks → now_asked
+      row("ToolAsk", "allow"),
+    ];
+
+    const result = computeDecisionReplay(fakeLog(entries), {
+      workspace: "/ws",
+      loadRulesFn: () => rules,
+    });
+
+    expect(result.nowAskedCount).toBe(1);
+    expect(result.rows[0]?.changeKind).toBe("now_asked");
+    expect(result.changedCount).toBe(1);
+    expect(
+      result.nowAllowedCount + result.nowDeniedCount + result.nowAskedCount,
+    ).toBe(result.changedCount);
+  });
+
+  it("every changed row maps to exactly one bucket across a mixed fixture", () => {
+    const rules: PermissionRules = {
+      allow: ["ToolAllow"],
+      ask: ["ToolAsk"],
+      deny: ["ToolDeny"],
+    };
+    const entries = [
+      row("ToolDeny", "ask"), // ask → deny (now_denied)
+      row("ToolAllow", "ask"), // ask → allow (now_allowed)
+      row("ToolAsk", "allow"), // allow → ask (now_asked)
+      row("ToolDeny", "allow"), // allow → deny (now_denied)
+      row("Unmatched", "ask"), // ask → none (now_denied)
+      row("ToolAllow", "allow"), // unchanged
+      row("ToolDeny", "deny"), // unchanged
+    ];
+
+    const result = computeDecisionReplay(fakeLog(entries), {
+      workspace: "/ws",
+      loadRulesFn: () => rules,
+    });
+
+    // 5 changed, 2 unchanged.
+    expect(result.changedCount).toBe(5);
+    expect(result.nowAllowedCount).toBe(1);
+    expect(result.nowAskedCount).toBe(1);
+    expect(result.nowDeniedCount).toBe(3);
+
+    // Invariant: buckets sum to changedCount, and every changed row carries a kind.
+    expect(
+      result.nowAllowedCount + result.nowDeniedCount + result.nowAskedCount,
+    ).toBe(result.changedCount);
+    for (const r of result.rows) {
+      if (r.unchanged) {
+        expect(r.changeKind).toBeUndefined();
+      } else {
+        expect(r.changeKind).toBeDefined();
+      }
+    }
+  });
+});

--- a/src/__tests__/recipe-cli.integration.test.ts
+++ b/src/__tests__/recipe-cli.integration.test.ts
@@ -1,5 +1,6 @@
 import { type ChildProcess, spawn, spawnSync } from "node:child_process";
 import fs from "node:fs";
+import net from "node:net";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -13,6 +14,26 @@ const tsxBin = path.join(workspaceRoot, "node_modules", ".bin", "tsx");
 
 const tmpDirs: string[] = [];
 const childProcs = new Set<ChildProcess>();
+const servers = new Set<net.Server>();
+
+/**
+ * Accept TCP connections but never write a byte back — simulates a bridge
+ * whose PID is alive (so findBridgeLock accepts it) but whose HTTP server
+ * is wedged. Resolves with the bound port.
+ */
+function startWedgedServer(): Promise<{ port: number; server: net.Server }> {
+  return new Promise((resolve) => {
+    const server = net.createServer(() => {
+      /* hold the socket open, never respond */
+    });
+    servers.add(server);
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address();
+      const port = typeof addr === "object" && addr ? addr.port : 0;
+      resolve({ port, server });
+    });
+  });
+}
 
 function makeTmpDir(): string {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "patchwork-recipe-cli-"));
@@ -90,6 +111,11 @@ afterEach(async () => {
   }
   childProcs.clear();
 
+  for (const server of servers) {
+    server.close();
+  }
+  servers.clear();
+
   for (const dir of tmpDirs.splice(0)) {
     try {
       fs.rmSync(dir, { recursive: true, force: true });
@@ -125,6 +151,46 @@ describe.skipIf(process.platform === "win32")("recipe CLI integration", () => {
     expect(result.stdout).toContain(outputPath);
     expect(fs.readFileSync(outputPath, "utf-8")).toBe("run cli");
   });
+
+  it("recipe run aborts and exits non-zero when the bridge is wedged on HTTP", async () => {
+    // A bridge whose PID is alive (findBridgeLock accepts it) but whose
+    // HTTP server never responds. Before the AbortController fix the CLI
+    // would block forever; now it must abort after the 30s deadline and
+    // exit non-zero with a clear "did not respond" error.
+    const { port } = await startWedgedServer();
+
+    const configDir = makeTmpDir();
+    const ideDir = path.join(configDir, "ide");
+    fs.mkdirSync(ideDir, { recursive: true });
+    // PID = this test process: guaranteed live, so the lock survives the
+    // process.kill(pid, 0) check inside findBridgeLock.
+    fs.writeFileSync(
+      path.join(ideDir, `${port}.lock`),
+      JSON.stringify({
+        pid: process.pid,
+        authToken: "test-token",
+        workspace: workspaceRoot,
+        isBridge: true,
+      }),
+    );
+
+    const proc = spawn(tsxBin, [srcIndex, "recipe", "run", "some-recipe"], {
+      cwd: workspaceRoot,
+      env: { ...process.env, CLAUDE_CONFIG_DIR: configDir },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    childProcs.add(proc);
+
+    const stderrLines: string[] = [];
+    collectStream(proc.stderr, stderrLines);
+
+    // Allow generous headroom over the 30s in-CLI deadline.
+    const exitCode = await waitForExit(proc, 45_000);
+    childProcs.delete(proc);
+
+    expect(exitCode).not.toBe(0);
+    expect(stderrLines.join("\n")).toMatch(/did not respond within 30s/);
+  }, 50_000);
 
   it("recipe watch reruns the recipe on save and prints run output", async () => {
     const homeDir = makeTmpDir();

--- a/src/__tests__/transport.test.ts
+++ b/src/__tests__/transport.test.ts
@@ -1569,4 +1569,58 @@ describe("setDenyTools", () => {
     const resp = await waitFor(ws, (m) => m.id === 12);
     expect(resp.result.isError).toBeUndefined();
   });
+
+  it("denies a dynamic-dispatch (unregistered) tool when it is in the deny list", async () => {
+    let dispatched = false;
+    const { ws } = await setup("deny-tools-test-token-dyn000000000", (t) => {
+      // No static tool with this name — it routes through dynamicToolDispatch.
+      t.setDynamicToolDispatch(async () => {
+        dispatched = true;
+        return { content: [{ type: "text", text: "should not run" }] };
+      });
+      t.setDenyTools(new Set(["proxiedTool"]));
+    });
+
+    send(ws, {
+      jsonrpc: "2.0",
+      id: 13,
+      method: "tools/call",
+      params: { name: "proxiedTool", arguments: {} },
+    });
+    // The denied response is an isError:true result mentioning "denied".
+    const resp = await waitFor(
+      ws,
+      (m) => m.id === 13 && m.result?.isError === true,
+    );
+    expect(resp.result.content[0].text).toMatch(/denied/);
+    // Give any (incorrectly) scheduled dynamic dispatch a tick to run.
+    await new Promise((r) => setTimeout(r, 30));
+    // The proxy handler must never have been invoked for a denied tool.
+    expect(dispatched).toBe(false);
+  });
+
+  it("allows a dynamic-dispatch tool when it is not in the deny list", async () => {
+    let dispatched = false;
+    const { ws } = await setup("deny-tools-test-token-dyn111111111", (t) => {
+      t.setDynamicToolDispatch(async () => {
+        dispatched = true;
+        return { content: [{ type: "text", text: "dynamic ok" }] };
+      });
+      t.setDenyTools(new Set(["somethingElse"]));
+    });
+
+    send(ws, {
+      jsonrpc: "2.0",
+      id: 14,
+      method: "tools/call",
+      params: { name: "proxiedTool", arguments: {} },
+    });
+    // The proxy result carries the dispatch handler's content.
+    const resp = await waitFor(
+      ws,
+      (m) => m.id === 14 && m.result?.content?.[0]?.text === "dynamic ok",
+    );
+    expect(resp.result.content[0].text).toBe("dynamic ok");
+    expect(dispatched).toBe(true);
+  });
 });

--- a/src/connectors/__tests__/datadog.test.ts
+++ b/src/connectors/__tests__/datadog.test.ts
@@ -47,6 +47,44 @@ describe("datadog token helpers", () => {
     expect(loadTokens()).toBeNull();
   });
 
+  // Regression: DATADOG_SITE env var bypassed the SSRF allowlist that the
+  // connect handler enforces. baseUrl() interpolates site into
+  // `https://api.${site}` so an unvalidated env value redirects credentials.
+  it("loadTokens rejects a non-allowlisted DATADOG_SITE (falls back to default)", async () => {
+    process.env.DATADOG_API_KEY = "api-key-123";
+    process.env.DATADOG_APP_KEY = "app-key-456";
+    process.env.DATADOG_SITE = "evil.com";
+    const { loadTokens } = await import("../datadog.js");
+    const tokens = loadTokens();
+    expect(tokens).not.toBeNull();
+    // Must NOT carry the attacker-supplied site through to baseUrl().
+    expect(tokens!.site).not.toBe("evil.com");
+    expect(tokens!.site).toBe("datadoghq.com");
+  });
+
+  it("loadTokens rejects SSRF-shaped DATADOG_SITE values", async () => {
+    process.env.DATADOG_API_KEY = "k";
+    process.env.DATADOG_APP_KEY = "k";
+    const { loadTokens } = await import("../datadog.js");
+    for (const bad of [
+      "127.0.0.1:9091/x",
+      "169.254.169.254",
+      "evil.com/datadoghq.com",
+    ]) {
+      process.env.DATADOG_SITE = bad;
+      const tokens = loadTokens();
+      expect(tokens!.site).toBe("datadoghq.com");
+    }
+  });
+
+  it("loadTokens preserves an allowlisted DATADOG_SITE", async () => {
+    process.env.DATADOG_API_KEY = "k";
+    process.env.DATADOG_APP_KEY = "k";
+    process.env.DATADOG_SITE = "us3.datadoghq.com";
+    const { loadTokens } = await import("../datadog.js");
+    expect(loadTokens()!.site).toBe("us3.datadoghq.com");
+  });
+
   it("saveTokens + loadTokens round-trips", async () => {
     const { loadTokens, saveTokens } = await import("../datadog.js");
     const tokens = {

--- a/src/connectors/__tests__/mcpClient.test.ts
+++ b/src/connectors/__tests__/mcpClient.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Regression test: McpClient.post must reactively refresh + retry once on an
+ * upstream 401.
+ *
+ * MCP connectors (GitHub / Linear) cache the OAuth access token between calls.
+ * When the upstream server rejects a still-cached token with 401 (e.g. the
+ * token was revoked or rotated server-side before our local expiry buffer
+ * tripped), the client must re-fetch the token (re-entering refreshIfNeeded in
+ * mcpOAuth) and retry the POST exactly once — not throw on the first 401.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { McpClient } from "../mcpClient.js";
+
+function jsonRpcResponse(id: number, result: unknown): Response {
+  return new Response(JSON.stringify({ jsonrpc: "2.0", id, result }), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("McpClient 401 refresh + retry", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("refreshes the token once and retries the POST after a 401", async () => {
+    // getAccessToken yields a stale token first, then a fresh one. Subsequent
+    // posts (notifications/initialized, tools/list) re-read the fresh token.
+    let refreshes = 0;
+    const getAccessToken = vi.fn(async () => {
+      // The first call returns the stale token; every call after the 401-driven
+      // re-fetch returns the refreshed token.
+      if (refreshes === 0) {
+        refreshes = 1;
+        return "stale-token";
+      }
+      return "fresh-token";
+    });
+
+    // First fetch (initialize) → 401. After the retry, all posts succeed.
+    let call = 0;
+    const fetchMock = vi.fn(async (_url: string, _init?: RequestInit) => {
+      call += 1;
+      if (call === 1) return new Response("unauthorized", { status: 401 });
+      // Retry of initialize + notifications + tools/list: valid JSON-RPC.
+      return jsonRpcResponse(call, { tools: [] });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new McpClient(
+      "https://mcp.example.test/mcp",
+      getAccessToken,
+    );
+
+    // ping → listTools → ensureInitialized → first post is `initialize`,
+    // which 401s, triggers a single token re-fetch + retry, then succeeds.
+    const ok = await client.ping();
+
+    expect(ok).toBe(true);
+    // The retried (2nd) fetch carried the refreshed token, proving the client
+    // re-fetched the access token after the 401 and used it on the retry.
+    const secondCallHeaders = fetchMock.mock.calls[1]?.[1]?.headers as
+      | Record<string, string>
+      | undefined;
+    expect(secondCallHeaders?.Authorization).toBe("Bearer fresh-token");
+    // The first (401'd) fetch carried the stale token.
+    const firstCallHeaders = fetchMock.mock.calls[0]?.[1]?.headers as
+      | Record<string, string>
+      | undefined;
+    expect(firstCallHeaders?.Authorization).toBe("Bearer stale-token");
+  });
+
+  it("does not retry more than once (no infinite loop) on repeated 401", async () => {
+    const getAccessToken = vi.fn(async () => "any-token");
+    const fetchMock = vi.fn(
+      async () => new Response("unauthorized", { status: 401 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new McpClient(
+      "https://mcp.example.test/mcp",
+      getAccessToken,
+    );
+
+    // Always-401: ping() swallows the throw and returns false.
+    const ok = await client.ping();
+    expect(ok).toBe(false);
+
+    // Exactly one initialize POST + one retry = 2 fetches; no infinite loop.
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    // Token re-fetched once for the retry.
+    expect(getAccessToken).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/connectors/__tests__/notion.test.ts
+++ b/src/connectors/__tests__/notion.test.ts
@@ -117,6 +117,36 @@ describe("handleNotionConnect", () => {
     expect(JSON.parse(result.body).ok).toBe(false);
   });
 
+  it("accepts an ntn_-prefixed token (Notion's newer token format)", async () => {
+    const tmpDirN = join(os.tmpdir(), `patchwork-notion-ntn-${Date.now()}`);
+    const homeDirN = join(tmpDirN, "home");
+    const patchworkHomeN = join(homeDirN, ".patchwork");
+    mkdirSync(join(patchworkHomeN, "tokens"), { recursive: true });
+    process.env.HOME = homeDirN;
+    process.env.PATCHWORK_HOME = patchworkHomeN;
+    process.env.PATCHWORK_TOKEN_STORAGE_BACKEND = "file";
+
+    global.fetch = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        bot: { workspace_name: "NtnWS", owner: { workspace_id: "ws-ntn" } },
+      }),
+    }) as unknown as typeof fetch;
+
+    const { handleNotionConnect, loadTokens } = await import("../notion.js");
+    const result = await handleNotionConnect(
+      JSON.stringify({ token: "ntn_abc123def456" }),
+    );
+    expect(result.status).toBe(200);
+    expect(JSON.parse(result.body).ok).toBe(true);
+    expect(loadTokens()?.accessToken).toBe("ntn_abc123def456");
+
+    rmSync(tmpDirN, { recursive: true, force: true });
+    delete process.env.HOME;
+    delete process.env.PATCHWORK_HOME;
+    delete process.env.PATCHWORK_TOKEN_STORAGE_BACKEND;
+  });
+
   it("returns 401 when Notion API rejects the token", async () => {
     global.fetch = vi.fn().mockResolvedValueOnce({
       ok: false,

--- a/src/connectors/__tests__/redis.test.ts
+++ b/src/connectors/__tests__/redis.test.ts
@@ -199,6 +199,41 @@ describe("redis allowlist", () => {
     // DEBUG alone (without OBJECT subcommand) is not in the set
     expect(isReadOnlyCommand("DEBUG")).toBe(false);
   });
+
+  // Regression: bare "CLIENT"/"MEMORY" were in the allowlist, so mutating
+  // subcommands (CLIENT KILL/SETNAME/NO-EVICT/UNPAUSE, MEMORY PURGE) all
+  // passed as "read-only". Only the safe two-word forms should be allowed.
+  it("rejects bare CLIENT (no read-only subcommand)", () => {
+    expect(isReadOnlyCommand("CLIENT")).toBe(false);
+  });
+
+  it("rejects bare MEMORY (no read-only subcommand)", () => {
+    expect(isReadOnlyCommand("MEMORY")).toBe(false);
+  });
+
+  it("rejects mutating CLIENT subcommands", () => {
+    expect(isReadOnlyCommand("CLIENT", ["KILL", "ID", "5"])).toBe(false);
+    expect(isReadOnlyCommand("CLIENT", ["SETNAME", "x"])).toBe(false);
+    expect(isReadOnlyCommand("CLIENT", ["NO-EVICT", "ON"])).toBe(false);
+    expect(isReadOnlyCommand("CLIENT", ["UNPAUSE"])).toBe(false);
+  });
+
+  it("rejects MEMORY PURGE", () => {
+    expect(isReadOnlyCommand("MEMORY", ["PURGE"])).toBe(false);
+  });
+
+  it("still allows safe CLIENT subcommands", () => {
+    expect(isReadOnlyCommand("CLIENT", ["GETNAME"])).toBe(true);
+    expect(isReadOnlyCommand("CLIENT", ["ID"])).toBe(true);
+    expect(isReadOnlyCommand("CLIENT", ["INFO"])).toBe(true);
+    expect(isReadOnlyCommand("CLIENT", ["LIST"])).toBe(true);
+  });
+
+  it("still allows safe MEMORY subcommands", () => {
+    expect(isReadOnlyCommand("MEMORY", ["USAGE", "key"])).toBe(true);
+    expect(isReadOnlyCommand("MEMORY", ["STATS"])).toBe(true);
+    expect(isReadOnlyCommand("MEMORY", ["DOCTOR"])).toBe(true);
+  });
 });
 
 describe("RedisConnector.command_run", () => {
@@ -238,6 +273,34 @@ describe("RedisConnector.command_run", () => {
     expect(out).toBe("pong-ish");
     const lastSend = calls.find((c) => c.method === "sendCommand");
     expect(lastSend?.args[0]).toEqual(["PING"]);
+  });
+
+  it("rejects CLIENT KILL / MEMORY PURGE before reaching the wire", async () => {
+    seed();
+    const { client } = makeFakeClient();
+    __setRedisModuleForTest(makeFakeModule(client));
+    const conn = new RedisConnector();
+    await expect(
+      conn.command_run("CLIENT", ["KILL", "ID", "5"]),
+    ).rejects.toThrow(/not in the read-only allowlist/i);
+    await expect(conn.command_run("MEMORY", ["PURGE"])).rejects.toThrow(
+      /not in the read-only allowlist/i,
+    );
+    expect(client.sendCommand).not.toHaveBeenCalled();
+  });
+
+  it("allows CLIENT LIST / MEMORY USAGE through command_run", async () => {
+    seed();
+    const { client, calls } = makeFakeClient({
+      sendCommandImpl: async (args) => args.join(" "),
+    });
+    __setRedisModuleForTest(makeFakeModule(client));
+    const conn = new RedisConnector();
+    expect(await conn.command_run("CLIENT", ["LIST"])).toBe("CLIENT LIST");
+    expect(await conn.command_run("MEMORY", ["USAGE", "k"])).toBe(
+      "MEMORY USAGE k",
+    );
+    expect(calls.filter((c) => c.method === "sendCommand")).toHaveLength(2);
   });
 });
 

--- a/src/connectors/__tests__/snowflake.test.ts
+++ b/src/connectors/__tests__/snowflake.test.ts
@@ -339,6 +339,44 @@ describe("executeQuery", () => {
     expect(body.warehouse).toBe("COMPUTE_WH");
   });
 
+  // Regression: SQL API v2 returns HTTP 202 (still in 2xx) with a
+  // statementHandle and no data when a query exceeds the sync window.
+  // postStatement only checked res.ok, so it silently returned rows:[].
+  it("throws (not silent empty) when the statement is still executing async (202)", async () => {
+    process.env.SNOWFLAKE_ACCOUNT = "xy12345";
+    process.env.SNOWFLAKE_USER = "alice";
+    process.env.SNOWFLAKE_PAT = "pat";
+    installFetchMock(() =>
+      mockFetchResponse({
+        status: 202,
+        body: {
+          statementHandle: "01b2-async-handle",
+          message: "Asynchronous execution in progress.",
+        },
+      }),
+    );
+    const { getSnowflakeConnector } = await import("../snowflake.js");
+    const c = getSnowflakeConnector();
+    await expect(c.executeQuery("SELECT 1")).rejects.toThrow(
+      /still (executing|running)|async/i,
+    );
+  });
+
+  it("async 202 error mentions the statementHandle so the user can poll", async () => {
+    process.env.SNOWFLAKE_ACCOUNT = "xy12345";
+    process.env.SNOWFLAKE_USER = "alice";
+    process.env.SNOWFLAKE_PAT = "pat";
+    installFetchMock(() =>
+      mockFetchResponse({
+        status: 202,
+        body: { statementHandle: "handle-xyz-123" },
+      }),
+    );
+    const { getSnowflakeConnector } = await import("../snowflake.js");
+    const c = getSnowflakeConnector();
+    await expect(c.executeQuery("SELECT 1")).rejects.toThrow(/handle-xyz-123/);
+  });
+
   it("truncates result rows above the row limit", async () => {
     process.env.SNOWFLAKE_ACCOUNT = "xy12345";
     process.env.SNOWFLAKE_USER = "alice";

--- a/src/connectors/datadog.ts
+++ b/src/connectors/datadog.ts
@@ -323,10 +323,18 @@ export function loadTokens(): DatadogTokens | null {
   const envApiKey = process.env.DATADOG_API_KEY;
   const envAppKey = process.env.DATADOG_APP_KEY;
   if (envApiKey && envAppKey) {
+    // Defend against authenticated SSRF: site flows into baseUrl()
+    // (`https://api.${site}`), so an unvalidated env value would redirect
+    // Datadog credentials to an attacker-chosen host. Mirror the
+    // connect-handler enum check — fall back to the default if the env
+    // value isn't an allowlisted Datadog site. Audit 2026-06-02.
+    const envSite = process.env.DATADOG_SITE;
+    const site =
+      envSite && DATADOG_ALLOWED_SITES.has(envSite) ? envSite : "datadoghq.com";
     return {
       apiKey: envApiKey,
       appKey: envAppKey,
-      site: process.env.DATADOG_SITE ?? "datadoghq.com",
+      site,
       connected_at: new Date().toISOString(),
     };
   }

--- a/src/connectors/mcpClient.ts
+++ b/src/connectors/mcpClient.ts
@@ -114,30 +114,50 @@ export class McpClient {
     body: unknown,
     opts: McpCallOptions = {},
   ): Promise<unknown> {
-    const token = await this.getAccessToken();
-    const signal = withTimeout(opts.signal, opts.timeoutMs ?? DEFAULT_TIMEOUT);
-    const headers: Record<string, string> = {
-      "Content-Type": "application/json",
-      Accept: "application/json, text/event-stream",
-      Authorization: `Bearer ${token}`,
-    };
-    if (this.sessionId) headers["Mcp-Session-Id"] = this.sessionId;
+    // On a 401 the upstream rejected our (possibly stale) access token. Re-fetch
+    // the token — which re-enters refreshIfNeeded in mcpOAuth (with refreshInflight
+    // dedup) — and retry the POST exactly once. The `retried` guard prevents a
+    // refresh/retry loop when the refreshed token is also rejected.
+    const serialized = JSON.stringify(body);
+    let retried = false;
+    for (;;) {
+      const token = await this.getAccessToken();
+      const signal = withTimeout(
+        opts.signal,
+        opts.timeoutMs ?? DEFAULT_TIMEOUT,
+      );
+      const headers: Record<string, string> = {
+        "Content-Type": "application/json",
+        Accept: "application/json, text/event-stream",
+        Authorization: `Bearer ${token}`,
+      };
+      if (this.sessionId) headers["Mcp-Session-Id"] = this.sessionId;
 
-    const res = await fetch(this.endpoint, {
-      method: "POST",
-      headers,
-      body: JSON.stringify(body),
-      signal,
-    });
-    // Pick up session id if server issued one
-    const sid = res.headers.get("mcp-session-id");
-    if (sid) this.sessionId = sid;
+      const res = await fetch(this.endpoint, {
+        method: "POST",
+        headers,
+        body: serialized,
+        signal,
+      });
+      // Pick up session id if server issued one
+      const sid = res.headers.get("mcp-session-id");
+      if (sid) this.sessionId = sid;
 
-    if (!res.ok) {
-      const snippet = (await res.text()).slice(0, 300);
-      throw new Error(`MCP HTTP ${res.status} at ${this.endpoint}: ${snippet}`);
+      if (res.status === 401 && !retried) {
+        retried = true;
+        // Drain the body so the connection can be reused, then loop to refresh.
+        await res.text().catch(() => {});
+        continue;
+      }
+
+      if (!res.ok) {
+        const snippet = (await res.text()).slice(0, 300);
+        throw new Error(
+          `MCP HTTP ${res.status} at ${this.endpoint}: ${snippet}`,
+        );
+      }
+      return parseMcpResponse(res);
     }
-    return parseMcpResponse(res);
   }
 
   private async ensureInitialized(opts: McpCallOptions = {}): Promise<void> {

--- a/src/connectors/notion.ts
+++ b/src/connectors/notion.ts
@@ -475,7 +475,7 @@ export interface ConnectorHandlerResult {
 }
 
 /**
- * POST /connections/notion/connect  { token: "secret_..." }
+ * POST /connections/notion/connect  { token: "secret_..." | "ntn_..." }
  * Stores the integration token and verifies it by calling /users/me.
  */
 export async function handleNotionConnect(
@@ -486,7 +486,7 @@ export async function handleNotionConnect(
     const parsed = JSON.parse(body) as { token?: unknown };
     if (
       typeof parsed.token !== "string" ||
-      !parsed.token.startsWith("secret_")
+      !(parsed.token.startsWith("secret_") || parsed.token.startsWith("ntn_"))
     ) {
       return {
         status: 400,
@@ -494,7 +494,7 @@ export async function handleNotionConnect(
         body: JSON.stringify({
           ok: false,
           error:
-            'Notion integration token must start with "secret_". Find it at https://www.notion.so/my-integrations',
+            'Notion integration token must start with "secret_" or "ntn_". Find it at https://www.notion.so/my-integrations',
         }),
       };
     }

--- a/src/connectors/redis.ts
+++ b/src/connectors/redis.ts
@@ -143,8 +143,16 @@ export const READ_ONLY_COMMANDS: ReadonlySet<string> = new Set([
   "DBSIZE",
   "INFO",
   "PING",
-  "CLIENT",
-  "MEMORY",
+  // CLIENT / MEMORY are containers for both read-only AND mutating
+  // subcommands (CLIENT KILL/SETNAME/NO-EVICT/UNPAUSE, MEMORY PURGE).
+  // Allowlist only the safe two-word forms — never the bare command.
+  "CLIENT GETNAME",
+  "CLIENT ID",
+  "CLIENT INFO",
+  "CLIENT LIST",
+  "MEMORY USAGE",
+  "MEMORY STATS",
+  "MEMORY DOCTOR",
   "DEBUG OBJECT",
 ]);
 

--- a/src/connectors/snowflake.ts
+++ b/src/connectors/snowflake.ts
@@ -365,6 +365,25 @@ export class SnowflakeConnector extends BaseConnector {
       }
       throw new SnowflakeHttpError(res.status, detail);
     }
+    // HTTP 202 is in the 2xx range (res.ok === true) but carries NO data:
+    // the SQL API moved the statement to asynchronous execution because it
+    // exceeded the synchronous window. Returning here would silently yield
+    // rows:[]. Surface a clear error with the handle so the caller can poll
+    // GET /api/v2/statements/<handle> instead of assuming an empty result.
+    if (res.status === 202) {
+      let handle: string | undefined;
+      try {
+        const partial = (await res.json()) as SnowflakeStatementResponse;
+        handle = partial.statementHandle;
+      } catch {
+        // ignore — fall back to a handle-less message
+      }
+      throw new Error(
+        handle
+          ? `Snowflake statement is still executing asynchronously (statementHandle "${handle}"); it exceeded the synchronous window. Poll GET /api/v2/statements/${handle} for results.`
+          : "Snowflake statement is still executing asynchronously; it exceeded the synchronous window. Poll GET /api/v2/statements/<statementHandle> for results.",
+      );
+    }
     return (await res.json()) as SnowflakeStatementResponse;
   }
 }

--- a/src/decisionReplay.ts
+++ b/src/decisionReplay.ts
@@ -35,10 +35,10 @@ export interface ReplayRow {
   /** True when original === replay. */
   unchanged: boolean;
   /**
-   * Direction of change for changed rows:
-   *   "now_allowed"  — was deny/ask, would now be allow
-   *   "now_denied"   — was allow, would now be deny/ask
-   *   "now_asked"    — was allow/deny, would now be ask
+   * Direction of change for changed rows, keyed off the NEW (replay) outcome:
+   *   "now_allowed"  — would now be allow (was deny/ask/none)
+   *   "now_denied"   — would now be deny or none/blocked (was allow/ask/none)
+   *   "now_asked"    — would now be ask (was allow/deny/none)
    */
   changeKind?: "now_allowed" | "now_denied" | "now_asked";
   /**
@@ -58,23 +58,50 @@ export interface DecisionReplayResult {
   totalRows: number;
   /** Rows where the decision would have changed. */
   changedCount: number;
-  /** Rows that would flip from deny/ask → allow under current policy. */
+  /** Rows that would flip to allow under current policy. */
   nowAllowedCount: number;
-  /** Rows that would flip from allow → deny/ask under current policy. */
+  /** Rows that would flip to deny/none (effectively blocked) under current policy. */
   nowDeniedCount: number;
+  /** Rows that would flip to ask under current policy. */
+  nowAskedCount: number;
   /** Workspace path used to load current rules. */
   workspace: string;
 }
 
+/**
+ * Decide whether two decisions are equivalent for replay purposes.
+ *
+ * A `replay` of "none" (no current rule matched) is treated as unchanged when
+ * the original was "allow" or "deny" — absence of an explicit rule defaults to
+ * the same effective outcome the user already saw, so it is not a real flip.
+ */
+function isUnchanged(original: string, replay: ReplayDecision): boolean {
+  return (
+    replay === original ||
+    (replay === "none" && original === "allow") ||
+    (replay === "none" && original === "deny")
+  );
+}
+
+/**
+ * Bucket a CHANGED row by its NEW (replay) outcome. Keyed purely off the replay
+ * direction so every changed row maps to exactly one bucket and the three
+ * bucket counts always sum to changedCount:
+ *   - replay "allow"        → now_allowed
+ *   - replay "ask"          → now_asked
+ *   - replay "deny"/"none"  → now_denied (effectively blocked)
+ *
+ * Returns undefined for unchanged rows (no bucket).
+ */
 function changeKind(
   original: string,
   replay: ReplayDecision,
 ): ReplayRow["changeKind"] | undefined {
-  if (replay === "allow" && original !== "allow") return "now_allowed";
-  if ((replay === "deny" || replay === "none") && original === "allow")
-    return "now_denied";
-  if (replay === "ask" && original !== "ask") return "now_asked";
-  return undefined;
+  if (isUnchanged(original, replay)) return undefined;
+  if (replay === "allow") return "now_allowed";
+  if (replay === "ask") return "now_asked";
+  // A changed row whose replay is "deny" or "none" is effectively now blocked.
+  return "now_denied";
 }
 
 export function computeDecisionReplay(
@@ -132,10 +159,8 @@ export function computeDecisionReplay(
     const incomplete = specifier === undefined;
     const replay = evaluateRules(toolName, specifier, rules);
 
-    const unchanged =
-      replay === originalDecision ||
-      (replay === "none" && originalDecision === "allow") ||
-      (replay === "none" && originalDecision === "deny");
+    const unchanged = isUnchanged(originalDecision, replay);
+    const kind = changeKind(originalDecision, replay);
 
     rows.push({
       timestamp: entry.timestamp,
@@ -144,9 +169,7 @@ export function computeDecisionReplay(
       originalDecision,
       replayDecision: replay,
       unchanged,
-      ...(changeKind(originalDecision, replay) !== undefined && {
-        changeKind: changeKind(originalDecision, replay),
-      }),
+      ...(kind !== undefined && { changeKind: kind }),
       ...(incomplete && { incomplete: true }),
     });
   }
@@ -154,11 +177,13 @@ export function computeDecisionReplay(
   let changedCount = 0;
   let nowAllowedCount = 0;
   let nowDeniedCount = 0;
+  let nowAskedCount = 0;
   for (const r of rows) {
     if (r.unchanged) continue;
     changedCount++;
     if (r.changeKind === "now_allowed") nowAllowedCount++;
     else if (r.changeKind === "now_denied") nowDeniedCount++;
+    else if (r.changeKind === "now_asked") nowAskedCount++;
   }
 
   return {
@@ -168,6 +193,7 @@ export function computeDecisionReplay(
     changedCount,
     nowAllowedCount,
     nowDeniedCount,
+    nowAskedCount,
     workspace,
   };
 }

--- a/src/drivers/__tests__/claude-api.test.ts
+++ b/src/drivers/__tests__/claude-api.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ApiDriver } from "../claude/api.js";
+import type { ProviderTaskInput } from "../types.js";
+
+const mockCreate = vi.fn();
+vi.mock("@anthropic-ai/sdk", () => ({
+  default: vi.fn().mockImplementation(() => ({
+    messages: { create: mockCreate },
+  })),
+}));
+
+const log = vi.fn();
+
+beforeEach(() => {
+  process.env.ANTHROPIC_API_KEY = "test-anthropic-key";
+  mockCreate.mockReset();
+  log.mockReset();
+});
+
+afterEach(() => {
+  delete process.env.ANTHROPIC_API_KEY;
+});
+
+function makeInput(
+  overrides: Partial<ProviderTaskInput> = {},
+): ProviderTaskInput {
+  return {
+    prompt: "hi",
+    workspace: "/tmp",
+    timeoutMs: 5000,
+    signal: new AbortController().signal,
+    ...overrides,
+  };
+}
+
+describe("ApiDriver", () => {
+  it("returns concatenated text on success", async () => {
+    mockCreate.mockResolvedValue({
+      content: [
+        { type: "text", text: "Hello" },
+        { type: "text", text: ", world" },
+      ],
+    });
+    const driver = new ApiDriver(log);
+    const result = await driver.run(makeInput());
+    expect(result.text).toBe("Hello, world");
+    expect(result.exitCode).toBe(0);
+  });
+
+  // Bug 2 regression: ProviderDriver.run must resolve, never reject. Before the
+  // try/catch was added, a rejecting messages.create propagated the rejection.
+  it("resolves with errorMessage when messages.create throws (does not reject)", async () => {
+    mockCreate.mockRejectedValue(new Error("rate limit"));
+    const driver = new ApiDriver(log);
+    const result = await driver.run(makeInput());
+    expect(result.errorMessage).toBe("rate limit");
+    expect(result.text).toBe("");
+    expect(result.wasAborted).toBeUndefined();
+  });
+
+  it("resolves with wasAborted on AbortError (does not reject)", async () => {
+    const ac = new AbortController();
+    mockCreate.mockImplementation(async () => {
+      ac.abort();
+      throw Object.assign(new Error("aborted"), { name: "AbortError" });
+    });
+    const driver = new ApiDriver(log);
+    const result = await driver.run(makeInput({ signal: ac.signal }));
+    expect(result.wasAborted).toBe(true);
+    expect(result.text).toBe("");
+    expect(result.errorMessage).toBeUndefined();
+  });
+
+  it("treats a thrown error as aborted when the signal is already aborted", async () => {
+    const ac = new AbortController();
+    ac.abort();
+    mockCreate.mockRejectedValue(new Error("request cancelled"));
+    const driver = new ApiDriver(log);
+    const result = await driver.run(makeInput({ signal: ac.signal }));
+    expect(result.wasAborted).toBe(true);
+    expect(result.errorMessage).toBeUndefined();
+  });
+});

--- a/src/drivers/__tests__/claude-subprocess-byte-cap.test.ts
+++ b/src/drivers/__tests__/claude-subprocess-byte-cap.test.ts
@@ -1,0 +1,164 @@
+import { EventEmitter } from "node:events";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+class MockChild extends EventEmitter {
+  stdout = new EventEmitter();
+  stderr = new EventEmitter();
+  exitCode: number | null = null;
+  killed = false;
+  kill = vi.fn(() => {
+    this.killed = true;
+    this.emit("close", 0);
+    return true;
+  });
+}
+
+let mockChild: MockChild;
+
+vi.mock("node:child_process", async (importOriginal) => {
+  const original = await importOriginal<typeof import("node:child_process")>();
+  return {
+    ...original,
+    spawn: vi.fn(() => {
+      mockChild = new MockChild();
+      mockChild.stdout = new EventEmitter();
+      mockChild.stderr = new EventEmitter();
+      (mockChild.stdout as { setEncoding?: () => void }).setEncoding = vi.fn();
+      (mockChild.stderr as { setEncoding?: () => void }).setEncoding = vi.fn();
+      return mockChild;
+    }),
+  };
+});
+
+import { SubprocessDriver } from "../claude/subprocess.js";
+import type { ProviderTaskInput } from "../types.js";
+
+const OUTPUT_CAP = 50 * 1024;
+// Buffer.toString("utf8") substitutes a 3-byte U+FFFD for the incomplete
+// trailing sequence when the cap lands mid-codepoint, so the byte total may
+// exceed the cap by up to 2 bytes (replacement char minus the partial bytes
+// it stands in for). This is bounded — the bug being fixed is a 3-4x overshoot
+// (slice() counts UTF-16 code units), not this single-replacement slack.
+const CAP_TOLERANCE = OUTPUT_CAP + 2;
+
+function makeInput(
+  overrides: Partial<ProviderTaskInput> = {},
+): ProviderTaskInput {
+  return {
+    prompt: "hello",
+    workspace: "/tmp/test",
+    timeoutMs: 5000,
+    signal: new AbortController().signal,
+    ...overrides,
+  };
+}
+
+/** True if the string contains a lone (unpaired) UTF-16 surrogate. */
+function hasLoneSurrogate(s: string): boolean {
+  for (let i = 0; i < s.length; i++) {
+    const code = s.charCodeAt(i);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      // high surrogate — must be followed by a low surrogate
+      const next = i + 1 < s.length ? s.charCodeAt(i + 1) : 0;
+      if (next < 0xdc00 || next > 0xdfff) return true;
+      i++; // valid pair, skip the low surrogate
+    } else if (code >= 0xdc00 && code <= 0xdfff) {
+      // low surrogate with no preceding high surrogate
+      return true;
+    }
+  }
+  return false;
+}
+
+describe("SubprocessDriver UTF-8 byte cap", () => {
+  let driver: SubprocessDriver;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    driver = new SubprocessDriver("claude", "ant", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // Bug 1 regression: OUTPUT_CAP is a BYTE budget. Streaming multi-byte CJK /
+  // emoji text via String.slice(0, cap) overshoots the cap ~3-4x (slice counts
+  // UTF-16 code units, not bytes) and can emit a lone surrogate at the boundary.
+  it("caps streamed onChunk output to <= OUTPUT_CAP bytes for multi-byte assistant text and emits no lone surrogate", async () => {
+    const chunks: string[] = [];
+    // A long run of 3-byte CJK chars: 30,000 chars == 90,000 UTF-8 bytes,
+    // comfortably exceeding the 50KB cap. With the byte-safe fix the forwarded
+    // bytes must be <= cap; with the buggy slice() they'd be ~90KB.
+    const cjk = "中".repeat(30_000);
+    const p = driver.run(makeInput({ onChunk: (c) => chunks.push(c) }));
+    await new Promise<void>((r) => setTimeout(r, 0));
+    mockChild.stdout.emit(
+      "data",
+      `${JSON.stringify({
+        type: "assistant",
+        message: { role: "assistant", content: [{ type: "text", text: cjk }] },
+      })}\n`,
+    );
+    mockChild.stdout.emit(
+      "data",
+      `${JSON.stringify({ type: "result", is_error: false, result: cjk })}\n`,
+    );
+    mockChild.emit("close", 0);
+    await p;
+
+    const forwarded = chunks.join("");
+    const forwardedBytes = Buffer.byteLength(forwarded, "utf8");
+    expect(forwardedBytes).toBeLessThanOrEqual(CAP_TOLERANCE);
+    expect(hasLoneSurrogate(forwarded)).toBe(false);
+  });
+
+  it("caps emoji (4-byte / surrogate-pair) streamed output to <= OUTPUT_CAP bytes with no lone surrogate at the boundary", async () => {
+    const chunks: string[] = [];
+    // Emoji are surrogate pairs (2 UTF-16 units, 4 UTF-8 bytes). Use a count
+    // whose byte total straddles the cap so the truncation boundary can land
+    // mid-codepoint under the buggy slice().
+    const emoji = "😀".repeat(20_000); // 80,000 UTF-8 bytes
+    const p = driver.run(makeInput({ onChunk: (c) => chunks.push(c) }));
+    await new Promise<void>((r) => setTimeout(r, 0));
+    mockChild.stdout.emit(
+      "data",
+      `${JSON.stringify({
+        type: "assistant",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: emoji }],
+        },
+      })}\n`,
+    );
+    mockChild.stdout.emit(
+      "data",
+      `${JSON.stringify({ type: "result", is_error: false, result: emoji })}\n`,
+    );
+    mockChild.emit("close", 0);
+    await p;
+
+    const forwarded = chunks.join("");
+    expect(Buffer.byteLength(forwarded, "utf8")).toBeLessThanOrEqual(
+      CAP_TOLERANCE,
+    );
+    expect(hasLoneSurrogate(forwarded)).toBe(false);
+  });
+
+  it("caps final returned text to <= OUTPUT_CAP bytes (not UTF-16 units)", async () => {
+    const cjk = "中".repeat(30_000); // 90,000 UTF-8 bytes
+    const p = driver.run(makeInput());
+    await new Promise<void>((r) => setTimeout(r, 0));
+    mockChild.stdout.emit(
+      "data",
+      `${JSON.stringify({ type: "result", is_error: false, result: cjk })}\n`,
+    );
+    mockChild.emit("close", 0);
+    const result = await p;
+
+    expect(Buffer.byteLength(result.text, "utf8")).toBeLessThanOrEqual(
+      CAP_TOLERANCE,
+    );
+    expect(hasLoneSurrogate(result.text)).toBe(false);
+  });
+});

--- a/src/drivers/__tests__/claude-subprocess-byte-cap.test.ts
+++ b/src/drivers/__tests__/claude-subprocess-byte-cap.test.ts
@@ -1,4 +1,6 @@
 import { EventEmitter } from "node:events";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 class MockChild extends EventEmitter {
@@ -46,7 +48,7 @@ function makeInput(
 ): ProviderTaskInput {
   return {
     prompt: "hello",
-    workspace: "/tmp/test",
+    workspace: join(tmpdir(), "claude-subprocess-byte-cap-test"),
     timeoutMs: 5000,
     signal: new AbortController().signal,
     ...overrides,

--- a/src/drivers/claude/api.ts
+++ b/src/drivers/claude/api.ts
@@ -47,14 +47,37 @@ export class ApiDriver implements ProviderDriver {
 
     this.log("[ApiDriver] sending request to Anthropic API");
 
-    const message = await client.messages.create(
-      {
-        model: input.model ?? "claude-haiku-4-5-20251001",
-        max_tokens: 4096,
-        messages: [{ role: "user", content: input.prompt + contextNote }],
-      },
-      { signal: input.signal },
-    );
+    // ProviderDriver contract (types.ts): run() must resolve, never reject —
+    // swallow auth/429/network/abort errors into the result. messages.create
+    // rejects on all of these, so wrap it and translate into an errorMessage
+    // (or wasAborted for an abort/cancellation), mirroring OpenAIApiDriver.run.
+    let message: unknown;
+    try {
+      message = await client.messages.create(
+        {
+          model: input.model ?? "claude-haiku-4-5-20251001",
+          max_tokens: 4096,
+          messages: [{ role: "user", content: input.prompt + contextNote }],
+        },
+        { signal: input.signal },
+      );
+    } catch (err) {
+      const isAbort =
+        (err instanceof Error && err.name === "AbortError") ||
+        input.signal.aborted;
+      if (isAbort) {
+        return {
+          text: "",
+          durationMs: Date.now() - start,
+          wasAborted: true,
+        };
+      }
+      return {
+        text: "",
+        durationMs: Date.now() - start,
+        errorMessage: err instanceof Error ? err.message : String(err),
+      };
+    }
 
     // biome-ignore lint/suspicious/noExplicitAny: message is from dynamically imported optional dep
     const content = (message as any).content as Array<{

--- a/src/drivers/claude/subprocess.ts
+++ b/src/drivers/claude/subprocess.ts
@@ -17,6 +17,38 @@ import { createSubprocessSettings } from "./subprocessSettings.js";
 const OUTPUT_CAP = 50 * 1024; // 50KB
 
 /**
+ * Truncate `text` to at most `cap` UTF-8 bytes without splitting a multi-byte
+ * codepoint mid-sequence. `String.slice(0, cap)` operates on UTF-16 code
+ * units, so a 50K cap can store ~50K code points but emit up to ~200KB of
+ * UTF-8 wire bytes for CJK / emoji content — and may produce a lone surrogate
+ * at the boundary. `Buffer.toString("utf8")` substitutes U+FFFD for incomplete
+ * trailing sequences instead.
+ */
+function truncateUtf8Bytes(text: string, cap: number): string {
+  const buf = Buffer.from(text, "utf8");
+  if (buf.length <= cap) return text;
+  return buf.subarray(0, cap).toString("utf8");
+}
+
+/**
+ * Truncate `text` so it adds at most `remaining` UTF-8 bytes to the stream and
+ * never splits a multi-byte codepoint mid-sequence. Returns the safely-
+ * truncated slice plus its actual byte length so the running byte total can be
+ * advanced correctly.
+ */
+function truncateToBytes(
+  text: string,
+  remaining: number,
+): { send: string; bytes: number } {
+  const buf = Buffer.from(text, "utf8");
+  if (buf.length <= remaining) return { send: text, bytes: buf.length };
+  // Buffer.toString("utf8") substitutes U+FFFD for incomplete trailing
+  // sequences, which is the correct UTF-8 truncation behavior.
+  const sliced = buf.subarray(0, remaining).toString("utf8");
+  return { send: sliced, bytes: Buffer.byteLength(sliced, "utf8") };
+}
+
+/**
  * Write a single-server MCP config to a 0600 temp file, return the path.
  * Caller passes path via `--mcp-config <path>` to claude -p.
  *
@@ -218,10 +250,13 @@ export class SubprocessDriver implements ProviderDriver {
         if (parsed.kind === "raw") {
           accumulated += parsed.text;
           if (outputBytesSent < OUTPUT_CAP) {
-            const send = parsed.text.slice(0, OUTPUT_CAP - outputBytesSent);
-            if (send.length > 0) {
+            const { send, bytes } = truncateToBytes(
+              parsed.text,
+              OUTPUT_CAP - outputBytesSent,
+            );
+            if (bytes > 0) {
               input.onChunk?.(send);
-              outputBytesSent += send.length;
+              outputBytesSent += bytes;
             }
           }
           continue;
@@ -233,10 +268,13 @@ export class SubprocessDriver implements ProviderDriver {
           if (text.length > 0) {
             accumulated += text;
             if (outputBytesSent < OUTPUT_CAP) {
-              const send = text.slice(0, OUTPUT_CAP - outputBytesSent);
-              if (send.length > 0) {
+              const { send, bytes } = truncateToBytes(
+                text,
+                OUTPUT_CAP - outputBytesSent,
+              );
+              if (bytes > 0) {
                 input.onChunk?.(send);
-                outputBytesSent += send.length;
+                outputBytesSent += bytes;
               }
             }
           }
@@ -251,9 +289,15 @@ export class SubprocessDriver implements ProviderDriver {
     let stderr = "";
     child.stderr.setEncoding("utf-8");
     child.stderr.on("data", (chunk: string) => {
-      if (stderr.length < OUTPUT_CAP) {
+      // Apply the same byte-budget cap to stderr to prevent unbounded memory
+      // growth on multi-byte UTF-8 output. Counting via Buffer.byteLength /
+      // truncateUtf8Bytes keeps the cap a true byte budget rather than a
+      // UTF-16 code-unit budget.
+      if (Buffer.byteLength(stderr, "utf8") < OUTPUT_CAP) {
         stderr += chunk;
-        if (stderr.length > OUTPUT_CAP) stderr = stderr.slice(0, OUTPUT_CAP);
+        if (Buffer.byteLength(stderr, "utf8") > OUTPUT_CAP) {
+          stderr = truncateUtf8Bytes(stderr, OUTPUT_CAP);
+        }
       }
     });
 
@@ -283,7 +327,7 @@ export class SubprocessDriver implements ProviderDriver {
       if (startupHandle) clearTimeout(startupHandle);
       if (doneFromResult) {
         return {
-          text: resultText.slice(0, OUTPUT_CAP),
+          text: truncateUtf8Bytes(resultText, OUTPUT_CAP),
           exitCode: resultIsError ? 1 : 0,
           durationMs: Date.now() - start,
           stderrTail: stderrTailOf(stderr),
@@ -295,7 +339,7 @@ export class SubprocessDriver implements ProviderDriver {
         input.signal.aborted;
       if (isAbort) {
         return {
-          text: accumulated.slice(0, OUTPUT_CAP),
+          text: truncateUtf8Bytes(accumulated, OUTPUT_CAP),
           exitCode: -1,
           durationMs: Date.now() - start,
           stderrTail: stderrTailOf(stderr),
@@ -316,7 +360,7 @@ export class SubprocessDriver implements ProviderDriver {
 
     if (startupTimedOut) {
       return {
-        text: accumulated.slice(0, OUTPUT_CAP),
+        text: truncateUtf8Bytes(accumulated, OUTPUT_CAP),
         exitCode: -1,
         durationMs: Date.now() - start,
         stderrTail: stderrTailOf(stderr),
@@ -330,7 +374,7 @@ export class SubprocessDriver implements ProviderDriver {
     }
 
     return {
-      text: finalText.slice(0, OUTPUT_CAP),
+      text: truncateUtf8Bytes(finalText, OUTPUT_CAP),
       exitCode: effectiveExitCode,
       durationMs: Date.now() - start,
       stderrTail: stderrTailOf(stderr),

--- a/src/fp/__tests__/automationInterpreter.test.ts
+++ b/src/fp/__tests__/automationInterpreter.test.ts
@@ -530,6 +530,115 @@ describe("WithDedup", () => {
   });
 });
 
+// ── WithCooldown: per-file (templated) key ────────────────────────────────────
+
+describe("WithCooldown templated key (per-file cooldown)", () => {
+  // onRecipeSave emits the template `recipesave:{{file}}`; the interpreter
+  // resolves `{{file}}` from ctx.eventData.file so each saved file gets its
+  // own cooldown bucket. Two different files must NOT share a bucket.
+  const recipeHook = hook({
+    hookType: "onRecipeSave",
+    enabled: true,
+    promptSource: INLINE_SOURCE,
+  });
+
+  it("two different saved files do NOT share a cooldown bucket", async () => {
+    const backend = new TestBackend();
+    const wc = withCooldown("recipesave:{{file}}", 10_000, recipeHook);
+
+    // First file fires and records its cooldown.
+    const ctxA = makeCtx({
+      backend,
+      eventType: "onRecipeSave",
+      eventData: { file: "/recipes/a.yaml" },
+    });
+    const resA = await executeAutomationPolicy([wc], ctxA);
+    expect(resA.ok).toBe(true);
+    if (!resA.ok) return;
+    expect(resA.value.taskIds).toHaveLength(1);
+
+    // A DIFFERENT file, within the cooldown window, must still fire — it has
+    // its own bucket (`recipesave:/recipes/b.yaml`).
+    const ctxB = makeCtx({
+      backend,
+      state: resA.value.updatedState,
+      now: NOW + 1_000, // well within the 10s window
+      eventType: "onRecipeSave",
+      eventData: { file: "/recipes/b.yaml" },
+    });
+    const resB = await executeAutomationPolicy([wc], ctxB);
+    expect(resB.ok).toBe(true);
+    if (!resB.ok) return;
+    expect(resB.value.taskIds).toHaveLength(1);
+    expect(resB.value.skipped).toHaveLength(0);
+  });
+
+  it("the SAME saved file IS cooled down within the window", async () => {
+    const backend = new TestBackend();
+    const wc = withCooldown("recipesave:{{file}}", 10_000, recipeHook);
+
+    const ctx1 = makeCtx({
+      backend,
+      eventType: "onRecipeSave",
+      eventData: { file: "/recipes/a.yaml" },
+    });
+    const res1 = await executeAutomationPolicy([wc], ctx1);
+    expect(res1.ok).toBe(true);
+    if (!res1.ok) return;
+    expect(res1.value.taskIds).toHaveLength(1);
+
+    // Same file again within the window → cooled down (no task).
+    const ctx2 = makeCtx({
+      backend,
+      state: res1.value.updatedState,
+      now: NOW + 1_000,
+      eventType: "onRecipeSave",
+      eventData: { file: "/recipes/a.yaml" },
+    });
+    const res2 = await executeAutomationPolicy([wc], ctx2);
+    expect(res2.ok).toBe(true);
+    if (!res2.ok) return;
+    expect(res2.value.taskIds).toHaveLength(0);
+    expect(res2.value.skipped[0]?.reason).toBe(
+      "cooldown:recipesave:/recipes/a.yaml",
+    );
+  });
+
+  it("static (non-templated) cooldown keys are unchanged", async () => {
+    // A hook whose key has no `{{…}}` token uses the key verbatim — every
+    // other hook's cooldown behaviour must be untouched by the template path.
+    const backend = new TestBackend();
+    const gitHook = hook({
+      hookType: "onGitCommit",
+      enabled: true,
+      promptSource: INLINE_SOURCE,
+    });
+    const wc = withCooldown("gitcommit", 10_000, gitHook);
+
+    const ctx1 = makeCtx({
+      backend,
+      eventType: "onGitCommit",
+      eventData: { hash: "abc", branch: "main" },
+    });
+    const res1 = await executeAutomationPolicy([wc], ctx1);
+    if (!res1.ok) return;
+    expect(res1.value.taskIds).toHaveLength(1);
+
+    // Different commit, same static bucket → cooled down.
+    const ctx2 = makeCtx({
+      backend,
+      state: res1.value.updatedState,
+      now: NOW + 1_000,
+      eventType: "onGitCommit",
+      eventData: { hash: "def", branch: "main" },
+    });
+    const res2 = await executeAutomationPolicy([wc], ctx2);
+    if (!res2.ok) return;
+    expect(res2.value.taskIds).toHaveLength(0);
+    expect(res2.value.skipped[0]?.reason).toBe("cooldown:gitcommit");
+  });
+});
+
 // ── PBT: cooldown gate ────────────────────────────────────────────────────────
 
 describe("PBT: cooldown gate", () => {
@@ -887,6 +996,75 @@ describe("WithRetry re-execution", () => {
 
     expect(attempts).toBeGreaterThanOrEqual(2);
     expect(realRetryBackend.collector.scheduledRetries.length).toBe(1);
+  });
+
+  it("schedules up to maxRetries retries when every attempt fails (no early cap)", async () => {
+    // Regression: WithRetry's retry callback re-ran the INNER program, not the
+    // WithRetry node, so a second failure never re-entered the WithRetry branch
+    // → only ONE retry was ever scheduled regardless of maxRetries. With
+    // maxRetries:3 we expect 3 scheduled retries (attempts 1, 2, 3), then stop.
+    const realRetryBackend = new TestBackend();
+    realRetryBackend.enqueueTask = async () => {
+      throw new Error("always-fail");
+    };
+    // Defer fired callbacks into a manual queue so the initial run's state is
+    // committed to `live` before any retry callback reads it — mirroring a real
+    // timer firing AFTER the initiating mutation has committed.
+    const pendingTimers: Array<() => void> = [];
+    realRetryBackend.scheduleRetry = (key, delayMs, fn) => {
+      realRetryBackend.collector.scheduledRetries.push({ key, delayMs });
+      pendingTimers.push(fn);
+      return () => {};
+    };
+
+    let live = EMPTY_AUTOMATION_STATE;
+    // Serialize retry work like AutomationHooks' mutation chain: each unit of
+    // retry work reads the truly-current `live`, runs, and writes back before
+    // the next unit starts. Without this the re-entrant retries race on a
+    // shared snapshot.
+    let chain: Promise<void> = Promise.resolve();
+    const runRetryUnderLock = (
+      work: (
+        l: import("../automationState.js").AutomationState,
+      ) => Promise<import("../automationState.js").AutomationState>,
+    ) => {
+      chain = chain.then(async () => {
+        live = await work(live);
+      });
+    };
+
+    const prog = withRetry(
+      "retry-key",
+      3,
+      5000,
+      hook({
+        hookType: "onFileSave",
+        enabled: true,
+        promptSource: INLINE_SOURCE,
+      }),
+    );
+    const ctx = makeCtx({
+      backend: realRetryBackend,
+      getLiveState: () => live,
+      runRetryUnderLock,
+    });
+    const result = await executeAutomationPolicy([prog], ctx);
+    if (!result.ok) throw new Error("not ok");
+    // Commit the initiating run's state BEFORE firing any deferred timer.
+    live = result.value.updatedState;
+
+    // Drain the timer queue: each fired callback may enqueue another retry.
+    // Process FIFO, settling the serialized chain between fires so each retry
+    // observes the committed state of the previous one.
+    for (let i = 0; i < pendingTimers.length; i++) {
+      pendingTimers[i]!();
+      await chain;
+    }
+
+    // attempts 1, 2, 3 scheduled — and no more (stops at maxRetries).
+    expect(realRetryBackend.collector.scheduledRetries.length).toBe(3);
+    // After exhausting retries, the pending entry is cleaned up (no leak).
+    expect(live.pendingRetries.has("retry-key")).toBe(false);
   });
 });
 

--- a/src/fp/__tests__/policyParser.test.ts
+++ b/src/fp/__tests__/policyParser.test.ts
@@ -229,7 +229,9 @@ describe("parsePolicy", () => {
       expect(top._tag).toBe("WithCooldown");
       if (top._tag === "WithCooldown") {
         expect(top.cooldownMs).toBe(15_000);
-        expect(top.key).toBe("recipesave:*");
+        // Per-file cooldown bucket: the `{{file}}` template is resolved at
+        // interpret time so one saved recipe doesn't cool down all of them.
+        expect(top.key).toBe("recipesave:{{file}}");
         if (top.program._tag === "Hook") {
           expect(top.program.hookType).toBe("onRecipeSave");
           const src = top.program.promptSource;
@@ -238,6 +240,26 @@ describe("parsePolicy", () => {
             expect(src.prompt).toBe("recipe saved: {{file}}");
           }
         }
+      }
+    });
+
+    it("uses a per-file cooldown key template, not a global bucket", () => {
+      // Regression: onRecipeSave previously emitted the constant cooldown key
+      // `recipesave:*`, so saving one recipe cooled down ALL recipes. The
+      // parser now emits the per-file template `recipesave:{{file}}` which the
+      // interpreter resolves against ctx.eventData.file at runtime.
+      const policy = minPolicy({
+        onRecipeSave: { enabled: true, cooldownMs: 10_000 },
+      });
+      const result = parsePolicy(policy);
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      const top = result.value[0];
+      if (!top) throw new Error("expected first node");
+      expect(top._tag).toBe("WithCooldown");
+      if (top._tag === "WithCooldown") {
+        expect(top.key).toBe("recipesave:{{file}}");
+        expect(top.key).not.toBe("recipesave:*");
       }
     });
 

--- a/src/fp/automationInterpreter.ts
+++ b/src/fp/automationInterpreter.ts
@@ -303,6 +303,29 @@ function buildFinalPrompt(
   return truncatePrompt(meta + resolved);
 }
 
+/**
+ * Resolve `{{placeholder}}` tokens in a WithCooldown key against the live
+ * `eventData` at interpret time. Lets a hook scope its cooldown bucket per
+ * dynamic value — e.g. `recipesave:{{file}}` cools down only the saved file,
+ * not every recipe. Keys without any `{{…}}` token pass through unchanged, so
+ * every other hook's cooldown behaviour is untouched.
+ *
+ * Sanitised to a stable map-key shape: control chars stripped, length capped,
+ * unresolved placeholders collapse to `*` so a missing value still produces a
+ * deterministic bucket (rather than leaking the raw `{{file}}` literal).
+ */
+function resolveCooldownKey(
+  key: string,
+  eventData: Readonly<Record<string, string>>,
+): string {
+  if (!key.includes("{{")) return key;
+  return key.replace(/\{\{(\w+)\}\}/g, (_m, name: string) => {
+    const val = eventData[name];
+    if (val === undefined || val === "") return "*";
+    return val.replace(/[\x00-\x1F\x7F]/g, "").slice(0, 256);
+  });
+}
+
 // ── Interpreter ───────────────────────────────────────────────────────────────
 
 async function interpret(
@@ -587,16 +610,20 @@ async function interpret(
     }
 
     case "WithCooldown": {
-      if (isOnCooldown(acc.state, program.key, ctx.now, program.cooldownMs)) {
+      // Resolve any `{{placeholder}}` in the cooldown key against the live
+      // event so a per-file hook (e.g. onRecipeSave → `recipesave:{{file}}`)
+      // gets its OWN cooldown bucket. Static keys pass through unchanged.
+      const cooldownKey = resolveCooldownKey(program.key, ctx.eventData);
+      if (isOnCooldown(acc.state, cooldownKey, ctx.now, program.cooldownMs)) {
         const hookLabel =
           program.program._tag === "Hook"
             ? program.program.hookType
-            : program.key;
+            : cooldownKey;
         return {
           ...acc,
           skipped: [
             ...acc.skipped,
-            { reason: `cooldown:${program.key}`, hook: hookLabel },
+            { reason: `cooldown:${cooldownKey}`, hook: hookLabel },
           ],
         };
       }
@@ -625,7 +652,7 @@ async function interpret(
         const lastTaskId = newTaskIds[newTaskIds.length - 1] ?? "";
         const newState = recordTrigger(
           innerAcc.state,
-          program.key,
+          cooldownKey,
           lastTaskId,
           ctx.now,
         );
@@ -634,7 +661,7 @@ async function interpret(
       if (webhookFired) {
         const newState = recordTrigger(
           innerAcc.state,
-          program.key,
+          cooldownKey,
           "webhook",
           ctx.now,
         );
@@ -707,8 +734,17 @@ async function interpret(
           const nextAttempt = attempt + 1;
           const nextRetryAt = ctx.now + program.retryDelayMs;
 
-          // Schedule retry: re-run the wrapped program when the timer
-          // fires. The work runs INSIDE AutomationHooks' mutation lock
+          // Schedule retry: re-run the WithRetry NODE (not just its wrapped
+          // child) when the timer fires. Re-entering the WithRetry case is
+          // what lets each successive failure re-check `attempt < maxRetries`
+          // and schedule the next retry — running only `program.program`
+          // capped retries at 1 because the inner program never re-enters
+          // this branch. The interpret() result already carries the
+          // pendingRetries bookkeeping the node performs (record on
+          // re-schedule, clear on success/exhaustion), so the retry returns
+          // it as-is rather than force-clearing.
+          //
+          // The work runs INSIDE AutomationHooks' mutation lock
           // (`runRetryUnderLock`) so:
           //   1. Read of live state is atomic w.r.t. concurrent _runInterpreter
           //      calls — the retry sees their cooldown / dedup / rateLimit
@@ -716,15 +752,14 @@ async function interpret(
           //   2. Write of post-retry state is atomic w.r.t. the same chain,
           //      so the retry's effects can't be lost to a concurrent run
           //      that started between scheduling and merge.
-          //   3. `clearPendingRetry` is in a try/finally so the
-          //      pendingRetries entry is dropped even if the inner
+          //   3. The catch clears the pendingRetries entry even if the inner
           //      interpret() throws (otherwise the retry leaks the entry
           //      forever).
           //
           // TestBackend records the call but does not actually fire the timer.
           // Tests that exercise retry dispatch synchronously override
           // `scheduleRetry`.
-          const wrappedProgram = program.program;
+          const retryProgram = program;
           const retrySnapshot = innerAcc.state;
           const liveStateFn = ctx.getLiveState;
           const runUnderLock = ctx.runRetryUnderLock;
@@ -741,12 +776,16 @@ async function interpret(
                   state: live,
                   now: Date.now(),
                 };
+                // Re-enter the WithRetry node so a repeated failure can
+                // schedule the next attempt (up to maxRetries). The node
+                // owns the pendingRetries lifecycle — return its state
+                // directly so a re-scheduled attempt isn't force-cleared.
                 const retryResult = await interpret(
-                  wrappedProgram,
+                  retryProgram,
                   retryCtx,
                   emptyAcc(live),
                 );
-                return clearPendingRetry(retryResult.state, program.key);
+                return retryResult.state;
               } catch (e) {
                 const m = e instanceof Error ? e.message : String(e);
                 ctx.log(`[interpreter] retry ${program.key} failed: ${m}`);
@@ -778,6 +817,15 @@ async function interpret(
           );
           return { ...innerAcc, state: newState };
         }
+
+        // Retries exhausted (attempt >= maxRetries): the inner program still
+        // failed but no further retry is scheduled. Drop the pendingRetries
+        // entry so it doesn't leak and block a future, unrelated retry for
+        // the same key.
+        return {
+          ...innerAcc,
+          state: clearPendingRetry(innerAcc.state, program.key),
+        };
       }
 
       return innerAcc;

--- a/src/fp/policyParser.ts
+++ b/src/fp/policyParser.ts
@@ -66,7 +66,11 @@ function cooldownKey(hookType: HookType, condition?: string): string {
     case "onDebugSessionEnd":
       return "debugend";
     case "onRecipeSave":
-      return `recipesave:${condition ?? "*"}`;
+      // Per-file cooldown bucket. The `{{file}}` template is resolved at
+      // interpret time from `ctx.eventData.file` (see resolveCooldownKey in
+      // automationInterpreter) so one saved recipe doesn't cool down all of
+      // them. Documented as "Cooldown key: per-file" in automation.md.
+      return condition ? `recipesave:${condition}` : "recipesave:{{file}}";
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1389,22 +1389,46 @@ if (process.argv[2] === "recipe" && process.argv[3] === "run") {
       const { findBridgeLock } = await import("./bridgeLockDiscovery.js");
       const lock = localFlag ? null : findBridgeLock();
       if (lock && !dryRun && !step && !explicitFile && !attemptId) {
-        const res = await fetch(`http://127.0.0.1:${lock.port}/recipes/run`, {
-          method: "POST",
-          headers: {
-            Authorization: `Bearer ${lock.authToken}`,
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({
-            name: recipeArg,
-            ...(seedVars ? { vars: seedVars } : {}),
-          }),
-        });
-        const body = (await res.json()) as {
-          ok: boolean;
-          taskId?: string;
-          error?: string;
-        };
+        // 30s per-request deadline — the bridge can pass the findBridgeLock
+        // PID check yet be wedged on HTTP. Without this abort the fetch
+        // blocks forever. Mirrors the AbortController pattern used by every
+        // sibling bridge call (halts, judgments, recipe doctor, kill-switch).
+        const controller = new AbortController();
+        const timer = setTimeout(() => controller.abort(), 30_000);
+        let res: Response;
+        let body: { ok: boolean; taskId?: string; error?: string };
+        try {
+          res = await fetch(`http://127.0.0.1:${lock.port}/recipes/run`, {
+            method: "POST",
+            headers: {
+              Authorization: `Bearer ${lock.authToken}`,
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+              name: recipeArg,
+              ...(seedVars ? { vars: seedVars } : {}),
+            }),
+            signal: controller.signal,
+          });
+          body = (await res.json()) as {
+            ok: boolean;
+            taskId?: string;
+            error?: string;
+          };
+        } catch (err) {
+          const aborted =
+            err instanceof Error &&
+            (err.name === "AbortError" || controller.signal.aborted);
+          process.stderr.write(
+            aborted
+              ? `Error: bridge on port ${lock.port} did not respond within 30s — it may be wedged. Restart the bridge or re-run with --local.\n`
+              : `Error: failed to reach bridge on port ${lock.port}: ${err instanceof Error ? err.message : String(err)}\n`,
+          );
+          process.exit(1);
+          return;
+        } finally {
+          clearTimeout(timer);
+        }
         if (!body.ok) {
           // Fall through to local YAML runner if bridge doesn't know the recipe.
           if (!(body.error ?? "").includes("not found")) {

--- a/src/orchestrator/__tests__/orchestratorBridge.probe.test.ts
+++ b/src/orchestrator/__tests__/orchestratorBridge.probe.test.ts
@@ -1,0 +1,411 @@
+/**
+ * OrchestratorBridge health-probe regression tests.
+ *
+ * Two MEDIUM bugs in the probe loop:
+ *
+ *  (1) Transient empty listTools() clobbers a healthy bridge's tools.
+ *      A child's HTTP session can expire (or listTools() can swallow a transient
+ *      error and return []). For an already-healthy bridge this must be treated
+ *      as a probe miss — the previous tool list must be preserved, NOT replaced
+ *      with [] (which would deregister every proxied tool).
+ *
+ *  (2) No re-entrancy guard on the health-probe loop.
+ *      setInterval fires every healthIntervalMs and runs refresh()+probeAll()
+ *      without awaiting the prior probeAll. A slow probe can overlap, racing on
+ *      shared registry/client state. Overlapping ticks must be skipped while a
+ *      probe is in flight.
+ *
+ * Like the sibling integration tests we bypass OrchestratorBridge.start()'s
+ * signal handlers where possible and reach into the (TypeScript-private) probe
+ * internals via a typed accessor cast.
+ */
+
+import { randomBytes, randomUUID } from "node:crypto";
+import fs from "node:fs";
+import http from "node:http";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { Server } from "../../server.js";
+import { ChildBridgeClient } from "../childBridgeClient.js";
+import type { ChildBridgeRegistry } from "../childBridgeRegistry.js";
+import { OrchestratorBridge } from "../orchestratorBridge.js";
+import type { OrchestratorConfig } from "../orchestratorConfig.js";
+
+// ── cleanup tracking ──────────────────────────────────────────────────────────
+
+const servers: Server[] = [];
+const orchBridges: OrchestratorBridge[] = [];
+const registries: ChildBridgeRegistry[] = [];
+
+afterEach(async () => {
+  for (const o of orchBridges) {
+    // Reach into the private members to tear down without process.exit.
+    const internal = o as unknown as {
+      healthTimer: ReturnType<typeof setInterval> | null;
+      registry: ChildBridgeRegistry;
+      server: { close: () => void };
+      lockFile: { delete: () => void };
+    };
+    if (internal.healthTimer) clearInterval(internal.healthTimer);
+    internal.registry.stop();
+    internal.server.close();
+    try {
+      internal.lockFile.delete();
+    } catch {
+      // ignore
+    }
+  }
+  orchBridges.length = 0;
+
+  for (const r of registries) r.stop();
+  registries.length = 0;
+
+  for (const s of servers) await s.close();
+  servers.length = 0;
+});
+
+// ── helpers ─────────────────────────────────────────────────────────────────
+
+function writeBridgeLock(
+  lockDir: string,
+  port: number,
+  authToken: string,
+  workspace: string,
+): void {
+  const content = JSON.stringify({
+    pid: process.pid,
+    startedAt: Date.now(),
+    nonce: randomBytes(8).toString("hex"),
+    workspace,
+    workspaceFolders: [workspace],
+    ideName: "VSCode",
+    isBridge: true,
+    orchestrator: false,
+    transport: "ws",
+    authToken,
+  });
+  fs.writeFileSync(path.join(lockDir, `${port}.lock`), content, {
+    mode: 0o600,
+  });
+}
+
+/**
+ * Spin up a child bridge whose tools/list response is controlled by a mutable
+ * `toolsRef`. Lets a test flip the next probe's tool list to [] to simulate a
+ * transient empty result (expired HTTP session / swallowed error).
+ */
+async function startTogglableChildBridge(
+  _workspace: string,
+  toolsRef: { tools: Array<{ name: string; description: string }> },
+): Promise<{ server: Server; port: number; authToken: string }> {
+  const authToken = randomUUID();
+  const { Logger } = await import("../../logger.js");
+  const logger = new Logger(false);
+  const server = new Server(authToken, logger);
+  const mcpSessionId = randomUUID();
+
+  server.httpMcpHandler = async (req, res) => {
+    if (req.method !== "POST") {
+      res.writeHead(405).end();
+      return;
+    }
+    const chunks: Buffer[] = [];
+    await new Promise<void>((resolve) => {
+      req.on("data", (c: Buffer) => chunks.push(c));
+      req.on("end", resolve);
+    });
+    let body: Record<string, unknown>;
+    try {
+      body = JSON.parse(Buffer.concat(chunks).toString("utf-8")) as Record<
+        string,
+        unknown
+      >;
+    } catch {
+      res.writeHead(400).end();
+      return;
+    }
+    const method = body.method as string;
+    const id = body.id;
+
+    if (method === "initialize") {
+      res.setHeader("mcp-session-id", mcpSessionId);
+      res.writeHead(200, { "content-type": "application/json" }).end(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id,
+          result: {
+            protocolVersion: "2025-11-25",
+            capabilities: { tools: {} },
+            serverInfo: { name: "togglable-child", version: "1.0.0" },
+          },
+        }),
+      );
+    } else if (method === "notifications/initialized") {
+      res.writeHead(204).end();
+    } else if (method === "tools/list") {
+      res.writeHead(200, { "content-type": "application/json" }).end(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id,
+          result: {
+            tools: toolsRef.tools.map((t) => ({
+              ...t,
+              inputSchema: { type: "object", properties: {} },
+            })),
+          },
+        }),
+      );
+    } else {
+      res
+        .writeHead(200, { "content-type": "application/json" })
+        .end(JSON.stringify({ jsonrpc: "2.0", id, result: {} }));
+    }
+  };
+
+  const port = await server.findAndListen(null);
+  servers.push(server);
+  return { server, port, authToken };
+}
+
+interface ProbeInternals {
+  probeAll(): Promise<void>;
+  registry: ChildBridgeRegistry;
+  runHealthTick(): void;
+  probing: boolean;
+}
+
+function internals(o: OrchestratorBridge): ProbeInternals {
+  return o as unknown as ProbeInternals;
+}
+
+async function startOrchBridge(
+  lockDir: string,
+): Promise<{ orch: OrchestratorBridge; port: number; token: string }> {
+  // Pre-allocate a free port so the lock file uses a known filename.
+  const port = await new Promise<number>((resolve, reject) => {
+    const tmp = http.createServer();
+    tmp.listen(0, "127.0.0.1", () => {
+      const addr = tmp.address() as { port: number };
+      tmp.close((err) => (err ? reject(err) : resolve(addr.port)));
+    });
+  });
+  const token = randomUUID();
+  const config: OrchestratorConfig = {
+    port,
+    bindAddress: "127.0.0.1",
+    lockDir,
+    healthIntervalMs: 60_000, // long — we drive probes manually
+    verbose: false,
+    jsonl: false,
+    watch: false,
+    fixedToken: token,
+  };
+  const orch = new OrchestratorBridge(config);
+  orchBridges.push(orch);
+  await orch.start();
+  return { orch, port, token };
+}
+
+// ── Bug (1): transient empty listTools() must not clobber a healthy bridge ─────
+
+describe("OrchestratorBridge probe: transient empty listTools() preserves tools", () => {
+  it("a healthy bridge that returns [] on one probe keeps its previous tools", async () => {
+    const lockDir = fs.mkdtempSync(path.join(os.tmpdir(), "orch-probe-empty-"));
+
+    const toolsRef = {
+      tools: [{ name: "echo", description: "Echo the input back" }],
+    };
+    const child = await startTogglableChildBridge("/projects/empty", toolsRef);
+    writeBridgeLock(lockDir, child.port, child.authToken, "/projects/empty");
+
+    const { orch } = await startOrchBridge(lockDir);
+    const reg = internals(orch).registry;
+
+    // After start()'s initial probe the bridge is healthy with the echo tool.
+    const before = reg.get(child.port);
+    expect(before?.healthy).toBe(true);
+    expect(before?.tools.map((t) => t.name)).toEqual(["echo"]);
+
+    // Simulate a transient empty result on the next probe (expired session /
+    // swallowed error): the child now reports zero tools.
+    toolsRef.tools = [];
+
+    await internals(orch).probeAll();
+
+    // BUG (1): the previous guard `tools.length === 0 && !b.healthy` falls
+    // through to markHealthy(port, []) for an already-healthy bridge, wiping
+    // its tools. After the fix the previous tool list must be preserved.
+    const after = reg.get(child.port);
+    expect(after?.tools.map((t) => t.name)).toEqual(["echo"]);
+    expect(after?.healthy).toBe(true);
+  });
+
+  it("a never-healthy bridge that returns [] stays warming (unchanged behavior)", async () => {
+    const lockDir = fs.mkdtempSync(path.join(os.tmpdir(), "orch-probe-warm-"));
+
+    // Child reports zero tools from the very first probe.
+    const toolsRef = {
+      tools: [] as Array<{ name: string; description: string }>,
+    };
+    const child = await startTogglableChildBridge("/projects/warm", toolsRef);
+    writeBridgeLock(lockDir, child.port, child.authToken, "/projects/warm");
+
+    const { orch } = await startOrchBridge(lockDir);
+    const reg = internals(orch).registry;
+
+    const b = reg.get(child.port);
+    // Never marked healthy — stays warming with no tools.
+    expect(b?.healthy).toBe(false);
+    expect(b?.tools).toEqual([]);
+  });
+});
+
+// ── childBridgeClient: swallowed-error [] must not wipe a healthy bridge ───────
+
+describe("ChildBridgeClient.listTools 404 session-expiry recovery", () => {
+  let server: http.Server;
+  let client: ChildBridgeClient;
+
+  afterEach(async () => {
+    client?.destroy();
+    if (server)
+      await new Promise<void>((resolve, reject) =>
+        server.close((err) => (err ? reject(err) : resolve())),
+      );
+  });
+
+  it("re-initializes the session and retries when tools/list gets a 404", async () => {
+    let initCount = 0;
+    let sess1Calls = 0;
+
+    const echoResult = JSON.stringify({
+      jsonrpc: "2.0",
+      id: 0,
+      result: {
+        tools: [
+          {
+            name: "echo",
+            description: "Echo",
+            inputSchema: { type: "object", properties: {} },
+          },
+        ],
+      },
+    });
+
+    server = http.createServer((req, res) => {
+      const chunks: Buffer[] = [];
+      req.on("data", (c: Buffer) => chunks.push(c));
+      req.on("end", () => {
+        const body = JSON.parse(
+          Buffer.concat(chunks).toString("utf-8"),
+        ) as Record<string, unknown>;
+        const id = body.id;
+        const sessionId = req.headers["mcp-session-id"] as string | undefined;
+
+        if (body.method === "initialize") {
+          initCount++;
+          res.setHeader("mcp-session-id", `sess-${initCount}`);
+          res.writeHead(200, { "content-type": "application/json" }).end(
+            JSON.stringify({
+              jsonrpc: "2.0",
+              id,
+              result: { protocolVersion: "2025-11-25", capabilities: {} },
+            }),
+          );
+        } else if (body.method === "notifications/initialized") {
+          res.writeHead(204).end();
+        } else if (body.method === "tools/list") {
+          if (sessionId === "sess-1") {
+            sess1Calls++;
+            // First tools/list on sess-1 succeeds (primes the cache); the
+            // session then expires, so the SECOND tools/list returns 404.
+            if (sess1Calls === 1) {
+              res
+                .writeHead(200, { "content-type": "application/json" })
+                .end(
+                  echoResult.replace('"id":0', `"id":${JSON.stringify(id)}`),
+                );
+            } else {
+              res.writeHead(404).end();
+            }
+          } else {
+            // Re-initialized session (sess-2+) works.
+            res
+              .writeHead(200, { "content-type": "application/json" })
+              .end(echoResult.replace('"id":0', `"id":${JSON.stringify(id)}`));
+          }
+        } else {
+          res.writeHead(200).end("{}");
+        }
+      });
+    });
+    await new Promise<void>((resolve) =>
+      server.listen(0, "127.0.0.1", resolve),
+    );
+    const port = (server.address() as { port: number }).port;
+    client = new ChildBridgeClient(port, "test-token");
+
+    // First listTools() primes the session (sess-1) and returns the echo tool.
+    const first = await client.listTools();
+    expect(first.map((t) => t.name)).toEqual(["echo"]);
+
+    // Second listTools() now hits a 404 (session expired). Before the fix the
+    // client swallows the error and returns [] — which the orchestrator would
+    // then write over a healthy bridge's tools. After the fix the session is
+    // re-initialized and the call retried, returning the real tool list.
+    const second = await client.listTools();
+    expect(second.map((t) => t.name)).toEqual(["echo"]);
+    expect(initCount).toBe(2); // initial + reinit after 404
+  });
+});
+
+// ── Bug (2): re-entrancy guard on the health-probe tick ───────────────────────
+
+describe("OrchestratorBridge probe: health tick re-entrancy guard", () => {
+  it("skips overlapping ticks while a probe is in flight", async () => {
+    const lockDir = fs.mkdtempSync(path.join(os.tmpdir(), "orch-probe-race-"));
+    const toolsRef = {
+      tools: [{ name: "echo", description: "Echo" }],
+    };
+    const child = await startTogglableChildBridge("/projects/race", toolsRef);
+    writeBridgeLock(lockDir, child.port, child.authToken, "/projects/race");
+
+    const { orch } = await startOrchBridge(lockDir);
+    const ix = internals(orch);
+
+    // Replace probeAll with a slow, controllable stub that counts concurrent
+    // invocations. If runHealthTick() lacks a re-entrancy guard, the second
+    // tick fires probeAll while the first is still pending.
+    let active = 0;
+    let maxActive = 0;
+    let calls = 0;
+    let release!: () => void;
+    const gate = new Promise<void>((r) => {
+      release = r;
+    });
+    ix.probeAll = async () => {
+      calls++;
+      active++;
+      maxActive = Math.max(maxActive, active);
+      await gate;
+      active--;
+    };
+
+    // Fire two ticks back-to-back while the first probe is still in flight.
+    ix.runHealthTick();
+    ix.runHealthTick();
+
+    // The second tick must have been skipped by the `probing` guard.
+    expect(calls).toBe(1);
+    expect(maxActive).toBe(1);
+
+    // Release the in-flight probe and let the guard reset.
+    release();
+    await new Promise((r) => setTimeout(r, 10));
+
+    // After the in-flight probe settles a fresh tick runs again.
+    ix.runHealthTick();
+    expect(calls).toBe(2);
+  });
+});

--- a/src/orchestrator/childBridgeClient.ts
+++ b/src/orchestrator/childBridgeClient.ts
@@ -101,7 +101,20 @@ export class ChildBridgeClient {
         params: {},
       });
 
-      const res = await this.post(body, INIT_TIMEOUT_MS, this.sessionId);
+      let res = await this.post(body, INIT_TIMEOUT_MS, this.sessionId);
+
+      // 404 means the child's HTTP session expired (2-hour idle TTL). This is
+      // NOT a bridge failure — re-initialize the session and retry once.
+      // Returning [] here would let the orchestrator clobber a healthy bridge's
+      // tool list (it writes whatever listTools returns), so recovering the
+      // session is what keeps proxied tools alive across an idle window.
+      if (res.status === 404) {
+        this.sessionId = null;
+        const ok = await this.initSession();
+        if (!ok) return [];
+        res = await this.post(body, INIT_TIMEOUT_MS, this.sessionId);
+      }
+
       if (!res.ok) {
         this.onFailure();
         return [];

--- a/src/orchestrator/orchestratorBridge.ts
+++ b/src/orchestrator/orchestratorBridge.ts
@@ -56,6 +56,11 @@ export class OrchestratorBridge {
   private authToken: string;
   private startedAt = Date.now();
   private healthTimer: ReturnType<typeof setInterval> | null = null;
+  /** Re-entrancy guard for the health-probe loop. A single probe (ping +
+   *  listTools across every child) can outlast healthIntervalMs; without this
+   *  guard a fresh interval tick would start a second probe that races on the
+   *  shared registry/clients state. Overlapping ticks are skipped. */
+  private probing = false;
 
   constructor(private config: OrchestratorConfig) {
     this.logger = new Logger(config.verbose, config.jsonl);
@@ -81,12 +86,10 @@ export class OrchestratorBridge {
     await this.probeAll();
 
     // Start health probe loop
-    this.healthTimer = setInterval(() => {
-      this.registry.refresh();
-      this.probeAll().catch((err) =>
-        this.logger.error("orchestrator health probe failed", { err }),
-      );
-    }, this.config.healthIntervalMs);
+    this.healthTimer = setInterval(
+      () => this.runHealthTick(),
+      this.config.healthIntervalMs,
+    );
     this.healthTimer.unref();
 
     // Start HTTP/WS server
@@ -149,6 +152,26 @@ export class OrchestratorBridge {
     }
   }
 
+  /**
+   * One health-probe tick: refresh the lock-file registry, then probe every
+   * child bridge. Guarded against re-entrancy — if the previous tick's
+   * probeAll() is still in flight (a slow ping + listTools across many bridges
+   * can outlast healthIntervalMs), this tick is skipped rather than racing on
+   * the shared registry/clients state.
+   */
+  private runHealthTick(): void {
+    if (this.probing) return;
+    this.probing = true;
+    this.registry.refresh();
+    this.probeAll()
+      .catch((err) =>
+        this.logger.error("orchestrator health probe failed", { err }),
+      )
+      .finally(() => {
+        this.probing = false;
+      });
+  }
+
   private async probeAll(): Promise<void> {
     const bridges = this.registry.getAll();
 
@@ -183,12 +206,17 @@ export class OrchestratorBridge {
           const prevToolNames = b.tools.map((t) => t.name).join(",");
           const tools = await client.listTools();
 
-          // If listTools() returned empty, the HTTP session init likely failed silently.
-          // Don't mark the bridge healthy yet — keep it warming so the next probe retries.
-          // A real bridge always has at least one tool registered.
-          if (tools.length === 0 && !b.healthy) {
+          // If listTools() returned empty, the HTTP session init likely failed
+          // silently (e.g. the child's HTTP session expired and listTools
+          // swallowed the error returning []). A real bridge always has at least
+          // one tool registered, so treat ANY empty result as a probe miss —
+          // regardless of current health. Crucially we must NOT fall through to
+          // markHealthy(port, []) for an already-healthy bridge: that would wipe
+          // b.tools and deregister every proxied tool. Return early and let the
+          // next probe retry; the existing tool list is preserved.
+          if (tools.length === 0) {
             this.logger.debug(
-              `Bridge port ${b.port} (${b.ideName}) pinged alive but returned 0 tools — retrying next cycle`,
+              `Bridge port ${b.port} (${b.ideName}) pinged alive but returned 0 tools — keeping previous tools, retrying next cycle`,
             );
             this.registry.keepWarm(b.port);
             return;

--- a/src/recipes/__tests__/githubInstallSource.test.ts
+++ b/src/recipes/__tests__/githubInstallSource.test.ts
@@ -180,6 +180,82 @@ describe("parseGithubInstallSource", () => {
       ).ok,
     ).toBe(true);
   });
+
+  it("extracts a trailing @ref from the name segment", () => {
+    const result = parseGithubInstallSource(
+      "github:patchworkos/recipes/recipes/morning-brief@v1.2.0",
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.parsed.name).toBe("morning-brief");
+      expect(result.parsed.ref).toBe("v1.2.0");
+    }
+  });
+
+  it("leaves ref undefined when no @ref is present", () => {
+    const result = parseGithubInstallSource(
+      "github:patchworkos/recipes/recipes/morning-brief",
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.parsed.ref).toBeUndefined();
+    }
+  });
+
+  it("preserves ref case (refs are not lowercased)", () => {
+    const result = parseGithubInstallSource(
+      "github:patchworkos/recipes/recipes/morning-brief@Release-2.0",
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.parsed.ref).toBe("Release-2.0");
+    }
+  });
+
+  it("accepts a commit SHA as a ref", () => {
+    const result = parseGithubInstallSource(
+      "github:patchworkos/recipes/recipes/morning-brief@abc123def456",
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.parsed.ref).toBe("abc123def456");
+    }
+  });
+
+  it("rejects an empty ref (trailing @)", () => {
+    const result = parseGithubInstallSource(
+      "github:patchworkos/recipes/recipes/morning-brief@",
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.code).toBe("bad_segment");
+  });
+
+  it("rejects refs with disallowed characters", () => {
+    expect(
+      parseGithubInstallSource("github:patchworkos/recipes/recipes/foo@a:b").ok,
+    ).toBe(false);
+    expect(
+      parseGithubInstallSource("github:patchworkos/recipes/recipes/foo@a?b").ok,
+    ).toBe(false);
+    expect(
+      parseGithubInstallSource("github:patchworkos/recipes/recipes/foo@a#b").ok,
+    ).toBe(false);
+    expect(
+      parseGithubInstallSource("github:patchworkos/recipes/recipes/foo@a b").ok,
+    ).toBe(false);
+    expect(
+      parseGithubInstallSource("github:patchworkos/recipes/recipes/foo@a..b")
+        .ok,
+    ).toBe(false);
+  });
+
+  it("still validates the name segment after stripping the ref", () => {
+    // name ".." is invalid even with a valid ref
+    expect(
+      parseGithubInstallSource("github:patchworkos/recipes/recipes/..@v1.0.0")
+        .ok,
+    ).toBe(false);
+  });
 });
 
 describe("buildGithubRawUrl", () => {
@@ -208,6 +284,20 @@ describe("buildGithubRawUrl", () => {
       "https://raw.githubusercontent.com/acme/cookbook/main/bundles/ops-pack/patchwork-bundle.json",
     );
   });
+
+  it("uses the pinned ref instead of 'main' when present", () => {
+    expect(
+      buildGithubRawUrl({
+        kind: "recipe",
+        owner: "patchworkos",
+        repo: "recipes",
+        name: "morning-brief",
+        ref: "v1.2.0",
+      }),
+    ).toBe(
+      "https://raw.githubusercontent.com/patchworkos/recipes/v1.2.0/recipes/morning-brief/morning-brief.yaml",
+    );
+  });
 });
 
 describe("buildGithubApiUrl", () => {
@@ -234,6 +324,20 @@ describe("buildGithubApiUrl", () => {
       }),
     ).toBe(
       "https://api.github.com/repos/acme/cookbook/contents/bundles/ops-pack/patchwork-bundle.json?ref=main",
+    );
+  });
+
+  it("uses the pinned ref in the ?ref= query when present", () => {
+    expect(
+      buildGithubApiUrl({
+        kind: "recipe",
+        owner: "patchworkos",
+        repo: "recipes",
+        name: "morning-brief",
+        ref: "v1.2.0",
+      }),
+    ).toBe(
+      "https://api.github.com/repos/patchworkos/recipes/contents/recipes/morning-brief/morning-brief.yaml?ref=v1.2.0",
     );
   });
 });

--- a/src/recipes/__tests__/parser.test.ts
+++ b/src/recipes/__tests__/parser.test.ts
@@ -30,6 +30,30 @@ describe("parseRecipe", () => {
     expect(() => parseRecipe({ ...VALID, name: "" })).toThrow(RecipeParseError);
   });
 
+  // Regression: parseRecipe hard-rejected a version-less recipe with
+  // "missing or empty 'version'", but the JSON schema marks version
+  // optional with default "1.0.0" and neither validateRecipeDefinition
+  // nor the yaml runner check it. A version-less recipe linted + ran but
+  // failed at install with a confusing error. version is optional and
+  // defaults to "1.0.0" at the parse boundary.
+  describe("version is optional (parity with schema default)", () => {
+    it("defaults version to 1.0.0 when omitted", () => {
+      const { version: _omit, ...noVersion } = VALID;
+      const r = parseRecipe(noVersion);
+      expect(r.version).toBe("1.0.0");
+    });
+
+    it("defaults version to 1.0.0 when empty", () => {
+      const r = parseRecipe({ ...VALID, version: "" });
+      expect(r.version).toBe("1.0.0");
+    });
+
+    it("preserves an explicit version string", () => {
+      const r = parseRecipe({ ...VALID, version: "2.3.1" });
+      expect(r.version).toBe("2.3.1");
+    });
+  });
+
   it("rejects empty steps", () => {
     expect(() => parseRecipe({ ...VALID, steps: [] })).toThrow(/non-empty/);
   });

--- a/src/recipes/__tests__/schemaGenerator.test.ts
+++ b/src/recipes/__tests__/schemaGenerator.test.ts
@@ -1,5 +1,6 @@
 import { Ajv } from "ajv";
 import { beforeEach, describe, expect, it } from "vitest";
+import { RECIPE_NAME_RE } from "../names.js";
 import {
   generateDryRunPlanSchema,
   generateSchemaSet,
@@ -68,6 +69,48 @@ describe("schemaGenerator", () => {
     expect((schemas.namespaces.test as Record<string, unknown>).title).toBe(
       "Test Tools",
     );
+  });
+
+  // Regression: the generator hardcoded the name pattern as
+  // "^[a-z0-9-]+$" — weaker than RECIPE_NAME_RE (allowed a leading "-",
+  // no 64-char cap, no @scope/name form) and divergent from the
+  // corrected committed schemas/recipe.v1.json. Re-running the generator
+  // silently clobbered the strict committed pattern. The generated
+  // pattern is now derived from RECIPE_NAME_RE so regen is idempotent.
+  describe("recipe name pattern matches RECIPE_NAME_RE (idempotent regen)", () => {
+    // The committed schema accepts an optional @scope/ prefix (stripped
+    // by stripRecipeScope before validation) followed by the canonical
+    // RECIPE_NAME_RE body.
+    const expectedPattern = `^(@[a-z0-9-]+/)?${RECIPE_NAME_RE.source.replace(
+      /^\^/,
+      "",
+    )}`;
+
+    it("emits the RECIPE_NAME_RE-derived pattern, not the weak hardcoded one", () => {
+      const schemas = generateSchemaSet();
+      const recipeSchema = schemas.recipe as {
+        properties?: { name?: { pattern?: string } };
+      };
+      const pattern = recipeSchema.properties?.name?.pattern;
+      expect(pattern).toBe(expectedPattern);
+      // The old weak pattern must be gone.
+      expect(pattern).not.toBe("^[a-z0-9-]+$");
+    });
+
+    it("rejects a leading-dash name and an over-long name", () => {
+      const schemas = generateSchemaSet();
+      const recipeSchema = schemas.recipe as {
+        properties?: { name?: { pattern?: string } };
+      };
+      const pattern = recipeSchema.properties?.name?.pattern as string;
+      const re = new RegExp(pattern);
+
+      expect(re.test("-bad")).toBe(false);
+      expect(re.test("a".repeat(65))).toBe(false);
+      // Sanity: well-formed names (bare + scoped) still pass.
+      expect(re.test("sprint-review-prep")).toBe(true);
+      expect(re.test("@patchworkos/sprint-review-prep")).toBe(true);
+    });
   });
 
   it("generates tool schema with merged properties", () => {

--- a/src/recipes/__tests__/toolRegistry.pluginWrite.test.ts
+++ b/src/recipes/__tests__/toolRegistry.pluginWrite.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Regression test — plugin tools must honour `annotations.destructiveHint`
+ * so they participate in the kill-switch gate + idempotency ledger.
+ *
+ * Before the fix, `registerPluginTools` hard-coded `isWrite: false` for every
+ * plugin tool, so a destructive plugin tool bypassed `assertWriteAllowed` and
+ * the write-effect dedup ledger entirely.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  clearRegistry,
+  getTool,
+  registerPluginTools,
+} from "../toolRegistry.js";
+
+function makePluginTool(name: string, destructiveHint?: boolean) {
+  return {
+    name,
+    handler: async () => ({ content: [{ type: "text", text: "ok" }] }),
+    schema: {
+      name,
+      description: `plugin tool ${name}`,
+      inputSchema: { type: "object" as const },
+      ...(destructiveHint === undefined
+        ? {}
+        : { annotations: { destructiveHint } }),
+    },
+  };
+}
+
+describe("registerPluginTools — destructiveHint → isWrite", () => {
+  beforeEach(() => {
+    clearRegistry();
+  });
+  afterEach(() => {
+    clearRegistry();
+  });
+
+  it("registers a tool with annotations.destructiveHint:true as a write tool", () => {
+    const count = registerPluginTools([
+      makePluginTool("myplug_deleteThing", true),
+    ]);
+    expect(count).toBe(1);
+    const tool = getTool("myplug_deleteThing");
+    expect(tool?.isWrite).toBe(true);
+    expect(tool?.riskDefault).toBe("medium");
+  });
+
+  it("leaves a tool without destructiveHint as a non-write tool", () => {
+    registerPluginTools([makePluginTool("myplug_readThing")]);
+    const tool = getTool("myplug_readThing");
+    expect(tool?.isWrite).toBe(false);
+    expect(tool?.riskDefault).toBe("low");
+  });
+
+  it("treats destructiveHint:false as a non-write tool", () => {
+    registerPluginTools([makePluginTool("myplug_safeThing", false)]);
+    const tool = getTool("myplug_safeThing");
+    expect(tool?.isWrite).toBe(false);
+    expect(tool?.riskDefault).toBe("low");
+  });
+});

--- a/src/recipes/__tests__/yamlRunner.test.ts
+++ b/src/recipes/__tests__/yamlRunner.test.ts
@@ -29,6 +29,15 @@ vi.mock("../../connectors/github.js", () => ({
   listPRs: vi.fn(),
 }));
 
+// Bug (1): exercises the *default* providerDriverFn (makeProviderDriverFn).
+// API drivers (OpenAI / Grok) never set exitCode — on failure they resolve
+// with { text: "", errorMessage } (or { wasAborted }). The stub lets a test
+// drive those shapes through the real factory by stubbing `createDriver`.
+const mockProviderRun = vi.fn();
+vi.mock("../../drivers/index.js", () => ({
+  createDriver: vi.fn(() => ({ name: "stub", run: mockProviderRun })),
+}));
+
 import {
   listIssues as listGithubIssues,
   listPRs as listGithubPRs,
@@ -45,6 +54,7 @@ import {
   evaluateExpect,
   type FetchFn,
   listYamlRecipes,
+  makeProviderDriverFn,
   type RunnerDeps,
   render,
   runYamlRecipe,
@@ -638,6 +648,173 @@ describe("runYamlRecipe — on_error retry + fallback", () => {
       }),
     );
     expect(result.errorMessage).toBeDefined();
+  });
+});
+
+// ── Bug (2): flat runner aborts on a fatal failure (mirrors chainedRunner) ─────
+// The flat runner used to record the first non-optional failure in runError
+// but kept executing later steps. It now breaks at the next loop top —
+// EXCEPT when the failure is fail-open (step.optional / on_error.fallback=
+// log_only|deliver_original) or a soft silent-fail connector envelope, both
+// of which still let the run continue.
+
+describe("runYamlRecipe — abort-on-fatal-failure (Bug 2)", () => {
+  function depsRead(readFile: () => string): RunnerDeps {
+    return { ...noop(), readFile };
+  }
+
+  it("does NOT run steps after a hard tool throw (default on_error)", async () => {
+    const written: Record<string, string> = {};
+    const recipe = makeRecipe({
+      steps: [
+        { tool: "file.read", path: path.join(TMP, "missing"), into: "data" },
+        {
+          tool: "file.write",
+          path: path.join(TMP, "after.md"),
+          content: "should not be written",
+        },
+      ],
+    });
+    const result = await runYamlRecipe(recipe, {
+      ...depsRead(() => {
+        throw new Error("boom");
+      }),
+      writeFile: (p, c) => {
+        written[p] = c;
+      },
+    });
+    // Step 1 errored; step 2 must never have run.
+    expect(result.stepResults[0]?.status).toBe("error");
+    expect(written[path.join(TMP, "after.md")]).toBeUndefined();
+    // Only one step recorded — the loop broke before step 2.
+    expect(result.stepResults).toHaveLength(1);
+    expect(result.stepsRun).toBe(1);
+    expect(result.errorMessage).toBeDefined();
+  });
+
+  it("does NOT run steps after a hard agent failure (default on_error)", async () => {
+    const written: Record<string, string> = {};
+    let secondAgentCalls = 0;
+    const recipe = makeRecipe({
+      steps: [
+        {
+          agent: {
+            prompt: "step 1",
+            model: "claude-haiku-4-5-20251001",
+            into: "out1",
+          },
+        },
+        {
+          tool: "file.write",
+          path: path.join(TMP, "after.md"),
+          content: "should not be written",
+        },
+      ],
+    });
+    const result = await runYamlRecipe(recipe, {
+      ...noop(),
+      // Hard agent failure — the `[agent step failed: ...]` marker.
+      claudeFn: async () => {
+        secondAgentCalls++;
+        return "[agent step failed: driver exploded]";
+      },
+      writeFile: (p, c) => {
+        written[p] = c;
+      },
+    });
+    expect(secondAgentCalls).toBe(1);
+    expect(result.stepResults[0]?.status).toBe("error");
+    expect(written[path.join(TMP, "after.md")]).toBeUndefined();
+    expect(result.stepResults).toHaveLength(1);
+  });
+
+  it("STILL delivers a downstream payload after a soft silent-fail envelope (contract preserved)", async () => {
+    // A connector list-tool returning {count:0,error} is silent-fail-detected
+    // (soft) — the run must continue so the recipe can deliver the degraded
+    // payload. This pins the carve-out that keeps the existing
+    // "linear.list_issues returns error payload" tests green.
+    mockLoadTokens.mockReturnValue(null); // → {count:0, error:"not connected"}
+    const written: Record<string, string> = {};
+    const result = await runYamlRecipe(
+      makeRecipe({
+        steps: [
+          { tool: "linear.list_issues", into: "issues" },
+          {
+            tool: "file.write",
+            path: path.join(TMP, "soft.md"),
+            content: "{{issues}}",
+          },
+        ],
+      }),
+      {
+        ...noop(),
+        writeFile: (p, c) => {
+          written[p] = c;
+        },
+      },
+    );
+    // Step 1 flagged error (silent-fail) but step 2 still ran.
+    expect(result.stepResults[0]?.status).toBe("error");
+    expect(written[path.join(TMP, "soft.md")]).toContain("not connected");
+    expect(result.stepResults).toHaveLength(2);
+  });
+
+  it("STILL runs later steps when on_error.fallback=log_only (fail-open preserved)", async () => {
+    const written: Record<string, string> = {};
+    const recipe = makeRecipe({
+      on_error: { fallback: "log_only" },
+      steps: [
+        { tool: "file.read", path: path.join(TMP, "missing"), into: "data" },
+        {
+          tool: "file.write",
+          path: path.join(TMP, "after.md"),
+          content: "delivered anyway",
+        },
+      ],
+    });
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const result = await runYamlRecipe(recipe, {
+      ...depsRead(() => {
+        throw new Error("boom");
+      }),
+      writeFile: (p, c) => {
+        written[p] = c;
+      },
+    });
+    warn.mockRestore();
+    expect(result.stepResults[0]?.status).toBe("error");
+    // Fail-open: step 2 still ran.
+    expect(written[path.join(TMP, "after.md")]).toBe("delivered anyway");
+    expect(result.stepResults).toHaveLength(2);
+  });
+
+  it("STILL runs later steps when the failing step is optional:true", async () => {
+    const written: Record<string, string> = {};
+    const recipe = makeRecipe({
+      steps: [
+        {
+          tool: "file.read",
+          path: path.join(TMP, "missing"),
+          into: "data",
+          optional: true,
+        },
+        {
+          tool: "file.write",
+          path: path.join(TMP, "after.md"),
+          content: "delivered anyway",
+        },
+      ],
+    });
+    const result = await runYamlRecipe(recipe, {
+      ...depsRead(() => {
+        throw new Error("boom");
+      }),
+      writeFile: (p, c) => {
+        written[p] = c;
+      },
+    });
+    expect(written[path.join(TMP, "after.md")]).toBe("delivered anyway");
+    expect(result.stepResults).toHaveLength(2);
   });
 });
 
@@ -2364,6 +2541,70 @@ describe("runYamlRecipe — agent step with provider drivers", () => {
   });
 });
 
+// ── Bug (1): default providerDriverFn surfaces the real API error ─────────────
+// API drivers (OpenAI / Grok) never set exitCode; on failure they resolve with
+// { text: "", errorMessage } (or { wasAborted }). The old default only checked
+// exitCode, so a 401/429 fell through to the generic "returned empty output"
+// branch and the real cause was lost. These pin the corrected behaviour.
+
+describe("makeProviderDriverFn — surfaces provider failure cause", () => {
+  afterEach(() => {
+    mockProviderRun.mockReset();
+  });
+
+  it("surfaces errorMessage (401/429) instead of generic empty-output", async () => {
+    mockProviderRun.mockResolvedValueOnce({
+      text: "",
+      errorMessage: "401 unauthorized",
+      durationMs: 5,
+    });
+    const fn = makeProviderDriverFn();
+    const out = await fn("openai", "hello", undefined);
+    expect(out).toContain("401 unauthorized");
+    expect(out).toContain("openai");
+    expect(out).not.toContain("returned empty output");
+  });
+
+  it("surfaces wasAborted (timeout/cancel) before the empty-output branch", async () => {
+    mockProviderRun.mockResolvedValueOnce({
+      text: "",
+      wasAborted: true,
+      durationMs: 5,
+    });
+    const fn = makeProviderDriverFn();
+    const out = await fn("grok", "hello", undefined);
+    expect(out).toMatch(/timed out or was cancelled/);
+    expect(out).toContain("grok");
+    expect(out).not.toContain("returned empty output");
+  });
+
+  it("truncates a very long errorMessage to keep the marker readable", async () => {
+    mockProviderRun.mockResolvedValueOnce({
+      text: "",
+      errorMessage: "x".repeat(500),
+      durationMs: 5,
+    });
+    const fn = makeProviderDriverFn();
+    const out = await fn("openai", "hello", undefined);
+    // 200-char cap on the message fragment (plus the surrounding marker text).
+    expect(out.length).toBeLessThan(260);
+  });
+
+  it("still reports generic empty-output when there is no error signal", async () => {
+    mockProviderRun.mockResolvedValueOnce({ text: "", durationMs: 5 });
+    const fn = makeProviderDriverFn();
+    const out = await fn("openai", "hello", undefined);
+    expect(out).toContain("returned empty output");
+  });
+
+  it("returns text unchanged on success", async () => {
+    mockProviderRun.mockResolvedValueOnce({ text: "all good", durationMs: 5 });
+    const fn = makeProviderDriverFn();
+    const out = await fn("openai", "hello", undefined);
+    expect(out).toBe("all good");
+  });
+});
+
 // ── dispatchRecipe ────────────────────────────────────────────────────────────
 
 import type { ChainedRecipe, ExecutionDeps } from "../chainedRunner.js";
@@ -2949,6 +3190,82 @@ describe("recipe.budget — tokensMax enforcement (PR2b)", () => {
     expect(calls).toBe(2);
     expect(result.stepResults[0]?.status).toBe("ok");
     expect(result.stepResults[1]?.status).toBe("ok");
+  });
+
+  // Bug (3): the admission check used to live inside the agent branch, so a
+  // breached budget left TOOL steps running unbounded. The gate now sits at
+  // the top of the loop and halts ALL step kinds.
+  it("halts a TOOL step that follows a budget-breaching agent step", async () => {
+    const written: Record<string, string> = {};
+    const recipe = makeRecipe({
+      budget: { tokensMax: 100 },
+      steps: [
+        {
+          agent: {
+            prompt: "step 1",
+            model: "claude-haiku-4-5-20251001",
+            into: "out1",
+          },
+        },
+        {
+          tool: "file.write",
+          path: path.join(TMP, "post-budget.md"),
+          content: "should not be written",
+        },
+      ],
+    });
+    const result = await runYamlRecipe(recipe, {
+      ...noop(),
+      claudeFn: async () => ({
+        text: "out",
+        usage: { inputTokens: 60, outputTokens: 60 }, // 120 > 100 → breach
+      }),
+      writeFile: (p, c) => {
+        written[p] = c;
+      },
+    });
+    expect(result.stepResults[0]?.status).toBe("ok");
+    // The tool step is denied admission and recorded as a budget error.
+    expect(result.stepResults[1]?.status).toBe("error");
+    expect(result.stepResults[1]?.haltReason).toMatch(/budget_exceeded/);
+    expect(result.stepResults[1]?.haltCategory).toBe("budget_exceeded");
+    // The tool body never executed.
+    expect(written[path.join(TMP, "post-budget.md")]).toBeUndefined();
+    expect(result.errorMessage).toMatch(/budget_exceeded/);
+  });
+
+  it("onBreach='warn' lets a TOOL step run past the cap", async () => {
+    const written: Record<string, string> = {};
+    const recipe = makeRecipe({
+      budget: { tokensMax: 100, onBreach: "warn" },
+      steps: [
+        {
+          agent: {
+            prompt: "step 1",
+            model: "claude-haiku-4-5-20251001",
+            into: "out1",
+          },
+        },
+        {
+          tool: "file.write",
+          path: path.join(TMP, "warn-budget.md"),
+          content: "delivered",
+        },
+      ],
+    });
+    const result = await runYamlRecipe(recipe, {
+      ...noop(),
+      claudeFn: async () => ({
+        text: "out",
+        usage: { inputTokens: 200, outputTokens: 200 }, // breach but warn-mode
+      }),
+      writeFile: (p, c) => {
+        written[p] = c;
+      },
+    });
+    expect(result.stepResults[0]?.status).toBe("ok");
+    expect(result.stepResults[1]?.status).toBe("ok");
+    expect(written[path.join(TMP, "warn-budget.md")]).toBe("delivered");
   });
 });
 

--- a/src/recipes/githubInstallSource.ts
+++ b/src/recipes/githubInstallSource.ts
@@ -30,6 +30,13 @@ export interface ParsedGithubInstallSource {
   repo: string;
   /** Recipe name (single basename) or bundle name. */
   name: string;
+  /**
+   * Optional git ref (branch / tag / commit SHA) parsed from a trailing
+   * `@<ref>` on the name segment. Mirrors the CLI install path
+   * (`github:owner/repo[@ref]`). When absent, the URL builders default to
+   * `main`. Refs are NOT lowercased — tags/SHAs are case-sensitive.
+   */
+  ref?: string;
 }
 
 export type GithubInstallParseResult =
@@ -113,10 +120,37 @@ export function parseGithubInstallSource(
       error: "third path segment must be 'recipes' or 'bundles'",
     };
   }
+  // Extract an optional trailing `@<ref>` from the name segment so dashboard /
+  // HTTP installs can pin a branch / tag / commit SHA, matching the CLI path
+  // (`github:owner/repo[@ref]`). The ref is opaque to us — git accepts
+  // branches, tags, and SHAs in the same slot — but we apply the same charset
+  // guard recipeInstall.ts uses so it can't smuggle URL syntax into the
+  // constructed raw / api URLs.
+  let name = nameRaw;
+  let ref: string | undefined;
+  const atIdx = nameRaw.lastIndexOf("@");
+  if (atIdx !== -1) {
+    ref = nameRaw.slice(atIdx + 1);
+    name = nameRaw.slice(0, atIdx);
+    if (!ref) {
+      return {
+        ok: false,
+        code: "bad_segment",
+        error: "ref after '@' must not be empty",
+      };
+    }
+    if (/[@:?#\s]/.test(ref) || ref.includes("..")) {
+      return {
+        ok: false,
+        code: "bad_segment",
+        error: "ref contains disallowed characters",
+      };
+    }
+  }
   // Reuse the strict basename predicate inline rather than importing
   // recipeInstall.ts here (circular deps), but match its rules:
   // single segment, no `..`, no slashes, conservative charset, ≤100.
-  if (!SEGMENT_RE.test(nameRaw.toLowerCase())) {
+  if (!SEGMENT_RE.test(name.toLowerCase())) {
     return {
       ok: false,
       code: "bad_segment",
@@ -137,7 +171,8 @@ export function parseGithubInstallSource(
       kind: kindRaw === "recipes" ? "recipe" : "bundle",
       owner,
       repo,
-      name: nameRaw,
+      name,
+      ...(ref ? { ref } : {}),
     },
   };
 }
@@ -155,11 +190,12 @@ function repoRelativePath(parsed: ParsedGithubInstallSource): string {
 
 /**
  * Build the raw.githubusercontent URL for a parsed install source.
- * Always pulls `main` branch HEAD — version pinning is on the
- * deferred audit backlog.
+ * Uses the pinned `parsed.ref` (branch / tag / commit SHA) when present,
+ * else defaults to the `main` branch HEAD.
  */
 export function buildGithubRawUrl(parsed: ParsedGithubInstallSource): string {
-  return `https://raw.githubusercontent.com/${parsed.owner}/${parsed.repo}/main/${repoRelativePath(parsed)}`;
+  const ref = parsed.ref ?? "main";
+  return `https://raw.githubusercontent.com/${parsed.owner}/${parsed.repo}/${ref}/${repoRelativePath(parsed)}`;
 }
 
 /**
@@ -172,7 +208,8 @@ export function buildGithubRawUrl(parsed: ParsedGithubInstallSource): string {
  * directly — no base64 decode needed. Public repos work unauthenticated.
  */
 export function buildGithubApiUrl(parsed: ParsedGithubInstallSource): string {
-  return `https://api.github.com/repos/${parsed.owner}/${parsed.repo}/contents/${repoRelativePath(parsed)}?ref=main`;
+  const ref = parsed.ref ?? "main";
+  return `https://api.github.com/repos/${parsed.owner}/${parsed.repo}/contents/${repoRelativePath(parsed)}?ref=${ref}`;
 }
 
 /**

--- a/src/recipes/parser.ts
+++ b/src/recipes/parser.ts
@@ -41,7 +41,13 @@ export function parseRecipe(raw: unknown): Recipe {
       ["name"],
     );
   }
-  const version = requireString(r, "version");
+  // version is optional at the parse boundary: the JSON schema marks it
+  // optional with default "1.0.0", and neither validateRecipeDefinition
+  // nor the yaml runner require it. Hard-rejecting a version-less recipe
+  // here meant a recipe that lints + runs still failed at install with a
+  // confusing "missing or empty 'version'". Default to "1.0.0" to match.
+  const version =
+    typeof r.version === "string" && r.version ? r.version : "1.0.0";
   const trigger = parseTrigger(r.trigger);
   const stepsRaw = r.steps;
   if (!Array.isArray(stepsRaw) || stepsRaw.length === 0) {

--- a/src/recipes/schemaGenerator.ts
+++ b/src/recipes/schemaGenerator.ts
@@ -6,7 +6,25 @@
  *   - schemas/tools/<namespace>.json — per-namespace tool param schemas
  */
 
+import { RECIPE_NAME_RE } from "./names.js";
 import { getNamespaces, listTools, type ToolMetadata } from "./toolRegistry.js";
+
+/**
+ * JSON-Schema `pattern` for a recipe `name`, derived from the canonical
+ * RECIPE_NAME_RE (`src/recipes/names.ts`) so the generated schema can
+ * never silently weaken the committed strict pattern on regen.
+ *
+ * RECIPE_NAME_RE is the bare kebab slug (`^[a-z0-9][a-z0-9-]{0,63}$`).
+ * The schema additionally accepts an optional `@scope/` prefix because
+ * marketplace registry recipes ship a scoped name (`@patchworkos/foo`)
+ * which `stripRecipeScope` normalizes to the bare slug before the
+ * RECIPE_NAME_RE check runs. We inject that prefix group right after the
+ * leading `^` of RECIPE_NAME_RE.source.
+ */
+const RECIPE_NAME_SCHEMA_PATTERN = `^(@[a-z0-9-]+/)?${RECIPE_NAME_RE.source.replace(
+  /^\^/,
+  "",
+)}`;
 
 export interface SchemaSet {
   /** Top-level recipe schema */
@@ -357,8 +375,9 @@ function generateRecipeSchema(
     properties: {
       name: {
         type: "string",
-        description: "Recipe name (kebab-case recommended)",
-        pattern: "^[a-z0-9-]+$",
+        description:
+          "Recipe name (kebab-case, 1-64 chars). Scoped names like @scope/name are accepted for registry recipes.",
+        pattern: RECIPE_NAME_SCHEMA_PATTERN,
       },
       description: {
         type: "string",

--- a/src/recipes/toolRegistry.ts
+++ b/src/recipes/toolRegistry.ts
@@ -179,18 +179,27 @@ export function registerPluginTools(
         return typeof result === "string" ? result : JSON.stringify(result);
       };
 
+      // Honour the plugin tool's `annotations.destructiveHint` (PluginToolSchema
+      // in src/plugin.ts). A destructive plugin tool must be treated as a write
+      // so it participates in the kill-switch gate (assertWriteAllowed) and the
+      // idempotency dedup ledger in executeTool. Authors who omit the hint keep
+      // the prior read-only behaviour — zero API change.
+      const schema = t.schema as Record<string, unknown> | null;
+      const annotations = schema?.annotations as
+        | Record<string, unknown>
+        | undefined;
+      const isWrite = annotations?.destructiveHint === true;
+
       registerTool({
         id: t.name,
         namespace,
         description:
-          ((t.schema as Record<string, unknown> | null)?.description as
-            | string
-            | undefined) ?? `Plugin tool: ${t.name}`,
-        paramsSchema:
-          (t.schema as Record<string, unknown> | null)?.inputSchema ?? {},
+          (schema?.description as string | undefined) ??
+          `Plugin tool: ${t.name}`,
+        paramsSchema: schema?.inputSchema ?? {},
         outputSchema: {},
-        riskDefault: "low",
-        isWrite: false,
+        riskDefault: isWrite ? "medium" : "low",
+        isWrite,
         execute,
       });
       registered++;

--- a/src/recipes/yamlRunner.ts
+++ b/src/recipes/yamlRunner.ts
@@ -892,6 +892,15 @@ export async function runYamlRecipe(
   const stepResults: StepResult[] = [];
   let stepsRun = 0;
   let runError: string | undefined;
+  // Bug (2): the flat runner historically recorded the first non-optional
+  // failure in `runError` but kept executing later steps — diverging from
+  // chainedRunner, which aborts on a fatal failure. This flag is set ONLY
+  // when a failure is fatal (non-optional AND fail-open semantics do not
+  // apply via step.optional / on_error.fallback=log_only|deliver_original).
+  // The loop checks it at the top and breaks, matching chainedRunner's
+  // abort-on-failure contract. Fail-open failures never set it, so
+  // log_only/deliver_original/optional steps still let the run continue.
+  let haltAfterFailure = false;
 
   // Live-tail SSE broadcaster. Wrapped in a try/catch on every call so a
   // misbehaving listener can never break the run (mirrors chainedRunner).
@@ -976,6 +985,13 @@ export async function runYamlRecipe(
   // finalization path, which marks the run "error".
   try {
     for (const step of recipe.steps) {
+      // Bug (2): abort on a prior fatal failure. chainedRunner throws (and
+      // stops) when a non-optional step fails; the flat runner used to keep
+      // going. Break here so later steps don't run on top of a failed
+      // dependency. Fail-open failures (step.optional / on_error.fallback=
+      // log_only|deliver_original) never set `haltAfterFailure`, so they
+      // still let the run continue exactly as before.
+      if (haltAfterFailure) break;
       const stepIdForEmit = step.into ?? step.agent?.into ?? `step_${stepsRun}`;
       const stepTs = Date.now();
       stepStartTs.set(stepIdForEmit, stepTs);
@@ -1023,6 +1039,38 @@ export async function runYamlRecipe(
         }
       }
 
+      // Bug (3): per-recipe token budget gates ALL step types, not just
+      // agent steps. The admission check used to live inside the
+      // `if (step.agent)` branch, so once the budget was breached the run
+      // kept executing tool steps unbounded. Gate here — after the `when:`
+      // guard resolves truthy, before the agent/tool split — so a breach
+      // halts the run regardless of the next step's kind. Subscription
+      // drivers report no usage and fail open inside RunBudget, so this is
+      // a no-op until a measured agent step actually breaches the cap.
+      const budgetAdmission = runBudget.admit();
+      if (!budgetAdmission.admitted) {
+        const reason =
+          budgetAdmission.reason ??
+          "Run exceeded its token budget — budget_exceeded.";
+        runError = runError ?? reason;
+        haltAfterFailure = true;
+        const budgetStepId =
+          step.into ?? step.agent?.into ?? `step_${stepsRun}`;
+        stepResults.push({
+          id: budgetStepId,
+          tool: step.agent ? "agent" : step.tool,
+          status: "error",
+          error: reason,
+          haltReason: reason,
+          haltCategory: "budget_exceeded",
+          durationMs: 0,
+        });
+        stepsRun++;
+        persistLiveStepResults();
+        emitStepDone(stepIdForEmit);
+        continue;
+      }
+
       // Handle agent steps separately
       if (step.agent) {
         const agentCfg = step.agent;
@@ -1041,31 +1089,22 @@ export async function runYamlRecipe(
         const stepId = intoKey;
         const stepStart = Date.now();
         let agentResult: string;
-        // PR2b: per-recipe token budget. Admission check before dispatch;
-        // reconcile actual consumption after. Subscription drivers
-        // (Claude CLI, provider subprocess) report `usage === undefined`
-        // — `RunBudget.reconcile` records a fail-open warning per driver
-        // per run and continues.
-        const admission = runBudget.admit();
-        if (!admission.admitted) {
-          const reason =
-            admission.reason ??
-            "Run exceeded its token budget — budget_exceeded.";
-          runError = runError ?? reason;
-          stepResults.push({
-            id: stepId,
-            tool: "agent",
-            status: "error",
-            error: reason,
-            haltReason: reason,
-            haltCategory: "budget_exceeded",
-            durationMs: 0,
-          });
-          stepsRun++;
-          persistLiveStepResults();
-          emitStepDone(stepIdForEmit);
-          continue;
-        }
+        // Bug (2): fail-open semantics for THIS agent step. Mirrors the
+        // tool-branch `failOpen` (step.optional OR recipe-level
+        // on_error.fallback=log_only|deliver_original). Used to decide
+        // whether an agent failure is fatal (sets `haltAfterFailure`, which
+        // aborts the run at the next loop top) or fail-open (records the
+        // error but lets the run continue, as before).
+        const agentFallback = recipe.on_error?.fallback;
+        const agentFallbackFailOpen =
+          agentFallback === "log_only" || agentFallback === "deliver_original";
+        const failOpenAgent = step.optional === true || agentFallbackFailOpen;
+        // PR2b: per-recipe token budget. Admission is now checked once at the
+        // top of the loop (Bug (3)) so it gates tool steps too; here we only
+        // reconcile actual consumption after the call. Subscription drivers
+        // (Claude CLI, provider subprocess) report `usage === undefined` —
+        // `RunBudget.reconcile` records a fail-open warning per driver per
+        // run and continues.
         try {
           const agentReturn = await _executeAgent(
             {
@@ -1100,6 +1139,7 @@ export async function runYamlRecipe(
               ? `silent-fail detected (${agentSilentFail.reason}): ${agentSilentFail.matched}`
               : agentResult;
             runError = runError ?? reason;
+            if (!failOpenAgent) haltAfterFailure = true;
             stepResults.push({
               id: stepId,
               tool: "agent",
@@ -1116,6 +1156,7 @@ export async function runYamlRecipe(
             if (!stripped.trim()) {
               const errMsg = `[agent step failed: ${agentCfg.driver ?? "agent"} returned only narration or whitespace — no content]`;
               runError = runError ?? errMsg;
+              if (!failOpenAgent) haltAfterFailure = true;
               stepResults.push({
                 id: stepId,
                 tool: "agent",
@@ -1171,12 +1212,9 @@ export async function runYamlRecipe(
                       last.error = `expect_failed: ${failures.join("; ")}`;
                       last.haltReason = `expect_failed in step "${stepId}": ${failures.join("; ")}`;
                       last.haltCategory = "expect_failed";
-                      const fbk = recipe.on_error?.fallback;
-                      const fbkOpen =
-                        fbk === "log_only" || fbk === "deliver_original";
-                      const failOpenAgent = step.optional === true || fbkOpen;
                       if (!failOpenAgent) {
                         runError = runError ?? last.haltReason;
+                        haltAfterFailure = true;
                       }
                       delete ctx[intoKey];
                     } else {
@@ -1190,6 +1228,7 @@ export async function runYamlRecipe(
         } catch (err) {
           const msg = err instanceof Error ? err.message : String(err);
           runError = runError ?? `agent step "${stepId}" failed: ${msg}`;
+          if (!failOpenAgent) haltAfterFailure = true;
           stepResults.push({
             id: stepId,
             tool: "agent",
@@ -1214,6 +1253,16 @@ export async function runYamlRecipe(
         step.retryDelay ?? recipe.on_error?.retryDelay ?? 1000;
       let result: string | null = null;
       let stepError: string | undefined;
+      // Bug (2): distinguish a HARD tool error (a thrown error or a
+      // `{ok:false}` JSON envelope) from a SOFT silent-fail detection
+      // (`{count:0,error}` connector envelopes, string placeholders). Only
+      // hard failures abort the run; soft silent-fail detections keep the
+      // run going so connector health-check recipes can still deliver the
+      // degraded payload downstream (a long-standing, tested contract —
+      // see "linear.list_issues — returns error payload" tests). Silent-fail
+      // detection is an observability augment; it was never meant to gate
+      // delivery for these envelopes.
+      let stepErrorIsSilentFail = false;
       let thrownError: string | undefined;
       let thrownErrorCode: string | undefined;
       for (let attempt = 0; attempt <= retryCount; attempt++) {
@@ -1221,6 +1270,7 @@ export async function runYamlRecipe(
           await new Promise((r) => setTimeout(r, retryDelayMs));
         }
         stepError = undefined;
+        stepErrorIsSilentFail = false;
         thrownError = undefined;
         thrownErrorCode = undefined;
         try {
@@ -1280,6 +1330,7 @@ export async function runYamlRecipe(
             const detected = detectSilentFail(result);
             if (detected) {
               stepError = `silent-fail detected (${detected.reason}): ${detected.matched}`;
+              stepErrorIsSilentFail = true;
             }
           }
         } catch (err) {
@@ -1319,6 +1370,7 @@ export async function runYamlRecipe(
         });
         if (!failOpen) {
           runError = runError ?? `${step.tool} failed: ${thrownError}`;
+          haltAfterFailure = true;
         } else if (fallbackFailOpen && !step.optional) {
           console.warn(
             `step ${stepId} failed but on_error.fallback=${fallback} — treating as non-fatal: ${thrownError}`,
@@ -1345,6 +1397,10 @@ export async function runYamlRecipe(
         if (stepError) {
           if (!failOpen) {
             runError = runError ?? `${step.tool} failed: ${stepError}`;
+            // Soft silent-fail detections (connector error envelopes) record
+            // the error but must NOT abort the run — see the
+            // `stepErrorIsSilentFail` note above. Hard `{ok:false}` errors do.
+            if (!stepErrorIsSilentFail) haltAfterFailure = true;
           } else if (fallbackFailOpen && !step.optional) {
             console.warn(
               `step ${stepId} failed but on_error.fallback=${fallback} — treating as non-fatal: ${stepError}`,
@@ -1383,6 +1439,7 @@ export async function runYamlRecipe(
                 last.haltCategory = "expect_failed";
                 if (!failOpen) {
                   runError = runError ?? last.haltReason;
+                  haltAfterFailure = true;
                 }
                 result = null;
               } else {
@@ -2029,7 +2086,7 @@ export function defaultClaudeCodeFn(
 }
 
 /** Returns a providerDriverFn with a per-run driver cache (not shared across runs). */
-function makeProviderDriverFn(): (
+export function makeProviderDriverFn(): (
   driverName: "openai" | "grok" | "gemini",
   prompt: string,
   model: string | undefined,
@@ -2071,6 +2128,16 @@ function makeProviderDriverFn(): (
         if (result.exitCode !== undefined && result.exitCode !== 0) {
           const detail = result.stderrTail ?? result.text ?? "";
           return `[agent step failed: ${driverName} exited ${result.exitCode}${detail ? ` — ${detail.slice(0, 200)}` : ""}]`;
+        }
+        // API drivers (OpenAI / Grok) never set exitCode. On failure they
+        // resolve with `{ text: "", wasAborted?/errorMessage }` — surface the
+        // real cause (timeout / 401 / 429) instead of the generic
+        // "empty output" branch below, which swallows the actual reason.
+        if (result.wasAborted) {
+          return `[agent step failed: ${driverName} timed out or was cancelled]`;
+        }
+        if (result.errorMessage) {
+          return `[agent step failed: ${driverName} — ${result.errorMessage.slice(0, 200)}]`;
         }
         if (!result.text) {
           return `[agent step failed: ${driverName} returned empty output (possible timeout or auth error)]`;

--- a/src/tools/__tests__/getToolCapabilities.test.ts
+++ b/src/tools/__tests__/getToolCapabilities.test.ts
@@ -143,7 +143,8 @@ describe("createGetToolCapabilitiesTool — extension connected", () => {
       cfg(),
     );
     const data = parse(await tool.handler());
-    expect(data.availableTools.github).toBe(11);
+    // 16 github* tools + 2 AI-comment tools, all gated behind the gh probe.
+    expect(data.availableTools.github).toBe(18);
   });
 });
 
@@ -338,5 +339,110 @@ describe("LSP tool list consistency", () => {
       lspSet.has(t),
     ).length;
     expect(lspTools.length).toBe(slimLspCount);
+  });
+
+  it("verbose connected lsp array length equals the non-verbose lsp count", async () => {
+    const tool = createGetToolCapabilitiesTool(
+      fullProbes,
+      makeClient(true),
+      cfg(),
+    );
+    const verboseData = parse(await tool.handler({ verbose: true }));
+    const countData = parse(await tool.handler());
+    expect(verboseData.availableTools.lsp.length).toBe(
+      countData.availableTools.lsp,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Headless-cli LSP tier: when the extension is disconnected but a
+// language-server / ctags probe is present, several LSP tools still work via
+// CLI fallbacks. The feature must report "headless-cli" (not "unavailable")
+// and the lsp count/array must reflect the fallback-capable tools.
+// ---------------------------------------------------------------------------
+
+describe("LSP headless-cli fallback tier (extension disconnected)", () => {
+  const tlsProbes = {
+    ...minimalProbes,
+    typescriptLanguageServer: true,
+  } as any;
+  const ctagsProbes = {
+    ...minimalProbes,
+    universalCtags: true,
+  } as any;
+  const bothProbes = {
+    ...minimalProbes,
+    typescriptLanguageServer: true,
+    universalCtags: true,
+  } as any;
+
+  it("reports lsp feature 'headless-cli' when typescript-language-server is present", async () => {
+    const tool = createGetToolCapabilitiesTool(
+      tlsProbes,
+      makeClient(false),
+      cfg(),
+    );
+    const data = parse(await tool.handler());
+    expect(data.features.lsp).toBe("headless-cli");
+  });
+
+  it("lists the typescript-language-server-backed fallback tools", async () => {
+    const tool = createGetToolCapabilitiesTool(
+      tlsProbes,
+      makeClient(false),
+      cfg(),
+    );
+    const data = parse(await tool.handler({ verbose: true }));
+    expect(data.availableTools.lsp).toEqual([
+      "goToDefinition",
+      "findReferences",
+      "getTypeSignature",
+    ]);
+  });
+
+  it("lists the ctags-backed fallback tool (searchWorkspaceSymbols)", async () => {
+    const tool = createGetToolCapabilitiesTool(
+      ctagsProbes,
+      makeClient(false),
+      cfg(),
+    );
+    const data = parse(await tool.handler({ verbose: true }));
+    expect(data.features.lsp).toBe("headless-cli");
+    expect(data.availableTools.lsp).toEqual(["searchWorkspaceSymbols"]);
+  });
+
+  it("merges both probes' fallback tools and count matches array length", async () => {
+    const tool = createGetToolCapabilitiesTool(
+      bothProbes,
+      makeClient(false),
+      cfg(),
+    );
+    const verboseData = parse(await tool.handler({ verbose: true }));
+    const countData = parse(await tool.handler());
+    expect(verboseData.availableTools.lsp).toEqual([
+      "goToDefinition",
+      "findReferences",
+      "getTypeSignature",
+      "searchWorkspaceSymbols",
+    ]);
+    // Internal consistency: non-verbose count === verbose array length.
+    expect(countData.availableTools.lsp).toBe(
+      verboseData.availableTools.lsp.length,
+    );
+    expect(countData.availableTools.lsp).toBe(4);
+  });
+
+  it("stays 'unavailable' with empty/zero lsp when no fallback probe present", async () => {
+    const tool = createGetToolCapabilitiesTool(
+      minimalProbes,
+      makeClient(false),
+      cfg(),
+    );
+    const verboseData = parse(await tool.handler({ verbose: true }));
+    const countData = parse(await tool.handler());
+    expect(verboseData.features.lsp).toBe("unavailable");
+    expect(verboseData.availableTools.lsp).toEqual([]);
+    expect(countData.availableTools.lsp).toBe(0);
   });
 });

--- a/src/tools/__tests__/git.test.ts
+++ b/src/tools/__tests__/git.test.ts
@@ -77,6 +77,24 @@ describe("git tools", () => {
 
       expect(data.unstaged).toContain("hello.txt");
     });
+
+    it("reports the destination path for a staged rename", async () => {
+      // Porcelain v1 renders renames as `R  old.txt -> new.txt`. The parser
+      // must extract the destination path, not the literal arrow string.
+      execSync("git mv hello.txt renamed.txt", {
+        cwd: tmpDir,
+        stdio: "ignore",
+      });
+      const tool = createGetGitStatusTool(tmpDir);
+      const result = await tool.handler({});
+      const data = parse(result);
+
+      expect(data.staged).toContain("renamed.txt");
+      // The literal arrow string must NOT leak through as a path.
+      for (const p of data.staged) {
+        expect(p).not.toContain(" -> ");
+      }
+    });
   });
 
   describe("getGitStatus on non-git directory", () => {

--- a/src/tools/__tests__/githubComposite.test.ts
+++ b/src/tools/__tests__/githubComposite.test.ts
@@ -193,6 +193,119 @@ describe("githubPR", () => {
 });
 
 // ---------------------------------------------------------------------------
+// githubPR composite — configured defaultRepo threading
+// ---------------------------------------------------------------------------
+describe("githubPR defaultRepo", () => {
+  const DEFAULT_REPO = "octo/configured";
+
+  function ghArgsOf(callIndex: number): string[] {
+    return mockExecSafe.mock.calls[callIndex]?.[1] as string[];
+  }
+
+  it("list — uses the configured defaultRepo when no repo arg given", async () => {
+    const tool = createGithubPRTool(ws, undefined, DEFAULT_REPO);
+    mockExecSafe.mockResolvedValueOnce(ok(JSON.stringify([{ number: 1 }])));
+    await tool.handler({ operation: "list" });
+
+    const args = ghArgsOf(0);
+    expect(args).toContain("--repo");
+    expect(args[args.indexOf("--repo") + 1]).toBe(DEFAULT_REPO);
+  });
+
+  it("view — uses the configured defaultRepo when no repo arg given", async () => {
+    const tool = createGithubPRTool(ws, undefined, DEFAULT_REPO);
+    mockExecSafe.mockResolvedValueOnce(
+      ok(JSON.stringify({ number: 7, title: "t", state: "OPEN", url: "u" })),
+    );
+    await tool.handler({ operation: "view", number: 7 });
+
+    const args = ghArgsOf(0);
+    expect(args).toContain("--repo");
+    expect(args[args.indexOf("--repo") + 1]).toBe(DEFAULT_REPO);
+  });
+
+  it("getDiff — falls back to defaultRepo when no repo arg given", async () => {
+    const tool = createGithubPRTool(ws, undefined, DEFAULT_REPO);
+    const metaJson = JSON.stringify({
+      number: 3,
+      title: "Diff PR",
+      changedFiles: 0,
+      files: [],
+    });
+    mockExecSafe
+      .mockResolvedValueOnce(ok(metaJson)) // pr view --json
+      .mockResolvedValueOnce(ok("diff --git a b\n")); // pr diff
+    await tool.handler({ operation: "getDiff", prNumber: 3 });
+
+    // Both the meta (call 0) and diff (call 1) invocations must carry --repo.
+    for (const call of [0, 1]) {
+      const args = ghArgsOf(call);
+      expect(args).toContain("--repo");
+      expect(args[args.indexOf("--repo") + 1]).toBe(DEFAULT_REPO);
+    }
+  });
+
+  it("getDiff — explicit repo arg overrides the configured defaultRepo", async () => {
+    const tool = createGithubPRTool(ws, undefined, DEFAULT_REPO);
+    const metaJson = JSON.stringify({
+      number: 3,
+      title: "Diff PR",
+      changedFiles: 0,
+      files: [],
+    });
+    mockExecSafe
+      .mockResolvedValueOnce(ok(metaJson))
+      .mockResolvedValueOnce(ok("diff --git a b\n"));
+    await tool.handler({
+      operation: "getDiff",
+      prNumber: 3,
+      repo: "other/repo",
+    });
+
+    const args = ghArgsOf(0);
+    expect(args[args.indexOf("--repo") + 1]).toBe("other/repo");
+  });
+
+  it("postReview — uses defaultRepo without calling gh repo view", async () => {
+    const tool = createGithubPRTool(ws, undefined, DEFAULT_REPO);
+    // Only the review API call should run — no resolveRepo `gh repo view`.
+    mockExecSafe.mockResolvedValueOnce(ok(JSON.stringify({ id: 99 })));
+    await tool.handler({
+      operation: "postReview",
+      prNumber: 5,
+      body: "LGTM",
+      event: "COMMENT",
+    });
+
+    expect(mockExecSafe).toHaveBeenCalledTimes(1);
+    const args = ghArgsOf(0);
+    expect(args).toContain(`repos/${DEFAULT_REPO}/pulls/5/reviews`);
+  });
+
+  it("approve — uses defaultRepo without calling gh repo view", async () => {
+    const tool = createGithubPRTool(ws, undefined, DEFAULT_REPO);
+    mockExecSafe.mockResolvedValueOnce(ok(JSON.stringify({ id: 55 })));
+    await tool.handler({ operation: "approve", prNumber: 6 });
+
+    expect(mockExecSafe).toHaveBeenCalledTimes(1);
+    const args = ghArgsOf(0);
+    expect(args).toContain(`repos/${DEFAULT_REPO}/pulls/6/reviews`);
+  });
+
+  it("merge — uses defaultRepo without calling gh repo view", async () => {
+    const tool = createGithubPRTool(ws, undefined, DEFAULT_REPO);
+    mockExecSafe.mockResolvedValueOnce(
+      ok(JSON.stringify({ merged: true, sha: "abc", message: "Merged" })),
+    );
+    await tool.handler({ operation: "merge", prNumber: 8 });
+
+    expect(mockExecSafe).toHaveBeenCalledTimes(1);
+    const args = ghArgsOf(0);
+    expect(args).toContain(`repos/${DEFAULT_REPO}/pulls/8/merge`);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // githubIssue composite
 // ---------------------------------------------------------------------------
 describe("githubIssue", () => {

--- a/src/tools/__tests__/previewEdit.test.ts
+++ b/src/tools/__tests__/previewEdit.test.ts
@@ -8,6 +8,7 @@ import {
   computeUnifiedDiff,
   createPreviewEditTool,
 } from "../previewEdit.js";
+import { hasNestedQuantifier } from "../utils.js";
 
 function parse(r: { content: Array<{ text: string }> }) {
   return JSON.parse(r.content[0]?.text ?? "{}");
@@ -108,6 +109,44 @@ describe("applySearchReplace", () => {
       false,
     );
     expect(result).toBe("bar bar bar");
+  });
+
+  it("rejects nested-quantifier regex (ReDoS guard)", () => {
+    // A catastrophic-backtracking pattern like (a+)+$ must be rejected before
+    // it ever reaches new RegExp + content.replace on the full file.
+    expect(() =>
+      applySearchReplace("aaaaaaaaaaaaaaaaaaaaaaaa!", "(a+)+$", "X", true),
+    ).toThrow(/nested quantifier/i);
+  });
+
+  it("allows a simple non-nested quantifier regex", () => {
+    expect(applySearchReplace("aaa bbb", "a+", "X", true)).toBe("X bbb");
+  });
+
+  it("does not apply the ReDoS guard to literal (non-regex) searches", () => {
+    // Literal mode must accept any string verbatim, including text that would
+    // look like a nested quantifier if interpreted as a regex.
+    expect(applySearchReplace("(a+)+ literal", "(a+)+", "X", false)).toBe(
+      "X literal",
+    );
+  });
+});
+
+describe("hasNestedQuantifier", () => {
+  it("flags nested quantifiers", () => {
+    expect(hasNestedQuantifier("(a+)+")).toBe(true);
+    expect(hasNestedQuantifier("(a+)+$")).toBe(true);
+    expect(hasNestedQuantifier("(ab*)*")).toBe(true);
+    expect(hasNestedQuantifier("(a{1,3})+")).toBe(true);
+    expect(hasNestedQuantifier("a++")).toBe(true);
+    expect(hasNestedQuantifier("a{2,4}+")).toBe(true);
+  });
+
+  it("allows non-nested quantifiers", () => {
+    expect(hasNestedQuantifier("a+")).toBe(false);
+    expect(hasNestedQuantifier("\\w+")).toBe(false);
+    expect(hasNestedQuantifier("foo|bar")).toBe(false);
+    expect(hasNestedQuantifier("[a-z]{2,4}")).toBe(false);
   });
 });
 

--- a/src/tools/__tests__/transaction.test.ts
+++ b/src/tools/__tests__/transaction.test.ts
@@ -133,6 +133,72 @@ describe("transaction tools", () => {
     expect(afterRollback).toBe(originalContent);
   });
 
+  it("commitTransaction returns a conflict error when a staged file is modified on disk between stage and commit", async () => {
+    const conflictFile = path.join(workspace, "conflict.ts");
+    fs.writeFileSync(conflictFile, "original\ncontent\n");
+
+    const { beginTransaction, stageEdit, commitTransaction } =
+      createTransactionTools(workspace);
+
+    const { transactionId } = parse(
+      await beginTransaction.handler({ transactionId: "conflict-tx" }),
+    );
+
+    await stageEdit.handler({
+      transactionId,
+      filePath: "conflict.ts",
+      operation: "lineRange",
+      startLine: 1,
+      endLine: 1,
+      newContent: "TX_EDIT",
+    });
+
+    // Simulate an intervening edit on disk after stage but before commit.
+    // Bump mtime explicitly so the change is observable even if the write
+    // lands within the same millisecond as the stage stat.
+    fs.writeFileSync(conflictFile, "intervening\nedit\n");
+    const future = new Date(Date.now() + 5000);
+    fs.utimesSync(conflictFile, future, future);
+
+    const result = await commitTransaction.handler({ transactionId });
+
+    // The transaction must NOT clobber the intervening edit.
+    const onDisk = fs.readFileSync(conflictFile, "utf-8");
+    expect(onDisk).toBe("intervening\nedit\n");
+
+    // The conflict must surface as a per-file error, not a silent overwrite.
+    const parsed = parse(result);
+    expect(parsed.committed).toBe(0);
+    expect(parsed.errors?.length).toBe(1);
+    expect(parsed.errors[0].file).toContain("conflict.ts");
+    expect(parsed.errors[0].error).toMatch(/modified|conflict/i);
+  });
+
+  it("commitTransaction still writes when the staged file is untouched on disk", async () => {
+    const cleanFile = path.join(workspace, "clean-commit.ts");
+    fs.writeFileSync(cleanFile, "keep\nme\n");
+
+    const { beginTransaction, stageEdit, commitTransaction } =
+      createTransactionTools(workspace);
+
+    const { transactionId } = parse(
+      await beginTransaction.handler({ transactionId: "clean-commit-tx" }),
+    );
+
+    await stageEdit.handler({
+      transactionId,
+      filePath: "clean-commit.ts",
+      operation: "lineRange",
+      startLine: 1,
+      endLine: 1,
+      newContent: "WRITTEN",
+    });
+
+    const result = parse(await commitTransaction.handler({ transactionId }));
+    expect(result.committed).toBe(1);
+    expect(fs.readFileSync(cleanFile, "utf-8")).toContain("WRITTEN");
+  });
+
   it("beginTransaction errors on duplicate id", async () => {
     const { beginTransaction } = createTransactionTools(workspace);
     await beginTransaction.handler({ transactionId: "dup-tx-2" });

--- a/src/tools/getGitStatus.ts
+++ b/src/tools/getGitStatus.ts
@@ -100,7 +100,13 @@ export function createGetGitStatusTool(workspace: string) {
         if (!line) continue;
         const x = line[0] ?? " ";
         const y = line[1] ?? " ";
-        const file = line.slice(3);
+        let file = line.slice(3);
+
+        // Renames (R) and copies (C) render as `old -> new` in porcelain v1.
+        // Extract the destination path so the arrow string never leaks through.
+        if ((x === "R" || x === "C") && file.includes(" -> ")) {
+          file = file.split(" -> ").pop() ?? file;
+        }
 
         // Conflict markers
         if (

--- a/src/tools/getToolCapabilities.ts
+++ b/src/tools/getToolCapabilities.ts
@@ -60,7 +60,28 @@ export function createGetToolCapabilitiesTool(
     handler: async (params: { verbose?: boolean } = {}) => {
       const connected = extensionClient.isConnected();
       const verbose = params.verbose === true;
-      return successStructured({
+
+      // Headless CLI fallbacks: several LSP-category tools still work without the
+      // VS Code extension by shelling out to a language server / ctags probe.
+      //   - typescript-language-server backs goToDefinition / findReferences /
+      //     getTypeSignature
+      //   - universal-ctags backs searchWorkspaceSymbols
+      // When the extension is disconnected but a probe is present, report a
+      // "headless-cli" degraded tier instead of "unavailable" / 0.
+      const headlessLspTools: string[] = [
+        ...(probes.typescriptLanguageServer
+          ? ["goToDefinition", "findReferences", "getTypeSignature"]
+          : []),
+        ...(probes.universalCtags ? ["searchWorkspaceSymbols"] : []),
+      ];
+      const hasHeadlessLsp = headlessLspTools.length > 0;
+      const lspFeature = connected
+        ? "vscode"
+        : hasHeadlessLsp
+          ? "headless-cli"
+          : "unavailable";
+
+      const data = {
         extensionConnected: connected,
         tier: connected ? "full" : "basic",
         editor: config.editorCommand ?? "none",
@@ -119,7 +140,7 @@ export function createGetToolCapabilitiesTool(
             : config.editorCommand
               ? "editor-cli"
               : "no-op",
-          lsp: connected ? "vscode" : "unavailable",
+          lsp: lspFeature,
           terminalOutput: connected ? "available" : "unavailable",
         },
         commandAllowlist: config.commandAllowlist,
@@ -131,6 +152,9 @@ export function createGetToolCapabilitiesTool(
           git: 16,
           diagnostics: connected ? 3 : 2,
           search: 2,
+          // Connected tier only. The disconnected headless-cli tier is applied
+          // as a post-construction override below so this inline array stays
+          // cross-validated against SLIM_TOOL_NAMES (audit-lsp-tools.mjs).
           lsp: verbose
             ? connected
               ? [
@@ -177,10 +201,25 @@ export function createGetToolCapabilitiesTool(
           debug: connected ? 5 : 0,
           http: 2,
           analysis: 8 + (probes.gh ? 1 : 0),
-          ...(probes.gh ? { github: 11 } : {}),
+          // 16 github* tools + 2 AI-comment tools, all gated behind the gh probe
+          // (see the probes.gh block in src/tools/index.ts).
+          ...(probes.gh ? { github: 18 } : {}),
           other: connected ? 23 : 10,
         },
-      });
+      };
+
+      // Headless-cli LSP tier override. When the extension is disconnected but a
+      // language-server / ctags probe is present, the inline array above resolved
+      // to [] / 0 (so it stays cross-validated against SLIM_TOOL_NAMES). Replace
+      // it here with the fallback-capable tool names / count. verbose → name
+      // array, otherwise the count; count === array length by construction.
+      if (!connected && hasHeadlessLsp) {
+        data.availableTools.lsp = verbose
+          ? headlessLspTools
+          : headlessLspTools.length;
+      }
+
+      return successStructured(data);
     },
   };
 }

--- a/src/tools/github/composite.ts
+++ b/src/tools/github/composite.ts
@@ -23,15 +23,15 @@ import {
 export function createGithubPRTool(
   workspace: string,
   onPullRequest?: (result: PullRequestCallbackResult) => void,
-  _defaultRepo: string | null = null,
+  defaultRepo: string | null = null,
 ) {
   const createPR = createGithubCreatePRTool(workspace, onPullRequest);
-  const viewPR = createGithubViewPRTool(workspace);
-  const listPRs = createGithubListPRsTool(workspace);
-  const getDiff = createGithubGetPRDiffTool(workspace);
-  const postReview = createGithubPostPRReviewTool(workspace);
-  const approvePR = createGithubApprovePRTool(workspace);
-  const mergePR = createGithubMergePRTool(workspace);
+  const viewPR = createGithubViewPRTool(workspace, defaultRepo);
+  const listPRs = createGithubListPRsTool(workspace, defaultRepo);
+  const getDiff = createGithubGetPRDiffTool(workspace, defaultRepo);
+  const postReview = createGithubPostPRReviewTool(workspace, defaultRepo);
+  const approvePR = createGithubApprovePRTool(workspace, defaultRepo);
+  const mergePR = createGithubMergePRTool(workspace, defaultRepo);
 
   return {
     schema: {

--- a/src/tools/github/pr.ts
+++ b/src/tools/github/pr.ts
@@ -24,8 +24,10 @@ async function resolveRepo(
   workspace: string,
   repoArg: string | undefined,
   signal?: AbortSignal,
+  defaultRepo?: string | null,
 ): Promise<string | null> {
   if (repoArg) return repoArg;
+  if (defaultRepo) return defaultRepo;
   const result = await execSafe(
     "gh",
     ["repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner", "--"],
@@ -166,7 +168,10 @@ export function createGithubCreatePRTool(
   };
 }
 
-export function createGithubListPRsTool(workspace: string) {
+export function createGithubListPRsTool(
+  workspace: string,
+  defaultRepo: string | null = null,
+) {
   return {
     schema: {
       name: "githubListPRs",
@@ -241,6 +246,7 @@ export function createGithubListPRsTool(workspace: string) {
         "number,title,state,url,headRefName,baseRefName,author,createdAt,isDraft",
       ];
       if (author) listArgs.push("--author", author);
+      if (defaultRepo) listArgs.push("--repo", defaultRepo);
 
       const result = await execSafe("gh", listArgs, {
         cwd: workspace,
@@ -270,7 +276,10 @@ export function createGithubListPRsTool(workspace: string) {
   };
 }
 
-export function createGithubViewPRTool(workspace: string) {
+export function createGithubViewPRTool(
+  workspace: string,
+  defaultRepo: string | null = null,
+) {
   return {
     schema: {
       name: "githubViewPR",
@@ -322,6 +331,7 @@ export function createGithubViewPRTool(workspace: string) {
         "number,title,state,url,body,author,createdAt,updatedAt,baseRefName,headRefName,isDraft,mergeable,reviewDecision,reviews",
       ];
       if (number !== undefined) viewArgs.splice(2, 0, String(number));
+      if (defaultRepo) viewArgs.push("--repo", defaultRepo);
 
       const result = await execSafe("gh", viewArgs, {
         cwd: workspace,
@@ -358,7 +368,10 @@ export function createGithubViewPRTool(workspace: string) {
   };
 }
 
-export function createGithubGetPRDiffTool(workspace: string) {
+export function createGithubGetPRDiffTool(
+  workspace: string,
+  defaultRepo: string | null = null,
+) {
   return {
     schema: {
       name: "githubGetPRDiff",
@@ -413,7 +426,8 @@ export function createGithubGetPRDiffTool(workspace: string) {
       const prNumber = requireInt(args, "prNumber", 1);
       const repoArg = optionalString(args, "repo", 256);
 
-      const repoFlags = repoArg ? ["--repo", repoArg] : [];
+      const repoForFlags = repoArg ?? defaultRepo ?? undefined;
+      const repoFlags = repoForFlags ? ["--repo", repoForFlags] : [];
 
       const [metaResult, diffResult] = await Promise.all([
         execSafe(
@@ -496,7 +510,10 @@ export function createGithubGetPRDiffTool(workspace: string) {
   };
 }
 
-export function createGithubPostPRReviewTool(workspace: string) {
+export function createGithubPostPRReviewTool(
+  workspace: string,
+  defaultRepo: string | null = null,
+) {
   return {
     schema: {
       name: "githubPostPRReview",
@@ -627,7 +644,7 @@ export function createGithubPostPRReviewTool(workspace: string) {
         }
       }
 
-      const repo = await resolveRepo(workspace, repoArg, signal);
+      const repo = await resolveRepo(workspace, repoArg, signal, defaultRepo);
       if (!repo) {
         return error(
           "Could not determine repository. Pass 'repo' as owner/repo or run from inside a git repository.",
@@ -709,7 +726,10 @@ export function createGithubPostPRReviewTool(workspace: string) {
   };
 }
 
-export function createGithubApprovePRTool(workspace: string) {
+export function createGithubApprovePRTool(
+  workspace: string,
+  defaultRepo: string | null = null,
+) {
   return {
     schema: {
       name: "githubApprovePR",
@@ -751,7 +771,7 @@ export function createGithubApprovePRTool(workspace: string) {
       const body = optionalString(args, "body", 65_535) ?? "";
       const repoArg = optionalString(args, "repo", 256);
 
-      const repo = await resolveRepo(workspace, repoArg, signal);
+      const repo = await resolveRepo(workspace, repoArg, signal, defaultRepo);
       if (!repo) {
         return error(
           "Could not determine repository. Pass 'repo' as owner/repo or run from inside a git repository.",
@@ -804,7 +824,10 @@ export function createGithubApprovePRTool(workspace: string) {
   };
 }
 
-export function createGithubMergePRTool(workspace: string) {
+export function createGithubMergePRTool(
+  workspace: string,
+  defaultRepo: string | null = null,
+) {
   return {
     schema: {
       name: "githubMergePR",
@@ -864,7 +887,7 @@ export function createGithubMergePRTool(workspace: string) {
         );
       }
 
-      const repo = await resolveRepo(workspace, repoArg, signal);
+      const repo = await resolveRepo(workspace, repoArg, signal, defaultRepo);
       if (!repo) {
         return error(
           "Could not determine repository. Pass 'repo' as owner/repo or run from inside a git repository.",

--- a/src/tools/previewEdit.ts
+++ b/src/tools/previewEdit.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import {
   error,
+  hasNestedQuantifier,
   optionalBool,
   optionalInt,
   optionalString,
@@ -9,6 +10,9 @@ import {
   resolveFilePath,
   successStructured,
 } from "./utils.js";
+
+/** Max content size for a single searchReplace pass — matches searchAndReplace's 2MB per-file cap. */
+const MAX_SEARCH_REPLACE_SIZE = 2 * 1024 * 1024;
 
 /**
  * Compute a simple unified diff between two arrays of lines.
@@ -146,7 +150,24 @@ export function applySearchReplace(
   useRegex: boolean,
   caseSensitive = true,
 ): string {
+  // File-size bound — applied to both regex and literal modes. A multi-MB
+  // String.prototype.replace / split is itself a denial-of-service vector even
+  // without a pathological regex. Matches searchAndReplace's 2MB per-file cap.
+  if (Buffer.byteLength(content, "utf-8") > MAX_SEARCH_REPLACE_SIZE) {
+    throw new Error(
+      `Content exceeds the ${MAX_SEARCH_REPLACE_SIZE / (1024 * 1024)}MB searchReplace size limit — split the edit or use a line-range operation.`,
+    );
+  }
   if (useRegex) {
+    // ReDoS guard — reject nested quantifiers (e.g. (a+)+) before they reach
+    // new RegExp + content.replace on the full file. Shared with
+    // searchAndReplace via hasNestedQuantifier.
+    if (hasNestedQuantifier(search)) {
+      throw new Error(
+        "Pattern contains nested quantifiers (e.g. (a+)+) which can cause catastrophic backtracking. " +
+          "Simplify the regex — use a literal string match or a non-nested quantifier.",
+      );
+    }
     const flags = caseSensitive ? "g" : "gi";
     const re = new RegExp(search, flags);
     return content.replace(re, replace);

--- a/src/tools/searchAndReplace.ts
+++ b/src/tools/searchAndReplace.ts
@@ -5,6 +5,7 @@ import { writeFileAtomic } from "../writeFileAtomic.js";
 import {
   error,
   execSafe,
+  hasNestedQuantifier,
   optionalBool,
   optionalString,
   requireString,
@@ -117,12 +118,9 @@ export function createSearchAndReplaceTool(workspace: string) {
       let regex: RegExp | null = null;
       if (isRegex) {
         // Reject patterns with nested quantifiers — these can cause catastrophic
-        // backtracking (ReDoS) when applied to large files. Same guard as waitForTerminalOutput.
-        if (
-          /\([^)]*[+*]\)[+*?]/.test(pattern) ||
-          /\([^)]*\{[^}]+\}\)[+*{?]/.test(pattern) ||
-          /[+*][+*]|\{[^}]+\}[+*]/.test(pattern)
-        ) {
+        // backtracking (ReDoS) when applied to large files. Shared guard
+        // (hasNestedQuantifier) is also used by applySearchReplace.
+        if (hasNestedQuantifier(pattern)) {
           return error(
             "Pattern contains nested quantifiers (e.g. (a+)+) which can cause catastrophic backtracking. " +
               "Simplify the regex — use a literal string match or a non-nested quantifier.",

--- a/src/tools/transaction.ts
+++ b/src/tools/transaction.ts
@@ -1,5 +1,6 @@
 import crypto from "node:crypto";
 import fs from "node:fs";
+import type { FileLock } from "../fileLock.js";
 import { writeFileAtomic } from "../writeFileAtomic.js";
 import { applyLineRange, applySearchReplace } from "./previewEdit.js";
 import {
@@ -16,6 +17,14 @@ interface StagedEdit {
   filePath: string; // absolute resolved path
   originalContent: string;
   newContent: string;
+  /**
+   * mtimeMs of the file at stage time. Used for optimistic-concurrency
+   * detection at commit — if the file's mtime changed since staging, an
+   * intervening edit (editText/replaceBlock/external) happened and we refuse
+   * to clobber it. `undefined` when the file could not be stat'd at stage
+   * time (rare; check is then skipped for that edit).
+   */
+  originalMtimeMs?: number;
 }
 
 interface Transaction {
@@ -106,13 +115,32 @@ _ttlInterval.unref();
 function resolveAndRead(
   rawPath: string,
   workspace: string,
-): { resolved: string; content: string } {
+): { resolved: string; content: string; mtimeMs?: number } {
   const resolved = resolveFilePath(rawPath, workspace, { write: true });
+  // stat before read so we capture the mtime as of the staged snapshot. If the
+  // stat fails for any reason, fall through with mtimeMs undefined — the commit
+  // conflict check is skipped for that edit rather than blocking the stage.
+  let mtimeMs: number | undefined;
+  try {
+    mtimeMs = fs.statSync(resolved).mtimeMs;
+  } catch {
+    mtimeMs = undefined;
+  }
   const content = fs.readFileSync(resolved, "utf-8");
-  return { resolved, content };
+  return { resolved, content, mtimeMs };
 }
 
-export function createTransactionTools(workspace: string) {
+/**
+ * @param fileLock - Optional per-file lock. Reserved for future commit-time
+ *   serialization plumbing (see follow-up: wire from src/tools/index.ts). The
+ *   mtime-based optimistic-concurrency check works WITHOUT a lock and stands
+ *   alone — the lock would only narrow the (already-small) window between the
+ *   commit-time re-stat and the atomic write.
+ */
+export function createTransactionTools(workspace: string, fileLock?: FileLock) {
+  // Referenced so the optional param is retained for future wiring without a
+  // lint error; the mtime check below is independent of it.
+  void fileLock;
   const beginTransaction = {
     schema: {
       name: "beginTransaction",
@@ -245,11 +273,13 @@ export function createTransactionTools(workspace: string) {
 
       let resolved: string;
       let originalContent: string;
+      let originalMtimeMs: number | undefined;
       try {
-        ({ resolved, content: originalContent } = resolveAndRead(
-          rawPath,
-          workspace,
-        ));
+        ({
+          resolved,
+          content: originalContent,
+          mtimeMs: originalMtimeMs,
+        } = resolveAndRead(rawPath, workspace));
       } catch (e) {
         return error(
           `Cannot read file: ${e instanceof Error ? e.message : String(e)}`,
@@ -299,7 +329,12 @@ export function createTransactionTools(workspace: string) {
         }
       }
 
-      tx.edits.push({ filePath: resolved, originalContent, newContent });
+      tx.edits.push({
+        filePath: resolved,
+        originalContent,
+        newContent,
+        originalMtimeMs,
+      });
       return successStructured({
         staged: tx.edits.length,
         transactionId: txId,
@@ -367,6 +402,33 @@ export function createTransactionTools(workspace: string) {
 
       for (const edit of tx.edits) {
         try {
+          // Optimistic-concurrency check: re-stat the file and compare against
+          // the mtime captured at stage time. If it changed, an intervening
+          // edit happened (editText/replaceBlock/external) — refuse to clobber
+          // it. Matches the mtime guard in editText's native write path.
+          if (edit.originalMtimeMs !== undefined) {
+            let currentMtimeMs: number | undefined;
+            try {
+              currentMtimeMs = fs.statSync(edit.filePath).mtimeMs;
+            } catch {
+              // File was deleted between stage and commit.
+              errors.push({
+                file: edit.filePath,
+                error:
+                  "File was deleted after staging — commit aborted to avoid recreating a removed file",
+              });
+              continue;
+            }
+            if (currentMtimeMs !== edit.originalMtimeMs) {
+              errors.push({
+                file: edit.filePath,
+                error:
+                  "File was modified concurrently after staging — commit aborted to avoid clobbering the intervening edit. Re-stage this file.",
+              });
+              continue;
+            }
+          }
+
           await writeFileAtomic(edit.filePath, edit.newContent, {
             encoding: "utf-8",
           });

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -8,6 +8,28 @@ import { ensureCmdShimIfKnown } from "../winShim.js";
 
 const execFileAsync = promisify(execFile);
 
+/**
+ * Detect regex patterns with nested quantifiers that can trigger catastrophic
+ * backtracking (ReDoS) — e.g. `(a+)+`, `(ab*)*`, `(a{1,3})+`, `a++`, `a{2,4}+`.
+ *
+ * Shared guard used by `searchAndReplace` and `applySearchReplace`
+ * (previewEdit / stageEdit / transaction commit). Callers should reject the
+ * pattern before passing it to `new RegExp(...)` + `String.prototype.replace`,
+ * which would otherwise run unbounded on the full file content.
+ *
+ * This is a heuristic (string-level, not a full regex parser). It is
+ * deliberately conservative: it flags the common nesting shapes and may reject
+ * a small number of safe-but-unusual patterns. Literal (non-regex) searches
+ * must NOT be passed here.
+ */
+export function hasNestedQuantifier(pattern: string): boolean {
+  return (
+    /\([^)]*[+*]\)[+*?]/.test(pattern) ||
+    /\([^)]*\{[^}]+\}\)[+*{?]/.test(pattern) ||
+    /[+*][+*]|\{[^}]+\}[+*]/.test(pattern)
+  );
+}
+
 export function requireString(
   args: Record<string, unknown>,
   key: string,

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -1128,6 +1128,29 @@ export class McpTransport {
             };
             const tool = this.tools.get(params.name);
             if (!tool && this.dynamicToolDispatch) {
+              // Per-session deny list applies to dynamic/proxied tools too.
+              // Registered tools are gated below (denyTools.has check), but the
+              // dynamic-dispatch path bypassed it — a session that denied a tool
+              // via X-Bridge-Deny-Tools could still invoke it as an orchestrator
+              // child/proxy tool. Mirror the registered-tool deny response.
+              if (this.denyTools.has(params.name)) {
+                this.callCount++;
+                this.errorCount++;
+                response = {
+                  jsonrpc: "2.0",
+                  id: msg.id,
+                  result: {
+                    content: [
+                      {
+                        type: "text",
+                        text: `Tool "${params.name}" is denied for this session.`,
+                      },
+                    ],
+                    isError: true,
+                  },
+                };
+                break;
+              }
               // Read-only scope check — unknown tools are not in the registry so
               // we cannot inspect their annotations; block them under mcp:read.
               if (this.sessionScope === "mcp:read") {

--- a/vscode-extension/src/__tests__/handlers/workspaceSettings.test.ts
+++ b/vscode-extension/src/__tests__/handlers/workspaceSettings.test.ts
@@ -47,6 +47,68 @@ describe("handleSetWorkspaceSetting", () => {
     ).rejects.toThrow("blocked for safety");
   });
 
+  it("throws when targeting an ancestor section with a blocked leaf in the value object", async () => {
+    // Shell-hijack bypass: write to the parent section "terminal.integrated"
+    // and smuggle blocked leaf keys (defaultProfile / shellArgs) inside value.
+    await expect(
+      handleSetWorkspaceSetting({
+        key: "terminal.integrated",
+        value: {
+          defaultProfile: { osx: "evil" },
+          shellArgs: { osx: ["-c", "rm -rf ~"] },
+        },
+      }),
+    ).rejects.toThrow("blocked for safety");
+  });
+
+  it("throws when targeting an ancestor section with a nested blocked leaf", async () => {
+    // Even deeper nesting: terminal.integrated -> defaultProfile -> osx.
+    await expect(
+      handleSetWorkspaceSetting({
+        key: "terminal",
+        value: { integrated: { defaultProfile: { osx: "evil" } } },
+      }),
+    ).rejects.toThrow("blocked for safety");
+  });
+
+  it("throws when overwriting an ancestor section with a non-object value", async () => {
+    // Can't introspect leaves of a scalar, and there's no legitimate reason to
+    // replace a whole security-sensitive section with a scalar.
+    await expect(
+      handleSetWorkspaceSetting({ key: "terminal.integrated", value: "evil" }),
+    ).rejects.toThrow("blocked for safety");
+  });
+
+  it("throws for direct blocked key 'terminal.integrated.defaultProfile.osx'", async () => {
+    await expect(
+      handleSetWorkspaceSetting({
+        key: "terminal.integrated.defaultProfile.osx",
+        value: "evil",
+      }),
+    ).rejects.toThrow("blocked for safety");
+  });
+
+  it("allows an unrelated terminal setting with a plain object value", async () => {
+    const mockUpdate = vi.fn(async () => {});
+    vi.mocked(vscode.workspace.getConfiguration).mockReturnValue({
+      get: vi.fn(),
+      inspect: vi.fn(),
+      update: mockUpdate,
+    } as any);
+
+    const result = (await handleSetWorkspaceSetting({
+      key: "terminal.integrated",
+      value: { cursorBlinking: true, fontSize: 12 },
+    })) as any;
+
+    expect(mockUpdate).toHaveBeenCalledWith(
+      "integrated",
+      { cursorBlinking: true, fontSize: 12 },
+      vscode.ConfigurationTarget.Workspace,
+    );
+    expect(result.set).toBe(true);
+  });
+
   it("throws for __proto__ key (prototype pollution)", async () => {
     await expect(
       handleSetWorkspaceSetting({ key: "__proto__" }),

--- a/vscode-extension/src/handlers/workspaceSettings.ts
+++ b/vscode-extension/src/handlers/workspaceSettings.ts
@@ -16,6 +16,44 @@ const BLOCKED_KEY_PREFIXES = new Set([
   "terminal.integrated.defaultProfile",
 ]);
 
+// Plain-object check that excludes arrays and null. Used to decide whether a
+// setting value carries nested leaf keys we need to vet against the blocklist.
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+// Recursively enumerate the dotted leaf paths of a plain object. Arrays and
+// primitive values terminate a branch; only nested plain objects recurse, since
+// VS Code settings keys are dotted object paths.
+function enumerateLeafPaths(value: Record<string, unknown>): string[] {
+  const paths: string[] = [];
+  for (const segment of Object.keys(value)) {
+    // Skip prototype-polluting keys; they're rejected separately.
+    if (
+      segment === "__proto__" ||
+      segment === "constructor" ||
+      segment === "prototype"
+    ) {
+      paths.push(segment);
+      continue;
+    }
+    const child = value[segment];
+    if (isPlainObject(child)) {
+      const childPaths = enumerateLeafPaths(child);
+      if (childPaths.length === 0) {
+        paths.push(segment);
+      } else {
+        for (const childPath of childPaths) {
+          paths.push(`${segment}.${childPath}`);
+        }
+      }
+    } else {
+      paths.push(segment);
+    }
+  }
+  return paths;
+}
+
 export async function handleGetWorkspaceSettings(
   params: Record<string, unknown>,
 ): Promise<unknown> {
@@ -61,6 +99,36 @@ export async function handleSetWorkspaceSetting(
     (prefix) => key === prefix || key.startsWith(`${prefix}.`),
   );
   if (isBlocked) {
+    throw new Error(`Writing to "${key}" settings is blocked for safety`);
+  }
+
+  // Shell-hijack bypass guard. config.update(section, value) writes value into
+  // the section, so an agent can target an ANCESTOR of a blocked prefix
+  // (e.g. key="terminal.integrated") and smuggle blocked leaf keys via a nested
+  // object value, sidestepping the exact/sub-key match above. When the key is
+  // an ancestor of a blocked prefix:
+  //   - If value is a plain object, enumerate its leaf paths and reject only
+  //     when a resolved path lands on a blocked prefix — legitimate unrelated
+  //     writes to the same section still succeed.
+  //   - Otherwise (non-object value), we can't introspect leaves, so block the
+  //     write outright: there is no legitimate reason to overwrite a whole
+  //     security-sensitive section with a scalar.
+  const keyIsAncestorOfBlocked = [...BLOCKED_KEY_PREFIXES].some((prefix) =>
+    prefix.startsWith(`${key}.`),
+  );
+  if (isPlainObject(value)) {
+    for (const leafPath of enumerateLeafPaths(value)) {
+      const resolved = `${key}.${leafPath}`;
+      const leafBlocked = [...BLOCKED_KEY_PREFIXES].some(
+        (prefix) => resolved === prefix || resolved.startsWith(`${prefix}.`),
+      );
+      if (leafBlocked) {
+        throw new Error(
+          `Writing to "${resolved}" settings is blocked for safety`,
+        );
+      }
+    }
+  } else if (keyIsAncestorOfBlocked) {
     throw new Error(`Writing to "${key}" settings is blocked for safety`);
   }
 


### PR DESCRIPTION
## What

Fixes the **medium-severity** findings from the 2026-06-02 codebase audit (29 findings). Test-first per the Bug Fix Protocol.

> ⚠️ **Stacked on #848** (critical + high tier). This PR's diff is medium-tier-only. After #848 squash-merges, retarget this PR's base to `main` (the repo squashes, so the leaf must point at `main` before merge).

## 🔬 Two changes need an explicit product sign-off

These alter recipe-runner *semantics* — they're correct per the findings and all tests pass, but "tests green" ≠ "intended behavior". Please confirm:

1. **Flat YAML runner now halts after a hard failure** (`yamlRunner.ts`) — previously every remaining step ran after a failure, diverging from `chainedRunner` which aborts. The halt respects `on_error.fallback` (`log_only`/`deliver_original` still continue) and deliberately does **not** halt on soft `{count:0,error}` silent-fail envelopes (two existing tests pin that contract). Hard failures (throws, `{ok:false}`, agent failures) now stop the run.
2. **Token budget now gates all step types** (`yamlRunner.ts` / `runBudget.ts`) — `admit()` was only called for agent steps, so tool steps ran unbounded after a breach. Now every step kind is gated.

## Security

- Datadog `DATADOG_SITE` env validated against the SSRF allowlist
- Redis read-only allowlist no longer admits mutating `CLIENT`/`MEMORY` subcommands
- Transport dynamic-dispatch path now honors the per-session deny list (`X-Bridge-Deny-Tools`)
- `setWorkspaceSetting` blocks a parent section whose object value nests a blocked terminal-shell sub-key
- Dashboard login no longer shares a single `"unknown"` brute-force bucket without a trusted proxy (was a trivial global-lockout DoS)

## Correctness / reliability

- `WithRetry` honors `maxRetries > 1` (was capped at 1); `onRecipeSave` cooldown is now per-file
- `recipe run` CLI fetch has a 30s timeout (wedged bridge no longer hangs)
- Notion connect accepts `ntn_` tokens; MCP connectors refresh+retry once on 401
- Snowflake surfaces async (HTTP 202) statements instead of empty results
- Claude subprocess driver truncates `OUTPUT_CAP` by UTF-8 bytes; `ApiDriver.run` never rejects (honors the `ProviderDriver` contract); provider-driver errors surface the real message
- Orchestrator: transient empty `listTools` no longer wipes a healthy bridge's tools; health probe loop has a re-entrancy guard
- Dashboard approval push relay respects the per-subscription `approvals` opt-out
- `decisionReplay` buckets `ask→deny/none` and adds `nowAskedCount`
- `getGitStatus` parses renamed/copied paths; `githubPR` composite honors `githubDefaultRepo`; `getToolCapabilities` reports a headless-CLI LSP tier + corrected counts
- `applySearchReplace` gains the ReDoS guard + size bound; `commitTransaction` adds an mtime optimistic-concurrency check
- Recipe `version` optional at install; generated name pattern matches `RECIPE_NAME_RE`
- Plugin tools honor `annotations.destructiveHint` for write-gating; dashboard github install supports `@ref` pinning

## Verification

- `tsc` (main) + strict `tests.core` ratchet: **clean**
- Bridge **6950** · dashboard **754** · extension **575** tests pass

## Follow-ups surfaced during this work (not in this PR)

- Pre-existing **transport double-send**: the dynamic-dispatch success path leaves `response` at its `-32603` default, which is sent before the real async result (likely `return` vs `break`).
- `commitTransaction` fileLock serialization: the mtime check covers the realistic case; full lock-serialization (`index.ts` wiring) is deferred.
- Bundle install doesn't thread `@ref` to sub-recipes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
