### PR TITLE
fix(marketplace): default-deny install-confirm gate + browse diagnostics

### DIFF
--- a/dashboard/src/app/marketplace/[...slug]/InstallPanel.tsx
+++ b/dashboard/src/app/marketplace/[...slug]/InstallPanel.tsx
@@ -6,6 +6,7 @@ import { apiPath } from "@/lib/api";
 import {
   assertValidInstallSource,
   formatConnectorLabel,
+  requiresElevatedConfirm,
   type RiskLevel,
   shortName,
 } from "@/lib/registry";
@@ -64,25 +65,16 @@ export default function InstallPanel({
   // troubleshoot if the recipe never runs.
   const [missingConnectors, setMissingConnectors] = useState<string[]>([]);
 
-  // Marketplace trust Wave 0 (#782 follow-up): default-deny semantics.
-  //
-  // Previously the confirmation dialog ONLY appeared when one of
-  // {riskLevel >= medium, networkAccess === true, fileAccess === true}
-  // was set, which meant a registry author who forgot to flag a
-  // file-writing recipe gave users a silent one-tap install. The live
-  // marketplace registry has NO trust metadata on any recipe today
-  // (`risk_level`/`network_access`/`file_access` are absent), so every
-  // live install bypassed confirmation.
-  //
-  // New rule: only bypass confirmation if the recipe EXPLICITLY claims
-  // low risk AND explicitly disclaims network + file access. Anything
-  // missing those flags is treated as elevated — same as if the author
-  // explicitly marked it high-risk. Honest fail-closed.
-  const elevated = !(
-    riskLevel === "low" &&
-    networkAccess === false &&
-    fileAccess === false
-  );
+  // Marketplace trust Wave 0 (#782 follow-up): default-deny semantics,
+  // now shared with the browse view via requiresElevatedConfirm so there
+  // is exactly ONE definition of "needs confirmation". Only bypass the
+  // dialog when the recipe EXPLICITLY claims low risk AND disclaims
+  // network + file access; anything missing those flags fails closed.
+  const elevated = requiresElevatedConfirm({
+    risk_level: riskLevel,
+    network_access: networkAccess,
+    file_access: fileAccess,
+  });
 
   useEffect(() => {
     let cancelled = false;

--- a/dashboard/src/app/marketplace/page.tsx
+++ b/dashboard/src/app/marketplace/page.tsx
@@ -15,6 +15,7 @@ import {
   type RegistryBundle,
   type RegistryData,
   type RegistryRecipe,
+  requiresElevatedConfirm,
   type RiskLevel,
   shortName,
 } from "@/lib/registry";
@@ -172,6 +173,26 @@ const FALLBACK_REGISTRY: RegistryData = {
 
 // ------------------------------------------------------------------ constants
 
+// Format FALLBACK_REGISTRY.updated_at as a plain YYYY-MM-DD for the
+// registry-unreachable banner. Falls back to the raw value if it isn't a
+// parseable date so the banner never shows "Invalid Date".
+function fallbackSnapshotDate(): string {
+  const raw = FALLBACK_REGISTRY.updated_at;
+  const d = new Date(raw);
+  return Number.isNaN(d.getTime()) ? raw : d.toISOString().slice(0, 10);
+}
+
+// Map known bridge install-error `code`s to clearer, actionable copy.
+// Falls through to the raw `error` string for unrecognised codes.
+const INSTALL_ERROR_MESSAGES: Record<string, string> = {
+  not_allowlisted:
+    "This recipe's source repo isn't on the bridge's install allowlist. Add it via PATCHWORK_RECIPE_REPO_ALLOWLIST and restart the bridge.",
+  host_not_allowlisted:
+    "This recipe's install host isn't allowed. Add it via CLAUDE_IDE_BRIDGE_INSTALL_ALLOWED_HOSTS (default: github.com) and restart the bridge.",
+  bad_shape:
+    "The bridge rejected the install source as malformed. Expected `github:owner/repo[/path]@ref`.",
+};
+
 const PROVIDER_COLORS: Record<string, string> = {
   gmail: "#EA4335",
   slack: "#4A154B",
@@ -241,15 +262,13 @@ function RecipeCard({
 
   const isInstalled = installed || justInstalled;
 
-  // Risk-aware confirmation. Low-risk recipes install on a single click
-  // (preserves the existing one-click flow); medium/high or any recipe
-  // that requests network/file access opens a styled summary dialog so
-  // the operator sees what they're agreeing to before the bridge fetches it.
-  const elevated =
-    recipe.risk_level === "medium" ||
-    recipe.risk_level === "high" ||
-    recipe.network_access ||
-    recipe.file_access;
+  // Risk-aware confirmation (default-deny — see requiresElevatedConfirm).
+  // Only a recipe that EXPLICITLY claims low risk and disclaims network +
+  // file access installs on a single click; anything missing those flags
+  // (which is every live-registry recipe today) opens a styled summary
+  // dialog so the operator sees what they're agreeing to first. Shared
+  // with the detail-page InstallPanel via the same helper.
+  const elevated = requiresElevatedConfirm(recipe);
 
   async function runInstall() {
     setLoading(true);
@@ -665,10 +684,15 @@ export default function MarketplacePage() {
       } else {
         // Both bridge and GitHub failed — show the hardcoded fallback BUT
         // surface the failure so users know they're looking at stale,
-        // pre-seeded data rather than live registry contents.
+        // pre-seeded data rather than live registry contents. Include the
+        // FALLBACK_REGISTRY snapshot date so the staleness is concrete
+        // (a fixed ISO date the user can reason about) instead of a vague
+        // "built-in fallback".
         setRegistry(FALLBACK_REGISTRY.recipes);
         setBundles(registryBundles);
-        setLoadErr("registry unreachable — showing built-in fallback");
+        setLoadErr(
+          `registry unreachable — showing built-in fallback (snapshot ${fallbackSnapshotDate()})`,
+        );
       }
     }
 
@@ -729,6 +753,7 @@ export default function MarketplacePage() {
     let parsed: {
       ok?: boolean;
       error?: string;
+      code?: string;
       missingConnectors?: string[];
     } = {};
     try {
@@ -754,7 +779,13 @@ export default function MarketplacePage() {
           "Dashboard session expired. Log in and try again.",
         );
       }
-      throw new Error(parsed.error ?? `Error ${res.status}`);
+      // Bridge install errors carry a machine-readable `code` (see
+      // recipeRoutes install handler). Map the known ones to a clearer,
+      // actionable message before falling back to the raw `error` string
+      // — an operator who misconfigured the allowlist otherwise sees an
+      // opaque message with no hint about what to fix.
+      const coded = parsed.code ? INSTALL_ERROR_MESSAGES[parsed.code] : undefined;
+      throw new Error(coded ?? parsed.error ?? `Error ${res.status}`);
     }
 
     // Optimistic update so the card flips to "Installed" immediately.

--- a/dashboard/src/lib/__tests__/registry.test.ts
+++ b/dashboard/src/lib/__tests__/registry.test.ts
@@ -9,6 +9,7 @@ import {
   githubBlobUrlFor,
   type ParsedInstallSource,
   rawUrlFor,
+  requiresElevatedConfirm,
   shortName,
   summarizeRisk,
 } from "@/lib/registry";
@@ -399,6 +400,69 @@ describe("fetch* functions use the fallback", () => {
       vi.fn(async () => notOk()),
     );
     expect(await fetchBundleManifest(SRC)).toBeNull();
+  });
+});
+
+describe("requiresElevatedConfirm (default-deny trust gate)", () => {
+  // SECURITY: the all-undefined case is the live-registry case — no
+  // recipe in the GitHub index.json carries trust metadata today. It
+  // MUST require confirmation (return true) or every live install
+  // bypasses the dialog.
+  it("returns true when ALL trust fields are absent (the vulnerability case)", () => {
+    expect(requiresElevatedConfirm({})).toBe(true);
+  });
+
+  it("returns false ONLY when explicitly proven safe (low + no network + no file)", () => {
+    expect(
+      requiresElevatedConfirm({
+        risk_level: "low",
+        network_access: false,
+        file_access: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("returns true when risk_level is medium/high even with no access flags", () => {
+    expect(
+      requiresElevatedConfirm({
+        risk_level: "medium",
+        network_access: false,
+        file_access: false,
+      }),
+    ).toBe(true);
+    expect(
+      requiresElevatedConfirm({
+        risk_level: "high",
+        network_access: false,
+        file_access: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("returns true when network_access is true", () => {
+    expect(
+      requiresElevatedConfirm({
+        risk_level: "low",
+        network_access: true,
+        file_access: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("returns true when file_access is true", () => {
+    expect(
+      requiresElevatedConfirm({
+        risk_level: "low",
+        network_access: false,
+        file_access: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("returns true when risk_level is low but access flags are undefined (partial metadata)", () => {
+    // A registry author who set risk_level but forgot the access flags
+    // must still get a confirm — undefined is not a disclaimer.
+    expect(requiresElevatedConfirm({ risk_level: "low" })).toBe(true);
   });
 });
 

--- a/dashboard/src/lib/registry.ts
+++ b/dashboard/src/lib/registry.ts
@@ -27,6 +27,33 @@ export interface TrustMetadata {
   maintainer?: string;
 }
 
+/**
+ * Default-deny trust gate for the install-confirm dialog.
+ *
+ * Returns `false` (bypass the confirm dialog, allow one-click install)
+ * ONLY when the recipe is provably safe: it explicitly claims low risk
+ * AND explicitly disclaims both network and file access. Any missing /
+ * undefined field is treated as elevated → returns `true` (ask first).
+ *
+ * Rationale: the live marketplace registry carries NO trust metadata on
+ * any recipe today (`risk_level`/`network_access`/`file_access` are all
+ * absent). A permissive OR-chain over optional fields evaluates to
+ * "not elevated" for every live recipe, silently one-click-installing
+ * them. Failing closed on missing metadata is the safe default — a
+ * registry author who forgets to flag a file-writing recipe must not be
+ * able to grant users a silent install.
+ *
+ * Shared by the browse view (page.tsx) and the detail-page InstallPanel
+ * so there is exactly ONE definition of "needs confirmation".
+ */
+export function requiresElevatedConfirm(meta: TrustMetadata): boolean {
+  const provablySafe =
+    meta.risk_level === "low" &&
+    meta.network_access === false &&
+    meta.file_access === false;
+  return !provablySafe;
+}
+
 export interface RegistryRecipe extends TrustMetadata {
   name: string;
   version: string;


### PR DESCRIPTION
## Problem (security)

The marketplace browse view (`dashboard/src/app/marketplace/page.tsx`) computed its `elevated` install-confirm flag as a permissive OR-chain over four **optional** trust fields (`risk_level` / `network_access` / `file_access` / `approval_behavior`):

```ts
const elevated =
  recipe.risk_level === "medium" ||
  recipe.risk_level === "high" ||
  recipe.network_access ||
  recipe.file_access;
```

Every live registry recipe today carries **no** trust metadata (`risk_level`/`network_access`/`file_access` are all absent in `patchworkos/recipes@main/index.json`), so `elevated` evaluated falsy for all of them — the confirm dialog was skipped and the recipe **one-click-installed**. The detail-page `InstallPanel.tsx` already had the correct default-deny form; the browse view diverged.

## Change

- Added an exported pure helper `requiresElevatedConfirm(meta: TrustMetadata): boolean` to `dashboard/src/lib/registry.ts`. It returns `false` (bypass the dialog) **only** when the recipe is provably safe — `risk_level === 'low' && network_access === false && file_access === false`. Any missing/undefined field fails closed → returns `true` (ask first). Default-deny rationale documented inline.
- Wired the helper into **both** paths so there is exactly one definition of "needs confirmation": `page.tsx` (RecipeCard, browse view) and `InstallPanel.tsx` (replaces its inline equivalent — behavior unchanged, existing InstallPanel tests still pass).

### Secondary (grouped only because they share `page.tsx`)

- **Bridge error codes**: added `code?: string` to the parsed install-error type and an `INSTALL_ERROR_MESSAGES` map (`not_allowlisted` / `host_not_allowlisted` / `bad_shape` → clearer, actionable copy) consulted before the generic `parsed.error` fallback. An operator who misconfigures the allowlist now gets a diagnostic hint instead of an opaque string.
- **Fallback staleness date**: the registry-unreachable banner now surfaces `FALLBACK_REGISTRY.updated_at` as `(snapshot YYYY-MM-DD)` instead of a generic "built-in fallback" string.

## Testing

Bug Fix Protocol followed (red-first):

1. Added 7 `requiresElevatedConfirm` cases to `dashboard/src/lib/__tests__/registry.test.ts`, including `requiresElevatedConfirm({}) === true` (the security case proving the vulnerability is closed) and `requiresElevatedConfirm({risk_level:'low', network_access:false, file_access:false}) === false`.
2. Ran before implementing → `TypeError: requiresElevatedConfirm is not a function`, 6 failing.
3. Implemented the helper → 37/37 green.
4. Full sweep (registry + InstallPanel): 44/44 green; InstallPanel behavior unchanged.

`cd dashboard && npx tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)