### PR TITLE
feat(recipes): What-If Preview — static recipe simulation (recipe simulate)

### DIFF
--- a/docs/counterfactual-sim-engine-investigation.md
+++ b/docs/counterfactual-sim-engine-investigation.md
@@ -1,0 +1,124 @@
+# Counterfactual Simulation Engine — Final Investigation Report
+
+> Investigation date: 2026-06-04. Produced by a 31-agent workflow (map 7 subsystems →
+> 4 design proposals → 3-lens judge panel → adversarial verification of the winner's
+> load-bearing assumptions → synthesis). All 6 verified assumptions came back **breaks**.
+
+## 1. Verdict
+
+**Yes — but scoped, phased, and renamed in the UI.** Patchwork should build this. It is the single most defensible "AI-native trust" feature on the roadmap: "see exactly what this recipe would do before you arm it" is the natural capstone of the dry-run plan, trace memory, cost ledger, and approval-gate work the team has already shipped. The architecture genuinely supports it — the FP `Backend`/`TestBackend` seam (`src/fp/interpreterContext.ts`) is a textbook simulation seam, and the chained runner's `dryRun` + `mockedOutputs` paths are a working partial implementation. **However**, the adversarial verification falsifies the winner's load-bearing assumptions, and one of them — "show which approvals WOULD trigger" — is not just incomplete but *actively misleading* if shipped as proposed, because the approval gate (`src/transport.ts:1408`) does not gate recipe-runner tools at all. Build it, but lead with the dimensions that hold (actions, structural side-effects, derived risk over the chained DAG), gate the approval and cost dimensions behind real prerequisite work, and make incompleteness loud in the output schema rather than papered over with a tooltip.
+
+## 2. Why it fits Patchwork
+
+This feature is a *composition layer*, not a new runtime. Almost every primitive it needs already exists as a pure, side-effect-free function:
+
+- **Dry-run plan / static skeleton.** `runRecipeDryPlan` (`src/commands/recipe.ts:1569`) and `generateExecutionPlan` (`src/recipes/chainedRunner.ts:1195`) already produce the full step DAG with parallel groups, dependencies, and per-step `isWrite`/`isConnector`/`risk` via `enrichStepFromRegistry` (`src/commands/recipe.ts:1344`). `RecipeDryRunPlan`/`RecipeDryRunPlanStep` (`src/commands/recipe.ts:1315`/`1279`) are stable wire types a sim result can superset, and `generateDryRunPlanSchema` (`src/recipes/schemaGenerator.ts:59`) already has a stable `$id`.
+- **The simulation seam.** The automation DSL's `Backend` interface (`src/fp/interpreterContext.ts:49-62`) routes *all* side effects through one injectable surface, and `TestBackend` (`src/fp/interpreterContext.ts:248-289`) is already a recording mock — a `SimulationBackend` is a renamed, annotated `TestBackend`. On the recipe side, `ExecutionDeps` (`src/recipes/chainedRunner.ts:145-152`) is the chained runner's injection point, and `executeTool` (`src/recipes/toolRegistry.ts:113-138`) is the *single* tool-dispatch choke point, branching on `isWrite`.
+- **Mocked replay.** `replayMockedRun`/`buildMockedOutputs` (`src/recipes/replayRun.ts:92`/`58`) already re-run a recipe with captured historical outputs and zero external I/O — the direct ancestor of a sim engine.
+- **Cost.** The price table trio is clean and pure: `costUsd`/`priceFor` (`src/recipes/pricing/priceTable.ts:162`/`145`), `RunBudget.quoteUsd` (`src/recipes/runBudget.ts:282`), and `costRouter` (`src/recipes/pricing/costRouter.ts:49`).
+- **Risk & approval primitives.** `classifyTool`/`requiresApproval` (`src/riskTier.ts:153`/`162`), `computeRiskSignals` (`src/approvalHttp.ts:636`), `computePersonalSignals` (`src/approvalSignals.ts:200`), and the `ToolMetadata.riskDefault` field already populated on every recipe tool (`src/recipes/toolRegistry.ts:28`).
+- **Trace memory & taxonomy.** `RecipeRunLog` (`src/runLog.ts:71`), `categoriseHaltReason`/`summariseHalts` + `HALT_CATEGORY_HINTS` (`src/recipes/haltCategory.ts`), `computePercentiles` (`src/fp/activityAnalytics.ts:51`), and the read APIs `ctxQueryTraces`/`ctxSaveTrace` (`src/tools/ctxQueryTraces.ts:108`, `src/tools/ctxSaveTrace.ts:20`).
+- **Dashboard.** `RecipePlanPage` already renders a per-step table with risk badges, write flags, connectors, and token/cost columns (`dashboard/src/app/recipes/[...name]/_plan/page.tsx`); the Decision Replay page (`dashboard/src/app/insights/replay/page.tsx`) is a *working* narrow counterfactual ("what would current policy decide on past approvals"); the mocked-replay confirm modal (`dashboard/src/app/runs/[seq]/page.tsx`) is a working "simulate-before-enable" UX prototype; `DoctorPanel`'s `autoRun` + `?diagnose=1` deep-link pattern (`dashboard/src/app/recipes/[...name]/_components/DoctorPanel.tsx`) is the exact trigger mechanism.
+
+The conceptual framing already lives in the codebase — `decisionReplay.ts` and `shadowRun.ts` (`src/testing/shadowRun.ts`) both think in "what would policy X predict for event Y." The sim engine *composes* this, it does not invent it.
+
+## 3. The honest hard parts
+
+Driven directly by the adversarial verification verdicts. Each graded **holds / partial / breaks** as of today.
+
+### 3a. Side-effect interception completeness — **PARTIAL (holds for chained, breaks for flat)**
+The zero-IO short-circuit fires before the write gate **only for chained recipes**: `chainedRunner.ts:319-331` returns `{dryRun:true}` before `deps.executeTool`/`deps.executeAgent`, with `mockedOutputs` as a second intercept (`375-393`). **Flat YAML recipes break the safety guarantee entirely.** `runYamlRecipe` → `executeStep` has *no* `dryRun` flag and *no* `mockedOutputs` map; the only gate before real dispatch is `assertWriteAllowed` (the kill-switch, not a sim gate). `resolveStepDeps` bakes in real `writeFileSync`/`appendFileSync` and inline `spawnSync` as defaults, and flat agent steps call real LLMs. `runRecipeDryPlan` for non-chained recipes routes to `buildSimpleRecipeDryRunSteps` — a *static analyzer* that never touches the runner. **The plan path and execution path are fully disjoint for flat recipes.**
+**Mitigation:** Hard-scope Phase-2 mocked execution to **chained recipes only** at v1. For flat recipes, ship Phase-1 *static* projection (never executes anything) and a visible "flat recipe — structural projection only, no sandbox" badge. The full fix (add `dryRun` + `mockedOutputs` to `RunnerDeps`, short-circuit `executeStep`, thread through `dispatchRecipe`) is real refactoring; defer behind a feature flag, never let it leak real I/O silently.
+
+### 3b. Projecting approvals without executing — **BREAKS (the single most dangerous claim)**
+The approval gate (`src/transport.ts:1408`) is a live-blocking await on **MCP bridge tool calls** (`gitPush`, `githubCreatePR`). It is **not wired into the recipe runner at all** — grepping `src/recipes/` for `approvalGate`/`classifyTool`/`queue.request` returns zero hits. Worse, `TIER_MAP` in `riskTier.ts` holds flat camelCase bridge names; recipe tool IDs are namespaced (`github.create_pr`, `file.write`, `git.log_since`) and match neither `TIER_MAP` nor the `^`-anchored `inferTierFromName` regexes — **every recipe tool falls through to `medium`.** A user who sees "2 approvals would trigger" and runs the recipe will see **zero** approvals fire. That is the opposite of trust-building.
+**Mitigation:** Two paths, pick one per phase. (1) **Honest-scoped projection** — use `ToolMetadata.riskDefault` (already correct per-tool) as the tier source, *not* `classifyTool`, and label the column unambiguously: *"would gate IF the approval gate were applied to recipe steps — it is not today."* (2) **Make it real** — wire an injectable approval predictor into `executeTool` (`deps.approvalPredictor?`) so `riskDefault` actually feeds a gate. Do **not** ship the approval column using `classifyTool` against namespaced IDs — it returns uniform `medium` and is confidently wrong.
+
+### 3c. Non-determinism of LLM/agent steps — **BREAKS for output content (inherent)**
+Agent steps call a real LLM; output content cannot be projected. A second simulation produces different outputs, different downstream templates, potentially a different DAG path. Synthetic/median outputs can mislead downstream template propagation. There is no `synthesizeMockedOutputs`; the real mechanism `buildMockedOutputs` requires a *single concrete prior run* and **drops truncated outputs** (>8 KB via `captureForRunlog`, `src/recipes/stepObservation.ts`) to `unmocked[]` — which then *fall through to real execution*. The large, useful payloads (PR bodies, file contents) are exactly the ones dropped.
+**Mitigation:** **Never execute agent steps in sim.** Resolve them to a historical-median output (when traces exist) or a clearly-labeled schema stub, each annotated with `confidence` + `sampleN`. Mark every agent output `"sampled from history, not predictive."` Accept that sim of an agent-heavy recipe projects *one plausible run*, not *the* run — and say so in the schema.
+
+### 3d. Cost/risk estimation accuracy — **BREAKS for cost as a data-driven number; PARTIAL for risk**
+**Cost:** `RunStepResult` has no token/cost fields; `RunBudget.totals()` (`BudgetTotals`) is computed but **never persisted** — only text `budgetWarnings` reach the run log. `quoteUsd` returns `undefined` for non-billable drivers, and **all shipped templates use `driver: claude-code` → `"subprocess"`**, outside `BILLABLE_DRIVERS = {anthropic, openai, grok}`. So `quoteUsd` returns `undefined` for the recipes users actually run, and there is no historical token corpus to fall back to — every projection is the `chars/4` heuristic the codebase itself calls "deliberately rough." The dashboard's "Min. cost" is already a hardcoded `$3/1M` lower-bound display heuristic.
+**Risk:** `aggregateRunRisk` does not exist. Per-step `risk` is `s.risk ?? "low"` with **no propagation** along dependencies. The DAG with dependencies exists only for chained recipes (`generateExecutionPlan`); flat recipes get a flat list with no edges.
+**Mitigation (cost):** Persist per-step tokens first (add `inputTokens`/`outputTokens`/`costUsd` to `RunStepResult`, persist `BudgetTotals` on `RecipeRun`) — a hot-path, augment-only schema change and a prerequisite, not a nice-to-have. Until that lands and runs accrue, present cost as `{minUsd, maxUsd, basis: "chars/4 heuristic", confidence: "low"}` and mark subprocess/claude-code steps explicitly **"notional — not billed"** (never `$0`, which reads as "free"). **Mitigation (risk):** Implement `aggregateRunRisk` as topological max-wins propagation over the chained DAG; for flat recipes either model the linear sequence as a chain or document "no blast-radius propagation."
+
+### 3e. False-confidence danger — **THE central UX risk, applies to all of the above**
+A polished panel showing "$0.04–$0.12, 80% approve" over `n=0` samples is worse than no panel. The existing dashboard primitives (`RiskMeter`, `EntityTimeline`, the DryRunPlan renderer) have **no low-confidence / ghost rendering mode**. The when-condition evaluator treats `[dry-run:fetch.result]` sentinels as **truthy** (`chainedRunner.ts:265-272`), so a `when: '{{ fetch_emails.count }}'` that should be `0` (false) will evaluate **true** in sim — silently predicting a step runs that the real run skips. "Rejected paths" built on sentinel branch evaluation is built on a broken foundation.
+**Mitigation:** Make confidence a first-class, *loud* field in the schema and the UI — `sampleN`, `basis`, and an `undetermined` outcome for any branch whose condition depends on un-projected agent/connector output. Never silently resolve a sentinel-driven `when:` as taken/skipped — emit `"undetermined: depends on <stepId> output not available in simulation."`
+
+## 4. Recommended approach
+
+**Winner: "Patchwork What-If" (the hybrid design).** It won the judge panel (3.33/5) because it is the only proposal that (a) treats the engine as a thin composition over five proven subsystems rather than a new runtime, (b) explicitly phases static-predictive (P1) before mocked-sandbox (P2) before automation-DSL extension (P3), and (c) refuses to execute agent steps — sidestepping the non-determinism trap that sank the SimBackend proposal.
+
+**Why it beat the others:**
+- **vs. Static-Analysis-First (3.00):** What-If keeps the static layer as its P0 but adds the trace-seeded `mockedOutputs` sandbox for realistic downstream template propagation — the static-only proposal degrades to "undetermined" on exactly the data-driven branches that matter most, and the judges flagged its sentinel-truthiness branch bug as "the highest-confidence false-confidence risk in the entire design."
+- **vs. Full Mocked Sandbox / SimBackend (2.33):** Its agent "no-write jail" is architecturally infeasible without threading sim state into `transport.ts` — agent MCP write calls go through the *bridge* transport gate, a different dispatch path than the recipe runner's `executeTool`. The jail leaks or the feature collapses to trace-mock anyway. What-If sidesteps this by never running agents live.
+- **vs. Monte-Carlo "Crystal Ball" (2.33):** Its two headline dimensions (cost, approval likelihood) are *data-starved at launch* — no persisted tokens, ephemeral approval history. Polished probability numbers over `n=0` are the exact hazard. What-If shares the data-starvation problem but doesn't *brand itself* on statistics it can't back.
+
+**Best ideas to graft from the runners-up:**
+- From **Crystal Ball**: the historical-median seeding of `mockedOutputs` (vs. one verbatim prior run), the `sampleN`/confidence-band discipline, and `summariseHalts`-derived per-step halt-probability with `HALT_CATEGORY_HINT` display. *Adopt these once token/trace persistence lands.*
+- From **Static-Analysis-First**: the stateless `POST /recipes/simulate` body shape (`{vars, policyOverrides, budgetOverride, approvalGate}`) for the instant re-sim loop, and the honest `SideEffect[]` taxonomy (read | local-write | connector-write | external-http).
+- From **SimBackend**: `costRouterCandidates()` returning *all* candidates + verdicts (today `costRouter` discards rejected ones) — the cleanest real "alternative paths considered" data source, and the `recipe_step_simulated` activity event so SSE subscribers distinguish sim from real runs.
+
+## 5. Phased implementation plan
+
+Each phase is independently shippable and independently valuable.
+
+### P0 — Honest static projection (chained + flat), no execution. **Effort: M**
+The minimal *honest* slice. Pure composition over `runRecipeDryPlan`. Per step: tool/type/resolved-params (already in the plan), structural `SideEffect[]` from `isWrite`/`isConnector` + `detectRequiredConnectors` (`src/recipes/connectorPreflight.ts:157`), per-step risk tier from `ToolMetadata.riskDefault`, and `aggregateRunRisk` (new) over the chained DAG. Cost shown as `chars/4` range explicitly badged "low confidence / heuristic." Approval column shows tier **only**, labeled "not gated on recipe steps today." Stateless `POST /recipes/simulate`.
+- *Extend:* `src/commands/recipe.ts` (add `runRecipeSimulate` + `RecipeSimulationReport` superset of `RecipeDryRunPlan`), `src/recipes/schemaGenerator.ts` (new `generateSimulationSchema`, **new `$id`** — never repurpose the dry-run `$id`), `src/recipeRoutes.ts` (add route via `deps.simulateFn`, mirror `runPlanFn`), `src/bridge.ts` (wire deps).
+- *New:* `src/recipes/simulation/simulate.ts`, `src/recipes/simulation/aggregateRunRisk.ts`, `src/recipes/simulation/types.ts`, `src/recipes/simulation/__tests__/*.test.ts`.
+- *Dashboard:* extend `dashboard/src/app/recipes/[...name]/_plan/page.tsx` renderer, new `SimulatePanel.tsx`, new dedicated proxy `dashboard/src/app/api/bridge/recipes/simulate/route.ts` (the dynamic `[...name]` proxy swallows the body — same lesson as the doctor proxy), Simulate button in the Controls PatchCard.
+
+### P1 — Cost-data persistence (prerequisite for any real cost number). **Effort: M**
+Augment-only, round-trip-safe schema change to the hot capture path. Add `inputTokens?`/`outputTokens?`/`costUsd?` to `RunStepResult` (`src/runLog.ts:37`), add `budgetTotals?: BudgetTotals` to `RecipeRun`, persist `RunBudget.totals()` at completion, add a `RunBudget.lastStepUsage()` accessor and capture per-step deltas after each `reconcile()` in `yamlRunner.ts` and `chainedRunner.ts`. **No projection logic yet** — this just builds the corpus future sims project from. Mark subprocess/claude-code as "notional" explicitly. Tests for old-row compatibility.
+
+### P2 — Trace-seeded mocked sandbox (chained recipes only). **Effort: L**
+Realistic downstream template propagation. New `synthesizeMockedOutputs(recipeName)` queries `RecipeRunLog` across runs, picks most-recent non-truncated output per stepId, falls back to `seedToolOutputPreviewContext` sentinels. Drives the existing `chainedRunner` `dryRun` + `mockedOutputs` seam. Agent steps resolve to historical-median or labeled stub — **never executed.** `when:` conditions emit `"undetermined"` when they depend on un-projected output (fixes the sentinel-truthiness bug). Add `costRouterCandidates()` for honest rejected-path data. Hard guard: **flat recipes get P0 static projection only**, with a visible badge.
+- *Extend:* `src/recipes/replayRun.ts` (multi-run seeding), `src/recipes/pricing/costRouter.ts` (`costRouterCandidates`), `src/recipes/chainedRunner.ts` (sim hook, no behavior change when absent), `src/recipes/toolRegistry.ts` (generalize `seedToolOutputPreviewContext` → `synthesizeOutput`), `src/activityLog.ts` (`recipe_step_simulated` event).
+- *New:* `src/recipes/simulation/synthesizeMockedOutputs.ts`, `src/recipes/simulation/branchEnumerator.ts`.
+
+### P3 — Real cost projection from accrued history + confidence UX. **Effort: M**
+Once P1 has accrued runs: pre-run estimator walks plan steps, uses historical per-step median tokens when `sampleN ≥ threshold`, else `chars/4`. Returns `{minUsd, maxUsd, basis, confidence, sampleN, unmeasuredSteps}`. Add a low-confidence/ghost rendering mode to the dashboard (the primitives lack one today). Replace the hardcoded `$3/1M` constant in `_plan/page.tsx`.
+
+### P4 — Real approval prediction (optional, requires gate wiring). **Effort: L**
+Only if the team decides recipe steps *should* be gated. Wire `deps.approvalPredictor?` into `executeTool`, feed `riskDefault` + `computePersonalSignals` (against recipe-tool ActivityLog history, which must first exist). Until this ships, P0's tier-only labeled column stands.
+
+### P5 — Automation-DSL "what would fire" + sim history/compare. **Effort: L (deferred)**
+Apply a `SimulationBackend` (copy of `TestBackend`) to `executeAutomationPolicy` for "what would fire on file save." Add `sim_run` trace type, A/B compare, sim job lifecycle. Explicitly deferred to keep P0–P4 at sane effort.
+
+## 6. Risk score & approval-prediction design (given today's code)
+
+**Risk score — buildable now, derived not oracular.** Implement `aggregateRunRisk(plan)`:
+1. Source per-step tier from `ToolMetadata.riskDefault` (already populated and correct), not `classifyTool` (which mis-classifies namespaced IDs to uniform `medium`).
+2. For chained recipes, walk `steps[].dependencies` / `parallelGroups` in topological order, max-wins: a step inherits the highest tier among its transitive upstreams. Add an `effectiveRisk` field distinct from the author literal.
+3. Map to a 0–100 workflow score weighting count of high-tier steps, unacknowledged writes (reuse the `runPreflight` write-ack check), and connector blast-radius. **Always show the inputs** — a derived score with components, not a black box.
+4. For flat recipes, model the linear sequence as a chain (step N depends on N−1) and propagate forward, or document "no propagation."
+
+**Approval prediction — two honest options, never `classifyTool`-on-namespaced-IDs:**
+- *Option A (P0, no code-path change):* tier from `riskDefault`; column header reads *"Risk tier — recipe steps are NOT gated by the approval queue today; this is the tier that would apply if they were."* Attach `computeRiskSignals` (content-level, pure) per step. Add `computePersonalSignals` **only** when ActivityLog has matching history, degrade to tier-only on cold start.
+- *Option B (P4, real):* wire `riskDefault` → injectable `approvalPredictor` inside `executeTool`, so the gate actually fires and the prediction matches runtime. The live gate (`transport.ts:1408`) cannot be reused — it is a blocking human await, not a predictor.
+
+Non-negotiable: the output schema must carry a `gatedOnRecipeSteps: boolean` field so the UI can never imply a gate that doesn't exist.
+
+## 7. What NOT to do / scope traps
+
+- **Do NOT ship the approval column using `classifyTool` against recipe tool IDs.** It returns uniform `medium` and predicts a gate that never fires. The verification's most damning finding — sim can *actively erode trust*.
+- **Do NOT present cost as a precise dollar figure or `$0`.** `quoteUsd` returns `undefined` for the default `claude-code`/subprocess driver; the only data is `chars/4`. Always a labeled range; subprocess steps are "notional," never "free."
+- **Do NOT let flat-recipe sim touch the runner.** Flat `executeStep` has no dry-run short-circuit; a Phase-2 attempt invokes real `writeFileSync`/`spawnSync`/LLM calls. Static-only for flat at v1, hard-guarded.
+- **Do NOT resolve sentinel-driven `when:` branches as taken/skipped.** Sentinels are truthy; emit `"undetermined"` instead.
+- **Do NOT brand it "Monte-Carlo" / statistical** until token persistence (P1) has accrued real data. Polished probabilities over `n=0` are the central UX hazard.
+- **Do NOT try to mock every connector for value-level fidelity.** Projecting *which* connector fires (namespace) is cheap and reliable; projecting *what payload* it sends requires per-connector simulators that drift from reality. Stay at the taxonomy level.
+- **Do NOT mutate the dry-run plan `$id`.** Superset with a new `$id`/schemaVersion or break pinned consumers.
+- **Do NOT build agent no-write jails.** Agent write calls route through the bridge transport gate, not `executeTool`. Resolve agents to history/stub, never run live.
+- **Do NOT scope-creep into sim job lifecycle / A/B compare / `sim_run` traces** at v1. Keep `POST /recipes/simulate` stateless; defer to P5.
+
+## 8. Open questions for the team
+
+1. **Should recipe-runner tools actually be gated by the approval queue?** The strategic fork. If yes, P4 becomes a priority and the approval column becomes literally true. If no, the column stays a clearly-labeled "tier-if-applied" projection forever.
+2. **Flat-recipe sandbox: refactor or document the limitation?** Acceptable to ship "chained recipes get the sandbox, flat recipes get static projection" at v1, or is flat-recipe parity a hard requirement?
+3. **How aggressive on cost-data persistence?** P1 touches the hot capture path (`yamlRunner`/`runLog`). Comfortable adding token/cost fields to `RunStepResult` now (augment-only), or defer cost projection entirely?
+4. **Naming.** "Counterfactual Simulation Engine" over-promises given the honest fidelity ceiling. "What-If Preview" / "Pre-flight" / "Dry-Run+" set expectations lower.
+5. **Confidence-rendering investment.** The dashboard primitives lack a low-confidence/ghost mode. Build that affordance (the antidote to false confidence), or ship plain numbers with text caveats at v1?
+6. **Trace-corpus floor.** What `sampleN` threshold gates "data-driven projection" vs. "heuristic estimate"? (Suggest ≥5 for cost/latency, ≥10 for approval likelihood.)

