### PR TITLE
feat(cli): add 'patchwork connect' connector auth front-door

### DIFF
--- a/src/commands/__tests__/connect.test.ts
+++ b/src/commands/__tests__/connect.test.ts
@@ -1,0 +1,314 @@
+/**
+ * Tests for `patchwork connect` — the connector front-door CLI.
+ *
+ * `runConnect` is a thin CLI→HTTP shim over already-built bridge
+ * `/connections/*` routes. These tests inject a fake `findBridgeLock`
+ * (so no real lock file is read) and a fake `fetchFn` (so no real HTTP
+ * is made), plus capture-only `write`/`writeErr`/`exit` seams so the
+ * test process is never torn down by `process.exit`.
+ *
+ * Bug Fix Protocol: written before `runConnect` exists.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import type { ConnectorDescriptor } from "../../connectors/connectorRegistry.js";
+import { type ConnectDeps, runConnect } from "../connect.js";
+
+// ── test harness ──────────────────────────────────────────────────────────────
+
+const FAKE_LOCK = { port: 1234, authToken: "t" };
+
+const TEST_CONNECTORS: readonly ConnectorDescriptor[] = [
+  {
+    id: "gmail",
+    label: "Gmail",
+    authKind: "oauth",
+    supports: { auth: true, test: true, delete: true },
+  },
+  {
+    id: "notion",
+    label: "Notion",
+    authKind: "pat",
+    supports: { auth: true, connect: true, test: true, delete: true },
+  },
+  {
+    id: "caldiy",
+    label: "Cal.diy",
+    authKind: "pat",
+    supports: { connect: true, test: true, delete: true },
+  },
+];
+
+interface Capture {
+  out: string;
+  err: string;
+  code: number | null;
+}
+
+interface HarnessResult {
+  capture: Capture;
+  fetchFn: ReturnType<typeof vi.fn>;
+}
+
+/** Build deps with capture seams + a scripted fetch. */
+function makeDeps(
+  fetchImpl: (url: string, init?: RequestInit) => Promise<Response>,
+  overrides: Partial<ConnectDeps> = {},
+): { deps: ConnectDeps; result: HarnessResult } {
+  const capture: Capture = { out: "", err: "", code: null };
+  const fetchFn = vi.fn(fetchImpl);
+  const deps: ConnectDeps = {
+    findBridgeLock: () => FAKE_LOCK,
+    fetchFn: fetchFn as unknown as ConnectDeps["fetchFn"],
+    connectors: TEST_CONNECTORS,
+    write: (s: string) => {
+      capture.out += s;
+    },
+    writeErr: (s: string) => {
+      capture.err += s;
+    },
+    exit: (c: number) => {
+      capture.code = c;
+    },
+    ...overrides,
+  };
+  return { deps, result: { capture, fetchFn } };
+}
+
+/** Minimal Response stub for JSON bodies. */
+function jsonResponse(status: number, body: unknown): Response {
+  return {
+    status,
+    ok: status >= 200 && status < 300,
+    headers: new Headers({ "content-type": "application/json" }),
+    text: async () => JSON.stringify(body),
+  } as unknown as Response;
+}
+
+/** Minimal Response stub for a 302 redirect with a Location header. */
+function redirectResponse(location: string): Response {
+  return {
+    status: 302,
+    ok: false,
+    headers: new Headers({ location }),
+    text: async () => "",
+  } as unknown as Response;
+}
+
+// ── list ──────────────────────────────────────────────────────────────────────
+
+describe("patchwork connect list", () => {
+  it("joins live status with registry label + authKind", async () => {
+    const { deps, result } = makeDeps(async () =>
+      jsonResponse(200, {
+        connectors: [
+          { id: "gmail", status: "connected" },
+          { id: "notion", status: "needs_reauth" },
+          // caldiy absent from the live response → treated as disconnected
+        ],
+      }),
+    );
+    await runConnect(["list"], deps);
+
+    const { fetchFn, capture } = result;
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchFn.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("http://127.0.0.1:1234/connections");
+    expect((init.headers as Record<string, string>).Authorization).toBe(
+      "Bearer t",
+    );
+
+    // Every registry connector is listed with its label.
+    expect(capture.out).toContain("Gmail");
+    expect(capture.out).toContain("Notion");
+    expect(capture.out).toContain("Cal.diy");
+    // Status surfaced from the live response.
+    expect(capture.out.toLowerCase()).toContain("connected");
+    expect(capture.out.toLowerCase()).toContain("reauth");
+    expect(capture.code === null || capture.code === 0).toBe(true);
+  });
+
+  it("emits machine-readable JSON with --json", async () => {
+    const { deps, result } = makeDeps(async () =>
+      jsonResponse(200, {
+        connectors: [{ id: "gmail", status: "connected" }],
+      }),
+    );
+    await runConnect(["list", "--json"], deps);
+
+    const parsed = JSON.parse(result.capture.out) as {
+      connectors: Array<{ id: string; status: string; label: string }>;
+    };
+    const gmail = parsed.connectors.find((c) => c.id === "gmail");
+    expect(gmail?.status).toBe("connected");
+    expect(gmail?.label).toBe("Gmail");
+  });
+
+  it("bare `connect` with no args lists connectors", async () => {
+    const { deps, result } = makeDeps(async () =>
+      jsonResponse(200, { connectors: [{ id: "gmail", status: "connected" }] }),
+    );
+    await runConnect([], deps);
+    expect(result.fetchFn).toHaveBeenCalledTimes(1);
+    expect(result.capture.out).toContain("Gmail");
+  });
+});
+
+// ── OAuth ──────────────────────────────────────────────────────────────────────
+
+describe("patchwork connect <oauth-vendor>", () => {
+  it("captures the 302 Location and prints the authorize URL", async () => {
+    const authorizeUrl = "https://accounts.google.com/o/oauth2/v2/auth?x=1";
+    const { deps, result } = makeDeps(async () =>
+      redirectResponse(authorizeUrl),
+    );
+    await runConnect(["gmail"], deps);
+
+    const [url, init] = result.fetchFn.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("http://127.0.0.1:1234/connections/gmail/auth");
+    expect(init.redirect).toBe("manual");
+    expect((init.headers as Record<string, string>).Authorization).toBe(
+      "Bearer t",
+    );
+    // The URL the user should open is surfaced to stdout.
+    expect(result.capture.out).toContain(authorizeUrl);
+    expect(result.capture.out).toContain("Gmail");
+  });
+
+  it("--url-only prints ONLY the authorize URL", async () => {
+    const authorizeUrl = "https://accounts.google.com/o/oauth2/v2/auth?x=2";
+    const { deps, result } = makeDeps(async () =>
+      redirectResponse(authorizeUrl),
+    );
+    await runConnect(["gmail", "--url-only"], deps);
+    expect(result.capture.out.trim()).toBe(authorizeUrl);
+  });
+
+  it("errors clearly when no Location header is returned", async () => {
+    const { deps, result } = makeDeps(async () =>
+      jsonResponse(503, { error: "not configured" }),
+    );
+    await runConnect(["gmail"], deps);
+    expect(result.capture.err.length).toBeGreaterThan(0);
+    expect(result.capture.code).toBe(1);
+  });
+});
+
+// ── PAT ────────────────────────────────────────────────────────────────────────
+
+describe("patchwork connect <pat-vendor>", () => {
+  it("POSTs {token} to /connect when --token is provided", async () => {
+    const { deps, result } = makeDeps(async () =>
+      jsonResponse(200, { ok: true, workspace: "Acme" }),
+    );
+    await runConnect(["notion", "--token", "secret_abc"], deps);
+
+    const [url, init] = result.fetchFn.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("http://127.0.0.1:1234/connections/notion/connect");
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(init.body as string)).toEqual({ token: "secret_abc" });
+    expect(result.capture.out).toContain("Notion");
+    expect(result.capture.code === null || result.capture.code === 0).toBe(
+      true,
+    );
+  });
+
+  it("reports failure (nonzero exit) when /connect rejects the token", async () => {
+    const { deps, result } = makeDeps(async () =>
+      jsonResponse(401, { ok: false, error: "Token rejected" }),
+    );
+    await runConnect(["notion", "--token", "bad"], deps);
+    expect(result.capture.err).toContain("Token rejected");
+    expect(result.capture.code).toBe(1);
+  });
+
+  it("prints instructions and does NOT POST when no --token is given", async () => {
+    const { deps, result } = makeDeps(async () =>
+      jsonResponse(200, { ok: true }),
+    );
+    await runConnect(["notion"], deps);
+    expect(result.fetchFn).not.toHaveBeenCalled();
+    expect(result.capture.out).toContain("--token");
+    // Multi-field connectors are directed to the dashboard.
+    expect(result.capture.out.toLowerCase()).toContain("dashboard");
+  });
+});
+
+// ── test verb ──────────────────────────────────────────────────────────────────
+
+describe("patchwork connect test <vendor>", () => {
+  it("POSTs to /test and reports pass", async () => {
+    const { deps, result } = makeDeps(async () =>
+      jsonResponse(200, { ok: true }),
+    );
+    await runConnect(["test", "gmail"], deps);
+    const [url, init] = result.fetchFn.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("http://127.0.0.1:1234/connections/gmail/test");
+    expect(init.method).toBe("POST");
+    expect(result.capture.code === null || result.capture.code === 0).toBe(
+      true,
+    );
+  });
+
+  it("exits nonzero on a failing health probe", async () => {
+    const { deps, result } = makeDeps(async () =>
+      jsonResponse(401, { ok: false, error: "expired" }),
+    );
+    await runConnect(["test", "gmail"], deps);
+    expect(result.capture.err).toContain("expired");
+    expect(result.capture.code).toBe(1);
+  });
+});
+
+// ── disconnect verb ─────────────────────────────────────────────────────────────
+
+describe("patchwork connect disconnect <vendor>", () => {
+  it("issues a DELETE and reports success", async () => {
+    const { deps, result } = makeDeps(async () =>
+      jsonResponse(200, { ok: true }),
+    );
+    await runConnect(["disconnect", "gmail"], deps);
+    const [url, init] = result.fetchFn.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("http://127.0.0.1:1234/connections/gmail");
+    expect(init.method).toBe("DELETE");
+    expect(result.capture.code === null || result.capture.code === 0).toBe(
+      true,
+    );
+  });
+});
+
+// ── error paths ─────────────────────────────────────────────────────────────────
+
+describe("patchwork connect error handling", () => {
+  it("rejects an unknown vendor with a nonzero exit + suggestion", async () => {
+    const { deps, result } = makeDeps(async () =>
+      jsonResponse(200, { connectors: [] }),
+    );
+    await runConnect(["gmial"], deps);
+    expect(result.fetchFn).not.toHaveBeenCalled();
+    expect(result.capture.err.toLowerCase()).toContain("unknown");
+    // Should hint at the closest valid id.
+    expect(result.capture.err).toContain("gmail");
+    expect(result.capture.code).toBe(1);
+  });
+
+  it("prints the start hint and exits nonzero when no bridge is running", async () => {
+    const { deps, result } = makeDeps(
+      async () => jsonResponse(200, { connectors: [] }),
+      { findBridgeLock: () => null },
+    );
+    await runConnect(["list"], deps);
+    expect(result.fetchFn).not.toHaveBeenCalled();
+    expect(result.capture.err).toContain("patchwork start");
+    expect(result.capture.code).toBe(1);
+  });
+
+  it("fails soft on a network error with a readable message", async () => {
+    const { deps, result } = makeDeps(async () => {
+      throw new Error("ECONNREFUSED");
+    });
+    await runConnect(["list"], deps);
+    expect(result.capture.err).toContain("ECONNREFUSED");
+    expect(result.capture.code).toBe(1);
+  });
+});

