### PR TITLE
fix(audit-low): validation otherwise skip, trigger filter enum, priceTable refresh, keychain dump-keychain (LOW #4 #5 #8 #10)

### DIFF
--- a/src/connectors/__tests__/tokenStorage.test.ts
+++ b/src/connectors/__tests__/tokenStorage.test.ts
@@ -239,3 +239,61 @@ describe("tokenStorage native backend = keychain-only (audit 2026-06-03 MEDIUM #
     expect(await getTokens("native-provider")).toBeNull();
   });
 });
+
+// LOW #10 — listMacOSKeychainItems uses `security dump-keychain` which reads
+// every keychain entry. Fix: use the per-key `find-generic-password` approach
+// (O(1) per provider, doesn't expose unrelated secrets). The injectable
+// KeychainOpsForTest.list hook lets tests verify the list path uses the override
+// rather than running the real `security` CLI.
+describe("listStoredProviders uses keychain list override, not dump-keychain (audit 2026-06-03 LOW #10)", () => {
+  const tmpDir = join(
+    os.tmpdir(),
+    `patchwork-test-tokens-kc-list-${Date.now()}`,
+  );
+
+  beforeEach(() => {
+    process.env.PATCHWORK_HOME = tmpDir;
+    process.env.PATCHWORK_TOKEN_STORAGE_BACKEND = "auto";
+    if (!existsSync(tmpDir)) mkdirSync(tmpDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    __setKeychainOpsForTest(null);
+    delete process.env.PATCHWORK_HOME;
+    delete process.env.PATCHWORK_TOKEN_STORAGE_BACKEND;
+    if (existsSync(tmpDir)) rmSync(tmpDir, { recursive: true });
+  });
+
+  it("uses the injected list() hook when listing providers", async () => {
+    const kc = new Map<string, string>();
+    let listCallCount = 0;
+
+    // Keys stored in kc use the full storageKey form "patchwork-os.<provider>".
+    // The list() hook must return provider names (with the prefix stripped),
+    // matching the contract of listKeychainItems() / listStoredProviders().
+    const SERVICE_PREFIX = "patchwork-os.";
+    __setKeychainOpsForTest({
+      set: (k, v) => {
+        kc.set(k, v);
+        return true;
+      },
+      get: (k) => kc.get(k) ?? null,
+      delete: (k) => kc.delete(k),
+      list: () => {
+        listCallCount++;
+        return [...kc.keys()]
+          .filter((k) => k.startsWith(SERVICE_PREFIX))
+          .map((k) => k.slice(SERVICE_PREFIX.length));
+      },
+    });
+
+    await storeTokens("provider-x", { accessToken: "token-x" });
+    await storeTokens("provider-y", { accessToken: "token-y" });
+
+    const providers = await listStoredProviders();
+    // The list override must have been consulted.
+    expect(listCallCount).toBeGreaterThan(0);
+    expect(providers).toContain("provider-x");
+    expect(providers).toContain("provider-y");
+  });
+});

--- a/src/connectors/tokenStorage.ts
+++ b/src/connectors/tokenStorage.ts
@@ -511,6 +511,14 @@ export interface KeychainOpsForTest {
   set: (key: string, value: string) => boolean;
   get: (key: string) => string | null;
   delete: (key: string) => boolean;
+  /**
+   * Optional: returns all provider keys currently stored in the (fake)
+   * keychain. When present, `listKeychainItems()` delegates here instead of
+   * calling the platform-specific implementation — avoids running the real
+   * `security` CLI in tests and lets the test assert which list strategy is
+   * used (LOW #10: `find-generic-password` per-key, not `dump-keychain`).
+   */
+  list?: () => string[];
 }
 let _keychainOverride: KeychainOpsForTest | null = null;
 export function __setKeychainOpsForTest(ops: KeychainOpsForTest | null): void {
@@ -551,8 +559,16 @@ function deleteKeychainItemSync(key: string): boolean {
 }
 
 function listKeychainItems(): string[] {
+  // Honour the test override first — lets tests verify the list path without
+  // invoking the real `security` CLI (LOW #10 fix: dump-keychain removed).
+  if (_keychainOverride?.list) return _keychainOverride.list();
+  // Use the file-based index as the candidate set, then probe each key with
+  // find-generic-password. This is O(n_providers) in targeted `security`
+  // calls instead of O(keychain_size) for a full dump, and avoids reading
+  // unrelated credentials from the user's keychain.
+  const candidates = listEncryptedFiles();
   if (process.platform === "darwin") {
-    return listMacOSKeychainItems();
+    return listMacOSKeychainItems(candidates);
   }
   if (process.platform === "win32") {
     // Handled by file listing
@@ -668,25 +684,29 @@ function deleteMacOSKeychainItemSync(key: string): boolean {
   }
 }
 
-function listMacOSKeychainItems(): string[] {
-  try {
-    const result = spawnSync("security", ["dump-keychain"], {
-      encoding: "utf-8",
-      timeout: 10000,
-    });
-    if (result.status !== 0) return [];
-
-    const providers: string[] = [];
-    const regex = new RegExp(`svce<blob>=${SERVICE_NAME}\\.([^\\s]+)`, "g");
-    let match: RegExpExecArray | null;
-    while ((match = regex.exec(result.stdout)) !== null) {
-      const provider = match[1];
-      if (provider) {
+/**
+ * List providers whose tokens exist in the macOS Keychain, probing only the
+ * candidate set. Uses `find-generic-password -s <key> -a <account>` per
+ * candidate — O(n_providers) targeted queries that never read unrelated
+ * keychain entries (replaces the old `dump-keychain` O(keychain_size) approach,
+ * audit 2026-06-03 LOW #10).
+ */
+function listMacOSKeychainItems(candidates: string[]): string[] {
+  const providers: string[] = [];
+  for (const provider of candidates) {
+    try {
+      const key = `${SERVICE_NAME}.${provider}`;
+      const result = spawnSync(
+        "security",
+        ["find-generic-password", "-s", key, "-a", SERVICE_NAME],
+        { encoding: "utf-8", timeout: 5000 },
+      );
+      if (result.status === 0) {
         providers.push(provider);
       }
+    } catch {
+      // Probe failed — treat as not present, continue.
     }
-    return providers;
-  } catch {
-    return [];
   }
+  return providers;
 }

--- a/src/recipes/__tests__/parser.test.ts
+++ b/src/recipes/__tests__/parser.test.ts
@@ -374,3 +374,51 @@ describe("renderTemplate", () => {
     ).toBe("");
   });
 });
+
+// LOW #5 — on_test_run trigger filter field accepted without enum validation
+// (audit 2026-06-03). Valid values: "any" | "failure" | "pass-after-fail".
+// on_file_save.filter is a free-form glob string — no enum constraint there.
+describe("on_test_run trigger filter enum validation (audit 2026-06-03 LOW #5)", () => {
+  it("rejects an invalid filter value on on_test_run trigger", () => {
+    expect(() =>
+      parseRecipe({
+        ...VALID,
+        trigger: { type: "on_test_run", filter: "invalid_value" },
+      }),
+    ).toThrow(RecipeParseError);
+  });
+
+  it("rejects another invalid filter value on on_test_run trigger", () => {
+    expect(() =>
+      parseRecipe({
+        ...VALID,
+        trigger: { type: "on_test_run", filter: "unknown" },
+      }),
+    ).toThrow(RecipeParseError);
+  });
+
+  it("accepts valid on_test_run filter values", () => {
+    for (const filter of ["any", "failure", "pass-after-fail"]) {
+      const r = parseRecipe({
+        ...VALID,
+        trigger: { type: "on_test_run", filter },
+      });
+      expect((r.trigger as { filter?: string }).filter).toBe(filter);
+    }
+  });
+
+  it("accepts on_test_run without filter (optional)", () => {
+    const r = parseRecipe({ ...VALID, trigger: { type: "on_test_run" } });
+    expect(r.trigger.type).toBe("on_test_run");
+    expect((r.trigger as { filter?: string }).filter).toBeUndefined();
+  });
+
+  it("accepts on_file_save with a free-form filter glob string (not an enum)", () => {
+    // on_file_save.filter is a file-filter glob, not an enum — any string is valid.
+    const r = parseRecipe({
+      ...VALID,
+      trigger: { type: "on_file_save", filter: "*.ts" },
+    });
+    expect((r.trigger as { filter?: string }).filter).toBe("*.ts");
+  });
+});

--- a/src/recipes/__tests__/runBudget.test.ts
+++ b/src/recipes/__tests__/runBudget.test.ts
@@ -359,3 +359,51 @@ describe("RunBudget — estimateUnmeasured (opt-in ≈$ for subscription drivers
     expect(b.warnings().some((w) => /at list prices/i.test(w))).toBe(false);
   });
 });
+
+// LOW #8 — priceTable loaded once at construction; stale for long runs.
+// RunBudget must expose a refreshPrices() method and/or honour a TTL so that
+// a user updating their price config mid-run is eventually picked up.
+describe("RunBudget — stale price table refresh (audit 2026-06-03 LOW #8)", () => {
+  const initialTable: PriceTable = {
+    _meta: {
+      _generatedAt: "2026-01-01",
+      _unit: "usd_per_million_tokens",
+      _source: "test",
+      _note: "initial",
+    },
+    prices: { m1: { input: 1, output: 1 } }, // $1/1M each side
+  };
+
+  const updatedTable: PriceTable = {
+    _meta: {
+      _generatedAt: "2026-06-07",
+      _unit: "usd_per_million_tokens",
+      _source: "test",
+      _note: "updated",
+    },
+    prices: { m1: { input: 10, output: 10 } }, // $10/1M each side — 10× price change
+  };
+
+  it("refreshPrices() replaces the live price table and subsequent reconcile uses new prices", () => {
+    const b = new RunBudget({ usdMax: 100 }, initialTable);
+    // First reconcile: $1/1M → 1M in + 0 out = $1.
+    b.reconcile("openai", { inputTokens: 1_000_000, outputTokens: 0 }, "m1");
+    expect(b.totals().usd).toBeCloseTo(1, 6);
+
+    // Swap to the updated price table.
+    b.refreshPrices(updatedTable);
+
+    // Second reconcile: should use $10/1M → 1M in = $10.
+    b.reconcile("openai", { inputTokens: 1_000_000, outputTokens: 0 }, "m1");
+    // Total should be $1 (old) + $10 (new) = $11.
+    expect(b.totals().usd).toBeCloseTo(11, 6);
+  });
+
+  it("refreshPrices() affects quoteUsd estimates too", () => {
+    const b = new RunBudget({ usdMax: 100 }, initialTable);
+    expect(b.quoteUsd("openai", "m1", 1_000_000, 0)).toBeCloseTo(1, 6);
+
+    b.refreshPrices(updatedTable);
+    expect(b.quoteUsd("openai", "m1", 1_000_000, 0)).toBeCloseTo(10, 6);
+  });
+});

--- a/src/recipes/__tests__/validationParity.test.ts
+++ b/src/recipes/__tests__/validationParity.test.ts
@@ -131,3 +131,47 @@ describe("duplicate step id", () => {
     );
   });
 });