--- a/src/commands/recipe.ts
+++ b/src/commands/recipe.ts
@@ -34,6 +34,8 @@ import {
 } from "../recipes/migrations/index.js";
 import { tryResolveRecipePath } from "../recipes/resolveRecipePath.js";
 import { generateSchemaSet, writeSchemas } from "../recipes/schemaGenerator.js";
+import { simulateFromPlan } from "../recipes/simulation/simulate.js";
+import type { RecipeSimulationReport } from "../recipes/simulation/types.js";
 import {
   getTool,
   isConnectorNamespace,
@@ -1648,6 +1650,23 @@ export async function runRecipeDryPlan(
     ...summarizePlanSteps(steps),
     lint,
   };
+}
+
+/**
+ * What-If Preview — run a static counterfactual simulation of a recipe.
+ *
+ * Produces the dry-run plan first (no execution), then transforms it into a
+ * {@link RecipeSimulationReport} that projects actions, side-effect taxonomy,
+ * blast-radius-aware risk, a tier-only approval projection (honestly flagged as
+ * NOT gated on recipe steps today), a low-confidence cost estimate, and the
+ * conditional branches it refuses to resolve statically. Zero side effects.
+ */
+export async function runRecipeSimulate(
+  recipeRef: string,
+  options: RunRecipeOptions = {},
+): Promise<RecipeSimulationReport> {
+  const plan = await runRecipeDryPlan(recipeRef, options);
+  return simulateFromPlan(plan);
 }
 
 // ============================================================================

