### PR TITLE
feat(recipes): persist per-step agent token usage + run cost totals (P1)

### DIFF
--- a/src/recipes/__tests__/runCostPersistence.test.ts
+++ b/src/recipes/__tests__/runCostPersistence.test.ts
@@ -1,0 +1,324 @@
+/**
+ * P1 — recipe run cost/token persistence.
+ *
+ * Per-step agent token usage (AgentResult.usage) is captured at the runner
+ * level and persisted onto the run record (per-step inputTokens/outputTokens/
+ * costUsd + run-level tokenTotals). This is corpus-building only — no
+ * projection / new enforcement. Constraints proved here:
+ *   - usage lands on the persisted step + run when a driver reports it
+ *   - a judge→refine step sums usage across ALL its agent calls
+ *   - no usage (tool-only / subscription / undefined) → fields ABSENT
+ *     (old rows round-trip unchanged)
+ *   - costUsd is set ONLY for a priceable billable model, never 0
+ */
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AgentResult } from "../agentExecutor.js";
+import type {
+  ChainedRecipe,
+  ExecutionDeps,
+  RunOptions,
+} from "../chainedRunner.js";
+import { runChainedRecipe } from "../chainedRunner.js";
+import {
+  type RunnerDeps,
+  runYamlRecipe,
+  type YamlRecipe,
+} from "../yamlRunner.js";
+
+// A priceable billable model from the built-in price table.
+const PRICED_MODEL = "claude-haiku-4-5-20251001"; // input 1, output 5 ($/1M)
+
+let tmpDir: string;
+beforeEach(() => {
+  tmpDir = mkdtempSync(path.join(os.tmpdir(), "run-cost-persist-"));
+});
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function readRunLog(): Array<Record<string, unknown>> {
+  const file = path.join(tmpDir, "runs.jsonl");
+  if (!existsSync(file)) return [];
+  return readFileSync(file, "utf-8")
+    .split("\n")
+    .filter(Boolean)
+    .map((l) => JSON.parse(l) as Record<string, unknown>);
+}
+
+// ── yamlRunner (flat) ───────────────────────────────────────────────────────
+
+describe("yamlRunner — per-step token capture + persistence", () => {
+  it("persists inputTokens/outputTokens/costUsd for a priceable agent step and run-level tokenTotals", async () => {
+    const recipe: YamlRecipe = {
+      name: "cost-flat",
+      trigger: { type: "manual" },
+      steps: [
+        {
+          agent: {
+            prompt: "do the thing",
+            driver: "anthropic",
+            model: PRICED_MODEL,
+            into: "out",
+          },
+        },
+      ],
+    } as YamlRecipe;
+
+    // claudeFn may return a full AgentResult; usage + servedBy flow through.
+    const deps: RunnerDeps = {
+      logDir: tmpDir,
+      claudeFn: async (): Promise<AgentResult> => ({
+        text: "the answer",
+        usage: { inputTokens: 1000, outputTokens: 200 },
+        servedBy: { driver: "anthropic", model: PRICED_MODEL },
+      }),
+    };
+
+    const result = await runYamlRecipe(recipe, deps);
+    const step = result.stepResults.find((s) => s.tool === "agent");
+    expect(step?.inputTokens).toBe(1000);
+    expect(step?.outputTokens).toBe(200);
+    // 1000/1e6*1 + 200/1e6*5 = 0.001 + 0.001 = 0.002
+    expect(step?.costUsd).toBeCloseTo(0.002, 9);
+    expect(step?.costUsd).not.toBe(0);
+
+    expect(result.tokenTotals).toEqual({
+      inputTokens: 1000,
+      outputTokens: 200,
+      costUsd: expect.closeTo(0.002, 9),
+    });
+
+    // Persisted row carries the same fields.
+    const rows = readRunLog();
+    expect(rows).toHaveLength(1);
+    const persistedStep = (
+      rows[0]!.stepResults as Array<Record<string, unknown>>
+    )[0]!;
+    expect(persistedStep.inputTokens).toBe(1000);
+    expect(persistedStep.outputTokens).toBe(200);
+    expect(persistedStep.costUsd).toBeCloseTo(0.002, 9);
+    expect(rows[0]!.tokenTotals).toMatchObject({
+      inputTokens: 1000,
+      outputTokens: 200,
+    });
+  });
+
+  it("sums per-step tokens across all agent calls in a judge→refine loop", async () => {
+    const recipe: YamlRecipe = {
+      name: "cost-judge-refine",
+      trigger: { type: "manual" },
+      steps: [
+        {
+          agent: {
+            prompt: "write the thing",
+            driver: "anthropic",
+            model: PRICED_MODEL,
+            into: "draft",
+          },
+        },
+        {
+          agent: {
+            kind: "judge",
+            reviews: "draft",
+            max_revisions: 1,
+            on_exhausted: "proceed",
+            prompt: "review the draft",
+            driver: "anthropic",
+            model: PRICED_MODEL,
+          },
+        },
+      ],
+    } as YamlRecipe;
+
+    const REQUEST_CHANGES =
+      '```json\n{"verdict":"request_changes","fixList":["tighten"]}\n```';
+    const APPROVE = '```json\n{"verdict":"approve","reasons":["ok"]}\n```';
+
+    // Each call reports 100/10 usage. The judge step makes 3 calls:
+    //  1) first judge verdict (request_changes)
+    //  2) revise (reviewed agent re-run)
+    //  3) re-judge (approve)
+    // → per-step sum for the judge step = 300 in / 30 out.
+    const deps: RunnerDeps = {
+      logDir: tmpDir,
+      claudeFn: async (prompt: string): Promise<AgentResult> => {
+        let text: string;
+        if (prompt.includes("<revision-request>")) text = "REVISED v2";
+        else if (prompt.includes("<artefact>"))
+          text = prompt.includes("REVISED v2") ? APPROVE : REQUEST_CHANGES;
+        else text = "DRAFT v1";
+        return {
+          text,
+          usage: { inputTokens: 100, outputTokens: 10 },
+          servedBy: { driver: "anthropic", model: PRICED_MODEL },
+        };
+      },
+    };
+
+    const result = await runYamlRecipe(recipe, deps);
+    const judge = result.stepResults.find((s) => s.judgeVerdict !== undefined);
+    expect(judge).toBeDefined();
+    // first judge + revise + re-judge = 3 agent calls folded into this step.
+    expect(judge?.inputTokens).toBe(300);
+    expect(judge?.outputTokens).toBe(30);
+
+    // run-level total = draft(100/10) + judge(300/30) = 400/40.
+    expect(result.tokenTotals?.inputTokens).toBe(400);
+    expect(result.tokenTotals?.outputTokens).toBe(40);
+  });
+
+  it("omits token fields when no driver reports usage (tool-only run round-trips unchanged)", async () => {
+    const recipe: YamlRecipe = {
+      name: "no-usage",
+      trigger: { type: "manual" },
+      steps: [
+        // agent step served by a plain-string driver → usage undefined.
+        {
+          agent: {
+            prompt: "x",
+            driver: "anthropic",
+            model: PRICED_MODEL,
+            into: "o",
+          },
+        },
+      ],
+    } as YamlRecipe;
+
+    const deps: RunnerDeps = {
+      logDir: tmpDir,
+      // plain string → toAgentResult → { text } with no usage.
+      claudeFn: async () => "just text, no usage",
+    };
+
+    const result = await runYamlRecipe(recipe, deps);
+    const step = result.stepResults.find((s) => s.tool === "agent");
+    expect(step).toBeDefined();
+    expect(step).not.toHaveProperty("inputTokens");
+    expect(step).not.toHaveProperty("outputTokens");
+    expect(step).not.toHaveProperty("costUsd");
+    expect(result.tokenTotals).toBeUndefined();
+
+    const rows = readRunLog();
+    const persistedStep = (
+      rows[0]!.stepResults as Array<Record<string, unknown>>
+    )[0]!;
+    expect(persistedStep).not.toHaveProperty("inputTokens");
+    expect(rows[0]!).not.toHaveProperty("tokenTotals");
+  });
+
+  it("omits costUsd (but keeps tokens) for usage on an unpriced model — never 0", async () => {
+    const recipe: YamlRecipe = {
+      name: "unpriced",
+      trigger: { type: "manual" },
+      steps: [
+        {
+          agent: {
+            prompt: "x",
+            driver: "anthropic",
+            model: "some-unlisted-model-9000",
+            into: "o",
+          },
+        },
+      ],
+    } as YamlRecipe;
+
+    const deps: RunnerDeps = {
+      logDir: tmpDir,
+      claudeFn: async (): Promise<AgentResult> => ({
+        text: "text",
+        usage: { inputTokens: 500, outputTokens: 50 },
+        servedBy: { driver: "anthropic", model: "some-unlisted-model-9000" },
+      }),
+    };
+
+    const result = await runYamlRecipe(recipe, deps);
+    const step = result.stepResults.find((s) => s.tool === "agent");
+    expect(step?.inputTokens).toBe(500);
+    expect(step?.outputTokens).toBe(50);
+    expect(step).not.toHaveProperty("costUsd");
+    expect(result.tokenTotals).toMatchObject({
+      inputTokens: 500,
+      outputTokens: 50,
+    });
+    expect(result.tokenTotals).not.toHaveProperty("costUsd");
+  });
+});
+
+// ── chainedRunner ───────────────────────────────────────────────────────────
+
+describe("chainedRunner — per-step token capture + persistence", () => {
+  function chainedRecipe(): ChainedRecipe & { trigger: { type: string } } {
+    return {
+      name: "cost-chained",
+      trigger: { type: "chained" },
+      steps: [
+        {
+          id: "s1",
+          agent: { prompt: "go", driver: "anthropic", model: PRICED_MODEL },
+        },
+      ],
+    } as ChainedRecipe & { trigger: { type: string } };
+  }
+
+  function opts(): RunOptions {
+    return {
+      env: {},
+      maxConcurrency: 4,
+      maxDepth: 3,
+      dryRun: false,
+      runLogDir: tmpDir,
+    } as RunOptions;
+  }
+
+  it("persists per-step tokens/costUsd and run tokenTotals for a priceable agent step", async () => {
+    const deps: ExecutionDeps = {
+      executeTool: vi.fn().mockResolvedValue("ok"),
+      executeAgent: vi.fn().mockResolvedValue({
+        text: "answer",
+        usage: { inputTokens: 2000, outputTokens: 100 },
+        servedBy: { driver: "anthropic", model: PRICED_MODEL },
+      } satisfies AgentResult),
+      loadNestedRecipe: vi.fn().mockResolvedValue(null),
+    };
+
+    const result = await runChainedRecipe(chainedRecipe(), opts(), deps);
+    expect(result.success).toBe(true);
+
+    const rows = readRunLog();
+    expect(rows).toHaveLength(1);
+    const step = (rows[0]!.stepResults as Array<Record<string, unknown>>).find(
+      (s) => s.id === "s1",
+    )!;
+    expect(step.inputTokens).toBe(2000);
+    expect(step.outputTokens).toBe(100);
+    // 2000/1e6*1 + 100/1e6*5 = 0.002 + 0.0005 = 0.0025
+    expect(step.costUsd).toBeCloseTo(0.0025, 9);
+    expect(step.costUsd).not.toBe(0);
+    expect(rows[0]!.tokenTotals).toMatchObject({
+      inputTokens: 2000,
+      outputTokens: 100,
+    });
+  });
+
+  it("omits token fields when the agent reports no usage (round-trip unchanged)", async () => {
+    const deps: ExecutionDeps = {
+      executeTool: vi.fn().mockResolvedValue("ok"),
+      executeAgent: vi.fn().mockResolvedValue("plain text, no usage"),
+      loadNestedRecipe: vi.fn().mockResolvedValue(null),
+    };
+
+    const result = await runChainedRecipe(chainedRecipe(), opts(), deps);
+    expect(result.success).toBe(true);
+
+    const rows = readRunLog();
+    const step = (rows[0]!.stepResults as Array<Record<string, unknown>>).find(
+      (s) => s.id === "s1",
+    )!;
+    expect(step).not.toHaveProperty("inputTokens");
+    expect(step).not.toHaveProperty("costUsd");
+    expect(rows[0]!).not.toHaveProperty("tokenTotals");
+  });
+});