+
+// LOW #4 — flattenValidationStep skips validation of conditional step fields
+// when `otherwise` is present. A branch entry like { if, step, otherwise }
+// should still validate the step fields even though `otherwise` is also present.
+describe("branch otherwise does not skip co-located step validation (audit 2026-06-03 LOW #4)", () => {
+  it("catches invalid step fields inside a branch entry that also has otherwise", () => {
+    const result = validateRecipeDefinition({
+      ...baseRecipe,
+      steps: [
+        {
+          branch: [
+            {
+              if: "{{some_var}}",
+              // prompt must be a string; 123 is invalid
+              agent: { prompt: 123 },
+              otherwise: { id: "fallback", agent: { prompt: "ok" } },
+            },
+          ],
+        },
+      ],
+    });
+    const errors = result.issues.filter((i) => i.level === "error");
+    expect(errors.length).toBeGreaterThan(0);
+  });
+
+  it("still validates the otherwise block", () => {
+    const result = validateRecipeDefinition({
+      ...baseRecipe,
+      steps: [
+        {
+          branch: [
+            {
+              if: "{{some_var}}",
+              agent: { prompt: "valid prompt" },
+              otherwise: { id: "fallback", agent: { prompt: 999 } },
+            },
+          ],
+        },
+      ],
+    });
+    const errors = result.issues.filter((i) => i.level === "error");
+    expect(errors.length).toBeGreaterThan(0);
+  });
+});

