### PR TITLE
fix(recipes): standardize connector-tool error normalization

### DIFF
--- a/src/recipes/tools/__tests__/connectorErrorNormalization.test.ts
+++ b/src/recipes/tools/__tests__/connectorErrorNormalization.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Connector error-normalization tests (S6 reliability).
+ *
+ * Newer connector tools historically had no try/catch in `execute()`: a
+ * connector throw (network failure, missing-token `authenticate()`/`loadTokens()`
+ * inside a class-accessor connector, …) propagated uncaught → the recipe runner
+ * recorded a null result → `ctx[step.into]` was never written → downstream
+ * `{{steps.X.field}}` resolved empty → the run halted.
+ *
+ * The early tools (slack/linear/jira) instead return a SOFT envelope:
+ *   JSON.stringify({ ok: false, error })
+ * so a downstream step can read `.error` and the run can continue.
+ *
+ * These tests drive two representative tools — `monday.list_boards`
+ * (module-function connector) and `stripe.listCharges` (class-accessor connector
+ * that can throw inside the accessor) — with an injected dependency that THROWS,
+ * and assert the tool returns the soft envelope instead of throwing. They also
+ * assert the success path is unchanged.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// ── Connector mocks ──────────────────────────────────────────────────────────
+const listBoards = vi.fn();
+vi.mock("../../../connectors/monday.js", () => ({
+  listBoards,
+  listItems: vi.fn(),
+  getItem: vi.fn(),
+  createItem: vi.fn(),
+}));
+
+const getStripeConnector = vi.fn();
+vi.mock("../../../connectors/stripe.js", () => ({ getStripeConnector }));
+
+// Import AFTER mocks so the self-registering modules pick them up.
+import "../monday.js";
+import "../stripe.js";
+import { getTool } from "../../toolRegistry.js";
+import type { RunContext, StepDeps } from "../../yamlRunner.js";
+
+function ctx(params: Record<string, unknown>) {
+  return {
+    params,
+    step: {} as Record<string, unknown>,
+    ctx: {} as RunContext,
+    deps: {} as StepDeps,
+  };
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.restoreAllMocks();
+});
+
+describe("connector error normalization → soft { ok:false, error } envelope", () => {
+  describe("monday.list_boards (module-function connector throw)", () => {
+    it("returns the soft envelope instead of throwing when the connector throws", async () => {
+      listBoards.mockRejectedValue(new Error("network down"));
+      const tool = getTool("monday.list_boards");
+
+      // Must resolve to the soft envelope, NOT reject.
+      const out = await tool?.execute(ctx({ limit: 10 }));
+      expect(out).toBe(JSON.stringify({ ok: false, error: "network down" }));
+    });
+
+    it("passes the success path through unchanged", async () => {
+      const boards = [{ id: "1", name: "Roadmap" }];
+      listBoards.mockResolvedValue(boards);
+      const tool = getTool("monday.list_boards");
+
+      const out = await tool?.execute(ctx({ limit: 10 }));
+      expect(out).toBe(JSON.stringify(boards));
+    });
+  });
+
+  describe("stripe.listCharges (class-accessor connector throw)", () => {
+    it("returns the soft envelope when the accessor itself throws (missing config)", async () => {
+      getStripeConnector.mockImplementation(() => {
+        throw new Error("Stripe not connected");
+      });
+      const tool = getTool("stripe.listCharges");
+
+      // Accessor throws synchronously inside execute → wrapper must catch it.
+      const out = await tool?.execute(ctx({}));
+      expect(out).toBe(
+        JSON.stringify({ ok: false, error: "Stripe not connected" }),
+      );
+    });
+
+    it("returns the soft envelope when the connector method rejects", async () => {
+      getStripeConnector.mockReturnValue({
+        listCharges: vi.fn().mockRejectedValue(new Error("401 unauthorized")),
+      });
+      const tool = getTool("stripe.listCharges");
+
+      const out = await tool?.execute(ctx({}));
+      expect(out).toBe(
+        JSON.stringify({ ok: false, error: "401 unauthorized" }),
+      );
+    });
+
+    it("passes the success path through unchanged", async () => {
+      const result = { data: [{ id: "ch_1" }], has_more: false };
+      getStripeConnector.mockReturnValue({
+        listCharges: vi.fn().mockResolvedValue(result),
+      });
+      const tool = getTool("stripe.listCharges");
+
+      const out = await tool?.execute(ctx({}));
+      expect(out).toBe(JSON.stringify(result));
+    });
+  });
+});

