### PR TITLE
fix(recipes): recipe parse/validation hardening — 2 MEDIUM audit findings

### DIFF
--- a/src/recipes/__tests__/errorPolicyValidation.test.ts
+++ b/src/recipes/__tests__/errorPolicyValidation.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Recipe `on_error` policy validation — audit 2026-06-03 (MEDIUM): before this,
+ * validateRecipeDefinition never checked the on_error block, so a typo'd
+ * `fallback`, a non-numeric `retry`, or a negative `retry` (a real runtime
+ * footgun — see chainedRunner.withRetry clamp, audit HIGH #8) all linted clean.
+ * Mirrors budgetValidation.test.ts.
+ */
+import { describe, expect, it } from "vitest";
+import { validateRecipeDefinition } from "../validation.js";
+
+const BASE = {
+  name: "e",
+  version: "1.0.0",
+  trigger: { type: "manual" },
+  steps: [{ id: "s", agent: { prompt: "hi" } }],
+};
+
+function onErrorErrors(onError: unknown): string {
+  const r = validateRecipeDefinition({ ...BASE, on_error: onError });
+  return r.issues
+    .filter((i) => i.level === "error")
+    .map((i) => i.message)
+    .join(" | ");
+}
+
+describe("recipe on_error policy validation", () => {
+  it("accepts an absent on_error", () => {
+    expect(validateRecipeDefinition(BASE).errors).toBe(0);
+  });
+
+  it("accepts a valid on_error (retry + retryDelay + fallback)", () => {
+    expect(
+      onErrorErrors({ retry: 3, retryDelay: 2000, fallback: "log_only" }),
+    ).toBe("");
+    expect(onErrorErrors({ fallback: "abort" })).toBe("");
+    expect(onErrorErrors({ fallback: "deliver_original" })).toBe("");
+  });
+
+  it("rejects a negative or non-integer retry (the previously-missing check)", () => {
+    expect(onErrorErrors({ retry: -1 })).toMatch(
+      /on_error\.retry must be a non-negative integer/,
+    );
+    expect(onErrorErrors({ retry: 1.5 })).toMatch(
+      /on_error\.retry must be a non-negative integer/,
+    );
+    expect(onErrorErrors({ retry: "lots" })).toMatch(
+      /on_error\.retry must be a non-negative integer/,
+    );
+  });
+
+  it("rejects a negative or non-numeric retryDelay", () => {
+    expect(onErrorErrors({ retryDelay: -100 })).toMatch(
+      /on_error\.retryDelay must be a non-negative number/,
+    );
+    expect(onErrorErrors({ retryDelay: "soon" })).toMatch(
+      /on_error\.retryDelay must be a non-negative number/,
+    );
+  });
+
+  it("rejects an unknown fallback enum value", () => {
+    expect(onErrorErrors({ fallback: "explode" })).toMatch(
+      /on_error\.fallback must be/,
+    );
+  });
+
+  it("rejects a non-object on_error", () => {
+    expect(onErrorErrors("halt")).toMatch(/'on_error' must be an object/);
+    expect(onErrorErrors([1, 2])).toMatch(/'on_error' must be an object/);
+  });
+});

--- a/src/recipes/__tests__/parser.test.ts
+++ b/src/recipes/__tests__/parser.test.ts
@@ -130,6 +130,26 @@ describe("parseRecipe", () => {
     );
   });
 
+  // Regression (audit 2026-06-03 MEDIUM): a file_watch patterns array of only
+  // non-strings passed the length check but filtered to [], so the trigger
+  // silently watched nothing. It must throw, not produce an empty watcher.
+  it("rejects a file_watch patterns array with no usable string globs", () => {
+    expect(() =>
+      parseRecipe({
+        ...VALID,
+        trigger: { type: "file_watch", patterns: [123, true] },
+      }),
+    ).toThrow(/file_watch\.patterns must contain at least one string/);
+  });
+
+  it("keeps the valid string globs in a mixed file_watch patterns array", () => {
+    const r = parseRecipe({
+      ...VALID,
+      trigger: { type: "file_watch", patterns: ["**/*.ts", 5] },
+    });
+    expect((r.trigger as { patterns: string[] }).patterns).toEqual(["**/*.ts"]);
+  });
+
   // Regression: parser.ts rejected `chained`, `on_file_save`, and
   // `on_test_run` even though validateRecipeDefinition, the JSON schema,
   // and the runtime (chainedRunner / dispatchRecipe / yamlRunner) all

--- a/src/recipes/parser.ts
+++ b/src/recipes/parser.ts
@@ -128,16 +128,26 @@ function parseTrigger(raw: unknown): Trigger {
         ]);
       return { type: "cron", schedule: cronExpr };
     }
