### PR TITLE
feat(recipes): cost-routing Phase 0 — fix the budget's dropped + mis-attributed data

### DIFF
--- a/docs/design/cost-aware-routing.md
+++ b/docs/design/cost-aware-routing.md
@@ -1,0 +1,141 @@
+# Design: Cross-driver cost-aware model routing
+
+**Status:** ACCEPTED (direction) — Phase 0 in progress. Two product decisions made 2026-06-03: estimation is **warn-only** (`estimateUnmeasured` defaults to `false`); a local per-recipe `usdMax` **ships free in OSS core**. (The implementing ADR is written in the final phase.)
+**Date:** 2026-06-03
+**Author:** generated from a grounded design workflow (6 subsystem maps → 3 independent design stances → adversarial critique → synthesis), then fact-checked against source.
+
+---
+
+## 1. Problem
+
+Recipes can already name a `model` and a `driver` per agent step, and a recipe can set a **token** budget (`budget.tokensMax`, `onBreach: halt|warn`). What's missing:
+
+- **No USD cost model.** `RunBudget` is token-only. `usdMax` was deliberately deferred — the comment in [`runBudget.ts`](../../src/recipes/runBudget.ts) says it "needs a price table; subscription drivers complicate."
+- **No cost-aware routing.** There's no way to say "use the cheap model for the draft, the strong model for the judge" or "downshift to a cheaper model when the budget is running low."
+- **Provider drivers silently fail open.** Even the *token* budget doesn't work for `openai`/`grok`/`gemini` because those drivers never surface usage (see §3).
+
+> A prior memory claimed a `model_fallback` field "exists but is ignored." **It does not exist in `src/`** — it appears only in `examples/recipes/advanced-patterns/` docs (4 refs, 0 in code). That doc-drift is reconciled in Phase 0.
+
+The brief: design **cross-driver cost-aware model routing** that is opt-in, composes with everything we just shipped (judge→refine #859, fail-open `on_error`, augment-only judges), and is honest about the fact that the **default driver is a flat-rate subscription that reports no tokens.**
+
+## 2. Ground truth (verified against source)
+
+The authors left a **forward-compatible socket** and wrote down exactly why they stopped:
+
+| Fact | Location (verified) |
+|---|---|
+| `RunBudget` is token-only; `usdMax` explicitly out of scope ("needs a price table; subscription drivers complicate") | `runBudget.ts:24` |
+| `BudgetPolicy` is a **nested** object specifically so `usdMax` can be added as a sibling | `schema.ts:146` ("future siblings — `usdMax` …") |
+| Subscription drivers **fail open** (record driver once, warn, never block) — called a non-negotiable invariant | `runBudget.ts:12–15`, `reconcile()` |
+| `budget_exceeded` halt category + `/budget[_ ]?exceeded/i` regex already exist (reusable for usdMax) | `haltCategory.ts:24,119` |
+
+…and three **latent bugs / gaps** any cost work must fix anyway (all verified):
+
+1. **`parseRecipe` drops `budget`.** The normalized object it returns (`parser.ts:69–82`) carries `name/version/description/trigger/context/steps/on_error` — **no `budget`**. Any recipe that round-trips through the parser loses its token budget. *(Pure pre-existing bug — must not be gated behind the cost feature.)*
+2. **`reconcile` mis-attributes the driver.** Both call sites (`yamlRunner.ts:1040`, `:1321`) pass the *configured* `driver ?? "auto"`, not the driver that actually served the call. So per-driver warnings/accounting are keyed on a guess.
+3. **Provider usage is thrown away.** `makeProviderDriverFn` returns a **bare string** (`yamlRunner.ts:~2379`, `return result.text`), so even when a driver *could* report tokens, `usage` never reaches `reconcile`. `RunBudget.totals()`/`warnings()` have **zero production call sites** — token warn-mode breaches and unmeasured-driver warnings are computed and silently discarded.
+
+## 3. Per-driver cost fidelity (the make-or-break constraint)
+
+| Driver | Mode | Reports tokens today? | Notes |
+|---|---|---|---|
+| `subprocess` (Claude CLI) — **the default** | subscription | ❌ none | stream-json `result` event *does* carry `usage` + `total_cost_usd`; `streamParser` ignores it |
+| `gemini` (CLI) | subscription | ❌ none | same shape, discarded |
+| `api` (Anthropic SDK) | API key | ❌ (but trivially fixable) | `messages.create` returns `usage`; driver discards it |
+| `openai` / `grok` / `gemini-api` / `local` | API key | ❌ (fixable) | `providerMeta` only carries `{model}`; needs `stream_options:{include_usage:true}` |
+
+**The trap:** a `usdMax` that silently no-ops for the default subscription driver is worse than no feature — it looks enforced but isn't. The design resolves this honestly (§5.3): **fail open with a loud warning by default; estimation is opt-in and can only WARN, never halt.**
+
+## 4. Approaches considered
+
+| Stance | Idea | Verdict |
+|---|---|---|
+| **A — resilience fallback chain** | per-step ordered `fallback: [{driver?,model}]`, retry next on error/budget-deny; no price table | **Cleanest scores, but answers the wrong question** — it's resilience, not cost. Its substrate fixes are harvested. |
+| **B — declarative cost tiers** | `(driver,model)→USD` price table + `tier:`/`routing:` map picking cheapest-capable upfront + `usdMax` | **Core (price table + usdMax) is right; the `routing`/`tier`/`escalate` dictionary + inline `pricing:` are cut** (schema bloat; inline pricing is a budget-evasion footgun). |
+| **C — USD ledger drives routing** | extend `RunBudget` into a USD ledger; estimate tokens for subscription drivers; downshift as budget shrinks | **Backbone of the recommendation, with one fix**: its `estimateUnmeasured: true` default inverts the fail-open invariant — flip it to **false**. Its `downshift` primitive is kept. |
+
+## 5. Recommendation — the hybrid
+
+> **Cost-ledger core + opt-in downshift routing, estimation off by default.**
+> Take B's minimal core (driver token capture + static price table + `budget.usdMax`) as the spine; graft A's `servedBy` reconcile fix and additive-`AgentResult` telemetry as the substrate; graft C's per-step `downshift` as the routing layer and its `usage.estimated`/`usdEstimatedPortion` honesty labels — **but with `estimateUnmeasured` defaulting to `false`** so opting into a cap never silently opts the subscription default driver into estimation-driven halts.
+
+All three critiques converged on the same minimal core and disagreed only about the bundled layers — the signature of a hybrid.
+
+### 5.1 Config surface (all opt-in; absent = byte-identical)
+
+```yaml
+# Recipe-level budget — extends today's token-only block
+budget:
+  tokensMax: 200000          # existing
+  usdMax: 2.50               # NEW — enforced for *measured* (API) drivers
+  onBreach: halt             # existing enum reused (halt | warn)
+  estimateUnmeasured: false  # NEW, DEFAULT false — when true, estimate tokens
+                             #   for subscription drivers; estimated spend can
+                             #   only WARN, never halt (renders "≈$X")
+
+steps:
+  - id: draft
+    agent:
+      prompt: ...
+      model: claude-sonnet-4-6
+      # NEW — author-ordered cheaper alternatives, tried pre-dispatch when the
+      # remaining USD budget is too tight for the preferred model. Absent =>
+      # the preferred model is always used (byte-identical).
+      downshift:
+        - { model: claude-haiku-4-5-20251001 }
+        - { driver: gemini-api, model: gemini-2.5-flash }
+```
+
+Price table — **data, not code**, overridable, never hot-path network:
+```
+src/recipes/pricing/priceTable.json   # checked-in list prices, dated _meta, CI staleness ratchet
+~/.patchwork/prices.json              # workspace override
+PATCHWORK_PRICE_TABLE=/path.json       # env override
+# precedence: env > file > checked-in ; fail-open on unknown (driver,model)
+```
+**Dropped from B:** the inline recipe `pricing:` field (a recipe could under-price a model to dodge `usdMax`). The two out-of-band overrides get ~95% of the value safely.
+
+### 5.2 Data model & integration points (verified anchors)
+
+- **`AgentResult`** (`agentExecutor.ts`): widen *additively* with `servedBy?: {driver, model, attempt}` and keep `usage?`. Unset ⇒ byte-identical.
+- **Drivers:** `ApiDriver` reads the `message.usage` it discards; `OpenAIApiDriver` adds `stream_options:{include_usage:true}` (covers openai/grok/gemini-api/local in one place); standardize a typed `providerMeta {model, inputTokens, outputTokens}`.
+- **`makeProviderDriverFn`** (`yamlRunner.ts:~2379`): return `AgentResult` (map `providerMeta → usage`) instead of a bare string — this is what stops openai/grok/gemini from silently failing open.
+- **`RunBudget`** (`runBudget.ts`): extend **in place** — `usdSpent` accumulator, `reconcile(driver, usage, model?)` computes USD via the price table, `admit()` gains a usd branch mirroring `tokensMax`, `totals()` gains `usd`/`usdRemaining`/`usdEstimatedPortion`. Reuse the `budget_exceeded` halt category (hint-text update only).
+- **`costRouter`** (new pure fn): `resolve(preferred, downshift, remainingUsd, promptText) → {driver, model}`; returns `preferred` unchanged when `downshift` is absent. Wired at **both** agent sites (`:1308` main, `:1031` refine loop) via one shared resolve+reconcile closure (the two-site hazard #859 also had to handle).
+- **Schema:** extract a **shared `agentStepProperties` const** before adding any agent-step field — the leaf (`~266–318`) and top-level (`~520–587`) blocks in `schemaGenerator.ts` are duplicated and a field added to only one is rejected inside parallel blocks.
+
+### 5.3 Failure & budget semantics (the honesty rules)
+
+- **Measured (API) drivers:** real `usage` → real USD → `usdMax` enforced; breach halts at the next `admit()` (never retroactively, same as tokens today).
+- **Subscription drivers (`subprocess`/`gemini`):** **fail open** with a *loud, per-driver* warning (now actually surfaced via the Phase 0 `completeRun` fix). A `usdMax` here measures **notional list-equivalent** spend, not real money out — docs/hint must say so.
+- **`estimateUnmeasured: true` (opt-in):** estimate tokens (~4 chars/token heuristic) → `usage.estimated = true`; estimated spend renders **"≈$X"** and can **only WARN, never halt**.
+- **Layering:** a `usdMax` admission denial **halts** (a run-level decision — a cheaper model can't rescue an exhausted cap). `downshift` operates **below** the admit gate, picking a cheaper model for a call admission already passed. So downshift slows the *rate* of spend; it never overrides a breach. *(Whether a denied admission may instead retry a cheaper entry is a deferred stretch flag — see decisions.)*
+
+### 5.4 Invariants honored
+
+Opt-in (absent config ⇒ byte-identical) · composes with judge→refine (router + reconcile wired at the refine site too) · augment-only judges untouched · fail-open preserved (estimation is opt-in, warn-only) · no hot-path network, no secrets, prices are reviewable data.
+
+## 6. Phased rollout (each phase an independently shippable, opt-in PR)
+
+- **Phase 0 — substrate & latent-bug fixes (no new user config).** `servedBy` reconcile fix + additive `AgentResult`; fix `parser.ts` to pass `budget` through; thread `RunBudget.totals()/warnings()` into `completeRun` (~1753) so dead warnings surface; extract shared `agentStepProperties` const; reconcile `model_fallback` doc-drift (alias or delete). *Valuable even if the cost feature is never built.*
+- **Phase 1 — driver token fidelity.** Make API drivers report tokens; `makeProviderDriverFn` returns `AgentResult`. **One behavior shift to changelog:** recipes that *already* set `tokensMax` AND use openai/grok/gemini start being measured (they fail open today) and could begin halting — a scoped correctness fix.
+- **Phase 2 — static price table asset.** `priceTable.json` + loader + override precedence + CI staleness ratchet. Consumed by nobody yet; lands so prices can be reviewed for accuracy independently.
+- **Phase 3 — `budget.usdMax` enforcement (the headline).** Extend `RunBudget` in place; add `usdMax` + `estimateUnmeasured` (default **false**) to schema/validation/parser; reuse `budget_exceeded`; dashboard renders `$`/`≈$`. **This alone closes the deferred-usdMax gap and is a reasonable stopping point if routing is descoped.**
+- **Phase 4 — opt-in per-step `downshift` routing.** Add the field + pure `costRouter`, wire at both agent sites, cross-field validation mirroring #859, parser passthrough. **+ write the ADR** (price-table source/refresh, fail-open USD semantics, estimate-warns-never-halts, `estimateUnmeasured=false`, OSS-vs-Pro boundary).
+
+## 7. Decisions for you (recommended answer in **bold**)
+
+1. **Price-table source & refresh:** ship list prices as a checked-in `priceTable.json`, PR-refreshed, with a CI staleness ratchet on `_generatedAt` (fail-loud at build, never a runtime network call). → **Yes; confirm who owns the refresh PR and cadence.**
+2. **Default-driver estimation:** `estimateUnmeasured` defaults to **`false`** (preserve fail-open; estimation is opt-in and warn-only). → ✅ **DECIDED (2026-06-03): warn-only.** Never hard-stop work on an estimate.
+3. **`downshift` semantics:** author-ordered list (the recipe author asserts each fallback is "good enough"), **no engine capability/tier taxonomy.** → **Recommend author-ordered.**
+4. **Breach vs downshift layering:** admission denial **halts**; `downshift` only picks a cheaper model below the admit gate. → **Recommend this layering** (retry-cheaper-on-denial deferred as a stretch flag).
+5. **Subscription USD framing:** docs/hint state plainly that `usdMax` on a subscription driver is **notional list-equivalent**, not real money. → **Recommend explicit wording.**
+6. **OSS vs Pro boundary:** does a *local, per-recipe* `usdMax` ship in the free OSS core? → ✅ **DECIDED (2026-06-03): ships free in OSS core.** Only cross-recipe / centralized billing is reserved for Pro.
+7. **Chained-runner scope:** the chained-runner wrapper (`yamlRunner ~2560`) discards `.usage` and bypasses the budget today. Cover sub-recipe/chained calls in this work, or document as out-of-scope for now? → **Recommend out-of-scope for v1, documented.**
+
+## 8. Test plan (per phase)
+
+- Phase 0: parser round-trip preserves `budget` (regression); `reconcile` receives the served driver; `completeRun` surfaces token warn/unmeasured warnings; schema const-extraction leaves both blocks identical.
+- Phase 1: each API driver populates typed `providerMeta` usage; `makeProviderDriverFn` maps to `AgentResult.usage`; tokensMax now enforced for openai/grok/gemini.
+- Phase 3: `usdMax` halts a measured run at the right point; subscription run fails open with exactly one warning; `estimateUnmeasured:true` warns but never halts; `usdEstimatedPortion` populated; unknown (driver,model) fails open.
+- Phase 4: `downshift` absent ⇒ preferred model unchanged (byte-identical); tight budget picks the first fitting candidate; router fires at both main and refine sites; invalid `downshift` entries rejected by validation.

--- a/examples/recipes/advanced-patterns/README.md
+++ b/examples/recipes/advanced-patterns/README.md
@@ -51,11 +51,14 @@ Requires: `transcription-mcp` (Whisper), `file-mcp`, `notify-mcp`.
 **Route each step to the right model based on cost/capability.**
 
 - Classification (fast + cheap) → `openai/gpt-4o-mini` or `claude-haiku-4-5`
-- Bulk summarization (private + free) → `ollama/llama3.2` with fallback to Haiku
+- Bulk summarization (private + free) → `ollama/llama3.2`
 - Final synthesis (quality) → `anthropic/claude-sonnet-4-6`
 
 The template for any batch workflow where not every step needs your best model.
-Uses the `model:` and `model_fallback:` per-step fields.
+Uses the per-step `model:` field. (Automatic cross-model fallback and
+cost-aware routing — a `downshift:` field — are a roadmap feature, not yet
+implemented; there is no `model_fallback:` field. See
+[../../../docs/design/cost-aware-routing.md](../../../docs/design/cost-aware-routing.md).)
 
 ---
 

--- a/examples/recipes/advanced-patterns/mixed-provider-pipeline.yaml
+++ b/examples/recipes/advanced-patterns/mixed-provider-pipeline.yaml
@@ -42,8 +42,11 @@ steps:
   # Step 2: Bulk summarization — local Ollama (free, private, good enough for summaries)
   - id: summarize_documents
     risk: low
-    model: ollama/llama3.2      # falls back to anthropic/claude-haiku-4-5 if Ollama unavailable
-    model_fallback: anthropic/claude-haiku-4-5-20251001
+    model: ollama/llama3.2      # local Ollama — free + private, fine for bulk summaries
+    # NOTE: automatic cross-model fallback (e.g. to Haiku when Ollama is down)
+    # is a roadmap feature — there is no `model_fallback:` field today, so do
+    # not rely on one. Per-step cost-aware fallback is designed as `downshift`
+    # in ../../../docs/design/cost-aware-routing.md. The `model:` field works now.
     awaits:
       - classify_documents
     agent:

--- a/src/recipes/__tests__/agentExecutor.test.ts
+++ b/src/recipes/__tests__/agentExecutor.test.ts
@@ -1,19 +1,21 @@
 /**
- * Phase 2a parity tests for the planned `agentExecutor` extraction.
+ * Dispatch + attribution tests for `agentExecutor`.
  *
- * These tests are intentionally RED — `src/recipes/agentExecutor.ts` does not
- * exist yet. They pin ALL dispatch branches (both from the standard agent block
- * in runYamlRecipe, lines 378-475, and the chainedRunner executeAgent factory,
- * lines 1030-1058) so that the extraction can prove superset behaviour.
+ * Pins ALL driver-resolution branches (both from the standard agent block in
+ * runYamlRecipe and the chainedRunner executeAgent factory) so the unified
+ * impl proves superset behaviour, AND that `executeAgent` stamps `servedBy`
+ * with the driver it ACTUALLY resolved+ran — the substrate RunBudget.reconcile
+ * uses instead of guessing from the configured `driver` string.
+ *
+ * Note: the injected deps return `AgentResult` objects ({text, usage?}), which
+ * is what the real wired deps return (buildAgentExecutorDeps normalizes every
+ * dep through `toAgentResult` before executeAgent sees it). Earlier revisions
+ * of this test returned bare strings, which did not match that contract.
  *
  * Drift bug documented:
- *   runYamlRecipe (lines 388-428) handles driver:"local" and
- *   pwCfg.model==="local" branches. chainedRunner.executeAgent (lines 1030-1058)
- *   does NOT — both local paths are absent. The extracted module must carry
- *   the superset (all 8 branches) so both callers converge on one impl.
- *
- * Deps injected via constructor/factory args so every branch is unit-testable
- * without spawning a real process or touching ~/.patchwork/config.
+ *   runYamlRecipe handles driver:"local" and pwCfg.model==="local" branches.
+ *   chainedRunner.executeAgent historically did NOT — both local paths were
+ *   absent. The extracted module carries the superset (all 8 branches).
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -25,14 +27,14 @@ function makeDeps(
   overrides: Partial<AgentExecutorDeps> = {},
 ): AgentExecutorDeps {
   return {
-    anthropicFn: vi.fn().mockResolvedValue("anthropic-result"),
+    anthropicFn: vi.fn().mockResolvedValue({ text: "anthropic-result" }),
     providerDriverFn: vi
       .fn()
       .mockImplementation((driver: string) =>
-        Promise.resolve(`${driver}-result`),
+        Promise.resolve({ text: `${driver}-result` }),
       ),
-    claudeCliFn: vi.fn().mockResolvedValue("claude-cli-result"),
-    localFn: vi.fn().mockResolvedValue("local-result"),
+    claudeCliFn: vi.fn().mockResolvedValue({ text: "claude-cli-result" }),
+    localFn: vi.fn().mockResolvedValue({ text: "local-result" }),
     probeClaudeCli: vi.fn().mockReturnValue(false),
     loadPatchworkConfig: vi.fn().mockReturnValue({}),
     ...overrides,
@@ -42,13 +44,17 @@ function makeDeps(
 // ── 1. Explicit driver:"anthropic" ───────────────────────────────────────────
 
 describe('driver:"anthropic"', () => {
-  it("calls anthropicFn, not others", async () => {
+  it("calls anthropicFn, not others; servedBy=anthropic", async () => {
     const deps = makeDeps();
     const result = await executeAgent(
       { driver: "anthropic", prompt: "hello", model: "claude-haiku" },
       deps,
     );
-    expect(result).toBe("anthropic-result");
+    expect(result.text).toBe("anthropic-result");
+    expect(result.servedBy).toEqual({
+      driver: "anthropic",
+      model: "claude-haiku",
+    });
     expect(deps.anthropicFn).toHaveBeenCalledWith("hello", "claude-haiku");
     expect(deps.localFn).not.toHaveBeenCalled();
     expect(deps.claudeCliFn).not.toHaveBeenCalled();
@@ -58,13 +64,14 @@ describe('driver:"anthropic"', () => {
 // ── 2. Explicit driver:"openai" ──────────────────────────────────────────────
 
 describe('driver:"openai"', () => {
-  it("calls providerDriverFn with openai, not others", async () => {
+  it("calls providerDriverFn with openai; servedBy=openai", async () => {
     const deps = makeDeps();
     const result = await executeAgent(
       { driver: "openai", prompt: "hello", model: "gpt-4o" },
       deps,
     );
-    expect(result).toBe("openai-result");
+    expect(result.text).toBe("openai-result");
+    expect(result.servedBy).toEqual({ driver: "openai", model: "gpt-4o" });
     expect(deps.providerDriverFn).toHaveBeenCalledWith(
       "openai",
       "hello",
@@ -78,13 +85,14 @@ describe('driver:"openai"', () => {
 // ── 3. Explicit driver:"gemini" ──────────────────────────────────────────────
 
 describe('driver:"gemini"', () => {
-  it("calls providerDriverFn with gemini, not others", async () => {
+  it("calls providerDriverFn with gemini; servedBy=gemini", async () => {
     const deps = makeDeps();
     const result = await executeAgent(
       { driver: "gemini", prompt: "hello", model: "gemini-pro" },
       deps,
     );
-    expect(result).toBe("gemini-result");
+    expect(result.text).toBe("gemini-result");
+    expect(result.servedBy).toEqual({ driver: "gemini", model: "gemini-pro" });
     expect(deps.providerDriverFn).toHaveBeenCalledWith(
       "gemini",
       "hello",
@@ -98,7 +106,7 @@ describe('driver:"gemini"', () => {
 // ── 4. Explicit driver:"subprocess" ─────────────────────────────────────────
 
 describe('driver:"subprocess"', () => {
-  it("calls claudeCliFn (probeClaudeCli is NOT consulted)", async () => {
+  it("calls claudeCliFn; servedBy=subprocess (probe NOT consulted)", async () => {
     const deps = makeDeps({
       probeClaudeCli: vi.fn().mockReturnValue(false), // should be irrelevant
     });
@@ -106,7 +114,8 @@ describe('driver:"subprocess"', () => {
       { driver: "subprocess", prompt: "hello" },
       deps,
     );
-    expect(result).toBe("claude-cli-result");
+    expect(result.text).toBe("claude-cli-result");
+    expect(result.servedBy?.driver).toBe("subprocess");
     expect(deps.claudeCliFn).toHaveBeenCalledWith("hello", undefined);
     expect(deps.anthropicFn).not.toHaveBeenCalled();
     expect(deps.localFn).not.toHaveBeenCalled();
@@ -117,13 +126,14 @@ describe('driver:"subprocess"', () => {
 // ── 5. Explicit driver:"local" (THE MISSING BRANCH in chained path) ──────────
 
 describe('driver:"local"', () => {
-  it("calls localFn — this branch is absent from chainedRunner.executeAgent", async () => {
+  it("calls localFn; servedBy=local — branch absent from chainedRunner", async () => {
     const deps = makeDeps();
     const result = await executeAgent(
       { driver: "local", prompt: "hello", model: "llama3" },
       deps,
     );
-    expect(result).toBe("local-result");
+    expect(result.text).toBe("local-result");
+    expect(result.servedBy).toEqual({ driver: "local", model: "llama3" });
     expect(deps.localFn).toHaveBeenCalledWith("hello", "llama3");
     expect(deps.anthropicFn).not.toHaveBeenCalled();
     expect(deps.claudeCliFn).not.toHaveBeenCalled();
@@ -131,20 +141,25 @@ describe('driver:"local"', () => {
 
   it("uses default model when none supplied", async () => {
     const deps = makeDeps();
-    await executeAgent({ driver: "local", prompt: "hello" }, deps);
+    const result = await executeAgent(
+      { driver: "local", prompt: "hello" },
+      deps,
+    );
     expect(deps.localFn).toHaveBeenCalledWith("hello", expect.any(String));
+    expect(result.servedBy?.driver).toBe("local");
   });
 });
 
 // ── 6. No driver + pwCfg model:"local" (THE OTHER MISSING BRANCH) ────────────
 
 describe("no driver + pwCfg model:local", () => {
-  it("calls localFn — this branch is absent from chainedRunner.executeAgent", async () => {
+  it("calls localFn; servedBy=local — branch absent from chainedRunner", async () => {
     const deps = makeDeps({
       loadPatchworkConfig: vi.fn().mockReturnValue({ model: "local" }),
     });
     const result = await executeAgent({ prompt: "hello" }, deps);
-    expect(result).toBe("local-result");
+    expect(result.text).toBe("local-result");
+    expect(result.servedBy?.driver).toBe("local");
     expect(deps.localFn).toHaveBeenCalledWith("hello", expect.any(String));
     expect(deps.anthropicFn).not.toHaveBeenCalled();
     expect(deps.claudeCliFn).not.toHaveBeenCalled();
@@ -158,25 +173,27 @@ describe("no driver + pwCfg non-local + claude CLI available", () => {
     delete process.env.ANTHROPIC_API_KEY;
   });
 
-  it("probes for claude CLI; calls claudeCliFn when probe succeeds", async () => {
+  it("probes for claude CLI; calls claudeCliFn; servedBy=subprocess", async () => {
     const deps = makeDeps({
       loadPatchworkConfig: vi.fn().mockReturnValue({}),
       probeClaudeCli: vi.fn().mockReturnValue(true),
     });
     const result = await executeAgent({ prompt: "hello" }, deps);
-    expect(result).toBe("claude-cli-result");
+    expect(result.text).toBe("claude-cli-result");
+    expect(result.servedBy?.driver).toBe("subprocess");
     expect(deps.claudeCliFn).toHaveBeenCalledWith("hello", undefined);
     expect(deps.probeClaudeCli).toHaveBeenCalled();
     expect(deps.anthropicFn).not.toHaveBeenCalled();
   });
 
-  it("falls back to anthropicFn when probe fails", async () => {
+  it("falls back to anthropicFn when probe fails; servedBy=anthropic", async () => {
     const deps = makeDeps({
       loadPatchworkConfig: vi.fn().mockReturnValue({}),
       probeClaudeCli: vi.fn().mockReturnValue(false),
     });
     const result = await executeAgent({ prompt: "hello" }, deps);
-    expect(result).toBe("anthropic-result");
+    expect(result.text).toBe("anthropic-result");
+    expect(result.servedBy?.driver).toBe("anthropic");
     expect(deps.anthropicFn).toHaveBeenCalled();
     expect(deps.claudeCliFn).not.toHaveBeenCalled();
   });
@@ -193,7 +210,7 @@ describe("no driver + ANTHROPIC_API_KEY set", () => {
     delete process.env.ANTHROPIC_API_KEY;
   });
 
-  it("skips probeClaudeCli entirely, calls anthropicFn", async () => {
+  it("skips probeClaudeCli, calls anthropicFn; servedBy=anthropic", async () => {
     const deps = makeDeps({
       loadPatchworkConfig: vi.fn().mockReturnValue({}),
     });
@@ -201,7 +218,11 @@ describe("no driver + ANTHROPIC_API_KEY set", () => {
       { prompt: "hello", model: "claude-haiku" },
       deps,
     );
-    expect(result).toBe("anthropic-result");
+    expect(result.text).toBe("anthropic-result");
+    expect(result.servedBy).toEqual({
+      driver: "anthropic",
+      model: "claude-haiku",
+    });
     expect(deps.anthropicFn).toHaveBeenCalledWith("hello", "claude-haiku");
     expect(deps.probeClaudeCli).not.toHaveBeenCalled();
     expect(deps.claudeCliFn).not.toHaveBeenCalled();
@@ -223,11 +244,15 @@ describe("no driver + ANTHROPIC_API_KEY + no model specified", () => {
     const deps = makeDeps({
       loadPatchworkConfig: vi.fn().mockReturnValue({}),
     });
-    await executeAgent({ prompt: "hello" }, deps);
+    const result = await executeAgent({ prompt: "hello" }, deps);
     expect(deps.anthropicFn).toHaveBeenCalledWith(
       "hello",
       "claude-haiku-4-5-20251001",
     );
+    expect(result.servedBy).toEqual({
+      driver: "anthropic",
+      model: "claude-haiku-4-5-20251001",
+    });
   });
 });
 
@@ -241,5 +266,24 @@ describe("unknown driver", () => {
     ).rejects.toThrow(/unknown.*driver|unsupported.*driver|foobar/i);
     expect(deps.anthropicFn).not.toHaveBeenCalled();
     expect(deps.localFn).not.toHaveBeenCalled();
+  });
+});
+
+// ── 10. servedBy is idempotent — a dep that already set it is preserved ──────
+
+describe("servedBy stamping", () => {
+  it("does not overwrite a servedBy a dep already provided", async () => {
+    const deps = makeDeps({
+      providerDriverFn: vi.fn().mockResolvedValue({
+        text: "openai-result",
+        servedBy: { driver: "openai", model: "gpt-4o-mini" },
+      }),
+    });
+    const result = await executeAgent(
+      { driver: "openai", prompt: "hello", model: "gpt-4o" },
+      deps,
+    );
+    // The dep's own attribution (the model it actually fell back to) wins.
+    expect(result.servedBy).toEqual({ driver: "openai", model: "gpt-4o-mini" });
   });
 });

--- a/src/recipes/__tests__/parser.test.ts
+++ b/src/recipes/__tests__/parser.test.ts
@@ -30,6 +30,21 @@ describe("parseRecipe", () => {
     expect(() => parseRecipe({ ...VALID, name: "" })).toThrow(RecipeParseError);
   });
 
+  // Regression: parseRecipe (the installer's normalizer) silently dropped the
+  // recipe-level `budget`, so a recipe round-tripped through it lost its token
+  // budget and RunBudget(recipe.budget) enforced nothing. Pass it through.
+  it("preserves the recipe-level budget", () => {
+    const r = parseRecipe({
+      ...VALID,
+      budget: { tokensMax: 50000, onBreach: "warn" },
+    });
+    expect(r.budget).toEqual({ tokensMax: 50000, onBreach: "warn" });
+  });
+
+  it("leaves budget undefined when absent (no synthetic policy)", () => {
+    expect(parseRecipe(VALID).budget).toBeUndefined();
+  });
+
   // Regression: parseRecipe hard-rejected a version-less recipe with
   // "missing or empty 'version'", but the JSON schema marks version
   // optional with default "1.0.0" and neither validateRecipeDefinition

--- a/src/recipes/agentExecutor.ts
+++ b/src/recipes/agentExecutor.ts
@@ -28,6 +28,17 @@ export interface AgentUsage {
 export interface AgentResult {
   text: string;
   usage?: AgentUsage;
+  /**
+   * Which driver (and model, when known) ACTUALLY served this call. Stamped
+   * by `executeAgent` — the single place that resolves driver auto-detection
+   * — so callers attribute the result to the real driver instead of guessing
+   * from the configured `driver` string (which is often undefined → the
+   * runner previously logged a literal `"auto"`). Consumed by
+   * `RunBudget.reconcile` for correct per-driver usage/warning attribution,
+   * and the substrate the forthcoming USD cost ledger needs. Additive:
+   * absent on results from callers that bypass `executeAgent`.
+   */
+  servedBy?: { driver: string; model?: string };
 }
 
 export interface AgentExecutorDeps {
@@ -71,17 +82,46 @@ export async function executeAgent(
   const { prompt, driver, model, mcpAccess } = input;
   const cliOpts = mcpAccess !== undefined ? { mcpAccess } : undefined;
 
+  // Stamp the driver that ACTUALLY ran onto the result. This is the single
+  // place driver auto-detection is resolved, so it is the only place that
+  // knows the true answer — callers (RunBudget.reconcile, future cost
+  // accounting) must not re-guess from the configured `driver` string.
+  // Additive and idempotent: never overwrites a servedBy a dep already set.
+  const stamp = async (
+    resolvedDriver: string,
+    resolvedModel: string | undefined,
+    p: Promise<AgentResult>,
+  ): Promise<AgentResult> => {
+    const r = await p;
+    if (r.servedBy) return r;
+    return {
+      ...r,
+      servedBy: {
+        driver: resolvedDriver,
+        ...(resolvedModel !== undefined ? { model: resolvedModel } : {}),
+      },
+    };
+  };
+
   if (driver === "anthropic" || driver === "claude") {
-    return deps.anthropicFn(prompt, model ?? DEFAULT_MODEL);
+    return stamp(
+      "anthropic",
+      model ?? DEFAULT_MODEL,
+      deps.anthropicFn(prompt, model ?? DEFAULT_MODEL),
+    );
   }
   if (driver === "openai" || driver === "grok" || driver === "gemini") {
-    return deps.providerDriverFn(driver, prompt, model);
+    return stamp(driver, model, deps.providerDriverFn(driver, prompt, model));
   }
   if (driver === "subprocess" || driver === "claude-code") {
-    return deps.claudeCliFn(prompt, cliOpts);
+    return stamp("subprocess", model, deps.claudeCliFn(prompt, cliOpts));
   }
   if (driver === "local") {
-    return deps.localFn(prompt, model ?? DEFAULT_MODEL);
+    return stamp(
+      "local",
+      model ?? DEFAULT_MODEL,
+      deps.localFn(prompt, model ?? DEFAULT_MODEL),
+    );
   }
   if (driver !== undefined) {
     throw new Error(`Unknown driver: "${driver}"`);
@@ -90,23 +130,35 @@ export async function executeAgent(
   // No driver — check pwCfg for local model preference (THE MISSING BRANCH).
   const pwCfg = deps.loadPatchworkConfig();
   if (pwCfg.model === "local") {
-    return deps.localFn(prompt, model ?? DEFAULT_MODEL);
+    return stamp(
+      "local",
+      model ?? DEFAULT_MODEL,
+      deps.localFn(prompt, model ?? DEFAULT_MODEL),
+    );
   }
 
   // Explicit subprocess driver config → skip API key check entirely.
   if (pwCfg.driver === "subprocess" || pwCfg.driver === "claude-code") {
-    return deps.claudeCliFn(prompt, cliOpts);
+    return stamp("subprocess", model, deps.claudeCliFn(prompt, cliOpts));
   }
 
   // Auto-detect: prefer API key, otherwise probe for claude CLI.
   if (process.env.ANTHROPIC_API_KEY) {
-    return deps.anthropicFn(prompt, model ?? DEFAULT_MODEL);
+    return stamp(
+      "anthropic",
+      model ?? DEFAULT_MODEL,
+      deps.anthropicFn(prompt, model ?? DEFAULT_MODEL),
+    );
   }
   if (deps.probeClaudeCli()) {
-    return deps.claudeCliFn(prompt, cliOpts);
+    return stamp("subprocess", model, deps.claudeCliFn(prompt, cliOpts));
   }
   // Probe failed and no API key — fall back to anthropicFn so the caller
   // surfaces a clear "[agent step skipped: ANTHROPIC_API_KEY not set]" message
   // (and so test overrides of claudeFn/anthropicFn are honored).
-  return deps.anthropicFn(prompt, model ?? DEFAULT_MODEL);
+  return stamp(
+    "anthropic",
+    model ?? DEFAULT_MODEL,
+    deps.anthropicFn(prompt, model ?? DEFAULT_MODEL),
+  );
 }

--- a/src/recipes/parser.ts
+++ b/src/recipes/parser.ts
@@ -79,6 +79,14 @@ export function parseRecipe(raw: unknown): Recipe {
       typeof r.on_error === "object" && r.on_error !== null
         ? (r.on_error as Recipe["on_error"])
         : undefined,
+    // Pass the recipe-level budget through. Without this the normalizer
+    // silently dropped `budget`, so any recipe round-tripped through
+    // parseRecipe (the installer's validation path) lost its token budget —
+    // RunBudget(recipe.budget) then saw undefined and enforced nothing.
+    budget:
+      typeof r.budget === "object" && r.budget !== null
+        ? (r.budget as Recipe["budget"])
+        : undefined,
   };
 }
 

--- a/src/recipes/yamlRunner.ts
+++ b/src/recipes/yamlRunner.ts
@@ -1038,7 +1038,11 @@ export async function runYamlRecipe(
       buildAgentExecutorDeps(stepDeps, deps),
     );
     runBudget.reconcile(
-      driver === "api" ? "anthropic" : (driver ?? "auto"),
+      // Prefer the driver executeAgent actually resolved+ran; fall back to
+      // the configured value only when servedBy is absent (non-executeAgent
+      // callers). Stops auto-detected runs being mis-attributed to "auto".
+      agentReturn.servedBy?.driver ??
+        (driver === "api" ? "anthropic" : (driver ?? "auto")),
       agentReturn.usage,
     );
     const text = agentReturn.text;
@@ -1319,9 +1323,13 @@ export async function runYamlRecipe(
           );
           agentResult = agentReturn.text;
           runBudget.reconcile(
-            agentCfg.driver === "api"
-              ? "anthropic"
-              : (agentCfg.driver ?? "auto"),
+            // Prefer the driver executeAgent actually resolved+ran; the
+            // configured value is only the fallback for non-executeAgent
+            // callers (it is often undefined → previously logged "auto").
+            agentReturn.servedBy?.driver ??
+              (agentCfg.driver === "api"
+                ? "anthropic"
+                : (agentCfg.driver ?? "auto")),
             agentReturn.usage,
           );
           // Catch both `[agent step failed: ...]` (existing) and the


### PR DESCRIPTION
First step of the **cost-aware-routing** initiative. Phase 0 is pure correctness — **no new user-facing config**, runtime behaviour byte-identical except that the existing token budget's data is now correct. These are the substrate fixes the cost layer needs anyway, and they're valuable even if the rest is never built.

> Design (accepted direction): [`docs/design/cost-aware-routing.md`](../blob/feat/cost-routing-phase0-data-integrity/docs/design/cost-aware-routing.md) — included in this PR so reviewers see the plan. Two product decisions recorded: estimation is **warn-only** (`estimateUnmeasured` defaults `false`); a local per-recipe `usdMax` **ships free in OSS core**.

## Three verified bugs fixed

| # | Bug | Fix |
|---|---|---|
| 1 | **`parseRecipe` dropped `budget`.** Its return object (`parser.ts`) carried `name/version/…/on_error` but not `budget`, so any recipe round-tripped through the normalizer (the installer's validation path) lost its token budget — `new RunBudget(recipe.budget)` then enforced nothing. | Pass `budget` through. Regression test in `parser.test.ts`. |
| 2 | **`reconcile` mis-attributed the driver.** Both `runBudget.reconcile()` sites passed the *configured* `driver ?? "auto"`, not the driver that actually ran — per-driver usage/warnings were keyed on a guess (a literal `"auto"` for auto-detected runs). | `executeAgent` (the single place auto-detection resolves) now stamps `servedBy: {driver, model?}`; reconcile prefers it. `AgentResult` widened additively. |
| 3 | **`model_fallback` doc-drift.** The field never existed in `src` — only 4 refs in `examples/recipes/advanced-patterns/` promising a fallback the parser silently ignores. | Docs corrected to point at the forthcoming `downshift:` design. |

## Why it's safe

- `executeAgent`'s deps always return real `AgentResult` objects in production (`buildAgentExecutorDeps` normalizes every dep through `toAgentResult` before `executeAgent` sees it), so stamping `servedBy` can't hit a bare-string path. The `servedBy` field is additive and read only by `reconcile` (which keeps the old guess as a fallback).
- No schema/type removals; `AgentResult.servedBy` and `Recipe.budget` passthrough are purely additive.

## Tests

- `agentExecutor.test.ts`: `servedBy` stamping across all 8 resolution branches + idempotence (a dep's own attribution is not overwritten). *(Updated the loose string-mocks to the real `AgentResult` contract.)*
- `parser.test.ts`: budget round-trip preserved; absent budget stays `undefined`.
- Full `src/recipes` suite **853 green**; `tsc` (main + `tests.core`) + `audit-{test-fixtures,lsp-tools,schema-changes}` all clean.

Phase 0 **part 2** (surface the budget's currently-discarded warnings into the run log; extract the shared agent-step schema const) follows separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)