--- a/src/recipes/tools/airtable.ts
+++ b/src/recipes/tools/airtable.ts
@@ -14,6 +14,7 @@
  */
 
 import { CommonSchemas, registerTool } from "../toolRegistry.js";
+import { wrapConnectorExecute } from "./wrapConnectorExecute.js";
 
 // ============================================================================
 // airtable.list_records
@@ -92,7 +93,7 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getAirtableConnector } = await import(
       "../../connectors/airtable.js"
     );
@@ -122,7 +123,7 @@ registerTool({
       },
     );
     return JSON.stringify(result);
-  },
+  }),
 });
 
 // ============================================================================
@@ -163,7 +164,7 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getAirtableConnector } = await import(
       "../../connectors/airtable.js"
     );
@@ -174,7 +175,7 @@ registerTool({
       params.recordId as string,
     );
     return JSON.stringify(result);
-  },
+  }),
 });
 
 // ============================================================================
@@ -216,7 +217,7 @@ registerTool({
   riskDefault: "medium",
   isWrite: true,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getAirtableConnector } = await import(
       "../../connectors/airtable.js"
     );
@@ -227,7 +228,7 @@ registerTool({
       (params.fields as Record<string, unknown>) ?? {},
     );
     return JSON.stringify(result);
-  },
+  }),
 });
 
 // ============================================================================
@@ -264,12 +265,12 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async () => {
+  execute: wrapConnectorExecute(async () => {
     const { getAirtableConnector } = await import(
       "../../connectors/airtable.js"
     );
     const connector = getAirtableConnector();
     const result = await connector.listBases();
     return JSON.stringify(result);
-  },
+  }),
 });

--- a/src/recipes/tools/circleci.ts
+++ b/src/recipes/tools/circleci.ts
@@ -9,6 +9,7 @@
  */
 
 import { CommonSchemas, registerTool } from "../toolRegistry.js";
+import { wrapConnectorExecute } from "./wrapConnectorExecute.js";
 
 // ============================================================================
 // circleci.list_pipelines
@@ -54,7 +55,7 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getCircleCIConnector } = await import(
       "../../connectors/circleci.js"
     );
@@ -64,7 +65,7 @@ registerTool({
       typeof params.branch === "string" ? params.branch : undefined,
     );
     return JSON.stringify(result);
-  },
+  }),
 });
 
 // ============================================================================
@@ -114,7 +115,7 @@ registerTool({
   riskDefault: "medium",
   isWrite: true,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getCircleCIConnector } = await import(
       "../../connectors/circleci.js"
     );
@@ -131,7 +132,7 @@ registerTool({
       },
     );
     return JSON.stringify(result);
-  },
+  }),
 });
 
 // ============================================================================
@@ -170,14 +171,14 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getCircleCIConnector } = await import(
       "../../connectors/circleci.js"
     );
     const connector = getCircleCIConnector();
     const result = await connector.getWorkflow(params.id as string);
     return JSON.stringify(result);
-  },
+  }),
 });
 
 // ============================================================================
@@ -222,7 +223,7 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getCircleCIConnector } = await import(
       "../../connectors/circleci.js"
     );
@@ -232,5 +233,5 @@ registerTool({
       params.jobNumber as number,
     );
     return JSON.stringify(result);
-  },
+  }),
 });