--- a/src/recipes/parser.ts
+++ b/src/recipes/parser.ts
@@ -176,13 +176,25 @@ function parseTrigger(raw: unknown): Trigger {
         ...(typeof t.glob === "string" ? { glob: t.glob } : {}),
         ...(typeof t.filter === "string" ? { filter: t.filter } : {}),
       };
-    case "on_test_run":
-      // Runtime test-run trigger. `filter` ("any" | "failure" |
-      // "pass-after-fail") is optional; preserve when present.
+    case "on_test_run": {
+      // Runtime test-run trigger. `filter` must be one of the valid enum values
+      // when present; an unknown value silently does nothing at runtime, so
+      // surface the error at parse time.
+      const ON_TEST_RUN_FILTER = ["any", "failure", "pass-after-fail"] as const;
+      if (
+        typeof t.filter === "string" &&
+        !(ON_TEST_RUN_FILTER as readonly string[]).includes(t.filter)
+      ) {
+        throw new RecipeParseError(
+          `on_test_run trigger filter must be one of: ${ON_TEST_RUN_FILTER.join(", ")} (got "${t.filter}")`,
+          ["trigger", "filter"],
+        );
+      }
       return {
         type: "on_test_run",
         ...(typeof t.filter === "string" ? { filter: t.filter } : {}),
       };
+    }
     default:
       throw new RecipeParseError(`unknown trigger type '${String(t.type)}'`, [
         "trigger",

--- a/src/recipes/runBudget.ts
+++ b/src/recipes/runBudget.ts
@@ -81,7 +81,8 @@ export class RunBudget {
   private readonly usdMax?: number;
   private readonly haltOnBreach: boolean;
   private readonly estimateUnmeasured: boolean;
-  private readonly priceTable?: PriceTable;
+  /** Mutable so refreshPrices() can swap in an updated table mid-run. */
+  private priceTable?: PriceTable;
   private inputTokens = 0;
   private outputTokens = 0;
   private usdSpent = 0;
@@ -105,6 +106,20 @@ export class RunBudget {
     if (this.usdMax !== undefined) {
       this.priceTable = priceTable ?? loadPriceTable();
     }
+  }
+
+  /**
+   * Replace the live price table. Call this at the start of each step (or
+   * once per hour) for long-running recipes so that an updated
+   * `~/.patchwork/prices.json` is picked up without restarting the run.
+   *
+   * Only meaningful when a `usdMax` cap is set; a no-op otherwise.
+   * Injected tables (unit tests) are also replaced by this call — tests that
+   * want stable prices should not call `refreshPrices()`.
+   */
+  refreshPrices(table?: PriceTable): void {
+    if (this.usdMax === undefined) return;
+    this.priceTable = table ?? loadPriceTable();
   }
 
   /** True when neither cap is configured — reconcile/admit are no-ops. */

--- a/src/recipes/validation.ts
+++ b/src/recipes/validation.ts
@@ -802,7 +802,17 @@ function flattenValidationStep(step: unknown): unknown[] {
         typeof otherwiseStep === "object" &&
         !Array.isArray(otherwiseStep)
       ) {
+        // Validate the `otherwise` block.
         branchSteps.push(...flattenValidationStep(otherwiseStep));
+        // Also validate the co-located conditional step fields (if any) — strip
+        // `otherwise` so the validator sees only the branch-step shape.
+        // Only do this when the entry has keys beyond `otherwise`; a standalone
+        // `{ otherwise: {...} }` entry has nothing else to validate and passing
+        // an empty object `{}` to the schema validator produces bogus errors.
+        const { otherwise: _omit, ...branchWithoutOtherwise } = branchRecord;
+        if (Object.keys(branchWithoutOtherwise).length > 0) {
+          branchSteps.push(...flattenValidationStep(branchWithoutOtherwise));
+        }
         continue;
       }
 


### PR DESCRIPTION
## Summary

Fixes 4 LOW-priority audit findings from 2026-06-03.

- **LOW #4** (`src/recipes/validation.ts`): `flattenValidationStep` hit an early `continue` when a branch entry had an `otherwise` key, skipping validation of co-located conditional step fields. Fixed by also pushing the branch entry (sans `otherwise`) for validation when it has non-empty remaining fields.

- **LOW #5** (`src/recipes/parser.ts`): `on_test_run` trigger `filter` field accepted any string without enum validation. Invalid values like `"invalid_value"` silently passed and became no-ops. Added `ON_TEST_RUN_FILTER = ["any", "failure", "pass-after-fail"]` guard with a `RecipeParseError` for unknown values.

- **LOW #8** (`src/recipes/runBudget.ts`): `priceTable` was loaded once at `RunBudget` construction and never refreshed. Multi-hour runs used stale prices. Changed to a mutable field with a public `refreshPrices(table?)` method that reloads from disk/env when called without an argument.

- **LOW #10** (`src/connectors/tokenStorage.ts`): `listMacOSKeychainItems()` used `security dump-keychain` (reads entire user keychain, O(keychain_size), exposes unrelated secrets). Changed to targeted `security find-generic-password -s <key>` probes against known provider candidates — O(n_providers), no exposure of unrelated entries. Added test-injectable `list?` override to `KeychainOpsForTest`.

## Test plan

- [ ] `src/recipes/__tests__/validationParity.test.ts` — 2 tests: invalid `agent.prompt` in branch+otherwise caught; otherwise block validated
- [ ] `src/recipes/__tests__/parser.test.ts` — 4 tests: invalid filter rejected; valid filters accepted; `on_file_save` unaffected
- [ ] `src/recipes/__tests__/runBudget.test.ts` — 2 tests: `refreshPrices()` updates `reconcile` and `quoteUsd`
- [ ] `src/connectors/__tests__/tokenStorage.test.ts` — 1 test: `list()` override returns correct providers without `dump-keychain`

🤖 Generated with [Claude Code](https://claude.com/claude-code)