### PR TITLE
feat(recipes): cost-routing Phase 2 — static model price table (dormant)

### DIFF
--- a/src/recipes/pricing/__tests__/priceTable.test.ts
+++ b/src/recipes/pricing/__tests__/priceTable.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Cost-aware routing Phase 2 — price table data + loader.
+ * Pins the override precedence (env > ~/.patchwork > built-in), fail-open on
+ * unknown model / malformed override, costUsd math, and the pure staleness
+ * helper. The table itself is dormant (no consumer yet) — these tests are the
+ * contract Phase 3's RunBudget will build on.
+ */
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  BUILTIN_PRICE_TABLE,
+  costUsd,
+  isPriceTableStale,
+  loadPriceTable,
+  priceFor,
+} from "../priceTable.js";
+
+let tmp = "";
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), "pw-prices-"));
+});
+afterEach(() => {
+  if (tmp) rmSync(tmp, { recursive: true, force: true });
+});
+
+function writeHomePrices(home: string, json: unknown): void {
+  mkdirSync(join(home, ".patchwork"), { recursive: true });
+  writeFileSync(join(home, ".patchwork", "prices.json"), JSON.stringify(json));
+}
+
+describe("BUILTIN_PRICE_TABLE", () => {
+  it("every entry has non-negative numeric input/output prices", () => {
+    for (const [model, p] of Object.entries(BUILTIN_PRICE_TABLE.prices)) {
+      expect(typeof p.input, model).toBe("number");
+      expect(typeof p.output, model).toBe("number");
+      expect(p.input, model).toBeGreaterThanOrEqual(0);
+      expect(p.output, model).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  it("carries a parseable, non-future _generatedAt that is not yet stale", () => {
+    const { _generatedAt } = BUILTIN_PRICE_TABLE._meta;
+    expect(Number.isNaN(Date.parse(_generatedAt))).toBe(false);
+    expect(isPriceTableStale(_generatedAt, Date.now())).toBe(false);
+  });
+
+  it("prices the default agent model (claude-haiku-4-5-20251001)", () => {
+    expect(priceFor("claude-haiku-4-5-20251001")).toBeDefined();
+  });
+});
+
+describe("costUsd", () => {
+  it("computes input+output cost from per-million prices", () => {
+    // gpt-4o = $2.5/1M in, $10/1M out. 400k in + 100k out = 1.0 + 1.0 = $2.00.
+    const cost = costUsd("gpt-4o", {
+      inputTokens: 400_000,
+      outputTokens: 100_000,
+    });
+    expect(cost).toBeCloseTo(2.0, 6);
+  });
+
+  it("returns undefined for an unpriced model (fail-open)", () => {
+    expect(
+      costUsd("some-unknown-model", { inputTokens: 1000, outputTokens: 1000 }),
+    ).toBeUndefined();
+  });
+});
+
+describe("loadPriceTable precedence", () => {
+  it("returns the built-in table when no override exists", () => {
+    const t = loadPriceTable({ env: {}, homeDir: tmp });
+    expect(t.prices).toEqual(BUILTIN_PRICE_TABLE.prices);
+    expect(t._meta._override).toBeUndefined();
+  });
+
+  it("merges ~/.patchwork/prices.json over the built-in", () => {
+    writeHomePrices(tmp, {
+      prices: {
+        "gpt-4o": { input: 99, output: 99 }, // override existing
+        "my-local-model": { input: 0, output: 0 }, // add new
+      },
+    });
+    const t = loadPriceTable({ env: {}, homeDir: tmp });
+    expect(t.prices["gpt-4o"]).toEqual({ input: 99, output: 99 });
+    expect(t.prices["my-local-model"]).toEqual({ input: 0, output: 0 });
+    // untouched built-in entries survive
+    expect(t.prices["claude-haiku-4-5-20251001"]).toEqual(
+      BUILTIN_PRICE_TABLE.prices["claude-haiku-4-5-20251001"],
+    );
+    expect(t._meta._override).toContain("prices.json");
+  });
+
+  it("env PATCHWORK_PRICE_TABLE takes precedence over ~/.patchwork", () => {
+    writeHomePrices(tmp, { prices: { "gpt-4o": { input: 1, output: 1 } } });
+    const envFile = join(tmp, "env-prices.json");
+    writeFileSync(
+      envFile,
+      JSON.stringify({ prices: { "gpt-4o": { input: 42, output: 42 } } }),
+    );
+    const t = loadPriceTable({
+      env: { PATCHWORK_PRICE_TABLE: envFile },
+      homeDir: tmp,
+    });
+    expect(t.prices["gpt-4o"]).toEqual({ input: 42, output: 42 });
+  });
+
+  it("accepts a bare {model: price} map (no wrapping `prices`)", () => {
+    writeHomePrices(tmp, { "gpt-4o": { input: 7, output: 7 } });
+    const t = loadPriceTable({ env: {}, homeDir: tmp });
+    expect(t.prices["gpt-4o"]).toEqual({ input: 7, output: 7 });
+  });
+
+  it("ignores malformed entries but keeps valid ones", () => {
+    writeHomePrices(tmp, {
+      prices: {
+        "gpt-4o": { input: "free", output: 5 }, // bad input type → skipped
+        "ok-model": { input: 1, output: 2 }, // valid → kept
+      },
+    });
+    const t = loadPriceTable({ env: {}, homeDir: tmp });
+    expect(t.prices["gpt-4o"]).toEqual(BUILTIN_PRICE_TABLE.prices["gpt-4o"]);
+    expect(t.prices["ok-model"]).toEqual({ input: 1, output: 2 });
+  });
+
+  it("fails open to the built-in on unreadable / malformed JSON", () => {
+    mkdirSync(join(tmp, ".patchwork"), { recursive: true });
+    writeFileSync(join(tmp, ".patchwork", "prices.json"), "{ not valid json");
+    const t = loadPriceTable({ env: {}, homeDir: tmp });
+    expect(t.prices).toEqual(BUILTIN_PRICE_TABLE.prices);
+  });
+});
+
+describe("isPriceTableStale", () => {
+  const now = Date.parse("2026-06-10T00:00:00Z");
+
+  it("is false for a recent date", () => {
+    expect(isPriceTableStale("2026-06-03", now)).toBe(false);
+  });
+
+  it("is true past the max age", () => {
+    expect(isPriceTableStale("2020-01-01", now)).toBe(true);
+  });
+
+  it("is true for a future date", () => {
+    expect(isPriceTableStale("2099-01-01", now)).toBe(true);
+  });
+
+  it("is true for an unparseable date", () => {
+    expect(isPriceTableStale("not-a-date", now)).toBe(true);
+  });
+
+  it("honours a custom maxAgeDays", () => {
+    // 100 days old, threshold 30 → stale.
+    const old = Date.parse("2026-03-02T00:00:00Z");
+    expect(isPriceTableStale("2026-03-02", old + 100 * 86_400_000, 30)).toBe(
+      true,
+    );
+  });
+});

--- a/src/recipes/pricing/priceTable.ts
+++ b/src/recipes/pricing/priceTable.ts
@@ -1,0 +1,183 @@
+/**
+ * Model price table — cost-aware routing Phase 2 (dormant data).
+ *
+ * A `(model id) → USD-per-million-tokens` table plus a loader. Nothing
+ * consumes it yet; Phase 3 wires `costUsd()` into RunBudget so `budget.usdMax`
+ * can be enforced for *measured* (API) drivers. Lands separately so the price
+ * data can be reviewed for accuracy on its own.
+ *
+ * Design notes (docs/design/cost-aware-routing.md):
+ *   - Prices are DATA, not code, and OVERRIDABLE without a release:
+ *       precedence  env `PATCHWORK_PRICE_TABLE` (path)  >
+ *                   `~/.patchwork/prices.json`          >
+ *                   the built-in table below.
+ *   - FAIL-OPEN everywhere: an unknown model, a malformed override, or a
+ *     missing file never throws — `costUsd` just returns `undefined` (and the
+ *     budget layer treats that as "unpriceable → don't enforce").
+ *   - The built-in default lives here as a TS const (compiled into dist, so it
+ *     is always available at runtime); overrides are JSON read from disk.
+ *   - NO runtime network calls. Prices drift; refresh the const below and bump
+ *     `_generatedAt`. `isPriceTableStale()` is provided for a scheduled check.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+/** USD per 1,000,000 tokens, split by input vs output. */
+export interface ModelPrice {
+  input: number;
+  output: number;
+}
+
+export interface PriceTableMeta {
+  /** ISO date (YYYY-MM-DD) the built-in prices were last reviewed. */
+  _generatedAt: string;
+  _unit: "usd_per_million_tokens";
+  _source: string;
+  _note: string;
+  /** Set by the loader when an override file was merged in. */
+  _override?: string;
+}
+
+export interface PriceTable {
+  _meta: PriceTableMeta;
+  /** Keyed by exact model id (e.g. "gpt-4o", "claude-haiku-4-5-20251001"). */
+  prices: Record<string, ModelPrice>;
+}
+
+/**
+ * Built-in default prices. **Approximate public list prices** (USD / 1M tokens)
+ * as of `_generatedAt` — VERIFY before relying on a USD cap; they drift, and a
+ * subscription/CLI driver's spend is notional, not real money out. Override via
+ * `~/.patchwork/prices.json` or `PATCHWORK_PRICE_TABLE`.
+ */
+export const BUILTIN_PRICE_TABLE: PriceTable = {
+  _meta: {
+    _generatedAt: "2026-06-03",
+    _unit: "usd_per_million_tokens",
+    _source: "provider public list prices",
+    _note:
+      "Approximate list prices (USD per 1M tokens). Review before relying on budget.usdMax; override via ~/.patchwork/prices.json or PATCHWORK_PRICE_TABLE.",
+  },
+  prices: {
+    // Anthropic (Claude 4.x)
+    "claude-opus-4-8": { input: 15, output: 75 },
+    "claude-sonnet-4-6": { input: 3, output: 15 },
+    "claude-haiku-4-5-20251001": { input: 1, output: 5 },
+    // OpenAI
+    "gpt-4o": { input: 2.5, output: 10 },
+    "gpt-4o-mini": { input: 0.15, output: 0.6 },
+    // xAI (Grok)
+    "grok-2-latest": { input: 2, output: 10 },
+    // Google (Gemini, API-keyed)
+    "gemini-2.5-pro": { input: 1.25, output: 10 },
+    "gemini-2.5-flash": { input: 0.3, output: 2.5 },
+  },
+};
+
+const MS_PER_DAY = 86_400_000;
+
+/** Resolve the override file path per the precedence rule (or undefined). */
+function resolveOverridePath(
+  env: NodeJS.ProcessEnv,
+  homeDir: string,
+): string | undefined {
+  const envPath = env.PATCHWORK_PRICE_TABLE;
+  if (typeof envPath === "string" && envPath.trim()) return envPath.trim();
+  const filePath = join(homeDir, ".patchwork", "prices.json");
+  return existsSync(filePath) ? filePath : undefined;
+}
+
+/** Extract a valid `{input, output}` price from an unknown override entry. */
+function coercePrice(value: unknown): ModelPrice | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const v = value as Record<string, unknown>;
+  if (typeof v.input === "number" && typeof v.output === "number") {
+    return { input: v.input, output: v.output };
+  }
+  return undefined;
+}
+
+/**
+ * Load the effective price table: the built-in default with any override file
+ * merged over its `prices`. Fail-open — an unreadable / malformed override is
+ * ignored and the built-in is returned unchanged.
+ *
+ * Override file shape: `{ "prices": { "<model>": { "input": N, "output": N } } }`
+ * (a bare `{ "<model>": { ... } }` map is also accepted for convenience).
+ */
+export function loadPriceTable(
+  opts: { env?: NodeJS.ProcessEnv; homeDir?: string } = {},
+): PriceTable {
+  const env = opts.env ?? process.env;
+  const homeDir = opts.homeDir ?? homedir();
+  const overridePath = resolveOverridePath(env, homeDir);
+  if (!overridePath) return BUILTIN_PRICE_TABLE;
+
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(overridePath, "utf8"));
+    const root = (parsed ?? {}) as Record<string, unknown>;
+    const rawPrices =
+      root.prices && typeof root.prices === "object" ? root.prices : root;
+
+    const merged: Record<string, ModelPrice> = {
+      ...BUILTIN_PRICE_TABLE.prices,
+    };
+    for (const [model, entry] of Object.entries(
+      rawPrices as Record<string, unknown>,
+    )) {
+      const price = coercePrice(entry);
+      if (price) merged[model] = price;
+    }
+    return {
+      _meta: { ...BUILTIN_PRICE_TABLE._meta, _override: overridePath },
+      prices: merged,
+    };
+  } catch {
+    // Malformed / unreadable override → fail open to the built-in table.
+    return BUILTIN_PRICE_TABLE;
+  }
+}
+
+/** Price for one model, or undefined if the table does not list it. */
+export function priceFor(
+  model: string,
+  table: PriceTable = loadPriceTable(),
+): ModelPrice | undefined {
+  return table.prices[model];
+}
+
+/**
+ * USD cost of a call given its token usage, or `undefined` when the model is
+ * not priced (fail-open: the budget layer then declines to enforce on it).
+ */
+export function costUsd(
+  model: string,
+  usage: { inputTokens: number; outputTokens: number },
+  table: PriceTable = loadPriceTable(),
+): number | undefined {
+  const price = priceFor(model, table);
+  if (!price) return undefined;
+  return (
+    (usage.inputTokens / 1_000_000) * price.input +
+    (usage.outputTokens / 1_000_000) * price.output
+  );
+}
+
+/**
+ * True when the table's `_generatedAt` is unparseable, in the future, or older
+ * than `maxAgeDays` (default 548 ≈ 18 months). Pure — caller supplies `now` —
+ * so a scheduled job can fail loudly without baking a wall-clock time-bomb into
+ * every PR's test run.
+ */
+export function isPriceTableStale(
+  generatedAt: string,
+  now: number,
+  maxAgeDays = 548,
+): boolean {
+  const t = Date.parse(generatedAt);
+  if (Number.isNaN(t)) return true;
+  if (t > now) return true;
+  return now - t > maxAgeDays * MS_PER_DAY;
+}