--- a/src/index.ts
+++ b/src/index.ts
@@ -2942,6 +2942,140 @@ if (process.argv[2] === "recipe" && process.argv[3] === "preflight") {
   })();
 }
 
+// `recipe simulate <name|file>` — What-If Preview. Statically simulates a
+// recipe before it is enabled: projected actions, side-effect taxonomy,
+// blast-radius risk, tier-only approval projection (honestly flagged as NOT
+// gated on recipe steps today), low-confidence cost, and undetermined
+// conditional branches. Executes nothing. See runRecipeSimulate in
+// commands/recipe.ts.
+if (process.argv[2] === "recipe" && process.argv[3] === "simulate") {
+  const args = process.argv.slice(4);
+  const usage =
+    "Usage: patchwork recipe simulate <name|file.yaml> [--json] [--step <id>] [--var k=v]\n\n" +
+    "What-If Preview: statically simulate a recipe before enabling it.\n" +
+    "Shows projected actions, side effects, risk, approvals (tier-only),\n" +
+    "cost (low-confidence), and undetermined branches. Executes nothing.\n";
+  let json = false;
+  let step: string | undefined;
+  const vars: Record<string, string> = {};
+  let target: string | undefined;
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === undefined) continue;
+    if (arg === "--json") {
+      json = true;
+      continue;
+    }
+    if (arg === "--step" || arg.startsWith("--step=")) {
+      const value = arg === "--step" ? args[++i] : arg.slice("--step=".length);
+      if (!value) {
+        process.stderr.write(`Error: --step requires a value\n${usage}`);
+        process.exit(1);
+      }
+      step = value;
+      continue;
+    }
+    if (arg === "--var" || arg.startsWith("--var=")) {
+      const value = arg === "--var" ? args[++i] : arg.slice("--var=".length);
+      if (!value?.includes("=")) {
+        process.stderr.write(`Error: --var requires k=v\n${usage}`);
+        process.exit(1);
+      }
+      const idx = value.indexOf("=");
+      vars[value.slice(0, idx)] = value.slice(idx + 1);
+      continue;
+    }
+    if (!arg.startsWith("--")) {
+      target = arg;
+    }
+  }
+
+  if (!target) {
+    process.stderr.write(usage);
+    process.exit(1);
+  }
+
+  (async () => {
+    try {
+      const { runRecipeSimulate } = await import("./commands/recipe.js");
+      const report = await runRecipeSimulate(target as string, {
+        ...(step ? { step } : {}),
+        ...(Object.keys(vars).length ? { vars } : {}),
+      });
+
+      if (json) {
+        process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+        process.exit(0);
+      }
+
+      const out = process.stdout;
+      const mark = (tier: string): string =>
+        tier === "high" ? "●" : tier === "medium" ? "◐" : "○";
+      out.write(
+        `\n  What-If Preview — ${report.recipe} (${report.topology}, ${report.fidelity} fidelity)\n`,
+      );
+      out.write(
+        `  Trigger: ${report.triggerType} · ${report.summary.totalSteps} step(s)\n\n`,
+      );
+      out.write(
+        `  Risk: ${report.risk.tier.toUpperCase()} (score ${report.risk.score}/100)\n`,
+      );
+      const c = report.risk.components;
+      out.write(
+        `    high:${c.highSteps} medium:${c.mediumSteps} writes:${c.writeSteps} connector-writes:${c.connectorWriteSteps} http:${c.externalHttpSteps} unresolved:${c.unresolvedSteps}\n\n`,
+      );
+      out.write("  Actions:\n");
+      for (const s of report.steps) {
+        const tool = s.tool ?? s.type;
+        const when = s.condition ? `  when: ${s.condition}` : "";
+        out.write(
+          `    ${mark(s.effectiveRisk)} ${s.id}  ${tool}  [${s.sideEffect}]${when}\n`,
+        );
+      }
+      out.write("\n");
+      const ns = report.summary.connectorNamespaces;
+      out.write(
+        `  Side effects: ${report.summary.writeSteps} write(s) · ${report.summary.connectorSteps} connector call(s)${
+          ns.length ? ` (${ns.join(", ")})` : ""
+        } · ${report.summary.agentSteps} agent step(s)\n`,
+      );
+      const gating = report.approvals.projected.filter(
+        (a) => a.wouldRequireApproval,
+      ).length;
+      out.write(
+        `  Approvals: ${gating} step(s) would gate IF recipe steps were gated — they are NOT gated today\n`,
+      );
+      out.write(
+        `  Cost: ${
+          report.cost.basis === "heuristic"
+            ? `~${report.cost.estPromptTokens} input token(s) over ${report.cost.estimatedAgentSteps} agent step(s) (heuristic); USD not projected`
+            : report.cost.note
+        }\n`,
+      );
+      if (report.branches.length > 0) {
+        out.write(
+          `  Branches: ${report.branches.length} conditional — undetermined (resolve in a later sandbox phase)\n`,
+        );
+      }
+      if (report.lint.errors.length > 0 || report.lint.warnings.length > 0) {
+        out.write(
+          `  Lint: ${report.lint.errors.length} error(s), ${report.lint.warnings.length} warning(s)\n`,
+        );
+      }
+      out.write("\n  Notes:\n");
+      for (const n of report.notes) out.write(`    • ${n}\n`);
+      out.write("\n");
+      process.exit(0);
+    } catch (err) {
+      process.stderr.write(
+        `Error: ${err instanceof Error ? err.message : String(err)}\n`,
+      );
+      process.exit(1);
+    }
+  })();
+}
+
 // `recipe doctor <name|file>` — one-screen "why is this recipe unhealthy
 // + how do I fix it" diagnosis. Composes the static preflight check with
 // the recipe-scoped runtime halt summary from a live bridge (fail-soft:

