### PR TITLE
feat(recipes): judge→refine loop — opt-in self-correction (the AI-native moat)

### DIFF
--- a/src/recipes/__tests__/recipeValidationConsistency.test.ts
+++ b/src/recipes/__tests__/recipeValidationConsistency.test.ts
@@ -152,3 +152,99 @@ describe("unknown awaits-target validation", () => {
     expect(errors.some((e) => e.message.includes("gather2"))).toBe(true);
   });
 });
+
+describe("judge refine-loop field validation (max_revisions / on_exhausted)", () => {
+  it("accepts max_revisions on a proper judge step (kind:judge + reviews)", () => {
+    const result = validateRecipeDefinition({
+      ...base,
+      steps: [
+        { id: "draft", agent: { prompt: "make", into: "draft" } },
+        {
+          id: "review",
+          agent: {
+            prompt: "review",
+            kind: "judge",
+            reviews: "draft",
+            max_revisions: 2,
+            on_exhausted: "proceed",
+          },
+        },
+      ],
+    });
+    const errors = result.issues.filter(
+      (i) =>
+        i.level === "error" &&
+        /max_revisions|on_exhausted|refine/i.test(i.message),
+    );
+    expect(errors).toHaveLength(0);
+  });
+
+  it("rejects max_revisions on a non-judge agent step", () => {
+    const result = validateRecipeDefinition({
+      ...base,
+      steps: [{ id: "s1", agent: { prompt: "hi", max_revisions: 2 } }],
+    });
+    const errors = result.issues.filter(
+      (i) => i.level === "error" && /max_revisions/i.test(i.message),
+    );
+    expect(errors.length).toBeGreaterThan(0);
+    expect(result.valid).toBe(false);
+  });
+
+  it("rejects max_revisions on a judge step without reviews", () => {
+    const result = validateRecipeDefinition({
+      ...base,
+      steps: [
+        { id: "s1", agent: { prompt: "hi", kind: "judge", max_revisions: 1 } },
+      ],
+    });
+    const errors = result.issues.filter(
+      (i) => i.level === "error" && /max_revisions|reviews/i.test(i.message),
+    );
+    expect(errors.length).toBeGreaterThan(0);
+  });
+
+  it("rejects a negative / non-integer max_revisions", () => {
+    for (const bad of [-1, 1.5, "two"]) {
+      const result = validateRecipeDefinition({
+        ...base,
+        steps: [
+          {
+            id: "s1",
+            agent: {
+              prompt: "hi",
+              kind: "judge",
+              reviews: "draft",
+              max_revisions: bad,
+            },
+          },
+        ],
+      });
+      const errors = result.issues.filter(
+        (i) => i.level === "error" && /max_revisions/i.test(i.message),
+      );
+      expect(errors.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("rejects an out-of-enum on_exhausted", () => {
+    const result = validateRecipeDefinition({
+      ...base,
+      steps: [
+        {
+          id: "s1",
+          agent: {
+            prompt: "hi",
+            kind: "judge",
+            reviews: "draft",
+            on_exhausted: "explode",
+          },
+        },
+      ],
+    });
+    const errors = result.issues.filter(
+      (i) => i.level === "error" && /on_exhausted/i.test(i.message),
+    );
+    expect(errors.length).toBeGreaterThan(0);
+  });
+});

--- a/src/recipes/__tests__/yamlRunner.test.ts
+++ b/src/recipes/__tests__/yamlRunner.test.ts
@@ -3057,6 +3057,259 @@ describe("agent kind: 'judge' — augment-only invariant (PR3a)", () => {
   });
 });
 
+// ── judge → refine loop (opt-in; departs augment-only when fields present) ────
+
+describe("agent kind: 'judge' — refine loop (opt-in)", () => {
+  it("(a) max_revisions absent → augment-only unchanged: request_changes stays ok, no re-run", async () => {
+    const recipe = makeRecipe({
+      steps: [
+        {
+          agent: {
+            prompt: "Make a draft.",
+            model: "claude-haiku-4-5-20251001",
+            into: "draft",
+          },
+        },
+        {
+          agent: {
+            prompt: "Review the draft.",
+            model: "claude-haiku-4-5-20251001",
+            into: "review",
+            kind: "judge",
+            reviews: "draft",
+            // no max_revisions → augment-only
+          },
+        },
+      ],
+    });
+    let calls = 0;
+    const result = await runYamlRecipe(recipe, {
+      ...noop(),
+      claudeFn: async () => {
+        calls++;
+        if (calls === 1) return "draft v1";
+        return `Bad.\n{"verdict": "request_changes", "reasons": ["nope"], "fixList": ["fix it"]}`;
+      },
+    });
+    // Exactly two calls: draft + single judge. No revision loop.
+    expect(calls).toBe(2);
+    const judge = result.stepResults[1]!;
+    expect(judge.status).toBe("ok");
+    expect(judge.judgeVerdict?.verdict).toBe("request_changes");
+    expect(judge.revisions).toBeUndefined();
+    expect(result.errorMessage).toBeUndefined();
+  });
+
+  it("(b) request_changes then approve after 1 revision → reviewed step re-run with fixList, ctx updated, final verdict approve, revisions:1", async () => {
+    const recipe = makeRecipe({
+      steps: [
+        {
+          agent: {
+            prompt: "Write the draft.",
+            model: "claude-haiku-4-5-20251001",
+            into: "draft",
+          },
+        },
+        {
+          agent: {
+            prompt: "Review the draft.",
+            model: "claude-haiku-4-5-20251001",
+            into: "review",
+            kind: "judge",
+            reviews: "draft",
+            max_revisions: 2,
+          },
+        },
+        {
+          agent: {
+            prompt: "Use the final draft: {{draft}}",
+            model: "claude-haiku-4-5-20251001",
+            into: "downstream",
+          },
+        },
+      ],
+    });
+    const prompts: string[] = [];
+    let calls = 0;
+    const result = await runYamlRecipe(recipe, {
+      ...noop(),
+      claudeFn: async (prompt) => {
+        calls++;
+        prompts.push(prompt);
+        // 1: draft, 2: judge request_changes, 3: revised draft, 4: judge approve, 5: downstream
+        if (calls === 1) return "draft v1";
+        if (calls === 2)
+          return `Bad.\n{"verdict": "request_changes", "reasons": ["too short"], "fixList": ["add a closing line"]}`;
+        if (calls === 3) return "draft v2 improved";
+        if (calls === 4)
+          return `Good.\n{"verdict": "approve", "reasons": ["fixed"]}`;
+        return "downstream used draft v2 improved";
+      },
+    });
+    expect(calls).toBe(5);
+    // The revision (call 3) prompt must include the prior draft + the fixList.
+    const revisionPrompt = prompts[2]!;
+    expect(revisionPrompt).toContain("draft v1");
+    expect(revisionPrompt).toContain("add a closing line");
+    // ctx[reviews target = "draft"] updated to revised draft for downstream.
+    expect(result.context.draft).toBe("draft v2 improved");
+    // downstream saw the revised draft.
+    const downstreamPrompt = prompts[4]!;
+    expect(downstreamPrompt).toContain("draft v2 improved");
+    // Final judge stepResult reflects the LAST (approve) verdict + revisions:1.
+    const judge = result.stepResults[1]!;
+    expect(judge.status).toBe("ok");
+    expect(judge.judgeVerdict?.verdict).toBe("approve");
+    expect(judge.revisions).toBe(1);
+    expect(result.errorMessage).toBeUndefined();
+  });
+
+  it("(c) all-request_changes for max_revisions=2 with on_exhausted:'halt' → run halts (status error, haltCategory judge_revisions_exhausted)", async () => {
+    const recipe = makeRecipe({
+      steps: [
+        {
+          agent: {
+            prompt: "Write the draft.",
+            model: "claude-haiku-4-5-20251001",
+            into: "draft",
+          },
+        },
+        {
+          agent: {
+            prompt: "Review the draft.",
+            model: "claude-haiku-4-5-20251001",
+            into: "review",
+            kind: "judge",
+            reviews: "draft",
+            max_revisions: 2,
+            on_exhausted: "halt",
+          },
+        },
+        {
+          agent: {
+            prompt: "Should never run.",
+            model: "claude-haiku-4-5-20251001",
+            into: "downstream",
+          },
+        },
+      ],
+    });
+    let calls = 0;
+    const requestChanges = `Nope.\n{"verdict": "request_changes", "reasons": ["still bad"], "fixList": ["try again"]}`;
+    const result = await runYamlRecipe(recipe, {
+      ...noop(),
+      claudeFn: async () => {
+        calls++;
+        if (calls === 1) return "draft v1";
+        // odd calls after first = revised drafts, even = judge request_changes
+        if (calls % 2 === 0) return requestChanges;
+        return `draft revision ${calls}`;
+      },
+    });
+    const judge = result.stepResults[1]!;
+    expect(judge.status).toBe("error");
+    expect(judge.haltCategory).toBe("judge_revisions_exhausted");
+    expect(judge.judgeVerdict?.verdict).toBe("request_changes");
+    expect(judge.revisions).toBe(2);
+    expect(result.errorMessage).toBeDefined();
+    expect(result.errorMessage).toContain("did not approve");
+    // downstream must NOT have run (run halted).
+    expect(
+      result.stepResults.find((s) => s.id === "downstream"),
+    ).toBeUndefined();
+  });
+
+  it("(d) all-request_changes with on_exhausted:'proceed' → status ok, final verdict request_changes, downstream continues", async () => {
+    const recipe = makeRecipe({
+      steps: [
+        {
+          agent: {
+            prompt: "Write the draft.",
+            model: "claude-haiku-4-5-20251001",
+            into: "draft",
+          },
+        },
+        {
+          agent: {
+            prompt: "Review the draft.",
+            model: "claude-haiku-4-5-20251001",
+            into: "review",
+            kind: "judge",
+            reviews: "draft",
+            max_revisions: 2,
+            on_exhausted: "proceed",
+          },
+        },
+        {
+          agent: {
+            prompt: "Downstream uses: {{draft}}",
+            model: "claude-haiku-4-5-20251001",
+            into: "downstream",
+          },
+        },
+      ],
+    });
+    let calls = 0;
+    const requestChanges = `Nope.\n{"verdict": "request_changes", "reasons": ["still bad"], "fixList": ["try again"]}`;
+    const result = await runYamlRecipe(recipe, {
+      ...noop(),
+      claudeFn: async () => {
+        calls++;
+        if (calls === 1) return "draft v1";
+        if (calls % 2 === 0) return requestChanges;
+        return `draft revision ${calls}`;
+      },
+    });
+    const judge = result.stepResults[1]!;
+    expect(judge.status).toBe("ok");
+    expect(judge.judgeVerdict?.verdict).toBe("request_changes");
+    expect(judge.revisions).toBe(2);
+    expect(result.errorMessage).toBeUndefined();
+    // downstream DID run with the last revised draft.
+    const downstream = result.stepResults.find((s) => s.id === "downstream");
+    expect(downstream?.status).toBe("ok");
+  });
+
+  it("does not loop when the reviewed key does not map to an agent step (graceful skip)", async () => {
+    const recipe = makeRecipe({
+      steps: [
+        {
+          // tool step writes into ctx; judge "reviews" it — but it's not an agent.
+          tool: "file.read",
+          path: path.join(TMP, "seed.txt"),
+          optional: true,
+          into: "seed",
+        },
+        {
+          agent: {
+            prompt: "Review the seed.",
+            model: "claude-haiku-4-5-20251001",
+            into: "review",
+            kind: "judge",
+            reviews: "seed",
+            max_revisions: 2,
+          },
+        },
+      ],
+    });
+    let calls = 0;
+    const result = await runYamlRecipe(recipe, {
+      ...noop(),
+      readFile: () => "seed contents",
+      claudeFn: async () => {
+        calls++;
+        return `Bad.\n{"verdict": "request_changes", "reasons": ["x"], "fixList": ["y"]}`;
+      },
+    });
+    // Only the single judge call — no agent step to re-run, so no loop.
+    expect(calls).toBe(1);
+    const judge = result.stepResults[1]!;
+    expect(judge.status).toBe("ok");
+    expect(judge.judgeVerdict?.verdict).toBe("request_changes");
+    expect(judge.revisions).toBeUndefined();
+  });
+});
+
 // ── PR2b — recipe.budget enforcement ─────────────────────────────────────────
 
 describe("recipe.budget — tokensMax enforcement (PR2b)", () => {

--- a/src/recipes/haltCategory.ts
+++ b/src/recipes/haltCategory.ts
@@ -27,6 +27,11 @@ export type HaltCategory =
   /** Per-step wall-clock `timeout_ms` exceeded (sandbox-alternative slice). */
   | "step_timeout"
   /**
+   * Opt-in judge→refine loop exhausted its `max_revisions` budget and the
+   * judge still returned `request_changes` with `on_exhausted: "halt"`.
+   */
+  | "judge_revisions_exhausted"
+  /**
    * Connector returned 401/403 — token expired or scopes insufficient.
    * Actionable: user should reconnect from /connections.
    */
@@ -66,6 +71,7 @@ export const HALT_CATEGORY_LABELS: Record<HaltCategory, string> = {
   budget_exceeded: "budget exceeded",
   expect_failed: "expect failed",
   step_timeout: "step timeout",
+  judge_revisions_exhausted: "judge revisions exhausted",
   auth_failure: "auth failure",
   rate_limited: "rate limited",
   network_error: "network error",
@@ -89,6 +95,8 @@ export const HALT_CATEGORY_HINTS: Record<HaltCategory, string> = {
   budget_exceeded: "raise tokensMax or shrink prompts",
   expect_failed: "inspect assertion vs actual output",
   step_timeout: "bump timeout_ms or speed up step",
+  judge_revisions_exhausted:
+    "raise max_revisions, refine the prompt, or set on_exhausted: proceed",
   auth_failure: "reconnect from /connections",
   rate_limited: "back off cron cadence or wait",
   network_error: "check connectivity to upstream",
@@ -111,6 +119,10 @@ export function categoriseHaltReason(reason: string | undefined): HaltCategory {
   if (/budget[_ ]?exceeded|exceeded its token budget/i.test(reason))
     return "budget_exceeded";
   if (/^expect_failed/i.test(reason)) return "expect_failed";
+  // Opt-in judge→refine loop exhaustion (`judge "x" did not approve after N
+  // revisions`). Must precede the generic `Agent step ... threw` matcher.
+  if (/did not approve after \d+ revision/i.test(reason))
+    return "judge_revisions_exhausted";
   // Must precede the `^Tool ... threw` matcher: timeouts surface wrapped
   // inside the tool-threw envelope (`Tool "x" in step "y" threw: step_timeout: ...`).
   if (/step_timeout/i.test(reason)) return "step_timeout";

--- a/src/recipes/judgeVerdict.ts
+++ b/src/recipes/judgeVerdict.ts
@@ -20,6 +20,16 @@
  * `status: "ok"` with a stashed verdict, never `status: "error"`.
  * That separation is what prevents the judge step from quietly
  * becoming a gate.
+ *
+ * ⚠️ OPT-IN DEPARTURE (judge→refine loop) — when a judge step sets the
+ * opt-in `agent.max_revisions > 0` (with `kind: "judge"` + `reviews`),
+ * the runner DELIBERATELY departs the augment-only invariant: a
+ * `request_changes` verdict drives a bounded revise→re-judge loop and
+ * MAY end with `status: "error"` (`on_exhausted: "halt"`). This is the
+ * single sanctioned exception and is reachable ONLY through those opt-in
+ * fields. When they're absent, the augment-only contract above holds
+ * byte-for-byte. The loop itself lives in `runJudgeRefineLoop` inside
+ * yamlRunner.ts; this parser is unchanged and still never gates.
  */
 
 export type JudgeVerdictKind = "approve" | "request_changes" | "unparseable";

--- a/src/recipes/schemaGenerator.ts
+++ b/src/recipes/schemaGenerator.ts
@@ -295,6 +295,23 @@ function generateRecipeSchema(
               description:
                 "When set to 'judge', the agent step emits a structured verdictReason and stores the verdict in the run log.",
             },
+            reviews: {
+              type: "string",
+              description:
+                "Step output key the judge reviews (its `into`, default 'agent_output'). Required for the judge→refine loop.",
+            },
+            max_revisions: {
+              type: "integer",
+              minimum: 0,
+              description:
+                "OPT-IN judge→refine loop. Max revise→re-judge cycles when the verdict is 'request_changes' (0/absent = augment-only, no loop). Requires kind:judge + reviews.",
+            },
+            on_exhausted: {
+              type: "string",
+              enum: ["halt", "proceed"],
+              description:
+                "When the revision budget is exhausted and the judge still requests changes: 'halt' (default) fails the run; 'proceed' continues with the last draft.",
+            },
           },
         },
       },
@@ -546,6 +563,23 @@ function generateRecipeSchema(
                       enum: ["judge"],
                       description:
                         "When set to 'judge', the agent step emits a structured verdictReason and stores the verdict in the run log.",
+                    },
+                    reviews: {
+                      type: "string",
+                      description:
+                        "Step output key the judge reviews (its `into`, default 'agent_output'). Required for the judge→refine loop.",
+                    },
+                    max_revisions: {
+                      type: "integer",
+                      minimum: 0,
+                      description:
+                        "OPT-IN judge→refine loop. Max revise→re-judge cycles when the verdict is 'request_changes' (0/absent = augment-only, no loop). Requires kind:judge + reviews.",
+                    },
+                    on_exhausted: {
+                      type: "string",
+                      enum: ["halt", "proceed"],
+                      description:
+                        "When the revision budget is exhausted and the judge still requests changes: 'halt' (default) fails the run; 'proceed' continues with the last draft.",
                     },
                   },
                 },

--- a/src/recipes/validation.ts
+++ b/src/recipes/validation.ts
@@ -160,6 +160,58 @@ export function validateRecipeDefinition(recipe: unknown): LintResult {
               message: `Step ${i + 1}: Agent step missing 'prompt'`,
             });
           }
