### PR TITLE
fix(audit-low): gmail escHtml quote, ANTHROPIC_API_KEY leak, inbox/recipes path exposure (LOW #13 #21 #31 #32)

### DIFF
--- a/src/__tests__/inbox-archive-delete.test.ts
+++ b/src/__tests__/inbox-archive-delete.test.ts
@@ -98,11 +98,9 @@ describe("inboxRoutes — archive + delete", () => {
     await flush(result);
 
     expect(result.status).toBe(200);
-    const body = JSON.parse(result.body) as { ok: boolean; path: string };
+    const body = JSON.parse(result.body) as { ok: boolean };
     expect(body.ok).toBe(true);
-    expect(body.path.replace(/\\/g, "/").endsWith(`.archive/${filename}`)).toBe(
-      true,
-    );
+    // path is intentionally absent from the response (LOW #31 — no fs path exposure)
 
     const inboxDir = path.join(fakeHome, ".patchwork", "inbox");
     expect(existsSync(path.join(inboxDir, filename))).toBe(false);
@@ -195,6 +193,44 @@ describe("inboxRoutes — archive + delete", () => {
     expect(archived.filter((f) => f.startsWith("branch-health")).length).toBe(
       2,
     );
+  });
+
+  it("DELETE response does not expose absolute filesystem path (LOW #31)", async () => {
+    const filename = "secret-path-test.md";
+    const inboxDir = path.join(fakeHome, ".patchwork", "inbox");
+    writeFileSync(path.join(inboxDir, filename), "content");
+
+    const { res, result } = captureResponse();
+    const handled = tryHandleInboxRoute(
+      fakeRequest("DELETE"),
+      res,
+      new URL(`http://x/inbox/${filename}`),
+    );
+    expect(handled).toBe(true);
+    await flush(result);
+
+    expect(result.status).toBe(200);
+    // Response must NOT contain the absolute path to the temp dir.
+    expect(result.body).not.toMatch(fakeHome);
+  });
+
+  it("archive response does not expose absolute filesystem path (LOW #31)", async () => {
+    const filename = "secret-archive-path.md";
+    const inboxDir = path.join(fakeHome, ".patchwork", "inbox");
+    writeFileSync(path.join(inboxDir, filename), "content");
+
+    const { res, result } = captureResponse();
+    const handled = tryHandleInboxRoute(
+      fakeRequest("POST"),
+      res,
+      new URL(`http://x/inbox/${filename}/archive`),
+    );
+    expect(handled).toBe(true);
+    await flush(result);
+
+    expect(result.status).toBe(200);
+    // Response must NOT contain the absolute path to the temp dir.
+    expect(result.body).not.toMatch(fakeHome);
   });
 
   it("inbox list excludes the .archive directory", async () => {

--- a/src/__tests__/server-recipes-content.test.ts
+++ b/src/__tests__/server-recipes-content.test.ts
@@ -259,4 +259,56 @@ describe("Server recipe content routes", () => {
       error: "Recipe deletion unavailable",
     });
   });
+
+  it("does not expose filesystem path in PUT /recipes/:name error response (LOW #32)", async () => {
+    server!.saveRecipeContentFn = () => ({
+      ok: false,
+      error:
+        "ENOENT: no such file or directory, open '/home/user/.patchwork/recipes/test.yaml'",
+    });
+
+    const { status, body } = await makeRequest(
+      {
+        method: "PUT",
+        path: "/recipes/test",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${TOKEN}`,
+        },
+      },
+      JSON.stringify({ content: "name: test\n" }),
+    );
+
+    expect(status).toBe(400);
+    const parsed = JSON.parse(body) as { ok: boolean; error: string };
+    expect(parsed.ok).toBe(false);
+    // Must not expose the home directory path.
+    expect(parsed.error).not.toMatch(/\/home\//);
+    expect(parsed.error).not.toMatch(/\/Users\//);
+    expect(parsed.error).not.toMatch(/\.patchwork/);
+    expect(parsed.error).toBe("Storage error");
+  });
+
+  it("does not expose filesystem path in DELETE /recipes/:name error response (LOW #32)", async () => {
+    server!.deleteRecipeContentFn = () => ({
+      ok: false,
+      error:
+        "EACCES: permission denied, unlink '/home/user/.patchwork/recipes/test.yaml'",
+    });
+
+    const { status, body } = await makeRequest({
+      method: "DELETE",
+      path: "/recipes/test",
+      headers: { Authorization: `Bearer ${TOKEN}` },
+    });
+
+    expect(status).toBe(400);
+    const parsed = JSON.parse(body) as { ok: boolean; error: string };
+    expect(parsed.ok).toBe(false);
+    // Must not expose the home directory path.
+    expect(parsed.error).not.toMatch(/\/home\//);
+    expect(parsed.error).not.toMatch(/\/Users\//);
+    expect(parsed.error).not.toMatch(/\.patchwork/);
+    expect(parsed.error).toBe("Storage error");
+  });
 });

--- a/src/connectors/__tests__/gmail.test.ts
+++ b/src/connectors/__tests__/gmail.test.ts
@@ -130,3 +130,18 @@ describe("handleGmailTest", () => {
     expect(JSON.parse(result.body)).toMatchObject({ ok: false });
   });
 });
+
+describe("escHtml (LOW #13)", () => {
+  it("escapes single quotes as &#39; to prevent HTML attribute injection", async () => {
+    const { escHtml } = await import("../gmail.js");
+    expect(escHtml("it's a test")).toContain("&#39;");
+    expect(escHtml("it's a test")).toBe("it&#39;s a test");
+  });
+
+  it("still escapes the standard HTML special chars", async () => {
+    const { escHtml } = await import("../gmail.js");
+    expect(escHtml('<script>&"test"</script>')).toBe(
+      "&lt;script&gt;&amp;&quot;test&quot;&lt;/script&gt;",
+    );
+  });
+});

--- a/src/connectors/gmail.ts
+++ b/src/connectors/gmail.ts
@@ -539,12 +539,13 @@ export async function handleGmailDisconnect(): Promise<ConnectorHandlerResult> {
 
 // ── Callback HTML ─────────────────────────────────────────────────────────────
 
-function escHtml(s: string): string {
+export function escHtml(s: string): string {
   return s
     .replace(/&/g, "&amp;")
     .replace(/</g, "&lt;")
     .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;");
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
 }
 
 function callbackHtml(

--- a/src/drivers/claude/__tests__/envSanitizer.test.ts
+++ b/src/drivers/claude/__tests__/envSanitizer.test.ts
@@ -26,12 +26,14 @@ describe("sanitizeEnv", () => {
     expect(out.CLAUDE_CODE_ENTRYPOINT).toBeUndefined();
   });
 
-  it("preserves ANTHROPIC_API_KEY", () => {
+  it("strips ANTHROPIC_API_KEY so non-Anthropic subprocesses do not receive it (LOW #21)", () => {
     const out = sanitizeEnv({
       ANTHROPIC_API_KEY: "sk-ant-api03-key",
       CLAUDECODE: "1",
+      PATH: "/usr/bin",
     });
-    expect(out.ANTHROPIC_API_KEY).toBe("sk-ant-api03-key");
+    expect(out.ANTHROPIC_API_KEY).toBeUndefined();
+    expect(out.PATH).toBe("/usr/bin");
   });
 
   it("leaves the input env unmodified (returns a copy)", () => {

--- a/src/drivers/claude/envSanitizer.ts
+++ b/src/drivers/claude/envSanitizer.ts
@@ -24,6 +24,7 @@ export function sanitizeEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
     if (PRESERVE.has(key)) continue;
     if (
       key === "CLAUDECODE" ||
+      key === "ANTHROPIC_API_KEY" ||
       key.startsWith("CLAUDE_CODE_") ||
       key.startsWith("MCP_")
     ) {

--- a/src/inboxRoutes.ts
+++ b/src/inboxRoutes.ts
@@ -217,7 +217,7 @@ export function tryHandleInboxRoute(
         }
         await unlink(filePath);
         res.writeHead(200, { "Content-Type": "application/json" });
-        res.end(JSON.stringify({ ok: true, path: filePath }));
+        res.end(JSON.stringify({ ok: true }));
       } catch (err: unknown) {
         const code = (err as NodeJS.ErrnoException).code;
         if (code === "ENOENT") {
@@ -263,7 +263,7 @@ export function tryHandleInboxRoute(
         }
         await rename(filePath, dest);
         res.writeHead(200, { "Content-Type": "application/json" });
-        res.end(JSON.stringify({ ok: true, path: dest }));
+        res.end(JSON.stringify({ ok: true }));
       } catch (err: unknown) {
         const code = (err as NodeJS.ErrnoException).code;
         if (code === "ENOENT") {

--- a/src/recipeRoutes.ts
+++ b/src/recipeRoutes.ts
@@ -47,6 +47,24 @@ import type { RecipeDraft } from "./recipesHttp.js";
 import { invalidateRecipesCache } from "./recipesHttp.js";
 import { validateSafeUrl } from "./ssrfGuard.js";
 
+/**
+ * Sanitize error messages from storage operations before including them in
+ * HTTP responses. Node.js filesystem errors (ENOENT, EACCES, etc.) often
+ * contain absolute paths (e.g. "ENOENT: no such file or directory, open
+ * '/home/user/.patchwork/recipes/foo.yaml'"). These must not be returned
+ * verbatim to clients. Returns "Storage error" for any message that looks
+ * like a filesystem error (identified by Node.js errno code prefix);
+ * otherwise returns the message unchanged.
+ */
+function sanitizeStorageError(msg: string): string {
+  // Node.js filesystem errors always start with an errno code such as
+  // "ENOENT:", "EACCES:", "EPERM:", "EBUSY:", "EISDIR:", etc.
+  if (/^E[A-Z]+:/.test(msg)) {
+    return "Storage error";
+  }
+  return msg;
+}
+
 // 5-minute cache of the public template registry from the patchworkos/recipes
 // GitHub repo. Process-wide; hoisted out of Server class state.
 // Sentinel `false` marks a negative-cache entry (fetch failed) — distinct from
@@ -1614,7 +1632,10 @@ export function tryHandleRecipeRoute(
         res.writeHead(result.ok ? 200 : 400, {
           "Content-Type": "application/json",
         });
-        res.end(JSON.stringify(result));
+        const safeResult = result.error
+          ? { ...result, error: sanitizeStorageError(result.error) }
+          : result;
+        res.end(JSON.stringify(safeResult));
       } catch {
         respondInvalidJson(res);
       }
@@ -1644,7 +1665,10 @@ export function tryHandleRecipeRoute(
         ? 404
         : 400;
     res.writeHead(status, { "Content-Type": "application/json" });
-    res.end(JSON.stringify(result));
+    const safeDeleteResult = result.error
+      ? { ...result, error: sanitizeStorageError(result.error) }
+      : result;
+    res.end(JSON.stringify(safeDeleteResult));
     return true;
   }
 
@@ -1669,7 +1693,10 @@ export function tryHandleRecipeRoute(
         ? 404
         : 400;
     res.writeHead(status, { "Content-Type": "application/json" });
-    res.end(JSON.stringify(result));
+    const safeArchiveResult = result.error
+      ? { ...result, error: sanitizeStorageError(result.error) }
+      : result;
+    res.end(JSON.stringify(safeArchiveResult));
     return true;
   }
 


### PR DESCRIPTION
## Summary

Fixes 4 LOW-priority security findings from 2026-06-03 audit.

- **LOW #13** (`src/connectors/gmail.ts`): `escHtml` was missing `'` → `&#39;` escape. Single quotes in HTML attribute values were passed through unescaped, enabling attribute injection.

- **LOW #21** (`src/drivers/claude/envSanitizer.ts`): `sanitizeEnv` stripped `CLAUDECODE`, `CLAUDE_CODE_*`, `MCP_*` but not `ANTHROPIC_API_KEY`. The Gemini subprocess was receiving the key unnecessarily. Added `ANTHROPIC_API_KEY` to the strip list.

- **LOW #31** (`src/inboxRoutes.ts`): DELETE and archive success responses included `path: <absolute-fs-path>`, exposing the home directory structure. Changed to return `{ ok: true }` only.

- **LOW #32** (`src/recipeRoutes.ts`): `saveRecipeContent`/`deleteRecipeContent` error catches returned raw `err.message` verbatim in HTTP responses. Node.js errno errors (ENOENT, EACCES, etc.) expose absolute file paths. Added `sanitizeStorageError()` helper that replaces errno-pattern messages with `"Storage error"`.

## Test plan

- [ ] `src/connectors/__tests__/gmail.test.ts` — 2 new tests for `escHtml` quote escaping
- [ ] `src/drivers/claude/__tests__/envSanitizer.test.ts` — updated test asserting `ANTHROPIC_API_KEY` is stripped
- [ ] `src/__tests__/inbox-archive-delete.test.ts` — 2 tests asserting no home path in response
- [ ] `src/__tests__/server-recipes-content.test.ts` — 2 tests asserting ENOENT/EACCES → `"Storage error"`
- [ ] Full suite: 7699 passing, 0 new failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)