### PR TITLE
fix(connectors,oauth): connector security hardening — 2 MEDIUM audit findings

### DIFF
--- a/src/__tests__/oauth-cimd-ssrf.test.ts
+++ b/src/__tests__/oauth-cimd-ssrf.test.ts
@@ -12,6 +12,7 @@
 
 import ipaddr from "ipaddr.js";
 import { describe, expect, it } from "vitest";
+import { isValidCimdRedirectUri } from "../oauth.js";
 
 /**
  * Mirror of the production guard. Kept inline so any drift in the actual
@@ -142,5 +143,38 @@ describe("CIMD SSRF — IPv4 numeric normalization", () => {
   });
   it("blocks hex IPv4 (0x7f000001 = 127.0.0.1)", () => {
     expect(isPrivateIp("0x7f000001")).toBe(true);
+  });
+});
+
+describe("isValidCimdRedirectUri (audit 2026-06-03 MEDIUM #28)", () => {
+  it("accepts a plain https redirect URI", () => {
+    expect(isValidCimdRedirectUri("https://claude.ai/api/mcp/callback")).toBe(
+      true,
+    );
+    expect(isValidCimdRedirectUri("https://app.example.com/cb?x=1")).toBe(true);
+  });
+
+  it("rejects non-https schemes (http downgrade, custom scheme)", () => {
+    expect(isValidCimdRedirectUri("http://claude.ai/cb")).toBe(false);
+    expect(isValidCimdRedirectUri("ftp://evil/cb")).toBe(false);
+    expect(isValidCimdRedirectUri("javascript:alert(1)")).toBe(false);
+  });
+
+  it("rejects a URI carrying a #fragment (RFC 6749 §3.1.2 / smuggling)", () => {
+    expect(isValidCimdRedirectUri("https://claude.ai/cb#frag")).toBe(false);
+    expect(isValidCimdRedirectUri("https://claude.ai/cb#")).toBe(false);
+  });
+
+  it("rejects embedded userinfo credentials", () => {
+    expect(isValidCimdRedirectUri("https://user:pass@claude.ai/cb")).toBe(
+      false,
+    );
+    expect(isValidCimdRedirectUri("https://user@claude.ai/cb")).toBe(false);
+  });
+
+  it("rejects unparseable / non-absolute values", () => {
+    expect(isValidCimdRedirectUri("/relative/cb")).toBe(false);
+    expect(isValidCimdRedirectUri("not a url")).toBe(false);
+    expect(isValidCimdRedirectUri("")).toBe(false);
   });
 });

--- a/src/connectors/__tests__/postgres.test.ts
+++ b/src/connectors/__tests__/postgres.test.ts
@@ -271,6 +271,65 @@ describe("query()", () => {
   });
 });
 
+describe("TLS verification (audit 2026-06-03 MEDIUM #25)", () => {
+  it("verifies the server certificate by default when ssl is enabled", async () => {
+    const { getPostgresConnector, __setPgModuleForTest, saveTokens } =
+      await import("../postgres.js");
+    const fake = makeFakePg({ rows: [] });
+    __setPgModuleForTest(fake.pg);
+    saveTokens({
+      host: "db.example.com",
+      database: "d",
+      user: "u",
+      password: "p",
+      ssl: true,
+      connected_at: new Date().toISOString(),
+    });
+    await getPostgresConnector().query("SELECT 1");
+    const config = (fake.pg.Pool as unknown as { mock: { calls: unknown[][] } })
+      .mock.calls[0]![0] as { ssl?: { rejectUnauthorized?: boolean } };
+    expect(config.ssl).toEqual({ rejectUnauthorized: true });
+  });
+
+  it("allows opting out of verification via sslRejectUnauthorized:false", async () => {
+    const { getPostgresConnector, __setPgModuleForTest, saveTokens } =
+      await import("../postgres.js");
+    const fake = makeFakePg({ rows: [] });
+    __setPgModuleForTest(fake.pg);
+    saveTokens({
+      host: "db.internal",
+      database: "d",
+      user: "u",
+      password: "p",
+      ssl: true,
+      sslRejectUnauthorized: false,
+      connected_at: new Date().toISOString(),
+    });
+    await getPostgresConnector().query("SELECT 1");
+    const config = (fake.pg.Pool as unknown as { mock: { calls: unknown[][] } })
+      .mock.calls[0]![0] as { ssl?: { rejectUnauthorized?: boolean } };
+    expect(config.ssl).toEqual({ rejectUnauthorized: false });
+  });
+
+  it("omits ssl config entirely when ssl is not set", async () => {
+    const { getPostgresConnector, __setPgModuleForTest, saveTokens } =
+      await import("../postgres.js");
+    const fake = makeFakePg({ rows: [] });
+    __setPgModuleForTest(fake.pg);
+    saveTokens({
+      host: "db.local",
+      database: "d",
+      user: "u",
+      password: "p",
+      connected_at: new Date().toISOString(),
+    });
+    await getPostgresConnector().query("SELECT 1");
+    const config = (fake.pg.Pool as unknown as { mock: { calls: unknown[][] } })
+      .mock.calls[0]![0] as { ssl?: unknown };
+    expect(config.ssl).toBeUndefined();
+  });
+});
+
 // ── Missing driver path ─────────────────────────────────────────────────────
 
 describe("missing pg driver", () => {

--- a/src/connectors/postgres.ts
+++ b/src/connectors/postgres.ts
@@ -37,6 +37,13 @@ export interface PostgresTokens {
   user?: string;
   password?: string;
   ssl?: boolean;
+  /**
+   * Opt OUT of TLS certificate verification (self-signed / internal CA setups).
+   * Defaults to verifying — see buildPgConfig. Audit 2026-06-03 (MEDIUM): the
+   * previous code disabled verification whenever `ssl` was set, silently
+   * exposing every "secure" connection to MITM.
+   */
+  sslRejectUnauthorized?: boolean;
   connected_at: string;
 }
 
