### PR TITLE
feat(recipes): cost-routing Phase 3 — budget.usdMax enforcement

### DIFF
--- a/src/recipes/__tests__/budgetValidation.test.ts
+++ b/src/recipes/__tests__/budgetValidation.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Recipe budget validation — cost-routing Phase 3 closes a real gap: before
+ * this, validateRecipeDefinition had NO budget checks, so `tokensMax: -5` or
+ * `usdMax: "lots"` linted clean and only misbehaved at runtime.
+ */
+import { describe, expect, it } from "vitest";
+import { validateRecipeDefinition } from "../validation.js";
+
+const BASE = {
+  name: "b",
+  version: "1.0.0",
+  trigger: { type: "manual" },
+  steps: [{ id: "s", agent: { prompt: "hi" } }],
+};
+
+function budgetErrors(budget: unknown): string {
+  const r = validateRecipeDefinition({ ...BASE, budget });
+  return r.issues
+    .filter((i) => i.level === "error")
+    .map((i) => i.message)
+    .join(" | ");
+}
+
+describe("recipe budget validation", () => {
+  it("accepts a valid budget (tokensMax + usdMax + onBreach)", () => {
+    expect(
+      budgetErrors({ tokensMax: 1000, usdMax: 2.5, onBreach: "warn" }),
+    ).toBe("");
+  });
+
+  it("accepts an absent budget", () => {
+    expect(validateRecipeDefinition(BASE).errors).toBe(0);
+  });
+
+  it("rejects a non-positive tokensMax (the previously-missing check)", () => {
+    expect(budgetErrors({ tokensMax: -5 })).toMatch(
+      /tokensMax must be a positive number/,
+    );
+    expect(budgetErrors({ tokensMax: 0 })).toMatch(
+      /tokensMax must be a positive number/,
+    );
+  });
+
+  it("rejects a non-numeric / non-positive usdMax", () => {
+    expect(budgetErrors({ usdMax: "lots" })).toMatch(
+      /usdMax must be a positive number/,
+    );
+    expect(budgetErrors({ usdMax: 0 })).toMatch(
+      /usdMax must be a positive number/,
+    );
+  });
+
+  it("rejects an invalid onBreach", () => {
+    expect(budgetErrors({ tokensMax: 10, onBreach: "explode" })).toMatch(
+      /onBreach must be/,
+    );
+  });
+
+  it("rejects a non-object budget", () => {
+    expect(budgetErrors("nope")).toMatch(/'budget' must be an object/);
+  });
+});

--- a/src/recipes/__tests__/runBudget.test.ts
+++ b/src/recipes/__tests__/runBudget.test.ts
@@ -1,5 +1,20 @@
 import { describe, expect, it } from "vitest";
+import type { PriceTable } from "../pricing/priceTable.js";
 import { RunBudget } from "../runBudget.js";
