### PR TITLE
fix(recipes): harden judge→refine loop + Anthropic API caller (R4)

### DIFF
--- a/src/recipes/__tests__/judgeRefineLoopR4.test.ts
+++ b/src/recipes/__tests__/judgeRefineLoopR4.test.ts
@@ -1,0 +1,176 @@
+/**
+ * GROUP R4 — run-engine correctness for the judge→refine loop and the
+ * Anthropic API caller (defaultClaudeFn).
+ *
+ * Covers:
+ *  (1) Unvalidated-draft contamination — a loop break must NOT leave the
+ *      unapproved revised draft in ctx; the prior accepted value must remain.
+ *  (2) Unparseable-verdict exhaustion-gate bypass — an unparseable verdict
+ *      after a revision must yield a non-ok run status, not silent 'ok'.
+ *  (3) defaultClaudeFn timeout + max_tokens=4096 (override honoured).
+ */
+import { mkdtempSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  defaultClaudeFn,
+  type RunnerDeps,
+  runYamlRecipe,
+  type YamlRecipe,
+} from "../yamlRunner.js";
+
+const logDir = mkdtempSync(path.join(os.tmpdir(), "judge-refine-r4-"));
+
+function judgeRecipe(
+  maxRevisions: number,
+  onExhausted: "halt" | "proceed",
+): YamlRecipe {
+  return {
+    name: "judge-refine-r4",
+    trigger: { type: "manual" },
+    steps: [
+      {
+        agent: {
+          prompt: "write the thing",
+          model: "claude-haiku-4-5-20251001",
+          driver: "anthropic",
+          into: "draft",
+        },
+      },
+      {
+        agent: {
+          kind: "judge",
+          reviews: "draft",
+          max_revisions: maxRevisions,
+          on_exhausted: onExhausted,
+          prompt: "review the draft",
+          model: "claude-haiku-4-5-20251001",
+          driver: "anthropic",
+        },
+      },
+    ],
+  } as YamlRecipe;
+}
+
+const REQUEST_CHANGES =
+  '```json\n{"verdict":"request_changes","fixList":["tighten the intro"]}\n```';
+
+/**
+ * Drive the agent calls by prompt shape:
+ *  - revision-request → reviewed agent revises → "REVISED v2"
+ *  - judge prompt over the revised artefact → `reJudge` (controllable)
+ *  - judge prompt over the first draft → REQUEST_CHANGES
+ *  - otherwise → "DRAFT v1"
+ */
+function depsWithReJudge(reJudge: string): RunnerDeps {
+  return {
+    now: () => new Date("2026-06-05T08:00:00Z"),
+    logDir,
+    claudeFn: async (prompt: string) => {
+      if (prompt.includes("<revision-request>")) return "REVISED v2";
+      if (prompt.includes("<artefact>")) {
+        return prompt.includes("REVISED v2") ? reJudge : REQUEST_CHANGES;
+      }
+      return "DRAFT v1";
+    },
+  };
+}
+
+function judgeResult(result: Awaited<ReturnType<typeof runYamlRecipe>>) {
+  return result.stepResults.find((s) => s.judgeVerdict !== undefined);
+}
+
+const UNPARSEABLE = "the draft is fine I guess, no JSON here";
+
+describe("R4 #1 — unvalidated draft contamination", () => {
+  it("leaves the ORIGINAL draft in ctx when the loop breaks on a failed re-judge", async () => {
+    // Re-judge fails → loop breaks → staged "REVISED v2" must NOT be committed.
+    const result = await runYamlRecipe(
+      judgeRecipe(1, "proceed"),
+      depsWithReJudge("[agent step failed: re-judge timeout]"),
+    );
+    expect(result.context.draft).toBe("DRAFT v1");
+    expect(result.context.draft).not.toBe("REVISED v2");
+  });
+});
+
+describe("R4 #2 — unparseable verdict exhaustion-gate bypass", () => {
+  it("yields a non-ok run status on an unparseable re-judge verdict", async () => {
+    const result = await runYamlRecipe(
+      judgeRecipe(1, "proceed"),
+      depsWithReJudge(UNPARSEABLE),
+    );
+    const judge = judgeResult(result);
+    expect(judge?.judgeVerdict?.verdict).toBe("unparseable");
+    // Bug: status stayed 'ok' (while-loop exits on unparseable, gate only
+    // fires on request_changes). Must now be an error.
+    expect(judge?.status).toBe("error");
+    expect(result.errorMessage).toMatch(/unparseable/i);
+    // And the unvalidated draft must not be promoted.
+    expect(result.context.draft).toBe("DRAFT v1");
+  });
+});
+
+describe("R4 #3/#4 — defaultClaudeFn timeout + max_tokens", () => {
+  const realFetch = globalThis.fetch;
+  const realKey = process.env.ANTHROPIC_API_KEY;
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+    if (realKey === undefined) delete process.env.ANTHROPIC_API_KEY;
+    else process.env.ANTHROPIC_API_KEY = realKey;
+    vi.restoreAllMocks();
+  });
+
+  it("aborts on a never-resolving fetch when a short timeout is supplied", async () => {
+    process.env.ANTHROPIC_API_KEY = "test-key";
+    // fetch that only resolves/rejects when its signal aborts.
+    globalThis.fetch = ((_url: string, init?: { signal?: AbortSignal }) => {
+      return new Promise((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => {
+          const e = new Error("aborted");
+          e.name = "AbortError";
+          reject(e);
+        });
+      });
+    }) as unknown as typeof fetch;
+
+    const out = await defaultClaudeFn("hi", "claude-haiku-4-5-20251001", {
+      timeoutMs: 20,
+    });
+    expect(out.text).toMatch(/timed out/i);
+  });
+
+  it("sends max_tokens=4096 by default and honours an override", async () => {
+    process.env.ANTHROPIC_API_KEY = "test-key";
+    const bodies: string[] = [];
+    globalThis.fetch = ((_url: string, init?: { body?: string }) => {
+      bodies.push(init?.body ?? "");
+      return Promise.resolve({
+        ok: true,
+        json: async () => ({ content: [{ type: "text", text: "ok" }] }),
+      } as unknown as Response);
+    }) as unknown as typeof fetch;
+
+    await defaultClaudeFn("hi", "claude-haiku-4-5-20251001");
+    await defaultClaudeFn("hi", "claude-haiku-4-5-20251001", {
+      maxTokens: 8000,
+    });
+    expect(JSON.parse(bodies[0] ?? "{}").max_tokens).toBe(4096);
+    expect(JSON.parse(bodies[1] ?? "{}").max_tokens).toBe(8000);
+  });
+
+  it("warns when the response was truncated at max_tokens", async () => {
+    process.env.ANTHROPIC_API_KEY = "test-key";
+    globalThis.fetch = (() =>
+      Promise.resolve({
+        ok: true,
+        json: async () => ({
+          content: [{ type: "text", text: "partial" }],
+          stop_reason: "max_tokens",
+        }),
+      } as unknown as Response)) as unknown as typeof fetch;
+    const out = await defaultClaudeFn("hi", "claude-haiku-4-5-20251001");
+    expect(out.text).toMatch(/truncated at max_tokens/i);
+  });
+});

