### PR TITLE
fix(recipes,automation): patch 5 HIGH-severity logic findings from 2026-06-03 audit

### DIFF
--- a/src/__tests__/claudeOrchestrator.test.ts
+++ b/src/__tests__/claudeOrchestrator.test.ts
@@ -437,6 +437,50 @@ describe("ClaudeOrchestrator — persistence", () => {
     expect(task?.prompt).toBe("persisted-pending");
   });
 
+  it("loadPersistedTasks — preserves useAnt/mcpAccess/isAutomationTask across reload + re-persist (audit 2026-06-03 HIGH #11)", async () => {
+    const stableId = "11111111-2222-3333-4444-555555555555";
+    const v1Payload = {
+      version: 1,
+      savedAt: Date.now(),
+      tasks: [
+        {
+          id: stableId,
+          sessionId: "",
+          prompt: "agent-task",
+          contextFiles: [],
+          status: "pending",
+          createdAt: Date.now() - 5000,
+          timeoutMs: 120_000,
+          tokenEstimate: 10,
+          useAnt: true,
+          mcpAccess: true,
+          isAutomationTask: true,
+        },
+      ],
+    };
+    mockReadFile.mockResolvedValueOnce(JSON.stringify(v1Payload));
+
+    const orch = new ClaudeOrchestrator(makeSlowDriver(60_000), "/tmp", noop);
+    await orch.loadPersistedTasks(9999);
+
+    // Restored task must carry the flags (else it runs with the wrong binary /
+    // no MCP access / no automation guard).
+    const task = orch.getTask(stableId);
+    expect(task?.useAnt).toBe(true);
+    expect(task?.mcpAccess).toBe(true);
+    expect(task?.isAutomationTask).toBe(true);
+
+    // And they must round-trip back out on the next persist.
+    await orch.persistTasks(9999);
+    const [, jsonStr] = mockWriteFile.mock.calls.at(-1) as [string, string];
+    const persisted = JSON.parse(jsonStr).tasks.find(
+      (t: { id: string }) => t.id === stableId,
+    );
+    expect(persisted.useAnt).toBe(true);
+    expect(persisted.mcpAccess).toBe(true);
+    expect(persisted.isAutomationTask).toBe(true);
+  });
+
   it("loadPersistedTasks — interrupted tasks become history (not re-enqueued)", async () => {
     const id = "ffffffff-0000-0000-0000-000000000001";
     const v1Payload = {

--- a/src/claudeOrchestrator.ts
+++ b/src/claudeOrchestrator.ts
@@ -140,6 +140,13 @@ interface PersistedTask {
   startupMs?: number;
   triggerSource?: string;
   systemPrompt?: string;
+  // Audit 2026-06-03 (HIGH #11): these must survive a persist→restart→reload
+  // round-trip. Dropping them silently re-ran tasks with the wrong binary
+  // (useAnt), without bridge tool access (mcpAccess), or without the
+  // automation infinite-chain guard (isAutomationTask).
+  useAnt?: boolean;
+  mcpAccess?: boolean;
+  isAutomationTask?: boolean;
 }
 
 export class ClaudeOrchestrator {
@@ -568,6 +575,11 @@ export class ClaudeOrchestrator {
         ...(t.wasAborted !== undefined && { wasAborted: t.wasAborted }),
         ...(t.startupMs !== undefined && { startupMs: t.startupMs }),
         ...(t.systemPrompt !== undefined && { systemPrompt: t.systemPrompt }),
+        ...(t.useAnt !== undefined && { useAnt: t.useAnt }),
+        ...(t.mcpAccess !== undefined && { mcpAccess: t.mcpAccess }),
+        ...(t.isAutomationTask !== undefined && {
+          isAutomationTask: t.isAutomationTask,
+        }),
         ...(t.triggerSource !== undefined && {
           triggerSource: t.triggerSource,
         }),
@@ -727,6 +739,11 @@ export class ClaudeOrchestrator {
               ...(t.systemPrompt !== undefined && {
                 systemPrompt: t.systemPrompt,
               }),
+              ...(t.useAnt !== undefined && { useAnt: t.useAnt }),
+              ...(t.mcpAccess !== undefined && { mcpAccess: t.mcpAccess }),
+              ...(t.isAutomationTask !== undefined && {
+                isAutomationTask: t.isAutomationTask,
+              }),
             });
             reenqueued++;
           } else {
@@ -804,6 +821,11 @@ export class ClaudeOrchestrator {
       }),
       ...(typeof t.startupMs === "number" && { startupMs: t.startupMs }),
       ...(t.systemPrompt !== undefined && { systemPrompt: t.systemPrompt }),
+      ...(t.useAnt !== undefined && { useAnt: t.useAnt }),
+      ...(t.mcpAccess !== undefined && { mcpAccess: t.mcpAccess }),
+      ...(t.isAutomationTask !== undefined && {
+        isAutomationTask: t.isAutomationTask,
+      }),
     };
     this.tasks.set(task.id, task);
   }

--- a/src/connectors/__tests__/tokenStorage.test.ts
+++ b/src/connectors/__tests__/tokenStorage.test.ts
@@ -10,6 +10,7 @@ import os from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
+  __setKeychainOpsForTest,
   deleteTokens,
   getTokens,
   listStoredProviders,
@@ -130,5 +131,48 @@ describe("tokenStorage", () => {
 
     expect(retrieved?.accessToken).toBe("no-refresh");
     expect(retrieved?.refreshToken).toBeUndefined();
+  });
+});
+
+describe("tokenStorage native-backend fallback eviction (audit 2026-06-03 HIGH #10)", () => {
+  const tmpDir = join(os.tmpdir(), `patchwork-test-tokens-kc-${Date.now()}`);
+
+  beforeEach(() => {
+    process.env.PATCHWORK_HOME = tmpDir;
+    process.env.PATCHWORK_TOKEN_STORAGE_BACKEND = "native";
+    if (!existsSync(tmpDir)) mkdirSync(tmpDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    __setKeychainOpsForTest(null);
+    delete process.env.PATCHWORK_HOME;
+    delete process.env.PATCHWORK_TOKEN_STORAGE_BACKEND;
+    if (existsSync(tmpDir)) rmSync(tmpDir, { recursive: true });
+  });
+
+  it("evicts the stale keychain entry when a later write falls back to file", async () => {
+    const kc = new Map<string, string>();
+    let keychainWritable = true;
+    __setKeychainOpsForTest({
+      set: (k, v) => {
+        if (!keychainWritable) return false;
+        kc.set(k, v);
+        return true;
+      },
+      get: (k) => (kc.has(k) ? (kc.get(k) as string) : null),
+      delete: (k) => kc.delete(k),
+    });
+
+    // 1) First write succeeds → lands in the (fake) keychain.
+    await storeTokens("kc-provider", { accessToken: "STALE-TOKEN" });
+    expect((await getTokens("kc-provider"))?.accessToken).toBe("STALE-TOKEN");
+
+    // 2) Keychain writes now fail (e.g. locked keychain). The fresh token must
+    //    fall back to the encrypted file AND the stale keychain entry must be
+    //    evicted — otherwise getTokens (keychain-first) returns the old token.
+    keychainWritable = false;
+    await storeTokens("kc-provider", { accessToken: "FRESH-TOKEN" });
+
+    expect((await getTokens("kc-provider"))?.accessToken).toBe("FRESH-TOKEN");
   });
 });

--- a/src/connectors/tokenStorage.ts
+++ b/src/connectors/tokenStorage.ts
@@ -71,6 +71,12 @@ export function storeSecretJsonSync(provider: string, value: unknown): void {
     return;
   }
 
+  // Keychain write failed — fall back to the encrypted file. Audit 2026-06-03
+  // (HIGH #10): evict any stale keychain entry first. getSecretJsonSync reads
+  // the keychain BEFORE the file, so leaving an old entry behind would make it
+  // return the stale credential and ignore this fresh write — leaving the
+  // connector "connected" with a revoked token until manual cleanup.
+  deleteKeychainItemSync(key);
   setEncryptedFileSync(key, json);
 }
 