-    case "file_watch":
+    case "file_watch": {
       if (!Array.isArray(t.patterns) || t.patterns.length === 0)
         throw new RecipeParseError("file_watch.patterns required", [
           "trigger",
           "patterns",
         ]);
-      return {
-        type: "file_watch",
-        patterns: (t.patterns as string[]).filter((p) => typeof p === "string"),
-      };
+      const patterns = (t.patterns as unknown[]).filter(
+        (p): p is string => typeof p === "string",
+      );
+      // Audit 2026-06-03 (MEDIUM): a patterns array containing only non-strings
+      // passed the length check above but filtered to []. The trigger then
+      // silently watched NOTHING — install/lint succeeded but the recipe never
+      // fired. Require at least one usable string pattern.
+      if (patterns.length === 0)
+        throw new RecipeParseError(
+          "file_watch.patterns must contain at least one string glob",
+          ["trigger", "patterns"],
+        );
+      return { type: "file_watch", patterns };
+    }
     case "git_hook":
       if (
         t.event !== "post-commit" &&

--- a/src/recipes/validation.ts
+++ b/src/recipes/validation.ts
@@ -311,6 +311,7 @@ export function validateRecipeDefinition(recipe: unknown): LintResult {
     }
 
     validateRecipeBudget(r, issues);
+    validateRecipeErrorPolicy(r, issues);
   }
 
   if (isEnabled(FLAG_SCHEMA_LINT)) {
@@ -387,6 +388,78 @@ function validateRecipeBudget(
       message: "budget.estimateUnmeasured must be a boolean",
       path: "budget.estimateUnmeasured",
       code: "budget-estimate-type",
+    });
+  }
+}
+
+/**
+ * Validate the optional recipe `on_error` policy block. Audit 2026-06-03
+ * (MEDIUM): the hand-rolled lint never checked it, so a typo'd `fallback`
+ * enum, a non-numeric `retry`, or a negative `retry` (which the runtime
+ * now clamps — see chainedRunner.withRetry, audit HIGH #8) passed lint
+ * silently. Mirrors validateRecipeBudget. `retry` is a non-negative integer;
+ * `retryDelay` a non-negative number (ms); `fallback` the documented enum.
+ */
+function validateRecipeErrorPolicy(
+  r: Record<string, unknown>,
+  issues: LintIssue[],
+): void {
+  const onError = r.on_error;
+  if (onError === undefined) return;
+  if (
+    typeof onError !== "object" ||
+    onError === null ||
+    Array.isArray(onError)
+  ) {
+    issues.push({
+      level: "error",
+      message: "'on_error' must be an object",
+      path: "on_error",
+      code: "on-error-type",
+    });
+    return;
+  }
+  const e = onError as Record<string, unknown>;
+  if (e.retry !== undefined) {
+    if (
+      typeof e.retry !== "number" ||
+      !Number.isInteger(e.retry) ||
+      e.retry < 0
+    ) {
+      issues.push({
+        level: "error",
+        message: "on_error.retry must be a non-negative integer",
+        path: "on_error.retry",
+        code: "on-error-retry",
+      });
+    }
+  }
+  if (e.retryDelay !== undefined) {
+    if (
+      typeof e.retryDelay !== "number" ||
+      !Number.isFinite(e.retryDelay) ||
+      e.retryDelay < 0
+    ) {
+      issues.push({
+        level: "error",
+        message: "on_error.retryDelay must be a non-negative number (ms)",
+        path: "on_error.retryDelay",
+        code: "on-error-retrydelay",
+      });
+    }
+  }
+  if (
+    e.fallback !== undefined &&
+    e.fallback !== "log_only" &&
+    e.fallback !== "abort" &&
+    e.fallback !== "deliver_original"
+  ) {
+    issues.push({
+      level: "error",
+      message:
+        "on_error.fallback must be 'log_only', 'abort', or 'deliver_original'",
+      path: "on_error.fallback",
+      code: "on-error-fallback-enum",
     });
   }
 }


### PR DESCRIPTION
## Summary

Two test-first MEDIUM fixes from the 2026-06-03 audit (`docs/audit-2026-06-03.md`). Continues the audit cleanup (after #868/#871 HIGH, #873 connector security).

| # | Bug | Fix |
|---|-----|-----|
| 19 | A `file_watch` `patterns` array of only non-strings passed the length check but filtered to `[]` — the trigger silently watched **nothing** (install + lint succeeded, recipe never fired) | `parseTrigger` now throws unless ≥1 usable string glob remains; mixed arrays keep the valid globs |
| 20 | `validateRecipeDefinition` never checked the `on_error` block — a typo'd `fallback`, a non-numeric `retry`, or a **negative `retry`** (the runtime footgun clamped in #871 HIGH #8) all linted clean | New `validateRecipeErrorPolicy` (mirrors `validateRecipeBudget`): `retry` = non-negative integer, `retryDelay` = non-negative number (ms), `fallback` ∈ {log_only, abort, deliver_original} |

## Testing
- #19: parser.test.ts — rejects an all-non-string patterns array; keeps valid globs in a mixed array.
- #20: new errorPolicyValidation.test.ts (mirrors budgetValidation.test.ts) — valid policies pass; negative/non-integer `retry`, negative/non-numeric `retryDelay`, unknown `fallback`, and non-object `on_error` are flagged.
- 49 tests across parser + budget + on_error suites; recipeValidationConsistency + chainedRunner regressions pass; biome + fixture-gate + `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)