+
+          // OPT-IN judge→refine loop fields. Both `max_revisions` and
+          // `on_exhausted` are meaningless without a `kind: "judge"` step
+          // that points at an upstream step via `reviews:` — a refine loop
+          // needs an agent output to re-run. Flag misuse as an error so
+          // `recipe lint` / `doctor` catch it before any run.
+          const hasRefineField =
+            agent.max_revisions !== undefined ||
+            agent.on_exhausted !== undefined;
+          if (hasRefineField) {
+            if (agent.kind !== "judge") {
+              issues.push({
+                level: "error",
+                message: `Step ${i + 1}: 'max_revisions'/'on_exhausted' require 'kind: judge' (the judge→refine loop only applies to judge steps)`,
+                code: "refine-requires-judge",
+                path: `steps.${i}.agent`,
+              });
+            } else if (
+              typeof agent.reviews !== "string" ||
+              agent.reviews.length === 0
+            ) {
+              issues.push({
+                level: "error",
+                message: `Step ${i + 1}: 'max_revisions'/'on_exhausted' require 'reviews' to be set (the loop re-runs the reviewed step)`,
+                code: "refine-requires-reviews",
+                path: `steps.${i}.agent`,
+              });
+            }
+          }
+          if (agent.max_revisions !== undefined) {
+            const mr = agent.max_revisions;
+            if (typeof mr !== "number" || !Number.isInteger(mr) || mr < 0) {
+              issues.push({
+                level: "error",
+                message: `Step ${i + 1}: 'max_revisions' must be a non-negative integer (got ${JSON.stringify(mr)})`,
+                code: "refine-max-revisions-invalid",
+                path: `steps.${i}.agent.max_revisions`,
+              });
+            }
+          }
+          if (
+            agent.on_exhausted !== undefined &&
+            agent.on_exhausted !== "halt" &&
+            agent.on_exhausted !== "proceed"
+          ) {
+            issues.push({
+              level: "error",
+              message: `Step ${i + 1}: invalid 'on_exhausted' '${String(agent.on_exhausted)}' — must be 'halt' or 'proceed'`,
+              code: "refine-on-exhausted-enum",
+              path: `steps.${i}.agent.on_exhausted`,
+            });
+          }
         }
 
         // Unconditional risk-enum check. `risk` was previously never

