### PR TITLE
test: stop the recurring Windows bridge-suite CI flake

### DIFF
--- a/src/__tests__/pong-starvation.test.ts
+++ b/src/__tests__/pong-starvation.test.ts
@@ -7,15 +7,23 @@
  *  - Disconnect log includes disconnectReason="pong_timeout" + lastPong age
  *  - Clean client close logs disconnectReason="client_initiated"
  *
- * Uses real timers with a very short pingIntervalMs (50ms) injected via the
- * Server constructor option, avoiding fake-timer / I/O callback ordering issues.
+ * Uses real timers with a short pingIntervalMs injected via the Server
+ * constructor option, avoiding fake-timer / I/O callback ordering issues.
  *
- * Threshold logic (interval 1 = first false flag, no miss counted):
- *   T+50ms:  isAlive=true → flag false, ping sent
- *   T+100ms: isAlive=false → missedPongs=1
- *   T+150ms: isAlive=false → missedPongs=2
- *   T+200ms: isAlive=false → missedPongs=3
- *   T+250ms: isAlive=false → missedPongs=4 → terminate()
+ * Threshold logic (interval 1 = first false flag, no miss counted), at the
+ * PING_MS below:
+ *   1×PING_MS: isAlive=true → flag false, ping sent
+ *   2×PING_MS: isAlive=false → missedPongs=1
+ *   3×PING_MS: isAlive=false → missedPongs=2
+ *   4×PING_MS: isAlive=false → missedPongs=3
+ *   5×PING_MS: isAlive=false → missedPongs=4 → terminate()
+ *
+ * PING_MS was 50ms, which left the "stays alive below threshold" test only a
+ * ~75ms wall-clock margin before the 5th interval — too tight for a loaded
+ * Windows CI runner under --coverage, where event-loop drift pushed the test's
+ * own setTimeout past the terminate point and it flaked (missedPongs=4). Raised
+ * to 200ms so that negative assertion has a ~300ms margin. (CI retry is a
+ * second backstop; see vitest.config.ts.)
  */
 
 import { randomUUID } from "node:crypto";
@@ -24,7 +32,7 @@ import { WebSocket, type WebSocketServer } from "ws";
 import { Logger } from "../logger.js";
 import { Server } from "../server.js";
 
-const PING_MS = 50; // short interval for tests
+const PING_MS = 200; // short interval for tests; wide enough margin for CI drift
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -100,7 +108,7 @@ describe("pong starvation — threshold is 4 missed pongs", () => {
     await connectNoAutoPong(port, authToken);
 
     // Wait for server to terminate the client (5 intervals = 250ms + slack)
-    await waitForClientsSize(server, 0, 2000);
+    await waitForClientsSize(server, 0, 3000);
 
     expect(getWssClients(server).size).toBe(0);
   });
@@ -151,7 +159,7 @@ describe("pong starvation — disconnect-reason logging", () => {
     const _ws = await connectNoAutoPong(port, authToken);
 
     // Wait for termination (5 intervals + slack)
-    await waitForClientsSize(server, 0, 2000);
+    await waitForClientsSize(server, 0, 3000);
 
     const warnMatch = warnLines.find((l) => l.includes("4 missed pongs"));
     expect(warnMatch).toBeDefined();
@@ -170,7 +178,7 @@ describe("pong starvation — disconnect-reason logging", () => {
 
     ws.close(1000, "done");
     // Wait until server side has removed the client (close handler has fired)
-    await waitForClientsSize(server, 0, 2000);
+    await waitForClientsSize(server, 0, 3000);
 
     const infoMatch = infoLines.find((l) =>
       l.includes("Claude Code WebSocket closed"),

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,14 @@ export default defineConfig({
     setupFiles: ["src/__tests__/testEnvSetup.ts"],
     testTimeout: 15_000,
     hookTimeout: 10_000,
+    // Retry only in CI: the bridge suite has timing/IO/port/fs.watch tests that
+    // run on shared, overloaded runners (worst on Windows under --coverage), so
+    // a genuinely-correct test can fail once on event-loop drift. Up to 3
+    // attempts ends the "re-run the whole job by hand" tax without masking real
+    // breaks — a true failure still fails all attempts. Local dev keeps retry 0
+    // so flakes surface and get fixed (e.g. the pong-starvation timing fix in
+    // this same change).
+    retry: process.env.CI ? 2 : 0,
     coverage: {
       provider: "v8",
       include: ["src/**/*.ts"],


### PR DESCRIPTION
The bridge `vitest run` flaked on **one OS per run** (mostly Windows under `--coverage`) on ~6 dashboard PRs this session — each cost a manual job re-run, despite none of those PRs touching bridge code. This fixes the root cause and adds a backstop.

## Root cause — `pong-starvation.test.ts` real-timer race
The *"does NOT terminate after 3 missed pongs"* test injected a 50ms ping interval, waited **175ms** on a real timer, then asserted the client was still connected. But the server terminates at the 5th interval (**250ms**) — only a **~75ms** wall-clock margin. On a loaded Windows runner under coverage instrumentation, the test's own `setTimeout` drifts past 250ms → the server has already terminated the socket (the `pong_timeout missedPongs=4` line seen in every failure log) → the assertion fails.

Fix: raise the injected interval to **200ms** so the negative assertion has a **~300ms** margin (and widened the positive waits to 3s). Both pong + heartbeat suites still pass.

## Backstop — CI-only test retry
Added `retry: process.env.CI ? 2 : 0` to `vitest.config.ts`. The bridge suite has many timing / IO / port / `fs.watch` tests running on shared runners; up to 3 attempts ends the re-run tax for *any* environmental flake **without masking real breaks** — a genuine failure still fails all attempts. Local dev keeps `retry: 0` so flakes surface and get fixed.

## Verification
Full bridge suite: **7459 passed / 2 skipped** (511 files); `pong-starvation` + `bridge-ws-heartbeat` green at the new timing; `typecheck:tests:core` + biome clean.

This should end the per-PR re-run tax. If a flake still slips through, the retry catches it; if a test fails for real, all 3 attempts fail and CI stays red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)