### PR TITLE
fix(marketplace): submit-time trust integrity — no-bypass syntax gate + trust-consistency warnings

### DIFF
--- a/dashboard/src/app/marketplace/submit/__tests__/page.test.tsx
+++ b/dashboard/src/app/marketplace/submit/__tests__/page.test.tsx
@@ -617,6 +617,73 @@ describe("MarketplaceSubmitPage — Validate-before-submit guard", () => {
 });
 
 // =====================================================================
+// S2 — mandatory client-side syntax gate (no full bypass)
+// =====================================================================
+
+describe("MarketplaceSubmitPage — S2 syntax gate", () => {
+  it("blocks submit on syntactically-broken YAML even when the bridge lint is gated (401)", async () => {
+    // Gated/public deploy: initial recipes load + the lint POST both
+    // return 401. Pre-fix the 401 set lintError and let submit through
+    // with no validation. With the client-side syntax gate, broken YAML
+    // is rejected regardless of the bridge response.
+    fetchMock.mockResolvedValue(jsonResponse(401, {}));
+
+    render(<MarketplaceSubmitPage />);
+    await fillRequiredFields();
+    // Unbalanced flow sequence — yaml.parse throws.
+    fireEvent.change(screen.getByTestId("fake-yaml-editor"), {
+      target: { value: "name: my-recipe\nsteps: [ - id: x" },
+    });
+
+    // Click Validate so the lintError (401 → soft path) is recorded —
+    // this is the exact bypass route the gate must close.
+    fireEvent.click(screen.getByRole("button", { name: /^Validate$/i }));
+    await waitFor(() =>
+      expect(screen.queryByText(/syntax validated only/i)).not.toBeNull(),
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /Open PR on GitHub/i }),
+    );
+
+    expect(
+      await screen.findByText(/not valid YAML/i),
+    ).toBeInTheDocument();
+    // GitHub tab was NOT opened — the broken YAML is blocked.
+    expect(openMock).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a non-blocking trust warning when network access is contradicted", async () => {
+    fetchMock.mockResolvedValue(jsonResponse(503, {}));
+
+    render(<MarketplaceSubmitPage />);
+    await fillRequiredFields();
+    // Valid YAML, but it reaches out to the network while the
+    // networkAccess checkbox stays unchecked (default false).
+    fireEvent.change(screen.getByTestId("fake-yaml-editor"), {
+      target: {
+        value:
+          "name: my-recipe\ntrigger:\n  type: manual\nsteps:\n  - id: fetch\n    agent:\n      prompt: call https://example.com/api\n",
+      },
+    });
+
+    // The warning surfaces live (before submit) since the manifest claims
+    // no network access but the YAML reaches out.
+    expect(
+      await screen.findByText(/trust-metadata warning/i),
+    ).toBeInTheDocument();
+
+    await runValidateAndWait();
+    fireEvent.click(
+      screen.getByRole("button", { name: /Open PR on GitHub/i }),
+    );
+
+    // ...but it does NOT block the GitHub handoff.
+    await waitFor(() => expect(openMock).toHaveBeenCalledTimes(1));
+  });
+});
+
+// =====================================================================
 // Draft-restored banner
 // =====================================================================
 

