### PR TITLE
fix(audit-2026-06-08): per-step timeout_ms on the chained runner (recipe-chained-4)

### DIFF
--- a/src/recipes/__tests__/chainedRunner.test.ts
+++ b/src/recipes/__tests__/chainedRunner.test.ts
@@ -162,6 +162,77 @@ describe("executeChainedStep", () => {
     expect(result.data).toEqual({ ok: true });
   });
 
+  // audit 2026-06-08 (recipe-chained-4) — per-step timeout_ms on the chained
+  // runner, mirroring the flat yamlRunner. Previously silently ignored.
+  it("fails a tool step with step_timeout when it exceeds timeout_ms", async () => {
+    const reg = createOutputRegistry();
+    const slowDeps = {
+      executeTool: () =>
+        new Promise((resolve) => setTimeout(() => resolve("late"), 200)),
+      executeAgent: vi.fn(),
+      loadNestedRecipe: vi.fn().mockResolvedValue(null),
+    };
+    const result = await executeChainedStep(
+      {
+        registry: reg,
+        step: { id: "s", tool: "slow.tool", timeout_ms: 20 },
+        options: baseOptions,
+        recipe: { name: "r", steps: [] },
+        depth: 0,
+      },
+      slowDeps,
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/step_timeout/);
+    expect(result.error).toContain("20ms");
+  });
+
+  it("does not time out a fast tool step under timeout_ms", async () => {
+    const reg = createOutputRegistry();
+    const fastDeps = {
+      executeTool: () =>
+        new Promise((resolve) => setTimeout(() => resolve("quick"), 5)),
+      executeAgent: vi.fn(),
+      loadNestedRecipe: vi.fn().mockResolvedValue(null),
+    };
+    const result = await executeChainedStep(
+      {
+        registry: reg,
+        step: { id: "s", tool: "fast.tool", timeout_ms: 500 },
+        options: baseOptions,
+        recipe: { name: "r", steps: [] },
+        depth: 0,
+      },
+      fastDeps,
+    );
+    expect(result.success).toBe(true);
+    expect(result.data).toBe("quick");
+  });
+
+  it("fails an agent step with step_timeout when it exceeds timeout_ms", async () => {
+    const reg = createOutputRegistry();
+    const slowDeps = {
+      executeTool: vi.fn(),
+      executeAgent: () =>
+        new Promise<string>((resolve) =>
+          setTimeout(() => resolve("late"), 200),
+        ),
+      loadNestedRecipe: vi.fn().mockResolvedValue(null),
+    };
+    const result = await executeChainedStep(
+      {
+        registry: reg,
+        step: { id: "s", agent: { prompt: "do it" }, timeout_ms: 20 },
+        options: baseOptions,
+        recipe: { name: "r", steps: [] },
+        depth: 0,
+      },
+      slowDeps,
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/step_timeout/);
+  });
+
   it("executes agent step", async () => {
     const reg = createOutputRegistry();
     const result = await executeChainedStep(

--- a/src/recipes/chainedRunner.ts
+++ b/src/recipes/chainedRunner.ts
@@ -67,6 +67,13 @@ export interface ChainedStep {
   retry?: number;
   /** Delay in ms between retries (default 1000). */
   retryDelay?: number;
+  /**
+   * Per-step wall-clock timeout (ms). When >0, the tool/agent dispatch is raced
+   * against a timer; on expiry the step fails with `step_timeout` (the
+   * underlying call keeps running but its result is ignored). Mirrors the flat
+   * yamlRunner's `timeout_ms` — audit 2026-06-08 (recipe-chained-4).
+   */
+  timeout_ms?: number;
   transform?: string; // template rendered after tool execution; $result = raw tool output
   expect?: StepExpect;
   [key: string]: unknown;
@@ -317,6 +324,32 @@ export function resolveStepTemplates(
   return { resolved, conditionResult, errors };
 }
 
+/**
+ * Race `work` against a per-step timeout. Returns `work` unchanged when no
+ * positive timeout is set. On expiry the returned promise rejects with a
+ * `step_timeout` error (executeChainedStep's catch turns that into a step
+ * failure). The underlying call is not cancellable here — it keeps running but
+ * its result is ignored — matching the flat runner's documented behaviour.
+ */
+function raceStepTimeout<T>(
+  work: Promise<T>,
+  timeoutMs: number | undefined,
+  label: string,
+): Promise<T> {
+  if (typeof timeoutMs !== "number" || timeoutMs <= 0) return work;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      reject(
+        new Error(`step_timeout: exceeded ${timeoutMs}ms in step "${label}"`),
+      );
+    }, timeoutMs);
+  });
+  return Promise.race([work, timeout]).finally(() => {
+    if (timer) clearTimeout(timer);
+  });
+}
+
 /** Execute a single step */
 export async function executeChainedStep(
   ctx: StepExecutionContext,
@@ -565,7 +598,11 @@ export async function executeChainedStep(
       }
 
       const agentReturn = toChainedAgentResult(
-        await deps.executeAgent(prompt, dispatchModel, dispatchDriver),
+        await raceStepTimeout(
+          deps.executeAgent(prompt, dispatchModel, dispatchDriver),
+          step.timeout_ms,
+          step.id,
+        ),
       );
 
       // Reconcile REAL usage after dispatch (the closure now surfaces it
@@ -641,7 +678,11 @@ export async function executeChainedStep(
       };
     } else if (step.tool) {
       // Tool step
-      let result: unknown = await deps.executeTool(step.tool, resolved);
+      let result: unknown = await raceStepTimeout(
+        deps.executeTool(step.tool, resolved),
+        step.timeout_ms,
+        step.id,
+      );
       // Detect tool-level errors reported as JSON {ok: false, error: ...} (mirrors flat runner)
       if (typeof result === "string") {
         try {


### PR DESCRIPTION
## Audit 2026-06-08 — per-step `timeout_ms` on the chained runner (recipe-chained-4)

The chained runner ignored `timeout_ms` entirely — drift from the flat
`yamlRunner`, which races every step against a timer. A chained recipe step that
hung (slow tool/agent) would block its branch indefinitely.

### Fix
- Added `timeout_ms` to `ChainedStep`.
- Added a `raceStepTimeout()` wrapper around the agent and tool dispatch in
  `executeChainedStep`. On expiry it rejects with `step_timeout: exceeded <n>ms
  in step "<id>"`, which the function's existing catch turns into a clean step
  failure. The underlying call isn't cancellable, so it keeps running but its
  result is ignored — matching the flat runner's documented behaviour.

### Tests (+3)
tool-step timeout, fast-tool-under-timeout (no false trip), agent-step timeout.
Full chainedRunner suite green (60); build + strict `tests:core` clean.

> Sibling **recipe-chained-1** (`parallel:{each}` map-reduce) is intentionally
> NOT in this PR — it needs runtime fan-out + a new template-binding namespace
> and would duplicate the existing `fan_out` primitive; tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
