### PR TITLE
feat(recipes): cost-routing — opt-in estimateUnmeasured (≈$ for subscription drivers)

### DIFF
--- a/docs/adr/0015-cost-aware-routing.md
+++ b/docs/adr/0015-cost-aware-routing.md
@@ -34,7 +34,7 @@ Five opt-in phases, each byte-identical when unconfigured:
 ## Alternatives considered
 
 - **Declarative cost tiers (`tier:`/`routing:` + inline `pricing:`).** Rejected: ~400 LOC of tier-dictionary that duplicates what per-step `driver`+`model` already expresses, and an inline `pricing:` field is a budget-evasion footgun (a recipe could under-price a model to dodge `usdMax`). The leaner per-step `downshift` + out-of-band price overrides get the value without the surface.
-- **Estimate-and-halt for subscription drivers (`estimateUnmeasured: true` default).** Rejected as the default: it would hard-halt the token-blind subscription driver on a ~4-chars/token guess of notional spend — inverting fail-open. Deferred entirely; if it lands later it must default `false` and can only *warn*.
+- **Estimate-and-halt for subscription drivers (`estimateUnmeasured: true` default).** Rejected *as the default*: it would hard-halt the token-blind subscription driver on a ~4-chars/token guess of notional spend — inverting fail-open. **Shipped as opt-in, default `false`, warn-only:** when enabled it estimates the notional list-price USD an unmeasured call would have cost (`totals().usdEstimated`, surfaced as a `≈$X` run-log line) but tracks it entirely separately from `usdMax` — `admit()` never reads it, so it can never halt a run. A flat-rate subscription call is not real money out, and halting on an estimate would be wrong.
 - **A wall-clock CI staleness gate on the price table.** Rejected: a time-based hard-fail eventually breaks an unrelated PR. Shipped instead as a pure `isPriceTableStale` helper + a structural test, ready for a scheduled (non-PR) check.
 
 ## Consequences

--- a/src/recipes/__tests__/budgetValidation.test.ts
+++ b/src/recipes/__tests__/budgetValidation.test.ts
@@ -56,6 +56,16 @@ describe("recipe budget validation", () => {
     );
   });
 
+  it("accepts a boolean estimateUnmeasured", () => {
+    expect(budgetErrors({ usdMax: 1, estimateUnmeasured: true })).toBe("");
+  });
+
+  it("rejects a non-boolean estimateUnmeasured", () => {
+    expect(budgetErrors({ usdMax: 1, estimateUnmeasured: "yes" })).toMatch(
+      /estimateUnmeasured must be a boolean/,
+    );
+  });
+
   it("rejects a non-object budget", () => {
     expect(budgetErrors("nope")).toMatch(/'budget' must be an object/);
   });

--- a/src/recipes/__tests__/runBudget.test.ts
+++ b/src/recipes/__tests__/runBudget.test.ts
@@ -269,3 +269,68 @@ describe("RunBudget — routing helpers (cost-routing Phase 4)", () => {
     expect(b.quoteUsd("openai", "m1", 1_000_000, 1_000_000)).toBeUndefined();
   });
 });
