### PR TITLE
feat(recipes): What-If Preview HTTP route + JSON schema (GET /recipes/:name/simulate)

### DIFF
--- a/src/__tests__/server-recipe-simulate.test.ts
+++ b/src/__tests__/server-recipe-simulate.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Integration tests for GET /recipes/:name/simulate — the What-If Preview
+ * endpoint backing the dashboard SimulatePanel + pre-run risk gate. Uses a stub
+ * simulateFn so server routing is tested independently of bridge state.
+ */
+import http from "node:http";
+import { afterEach, describe, expect, it } from "vitest";
+import { Logger } from "../logger.js";
+import { Server } from "../server.js";
+
+const logger = new Logger(false);
+const TOKEN = "test-recipe-simulate-token-0000000";
+
+let server: Server | null = null;
+let port = 0;
+
+const FIXTURE_REPORT = {
+  schemaVersion: 1,
+  kind: "what-if-preview",
+  recipe: "test-recipe",
+  triggerType: "manual",
+  generatedAt: new Date().toISOString(),
+  fidelity: "static",
+  topology: "flat",
+  gatedOnRecipeSteps: false,
+  steps: [],
+  summary: {
+    totalSteps: 0,
+    writeSteps: 0,
+    connectorSteps: 0,
+    agentSteps: 0,
+    unresolvedSteps: 0,
+    sideEffectCounts: {},
+    connectorNamespaces: [],
+  },
+  risk: {
+    score: 0,
+    tier: "low",
+    components: {
+      highSteps: 0,
+      mediumSteps: 0,
+      writeSteps: 0,
+      connectorWriteSteps: 0,
+      externalHttpSteps: 0,
+      unresolvedSteps: 0,
+    },
+    highestStepRisk: "low",
+  },
+  approvals: { gatedOnRecipeSteps: false, projected: [], note: "n/a" },
+  cost: {
+    basis: "unavailable",
+    agentSteps: 0,
+    estimatedAgentSteps: 0,
+    estPromptTokens: null,
+    usd: null,
+    note: "n/a",
+  },
+  branches: [],
+  lint: { errors: [], warnings: [] },
+  notes: [],
+};
+
+async function startServer(
+  simulateFn?: (name: string) => Promise<Record<string, unknown>>,
+): Promise<void> {
+  server = new Server(TOKEN, logger);
+  if (simulateFn) server.simulateFn = simulateFn;
+  port = await server.findAndListen(null);
+}
+
+afterEach(async () => {
+  await server?.close();
+  server = null;
+  port = 0;
+});
+
+function get(
+  path: string,
+  auth = true,
+): Promise<{ status: number; body: string }> {
+  return new Promise((resolve, reject) => {
+    const headers: Record<string, string> = {};
+    if (auth) headers.Authorization = `Bearer ${TOKEN}`;
+    const req = http.request(
+      { hostname: "127.0.0.1", port, method: "GET", path, headers },
+      (res) => {
+        let data = "";
+        res.on("data", (c) => (data += c));
+        res.on("end", () =>
+          resolve({ status: res.statusCode ?? 0, body: data }),
+        );
+      },
+    );
+    req.on("error", reject);
+    req.end();
+  });
+}
+
+describe("GET /recipes/:name/simulate", () => {
+  it("returns 503 when simulateFn is not wired", async () => {
+    await startServer();
+    const { status, body } = await get("/recipes/test-recipe/simulate");
+    expect(status).toBe(503);
+    expect(JSON.parse(body)).toMatchObject({ error: "simulate_unavailable" });
+  });
+
+  it("returns the simulation report", async () => {
+    await startServer(
+      async () => FIXTURE_REPORT as unknown as Record<string, unknown>,
+    );
+    const { status, body } = await get("/recipes/test-recipe/simulate");
+    expect(status).toBe(200);
+    const parsed = JSON.parse(body) as { report: typeof FIXTURE_REPORT };
+    expect(parsed.report.kind).toBe("what-if-preview");
+    expect(parsed.report.recipe).toBe("test-recipe");
+    // The honesty field must round-trip over the wire.
+    expect(parsed.report.gatedOnRecipeSteps).toBe(false);
+  });
+
+  it("returns 404 when the recipe is not found", async () => {
+    await startServer(async () => {
+      const err = new Error("nope") as NodeJS.ErrnoException;
+      err.code = "RECIPE_NOT_FOUND";
+      throw err;
+    });
+    const { status, body } = await get("/recipes/missing/simulate");
+    expect(status).toBe(404);
+    expect(JSON.parse(body)).toMatchObject({ error: "Recipe not found" });
+  });
+
+  it("requires bearer auth", async () => {
+    await startServer(
+      async () => FIXTURE_REPORT as unknown as Record<string, unknown>,
+    );
+    const { status } = await get("/recipes/test-recipe/simulate", false);
+    expect(status).toBe(401);
+  });
+});