@@ -411,7 +418,13 @@ function buildPgConfig(tokens: PostgresTokens): Record<string, unknown> {
     if (tokens.user) config.user = tokens.user;
     if (tokens.password) config.password = tokens.password;
   }
-  if (tokens.ssl) config.ssl = { rejectUnauthorized: false };
+  if (tokens.ssl) {
+    // Audit 2026-06-03 (MEDIUM): verify the server certificate by default.
+    // `rejectUnauthorized: false` unconditionally turned "SSL on" into
+    // "encrypted but unauthenticated" — trivially MITM-able. Self-signed /
+    // internal-CA deployments can opt out via sslRejectUnauthorized: false.
+    config.ssl = { rejectUnauthorized: tokens.sslRejectUnauthorized ?? true };
+  }
   return config;
 }
 

--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -127,6 +127,33 @@ function isPrivateCimdHost(hostname: string): boolean {
   return false;
 }
 
+/**
+ * Validate a redirect_uri pulled from a Client ID Metadata Document before it
+ * is pinned as an allowed redirect target.
+ *
+ * Audit 2026-06-03 (MEDIUM): CIMD redirect_uris were accepted with only a
+ * `typeof === "string"` filter. An attacker controlling the (HTTPS, public)
+ * CIMD doc could therefore list `http://…` (downgrade), a `#fragment`
+ * (forbidden by RFC 6749 §3.1.2 and a token-smuggling vector), or
+ * `https://user:pass@…` (embedded credentials) and have the OAuth server
+ * redirect the auth code there. Require an absolute https:// URL with no
+ * fragment and no userinfo.
+ */
+export function isValidCimdRedirectUri(uri: string): boolean {
+  // Reject any fragment component on the RAW string — RFC 6749 §3.1.2. The
+  // parsed `URL.hash` is "" for a bare trailing "#", so check the literal text.
+  if (uri.includes("#")) return false;
+  let u: URL;
+  try {
+    u = new URL(uri);
+  } catch {
+    return false;
+  }
+  if (u.protocol !== "https:") return false;
+  if (u.username || u.password) return false;
+  return true;
+}
+
 // ── Constants ─────────────────────────────────────────────────────────────────
 
 const CODE_TTL_MS = 5 * 60 * 1_000; // 5 min
@@ -1090,9 +1117,12 @@ export class OAuthServerImpl implements OAuthServer {
       const doc = JSON.parse(body) as Record<string, unknown>;
       const uris = doc.redirect_uris;
       if (!Array.isArray(uris) || uris.length === 0) return null;
-      const redirectUris = uris.filter(
-        (u) => typeof u === "string",
-      ) as string[];
+      // Audit 2026-06-03 (MEDIUM): only pin https:// redirect URIs with no
+      // fragment / userinfo — a malicious CIMD doc must not be able to
+      // register an http downgrade or a fragment-smuggling redirect target.
+      const redirectUris = (uris as unknown[]).filter(
+        (u): u is string => typeof u === "string" && isValidCimdRedirectUri(u),
+      );
       if (redirectUris.length === 0) return null;
 
       this.cimdCache.set(clientIdUrl, { redirectUris, fetchedAt: Date.now() });


### PR DESCRIPTION
## Summary

Two test-first MEDIUM security fixes from the 2026-06-03 audit (`docs/audit-2026-06-03.md`). Follows #868 (HIGH security) and #871 (HIGH logic).

| # | Bug | Fix |
|---|-----|-----|
| 25 | Postgres `buildPgConfig` set `ssl: { rejectUnauthorized: false }` whenever SSL was enabled → every "secure" connection was encrypted-but-**unauthenticated** (MITM) | Verify by default; opt out for self-signed via new `sslRejectUnauthorized: false` token field |
| 28 | CIMD `redirect_uris` were pinned as allowed redirect targets after only a `typeof === "string"` filter → a malicious (public-HTTPS) CIMD doc could register an `http://` downgrade, a `#fragment` (RFC 6749 §3.1.2 / smuggling), or `https://user:pass@…` redirect | New exported `isValidCimdRedirectUri` — requires absolute `https://`, no fragment (raw-string check, since `URL.hash` is `""` for a bare `#`), no userinfo |

## Testing
- #25: 3 new cases via the existing `pg`-mock harness assert the `Pool` config `ssl.rejectUnauthorized` is `true` by default, `false` only when opted out, and absent when SSL is off.
- #28: 5 new cases unit-test the extracted pure validator (https-only, fragment/userinfo/relative/unparseable rejection) in `oauth-cimd-ssrf.test.ts`.
- 98 tests pass across postgres + oauth + cimd-ssrf suites; biome + fixture-gate + `tsc` clean.

## Not in scope
Deferred (noted in the audit doc): #22 Slack callback wildcard `postMessage` (carries no secret; a correct fix needs origin plumbing across all OAuth callbacks) and #23 Notion/Stripe `Retry-After` (retry already happens; only tunes backoff, needs header threading into baseConnector).

🤖 Generated with [Claude Code](https://claude.com/claude-code)