### PR TITLE
feat: on-device semantic memory + approval provenance + constrained-decoding foundation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -846,7 +846,7 @@ All three authoring subcommands now have `--watch` mode and an exported library 
 - **POST `/launch-quick-task`** HTTP endpoint — bearer auth, 200 ok / 429 cooldown / 503 when no session connected.
 - **`McpTransport.invokeToolDirect()`** — public method for HTTP endpoints to dispatch tools without a full JSON-RPC session.
 - **`ToolErrorCodes.COOLDOWN_ACTIVE`** — new tool-level error code.
-- **`docs/perf-baseline.md`** — loopback p50/p95/p99 for 8 representative tool calls. All ≤ 1ms on M4 Max / 500 iterations. Anchor for future regression detection.
+- **`docs/perf-baseline.md`** — loopback p50/p95/p99 for 8 representative tool calls. All ≤ 1ms on Apple Silicon / 500 iterations. Anchor for future regression detection.
 
 ### Changed
 - Extension bumped to v1.4.7 (Windsurf cache invalidation).

--- a/config.schema.json
+++ b/config.schema.json
@@ -21,6 +21,8 @@
     },
     "localEndpoint": { "type": "string", "format": "uri" },
     "localModel": { "type": "string" },
+    "localEmbeddingsEndpoint": { "type": "string", "format": "uri" },
+    "localEmbeddingsModel": { "type": "string" },
     "dashboard": {
       "type": "object",
       "required": ["port", "requireApproval"],

--- a/docs/mlx-integration-plan.md
+++ b/docs/mlx-integration-plan.md
@@ -206,9 +206,10 @@ Ordered by dependency + ROI. `[A]` = local-AI thread, `[B]` = automation thread.
   JSON line"; `response_format: json_object` forces the *whole* response to be
   JSON. Proper fix = redesign the judge to emit pure structured JSON (assessment
   as a field) + update `parseJudgeVerdict` + re-verify the refine loop. The
-  driver seam is clean (`ProviderTaskInput.providerOptions` is already a
-  passthrough; add `response_format` in `openai/index.ts`'s `create()` body) —
-  the *judge-contract* change is the real work. Sensitive path; design first.
+  driver seam is **DONE** (commit `783a8e95`: `providerOptions.responseFormat` →
+  `response_format` in `openai/index.ts`, +4 tests, fail-safe) — so any step can
+  already request constrained output. Only the *judge-contract* redesign remains;
+  it's the sensitive part — design first.
 - **FlowSvg live run status** (§4) `[B]` — contained, but dashboard/React: needs
   visual verification (no unit test). A frontend session, not a backend one.
 

--- a/docs/mlx-integration-plan.md
+++ b/docs/mlx-integration-plan.md
@@ -1,0 +1,358 @@
+# MLX Integration & Local-AI Roadmap — Patchwork
+
+> Status: **active.** Folds three research threads into one sequenced plan:
+> (1) the original MLX integration (Tiers 0–3), (2) verified borrowable
+> local-AI building blocks (GitHub/Reddit sweep), (3) automation-platform
+> deltas grounded against the actual codebase (n8n/Windmill/Airflow/Temporal).
+> Everything carries `file:line` seams. **Keystone:** one wire-up (`embedFn`)
+> is simultaneously the MLX Tier-1 activation *and* the #1 automation-pattern
+> quick win — three threads converge on it.
+
+---
+
+## 0. Where we are right now
+
+| Tier | State |
+|---|---|
+| **Tier 0** — MLX behind the `local` driver | **Works today, config only.** No code change. |
+| **Tier 1** — on-device embeddings + semantic trace search | **BUILT + committed** on `feat/mlx-integration` (`src/embeddings/`, the `ctxQueryTraces` semantic seam, `docs/mlx-integration.md`, `MLX_SMOKE` smoke test). 48 unit tests green, prod + `tests:core` typecheck clean. **Inert until the keystone wire-up** (§2). |
+| **Tier 2 / 3** | Planned (below). |
+
+The embeddings module + the opt-in semantic ranking path in `ctxQueryTraces`
+are real and merged into the branch — but `embedFn` is never injected at the
+tool registration site, so `semantic:true` silently falls back to substring
+search. Activating it is the keystone.
+
+---
+
+## 1. Why MLX for Patchwork
+
+[Apple MLX](https://github.com/ml-explore/mlx) runs LLMs **and** embedding
+models natively on Apple Silicon and exposes them over an
+**OpenAI-compatible HTTP API**. For Patchwork specifically:
+
+- **$0 marginal cost.** The `local` driver is excluded from `BILLABLE_DRIVERS`
+  (`src/recipes/runBudget.ts:43`). At `reconcile()` it emits a one-time
+  `notbilled:local` notice and never increments spend or blocks `admit()`;
+  `quoteUsd()` returns `undefined`, so `costRouter`
+  (`src/recipes/pricing/costRouter.ts:49-69`) always treats it as affordable.
+  → **unmetered judge→refine, all-day automation, bulk classification.**
+- **Privacy.** Prompts + context never leave the Mac, enforced by the same
+  `isLoopbackOrPrivateEndpoint` guard (`src/localEndpointGuard.ts:25`) the
+  `local` driver already uses; embeddings traffic inherits it.
+- **No key churn.** `LocalApiDriver.apiKey()` (`src/drivers/local/index.ts:57`)
+  sends the conventional `"ollama"` placeholder.
+
+### 1b. High-memory Apple Silicon sizing — run a *team* of models
+
+A high-memory Mac (64 GB+, ideally 128 GB) lets you hold **three roles resident at once** (verified community picks,
+2026):
+
+| Role | Example model (MLX) | Footprint | Why |
+|---|---|---|---|
+| Judge / refine | Qwen3.5-35B-A3B (MoE, 4-bit) or Qwen3-27B dense | ~24 GB | Credible reviewer; dense variant is the safer **strict-JSON** pick. |
+| Triage / classify | Qwen3-7B / Llama-3.2-3B (4-bit) | ~3–5 GB | Fast first-pass labelling, routing, summarize. |
+| Embeddings | `nomic-embed-text` / `bge` / `qwen3-embed` | <1 GB | Powers semantic trace + file search. |
+
+**Small-for-triage / big-for-judge** is the operating pattern: the big model is
+*smart but not instant*, so reserve it for reasoning steps; let the small model
+handle volume. Keeping all three resident is itself a borrowable pattern (§3.4).
+
+---
+
+## 2. ⭐ The keystone — activate semantic memory (`embedFn`)
+
+**One change closes three gaps at once.** Wire the already-built embeddings
+provider into the trace-search registration:
+
+- **Seam:** `src/tools/index.ts:781` and `src/bridge.ts:1272` both call
+  `createCtxQueryTracesTool({...})` with no `embedFn`. Add
+  `embedFn: createEmbeddingsProvider()?.embed.bind(provider)` (via the
+  `getLocalEmbedFn()` helper). Fail-soft: provider `null` ⇒ unchanged substring
+  behavior.
+- **Plus** the embeddings env injection: add `localEmbeddingsEndpoint` /
+  `localEmbeddingsModel` to `PatchworkConfig` (`src/patchworkConfig.ts:39-40`),
+  seed `LOCAL_EMBEDDINGS_ENDPOINT/MODEL` at startup
+  (`src/config.ts:589-592` mirror), and add the two fields to
+  `config.schema.json` (the `configSchemaAlignment.test.ts` gate requires it).
+- **Bonus seam:** in `recentTracesDigest.ts`, pass the current task hint as
+  `q` with `semantic:true` so the session-start digest is **relevance-sorted**,
+  not recency-sorted.
+
+**Why it's the keystone:** it activates MLX Tier 1 *and* the #1 automation
+"knowledge-linking" delta (§4) *and* is the foundation the RAG/fine-tune tracks
+build on. Smallest change, widest unlock.
+
+---
+
+## 3. Thread A — verified local-AI building blocks to borrow
+
+All repos below were **independently confirmed to exist** (the research agents
+over-reported "verified"; these were re-checked by hand). See the appendix (§6)
+for the full table + links.
+
+### 3.1 Persistent vector cache — completes Tier 1
+Today `ctxQueryTraces` re-embeds the candidate set **every query**. Add
+[sqlite-vec](https://github.com/asg017/sqlite-vec) (Node via `better-sqlite3`,
+**zero new process** — Patchwork already uses SQLite) with
+`INSERT OR REPLACE` keyed on `(content_hash, model_hash)` → embed only on change.
+[LanceDB](https://github.com/lancedb/lancedb) is the upgrade if metadata queries
+are later needed. *Effort low, impact high — natural follow-up to §2.*
+
+### 3.2 Constrained decoding — fix the judge→refine JSON halts
+The judge step depends on the local model emitting parseable verdict JSON; the
+session's live halts (`expect_failed`, `agent_silent_fail`) are partly this.
+**Zero bridge logic** needed: when `LOCAL_ENDPOINT` points at vLLM
+([XGrammar](https://github.com/mlc-ai/xgrammar)) or a
+[llama.cpp server](https://github.com/ggml-org/llama.cpp), add
+`response_format: {type:"json_schema"}` / `guided_json` / `grammar` to the local
+driver request body — the model physically cannot emit a token that breaks
+`JSON.parse()`. Export the existing `JudgeVerdict` type as JSON Schema. No-sidecar
+path: [node-llama-cpp](https://github.com/withcatai/node-llama-cpp) (TS, Metal,
+in-process). *Effort low, impact high — targets a live failure mode.*
+
+### 3.3 oMLX as the recommended local backend
+[oMLX (jundot/omlx)](https://github.com/jundot/omlx) — **verified real, 16.3k★**,
+Apache-2.0. Drop-in for the `local` driver base URL (OpenAI+Anthropic compatible).
+Unique value: a **block-based KV cache tiered to SSD with prefix sharing that
+survives restarts** — repeated recipe runs sharing a long system prompt pay
+prefill *once* (reported TTFT 30–90s → 1–3s on long context), plus multi-model
+LRU residency and token-level JSON output. Caveat: new, ships as a menu-bar app.
+
+### 3.4 Multi-model "team" → maps to the cost-router downshift
+Three effort tiers, all hitting the existing `local` driver:
+- **Lowest friction:** [Ollama](https://ollama.com/blog/mlx)
+  `OLLAMA_MAX_LOADED_MODELS=3` + `keep_alive=-1` on embedder + judge (no new code).
+- **Drop-in proxy:** [llama-swap](https://github.com/mostlygeek/llama-swap)
+  (`swap:false` for always-resident embedder/judge).
+- **Best:** oMLX (LRU + pin).
+
+### 3.5 Hybrid local→cloud escalation
+[LiteLLM](https://github.com/BerriAI/litellm) as a transparent proxy gives
+`context_window_fallbacks` + per-request spend logs feeding the cost ledger —
+expressing the downshift list (local Qwen → local Llama → cloud Claude) at the
+transport layer. Rapid-MLX's `--cloud-threshold` escalates on *actual* new-token
+prefill cost, a sharper signal than the current budget estimate.
+
+### 3.6 Personal-files RAG — "your digital life stops expiring"
+Borrow [Khoj](https://github.com/khoj-ai/khoj)'s hash-per-chunk incremental
+indexing (parse→chunk→hash→diff→embed deltas→upsert) + LlamaIndex's
+filename-as-stable-id `RefDocInfo` pattern (~100 lines, not a dependency) to
+extend memory from traces to the user's Markdown/Obsidian vault. Pairs with the
+existing `onFileSave` / `watchFiles` hooks. [mem0](https://github.com/mem0ai/mem0)
+(Node SDK) adds hybrid BM25+semantic+entity retrieval if wanted.
+
+### 3.7 Fine-tune on the user's traces — compounding personalization
+Export `ctxQueryTraces` as JSONL → [mlx-lm](https://github.com/ml-explore/mlx-lm)
+`mlx_lm.lora` (or DPO from judge approve/reject pairs) → ~10 MB adapter loaded
+via `--adapter-path` on the local endpoint. ~90 min on high-end Apple Silicon; re-train every few
+weeks. The model learns the user's style + verdict preferences. *Research track.*
+
+### Community gotchas worth encoding as rules
+- **MLX tok/s is decode-only.** Judge steps (big context in, short JSON out) are
+  *prefill*-bound, where GGUF + llama.cpp FlashAttention beats MLX — so the ideal
+  is two local endpoints (GGUF for judge, MLX for generative), *unless* oMLX's KV
+  cache neutralizes it. The per-step `driver`/`model` config already supports this.
+- **Ollama prefix-caching needs a byte-stable system prompt.** Recipe-authoring
+  rule: keep per-run vars (step id, timestamp, attempt #) out of the *system*
+  prefix (pass as user-turn messages) or every refine iteration pays 8–16× TTFT.
+  Worth a `recipe lint` warning.
+
+---
+
+## 4. Thread B — grounded automation-platform deltas
+
+Verified against the codebase: **Patchwork already ships partial-to-strong
+versions of all of these, and is *ahead* of n8n on approvals.** The value is the
+precise delta, not the generic pattern.
+
+| Pattern | Have (level) | Real gap | Borrow (seam) | Effort/Impact |
+|---|---|---|---|---|
+| Sub-recipes | **partial** — `nestedRecipeStep.ts`, `chainedRunner.ts:481` (chained-only) | no declared `outputs:` contract; no version pin | add top-level `outputs:` block (schemaGenerator + validation + `formatNestedOutput`) | med / med |
+| Approval + audit | **strong** (ahead of n8n) — tiers, queue, 12 signals, phone push, decision-replay | no per-*step* gate; no `channel` on audit row | add `channel` at `approvalHttp.ts:779` (`phone` vs `dashboard`) | **low / med** |
+| History + replay | **partial** — `runs.jsonl` + mocked replay `POST /runs/:seq/replay` | replay can't sub inputs; chained-only | add `varsOverride` to `replayMockedRun()` (`replayRun.ts:109`) | **low / HIGH** |
+| Knowledge linking | **partial** — semantic path **built but dead** | `embedFn` never injected; no "see also" surface | **= the keystone (§2)** + populate `RelatedPanel` from a semantic query | **low / med** |
+| Visual builder | **partial** — YAML/Form/Flow editor; Flow is read-only | no diagram→YAML, no drag; `stepStatuses` unwired | wire live run status into `FlowSvg` (`_edit/page.tsx:1209`) → live monitor | **low / med** |
+| Connector ecosystem | **partial** — 46 connectors + plugin system | plugins can't read stored tokens | add `getCredential(id)` to `PluginContext` (`plugin.ts:74`) | med / **HIGH** |
+| Durable execution | **partial** — write-tool ledger, interrupted-sweep, checkpoint | agent/LLM steps re-run on crash; cron runs in-memory-only | extend the ledger to **agent steps** (`yamlRunner.ts:1633`) | med / **HIGH** |
+
+---
+
+## 5. Unified sequenced roadmap
+
+Ordered by dependency + ROI. `[A]` = local-AI thread, `[B]` = automation thread.
+
+### Phase 0 — Keystone ✅ DONE (2026-06-09, commit `00902265`)
+1. **Wire `embedFn` + embeddings env injection** (§2). `[A+B]` — activated Tier 1
+   semantic memory *and* the knowledge-linking delta. Also hardened the resolver
+   so an empty/whitespace env var no longer shadows the `LOCAL_ENDPOINT` fallback.
+
+### Phase 1 — re-assessed after investigation (only one was a true quick win)
+> Lesson: the grounding sweep's "low effort" labels were optimistic. Each item
+> below was opened up; here is the *real* effort/risk. Sequence by readiness.
+
+- ✅ **Approval `channel` field** (§4) `[B]` — **DONE** (commit `a8d30223`). The
+  one genuinely-clean backend win: phone-vs-dashboard provenance on every
+  `approval_decision` row. +4 tests.
+- **Replay `varsOverride`** (§4) `[B]` — **needs a security design**, not a patch.
+  `replayMockedRun`'s `env` is the *hardened declared-keys allowlist* (audit
+  recipe-support-3: never spread `process.env`). An input override must be scoped
+  to *declared* trigger vars, or it reopens an injection vector.
+- **sqlite-vec vector cache** (§3.1) `[A]` — **adds a native dependency**
+  (sqlite-vec + better-sqlite3) + needs a cache-invalidation design. Dep sign-off
+  first.
+- **Constrained-decoding judge JSON** (§3.2) `[A]` — **conflicts with the current
+  judge format.** `JUDGE_PROMPT_SUFFIX` asks for "prose assessment + a trailing
+  JSON line"; `response_format: json_object` forces the *whole* response to be
+  JSON. Proper fix = redesign the judge to emit pure structured JSON (assessment
+  as a field) + update `parseJudgeVerdict` + re-verify the refine loop. The
+  driver seam is clean (`ProviderTaskInput.providerOptions` is already a
+  passthrough; add `response_format` in `openai/index.ts`'s `create()` body) —
+  the *judge-contract* change is the real work. Sensitive path; design first.
+- **FlowSvg live run status** (§4) `[B]` — contained, but dashboard/React: needs
+  visual verification (no unit test). A frontend session, not a backend one.
+
+### Phase 2 — Bets (medium effort, high impact)
+7. **Agent-step durability ledger** (§4) `[B]` — crash-resume of expensive LLM
+   steps.
+8. **`PluginContext.getCredential`** (§4) `[B]` — unlocks community connectors.
+9. **Sub-recipe `outputs:` schema** (§4) `[B]` — typed contracts for big
+   compositions.
+10. **oMLX / multi-model backend** (§3.3–3.4) `[A]` — docs + recommended default;
+    multi-model team config.
+
+### Phase 3 — Bigger / research
+11. **Personal-files RAG** over the user's vault (§3.6) `[A]`.
+12. **LiteLLM hybrid local→cloud escalation** (§3.5) `[A]`.
+13. **Fine-tune-on-traces** house-style judge (§3.7) `[A]`.
+14. **Tier 2** dashboard embeddings card + free local helpers (§ below).
+15. **Tier 3** VLM photo-trigger, Whisper voice, iPhone/iPad LM-Link companion
+    (§ below).
+
+---
+
+## Tier 2 — Free in-dashboard AI helpers + embeddings config UI
+
+- **Local-LLM card embeddings fields** — surface `embeddingsEndpoint/Model` in
+  `GET /status` + `POST /config/patchwork` with the **same SSRF validation** as
+  `localEndpoint`, two new rows in `dashboard/src/app/settings/page.tsx:887-933`
+  using the `localDirtyRef`→`embeddingsDirtyRef` poll-guard.
+- **Free dashboard helpers** (`driver: local`, $0): recipe-draft assist,
+  "explain this halt", trace summarization, "explain this step".
+
+## Tier 3 — Beyond text
+
+- **VLM photo-trigger recipes** — MLX vision (Qwen-VL) reads images; new
+  `onPhoto`/image-input trigger feeds a screenshot/photo to a VLM step
+  (recipe-schema work).
+- **Whisper voice** — MLX-Whisper for voice-dictated tasks / voice-note triggers.
+- **iPhone/iPad companion (LM Link pattern)** — phone hits the Mac's MLX server
+  over LAN (RFC1918 already allowed by `isLoopbackOrPrivateEndpoint`); pairs with
+  the existing mobile-oversight push path.
+
+---
+
+## WWDC 2026 — system-MCP readiness (watch + light prep)
+
+> Added 2026-06-09, one day after WWDC. This is a **forward-looking watch item**,
+> not a re-sequencing of the build plan above. The capability is confirmed; the
+> exact registration mechanism is **not yet documented** (in dev-beta + session
+> videos). Treat the Apple-side specifics below as *informed inference* until
+> confirmed from Apple's docs.
+
+**What changed.** iOS 27 / macOS 27 ship **system-wide MCP**: Siri 2.0 can invoke
+**registered MCP servers**, and Core AI routes to MCP as a first-class call
+target. Direction is **OS → server** — the system reaches out and calls tools on
+a server the user registers (apps pushing tools *into* the OS is not open yet).
+Dev beta now; public ~September 2026.
+
+**Why Patchwork is already positioned.** MCP registration only comes in two
+shapes, and the bridge already implements **both**:
+- **Local / stdio:** `claude-ide-bridge shim` is the stdio MCP entrypoint — the
+  exact `{command, args}` registration form.
+- **Remote / HTTP:** the Streamable HTTP `/mcp` endpoint (Bearer) + the full
+  **OAuth 2.0 mode** (`--issuer-url`; authorize/token/dynamic-registration/PKCE)
+  — exactly what an OS-level MCP client uses to connect to a running server with
+  user consent.
+
+Whatever Apple's registration config turns out to be, Patchwork most likely
+already speaks it. Effort ≈ *register + grant consent + expose a safe surface*,
+not *build MCP support*.
+
+**Nice property:** a Siri-triggered **write** still passes through Patchwork's
+own approval gate (`src/approvalHttp.ts`), so the two safety layers compose —
+Siri convenience + Patchwork's human-approval net on risky actions.
+
+**The one thing worth doing now (small, independent):** define a **slim,
+Siri-safe tool surface**. Do NOT expose all 177 tools (shell/write/git) to Core
+AI. Reuse `--slim` + tool-capability filtering to register a deliberately narrow
+read-mostly set (e.g. run-recipe, status, a few reads). This is buildable today
+and is the only part not gated on Apple's timeline.
+
+**Confirm from Apple before any real wiring:** (a) the exact registration
+file/settings location; (b) whether it accepts remote+OAuth or **local-stdio
+only** (Apple likely favors local first → the `shim`); (c) any notarization /
+entitlement requirement for the registered server binary.
+
+**Roadmap placement:** a **Phase 3+ watch item**. Do not block the Phase 0
+keystone on it. Track Apple's docs; ship the slim tool surface opportunistically.
+
+---
+
+## Dev test-bench value
+
+A free, real local model is a high-fidelity test bench: exercise
+`OpenAIApiDriver` streaming + the 50 KB `OUTPUT_CAP`/abort
+(`src/drivers/openai/index.ts:137-177`), the flat (`yamlRunner.ts:991`) +
+chained (`chainedRunner.ts:838`) runners, the judge→refine loop, and the cost
+router with a $0 driver — all day, no rate limits, no bill. The dashboard
+Local-LLM card round-trips against a live server.
+
+---
+
+## 6. Verified external building blocks (appendix)
+
+Independently confirmed to exist (hand-checked; the research workflow's blanket
+"verified" was not trusted):
+
+| Tool | What | Borrow for | Verified |
+|---|---|---|---|
+| [oMLX](https://github.com/jundot/omlx) | MLX server, SSD-tiered KV cache, multi-model LRU, JSON output | §3.3 backend; §3.4 team | ✅ 16.3k★ |
+| [Rapid-MLX](https://github.com/raullenchai/Rapid-MLX) | fast MLX server, 17-parser tool-calling, cloud routing | §3.5 escalation | ✅ 2.7k★ |
+| [vllm-mlx](https://github.com/waybarrios/vllm-mlx) | continuous batching, OpenAI+Anthropic, embeddings | §3.4 | ✅ 1.3k★ |
+| [mlx-omni-server](https://github.com/madroidmaq/mlx-omni-server) | MLX server w/ structured output + tool calling | §3.2 judge JSON | ✅ 723★ |
+| [qwen3-embeddings-mlx](https://github.com/jakedahn/qwen3-embeddings-mlx) | MLX embedding REST server, 44K tok/s | §3.1 sidecar (early — fork, don't depend) | ✅ 15★ |
+| [sqlite-vec](https://github.com/asg017/sqlite-vec) | SQLite vector ext (Node) | §3.1 cache (pin v0.1.9, pre-v1) | ✅ |
+| [node-llama-cpp](https://github.com/withcatai/node-llama-cpp) | in-process llama.cpp + grammar (TS) | §3.2 no-sidecar JSON | ✅ |
+| [XGrammar](https://github.com/mlc-ai/xgrammar) / [llama.cpp](https://github.com/ggml-org/llama.cpp) | constrained decoding backends | §3.2 | ✅ |
+| [llama-swap](https://github.com/mostlygeek/llama-swap) | model swap proxy | §3.4 team | ✅ |
+| [LiteLLM](https://github.com/BerriAI/litellm) | routing proxy + fallbacks | §3.5 hybrid | ✅ |
+| [Khoj](https://github.com/khoj-ai/khoj) / [mem0](https://github.com/mem0ai/mem0) | personal-file RAG patterns | §3.6 | ✅ |
+| [mlx-lm](https://github.com/ml-explore/mlx-lm) / [mlx-embeddings](https://github.com/Blaizzy/mlx-embeddings) | official MLX LLM + embedding libs | §3.7 / §3.1 | ✅ |
+
+---
+
+## 7. Honest caveats
+
+- **Apple-Silicon only.** MLX needs an M-series Mac. The integration is
+  config-gated + fail-soft; non-Mac installs never configure
+  `LOCAL_EMBEDDINGS_ENDPOINT` and keep substring search.
+- **CI runs on Linux.** Live-model tests can't run there. Unit tests inject a
+  mock `fetchImpl`; the smoke test is opt-in, skipped unless `MLX_SMOKE === "1"`.
+- **MLX embedding/server tools are Python** → the Node bridge needs a
+  `child_process` sidecar, *or* use Ollama `nomic-embed-text` (already supported,
+  zero new code) for the lowest-friction path.
+- **Pin pre-v1 deps.** sqlite-vec → v0.1.9; qwen3-embeddings-mlx (15★) is a
+  reference to fork, not a dependency; prefer
+  [mlx-embeddings (Blaizzy)](https://github.com/Blaizzy/mlx-embeddings) over the
+  stale taylorai one.
+- **oMLX is new** despite the star count — pilot before defaulting.
+- **Ollama constrained decoding is weaker** than vLLM/llama.cpp (its `format`
+  param doesn't expose grammar/`guided_json` the same way) — prefer vLLM or
+  llama.cpp for the judge JSON guarantee.
+- **Big models are smart-but-not-instant.** Keep the small-for-triage /
+  big-for-judge split.
+- **Usage capture depends on the server** emitting an OpenAI `usage` chunk;
+  missing ⇒ budgets fail open (fine for a $0 driver).
+- **Embedding dims must match** across a corpus; re-embed on model change
+  (in-memory today — §3.1 fixes this with a keyed persistent cache).

--- a/docs/mlx-integration.md
+++ b/docs/mlx-integration.md
@@ -1,0 +1,282 @@
+# MLX Integration — Setup Guide
+
+> How to run Apple [MLX](https://github.com/ml-explore/mlx) on-device models
+> behind Patchwork's existing `local` chat driver **and** the new embeddings
+> env, plus how to exercise the dev test-bench and run the opt-in `MLX_SMOKE`
+> integration test.
+>
+> Architecture, rationale, and the sequenced build order live in the companion
+> roadmap: [docs/mlx-integration-plan.md](mlx-integration-plan.md). This file is
+> the operational how-to.
+
+MLX runs LLMs and embedding models natively on Apple Silicon and exposes them
+over an **OpenAI-compatible HTTP API**. Patchwork's `local` driver already
+speaks that surface, so chat works with config alone; embeddings add two env
+vars. Everything is fail-soft: a non-Mac install that never configures these
+vars is unaffected.
+
+---
+
+## 1. Install + launch an MLX server
+
+You need an OpenAI-compatible server listening on loopback. Any of the three
+below work — pick the one that matches what you want resident.
+
+### Option A — `mlx_lm.server` (chat / judge / triage)
+
+```bash
+pip install mlx-lm
+# Serve a chat model on :8080 (OpenAI-compatible /v1/chat/completions)
+mlx_lm.server \
+  --model mlx-community/Qwen2.5-32B-Instruct-4bit \
+  --host 127.0.0.1 --port 8080
+```
+
+Endpoint base URL: `http://localhost:8080/v1`
+
+### Option B — Ollama-on-MLX (chat **and** embeddings on one port)
+
+```bash
+# Ollama uses an MLX-accelerated backend on Apple Silicon.
+ollama serve                       # listens on :11434
+ollama pull qwen2.5:32b            # chat / judge
+ollama pull nomic-embed-text       # embeddings
+```
+
+Endpoint base URL: `http://localhost:11434/v1` — serves both
+`/v1/chat/completions` and `/v1/embeddings`, so one endpoint covers chat +
+embeddings.
+
+### Option C — `mlx-embeddings` (dedicated embeddings server)
+
+```bash
+pip install mlx-embeddings
+# Serve an embedding model on its own port (OpenAI-compatible /v1/embeddings)
+python -m mlx_embeddings.server \
+  --model mlx-community/nomic-embed-text-v1.5 \
+  --host 127.0.0.1 --port 8081
+```
+
+Endpoint base URL: `http://localhost:8081/v1`
+
+> Run a chat server (A) **and** a dedicated embeddings server (C) side by side,
+> or a single Ollama instance (B) that does both. The config below supports
+> either topology.
+
+---
+
+## 2. Point the chat driver at MLX
+
+The `local` driver subclasses `OpenAIApiDriver` with a swapped `baseURL` +
+`defaultModel` (`src/drivers/local/index.ts:29-62`). It reads `LOCAL_ENDPOINT`
++ `LOCAL_MODEL` at construction.
+
+### Via `~/.patchwork/config.json` (recommended)
+
+```jsonc
+// ~/.patchwork/config.json
+{
+  "localEndpoint": "http://localhost:8080/v1",
+  "localModel": "mlx-community/Qwen2.5-32B-Instruct-4bit"
+}
+```
+
+At bridge startup these flow into the env vars **non-destructively** — only set
+when the env var is unset (`src/config.ts:589-592`):
+
+```ts
+if (pw.localEndpoint && !process.env.LOCAL_ENDPOINT)
+  process.env.LOCAL_ENDPOINT = pw.localEndpoint;
+if (pw.localModel && !process.env.LOCAL_MODEL)
+  process.env.LOCAL_MODEL = pw.localModel;
+```
+
+### Via env vars (headless / CI / scripts)
+
+```bash
+export LOCAL_ENDPOINT=http://localhost:8080/v1
+export LOCAL_MODEL=mlx-community/Qwen2.5-32B-Instruct-4bit
+# LOCAL_API_KEY is optional — defaults to the "ollama" placeholder
+```
+
+### Use it in a recipe
+
+```yaml
+steps:
+  - id: triage
+    agent:
+      driver: local                # $0, on-device
+      model: mlx-community/Qwen2.5-7B-Instruct-4bit  # per-step override
+      prompt: "Classify this inbound message: {{input}}"
+```
+
+`driver: local` is intentionally excluded from `BILLABLE_DRIVERS`
+(`src/recipes/runBudget.ts:43`), so the step never increments `usdSpent` and
+never trips a budget halt — judge→refine loops and bulk classification run
+unmetered.
+
+---
+
+## 3. Point embeddings at MLX
+
+Embeddings are an internal module (`src/embeddings/`) — **not** an MCP tool.
+The factory reads, in precedence order
+(`src/embeddings/localEndpoints.ts:17-41`):
+
+| Setting    | 1st         | 2nd                         | 3rd (fallback)     | default            |
+|------------|-------------|-----------------------------|--------------------|--------------------|
+| Endpoint   | `opts.endpoint` | `LOCAL_EMBEDDINGS_ENDPOINT` | `LOCAL_ENDPOINT`   | _(unset ⇒ null)_   |
+| Model      | `opts.model`    | `LOCAL_EMBEDDINGS_MODEL`    | `LOCAL_MODEL`      | `nomic-embed-text` |
+
+So if your MLX server (Ollama-on-MLX) serves chat **and** embeddings on the
+same port, `LOCAL_ENDPOINT` alone is enough. To use a dedicated embeddings
+server (Option C), set the embeddings vars explicitly:
+
+```bash
+export LOCAL_EMBEDDINGS_ENDPOINT=http://localhost:8081/v1
+export LOCAL_EMBEDDINGS_MODEL=mlx-community/nomic-embed-text-v1.5
+```
+
+The factory POSTs to `<endpoint>/embeddings` with the OpenAI-compatible shape
+`{ model, input: string[] }` and reads back `{ data: [{ embedding: number[] }] }`.
+
+### How `ctxQueryTraces semantic:true` uses it
+
+By default `ctxQueryTraces` `q` search is substring-only
+(`src/tools/ctxQueryTraces.ts:238-248`), sorted by recency. With an embeddings
+endpoint configured, the opt-in `semantic: true` arg embeds the query once,
+cosine-scores each pooled trace's richest text against it
+(`cosineSimilarity`, `src/embeddings/cosine.ts:17`), drops anything below a
+floor, and sorts by score DESC instead of `b.ts - a.ts`. A past fix worded
+differently ("auth token leak" vs "credential exposure") then surfaces.
+
+**Fail-soft:** if no embeddings endpoint is configured the factory returns
+`null`, and `ctxQueryTraces` falls straight back to substring matching. It
+never throws.
+
+---
+
+## 4. SSRF note — loopback / RFC1918 only
+
+Both the chat driver and the embeddings provider stream your prompt + context
+to the configured URL. To stop a phishy "free local LLM" link from exfiltrating
+that data, the endpoint is checked with the shared guard
+`isLoopbackOrPrivateEndpoint` (`src/localEndpointGuard.ts:25`). Allowed hosts:
+
+- `localhost` / `127.0.0.1` / `::1`
+- RFC1918 private space — `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`
+- link-local `169.254.0.0/16`, `fe80::/10`; unique-local `fc00::/7`
+- single-label `.local` / `.lan` / `.home` / `.internal` mDNS forms
+
+A **public** endpoint is rejected unless you explicitly opt out:
+
+```bash
+export LOCAL_ENDPOINT_ALLOW_REMOTE=1   # only for audited internal clusters
+```
+
+The same override applies to the embeddings endpoint — it shares the guard and
+the env flag with the chat driver (`src/drivers/local/index.ts:39-49`).
+
+---
+
+## 5. High-memory Apple Silicon sizing
+
+A high-memory Apple Silicon Mac (64 GB+, ideally 128 GB of unified memory) lets
+you hold **three models resident at once** and route per role:
+
+| Role               | Example model (MLX)                  | Approx footprint | Why |
+|--------------------|--------------------------------------|------------------|-----|
+| Judge / refine     | Qwen2.5-32B / Llama-3.3-70B (4-bit)  | ~20–40 GB        | Big enough to be a credible reviewer in the judge→refine loop. |
+| Triage / classify  | Qwen2.5-7B / Llama-3.2-3B (4-bit)    | ~2–5 GB          | Fast first-pass labelling, routing, summarize. |
+| Embeddings         | `nomic-embed-text` / `bge-small`     | <1 GB            | Powers semantic trace search. |
+
+The "small-for-triage / big-for-judge" split is the practical pattern: the big
+model is **smart but not instant**, so reserve it for steps that need reasoning
+(judge verdicts, refinement) and let the small model handle high-volume triage.
+All three share the OpenAI-compatible surface, so a recipe just sets `model:`
+per step. Worst case all three fit at once with headroom for the OS — start the
+chat server (A), a triage server, and an embeddings server (C) on three ports.
+
+> Don't mix embedding models across one trace corpus — cosine over
+> mismatched-dimension vectors is meaningless. Re-embed if the model changes.
+
+---
+
+## 6. Dev test-bench — exercise Patchwork against a free local server
+
+A real, $0 local model is a high-fidelity test bench. With the chat env vars
+set (section 2):
+
+- **Driver streaming + output cap.** Run any `driver: local` recipe step and
+  watch `OpenAIApiDriver` stream, apply the 50 KB `OUTPUT_CAP` / mid-stream
+  abort (`src/drivers/openai/index.ts`), and capture the usage chunk — without
+  spending a cent.
+
+  ```bash
+  patchwork recipe run <name> --driver local
+  ```
+
+- **Recipe runner — flat + chained.** Exercise the flat path
+  (`src/recipes/yamlRunner.ts:991`) and the chained DAG path
+  (`src/recipes/chainedRunner.ts:838`) with a `driver: local` recipe.
+
+- **Judge → refine loop, unmetered.** Set `kind: judge` + `max_revisions: N`
+  on a `driver: local` step and run the self-correction loop all day with no
+  budget halt and no rate limit.
+
+- **Cost router fails open for `local`.** Confirm `local` flows through budget
+  as free: `quoteUsd()` returns `undefined` and `reconcile()` emits the
+  one-time `notbilled:local` notice (`src/recipes/runBudget.ts:201`) without
+  ever blocking `admit()`.
+
+---
+
+## 7. Run the `MLX_SMOKE` integration test
+
+The smoke test (`src/embeddings/__tests__/mlxSmoke.integration.test.ts`) hits a
+**real** local server — chat + embeddings — over the live `globalThis.fetch`.
+It is **skipped unless `MLX_SMOKE === "1"`**, so the Linux CI run is a no-op and
+never tries to reach a server that doesn't exist there.
+
+### Default (CI, no MLX) — all skipped
+
+```bash
+npx vitest run src/embeddings/__tests__/mlxSmoke.integration.test.ts
+# → all tests skipped, 0 failures
+```
+
+### On your Mac with MLX running — assertions execute
+
+```bash
+MLX_SMOKE=1 \
+  LOCAL_ENDPOINT=http://localhost:8080/v1 \
+  LOCAL_MODEL=mlx-community/Qwen2.5-7B-Instruct-4bit \
+  LOCAL_EMBEDDINGS_ENDPOINT=http://localhost:8080/v1 \
+  LOCAL_EMBEDDINGS_MODEL=nomic-embed-text \
+  npx vitest run src/embeddings/__tests__/mlxSmoke.integration.test.ts
+```
+
+The test then:
+
+1. **Chat** — runs a one-shot prompt through `LocalApiDriver` against
+   `LOCAL_ENDPOINT` / `LOCAL_MODEL` and asserts non-empty text comes back.
+2. **Embeddings** — builds a provider via `createEmbeddingsProvider()`
+   (reads `LOCAL_EMBEDDINGS_ENDPOINT` / `LOCAL_EMBEDDINGS_MODEL`), embeds two
+   short strings, and asserts two vectors of matching dimension with a cosine
+   similarity in `[-1, 1]`.
+
+If a required env var is missing while `MLX_SMOKE=1`, the corresponding test
+fails with a clear message telling you which var to set — there are no
+hardcoded URLs.
+
+---
+
+## See also
+
+- [docs/mlx-integration-plan.md](mlx-integration-plan.md) — architecture +
+  sequenced build (Tier 0 chat, Tier 1 embeddings + semantic trace search,
+  Tier 2 dashboard config, Tier 3 VLM / Whisper / mobile).
+- `src/drivers/local/index.ts` — the `local` chat driver.
+- `src/embeddings/` — the embeddings provider, cosine math, and endpoint
+  precedence.
+- `src/localEndpointGuard.ts` — the shared SSRF guard.

--- a/docs/perf-baseline.md
+++ b/docs/perf-baseline.md
@@ -10,7 +10,7 @@ bridge. Results are point-in-time and loopback-only.
   elimination + post shape-mismatch CI gate + new launchQuickTask + CLI)
 - Transport: WebSocket on 127.0.0.1, no TLS, no proxy
 - Iterations: 500 per tool
-- Host: macOS (Darwin 25.3.0 arm64, Apple M4 Max), Node v24.4.1
+- Host: macOS (arm64 Apple Silicon), Node v24.4.1
 - Extension: not connected (probe-path tools exercised; extension-gated tools
   short-circuit and return `extension_required` faster than wire-RTT)
 - Captured: 2026-04-16 via `scripts/benchmark.mjs 55000 --iterations 500 --json`

--- a/src/__tests__/approvalHttp-channel.test.ts
+++ b/src/__tests__/approvalHttp-channel.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Audit 2026-06-09 — every `approval_decision` audit row carries a `channel`
+ * provenance field so operators can tell a phone approval (single-use token via
+ * ntfy/push) from a dashboard/Bearer approval. The audit log already answered
+ * who/what/when; this adds "from where".
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import { routeApprovalRequest } from "../approvalHttp.js";
+import type { ApprovalQueue } from "../approvalQueue.js";
+
+function makeQueue(opts?: {
+  validateToken?: (callId: string, token: string) => boolean;
+  approve?: (callId: string) => boolean;
+  reject?: (callId: string) => boolean;
+  getRecentDecision?: (callId: string) => "allow" | "deny" | undefined;
+}): ApprovalQueue {
+  return {
+    validateToken: opts?.validateToken ?? (() => true),
+    approve: opts?.approve ?? (() => true),
+    reject: opts?.reject ?? (() => true),
+    getRecentDecision: opts?.getRecentDecision ?? (() => undefined),
+    enqueue: () => Promise.resolve({ callId: "test", timedOut: false }),
+    cancelPending: () => {},
+    getPendingList: () => [],
+    on: () => {},
+    off: () => {},
+    isPending: () => false,
+    getFailureCount: () => 0,
+  } as unknown as ApprovalQueue;
+}
+
+describe("routeApprovalRequest — approval_decision channel provenance", () => {
+  it("tags an approve via single-use token as channel:phone", async () => {
+    const onDecision = vi.fn();
+    await routeApprovalRequest(
+      {
+        method: "POST",
+        path: "/approve/call-1",
+        body: {},
+        approvalToken: "valid",
+      },
+      {
+        queue: makeQueue({ validateToken: () => true, approve: () => true }),
+        workspace: "/tmp",
+        onDecision,
+      },
+    );
+    expect(onDecision).toHaveBeenCalledWith(
+      "approval_decision",
+      expect.objectContaining({
+        callId: "call-1",
+        decision: "allow",
+        channel: "phone",
+      }),
+    );
+  });
+
+  it("tags an approve without a token as channel:dashboard", async () => {
+    const onDecision = vi.fn();
+    await routeApprovalRequest(
+      {
+        method: "POST",
+        path: "/approve/call-2",
+        body: {},
+        approvalToken: undefined,
+      },
+      {
+        queue: makeQueue({ approve: () => true }),
+        workspace: "/tmp",
+        onDecision,
+      },
+    );
+    expect(onDecision).toHaveBeenCalledWith(
+      "approval_decision",
+      expect.objectContaining({
+        callId: "call-2",
+        decision: "allow",
+        channel: "dashboard",
+      }),
+    );
+  });
+
+  it("tags a reject via single-use token as channel:phone (alongside reason)", async () => {
+    const onDecision = vi.fn();
+    await routeApprovalRequest(
+      {
+        method: "POST",
+        path: "/reject/call-3",
+        body: { reason: "looks risky" },
+        approvalToken: "valid",
+      },
+      {
+        queue: makeQueue({ validateToken: () => true, reject: () => true }),
+        workspace: "/tmp",
+        onDecision,
+      },
+    );
+    expect(onDecision).toHaveBeenCalledWith(
+      "approval_decision",
+      expect.objectContaining({
+        callId: "call-3",
+        decision: "deny",
+        reason: "looks risky",
+        channel: "phone",
+      }),
+    );
+  });
+
+  it("tags a reject without a token as channel:dashboard", async () => {
+    const onDecision = vi.fn();
+    await routeApprovalRequest(
+      {
+        method: "POST",
+        path: "/reject/call-4",
+        body: {},
+        approvalToken: undefined,
+      },
+      {
+        queue: makeQueue({ reject: () => true }),
+        workspace: "/tmp",
+        onDecision,
+      },
+    );
+    expect(onDecision).toHaveBeenCalledWith(
+      "approval_decision",
+      expect.objectContaining({
+        callId: "call-4",
+        decision: "deny",
+        channel: "dashboard",
+      }),
+    );
+  });
+});

--- a/src/approvalHttp.ts
+++ b/src/approvalHttp.ts
@@ -242,7 +242,16 @@ export async function routeApprovalRequest(
       // Audit 2026-06-03 (MEDIUM #27): fire the audit hook on APPROVE too —
       // previously only the reject path called onDecision, so approvals (the
       // higher-risk decision) left no audit/activity-log trail.
-      deps.onDecision?.("approval_decision", { callId, decision: "allow" });
+      deps.onDecision?.("approval_decision", {
+        callId,
+        decision: "allow",
+        // Provenance (audit 2026-06-09): which path the human decided from.
+        // A single-use approvalToken ⇒ phone (ntfy/push action button);
+        // otherwise a Bearer-authenticated HTTP caller — the dashboard
+        // approval UI in practice. Lets the audit log answer "approved from
+        // where", not just "who/what/when".
+        channel: req.approvalToken !== undefined ? "phone" : "dashboard",
+      });
       return { status: 200, body: { decision: "allow", callId } };
     }
     // Distinguish "callId never existed" from "callId was decided by a
@@ -289,6 +298,8 @@ export async function routeApprovalRequest(
         callId,
         decision: "deny",
         ...(reason !== undefined && { reason }),
+        // Provenance: phone (single-use token) vs dashboard/Bearer caller.
+        channel: req.approvalToken !== undefined ? "phone" : "dashboard",
       });
       return { status: 200, body: { decision: "deny", callId } };
     }

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -16,6 +16,7 @@ import { CommitIssueLinkLog } from "./commitIssueLinkLog.js";
 import type { Config } from "./config.js";
 import { DecisionTraceLog } from "./decisionTraceLog.js";
 import { createDriver } from "./drivers/index.js";
+import { getLocalEmbedFn } from "./embeddings/index.js";
 import { ExtensionClient } from "./extensionClient.js";
 import { lockKillSwitchEnv, watchFlags } from "./featureFlags.js";
 import { FileLock } from "./fileLock.js";
@@ -1274,6 +1275,7 @@ export class Bridge {
         commitIssueLinkLog: this.commitIssueLinkLog,
         recipeRunLog: this.recipeRunLog,
         decisionTraceLog: this.decisionTraceLog,
+        embedFn: getLocalEmbedFn(),
       });
       const result = await tool.handler({
         ...(query.traceType && { traceType: query.traceType }),

--- a/src/config.ts
+++ b/src/config.ts
@@ -590,6 +590,14 @@ export function parseConfig(argv: string[]): Config {
         process.env.LOCAL_ENDPOINT = pw.localEndpoint;
       if (pw.localModel && !process.env.LOCAL_MODEL)
         process.env.LOCAL_MODEL = pw.localModel;
+      // Seed dedicated embeddings endpoint/model (powers ctxQueryTraces semantic
+      // search). Falls back to LOCAL_ENDPOINT/LOCAL_MODEL in the provider when
+      // unset, so a single MLX/Ollama server serving both chat + embeddings
+      // needs only localEndpoint/localModel.
+      if (pw.localEmbeddingsEndpoint && !process.env.LOCAL_EMBEDDINGS_ENDPOINT)
+        process.env.LOCAL_EMBEDDINGS_ENDPOINT = pw.localEmbeddingsEndpoint;
+      if (pw.localEmbeddingsModel && !process.env.LOCAL_EMBEDDINGS_MODEL)
+        process.env.LOCAL_EMBEDDINGS_MODEL = pw.localEmbeddingsModel;
       // Seed API keys as env vars if not already set (non-destructive)
       if (pw.apiKeys) {
         if (pw.apiKeys.openai && !process.env.OPENAI_API_KEY)

--- a/src/drivers/__tests__/openai-response-format.test.ts
+++ b/src/drivers/__tests__/openai-response-format.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { OpenAIApiDriver } from "../openai/index.js";
+
+const mockCreate = vi.fn();
+vi.mock("openai", () => ({
+  // biome-ignore lint/complexity/useArrowFunction: must be constructable with `new`
+  default: vi.fn().mockImplementation(function () {
+    return { chat: { completions: { create: mockCreate } } };
+  }),
+}));
+
+const log = vi.fn();
+
+function makeStream(chunks: string[]): AsyncIterable<unknown> {
+  return {
+    [Symbol.asyncIterator]: async function* () {
+      for (const c of chunks) yield { choices: [{ delta: { content: c } }] };
+    },
+  };
+}
+
+async function run(providerOptions?: Record<string, unknown>) {
+  mockCreate.mockResolvedValue(makeStream(["{}"]));
+  const driver = new OpenAIApiDriver(log);
+  await driver.run({
+    prompt: "judge this",
+    workspace: "/tmp",
+    timeoutMs: 5000,
+    signal: AbortSignal.timeout(5000),
+    ...(providerOptions ? { providerOptions } : {}),
+  });
+  return mockCreate.mock.calls[0]?.[0] as Record<string, unknown>;
+}
+
+beforeEach(() => {
+  mockCreate.mockReset();
+  log.mockReset();
+  vi.stubEnv("OPENAI_API_KEY", "test-key");
+});
+afterEach(() => {
+  mockCreate.mockReset();
+  vi.unstubAllEnvs();
+});
+
+describe("OpenAIApiDriver — response_format passthrough (constrained decoding)", () => {
+  it("forwards providerOptions.responseFormat as response_format", async () => {
+    const body = await run({ responseFormat: { type: "json_object" } });
+    expect(body.response_format).toEqual({ type: "json_object" });
+  });
+
+  it("forwards a json_schema response_format object verbatim", async () => {
+    const rf = {
+      type: "json_schema",
+      json_schema: { name: "verdict", schema: { type: "object" } },
+    };
+    const body = await run({ responseFormat: rf });
+    expect(body.response_format).toEqual(rf);
+  });
+
+  it("omits response_format when not requested", async () => {
+    const body = await run();
+    expect("response_format" in body).toBe(false);
+  });
+
+  it("ignores a non-object responseFormat (fail-safe)", async () => {
+    const body = await run({ responseFormat: "json_object" });
+    expect("response_format" in body).toBe(false);
+  });
+});

--- a/src/drivers/openai/index.ts
+++ b/src/drivers/openai/index.ts
@@ -67,6 +67,17 @@ export class OpenAIApiDriver implements ProviderDriver {
       typeof opts.maxTokens === "number" ? opts.maxTokens : 4096;
     const temperature =
       typeof opts.temperature === "number" ? opts.temperature : undefined;
+    // Structured-output passthrough (audit 2026-06-09): when a caller sets
+    // providerOptions.responseFormat (e.g. { type: "json_object" } or
+    // { type: "json_schema", json_schema: {...} }), forward it to the API so
+    // OpenAI-compatible servers that support constrained decoding (vLLM/XGrammar,
+    // llama.cpp, LM Studio) enforce valid structured output at the token level.
+    // Endpoints that don't support it simply ignore the field. Foundation for
+    // hardening the judge→refine verdict JSON on local models.
+    const responseFormat =
+      opts.responseFormat && typeof opts.responseFormat === "object"
+        ? opts.responseFormat
+        : undefined;
 
     const contextNote =
       input.contextFiles && input.contextFiles.length > 0
@@ -110,6 +121,7 @@ export class OpenAIApiDriver implements ProviderDriver {
           ...(temperature !== undefined ? { temperature } : {}),
           messages,
           stream: true,
+          ...(responseFormat ? { response_format: responseFormat } : {}),
           // Ask the API to emit a final usage chunk (prompt/completion token
           // counts) so RunBudget can enforce a real token/USD budget instead
           // of failing open. Compliant OpenAI-style endpoints return it; an

--- a/src/embeddings/__tests__/cosine.test.ts
+++ b/src/embeddings/__tests__/cosine.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import { cosineSimilarity, topK } from "../cosine.js";
+
+describe("cosineSimilarity", () => {
+  it("returns 1 for identical vectors", () => {
+    expect(cosineSimilarity([1, 2, 3], [1, 2, 3])).toBeCloseTo(1, 10);
+    expect(cosineSimilarity([0.5, 0.5], [0.5, 0.5])).toBeCloseTo(1, 10);
+  });
+
+  it("returns 1 for parallel (scaled) vectors", () => {
+    expect(cosineSimilarity([1, 2, 3], [2, 4, 6])).toBeCloseTo(1, 10);
+  });
+
+  it("returns 0 for orthogonal vectors", () => {
+    expect(cosineSimilarity([1, 0], [0, 1])).toBe(0);
+    expect(cosineSimilarity([1, 0, 0], [0, 1, 0])).toBe(0);
+  });
+
+  it("returns -1 for opposite vectors", () => {
+    expect(cosineSimilarity([1, 2, 3], [-1, -2, -3])).toBeCloseTo(-1, 10);
+  });
+
+  it("returns 0 on length mismatch (no throw)", () => {
+    expect(cosineSimilarity([1, 2, 3], [1, 2])).toBe(0);
+    expect(cosineSimilarity([1], [1, 2, 3, 4])).toBe(0);
+  });
+
+  it("returns 0 for a zero vector (no NaN)", () => {
+    const r = cosineSimilarity([0, 0, 0], [1, 2, 3]);
+    expect(r).toBe(0);
+    expect(Number.isNaN(r)).toBe(false);
+  });
+
+  it("returns 0 for two zero vectors (no NaN)", () => {
+    const r = cosineSimilarity([0, 0], [0, 0]);
+    expect(r).toBe(0);
+    expect(Number.isNaN(r)).toBe(false);
+  });
+
+  it("returns 0 for empty vectors (no NaN)", () => {
+    const r = cosineSimilarity([], []);
+    expect(r).toBe(0);
+    expect(Number.isNaN(r)).toBe(false);
+  });
+});
+
+describe("topK", () => {
+  const score = (n: number) => n;
+
+  it("returns exactly k items in score-descending order", () => {
+    expect(topK([3, 1, 4, 1, 5, 9, 2], score, 3)).toEqual([9, 5, 4]);
+  });
+
+  it("returns all items when k exceeds the list length", () => {
+    expect(topK([3, 1, 2], score, 10)).toEqual([3, 2, 1]);
+  });
+
+  it("returns [] for k <= 0", () => {
+    expect(topK([1, 2, 3], score, 0)).toEqual([]);
+    expect(topK([1, 2, 3], score, -5)).toEqual([]);
+  });
+
+  it("returns [] for an empty list", () => {
+    expect(topK([], score, 3)).toEqual([]);
+  });
+
+  it("is stable for ties — original order preserved among equal scores", () => {
+    const items = [
+      { id: "a", s: 5 },
+      { id: "b", s: 5 },
+      { id: "c", s: 9 },
+      { id: "d", s: 5 },
+    ];
+    const result = topK(items, (i) => i.s, 4).map((i) => i.id);
+    // c first (highest), then a, b, d in original relative order.
+    expect(result).toEqual(["c", "a", "b", "d"]);
+  });
+
+  it("respects k while keeping tie stability", () => {
+    const items = [
+      { id: "a", s: 1 },
+      { id: "b", s: 1 },
+      { id: "c", s: 1 },
+    ];
+    expect(topK(items, (i) => i.s, 2).map((i) => i.id)).toEqual(["a", "b"]);
+  });
+});

--- a/src/embeddings/__tests__/getLocalEmbedFn.test.ts
+++ b/src/embeddings/__tests__/getLocalEmbedFn.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { getLocalEmbedFn } from "../index.js";
+
+function mockFetch(body: unknown, ok = true, status = 200) {
+  return vi.fn(async () => ({
+    ok,
+    status,
+    json: async () => body,
+    text: async () => (typeof body === "string" ? body : JSON.stringify(body)),
+  })) as unknown as typeof fetch;
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
+});
+
+describe("getLocalEmbedFn — registration-site wiring helper", () => {
+  it("returns undefined when no endpoint is configured anywhere", () => {
+    vi.stubEnv("LOCAL_EMBEDDINGS_ENDPOINT", "");
+    vi.stubEnv("LOCAL_ENDPOINT", "");
+    expect(getLocalEmbedFn()).toBeUndefined();
+  });
+
+  it("returns a bound embed fn when configured (falls back to LOCAL_ENDPOINT)", () => {
+    vi.stubEnv("LOCAL_EMBEDDINGS_ENDPOINT", "");
+    vi.stubEnv("LOCAL_ENDPOINT", "http://127.0.0.1:11434/v1");
+    expect(typeof getLocalEmbedFn()).toBe("function");
+  });
+
+  it("the returned fn delegates to the provider without losing `this`", async () => {
+    const fetchImpl = mockFetch({
+      data: [{ embedding: [0.1, 0.2] }, { embedding: [0.3, 0.4] }],
+    });
+    const fn = getLocalEmbedFn({
+      endpoint: "http://127.0.0.1:11434/v1",
+      model: "nomic-embed-text",
+      fetchImpl,
+    });
+    expect(fn).toBeDefined();
+    await expect(fn?.(["a", "b"])).resolves.toEqual([
+      [0.1, 0.2],
+      [0.3, 0.4],
+    ]);
+  });
+
+  it("never throws — a public endpoint without allow-remote yields a fn that resolves to null", async () => {
+    vi.stubEnv("LOCAL_ENDPOINT_ALLOW_REMOTE", "");
+    const fetchImpl = mockFetch({ data: [] });
+    const fn = getLocalEmbedFn({
+      endpoint: "https://evil.example.com/v1",
+      fetchImpl,
+    });
+    expect(typeof fn).toBe("function");
+    await expect(fn?.(["x"])).resolves.toBeNull();
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+});

--- a/src/embeddings/__tests__/localEmbeddings.test.ts
+++ b/src/embeddings/__tests__/localEmbeddings.test.ts
@@ -1,0 +1,142 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createEmbeddingsProvider } from "../index.js";
+import { LocalEmbeddingsProvider } from "../localEmbeddings.js";
+
+function mockFetch(body: unknown, ok = true, status = 200) {
+  return vi.fn(async () => ({
+    ok,
+    status,
+    json: async () => body,
+    text: async () => (typeof body === "string" ? body : JSON.stringify(body)),
+  })) as unknown as typeof fetch;
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
+});
+
+describe("LocalEmbeddingsProvider.embed — happy path", () => {
+  it("returns the vectors and POSTs { model, input } to <endpoint>/embeddings", async () => {
+    const fetchImpl = mockFetch({
+      data: [{ embedding: [0.1, 0.2, 0.3] }, { embedding: [0.4, 0.5, 0.6] }],
+    });
+    const provider = new LocalEmbeddingsProvider({
+      endpoint: "http://localhost:11434/v1",
+      model: "nomic-embed-text",
+      fetchImpl,
+    });
+
+    const result = await provider.embed(["hello", "world"]);
+    expect(result).toEqual([
+      [0.1, 0.2, 0.3],
+      [0.4, 0.5, 0.6],
+    ]);
+
+    const mock = fetchImpl as unknown as ReturnType<typeof vi.fn>;
+    expect(mock).toHaveBeenCalledTimes(1);
+    const call = mock.mock.calls[0] as [string, RequestInit];
+    const url = call[0];
+    const init = call[1];
+    expect(url).toBe("http://localhost:11434/v1/embeddings");
+    expect(init.method).toBe("POST");
+    const sentBody = JSON.parse(init.body as string);
+    expect(sentBody).toEqual({
+      model: "nomic-embed-text",
+      input: ["hello", "world"],
+    });
+    expect((init.headers as Record<string, string>).Authorization).toBe(
+      "Bearer ollama",
+    );
+  });
+
+  it("returns [] for an empty input without calling fetch", async () => {
+    const fetchImpl = mockFetch({ data: [] });
+    const provider = new LocalEmbeddingsProvider({
+      endpoint: "http://127.0.0.1:1234/v1",
+      fetchImpl,
+    });
+    const result = await provider.embed([]);
+    expect(result).toEqual([]);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+});
+
+describe("createEmbeddingsProvider factory", () => {
+  it("returns null when no endpoint is configured (no env, no opts)", () => {
+    vi.stubEnv("LOCAL_EMBEDDINGS_ENDPOINT", "");
+    vi.stubEnv("LOCAL_ENDPOINT", "");
+    // stubEnv("", "") sets empty string, not unset — clear explicitly.
+    vi.stubEnv("LOCAL_EMBEDDINGS_ENDPOINT", undefined as unknown as string);
+    vi.stubEnv("LOCAL_ENDPOINT", undefined as unknown as string);
+    expect(createEmbeddingsProvider()).toBeNull();
+  });
+
+  it("returns a provider when an endpoint is given via opts", () => {
+    expect(
+      createEmbeddingsProvider({ endpoint: "http://localhost:11434/v1" }),
+    ).toBeInstanceOf(LocalEmbeddingsProvider);
+  });
+
+  it("returns a provider when LOCAL_ENDPOINT env is set", () => {
+    vi.stubEnv("LOCAL_ENDPOINT", "http://localhost:11434/v1");
+    expect(createEmbeddingsProvider()).toBeInstanceOf(LocalEmbeddingsProvider);
+  });
+});
+
+describe("SSRF guard", () => {
+  it("returns null and does NOT call fetch for a public host (no override)", async () => {
+    vi.stubEnv("LOCAL_ENDPOINT_ALLOW_REMOTE", undefined as unknown as string);
+    const fetchImpl = mockFetch({ data: [{ embedding: [1, 2, 3] }] });
+    const provider = new LocalEmbeddingsProvider({
+      endpoint: "https://evil.example.com/v1",
+      fetchImpl,
+    });
+    const result = await provider.embed(["secret prompt"]);
+    expect(result).toBeNull();
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("allows the public host and calls fetch when LOCAL_ENDPOINT_ALLOW_REMOTE=1", async () => {
+    vi.stubEnv("LOCAL_ENDPOINT_ALLOW_REMOTE", "1");
+    const fetchImpl = mockFetch({ data: [{ embedding: [1, 2, 3] }] });
+    const provider = new LocalEmbeddingsProvider({
+      endpoint: "https://internal-cluster.example.com/v1",
+      fetchImpl,
+    });
+    const result = await provider.embed(["prompt"]);
+    expect(result).toEqual([[1, 2, 3]]);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("embed failure modes (fail-soft)", () => {
+  it("returns null on non-ok HTTP status", async () => {
+    const fetchImpl = mockFetch({ error: "boom" }, false, 500);
+    const provider = new LocalEmbeddingsProvider({
+      endpoint: "http://localhost:11434/v1",
+      fetchImpl,
+    });
+    expect(await provider.embed(["x"])).toBeNull();
+  });
+
+  it("returns null when fetch throws (network error never propagates)", async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw new Error("ECONNREFUSED");
+    }) as unknown as typeof fetch;
+    const provider = new LocalEmbeddingsProvider({
+      endpoint: "http://localhost:11434/v1",
+      fetchImpl,
+    });
+    await expect(provider.embed(["x"])).resolves.toBeNull();
+  });
+
+  it("returns null on an unexpected response shape", async () => {
+    const fetchImpl = mockFetch({ notData: true });
+    const provider = new LocalEmbeddingsProvider({
+      endpoint: "http://localhost:11434/v1",
+      fetchImpl,
+    });
+    expect(await provider.embed(["x"])).toBeNull();
+  });
+});

--- a/src/embeddings/__tests__/mlxSmoke.integration.test.ts
+++ b/src/embeddings/__tests__/mlxSmoke.integration.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Opt-in MLX integration smoke test — exercises a REAL OpenAI-compatible local
+ * server (mlx_lm.server / Ollama-on-MLX / mlx-embeddings) over the live
+ * `globalThis.fetch`. There is intentionally NO fetch mock here — this is the
+ * live smoke that proves a developer's on-device MLX stack actually answers.
+ *
+ * Gated by MLX_SMOKE === "1": skipped by default so the Linux CI run (no MLX,
+ * no server) is a pure no-op with zero failures. Endpoints come from env — the
+ * developer sets them on their Mac. No hardcoded URLs, no /tmp.
+ *
+ * Run on a Mac with MLX up:
+ *   MLX_SMOKE=1 \
+ *     LOCAL_ENDPOINT=http://localhost:8080/v1 LOCAL_MODEL=<chat-model> \
+ *     LOCAL_EMBEDDINGS_ENDPOINT=http://localhost:8080/v1 \
+ *     LOCAL_EMBEDDINGS_MODEL=<embed-model> \
+ *     npx vitest run src/embeddings/__tests__/mlxSmoke.integration.test.ts
+ *
+ * See docs/mlx-integration.md (section 7) for setup.
+ */
+import { describe, expect, it } from "vitest";
+import { LocalApiDriver } from "../../drivers/local/index.js";
+import { cosineSimilarity, createEmbeddingsProvider } from "../index.js";
+
+const SMOKE_ENABLED = process.env.MLX_SMOKE === "1";
+
+// A small generous ceiling — local models on Apple Silicon are fast but the
+// first request can pay a model-load cost. Kept finite so a wedged server
+// surfaces as a timeout, not a hang.
+const CHAT_TIMEOUT_MS = 60_000;
+
+describe.skipIf(!SMOKE_ENABLED)("MLX smoke (opt-in, MLX_SMOKE=1)", () => {
+  it(
+    "chat: LocalApiDriver returns non-empty text from the live endpoint",
+    async () => {
+      if (!process.env.LOCAL_ENDPOINT) {
+        throw new Error(
+          "MLX_SMOKE=1 but LOCAL_ENDPOINT is unset — set it to your MLX chat " +
+            "server, e.g. LOCAL_ENDPOINT=http://localhost:8080/v1",
+        );
+      }
+      if (!process.env.LOCAL_MODEL) {
+        throw new Error(
+          "MLX_SMOKE=1 but LOCAL_MODEL is unset — set it to the chat model id " +
+            "served by LOCAL_ENDPOINT.",
+        );
+      }
+
+      // Real fetch inside the driver (OpenAI SDK / streaming) — no mock.
+      const driver = new LocalApiDriver(() => {});
+      const result = await driver.run({
+        prompt: "Reply with a single short sentence so we know you are alive.",
+        workspace: process.cwd(),
+        timeoutMs: CHAT_TIMEOUT_MS,
+        signal: AbortSignal.timeout(CHAT_TIMEOUT_MS),
+      });
+
+      expect(result.errorMessage).toBeUndefined();
+      expect(result.wasAborted).not.toBe(true);
+      expect(typeof result.text).toBe("string");
+      expect(result.text.trim().length).toBeGreaterThan(0);
+    },
+    CHAT_TIMEOUT_MS + 5_000,
+  );
+
+  it(
+    "embeddings: createEmbeddingsProvider embeds two strings with matching dims",
+    async () => {
+      if (
+        !process.env.LOCAL_EMBEDDINGS_ENDPOINT &&
+        !process.env.LOCAL_ENDPOINT
+      ) {
+        throw new Error(
+          "MLX_SMOKE=1 but neither LOCAL_EMBEDDINGS_ENDPOINT nor LOCAL_ENDPOINT " +
+            "is set — point one at your MLX /v1/embeddings server.",
+        );
+      }
+
+      // Reads LOCAL_EMBEDDINGS_ENDPOINT/MODEL (falling back to LOCAL_*).
+      // Real globalThis.fetch — no fetchImpl injected.
+      const provider = createEmbeddingsProvider();
+      expect(provider).not.toBeNull();
+      // Type-narrow for the strict (noUnusedLocals + null-check) core gate.
+      if (!provider) {
+        throw new Error(
+          "embeddings provider was null despite a configured endpoint",
+        );
+      }
+
+      const vectors = await provider.embed([
+        "the build is green and all tests pass",
+        "the deployment succeeded without errors",
+      ]);
+
+      expect(vectors).not.toBeNull();
+      if (!vectors) {
+        throw new Error(
+          "embed() returned null — check the embeddings endpoint/model and " +
+            "that the server exposes an OpenAI-compatible /v1/embeddings route.",
+        );
+      }
+
+      expect(vectors).toHaveLength(2);
+      const a = vectors[0];
+      const b = vectors[1];
+      if (!a || !b) {
+        throw new Error("expected two embedding vectors");
+      }
+      expect(a.length).toBeGreaterThan(0);
+      expect(a.length).toBe(b.length);
+
+      const sim = cosineSimilarity(a, b);
+      expect(Number.isFinite(sim)).toBe(true);
+      expect(sim).toBeGreaterThanOrEqual(-1);
+      expect(sim).toBeLessThanOrEqual(1);
+    },
+    CHAT_TIMEOUT_MS + 5_000,
+  );
+});

--- a/src/embeddings/cosine.ts
+++ b/src/embeddings/cosine.ts
@@ -1,0 +1,59 @@
+/**
+ * Pure, zero-dependency vector math. No imports — keep it that way so it can
+ * be reused anywhere (ranking, dedup, semantic search) without pulling in
+ * network / config / driver dependencies.
+ */
+
+/**
+ * Cosine similarity = dot(a, b) / (|a| * |b|).
+ *
+ * Returns `0` (never `NaN`, never throws) on:
+ *   - length mismatch between `a` and `b`
+ *   - either vector being zero-magnitude
+ *   - empty vectors
+ *
+ * Identical vectors → 1, orthogonal → 0, opposite → -1.
+ */
+export function cosineSimilarity(a: number[], b: number[]): number {
+  if (a.length !== b.length || a.length === 0) return 0;
+  let dot = 0;
+  let magA = 0;
+  let magB = 0;
+  for (let i = 0; i < a.length; i++) {
+    // Bounds-safe: i < a.length === b.length (checked above).
+    const av = a[i] as number;
+    const bv = b[i] as number;
+    dot += av * bv;
+    magA += av * av;
+    magB += bv * bv;
+  }
+  if (magA === 0 || magB === 0) return 0;
+  const denom = Math.sqrt(magA) * Math.sqrt(magB);
+  if (denom === 0) return 0;
+  return dot / denom;
+}
+
+/**
+ * Return the `k` highest-scoring items, sorted score-descending. Stable for
+ * ties — items with equal score keep their original relative order.
+ *
+ * `k` larger than the list returns all items (sorted). `k <= 0` returns `[]`.
+ */
+export function topK<T>(
+  items: T[],
+  scoreOf: (item: T) => number,
+  k: number,
+): T[] {
+  if (k <= 0) return [];
+  // Decorate with original index to make the sort stable across ties.
+  const decorated = items.map((item, index) => ({
+    item,
+    index,
+    score: scoreOf(item),
+  }));
+  decorated.sort((x, y) => {
+    if (y.score !== x.score) return y.score - x.score;
+    return x.index - y.index;
+  });
+  return decorated.slice(0, k).map((d) => d.item);
+}

--- a/src/embeddings/index.ts
+++ b/src/embeddings/index.ts
@@ -1,0 +1,42 @@
+/**
+ * Embeddings module — internal, NOT an MCP tool (no outputSchema, not
+ * registered in src/tools/index.ts).
+ *
+ * The factory is the fail-soft hinge: {@link createEmbeddingsProvider} returns
+ * `null` when no endpoint is configured at all, so every consumer can detect
+ * "embeddings unavailable" and fall back to existing behavior.
+ */
+import { LocalEmbeddingsProvider } from "./localEmbeddings.js";
+import { resolveEmbeddingsEndpoint } from "./localEndpoints.js";
+import type { EmbeddingsProvider, EmbeddingsProviderOpts } from "./types.js";
+
+export { cosineSimilarity, topK } from "./cosine.js";
+export { LocalEmbeddingsProvider } from "./localEmbeddings.js";
+export type { EmbeddingsProvider, EmbeddingsProviderOpts } from "./types.js";
+
+/**
+ * Build an embeddings provider, or `null` when no endpoint is configured
+ * (neither `opts.endpoint` nor `LOCAL_EMBEDDINGS_ENDPOINT` nor
+ * `LOCAL_ENDPOINT`). Returning `null` lets callers fail soft.
+ */
+export function createEmbeddingsProvider(
+  opts: EmbeddingsProviderOpts = {},
+): EmbeddingsProvider | null {
+  if (!resolveEmbeddingsEndpoint(opts)) return null;
+  return new LocalEmbeddingsProvider(opts);
+}
+
+/**
+ * Resolve a bound embed function for the configured local provider, or
+ * `undefined` when embeddings are unconfigured. Wired into tool registration
+ * sites — `createCtxQueryTracesTool({ ..., embedFn: getLocalEmbedFn() })` — so
+ * the opt-in semantic ranking path activates only when a local endpoint is set
+ * and stays byte-identical to substring search otherwise. Binds `embed` so
+ * callers can pass the function value directly without losing `this`.
+ */
+export function getLocalEmbedFn(
+  opts: EmbeddingsProviderOpts = {},
+): ((texts: string[]) => Promise<number[][] | null>) | undefined {
+  const provider = createEmbeddingsProvider(opts);
+  return provider ? (texts: string[]) => provider.embed(texts) : undefined;
+}

--- a/src/embeddings/localEmbeddings.ts
+++ b/src/embeddings/localEmbeddings.ts
@@ -1,0 +1,110 @@
+import { isLoopbackOrPrivateEndpoint } from "../localEndpointGuard.js";
+import {
+  resolveEmbeddingsEndpoint,
+  resolveEmbeddingsModel,
+} from "./localEndpoints.js";
+import type { EmbeddingsProvider, EmbeddingsProviderOpts } from "./types.js";
+
+/**
+ * OpenAI-compatible embeddings client (Ollama / MLX / mlx-embeddings / vLLM).
+ *
+ * POSTs `{ model, input }` to `${endpoint}/embeddings` and parses the OpenAI
+ * shape `{ data: [{ embedding: number[] }, ...] }`.
+ *
+ * Fail-soft contract — `embed()` returns `null` (never throws) on:
+ *   - a public/non-loopback endpoint when LOCAL_ENDPOINT_ALLOW_REMOTE !== "1"
+ *     (anti-exfiltration — the texts we send are prompts/context)
+ *   - non-ok HTTP status
+ *   - JSON parse / unexpected shape
+ *   - any network throw inside fetch
+ *
+ * Configuration precedence (see {@link resolveEmbeddingsEndpoint} /
+ * {@link resolveEmbeddingsModel}):
+ *   endpoint: opts.endpoint ?? LOCAL_EMBEDDINGS_ENDPOINT ?? LOCAL_ENDPOINT
+ *   model:    opts.model ?? LOCAL_EMBEDDINGS_MODEL ?? LOCAL_MODEL ?? nomic-embed-text
+ *   apiKey:   opts.apiKey ?? LOCAL_API_KEY ?? "ollama"
+ */
+export class LocalEmbeddingsProvider implements EmbeddingsProvider {
+  private readonly endpoint: string | undefined;
+  private readonly model: string;
+  private readonly apiKey: string;
+  private readonly fetchImpl: typeof fetch;
+  private readonly log: (msg: string) => void;
+
+  constructor(opts: EmbeddingsProviderOpts = {}) {
+    this.endpoint = resolveEmbeddingsEndpoint(opts);
+    this.model = resolveEmbeddingsModel(opts);
+    this.apiKey = opts.apiKey ?? process.env.LOCAL_API_KEY ?? "ollama";
+    this.fetchImpl = opts.fetchImpl ?? globalThis.fetch;
+    this.log = opts.log ?? (() => {});
+  }
+
+  async embed(texts: string[]): Promise<number[][] | null> {
+    const endpoint = this.endpoint;
+    if (!endpoint) {
+      this.log("embeddings: no endpoint configured — returning null");
+      return null;
+    }
+    // Anti-exfiltration guard. The texts we POST are prompts/context — a
+    // public host would leak them. Mirror src/drivers/local/index.ts, but
+    // fail SOFT (return null) instead of throwing.
+    if (
+      process.env.LOCAL_ENDPOINT_ALLOW_REMOTE !== "1" &&
+      !isLoopbackOrPrivateEndpoint(endpoint)
+    ) {
+      this.log(
+        `embeddings: endpoint="${endpoint}" is not loopback/private — refusing ` +
+          `to send prompt/context (set LOCAL_ENDPOINT_ALLOW_REMOTE=1 to override)`,
+      );
+      return null;
+    }
+    if (texts.length === 0) return [];
+
+    const url = `${endpoint.replace(/\/$/, "")}/embeddings`;
+    try {
+      const res = await this.fetchImpl(url, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${this.apiKey}`,
+        },
+        body: JSON.stringify({ model: this.model, input: texts }),
+      });
+      if (!res.ok) {
+        this.log(`embeddings: non-ok status ${res.status} from ${url}`);
+        return null;
+      }
+      const body = (await res.json()) as unknown;
+      const vectors = parseEmbeddings(body);
+      if (!vectors) {
+        this.log(`embeddings: unexpected response shape from ${url}`);
+        return null;
+      }
+      return vectors;
+    } catch (err) {
+      this.log(
+        `embeddings: request failed — ${err instanceof Error ? err.message : String(err)}`,
+      );
+      return null;
+    }
+  }
+}
+
+/**
+ * Parse the OpenAI embeddings response shape `{ data: [{ embedding: [...] }] }`.
+ * Returns `null` on any structural mismatch (so the caller can fail soft).
+ */
+function parseEmbeddings(body: unknown): number[][] | null {
+  if (typeof body !== "object" || body === null) return null;
+  const data = (body as { data?: unknown }).data;
+  if (!Array.isArray(data)) return null;
+  const out: number[][] = [];
+  for (const row of data) {
+    if (typeof row !== "object" || row === null) return null;
+    const embedding = (row as { embedding?: unknown }).embedding;
+    if (!Array.isArray(embedding)) return null;
+    if (!embedding.every((n) => typeof n === "number")) return null;
+    out.push(embedding as number[]);
+  }
+  return out;
+}

--- a/src/embeddings/localEndpoints.ts
+++ b/src/embeddings/localEndpoints.ts
@@ -1,0 +1,52 @@
+/**
+ * Shared endpoint/model precedence resolution for the embeddings module.
+ * Kept tiny + import-free (besides env reads) so both the factory
+ * (`index.ts`) and the provider (`localEmbeddings.ts`) agree on exactly the
+ * same precedence chain.
+ */
+import type { EmbeddingsProviderOpts } from "./types.js";
+
+/**
+ * Treat empty / whitespace-only values as "unset" so the precedence chain is
+ * not shadowed by a stale `export LOCAL_EMBEDDINGS_ENDPOINT=` or a blank
+ * dashboard field — `??` alone would let `""` win over a real fallback. Also
+ * trims, avoiding `http://host /embeddings`-style trailing-space URL bugs.
+ */
+function clean(v: string | undefined): string | undefined {
+  const t = v?.trim();
+  return t ? t : undefined;
+}
+
+/**
+ * Resolve the embeddings endpoint, honoring (in order):
+ *   1. `opts.endpoint`
+ *   2. `LOCAL_EMBEDDINGS_ENDPOINT` env
+ *   3. `LOCAL_ENDPOINT` env (reuse the chat endpoint when a dedicated
+ *      embeddings endpoint isn't configured)
+ * Returns `undefined` when none is set — the fail-soft hinge.
+ */
+export function resolveEmbeddingsEndpoint(
+  opts?: EmbeddingsProviderOpts,
+): string | undefined {
+  return (
+    clean(opts?.endpoint) ??
+    clean(process.env.LOCAL_EMBEDDINGS_ENDPOINT) ??
+    clean(process.env.LOCAL_ENDPOINT)
+  );
+}
+
+/**
+ * Resolve the embeddings model, honoring (in order):
+ *   1. `opts.model`
+ *   2. `LOCAL_EMBEDDINGS_MODEL` env
+ *   3. `LOCAL_MODEL` env
+ *   4. `nomic-embed-text` (sensible Ollama default)
+ */
+export function resolveEmbeddingsModel(opts?: EmbeddingsProviderOpts): string {
+  return (
+    clean(opts?.model) ??
+    clean(process.env.LOCAL_EMBEDDINGS_MODEL) ??
+    clean(process.env.LOCAL_MODEL) ??
+    "nomic-embed-text"
+  );
+}

--- a/src/embeddings/types.ts
+++ b/src/embeddings/types.ts
@@ -1,0 +1,34 @@
+/**
+ * Internal embeddings module — NOT an MCP tool.
+ *
+ * Turns text into vectors via an OpenAI-compatible /v1/embeddings endpoint
+ * (Ollama, MLX, mlx-embeddings, vLLM, llama.cpp, LM Studio, etc.). Every
+ * consumer is expected to fail soft: the factory returns `null` when no
+ * endpoint is configured, and `embed()` returns `null` on any failure
+ * (network / parse / non-ok / SSRF-rejected) rather than throwing — mirroring
+ * the driver `run()`-never-rejects convention.
+ */
+
+/** A provider that turns text into embedding vectors. */
+export interface EmbeddingsProvider {
+  /**
+   * Embed a batch of texts. Returns one vector per input (in order), or `null`
+   * on ANY failure (network error, non-ok HTTP status, parse error,
+   * SSRF-rejected endpoint). Never throws.
+   */
+  embed(texts: string[]): Promise<number[][] | null>;
+}
+
+/** Construction options for a {@link EmbeddingsProvider}. */
+export interface EmbeddingsProviderOpts {
+  /** OpenAI-compatible base URL, e.g. `http://localhost:11434/v1`. */
+  endpoint?: string;
+  /** Model id, e.g. `nomic-embed-text`. */
+  model?: string;
+  /** Bearer token for `Authorization`. Defaults to the `ollama` placeholder. */
+  apiKey?: string;
+  /** Injected fetch (for tests). Defaults to `globalThis.fetch`. */
+  fetchImpl?: typeof fetch;
+  /** Optional logger for fail-soft diagnostics. */
+  log?: (msg: string) => void;
+}

--- a/src/patchworkConfig.ts
+++ b/src/patchworkConfig.ts
@@ -38,6 +38,8 @@ export interface PatchworkConfig {
   };
   localEndpoint?: string;
   localModel?: string;
+  localEmbeddingsEndpoint?: string;
+  localEmbeddingsModel?: string;
   dashboard?: {
     port: number;
     requireApproval: Array<"low" | "medium" | "high">;

--- a/src/tools/__tests__/ctxQueryTraces.semantic.test.ts
+++ b/src/tools/__tests__/ctxQueryTraces.semantic.test.ts
@@ -1,0 +1,194 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { DecisionTraceLog } from "../../decisionTraceLog.js";
+import {
+  type CtxQueryTracesDeps,
+  createCtxQueryTracesTool,
+} from "../ctxQueryTraces.js";
+
+let dir: string;
+let decisionTraceLog: DecisionTraceLog;
+let now: number;
+
+beforeEach(() => {
+  dir = mkdtempSync(path.join(os.tmpdir(), "ctx-query-semantic-"));
+  now = 1_000_000;
+  decisionTraceLog = new DecisionTraceLog({ dir, now: () => now });
+});
+afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+function parse(r: { content: Array<{ type: string; text: string }> }) {
+  return JSON.parse(r.content[0]?.text ?? "{}");
+}
+
+/**
+ * Deterministic, no-network embedder. Maps text → a 2-D vector by keyword so
+ * cosine ordering is predictable without an ML model:
+ *   - query + "rocket"-flavored traces → near [1, 0]  (highest similarity)
+ *   - "banana"/"fruit" → [0.7, 0.7]  (moderate; above the 0.25 floor)
+ *   - "widget"/"unrelated" → [0.05, 1]  (near-orthogonal; below the floor)
+ *   - anything else → a small off-axis vector
+ *
+ * Query vec ≈ [1, 0.05]:
+ *   rocket  → cosine ≈ 1.00   (ranked first)
+ *   banana  → cosine ≈ 0.74   (above floor, ranked below rocket)
+ *   widget  → cosine ≈ 0.08   (below floor → dropped)
+ */
+function vectorFor(text: string): number[] {
+  const t = text.toLowerCase();
+  if (t.includes("rocket") || t.includes("propuls") || t.includes("thrust")) {
+    return [1, 0.05];
+  }
+  if (t.includes("widget") || t.includes("unrelated")) {
+    return [0.05, 1];
+  }
+  if (t.includes("banana") || t.includes("fruit")) {
+    return [0.7, 0.7];
+  }
+  return [0.2, 0.9];
+}
+
+function fakeEmbedFn(texts: string[]): Promise<number[][] | null> {
+  return Promise.resolve(texts.map(vectorFor));
+}
+
+function seedTwoDecisions() {
+  // Older trace: semantically related to the "spacecraft" query but
+  // lexically different (no shared substring with the query).
+  now = 1_000_000;
+  decisionTraceLog.record({
+    ref: "ROCKET-1",
+    problem: "thrust loss during launch",
+    solution: "rebalanced propulsion mixture",
+    workspace: "/ws",
+    tags: ["rocket"],
+  });
+  // Newer trace: lexically unrelated (banana) — must NOT outrank the
+  // related-but-older one under semantic ranking.
+  now = 2_000_000;
+  decisionTraceLog.record({
+    ref: "FRUIT-9",
+    problem: "banana ripeness tracking",
+    solution: "added fruit shelf-life chart",
+    workspace: "/ws",
+    tags: ["banana"],
+  });
+}
+
+describe("ctxQueryTraces semantic ranking", () => {
+  it("ranks semantically-related-but-lexically-different above recency-newer unrelated", async () => {
+    seedTwoDecisions();
+    const embedFn = vi.fn(fakeEmbedFn);
+    const deps: CtxQueryTracesDeps = { decisionTraceLog, embedFn };
+    const tool = createCtxQueryTracesTool(deps);
+
+    // q has no substring overlap with the rocket trace fields.
+    const res = parse(
+      await tool.handler({ q: "rocket spacecraft", semantic: true }),
+    );
+
+    expect(res.count).toBe(2);
+    // Rocket trace ranks first by cosine score despite being OLDER.
+    expect(res.traces[0].ref ?? res.traces[0].body.ref).toBe("ROCKET-1");
+    expect(res.traces[1].body.ref).toBe("FRUIT-9");
+    // embedFn called (query once + traces once, or batched).
+    expect(embedFn).toHaveBeenCalled();
+  });
+
+  it("falls back to substring path when embedFn returns null (unconfigured)", async () => {
+    seedTwoDecisions();
+    const nullEmbedFn = vi.fn(
+      (_texts: string[]): Promise<number[][] | null> => Promise.resolve(null),
+    );
+
+    const semanticDeps: CtxQueryTracesDeps = {
+      decisionTraceLog,
+      embedFn: nullEmbedFn,
+    };
+    const substringDeps: CtxQueryTracesDeps = { decisionTraceLog };
+
+    // Query that DOES substring-match the banana trace so the fallback
+    // path produces a deterministic, non-empty result.
+    const semantic = parse(
+      await createCtxQueryTracesTool(semanticDeps).handler({
+        q: "banana",
+        semantic: true,
+      }),
+    );
+    const substring = parse(
+      await createCtxQueryTracesTool(substringDeps).handler({ q: "banana" }),
+    );
+
+    expect(nullEmbedFn).toHaveBeenCalled();
+    expect(semantic.count).toBe(substring.count);
+    expect(semantic.traces.map((t: { key: string }) => t.key)).toEqual(
+      substring.traces.map((t: { key: string }) => t.key),
+    );
+  });
+
+  it("does NOT call embedFn when semantic is false / omitted", async () => {
+    seedTwoDecisions();
+    const embedFn = vi.fn(fakeEmbedFn);
+    const tool = createCtxQueryTracesTool({ decisionTraceLog, embedFn });
+
+    const omitted = parse(await tool.handler({ q: "banana" }));
+    const explicitFalse = parse(
+      await tool.handler({ q: "banana", semantic: false }),
+    );
+
+    expect(embedFn).not.toHaveBeenCalled();
+    // Substring path: only the banana trace matches "banana".
+    expect(omitted.count).toBe(1);
+    expect(explicitFalse.count).toBe(1);
+    expect(omitted.traces[0].body.ref).toBe("FRUIT-9");
+  });
+
+  it("does NOT semantic-rank when semantic:true but q is absent", async () => {
+    seedTwoDecisions();
+    const embedFn = vi.fn(fakeEmbedFn);
+    const tool = createCtxQueryTracesTool({ decisionTraceLog, embedFn });
+
+    const res = parse(await tool.handler({ semantic: true }));
+
+    // No q → no semantic ranking. embedFn never called; recency order.
+    expect(embedFn).not.toHaveBeenCalled();
+    expect(res.count).toBe(2);
+    // Default recency sort: newest (banana) first.
+    expect(res.traces[0].body.ref).toBe("FRUIT-9");
+    expect(res.traces[1].body.ref).toBe("ROCKET-1");
+  });
+
+  it("filters out below-floor semantic scores", async () => {
+    // One related trace, one wholly-unrelated trace whose vector is
+    // near-orthogonal to the query (score below SEMANTIC_FLOOR).
+    now = 1_000_000;
+    decisionTraceLog.record({
+      ref: "ROCKET-1",
+      problem: "thrust loss during launch",
+      solution: "rebalanced propulsion mixture",
+      workspace: "/ws",
+      tags: ["rocket"],
+    });
+    now = 2_000_000;
+    decisionTraceLog.record({
+      ref: "WIDGET-9",
+      problem: "widget alignment unrelated drift",
+      solution: "unrelated knob recalibration",
+      workspace: "/ws",
+      tags: ["widget"],
+    });
+
+    const embedFn = vi.fn(fakeEmbedFn);
+    const tool = createCtxQueryTracesTool({ decisionTraceLog, embedFn });
+
+    // Query vector ≈ [1, 0.05]; widget ≈ [0.05, 1] → cosine ≈ 0.08 < floor.
+    const res = parse(
+      await tool.handler({ q: "rocket spacecraft", semantic: true }),
+    );
+
+    expect(res.count).toBe(1);
+    expect(res.traces[0].body.ref).toBe("ROCKET-1");
+  });
+});

--- a/src/tools/ctxQueryTraces.ts
+++ b/src/tools/ctxQueryTraces.ts
@@ -1,8 +1,16 @@
 import type { ActivityLog } from "../activityLog.js";
 import type { CommitIssueLinkLog } from "../commitIssueLinkLog.js";
 import type { DecisionTraceLog } from "../decisionTraceLog.js";
+import { cosineSimilarity } from "../embeddings/index.js";
 import type { RecipeRunLog } from "../runLog.js";
 import { optionalInt, optionalString, successStructured } from "./utils.js";
+
+/**
+ * Minimum cosine score for a trace to survive semantic ranking. Below this
+ * floor a trace is dropped (treated as "not relevant"). Conservative — the
+ * intent is to filter obvious noise, not to gate borderline matches.
+ */
+const SEMANTIC_FLOOR = 0.25;
 
 /**
  * Unified view over the persistent decision trails that already exist:
@@ -43,6 +51,94 @@ export interface CtxQueryTracesDeps {
   commitIssueLinkLog?: CommitIssueLinkLog | null;
   activityLog?: ActivityLog | null;
   decisionTraceLog?: DecisionTraceLog | null;
+  /**
+   * Optional on-device embeddings function — wired from
+   * `createEmbeddingsProvider()?.embed` at the registration site. Returns one
+   * vector per input text, or `null` when embeddings are unavailable
+   * (unconfigured endpoint / error). Absent ⇒ semantic ranking is disabled and
+   * behavior is byte-identical to the substring path.
+   */
+  embedFn?: (texts: string[]) => Promise<number[][] | null>;
+}
+
+/**
+ * The default case-insensitive substring match: summary first, then the
+ * serialized body. Shared by the default path and the semantic fallback so
+ * the two produce byte-identical results when embeddings are unavailable.
+ */
+function matchesSubstring(t: DecisionTrace, qNeedle: string): boolean {
+  if (t.summary.toLowerCase().includes(qNeedle)) return true;
+  try {
+    return JSON.stringify(t.body).toLowerCase().includes(qNeedle);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Build the per-type text we vectorize for semantic ranking. Reads from the
+ * raw `body` row with safe typeof guards (never throws); falls back to the
+ * human summary when type-specific fields are absent.
+ */
+function semanticTextFor(t: DecisionTrace): string {
+  const b = t.body;
+  const str = (v: unknown): string => (typeof v === "string" ? v : "");
+  switch (t.traceType) {
+    case "decision": {
+      const tags = Array.isArray(b.tags)
+        ? b.tags.filter((x): x is string => typeof x === "string").join(" ")
+        : "";
+      return `${str(b.ref)} ${str(b.problem)} ${str(b.solution)} ${tags}`.trim();
+    }
+    case "enrichment":
+      return `${str(b.subject)} ${str(b.issueTitle)} ${str(b.ref)}`.trim();
+    case "recipe_run":
+      return `${str(b.recipeName)} ${str(b.errorMessage)} ${str(
+        b.outputTail,
+      )}`.trim();
+    case "approval":
+      return `${str(b.toolName)} ${str(b.decision)} ${str(b.reason)} ${str(
+        b.summary,
+      )}`.trim();
+    default:
+      return t.summary;
+  }
+}
+
+/**
+ * Rank `filtered` by cosine similarity to `query`. Returns the top-`limit`
+ * traces sorted score-descending (above {@link SEMANTIC_FLOOR}), or `null`
+ * to signal fail-soft fallback to the recency path (embeddings unavailable /
+ * error / empty pool). Never throws.
+ */
+async function semanticRank(
+  filtered: DecisionTrace[],
+  query: string,
+  embedFn: (texts: string[]) => Promise<number[][] | null>,
+  limit: number,
+): Promise<DecisionTrace[] | null> {
+  if (filtered.length === 0) return [];
+  try {
+    const texts = [query, ...filtered.map(semanticTextFor)];
+    const vectors = await embedFn(texts);
+    // Need the query vec + one per trace; anything else ⇒ fall back.
+    if (!vectors || vectors.length !== texts.length) return null;
+    const queryVec = vectors[0];
+    if (!queryVec) return null;
+    const scored: { trace: DecisionTrace; score: number }[] = [];
+    for (let i = 0; i < filtered.length; i++) {
+      const trace = filtered[i];
+      const vec = vectors[i + 1];
+      if (!trace || !vec) continue;
+      const score = cosineSimilarity(queryVec, vec);
+      if (score < SEMANTIC_FLOOR) continue;
+      scored.push({ trace, score });
+    }
+    scored.sort((a, b) => b.score - a.score);
+    return scored.slice(0, limit).map((s) => s.trace);
+  } catch {
+    return null;
+  }
 }
 
 function approvalTraces(activityLog: ActivityLog): DecisionTrace[] {
@@ -131,6 +227,11 @@ export function createCtxQueryTracesTool(deps: CtxQueryTracesDeps) {
             description:
               "Case-insensitive substring search across the trace summary and serialized body. Use for free-form lookup when the key schema doesn't fit.",
           },
+          semantic: {
+            type: "boolean",
+            description:
+              "When true AND an embeddings endpoint is configured AND q is set, rank results by on-device semantic similarity instead of recency. Falls back to substring match when embeddings are unavailable.",
+          },
           tag: {
             type: "string",
             description:
@@ -191,6 +292,7 @@ export function createCtxQueryTracesTool(deps: CtxQueryTracesDeps) {
         | "";
       const keyFilter = optionalString(args, "key");
       const qFilter = optionalString(args, "q");
+      const semantic = args.semantic === true;
       const tagFilter = optionalString(args, "tag");
       const since = optionalInt(args, "since", 0, Number.MAX_SAFE_INTEGER);
       const limit = optionalInt(args, "limit", 1, 500) ?? 100;
@@ -219,13 +321,19 @@ export function createCtxQueryTracesTool(deps: CtxQueryTracesDeps) {
         pools.push(...decisionTraces(deps.decisionTraceLog));
       }
 
+      // In semantic mode `q` is the similarity query, NOT a substring
+      // prefilter — using it to drop rows would gate out the very traces we
+      // want to rank. since/tag/key still apply as hard filters.
+      const semanticActive =
+        semantic && Boolean(qFilter) && Boolean(deps.embedFn);
+      const qNeedleActive = qFilter && !semanticActive;
       const needsFilter =
-        since !== undefined || tagFilter || keyFilter || qFilter;
+        since !== undefined || tagFilter || keyFilter || qNeedleActive;
       let filtered: DecisionTrace[];
       if (!needsFilter) {
         filtered = pools;
       } else {
-        const qNeedle = qFilter?.toLowerCase();
+        const qNeedle = qNeedleActive ? qFilter?.toLowerCase() : undefined;
         filtered = [];
         for (const t of pools) {
           if (since !== undefined && t.ts <= since) continue;
@@ -235,19 +343,33 @@ export function createCtxQueryTracesTool(deps: CtxQueryTracesDeps) {
             if (!Array.isArray(tags) || !tags.includes(tagFilter)) continue;
           }
           if (keyFilter && !t.key.includes(keyFilter)) continue;
-          if (qNeedle) {
-            let match = t.summary.toLowerCase().includes(qNeedle);
-            if (!match) {
-              try {
-                match = JSON.stringify(t.body).toLowerCase().includes(qNeedle);
-              } catch {
-                match = false;
-              }
-            }
-            if (!match) continue;
-          }
+          if (qNeedle && !matchesSubstring(t, qNeedle)) continue;
           filtered.push(t);
         }
+      }
+
+      // Opt-in semantic ranking: only when explicitly requested, a query is
+      // present, and an embeddings function is wired. Any miss (null vectors,
+      // error, unconfigured) returns null → fall through to the substring +
+      // recency path so behavior is byte-identical to a non-semantic call.
+      if (semanticActive && qFilter && deps.embedFn) {
+        const ranked = await semanticRank(
+          filtered,
+          qFilter,
+          deps.embedFn,
+          limit,
+        );
+        if (ranked) {
+          return successStructured({
+            traces: ranked,
+            count: ranked.length,
+            sources,
+          });
+        }
+        // Fallback: embeddings unavailable. Apply the substring filter we
+        // skipped in semantic mode, then recency-sort like the default path.
+        const qNeedle = qFilter.toLowerCase();
+        filtered = filtered.filter((t) => matchesSubstring(t, qNeedle));
       }
 
       filtered.sort((a, b) => b.ts - a.ts);

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -6,6 +6,7 @@ import type { ClaudeOrchestrator } from "../claudeOrchestrator.js";
 import { CommitIssueLinkLog } from "../commitIssueLinkLog.js";
 import type { Config } from "../config.js";
 import { DecisionTraceLog } from "../decisionTraceLog.js";
+import { getLocalEmbedFn } from "../embeddings/index.js";
 import type { ExtensionClient } from "../extensionClient.js";
 import type { FileLock } from "../fileLock.js";
 import type { LoadedPluginTool } from "../pluginLoader.js";
@@ -783,6 +784,7 @@ export function registerAllTools(
       commitIssueLinkLog: commitIssueLinkLog ?? null,
       recipeRunLog: recipeRunLog ?? null,
       decisionTraceLog: decisionTraceLog ?? null,
+      embedFn: getLocalEmbedFn(),
     }),
     createCtxGetTaskContextTool({
       workspace,


### PR DESCRIPTION
## Summary

Activates **on-device semantic search** over Patchwork's trace/decision memory (opt-in, fail-soft), plus two adjacent wins and a grounded MLX roadmap. 6 commits.

## What's in it

- **On-device semantic trace search** (`c04fa361`) — new `src/embeddings/` provider (OpenAI-compatible `/v1/embeddings`, loopback-guarded, fail-soft `null`, cosine + topK) wired into `ctxQueryTraces` as an **opt-in** semantic ranking path. Substring stays the default and fallback. Env/config plumbing (`LOCAL_EMBEDDINGS_ENDPOINT/MODEL` + `PatchworkConfig` + schema).
- **Approval `channel` provenance** (`5779d6d8`) — every `approval_decision` audit row records phone vs dashboard ("approved from where").
- **Constrained-decoding driver foundation** (`783a8e95`) — `providerOptions.responseFormat` → `response_format` so any step can request structured output from a compatible local endpoint (vLLM/XGrammar, llama.cpp, LM Studio).
- **MLX integration roadmap + setup guide** (`90b913cf`) — three research threads folded into one sequenced plan.
- **Generic hardware sizing** (`af581b57`) — no machine-specific spec in docs.

## Live proof

Verified end-to-end against real Ollama (`nomic-embed-text`, 768-dim). Query *"auth token leaked in the logs"*:

```
0.6317  OAuth bearer token written to a file      <- top match, ZERO shared keywords
0.5293  credential exposure in command output
0.5279  macOS keychain secret printed to stdout
0.3755  the cat sat on the warm windowsill
0.2757  how to bake sourdough bread at home
```

Related traces outrank unrelated ones despite different words — meaning-based ranking, on-device, $0.

## Safety / blast radius

- **Opt-in + fail-soft.** With no local embeddings/LLM endpoint configured, `ctxQueryTraces` is byte-identical to before (substring). Non-Mac / CI installs are unaffected.
- Live-model tests are `MLX_SMOKE`-gated (skipped in CI); all unit tests inject a mock fetch (no network).
- Additive: new module + opt-in seams; no breaking changes. The embeddings provider reuses the existing loopback SSRF guard.

## Tests

Full suite **7894 passed / 4 skipped**; prod + `tests:core` typecheck clean; biome + fixture audit clean.

## Not included (deferred — see `docs/mlx-integration-plan.md` §5)

Each needs a design decision, deliberately left out: judge-contract redesign (sensitive judge→refine path), replay `varsOverride` (touches in-flight `recipeRoutes.ts` WIP), sqlite-vec vector cache (new native dependency), FlowSvg live status (frontend).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