--- a/src/recipes/chainedRunner.ts
+++ b/src/recipes/chainedRunner.ts
@@ -36,7 +36,11 @@ import { captureForRunlog, detectSilentFail } from "./stepObservation.js";
 import type { TemplateContext, TemplateError } from "./templateEngine.js";
 import { compileTemplate } from "./templateEngine.js";
 import type { StepExpect } from "./yamlRunner.js";
-import { evaluateStepExpect, resolveRouting } from "./yamlRunner.js";
+import {
+  computeAgentCallUsage,
+  evaluateStepExpect,
+  resolveRouting,
+} from "./yamlRunner.js";
 
 export interface ChainedStep {
   id: string;
@@ -325,6 +329,12 @@ export async function executeChainedStep(
   /** VD-2: resolved params after template substitution — captured by the
    *  runner for the dashboard's per-step view. */
   resolvedParams?: unknown;
+  /**
+   * P1 cost/token corpus — agent token usage for this step (chained steps
+   * make exactly one agent call). Absent for tool steps and unmeasured
+   * drivers. `costUsd` set only for a priceable billable model (never 0).
+   */
+  usage?: { inputTokens: number; outputTokens: number; costUsd?: number };
 }> {
   const { registry, step, options, depth } = ctx;
   const { dryRun } = options;
@@ -573,19 +583,37 @@ export async function executeChainedStep(
         );
       }
 
+      // P1: per-step agent token usage (chained = one agent call per step).
+      // Attached to every return below so it lands on the persisted step row
+      // regardless of success / failure. Absent for unmeasured drivers.
+      const usage = computeAgentCallUsage(
+        agentReturn.usage,
+        agentReturn.servedBy,
+      );
+
       let result: unknown = agentReturn.text;
       // Detect failure signals returned as sentinel strings (mirrors flat runner)
       if (
         typeof result === "string" &&
         result.startsWith("[agent step failed:")
       ) {
-        return { success: false, error: result, resolvedParams: resolved };
+        return {
+          success: false,
+          error: result,
+          resolvedParams: resolved,
+          ...(usage ? { usage } : {}),
+        };
       }
       const agentSilentFail =
         step.silentFailDetection !== false ? detectSilentFail(result) : null;
       if (agentSilentFail) {
         const reason = `silent-fail detected (${agentSilentFail.reason}): ${agentSilentFail.matched}`;
-        return { success: false, error: reason, resolvedParams: resolved };
+        return {
+          success: false,
+          error: reason,
+          resolvedParams: resolved,
+          ...(usage ? { usage } : {}),
+        };
       }
       if (step.transform) {
         try {
@@ -601,10 +629,16 @@ export async function executeChainedStep(
             success: false,
             error: `expect failed: ${failures.join("; ")}`,
             resolvedParams: resolved,
+            ...(usage ? { usage } : {}),
           };
         }
       }
-      return { success: true, data: result, resolvedParams: resolved };
+      return {
+        success: true,
+        data: result,
+        resolvedParams: resolved,
+        ...(usage ? { usage } : {}),
+      };
     } else if (step.tool) {
       // Tool step
       let result: unknown = await deps.executeTool(step.tool, resolved);
@@ -664,6 +698,9 @@ interface StepExecResult {
   /** VD-2: forwarded from `executeChainedStep` so the runner can capture
    *  what params actually flew at the tool/agent. */
   resolvedParams?: unknown;
+  /** P1: agent token usage for this step — forwarded from
+   *  `executeChainedStep`. Absent for tool / unmeasured-driver steps. */
+  usage?: { inputTokens: number; outputTokens: number; costUsd?: number };
 }
 
 /** Upper bound on retries — clamps absurd/misconfigured values so a recipe
@@ -946,6 +983,13 @@ export async function runChainedRecipe(
       startedAt: number;
     }
   >();
+  // P1 cost/token corpus — per-step agent usage, keyed by stepId. Populated
+  // for every depth-0 agent step (independent of the VD-2 runLog-gated
+  // capture above) so both the bridge and CLI persistence paths get it.
+  const capturedUsage = new Map<
+    string,
+    { inputTokens: number; outputTokens: number; costUsd?: number }
+  >();
 
   // VD-1 live-tail: when an `activityLog` is provided AND we have a `runSeq`
   // (depth 0, runLog supplied), broadcast `recipe_step_start` /
@@ -1065,6 +1109,10 @@ export async function runChainedRecipe(
       durationMs: Date.now() - stepStart,
       skipped: result.skipped,
     });
+    // P1: stash this step's agent token usage (depth-0 persistence reads it).
+    if (depth === 0 && result.usage) {
+      capturedUsage.set(stepId, result.usage);
+    }
 
     // Recipe-level on_error.fallback: "log_only" and "deliver_original" both
     // treat step failures as non-fatal (fail-open) — same semantics as
@@ -1191,7 +1239,14 @@ export async function runChainedRecipe(
         output?: unknown;
         registrySnapshot?: Record<string, unknown>;
         startedAt?: number;
+        // P1 cost/token corpus.
+        inputTokens?: number;
+        outputTokens?: number;
+        costUsd?: number;
       }> = [];
+      // P1: run-level token aggregate, summed from per-step agent usage.
+      const runTok = { inputTokens: 0, outputTokens: 0, measured: false };
+      let runCostUsd: number | undefined;
       for (const [id, r] of enrichedResults) {
         const step = stepMap.get(id);
         const captured = capturedStepData.get(id);
@@ -1207,6 +1262,15 @@ export async function runChainedRecipe(
           status,
           error: errorMsg,
         });
+        const usage = capturedUsage.get(id);
+        if (usage) {
+          runTok.measured = true;
+          runTok.inputTokens += usage.inputTokens;
+          runTok.outputTokens += usage.outputTokens;
+          if (typeof usage.costUsd === "number") {
+            runCostUsd = (runCostUsd ?? 0) + usage.costUsd;
+          }
+        }
         stepResultsList.push({
           id,
           tool: step?.tool,
@@ -1224,8 +1288,28 @@ export async function runChainedRecipe(
           ...(captured?.startedAt !== undefined && {
             startedAt: captured.startedAt,
           }),
+          // P1: per-step token usage (absent for tool / unmeasured steps).
+          ...(usage
+            ? {
+                inputTokens: usage.inputTokens,
+                outputTokens: usage.outputTokens,
+                ...(typeof usage.costUsd === "number"
+                  ? { costUsd: usage.costUsd }
+                  : {}),
+              }
+            : {}),
         });
       }
+      // P1: assemble run-level totals (only when any step reported usage) +
+      // budget totals (only when a budget was configured).
+      const tokenTotals = runTok.measured
+        ? {
+            inputTokens: runTok.inputTokens,
+            outputTokens: runTok.outputTokens,
+            ...(typeof runCostUsd === "number" ? { costUsd: runCostUsd } : {}),
+          }
+        : undefined;
+      const budgetTotals = recipe.budget ? budget.totals() : undefined;
       const outputTail = stepResultsList
         .map(
           (s) =>
@@ -1247,6 +1331,8 @@ export async function runChainedRecipe(
           ...(result.errorMessage !== undefined && {
             errorMessage: result.errorMessage,
           }),
+          ...(tokenTotals ? { tokenTotals } : {}),
+          ...(budgetTotals ? { budgetTotals } : {}),
         });
         if (broadcastActivity && broadcastSeq !== undefined) {
           try {
@@ -1281,6 +1367,8 @@ export async function runChainedRecipe(
           errorMessage: result.errorMessage,
           stepResults: stepResultsList,
           ...(budgetWarnings.length > 0 && { budgetWarnings }),
+          ...(tokenTotals ? { tokenTotals } : {}),
+          ...(budgetTotals ? { budgetTotals } : {}),
         });
       }
     } catch {

--- a/src/recipes/yamlRunner.ts
+++ b/src/recipes/yamlRunner.ts
@@ -74,6 +74,11 @@ import {
   normalizeRecipeForRuntime,
 } from "./migrations/index.js";
 import { costRouter, type RouteCandidate } from "./pricing/costRouter.js";
+import {
+  loadPriceTable,
+  type PriceTable,
+  costUsd as priceCostUsd,
+} from "./pricing/priceTable.js";
 import { resolveRecipePath } from "./resolveRecipePath.js";
 import { RunBudget } from "./runBudget.js";
 import type { ErrorPolicy } from "./schema.js";
@@ -572,6 +577,13 @@ export interface RunResult {
    * now surfaced so callers and the run log can show them. Absent when none.
    */
   budgetWarnings?: string[];
+  /**
+   * P1 cost/token corpus — run-level aggregate of per-step agent token usage.
+   * Present ONLY when at least one step reported usage. `costUsd` summed from
+   * priceable steps only (omitted when none priceable). Forwarded to the
+   * persisted RecipeRun. Additive + optional.
+   */
+  tokenTotals?: { inputTokens: number; outputTokens: number; costUsd?: number };
 }
 
 export type StepResult = {
@@ -625,6 +637,20 @@ export type StepResult = {
    * instead and this stays undefined.
    */
   expectWarnings?: string[];
+  /**
+   * P1 cost/token corpus — agent token usage for this step, SUMMED across
+   * every agent call the step made (a judge→refine step makes several).
+   * Absent for tool steps and for unmeasured drivers (usage undefined).
+   * Mirrors RunStepResult so this stays assignable to it.
+   */
+  inputTokens?: number;
+  /** P1 — see `inputTokens`. Summed across all agent calls for this step. */
+  outputTokens?: number;
+  /**
+   * P1 — measured USD cost for this step. Set ONLY for a priceable billable
+   * model; NEVER `0` as a placeholder; omitted otherwise.
+   */
+  costUsd?: number;
   durationMs: number;
 };
 
@@ -781,6 +807,146 @@ export async function loadRecipeServers(specs: string[]): Promise<void> {
       );
     }
   }