--- a/src/recipes/yamlRunner.ts
+++ b/src/recipes/yamlRunner.ts
@@ -128,7 +128,8 @@ export interface YamlStep {
      * attached to the step result but **never gates the run** — judge
      * steps always finish with `status: "ok"` regardless of the
      * verdict. This is the augment-only invariant: judges add signal,
-     * they don't block.
+     * they don't block. (The sole sanctioned exception is the OPT-IN
+     * judge→refine loop below — see `max_revisions`.)
      *
      * Pair with `reviews: <stepId>` to point the judge at the output
      * of a prior step; the runner injects that step's `output` into
@@ -137,6 +138,29 @@ export interface YamlStep {
     kind?: "agent" | "judge";
     /** Step id whose output the judge should review. Required when `kind: "judge"`. */
     reviews?: string;
+    /**
+     * OPT-IN judge→refine loop (only meaningful for `kind: "judge"` + `reviews`).
+     *
+     * ⚠️ INVARIANT DEPARTURE — when set (`> 0`), the judge step *drives* a
+     * bounded revision loop and MAY gate the run on exhaustion. This
+     * deliberately departs the augment-only invariant documented in
+     * judgeVerdict.ts, but ONLY when these fields are present. When
+     * `max_revisions` is absent or 0 the behavior is byte-identical to the
+     * augment-only path (parse + stash verdict, `status: "ok"`, no re-run).
+     *
+     * On a `request_changes` verdict the runner re-runs the reviewed agent
+     * step with the prior draft + the verdict's `fixList` injected, then
+     * re-judges, up to `max_revisions` cycles or until `approve`.
+     */
+    max_revisions?: number;
+    /**
+     * What to do if the judge still returns `request_changes` after the
+     * revision budget is exhausted. `"halt"` (default) fails the run
+     * (respecting fail-open like other agent failures); `"proceed"`
+     * continues with the last draft and records the unapproved verdict.
+     * Only meaningful alongside `max_revisions > 0`.
+     */
+    on_exhausted?: "halt" | "proceed";
   };
   into?: string;
   optional?: boolean;
