### PR TITLE
feat(recipes): cost-routing Phase 0 pt2 — surface budget warnings + dedupe agent-step schema

### DIFF
--- a/src/recipes/__tests__/yamlRunner.test.ts
+++ b/src/recipes/__tests__/yamlRunner.test.ts
@@ -3409,6 +3409,13 @@ describe("recipe.budget — tokensMax enforcement (PR2b)", () => {
     expect(calls).toBe(2);
     expect(result.stepResults[0]?.status).toBe("ok");
     expect(result.stepResults[1]?.status).toBe("ok");
+    // Phase 0 pt2: the warn-mode breach warning is now surfaced on the
+    // result (RunBudget.warnings() previously had no production reader).
+    expect(result.budgetWarnings ?? []).toEqual(
+      expect.arrayContaining([
+        expect.stringMatching(/token budget exceeded.*onBreach="warn"/i),
+      ]),
+    );
   });
 
   it("subscription-driver fail-open: no usage = no enforcement", async () => {
@@ -3443,6 +3450,14 @@ describe("recipe.budget — tokensMax enforcement (PR2b)", () => {
     expect(calls).toBe(2);
     expect(result.stepResults[0]?.status).toBe("ok");
     expect(result.stepResults[1]?.status).toBe("ok");
+    // Phase 0 pt2: the unmeasured-driver warning ("does not report token
+    // usage — budget enforcement skipped") is now surfaced, so a user who
+    // set a budget learns it silently did nothing for this driver.
+    expect(result.budgetWarnings ?? []).toEqual(
+      expect.arrayContaining([
+        expect.stringMatching(/does not report token usage/i),
+      ]),
+    );
   });
 
   // Bug (3): the admission check used to live inside the agent branch, so a

--- a/src/recipes/schemaGenerator.ts
+++ b/src/recipes/schemaGenerator.ts
@@ -213,6 +213,74 @@ function generateRecipeSchema(
       },
     },
   };
