### PR TITLE
fix(dashboard): registry resilience — sanitize trust fields + GITHUB_TOKEN auth

### DIFF
--- a/dashboard/.env.example
+++ b/dashboard/.env.example
@@ -14,6 +14,14 @@ PATCHWORK_BRIDGE_PORT=3100
 PATCHWORK_BRIDGE_URL=https://patchworkos.com
 PATCHWORK_BRIDGE_TOKEN=your-uuid-token-here
 
+# Marketplace registry fetch auth (optional). The marketplace browse/detail
+# pages fetch index.json + recipe files from GitHub. Unauthenticated GitHub
+# requests are capped at 60/hr per IP — quickly exhausted on a shared NAT,
+# which silently degrades the marketplace to a stale built-in fallback. Set a
+# read-only token (public_repo scope is enough for the public recipes repo) to
+# raise the limit to 5,000/hr. A single ~1s retry on HTTP 429 is built in.
+GITHUB_TOKEN=
+
 # Mobile push notifications (optional — enables PWA push + settings card)
 # URL of the push relay service (services/push-relay/ or hosted at notify.patchwork.dev)
 PUSH_RELAY_URL=https://notify.patchwork.dev

--- a/dashboard/src/lib/__tests__/registry.test.ts
+++ b/dashboard/src/lib/__tests__/registry.test.ts
@@ -403,6 +403,217 @@ describe("fetch* functions use the fallback", () => {
   });
 });
 
