### PR TITLE
fix(gemini): spawn with detached:true so treeKill kills grandchildren on POSIX (audit MEDIUM #13)

### DIFF
--- a/src/drivers/__tests__/gemini.test.ts
+++ b/src/drivers/__tests__/gemini.test.ts
@@ -411,4 +411,26 @@ describe("GeminiSubprocessDriver", () => {
     });
     expect(result.wasAborted).toBe(true);
   });
+
+  // ── POSIX grandchild cleanup (audit 2026-06-03 MEDIUM #13) ───────────────────
+  //
+  // treeKill() uses process.kill(-pid, signal) on POSIX — a process-group kill
+  // that only works when the child was spawned with detached:true (setsid →
+  // process-group leader). Without detached:true, process.kill(-pid) throws
+  // ESRCH (caught silently), leaving grandchild processes (tool subprocesses
+  // launched by Gemini) orphaned on abort/cancel.
+  it("spawns with detached:true so treeKill can send a process-group signal on POSIX (audit 2026-06-03 MEDIUM #13)", async () => {
+    makeChild([INIT, ASSISTANT("ok"), RESULT_OK]);
+    const driver = new GeminiSubprocessDriver("gemini", log);
+    await driver.run({
+      prompt: "hi",
+      workspace: "/tmp",
+      timeoutMs: 5000,
+      signal: AbortSignal.timeout(5000),
+    });
+    const spawnOpts = vi.mocked(spawn).mock.calls[0]?.[2] as
+      | Record<string, unknown>
+      | undefined;
+    expect(spawnOpts?.detached).toBe(true);
+  });
 });

--- a/src/drivers/gemini/index.ts
+++ b/src/drivers/gemini/index.ts
@@ -252,17 +252,20 @@ export class GeminiSubprocessDriver implements ProviderDriver {
         cwd: homedir(),
         env,
         signal: input.signal,
+        // Audit 2026-06-03 MEDIUM #13: detached:true makes the child a
+        // process-group leader (setsid on POSIX) so treeKill can send
+        // process.kill(-pid, signal) to kill the entire subtree. Without it,
+        // process.kill(-pid) throws ESRCH (not a group leader) and grandchild
+        // tool-processes spawned by Gemini are orphaned on abort/cancel.
+        // Mirrors the Claude subprocess driver (src/drivers/claude/subprocess.ts).
+        detached: true,
         stdio: ["ignore", "pipe", "pipe"],
       });
-      // unref() so the bridge can exit without waiting for the subprocess,
-      // but keep detached=false so the subprocess dies cleanly with the bridge
-      // rather than getting SIGPIPE when the pipe closes mid-run.
+      // unref() so the bridge can exit without waiting for the subprocess.
       child.unref();
-      // Tree-kill on abort. Node's signal-driven auto-kill only signals the
-      // immediate child; gemini may spawn tool subprocesses that orphan on
-      // cancellation. On Windows this runs `taskkill /F /T /PID`; on POSIX
-      // (non-detached) it's effectively a no-op since there's no process
-      // group, leaving Node's auto-kill to handle the child.
+      // Tree-kill on abort: kills the immediate child AND its descendants.
+      // On Windows: taskkill /F /T /PID. On POSIX: process.kill(-pid, signal)
+      // (works because detached:true makes the child a process-group leader).
       const onAbort = () => treeKill(child);
       input.signal.addEventListener("abort", onAbort, { once: true });
       child.once("close", () => {


### PR DESCRIPTION
## Summary

- `treeKill()` on POSIX uses `process.kill(-pid, signal)` — a process-group signal that only works when the target process is a group leader (i.e., spawned with `detached: true`, which calls `setsid()`).
- Without `detached: true`, `process.kill(-pid)` throws `ESRCH` (caught silently), and only `child.kill()` fires — killing the immediate Gemini process but leaving any grandchildren (tool subprocesses, `bash`, etc.) orphaned when a task is cancelled or times out.
- Fix: add `detached: true` to the `spawn()` call, matching the pattern already in the Claude subprocess driver ([subprocess.ts:189](src/drivers/claude/subprocess.ts)).

## Test plan

- [ ] New test: `spawn` options include `detached: true`
- [ ] Existing abort test still passes (`wasAborted: true`)
- [ ] Full suite: `npm test` — 531 files, 7729+ tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)