+  // Single source of truth for the `agent:` step config sub-schema. Used in
+  // BOTH the leaf-step block and the nested/parallel-step block below. These
+  // two blocks had drifted (the leaf block was missing the prompt/model/
+  // driver/into descriptions); sharing one const reconciles that and means a
+  // new agent field (e.g. the forthcoming cost-routing `downshift`) only has
+  // to be added once instead of in two parallel places. Shared by reference,
+  // matching the existing `chainedStepMetadataProperties` pattern (the schema
+  // tree is never mutated in place after generation).
+  const agentStepConfigSchema = {
+    type: "object",
+    required: ["prompt"],
+    description: "Agent step configuration",
+    properties: {
+      prompt: {
+        type: "string",
+        description: "Prompt to send to the AI (supports {{templates}})",
+      },
+      model: {
+        type: "string",
+        description: "Model to use for the agent step",
+      },
+      driver: {
+        type: "string",
+        enum: [
+          "claude",
+          "claude-code",
+          "api",
+          "openai",
+          "grok",
+          "gemini",
+          "anthropic",
+        ],
+        description: "Driver for agent execution",
+      },
+      into: {
+        type: "string",
+        description: "Variable name to store output in context",
+      },
+      mcpAccess: {
+        type: "boolean",
+        description:
+          "When true, grants the agent step access to MCP tools registered on the bridge. Defaults to false for subprocess driver steps.",
+      },
+      kind: {
+        type: "string",
+        enum: ["judge"],
+        description:
+          "When set to 'judge', the agent step emits a structured verdictReason and stores the verdict in the run log.",
+      },
+      reviews: {
+        type: "string",
+        description:
+          "Step output key the judge reviews (its `into`, default 'agent_output'). Required for the judge→refine loop.",
+      },
+      max_revisions: {
+        type: "integer",
+        minimum: 0,
+        description:
+          "OPT-IN judge→refine loop. Max revise→re-judge cycles when the verdict is 'request_changes' (0/absent = augment-only, no loop). Requires kind:judge + reviews.",
+      },
+      on_exhausted: {
+        type: "string",
+        enum: ["halt", "proceed"],
+        description:
+          "When the revision budget is exhausted and the judge still requests changes: 'halt' (default) fails the run; 'proceed' continues with the last draft.",
+      },
+    },
+  };
   const toolRefs = Object.keys(namespaceSchemas).map((ns) => ({
     allOf: [
       {
@@ -264,56 +332,7 @@ function generateRecipeSchema(
       required: ["agent"],
       properties: {
         ...chainedStepMetadataProperties,
-        agent: {
-          type: "object",
-          required: ["prompt"],
-          description: "Agent step configuration",
-          properties: {
-            prompt: { type: "string" },
-            model: { type: "string" },
-            driver: {
-              type: "string",
-              enum: [
-                "claude",
-                "claude-code",
-                "api",
-                "openai",
-                "grok",
-                "gemini",
-                "anthropic",
-              ],
-            },
-            into: { type: "string" },
-            mcpAccess: {
-              type: "boolean",
-              description:
-                "When true, grants the agent step access to MCP tools registered on the bridge. Defaults to false for subprocess driver steps.",
-            },
-            kind: {
-              type: "string",
-              enum: ["judge"],
-              description:
-                "When set to 'judge', the agent step emits a structured verdictReason and stores the verdict in the run log.",
-            },
-            reviews: {
-              type: "string",
-              description:
-                "Step output key the judge reviews (its `into`, default 'agent_output'). Required for the judge→refine loop.",
-            },
-            max_revisions: {
-              type: "integer",
-              minimum: 0,
-              description:
-                "OPT-IN judge→refine loop. Max revise→re-judge cycles when the verdict is 'request_changes' (0/absent = augment-only, no loop). Requires kind:judge + reviews.",
-            },
-            on_exhausted: {
-              type: "string",
-              enum: ["halt", "proceed"],
-              description:
-                "When the revision budget is exhausted and the judge still requests changes: 'halt' (default) fails the run; 'proceed' continues with the last draft.",
-            },
-          },
-        },
+        agent: agentStepConfigSchema,
       },
     },
     {
@@ -522,67 +541,7 @@ function generateRecipeSchema(
               required: ["agent"],
               properties: {
                 ...chainedStepMetadataProperties,
-                agent: {
-                  type: "object",
-                  required: ["prompt"],
-                  description: "Agent step configuration",
-                  properties: {
-                    prompt: {
-                      type: "string",
-                      description:
-                        "Prompt to send to the AI (supports {{templates}})",
-                    },
-                    model: {
-                      type: "string",
-                      description: "Model to use for the agent step",
-                    },
-                    driver: {
-                      type: "string",
-                      enum: [
-                        "claude",
-                        "claude-code",
-                        "api",
-                        "openai",
-                        "grok",
-                        "gemini",
-                        "anthropic",
-                      ],
-                      description: "Driver for agent execution",
-                    },
-                    into: {
-                      type: "string",
-                      description: "Variable name to store output in context",
-                    },
-                    mcpAccess: {
-                      type: "boolean",
-                      description:
-                        "When true, grants the agent step access to MCP tools registered on the bridge. Defaults to false for subprocess driver steps.",
-                    },
-                    kind: {
-                      type: "string",
-                      enum: ["judge"],
-                      description:
-                        "When set to 'judge', the agent step emits a structured verdictReason and stores the verdict in the run log.",
-                    },
-                    reviews: {
-                      type: "string",
-                      description:
-                        "Step output key the judge reviews (its `into`, default 'agent_output'). Required for the judge→refine loop.",
-                    },
-                    max_revisions: {
-                      type: "integer",
-                      minimum: 0,
-                      description:
-                        "OPT-IN judge→refine loop. Max revise→re-judge cycles when the verdict is 'request_changes' (0/absent = augment-only, no loop). Requires kind:judge + reviews.",
-                    },
-                    on_exhausted: {
-                      type: "string",
-                      enum: ["halt", "proceed"],
-                      description:
-                        "When the revision budget is exhausted and the judge still requests changes: 'halt' (default) fails the run; 'proceed' continues with the last draft.",
-                    },
-                  },
-                },
+                agent: agentStepConfigSchema,
               },
             },
             {

--- a/src/recipes/yamlRunner.ts
+++ b/src/recipes/yamlRunner.ts
@@ -555,6 +555,12 @@ export interface RunResult {
   stepResults: StepResult[];
   errorMessage?: string;
   assertionFailures?: AssertionFailure[];
+  /**
+   * Budget warnings collected by RunBudget over the run — warn-mode token
+   * breaches + unmeasured-driver notices. Previously discarded (no reader);
+   * now surfaced so callers and the run log can show them. Absent when none.
+   */
+  budgetWarnings?: string[];
 }
 
 export type StepResult = {
@@ -1759,6 +1765,9 @@ export async function runYamlRecipe(
           ...(runError !== undefined && { errorMessage: runError }),
           ...(assertionFailures.length > 0 ? { assertionFailures } : {}),
           ...(inboxOutputs.length > 0 ? { inboxOutputs } : {}),
+          ...(runBudget.warnings().length > 0
+            ? { budgetWarnings: runBudget.warnings() }
+            : {}),
         });
         emit("recipe_done", {
           runSeq,
@@ -1851,6 +1860,9 @@ export async function runYamlRecipe(
     stepResults,
     errorMessage: runError,
     ...(assertionFailures.length > 0 ? { assertionFailures } : {}),
+    ...(runBudget.warnings().length > 0
+      ? { budgetWarnings: runBudget.warnings() }
+      : {}),
   };
 }
 

--- a/src/runLog.ts
+++ b/src/runLog.ts
@@ -134,6 +134,15 @@ export interface RecipeRun {
    * runs simply omit it.
    */
   inboxOutputs?: Array<{ filename: string; deliveredAt: number }>;
+  /**
+   * Budget warnings surfaced by RunBudget at completion — warn-mode token
+   * breaches and "driver X reports no usage, budget enforcement skipped"
+   * notices. Previously computed and then discarded (RunBudget.warnings()
+   * had no production reader); now persisted so the dashboard / `patchwork`
+   * surfaces can show them. Additive: absent when the run set no budget or
+   * tripped no warnings.
+   */
+  budgetWarnings?: string[];
 }
 
 const MAX_OUTPUT_TAIL = 2_000;
@@ -443,6 +452,7 @@ export class RecipeRunLog {
       errorMessage?: string;
       assertionFailures?: RecipeRun["assertionFailures"];
       inboxOutputs?: RecipeRun["inboxOutputs"];
+      budgetWarnings?: RecipeRun["budgetWarnings"];
     },
   ): void {
     const idx = this.runs.findIndex((r) => r.seq === seq);
@@ -469,6 +479,10 @@ export class RecipeRunLog {
       ...(opts.inboxOutputs !== undefined &&
         opts.inboxOutputs.length > 0 && {
           inboxOutputs: opts.inboxOutputs,
+        }),
+      ...(opts.budgetWarnings !== undefined &&
+        opts.budgetWarnings.length > 0 && {
+          budgetWarnings: opts.budgetWarnings,
         }),
     };
     this.runs[idx] = finalized;


### PR DESCRIPTION
Second Phase 0 substrate PR (design: [`docs/design/cost-aware-routing.md`](../blob/main/docs/design/cost-aware-routing.md), landed in #861). **No new user config; runtime behaviour byte-identical** — except previously-dead output now surfaces. Independent of #861 (different file regions; clean auto-merge either order).

## (c) Surface budget warnings

`RunBudget.warnings()` — warn-mode token breaches and *"driver X reports no usage → budget enforcement skipped"* notices — was computed every run and then **discarded** (`warnings()`/`totals()` had zero production readers). So a user who set `budget.tokensMax` on the token-blind subscription default driver got **silent non-enforcement with no signal**.

Now threaded onto:
- `RunResult.budgetWarnings` (in-process return), and
- the persisted run-log record (`RecipeRun.budgetWarnings`, via `completeRun`),

so the dashboard / `patchwork` surfaces can show them. Additive + optional (absent when no budget set or no warnings tripped).

## (d) Dedupe the agent-step schema

The leaf-step and nested/parallel-step `agent:` config blocks in `schemaGenerator` were maintained separately and had **already drifted** — the leaf block was missing the `prompt/model/driver/into` descriptions the nested block carries. Extracted a single `agentStepConfigSchema` const referenced by both (matching the existing `chainedStepMetadataProperties` shared-by-reference pattern), so a new agent field — e.g. the forthcoming cost-routing `downshift` — is added **once** instead of in two parallel `anyOf` branches where adding to only one is silently rejected.

- Validation behaviour unchanged (`description` is annotation-only); the leaf block now also carries the field descriptions (drift reconciled).
- Committed `schemas/recipe.v1.json` is a **release-time artifact** (regenerated wholesale at release; no per-PR freshness gate — a fresh regen today sweeps in ~1200 lines of unrelated accumulated drift from the connector campaign + #859), so it is **not** bumped here.

## Tests

The two existing PR2b budget tests (warn-mode breach + subscription fail-open) now also assert the matching warning surfaces on `result.budgetWarnings`. Full recipes + runLog + schema suites **888 green**; `tsc` (main + `tests.core`) + audit gates clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)