+}
+
+/**
+ * P1 cost/token corpus — drivers that incur real, metered, per-token API
+ * billing (the only ones whose spend is real money and thus priceable here).
+ * Mirrors `BILLABLE_DRIVERS` in runBudget.ts (kept local — that set is private
+ * and runBudget.ts is enforcement-critical / must not be modified for P1).
+ * `local` reports usage but costs no real money, so it is NOT billable.
+ */
+const COST_BILLABLE_DRIVERS = new Set([
+  "anthropic",
+  "openai",
+  "grok",
+  "gemini",
+]);
+
+/**
+ * Per-step token accumulator, summed across every agent call a step makes.
+ * `costUsd` accrues only the priceable portion (billable driver + priced
+ * model); it stays `undefined` until a priceable call contributes. Used by
+ * both runners.
+ */
+interface StepUsageAccumulator {
+  inputTokens: number;
+  outputTokens: number;
+  /** Undefined until at least one priceable agent call contributed. */
+  costUsd?: number;
+  /** True once any agent call reported usage (gates field emission). */
+  measured: boolean;
+}
+
+function newStepUsageAccumulator(): StepUsageAccumulator {
+  return { inputTokens: 0, outputTokens: 0, measured: false };
+}
+
+/**
+ * Fold one agent call's usage into a per-step accumulator. Adds tokens when
+ * `usage` is present; adds USD only when the served model is billable AND
+ * present in the price table (NEVER a `0` placeholder for the unpriced case).
+ */
+function accumulateAgentUsage(
+  acc: StepUsageAccumulator,
+  usage: AgentUsage | undefined,
+  servedBy: { driver?: string; model?: string } | undefined,
+  priceTable: PriceTable,
+): void {
+  if (!usage) return;
+  acc.measured = true;
+  acc.inputTokens += usage.inputTokens;
+  acc.outputTokens += usage.outputTokens;
+  const driver = servedBy?.driver;
+  const model = servedBy?.model;
+  if (driver && model && COST_BILLABLE_DRIVERS.has(driver)) {
+    const cost = priceCostUsd(model, usage, priceTable);
+    if (typeof cost === "number") {
+      acc.costUsd = (acc.costUsd ?? 0) + cost;
+    }
+  }
+}
+
+/**
+ * Build the optional token fields for a step result from its accumulator.
+ * Returns an empty object (no fields) when the step reported no usage, so a
+ * tool step or unmeasured-driver step round-trips with the fields ABSENT.
+ */
+function stepUsageFields(acc: StepUsageAccumulator): {
+  inputTokens?: number;
+  outputTokens?: number;
+  costUsd?: number;
+} {
+  if (!acc.measured) return {};
+  return {
+    inputTokens: acc.inputTokens,
+    outputTokens: acc.outputTokens,
+    ...(typeof acc.costUsd === "number" ? { costUsd: acc.costUsd } : {}),
+  };
+}
+
+/**
+ * P1 — single-call usage → persisted-step usage fields. Exported for the
+ * chained runner, whose agent steps make exactly one agent call (no
+ * judge→refine loop), so a per-call computation suffices. Returns undefined
+ * when the driver reported no usage (fields stay ABSENT). `costUsd` set only
+ * for a billable driver + priced model; never a `0` placeholder.
+ */
+export function computeAgentCallUsage(
+  usage: AgentUsage | undefined,
+  servedBy: { driver?: string; model?: string } | undefined,
+  priceTable: PriceTable = loadPriceTable(),
+): { inputTokens: number; outputTokens: number; costUsd?: number } | undefined {
+  if (!usage) return undefined;
+  const driver = servedBy?.driver;
+  const model = servedBy?.model;
+  let cost: number | undefined;
+  if (driver && model && COST_BILLABLE_DRIVERS.has(driver)) {
+    const c = priceCostUsd(model, usage, priceTable);
+    if (typeof c === "number") cost = c;
+  }
+  return {
+    inputTokens: usage.inputTokens,
+    outputTokens: usage.outputTokens,
+    ...(typeof cost === "number" ? { costUsd: cost } : {}),
+  };
+}
+
+/** Run-level token aggregate, summed from per-step accumulators. */
+interface RunUsageAccumulator {
+  inputTokens: number;
+  outputTokens: number;
+  costUsd?: number;
+  measured: boolean;
+}
+
+function newRunUsageAccumulator(): RunUsageAccumulator {
+  return { inputTokens: 0, outputTokens: 0, measured: false };
+}
+
+function foldStepIntoRun(
+  run: RunUsageAccumulator,
+  step: StepUsageAccumulator,
+): void {
+  if (!step.measured) return;
+  run.measured = true;
+  run.inputTokens += step.inputTokens;
+  run.outputTokens += step.outputTokens;
+  if (typeof step.costUsd === "number") {
+    run.costUsd = (run.costUsd ?? 0) + step.costUsd;
+  }
+}
+
+/** Build the optional `tokenTotals` for a run, or undefined when none measured. */
+function runTokenTotals(
+  run: RunUsageAccumulator,
+): { inputTokens: number; outputTokens: number; costUsd?: number } | undefined {
+  if (!run.measured) return undefined;
+  return {
+    inputTokens: run.inputTokens,
+    outputTokens: run.outputTokens,
+    ...(typeof run.costUsd === "number" ? { costUsd: run.costUsd } : {}),
+  };
 }
 
 export async function runYamlRecipe(
@@ -948,6 +1114,13 @@ export async function runYamlRecipe(
 
   const outputs: string[] = [];
   const stepResults: StepResult[] = [];
+  // P1 cost/token corpus. The price table is loaded once per run (fail-open).
+  // `currentStepUsage` accumulates usage across all agent calls of the CURRENT
+  // agent step (including judge→refine re-runs via `runAgentText`); `runUsage`
+  // sums measured steps into the run-level total.
+  const priceTable = loadPriceTable();
+  const runUsage = newRunUsageAccumulator();
+  let currentStepUsage = newStepUsageAccumulator();
   let stepsRun = 0;
   let runError: string | undefined;
   // Bug (2): the flat runner historically recorded the first non-optional
@@ -1084,6 +1257,13 @@ export async function runYamlRecipe(
       agentReturn.servedBy?.model,
       // Char counts for the opt-in unmeasured-driver ≈$ estimate (warn-only).
       { inputChars: prompt.length, outputChars: agentReturn.text.length },
+    );
+    // P1: fold this refine-loop agent call into the current step's usage.
+    accumulateAgentUsage(
+      currentStepUsage,
+      agentReturn.usage,
+      agentReturn.servedBy,
+      priceTable,
     );
     const text = agentReturn.text;
     // Same failure detection as the main agent branch: explicit failure
@@ -1380,6 +1560,9 @@ export async function runYamlRecipe(
         const intoKey = agentCfg.into ?? "agent_output";
         const stepId = intoKey;
         const stepStart = Date.now();
+        // P1: fresh per-step usage accumulator for this agent step (and any
+        // judge→refine re-runs it spawns via runAgentText, which share it).
+        currentStepUsage = newStepUsageAccumulator();
         let agentResult: string;
         // Bug (2): fail-open semantics for THIS agent step. Mirrors the
         // tool-branch `failOpen` (step.optional OR recipe-level
@@ -1434,6 +1617,13 @@ export async function runYamlRecipe(
               inputChars: renderedPrompt.length,
               outputChars: agentReturn.text.length,
             },
+          );
+          // P1: fold this primary agent call into the current step's usage.
+          accumulateAgentUsage(
+            currentStepUsage,
+            agentReturn.usage,
+            agentReturn.servedBy,
+            priceTable,
           );
           // Catch both `[agent step failed: ...]` (existing) and the
           // silent-fail patterns `[agent step skipped: ...]` etc. via the
@@ -1584,6 +1774,14 @@ export async function runYamlRecipe(
             durationMs: Date.now() - stepStart,
           });
         }
