### PR TITLE
fix(approvals): SSRF guard resolves ALL DNS addresses, not just the first (MEDIUM #26)

### DIFF
--- a/src/__tests__/approvalHttp.test.ts
+++ b/src/__tests__/approvalHttp.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it, vi } from "vitest";
 import { routeApprovalRequest } from "../approvalHttp.js";
 import { ApprovalQueue } from "../approvalQueue.js";
 
+// The SSRF guards call dns.lookup(host, { all: true }) → an ARRAY of addresses
+// (audit 2026-06-03 MEDIUM #26: resolve-all to defeat split-horizon DNS).
 vi.mock("node:dns/promises", () => ({
-  lookup: vi.fn().mockResolvedValue({ address: "93.184.216.34", family: 4 }),
+  lookup: vi.fn().mockResolvedValue([{ address: "93.184.216.34", family: 4 }]),
 }));
 
 type Rules = { allow: string[]; ask: string[]; deny: string[] };
@@ -937,6 +939,74 @@ describe("routeApprovalRequest", () => {
         queue.approve(item.callId);
         await pending;
         expect(calls).toHaveLength(0);
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    });
+
+    it("blocks dispatch when ANY resolved address is private — split-horizon (audit 2026-06-03 MEDIUM #26)", async () => {
+      // The host's FIRST address is public (would pass the old single-address
+      // check) but a later one is private. Resolve-all must catch it.
+      const dnsMod = await import("node:dns/promises");
+      vi.mocked(dnsMod.lookup).mockResolvedValueOnce([
+        { address: "93.184.216.34", family: 4 },
+        { address: "10.0.0.5", family: 4 },
+      ] as never);
+      const originalFetch = globalThis.fetch;
+      const calls: string[] = [];
+      globalThis.fetch = (async (url: string) => {
+        calls.push(url);
+        return new Response("{}", { status: 200 });
+      }) as typeof globalThis.fetch;
+      try {
+        const queue = new ApprovalQueue();
+        const pending = routeApprovalRequest(
+          { method: "POST", path: "/approvals", body: { toolName: "gitPush" } },
+          {
+            queue,
+            workspace: "/tmp",
+            ccLoader: emptyRules(),
+            approvalGate: "all",
+            webhookUrl: "https://rebind.example.com/hook",
+          },
+        );
+        await new Promise((r) => setTimeout(r, 20));
+        const item = queue.list()[0];
+        if (!item) throw new Error("missing queued item");
+        queue.approve(item.callId);
+        await pending;
+        expect(calls).toHaveLength(0);
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    });
+
+    it("resolves ALL addresses (dns.lookup called with { all: true })", async () => {
+      const dnsMod = await import("node:dns/promises");
+      const spy = vi.mocked(dnsMod.lookup);
+      spy.mockClear();
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = (async () =>
+        new Response("{}", { status: 200 })) as typeof globalThis.fetch;
+      try {
+        const queue = new ApprovalQueue();
+        const pending = routeApprovalRequest(
+          { method: "POST", path: "/approvals", body: { toolName: "gitPush" } },
+          {
+            queue,
+            workspace: "/tmp",
+            ccLoader: emptyRules(),
+            approvalGate: "all",
+            webhookUrl: "https://hook.example.com/x",
+          },
+        );
+        await new Promise((r) => setTimeout(r, 20));
+        queue.approve(queue.list()[0]!.callId);
+        await pending;
+        expect(spy).toHaveBeenCalledWith(
+          "hook.example.com",
+          expect.objectContaining({ all: true }),
+        );
       } finally {
         globalThis.fetch = originalFetch;
       }

--- a/src/__tests__/mobileOversight.e2e.test.ts
+++ b/src/__tests__/mobileOversight.e2e.test.ts
@@ -15,9 +15,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { routeApprovalRequest } from "../approvalHttp.js";
 import { ApprovalQueue, resetApprovalQueueForTests } from "../approvalQueue.js";
 
-// Mock dns so push.mock-relay.local resolves to a public IP (passes SSRF check)
+// Mock dns so push.mock-relay.local resolves to a public IP (passes SSRF check).
+// The SSRF guard calls dns.lookup(host, { all: true }) → an ARRAY (audit
+// 2026-06-03 MEDIUM #26: resolve-all to defeat split-horizon DNS).
 vi.mock("node:dns/promises", () => ({
-  lookup: vi.fn().mockResolvedValue({ address: "93.184.216.34", family: 4 }),
+  lookup: vi.fn().mockResolvedValue([{ address: "93.184.216.34", family: 4 }]),
 }));
 
 // ── Mock relay server ─────────────────────────────────────────────────────

--- a/src/approvalHttp.ts
+++ b/src/approvalHttp.ts
@@ -309,6 +309,42 @@ function isBlockedIp(ip: string): boolean {
 }
 
 /**
+ * Resolve a hostname and return true if it should be blocked for SSRF defense.
+ *
+ * Audit 2026-06-03 (MEDIUM #26): resolve ALL addresses (`{ all: true }`) and
+ * block if ANY is private. The previous single-address `dns.lookup(hostname)`
+ * checked only the first result, so split-horizon DNS could return a public
+ * address to the guard while the subsequent `fetch` resolved a private one.
+ * DNS-resolution failure is treated as blocked (fail-closed), matching the
+ * prior per-site catch-and-skip behavior. `label` (when set) reproduces the
+ * per-dispatcher warn messages.
+ */
+async function hostResolvesToBlockedIp(
+  hostname: string,
+  label?: string,
+): Promise<boolean> {
+  let resolved: Array<{ address: string }>;
+  try {
+    resolved = await dns.lookup(hostname, { all: true });
+  } catch (err) {
+    if (label)
+      console.warn(
+        `[${label}] DNS resolution failed for ${hostname}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    return true;
+  }
+  const blocked = resolved.find((r) => isBlockedIp(r.address));
+  if (blocked) {
+    if (label)
+      console.warn(
+        `[${label}] Blocked private/loopback IP: ${blocked.address}`,
+      );
+    return true;
+  }
+  return false;
+}
+
+/**
  * Dispatch a JSON webhook notification when an approval is queued.
  * Failures are logged but never thrown — webhook errors must not block
  * the approval flow.
@@ -346,21 +382,8 @@ async function dispatchApprovalWebhook(
     return;
   }
 
-  // Resolve hostname and check resolved IP against blocklist
-  try {
-    const resolved = await dns.lookup(hostname);
-    if (isBlockedIp(resolved.address)) {
-      console.warn(
-        `[webhook] Blocked private/loopback IP for webhook: ${resolved.address}`,
-      );
-      return;
-    }
-  } catch (err) {
-    console.warn(
-      `[webhook] DNS resolution failed for ${hostname}: ${err instanceof Error ? err.message : String(err)}`,
-    );
-    return;
-  }
+  // Resolve hostname and check EVERY resolved IP against the blocklist.
+  if (await hostResolvesToBlockedIp(hostname, "webhook")) return;
 
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), 5_000);
@@ -423,20 +446,7 @@ async function dispatchPushNotification(
     console.warn(`[push] Blocked loopback push service hostname`);
     return;
   }
-  try {
-    const resolved = await dns.lookup(hostname);
-    if (isBlockedIp(resolved.address)) {
-      console.warn(
-        `[push] Blocked private/loopback IP for push service: ${resolved.address}`,
-      );
-      return;
-    }
-  } catch (err) {
-    console.warn(
-      `[push] DNS resolution failed for ${hostname}: ${err instanceof Error ? err.message : String(err)}`,
-    );
-    return;
-  }
+  if (await hostResolvesToBlockedIp(hostname, "push")) return;
 
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), 5_000);
@@ -506,20 +516,7 @@ async function dispatchNtfyApproval(
     console.warn(`[ntfy] Blocked loopback ntfy server hostname`);
     return;
   }
-  try {
-    const resolved = await dns.lookup(hostname);
-    if (isBlockedIp(resolved.address)) {
-      console.warn(
-        `[ntfy] Blocked private/loopback IP for ntfy server: ${resolved.address}`,
-      );
-      return;
-    }
-  } catch (err) {
-    console.warn(
-      `[ntfy] DNS resolution failed for ${hostname}: ${err instanceof Error ? err.message : String(err)}`,
-    );
-    return;
-  }
+  if (await hostResolvesToBlockedIp(hostname, "ntfy")) return;
 
   const callbackBase = payload.bridgeCallbackBase.replace(/\/+$/, "");
   // SECURITY (audit 2026-06-03 HIGH #6): carry the single-use approval token in
@@ -599,12 +596,7 @@ async function dispatchNtfyConfirmation(
     return;
   }
   if (hostname === "localhost") return;
-  try {
-    const resolved = await dns.lookup(hostname);
-    if (isBlockedIp(resolved.address)) return;
-  } catch {
-    return;
-  }
+  if (await hostResolvesToBlockedIp(hostname)) return;
   const approved = payload.outcome === "approved";
   const body = JSON.stringify({
     topic: payload.topic,

--- a/src/approvalHttp.ts
+++ b/src/approvalHttp.ts
@@ -325,7 +325,11 @@ async function hostResolvesToBlockedIp(
 ): Promise<boolean> {
   let resolved: Array<{ address: string }>;
   try {
-    resolved = await dns.lookup(hostname, { all: true });
+    const r = await dns.lookup(hostname, { all: true });
+    // `{ all: true }` always yields an array; coerce defensively so a single
+    // LookupAddress (e.g. a test mock that forgot the array) can't throw on
+    // `.find` and silently fail open vs closed.
+    resolved = Array.isArray(r) ? r : [r as { address: string }];
   } catch (err) {
     if (label)
       console.warn(


### PR DESCRIPTION
## Summary

Test-first fix for audit MEDIUM #26 — the one I **deferred in #876**. Now done right.

The webhook / push / ntfy dispatchers resolved a hostname with single-address `dns.lookup(hostname)` and checked **only the first** result. A split-horizon DNS server could return a public address to that check while the subsequent `fetch` re-resolved to a **private** one (SSRF). New `hostResolvesToBlockedIp` resolves with `{ all: true }` and blocks if **any** address is private (fail-closed on resolution error). Applied to all four dispatch sites.

## Why it was deferred — and why that's resolved now

I initially believed the dispatcher tests hit **real DNS** (my standalone `node` probe of `*.example.com` returned `ENOTFOUND`, and the tests still passed). The real reason: `approvalHttp.test.ts` **mocks `node:dns/promises`** — the mock returned a single `{ address }` object, so switching to `{ all: true }` (which returns an array) surfaced a **mock-shape mismatch**, not a real-DNS dependency. Fixing the mock to the array shape makes the whole thing deterministic and offline.

## Testing
- Updated the dns mock to the `{ all: true }` array shape.
- New: split-horizon test (public address first, private second → dispatch **blocked**, no fetch) + assertion that `dns.lookup` is called with `{ all: true }`.
- Full `approvalHttp.test.ts` (57) + biome + fixture-gate + `tsc` (incl. tests-core) clean.

Supersedes the #26 deferral noted in #876 (independent file regions; merges cleanly in any order).

🤖 Generated with [Claude Code](https://claude.com/claude-code)