### PR TITLE
fix(recipes): unify chained runner with flat runner on budget + cost (S1)

### DIFF
--- a/src/recipes/__tests__/chainedRunner.test.ts
+++ b/src/recipes/__tests__/chainedRunner.test.ts
@@ -929,3 +929,131 @@ describe("expandParallelSteps", () => {
     );
   });
 });
+
+describe("runChainedRecipe — budget enforcement (S1 alignment)", () => {
+  // A deterministic agent that reports usage so RunBudget reconciles real
+  // spend. Each call returns a fixed token usage stamped as an API driver.
+  function meteredAgentDeps(perCallTokens: number) {
+    const calls: string[] = [];
+    const executeAgent = vi.fn(async (prompt: string) => {
+      calls.push(prompt);
+      return {
+        text: `done:${calls.length}`,
+        usage: {
+          inputTokens: perCallTokens / 2,
+          outputTokens: perCallTokens / 2,
+        },
+        servedBy: { driver: "anthropic", model: "test-model" },
+      };
+    });
+    const deps: ExecutionDeps = {
+      executeTool: vi.fn().mockResolvedValue({ ok: true }),
+      executeAgent,
+      loadNestedRecipe: vi.fn().mockResolvedValue(null),
+    };
+    return { deps, executeAgent, calls };
+  }
+
+  it("HALTS further agent dispatch once cumulative spend exceeds tokensMax", async () => {
+    // tokensMax=1000, each agent call burns 600 tokens.
+    //   a: admit ok (total 0) → dispatch → reconcile 600
+    //   b: admit ok (600 < 1000) → dispatch → reconcile 1200 (breached)
+    //   c: admit DENIED (1200 >= 1000) → no dispatch
+    const { deps, executeAgent } = meteredAgentDeps(600);
+    const recipe: ChainedRecipe = {
+      name: "budget-chain",
+      budget: { tokensMax: 1000 },
+      steps: [
+        { id: "a", agent: { prompt: "step a" } },
+        { id: "b", agent: { prompt: "step b" }, awaits: ["a"] },
+        { id: "c", agent: { prompt: "step c" }, awaits: ["b"] },
+      ],
+    };
+
+    const result = await runChainedRecipe(recipe, baseOptions, deps);
+
+    // Only two agent dispatches happened — the third was admission-denied.
+    expect(executeAgent).toHaveBeenCalledTimes(2);
+    // The run failed because step c halted on the budget.
+    expect(result.success).toBe(false);
+    const stepC = result.stepResults.get("c");
+    expect(stepC?.success).toBe(false);
+    expect(stepC?.error?.message).toMatch(/budget_exceeded/);
+  });
+
+  it("admits all dispatches when cumulative spend stays under tokensMax", async () => {
+    // 3 calls * 100 tokens = 300 < tokensMax 10000 → all run.
+    const { deps, executeAgent } = meteredAgentDeps(100);
+    const recipe: ChainedRecipe = {
+      name: "budget-chain-ok",
+      budget: { tokensMax: 10000 },
+      steps: [
+        { id: "a", agent: { prompt: "a" } },
+        { id: "b", agent: { prompt: "b" }, awaits: ["a"] },
+        { id: "c", agent: { prompt: "c" }, awaits: ["b"] },
+      ],
+    };
+    const result = await runChainedRecipe(recipe, baseOptions, deps);
+    expect(executeAgent).toHaveBeenCalledTimes(3);
+    expect(result.success).toBe(true);
+  });
+
+  it("records the budget breach + spend in the run log (runLogDir path)", async () => {
+    const { mkdtempSync, readFileSync } = await import("node:fs");
+    const { tmpdir } = await import("node:os");
+    const { join } = await import("node:path");
+    const dir = mkdtempSync(join(tmpdir(), "chained-budget-"));
+
+    const { deps } = meteredAgentDeps(600);
+    const recipe: ChainedRecipe = {
+      name: "budget-runlog",
+      budget: { tokensMax: 1000 },
+      steps: [
+        { id: "a", agent: { prompt: "a" } },
+        { id: "b", agent: { prompt: "b" }, awaits: ["a"] },
+        { id: "c", agent: { prompt: "c" }, awaits: ["b"] },
+      ],
+    };
+
+    const result = await runChainedRecipe(
+      recipe,
+      { ...baseOptions, runLogDir: dir },
+      deps,
+    );
+    expect(result.success).toBe(false);
+
+    const lines = readFileSync(join(dir, "runs.jsonl"), "utf8")
+      .trim()
+      .split("\n")
+      .filter(Boolean);
+    const lastLine = lines[lines.length - 1] ?? "";
+    const run = JSON.parse(lastLine) as {
+      status: string;
+      stepResults: Array<{ id: string; status: string; haltReason?: string }>;
+    };
+    expect(run.status).toBe("error");
+    const cRow = run.stepResults.find((s) => s.id === "c");
+    expect(cRow?.status).toBe("error");
+    // haltReason carries the budget breach so the dashboard pill categorises it.
+    expect(cRow?.haltReason).toMatch(/budget/i);
+  });
+
+  it("reconcile is fed REAL usage — no breach when usage is small enough", async () => {
+    // Same step count as the halting test but tiny per-call usage proves the
+    // budget reconciles the ACTUAL reported usage (not a fixed guess): with
+    // 1-token calls the 1000 cap is never reached.
+    const { deps, executeAgent } = meteredAgentDeps(2);
+    const recipe: ChainedRecipe = {
+      name: "budget-real-usage",
+      budget: { tokensMax: 1000 },
+      steps: [
+        { id: "a", agent: { prompt: "a" } },
+        { id: "b", agent: { prompt: "b" }, awaits: ["a"] },
+        { id: "c", agent: { prompt: "c" }, awaits: ["b"] },
+      ],
+    };
+    const result = await runChainedRecipe(recipe, baseOptions, deps);
+    expect(executeAgent).toHaveBeenCalledTimes(3);
+    expect(result.success).toBe(true);
+  });
+});

