### PR TITLE
feat(dashboard): theme redesign — decoration quieting (AP-03 / AP-04)

### DIFF
--- a/dashboard/src/app/globals.css
+++ b/dashboard/src/app/globals.css
@@ -186,7 +186,9 @@
   --card-bg:     rgba(251,248,240,0.96);
   --card-blur:   none;
   --card-shadow: 0 1px 0 0 rgba(255,255,255,0.85) inset, var(--shadow-s);
-  --card-shadow-hover: 0 1px 0 0 rgba(255,255,255,0.95) inset, 0 0 30px rgba(var(--orange-rgb),0.10), var(--shadow-l);
+  /* Theme-redesign AP-04: drop the orange bloom from generic card hovers —
+     elevation comes from --shadow-l only; orange stays reserved for brand/CTA. */
+  --card-shadow-hover: 0 1px 0 0 rgba(255,255,255,0.95) inset, var(--shadow-l);
 
   /* glass — blur disabled for scroll perf, see --card-blur note above. */
   --glass-bg:     rgba(251,248,240,0.92);
@@ -199,17 +201,15 @@
   --header-h: 56px;
   --transition: cubic-bezier(0.4, 0, 0.2, 1);
   --stitch-line: rgba(60,45,20,0.10);
-  --quilt-soft: rgba(197,83,42,0.07);
-  --aurora-1: rgba(197,83,42,0.05);
-  --aurora-2: rgba(120,90,40,0.04);
-  --aurora-3: rgba(160,120,60,0.04);
-  --grid-mask-opacity: 0.55;
-  --paper-grain:
-    radial-gradient(circle at 13% 22%, rgba(120,90,40,0.025) 0, transparent 0.7px),
-    radial-gradient(circle at 67% 41%, rgba(120,90,40,0.025) 0, transparent 0.7px),
-    radial-gradient(circle at 89% 78%, rgba(120,90,40,0.025) 0, transparent 0.7px),
-    radial-gradient(circle at 31% 89%, rgba(120,90,40,0.02) 0, transparent 0.7px),
-    radial-gradient(circle at 52% 12%, rgba(120,90,40,0.02) 0, transparent 0.7px);
+  /* Theme-redesign AP-03: quiet the decorative layers behind data.
+     Neutral quilt tint (no orange), halved aurora, grid as a faint top-edge
+     texture (0.55→0.18), paper-grain removed (imperceptible benefit, real noise). */
+  --quilt-soft: rgba(120,90,40,0.05);
+  --aurora-1: rgba(197,83,42,0.03);
+  --aurora-2: rgba(120,90,40,0.02);
+  --aurora-3: rgba(160,120,60,0.02);
+  --grid-mask-opacity: 0.18;
+  --paper-grain: none;
 
   /* spacing */
   --s-1: 4px;  --s-2: 8px;   --s-3: 12px; --s-4: 16px;
@@ -300,11 +300,13 @@
   --accent-strong: #e8956e;
   --accent-glow: rgba(255,122,69,0.35);
   --stitch-line: rgba(255,255,255,0.05);
-  --quilt-soft: rgba(255,122,69,0.06);
-  --aurora-1: rgba(255,122,69,0.06);
-  --aurora-2: rgba(110,168,254,0.05);
-  --aurora-3: rgba(176,140,232,0.04);
-  --grid-mask-opacity: 0.4;
+  /* Theme-redesign AP-03: neutral quilt tint (no orange) + halved aurora +
+     calmer grid in dark, matching the light-mode decoration quieting. */
+  --quilt-soft: rgba(255,255,255,0.04);
+  --aurora-1: rgba(255,122,69,0.04);
+  --aurora-2: rgba(110,168,254,0.03);
+  --aurora-3: rgba(176,140,232,0.03);
+  --grid-mask-opacity: 0.15;
   --paper-grain: none;
 
   --card-bg:     rgba(16,18,22,0.94);
@@ -579,11 +581,11 @@ button { font-family: inherit; }
    * `clip` clamps overflow on a single axis without creating a scroll box. */
   overflow-x: clip;
   overflow-y: visible;
+  /* Theme-redesign AP-03: two faint top radials only — dropped the bottom
+     aurora-3 radial and the paper-grain stack so the canvas stays quiet. */
   background:
     radial-gradient(600px 400px at 15% 20%, var(--aurora-2), transparent 60%),
