### PR TITLE
fix(audit): MEDIUM #7/#8/#16/#17 — Retry-After, pagination, depth-map, https-name injection

### DIFF
--- a/src/__tests__/recipeRoutes-https-install-name.test.ts
+++ b/src/__tests__/recipeRoutes-https-install-name.test.ts
@@ -1,0 +1,209 @@
+/**
+ * /recipes/install — https:// source recipe-name validation.
+ *
+ * When a recipe is installed via an https:// source URL, the recipe name is
+ * derived from the last path segment. Before the audit fix (2026-06-03
+ * MEDIUM #17), no validation was applied to that derived name: a URL like
+ * `https://host/recipes/bad%20name.yaml` would extract `bad%20name` and
+ * write it into the recipes directory without any sanitisation, opening a
+ * path-injection / path-traversal vector.
+ *
+ * Fix: validate the extracted name against the same SEGMENT_RE used for
+ * github: sources and reject with 400 `invalid_recipe_name` before the fetch
+ * step is reached.
+ *
+ * Tests stub `globalThis.fetch` and spy on `dns.lookup` to prevent real
+ * network I/O. Pattern mirrors `recipeRoutes-bundle-install.test.ts`.
+ */
+
+import dns from "node:dns/promises";
+import http from "node:http";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import { Logger } from "../logger.js";
+import { Server } from "../server.js";
+
+const logger = new Logger(false);
+const TOKEN = "test-https-install-name-token-0000000000";
+
+let server: Server | null = null;
+let port = 0;
+const originalFetch = globalThis.fetch;
+
+function makeRequest(
+  options: http.RequestOptions,
+  body = "",
+): Promise<{ status: number; body: string }> {
+  return new Promise((resolve, reject) => {
+    let resolved = false;
+    const finish = (status: number, data: string) => {
+      if (resolved) return;
+      resolved = true;
+      resolve({ status, body: data });
+    };
+    const req = http.request(
+      { hostname: "127.0.0.1", port, ...options },
+      (res) => {
+        let data = "";
+        res.on("data", (chunk: Buffer) => (data += chunk));
+        res.on("end", () => finish(res.statusCode ?? 0, data));
+        res.on("error", () => finish(res.statusCode ?? 0, data));
+        res.on("close", () => finish(res.statusCode ?? 0, data));
+      },
+    );
+    req.on("error", (err) => {
+      if (resolved) return;
+      reject(err);
+    });
+    if (body) req.write(body);
+    req.end();
+  });
+}
+
+beforeAll(() => {
+  delete process.env.CLAUDE_IDE_BRIDGE_INSTALL_ALLOWED_HOSTS;
+});
+
+beforeEach(async () => {
+  server = new Server(TOKEN, logger);
+  port = await server.findAndListen(null);
+});
+
+afterEach(async () => {
+  await server?.close();
+  server = null;
+  port = 0;
+  globalThis.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+afterAll(() => {
+  globalThis.fetch = originalFetch;
+});
+
+const installOptions = {
+  method: "POST" as const,
+  path: "/recipes/install",
+  headers: {
+    "Content-Type": "application/json",
+    Authorization: `Bearer ${TOKEN}`,
+  },
+};
+
+describe("Server /recipes/install — https:// recipe name validation (audit 2026-06-03 MEDIUM #17)", () => {
+  it("400 when https:// URL last segment contains URL-encoded chars (e.g. %20)", async () => {
+    // Mock DNS to return a public IP so the SSRF guard passes without
+    // real network I/O.
+    vi.spyOn(dns, "lookup").mockResolvedValue({
+      address: "185.199.108.133",
+      family: 4,
+    } as Awaited<ReturnType<typeof dns.lookup>>);
+
+    // If the fix is not in place, the code reaches the fetch step.
+    // Mock fetch to throw so we can distinguish the two code paths:
+    //   without fix → 502 fetch_network_error (reached fetch)
+    //   with fix    → 400 invalid_recipe_name (rejected before fetch)
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValue(new Error("should not reach fetch"));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const payload = JSON.stringify({
+      source:
+        "https://raw.githubusercontent.com/user/repo/main/bad%20recipe.yaml",
+    });
+    const { status, body } = await makeRequest(
+      {
+        ...installOptions,
+        headers: {
+          ...installOptions.headers,
+          "Content-Length": String(Buffer.byteLength(payload)),
+        },
+      },
+      payload,
+    );
+
+    expect(status).toBe(400);
+    const json = JSON.parse(body);
+    expect(json.ok).toBe(false);
+    expect(json.code).toBe("invalid_recipe_name");
+    // Fetch must NOT be called — the validation rejects before the fetch
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("400 when https:// URL last segment contains path traversal (..)", async () => {
+    vi.spyOn(dns, "lookup").mockResolvedValue({
+      address: "185.199.108.133",
+      family: 4,
+    } as Awaited<ReturnType<typeof dns.lookup>>);
+
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValue(new Error("should not reach fetch"));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const payload = JSON.stringify({
+      source: "https://raw.githubusercontent.com/user/repo/main/..evil.yaml",
+    });
+    const { status, body } = await makeRequest(
+      {
+        ...installOptions,
+        headers: {
+          ...installOptions.headers,
+          "Content-Length": String(Buffer.byteLength(payload)),
+        },
+      },
+      payload,
+    );
+
+    expect(status).toBe(400);
+    const json = JSON.parse(body);
+    expect(json.ok).toBe(false);
+    expect(json.code).toBe("invalid_recipe_name");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("proceeds past name check when https:// URL has a valid recipe name", async () => {
+    vi.spyOn(dns, "lookup").mockResolvedValue({
+      address: "185.199.108.133",
+      family: 4,
+    } as Awaited<ReturnType<typeof dns.lookup>>);
+
+    // Valid name: lowercase kebab-case. Fetch returns 404 so we don't
+    // need a full YAML — the important thing is the route got past the
+    // name validation (status ≠ 400 invalid_recipe_name).
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response("Not Found", { status: 404 }));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const payload = JSON.stringify({
+      source:
+        "https://raw.githubusercontent.com/user/repo/main/my-valid-recipe.yaml",
+    });
+    const { status, body } = await makeRequest(
+      {
+        ...installOptions,
+        headers: {
+          ...installOptions.headers,
+          "Content-Length": String(Buffer.byteLength(payload)),
+        },
+      },
+      payload,
+    );
+
+    // Must NOT be 400 invalid_recipe_name — some other status is fine
+    // (likely 404 from the mocked upstream).
+    expect(status).not.toBe(400);
+    const json = JSON.parse(body);
+    expect(json.code).not.toBe("invalid_recipe_name");
+  });
+});

--- a/src/connectors/__tests__/notion.test.ts
+++ b/src/connectors/__tests__/notion.test.ts
@@ -287,3 +287,67 @@ describe("clearTokens deletes secure storage", () => {
     expect(deleteSecretJsonSync).toHaveBeenCalledWith("notion");
   });
 });
+
+// ── NotionConnector.normalizeError — 429 Retry-After (audit 2026-06-03 MEDIUM #7) ──
+
+describe("NotionConnector.normalizeError — 429 Retry-After (audit 2026-06-03 MEDIUM #7)", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    delete process.env.NOTION_TOKEN;
+  });
+
+  it("includes retryAfterSec when 429 Response has Retry-After header", async () => {
+    vi.resetModules();
+    const { NotionConnector } = await import("../notion.js");
+    const connector = new NotionConnector();
+    const response = new Response("Rate limited", {
+      status: 429,
+      headers: { "Retry-After": "60" },
+    });
+    const err = connector.normalizeError(response);
+    expect(err.code).toBe("rate_limited");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((err as any).retryAfterSec).toBe(60);
+  });
+
+  it("omits retryAfterSec when 429 Response has no Retry-After header", async () => {
+    vi.resetModules();
+    const { NotionConnector } = await import("../notion.js");
+    const connector = new NotionConnector();
+    const response = new Response("Rate limited", { status: 429 });
+    const err = connector.normalizeError(response);
+    expect(err.code).toBe("rate_limited");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((err as any).retryAfterSec).toBeUndefined();
+  });
+
+  it("healthCheck returns rate_limited (not provider_error) when fetch returns 429", async () => {
+    vi.useFakeTimers();
+    process.env.NOTION_TOKEN = "secret_med7_notion";
+    vi.resetModules();
+    const { NotionConnector } = await import("../notion.js");
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response("Rate limited", {
+          status: 429,
+          headers: { "Retry-After": "60" },
+        }),
+      ),
+    );
+
+    const connector = new NotionConnector();
+    const promise = connector.healthCheck();
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result.ok).toBe(false);
+    expect(result.error?.code).toBe("rate_limited");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((result.error as any)?.retryAfterSec).toBe(60);
+
+    vi.useRealTimers();
+  });
+});

