### PR TITLE
fix(marketplace): warn when registry trust metadata diverges from recipe YAML risk (S3)

### DIFF
--- a/dashboard/src/app/marketplace/[...slug]/page.tsx
+++ b/dashboard/src/app/marketplace/[...slug]/page.tsx
@@ -14,6 +14,7 @@ import {
   shortName,
   summarizeRisk,
 } from "@/lib/registry";
+import { TrustDivergenceNotice } from "../_components/TrustDivergenceNotice";
 import InstallPanel from "./InstallPanel";
 
 // 60s ISR (was 300s). A 5-minute cache hides freshly merged recipes
@@ -127,6 +128,15 @@ export default async function RecipeDetailPage({ params }: PageProps) {
       <Steps yaml={yaml} />
 
       <TrustMetadataCard recipe={recipe} />
+
+      <TrustDivergenceNotice
+        meta={{
+          risk_level: recipe.risk_level,
+          network_access: recipe.network_access,
+          file_access: recipe.file_access,
+        }}
+        riskSummary={yaml ? summarizeRisk(yaml) : { low: 0, medium: 0, high: 0, steps: 0 }}
+      />
 
       <YamlPreview yaml={yaml} src={src} mainFile={manifest?.recipes?.main} />
 

--- a/dashboard/src/app/marketplace/_components/TrustDivergenceNotice.tsx
+++ b/dashboard/src/app/marketplace/_components/TrustDivergenceNotice.tsx
@@ -1,0 +1,142 @@
+import type { TrustMetadata } from "@/lib/registry";
+
+/**
+ * Trust-vs-YAML reconciliation for the recipe DETAIL page.
+ *
+ * GROUP S3 (marketplace investigation 2026-06-04): the detail page renders
+ * the registry trust metadata (TrustMetadataCard, sourced from index.json)
+ * and a YAML-derived risk summary (summarizeRisk over the actual recipe YAML)
+ * adjacently with NO reconciliation. A green "low risk" / "no file access"
+ * pill could sit beside high-risk YAML steps and nothing warned the user —
+ * a stale OR tampered registry index could mask what the recipe actually does.
+ *
+ * The metadata is self-reported (and the registry is community-maintained,
+ * not signature-verified). The YAML is the ground truth that will run. When
+ * they disagree, surface it: prefer the more dangerous of the two signals and
+ * tell the user exactly which claim the YAML contradicts.
+ *
+ * The detection helper lives here (not in registry.ts, which is locked by an
+ * open PR) so it is independently unit-testable.
+ */
+
+/** The metadata fields this reconciliation inspects (subset of TrustMetadata). */
+export type DivergenceMeta = Pick<
+  TrustMetadata,
+  "risk_level" | "network_access" | "file_access"
+>;
+
+/** Shape returned by `summarizeRisk(yaml)` in @/lib/registry. */
+export interface RiskSummary {
+  low: number;
+  medium: number;
+  high: number;
+  steps: number;
+}
+
+/**
+ * Return the list of contradictions between the registry trust metadata and
+ * the YAML-derived risk summary. Empty list ⇒ no divergence (render nothing).
+ *
+ * Pure + dependency-free so it can be unit-tested in isolation.
+ */
+export function detectTrustDivergence(
+  meta: DivergenceMeta,
+  riskSummary: RiskSummary,
+): string[] {
+  const contradictions: string[] = [];
+
+  // No steps parsed from the YAML ⇒ nothing to reconcile against. The risk
+  // summary returns all-zeros on parse failure too, so this also avoids
+  // false positives when the YAML couldn't be fetched / parsed.
+  if (riskSummary.steps === 0) return contradictions;
+
+  const hasMedium = riskSummary.medium > 0;
+  const hasHigh = riskSummary.high > 0;
+  const hasElevated = hasMedium || hasHigh;
+
+  // 1. risk_level claims "low" but the YAML declares medium/high-risk steps.
+  if (meta.risk_level === "low" && hasElevated) {
+    const parts: string[] = [];
+    if (hasHigh) parts.push(`${riskSummary.high} high-risk`);
+    if (hasMedium) parts.push(`${riskSummary.medium} medium-risk`);
+    contradictions.push(
+      `Listed as low risk, but the recipe YAML declares ${parts.join(
+        " and ",
+      )} step${riskSummary.high + riskSummary.medium === 1 ? "" : "s"}.`,
+    );
+  }
+
+  // High-risk YAML steps are the strongest signal that the recipe does more
+  // than its metadata claims — they typically write files and/or make network
+  // calls. When the metadata explicitly opts OUT of those capabilities, flag it.
+  if (hasHigh) {
+    // 2. file_access:false but high-risk steps present.
+    if (meta.file_access === false) {
+      contradictions.push(
+        `Declares no file access, but the recipe YAML contains ${riskSummary.high} high-risk step${riskSummary.high === 1 ? "" : "s"} that may read or write local files.`,
+      );
+    }
+    // 3. network_access:false but high-risk steps present.
+    if (meta.network_access === false) {
+      contradictions.push(
+        `Declares no network access, but the recipe YAML contains ${riskSummary.high} high-risk step${riskSummary.high === 1 ? "" : "s"} that may make outbound requests.`,
+      );
+    }
+  }
+
+  return contradictions;
+}
+
+/**
+ * Inline warning rendered between the trust card and the install panel.
+ * Renders nothing when the metadata and YAML are consistent.
+ */
+export function TrustDivergenceNotice({
+  meta,
+  riskSummary,
+}: {
+  meta: DivergenceMeta;
+  riskSummary: RiskSummary;
+}) {
+  const contradictions = detectTrustDivergence(meta, riskSummary);
+  if (contradictions.length === 0) return null;
+
+  return (
+    <div
+      role="alert"
+      className="glass-card"
+      style={{
+        padding: "var(--s-4) var(--s-5)",
+        background: "var(--err-soft, var(--warn-soft))",
+        border: "1px solid var(--err, var(--warn))",
+        fontSize: "var(--fs-s)",
+        color: "var(--ink-1)",
+        lineHeight: 1.6,
+        display: "flex",
+        flexDirection: "column",
+        gap: "var(--s-2)",
+      }}
+    >
+      <strong style={{ color: "var(--ink-0)" }}>
+        Trust metadata doesn&apos;t match the recipe YAML
+      </strong>
+      <p style={{ margin: 0, color: "var(--ink-2)" }}>
+        The self-reported trust labels below disagree with what the recipe
+        source actually declares. Trust the YAML — review it before installing.
+      </p>
+      <ul
+        style={{
+          margin: 0,
+          paddingLeft: "1.2em",
+          display: "flex",
+          flexDirection: "column",
+          gap: "var(--s-1)",
+        }}
+      >
+        {contradictions.map((c) => (
+          <li key={c}>{c}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/dashboard/src/app/marketplace/_components/__tests__/TrustDivergenceNotice.test.tsx
+++ b/dashboard/src/app/marketplace/_components/__tests__/TrustDivergenceNotice.test.tsx
@@ -1,0 +1,105 @@
+/**
+ * TrustDivergenceNotice — reconciles registry index.json trust metadata
+ * against the YAML-derived risk summary so a green "low risk" pill can't
+ * silently sit next to high-risk YAML steps.
+ *
+ * GROUP S3 (marketplace investigation 2026-06-04): the detail page rendered
+ * the TrustMetadataCard (from index.json) and the "Steps & risk" summary
+ * (from the actual recipe YAML) adjacently with NO reconciliation. A tampered
+ * or stale registry index claiming low/no-access could mask a recipe whose
+ * YAML clearly writes files / hits the network / runs high-risk steps.
+ */
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import {
+  detectTrustDivergence,
+  TrustDivergenceNotice,
+} from "../TrustDivergenceNotice";
+
+// Mirror the real shapes the detail page already computes:
+//   - meta: subset of RegistryRecipe (index.json trust metadata)
+//   - riskSummary: return shape of summarizeRisk(yaml)
+const emptyRisk = { low: 0, medium: 0, high: 0, steps: 0 };
+
+describe("detectTrustDivergence", () => {
+  it("flags low-risk metadata when YAML has high-risk steps", () => {
+    const out = detectTrustDivergence(
+      { risk_level: "low" },
+      { low: 1, medium: 0, high: 2, steps: 3 },
+    );
+    expect(out.length).toBeGreaterThan(0);
+  });
+
+  it("flags low-risk metadata when YAML has medium-risk steps", () => {
+    const out = detectTrustDivergence(
+      { risk_level: "low" },
+      { low: 0, medium: 1, high: 0, steps: 1 },
+    );
+    expect(out.length).toBeGreaterThan(0);
+  });
+
+  it("flags file_access:false when YAML has high-risk steps (likely file writes)", () => {
+    const out = detectTrustDivergence(
+      { file_access: false },
+      { low: 0, medium: 0, high: 1, steps: 1 },
+    );
+    expect(out.length).toBeGreaterThan(0);
+  });
+
+  it("flags network_access:false when YAML has high-risk steps (likely network)", () => {
+    const out = detectTrustDivergence(
+      { network_access: false },
+      { low: 0, medium: 0, high: 1, steps: 1 },
+    );
+    expect(out.length).toBeGreaterThan(0);
+  });
+
+  it("returns empty for fully-consistent inputs (low meta + only low steps)", () => {
+    const out = detectTrustDivergence(
+      { risk_level: "low", network_access: false, file_access: false },
+      { low: 3, medium: 0, high: 0, steps: 3 },
+    );
+    expect(out).toEqual([]);
+  });
+
+  it("returns empty when metadata matches elevated YAML risk", () => {
+    const out = detectTrustDivergence(
+      { risk_level: "high", network_access: true, file_access: true },
+      { low: 0, medium: 1, high: 2, steps: 3 },
+    );
+    expect(out).toEqual([]);
+  });
+
+  it("returns empty when there are no steps to reconcile against", () => {
+    const out = detectTrustDivergence({ risk_level: "low" }, emptyRisk);
+    expect(out).toEqual([]);
+  });
+
+  it("returns empty when metadata is absent (nothing to contradict)", () => {
+    const out = detectTrustDivergence({}, { low: 0, medium: 1, high: 1, steps: 2 });
+    expect(out).toEqual([]);
+  });
+});
+
+describe("TrustDivergenceNotice (render)", () => {
+  it("renders an alert when metadata diverges from YAML risk", () => {
+    render(
+      <TrustDivergenceNotice
+        meta={{ risk_level: "low" }}
+        riskSummary={{ low: 0, medium: 0, high: 2, steps: 2 }}
+      />,
+    );
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+  });
+
+  it("renders nothing when inputs are consistent", () => {
+    const { container } = render(
+      <TrustDivergenceNotice
+        meta={{ risk_level: "low", network_access: false, file_access: false }}
+        riskSummary={{ low: 2, medium: 0, high: 0, steps: 2 }}
+      />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+});


### PR DESCRIPTION
## What

Recipe detail page (`dashboard/src/app/marketplace/[...slug]/page.tsx`) rendered two trust signals side by side with no reconciliation:

- **TrustMetadataCard** — `risk_level` / `network_access` / `file_access` from the registry `index.json` (self-reported, community-maintained, **not** signature-verified)
- **Steps & risk** — derived from `summarizeRisk()` over the actual recipe YAML (the ground truth that runs)

A stale or tampered index claiming `low risk` / `no file access` could sit next to high-risk YAML steps and nothing warned the user.

## Change

New file `dashboard/src/app/marketplace/_components/TrustDivergenceNotice.tsx`:

- `detectTrustDivergence(meta, riskSummary)` — pure, dependency-free helper returning the list of contradictions. (Helper lives here, **not** in the open-PR-locked `registry.ts`; it imports `TrustMetadata` read-only for typing.) Flags: `risk_level==='low'` vs medium/high YAML steps; `file_access===false` vs high-risk steps; `network_access===false` vs high-risk steps. Returns `[]` when there are no steps to reconcile (also the YAML-unparseable/unfetched case) or no metadata.
- `TrustDivergenceNotice` — inline `role="alert"` listing the contradictions; renders nothing when consistent.

Wired into the detail page with a minimal import + one render block immediately after the `TrustMetadataCard`, passing the recipe trust fields and `summarizeRisk(yaml)`.

## Tests

`dashboard/src/app/marketplace/_components/__tests__/TrustDivergenceNotice.test.tsx` (test-first; red before the component existed, green after). 10 tests: helper divergence/no-divergence cases matching the real `summarizeRisk` shape + 2 render assertions (alert present / DOM empty).

## Gates

- Test: 10/10 pass
- `tsc --noEmit` (dashboard): clean
- `next lint` on changed files: no warnings or errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)