### PR TITLE
fix(recipes): registry/install hardening — entry sanitization + post-redirect SSRF re-check (B3-A)

### DIFF
--- a/src/__tests__/recipeRoutes-install.test.ts
+++ b/src/__tests__/recipeRoutes-install.test.ts
@@ -119,6 +119,7 @@ function fakeResponse(
   ok: boolean;
   status: number;
   statusText: string;
+  headers: Headers;
   body: ReadableStream<Uint8Array>;
 } {
   const enc = new TextEncoder();
@@ -132,6 +133,10 @@ function fakeResponse(
     ok: status >= 200 && status < 300,
     status,
     statusText: status === 200 ? "OK" : "Not Found",
+    // B3-A: the non-github install path now follows redirects manually and
+    // reads `Location` off the response — a real fetch Response always has a
+    // `headers` object, so the stub must too.
+    headers: new Headers(),
     body: stream,
   };
 }
@@ -223,6 +228,46 @@ describe("Server /recipes/install — A-PR2 (dogfood F-05 / H-routes Bug 2)", ()
     const parsed = JSON.parse(body);
     expect(parsed.ok).toBe(false);
     expect(parsed.code).toBe("ssrf_blocked");
+  });
+
+  it("install-post-redirect-ssrf: 302 → loopback host is rejected without following (B3-A)", async () => {
+    // Allowlist a public host so the upfront allowlist + validateSafeUrl pass;
+    // the upstream then 302-redirects to a loopback host. The manual redirect
+    // loop must re-validate the hop and reject it BEFORE fetching the private
+    // host. Pre-fix (`redirect: "follow"`) this slipped straight through.
+    process.env.CLAUDE_IDE_BRIDGE_INSTALL_ALLOWED_HOSTS = "example.org";
+    const fetched: string[] = [];
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input.toString();
+      fetched.push(url);
+      if (url === "https://example.org/foo.yaml") {
+        return {
+          ok: false,
+          status: 302,
+          statusText: "Found",
+          headers: new Headers({ location: "https://127.0.0.1/evil.yaml" }),
+          body: null,
+        } as unknown as Response;
+      }
+      // Reaching here means the private host WAS followed — guard failed.
+      return fakeResponse(200, "name: evil\n") as unknown as Response;
+    }) as unknown as typeof fetch;
+
+    const { status, body } = await makeRequest(
+      {
+        method: "POST",
+        path: "/recipes/install",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${TOKEN}`,
+        },
+      },
+      JSON.stringify({ source: "https://example.org/foo.yaml" }),
+    );
+    expect(status).toBe(403);
+    expect(JSON.parse(body).code).toBe("ssrf_blocked");
+    // The loopback redirect target must never have been fetched.
+    expect(fetched).not.toContain("https://127.0.0.1/evil.yaml");
   });
 
   it("install-hot-reload: success path invokes server.onRecipesChangedFn exactly once", async () => {

--- a/src/__tests__/recipeRoutes-registry-hardening.test.ts
+++ b/src/__tests__/recipeRoutes-registry-hardening.test.ts
@@ -1,0 +1,172 @@
+/**
+ * GROUP B3-A — Bridge registry/install hardening (SECURITY).
+ *
+ * Two units under test, both in `src/recipeRoutes.ts`:
+ *
+ *  (1) `isWellFormedTemplatesPayload` — must SANITIZE each entry rather than
+ *      reject the whole payload. A tampered/future `index.json` entry with an
+ *      out-of-enum `risk_level` (e.g. "critical" | null | 42), an out-of-enum
+ *      `approval_behavior`, or a non-numeric `downloads` must have those fields
+ *      stripped to `undefined` (or coerced to a number) while the entry itself
+ *      is retained. Goal: one malformed entry cannot poison the 5-minute
+ *      registry cache for every client, and an out-of-enum risk never silently
+ *      reads as "safe" downstream.
+ *
+ *  (2) `fetchFollowingRedirectsSafely` — post-redirect SSRF re-check on the
+ *      non-github HTTPS install path. A 302 whose `Location` points at a
+ *      private/loopback host must be rejected WITHOUT the loop following to the
+ *      private host (the upfront `validateSafeUrl` only pins the first hop).
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import {
+  fetchFollowingRedirectsSafely,
+  isWellFormedTemplatesPayload,
+} from "../recipeRoutes.js";
+
+describe("isWellFormedTemplatesPayload — enum/field sanitization (B3-A.1)", () => {
+  it("strips out-of-enum risk_level and non-numeric downloads but keeps the entry", () => {
+    const payload = {
+      recipes: [
+        {
+          slug: "evil",
+          name: "Evil Recipe",
+          // Out-of-enum: must NOT survive as "critical" downstream.
+          risk_level: "critical",
+          // Out-of-enum: must be stripped.
+          approval_behavior: "auto_approve_everything",
+          // Non-numeric: must be coerced/dropped — never passed through as a string.
+          downloads: "abc",
+        },
+      ],
+    };
+
+    const ok = isWellFormedTemplatesPayload(payload);
+    expect(ok).toBe(true);
+
+    const entry = payload.recipes[0] as Record<string, unknown>;
+    // Entry retained.
+    expect(entry).toBeDefined();
+    expect(entry.slug).toBe("evil");
+    // Out-of-enum risk_level stripped — must not silently read as a valid level.
+    expect(entry.risk_level).toBeUndefined();
+    // Out-of-enum approval_behavior stripped.
+    expect(entry.approval_behavior).toBeUndefined();
+    // Non-numeric downloads must not remain a string.
+    expect(typeof entry.downloads).not.toBe("string");
+    expect(entry.downloads).toBeUndefined();
+  });
+
+  it("keeps valid enum + numeric fields untouched", () => {
+    const payload = {
+      recipes: [
+        {
+          slug: "good",
+          risk_level: "low",
+          approval_behavior: "always_ask",
+          downloads: 42,
+        },
+      ],
+    };
+    const ok = isWellFormedTemplatesPayload(payload);
+    expect(ok).toBe(true);
+    const entry = payload.recipes[0] as Record<string, unknown>;
+    expect(entry.risk_level).toBe("low");
+    expect(entry.approval_behavior).toBe("always_ask");
+    expect(entry.downloads).toBe(42);
+  });
+});
+
+describe("fetchFollowingRedirectsSafely — post-redirect SSRF re-check (B3-A.2)", () => {
+  it("rejects a 302 whose Location points at a loopback host, without following", () => {
+    const followed: string[] = [];
+    const fakeFetch = vi.fn(async (url: string) => {
+      followed.push(url);
+      if (url === "https://example.org/recipe.yaml") {
+        return {
+          ok: false,
+          status: 302,
+          statusText: "Found",
+          headers: new Headers({ location: "https://127.0.0.1/evil.yaml" }),
+          body: null,
+        } as unknown as Response;
+      }
+      // Any actual fetch of the private host means the guard FAILED.
+      return {
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        headers: new Headers(),
+        body: null,
+      } as unknown as Response;
+    });
+
+    return expect(
+      fetchFollowingRedirectsSafely("https://example.org/recipe.yaml", {
+        fetchImpl: fakeFetch as unknown as typeof fetch,
+      }),
+    )
+      .rejects.toThrow(/ssrf|private|blocked/i)
+      .then(() => {
+        // The private-host hop must never have been fetched.
+        expect(followed).not.toContain("https://127.0.0.1/evil.yaml");
+        expect(followed).toEqual(["https://example.org/recipe.yaml"]);
+      });
+  });
+
+  it("rejects a 302 to a private RFC-1918 host", async () => {
+    const followed: string[] = [];
+    const fakeFetch = vi.fn(async (url: string) => {
+      followed.push(url);
+      return {
+        ok: false,
+        status: 302,
+        statusText: "Found",
+        headers: new Headers({ location: "https://10.0.0.5/x.yaml" }),
+        body: null,
+      } as unknown as Response;
+    });
+    await expect(
+      fetchFollowingRedirectsSafely("https://example.org/recipe.yaml", {
+        fetchImpl: fakeFetch as unknown as typeof fetch,
+      }),
+    ).rejects.toThrow(/ssrf|private|blocked/i);
+    expect(followed).not.toContain("https://10.0.0.5/x.yaml");
+  });
+
+  it("caps the redirect chain at 5 hops", async () => {
+    let n = 0;
+    const fakeFetch = vi.fn(async (_url: string) => {
+      n += 1;
+      // Always redirect to another public host → never terminates on its own.
+      return {
+        ok: false,
+        status: 302,
+        statusText: "Found",
+        headers: new Headers({ location: `https://example.org/hop-${n}.yaml` }),
+        body: null,
+      } as unknown as Response;
+    });
+    await expect(
+      fetchFollowingRedirectsSafely("https://example.org/start.yaml", {
+        fetchImpl: fakeFetch as unknown as typeof fetch,
+      }),
+    ).rejects.toThrow(/redirect/i);
+  });
+
+  it("returns the terminal response on a non-redirect status", async () => {
+    const terminal = {
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      headers: new Headers(),
+      body: null,
+    } as unknown as Response;
+    const fakeFetch = vi.fn(async () => terminal);
+    const res = await fetchFollowingRedirectsSafely(
+      "https://example.org/recipe.yaml",
+      { fetchImpl: fakeFetch as unknown as typeof fetch },
+    );
+    expect(res.status).toBe(200);
+  });
+});