--- a/src/connectors/__tests__/slack.test.ts
+++ b/src/connectors/__tests__/slack.test.ts
@@ -229,3 +229,88 @@ describe("slack OAuth callback - postMessage targetOrigin (audit 2026-06-03 MEDI
     expect(result.body).toContain("window.location.origin");
   });
 });
+
+describe("slack listChannels — cursor pagination (audit 2026-06-03 MEDIUM #8)", () => {
+  // Slack's conversations.list API is paginated: when there are more
+  // channels than `limit`, the response includes a non-empty
+  // `response_metadata.next_cursor`. The old implementation made a single
+  // request and stopped, silently dropping all channels past the first page.
+  //
+  // Fix: follow `next_cursor` in a loop until it is empty.
+
+  const tmpDir = join(os.tmpdir(), `patchwork-slack-pagination-${Date.now()}`);
+  const homeDir = join(tmpDir, "home");
+  const patchworkHome = join(homeDir, ".patchwork");
+  const tokensDir = join(patchworkHome, "tokens");
+
+  beforeEach(() => {
+    process.env.HOME = homeDir;
+    process.env.PATCHWORK_HOME = patchworkHome;
+    process.env.PATCHWORK_TOKEN_STORAGE_BACKEND = "file";
+    mkdirSync(tokensDir, { recursive: true });
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    delete process.env.HOME;
+    delete process.env.PATCHWORK_HOME;
+    delete process.env.PATCHWORK_TOKEN_STORAGE_BACKEND;
+    if (existsSync(tmpDir)) rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("follows next_cursor and returns channels from all pages", async () => {
+    const { storeSecretJsonSync } = await import("../tokenStorage.js");
+    storeSecretJsonSync("slack", {
+      access_token: "xoxb-paginate-test",
+      bot_user_id: "U0",
+      team_id: "T0",
+      team_name: "Paginate",
+      connected_at: new Date().toISOString(),
+    });
+
+    // First page: 1 channel + non-empty cursor.
+    // Second page: 1 more channel + empty cursor (last page).
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            ok: true,
+            channels: [
+              { id: "C1", name: "general", is_member: true, is_private: false },
+            ],
+            response_metadata: { next_cursor: "cursor-page2" },
+          }),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            ok: true,
+            channels: [
+              { id: "C2", name: "random", is_member: false, is_private: false },
+            ],
+            response_metadata: { next_cursor: "" },
+          }),
+          { status: 200 },
+        ),
+      );
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    vi.resetModules();
+    const { listChannels } = await import("../slack.js");
+    const channels = await listChannels(100);
+
+    // Without the fix: only the first page is fetched → 1 channel.
+    // With the fix: both pages are fetched → 2 channels.
+    expect(channels).toHaveLength(2);
+    expect(channels[0].id).toBe("C1");
+    expect(channels[1].id).toBe("C2");
+
+    // Second fetch must have included the cursor from the first response.
+    const secondCallUrl = fetchMock.mock.calls[1]?.[0] as string;
+    expect(secondCallUrl).toContain("cursor=cursor-page2");
+  });
+});

