### PR TITLE
fix(dashboard): per-session rate limit on the recipe-install proxy (B3-C)

### DIFF
--- a/dashboard/src/app/api/bridge/recipes/install/__tests__/route.test.ts
+++ b/dashboard/src/app/api/bridge/recipes/install/__tests__/route.test.ts
@@ -8,8 +8,9 @@
  * validate, but the dashboard layer should reject obviously bad input
  * before opening the bridge socket.
  */
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { _resetRateLimitForTests, _rateLimitConfig } from "@/lib/authRateLimit";
 import { POST } from "../route";
 
 const bridgeFetchMock = vi.fn(
@@ -24,16 +25,27 @@ vi.mock("@/lib/bridge", () => ({
     bridgeFetchMock(path, init),
 }));
 
-function makeReq(body: string): Request {
+function makeReq(body: string, extraHeaders?: Record<string, string>): Request {
   return new Request("https://dashboard.local/api/bridge/recipes/install", {
     method: "POST",
     headers: {
       "content-type": "application/json",
       "sec-fetch-site": "same-origin",
+      ...extraHeaders,
     },
     body,
   });
 }
+
+// The install route applies a per-session/per-IP call-count limiter whose
+// state is a module singleton. Reset it around every test so accumulated
+// calls from earlier specs can't trip the limiter for unrelated cases.
+beforeEach(() => {
+  _resetRateLimitForTests();
+});
+afterEach(() => {
+  _resetRateLimitForTests();
+});
 
 describe("POST /api/bridge/recipes/install — source validation", () => {
   it("rejects non-JSON bodies with 400 / bad_json", async () => {
@@ -165,6 +177,56 @@ describe("POST /api/bridge/recipes/install — content-type mirroring", () => {
     );
     expect(res.status).toBe(200);
     expect(res.headers.get("content-type")).toBe("application/json");
+  });
+});
+
+describe("POST /api/bridge/recipes/install — per-session rate limit", () => {
+  const goodBody = JSON.stringify({
+    source: "github:patchworkos/recipes/recipes/morning-brief",
+  });
+
+  it("returns 429 + Retry-After once a session exceeds the call limit", async () => {
+    bridgeFetchMock.mockClear();
+    // Same session cookie on every call → same bucket.
+    const cookie = "patchwork_session=v1.9999999999999.sig-abc";
+    const limit = _rateLimitConfig.MAX_CALLS;
+
+    // Calls up to the limit pass through to the bridge (mocked 200).
+    for (let i = 0; i < limit; i++) {
+      const res = await POST(makeReq(goodBody, { cookie }));
+      expect(res.status).toBe(200);
+    }
+    expect(bridgeFetchMock).toHaveBeenCalledTimes(limit);
+
+    // The next call is rejected BEFORE forwarding to the bridge.
+    const blocked = await POST(makeReq(goodBody, { cookie }));
+    expect(blocked.status).toBe(429);
+    const retryAfter = blocked.headers.get("retry-after");
+    expect(retryAfter).not.toBeNull();
+    expect(Number.parseInt(retryAfter ?? "0", 10)).toBeGreaterThan(0);
+    const body = (await blocked.json()) as { error?: string; code?: string };
+    expect(body.code).toBe("rate_limited");
+    expect(typeof body.error).toBe("string");
+    // Bridge must NOT have been called for the over-limit request.
+    expect(bridgeFetchMock).toHaveBeenCalledTimes(limit);
+  });
+
+  it("isolates distinct sessions — one saturated cookie does not block another", async () => {
+    bridgeFetchMock.mockClear();
+    const limit = _rateLimitConfig.MAX_CALLS;
+    const noisy = "patchwork_session=v1.9999999999999.noisy";
+    const quiet = "patchwork_session=v1.9999999999999.quiet";
+
+    for (let i = 0; i <= limit; i++) {
+      await POST(makeReq(goodBody, { cookie: noisy }));
+    }
+    // Noisy session is now blocked.
+    const noisyRes = await POST(makeReq(goodBody, { cookie: noisy }));
+    expect(noisyRes.status).toBe(429);
+
+    // A different session still gets through.
+    const quietRes = await POST(makeReq(goodBody, { cookie: quiet }));
+    expect(quietRes.status).toBe(200);
   });
 });
 

--- a/dashboard/src/app/api/bridge/recipes/install/route.ts
+++ b/dashboard/src/app/api/bridge/recipes/install/route.ts
@@ -1,4 +1,8 @@
+import { createHash } from "node:crypto";
+
+import { checkRateLimit } from "@/lib/authRateLimit";
 import { bridgeFetch } from "@/lib/bridge";
+import { clientKey } from "@/lib/clientIp";
 import { requireSameOrigin } from "@/lib/csrf";
 import {
   BRIDGE_BODY_CAPS,
@@ -6,6 +10,7 @@ import {
   readBodyWithCap,
 } from "@/lib/readBodyWithCap";
 import { assertValidInstallSource } from "@/lib/registry";
+import { SESSION_COOKIE_NAME } from "@/lib/session";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -14,16 +19,59 @@ function jsonError(
   status: number,
   error: string,
   code?: string,
+  extraHeaders?: Record<string, string>,
 ): Response {
   return new Response(JSON.stringify(code ? { error, code } : { error }), {
     status,
-    headers: { "content-type": "application/json" },
+    headers: { "content-type": "application/json", ...extraHeaders },
   });
+}
+
+/**
+ * Derive an opaque per-caller key for the install rate limiter.
+ *
+ * Preferred identity is the session cookie — hashed (SHA-256, truncated) so
+ * the raw token never lives in the limiter's in-memory map. When no session
+ * cookie is present (e.g. unauthenticated dev deploy, or a malformed
+ * request), fall back to the coarse client-IP bucket from clientKey() so the
+ * route is never left completely unbounded. clientKey returns "unknown"
+ * without a trusted proxy, which collapses to a single shared global bucket
+ * — intentionally conservative.
+ */
+function rateLimitKey(req: Request): string {
+  const cookieHeader = req.headers.get("cookie") ?? "";
+  for (const part of cookieHeader.split(";")) {
+    const eq = part.indexOf("=");
+    if (eq === -1) continue;
+    const name = part.slice(0, eq).trim();
+    if (name === SESSION_COOKIE_NAME) {
+      const value = part.slice(eq + 1).trim();
+      if (value) {
+        const digest = createHash("sha256").update(value).digest("hex");
+        return `sess:${digest.slice(0, 32)}`;
+      }
+    }
+  }
+  return `ip:${clientKey(req.headers)}`;
 }
 
 export async function POST(req: Request): Promise<Response> {
   const guard = requireSameOrigin(req);
   if (guard) return guard;
+
+  // Per-session call-count cap BEFORE any bridge work. Each install triggers
+  // a GitHub fetch + filesystem write on the bridge; an unbounded POST loop
+  // (stolen cookie / insider) can exhaust disk or GitHub's 60 req/hr limit
+  // for everyone. See B3-C in docs/marketplace-investigation-2026-06-04.md.
+  const rl = checkRateLimit(rateLimitKey(req));
+  if (rl.limited) {
+    return jsonError(
+      429,
+      "Too many install requests — slow down and retry shortly.",
+      "rate_limited",
+      { "retry-after": String(rl.retryAfterSec) },
+    );
+  }
 
   const read = await readBodyWithCap(req, BRIDGE_BODY_CAPS.install);
   if (!read.ok) return bodyTooLargeResponse(BRIDGE_BODY_CAPS.install);

--- a/dashboard/src/lib/__tests__/callRateLimit.test.ts
+++ b/dashboard/src/lib/__tests__/callRateLimit.test.ts
@@ -1,0 +1,108 @@
+/** @vitest-environment node */
+/**
+ * Unit tests for the generic call-count rate limiter in authRateLimit.ts.
+ *
+ * Distinct from the login failure-tracker in the same module: this limiter
+ * counts ALL calls (not just failures) in a sliding window and is used to
+ * cap expensive operations (e.g. the recipe-install proxy, which triggers a
+ * GitHub fetch + filesystem write per call). See B3-C security item in
+ * docs/marketplace-investigation-2026-06-04.md.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+let mod: typeof import("../authRateLimit");
+
+beforeEach(async () => {
+  mod = await import("../authRateLimit");
+  mod._resetRateLimitForTests();
+});
+
+afterEach(() => {
+  mod._resetRateLimitForTests();
+});
+
+describe("callRateLimit (generic call-count limiter)", () => {
+  it("allows calls up to the limit within the window", () => {
+    const key = "session-a";
+    const now = 1_000_000;
+    for (let i = 0; i < mod._rateLimitConfig.MAX_CALLS; i++) {
+      const r = mod.checkRateLimit(key, now + i);
+      expect(r.limited).toBe(false);
+    }
+  });
+
+  it("blocks the call that exceeds the limit and reports Retry-After", () => {
+    const key = "session-a";
+    const now = 1_000_000;
+    let last: ReturnType<typeof mod.checkRateLimit> = { limited: false };
+    // First MAX_CALLS calls pass; the next one is blocked.
+    for (let i = 0; i <= mod._rateLimitConfig.MAX_CALLS; i++) {
+      last = mod.checkRateLimit(key, now + i);
+    }
+    expect(last.limited).toBe(true);
+    if (last.limited) {
+      expect(last.retryAfterSec).toBeGreaterThan(0);
+      expect(last.retryAfterSec).toBeLessThanOrEqual(
+        Math.ceil(mod._rateLimitConfig.WINDOW_MS / 1000),
+      );
+    }
+  });
+
+  it("counts each call (not just failures) — repeated successes still trip", () => {
+    const key = "session-a";
+    const now = 1_000_000;
+    let blocked = false;
+    for (let i = 0; i < mod._rateLimitConfig.MAX_CALLS + 5; i++) {
+      const r = mod.checkRateLimit(key, now + i);
+      if (r.limited) blocked = true;
+    }
+    expect(blocked).toBe(true);
+  });
+
+  it("frees up capacity after the sliding window passes", () => {
+    const key = "session-a";
+    const t0 = 1_000_000;
+    // Saturate the window.
+    for (let i = 0; i < mod._rateLimitConfig.MAX_CALLS; i++) {
+      mod.checkRateLimit(key, t0 + i);
+    }
+    // One more inside the window is blocked.
+    expect(mod.checkRateLimit(key, t0 + mod._rateLimitConfig.MAX_CALLS).limited).toBe(
+      true,
+    );
+    // After the window fully elapses, a fresh call is allowed again.
+    const after = t0 + mod._rateLimitConfig.WINDOW_MS + 1;
+    expect(mod.checkRateLimit(key, after).limited).toBe(false);
+  });
+
+  it("tracks keys independently — one saturated key does not block another", () => {
+    const t0 = 1_000_000;
+    for (let i = 0; i <= mod._rateLimitConfig.MAX_CALLS; i++) {
+      mod.checkRateLimit("noisy", t0 + i);
+    }
+    expect(mod.checkRateLimit("noisy", t0 + 1).limited).toBe(true);
+    // A different key has a clean window.
+    expect(mod.checkRateLimit("quiet", t0 + 1).limited).toBe(false);
+  });
+
+  it("_resetRateLimitForTests clears all state", () => {
+    const key = "session-a";
+    const t0 = 1_000_000;
+    for (let i = 0; i <= mod._rateLimitConfig.MAX_CALLS; i++) {
+      mod.checkRateLimit(key, t0 + i);
+    }
+    expect(mod.checkRateLimit(key, t0 + 1).limited).toBe(true);
+    mod._resetRateLimitForTests();
+    expect(mod.checkRateLimit(key, t0 + 1).limited).toBe(false);
+  });
+
+  it("evicts the oldest entry when MAX_ENTRIES is exceeded (memory bound)", () => {
+    const t0 = 1_000_000;
+    mod.checkRateLimit("first", t0);
+    for (let i = 0; i < mod._rateLimitConfig.MAX_ENTRIES; i++) {
+      mod.checkRateLimit(`k-${i}`, t0 + i + 1);
+    }
+    // "first" was evicted, so it gets a fresh window (not pre-populated).
+    expect(mod.checkRateLimit("first", t0 + 1).limited).toBe(false);
+  });
+});

--- a/dashboard/src/lib/authRateLimit.ts
+++ b/dashboard/src/lib/authRateLimit.ts
@@ -108,3 +108,87 @@ export const _config = {
   LOCKOUT_MS,
   MAX_ENTRIES,
 };
+
+/* ------------------------------------------------------------------------- *
+ * Generic call-count rate limiter (NOT the failure tracker above).
+ *
+ * The failure tracker only records auth *failures* — a successful login
+ * clears the entry, so it cannot bound the rate of *successful* expensive
+ * calls. The recipe-install proxy needs the opposite: every call is
+ * expensive (a GitHub fetch + filesystem write on the bridge), so a stolen
+ * cookie or insider can hammer it at full speed and exhaust disk or GitHub's
+ * unauthenticated 60 req/hr limit for everyone. This is a separate sliding-
+ * window counter that counts ALL calls within a window, keyed by an opaque
+ * caller identity (a hash of the session cookie, or a coarse IP fallback).
+ *
+ * Same single-process scope caveat as the failure tracker.
+ * ------------------------------------------------------------------------- */
+
+const MAX_CALLS = parsePositiveInt(
+  process.env.DASHBOARD_INSTALL_RATE_MAX,
+  30,
+);
+const RATE_WINDOW_MS = parsePositiveInt(
+  process.env.DASHBOARD_INSTALL_RATE_WINDOW_MS,
+  60 * 1000,
+);
+const RATE_MAX_ENTRIES = 10_000;
+
+// Sliding window of call timestamps (ms) per key.
+const callStore = new Map<string, number[]>();
+
+export type RateLimitResult =
+  | { limited: false }
+  | { limited: true; retryAfterSec: number };
+
+/**
+ * Record a call against `key` and report whether it should be rejected.
+ *
+ * Returns `{ limited: false }` when the call is within budget (the call IS
+ * counted), or `{ limited: true, retryAfterSec }` when the window is already
+ * saturated (the call is NOT counted — a rejected call must not extend the
+ * lockout, or a caller hammering a saturated bucket would never recover).
+ *
+ * `now` is injectable for deterministic tests.
+ */
+export function checkRateLimit(
+  key: string,
+  now: number = Date.now(),
+): RateLimitResult {
+  const cutoff = now - RATE_WINDOW_MS;
+  let calls = callStore.get(key);
+  if (calls) {
+    calls = calls.filter((t) => t > cutoff);
+  } else {
+    if (callStore.size >= RATE_MAX_ENTRIES) {
+      const oldest = callStore.keys().next().value;
+      if (oldest !== undefined) callStore.delete(oldest);
+    }
+    calls = [];
+  }
+
+  if (calls.length >= MAX_CALLS) {
+    // Saturated. Persist the pruned list so the entry doesn't grow, but do
+    // NOT add this call. retryAfterSec = time until the oldest in-window
+    // call ages out, freeing one slot.
+    callStore.set(key, calls);
+    const oldest = calls[0] ?? now;
+    const freesAt = oldest + RATE_WINDOW_MS;
+    const retryAfterSec = Math.max(1, Math.ceil((freesAt - now) / 1000));
+    return { limited: true, retryAfterSec };
+  }
+
+  calls.push(now);
+  callStore.set(key, calls);
+  return { limited: false };
+}
+
+export function _resetRateLimitForTests(): void {
+  callStore.clear();
+}
+
+export const _rateLimitConfig = {
+  MAX_CALLS,
+  WINDOW_MS: RATE_WINDOW_MS,
+  MAX_ENTRIES: RATE_MAX_ENTRIES,
+};


### PR DESCRIPTION
## Problem (SECURITY — B3-C)

The `/api/bridge/recipes/install` POST proxy had no rate limit. Any authenticated session could POST at full speed, and each call triggers a GitHub fetch + filesystem write on the bridge. A stolen cookie or an insider could exhaust local disk or burn through GitHub's 60 req/hr unauthenticated limit, degrading the marketplace for everyone.

The existing `authRateLimit.ts` only tracks failure timestamps for the login form (a successful login clears the entry) — it cannot bound the rate of *successful* expensive calls, so a new generic call-count helper was required rather than extending the failure tracker.

## Change

- New generic limiter in `dashboard/src/lib/authRateLimit.ts`: a sliding-window call-count bucket (`checkRateLimit`, `_resetRateLimitForTests`, `_rateLimitConfig`) with its own store, separate from the untouched failure tracker. Counts every call in a window; default 30 calls / 60s (env-overridable: `DASHBOARD_INSTALL_RATE_MAX`, `DASHBOARD_INSTALL_RATE_WINDOW_MS`); 10k-entry memory bound; injectable clock for deterministic tests. Over-limit calls are not counted (so a saturated bucket recovers) and `retryAfterSec` reflects when the oldest in-window call ages out.
- Wired into the install POST at the top of the handler — after the CSRF guard, before the body read and the bridge forward. Keyed by `sha256(patchwork_session cookie)` (raw token never stored), falling back to a coarse `clientKey()` IP/global bucket when no session cookie is present, so the route is never unbounded.
- On exceed: HTTP 429 + `Retry-After` header + `{error, code:\"rate_limited\"}` JSON consistent with the route's existing error shape.

## Tests (red → green)

- New `dashboard/src/lib/__tests__/callRateLimit.test.ts` — unit coverage of the limiter (limit boundary, Retry-After, per-key isolation, window expiry, eviction, reset). Failed red before the helper existed.
- Extended `dashboard/src/app/api/bridge/recipes/install/__tests__/route.test.ts` — under-threshold calls forward to the (mocked) bridge and return 200; the over-threshold call returns 429 + Retry-After + `code:rate_limited` and is NOT forwarded; distinct session cookies are isolated. Failed red (no 429 ever) before the route change.

Dashboard `tsc --noEmit` clean; ESLint clean (only pre-existing unrelated warnings in the test mock). Existing failure-tracker tests unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)