### PR TITLE
feat(recipes): What-If Preview P2 — trace-seeded mocked sandbox (chained, zero-IO)

### DIFF
--- a/src/commands/recipe.ts
+++ b/src/commands/recipe.ts
@@ -34,7 +34,11 @@ import {
 } from "../recipes/migrations/index.js";
 import { tryResolveRecipePath } from "../recipes/resolveRecipePath.js";
 import { generateSchemaSet, writeSchemas } from "../recipes/schemaGenerator.js";
-import { simulateFromPlan } from "../recipes/simulation/simulate.js";
+import {
+  simulateFromPlan,
+  simulateMockedFromPlan,
+} from "../recipes/simulation/simulate.js";
+import { simulateMockedRun } from "../recipes/simulation/simulateMockedRun.js";
 import type { RecipeSimulationReport } from "../recipes/simulation/types.js";
 import {
   getTool,
@@ -61,6 +65,7 @@ import {
   type YamlStep,
 } from "../recipes/yamlRunner.js";
 import { findYamlRecipePath } from "../recipesHttp.js";
+import type { RecipeRunLog } from "../runLog.js";
 import { findInstalledRecipeEntrypoint } from "./recipeInstall.js";
 
 const RECIPES_DIR = join(os.homedir(), ".patchwork", "recipes");
@@ -1663,9 +1668,32 @@ export async function runRecipeDryPlan(
  */
 export async function runRecipeSimulate(
   recipeRef: string,
-  options: RunRecipeOptions = {},
+  options: RunRecipeOptions & { runLog?: RecipeRunLog } = {},
 ): Promise<RecipeSimulationReport> {
   const plan = await runRecipeDryPlan(recipeRef, options);
+
+  // P2 mocked sandbox — ONLY for chained recipes WITH run history and a
+  // provided runLog. Flat recipes ALWAYS stay static (hard guard: the runner
+  // is never driven for a flat recipe). Callers with no runLog (CLI) stay
+  // static too.
+  if (plan.triggerType === "chained" && options.runLog) {
+    try {
+      const recipePath = resolveRecipePath(recipeRef);
+      const recipe = loadYamlRecipe(recipePath);
+      const recipeToPlan = options.step
+        ? { ...recipe, steps: [selectRecipeStep(recipe, options.step).step] }
+        : recipe;
+      const chainedRecipe =
+        recipeToPlan as unknown as import("../recipes/chainedRunner.js").ChainedRecipe;
+      const mocked = await simulateMockedRun(chainedRecipe, options.runLog);
+      if (mocked.sampleRuns > 0) {
+        return simulateMockedFromPlan(plan, mocked);
+      }
+    } catch {
+      // Fail-soft: fall through to the static report.
+    }
+  }
+
   return simulateFromPlan(plan);
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3012,8 +3012,12 @@ if (process.argv[2] === "recipe" && process.argv[3] === "simulate") {
       const out = process.stdout;
       const mark = (tier: string): string =>
         tier === "high" ? "●" : tier === "medium" ? "◐" : "○";
+      const fidelityLabel =
+        report.fidelity === "mocked"
+          ? `mocked fidelity, ${report.sampleRuns ?? 0} prior run(s)`
+          : `${report.fidelity} fidelity`;
       out.write(
-        `\n  What-If Preview — ${report.recipe} (${report.topology}, ${report.fidelity} fidelity)\n`,
+        `\n  What-If Preview — ${report.recipe} (${report.topology}, ${fidelityLabel})\n`,
       );
       out.write(
         `  Trigger: ${report.triggerType} · ${report.summary.totalSteps} step(s)\n\n`,
@@ -3054,9 +3058,29 @@ if (process.argv[2] === "recipe" && process.argv[3] === "simulate") {
         }\n`,
       );
       if (report.branches.length > 0) {
-        out.write(
-          `  Branches: ${report.branches.length} conditional — undetermined (resolve in a later sandbox phase)\n`,
-        );
+        if (report.fidelity === "mocked") {
+          const taken = report.branches.filter(
+            (b) => b.outcome === "taken",
+          ).length;
+          const skipped = report.branches.filter(
+            (b) => b.outcome === "skipped",
+          ).length;
+          const undet = report.branches.filter(
+            (b) => b.outcome === "undetermined",
+          ).length;
+          out.write(
+            `  Branches: ${report.branches.length} conditional — ${taken} taken, ${skipped} skipped, ${undet} undetermined\n`,
+          );
+          for (const b of report.branches) {
+            out.write(
+              `    ${b.outcome.padEnd(12)} ${b.stepId}  ${b.condition}\n`,
+            );
+          }
+        } else {
+          out.write(
+            `  Branches: ${report.branches.length} conditional — undetermined (resolve in a later sandbox phase)\n`,
+          );
+        }
       }
       if (report.lint.errors.length > 0 || report.lint.warnings.length > 0) {
         out.write(

--- a/src/recipeOrchestration.ts
+++ b/src/recipeOrchestration.ts
@@ -262,10 +262,13 @@ export class RecipeOrchestration {
 
     server.simulateFn = async (recipeName: string) => {
       const { runRecipeSimulate } = await import("./commands/recipe.js");
-      return (await runRecipeSimulate(recipeName)) as unknown as Record<
-        string,
-        unknown
-      >;
+      // P2: pass the long-lived run log so chained recipes WITH history get a
+      // higher-fidelity "mocked" report (zero real I/O — the runner is driven
+      // with history-backed mockedOutputs + stubbed deps + no persistence).
+      // Flat recipes / no-history recipes fall back to the static report.
+      return (await runRecipeSimulate(recipeName, {
+        ...(this.deps.recipeRunLog ? { runLog: this.deps.recipeRunLog } : {}),
+      })) as unknown as Record<string, unknown>;
     };
 
     // VD-4 mocked replay: load the original run, re-parse its recipe

--- a/src/recipes/__tests__/schemaGenerator.test.ts
+++ b/src/recipes/__tests__/schemaGenerator.test.ts
@@ -452,9 +452,12 @@ describe("schemaGenerator", () => {
         "https://raw.githubusercontent.com/patchworkos/recipes/main/schema/simulation-report.v1.json",
       );
       const properties = schema.properties as Record<string, unknown>;
-      expect(properties.schemaVersion).toMatchObject({ const: 1 });
+      expect(properties.schemaVersion).toMatchObject({ const: 2 });
       expect(properties.kind).toMatchObject({ const: "what-if-preview" });
       expect(properties.gatedOnRecipeSteps).toMatchObject({ type: "boolean" });
+      expect(properties.fidelity).toMatchObject({
+        enum: ["static", "mocked"],
+      });
     });
 
     it("validates a real simulateFromPlan output via Ajv", () => {

--- a/src/recipes/schemaGenerator.ts
+++ b/src/recipes/schemaGenerator.ts
@@ -176,6 +176,12 @@ export function generateSimulationSchema(): unknown {
       sideEffect: sideEffectEnum,
       isWrite: { type: "boolean" },
       isConnector: { type: "boolean" },
+      mockedFrom: {
+        type: "string",
+        enum: ["history", "synthesized"],
+        description:
+          "Mocked fidelity only — whether this step's output came from real run history or a synthesized placeholder.",
+      },
     },
   };
 
@@ -205,7 +211,7 @@ export function generateSimulationSchema(): unknown {
       "notes",
     ],
     properties: {
-      schemaVersion: { type: "number", const: 1 },
+      schemaVersion: { type: "number", const: 2 },
       kind: { type: "string", const: "what-if-preview" },
       recipe: { type: "string" },
       triggerType: { type: "string" },
@@ -213,7 +219,12 @@ export function generateSimulationSchema(): unknown {
         type: "string",
         description: "ISO-8601 timestamp (reused from the dry-run plan)",
       },
-      fidelity: { type: "string", enum: ["static"] },
+      fidelity: { type: "string", enum: ["static", "mocked"] },
+      sampleRuns: {
+        type: "number",
+        description:
+          "Mocked fidelity only — number of prior runs sampled to seed the mocked sandbox.",
+      },
       topology: { type: "string", enum: ["chained", "flat"] },
       gatedOnRecipeSteps: {
         type: "boolean",
@@ -322,7 +333,10 @@ export function generateSimulationSchema(): unknown {
           properties: {
             stepId: { type: "string" },
             condition: { type: "string" },
-            outcome: { type: "string", const: "undetermined" },
+            outcome: {
+              type: "string",
+              enum: ["taken", "skipped", "undetermined"],
+            },
             reason: { type: "string" },
           },
         },

--- a/src/recipes/simulation/__tests__/mockedSandbox.test.ts
+++ b/src/recipes/simulation/__tests__/mockedSandbox.test.ts
@@ -1,0 +1,415 @@
+/**
+ * What-If Preview (P2) — trace-seeded mocked sandbox tests.
+ *
+ * These prove the non-negotiable safety invariant (ZERO real I/O, ZERO
+ * persistence), the history-wins synthesis rule, the determinable-branch rule,
+ * the routing hard guards, and the v2 schema.
+ */
+
+import {
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { Ajv } from "ajv";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { RecipeDryRunPlan } from "../../../commands/recipe.js";
+import { type RecipeRun, RecipeRunLog } from "../../../runLog.js";
+import type { ChainedRecipe } from "../../chainedRunner.js";
+import { generateSimulationSchema } from "../../schemaGenerator.js";
+import {
+  extractReferencedStepIds,
+  simulateMockedFromPlan,
+} from "../simulate.js";
+import { createStubDeps, simulateMockedRun } from "../simulateMockedRun.js";
+import { synthesizeMockedOutputs } from "../synthesizeMockedOutputs.js";
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(path.join(os.tmpdir(), "p2-mocked-"));
+});
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+/** Build an in-memory-backed RecipeRunLog seeded with the given runs. */
+function makeRunLog(runs: Array<Partial<RecipeRun> & { recipeName: string }>): {
+  log: RecipeRunLog;
+  dir: string;
+} {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "p2-runlog-"));
+  const log = new RecipeRunLog({ dir });
+  // Seed via the documented public startRun/completeRun lifecycle so query()
+  // returns these runs newest-first.
+  let seq = 0;
+  for (const r of runs) {
+    seq += 1;
+    const startedSeq = log.startRun({
+      taskId: `chained:${r.recipeName}:${seq}`,
+      recipeName: r.recipeName,
+      trigger: "recipe",
+      createdAt: r.createdAt ?? seq * 1000,
+    });
+    const doneAt = r.doneAt ?? seq * 1000 + 100;
+    log.completeRun(startedSeq, {
+      status: (r.status as "done") ?? "done",
+      doneAt,
+      durationMs: 100,
+      stepResults: (r.stepResults ?? []).map((s) => ({
+        ...s,
+        durationMs: s.durationMs ?? 1,
+      })),
+    });
+  }
+  return { log, dir };
+}
+
+function staticPlan(
+  steps: RecipeDryRunPlan["steps"],
+  triggerType = "chained",
+): RecipeDryRunPlan {
+  return {
+    schemaVersion: 1,
+    recipe: "r",
+    mode: "dry-run",
+    triggerType,
+    generatedAt: new Date().toISOString(),
+    steps,
+    lint: { errors: [], warnings: [] },
+  };
+}
+
+// ── synthesizeMockedOutputs: history wins, skip truncated/skipped ───────────
+
+describe("synthesizeMockedOutputs", () => {
+  it("takes the MOST RECENT non-truncated, non-skipped output per step id", () => {
+    const { log } = makeRunLog([
+      // older run (seq 1) — older value for "a"
+      {
+        recipeName: "r",
+        stepResults: [{ id: "a", status: "ok", output: "old-a" }] as never,
+      },
+      // newer run (seq 2) — newer value for "a", plus "b"
+      {
+        recipeName: "r",
+        stepResults: [
+          { id: "a", status: "ok", output: "new-a" },
+          { id: "b", status: "ok", output: { val: 2 } },
+        ] as never,
+      },
+    ]);
+    const { outputs, historyStepIds, sampleRuns } = synthesizeMockedOutputs(
+      "r",
+      log,
+    );
+    expect(sampleRuns).toBe(2);
+    expect(outputs.get("a")).toBe("new-a"); // most-recent wins
+    expect(outputs.get("b")).toEqual({ val: 2 });
+    expect([...historyStepIds].sort()).toEqual(["a", "b"]);
+  });
+
+  it("ignores truncated and skipped outputs and undefined outputs", () => {
+    const { log } = makeRunLog([
+      {
+        recipeName: "r",
+        stepResults: [
+          { id: "trunc", status: "ok", output: { "[truncated]": true } },
+          { id: "skip", status: "skipped", output: "ignored" },
+          { id: "undef", status: "ok" },
+          { id: "good", status: "ok", output: "kept" },
+        ] as never,
+      },
+    ]);
+    const { outputs, historyStepIds } = synthesizeMockedOutputs("r", log);
+    expect(outputs.has("trunc")).toBe(false);
+    expect(outputs.has("skip")).toBe(false);
+    expect(outputs.has("undef")).toBe(false);
+    expect(outputs.get("good")).toBe("kept");
+    expect([...historyStepIds]).toEqual(["good"]);
+  });
+});
+
+// ── SAFETY: uncovered steps hit the STUB, no real I/O, no persistence ───────
+
+describe("simulateMockedRun — safety invariant", () => {
+  it("calls the STUB executor for a step with NO history and writes no run log", async () => {
+    // step "a" HAS history; step "b" does NOT.
+    const { log, dir } = makeRunLog([
+      {
+        recipeName: "r",
+        stepResults: [{ id: "a", status: "ok", output: "hist-a" }] as never,
+      },
+    ]);
+
+    const beforeFiles = readdirSync(dir);
+
+    const stubTool = vi.fn(async (tool: string) => `[simulated:${tool}]`);
+    const stubAgent = vi.fn(async () => ({ text: "[simulated:agent]" }));
+    const stubLoad = vi.fn(async () => null);
+    const stub = {
+      executeTool: stubTool,
+      executeAgent: stubAgent,
+      loadNestedRecipe: stubLoad,
+    };
+
+    const recipe: ChainedRecipe = {
+      name: "r",
+      steps: [
+        { id: "a", tool: "toolA" },
+        { id: "b", tool: "toolB", awaits: ["a"] },
+      ],
+    };
+
+    const result = await simulateMockedRun(recipe, log, {}, stub);
+
+    // "a" came from history → stub NOT called for it.
+    // "b" had no history → stub WAS called (no real execution).
+    expect(stubTool).toHaveBeenCalledTimes(1);
+    expect(stubTool).toHaveBeenCalledWith("toolB", expect.anything());
+
+    // Result still returned with both steps.
+    expect(result.stepData.get("a")?.mockedFrom).toBe("history");
+    expect(result.stepData.get("b")?.mockedFrom).toBe("synthesized");
+    expect(result.historyStepIds.has("a")).toBe(true);
+
+    // No persistence: the seeded runs.jsonl is unchanged; no NEW run appended
+    // by the sandbox (we passed no runLog to the runner).
+    const afterFiles = readdirSync(dir);
+    expect(afterFiles).toEqual(beforeFiles);
+    // The run log still only has the one seeded run.
+    expect(log.query({ recipe: "r" }).length).toBe(1);
+  });
+
+  it("default stub deps return synthesized placeholders and never null-throw", async () => {
+    const stub = createStubDeps();
+    await expect(stub.executeTool("x", {})).resolves.toBe("[simulated:x]");
+    await expect(stub.executeAgent("p")).resolves.toEqual({
+      text: "[simulated:agent]",
+    });
+    await expect(stub.loadNestedRecipe("n")).resolves.toBeNull();
+  });
+});
+
+// ── extractReferencedStepIds + branch resolution ───────────────────────────
+
+describe("extractReferencedStepIds", () => {
+  it("pulls step ids from steps.<id>.data / outputs.<id> / bare id", () => {
+    expect([...extractReferencedStepIds("{{ steps.a.data }}")]).toEqual(["a"]);
+    expect([...extractReferencedStepIds("{{ outputs.b }}")]).toEqual(["b"]);
+    expect([...extractReferencedStepIds("{{ c }}")]).toEqual(["c"]);
+    expect([...extractReferencedStepIds("{{ env.FOO }}")]).toEqual([]);
+  });
+});
+
+describe("branch resolution (mocked overlay)", () => {
+  it("a when: referencing a step WITH history resolves to taken/skipped", async () => {
+    // "a" has a truthy output → branch "b" (when steps.a.data) is taken.
+    const { log } = makeRunLog([
+      {
+        recipeName: "r",
+        stepResults: [{ id: "a", status: "ok", output: "yes" }] as never,
+      },
+    ]);
+    const recipe: ChainedRecipe = {
+      name: "r",
+      steps: [
+        { id: "a", tool: "toolA" },
+        { id: "b", tool: "toolB", awaits: ["a"], when: "{{ steps.a.data }}" },
+      ],
+    };
+    const mocked = await simulateMockedRun(recipe, log);
+
+    const plan = staticPlan([
+      { id: "a", type: "tool", tool: "toolA", resolved: true },
+      {
+        id: "b",
+        type: "tool",
+        tool: "toolB",
+        resolved: true,
+        condition: "{{ steps.a.data }}",
+      },
+    ]);
+    const report = simulateMockedFromPlan(plan, mocked);
+    expect(report.fidelity).toBe("mocked");
+    expect(report.branches).toHaveLength(1);
+    expect(report.branches[0]?.outcome).toBe("taken");
+  });
+
+  it("a when: referencing a falsy historical output resolves to skipped", async () => {
+    const { log } = makeRunLog([
+      {
+        recipeName: "r",
+        stepResults: [{ id: "a", status: "ok", output: "" }] as never,
+      },
+    ]);
+    const recipe: ChainedRecipe = {
+      name: "r",
+      steps: [
+        { id: "a", tool: "toolA" },
+        { id: "b", tool: "toolB", awaits: ["a"], when: "{{ steps.a.data }}" },
+      ],
+    };
+    const mocked = await simulateMockedRun(recipe, log);
+    const plan = staticPlan([
+      { id: "a", type: "tool", tool: "toolA", resolved: true },
+      {
+        id: "b",
+        type: "tool",
+        tool: "toolB",
+        resolved: true,
+        condition: "{{ steps.a.data }}",
+      },
+    ]);
+    const report = simulateMockedFromPlan(plan, mocked);
+    expect(report.branches[0]?.outcome).toBe("skipped");
+  });
+
+  it("a when: referencing a SYNTHESIZED (no-history) step stays undetermined", async () => {
+    // No history at all → "a" is synthesized → branch undetermined.
+    const { log } = makeRunLog([
+      {
+        recipeName: "r",
+        stepResults: [{ id: "z", status: "ok", output: "unrelated" }] as never,
+      },
+    ]);
+    const recipe: ChainedRecipe = {
+      name: "r",
+      steps: [
+        { id: "a", tool: "toolA" },
+        { id: "b", tool: "toolB", awaits: ["a"], when: "{{ steps.a.data }}" },
+      ],
+    };
+    const mocked = await simulateMockedRun(recipe, log);
+    const plan = staticPlan([
+      { id: "a", type: "tool", tool: "toolA", resolved: true },
+      {
+        id: "b",
+        type: "tool",
+        tool: "toolB",
+        resolved: true,
+        condition: "{{ steps.a.data }}",
+      },
+    ]);
+    const report = simulateMockedFromPlan(plan, mocked);
+    expect(mocked.historyStepIds.has("a")).toBe(false);
+    expect(report.branches[0]?.outcome).toBe("undetermined");
+  });
+});
+
+// ── Routing (runRecipeSimulate hard guards) ────────────────────────────────
+
+describe("runRecipeSimulate routing", () => {
+  function writeRecipe(name: string, body: string): void {
+    const recipesDir = path.join(os.homedir(), ".patchwork", "recipes");
+    mkdirSync(recipesDir, { recursive: true });
+    writeFileSync(path.join(recipesDir, `${name}.yaml`), body);
+  }
+
+  it("chained + runLog-with-history → fidelity:mocked", async () => {
+    const name = `p2route-chained-${Date.now()}`;
+    writeRecipe(
+      name,
+      `name: ${name}\ntrigger:\n  type: chained\nsteps:\n  - id: a\n    tool: noop.tool\n`,
+    );
+    const { log } = makeRunLog([
+      {
+        recipeName: name,
+        stepResults: [{ id: "a", status: "ok", output: "hist" }] as never,
+      },
+    ]);
+    const { runRecipeSimulate } = await import("../../../commands/recipe.js");
+    const report = await runRecipeSimulate(name, { runLog: log });
+    expect(report.fidelity).toBe("mocked");
+    expect(report.sampleRuns).toBe(1);
+    rmSync(path.join(os.homedir(), ".patchwork", "recipes", `${name}.yaml`), {
+      force: true,
+    });
+  });
+
+  it("chained + NO runLog → fidelity:static", async () => {
+    const name = `p2route-norunlog-${Date.now()}`;
+    writeRecipe(
+      name,
+      `name: ${name}\ntrigger:\n  type: chained\nsteps:\n  - id: a\n    tool: noop.tool\n`,
+    );
+    const { runRecipeSimulate } = await import("../../../commands/recipe.js");
+    const report = await runRecipeSimulate(name);
+    expect(report.fidelity).toBe("static");
+    rmSync(path.join(os.homedir(), ".patchwork", "recipes", `${name}.yaml`), {
+      force: true,
+    });
+  });
+
+  it("FLAT recipe → fidelity:static even WITH runLog (hard guard, runner never invoked)", async () => {
+    const name = `p2route-flat-${Date.now()}`;
+    writeRecipe(
+      name,
+      `name: ${name}\ntrigger:\n  type: manual\nsteps:\n  - tool: noop.tool\n    into: a\n`,
+    );
+    const { log } = makeRunLog([
+      {
+        recipeName: name,
+        stepResults: [{ id: "a", status: "ok", output: "hist" }] as never,
+      },
+    ]);
+    const { runRecipeSimulate } = await import("../../../commands/recipe.js");
+    const report = await runRecipeSimulate(name, { runLog: log });
+    expect(report.fidelity).toBe("static");
+    rmSync(path.join(os.homedir(), ".patchwork", "recipes", `${name}.yaml`), {
+      force: true,
+    });
+  });
+});
+
+// ── Schema v2 ──────────────────────────────────────────────────────────────
+
+describe("simulation schema v2", () => {
+  it("validates a real mocked report; schemaVersion const 2; fidelity accepts mocked", async () => {
+    const { log } = makeRunLog([
+      {
+        recipeName: "r",
+        stepResults: [{ id: "a", status: "ok", output: "yes" }] as never,
+      },
+    ]);
+    const recipe: ChainedRecipe = {
+      name: "r",
+      steps: [
+        { id: "a", tool: "toolA" },
+        { id: "b", tool: "toolB", awaits: ["a"], when: "{{ steps.a.data }}" },
+      ],
+    };
+    const mocked = await simulateMockedRun(recipe, log);
+    const plan = staticPlan([
+      { id: "a", type: "tool", tool: "toolA", resolved: true },
+      {
+        id: "b",
+        type: "tool",
+        tool: "toolB",
+        resolved: true,
+        condition: "{{ steps.a.data }}",
+      },
+    ]);
+    const report = simulateMockedFromPlan(plan, mocked);
+
+    const schema = generateSimulationSchema() as Record<string, unknown>;
+    const props = schema.properties as Record<string, { const?: number }>;
+    expect(props.schemaVersion?.const).toBe(2);
+
+    const ajv = new Ajv({ strict: false });
+    const validate = ajv.compile(schema as object);
+    const ok = validate(report);
+    if (!ok) {
+      throw new Error(
+        `schema errors: ${JSON.stringify(validate.errors, null, 2)}`,
+      );
+    }
+    expect(ok).toBe(true);
+    expect(report.fidelity).toBe("mocked");
+    expect(report.schemaVersion).toBe(2);
+  });
+});

--- a/src/recipes/simulation/simulate.ts
+++ b/src/recipes/simulation/simulate.ts
@@ -17,6 +17,7 @@ import {
   classifyStepSideEffect,
   emptySideEffectCounts,
 } from "./sideEffects.js";
+import type { MockedRunResult } from "./simulateMockedRun.js";
 import {
   type ApprovalProjection,
   type BranchProjection,
@@ -224,6 +225,109 @@ export function simulateFromPlan(
     cost,
     branches,
     lint: plan.lint,
+    notes,
+  };
+}
+
+/**
+ * Extract the step ids a `when:` condition references via `{{ ... }}`
+ * placeholders. Covers the common dotted forms the chained runner exposes
+ * (`steps.<id>.data`, `outputs.<id>`, or a bare `<id>`). A coarse regex is
+ * deliberate — we only need to know WHICH step ids the branch depends on so we
+ * can decide whether the branch is determinable from history.
+ */
+export function extractReferencedStepIds(condition: string): Set<string> {
+  const ids = new Set<string>();
+  const placeholder = /\{\{\s*([^}]+?)\s*\}\}/g;
+  let m: RegExpExecArray | null = placeholder.exec(condition);
+  while (m !== null) {
+    const expr = (m[1] ?? "").trim();
+    // First identifier-ish token of the expression.
+    const head = /^[A-Za-z_$][\w$]*/.exec(expr)?.[0];
+    if (head) {
+      if ((head === "steps" || head === "outputs") && expr.includes(".")) {
+        // steps.<id>.data | outputs.<id>
+        const seg = /^(?:steps|outputs)\.([A-Za-z_$][\w$]*)/.exec(expr)?.[1];
+        if (seg) ids.add(seg);
+      } else if (head !== "env") {
+        // bare step id (env keys are not steps)
+        ids.add(head);
+      }
+    }
+    m = placeholder.exec(condition);
+  }
+  return ids;
+}
+
+/**
+ * P2 — compose the mocked report: take the static report and OVERLAY the
+ * results of the trace-seeded mocked sandbox run.
+ *
+ *   - `fidelity:"mocked"` + `sampleRuns`.
+ *   - each step's `mockedFrom` ("history" | "synthesized").
+ *   - `branches[].outcome` recomputed: `"taken"`/`"skipped"` when EVERY step id
+ *     the `when:` references is in `historyStepIds` (determinable from real
+ *     data), else `"undetermined"`.
+ *
+ * Risk / side-effect / cost / approvals sections are carried over unchanged
+ * from the static report. `gatedOnRecipeSteps` stays false (P0/P4 truth).
+ */
+export function simulateMockedFromPlan(
+  plan: RecipeDryRunPlan,
+  mocked: MockedRunResult,
+): RecipeSimulationReport {
+  const base = simulateFromPlan(plan);
+
+  const steps: SimulationStep[] = base.steps.map((s) => {
+    const state = mocked.stepData.get(s.id);
+    const mockedFrom: "history" | "synthesized" =
+      state?.mockedFrom ??
+      (mocked.historyStepIds.has(s.id) ? "history" : "synthesized");
+    return { ...s, mockedFrom };
+  });
+
+  const branches: BranchProjection[] = base.branches.map((b) => {
+    const refs = extractReferencedStepIds(b.condition);
+    const determinable =
+      refs.size > 0 && [...refs].every((id) => mocked.historyStepIds.has(id));
+    if (!determinable) {
+      return {
+        ...b,
+        outcome: "undetermined" as const,
+        reason:
+          refs.size === 0
+            ? "Condition references no resolvable step output — left undetermined."
+            : "Condition references at least one step with no run history — outcome cannot be resolved from real data.",
+      };
+    }
+    const state = mocked.stepData.get(b.stepId);
+    const outcome: "taken" | "skipped" = state?.skipped ? "skipped" : "taken";
+    return {
+      ...b,
+      outcome,
+      reason: `Resolved from history-backed upstream output(s): ${[...refs].join(", ")}.`,
+    };
+  });
+
+  const notes: string[] = [
+    `Mocked fidelity: downstream templates and conditions were resolved by driving the chained runner with ${mocked.sampleRuns} prior run(s) of history. No step executed for real (stubbed deps, no persistence).`,
+    "Steps without run history were fed synthesized placeholders; their downstream effects are approximate.",
+    "Approval projection shows the tier that WOULD apply if recipe steps were gated — they are NOT gated on the execution path today (gatedOnRecipeSteps=false).",
+    "Cost remains a static estimate at this phase; USD is not projected (P3).",
+  ];
+  if (base.summary.unresolvedSteps > 0) {
+    notes.push(
+      `${base.summary.unresolvedSteps} step(s) reference tools unknown to the registry — their side effects could not be classified.`,
+    );
+  }
+
+  return {
+    ...base,
+    schemaVersion: SIMULATION_SCHEMA_VERSION,
+    fidelity: "mocked",
+    sampleRuns: mocked.sampleRuns,
+    steps,
+    branches,
     notes,
   };
 }

--- a/src/recipes/simulation/simulateMockedRun.ts
+++ b/src/recipes/simulation/simulateMockedRun.ts
@@ -1,0 +1,106 @@
+/**
+ * What-If Preview (P2) — trace-seeded mocked sandbox.
+ *
+ * Drives the EXISTING chained runner with a history-backed `mockedOutputs`
+ * map + fully-stubbed `ExecutionDeps`, so downstream templates and `when:`
+ * branches resolve realistically — while executing NOTHING for real.
+ *
+ * ★ ZERO real I/O + ZERO persistence is the non-negotiable safety invariant ★
+ *   - `STUB_DEPS.executeTool` / `executeAgent` return synthesized placeholders
+ *     and never touch a real tool / connector / LLM / fs.
+ *   - `loadNestedRecipe` returns null (no nested-recipe execution).
+ *   - NO `runLog`, NO `runLogDir`, NO `activityLog` are passed to
+ *     `runChainedRecipe`, so nothing is persisted.
+ *   - `dryRun:false` (we WANT template/condition resolution), with
+ *     `mockedOutputs` covering history-backed steps; any uncovered step falls
+ *     through to the STUB deps — still no real execution.
+ *
+ * Fail-soft: any error is caught and we return what we have; this never throws
+ * out to the caller (the static report is always the safe fallback upstream).
+ */
+
+import type { RecipeRunLog } from "../../runLog.js";
+import type { ChainedRecipe, ExecutionDeps } from "../chainedRunner.js";
+import { runChainedRecipe } from "../chainedRunner.js";
+import { synthesizeMockedOutputs } from "./synthesizeMockedOutputs.js";
+
+/**
+ * Stub execution deps. Returns deterministic synthesized placeholders and
+ * performs no real I/O. Exported so tests can spy on the same shape; callers
+ * normally pass the default created in `simulateMockedRun`.
+ */
+export function createStubDeps(): ExecutionDeps {
+  return {
+    executeTool: async (tool: string) => `[simulated:${tool}]`,
+    executeAgent: async (_prompt: string) => ({
+      text: "[simulated:agent]",
+    }),
+    loadNestedRecipe: async () => null,
+  };
+}
+
+export interface MockedStepState {
+  ran: boolean;
+  skipped: boolean;
+  mockedFrom: "history" | "synthesized";
+}
+
+export interface MockedRunResult {
+  /** Per-step id → ran/skipped + whether its value came from history. */
+  stepData: Map<string, MockedStepState>;
+  /** Step ids that got a real historical value. */
+  historyStepIds: Set<string>;
+  /** Number of prior runs sampled. */
+  sampleRuns: number;
+}
+
+/**
+ * Run the mocked sandbox for `recipe`, seeded from `runLog` history.
+ */
+export async function simulateMockedRun(
+  recipe: ChainedRecipe,
+  runLog: RecipeRunLog,
+  opts: { maxRuns?: number } = {},
+  /**
+   * Test seam — override the stub deps to spy that uncovered steps hit the
+   * stub (and never real execution). Defaults to `createStubDeps()`.
+   */
+  deps: ExecutionDeps = createStubDeps(),
+): Promise<MockedRunResult> {
+  const { outputs, historyStepIds, sampleRuns } = synthesizeMockedOutputs(
+    recipe.name,
+    runLog,
+    opts,
+  );
+
+  const stepData = new Map<string, MockedStepState>();
+
+  try {
+    const result = await runChainedRecipe(
+      recipe,
+      {
+        env: { ...process.env } as Record<string, string | undefined>,
+        maxConcurrency: Math.max(1, recipe.maxConcurrency ?? 4),
+        maxDepth: recipe.maxDepth ?? 3,
+        dryRun: false,
+        mockedOutputs: outputs,
+        // NO runLog / runLogDir / activityLog — nothing is persisted.
+      },
+      deps,
+    );
+
+    for (const [id, stepResult] of result.stepResults) {
+      const skipped = stepResult.skipped === true;
+      stepData.set(id, {
+        ran: !skipped,
+        skipped,
+        mockedFrom: historyStepIds.has(id) ? "history" : "synthesized",
+      });
+    }
+  } catch {
+    // Fail-soft: return whatever we have (possibly empty stepData). The
+    // caller falls back to the static report shape.
+  }
+
+  return { stepData, historyStepIds, sampleRuns };
+}

--- a/src/recipes/simulation/synthesizeMockedOutputs.ts
+++ b/src/recipes/simulation/synthesizeMockedOutputs.ts
@@ -1,0 +1,68 @@
+/**
+ * What-If Preview (P2) — synthesize a `mockedOutputs` map from run history.
+ *
+ * For a chained recipe with prior runs, walk the most recent N runs (newest
+ * first) and, for each step id, take the MOST RECENT non-truncated,
+ * non-skipped, defined `output`. The result is the `mockedOutputs` map the
+ * mocked sandbox feeds into the chained runner so downstream templates and
+ * `when:` conditions resolve against real historical values.
+ *
+ * Pure except for the single `runLog.query(...)` read. The skip rules mirror
+ * `buildMockedOutputs` (replayRun.ts): skip `status:"skipped"`, skip
+ * `output === undefined`, skip the `{"[truncated]": true}` capture envelope.
+ */
+
+import type { RecipeRunLog } from "../../runLog.js";
+
+const DEFAULT_MAX_RUNS = 20;
+
+/** True when `out` is the VD-2 truncation envelope (`{"[truncated]": true}`). */
+function isTruncated(out: unknown): boolean {
+  return (
+    out !== null &&
+    typeof out === "object" &&
+    (out as Record<string, unknown>)["[truncated]"] === true
+  );
+}
+
+export interface SynthesizedMockedOutputs {
+  /** stepId → most-recent usable historical output. */
+  outputs: Map<string, unknown>;
+  /** Step ids that received a real historical value. */
+  historyStepIds: Set<string>;
+  /** Number of prior runs actually sampled. */
+  sampleRuns: number;
+}
+
+/**
+ * Build a history-backed `mockedOutputs` map for `recipeName`.
+ *
+ * `runLog.query` returns newest-first, so the FIRST usable output we see for a
+ * given step id is the most recent — we never overwrite it with an older run.
+ */
+export function synthesizeMockedOutputs(
+  recipeName: string,
+  runLog: RecipeRunLog,
+  opts: { maxRuns?: number } = {},
+): SynthesizedMockedOutputs {
+  const maxRuns = opts.maxRuns ?? DEFAULT_MAX_RUNS;
+  const runs = runLog.query({ recipe: recipeName, limit: maxRuns });
+
+  const outputs = new Map<string, unknown>();
+  const historyStepIds = new Set<string>();
+
+  // runs are newest-first; first usable value per id wins (most recent).
+  for (const run of runs) {
+    for (const step of run.stepResults ?? []) {
+      if (historyStepIds.has(step.id)) continue;
+      if (step.status === "skipped") continue;
+      const out = step.output;
+      if (out === undefined) continue;
+      if (isTruncated(out)) continue;
+      outputs.set(step.id, out);
+      historyStepIds.add(step.id);
+    }
+  }
+
+  return { outputs, historyStepIds, sampleRuns: runs.length };
+}

--- a/src/recipes/simulation/types.ts
+++ b/src/recipes/simulation/types.ts
@@ -19,8 +19,15 @@
  * Later phases bump `fidelity` ("mocked" | "hybrid") and `schemaVersion`.
  */
 
-/** Stable schema version for consumers; bump on breaking shape changes. */
-export const SIMULATION_SCHEMA_VERSION = 1;
+/**
+ * Stable schema version for consumers; bump on breaking shape changes.
+ *
+ * v2 (P2 mocked sandbox): adds `fidelity:"mocked"`, `SimulationStep.mockedFrom`,
+ * and the `taken`/`skipped` branch outcomes (alongside the existing
+ * `undetermined`). All additions are additive/back-compatible — a static report
+ * is still a valid v2 report.
+ */
+export const SIMULATION_SCHEMA_VERSION = 2;
 
 export type RiskTier = "low" | "medium" | "high";
 
@@ -60,6 +67,14 @@ export interface SimulationStep {
   sideEffect: SideEffectKind;
   isWrite: boolean;
   isConnector: boolean;
+  /**
+   * P2 mocked fidelity only. Present when the report is `fidelity:"mocked"`:
+   * `"history"` → this step's output was taken from a real prior run;
+   * `"synthesized"` → no history existed, so the mocked sandbox fed the step a
+   * synthesized placeholder (still executing nothing for real). Absent at
+   * static fidelity.
+   */
+  mockedFrom?: "history" | "synthesized";
 }
 
 /** Per-step approval projection — "what WOULD gate, if recipe steps were gated". */
@@ -72,12 +87,17 @@ export interface ApprovalProjection {
   reason: string;
 }
 
-/** A conditional branch the engine refuses to resolve statically. */
+/** A conditional branch surfaced by the engine. */
 export interface BranchProjection {
   stepId: string;
   condition: string;
-  /** Always "undetermined" at static fidelity — sentinels would lie. */
-  outcome: "undetermined";
+  /**
+   * At static fidelity always `"undetermined"` — sentinels would lie.
+   * At mocked fidelity (P2): `"taken"` / `"skipped"` when every step id the
+   * `when:` references has a real historical value (so the condition resolves
+   * realistically), else `"undetermined"`.
+   */
+  outcome: "taken" | "skipped" | "undetermined";
   reason: string;
 }
 
@@ -133,8 +153,19 @@ export interface RecipeSimulationReport {
   triggerType: string;
   /** ISO-8601 generation timestamp. */
   generatedAt: string;
-  /** Simulation fidelity. P0 is always "static". */
-  fidelity: "static";
+  /**
+   * Simulation fidelity. `"static"` (P0): pure transform of the dry-run plan,
+   * nothing executed. `"mocked"` (P2): a chained recipe WITH run history driven
+   * through the real chained runner with history-backed `mockedOutputs` +
+   * fully-stubbed deps — still zero real I/O, but downstream templates and
+   * `when:` branches resolve realistically.
+   */
+  fidelity: "static" | "mocked";
+  /**
+   * P2 mocked fidelity only — number of prior runs sampled to synthesize the
+   * mocked outputs. Absent at static fidelity.
+   */
+  sampleRuns?: number;
   /** "chained" recipes have a real DAG; "flat" recipes are a linear list. */
   topology: "chained" | "flat";
   /**


### PR DESCRIPTION
## What

P2 of What-If Preview. For **chained** recipes **with run history**, raises the simulation from `static` → `mocked` fidelity: drives the existing chained runner with a history-backed `mockedOutputs` map so downstream templates and `when:` branches resolve against **real prior outputs** — while executing nothing.

## ★ Safety invariant — zero real I/O, zero persistence

`simulateMockedRun` passes **stub** `ExecutionDeps` (`executeTool`/`executeAgent` return synthesized placeholders; `loadNestedRecipe → null`) and **no** `runLog`/`runLogDir`/`activityLog` to `runChainedRecipe`. Steps without history fall through to the stub — never real execution. Proven by a test that asserts the stub fires for a no-history step and `runs.jsonl` is untouched. Flat recipes are hard-guarded to static (the runner is never driven for them).

## Changes

- **`synthesizeMockedOutputs`** — most-recent non-truncated, non-skipped output per step id across recent runs (reuses `replayRun` skip rules).
- **`simulateMockedRun`** — drives the runner with stub deps; returns per-step `ran`/`skipped` + `mockedFrom: history|synthesized`. Fail-soft.
- **`simulateMockedFromPlan`** — overlays the P0 static report → `fidelity:"mocked"`, per-step `mockedFrom`, and branch `outcome` resolved from the mocked run: `taken`/`skipped` **only** when every step id the `when:` references is history-backed, else `"undetermined"` (fixes the sentinel-truthiness lie that static couldn't).
- **types/schema** — `fidelity: "static"|"mocked"`, `sampleRuns`, `mockedFrom`, branch `outcome` enum; `SIMULATION_SCHEMA_VERSION → 2` (+ `generateSimulationSchema`).
- **routing** (`runRecipeSimulate`) — chained + runLog + history → mocked; flat **always** static; no runLog (CLI) → static; fail-soft to static. `simulateFn` now passes the bridge `recipeRunLog`.
- **CLI** — shows mocked label + sampleRuns + per-branch outcome.

## Out of scope (follow-ups)
Real cost projection (**P3**, next), `costRouterCandidates` rejected paths, `recipe_step_simulated` events, dashboard "mocked" badge.

## Tests
`mockedSandbox.test.ts` (12): no-I/O safety, branch determinable vs undetermined, history-wins, routing (chained→mocked / flat→static), schema v2. **111 pass** (incl. chainedRunner/replayRun/simulate/schema regression); `tsc -p tsconfig.tests.core.json` exit 0; biome clean.

Builds on P0 #916 · P1 #917 · route #918. (Note: #919 dashboard types render the report loosely — a follow-up will teach the panel the `mocked` fidelity + per-branch outcome.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)