### PR TITLE
fix(approvals): audit-log approvals too, not just rejections (MEDIUM #27)

### DIFF
--- a/src/__tests__/approvalHttp.test.ts
+++ b/src/__tests__/approvalHttp.test.ts
@@ -123,6 +123,34 @@ describe("routeApprovalRequest", () => {
     });
   });
 
+  it("POST /approve fires the onDecision audit hook (audit 2026-06-03 MEDIUM #27)", async () => {
+    // Previously only the reject path called onDecision, so approvals — the
+    // higher-risk decision — left no audit/activity trail.
+    const queue = new ApprovalQueue();
+    const { callId } = queue.request({
+      toolName: "gitPush",
+      params: {},
+      tier: "high",
+    });
+    const events: Array<{ event: string; meta: Record<string, unknown> }> = [];
+    const res = await routeApprovalRequest(
+      { method: "POST", path: `/approve/${callId}` },
+      {
+        queue,
+        workspace: "/tmp",
+        ccLoader: emptyRules(),
+        onDecision: (event, meta) => events.push({ event, meta }),
+      },
+    );
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ decision: "allow", callId });
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      event: "approval_decision",
+      meta: { callId, decision: "allow" },
+    });
+  });
+
   it("POST /approve on truly-unknown callId → 404 (not 409)", async () => {
     const queue = new ApprovalQueue();
     const res = await routeApprovalRequest(

--- a/src/approvalHttp.ts
+++ b/src/approvalHttp.ts
@@ -236,6 +236,10 @@ export async function routeApprovalRequest(
     }
     const ok = deps.queue.approve(callId);
     if (ok) {
+      // Audit 2026-06-03 (MEDIUM #27): fire the audit hook on APPROVE too —
+      // previously only the reject path called onDecision, so approvals (the
+      // higher-risk decision) left no audit/activity-log trail.
+      deps.onDecision?.("approval_decision", { callId, decision: "allow" });
       return { status: 200, body: { decision: "allow", callId } };
     }
     // Distinguish "callId never existed" from "callId was decided by a


### PR DESCRIPTION
## Summary

Test-first MEDIUM fix from the 2026-06-03 audit (`docs/audit-2026-06-03.md` #27).

The explicit `POST /approve/:callId` endpoint returned success **without** calling `deps.onDecision`, while `POST /reject/:callId` always did. So approvals — the higher-risk decision — left **no audit / activity-log trail**. Fix fires `onDecision("approval_decision", { callId, decision: "allow" })` on the approve success path, symmetric with reject.

## Testing
- New test: `queue.request()` → `POST /approve/:callId` with an `onDecision` spy → asserts the audit event fires with `decision: "allow"`.
- Full `approvalHttp.test.ts` (56) + biome + fixture-gate + `tsc` clean.

## Scoping note — #26 deferred (not in this PR)
Audit #26 (webhook/push/ntfy SSRF guard resolves only the **first** DNS address → split-horizon bypass) is a real finding, but a correct resolve-ALL fix is entangled with the dispatcher tests' reliance on **real DNS resolution** of `*.example.com`: switching to `dns.lookup(host, { all: true })` changed resolution behavior and broke those tests in ways that aren't reliably reproducible/verifiable locally. The right fix is to **inject the resolver into the dispatchers** so those tests stop hitting the network, then add resolve-all + per-address checks. Tracked for a separate PR rather than shipped unverified here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)