### PR TITLE
feat(dashboard): facelift PR 3 — overview sparkline labels + recipe-aside fallbacks

### DIFF
--- a/dashboard/src/app/globals.css
+++ b/dashboard/src/app/globals.css
@@ -2413,6 +2413,11 @@ a.btn { text-decoration: none; }
   inset: 0;
   pointer-events: none;
   opacity: 0.85;
+  /* Fade the mosaic out under the hero copy (left) and let it resolve into a
+     clean tile field on the right, so the two regions stop competing in the
+     same column (facelift P2-10 / guardrail G-1). */
+  mask-image: linear-gradient(to right, transparent 38%, rgba(0, 0, 0, 0.6) 58%, black 72%);
+  -webkit-mask-image: linear-gradient(to right, transparent 38%, rgba(0, 0, 0, 0.6) 58%, black 72%);
 }
 .quilt-bg svg {
   width: 100%;
@@ -3235,7 +3240,13 @@ a.btn { text-decoration: none; }
   [data-theme="dark"] .quilt-content::before {
     background: linear-gradient(to bottom, var(--surface) 60%, color-mix(in srgb, var(--surface) 75%, transparent) 100%);
   }
-  .quilt-bg { opacity: 0.55; }
+  /* On narrow screens the hero stacks vertically, so fade the mosaic top-to-
+     bottom instead of left-to-right (facelift P2-10). */
+  .quilt-bg {
+    opacity: 0.65;
+    mask-image: linear-gradient(to bottom, transparent 42%, rgba(0, 0, 0, 0.5) 62%, black 78%);
+    -webkit-mask-image: linear-gradient(to bottom, transparent 42%, rgba(0, 0, 0, 0.5) 62%, black 78%);
+  }
 }
 
 /* ---- Chip (2.0 small inline pills) ---- */

--- a/dashboard/src/app/page.tsx
+++ b/dashboard/src/app/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { apiPath } from "@/lib/api";
 import { bandSeverity, buildAttentionItems } from "@/lib/attention";
+import { recipeDisplayName } from "@/lib/recipeDisplay";
 import { FirstRunChecklist } from "@/components/FirstRunChecklist";
 import { StatCard } from "@/components/StatCard";
 import { SkeletonStatCard } from "@/components/Skeleton";
@@ -400,11 +401,6 @@ function ragInitials(name: string): string {
   return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
 }
 
-/** Human-readable display name (capitalised, dashes→spaces). */
-function ragDisplayName(name: string): string {
-  return name.replace(/[-_]/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
-}
-
 /** Short role text per column. */
 function ragRole(
   kind: "draft" | "paused" | "active",
@@ -634,7 +630,7 @@ function RecipesAtAGlance({
                           {ragInitials(recipe.name)}
                         </span>
                         <div className="rag3-card-info">
-                          <div className="rag3-card-name" title={ragDisplayName(recipe.name)}>{ragDisplayName(recipe.name)}</div>
+                          <div className="rag3-card-name" title={recipeDisplayName(recipe.name)}>{recipeDisplayName(recipe.name)}</div>
                           <div className="rag3-card-role">{roleText}</div>
                         </div>
                       </div>
@@ -656,8 +652,8 @@ function RecipesAtAGlance({
                       <button
                         type="button"
                         className="rag3-card-run"
-                        aria-label={`Run ${ragDisplayName(recipe.name)} now`}
-                        title={`Run ${ragDisplayName(recipe.name)}`}
+                        aria-label={`Run ${recipeDisplayName(recipe.name)} now`}
+                        title={`Run ${recipeDisplayName(recipe.name)}`}
                         disabled={isQueueing}
                         onClick={(e) => { e.preventDefault(); void runRecipe(canonicalRecipeKey(recipe.name)); }}
                       >
@@ -973,6 +969,19 @@ export default function HomePage() {
       return sum;
     });
   })();
+  // Hour-of-day labels aligned to curveSeries (index 0 = oldest hour, 23 =
+  // current), so the Tools sparkline carries a hover inspector instead of an
+  // unlabelled curve (facelift P1-4).
+  const hours24Labels = (() => {
+    const HOURS = 24;
+    const HOUR_MS = 60 * 60 * 1000;
+    const windowStart = Date.now() - HOURS * HOUR_MS;
+    return Array.from({ length: HOURS }, (_, i) => {
+      const h = new Date(windowStart + i * HOUR_MS).getHours();
+      const h12 = h % 12 === 0 ? 12 : h % 12;
+      return `${h12}${h < 12 ? "am" : "pm"}`;
+    });
+  })();
   return (
     <section>
       {/* Kill-switch banner rendered globally by Shell — was duplicated here. */}
@@ -1017,7 +1026,7 @@ export default function HomePage() {
           }
           return stats.length > 0 ? stats : undefined;
         })()}
-        aside={<FeaturedRecipeAside runs={runs as LeaderboardRun[]} />}
+        aside={<FeaturedRecipeAside runs={runs as LeaderboardRun[]} recipesCount={recipes.length} />}
       />
 
       {/* ------------------------------------------------------------------ */}
@@ -1180,6 +1189,8 @@ export default function HomePage() {
                               values={curveSeries}
                               color="var(--accent-cool)"
                               height={22}
+                              labels={hours24Labels}
+                              unit="calls"
                             />
                           </div>
                         )}

