### PR TITLE
fix(audit-low): McpClient cache, mcpOAuth TTL, OpenAI chunk cap, severity type, gitBlame bound, connector-requests (LOW #11 #12 #19 #24 #28 #38)

### DIFF
--- a/dashboard/src/app/api/connector-requests/__tests__/route.test.ts
+++ b/dashboard/src/app/api/connector-requests/__tests__/route.test.ts
@@ -228,4 +228,33 @@ describe("POST /api/connector-requests — persistence", () => {
     writeSpy.mockRestore();
     errSpy.mockRestore();
   });
+
+  // LOW #38 — within-process concurrent writes must both land (no lost update)
+  it("two concurrent POSTs both persist their entries (in-process write serialization)", async () => {
+    // Before the fix: two concurrent POSTs could both read the empty array,
+    // each push their entry, each write — last writer wins and one entry is lost.
+    // After the fix: the promise-chain serializes writes so both entries land.
+    //
+    // Note: the module-level writeChain only covers a single Node.js process.
+    // A multi-worker deployment would need an external lock. This test documents
+    // and verifies the in-process case.
+    const [res1, res2] = await Promise.all([
+      POST(makeReq({ name: "Connector-A" })),
+      POST(makeReq({ name: "Connector-B" })),
+    ]);
+
+    expect(res1.status).toBe(200);
+    expect(res2.status).toBe(200);
+
+    // Both entries must be present — no silent last-writer-wins data loss.
+    const persisted = JSON.parse(fs.readFileSync(storeFile, "utf8")) as {
+      name: string;
+    }[];
+    const names = persisted.map((r) => r.name).sort();
+    // With the bug (no serialization): only one entry would survive.
+    // With the fix: both entries survive.
+    expect(names).toContain("Connector-A");
+    expect(names).toContain("Connector-B");
+    expect(persisted).toHaveLength(2);
+  });
 });

--- a/src/automation.ts
+++ b/src/automation.ts
@@ -49,8 +49,16 @@ const DEFAULT_AUTOMATION_SYSTEM_PROMPT =
 export interface AutomationCondition {
   /** Only fire if the active file's diagnostic count meets this threshold. */
   minDiagnosticCount?: number;
-  /** Only fire if the active file has a diagnostic of at least this severity. */
-  diagnosticsMinSeverity?: "error" | "warning";
+  /**
+   * Only fire if the active file has a diagnostic of at least this severity.
+   *
+   * LOW #24 audit 2026-06-03: broadened from "error" | "warning" to include
+   * "info" and "hint" to match the runtime evaluator (severityToNumber in
+   * automationInterpreter.ts) which already handles all four values.
+   * Previously the TypeScript type was narrower than what the runtime accepts,
+   * causing a compile-time error when users set "info" or "hint".
+   */
+  diagnosticsMinSeverity?: "error" | "warning" | "info" | "hint";
   /** Only fire if the last test run for any runner had this outcome. */
   testRunnerLastStatus?: "passed" | "failed" | "any";
 }

