### PR TITLE
fix(drivers): cap output by UTF-8 bytes, not UTF-16 units (MEDIUM #30 / #57)

### DIFF
--- a/src/drivers/__tests__/outputCap.test.ts
+++ b/src/drivers/__tests__/outputCap.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Shared UTF-8 output-cap helpers — audit 2026-06-03 (MEDIUM #30 / #57).
+ *
+ * The API drivers used to cap output with `text.slice(0, cap)`, which counts
+ * UTF-16 code units, so a byte cap was not honored for multi-byte content and a
+ * cut could split a codepoint. These pure helpers cut by UTF-8 bytes.
+ */
+import { describe, expect, it } from "vitest";
+import { truncateToBytes, truncateUtf8Bytes } from "../outputCap.js";
+
+const bytes = (s: string) => Buffer.byteLength(s, "utf8");
+
+describe("truncateUtf8Bytes", () => {
+  it("returns the input unchanged when it fits the byte cap", () => {
+    expect(truncateUtf8Bytes("hello", 10)).toBe("hello");
+    expect(truncateUtf8Bytes("héllo", 10)).toBe("héllo"); // 6 bytes ≤ 10
+  });
+
+  it("caps by BYTES, not UTF-16 units — the core bug", () => {
+    // 10 emoji = 10 code points (.length 20 UTF-16 units) but 40 UTF-8 bytes.
+    // A char-based slice(0, 20) would keep all 10; a byte cap of 20 keeps 5.
+    const s = "🚀".repeat(10);
+    expect(s.length).toBe(20); // UTF-16 units
+    expect(bytes(s)).toBe(40); // UTF-8 bytes
+    const out = truncateUtf8Bytes(s, 20);
+    expect(bytes(out)).toBeLessThanOrEqual(20);
+    expect(out).toBe("🚀".repeat(5));
+  });
+
+  it("never splits a multi-byte codepoint at the boundary", () => {
+    // Cap lands mid-emoji (🚀 is 4 bytes). Result must not contain U+FFFD and
+    // must re-encode to ≤ cap bytes (the partial trailing codepoint is dropped).
+    const s = "ab🚀";
+    const out = truncateUtf8Bytes(s, 4); // "ab" = 2 bytes, then partial 🚀
+    expect(out).toBe("ab");
+    expect(out).not.toContain("�");
+    expect(bytes(out)).toBeLessThanOrEqual(4);
+  });
+
+  it("truncates a CJK string whose char-length is under the cap but byte-length is over", () => {
+    const s = "字".repeat(30); // 30 chars, 90 UTF-8 bytes
+    expect(s.length).toBe(30);
+    const out = truncateUtf8Bytes(s, 30);
+    expect(bytes(out)).toBeLessThanOrEqual(30);
+    expect(out).toBe("字".repeat(10)); // 10 × 3 bytes = 30
+  });
+});
+
+describe("truncateToBytes (streaming counter)", () => {
+  it("reports the actual UTF-8 byte length consumed", () => {
+    const r = truncateToBytes("🚀🚀", 100);
+    expect(r.send).toBe("🚀🚀");
+    expect(r.bytes).toBe(8); // 2 × 4 bytes — NOT the UTF-16 length (4)
+  });
+
+  it("respects the remaining-bytes budget without splitting a codepoint", () => {
+    const r = truncateToBytes("🚀🚀🚀", 6); // budget fits 1 emoji (4 bytes)
+    expect(r.send).toBe("🚀");
+    expect(r.bytes).toBe(4);
+    expect(r.bytes).toBeLessThanOrEqual(6);
+  });
+
+  it("passes short ASCII through with its true byte length", () => {
+    const r = truncateToBytes("ok", 50);
+    expect(r.send).toBe("ok");
+    expect(r.bytes).toBe(2);
+  });
+});

--- a/src/drivers/claude/api.ts
+++ b/src/drivers/claude/api.ts
@@ -1,3 +1,4 @@
+import { truncateUtf8Bytes } from "../outputCap.js";
 import type {
   ProviderDriver,
   ProviderTaskInput,
@@ -99,7 +100,7 @@ export class ApiDriver implements ProviderDriver {
     const model = typeof msg.model === "string" ? msg.model : input.model;
 
     return {
-      text: text.slice(0, OUTPUT_CAP),
+      text: truncateUtf8Bytes(text, OUTPUT_CAP),
       exitCode: 0,
       durationMs: Date.now() - start,
       providerMeta: {

--- a/src/drivers/claude/subprocess.ts
+++ b/src/drivers/claude/subprocess.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { treeKill } from "../../processTree.js";
 import { ensureCmdShim } from "../../winShim.js";
+import { truncateToBytes, truncateUtf8Bytes } from "../outputCap.js";
 import type {
   ProviderDriver,
   ProviderTaskInput,
@@ -15,38 +16,6 @@ import { parseStreamLine, splitLines } from "./streamParser.js";
 import { createSubprocessSettings } from "./subprocessSettings.js";
 
 const OUTPUT_CAP = 50 * 1024; // 50KB
-
-/**
- * Truncate `text` to at most `cap` UTF-8 bytes without splitting a multi-byte
- * codepoint mid-sequence. `String.slice(0, cap)` operates on UTF-16 code
- * units, so a 50K cap can store ~50K code points but emit up to ~200KB of
- * UTF-8 wire bytes for CJK / emoji content — and may produce a lone surrogate
- * at the boundary. `Buffer.toString("utf8")` substitutes U+FFFD for incomplete
- * trailing sequences instead.
- */
-function truncateUtf8Bytes(text: string, cap: number): string {
-  const buf = Buffer.from(text, "utf8");
-  if (buf.length <= cap) return text;
-  return buf.subarray(0, cap).toString("utf8");
-}
-
-/**
- * Truncate `text` so it adds at most `remaining` UTF-8 bytes to the stream and
- * never splits a multi-byte codepoint mid-sequence. Returns the safely-
- * truncated slice plus its actual byte length so the running byte total can be
- * advanced correctly.
- */
-function truncateToBytes(
-  text: string,
-  remaining: number,
-): { send: string; bytes: number } {
-  const buf = Buffer.from(text, "utf8");
-  if (buf.length <= remaining) return { send: text, bytes: buf.length };
-  // Buffer.toString("utf8") substitutes U+FFFD for incomplete trailing
-  // sequences, which is the correct UTF-8 truncation behavior.
-  const sliced = buf.subarray(0, remaining).toString("utf8");
-  return { send: sliced, bytes: Buffer.byteLength(sliced, "utf8") };
-}
 
 /**
  * Write a single-server MCP config to a 0600 temp file, return the path.

--- a/src/drivers/gemini/index.ts
+++ b/src/drivers/gemini/index.ts
@@ -12,6 +12,7 @@ import { treeKill } from "../../processTree.js";
 import { ensureCmdShim } from "../../winShim.js";
 import { sanitizeEnv } from "../claude/envSanitizer.js";
 import { splitLines } from "../claude/streamParser.js";
+import { truncateToBytes, truncateUtf8Bytes } from "../outputCap.js";
 import type {
   ProviderDriver,
   ProviderTaskInput,
@@ -299,10 +300,16 @@ export class GeminiSubprocessDriver implements ProviderDriver {
             const text = event.content;
             accumulated += text;
             if (outputBytesSent < OUTPUT_CAP) {
-              const send = text.slice(0, OUTPUT_CAP - outputBytesSent);
+              // Audit 2026-06-03 (#57): count UTF-8 BYTES, not UTF-16 units, so
+              // the cap is honored for multi-byte output and chunks never split
+              // a codepoint.
+              const { send, bytes } = truncateToBytes(
+                text,
+                OUTPUT_CAP - outputBytesSent,
+              );
               if (send.length > 0) {
                 input.onChunk?.(send);
-                outputBytesSent += send.length;
+                outputBytesSent += bytes;
               }
             }
           } else if (event.type === "result") {
@@ -350,7 +357,7 @@ export class GeminiSubprocessDriver implements ProviderDriver {
           input.signal.aborted;
         if (isAbort) {
           return {
-            text: accumulated.slice(0, OUTPUT_CAP),
+            text: truncateUtf8Bytes(accumulated, OUTPUT_CAP),
             durationMs: Date.now() - start,
             wasAborted: true,
             startupMs: startupMsOf(),
@@ -363,7 +370,7 @@ export class GeminiSubprocessDriver implements ProviderDriver {
 
       if (startupTimedOut) {
         return {
-          text: accumulated.slice(0, OUTPUT_CAP),
+          text: truncateUtf8Bytes(accumulated, OUTPUT_CAP),
           durationMs: Date.now() - start,
           wasAborted: true,
           startupTimedOut: true,
@@ -381,7 +388,7 @@ export class GeminiSubprocessDriver implements ProviderDriver {
       }
 
       return {
-        text: accumulated.slice(0, OUTPUT_CAP),
+        text: truncateUtf8Bytes(accumulated, OUTPUT_CAP),
         exitCode: effectiveExitCode,
         durationMs: Date.now() - start,
         stderrTail: stderrTailOf(stderr),

--- a/src/drivers/openai/index.ts
+++ b/src/drivers/openai/index.ts
@@ -1,3 +1,4 @@
+import { truncateUtf8Bytes } from "../outputCap.js";
 import type {
   ProviderDriver,
   ProviderTaskInput,
@@ -160,7 +161,7 @@ export class OpenAIApiDriver implements ProviderDriver {
         input.signal.aborted;
       if (isAbort) {
         return {
-          text: text.slice(0, OUTPUT_CAP),
+          text: truncateUtf8Bytes(text, OUTPUT_CAP),
           durationMs: Date.now() - start,
           wasAborted: true,
           startupMs:
@@ -168,14 +169,14 @@ export class OpenAIApiDriver implements ProviderDriver {
         };
       }
       return {
-        text: text.slice(0, OUTPUT_CAP),
+        text: truncateUtf8Bytes(text, OUTPUT_CAP),
         durationMs: Date.now() - start,
         errorMessage: err instanceof Error ? err.message : String(err),
       };
     }
 
     return {
-      text: text.slice(0, OUTPUT_CAP),
+      text: truncateUtf8Bytes(text, OUTPUT_CAP),
       durationMs: Date.now() - start,
       startupMs: firstChunkAt !== undefined ? firstChunkAt - start : undefined,
       providerMeta: {

--- a/src/drivers/outputCap.ts
+++ b/src/drivers/outputCap.ts
@@ -1,0 +1,52 @@
+/**
+ * Shared UTF-8-aware output truncation for driver results.
+ *
+ * Audit 2026-06-03 (MEDIUM #30): the API drivers (claude/api, openai, gemini)
+ * capped output with `text.slice(0, OUTPUT_CAP)`, which counts UTF-16 code
+ * units — so a 50K "byte" cap could emit ~200KB of UTF-8 wire bytes for CJK /
+ * emoji content and could leave a lone surrogate at the boundary. These
+ * helpers (previously private to claude/subprocess.ts) measure and cut by
+ * UTF-8 bytes. Shared so every driver path uses one implementation.
+ */
+
+/**
+ * Largest byte length ≤ `cap` that ends on a UTF-8 codepoint boundary. UTF-8
+ * continuation bytes match `0b10xxxxxx`; if the byte at the cut is one, we're
+ * mid-sequence, so back off to the preceding lead byte. This drops a partial
+ * trailing codepoint cleanly (no U+FFFD, no lone surrogate, never over `cap`).
+ */
+function codepointBoundary(buf: Buffer, cap: number): number {
+  let end = cap;
+  while (end > 0 && ((buf[end] as number) & 0xc0) === 0x80) end--;
+  return end;
+}
+
+/**
+ * Truncate `text` to at most `cap` UTF-8 bytes without splitting a multi-byte
+ * codepoint. `String.slice(0, cap)` counts UTF-16 code units, so a 50K cap can
+ * emit ~200KB of UTF-8 wire bytes for CJK / emoji content; this cuts by bytes
+ * at a codepoint boundary.
+ */
+export function truncateUtf8Bytes(text: string, cap: number): string {
+  const buf = Buffer.from(text, "utf8");
+  if (buf.length <= cap) return text;
+  return buf.subarray(0, codepointBoundary(buf, cap)).toString("utf8");
+}
+
+/**
+ * Truncate `text` so it adds at most `remaining` UTF-8 bytes to a stream and
+ * never splits a multi-byte codepoint. Returns the safely-truncated slice plus
+ * its actual byte length so a running byte total can be advanced correctly
+ * (used by the streaming accumulators).
+ */
+export function truncateToBytes(
+  text: string,
+  remaining: number,
+): { send: string; bytes: number } {
+  const buf = Buffer.from(text, "utf8");
+  if (buf.length <= remaining) return { send: text, bytes: buf.length };
+  const send = buf
+    .subarray(0, codepointBoundary(buf, remaining))
+    .toString("utf8");
+  return { send, bytes: Buffer.byteLength(send, "utf8") };
+}


### PR DESCRIPTION
## Summary

Test-first MEDIUM fix from the 2026-06-03 audit. The API drivers (`claude/api`, `openai`, `gemini`) capped output with `text.slice(0, OUTPUT_CAP)` — which counts **UTF-16 code units**, not bytes. So a 50K *byte* cap could emit ~200KB of UTF-8 wire bytes for CJK/emoji output and could split a codepoint at the boundary. The gemini streaming counter advanced `outputBytesSent` by char length too (#57).

- Extracted the byte-aware helpers that already lived (privately) in `claude/subprocess.ts` into a shared **`src/drivers/outputCap.ts`**, and routed every driver's final + streaming truncation through them — single implementation, no drift.
- Hardened the cut to land on a **UTF-8 codepoint boundary** (back off past continuation bytes): result is always ≤ cap bytes with no U+FFFD / lone surrogate (the old `Buffer.toString` substitution could nudge +2 over and emit U+FFFD).

## Testing
- New `outputCap.test.ts` (pure functions): byte cap honored for emoji/CJK where char-length < cap but byte-length > cap; no mid-codepoint split; streaming byte accounting returns true UTF-8 byte counts.
- `claude-subprocess-byte-cap` + `gemini` + driver-`index` suites stay green (extraction is faithful; clean-cut satisfies the existing `cap+2` tolerance and no-lone-surrogate checks).

## Pre-existing failure (not from this PR)
`claude-api.test.ts` / `openai.test.ts` fail **on clean `main`** with `() => ({...}) is not a constructor` — the in-progress vitest-4 migration's arrow-function constructor-mock breakage (same class as the `postgres.test.ts` `function()` fix already on main). Unrelated to this change; this PR adds no SDK-mock tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)