### PR TITLE
fix(dashboard): no-store on the What-If Preview fetch

### DIFF
--- a/dashboard/src/lib/simulation.ts
+++ b/dashboard/src/lib/simulation.ts
@@ -117,8 +117,13 @@ export function riskGlyph(tier: RiskTier): string {
 export async function fetchSimulation(
   recipeName: string,
 ): Promise<SimulationReport> {
+  // no-store: the simulation reflects live bridge/recipe state; a cached 404
+  // (e.g. before the bridge had the route) must never stick in the browser.
   const res = await fetch(
-    apiPath(`/api/bridge/recipes/simulate?recipe=${encodeURIComponent(recipeName)}`),
+    apiPath(
+      `/api/bridge/recipes/simulate?recipe=${encodeURIComponent(recipeName)}`,
+    ),
+    { cache: "no-store" },
   );
   const data = (await res.json().catch(() => ({}))) as
     | { report: SimulationReport }


### PR DESCRIPTION
Follow-up to #919 (merged). The What-If Preview reflects **live** bridge/recipe state, so the client fetch must not be cacheable.

Without `cache: "no-store"`, the browser **and the PWA service worker** cached a 404 returned before the bridge had the `/recipes/:name/simulate` route, then kept serving that stale 404 after the bridge was updated — the panel showed "Couldn't simulate: HTTP 404" indefinitely.

**Verified live** on the dashboard: with `no-store`, the panel fetches fresh and renders the populated report (risk badge, per-step actions, side-effect taxonomy, the "NOT gated today" honesty caveat, cost).

One-line change in `fetchSimulation` (`dashboard/src/lib/simulation.ts`). SimulatePanel tests still pass; biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)