### PR TITLE
feat(dashboard): label the Traces waterfall bars + type-color legend

### DIFF
--- a/dashboard/src/app/globals.css
+++ b/dashboard/src/app/globals.css
@@ -6209,6 +6209,24 @@ a.btn { text-decoration: none; }
 .traces-view-label { font-size: var(--fs-s); color: var(--ink-3); }
 .traces-view-pill { cursor: pointer; }
 
+/* -- type-color legend -- */
+.traces-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px;
+  margin: 0 2px 12px;
+  font-size: var(--fs-2xs);
+  font-family: var(--font-mono);
+  color: var(--ink-2);
+}
+.traces-legend-item { display: inline-flex; align-items: center; gap: 6px; }
+.traces-legend-swatch {
+  width: 9px;
+  height: 9px;
+  border-radius: 2px;
+  flex-shrink: 0;
+}
+
 /* -- card / outer -- */
 .traces-card { padding: 0; overflow-x: auto; }
 

--- a/dashboard/src/app/page.tsx
+++ b/dashboard/src/app/page.tsx
@@ -1095,7 +1095,7 @@ export default function HomePage() {
               <StatCard
                 label="Runs · 24h"
                 className="stat-card--runs"
-                icon={<span className="stat-tile-icon stat-tile-icon--runs" style={{ color: "var(--accent)" }}><TileIconPlay /></span>}
+                icon={<span className="stat-tile-icon stat-tile-icon--runs" style={{ color: "var(--ok)" }}><TileIconPlay /></span>}
                 value={<AnimatedNumber value={runsCount24h} />}
                 foot={
                   <div>

--- a/dashboard/src/app/traces/page.tsx
+++ b/dashboard/src/app/traces/page.tsx
@@ -303,6 +303,7 @@ function SpanBar({
   groupStartMs,
   groupEndMs,
   color,
+  label,
 }: {
   startMs: number;
   durationMs: number;
@@ -312,10 +313,15 @@ function SpanBar({
   label?: string;
 }) {
   const range = groupEndMs - groupStartMs;
+  // The bar was previously unreadable: `label` was declared but never
+  // rendered, so the track carried no hover tooltip or screen-reader text and
+  // children passed no label at all. Surface it as title + aria-label on the
+  // track in every branch, falling back to the duration.
+  const barLabel = label ?? (durationMs > 0 ? `${durationMs}ms` : "instant");
 
   if (range <= 0) {
     return (
-      <div className="traces-span-track">
+      <div className="traces-span-track" title={barLabel} aria-label={barLabel}>
         <div className="traces-span-fill" style={{ inset: 0, background: color }} />
       </div>
     );
@@ -325,7 +331,7 @@ function SpanBar({
 
   if (durationMs <= 0) {
     return (
-      <div className="traces-span-track">
+      <div className="traces-span-track" title={barLabel} aria-label={barLabel}>
         <div
           className="traces-span-tick"
           style={{ left: `${Math.min(leftPct, 98)}%`, background: color }}
@@ -337,7 +343,7 @@ function SpanBar({
   const widthPct = Math.max(2, (durationMs / range) * 100);
 
   return (
-    <div className="traces-span-track">
+    <div className="traces-span-track" title={barLabel} aria-label={barLabel}>
       <div
         className="traces-span-fill"
         style={{
@@ -692,6 +698,24 @@ export default function TracesPage() {
         </div>
       </div>
 
+      {/* Type-color legend — the waterfall bar + row-icon colors encode the
+          trace type; without a key those colors are meaningless (facelift
+          addendum, Traces waterfall pass). */}
+      <div className="traces-legend" aria-label="Trace type colors">
+        {(Object.entries(TYPE_THEME) as Array<[TraceType, (typeof TYPE_THEME)[TraceType]]>).map(
+          ([type, theme]) => (
+            <span key={type} className="traces-legend-item">
+              <span
+                className="traces-legend-swatch"
+                style={{ background: theme.fg }}
+                aria-hidden="true"
+              />
+              {type.replace(/_/g, " ")}
+            </span>
+          ),
+        )}
+      </div>
+
       {loading && traces.length === 0 && (
         <SkeletonList rows={6} columns={4} />
       )}
@@ -904,6 +928,7 @@ export default function TracesPage() {
                                 groupStartMs={groupStartMs}
                                 groupEndMs={groupEndMs}
                                 color={childTheme.fg}
+                                label={`${child.key} · ${childDuration > 0 ? `${childDuration}ms` : "instant"} · +${child.ts - groupStartMs}ms from start`}
                               />
                             </div>
                             {childDuration > 0 && (


### PR DESCRIPTION
Cherry-picked the **highest-value remaining facelift item** (the live Playwright review showed the Traces page as rows of identical, meaning-free blue bars). Scoped tight — no mechanical-cleanup churn.

## Traces waterfall
- **`SpanBar` declared a `label` prop but never rendered it** — the track carried no `title`/`aria-label`, and child bars passed no label at all. Now every bar (all three render branches: full bar, zero-duration tick, zero-range fill) gets a `title` + `aria-label`, falling back to the duration. Child bars pass a composed `"<key> · <dur> · +<offset>ms from start"` label.
- **Type-color legend** strip above the list (approval / enrichment / recipe run / decision) so the bar + row-icon colors are actually decodable — there was no key before, so the colors meant nothing.
- **Skipped the per-row time axis** from the addendum on purpose: each bar already shows its duration as text beside it, so an axis adds noise for little gain.

## Folded-in nit
- Overview *Runs* telemetry-tile icon was orange while its sparkline is green (the residual flagged in PR 1) — re-pointed to `--ok` for agreement.

Verified live with Playwright: legend renders, 0 console errors.

## Verification
`tsc --noEmit` ✓ · `next lint` (0 errors) ✓ · `tokens:check` ✓ · `lint:vocabulary` ✓ · `lint:inline-fontsize` ✓ · **767/767 dashboard tests pass**.

This is the deliberate stopping point for the facelift — the remaining plan items (focus-trap a11y, sidebar collapse, CSS-class cleanup) are either separate-PR-worthy or low-payoff polish, per the by-value triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)