### PR TITLE
fix(recipes): Gemini API spend no longer fails open against usdMax

### DIFF
--- a/src/recipes/__tests__/runBudget.test.ts
+++ b/src/recipes/__tests__/runBudget.test.ts
@@ -117,6 +117,31 @@ describe("RunBudget — usdMax (cost-routing Phase 3)", () => {
     expect(a.reason).toMatch(/usdMax=\$10/);
   });
 
+  it("bills the gemini API driver against usdMax (does not fail open)", () => {
+    const b = new RunBudget({ usdMax: 10 }, TABLE);
+    // m1 = $1/1M each side → 5M in + 5M out = $10.00.
+    b.reconcile(
+      "gemini",
+      { inputTokens: 5_000_000, outputTokens: 5_000_000 },
+      "m1",
+    );
+    expect(b.totals().usd).toBeCloseTo(10, 6);
+    expect(b.totals().usdBreached).toBe(true);
+    const a = b.admit();
+    expect(a.admitted).toBe(false);
+    expect(a.reason).toMatch(/budget_exceeded/);
+    // No "not-billed" fail-open warning for gemini.
+    expect(b.warnings().some((w) => /does not incur metered/.test(w))).toBe(
+      false,
+    );
+  });
+
+  it("quoteUsd prices a gemini call (mirrors reconcile billing)", () => {
+    const b = new RunBudget({ usdMax: 10 }, TABLE);
+    const q = b.quoteUsd("gemini", "m1", 1_000_000, 0); // $1
+    expect(q).toBeCloseTo(1, 6);
+  });
+
   it("admits under the cap and reports usd / usdRemaining", () => {
     const b = new RunBudget({ usdMax: 10 }, TABLE);
     b.reconcile("openai", { inputTokens: 1_000_000, outputTokens: 0 }, "m1"); // $1

--- a/src/recipes/runBudget.ts
+++ b/src/recipes/runBudget.ts
@@ -33,13 +33,14 @@ import type { BudgetPolicy } from "./schema.js";
 
 /**
  * Drivers that incur real, metered, per-token API billing — the ONLY ones a
- * USD cap is enforced against. Subscription/CLI drivers (subprocess Claude/
- * Gemini) report no usage and never reach the pricing path; `local`
+ * USD cap is enforced against. Includes the metered Gemini API driver
+ * (stamped "gemini"); the subscription/CLI subprocess drivers report no usage
+ * and never reach the pricing path; `local`
  * (self-hosted Ollama / LM Studio) DOES report usage but costs no real money,
  * so it must not be priced at notional API rates and halted on spend that
  * never happened. Anything not in this set fails open with a one-time notice.
  */
-const BILLABLE_DRIVERS = new Set(["anthropic", "openai", "grok"]);
+const BILLABLE_DRIVERS = new Set(["anthropic", "openai", "grok", "gemini"]);
 
 /** Rough chars-per-token used for the opt-in unmeasured-driver USD estimate. */
 const ESTIMATE_CHARS_PER_TOKEN = 4;


### PR DESCRIPTION
## Problem
The metered Gemini API driver (stamped `servedBy.driver="gemini"`) was missing from `BILLABLE_DRIVERS` in `src/recipes/runBudget.ts`. As a result:
- `reconcile()` routed gemini usage into the not-billed fail-open branch — Gemini API spend was never counted toward `budget.usdMax`.
- `quoteUsd()` returned `undefined` for gemini, so cost-aware routing treated gemini calls as free.

This is a cost/security fail-open: a recipe with a USD cap on a gemini driver could spend unbounded real money.

## Fix
- Add `"gemini"` to `BILLABLE_DRIVERS`. The price table already carries gemini model prices, so no alias was needed.
- Refresh the stale doc comment that incorrectly lumped Gemini in with subscription-only drivers.

`quoteUsd` required no further change — once gemini clears the billable guard it prices the explicit model the same as openai/grok.

## Test (red → green)
Added two cases to `src/recipes/__tests__/runBudget.test.ts`:
- `reconcile("gemini", usage, model)` is billed, trips `usdBreached`, halts admission, and emits no "does not incur metered" fail-open warning.
- `quoteUsd("gemini", model, …)` returns a non-zero quote.

Both FAILED before the one-line fix (usd=0 / quote=undefined) and PASS after. Full suite: 29/29 green. Lint (biome) and typecheck (tsconfig.tests.core.json strict) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)