### PR TITLE
test(shim): fix leaked-mock-server EADDRINUSE flake (shim-reconnect + shim-backoff)

### DIFF
--- a/src/__tests__/shim-backoff.test.ts
+++ b/src/__tests__/shim-backoff.test.ts
@@ -56,6 +56,12 @@ async function waitFor(
   return false;
 }
 
+// Track every server so afterEach guarantees cleanup even when a test throws
+// before its manual closeServer() — a leaked listener (plus a freePort TOCTOU
+// re-bind) is the EADDRINUSE-uncaught-exception flake class (see PR #924 /
+// shim-reconnect.test.ts).
+const activeServers = new Set<http.Server | WebSocketServer>();
+
 /** Find a free TCP port. */
 async function freePort(): Promise<number> {
   return new Promise((resolve, reject) => {
@@ -76,6 +82,10 @@ async function freePort(): Promise<number> {
 function startRejectServer(statusCode: number): Promise<http.Server> {
   return new Promise((resolve) => {
     const srv = http.createServer();
+    activeServers.add(srv);
+    srv.on("error", (err) => {
+      console.error(`[reject-server] server error: ${(err as Error).message}`);
+    });
     srv.on("upgrade", (_req, socket) => {
       socket.write(
         `HTTP/1.1 ${statusCode} ${statusCode === 429 ? "Too Many Requests" : "Unauthorized"}\r\n\r\n`,
@@ -88,6 +98,14 @@ function startRejectServer(statusCode: number): Promise<http.Server> {
 
 function startMockBridge(port: number, token: string): WebSocketServer {
   const wss = new WebSocketServer({ port, host: "127.0.0.1" });
+  activeServers.add(wss);
+  // A bind error (e.g. EADDRINUSE from a freePort TOCTOU re-bind on a retry)
+  // must never escape as an uncaught exception that fails the whole run.
+  wss.on("error", (err) => {
+    console.error(
+      `[mock-bridge:${port}] server error: ${(err as Error).message}`,
+    );
+  });
   wss.on("connection", (ws, req) => {
     const auth = req.headers["x-claude-code-ide-authorization"];
     if (auth !== token) ws.close(4001, "Unauthorized");
@@ -96,11 +114,15 @@ function startMockBridge(port: number, token: string): WebSocketServer {
 }
 
 async function closeServer(srv: http.Server | WebSocketServer): Promise<void> {
-  await new Promise<void>((resolve, reject) => {
-    srv.close((err) => (err ? reject(err) : resolve()));
-    if ("clients" in srv) {
-      for (const client of srv.clients) client.terminate();
-    }
+  // Idempotent: safe for both the per-test manual close and the afterEach net.
+  // Close errors are ignored — this is teardown.
+  if (!activeServers.has(srv)) return;
+  activeServers.delete(srv);
+  if ("clients" in srv) {
+    for (const client of srv.clients) client.terminate();
+  }
+  await new Promise<void>((resolve) => {
+    srv.close(() => resolve());
   });
 }
 
@@ -117,6 +139,10 @@ beforeEach(() => {
 afterEach(async () => {
   shimProcess?.kill();
   shimProcess = null;
+  // Authoritative cleanup: close any server a test left open (e.g. one whose
+  // body threw before its manual closeServer) so a CI retry never inherits a
+  // bound port.
+  await Promise.all([...activeServers].map((srv) => closeServer(srv)));
   await new Promise((r) => setTimeout(r, 150));
   fs.rmSync(tmpDir, { recursive: true, force: true });
 });

--- a/src/__tests__/shim-reconnect.test.ts
+++ b/src/__tests__/shim-reconnect.test.ts
@@ -49,8 +49,23 @@ function writelockOrchestrator(lockDir: string, port: number, token: string) {
   return writelock(lockDir, port, token, true, true);
 }
 
+// Track every mock bridge so afterEach can guarantee cleanup even when a test
+// throws before reaching its manual closeServer() — otherwise the leaked
+// listener keeps the fixed port bound and CI's `retry` re-run of the same test
+// hits EADDRINUSE, which (as an unhandled server 'error') would kill the run.
+const activeServers = new Set<WebSocketServer>();
+
 function startMockBridge(port: number, token: string): WebSocketServer {
   const wss = new WebSocketServer({ port, host: "127.0.0.1" });
+  activeServers.add(wss);
+  // A bind error (e.g. EADDRINUSE from a not-yet-released port on a retry) must
+  // never escape as an uncaught exception that fails the entire run — surface
+  // it via the next assertion/timeout instead of crashing the worker.
+  wss.on("error", (err) => {
+    console.error(
+      `[mock-bridge:${port}] server error: ${(err as Error).message}`,
+    );
+  });
   wss.on("connection", (ws, req) => {
     const auth = req.headers["x-claude-code-ide-authorization"];
     if (auth !== token) {
@@ -74,9 +89,14 @@ async function waitFor(
 }
 
 async function closeServer(wss: WebSocketServer): Promise<void> {
-  await new Promise<void>((resolve, reject) => {
-    wss.close((err) => (err ? reject(err) : resolve()));
-    for (const client of wss.clients) client.terminate();
+  // Idempotent: safe to call from both the per-test manual close and the
+  // afterEach safety net. Close errors (e.g. "not running") are ignored — this
+  // is teardown, and a half-open server must never fail a test.
+  if (!activeServers.has(wss)) return;
+  activeServers.delete(wss);
+  for (const client of wss.clients) client.terminate();
+  await new Promise<void>((resolve) => {
+    wss.close(() => resolve());
   });
 }
 
@@ -91,6 +111,10 @@ beforeEach(() => {
 afterEach(async () => {
   shimProcess?.kill();
   shimProcess = null;
+  // Authoritative cleanup: close any mock bridge a test left open (e.g. one
+  // whose body threw before its manual closeServer). Without this, the leaked
+  // fixed-port listener makes a CI retry of the same test crash on EADDRINUSE.
+  await Promise.all([...activeServers].map((wss) => closeServer(wss)));
   await new Promise((r) => setTimeout(r, 100));
   fs.rmSync(tmpDir, { recursive: true, force: true });
 });


### PR DESCRIPTION
## The flake

Intermittent **Windows CI** failures: the **`Coverage`** step exits 1 while **all 516 test files pass**. The real failure is vitest's post-run **Unhandled Errors** — `Uncaught Exception: listen EADDRINUSE 127.0.0.1:19810` from `src/__tests__/shim-reconnect.test.ts`. Not a timeout (failed at 267s vs the 8-min limit), not a coverage-threshold miss, not an assertion failure.

## Root cause (two compounding bugs)

1. **Leaked listeners.** Mock bridges are bound (fixed ports in shim-reconnect; freePort-derived in shim-backoff) and closed only at the **end of each `it` body**; `afterEach` cleaned the shim subprocess + tmpdir but **never the servers**. A timing-sensitive assertion **flaked under the slower coverage run** → the test threw before its `closeServer()` → the listener leaked.
2. **Retry → collision → uncaught.** CI runs with **`retry: 2`**. The retry re-ran the test → re-bind hit **EADDRINUSE**, and with **no `'error'` handler** on the server it became an **uncaught exception** that fails the whole run instead of a normal retryable failure.

Intermittent + Windows/coverage-prone (slower → first attempt more likely to flake) + surfaces as EADDRINUSE-on-retry.

## Sweep

Swept all server-binding tests. **Only two** match the leaked-server pattern (both fixed here):
- `shim-reconnect.test.ts` — **fixed ports** 19800–19816 (the one that actually went red).
- `shim-backoff.test.ts` — `freePort()`-derived port (partially shielded — a retry picks a new port — but a freePort TOCTOU re-bind would still be an uncaught EADDRINUSE, and thrown tests still leak servers).

All other server tests already use **ephemeral `port: 0` / `listen(0, …)`** and have `afterEach`/`afterAll` cleanup, so they can't collide. No other changes needed.

## Fix (test-only — no production code)

Both files: track every server in `activeServers`; **`afterEach` closes them all** (authoritative cleanup survives a thrown body, so a retry never inherits a bound port); add `'error'` handlers (HTTP + WS) so a bind error can't escape as an uncaught exception; make `closeServer` idempotent.

## Verification
`shim-reconnect` 8/8, `shim-backoff` 6/6 · `tsc -p tsconfig.tests.core.json` exit 0 · biome clean. (The race only reproduces under CI retry + slow coverage timing, so verified structurally + clean local runs; this PR's Windows coverage job exercises the path.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)