--- a/src/commands/connect.ts
+++ b/src/commands/connect.ts
@@ -1,0 +1,548 @@
+/**
+ * `patchwork connect` — the connector front-door.
+ *
+ * A thin CLI→HTTP shim over the bridge's already-built `/connections/*`
+ * routes (see src/connectorRoutes.ts). 23 connector error messages already
+ * tell users to "Run: patchwork connect <vendor>"; this is that command.
+ *
+ * NO new bridge or connector logic lives here — every verb maps to one
+ * existing HTTP route:
+ *   - list       → GET    /connections                (Bearer)
+ *   - <vendor>   → GET    /connections/<id>/auth       (OAuth, 302 Location)
+ *              or  POST   /connections/<id>/connect    (PAT, {token})
+ *   - test       → POST   /connections/<id>/test       (health probe)
+ *   - disconnect → DELETE /connections/<id>            (revoke)
+ *
+ * Bridge discovery + Bearer auth mirror src/commands/task.ts. All side
+ * effects (lock discovery, fetch, stdout/stderr, exit) are injectable so
+ * the command is unit-testable without a live bridge.
+ */
+
+import {
+  CONNECTORS,
+  type ConnectorDescriptor,
+} from "../connectors/connectorRegistry.js";
+
+interface LockInfo {
+  port: number;
+  authToken: string;
+}
+
+export interface ConnectDeps {
+  /** Resolve a running bridge. `port` selects a specific lock. */
+  findBridgeLock: (port?: number) => LockInfo | null;
+  /** HTTP transport (defaults to global fetch). */
+  fetchFn: typeof fetch;
+  /** Connector roster (defaults to the shared registry). */
+  connectors: readonly ConnectorDescriptor[];
+  /** stdout sink. */
+  write: (s: string) => void;
+  /** stderr sink. */
+  writeErr: (s: string) => void;
+  /** Process exit (capture-only in tests). */
+  exit: (code: number) => void;
+}
+
+// ── live `/connections` response shape (id + status only) ────────────────────
+
+type ConnectionStatus = "connected" | "disconnected" | "needs_reauth";
+
+interface LiveConnector {
+  id?: string;
+  status?: string;
+  lastSync?: string;
+}
+
+interface ConnectionsListResponse {
+  connectors?: LiveConnector[];
+}
+
+/** Generic `{ ok, error, ... }` body returned by connect/test/delete routes. */
+interface ConnectorActionResponse {
+  ok?: boolean;
+  error?: string;
+  workspace?: string;
+  [k: string]: unknown;
+}
+
+const TIMEOUT_MS = 10_000;
+
+// ── arg parsing ──────────────────────────────────────────────────────────────
+
+interface ParsedArgs {
+  positional: string[];
+  json: boolean;
+  urlOnly: boolean;
+  help: boolean;
+  token?: string;
+  port?: number;
+}
+
+function parseArgs(argv: string[]): ParsedArgs {
+  const out: ParsedArgs = {
+    positional: [],
+    json: false,
+    urlOnly: false,
+    help: false,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === undefined) continue;
+    if (a === "--json") out.json = true;
+    else if (a === "--url-only") out.urlOnly = true;
+    else if (a === "--help" || a === "-h") out.help = true;
+    else if (a === "--token") {
+      const next = argv[++i];
+      if (next !== undefined) out.token = next;
+    } else if (a === "--port") {
+      const next = argv[++i];
+      if (next !== undefined) out.port = Number(next);
+    } else if (!a.startsWith("-")) {
+      out.positional.push(a);
+    }
+  }
+  return out;
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+function bearer(lock: LockInfo): Record<string, string> {
+  return { Authorization: `Bearer ${lock.authToken}` };
+}
+
+function statusGlyph(status: ConnectionStatus): string {
+  if (status === "connected") return "✓ connected";
+  if (status === "needs_reauth") return "⚠ needs reauth";
+  return "✗ not connected";
+}
+
+function normalizeStatus(raw: string | undefined): ConnectionStatus {
+  if (raw === "connected" || raw === "needs_reauth") return raw;
+  return "disconnected";
+}
+
+/** Levenshtein distance for "did you mean" suggestions. */
+function editDistance(a: string, b: string): number {
+  const m = a.length;
+  const n = b.length;
+  const prev: number[] = Array.from({ length: n + 1 }, (_, j) => j);
+  const curr: number[] = new Array<number>(n + 1).fill(0);
+  for (let i = 1; i <= m; i++) {
+    curr[0] = i;
+    for (let j = 1; j <= n; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      const del = (prev[j] ?? 0) + 1;
+      const ins = (curr[j - 1] ?? 0) + 1;
+      const sub = (prev[j - 1] ?? 0) + cost;
+      curr[j] = Math.min(del, ins, sub);
+    }
+    for (let j = 0; j <= n; j++) prev[j] = curr[j] ?? 0;
+  }
+  return prev[n] ?? 0;
+}
+
+function suggestVendor(
+  input: string,
+  connectors: readonly ConnectorDescriptor[],
+): string | undefined {
+  let best: { id: string; dist: number } | undefined;
+  for (const c of connectors) {
+    const dist = editDistance(input, c.id);
+    if (!best || dist < best.dist) best = { id: c.id, dist };
+  }
+  // Only suggest when reasonably close.
+  return best && best.dist <= 3 ? best.id : undefined;
+}
+
+function resolveLock(deps: ConnectDeps, port?: number): LockInfo | null {
+  const lock = deps.findBridgeLock(port);
+  if (!lock) {
+    deps.writeErr(
+      "No running bridge — start it with: patchwork start\n" +
+        (port !== undefined
+          ? `(checked port ${port}; lock missing, IDE-owned, or dead)\n`
+          : ""),
+    );
+    deps.exit(1);
+    return null;
+  }
+  return lock;
+}
+
+async function readJson<T>(res: Response): Promise<T | null> {
+  const text = await res.text();
+  if (!text) return null;
+  try {
+    return JSON.parse(text) as T;
+  } catch {
+    return null;
+  }
+}
+
+function networkError(deps: ConnectDeps, err: unknown, json: boolean): void {
+  const msg = err instanceof Error ? err.message : String(err);
+  if (json) {
+    deps.write(`${JSON.stringify({ ok: false, error: msg })}\n`);
+  }
+  deps.writeErr(`Error contacting bridge: ${msg}\n`);
+  deps.exit(1);
+}
+
+// ── verbs ────────────────────────────────────────────────────────────────────
+
+async function runList(deps: ConnectDeps, args: ParsedArgs): Promise<void> {
+  const lock = resolveLock(deps, args.port);
+  if (!lock) return;
+
+  let live: ConnectionsListResponse | null;
+  try {
+    const res = await deps.fetchFn(
+      `http://127.0.0.1:${lock.port}/connections`,
+      {
+        method: "GET",
+        headers: bearer(lock),
+        signal: AbortSignal.timeout(TIMEOUT_MS),
+      },
+    );
+    live = await readJson<ConnectionsListResponse>(res);
+  } catch (err) {
+    networkError(deps, err, args.json);
+    return;
+  }
+
+  // Join live status onto the full registry roster so connectors absent
+  // from the response render as not-connected rather than vanishing.
+  const statusById = new Map<string, ConnectionStatus>();
+  for (const c of live?.connectors ?? []) {
+    if (c.id) statusById.set(c.id, normalizeStatus(c.status));
+  }
+
+  const rows = deps.connectors.map((c) => ({
+    id: c.id,
+    label: c.label,
+    authKind: c.authKind,
+    status: statusById.get(c.id) ?? ("disconnected" as ConnectionStatus),
+  }));
+
+  if (args.json) {
+    deps.write(`${JSON.stringify({ connectors: rows })}\n`);
+    deps.exit(0);
+    return;
+  }
+
+  // Connected first, then needs_reauth, then disconnected; stable by label.
+  const rank: Record<ConnectionStatus, number> = {
+    connected: 0,
+    needs_reauth: 1,
+    disconnected: 2,
+  };
+  rows.sort(
+    (a, b) => rank[a.status] - rank[b.status] || a.label.localeCompare(b.label),
+  );
+
+  const idWidth = Math.max(...rows.map((r) => r.id.length), 2);
+  deps.write("Connectors:\n");
+  for (const r of rows) {
+    deps.write(
+      `  ${r.id.padEnd(idWidth)}  ${statusGlyph(r.status).padEnd(16)}` +
+        `${r.label} (${r.authKind})\n`,
+    );
+  }
+  deps.exit(0);
+}
+
+async function runOauth(
+  deps: ConnectDeps,
+  descriptor: ConnectorDescriptor,
+  args: ParsedArgs,
+): Promise<void> {
+  const lock = resolveLock(deps, args.port);
+  if (!lock) return;
+
+  let res: Response;
+  try {
+    res = await deps.fetchFn(
+      `http://127.0.0.1:${lock.port}/connections/${descriptor.id}/auth`,
+      {
+        method: "GET",
+        headers: bearer(lock),
+        redirect: "manual",
+        signal: AbortSignal.timeout(TIMEOUT_MS),
+      },
+    );
+  } catch (err) {
+    networkError(deps, err, args.json);
+    return;
+  }
+
+  const location = res.headers.get("location");
+  if (res.status === 302 && location) {
+    if (args.json) {
+      deps.write(`${JSON.stringify({ ok: true, url: location })}\n`);
+    } else if (args.urlOnly) {
+      deps.write(`${location}\n`);
+    } else {
+      deps.write(
+        `Open this URL in your browser to authorize ${descriptor.label}:\n` +
+          `  ${location}\n`,
+      );
+    }
+    deps.exit(0);
+    return;
+  }
+
+  // No redirect — surface the bridge's error body if present.
+  const body = await readJson<ConnectorActionResponse>(res);
+  const detail = body?.error ?? `HTTP ${res.status}`;
+  if (args.json) {
+    deps.write(`${JSON.stringify({ ok: false, error: detail })}\n`);
+  }
+  deps.writeErr(
+    `Could not start ${descriptor.label} authorization: ${detail}\n`,
+  );
+  deps.exit(1);
+}
+
+async function runPatConnect(
+  deps: ConnectDeps,
+  descriptor: ConnectorDescriptor,
+  args: ParsedArgs,
+): Promise<void> {
+  if (!args.token) {
+    // No token supplied — print honest instructions rather than guessing.
+    deps.write(
+      `${descriptor.label} is a token (PAT) connector.\n` +
+        `  Pass a token directly:\n` +
+        `    patchwork connect ${descriptor.id} --token <TOKEN>\n` +
+        `  Some connectors need more than one field (e.g. Jira/Confluence/` +
+        `Zendesk/Datadog need a URL + email + token).\n` +
+        `  For those, use the dashboard /connections page to connect.\n`,
+    );
+    deps.exit(0);
+    return;
+  }
+
+  const lock = resolveLock(deps, args.port);
+  if (!lock) return;
+
+  let res: Response;
+  try {
+    res = await deps.fetchFn(
+      `http://127.0.0.1:${lock.port}/connections/${descriptor.id}/connect`,
+      {
+        method: "POST",
+        headers: { ...bearer(lock), "Content-Type": "application/json" },
+        body: JSON.stringify({ token: args.token }),
+        signal: AbortSignal.timeout(TIMEOUT_MS),
+      },
+    );
+  } catch (err) {
+    networkError(deps, err, args.json);
+    return;
+  }
+
+  const body = await readJson<ConnectorActionResponse>(res);
+  const ok = res.status >= 200 && res.status < 300 && body?.ok !== false;
+  if (args.json) {
+    deps.write(`${JSON.stringify({ ok, ...(body ?? {}) })}\n`);
+  } else if (ok) {
+    const where = body?.workspace ? ` (workspace: ${body.workspace})` : "";
+    deps.write(`✓ Connected ${descriptor.label}${where}\n`);
+  } else {
+    deps.writeErr(
+      `✗ Failed to connect ${descriptor.label}: ${body?.error ?? `HTTP ${res.status}`}\n`,
+    );
+  }
+  deps.exit(ok ? 0 : 1);
+}
+
+async function runTest(
+  deps: ConnectDeps,
+  vendor: string | undefined,
+  args: ParsedArgs,
+): Promise<void> {
+  const descriptor = resolveVendor(deps, vendor);
+  if (!descriptor) return;
+  const lock = resolveLock(deps, args.port);
+  if (!lock) return;
+
+  let res: Response;
+  try {
+    res = await deps.fetchFn(
+      `http://127.0.0.1:${lock.port}/connections/${descriptor.id}/test`,
+      {
+        method: "POST",
+        headers: bearer(lock),
+        signal: AbortSignal.timeout(TIMEOUT_MS),
+      },
+    );
+  } catch (err) {
+    networkError(deps, err, args.json);
+    return;
+  }
+
+  const body = await readJson<ConnectorActionResponse>(res);
+  const ok = res.status >= 200 && res.status < 300 && body?.ok !== false;
+  if (args.json) {
+    deps.write(`${JSON.stringify({ ok, ...(body ?? {}) })}\n`);
+  } else if (ok) {
+    deps.write(`✓ ${descriptor.label} is healthy\n`);
+  } else {
+    deps.writeErr(
+      `✗ ${descriptor.label} test failed: ${body?.error ?? `HTTP ${res.status}`}\n`,
+    );
+  }
+  deps.exit(ok ? 0 : 1);
+}
+
+async function runDisconnect(
+  deps: ConnectDeps,
+  vendor: string | undefined,
+  args: ParsedArgs,
+): Promise<void> {
+  const descriptor = resolveVendor(deps, vendor);
+  if (!descriptor) return;
+  const lock = resolveLock(deps, args.port);
+  if (!lock) return;
+
+  let res: Response;
+  try {
+    res = await deps.fetchFn(
+      `http://127.0.0.1:${lock.port}/connections/${descriptor.id}`,
+      {
+        method: "DELETE",
+        headers: bearer(lock),
+        signal: AbortSignal.timeout(TIMEOUT_MS),
+      },
+    );
+  } catch (err) {
+    networkError(deps, err, args.json);
+    return;
+  }
+
+  const body = await readJson<ConnectorActionResponse>(res);
+  const ok = res.status >= 200 && res.status < 300 && body?.ok !== false;
+  if (args.json) {
+    deps.write(`${JSON.stringify({ ok, ...(body ?? {}) })}\n`);
+  } else if (ok) {
+    deps.write(`✓ Disconnected ${descriptor.label}\n`);
+  } else {
+    deps.writeErr(
+      `✗ Failed to disconnect ${descriptor.label}: ${body?.error ?? `HTTP ${res.status}`}\n`,
+    );
+  }
+  deps.exit(ok ? 0 : 1);
+}
+
+/** Resolve a vendor id to its descriptor, or emit an error + exit(1). */
+function resolveVendor(
+  deps: ConnectDeps,
+  vendor: string | undefined,
+): ConnectorDescriptor | undefined {
+  if (!vendor) {
+    deps.writeErr("Missing connector id.\n");
+    deps.exit(1);
+    return undefined;
+  }
+  const descriptor = deps.connectors.find((c) => c.id === vendor);
+  if (!descriptor) {
+    const hint = suggestVendor(vendor, deps.connectors);
+    const validIds = deps.connectors.map((c) => c.id).join(", ");
+    deps.writeErr(
+      `Unknown connector "${vendor}".\n` +
+        (hint ? `Did you mean "${hint}"?\n` : "") +
+        `Valid ids: ${validIds}\n`,
+    );
+    deps.exit(1);
+    return undefined;
+  }
+  return descriptor;
+}
+
+function printHelp(deps: ConnectDeps): void {
+  deps.write(
+    "Usage: patchwork connect [<vendor>|list|test <vendor>|disconnect <vendor>]\n" +
+      "\n" +
+      "  connect [list] [--json]            List connectors + connection status\n" +
+      "  connect <vendor> [--url-only]      OAuth: print the authorize URL to open\n" +
+      "  connect <vendor> --token <TOKEN>   PAT: paste a token to connect\n" +
+      "  connect test <vendor> [--json]     Health-probe a connector\n" +
+      "  connect disconnect <vendor>        Revoke a connector\n" +
+      "\n" +
+      "  --port <n>   Target a specific bridge lock\n" +
+      "  --url-only   Print only the OAuth URL (headless/CI)\n" +
+      "  --json       Machine-readable output\n",
+  );
+  deps.exit(0);
+}
+
+// ── entrypoint ───────────────────────────────────────────────────────────────
+
+const DEFAULT_DEPS: Omit<ConnectDeps, "findBridgeLock"> = {
+  fetchFn: globalThis.fetch,
+  connectors: CONNECTORS,
+  write: (s) => process.stdout.write(s),
+  writeErr: (s) => process.stderr.write(s),
+  exit: (c) => process.exit(c),
+};
+
+/**
+ * `patchwork connect ...` dispatcher.
+ *
+ * `deps` is fully injectable for tests. In production, callers pass
+ * `findBridgeLock` (from src/commands/task.ts's lock helper) plus any
+ * overrides; everything else defaults to real process I/O.
+ */
+export async function runConnect(
+  argv: string[],
+  deps: Partial<ConnectDeps> & Pick<ConnectDeps, "findBridgeLock">,
+): Promise<void> {
+  const resolved: ConnectDeps = { ...DEFAULT_DEPS, ...deps };
+  const args = parseArgs(argv);
+
+  if (args.help) {
+    printHelp(resolved);
+    return;
+  }
+
+  const verb = args.positional[0];
+
+  // Bare `connect` or `connect list` → list.
+  if (verb === undefined || verb === "list") {
+    await runList(resolved, args);
+    return;
+  }
+
+  if (verb === "test") {
+    await runTest(resolved, args.positional[1], args);
+    return;
+  }
+
+  if (verb === "disconnect") {
+    await runDisconnect(resolved, args.positional[1], args);
+    return;
+  }
+
+  // Otherwise `verb` is a vendor id: OAuth (auth) or PAT (connect).
+  const descriptor = resolveVendor(resolved, verb);
+  if (!descriptor) return;
+
+  if (descriptor.authKind === "oauth" && descriptor.supports.auth) {
+    await runOauth(resolved, descriptor, args);
+    return;
+  }
+  if (descriptor.supports.connect) {
+    await runPatConnect(resolved, descriptor, args);
+    return;
+  }
+  // OAuth-capable PAT connectors (auth:true but pat): prefer the token path.
+  if (descriptor.supports.auth) {
+    await runOauth(resolved, descriptor, args);
+    return;
+  }
+
+  resolved.writeErr(
+    `Connector "${descriptor.id}" does not support an interactive connect flow.\n`,
+  );
+  resolved.exit(1);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -179,6 +179,7 @@ const KNOWN_SUBCOMMANDS = [
   "status",
   "shim",
   "recipe",
+  "connect",
   "traces",
   "suggest",
   "dashboard",
@@ -257,6 +258,11 @@ if (
       `  recipe run <name> [--vars k=v]            Run a recipe by name\n` +
       `  recipe install <source>                   Install from a path or GitHub source\n` +
       `  recipe --help                             Full recipe subcommand index\n\n` +
+      `Connectors\n` +
+      `  connect [list]                            List connectors + connection status\n` +
+      `  connect <vendor>                          OAuth: print authorize URL / PAT: connect\n` +
+      `  connect test <vendor>                     Health-probe a connector\n` +
+      `  connect disconnect <vendor>               Revoke a connector\n\n` +
       `Operate\n` +
       `  start [--port N] [--workspace <dir>]      Start a single bridge (no tmux)\n` +
       `  status                                    One-line bridge status (port, uptime)\n` +
@@ -2339,6 +2345,21 @@ if (process.argv[2] === "halts") {
       );
       process.exit(1);
     }
+  })();
+}
+
+// `patchwork connect` — connector front-door. Thin CLI→HTTP shim over the
+// bridge's `/connections/*` routes (list / OAuth auth / PAT connect / test /
+// disconnect). This is the command the 23 connector "Run: patchwork connect
+// <vendor>" error messages point at. Lock discovery reuses the same
+// isBridge:true + live-PID selector as `recipe run`, `quick-task`, etc.
+if (process.argv[2] === "connect") {
+  (async () => {
+    const { runConnect } = await import("./commands/connect.js");
+    const { findBridgeLockForTask } = await import("./commands/task.js");
+    await runConnect(process.argv.slice(3), {
+      findBridgeLock: (port?: number) => findBridgeLockForTask(port),
+    });
   })();
 }
 


