### PR TITLE
fix(recipes): recipe-validation parity — root-vars, reserved-case, driver-key, dup-id, schema vars

### DIFF
--- a/src/recipes/__tests__/schemaGenerator.test.ts
+++ b/src/recipes/__tests__/schemaGenerator.test.ts
@@ -194,6 +194,28 @@ describe("schemaGenerator", () => {
     });
   });
 
+  it("includes trigger.vars / trigger.inputs array schema", () => {
+    const schemas = generateSchemaSet();
+    const recipeSchema = schemas.recipe as {
+      properties?: {
+        trigger?: {
+          properties?: Record<string, { type?: string; items?: unknown }>;
+        };
+      };
+    };
+    const trigProps = recipeSchema.properties?.trigger?.properties;
+    expect(trigProps?.vars).toMatchObject({ type: "array" });
+    expect(trigProps?.inputs).toMatchObject({ type: "array" });
+    const varItems = trigProps?.vars?.items as {
+      required?: string[];
+      properties?: { name?: { pattern?: string } };
+    };
+    expect(varItems.required).toContain("name");
+    expect(varItems.properties?.name?.pattern).toBe(
+      "^[A-Za-z_][A-Za-z0-9_]{0,63}$",
+    );
+  });
+
   it("includes chained recipe trigger and nested recipe step support", () => {
     const schemas = generateSchemaSet();
     const recipeSchema = schemas.recipe as {

--- a/src/recipes/__tests__/validationParity.test.ts
+++ b/src/recipes/__tests__/validationParity.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Recipe-validation parity gaps (Group R2). Each block reproduces a real
+ * deficiency in `validateRecipeDefinition` before its fix:
+ *   1. root-level `vars:` silently dropped at runtime (only trigger.vars /
+ *      trigger.inputs are read — PR#259 trap) → no warning.
+ *   2. reserved-var case mismatch — `yyyy` shadows the built-in date key but
+ *      passed the reserved-name gate (set stored UPPERCASE, lookup lowercased).
+ *   3. driver: claude|anthropic with no ANTHROPIC_API_KEY in env → no warning
+ *      (the "driver:claude = API not subscription" trap).
+ *   4. duplicate step id → never rejected.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { validateRecipeDefinition } from "../validation.js";
+
+const baseRecipe = {
+  name: "parity-test",
+  description: "test recipe",
+  trigger: { type: "manual" as const },
+  steps: [{ id: "s1", agent: { prompt: "hi" } }],
+};
+
+describe("root-level vars warning", () => {
+  it("warns that a top-level `vars` key is ignored at runtime", () => {
+    const result = validateRecipeDefinition({
+      ...baseRecipe,
+      vars: { foo: "bar" },
+    });
+    const issue = result.issues.find((i) => i.code === "root-vars-ignored");
+    expect(issue).toBeDefined();
+    expect(issue?.level).toBe("warning");
+  });
+
+  it("does not warn when there is no root vars key", () => {
+    const result = validateRecipeDefinition(baseRecipe);
+    expect(result.issues.some((i) => i.code === "root-vars-ignored")).toBe(
+      false,
+    );
+  });
+});
+
+describe("reserved-var case mismatch", () => {
+  it.each([
+    "yyyy",
+    "YYYY",
+    "iso_now",
+    "Hh",
+  ])("rejects date-key var name regardless of case: %s", (name) => {
+    const result = validateRecipeDefinition({
+      ...baseRecipe,
+      trigger: { type: "manual", vars: [{ name }] },
+    });
+    const errors = result.issues.filter((i) => i.level === "error");
+    expect(
+      errors.some((e) => e.message.includes("shadows a reserved built-in")),
+    ).toBe(true);
+  });
+});
+
+describe("driver-api-key preflight", () => {
+  const saved = process.env.ANTHROPIC_API_KEY;
+  beforeEach(() => {
+    delete process.env.ANTHROPIC_API_KEY;
+  });
+  afterEach(() => {
+    if (saved === undefined) delete process.env.ANTHROPIC_API_KEY;
+    else process.env.ANTHROPIC_API_KEY = saved;
+  });
+
+  it.each([
+    "claude",
+    "anthropic",
+  ])("warns when driver:%s is used with no ANTHROPIC_API_KEY", (driver) => {
+    const result = validateRecipeDefinition({
+      ...baseRecipe,
+      steps: [{ id: "s1", agent: { prompt: "hi", driver } }],
+    });
+    const issue = result.issues.find(
+      (i) => i.code === "driver-api-key-required",
+    );
+    expect(issue).toBeDefined();
+    expect(issue?.level).toBe("warning");
+  });
+
+  it("does not warn when ANTHROPIC_API_KEY is set", () => {
+    process.env.ANTHROPIC_API_KEY = "sk-test";
+    const result = validateRecipeDefinition({
+      ...baseRecipe,
+      steps: [{ id: "s1", agent: { prompt: "hi", driver: "claude" } }],
+    });
+    expect(
+      result.issues.some((i) => i.code === "driver-api-key-required"),
+    ).toBe(false);
+  });
+
+  it("does not warn for subprocess driver", () => {
+    const result = validateRecipeDefinition({
+      ...baseRecipe,
+      steps: [{ id: "s1", agent: { prompt: "hi", driver: "subprocess" } }],
+    });
+    expect(
+      result.issues.some((i) => i.code === "driver-api-key-required"),
+    ).toBe(false);
+  });
+});
+
+describe("duplicate step id", () => {
+  it("rejects two steps with the same id", () => {
+    const result = validateRecipeDefinition({
+      ...baseRecipe,
+      steps: [
+        { id: "dup", agent: { prompt: "a" } },
+        { id: "dup", agent: { prompt: "b" } },
+      ],
+    });
+    const issue = result.issues.find((i) => i.code === "duplicate-step-id");
+    expect(issue).toBeDefined();
+    expect(issue?.level).toBe("error");
+  });
+
+  it("accepts distinct step ids", () => {
+    const result = validateRecipeDefinition({
+      ...baseRecipe,
+      steps: [
+        { id: "one", agent: { prompt: "a" } },
+        { id: "two", agent: { prompt: "b" } },
+      ],
+    });
+    expect(result.issues.some((i) => i.code === "duplicate-step-id")).toBe(
+      false,
+    );
+  });
+});

--- a/src/recipes/names.ts
+++ b/src/recipes/names.ts
@@ -64,15 +64,20 @@ export const RECIPE_VAR_NAME_RE = /^[A-Za-z_][A-Za-z0-9_]{0,63}$/;
  * data silently. The simple-identifier subset of
  * `registerRecipeContextKeys` + `extractTemplateExpressions builtinKeys`
  * (see `src/recipes/validation.ts`).
+ *
+ * Entries are stored LOWERCASE: the validator (and the dashboard mirror)
+ * look up `name.toLowerCase()`, so the date-format keys (`yyyy`, `iso_now`,
+ * `hh`, `mm`, `ss`) must be lowercase here or they would never match —
+ * letting a `yyyy`/`YYYY` var silently shadow the built-in date key.
  */
 export const RESERVED_VAR_NAMES: ReadonlySet<string> = new Set([
   "date",
   "time",
-  "YYYY",
-  "ISO_NOW",
-  "HH",
-  "MM",
-  "SS",
+  "yyyy",
+  "iso_now",
+  "hh",
+  "mm",
+  "ss",
   "this",
   "hash",
   "message",

--- a/src/recipes/schemaGenerator.ts
+++ b/src/recipes/schemaGenerator.ts
@@ -500,7 +500,64 @@ function generateRecipeSchema(
           },
           filter: {
             type: "string",
-            description: "File filter pattern (for file_watch trigger)",
+            description:
+              "File filter pattern (for file_watch trigger). For on_test_run triggers, one of: any | failure | pass-after-fail.",
+          },
+          vars: {
+            type: "array",
+            description:
+              "Declared input variables resolvable as {{name}} in steps. Place declared variables here (NOT at recipe root — top-level vars are ignored at runtime).",
+            items: {
+              type: "object",
+              required: ["name"],
+              properties: {
+                name: {
+                  type: "string",
+                  pattern: "^[A-Za-z_][A-Za-z0-9_]{0,63}$",
+                  description:
+                    "Variable name (letter/underscore start; letters, digits, underscores; max 64 chars).",
+                },
+                required: {
+                  type: "boolean",
+                  description: "Whether the variable must be supplied.",
+                },
+                default: {
+                  description: "Default value when not supplied.",
+                },
+                description: {
+                  type: "string",
+                  description: "Human-readable description of the variable.",
+                },
+              },
+            },
+          },
+          inputs: {
+            type: "array",
+            description:
+              "Alias for trigger.vars — declared input variables resolvable as {{name}} in steps.",
+            items: {
+              type: "object",
+              required: ["name"],
+              properties: {
+                name: {
+                  type: "string",
+                  pattern: "^[A-Za-z_][A-Za-z0-9_]{0,63}$",
+                  description:
+                    "Variable name (letter/underscore start; letters, digits, underscores; max 64 chars).",
+                },
+                required: {
+                  type: "boolean",
+                  description: "Whether the variable must be supplied.",
+                },
+                default: {
+                  description: "Default value when not supplied.",
+                },
+                description: {
+                  type: "string",
+                  description: "Human-readable description of the variable.",
+                },
+              },
+            },
           },
           eventSource: {
             type: "string",

--- a/src/recipes/validation.ts
+++ b/src/recipes/validation.ts
@@ -66,6 +66,19 @@ export function validateRecipeDefinition(recipe: unknown): LintResult {
   } else {
     const r = normalizedRecipe as Record<string, unknown>;
 
+    // Root-level `vars:` is silently dropped at runtime — the runner reads
+    // only `trigger.vars` / `trigger.inputs` (PR#259 trap). Warn so the
+    // author moves it under `trigger:` instead of debugging empty {{vars}}.
+    if (r.vars !== undefined) {
+      issues.push({
+        level: "warning",
+        message:
+          "Top-level 'vars' is ignored at runtime — only 'trigger.vars' / 'trigger.inputs' are read. Move declared variables under 'trigger:'.",
+        code: "root-vars-ignored",
+        path: "vars",
+      });
+    }
+
     if (!r.name || typeof r.name !== "string") {
       issues.push({
         level: "error",
@@ -151,8 +164,26 @@ export function validateRecipeDefinition(recipe: unknown): LintResult {
         message: "Recipe must have at least one step",
       });
     } else {
+      const seenStepIds = new Set<string>();
       for (let i = 0; i < r.steps.length; i++) {
         const step = r.steps[i] as Record<string, unknown>;
+
+        // Duplicate step ids break dependency wiring (`awaits:`, `into:`
+        // overwrite, output keying) — the runner keys outputs by id and a
+        // second step with the same id silently clobbers the first. Reject.
+        if (typeof step.id === "string") {
+          if (seenStepIds.has(step.id)) {
+            issues.push({
+              level: "error",
+              message: `Step ${i + 1}: duplicate step id '${step.id}' — step ids must be unique`,
+              code: "duplicate-step-id",
+              path: `steps.${i}.id`,
+            });
+          } else {
+            seenStepIds.add(step.id);
+          }
+        }
+
         const hasTool = typeof step.tool === "string";
         const hasAgent = !!step.agent;
         const hasNestedRecipe =
@@ -170,6 +201,24 @@ export function validateRecipeDefinition(recipe: unknown): LintResult {
             issues.push({
               level: "error",
               message: `Step ${i + 1}: Agent step missing 'prompt'`,
+            });
+          }
+
+          // `driver: claude|anthropic` routes to the Anthropic API (needs
+          // ANTHROPIC_API_KEY), NOT the Claude Code subscription — a common
+          // trap. Warn at lint time when the key is absent so the step
+          // doesn't silently no-op ("[agent step skipped: ANTHROPIC_API_KEY
+          // not set]") at run time. Use `driver: subprocess`/`claude-code`
+          // for the subscription path.
+          if (
+            (agent.driver === "claude" || agent.driver === "anthropic") &&
+            !process.env.ANTHROPIC_API_KEY
+          ) {
+            issues.push({
+              level: "warning",
+              message: `Step ${i + 1}: driver '${String(agent.driver)}' uses the Anthropic API but ANTHROPIC_API_KEY is not set — the step will be skipped at run time. Set ANTHROPIC_API_KEY, or use 'driver: subprocess' for the Claude Code subscription.`,
+              code: "driver-api-key-required",
+              path: `steps.${i}.agent.driver`,
             });
           }
 


### PR DESCRIPTION
## What

Closes five recipe-validation parity gaps (Group R2). Each grounded by reading the runtime path first.

- **Root-level `vars:` warning** (`validation.ts`) — runner reads only `trigger.vars`/`trigger.inputs`; a top-level `vars` was silently dropped (PR#259 trap). New warning `root-vars-ignored`.
- **Reserved-var case mismatch** (`names.ts`) — `RESERVED_VAR_NAMES` stored date keys UPPERCASE but both consumers look up `name.toLowerCase()`, so `yyyy`/`YYYY` shadowed built-in date keys undetected. Lowercased the source entries.
- **Driver-API-key preflight** (`validation.ts`) — `driver: claude|anthropic` routes to the Anthropic API (needs `ANTHROPIC_API_KEY`), not the subscription; without the key the step no-ops. New warning `driver-api-key-required`.
- **Duplicate step id** (`validation.ts`) — no uniqueness check existed; duplicates clobber output keying / `awaits` wiring. New error `duplicate-step-id`.
- **Schema** (`schemaGenerator.ts`) — added `trigger.vars` / `trigger.inputs` array schemas (item `name` pattern `^[A-Za-z_][A-Za-z0-9_]{0,63}$`). Documented `on_test_run.filter` values in the shared `filter` description rather than forcing an enum that would break `file_watch`.

## Test-first

New `validationParity.test.ts`: 9 RED failures before the fixes, all GREEN after. Added a `schemaGenerator.test.ts` case for `trigger.vars/inputs`. Full recipe suite 929/929. Lint + tests-core typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)