-    radial-gradient(500px 350px at 90% 70%, var(--aurora-1), transparent 65%),
-    radial-gradient(400px 300px at 50% 110%, var(--aurora-3), transparent 60%),
-    var(--paper-grain);
+    radial-gradient(500px 350px at 90% 70%, var(--aurora-1), transparent 65%);
 }
 
 .app-main::before {
@@ -596,8 +598,10 @@ button { font-family: inherit; }
   background-size: 32px 32px;
   background-position: -1px -1px;
   opacity: var(--grid-mask-opacity);
-  mask-image: radial-gradient(ellipse at top, black 30%, transparent 80%);
-  -webkit-mask-image: radial-gradient(ellipse at top, black 30%, transparent 80%);
+  /* Theme-redesign AP-03: confine the grid to a faint top-edge texture
+     (~top 22%) so it never sits behind tables, cards, or the fold. */
+  mask-image: radial-gradient(ellipse 120% 22% at 50% 0%, black 0%, transparent 100%);
+  -webkit-mask-image: radial-gradient(ellipse 120% 22% at 50% 0%, black 0%, transparent 100%);
   pointer-events: none;
 }
 
@@ -605,10 +609,10 @@ button { font-family: inherit; }
   content: "";
   position: absolute;
   inset: 0;
+  /* Theme-redesign AP-03: one static top-right wash, no animation — was an
+     18s two-aurora keyframe drifting behind the data. */
   background:
-    radial-gradient(720px 460px at 82% 0%, var(--aurora-1), transparent 62%),
-    radial-gradient(520px 360px at 8% 58%, var(--aurora-2), transparent 65%);
-  animation: aurora 18s ease-in-out infinite alternate;
+    radial-gradient(600px 320px at 90% 0%, var(--aurora-1), transparent 60%);
   pointer-events: none;
 }
 
@@ -891,9 +895,11 @@ button.topbar-search {
   position: absolute;
   inset: 0;
   border-radius: inherit;
+  /* Theme-redesign AP-04: neutral light sheen, not an orange bloom — orange is
+     reserved for brand/CTA, not sprayed on every hoverable card. */
   background: radial-gradient(
     400px circle at var(--mouse-x, 50%) var(--mouse-y, 50%),
-    rgba(var(--orange-rgb), 0.12),
+    rgba(255, 255, 255, 0.45),
     transparent 65%
   );
   opacity: 0;
@@ -2412,13 +2418,14 @@ a.btn { text-decoration: none; }
   position: absolute;
   inset: 0;
   pointer-events: none;
-  opacity: 0.85;
-  /* Fade the mosaic out under the hero copy (left) and let it resolve into a
-     clean tile field on the right, so the two regions stop competing in the
-     same column (facelift P2-10 / guardrail G-1). */
-  mask-image: linear-gradient(to right, transparent 38%, rgba(0, 0, 0, 0.6) 58%, black 72%);
-  -webkit-mask-image: linear-gradient(to right, transparent 38%, rgba(0, 0, 0, 0.6) 58%, black 72%);
+  /* Theme-redesign AP-03: confine the mosaic to a far-right strip at reduced
+     opacity (was 0.85, full mask from 38%) so it reads as a quiet texture, not
+     a competing field. Paired with the neutral QuiltBg PALETTE (no orange). */
+  opacity: 0.55;
+  mask-image: linear-gradient(to right, transparent 55%, rgba(0, 0, 0, 0.5) 72%, black 85%);
+  -webkit-mask-image: linear-gradient(to right, transparent 55%, rgba(0, 0, 0, 0.5) 72%, black 85%);
 }