--- a/src/recipes/tools/cloudflare.ts
+++ b/src/recipes/tools/cloudflare.ts
@@ -12,6 +12,7 @@
  */
 
 import { CommonSchemas, registerTool } from "../toolRegistry.js";
+import { wrapConnectorExecute } from "./wrapConnectorExecute.js";
 
 // ============================================================================
 // cloudflare.list_zones
@@ -49,7 +50,7 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getCloudflareConnector } = await import(
       "../../connectors/cloudflare.js"
     );
@@ -58,7 +59,7 @@ registerTool({
       typeof params.name === "string" ? params.name : undefined,
     );
     return JSON.stringify(result);
-  },
+  }),
 });
 
 // ============================================================================
@@ -109,7 +110,7 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getCloudflareConnector } = await import(
       "../../connectors/cloudflare.js"
     );
@@ -120,7 +121,7 @@ registerTool({
       typeof params.name === "string" ? params.name : undefined,
     );
     return JSON.stringify(result);
-  },
+  }),
 });
 
 // ============================================================================
@@ -180,7 +181,7 @@ registerTool({
   riskDefault: "medium",
   isWrite: true,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getCloudflareConnector } = await import(
       "../../connectors/cloudflare.js"
     );
@@ -194,7 +195,7 @@ registerTool({
       typeof params.proxied === "boolean" ? params.proxied : undefined,
     );
     return JSON.stringify(result);
-  },
+  }),
 });
 
 // ============================================================================
@@ -233,7 +234,7 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getCloudflareConnector } = await import(
       "../../connectors/cloudflare.js"
     );
@@ -244,5 +245,5 @@ registerTool({
       typeof params.until === "string" ? params.until : undefined,
     );
     return JSON.stringify(result);
-  },
+  }),
 });

--- a/src/recipes/tools/grafana.ts
+++ b/src/recipes/tools/grafana.ts
@@ -10,6 +10,7 @@
  */
 
 import { CommonSchemas, registerTool } from "../toolRegistry.js";
+import { wrapConnectorExecute } from "./wrapConnectorExecute.js";
 
 // ============================================================================
 // grafana.list_dashboards
@@ -54,7 +55,7 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getGrafanaConnector } = await import("../../connectors/grafana.js");
     const connector = getGrafanaConnector();
     const result = await connector.getDashboards(
@@ -62,7 +63,7 @@ registerTool({
       typeof params.limit === "number" ? params.limit : undefined,
     );
     return JSON.stringify(result);
-  },
+  }),
 });
 
 // ============================================================================
@@ -104,14 +105,14 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getGrafanaConnector } = await import("../../connectors/grafana.js");
     const connector = getGrafanaConnector();
     const result = await connector.getAlertRules(
       typeof params.limit === "number" ? params.limit : undefined,
     );
     return JSON.stringify(result);
-  },
+  }),
 });
 
 // ============================================================================
@@ -164,7 +165,7 @@ registerTool({
   riskDefault: "medium",
   isWrite: true,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getGrafanaConnector } = await import("../../connectors/grafana.js");
     const connector = getGrafanaConnector();
     const result = await connector.createAnnotation(
@@ -181,7 +182,7 @@ registerTool({
       },
     );
     return JSON.stringify(result);
-  },
+  }),
 });
 
 // ============================================================================
@@ -229,7 +230,7 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getGrafanaConnector } = await import("../../connectors/grafana.js");
     const connector = getGrafanaConnector();
     const result = await connector.queryDataSource(
@@ -239,5 +240,5 @@ registerTool({
       typeof params.to === "string" ? params.to : undefined,
     );
     return JSON.stringify(result);
-  },
+  }),
 });

--- a/src/recipes/tools/monday.ts
+++ b/src/recipes/tools/monday.ts
@@ -21,6 +21,7 @@
  */
 
 import { CommonSchemas, registerTool } from "../toolRegistry.js";
+import { wrapConnectorExecute } from "./wrapConnectorExecute.js";
 
 // ============================================================================
 // monday.list_boards