--- a/src/recipes/simulation/__tests__/simulate.test.ts
+++ b/src/recipes/simulation/__tests__/simulate.test.ts
@@ -1,0 +1,305 @@
+import { describe, expect, it } from "vitest";
+import type { RecipeDryRunPlan } from "../../../commands/recipe.js";
+import {
+  computeEffectiveRisks,
+  maxRisk,
+  summarizeRunRisk,
+} from "../aggregateRunRisk.js";
+import { classifyStepSideEffect } from "../sideEffects.js";
+import { simulateFromPlan } from "../simulate.js";
+
+function makePlan(over: Partial<RecipeDryRunPlan>): RecipeDryRunPlan {
+  return {
+    schemaVersion: 1,
+    recipe: "test-recipe",
+    mode: "dry-run",
+    triggerType: "manual",
+    generatedAt: "2026-06-05T00:00:00.000Z",
+    steps: [],
+    lint: { errors: [], warnings: [] },
+    ...over,
+  };
+}
+
+describe("classifyStepSideEffect", () => {
+  it("maps agent and recipe step types", () => {
+    expect(classifyStepSideEffect({ type: "agent" })).toBe("agent-llm");
+    expect(classifyStepSideEffect({ type: "recipe" })).toBe("nested-recipe");
+  });
+
+  it("returns unknown for unresolved tools", () => {
+    expect(
+      classifyStepSideEffect({
+        type: "tool",
+        tool: "mystery.thing",
+        resolved: false,
+      }),
+    ).toBe("unknown");
+  });
+
+  it("treats http/webhook namespaces as external-http regardless of write", () => {
+    expect(
+      classifyStepSideEffect({
+        type: "tool",
+        tool: "http.request",
+        resolved: true,
+      }),
+    ).toBe("external-http");
+    expect(
+      classifyStepSideEffect({
+        type: "tool",
+        tool: "webhook.post",
+        namespace: "webhook",
+        resolved: true,
+        isWrite: true,
+      }),
+    ).toBe("external-http");
+  });
+
+  it("splits connector vs local on isConnector + isWrite", () => {
+    expect(
+      classifyStepSideEffect({
+        type: "tool",
+        tool: "github.create_pr",
+        resolved: true,
+        isConnector: true,
+        isWrite: true,
+      }),
+    ).toBe("connector-write");
+    expect(
+      classifyStepSideEffect({
+        type: "tool",
+        tool: "github.list_prs",
+        resolved: true,
+        isConnector: true,
+        isWrite: false,
+      }),
+    ).toBe("connector-read");
+    expect(
+      classifyStepSideEffect({
+        type: "tool",
+        tool: "file.write",
+        resolved: true,
+        isWrite: true,
+      }),
+    ).toBe("local-write");
+    expect(
+      classifyStepSideEffect({
+        type: "tool",
+        tool: "git.log",
+        resolved: true,
+        isWrite: false,
+      }),
+    ).toBe("local-read");
+  });
+});
+
+describe("computeEffectiveRisks", () => {
+  it("propagates a high upstream dependency down to a low dependent (chained)", () => {
+    const eff = computeEffectiveRisks(
+      [
+        { id: "a", baseRisk: "high" },
+        { id: "b", baseRisk: "low", dependencies: ["a"] },
+        { id: "c", baseRisk: "low", dependencies: ["b"] },
+        { id: "d", baseRisk: "medium" },
+      ],
+      "chained",
+    );
+    expect(eff.get("a")).toBe("high");
+    expect(eff.get("b")).toBe("high");
+    expect(eff.get("c")).toBe("high");
+    expect(eff.get("d")).toBe("medium"); // independent branch unaffected
+  });
+
+  it("uses a linear running max for flat recipes", () => {
+    const eff = computeEffectiveRisks(
+      [
+        { id: "a", baseRisk: "low" },
+        { id: "b", baseRisk: "medium" },
+        { id: "c", baseRisk: "low" },
+        { id: "d", baseRisk: "high" },
+      ],
+      "flat",
+    );
+    expect(eff.get("a")).toBe("low");
+    expect(eff.get("b")).toBe("medium");
+    expect(eff.get("c")).toBe("medium");
+    expect(eff.get("d")).toBe("high");
+  });
+
+  it("does not infinite-loop on a dependency cycle", () => {
+    const eff = computeEffectiveRisks(
+      [
+        { id: "a", baseRisk: "low", dependencies: ["b"] },
+        { id: "b", baseRisk: "medium", dependencies: ["a"] },
+      ],
+      "chained",
+    );
+    expect(eff.get("a")).toBe("medium");
+    expect(eff.get("b")).toBe("medium");
+  });
+
+  it("maxRisk orders tiers correctly", () => {
+    expect(maxRisk("low", "high")).toBe("high");
+    expect(maxRisk("medium", "low")).toBe("medium");
+  });
+});
+
+describe("summarizeRunRisk", () => {
+  it("derives score + components and escalates tier on a high step", () => {
+    const s = summarizeRunRisk([
+      { effectiveRisk: "high", sideEffect: "connector-write", resolved: true },
+      { effectiveRisk: "low", sideEffect: "local-read", resolved: true },
+    ]);
+    expect(s.components.highSteps).toBe(1);
+    expect(s.components.connectorWriteSteps).toBe(1);
+    expect(s.components.writeSteps).toBe(1);
+    expect(s.highestStepRisk).toBe("high");
+    expect(s.tier).toBe("high");
+    expect(s.score).toBeGreaterThan(0);
+    expect(s.score).toBeLessThanOrEqual(100);
+  });
+
+  it("stays low for a read-only plan", () => {
+    const s = summarizeRunRisk([
+      { effectiveRisk: "low", sideEffect: "local-read", resolved: true },
+      { effectiveRisk: "low", sideEffect: "connector-read", resolved: true },
+    ]);
+    expect(s.tier).toBe("low");
+    expect(s.score).toBe(0);
+  });
+});
+
+describe("simulateFromPlan", () => {
+  it("is honest about the approval gate on every report", () => {
+    const report = simulateFromPlan(makePlan({}));
+    expect(report.gatedOnRecipeSteps).toBe(false);
+    expect(report.approvals.gatedOnRecipeSteps).toBe(false);
+    expect(report.kind).toBe("what-if-preview");
+    expect(report.fidelity).toBe("static");
+    expect(report.notes.some((n) => n.includes("NOT gated"))).toBe(true);
+  });
+
+  it("reuses the plan timestamp (pure, no clock dependency)", () => {
+    const report = simulateFromPlan(
+      makePlan({ generatedAt: "2020-01-02T03:04:05.000Z" }),
+    );
+    expect(report.generatedAt).toBe("2020-01-02T03:04:05.000Z");
+  });
+
+  it("estimates cost heuristically for a flat recipe with an agent prompt", () => {
+    const report = simulateFromPlan(
+      makePlan({
+        triggerType: "manual",
+        steps: [
+          { id: "draft", type: "agent", prompt: "x".repeat(40), into: "draft" },
+        ],
+      }),
+    );
+    expect(report.topology).toBe("flat");
+    expect(report.cost.basis).toBe("heuristic");
+    expect(report.cost.estPromptTokens).toBe(10); // 40 chars / 4
+    expect(report.cost.estimatedAgentSteps).toBe(1);
+    expect(report.cost.usd).toBeNull();
+  });
+
+  it("reports cost unavailable when there are no agent steps", () => {
+    const report = simulateFromPlan(
+      makePlan({
+        steps: [
+          {
+            id: "read",
+            type: "tool",
+            tool: "git.log",
+            risk: "low",
+            resolved: true,
+          },
+        ],
+      }),
+    );
+    expect(report.cost.basis).toBe("unavailable");
+    expect(report.cost.estPromptTokens).toBeNull();
+    expect(report.cost.note).toContain("no model cost");
+  });
+
+  it("reports cost unavailable for chained agent steps that carry no prompt", () => {
+    const report = simulateFromPlan(
+      makePlan({
+        triggerType: "chained",
+        steps: [{ id: "judge", type: "agent" }],
+      }),
+    );
+    expect(report.topology).toBe("chained");
+    expect(report.cost.basis).toBe("unavailable");
+    expect(report.cost.note).toContain("not present in the static plan");
+  });
+
+  it("projects approvals, side effects, risk and undetermined branches (chained)", () => {
+    const report = simulateFromPlan(
+      makePlan({
+        triggerType: "chained",
+        connectorNamespaces: ["github"],
+        steps: [
+          {
+            id: "fetch",
+            type: "tool",
+            tool: "github.list_prs",
+            namespace: "github",
+            risk: "low",
+            isConnector: true,
+            isWrite: false,
+            resolved: true,
+          },
+          {
+            id: "open_pr",
+            type: "tool",
+            tool: "github.create_pr",
+            namespace: "github",
+            risk: "high",
+            isConnector: true,
+            isWrite: true,
+            resolved: true,
+            dependencies: ["fetch"],
+            condition: "{{ fetch.count }}",
+          },
+        ],
+      }),
+    );
+
+    // side-effect taxonomy
+    expect(report.summary.sideEffectCounts["connector-read"]).toBe(1);
+    expect(report.summary.sideEffectCounts["connector-write"]).toBe(1);
+    expect(report.summary.connectorNamespaces).toEqual(["github"]);
+    expect(report.summary.writeSteps).toBe(1);
+
+    // blast radius: the read feeds nothing higher, the write is high
+    const openPr = report.steps.find((s) => s.id === "open_pr");
+    expect(openPr?.effectiveRisk).toBe("high");
+    expect(report.risk.tier).toBe("high");
+
+    // approval projection: the high write would gate; flagged not-gated-today
+    const proj = report.approvals.projected.find((a) => a.stepId === "open_pr");
+    expect(proj?.wouldRequireApproval).toBe(true);
+    expect(proj?.tier).toBe("high");
+
+    // honest branches: the condition is left undetermined, never faked
+    expect(report.branches).toHaveLength(1);
+    expect(report.branches[0]?.stepId).toBe("open_pr");
+    expect(report.branches[0]?.outcome).toBe("undetermined");
+  });
+
+  it("flags unresolved tools and adds a note", () => {
+    const report = simulateFromPlan(
+      makePlan({
+        steps: [
+          { id: "x", type: "tool", tool: "mystery.thing", resolved: false },
+        ],
+      }),
+    );
+    expect(report.summary.unresolvedSteps).toBe(1);
+    expect(report.summary.sideEffectCounts.unknown).toBe(1);
+    expect(
+      report.notes.some((n) => n.includes("unknown to the registry")),
+    ).toBe(true);
+  });
+});