--- a/src/connectors/__tests__/slack.test.ts
+++ b/src/connectors/__tests__/slack.test.ts
@@ -306,8 +306,8 @@ describe("slack listChannels — cursor pagination (audit 2026-06-03 MEDIUM #8)"
     // Without the fix: only the first page is fetched → 1 channel.
     // With the fix: both pages are fetched → 2 channels.
     expect(channels).toHaveLength(2);
-    expect(channels[0].id).toBe("C1");
-    expect(channels[1].id).toBe("C2");
+    expect(channels[0]!.id).toBe("C1");
+    expect(channels[1]!.id).toBe("C2");
 
     // Second fetch must have included the cursor from the first response.
     const secondCallUrl = fetchMock.mock.calls[1]?.[0] as string;

--- a/src/connectors/__tests__/stripe.test.ts
+++ b/src/connectors/__tests__/stripe.test.ts
@@ -203,3 +203,67 @@ describe("handleStripeDisconnect", () => {
     expect(JSON.parse(result.body).ok).toBe(true);
   });
 });
+
+// ── StripeConnector.normalizeError — 429 Retry-After (audit 2026-06-03 MEDIUM #7) ──
+
+describe("StripeConnector.normalizeError — 429 Retry-After (audit 2026-06-03 MEDIUM #7)", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    delete process.env.STRIPE_SECRET_KEY;
+  });
+
+  it("includes retryAfterSec when 429 Response has Retry-After header", async () => {
+    vi.resetModules();
+    const { StripeConnector } = await import("../stripe.js");
+    const connector = new StripeConnector();
+    const response = new Response("Rate limited", {
+      status: 429,
+      headers: { "Retry-After": "30" },
+    });
+    const err = connector.normalizeError(response);
+    expect(err.code).toBe("rate_limited");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((err as any).retryAfterSec).toBe(30);
+  });
+
+  it("omits retryAfterSec when 429 Response has no Retry-After header", async () => {
+    vi.resetModules();
+    const { StripeConnector } = await import("../stripe.js");
+    const connector = new StripeConnector();
+    const response = new Response("Rate limited", { status: 429 });
+    const err = connector.normalizeError(response);
+    expect(err.code).toBe("rate_limited");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((err as any).retryAfterSec).toBeUndefined();
+  });
+
+  it("healthCheck returns rate_limited (not provider_error) when fetch returns 429", async () => {
+    vi.useFakeTimers();
+    process.env.STRIPE_SECRET_KEY = "sk_test_med7_stripe";
+    vi.resetModules();
+    const { StripeConnector } = await import("../stripe.js");
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response("Rate limited", {
+          status: 429,
+          headers: { "Retry-After": "30" },
+        }),
+      ),
+    );
+
+    const connector = new StripeConnector();
+    const promise = connector.healthCheck();
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result.ok).toBe(false);
+    expect(result.error?.code).toBe("rate_limited");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((result.error as any)?.retryAfterSec).toBe(30);
+
+    vi.useRealTimers();
+  });
+});

