### PR TITLE
fix(recipes): never send type:env secrets to the LLM verbatim

### DIFF
--- a/src/recipes/__tests__/yamlRunner.test.ts
+++ b/src/recipes/__tests__/yamlRunner.test.ts
@@ -4098,3 +4098,63 @@ describe("runYamlRecipe — orphaned-run guard", () => {
     }
   });
 });
+
+// ── SECRETS-IN-VARS: env-sourced secrets redacted from agent prompts ─────────
+// An env (`type: env`) context value must NEVER reach the LLM verbatim, but a
+// TOOL step still needs the real value (http header / DB password). See
+// docs/recipe-feature-investigation-2026-06-05.md (#1 gap: SECRETS-IN-VARS).
+describe("runYamlRecipe — env secret redaction (agent vs tool)", () => {
+  const SECRET_ENV = "PATCHWORK_TEST_SECRET_REDACT";
+  const SECRET_VALUE = "sk-supersecret-deadbeef-1234";
+
+  afterEach(() => {
+    delete process.env[SECRET_ENV];
+  });
+
+  it("redacts the secret in the agent prompt but passes the raw value to the tool", async () => {
+    process.env[SECRET_ENV] = SECRET_VALUE;
+
+    let receivedPrompt = "";
+    const writtenContent: string[] = [];
+
+    const recipe = makeRecipe({
+      name: "secret-redact",
+      context: [{ type: "env", keys: [SECRET_ENV] }],
+      steps: [
+        {
+          agent: {
+            prompt: `Use the key: {{${SECRET_ENV}}}`,
+            into: "out",
+          },
+        },
+        {
+          tool: "file.write",
+          path: path.join(TMP, "secret-tool-out.txt"),
+          content: `header={{${SECRET_ENV}}}`,
+        },
+      ],
+    } as Partial<YamlRecipe>);
+
+    const result = await runYamlRecipe(recipe, {
+      ...noop(),
+      claudeFn: async (prompt) => {
+        receivedPrompt = prompt;
+        return "ok";
+      },
+      writeFile: (_p, c) => {
+        writtenContent.push(c);
+      },
+    });
+
+    expect(result.errorMessage).toBeUndefined();
+
+    // Agent (LLM-facing) prompt: secret redacted, raw value absent.
+    expect(receivedPrompt).toContain("[REDACTED]");
+    expect(receivedPrompt).not.toContain(SECRET_VALUE);
+
+    // Tool step: raw secret preserved (tools legitimately need it).
+    expect(writtenContent).toHaveLength(1);
+    expect(writtenContent[0]).toBe(`header=${SECRET_VALUE}`);
+    expect(writtenContent[0]).not.toContain("[REDACTED]");
+  });
+});

--- a/src/recipes/stepObservation.ts
+++ b/src/recipes/stepObservation.ts
@@ -186,8 +186,30 @@ const SENSITIVE_KEY_PATTERNS = [
   "access_token",
 ];
 
-const REDACTED = "[REDACTED]";
+export const REDACTED = "[REDACTED]";
 const TRUNCATED = "[truncated]";
