### PR TITLE
fix(audit-2026-06-08): wire /sessions/:id sessionDetailFn (server-1, HIGH)

### DIFF
--- a/src/__tests__/bridge-activation-metrics.test.ts
+++ b/src/__tests__/bridge-activation-metrics.test.ts
@@ -152,6 +152,29 @@ describe("Bridge activation metrics", () => {
     }
   });
 
+  it("wires sessionDetailFn in start() so GET /sessions/:id is not a dead endpoint (audit 2026-06-08 server-1)", async () => {
+    // Regression guard for the same class as the sessionsFn bug: the Fn was
+    // declared on Server but never assigned in bridge.ts, so /sessions/:id
+    // 404'd forever. A route-with-stub test can't catch a missing wire.
+    const workspace = fs.mkdtempSync(path.join(tempDir, "workspace-sd-"));
+    const bridge = new Bridge(makeConfig(workspace));
+    try {
+      await bridge.start();
+      const server = (
+        bridge as unknown as {
+          server: {
+            sessionDetailFn: ((id: string) => { summary: unknown }) | null;
+          };
+        }
+      ).server;
+      expect(typeof server.sessionDetailFn).toBe("function");
+      // No sessions connected → unknown id → summary:null (route → 404).
+      expect(server.sessionDetailFn?.("nosuch")?.summary).toBeNull();
+    } finally {
+      await bridge.stop();
+    }
+  });
+
   it("records a successful YAML recipe run", async () => {
     yamlRunnerModule.dispatchRecipe.mockResolvedValue({
       success: true,

--- a/src/__tests__/sessionDetail.test.ts
+++ b/src/__tests__/sessionDetail.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Unit tests for buildSessionDetail — the GET /sessions/:id payload builder.
+ * Audit 2026-06-08 HIGH (server-1).
+ */
+import { describe, expect, it } from "vitest";
+import {
+  buildSessionDetail,
+  type SessionDetailActivityLog,
+  type SessionDetailSession,
+} from "../sessionDetail.js";
+
+const FULL = "abcd1234-5678-90ab-cdef-1234567890ab";
+const SHORT = FULL.slice(0, 8); // "abcd1234"
+
+function sessions(): SessionDetailSession[] {
+  return [
+    {
+      id: FULL,
+      connectedAt: Date.parse("2026-06-09T08:00:00.000Z"),
+      openedFiles: new Set(["a.ts", "b.ts"]),
+      remoteAddr: "10.0.0.5",
+    },
+  ];
+}
+
+function activityLog(): SessionDetailActivityLog {
+  return {
+    querySessionLifecycle: (sid) =>
+      sid === FULL
+        ? [
+            { event: "claude_connected" },
+            { event: "approval_decision" },
+            { event: "grace_started" },
+          ]
+        : [],
+    querySessionTools: (sid) =>
+      sid === FULL ? [{ tool: "getGitStatus" }, { tool: "gitCommit" }] : [],
+  };
+}
+
+describe("buildSessionDetail", () => {
+  it("resolves the 8-char prefix to the active session and slices its activity", () => {
+    const approvals = [{ sessionId: FULL }, { sessionId: "ffff0000-other" }];
+    const r = buildSessionDetail(SHORT, sessions(), activityLog(), approvals);
+
+    expect(r.summary).not.toBeNull();
+    expect(r.summary?.id).toBe(SHORT);
+    expect(r.summary?.openedFileCount).toBe(2);
+    expect(r.summary?.connectedAt).toBe("2026-06-09T08:00:00.000Z");
+    expect(r.summary?.remoteAddr).toBe("10.0.0.5");
+    // Only the approval whose sessionId shares the prefix counts.
+    expect(r.summary?.pendingApprovals).toBe(1);
+    expect(r.approvals).toHaveLength(1);
+
+    expect(r.lifecycle).toHaveLength(3);
+    expect(r.tools).toHaveLength(2);
+    // decisions is the approval_decision subset of lifecycle.
+    expect(r.decisions).toHaveLength(1);
+    expect((r.decisions[0] as { event: string }).event).toBe(
+      "approval_decision",
+    );
+  });
+
+  it("also resolves a full session id", () => {
+    const r = buildSessionDetail(FULL, sessions(), activityLog(), []);
+    expect(r.summary?.id).toBe(SHORT);
+    expect(r.tools).toHaveLength(2);
+  });
+
+  it("returns summary:null (→ route 404) for an unknown session", () => {
+    const r = buildSessionDetail("deadbeef", sessions(), activityLog(), []);
+    expect(r.summary).toBeNull();
+    expect(r.lifecycle).toEqual([]);
+    expect(r.tools).toEqual([]);
+    expect(r.decisions).toEqual([]);
+    expect(r.approvals).toEqual([]);
+  });
+
+  it("omits remoteAddr when the session has none", () => {
+    const s: SessionDetailSession[] = [
+      {
+        id: FULL,
+        connectedAt: Date.now(),
+        openedFiles: new Set(),
+      },
+    ];
+    const r = buildSessionDetail(SHORT, s, activityLog(), []);
+    expect(r.summary).not.toBeNull();
+    expect("remoteAddr" in (r.summary as object)).toBe(false);
+  });
+
+  it("tolerates an absent activity log (summary still returned)", () => {
+    const r = buildSessionDetail(SHORT, sessions(), undefined, [
+      { sessionId: FULL },
+    ]);
+    expect(r.summary?.id).toBe(SHORT);
+    expect(r.summary?.pendingApprovals).toBe(1);
+    expect(r.lifecycle).toEqual([]);
+    expect(r.tools).toEqual([]);
+    expect(r.decisions).toEqual([]);
+  });
+});

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -49,6 +49,7 @@ import { classifyTool } from "./riskTier.js";
 import { RecipeRunLog } from "./runLog.js";
 import { Server } from "./server.js";
 import { type CheckpointData, SessionCheckpoint } from "./sessionCheckpoint.js";
+import { buildSessionDetail } from "./sessionDetail.js";
 import { StreamableHttpHandler } from "./streamableHttp.js";
 import { initTelemetry, shutdownTelemetry } from "./telemetry.js";
 import { TokenUsageTracker } from "./tokenUsageTracker.js";
@@ -1400,6 +1401,19 @@ export class Bridge {
       }
       return out;
     };
+    // Wire `/sessions/:id` for the dashboard's session-detail page. Audit
+    // 2026-06-08 HIGH (server-1): sessionDetailFn was declared in server.ts but
+    // never assigned, so GET /sessions/:id returned 404 forever and the page
+    // was permanently blank. The dashboard navigates with the 8-char prefix
+    // sessionsFn emits (`s.id.slice(0,8)`), so resolve that (or a full id) to
+    // the active session, then slice the per-session activity from the log.
+    this.server.sessionDetailFn = (id) =>
+      buildSessionDetail(
+        id,
+        this.sessions.values(),
+        this.activityLog,
+        getApprovalQueue().list(),
+      );
     this.server.restartCheckFn = () => {
       let totalSessions = 0;
       let totalInFlight = 0;

--- a/src/sessionDetail.ts
+++ b/src/sessionDetail.ts
@@ -1,0 +1,96 @@
+/**
+ * GET /sessions/:id detail payload builder.
+ *
+ * Audit 2026-06-08 HIGH (server-1): `sessionDetailFn` was declared in server.ts
+ * but never wired in bridge.ts, so the endpoint 404'd forever and the dashboard
+ * session-detail page was permanently blank. The logic lives here (pure, no I/O)
+ * so it is unit-testable; bridge.ts wires a thin closure that supplies the live
+ * session map, activity log, and approval queue.
+ */
+
+import type { SessionSummary } from "./server.js";
+
+/** Minimal shape of an active session needed to build the summary. */
+export interface SessionDetailSession {
+  id: string;
+  connectedAt: number;
+  openedFiles: { readonly size: number };
+  remoteAddr?: string;
+}
+
+/** Minimal activity-log surface used here (subset of ActivityLog). */
+export interface SessionDetailActivityLog {
+  querySessionLifecycle(
+    sessionId: string,
+    limit?: number,
+  ): Array<{ event: string }>;
+  querySessionTools(sessionId: string, limit?: number): unknown[];
+}
+
+export interface SessionDetailResult {
+  summary: SessionSummary | null;
+  lifecycle: Record<string, unknown>[];
+  tools: Record<string, unknown>[];
+  decisions: Record<string, unknown>[];
+  approvals: Record<string, unknown>[];
+}
+
+/**
+ * Build the detail payload for one session. `id` is the 8-char prefix the
+ * dashboard navigates with (sessionsFn emits `s.id.slice(0,8)`) or a full id.
+ *
+ * Returns `summary: null` for an unknown/disconnected session — the route turns
+ * that into a 404 (sessionsFn only lists active sessions, so that's the miss).
+ */
+export function buildSessionDetail(
+  id: string,
+  sessions: Iterable<SessionDetailSession>,
+  activityLog: SessionDetailActivityLog | undefined,
+  pendingApprovals: ReadonlyArray<{ sessionId?: string }>,
+): SessionDetailResult {
+  let session: SessionDetailSession | undefined;
+  for (const s of sessions) {
+    if (s.id === id || s.id.slice(0, 8) === id) {
+      session = s;
+      break;
+    }
+  }
+  if (!session) {
+    return {
+      summary: null,
+      lifecycle: [],
+      tools: [],
+      decisions: [],
+      approvals: [],
+    };
+  }
+
+  const fullId = session.id;
+  const shortId = fullId.slice(0, 8);
+  // Approval-queue sessionIds are full ids; match by the same 8-char prefix
+  // sessionsFn uses so the count is consistent with the list view.
+  const approvals = pendingApprovals.filter(
+    (a) => a.sessionId && a.sessionId.slice(0, 8) === shortId,
+  );
+  const summary: SessionSummary = {
+    id: shortId,
+    connectedAt: new Date(session.connectedAt).toISOString(),
+    openedFileCount: session.openedFiles.size,
+    pendingApprovals: approvals.length,
+    ...(session.remoteAddr ? { remoteAddr: session.remoteAddr } : {}),
+  };
+
+  const lifecycle = activityLog?.querySessionLifecycle(fullId) ?? [];
+  const tools = activityLog?.querySessionTools(fullId) ?? [];
+  // approval_decision rows are lifecycle entries; surface them separately so
+  // the page's "decisions" section doesn't re-filter.
+  const decisions = lifecycle.filter((e) => e.event === "approval_decision");
+
+  return {
+    summary,
+    lifecycle: lifecycle as unknown as Record<string, unknown>[],
+    tools: tools as unknown as Record<string, unknown>[],
+    decisions: decisions as unknown as Record<string, unknown>[],
+    approvals: approvals as unknown as Record<string, unknown>[],
+  };
+}


### PR DESCRIPTION
## Audit 2026-06-08 — wire `/sessions/:id` (server-1, HIGH)

`Server.sessionDetailFn` was declared but **never assigned in bridge.ts** — the
same "declared-but-unwired" class as the earlier `sessionsFn` miss — so
`GET /sessions/:id` returned 404 forever and the dashboard's session-detail
drill-down page was permanently blank (its parser + UI already existed).

### Fix
- Extracted the payload logic into a pure, unit-testable **`buildSessionDetail()`** (`src/sessionDetail.ts`): resolves the 8-char prefix the dashboard navigates with (`sessionsFn` emits `s.id.slice(0,8)`) — or a full id — to the active session, then slices its **lifecycle / tools / decisions (the `approval_decision` subset) / approvals** from the activity log + approval queue. Returns `summary:null` for an unknown session (the route turns that into 404).
- `bridge.ts` wires a thin closure to it in `start()`, alongside `sessionsFn`.

### Tests (3 levels)
- **Pure helper** (`sessionDetail.test.ts`): prefix + full-id resolution, activity slicing, summary shape, `remoteAddr` omission, absent-activity-log tolerance.
- **Route** (existing `server-session-detail.test.ts`): unchanged, still green.
- **Bridge wiring** (`bridge-activation-metrics.test.ts`): `start()` actually assigns the Fn — catches the missing-wire that a route-with-stub test cannot (the exact regression that caused this bug).

### Verification
Full bridge **7847**, 0 failures; build + strict `tests:core` + fixture-hygiene + lsp/schema gates + biome all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