@@ -449,7 +455,21 @@ function resolveBackend(): TokenStorageBackend {
 }
 
 // Platform abstraction
+
+/** Injectable keychain ops — lets tests exercise the native backend + its
+ *  fallback paths without touching the real OS credential store. */
+export interface KeychainOpsForTest {
+  set: (key: string, value: string) => boolean;
+  get: (key: string) => string | null;
+  delete: (key: string) => boolean;
+}
+let _keychainOverride: KeychainOpsForTest | null = null;
+export function __setKeychainOpsForTest(ops: KeychainOpsForTest | null): void {
+  _keychainOverride = ops;
+}
+
 function setKeychainItemSync(key: string, value: string): boolean {
+  if (_keychainOverride) return _keychainOverride.set(key, value);
   if (process.platform === "darwin") {
     return setMacOSKeychainItemSync(key, value);
   }
@@ -460,6 +480,7 @@ function setKeychainItemSync(key: string, value: string): boolean {
 }
 
 function getKeychainItemSync(key: string): string | null {
+  if (_keychainOverride) return _keychainOverride.get(key);
   if (process.platform === "darwin") {
     return getMacOSKeychainItemSync(key);
   }
@@ -470,6 +491,7 @@ function getKeychainItemSync(key: string): string | null {
 }
 
 function deleteKeychainItemSync(key: string): boolean {
+  if (_keychainOverride) return _keychainOverride.delete(key);
   if (process.platform === "darwin") {
     return deleteMacOSKeychainItemSync(key);
   }

--- a/src/fp/__tests__/policyParser.test.ts
+++ b/src/fp/__tests__/policyParser.test.ts
@@ -98,6 +98,41 @@ describe("parsePolicy", () => {
     }
   });
 
+  it("nests WithRetry OUTSIDE WithDedup when both are configured (audit 2026-06-03 HIGH #12)", () => {
+    // A scheduled retry re-enters the OUTERMOST node. If WithDedup were the
+    // outer wrapper (WithDedup → WithRetry → Hook), a task that only succeeds
+    // on a retry would never re-pass through WithDedup, so the dedup key would
+    // never be recorded and identical content would re-fire forever. Retry
+    // must wrap dedup: WithRetry → WithDedup → Hook.
+    const policy = minPolicy({
+      onDiagnosticsError: {
+        enabled: true,
+        minSeverity: "error",
+        cooldownMs: 10_000,
+        prompt: "check errors in {{file}}",
+        dedupeByContent: true,
+        dedupeContentCooldownMs: 900_000,
+        retryCount: 2,
+        retryDelayMs: 15_000,
+      },
+    });
+    const result = parsePolicy(policy);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const top = result.value[0];
+    if (!top) throw new Error("expected first node");
+    expect(top._tag).toBe("WithRetry");
+    if (top._tag === "WithRetry") {
+      expect(top.maxRetries).toBe(2);
+      expect(top.program._tag).toBe("WithDedup");
+      if (top.program._tag === "WithDedup") {
+        expect(top.program.cooldownMs).toBe(900_000);
+        expect(top.program.program._tag).toBe("Hook");
+      }
+    }
+  });
+
   it("wraps WithRetry for hook with retryCount > 0", () => {
     const policy = minPolicy({
       onGitPush: {

--- a/src/fp/policyParser.ts
+++ b/src/fp/policyParser.ts
@@ -188,14 +188,12 @@ function buildHook(
     ? hookNode
     : withCooldown(key, safeCooldownMs, hookNode);
 
-  // Wrap WithRetry around WithCooldown if retryCount > 0
-  const retryCount = src.retryCount ?? 0;
-  if (retryCount > 0) {
-    const retryDelayMs = Math.max(5_000, src.retryDelayMs ?? 30_000);
-    program = withRetry(key, retryCount, retryDelayMs, program);
-  }
-
-  // Wrap WithDedup for diagnostics error with dedupeByContent
+  // Wrap WithDedup for diagnostics error with dedupeByContent.
+  // Audit 2026-06-03 (HIGH #12): dedup must be wrapped BEFORE (inside) retry.
+  // A scheduled retry re-enters the OUTERMOST node; with WithDedup as the outer
+  // wrapper a retried-into-success task never re-passed through dedup, so the
+  // dedup key was never recorded and identical content re-fired forever.
+  // Final order: WithRetry → WithDedup → Hook.
   if (useDedup) {
     const dedupCooldown = Math.max(
       5_000,
@@ -203,6 +201,14 @@ function buildHook(
         .dedupeContentCooldownMs ?? 900_000,
     );
     program = withDedup(`dedup:${key}`, dedupCooldown, program);
+  }
+
+  // Wrap WithRetry (outermost) so retries re-enter the full stack — cooldown
+  // and dedup included — and record their state on success.
+  const retryCount = src.retryCount ?? 0;
+  if (retryCount > 0) {
+    const retryDelayMs = Math.max(5_000, src.retryDelayMs ?? 30_000);
+    program = withRetry(key, retryCount, retryDelayMs, program);
   }
 
   return ok(program);

--- a/src/recipes/__tests__/chainedRunner.test.ts
+++ b/src/recipes/__tests__/chainedRunner.test.ts
@@ -448,6 +448,38 @@ describe("runChainedRecipe", () => {
     expect(alwaysFailDeps.executeTool).toHaveBeenCalledTimes(3);
   });
 
+  it("still runs the step exactly once when retry is negative (audit 2026-06-03 HIGH #8)", async () => {
+    // A negative retry (typo / misconfig) previously made `attempt <= maxRetries`
+    // immediately false, so the step NEVER executed and reported as failed with
+    // no diagnostic. The step must still run once (retries clamped to >= 0).
+    const okDeps = {
+      ...noopDeps,
+      executeTool: vi.fn().mockResolvedValue(undefined),
+    };
+    const recipe: ChainedRecipe = {
+      name: "test",
+      steps: [{ id: "a", tool: "t", retry: -1, retryDelay: 0 }],
+    };
+    const result = await runChainedRecipe(recipe, baseOptions, okDeps);
+    expect(result.success).toBe(true);
+    expect(okDeps.executeTool).toHaveBeenCalledTimes(1);
+  });
+
+  it("caps an absurdly large retry count instead of looping unboundedly (audit 2026-06-03 HIGH #8)", async () => {
+    const alwaysFailDeps = {
+      ...noopDeps,
+      executeTool: vi.fn().mockRejectedValue(new Error("permanent")),
+    };
+    const recipe: ChainedRecipe = {
+      name: "test",
+      steps: [{ id: "a", tool: "t", retry: 1_000_000, retryDelay: 0 }],
+    };
+    const result = await runChainedRecipe(recipe, baseOptions, alwaysFailDeps);
+    expect(result.success).toBe(false);
+    // Clamped to MAX_RETRIES (20) → 1 initial + 20 retries = 21 calls, not 1e6.
+    expect(alwaysFailDeps.executeTool).toHaveBeenCalledTimes(21);
+  });
+
   it("counts skipped steps correctly", async () => {
     const recipe: ChainedRecipe = {
       name: "test",

--- a/src/recipes/__tests__/parser.test.ts
+++ b/src/recipes/__tests__/parser.test.ts
@@ -110,6 +110,26 @@ describe("parseRecipe", () => {
     }
   });
 
+  // Regression (audit 2026-06-03 HIGH #9): the JSON schema documents the cron
+  // expression field as `at`, and validateRecipeDefinition reads `trigger.at`
+  // (after normalization), but parseRecipe — the install path — only read
+  // `trigger.schedule` and threw `cron.schedule required`. A schema-compliant
+  // recipe using `at:` passed `recipe lint` but failed `recipe install`.
+  it("accepts cron `at` as an alias for `schedule`", () => {
+    const r = parseRecipe({
+      ...VALID,
+      trigger: { type: "cron", at: "0 9 * * *" },
+    });
+    expect(r.trigger.type).toBe("cron");
+    expect((r.trigger as { schedule: string }).schedule).toBe("0 9 * * *");
+  });
+
+  it("still requires a cron expression (neither schedule nor at)", () => {
+    expect(() => parseRecipe({ ...VALID, trigger: { type: "cron" } })).toThrow(
+      /cron\.schedule/,
+    );
+  });
+
   // Regression: parser.ts rejected `chained`, `on_file_save`, and
   // `on_test_run` even though validateRecipeDefinition, the JSON schema,
   // and the runtime (chainedRunner / dispatchRecipe / yamlRunner) all

--- a/src/recipes/chainedRunner.ts
+++ b/src/recipes/chainedRunner.ts
@@ -579,13 +579,26 @@ interface StepExecResult {
   resolvedParams?: unknown;
 }
 
+/** Upper bound on retries — clamps absurd/misconfigured values so a recipe
+ *  can't spin a step unboundedly. Mirrors the `maximum` on `retry` in the
+ *  recipe JSON schema. */
+const MAX_RETRIES = 20;
+
 async function withRetry(
   fn: () => Promise<StepExecResult>,
   maxRetries: number,
   delayMs: number,
 ): Promise<StepExecResult> {
+  // Audit 2026-06-03 (HIGH #8): clamp the retry count. A negative value (typo
+  // like `retry: -1`) made `attempt <= maxRetries` immediately false, so the
+  // step NEVER ran and silently reported as failed. A non-finite or huge value
+  // would spin unboundedly. Floor to an integer in [0, MAX_RETRIES]; non-finite
+  // → 0 (run once, no retries).
+  const safeRetries = Number.isFinite(maxRetries)
+    ? Math.min(MAX_RETRIES, Math.max(0, Math.floor(maxRetries)))
+    : 0;
   let last: StepExecResult = { success: false };
-  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+  for (let attempt = 0; attempt <= safeRetries; attempt++) {
     if (attempt > 0) {
       await new Promise((r) => setTimeout(r, delayMs));
     }

--- a/src/recipes/parser.ts
+++ b/src/recipes/parser.ts
@@ -109,13 +109,25 @@ function parseTrigger(raw: unknown): Trigger {
           "path",
         ]);
       return { type: "webhook", path: t.path };
-    case "cron":
-      if (typeof t.schedule !== "string" || !t.schedule.trim())
-        throw new RecipeParseError("cron.schedule required", [
+    case "cron": {
+      // Audit 2026-06-03 (HIGH #9): accept both `schedule` and the schema-
+      // documented `at` field. validateRecipeDefinition reads `trigger.at`
+      // (post-normalization) so a recipe authored with `at:` lints fine; the
+      // install path goes through here, so without this alias it threw
+      // `cron.schedule required` and lint-passing recipes failed to install.
+      const cronExpr =
+        typeof t.schedule === "string" && t.schedule.trim()
+          ? t.schedule
+          : typeof t.at === "string" && t.at.trim()
+            ? t.at
+            : null;
+      if (!cronExpr)
+        throw new RecipeParseError("cron.schedule (or cron.at) required", [
           "trigger",
           "schedule",
         ]);
-      return { type: "cron", schedule: t.schedule };
+      return { type: "cron", schedule: cronExpr };
+    }
     case "file_watch":
       if (!Array.isArray(t.patterns) || t.patterns.length === 0)
         throw new RecipeParseError("file_watch.patterns required", [


### PR DESCRIPTION
## Summary

Test-first fixes for the five non-security HIGH-severity bugs from the 2026-06-03 audit (`docs/audit-2026-06-03.md`). Follow-up to #868 (security batch).

| # | Bug | Fix |
|---|-----|-----|
| 8 | Negative `on_error.retry`/`step.retry` made the step **never run** (loop `attempt <= -1` is false) and report failed with no diagnostic; huge values spun unboundedly | Clamp retries to `[0, 20]` in `withRetry` |
| 9 | Cron `trigger.at` (the schema-documented field) passed `recipe lint` but failed `recipe install` — `parseRecipe` only read `schedule` | Accept `at` as an alias for `schedule` |
| 10 | After a keychain write fails and falls back to the encrypted file, a **stale keychain entry** was left behind; `getSecretJsonSync` reads keychain-first → returned the revoked token | Evict the keychain entry before the file fallback (+ injectable keychain seam for tests) |
| 11 | `useAnt` / `mcpAccess` / `isAutomationTask` were **dropped** on the persist→restart→reload round-trip → re-enqueued tasks lost the ant binary / MCP access / automation guard | Add the fields to `PersistedTask` + serialize + both restore paths |
| 12 | `WithDedup(WithRetry(Hook))` — a scheduled retry re-enters only the retry node, so a task that succeeds on retry **never records the dedup key** → identical content re-fires forever | Reorder to `WithRetry(WithDedup(Hook))` so retries re-enter dedup |

## Testing

Each fix is test-first (reproduce → fix → prove); 205 tests across the 6 affected suites pass:
- `chainedRunner` (negative + absurd retry), `parser` (cron `at` alias), `tokenStorage` (keychain fallback eviction round-trip), `claudeOrchestrator` (field round-trip), `policyParser` (retry-outside-dedup structure), `automationInterpreter` (regression).
- Fixture-hygiene gate, `tsc --noEmit`, and biome all clean.

## Notes
- #10 adds a small `__setKeychainOpsForTest` seam (mirrors the existing `__setPgModuleForTest` pattern) so the native-backend fallback is testable without touching the real OS credential store.
- Remaining audit items (19 MEDIUM / 44 LOW, connector-step parity, dashboard facelift) stay tracked in `docs/audit-2026-06-03.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)