### PR TITLE
fix(recipes): http.post SSRF hardening — canonical guard + allowPrivate kill-flag

### DIFF
--- a/src/featureFlags.ts
+++ b/src/featureFlags.ts
@@ -304,6 +304,16 @@ export const FLAG_SCHEMA_LINT = "ui.schema-lint";
  */
 export const FLAG_REPAIR_AI = "recipe.repair-ai";
 
+/**
+ * Globally disable the per-step `allowPrivate: true` SSRF bypass in the
+ * recipe `http.post` tool. Default OFF (backward-compatible — recipes that
+ * set `allowPrivate: true` keep working). When an operator turns this ON
+ * (e.g. for a shared / multi-tenant bridge running untrusted marketplace
+ * recipes), the bypass is ignored and private/loopback hosts are blocked
+ * regardless of what the recipe requests.
+ */
+export const FLAG_BLOCK_RECIPE_ALLOW_PRIVATE = "block-recipe-allow-private";
+
 // Register built-in flags
 registerFlag({
   id: KILL_SWITCH_WRITES,
@@ -329,6 +339,15 @@ registerFlag({
     "Phase 2A: enable the /recipes/repair LLM-driven fix endpoint. Costs API tokens per call; gated by a per-session token bucket and prompt-injection sanitization.",
   defaultValue: false,
   category: "ui",
+  requiresOptIn: true,
+});
+
+registerFlag({
+  id: FLAG_BLOCK_RECIPE_ALLOW_PRIVATE,
+  description:
+    "Globally disable the per-step allowPrivate:true SSRF bypass in the recipe http.post tool. When on, private/loopback hosts are blocked even if a recipe sets allowPrivate:true.",
+  defaultValue: false,
+  category: "safety",
   requiresOptIn: true,
 });
 

--- a/src/recipes/tools/__tests__/http.test.ts
+++ b/src/recipes/tools/__tests__/http.test.ts
@@ -73,6 +73,15 @@ describe("http.post — SSRF guard (lexical)", () => {
     expect(isPrivateHost("172.15.0.1")).toBe(false);
     expect(isPrivateHost("172.32.0.1")).toBe(false);
   });
+  it("rejects CGNAT (RFC 6598 100.64.0.0/10) — canonical-guard coverage", () => {
+    // The local lexical copy in http.ts missed 100.64.0.0/10; the canonical
+    // ssrfGuard covers it. Concrete address verified by reading both impls.
+    expect(isPrivateHost("100.64.0.1")).toBe(true);
+    expect(isPrivateHost("100.127.255.254")).toBe(true);
+    // outside the /10 stays public
+    expect(isPrivateHost("100.63.0.1")).toBe(false);
+    expect(isPrivateHost("100.128.0.1")).toBe(false);
+  });
 });
 
 describe("http.post — execute", () => {
@@ -134,5 +143,25 @@ describe("http.post — execute", () => {
     await expect(
       executeTool("http.post", makeCtx({ url: "not a url", body: "" })),
     ).rejects.toThrow(/invalid URL/);
+  });
+
+  it("blocks allowPrivate bypass when PATCHWORK_FLAG_BLOCK_RECIPE_ALLOW_PRIVATE is on", async () => {
+    vi.stubEnv("PATCHWORK_FLAG_BLOCK_RECIPE_ALLOW_PRIVATE", "true");
+    try {
+      await expect(
+        executeTool(
+          "http.post",
+          makeCtx({
+            url: "http://127.0.0.1:9000/x",
+            body: "x",
+            allowPrivate: true,
+          }),
+        ),
+      ).rejects.toThrow(/private\/loopback/);
+      // fetch must never be reached when the bypass is disabled
+      expect(mockUndiciFetch).not.toHaveBeenCalled();
+    } finally {
+      vi.unstubAllEnvs();
+    }
   });
 });

--- a/src/recipes/tools/http.ts
+++ b/src/recipes/tools/http.ts
@@ -8,7 +8,15 @@
  */
 
 import { Agent, fetch as undiciFetch } from "undici";
