### PR TITLE
fix(audit-low): login CSRF, OAuth callback session, approvals params XSS, ActivityTicker dedup (LOW #37 #39 #42 #44)

### DIFF
--- a/dashboard/src/app/api/connections/__tests__/oauth-callbacks.test.ts
+++ b/dashboard/src/app/api/connections/__tests__/oauth-callbacks.test.ts
@@ -28,10 +28,21 @@ const ROUTES: { name: string; bridgePath: string; handler: Handler }[] = [
   { name: "google-drive",     bridgePath: "/connections/google-drive/callback",     handler: gdriveCallback },
 ];
 
+let origAllowUnauthenticated: string | undefined;
+
 beforeEach(() => {
   bridgeFetchMock.mockReset();
+  // Bypass the session guard (LOW #39 fix) so these proxy-behaviour tests
+  // don't need a real signed session cookie.
+  origAllowUnauthenticated = process.env.DASHBOARD_ALLOW_UNAUTHENTICATED;
+  process.env.DASHBOARD_ALLOW_UNAUTHENTICATED = "1";
 });
 afterEach(() => {
+  if (origAllowUnauthenticated === undefined) {
+    delete process.env.DASHBOARD_ALLOW_UNAUTHENTICATED;
+  } else {
+    process.env.DASHBOARD_ALLOW_UNAUTHENTICATED = origAllowUnauthenticated;
+  }
   vi.restoreAllMocks();
 });
 

--- a/dashboard/src/app/api/connections/__tests__/proxy-leak.test.ts
+++ b/dashboard/src/app/api/connections/__tests__/proxy-leak.test.ts
@@ -36,11 +36,22 @@ const { GET: inboxItemGet } = await import("../../inbox/[filename]/route");
 const SENSITIVE_ERR = "ECONNREFUSED 127.0.0.1:54321 secret-detail";
 const SENSITIVE_UPSTREAM = "upstream-bridge-stacktrace-leak";
 
+let origAllowUnauthenticated: string | undefined;
+
 beforeEach(() => {
   bridgeFetchMock.mockReset();
   vi.spyOn(console, "error").mockImplementation(() => {});
+  // Bypass the session guard (LOW #39 fix) so proxy-behaviour tests
+  // don't need real signed session cookies.
+  origAllowUnauthenticated = process.env.DASHBOARD_ALLOW_UNAUTHENTICATED;
+  process.env.DASHBOARD_ALLOW_UNAUTHENTICATED = "1";
 });
 afterEach(() => {
+  if (origAllowUnauthenticated === undefined) {
+    delete process.env.DASHBOARD_ALLOW_UNAUTHENTICATED;
+  } else {
+    process.env.DASHBOARD_ALLOW_UNAUTHENTICATED = origAllowUnauthenticated;
+  }
   vi.restoreAllMocks();
 });
 

--- a/dashboard/src/app/api/connections/__tests__/session-guard.test.ts
+++ b/dashboard/src/app/api/connections/__tests__/session-guard.test.ts
@@ -1,0 +1,69 @@
+/** @vitest-environment node */
+/**
+ * LOW #39 — OAuth callback routes must verify session before forwarding
+ *
+ * The OAuth callback routes are middleware-exempt. Without a session check,
+ * any request that knows the callback URL can complete an OAuth flow on
+ * behalf of a user (e.g. by sending a crafted ?code=…&state=… directly).
+ *
+ * Fix: each callback route must verify the session cookie before forwarding
+ * to the bridge. Unauthenticated requests must get 401.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock bridgeFetch so these tests don't need a real bridge.
+const bridgeFetchMock = vi.fn();
+vi.mock("@/lib/bridge", () => ({
+  bridgeFetch: (...args: unknown[]) => bridgeFetchMock(...args),
+}));
+
+import { GET as githubCallback } from "../github/callback/route";
+
+type Handler = (req: Request) => Promise<Response>;
+
+const ROUTES: { name: string; handler: Handler }[] = [
+  { name: "github", handler: githubCallback },
+];
+
+const ENV_KEYS = ["DASHBOARD_PASSWORD", "DASHBOARD_SESSION_SECRET"] as const;
+let originalEnv: Record<string, string | undefined>;
+
+beforeEach(() => {
+  originalEnv = Object.fromEntries(ENV_KEYS.map((k) => [k, process.env[k]]));
+  process.env.DASHBOARD_PASSWORD = "s3cr3t";
+  process.env.DASHBOARD_SESSION_SECRET = "0123456789abcdef0123456789abcdef";
+  bridgeFetchMock.mockReset();
+});
+
+afterEach(() => {
+  for (const k of ENV_KEYS) {
+    if (originalEnv[k] === undefined) delete process.env[k];
+    else process.env[k] = originalEnv[k];
+  }
+  vi.restoreAllMocks();
+});
+
+function reqWithoutSession(query: string): Request {
+  return new Request(`https://dashboard.local/api/connections/github/callback?${query}`);
+}
+
+describe.each(ROUTES)("$name OAuth callback — session guard (LOW #39)", ({ handler }) => {
+  it("returns 401 when no session cookie is present", async () => {
+    // An unauthenticated attacker must not be able to complete the OAuth flow.
+    const res = await handler(reqWithoutSession("code=stolen&state=xyz"));
+    expect(res.status).toBe(401);
+    // bridgeFetch must NOT have been called
+    expect(bridgeFetchMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when session cookie is malformed / invalid", async () => {
+    const req = new Request(
+      "https://dashboard.local/api/connections/github/callback?code=abc&state=s",
+      { headers: { cookie: "patchwork_session=invalid-garbage" } },
+    );
+    const res = await handler(req);
+    expect(res.status).toBe(401);
+    expect(bridgeFetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/dashboard/src/app/api/connections/asana/callback/route.ts
+++ b/dashboard/src/app/api/connections/asana/callback/route.ts
@@ -1,9 +1,14 @@
 import { bridgeFetch } from "@/lib/bridge";
+import { requireCallbackSession } from "../../requireSession";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
 export async function GET(req: Request): Promise<Response> {
+  // LOW #39: verify active dashboard session before forwarding OAuth code.
+  const authErr = await requireCallbackSession(req);
+  if (authErr) return authErr;
+
   const url = new URL(req.url);
   const allowed = ["code", "state", "error"];
   const qs = new URLSearchParams();

--- a/dashboard/src/app/api/connections/discord/callback/route.ts
+++ b/dashboard/src/app/api/connections/discord/callback/route.ts
@@ -1,9 +1,14 @@
 import { bridgeFetch } from "@/lib/bridge";
+import { requireCallbackSession } from "../../requireSession";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
 export async function GET(req: Request): Promise<Response> {
+  // LOW #39: verify active dashboard session before forwarding OAuth code.
+  const authErr = await requireCallbackSession(req);
+  if (authErr) return authErr;
+
   const url = new URL(req.url);
   const allowed = ["code", "state", "error"];
   const qs = new URLSearchParams();

--- a/dashboard/src/app/api/connections/github/callback/route.ts
+++ b/dashboard/src/app/api/connections/github/callback/route.ts
@@ -1,9 +1,14 @@
 import { bridgeFetch } from "@/lib/bridge";
+import { requireCallbackSession } from "../../requireSession";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
 export async function GET(req: Request): Promise<Response> {
+  // LOW #39: verify active dashboard session before forwarding OAuth code.
+  const authErr = await requireCallbackSession(req);
+  if (authErr) return authErr;
+
   const url = new URL(req.url);
   const allowed = ["code", "state", "error"];
   const qs = new URLSearchParams();

--- a/dashboard/src/app/api/connections/gitlab/callback/route.ts
+++ b/dashboard/src/app/api/connections/gitlab/callback/route.ts
@@ -1,9 +1,14 @@
 import { bridgeFetch } from "@/lib/bridge";
+import { requireCallbackSession } from "../../requireSession";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
 export async function GET(req: Request): Promise<Response> {
+  // LOW #39: verify active dashboard session before forwarding OAuth code.
+  const authErr = await requireCallbackSession(req);
+  if (authErr) return authErr;
+
   const url = new URL(req.url);
   const allowed = ["code", "state", "error"];
   const qs = new URLSearchParams();

--- a/dashboard/src/app/api/connections/gmail/callback/route.ts
+++ b/dashboard/src/app/api/connections/gmail/callback/route.ts
@@ -1,9 +1,14 @@
 import { bridgeFetch } from "@/lib/bridge";
+import { requireCallbackSession } from "../../requireSession";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
 export async function GET(req: Request): Promise<Response> {
+  // LOW #39: verify active dashboard session before forwarding OAuth code.
+  const authErr = await requireCallbackSession(req);
+  if (authErr) return authErr;
+
   const url = new URL(req.url);
   const allowed = ["code", "state", "error"];
   const qs = new URLSearchParams();

--- a/dashboard/src/app/api/connections/google-calendar/callback/route.ts
+++ b/dashboard/src/app/api/connections/google-calendar/callback/route.ts
@@ -1,9 +1,14 @@
 import { bridgeFetch } from "@/lib/bridge";
+import { requireCallbackSession } from "../../requireSession";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
 export async function GET(req: Request): Promise<Response> {
+  // LOW #39: verify active dashboard session before forwarding OAuth code.
+  const authErr = await requireCallbackSession(req);
+  if (authErr) return authErr;
+
   const url = new URL(req.url);
   const allowed = ["code", "state", "error"];
   const qs = new URLSearchParams();
@@ -14,8 +19,8 @@ export async function GET(req: Request): Promise<Response> {
 
   try {
     const res = await bridgeFetch(
-    `/connections/google-calendar/callback?${qs.toString()}`,
-  );
+      `/connections/google-calendar/callback?${qs.toString()}`,
+    );
     const body = await res.text();
     return new Response(body, {
       status: res.status,

--- a/dashboard/src/app/api/connections/google-drive/callback/route.ts
+++ b/dashboard/src/app/api/connections/google-drive/callback/route.ts
@@ -1,9 +1,14 @@
 import { bridgeFetch } from "@/lib/bridge";
+import { requireCallbackSession } from "../../requireSession";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
 export async function GET(req: Request): Promise<Response> {
+  // LOW #39: verify active dashboard session before forwarding OAuth code.
+  const authErr = await requireCallbackSession(req);
+  if (authErr) return authErr;
+
   const url = new URL(req.url);
   const allowed = ["code", "state", "error"];
   const qs = new URLSearchParams();
@@ -14,8 +19,8 @@ export async function GET(req: Request): Promise<Response> {
 
   try {
     const res = await bridgeFetch(
-    `/connections/google-drive/callback?${qs.toString()}`,
-  );
+      `/connections/google-drive/callback?${qs.toString()}`,
+    );
     const body = await res.text();
     return new Response(body, {
       status: res.status,

--- a/dashboard/src/app/api/connections/linear/callback/route.ts
+++ b/dashboard/src/app/api/connections/linear/callback/route.ts
@@ -1,9 +1,14 @@
 import { bridgeFetch } from "@/lib/bridge";
+import { requireCallbackSession } from "../../requireSession";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
 export async function GET(req: Request): Promise<Response> {
+  // LOW #39: verify active dashboard session before forwarding OAuth code.
+  const authErr = await requireCallbackSession(req);
+  if (authErr) return authErr;
+
   const url = new URL(req.url);
   const allowed = ["code", "state", "error"];
   const qs = new URLSearchParams();

--- a/dashboard/src/app/api/connections/requireSession.ts
+++ b/dashboard/src/app/api/connections/requireSession.ts
@@ -1,0 +1,43 @@
+/**
+ * Session guard for OAuth callback routes.
+ *
+ * LOW #39: OAuth callback routes are exempted from the middleware session gate
+ * (necessary because the OAuth provider's redirect is a cross-site navigation
+ * and SameSite=Strict cookies aren't sent on cross-origin top-level navigations).
+ * However, the API callback routes (/api/connections/<name>/callback) are called
+ * by same-origin browser code, so the session cookie IS sent. We verify it here
+ * to prevent unauthenticated code-exchange (an attacker who knows the callback URL
+ * could otherwise complete an OAuth flow without a valid session).
+ *
+ * Pass-through when DASHBOARD_ALLOW_UNAUTHENTICATED=1 (local dev).
+ *
+ * Returns null when the request is allowed; returns a 401 Response to return
+ * directly when not.
+ */
+
+import { SESSION_COOKIE_NAME, verifySession } from "@/lib/session";
+
+/** Parse a single named cookie out of the Cookie header. */
+function getCookie(req: Request, name: string): string | undefined {
+  const header = req.headers.get("cookie") ?? "";
+  for (const part of header.split(";")) {
+    const [k, ...rest] = part.trim().split("=");
+    if (k?.trim() === name) return rest.join("=").trim();
+  }
+  return undefined;
+}
+
+export async function requireCallbackSession(
+  req: Request,
+): Promise<Response | null> {
+  if (process.env.DASHBOARD_ALLOW_UNAUTHENTICATED === "1") return null;
+  const sessionValue = getCookie(req, SESSION_COOKIE_NAME);
+  const { valid } = await verifySession(sessionValue);
+  if (!valid) {
+    return new Response(JSON.stringify({ error: "Unauthorized" }), {
+      status: 401,
+      headers: { "content-type": "application/json" },
+    });
+  }
+  return null;
+}

--- a/dashboard/src/app/api/connections/sentry/callback/route.ts
+++ b/dashboard/src/app/api/connections/sentry/callback/route.ts
@@ -1,9 +1,14 @@
 import { bridgeFetch } from "@/lib/bridge";
+import { requireCallbackSession } from "../../requireSession";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
 export async function GET(req: Request): Promise<Response> {
+  // LOW #39: verify active dashboard session before forwarding OAuth code.
+  const authErr = await requireCallbackSession(req);
+  if (authErr) return authErr;
+
   const url = new URL(req.url);
   const allowed = ["code", "state", "error"];
   const qs = new URLSearchParams();

--- a/dashboard/src/app/api/connections/slack/callback/route.ts
+++ b/dashboard/src/app/api/connections/slack/callback/route.ts
@@ -1,9 +1,14 @@
 import { bridgeFetch } from "@/lib/bridge";
+import { requireCallbackSession } from "../../requireSession";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
 export async function GET(req: Request): Promise<Response> {
+  // LOW #39: verify active dashboard session before forwarding OAuth code.
+  const authErr = await requireCallbackSession(req);
+  if (authErr) return authErr;
+
   const url = new URL(req.url);
   const allowed = ["code", "state", "error"];
   const qs = new URLSearchParams();

--- a/dashboard/src/app/api/login/__tests__/csrf.test.ts
+++ b/dashboard/src/app/api/login/__tests__/csrf.test.ts
@@ -1,0 +1,105 @@
+/** @vitest-environment node */
+/**
+ * LOW #37 — POST /api/login CSRF guard
+ *
+ * A cross-origin page can POST a form with Content-Type
+ * application/x-www-form-urlencoded (browsers allow it in cross-origin forms).
+ * The endpoint must reject requests that don't originate from the same site.
+ * The fix uses requireSameOrigin() which checks sec-fetch-site.
+ */
+
+import { NextRequest } from "next/server";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { POST } from "@/app/api/login/route";
+import { _resetForTests } from "@/lib/authRateLimit";
+
+const PASSWORD = "test-pass-csrf";
+const SECRET = "deadbeefdeadbeefdeadbeefdeadbeef";
+
+const ENV_KEYS = [
+  "DASHBOARD_PASSWORD",
+  "DASHBOARD_SESSION_SECRET",
+  "BRIDGE_TRUST_PROXY",
+] as const;
+
+let originalEnv: Record<string, string | undefined>;
+
+beforeEach(() => {
+  originalEnv = Object.fromEntries(ENV_KEYS.map((k) => [k, process.env[k]]));
+  process.env.DASHBOARD_PASSWORD = PASSWORD;
+  process.env.DASHBOARD_SESSION_SECRET = SECRET;
+  delete process.env.BRIDGE_TRUST_PROXY;
+  _resetForTests();
+});
+
+afterEach(() => {
+  for (const k of ENV_KEYS) {
+    if (originalEnv[k] === undefined) delete process.env[k];
+    else process.env[k] = originalEnv[k];
+  }
+  _resetForTests();
+});
+
+describe("POST /api/login — CSRF guard (LOW #37)", () => {
+  it("rejects a cross-origin form POST (sec-fetch-site: cross-site) with 403", async () => {
+    // A cross-origin page can submit application/x-www-form-urlencoded forms —
+    // this must be blocked before the password is even checked.
+    const formBody = `password=${encodeURIComponent(PASSWORD)}`;
+    const r = await POST(
+      new NextRequest("http://localhost:3200/api/login", {
+        method: "POST",
+        headers: {
+          "content-type": "application/x-www-form-urlencoded",
+          "sec-fetch-site": "cross-site",
+        },
+        body: formBody,
+      }),
+    );
+    expect(r.status).toBe(403);
+  });
+
+  it("rejects a cross-origin JSON POST (sec-fetch-site: cross-site) with 403", async () => {
+    // Even a CORS-preflight-gated JSON POST from cross-site must be blocked.
+    const r = await POST(
+      new NextRequest("http://localhost:3200/api/login", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "sec-fetch-site": "cross-site",
+        },
+        body: JSON.stringify({ password: PASSWORD }),
+      }),
+    );
+    expect(r.status).toBe(403);
+  });
+
+  it("allows a same-origin POST (sec-fetch-site: same-origin)", async () => {
+    const r = await POST(
+      new NextRequest("http://localhost:3200/api/login", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "sec-fetch-site": "same-origin",
+        },
+        body: JSON.stringify({ password: PASSWORD }),
+      }),
+    );
+    expect(r.status).toBe(200);
+  });
+
+  it("allows a direct navigation POST (sec-fetch-site: none)", async () => {
+    // sec-fetch-site: none means direct navigation (no cross-origin involved)
+    const r = await POST(
+      new NextRequest("http://localhost:3200/api/login", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "sec-fetch-site": "none",
+        },
+        body: JSON.stringify({ password: PASSWORD }),
+      }),
+    );
+    expect(r.status).toBe(200);
+  });
+});