+describe("fetchRegistry sanitization (tampered-index resilience)", () => {
+  const INDEX_SRC: ParsedInstallSource = {
+    owner: "patchworkos",
+    repo: "recipes",
+    path: "",
+    ref: "main",
+  };
+  const okText = (body: string) => ({ ok: true, text: async () => body }) as Response;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("strips an out-of-enum risk_level and coerces non-number downloads on recipes", async () => {
+    const rawUrl = rawUrlFor(INDEX_SRC, "index.json");
+    const payload = JSON.stringify({
+      version: "1",
+      updated_at: "2026-06-04",
+      recipes: [
+        {
+          name: "tampered",
+          version: "1.0.0",
+          description: "d",
+          tags: [],
+          connectors: [],
+          install: "github:o/r@main",
+          // SECURITY: a tampered index can set an out-of-enum risk so that
+          // RISK_PILL_CLASS[risk_level] renders `undefined` and the value
+          // reads as not-elevated. Sanitization must drop it.
+          risk_level: "bogus",
+          approval_behavior: "definitely_safe",
+          // Non-number downloads must coerce to a number-or-undefined.
+          downloads: "12",
+        },
+      ],
+    });
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url === rawUrl) return okText(payload);
+      throw new Error(`unexpected url: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const data = await fetchRegistry();
+    const r = data?.recipes[0];
+    expect(r?.risk_level).toBeUndefined();
+    expect(r?.approval_behavior).toBeUndefined();
+    expect(typeof r?.downloads === "number" || r?.downloads === undefined).toBe(true);
+    expect(r?.downloads).not.toBe("12");
+  });
+
+  it("preserves valid enum + numeric downloads unchanged", async () => {
+    const rawUrl = rawUrlFor(INDEX_SRC, "index.json");
+    const payload = JSON.stringify({
+      version: "1",
+      updated_at: "2026-06-04",
+      recipes: [
+        {
+          name: "good",
+          version: "1.0.0",
+          description: "d",
+          tags: [],
+          connectors: [],
+          install: "github:o/r@main",
+          risk_level: "low",
+          approval_behavior: "auto_approve",
+          downloads: 42,
+        },
+      ],
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string) => {
+        if (url === rawUrl) return okText(payload);
+        throw new Error(`unexpected url: ${url}`);
+      }),
+    );
+
+    const data = await fetchRegistry();
+    const r = data?.recipes[0];
+    expect(r?.risk_level).toBe("low");
+    expect(r?.approval_behavior).toBe("auto_approve");
+    expect(r?.downloads).toBe(42);
+  });
+
+  it("sanitizes bundle entries too", async () => {
+    const rawUrl = rawUrlFor(INDEX_SRC, "index.json");
+    const payload = JSON.stringify({
+      version: "2",
+      updated_at: "2026-06-04",
+      recipes: [],
+      bundles: [
+        {
+          name: "@o/b",
+          version: "1.0.0",
+          description: "d",
+          tags: [],
+          connectors: [],
+          install: "github:o/r@main",
+          risk_level: 42,
+          downloads: null,
+        },
+      ],
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string) => {
+        if (url === rawUrl) return okText(payload);
+        throw new Error(`unexpected url: ${url}`);
+      }),
+    );
+
+    const data = await fetchRegistry();
+    const b = data?.bundles?.[0];
+    expect(b?.risk_level).toBeUndefined();
+    expect(typeof b?.downloads === "number" || b?.downloads === undefined).toBe(true);
+  });
+});
+
+describe("fetchGithubFile GITHUB_TOKEN auth", () => {
+  // The fetch mocks below declare only a `url` param, so the recorded
+  // `mock.calls` entries are typed as 1-tuples. `fetchGithubFile` always
+  // passes a second `init` arg at runtime; read it through this helper so the
+  // tuple index stays type-safe and the unused-param lint stays quiet.
+  const initOf = (call: unknown[]): { headers?: Record<string, string> } | undefined =>
+    call[1] as { headers?: Record<string, string> } | undefined;
+
+  const SRC: ParsedInstallSource = {
+    owner: "patchworkos",
+    repo: "recipes",
+    path: "examples/hello",
+    ref: "main",
+  };
+  const RAW = rawUrlFor(SRC, "recipe.yaml");
+  const API = contentsApiUrlFor(SRC, "recipe.yaml");
+  const okText = (body: string) => ({ ok: true, text: async () => body }) as Response;
+  const rateLimited = () => ({ ok: false, status: 429, text: async () => "" }) as Response;
+  const notOk = () => ({ ok: false, status: 404, text: async () => "" }) as Response;
+
+  const origToken = process.env.GITHUB_TOKEN;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+    if (origToken === undefined) delete process.env.GITHUB_TOKEN;
+    else process.env.GITHUB_TOKEN = origToken;
+  });
+
+  it("attaches Authorization: Bearer on the raw fetch when GITHUB_TOKEN is set", async () => {
+    process.env.GITHUB_TOKEN = "ghp_test_token";
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url === RAW) return okText("ok");
+      throw new Error(`unexpected url: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await fetchGithubFile(SRC, "recipe.yaml");
+    const init = initOf(fetchMock.mock.calls[0]);
+    expect(init?.headers?.Authorization).toBe("Bearer ghp_test_token");
+  });
+
+  it("attaches Authorization: Bearer on the Contents-API fallback when GITHUB_TOKEN is set", async () => {
+    process.env.GITHUB_TOKEN = "ghp_test_token";
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url === RAW) return notOk();
+      if (url === API) return okText("ok");
+      throw new Error(`unexpected url: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await fetchGithubFile(SRC, "recipe.yaml");
+    const apiCall = fetchMock.mock.calls.find(([u]) => u === API);
+    const init = apiCall ? initOf(apiCall) : undefined;
+    expect(init?.headers?.Authorization).toBe("Bearer ghp_test_token");
+  });
+
+  it("does NOT attach Authorization when GITHUB_TOKEN is absent", async () => {
+    delete process.env.GITHUB_TOKEN;
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url === RAW) return okText("ok");
+      throw new Error(`unexpected url: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await fetchGithubFile(SRC, "recipe.yaml");
+    const init = initOf(fetchMock.mock.calls[0]);
+    expect(init?.headers?.Authorization).toBeUndefined();
+  });
+
+  it("retries once on HTTP 429 then succeeds", async () => {
+    let rawCalls = 0;
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url === RAW) {
+        rawCalls++;
+        if (rawCalls === 1) return rateLimited();
+        return okText("ok-after-retry");
+      }
+      throw new Error(`unexpected url: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const text = await fetchGithubFile(SRC, "recipe.yaml");
+    expect(text).toBe("ok-after-retry");
+    expect(rawCalls).toBe(2);
+  });
+});
+
 describe("requiresElevatedConfirm (default-deny trust gate)", () => {
   // SECURITY: the all-undefined case is the live-registry case — no
   // recipe in the GitHub index.json carries trust metadata today. It

--- a/dashboard/src/lib/registry.ts
+++ b/dashboard/src/lib/registry.ts
@@ -274,25 +274,45 @@ const REGISTRY_INDEX_SRC: ParsedInstallSource = {
  * sandboxed networks even when `github.com` + `api.github.com` are
  * reachable, which previously broke marketplace browse + install 100%.
  *
- * Returns the file text, or `null` if BOTH endpoints fail. No auth token
- * is attached — both endpoints work unauthenticated for public repos.
- * The Contents API has a 60 req/hr unauthenticated rate limit; that is
- * acceptable for this read path (it is only hit when raw is unreachable).
+ * Returns the file text, or `null` if BOTH endpoints fail.
+ *
+ * Auth: both endpoints work unauthenticated for public repos, but the
+ * unauthenticated rate limit is 60 req/hr per IP — quickly exhausted on a
+ * shared NAT where many dashboard clients poll the same registry, which
+ * then silently degrades to the stale FALLBACK_REGISTRY. When the optional
+ * `GITHUB_TOKEN` env var is present we attach `Authorization: Bearer
+ * <token>` (raises the limit to 5 000 req/hr) and add a single ~1s retry on
+ * HTTP 429 so a transient rate-limit blip doesn't drop straight to fallback.
  */
+async function fetchOnceWithRetry(url: string, init: RequestInit): Promise<Response> {
+  const res = await fetch(url, init);
+  if (res.status === 429) {
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+    return fetch(url, init);
+  }
+  return res;
+}
+
 export async function fetchGithubFile(
   src: ParsedInstallSource,
   file: string,
   opts: FetchOpts = {},
 ): Promise<string | null> {
   const revalidate = opts.revalidate ?? 300;
-  const init = {
-    next: { revalidate },
-    signal: opts.signal,
-  } as RequestInit;
+  // Optional auth token — raises the GitHub rate limit from 60 to 5 000
+  // req/hr, preventing silent fallback to the stale registry on shared NAT.
+  const token = process.env.GITHUB_TOKEN;
+  const authHeader: Record<string, string> = token
+    ? { Authorization: `Bearer ${token}` }
+    : {};
 
   // 1. raw.githubusercontent.com (preferred)
   try {
-    const res = await fetch(rawUrlFor(src, file), init);
+    const res = await fetchOnceWithRetry(rawUrlFor(src, file), {
+      next: { revalidate },
+      signal: opts.signal,
+      headers: { ...authHeader },
+    } as RequestInit);
     if (res.ok) return await res.text();
   } catch {
     // fall through to the API fallback
@@ -300,9 +320,10 @@ export async function fetchGithubFile(
 
   // 2. api.github.com Contents API (fallback for raw-blocked networks)
   try {
-    const res = await fetch(contentsApiUrlFor(src, file), {
-      ...init,
-      headers: { Accept: "application/vnd.github.raw" },
+    const res = await fetchOnceWithRetry(contentsApiUrlFor(src, file), {
+      next: { revalidate },
+      signal: opts.signal,
+      headers: { Accept: "application/vnd.github.raw", ...authHeader },
     } as RequestInit);
     if (res.ok) return await res.text();
   } catch {
@@ -312,14 +333,74 @@ export async function fetchGithubFile(
   return null;
 }
 
+const RISK_LEVELS: readonly RiskLevel[] = ["low", "medium", "high"];
+const APPROVAL_BEHAVIORS: readonly ApprovalBehavior[] = [
+  "always_ask",
+  "ask_on_novel",
+  "auto_approve",
+];
+
+/**
+ * Runtime-sanitize one recipe/bundle entry's untrusted trust fields.
+ *
+ * `fetchRegistry` parses an `index.json` served from a public GitHub repo —
+ * a tampered or MITM-flipped index can carry an out-of-enum `risk_level`
+ * (`"bogus"`, `42`, `null`) or a non-number `downloads` (`"12"`). Left
+ * unchecked, `RISK_PILL_CLASS[risk_level]` renders `class="pill undefined"`
+ * and an out-of-enum risk reads as falsy → silently NOT elevated in the
+ * trust gate. We strip any value outside the known enum (so it becomes
+ * `undefined`, which `requiresElevatedConfirm` correctly treats as elevated)
+ * and coerce `downloads` to a finite number or `undefined`. Mutates in place
+ * and returns the same reference. Conservative: unknown extra fields are
+ * left untouched.
+ */
+function sanitizeRegistryEntry<T extends TrustMetadata & { downloads?: unknown }>(
+  entry: T,
+): T {
+  if (
+    entry.risk_level !== undefined &&
+    !RISK_LEVELS.includes(entry.risk_level as RiskLevel)
+  ) {
+    entry.risk_level = undefined;
+  }
+  if (
+    entry.approval_behavior !== undefined &&
+    !APPROVAL_BEHAVIORS.includes(entry.approval_behavior as ApprovalBehavior)
+  ) {
+    entry.approval_behavior = undefined;
+  }
+  const dl = entry.downloads;
+  if (typeof dl !== "number" || !Number.isFinite(dl)) {
+    entry.downloads = typeof dl === "string" && dl.trim() !== "" && Number.isFinite(Number(dl))
+      ? Number(dl)
+      : undefined;
+  }
+  return entry;
+}
+
 export async function fetchRegistry(opts: FetchOpts = {}): Promise<RegistryData | null> {
   const text = await fetchGithubFile(REGISTRY_INDEX_SRC, "index.json", opts);
   if (text === null) return null;
+  let data: RegistryData;
   try {
-    return JSON.parse(text) as RegistryData;
+    data = JSON.parse(text) as RegistryData;
   } catch {
     return null;
   }
+  // Sanitize the untrusted trust fields BEFORE returning so a tampered
+  // index.json can't make RISK_PILL_CLASS[risk_level] render undefined or
+  // smuggle an out-of-enum risk past the elevation gate.
+  if (Array.isArray(data.recipes)) {
+    for (const r of data.recipes) {
+      if (r && typeof r === "object") sanitizeRegistryEntry(r);
+    }
+  }
+  if (Array.isArray(data.bundles)) {
+    for (const b of data.bundles) {
+      if (b && typeof b === "object") sanitizeRegistryEntry(b);
+    }
+  }
+  return data;
 }
 
 export async function fetchManifest(


### PR DESCRIPTION
## What

Hardens `dashboard/src/lib/registry.ts` against two marketplace resilience gaps surfaced in the 2026-06-04 investigation (Group B3-B).

### 1. Validate before the cast (security)
`fetchRegistry` did a bare `JSON.parse(text) as RegistryData`. A tampered / MITM-flipped `index.json` could carry an out-of-enum `risk_level` (`"bogus"`, `42`, `null`), an out-of-enum `approval_behavior`, or a non-number `downloads` (`"12"`) — cached for 5 min and served to every client. The consequences:
- `RISK_PILL_CLASS[risk_level]` resolves to `undefined` → renders `class="pill undefined"`.
- An out-of-enum risk evaluates falsy → silently reads as **not elevated** in the trust gate.

Added a conservative `sanitizeRegistryEntry` pass run over every recipe **and** bundle before return: strips `risk_level` / `approval_behavior` values outside the known enum to `undefined` (which `requiresElevatedConfirm` correctly treats as elevated), and coerces `downloads` to a finite number or `undefined`. Reuses the existing `TrustMetadata` typing; unknown extra fields are left untouched.

### 2. Authenticate the GitHub fetches (reliability)
The raw-CDN + `api.github.com` Contents-API fetches in `fetchGithubFile` were unauthenticated → 60 req/hr per IP, quickly exhausted on a shared NAT → silent fallback to the stale built-in registry. Now reads optional `GITHUB_TOKEN` and attaches `Authorization: Bearer <token>` to **both** endpoints when present (raises the limit to 5,000 req/hr), plus a single ~1s retry on HTTP 429 via a `fetchOnceWithRetry` wrapper. Documented the env var in `dashboard/.env.example`.

## Test-first proof
New tests added to `registry.test.ts`. Before the fix: 5 failed (strip out-of-enum risk_level, strip out-of-enum approval_behavior, sanitize bundle entries, Bearer-on-raw, Bearer-on-API-fallback, 429-retry), 2 deliberate controls passed. After: all 44 pass.

## Gates
- `cd dashboard && npx tsc --noEmit` — clean
- `cd dashboard && npx next lint` on the two changed src files — clean
- `cd dashboard && npx vitest run src/lib/__tests__/registry.test.ts` — 44/44

Did not modify the locked PR #905 files. `page.tsx` downloads consumers already guard with `recipe.downloads > 0`, so runtime-undefined coercion is safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)