@@ -66,12 +67,12 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { listBoards } = await import("../../connectors/monday.js");
     const limit = typeof params.limit === "number" ? params.limit : undefined;
     const boards = await listBoards(limit);
     return JSON.stringify(boards);
-  },
+  }),
 });
 
 // ============================================================================
@@ -125,14 +126,14 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { listItems } = await import("../../connectors/monday.js");
     const limit = typeof params.limit === "number" ? params.limit : undefined;
     const cursor =
       typeof params.cursor === "string" ? params.cursor : undefined;
     const page = await listItems(params.boardId as string, limit, cursor);
     return JSON.stringify(page);
-  },
+  }),
 });
 
 // ============================================================================
@@ -196,11 +197,11 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getItem } = await import("../../connectors/monday.js");
     const item = await getItem(params.itemId as string);
     return JSON.stringify(item);
-  },
+  }),
 });
 
 // ============================================================================
@@ -246,7 +247,7 @@ registerTool({
   riskDefault: "medium",
   isWrite: true,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { createItem } = await import("../../connectors/monday.js");
     const columnValues =
       typeof params.columnValues === "string" ? params.columnValues : undefined;
@@ -257,5 +258,5 @@ registerTool({
       columnValues,
     );
     return JSON.stringify(created);
-  },
+  }),
 });

--- a/src/recipes/tools/posthog.ts
+++ b/src/recipes/tools/posthog.ts
@@ -15,6 +15,7 @@
  */
 
 import { CommonSchemas, registerTool } from "../toolRegistry.js";
+import { wrapConnectorExecute } from "./wrapConnectorExecute.js";
 
 // ============================================================================
 // posthog.capture_event  (write-gated)
@@ -58,7 +59,7 @@ registerTool({
   riskDefault: "medium",
   isWrite: true,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getPostHogConnector } = await import("../../connectors/posthog.js");
     const connector = getPostHogConnector();
     const result = await connector.captureEvent(
@@ -70,7 +71,7 @@ registerTool({
       typeof params.timestamp === "string" ? params.timestamp : undefined,
     );
     return JSON.stringify(result);
-  },
+  }),
 });
 
 // ============================================================================
@@ -113,7 +114,7 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getPostHogConnector } = await import("../../connectors/posthog.js");
     const connector = getPostHogConnector();
     const result = await connector.getInsights(
@@ -121,7 +122,7 @@ registerTool({
       typeof params.limit === "number" ? params.limit : undefined,
     );
     return JSON.stringify(result);
-  },
+  }),
 });
 
 // ============================================================================
@@ -158,7 +159,7 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getPostHogConnector } = await import("../../connectors/posthog.js");
     const connector = getPostHogConnector();
     const result = await connector.queryInsight(
@@ -166,7 +167,7 @@ registerTool({
       params.query as Record<string, unknown>,
     );
     return JSON.stringify(result);
-  },
+  }),
 });
 
 // ============================================================================
@@ -226,7 +227,7 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getPostHogConnector } = await import("../../connectors/posthog.js");
     const connector = getPostHogConnector();
     const result = await connector.getEvents(
@@ -241,5 +242,5 @@ registerTool({
       },
     );
     return JSON.stringify(result);
-  },
+  }),
 });

--- a/src/recipes/tools/resend.ts
+++ b/src/recipes/tools/resend.ts
@@ -7,6 +7,7 @@
  */
 
 import { CommonSchemas, registerTool } from "../toolRegistry.js";
+import { wrapConnectorExecute } from "./wrapConnectorExecute.js";
 
 // ============================================================================
 // resend.send_email  (write-gated)
@@ -56,7 +57,7 @@ registerTool({
   riskDefault: "medium",
   isWrite: true,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getResendConnector } = await import("../../connectors/resend.js");
     const connector = getResendConnector();
     const result = await connector.sendEmail({
@@ -71,7 +72,7 @@ registerTool({
           : undefined,
     });
     return JSON.stringify(result);
-  },
+  }),
 });
 
 // ============================================================================
