### PR TITLE
fix(audit-2026-06-08): byte-accurate output caps + terminal flag (batch 3)

### DIFF
--- a/src/drivers/gemini/index.ts
+++ b/src/drivers/gemini/index.ts
@@ -332,11 +332,20 @@ export class GeminiSubprocessDriver implements ProviderDriver {
       });
 
       let stderr = "";
+      // Audit 2026-06-08 (drivers-5): cap stderr by BYTES, not string length.
+      // setEncoding("utf-8") yields string chunks, so `.length`/`.slice` counted
+      // UTF-16 units and let multi-byte stderr exceed OUTPUT_CAP (and split a
+      // surrogate pair on slice). truncateUtf8Bytes cuts on a byte boundary.
+      let stderrBytes = 0;
       child.stderr.setEncoding("utf-8");
       child.stderr.on("data", (chunk: string) => {
-        if (stderr.length < OUTPUT_CAP) {
+        if (stderrBytes < OUTPUT_CAP) {
           stderr += chunk;
-          if (stderr.length > OUTPUT_CAP) stderr = stderr.slice(0, OUTPUT_CAP);
+          stderrBytes += Buffer.byteLength(chunk, "utf-8");
+          if (stderrBytes > OUTPUT_CAP) {
+            stderr = truncateUtf8Bytes(stderr, OUTPUT_CAP);
+            stderrBytes = OUTPUT_CAP;
+          }
         }
       });
 

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -692,6 +692,10 @@ export async function execSafeStreaming(
     let linePartial = ""; // incomplete line being buffered
     let stderrBuf = "";
     let stdoutBytes = 0;
+    // Audit 2026-06-08 (tools-1): track stderr in BYTES like stdout. The old
+    // `stderrBuf.length + chunk.length` mixed string char-count (UTF-16 units)
+    // with Buffer byte-count, so multi-byte stderr overran maxBuffer.
+    let stderrBytes = 0;
     let timedOut = false;
 
     const timer = setTimeout(() => {
@@ -728,7 +732,8 @@ export async function execSafeStreaming(
 
     let stderrPartial = "";
     proc.stderr.on("data", (chunk: Buffer) => {
-      if (stderrBuf.length + chunk.length <= maxBuffer) {
+      stderrBytes += chunk.length;
+      if (stderrBytes <= maxBuffer) {
         const text = chunk.toString("utf-8");
         stderrBuf += text;
         if (onStderrLine) {

--- a/vscode-extension/src/__tests__/handlers/terminal.test.ts
+++ b/vscode-extension/src/__tests__/handlers/terminal.test.ts
@@ -250,6 +250,46 @@ describe("handleGetTerminalOutput", () => {
 
     deleteTerminalBuffer(t2 as any);
   });
+
+  // audit 2026-06-08 (extension-7) — `truncated` must mean OUTPUT LOST (ring
+  // buffer overflow), not "caller requested fewer lines than were written".
+  it("truncated is false when fewer lines are requested than written (no data loss)", async () => {
+    const t = _mockTerminal({ name: "t1" });
+    vscode.window.terminals = [t] as any;
+    setOutputCaptureEnabled(true);
+    const buf = getOrCreateBuffer(t as any)!;
+    writeToRingBuffer(buf, "a\nb\nc\n"); // 3 lines, well under the 5000 cap
+
+    const result = (await handleGetTerminalOutput({
+      name: "t1",
+      lines: 2, // ask for fewer than written
+    })) as any;
+    expect(result.lines).toHaveLength(2);
+    expect(result.totalLinesWritten).toBe(3);
+    expect(result.truncated).toBe(false);
+
+    deleteTerminalBuffer(t as any);
+  });
+
+  it("truncated is true only when the ring buffer overflowed (data loss)", async () => {
+    const t = _mockTerminal({ name: "t1" });
+    vscode.window.terminals = [t] as any;
+    setOutputCaptureEnabled(true);
+    const buf = getOrCreateBuffer(t as any)!;
+    // Write more than MAX_LINES_PER_TERMINAL (5000) so old lines are dropped.
+    let blob = "";
+    for (let i = 0; i < 5005; i++) blob += `line${i}\n`;
+    writeToRingBuffer(buf, blob);
+
+    const result = (await handleGetTerminalOutput({
+      name: "t1",
+      lines: 10,
+    })) as any;
+    expect(result.totalLinesWritten).toBe(5005);
+    expect(result.truncated).toBe(true);
+
+    deleteTerminalBuffer(t as any);
+  });
 });
 
 // ── handleCreateTerminal ──────────────────────────────────────

--- a/vscode-extension/src/handlers/terminal.ts
+++ b/vscode-extension/src/handlers/terminal.ts
@@ -139,7 +139,11 @@ export async function handleGetTerminalOutput(
     lines,
     lineCount: lines.length,
     totalLinesWritten: buf.totalWritten,
-    truncated: lineCount < buf.totalWritten,
+    // Audit 2026-06-08 (extension-7): `truncated` means OUTPUT WAS LOST — i.e.
+    // the ring buffer overflowed and dropped old lines. The old
+    // `lineCount < totalWritten` also fired when the caller simply requested
+    // fewer lines than exist (no data loss), which is misleading.
+    truncated: buf.totalWritten > MAX_LINES_PER_TERMINAL,
   };
 }
 
@@ -392,7 +396,10 @@ export async function handleExecuteInTerminal(
         [Symbol.asyncIterator]: () => readerIterator,
       }) {
         if (!truncated) {
-          outputBytes += chunk.length;
+          // Audit 2026-06-08 (extension-12): count actual UTF-8 bytes, not
+          // string .length (UTF-16 units), so the MAX_EXECUTE_OUTPUT_BYTES cap
+          // holds for multi-byte (CJK/emoji) output — mirrors the clipboard cap.
+          outputBytes += Buffer.byteLength(chunk, "utf8");
           if (outputBytes > MAX_EXECUTE_OUTPUT_BYTES) {
             truncated = true;
           } else {


### PR DESCRIPTION
## Audit 2026-06-08 — byte-accurate output caps + terminal flag (batch 3)

A small, coherent cluster of multi-byte (CJK/emoji) correctness bugs where size
caps counted UTF-16 string length instead of UTF-8 bytes, plus one misleading
flag. Each verified still-open against current main (the 2026-06-03 audit-low
wave fixed some siblings — see below).

| Finding | Fix |
|---|---|
| **tools-1** | `execSafeStreaming` stderr compared `stderrBuf.length` (chars) + chunk bytes → dedicated `stderrBytes` byte counter, mirroring stdout. |
| **drivers-5** | `GeminiSubprocessDriver` stderr cap used `stderr.length`/`.slice` (chars; could split a surrogate pair) → byte counter + `truncateUtf8Bytes` (boundary-safe). |
| **extension-12** | `handleExecuteInTerminal` counted `chunk.length` (UTF-16) against the byte cap → `Buffer.byteLength`. |
| **extension-7** | `getTerminalOutput.truncated` was `lineCount < totalWritten` — true even when the caller just requested fewer lines than written (no data loss). Now means actual ring-buffer overflow (`totalWritten > MAX_LINES_PER_TERMINAL`). **+2 tests.** |

**Already fixed (verified, not included):** drivers-4 (OpenAI in-loop cap) was fixed by audit-low #19 — it already uses a byte counter + `truncateToBytes`.

### Verification
- Full bridge **7844**, extension **581** (+2), 0 failures.
- `tsc` build + strict `tests:core` ratchet + fixture-hygiene + lsp-tools + schema gates + biome all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