+        // P1: attach this agent step's summed token usage (across primary +
+        // any judge→refine re-runs) to the result just pushed, and fold it
+        // into the run-level total. Fields are ABSENT when no usage measured.
+        const pushedAgentResult = stepResults[stepResults.length - 1];
+        if (pushedAgentResult) {
+          Object.assign(pushedAgentResult, stepUsageFields(currentStepUsage));
+        }
+        foldStepIntoRun(runUsage, currentStepUsage);
         stepsRun++;
         persistLiveStepResults();
         emitStepDone(stepIdForEmit);
@@ -1858,8 +2056,21 @@ export async function runYamlRecipe(
         ...(s.haltReason ? { haltReason: s.haltReason } : {}),
         ...(s.haltCategory ? { haltCategory: s.haltCategory } : {}),
         ...(s.judgeVerdict ? { judgeVerdict: s.judgeVerdict } : {}),
+        // P1: carry per-step token usage through to the persisted run row.
+        // Absent for tool / unmeasured-driver steps (round-trips unchanged).
+        ...(typeof s.inputTokens === "number"
+          ? { inputTokens: s.inputTokens }
+          : {}),
+        ...(typeof s.outputTokens === "number"
+          ? { outputTokens: s.outputTokens }
+          : {}),
+        ...(typeof s.costUsd === "number" ? { costUsd: s.costUsd } : {}),
         durationMs: s.durationMs,
       }));