--- a/src/recipes/simulation/aggregateRunRisk.ts
+++ b/src/recipes/simulation/aggregateRunRisk.ts
@@ -1,0 +1,141 @@
+/**
+ * What-If Preview — run-level risk aggregation.
+ *
+ * Two pure pieces:
+ *   1. `computeEffectiveRisks` — blast-radius propagation. A step's effective
+ *      risk is at least as high as the highest risk among the steps that must
+ *      have run before it (its transitive dependencies). Chained recipes use
+ *      the real dependency DAG; flat recipes model the linear sequence
+ *      (step N implicitly depends on N-1).
+ *   2. `summarizeRunRisk` — a transparent 0–100 workflow score derived from
+ *      step counts, returned WITH its components so it is never a black box.
+ *
+ * Risk tier source is `riskDefault` (already enriched onto the plan step),
+ * NOT `classifyTool` — which mis-tiers namespaced recipe tool ids to a uniform
+ * "medium" (see the investigation report, §3b).
+ */
+
+import type {
+  RiskComponents,
+  RiskTier,
+  RunRiskSummary,
+  SideEffectKind,
+} from "./types.js";
+
+const RISK_ORDER: Record<RiskTier, number> = { low: 0, medium: 1, high: 2 };
+const RISK_BY_ORDER: RiskTier[] = ["low", "medium", "high"];
+
+export function maxRisk(a: RiskTier, b: RiskTier): RiskTier {
+  return RISK_ORDER[a] >= RISK_ORDER[b] ? a : b;
+}
+
+export interface RiskStepInput {
+  id: string;
+  baseRisk: RiskTier;
+  /** Upstream step ids (chained). Ignored for flat topology. */
+  dependencies?: string[];
+}
+
+/**
+ * Compute each step's effective (blast-radius-aware) risk.
+ *
+ * Returns a map keyed by step id. Cycles are broken safely: a step already on
+ * the current resolution stack contributes only its own base risk to break the
+ * loop, so a malformed DAG can never infinite-loop the planner.
+ */
+export function computeEffectiveRisks(
+  steps: RiskStepInput[],
+  topology: "chained" | "flat",
+): Map<string, RiskTier> {
+  const byId = new Map<string, RiskStepInput>();
+  for (const s of steps) byId.set(s.id, s);
+
+  const memo = new Map<string, RiskTier>();
+
+  if (topology === "flat") {
+    // Linear: running max down the list.
+    let running: RiskTier = "low";
+    for (const s of steps) {
+      running = maxRisk(running, s.baseRisk);
+      memo.set(s.id, running);
+    }
+    return memo;
+  }
+
+  // Chained: forward propagation along the dependency edges.
+  const resolving = new Set<string>();
+  const resolve = (id: string): RiskTier => {
+    const cached = memo.get(id);
+    if (cached !== undefined) return cached;
+    const step = byId.get(id);
+    if (!step) return "low";
+    if (resolving.has(id)) return step.baseRisk; // cycle guard
+    resolving.add(id);
+    let eff = step.baseRisk;
+    for (const dep of step.dependencies ?? []) {
+      if (dep === id || !byId.has(dep)) continue;
+      eff = maxRisk(eff, resolve(dep));
+    }
+    resolving.delete(id);
+    memo.set(id, eff);
+    return eff;
+  };
+
+  for (const s of steps) resolve(s.id);
+  return memo;
+}
+
+export interface RiskTallyInput {
+  effectiveRisk: RiskTier;
+  sideEffect: SideEffectKind;
+  resolved: boolean;
+}
+
+const clamp100 = (n: number): number => Math.max(0, Math.min(100, n));
+
+/**
+ * Derive a transparent 0–100 workflow risk score + tier from per-step tallies.
+ * The weights are intentionally simple and surfaced via `components` so a
+ * consumer can always explain the number.
+ */
+export function summarizeRunRisk(steps: RiskTallyInput[]): RunRiskSummary {
+  const components: RiskComponents = {
+    highSteps: 0,
+    mediumSteps: 0,
+    writeSteps: 0,
+    connectorWriteSteps: 0,
+    externalHttpSteps: 0,
+    unresolvedSteps: 0,
+  };
+  let highestOrder = 0;
+
+  for (const s of steps) {
+    highestOrder = Math.max(highestOrder, RISK_ORDER[s.effectiveRisk]);
+    if (s.effectiveRisk === "high") components.highSteps += 1;
+    else if (s.effectiveRisk === "medium") components.mediumSteps += 1;
+
+    if (s.sideEffect === "local-write" || s.sideEffect === "connector-write") {
+      components.writeSteps += 1;
+    }
+    if (s.sideEffect === "connector-write") components.connectorWriteSteps += 1;
+    if (s.sideEffect === "external-http") components.externalHttpSteps += 1;
+    if (!s.resolved) components.unresolvedSteps += 1;
+  }
+
+  const score = clamp100(
+    components.highSteps * 30 +
+      components.mediumSteps * 10 +
+      components.writeSteps * 8 +
+      components.connectorWriteSteps * 10 +
+      components.externalHttpSteps * 6 +
+      components.unresolvedSteps * 5,
+  );
+
+  const highestStepRisk = RISK_BY_ORDER[highestOrder] ?? "low";
+  let tier: RiskTier;
+  if (highestStepRisk === "high" || score >= 60) tier = "high";
+  else if (highestStepRisk === "medium" || score >= 25) tier = "medium";
+  else tier = "low";
+
+  return { score, tier, components, highestStepRisk };
+}