--- a/src/recipeOrchestration.ts
+++ b/src/recipeOrchestration.ts
@@ -260,6 +260,14 @@ export class RecipeOrchestration {
       >;
     };
 
+    server.simulateFn = async (recipeName: string) => {
+      const { runRecipeSimulate } = await import("./commands/recipe.js");
+      return (await runRecipeSimulate(recipeName)) as unknown as Record<
+        string,
+        unknown
+      >;
+    };
+
     // VD-4 mocked replay: load the original run, re-parse its recipe
     // from disk (so a later edit replays against the new logic), and
     // re-fire through chainedRunner with `mockedOutputs` populated from

--- a/src/recipeRoutes.ts
+++ b/src/recipeRoutes.ts
@@ -607,6 +607,8 @@ export interface RecipeRouteDeps {
       }) => import("./recipes/judgeSummary.js").JudgeSummary)
     | null;
   runPlanFn: ((recipeName: string) => Promise<Record<string, unknown>>) | null;
+  /** What-If Preview: static counterfactual simulation for a recipe by name. */
+  simulateFn: ((recipeName: string) => Promise<Record<string, unknown>>) | null;
   runReplayFn:
     | ((seq: number) => Promise<{
         ok: boolean;
@@ -1502,6 +1504,41 @@ export function tryHandleRecipeRoute(
           res.end(JSON.stringify({ error: "Recipe not found" }));
         } else {
           respond500(res, err, "recipes plan");
+        }
+      }
+    })();
+    return true;
+  }
+
+  // GET /recipes/:name/simulate — What-If Preview: static counterfactual
+  // simulation of a recipe by name (projected actions, side-effect taxonomy,
+  // blast-radius risk, tier-only approval projection honestly flagged as NOT
+  // gated on recipe steps today, low-confidence cost, undetermined branches).
+  // Executes nothing; superset of the dry-run plan. See runRecipeSimulate.
+  const recipeSimulateMatch =
+    req.method === "GET"
+      ? /^\/recipes\/([^/]+)\/simulate$/.exec(parsedUrl.pathname)
+      : null;
+  if (recipeSimulateMatch?.[1]) {
+    const name = decodeURIComponent(recipeSimulateMatch[1]);
+    void (async () => {
+      try {
+        if (!deps.simulateFn) {
+          res.writeHead(503, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ error: "simulate_unavailable" }));
+          return;
+        }
+        const report = await deps.simulateFn(name);
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ report }));
+      } catch (err) {
+        // #605: classify by code, not substring (see /recipes/:name/plan).
+        const code = (err as NodeJS.ErrnoException)?.code;
+        if (code === "ENOENT" || code === "RECIPE_NOT_FOUND") {
+          res.writeHead(404, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ error: "Recipe not found" }));
+        } else {
+          respond500(res, err, "recipes simulate");
         }
       }
     })();

--- a/src/recipes/__tests__/schemaGenerator.test.ts
+++ b/src/recipes/__tests__/schemaGenerator.test.ts
@@ -4,7 +4,9 @@ import { RECIPE_NAME_RE } from "../names.js";
 import {
   generateDryRunPlanSchema,
   generateSchemaSet,
+  generateSimulationSchema,
 } from "../schemaGenerator.js";