+[data-theme="dark"] .quilt-bg { opacity: 0.50; }
 .quilt-bg svg {
   width: 100%;
   height: 100%;

--- a/dashboard/src/app/page.tsx
+++ b/dashboard/src/app/page.tsx
@@ -383,14 +383,17 @@ function NeedsAttentionBand({
 // ---------------------------------------------------------------------------
 
 /** Derive stable pastel avatar colour from recipe name. */
+// Theme-redesign AP-04: a fixed 5-tone muted palette instead of a 360° hue
+// rotation, so recipe avatars stop forming a rainbow that competes with the
+// semantic status hues. Tones are dark + low-chroma (warm taupe / sage /
+// slate / mauve / ochre) so the white initials (.rag3-avatar) clear ~5:1+ in
+// both themes. (The audit's light-pastel palette assumed dark ink; these
+// initials are #fff, so the tones must stay dark.)
+const AVATAR_PALETTE = ["#6b5d4f", "#5a6b50", "#4f5d6b", "#6b5060", "#6b5a3a"];
 function ragColor(name: string): string {
   let h = 0;
   for (let i = 0; i < name.length; i++) h = (h * 31 + name.charCodeAt(i)) >>> 0;
-  const hue = h % 360;
-  // Yellow-green hues (40–200) read brighter to the eye; cap their lightness
-  // lower so white initials clear ~5.2:1 across all hues (facelift P3-13).
-  const lightness = hue >= 40 && hue <= 200 ? 28 : 34;
-  return `hsl(${hue}, 55%, ${lightness}%)`;
+  return AVATAR_PALETTE[h % AVATAR_PALETTE.length];
 }
 
 /** Up to 2 uppercase initials from a recipe name. */

--- a/dashboard/src/components/patchwork/QuiltBg.tsx
+++ b/dashboard/src/components/patchwork/QuiltBg.tsx
@@ -1,15 +1,18 @@
 "use client";
 import { useEffect, useMemo, useState } from "react";
 
+// Theme-redesign AP-03: neutral tile palette — no orange/ink bleeding through
+// the hero text mask. Quiet surface tones + transparency only; the mosaic is a
+// texture, not a competing color field.
 const PALETTE = [
-  "var(--orange)",
-  "var(--orange-soft)",
+  "var(--recess)",
+  "var(--pressed)",
+  "var(--surface)",
   "var(--quilt-soft)",
   "transparent",
   "transparent",
   "transparent",
-  "var(--ink-3)",
-  "var(--pressed)",
+  "var(--canvas)",
 ];
 
 interface Cell {
@@ -98,7 +101,7 @@ export function QuiltBg({
           }
           return next;
         });
-      }, 1400);
+      }, 2800);
     };
     const stop = () => {
       if (id !== null) {


### PR DESCRIPTION
The high-visibility slice of the workflow-driven redesign ([docs/theme-redesign-2026-06.md](docs/theme-redesign-2026-06.md)) — calm the decorative layers that compete with data, and pull orange off non-brand surfaces. **Independent of the token-foundation PR (#886)** (touches only untracked decorative tokens + components), so it can merge in any order.

## AP-03 — decorative-layer noise
- **Grid**: `--grid-mask-opacity` 0.55→0.18 (light) / 0.4→0.15 (dark); `.app-main::before` mask tightened to a top-edge ellipse (~top 22%) so the 32px grid no longer sits behind tables / cards / the fold.
- **Aurora**: all `--aurora-*` halved (both themes); the animated 18s two-aurora `.app-main::after` keyframe → one **static** top-right wash; dropped the third `.app-main` background radial.
- **Paper-grain**: the 5-radial light stack → `none`.
- **Quilt mosaic**: opacity 0.85→0.55 (light) / 0.50 (dark), mask pushed to a far-right strip, and a **neutral QuiltBg palette** (recess/pressed/surface/canvas + transparent — no orange/ink tiles bleeding through the hero text mask); flicker 1400→2800ms.

## AP-04 — orange over-distribution
- Removed the orange bloom from `--card-shadow-hover` (hover lifts via shadow only).
- Neutralized the card mouse-tracking `::before` glow (orange → faint white sheen).
- **`ragColor`**: a fixed 5-tone muted palette (taupe/sage/slate/mauve/ochre) instead of a 360° hue rotation — ends the recipe-avatar **rainbow**. Tones stay dark so the white initials clear ~5:1+ (the audit's light-pastel palette assumed dark ink; these initials are `#fff`).

## Before / after (Playwright, both themes)
Grid texture noise **gone** (now a faint top-edge only), hero mosaic calmed to a faint right strip, avatars muted, canvas reads clean — most dramatic in light mode. 0 console errors.

`tokens:check` ✓ · `tsc` ✓ · `next lint` (0 errors) ✓ · **767 tests** ✓.

## Series status
- #886 — token foundation + AA bg-under-text (open)
- **this** — decoration quieting (open, independent)
- next: light standalone-text + tag-chip AA sweep (consumes #886 tokens, so after #886 merges); then dark structural parity + focus; then scale + type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)