### PR TITLE
fix(dashboard): facelift PR 2 — runs-page render fixes + attention-band severity

### DIFF
--- a/dashboard/src/app/globals.css
+++ b/dashboard/src/app/globals.css
@@ -1937,6 +1937,10 @@ a.btn { text-decoration: none; }
 .runs-stat-card[data-variant="all"][data-active="true"]  { border-left-color: var(--orange); }
 .runs-stat-card[data-variant="done"][data-active="true"] { border-left-color: var(--ok); }
 .runs-stat-card[data-variant="error"][data-active="true"]{ border-left-color: var(--err); }
+/* Subtle semantic wash so the done / errored tiles read at a glance, not just
+   via the small colored label (facelift P0-2). The "all" tile stays neutral. */
+.runs-stat-card[data-variant="done"]  { background: color-mix(in srgb, var(--ok) 5%, transparent); }
+.runs-stat-card[data-variant="error"] { background: color-mix(in srgb, var(--err) 6%, transparent); }
 .runs-stat-label {
   font-size: var(--fs-xs);
   font-weight: 500;
@@ -5457,6 +5461,13 @@ a.btn { text-decoration: none; }
   box-shadow: var(--card-shadow);
   flex-wrap: wrap;
 }
+/* Band border/tint takes the highest severity present — a band containing a
+   failed-run or halt chip reads red, not amber (facelift P1-7). */
+.attention-band[data-severity="err"] {
+  background: color-mix(in srgb, var(--err) 4%, var(--card-bg));
+  border-color: color-mix(in srgb, var(--err) 18%, var(--line-1));
+  border-left-color: var(--err);
+}
 .attention-band-label {
   font-family: var(--font-mono);
   font-size: var(--fs-2xs);
@@ -5487,12 +5498,14 @@ a.btn { text-decoration: none; }
   border: 1px solid;
 }
 .attention-chip:hover { filter: brightness(1.06); transform: translateY(-1px); }