--- a/src/recipes/__tests__/yamlRunner.test.ts
+++ b/src/recipes/__tests__/yamlRunner.test.ts
@@ -2713,7 +2713,7 @@ describe("buildChainedDeps executeAgent", () => {
     const deps = buildChainedDeps({ ...noop(), claudeCodeFn, testMode: true });
     const result = await deps.executeAgent("hello", undefined, "claude-code");
     expect(claudeCodeFn).toHaveBeenCalledWith("hello", undefined);
-    expect(result).toBe("cc result");
+    expect((result as { text: string }).text).toBe("cc result");
   });
 
   it("routes anthropic driver to claudeFn", async () => {
@@ -2725,14 +2725,14 @@ describe("buildChainedDeps executeAgent", () => {
       "anthropic",
     );
     expect(claudeFn).toHaveBeenCalledWith("hello", "claude-haiku-4-5-20251001");
-    expect(result).toBe("api result");
+    expect((result as { text: string }).text).toBe("api result");
   });
 
   it("routes claude driver to claudeFn", async () => {
     const claudeFn = vi.fn().mockResolvedValue("api result 2");
     const deps = buildChainedDeps({ ...noop(), claudeFn, testMode: true });
     const result = await deps.executeAgent("hi", undefined, "claude");
-    expect(result).toBe("api result 2");
+    expect((result as { text: string }).text).toBe("api result 2");
   });
 
   it("routes openai driver to providerDriverFn", async () => {
@@ -2744,7 +2744,7 @@ describe("buildChainedDeps executeAgent", () => {
     });
     const result = await deps.executeAgent("prompt", "gpt-4", "openai");
     expect(providerDriverFn).toHaveBeenCalledWith("openai", "prompt", "gpt-4");
-    expect(result).toBe("openai");
+    expect((result as { text: string }).text).toBe("openai");
   });
 
   it("uses claudeCodeFnOverride when no driver specified and no API key", async () => {
@@ -2757,8 +2757,8 @@ describe("buildChainedDeps executeAgent", () => {
     delete process.env.ANTHROPIC_API_KEY;
     try {
       const result = await deps.executeAgent("q", undefined, undefined);
-      // Either claudeFn or override was called — result is a string
-      expect(typeof result).toBe("string");
+      // Either claudeFn or override was called — closure now returns AgentResult
+      expect(typeof (result as { text: string }).text).toBe("string");
     } finally {
       if (savedKey !== undefined) process.env.ANTHROPIC_API_KEY = savedKey;
     }

--- a/src/recipes/chainedRunner.ts
+++ b/src/recipes/chainedRunner.ts
@@ -7,6 +7,7 @@
  *   - Dry-run mode
  */
 
+import type { AgentResult } from "./agentExecutor.js";
 import type { ExecutionOptions, StepExecutor } from "./dependencyGraph.js";
 import {
   buildDependencyGraph,
@@ -27,18 +28,27 @@ import {
 } from "./nestedRecipeStep.js";
 import type { OutputRegistry } from "./outputRegistry.js";
 import { createOutputRegistry } from "./outputRegistry.js";
+import type { RouteCandidate } from "./pricing/costRouter.js";
 import { resolveRecipePath } from "./resolveRecipePath.js";
-import type { ErrorPolicy } from "./schema.js";
+import { RunBudget } from "./runBudget.js";
+import type { BudgetPolicy, ErrorPolicy } from "./schema.js";
 import { captureForRunlog, detectSilentFail } from "./stepObservation.js";
 import type { TemplateContext, TemplateError } from "./templateEngine.js";
 import { compileTemplate } from "./templateEngine.js";
 import type { StepExpect } from "./yamlRunner.js";
-import { evaluateStepExpect } from "./yamlRunner.js";
+import { evaluateStepExpect, resolveRouting } from "./yamlRunner.js";
 
 export interface ChainedStep {
   id: string;
   tool?: string;
-  agent?: { prompt: string; model?: string; driver?: string };
+  agent?: {
+    prompt: string;
+    model?: string;
+    driver?: string;
+    /** Cost-aware routing fallbacks (Phase 4) — mirrors the flat path. */
+    downshift?: RouteCandidate[];
+    mcpAccess?: boolean;
+  };
   recipe?: NestedRecipeConfig["recipe"];
   chain?: NestedRecipeConfig["recipe"];
   /** Sugar: run these steps concurrently. Expanded to flat steps at runtime. */
@@ -67,6 +77,14 @@ export interface ChainedRecipe {
   /** Plugin specs (npm package name or local path) to load before running steps. */
   servers?: string[];
   on_error?: ErrorPolicy;
+  /**
+   * Per-recipe token / USD budget. Mirrors the flat (yamlRunner) path: one
+   * `RunBudget` is constructed per top-level run, agent steps consult it
+   * before dispatch (admission) and reconcile actual consumption after. Absent
+   * → no enforcement, no overhead. SECURITY: without this thread a chained
+   * recipe ran UNBOUNDED API calls (S1 finding).
+   */
+  budget?: BudgetPolicy;
 }
 
 export interface RunOptions {
@@ -121,6 +139,13 @@ export interface RunOptions {
    * run log entry so the dashboard can render the causal chain.
    */
   parentSeq?: number;
+  /**
+   * Shared per-run budget. Constructed once by the top-level
+   * `runChainedRecipe` from `recipe.budget` and threaded into nested recipe
+   * calls so the whole tree shares one cap (mirrors the flat path's single
+   * `RunBudget` per run). Internal — callers don't set this.
+   */
+  budget?: RunBudget;
 }
 
 export interface StepExecutionContext {
@@ -129,6 +154,8 @@ export interface StepExecutionContext {
   options: RunOptions;
   recipe: ChainedRecipe;
   depth: number;
+  /** Shared per-run budget (admit before dispatch, reconcile after). */
+  budget?: RunBudget;
 }
 
 export type ToolExecutor = (
@@ -136,11 +163,22 @@ export type ToolExecutor = (
   params: Record<string, unknown>,
 ) => Promise<unknown>;
 
+/**
+ * Agent dispatch closure. Returns either a bare string (legacy / simple test
+ * mocks) or an `AgentResult` carrying `usage` + `servedBy` so the chained
+ * runner can reconcile real spend against the run budget (alignment with the
+ * flat path — previously the yamlRunner closure discarded `.usage`).
+ */
 export type AgentExecutor = (
   prompt: string,
   model?: string,
   driver?: string,
-) => Promise<string>;
+) => Promise<string | AgentResult>;
+
+/** Normalise the union AgentExecutor return into an AgentResult. */
+function toChainedAgentResult(v: string | AgentResult): AgentResult {
+  return typeof v === "string" ? { text: v } : v;
+}
 
 export interface ExecutionDeps {
   executeTool: ToolExecutor;
@@ -459,6 +497,7 @@ export async function executeChainedStep(
         maxDepth: options.maxDepth,
         sourcePath: nestedRecipe.sourcePath,
         env: { ...options.env, ...resolvedVars }, // Merge resolved vars into env
+        budget: ctx.budget, // share the single per-run budget across the tree
       };
 
       const childResult = await runChainedRecipe(
@@ -482,11 +521,59 @@ export async function executeChainedStep(
     } else if (step.agent) {
       // Agent step
       const prompt = (resolved.agentPrompt as string) ?? step.agent.prompt;
-      let result: unknown = await deps.executeAgent(
-        prompt,
-        step.agent.model,
-        step.agent.driver,
+
+      // Budget admission BEFORE dispatch — mirrors the flat path. A denied
+      // admission halts this step (and, via the dependency graph, its
+      // dependents) with a `budget_exceeded`-categorised reason. SECURITY:
+      // without this the chained path made UNBOUNDED API calls.
+      const budget = ctx.budget;
+      if (budget) {
+        const admission = budget.admit();
+        if (!admission.admitted) {
+          return {
+            success: false,
+            error:
+              admission.reason ?? "Run exceeded its budget — budget_exceeded.",
+            resolvedParams: resolved,
+          };
+        }
+      }
+
+      // Phase 4: opt-in cost-aware routing. No-op when the step has no
+      // `downshift` list or no USD cap is set on the run budget.
+      let dispatchDriver = step.agent.driver;
+      let dispatchModel = step.agent.model;
+      if (budget && step.agent.downshift?.length) {
+        const routed = resolveRouting(
+          { driver: step.agent.driver, model: step.agent.model },
+          step.agent.downshift,
+          prompt,
+          budget,
+        );
+        dispatchDriver = routed.driver === "api" ? "anthropic" : routed.driver;
+        dispatchModel = routed.model;
+      }
+
+      const agentReturn = toChainedAgentResult(
+        await deps.executeAgent(prompt, dispatchModel, dispatchDriver),
       );
+
+      // Reconcile REAL usage after dispatch (the closure now surfaces it
+      // instead of discarding it). Subscription drivers report no usage →
+      // RunBudget fails open with a one-time warning.
+      if (budget) {
+        budget.reconcile(
+          agentReturn.servedBy?.driver ?? dispatchDriver ?? "auto",
+          agentReturn.usage,
+          agentReturn.servedBy?.model ?? dispatchModel,
+          {
+            inputChars: prompt.length,
+            outputChars: agentReturn.text.length,
+          },
+        );
+      }
+
+      let result: unknown = agentReturn.text;
       // Detect failure signals returned as sentinel strings (mirrors flat runner)
       if (
         typeof result === "string" &&
@@ -731,6 +818,13 @@ export async function runChainedRecipe(
 
   const registry = existingRegistry ?? createOutputRegistry();
 
+  // Per-run budget: build once at the top level from `recipe.budget`; nested
+  // recipe calls inherit the SAME instance via `options.budget` so the whole
+  // tree shares one cap (mirrors the flat path's single RunBudget per run).
+  // Absent `recipe.budget` → an empty RunBudget whose admit/reconcile are
+  // no-ops, so there's no behaviour change for budget-less recipes.
+  const budget = options.budget ?? new RunBudget(recipe.budget);
+
   // Expand parallel: sugar into flat steps before building the dependency graph.
   const steps = expandParallelSteps(recipe.steps);
 
@@ -956,6 +1050,7 @@ export async function runChainedRecipe(
       options,
       recipe,
       depth,
+      budget,
     };
 
     const retryCount = step.retry ?? recipe.on_error?.retry ?? 0;
@@ -1138,6 +1233,9 @@ export async function runChainedRecipe(
         )
         .join("\n")
         .slice(0, 2000);
+      // Budget warnings/spend — record like the flat path so chained runs
+      // surface spend + fail-open notices on the same dashboard surfaces.
+      const budgetWarnings = budget.finalWarnings();
       if (options.runLog && runSeq !== undefined) {
         options.runLog.completeRun(runSeq, {
           status: result.success ? "done" : "error",
@@ -1145,6 +1243,7 @@ export async function runChainedRecipe(
           durationMs: doneAt - runStartedAt,
           stepResults: stepResultsList,
           outputTail,
+          ...(budgetWarnings.length > 0 && { budgetWarnings }),
           ...(result.errorMessage !== undefined && {
             errorMessage: result.errorMessage,
           }),
@@ -1181,6 +1280,7 @@ export async function runChainedRecipe(
           outputTail,
           errorMessage: result.errorMessage,
           stepResults: stepResultsList,
+          ...(budgetWarnings.length > 0 && { budgetWarnings }),
         });
       }
     } catch {

--- a/src/recipes/yamlRunner.ts
+++ b/src/recipes/yamlRunner.ts
@@ -2767,20 +2767,21 @@ export function buildChainedDeps(
     model?: string,
     driver?: string,
     mcpAccess?: boolean,
-  ): Promise<string> => {
-    // chainedRunner's AgentExecutor contract still returns a plain string —
-    // PR2b's token-budget consumer will plug in here as well, but for now
-    // we discard `.usage`.
-    const result = await _executeAgent(
+  ): Promise<AgentResult> => {
+    // Surface the FULL AgentResult (text + usage + servedBy) so the chained
+    // runner can reconcile real spend against the run budget — alignment with
+    // the flat path, which already reads `.usage`. (Previously this closure
+    // discarded everything but `.text`, leaving the chained path's budget
+    // unenforced — the S1 SECURITY finding.)
+    return _executeAgent(
       {
         prompt,
         model,
-        driver,
+        driver: driver === "api" ? "anthropic" : driver,
         ...(mcpAccess !== undefined && { mcpAccess }),
       },
       buildAgentExecutorDeps(stepDeps, runnerDeps, claudeCodeFnOverride),
     );
-    return result.text;
   };
 
   // ---------------------------------------------------------------------


### PR DESCRIPTION
## Problem (S1 — verified #1 strategic finding, SECURITY/cost)

`src/recipes/chainedRunner.ts` had **zero** `RunBudget` references. A recipe with `trigger.type: chained` and `budget.usdMax`/`tokensMax` ran **unbounded** API calls — the flat `src/recipes/yamlRunner.ts` path enforces budget, the chained path did not. The chained `executeAgent` closure in `yamlRunner.ts` also discarded `result.usage` (TODO).

## Fix (alignment, mirrors flat path)

- `ChainedRecipe.budget` threaded through `runChainedRecipe`; one `RunBudget` built at depth 0 and shared into nested recipe calls (single cap for the whole tree, like the flat path).
- Agent steps: `budget.admit()` **before** dispatch (deny → halt with a `budget_exceeded`-categorised reason), `budget.reconcile(driver, usage, model)` **after** with the real usage.
- `resolveRouting` (model downshift) applied in the chained path when a USD cap is set, matching the flat path.
- `buildChainedDeps.executeAgent` now returns the full `AgentResult` (text + usage + servedBy) instead of discarding everything but `.text`.
- Chained `completeRun`/`appendDirect` record `budgetWarnings` so chained runs log spend like flat runs.

## Tests (test-first)

New `runChainedRecipe — budget enforcement (S1 alignment)` suite with a deterministic usage-reporting agent. Asserts cumulative spend > `tokensMax` halts further dispatches and records the breach; reconcile is fed real usage. RED before the fix (ran unbounded / no breach recorded), GREEN after. Existing `buildChainedDeps executeAgent` tests updated for the new `AgentResult` return contract.

Gates: vitest 268 passed (chainedRunner + runLog + runBudget + yamlRunner), biome clean, `tsc -p tsconfig.tests.core.json` exit 0. No dashboard files touched; `runBudget.ts` unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)