### PR TITLE
feat(grok): Grok Build (Grok CLI) onboarding + shim footgun fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ The bridge runs without any flags. No recipes, no automation, no dashboard — j
 | Client | Protocol |
 |---|---|
 | Claude Code CLI | WebSocket `ws://127.0.0.1:<port>` |
-| Claude Desktop | stdio shim → WebSocket |
+| Claude Desktop, Grok Build (Grok CLI) | stdio shim → WebSocket |
 | Gemini CLI, Codex CLI, claude.ai | Streamable HTTP + Bearer token |
 
 **Connecting Gemini CLI:**
@@ -133,6 +133,25 @@ gemini mcp add patchwork http://127.0.0.1:<port>/mcp \
 ```
 
 The bridge auto-responds to the GET probe Gemini sends before initializing, so it shows as **Connected** immediately.
+
+**Connecting Grok Build (Grok CLI):**
+
+Grok Build connects over the same **stdio shim** as Claude Desktop. Add this block to `~/.grok/config.toml` (the `--workspace` arg is the important part):
+
+```toml
+[mcp_servers.patchwork]
+command = "claude-ide-bridge"
+args = ["shim", "--workspace", "/absolute/path/to/your/project"]
+enabled = true
+```
+
+Three gotchas that look like bugs but aren't:
+
+- **`--workspace` is required.** Without it the shim picks the newest bridge lock across *all* workspaces — in a multi-bridge setup (orchestrator, leftover dev bridges) that can be the wrong or a dead bridge, so tools act on the wrong project or hang. Always pin it to your project path.
+- **`grok mcp doctor` hangs — don't use it.** The shim is a long-lived relay that stays open for the session, so `doctor` waits forever for it to exit. Verify with the in-TUI **`/mcps`** instead, or run `claude-ide-bridge shim --ping` (one-shot: connects, lists tools, exits).
+- **The approval gate can park tool calls.** If `~/.patchwork/config.json` has `"approvalGate": "all"` (or `"high"`), tool calls queue for human approval in the dashboard and look like they're hanging to Grok. Set it to `"high"` (gate only risky writes) or `"off"`, or approve in the dashboard at `localhost:3000`.
+
+Grok Build can also connect over Streamable HTTP + Bearer (same as Gemini, above) if you'd rather not use the shim.
 
 **Tool modes:**
 

--- a/documents/platform-docs.md
+++ b/documents/platform-docs.md
@@ -860,6 +860,8 @@ The `--driver` flag selects the provider backend for subprocess orchestration ta
 
 **Subscription vs API key:** `subprocess` and `gemini` drivers spawn the provider's CLI, which handles OAuth/subscription auth locally. No API key required if you have an active subscription. `api`, `openai`, and `grok` always require an API key.
 
+> **`grok` here is the *outbound* path** — the bridge calling xAI's API to run recipe/agent steps. It is **not** how Grok Build (the Grok CLI) connects *to* the bridge as an MCP client to use the IDE tools. For that inbound setup (stdio shim, the mandatory `--workspace`, and the `grok mcp doctor`/approval-gate gotchas) see **[Connecting Grok Build](../README.md#transport-layers)** in the README.
+
 **Default model per driver:**
 
 | Driver | Default model |

--- a/scripts/mcp-stdio-shim.cjs
+++ b/scripts/mcp-stdio-shim.cjs
@@ -30,6 +30,27 @@ const { randomUUID } = require("node:crypto");
 // Resolve ws from the bridge's own node_modules (script lives in scripts/)
 const { WebSocket } = require(path.join(__dirname, "..", "node_modules", "ws"));
 
+// process.kill(pid, 0) probes liveness without delivering a signal: it throws
+// ESRCH when the process is gone and EPERM when it exists but isn't ours (still
+// alive). A stale lock whose bridge has exited would otherwise be "selected"
+// (newest mtime within its tier) and every connect would hang on a refused port
+// until backoff gives up — the multi-bridge footgun. Mirrors the shared
+// src/bridgeLockDiscovery.ts isLive() check.
+function isAlive(pid) {
+  if (typeof pid !== "number" || !Number.isFinite(pid)) return true; // unknown pid → don't exclude
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return err.code === "EPERM";
+  }
+}
+
+// Remembers the last lock we logged a selection for, so the diagnostic below
+// fires once at startup (and again only when the selection actually changes)
+// rather than on every poll tick.
+let lastSelectedLockPath = null;
+
 function findLockFile() {
   const lockDir = path.join(
     process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), ".claude"),
@@ -38,49 +59,40 @@ function findLockFile() {
   // Three-tier preference: orchestrator > bridge > any lock (each by newest mtime).
   // Orchestrator locks win because child bridge restarts produce newer lock files,
   // which would hijack the shim away from the orchestrator if we only used mtime.
-  let orchestratorLock = null;
-  let orchestratorMtime = 0;
-  let bridgeLock = null;
-  let bridgeMtime = 0;
-  let fallbackLock = null;
-  let fallbackMtime = 0;
+  const orchestrator = { path: null, mtime: 0, data: null };
+  const bridge = { path: null, mtime: 0, data: null };
+  const fallback = { path: null, mtime: 0, data: null };
   try {
     for (const f of fs.readdirSync(lockDir)) {
       if (!f.endsWith(".lock")) continue;
       const fullPath = path.join(lockDir, f);
       try {
         const stat = fs.statSync(fullPath);
-        let isBridge = false;
-        let isOrchestrator = false;
+        let data = null;
         try {
-          const data = JSON.parse(fs.readFileSync(fullPath, "utf8"));
-          isBridge = data.isBridge === true;
-          isOrchestrator = data.orchestrator === true;
-          // Skip locks that don't match the requested workspace
-          if (
-            workspaceFilter &&
-            data.workspace &&
-            data.workspace !== workspaceFilter
-          )
-            continue;
+          data = JSON.parse(fs.readFileSync(fullPath, "utf8"));
         } catch {
-          // unparseable — treat as non-bridge
+          // unparseable — treated as a fallback lock with no metadata
         }
-        if (isOrchestrator) {
-          if (stat.mtimeMs > orchestratorMtime) {
-            orchestratorMtime = stat.mtimeMs;
-            orchestratorLock = fullPath;
-          }
-        } else if (isBridge) {
-          if (stat.mtimeMs > bridgeMtime) {
-            bridgeMtime = stat.mtimeMs;
-            bridgeLock = fullPath;
-          }
-        } else {
-          if (stat.mtimeMs > fallbackMtime) {
-            fallbackMtime = stat.mtimeMs;
-            fallbackLock = fullPath;
-          }
+        // Skip locks whose owning bridge process has exited. Without this a
+        // wedged/stale lock can be picked and the connection hangs.
+        if (data && !isAlive(data.pid)) continue;
+        // When a workspace filter is set, require an EXACT workspace match — a
+        // lock with a missing/blank workspace field must not be picked under the
+        // filter (otherwise the shim can latch onto an unrelated bridge).
+        if (workspaceFilter && (!data || data.workspace !== workspaceFilter))
+          continue;
+        const isBridge = data ? data.isBridge === true : false;
+        const isOrchestrator = data ? data.orchestrator === true : false;
+        const tier = isOrchestrator
+          ? orchestrator
+          : isBridge
+            ? bridge
+            : fallback;
+        if (stat.mtimeMs > tier.mtime) {
+          tier.mtime = stat.mtimeMs;
+          tier.path = fullPath;
+          tier.data = data;
         }
       } catch {
         // skip unreadable files
@@ -90,7 +102,25 @@ function findLockFile() {
     // lock dir doesn't exist
   }
   // Prefer orchestrator > bridge > fallback (each newest mtime within tier)
-  return orchestratorLock ?? bridgeLock ?? fallbackLock;
+  const chosen = orchestrator.path
+    ? orchestrator
+    : bridge.path
+      ? bridge
+      : fallback.path
+        ? fallback
+        : null;
+  // One-line stderr diagnostic so operators can see which bridge/workspace the
+  // shim latched onto — silent wrong-bridge selection was a real footgun. stderr
+  // is not the JSON-RPC stream, so this never corrupts protocol traffic.
+  if (chosen && chosen.path !== lastSelectedLockPath) {
+    lastSelectedLockPath = chosen.path;
+    const wsName = chosen.data?.workspace || "(unknown workspace)";
+    const pid = chosen.data?.pid || "?";
+    process.stderr.write(
+      `mcp-stdio-shim: selected ${path.basename(chosen.path)} (workspace=${wsName}, pid=${pid})\n`,
+    );
+  }
+  return chosen ? chosen.path : null;
 }
 
 function parseLock(lockPath) {
@@ -199,11 +229,16 @@ function scheduleBackoffReconnect(errorType) {
 // Parse named flags first so they don't pollute positional port/token detection.
 const args = process.argv.slice(2);
 let workspaceFilter = null;
+let pingMode = false;
 for (let i = 0; i < args.length; i++) {
-  if (args[i] === "--workspace" && args[i + 1]) {
+  if (args[i] === "--ping" || args[i] === "--probe") {
+    pingMode = true;
+    args.splice(i, 1);
+    i--;
+  } else if (args[i] === "--workspace" && args[i + 1] !== undefined) {
     workspaceFilter = args[i + 1];
     args.splice(i, 2);
-    break;
+    i--;
   }
 }
 const explicitPort = args[0] && args[1] ? Number(args[0]) : null;
@@ -369,8 +404,104 @@ function startPoll() {
   }, POLL_INTERVAL_MS);
 }
 
-// --- Initial connection ---
-if (explicitPort !== null) {
+// --- Ping mode: one-shot probe, then exit ---
+// `grok mcp doctor` (and similar stdio MCP verifiers) hang on this shim because
+// it is a long-lived relay that only exits on stdin EOF. `--ping` / `--probe`
+// gives those tools a clean check: connect, run initialize + tools/list, print a
+// one-line summary, and exit. It skips the relay, lock watcher, and reconnect
+// loops entirely.
+if (pingMode) {
+  let pingPort = explicitPort;
+  let pingToken = explicitToken;
+  if (pingPort === null) {
+    const lockFile = findLockFile();
+    if (!lockFile) {
+      process.stderr.write("mcp-stdio-shim: --ping: no bridge lock found.\n");
+      process.exit(1);
+    }
+    try {
+      const parsed = parseLock(lockFile);
+      pingPort = parsed.port;
+      pingToken = parsed.authToken;
+    } catch (err) {
+      process.stderr.write(
+        `mcp-stdio-shim: --ping: lock unreadable (${err.message}).\n`,
+      );
+      process.exit(1);
+    }
+  }
+  let pingDone = false;
+  const pingWs = new WebSocket(`ws://127.0.0.1:${pingPort}`, {
+    headers: {
+      "x-claude-code-ide-authorization": pingToken,
+      "x-claude-code-session-id": CLIENT_SESSION_ID,
+    },
+  });
+  const failPing = (msg) => {
+    if (pingDone) return;
+    pingDone = true;
+    process.stderr.write(`mcp-stdio-shim: --ping: ${msg}\n`);
+    try {
+      pingWs.terminate();
+    } catch {
+      /* ignore */
+    }
+    process.exit(1);
+  };
+  const pingTimer = setTimeout(
+    () => failPing(`timed out after 5s (port ${pingPort})`),
+    5000,
+  );
+  pingWs.on("open", () => {
+    pingWs.send(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {
+          protocolVersion: "2025-06-18",
+          capabilities: {},
+          clientInfo: { name: "shim-ping", version: "1" },
+        },
+      }),
+    );
+  });
+  pingWs.on("message", (raw) => {
+    let msg;
+    try {
+      msg = JSON.parse(raw.toString());
+    } catch {
+      return;
+    }
+    if (msg.id === 1) {
+      pingWs.send(
+        JSON.stringify({ jsonrpc: "2.0", method: "notifications/initialized" }),
+      );
+      pingWs.send(
+        JSON.stringify({ jsonrpc: "2.0", id: 2, method: "tools/list" }),
+      );
+    } else if (msg.id === 2) {
+      clearTimeout(pingTimer);
+      pingDone = true;
+      const n =
+        msg.result && Array.isArray(msg.result.tools)
+          ? msg.result.tools.length
+          : "?";
+      process.stdout.write(`bridge OK — port ${pingPort}, ${n} tools\n`);
+      try {
+        pingWs.close();
+      } catch {
+        /* ignore */
+      }
+      process.exit(0);
+    }
+  });
+  pingWs.on("error", (err) => failPing(`connect failed (${err.message})`));
+  pingWs.on("close", (code) =>
+    failPing(`closed before tools/list (code ${code})`),
+  );
+} else if (explicitPort !== null) {
+  // --- Initial connection ---
   connect(explicitPort, explicitToken);
 } else {
   const lockFile = findLockFile();
@@ -398,7 +529,7 @@ if (explicitPort !== null) {
 // Watches ~/.claude/ide/ for .lock file changes. When a new bridge lock appears
 // on a different port, reconnects automatically. This means Claude Desktop never
 // needs to be restarted when the bridge restarts on a new port.
-if (explicitPort === null) {
+if (!pingMode && explicitPort === null) {
   const lockDir = path.join(
     process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), ".claude"),
     "ide",
@@ -439,52 +570,38 @@ if (explicitPort === null) {
 
 // --- stdin → bridge (newline-delimited JSON-RPC) ---
 // Messages that arrive before the WebSocket is open are queued and flushed on connect.
-process.stdin.setEncoding("utf8");
-process.stdin.on("data", (chunk) => {
-  buffer += chunk;
-  const lines = buffer.split("\n");
-  buffer = lines.pop() ?? "";
-  for (const line of lines) {
-    const trimmed = line.trim();
-    if (!trimmed) continue;
-    if (ws && ws.readyState === WebSocket.OPEN) {
-      try {
-        ws.send(trimmed);
-      } catch (sendErr) {
-        process.stderr.write(
-          `mcp-stdio-shim: ws.send failed (${sendErr.message}) — queuing message.\n`,
-        );
-        if (pendingLines.length < MAX_PENDING_LINES) {
-          pendingLines.push(trimmed);
+// Skipped in --ping mode — the one-shot probe manages its own lifecycle and exits.
+if (!pingMode) {
+  process.stdin.setEncoding("utf8");
+  process.stdin.on("data", (chunk) => {
+    buffer += chunk;
+    const lines = buffer.split("\n");
+    buffer = lines.pop() ?? "";
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      if (ws && ws.readyState === WebSocket.OPEN) {
+        try {
+          ws.send(trimmed);
+        } catch (sendErr) {
+          process.stderr.write(
+            `mcp-stdio-shim: ws.send failed (${sendErr.message}) — queuing message.\n`,
+          );
+          if (pendingLines.length < MAX_PENDING_LINES) {
+            pendingLines.push(trimmed);
+          }
         }
+      } else if (pendingLines.length < MAX_PENDING_LINES) {
+        pendingLines.push(trimmed);
+      } else {
+        process.stderr.write(
+          `mcp-stdio-shim: pendingLines overflow (${MAX_PENDING_LINES}) — dropping message (bridge not connected)\n`,
+        );
       }
-    } else if (pendingLines.length < MAX_PENDING_LINES) {
-      pendingLines.push(trimmed);
-    } else {
-      process.stderr.write(
-        `mcp-stdio-shim: pendingLines overflow (${MAX_PENDING_LINES}) — dropping message (bridge not connected)\n`,
-      );
     }
-  }
-});
+  });
 
-process.stdin.on("end", () => {
-  if (ws) {
-    try {
-      ws.close();
-    } catch {
-      /* ignore */
-    }
-  }
-  process.exit(0);
-});
-
-process.stdin.on("error", (err) => {
-  // EPIPE / ERR_STREAM_DESTROYED means the MCP host closed the pipe — clean shutdown.
-  if (err.code === "EPIPE" || err.code === "ERR_STREAM_DESTROYED") {
-    process.stderr.write(
-      `mcp-stdio-shim: stdin closed (${err.code}) — shutting down.\n`,
-    );
+  process.stdin.on("end", () => {
     if (ws) {
       try {
         ws.close();
@@ -493,6 +610,23 @@ process.stdin.on("error", (err) => {
       }
     }
     process.exit(0);
-  }
-  process.stderr.write(`mcp-stdio-shim: stdin error: ${err.message}\n`);
-});
+  });
+
+  process.stdin.on("error", (err) => {
+    // EPIPE / ERR_STREAM_DESTROYED means the MCP host closed the pipe — clean shutdown.
+    if (err.code === "EPIPE" || err.code === "ERR_STREAM_DESTROYED") {
+      process.stderr.write(
+        `mcp-stdio-shim: stdin closed (${err.code}) — shutting down.\n`,
+      );
+      if (ws) {
+        try {
+          ws.close();
+        } catch {
+          /* ignore */
+        }
+      }
+      process.exit(0);
+    }
+    process.stderr.write(`mcp-stdio-shim: stdin error: ${err.message}\n`);
+  });
+}

--- a/src/__tests__/shim-ping.test.ts
+++ b/src/__tests__/shim-ping.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Tests for two mcp-stdio-shim.cjs hardening features:
+ *   1. `--ping` one-shot probe — connects, does initialize + tools/list, prints a
+ *      summary, and exits. Gives `grok mcp doctor`-style verifiers a clean exit
+ *      instead of hanging on the persistent relay.
+ *   2. Lock liveness — findLockFile skips locks whose owning bridge process has
+ *      exited, so a stale/wedged lock can't be "selected" and hang the connect.
+ */
+
+import { type ChildProcess, spawn, spawnSync } from "node:child_process";
+import fs from "node:fs";
+import type { AddressInfo } from "node:net";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { WebSocketServer } from "ws";
+
+const SHIM_PATH = path.join(
+  import.meta.dirname,
+  "..",
+  "..",
+  "scripts",
+  "mcp-stdio-shim.cjs",
+);
+
+function writeBridgeLock(
+  lockDir: string,
+  port: number,
+  token: string,
+  pid: number = process.pid,
+): void {
+  fs.writeFileSync(
+    path.join(lockDir, `${port}.lock`),
+    JSON.stringify({ pid, authToken: token, isBridge: true, workspace: "/p" }),
+    { mode: 0o600 },
+  );
+}
+
+/** A pid guaranteed dead: spawn a no-op node child, which has exited by the time
+ *  spawnSync returns, then reuse its (now-free) pid. */
+function deadPid(): number {
+  const r = spawnSync(process.execPath, ["-e", ""], { stdio: "ignore" });
+  return r.pid as number;
+}
+
+/** Mock bridge that speaks just enough MCP for --ping: validates the auth header
+ *  and answers initialize (id 1) + tools/list (id 2). Binds an ephemeral port. */
+async function startMcpBridge(
+  token: string,
+  toolCount = 3,
+): Promise<{ wss: WebSocketServer; port: number }> {
+  const wss = new WebSocketServer({ port: 0, host: "127.0.0.1" });
+  await new Promise<void>((res) => wss.once("listening", () => res()));
+  wss.on("connection", (ws, req) => {
+    if (req.headers["x-claude-code-ide-authorization"] !== token) {
+      ws.close(4001, "Unauthorized");
+      return;
+    }
+    ws.on("message", (raw) => {
+      let m: { id?: number };
+      try {
+        m = JSON.parse(raw.toString());
+      } catch {
+        return;
+      }
+      if (m.id === 1) {
+        ws.send(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            result: { protocolVersion: "2025-06-18", capabilities: {} },
+          }),
+        );
+      } else if (m.id === 2) {
+        ws.send(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            id: 2,
+            result: {
+              tools: Array.from({ length: toolCount }, (_v, i) => ({
+                name: `t${i}`,
+              })),
+            },
+          }),
+        );
+      }
+    });
+  });
+  return { wss, port: (wss.address() as AddressInfo).port };
+}
+
+async function closeServer(wss: WebSocketServer): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    wss.close((err) => (err ? reject(err) : resolve()));
+    for (const client of wss.clients) client.terminate();
+  });
+}
+
+async function waitFor(
+  fn: () => boolean,
+  timeoutMs: number,
+  intervalMs = 50,
+): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (fn()) return true;
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+  return false;
+}
+
+let tmpDir: string;
+let proc: ChildProcess | null = null;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "shim-ping-"));
+  fs.mkdirSync(path.join(tmpDir, "ide"), { mode: 0o700 });
+});
+
+afterEach(async () => {
+  proc?.kill();
+  proc = null;
+  await new Promise((r) => setTimeout(r, 100));
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function spawnShim(args: string[]): ChildProcess {
+  const p = spawn(process.execPath, [SHIM_PATH, ...args], {
+    env: { ...process.env, CLAUDE_CONFIG_DIR: tmpDir },
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+  proc = p;
+  return p;
+}
+
+function collect(p: ChildProcess): { out: () => string; err: () => string } {
+  const outC: string[] = [];
+  const errC: string[] = [];
+  p.stdout?.setEncoding("utf8");
+  p.stdout?.on("data", (d: string) => outC.push(d));
+  p.stderr?.setEncoding("utf8");
+  p.stderr?.on("data", (d: string) => errC.push(d));
+  return { out: () => outC.join(""), err: () => errC.join("") };
+}
+
+describe("shim --ping (one-shot probe)", () => {
+  it("connects, lists tools, prints a summary, and exits 0", async () => {
+    const token = "ping-token";
+    const { wss, port } = await startMcpBridge(token, 2);
+    writeBridgeLock(path.join(tmpDir, "ide"), port, token);
+
+    const p = spawnShim(["--ping"]);
+    const io = collect(p);
+    const code = await new Promise<number | null>((res) => p.on("exit", res));
+
+    expect(code).toBe(0);
+    expect(io.out()).toMatch(/bridge OK/);
+    expect(io.out()).toMatch(/2 tools/);
+    await closeServer(wss);
+  });
+
+  it("exits non-zero when no bridge lock is present", async () => {
+    const p = spawnShim(["--ping"]);
+    const io = collect(p);
+    const code = await new Promise<number | null>((res) => p.on("exit", res));
+
+    expect(code).toBe(1);
+    expect(io.err()).toMatch(/no bridge lock/i);
+  });
+});
+
+describe("shim lock liveness", () => {
+  it("ignores a lock whose bridge process is dead (treats as no live bridge)", async () => {
+    writeBridgeLock(path.join(tmpDir, "ide"), 19990, "dead", deadPid());
+
+    const p = spawnShim([]);
+    const io = collect(p);
+
+    const waited = await waitFor(
+      () => io.err().includes("No bridge lock file found"),
+      2500,
+    );
+    expect(waited).toBe(true);
+    // It must never have tried to connect to the dead bridge's port.
+    expect(io.err()).not.toMatch(/Connecting to bridge/);
+  });
+
+  it("connects to the live bridge even when a dead lock has a newer mtime", async () => {
+    const ideDir = path.join(tmpDir, "ide");
+    const token = "live-tok";
+    const { wss, port } = await startMcpBridge(token);
+
+    writeBridgeLock(ideDir, port, token); // live (pid = this process)
+    await new Promise((r) => setTimeout(r, 40));
+    // Written later → newer mtime → would win the tier on mtime alone.
+    writeBridgeLock(ideDir, 19991, "dead", deadPid());
+
+    const p = spawnShim([]);
+    const io = collect(p);
+
+    const connected = await waitFor(() => io.err().includes("Connected"), 3000);
+    expect(connected).toBe(true);
+    expect(io.err()).toContain(`ws://127.0.0.1:${port}`);
+    expect(io.err()).not.toMatch(/19991/); // never tried the dead newer lock
+    await closeServer(wss);
+  });
+});

--- a/src/adapters/grok.ts
+++ b/src/adapters/grok.ts
@@ -7,7 +7,12 @@ import { OpenAIAdapter } from "./openai.js";
  */
 
 const API_URL = "https://api.x.ai/v1/chat/completions";
-const DEFAULT_MODEL = "grok-beta";
+// Keep in sync with the driver path (src/drivers/grok/index.ts), which already
+// defaults to grok-2-latest. grok-beta is a legacy alias; defaulting the two
+// Grok entry points to different models meant the effective model depended on
+// which path ran. grok-2-latest is a stable alias — verify the current model
+// at console.x.ai before bumping further (e.g. to grok-4.x).
+const DEFAULT_MODEL = "grok-2-latest";
 
 export function createGrokAdapter(opts: {
   apiKey?: string;

--- a/src/mcpRoutes.ts
+++ b/src/mcpRoutes.ts
@@ -53,7 +53,7 @@ export function tryHandleMcpRoute(
       name: "claude-ide-bridge",
       version: BRIDGE_PROTOCOL_VERSION,
       description:
-        "MCP bridge providing full IDE integration for Claude Code — LSP, diagnostics, file operations, terminal, debug adapters, and AI task orchestration",
+        "MCP bridge providing full IDE integration for AI coding assistants — LSP, diagnostics, file operations, terminal, debug adapters, and AI task orchestration",
       homepage: "https://github.com/Oolab-labs/claude-ide-bridge",
       transport: ["websocket", "stdio", "streamable-http"],
       capabilities: {


### PR DESCRIPTION
## What
Makes the **Grok CLI (Grok Build)** a first-class MCP client of the bridge and fixes the runtime footguns that make tools act on the wrong project or hang. Scoped from a verified 13-agent audit of the integration (the runtime gotchas here were lived through during a long debugging session).

## Onboarding (zero-risk)
- **`adapters/grok.ts`**: default model `grok-beta` → `grok-2-latest` (matches the driver path; `grok-beta` is a legacy alias). The two Grok entry points defaulting to different models meant the effective model depended on which path ran.
- **Server-card description** neutralized (`mcpRoutes.ts`): "for Claude Code" → "for AI coding assistants" — it's shown verbatim in any client's MCP discovery UI.
- **README** transport table + a **"Connecting Grok Build"** section with the three real gotchas (`grok mcp doctor` hangs → use `/mcps` or `--ping`; `approvalGate` parks tool calls; `--workspace` mandatory in multi-bridge setups); **platform-docs** cross-ref distinguishing the outbound `grok` driver from inbound MCP-client setup.

## Shim hardening (`scripts/mcp-stdio-shim.cjs`)
- **Liveness**: `findLockFile` skips locks whose owning bridge process has exited (`process.kill(pid,0)`, mirroring `bridgeLockDiscovery.ts`). A wedged/stale lock could previously be "selected" (newest mtime in its tier) and every connect would hang on a refused port until backoff gave up.
- **Tighter `--workspace` filter**: with a filter set, require an exact workspace match — a lock with a missing workspace field is no longer eligible.
- **Selection diagnostic** to stderr (chosen lock basename / workspace / pid), once at startup and again only when it changes — silent wrong-bridge selection was invisible before.
- **`--ping` / `--probe` one-shot**: connect → `initialize` + `tools/list` → print `bridge OK — port P, N tools` → exit. Gives `grok mcp doctor` and similar verifiers a clean exit instead of hanging on the persistent relay.

## Tests / gates
- New `src/__tests__/shim-ping.test.ts` (`--ping` success/no-lock + dead-lock liveness skip). All existing shim tests pass.
- Full suite green · `tsc -p tsconfig.tests.core.json` clean · biome clean · fixture-hygiene audit clean.

## Notes for review
- Model IDs intentionally **not** hardcoded to a `grok-4.x` value — that needs a live console.x.ai check (noted in a code comment). Aligning to the existing `grok-2-latest` alias is the safe, drift-killing change.
- **Deferred** (separate, each needs a decision): approval-gate visibility (opt-in bypass header / progress-notification signalling) and a `patchwork mcp-config grok` helper. The audit also confirmed a Grok *subprocess* driver is not worth it (no cost benefit over the API path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)