-import { assertWriteAllowed } from "../../featureFlags.js";
+import {
+  assertWriteAllowed,
+  FLAG_BLOCK_RECIPE_ALLOW_PRIVATE,
+  isEnabled,
+} from "../../featureFlags.js";
+// Canonical SSRF guard — single source of truth (handles CGNAT 100.64/10,
+// 6to4 2002::/16, hex/octal IPv4, ::ffff:0: translated forms — none of which
+// the previous local copy covered).
+import { isPrivateHost } from "../../ssrfGuard.js";
 import { CommonSchemas, registerTool } from "../toolRegistry.js";
 
 // Custom dispatcher pinning DNS resolution to IPv4. Node's Happy-Eyeballs
@@ -29,22 +37,6 @@ const httpAgent = new Agent({
   keepAliveTimeout: 5_000,
   keepAliveMaxTimeout: 10_000,
 });
-
-function isPrivateHost(hostname: string): boolean {
-  const h = hostname.toLowerCase().replace(/^\[|\]$/g, "");
-  if (h === "localhost" || h.endsWith(".localhost")) return true;
-  if (h === "::1") return true;
-  if (h.startsWith("::ffff:")) return isPrivateHost(h.slice(7));
-  if (/^127\./.test(h)) return true;
-  if (/^10\./.test(h)) return true;
-  if (/^192\.168\./.test(h)) return true;
-  if (/^172\.(1[6-9]|2\d|3[01])\./.test(h)) return true;
-  if (/^169\.254\./.test(h)) return true;
-  if (/^0\./.test(h)) return true;
-  if (/^fc[0-9a-f]{2}:/.test(h) || /^fd[0-9a-f]{2}:/.test(h)) return true;
-  if (/^fe80:/.test(h)) return true;
-  return false;
-}
 
 registerTool({
   id: "http.post",
@@ -126,7 +118,11 @@ registerTool({
       );
     }
 
-    const allowPrivate = params.allowPrivate === true;
+    // Operator kill-flag: when on, the per-step allowPrivate:true bypass is
+    // ignored so a (potentially marketplace-installed) recipe can never reach
+    // a private/loopback host.
+    const bypassDisabled = isEnabled(FLAG_BLOCK_RECIPE_ALLOW_PRIVATE);
+    const allowPrivate = !bypassDisabled && params.allowPrivate === true;
     if (!allowPrivate && isPrivateHost(parsed.hostname)) {
       throw new Error(
         `http.post: refusing to reach private/loopback host "${parsed.hostname}" — set allowPrivate: true to override`,


### PR DESCRIPTION
## What

Hardens the recipe `http.post` built-in tool (callable by marketplace recipes) against SSRF.

### 1. Use the canonical SSRF guard
`src/recipes/tools/http.ts` shipped its own local `isPrivateHost`. Compared against the canonical `src/ssrfGuard.ts` guard, the local copy missed:
- CGNAT `100.64.0.0/10` (RFC 6598)
- 6to4 `2002::/16` (private IPv4 wrapped in IPv6)
- non-decimal IPv4 (`0x…` / octal)
- `::ffff:0:` IPv4-translated and hex-compressed IPv6 forms

Replaced the local copy with an import of the canonical `isPrivateHost`; the existing public re-export is preserved.

### 2. `PATCHWORK_FLAG_BLOCK_RECIPE_ALLOW_PRIVATE` kill-flag
New feature flag (default OFF, backward-compatible). When an operator turns it ON — e.g. a shared/multi-tenant bridge running untrusted marketplace recipes — the per-step `allowPrivate: true` bypass in `http.post` is ignored and private/loopback hosts are blocked regardless of what the recipe requests.

## Test-first proof
- Before: CGNAT `isPrivateHost("100.64.0.1")` returned `false`; flag-gated `allowPrivate:true` → 127.0.0.1 resolved 202 instead of rejecting. Both red.
- After: 12/12 in `http.test.ts`; 55/55 across `featureFlags` + `ssrfGuard` + `http` suites.

## Gates
- `biome check` clean
- `tsc -p tsconfig.tests.core.json --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>