### PR TITLE
feat(dashboard): surface mocked fidelity + cost band + per-branch outcomes in What-If Preview

### DIFF
--- a/dashboard/src/app/recipes/[...name]/__tests__/SimulatePanel.test.tsx
+++ b/dashboard/src/app/recipes/[...name]/__tests__/SimulatePanel.test.tsx
@@ -119,8 +119,77 @@ describe("SimulatePanel", () => {
     expect(screen.getByText(/\[connector-write\]/)).toBeTruthy();
     // the honesty caveat — approval projection is NOT a live gate
     expect(screen.getByText(/NOT gated today/)).toBeTruthy();
-    // undetermined branch surfaced
-    expect(screen.getByText(/conditional branch\(es\) undetermined/)).toBeTruthy();
+    // static fidelity badge
+    expect(screen.getByText(/^static$/)).toBeTruthy();
+    // undetermined branch surfaced (per-outcome summary)
+    expect(screen.getByText(/1 undetermined/)).toBeTruthy();
+  });
+
+  it("renders mocked fidelity, history cost band, per-branch outcome and synth steps", async () => {
+    const mocked: SimulationReport = {
+      ...REPORT,
+      fidelity: "mocked",
+      sampleRuns: 7,
+      steps: [
+        { ...REPORT.steps[0]!, mockedFrom: "history" },
+        {
+          id: "notify",
+          type: "tool",
+          tool: "slack.postMessage",
+          namespace: "slack",
+          resolved: true,
+          baseRisk: "medium",
+          effectiveRisk: "medium",
+          sideEffect: "connector-write",
+          isWrite: true,
+          isConnector: true,
+          mockedFrom: "synthesized",
+        },
+      ],
+      cost: {
+        basis: "history",
+        confidence: "high",
+        sampleRuns: 7,
+        agentSteps: 1,
+        estimatedAgentSteps: 1,
+        estPromptTokens: 1200,
+        estInputTokens: 1200,
+        estOutputTokens: 300,
+        usd: 0.0025,
+        minUsd: 0.0018,
+        maxUsd: 0.004,
+        historyAgentSteps: 1,
+        note: "history",
+      },
+      branches: [
+        {
+          stepId: "open_pr",
+          condition: "{{ fetch.count }}",
+          outcome: "taken",
+          reason: "resolved from history",
+        },
+        {
+          stepId: "notify",
+          condition: "{{ x }}",
+          outcome: "skipped",
+          reason: "resolved from history",
+        },
+      ],
+    };
+    mockFetchOnce({ report: mocked });
+    render(<SimulatePanel recipeName="demo" autoRun />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/mocked · 7 runs/)).toBeTruthy();
+    });
+    // history cost band with USD range + confidence
+    expect(screen.getByText(/\$0\.0025/)).toBeTruthy();
+    expect(screen.getByText(/high confidence/)).toBeTruthy();
+    // per-branch outcomes
+    expect(screen.getByText(/1 taken/)).toBeTruthy();
+    expect(screen.getByText(/1 skipped/)).toBeTruthy();
+    // synthesized step flagged
+    expect(screen.getByText(/synth/)).toBeTruthy();
   });
 
   it("auto-runs on mount when autoRun is set", async () => {

--- a/dashboard/src/app/recipes/[...name]/_components/SimulatePanel.tsx
+++ b/dashboard/src/app/recipes/[...name]/_components/SimulatePanel.tsx
@@ -4,8 +4,9 @@
  * What-If Preview panel — the dashboard home for `recipe simulate`. Calls the
  * bridge `GET /recipes/:name/simulate` (via the `/api/bridge/recipes/simulate`
  * proxy) and renders the static counterfactual: projected actions, side-effect
- * taxonomy, blast-radius risk, a tier-only approval projection, a
- * low-confidence cost note, and undetermined branches. Executes nothing.
+ * taxonomy, blast-radius risk, a tier-only approval projection, a cost
+ * projection (history band or heuristic), the simulation fidelity
+ * (static/mocked), and per-branch outcomes. Executes nothing.
  *
  * The bridge owns the simulation (single source of truth); this only renders
  * it — and surfaces the `gatedOnRecipeSteps=false` honesty caveat loudly so the
@@ -14,7 +15,10 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import {
+  branchOutcomeCounts,
   fetchSimulation,
+  fidelityLabel,
+  formatCost,
   riskColor,
   riskGlyph,
   type SimulationReport,
@@ -78,6 +82,19 @@ export function SimulatePanel({
             {report.topology}
           </span>
         )}
+        {report && (
+          <span
+            className="mono muted"
+            style={{ fontSize: "var(--fs-2xs)" }}
+            title={
+              report.fidelity === "mocked"
+                ? "Driven by run history — branches + downstream values resolved against real prior outputs."
+                : "Static projection — no run history used; data-dependent branches are undetermined."
+            }
+          >
+            {fidelityLabel(report)}
+          </span>
+        )}
       </div>
 
       {error && (
@@ -127,6 +144,16 @@ export function SimulatePanel({
                   </span>
                   <span className="mono">{s.id}</span> {s.tool ?? s.type}{" "}
                   <span className="muted">[{s.sideEffect}]</span>
+                  {report.fidelity === "mocked" &&
+                    s.mockedFrom === "synthesized" && (
+                      <span
+                        className="muted"
+                        title="No run history for this step — value was synthesized, not from a real prior run."
+                      >
+                        {" "}
+                        · synth
+                      </span>
+                    )}
                   {s.condition && (
                     <span className="muted"> · when: {s.condition}</span>
                   )}
@@ -161,21 +188,42 @@ export function SimulatePanel({
             )}
           </div>
 
-          {/* Cost */}
+          {/* Cost — history band / heuristic tokens / unavailable note */}
           <div className="muted" style={{ fontSize: "var(--fs-xs)" }}>
-            cost:{" "}
-            {report.cost.basis === "heuristic"
-              ? `~${report.cost.estPromptTokens} input token(s) over ${report.cost.estimatedAgentSteps} agent step(s) (heuristic; USD not projected)`
-              : report.cost.note}
+            <span className="mono" style={{ fontSize: "var(--fs-2xs)" }}>
+              cost:{" "}
+            </span>
+            {formatCost(report.cost)}
           </div>
 
-          {/* Undetermined branches */}
-          {report.branches.length > 0 && (
-            <div style={{ fontSize: "var(--fs-xs)", color: "var(--warn)" }}>
-              {report.branches.length} conditional branch(es) undetermined —
-              resolved only in a later sandbox phase.
-            </div>
-          )}
+          {/* Branches — per-outcome (P2 resolves taken/skipped from history) */}
+          {report.branches.length > 0 &&
+            (() => {
+              const c = branchOutcomeCounts(report.branches);
+              return (
+                <div style={{ fontSize: "var(--fs-xs)" }}>
+                  <span
+                    className="mono muted"
+                    style={{ fontSize: "var(--fs-2xs)" }}
+                  >
+                    branches:{" "}
+                  </span>
+                  {c.taken > 0 && (
+                    <span style={{ color: "var(--ok)" }}>{c.taken} taken</span>
+                  )}
+                  {c.taken > 0 && (c.skipped > 0 || c.undetermined > 0) && " · "}
+                  {c.skipped > 0 && (
+                    <span className="muted">{c.skipped} skipped</span>
+                  )}
+                  {c.skipped > 0 && c.undetermined > 0 && " · "}
+                  {c.undetermined > 0 && (
+                    <span style={{ color: "var(--warn)" }}>
+                      {c.undetermined} undetermined
+                    </span>
+                  )}
+                </div>
+              );
+            })()}
 
           {/* Lint */}
           {(report.lint.errors.length > 0 || report.lint.warnings.length > 0) && (

--- a/dashboard/src/lib/__tests__/simulation.test.ts
+++ b/dashboard/src/lib/__tests__/simulation.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import {
+  branchOutcomeCounts,
+  fidelityLabel,
+  formatCost,
+  type SimulationReport,
+} from "@/lib/simulation";
+
+type Cost = SimulationReport["cost"];
+const cost = (over: Partial<Cost>): Cost => ({
+  basis: "unavailable",
+  agentSteps: 0,
+  estimatedAgentSteps: 0,
+  estPromptTokens: null,
+  usd: null,
+  note: "n/a",
+  ...over,
+});
+
+describe("formatCost", () => {
+  it("history basis with billable USD shows expected + range + confidence", () => {
+    const s = formatCost(
+      cost({
+        basis: "history",
+        confidence: "high",
+        sampleRuns: 7,
+        usd: 0.0025,
+        minUsd: 0.0018,
+        maxUsd: 0.004,
+      }),
+    );
+    expect(s).toContain("$0.0025");
+    expect(s).toContain("$0.0018");
+    expect(s).toContain("high confidence");
+    expect(s).toContain("7 run(s)");
+  });
+
+  it("history basis without billable USD falls back to tokens, never $0", () => {
+    const s = formatCost(
+      cost({
+        basis: "history",
+        confidence: "low",
+        sampleRuns: 3,
+        usd: null,
+        estInputTokens: 900,
+      }),
+    );
+    expect(s).toContain("900 input token(s)");
+    expect(s).toContain("USD not billed");
+    expect(s).not.toContain("$0");
+  });
+
+  it("sub-cent USD renders as <$0.01, not $0.00", () => {
+    const s = formatCost(cost({ basis: "history", usd: 0.004 }));
+    // 0.004 -> toFixed(4) -> $0.0040 (>0, shown precisely)
+    expect(s).toContain("$0.0040");
+    const tiny = formatCost(cost({ basis: "history", usd: 0.000001 }));
+    expect(tiny).toContain("<$0.0001");
+  });
+
+  it("heuristic basis shows token estimate", () => {
+    const s = formatCost(
+      cost({ basis: "heuristic", estPromptTokens: 40, estimatedAgentSteps: 2 }),
+    );
+    expect(s).toContain("40 input token(s)");
+    expect(s).toContain("heuristic");
+  });
+
+  it("unavailable basis returns the bridge note", () => {
+    expect(formatCost(cost({ basis: "unavailable", note: "no agent steps" }))).toBe(
+      "no agent steps",
+    );
+  });
+});
+
+describe("branchOutcomeCounts", () => {
+  it("tallies taken/skipped/undetermined", () => {
+    const c = branchOutcomeCounts([
+      { stepId: "a", condition: "x", outcome: "taken", reason: "" },
+      { stepId: "b", condition: "y", outcome: "skipped", reason: "" },
+      { stepId: "c", condition: "z", outcome: "undetermined", reason: "" },
+      { stepId: "d", condition: "w", outcome: "taken", reason: "" },
+    ]);
+    expect(c).toEqual({ taken: 2, skipped: 1, undetermined: 1 });
+  });
+});
+
+describe("fidelityLabel", () => {
+  const base = { fidelity: "static" } as SimulationReport;
+  it("static", () => {
+    expect(fidelityLabel(base)).toBe("static");
+  });
+  it("mocked with run count (singular/plural)", () => {
+    expect(
+      fidelityLabel({ ...base, fidelity: "mocked", sampleRuns: 1 }),
+    ).toBe("mocked · 1 run");
+    expect(
+      fidelityLabel({ ...base, fidelity: "mocked", sampleRuns: 5 }),
+    ).toBe("mocked · 5 runs");
+  });
+});

--- a/dashboard/src/lib/simulation.ts
+++ b/dashboard/src/lib/simulation.ts
@@ -33,6 +33,8 @@ export interface SimulationStep {
   sideEffect: SideEffectKind;
   isWrite: boolean;
   isConnector: boolean;
+  /** P2 mocked sandbox — whether this step's value came from run history. */
+  mockedFrom?: "history" | "synthesized";
 }
 
 export interface SimulationReport {
@@ -41,7 +43,10 @@ export interface SimulationReport {
   recipe: string;
   triggerType: string;
   generatedAt: string;
-  fidelity: "static";
+  /** "mocked" when driven by run history (P2); "static" otherwise. */
+  fidelity: "static" | "mocked";
+  /** Prior runs sampled for a mocked simulation (P2). */
+  sampleRuns?: number;
   topology: "chained" | "flat";
   gatedOnRecipeSteps: boolean;
   steps: SimulationStep[];
@@ -79,17 +84,30 @@ export interface SimulationReport {
     note: string;
   };
   cost: {
-    basis: "heuristic" | "unavailable";
+    /** "history" = P1 median corpus; "heuristic" = chars/4; "unavailable". */
+    basis: "history" | "heuristic" | "unavailable";
+    /** Loud confidence signal (P3). */
+    confidence?: "high" | "low" | "none";
+    /** Prior runs that contributed a sample (history basis). */
+    sampleRuns?: number;
     agentSteps: number;
     estimatedAgentSteps: number;
     estPromptTokens: number | null;
-    usd: null;
+    estInputTokens?: number | null;
+    estOutputTokens?: number | null;
+    /** Expected USD (median-summed). null when no billable history; never $0. */
+    usd: number | null;
+    /** USD range across history (P3). */
+    minUsd?: number | null;
+    maxUsd?: number | null;
+    /** Agent steps whose projection used real history vs chars/4. */
+    historyAgentSteps?: number;
     note: string;
   };
   branches: Array<{
     stepId: string;
     condition: string;
-    outcome: "undetermined";
+    outcome: "taken" | "skipped" | "undetermined";
     reason: string;
   }>;
   lint: { errors: string[]; warnings: string[] };
@@ -108,6 +126,58 @@ export function riskColor(tier: RiskTier): string {
 /** Per-step effective-risk glyph used in the actions list. */
 export function riskGlyph(tier: RiskTier): string {
   return tier === "high" ? "●" : tier === "medium" ? "◐" : "○";
+}
+
+/** Short human label for the simulation fidelity (P2). */
+export function fidelityLabel(report: SimulationReport): string {
+  if (report.fidelity === "mocked") {
+    const n = report.sampleRuns ?? 0;
+    return `mocked · ${n} run${n === 1 ? "" : "s"}`;
+  }
+  return "static";
+}
+
+/** Format a USD amount with adaptive precision; never shows a bare "$0.00". */
+function formatUsd(n: number): string {
+  if (n <= 0) return "$0.00";
+  const s = n < 1 ? n.toFixed(4) : n.toFixed(2);
+  // A positive value that still rounds to zero (e.g. 1e-6) — don't lie with $0.
+  return Number.parseFloat(s) === 0 ? "<$0.0001" : `$${s}`;
+}
+
+/**
+ * Human cost string honoring the P3 contract: a history projection shows an
+ * expected USD (+ range + confidence), heuristic shows tokens, unavailable
+ * shows the bridge note. USD is NEVER a "$0" placeholder.
+ */
+export function formatCost(cost: SimulationReport["cost"]): string {
+  if (cost.basis === "history") {
+    const conf = cost.confidence ? ` · ${cost.confidence} confidence` : "";
+    const runs = cost.sampleRuns ? ` · ${cost.sampleRuns} run(s)` : "";
+    if (typeof cost.usd === "number") {
+      const range =
+        typeof cost.minUsd === "number" && typeof cost.maxUsd === "number"
+          ? ` (${formatUsd(cost.minUsd)}–${formatUsd(cost.maxUsd)})`
+          : "";
+      return `~${formatUsd(cost.usd)}${range}${conf}${runs}`;
+    }
+    // History tokens but no billable USD (subscription/subprocess driver).
+    const tok = cost.estInputTokens ?? cost.estPromptTokens;
+    return `~${tok ?? "?"} input token(s)${conf}${runs} · USD not billed (subscription driver)`;
+  }
+  if (cost.basis === "heuristic") {
+    return `~${cost.estPromptTokens} input token(s) over ${cost.estimatedAgentSteps} agent step(s) (heuristic; USD not projected)`;
+  }
+  return cost.note;
+}
+
+/** Tally branch outcomes (P2) for a compact summary line. */
+export function branchOutcomeCounts(
+  branches: SimulationReport["branches"],
+): { taken: number; skipped: number; undetermined: number } {
+  const out = { taken: 0, skipped: 0, undetermined: 0 };
+  for (const b of branches) out[b.outcome] += 1;
+  return out;
 }
 
 /**


### PR DESCRIPTION
## What

The bridge has emitted richer What-If Preview output since **P2 (#920)** and **P3 (#921)**, but the dashboard `SimulatePanel` still rendered the P0 static shape — so a recipe with run history showed generic "undetermined" branches and no cost. This teaches the panel the schema-v2 report.

## Changes
- **Type sync** (`lib/simulation.ts`): `fidelity: "static"|"mocked"`, `sampleRuns`, per-step `mockedFrom`, branch `outcome: "taken"|"skipped"|"undetermined"`, and the full P3 cost shape (`basis: history|heuristic|unavailable`, `confidence`, `usd`, `minUsd`/`maxUsd`, `estInputTokens`/`estOutputTokens`, `sampleRuns`, `historyAgentSteps`).
- **`SimulatePanel`**:
  - **Fidelity badge** — `mocked · N runs` / `static` (with explanatory tooltip).
  - **Cost line** via `formatCost` — history → `~$expected ($min–$max) · confidence · runs`; heuristic → tokens; unavailable → bridge note. **Never a `$0` placeholder** (sub-cent → `<$0.0001`).
  - **Per-branch outcome** summary — `N taken · N skipped · N undetermined` (color-coded) replacing the flat undetermined count; the taken/skipped come from P2's history-driven resolution.
  - **`synth`** marker on mocked steps that had no run history (value synthesized).
- New pure helpers `formatCost` / `branchOutcomeCounts` / `fidelityLabel`.

## Honesty preserved
The `gatedOnRecipeSteps=false` caveat still renders loudly; cost confidence is shown explicitly; synthesized steps are flagged so a mocked run is never mistaken for a real one.

## Tests
- `SimulatePanel.test.tsx`: mocked-fidelity + history-cost render (badge, `$` band, confidence, taken/skipped, synth) + updated static assertions.
- `lib/__tests__/simulation.test.ts`: `formatCost` variants (history USD/range/confidence, subscription fallback, sub-cent never-`$0`, heuristic, unavailable), `branchOutcomeCounts`, `fidelityLabel`.
- **12 pass** · dashboard `tsc` exit 0 · `next lint` clean (only pre-existing warnings).

Completes the UI surfacing for P2/P3. Verified the live render earlier (mocked report populates with the new sections).

🤖 Generated with [Claude Code](https://claude.com/claude-code)