### PR TITLE
feat(approval): signal pending-approval to agentic MCP clients (progress notification)

### DIFF
--- a/src/__tests__/approvalGate.e2e.test.ts
+++ b/src/__tests__/approvalGate.e2e.test.ts
@@ -90,17 +90,20 @@ function setup(): {
     },
   );
 
-  transport.setApprovalGate(async ({ toolName, params, sessionId }) => {
-    const tier = classifyTool(toolName);
-    if (tier !== "high") return "bypass";
-    const { promise } = queue.request({
-      toolName,
-      params,
-      tier,
-      sessionId: sessionId ?? undefined,
-    });
-    return promise;
-  });
+  transport.setApprovalGate(
+    async ({ toolName, params, sessionId, onPending }) => {
+      const tier = classifyTool(toolName);
+      if (tier !== "high") return "bypass";
+      const { promise, callId } = queue.request({
+        toolName,
+        params,
+        tier,
+        sessionId: sessionId ?? undefined,
+      });
+      onPending?.(callId);
+      return promise;
+    },
+  );
 
   const ws = new MockWs();
   transport.attach(ws as unknown as import("ws").WebSocket);
@@ -186,6 +189,39 @@ describe("approval gate E2E", () => {
     expect(result.isError).toBeFalsy();
     expect(result.content[0]!.text).toBe("committed");
     expect(handlerRan.value).toBe(true);
+  });
+
+  it("signals 'pending approval' via a progress notification when the client sent a progressToken", async () => {
+    const { queue, send, nextMatching } = setup();
+
+    send({
+      jsonrpc: "2.0",
+      id: 7,
+      method: "tools/call",
+      params: {
+        name: "gitCommit",
+        arguments: { message: "needs approval" },
+        _meta: { progressToken: "ptok-7" },
+      },
+    });
+
+    // The dispatcher should emit a progress notification the moment the call is
+    // parked — before any approve/reject — so the agent knows it isn't hung.
+    const progress = await nextMatching(
+      (m) => m.method === "notifications/progress",
+    );
+    const p = progress.params as {
+      progressToken: string | number;
+      message?: string;
+    };
+    expect(p.progressToken).toBe("ptok-7");
+    expect(p.message).toMatch(/awaiting human approval/i);
+
+    // Clean up: approve so the tool resolves and the request completes.
+    const pending = queue.list();
+    expect(pending).toHaveLength(1);
+    queue.approve(pending[0]!.callId);
+    await nextMatching((m) => m.id === 7);
   });
 
   it("reject: tool is blocked and reply carries isError:true", async () => {

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -348,21 +348,24 @@ export class Bridge {
         } catch {
           // Best-effort warning — never block startup on a hook check failure.
         }
-        transport.setApprovalGate(async ({ toolName, params, sessionId }) => {
-          const tier = classifyTool(toolName);
-          if (this.server.approvalGate === "off") return "bypass";
-          if (this.server.approvalGate !== "all" && tier !== "high")
-            return "bypass";
-          const queue = getApprovalQueue();
-          const { promise } = queue.request({
-            toolName,
-            params,
-            tier,
-            sessionId: sessionId ?? undefined,
-            riskSignals: [],
-          });
-          return promise;
-        });
+        transport.setApprovalGate(
+          async ({ toolName, params, sessionId, onPending }) => {
+            const tier = classifyTool(toolName);
+            if (this.server.approvalGate === "off") return "bypass";
+            if (this.server.approvalGate !== "all" && tier !== "high")
+              return "bypass";
+            const queue = getApprovalQueue();
+            const { promise, callId } = queue.request({
+              toolName,
+              params,
+              tier,
+              sessionId: sessionId ?? undefined,
+              riskSignals: [],
+            });
+            onPending?.(callId);
+            return promise;
+          },
+        );
       }
       transport.setExtensionConnectedFn(() =>
         this.extensionClient.isConnected(),

--- a/src/streamableHttp.ts
+++ b/src/streamableHttp.ts
@@ -830,19 +830,22 @@ export class StreamableHttpHandler {
     if (denyTools.size > 0) transport.setDenyTools(denyTools);
     if (this.config.approvalGate !== "off") {
       const gateAll = this.config.approvalGate === "all";
-      transport.setApprovalGate(async ({ toolName, params, sessionId }) => {
-        const tier = classifyTool(toolName);
-        if (!gateAll && tier !== "high") return "bypass";
-        const queue = getApprovalQueue();
-        const { promise } = queue.request({
-          toolName,
-          params,
-          tier,
-          sessionId: sessionId ?? undefined,
-          riskSignals: [],
-        });
-        return promise;
-      });
+      transport.setApprovalGate(
+        async ({ toolName, params, sessionId, onPending }) => {
+          const tier = classifyTool(toolName);
+          if (!gateAll && tier !== "high") return "bypass";
+          const queue = getApprovalQueue();
+          const { promise, callId } = queue.request({
+            toolName,
+            params,
+            tier,
+            sessionId: sessionId ?? undefined,
+            riskSignals: [],
+          });
+          onPending?.(callId);
+          return promise;
+        },
+      );
     }
 
     const terminalPrefix = `h${id.slice(0, 8)}-`; // "h" prefix distinguishes HTTP sessions

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -193,6 +193,9 @@ export class McpTransport {
         toolName: string;
         params: Record<string, unknown>;
         sessionId: string | null;
+        /** Called with the queue callId when (and only when) the call is parked
+         *  for human approval — lets the dispatcher signal "pending" to clients. */
+        onPending?: (callId: string) => void;
       }) => Promise<
         "approved" | "rejected" | "expired" | "cancelled" | "bypass"
       >)
@@ -203,6 +206,7 @@ export class McpTransport {
       toolName: string;
       params: Record<string, unknown>;
       sessionId: string | null;
+      onPending?: (callId: string) => void;
     }) => Promise<"approved" | "rejected" | "expired" | "cancelled" | "bypass">,
   ): void {
     this.approvalGate = fn;
@@ -1410,6 +1414,18 @@ export class McpTransport {
                     toolName: params.name,
                     params: toolArgs as Record<string, unknown>,
                     sessionId: this.sessionId,
+                    // When a call is parked for human approval, tell agentic
+                    // clients that sent a progressToken instead of letting the
+                    // request look hung. Purely additive — never changes the
+                    // gate's decision.
+                    onPending: progressFn
+                      ? (callId) =>
+                          progressFn(
+                            0,
+                            undefined,
+                            `Awaiting human approval in the Patchwork dashboard (callId ${callId}); expires in ~5 min.`,
+                          )
+                      : undefined,
                   });
                   if (
                     decision === "rejected" ||


### PR DESCRIPTION
## Problem
With `approvalGate: "high"`/`"all"`, a gated tool call blocks until a human approves in the dashboard (up to the ~5-min TTL). To an autonomous agent — e.g. **Grok Build via the stdio shim** — that is indistinguishable from a hung/broken tool: there was **no in-flight signal**. This is the recurring "tools aren't working" footgun for agentic clients.

## Change (purely additive — gate decision unchanged)
- Add an optional `onPending(callId)` to the approval-gate contract.
- `McpTransport` passes it **only when the client sent a `progressToken`**; the gate fires it the instant a call is parked; the dispatcher emits a `notifications/progress` — *"Awaiting human approval in the Patchwork dashboard (callId X); expires in ~5 min."*
- Wired at both gate sites: `bridge.ts` (WebSocket) and `streamableHttp.ts` (HTTP) — they share one `McpTransport`, so the dispatch hook is written once.

Nothing is emitted for clients without a `progressToken` or sessions with the gate off. This is the standards-compliant alternative to the JSON-RPC-violating "return `isError` early" approach the audit rejected (one response per id).

## Scope / follow-up
- **Only helps clients that send a `progressToken`** on tool calls. Whether **Grok Build** does is still to be confirmed empirically — this change is the natural way to find out (run a gated call from Grok; if a progress notification arrives, it does). If it doesn't, an **opt-in headless-bypass header** is the remaining lever — deliberately deferred as a separate **security/UX decision**.

## Tests / gates
- New progress-notification case in `approvalGate.e2e.test.ts` (parked call with a `progressToken` → `notifications/progress` with the token + message).
- Full suite green (512 files) · `tsc` strict-tests clean · biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)