@@ -107,7 +108,7 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getResendConnector } = await import("../../connectors/resend.js");
     const connector = getResendConnector();
     const result = await connector.listEmails({
@@ -115,7 +116,7 @@ registerTool({
       page: typeof params.page === "number" ? params.page : undefined,
     });
     return JSON.stringify(result);
-  },
+  }),
 });
 
 // ============================================================================
@@ -151,10 +152,10 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getResendConnector } = await import("../../connectors/resend.js");
     const connector = getResendConnector();
     const result = await connector.getEmail(params.id as string);
     return JSON.stringify(result);
-  },
+  }),
 });

--- a/src/recipes/tools/salesforce.ts
+++ b/src/recipes/tools/salesforce.ts
@@ -15,6 +15,7 @@
  */
 
 import { CommonSchemas, registerTool } from "../toolRegistry.js";
+import { wrapConnectorExecute } from "./wrapConnectorExecute.js";
 
 // ============================================================================
 // salesforce.query  (SOQL — read)
@@ -58,14 +59,14 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { query } = await import("../../connectors/salesforce.js");
     const result = await query(
       params.soql as string,
       typeof params.limit === "number" ? { limit: params.limit } : undefined,
     );
     return JSON.stringify(result);
-  },
+  }),
 });
 
 // ============================================================================
@@ -102,11 +103,11 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { searchSosl } = await import("../../connectors/salesforce.js");
     const result = await searchSosl(params.sosl as string);
     return JSON.stringify(result);
-  },
+  }),
 });
 
 // ============================================================================
@@ -142,14 +143,14 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getObject } = await import("../../connectors/salesforce.js");
     const result = await getObject(
       params.object_name as string,
       params.record_id as string,
     );
     return JSON.stringify(result);
-  },
+  }),
 });
 
 // ============================================================================
@@ -191,7 +192,7 @@ registerTool({
   riskDefault: "medium",
   isWrite: true,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { createRecord } = await import("../../connectors/salesforce.js");
     const fields =
       params.fields && typeof params.fields === "object"
@@ -199,5 +200,5 @@ registerTool({
         : {};
     const result = await createRecord(params.object_name as string, fields);
     return JSON.stringify(result);
-  },
+  }),
 });

--- a/src/recipes/tools/snowflake.ts
+++ b/src/recipes/tools/snowflake.ts
@@ -15,6 +15,7 @@
  */
 
 import { CommonSchemas, registerTool } from "../toolRegistry.js";
+import { wrapConnectorExecute } from "./wrapConnectorExecute.js";
 
 // Shared output schema — every Snowflake connector method resolves to a
 // SnowflakeQueryResult (see src/connectors/snowflake.ts).
@@ -73,7 +74,7 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getSnowflakeConnector } = await import(
       "../../connectors/snowflake.js"
     );
@@ -83,7 +84,7 @@ registerTool({
       typeof params.schema === "string" ? params.schema : undefined,
     );
     return JSON.stringify(result);
-  },
+  }),
 });
 
 // ============================================================================
@@ -109,7 +110,7 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getSnowflakeConnector } = await import(
       "../../connectors/snowflake.js"
     );
@@ -120,7 +121,7 @@ registerTool({
       params.table as string,
     );
     return JSON.stringify(result);
-  },
+  }),
 });
 
 // ============================================================================
@@ -143,14 +144,14 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async () => {
+  execute: wrapConnectorExecute(async () => {
     const { getSnowflakeConnector } = await import(
       "../../connectors/snowflake.js"
     );
     const connector = getSnowflakeConnector();
     const result = await connector.listDatabases();
     return JSON.stringify(result);
-  },
+  }),
 });
 
 // ============================================================================
@@ -189,7 +190,7 @@ registerTool({
   riskDefault: "medium",
   isWrite: true,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getSnowflakeConnector } = await import(
       "../../connectors/snowflake.js"
     );
@@ -200,5 +201,5 @@ registerTool({
       typeof params.rowLimit === "number" ? params.rowLimit : undefined,
     );
     return JSON.stringify(result);
-  },
+  }),
 });