+import { simulateFromPlan } from "../simulation/simulate.js";
 import { clearRegistry, registerTool } from "../toolRegistry.js";
 
 describe("schemaGenerator", () => {
@@ -440,6 +442,64 @@ describe("schemaGenerator", () => {
       };
 
       expect(validate(invalid)).toBe(false);
+    });
+  });
+
+  describe("simulation report schema (What-If Preview)", () => {
+    it("exposes a stable id + schemaVersion/kind const", () => {
+      const schema = generateSimulationSchema() as Record<string, unknown>;
+      expect(schema.$id).toBe(
+        "https://raw.githubusercontent.com/patchworkos/recipes/main/schema/simulation-report.v1.json",
+      );
+      const properties = schema.properties as Record<string, unknown>;
+      expect(properties.schemaVersion).toMatchObject({ const: 1 });
+      expect(properties.kind).toMatchObject({ const: "what-if-preview" });
+      expect(properties.gatedOnRecipeSteps).toMatchObject({ type: "boolean" });
+    });
+
+    it("validates a real simulateFromPlan output via Ajv", () => {
+      const ajv = new Ajv({ strict: false });
+      const validate = ajv.compile(generateSimulationSchema() as object);
+
+      // A real report from the engine — keeps the schema honest against impl.
+      const report = simulateFromPlan({
+        schemaVersion: 1,
+        recipe: "example",
+        mode: "dry-run",
+        triggerType: "chained",
+        generatedAt: new Date().toISOString(),
+        connectorNamespaces: ["slack"],
+        steps: [
+          {
+            id: "post",
+            type: "tool",
+            tool: "slack.post_message",
+            namespace: "slack",
+            risk: "high",
+            isWrite: true,
+            isConnector: true,
+            resolved: true,
+            condition: "{{ ok }}",
+          },
+        ],
+        lint: { errors: [], warnings: [] },
+      });
+
+      const ok = validate(report);
+      if (!ok) {
+        throw new Error(
+          `schema errors: ${JSON.stringify(validate.errors, null, 2)}`,
+        );
+      }
+      expect(ok).toBe(true);
+    });
+
+    it("rejects a report missing required fields", () => {
+      const ajv = new Ajv({ strict: false });
+      const validate = ajv.compile(generateSimulationSchema() as object);
+      expect(validate({ schemaVersion: 1, kind: "what-if-preview" })).toBe(
+        false,
+      );
     });
   });
 });

