### PR TITLE
fix(audit-2026-06-08): OAuth callback pages for google-docs/monday/salesforce (unsurfaced-1)

### DIFF
--- a/dashboard/src/app/api/connections/__tests__/oauth-callbacks.test.ts
+++ b/dashboard/src/app/api/connections/__tests__/oauth-callbacks.test.ts
@@ -15,6 +15,11 @@ import { GET as gitlabCallback } from "../gitlab/callback/route";
 import { GET as slackCallback } from "../slack/callback/route";
 import { GET as gcalCallback } from "../google-calendar/callback/route";
 import { GET as gdriveCallback } from "../google-drive/callback/route";
+// Audit 2026-06-08 (unsurfaced-1): these three were offered + auth-capable but
+// had no dashboard callback route/page, so OAuth 404'd at the redirect-back.
+import { GET as googleDocsCallback } from "../google-docs/callback/route";
+import { GET as mondayCallback } from "../monday/callback/route";
+import { GET as salesforceCallback } from "../salesforce/callback/route";
 
 type Handler = (req: Request) => Promise<Response>;
 
@@ -26,6 +31,9 @@ const ROUTES: { name: string; bridgePath: string; handler: Handler }[] = [
   { name: "slack",            bridgePath: "/connections/slack/callback",            handler: slackCallback },
   { name: "google-calendar",  bridgePath: "/connections/google-calendar/callback",  handler: gcalCallback },
   { name: "google-drive",     bridgePath: "/connections/google-drive/callback",     handler: gdriveCallback },
+  { name: "google-docs",      bridgePath: "/connections/google-docs/callback",      handler: googleDocsCallback },
+  { name: "monday",           bridgePath: "/connections/monday/callback",           handler: mondayCallback },
+  { name: "salesforce",       bridgePath: "/connections/salesforce/callback",       handler: salesforceCallback },
 ];
 
 let origAllowUnauthenticated: string | undefined;

--- a/dashboard/src/app/api/connections/google-docs/callback/route.ts
+++ b/dashboard/src/app/api/connections/google-docs/callback/route.ts
@@ -1,0 +1,36 @@
+import { bridgeFetch } from "@/lib/bridge";
+import { requireCallbackSession } from "../../requireSession";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function GET(req: Request): Promise<Response> {
+  // LOW #39: verify active dashboard session before forwarding OAuth code.
+  const authErr = await requireCallbackSession(req);
+  if (authErr) return authErr;
+
+  const url = new URL(req.url);
+  const allowed = ["code", "state", "error"];
+  const qs = new URLSearchParams();
+  for (const key of allowed) {
+    const v = url.searchParams.get(key);
+    if (v !== null) qs.set(key, v);
+  }
+
+  try {
+    const res = await bridgeFetch(`/connections/google-docs/callback?${qs.toString()}`);
+    const body = await res.text();
+    return new Response(body, {
+      status: res.status,
+      headers: {
+        "content-type": res.headers.get("content-type") ?? "application/json",
+      },
+    });
+  } catch (err) {
+    console.error("[connections/google-docs/callback GET] bridge fetch failed:", err);
+    return new Response(JSON.stringify({ error: "Bridge unreachable" }), {
+      status: 502,
+      headers: { "content-type": "application/json" },
+    });
+  }
+}

--- a/dashboard/src/app/api/connections/monday/callback/route.ts
+++ b/dashboard/src/app/api/connections/monday/callback/route.ts
@@ -1,0 +1,36 @@
+import { bridgeFetch } from "@/lib/bridge";
+import { requireCallbackSession } from "../../requireSession";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function GET(req: Request): Promise<Response> {
+  // LOW #39: verify active dashboard session before forwarding OAuth code.
+  const authErr = await requireCallbackSession(req);
+  if (authErr) return authErr;
+
+  const url = new URL(req.url);
+  const allowed = ["code", "state", "error"];
+  const qs = new URLSearchParams();
+  for (const key of allowed) {
+    const v = url.searchParams.get(key);
+    if (v !== null) qs.set(key, v);
+  }
+
+  try {
+    const res = await bridgeFetch(`/connections/monday/callback?${qs.toString()}`);
+    const body = await res.text();
+    return new Response(body, {
+      status: res.status,
+      headers: {
+        "content-type": res.headers.get("content-type") ?? "application/json",
+      },
+    });
+  } catch (err) {
+    console.error("[connections/monday/callback GET] bridge fetch failed:", err);
+    return new Response(JSON.stringify({ error: "Bridge unreachable" }), {
+      status: 502,
+      headers: { "content-type": "application/json" },
+    });
+  }
+}

