### PR TITLE
style(dashboard): facelift PR 1 — color-token grammar + orange reservation

### DIFF
--- a/dashboard/src/app/activity/page.tsx
+++ b/dashboard/src/app/activity/page.tsx
@@ -611,11 +611,11 @@ export default function ActivityPage() {
                 cursor: "pointer",
                 color: isActive ? "var(--ink-0)" : "var(--ink-2)",
                 background: isActive
-                  ? "color-mix(in srgb, var(--accent) 8%, transparent 92%)"
+                  ? "color-mix(in srgb, var(--accent-cool) 8%, transparent 92%)"
                   : "none",
                 border: "none",
                 borderBottom: isActive
-                  ? "2px solid var(--accent)"
+                  ? "2px solid var(--accent-cool)"
                   : "2px solid transparent",
                 borderRadius: isActive ? "4px 4px 0 0" : "4px 4px 0 0",
               }}
@@ -624,7 +624,7 @@ export default function ActivityPage() {
               <span
                 style={{
                   fontSize: "var(--fs-xs)",
-                  color: isActive ? "var(--accent)" : "var(--ink-3)",
+                  color: isActive ? "var(--accent-cool)" : "var(--ink-3)",
                   fontFamily: "var(--font-mono)",
                   transition: "color 0.15s ease",
                 }}

--- a/dashboard/src/app/approvals/[callId]/page.tsx
+++ b/dashboard/src/app/approvals/[callId]/page.tsx
@@ -492,7 +492,7 @@ export default function ApprovalDetailPage() {
             </code>
             <Link
               href={`/approvals?session=${sessionId}`}
-              style={{ fontSize: "var(--fs-m)", color: "var(--accent)" }}
+              style={{ fontSize: "var(--fs-m)", color: "var(--info)" }}
             >
               All approvals for this session →
             </Link>

--- a/dashboard/src/app/connections/page.tsx
+++ b/dashboard/src/app/connections/page.tsx
@@ -1807,7 +1807,7 @@ export default function ConnectionsPage() {
                   No connections yet
                 </p>
                 <p style={{ margin: 0, fontSize: "var(--fs-s)", color: "var(--ink-2)" }}>
-                  Connect a service to start automating workflows.
+                  Connect a service to start automating with recipes.
                 </p>
               </div>
               <button
@@ -1833,7 +1833,7 @@ export default function ConnectionsPage() {
                 key={k}
                 type="button"
                 onClick={() => setStatusFilter(k)}
-                className={statusFilter === k ? "pill accent conn-filter-pill" : "pill muted conn-filter-pill"}
+                className={statusFilter === k ? "pill info conn-filter-pill" : "pill muted conn-filter-pill"}
               >
                 {label}
               </button>

--- a/dashboard/src/app/decisions/page.tsx
+++ b/dashboard/src/app/decisions/page.tsx
@@ -262,7 +262,7 @@ function DecisionsContent() {
               onClick={() => setTag(tag === t ? "" : t)}
               aria-pressed={tag === t}
               aria-label={`Filter by tag: ${t}`}
-              className={tag === t ? "pill accent" : "pill muted"}
+              className={tag === t ? "pill info" : "pill muted"}
               style={{ cursor: "pointer", fontFamily: "var(--font-mono)" }}
             >
               {t}
@@ -413,12 +413,12 @@ function DecisionsContent() {
                       <div
                         style={{
                           padding: "10px 14px",
-                          background: "var(--orange-soft)",
+                          background: "var(--err-soft)",
                           borderRadius: "var(--r-s)",
-                          border: "1px solid var(--orange-tint)",
+                          border: "1px solid color-mix(in srgb, var(--err) 30%, transparent)",
                         }}
                       >
-                        <div style={{ fontFamily: "var(--font-mono)", fontSize: "var(--fs-2xs)", fontWeight: 600, color: "var(--orange)", marginBottom: 6 }}>
+                        <div style={{ fontFamily: "var(--font-mono)", fontSize: "var(--fs-2xs)", fontWeight: 600, color: "var(--err-text)", marginBottom: 6 }}>
                           <span aria-hidden="true">✻ </span>Problem
                         </div>
                         <div style={{ fontSize: "var(--fs-m)", color: "var(--ink-1)", lineHeight: 1.55 }}>

--- a/dashboard/src/app/globals.css
+++ b/dashboard/src/app/globals.css
@@ -24,7 +24,10 @@
      Darkened to ~4.8:1; the ~190 text sites that use --ink-3/--fg-3/--text-3
      pass AA in one swap. Non-text idle/offline dots and tinted swatches now
      point at --dot-muted (defined below) to preserve their soft tone. */
-  --ink-3: #7a6f57;
+  /* Darkened a further 4 lightness points (#7a6f57 → #706550): lifts 10px
+     sidebar/eyebrow label contrast from 4.31→4.65:1 (facelift P0-1-A / P2-9).
+     Non-text muted dots keep their soft tone via --dot-muted below. */
+  --ink-3: #706550;
   --dot-muted: #9a907a;
   --text-0: var(--ink-0);
   --text-1: var(--ink-1);
@@ -72,6 +75,12 @@
   --err-bg:        var(--red-soft);
   --info:          var(--blue);
   --info-soft:     var(--blue-soft);
+  /* Pill TEXT variants — darker than the decoration tokens so soft-tinted
+     pills clear AA on the light canvas (facelift P0-1-A / P0-3-A). Dark mode
+     re-points these back to the bright tokens (see [data-theme="dark"]). */
+  --ok-text:       #3d6635;   /* 5.5:1 on --ok-soft   */
+  --warn-text:     #7a5200;   /* 5.8:1 on --warn-soft */
+  --err-text:      #aa3838;   /* 5.5:1 on --err-soft  */
   --overlay-bg:    rgba(10, 11, 13, 0.55);
   --shadow-modal:  0 20px 50px rgba(10, 11, 13, 0.35);
   --on-accent:     #fff;
@@ -271,10 +280,23 @@
   --orange-tint:  rgba(255,122,69,0.25);
   --orange-rgb: 255, 122, 69;
   --purple-soft:  #1c1b32;
+  /* --green #5b8a4f is borderline (4.87:1) on the dark canvas; lift to
+     #6da060 (5.7:1) so --ok text/strokes pass AA (facelift Orig-15). */
+  --green:        #6da060;
   --green-soft:   #0e2519;
   --amber-soft:   #2b2110;
-  --red-soft:     #2b1511;
+  /* --red #b54343 fails (3.6:1) on the dark canvas; lift to #d05757
+     (4.86:1 on #0a0b0d) so --err passes AA. --err aliases --red, so this
+     cascades (facelift P0-1-A). */
+  --red:          #d05757;
+  --red-soft:     rgba(208,87,87,0.16);
   --blue-soft:    #101b2c;
+  /* Pill TEXT tokens point back to the bright palette in dark mode — the
+     light-mode #3d6635/#7a5200/#aa3838 would be near-invisible on the dark
+     soft pill fills (facelift P0-1-A dark-pill gap). */
+  --ok-text:      var(--green);
+  --warn-text:    var(--amber);
+  --err-text:     var(--err);
   --accent-strong: #e8956e;
   --accent-glow: rgba(255,122,69,0.35);
   --stitch-line: rgba(255,255,255,0.05);
@@ -442,10 +464,10 @@ button { font-family: inherit; }
 }
 
 .app-nav-section-label {
-  font-size: 10px;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
+  font-size: var(--fs-2xs);
+  font-weight: 500;
+  letter-spacing: 0.01em;
+  text-transform: none;
   color: var(--ink-3);
   padding: 10px 8px 3px;
 }
@@ -517,7 +539,7 @@ button { font-family: inherit; }
   height: 18px;
   padding: 0 5px;
   border-radius: 999px;
-  background: var(--orange);
+  background: var(--info);
   color: #fff;
   font-size: 10px;
   font-weight: 700;
@@ -528,9 +550,9 @@ button { font-family: inherit; }
   line-height: 1;
 }
 
-/* "Live now" variant — blue tone + soft pulse to signal motion
-   (active recipe runs). Distinct from .nav-badge (orange, static
-   counter for pending/queued things). */
+/* "Live now" variant — soft pulse to signal motion (active recipe runs).
+   Distinct from the static .nav-badge counter for pending/queued things;
+   both use the info/blue tone (orange is reserved for brand/CTA). */
 .nav-badge.is-live {
   background: var(--blue);
   animation: nav-badge-live-pulse 1.8s ease-in-out infinite;
@@ -800,7 +822,7 @@ button.topbar-search {
 .global-live-runs-strip-bar > span {
   display: block;
   height: 100%;
-  background: var(--accent);
+  background: var(--accent-cool);
   transition: width 0.25s ease;
 }
 .global-live-runs-strip-overflow {
@@ -1216,10 +1238,10 @@ a.btn { text-decoration: none; }
   background: currentColor;
   flex-shrink: 0;
 }
-.pill.ok   { background: var(--green-soft); color: var(--green); border-color: transparent; }
-.pill.warn { background: var(--amber-soft); color: var(--amber); border-color: transparent; }
-.pill.err  { background: var(--red-soft);   color: var(--red);   border-color: transparent; }
-.pill.info { background: var(--blue-soft);  color: var(--blue);  border-color: transparent; }
+.pill.ok   { background: var(--ok-soft);   color: var(--ok-text);   border-color: transparent; }
+.pill.warn { background: var(--warn-soft); color: var(--warn-text); border-color: transparent; }
+.pill.err  { background: var(--err-soft);  color: var(--err-text);  border-color: transparent; }
+.pill.info { background: var(--blue-soft);  color: var(--blue);      border-color: transparent; }
 .pill.muted { color: var(--ink-3); background: var(--recess); border-color: transparent; }
 /* ── VD-3: per-step hover diff panel ─────────────────────────────── */
 /* Position is set inline (fixed coordinates from the anchor row's
@@ -1320,9 +1342,10 @@ a.btn { text-decoration: none; }
    (.ok/.warn/.err/.info) cover those tones. */
 .pill.purp   { background: var(--purple-soft); color: var(--purple); border-color: transparent; }
 
-/* Active filter / accent state — used by traces filter buttons
-   (`pill accent` / `pill muted` toggle). */
-.pill.accent { background: var(--orange-soft); color: var(--orange); border-color: var(--orange-tint); }
+/* Active filter / info state — used by traces filter buttons
+   (`pill info` / `pill muted` toggle). Orange `.pill.accent` removed in the
+   facelift token-grammar pass: orange is reserved for brand/CTA, not a pill
+   tone. Filter-active pills now use `.pill.info` (defined above). */
 
 /* ---- Connector dot (marketplace + health panel) ---- */
 .connector-dot {
@@ -1714,7 +1737,7 @@ a.btn { text-decoration: none; }
 .progress-fill {
   height: 100%;
   border-radius: 999px;
-  background: var(--orange);
+  background: var(--ok);
   position: relative;
   overflow: hidden;
   transition: width 600ms var(--transition);
@@ -2298,11 +2321,17 @@ a.btn { text-decoration: none; }
   color: var(--ink-0);
   margin: 0 0 6px;
 }
+/* Editorial accent on operational page headers (insights/settings/tasks/
+   activity/runs/traces/analytics) — neutral by default. Orange is reserved
+   for brand/CTA (facelift P0-1 orange reservation / P2-8). The Overview hero
+   keeps its orange via the separate `.quilt-title .accent` rule below, which
+   is already scoped to the hero. PR 4 (P2-8-B) removes the spans that no
+   longer earn emphasis; until then they render as neutral serif italics. */
 .editorial-h1 .accent {
   font-family: var(--font-serif);
   font-style: italic;
   font-weight: 400;
-  color: var(--orange);
+  color: var(--ink-2);
   letter-spacing: 0;
 }
 .editorial-h1 .num {
@@ -5439,7 +5468,7 @@ a.btn { text-decoration: none; }
 .attention-chips { display: flex; gap: 8px; flex-wrap: wrap; }
 /* Offline band text nodes */
 .attention-offline-label { color: var(--err); font-weight: 700; }
-.attention-offline-link { color: var(--accent); text-decoration: none; font-weight: 600; }
+.attention-offline-link { color: var(--info); text-decoration: none; font-weight: 600; }
 /* Bridge-offline banner dismiss button: bump tap target on touch devices */
 @media (hover: none) and (pointer: coarse) {
   .bridge-offline-dismiss { min-height: 44px; padding: 10px 14px; }
@@ -5500,7 +5529,7 @@ a.btn { text-decoration: none; }
   width: 3px;
   height: 14px;
   border-radius: 2px;
-  background: var(--accent);
+  background: var(--line-3);
   flex-shrink: 0;
 }
 .pg-section-head-rule {

--- a/dashboard/src/app/page.tsx
+++ b/dashboard/src/app/page.tsx
@@ -404,7 +404,10 @@ function ragColor(name: string): string {
   let h = 0;
   for (let i = 0; i < name.length; i++) h = (h * 31 + name.charCodeAt(i)) >>> 0;
   const hue = h % 360;
-  return `hsl(${hue}, 52%, 38%)`;
+  // Yellow-green hues (40–200) read brighter to the eye; cap their lightness
+  // lower so white initials clear ~5.2:1 across all hues (facelift P3-13).
+  const lightness = hue >= 40 && hue <= 200 ? 28 : 34;
+  return `hsl(${hue}, 55%, ${lightness}%)`;
 }
 
 /** Up to 2 uppercase initials from a recipe name. */
@@ -1110,7 +1113,7 @@ export default function HomePage() {
                       <div className="mt-1">
                         <Sparkline
                           values={runs7dSeries}
-                          color="var(--accent)"
+                          color="var(--ok)"
                           height={22}
                           labels={days7dLabels}
                           unit="runs"

--- a/dashboard/src/app/recipes/[...name]/_components/DoctorPanel.tsx
+++ b/dashboard/src/app/recipes/[...name]/_components/DoctorPanel.tsx
@@ -210,7 +210,7 @@ export function DoctorPanel({
                       <li key={cat} style={{ color: "var(--err)" }}>
                         {HALT_CATEGORY_LABEL[category] ?? cat}: {count}
                         <span
-                          style={{ color: "var(--accent)", marginLeft: 6 }}
+                          style={{ color: "var(--ink-2)", marginLeft: 6 }}
                           title="suggested fix"
                         >
                           → {HALT_CATEGORY_HINT[category] ?? "open run trace"}

--- a/dashboard/src/app/recipes/[...name]/_edit/page.tsx
+++ b/dashboard/src/app/recipes/[...name]/_edit/page.tsx
@@ -1074,7 +1074,7 @@ export default function RecipeEditPage({ name }: { name: string }) {
                 href="/connections"
                 style={{
                   fontSize: "var(--fs-xs)",
-                  color: "var(--accent)",
+                  color: "var(--info)",
                   textDecoration: "none",
                 }}
               >

--- a/dashboard/src/app/recipes/[...name]/_plan/page.tsx
+++ b/dashboard/src/app/recipes/[...name]/_plan/page.tsx
@@ -92,7 +92,7 @@ function formatCost(tokens: number): string {
 
 function TypeBadge({ type }: { type: string }) {
   const colors: Record<string, string> = {
-    tool: "var(--accent)",
+    tool: "var(--accent-cool)",
     agent: "var(--purple)",
     recipe: "var(--blue)",
   };

--- a/dashboard/src/app/runs/[seq]/page.tsx
+++ b/dashboard/src/app/runs/[seq]/page.tsx
@@ -478,7 +478,7 @@ function StepRow({
               style={{
                 fontSize: "var(--fs-xs)",
                 marginTop: 2,
-                color: "var(--accent)",
+                color: "var(--ink-2)",
                 whiteSpace: "normal",
                 wordBreak: "break-word",
               }}
@@ -549,7 +549,7 @@ function StepRow({
               <Link
                 href={`/recipes/${encodeURIComponent(recipeName)}/edit#step-${encodeURIComponent(step.id)}`}
                 style={{
-                  color: "var(--accent)",
+                  color: "var(--info)",
                   textDecoration: "none",
                   fontWeight: 600,
                   // ≥44pt touch target on mobile — explicit padding lets

--- a/dashboard/src/app/sessions/page.tsx
+++ b/dashboard/src/app/sessions/page.tsx
@@ -200,7 +200,7 @@ export default function SessionsPage() {
                 href="https://docs.anthropic.com/claude-code"
                 target="_blank"
                 rel="noreferrer"
-                style={{ color: "var(--accent)" }}
+                style={{ color: "var(--info)" }}
               >
                 Learn how to connect →
               </a>

--- a/dashboard/src/app/tasks/page.tsx
+++ b/dashboard/src/app/tasks/page.tsx
@@ -722,7 +722,7 @@ function TasksContent() {
                 t.status === "error"
                   ? "var(--err)"
                   : t.status === "running" || t.status === "pending"
-                    ? "var(--accent)"
+                    ? "var(--accent-cool)"
                     : t.status === "cancelled" || t.status === "interrupted"
                       ? "var(--warn)"
                       : "var(--ok)";
@@ -730,7 +730,7 @@ function TasksContent() {
                 t.status === "error"
                   ? "var(--err)"
                   : t.status === "running" || t.status === "pending"
-                    ? "var(--accent)"
+                    ? "var(--accent-cool)"
                     : t.status === "done"
                       ? "var(--ok)"
                       : t.status === "cancelled" || t.status === "interrupted"

--- a/dashboard/src/app/traces/page.tsx
+++ b/dashboard/src/app/traces/page.tsx
@@ -652,7 +652,7 @@ export default function TracesPage() {
               key={k}
               type="button"
               onClick={() => setStatusFilter(k)}
-              className={statusFilter === k ? "pill accent traces-filter-pill" : "pill muted traces-filter-pill"}
+              className={statusFilter === k ? "pill info traces-filter-pill" : "pill muted traces-filter-pill"}
             >
               {k === "all" ? `All (${traces.length})` : k === "done" ? `Done (${doneCount})` : `Errors (${errorCount})`}
             </button>
@@ -660,7 +660,7 @@ export default function TracesPage() {
           <button
             type="button"
             onClick={() => setKsOnly((v) => !v)}
-            className={ksOnly ? "pill accent traces-filter-pill traces-ks-pill" : "pill muted traces-filter-pill"}
+            className={ksOnly ? "pill info traces-filter-pill traces-ks-pill" : "pill muted traces-filter-pill"}
           >
             Kill-switch
           </button>
@@ -684,7 +684,7 @@ export default function TracesPage() {
               key={v}
               type="button"
               onClick={() => setView(v)}
-              className={view === v ? "pill accent traces-filter-pill traces-view-pill" : "pill muted traces-filter-pill traces-view-pill"}
+              className={view === v ? "pill info traces-filter-pill traces-view-pill" : "pill muted traces-filter-pill traces-view-pill"}
             >
               {v}
             </button>

--- a/dashboard/src/app/transactions/page.tsx
+++ b/dashboard/src/app/transactions/page.tsx
@@ -192,7 +192,7 @@ export default function TransactionsPage() {
               href="https://github.com/Oolab-labs/patchwork-os/blob/HEAD/documents/speculative-refactoring.md"
               target="_blank"
               rel="noopener noreferrer"
-              style={{ color: "var(--accent)" }}
+              style={{ color: "var(--info)" }}
             >
               the speculative-refactoring doc
             </a>{" "}

--- a/dashboard/src/components/patchwork/EntityTimeline.tsx
+++ b/dashboard/src/components/patchwork/EntityTimeline.tsx
@@ -57,7 +57,7 @@ function kindDotColor(kind: TimelineEvent["kind"]): string {
     case "run":      return "var(--blue, #4a90d9)";
     case "inbox":    return "var(--green, #4caf50)";
     case "approval": return "var(--amber, #d49a3a)";
-    case "trace":    return "var(--accent, #7c6ff7)";
+    case "trace":    return "var(--accent-cool, #0787ff)";
     case "step":     return "var(--ink-3, #9ca3af)";
     case "trigger":  return "var(--ink-2, #6b7280)";
     default:         return "var(--line-2)";
@@ -122,7 +122,7 @@ function EntityChip({ event }: { event: TimelineEvent }) {
         href={event.href}
         style={{
           fontSize: "var(--fs-xs)",
-          color: "var(--accent)",
+          color: "var(--info)",
           textDecoration: "none",
         }}
       >

--- a/dashboard/src/components/patchwork/HBarList.tsx
+++ b/dashboard/src/components/patchwork/HBarList.tsx
@@ -55,7 +55,7 @@ export function HBarList({
                   style={{
                     width: `${Math.max(2, pct)}%`,
                     height: "100%",
-                    background: item.color ?? "var(--orange)",
+                    background: item.color ?? "var(--ink-3)",
                     borderRadius: height,
                     transition: "width 0.4s ease",
                   }}

--- a/dashboard/src/components/patchwork/RelationStrip.tsx
+++ b/dashboard/src/components/patchwork/RelationStrip.tsx
@@ -54,9 +54,9 @@ function toneStyles(tone: RelationTone = "neutral"): {
   switch (tone) {
     case "accent":
       return {
-        borderColor: "color-mix(in srgb, var(--accent) 35%, transparent)",
-        color: "var(--accent)",
-        background: "color-mix(in srgb, var(--accent) 8%, transparent)",
+        borderColor: "color-mix(in srgb, var(--accent-cool) 35%, transparent)",
+        color: "var(--accent-cool)",
+        background: "color-mix(in srgb, var(--accent-cool) 8%, transparent)",
       };
     case "warn":
       return {

--- a/dashboard/src/components/patchwork/Sparkline.tsx
+++ b/dashboard/src/components/patchwork/Sparkline.tsx
@@ -12,7 +12,10 @@ import { useEffect, useId, useRef, useState } from "react";
  */
 export function Sparkline({
   values,
-  color = "var(--orange)",
+  // Neutral default — orange is reserved for brand/CTA (facelift P0-1-I).
+  // Callers pass a semantic color (runs→--ok, halts→--err, tools→--accent-cool);
+  // a missed caller degrades to neutral ink rather than an off-grammar orange.
+  color = "var(--ink-3)",
   height = 36,
   labels,
   unit = "",

--- a/dashboard/tokens.json
+++ b/dashboard/tokens.json
@@ -13,7 +13,7 @@
       "ink-0":    "#2a2418",
       "ink-1":    "#4a4030",
       "ink-2":    "#6e6450",
-      "ink-3":    "#7a6f57",
+      "ink-3":    "#706550",
       "orange":       "#c5532a",
       "orange-hover": "#ab4622",
       "orange-soft":  "rgba(197,83,42,0.13)",
@@ -112,9 +112,11 @@
       "accent-strong": "#e8956e",
       "accent-glow":   "rgba(255,122,69,0.35)",
       "purple-soft":  "#1c1b32",
+      "green":        "#6da060",
       "green-soft":   "#0e2519",
       "amber-soft":   "#2b2110",
-      "red-soft":     "#2b1511",
+      "red":          "#d05757",
+      "red-soft":     "rgba(208,87,87,0.16)",
       "blue-soft":    "#101b2c"
     },
     "shadow": {


### PR DESCRIPTION
**Keystone of the dashboard facelift** ([docs/dashboard-facelift-plan.md](docs/dashboard-facelift-plan.md), PR #881). Pure token/color cascade — **no logic changes, no JSX-structure changes**. Every change is either a token value or a `var(--accent)` → semantic-token swap, so it reviews as a flat diff.

Reserves **orange for brand / primary-CTA / active-nav / functional-focus only**; re-points every other use to a semantic token.

## Token grammar (`globals.css` + `tokens.json`)
- **Pill text tokens** `--ok-text` / `--warn-text` / `--err-text` — darker than the decoration tokens so soft-tinted pills clear AA on the light canvas. Dark mode re-points them back to the bright palette (the light values would be near-invisible on the dark soft fills — a gap in the plan).
- **`--ink-3`** light `#7a6f57`→`#706550` (10px label contrast 4.31→4.65:1).
- **Dark mode**: `--red` `#b54343`→`#d05757` (`--err` was 3.6:1, now 4.86:1 — AA); `--green`→`#6da060` (Orig-15); `--red-soft`→rgba so err pill fills tint cleanly.
- **Pill system**: `.ok/.warn/.err` use the text tokens; **removed the orange `.pill.accent` tone** (filter-active pills now use the existing `.pill.info`).

## Orange re-pointing (mechanical)
- **→ `--accent-cool`**: running-strip bar, activity filter chips, traces/decisions/connections filter pills (→ `.pill.info`), recipe plan tool node, EntityTimeline trace dot, RelationStrip accent tone, tasks running/pending dot+border, overview runs sparkline (→ `--ok`).
- **→ `--info` (links)**: navigational links the plan mis-labelled as "field labels" (approvals / sessions / transactions / runs-detail step link / recipe-edit / timeline).
- **→ `--ink-2` (neutral)**: `.editorial-h1 .accent` (hero keeps orange via the separate `.quilt-title` rule), suggested-fix hints, section-head bar (→ `--line-3`).
- nav-badge → `--info`; progress-fill → `--ok`; attention-offline-link → `--info`; Sparkline/HBarList orange defaults → neutral `--ink-3`.

## Also bundled (per the rollout)
- **P2-9** sidebar label typography (sentence case, ≤0.02em tracking — guardrail G-2).
- **P3-13** `ragColor` lightness cap (white initials ≥5.2:1 across all hues).

## Grounding corrected three plan errors
1. The overview hero uses `.quilt-title` (not `.editorial-h1`) — so the plan's "add `overview-hero` class + dual selector" was unnecessary; neutralizing `.editorial-h1 .accent` alone is sufficient and the hero stays orange.
2. The plan's "field labels → `--ink-2`" group was actually a **mix of links and running-status indicators** — re-pointed by real role (links→`--info`, running→`--accent-cool`) instead of a blanket grey that would have killed affordances/status meaning.
3. **Two `.pill.accent` sites the plan missed** (decisions, connections) migrated to `.pill.info` so removing the CSS class doesn't break them.

Logic-bearing runs-page items (P0-2 errored card, P0-3-B duplicate-dot removal, P0-3-C `statusPill` unification) stay in **PR 2** per the rollout. A pre-existing vocabulary-ratchet drift (connections empty-state "workflows"→"recipes") is fixed so the lint stays green.

## Verification
`tsc --noEmit` ✓ · `biome check` ✓ · `tokens:check` ✓ · `lint:vocabulary` ✓ · `lint:inline-fontsize` ✓ · **757/757 dashboard tests pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)