+
+describe("RunBudget — estimateUnmeasured (opt-in ≈$ for subscription drivers)", () => {
+  // 4M chars / 4 = 1M tokens each side.
+  const est = { inputChars: 4_000_000, outputChars: 4_000_000 };
+
+  it("default (false): an unmeasured driver is skipped, no estimate", () => {
+    const b = new RunBudget({ usdMax: 1 }, TABLE);
+    b.reconcile("subprocess", undefined, "m1", est);
+    expect(b.totals().usdEstimated).toBeUndefined();
+    expect(
+      b.warnings().some((w) => /does not report token usage/i.test(w)),
+    ).toBe(true);
+  });
+
+  it("when true: accumulates a notional ≈$ estimate (m1 $1/1M each → $2)", () => {
+    const b = new RunBudget({ usdMax: 1, estimateUnmeasured: true }, TABLE);
+    b.reconcile("subprocess", undefined, "m1", est);
+    expect(b.totals().usdEstimated).toBeCloseTo(2, 6);
+    expect(b.warnings().some((w) => /estimating notional/i.test(w))).toBe(true);
+  });
+
+  it("NEVER halts on the estimate (warn-only) and never touches measured usd", () => {
+    const b = new RunBudget({ usdMax: 0.001, estimateUnmeasured: true }, TABLE);
+    b.reconcile("subprocess", undefined, "m1", est); // ≈$2 ≫ $0.001 cap
+    expect(b.admit().admitted).toBe(true); // estimate never gates admission
+    expect(b.totals().usd).toBe(0); // never enters measured usdSpent
+    expect(b.totals().usdBreached).toBe(false);
+  });
+
+  it("uses DEFAULT_MODEL when the step omits a model", () => {
+    const b = new RunBudget({ usdMax: 1, estimateUnmeasured: true }, TABLE);
+    // DEFAULT_MODEL $1 in / $5 out → 1M*$1 + 1M*$5 = $6.
+    b.reconcile("subprocess", undefined, undefined, est);
+    expect(b.totals().usdEstimated).toBeCloseTo(6, 6);
+  });
+
+  it("falls back to the skipped notice when no estimate chars are provided", () => {
+    const b = new RunBudget({ usdMax: 1, estimateUnmeasured: true }, TABLE);
+    b.reconcile("subprocess", undefined, "m1"); // no estimate arg
+    expect(b.totals().usdEstimated).toBeUndefined();
+    expect(
+      b.warnings().some((w) => /does not report token usage/i.test(w)),
+    ).toBe(true);
+  });
+
+  it("does nothing when estimateUnmeasured is set but usdMax is not", () => {
+    const b = new RunBudget(
+      { tokensMax: 100, estimateUnmeasured: true },
+      TABLE,
+    );
+    b.reconcile("subprocess", undefined, "m1", est);
+    expect(b.totals().usdEstimated).toBeUndefined();
+  });
+
+  it("finalWarnings appends a ≈$ summary; warnings() (live) does not", () => {
+    const b = new RunBudget({ usdMax: 1, estimateUnmeasured: true }, TABLE);
+    b.reconcile("subprocess", undefined, "m1", est);
+    expect(
+      b
+        .finalWarnings()
+        .some((w) => w.includes("≈$2.0000") && /never enforced/i.test(w)),
+    ).toBe(true);
+    expect(b.warnings().some((w) => /at list prices/i.test(w))).toBe(false);
+  });
+});

--- a/src/recipes/__tests__/yamlRunner.test.ts
+++ b/src/recipes/__tests__/yamlRunner.test.ts
@@ -3530,6 +3530,41 @@ describe("recipe.budget — tokensMax enforcement (PR2b)", () => {
     expect(seen).toEqual(["big-model"]); // preferred used; no routing
   });
 