### PR DESCRIPTION
The `(model id → USD-per-million-tokens)` price table + loader that **Phase 3** will wire into `RunBudget` for `budget.usdMax`. Lands on its own — **consumed by nobody yet** — so the price *data* can be reviewed for accuracy independently of the enforcement logic. Design: [`docs/design/cost-aware-routing.md`](../blob/main/docs/design/cost-aware-routing.md).

## `src/recipes/pricing/priceTable.ts`

- **`BUILTIN_PRICE_TABLE`** — a TS const (compiled into `dist`, always available at runtime; sidesteps the "tsc doesn't copy `.json` to dist" trap). Approximate **public list prices** with a dated `_meta`, clearly labelled *"verify before relying on a USD cap."* → **please sanity-check the numbers.**
- **`loadPriceTable()`** — override precedence: env `PATCHWORK_PRICE_TABLE` (path) > `~/.patchwork/prices.json` > built-in. **Fail-open** — unknown model, malformed override, or missing file never throws.
- **`costUsd(model, usage)`** → `number | undefined` (undefined = unpriced → the budget layer declines to enforce). No runtime network calls.
- **`isPriceTableStale(generatedAt, now, maxAgeDays=548)`** — a *pure* staleness helper (caller supplies `now`).

## On the design's "CI staleness ratchet"

Implemented as the **pure `isPriceTableStale` helper + a structural test** (built-in prices numeric, `_meta` parseable + non-future + not-yet-stale) **rather than a blocking wall-clock gate on every PR**. A time-based hard-fail would eventually break an unrelated PR for a reason that has nothing to do with it — an anti-pattern. The helper is ready to wire into a scheduled (non-PR) job that fails loudly. Flagging this as a deliberate deviation from the written design.

## Tests (16)

Override precedence (env > home > built-in); bare-map + wrapped override forms; malformed-entry skip; fail-open on bad JSON; `costUsd` math; `isPriceTableStale` table (recent / old / future / unparseable / custom max-age). Temp dirs via `os.tmpdir()` (fixture gate). `tsc` (main + `tests.core`) + audit gates clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)