### PR TITLE
fix(bridge): add AbortController timeout to /templates registry fetch

### DIFF
--- a/src/__tests__/recipeRoutes-templates-timeout.test.ts
+++ b/src/__tests__/recipeRoutes-templates-timeout.test.ts
@@ -1,0 +1,111 @@
+/**
+ * /templates — registry fetch must be abortable (RELIABILITY).
+ *
+ * The handler fetches the public template registry index.json from the
+ * GitHub CDN. Without an AbortController the request parks the handler
+ * indefinitely on a stalled connection — the negative-cache sentinel only
+ * fires on rejection, which a hung socket never produces. Every other
+ * fetch site in recipeRoutes.ts already wraps fetch in an AbortController
+ * timeout; this test pins the /templates fetch to the same idiom by
+ * asserting it passes an AbortSignal.
+ *
+ * Tests stub `globalThis.fetch` to fully control upstream + capture the
+ * call args; no real network IO. Pattern mirrors
+ * `recipeRoutes-bundle-install.test.ts`.
+ */
+
+import http from "node:http";
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import { Logger } from "../logger.js";
+import { Server } from "../server.js";
+
+const logger = new Logger(false);
+const TOKEN = "test-templates-timeout-token-000000000000";
+
+let server: Server | null = null;
+let port = 0;
+const originalFetch = globalThis.fetch;
+
+function makeRequest(
+  options: http.RequestOptions,
+  body = "",
+): Promise<{ status: number; body: string }> {
+  return new Promise((resolve, reject) => {
+    let resolved = false;
+    const finish = (status: number, data: string) => {
+      if (resolved) return;
+      resolved = true;
+      resolve({ status, body: data });
+    };
+    const req = http.request(
+      { hostname: "127.0.0.1", port, ...options },
+      (res) => {
+        let data = "";
+        res.on("data", (chunk: Buffer) => (data += chunk));
+        res.on("end", () => finish(res.statusCode ?? 0, data));
+        res.on("error", () => finish(res.statusCode ?? 0, data));
+        res.on("close", () => finish(res.statusCode ?? 0, data));
+      },
+    );
+    req.on("error", (err) => {
+      if (resolved) return;
+      reject(err);
+    });
+    if (body) req.write(body);
+    req.end();
+  });
+}
+
+beforeEach(async () => {
+  server = new Server(TOKEN, logger);
+  port = await server.findAndListen(null);
+});
+
+afterEach(async () => {
+  await server?.close();
+  server = null;
+  port = 0;
+  globalThis.fetch = originalFetch;
+});
+
+afterAll(() => {
+  globalThis.fetch = originalFetch;
+});
+
+const templatesPath = {
+  method: "GET" as const,
+  path: "/templates",
+  headers: {
+    Authorization: `Bearer ${TOKEN}`,
+  },
+};
+
+describe("Server /templates — registry fetch is abortable", () => {
+  it("passes an AbortSignal to fetch (timeout wiring)", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ recipes: [] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    globalThis.fetch = fetchMock;
+
+    const { status } = await makeRequest(templatesPath);
+    expect(status).toBe(200);
+
+    // The handler must wrap the upstream fetch in an AbortController so a
+    // stalled CDN connection can't park the request handler forever.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const init = fetchMock.mock.calls[0]?.[1] as RequestInit | undefined;
+    expect(init).toBeDefined();
+    expect(init?.signal).toBeInstanceOf(AbortSignal);
+  });
+});

--- a/src/recipeRoutes.ts
+++ b/src/recipeRoutes.ts
@@ -1594,9 +1594,22 @@ export function tryHandleRecipeRoute(
       try {
         const now = Date.now();
         if (templatesCache === null || now - templatesCacheTs > 5 * 60 * 1000) {
-          const ghRes = await fetch(
-            "https://raw.githubusercontent.com/patchworkos/recipes/main/index.json",
-          );
+          // Abort a stalled CDN connection — without this a hung socket
+          // parks the handler forever (the negative-cache sentinel only
+          // fires on rejection, which a hung connection never produces).
+          // Matches the AbortController idiom used by the other fetch
+          // sites in this file.
+          const ctl = new AbortController();
+          const timeout = setTimeout(() => ctl.abort(), 30_000);
+          let ghRes: Response;
+          try {
+            ghRes = await fetch(
+              "https://raw.githubusercontent.com/patchworkos/recipes/main/index.json",
+              { signal: ctl.signal },
+            );
+          } finally {
+            clearTimeout(timeout);
+          }
           if (!ghRes.ok) {
             throw new Error(`GitHub returned ${ghRes.status}`);
           }


### PR DESCRIPTION
## Problem

The bridge `/templates` route in `src/recipeRoutes.ts` fetched the public recipe registry `index.json` from the GitHub CDN with **no timeout**. On a stalled connection the request handler parks indefinitely: the negative-cache sentinel (`templatesCache = false`) only fires inside the `catch` block on a rejection, and a hung socket never rejects. Every dashboard client polling `/templates` would hang behind it.

## Change

Wrapped the upstream fetch in the same `AbortController` idiom already used by every other fetch site in this file (the `/recipes/install` bundle + yaml fetches):

```ts
const ctl = new AbortController();
const timeout = setTimeout(() => ctl.abort(), 30_000);
try {
  ghRes = await fetch(url, { signal: ctl.signal });
} finally {
  clearTimeout(timeout);
}
```

- Matched the existing `30_000` ms timeout value (every sibling site uses `30_000`; there is no 10s site in this file).
- `clearTimeout` is in a `finally` so the timer is always cleared even when fetch rejects; the surrounding `catch` then writes the 502 + sets the negative-cache sentinel as before.

## Testing

Added `src/__tests__/recipeRoutes-templates-timeout.test.ts` (test-first, red→green): spins up the real `Server`, stubs `globalThis.fetch`, hits `GET /templates`, and asserts fetch was invoked with an `init.signal` that is an `AbortSignal`.

- Red before fix: `expected undefined to be defined` (fetch called with no init arg).
- Green after fix.
- Neighboring suites (`recipeRoutes-bundle-install`, `recipeRoutes-install` — 25 tests) still pass.
- `biome check` clean; `tsc -p tsconfig.tests.core.json` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)