### PR TITLE
fix(dashboard): install-path robustness — content-type mirror, empty-token guard, bundle probe timeout

### DIFF
--- a/dashboard/src/app/api/bridge/recipes/doctor/route.ts
+++ b/dashboard/src/app/api/bridge/recipes/doctor/route.ts
@@ -19,10 +19,18 @@ export async function GET(req: NextRequest): Promise<Response> {
   const target = `/recipes/doctor?recipe=${encodeURIComponent(recipe)}`;
   try {
     const res = await bridgeFetch(target, { method: "GET" });
+    // Mirror the upstream content-type so a non-JSON body (e.g. a
+    // reverse-proxy HTML error page in remote mode) isn't mislabelled
+    // application/json. Same logic as the catch-all `[...path]` proxy.
+    const upstreamCt = res.headers.get("content-type") ?? "";
     const text = await res.text();
+    const ct =
+      upstreamCt.includes("application/json") || upstreamCt === ""
+        ? "application/json"
+        : upstreamCt;
     return new Response(text, {
       status: res.status,
-      headers: { "content-type": "application/json" },
+      headers: { "content-type": ct },
     });
   } catch (err) {
     console.error("[recipes/doctor] bridge fetch failed:", err);

--- a/dashboard/src/app/api/bridge/recipes/install/__tests__/route.test.ts
+++ b/dashboard/src/app/api/bridge/recipes/install/__tests__/route.test.ts
@@ -130,6 +130,44 @@ describe("POST /api/bridge/recipes/install — source validation", () => {
   });
 });
 
