### PR TITLE
feat(init): detect Grok Build (Grok CLI) + surface MCP-client onboarding

### DIFF
--- a/src/commands/__tests__/patchworkInit-detect.test.ts
+++ b/src/commands/__tests__/patchworkInit-detect.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Unit tests for detectGrokCli — the Grok Build (Grok CLI) detection used by
+ * `patchwork init`. Probes `grok --version`, then falls back to the path the
+ * official installer symlinks (~/.grok/bin/grok) when the binary isn't on PATH.
+ */
+
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("node:child_process", async (orig) => ({
+  ...(await orig<typeof import("node:child_process")>()),
+  spawnSync: vi.fn(),
+}));
+
+import { detectGrokCli } from "../patchworkInit.js";
+
+const mockSpawn = vi.mocked(spawnSync);
+
+let home: string;
+
+beforeEach(() => {
+  home = fs.mkdtempSync(path.join(os.tmpdir(), "grok-detect-"));
+  mockSpawn.mockReset();
+});
+
+afterEach(() => {
+  fs.rmSync(home, { recursive: true, force: true });
+});
+
+describe("detectGrokCli", () => {
+  it("returns true when `grok --version` exits 0", () => {
+    mockSpawn.mockReturnValue({ status: 0 } as never);
+    expect(detectGrokCli(home)).toBe(true);
+  });
+
+  it("falls back to ~/.grok/bin/grok when the binary isn't on PATH", () => {
+    mockSpawn.mockReturnValue({ status: 1 } as never);
+    fs.mkdirSync(path.join(home, ".grok", "bin"), { recursive: true });
+    fs.writeFileSync(path.join(home, ".grok", "bin", "grok"), "");
+    expect(detectGrokCli(home)).toBe(true);
+  });
+
+  it("returns false when neither the binary nor ~/.grok/bin/grok is present", () => {
+    mockSpawn.mockReturnValue({ status: 1 } as never);
+    expect(detectGrokCli(home)).toBe(false);
+  });
+
+  it("returns false (does not throw) when spawnSync throws", () => {
+    mockSpawn.mockImplementation(() => {
+      throw new Error("ENOENT");
+    });
+    expect(detectGrokCli(home)).toBe(false);
+  });
+});

--- a/src/commands/patchworkInit.ts
+++ b/src/commands/patchworkInit.ts
@@ -157,6 +157,26 @@ function detectGeminiCli(): boolean {
   }
 }
 
+/**
+ * Detect Grok Build (the Grok CLI). Probes `grok --version`; if the binary
+ * isn't on PATH (e.g. a fresh install whose shell PATH hasn't been reloaded yet)
+ * it falls back to the path the official installer symlinks. Exported for tests.
+ */
+export function detectGrokCli(home: string): boolean {
+  try {
+    // grok is `.cmd` on Windows when installed via npm — without ensureCmdShim
+    // this silently returns false on Windows (mirrors the detectGeminiCli note).
+    const r = spawnSync(ensureCmdShim("grok"), ["--version"], {
+      stdio: "pipe",
+      timeout: 3000,
+    });
+    if (r.status === 0) return true;
+  } catch {
+    // not on PATH — fall through to the filesystem check
+  }
+  return existsSync(join(home, ".grok", "bin", "grok"));
+}
+
 async function detectOllama(timeoutMs = 500): Promise<boolean> {
   try {
     const controller = new AbortController();
@@ -178,6 +198,7 @@ interface InitResult {
   recipesSkipped: number;
   ollamaDetected: boolean;
   geminiCliDetected: boolean;
+  grokCliDetected: boolean;
   configAction: "created" | "merged" | "overwritten";
   /**
    * State of the Claude Code PreToolUse hook after init ran.
@@ -254,6 +275,13 @@ export async function runPatchworkInit(
     geminiCliDetected
       ? `  ✓ Gemini CLI detected — driver will default to gemini\n`
       : `  · Gemini CLI not detected (install from https://github.com/google-gemini/gemini-cli)\n`,
+  );
+
+  const grokCliDetected = detectGrokCli(home);
+  log(
+    grokCliDetected
+      ? `  ✓ Grok Build (Grok CLI) detected — to use the bridge's tools from it, add the stdio-shim block to ~/.grok/config.toml (see "Connecting Grok Build" in the README) and set approvalGate to "high"/"off" so calls don't queue for approval.\n`
+      : `  · Grok Build not detected (install from https://x.ai/cli)\n`,
   );
 
   let ollamaDetected = false;
@@ -358,6 +386,7 @@ Next:
     recipesSkipped,
     ollamaDetected,
     geminiCliDetected,
+    grokCliDetected,
     configAction,
     preToolUseHook,
   };


### PR DESCRIPTION
## What
`patchwork init` already greets Gemini CLI and Ollama but said nothing about **Grok Build** (the Grok CLI). This adds the missing detection — completing the "Grok is a first-class client" arc started in #896.

## Change
- **`detectGrokCli(home)`** — mirrors `detectGeminiCli`: probes `grok --version`, with a `~/.grok/bin/grok` fallback for fresh installs whose shell PATH hasn't been reloaded. Exported for tests.
- **`grokCliDetected`** added to `InitResult` and returned.
- **Onboarding line** printed when found: points at the "Connecting Grok Build" README setup and the `approvalGate` caveat (the #1 "looks hung" footgun).

## Deliberately scoped
- **No auto driver-default to `grok`** (unlike gemini). The grok driver is API-keyed (`XAI_API_KEY`); a keyless default would be broken. The value here is the *inbound* MCP-client onboarding hint, not an outbound driver switch.

## Tests / gates
- New `patchworkInit-detect.test.ts` (binary-present / `~/.grok` fallback / absent / spawn-throws).
- Full suite green (513 files) · `tsc` strict-tests clean · biome clean · fixture audit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)