--- a/dashboard/src/components/FeaturedRecipeAside.tsx
+++ b/dashboard/src/components/FeaturedRecipeAside.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from "react";
 import { RunSparkBars, SuccessRing } from "@/components/patchwork";
 import { relTime } from "@/components/time";
 import { useRunRecipe } from "@/hooks/useRunRecipe";
+import { recipeDisplayName } from "@/lib/recipeDisplay";
 import type { LeaderboardRun } from "./RecipeLeaderboard";
 
 /**
@@ -27,6 +28,8 @@ interface FeaturedRecipeAsideProps {
   runs: LeaderboardRun[];
   /** Window in ms for volume ranking. Defaults to 24h. */
   windowMs?: number;
+  /** Installed-recipe count, for the empty state's "N recipes installed" line. */
+  recipesCount?: number;
 }
 
 type Mode = "running" | "needs-retry" | "top" | "empty";
@@ -136,6 +139,7 @@ function fmtElapsed(ms: number): string {
 export function FeaturedRecipeAside({
   runs,
   windowMs = 24 * 60 * 60 * 1000,
+  recipesCount,
 }: FeaturedRecipeAsideProps) {
   const pick = pickAside(runs, windowMs);
   const { run, pending } = useRunRecipe();
@@ -149,16 +153,22 @@ export function FeaturedRecipeAside({
   }, [pick?.mode]);
 
   if (!pick) {
+    // Distinguish "have recipes, none run yet" from "nothing installed" so the
+    // slot reflects the real next step (facelift P1-5-C).
+    const hasRecipes = (recipesCount ?? 0) > 0;
+    const emptyValue = hasRecipes
+      ? `${recipesCount} recipe${recipesCount === 1 ? "" : "s"} installed`
+      : "No recipes yet";
     return (
       <div className="quilt-aside-empty" aria-label="No recipes ready yet">
         <div className="quilt-aside-empty-label">Start here</div>
-        <div className="quilt-aside-empty-value">No runs yet</div>
+        <div className="quilt-aside-empty-value">{emptyValue}</div>
         <div className="quilt-aside-empty-foot">
           <Link
-            href="/marketplace"
-            style={{ color: "var(--accent)", textDecoration: "none", fontWeight: 600 }}
+            href={hasRecipes ? "/recipes" : "/marketplace"}
+            style={{ color: "var(--info)", textDecoration: "none", fontWeight: 600 }}
           >
-            Browse recipes →
+            {hasRecipes ? "Run one →" : "Browse recipes →"}
           </Link>
         </div>
       </div>
@@ -212,7 +222,7 @@ export function FeaturedRecipeAside({
     <div
       className="quilt-aside-featured"
       data-mode={pick.mode}
-      aria-label={`Recipe ${pick.name}`}
+      aria-label={`Recipe ${recipeDisplayName(pick.name)}`}
     >
       <div className="quilt-aside-eyebrow">
         {eyebrow}
@@ -221,9 +231,9 @@ export function FeaturedRecipeAside({
         <Link
           href={`/recipes/${encodeURIComponent(pick.name)}/edit`}
           className="quilt-aside-name"
-          title={`Edit ${pick.name}`}
+          title={`Edit ${recipeDisplayName(pick.name)}`}
         >
-          {pick.name}
+          {recipeDisplayName(pick.name)}
         </Link>
         <SuccessRing pct={pick.okRate} size={28} stroke={3.5} />
       </div>
@@ -244,7 +254,7 @@ export function FeaturedRecipeAside({
           href={ctaHref}
           className="quilt-aside-run"
           data-mode={pick.mode}
-          title={`Open live run of ${pick.name}`}
+          title={`Open live run of ${recipeDisplayName(pick.name)}`}
         >
           {ctaLabel}
         </Link>
@@ -255,7 +265,7 @@ export function FeaturedRecipeAside({
           disabled={isQueueing}
           className="quilt-aside-run"
           data-mode={pick.mode}
-          title={`Run ${pick.name} now`}
+          title={`Run ${recipeDisplayName(pick.name)} now`}
         >
           {ctaLabel}
         </button>

--- a/dashboard/src/components/patchwork/SuccessRing.tsx
+++ b/dashboard/src/components/patchwork/SuccessRing.tsx
@@ -67,7 +67,7 @@ export function SuccessRing({ pct, size = 28, stroke = 4 }: SuccessRingProps) {
           fill: "var(--ink-1)",
         }}
       >
-        {pct == null ? "—" : `${Math.round(safePct)}`}
+        {pct == null ? "—" : `${Math.round(safePct)}%`}
       </text>
     </svg>
   );

--- a/dashboard/src/lib/__tests__/recipeDisplay.test.ts
+++ b/dashboard/src/lib/__tests__/recipeDisplay.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { recipeDisplayName } from "../recipeDisplay";
+
+describe("recipeDisplayName", () => {
+  it("turns dashes and underscores into spaced, capitalised words", () => {
+    expect(recipeDisplayName("morning-brief")).toBe("Morning Brief");
+    expect(recipeDisplayName("inbox_triage")).toBe("Inbox Triage");
+    expect(recipeDisplayName("apple-watch_health-log")).toBe("Apple Watch Health Log");
+  });
+
+  it("capitalises a single bare word", () => {
+    expect(recipeDisplayName("standup")).toBe("Standup");
+  });
+
+  it("leaves already-spaced names capitalised", () => {
+    expect(recipeDisplayName("daily report")).toBe("Daily Report");
+  });
+
+  it("returns an empty string unchanged", () => {
+    expect(recipeDisplayName("")).toBe("");
+  });
+});

--- a/dashboard/src/lib/recipeDisplay.ts
+++ b/dashboard/src/lib/recipeDisplay.ts
@@ -1,0 +1,11 @@
+/**
+ * Human-readable recipe display name: dashes/underscores → spaces, each word
+ * capitalised (e.g. "morning-brief" → "Morning Brief").
+ *
+ * Shared so the Overview recipe grid and the FeaturedRecipeAside render the
+ * same label (facelift P1-5-A). Routing still uses the raw recipe name —
+ * only display text/titles should use this.
+ */
+export function recipeDisplayName(name: string): string {
+  return name.replace(/[-_]/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+}


### PR DESCRIPTION
Third PR of the dashboard facelift ([docs/dashboard-facelift-plan.md](docs/dashboard-facelift-plan.md)). Overview-page polish, building on PR 1/PR 2.

- **P1-4** — the *Tools called* sparkline now carries hour-of-day labels + a `calls` unit, so hovering it reads `3pm · 5 calls` instead of an unlabelled curve. `hours24Labels` is built index-aligned with `curveSeries`.
- **P1-5-A** — extracted the recipe display-name helper to [`src/lib/recipeDisplay.ts`](dashboard/src/lib/recipeDisplay.ts) (shared by the Overview recipe grid + `FeaturedRecipeAside`). The aside now shows **Morning Brief**, not `morning-brief`, in its name/title/aria — routing hrefs stay on the raw name. Unit-tested.
- **P1-5-B** — `SuccessRing` renders `87%`, not a bare `87`.
- **P1-5-C** — `FeaturedRecipeAside` empty state distinguishes **N recipes installed** (→ *Run one*) from **No recipes yet** (→ *Browse recipes*) via a `recipesCount` prop; its CTA link moves off orange to `--info` (the link convention from PR 1).
- **P2-10** — `QuiltBg` gets a CSS mask so the hero mosaic fades out under the copy (horizontal on desktop, vertical on the stacked mobile layout) instead of bleeding into the text column (guardrail G-1).

**Deferred:** Orig-25 (once-per-session entrance gate) — doing it hydration-safely without an animation-replay flash isn't worth the regression risk for a P3 polish item; left for a focused follow-up.

## Verification
`tsc --noEmit` ✓ · `next lint` (0 errors, no new warnings) ✓ · `tokens:check` ✓ · `lint:vocabulary` ✓ · `lint:inline-fontsize` ✓ · **767/767 dashboard tests pass** (4 new).

Next: PR 4 (operational-page taglines P2-8-B, dual-offline-alert removal P3-11, reduced-motion Orig-6, card-class cleanup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)