--- a/src/recipes/schemaGenerator.ts
+++ b/src/recipes/schemaGenerator.ts
@@ -128,6 +128,219 @@ export function generateDryRunPlanSchema(): unknown {
 }
 
 /**
+ * JSON Schema for the What-If Preview `RecipeSimulationReport`
+ * (`src/recipes/simulation/types.ts`), the output of
+ * `GET /recipes/:name/simulate` and `patchwork recipe simulate`. A superset of
+ * the dry-run plan; consumers pin on `schemaVersion`. Standalone (not part of
+ * `generateSchemaSet`/`writeSchemas`) — served on demand to consumers that want
+ * to validate the wire contract.
+ */
+export function generateSimulationSchema(): unknown {
+  const riskEnum = { type: "string", enum: ["low", "medium", "high"] };
+  const sideEffectEnum = {
+    type: "string",
+    enum: [
+      "local-read",
+      "local-write",
+      "connector-read",
+      "connector-write",
+      "external-http",
+      "agent-llm",
+      "nested-recipe",
+      "unknown",
+    ],
+  };
+  const simStep = {
+    type: "object",
+    required: [
+      "id",
+      "type",
+      "resolved",
+      "baseRisk",
+      "effectiveRisk",
+      "sideEffect",
+      "isWrite",
+      "isConnector",
+    ],
+    properties: {
+      id: { type: "string" },
+      type: { type: "string", enum: ["tool", "agent", "recipe"] },
+      tool: { type: "string" },
+      namespace: { type: "string" },
+      resolved: { type: "boolean" },
+      optional: { type: "boolean" },
+      dependencies: { type: "array", items: { type: "string" } },
+      condition: { type: "string" },
+      baseRisk: riskEnum,
+      effectiveRisk: riskEnum,
+      sideEffect: sideEffectEnum,
+      isWrite: { type: "boolean" },
+      isConnector: { type: "boolean" },
+    },
+  };
+
+  return {
+    $schema: "http://json-schema.org/draft-07/schema#",
+    $id: "https://raw.githubusercontent.com/patchworkos/recipes/main/schema/simulation-report.v1.json",
+    title: "Patchwork Recipe What-If Preview",
+    description:
+      "Stable machine-readable output of `patchwork recipe simulate` / GET /recipes/:name/simulate. Static counterfactual simulation — executes nothing. Pin consumers on schemaVersion. `gatedOnRecipeSteps` is false today: recipe steps are NOT gated by the approval queue.",
+    type: "object",
+    required: [
+      "schemaVersion",
+      "kind",
+      "recipe",
+      "triggerType",
+      "generatedAt",
+      "fidelity",
+      "topology",
+      "gatedOnRecipeSteps",
+      "steps",
+      "summary",
+      "risk",
+      "approvals",
+      "cost",
+      "branches",
+      "lint",
+      "notes",
+    ],
+    properties: {
+      schemaVersion: { type: "number", const: 1 },
+      kind: { type: "string", const: "what-if-preview" },
+      recipe: { type: "string" },
+      triggerType: { type: "string" },
+      generatedAt: {
+        type: "string",
+        description: "ISO-8601 timestamp (reused from the dry-run plan)",
+      },
+      fidelity: { type: "string", enum: ["static"] },
+      topology: { type: "string", enum: ["chained", "flat"] },
+      gatedOnRecipeSteps: {
+        type: "boolean",
+        description:
+          "False today — recipe-runner steps are NOT gated by the approval queue. The approval projection is the tier that WOULD apply if they were.",
+      },
+      steps: { type: "array", items: simStep },
+      summary: {
+        type: "object",
+        required: [
+          "totalSteps",
+          "writeSteps",
+          "connectorSteps",
+          "agentSteps",
+          "unresolvedSteps",
+          "sideEffectCounts",
+          "connectorNamespaces",
+        ],
+        properties: {
+          totalSteps: { type: "number" },
+          writeSteps: { type: "number" },
+          connectorSteps: { type: "number" },
+          agentSteps: { type: "number" },
+          unresolvedSteps: { type: "number" },
+          sideEffectCounts: {
+            type: "object",
+            additionalProperties: { type: "number" },
+          },
+          connectorNamespaces: { type: "array", items: { type: "string" } },
+        },
+      },
+      risk: {
+        type: "object",
+        required: ["score", "tier", "components", "highestStepRisk"],
+        properties: {
+          score: { type: "number" },
+          tier: riskEnum,
+          highestStepRisk: riskEnum,
+          components: {
+            type: "object",
+            required: [
+              "highSteps",
+              "mediumSteps",
+              "writeSteps",
+              "connectorWriteSteps",
+              "externalHttpSteps",
+              "unresolvedSteps",
+            ],
+            properties: {
+              highSteps: { type: "number" },
+              mediumSteps: { type: "number" },
+              writeSteps: { type: "number" },
+              connectorWriteSteps: { type: "number" },
+              externalHttpSteps: { type: "number" },
+              unresolvedSteps: { type: "number" },
+            },
+          },
+        },
+      },
+      approvals: {
+        type: "object",
+        required: ["gatedOnRecipeSteps", "projected", "note"],
+        properties: {
+          gatedOnRecipeSteps: { type: "boolean" },
+          note: { type: "string" },
+          projected: {
+            type: "array",
+            items: {
+              type: "object",
+              required: ["stepId", "tier", "wouldRequireApproval", "reason"],
+              properties: {
+                stepId: { type: "string" },
+                tool: { type: "string" },
+                tier: riskEnum,
+                wouldRequireApproval: { type: "boolean" },
+                reason: { type: "string" },
+              },
+            },
+          },
+        },
+      },
+      cost: {
+        type: "object",
+        required: [
+          "basis",
+          "agentSteps",
+          "estimatedAgentSteps",
+          "estPromptTokens",
+          "usd",
+          "note",
+        ],
+        properties: {
+          basis: { type: "string", enum: ["heuristic", "unavailable"] },
+          agentSteps: { type: "number" },
+          estimatedAgentSteps: { type: "number" },
+          estPromptTokens: { type: ["number", "null"] },
+          usd: { type: "null" },
+          note: { type: "string" },
+        },
+      },
+      branches: {
+        type: "array",
+        items: {
+          type: "object",
+          required: ["stepId", "condition", "outcome", "reason"],
+          properties: {
+            stepId: { type: "string" },
+            condition: { type: "string" },
+            outcome: { type: "string", const: "undetermined" },
+            reason: { type: "string" },
+          },
+        },
+      },
+      lint: {
+        type: "object",
+        required: ["errors", "warnings"],
+        properties: {
+          errors: { type: "array", items: { type: "string" } },
+          warnings: { type: "array", items: { type: "string" } },
+        },
+      },
+      notes: { type: "array", items: { type: "string" } },
+    },
+  };
+}
+
+/**
  * Generate top-level recipe schema that composes namespace tool schemas.
  */
 function generateRecipeSchema(

--- a/src/server.ts
+++ b/src/server.ts
@@ -295,6 +295,11 @@ export class Server extends EventEmitter<ServerEvents> {
   public runPlanFn:
     | ((recipeName: string) => Promise<Record<string, unknown>>)
     | null = null;
+  /** Patchwork: set by bridge to generate a What-If Preview simulation for a
+   *  recipe by name (static counterfactual; superset of the dry-run plan). */
+  public simulateFn:
+    | ((recipeName: string) => Promise<Record<string, unknown>>)
+    | null = null;
   /** Patchwork (VD-4): mocked replay of an existing run. Returns the new
    *  run's seq plus any unmocked steps the caller may want to surface. */
   public runReplayFn:
@@ -1532,6 +1537,7 @@ export class Server extends EventEmitter<ServerEvents> {
           haltSummaryFn: this.haltSummaryFn,
           judgeSummaryFn: this.judgeSummaryFn,
           runPlanFn: this.runPlanFn,
+          simulateFn: this.simulateFn,
           runReplayFn: this.runReplayFn,
           runRecipeFn: this.runRecipeFn,
           onRecipesChangedFn: this.onRecipesChangedFn,


### PR DESCRIPTION
## What

Exposes the P0 static **What-If Preview** simulation engine (#916) over HTTP so the dashboard `SimulatePanel` + a Run-Now pre-run risk gate can consume it. Mirrors the existing `runPlanFn` / `GET /recipes/:name/plan` wiring exactly.

## Changes

- **`server.ts`** — add `simulateFn` field + wire into the recipe-routes deps (next to `runPlanFn`).
- **`recipeOrchestration.ts`** — set `server.simulateFn` → `runRecipeSimulate(name)`.
- **`recipeRoutes.ts`** — add `simulateFn` to the route deps + `GET /recipes/:name/simulate` handler: `200 {report}` / `404` (RECIPE_NOT_FOUND, classified by error **code** not substring per #605) / `503 simulate_unavailable`.
- **`schemaGenerator.ts`** — `generateSimulationSchema()`: stable wire contract for `RecipeSimulationReport` (new `$id`, `schemaVersion` const 1). **Standalone** — not added to `generateSchemaSet`/`writeSchemas`, so no committed-artifact regeneration.

## Honesty

The `gatedOnRecipeSteps: false` field round-trips over the wire (asserted in the route test) so any consumer can never imply an approval gate that doesn't exist on the recipe execution path today.

## Tests

- `src/__tests__/server-recipe-simulate.test.ts` — real HTTP server: 200 / 404 / 503 / 401 (bearer).
- `schemaGenerator.test.ts` — validates a **real `simulateFromPlan` output** against the schema (keeps the contract honest against the impl) + reject-missing-fields.
- **39 passed** across route + schema + `server-run-detail` + `recipeOrchestration` regression; `tsc -p tsconfig.tests.core.json` exit 0; biome clean; schema audit 0 breaking.

Part of the What-If Preview roadmap (P0 #916, P1 cost persistence #917). Next: dashboard `SimulatePanel` + Run-Now risk gate (step 4) consuming this route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)