### PR TITLE
feat(dashboard): What-If Preview panel + Run-Now pre-run risk gate

### DIFF
--- a/dashboard/src/app/api/bridge/recipes/simulate/__tests__/route.test.ts
+++ b/dashboard/src/app/api/bridge/recipes/simulate/__tests__/route.test.ts
@@ -1,0 +1,69 @@
+/** @vitest-environment node */
+/**
+ * Tests for the /api/bridge/recipes/simulate proxy — translates the
+ * `?recipe=` query into the bridge's path param `/recipes/:name/simulate`.
+ * A dedicated static segment is required so the request doesn't fall through
+ * to the dynamic `recipes/[...name]` catch-all proxy.
+ */
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { bridgeFetch } from "@/lib/bridge";
+
+vi.mock("@/lib/bridge", () => ({ bridgeFetch: vi.fn() }));
+
+import { GET } from "../route";
+
+const mockBridgeFetch = vi.mocked(bridgeFetch);
+
+function req(url: string): NextRequest {
+  return new NextRequest(`https://dashboard.local${url}`);
+}
+
+function okResponse(): Response {
+  return new Response(
+    JSON.stringify({ report: { kind: "what-if-preview" } }),
+    { status: 200, headers: { "content-type": "application/json" } },
+  );
+}
+
+beforeEach(() => {
+  mockBridgeFetch.mockReset();
+  mockBridgeFetch.mockResolvedValue(okResponse());
+});
+
+describe("GET /api/bridge/recipes/simulate", () => {
+  it("400s when the recipe query is missing", async () => {
+    const res = await GET(req("/api/bridge/recipes/simulate"));
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({ error: "missing_recipe" });
+    expect(mockBridgeFetch).not.toHaveBeenCalled();
+  });
+
+  it("translates ?recipe= into the bridge path param and forwards the body", async () => {
+    const res = await GET(
+      req("/api/bridge/recipes/simulate?recipe=morning-brief"),
+    );
+    expect(mockBridgeFetch).toHaveBeenCalledWith(
+      "/recipes/morning-brief/simulate",
+      { method: "GET" },
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({
+      report: { kind: "what-if-preview" },
+    });
+  });
+
+  it("encodes scoped recipe names safely", async () => {
+    await GET(req("/api/bridge/recipes/simulate?recipe=%40scope%2Ffoo"));
+    expect(mockBridgeFetch).toHaveBeenCalledWith(
+      "/recipes/%40scope%2Ffoo/simulate",
+      { method: "GET" },
+    );
+  });
+
+  it("502s when the bridge is unreachable", async () => {
+    mockBridgeFetch.mockRejectedValueOnce(new Error("down"));
+    const res = await GET(req("/api/bridge/recipes/simulate?recipe=x"));
+    expect(res.status).toBe(502);
+  });
+});

--- a/dashboard/src/app/api/bridge/recipes/simulate/route.ts
+++ b/dashboard/src/app/api/bridge/recipes/simulate/route.ts
@@ -1,0 +1,48 @@
+/**
+ * Proxy for the bridge's `GET /recipes/:name/simulate` (What-If Preview).
+ *
+ * A dedicated static `recipes/simulate` segment is required: without it the
+ * request falls through to the dynamic `recipes/[...name]` proxy, which would
+ * treat "simulate" as part of a recipe name. We accept the recipe as a
+ * `?recipe=` query here (no `[name]` sibling — that conflicts with the
+ * `[...name]` catch-all slug) and translate it to the bridge's path param.
+ * Mirrors the `recipes/doctor` proxy.
+ */
+
+import type { NextRequest } from "next/server";
+import { bridgeFetch } from "@/lib/bridge";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function GET(req: NextRequest): Promise<Response> {
+  const recipe = req.nextUrl.searchParams.get("recipe") ?? "";
+  if (!recipe) {
+    return new Response(JSON.stringify({ error: "missing_recipe" }), {
+      status: 400,
+      headers: { "content-type": "application/json" },
+    });
+  }
+  const target = `/recipes/${encodeURIComponent(recipe)}/simulate`;
+  try {
+    const res = await bridgeFetch(target, { method: "GET" });
+    // Mirror the upstream content-type so a non-JSON body (e.g. a reverse-proxy
+    // HTML error page in remote mode) isn't mislabelled application/json.
+    const upstreamCt = res.headers.get("content-type") ?? "";
+    const text = await res.text();
+    const ct =
+      upstreamCt.includes("application/json") || upstreamCt === ""
+        ? "application/json"
+        : upstreamCt;
+    return new Response(text, {
+      status: res.status,
+      headers: { "content-type": ct },
+    });
+  } catch (err) {
+    console.error("[recipes/simulate] bridge fetch failed:", err);
+    return new Response(JSON.stringify({ error: "Bridge unreachable" }), {
+      status: 502,
+      headers: { "content-type": "application/json" },
+    });
+  }
+}

--- a/dashboard/src/app/recipes/[...name]/__tests__/SimulatePanel.test.tsx
+++ b/dashboard/src/app/recipes/[...name]/__tests__/SimulatePanel.test.tsx
@@ -1,0 +1,142 @@
+/**
+ * Tests for SimulatePanel — the recipe-detail "What-If Preview" panel that
+ * calls GET /api/bridge/recipes/simulate and renders the static simulation.
+ * Mocks fetch; asserts risk, projected actions, the gatedOnRecipeSteps honesty
+ * caveat, and the error path.
+ */
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { SimulationReport } from "@/lib/simulation";
+import { SimulatePanel } from "../_components/SimulatePanel";
+
+function mockFetchOnce(body: unknown, ok = true, status = 200) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => ({
+      ok,
+      status,
+      json: async () => body,
+    })) as unknown as typeof fetch,
+  );
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+const REPORT: SimulationReport = {
+  schemaVersion: 1,
+  kind: "what-if-preview",
+  recipe: "demo",
+  triggerType: "chained",
+  generatedAt: "2026-06-05T00:00:00.000Z",
+  fidelity: "static",
+  topology: "chained",
+  gatedOnRecipeSteps: false,
+  steps: [
+    {
+      id: "open_pr",
+      type: "tool",
+      tool: "github.create_pr",
+      namespace: "github",
+      resolved: true,
+      baseRisk: "high",
+      effectiveRisk: "high",
+      sideEffect: "connector-write",
+      isWrite: true,
+      isConnector: true,
+      condition: "{{ fetch.count }}",
+    },
+  ],
+  summary: {
+    totalSteps: 1,
+    writeSteps: 1,
+    connectorSteps: 1,
+    agentSteps: 0,
+    unresolvedSteps: 0,
+    sideEffectCounts: { "connector-write": 1 },
+    connectorNamespaces: ["github"],
+  },
+  risk: {
+    score: 48,
+    tier: "high",
+    components: {
+      highSteps: 1,
+      mediumSteps: 0,
+      writeSteps: 1,
+      connectorWriteSteps: 1,
+      externalHttpSteps: 0,
+      unresolvedSteps: 0,
+    },
+    highestStepRisk: "high",
+  },
+  approvals: {
+    gatedOnRecipeSteps: false,
+    projected: [
+      {
+        stepId: "open_pr",
+        tool: "github.create_pr",
+        tier: "high",
+        wouldRequireApproval: true,
+        reason: "high-risk connector-write",
+      },
+    ],
+    note: "not gated today",
+  },
+  cost: {
+    basis: "unavailable",
+    agentSteps: 0,
+    estimatedAgentSteps: 0,
+    estPromptTokens: null,
+    usd: null,
+    note: "No AI/agent steps — this recipe incurs no model cost.",
+  },
+  branches: [
+    {
+      stepId: "open_pr",
+      condition: "{{ fetch.count }}",
+      outcome: "undetermined",
+      reason: "depends on prior step output",
+    },
+  ],
+  lint: { errors: [], warnings: [] },
+  notes: ["Static fidelity: no step is executed."],
+};
+
+describe("SimulatePanel", () => {
+  it("renders risk, actions and the not-gated honesty caveat", async () => {
+    mockFetchOnce({ report: REPORT });
+    render(<SimulatePanel recipeName="demo" />);
+    fireEvent.click(screen.getByRole("button", { name: /run simulation/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/HIGH risk · 48\/100 · chained/)).toBeTruthy();
+    });
+    // projected action with its tool + side-effect class
+    expect(screen.getByText("github.create_pr")).toBeTruthy();
+    expect(screen.getByText(/\[connector-write\]/)).toBeTruthy();
+    // the honesty caveat — approval projection is NOT a live gate
+    expect(screen.getByText(/NOT gated today/)).toBeTruthy();
+    // undetermined branch surfaced
+    expect(screen.getByText(/conditional branch\(es\) undetermined/)).toBeTruthy();
+  });
+
+  it("auto-runs on mount when autoRun is set", async () => {
+    mockFetchOnce({ report: REPORT });
+    render(<SimulatePanel recipeName="demo" autoRun />);
+    await waitFor(() => {
+      expect(screen.getByText(/HIGH risk/)).toBeTruthy();
+    });
+  });
+
+  it("shows an error when the simulation fails", async () => {
+    mockFetchOnce({ error: "boom" }, false, 500);
+    render(<SimulatePanel recipeName="demo" />);
+    fireEvent.click(screen.getByRole("button", { name: /run simulation/i }));
+    await waitFor(() => {
+      expect(screen.getByText(/Couldn't simulate: boom/)).toBeTruthy();
+    });
+  });
+});

--- a/dashboard/src/app/recipes/[...name]/_components/SimulatePanel.tsx
+++ b/dashboard/src/app/recipes/[...name]/_components/SimulatePanel.tsx
@@ -1,0 +1,199 @@
+"use client";
+
+/**
+ * What-If Preview panel — the dashboard home for `recipe simulate`. Calls the
+ * bridge `GET /recipes/:name/simulate` (via the `/api/bridge/recipes/simulate`
+ * proxy) and renders the static counterfactual: projected actions, side-effect
+ * taxonomy, blast-radius risk, a tier-only approval projection, a
+ * low-confidence cost note, and undetermined branches. Executes nothing.
+ *
+ * The bridge owns the simulation (single source of truth); this only renders
+ * it — and surfaces the `gatedOnRecipeSteps=false` honesty caveat loudly so the
+ * approval projection is never read as live gate behaviour.
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  fetchSimulation,
+  riskColor,
+  riskGlyph,
+  type SimulationReport,
+} from "@/lib/simulation";
+
+export function SimulatePanel({
+  recipeName,
+  autoRun = false,
+}: {
+  recipeName: string;
+  /** Run immediately on mount — used by `?simulate=1` deep-links. */
+  autoRun?: boolean;
+}) {
+  const [report, setReport] = useState<SimulationReport | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const run = useCallback(async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      setReport(await fetchSimulation(recipeName));
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+      setReport(null);
+    } finally {
+      setBusy(false);
+    }
+  }, [recipeName]);
+
+  const autoRanRef = useRef(false);
+  useEffect(() => {
+    if (autoRun && !autoRanRef.current) {
+      autoRanRef.current = true;
+      void run();
+    }
+  }, [autoRun, run]);
+
+  const gating = report?.approvals.projected.filter(
+    (a) => a.wouldRequireApproval,
+  ).length;
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "var(--s-3)" }}>
+      <div style={{ display: "flex", alignItems: "center", gap: "var(--s-3)" }}>
+        <button
+          type="button"
+          className="btn ghost"
+          onClick={() => void run()}
+          disabled={busy}
+          title="See what this recipe would do before you run it — executes nothing"
+        >
+          {busy ? "Simulating…" : "Run simulation"}
+        </button>
+        {report && (
+          <span
+            className="mono"
+            style={{ fontSize: "var(--fs-xs)", color: riskColor(report.risk.tier) }}
+          >
+            {report.risk.tier.toUpperCase()} risk · {report.risk.score}/100 ·{" "}
+            {report.topology}
+          </span>
+        )}
+      </div>
+
+      {error && (
+        <div style={{ fontSize: "var(--fs-xs)", color: "var(--err)" }}>
+          Couldn&apos;t simulate: {error}
+        </div>
+      )}
+
+      {report && (
+        <div
+          style={{ display: "flex", flexDirection: "column", gap: "var(--s-3)" }}
+        >
+          {/* Risk components — transparent, never a black-box number */}
+          <div className="mono muted" style={{ fontSize: "var(--fs-2xs)" }}>
+            high:{report.risk.components.highSteps} · medium:
+            {report.risk.components.mediumSteps} · writes:
+            {report.risk.components.writeSteps} · connector-writes:
+            {report.risk.components.connectorWriteSteps} · http:
+            {report.risk.components.externalHttpSteps} · unresolved:
+            {report.risk.components.unresolvedSteps}
+          </div>
+
+          {/* Actions */}
+          <div>
+            <div
+              className="mono muted"
+              style={{ fontSize: "var(--fs-2xs)", marginBottom: 2 }}
+            >
+              projected actions ({report.summary.totalSteps})
+            </div>
+            <ul
+              style={{
+                margin: 0,
+                paddingLeft: 16,
+                fontSize: "var(--fs-xs)",
+                display: "flex",
+                flexDirection: "column",
+                gap: 2,
+              }}
+            >
+              {report.steps.map((s) => (
+                <li key={s.id} style={{ wordBreak: "break-word" }}>
+                  <span
+                    style={{ color: riskColor(s.effectiveRisk), marginRight: 4 }}
+                  >
+                    {riskGlyph(s.effectiveRisk)}
+                  </span>
+                  <span className="mono">{s.id}</span> {s.tool ?? s.type}{" "}
+                  <span className="muted">[{s.sideEffect}]</span>
+                  {s.condition && (
+                    <span className="muted"> · when: {s.condition}</span>
+                  )}
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          {/* Side effects + connectors */}
+          <div style={{ fontSize: "var(--fs-xs)" }}>
+            <span className="mono muted" style={{ fontSize: "var(--fs-2xs)" }}>
+              side effects:{" "}
+            </span>
+            {report.summary.writeSteps} write(s) · {report.summary.connectorSteps}{" "}
+            connector call(s)
+            {report.summary.connectorNamespaces.length > 0 &&
+              ` (${report.summary.connectorNamespaces.join(", ")})`}{" "}
+            · {report.summary.agentSteps} agent step(s)
+          </div>
+
+          {/* Approvals — loud honesty caveat */}
+          <div style={{ fontSize: "var(--fs-xs)" }}>
+            <span className="mono muted" style={{ fontSize: "var(--fs-2xs)" }}>
+              approvals:{" "}
+            </span>
+            {gating} step(s) would gate
+            {!report.gatedOnRecipeSteps && (
+              <span style={{ color: "var(--warn)" }}>
+                {" "}
+                — but recipe steps are NOT gated today (projection only)
+              </span>
+            )}
+          </div>
+
+          {/* Cost */}
+          <div className="muted" style={{ fontSize: "var(--fs-xs)" }}>
+            cost:{" "}
+            {report.cost.basis === "heuristic"
+              ? `~${report.cost.estPromptTokens} input token(s) over ${report.cost.estimatedAgentSteps} agent step(s) (heuristic; USD not projected)`
+              : report.cost.note}
+          </div>
+
+          {/* Undetermined branches */}
+          {report.branches.length > 0 && (
+            <div style={{ fontSize: "var(--fs-xs)", color: "var(--warn)" }}>
+              {report.branches.length} conditional branch(es) undetermined —
+              resolved only in a later sandbox phase.
+            </div>
+          )}
+
+          {/* Lint */}
+          {(report.lint.errors.length > 0 || report.lint.warnings.length > 0) && (
+            <div style={{ fontSize: "var(--fs-xs)" }}>
+              <span className="mono muted" style={{ fontSize: "var(--fs-2xs)" }}>
+                lint:{" "}
+              </span>
+              <span style={{ color: "var(--err)" }}>
+                {report.lint.errors.length} error(s)
+              </span>
+              ,{" "}
+              <span style={{ color: "var(--warn)" }}>
+                {report.lint.warnings.length} warning(s)
+              </span>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/dashboard/src/app/recipes/[...name]/page.tsx
+++ b/dashboard/src/app/recipes/[...name]/page.tsx
@@ -17,7 +17,13 @@
 
 import Link from "next/link";
 import { use, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  fetchSimulation,
+  riskColor,
+  type SimulationReport,
+} from "@/lib/simulation";
 import { DoctorPanel } from "./_components/DoctorPanel";
+import { SimulatePanel } from "./_components/SimulatePanel";
 import RecipeEditPage from "./_edit/page";
 import RecipePlanPage from "./_plan/page";
 import { useRouter, useSearchParams } from "next/navigation";
@@ -195,6 +201,31 @@ function RunModal({
     setValues(init);
   }, [open, recipe]);
   const vars = recipe?.vars ?? [];
+
+  // Run-Now pre-run risk gate: when the modal opens, fetch the What-If Preview
+  // and show a compact risk banner so the user sees what this run WOULD do
+  // before confirming. Best-effort — a failed/absent simulation never blocks
+  // the run (the banner just doesn't render).
+  const [sim, setSim] = useState<SimulationReport | null>(null);
+  useEffect(() => {
+    if (!open || !recipe) {
+      setSim(null);
+      return;
+    }
+    let cancelled = false;
+    setSim(null);
+    void fetchSimulation(recipe.name)
+      .then((r) => {
+        if (!cancelled) setSim(r);
+      })
+      .catch(() => {
+        /* best-effort gate — ignore */
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [open, recipe]);
+
   return (
     <Dialog open={open} onClose={onClose} ariaLabelledBy="hub-run-modal-title" maxWidth={480}>
       {recipe && (
@@ -211,6 +242,35 @@ function RunModal({
               onConfirm(values);
             }}
           >
+            {sim && (
+              <div
+                style={{
+                  marginBottom: "var(--s-4)",
+                  padding: "var(--s-3) var(--s-4)",
+                  border: `1px solid ${riskColor(sim.risk.tier)}`,
+                  borderRadius: "var(--r-1)",
+                  background: "var(--bg-2)",
+                  fontSize: "var(--fs-s)",
+                }}
+              >
+                <strong style={{ color: riskColor(sim.risk.tier) }}>
+                  {sim.risk.tier.toUpperCase()} risk
+                </strong>{" "}
+                ({sim.risk.score}/100) — {sim.summary.writeSteps} write(s),{" "}
+                {sim.summary.connectorSteps} connector call(s)
+                {sim.summary.connectorNamespaces.length > 0 &&
+                  ` (${sim.summary.connectorNamespaces.join(", ")})`}
+                , {sim.summary.agentSteps} agent step(s).{" "}
+                <Link
+                  href={`/recipes/${encodeURIComponent(
+                    canonicalRecipeKey(recipe.name),
+                  )}?simulate=1#simulate`}
+                  style={{ color: "var(--ink-2)" }}
+                >
+                  Full preview →
+                </Link>
+              </div>
+            )}
             {vars.length === 0 && (
               <div
                 style={{
@@ -280,6 +340,8 @@ function RecipeHubOverviewPage({ name }: { name: string }) {
   // Deep-link: `?diagnose=1` (from the recipes list / failed-run views)
   // auto-runs the Doctor panel and scrolls to it.
   const autoDiagnose = useSearchParams().get("diagnose") === "1";
+  // Deep-link: `?simulate=1` auto-runs the What-If Preview panel + scrolls to it.
+  const autoSimulate = useSearchParams().get("simulate") === "1";
 
   // Reusable list fetch for the recipe row (matches layout's data source).
   const { data: recipes, refetch: refetchRecipes } = useBridgeFetch<Recipe[]>(
@@ -841,6 +903,14 @@ function RecipeHubOverviewPage({ name }: { name: string }) {
             Plan
           </Link>
           <Link
+            href={`/recipes/${encodeURIComponent(name)}?simulate=1#simulate`}
+            className="btn ghost hub-control-btn"
+            style={{ textDecoration: "none" }}
+            title="What-If Preview — see what this recipe would do before running it"
+          >
+            Simulate
+          </Link>
+          <Link
             href={`/recipes/compare?name=${encodeURIComponent(name)}`}
             className="btn ghost hub-control-btn"
             style={{ textDecoration: "none" }}
@@ -865,6 +935,15 @@ function RecipeHubOverviewPage({ name }: { name: string }) {
       <PatchCard className="hub-card" style={{ padding: "var(--s-4)", animation: "hubCardIn 260ms 160ms ease both", animationFillMode: "both" }}>
         <SectionHeader>Doctor</SectionHeader>
         <DoctorPanel recipeName={name} autoRun={autoDiagnose} />
+      </PatchCard>
+      </div>
+
+      {/* WHAT-IF PREVIEW — static counterfactual simulation (no execution).
+          The wrapping `#simulate` div is the scroll target for deep-links. */}
+      <div id="simulate">
+      <PatchCard className="hub-card" style={{ padding: "var(--s-4)", animation: "hubCardIn 280ms 180ms ease both", animationFillMode: "both" }}>
+        <SectionHeader>What-If Preview</SectionHeader>
+        <SimulatePanel recipeName={name} autoRun={autoSimulate} />
       </PatchCard>
       </div>
       </div>{/* end main column */}

--- a/dashboard/src/lib/simulation.ts
+++ b/dashboard/src/lib/simulation.ts
@@ -1,0 +1,134 @@
+/**
+ * What-If Preview — client types + helpers for the recipe simulation report
+ * (bridge `GET /recipes/:name/simulate`, proxied via
+ * `/api/bridge/recipes/simulate?recipe=`). A local mirror of the bridge's
+ * `RecipeSimulationReport` (src/recipes/simulation/types.ts) — only the fields
+ * the dashboard renders. Keep in sync with `schemaVersion`.
+ */
+
+import { apiPath } from "@/lib/api";
+
+export type RiskTier = "low" | "medium" | "high";
+
+export type SideEffectKind =
+  | "local-read"
+  | "local-write"
+  | "connector-read"
+  | "connector-write"
+  | "external-http"
+  | "agent-llm"
+  | "nested-recipe"
+  | "unknown";
+
+export interface SimulationStep {
+  id: string;
+  type: "tool" | "agent" | "recipe";
+  tool?: string;
+  namespace?: string;
+  resolved: boolean;
+  optional?: boolean;
+  condition?: string;
+  baseRisk: RiskTier;
+  effectiveRisk: RiskTier;
+  sideEffect: SideEffectKind;
+  isWrite: boolean;
+  isConnector: boolean;
+}
+
+export interface SimulationReport {
+  schemaVersion: number;
+  kind: "what-if-preview";
+  recipe: string;
+  triggerType: string;
+  generatedAt: string;
+  fidelity: "static";
+  topology: "chained" | "flat";
+  gatedOnRecipeSteps: boolean;
+  steps: SimulationStep[];
+  summary: {
+    totalSteps: number;
+    writeSteps: number;
+    connectorSteps: number;
+    agentSteps: number;
+    unresolvedSteps: number;
+    sideEffectCounts: Record<string, number>;
+    connectorNamespaces: string[];
+  };
+  risk: {
+    score: number;
+    tier: RiskTier;
+    components: {
+      highSteps: number;
+      mediumSteps: number;
+      writeSteps: number;
+      connectorWriteSteps: number;
+      externalHttpSteps: number;
+      unresolvedSteps: number;
+    };
+    highestStepRisk: RiskTier;
+  };
+  approvals: {
+    gatedOnRecipeSteps: boolean;
+    projected: Array<{
+      stepId: string;
+      tool?: string;
+      tier: RiskTier;
+      wouldRequireApproval: boolean;
+      reason: string;
+    }>;
+    note: string;
+  };
+  cost: {
+    basis: "heuristic" | "unavailable";
+    agentSteps: number;
+    estimatedAgentSteps: number;
+    estPromptTokens: number | null;
+    usd: null;
+    note: string;
+  };
+  branches: Array<{
+    stepId: string;
+    condition: string;
+    outcome: "undetermined";
+    reason: string;
+  }>;
+  lint: { errors: string[]; warnings: string[] };
+  notes: string[];
+}
+
+/** CSS var for a risk tier — matches the dashboard ok/warn/err palette. */
+export function riskColor(tier: RiskTier): string {
+  return tier === "high"
+    ? "var(--err)"
+    : tier === "medium"
+      ? "var(--warn)"
+      : "var(--ok)";
+}
+
+/** Per-step effective-risk glyph used in the actions list. */
+export function riskGlyph(tier: RiskTier): string {
+  return tier === "high" ? "●" : tier === "medium" ? "◐" : "○";
+}
+
+/**
+ * Fetch a recipe's simulation report. Returns the parsed report or throws with
+ * a human message. Shared by the SimulatePanel and the Run-Now risk gate.
+ */
+export async function fetchSimulation(
+  recipeName: string,
+): Promise<SimulationReport> {
+  const res = await fetch(
+    apiPath(`/api/bridge/recipes/simulate?recipe=${encodeURIComponent(recipeName)}`),
+  );
+  const data = (await res.json().catch(() => ({}))) as
+    | { report: SimulationReport }
+    | { error?: string; message?: string };
+  if (!res.ok || !("report" in data) || !data.report) {
+    const msg =
+      ("message" in data && data.message) ||
+      ("error" in data && data.error) ||
+      `HTTP ${res.status}`;
+    throw new Error(String(msg));
+  }
+  return data.report;
+}


### PR DESCRIPTION
## What

Surfaces the recipe simulation engine (P0 #916, HTTP route #918) in the dashboard so users can **see what a recipe would do before they run it**. Final piece of the What-If Preview roadmap.

## Changes

- **`api/bridge/recipes/simulate/route.ts`** — dedicated **static** proxy translating `?recipe=` → the bridge's path param `GET /recipes/:name/simulate`. A static segment is required so the request doesn't fall through to the `recipes/[...name]` catch-all (same lesson as the doctor proxy); a `[name]` sibling would conflict with the catch-all slug.
- **`lib/simulation.ts`** — client mirror of `RecipeSimulationReport` + `fetchSimulation`/`riskColor`/`riskGlyph` helpers, shared by the panel and the run gate.
- **`SimulatePanel.tsx`** — mirrors `DoctorPanel`: projected actions, side-effect taxonomy, blast-radius risk (with **transparent components**, never a black-box number), a tier-only approval projection that **loudly flags "recipe steps are NOT gated today"**, low-confidence cost note, undetermined branches. Mounted as a **What-If Preview** card + a Controls **Simulate** button + `?simulate=1` deep-link (mirrors `?diagnose=1`).
- **RunModal** — a best-effort **pre-run risk banner** (tier/score + write/connector/agent counts + link to the full preview), fetched when the run modal opens. Never blocks the run if the simulation is unavailable.

## Honesty

The `gatedOnRecipeSteps:false` field is surfaced prominently in both the panel and the approval line, so the projection is never read as live gate behaviour.

## Tests

- `SimulatePanel.test.tsx` — risk/actions render, the not-gated honesty caveat, undetermined branches, auto-run, error path.
- `simulate/__tests__/route.test.ts` — query→path translation, scoped-name encoding, 400 (missing recipe) / 502 (bridge down).
- **7 pass**; dashboard `tsc --noEmit` + biome clean.

## Visual verification

Skipped live Playwright: no Patchwork dashboard instance was running, and standing up the dashboard + a freshly-built bridge + an installed recipe is disproportionate for a component that is structurally identical to the already-shipped, unit-tested `DoctorPanel` and uses **only theme-aware semantic tokens** (`--err`/`--warn`/`--ok`/`--ink`/`--bg-2`), so both light and dark are safe by construction. Worth a quick manual look on a live instance before merge if desired.

Completes: P0 engine #916 · P1 cost persistence #917 · HTTP route + schema #918 · **this** (dashboard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)