--- a/src/connectors/baseConnector.ts
+++ b/src/connectors/baseConnector.ts
@@ -40,6 +40,7 @@ export interface ConnectorError {
   providerDetail?: unknown;
   retryable: boolean;
   suggestedAction?: string;
+  retryAfterSec?: number;
 }
 
 export interface RateLimitState {

--- a/src/connectors/notion.ts
+++ b/src/connectors/notion.ts
@@ -183,7 +183,7 @@ export class NotionConnector extends BaseConnector {
         const res = await fetch(`${NOTION_API}/users/me`, {
           headers: this.buildHeaders(token),
         });
-        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        if (!res.ok) throw res;
         return res.json() as Promise<NotionUser>;
       });
       if ("error" in result) return { ok: false, error: result.error };
@@ -219,13 +219,22 @@ export class NotionConnector extends BaseConnector {
           message: "Notion page or database not found",
           retryable: false,
         };
-      if (status === 429)
+      if (status === 429) {
+        // Audit 2026-06-03 MEDIUM #7: read Retry-After hint when present.
+        const retryAfter =
+          error instanceof Response ? error.headers.get("Retry-After") : null;
+        const retryAfterSec =
+          retryAfter !== null ? Number.parseInt(retryAfter, 10) : undefined;
         return {
           code: "rate_limited",
           message: "Notion API rate limit exceeded",
           retryable: true,
           suggestedAction: "Wait and retry",
+          ...(retryAfterSec !== undefined && !Number.isNaN(retryAfterSec)
+            ? { retryAfterSec }
+            : {}),
         };
+      }
       return {
         code: "provider_error",
         message: `Notion API error: HTTP ${status}`,

--- a/src/connectors/slack.ts
+++ b/src/connectors/slack.ts
@@ -301,24 +301,49 @@ export async function listChannels(
     throw new Error(
       "Slack not connected. GET /connections/slack/authorize first.",
     );
-  const res = await slackGet(
-    "conversations.list",
-    {
+  // Audit 2026-06-03 MEDIUM #8: the previous implementation made a single
+  // request and stopped, silently dropping all channels past the first page.
+  // Slack's conversations.list API paginates via response_metadata.next_cursor.
+  const pageSize = Math.min(limit, 200);
+  const channels: SlackChannel[] = [];
+  let cursor = "";
+
+  while (channels.length < limit) {
+    const params: Record<string, string> = {
       types: "public_channel",
       exclude_archived: "true",
-      limit: String(Math.min(limit, 200)),
-    },
-    tokens.access_token,
-    signal,
-  );
-  const channels = (res.channels as Array<Record<string, unknown>>) ?? [];
-  return channels.map((c) => ({
-    id: (c.id as string) ?? "",
-    name: (c.name as string) ?? "",
-    isMember: Boolean(c.is_member),
-    isPrivate: Boolean(c.is_private),
-    numMembers: typeof c.num_members === "number" ? c.num_members : undefined,
-  }));
+      limit: String(Math.min(pageSize, limit - channels.length)),
+    };
+    if (cursor) params.cursor = cursor;
+
+    const res = await slackGet(
+      "conversations.list",
+      params,
+      tokens.access_token,
+      signal,
+    );
+    const page = (res.channels as Array<Record<string, unknown>>) ?? [];
+
+    for (const c of page) {
+      channels.push({
+        id: (c.id as string) ?? "",
+        name: (c.name as string) ?? "",
+        isMember: Boolean(c.is_member),
+        isPrivate: Boolean(c.is_private),
+        numMembers:
+          typeof c.num_members === "number" ? c.num_members : undefined,
+      });
+      if (channels.length >= limit) break;
+    }
+
+    const meta = res.response_metadata as Record<string, unknown> | undefined;
+    const nextCursor =
+      typeof meta?.next_cursor === "string" ? meta.next_cursor : "";
+    if (!nextCursor) break;
+    cursor = nextCursor;
+  }
+
+  return channels;
 }
 
 export interface SlackProfile {

--- a/src/connectors/stripe.ts
+++ b/src/connectors/stripe.ts
@@ -106,7 +106,7 @@ export class StripeConnector extends BaseConnector {
         const res = await fetch(`${BASE_URL}/v1/balance`, {
           headers: this.buildHeaders(),
         });
-        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        if (!res.ok) throw res;
         return res.json();
       });
       if ("error" in result) return { ok: false, error: result.error };
@@ -138,13 +138,21 @@ export class StripeConnector extends BaseConnector {
           message: "Stripe resource not found",
           retryable: false,
         };
-      if (s === 429)
+      if (s === 429) {
+        // Audit 2026-06-03 MEDIUM #7: read Retry-After hint when present.
+        const retryAfter = error.headers.get("Retry-After");
+        const retryAfterSec =
+          retryAfter !== null ? Number.parseInt(retryAfter, 10) : undefined;
         return {
           code: "rate_limited",
           message: "Stripe API rate limit exceeded",
           retryable: true,
           suggestedAction: "Wait and retry",
+          ...(retryAfterSec !== undefined && !Number.isNaN(retryAfterSec)
+            ? { retryAfterSec }
+            : {}),
         };
+      }
       return {
         code: "provider_error",
         message: `Stripe API error: HTTP ${s}`,

--- a/src/recipeRoutes.ts
+++ b/src/recipeRoutes.ts
@@ -2339,10 +2339,29 @@ export function tryHandleRecipeRoute(
           }
           fetchUrl = source;
           const urlParts = fetchUrl.split("/");
-          recipeName = (urlParts[urlParts.length - 1] ?? "recipe").replace(
+          const rawRecipeName = (urlParts[urlParts.length - 1] ?? "").replace(
             /\.ya?ml$/i,
             "",
           );
+          // Audit 2026-06-03 MEDIUM #17: the derived recipe name was written
+          // into the recipes directory without any sanitisation, opening a
+          // path-injection vector (e.g. `bad%20name`, `..evil`, etc.).
+          // Validate against the same SEGMENT_RE used for github: sources.
+          recipeName = rawRecipeName.toLowerCase();
+          const { SEGMENT_RE: installSegRE } = await import(
+            "./recipes/githubInstallSource.js"
+          );
+          if (!recipeName || !installSegRE.test(recipeName)) {
+            res.writeHead(400, { "Content-Type": "application/json" });
+            res.end(
+              JSON.stringify({
+                ok: false,
+                error: "Invalid recipe name in source URL",
+                code: "invalid_recipe_name",
+              }),
+            );
+            return;
+          }
         } else {
           res.writeHead(400, { "Content-Type": "application/json" });
           res.end(

--- a/src/tools/__tests__/getDocumentSymbols.test.ts
+++ b/src/tools/__tests__/getDocumentSymbols.test.ts
@@ -263,3 +263,59 @@ describe("getDocumentSymbols: Rust grep fallback", () => {
     expect(st.kind).toBe("Struct");
   });
 });
+
+// ── LSP depth map: duplicate symbol names (audit 2026-06-03 MEDIUM #16) ─────
+
+describe("getDocumentSymbols: depth map with duplicate symbol names", () => {
+  // When two symbols share the same name, the `byName` Map used to compute
+  // parent-chain depth used last-write-wins, so the second entry silently
+  // overwrote the first. If the later duplicate had a different parent chain,
+  // the overwrite corrupted `depthOf()` for any symbol whose parent chain
+  // passed through the duplicate name — most visibly creating a phantom
+  // cycle that caused the cycle-guard to fire (returning depth 33) and
+  // incorrect maxDepth filtering.
+  //
+  // Fix: keep the FIRST occurrence (keep-first) so the original parent
+  // chain is preserved.
+
+  it("keeps child symbol when its parent chain is broken by a duplicate name (last-write-wins bug)", async () => {
+    const filePath = writeFile(
+      "dup-names.ts",
+      "// symbols with duplicate names",
+    );
+
+    // Scenario:
+    //   Container (depth 0, no parent)
+    //   method    (depth 1, parent: Container)
+    //   Container (depth ?, parent: method) ← duplicate "Container" at deeper level
+    //
+    // With last-write-wins: byName["Container"] = the second one (parent: "method").
+    //   depthOf(method) → walks Container₂ → method → Container₂ → ... → CYCLE → 33
+    //   maxDepth:1 filtering would DROP method (33 > 1).
+    //
+    // With keep-first: byName["Container"] = the first one (parent: null).
+    //   depthOf(method) = 1 (method → Container₁ → null).
+    //   maxDepth:1 keeps both Container₁ and method.
+
+    const symbols = [
+      { name: "Container", kind: "Class", line: 1, parent: null },
+      { name: "method", kind: "Function", line: 2, parent: "Container" },
+      { name: "Container", kind: "Class", line: 10, parent: "method" },
+    ];
+    const lspResult = { symbols, count: symbols.length };
+    const tool = createGetDocumentSymbolsTool(
+      workspace,
+      mockConnected(lspResult),
+    );
+
+    const result = await tool.handler({ filePath, maxDepth: 1 });
+    expect(result.isError).toBeFalsy();
+    const data = parse(result);
+
+    // With the fix, Container (depth 0) AND method (depth 1) are kept.
+    // Without the fix, depthOf(method) = 33 due to the cycle → method is
+    // filtered out and only Container (depth 0) survives.
+    const names: string[] = data.symbols.map((s: { name: string }) => s.name);
+    expect(names).toContain("method");
+  });
+});

--- a/src/tools/getDocumentSymbols.ts
+++ b/src/tools/getDocumentSymbols.ts
@@ -140,9 +140,14 @@ export function createGetDocumentSymbolsTool(
               // Build parent-depth map by walking the parent chain. LSP
               // returns a flattened list with `parent: <name|null>`; depth
               // is the chain length to a null parent.
+              // Audit 2026-06-03 MEDIUM #16: last-write-wins overwrote the
+              // first occurrence when two symbols shared a name, creating a
+              // phantom cycle in depthOf() and corrupting maxDepth filtering.
+              // Keep-first preserves the original parent chain.
               const byName = new Map<string, Sym>();
               for (const s of all) {
-                if (typeof s.name === "string") byName.set(s.name, s);
+                if (typeof s.name === "string" && !byName.has(s.name))
+                  byName.set(s.name, s);
               }
               const depthOf = (s: Sym): number => {
                 let d = 0;


### PR DESCRIPTION
## Summary

Correctness and security fixes from the 2026-06-03 audit, MEDIUM priority tier.

- **#7 — Notion + Stripe 429 `Retry-After` never read**: Both connectors' `healthCheck` threw `new Error('HTTP N')` instead of the Response, so `normalizeError` never saw the response headers. Fixed to `throw res`; `normalizeError` now reads `Retry-After` and populates `retryAfterSec` on `ConnectorError`. Added `retryAfterSec?: number` field to the `ConnectorError` interface.
- **#8 — Slack `listChannels` drops paginated channels**: The implementation made a single `conversations.list` request and stopped, silently discarding all channels past the first API page. Replaced with a cursor-following loop that continues until `response_metadata.next_cursor` is empty or the caller's `limit` is reached.
- **#16 — `getDocumentSymbols` depth-map last-write-wins**: When two symbols shared a name, the `byName` Map used last-write-wins, overwriting the first entry. If the later duplicate had a different parent chain, `depthOf()` would detect a phantom cycle (depth 33), causing `maxDepth` filtering to silently drop valid symbols. Changed to keep-first.
- **#17 — `https://` recipe install name injection**: A URL like `https://host/recipes/bad%20name.yaml` would extract `bad%20name` and write it to the recipes directory without sanitisation (path-traversal vector). Fixed to validate the extracted name against the same `SEGMENT_RE` used for `github:` sources before reaching the fetch step.

> **Stacked on #932** (`fix/audit-medium-6-15-18-19`) — targets `main` directly; the slack.test.ts additions are additive.

## Test plan

- [ ] Notion/Stripe: `normalizeError(Response(429, {"Retry-After":"60"}))` returns `retryAfterSec: 60`
- [ ] Notion/Stripe: `healthCheck()` with 429 fetch returns `code: "rate_limited"` (not `"provider_error"`)
- [ ] Slack: paginated `listChannels` follows `next_cursor` across pages
- [ ] `getDocumentSymbols`: `maxDepth:1` keeps child symbol when sibling name conflicts with parent
- [ ] Recipe install `https://` URL with `%20` or `..` in name → 400 `invalid_recipe_name`
- [ ] Full test suite: `npm test` — 531 files, 7738+ tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)