### PR TITLE
feat(recipes): flagship incident-to-pr recipe (judge→refine + approval gate)

### DIFF
--- a/src/recipes/__tests__/incidentToPrRecipe.test.ts
+++ b/src/recipes/__tests__/incidentToPrRecipe.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Guard for the flagship `incident-to-pr` recipe.
+ *
+ * `incident-to-pr.yaml` is the end-to-end showcase: incident → autonomous
+ * root-cause → fix draft → judge→refine loop (#859) → human approval gate →
+ * pull request. Because it is the recipe we point new users at, it must stay
+ * (a) schema-valid and (b) wired so the judge→refine loop actually ENGAGES —
+ * the subtle failure mode is a judge whose `reviews` key nothing writes to, in
+ * which case `runJudgeRefineLoop` finds no step to re-run and the loop silently
+ * no-ops. This test pins both.
+ */
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { parse as parseYaml } from "yaml";
+import { parseRecipe } from "../parser.js";
+import { validateRecipeDefinition } from "../validation.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+// src/recipes/__tests__ → repo root is three levels up.
+const recipePath = join(
+  here,
+  "..",
+  "..",
+  "..",
+  "templates",
+  "recipes",
+  "incident-to-pr.yaml",
+);
+
+interface AgentLike {
+  kind?: string;
+  reviews?: string;
+  max_revisions?: number;
+  into?: string;
+}
+interface StepLike {
+  agent?: AgentLike;
+}
+
+const raw = readFileSync(recipePath, "utf8");
+const recipe = parseYaml(raw) as { steps?: StepLike[] };
+
+describe("flagship incident-to-pr recipe", () => {
+  it("validates against the recipe schema with zero errors", () => {
+    const result = validateRecipeDefinition(recipe);
+    const errors = result.issues.filter((i) => i.level === "error");
+    expect(errors, JSON.stringify(errors, null, 2)).toHaveLength(0);
+    expect(result.errors).toBe(0);
+  });
+
+  it("parses without throwing (the install path)", () => {
+    expect(() => parseRecipe(recipe)).not.toThrow();
+  });
+
+  it("wires the judge→refine loop so it actually engages", () => {
+    const steps = recipe.steps ?? [];
+
+    const judge = steps.find((s) => s.agent?.kind === "judge");
+    expect(judge, "expected a kind:judge step").toBeTruthy();
+    const j = judge?.agent as AgentLike;
+
+    // A bounded revision loop the judge can drive.
+    expect(typeof j.max_revisions).toBe("number");
+    expect(j.max_revisions ?? 0).toBeGreaterThan(0);
+    expect(j.reviews, "judge must review a ctx key").toBeTruthy();
+
+    // The reviewed step must write into the SAME ctx key the judge reviews —
+    // yamlRunner finds the step to re-run via
+    // (s.agent.into ?? "agent_output") === reviewsKey. If nothing writes that
+    // key, the loop no-ops and the "moat" is decorative.
+    const reviewed = steps.find(
+      (s) => s.agent && (s.agent.into ?? "agent_output") === j.reviews,
+    );
+    expect(
+      reviewed,
+      `no step writes into "${j.reviews}" — the refine loop would silently no-op`,
+    ).toBeTruthy();
+  });
+});

--- a/templates/recipes/incident-to-pr.yaml
+++ b/templates/recipes/incident-to-pr.yaml
@@ -1,0 +1,187 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/patchworkos/recipes/main/schema/recipe.v1.json
+apiVersion: patchwork.sh/v1
+version: 1.0.0
+name: incident-to-pr
+description: |
+  FLAGSHIP — the end-to-end AI-native incident-response loop. Turns a
+  production incident into a reviewed, ready-to-merge pull request. Every
+  primitive Patchwork added during the connector + judge→refine campaign
+  shows up here in one pipeline:
+
+    1. investigate — an agent root-causes the incident against THIS repo
+                     using the read/git tools it has via MCP (no writes).
+    2. draft_fix   — an agent writes the smallest correct patch + a PR
+                     title/body. This is the draft the judge reviews.
+    3. review_fix  — a JUDGE step (agent.kind: judge) gives the draft a
+                     cold-eyes senior-engineer review. On `request_changes`
+                     it DRIVES the judge→refine loop: the draft step is
+                     re-run with the judge's fix-list injected, up to
+                     `max_revisions` cycles, until the judge approves. This
+                     is the moat — quality is gated by an AI reviewer, not
+                     by hope.
+    4. open_pr     — an agent opens the PR via the githubCreatePR MCP tool.
+                     Opening a PR is a high-risk WRITE, so the runtime
+                     approval gate pauses here for a human to sign off — the
+                     human-in-the-loop checkpoint before anything lands.
+    5. notify      — posts the PR link + judge verdict to Slack.
+
+  REQUIREMENTS
+    - Bridge running with `--driver subprocess` so the agent steps have MCP
+      tool access (read files, git, githubCreatePR).
+    - GitHub connector connected (for the PR) and Slack connector connected
+      (for the alert) — visit /connections, or `patchwork connect github` /
+      `patchwork connect slack`.
+    - An approval gate of "high" or "all" to exercise the open_pr pause
+      (with the gate off, the PR opens unattended).
+
+  MANUAL RUN
+    patchwork recipe run incident-to-pr \
+      --var INCIDENT_TITLE="checkout 500s on /api/pay" \
+      --var STACK_TRACE="TypeError: cannot read 'id' of undefined at pay.ts:42"
+
+  WEBHOOK CONVERSION (PagerDuty / Sentry / Datadog)
+    Replace the trigger block with:
+      trigger:
+        type: webhook
+        path: /hooks/incident-to-pr
+    and reference {{payload.title}} / {{payload.body}} in place of the vars.
+
+trigger:
+  type: manual
+  vars:
+    - name: INCIDENT_TITLE
+      description: "One-line incident summary (seeds the PR title)"
+      required: true
+    - name: STACK_TRACE
+      description: "Stack trace / error text to root-cause (optional, recommended)"
+      required: false
+    - name: SEVERITY
+      description: "critical | high | medium | low"
+      required: false
+      default: "high"
+    - name: SLACK_CHANNEL
+      description: "Slack channel for the resolution alert"
+      required: false
+      default: "#incidents"
+
+steps:
+  - id: investigate
+    agent:
+      driver: claude-code
+      prompt: |
+        A production incident has fired. Root-cause it against THIS repository.
+
+        Incident: {{INCIDENT_TITLE}}
+        Severity: {{SEVERITY}}
+        Stack trace / error:
+        {{STACK_TRACE}}
+
+        Use the read and git tools available to you — read files, search the
+        codebase, inspect recent commits and run git blame on the implicated
+        files. Do NOT write any files in this step.
+
+        Respond with a concise root-cause analysis containing:
+          - the offending file(s) and line(s)
+          - what is going wrong and why
+          - the commit that most likely introduced it (if identifiable)
+          - the smallest correct fix you would make
+      into: investigation
+    risk: low
+
+  - id: draft_fix
+    awaits:
+      - investigate
+    agent:
+      driver: claude-code
+      prompt: |
+        Using the root-cause analysis below, write a concrete, MINIMAL fix.
+
+        Root-cause analysis:
+        {{investigation}}
+
+        Output exactly these four markdown sections and nothing else:
+
+        ## PR title
+        <conventional-commit-style title, <= 70 chars>
+
+        ## Summary
+        <2-4 sentences: what the bug was and how this change fixes it>
+
+        ## Patch
+        <a unified diff of the smallest change that fixes the root cause —
+         touch as few lines as possible; no drive-by refactors>
+
+        ## Test
+        <the test you would add or modify to prove the fix (a diff), or a
+         short note if existing coverage already exercises the path>
+
+        Do NOT write files in this step — only emit the four sections.
+      into: fix_draft
+    risk: low
+
+  - id: review_fix
+    awaits:
+      - draft_fix
+    agent:
+      kind: judge
+      reviews: fix_draft
+      max_revisions: 2
+      on_exhausted: proceed
+      driver: claude-code
+      prompt: |
+        You are a senior engineer doing a cold-eyes review of the proposed
+        fix below BEFORE it becomes a pull request. Judge it on:
+          - correctness:  does it actually fix the root cause?
+          - minimality:   smallest possible change, nothing unrelated?
+          - safety:       regression risk, edge cases, missing guards?
+          - tests:        is there a test that would FAIL without the fix?
+          - PR hygiene:   clear, accurate title and summary?
+
+        Return a verdict: approve | request_changes | unparseable.
+        If request_changes, list concrete, actionable fixes — each one a
+        specific change the author must make. Those drive the revision loop;
+        the draft is regenerated with your fix-list and re-reviewed.
+      into: review
+    risk: low
+
+  - id: open_pr
+    awaits:
+      - review_fix
+    agent:
+      driver: claude-code
+      prompt: |
+        The fix below has passed judge review. Open a pull request for it.
+
+        Approved fix:
+        {{fix_draft}}
+
+        Do this:
+          1. Create a branch off the default branch named
+             fix/<short-slug-derived-from-the-PR-title>.
+          2. Apply the change from the "## Patch" section and add the test
+             from the "## Test" section.
+          3. Open a pull request using the githubCreatePR tool, with the
+             "## PR title" as the title and the "## Summary" — followed by a
+             line "Fixes incident: {{INCIDENT_TITLE}}" — as the body.
+
+        Opening a PR is a write action; it will pause at the approval gate
+        for a human to confirm before it lands. After it succeeds, respond
+        with ONLY this JSON object (no markdown fences):
+        {"prUrl": "<url>", "prNumber": <number>, "branch": "<branch>"}
+
+        If the GitHub connector is not connected, respond with:
+        {"error": "GitHub connector not connected — visit /connections"}
+      into: pr
+    risk: high
+
+  - id: notify
+    awaits:
+      - open_pr
+    tool: slack.post_message
+    channel: "{{SLACK_CHANNEL}}"
+    text: |
+      :white_check_mark: Incident fix ready for review
+      *Incident:* {{INCIDENT_TITLE}} ({{SEVERITY}})
+      *Pull request:* {{pr}}
+      *Judge review:* {{review}}
+    risk: medium


### PR DESCRIPTION
## What

The capstone of the connector + judge→refine campaign: a single recipe that turns a production incident into a **reviewed, ready-to-merge pull request**. Every primitive shipped over #851–#859 shows up in one pipeline.

```
investigate → draft_fix → review_fix (JUDGE) → open_pr → notify
                              │
                              └─ judge→refine loop (#859): on request_changes,
                                 re-run draft_fix with the fix-list injected,
                                 up to max_revisions, until approve
```

| Step | What it does | Primitive shown |
|---|---|---|
| `investigate` | agent root-causes the incident against the repo (read/git tools, no writes) | MCP agent step |
| `draft_fix` | agent writes the minimal patch + PR title/body → `into: fix_draft` | agent draft |
| `review_fix` | `kind: judge`, `reviews: fix_draft`, `max_revisions: 2`, `on_exhausted: proceed` | **judge→refine loop (the moat)** |
| `open_pr` | agent opens the PR via `githubCreatePR` — a high-risk write, so the **runtime approval gate pauses for a human** | approval gate / connector write |
| `notify` | posts PR link + judge verdict to Slack | connector step |

Manual trigger with vars (`INCIDENT_TITLE`, `STACK_TRACE`, `SEVERITY`, `SLACK_CHANNEL`); the description documents the one-block webhook conversion for PagerDuty/Sentry/Datadog.

## Why a test ships with it

`incident-to-pr.yaml` is the recipe we point new users at, so a guard test (`src/recipes/__tests__/incidentToPrRecipe.test.ts`) pins two invariants CI will keep true:

1. **It validates** — `validateRecipeDefinition` reports zero errors and `parseRecipe` (the install path) doesn't throw.
2. **The judge→refine loop actually engages** — the reviewed step writes into the *same* ctx key the judge `reviews`, so `runJudgeRefineLoop` can find the step to re-run. The subtle failure mode — a judge whose `reviews` key nothing writes to, leaving the loop a silent no-op — is now a red build.

## Notes

- No engine/source changes — a recipe template + a test. Behaviour of existing recipes is untouched.
- Requires `--driver subprocess` + GitHub/Slack connectors + an approval gate of `high`/`all` to exercise end-to-end (documented in the recipe header).

## Test plan

- [x] `vitest run src/recipes/__tests__/incidentToPrRecipe.test.ts` — 3/3 green
- [x] `tsc -p tsconfig.tests.core.json` — exit 0
- [x] `audit-test-fixtures.mjs` / `audit-lsp-tools.mjs` / `audit-schema-changes.mjs` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)