--- a/src/recipes/yamlRunner.ts
+++ b/src/recipes/yamlRunner.ts
@@ -1166,14 +1166,20 @@ export async function runYamlRecipe(
         // loop as exhausted with the last good verdict still in place.
         break;
       }
-      // Commit the revised draft so downstream steps (and the re-judge) see
-      // the improved value under the reviewed step's key.
-      ctx[reviewsKey] = revised.value as RunContext[string];
+      // R4 #1 (HIGH): stage the revised draft locally — do NOT commit to ctx
+      // yet. Committing before the verdict resolves leaves an UNAPPROVED draft
+      // in ctx on any loop break (unparseable verdict, budget denial, failed
+      // re-judge), so downstream steps treat it as approved. The revised value
+      // is only promoted to ctx once a verdict accepts it (approve, or
+      // exhaustion with on_exhausted: "proceed").
+      const pendingRevised = revised.value as RunContext[string];
 
-      // RE-JUDGE: rebuild the judge prompt against the revised artefact.
+      // RE-JUDGE: rebuild the judge prompt against the revised artefact. The
+      // judge reviews the STAGED draft, not ctx (which still holds the prior
+      // accepted value).
       const reJudgePrompt =
         render(agentCfg.prompt, ctx) +
-        buildJudgeArtefactBlock(ctx[reviewsKey]) +
+        buildJudgeArtefactBlock(pendingRevised) +
         JUDGE_PROMPT_SUFFIX;
       const judged = await runAgentText(
         reJudgePrompt,
@@ -1197,6 +1203,32 @@ export async function runYamlRecipe(
           : JSON.stringify(judged.value);
       currentVerdict = parseJudgeVerdict(stripLeadingNarration(judgedText));
       revisions++;
+
+      // R4 #2 (HIGH): an UNPARSEABLE verdict exits the while-loop (only
+      // "request_changes" continues it), but the exhaustion gate below fires
+      // ONLY on "request_changes" — so an unparseable verdict would leave the
+      // run 'ok' with the unvalidated draft never committed and no error.
+      // Treat it as a hard, non-ok stop (distinct from the failed-re-judge
+      // break above, which keeps the prior good verdict). Do NOT promote the
+      // staged draft.
+      if (currentVerdict.verdict === "unparseable") {
+        const reason = `judge "${judgeStepId}" returned an unparseable verdict after revision`;
+        judgeStepResult.judgeVerdict = currentVerdict;
+        judgeStepResult.revisions = revisions;
+        judgeStepResult.status = "error";
+        judgeStepResult.error = reason;
+        judgeStepResult.haltReason = reason;
+        judgeStepResult.haltCategory = "judge_revisions_exhausted";
+        return {
+          runError: reason,
+          haltAfterFailure: !failOpenAgent,
+        };
+      }
+
+      // R4 #1: verdict accepted the revision (approve, or non-exhausted
+      // continuation). Promote the staged draft to ctx so downstream steps and
+      // the next iteration see the improved, judged value.
+      ctx[reviewsKey] = pendingRevised;
     }
 
     // Record the FINAL verdict + the revision count on the judge step result.
@@ -2523,16 +2555,37 @@ export function makeProviderDriverFn(): (
   };
 }
 