--- a/src/connectors/__tests__/mcpClient.test.ts
+++ b/src/connectors/__tests__/mcpClient.test.ts
@@ -33,7 +33,7 @@ describe("McpClient instance-level cache isolation (LOW #11)", () => {
     // result instead of making its own network call.
     let fetchCallCount = 0;
 
-    function makeSuccessResponse(id: number, value: string): Response {
+    function makeSuccessResponse(id: number, _value: string): Response {
       return new Response(
         JSON.stringify({
           jsonrpc: "2.0",

--- a/src/connectors/__tests__/mcpClient.test.ts
+++ b/src/connectors/__tests__/mcpClient.test.ts
@@ -12,12 +12,105 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { McpClient } from "../mcpClient.js";
 
+// ── LOW #11 — module-level cache shared across instances ──────────────────────
+
 function jsonRpcResponse(id: number, result: unknown): Response {
   return new Response(JSON.stringify({ jsonrpc: "2.0", id, result }), {
     status: 200,
     headers: { "Content-Type": "application/json" },
   });
 }
+
+describe("McpClient instance-level cache isolation (LOW #11)", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("two instances with the same cacheKey do not share cached results", async () => {
+    // Both clients call the same tool with the same cacheKey. Before the fix
+    // the module-level cache meant instanceB would return instanceA's cached
+    // result instead of making its own network call.
+    let fetchCallCount = 0;
+
+    function makeSuccessResponse(id: number, value: string): Response {
+      return new Response(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id,
+          result: { tools: [] },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    }
+
+    function makeToolResponse(id: number, text: string): Response {
+      return new Response(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id,
+          result: {
+            content: [{ type: "text", text }],
+            isError: false,
+          },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    }
+
+    const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
+      const body = JSON.parse((init?.body as string) ?? "{}") as {
+        method?: string;
+        id?: number;
+      };
+      fetchCallCount += 1;
+      if (body.method === "initialize")
+        return makeSuccessResponse(body.id ?? 0, "init");
+      if (body.method === "notifications/initialized")
+        return new Response("", { status: 202 });
+      if (body.method === "tools/call") {
+        // Return different payloads depending on call order so we can detect
+        // if the second client got the first client's cached response.
+        const responseText =
+          fetchCallCount <= 3 ? "result-from-client-A" : "result-from-client-B";
+        return makeToolResponse(body.id ?? 0, responseText);
+      }
+      return makeSuccessResponse(body.id ?? 0, "ok");
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const clientA = new McpClient(
+      "https://mcp.test/mcp",
+      async () => "token-a",
+    );
+    const clientB = new McpClient(
+      "https://mcp.test/mcp",
+      async () => "token-b",
+    );
+
+    const CACHE_KEY = "shared-cache-key";
+    const resultA = await clientA.callTool(
+      "myTool",
+      {},
+      { cacheKey: CACHE_KEY, cacheTtlMs: 60_000 },
+    );
+    const resultB = await clientB.callTool(
+      "myTool",
+      {},
+      { cacheKey: CACHE_KEY, cacheTtlMs: 60_000 },
+    );
+
+    // After the fix each instance has its own cache so both make network calls
+    // and resultB carries the second response, not the first client's cached value.
+    const textA = resultA.content.find((c) => c.type === "text")?.text;
+    const textB = resultB.content.find((c) => c.type === "text")?.text;
+
+    // With the module-level cache (bug), clientB would return "result-from-client-A".
+    // With per-instance cache (fix), clientB makes its own call and gets a different value.
+    expect(textA).toBe("result-from-client-A");
+    expect(textB).not.toBe("result-from-client-A");
+  });
+});
 
 describe("McpClient 401 refresh + retry", () => {
   afterEach(() => {

--- a/src/connectors/__tests__/mcpOAuth-hardening.test.ts
+++ b/src/connectors/__tests__/mcpOAuth-hardening.test.ts
@@ -18,6 +18,9 @@ import os from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+// LOW #12 — completeAuthorize must reject expired state even when gcPending
+// ran just before the state was created (tight timing window bypasses GC)
+
 describe("mcpOAuth hardening", () => {
   const tmpDir = join(
     os.tmpdir(),
@@ -224,5 +227,82 @@ describe("mcpOAuth hardening", () => {
     const body = new URLSearchParams(String(init.body));
     expect(body.get("token")).toBe("only-access-token");
     expect(body.get("token_type_hint")).toBe(null);
+  });
+});
+
+// ── LOW #12 — completeAuthorize TTL re-check after deletion ──────────────────
+
+describe("completeAuthorize TTL re-validation (LOW #12)", () => {
+  const tmpDir = join(os.tmpdir(), `patchwork-mcp-oauth-ttl-${Date.now()}`);
+  const homeDir = join(tmpDir, "home");
+  const patchworkHome = join(homeDir, ".patchwork");
+  const tokensDir = join(patchworkHome, "tokens");
+
+  beforeEach(() => {
+    process.env.HOME = homeDir;
+    process.env.USERPROFILE = homeDir;
+    process.env.PATCHWORK_HOME = patchworkHome;
+    process.env.PATCHWORK_TOKEN_STORAGE_BACKEND = "file";
+    mkdirSync(tokensDir, { recursive: true });
+    vi.resetModules();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    delete process.env.HOME;
+    delete process.env.USERPROFILE;
+    delete process.env.PATCHWORK_HOME;
+    delete process.env.PATCHWORK_TOKEN_STORAGE_BACKEND;
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    if (existsSync(tmpDir)) {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects completeAuthorize when the state TTL has elapsed exactly (borderline expiresAt === now)", async () => {
+    // The bug: gcPending() uses strict `<` so an entry at expiresAt === now is
+    // NOT removed by GC, but it IS expired. completeAuthorize must re-check
+    // expiry on the retrieved value so the borderline case is always rejected.
+    //
+    // Mock fetch so startAuthorize (dyn-reg) succeeds and the token exchange
+    // would succeed if expiry were not checked after GC.
+    const dynRegResponse = new Response(
+      JSON.stringify({ client_id: "dyn-client-id" }),
+      { status: 201, headers: { "Content-Type": "application/json" } },
+    );
+    const tokenResponse = new Response(
+      JSON.stringify({ access_token: "access", expires_in: 3600 }),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    );
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValueOnce(dynRegResponse)
+        .mockResolvedValueOnce(tokenResponse),
+    );
+
+    const { startAuthorize, completeAuthorize, vendorConfig } = await import(
+      "../mcpOAuth.js"
+    );
+    const config = vendorConfig("linear");
+
+    // Record the time BEFORE startAuthorize; the state will have expiresAt ~= now + 10min
+    const { state } = await startAuthorize(config);
+
+    // Advance time to EXACTLY the TTL boundary (10 minutes). At this point
+    // gcPending uses `v.expiresAt < now` which evaluates to `false` (equal, not
+    // less-than), so the entry is NOT removed by GC. Without the post-delete
+    // re-check, completeAuthorize would proceed with the expired state.
+    vi.advanceTimersByTime(10 * 60 * 1000);
+
+    // The fix: after pending.delete(state), verify p.expiresAt <= Date.now().
+    // Without the fix this call succeeds (bug) because gcPending skips the
+    // borderline entry and no second TTL check exists.
+    await expect(
+      completeAuthorize(config, "auth-code-xyz", state),
+    ).rejects.toThrow(/invalid or expired state/);
   });
 });

--- a/src/connectors/mcpClient.ts
+++ b/src/connectors/mcpClient.ts
@@ -41,26 +41,16 @@ interface CacheEntry {
   expiresAt: number;
 }
 
-const cache = new Map<string, CacheEntry>();
-
 const DEFAULT_TIMEOUT = 15_000;
 
-function getCached(key: string): McpToolResult | null {
-  const e = cache.get(key);
-  if (!e) return null;
-  if (Date.now() > e.expiresAt) {
-    cache.delete(key);
-    return null;
-  }
-  return e.value;
-}
-
-function setCached(key: string, value: McpToolResult, ttlMs: number): void {
-  cache.set(key, { value, expiresAt: Date.now() + ttlMs });
-}
-
+/**
+ * No-op kept for backwards-compat — cache is now per-instance so there is no
+ * global map to clear. Call `client.clearCache()` on a specific instance if
+ * needed, or simply discard the instance.
+ * @deprecated Use McpClient#clearCache() on the specific instance.
+ */
 export function clearMcpCache(): void {
-  cache.clear();
+  // no-op — cache moved to McpClient instances (LOW #11 audit 2026-06-03)
 }
 
 /**
@@ -104,11 +94,36 @@ export class McpClient {
   private sessionId: string | null = null;
   private initialized = false;
   private nextId = 1;
+  /**
+   * Per-instance result cache. Moved from module level (LOW #11 audit 2026-06-03):
+   * a shared module-level cache meant two clients with different credentials but
+   * the same cacheKey would return each other's results.
+   */
+  private readonly _cache = new Map<string, CacheEntry>();
 
   constructor(
     private readonly endpoint: string,
     private readonly getAccessToken: () => Promise<string>,
   ) {}
+
+  private _getCached(key: string): McpToolResult | null {
+    const e = this._cache.get(key);
+    if (!e) return null;
+    if (Date.now() > e.expiresAt) {
+      this._cache.delete(key);
+      return null;
+    }
+    return e.value;
+  }
+
+  private _setCached(key: string, value: McpToolResult, ttlMs: number): void {
+    this._cache.set(key, { value, expiresAt: Date.now() + ttlMs });
+  }
+
+  /** Clear this instance's result cache. */
+  clearCache(): void {
+    this._cache.clear();
+  }
 
   private async post(
     body: unknown,
@@ -216,7 +231,7 @@ export class McpClient {
     opts: McpCallOptions = {},
   ): Promise<McpToolResult> {
     if (opts.cacheKey) {
-      const hit = getCached(opts.cacheKey);
+      const hit = this._getCached(opts.cacheKey);
       if (hit) return hit;
     }
     await this.ensureInitialized(opts);
@@ -242,7 +257,7 @@ export class McpClient {
       throw new Error(`MCP tool ${name} returned error: ${msg || "unknown"}`);
     }
     if (opts.cacheKey && opts.cacheTtlMs) {
-      setCached(opts.cacheKey, result, opts.cacheTtlMs);
+      this._setCached(opts.cacheKey, result, opts.cacheTtlMs);
     }
     return result;
   }

--- a/src/connectors/mcpOAuth.ts
+++ b/src/connectors/mcpOAuth.ts
@@ -407,7 +407,13 @@ export async function completeAuthorize(
   gcPending();
   const p = pending.get(state);
   if (!p) throw new Error(`${config.vendor}: invalid or expired state`);
+  // Delete BEFORE checking TTL: consume-then-validate so a concurrent call
+  // with the same state always fails even if timing allows both to pass gcPending.
+  // LOW #12 audit 2026-06-03: gcPending uses strict `<` so an entry at exactly
+  // expiresAt === now is NOT removed by GC. Re-check here for defence-in-depth.
   pending.delete(state);
+  if (Date.now() >= p.expiresAt)
+    throw new Error(`${config.vendor}: invalid or expired state`);
   if (p.vendor !== config.vendor)
     throw new Error(`${config.vendor}: vendor mismatch on state`);
 

--- a/src/drivers/__tests__/openai.test.ts
+++ b/src/drivers/__tests__/openai.test.ts
@@ -58,6 +58,45 @@ function makeStreamWithUsage(
   };
 }
 
+// ── LOW #19 — onChunk streaming must not exceed result.text bytes ──────────────
+describe("OpenAIApiDriver onChunk/result.text byte-cap consistency (LOW #19)", () => {
+  afterEach(() => {
+    mockCreate.mockReset();
+  });
+
+  it("sum of onChunk bytes never exceeds result.text byte length when stream crosses OUTPUT_CAP", async () => {
+    // OUTPUT_CAP is 50 * 1024 bytes. Emit chunks that cross the cap boundary.
+    // The last chunk straddles the cap so onChunk + result.text can diverge.
+    const CAP = 50 * 1024;
+    // Fill almost to the cap with ASCII
+    const bigChunk = "a".repeat(CAP - 10);
+    // This 20-char chunk straddles the cap
+    const bridgeChunk = "b".repeat(20);
+
+    mockCreate.mockResolvedValue(
+      makeStream([bigChunk, bridgeChunk, "extra text after cap"]),
+    );
+    const driver = new OpenAIApiDriver(log);
+    const chunks: string[] = [];
+    const result = await driver.run({
+      prompt: "fill up",
+      workspace: "/tmp",
+      timeoutMs: 5000,
+      signal: AbortSignal.timeout(5000),
+      onChunk: (c) => chunks.push(c),
+    });
+
+    const onChunkTotal = Buffer.byteLength(chunks.join(""), "utf8");
+    const resultBytes = Buffer.byteLength(result.text, "utf8");
+
+    // After fix: onChunk sum === result.text bytes (both capped together).
+    // Before fix: onChunk sum > result.text bytes (full delta passed to onChunk,
+    // then result.text truncated later by truncateUtf8Bytes).
+    expect(onChunkTotal).toBe(resultBytes);
+    expect(resultBytes).toBeLessThanOrEqual(CAP);
+  });
+});
+
 describe("OpenAIApiDriver", () => {
   it("streams chunks and returns concatenated text", async () => {
     mockCreate.mockResolvedValue(makeStream(["Hello", ", ", "world"]));

--- a/src/drivers/openai/index.ts
+++ b/src/drivers/openai/index.ts
@@ -1,4 +1,4 @@
-import { truncateUtf8Bytes } from "../outputCap.js";
+import { truncateToBytes, truncateUtf8Bytes } from "../outputCap.js";
 import type {
   ProviderDriver,
   ProviderTaskInput,
@@ -96,6 +96,7 @@ export class OpenAIApiDriver implements ProviderDriver {
     );
 
     let text = "";
+    let outputBytesSent = 0;
     let firstChunkAt: number | undefined;
     let promptTokens: number | undefined;
     let completionTokens: number | undefined;
@@ -133,14 +134,35 @@ export class OpenAIApiDriver implements ProviderDriver {
         const delta: string = chunk.choices?.[0]?.delta?.content ?? "";
         if (delta) {
           if (firstChunkAt === undefined) firstChunkAt = Date.now();
-          if (text.length < OUTPUT_CAP) {
+          if (outputBytesSent < OUTPUT_CAP) {
             // Cap accumulation in-loop to bound memory under runaway streams
             // (e.g. local LLMs that loop). Once we hit the cap, stop appending
             // and abort the upstream stream so sockets and decoder buffers
-            // are released. onChunk is gated by the same cap so partial
-            // listeners stop receiving deltas.
-            text += delta;
-            input.onChunk?.(delta);
+            // are released.
+            //
+            // LOW #19 audit 2026-06-03: use truncateToBytes so the chunk sent
+            // to onChunk is always the SAME bytes as what lands in result.text.
+            // The previous pattern appended the full `delta` to `text` then
+            // called `onChunk(delta)`, but `truncateUtf8Bytes(text, OUTPUT_CAP)`
+            // at the end could cut the last delta — so onChunk sum > result.text.
+            const remaining = OUTPUT_CAP - outputBytesSent;
+            const { send, bytes } = truncateToBytes(delta, remaining);
+            text += send;
+            outputBytesSent += bytes;
+            if (send) input.onChunk?.(send);
+            if (bytes < Buffer.byteLength(delta, "utf8")) {
+              // We've hit the cap mid-delta — abort the stream.
+              // biome-ignore lint/suspicious/noExplicitAny: stream shape
+              const ctrl = (stream as any).controller;
+              if (ctrl && typeof ctrl.abort === "function") {
+                try {
+                  ctrl.abort();
+                } catch {
+                  /* best effort */
+                }
+              }
+              break;
+            }
           } else {
             // biome-ignore lint/suspicious/noExplicitAny: stream shape
             const ctrl = (stream as any).controller;

--- a/src/fp/__tests__/policyParser.test.ts
+++ b/src/fp/__tests__/policyParser.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import type { AutomationPolicy } from "../../automation.js";
+import type {
+  AutomationCondition,
+  AutomationPolicy,
+} from "../../automation.js";
 import { parsePolicy } from "../policyParser.js";
 
 const INLINE_PROMPT = "check the file {{file}}";
@@ -370,6 +373,57 @@ describe("parsePolicy", () => {
           expect(src.promptName).toBe("project-status");
         }
       }
+    });
+  });
+
+  // ── LOW #24 — diagnosticsMinSeverity type alignment ────────────────────────
+
+  describe("AutomationCondition.diagnosticsMinSeverity (LOW #24)", () => {
+    it("accepts info as diagnosticsMinSeverity in AutomationCondition (type check)", () => {
+      // The bug: AutomationCondition typed only "error" | "warning", but the
+      // runtime evaluator (severityToNumber) handles "info" and "hint" too.
+      // The fix broadens the TypeScript type to "error" | "warning" | "info" | "hint".
+      // This test will fail to COMPILE if the type is still too narrow.
+      const condition: AutomationCondition = {
+        diagnosticsMinSeverity: "info",
+      };
+      // Should not throw — just verifying the type is assignable.
+      expect(condition.diagnosticsMinSeverity).toBe("info");
+    });
+
+    it("accepts hint as diagnosticsMinSeverity in AutomationCondition (type check)", () => {
+      const condition: AutomationCondition = {
+        diagnosticsMinSeverity: "hint",
+      };
+      expect(condition.diagnosticsMinSeverity).toBe("hint");
+    });
+
+    it("parses onFileSave with when.diagnosticsMinSeverity: info into a valid Hook", () => {
+      // Runtime path: when "info" is passed through the policy, the parser
+      // should forward it to the WhenCondition without error.
+      // After the fix AutomationCondition accepts "info" directly (no cast needed).
+      const condition: AutomationCondition = {
+        diagnosticsMinSeverity: "info",
+      };
+      const policy = minPolicy({
+        onFileSave: {
+          enabled: true,
+          patterns: ["**/*.ts"],
+          cooldownMs: 10_000,
+          prompt: "check {{file}}",
+          when: condition,
+        },
+      });
+      const result = parsePolicy(policy);
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      const top = result.value[0];
+      if (!top) throw new Error("expected first node");
+      // Walk to the Hook node to check the WhenCondition was preserved.
+      const hookNode = top._tag === "WithCooldown" ? top.program : undefined;
+      if (!hookNode || hookNode._tag !== "Hook")
+        throw new Error("expected Hook");
+      expect(hookNode.when?.diagnosticsMinSeverity).toBe("info");
     });
   });
 });

--- a/src/tools/__tests__/gitWrite.test.ts
+++ b/src/tools/__tests__/gitWrite.test.ts
@@ -2,7 +2,7 @@ import { execSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { isValidRef } from "../git-utils.js";
 import {
   createGitAddTool,

--- a/src/tools/__tests__/gitWrite.test.ts
+++ b/src/tools/__tests__/gitWrite.test.ts
@@ -2,7 +2,7 @@ import { execSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { isValidRef } from "../git-utils.js";
 import {
   createGitAddTool,
@@ -254,6 +254,36 @@ describe("gitWrite tools", () => {
       const result = await tool.handler({ filePath: "untracked.txt" });
 
       expect(result.isError).toBe(true);
+    });
+
+    it("clamps startLine to MAX_BLAME_LINE (LOW #28 — no unbounded large line numbers)", async () => {
+      // Write a multi-line file so blame has real content to return.
+      fs.writeFileSync(
+        path.join(tmpDir, "multi.txt"),
+        Array.from({ length: 5 }, (_, i) => `line ${i + 1}`).join("\n") + "\n",
+      );
+      execSync("git add multi.txt", { cwd: tmpDir, stdio: "ignore" });
+      execSync('git commit -m "add multi"', { cwd: tmpDir, stdio: "ignore" });
+
+      const tool = createGitBlameTool(tmpDir);
+
+      // Verify that startLine=1, endLine=999_999_999 completes without hanging.
+      // Before the fix: git receives `-L1,999999999` which is unbounded.
+      // After the fix: endLine is clamped to MAX_BLAME_LINE (1_000_000).
+      const result = await tool.handler({
+        filePath: "multi.txt",
+        startLine: 1,
+        endLine: 999_999_999,
+      });
+      expect(result.content.length).toBeGreaterThan(0);
+
+      // Verify startLine=999_999_999 also results in a handled error (not an
+      // unhandled exception). Git will say "file has only 5 lines".
+      const result2 = await tool.handler({
+        filePath: "multi.txt",
+        startLine: 999_999_999,
+      });
+      expect(result2.content.length).toBeGreaterThan(0);
     });
   });
 });

--- a/src/tools/gitWrite.ts
+++ b/src/tools/gitWrite.ts
@@ -441,13 +441,22 @@ export function createGitBlameTool(workspace: string) {
 
       const rawPath = requireString(args, "filePath");
       const filePath = resolveFilePath(rawPath, workspace);
+
+      // LOW #28 audit 2026-06-03: clamp line numbers to a sensible upper bound.
+      // Without this, callers could pass 999_999_999 and git would receive it
+      // verbatim — harmless for small files but wasteful and unvalidated for large
+      // ones. 1_000_000 is larger than any realistic source file.
+      const MAX_BLAME_LINE = 1_000_000;
       const startLine =
         typeof args.startLine === "number"
-          ? Math.max(1, Math.floor(args.startLine))
+          ? Math.min(MAX_BLAME_LINE, Math.max(1, Math.floor(args.startLine)))
           : undefined;
       const endLine =
         typeof args.endLine === "number"
-          ? Math.max(1, Math.floor(args.endLine))
+          ? Math.min(
+              MAX_BLAME_LINE,
+              Math.max(startLine ?? 1, Math.floor(args.endLine)),
+            )
           : undefined;
 
       const blameArgs = ["blame", "--porcelain"];


### PR DESCRIPTION
## Summary

Fixes 6 LOW-priority audit findings from 2026-06-03.

- **LOW #11** (`src/connectors/mcpClient.ts`): Module-level `cache` Map was shared across all `McpClient` instances, risking cross-request result pollution. Moved to per-instance `_cache` property. `clearMcpCache()` deprecated as a no-op.

- **LOW #12** (`src/connectors/mcpOAuth.ts`): `completeAuthorize()` deleted the state before re-checking TTL. A borderline entry at exactly the TTL boundary survived GC but could still slip through. Added post-deletion `Date.now() >= p.expiresAt` check.

- **LOW #19** (`src/drivers/openai/index.ts`): `onChunk` callbacks streamed raw chunk text without the output-byte cap, while `result.text` was capped. Replaced char-count guard with `truncateToBytes()` so both always agree.

- **LOW #24** (`src/automation.ts`): `AutomationCondition.diagnosticsMinSeverity` was typed as `"error" | "warning"` but the runtime table also handles `"info"` and `"hint"`. Broadened the type to match.

- **LOW #28** (`src/tools/gitWrite.ts`): `gitBlame` accepted arbitrarily large line numbers. Added `MAX_BLAME_LINE = 1_000_000` clamp and `endLine >= startLine` enforcement.

- **LOW #38** (`dashboard/src/app/api/connector-requests/route.ts`): The in-process `writeChain` serialization was already present; added a concurrent-write regression test and a comment documenting the cross-process limitation.

## Test plan

- [ ] `src/connectors/__tests__/mcpClient.test.ts` — two instances, same key, independent caches
- [ ] `src/connectors/__tests__/mcpOAuth-hardening.test.ts` — TTL boundary replay rejected
- [ ] `src/drivers/__tests__/openai.test.ts` — onChunk sum == result.text bytes
- [ ] `src/fp/__tests__/policyParser.test.ts` — `"info"` and `"hint"` accepted without type error
- [ ] `src/tools/__tests__/gitWrite.test.ts` — large line number clamped
- [ ] `dashboard/src/app/api/connector-requests/__tests__/route.test.ts` — concurrent writes regression test
- [ ] Bridge suite: 7695/7737 pass; dashboard: 851 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)