--- a/dashboard/src/app/marketplace/submit/page.tsx
+++ b/dashboard/src/app/marketplace/submit/page.tsx
@@ -16,6 +16,7 @@ import {
 import { apiPath } from "@/lib/api";
 import { useToast } from "@/components/Toast";
 import {
+  analyzeTrustConsistency,
   buildGithubCreateFileUrl,
   buildManifestJson,
   extractYamlName,
@@ -326,6 +327,21 @@ export default function MarketplaceSubmitPage() {
     [formData],
   );
 
+  // S2: live, non-blocking trust-consistency warnings. Computed
+  // continuously (not just on submit) so the author sees a contradiction
+  // — e.g. manifest says no-network but the YAML has an http step —
+  // while composing, before the GitHub handoff. Conservative heuristics:
+  // warn, never block. Returns [] when the YAML doesn't parse (the
+  // submit-time syntax gate handles that case as a blocking error).
+  const trustWarnings = useMemo<string[]>(() => {
+    if (yaml.trim().length === 0) return [];
+    try {
+      return analyzeTrustConsistency(formData, yaml).map((i) => i.message);
+    } catch {
+      return [];
+    }
+  }, [formData, yaml]);
+
   // Live estimate of the full GitHub create-file URL we'd open at submit.
   // Lets the action bar warn the user before they hit the silent-truncation
   // ceiling (GitHub's prefill ~8 KB hard limit; we warn from URL_SAFE_CONTENT_LIMIT).
@@ -471,11 +487,17 @@ export default function MarketplaceSubmitPage() {
       if (!res.ok) {
         if (res.status === 502 || res.status === 503 || res.status === 504) {
           setLintError(
-            "Bridge isn't responding. You can still submit — full validation will run during PR review.",
+            "Bridge isn't responding — syntax validated only. You can still submit (YAML syntax is checked client-side; full schema validation runs during PR review).",
           );
           return;
         }
-        setLintError(`Validation request failed: HTTP ${res.status}`);
+        // Any other non-OK status (e.g. 401 on a gated/public deploy)
+        // degrades to syntax-only too — never a full bypass: the
+        // client-side YAML syntax gate in validateSubmission still runs
+        // at submit time.
+        setLintError(
+          `Validation request failed: HTTP ${res.status} — syntax validated only. Full schema validation runs during PR review.`,
+        );
         return;
       }
       const data = (await res.json()) as {
@@ -531,19 +553,28 @@ export default function MarketplaceSubmitPage() {
   // ---- submit ------------------------------------------------------
   function handleSubmit(e: FormEvent) {
     e.preventDefault();
-    const issues = validateSubmission(formData);
+    // S2: pass the YAML so validateSubmission runs the client-side syntax
+    // gate (blocking) + trust-consistency heuristics (non-blocking). The
+    // syntax gate is independent of the bridge lint endpoint, so broken
+    // YAML can't slip through even when the bridge is offline / gated.
+    const issues = validateSubmission(formData, yaml);
     const errMap: Partial<Record<keyof SubmissionFormData | "yaml", string>> =
       {};
     for (const issue of issues) {
-      // Only record the first issue per field; the UI shows one line each.
+      // Trust-consistency warnings are non-blocking — they're surfaced
+      // live via the trustWarnings memo, not as submit-blocking errors.
+      if (issue.level === "warning") continue;
+      // Only record the first blocking issue per field; the UI shows one
+      // line each.
       if (!errMap[issue.field]) errMap[issue.field] = issue.message;
     }
     if (yaml.trim().length === 0) {
       errMap.yaml = "Recipe YAML is required.";
-    } else {
+    } else if (!errMap.yaml) {
       // Cross-check the YAML's `name:` against the form slug. They land in
       // separate files (recipe.yaml + recipe.json) so a mismatch would mean
       // the index builder shows one name but the YAML asserts another.
+      // Skip if the syntax gate already flagged this field.
       const yamlName = extractYamlName(yaml);
       if (yamlName !== null && yamlName !== formData.slug) {
         errMap.yaml = `YAML "name: ${yamlName}" doesn't match the slug "${formData.slug}". They must match — update one or the other.`;
@@ -1311,6 +1342,35 @@ export default function MarketplaceSubmitPage() {
             {manifestContent}
           </pre>
         </details>
+
+        {/* -------- trust-consistency warnings (S2, non-blocking) - */}
+        {trustWarnings.length > 0 && (
+          <div
+            role="status"
+            style={{
+              background: "var(--warn-soft, var(--bg-2))",
+              border: "1px solid var(--warn, var(--border-default))",
+              borderRadius: "var(--r-2)",
+              color: "var(--ink-1)",
+              fontSize: "var(--fs-s)",
+              gridColumn: "1 / -1",
+              padding: "var(--s-3) var(--s-4)",
+            }}
+          >
+            <strong style={{ color: "var(--warn)" }}>
+              {trustWarnings.length} trust-metadata warning
+              {trustWarnings.length === 1 ? "" : "s"}
+            </strong>{" "}
+            — these don&apos;t block submission, but reviewers will likely
+            flag them:
+            <ul style={{ margin: "var(--s-2) 0 0 var(--s-4)" }}>
+              {trustWarnings.map((w, i) => (
+                // biome-ignore lint/suspicious/noArrayIndexKey: warnings are plain strings, order-stable
+                <li key={i}>{w}</li>
+              ))}
+            </ul>
+          </div>
+        )}
 
         {/* -------- action bar (inside form so Enter submits) ----- */}
         <div

--- a/dashboard/src/lib/__tests__/marketplaceSubmit.test.ts
+++ b/dashboard/src/lib/__tests__/marketplaceSubmit.test.ts
@@ -380,6 +380,146 @@ describe("path builders", () => {
   });
 });
 
+describe("validateSubmission — YAML syntax gate (S2)", () => {
+  it("returns a blocking yaml error for syntactically-invalid YAML", () => {
+    // Unbalanced flow mapping — yaml.parse throws on this. The gate must
+    // catch it client-side so a broken recipe can't be submitted even
+    // with the bridge offline (no full lint available).
+    const brokenYaml = "name: my-recipe\nsteps: [ - id: x";
+    const issues = validateSubmission(baseForm, brokenYaml);
+    const yamlIssue = issues.find((i) => i.field === "yaml");
+    expect(yamlIssue).toBeDefined();
+    // Default level for a syntax failure is a blocking error.
+    expect(yamlIssue?.level ?? "error").toBe("error");
+  });
+
+  it("does not add a yaml syntax error for valid YAML", () => {
+    const validYaml =
+      "name: my-recipe\ntrigger:\n  type: manual\nsteps:\n  - id: step-1\n";
+    const issues = validateSubmission(baseForm, validYaml);
+    expect(issues.some((i) => i.field === "yaml")).toBe(false);
+  });
+
+  it("preserves existing field validation when a yaml arg is supplied", () => {
+    const validYaml = "name: my-recipe\ntrigger:\n  type: manual\n";
+    const issues = validateSubmission({ ...baseForm, slug: "" }, validYaml);
+    expect(issues.some((i) => i.field === "slug")).toBe(true);
+  });
+});
+
+describe("validateSubmission — trust-consistency warnings (S2)", () => {
+  it("warns when manifest says network_access=false but YAML has an http step", () => {
+    const yamlWithHttp = `name: my-recipe
+trigger:
+  type: manual
+steps:
+  - id: fetch
+    agent:
+      prompt: |
+        Call https://example.com/api and POST the data out.
+`;
+    const issues = validateSubmission(
+      { ...baseForm, networkAccess: false },
+      yamlWithHttp,
+    );
+    const warn = issues.find(
+      (i) => i.field === "networkAccess" && i.level === "warning",
+    );
+    expect(warn).toBeDefined();
+  });
+
+  it("does not warn about network when networkAccess=true", () => {
+    const yamlWithHttp = `name: my-recipe
+trigger:
+  type: manual
+steps:
+  - id: fetch
+    agent:
+      prompt: Call https://example.com/api
+`;
+    const issues = validateSubmission(
+      { ...baseForm, networkAccess: true },
+      yamlWithHttp,
+    );
+    expect(
+      issues.some((i) => i.field === "networkAccess"),
+    ).toBe(false);
+  });
+
+  it("warns when risk_level=low but a step is annotated risk: high", () => {
+    const yamlHighRisk = `name: my-recipe
+trigger:
+  type: manual
+steps:
+  - id: danger
+    risk: high
+    agent:
+      prompt: Do something risky.
+`;
+    const issues = validateSubmission(
+      { ...baseForm, riskLevel: "low" },
+      yamlHighRisk,
+    );
+    const warn = issues.find(
+      (i) => i.field === "riskLevel" && i.level === "warning",
+    );
+    expect(warn).toBeDefined();
+  });
+
+  it("warns when file_access=false but YAML has a file-writing step", () => {
+    const yamlWritesFile = `name: my-recipe
+trigger:
+  type: manual
+steps:
+  - id: write
+    tool: fs.writeFile
+    with:
+      path: ./out.txt
+`;
+    const issues = validateSubmission(
+      { ...baseForm, fileAccess: false },
+      yamlWritesFile,
+    );
+    const warn = issues.find(
+      (i) => i.field === "fileAccess" && i.level === "warning",
+    );
+    expect(warn).toBeDefined();
+  });
+
+  it("emits no trust warnings when the manifest matches the YAML", () => {
+    const cleanYaml = `name: my-recipe
+trigger:
+  type: manual
+steps:
+  - id: step-1
+    agent:
+      prompt: Summarize the input.
+`;
+    const issues = validateSubmission(
+      { ...baseForm, networkAccess: false, fileAccess: false, riskLevel: "low" },
+      cleanYaml,
+    );
+    expect(issues.some((i) => i.level === "warning")).toBe(false);
+  });
+
+  it("trust warnings are non-blocking (level=warning, not error)", () => {
+    const yamlWithHttp = `name: my-recipe
+trigger:
+  type: manual
+steps:
+  - id: fetch
+    agent:
+      prompt: fetch https://example.com
+`;
+    const issues = validateSubmission(
+      { ...baseForm, networkAccess: false },
+      yamlWithHttp,
+    );
+    const networkIssue = issues.find((i) => i.field === "networkAccess");
+    expect(networkIssue?.level).toBe("warning");
+  });
+});
+
 describe("buildGithubCreateFileUrl", () => {
   it("targets the registry repo by default", () => {
     const url = buildGithubCreateFileUrl({

--- a/dashboard/src/lib/marketplaceSubmit.ts
+++ b/dashboard/src/lib/marketplaceSubmit.ts
@@ -16,6 +16,7 @@
  * user with a GitHub account.
  */
 
+import { parse as parseYaml } from "yaml";
 import type { ApprovalBehavior, RiskLevel } from "./registry";
 
 export const REGISTRY_OWNER = "patchworkos";
@@ -173,6 +174,15 @@ export function normalizeAuthor(input: string): string {
 export interface ValidationIssue {
   field: keyof SubmissionFormData | "yaml";
   message: string;
+  /**
+   * Severity of the issue. Absent is treated as "error" (blocking) by
+   * every existing call site — kept optional so the long-standing
+   * form-field issues don't all have to be touched. Trust-consistency
+   * heuristics (S2) emit "warning": surfaced to the author but never
+   * blocking, since the heuristics are deliberately conservative and
+   * can false-positive.
+   */
+  level?: "error" | "warning";
 }
 
 /**
@@ -194,7 +204,27 @@ export function extractYamlName(yaml: string): string | null {
   return match[2] ?? match[3] ?? match[4] ?? null;
 }
 
-export function validateSubmission(data: SubmissionFormData): ValidationIssue[] {
+/**
+ * Validate the submission form.
+ *
+ * When `yaml` is supplied, two extra families of checks run:
+ *  1. A CLIENT-SIDE syntax gate (S2): the YAML is parsed with the bundled
+ *     `yaml` package. A parse failure is a BLOCKING `field: "yaml"` error.
+ *     This is independent of the bridge lint endpoint — so a syntactically
+ *     broken recipe can never be submitted even when the bridge is offline
+ *     or its lint route returns a non-OK status (401 on a gated deploy, a
+ *     network hiccup, etc.). The bridge lint, when reachable, layers richer
+ *     schema validation on top; when unreachable the UI degrades to
+ *     "syntax validated only" rather than a full bypass.
+ *  2. TRUST-CONSISTENCY heuristics (S2): conservative, non-blocking
+ *     `level: "warning"` issues flagging obvious contradictions between the
+ *     manifest trust dropdowns and what the YAML actually does (see
+ *     analyzeTrustConsistency).
+ */
+export function validateSubmission(
+  data: SubmissionFormData,
+  yaml?: string,
+): ValidationIssue[] {
   const issues: ValidationIssue[] = [];
   if (!SLUG_RE.test(data.slug)) {
     issues.push({
@@ -284,6 +314,112 @@ export function validateSubmission(data: SubmissionFormData): ValidationIssue[] 
       }
     }
   }
+
+  // ---- YAML-aware checks (S2) -------------------------------------
+  // Only run when a YAML doc is supplied. Keeps the data-only call sites
+  // (and their existing tests) unchanged.
+  if (typeof yaml === "string") {
+    const trimmed = yaml.trim();
+    if (trimmed.length > 0) {
+      let parseFailed = false;
+      try {
+        parseYaml(yaml);
+      } catch (err) {
+        parseFailed = true;
+        const detail = err instanceof Error ? err.message : String(err);
+        // Collapse multi-line parser output to a single line so the inline
+        // error box stays compact.
+        const oneLine = detail.split("\n")[0]?.trim() || "syntax error";
+        issues.push({
+          field: "yaml",
+          level: "error",
+          message: `Recipe YAML is not valid YAML: ${oneLine}`,
+        });
+      }
+      // Trust heuristics need a parseable doc; skip when parsing failed.
+      if (!parseFailed) {
+        issues.push(...analyzeTrustConsistency(data, yaml));
+      }
+    }
+  }
+
+  return issues;
+}
+
+/**
+ * Conservative trust-consistency heuristics (S2).
+ *
+ * buildManifestJson copies the risk/network/file dropdowns straight from
+ * the form, so a data-exfiltrating recipe can be declared low-risk /
+ * no-access. These heuristics parse the YAML and flag obvious
+ * contradictions as NON-BLOCKING warnings. Deliberately conservative —
+ * they warn, never block, because a false positive here must not stop a
+ * legitimate submission.
+ *
+ * Detection is text-based against the raw YAML (covers prompts and values
+ * uniformly), with the parse already proven to succeed by the caller.
+ *
+ *  - network_access=false but YAML mentions http(s):// URLs or a
+ *    fetch/curl/http(.request) call  → warn on networkAccess.
+ *  - file_access=false but YAML has a file read/write op (fs.*,
+ *    writeFile/readFile, or a `path:` value)  → warn on fileAccess.
+ *  - risk_level=low but a step declares `risk: high|medium`  → warn on
+ *    riskLevel.
+ */
+export function analyzeTrustConsistency(
+  data: SubmissionFormData,
+  yaml: string,
+): ValidationIssue[] {
+  const issues: ValidationIssue[] = [];
+
+  // Network: declared no-network but the YAML reaches out.
+  if (!data.networkAccess) {
+    const networkSignal =
+      /https?:\/\//i.test(yaml) ||
+      /\b(?:fetch|curl|wget|axios|http\.request|sendHttpRequest|webhook)\b/i.test(
+        yaml,
+      );
+    if (networkSignal) {
+      issues.push({
+        field: "networkAccess",
+        level: "warning",
+        message:
+          'The YAML references network calls (a URL or fetch/http step) but "Makes outbound network requests" is unchecked. Reviewers may flag this — re-check the box if the recipe reaches the network.',
+      });
+    }
+  }
+
+  // Files: declared no-file-access but the YAML reads/writes files.
+  if (!data.fileAccess) {
+    const fileSignal =
+      /\bfs\.[a-z]/i.test(yaml) ||
+      /\b(?:writeFile|readFile|createFile|editText|writeFileSync|readFileSync)\b/i.test(
+        yaml,
+      ) ||
+      /^\s*path:\s*\S/m.test(yaml);
+    if (fileSignal) {
+      issues.push({
+        field: "fileAccess",
+        level: "warning",
+        message:
+          'The YAML references local file operations (an fs/writeFile step or a path: value) but "Reads or writes local files" is unchecked. Re-check the box if the recipe touches the filesystem.',
+      });
+    }
+  }
+
+  // Risk: declared low but a step annotates itself higher.
+  if (data.riskLevel === "low") {
+    const declaresHigherRisk = /^\s*risk:\s*(high|medium)\b/im.test(yaml);
+    if (declaresHigherRisk) {
+      issues.push({
+        field: "riskLevel",
+        level: "warning",
+        message:
+          'A step in the YAML is annotated risk: high/medium but the manifest risk level is "low". Consider raising the risk level so the install confirmation matches.',
+      });
+    }
+  }
+
   return issues;
 }
 


### PR DESCRIPTION
## What

Closes two security gaps in the marketplace recipe-submit flow (GROUP S2).

### 1. Mandatory client-side YAML syntax gate (no full bypass)
The submit-enable logic previously unblocked submission whenever the bridge lint endpoint returned **any** non-OK HTTP status (e.g. a 401 on a gated/public deployment, or a transient 5xx). It set `lintError` and forwarded the YAML straight to GitHub with **zero validation** — so syntactically-broken YAML could be submitted with the bridge offline.

`validateSubmission` now accepts an optional `yaml` argument and parses it with the bundled `yaml` package. A parse failure is a **blocking** `field: "yaml"` error, independent of the bridge. When the bridge lint is unreachable the UI degrades to **"syntax validated only"** (a notice) rather than a full bypass. Net: you can never submit syntactically-broken YAML, even bridge-offline.

### 2. Trust-consistency warnings
`buildManifestJson` writes `risk_level` / `network_access` / `file_access` straight from the form dropdowns with no YAML analysis — a data-exfiltrating recipe could be declared low-risk/no-access. New exported `analyzeTrustConsistency(data, yaml)` emits **conservative, non-blocking** `level: "warning"` issues for obvious contradictions:
- `network_access=false` but the YAML has a URL / fetch / http step
- `file_access=false` but the YAML has an `fs.*` / `writeFile` / `path:` step
- `risk_level=low` but a step is annotated `risk: high|medium`

These surface live in a non-blocking warning panel while composing (warn, don't block — heuristics can false-positive).

`ValidationIssue` gained an optional `level?: "error" | "warning"` field (absent = blocking error → fully backward-compatible).

## Tests
Test-first per the Bug Fix Protocol. Added 5 lib tests + 2 page tests — confirmed red before the fix (5 lib failures captured), green after. Full marketplace + lib dashboard suites: 391/391 pass. Typecheck + ESLint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)