### PR TITLE
fix(install): build before pack in install:global (was shipping a stale dist)

### DIFF
--- a/scripts/install-global.mjs
+++ b/scripts/install-global.mjs
@@ -27,6 +27,16 @@ function capture(cmd) {
   return execSync(cmd, { cwd, encoding: "utf-8" }).trim();
 }
 
+// Build FIRST. `npm pack` tars whatever is already in dist/ — it does NOT run
+// the build (only `prepublishOnly` builds, and that runs on `npm publish`, never
+// on `npm pack`). Without this, install:global silently ships a STALE dist (e.g.
+// freshly-merged code missing its latest wiring), and the global bridge runs old
+// behaviour even though the source is current. Always rebuild before packing.
+console.error(
+  "→ npm run build (fresh dist — npm pack alone tars a stale dist/)",
+);
+run("npm run build");
+
 console.error("→ npm pack");
 const packOutput = capture("npm pack --silent");
 // `npm pack --silent` prints the tarball name on stdout (last non-empty line).


### PR DESCRIPTION
## Problem

`npm run install:global` → `npm pack` → `npm install -g <tgz>`. But `npm pack` tars whatever is already in `dist/` and **does not run the build** — only `prepublishOnly` builds, and that fires on `npm publish`, never on `npm pack`. So a global install could ship a **stale `dist`**: freshly-merged source minus its latest compiled output.

Caught live: installing the just-merged on-device embeddings feature, the global binary had the semantic-search parser but **not** `getLocalEmbedFn` / the `response_format` wiring — so `embedFn` never wired and semantic silently fell back to substring, despite source being current.

## Fix

Add an explicit `npm run build` (which wipes + recompiles `dist/`) in `scripts/install-global.mjs` before `npm pack`. Surgical — does not touch the publish lifecycle (`prepublishOnly` already builds there).

## Verify

`npm run install:global` now prints the build step before pack; the installed binary reflects current source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)