--- a/src/recipes/tools/stripe.ts
+++ b/src/recipes/tools/stripe.ts
@@ -5,6 +5,7 @@
  */
 
 import { CommonSchemas, registerTool } from "../toolRegistry.js";
+import { wrapConnectorExecute } from "./wrapConnectorExecute.js";
 
 // ============================================================================
 // stripe.listCharges
@@ -45,7 +46,7 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getStripeConnector } = await import("../../connectors/stripe.js");
     const connector = getStripeConnector();
     const result = await connector.listCharges({
@@ -55,7 +56,7 @@ registerTool({
       status: typeof params.status === "string" ? params.status : undefined,
     });
     return JSON.stringify(result);
-  },
+  }),
 });
 
 // ============================================================================
@@ -86,12 +87,12 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getStripeConnector } = await import("../../connectors/stripe.js");
     const connector = getStripeConnector();
     const result = await connector.getCharge(params.chargeId as string);
     return JSON.stringify(result);
-  },
+  }),
 });
 
 // ============================================================================
@@ -128,7 +129,7 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getStripeConnector } = await import("../../connectors/stripe.js");
     const connector = getStripeConnector();
     const result = await connector.listCustomers({
@@ -136,7 +137,7 @@ registerTool({
       email: typeof params.email === "string" ? params.email : undefined,
     });
     return JSON.stringify(result);
-  },
+  }),
 });
 
 // ============================================================================
@@ -170,12 +171,12 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getStripeConnector } = await import("../../connectors/stripe.js");
     const connector = getStripeConnector();
     const result = await connector.getCustomer(params.customerId as string);
     return JSON.stringify(result);
-  },
+  }),
 });
 
 // ============================================================================
@@ -219,7 +220,7 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getStripeConnector } = await import("../../connectors/stripe.js");
     const connector = getStripeConnector();
     const result = await connector.listSubscriptions({
@@ -229,7 +230,7 @@ registerTool({
       status: typeof params.status === "string" ? params.status : undefined,
     });
     return JSON.stringify(result);
-  },
+  }),
 });
 
 // ============================================================================
@@ -272,7 +273,7 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getStripeConnector } = await import("../../connectors/stripe.js");
     const connector = getStripeConnector();
     const result = await connector.listInvoices({
@@ -282,5 +283,5 @@ registerTool({
       status: typeof params.status === "string" ? params.status : undefined,
     });
     return JSON.stringify(result);
-  },
+  }),
 });

--- a/src/recipes/tools/twilio.ts
+++ b/src/recipes/tools/twilio.ts
@@ -10,6 +10,7 @@
  */
 
 import { CommonSchemas, registerTool } from "../toolRegistry.js";
+import { wrapConnectorExecute } from "./wrapConnectorExecute.js";
 
 // ============================================================================
 // twilio.send_sms  (write-gated)
@@ -65,7 +66,7 @@ registerTool({
   riskDefault: "medium",
   isWrite: true,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getTwilioConnector } = await import("../../connectors/twilio.js");
     const connector = getTwilioConnector();
     const result = await connector.sendSms({
@@ -74,7 +75,7 @@ registerTool({
       from: typeof params.from === "string" ? params.from : undefined,
     });
     return JSON.stringify(result);
-  },
+  }),
 });
 
 // ============================================================================
@@ -122,7 +123,7 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getTwilioConnector } = await import("../../connectors/twilio.js");
     const connector = getTwilioConnector();
     const result = await connector.listMessages({
@@ -133,7 +134,7 @@ registerTool({
       limit: typeof params.limit === "number" ? params.limit : undefined,
     });
     return JSON.stringify(result);
-  },
+  }),
 });
 
 // ============================================================================