+describe("POST /api/bridge/recipes/install — content-type mirroring", () => {
+  it("mirrors an upstream text/html content-type instead of forcing JSON", async () => {
+    bridgeFetchMock.mockClear();
+    // Remote mode: a reverse proxy in front of the bridge returns an HTML
+    // error page. The proxy must NOT relabel it application/json — that
+    // makes the client silently fail to parse the (HTML) body.
+    bridgeFetchMock.mockResolvedValueOnce(
+      new Response("<html><body>502 Bad Gateway</body></html>", {
+        status: 502,
+        headers: { "content-type": "text/html; charset=utf-8" },
+      }),
+    );
+    const res = await POST(
+      makeReq(
+        JSON.stringify({
+          source: "github:patchworkos/recipes/recipes/morning-brief",
+        }),
+      ),
+    );
+    expect(res.status).toBe(502);
+    expect(res.headers.get("content-type")).toBe("text/html; charset=utf-8");
+    expect(await res.text()).toContain("502 Bad Gateway");
+  });
+
+  it("still labels a JSON upstream body application/json", async () => {
+    bridgeFetchMock.mockClear();
+    const res = await POST(
+      makeReq(
+        JSON.stringify({
+          source: "github:patchworkos/recipes/recipes/morning-brief",
+        }),
+      ),
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe("application/json");
+  });
+});
+
 describe("POST /api/bridge/recipes/install — CSRF gate", () => {
   it("rejects cross-site POST with 403", async () => {
     const req = new Request("https://dashboard.local/api/bridge/recipes/install", {

--- a/dashboard/src/app/api/bridge/recipes/install/route.ts
+++ b/dashboard/src/app/api/bridge/recipes/install/route.ts
@@ -70,10 +70,19 @@ export async function POST(req: Request): Promise<Response> {
       headers: { "content-type": "application/json" },
       body: read.body,
     });
+    // Mirror the upstream content-type so a non-JSON body (e.g. a
+    // reverse-proxy HTML error page in remote mode) isn't mislabelled
+    // application/json — that makes the client silently fail to parse it.
+    // Same logic as the catch-all `[...path]` proxy.
+    const upstreamCt = res.headers.get("content-type") ?? "";
     const text = await res.text();
+    const ct =
+      upstreamCt.includes("application/json") || upstreamCt === ""
+        ? "application/json"
+        : upstreamCt;
     return new Response(text, {
       status: res.status,
-      headers: { "content-type": "application/json" },
+      headers: { "content-type": ct },
     });
   } catch (err) {
     // #600: don't leak err.message detail; see [name]/route.ts.

--- a/dashboard/src/app/marketplace/bundle/[...slug]/BundleInstallPanel.tsx
+++ b/dashboard/src/app/marketplace/bundle/[...slug]/BundleInstallPanel.tsx
@@ -56,7 +56,10 @@ interface BundleInstallResponse {
   code?: string;
 }
 
-const POLL_TIMEOUT_MS = 1500;
+// 4000ms matches the single-recipe InstallPanel — a shorter window caused
+// false "No local bridge detected" banners on cold start (slow first
+// /api/bridge/recipes probe).
+const POLL_TIMEOUT_MS = 4000;
 
 export default function BundleInstallPanel({
   installSource,

--- a/dashboard/src/lib/__tests__/bridge.test.ts
+++ b/dashboard/src/lib/__tests__/bridge.test.ts
@@ -199,11 +199,40 @@ describe("findBridge — lock-file scan", () => {
     expect(findBridge()).toBeNull();
   });
 
-  it("treats missing optional fields as empty strings rather than crashing", () => {
-    writeLock(4242, { pid: process.pid, isBridge: true });
+  it("treats a missing workspace as an empty string rather than crashing", () => {
+    writeLock(4242, { pid: process.pid, authToken: "tok", isBridge: true });
     const got = findBridge();
     expect(got).not.toBeNull();
     expect(got!.workspace).toBe("");
-    expect(got!.authToken).toBe("");
+    expect(got!.authToken).toBe("tok");
+  });
+
+  it("skips locks with a missing authToken (would send `Bearer ` empty)", () => {
+    writeLock(4242, { pid: process.pid, isBridge: true });
+    expect(findBridge()).toBeNull();
+  });
+
+  it("skips locks with an empty-string authToken and falls through to a valid one", () => {
+    writeLock(4242, {
+      pid: process.pid,
+      authToken: "",
+      isBridge: true,
+    });
+    fs.utimesSync(
+      path.join(ideDir, "4242.lock"),
+      Date.now() / 1000,
+      Date.now() / 1000,
+    );
+    writeLock(4243, {
+      pid: process.pid,
+      authToken: "good",
+      isBridge: true,
+    });
+    // Bump the empty-token lock's mtime forward so it would win the
+    // most-recent-first sort — proving the guard, not the ordering, is
+    // what skips it.
+    const future = Date.now() / 1000 + 60;
+    fs.utimesSync(path.join(ideDir, "4242.lock"), future, future);
+    expect(findBridge()?.authToken).toBe("good");
   });
 });

--- a/dashboard/src/lib/bridge.ts
+++ b/dashboard/src/lib/bridge.ts
@@ -76,13 +76,17 @@ function _scanLockFiles(): BridgeLock | null {
       const parsed = JSON.parse(raw) as Partial<BridgeLock>;
       if (!parsed.isBridge) continue;
       if (!parsed.pid || !isPidAlive(parsed.pid)) continue;
+      // An empty/missing authToken would still pass every other guard and
+      // send `Authorization: Bearer ` (empty) — which the bridge rejects.
+      // Skip it so discovery can fall through to a healthy lock instead.
+      if (!parsed.authToken) continue;
       const port = Number.parseInt(f.replace(/\.lock$/, ""), 10);
       if (!Number.isFinite(port)) continue;
       return {
         pid: parsed.pid,
         port,
         workspace: parsed.workspace ?? "",
-        authToken: parsed.authToken ?? "",
+        authToken: parsed.authToken,
         isBridge: true,
       };
     } catch {


### PR DESCRIPTION
## Problem

Three small dashboard install-path reliability gaps:

1. **Content-type mislabelling.** `/api/bridge/recipes/install` and `/api/bridge/recipes/doctor` hardcoded `content-type: application/json` on the proxied response. In remote mode a reverse proxy in front of the bridge can return an HTML error page; the client then got a JSON header on an HTML body and silently failed to parse it.
2. **Empty-authToken lock used.** `findBridge()` used `parsed.authToken ?? ''`, so a lock file with an empty/missing token passed every guard and produced `Authorization: Bearer ` (empty), which the bridge rejects — instead of falling through to a healthy lock.
3. **Bundle panel false-negative.** The bundle install panel probed the bridge with a 1500ms timeout, causing false "No local bridge detected" banners on cold start. The single-recipe panel was already raised to 4000ms.

## Change

- `dashboard/src/app/api/bridge/recipes/install/route.ts` and `.../recipes/doctor/route.ts`: mirror the upstream `content-type` using the same `upstreamCt` logic as the catch-all `[...path]` proxy (JSON/empty → `application/json`, otherwise pass through).
- `dashboard/src/lib/bridge.ts`: skip lock files with an empty/missing `authToken` (`if (!parsed.authToken) continue;`), letting discovery fall through to a valid lock.
- `dashboard/src/app/marketplace/bundle/[...slug]/BundleInstallPanel.tsx`: bump `POLL_TIMEOUT_MS` 1500 → 4000 to match the single-recipe `InstallPanel`.

## Testing

Bug Fix Protocol followed (red → green) for items 1 and 2:

- Added an HTML-content-type-mirror test to `install/__tests__/route.test.ts` — failed first (got `application/json`), passes now.
- Added empty/missing-authToken skip tests to `lib/__tests__/bridge.test.ts` — failed first (synthetic lock with `authToken:''` returned), pass now. The pre-existing case asserting the buggy `authToken:''` return was rewritten.
- Item 3 is a constant-only change; existing `BundleInstallPanel.test.tsx` still passes (no artificial test forced).

`cd dashboard && npx vitest run` over the 3 touched test files: 45/45 passing. `tsc --noEmit` clean. ESLint (`next lint`) clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)