### PR TITLE
fix(audit-low): fanOut import hoist, lineBuf flush, diagnostics zero-guard, hotspots path validation (LOW #3 #20 #23 #29)

### DIFF
--- a/src/__tests__/automation.test.ts
+++ b/src/__tests__/automation.test.ts
@@ -272,6 +272,28 @@ describe("AutomationHooks.handleDiagnosticsChanged", () => {
     hooks.handleDiagnosticsChanged("/src/foo.ts", errorDiag);
     expect(orch.list().length).toBe(0);
   });
+
+  it("LOW#23 - does NOT enqueue a task when currentErrorCount === 0", () => {
+    // Bug: onDiagnosticsError was always enqueued even with zero errors.
+    // When diagnostics list is empty (or all info/hint severity), no task
+    // should be triggered.
+    const orch = makeInstantOrchestrator();
+    const hooks = new AutomationHooks(
+      {
+        onDiagnosticsError: {
+          enabled: true,
+          minSeverity: "error",
+          prompt: "Fix: {{diagnostics}}",
+          cooldownMs: 5_000,
+        },
+      },
+      orch,
+      () => {},
+    );
+    // Call with an empty diagnostics array (zero error count)
+    hooks.handleDiagnosticsChanged("/src/foo.ts", []);
+    expect(orch.list().length).toBe(0);
+  });
 });
 
 // ── handleFileSaved tests ─────────────────────────────────────────────────────