--- a/dashboard/src/app/api/login/__tests__/route.test.ts
+++ b/dashboard/src/app/api/login/__tests__/route.test.ts
@@ -47,7 +47,8 @@ afterEach(() => {
 function req(body: unknown, headers: Record<string, string> = {}): NextRequest {
   return new NextRequest("http://localhost:3200/api/login", {
     method: "POST",
-    headers: { "content-type": "application/json", ...headers },
+    // sec-fetch-site: same-origin passes the CSRF guard (LOW #37 fix).
+    headers: { "content-type": "application/json", "sec-fetch-site": "same-origin", ...headers },
     body: JSON.stringify(body),
   });
 }

--- a/dashboard/src/app/api/login/route.ts
+++ b/dashboard/src/app/api/login/route.ts
@@ -8,6 +8,7 @@ import {
   recordSuccess,
 } from "@/lib/authRateLimit";
 import { clientKey } from "@/lib/clientIp";
+import { requireSameOrigin } from "@/lib/csrf";
 import {
   DASHBOARD_API_BODY_CAPS,
   bodyTooLargeResponse,
@@ -39,6 +40,12 @@ function isSafeRedirect(next: unknown): next is string {
 }
 
 export async function POST(req: NextRequest) {
+  // LOW #37: CSRF guard — reject cross-origin form submissions.
+  // sec-fetch-site header is browser-enforced (cannot be set by page JS);
+  // falls back to Origin/Host equality check when the header is absent.
+  const csrfErr = requireSameOrigin(req);
+  if (csrfErr) return csrfErr;
+
   const expected = process.env.DASHBOARD_PASSWORD ?? "";
   const secret = process.env.DASHBOARD_SESSION_SECRET ?? "";
   if (!expected || !secret) {

--- a/dashboard/src/app/approvals/[callId]/page.tsx
+++ b/dashboard/src/app/approvals/[callId]/page.tsx
@@ -6,6 +6,7 @@ import { apiPath } from '@/lib/api';
 import { BackLink, RelationStrip } from "@/components/patchwork";
 import { relTime } from "@/components/time";
 import { useBridgeFetch } from "@/hooks/useBridgeFetch";
+import { syntaxHighlightJson } from "@/lib/syntaxHighlight";
 
 interface RiskSignal {
   kind: string;
@@ -611,27 +612,4 @@ function tierClass(t: string): string {
   return t === "high" ? "err" : t === "medium" ? "warn" : "ok";
 }
 
-/** Tokenise a JSON string into HTML spans with colour classes.
- *  Runs only in-browser on human-reviewed agent params — no XSS risk
- *  beyond what JSON.stringify already guarantees (no raw HTML in values).
- *  We escape angle brackets just in case. */
-function syntaxHighlightJson(json: string): string {
-  return json
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(
-      /("(\\u[a-zA-Z0-9]{4}|\\[^u]|[^\\"])*"(\s*:)?|\b(true|false|null)\b|-?\d+(?:\.\d*)?(?:[eE][+-]?\d+)?)/g,
-      (match) => {
-        if (/^"/.test(match)) {
-          if (/:$/.test(match)) {
-            return `<span class="json-key">${match}</span>`;
-          }
-          return `<span class="json-str">${match}</span>`;
-        }
-        if (/true|false/.test(match)) return `<span class="json-bool">${match}</span>`;
-        if (/null/.test(match)) return `<span class="json-null">${match}</span>`;
-        return `<span class="json-num">${match}</span>`;
-      },
-    );
-}
+// syntaxHighlightJson imported from @/lib/syntaxHighlight (shared with approvals list page)

--- a/dashboard/src/app/approvals/page.tsx
+++ b/dashboard/src/app/approvals/page.tsx
@@ -11,6 +11,7 @@ import { useToast } from "@/components/Toast";
 import { CountdownTimer } from "./_components/CountdownTimer";
 import { Spinner } from "./_components/Spinner";
 import { RiskMeter } from "./_components/RiskMeter";
+import { syntaxHighlightJson } from "@/lib/syntaxHighlight";
 
 interface RiskSignal {
   kind: "destructive_flag" | "domain_reputation" | "path_escape" | "chaining";
@@ -368,9 +369,15 @@ const ApprovalCard = memo(function ApprovalCard({
               >
                 {paramsCopied ? "✓ Copied" : "Copy JSON"}
               </button>
-              <pre className="approval-params-json">
-                {safeStringify(p.params)}
-              </pre>
+              <pre
+                className="approval-params-json"
+                // LOW #42: use syntaxHighlightJson (same as detail page) for
+                // consistent rendering and HTML-safe output.
+                // eslint-disable-next-line react/no-danger
+                dangerouslySetInnerHTML={{
+                  __html: syntaxHighlightJson(safeStringify(p.params)),
+                }}
+              />
             </div>
           )}
         </div>

--- a/dashboard/src/components/ActivityTicker.tsx
+++ b/dashboard/src/components/ActivityTicker.tsx
@@ -97,7 +97,12 @@ const TONE_COLORS: Record<"ok" | "err" | "muted", string> = {
 export function ActivityTicker() {
   const [events, setEvents] = useState<TickerEvent[]>([]);
   const [dismissed, setDismissed] = useState(false);
-  const lastIdRef = useRef<number | undefined>(undefined);
+  // LOW #44: replace lastIdRef (single value) with a bounded Set so
+  // non-adjacent duplicates (id:5, id:6, id:5) are also deduplicated.
+  // Oldest ID is evicted once the set exceeds MAX_DEDUP_IDS entries.
+  const MAX_DEDUP_IDS = 50;
+  const seenIdsRef = useRef<Set<number>>(new Set());
+  const seenIdsOrderRef = useRef<number[]>([]);
 
   useEffect(() => {
     setDismissed(readDismissed());
@@ -106,10 +111,18 @@ export function ActivityTicker() {
   const onEvent = useCallback((_type: string, data: unknown) => {
     if (!data || typeof data !== "object") return;
     const e = data as TickerEvent;
-    // Dedup by id (the bridge emits monotonic IDs); ignore the rare
-    // case where the SSE replay sends an event we already have.
-    if (e.id !== undefined && lastIdRef.current === e.id) return;
-    if (e.id !== undefined) lastIdRef.current = e.id;
+    // Dedup by id using a bounded Set — catches both adjacent and non-adjacent
+    // duplicates (e.g. SSE replay of an ID we already showed).
+    if (e.id !== undefined) {
+      if (seenIdsRef.current.has(e.id)) return;
+      seenIdsRef.current.add(e.id);
+      seenIdsOrderRef.current.push(e.id);
+      // Evict oldest when window exceeds cap.
+      if (seenIdsOrderRef.current.length > MAX_DEDUP_IDS) {
+        const evicted = seenIdsOrderRef.current.shift();
+        if (evicted !== undefined) seenIdsRef.current.delete(evicted);
+      }
+    }
     setEvents((prev) => {
       const next: TickerEvent[] = [e, ...prev];
       // Keep a small window — older events leave the ticker quickly.

--- a/dashboard/src/components/__tests__/ActivityTicker.test.tsx
+++ b/dashboard/src/components/__tests__/ActivityTicker.test.tsx
@@ -129,4 +129,58 @@ describe("<ActivityTicker/>", () => {
     const { container: c2 } = render(<ActivityTicker />);
     expect(c2.firstChild).toBeNull();
   });
+
+  // LOW #44 — dedup set tests
+  it("deduplicates adjacent events with the same id", async () => {
+    const { container } = render(<ActivityTicker />);
+    const es = MockEventSource.instances[0]!;
+    await act(async () => {
+      es.emit({ kind: "tool", tool: "Bash", status: "success", id: 10 });
+      es.emit({ kind: "tool", tool: "Bash", status: "success", id: 10 }); // duplicate
+    });
+    // Should only appear once in the visible list
+    const items = container.querySelectorAll("li");
+    expect(items.length).toBe(1);
+  });
+
+  it("deduplicates non-adjacent events with the same id (LOW #44)", async () => {
+    // Non-adjacent duplicate — the old lastIdRef approach only caught adjacent
+    // duplicates (id5, id5) but missed (id5, id6, id5).
+    const { container } = render(<ActivityTicker />);
+    const es = MockEventSource.instances[0]!;
+    await act(async () => {
+      es.emit({ kind: "tool", tool: "First",  status: "success", id: 5 });
+      es.emit({ kind: "tool", tool: "Second", status: "success", id: 6 });
+      es.emit({ kind: "tool", tool: "First",  status: "success", id: 5 }); // duplicate of id:5
+    });
+    // Only 2 unique events (id:5 and id:6), not 3.
+    const items = container.querySelectorAll("li");
+    // With MAX_VISIBLE=3, all unique events show; but id:5 must appear only once.
+    const texts = Array.from(items).map((li) => li.textContent ?? "");
+    const firstCount = texts.filter((t) => /^First/.test(t)).length;
+    expect(firstCount).toBe(1);
+    expect(items.length).toBe(2);
+  });
+
+  it("allows the same id to be re-shown after the dedup window (set > 50) is evicted", async () => {
+    // Emit 51 distinct events to push id:1 out of the 50-slot window,
+    // then re-emit id:1 — it should reappear.
+    const { container } = render(<ActivityTicker />);
+    const es = MockEventSource.instances[0]!;
+    await act(async () => {
+      // First emit: id 1
+      es.emit({ kind: "tool", tool: "Original", status: "success", id: 1 });
+      // Flood with 50 more distinct ids to evict id:1 from the window
+      for (let i = 2; i <= 51; i++) {
+        es.emit({ kind: "tool", tool: `T${i}`, status: "success", id: i });
+      }
+      // Re-emit id:1 — should now be accepted (evicted from window)
+      es.emit({ kind: "tool", tool: "Reappeared", status: "success", id: 1 });
+    });
+    // The ticker shows MAX_VISIBLE=3 most recent. The last event re-emitted
+    // id:1 ("Reappeared"), so it should be in the visible list.
+    const items = container.querySelectorAll("li");
+    const texts = Array.from(items).map((li) => li.textContent ?? "");
+    expect(texts[0]).toMatch(/^Reappeared/);
+  });
 });

--- a/dashboard/src/lib/__tests__/syntaxHighlight.test.ts
+++ b/dashboard/src/lib/__tests__/syntaxHighlight.test.ts
@@ -1,0 +1,64 @@
+/**
+ * LOW #42 — syntaxHighlightJson shared utility
+ *
+ * The function must:
+ *  1. HTML-escape angle brackets, ampersands (XSS-safe).
+ *  2. Wrap JSON tokens in spans for syntax highlighting.
+ *  3. Be importable from @/lib/syntaxHighlight (shared between both
+ *     approvals pages).
+ */
+
+import { describe, expect, it } from "vitest";
+import { syntaxHighlightJson } from "@/lib/syntaxHighlight";
+
+describe("syntaxHighlightJson (LOW #42)", () => {
+  it("is importable from @/lib/syntaxHighlight", () => {
+    // This will fail until the file exists.
+    expect(typeof syntaxHighlightJson).toBe("function");
+  });
+
+  it("HTML-escapes < and > in string values (XSS guard)", () => {
+    const json = JSON.stringify({ x: "<script>alert(1)</script>" }, null, 2);
+    const result = syntaxHighlightJson(json);
+    expect(result).not.toContain("<script>");
+    expect(result).not.toContain("</script>");
+    expect(result).toContain("&lt;script&gt;");
+  });
+
+  it("HTML-escapes & in string values", () => {
+    const json = JSON.stringify({ q: "a&b" }, null, 2);
+    const result = syntaxHighlightJson(json);
+    expect(result).not.toContain('"a&b"');
+    expect(result).toContain("&amp;");
+  });
+
+  it("wraps string values in json-str spans", () => {
+    const json = JSON.stringify({ name: "hello" }, null, 2);
+    const result = syntaxHighlightJson(json);
+    expect(result).toContain('<span class="json-str">');
+  });
+
+  it("wraps object keys in json-key spans", () => {
+    const json = JSON.stringify({ myKey: 1 }, null, 2);
+    const result = syntaxHighlightJson(json);
+    expect(result).toContain('<span class="json-key">');
+  });
+
+  it("wraps numbers in json-num spans", () => {
+    const json = JSON.stringify({ n: 42 }, null, 2);
+    const result = syntaxHighlightJson(json);
+    expect(result).toContain('<span class="json-num">');
+  });
+
+  it("wraps booleans in json-bool spans", () => {
+    const json = JSON.stringify({ flag: true }, null, 2);
+    const result = syntaxHighlightJson(json);
+    expect(result).toContain('<span class="json-bool">');
+  });
+
+  it("wraps null in json-null spans", () => {
+    const json = JSON.stringify({ x: null }, null, 2);
+    const result = syntaxHighlightJson(json);
+    expect(result).toContain('<span class="json-null">');
+  });
+});

--- a/dashboard/src/lib/syntaxHighlight.ts
+++ b/dashboard/src/lib/syntaxHighlight.ts
@@ -1,0 +1,31 @@
+/**
+ * Shared JSON syntax highlighter for the approvals UI.
+ *
+ * Tokenises a JSON string into HTML spans with colour classes, HTML-escaping
+ * angle brackets and ampersands first (XSS guard). Moved here from
+ * `app/approvals/[callId]/page.tsx` so both the list page and the detail page
+ * can share the same implementation (LOW #42).
+ *
+ * Usage:
+ *   <pre dangerouslySetInnerHTML={{ __html: syntaxHighlightJson(json) }} />
+ */
+export function syntaxHighlightJson(json: string): string {
+  return json
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(
+      /("(\\u[a-zA-Z0-9]{4}|\\[^u]|[^\\"])*"(\s*:)?|\b(true|false|null)\b|-?\d+(?:\.\d*)?(?:[eE][+-]?\d+)?)/g,
+      (match) => {
+        if (/^"/.test(match)) {
+          if (/:$/.test(match)) {
+            return `<span class="json-key">${match}</span>`;
+          }
+          return `<span class="json-str">${match}</span>`;
+        }
+        if (/true|false/.test(match)) return `<span class="json-bool">${match}</span>`;
+        if (/null/.test(match)) return `<span class="json-null">${match}</span>`;
+        return `<span class="json-num">${match}</span>`;
+      },
+    );
+}


### PR DESCRIPTION
## Summary

Fixes 4 LOW-priority security/UI audit findings from 2026-06-03 — all in the dashboard.

- **LOW #37** (`dashboard/src/app/api/login/route.ts`): No CSRF guard on `POST /api/login`. Added `requireSameOrigin(req)` using the existing `/lib/csrf.ts` helper. Blocks cross-site form POSTs via `sec-fetch-site: cross-site`; falls back to Origin/Host equality check.

- **LOW #39** (10 OAuth callback routes): Callback routes were middleware-exempt and forwarded `code`/`state`/`error` to the bridge without verifying an active session. Created shared `requireCallbackSession()` helper that checks the `patchwork_session` cookie. Applied to all 10 connectors (github, slack, gmail, google-calendar, google-drive, asana, discord, gitlab, linear, sentry). Bypassed when `DASHBOARD_ALLOW_UNAUTHENTICATED=1`.

- **LOW #42** (`dashboard/src/app/approvals/page.tsx`): The approvals list rendered `params` as plain text — a UX inconsistency with the detail page and an XSS risk for params containing HTML. Extracted `syntaxHighlightJson` to `dashboard/src/lib/syntaxHighlight.ts` and applied it to both pages.

- **LOW #44** (`dashboard/src/components/ActivityTicker.tsx`): Dedup tracked only the most-recently-seen ID (`lastIdRef`). Non-adjacent duplicates (id:5, id:6, id:5) weren't caught. Replaced with a `Set` of up to 50 recently-seen IDs with LRU eviction.

## Test plan

- [ ] `dashboard/src/app/api/login/__tests__/csrf.test.ts` — 4 tests: cross-site form/JSON → 403, same-origin → 200
- [ ] `dashboard/src/app/api/connections/__tests__/session-guard.test.ts` — 2 tests: no/invalid cookie → 401
- [ ] `dashboard/src/lib/__tests__/syntaxHighlight.test.ts` — 8 tests: HTML escaping, span wrapping
- [ ] `dashboard/src/__tests__/ActivityTicker.test.tsx` — 3 new tests: adjacent dedup, non-adjacent dedup, window eviction
- [ ] Full dashboard suite: 850 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)