@@ -545,6 +569,14 @@ export type StepResult = {
    * and `bridge_recipe_judgments` metrics (forthcoming PR3b/c).
    */
   judgeVerdict?: import("./judgeVerdict.js").JudgeVerdict;
+  /**
+   * OPT-IN judge→refine loop — number of revise→re-judge cycles the judge
+   * step drove. Present only when `agent.max_revisions > 0` triggered at
+   * least the loop entry (i.e. the first verdict was `request_changes` and
+   * a reviewable agent step was found). The attached `judgeVerdict` reflects
+   * the FINAL verdict after the loop, not the first.
+   */
+  revisions?: number;
   /**
    * Structured error code propagated from a thrown step error. Currently
    * populated for `recipe_path_jail_escape` (G-security A-PR1) so tests
@@ -977,6 +1009,174 @@ export async function runYamlRecipe(
     });
   };
 
+  // ── OPT-IN judge → refine loop (helper closure) ──────────────────────────
+  //
+  // ⚠️ INVARIANT DEPARTURE — this drives a bounded revise→re-judge loop and
+  // MAY gate the run on exhaustion. It departs the augment-only invariant in
+  // judgeVerdict.ts, but is reachable ONLY when the judge step opts in via
+  // `agent.max_revisions > 0`. The augment-only PR3a path is untouched.
+  //
+  // `runAgentText` mirrors the main agent path's text processing exactly
+  // (strip leading narration, then JSON-fence parse + sanitize, else use the
+  // raw string) so a revised draft commits to ctx the same way a first-pass
+  // agent step would. It returns `{ value, ok }`; `ok: false` signals a
+  // failed / silent-fail / empty agent response — the caller stops the loop
+  // and treats it as exhausted (we don't re-judge a non-result).
+  const runAgentText = async (
+    prompt: string,
+    driver: string | undefined,
+    model: string | undefined,
+    mcpAccess: boolean | undefined,
+  ): Promise<{ value: unknown; ok: boolean }> => {
+    const agentReturn = await _executeAgent(
+      {
+        prompt,
+        driver: driver === "api" ? "anthropic" : driver,
+        model,
+        ...(mcpAccess !== undefined && { mcpAccess }),
+      },
+      buildAgentExecutorDeps(stepDeps, deps),
+    );
+    runBudget.reconcile(
+      driver === "api" ? "anthropic" : (driver ?? "auto"),
+      agentReturn.usage,
+    );
+    const text = agentReturn.text;
+    // Same failure detection as the main agent branch: explicit failure
+    // marker or silent-fail patterns ⇒ not a usable result.
+    if (text.startsWith("[agent step failed:") || detectSilentFail(text)) {
+      return { value: text, ok: false };
+    }
+    const stripped = stripLeadingNarration(text);
+    if (!stripped.trim()) {
+      return { value: stripped, ok: false };
+    }
+    try {
+      const jsonMatch = /```(?:json)?\s*([\s\S]*?)```/.exec(stripped) ?? [
+        null,
+        stripped,
+      ];
+      const parsed = sanitizeParsed(JSON.parse((jsonMatch[1] ?? "").trim()));
+      return { value: parsed, ok: true };
+    } catch {
+      return { value: stripped, ok: true };
+    }
+  };
+
+  const runJudgeRefineLoop = async (params: {
+    agentCfg: NonNullable<YamlStep["agent"]>;
+    reviewsKey: string;
+    maxRevisions: number;
+    judgeStepId: string;
+    firstVerdict: import("./judgeVerdict.js").JudgeVerdict;
+    judgeStepResult: StepResult;
+    failOpenAgent: boolean;
+  }): Promise<{ runError?: string; haltAfterFailure: boolean }> => {
+    const {
+      agentCfg,
+      reviewsKey,
+      maxRevisions,
+      judgeStepId,
+      firstVerdict,
+      judgeStepResult,
+      failOpenAgent,
+    } = params;
+
+    // Find the agent step whose output the judge reviews. A judge that
+    // reviews a tool step or a seed var (no agent to re-run) cannot be
+    // refined — skip the loop gracefully, leaving the augment-only verdict
+    // already stashed on the judge step result untouched.
+    const reviewedStep = recipe.steps.find(
+      (s) => s.agent && (s.agent.into ?? "agent_output") === reviewsKey,
+    );
+    if (!reviewedStep?.agent) {
+      return { haltAfterFailure: false };
+    }
+    const reviewedAgent = reviewedStep.agent;
+
+    let currentVerdict = firstVerdict;
+    let revisions = 0;
+    while (
+      revisions < maxRevisions &&
+      currentVerdict.verdict === "request_changes"
+    ) {
+      // Budget gate: never exceed the run's token budget. If admission is
+      // refused, stop early (treat as exhausted) — the budget halt is
+      // surfaced by the next top-of-loop admission check for later steps.
+      const admission = runBudget.admit();
+      if (!admission.admitted) {
+        break;
+      }
+
+      // REVISE: re-run the reviewed agent with the prior draft + fixList.
+      const priorDraft = ctx[reviewsKey];
+      const fixList = currentVerdict.fixList ?? [];
+      const revisionBlock =
+        `\n\n<revision-request>\n` +
+        `A reviewer requested changes to your previous draft. Address every` +
+        ` item, then return the full revised draft only.\n\n` +
+        `<previous-draft>\n${typeof priorDraft === "string" ? priorDraft : JSON.stringify(priorDraft, null, 2)}\n</previous-draft>\n\n` +
+        `<fix-list>\n${fixList.length > 0 ? fixList.map((f) => `- ${f}`).join("\n") : "- (no explicit fix list provided)"}\n</fix-list>\n` +
+        `</revision-request>`;
+      const revisionPrompt = render(reviewedAgent.prompt, ctx) + revisionBlock;
+      const revised = await runAgentText(
+        revisionPrompt,
+        reviewedAgent.driver,
+        reviewedAgent.model,
+        reviewedAgent.mcpAccess,
+      );
+      if (!revised.ok) {
+        // A failed / empty revision can't be re-judged — stop and treat the
+        // loop as exhausted with the last good verdict still in place.
+        break;
+      }
+      // Commit the revised draft so downstream steps (and the re-judge) see
+      // the improved value under the reviewed step's key.
+      ctx[reviewsKey] = revised.value as RunContext[string];
+
+      // RE-JUDGE: rebuild the judge prompt against the revised artefact.
+      const reJudgePrompt =
+        render(agentCfg.prompt, ctx) +
+        buildJudgeArtefactBlock(ctx[reviewsKey]) +
+        JUDGE_PROMPT_SUFFIX;
+      const judged = await runAgentText(
+        reJudgePrompt,
+        agentCfg.driver,
+        agentCfg.model,
+        agentCfg.mcpAccess,
+      );
+      const judgedText =
+        typeof judged.value === "string"
+          ? judged.value
+          : JSON.stringify(judged.value);
+      currentVerdict = parseJudgeVerdict(stripLeadingNarration(judgedText));
+      revisions++;
+    }
+
+    // Record the FINAL verdict + the revision count on the judge step result.
+    judgeStepResult.judgeVerdict = currentVerdict;
+    judgeStepResult.revisions = revisions;
+
+    // EXHAUSTION: still requesting changes after the loop.
+    if (currentVerdict.verdict === "request_changes") {
+      const onExhausted = agentCfg.on_exhausted ?? "halt";
+      if (onExhausted === "halt") {
+        const reason = `judge "${judgeStepId}" did not approve after ${maxRevisions} revisions`;
+        judgeStepResult.status = "error";
+        judgeStepResult.error = reason;
+        judgeStepResult.haltReason = reason;
+        judgeStepResult.haltCategory = "judge_revisions_exhausted";
+        return {
+          runError: reason,
+          // Respect fail-open like other agent failures.
+          haltAfterFailure: !failOpenAgent,
+        };
+      }
+      // "proceed": leave status ok, keep the recorded (unapproved) verdict.
+    }
+    return { haltAfterFailure: false };
+  };
+
   // The step loop is wrapped so an uncaught throw from any unguarded
   // call site (a `when`/prompt render on a malformed step, a path-jail
   // re-check, etc.) cannot escape `runYamlRecipe` and strand the
@@ -1187,13 +1387,47 @@ export async function runYamlRecipe(
               const judgeVerdict = isJudge
                 ? parseJudgeVerdict(stripped)
                 : undefined;
-              stepResults.push({
+              const judgeStepResult: StepResult = {
                 id: stepId,
                 tool: "agent",
                 status: "ok",
                 ...(judgeVerdict !== undefined && { judgeVerdict }),
                 durationMs: Date.now() - stepStart,
-              });
+              };
+              stepResults.push(judgeStepResult);
+
+              // ── OPT-IN judge → refine loop ───────────────────────────────
+              // ⚠️ INVARIANT DEPARTURE: when the judge step opts in via
+              // `max_revisions > 0`, a `request_changes` verdict now DRIVES a
+              // bounded revise→re-judge loop instead of merely stashing the
+              // verdict. This deliberately departs the augment-only invariant
+              // (see judgeVerdict.ts) — but ONLY when the opt-in fields are
+              // present. With them absent the block below is skipped entirely
+              // and behavior is byte-identical to the PR3a augment-only path.
+              if (
+                isJudge &&
+                agentCfg.reviews &&
+                typeof agentCfg.max_revisions === "number" &&
+                agentCfg.max_revisions > 0 &&
+                judgeVerdict?.verdict === "request_changes"
+              ) {
+                const loopOutcome = await runJudgeRefineLoop({
+                  agentCfg,
+                  reviewsKey: agentCfg.reviews,
+                  maxRevisions: agentCfg.max_revisions,
+                  judgeStepId: stepId,
+                  firstVerdict: judgeVerdict,
+                  judgeStepResult,
+                  failOpenAgent,
+                });
+                if (loopOutcome.runError !== undefined) {
+                  runError = runError ?? loopOutcome.runError;
+                }
+                if (loopOutcome.haltAfterFailure) {
+                  haltAfterFailure = true;
+                }
+              }
+
               // Slice 2 — per-step expect eval. Runs on the value just
               // committed to ctx[intoKey]. Halt failure flips the just-pushed
               // result to error and rolls back the ctx commit so downstream


### PR DESCRIPTION
## What

The **judge→refine loop** — the AI-native capability a non-LLM tool structurally can't have. A judge step already produces `{verdict, reasons, fixList}`, but the `fixList` was captured and **never acted on**. This makes a judge *drive* a bounded self-correction loop: on `request_changes`, re-run the reviewed step with the prior draft + fixList injected, re-judge, until `approve` or a revision budget is spent.

## 🔬 The one design decision that needs a sign-off

This **deliberately departs the documented "augment-only" invariant** (judges add signal, never gate — `judgeVerdict.ts`). It does so **only when the new opt-in field is set**:

> When `max_revisions` is absent/0, behavior is **byte-identical** to today. **Proof:** the existing `yamlRunner.test.ts` (161) + `chainedRunner.test.ts` (51) suites pass **unchanged**.

The shape choices I made (flag if you'd prefer otherwise):
- **`max_revisions: N` on the judge step** (co-locates the budget with the judge that drives the loop) — vs. a separate `revise:` block.
- **`on_exhausted: "halt" | "proceed"`, default `halt`** — if still `request_changes` after the budget: `halt` fails the run (respecting fail-open), `proceed` continues with the last draft + records the unapproved verdict.

## How it works

```yaml
- agent: { prompt: "Draft the incident postmortem...", into: draft }
- agent:
    kind: judge
    reviews: draft
    prompt: "Review the draft for completeness + accuracy."
    max_revisions: 3          # NEW — opt in to the loop
    on_exhausted: proceed     # NEW — default is halt
```

On `request_changes`: the runner re-runs the `draft` step with `<previous-draft>` + `<fix-list>` injected, commits the revised draft to `ctx.draft` (so downstream steps see the improved version), re-judges, and loops. The judge `StepResult` records the **final** verdict + a new `revisions: N` count.

## Safety / guardrails

- **Token-budget-gated**: each revise→re-judge cycle calls `runBudget.admit()`; refused → stop (no overspend). Bounded by `max_revisions`.
- **Graceful skips**: a judge reviewing a *tool* step or seed var (no agent to re-run) skips the loop. A failed/empty/silent-fail revision stops the loop (treated as exhausted with the last good verdict).
- **`runAgentText` mirrors the main agent path exactly** (narration-strip → JSON-fence parse + sanitize, else raw string) so a revised draft commits identically to a first-pass step.
- New halt category `judge_revisions_exhausted` (+ label/hint). Validation: refine fields require `kind: judge` + `reviews`; `max_revisions` non-negative int; `on_exhausted` enum.

## Verification

- 10 new tests (5 runner: augment-only-unchanged / approve-after-revision / halt-on-exhaustion / proceed-on-exhaustion / non-agent-review-skips; 5 validation).
- **Existing recipe suites pass unchanged** (the opt-in proof). Full bridge suite **7240 passing, 0 failures**. `tsc` (main + strict `tests.core`) + fixture-hygiene + LSP-audit gates clean.

## Note

The committed `schemas/recipe.v1.json` (+ CDN copy) is regenerated at release (no per-PR freshness gate; it's already several generator-changes behind). The new fields will surface in editor autocomplete on the next `schema:generate`. The runner + validation work regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