-.attention-chip--urgent {
-  background: color-mix(in srgb, var(--amber) 10%, var(--card-bg));
-  border-color: color-mix(in srgb, var(--amber) 40%, var(--line-1));
-  color: var(--amber);
-}
+/* Severity tones — class name now matches the rendered color (facelift P1-7).
+   warn = amber (pending approvals), err = red (failed runs / halts). */
 .attention-chip--warn {
+  background: color-mix(in srgb, var(--warn) 10%, var(--card-bg));
+  border-color: color-mix(in srgb, var(--warn) 40%, var(--line-1));
+  color: var(--warn);
+}
+.attention-chip--err {
   background: color-mix(in srgb, var(--err) 8%, var(--card-bg));
   border-color: color-mix(in srgb, var(--err) 32%, var(--line-1));
   color: var(--err);

--- a/dashboard/src/app/page.tsx
+++ b/dashboard/src/app/page.tsx
@@ -2,6 +2,7 @@
 import Link from "next/link";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { apiPath } from "@/lib/api";
+import { bandSeverity, buildAttentionItems } from "@/lib/attention";
 import { FirstRunChecklist } from "@/components/FirstRunChecklist";
 import { StatCard } from "@/components/StatCard";
 import { SkeletonStatCard } from "@/components/Skeleton";
@@ -315,26 +316,7 @@ function NeedsAttentionBand({
   failingCount24h: number;
   bridgeOk: boolean;
 }) {
-  const items = [
-    pendingCount > 0 && {
-      count: pendingCount,
-      label: pendingCount === 1 ? "approval pending" : "approvals pending",
-      href: "/approvals",
-      urgent: true,
-    },
-    haltCount24h > 0 && {
-      count: haltCount24h,
-      label: haltCount24h === 1 ? "halt · 24h" : "halts · 24h",
-      href: "/runs?halt=1",
-      urgent: false,
-    },
-    failingCount24h > 0 && {
-      count: failingCount24h,
-      label: failingCount24h === 1 ? "run failed · 24h" : "runs failed · 24h",
-      href: "/runs?window=24h",
-      urgent: false,
-    },
-  ].filter(Boolean) as Array<{ count: number; label: string; href: string; urgent: boolean }>;
+  const items = buildAttentionItems({ pendingCount, haltCount24h, failingCount24h });
 
   const allClear = items.length === 0;
 
@@ -375,14 +357,14 @@ function NeedsAttentionBand({
   }
 
   return (
-    <div className="attention-band">
+    <div className="attention-band" data-severity={bandSeverity(items)}>
       <span className="attention-band-label">Needs attention</span>
       <div className="attention-chips">
         {items.map((item) => (
           <Link
             key={item.href}
             href={item.href}
-            className={`attention-chip ${item.urgent ? "attention-chip--urgent" : "attention-chip--warn"}`}
+            className={`attention-chip attention-chip--${item.severity}`}
             aria-label={`${item.count} ${item.label} — view all`}
           >
             <span className="attention-chip-count">{item.count}</span>

--- a/dashboard/src/app/runs/page.tsx
+++ b/dashboard/src/app/runs/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 import React from "react";
 import { apiPath } from "@/lib/api";
+import { deriveRunStatus } from "@/components/patchwork/StatusPill";
 import { HALT_CATEGORY_HINT, HALT_CATEGORY_LABEL } from "@/lib/haltCategory";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
@@ -108,23 +109,24 @@ function fmtDur(ms: number): string {
   return s === 0 ? `${m}m` : `${m}m ${s}s`;
 }
 
-function statusPill(r: Run): "ok" | "err" | "warn" | "muted" | "running" {
-  if (r.status === "running") return "running";
-  if (r.assertionFailures && r.assertionFailures.length > 0) return "err";
-  // Honest partial-failure: a run can finish `done` while a step errored.
-  // Render amber "completed with errors" instead of a clean green "done".
-  if (r.status === "done" && r.hadStepErrors) return "warn";
-  if (r.status === "done") return "ok";
-  if (r.status === "error") return "err";
-  return "warn";
-}
-
-/** Display label for the status cell — honest about partial failure. */
-function statusLabel(r: Run): string {
-  if (r.status === "done" && r.hadStepErrors && !r.assertionFailures?.length) {
-    return "completed with errors";
-  }
-  return r.status;
+/**
+ * Runs-list status view, derived from the shared `deriveRunStatus` so the
+ * list cell and the run-detail header render one verdict from one place
+ * (facelift P0-3-C). `running` keeps its dedicated pill class so
+ * `.pill.running::before` draws the pulse dot (no inline JSX dot). The
+ * returned label already folds in assertion failures ("error · N fail") and
+ * partial failures ("completed with errors") — callers render it verbatim.
+ */
+function runStatusView(r: Run): { cls: string; label: string } {
+  if (r.status === "running") return { cls: "running", label: "running" };
+  const { tone, label } = deriveRunStatus(r.status, {
+    hadStepErrors: r.hadStepErrors,
+    assertionFailures: r.assertionFailures?.length ?? 0,
+  });
+  // deriveRunStatus only yields "info" for running (handled above); ok/err/warn
+  // map 1:1 to pill tone classes, anything else falls back to muted.
+  const cls = tone === "ok" || tone === "err" || tone === "warn" ? tone : "muted";
+  return { cls, label };
 }
 
 const RUNS_PAGE_SIZE = 100;
@@ -474,7 +476,16 @@ export default function RunsPage() {
       <div className="page-head">
         <div>
           <h1 className="editorial-h1">
-            Runs — <span className="accent">every patch your agents stitched.</span>
+            {/* Editorial tagline only when there's no data to speak for itself;
+                once runs are loaded the factual subtitle below carries the
+                context, so the header stays operational (facelift P2-8-A). */}
+            Runs
+            {(!runs || runs.length === 0) && (
+              <>
+                {" — "}
+                <span className="accent">every patch your agents stitched.</span>
+              </>
+            )}
           </h1>
           <div className="editorial-sub">
             {runs ? `${runs.length} runs` : "— runs"} · {TIME_WINDOW_LABEL[window].toLowerCase()} · avg {fmtDur(stats.avgMs)}
@@ -500,7 +511,9 @@ export default function RunsPage() {
           <RelationStrip
             items={[
               { label: "Recipes", href: "/recipes", title: "The YAML that produced these runs" },
-              { label: "Halts", href: "/runs?halt=1", tone: "warn", title: "Runs that hit a halt reason" },
+              // Only tint the Halts chip when halts actually exist; otherwise
+              // it sits ghost-neutral like its siblings (facelift P3-12).
+              { label: "Halts", href: "/runs?halt=1", tone: (haltSummary?.total ?? 0) > 0 ? "err" : undefined, title: "Runs that hit a halt reason" },
               { label: "Traces", href: "/traces", title: "Decision logs for these runs" },
               { label: "Activity", href: "/activity", title: "Live event firehose" },
             ]}
@@ -703,7 +716,7 @@ export default function RunsPage() {
           aria-pressed={status === "error"}
           aria-label={`Filter: errored runs (${stats.err})`}
         >
-          <div className="runs-stat-label runs-stat-label--err">⚠ Errored</div>
+          <div className="runs-stat-label runs-stat-label--err">✗ Errored</div>
           <div className={`runs-stat-value${stats.err > 0 ? " runs-stat-value--err" : ""}`}><AnimatedNumber value={stats.err} /></div>
           <div className="runs-stat-foot">{stats.total > 0 ? Math.round(stats.err / stats.total * 100) + "%" : "—"} error rate</div>
         </button>
@@ -816,7 +829,7 @@ export default function RunsPage() {
                   3,
                   Math.round((r.durationMs / maxDur) * 100),
                 );
-                const sClass = statusPill(r);
+                const { cls: sClass, label: sLabel } = runStatusView(r);
                 const barColor =
                   sClass === "ok"
                     ? "var(--green)"
@@ -841,7 +854,7 @@ export default function RunsPage() {
                       tabIndex={0}
                       role="button"
                       aria-expanded={isExpanded}
-                      aria-label={`Run of ${formatRecipeName(r.recipeName, r.trigger)}, ${statusLabel(r)}, ${normaliseTrigger(r.trigger)} trigger`}
+                      aria-label={`Run of ${formatRecipeName(r.recipeName, r.trigger)}, ${sLabel}, ${normaliseTrigger(r.trigger)} trigger`}
                     >
                       <td className="mono muted">
                         {fmtWhen(
@@ -881,31 +894,22 @@ export default function RunsPage() {
                       </td>
                       <td>
                         <span className={`pill ${sClass} runs-status-pill`}>
-                          {sClass === "running" ? (
-                            <span
-                              style={{
-                                display: "inline-block",
-                                width: 7,
-                                height: 7,
-                                borderRadius: "50%",
-                                background: "var(--accent)",
-                                marginRight: 5,
-                                animation: "runs-pulse 1.4s ease-in-out infinite",
-                                verticalAlign: "middle",
-                              }}
-                            />
-                          ) : (
-                            <span className="pill-dot" />
-                          )}
-                          {statusLabel(r)}
-                          {r.assertionFailures &&
-                            r.assertionFailures.length > 0 &&
-                            ` · ${r.assertionFailures.length} fail`}
+                          {/* Running pills draw their pulse dot via
+                              `.pill.running::before`; only non-running pills
+                              need the static dot (facelift P0-3-B). */}
+                          {sClass !== "running" && <span className="pill-dot" />}
+                          {sLabel}
                         </span>
                       </td>
-                      <td>
+                      <td
+                        aria-label={`Duration ${
+                          r.status === "running"
+                            ? fmtDur(Date.now() - (r.startedAt ?? r.createdAt))
+                            : fmtDur(r.durationMs)
+                        }, status: ${sLabel}`}
+                      >
                         <div className="runs-dur-cell">
-                          <div className="progress runs-dur-bar">
+                          <div className="progress runs-dur-bar" aria-hidden="true">
                             <div
                               className="progress-fill"
                               style={{
@@ -1040,7 +1044,7 @@ export default function RunsPage() {
           {windowedRuns.map((r, rowIdx) => {
             const key = `${r.taskId}-${r.seq}`;
             const isExpanded = expanded === key;
-            const sClass = statusPill(r);
+            const { cls: sClass, label: sLabel } = runStatusView(r);
             return (
               <div
                 key={key}
@@ -1072,26 +1076,10 @@ export default function RunsPage() {
                     />
                   </span>
                   <span className={`pill ${sClass} xs`}>
-                    {sClass === "running" ? (
-                      <span
-                        style={{
-                          display: "inline-block",
-                          width: 6,
-                          height: 6,
-                          borderRadius: "50%",
-                          background: "currentColor",
-                          marginRight: 4,
-                          animation: "runs-pulse 1.4s ease-in-out infinite",
-                          verticalAlign: "middle",
-                        }}
-                      />
-                    ) : (
-                      <span className="pill-dot" />
-                    )}
-                    {statusLabel(r)}
-                    {r.assertionFailures &&
-                      r.assertionFailures.length > 0 &&
-                      ` · ${r.assertionFailures.length} fail`}
+                    {/* Running pills draw their pulse dot via
+                        `.pill.running::before` (facelift P0-3-B). */}
+                    {sClass !== "running" && <span className="pill-dot" />}
+                    {sLabel}
                   </span>
                 </div>
                 <div className="run-card-meta">

--- a/dashboard/src/lib/__tests__/attention.test.ts
+++ b/dashboard/src/lib/__tests__/attention.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import {
+  type AttentionItem,
+  bandSeverity,
+  buildAttentionItems,
+} from "../attention";
+
+describe("buildAttentionItems", () => {
+  it("omits any category with a zero count", () => {
+    expect(
+      buildAttentionItems({ pendingCount: 0, haltCount24h: 0, failingCount24h: 0 }),
+    ).toEqual([]);
+  });
+
+  it("orders approvals → failed runs → halts", () => {
+    const items = buildAttentionItems({
+      pendingCount: 2,
+      haltCount24h: 1,
+      failingCount24h: 3,
+    });
+    expect(items.map((i) => i.href)).toEqual([
+      "/approvals",
+      "/runs?window=24h",
+      "/runs?halt=1",
+    ]);
+  });
+
+  it("marks failed runs and halts as 'err', approvals as 'warn' (no inversion)", () => {
+    const items = buildAttentionItems({
+      pendingCount: 1,
+      haltCount24h: 1,
+      failingCount24h: 1,
+    });
+    const bySeverity = Object.fromEntries(
+      items.map((i) => [i.href, i.severity]),
+    );
+    // The bug being fixed: failed runs / halts are more severe than a pending
+    // approval, so they must render in the higher-alarm err (red) register —
+    // never below an approval's warn (amber).
+    expect(bySeverity["/runs?window=24h"]).toBe("err");
+    expect(bySeverity["/runs?halt=1"]).toBe("err");
+    expect(bySeverity["/approvals"]).toBe("warn");
+  });
+
+  it("pluralises labels on the count", () => {
+    const one = buildAttentionItems({ pendingCount: 1, haltCount24h: 1, failingCount24h: 1 });
+    expect(one.find((i) => i.href === "/approvals")?.label).toBe("approval pending");
+    expect(one.find((i) => i.href === "/runs?window=24h")?.label).toBe("run failed · 24h");
+    expect(one.find((i) => i.href === "/runs?halt=1")?.label).toBe("halt · 24h");
+
+    const many = buildAttentionItems({ pendingCount: 2, haltCount24h: 2, failingCount24h: 2 });
+    expect(many.find((i) => i.href === "/approvals")?.label).toBe("approvals pending");
+    expect(many.find((i) => i.href === "/runs?window=24h")?.label).toBe("runs failed · 24h");
+    expect(many.find((i) => i.href === "/runs?halt=1")?.label).toBe("halts · 24h");
+  });
+});
+
+describe("bandSeverity", () => {
+  it("is 'err' when any err item is present", () => {
+    const items: AttentionItem[] = [
+      { count: 1, label: "approvals pending", href: "/approvals", severity: "warn" },
+      { count: 1, label: "runs failed · 24h", href: "/runs?window=24h", severity: "err" },
+    ];
+    expect(bandSeverity(items)).toBe("err");
+  });
+
+  it("is 'warn' when only warn items are present (approvals only)", () => {
+    const items = buildAttentionItems({ pendingCount: 3, haltCount24h: 0, failingCount24h: 0 });
+    expect(bandSeverity(items)).toBe("warn");
+  });
+});

--- a/dashboard/src/lib/attention.ts
+++ b/dashboard/src/lib/attention.ts
@@ -1,0 +1,69 @@
+/**
+ * "Needs attention" band model — single source of truth for the overview
+ * band's items, their order, and their severity.
+ *
+ * Facelift P1-7: the band previously used an `urgent: boolean` discriminant
+ * whose CSS classes were backwards (`--urgent` rendered amber, `--warn`
+ * rendered red) and whose band border was always amber regardless of the
+ * items present. This model replaces it with an explicit severity so the
+ * field name, the chip color, and the band border all agree:
+ *
+ *   - pending approvals → "warn" (amber): actionable, not yet a failure
+ *   - failed runs / halts → "err" (red): something already went wrong
+ *
+ * Order is approvals → failed runs → halts (most-actionable first, then by
+ * severity), and the band border takes the highest severity present.
+ */
+
+export type AttentionSeverity = "err" | "warn";
+
+export interface AttentionItem {
+  count: number;
+  label: string;
+  href: string;
+  severity: AttentionSeverity;
+}
+
+export interface AttentionCounts {
+  pendingCount: number;
+  haltCount24h: number;
+  failingCount24h: number;
+}
+
+export function buildAttentionItems({
+  pendingCount,
+  haltCount24h,
+  failingCount24h,
+}: AttentionCounts): AttentionItem[] {
+  const items: AttentionItem[] = [];
+  if (pendingCount > 0) {
+    items.push({
+      count: pendingCount,
+      label: pendingCount === 1 ? "approval pending" : "approvals pending",
+      href: "/approvals",
+      severity: "warn",
+    });
+  }
+  if (failingCount24h > 0) {
+    items.push({
+      count: failingCount24h,
+      label: failingCount24h === 1 ? "run failed · 24h" : "runs failed · 24h",
+      href: "/runs?window=24h",
+      severity: "err",
+    });
+  }
+  if (haltCount24h > 0) {
+    items.push({
+      count: haltCount24h,
+      label: haltCount24h === 1 ? "halt · 24h" : "halts · 24h",
+      href: "/runs?halt=1",
+      severity: "err",
+    });
+  }
+  return items;
+}
+
+/** Highest severity among the items — drives the band's left-border color. */
+export function bandSeverity(items: AttentionItem[]): AttentionSeverity {
+  return items.some((i) => i.severity === "err") ? "err" : "warn";
+}


### PR DESCRIPTION
Second PR of the dashboard facelift ([docs/dashboard-facelift-plan.md](docs/dashboard-facelift-plan.md)). Builds on PR 1's token grammar. Scope is the Runs page, the overview "Needs attention" band, and additive CSS.

## Attention band (P1-7) — a real severity bug, not just polish
The band used an `urgent: boolean` discriminant whose CSS classes were **backwards** (`.attention-chip--urgent` rendered amber, `--warn` rendered red) and whose left border was **always amber** — so a band containing failed-run/halt chips read less alarming than its red chips.

- New explicit, unit-tested severity model in [`src/lib/attention.ts`](dashboard/src/lib/attention.ts): approvals → `warn` (amber), failed runs + halts → `err` (red). Order: approvals → failed runs → halts. Band border takes the highest severity present.
- CSS class names now **match** their rendered color; band gains `[data-severity="err"]` → red border/tint.
- **6 new tests** in `attention.test.ts` pin the no-inversion invariant + ordering + band severity.

## Runs page
- **P0-3-C** — unify the list status with the shared `deriveRunStatus` so the list cell and the run-detail header render one verdict. Replaces the duplicated local `statusPill`/`statusLabel` with one `runStatusView` adapter; the label now folds in assertion failures (`error · N fail`) and partial failures, so the separate JSX `· N fail` suffix is gone (no more `done · 2 fail`).
- **P0-3-B** — drop the inline running-dot JSX in both desktop + mobile rows; the pulse is drawn by `.pill.running::before` (no duplicate dot, no orange).
- **P0-2** — subtle semantic bg wash on the done / errored stat tiles; `⚠ Errored` → `✗ Errored`.
- **P1-6** — `aria-label` on the duration cell (the decorative bar is now `aria-hidden`).
- **P2-8-A** — editorial tagline on the Runs `h1` only in the empty/loading state; once runs load the factual subtitle carries context (operational, not marketing). *(Cleaner than the plan's literal version, which duplicated the subtitle count.)*
- **P3-12** — Halts relation chip is tinted `err` only when halts exist; otherwise ghost-neutral like its siblings.

## Verification
`tsc --noEmit` ✓ · `next lint` (0 errors, **no new warnings** — the pre-existing unused-import warnings are unchanged) ✓ · `tokens:check` ✓ · `lint:vocabulary` ✓ · `lint:inline-fontsize` ✓ · **763/763 dashboard tests pass** (6 new).

Next: PR 3 (overview sparkline labels + FeaturedRecipeAside fallbacks + QuiltBg mask).

🤖 Generated with [Claude Code](https://claude.com/claude-code)