@@ -180,10 +181,10 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getTwilioConnector } = await import("../../connectors/twilio.js");
     const connector = getTwilioConnector();
     const result = await connector.getMessage(params.messageSid as string);
     return JSON.stringify(result);
-  },
+  }),
 });

--- a/src/recipes/tools/wrapConnectorExecute.ts
+++ b/src/recipes/tools/wrapConnectorExecute.ts
@@ -1,0 +1,38 @@
+/**
+ * wrapConnectorExecute — soft error-envelope normalization for connector tools.
+ *
+ * Many newer connector tools (monday, stripe, twilio, …) have no try/catch in
+ * their `execute()` body. A connector throw — a network failure, a missing-token
+ * `authenticate()`/`loadTokens()` error inside a class-accessor connector, etc. —
+ * then propagates uncaught. The recipe runner treats an uncaught throw as a
+ * null result: `ctx[step.into]` is never written, downstream
+ * `{{steps.X.field}}` references resolve empty, and the run halts.
+ *
+ * The early connector tools (slack.ts, linear.ts, jira.ts) instead return a
+ * SOFT error envelope — `JSON.stringify({ ok: false, error })` — so a
+ * downstream step can read `.error` and the run can continue.
+ *
+ * This helper brings throwing tools up to that same standard: it runs the tool
+ * body and, on throw, returns the identical envelope. The success path is
+ * passed through verbatim (string or null).
+ */
+
+import type { ToolContext, ToolExecute } from "../toolRegistry.js";
+
+/**
+ * Wrap a connector tool's execute fn so any thrown error becomes the soft
+ * error envelope `{ ok: false, error }` (matching slack/linear/jira), instead
+ * of propagating and halting the run. Success path is unchanged.
+ */
+export function wrapConnectorExecute(inner: ToolExecute): ToolExecute {
+  return async (context: ToolContext): Promise<string | null> => {
+    try {
+      return await inner(context);
+    } catch (err) {
+      return JSON.stringify({
+        ok: false,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  };
+}


### PR DESCRIPTION
## Problem

Many newer connector tools in `src/recipes/tools/` had no `try/catch` in `execute()`. A connector throw — network failure, or a missing-config throw inside a class-accessor connector's `getXxxConnector()`/`authenticate()`/`loadTokens()` — propagated uncaught. The recipe runner then records a `null` result: `ctx[step.into]` is never written, downstream `{{steps.X.field}}` references resolve empty, and the run halts.

The early connector tools (`slack.ts`, `linear.ts`, `jira.ts`) instead return a SOFT error envelope — `JSON.stringify({ ok: false, error })` — so a downstream step can read `.error` and the run continues. This PR brings the throwing tools up to that same standard.

## Change

- New helper `src/recipes/tools/wrapConnectorExecute.ts`: `wrapConnectorExecute(inner)` runs the tool body and, on any throw (async reject or synchronous accessor throw), returns the identical `{ ok: false, error }` envelope. Success path (string | null) is passed through verbatim.
- Applied mechanically to every genuinely-unwrapped connector tool's `execute()` — 45 execute bodies across 11 files: monday, salesforce, cloudflare, circleci, stripe, airtable, grafana, posthog, resend, twilio, snowflake. No success-path behavior, schemas, or metadata changed.

Scope strictly `src/recipes/tools/*`. `yamlRunner.ts`, `chainedRunner.ts`, dashboard untouched.

## Test (test-first)

`connectorErrorNormalization.test.ts` drives `monday.list_boards` (module-function connector) and `stripe.listCharges` (class-accessor — both synchronous accessor throw and async method reject), asserting the soft envelope instead of a throw plus success-path pass-through.

- BEFORE (helper not applied): RED — throws propagated uncaught (Unhandled Rejection).
- AFTER: GREEN — full tools test dir 31 files / 282 tests pass.

## Gates

- `npx vitest run src/recipes/tools/__tests__/` — 282 passing
- `npx biome check` — clean
- `npx tsc -p tsconfig.tests.core.json --noEmit` — exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)