-async function defaultClaudeFn(
+/** Default Anthropic API request timeout. Mirrors the provider path (300s). */
+const DEFAULT_CLAUDE_API_TIMEOUT_MS = 300_000;
+/**
+ * R4 #4 (HIGH): default max output tokens. The old hard-coded 1024 silently
+ * truncated structured JSON (judge verdicts, multi-field agent outputs).
+ */
+const DEFAULT_CLAUDE_MAX_TOKENS = 4096;
+
+export async function defaultClaudeFn(
   prompt: string,
   model: string,
+  opts?: { timeoutMs?: number; maxTokens?: number },
 ): Promise<AgentResult> {
   const apiKey = process.env.ANTHROPIC_API_KEY;
   if (!apiKey)
     return { text: "[agent step skipped: ANTHROPIC_API_KEY not set]" };
+  const maxTokens =
+    typeof opts?.maxTokens === "number" && opts.maxTokens > 0
+      ? opts.maxTokens
+      : DEFAULT_CLAUDE_MAX_TOKENS;
+  // R4 #3 (HIGH): abort a stalled gateway instead of hanging the run forever.
+  const timeoutMs =
+    typeof opts?.timeoutMs === "number" && opts.timeoutMs > 0
+      ? opts.timeoutMs
+      : DEFAULT_CLAUDE_API_TIMEOUT_MS;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
   try {
     const res = await fetch("https://api.anthropic.com/v1/messages", {
       method: "POST",
+      signal: controller.signal,
       headers: {
         "x-api-key": apiKey,
         "anthropic-version": "2023-06-01",
@@ -2540,7 +2593,7 @@ async function defaultClaudeFn(
       },
       body: JSON.stringify({
         model,
-        max_tokens: 1024,
+        max_tokens: maxTokens,
         messages: [
           {
             role: "user",
@@ -2560,9 +2613,14 @@ async function defaultClaudeFn(
     const data = (await res.json()) as {
       content?: Array<{ type: string; text?: string }>;
       usage?: { input_tokens?: number; output_tokens?: number };
+      stop_reason?: string;
     };
-    const text =
-      data.content?.[0]?.text ?? "[agent step failed: empty response]";
+    let text = data.content?.[0]?.text ?? "[agent step failed: empty response]";
+    // R4 #4: detect+warn when the response was cut off at the token cap so a
+    // truncated (likely unparseable) JSON payload isn't silently trusted.
+    if (data.stop_reason === "max_tokens") {
+      text = `[warning: response truncated at max_tokens=${maxTokens}; raise max_tokens]\n${text}`;
+    }
     const inputTokens = data.usage?.input_tokens;
     const outputTokens = data.usage?.output_tokens;
     if (typeof inputTokens === "number" && typeof outputTokens === "number") {
@@ -2570,9 +2628,19 @@ async function defaultClaudeFn(
     }
     return { text };
   } catch (err) {
+    const aborted =
+      controller.signal.aborted ||
+      (err instanceof Error && err.name === "AbortError");
+    if (aborted) {
+      return {
+        text: `[agent step failed: Anthropic API request timed out after ${timeoutMs}ms]`,
+      };
+    }
     return {
       text: `[agent step failed: ${err instanceof Error ? err.message : String(err)}]`,
     };
+  } finally {
+    clearTimeout(timeout);
   }
 }
 


### PR DESCRIPTION
## GROUP R4 — run-engine correctness (yamlRunner.ts)

Four HIGH fixes, each proven test-first (`src/recipes/__tests__/judgeRefineLoopR4.test.ts`, 5 tests RED before / GREEN after).

### 1. Judge loop — unvalidated draft contamination
`ctx[reviewsKey] = revised.value` committed the revised draft to context **before** the re-judge. On any loop break (failed revision, failed re-judge, unparseable verdict, budget denial) the UNAPPROVED draft stayed in ctx and downstream steps treated it as approved. Now staged in a local `pendingRevised` and promoted to ctx only once the verdict resolves to an accepted state.

### 2. Judge loop — unparseable exhaustion-gate bypass
The while-loop exits on any non-`request_changes` verdict (including `unparseable`), but the exhaustion gate fired only on `request_changes` — so an unparseable re-judge left run status `'ok'`. Added an explicit `unparseable` branch → non-ok status, `haltCategory: judge_revisions_exhausted`, respects fail-open, does not promote the staged draft.

### 3. API path — no timeout
`defaultClaudeFn`'s `fetch()` had no abort signal; a stalled gateway hung the run forever. Added `AbortController` + `setTimeout` (default 300s, mirroring the provider path) with an optional per-call `timeoutMs` override.

### 4. API path — 1024-token silent truncation
Hard-coded `max_tokens: 1024` truncated structured JSON. Default raised to 4096, optional per-call `maxTokens` override, and `stop_reason === 'max_tokens'` now prepends a truncation warning. `defaultClaudeFn` exported for testability.

### Gates
- New tests RED→GREEN; `judgeRefineLoop.test.ts` + `yamlRunner.test.ts` still green (8 + 167).
- biome clean; `tsc -p tsconfig.tests.core.json` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)