--- a/src/recipeRoutes.ts
+++ b/src/recipeRoutes.ts
@@ -54,20 +54,89 @@ let templatesCache: unknown = null;
 let templatesCacheTs = 0;
 
 /**
- * #605: shape-validate the upstream templates payload before caching.
- * The minimal contract used by the dashboard marketplace is `{recipes:
- * Array}` (other fields are optional). Anything else (an error page
- * JSON, a tampered file with a flipped key, a future GitHub schema
- * change) is rejected so we don't serve garbage for 5 minutes to every
- * dashboard client.
+ * Canonical trust enums the dashboard understands. Anything outside these
+ * sets must NOT survive into the cached registry — an out-of-enum
+ * `risk_level` evaluates falsy downstream (silently reading as "safe") and
+ * `RISK_PILL_CLASS[risk_level]` resolves to `undefined`.
  */
-function isWellFormedTemplatesPayload(raw: unknown): boolean {
+const TEMPLATE_RISK_LEVELS = new Set(["low", "medium", "high"]);
+const TEMPLATE_APPROVAL_BEHAVIORS = new Set([
+  "always_ask",
+  "ask_on_novel",
+  "auto_approve",
+]);
+
+/**
+ * #605 / B3-A: shape-validate AND sanitize the upstream templates payload
+ * before caching.
+ *
+ * The minimal contract used by the dashboard marketplace is `{recipes:
+ * Array}` (other fields are optional). A bare array is accepted too (legacy).
+ * Anything that fails that contract (an error page JSON, a tampered file with
+ * a flipped top-level key, a future GitHub schema change) is rejected so we
+ * don't serve garbage for 5 minutes to every dashboard client.
+ *
+ * B3-A SECURITY change: rather than reject the WHOLE payload when a single
+ * entry carries a malformed trust field, we SANITIZE each entry IN PLACE so
+ * one bad entry can't poison the registry for every client. For each entry:
+ *
+ *   - `risk_level` not in {low,medium,high}        → stripped (set undefined)
+ *   - `approval_behavior` not in the canonical set → stripped (set undefined)
+ *   - `downloads` not a finite number              → coerced if it parses to a
+ *                                                     finite number, else dropped
+ *
+ * Conservative by design: stripping an out-of-enum `risk_level` means the
+ * dashboard treats trust as UNKNOWN (which the default-deny gate renders as
+ * elevated), never silently as "low"/"safe".
+ */
+export function isWellFormedTemplatesPayload(raw: unknown): boolean {
   if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
-    // Some legacy callers used a bare array; accept that too.
-    return Array.isArray(raw);
+    // Some legacy callers used a bare array; accept (and sanitize) that too.
+    if (Array.isArray(raw)) {
+      for (const entry of raw) sanitizeTemplateEntry(entry);
+      return true;
+    }
+    return false;
   }
   const r = raw as { recipes?: unknown };
-  return Array.isArray(r.recipes);
+  if (!Array.isArray(r.recipes)) return false;
+  for (const entry of r.recipes) sanitizeTemplateEntry(entry);
+  return true;
+}
+
+/**
+ * Strip/coerce untrusted trust fields on a single registry entry, mutating it
+ * in place. Non-object entries are left untouched (the dashboard tolerates
+ * them; they simply won't render trust pills). Kept conservative: we only
+ * touch the three fields with a downstream safety impact.
+ */
+function sanitizeTemplateEntry(entry: unknown): void {
+  if (typeof entry !== "object" || entry === null || Array.isArray(entry)) {
+    return;
+  }
+  const e = entry as Record<string, unknown>;
+
+  // risk_level: must be one of the canonical levels, else undefined.
+  if ("risk_level" in e && !TEMPLATE_RISK_LEVELS.has(e.risk_level as string)) {
+    e.risk_level = undefined;
+  }
+
+  // approval_behavior: must be one of the canonical behaviors, else undefined.
+  if (
+    "approval_behavior" in e &&
+    !TEMPLATE_APPROVAL_BEHAVIORS.has(e.approval_behavior as string)
+  ) {
+    e.approval_behavior = undefined;
+  }
+
+  // downloads: must be a finite number. Coerce a numeric string; otherwise
+  // drop. A non-numeric value (e.g. "abc") must never pass through as-is.
+  if ("downloads" in e && typeof e.downloads !== "number") {
+    const n = Number(e.downloads);
+    e.downloads = Number.isFinite(n) ? n : undefined;
+  } else if (typeof e.downloads === "number" && !Number.isFinite(e.downloads)) {
+    e.downloads = undefined;
+  }
 }
 
 /**
@@ -343,6 +412,87 @@ function respondInvalidJson(res: ServerResponse): void {
   res.end(JSON.stringify({ ok: false, error: "Invalid JSON body" }));
 }
 // END A-PR2 EDIT BLOCK
+
+// ---------------------------------------------------------------------
+// B3-A — post-redirect SSRF re-check for the non-github HTTPS install path.
+//
+// `validateSafeUrl` only validates the FIRST hop and explicitly does NOT pin
+// the resolved IP across redirects (see src/ssrfGuard.ts header comment). A
+// bare `fetch(url, { redirect: "follow" })` therefore lets a 302 → private
+// IP / IMDS slip past the upfront guard. This helper replays the manual
+// redirect-loop pattern from the CLI `httpsGet` in
+// src/commands/recipeInstall.ts: every hop's host is re-validated with the
+// canonical async guard (`validateSafeUrl`, which re-resolves DNS), the chain
+// is capped, and relative `Location` values are resolved against the current
+// URL before re-validation.
+// ---------------------------------------------------------------------
+const INSTALL_FETCH_MAX_REDIRECTS = 5;
+
+/**
+ * Fetch `startUrl` following HTTP redirects manually, re-validating every hop
+ * against the SSRF guard. Throws on a blocked host (private/loopback),
+ * unsupported protocol, malformed `Location`, or exceeding the hop cap.
+ * Returns the terminal (non-redirect) `Response`.
+ *
+ * `fetchImpl` is injectable for tests; defaults to the global `fetch`.
+ * `signal` is forwarded to every hop so the install timeout still applies.
+ */
+export async function fetchFollowingRedirectsSafely(
+  startUrl: string,
+  opts: { signal?: AbortSignal; fetchImpl?: typeof fetch } = {},
+): Promise<Response> {
+  const doFetch = opts.fetchImpl ?? fetch;
+  let currentUrl = startUrl;
+
+  for (let hop = 0; hop <= INSTALL_FETCH_MAX_REDIRECTS; hop++) {
+    // Re-validate the host of THIS hop before issuing the request. The first
+    // hop was already validated by the route, but re-checking is cheap and
+    // keeps this helper self-contained / correct in isolation.
+    const ssrf = await validateSafeUrl(currentUrl);
+    if (!ssrf.ok) {
+      throw new Error(
+        `SSRF guard blocked redirect target: ${ssrf.detail ?? ssrf.reason ?? "unknown"}`,
+      );
+    }
+
+    const res = await doFetch(currentUrl, {
+      ...(opts.signal ? { signal: opts.signal } : {}),
+      redirect: "manual",
+    });
+
+    const isRedirect = res.status >= 300 && res.status < 400;
+    // Defensive: a non-redirect response with no `Location` is terminal even
+    // if a stub omits the `headers` object entirely.
+    const location =
+      typeof res.headers?.get === "function"
+        ? res.headers.get("location")
+        : null;
+    if (!isRedirect || !location) {
+      // Terminal response — host already validated above.
+      return res;
+    }
+
+    if (hop >= INSTALL_FETCH_MAX_REDIRECTS) {
+      throw new Error(
+        `Too many redirects (>${INSTALL_FETCH_MAX_REDIRECTS}) installing recipe`,
+      );
+    }
+
+    // Resolve relative redirects against the current URL so a relative
+    // `Location: /foo` isn't treated as an empty hostname.
+    let nextUrl: URL;
+    try {
+      nextUrl = new URL(location, currentUrl);
+    } catch {
+      throw new Error(`Invalid redirect location: "${location}"`);
+    }
+    currentUrl = nextUrl.toString();
+    // Loop re-validates currentUrl at the top before fetching it.
+  }
+
+  // Unreachable: the loop either returns a terminal response or throws.
+  throw new Error("Too many redirects installing recipe");
+}
 
 export interface RecipeRouteDeps {
   setRecipeTrustFn:
@@ -2222,12 +2372,30 @@ export function tryHandleRecipeRoute(
           yamlRes = fetched.response;
         } else {
           try {
-            yamlRes = await fetch(fetchUrl, {
+            // B3-A: manual redirect loop with per-hop SSRF re-validation —
+            // the upfront validateSafeUrl above only pins the first hop, so a
+            // 302 → private IP / IMDS would otherwise bypass it under
+            // `redirect: "follow"`.
+            yamlRes = await fetchFollowingRedirectsSafely(fetchUrl, {
               signal: fetchCtl.signal,
-              redirect: "follow",
             });
           } catch (err) {
             clearTimeout(fetchTimeout);
+            // A redirect to a blocked host is an SSRF attempt, not a generic
+            // network failure — surface it as 403 ssrf_blocked so it isn't
+            // confused with an unreachable upstream.
+            const msg = err instanceof Error ? err.message : String(err);
+            if (/^SSRF guard blocked/.test(msg)) {
+              res.writeHead(403, { "Content-Type": "application/json" });
+              res.end(
+                JSON.stringify({
+                  ok: false,
+                  error: msg,
+                  code: "ssrf_blocked",
+                }),
+              );
+              return;
+            }
             console.error(`[recipes/install] fetch failed:`, err);
             // Network-level error → 502 (upstream unreachable), not 500.
             res.writeHead(502, { "Content-Type": "application/json" });


### PR DESCRIPTION
## GROUP B3-A — Bridge registry/install hardening (SECURITY)

Two defense-in-depth fixes in `src/recipeRoutes.ts`, both written test-first per the Bug Fix Protocol.

### 1. Enum/field sanitization before the registry cache
`isWellFormedTemplatesPayload` previously only checked `Array.isArray(recipes)`. A tampered or future `index.json` entry carrying `risk_level: "critical" | null | 42`, an out-of-enum `approval_behavior`, or a non-numeric `downloads` was cached for 5 minutes and served to every dashboard client. An out-of-enum `risk_level` evaluates falsy downstream (silently reads as "safe") and `RISK_PILL_CLASS[risk_level]` resolves to `undefined`.

Now each entry is **sanitized in place** rather than the whole payload rejected:
- `risk_level` not in `{low,medium,high}` → stripped to `undefined`
- `approval_behavior` not in `{always_ask,ask_on_novel,auto_approve}` → stripped
- `downloads` not a finite number → coerced from a numeric string, else dropped

The entry itself is retained, so a single malformed entry can no longer poison the registry for every client, and out-of-enum risk never silently reads as low/safe (default-deny treats stripped = unknown = elevated).

### 2. Post-redirect SSRF re-check on the non-github HTTPS install path
The bare `fetch(url, { redirect: "follow" })` ran after `validateSafeUrl()`, which explicitly does **not** pin the resolved IP across redirects — a `302` to a private IP / IMDS bypassed the upfront guard. Replaced with `fetchFollowingRedirectsSafely`: a manual `redirect: "manual"` loop, capped at 5 hops, re-validating every hop's host with the canonical async guard (`validateSafeUrl`, which re-resolves DNS) and resolving relative `Location` values against the current URL. Mirrors the CLI `httpsGet` manual loop in `src/commands/recipeInstall.ts`. A blocked-host redirect returns `403 ssrf_blocked`. The github: branch (`fetchGithubInstallFile`) is unchanged.

### Tests
- New unit suite `recipeRoutes-registry-hardening.test.ts` (6 tests) — proven RED before the fix (functions absent), GREEN after.
- New end-to-end `install-post-redirect-ssrf` case in `recipeRoutes-install.test.ts` (302 → loopback rejected without following) — proven RED by temporarily restoring the bare `redirect: "follow"` fetch, GREEN after.
- All sibling recipeRoutes suites green; Biome clean; `tsc` strict clean; fixture-hygiene audit passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)