+      // P1: run-level token aggregate + budget totals (latter only when a
+      // budget was configured — never persist all-zero no-budget totals).
+      const tokenTotals = runTokenTotals(runUsage);
+      const budgetTotals = recipe.budget ? runBudget.totals() : undefined;
       if (deps.runLog && runSeq !== undefined) {
         deps.runLog.completeRun(runSeq, {
           status: runError ? "error" : "done",
@@ -1873,6 +2084,8 @@ export async function runYamlRecipe(
           ...(runBudget.finalWarnings().length > 0
             ? { budgetWarnings: runBudget.finalWarnings() }
             : {}),
+          ...(tokenTotals ? { tokenTotals } : {}),
+          ...(budgetTotals ? { budgetTotals } : {}),
         });
         emit("recipe_done", {
           runSeq,
@@ -1910,6 +2123,8 @@ export async function runYamlRecipe(
           stepResults: finalStepResults,
           ...(assertionFailures.length > 0 ? { assertionFailures } : {}),
           ...(inboxOutputs.length > 0 ? { inboxOutputs } : {}),
+          ...(tokenTotals ? { tokenTotals } : {}),
+          ...(budgetTotals ? { budgetTotals } : {}),
         });
       }
     } catch {
@@ -1968,6 +2183,11 @@ export async function runYamlRecipe(
     ...(runBudget.finalWarnings().length > 0
       ? { budgetWarnings: runBudget.finalWarnings() }
       : {}),
+    // P1: forward run-level token aggregate to callers / persisters.
+    ...(() => {
+      const tt = runTokenTotals(runUsage);
+      return tt ? { tokenTotals: tt } : {};
+    })(),
   };
 }
 

--- a/src/runLog.ts
+++ b/src/runLog.ts
@@ -66,6 +66,23 @@ export interface RunStepResult {
   registrySnapshot?: Record<string, unknown>;
   /** Step start time (ms epoch) — useful for live-tail correlation. */
   startedAt?: number;
+  /**
+   * P1 cost/token corpus — agent token usage for this step, SUMMED across
+   * every agent call the step made (a judge→refine step makes several).
+   * Additive + optional: ABSENT for non-agent (tool) steps and for steps
+   * served by drivers that report no usage (subscription Claude CLI, some
+   * local stacks). Pre-P1 `runs.jsonl` rows round-trip unchanged (omitted).
+   */
+  inputTokens?: number;
+  /** P1 — see `inputTokens`. Summed across all agent calls for this step. */
+  outputTokens?: number;
+  /**
+   * P1 — measured USD cost for this step's token usage. Set ONLY when the
+   * served model is actually priceable (billable driver + model present in
+   * the price table). NEVER `0` as a placeholder — OMITTED when unpriceable
+   * (subscription / unmeasured driver, or model absent from the price table).
+   */
+  costUsd?: number;
 }
 
 export interface RecipeRun {
@@ -143,6 +160,21 @@ export interface RecipeRun {
    * tripped no warnings.
    */
   budgetWarnings?: string[];
+  /**
+   * P1 cost/token corpus — run-level aggregate of per-step agent token usage,
+   * summed across all steps that reported usage. Present ONLY when at least
+   * one step reported usage; absent for tool-only runs and runs served
+   * entirely by unmeasured drivers. `costUsd` is the sum of the per-step
+   * measured costs (priceable steps only) and is itself omitted when no step
+   * was priceable. Additive + optional: pre-P1 rows round-trip unchanged.
+   */
+  tokenTotals?: { inputTokens: number; outputTokens: number; costUsd?: number };
+  /**
+   * P1 — `RunBudget.totals()` snapshot at completion, persisted ONLY when a
+   * budget was configured for the run (we never persist the all-zero no-budget
+   * case, which would be misleading). Additive + optional.
+   */
+  budgetTotals?: import("./recipes/runBudget.js").BudgetTotals;
 }
 
 const MAX_OUTPUT_TAIL = 2_000;


### PR DESCRIPTION
## What

P1 of the What-If Preview roadmap (see `docs/counterfactual-sim-engine-investigation.md`, shipped in #916). Captures per-step agent token usage and persists it onto the run record so a later cost-projection / simulation layer has a **real historical corpus**.

**Corpus-building only** — no projection logic, no new cost enforcement. `RunBudget` (enforcement-critical, hardened in #913) is left untouched; usage is captured at the runner level from `AgentResult.usage`, which is already in scope at each `reconcile()` site (and was previously discarded when no budget cap was set).

## Changes

- **`RunStepResult`** — optional `inputTokens` / `outputTokens` / `costUsd`. Summed across all of a step's agent calls (a judge→refine step makes several). Absent for tool steps and unmeasured drivers.
- **`RecipeRun`** — optional `tokenTotals` (run aggregate) + `budgetTotals` (persisted only when a budget is configured — never the misleading all-zero no-budget case).
- **`yamlRunner` + `chainedRunner`** — capture usage at each reconcile site, summing judge→refine re-runs into one per-step figure; price via the price table **only** when the served model is billable + priced (never a `$0` placeholder); thread through both persistence paths (bridge runLog + CLI runLogDir).

## Honesty constraints (tested)

- `costUsd` is set **only** for a priceable billable model; never `0` as a placeholder (tokens still persisted for unpriced models, `costUsd` omitted).
- No usage reported (tool-only / subscription / `usage: undefined`) → fields **absent**; pre-P1 `runs.jsonl` rows round-trip unchanged.

## Tests

`src/recipes/__tests__/runCostPersistence.test.ts` (6 tests): per-step + run-level persistence, judge→refine summation (3 calls → 300/30), unpriced-model omits `costUsd`, no-usage round-trip — for both runners.

- `runCostPersistence` + `yamlRunner` + `chainedRunner` + `runBudget` + `judgeRefineLoop`: **263 passed**
- `tsc -p tsconfig.tests.core.json`: exit 0 · biome clean · fixtures + schema audit gates pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)