### PR TITLE
ci: fix recurring Docker-smoke flake (drop dockerfile syntax frontend + retry)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -342,7 +342,18 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Build image
-        run: docker build --build-arg GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} -t patchwork-smoke .
+        # Retry to ride out transient Docker Hub registry timeouts on base-image
+        # pulls. The `# syntax=` directive was removed from the Dockerfile so
+        # BuildKit no longer fetches the docker/dockerfile frontend at build start
+        # (the recurring `registry-1.docker.io ... i/o timeout` flake).
+        run: |
+          for attempt in 1 2 3; do
+            docker build --build-arg GITHUB_TOKEN="${{ secrets.GITHUB_TOKEN }}" -t patchwork-smoke . && exit 0
+            echo "::warning::docker build attempt $attempt failed (likely a transient Docker Hub timeout); retrying in 15s"
+            sleep 15
+          done
+          echo "docker build failed after 3 attempts"
+          exit 1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Start container

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,3 @@
-# syntax=docker/dockerfile:1
 FROM node:22-alpine AS builder
 ARG GITHUB_TOKEN
 WORKDIR /app


### PR DESCRIPTION
## Problem

The **Docker smoke test** job has flaked ~5× across recent PRs with:
```
ERROR: failed to solve: failed to resolve source metadata for docker.io/docker/dockerfile:1:
  ... Head "https://registry-1.docker.io/v2/docker/dockerfile/manifests/1": dial tcp ...:443: i/o timeout
```

**Root cause:** the `# syntax=docker/dockerfile:1` directive makes BuildKit fetch that frontend image from Docker Hub at build start, and the runner's Docker Hub connection intermittently times out. It's non-required (PRs stay mergeable) but wastes a re-run every time.

## Fix

1. **Drop the `# syntax=` directive** from the Dockerfile. It uses only standard instructions (multi-stage `COPY --from`, no `RUN --mount`/heredocs/frontend-specific syntax), so BuildKit's **built-in frontend** handles it with **no Docker Hub fetch**.
2. **Wrap the build step in a 3-attempt retry** to ride out any residual transient Docker Hub timeout on base-image (`FROM node:22-alpine`) pulls.

## Validation

Built locally with the directive removed: BuildKit used the built-in frontend (**zero `docker/dockerfile:1` fetch, no registry timeout**) and proceeded cleanly through `FROM`/`COPY` to `npm ci`. (`npm ci` then needs the real `GITHUB_TOKEN` for the `@vscode/ripgrep` prebuilt-binary download, which CI passes via `secrets.GITHUB_TOKEN` — a dummy token rate-limited locally, unrelated to this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)