### PR DESCRIPTION
## What

Adds the `patchwork connect` CLI — the connector auth front-door. **23 existing connector error messages already tell users to run `patchwork connect <vendor>`** (e.g. `caldiy.ts`: "Run: patchwork connect caldiy"), but the command didn't exist. This is a thin CLI→HTTP shim over the **already-built** bridge connector routes — no new bridge or connector logic.

First piece of the **connector-enablement campaign** (the top-ROI theme from the discovery review; the connector-step parity ratchet in #851 quantified that only 19 of 46 connectors are usable in a recipe — this makes the *auth* half a one-command CLI flow).

## Verbs

- **`connect` / `connect list [--json]`** — list every connector with auth status (joins `GET /connections` onto the `CONNECTORS` registry → label, authKind, status). Sorted connected → needs-reauth → disconnected.
- **`connect <oauth-vendor> [--url-only]`** — `GET /connections/<id>/auth` with `redirect:"manual"`, captures the `302 Location` (the provider authorize URL), and prints it to open in a browser. `--url-only` for headless/CI.
- **`connect <pat-vendor> [--token X]`** — `POST /connections/<id>/connect {token}`; without `--token`, prints honest instructions (single-token connectors connect via `--token`; multi-field PAT connectors — Jira/Confluence/Zendesk/Datadog — are directed to the dashboard).
- **`connect test <vendor>`** — `POST /connections/<id>/test`.
- **`connect disconnect <vendor>`** — `DELETE /connections/<id>`.
- Common: `--port` override, `--json`, `AbortSignal.timeout(10s)`, "no running bridge — start it with: patchwork start" hint, unknown-vendor "did you mean".

Implementation is fully dependency-injected (`findBridgeLock`, `fetchFn`, `connectors`) for testability; wired into `KNOWN_SUBCOMMANDS` + dispatch via the existing `findBridgeLockForTask` (isBridge + live-PID) selector.

## Verification

- 15 new tests (`src/commands/__tests__/connect.test.ts`): list join + `--json`; OAuth 302-`location` capture + `--url-only` + no-location error; PAT `--token` POST + no-token instructions; test/disconnect; unknown vendor; no-bridge hint; network fail-soft.
- `tsc` (main) + strict `tests.core`: clean. LSP-tool-registry audit + fixture-hygiene gate: clean. Full bridge suite green (one unrelated `fs.watch` timing flake, passes in isolation).

## Notes

- No MCP tools added (CLI-only) → no tool-count/schema-snapshot impact.
- Touches the same `KNOWN_SUBCOMMANDS` array as #851 — trivial merge-order conflict at worst.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
