### PR TITLE
feat(recipes): cost-routing Phase 4 — opt-in per-step downshift routing

### DIFF
--- a/docs/adr/0015-cost-aware-routing.md
+++ b/docs/adr/0015-cost-aware-routing.md
@@ -1,0 +1,44 @@
+# ADR-0015: Cost-Aware Model Routing
+
+**Status:** Accepted
+**Date:** 2026-06-03
+
+## Context
+
+Recipes hand work to LLM drivers, and every call costs money (pay-as-you-go API) or a slice of a flat subscription. Before this work there was no way to **cap** a recipe's spend or to **route** a step to a cheaper model under budget pressure. A token budget (`tokensMax`, PR2b) existed but was silently broken in three ways and didn't measure most drivers. Full design + the multi-agent review that shaped it: [docs/design/cost-aware-routing.md](../design/cost-aware-routing.md).
+
+The hard constraint throughout: the **default driver is a flat-rate subscription that reports no tokens**, so any USD cap that silently no-ops (or worse, *halts*) on it is a trap. Two product decisions framed the design: estimation is **warn-only** (never hard-stop on a guess), and a local per-recipe `usdMax` ships in the **free OSS core**.
+
+## Decision
+
+Five opt-in phases, each byte-identical when unconfigured:
+
+1. **Phase 0 — substrate (#861/#862).** Fix the budget's dropped/guessed data: `parseRecipe` now passes `budget` through; `RunBudget.reconcile` attributes usage to the driver `executeAgent` *actually ran* (`AgentResult.servedBy`, stamped at the single driver-resolution point) instead of a guessed `"auto"`; the previously-discarded `RunBudget.warnings()` are threaded into the run log; the two duplicated agent-step schema blocks are deduped into one shared const.
+
+2. **Phase 1 — driver token fidelity (#863).** API drivers actually report tokens now: `OpenAIApiDriver` requests `stream_options:{include_usage:true}`; `ApiDriver` forwards the `message.usage` it discarded; `makeProviderDriverFn` maps `providerMeta → usage` (pure `providerMetaToUsage`) and propagates the driver-resolved `providerMeta.model` via `servedBy`. Subscription/subprocess drivers report nothing and **fail open**.
+
+3. **Phase 2 — price table (#864).** A `(model id → USD-per-million-tokens)` table as **data**: a built-in TS const (compiled into `dist`, so always available) overridable by `~/.patchwork/prices.json` and `PATCHWORK_PRICE_TABLE`. `costUsd` / `priceFor` fail open on an unknown model. **No runtime network calls.** `priceFor` uses `Object.hasOwn` (a model named `__proto__`/`constructor` must resolve to *unpriced*, not a prototype member → `NaN`).
+
+4. **Phase 3 — `usdMax` enforcement (#865).** `RunBudget` gains a USD accumulator; `admit()` denies at `usd >= usdMax` (reusing the existing `budget_exceeded` halt category); `totals()` reports `usd`/`usdRemaining`. USD is enforced **only for genuinely-billed drivers** — `BILLABLE_DRIVERS = {anthropic, openai, grok}`. `local` (self-hosted, $0) and subscription drivers are **never** priced, so a run can never halt on notional money it didn't spend. The price table loads once, only when `usdMax` is set.
+
+5. **Phase 4 — `downshift` routing (this ADR).** Per-step `agent.downshift: [{driver?, model?}]` — an author-ordered list of cheaper fallbacks. Before each agent dispatch, a **pure `costRouter`** ([src/recipes/pricing/costRouter.ts](../../src/recipes/pricing/costRouter.ts)) picks the most-preferred candidate whose estimated cost fits the remaining USD budget; a downshift entry inherits the preferred driver/model for any field it omits; an unpriced/free candidate (e.g. a local model) is always affordable. Wired at **both** agent dispatch sites — the main path and the judge→refine revise call — via the shared `resolveRouting` helper. Absent `downshift` (or no `usdMax`) ⇒ the preferred model is used unchanged.
+
+## Key design points
+
+- **Routing operates below the brake.** `admit()` still halts a breached run; `downshift` only chooses a cheaper model for a call that admission already passed. It slows the *rate* of spend; it never overrides a breach, and never "rescues" an already-exhausted cap.
+- **Author asserts capability, engine checks affordability.** `downshift` is an ordered list the recipe author vouches for — the engine does not model whether the cheaper model is "good enough", only whether it fits. This is deliberate: a capability/tier taxonomy was rejected as premature surface area (see the design doc's killed approaches).
+- **Pre-dispatch estimate is intentionally rough.** Cost can't be known before the call runs, so `resolveRouting` estimates `inputTokens ≈ promptChars/4` and `outputTokens ≈ inputTokens` (1:1). This only picks the gear; the real cost is reconciled after the call, and the next `admit()` enforces the cap precisely. A wrong estimate can pick a sub-optimal model but cannot overspend the cap.
+- **Fail-open is the safe direction everywhere.** Unmeasured driver, unpriced model, non-billable driver, prototype-key model id, malformed price override — every one resolves to "not enforced, one-time warning", never a wrong halt.
+- **Quote parity with reconcile.** `RunBudget.quoteUsd` (the router's affordability oracle) resolves the driver/model exactly as `executeAgent`/`reconcile` do — `api`/`claude` → the billable `anthropic` path, and an omitted model on that path → `DEFAULT_MODEL` — so a candidate the router calls "free" is precisely one `reconcile` would not charge. Two documented residuals, both fail-toward-preferred (never a wrong halt): an **omitted model on `openai`/`grok`** is quoted unpriced (the provider's internal default is unknowable pre-dispatch — specify the model for downshift to engage there), and an **undefined driver** is optimistically quoted as the metered anthropic path (if auto-detect lands on a subscription driver the call is simply free).
+
+## Alternatives considered
+
+- **Declarative cost tiers (`tier:`/`routing:` + inline `pricing:`).** Rejected: ~400 LOC of tier-dictionary that duplicates what per-step `driver`+`model` already expresses, and an inline `pricing:` field is a budget-evasion footgun (a recipe could under-price a model to dodge `usdMax`). The leaner per-step `downshift` + out-of-band price overrides get the value without the surface.
+- **Estimate-and-halt for subscription drivers (`estimateUnmeasured: true` default).** Rejected as the default: it would hard-halt the token-blind subscription driver on a ~4-chars/token guess of notional spend — inverting fail-open. Deferred entirely; if it lands later it must default `false` and can only *warn*.
+- **A wall-clock CI staleness gate on the price table.** Rejected: a time-based hard-fail eventually breaks an unrelated PR. Shipped instead as a pure `isPriceTableStale` helper + a structural test, ready for a scheduled (non-PR) check.
+
+## Consequences
+
+- Recipes get enforceable per-recipe USD caps for measured API drivers, an honest fail-open-with-warning story for subscription/local drivers, and opt-in cheaper-model downshift — all in the free core.
+- The price table is **list-price data that drifts**; it is reviewable, dated, and overridable, and a USD cap on a subscription driver is explicitly *notional, not real money out* (documented in the hint text).
+- `model_fallback` (a field that only ever existed in `examples/recipes/advanced-patterns/` docs) is reconciled to point at `downshift`.

--- a/src/recipes/__tests__/downshiftValidation.test.ts
+++ b/src/recipes/__tests__/downshiftValidation.test.ts
@@ -1,0 +1,57 @@
+/**
+ * agent.downshift validation — cost-routing Phase 4. Each entry must set at
+ * least one of {driver, model}, and any driver must be dispatch-known.
+ */
+import { describe, expect, it } from "vitest";
+import { validateRecipeDefinition } from "../validation.js";
+
+function agentErrors(extra: Record<string, unknown>): string {
+  const r = validateRecipeDefinition({
+    name: "d",
+    version: "1.0.0",
+    trigger: { type: "manual" },
+    steps: [{ id: "s", agent: { prompt: "hi", ...extra } }],
+  });
+  return r.issues
+    .filter((i) => i.level === "error")
+    .map((i) => i.message)
+    .join(" | ");
+}
+
+describe("agent.downshift validation", () => {
+  it("accepts a valid downshift list", () => {
+    expect(
+      agentErrors({
+        downshift: [{ model: "cheap" }, { driver: "local", model: "llama3" }],
+      }),
+    ).toBe("");
+  });
+
+  it("accepts a driver-only and a model-only entry", () => {
+    expect(
+      agentErrors({ downshift: [{ driver: "openai" }, { model: "x" }] }),
+    ).toBe("");
+  });
+
+  it("rejects a non-array downshift", () => {
+    expect(agentErrors({ downshift: "cheap" })).toMatch(
+      /'downshift' must be an array/,
+    );
+  });
+
+  it("rejects a non-object entry", () => {
+    expect(agentErrors({ downshift: ["cheap"] })).toMatch(/must be an object/);
+  });
+
+  it("rejects an empty entry (no driver or model)", () => {
+    expect(agentErrors({ downshift: [{}] })).toMatch(
+      /at least one of 'driver' or 'model'/,
+    );
+  });
+
+  it("rejects an unknown driver", () => {
+    expect(
+      agentErrors({ downshift: [{ driver: "telepathy", model: "x" }] }),
+    ).toMatch(/not a known driver/);
+  });
+});

--- a/src/recipes/__tests__/runBudget.test.ts
+++ b/src/recipes/__tests__/runBudget.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { DEFAULT_MODEL } from "../agentExecutor.js";
 import type { PriceTable } from "../pricing/priceTable.js";
 import { RunBudget } from "../runBudget.js";
 
@@ -13,6 +14,7 @@ const TABLE: PriceTable = {
   prices: {
     m1: { input: 1, output: 1 }, // $1/1M in, $1/1M out
     m2: { input: 2, output: 4 }, // $2/1M in, $4/1M out
+    [DEFAULT_MODEL]: { input: 1, output: 5 }, // the omitted-model fallback
   },
 };
 
@@ -209,5 +211,61 @@ describe("RunBudget — usdMax (cost-routing Phase 3)", () => {
     );
     expect(b.totals().usd).toBeCloseTo(10, 6);
     expect(b.admit().admitted).toBe(false);
+  });
+});
+
+describe("RunBudget — routing helpers (cost-routing Phase 4)", () => {
+  it("remainingUsd tracks spend; undefined without a usd cap", () => {
+    expect(
+      new RunBudget({ tokensMax: 100 }, TABLE).remainingUsd(),
+    ).toBeUndefined();
+    const b = new RunBudget({ usdMax: 10 }, TABLE);
+    expect(b.remainingUsd()).toBe(10);
+    b.reconcile("openai", { inputTokens: 1_000_000, outputTokens: 0 }, "m1"); // $1
+    expect(b.remainingUsd()).toBeCloseTo(9, 6);
+  });
+
+  it("quoteUsd prices a billable+priced call; undefined otherwise", () => {
+    const b = new RunBudget({ usdMax: 10 }, TABLE);
+    // m1 $1/1M each side → 1M+1M = $2.
+    expect(b.quoteUsd("openai", "m1", 1_000_000, 1_000_000)).toBeCloseTo(2, 6);
+    // undefined driver (auto-detect) is treated as billable (anthropic).
+    expect(b.quoteUsd(undefined, "m1", 1_000_000, 0)).toBeCloseTo(1, 6);
+    // non-billable driver (local) → undefined (free, never enforced).
+    expect(b.quoteUsd("local", "m1", 1_000_000, 1_000_000)).toBeUndefined();
+    // unpriced model → undefined.
+    expect(b.quoteUsd("openai", "nope", 1_000_000, 1_000_000)).toBeUndefined();
+    // openai with missing model → undefined (provider default unknown here).
+    expect(
+      b.quoteUsd("openai", undefined, 1_000_000, 1_000_000),
+    ).toBeUndefined();
+  });
+
+  it("quoteUsd mirrors reconcile resolution for the anthropic aliases (review fix)", () => {
+    const b = new RunBudget({ usdMax: 10 }, TABLE);
+    // "api" and "claude" both resolve to the billable anthropic path, so they
+    // must be priced exactly like an explicit "anthropic" — not treated as free
+    // (the bug: the router never downshifted driver: api/claude steps).
+    const expected = b.quoteUsd("anthropic", "m1", 1_000_000, 1_000_000);
+    expect(expected).toBeCloseTo(2, 6);
+    expect(b.quoteUsd("api", "m1", 1_000_000, 1_000_000)).toBe(expected);
+    expect(b.quoteUsd("claude", "m1", 1_000_000, 1_000_000)).toBe(expected);
+  });
+
+  it("quoteUsd prices an omitted model on the anthropic path at DEFAULT_MODEL", () => {
+    const b = new RunBudget({ usdMax: 10 }, TABLE);
+    // DEFAULT_MODEL priced $1 in / $5 out → 1M+1M = $6 — what reconcile charges.
+    expect(
+      b.quoteUsd("anthropic", undefined, 1_000_000, 1_000_000),
+    ).toBeCloseTo(6, 6);
+    expect(b.quoteUsd(undefined, undefined, 1_000_000, 1_000_000)).toBeCloseTo(
+      6,
+      6,
+    );
+  });
+
+  it("quoteUsd is undefined when no usd cap is set (no routing)", () => {
+    const b = new RunBudget({ tokensMax: 100 }, TABLE);
+    expect(b.quoteUsd("openai", "m1", 1_000_000, 1_000_000)).toBeUndefined();
   });
 });

--- a/src/recipes/__tests__/yamlRunner.test.ts
+++ b/src/recipes/__tests__/yamlRunner.test.ts
@@ -3460,6 +3460,76 @@ describe("recipe.budget — tokensMax enforcement (PR2b)", () => {
     expect(result.stepResults[1]?.haltReason).toMatch(/budget_exceeded/);
   });
 
+  it("downshifts to a cheaper model when usdMax is tight (Phase 4)", async () => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), "pw-downshift-"));
+    const fixture = path.join(dir, "prices.json");
+    writeFileSync(
+      fixture,
+      JSON.stringify({
+        prices: {
+          "big-model": { input: 1_000_000, output: 1_000_000 }, // ~$1/token
+          "small-model": { input: 0.001, output: 0.001 },
+        },
+      }),
+    );
+    const prev = process.env.PATCHWORK_PRICE_TABLE;
+    process.env.PATCHWORK_PRICE_TABLE = fixture;
+    try {
+      const recipe = makeRecipe({
+        budget: { usdMax: 1 },
+        steps: [
+          {
+            agent: {
+              prompt: "do the thing",
+              model: "big-model",
+              downshift: [{ model: "small-model" }],
+              into: "o1",
+            },
+          },
+        ],
+      });
+      const seenModels: (string | undefined)[] = [];
+      await runYamlRecipe(recipe, {
+        ...noop(),
+        claudeFn: async (_prompt, model) => {
+          seenModels.push(model);
+          return { text: "ok", usage: { inputTokens: 10, outputTokens: 10 } };
+        },
+      });
+      // The expensive preferred model can't fit the $1 cap for the call, so the
+      // run downshifts to the cheaper listed model.
+      expect(seenModels).toEqual(["small-model"]);
+    } finally {
+      if (prev === undefined) delete process.env.PATCHWORK_PRICE_TABLE;
+      else process.env.PATCHWORK_PRICE_TABLE = prev;
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("ignores downshift when no usdMax is set (byte-identical)", async () => {
+    const recipe = makeRecipe({
+      steps: [
+        {
+          agent: {
+            prompt: "x",
+            model: "big-model",
+            downshift: [{ model: "small-model" }],
+            into: "o1",
+          },
+        },
+      ],
+    });
+    const seen: (string | undefined)[] = [];
+    await runYamlRecipe(recipe, {
+      ...noop(),
+      claudeFn: async (_p, m) => {
+        seen.push(m);
+        return "ok";
+      },
+    });
+    expect(seen).toEqual(["big-model"]); // preferred used; no routing
+  });
+
   it("does not enforce when recipe.budget is absent (no overhead)", async () => {
     const recipe = makeRecipe({
       steps: [

--- a/src/recipes/agentExecutor.ts
+++ b/src/recipes/agentExecutor.ts
@@ -73,7 +73,12 @@ export interface AgentExecutorInput {
   mcpAccess?: boolean;
 }
 
-const DEFAULT_MODEL = "claude-haiku-4-5-20251001";
+/**
+ * Model the anthropic/local agent paths fall back to when a step omits `model`.
+ * Exported so RunBudget.quoteUsd prices the same model executeAgent will run
+ * (keeps cost-routing quotes in parity with actual reconcile billing).
+ */
+export const DEFAULT_MODEL = "claude-haiku-4-5-20251001";
 
 export async function executeAgent(
   input: AgentExecutorInput,

--- a/src/recipes/pricing/__tests__/costRouter.test.ts
+++ b/src/recipes/pricing/__tests__/costRouter.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Cost-aware routing Phase 4 — the pure model selector. Author-ordered
+ * candidates [preferred, ...downshift]; pick the most-preferred that fits the
+ * remaining USD budget. Absent downshift ⇒ preferred unchanged.
+ */
+import { describe, expect, it } from "vitest";
+import { costRouter, type RouteCandidate } from "../costRouter.js";
+
+/** quote by model from a fixture; undefined = free/unpriced (always affordable). */
+function quoteFrom(prices: Record<string, number | undefined>) {
+  return (_driver: string | undefined, model: string | undefined) =>
+    model ? prices[model] : undefined;
+}
+
+const PREF: RouteCandidate = { driver: "openai", model: "gpt-4o" };
+
+describe("costRouter", () => {
+  it("returns preferred unchanged when downshift is absent or empty", () => {
+    expect(
+      costRouter(PREF, undefined, { remainingUsd: 0, quote: () => 999 }),
+    ).toEqual(PREF);
+    expect(costRouter(PREF, [], { remainingUsd: 0, quote: () => 999 })).toEqual(
+      PREF,
+    );
+  });
+
+  it("keeps preferred when it fits the remaining budget", () => {
+    const out = costRouter(PREF, [{ model: "cheap" }], {
+      remainingUsd: 5,
+      quote: quoteFrom({ "gpt-4o": 2, cheap: 0.1 }),
+    });
+    expect(out).toEqual({ driver: "openai", model: "gpt-4o" });
+  });
+
+  it("downshifts to the first cheaper candidate that fits", () => {
+    const out = costRouter(PREF, [{ model: "mid" }, { model: "cheap" }], {
+      remainingUsd: 1,
+      quote: quoteFrom({ "gpt-4o": 5, mid: 2, cheap: 0.5 }),
+    });
+    expect(out).toEqual({ driver: "openai", model: "cheap" });
+  });
+
+  it("inherits the preferred driver for a model-only downshift entry", () => {
+    const out = costRouter(PREF, [{ model: "cheap" }], {
+      remainingUsd: 0.1,
+      quote: quoteFrom({ "gpt-4o": 5, cheap: 0.05 }),
+    });
+    expect(out).toEqual({ driver: "openai", model: "cheap" });
+  });
+
+  it("treats a free/unpriced candidate (quote undefined) as affordable", () => {
+    const out = costRouter(PREF, [{ driver: "local", model: "llama3" }], {
+      remainingUsd: 0,
+      quote: (driver) => (driver === "local" ? undefined : 999),
+    });
+    expect(out).toEqual({ driver: "local", model: "llama3" });
+  });
+
+  it("falls back to the cheapest listed when none fit (admit then halts)", () => {
+    const out = costRouter(PREF, [{ model: "mid" }, { model: "cheap" }], {
+      remainingUsd: 0.01,
+      quote: quoteFrom({ "gpt-4o": 5, mid: 2, cheap: 0.5 }),
+    });
+    expect(out).toEqual({ driver: "openai", model: "cheap" }); // last listed
+  });
+});

--- a/src/recipes/pricing/costRouter.ts
+++ b/src/recipes/pricing/costRouter.ts
@@ -1,0 +1,69 @@
+/**
+ * Cost-aware model routing — cost-routing Phase 4 (pure selection).
+ *
+ * Opt-in, author-controlled "gearbox" on top of the `usdMax` brake (Phase 3):
+ * a per-step `downshift` list lets a recipe drop to a cheaper model as the USD
+ * budget tightens, instead of either blowing the cap or halting outright. The
+ * recipe author asserts each fallback is "good enough" for the step — the
+ * engine does NOT reason about model quality, only affordability.
+ *
+ * This module is the pure decision: given the preferred (driver, model), the
+ * author's ordered downshift candidates, and a quote() that estimates each
+ * candidate's USD cost, pick the most-preferred candidate that still fits the
+ * remaining budget. It loads nothing and has no side effects — the runner
+ * supplies remainingUsd + quote from RunBudget.
+ *
+ * Absent / empty `downshift` ⇒ returns `preferred` unchanged (byte-identical
+ * to no routing). Routing only runs when a USD cap is set (the runner passes
+ * remainingUsd only then).
+ */
+
+export interface RouteCandidate {
+  driver?: string;
+  model?: string;
+}
+
+export interface RouteContext {
+  /** USD left before `budget.usdMax`. The router runs only when a cap is set. */
+  remainingUsd: number;
+  /**
+   * Pre-dispatch USD estimate for a prospective (driver, model) call, or
+   * `undefined` when that call is NOT USD-enforced — a non-billable driver
+   * (local / subscription) or an unpriced model. An unenforced candidate is
+   * treated as always affordable (it costs nothing against the cap), so it is
+   * a valid "free" downshift target.
+   */
+  quote: (
+    driver: string | undefined,
+    model: string | undefined,
+  ) => number | undefined;
+}
+
+/**
+ * Pick the most-preferred candidate whose estimated cost fits `remainingUsd`.
+ * Candidates are tried in order `[preferred, ...downshift]`; a downshift entry
+ * inherits the preferred driver/model for any field it omits. If none fit, the
+ * last (cheapest listed) is returned and the admit()/reconcile() gate decides
+ * whether to halt — downshift slows the spend rate, it never overrides a breach.
+ */
+export function costRouter(
+  preferred: RouteCandidate,
+  downshift: RouteCandidate[] | undefined,
+  ctx: RouteContext,
+): RouteCandidate {
+  if (!downshift || downshift.length === 0) return preferred;
+
+  const candidates: RouteCandidate[] = [preferred, ...downshift].map((c) => ({
+    driver: c.driver ?? preferred.driver,
+    model: c.model ?? preferred.model,
+  }));
+
+  for (const cand of candidates) {
+    const q = ctx.quote(cand.driver, cand.model);
+    // undefined quote = unenforced (free / unpriced) → always affordable.
+    if (q === undefined || q <= ctx.remainingUsd) return cand;
+  }
+  // None fit — fall back to the cheapest listed; the budget gate halts if even
+  // that exceeds the cap on the next admission check.
+  return candidates[candidates.length - 1] ?? preferred;
+}

--- a/src/recipes/runBudget.ts
+++ b/src/recipes/runBudget.ts
@@ -23,7 +23,7 @@
  * = fail-open, which is the conservative default the design calls for.)
  */
 
-import type { AgentUsage } from "./agentExecutor.js";
+import { type AgentUsage, DEFAULT_MODEL } from "./agentExecutor.js";
 import {
   costUsd,
   loadPriceTable,
@@ -203,6 +203,56 @@ export class RunBudget {
   /** Warnings collected so the runner can surface them in the run log. */
   warnings(): string[] {
     return [...this.warningList];
+  }
+
+  /**
+   * USD remaining before the cap, or undefined when no USD cap is set.
+   * Cost-aware routing (Phase 4) uses this to decide when to downshift.
+   */
+  remainingUsd(): number | undefined {
+    if (this.usdMax === undefined) return undefined;
+    return Math.max(0, this.usdMax - this.usdSpent);
+  }
+
+  /**
+   * Pre-dispatch USD estimate for a prospective (driver, model) call, or
+   * undefined when it would NOT be USD-enforced: no USD cap, a non-billable
+   * driver (local / subscription), or an unpriced model. Mirrors exactly the
+   * enforcement rule in `reconcile`, so a candidate the router treats as
+   * "free" is precisely one `reconcile` would not charge.
+   */
+  quoteUsd(
+    driver: string | undefined,
+    model: string | undefined,
+    inputTokens: number,
+    outputTokens: number,
+  ): number | undefined {
+    if (this.usdMax === undefined) return undefined;
+    // Mirror executeAgent/reconcile resolution so a candidate the router calls
+    // "free" is EXACTLY one reconcile would not charge:
+    //   - "api"/"claude" select the billable Anthropic path (→ "anthropic").
+    //   - undefined optimistically assumes auto-detect lands on a metered API
+    //     driver (usually anthropic); if it actually resolves to a subscription
+    //     driver the call is free and the cap simply isn't enforced there.
+    const resolvedDriver =
+      driver === "api" || driver === "claude" ? "anthropic" : driver;
+    if (resolvedDriver !== undefined && !BILLABLE_DRIVERS.has(resolvedDriver)) {
+      return undefined;
+    }
+    // The anthropic path bills DEFAULT_MODEL when the step omits `model`.
+    // (Provider drivers default internally to a model unknowable pre-dispatch,
+    // so an omitted model there stays unpriced → not routed on.)
+    const onAnthropicPath =
+      resolvedDriver === "anthropic" || resolvedDriver === undefined;
+    const resolvedModel =
+      model ?? (onAnthropicPath ? DEFAULT_MODEL : undefined);
+    if (!resolvedModel) return undefined;
+    const cost = costUsd(
+      resolvedModel,
+      { inputTokens, outputTokens },
+      this.priceTable,
+    );
+    return cost !== undefined && Number.isFinite(cost) ? cost : undefined;
   }
 
   private pushOnce(key: string, msg: string): void {

--- a/src/recipes/schemaGenerator.ts
+++ b/src/recipes/schemaGenerator.ts
@@ -279,6 +279,32 @@ function generateRecipeSchema(
         description:
           "When the revision budget is exhausted and the judge still requests changes: 'halt' (default) fails the run; 'proceed' continues with the last draft.",
       },
+      downshift: {
+        type: "array",
+        description:
+          "OPT-IN cost-aware routing (Phase 4). Ordered cheaper fallbacks tried when budget.usdMax is set and the remaining budget is too tight for the preferred driver/model. Each entry overrides driver and/or model. Absent → preferred model always used.",
+        items: {
+          type: "object",
+          additionalProperties: false,
+          minProperties: 1,
+          properties: {
+            driver: {
+              type: "string",
+              enum: [
+                "claude",
+                "claude-code",
+                "api",
+                "openai",
+                "grok",
+                "gemini",
+                "anthropic",
+                "local",
+              ],
+            },
+            model: { type: "string" },
+          },
+        },
+      },
     },
   };
   const toolRefs = Object.keys(namespaceSchemas).map((ns) => ({

--- a/src/recipes/validation.ts
+++ b/src/recipes/validation.ts
@@ -14,6 +14,18 @@ import {
 import { generateSchemaSet } from "./schemaGenerator.js";
 import { listToolOutputContextKeys } from "./toolRegistry.js";
 
+/** Driver ids a `downshift` candidate may name (mirrors the JSON-schema enum). */
+const DOWNSHIFT_KNOWN_DRIVERS = new Set([
+  "claude",
+  "claude-code",
+  "api",
+  "openai",
+  "grok",
+  "gemini",
+  "anthropic",
+  "local",
+]);
+
 export interface LintIssue {
   level: "error" | "warning";
   message: string;
@@ -211,6 +223,58 @@ export function validateRecipeDefinition(recipe: unknown): LintResult {
               code: "refine-on-exhausted-enum",
               path: `steps.${i}.agent.on_exhausted`,
             });
+          }
+
+          // OPT-IN cost-aware routing (Phase 4). `downshift` is an ordered list
+          // of {driver?, model?} cheaper fallbacks; each entry must set at
+          // least one field and any driver must be dispatch-known.
+          if (agent.downshift !== undefined) {
+            if (!Array.isArray(agent.downshift)) {
+              issues.push({
+                level: "error",
+                message: `Step ${i + 1}: 'downshift' must be an array of {driver?, model?} candidates`,
+                code: "downshift-type",
+                path: `steps.${i}.agent.downshift`,
+              });
+            } else {
+              agent.downshift.forEach((entry: unknown, di: number) => {
+                if (
+                  typeof entry !== "object" ||
+                  entry === null ||
+                  Array.isArray(entry)
+                ) {
+                  issues.push({
+                    level: "error",
+                    message: `Step ${i + 1}: downshift[${di}] must be an object with 'driver' and/or 'model'`,
+                    code: "downshift-entry-type",
+                    path: `steps.${i}.agent.downshift.${di}`,
+                  });
+                  return;
+                }
+                const e = entry as Record<string, unknown>;
+                const hasDriver = typeof e.driver === "string";
+                const hasModel = typeof e.model === "string";
+                if (!hasDriver && !hasModel) {
+                  issues.push({
+                    level: "error",
+                    message: `Step ${i + 1}: downshift[${di}] must set at least one of 'driver' or 'model'`,
+                    code: "downshift-entry-empty",
+                    path: `steps.${i}.agent.downshift.${di}`,
+                  });
+                }
+                if (
+                  hasDriver &&
+                  !DOWNSHIFT_KNOWN_DRIVERS.has(e.driver as string)
+                ) {
+                  issues.push({
+                    level: "error",
+                    message: `Step ${i + 1}: downshift[${di}].driver '${String(e.driver)}' is not a known driver`,
+                    code: "downshift-driver-enum",
+                    path: `steps.${i}.agent.downshift.${di}.driver`,
+                  });
+                }
+              });
+            }
           }
         }
 

--- a/src/recipes/yamlRunner.ts
+++ b/src/recipes/yamlRunner.ts
@@ -73,6 +73,7 @@ import {
   defaultDeprecationWarn,
   normalizeRecipeForRuntime,
 } from "./migrations/index.js";
+import { costRouter, type RouteCandidate } from "./pricing/costRouter.js";
 import { resolveRecipePath } from "./resolveRecipePath.js";
 import { RunBudget } from "./runBudget.js";
 import type { ErrorPolicy } from "./schema.js";
@@ -162,6 +163,15 @@ export interface YamlStep {
      * Only meaningful alongside `max_revisions > 0`.
      */
     on_exhausted?: "halt" | "proceed";
+    /**
+     * OPT-IN cost-aware routing (cost-routing Phase 4). Ordered cheaper
+     * fallbacks, each overriding `driver` and/or `model`, tried when
+     * `budget.usdMax` is set and the remaining budget is too tight for the
+     * preferred driver/model. The author asserts each is good enough for the
+     * step — the engine only checks affordability. Absent ⇒ the preferred
+     * model is always used (byte-identical to no routing).
+     */
+    downshift?: import("./pricing/costRouter.js").RouteCandidate[];
   };
   into?: string;
   optional?: boolean;
@@ -1034,22 +1044,31 @@ export async function runYamlRecipe(
     driver: string | undefined,
     model: string | undefined,
     mcpAccess: boolean | undefined,
+    downshift?: RouteCandidate[],
   ): Promise<{ value: unknown; ok: boolean }> => {
+    // Phase 4: route revisions too, so a downshift on the reviewed step also
+    // applies to its refine-loop re-runs (no-op when downshift is absent).
+    const routed = resolveRouting(
+      { driver, model },
+      downshift,
+      prompt,
+      runBudget,
+    );
     const agentReturn = await _executeAgent(
       {
         prompt,
-        driver: driver === "api" ? "anthropic" : driver,
-        model,
+        driver: routed.driver === "api" ? "anthropic" : routed.driver,
+        model: routed.model,
         ...(mcpAccess !== undefined && { mcpAccess }),
       },
       buildAgentExecutorDeps(stepDeps, deps),
     );
     runBudget.reconcile(
       // Prefer the driver executeAgent actually resolved+ran; fall back to
-      // the configured value only when servedBy is absent (non-executeAgent
+      // the routed value only when servedBy is absent (non-executeAgent
       // callers). Stops auto-detected runs being mis-attributed to "auto".
       agentReturn.servedBy?.driver ??
-        (driver === "api" ? "anthropic" : (driver ?? "auto")),
+        (routed.driver === "api" ? "anthropic" : (routed.driver ?? "auto")),
       agentReturn.usage,
       // Resolved model for USD pricing (Phase 3). Absent → unpriced → the USD
       // cap fails open for this call.
@@ -1138,6 +1157,7 @@ export async function runYamlRecipe(
         reviewedAgent.driver,
         reviewedAgent.model,
         reviewedAgent.mcpAccess,
+        reviewedAgent.downshift,
       );
       if (!revised.ok) {
         // A failed / empty revision can't be re-judged — stop and treat the
@@ -1320,11 +1340,19 @@ export async function runYamlRecipe(
         // `RunBudget.reconcile` records a fail-open warning per driver per
         // run and continues.
         try {
+          // Phase 4: opt-in cost-aware routing. No-op (returns preferred) when
+          // the step has no `downshift` list or no USD cap is set.
+          const routed = resolveRouting(
+            { driver: agentCfg.driver, model: agentCfg.model },
+            agentCfg.downshift,
+            renderedPrompt,
+            runBudget,
+          );
           const agentReturn = await _executeAgent(
             {
               prompt: renderedPrompt,
-              driver: agentCfg.driver === "api" ? "anthropic" : agentCfg.driver,
-              model: agentCfg.model,
+              driver: routed.driver === "api" ? "anthropic" : routed.driver,
+              model: routed.model,
               ...(agentCfg.mcpAccess !== undefined && {
                 mcpAccess: agentCfg.mcpAccess,
               }),
@@ -1333,13 +1361,13 @@ export async function runYamlRecipe(
           );
           agentResult = agentReturn.text;
           runBudget.reconcile(
-            // Prefer the driver executeAgent actually resolved+ran; the
-            // configured value is only the fallback for non-executeAgent
-            // callers (it is often undefined → previously logged "auto").
+            // Prefer the driver executeAgent actually resolved+ran; the routed
+            // value is only the fallback for non-executeAgent callers (it is
+            // often undefined → previously logged "auto").
             agentReturn.servedBy?.driver ??
-              (agentCfg.driver === "api"
+              (routed.driver === "api"
                 ? "anthropic"
-                : (agentCfg.driver ?? "auto")),
+                : (routed.driver ?? "auto")),
             agentReturn.usage,
             // Resolved model for USD pricing (Phase 3); absent → fail open.
             agentReturn.servedBy?.model,
@@ -2360,6 +2388,34 @@ export function providerMetaToUsage(
     return { inputTokens, outputTokens };
   }
   return undefined;
+}
+
+const ROUTER_CHARS_PER_TOKEN = 4;
+
+/**
+ * Apply opt-in cost-aware routing (Phase 4) to choose the driver/model for an
+ * agent dispatch. Returns `preferred` UNCHANGED when there is no downshift list
+ * or no USD cap is set (byte-identical to no routing). The output-token figure
+ * is a deliberately-rough 1:1-of-input pre-dispatch estimate — enough to pick a
+ * gear; the real cost is reconciled after the call (see the cost-routing ADR).
+ * Exported for unit testing.
+ */
+export function resolveRouting(
+  preferred: RouteCandidate,
+  downshift: RouteCandidate[] | undefined,
+  promptText: string,
+  budget: RunBudget,
+): RouteCandidate {
+  if (!downshift || downshift.length === 0) return preferred;
+  const remainingUsd = budget.remainingUsd();
+  if (remainingUsd === undefined) return preferred; // no USD cap → no routing
+  const estInputTokens = Math.ceil(promptText.length / ROUTER_CHARS_PER_TOKEN);
+  const estOutputTokens = estInputTokens; // rough 1:1 assumption (documented)
+  return costRouter(preferred, downshift, {
+    remainingUsd,
+    quote: (driver, model) =>
+      budget.quoteUsd(driver, model, estInputTokens, estOutputTokens),
+  });
 }
 
 /** Returns a providerDriverFn with a per-run driver cache (not shared across runs). */


### PR DESCRIPTION
The "gearbox" on top of Phase 3's "brake": a per-step `agent.downshift: [{driver?, model?}]` lists cheaper fallbacks, and when the USD budget tightens the runner picks the most-preferred candidate that still fits instead of halting. **Opt-in + author-controlled** — the author asserts each fallback is good enough; the engine only checks affordability. Design: [`docs/design/cost-aware-routing.md`](../blob/main/docs/design/cost-aware-routing.md); **ADR: [`docs/adr/0015-cost-aware-routing.md`](../blob/feat/cost-routing-phase4-downshift/docs/adr/0015-cost-aware-routing.md)**.

> ⚠️ **Stacked on #865** (Phase 3 usdMax). Merge **#865 first**, then I rebase this onto main.

## Change

- **`costRouter.ts`** (pure): try `[preferred, ...downshift]` in order, pick the first whose estimated cost fits the remaining USD; a free/unpriced candidate (e.g. a local model) always fits; none fit → cheapest listed (`admit()` then halts). Absent/empty `downshift` → preferred unchanged.
- **`RunBudget.remainingUsd()` + `quoteUsd()`** — the router's inputs; `quoteUsd` mirrors `reconcile`'s enforcement exactly.
- **`resolveRouting()`** wired at **both** dispatch sites (main path + judge→refine revise); the re-judge call never downshifts. Routing sits **below** the `admit()` brake — it never overspends the cap or causes a wrong halt.
- Schema + validation for `downshift`.

## ⚠️ Adversarial review found one real parity bug (fixed + tested)

The 3-lens review converged on it: `quoteUsd` gated on the **raw** driver string, so `driver: api`/`claude` (both resolve to the billable `anthropic` path) and omitted-model anthropic steps were quoted **"free"** → the router never downshifted them, **silently defeating the feature for the most common Anthropic configs** (bounded by the `admit()` brake, so no overspend — but no routing either).

**Fix:** `quoteUsd` now resolves the driver (`api`/`claude` → `anthropic`) and the omitted-model default (→ `DEFAULT_MODEL`, now exported) exactly as `executeAgent`/`reconcile` do. Two documented residuals, both fail-toward-preferred (never a wrong halt): an omitted model on `openai`/`grok` is quoted unpriced (provider default unknowable pre-dispatch — specify the model); an undefined driver is optimistically the metered anthropic path.

## Tests

`costRouter` table; `RunBudget` `remainingUsd`/`quoteUsd` incl. the api/claude/omitted-model parity cases; `downshift` validation; integration (routes to the cheaper model when tight; **byte-identical no-op without `usdMax`**). Full suites **1008 green**; `tsc` (main + `tests.core`) + audit gates clean.

This completes the cost-aware-routing initiative (Phases 0–4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)