### PR TITLE
fix(connectors): native token backend is keychain-only, not a silent auto (MEDIUM #21)

### DIFF
--- a/src/connectors/__tests__/tokenStorage.test.ts
+++ b/src/connectors/__tests__/tokenStorage.test.ts
@@ -134,12 +134,15 @@ describe("tokenStorage", () => {
   });
 });
 
-describe("tokenStorage native-backend fallback eviction (audit 2026-06-03 HIGH #10)", () => {
+describe("tokenStorage auto-backend fallback eviction (audit 2026-06-03 HIGH #10)", () => {
+  // NB: this is the AUTO path (keychain with encrypted-file fallback). The
+  // keychain-only `native` backend (MEDIUM #21) deliberately does NOT fall
+  // back to file, so the fallback-eviction behavior tested here lives in auto.
   const tmpDir = join(os.tmpdir(), `patchwork-test-tokens-kc-${Date.now()}`);
 
   beforeEach(() => {
     process.env.PATCHWORK_HOME = tmpDir;
-    process.env.PATCHWORK_TOKEN_STORAGE_BACKEND = "native";
+    process.env.PATCHWORK_TOKEN_STORAGE_BACKEND = "auto";
     if (!existsSync(tmpDir)) mkdirSync(tmpDir, { recursive: true });
   });
 
@@ -174,5 +177,65 @@ describe("tokenStorage native-backend fallback eviction (audit 2026-06-03 HIGH #
     await storeTokens("kc-provider", { accessToken: "FRESH-TOKEN" });
 
     expect((await getTokens("kc-provider"))?.accessToken).toBe("FRESH-TOKEN");
+  });
+});
+
+describe("tokenStorage native backend = keychain-only (audit 2026-06-03 MEDIUM #21)", () => {
+  const tmpDir = join(
+    os.tmpdir(),
+    `patchwork-test-tokens-native-${Date.now()}`,
+  );
+
+  beforeEach(() => {
+    process.env.PATCHWORK_HOME = tmpDir;
+    process.env.PATCHWORK_TOKEN_STORAGE_BACKEND = "native";
+    if (!existsSync(tmpDir)) mkdirSync(tmpDir, { recursive: true });
+  });
+  afterEach(() => {
+    __setKeychainOpsForTest(null);
+    delete process.env.PATCHWORK_HOME;
+    delete process.env.PATCHWORK_TOKEN_STORAGE_BACKEND;
+    if (existsSync(tmpDir)) rmSync(tmpDir, { recursive: true });
+  });
+
+  it("stores and reads via the keychain only (no file written)", async () => {
+    const kc = new Map<string, string>();
+    __setKeychainOpsForTest({
+      set: (k, v) => {
+        kc.set(k, v);
+        return true;
+      },
+      get: (k) => (kc.has(k) ? (kc.get(k) as string) : null),
+      delete: (k) => kc.delete(k),
+    });
+    await storeTokens("native-provider", { accessToken: "KC-ONLY" });
+    expect((await getTokens("native-provider"))?.accessToken).toBe("KC-ONLY");
+    // The credential lives in the (fake) keychain, not on disk.
+    expect(kc.size).toBe(1);
+  });
+
+  it("THROWS instead of silently writing a file when the keychain is unavailable", async () => {
+    __setKeychainOpsForTest({
+      set: () => false, // keychain write fails
+      get: () => null,
+      delete: () => false,
+    });
+    await expect(
+      storeTokens("native-provider", { accessToken: "x" }),
+    ).rejects.toThrow(/native.*keychain|refusing to fall back/i);
+  });
+
+  it("does NOT fall back to reading a stale file (keychain-only read)", async () => {
+    // Pre-seed an encrypted file under file-backend, then switch to native.
+    process.env.PATCHWORK_TOKEN_STORAGE_BACKEND = "file";
+    await storeTokens("native-provider", { accessToken: "STALE-FILE" });
+    process.env.PATCHWORK_TOKEN_STORAGE_BACKEND = "native";
+    __setKeychainOpsForTest({
+      set: () => true,
+      get: () => null, // keychain empty
+      delete: () => true,
+    });
+    // native read must return null (keychain empty) — never the stale file.
+    expect(await getTokens("native-provider")).toBeNull();
   });
 });

--- a/src/connectors/tokenStorage.ts
+++ b/src/connectors/tokenStorage.ts
@@ -55,7 +55,9 @@ export function storeSecretJsonSync(provider: string, value: unknown): void {
   const key = storageKey(provider);
   const json = JSON.stringify(value);
 
-  if (resolveBackend() === "file") {
+  const backend = resolveBackend();
+
+  if (backend === "file") {
     setEncryptedFileSync(key, json);
     // Cross-backend orphan guard: if a prior session wrote to the native
     // keychain (auto-mode default), forcing PATCHWORK_TOKEN_STORAGE_BACKEND=file
@@ -66,6 +68,23 @@ export function storeSecretJsonSync(provider: string, value: unknown): void {
     return;
   }
 
+  // Audit 2026-06-03 (MEDIUM #21): `native` means keychain-ONLY. Previously it
+  // fell through to the same keychain-then-file path as `auto`, so a keychain
+  // write failure silently wrote the secret to a file the operator explicitly
+  // opted out of. Fail loud instead of downgrading their chosen security level.
+  if (backend === "native") {
+    if (!setKeychainItemSync(key, json)) {
+      throw new Error(
+        "PATCHWORK_TOKEN_STORAGE_BACKEND=native but the OS keychain is " +
+          "unavailable; refusing to fall back to file storage. Unset the env " +
+          "var (or set it to 'auto') to allow encrypted-file fallback.",
+      );
+    }
+    deleteEncryptedFileSync(key); // evict any stale file credential
+    return;
+  }
+
+  // auto: keychain with encrypted-file fallback.
   if (setKeychainItemSync(key, json)) {
     deleteEncryptedFileSync(key);
     return;
@@ -82,11 +101,21 @@ export function storeSecretJsonSync(provider: string, value: unknown): void {
 
 export function getSecretJsonSync<T>(provider: string): T | null {
   const key = storageKey(provider);
+  const backend = resolveBackend();
 
-  if (resolveBackend() === "file") {
+  if (backend === "file") {
     return parseJson<T>(getEncryptedFileSync(key));
   }
 
+  // Audit 2026-06-03 (MEDIUM #21): `native` reads the keychain ONLY — it must
+  // not fall back to the encrypted file (symmetric with the keychain-only
+  // write path), so a stale file can never shadow the operator's keychain-only
+  // intent.
+  if (backend === "native") {
+    return parseJson<T>(getKeychainItemSync(key));
+  }
+
+  // auto: keychain first, then encrypted-file fallback.
   const fromKeychain = getKeychainItemSync(key);
   if (fromKeychain !== null) {
     return parseJson<T>(fromKeychain);


### PR DESCRIPTION
## Summary

Test-first MEDIUM fix from the 2026-06-03 audit. `PATCHWORK_TOKEN_STORAGE_BACKEND=native` was accepted but behaved **identically to `auto`** — both the store and read paths used keychain-with-encrypted-file fallback. So an operator who set `native` (deliberately opting **out** of on-disk secrets) would have their credential silently written to a file whenever the OS keychain was momentarily unavailable — a security level downgrade they didn't choose.

The three backends are now distinct:
| Backend | Behavior |
|---|---|
| `file` | encrypted file only |
| `native` | **keychain only** — store **throws** if the keychain is unavailable (no silent file fallback); reads never fall back to a stale file |
| `auto` (default) | keychain with encrypted-file fallback (unchanged) |

## Testing
- New describe (uses the `__setKeychainOpsForTest` seam from #871): native store+read via keychain only (no file written); native **throws** when the keychain write fails; native read does **not** fall back to a pre-seeded stale file.
- Retargeted the existing #10 fallback-eviction test from `native` → `auto` (that behavior now lives in `auto`; the #10 fix is unchanged).
- 11/11 tokenStorage + biome + fixture-gate + `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)