--- a/dashboard/src/app/api/connections/salesforce/callback/route.ts
+++ b/dashboard/src/app/api/connections/salesforce/callback/route.ts
@@ -1,0 +1,36 @@
+import { bridgeFetch } from "@/lib/bridge";
+import { requireCallbackSession } from "../../requireSession";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function GET(req: Request): Promise<Response> {
+  // LOW #39: verify active dashboard session before forwarding OAuth code.
+  const authErr = await requireCallbackSession(req);
+  if (authErr) return authErr;
+
+  const url = new URL(req.url);
+  const allowed = ["code", "state", "error"];
+  const qs = new URLSearchParams();
+  for (const key of allowed) {
+    const v = url.searchParams.get(key);
+    if (v !== null) qs.set(key, v);
+  }
+
+  try {
+    const res = await bridgeFetch(`/connections/salesforce/callback?${qs.toString()}`);
+    const body = await res.text();
+    return new Response(body, {
+      status: res.status,
+      headers: {
+        "content-type": res.headers.get("content-type") ?? "application/json",
+      },
+    });
+  } catch (err) {
+    console.error("[connections/salesforce/callback GET] bridge fetch failed:", err);
+    return new Response(JSON.stringify({ error: "Bridge unreachable" }), {
+      status: 502,
+      headers: { "content-type": "application/json" },
+    });
+  }
+}

--- a/dashboard/src/app/connections/google-docs/callback/page.tsx
+++ b/dashboard/src/app/connections/google-docs/callback/page.tsx
@@ -1,0 +1,5 @@
+import { OAuthCallback } from "@/components/OAuthCallback";
+
+export default function GoogleDocsCallbackPage() {
+  return <OAuthCallback provider={{ id: "google-docs", label: "Google Docs" }} />;
+}

--- a/dashboard/src/app/connections/monday/callback/page.tsx
+++ b/dashboard/src/app/connections/monday/callback/page.tsx
@@ -1,0 +1,5 @@
+import { OAuthCallback } from "@/components/OAuthCallback";
+
+export default function MondayCallbackPage() {
+  return <OAuthCallback provider={{ id: "monday", label: "Monday" }} />;
+}

--- a/dashboard/src/app/connections/salesforce/callback/page.tsx
+++ b/dashboard/src/app/connections/salesforce/callback/page.tsx
@@ -1,0 +1,5 @@
+import { OAuthCallback } from "@/components/OAuthCallback";
+
+export default function SalesforceCallbackPage() {
+  return <OAuthCallback provider={{ id: "salesforce", label: "Salesforce" }} />;
+}


### PR DESCRIPTION
## Audit 2026-06-08 — OAuth callback pages for google-docs/monday/salesforce (unsurfaced-1)

These three connectors are offered in the dashboard Connect UI (in
`SUPPORTED_CONNECTORS`) and are auth-capable with **full bridge callback routes**
(`connectorRoutes.ts`), but the dashboard had **no** `/connections/<id>/callback`
page nor `/api/connections/<id>/callback` proxy route. After the user authorized,
the OAuth provider redirected the browser back to a dashboard **404**, silently
breaking the entire auth flow for all three.

### Fix
For each of google-docs, monday, salesforce, added:
- **Page** `connections/<id>/callback/page.tsx` — one-line `<OAuthCallback ...>` (mirrors the 10 existing connectors).
- **API route** `api/connections/<id>/callback/route.ts` — session-guarded proxy that forwards the allowlisted `code`/`state`/`error` to the bridge (identical shape to the existing per-connector routes).

Extended the parameterized `oauth-callbacks.test.ts` to cover the 3 new routes (now 10).

### Verification
Dashboard `tsc` clean; full dashboard suite **897 passed** (callback test 50).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