+
+/** Deterministic price table injected so USD tests don't read ~/.patchwork. */
+const TABLE: PriceTable = {
+  _meta: {
+    _generatedAt: "2026-06-03",
+    _unit: "usd_per_million_tokens",
+    _source: "test",
+    _note: "test",
+  },
+  prices: {
+    m1: { input: 1, output: 1 }, // $1/1M in, $1/1M out
+    m2: { input: 2, output: 4 }, // $2/1M in, $4/1M out
+  },
+};
 
 describe("RunBudget — no policy", () => {
   it("admits everything when no policy is set", () => {
@@ -79,5 +94,120 @@ describe("RunBudget — subscription-driver fail-open", () => {
     const b = new RunBudget();
     b.reconcile("subprocess", undefined);
     expect(b.warnings()).toHaveLength(0);
+  });
+});
+
+describe("RunBudget — usdMax (cost-routing Phase 3)", () => {
+  it("enforces usdMax for a measured + priced call (halt)", () => {
+    const b = new RunBudget({ usdMax: 10 }, TABLE);
+    expect(b.admit().admitted).toBe(true);
+    // m1 = $1/1M each side → 5M in + 5M out = $10.00.
+    b.reconcile(
+      "openai",
+      { inputTokens: 5_000_000, outputTokens: 5_000_000 },
+      "m1",
+    );
+    expect(b.totals().usd).toBeCloseTo(10, 6);
+    expect(b.totals().usdBreached).toBe(true);
+    const a = b.admit();
+    expect(a.admitted).toBe(false);
+    expect(a.reason).toMatch(/budget_exceeded/);
+    expect(a.reason).toMatch(/usdMax=\$10/);
+  });
+
+  it("admits under the cap and reports usd / usdRemaining", () => {
+    const b = new RunBudget({ usdMax: 10 }, TABLE);
+    b.reconcile("openai", { inputTokens: 1_000_000, outputTokens: 0 }, "m1"); // $1
+    expect(b.admit().admitted).toBe(true);
+    expect(b.totals().usd).toBeCloseTo(1, 6);
+    expect(b.totals().usdRemaining).toBeCloseTo(9, 6);
+    expect(b.totals().usdBreached).toBe(false);
+  });
+
+  it("fails open for an unpriced model (warn once, no spend, never halts)", () => {
+    const b = new RunBudget({ usdMax: 1 }, TABLE);
+    const huge = { inputTokens: 9_000_000, outputTokens: 9_000_000 };
+    b.reconcile("openai", huge, "unknown-model");
+    b.reconcile("openai", huge, "unknown-model");
+    expect(b.totals().usd).toBe(0);
+    expect(b.admit().admitted).toBe(true);
+    expect(
+      b.warnings().filter((w) => /not in the price table/i.test(w)),
+    ).toHaveLength(1);
+  });
+
+  it("fails open for an unmeasured driver under a usd cap", () => {
+    const b = new RunBudget({ usdMax: 1 }, TABLE);
+    b.reconcile("subprocess", undefined, "m1");
+    expect(b.totals().usd).toBe(0);
+    expect(b.admit().admitted).toBe(true);
+    expect(
+      b.warnings().some((w) => /does not report token usage/i.test(w)),
+    ).toBe(true);
+  });
+
+  it("warn mode never refuses on a usd breach", () => {
+    const b = new RunBudget({ usdMax: 1, onBreach: "warn" }, TABLE);
+    b.reconcile("openai", { inputTokens: 2_000_000, outputTokens: 0 }, "m1"); // $2
+    expect(b.admit().admitted).toBe(true);
+    expect(b.warnings().some((w) => /USD budget exceeded.*warn/i.test(w))).toBe(
+      true,
+    );
+  });
+
+  it("computes no usd when usdMax is absent", () => {
+    const b = new RunBudget({ tokensMax: 100 }, TABLE);
+    b.reconcile("openai", { inputTokens: 1_000_000, outputTokens: 0 }, "m1");
+    expect(b.totals().usd).toBeUndefined();
+  });
+
+  it("enforces tokensMax and usdMax together (usd trips first here)", () => {
+    const b = new RunBudget({ tokensMax: 10_000_000, usdMax: 3 }, TABLE);
+    // m2 output $4/1M → 1M out = $4 ≥ $3 while only 1M << 10M tokens.
+    b.reconcile("openai", { inputTokens: 0, outputTokens: 1_000_000 }, "m2");
+    const a = b.admit();
+    expect(a.admitted).toBe(false);
+    expect(a.reason).toMatch(/usd=/);
+  });
+
+  it("does not enforce usd for a non-billable driver (local), even with a priced model", () => {
+    // Regression: `local` reports usage but costs no real money. A priced
+    // model (or the Haiku default stamp) must not charge it notional $.
+    const b = new RunBudget({ usdMax: 0.5 }, TABLE);
+    b.reconcile(
+      "local",
+      { inputTokens: 9_000_000, outputTokens: 9_000_000 },
+      "m1",
+    );
+    expect(b.totals().usd).toBe(0);
+    expect(b.admit().admitted).toBe(true);
+    expect(
+      b.warnings().some((w) => /does not incur metered API cost/i.test(w)),
+    ).toBe(true);
+  });
+
+  it("never poisons usd accounting for a prototype-key model name", () => {
+    // Regression: a model id colliding with an Object.prototype key
+    // ("__proto__", "constructor", …) must resolve to unpriced (undefined),
+    // not a prototype member → NaN → permanently-disabled cap.
+    const b = new RunBudget({ usdMax: 1 }, TABLE);
+    for (const evil of ["__proto__", "constructor", "toString", "valueOf"]) {
+      b.reconcile(
+        "openai",
+        { inputTokens: 9_000_000, outputTokens: 9_000_000 },
+        evil,
+      );
+    }
+    expect(b.totals().usd).toBe(0);
+    expect(Number.isNaN(b.totals().usd as number)).toBe(false);
+    expect(b.admit().admitted).toBe(true);
+    // A genuinely-priced call afterward still enforces (accounting not poisoned).
+    b.reconcile(
+      "openai",
+      { inputTokens: 5_000_000, outputTokens: 5_000_000 },
+      "m1",
+    );
+    expect(b.totals().usd).toBeCloseTo(10, 6);
+    expect(b.admit().admitted).toBe(false);
   });
 });

--- a/src/recipes/__tests__/yamlRunner.test.ts
+++ b/src/recipes/__tests__/yamlRunner.test.ts
@@ -2607,7 +2607,11 @@ describe("makeProviderDriverFn — surfaces provider failure cause", () => {
     expect(out).toBe("all good");
   });
 
-  it("forwards token usage when the driver reports it (Phase 1)", async () => {
+  it("forwards usage AND the driver-resolved model even when the step omits model (Phase 1 + Phase 3)", async () => {
+    // Called with model=undefined (omitted on the step); the driver resolves
+    // "gpt-4o" and reports it in providerMeta.model. That must propagate via
+    // servedBy.model so RunBudget can price + enforce usdMax — otherwise an
+    // omitted-model openai step silently fails open.
     mockProviderRun.mockResolvedValueOnce({
       text: "all good",
       durationMs: 5,
@@ -2618,6 +2622,7 @@ describe("makeProviderDriverFn — surfaces provider failure cause", () => {
     expect(out).toEqual({
       text: "all good",
       usage: { inputTokens: 30, outputTokens: 12 },
+      servedBy: { driver: "openai", model: "gpt-4o" },
     });
   });
 });
@@ -3368,6 +3373,48 @@ describe("recipe.budget — tokensMax enforcement (PR2b)", () => {
     expect(result.stepResults[0]?.status).toBe("ok");
     expect(result.stepResults[1]?.status).toBe("error");
     expect(result.stepResults[1]?.haltReason).toMatch(/budget_exceeded/);
+  });
+
+  it("enforces budget.usdMax via the price table (Phase 3 end-to-end)", async () => {
+    // Deterministic: point the price loader at a temp fixture so the run does
+    // not depend on the built-in prices or a dev's ~/.patchwork/prices.json.
+    const dir = mkdtempSync(path.join(os.tmpdir(), "pw-usdmax-"));
+    const fixture = path.join(dir, "prices.json");
+    writeFileSync(
+      fixture,
+      JSON.stringify({ prices: { "test-haiku": { input: 1, output: 5 } } }),
+    );
+    const prev = process.env.PATCHWORK_PRICE_TABLE;
+    process.env.PATCHWORK_PRICE_TABLE = fixture;
+    try {
+      const recipe = makeRecipe({
+        budget: { usdMax: 5 },
+        steps: [
+          { agent: { prompt: "s1", model: "test-haiku", into: "o1" } },
+          { agent: { prompt: "s2", model: "test-haiku", into: "o2" } },
+        ],
+      });
+      let calls = 0;
+      const result = await runYamlRecipe(recipe, {
+        ...noop(),
+        claudeFn: async () => {
+          calls++;
+          // test-haiku $1/1M in + $5/1M out → 1M + 1M = $6, over the $5 cap.
+          return {
+            text: `out ${calls}`,
+            usage: { inputTokens: 1_000_000, outputTokens: 1_000_000 },
+          };
+        },
+      });
+      expect(calls).toBe(1); // second admission refused on USD breach
+      expect(result.stepResults[1]?.status).toBe("error");
+      expect(result.stepResults[1]?.haltReason).toMatch(/budget_exceeded/);
+      expect(result.stepResults[1]?.haltCategory).toBe("budget_exceeded");
+    } finally {
+      if (prev === undefined) delete process.env.PATCHWORK_PRICE_TABLE;
+      else process.env.PATCHWORK_PRICE_TABLE = prev;
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   it("enforces the budget on the openai/grok/gemini path (Phase 1: these now report usage)", async () => {

--- a/src/recipes/haltCategory.ts
+++ b/src/recipes/haltCategory.ts
@@ -92,7 +92,7 @@ export const HALT_CATEGORY_HINTS: Record<HaltCategory, string> = {
   tool_threw: "check inner error in trace",
   tool_error: "check inner error in trace",
   kill_switch: "run `patchwork kill-switch release`",
-  budget_exceeded: "raise tokensMax or shrink prompts",
+  budget_exceeded: "raise tokensMax / usdMax or shrink prompts",
   expect_failed: "inspect assertion vs actual output",
   step_timeout: "bump timeout_ms or speed up step",
   judge_revisions_exhausted:

--- a/src/recipes/pricing/__tests__/priceTable.test.ts
+++ b/src/recipes/pricing/__tests__/priceTable.test.ts
@@ -66,6 +66,18 @@ describe("costUsd", () => {
       costUsd("some-unknown-model", { inputTokens: 1000, outputTokens: 1000 }),
     ).toBeUndefined();
   });
+
+  it("returns undefined (not NaN) for a prototype-key model name", () => {
+    // Regression: bare bracket lookup would return Object.prototype members.
+    for (const evil of ["__proto__", "constructor", "toString", "valueOf"]) {
+      expect(priceFor(evil), evil).toBeUndefined();
+      const cost = costUsd(evil, {
+        inputTokens: 1_000_000,
+        outputTokens: 1_000_000,
+      });
+      expect(cost, evil).toBeUndefined();
+    }
+  });
 });
 
 describe("loadPriceTable precedence", () => {

--- a/src/recipes/pricing/priceTable.ts
+++ b/src/recipes/pricing/priceTable.ts
@@ -121,9 +121,10 @@ export function loadPriceTable(
     const rawPrices =
       root.prices && typeof root.prices === "object" ? root.prices : root;
 
-    const merged: Record<string, ModelPrice> = {
-      ...BUILTIN_PRICE_TABLE.prices,
-    };
+    // Null-prototype base so a user override keyed "__proto__" creates an own
+    // property instead of mutating the prototype (bracket-assign pollution).
+    const merged: Record<string, ModelPrice> = Object.create(null);
+    Object.assign(merged, BUILTIN_PRICE_TABLE.prices);
     for (const [model, entry] of Object.entries(
       rawPrices as Record<string, unknown>,
     )) {
@@ -145,7 +146,13 @@ export function priceFor(
   model: string,
   table: PriceTable = loadPriceTable(),
 ): ModelPrice | undefined {
-  return table.prices[model];
+  // Own-property lookup only. A user-controlled model id that collides with an
+  // Object.prototype key ("__proto__", "constructor", "valueOf", "toString", …)
+  // must resolve to undefined (unpriced → fail open), NOT to an inherited
+  // prototype member — otherwise costUsd would compute on a function and return
+  // NaN, silently poisoning the USD budget (a prototype-walk bug class this
+  // codebase has been bitten by before — use Object.hasOwn, never `in`/bracket).
+  return Object.hasOwn(table.prices, model) ? table.prices[model] : undefined;
 }
 
 /**

--- a/src/recipes/runBudget.ts
+++ b/src/recipes/runBudget.ts
@@ -1,32 +1,45 @@
 /**
- * Per-recipe token budget — PR2b.
+ * Per-recipe budget — PR2b (tokens) + cost-routing Phase 3 (USD).
  *
- * Built on PR2a's `AgentResult.usage` plumbing. The runner constructs
- * one `RunBudget` per recipe execution; agent steps consult it before
- * dispatch (admission) and reconcile actual consumption after the call
- * returns. On breach the run halts at the *next* admission check (we
- * never retroactively fail a step that succeeded — the user's tokens
- * are already spent, halting after-the-fact would just confuse the
- * audit trail).
+ * Built on PR2a's `AgentResult.usage` plumbing. The runner constructs one
+ * `RunBudget` per recipe execution; agent steps consult it before dispatch
+ * (admission) and reconcile actual consumption after the call returns. On
+ * breach the run halts at the *next* admission check (we never retroactively
+ * fail a step that succeeded — the user's tokens/dollars are already spent;
+ * halting after-the-fact would just confuse the audit trail).
  *
- * Subscription drivers (Claude CLI, provider subprocess CLIs) don't
- * surface per-call token counts. `RunBudget` tracks which drivers were
- * unmeasured and exposes a deduped warnings list — fail-open with a
- * single notice per driver per run, never block.
+ * Two independent caps, either or both:
+ *   - `tokensMax` — cumulative input + output tokens.
+ *   - `usdMax`    — cumulative USD, priced from token usage via the Phase 2
+ *                   price table (`costUsd`).
  *
- * Scope (PR2b only):
- *   - cumulative token enforcement (input + output)
- *   - halt-on-breach OR warn-on-breach via `BudgetPolicy.onBreach`
- *   - subscription-driver fail-open with warning
- *
- * Out of scope (future):
- *   - per-step caps (extend `BudgetPolicy` or add `AgentStep.tokensMax`)
- *   - `usdMax` (needs a price table; subscription drivers complicate)
- *   - `wallClockMs` (orthogonal to tokens, separate accounting)
+ * Subscription drivers (Claude CLI, provider subprocess CLIs) don't surface
+ * per-call token counts, and a model with no price-table entry can't be
+ * costed. Both cases FAIL OPEN: `RunBudget` records a deduped one-time
+ * warning and never blocks. So a USD cap enforces for *measured + priced*
+ * (API) drivers and is a no-op-with-notice for everything else — never a
+ * silent or a surprise halt on the token-blind default driver. (The opt-in
+ * estimate-the-unmeasured path is a planned follow-up; absent it, unmeasured
+ * = fail-open, which is the conservative default the design calls for.)
  */
 
 import type { AgentUsage } from "./agentExecutor.js";
+import {
+  costUsd,
+  loadPriceTable,
+  type PriceTable,
+} from "./pricing/priceTable.js";
 import type { BudgetPolicy } from "./schema.js";
+
+/**
+ * Drivers that incur real, metered, per-token API billing — the ONLY ones a
+ * USD cap is enforced against. Subscription/CLI drivers (subprocess Claude/
+ * Gemini) report no usage and never reach the pricing path; `local`
+ * (self-hosted Ollama / LM Studio) DOES report usage but costs no real money,
+ * so it must not be priced at notional API rates and halted on spend that
+ * never happened. Anything not in this set fails open with a one-time notice.
+ */
+const BILLABLE_DRIVERS = new Set(["anthropic", "openai", "grok"]);
 
 export interface BudgetAdmission {
   /** True = step may proceed. False = budget exhausted. */
@@ -39,72 +52,129 @@ export interface BudgetTotals {
   inputTokens: number;
   outputTokens: number;
   total: number;
-  /** Remaining tokens before breach. Undefined when no limit is set. */
+  /** Remaining tokens before breach. Undefined when no token limit is set. */
   remaining?: number;
-  /** True once total >= tokensMax. */
+  /** Cumulative measured USD. Undefined when no USD limit is set. */
+  usd?: number;
+  /** Remaining USD before breach. Undefined when no USD limit is set. */
+  usdRemaining?: number;
+  /** True once total tokens >= tokensMax (false when no token limit). */
   breached: boolean;
+  /** True once measured usd >= usdMax (false when no USD limit). */
+  usdBreached: boolean;
   /** Whether the configured policy halts on breach (vs warn). */
   haltOnBreach: boolean;
 }
 
 export class RunBudget {
   private readonly tokensMax?: number;
+  private readonly usdMax?: number;
   private readonly haltOnBreach: boolean;
+  private readonly priceTable?: PriceTable;
   private inputTokens = 0;
   private outputTokens = 0;
-  /** Drivers that returned `usage: undefined` during this run, deduped. */
-  private readonly unmeasuredDrivers = new Set<string>();
+  private usdSpent = 0;
+  /** Dedup keys for one-time warnings (unmeasured driver, breach, etc.). */
+  private readonly warnedKeys = new Set<string>();
   /** Free-form warnings surfaced via the run log. */
   private readonly warningList: string[] = [];
 
-  constructor(policy?: BudgetPolicy) {
+  /**
+   * @param policy   recipe budget block.
+   * @param priceTable  optional injected table (tests); otherwise loaded once
+   *                    here when a USD cap is set (file/env override aware).
+   */
+  constructor(policy?: BudgetPolicy, priceTable?: PriceTable) {
     this.tokensMax = policy?.tokensMax;
+    this.usdMax = policy?.usdMax;
     this.haltOnBreach = (policy?.onBreach ?? "halt") === "halt";
+    if (this.usdMax !== undefined) {
+      this.priceTable = priceTable ?? loadPriceTable();
+    }
+  }
+
+  /** True when neither cap is configured — reconcile/admit are no-ops. */
+  private get hasBudget(): boolean {
+    return this.tokensMax !== undefined || this.usdMax !== undefined;
   }
 
   /** Cheap admission check before dispatching an agent step. */
   admit(): BudgetAdmission {
-    if (this.tokensMax === undefined) return { admitted: true };
-    if (this.breached()) {
-      if (!this.haltOnBreach) {
-        // warn-mode: never block, just keep going. The warning was
-        // already emitted on the post-call reconcile that breached.
-        return { admitted: true };
-      }
+    // warn-mode never blocks; the breach warning was emitted at reconcile.
+    if (!this.haltOnBreach) return { admitted: true };
+    if (this.tokenBreached()) {
       return {
         admitted: false,
-        reason: `Run exceeded its token budget — budget_exceeded: total=${this.totalTokens()} > tokensMax=${this.tokensMax}.`,
+        reason: `Run exceeded its token budget — budget_exceeded: total=${this.totalTokens()} >= tokensMax=${this.tokensMax}.`,
+      };
+    }
+    if (this.usdMaxBreached()) {
+      return {
+        admitted: false,
+        reason: `Run exceeded its USD budget — budget_exceeded: usd=$${this.usdSpent.toFixed(4)} >= usdMax=$${this.usdMax}.`,
       };
     }
     return { admitted: true };
   }
 
   /**
-   * Record the actual usage reported by an agent call. `usage` may be
-   * undefined when the driver doesn't surface token counts — we record
-   * the driver name once per run and continue (fail-open).
+   * Record the actual usage reported by an agent call. `usage` is undefined
+   * when the driver doesn't surface token counts — record the driver once and
+   * continue (fail-open). `model` is the resolved model (from `servedBy`) used
+   * to price USD; an unpriced model fails open with a one-time notice.
    */
-  reconcile(driver: string, usage: AgentUsage | undefined): void {
-    if (this.tokensMax === undefined) return;
+  reconcile(
+    driver: string,
+    usage: AgentUsage | undefined,
+    model?: string,
+  ): void {
+    if (!this.hasBudget) return;
     if (!usage) {
-      if (!this.unmeasuredDrivers.has(driver)) {
-        this.unmeasuredDrivers.add(driver);
-        this.warningList.push(
-          `Driver "${driver}" does not report token usage — budget enforcement skipped for its calls. Set recipe.budget.onBreach="warn" or move to an API driver to fix.`,
-        );
-      }
+      this.pushOnce(
+        `unmeasured:${driver}`,
+        `Driver "${driver}" does not report token usage — budget enforcement skipped for its calls. Set recipe.budget.onBreach="warn" or move to an API driver to fix.`,
+      );
       return;
     }
+
     this.inputTokens += usage.inputTokens;
     this.outputTokens += usage.outputTokens;
-    if (this.breached() && !this.haltOnBreach) {
-      // warn-mode: emit a single in-band warning the first time we
-      // cross the line. Subsequent steps continue running.
-      const breachKey = "warn-breach-emitted";
-      if (!this.unmeasuredDrivers.has(breachKey)) {
-        this.unmeasuredDrivers.add(breachKey);
-        this.warningList.push(
+
+    if (this.usdMax !== undefined) {
+      if (!BILLABLE_DRIVERS.has(driver)) {
+        // Not a metered-API driver (local / subscription) — a USD cap here
+        // would be notional, not real money out. Fail open with a notice.
+        this.pushOnce(
+          `notbilled:${driver}`,
+          `Driver "${driver}" does not incur metered API cost — usdMax is not enforced for its calls.`,
+        );
+      } else {
+        const cost = costUsd(model ?? "", usage, this.priceTable);
+        // `cost === undefined` (unpriced model) OR a non-finite cost (defends
+        // against a malformed price entry) → fail open, never poison usdSpent.
+        if (cost === undefined || !Number.isFinite(cost)) {
+          this.pushOnce(
+            `unpriced:${model ?? "(no model)"}`,
+            `Model "${model ?? "(unspecified)"}" is not in the price table — USD budget enforcement skipped for its calls. Add it to ~/.patchwork/prices.json or set the agent step's model.`,
+          );
+        } else {
+          this.usdSpent += cost;
+        }
+      }
+    }
+
+    // warn-mode: emit a single in-band notice the first time we cross a cap.
+    if (!this.haltOnBreach) {
+      if (this.tokenBreached()) {
+        this.pushOnce(
+          "warn-token-breach",
           `Token budget exceeded (total=${this.totalTokens()}, tokensMax=${this.tokensMax}) but onBreach="warn" — continuing.`,
+        );
+      }
+      if (this.usdMaxBreached()) {
+        this.pushOnce(
+          "warn-usd-breach",
+          `USD budget exceeded (usd=$${this.usdSpent.toFixed(4)}, usdMax=$${this.usdMax}) but onBreach="warn" — continuing.`,
         );
       }
     }
@@ -120,7 +190,12 @@ export class RunBudget {
       ...(this.tokensMax !== undefined && {
         remaining: Math.max(0, this.tokensMax - total),
       }),
-      breached: this.breached(),
+      ...(this.usdMax !== undefined && {
+        usd: this.usdSpent,
+        usdRemaining: Math.max(0, this.usdMax - this.usdSpent),
+      }),
+      breached: this.tokenBreached(),
+      usdBreached: this.usdMaxBreached(),
       haltOnBreach: this.haltOnBreach,
     };
   }
@@ -130,11 +205,21 @@ export class RunBudget {
     return [...this.warningList];
   }
 
+  private pushOnce(key: string, msg: string): void {
+    if (this.warnedKeys.has(key)) return;
+    this.warnedKeys.add(key);
+    this.warningList.push(msg);
+  }
+
   private totalTokens(): number {
     return this.inputTokens + this.outputTokens;
   }
 
-  private breached(): boolean {
+  private tokenBreached(): boolean {
     return this.tokensMax !== undefined && this.totalTokens() >= this.tokensMax;
+  }
+
+  private usdMaxBreached(): boolean {
+    return this.usdMax !== undefined && this.usdSpent >= this.usdMax;
   }
 }

--- a/src/recipes/schema.ts
+++ b/src/recipes/schema.ts
@@ -143,18 +143,29 @@ export interface ErrorPolicy {
  * drivers (Anthropic API, OpenAI/Gemini/Grok subprocess that surfaces
  * usage, local LLM adapters) get full enforcement.
  *
- * Nested object (not flat `tokensMax`) so future siblings — `usdMax`,
- * `wallClockMs`, `stepsMax` — don't churn the schema again.
+ * Nested object (not flat `tokensMax`) so siblings — `usdMax` (added in
+ * cost-routing Phase 3), and future `wallClockMs` / `stepsMax` — don't churn
+ * the schema again.
  */
 export interface BudgetPolicy {
   /** Cumulative input + output tokens allowed across the whole run. */
   tokensMax?: number;
   /**
-   * What to do when the budget is breached. `halt` (default) stops the
+   * Cumulative USD allowed across the whole run, priced from token usage via
+   * the model price table (`src/recipes/pricing`). Enforced for measured +
+   * priced (API) drivers; a subscription driver that reports no tokens, or a
+   * model with no price-table entry, FAILS OPEN with a one-time warning and
+   * never halts on it. Same `onBreach` semantics as `tokensMax`. A USD cap on
+   * a subscription driver would be notional, not real money out — so it is
+   * deliberately not enforced there.
+   */
+  usdMax?: number;
+  /**
+   * What to do when a budget is breached. `halt` (default) stops the
    * run on the next admission check with a `budget_exceeded` halt
    * reason. `warn` continues the run but emits a warning + records the
    * breach in the run log; useful for tuning budgets without breaking
-   * production cron recipes.
+   * production cron recipes. Applies to both `tokensMax` and `usdMax`.
    */
   onBreach?: "halt" | "warn";
 }

--- a/src/recipes/schemaGenerator.ts
+++ b/src/recipes/schemaGenerator.ts
@@ -633,18 +633,25 @@ function generateRecipeSchema(
       budget: {
         type: "object",
         description:
-          "Per-recipe token budget (PR2b). When set, the runner tracks cumulative tokens across API driver calls; on breach the run halts with budget_exceeded. Subscription drivers (Claude CLI) don't report token counts and are skipped.",
+          "Per-recipe budget. Set tokensMax and/or usdMax; on breach the run halts with budget_exceeded (or warns). Enforced for API drivers that report token usage and (for usdMax) have a price-table entry; subscription drivers (Claude CLI) report no tokens and are skipped (fail-open with a one-time warning).",
         properties: {
           tokensMax: {
             type: "number",
+            exclusiveMinimum: 0,
             description:
               "Cumulative input + output tokens allowed across the whole run",
+          },
+          usdMax: {
+            type: "number",
+            exclusiveMinimum: 0,
+            description:
+              "Cumulative USD allowed across the whole run, priced from token usage via the model price table. Unpriced models / subscription drivers fail open (never halt on them).",
           },
           onBreach: {
             type: "string",
             enum: ["halt", "warn"],
             description:
-              "halt (default): stop run on next admission check. warn: continue but record the breach in the run log.",
+              "halt (default): stop run on next admission check. warn: continue but record the breach in the run log. Applies to both tokensMax and usdMax.",
             default: "halt",
           },
         },

--- a/src/recipes/validation.ts
+++ b/src/recipes/validation.ts
@@ -245,6 +245,8 @@ export function validateRecipeDefinition(recipe: unknown): LintResult {
 
       validateTemplateReferences(r, issues, collectParallelEachKeys(recipe));
     }
+
+    validateRecipeBudget(r, issues);
   }
 
   if (isEnabled(FLAG_SCHEMA_LINT)) {
@@ -264,6 +266,54 @@ export function validateRecipeDefinition(recipe: unknown): LintResult {
     warnings,
     errors,
   };
+}
+
+/**
+ * Validate the optional recipe `budget` block. Closes a real gap: before
+ * cost-routing Phase 3 there was NO budget validation, so `tokensMax: -5` or
+ * `tokensMax: "lots"` passed lint silently. A present cap must be a positive
+ * number; `onBreach` must be the halt|warn enum.
+ */
+function validateRecipeBudget(
+  r: Record<string, unknown>,
+  issues: LintIssue[],
+): void {
+  const budget = r.budget;
+  if (budget === undefined) return;
+  if (typeof budget !== "object" || budget === null || Array.isArray(budget)) {
+    issues.push({
+      level: "error",
+      message: "'budget' must be an object",
+      path: "budget",
+      code: "budget-type",
+    });
+    return;
+  }
+  const b = budget as Record<string, unknown>;
+  for (const key of ["tokensMax", "usdMax"] as const) {
+    const value = b[key];
+    if (value === undefined) continue;
+    if (typeof value !== "number" || !(value > 0)) {
+      issues.push({
+        level: "error",
+        message: `budget.${key} must be a positive number`,
+        path: `budget.${key}`,
+        code: "budget-positive",
+      });
+    }
+  }
+  if (
+    b.onBreach !== undefined &&
+    b.onBreach !== "halt" &&
+    b.onBreach !== "warn"
+  ) {
+    issues.push({
+      level: "error",
+      message: "budget.onBreach must be 'halt' or 'warn'",
+      path: "budget.onBreach",
+      code: "budget-onbreach-enum",
+    });
+  }
 }
 
 /**

--- a/src/recipes/yamlRunner.ts
+++ b/src/recipes/yamlRunner.ts
@@ -1051,6 +1051,9 @@ export async function runYamlRecipe(
       agentReturn.servedBy?.driver ??
         (driver === "api" ? "anthropic" : (driver ?? "auto")),
       agentReturn.usage,
+      // Resolved model for USD pricing (Phase 3). Absent → unpriced → the USD
+      // cap fails open for this call.
+      agentReturn.servedBy?.model,
     );
     const text = agentReturn.text;
     // Same failure detection as the main agent branch: explicit failure
@@ -1338,6 +1341,8 @@ export async function runYamlRecipe(
                 ? "anthropic"
                 : (agentCfg.driver ?? "auto")),
             agentReturn.usage,
+            // Resolved model for USD pricing (Phase 3); absent → fail open.
+            agentReturn.servedBy?.model,
           );
           // Catch both `[agent step failed: ...]` (existing) and the
           // silent-fail patterns `[agent step skipped: ...]` etc. via the
@@ -2418,7 +2423,24 @@ export function makeProviderDriverFn(): (
         // enforce a real budget for openai/grok/gemini instead of failing
         // open. No usage → bare string, normalised to {text} downstream.
         const usage = providerMetaToUsage(result.providerMeta);
-        return usage ? { text: result.text, usage } : result.text;
+        // Carry the model the driver ACTUALLY resolved+billed (providerMeta.
+        // model, e.g. openai's "gpt-4o" default when the step omitted model) so
+        // RunBudget prices the real model. executeAgent's stamp() is idempotent
+        // — it preserves this servedBy rather than re-deriving from raw input.
+        const resolvedModel =
+          typeof result.providerMeta?.model === "string"
+            ? result.providerMeta.model
+            : undefined;
+        if (usage || resolvedModel) {
+          return {
+            text: result.text,
+            ...(usage ? { usage } : {}),
+            ...(resolvedModel
+              ? { servedBy: { driver: driverName, model: resolvedModel } }
+              : {}),
+          };
+        }
+        return result.text;
       } finally {
         clearTimeout(timeout);
       }


### PR DESCRIPTION
The headline: closes the long-deferred **`usdMax`** gap. Extends `RunBudget` in place to enforce a cumulative USD cap for **measured + priced (real-API-billed)** drivers — priced from token usage (Phase 1) via the price table (Phase 2). Design: [`docs/design/cost-aware-routing.md`](../blob/main/docs/design/cost-aware-routing.md).

> ⚠️ **Stacked on #864** (price table). The diff includes #864's `src/recipes/pricing/` until it merges; merge **#864 first**, then I rebase this onto main (clean — different regions). Phases #861/#862/#863 are already on main.

Honors your two decisions: estimation is **warn-only** (unmeasured drivers stay fail-open; no estimate path here), and a local per-recipe `usdMax` **ships in OSS core**.

## Core

- **`RunBudget`**: `usdSpent` accumulator; `reconcile(driver, usage, model?)` prices via `costUsd`; `admit()` denies at `usd >= usdMax` (reuses `budget_exceeded`); `totals()` gains `usd`/`usdRemaining`/`usdBreached`. Price table loaded **once, only when `usdMax` is set** (zero-overhead otherwise). Existing `tokensMax` behavior byte-identical.
- **schema** `budget.usdMax` (+ `exclusiveMinimum`); **new `validateRecipeBudget`** — closes a real gap (`tokensMax: -5` / `usdMax: "x"` linted clean before); halt-hint + reconcile call sites updated.

## Adversarial-review fixes (4-lens review → verify each; all confirmed + regression-tested)

| Sev | Issue | Fix |
|---|---|---|
| HIGH | A model id colliding with an `Object.prototype` key (`__proto__`/`constructor`/…) made `priceFor` return a prototype member → `costUsd` `NaN` → `usdSpent` poisoned → **cap silently disabled** | `priceFor` uses `Object.hasOwn`; override merge uses a null-proto base; `reconcile` drops a non-finite cost |
| HIGH | A `local` step (self-hosted, $0) was stamped the priced Haiku default → could **halt on money never spent** | only genuinely-billed drivers `{anthropic, openai, grok}` are priced; others fail open with a notice |
| HIGH | An openai/grok step that **omits `model:`** resolves a priced default internally, but `servedBy.model` was undefined → silently unenforced | `makeProviderDriverFn` propagates the driver-resolved `providerMeta.model` via `servedBy` |
| nit | token halt-reason said `>` while the gate is `>=` | wording fixed |

## Tests

22 RunBudget/integration assertions (USD enforce, fail-open paths, **local-not-priced**, **prototype-key**, warn-mode, token+usd together), the budget-validation table, provider model propagation, and an **end-to-end** `usdMax` halt via a fixture price table. Full recipes + drivers + pricing suites **989 green**; `tsc` (main + `tests.core`) + audit gates clean.

The opt-in `estimateUnmeasured` ≈$ estimator is deferred to a clean follow-up (needs prompt/output text threaded through `reconcile`); fail-open already delivers the warn-only guarantee.

🤖 Generated with [Claude Code](https://claude.com/claude-code)