--- a/src/recipes/simulation/sideEffects.ts
+++ b/src/recipes/simulation/sideEffects.ts
@@ -1,0 +1,75 @@
+/**
+ * What-If Preview — static side-effect classification.
+ *
+ * Classifies a single plan step into a {@link SideEffectKind} using ONLY
+ * registry metadata already present on the dry-run plan step
+ * (`type` / `tool` / `namespace` / `isWrite` / `isConnector` / `resolved`).
+ * No execution, no network, no token resolution.
+ */
+
+import type { SideEffectKind } from "./types.js";
+
+/** Namespaces whose writes are arbitrary outbound HTTP rather than a SaaS connector. */
+const EXTERNAL_HTTP_NAMESPACES = new Set(["http", "webhook"]);
+
+export interface SideEffectInput {
+  type: "tool" | "agent" | "recipe";
+  tool?: string;
+  namespace?: string;
+  resolved?: boolean;
+  isWrite?: boolean;
+  isConnector?: boolean;
+}
+
+/**
+ * Map a plan step to its side-effect class. Pure and total.
+ *
+ * Precedence:
+ *   agent → agent-llm; recipe → nested-recipe.
+ *   unresolved tool → unknown (we cannot claim a side effect we can't see).
+ *   http/webhook namespace → external-http (write or read).
+ *   connector → connector-write / connector-read on isWrite.
+ *   otherwise local-write / local-read on isWrite.
+ */
+export function classifyStepSideEffect(step: SideEffectInput): SideEffectKind {
+  if (step.type === "agent") return "agent-llm";
+  if (step.type === "recipe") return "nested-recipe";
+
+  // type === "tool"
+  if (step.resolved === false) return "unknown";
+
+  const ns = step.namespace ?? step.tool?.split(".")[0];
+  if (ns && EXTERNAL_HTTP_NAMESPACES.has(ns)) return "external-http";
+
+  const isWrite = step.isWrite === true;
+  if (step.isConnector === true) {
+    return isWrite ? "connector-write" : "connector-read";
+  }
+  return isWrite ? "local-write" : "local-read";
+}
+
+/** Human-readable, one-line description of a side-effect class. */
+export const SIDE_EFFECT_LABELS: Record<SideEffectKind, string> = {
+  "local-read": "reads local/workspace state",
+  "local-write": "writes local/workspace state",
+  "connector-read": "reads an external connector",
+  "connector-write": "writes to an external connector",
+  "external-http": "makes an outbound HTTP/webhook call",
+  "agent-llm": "runs an AI/agent step (not executed in simulation)",
+  "nested-recipe": "delegates to a nested recipe",
+  unknown: "unresolved tool — side effect unknown",
+};
+
+/** Empty side-effect tally with every kind present (so consumers can index safely). */
+export function emptySideEffectCounts(): Record<SideEffectKind, number> {
+  return {
+    "local-read": 0,
+    "local-write": 0,
+    "connector-read": 0,
+    "connector-write": 0,
+    "external-http": 0,
+    "agent-llm": 0,
+    "nested-recipe": 0,
+    unknown: 0,
+  };
+}