+  it("surfaces a ≈$ estimate for unmeasured drivers when estimateUnmeasured is on", async () => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), "pw-estimate-"));
+    const fixture = path.join(dir, "prices.json");
+    writeFileSync(
+      fixture,
+      JSON.stringify({ prices: { "sub-model": { input: 100, output: 100 } } }),
+    );
+    const prev = process.env.PATCHWORK_PRICE_TABLE;
+    process.env.PATCHWORK_PRICE_TABLE = fixture;
+    try {
+      const recipe = makeRecipe({
+        budget: { usdMax: 1000, estimateUnmeasured: true },
+        steps: [
+          {
+            agent: {
+              prompt: "estimate me please",
+              model: "sub-model",
+              into: "o1",
+            },
+          },
+        ],
+      });
+      const result = await runYamlRecipe(recipe, {
+        ...noop(),
+        // Returns a STRING (no usage) → unmeasured, like a subscription CLI.
+        claudeFn: async () => "ok output",
+      });
+      expect(result.budgetWarnings?.some((w) => w.includes("≈$"))).toBe(true);
+    } finally {
+      if (prev === undefined) delete process.env.PATCHWORK_PRICE_TABLE;
+      else process.env.PATCHWORK_PRICE_TABLE = prev;
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it("does not enforce when recipe.budget is absent (no overhead)", async () => {
     const recipe = makeRecipe({
       steps: [

--- a/src/recipes/runBudget.ts
+++ b/src/recipes/runBudget.ts
@@ -41,6 +41,9 @@ import type { BudgetPolicy } from "./schema.js";
  */
 const BILLABLE_DRIVERS = new Set(["anthropic", "openai", "grok"]);
 
+/** Rough chars-per-token used for the opt-in unmeasured-driver USD estimate. */
+const ESTIMATE_CHARS_PER_TOKEN = 4;
+
 export interface BudgetAdmission {
   /** True = step may proceed. False = budget exhausted. */
   admitted: boolean;
@@ -58,6 +61,12 @@ export interface BudgetTotals {
   usd?: number;
   /** Remaining USD before breach. Undefined when no USD limit is set. */
   usdRemaining?: number;
+  /**
+   * Notional list-price USD estimated for unmeasured (subscription) calls when
+   * `estimateUnmeasured` is on. A label ONLY — never counted toward `usd` or
+   * `usdMax`, never halts. Present only when > 0.
+   */
+  usdEstimated?: number;
   /** True once total tokens >= tokensMax (false when no token limit). */
   breached: boolean;
   /** True once measured usd >= usdMax (false when no USD limit). */
@@ -70,10 +79,13 @@ export class RunBudget {
   private readonly tokensMax?: number;
   private readonly usdMax?: number;
   private readonly haltOnBreach: boolean;
+  private readonly estimateUnmeasured: boolean;
   private readonly priceTable?: PriceTable;
   private inputTokens = 0;
   private outputTokens = 0;
   private usdSpent = 0;
+  /** Notional list-price USD for unmeasured calls (warn-only; never enforced). */
+  private usdEstimated = 0;
   /** Dedup keys for one-time warnings (unmeasured driver, breach, etc.). */
   private readonly warnedKeys = new Set<string>();
   /** Free-form warnings surfaced via the run log. */
@@ -88,6 +100,7 @@ export class RunBudget {
     this.tokensMax = policy?.tokensMax;
     this.usdMax = policy?.usdMax;
     this.haltOnBreach = (policy?.onBreach ?? "halt") === "halt";
+    this.estimateUnmeasured = policy?.estimateUnmeasured ?? false;
     if (this.usdMax !== undefined) {
       this.priceTable = priceTable ?? loadPriceTable();
     }
@@ -127,9 +140,37 @@ export class RunBudget {
     driver: string,
     usage: AgentUsage | undefined,
     model?: string,
+    estimate?: { inputChars: number; outputChars: number },
   ): void {
     if (!this.hasBudget) return;
     if (!usage) {
+      if (this.usdMax !== undefined && this.estimateUnmeasured && estimate) {
+        // OPT-IN notional estimate for an unmeasured (subscription) driver.
+        // WARN-ONLY: accumulates into usdEstimated, NEVER usdSpent, and never
+        // affects admit() — a flat-rate subscription call is not real money out,
+        // and halting on a ~4-chars/token guess would be wrong.
+        const estModel = model ?? DEFAULT_MODEL;
+        const estCost = costUsd(
+          estModel,
+          {
+            inputTokens: Math.ceil(
+              estimate.inputChars / ESTIMATE_CHARS_PER_TOKEN,
+            ),
+            outputTokens: Math.ceil(
+              estimate.outputChars / ESTIMATE_CHARS_PER_TOKEN,
+            ),
+          },
+          this.priceTable,
+        );
+        if (estCost !== undefined && Number.isFinite(estCost)) {
+          this.usdEstimated += estCost;
+          this.pushOnce(
+            `estimate:${driver}`,
+            `Driver "${driver}" reports no usage — estimating notional list-price cost (≈, never enforced; see usdEstimated).`,
+          );
+          return;
+        }
+      }
       this.pushOnce(
         `unmeasured:${driver}`,
         `Driver "${driver}" does not report token usage — budget enforcement skipped for its calls. Set recipe.budget.onBreach="warn" or move to an API driver to fix.`,
@@ -194,6 +235,7 @@ export class RunBudget {
         usd: this.usdSpent,
         usdRemaining: Math.max(0, this.usdMax - this.usdSpent),
       }),
+      ...(this.usdEstimated > 0 && { usdEstimated: this.usdEstimated }),
       breached: this.tokenBreached(),
       usdBreached: this.usdMaxBreached(),
       haltOnBreach: this.haltOnBreach,
@@ -203,6 +245,22 @@ export class RunBudget {
   /** Warnings collected so the runner can surface them in the run log. */
   warnings(): string[] {
     return [...this.warningList];
+  }
+
+  /**
+   * Run-completion warnings: the live `warnings()` plus a one-line ≈$ summary
+   * of the notional cost estimated for unmeasured calls (only when
+   * `estimateUnmeasured` produced one). Use at run end; `warnings()` is the
+   * live per-driver list without the (end-of-run-only) summary.
+   */
+  finalWarnings(): string[] {
+    const out = [...this.warningList];
+    if (this.usdEstimated > 0) {
+      out.push(
+        `Unmeasured (subscription) calls would cost ≈$${this.usdEstimated.toFixed(4)} at list prices — estimate only, never enforced.`,
+      );
+    }
+    return out;
   }
 
   /**

--- a/src/recipes/schema.ts
+++ b/src/recipes/schema.ts
@@ -168,6 +168,16 @@ export interface BudgetPolicy {
    * production cron recipes. Applies to both `tokensMax` and `usdMax`.
    */
   onBreach?: "halt" | "warn";
+  /**
+   * OPT-IN, default **false**. When true, the runner ESTIMATES the notional USD
+   * a subscription/unmeasured driver call would have cost at list prices (from
+   * the prompt + output length) and surfaces a `≈$X` figure. This is a label
+   * ONLY — estimated spend is tracked separately from `usdMax` and can NEVER
+   * halt a run (subscription spend is flat-rate, not real money out; halting on
+   * a ~4-chars/token guess would be wrong). Requires `usdMax` to be set (it
+   * reuses the price table). Default false preserves the fail-open invariant.
+   */
+  estimateUnmeasured?: boolean;
 }
 
 export interface Recipe {

--- a/src/recipes/schemaGenerator.ts
+++ b/src/recipes/schemaGenerator.ts
@@ -673,6 +673,11 @@ function generateRecipeSchema(
             description:
               "Cumulative USD allowed across the whole run, priced from token usage via the model price table. Unpriced models / subscription drivers fail open (never halt on them).",
           },
+          estimateUnmeasured: {
+            type: "boolean",
+            description:
+              "OPT-IN (default false). Estimate the notional list-price USD an unmeasured/subscription call would have cost and surface a ≈$ figure. Label only — never counted toward usdMax, never halts. Requires usdMax.",
+          },
           onBreach: {
             type: "string",
             enum: ["halt", "warn"],

--- a/src/recipes/validation.ts
+++ b/src/recipes/validation.ts
@@ -378,6 +378,17 @@ function validateRecipeBudget(
       code: "budget-onbreach-enum",
     });
   }
+  if (
+    b.estimateUnmeasured !== undefined &&
+    typeof b.estimateUnmeasured !== "boolean"
+  ) {
+    issues.push({
+      level: "error",
+      message: "budget.estimateUnmeasured must be a boolean",
+      path: "budget.estimateUnmeasured",
+      code: "budget-estimate-type",
+    });
+  }
 }
 
 /**

--- a/src/recipes/yamlRunner.ts
+++ b/src/recipes/yamlRunner.ts
@@ -1073,6 +1073,8 @@ export async function runYamlRecipe(
       // Resolved model for USD pricing (Phase 3). Absent → unpriced → the USD
       // cap fails open for this call.
       agentReturn.servedBy?.model,
+      // Char counts for the opt-in unmeasured-driver ≈$ estimate (warn-only).
+      { inputChars: prompt.length, outputChars: agentReturn.text.length },
     );
     const text = agentReturn.text;
     // Same failure detection as the main agent branch: explicit failure
@@ -1371,6 +1373,11 @@ export async function runYamlRecipe(
             agentReturn.usage,
             // Resolved model for USD pricing (Phase 3); absent → fail open.
             agentReturn.servedBy?.model,
+            // Char counts for the opt-in unmeasured-driver ≈$ estimate.
+            {
+              inputChars: renderedPrompt.length,
+              outputChars: agentReturn.text.length,
+            },
           );
           // Catch both `[agent step failed: ...]` (existing) and the
           // silent-fail patterns `[agent step skipped: ...]` etc. via the
@@ -1807,8 +1814,8 @@ export async function runYamlRecipe(
           ...(runError !== undefined && { errorMessage: runError }),
           ...(assertionFailures.length > 0 ? { assertionFailures } : {}),
           ...(inboxOutputs.length > 0 ? { inboxOutputs } : {}),
-          ...(runBudget.warnings().length > 0
-            ? { budgetWarnings: runBudget.warnings() }
+          ...(runBudget.finalWarnings().length > 0
+            ? { budgetWarnings: runBudget.finalWarnings() }
             : {}),
         });
         emit("recipe_done", {
@@ -1902,8 +1909,8 @@ export async function runYamlRecipe(
     stepResults,
     errorMessage: runError,
     ...(assertionFailures.length > 0 ? { assertionFailures } : {}),
-    ...(runBudget.warnings().length > 0
-      ? { budgetWarnings: runBudget.warnings() }
+    ...(runBudget.finalWarnings().length > 0
+      ? { budgetWarnings: runBudget.finalWarnings() }
       : {}),
   };
 }


### PR DESCRIPTION
The deferred Phase-3 honesty mechanism: when `budget.estimateUnmeasured` is true (**default false**), the runner estimates the notional list-price USD a subscription/unmeasured-driver call would have cost (from prompt+output length) and surfaces a **`≈$X`** figure. Closes out the cost-aware-routing initiative.

> ⚠️ **Stacked on #866** (Phase 4). Merge **#866 first**, then I rebase this onto main.

## It's a label, never a brake

This was the one feature with a real footgun — estimating-then-halting the token-blind subscription driver on a guess would invert fail-open. So:

- `usdEstimated` is tracked **entirely separately** from `usdSpent`/`usdMax`. **`admit()` never reads it**, so estimation can **never halt a run**. A flat-rate subscription call is not real money out.
- **Default `false`** preserves the existing fail-open behaviour exactly.

## Change

- `RunBudget`: `estimateUnmeasured` + `usdEstimated`; `reconcile()` gains an optional `{inputChars, outputChars}` arg and, **in the unmeasured branch only**, prices `model ?? DEFAULT_MODEL` into `usdEstimated`; `totals().usdEstimated`; `finalWarnings()` appends a one-line `≈$X … never enforced` summary, surfaced via the existing `budgetWarnings` run-log channel.
- Both reconcile call sites pass the prompt/output char counts. Schema + validation for `budget.estimateUnmeasured` (boolean). ADR-0015 updated.

## Tests

default-off no-op; accumulation; **NEVER-halts** (admit stays `true` far over `usdMax`, `usd` stays 0); `DEFAULT_MODEL` fallback for an omitted model; no-`usdMax` no-op; `finalWarnings` `≈$` summary; validation; end-to-end (string-returning `claudeFn` → `budgetWarnings` contains `≈$`). Full suites **1018 green**; `tsc` (main + `tests.core`) + audit gates clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)