--- a/src/automation.ts
+++ b/src/automation.ts
@@ -1631,13 +1631,18 @@ export class AutomationHooks {
     if (prevErrorCount > 0 && currentErrorCount === 0) {
       this._enqueueRun("onDiagnosticsCleared", { file: normalizedFile });
     }
-    this._enqueueRun("onDiagnosticsError", {
-      file: normalizedFile,
-      diagnostics: diagnosticsText,
-      diagnosticSources,
-      diagnosticSig,
-      count: String(diagnostics.length),
-    });
+    // Only fire onDiagnosticsError when there are actual errors/warnings.
+    // Firing with zero error count causes spurious Claude tasks to run with
+    // empty diagnostics lists (audit 2026-06-03 LOW #23).
+    if (currentErrorCount > 0) {
+      this._enqueueRun("onDiagnosticsError", {
+        file: normalizedFile,
+        diagnostics: diagnosticsText,
+        diagnosticSources,
+        diagnosticSig,
+        count: String(diagnostics.length),
+      });
+    }
   }
 
   /**

--- a/src/drivers/__tests__/gemini.test.ts
+++ b/src/drivers/__tests__/gemini.test.ts
@@ -360,6 +360,72 @@ describe("GeminiSubprocessDriver", () => {
     expect(result.stderrTail).toContain("[REDACTED_API_KEY]");
   });
 
+  it("LOW#20 - flushes final assistant line that lacks a trailing newline", async () => {
+    // Simulates a stream where the LAST assistant message is emitted without
+    // a trailing '\n'. Without the lineBuf flush fix, this partial line stays
+    // in lineBuf and is silently dropped, causing the last message to be lost.
+    const stdout = new EventEmitter() as EventEmitter & {
+      setEncoding: () => void;
+    };
+    stdout.setEncoding = () => {};
+    const stderr = new EventEmitter() as EventEmitter & {
+      setEncoding: () => void;
+    };
+    stderr.setEncoding = () => {};
+    const child = new EventEmitter() as EventEmitter & {
+      stdout: typeof stdout;
+      stderr: typeof stderr;
+      stdin: null;
+      stdio: unknown[];
+      kill: () => void;
+      unref: () => void;
+      killed: boolean;
+      connected: boolean;
+      pid: number;
+      exitCode: number | null;
+    };
+    child.stdout = stdout;
+    child.stderr = stderr;
+    child.stdin = null;
+    child.stdio = [null, stdout, stderr];
+    child.killed = false;
+    child.connected = false;
+    child.pid = 12345;
+    child.exitCode = null;
+    child.kill = () => {};
+    child.unref = () => {};
+
+    vi.mocked(spawn).mockReturnValueOnce(
+      child as unknown as ReturnType<typeof spawn>,
+    );
+
+    // Emit RESULT_OK with a newline so doneFromResult fires, but emit the
+    // last assistant message WITHOUT a trailing newline — it stays in lineBuf
+    // until close, at which point it should be flushed.
+    const LAST_ASSISTANT_NO_NEWLINE = ASSISTANT("the-dropped-line");
+    setTimeout(() => {
+      stdout.emit("data", `${INIT}\n`);
+      stdout.emit("data", `${RESULT_OK}\n`);
+      // Emit LAST_ASSISTANT_NO_NEWLINE after result, without '\n'.
+      // This simulates any partial line left in the buffer at stream end.
+      stdout.emit("data", LAST_ASSISTANT_NO_NEWLINE); // no trailing '\n'
+      child.emit("close", 0);
+    }, 0);
+
+    const driver = new GeminiSubprocessDriver("gemini", log);
+    const chunks: string[] = [];
+    const result = await driver.run({
+      prompt: "hi",
+      workspace: "/tmp",
+      timeoutMs: 5000,
+      signal: AbortSignal.timeout(5000),
+      onChunk: (c) => chunks.push(c),
+    });
+    // Without the fix, "the-dropped-line" is silently lost.
+    expect(chunks).toContain("the-dropped-line");
+    expect(result.text).toContain("the-dropped-line");
+  });
+
   it("returns wasAborted on AbortError", async () => {
     const ac = new AbortController();
     const stdout = new EventEmitter() as EventEmitter & {

--- a/src/drivers/claude/subprocess.ts
+++ b/src/drivers/claude/subprocess.ts
@@ -320,6 +320,50 @@ export class SubprocessDriver implements ProviderDriver {
     }
     if (startupHandle) clearTimeout(startupHandle);
 
+    // Flush any partial line remaining in lineBuf after stdout closes.
+    // splitLines() leaves content without a trailing '\n' in the remainder;
+    // when the subprocess exits without a final newline the last JSON event
+    // (e.g. the result event) is silently dropped. Process it now.
+    if (lineBuf.trim().length > 0) {
+      const parsed = parseStreamLine(lineBuf);
+      if (parsed.kind === "raw") {
+        accumulated += parsed.text;
+        if (outputBytesSent < OUTPUT_CAP) {
+          const { send, bytes } = truncateToBytes(
+            parsed.text,
+            OUTPUT_CAP - outputBytesSent,
+          );
+          if (bytes > 0) {
+            input.onChunk?.(send);
+            outputBytesSent += bytes;
+          }
+        }
+      } else {
+        const { event, text } = parsed;
+        if (event.type === "assistant") {
+          if (firstAssistantAt === undefined) firstAssistantAt = Date.now();
+          if (text.length > 0) {
+            accumulated += text;
+            if (outputBytesSent < OUTPUT_CAP) {
+              const { send, bytes } = truncateToBytes(
+                text,
+                OUTPUT_CAP - outputBytesSent,
+              );
+              if (bytes > 0) {
+                input.onChunk?.(send);
+                outputBytesSent += bytes;
+              }
+            }
+          }
+        } else if (event.type === "result") {
+          doneFromResult = true;
+          resultIsError = event.is_error === true;
+          resultText = text || accumulated;
+        }
+      }
+      lineBuf = "";
+    }
+
     const effectiveExitCode = doneFromResult
       ? resultIsError
         ? 1

--- a/src/drivers/gemini/index.ts
+++ b/src/drivers/gemini/index.ts
@@ -368,6 +368,42 @@ export class GeminiSubprocessDriver implements ProviderDriver {
       }
       if (startupHandle) clearTimeout(startupHandle);
 
+      // Flush any partial line remaining in lineBuf after stdout closes.
+      // splitLines() leaves content without a trailing '\n' in the remainder;
+      // when the subprocess exits without a final newline the last JSON event
+      // (e.g. the last assistant message) is silently dropped. Process it now.
+      if (lineBuf.trim().length > 0) {
+        let event: GeminiEvent;
+        try {
+          event = JSON.parse(lineBuf) as GeminiEvent;
+          if (
+            event.type === "message" &&
+            event.role === "assistant" &&
+            event.content
+          ) {
+            if (firstAssistantAt === undefined) firstAssistantAt = Date.now();
+            const text = event.content;
+            accumulated += text;
+            if (outputBytesSent < OUTPUT_CAP) {
+              const { send, bytes } = truncateToBytes(
+                text,
+                OUTPUT_CAP - outputBytesSent,
+              );
+              if (send.length > 0) {
+                input.onChunk?.(send);
+                outputBytesSent += bytes;
+              }
+            }
+          } else if (event.type === "result") {
+            doneFromResult = true;
+            resultSuccess = event.status === "success";
+          }
+        } catch {
+          // Non-JSON remainder — ignore (same as the data handler)
+        }
+        lineBuf = "";
+      }
+
       if (startupTimedOut) {
         return {
           text: truncateUtf8Bytes(accumulated, OUTPUT_CAP),

--- a/src/recipes/tools/fanOut.ts
+++ b/src/recipes/tools/fanOut.ts
@@ -157,6 +157,11 @@ registerTool({
 
     const aggregate: IterResult[] = [];
 
+    // Hoist the lazy import outside the loop — dynamic imports cache the
+    // module after the first load so correctness is unaffected, but resolving
+    // the same promise on every iteration adds async overhead for each item.
+    const { render } = await import("../yamlRunner.js");
+
     for (let i = 0; i < items.length; i++) {
       const item = items[i];
       // Build per-iter ctx clone. Bind the loop variable as the raw item
@@ -168,10 +173,6 @@ registerTool({
       iterCtx[`${loopVar}_index`] = String(i);
       iterCtx[`${loopVar}_total`] = String(items.length);
 
-      // Deep-render the raw `do` sub-step against iterCtx, then dispatch
-      // via executeTool. We import render lazily to avoid a circular
-      // import with yamlRunner.
-      const { render } = await import("../yamlRunner.js");
       const innerParams: Record<string, unknown> = {};
       for (const [k, v] of Object.entries(doObj)) {
         if (k === "tool") continue;

--- a/src/tools/__tests__/getGitHotspots.test.ts
+++ b/src/tools/__tests__/getGitHotspots.test.ts
@@ -98,4 +98,25 @@ describe("getGitHotspots", () => {
     const result = parse(await tool.handler({ path: "src/" }));
     expect(result.scopedTo).toBe("src/");
   });
+
+  it("LOW#29 - rejects path traversal in scopedTo (../../../etc/passwd)", async () => {
+    // Bug: scopedTo echoed unvalidated user input. A path with '..' should be
+    // rejected with an error rather than echoed back in the response.
+    mockExecSafe.mockResolvedValueOnce(ok(".git")); // rev-parse succeeds
+
+    const tool = createGetGitHotspotsTool(WORKSPACE);
+    const result = await tool.handler({ path: "../../../etc/passwd" });
+    // Should return an error, not a successful response with the traversal path
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.text).toContain("invalid");
+  });
+
+  it("LOW#29 - rejects absolute paths in scopedTo", async () => {
+    mockExecSafe.mockResolvedValueOnce(ok(".git")); // rev-parse succeeds
+
+    const tool = createGetGitHotspotsTool(WORKSPACE);
+    const result = await tool.handler({ path: "/etc/passwd" });
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.text).toContain("invalid");
+  });
 });

--- a/src/tools/getGitHotspots.ts
+++ b/src/tools/getGitHotspots.ts
@@ -85,7 +85,23 @@ export function createGetGitHotspotsTool(workspace: string) {
     async handler(args: Record<string, unknown>, signal?: AbortSignal) {
       const days = optionalInt(args, "days", 1, 365) ?? 90;
       const limit = optionalInt(args, "limit", 1, 100) ?? 20;
-      const path = optionalString(args, "path");
+      const rawPath = optionalString(args, "path");
+
+      // Validate scopedTo path: reject absolute paths, null bytes, and path
+      // traversal sequences. The value is echoed back in the response so it
+      // must not reflect unvalidated user input (audit 2026-06-03 LOW #29).
+      if (rawPath !== undefined) {
+        if (
+          rawPath.includes("\0") ||
+          rawPath.startsWith("/") ||
+          rawPath.split(/[/\\]/).some((seg) => seg === "..")
+        ) {
+          return error(
+            `invalid path argument: "${rawPath}" (absolute paths and '..' traversal are not allowed)`,
+          );
+        }
+      }
+      const path = rawPath;
 
       // Verify git repo
       const check = await execSafe("git", ["rev-parse", "--git-dir"], {


### PR DESCRIPTION
## Summary

Fixes 4 LOW-priority audit findings from 2026-06-03.

- **LOW #3** (`src/recipes/tools/fanOut.ts`): Hoisted `await import('../yamlRunner.js')` out of the iteration loop. Dynamic imports cache after the first load, so this is a correctness no-op but removes per-iteration async resolution overhead.

- **LOW #20** (`src/drivers/gemini/index.ts`, `src/drivers/claude/subprocess.ts`): After `await child_close`, both drivers now flush any remaining `lineBuf` content as a final line. POSIX streams can end without a trailing `\n`, silently dropping the last JSON event. The fix processes any non-empty remainder as a complete line.

- **LOW #23** (`src/automation.ts`): `_enqueueRun('onDiagnosticsError', ...)` was called unconditionally even when `currentErrorCount === 0`. Added `if (currentErrorCount > 0)` guard. The downstream `evaluateWhen` already filtered this, but the guard prevents unnecessary work and is defense-in-depth.

- **LOW #29** (`src/tools/getGitHotspots.ts`): The `path`/`scopedTo` argument was echoed unvalidated into the response. Added validation that rejects null bytes, absolute paths, and `..` segments before use. Returns a structured error for invalid inputs.

## Test plan

- [ ] `src/drivers/__tests__/gemini.test.ts` — new test: assistant message without trailing `\n` appears in result
- [ ] `src/automation.test.ts` — new test: zero-error diagnostics event produces no enqueued tasks
- [ ] `src/tools/__tests__/getGitHotspots.test.ts` — 2 tests: `../../../etc/passwd` and `/etc/passwd` both rejected
- [ ] Full suite: no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)