--- a/src/recipes/simulation/simulate.ts
+++ b/src/recipes/simulation/simulate.ts
@@ -1,0 +1,229 @@
+/**
+ * What-If Preview — static simulation core.
+ *
+ * `simulateFromPlan` is a PURE transform: dry-run plan → simulation report.
+ * It performs no I/O and has no clock dependency (it reuses the plan's
+ * `generatedAt`), so it is fully deterministic and unit-testable. The
+ * I/O-bearing entrypoint (`runRecipeSimulate`, which produces the plan first)
+ * lives in `src/commands/recipe.ts`.
+ */
+
+import type {
+  RecipeDryRunPlan,
+  RecipeDryRunPlanStep,
+} from "../../commands/recipe.js";
+import { computeEffectiveRisks, summarizeRunRisk } from "./aggregateRunRisk.js";
+import {
+  classifyStepSideEffect,
+  emptySideEffectCounts,
+} from "./sideEffects.js";
+import {
+  type ApprovalProjection,
+  type BranchProjection,
+  type RecipeSimulationReport,
+  type RiskTier,
+  SIMULATION_SCHEMA_VERSION,
+  type SimulationCost,
+  type SimulationStep,
+} from "./types.js";
+
+/** Chars-per-token heuristic, matching the codebase's deliberately-rough estimate. */
+const CHARS_PER_TOKEN = 4;
+
+const isTier = (v: unknown): v is RiskTier =>
+  v === "low" || v === "medium" || v === "high";
+
+/** A step is "resolved" unless it is a tool whose id was not in the registry. */
+function stepResolved(step: RecipeDryRunPlanStep): boolean {
+  if (step.type !== "tool") return true;
+  return step.resolved === true;
+}
+
+function buildSteps(
+  plan: RecipeDryRunPlan,
+  topology: "chained" | "flat",
+): SimulationStep[] {
+  const baseRisks = plan.steps.map(
+    (s): { id: string; baseRisk: RiskTier; dependencies?: string[] } => ({
+      id: s.id,
+      baseRisk: isTier(s.risk) ? s.risk : "low",
+      ...(s.dependencies ? { dependencies: s.dependencies } : {}),
+    }),
+  );
+  const effective = computeEffectiveRisks(baseRisks, topology);
+
+  return plan.steps.map((s): SimulationStep => {
+    const resolved = stepResolved(s);
+    const isWrite = s.isWrite === true;
+    const isConnector = s.isConnector === true;
+    const baseRisk = isTier(s.risk) ? s.risk : "low";
+    const sideEffect = classifyStepSideEffect({
+      type: s.type,
+      ...(s.tool !== undefined ? { tool: s.tool } : {}),
+      ...(s.namespace !== undefined ? { namespace: s.namespace } : {}),
+      resolved,
+      isWrite,
+      isConnector,
+    });
+    return {
+      id: s.id,
+      type: s.type,
+      ...(s.tool !== undefined ? { tool: s.tool } : {}),
+      ...(s.namespace !== undefined ? { namespace: s.namespace } : {}),
+      resolved,
+      ...(s.optional !== undefined ? { optional: s.optional } : {}),
+      ...(s.dependencies ? { dependencies: s.dependencies } : {}),
+      ...(s.condition !== undefined ? { condition: s.condition } : {}),
+      baseRisk,
+      effectiveRisk: effective.get(s.id) ?? baseRisk,
+      sideEffect,
+      isWrite,
+      isConnector,
+    };
+  });
+}
+
+function buildCost(plan: RecipeDryRunPlan): SimulationCost {
+  const agentPlanSteps = plan.steps.filter((s) => s.type === "agent");
+  const agentSteps = agentPlanSteps.length;
+  const withPrompt = agentPlanSteps.filter(
+    (s) => typeof s.prompt === "string" && s.prompt.length > 0,
+  );
+  const estimatedAgentSteps = withPrompt.length;
+
+  if (agentSteps === 0) {
+    return {
+      basis: "unavailable",
+      agentSteps: 0,
+      estimatedAgentSteps: 0,
+      estPromptTokens: null,
+      usd: null,
+      note: "No AI/agent steps — this recipe incurs no model cost.",
+    };
+  }
+
+  if (estimatedAgentSteps === 0) {
+    return {
+      basis: "unavailable",
+      agentSteps,
+      estimatedAgentSteps: 0,
+      estPromptTokens: null,
+      usd: null,
+      note: "Agent prompts are not present in the static plan for this recipe topology — cost not estimable until a mocked/sandbox run (later phase).",
+    };
+  }
+
+  const estPromptTokens = withPrompt.reduce(
+    (sum, s) => sum + Math.ceil((s.prompt as string).length / CHARS_PER_TOKEN),
+    0,
+  );
+  return {
+    basis: "heuristic",
+    agentSteps,
+    estimatedAgentSteps,
+    estPromptTokens,
+    usd: null,
+    note: "Low-confidence chars/4 token estimate over agent prompts (input only). USD is not projected at static fidelity — the default driver is a subscription/subprocess driver that is not billed; set an API driver + budget for a cost number.",
+  };
+}
+
+/** Pure transform: a dry-run plan → a What-If Preview simulation report. */
+export function simulateFromPlan(
+  plan: RecipeDryRunPlan,
+): RecipeSimulationReport {
+  const topology: "chained" | "flat" =
+    plan.triggerType === "chained" ? "chained" : "flat";
+  const gatedOnRecipeSteps = false; // P0/P4 truth: recipe steps are not gated today.
+
+  const steps = buildSteps(plan, topology);
+
+  const sideEffectCounts = emptySideEffectCounts();
+  for (const s of steps) sideEffectCounts[s.sideEffect] += 1;
+
+  const summary = {
+    totalSteps: steps.length,
+    writeSteps: steps.filter((s) => s.isWrite).length,
+    connectorSteps: steps.filter((s) => s.isConnector).length,
+    agentSteps: steps.filter((s) => s.type === "agent").length,
+    unresolvedSteps: steps.filter((s) => !s.resolved).length,
+    sideEffectCounts,
+    connectorNamespaces: plan.connectorNamespaces ?? [],
+  };
+
+  const risk = summarizeRunRisk(
+    steps.map((s) => ({
+      effectiveRisk: s.effectiveRisk,
+      sideEffect: s.sideEffect,
+      resolved: s.resolved,
+    })),
+  );
+
+  const projected: ApprovalProjection[] = steps
+    .filter((s) => s.baseRisk !== "low" || s.isWrite)
+    .map((s) => ({
+      stepId: s.id,
+      ...(s.tool !== undefined ? { tool: s.tool } : {}),
+      tier: s.baseRisk,
+      wouldRequireApproval: s.baseRisk !== "low",
+      reason:
+        s.baseRisk !== "low"
+          ? `${s.baseRisk}-risk ${s.sideEffect}`
+          : `write step (${s.sideEffect}), low tier`,
+    }));
+
+  const branches: BranchProjection[] = steps
+    .filter((s) => typeof s.condition === "string" && s.condition.length > 0)
+    .map((s) => ({
+      stepId: s.id,
+      condition: s.condition as string,
+      outcome: "undetermined" as const,
+      reason:
+        "Condition is evaluated at runtime against prior step output, which is not available in a static simulation.",
+    }));
+
+  const cost = buildCost(plan);
+
+  const notes: string[] = [
+    "Static fidelity: no step is executed. Agent/LLM outputs and data-dependent branches are not resolved.",
+    "Approval projection shows the tier that WOULD apply if recipe steps were gated — they are NOT gated on the execution path today (gatedOnRecipeSteps=false).",
+    "Cost is a low-confidence estimate; USD is not projected at this phase.",
+  ];
+  if (topology === "flat") {
+    notes.push(
+      "Flat recipe: risk propagates linearly (step N inherits prior steps' risk); there is no dependency DAG.",
+    );
+  }
+  if (summary.unresolvedSteps > 0) {
+    notes.push(
+      `${summary.unresolvedSteps} step(s) reference tools unknown to the registry — their side effects could not be classified.`,
+    );
+  }
+  if (branches.length > 0) {
+    notes.push(
+      `${branches.length} conditional branch(es) left undetermined — re-run after a mocked/sandbox phase to resolve them.`,
+    );
+  }
+
+  return {
+    schemaVersion: SIMULATION_SCHEMA_VERSION,
+    kind: "what-if-preview",
+    recipe: plan.recipe,
+    triggerType: plan.triggerType,
+    generatedAt: plan.generatedAt,
+    fidelity: "static",
+    topology,
+    gatedOnRecipeSteps,
+    steps,
+    summary,
+    risk,
+    approvals: {
+      gatedOnRecipeSteps,
+      projected,
+      note: "Recipe-runner steps are NOT gated by the approval queue today; this column is the tier that would apply if they were.",
+    },
+    cost,
+    branches,
+    lint: plan.lint,
+    notes,
+  };
+}