+
+/**
+ * Build a context copy in which the values of `secretKeys` (keys populated
+ * from a recipe-level `type: env` block) are replaced with the REDACTED
+ * marker. Used to render the LLM-facing agent prompt so an env-sourced
+ * secret never reaches the model verbatim. Tool-step param interpolation
+ * uses the ORIGINAL context — tools legitimately need the real value.
+ *
+ * Returns the input unchanged (same reference) when there are no secret
+ * keys, so the common no-secrets recipe path allocates nothing.
+ */
+export function redactSecretsForPrompt<T extends Record<string, string>>(
+  ctx: T,
+  secretKeys: ReadonlySet<string>,
+): T {
+  if (secretKeys.size === 0) return ctx;
+  const out: Record<string, string> = { ...ctx };
+  for (const key of secretKeys) {
+    if (Object.hasOwn(out, key)) out[key] = REDACTED;
+  }
+  return out as T;
+}
 
 function isSensitiveKey(key: string): boolean {
   const lower = key.toLowerCase();

--- a/src/recipes/yamlRunner.ts
+++ b/src/recipes/yamlRunner.ts
@@ -77,7 +77,7 @@ import { costRouter, type RouteCandidate } from "./pricing/costRouter.js";
 import { resolveRecipePath } from "./resolveRecipePath.js";
 import { RunBudget } from "./runBudget.js";
 import type { ErrorPolicy } from "./schema.js";
-import { detectSilentFail } from "./stepObservation.js";
+import { detectSilentFail, redactSecretsForPrompt } from "./stepObservation.js";
 // Import tool registry and trigger tool self-registration
 import {
   applyToolOutputContext,
@@ -796,6 +796,12 @@ export async function runYamlRecipe(
 
   // Resolve recipe-level context blocks (type: env) into seed context
   const envCtx: RunContext = {};
+  // SECRETS-IN-VARS: track which ctx keys came from a `type: env` block so the
+  // agent (LLM-facing) prompt can redact them. Their raw values still flow to
+  // TOOL steps (an http header / DB password legitimately needs the secret),
+  // but they must never reach the model verbatim — the secure default is
+  // redaction. See PR body / docs/recipe-feature-investigation-2026-06-05.md.
+  const secretKeys = new Set<string>();
   if (Array.isArray((recipe as unknown as Record<string, unknown>).context)) {
     for (const block of (recipe as unknown as Record<string, unknown[]>)
       .context ?? []) {
@@ -803,7 +809,10 @@ export async function runYamlRecipe(
       if (b.type === "env" && Array.isArray(b.keys)) {
         for (const key of b.keys as string[]) {
           const v = process.env[key];
-          if (v !== undefined) envCtx[key] = v;
+          if (v !== undefined) {
+            envCtx[key] = v;
+            secretKeys.add(key);
+          }
         }
       }
     }
@@ -1153,7 +1162,9 @@ export async function runYamlRecipe(
         `<previous-draft>\n${typeof priorDraft === "string" ? priorDraft : JSON.stringify(priorDraft, null, 2)}\n</previous-draft>\n\n` +
         `<fix-list>\n${fixList.length > 0 ? fixList.map((f) => `- ${f}`).join("\n") : "- (no explicit fix list provided)"}\n</fix-list>\n` +
         `</revision-request>`;
-      const revisionPrompt = render(reviewedAgent.prompt, ctx) + revisionBlock;
+      const revisionPrompt =
+        render(reviewedAgent.prompt, redactSecretsForPrompt(ctx, secretKeys)) +
+        revisionBlock;
       const revised = await runAgentText(
         revisionPrompt,
         reviewedAgent.driver,
@@ -1178,7 +1189,7 @@ export async function runYamlRecipe(
       // judge reviews the STAGED draft, not ctx (which still holds the prior
       // accepted value).
       const reJudgePrompt =
-        render(agentCfg.prompt, ctx) +
+        render(agentCfg.prompt, redactSecretsForPrompt(ctx, secretKeys)) +
         buildJudgeArtefactBlock(pendingRevised) +
         JUDGE_PROMPT_SUFFIX;
       const judged = await runAgentText(
@@ -1356,7 +1367,10 @@ export async function runYamlRecipe(
         // PR3a: judge prompt convention. Append the structured-verdict
         // suffix and, when `reviews: <stepId>` is set, inject the
         // upstream step's output as an <artefact> block.
-        let renderedPrompt = render(agentCfg.prompt, ctx);
+        let renderedPrompt = render(
+          agentCfg.prompt,
+          redactSecretsForPrompt(ctx, secretKeys),
+        );
         if (isJudge) {
           if (agentCfg.reviews) {
             renderedPrompt += buildJudgeArtefactBlock(ctx[agentCfg.reviews]);


### PR DESCRIPTION
## Problem

Recipe-level `type: env` context blocks load raw `process.env[key]` values into the run context (yamlRunner `:~805`). Those values flow through `{{template}}` substitution. Redaction existed ONLY for run-log capture (`stepObservation.ts` `redactSensitive`, key-name based) — NOT the model-facing path. So an env-sourced secret interpolated into an agent prompt reached the LLM in cleartext. This was the completeness critic's #1 gap (SECRETS-IN-VARS) in `docs/recipe-feature-investigation-2026-06-05.md`.

## Fix (conservative, minimal)

- Track the set of ctx keys populated from a `type: env` block (`secretKeys` Set built at the load site).
- Render the AGENT (LLM-facing) prompt against a ctx copy where those keys' values are replaced with the existing `[REDACTED]` marker. Applied at all three agent-prompt render sites (main agent path + judge-refine revision + re-judge).
- New helper `redactSecretsForPrompt(ctx, secretKeys)` in `stepObservation.ts`; reuses (and now exports) the existing `REDACTED` constant. No-alloc fast path when there are no secrets.

Tool-step param interpolation is deliberately UNCHANGED — a tool (http header, DB password) legitimately needs the real value.

Scope limited to `src/recipes/yamlRunner.ts` + `src/recipes/stepObservation.ts` (+ test). `chainedRunner.ts`, dashboard, and unrelated code untouched.

## ⚠️ Deliberate behavior change

Agent prompts can **no longer contain env-sourced secrets verbatim** — the secure default is redaction. If a recipe genuinely needs a secret's value reasoned about by the LLM, that is intentionally out of scope and not supported by this change. Tool steps continue to receive the real value, so http-header / credential use cases are unaffected.

## Test (test-first)

`runYamlRecipe — env secret redaction (agent vs tool)`: a `type:env` block exposes a secret; a deterministic claudeFn records the agent prompt; a `file.write` tool step records its interpolated content via the `writeFile` dep. Asserts the prompt contains `[REDACTED]` and NOT the raw secret, while the tool received the RAW secret. Verified RED before the fix (prompt leaked the secret), GREEN after. Env var set/cleared within the test; tmp paths via `os.tmpdir()`.

## Gates
- `vitest` — 176 passed (yamlRunner + judgeRefineLoop + judgeRefineLoopR4)
- `biome check` — clean on changed prod files
- `tsc -p tsconfig.tests.core.json --noEmit` — exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>