### PR TITLE
feat(traces): 'by meaning' toggle on the dashboard traces search

### DIFF
--- a/dashboard/src/app/traces/page.tsx
+++ b/dashboard/src/app/traces/page.tsx
@@ -501,6 +501,10 @@ export default function TracesPage() {
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
   const [view, setView] = useState<"flat" | "tree">("tree");
   const [ksOnly, setKsOnly] = useState(false);
+  // Opt-in meaning-based ranking (cosine over the configured on-device
+  // embeddings model). Server-side it falls back to substring when no
+  // embeddings endpoint is configured, so this is always safe to toggle.
+  const [semantic, setSemantic] = useState(false);
 
   // Re-seed on URL change (e.g. user clicks another ?recipe= chip without
   // a full page nav). Keep this minimal — only re-apply when the inbound
@@ -540,9 +544,16 @@ export default function TracesPage() {
 
   const qs = useMemo(() => {
     const params = new URLSearchParams();
-    if (debouncedSearch.trim()) {
-      params.set("key", debouncedSearch.trim());
-      params.set("q", debouncedSearch.trim());
+    const term = debouncedSearch.trim();
+    if (term) {
+      params.set("q", term);
+      // `key` is a hard substring filter; skip it in meaning-mode so cosine
+      // ranks across ALL traces instead of only key-matching ones.
+      if (semantic) {
+        params.set("semantic", "true");
+      } else {
+        params.set("key", term);
+      }
     }
     const sinceMs = SINCE_OPTIONS.find((o) => o.k === since)?.ms;
     if (sinceMs != null) {
@@ -554,7 +565,7 @@ export default function TracesPage() {
     }
     const s = params.toString();
     return s ? `?${s}` : "";
-  }, [debouncedSearch, since, ksOnly]);
+  }, [debouncedSearch, since, ksOnly, semantic]);
 
   const { data, error, loading, refetch } = useBridgeFetch<TracesResponse>(
     `/api/bridge/traces${qs}`,
@@ -634,6 +645,16 @@ export default function TracesPage() {
               <span className="traces-search-loading" aria-label="Searching…" title="Searching…" />
             )}
           </div>
+          <button
+            type="button"
+            onClick={() => setSemantic((v) => !v)}
+            disabled={!debouncedSearch.trim()}
+            aria-pressed={semantic}
+            title="Rank results by meaning (on-device embeddings) instead of exact words. Falls back to word match when no local model is configured."
+            className={semantic ? "pill info traces-filter-pill" : "pill muted traces-filter-pill"}
+          >
+            By meaning
+          </button>
           <ExportButton disabled={traces.length === 0} />
         </div>
       </div>

--- a/src/__tests__/server-traces.test.ts
+++ b/src/__tests__/server-traces.test.ts
@@ -22,6 +22,7 @@ async function startServer(
     q?: string;
     since?: number;
     limit?: number;
+    semantic?: boolean;
   }) => Promise<Record<string, unknown>>,
 ): Promise<void> {
   server = new Server(TOKEN, logger);
@@ -110,7 +111,22 @@ describe("GET /traces", () => {
       q: "needle",
       since: 1_700_000_000_000,
       limit: 25,
+      semantic: false,
     });
+  });
+
+  it("parses ?semantic=true (and defaults to false otherwise)", async () => {
+    const received: Array<Record<string, unknown>> = [];
+    await startServer(async (q) => {
+      received.push(q);
+      return { traces: [], count: 0, sources: {} };
+    });
+    await get("/traces?q=auth+leak&semantic=true");
+    await get("/traces?q=auth+leak&semantic=false");
+    await get("/traces?q=auth+leak");
+    expect(received[0]?.semantic).toBe(true);
+    expect(received[1]?.semantic).toBe(false);
+    expect(received[2]?.semantic).toBe(false);
   });
 
   it("ignores non-numeric since / limit values", async () => {

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -1284,6 +1284,7 @@ export class Bridge {
         ...(query.tag && { tag: query.tag }),
         ...(query.since !== undefined && { since: query.since }),
         ...(query.limit !== undefined && { limit: query.limit }),
+        ...(query.semantic && { semantic: true }),
       });
       const structured = (result as { structuredContent?: unknown })
         .structuredContent;

--- a/src/server.ts
+++ b/src/server.ts
@@ -513,6 +513,7 @@ export class Server extends EventEmitter<ServerEvents> {
         tag?: string;
         since?: number;
         limit?: number;
+        semantic?: boolean;
       }) => Promise<Record<string, unknown>>)
     | null = null;
   /** Set by bridge to handle CC hook notify events via POST /notify */
@@ -973,6 +974,11 @@ export class Server extends EventEmitter<ServerEvents> {
                   limitStr !== null && /^\d+$/.test(limitStr)
                     ? Number(limitStr)
                     : undefined,
+                // Opt-in meaning-based ranking (?semantic=true). The bridge's
+                // tracesFn forwards it to ctxQueryTraces, which only ranks by
+                // cosine when an embeddings endpoint is configured — otherwise
+                // it falls back to the substring path. Safe default: false.
+                semantic: q.get("semantic") === "true",
               })
             : {
                 traces: [],


### PR DESCRIPTION
## What

Adds a **By meaning** toggle to the dashboard /traces search, so the search box can rank your decision/run history by *meaning* (on-device embeddings) instead of exact words — the user-facing surface for the merged semantic-memory feature.

## How it threads through

`/traces page toggle` → `/api/bridge/traces?semantic=true` → catch-all proxy → bridge `GET /traces` → `tracesFn` → `ctxQueryTraces`. The bridge route previously parsed `traceType/key/q/tag/since/limit` but dropped `semantic`; now it forwards it.

Key detail: in meaning-mode the dashboard sends **only `q`** (the similarity query), not `key` (a hard substring filter) — otherwise cosine would only rank key-matching traces instead of ranking across all of them.

## Fail-soft

`ctxQueryTraces` falls back to substring ranking when no embeddings endpoint is configured, so the toggle is always safe — no-op on installs without a local model.

## Tests

- Extended `server-traces.test.ts`: route parses `?semantic=true` (and defaults false).
- Full suite **7895 passed / 4 skipped**; prod + tests:core + dashboard typecheck + lint all clean.

## Not yet done

**Visual confirmation** — the pill reuses existing pill styling + standard patterns and typechecks, but I haven't rendered it in a running dashboard yet. Worth an eyeball before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)