--- a/src/recipes/simulation/types.ts
+++ b/src/recipes/simulation/types.ts
@@ -1,0 +1,160 @@
+/**
+ * What-If Preview — types for the static counterfactual simulation of a recipe.
+ *
+ * P0 ("static" fidelity): the report is a pure, honest superset of the
+ * dry-run plan (`RecipeDryRunPlan`). It NEVER executes a step. Every field is
+ * derived from the static plan + tool-registry metadata, so the report cannot
+ * make a real external call, write a file, or spend a token.
+ *
+ * Design constraints baked into the shape (from the 2026-06-04 investigation,
+ * `docs/counterfactual-sim-engine-investigation.md`):
+ *   - `gatedOnRecipeSteps` is a first-class boolean so a consumer can NEVER
+ *     imply an approval gate that does not exist on the recipe execution path
+ *     today (the live gate in transport.ts only gates MCP bridge calls).
+ *   - cost carries an explicit `basis` and is never a precise dollar figure or
+ *     `$0` — at static fidelity USD is genuinely not projectable.
+ *   - conditional branches resolve to `"undetermined"`, never a faked
+ *     taken/skipped, because dry-run sentinels are truthy and would lie.
+ *
+ * Later phases bump `fidelity` ("mocked" | "hybrid") and `schemaVersion`.
+ */
+
+/** Stable schema version for consumers; bump on breaking shape changes. */
+export const SIMULATION_SCHEMA_VERSION = 1;
+
+export type RiskTier = "low" | "medium" | "high";
+
+/**
+ * Side-effect class for a single step, derived from registry metadata
+ * (`isWrite` / `isConnector` / `namespace`) — never from execution.
+ */
+export type SideEffectKind =
+  | "local-read" // reads local/workspace state (git log, file read, diagnostics)
+  | "local-write" // mutates local state (file write, git commit)
+  | "connector-read" // reads an external SaaS connector (github list, gmail fetch)
+  | "connector-write" // mutates an external SaaS connector (github create_pr, slack post)
+  | "external-http" // arbitrary outbound HTTP / webhook
+  | "agent-llm" // an LLM/agent step (non-deterministic; never executed in sim)
+  | "nested-recipe" // delegates to a nested recipe
+  | "unknown"; // tool id not resolvable in the registry at plan time
+
+export interface SimulationStep {
+  id: string;
+  type: "tool" | "agent" | "recipe";
+  tool?: string;
+  namespace?: string;
+  /** True when the tool id resolved in the registry at plan time. */
+  resolved: boolean;
+  optional?: boolean;
+  dependencies?: string[];
+  /** Present for chained steps with a `when:` condition. */
+  condition?: string;
+  /** The step's own risk (explicit on the step, or the registry default). */
+  baseRisk: RiskTier;
+  /**
+   * Risk including blast-radius propagation: at least as high as the highest
+   * risk among the steps that must have run before this one (its transitive
+   * dependencies). Equals `baseRisk` when nothing higher-risk precedes it.
+   */
+  effectiveRisk: RiskTier;
+  sideEffect: SideEffectKind;
+  isWrite: boolean;
+  isConnector: boolean;
+}
+
+/** Per-step approval projection — "what WOULD gate, if recipe steps were gated". */
+export interface ApprovalProjection {
+  stepId: string;
+  tool?: string;
+  tier: RiskTier;
+  /** True if this step's tier would trip an approval gate (tier !== "low"). */
+  wouldRequireApproval: boolean;
+  reason: string;
+}
+
+/** A conditional branch the engine refuses to resolve statically. */
+export interface BranchProjection {
+  stepId: string;
+  condition: string;
+  /** Always "undetermined" at static fidelity — sentinels would lie. */
+  outcome: "undetermined";
+  reason: string;
+}
+
+export interface RiskComponents {
+  highSteps: number;
+  mediumSteps: number;
+  writeSteps: number;
+  connectorWriteSteps: number;
+  externalHttpSteps: number;
+  unresolvedSteps: number;
+}
+
+export interface RunRiskSummary {
+  /** 0–100 derived workflow risk score. Always shown WITH its components. */
+  score: number;
+  tier: RiskTier;
+  components: RiskComponents;
+  /** Highest single-step effective risk in the plan. */
+  highestStepRisk: RiskTier;
+}
+
+export interface SimulationCost {
+  /**
+   * "heuristic": a coarse chars/4 token estimate (low confidence).
+   * "unavailable": no static basis for an estimate (e.g. chained agent steps
+   *   carry no prompt in the plan).
+   */
+  basis: "heuristic" | "unavailable";
+  agentSteps: number;
+  /** Agent steps whose prompt was available to estimate from. */
+  estimatedAgentSteps: number;
+  /** Sum of chars/4 over available agent prompts. null when basis unavailable. */
+  estPromptTokens: number | null;
+  /** USD is deliberately never projected at static fidelity. Always null. */
+  usd: null;
+  note: string;
+}
+
+export interface SimulationSummary {
+  totalSteps: number;
+  writeSteps: number;
+  connectorSteps: number;
+  agentSteps: number;
+  unresolvedSteps: number;
+  sideEffectCounts: Record<SideEffectKind, number>;
+  connectorNamespaces: string[];
+}
+
+export interface RecipeSimulationReport {
+  schemaVersion: typeof SIMULATION_SCHEMA_VERSION;
+  kind: "what-if-preview";
+  recipe: string;
+  triggerType: string;
+  /** ISO-8601 generation timestamp. */
+  generatedAt: string;
+  /** Simulation fidelity. P0 is always "static". */
+  fidelity: "static";
+  /** "chained" recipes have a real DAG; "flat" recipes are a linear list. */
+  topology: "chained" | "flat";
+  /**
+   * CRITICAL honesty field. False today: the approval queue does NOT gate
+   * recipe-runner steps. Consumers MUST surface this so the approval
+   * projection is never read as live gate behaviour.
+   */
+  gatedOnRecipeSteps: boolean;
+  steps: SimulationStep[];
+  summary: SimulationSummary;
+  risk: RunRiskSummary;
+  approvals: {
+    gatedOnRecipeSteps: boolean;
+    projected: ApprovalProjection[];
+    note: string;
+  };
+  cost: SimulationCost;
+  /** Conditional branches surfaced but not resolved (honest "rejected paths"). */
+  branches: BranchProjection[];
+  lint: { errors: string[]; warnings: string[] };
+  /** Loud, human-readable caveats about what this fidelity can and cannot show. */
+  notes: string[];
+}


### PR DESCRIPTION
## What-If Preview — static recipe simulation (P0)

Adds `patchwork recipe simulate <name|file>` — a static, **zero-side-effect** counterfactual preview of what a recipe *would* do before you enable it: projected actions, side-effect taxonomy, blast-radius risk, a tier-only approval projection, a low-confidence cost estimate, and the conditional branches it refuses to resolve statically.

### New module `src/recipes/simulation/`
- **`types.ts`** — `RecipeSimulationReport`, with the `gatedOnRecipeSteps` honesty field baked in.
- **`sideEffects.ts`** — `classifyStepSideEffect` → `local/connector read|write · external-http · agent-llm · nested-recipe · unknown`.
- **`aggregateRunRisk.ts`** — blast-radius risk propagation (DAG for chained, linear for flat, cycle-guarded) + a transparent 0–100 score with components.
- **`simulate.ts`** — `simulateFromPlan`, a **pure** transform of the dry-run plan (reuses `plan.generatedAt` → no clock dependency, fully deterministic).

### Wiring
- `runRecipeSimulate()` in `commands/recipe.ts` composes `runRecipeDryPlan` → `simulateFromPlan` (zero side effects).
- CLI verb `patchwork recipe simulate <name> [--json] [--step <id>] [--var k=v]`.

### Honesty guarantees (enforced in code)
- Never executes a step.
- Branches → `"undetermined"` (no sentinel pretending a result).
- Cost is never `$0`/precise — at static fidelity USD is genuinely not projectable, and the report says so loudly.
- Approval column is flagged **NOT gated on recipe steps today** (`gatedOnRecipeSteps: false`); tier comes from `riskDefault`. Real gating is future work (P4).

### Verified
- `npm run build` (full `tsc`) exit 0.
- `simulate.test.ts` — **17/17** unit tests pass.
- `biome check` clean; `tsc -p tsconfig.tests.core.json --noEmit` exit 0.
- E2E CLI on `morning-brief-slack.yaml`: MEDIUM (46/100), 2 writes (1 connector-write: slack), 4 connector reads, 1 agent step, cost flagged heuristic/USD-not-projected, approval honestly flagged. `--json` serializes correctly.

### Deliberately deferred (documented in `docs/counterfactual-sim-engine-investigation.md`)
P1 token persistence · `GET /recipes/:name/simulate` HTTP route · dashboard SimulatePanel + Run-Now risk gate · JSON-schema entry in schemaGenerator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>