### PR TITLE
feat(recipes): cost-routing Phase 1 — API drivers report tokens

### DIFF
--- a/src/drivers/__tests__/claude-api.test.ts
+++ b/src/drivers/__tests__/claude-api.test.ts
@@ -47,6 +47,29 @@ describe("ApiDriver", () => {
     expect(result.exitCode).toBe(0);
   });
 
+  it("forwards token usage from message.usage into providerMeta", async () => {
+    mockCreate.mockResolvedValue({
+      model: "claude-haiku-4-5-20251001",
+      content: [{ type: "text", text: "hi" }],
+      usage: { input_tokens: 10, output_tokens: 20 },
+    });
+    const driver = new ApiDriver(log);
+    const result = await driver.run(makeInput());
+    expect(result.providerMeta).toEqual({
+      model: "claude-haiku-4-5-20251001",
+      inputTokens: 10,
+      outputTokens: 20,
+    });
+  });
+
+  it("omits token counts when usage is absent (fail-open)", async () => {
+    mockCreate.mockResolvedValue({ content: [{ type: "text", text: "hi" }] });
+    const driver = new ApiDriver(log);
+    const result = await driver.run(makeInput({ model: "claude-x" }));
+    // model falls back to input.model; no token fields → RunBudget skips it.
+    expect(result.providerMeta).toEqual({ model: "claude-x" });
+  });
+
   // Bug 2 regression: ProviderDriver.run must resolve, never reject. Before the
   // try/catch was added, a rejecting messages.create propagated the rejection.
   it("resolves with errorMessage when messages.create throws (does not reject)", async () => {

--- a/src/drivers/__tests__/openai.test.ts
+++ b/src/drivers/__tests__/openai.test.ts
@@ -42,6 +42,21 @@ function makeStream(chunks: string[]): AsyncIterable<unknown> {
   };
 }
 
+/** Stream that ends with an include_usage final chunk (empty choices + usage). */
+function makeStreamWithUsage(
+  chunks: string[],
+  usage: { prompt_tokens: number; completion_tokens: number },
+): AsyncIterable<unknown> {
+  return {
+    [Symbol.asyncIterator]: async function* () {
+      for (const c of chunks) {
+        yield { choices: [{ delta: { content: c } }] };
+      }
+      yield { choices: [], usage };
+    },
+  };
+}
+
 describe("OpenAIApiDriver", () => {
   it("streams chunks and returns concatenated text", async () => {
     mockCreate.mockResolvedValue(makeStream(["Hello", ", ", "world"]));
@@ -57,6 +72,42 @@ describe("OpenAIApiDriver", () => {
     expect(result.text).toBe("Hello, world");
     expect(chunks).toEqual(["Hello", ", ", "world"]);
     expect(result.durationMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it("requests usage and captures it from the include_usage final chunk", async () => {
+    mockCreate.mockResolvedValue(
+      makeStreamWithUsage(["Hi"], { prompt_tokens: 12, completion_tokens: 8 }),
+    );
+    const driver = new OpenAIApiDriver(log);
+    const result = await driver.run({
+      prompt: "hi",
+      workspace: "/tmp",
+      timeoutMs: 5000,
+      signal: AbortSignal.timeout(5000),
+    });
+    expect(result.text).toBe("Hi");
+    expect(result.providerMeta).toMatchObject({
+      inputTokens: 12,
+      outputTokens: 8,
+    });
+    // The usage chunk must have been requested.
+    expect(mockCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ stream_options: { include_usage: true } }),
+      expect.anything(),
+    );
+  });
+
+  it("omits token counts when the endpoint returns no usage chunk", async () => {
+    mockCreate.mockResolvedValue(makeStream(["ok"]));
+    const driver = new OpenAIApiDriver(log);
+    const result = await driver.run({
+      prompt: "hi",
+      workspace: "/tmp",
+      timeoutMs: 5000,
+      signal: AbortSignal.timeout(5000),
+    });
+    // Fail-open: model only, no token fields (RunBudget then skips this call).
+    expect(result.providerMeta).toEqual({ model: "gpt-4o" });
   });
 
   it("returns errorMessage on API failure", async () => {

--- a/src/drivers/claude/api.ts
+++ b/src/drivers/claude/api.ts
@@ -80,7 +80,8 @@ export class ApiDriver implements ProviderDriver {
     }
 
     // biome-ignore lint/suspicious/noExplicitAny: message is from dynamically imported optional dep
-    const content = (message as any).content as Array<{
+    const msg = message as any;
+    const content = msg.content as Array<{
       type: string;
       text?: string;
     }>;
@@ -91,10 +92,22 @@ export class ApiDriver implements ProviderDriver {
 
     input.onChunk?.(text);
 
+    // The SDK returns usage on every message; forward it so RunBudget can
+    // enforce a real token/USD budget. Both fields together or neither.
+    const inputTokens = msg.usage?.input_tokens;
+    const outputTokens = msg.usage?.output_tokens;
+    const model = typeof msg.model === "string" ? msg.model : input.model;
+
     return {
       text: text.slice(0, OUTPUT_CAP),
       exitCode: 0,
       durationMs: Date.now() - start,
+      providerMeta: {
+        ...(model !== undefined ? { model } : {}),
+        ...(typeof inputTokens === "number" && typeof outputTokens === "number"
+          ? { inputTokens, outputTokens }
+          : {}),
+      },
     };
   }
 }

--- a/src/drivers/openai/index.ts
+++ b/src/drivers/openai/index.ts
@@ -96,6 +96,8 @@ export class OpenAIApiDriver implements ProviderDriver {
 
     let text = "";
     let firstChunkAt: number | undefined;
+    let promptTokens: number | undefined;
+    let completionTokens: number | undefined;
 
     try {
       // biome-ignore lint/suspicious/noExplicitAny: dynamic import shape
@@ -106,12 +108,27 @@ export class OpenAIApiDriver implements ProviderDriver {
           ...(temperature !== undefined ? { temperature } : {}),
           messages,
           stream: true,
+          // Ask the API to emit a final usage chunk (prompt/completion token
+          // counts) so RunBudget can enforce a real token/USD budget instead
+          // of failing open. Compliant OpenAI-style endpoints return it; an
+          // endpoint that ignores the option simply omits usage and we fail
+          // open (providerMeta carries no tokens).
+          stream_options: { include_usage: true },
         },
         { signal: input.signal },
       );
 
       // biome-ignore lint/suspicious/noExplicitAny: stream shape from dynamic import
       for await (const chunk of stream as AsyncIterable<any>) {
+        // The include_usage final chunk carries an empty `choices` array and a
+        // `usage` object; capture it whenever present (so it works even if an
+        // endpoint attaches usage to a content-bearing chunk).
+        if (chunk.usage) {
+          if (typeof chunk.usage.prompt_tokens === "number")
+            promptTokens = chunk.usage.prompt_tokens;
+          if (typeof chunk.usage.completion_tokens === "number")
+            completionTokens = chunk.usage.completion_tokens;
+        }
         const delta: string = chunk.choices?.[0]?.delta?.content ?? "";
         if (delta) {
           if (firstChunkAt === undefined) firstChunkAt = Date.now();
@@ -161,7 +178,14 @@ export class OpenAIApiDriver implements ProviderDriver {
       text: text.slice(0, OUTPUT_CAP),
       durationMs: Date.now() - start,
       startupMs: firstChunkAt !== undefined ? firstChunkAt - start : undefined,
-      providerMeta: { model },
+      providerMeta: {
+        model,
+        // Present only when the endpoint returned a usage chunk. Both fields
+        // together or neither — a half-populated count would mislead budgets.
+        ...(promptTokens !== undefined && completionTokens !== undefined
+          ? { inputTokens: promptTokens, outputTokens: completionTokens }
+          : {}),
+      },
     };
   }
 

--- a/src/recipes/__tests__/providerMetaToUsage.test.ts
+++ b/src/recipes/__tests__/providerMetaToUsage.test.ts
@@ -1,0 +1,35 @@
+/**
+ * Phase 1 (cost-aware routing) — the providerMeta → AgentUsage mapper that lets
+ * makeProviderDriverFn forward openai/grok/gemini token counts to RunBudget.
+ * Both counts must be present as numbers; a half-populated count is dropped so
+ * a budget is never enforced on a misleading partial figure.
+ */
+import { describe, expect, it } from "vitest";
+import { providerMetaToUsage } from "../yamlRunner.js";
+
+describe("providerMetaToUsage", () => {
+  it("maps both token counts to AgentUsage", () => {
+    expect(
+      providerMetaToUsage({ model: "x", inputTokens: 12, outputTokens: 8 }),
+    ).toEqual({ inputTokens: 12, outputTokens: 8 });
+  });
+
+  it("returns undefined when meta is undefined", () => {
+    expect(providerMetaToUsage(undefined)).toBeUndefined();
+  });
+
+  it("returns undefined when only one count is present", () => {
+    expect(providerMetaToUsage({ inputTokens: 12 })).toBeUndefined();
+    expect(providerMetaToUsage({ outputTokens: 8 })).toBeUndefined();
+  });
+
+  it("returns undefined for non-number counts", () => {
+    expect(
+      providerMetaToUsage({ inputTokens: "12", outputTokens: "8" }),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined for a model-only meta (no usage reported)", () => {
+    expect(providerMetaToUsage({ model: "gpt-4o" })).toBeUndefined();
+  });
+});

--- a/src/recipes/__tests__/yamlRunner.test.ts
+++ b/src/recipes/__tests__/yamlRunner.test.ts
@@ -2587,7 +2587,10 @@ describe("makeProviderDriverFn — surfaces provider failure cause", () => {
     const fn = makeProviderDriverFn();
     const out = await fn("openai", "hello", undefined);
     // 200-char cap on the message fragment (plus the surrounding marker text).
-    expect(out.length).toBeLessThan(260);
+    // Error paths return the bare marker string; narrow for the union.
+    expect(typeof out === "string" ? out.length : out.text.length).toBeLessThan(
+      260,
+    );
   });
 
   it("still reports generic empty-output when there is no error signal", async () => {
@@ -2597,11 +2600,25 @@ describe("makeProviderDriverFn — surfaces provider failure cause", () => {
     expect(out).toContain("returned empty output");
   });
 
-  it("returns text unchanged on success", async () => {
+  it("returns text unchanged on success (no usage → bare string)", async () => {
     mockProviderRun.mockResolvedValueOnce({ text: "all good", durationMs: 5 });
     const fn = makeProviderDriverFn();
     const out = await fn("openai", "hello", undefined);
     expect(out).toBe("all good");
+  });
+
+  it("forwards token usage when the driver reports it (Phase 1)", async () => {
+    mockProviderRun.mockResolvedValueOnce({
+      text: "all good",
+      durationMs: 5,
+      providerMeta: { model: "gpt-4o", inputTokens: 30, outputTokens: 12 },
+    });
+    const fn = makeProviderDriverFn();
+    const out = await fn("openai", "hello", undefined);
+    expect(out).toEqual({
+      text: "all good",
+      usage: { inputTokens: 30, outputTokens: 12 },
+    });
   });
 });
 
@@ -3348,6 +3365,49 @@ describe("recipe.budget — tokensMax enforcement (PR2b)", () => {
     });
     expect(calls).toBe(1); // second admission refused
     expect(result.stepResults).toHaveLength(2);
+    expect(result.stepResults[0]?.status).toBe("ok");
+    expect(result.stepResults[1]?.status).toBe("error");
+    expect(result.stepResults[1]?.haltReason).toMatch(/budget_exceeded/);
+  });
+
+  it("enforces the budget on the openai/grok/gemini path (Phase 1: these now report usage)", async () => {
+    // Before Phase 1, makeProviderDriverFn returned a bare string and usage
+    // was dropped, so openai/grok/gemini agent steps ALWAYS failed open even
+    // with a budget set. With usage now forwarded, the provider path halts
+    // like the anthropic path does.
+    const recipe = makeRecipe({
+      budget: { tokensMax: 100 },
+      steps: [
+        {
+          agent: {
+            prompt: "s1",
+            driver: "openai",
+            model: "gpt-4o",
+            into: "o1",
+          },
+        },
+        {
+          agent: {
+            prompt: "s2",
+            driver: "openai",
+            model: "gpt-4o",
+            into: "o2",
+          },
+        },
+      ],
+    });
+    let calls = 0;
+    const result = await runYamlRecipe(recipe, {
+      ...noop(),
+      providerDriverFn: async () => {
+        calls++;
+        return {
+          text: `output ${calls}`,
+          usage: { inputTokens: 60, outputTokens: 60 },
+        };
+      },
+    });
+    expect(calls).toBe(1); // second admission refused
     expect(result.stepResults[0]?.status).toBe("ok");
     expect(result.stepResults[1]?.status).toBe("error");
     expect(result.stepResults[1]?.haltReason).toMatch(/budget_exceeded/);

--- a/src/recipes/yamlRunner.ts
+++ b/src/recipes/yamlRunner.ts
@@ -56,6 +56,7 @@ import {
   executeAgent as _executeAgent,
   type AgentExecutorDeps,
   type AgentResult,
+  type AgentUsage,
 } from "./agentExecutor.js";
 import { categoriseHaltReason, type HaltCategory } from "./haltCategory.js";
 import {
@@ -2319,18 +2320,35 @@ export function defaultClaudeCodeFn(
   }
 }
 
+/**
+ * Map a driver's `providerMeta` to AgentUsage. Returns undefined unless BOTH
+ * token counts are present as numbers — a half-populated count would mislead
+ * RunBudget. Pure + exported for tests.
+ */
+export function providerMetaToUsage(
+  meta: Record<string, unknown> | undefined,
+): AgentUsage | undefined {
+  if (!meta) return undefined;
+  const inputTokens = meta.inputTokens;
+  const outputTokens = meta.outputTokens;
+  if (typeof inputTokens === "number" && typeof outputTokens === "number") {
+    return { inputTokens, outputTokens };
+  }
+  return undefined;
+}
+
 /** Returns a providerDriverFn with a per-run driver cache (not shared across runs). */
 export function makeProviderDriverFn(): (
   driverName: "openai" | "grok" | "gemini",
   prompt: string,
   model: string | undefined,
-) => Promise<string> {
+) => Promise<string | AgentResult> {
   const cache = new Map<string, import("../drivers/types.js").ProviderDriver>();
   return async function defaultProviderDriverFn(
     driverName: "openai" | "grok" | "gemini",
     prompt: string,
     model: string | undefined,
-  ): Promise<string> {
+  ): Promise<string | AgentResult> {
     try {
       let driver = cache.get(driverName);
       if (!driver) {
@@ -2376,7 +2394,11 @@ export function makeProviderDriverFn(): (
         if (!result.text) {
           return `[agent step failed: ${driverName} returned empty output (possible timeout or auth error)]`;
         }
-        return result.text;
+        // Forward token usage (when the driver reported it) so RunBudget can
+        // enforce a real budget for openai/grok/gemini instead of failing
+        // open. No usage → bare string, normalised to {text} downstream.
+        const usage = providerMetaToUsage(result.providerMeta);
+        return usage ? { text: result.text, usage } : result.text;
       } finally {
         clearTimeout(timeout);
       }


### PR DESCRIPTION
Closes the *"provider drivers always unmeasured"* gap (design: [`docs/design/cost-aware-routing.md`](../blob/main/docs/design/cost-aware-routing.md)). Until now `makeProviderDriverFn` returned a bare string and `ApiDriver` discarded the usage the SDK already returns, so a recipe `budget.tokensMax` **silently failed open** for the API drivers. This makes them measurable — the prerequisite for USD enforcement (Phase 3).

## Changes

- **`OpenAIApiDriver.run()`** requests `stream_options: {include_usage: true}` and captures the final usage chunk into `providerMeta {model, inputTokens, outputTokens}`. `GrokApiDriver` / `GeminiApiDriver` / `LocalApiDriver` inherit it. An endpoint that ignores the option just omits usage → **fail open** (no tokens).
- **`ApiDriver`** (Anthropic SDK) forwards the `message.usage` it previously discarded. Standardizes the `providerMeta {model, inputTokens, outputTokens}` convention across API drivers.
- **`makeProviderDriverFn`** now returns `string | AgentResult`, mapping `providerMeta → usage` via a new pure, exported `providerMetaToUsage` (both counts required as numbers, else dropped). Error paths stay bare strings; `toAgentResult` normalizes downstream — no type cascade (`StepDeps.providerDriverFn` was already `string | AgentResult`).

## ⚠️ Behaviour shift (scoped)

A recipe that **already** sets `budget.tokensMax` **and** uses the `openai` or `grok` agent driver will now be **measured** and can begin **halting** on breach — it failed open before. Limited to exactly that intersection.

- `gemini` (recipe driver) → Gemini **CLI subprocess** (subscription, no token counts → still fail-open, correctly).
- `local` (recipe driver) → separate local adapter (unaffected).

## Tests

- `providerMetaToUsage` unit table (both/one/none/non-number/model-only).
- `OpenAIApiDriver`: usage-chunk capture + `stream_options` requested + no-usage fail-open.
- `ApiDriver`: `message.usage → providerMeta`; absent-usage fail-open.
- `makeProviderDriverFn`: success-with-usage returns `{text, usage}`.
- **Integration**: an `openai`-driver recipe with `budget.tokensMax` now **halts** on breach (the changelog behaviour, pinned).

Full drivers + recipes suites **948 green**; `tsc` (main + `tests.core`) + audit gates clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)