### PR TITLE
fix(connectors): redact IdP token-exchange error bodies + fix postMessage origins (audit 2026-06-09 HIGH #1)

### DIFF
--- a/docs/audit-2026-06-09.md
+++ b/docs/audit-2026-06-09.md
@@ -1,0 +1,1854 @@
+# Patchwork OS — Incremental Full-Surface Audit (2026-06-09)
+
+> Multi-agent audit, one day after [audit-2026-06-08.md](audit-2026-06-08.md) and the #947–#953 fix wave. 17 finder agents swept every subsystem **deduped against the 06-08 doc**, with dedicated finders for the never-audited PR #953 semantic-memory code, the current branch (`feat/traces-semantic-toggle`), and a regression review of the six fix PRs themselves. Every finding adversarially verified by an independent skeptic. **143 agents, ~9.6M tokens, 27 min.**
+
+## Results at a glance
+
+| | |
+|---|---|
+| Findings raised | 125 |
+| **Confirmed** (real + reachable + NEW) | **92** |
+| False-positives (killed by verifier) | 18 |
+| Duplicates of 06-08 doc (already tracked) | 15 |
+
+**Confirmed by severity:** 🟠 HIGH 4 · 🟡 MEDIUM 31 · ⚪ LOW 57
+
+**Confirmed by category:** 🐛 bug 40 · 🧩 logic-gap 17 · 🔒 security 14 · 📚 docs-drift 13 · 💥 data-loss 4 · ⚡ perf 2 · 👻 unsurfaced 2
+
+**Confidence:** 91 of 92 verified at *high* confidence.
+
+---
+
+## Executive summary
+
+The dominant theme of this pass is **incomplete bug-class fixes from the #947–#953 wave**. The single worst case: #947 fixed the token-exchange-error-body credential leak in `mcpOAuth.ts` only — the identical pattern (raw IdP response body embedded in a thrown Error that lands verbatim in the HTTP response) is still live in **five connectors**: Discord, Asana and GitLab echo it into the HTML callback page; Monday.com and Google Docs propagate it into the JSON API response. Two more fixes from the wave are similarly partial: #948's byte-accurate output caps missed three UTF-16 `.length` sites (`ctxGetTaskContext`, legacy `claudeDriver`, `recipeOrchestration`), and #949's keychain-key allowlist guards the macOS `security` spawn but not the Linux `secret-tool` sinks. When a finding names a bug *class*, the fix has to sweep every instance — grep before closing.
+
+Beyond the incomplete fixes, two new HIGHs: `sendHttpRequest`'s manual redirect loop forwards caller-supplied credential headers (Authorization, X-Api-Key, Cookie) unchanged to **cross-origin** redirect destinations — any redirecting intermediary can harvest them; and `runLog.completeRun()`'s opts type silently drops `tokenTotals`/`budgetTotals` (spread bypasses TS excess-property checks), so **no bridge-path recipe run has ever persisted cost/token data** — which also means the 06-08 finding about the dashboard not rendering cost data (unsurfaced-3) is doubly broken: there is nothing in the rows to render.
+
+One cluster has live production evidence: connector recipe tools are inconsistent about error envelopes — Notion/Obsidian write tools and most Shopify/etc. read tools propagate raw exceptions instead of returning the soft-error envelope, hard-halting recipes on transient errors. The bridge's own last-12h halt summary at the time of this audit showed **`tool_error·18`** as the top halt category.
+
+The never-audited PR #953 / current-branch code held up reasonably well (no HIGHs): the worst items are `GET /traces?limit=N` returning 500 instead of 400 for out-of-range N, semantic search silently returning empty results when all scores fall below the floor (no keyword fallback), and the embeddings provider being re-allocated on every `/traces` request. All three are worth fixing **before merging `feat/traces-semantic-toggle`**.
+
+The rest is a familiar long tail: an automation-interpreter correctness cluster (double `recordTrigger` halving the effective rate limit, conditions evaluated against the wrong field so they silently never match), chained-runner DAG gaps (nested parallel groups produce unresolvable await targets), a scheduler that silently rejects 6-field cron expressions, CLI commands that lie about outcomes (`recipe run --local` exits 0 on failure), and 10 documentation-drift findings including a `--grace-period` help default that is 4x off.
+
+## Cross-cutting themes
+
+- **Incomplete bug-class fixes from #947–#953** (7) — connector-new-1, connector-new-2 (token-exchange leak: 5 connectors missed), pr949-1 (Linux secret-tool sinks), tools-ctx-1, orch-driver-5, orch-driver-6 (UTF-16 vs bytes: 3 sites missed), pr950-1 (prefix-match collision).
+- **Credential / sensitive-data egress** (8) — tools-http-1 (headers across cross-origin redirects), connector-new-1/2 (IdP bodies), connector-new-3/4 (postMessage to hardcoded/wildcard origins), connector-new-5 (upstream MCP error bodies), dash-new-4 (passphrase in GET header → access logs), cli-kill-switch trace file mode.
+- **Cost/token accounting broken end-to-end** (4) — data-loss-1 (completeRun drops totals), DAG-4 (only last retry attempt logged), chain-price-1 (budget vs logging price divergence), sim-cost-1 (min/max bounds are per-step extreme sums).
+- **Silently-never-fires automation** (6) — fp-new-2 (onPullRequest condition vs empty string), fp-new-6 (condition vs taskId), fp-new-5 (retry skipped on prompt_unresolved), fp-new-1 (rate limit halved), fp-new-3 (cross-runner passAfterFail), fp-new-7 (activeTasks leak).
+- **Recipes silently not running / halting** (5) — sched-cron6-1 (6-field cron rejected), orch-hang-1 (inFlight never cleared on hang), DAG-1 (nested parallel await targets), connector-tools-1/2/3 (hard-halt on transient errors — matches live `tool_error·18`).
+- **`req.url` vs `parsedUrl.pathname`** (2 more sites) — server-new-1 (pre-auth `/ping`, `/dashboard`), server-new-2 (post-auth `/health`, `/status`, `/ready`, `/stream`, `/tasks`). Same class as 06-08's recipe-routes findings; sweep the whole server once.
+- **Docs drift** (10) — connector/prompt/tool counts, `--grace-period` default 30s vs 120s, `tools --slim` ignored, ADR-0005 TTL claim, automation hooks table.
+
+## Top fixes (ranked, do #1 first)
+
+| # | Sev | Fix | Findings |
+|---|---|---|---|
+| 1 | 🟠 HIGH | Port the #947 token-exchange-leak fix to Discord, Asana, GitLab, Monday, Google Docs; fix postMessage target origins in the same files | connector-new-1, connector-new-2, connector-new-3, connector-new-4 |
+| 2 | 🟠 HIGH | Strip credential headers (Authorization, Cookie, X-Api-Key…) on cross-origin redirect hops in sendHttpRequest | tools-http-1 |
+| 3 | 🟠 HIGH | Persist tokenTotals/budgetTotals in completeRun (add to opts type + finalized object) | data-loss-1, DAG-4, chain-price-1 |
+| 4 | 🟡 MED | Normalize connector recipe-tool error envelopes — soft-error instead of thrown exceptions (live `tool_error·18` halts) | connector-tools-1, connector-tools-2, connector-tools-3 |
+| 5 | 🟡 MED | Automation interpreter cluster: single recordTrigger, fix condition source fields, retry on prompt_unresolved, clear activeTasks | fp-new-1, fp-new-2, fp-new-3, fp-new-5, fp-new-6, fp-new-7 |
+| 6 | 🟡 MED | Fix before merging this branch: /traces limit → 400, semantic empty-result fallback, hoist embeddings provider allocation | sem-1, sem-2, sem-4 |
+| 7 | 🟡 MED | Chained-runner DAG: nested parallel group await-target rewrite, summary.total cascade count, STEP_META_KEYS | DAG-1, DAG-5, DAG-9 |
+| 8 | 🟡 MED | Recipe scheduling reliability: accept 6-field cron (or lint-reject loudly), add dispatch timeout to RecipeOrchestrator.fire() | sched-cron6-1, orch-hang-1 |
+| 9 | 🟡 MED | CLI honesty batch: recipe run --local exit code, traces import secure tmpdir, launchd status, analytics clear, recipe fmt atomic write | cli-recipe-run-exit-0, cli-traces-import…, cli-launchd-status…, cli-analytics-clear…, cli-recipe-fmt… |
+| 10 | 🟡 MED | Finish the incomplete fixes: Linux secret-tool allowlist, sessionDetail prefix collision, remaining UTF-16 byte caps | pr949-1, pr950-1, tools-ctx-1, orch-driver-5, orch-driver-6 |
+| 11 | ⚪ LOW | req.url → parsedUrl.pathname sweep across server.ts; docs-drift batch (10 one-line doc fixes) | server-new-1, server-new-2, docs-drift-1…11 |
+
+---
+
+## Confirmed findings by subsystem
+
+
+### Bridge transport & server routing
+
+#### ⚪ LOW · `server-new-1` — Pre-auth public routes use req.url instead of parsedUrl.pathname — query strings bypass fast-path
+
+**Location:** `src/server.ts:744` · **Category:** logic-gap · **Verifier confidence:** high
+
+The unauthenticated fast-path routes `/ping`, `/dashboard`, and `/dashboard/data` are matched with strict equality against `req.url`, which includes the full query string. A request like `GET /ping?v=1` or `GET /dashboard?tab=runs` fails to match, falls through to the bearer-auth gate, and receives a 401. This breaks health/liveness probes with any monitoring tool that appends a query parameter, and makes the dashboard unreachable when the browser appends a query string. The rest of the routing code already parses `parsedUrl = new URL(req.url, 'http://h')` — the pathname field is available but unused in these comparisons.
+
+```
+Line 713: (req.url === "/dashboard" || req.url === "/dashboard/") &&
+Line 722: req.url === "/dashboard/data" &&
+Line 744: if (req.url === "/ping" && req.method === "GET") {
+All three use req.url (includes query string) for equality. The existing audit (audit-2026-06-08.md) only flags recipeRoutes.ts /recipes for this pattern — these server.ts routes are not covered.
+```
+
+> **Verifier:** Code at src/server.ts lines 712-713, 721-722, and 744 confirmed on HEAD: all three pre-auth fast-path routes (/dashboard, /dashboard/, /dashboard/data, /ping) use req.url with strict equality. parsedUrl is constructed at line 684 in the same handler (new URL(req.url ?? "/", "http://localhost")) and its .pathname is used by all other routes in the function (/schemas/, connector callbacks, etc.) but is unused for these three checks. Any request with a query string (GET /ping?v=1, GET /dashboard?tab=runs) fails to match, falls through to the bearer-auth gate at ~line 797, and receives a 401. This is a real, reachable defect. The audit doc (docs/audit-2026-06-08.md) documents the same req.url […]
+
+#### ⚪ LOW · `server-new-2` — Post-auth probe and stream routes use req.url instead of parsedUrl.pathname
+
+**Location:** `src/server.ts:928` · **Category:** logic-gap · **Verifier confidence:** high
+
+The authenticated routes `/health`, `/status`, `/ready`, `/stream`, and `/tasks` are matched with `req.url` strict equality, meaning any client that appends a query parameter gets a 404 instead of the expected response. This is a less severe variant of server-new-1 (these routes are behind auth, so no security bypass), but it silently breaks integrations that use query strings for cache-busting or versioning.
+
+```
+Line 928:  if (req.url === "/health" && req.method === "GET") {
+Line 1108: if (req.url === "/status" && req.method === "GET") {
+Line 1121: if (req.url === "/ready" && req.method === "GET") {
+Line 1151: if (req.url === "/stream" && req.method === "GET") {
+Line 1228: if (req.url === "/tasks" && req.method === "GET") {
+All five use raw req.url (query string included) rather than parsedUrl.pathname.
+```
+
+> **Verifier:** The code defect is confirmed: lines 928, 1108, 1121, 1151, and 1228 of src/server.ts use `req.url === "/health"` etc. (strict equality that includes any query string), while `/metrics` (line 916), `/activity` (line 943), `/traces` (line 958), and all other sibling routes in the same function correctly use `parsedUrl.pathname`. The `parsedUrl` object is constructed at line 684 and is in scope at all five locations. The dashboard proxy at `[...path]/route.ts` lines 14-15 does forward query strings (`qs = req.nextUrl.search; target = \`/${segments.join("/")}${qs}\``), so a query string on any of these routes would reach the bridge with the query string in `req.url`. No current first-party […]
+
+
+### Auth & OAuth
+
+#### 🟡 MEDIUM · `oauth-1` — CIMD auto-registration bypasses the 500-client cap — unauthenticated DoS on registeredClients map
+
+**Location:** `src/oauth.ts:1172` · **Category:** security · **Verifier confidence:** high
+
+handleRegister (POST /oauth/register) guards map size with `if (this.registeredClients.size >= 500) return 429`. However parseAuthorizeParams, called from the unauthenticated GET /oauth/authorize path, auto-registers CIMD client_id URLs via a direct `this.registeredClients.set()` at line 1172 without checking the cap. An attacker can trigger CIMD auto-registrations sequentially (CIMD_MAX_CONCURRENT=4 only limits concurrent in-flight fetches, not total throughput) to grow registeredClients indefinitely. The per-IP /oauth/register rate limiter also does not apply here. GC removes entries after CLIENT_TTL_MS=7 days, so the map accumulates entries for the full week.
+
+```ts
+// Line 1172 — no size cap check before this set:
+this.registeredClients.set(clientId, {
+  redirectUris: cimdUris,
+  issuedAt: Date.now(),
+});
+// Contrast with handleRegister line 409 which guards:
+if (this.registeredClients.size >= 500) {
+  this.sendJson(res, 429, { error: 'too_many_requests', ... });
+  return;
+}
+```
+The cap exists only in handleRegister (line 409) and is absent from the parseAuthorizeParams code path (line 1172). The authorize GET is unauthenticated and there is no per-IP rate limit on it.
+
+> **Verifier:** The code evidence is confirmed at HEAD. Line 409 of src/oauth.ts guards handleRegister with `if (this.registeredClients.size >= 500) return 429`, but line 1172 inside parseAuthorizeParams (called from the unauthenticated GET /oauth/authorize path) does `this.registeredClients.set(clientId, ...)` with no size check. Since the map key is the CIMD URL and the line-1164 `registeredClients.get(clientId)` check only deduplicates requests for the same URL, an attacker can grow the map by using distinct URLs (e.g. https://evil.com/1, /2, ...). The CIMD_MAX_CONCURRENT=4 cap slows throughput (each entry requires a completed HTTP fetch) but does not bound the total number of entries. GC runs every 10 […]
+
+#### 🟡 MEDIUM · `local-guard-1` — localEndpointGuard.ts does not block ::ffff: IPv4-mapped IPv6 — allows http://[::ffff:192.168.1.1]:11434/ to reach private hosts
+
+**Location:** `src/localEndpointGuard.ts:60` · **Category:** security · **Verifier confidence:** high
+
+isLoopbackOrPrivateEndpoint() handles IPv6 ranges (fe80::/10, fc00::/7) but has no handler for ::ffff: (IPv4-mapped) addresses. Node's URL parser normalises http://[::ffff:192.168.1.1]:11434/ to hostname=[::ffff:c0a8:101] (hex-compressed). After bracket stripping, host='::ffff:c0a8:101', wasBracketed=true. The guard then checks fe8/fe9/fea/feb/fc/fd prefixes — none match — and returns false, permitting the URL. The companion ssrfGuard.ts isPrivateHost() handles exactly this case (lines 118-121) by delegating to hexIpv4ToDotted() and recursing. A recipe operator who sets LOCAL_ENDPOINT=http://[::ffff:192.168.1.1]:11434/ can reach private 192.168.1.1 hosts despite the intended restriction.
+
+```ts
+// localEndpointGuard.ts lines 60-72
+if (wasBracketed || /^[0-9a-f:]+$/.test(host)) {
+  if (host.startsWith('fe8') || host.startsWith('fe9') || ...) return true; // link-local
+  if (host.startsWith('fc') || host.startsWith('fd')) return true; // ULA
+  // ::ffff:c0a8:101 (=192.168.1.1) falls through to false
+}
+// Compare ssrfGuard.ts lines 118-121 which handles this correctly:
+if (host.startsWith('::ffff:')) {
+  const rest = host.slice(7);
+  const dotted = hexIpv4ToDotted(rest);   // 'c0a8:101' → '192.168.1.1'
+  return isPrivateHost(dotted ?? rest);   // returns true
+}
+```
+Verification: `new URL('http://[::ffff:192.168.1.1]:11434/').hostname` returns `[::ffff:c0a8:101]` in Node.js; after bracket-stripping the guard string is `::ffff:c0a8:101`, which is not caught by any existing check in localEndpointGuard.ts.
+
+> **Verifier:** The defect is confirmed real on current HEAD. Three verification steps:
+
+1. CODE CONFIRMED: /Users/wesh/Documents/Anthropic Workspace/Patchwork OS/src/localEndpointGuard.ts lines 60-72 contain exactly the described logic — wasBracketed gate then fe8/fe9/fea/feb (link-local) and fc/fd (ULA) prefix checks, with no ::ffff: handler.
+
+2. EXPLOIT CONFIRMED VIA NODE: `new URL('http://[::ffff:192.168.1.1]:11434/').hostname` → `[::ffff:c0a8:101]`. After bracket-stripping → `::ffff:c0a8:101`. The `/^[0-9a-f:]+$/` regex matches (wasBracketed=true anyway). None of `fe8/fe9/fea/feb/fc/fd` match `::ffff:...`. Guard returns `false`, meaning "not private, allow". A recipe operator setting `localEndpoint: […]
+
+#### ⚪ LOW · `oauth-2` — POST /oauth/authorize bridge-token brute-force has no per-IP rate limit — new CSRF nonce issued on every failed attempt
+
+**Location:** `src/oauth.ts:574` · **Category:** security · **Verifier confidence:** high
+
+On a failed bridge_token submission at POST /oauth/authorize (action=approve), the server generates a fresh CSRF flowId+nonce (lines 576-582) and returns a new approval page, allowing the attacker to retry immediately with no throttle. The /oauth/register and /oauth/token endpoints both have per-IP rate limiters (REGISTER_IP_MAX=10, TOKEN_IP_MAX=30), but the /oauth/authorize POST has none. Any attacker who reaches the bridge (has a valid registered client_id and CSRF nonce from a GET) can spray bridge_token guesses at full network speed. In practice bridge tokens are random UUIDs (122-bit entropy) so brute-force is computationally infeasible, but the missing rate limit is a defence-in-depth gap consistent with the other endpoint protections and leaves slow/distributed attacks undetected.
+
+```ts
+// oauth.ts lines 573-596
+const presentedToken = body.get('bridge_token') ?? '';
+if (!timingSafeStringEqual(presentedToken, this.bridgeToken)) {
+  // Issue a fresh flowId + nonce for the retry so the form remains usable.
+  const retryCsrfNonce = crypto.randomBytes(16).toString('hex');
+  const retryFlowId = crypto.randomBytes(8).toString('hex');
+  this.csrfNonces.set(retryFlowId, { nonce: retryCsrfNonce, clientId, ... });
+  // returns 200 with new approval page — no rate-limit check before this
+  res.end(this.approvalPage({ ..., csrfNonce: retryCsrfNonce, flowId: retryFlowId }));
+  return;
+}
+```
+No per-IP counter is consulted or incremented before issuing the retry nonce.
+
+> **Verifier:** The code at src/oauth.ts lines 574-596 exactly matches the cited evidence: on a failed bridge_token check, the CSRF nonce is already consumed (line 545), a fresh flowId+nonce is issued (lines 576-582), and the response is returned with no per-IP rate limit counter consulted or incremented. No global HTTP rate limiter exists on this path (confirmed by the server-5 verifier note in the audit doc: "There is no global HTTP rate limiter anywhere in the request handler path"). The finding is not documented in docs/audit-2026-06-08.md.
+
+However, severity should be LOW rather than MEDIUM for two reasons:
+
+1. The CSRF nonce gate enforces strict serialization: the attacker must parse the new nonce […]
+
+#### ⚪ LOW · `oauth-3` — hashedTokens (disk-loaded tokens) never GC'd by the periodic timer — expired entries accumulate in memory
+
+**Location:** `src/oauth.ts:254` · **Category:** bug · **Verifier confidence:** high
+
+The GC setInterval at lines 254-277 iterates authCodes, accessTokens, registeredClients, csrfNonces, registerIpCounts, tokenIpCounts, and cimdCache — but never hashedTokens. Disk-loaded hashed tokens that expire before they are ever queried remain in the hashedTokens map forever (or until the bridge restarts). lookupToken does delete an entry when it finds it expired, so there is no auth bypass, but the stale entries accumulate as a memory leak. The loadTokens cap (10,000 entries) bounds the initial load, but tokens are never pruned mid-session unless individually accessed.
+
+```ts
+// GC loop, lines 254-277 — hashedTokens not included:
+this.gcTimer = setInterval(() => {
+  for (const [k, v] of this.authCodes)       if (v.expiresAt < now) ...
+  for (const [k, v] of this.accessTokens)    if (v.expiresAt < now) ...
+  for (const [k, v] of this.registeredClients) ...
+  for (const [k, v] of this.csrfNonces)      ...
+  for (const [k, v] of this.registerIpCounts) ...
+  for (const [k, v] of this.tokenIpCounts)   ...
+  for (const [k, v] of this.cimdCache)       ...
+  // hashedTokens: zero GC passes
+}, 10 * 60 * 1_000);
+```
+The fix is to add `for (const [k, v] of this.hashedTokens) if (v.expiresAt < now) this.hashedTokens.delete(k);` inside the GC callback.
+
+> **Verifier:** The GC loop at lines 254-277 of src/oauth.ts is confirmed to omit hashedTokens — every other in-memory map (authCodes, accessTokens, registeredClients, csrfNonces, registerIpCounts, tokenIpCounts, cimdCache) gets a GC pass, but hashedTokens does not. The mechanism is real.
+
+The severity is LOW and correctly bounded: (1) loadTokens (line 875) only ingests entries where expiresAt > now, so no already-expired entries enter at startup; (2) lookupToken (lines 776-782) lazily deletes expired entries on any access; (3) persistTokens (lines 913-921) filters expiresAt > now before writing, so expired tokens don't re-appear after restart; (4) the 10,000-entry cap in loadTokens hard-bounds the initial […]
+
+
+### MCP tool layer
+
+#### 🟠 HIGH · `tools-http-1` — sendHttpRequest forwards credential headers (Authorization, X-Api-Key, etc.) to cross-origin redirect destinations
+
+**Location:** `src/tools/httpClient.ts:283` · **Category:** security · **Verifier confidence:** high
+
+The manual redirect loop updates only `headers.host` on each hop. Any caller-supplied credential headers (Authorization, X-Api-Key, Cookie, etc.) are present in the shared `headers` object and are forwarded unchanged to every redirect destination, including cross-origin ones. An attacker who controls any intermediate server can redirect the request to their own origin and harvest these credentials. The code already strips URL userinfo (lines 287-288) but neglects header-based credentials.
+
+```
+Line 283: `headers.host = nextDisplayUrl.hostname;` — only Host is updated before the next fetch call. The shared `headers` object passed into every `fetch(currentUrl, { method, headers, ... })` call at line 242 is never stripped of Authorization/X-Api-Key/Cookie etc. on origin change. URL userinfo is stripped at lines 287-288, but header credentials are not.
+```
+
+> **Verifier:** Code at src/tools/httpClient.ts confirmed on HEAD. The `headers` object (line 164) is built from caller-supplied key/value pairs and passed unmodified into every fetch call in the redirect loop (line 242). On each redirect hop, only `headers.host` is updated (line 283); no credential headers (Authorization, X-Api-Key, Cookie, etc.) are stripped when the destination origin changes. URL userinfo is stripped (lines 287-288) but that is orthogonal. The private-host SSRF guard blocks redirects to RFC-1918 ranges, but cross-origin redirects to public attacker-controlled servers are permitted — an attacker who controls any intermediate server can 302 to their harvest endpoint and receive full […]
+
+#### 🟡 MEDIUM · `tools-tx-1` — commitTransaction silently drops second stageEdit on the same file — data loss with no top-level error signal
+
+**Location:** `src/tools/transaction.ts:422` · **Category:** data-loss · **Verifier confidence:** high
+
+When two stageEdit calls are made on the same file within one transaction, commitTransaction iterates all edits sequentially. After writing the first edit (line 432) the file's mtime changes. The second edit was staged with the original (pre-write) mtime, so the check `currentMtimeMs !== edit.originalMtimeMs` fires for the second edit and it is silently skipped via `continue`. The error is appended to `errors[]` but `committed` count and the happy-path response give no indication that an edit was lost. The caller must explicitly check for `errors` in the response to detect this.
+
+```
+Line 422: `if (currentMtimeMs !== edit.originalMtimeMs) { errors.push({...}); continue; }` — after `writeFileAtomic` at line 432 updates the file's mtime, any subsequent edit on the same file will fail this check with 'File was modified concurrently after staging'. The top-level response at line 446 returns `committed: written.length` with no error flag at the root level; `errors` is only included when non-empty, meaning callers that do not check for the `errors` key see a successful partial commit.
+```
+
+> **Verifier:** The defect is confirmed on HEAD at /Users/wesh/Documents/Anthropic Workspace/Patchwork OS/src/tools/transaction.ts. The mechanism is correct: stageEdit always calls resolveAndRead (fs.statSync + fs.readFileSync from disk) with no deduplication or merging logic — two stageEdit calls on the same file both record originalMtimeMs=T1 (the on-disk mtime at stage time). At commitTransaction, after writeFileAtomic writes the first edit (mtime advances to T2), the second edit's check `currentMtimeMs !== edit.originalMtimeMs` fires (T2 != T1) and the edit is skipped via continue with an error pushed to errors[]. The response is always successStructured (not error()), and errors is only conditionally […]
+
+#### ⚪ LOW · `tools-ctx-1` — ctxGetTaskContext trimBody uses UTF-16 string .length for a byte-count cap — CJK/emoji bodies can be 2-3x larger than intended
+
+**Location:** `src/tools/ctxGetTaskContext.ts:79` · **Category:** bug · **Verifier confidence:** high
+
+The `trimBody` function enforces a `BODY_CAP = 500` limit using `raw.length`, which counts UTF-16 code units (characters), not bytes. For issue/PR bodies with CJK characters or emoji (each consuming 2-4 bytes), `raw.length === 500` can represent up to ~2000 bytes. This is a context-size policy cap, not a memory safety boundary, so severity is low — but it means CJK-heavy issue bodies are returned at 2-3x the intended cap, consuming more of Claude's context window than designed.
+
+```
+Line 75: `const BODY_CAP = 500;`. Line 79: `if (raw.length <= BODY_CAP) return { value: raw, truncated: false };` — `raw.length` is UTF-16 char count, not byte length. Line 80: `return { value: raw.slice(0, BODY_CAP), truncated: true };` — slice is also by char count. For a string of 500 CJK characters, `Buffer.byteLength(raw)` would be 1500 bytes.
+```
+
+> **Verifier:** Code at ctxGetTaskContext.ts:75-80 exactly matches the cited evidence: BODY_CAP=500 is compared and sliced using raw.length (UTF-16 code units). For a 500-character CJK body, Buffer.byteLength would be ~1500 bytes. The path is reachable — any GitHub/Linear issue or PR with a CJK or emoji body that reaches ctxGetTaskContext will hit this. Not fixed in recent PRs (#947-#953). Not a duplicate: docs/audit-2026-06-08.md entry tools-1 covers execSafeStreaming's stderr cap mixing, not this BODY_CAP in ctxGetTaskContext. The broader UTF-16 pattern is mentioned generically in the audit summary (line 31, row 13) but no specific finding covers ctxGetTaskContext.ts BODY_CAP. Severity stays LOW: this is […]
+
+
+### Flat recipe runner (yamlRunner)
+
+#### 🟡 MEDIUM · `recipe-flat-new-1` — Agent step outputs.push(intoKey) before expect evaluation — failed expect leaves dangling entry in outputs
+
+**Location:** `src/recipes/yamlRunner.ts:1724` · **Category:** bug · **Verifier confidence:** high
+
+For agent steps, `outputs.push(intoKey)` fires at line 1724 (inside the successful agent-text branch) before `step.expect` is evaluated at line 1777. When `step.expect` fails with `on_fail: 'halt'`, `delete ctx[intoKey]` at line 1795 removes the value from ctx, but `intoKey` is still in the `outputs` array. The recipe-level `expect.outputs` assertion (line 2069) and the run-log `outputs` field therefore report a key that no longer has a value in ctx — a misrepresentation of what the run produced. The tool-step path avoids this: it defers all ctx commits to after expect evaluation by setting `result = null` (line 2028) and only commits when `result !== null` (line 2035). No analogous guard exists for the agent-step path.
+
+```
+Line 1724: `outputs.push(intoKey);`  — runs unconditionally on any successful agent text.
+Line 1777–1795: `if (step.expect) { ... if (onFail === 'halt') { ... delete ctx[intoKey]; } }` — runs AFTER the push, deletes the ctx entry but never removes it from `outputs`.
+Contrast tool-step path line 2028: `result = null;` + line 2035: `if (result !== null && step.into) { ctx[step.into] = result; }` — correct deferred-commit pattern.
+```
+
+> **Verifier:** Code at the cited lines confirms the defect exactly as described. Line 1724 pushes intoKey to the outputs array inside the successful-agent-text branch, before step.expect evaluation at lines 1777-1801. When expect fails with on_fail:'halt' (the default), line 1795 deletes ctx[intoKey] but the outputs array is never cleaned up. The dangling entry then flows to: (a) evaluateExpect at line 2070 where recipe-level expect.outputs checks use outputs.includes(key) — this will incorrectly PASS for a key whose ctx value was deleted; (b) the RunResult returned at line 2219 which the dashboard and callers consume. The contrast with the tool-step path is accurate: tool steps set result=null on […]
+
+#### ⚪ LOW · `recipe-flat-new-2` — step.expect overwrites specific judge-loop haltReason on already-errored step result
+
+**Location:** `src/recipes/yamlRunner.ts:1788` · **Category:** bug · **Verifier confidence:** high
+
+When `runJudgeRefineLoop` terminates via the unparseable-verdict path (line 1446) or the exhaustion-halt path (line 1473), it mutates `judgeStepResult.haltReason` to a precise message (e.g. 'judge X did not approve after N revisions') and sets `judgeStepResult.status = 'error'`. Control then returns to the outer agent block, which falls through unconditionally to `step.expect` at line 1777. If the expect block also fires (author placed a `step.expect.contains` on the judge step), `last.haltReason` is overwritten with a generic `expect_failed in step ...` message (line 1789). The precise judge-loop failure reason is lost in the run log and dashboard, making it impossible to distinguish 'judge exhausted revisions' from 'judge output did not match author assertion' without reading raw step results.
+
+```
+Lines 1446–1457 (unparseable path): `judgeStepResult.haltReason = reason; ... return { runError: reason, haltAfterFailure: !failOpenAgent };` — sets a specific reason.
+Lines 1473–1483 (exhaustion-halt path): same pattern.
+Lines 1765–1770: caller sets `haltAfterFailure = true` but does NOT return or break from the agent block.
+Lines 1777–1789: `if (step.expect) { ... last.haltReason = 'expect_failed in step ...'; }` — unconditionally overwrites the specific reason set by the loop.
+```
+
+> **Verifier:** The code at the cited lines is exactly as described. `judgeStepResult` is pushed to `stepResults` at line 1739 before the loop runs (no intervening push), so `last = stepResults[stepResults.length - 1]` at line 1784 IS `judgeStepResult` by reference. When `runJudgeRefineLoop` returns via the unparseable path (line 1452) or the exhaustion-halt path (line 1477), it sets `judgeStepResult.haltReason` to a specific message. Control then falls through to `step.expect` at line 1777 with no guard on `haltAfterFailure`. If `step.expect` is defined AND its evaluation fails, line 1789 overwrites `last.haltReason` (i.e., `judgeStepResult.haltReason`) with a generic `expect_failed in step...` message. […]
+
+#### ⚪ LOW · `recipe-flat-new-4` — evaluateStepExpect compiles AJV schema on every invocation — no per-schema caching
+
+**Location:** `src/recipes/yamlRunner.ts:440` · **Category:** perf · **Verifier confidence:** high
+
+In `evaluateStepExpect`, `ajv.compile(expect.schema)` is called at line 440 on every invocation. For a recipe step that uses `expect.schema` and runs many times (e.g., a cron recipe, retried steps, or refine-loop re-judgments), the same schema JSON object is compiled from scratch each time. AJV compilation is CPU-intensive for complex schemas (deeply nested `$ref`, `if/then/else` keywords). The `_stepExpectAjv` instance is cached at module level (line 334), but the compiled validator is not — it is created, used once, then discarded. A per-schema cache keyed on `JSON.stringify(expect.schema)` would amortize compilation across identical schemas.
+
+```
+Lines 439–450: `const ajv = await getStepExpectAjv(); const validate = ajv.compile(expect.schema); if (!validate(parsed)) { ... }` — `validate` is a local variable, thrown away after each call. There is no map of compiled validators keyed by schema content.
+```
+
+> **Verifier:** The code at src/recipes/yamlRunner.ts:440 confirms `ajv.compile(expect.schema)` is called on every `evaluateStepExpect` invocation. AJV does have an internal `_cache` (a Map at core.js:100), but it keys on **object identity** (`this._cache.get(schema)` at core.js:447). Since `loadYamlRecipe` re-parses YAML from disk on every recipe run invocation (RecipeOrchestrator.ts:79 calls `loadYamlRecipe` per `fire()` call), each run produces a fresh `expect.schema` object — AJV's internal cache always misses cross-run. Within a single run the schema object reference is stable, so the second refine-loop iteration within one run does hit the AJV cache; the problem is real only across runs. The finding […]
+
+#### ⚪ LOW · `recipe-flat-new-5` — step.expect skips evaluation when stepError or thrownError set on tool steps, but not on agent steps — inconsistent guard
+
+**Location:** `src/recipes/yamlRunner.ts:2013` · **Category:** logic-gap · **Verifier confidence:** high
+
+For tool steps, `step.expect` is guarded by `!thrownError && !stepError` (line 2013): if the step already errored, expect is not evaluated (no double-error noise). For agent steps, the expect block at line 1777 has no such guard: if `runJudgeRefineLoop` returned `haltAfterFailure:true` (the step already errored), `step.expect` still runs on `ctx[intoKey]` (the judge's verdict text). This inconsistency means agent steps can produce a double-error: the judge-loop error AND an additional expect_failed error, potentially masking the root cause. At minimum the agent expect block should be guarded by `if (step.expect && judgeStepResult.status !== 'error')`.
+
+```
+Line 2013 (tool path): `if (step.expect && !thrownError && !stepError && result !== null) {` — conditional on no prior error.
+Line 1777 (agent path): `if (step.expect) {` — unconditional. No check on whether `judgeStepResult.status === 'error'` (set by `runJudgeRefineLoop` at lines 1450, 1475).
+```
+
+> **Verifier:** Code evidence confirmed on HEAD. Line 2013 (tool path): `if (step.expect && !thrownError && !stepError && result !== null)` — explicitly guards against evaluating expect when the step already errored. Line 1777 (agent path): `if (step.expect)` — unconditional, with no check on whether runJudgeRefineLoop returned an error.
+
+Reachability: The agent path enters the `else` block at line 1711 only when `stripped.trim()` is non-empty (ctx[intoKey] has been set). The judge-refine loop at lines 1749-1771 can set `judgeStepResult.status = "error"` (lines 1450, 1475 in runJudgeRefineLoop) and return `haltAfterFailure:true`, but it does NOT return early from the outer block — execution falls through […]
+
+#### ⚪ LOW · `recipe-flat-new-7` — render() regex allows multi-line capture in template expressions — mismatched braces produce silent partial renders
+
+**Location:** `src/recipes/yamlRunner.ts:2293` · **Category:** bug · **Verifier confidence:** high
+
+The `render()` template regex at line 2293 is `/\{\{\s*([^}]+?)\s*\}\}/g`. The character class `[^}]` matches anything except a single `}`. A template string with an improperly-closed expression like `{{some_key}` (single closing brace) will match the regex — `[^}]+?` consumes `some_key` and the regex matches on the first `}` after the `{{`. The captured group is `some_key`, which is then looked up in ctx. Similarly `{{a} {{b}}` renders `{{a}` as `a` (if `a}` is in ctx as a literal key) or silently as empty string, treating the malformed `{{a}` as a valid expression. This is not the same as the compile-time detection in `compileTemplate` (which uses a stricter `[^{}]+` pattern). Recipe authors who accidentally write `{{key}` instead of `{{key}}` get silent empty substitution instead of a clear error.
+
+```
+Line 2293: `template.replace(/\{\{\s*([^}]+?)\s*\}\}/g, ...)` — `[^}]+?` is permissive; it stops at the FIRST `}` after `{{`. A string `{{foo}` matches because after `{{` and `foo`, the next char is `}` which satisfies the closing `}}` when the `?` (lazy) matches just `f`, then `o`, then `o` and the overall pattern closes on the lone `}`. Actually `\}\}` requires two consecutive `}` so `{{foo}` (single close) does NOT match — but `{{foo}bar}}` WOULD match, capturing `foo}bar` as the key. `[^}]` in `[^}]+?` stops before `}`, so `foo}bar` can't be captured. Re-examination: `[^}]+?` cannot cross a `}`, so `{{foo}bar}}` captures only `foo` on the first pass, leaving `bar}}` unmatched. This means the concern is moot for single-brace typos, but a template `{{ }}`  (two braces with whitespace) was specifically fixed at compileTemplate line 69 but NOT in `render()` — `\{\{\s*([^}]+?)\s*\}\}` with a whitespace-only interior: `[^}]+?` matches whitespace (tabs, spaces), so `{{ }}` resolves to a whitespace key looked up in ctx, returning empty string silently instead of preserving the original `{{ }}` literal as compileTemplate does.
+```
+
+> **Verifier:** The finding's primary claimed mechanism — that `{{key}` (single closing brace) silently substitutes as empty — is FALSE. The regex `\{\{\s*([^}]+?)\s*\}\}` requires `\}\}` (two consecutive closing braces), so `{{key}` does not match and is passed through as the literal string `{{key}` unchanged. The finding's own evidence section partially acknowledges this self-refutation.
+
+However, a real secondary bug exists: `{{ }}` (whitespace-only expression) DOES match the `render()` regex. The space is captured by `[^}]+?` (not consumed by the outer `\s*`), then `expr.trim()` produces an empty string `''`, which is not found in `ctx`, so `render()` silently emits `''` — erasing the `{{ }}` literal. […]
+
+#### ⚪ LOW · `recipe-flat-new-8` — loadRecipeServers uses process.cwd() as workspace for plugin loading — not the recipe-configured workspace
+
+**Location:** `src/recipes/yamlRunner.ts:777` · **Category:** bug · **Verifier confidence:** high
+
+In `loadRecipeServers`, the `minimalConfig` passed to `loadPluginsFull` hardcodes `workspace: process.cwd()` and `workspaceFolders: [process.cwd()]` (lines 777-778). This config is used by the plugin loader to anchor any workspace-relative paths the plugin registers. When the bridge is started with `--workspace /project` (so `config.workspace` differs from `process.cwd()`), plugin tools that resolve paths relative to the workspace will use the wrong root. This is a minor practical impact since plugin servers are rare, but it is inconsistent with the rest of the runner which threads the configured workdir through `resolveStepDeps`.
+
+```
+Lines 776–781: `const minimalConfig = { workspace: process.cwd(), workspaceFolders: [process.cwd()], ... }` — `process.cwd()` is unconditionally used regardless of `deps.workdir` or any configured workspace.
+Contrast: `resolveStepDeps` at line 2460: `const workdir = deps.workdir ?? process.cwd();` — correctly prefers the injected workdir.
+```
+
+> **Verifier:** The code evidence is accurate: `loadRecipeServers` at line 762 of `/Users/wesh/Documents/Anthropic Workspace/Patchwork OS/src/recipes/yamlRunner.ts` takes only `specs: string[]` with no deps parameter, and constructs `minimalConfig` at lines 776-781 hardcoding `workspace: process.cwd()` and `workspaceFolders: [process.cwd()]`. The bridge calls `runYamlRecipe` with `workdir: this.config.workspace` (bridge.ts:1073/1086), so when `--workspace /project` differs from process CWD, plugins loaded via recipe `servers:` get the wrong workspace in their `PluginContext`. The inconsistency with `resolveStepDeps` (line 2460 correctly uses `deps.workdir ?? process.cwd()`) is also real. However, severity […]
+
+
+### DAG recipe runner (chainedRunner)
+
+#### 🟡 MEDIUM · `DAG-1` — Nested parallel groups produce unknownAwaitTargets: fan-in rewrite uses non-existent intermediate group IDs
+
+**Location:** `src/recipes/chainedRunner.ts:847` · **Category:** bug · **Verifier confidence:** high
+
+When a `parallel:` group contains a child that is itself a `parallel:` group, `expandParallelSteps` registers the intermediate group's id in `groupChildren` but never pushes it to the `flat` output array. The fan-in rewrite pass at line 864 then maps any step that awaits the outer group to await the intermediate group id, which does not exist in the flat step list. `buildDependencyGraph` classifies it as `unknownAwaitTargets`, and `runChainedRecipe` rejects the run with 'Recipe has steps that await unknown step(s): <inner_group_id>'. The comment at line 806 explicitly documents that nested parallel blocks work, so this is an undocumented failure mode for a supported feature.
+
+```
+groupChildren.set(groupId, childIds);  // line 847
+// childIds contains 'inner_group' (a parallel-group child), but that id was never pushed to `flat`
+// because expandParallelSteps([{id:'inner_group', parallel:[...]}]) returns its children (leaf_a, leaf_b), not inner_group itself
+
+// Rewrite pass (line 864):
+const rewritten = step.awaits.flatMap(
+  (dep) => groupChildren.get(dep) ?? [dep],
+);
+// step.awaits=['outer_group'] → ['inner_group'] but 'inner_group' is absent from flat
+// buildDependencyGraph flags 'inner_group' as unknownAwaitTargets → run rejected
+```
+
+> **Verifier:** The bug is real and confirmed by simulation. In `expandParallelSteps` (line 808), when processing a parallel group, `childIds` collects the direct child ids (e.g., `inner_group`) and registers them in `groupChildren` for the outer group (line 847). For a child that is itself a parallel group, the recursive call to `expandParallelSteps` at line 837 correctly expands the grandchildren into `flat`, but `inner_group` itself is never pushed to `flat` — only `leaf_a` and `leaf_b` land there. The rewrite pass at line 864 then maps `outer_group → [inner_group]` (from `groupChildren`), producing a `fan_in` step that awaits `inner_group`, which is absent from `flat`. `buildDependencyGraph` at line […]
+
+#### 🟡 MEDIUM · `DAG-4` — Per-retry token usage in run log only captures last attempt; budget accumulates all attempts
+
+**Location:** `src/recipes/chainedRunner.ts:1154` · **Category:** data-loss · **Verifier confidence:** high
+
+When an agent step is retried (step.retry > 0), `withRetry` calls `executeChainedStep` up to N times. Each invocation calls `budget.reconcile()` with that attempt's real usage, so the RunBudget correctly accumulates tokens/cost across ALL attempts. However, `capturedUsage.set(stepId, result.usage)` at line 1154 only stores the usage from the FINAL attempt (the one returned by `withRetry`). The `tokenTotals` written to the run log (line 1346-1352) sums `capturedUsage`, so it systematically understates real token consumption for retried agent steps. A step that fails 3 times (each using 500 tokens) before succeeding on the 4th try (200 tokens) shows 200 tokens in the run log but consumed 1700 in the budget.
+
+```
+// chainedRunner.ts line 1144-1155:
+const result = await withRetry(
+  () => executeChainedStep(ctx, deps), // calls budget.reconcile() on EVERY attempt
+  retryCount,
+  retryDelay,
+);
+// ...
+if (depth === 0 && result.usage) {
+  capturedUsage.set(stepId, result.usage); // only last attempt's usage
+}
+
+// run log tokenTotals (lines 1346-1352) sums capturedUsage only:
+const tokenTotals = runTok.measured
+  ? { inputTokens: runTok.inputTokens, outputTokens: runTok.outputTokens, ... }
+  : undefined;
+// runTok is built from capturedUsage (line 1306-1313), not from budget totals
+```
+
+> **Verifier:** The structural claim is fully confirmed by the code on HEAD:
+
+1. `withRetry` at line 752-774 loops calling `executeChainedStep`. Inside that function, `budget.reconcile()` fires at line 612 on every attempt — budget accumulates all attempts correctly.
+
+2. `withRetry` returns the last failed result (or the first success). The caller at line 1154-1155 does `capturedUsage.set(stepId, result.usage)` — this is the single return value from `withRetry`, so only the final attempt's usage is stored.
+
+3. The run log `tokenTotals` (lines 1346-1352) sums solely from `capturedUsage` (line 1306-1313). The `budgetTotals` field at line 1353 is written separately and only when `recipe.budget` is configured […]
+
+#### 🟡 MEDIUM · `DAG-5` — ChainedRunResult.summary.total undercounts when dependency-failure cascades skip steps
+
+**Location:** `src/recipes/chainedRunner.ts:1253` · **Category:** logic-gap · **Verifier confidence:** high
+
+When step B fails and step C (which awaits B) is cascade-skipped by `dependencyGraph.ts`, C never reaches `stepExecutor`, so `registry.set()` is never called for C. `ChainedRunResult.summary` comes from `registry.summary()` which only counts entries that called `registry.set()`. The result: `summary.total` is lower than `stepResults.size`. For a 5-step recipe where the first step fails and 4 downstream steps are cascade-skipped, `summary` shows `{total:1, failed:1, ...}` while `stepResults` has 5 entries. The dashboard and test assertions that rely on `summary.total` to report step counts produce misleading progress data.
+
+```
+// dependencyGraph.ts lines 193-203: cascade-skip path
+const failedDep = deps.find((d) => failed.has(d));
+if (failedDep) {
+  results.set(stepId, { success: false, error: err }); // recorded in stepResults
+  completed.add(stepId);
+  // ... but stepExecutor is NEVER called, so registry.set() is never called
+  return;
+}
+
+// chainedRunner.ts line 1253:
+result.summary = registry.summary(); // total = only steps that ran (not cascade-skipped)
+
+// vs:
+result.stepResults = enrichedResults; // size = ALL steps including cascade-skipped
+```
+
+> **Verifier:** The defect is structurally confirmed at HEAD. The cascade-skip path in dependencyGraph.ts (lines 192-203) calls `results.set(stepId, ...)` and returns early, bypassing `executeStep(stepId)`. The `stepExecutor` in chainedRunner.ts is the sole caller of `registry.set()`, and it is only invoked from `executeStep()` (dependencyGraph.ts line 211). Therefore cascade-skipped steps populate `stepResults` (via the `results` map returned by `executeWithDependencies`) but never populate the `OutputRegistry`. `registry.summary()` at chainedRunner.ts:1253 counts only `this.outputs.size` — entries added via `registry.set()` — so `summary.total` is strictly less than `enrichedResults.size` whenever […]
+
+#### ⚪ LOW · `DAG-9` — STEP_META_KEYS missing timeout_ms, expect, silentFailDetection — these keys leak into tool parameters
+
+**Location:** `src/recipes/chainedRunner.ts:232` · **Category:** logic-gap · **Verifier confidence:** high
+
+The `STEP_META_KEYS` set used in `resolveStepTemplates` (line 232) does not include `timeout_ms`, `expect`, or `silentFailDetection`. These are first-class `ChainedStep` fields that control runner behavior, not tool parameters. When a tool step has `timeout_ms: 5000` or `expect: {check: '...'}`, these keys pass through `resolveStepTemplates` into `resolved` and then into `deps.executeTool(step.tool, resolved)`. Inside `buildChainedDeps.executeTool` (yamlRunner.ts line 3056), `const step: YamlStep = { tool, ...params }` spreads them into the step object, and `executeStep` then includes them in the tool's `params` object. Recipe tools generally ignore unknown params, but any tool with strict schema validation would reject the call.
+
+```
+// chainedRunner.ts lines 232-248: STEP_META_KEYS set
+const STEP_META_KEYS = new Set([
+  'id', 'tool', 'agent', 'recipe', 'chain', 'awaits', 'when', 'output',
+  'risk', 'optional', 'vars', 'transform', 'retry', 'retryDelay', 'parallel',
+  // ← timeout_ms missing
+  // ← expect missing
+  // ← silentFailDetection missing
+]);
+
+// ChainedStep interface (lines 45-80) has:
+timeout_ms?: number;  // line 76
+expect?: StepExpect;  // line 78
+// silentFailDetection via [key: string]: unknown
+
+// result: for a tool step with timeout_ms:5000,
+// deps.executeTool('some.tool', {timeout_ms: 5000, ...real_params})
+```
+
+> **Verifier:** The STEP_META_KEYS gap is real and confirmed at /src/recipes/chainedRunner.ts lines 232-248: `timeout_ms`, `expect`, and `silentFailDetection` are absent from the set. Since `resolveStepTemplates` iterates all step fields not in STEP_META_KEYS, these three fields DO land in `resolved` and flow into `deps.executeTool(step.tool, resolved)` at line 682. Inside `buildChainedDeps.executeTool` (yamlRunner.ts line 3055), `const step: YamlStep = { tool, ...params }` spreads them into the step object, and `executeStep` (line 2254) iterates all keys except `tool`/`agent`/`into`, so they end up in `params`.
+
+However, the finding's claimed impact — "any tool with strict schema validation would reject […]
+
+
+### Recipe support (scheduler, orchestrator, pricing, simulation)
+
+#### 🟡 MEDIUM · `sched-cron6-1` — parseSchedule silently rejects 6-field cron expressions — node-cron supports them but recipes using seconds precision are never scheduled
+
+**Location:** `src/recipes/scheduler.ts:451` · **Category:** logic-gap · **Verifier confidence:** high
+
+parseSchedule accepts only 5-field cron expressions (the regex `/^\S+\s+\S+\s+\S+\s+\S+\s+\S+$/` matches exactly 5 whitespace-separated tokens). node-cron (the underlying scheduler) supports an optional 6th leading seconds field (e.g. `0 0 8 * * 1-5` = every weekday at 08:00:00). A recipe author who writes a 6-field cron passes cron.validate() (returns true) but the 5-field regex rejects it first, so parseSchedule returns null, the scheduler logs a generic 'unsupported schedule' warning, and the recipe is silently never scheduled. There is no indication the 6-field form was the issue.
+
+```ts
+// scheduler.ts:450-454
+// 5-field cron expression (e.g. "0 8 * * 1-5")
+if (/^\S+\s+\S+\s+\S+\s+\S+\s+\S+$/.test(trimmed)) {
+  if (cron.validate(trimmed)) {
+    return { kind: "cron5", expression: trimmed };
+  }
+}
+return null;
+```
+Verified: `cron.validate('0 0 8 * * 1-5')` returns `true` but the 6-token string fails the 5-field regex → `null` → warning 'unsupported schedule … use @every Ns|Nm|Nh or a 5-field cron expression'. Users see no indication their 6-field format was the cause.
+
+> **Verifier:** All three claims verified on HEAD. (1) Code at scheduler.ts:451 exactly matches the quoted snippet — the regex `/^\S+\s+\S+\s+\S+\s+\S+\s+\S+$/` requires exactly 5 whitespace-separated tokens. (2) `node -e` confirms: `cron.validate('0 0 8 * * 1-5')` returns `true` but the 5-field regex returns `false` for the same string — so a 6-field expression passes library validation but is rejected before reaching it, returning `null`. (3) The caller at scheduler.ts:241 emits "unsupported schedule … use @every Ns|Nm|Nh or a 5-field cron expression" with no indication the 6-field form was the issue. (4) Not present in docs/audit-2026-06-08.md (grep found zero hits for the relevant terms). (5) […]
+
+#### 🟡 MEDIUM · `orch-hang-1` — RecipeOrchestrator.fire() has no dispatch timeout — inFlight entry never cleared if recipe hangs, permanently blocking future fires
+
+**Location:** `src/recipes/RecipeOrchestrator.ts:88` · **Category:** logic-gap · **Verifier confidence:** high
+
+RecipeOrchestrator.fire() adds the recipe name to `this.inFlight` at line 88 and removes it only in the `.finally()` callback of the dispatch promise. There is no timeout or TTL on the inFlight entry. If the dispatched recipe run hangs indefinitely (e.g. a tool step without a timeout_ms that never returns — already a known gap per audit finding recipe-chained-4), inFlight.delete(name) is never called. Every subsequent fire() with `dedupPolicy:'reject'` (the default) returns `{ ok: false, error: 'already_in_flight' }` permanently. Cron ticks, webhook triggers, and CLI runs for that recipe are all silently rejected until the bridge is restarted. The scheduler has a parallel inflight guard (scheduler.ts:383) with the same defect.
+
+```ts
+// RecipeOrchestrator.ts:88-98
+this.inFlight.add(name);  // added here
+
+dispatch(recipe, this.deps, seedContext)
+  .finally(() => {
+    this.inFlight.delete(name);  // only removed on promise settlement
+  })
+  .catch((err: unknown) => { ... });
+
+return { ok: true, taskId, name };
+// No timeout. No TTL. If dispatch never settles, inFlight grows forever.
+```
+
+> **Verifier:** The code at /Users/wesh/Documents/Anthropic Workspace/Patchwork OS/src/recipes/RecipeOrchestrator.ts lines 88-98 exactly matches the quoted evidence: inFlight.add(name) at line 88, removal only in the .finally() callback, no timeout or TTL anywhere in the file. grep confirms zero timeout/clearTimeout/TTL references near inFlight in either RecipeOrchestrator.ts or scheduler.ts (which has the identical pattern at line 383). The defect is real and reachable: if any recipe step hangs without an explicit timeout_ms (still possible even after the recipe-chained-4 fix in PR #952, since timeout_ms is opt-in per-step and the flat yamlRunner path is also affected), the dispatch promise never settles, […]
+
+#### ⚪ LOW · `chain-price-1` — chainedRunner calls computeAgentCallUsage without priceTable — N per-step disk reads and budget/logging price divergence
+
+**Location:** `src/recipes/chainedRunner.ts:626` · **Category:** bug · **Verifier confidence:** high
+
+computeAgentCallUsage is exported from yamlRunner.ts with a default parameter `priceTable = loadPriceTable()`. Every call without an explicit table triggers a fresh readFileSync from disk. The chainedRunner calls it at line 626 without passing a table argument, causing one disk read per agent step. In contrast the flat runner (yamlRunner.ts line 1146) loads the table once at run start and threads it through. This creates two independent problems: (1) O(n) disk reads per recipe run where n = agent step count, and (2) a correctness gap between RunBudget's enforcement table (loaded once at construction, line 904) and the per-step costUsd logged to the run record — if prices.json changes mid-run, `sum(step.costUsd)` will not equal `runBudget.totals().usd`.
+
+```ts
+// chainedRunner.ts:626 — no priceTable arg passed
+const usage = computeAgentCallUsage(
+  agentReturn.usage,
+  agentReturn.servedBy,
+);
+
+// yamlRunner.ts:903 — default triggers loadPriceTable() on every call without arg
+export function computeAgentCallUsage(
+  usage: AgentUsage | undefined,
+  servedBy: { driver?: string; model?: string } | undefined,
+  priceTable: PriceTable = loadPriceTable(),  // re-read each call
+```
+Budget table loaded once at runChainedRecipe line 904: `const budget = options.budget ?? new RunBudget(recipe.budget);`
+
+> **Verifier:** The code evidence is accurate: chainedRunner.ts:626 calls computeAgentCallUsage without a priceTable argument, triggering the default parameter loadPriceTable() on every agent step. The flat yamlRunner loads the table once at line 1146 and threads it through. This asymmetry is real and confirmed on HEAD.
+
+However, the severity is overstated from MEDIUM to LOW for two reasons:
+
+1. Performance impact is minimal in practice. loadPriceTable() without an override file (~/.patchwork/prices.json or PATCHWORK_PRICE_TABLE) returns BUILTIN_PRICE_TABLE immediately after a single existsSync() check — no readFileSync. For the common case (no override file), the per-step "disk read" is just one stat […]
+
+#### ⚪ LOW · `sim-cost-1` — costProjector minUsd/maxUsd are sums of per-step extremes, not true run-level bounds — misleads budget planning
+
+**Location:** `src/recipes/simulation/costProjector.ts:143` · **Category:** docs-drift · **Verifier confidence:** high
+
+projectCost accumulates `minUsd += Math.min(...bucket.cost)` and `maxUsd += Math.max(...bucket.cost)` per agent step. These are uncorrelated step-level extremes: the run that produced the minimum cost for step A is not necessarily the same run that produced the minimum cost for step B. The returned `minUsd` / `maxUsd` are therefore NOT the observed minimum and maximum run costs — they underestimate the minimum (steps could be cheap in different runs) and similarly distort the maximum. The `SimulationCost` shape and the UI treat these as run-level bounds. There is no comment or note explaining this statistical artifact.
+
+```ts
+// costProjector.ts:140-146
+if (bucket.cost.length > 0) {
+  anyCost = true;
+  expectedUsd += median(bucket.cost);
+  minUsd += Math.min(...bucket.cost);  // per-step min, not run min
+  maxUsd += Math.max(...bucket.cost);  // per-step max, not run max
+}
+```
+A 2-step recipe where step A costs {0.01, 0.05} and step B costs {0.05, 0.01} (different runs) yields minUsd=0.02, maxUsd=0.10 — but the actual cheapest run cost 0.06 and the most expensive cost 0.06. The bounds are artifacts.
+
+> **Verifier:** The code at lines 140-145 of /Users/wesh/Documents/Anthropic Workspace/Patchwork OS/src/recipes/simulation/costProjector.ts exactly matches the quoted evidence: minUsd accumulates Math.min(...bucket.cost) per step and maxUsd accumulates Math.max(...bucket.cost). The statistical artifact is real — these are uncorrelated step-level extremes, not true run-level bounds. A run where step A is cheap and step B is expensive (and vice versa in another run) yields a minUsd that is lower than any actual run cost.
+
+However, the finding overstates the severity as "docs-drift": the JSDoc in types.ts line 154 explicitly says "sum of per-step min/max" — the documentation is accurate about the semantic, […]
+
+
+### Recipe tool registry & per-connector tools
+
+#### 🟡 MEDIUM · `connector-tools-1` — notion write tools propagate exceptions instead of returning soft-error envelope
+
+**Location:** `src/recipes/tools/notion.ts:225` · **Category:** bug · **Verifier confidence:** high
+
+notion.createPage and notion.appendBlock have no try/catch and do not use wrapConnectorExecute. Any connector throw (network error, auth failure, invalid parentId) propagates uncaught through executeTool to the recipe runner, which catches it at yamlRunner.ts:1920, sets haltAfterFailure=true, and hard-aborts the run as 'tool_threw'. This contradicts the intended soft-error contract evidenced by the success path returning {ok:true}: a failure should return {ok:false,error} so the run can continue (optional step or fallback path). All other write tools in the registry either have explicit try/catch or use wrapConnectorExecute.
+
+```
+execute: async ({ params }) => {
+    assertWriteAllowed("notion.createPage");
+    const { getNotionConnector } = await import("../../connectors/notion.js");
+    const connector = getNotionConnector();
+    const page = await connector.createPage({...}); // no try/catch — throws hard-halt the run
+    return JSON.stringify({ id: page.id, ..., ok: true });
+  }
+Same pattern at notion.appendBlock (line 295). The runner (yamlRunner.ts:1920) catches raw throws as thrownError, sets haltAfterFailure=true — different from the {ok:false} path which continues if optional/fallback is set.
+```
+
+> **Verifier:** The code at notion.ts lines 225 and 294 exactly matches the cited evidence: no try/catch, no wrapConnectorExecute import, connector calls unguarded. The wrapConnectorExecute helper exists (src/recipes/tools/wrapConnectorExecute.ts) and is used by twilio, stripe, circleci, snowflake. The "early" connectors (slack.ts, linear.ts) use explicit try/catch instead. Notion uses neither pattern. The runner at yamlRunner.ts:1920-1927 catches raw throws into thrownError, and at line 1955-1957 sets haltAfterFailure=true (haltCategory: tool_threw) unless the step has optional:true or the recipe has on_error.fallback. The bug is real and reachable whenever a notion connector call throws (auth failure, […]
+
+#### 🟡 MEDIUM · `connector-tools-2` — Widespread missing error handling in connector read tools — hard-halts recipe on transient error
+
+**Location:** `src/recipes/tools/shopify.ts:78` · **Category:** bug · **Verifier confidence:** high
+
+At least 10 connector tool files (shopify.ts, vercel.ts, pipedrive.ts, caldiy.ts, webflow.ts, woocommerce.ts, supabase.ts, todoist.ts, redis.ts, paystack.ts) have zero try/catch blocks and do not wrap with wrapConnectorExecute. Any connector throw (missing token, network failure, 429 rate-limit) propagates uncaught, causing the recipe runner to hard-halt the entire run with 'tool_threw' category instead of returning the soft {count:0,error} or {ok:false,error} envelope that the runner's non-fatal path expects. The wrapConnectorExecute helper exists precisely for this — it's just not applied. shopify.list_products and shopify.list_orders are the most reachable examples given Shopify's popularity.
+
+```
+// shopify.ts line 78:
+execute: async ({ params }) => {
+    const { getShopifyConnector } = await import("../../connectors/shopify.js");
+    const connector = getShopifyConnector(); // throws if no token stored
+    const result = await connector.listProducts({...}); // throws on HTTP error
+    return JSON.stringify(result); // unreachable on error
+}
+// vercel.ts line 59: same pattern (no try, no wrapConnectorExecute)
+// pipedrive.ts line 141: create_deal (write) also missing
+// wrapConnectorExecute exists at src/recipes/tools/wrapConnectorExecute.ts and is used by stripe, twilio, circleci, monday, snowflake, airtable, salesforce — but NOT by these tools.
+```
+
+> **Verifier:** The code evidence is unambiguous. shopify.ts (and vercel.ts, pipedrive.ts, todoist.ts, and others) have zero try/catch blocks and do not call wrapConnectorExecute. The execute functions call getShopifyConnector() and connector.listProducts() with no error handling; any throw propagates raw out of tool.execute(). 
+
+The runner-level behavior (verified in yamlRunner.ts lines 1920-1957 and chainedRunner.ts lines 728-1216) confirms the throw is caught at the runner level, but for a default non-optional step it sets haltAfterFailure=true (yamlRunner) or throws to executeWithDependencies (chainedRunner), aborting the run. The fail-open path (step.optional=true or […]
+
+#### 🟡 MEDIUM · `connector-tools-3` — obsidian.write_note (isWrite:true) propagates exceptions without soft-error envelope
+
+**Location:** `src/recipes/tools/obsidian.ts:140` · **Category:** bug · **Verifier confidence:** high
+
+obsidian.write_note is a write-gated tool (isWrite:true, riskDefault:medium) with no try/catch and no wrapConnectorExecute. The connector.writeNote call can throw if the Obsidian vault is unreachable or the Local REST API plugin is not running. This causes the recipe runner to hard-halt the entire run as 'tool_threw' rather than returning {ok:false,error}. The success path explicitly builds {ok:true,path,append}, signalling the intended soft-error pattern was omitted by mistake.
+
+```
+execute: async ({ params }) => {
+    const { getObsidianConnector } = await import("../../connectors/obsidian.js");
+    const connector = getObsidianConnector();
+    const notePath = params.notePath as string;
+    const append = params.append === true;
+    await connector.writeNote(notePath, params.content as string, append); // throws — no catch
+    return JSON.stringify({ ok: true, path: notePath, append });
+  },
+```
+
+> **Verifier:** The cited code at /Users/wesh/Documents/Anthropic Workspace/Patchwork OS/src/recipes/tools/obsidian.ts:140-149 is confirmed on HEAD: `obsidian.write_note` has no try/catch and does not use `wrapConnectorExecute`. The `wrapConnectorExecute` helper at src/recipes/tools/wrapConnectorExecute.ts exists explicitly for this pattern — its docstring even describes the problem ("A connector throw ... then propagates uncaught. The recipe runner treats an uncaught throw as a null result"). It is used by twilio, stripe, resend, circleci, snowflake connectors but NOT by any obsidian tool. The yamlRunner.ts catch at line 1920 confirms the downstream behavior: an uncaught throw becomes `thrownError`, which […]
+
+#### 🟡 MEDIUM · `connector-tools-6` — Stripe list tools expose has_more in output schema but provide no cursor/pagination params
+
+**Location:** `src/recipes/tools/stripe.ts:43` · **Category:** logic-gap · **Verifier confidence:** high
+
+All four Stripe list tools (stripe.listCharges, stripe.listCustomers, stripe.listSubscriptions, stripe.listInvoices) return Stripe's native list envelope which includes has_more:true when more pages exist, and this field is explicitly declared in the outputSchema. However, none of the tools expose starting_after or ending_before cursor parameters, and neither does the underlying connector method. A recipe that sets limit:10 and sees has_more:true in ctx has no way to request the next page — the rest of the data is silently inaccessible. The connector itself (src/connectors/stripe.ts listCharges etc.) also lacks cursor support.
+
+```
+// stripe.ts outputSchema (line 39-45):
+outputSchema: {
+  type: "object",
+  properties: {
+    data: { type: "array", items: { type: "object" } },
+    has_more: { type: "boolean" }, // surfaced but unactionable
+  },
+},
+// paramsSchema (lines 20-38): only limit, customerId, status — no starting_after/ending_before
+// connector (src/connectors/stripe.ts:195-210):
+async listCharges(params: { limit?: number; customerId?: string; status?: string }):
+  // no cursor param in method signature
+```
+
+> **Verifier:** Evidence confirmed on HEAD. All four Stripe list tools (stripe.listCharges, stripe.listCustomers, stripe.listSubscriptions, stripe.listInvoices) in src/recipes/tools/stripe.ts declare has_more: boolean in outputSchema but expose no starting_after or ending_before cursor params in paramsSchema. The underlying connector methods in src/connectors/stripe.ts (lines 195-196, 225-226, 254-255, 272-273) also lack cursor params in their TypeScript signatures — they build URLSearchParams with only limit/customerId/status/email, never a cursor. A recipe that sets limit:10 and receives has_more:true in ctx has no mechanism to fetch subsequent pages; the remaining data is silently inaccessible. The […]
+
+#### 🟡 MEDIUM · `connector-tools-7` — meetingNotes namespace missing from TOOL_NAMESPACE_TO_CONNECTOR — preflight skips Linear auth warning
+
+**Location:** `src/recipes/connectorPreflight.ts:39` · **Category:** unsurfaced · **Verifier confidence:** high
+
+meetingNotes.createLinearIssues (src/recipes/tools/meetingNotes.ts:422) is registered with namespace 'meetingNotes', declares isConnector:true, and calls linear.ts connector methods at runtime. However, 'meetingNotes' is absent from TOOL_NAMESPACE_TO_CONNECTOR. The detectRequiredConnectors function (connectorPreflight.ts:187) extracts the namespace 'meetingNotes' from the tool ID, looks it up in the map, finds nothing, and silently skips it. Recipes using meetingNotes.createLinearIssues will pass preflight with no missing-connector warning — they will only fail at first run when loadTokens() returns null.
+
+```
+// connectorPreflight.ts TOOL_NAMESPACE_TO_CONNECTOR (lines 39-89):
+// Contains: slack, github, jira, linear, gmail, calendar, drive, docs,
+// intercom, hubspot, datadog, stripe, sentry, zendesk, asana, notion,
+// confluence, discord, gitlab, pagerduty, airtable, caldiy, circleci,
+// cloudflare, elasticsearch, figma, grafana, monday, obsidian, paystack,
+// pipedrive, postgres, posthog, redis, resend, salesforce, sendgrid,
+// shopify, snowflake, supabase, todoist, twilio, vercel, webflow, woocommerce
+// NOT present: 'meetingNotes'
+// meetingNotes.ts line 422-463: registers id 'meetingNotes.createLinearIssues',
+// namespace 'meetingNotes', isConnector:true — calls linear connector at runtime
+```
+
+> **Verifier:** Confirmed on HEAD. `TOOL_NAMESPACE_TO_CONNECTOR` at `/src/recipes/connectorPreflight.ts:39-89` has 46 namespace entries but does not include `meetingNotes`. The `detectRequiredConnectors` function extracts namespace from tool IDs via `extractNamespace()` and looks up the map — for `meetingNotes.createLinearIssues` it extracts `meetingNotes`, finds no map entry, and silently skips it. `meetingNotes.createLinearIssues` in `/src/recipes/tools/meetingNotes.ts:422-469` is registered with `isConnector: true` and dynamically imports `../../connectors/linear.js` at runtime, calling `loadTokens()` immediately. `isConnector` is never read by `connectorPreflight.ts` — the field is purely metadata with […]
+
+#### ⚪ LOW · `connector-tools-4` — jira.add_comment and pagerduty.add_incident_note have riskDefault:"low" but isWrite:true
+
+**Location:** `src/recipes/tools/jira.ts:368` · **Category:** logic-gap · **Verifier confidence:** high
+
+jira.add_comment (line 368) and pagerduty.add_incident_note (pagerduty.ts:390) declare riskDefault:"low" while also declaring isWrite:true. The riskDefault drives the approval gate decision in the dashboard and recipe preflight display; 'low' signals to the user that no approval is needed, but these are real writes (persisting a comment or note in an external system). Every other write tool in the registry uses riskDefault:"medium" or "high". The inconsistency means recipe authors see 'low' risk for an irreversible write-to-external-system action, and automated approval policies that gate on risk tier will not intercept these steps.
+
+```
+// jira.ts lines 368-369:
+  riskDefault: "low",
+  isWrite: true,
+// pagerduty.ts lines 390-391:
+  riskDefault: "low",
+  isWrite: true,
+// All other write tools in the registry: riskDefault: "medium" or "high" (slack.ts:58, linear.ts:147, jira.create_issue:236, pagerduty.acknowledge_incident:268, notion.createPage:222, etc.)
+```
+
+> **Verifier:** The code evidence is confirmed exactly as cited. Both jira.add_comment (jira.ts:368-369) and pagerduty.add_incident_note (pagerduty.ts:390-391) declare riskDefault:"low" with isWrite:true, while all other write tools in those files use riskDefault:"medium".
+
+However, the severity should be downgraded to LOW rather than MEDIUM for this reason: the runtime approval gate (bridge.ts:359-362, streamableHttp.ts:856) calls classifyTool() from riskTier.ts, which does NOT use riskDefault at all. It uses a hardcoded TIER_MAP plus inferTierFromName(). The name "jira.add_comment" contains a dot and doesn't match any TIER_MAP entry, so inferTierFromName() is called. That function's write-heuristic regex […]
+
+#### ⚪ LOW · `connector-tools-5` — notion.createPage and notion.appendBlock call assertWriteAllowed directly AND rely on executeTool — double invocation
+
+**Location:** `src/recipes/tools/notion.ts:226` · **Category:** bug · **Verifier confidence:** high
+
+notion.createPage (line 226), notion.appendBlock (line 295), intercom.replyToConversation, intercom.closeConversation, datadog.muteMonitor, slack.post_message, confluence.createPage, confluence.appendToPage, zendesk.addComment, zendesk.updateStatus, hubspot.createNote, http.post, and file.write/file.append all call assertWriteAllowed() inside their execute() body. However, toolRegistry.executeTool (toolRegistry.ts:122) ALSO calls assertWriteAllowed(id) unconditionally when tool.isWrite is true, BEFORE calling tool.execute(). Result: assertWriteAllowed fires twice per write-tool call. While not a correctness bug (idempotent if kill switch is off; throws on first check if on), it creates a maintenance trap: if executeTool's guard is ever removed, only the tools with the inline guard remain protected.
+
+```
+// toolRegistry.ts:121-122 (registry-level guard):
+  if (tool.isWrite) {
+    assertWriteAllowed(id); // first invocation
+    ...
+    return ledger.getOrExecute(key, () => tool.execute(context)); // calls tool.execute
+  }
+// notion.ts:226 (inline guard inside execute — second invocation):
+  execute: async ({ params }) => {
+    assertWriteAllowed("notion.createPage"); // second invocation — redundant
+    ...
+```
+
+> **Verifier:** The double invocation is confirmed on HEAD. toolRegistry.ts:122 calls assertWriteAllowed(id) for any isWrite=true tool before dispatching to tool.execute(). notion.ts:226 and :295 (and 10+ other write tools) also call assertWriteAllowed inside their execute() body. Since assertWriteAllowed is a pure guard with no side effects — it either throws (kill switch ON, first call wins) or is a no-op (kill switch OFF) — there is zero functional difference from calling it twice. No correctness bug, no security gap, no performance concern. The finding's own description correctly classifies it as a maintenance trap rather than an active defect. The finding is not documented in docs/audit-2026-06-08.md. […]
+
+#### ⚪ LOW · `connector-tools-8` — jira.list_issues interpolates project param directly into JQL string — unquoted, breakable with special chars
+
+**Location:** `src/recipes/tools/jira.ts:63` · **Category:** bug · **Verifier confidence:** high
+
+When the jql param is absent and project is supplied, jira.list_issues builds the JQL query as project = ${projectInput} ORDER BY created DESC (unquoted). A project name containing spaces (e.g. 'My Project') produces invalid JQL that the Jira API rejects, silently returning an error envelope. A project name containing JQL operators (e.g. 'ENG AND status = Done') appends unsolicited clauses. The correct form is project = "${escaped}" with double-quote wrapping and escaping of embedded quotes.
+
+```
+// jira.ts lines 58-64:
+const projectInput = typeof params.project === "string" ? params.project.trim() : "";
+const jql = jqlInput
+  ? jqlInput
+  : projectInput
+    ? `project = ${projectInput} ORDER BY created DESC`  // unquoted interpolation
+    : "ORDER BY created DESC";
+// E.g. params.project = "ENG TEAM" → JQL: project = ENG TEAM ORDER BY created DESC
+// → Jira 400 'JQL syntax error: expected closing quote'
+```
+
+> **Verifier:** The defect is real and exactly matches the cited evidence. Line 63 of /Users/wesh/Documents/Anthropic Workspace/Patchwork OS/src/recipes/tools/jira.ts contains the unquoted interpolation: `project = ${projectInput} ORDER BY created DESC`. The code is reachable: any recipe that calls jira.list_issues with a project param (and no jql) hits this path. Not found in docs/audit-2026-06-08.md so not a duplicate. Severity remains LOW, not higher, because: (1) Jira project keys are constrained by Jira itself to uppercase alphanumeric + hyphens — spaces and JQL operators are invalid Jira project keys, making the failure mode an edge case tied to misuse rather than normal use; (2) the failure for […]
+
+#### ⚪ LOW · `connector-tools-9` — pagerduty.get_incident outputSchema declares {count,items} shape but semantics differ from pagerduty.list_incidents
+
+**Location:** `src/recipes/tools/pagerduty.ts:109` · **Category:** docs-drift · **Verifier confidence:** high
+
+pagerduty.get_incident fetches a single incident by ID but wraps the result in {count:1, items:[incident]} using the list-style output schema (identical to pagerduty.list_incidents). Recipe authors who read the schema or use {{steps.x.json}} template variable would expect a single-object shape (matching how gitlab.get_issue, jira.get_issue, etc. work) but instead receive a list envelope. Downstream steps using {{steps.x.items[0].id}} instead of {{steps.x.id}} is a non-obvious mismatch.
+
+```
+// pagerduty.ts outputSchema for get_incident (line 109-116):
+outputSchema: {
+  type: "object",
+  properties: {
+    count: { type: "number" },  // list-style schema — inconsistent with single-fetch intent
+    items: { type: "array", items: { type: "object" } },
+    error: { type: "string" },
+  },
+},
+// execute (lines 125-128): returns JSON.stringify({ count: 1, items: [incident] })
+// Compare: gitlab.get_issue (gitlab.ts:223) returns JSON.stringify({ ...issue }) — flat object
+```
+
+> **Verifier:** The code at the cited location exactly matches the evidence. `pagerduty.get_incident` (lines 109-116, 127) uses `{count:1, items:[incident]}` list-envelope shape for a single-item fetch, and the outputSchema mirrors `pagerduty.list_incidents` exactly. The inconsistency with peer connectors like `gitlab.get_issue` (which returns a flat object spread) is real and documented in gitlab.ts header: "single-object lookups return the object spread." The pagerduty.ts header (lines 5-8) reveals this is an *intentional* design choice — the `{count, items}` envelope was chosen so the runner's silent-fail detector (PR #75) catches empty responses as step errors. The pattern is internally consistent […]
+
+
+### Connector core & OAuth callbacks
+
+#### 🟠 HIGH · `connector-new-1` — Discord/Asana/GitLab token-exchange raw IdP body echoed into HTML response
+
+**Location:** `src/connectors/discord.ts:562` · **Category:** security · **Verifier confidence:** high
+
+When the token-exchange POST to the OAuth provider returns a non-2xx status, the raw response body (which can contain access_token, error_description, or other sensitive values in form-encoded or JSON error bodies) is embedded verbatim in the thrown Error message. That Error propagates to the callback handler and is written into the HTML response body returned to the browser. This is the same class of bug as audit finding connectors-core-2 (which only covered mcpOAuth.ts and was subsequently fixed there) but the same pattern survived in three other connectors that were not patched. Discord: lines 561-562 throw, line 619 surfaces in HTML. Asana: lines 731-732 throw, line 798 surfaces in HTML. GitLab: lines 636-637 throw, line 698 surfaces in HTML.
+
+```
+discord.ts:560-562:
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`Token exchange HTTP ${res.status}: ${body}`);
+  }
+...
+discord.ts:619:
+  body: `<html><body><h2>Discord connect failed</h2><pre>${escHtml(err instanceof Error ? err.message : String(err))}</pre></body></html>`
+
+The same pattern appears in asana.ts:731-732 and gitlab.ts:636-637, reaching HTML at asana.ts:798 and gitlab.ts:698. Compare mcpOAuth.ts:374 which was FIXED to `throw new Error('${config.vendor} token exchange failed (${res.status})')` — status only.
+```
+
+> **Verifier:** All three cited code paths exist verbatim on HEAD and are unfixed. discord.ts:560-562 does `const body = await res.text(); throw new Error(\`Token exchange HTTP ${res.status}: ${body}\`)`, and line 619 writes `escHtml(err.message)` into the HTML response body. Identical pattern confirmed at asana.ts:730-732/798 and gitlab.ts:635-637/698. PR #947 (802257a3) fixed connectors-core-2 in mcpOAuth.ts only — git diff confirms discord.ts and asana.ts were not touched, and the gitlab.ts change in #947 was exclusively the OAuth state store migration (connectors-core-3), not the token-exchange path. The audit doc (connectors-core-2) is scoped only to mcpOAuth.ts:370 and uses github.ts as the example […]
+
+#### 🟠 HIGH · `connector-new-2` — Monday.com and Google Docs token-exchange raw body propagates into JSON API response
+
+**Location:** `src/connectors/monday.ts:266` · **Category:** security · **Verifier confidence:** high
+
+monday.ts and googleDocs.ts embed the full raw IdP response body in the thrown Error during token exchange and token refresh, which then propagates into the JSON response body of the POST /connections/<vendor>/callback endpoint. An attacker who induces a failed auth on Monday.com or Google Docs can observe IdP error detail. Google OAuth error bodies include error_description fields that can contain partial secrets or sensitive parameter values. This is a distinct code path from connectors-core-2 (mcpOAuth.ts) which was patched separately; these connectors were not included in that fix.
+
+```
+monday.ts:264-266:
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`Token exchange failed: ${res.status} ${body}`);
+  }
+monday.ts:308: same pattern for token refresh
+
+googleDocs.ts:211-212:
+  const body = await res.text();
+  throw new Error(`Token exchange failed: ${res.status} ${body}`);
+googleDocs.ts:253-254: same for refresh
+
+The error reaches the caller's JSON response at monday.ts:970 and googleDocs.ts:509:
+  error: err instanceof Error ? err.message : String(err)
+```
+
+> **Verifier:** Code at the cited lines is confirmed present on HEAD and unfixed. monday.ts:264-266 and 306-308 call `res.text()` (unbounded) and embed it verbatim in a thrown Error. googleDocs.ts:210-212 and 252-254 do the same. Both errors propagate to handleMondayCallback() (~line 964-970) and handleDocsCallback() (lines 503-511) which serialize `err.message` directly into the JSON response body. PRs #947-#953 did not touch either file (monday.ts last modified in #781, googleDocs.ts in #780). The audit doc entry connectors-core-2 explicitly scopes to mcpOAuth.ts:370 only and covers only the GitHub/Linear/Sentry MCP-OAuth code path — monday.ts and googleDocs.ts implement their own independent […]
+
+#### 🟡 MEDIUM · `connector-new-3` — Gmail callback postMessage uses hardcoded 'http://localhost:3200' target origin
+
+**Location:** `src/connectors/gmail.ts:578` · **Category:** bug · **Verifier confidence:** high
+
+The OAuth callback success page for Gmail sends a postMessage with a hardcoded origin 'http://localhost:3200'. In any non-local deployment (remote bridge, VPS, docker) the opener window is on the dashboard origin, not localhost:3200. postMessage silently drops messages when the target origin does not match the actual window origin — so the opener tab never receives the completion signal and the dashboard's poll/listener never fires. The auth succeeds server-side but the dashboard popup cannot signal the parent tab to refresh status. A secondary security concern: if some service happens to run on localhost:3200, a page there could listen for this message.
+
+```
+gmail.ts:577-578:
+  // Notify the opener tab that auth completed so it can poll.
+  if (window.opener) { try { window.opener.postMessage('patchwork:gmail:connected', 'http://localhost:3200'); } catch(_) {} }
+
+Contrast with slack.ts:458 which correctly uses `window.location.origin`:
+  window.opener.postMessage('patchwork:slack:connected', window.location.origin)
+```
+
+> **Verifier:** Code at gmail.ts:578 exactly matches the quoted evidence: `window.opener.postMessage('patchwork:gmail:connected', 'http://localhost:3200')`. The dashboard listener at connections/page.tsx:1594 guards with `if (e.origin !== window.location.origin) return` — it only accepts messages from the dashboard's own origin. The browser's postMessage spec delivers the message only to a window whose actual origin matches the target-origin argument; since the dashboard is never on http://localhost:3200 (dev is typically :3000/:3001, production is https://app.patchworkos.com), the browser silently drops the message and the listener never fires. Auth succeeds server-side (tokens saved), but the popup […]
+
+#### 🟡 MEDIUM · `connector-new-4` — Discord, Asana, and GitLab callback pages use wildcard '*' postMessage target origin
+
+**Location:** `src/connectors/discord.ts:613` · **Category:** security · **Verifier confidence:** high
+
+The OAuth callback success pages for Discord, Asana, and GitLab post an auth-completion event using window.opener.postMessage('patchwork:<vendor>:connected', '*'). The wildcard target origin means any page in any browser tab, including a malicious page that opened the OAuth popup, can listen for and receive this event. While the event payload itself is not sensitive (it is just a string signal), a cross-origin attacker can detect when the user successfully authenticates (timing and identity information) and could use it as part of a phishing or social-engineering attack. Slack correctly uses window.location.origin. The slack.test.ts file acknowledges the risk in a comment but no fix was applied to the other connectors.
+
+```
+discord.ts:613:
+  body: `...<script>try { window.opener.postMessage('patchwork:discord:connected', '*'); } catch(_) {} window.close();</script>...`
+
+asana.ts:792:
+  window.opener.postMessage('patchwork:asana:connected', '*');
+
+gitlab.ts:692:
+  window.opener.postMessage('patchwork:gitlab:connected', '*');
+
+slack.ts:458 (correct pattern):
+  window.opener.postMessage('patchwork:slack:connected', window.location.origin);
+
+slack.test.ts:173 comment:
+  // window.opener.postMessage(msg, '*') is a wildcard origin — any page in [any tab] could receive it
+```
+
+> **Verifier:** All three cited lines exist exactly as claimed on HEAD. discord.ts:613, asana.ts:792, and gitlab.ts:692 each use postMessage with wildcard '*' target origin, while slack.ts:458 correctly uses window.location.origin. The finding is reachable in normal use — these are the OAuth callback success pages that fire after any successful user authentication via the browser popup flow. Not fixed in PRs #947-#953 (those PRs addressed sessions, OAuth callback pages/routes for google-docs/monday/salesforce, per-step timeout_ms, and on-device semantic memory). Not documented in docs/audit-2026-06-08.md (searched for postMessage, window.opener, wildcard origin — no matches). Severity MEDIUM is correct: […]
+
+#### 🟡 MEDIUM · `connector-new-5` — McpClient.post() embeds 300-char upstream MCP server error body in thrown Error
+
+**Location:** `src/connectors/mcpClient.ts:169` · **Category:** security · **Verifier confidence:** high
+
+When an upstream MCP server (GitHub MCP, Linear MCP, Sentry MCP) returns a non-2xx, non-401 status, the client captures the first 300 characters of the response body and embeds them in the thrown Error. This Error propagates to the recipe tool wrappers and into the tool result content that the recipe runner passes to the LLM. MCP error responses from upstream servers can include internal server context, stack traces, or in misconfigured deployments, token values. The upstream endpoint URL (which includes the provider domain) is also included. This differs from connectors-core-2 (fixed in mcpOAuth.ts) — this is the downstream tool-call path, not the token-exchange path.
+
+```
+mcpClient.ts:168-172:
+  if (!res.ok) {
+    const snippet = (await res.text()).slice(0, 300);
+    throw new Error(
+      `MCP HTTP ${res.status} at ${this.endpoint}: ${snippet}`,
+    );
+  }
+
+This error propagates through callTool() -> recipe tools (github.ts listIssues, listPRs, listCommits) -> tool result content -> LLM context.
+```
+
+> **Verifier:** The code at mcpClient.ts:168-172 exactly matches the quoted evidence — non-2xx, non-401 responses embed up to 300 chars of the upstream response body plus the endpoint URL in the thrown Error. The propagation chain is fully traceable: post() → callTool() → github.ts/linear.ts/sentry.ts connector wrappers → recipe tools (src/recipes/tools/github.ts:53-63) where the catch block places err.message verbatim into the JSON result returned to the recipe runner as LLM tool context. This path is reachable in normal use whenever an upstream GitHub/Linear/Sentry MCP server returns a 5xx or 4xx (non-401). It is not a duplicate of connectors-core-2: that finding covers mcpOAuth.ts:370 (token-exchange […]
+
+
+### NEW: semantic memory / traces (PR #953 + current branch)
+
+#### 🟡 MEDIUM · `sem-2` — Semantic search returning all-below-floor scores silently returns empty results with no substring fallback
+
+**Location:** `src/tools/ctxQueryTraces.ts:362` · **Category:** logic-gap · **Verifier confidence:** high
+
+When the embeddings endpoint is configured and returns vectors, but every trace scores below SEMANTIC_FLOOR (0.25), semanticRank() returns an empty array []. The handler checks `if (ranked)` at line 362 — an empty array is truthy in JavaScript — and immediately returns { traces: [], count: 0 } with no fallback to substring search. The substring fallback at lines 371-372 is only reached when ranked is null (embeddings failure/unconfigured). The PR description states the toggle is 'always safe to flip' because it 'falls back to substring when no embeddings endpoint is configured', but this claim is incomplete: when embeddings ARE configured but all cosine scores fall below 0.25 (common for short approval-log entries like 'allow runCommand (gate_off)'), the user gets zero results with no indication, even though substring search would have found matches.
+
+src/tools/ctxQueryTraces.ts lines 130-142 and 362-372:
+```ts
+// semanticRank: empty array returned when all scores < SEMANTIC_FLOOR
+if (score < SEMANTIC_FLOOR) continue;  // line 134
+...
+scored.sort(...);
+return scored.slice(0, limit).map((s) => s.trace);  // returns [] when all filtered
+
+// handler:
+if (ranked) {          // line 362 — [] is truthy!
+  return successStructured({ traces: ranked, count: ranked.length, sources });
+}
+// Fallback (lines 371-372) unreachable for empty-but-valid embedding result:
+const qNeedle = qFilter.toLowerCase();
+filtered = filtered.filter((t) => matchesSubstring(t, qNeedle));
+```
+The test at ctxQueryTraces.semantic.test.ts line 163 only verifies that below-floor traces are excluded when above-floor ones exist; it does not test the all-below-floor case, so this silent empty-result mode is untested.
+
+> **Verifier:** The finding is confirmed on HEAD. At /Users/wesh/Documents/Anthropic Workspace/Patchwork OS/src/tools/ctxQueryTraces.ts:
+
+1. semanticRank() returns [] (empty array, not null) when all traces score below SEMANTIC_FLOOR (0.25) — confirmed at lines 134-138: the `if (score < SEMANTIC_FLOOR) continue` loop produces an empty `scored` array, and line 138 returns `scored.slice(0, limit).map(...)` which is [].
+
+2. The handler at line 362 checks `if (ranked)` — an empty array is truthy in JavaScript, so this branch fires and returns { traces: [], count: 0 } immediately.
+
+3. The substring fallback at lines 371-372 is only reached when `ranked` is null (embeddings failure, error thrown, or vectors […]
+
+#### ⚪ LOW · `sem-1` — GET /traces?limit=N where N > 500 (or N = 0) returns HTTP 500 instead of 400
+
+**Location:** `src/server.ts:974` · **Category:** bug · **Verifier confidence:** high
+
+The /traces route accepts any digit-only value for `limit` (regex /^\d+$/) and passes it as a raw Number to tracesFn. tracesFn calls ctxQueryTraces tool.handler(), which calls optionalInt(args, 'limit', 1, 500). Any value > 500 or equal to 0 causes optionalInt to throw ("limit must be an integer between 1 and 500"). That throw is not caught inside tracesFn, propagates to the server.ts try/catch at line 958, and becomes a respond500() call. The client receives HTTP 500 with generic 'Internal server error' instead of a 400 with the validation message. The same applies to since > Number.MAX_SAFE_INTEGER.
+
+src/server.ts line 973-976:
+```
+limit:
+  limitStr !== null && /^\d+$/.test(limitStr)
+    ? Number(limitStr)
+    : undefined,
+```
+Number('501') = 501 passes the regex check and is handed to tracesFn. Inside ctxQueryTraces.ts line 298: `optionalInt(args, 'limit', 1, 500)` throws for values outside [1, 500]. The throw propagates uncaught to server.ts line 995-997: `} catch (err) { respond500(res, err); }` — returning HTTP 500 with 'Internal server error' body, leaking nothing but also giving the caller no actionable feedback. Dashboard hardcodes limit=50 so it is unexposed, but raw API callers hit it.
+
+> **Verifier:** The defect is real and the code path is exactly as described. Confirmed at HEAD:
+
+1. server.ts:973-976 parses `limit` with `/^\d+$/` and passes `Number(limitStr)` to `tracesFn` — no upper-bound guard.
+2. bridge.ts:1280 calls `tool.handler({ limit: query.limit })` with no try/catch wrapping.
+3. ctxQueryTraces.ts:298 calls `optionalInt(args, "limit", 1, 500)` which throws `Error: limit must be an integer between 1 and 500` for any value outside [1,500].
+4. The throw propagates uncaught through `tracesFn` to server.ts:995 `catch (err) { respond500(res, err); }` — returning HTTP 500 instead of 400.
+
+Not documented in docs/audit-2026-06-08.md (searched all relevant terms).
+
+Severity adjusted […]
+
+#### ⚪ LOW · `sem-3` — Queued-approval audit trail is split across two events: only the first carries the new 'channel' field
+
+**Location:** `src/approvalHttp.ts:985` · **Category:** logic-gap · **Verifier confidence:** high
+
+For a human-decided queued approval, two approval_decision events are written to the activity log. The first is emitted by the /approve/:callId or /reject/:callId route handler (lines 245-254 and 297-303) and carries the new 'channel' field ('phone' or 'dashboard') from PR #953. The second is emitted at line 985 by handleApprovalRequest after awaiting the queue promise, and uses the emit() closure defined at line 790-814 which does NOT include 'channel'. Before PR #953, both events lacked 'channel' (consistently no-channel). After PR #953, the first has 'channel' and the second does not, making the audit trail inconsistent. A query for all phone-approved decisions finds only half the events; the duplicate-without-channel event has a different 'reason' field ('approved' instead of 'allow') causing further confusion. The channel tests in approvalHttp-channel.test.ts only exercise the direct /approve/:callId path, not the full queued-await path.
+
+```
+src/approvalHttp.ts:
+- Line 245-254: /approve handler emits { callId, decision:'allow', channel:'phone'|'dashboard' }
+- Line 985: handleApprovalRequest emits via emit() closure: emit(outcome === 'approved' ? 'allow' : 'deny', outcome, { callId })
+- emit() at lines 790-814 includes toolName, specifier, decision, reason, permissionMode, sessionId, tier, workspace, params, riskSignals, summary — but NO 'channel' field.
+Result: two approval_decision events per queued approval decision; only the first has provenance channel data.
+```
+
+> **Verifier:** The double-emit is confirmed on HEAD. For a queued human approval: (1) POST /approve/:callId fires deps.onDecision at line 245 with channel:'phone'|'dashboard'; this also calls deps.queue.approve() which resolves the promise. (2) handleApprovalRequest at line 985 then fires emit() (the closure at lines 790-814) after awaiting the same promise — that closure has no channel field. Both are real calls to deps.onDecision("approval_decision", ...). The route handler (line 245) and the awaited-promise emit (line 985) are independent; there is no guard preventing both from firing. The test file src/__tests__/approvalHttp-channel.test.ts only calls routeApprovalRequest with /approve/:callId paths […]
+
+#### ⚪ LOW · `sem-4` — ctxQueryTracesTool and LocalEmbeddingsProvider re-allocated on every GET /traces request
+
+**Location:** `src/bridge.ts:1273` · **Category:** perf · **Verifier confidence:** high
+
+The tracesFn closure in bridge.ts calls createCtxQueryTracesTool() and getLocalEmbedFn() on every invocation (every /traces HTTP request, polled every 3 seconds by the dashboard). getLocalEmbedFn() calls createEmbeddingsProvider() which calls new LocalEmbeddingsProvider(), reading environment variables and allocating a closure on each call. On non-semantic requests this allocation is wasted (the embedFn is passed to ctxQueryTracesTool but never invoked since semanticActive=false). The tool, deps object, and provider should be constructed once at bridge startup and reused across requests.
+
+src/bridge.ts lines 1272-1278:
+```ts
+this.server.tracesFn = async (query) => {
+  const tool = createCtxQueryTracesTool({   // re-created every call
+    activityLog: this.activityLog,
+    ...
+    embedFn: getLocalEmbedFn(),             // new provider every call
+  });
+```
+The dashboard polls /api/bridge/traces every 3 seconds (page.tsx line 572: `intervalMs: 3000`). With 4 active dashboard tabs: 80 provider allocations/minute even with embeddings disabled.
+
+> **Verifier:** The cited code at src/bridge.ts:1272-1278 exactly matches the finding: createCtxQueryTracesTool() and getLocalEmbedFn() are called on every tracesFn invocation, and getLocalEmbedFn() calls createEmbeddingsProvider() → new LocalEmbeddingsProvider() on each call. The dashboard does poll /api/bridge/traces every 3 seconds (page.tsx:572). However, the actual cost is minimal: when no embeddings endpoint is configured (the common case), createEmbeddingsProvider() returns null immediately after 2-3 env var reads, so no LocalEmbeddingsProvider is allocated. When an endpoint IS configured, the allocation is just reading env vars and storing strings — no I/O, no network, no persistent resources. The […]
+
+#### ⚪ LOW · `sem-5` — responseFormat passthrough accepts arrays, forwarding invalid response_format to OpenAI-compatible APIs
+
+**Location:** `src/drivers/openai/index.ts:78` · **Category:** bug · **Verifier confidence:** high
+
+The new responseFormat passthrough in PR #953 checks `typeof opts.responseFormat === 'object'`. In JavaScript, arrays also pass this check (typeof [] === 'object'). A recipe step that accidentally sets providerOptions.responseFormat to an array (e.g. [{ type: 'json_object' }] from a YAML parsing mistake) will have the array forwarded as response_format to the API, causing an immediate 400 error from the endpoint. The error is caught by the driver's outer try/catch and surfaces as a ProviderTaskResult with an error text, not a throw. The fail-safe behavior is correct but the missing array check means a silent config mistake is not rejected early at input validation, and the error message from the API ('invalid response_format') may be confusing.
+
+src/drivers/openai/index.ts lines 77-79:
+```ts
+const responseFormat =
+  opts.responseFormat && typeof opts.responseFormat === 'object'
+    ? opts.responseFormat
+    : undefined;
+```
+No `!Array.isArray(opts.responseFormat)` guard. The test at openai-response-format.test.ts line 65-67 only covers the string case ('json_object' as string), not the array case. An array passes silently and is sent to the API.
+
+> **Verifier:** The code defect is confirmed at src/drivers/openai/index.ts lines 77-79: `typeof opts.responseFormat === 'object'` with no `!Array.isArray()` guard. Arrays pass this check in JavaScript. However, the finding's severity and practical impact are low for several reasons: (1) Searching the entire non-test codebase, responseFormat has zero upstream callers — no recipe runner, orchestrator, or bridge code sets providerOptions.responseFormat. The only usage is the driver itself reading it. This is a brand-new field from PR #953 with no production call sites yet. (2) To trigger this, a user must explicitly set providerOptions.responseFormat to an array in a recipe YAML (e.g. a YAML sequence instead […]
+
+
+### Regression review of fix PRs #947–#952
+
+#### ⚪ LOW · `pr949-1` — isValidKeychainKey guard missing from Linux secret-tool spawn sinks
+
+**Location:** `src/connectors/tokenStorage.ts:599` · **Category:** security · **Verifier confidence:** high
+
+PR #949 added isValidKeychainKey guards to all three macOS keychain spawn sinks (lines 654, 678, 695) but left the three Linux secret-tool functions (setLinuxSecretSync, getLinuxSecretSync, deleteLinuxSecretSync) unguarded. The fix's own PR comment says it protects 'three macOS keychain spawn sinks' — the Linux path was explicitly out of scope. CodeQL #135 flags the full taint path from provider name → spawn argv; only the macOS branch is now sanitised. On Linux, a provider name that reaches storageKey() and then the Linux functions could still be argued to contain special shell-like tokens (though secret-tool passes key as a positional arg, not a shell string, the taint is still live). Defense-in-depth is asymmetric across platforms.
+
+```
+function setLinuxSecretSync(key: string, value: string): boolean {
+  try {
+    const result = spawnSync(
+      "secret-tool",
+      ["store", "--label", key, "service", SERVICE_NAME, "account", key],
+      { input: value, encoding: "utf-8", timeout: 5000 },
+    );
+  }
+}
+
+function getLinuxSecretSync(key: string): string | null { ... spawnSync("secret-tool", ["lookup", ... key], ...) }
+function deleteLinuxSecretSync(key: string): boolean { ... spawnSync("secret-tool", ["clear", ... key], ...) }
+
+Compare: macOS setMacOSKeychainItemSync at line 654: if (!isValidKeychainKey(key)) return false;
+Linux functions at lines 599, 612, 628 have no such guard.
+```
+
+> **Verifier:** The code at HEAD confirms the asymmetry: isValidKeychainKey guards exist at lines 654, 678, 695 for macOS but are absent from setLinuxSecretSync (line 599), getLinuxSecretSync (line 612), and deleteLinuxSecretSync (line 628). PR #949 (bdc450f7) explicitly added the macOS guards only. So the structural finding is accurate.
+
+However, the MEDIUM severity is wrong for two independent reasons:
+
+1. No shell injection is possible on the Linux path. The macOS setMacOSKeychainItemSync uses spawnSync with '/bin/sh', ['-c', 'security ... "$1" ...', '--', key] — a shell string with positional parameter expansion — which is why the guard matters there. The Linux functions use spawnSync('secret-tool', […]
+
+#### ⚪ LOW · `pr950-1` — buildSessionDetail: 8-char prefix match is first-match-wins with no collision detection
+
+**Location:** `src/sessionDetail.ts:52` · **Category:** logic-gap · **Verifier confidence:** high
+
+buildSessionDetail resolves the 8-char prefix used by the dashboard to a session via `s.id === id || s.id.slice(0, 8) === id`. With multiple concurrent sessions whose full UUIDs share the same 8-char prefix (probability low but non-zero in any deployment with many sessions), the function silently returns whichever session appears first in Map.values() iteration order, which is insertion order. The dashboard navigation with an 8-char prefix could consistently return the wrong session's detail. A 404 with a descriptive error would be safer than silently returning an unintended session.
+
+```
+for (const s of sessions) {
+  if (s.id === id || s.id.slice(0, 8) === id) {
+    session = s;
+    break;  // first match wins; no collision check
+  }
+}
+// If two sessions share the first 8 chars, the older one always wins regardless of which the dashboard intended
+```
+
+> **Verifier:** The code at src/sessionDetail.ts:52-56 exists exactly as described: a linear scan with first-match-wins on `s.id.slice(0,8) === id`, no collision detection. The function was introduced in PR #950 to fix audit-2026-06-08 server-1 (the sessionDetailFn was never wired). The finding is not documented anywhere in docs/audit-2026-06-08.md. However, the practical severity is extremely low, not medium/high: (1) sessions are UUID v4, so the 8-char hex prefix space is 16^8 = ~4.3 billion values; (2) the bridge caps HTTP sessions at 5 concurrent (ADR-0005, CLAUDE.md) and WebSocket sessions in a local dev setup are typically 1-2; (3) collision probability with 5 sessions is ~(5 choose 2)/16^8 ≈ 4.3e-9, […]
+
+
+### Dashboard UI pages
+
+#### 🟡 MEDIUM · `dash-new-3` — Run detail page never retries polling after initial fetch failure — stuck in error state
+
+**Location:** `dashboard/src/app/runs/[seq]/page.tsx:1010` · **Category:** bug · **Verifier confidence:** high
+
+When `doFetch()` fails on the first call (network error, bridge restart), it returns `null`. `isInFlight(null)` is `false`, so the `.then()` callback returns early and the polling interval is never started. The page then shows a persistent error banner for an actively-running run, with no auto-recovery mechanism. The user must navigate away and back to retry. This is particularly bad during bridge restarts while a run is in progress.
+
+```
+doFetch().then((initialRun) => {
+  if (!isInFlight(initialRun)) return;  // null → false → returns early, no interval set
+  intervalId = setInterval(() => { doFetch()... }, 5000);
+});
+// No error-path retry; error state is terminal until full page reload
+
+isInFlight: (r: RunDetail | null) => r?.status === "running" || r?.status === "pending"
+// null input → undefined?.status → false
+```
+
+> **Verifier:** Code at HEAD (lines 992-1025 of dashboard/src/app/runs/[seq]/page.tsx) exactly matches the quoted evidence. doFetch() catches all errors and returns null (lines 1001-1004). isInFlight(null) evaluates to false because null?.status is undefined, which is neither "running" nor "pending" (lines 1007-1008). The early return at line 1011 fires, and setInterval is never started. The SSE fallback (useBridgeStream at line 1100) is also gated on run?.status === "running" — since run remains null after a failed initial fetch, SSE is disabled too. There is no retry mechanism, no exponential backoff, and no recovery path short of a full page reload. Reachable whenever the bridge is restarting or the […]
+
+#### ⚪ LOW · `dash-new-1` — Traces 'since' window freezes — polling shows stale time range
+
+**Location:** `dashboard/src/app/traces/page.tsx:560` · **Category:** bug · **Verifier confidence:** high
+
+The `qs` useMemo computes `Date.now() - sinceMs` once at the time the dependency changes and bakes it into the URL path passed to `useBridgeFetch`. Because `useBridgeFetch` reuses the same `path` string on every 3-second tick, the absolute `since` timestamp never advances. After 30 minutes on the 'last 1 hour' filter, the page fetches traces from 30–90 minutes ago rather than 0–60 minutes ago. Users watching live runs see an increasingly stale window with no indication that data is frozen.
+
+```
+params.set("since", String(Date.now() - sinceMs));  // evaluated once at dep-change time
+}, [debouncedSearch, since, ksOnly, semantic]);
+
+const { data, ... } = useBridgeFetch<TracesResponse>(
+  `/api/bridge/traces${qs}`,
+  { intervalMs: 3000, ... },  // reuses the frozen path on every tick
+);
+
+The fix is to pass a factory function to useBridgeFetch (or move Date.now() inside the fetch callback), not into the memoized path string.
+```
+
+> **Verifier:** The code at line 560 of dashboard/src/app/traces/page.tsx exactly matches the evidence: `params.set("since", String(Date.now() - sinceMs))` is inside a `useMemo` with deps `[debouncedSearch, since, ksOnly, semantic]`. No time-based dep is present, so `Date.now()` is evaluated once at dep-change time and frozen into the `qs` string. `useBridgeFetch` receives this frozen path and its `useEffect` (line 134) only re-runs when `path` changes — the 3s polling loop reuses the same URL each tick.
+
+The bug is real: the `since` timestamp in the query URL never advances during a polling session. With a "last 1 hour" filter, after 30 minutes the window covers -30 to -90 minutes ago, not -0 to -60 […]
+
+#### ⚪ LOW · `dash-new-4` — Export passphrase leaked in server access logs via request header on GET
+
+**Location:** `dashboard/src/app/traces/page.tsx:405` · **Category:** security · **Verifier confidence:** high
+
+The traces export passphrase (an AES-256-GCM encryption key) is transmitted as an HTTP request header `x-trace-passphrase` on a GET request. Standard HTTP access logs (nginx, Apache, Next.js, Vercel) log all request headers. The passphrase is therefore written to server access logs in plaintext on every export. An attacker with log access can decrypt any captured export. The passphrase should be sent as a POST body or derived on the client before the request.
+
+```
+const headers: Record<string, string> = {};
+if (phrase) headers["x-trace-passphrase"] = phrase;  // line 405
+const res = await fetch(apiPath("/api/bridge/traces/export"), { headers });  // GET request
+
+The passphrase is the encryption key for the exported file. Sending it in a header on a GET request exposes it to any logging layer between browser and bridge.
+```
+
+> **Verifier:** The code defect exists exactly as described: line 405 of dashboard/src/app/traces/page.tsx sets headers["x-trace-passphrase"] = phrase and the fetch at line 406 uses the default GET method. The proxy route at dashboard/src/app/api/bridge/[...path]/route.ts (lines 144-147) also explicitly forwards this header to the bridge.
+
+However, the finding's severity is overstated because the stated mechanism — "Standard HTTP access logs (nginx, Apache, Next.js, Vercel) log all request headers" — is factually incorrect. Standard nginx/Apache access log formats log only the request line (method, path, protocol), status code, response size, referrer, and User-Agent. Request body headers like […]
+
+#### ⚪ LOW · `dash-new-6` — `window` state variable shadows global `window` — silent maintenance trap
+
+**Location:** `dashboard/src/app/runs/page.tsx:204` · **Category:** bug · **Verifier confidence:** high
+
+A state variable named `window` shadows the browser global `window` object throughout the entire component scope. The existing code works around this with `const g = globalThis`, but any future developer who writes `window.addEventListener`, `window.location`, or `window.confirm` within this component will silently call the React state setter (a no-op) or get a TypeError when trying to call methods on a string value. This is a latent bug waiting for the next edit.
+
+```
+const [window, setWindow] = useState<TimeWindow>(...)  // line ~204
+// Later:
+const g = globalThis;  // workaround comment explains the shadow
+const _initSp = new URLSearchParams(g.location?.search ?? "");
+
+The shadow means `window.addEventListener` anywhere in the component body calls the TimeWindow setter, not the DOM API.
+```
+
+> **Verifier:** The shadow is confirmed real on HEAD: `const [window, setWindow] = useState<TimeWindow>(...)` at line 204 of dashboard/src/app/runs/page.tsx shadows the browser global `window` throughout the component. However, the finding overstates the risk. The existing code already handles this correctly and defensively: (1) there is an explicit inline comment at line 659 saying "window is shadowed by a state variable in this file — reach the global through globalThis"; (2) every DOM operation already uses `const g = globalThis as typeof globalThis & { window?: Window }` and `g.window`; (3) there are zero unguarded uses of `window.addEventListener`, `window.location`, or `window.confirm` anywhere in […]
+
+#### ⚪ LOW · `dash-new-7` — 'Discard expired' button count lags real expiry by up to 3 seconds
+
+**Location:** `dashboard/src/app/transactions/page.tsx:133` · **Category:** bug · **Verifier confidence:** high
+
+`expiredIds` is a `useMemo` that recomputes only when the `transactions` array changes (every 3s poll). TtlPill components tick at 1s via a module-level subscription. When a transaction expires between poll ticks, the individual TtlPill correctly shows 'Expired' but the 'Discard expired (N)' bulk-action button still shows the previous count and remains hidden until the next poll. This creates a 1–3 second window where the pill says 'Expired' but the bulk action hasn't appeared yet.
+
+```
+const expiredIds = useMemo(
+  () => transactions.filter((t) => t.expiresAt <= Date.now()).map((t) => t.id),
+  // re-evaluate each tick — the page already polls every 3s...
+  [transactions],  // line 138 — only updates on 3s poll, not on 1s tick
+);
+
+TtlPill uses a module-level tickSubscribers set that fires at 1s intervals, but expiredIds has no dependency on that clock source.
+```
+
+> **Verifier:** Code at /dashboard/src/app/transactions/page.tsx lines 133-139 exactly matches the evidence. `expiredIds` is a `useMemo` depending only on `[transactions]` (refreshed every 3s by the poll). `TtlPill` independently subscribes to a 1s module-level tick via `subscribeTtlTick` (lines 51-67, 71-72), causing each pill to re-render every second. The `expiredIds.length > 0` guard on line 211 means the "Discard expired (N)" button visibility is gated on the slower (3s) dependency, not the pill's 1s clock — creating a real but bounded (0-3s) visual inconsistency. The row-level `isExpired` inline check at line 278 has the same lag. Not found in docs/audit-2026-06-08.md (searched for all relevant […]
+
+
+### Dashboard API layer
+
+#### ⚪ LOW · `dash-new-2` — recipes/[...name] GET and DELETE silently drop all query parameters — dash proxy does not forward ?search to bridge, unlike the catch-all [...path] proxy
+
+**Location:** `dashboard/src/app/api/bridge/recipes/[...name]/route.ts:58` · **Category:** logic-gap · **Verifier confidence:** high
+
+The GET handler (line 58-59) builds the upstream path as bridgeFetch(`/recipes/${encodedName}`) with no query string. Similarly DELETE (line 134) uses bridgeFetch(`/recipes/${encodedName}`, { method: 'DELETE' }) with no query string. The catch-all [...path] proxy explicitly appends req.nextUrl.search (line 14-15: 'const qs = req.nextUrl.search; const target = `/${segments.join("/")}${qs}`'). Any query parameters sent by the client — including future pagination/filter params or format selectors — are silently discarded before reaching the bridge. This becomes a silent breakage when the bridge adds GET query parameters to recipe endpoints.
+
+```
+// Line 57-59 in route.ts:
+const encodedName = name.join("/");
+const res = await bridgeFetch(`/recipes/${encodedName}`);
+
+// Compare with [...path]/route.ts lines 14-15:
+const qs = req.nextUrl.search;
+const target = `/${segments.join("/")}${qs}`;
+
+No search/nextUrl/searchParams/qs reference appears anywhere in the recipes/[...name] route, confirmed by grep returning empty output.
+```
+
+> **Verifier:** The code gap is real and confirmed: dashboard/src/app/api/bridge/recipes/[...name]/route.ts GET (line 58-59) and DELETE (line 134) build the bridge URL as bridgeFetch(`/recipes/${encodedName}`) with no query string, while the sibling [...path]/route.ts does forward qs via `const qs = req.nextUrl.search; const target = ...${qs}` (lines 14-15). However, severity must be downgraded from MEDIUM to LOW because: (1) The bridge-side handler for GET /recipes/:name (recipeRoutes.ts lines 1587-1605) reads only the path segment via regex match and calls loadRecipeContentFn(name) — it accepts zero query parameters today. There is no currently-supported query param on this endpoint that would be […]
+
+#### ⚪ LOW · `dash-new-4` — push/test reads VAPID keys at module load time (top-level const) while relay/push and relay/halt read them per-request — stale VAPID keys after HMR or test env changes
+
+**Location:** `dashboard/src/app/api/push/test/route.ts:6` · **Category:** bug · **Verifier confidence:** high
+
+push/test captures VAPID keys as module-level constants at startup (lines 6-8). The sibling relay routes explicitly read them at request time in a readVapidConfig() function: 'Env vars are read at REQUEST time (not module load) so test setup and dev-server HMR pick up changes without a process restart.' When VAPID keys are rotated or changed via environment (e.g. test setup calling process.env.VAPID_PRIVATE_KEY = ...), push/test continues using the stale keys while relay/push and relay/halt pick up the new values. In production this is benign (env vars don't change), but in test suites that manipulate env vars between test cases it causes push/test to silently use wrong VAPID keys.
+
+```
+// push/test/route.ts lines 6-8 (module-level constants):
+const vapidPublicKey = process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY ?? "";
+const vapidPrivateKey = process.env.VAPID_PRIVATE_KEY ?? "";
+const vapidSubject = process.env.VAPID_SUBJECT ?? "mailto:admin@example.com";
+
+// relay/push/route.ts lines 34-44 (per-request function):
+function readVapidConfig() { return {
+  publicKey: process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY ?? "",
+  privateKey: process.env.VAPID_PRIVATE_KEY ?? "",
+  ...
+}}
+// Comment: 'Env vars are read at REQUEST time (not module load) so test setup and dev-server HMR pick up changes'
+```
+
+> **Verifier:** The code asymmetry is confirmed exactly as described. Lines 6-8 of dashboard/src/app/api/push/test/route.ts capture VAPID keys as module-level constants, while relay/push/route.ts and relay/halt/route.ts both use a readVapidConfig() helper that reads process.env per-request (with an explicit comment explaining the HMR/test-setup rationale). The inconsistency is real.
+
+However, the practical impact is negligible: (1) No tests exist for push/test/route.ts that would mutate VAPID env vars between cases — a search finds no such test file. (2) In production, env vars are immutable after process start, making the two approaches equivalent. (3) The push/test endpoint is a developer convenience […]
+
+
+### CLI subcommands
+
+#### 🟡 MEDIUM · `cli-recipe-run-exit-0` — recipe run --local always exits 0 even when the recipe fails
+
+**Location:** `src/index.ts:1584` · **Category:** bug · **Verifier confidence:** high
+
+After a local recipe run, the CLI logs status:'error' in the run log and prints the error message to stderr, but unconditionally calls process.exit(0). Scripts that check $? to detect recipe failure (CI, shell pipelines, pre-commit hooks) will treat every run as successful regardless of outcome.
+
+```
+Lines 1552-1584: `const summary = summarizeRecipeExecution(run.result); ... if (summary.errorMessage) { process.stderr.write(...) } ... process.exit(0);` — the exit code is hardcoded to 0; `summary.ok` is checked only for the run-log `status` field (line 1570) and never used to select a non-zero exit code.
+```
+
+> **Verifier:** The defect is real and confirmed on HEAD. At src/index.ts:1584, `process.exit(0)` is hardcoded after the local recipe runner completes. `summary.ok` (computed at line 1552 via `summarizeRecipeExecution`) is only used at line 1570 to write `status: "error"` to the run log — it is never tested to select a non-zero exit code. A failing recipe (errorMessage set, ok=false) writes `status:'error'` to disk, prints to stderr, then exits 0. The path is reachable whenever `--local` is passed or when the bridge is unreachable and the runner falls through to the local YAML runner. The finding is NOT documented in docs/audit-2026-06-08.md (that file lists cli-1 through cli-10; no entry for this […]
+
+#### 🟡 MEDIUM · `cli-traces-import-encrypted-bundle-plaintext-in-tmpdir` — traces import decrypts encrypted bundle to world-readable tmpdir on Windows (mode 0o600 no-op)
+
+**Location:** `src/index.ts:1944` · **Category:** security · **Verifier confidence:** high
+
+When importing a keyed (.enc) bundle, the CLI decrypts the content and writes a plaintext .gz file to os.tmpdir() with mode 0o600. On Windows, NTFS ignores POSIX mode bits (as documented in CLAUDE.md Windows feedback). The plaintext trace file — potentially containing connector outputs, PII, and agent decisions — is readable by any process on the same Windows machine until the process.once('exit') cleanup fires. The cleanup itself is best-effort and will not fire on SIGKILL or process.abort().
+
+```
+src/index.ts:1940-1956: `const tmp = pathJoin(tmpdir(), ...); writeFileSync(tmp, plain, { mode: 0o600 }); ... process.once('exit', () => { try { unlinkSync(tmp); } catch {} });` — on Windows, mode 0o600 provides no access restriction, leaving plaintext trace data in a shared temp directory for the process lifetime.
+```
+
+> **Verifier:** The code at src/index.ts:1940-1956 exactly matches the finding. The developer even left an explicit comment at lines 1948-1949 acknowledging the problem: "On Windows mode:0o600 is a no-op (NTFS doesn't honour POSIX bits), so the plaintext would persist in %TEMP% until the next reboot." The code is fully reachable via `patchwork traces import <file.enc> --passphrase <phrase>` — standard CLI usage with no unusual guards. The cleanup uses process.once('exit') which fires on normal exit but not on SIGKILL/abort. Not documented in docs/audit-2026-06-08.md (that audit covers cli-1 through cli-10, none of which is this issue). Severity is correctly MEDIUM: real security issue on Windows, but blast […]
+
+#### ⚪ LOW · `cli-launchd-status-advertised-not-implemented` — launchd status subcommand advertised in help but not implemented — exits with usage error
+
+**Location:** `src/index.ts:4580` · **Category:** unsurfaced · **Verifier confidence:** high
+
+The global help string (line 275) lists `launchd <install|uninstall|status>` as a supported subcommand. The dispatch block at line 4571-4583 only handles `install` and `uninstall`; `status` falls into the else branch and prints `Usage: patchwork-os launchd install|uninstall` then exits 1. Any documentation, script, or user that runs `patchwork launchd status` gets an error instead of bridge status.
+
+```
+Line 275: `launchd <install|uninstall|status>  Manage the macOS auto-start LaunchAgent`. Lines 4572-4582: `if (sub === 'install') { ... } else if (sub === 'uninstall') { ... } else { process.stderr.write('Usage: patchwork-os launchd install|uninstall\n'); process.exit(1); }` — no `status` branch exists.
+```
+
+> **Verifier:** The finding is confirmed on HEAD. Line 275 of src/index.ts advertises `launchd <install|uninstall|status>` in the help string. Lines 4571-4583 only dispatch `install` and `uninstall`; `status` falls into the else branch which writes "Usage: patchwork-os launchd install|uninstall" to stderr and calls process.exit(1). src/commands/launchd.ts exports only runLaunchdInstall and runLaunchdUninstall — no status implementation exists anywhere. The defect is not present in docs/audit-2026-06-08.md and was not fixed by PRs #947-#953. However, severity should be LOW rather than MEDIUM: the user gets a clear, immediate error message (not silent failure or wrong output), no data is lost, no security […]
+
+#### ⚪ LOW · `cli-suggest-only-first-activity-file` — suggest command reads only the first activity file despite comment claiming it unions all
+
+**Location:** `src/index.ts:1709` · **Category:** logic-gap · **Verifier confidence:** high
+
+The suggest command promises to union all port-specific activity logs (`activity-<port>.jsonl`) to give complete suggestions. The loop breaks after the first matching file (line 1712). Furthermore, `ActivityLog.setPersistPath()` replaces the loaded entries each call — so even removing the `break` would produce only the last file's data, not a union. Users with multiple bridge instances (e.g. multiple workspaces) get suggestions based on only one bridge's activity, silently missing patterns from other bridges.
+
+```
+Lines 1702-1713: comment says '// For the suggest CLI we union all of them.' but the loop body calls `activityLog.setPersistPath(...)` then `break; // setPersistPath loads on call; first existing wins` — contradicting the union comment. ActivityLog.setPersistPath (activityLog.ts:76-78) replaces `this.persistPath` and calls `_loadFromDisk()`, which re-populates from the single file, discarding any prior content.
+```
+
+> **Verifier:** The primary defect is real and confirmed on HEAD at src/index.ts:1712. The comment at line 1702 says "we union all of them" but the loop body does `break` after the first matching file, so only one activity file is ever loaded. However, the finding's secondary claim is wrong: `_loadFromDisk()` does NOT reset `this.entries` — it only appends via `this.entries.push(...)`. Removing the `break` would actually produce a union. So the fix is simpler than described (just remove `break`), but the observable bug is real: multi-workspace users get suggestions from only one bridge's activity log.
+
+Severity adjustment from MEDIUM to LOW: this affects only the `suggest` CLI command, which is a […]
+
+#### ⚪ LOW · `cli-recipe-fmt-non-atomic-write` — recipe fmt writes formatted content non-atomically — file corruption on crash or SIGKILL
+
+**Location:** `src/commands/recipe.ts:1025` · **Category:** data-loss · **Verifier confidence:** high
+
+runFmt writes the reformatted YAML directly to the recipe file with writeFileSync (no tmp+rename), which is non-atomic. If the process is killed, the disk write stalls, or the serializer throws mid-write, the recipe file is left partially written and unreadable. The --watch variant re-runs runFmt on every save debounce, amplifying the window. Sibling commands (recipe new, recipe new --interactive, AI-suggest) also use bare writeFileSync for new recipe creation.
+
+```
+src/commands/recipe.ts:1024-1026: `if (!options.check) { writeFileSync(recipePath, formatted); }` — no tmp+rename, no mode flag, no atomic helper. The codebase has `writeFileAtomicSync` in src/writeFileAtomic.ts used by install.ts, analytics config, and rules files, but runFmt does not use it.
+```
+
+> **Verifier:** The evidence is confirmed on HEAD: src/commands/recipe.ts line 1025 does `writeFileSync(recipePath, formatted)` with no tmp+rename. writeFileAtomicSync exists at src/writeFileAtomic.ts:61 and is used in many other write paths (patchworkConfig.ts, featureFlags.ts, claudeOrchestrator.ts, index.ts rules writes, etc.) but not in runFmt. The finding is not in docs/audit-2026-06-08.md (that doc has a related cli-8 finding about ENOENT but not the atomic-write gap).
+
+However, the severity should be downgraded from MEDIUM to LOW. The data-loss window is extremely narrow: the formatted string is fully assembled in memory before writeFileSync is called, and for typical recipe YAML sizes (a few KB), […]
+
+#### ⚪ LOW · `cli-analytics-clear-lying-output` — analytics clear always prints 'removed <path>' even when no config file existed
+
+**Location:** `src/commands/analytics.ts:96` · **Category:** bug · **Verifier confidence:** high
+
+clearAnalyticsConfig() swallows ENOENT silently (correct behavior), but the CLI unconditionally prints `removed <configPath>` on the next line. Operators running analytics clear on a machine that never had a config file see false output suggesting a deletion occurred, making idempotent scripts and receipts misleading.
+
+```
+analytics.ts:95-98: `if (sub === 'clear') { clearAnalyticsConfig(); process.stdout.write('removed ${configPath()}\n'); return 0; }`. analyticsConfig.ts:98-104: `export function clearAnalyticsConfig(): void { try { fs.unlinkSync(configPath()); } catch { /* file may not exist */ } }` — ENOENT is swallowed, caller never knows if deletion actually happened.
+```
+
+> **Verifier:** Code at analytics.ts:95-98 exactly matches the claimed evidence: `clearAnalyticsConfig()` is called (swallows ENOENT silently per analyticsConfig.ts:98-103), then `process.stdout.write(`removed ${configPath()}\n`)` runs unconditionally regardless of whether the file existed. A user running `patchwork analytics clear` on a machine that never ran `patchwork analytics configure` will see a false "removed" message. Reachable via the normal CLI path with no guards. Not documented in docs/audit-2026-06-08.md. Severity stays LOW — misleading output only, no security impact, no data loss, no silent corruption.
+
+#### ⚪ LOW · `cli-kill-switch-force-local-trace-no-mode` — kill-switch --force-local audit trace written without 0o600 mode — world-readable on umask 0o022
+
+**Location:** `src/index.ts:2063` · **Category:** security · **Verifier confidence:** high
+
+The --force-local path writes a CLI audit trace to decision_traces.cli.jsonl using appendFileSync with no mode argument. With a typical umask of 0o022 the file is created 0o644 (world-readable). The sibling decision_traces.jsonl written by the bridge explicitly uses mode 0o600 (as documented in decisionTraceLog.ts). The CLI fallback file diverges from this convention without explanation.
+
+```
+src/index.ts:2063: `fs.appendFileSync(cliTraceFile, '${entry}\n');` — no mode option. Compare with the platform convention: writeFileSync in tracesImport.ts:248 and appendFileSync:250 both use `{ mode: 0o600 }` for all trace files.
+```
+
+> **Verifier:** The defect is confirmed real and unfixed on HEAD. At src/index.ts:2063, fs.appendFileSync(cliTraceFile, ...) has no mode argument. With umask 0o022, the file is created 0o644 (world-readable). Every other trace file writer in the platform passes { mode: 0o600 } explicitly: decisionTraceLog.ts:214-215, decisionTraceLog.ts:270, tracesImport.ts:248/250, tracesExport.ts:318/328. The code path is reachable via 'patchwork kill-switch engage --force-local' or 'patchwork panic --force-local' when no live bridge is running — a documented and supported CLI usage pattern. The finding is not in docs/audit-2026-06-08.md and none of the recent PRs (#947-#953) touched src/index.ts. Severity remains LOW: […]
+
+
+### Automation engine (src/fp)
+
+#### 🟡 MEDIUM · `fp-new-1` — Double recordTrigger per Hook fire halves effective maxTasksPerHour
+
+**Location:** `src/fp/automationInterpreter.ts:486` · **Category:** bug · **Verifier confidence:** high
+
+Every time a hook fires, recordTrigger is called twice: once inside the Hook case (line 486, key = program.hookType) and once inside the WithCooldown wrapper (line 653, key = cooldownKey). Each recordTrigger call unconditionally appends ctx.now to taskTimestamps. tasksInLastHour() counts all entries in taskTimestamps, so the WithRateLimit gate sees N*2 timestamps for N actual tasks fired. A policy with maxTasksPerHour: 20 effectively caps at 10 real tasks per hour. The Hook-case recordTrigger uses hookType as key (e.g. 'onDiagnosticsError'), which is never used for any cooldown lookup; it is pure overhead that inflates the rate-limit counter. isTaskActive/clearActiveTask which would read activeTasks are never called in production, so the activeTasks pollution is benign — but the taskTimestamps inflation is not.
+
+```
+automationInterpreter.ts line 486-491:
+  const newState = recordTrigger(
+    working.state,
+    program.hookType,  // key = 'onDiagnosticsError'
+    taskId,
+    ctx.now,
+  );
+then at line 653-658 inside WithCooldown:
+  const newState = recordTrigger(
+    innerAcc.state,
+    cooldownKey,       // key = 'diagnostics:/path/to/file.ts'
+    lastTaskId,
+    ctx.now,
+  );
+recordTrigger in automationState.ts line 141: pruned.push(now); — runs on BOTH calls, doubling taskTimestamps entries.
+```
+
+> **Verifier:** The defect is confirmed real and present on HEAD. The evidence is exact: at src/fp/automationInterpreter.ts:486-491, the Hook case calls recordTrigger(state, program.hookType, taskId, ctx.now), which unconditionally appends ctx.now to taskTimestamps. Then the WithCooldown wrapper (line 651-659) calls recordTrigger again on the innerAcc.state (which already contains the first timestamp), appending a second entry. automationState.ts:141 confirms every recordTrigger call does pruned.push(now). The policyParser wraps every hook as WithRateLimit → WithCooldown → Hook (line 189, 691), so this double-write occurs on every successful hook fire. The updated state (with 2 timestamps per real task) is […]
+
+#### 🟡 MEDIUM · `fp-new-2` — onPullRequest condition always matches against empty string — any non-trivial condition silently blocks the hook
+
+**Location:** `src/fp/automationInterpreter.ts:225` · **Category:** bug · **Verifier confidence:** high
+
+primaryValue() returns '' (empty string) for onPullRequest. matchesCondition(pattern, '') returns minimatch('', pattern) which is false for any non-wildcard pattern. HOOK_SUBJECT_KEY in automation.ts documents 'title' as the condition subject for onPullRequest, and the handler does dispatch with title: result.title in eventData. But primaryValue never reads eventData.title for this hook type — it falls through to the default return '' case. An operator who adds condition: 'main' or condition: 'feat/*' to onPullRequest expecting to filter by target branch or PR title will find the hook silently fires for nothing, every time.
+
+```
+automationInterpreter.ts lines 222-226:
+  case 'onPreCompact':
+  case 'onPostCompact':
+  case 'onInstructionsLoaded':
+  case 'onPullRequest':
+    return '';   // <-- always empty, condition can never match
+automation.ts line 1049: onPullRequest: 'title'  // doc says condition matches title
+automation.ts line 1807-1813: handlePullRequest dispatches with title: result.title in eventData — the title IS available but primaryValue ignores it.
+```
+
+> **Verifier:** The defect is confirmed exactly as described. In /src/fp/automationInterpreter.ts lines 222-226, `primaryValue()` groups `onPullRequest` with the genuinely condition-less hooks (`onPreCompact`, `onPostCompact`, `onInstructionsLoaded`) and returns `""`. Meanwhile `handlePullRequest` (automation.ts:1808) dispatches `{ title: result.title, ... }` into eventData, and HOOK_SUBJECT_KEY at line 1049 explicitly documents `onPullRequest: "title"` as the intended condition subject. `OnPullRequestPolicy` inherits `condition?: string` from `PromptSource`, so the field is schema-valid and accepted by the parser. When an operator sets `condition: "feat/*"` expecting title-based filtering, […]
+
+#### 🟡 MEDIUM · `fp-new-3` — handleTestRun uses aggregate pass/fail status for per-runner outcome tracking — spurious passAfterFail triggers when any runner fails
+
+**Location:** `src/automation.ts:1716` · **Category:** bug · **Verifier confidence:** high
+
+handleTestRun computes current = failureCount === 0 ? 'pass' : 'fail' from the combined summary across ALL runners (line 1716). This global current is then stored per-runner: lastTestOutcomeByRunner.set(runner, current) (line 1723). If a test run has 2 runners and runner-A fails while runner-B passes, both runners are stored as 'fail'. On the next run where both pass, both runners have prev='fail' and current='pass', so both are pushed into passAfterFailRunners and both trigger an onTestPassAfterFailure event — including runner-B which never actually failed. In a CI setup with jest (fast, flaky) and vitest (slow, stable), a single jest failure will cause vitest to also be marked failed, and the next green run fires two spurious passAfterFail tasks instead of one.
+
+```
+src/automation.ts line 1715-1735:
+  const failureCount = result.summary.failed + result.summary.errored; // combined
+  const current = failureCount === 0 ? 'pass' : 'fail';   // global across all runners
+  for (const runner of result.runners) {
+    const prev = this.lastTestOutcomeByRunner.get(runner);
+    this.lastTestOutcomeByRunner.set(runner, current);     // same global current for all
+    ...
+    if (prev === 'fail' && current === 'pass') {
+      passAfterFailRunners.push(runner);                   // both runners pushed even if only one failed
+    }
+  }
+```
+
+> **Verifier:** The bug is confirmed on HEAD at src/automation.ts lines 1714-1735. The code computes `current = failureCount === 0 ? "pass" : "fail"` from the aggregate summary across ALL runners (line 1715-1716), then stamps that same `current` onto every runner in the `for (const runner of result.runners)` loop (line 1723). The `TestRunResult` interface (line 278-289) carries no per-runner breakdown — only aggregate summary totals — so there is no data available to compute per-runner pass/fail status. The documentation comment at line 269-270 explicitly promises "vitest passing after a jest failure does NOT trigger — only the runner that was previously failing then passes triggers the hook," but the […]
+
+#### 🟡 MEDIUM · `fp-new-5` — WithRetry never schedules a retry when named-prompt resolution fails — prompt_unresolved skip treated as success
+
+**Location:** `src/fp/automationInterpreter.ts:729` · **Category:** logic-gap · **Verifier confidence:** high
+
+The WithRetry case schedules a retry only when innerAcc.errors.length > acc.errors.length (line 729). When a named prompt cannot be resolved (unknown promptName or missing required args), the Hook case returns a skip entry (reason: 'prompt_unresolved') rather than an error entry (line 451-459). WithRetry sees no new errors and no new taskIds, so it falls through to return innerAcc unchanged — no retry is scheduled, and the caller sees a successful (skipped) run. An operator who configures retryCount: 3 on a hook with a promptName expecting auto-retry when the prompt engine is temporarily unavailable will find that retries are silently never attempted.
+
+```
+automationInterpreter.ts lines 447-459 (Hook case):
+  const promptTemplate = resolvePromptSource(program.promptSource, ctx.eventData);
+  if (promptTemplate === null) {
+    return { ...acc, skipped: [...acc.skipped, { reason: 'prompt_unresolved', hook: ... }] };
+  }
+  // returns a skip, NOT an error
+
+automationInterpreter.ts lines 729-731 (WithRetry case):
+  if (innerAcc.errors.length > acc.errors.length) {
+    // schedule retry — only reached on errors, not skips
+  }
+  return innerAcc;  // skip silently treated as normal completion, no retry
+```
+
+> **Verifier:** The code at the cited locations exists exactly as described on HEAD. resolvePromptSource returns null when getPrompt() returns null (lines 263-264 of automationInterpreter.ts), and the Hook case converts that null into a skipped entry (lines 451-459), not an error entry. WithRetry at line 729 gates retry scheduling on `innerAcc.errors.length > acc.errors.length`, so a skip never triggers a retry. policyParser allows combining promptName + retryCount > 0 on the same hook (lines 83-86, 208-211), making this fully reachable. The audit doc has no mention of this issue, and PRs #947-#953 all touched unrelated surfaces (recipe runners, OAuth callbacks, session wiring, MLX memory). MEDIUM is […]
+
+#### ⚪ LOW · `fp-new-6` — onTaskCreated and onTaskSuccess condition matched against taskId instead of documented prompt/output
+
+**Location:** `src/fp/automationInterpreter.ts:213` · **Category:** docs-drift · **Verifier confidence:** high
+
+HOOK_SUBJECT_KEY in automation.ts documents that onTaskCreated.condition matches against eventData.prompt and onTaskSuccess.condition matches against eventData.output. But primaryValue() for both hook types returns eventData.taskId. A condition like 'fix-*' on onTaskCreated would be matched against the UUID-like taskId, not the prompt text — it would silently never match. The handlers do dispatch both prompt/output AND taskId in eventData, so the values are available; primaryValue just returns the wrong field.
+
+```
+src/fp/automationInterpreter.ts lines 213-216:
+  case 'onTaskCreated':
+  case 'onTaskSuccess':
+    return eventData.taskId ?? '';    // returns taskId, not prompt/output
+
+src/automation.ts HOOK_SUBJECT_KEY lines 1051-1052:
+  onTaskCreated: 'prompt',
+  onTaskSuccess: 'output',
+src/automation.ts handleTaskCreated line 1817: dispatches { taskId: result.taskId, prompt: result.prompt } — prompt IS in eventData
+```
+
+> **Verifier:** The defect is confirmed at HEAD. src/fp/automationInterpreter.ts lines 214-216 return eventData.taskId for both onTaskCreated and onTaskSuccess in primaryValue(). The HOOK_SUBJECT_KEY comment block in src/automation.ts lines 1051-1052 documents these should match against 'prompt' and 'output' respectively. Both OnTaskCreatedPolicy and OnTaskSuccessPolicy inherit condition?: string from PromptSource (automation.ts line 92), so the field is schema-valid and users can set it. The dispatch sites (handleTaskCreated line 1817, handleTaskSuccess line 1846) do include both prompt/output AND taskId in eventData, so the correct values are available — primaryValue just returns the wrong field. […]
+
+#### ⚪ LOW · `fp-new-7` — activeTasks entries keyed by hookType accumulate without bound — never cleared because clearActiveTask is never called
+
+**Location:** `src/fp/automationInterpreter.ts:486` · **Category:** bug · **Verifier confidence:** high
+
+The Hook case calls recordTrigger(working.state, program.hookType, taskId, now), which writes to activeTasks[hookType]. isTaskActive and clearActiveTask are defined in automationState.ts but are never called in production code (verified by grep). The WithCooldown wrapper writes activeTasks[cooldownKey] similarly but also never reads or clears it. In a long-running bridge with many hook fires, activeTasks grows continuously — one new entry per (hookType, cooldownKey) pair per fire. The LRU cap in recordTrigger (MAX_TRIGGER_KEYS = 5000) bounds lastTrigger but does NOT apply to activeTasks, so activeTasks is unbounded. On a bridge that has been running for weeks with onDiagnosticsError firing continuously across many files, activeTasks can grow to tens of thousands of entries.
+
+```
+automationState.ts lines 131-133:
+  const newActiveTasks = new Map(state.activeTasks);
+  newActiveTasks.set(key, taskId);  // no eviction cap applied to activeTasks
+  ...
+  while (newLastTrigger.size > MAX_TRIGGER_KEYS) { ... }  // cap only on lastTrigger
+
+Production grep for clearActiveTask usage (outside test/definition files): zero results.
+activeTasks will hold one entry per unique cooldownKey string ever seen (e.g. 'diagnostics:/abs/path/to/file.ts') and one per hookType string — both growing without eviction.
+```
+
+> **Verifier:** The finding is confirmed accurate on HEAD. In automationState.ts lines 131-132, recordTrigger always writes newActiveTasks.set(key, taskId) with no LRU cap — the eviction loop at lines 125-129 applies only to newLastTrigger. The grep confirms clearActiveTask and isTaskActive are imported only in test files (src/fp/__tests__/automationState.test.ts) and never called in any production path. The interpreter's imports at lines 16-25 of automationInterpreter.ts explicitly omit both functions. Both the Hook case (line 486, key=program.hookType) and the WithCooldown case (line 653, key=cooldownKey which expands {{file}} to actual file paths) write to activeTasks without eviction. The practical […]
+
+
+### VS Code extension
+
+#### 🟡 MEDIUM · `ext-new-1` — handleGetDocumentLinks: workspace='' bypass leaks all file paths
+
+**Location:** `vscode-extension/src/handlers/documentLinks.ts:49` · **Category:** security · **Verifier confidence:** high
+
+When no workspace folder is open, workspace is set to the empty string. The containment check `fsPath.startsWith(workspace)` then evaluates to `fsPath.startsWith("")` which is always `true` for any string. Every `file://` URI returned by VS Code's document link provider is returned to the caller unfiltered, including paths outside the workspace (e.g. /etc/passwd, ~/.ssh/config). The intent of the guard is the opposite: null means redact, but an empty workspace makes it a no-op.
+
+```
+Line 49: `const workspace = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath ?? "";`
+Line 24: `if (!fsPath.startsWith(workspace)) return null;`
+
+With no open workspace, `workspace = ""`, and `"/etc/passwd".startsWith("")` is `true`, so `return null` is never reached and the path is returned as-is.
+```
+
+> **Verifier:** Code at HEAD exactly matches the cited evidence. Line 49 of `/Users/wesh/Documents/Anthropic Workspace/Patchwork OS/vscode-extension/src/handlers/documentLinks.ts` sets `workspace = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath ?? ""`, and line 24's guard `if (!fsPath.startsWith(workspace)) return null` is bypassed when workspace is "" because every string satisfies "".startsWith(""). The handler is registered and callable. VS Code can and does run without workspace folders (single-file mode). Not documented in docs/audit-2026-06-08.md — the extension-6 finding there is about RelativePattern anchoring in file-watchers/debug handlers, not documentLinks. The test suite never exercises […]
+
+#### 🟡 MEDIUM · `ext-new-2` — handleGetDiagnostics uses Uri.parse with manual 'file://' prefix — breaks on Windows paths
+
+**Location:** `vscode-extension/src/handlers/diagnostics.ts:32` · **Category:** bug · **Verifier confidence:** high
+
+The per-file diagnostic query constructs a URI via `vscode.Uri.parse(fileUri.startsWith('file://') ? fileUri : 'file://' + fileUri)`. On Windows, a filesystem path like `C:\Users\foo\bar.ts` is neither absolute POSIX nor already a URI, so it becomes `file://C:\Users\foo\bar.ts`. `vscode.Uri.parse` treats `C` as the authority/hostname, producing a URI with the wrong structure. `vscode.languages.getDiagnostics(badUri)` returns an empty array. All other handlers in the extension use `vscode.Uri.file(path)` which handles Windows drive letters correctly.
+
+Line 32-34 of diagnostics.ts:
+```ts
+const uri = vscode.Uri.parse(
+  fileUri.startsWith("file://") ? fileUri : `file://${fileUri}`,
+);
+```
+Compare with files.ts line 71: `const uri = vscode.Uri.file(file);` — the correct idiom used everywhere else.
+
+> **Verifier:** The code at lines 32-34 of /Users/wesh/Documents/Anthropic Workspace/Patchwork OS/vscode-extension/src/handlers/diagnostics.ts exactly matches the finding. The handler constructs a URI via `vscode.Uri.parse('file://' + path)` for non-`file://` inputs. On Windows, when an absolute path like `C:\Users\foo\bar.ts` is passed, the resulting string `file://C:\Users\foo\bar.ts` causes `vscode.Uri.parse` to treat `C` as the authority/hostname component rather than a drive letter. This is the known VS Code URI edge case — the correct idiom is `vscode.Uri.file(path)`, which all 20+ other handlers in the extension use. The bridge's `getDiagnostics.ts` tool passes the raw `uri` argument string directly […]
+
+#### ⚪ LOW · `ext-new-4` — handleGetDocumentLinks: multi-root workspace uses workspaceFolders[0] for containment check
+
+**Location:** `vscode-extension/src/handlers/documentLinks.ts:49` · **Category:** logic-gap · **Verifier confidence:** high
+
+The file-link containment check always uses `workspaceFolders[0].uri.fsPath` as the workspace root. In a multi-root workspace with folders [A, B, C], any `file://` link whose target is under B or C is incorrectly treated as outside the workspace and redacted to `null`. The bridge creates one connection per workspace folder, so documents from folders B/C would receive an empty links list. This is the same class as extension-6 (fileWatcher/debug handlers) but in a separate handler not mentioned in that finding.
+
+Line 49 of documentLinks.ts:
+```ts
+const workspace = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath ?? "";
+```
+Only one root is ever checked. A link to `B/src/index.ts` in a multi-root workspace (A, B) fails the `fsPath.startsWith(workspace)` check at line 24 and returns null.
+
+> **Verifier:** The code at documentLinks.ts:49 exactly matches the quoted evidence: `const workspace = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath ?? ""`. The sanitizeTarget function at line 24 then returns null for any file:// link whose fsPath doesn't startWith that single root. The bug is real and reachable.
+
+However, two corrections to the finder's description reduce severity:
+
+1. "documents from folders B/C would receive an empty links list" is wrong. The handler still returns all link entries — just with target: null for cross-workspace file references. The links array is not empty; individual targets are nulled. This is a data-quality issue, not a complete feature failure.
+
+2. The blast […]
+
+#### ⚪ LOW · `ext-new-5` — handleGetSelection returns unbounded selectedText — no size cap unlike push-notification path
+
+**Location:** `vscode-extension/src/handlers/selection.ts:13` · **Category:** bug · **Verifier confidence:** high
+
+The pull handler `handleGetSelection` returns `editor.document.getText(sel)` without any size limit. The equivalent push-notification path in `events.ts` (lines 82–86) caps `selectedText` at `MAX_SELECTED_TEXT_BYTES` (100 KB) and truncates to a valid UTF-8 boundary. A caller who selects the entire document (e.g. Ctrl+A) before invoking `getCurrentSelection` or `getLatestSelection` causes an unbounded JSON payload. For a 5 MB file, this exceeds the 4 MB WebSocket `maxPayload` configured in `connection.ts:321`, causing the WS frame to be rejected and the handler to fail silently.
+
+handlers/selection.ts line 13:
+```ts
+selectedText: editor.document.getText(sel),  // no size cap
+```
+events.ts lines 82-86 (push path):
+```ts
+if (Buffer.byteLength(selectedText, 'utf-8') > MAX_SELECTED_TEXT_BYTES) {
+  selectedText = Buffer.from(selectedText, 'utf-8')
+    .subarray(0, MAX_SELECTED_TEXT_BYTES).toString('utf-8');
+}
+```
+MaxPayload in connection.ts:321: `maxPayload: 4 * 1024 * 1024`
+
+> **Verifier:** All three evidence claims check out on HEAD. (1) vscode-extension/src/handlers/selection.ts:13 has `editor.document.getText(sel)` with no size cap. (2) events.ts:82-86 does cap the push-notification path at MAX_SELECTED_TEXT_BYTES (100 KB) with a proper UTF-8 boundary truncation. (3) vscode-extension/src/connection.ts:321 sets `maxPayload: 4 * 1024 * 1024` on the extension-side WS client (matching server.ts:2884). The defect is reachable: calling `getCurrentSelection` or the live-request fallback of `getLatestSelection` (when `extensionClient.latestSelection` is null) invokes `extensionClient.getSelection()` → `tryRequest("extension/getSelection")` → `handleGetSelection` on the extension […]
+
+#### ⚪ LOW · `ext-new-6` — handleGetSemanticTokens: 'capped' flag fires on line-range filtering, not only on token-count cap
+
+**Location:** `vscode-extension/src/handlers/semanticTokens.ts:142` · **Category:** logic-gap · **Verifier confidence:** high
+
+`capped: decoded.length < totalTokens` is true whenever the decoded array has fewer entries than the total token count in the file — but this happens both when the `maxTokens` limit was hit AND when the line-range filter (`startLine`/`endLine`) excluded tokens from other ranges. A caller that requested tokens for lines 10-20 of a 1000-token file will always see `capped: true` even though they received all tokens in their range. This gives the wrong signal (callers may needlessly increase maxTokens). Same class of bug as extension-7 (now fixed) but in a different handler.
+
+semanticTokens.ts line 142:
+```ts
+capped: decoded.length < totalTokens,
+```
+`totalTokens = Math.floor(data.length / 5)` counts ALL tokens in the file. `decoded.length` only counts those that passed the line filter AND fit under `maxTokens`. The two conditions are conflated.
+
+> **Verifier:** The code at line 142 of vscode-extension/src/handlers/semanticTokens.ts exactly matches the evidence: `capped: decoded.length < totalTokens` where `totalTokens = Math.floor(data.length / 5)` is the whole-file token count and `decoded.length` is the post-filter, post-maxTokens count. When a caller provides startLine/endLine, the line-range filter at lines 121-122 excludes tokens outside that range, so decoded.length will be smaller than totalTokens even when the caller received every token in their requested range — causing a spurious `capped: true`. The bug is real and reachable by any caller that uses the optional startLine/endLine parameters. It is not documented in […]
+
+#### ⚪ LOW · `ext-new-7` — readinessTracker double-dispose when workspace folder removed from multi-root workspace
+
+**Location:** `vscode-extension/src/extension.ts:277` · **Category:** bug · **Verifier confidence:** high
+
+`readinessTracker` is pushed to `context.subscriptions` at line 277, and also explicitly disposed via `bridge.setOnDispose` at line 290. When `syncConnections` removes a stale bridge connection (folder removed from workspace), `bridge.dispose()` fires `onDispose`, which calls `readinessTracker.dispose()`. Later, at extension deactivation, VS Code iterates `context.subscriptions` and calls `readinessTracker.dispose()` a second time. The second call is benign (idempotent `clearTimeout` + already-disposed VS Code disposables), but the stale entry stays in `context.subscriptions` for the full extension lifetime, creating a reference-leak for each removed workspace folder.
+
+extension.ts line 277: `context.subscriptions.push(readinessTracker);`
+extension.ts lines 286-291:
+```ts
+bridge.setOnDispose(() => {
+  fileWatcherHandlers.disposeAll();
+  debugHandlers.disposeAll();
+  decorationHandlers.disposeAll();
+  readinessTracker.dispose();  // first dispose via bridge teardown
+});
+```
+When bridge is removed via syncConnections, the context.subscriptions entry for readinessTracker is never removed, so VS Code calls dispose() again on deactivation.
+
+> **Verifier:** Evidence confirmed on HEAD: line 277 pushes readinessTracker to context.subscriptions; line 290 calls readinessTracker.dispose() inside bridge.setOnDispose(). When syncConnections removes a stale bridge (line 329 calls bridge.dispose()), the onDispose callback fires the first dispose. VS Code deactivation then fires the second dispose via context.subscriptions. The double-dispose is real and reachable in any multi-root workspace session where a folder is removed. However, lspReadiness.ts dispose() is demonstrably idempotent: clearTimeout on a null/already-cleared timer is a no-op, and VS Code disposables (onDidChangeDiagnostics subscription) are safe to dispose twice. The stale entry in […]
+
+
+### Orchestration & drivers
+
+#### 🟡 MEDIUM · `orch-driver-1` — GeminiSubprocessDriver spawns with cwd: homedir() instead of input.workspace
+
+**Location:** `src/drivers/gemini/index.ts:261` · **Category:** bug · **Verifier confidence:** high
+
+GeminiSubprocessDriver._runLocked() spawns the gemini binary with `cwd: homedir()` (the user's home directory) rather than `input.workspace` (the project root). The log message at line 257 correctly prints workspace but the actual cwd used for the child process is `~`. All file-system-relative operations inside the gemini subprocess — git commands, relative-path resolution, working-tree lookups — run against the home directory instead of the recipe's intended workspace. Contrast with SubprocessDriver (claude subprocess) at line 184 which correctly uses `cwd: input.workspace`. The contextFiles paths ARE resolved against input.workspace (line 237) before being passed as --include-directories, so those paths land correctly, but the subprocess's own cwd is wrong for everything else.
+
+```
+src/drivers/gemini/index.ts line 257: `this.log('[GeminiSubprocessDriver] spawning: ... (workspace: ${input.workspace})')` then line 261: `cwd: homedir()` — the log says workspace but spawn uses homedir. Contrast: src/drivers/claude/subprocess.ts line 184: `cwd: input.workspace`.
+```
+
+> **Verifier:** The bug is real and confirmed on HEAD. At src/drivers/gemini/index.ts line 261, the spawn call uses `cwd: homedir()` while the log at line 257 correctly prints `input.workspace`. The contrast with SubprocessDriver (src/drivers/claude/subprocess.ts line 184, `cwd: input.workspace`) is exactly as described. Reachability is confirmed: recipe steps with `driver: gemini` dispatch to GeminiSubprocessDriver via agentExecutor.ts (the audit's own drivers-1 entry confirms the `"gemini"` case is live). The `cwd: homedir()` appears intentional for MCP settings injection (the code above sets up ~/.gemini/settings.json), but the homedir cwd was never switched back to `input.workspace` before spawning. […]
+
+#### 🟡 MEDIUM · `orch-driver-3` — patchwork-mcp-* temp directories accumulate per mcpAccess task run — never cleaned up
+
+**Location:** `src/drivers/claude/subprocess.ts:42` · **Category:** bug · **Verifier confidence:** high
+
+writeMcpConfigFile() creates a new mkdtemp directory under os.tmpdir() for every task that uses mcpAccess:true. The directory and the mcp.json file inside it are never deleted: there is no cleanup callback, no registration in bridge's cleanupTempDirs(), and no finalizer in the driver. The code comment says 'the dir is created with mkdtemp under os.tmpdir() so OS cleanup handles it' — this is correct on Linux (systemd-tmpfiles cleans /tmp), but on macOS, tmpdir is /var/folders/... which is NOT cleaned between reboots; it accumulates until disk quota enforcement. A long-running bridge that handles many mcpAccess tasks (e.g. automation hooks) produces two inodes per task indefinitely.
+
+```
+src/drivers/claude/subprocess.ts lines 41-58: `const dir = mkdtempSync(join(tmpdir(), 'patchwork-mcp-')); const path = join(dir, 'mcp.json'); writeFileSync(path, JSON.stringify(config), { mode: 0o600 }); return path;` — no rmdir/unlink, no registration with cleanupTempDirs. src/bridge.ts line 2109 only calls cleanupTempDirs() from tools/openDiff.js, which does not cover these dirs.
+```
+
+> **Verifier:** Code at src/drivers/claude/subprocess.ts lines 41-59 exactly matches the finding: writeMcpConfigFile() calls mkdtempSync under os.tmpdir(), writes mcp.json, returns the path — no unlink, no rmdir, no registration with cleanupTempDirs. The call site at line 154 (inside SubprocessDriver.run()) fires whenever mcp is truthy, which requires mcpAccess:true flowing through claudeOrchestrator.ts or yamlRunner.ts to SubprocessDriver — a production-wired path. The macOS claim is verified: os.tmpdir() returns /var/folders/.../T on this machine (Node.js confirmed), and 128 patchwork-mcp-* directories from June 7-9 are physically present, proving no OS-level cleanup occurred over 2 days. The audit doc […]
+
+#### ⚪ LOW · `orch-driver-4` — GeminiSubprocessDriver does not check signal.aborted after awaiting the settings-file mutex
+
+**Location:** `src/drivers/gemini/index.ts:103` · **Category:** bug · **Verifier confidence:** high
+
+When two concurrent Gemini tasks both need mcpAccess (require writing ~/.gemini/settings.json), the second task blocks on `await prior` (the static mutex chain). If the first task takes a long time and the second task's AbortController fires during the wait (e.g. orchestrator timeout), _runLocked() is still called after the mutex is acquired because there is no `if (input.signal.aborted) return { wasAborted: true, text: '', durationMs: 0 }` guard between `await prior` and `return await this._runLocked(input, mcp)`. The subprocess is then spawned with an already-aborted signal, Node immediately kills it, but the settings.json file is written and restored — all for a task that was already cancelled. This wastes I/O and holds the mutex slightly longer than necessary, delaying any subsequent queued Gemini task.
+
+```
+src/drivers/gemini/index.ts lines 96-107: `const prior = GeminiSubprocessDriver.settingsMutex; ... try { await prior; return await this._runLocked(input, mcp); } finally { releaseLock(); }` — no check of input.signal.aborted between await and _runLocked.
+```
+
+> **Verifier:** The code at lines 96-107 of src/drivers/gemini/index.ts confirms the pattern exactly: `await prior` at line 103 is followed immediately by `return await this._runLocked(input, mcp)` at line 104 with no `signal.aborted` guard between them. So the structural claim is accurate. However, the severity is overstated. When `_runLocked` is called with an already-aborted signal, `spawn(..., { signal: input.signal })` at line 263 causes Node to immediately kill/reject the subprocess — the `catch` block at lines 374-388 handles this cleanly via the `input.signal.aborted` check at line 378, returning `{ wasAborted: true, ... }`. The settings.json write and restore still happen (lines 133-200 in […]
+
+#### ⚪ LOW · `orch-driver-5` — generateRecipeFn / repairRecipeFn model-output truncation guard uses UTF-16 .length against a byte-named constant — dead code for all current driver paths
+
+**Location:** `src/recipeOrchestration.ts:645` · **Category:** bug · **Verifier confidence:** high
+
+generateRecipeFn (line 645) and repairRecipeFn (line 814) check `task.output.length > MAX_MODEL_OUTPUT_BYTES` where MAX_MODEL_OUTPUT_BYTES = 64 * 1024 bytes. String.length counts UTF-16 code units, not bytes, so the constant's name is misleading. More importantly, task.output is produced by SubprocessDriver which caps its output at OUTPUT_CAP = 50 * 1024 = 51,200 bytes via truncateUtf8Bytes(). Since 51,200 < 65,536, `task.output.length > MAX_MODEL_OUTPUT_BYTES` is never true for the subprocess path (and likewise for ApiDriver, which also caps at 50KB). The guard is effectively dead code — runaway model output that exceeds 64KB is impossible via any current driver, so the truncation and associated warning strings are never emitted.
+
+```
+src/recipeOrchestration.ts line 645: `task.output.length > MAX_MODEL_OUTPUT_BYTES` with MAX_MODEL_OUTPUT_BYTES=65536. src/drivers/claude/subprocess.ts line 18: `const OUTPUT_CAP = 50 * 1024` (51200). SubprocessDriver line 390: `text: truncateUtf8Bytes(finalText, OUTPUT_CAP)` ensures task.output ≤ 51200 < 65536. The check can never be true.
+```
+
+> **Verifier:** All four current drivers (claude/subprocess.ts, claude/api.ts, openai/index.ts, gemini/index.ts) each define OUTPUT_CAP = 50 * 1024 = 51,200 bytes and apply truncateUtf8Bytes(text, OUTPUT_CAP) before returning task.output. MAX_MODEL_OUTPUT_BYTES = 64 * 1024 = 65,536 in recipeOrchestration.ts. Since 51,200 < 65,536, task.output.length can never exceed MAX_MODEL_OUTPUT_BYTES via any wired driver path, making the guard at lines 645-652 and 814-820 effectively dead code. The constant name is also misleading (bytes vs UTF-16 code units). No security or data-loss risk — just unreachable defensive code that could confuse future developers if the output cap is raised above 64KB without updating […]
+
+#### ⚪ LOW · `orch-driver-6` — Legacy SubprocessDriver (claudeDriver.ts) startupTimedOut path uses accumulated.slice(0, OUTPUT_CAP) — UTF-16 code units instead of bytes
+
+**Location:** `src/claudeDriver.ts:555` · **Category:** bug · **Verifier confidence:** high
+
+In the @deprecated legacy SubprocessDriver in claudeDriver.ts, all return sites use truncateUtf8Bytes(text, OUTPUT_CAP) to respect the byte budget, except the startupTimedOut path at line 555 which uses `accumulated.slice(0, OUTPUT_CAP)`. String.slice counts UTF-16 code units, not bytes; for CJK content this allows up to ~200 KB of UTF-8 to be stored in the text field instead of the intended 50 KB. This is only present in the legacy file (not the production src/drivers/claude/subprocess.ts which correctly uses truncateUtf8Bytes in its startupTimedOut path at line 376). The legacy driver is @deprecated and not in the runtime call path, but since legacy tests still exercise it, the inconsistency can propagate incorrect values.
+
+```
+src/claudeDriver.ts line 555: `text: accumulated.slice(0, OUTPUT_CAP)` — UTF-16 slice. Compare with same driver's other return sites: line 515 `truncateUtf8Bytes(resultText, OUTPUT_CAP)`, line 529 `truncateUtf8Bytes(accumulated, OUTPUT_CAP)`, line 570 `truncateUtf8Bytes(finalText, OUTPUT_CAP)`. Production driver src/drivers/claude/subprocess.ts line 376: `text: truncateUtf8Bytes(accumulated, OUTPUT_CAP)` — correct.
+```
+
+> **Verifier:** Code evidence confirmed: src/claudeDriver.ts line 555 uses `accumulated.slice(0, OUTPUT_CAP)` (UTF-16 code-unit slice) in the startupTimedOut path, while the same file's other return sites (lines 515, 529, 570) correctly call `truncateUtf8Bytes(...)`. The production driver src/drivers/claude/subprocess.ts line 376 uses `truncateUtf8Bytes(accumulated, OUTPUT_CAP)` — correct. The inconsistency is real. However, reachability is extremely limited: the file header at line 2-17 explicitly states this is a "@deprecated LEGACY DRIVER FILE" that is "NOT in the runtime call path". Grepping all of src/ confirms it is only imported by two test files (src/__tests__/claudeDriver.test.ts and […]
+
+
+### Platform glue (logs, push, usage, plugins)
+
+#### 🟠 HIGH · `data-loss-1` — completeRun silently drops tokenTotals and budgetTotals — bridge-path cost data never persisted
+
+**Location:** `src/runLog.ts:483` · **Category:** data-loss · **Verifier confidence:** high
+
+RecipeRun.tokenTotals and RecipeRun.budgetTotals are defined on the interface (lines 171-177) and computed by both yamlRunner and chainedRunner, but the completeRun() opts parameter type (lines 485-495) omits both fields. TypeScript's excess-property check is bypassed when the caller uses spread expressions, so the compiler accepts the calls silently. Inside completeRun(), 'finalized' is built by explicitly spreading only the named opts fields — tokenTotals and budgetTotals are never referenced. Result: all bridge-path recipe runs (cron, webhook, live dashboard) have no cost or token data in the run log. Only the CLI path (appendDirect) correctly includes them. The dashboard's cost/token display is doubly broken: even if the rendering layer were fixed (audit-2026-06-08 unsurfaced-3), the data is not present in the bridge-path run rows to render.
+
+```
+src/runLog.ts lines 483-495: `completeRun(seq: number, opts: { status: TerminalRunStatus; doneAt: number; durationMs: number; stepResults: RunStepResult[]; outputTail?: string; errorMessage?: string; assertionFailures?: RecipeRun['assertionFailures']; inboxOutputs?: RecipeRun['inboxOutputs']; budgetWarnings?: RecipeRun['budgetWarnings']; }): void` — tokenTotals and budgetTotals absent from opts. Callers pass them: `deps.runLog.completeRun(runSeq, { ..., ...(tokenTotals ? { tokenTotals } : {}), ...(budgetTotals ? { budgetTotals } : {}) })` (yamlRunner.ts:2128-2129, chainedRunner.ts:1375-1376) but they're never read in the body.
+```
+
+> **Verifier:** The defect is confirmed on HEAD. `completeRun`'s opts parameter type (src/runLog.ts:485-495) omits `tokenTotals` and `budgetTotals`. Both yamlRunner.ts:2128-2129 and chainedRunner.ts:1375-1376 pass these fields via spread, which bypasses TypeScript's excess-property check, so the compiler emits no error. Inside `completeRun`, `finalized` is built by reading only named `opts.*` fields; `opts.tokenTotals` and `opts.budgetTotals` are never accessed, so both fields are silently dropped from the persisted record. The `...prev` spread does not save them either — `startRun` creates the initial running entry with no tokenTotals/budgetTotals. The bug was introduced in PR #917 (commit 735e2f96), […]
+
+#### 🟡 MEDIUM · `bug-1` — haltPushDispatch DNS lookup checks only first resolved address — split-horizon SSRF bypass
+
+**Location:** `src/haltPushDispatch.ts:70` · **Category:** security · **Verifier confidence:** high
+
+dispatchHaltPushNotification calls dns.lookup(hostname) without { all: true } (line 70), so only the first resolved address is checked against the private-IP blocklist. A split-horizon DNS setup can return a public IP to the resolver but route the actual fetch to a private host. approvalHttp.ts was fixed (audit-2026-06-03) to use { all: true } via hostResolvesToBlockedIp(), which resolves all addresses and blocks if ANY is private. haltPushDispatch.ts is the sibling module that was not updated with the same fix, creating an inconsistency in the SSRF guard surface.
+
+```
+src/haltPushDispatch.ts line 70: `const resolved = await dns.lookup(hostname);` — no `{ all: true }`. Contrast with approvalHttp.ts lines 348-354: `const r = await dns.lookup(hostname, { all: true }); resolved = Array.isArray(r) ? r : [r]; ... const blocked = resolved.find((r) => isBlockedIp(r.address));` which checks ALL addresses.
+```
+
+> **Verifier:** The evidence is confirmed exactly as described. At /Users/wesh/Documents/Anthropic Workspace/Patchwork OS/src/haltPushDispatch.ts line 70, `dns.lookup(hostname)` is called without `{ all: true }`, so only the first resolved address is checked against the private-IP blocklist via `isBlockedIp`. The sibling `approvalHttp.ts` was explicitly fixed (per its comments at lines 335-361) to use `{ all: true }` and check all resolved addresses via `hostResolvesToBlockedIp()`. The structural gap in `haltPushDispatch.ts` is a real split-horizon SSRF bypass vector: a split-horizon DNS setup can return a public IP to the resolver while routing the actual fetch to a private host.
+
+Reachability: the […]
+
+#### 🟡 MEDIUM · `bug-2` — activityLog._appendToDisk has no serialization — concurrent rotations can corrupt or lose entries
+
+**Location:** `src/activityLog.ts:136` · **Category:** bug · **Verifier confidence:** high
+
+ActivityLog._appendToDisk launches fire-and-forget async closures with no in-flight guard or lock. When many tool calls arrive rapidly (common under recipe execution), multiple concurrent closures can all stat the file and see size > MAX_PERSIST_BYTES, then all call _rotateDisk() simultaneously. _rotateDisk() itself is fully async (readFile → writeFileAtomic). The last rotation to complete wins and overwrites all others' writes — entries appended between rotations are lost. Additionally, _rotateDisk has no serialization flag, unlike runLog.ts and decisionTraceLog.ts which use withFileLockSync. The pattern differs from those two: activityLog uses async I/O to avoid blocking the event loop, but that comes at the cost of no cross-coroutine exclusion for rotation.
+
+```
+src/activityLog.ts line 136: `void (async () => { try { ... if (stat.size > MAX_PERSIST_BYTES) { await this._rotateDisk(); } ... await fs.promises.appendFile(persistPath, line, { mode: 0o600 }); }})()` — no guard preventing N concurrent invocations from each calling _rotateDisk(). No `_rotating` flag, no queue, no lock. Compare runLog.ts:546 `withFileLockSync(this.file, () => { appendFileSync(...) })` and decisionTraceLog.ts:213 same pattern.
+```
+
+> **Verifier:** The code at src/activityLog.ts line 136 confirms the finding exactly. The fire-and-forget async IIFE has no rotation guard: no `_rotating` flag, no lock, no in-flight dedup. Under rapid concurrent calls (recipe execution bursts), two async closures can both pass the `stat.size > MAX_PERSIST_BYTES` check before either completes `_rotateDisk()`, then both issue `readFile → writeFileAtomic` — the second write wins and silently drops entries the first rotation captured. This is a genuine async interleaving hazard reachable whenever multiple tool calls fire within the same tick gap during `await fs.promises.stat()`/`await writeFileAtomic()`.
+
+Reachability: confirmed — `record()` and […]
+
+#### ⚪ LOW · `bug-3` — TokenUsageTracker.seenMessageIds and files maps are unbounded — process-lifetime memory leak
+
+**Location:** `src/tokenUsageTracker.ts:35` · **Category:** bug · **Verifier confidence:** high
+
+TokenUsageTracker maintains two Maps that grow without bound. seenMessageIds (Set<string>) accumulates every unique Claude message ID ever seen across the process lifetime — in a long-running bridge serving many Claude sessions each with many turns, this can grow to tens of thousands of 26-char IDs. files (Map<string, FileState>) accumulates state per JSONL file path and is never pruned even after files are deleted or rotated. workspaceToProjectSlug() produces a single project slug from the workspace path, so all JSONL files under that project dir accumulate in the same Map indefinitely. Neither collection has a MAX_SIZE cap, eviction policy, or periodic cleanup. The tracker's start() method via setInterval never stops until stop() is called, so the leak is tied to process lifetime.
+
+```
+src/tokenUsageTracker.ts line 35-36: `private readonly files = new Map<string, FileState>(); private readonly seenMessageIds = new Set<string>();`. Line 160: `this.seenMessageIds.add(id)` — never removed. No cap on either collection anywhere in the file. Compare activityLog.ts line 227: `if (samples.length > MAX_DURATION_SAMPLES * 1.2) { this.durationSamples.set(tool, samples.slice(-MAX_DURATION_SAMPLES)); }` — has a cap; tokenUsageTracker lacks equivalent.
+```
+
+> **Verifier:** The code evidence is exact: src/tokenUsageTracker.ts lines 34-35 declare both unbounded collections; line 160 adds to seenMessageIds without any eviction path. The tracker is a real production object (bridge.ts:212 instantiates it, :936 starts it, :1994 stops it — tied to Bridge process lifetime). Not documented in docs/audit-2026-06-08.md (that doc's unbounded-maps theme lists mcpClient/claudeAuth/rejectedPorts/approvalIpCounts/loadedPluginSpecs — tokenUsageTracker is absent). However severity should be LOW not MEDIUM: this is a local single-user bridge that typically restarts daily/weekly; seenMessageIds grows at ~100 bytes/message-turn, which for even a heavy user over weeks produces […]
+
+#### ⚪ LOW · `bug-4` — PluginWatcher._reloadPluginInner writes loadedPlugins[spec]=fresh even when some transports fail — diverged state
+
+**Location:** `src/pluginWatcher.ts:167` · **Category:** bug · **Verifier confidence:** medium
+
+In _reloadPluginInner, the inner loop at lines 140-165 iterates over this.transports and applies deregisterToolsByPrefix + replaceTool for each. If patching fails for transport N and rollback is attempted (lines 154-163), only transport N is rolled back — transports 0..N-1 already have the fresh tools and are NOT rolled back. After the loop, line 167 unconditionally sets this.loadedPlugins.set(spec, fresh), so the watcher believes the fresh plugin is the canonical state. The next hot-reload will deregister fresh's prefix from ALL transports (including those that still have old tools), then register fresh tools — but if old.manifest.toolNamePrefix !== fresh.manifest.toolNamePrefix (prefix rename), the old tools on the partially-failed transports will be orphaned until the next successful reload.
+
+```
+src/pluginWatcher.ts lines 140-167: the for loop at line 140 (`for (const transport of this.transports)`) catches per-transport failure at line 146 and attempts rollback at line 154, but only for the current transport. No loop-break or compensating rollback for already-patched transports. Line 167: `this.loadedPlugins.set(spec, fresh)` always executes regardless of partial failure.
+```
+
+> **Verifier:** The code at src/pluginWatcher.ts lines 140-167 exactly matches the described defect: the for-loop does not break on per-transport error, already-patched transports (0..N-1) are not rolled back when transport N fails, and line 167 unconditionally sets loadedPlugins.set(spec, fresh). The finding is structurally correct.
+
+However, severity must be downgraded from MEDIUM to LOW for practical reachability reasons. The only way replaceTool throws is if the tool name fails /^[a-zA-Z0-9_]+$/ (lines 475-477 of transport.ts) or if ajv.compile throws on a malformed schema — both of which would normally be caught upstream in loadOnePluginFull (lines 117-130). deregisterToolsByPrefix never throws. So […]
+
+#### ⚪ LOW · `logic-gap-2` — runLog.rotateDisk runs outside withFileLockSync — multi-bridge concurrent rotation corrupts file
+
+**Location:** `src/runLog.ts:538` · **Category:** bug · **Verifier confidence:** high
+
+RecipeRunLog.append() calls rotateDisk() at line 538 before entering the withFileLockSync block at line 546. In the multi-bridge scenario that ADR-0007 exists to address, two bridges can both stat the file (both see size > MAX_PERSIST_BYTES) at the same moment, both call rotateDisk() concurrently, both readFileSync the same file content, both compute the trimmed content, and one writes and then the other overwrites it. The lock at line 546 only guards the final appendFileSync, not the rotation. The second bridge to write its rotation clobbers the first's rotation result with identical or slightly stale content — rows appended by the first bridge between its rotation and the second bridge's rotation write are silently lost.
+
+```
+src/runLog.ts lines 534-548: `try { const st = statSync(this.file); if (st.size > MAX_PERSIST_BYTES) this.rotateDisk(); } catch ... withFileLockSync(this.file, () => { appendFileSync(...) })` — rotateDisk() is outside the lock scope. decisionTraceLog.ts has the same pattern (lines 198-213) but processes far fewer writes in practice. runLog is hit on every recipe run completion.
+```
+
+> **Verifier:** The code evidence is confirmed exactly as cited. In src/runLog.ts lines 532-548, rotateDisk() is called at line 538 before withFileLockSync at line 546 — the lock guards only appendFileSync, not the read-trim-rewrite rotation. Both decisionTraceLog.ts (line 201) and commitIssueLinkLog.ts (line 198) have the identical pattern, so this is systemic across all three ADR-0007 JSONL logs.
+
+The race is theoretically real: two bridges sharing $HOME can both pass the statSync size check, both call rotateDisk(), both readFileSync the file, and the second write clobbers the first's trimmed result. The finding is not in docs/audit-2026-06-08.md under any ID — recipe-support-6 (lines 678-686 of the […]
+
+#### ⚪ LOW · `bug-5` — activityLog._loadFromDisk cross-contaminates tool entries and lifecycle entries into the wrong in-memory arrays
+
+**Location:** `src/activityLog.ts:84` · **Category:** bug · **Verifier confidence:** high
+
+In _loadFromDisk, the file is read and split into lines (line 85), then the last maxEntries lines are parsed (line 86: lines.slice(-this.maxEntries)). However, this slice is applied to the combined total line count — not separately to tool entries and lifecycle entries. The two arrays (this.entries and this.lifecycleEntries) can each hold up to maxEntries items, so the combined capacity is 2*maxEntries. Slicing the raw line array to maxEntries before parsing means that if the log has more lifecycle entries than tool entries, the tool entries (which appear earlier in the file) are truncated out of the initial load. After startup, queryTimeline() merges both arrays by id — but if tool entries were dropped from the slice, they will be absent even though they pre-date lifecycle entries that were loaded.
+
+```
+src/activityLog.ts line 84-86: `const raw = fs.readFileSync(this.persistPath, 'utf8'); const lines = raw.split('\n').filter((l) => l.trim()); for (const line of lines.slice(-this.maxEntries)) {` — the slice(-maxEntries) is on combined lines, but each entry type has its own array. A log with 300 lifecycle entries + 300 tool entries (600 lines) loaded with maxEntries=500 would parse 500 lines — the oldest 100 tool entries are dropped even though this.entries could hold them.
+```
+
+> **Verifier:** The code evidence is accurate and the defect exists on HEAD. At line 86 of src/activityLog.ts, `_loadFromDisk` does `lines.slice(-this.maxEntries)` (default 500) on the combined line array before dispatching each line to either `this.entries` (tool) or `this.lifecycleEntries` (lifecycle). The disk rotation threshold is MAX_PERSIST_LINES=10,000 (line 28), so a production log file will routinely have far more than 500 combined lines. If the tail of the file is lifecycle-heavy, earlier tool entries get truncated from the load window even though the in-memory capacity is effectively 2×maxEntries=1,000. The bug is real and reachable in normal production use after any bridge restart with a […]
+
+
+### Documentation drift
+
+#### ⚪ LOW · `docs-drift-1` — platform-docs.md claims 19 connectors; registry has 46
+
+**Location:** `documents/platform-docs.md:3` · **Category:** docs-drift · **Verifier confidence:** high
+
+The platform-docs.md header stat line and connector section name only 19 connectors, but the actual connectorRegistry.ts has 46 registered connectors. The 27 undocumented connectors include Google Docs, Jira, Monday, Salesforce, Shopify, Snowflake, Postgres, MongoDB, Redis, Elasticsearch, Sendgrid, Twilio, Figma, Airtable, Webflow, Resend, Obsidian, Todoist, Vercel, Paystack, Pipedrive, Cal.diy, Grafana, PostHog, Cloudflare, CircleCI, WooCommerce, and Supabase. A developer reading the docs gets a completely wrong picture of what connectors are available and what env vars to set.
+
+```
+documents/platform-docs.md line 3: '177 tools · 36 MCP prompts · 20 automation hooks · 19 connectors (Slack, GitHub, Linear, Gmail, Google Calendar, Google Drive, Sentry, Notion, Confluence, Datadog, HubSpot, Intercom, Stripe, Zendesk, Jira, PagerDuty, Discord, Asana, GitLab...'
+
+src/connectors/connectorRegistry.ts: 46 entries with `id:` — confirmed by `grep -c '  id: "'` returning 46, including id: "google-docs", id: "monday", id: "salesforce", id: "shopify", id: "snowflake", id: "supabase", etc.
+```
+
+> **Verifier:** The factual discrepancy is confirmed: platform-docs.md line 3 reads "19 connectors" while connectorRegistry.ts has 46 entries (grep -c returns 46). However, the severity classification of HIGH is wrong. This is purely a documentation staleness issue with no runtime, security, or data-loss impact. Additionally, the stat line itself already hedges with "see [README](../README.md) for canonical list" — so it explicitly defers the authoritative count to another document. The platform-docs connector section also discusses more connectors than the 19 listed in the header. No developer trying to use a connector is blocked: the registry, env var docs, and connectorRoutes.ts are the authoritative […]
+
+#### ⚪ LOW · `docs-drift-2` — data-reference.md claims 15 registered prompts; actual count is 36
+
+**Location:** `documents/data-reference.md:161` · **Category:** docs-drift · **Verifier confidence:** high
+
+data-reference.md says 'Registered prompts (15)' and lists only the first 15 prompts. The PROMPTS array in src/prompts.ts has 36 entries (confirmed by audit-lsp-tools output). The 21 missing prompts include all LSP composition prompts (orient-project, find-callers, blast-radius, why-error, unused-in, trace-to, imports-of, circular-deps, refactor-preview, module-exports, type-of, deprecations, coverage-gap, explore-type, ide-coverage, ide-deps, ide-diagnostics-board) and edit workflow prompts (safe-refactor, diagnose-and-fix, session-delta). A developer using data-reference.md as a reference will not know these prompts exist.
+
+```
+documents/data-reference.md line 161: '**Registered prompts (15):**' followed by a table of only 15 prompts ending at health-check.
+
+src/prompts.ts: PROMPTS array contains 36 entries at the top level (4-space-indented `name:` entries verified by awk), including orient-project, find-callers, blast-radius, safe-refactor, diagnose-and-fix, session-delta, ide-coverage, ide-deps, ide-diagnostics-board, etc.
+```
+
+> **Verifier:** The discrepancy is real and confirmed on HEAD: documents/data-reference.md line 161 says "Registered prompts (15)" and lists 15 prompts, while src/prompts.ts has 36 name entries (grep -c confirms 36). The 21 missing prompts are real entries in prompts.ts (orient-project, find-callers, blast-radius, why-error, unused-in, trace-to, imports-of, circular-deps, refactor-preview, module-exports, type-of, deprecations, coverage-gap, explore-type, ide-coverage, ide-deps, ide-diagnostics-board, safe-refactor, diagnose-and-fix, session-delta, review-changes). Not a duplicate: docs/audit-2026-06-08.md has no entry for this. However, severity is LOW not HIGH. This is documentation drift only — no […]
+
+#### ⚪ LOW · `docs-drift-3` — CLAUDE.md quick reference marks openFile as [full] but it is in SLIM_TOOL_NAMES
+
+**Location:** `CLAUDE.md:479` · **Category:** docs-drift · **Verifier confidence:** high
+
+CLAUDE.md quick reference table says openFile requires full mode ('[full]'), but src/tools/index.ts SLIM_TOOL_NAMES explicitly includes 'openFile' (line 249). A developer following the quick reference and running in --slim mode will avoid calling openFile unnecessarily, or mistakenly conclude they need to restart in full mode. The tool actually works in slim mode.
+
+```
+CLAUDE.md line 479: '| Open file in editor | `openFile` | **[full]** |'
+
+src/tools/index.ts line 249 (inside SLIM_TOOL_NAMES set literal, lines 242-310):
+  // Editor state
+  "getOpenEditors",
+  ...
+  "openFile",   ← line 249, clearly inside slim set
+```
+
+> **Verifier:** Both cited pieces of evidence exist verbatim on HEAD. `SLIM_TOOL_NAMES` in `/Users/wesh/Documents/Anthropic Workspace/Patchwork OS/src/tools/index.ts` begins at line 242 and `"openFile"` appears at line 249, firmly inside that set. CLAUDE.md line 479 labels openFile as `**[full]**`, contradicting the source. The audit file `docs/audit-2026-06-08.md` contains no mention of this discrepancy, so it is not a duplicate. Impact is purely documentation-driven developer confusion (unnecessary full-mode restarts or skipped calls); there is no security risk, data loss, or silent corruption. Severity is correctly LOW — not MEDIUM — because the only consequence is a developer choosing not to call a […]
+
+#### ⚪ LOW · `docs-drift-4` — CLAUDE.md quick reference marks executeVSCodeCommand as [full] but it is in SLIM_TOOL_NAMES
+
+**Location:** `CLAUDE.md:490` · **Category:** docs-drift · **Verifier confidence:** high
+
+CLAUDE.md quick reference says executeVSCodeCommand is full-mode only ('[full]'), but SLIM_TOOL_NAMES includes it at line 303 with the comment '// VS Code escape hatch'. Developers testing in slim mode who need to run a VS Code command will incorrectly believe the tool is unavailable.
+
+```
+CLAUDE.md line 490: '| Run VS Code command by ID | `executeVSCodeCommand` | **[full]** |'
+
+src/tools/index.ts line 302-303 (inside SLIM_TOOL_NAMES):
+  // VS Code escape hatch
+  "executeVSCodeCommand",
+```
+
+> **Verifier:** Both pieces of evidence exist verbatim on HEAD. CLAUDE.md line 490 lists executeVSCodeCommand with the [full] marker. src/tools/index.ts line 303 places it inside SLIM_TOOL_NAMES (the Set defined at line 242), with the comment "// VS Code escape hatch". The audit doc (docs/audit-2026-06-08.md) contains zero references to this finding, so it is not a duplicate. The defect is real: the documentation says the tool is full-mode only, but the code makes it available in slim mode too. However, severity should be LOW, not MEDIUM. The practical consequence is benign: a developer who reads the docs and believes the tool is unavailable in slim mode will simply be wrong in a conservative direction — […]
+
+#### ⚪ LOW · `docs-drift-5` — CLI --help says --grace-period default is 30000ms; actual code default is 120000ms
+
+**Location:** `src/config.ts:953` · **Category:** docs-drift · **Verifier confidence:** high
+
+The --grace-period CLI help text says 'default: 30000' but the actual default initialized in config.ts line 491 is `fileConfig.gracePeriodMs ?? 120_000` (120 seconds). The env-var warning message at line 1139 also echoes back whatever `gracePeriodMs` currently is, so it would say 120000. CLAUDE.md and data-reference.md are both correct (120s), but the CLI help text contradicts them. An operator who reads --help will set an unnecessarily short grace period to match the documented default.
+
+```
+src/config.ts line 953 (inside --help block):
+  '--grace-period <ms>       Reconnect grace period in ms (default: 30000, max: 600000)'
+
+src/config.ts line 491 (actual initialization):
+  'let gracePeriodMs = fileConfig.gracePeriodMs ?? 120_000;'
+
+src/bridge.ts line 1918 also uses 30_000 as a comparison reference ('if (this.config.gracePeriodMs !== 30_000)'), suggesting the default was changed from 30s to 120s at some point without updating the help text.
+```
+
+> **Verifier:** All three evidence points confirmed on HEAD: (1) src/config.ts line 953 prints "default: 30000" in the --help text; (2) src/config.ts line 491 initializes gracePeriodMs to 120_000 when no flag or file config is present; (3) src/bridge.ts line 1918 compares against 30_000, a remnant showing the default was once 30s before being raised to 120s without updating the help string. The defect is real and directly user-facing — any operator running `--help` sees the wrong default. Not found in docs/audit-2026-06-08.md (the audit doc mentions grace-period only in the context of a reconnect-leak bug, not this help-text discrepancy). Severity adjusted DOWN to LOW from MEDIUM: no data loss, no security […]
+
+#### ⚪ LOW · `docs-drift-6` — CLAUDE.md and CLI docs claim tools [--slim] filters to slim set; --slim flag is silently ignored
+
+**Location:** `src/commands/tools.ts:440` · **Category:** docs-drift · **Verifier confidence:** high
+
+CLAUDE.md line 50 documents `tools [--slim] [--json]` and the CLI help text at index.ts line 273 shows `tools [list|search <q>] [--slim] [--json]`. However, runToolsCommand() in src/commands/tools.ts does not parse or act on --slim at all — the flag is accepted by the command dispatch but silently discarded, and the output always lists all 177 tools. SLIM_TOOL_NAMES exists in tools/index.ts and could be applied. A developer running `patchwork tools list --slim` expecting the 61-tool subset gets all 177 tools.
+
+```
+CLAUDE.md line 50: '- `tools [--slim] [--json]` — List tools the bridge would register without starting it.'
+
+src/index.ts line 273 (help text):
+  '  tools [list|search <q>] [--slim] [--json] List tools the bridge would register\n'
+
+src/commands/tools.ts runToolsCommand() (lines 440-505): entire function body never references 'slim' — confirmed by grep returning no matches:
+  grep -n 'slim' src/commands/tools.ts  → (no output)
+```
+
+> **Verifier:** The finding is confirmed on HEAD. `runToolsCommand` in `/Users/wesh/Documents/Anthropic Workspace/Patchwork OS/src/commands/tools.ts` (lines 440-505) parses only `--json` from argv and calls `buildToolCatalog()` unconditionally — there is zero reference to "slim" in the entire file. The help text at `src/index.ts:273` advertises `tools [list|search <q>] [--slim] [--json]`, so a user running `patchwork tools list --slim` gets all tools silently. The `--slim` handling that does exist in `src/index.ts:374-376` is for the `start-all`/`patchwork` daemon dispatch path only, not the `tools` subcommand. `SLIM_TOOL_NAMES` exists in the codebase and could filter the catalog, but is never wired into […]
+
+#### ⚪ LOW · `docs-drift-7` — platform-docs.md automation hooks table: header claims 20 hooks, body says 18 keys, and 3 hooks in HookType are undocumented
+
+**Location:** `documents/platform-docs.md:536` · **Category:** docs-drift · **Verifier confidence:** high
+
+platform-docs.md has an internal contradiction: the page header says '20 automation hooks' but the automation section says 'any of these 18 hook keys'. The HookType union in automationProgram.ts has 21 entries. Three hook types are entirely absent from platform-docs.md: onRecipeSave (triggers on .yaml/.yml file save), onDebugSessionStart, and onDebugSessionEnd. These are functional, implemented, and supported by policyParser.ts but users consulting platform-docs.md will never discover them. CLAUDE.md documents all three correctly.
+
+```
+documents/platform-docs.md line 3: '20 automation hooks'
+documents/platform-docs.md line 536: '...policy is a JSON file with any of these 18 hook keys:'
+The table that follows (lines 538-558) does not include onRecipeSave, onDebugSessionStart, or onDebugSessionEnd.
+
+src/fp/automationProgram.ts lines 10-31 (HookType union, 21 entries):
+  | 'onDiagnosticsError' | 'onDiagnosticsCleared' | 'onFileSave' | 'onFileChanged'
+  | 'onCwdChanged' | 'onPreCompact' | 'onPostCompact' | 'onInstructionsLoaded'
+  | 'onTestRun' | 'onTestPassAfterFailure' | 'onGitCommit' | 'onGitPush'
+  | 'onGitPull' | 'onBranchCheckout' | 'onPullRequest' | 'onTaskCreated'
+  | 'onPermissionDenied' | 'onTaskSuccess' | 'onDebugSessionStart'
+  | 'onDebugSessionEnd' | 'onRecipeSave';
+```
+
+> **Verifier:** All evidence checks out on HEAD. platform-docs.md line 3 says "20 automation hooks"; line 536 says "18 hook keys"; the table at lines 538-558 has 19 rows but one is a duplicate (onGitCommit appears twice) and onPreCompact/onPostCompact share a row, yielding effectively 17-18 distinct hook names documented. HookType in automationProgram.ts lines 10-31 has exactly 21 members. Three hooks — onRecipeSave (line 31), onDebugSessionStart (line 29), onDebugSessionEnd (line 30) — are absent from the platform-docs.md automation table, and all three are fully implemented and handled in policyParser.ts (confirmed at lines 64-68 and 348-670). The finding's evidence is accurate. It is not in […]
+
+#### ⚪ LOW · `docs-drift-9` — ADR-0005 says SESSION_TTL_MS was reduced to 10 minutes; actual code uses 2 hours
+
+**Location:** `docs/adr/0005-http-session-eviction.md:29` · **Category:** docs-drift · **Verifier confidence:** high
+
+ADR-0005 Decision section states 'SESSION_TTL_MS: 30 min → 10 min (faster reclamation of legitimately abandoned sessions)' and its Consequences section says '10-min TTL reclaims abandoned sessions 3x faster'. However, the actual code uses SESSION_TTL_MS = 2 * 60 * 60 * 1000 (2 hours), with a code comment saying 'reduced from 24h to limit captured-session-ID reuse window'. CLAUDE.md correctly documents '2hr idle TTL'. The ADR was never updated after the TTL was changed again from 10 min to 2 hours.
+
+```
+docs/adr/0005-http-session-eviction.md line 29:
+  '- `SESSION_TTL_MS`: 30 min → **10 min** (faster reclamation of legitimately abandoned sessions)'
+
+src/streamableHttp.ts line 34:
+  'const SESSION_TTL_MS = 2 * 60 * 60 * 1000; // 2 hour idle TTL — reduced from 24h to limit captured-session-ID reuse window'
+```
+
+> **Verifier:** Both pieces of evidence are confirmed exactly on HEAD. ADR-0005 line 29 states "SESSION_TTL_MS: 30 min → 10 min" and line 37 states "10-min TTL reclaims abandoned sessions 3x faster", while src/streamableHttp.ts line 34 defines SESSION_TTL_MS = 2 * 60 * 60 * 1000 (2 hours) with comment "reduced from 24h to limit captured-session-ID reuse window". CLAUDE.md correctly documents the 2hr value. The ADR was written for the 30→10min change and never updated when the TTL was later changed to 2 hours for a different reason (security rather than performance). This is pure documentation drift — no runtime behavior is affected. The audit file docs/audit-2026-06-08.md contains no reference to this […]
+
+#### ⚪ LOW · `docs-drift-10` — platform-docs.md CC hook wiring table omits PreCompact; CLAUDE.md has it correctly
+
+**Location:** `documents/platform-docs.md:570` · **Category:** docs-drift · **Verifier confidence:** high
+
+The CC hook wiring table in platform-docs.md (lines 570-576) lists PostCompact, InstructionsLoaded, TaskCreated, PermissionDenied, CwdChanged — but omits PreCompact. This means a user following platform-docs.md to configure settings.json for the onCompaction phase='pre' automation hook will miss the PreCompact wiring entry. CLAUDE.md correctly lists PreCompact at line 340. Without the PreCompact hook wired in settings.json, the onCompaction pre-phase automation never fires.
+
+```
+documents/platform-docs.md lines 570-576:
+  | CC hook event | Settings.json command |
+  |------|------|
+  | `PostCompact` | `claude-ide-bridge notify PostCompact` |
+  | `InstructionsLoaded` | ... |
+  | `TaskCreated` | ... |
+  | `PermissionDenied` | ... |
+  | `CwdChanged` | ... |
+(PreCompact row is entirely absent)
+
+CLAUDE.md line 340 (correct):
+  | `PreCompact` | `claude-ide-bridge notify PreCompact` |
+```
+
+> **Verifier:** The evidence is exactly as claimed. documents/platform-docs.md lines 570-576 show a CC hook wiring table with five rows (PostCompact, InstructionsLoaded, TaskCreated, PermissionDenied, CwdChanged) and no PreCompact row. CLAUDE.md line 340 includes PreCompact correctly. The defect is a real documentation inconsistency on current HEAD. It is not present in docs/audit-2026-06-08.md (no docs-drift entries exist there). Severity stays LOW: the same paragraph (platform-docs.md line 568) states the bridge auto-wires these hooks when --automation is active, so users relying on auto-wiring are unaffected. The gap only hits users hand-editing settings.json by following platform-docs.md exclusively, […]
+
+#### ⚪ LOW · `docs-drift-11` — CLI --help says --slim mode registers ~60 tools and full mode ~140; actual counts are 61 and 177
+
+**Location:** `src/config.ts:958` · **Category:** docs-drift · **Verifier confidence:** high
+
+The --help text says '--slim: Register only the ~60 IDE-exclusive tools' and 'Default is full mode (~140 tools: adds git, terminal, file ops, HTTP, GitHub).' The actual confirmed counts (from audit-lsp-tools.mjs) are 61 slim tools and 177 total tools. The '~140' undercount means 37 full-mode tools are invisible to a user reading the help text. This could cause confusion when users debug tool availability.
+
+```
+src/config.ts line 958-960:
+  '--slim                    Register only the ~60 IDE-exclusive tools (LSP, debugger, editor state).'
+  ...
+  'Default is full mode (~140 tools: adds git, terminal, file ops, HTTP, GitHub).'
+
+scripts/audit-lsp-tools.mjs output:
+  'Stats: 61 slim tools · 33 LSP tools advertised · 177 total registered · 34 LSP implementations · 127 outputSchema tools'
+```
+
+> **Verifier:** The defect is confirmed at the exact cited location. Lines 958 and 960 of src/config.ts contain the strings "~60 IDE-exclusive tools" and "~140 tools" respectively. The audit script (scripts/audit-lsp-tools.mjs) on current HEAD outputs "Stats: 61 slim tools · 177 total registered", so the slim count (~60) is approximately correct but the full-mode count (~140) underrepresents by 37 tools (~26%). The text has not been updated by any of the recent PRs #947-#953 — the most recent commit to config.ts is #953 and grep confirms ~140 is still present. The finding is not documented in docs/audit-2026-06-08.md (searched for "~140", "docs-drift", "tool count", "help.*140" — no matches). Severity is […]
+
+
+---
+
+## Appendix A — Refuted findings (killed by adversarial verification)
+
+- bridge-transport/transport-new-1: Dynamic dispatch catch sends JSON-RPC error instead of isError:true content block
+- recipes-flat/recipe-flat-new-3: priorDraft embedded raw into revision LLM prompt — bypasses secretKeys redaction
+- recipes-flat/recipe-flat-new-6: validateRecipeTemplates always probes with empty context — compile_error from step-path references silently passes
+- recipes-chained/DAG-2: Nested recipe's own budget policy silently ignored when parent recipe has no budget
+- recipes-support/sim-env-1: simulateMockedRun spreads process.env into template context — secret exposure via {{env.VAR}}
+- recipes-support/install-ref-1: githubInstallSource ref validation allows forward slashes — path injection within the allowed GitHub repo
+- recipes-support/sched-timezone-1: Scheduler reads loadConfig() once per cron5 recipe — O(n) redundant disk reads at startup
+- fix-regressions/pr947-2: RECIPE_NAME_RE used before its const declaration in recipe.ts
+- fix-regressions/pr947-4: streamableHttp waitMs computation passes undefined to waitForSend for non-tools/call methods
+- dashboard-pages/dash-new-2: Approvals page ignores `?recipe=` URL filter — deep-link shows all approvals
+- dashboard-pages/dash-new-5: Approvals SSE stream does not filter by `?recipe=` — server also ignores the param
+- dashboard-api/dash-new-1: approvals/stream SSE error responses use comment ': retry' instead of the retry: directive — EventSource reconnects at browser default (~3s) when bridge is unavailable
+- dashboard-api/dash-new-3: relay/push: callId is interpolated unencoded into URL path for approveUrl/rejectUrl — a callId containing '../' creates path traversal, misdirecting the SW to a wrong bridge endpoint
+- dashboard-api/dash-new-5: connector-requests GET has no defense-in-depth session check in the handler — unlike push/subscribe and push/unsubscribe which layer handler checks on top of middleware
+- fp-automation/fp-new-4: WithDedup never records dedup key for webhook-only hooks — identical events bypass dedup gate every time
+- extension/ext-new-3: handleRunTask: onDidEndTaskProcess event dropped if exec not yet assigned
+- orchestrator-drivers/orch-driver-2: sanitizeEnv strips ANTHROPIC_API_KEY — API-key-only users silently fail to authenticate subprocess tasks
+- platform-misc/logic-gap-1: approvalInsights severity labels 'high' for ANY rejection regardless of approval rate — misleads operators
+
+## Appendix B — Duplicates of audit-2026-06-08 (already tracked there)
+
+- tools-core/tools-sar-1: searchAndReplace NUL byte in replacement passes through to written files
+- tools-core/tools-pre-1: previewEdit and stageEdit searchReplace: NUL byte in `replace` parameter written to disk unchecked
+- tools-core/tools-git-1: gitPull alreadyUpToDate is always false when rebase:true is set
+- recipes-chained/DAG-3: processQueue missing .catch(): onStepStart/onStepComplete throw causes permanent deadlock
+- recipes-chained/DAG-6: expect on_fail:'warn' failures silently dropped on chained runner — no log entry, no dashboard visibility
+- recipes-chained/DAG-7: recipe_started event reports unexpanded step count — progress indicators exceed 100% with parallel groups
+- recipes-chained/DAG-8: Nested recipe success derived from !childResult.errorMessage instead of childResult.success
+- connectors-core/connector-new-6: Slack OAuth state store is single-slot file — concurrent /authorize flows corrupt each other
+- connectors-core/connector-new-7: mcpOAuth.ts pending map is memory-only — in-flight OAuth state lost on bridge restart
+- connectors-core/connector-new-8: handleConnectionsList reports oauth connectors (monday, salesforce, google-docs) as 'connected' even when token is expired
+- fix-regressions/pr947-1: readBody in claudeAuthHttp.ts does not destroy the request stream on size overflow
+- fix-regressions/pr947-3: claudeAuthHttp sessions Map has no size cap — slow authenticated memory leak
+- cli/cli-doctor-sincems-timestamp-vs-duration: recipe doctor CLI passes Unix timestamp as sinceMs duration — bridge returns all-time halts
+- platform-misc/unsurfaced-1: GET /feature-flags endpoint missing — dashboard cannot read current flag values before toggling
+- docs-drift/docs-drift-8: CLAUDE.md webhook fan-out says 'any opted-in hook may add webhook' but code restricts to onCompaction hooks only

--- a/src/connectors/__tests__/connectorTokenLeak.redaction.test.ts
+++ b/src/connectors/__tests__/connectorTokenLeak.redaction.test.ts
@@ -59,45 +59,25 @@ describe("connector token-exchange error redaction", () => {
   const tokensDir = join(patchworkHome, "tokens");
 
   beforeEach(() => {
-    process.env.HOME = homeDir;
-    process.env.USERPROFILE = homeDir;
-    process.env.PATCHWORK_HOME = patchworkHome;
-    process.env.PATCHWORK_TOKEN_DIR = tokensDir;
-    process.env.PATCHWORK_TOKEN_STORAGE_BACKEND = "file";
+    vi.stubEnv("HOME", homeDir);
+    vi.stubEnv("USERPROFILE", homeDir);
+    vi.stubEnv("PATCHWORK_HOME", patchworkHome);
+    vi.stubEnv("PATCHWORK_TOKEN_DIR", tokensDir);
+    vi.stubEnv("PATCHWORK_TOKEN_STORAGE_BACKEND", "file");
     mkdirSync(tokensDir, { recursive: true });
     vi.resetModules();
   });
 
   afterEach(() => {
     vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
     vi.restoreAllMocks();
-    for (const k of [
-      "HOME",
-      "USERPROFILE",
-      "PATCHWORK_HOME",
-      "PATCHWORK_TOKEN_DIR",
-      "PATCHWORK_TOKEN_STORAGE_BACKEND",
-      "DISCORD_CLIENT_ID",
-      "DISCORD_CLIENT_SECRET",
-      "ASANA_CLIENT_ID",
-      "ASANA_CLIENT_SECRET",
-      "GITLAB_CLIENT_ID",
-      "GITLAB_CLIENT_SECRET",
-      "MONDAY_CLIENT_ID",
-      "MONDAY_CLIENT_SECRET",
-      "GOOGLE_DOCS_CLIENT_ID",
-      "GOOGLE_DOCS_CLIENT_SECRET",
-      "GOOGLE_DRIVE_CLIENT_ID",
-      "GOOGLE_DRIVE_CLIENT_SECRET",
-    ]) {
-      delete process.env[k];
-    }
     if (existsSync(tmpDir)) rmSync(tmpDir, { recursive: true, force: true });
   });
 
   it("discord callback (HTML) does not leak the raw IdP body", async () => {
-    process.env.DISCORD_CLIENT_ID = "cid";
-    process.env.DISCORD_CLIENT_SECRET = "csecret";
+    vi.stubEnv("DISCORD_CLIENT_ID", "cid");
+    vi.stubEnv("DISCORD_CLIENT_SECRET", "csecret");
     const { handleDiscordAuthorize, handleDiscordCallback } = await import(
       "../discord.js"
     );
@@ -110,8 +90,8 @@ describe("connector token-exchange error redaction", () => {
   });
 
   it("asana callback (HTML) does not leak the raw IdP body", async () => {
-    process.env.ASANA_CLIENT_ID = "cid";
-    process.env.ASANA_CLIENT_SECRET = "csecret";
+    vi.stubEnv("ASANA_CLIENT_ID", "cid");
+    vi.stubEnv("ASANA_CLIENT_SECRET", "csecret");
     const { handleAsanaAuthorize, handleAsanaCallback } = await import(
       "../asana.js"
     );
@@ -124,8 +104,8 @@ describe("connector token-exchange error redaction", () => {
   });
 
   it("gitlab callback (HTML) does not leak the raw IdP body", async () => {
-    process.env.GITLAB_CLIENT_ID = "cid";
-    process.env.GITLAB_CLIENT_SECRET = "csecret";
+    vi.stubEnv("GITLAB_CLIENT_ID", "cid");
+    vi.stubEnv("GITLAB_CLIENT_SECRET", "csecret");
     const { handleGitLabAuthorize, handleGitLabCallback } = await import(
       "../gitlab.js"
     );
@@ -138,8 +118,8 @@ describe("connector token-exchange error redaction", () => {
   });
 
   it("monday callback (JSON) does not leak the raw IdP body", async () => {
-    process.env.MONDAY_CLIENT_ID = "cid";
-    process.env.MONDAY_CLIENT_SECRET = "csecret";
+    vi.stubEnv("MONDAY_CLIENT_ID", "cid");
+    vi.stubEnv("MONDAY_CLIENT_SECRET", "csecret");
     const { handleMondayAuthRedirect, handleMondayCallback } = await import(
       "../monday.js"
     );
@@ -152,8 +132,8 @@ describe("connector token-exchange error redaction", () => {
   });
 
   it("googleDocs callback (JSON) does not leak the raw IdP body", async () => {
-    process.env.GOOGLE_DOCS_CLIENT_ID = "cid";
-    process.env.GOOGLE_DOCS_CLIENT_SECRET = "csecret";
+    vi.stubEnv("GOOGLE_DOCS_CLIENT_ID", "cid");
+    vi.stubEnv("GOOGLE_DOCS_CLIENT_SECRET", "csecret");
     const { handleDocsAuthRedirect, handleDocsCallback } = await import(
       "../googleDocs.js"
     );
@@ -166,8 +146,8 @@ describe("connector token-exchange error redaction", () => {
   });
 
   it("googleDrive callback (JSON) does not leak the raw IdP body", async () => {
-    process.env.GOOGLE_DRIVE_CLIENT_ID = "cid";
-    process.env.GOOGLE_DRIVE_CLIENT_SECRET = "csecret";
+    vi.stubEnv("GOOGLE_DRIVE_CLIENT_ID", "cid");
+    vi.stubEnv("GOOGLE_DRIVE_CLIENT_SECRET", "csecret");
     const { handleDriveAuthRedirect, handleDriveCallback } = await import(
       "../googleDrive.js"
     );

--- a/src/connectors/__tests__/connectorTokenLeak.redaction.test.ts
+++ b/src/connectors/__tests__/connectorTokenLeak.redaction.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Audit 2026-06-09 HIGH (connector-new-1 / connector-new-2): PR #947 fixed the
+ * token-exchange raw-IdP-body credential leak in mcpOAuth.ts ONLY. The identical
+ * pattern — `const body = await res.text(); throw new Error(\`... ${body}\`)` —
+ * survived in six independent connectors whose callback handlers surface the
+ * thrown Error message verbatim into the HTTP response (HTML for discord/asana/
+ * gitlab, JSON for monday/googleDocs/googleDrive).
+ *
+ * Some IdP error bodies embed an access_token / refresh_token / error_description
+ * that can contain secrets — so the raw body must never reach the thrown Error or
+ * the HTTP response. Only the HTTP status (and a parsed `error` code) is safe.
+ *
+ * Each case drives the real authorize→callback flow with a leaky 400 response and
+ * asserts the secret tokens are absent from the response body while the status is
+ * still surfaced for diagnosis.
+ */
+
+import { existsSync, mkdirSync, rmSync } from "node:fs";
+import os from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const LEAK_TOKEN = "LEAKED_SECRET_TOKEN_0001";
+const LEAKY_JSON_BODY = JSON.stringify({
+  error: "invalid_grant",
+  error_description: "secretdetail-should-not-leak",
+  access_token: LEAK_TOKEN,
+  refresh_token: "REFRESH_LEAK_9999",
+});
+
+function leakyFetch() {
+  return vi.fn().mockResolvedValue(
+    new Response(LEAKY_JSON_BODY, {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    }),
+  );
+}
+
+function stateFromRedirect(redirect: string | undefined): string {
+  const url = new URL(redirect ?? "");
+  const state = url.searchParams.get("state");
+  if (!state) throw new Error("authorize produced no state");
+  return state;
+}
+
+function assertNoLeak(body: string) {
+  expect(body).not.toContain(LEAK_TOKEN);
+  expect(body).not.toContain("REFRESH_LEAK_9999");
+  expect(body).not.toContain("secretdetail-should-not-leak");
+  expect(body).not.toContain("access_token");
+  expect(body).not.toContain("refresh_token");
+}
+
+describe("connector token-exchange error redaction", () => {
+  const tmpDir = join(os.tmpdir(), `patchwork-connector-leak-${Date.now()}`);
+  const homeDir = join(tmpDir, "home");
+  const patchworkHome = join(homeDir, ".patchwork");
+  const tokensDir = join(patchworkHome, "tokens");
+
+  beforeEach(() => {
+    process.env.HOME = homeDir;
+    process.env.USERPROFILE = homeDir;
+    process.env.PATCHWORK_HOME = patchworkHome;
+    process.env.PATCHWORK_TOKEN_DIR = tokensDir;
+    process.env.PATCHWORK_TOKEN_STORAGE_BACKEND = "file";
+    mkdirSync(tokensDir, { recursive: true });
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    for (const k of [
+      "HOME",
+      "USERPROFILE",
+      "PATCHWORK_HOME",
+      "PATCHWORK_TOKEN_DIR",
+      "PATCHWORK_TOKEN_STORAGE_BACKEND",
+      "DISCORD_CLIENT_ID",
+      "DISCORD_CLIENT_SECRET",
+      "ASANA_CLIENT_ID",
+      "ASANA_CLIENT_SECRET",
+      "GITLAB_CLIENT_ID",
+      "GITLAB_CLIENT_SECRET",
+      "MONDAY_CLIENT_ID",
+      "MONDAY_CLIENT_SECRET",
+      "GOOGLE_DOCS_CLIENT_ID",
+      "GOOGLE_DOCS_CLIENT_SECRET",
+      "GOOGLE_DRIVE_CLIENT_ID",
+      "GOOGLE_DRIVE_CLIENT_SECRET",
+    ]) {
+      delete process.env[k];
+    }
+    if (existsSync(tmpDir)) rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("discord callback (HTML) does not leak the raw IdP body", async () => {
+    process.env.DISCORD_CLIENT_ID = "cid";
+    process.env.DISCORD_CLIENT_SECRET = "csecret";
+    const { handleDiscordAuthorize, handleDiscordCallback } = await import(
+      "../discord.js"
+    );
+    const state = stateFromRedirect(handleDiscordAuthorize().redirect);
+    vi.stubGlobal("fetch", leakyFetch());
+    const res = await handleDiscordCallback("auth-code", state, null);
+    expect(res.status).toBe(400);
+    assertNoLeak(res.body);
+    expect(res.body).toMatch(/400/);
+  });
+
+  it("asana callback (HTML) does not leak the raw IdP body", async () => {
+    process.env.ASANA_CLIENT_ID = "cid";
+    process.env.ASANA_CLIENT_SECRET = "csecret";
+    const { handleAsanaAuthorize, handleAsanaCallback } = await import(
+      "../asana.js"
+    );
+    const state = stateFromRedirect(handleAsanaAuthorize().redirect);
+    vi.stubGlobal("fetch", leakyFetch());
+    const res = await handleAsanaCallback("auth-code", state, null);
+    expect(res.status).toBe(400);
+    assertNoLeak(res.body);
+    expect(res.body).toMatch(/400/);
+  });
+
+  it("gitlab callback (HTML) does not leak the raw IdP body", async () => {
+    process.env.GITLAB_CLIENT_ID = "cid";
+    process.env.GITLAB_CLIENT_SECRET = "csecret";
+    const { handleGitLabAuthorize, handleGitLabCallback } = await import(
+      "../gitlab.js"
+    );
+    const state = stateFromRedirect(handleGitLabAuthorize().redirect);
+    vi.stubGlobal("fetch", leakyFetch());
+    const res = await handleGitLabCallback("auth-code", state, null);
+    expect(res.status).toBe(400);
+    assertNoLeak(res.body);
+    expect(res.body).toMatch(/400/);
+  });
+
+  it("monday callback (JSON) does not leak the raw IdP body", async () => {
+    process.env.MONDAY_CLIENT_ID = "cid";
+    process.env.MONDAY_CLIENT_SECRET = "csecret";
+    const { handleMondayAuthRedirect, handleMondayCallback } = await import(
+      "../monday.js"
+    );
+    const state = stateFromRedirect(handleMondayAuthRedirect().redirect);
+    vi.stubGlobal("fetch", leakyFetch());
+    const res = await handleMondayCallback("auth-code", state, null);
+    expect(res.status).toBe(400);
+    assertNoLeak(res.body);
+    expect(res.body).toMatch(/400/);
+  });
+
+  it("googleDocs callback (JSON) does not leak the raw IdP body", async () => {
+    process.env.GOOGLE_DOCS_CLIENT_ID = "cid";
+    process.env.GOOGLE_DOCS_CLIENT_SECRET = "csecret";
+    const { handleDocsAuthRedirect, handleDocsCallback } = await import(
+      "../googleDocs.js"
+    );
+    const state = stateFromRedirect(handleDocsAuthRedirect().redirect);
+    vi.stubGlobal("fetch", leakyFetch());
+    const res = await handleDocsCallback("auth-code", state, null);
+    expect(res.status).toBe(400);
+    assertNoLeak(res.body);
+    expect(res.body).toMatch(/400/);
+  });
+
+  it("googleDrive callback (JSON) does not leak the raw IdP body", async () => {
+    process.env.GOOGLE_DRIVE_CLIENT_ID = "cid";
+    process.env.GOOGLE_DRIVE_CLIENT_SECRET = "csecret";
+    const { handleDriveAuthRedirect, handleDriveCallback } = await import(
+      "../googleDrive.js"
+    );
+    const state = stateFromRedirect(handleDriveAuthRedirect().redirect);
+    vi.stubGlobal("fetch", leakyFetch());
+    const res = await handleDriveCallback("auth-code", state, null);
+    expect(res.status).toBe(400);
+    assertNoLeak(res.body);
+    expect(res.body).toMatch(/400/);
+  });
+});

--- a/src/connectors/__tests__/mcpClient.test.ts
+++ b/src/connectors/__tests__/mcpClient.test.ts
@@ -165,6 +165,40 @@ describe("McpClient 401 refresh + retry", () => {
     expect(firstCallHeaders?.Authorization).toBe("Bearer stale-token");
   });
 
+  it("does not embed the upstream error body in the thrown Error (audit 2026-06-09 connector-new-5)", async () => {
+    // A non-401 upstream error whose body carries a secret. The thrown Error
+    // propagates into recipe tool results → LLM context, so it must surface only
+    // the status, never the raw body.
+    const leakyBody = JSON.stringify({
+      error: "internal",
+      token: "UPSTREAM_SECRET_TOKEN_42",
+      stack: "at Server.handler (/srv/secret/path.js:1:1)",
+    });
+    const getAccessToken = vi.fn(async () => "any-token");
+    const fetchMock = vi.fn(
+      async () => new Response(leakyBody, { status: 500 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new McpClient(
+      "https://mcp.example.test/mcp",
+      getAccessToken,
+    );
+
+    let caught: Error | undefined;
+    try {
+      await client.listTools();
+    } catch (e) {
+      caught = e as Error;
+    }
+    expect(caught).toBeDefined();
+    expect(caught?.message).not.toContain("UPSTREAM_SECRET_TOKEN_42");
+    expect(caught?.message).not.toContain("/srv/secret/path.js");
+    expect(caught?.message).not.toContain("token");
+    // Status is still surfaced for diagnosis.
+    expect(caught?.message).toMatch(/500/);
+  });
+
   it("does not retry more than once (no infinite loop) on repeated 401", async () => {
     const getAccessToken = vi.fn(async () => "any-token");
     const fetchMock = vi.fn(

--- a/src/connectors/asana.ts
+++ b/src/connectors/asana.ts
@@ -45,6 +45,7 @@ import {
 } from "./baseConnector.js";
 import { connectorRedirectUri } from "./connectorRedirectUri.js";
 import { escHtml } from "./htmlEscape.js";
+import { safeOAuthErrorCode } from "./oauthError.js";
 import { readSecret } from "./secrets.js";
 import {
   deleteSecretJsonSync,
@@ -728,8 +729,10 @@ export async function handleAsanaCallback(
       body: params.toString(),
     });
     if (!res.ok) {
-      const body = await res.text();
-      throw new Error(`Token exchange HTTP ${res.status}: ${body}`);
+      const body = await res.text().catch(() => "");
+      throw new Error(
+        `Token exchange HTTP ${res.status} (${safeOAuthErrorCode(body)})`,
+      );
     }
     const json = (await res.json()) as {
       access_token?: string;
@@ -789,7 +792,7 @@ export async function handleAsanaCallback(
     return {
       status: 200,
       contentType: "text/html",
-      body: `<html><body><h2>Asana connected${username ? ` as ${escHtml(username)}` : ""}</h2><script>try { window.opener.postMessage('patchwork:asana:connected', '*'); } catch(_) {} window.close();</script></body></html>`,
+      body: `<html><body><h2>Asana connected${username ? ` as ${escHtml(username)}` : ""}</h2><script>try { window.opener.postMessage('patchwork:asana:connected', window.location.origin); } catch(_) {} window.close();</script></body></html>`,
     };
   } catch (err) {
     return {

--- a/src/connectors/discord.ts
+++ b/src/connectors/discord.ts
@@ -41,6 +41,7 @@ import {
 } from "./baseConnector.js";
 import { connectorRedirectUri } from "./connectorRedirectUri.js";
 import { escHtml } from "./htmlEscape.js";
+import { safeOAuthErrorCode } from "./oauthError.js";
 import { readSecret } from "./secrets.js";
 import {
   deleteSecretJsonSync,
@@ -558,8 +559,10 @@ export async function handleDiscordCallback(
       body: params.toString(),
     });
     if (!res.ok) {
-      const body = await res.text();
-      throw new Error(`Token exchange HTTP ${res.status}: ${body}`);
+      const body = await res.text().catch(() => "");
+      throw new Error(
+        `Token exchange HTTP ${res.status} (${safeOAuthErrorCode(body)})`,
+      );
     }
     const json = (await res.json()) as {
       access_token?: string;
@@ -610,7 +613,7 @@ export async function handleDiscordCallback(
     return {
       status: 200,
       contentType: "text/html",
-      body: `<html><body><h2>Discord connected${username ? ` as ${escHtml(username)}` : ""}</h2><script>try { window.opener.postMessage('patchwork:discord:connected', '*'); } catch(_) {} window.close();</script></body></html>`,
+      body: `<html><body><h2>Discord connected${username ? ` as ${escHtml(username)}` : ""}</h2><script>try { window.opener.postMessage('patchwork:discord:connected', window.location.origin); } catch(_) {} window.close();</script></body></html>`,
     };
   } catch (err) {
     return {

--- a/src/connectors/gitlab.ts
+++ b/src/connectors/gitlab.ts
@@ -39,6 +39,7 @@ import {
 } from "./baseConnector.js";
 import { connectorRedirectUri } from "./connectorRedirectUri.js";
 import { escHtml } from "./htmlEscape.js";
+import { safeOAuthErrorCode } from "./oauthError.js";
 import { createOAuthStateStore } from "./oauthStateStore.js";
 import { readSecret } from "./secrets.js";
 import {
@@ -633,8 +634,10 @@ export async function handleGitLabCallback(
       body: params.toString(),
     });
     if (!res.ok) {
-      const body = await res.text();
-      throw new Error(`Token exchange HTTP ${res.status}: ${body}`);
+      const body = await res.text().catch(() => "");
+      throw new Error(
+        `Token exchange HTTP ${res.status} (${safeOAuthErrorCode(body)})`,
+      );
     }
     const json = (await res.json()) as {
       access_token?: string;
@@ -689,7 +692,7 @@ export async function handleGitLabCallback(
     return {
       status: 200,
       contentType: "text/html",
-      body: `<html><body><h2>GitLab connected${username ? ` as ${escHtml(username)}` : ""}</h2><script>try { window.opener.postMessage('patchwork:gitlab:connected', '*'); } catch(_) {} window.close();</script></body></html>`,
+      body: `<html><body><h2>GitLab connected${username ? ` as ${escHtml(username)}` : ""}</h2><script>try { window.opener.postMessage('patchwork:gitlab:connected', window.location.origin); } catch(_) {} window.close();</script></body></html>`,
     };
   } catch (err) {
     return {

--- a/src/connectors/gmail.ts
+++ b/src/connectors/gmail.ts
@@ -575,7 +575,7 @@ function callbackHtml(
 </div>
 <script>
   // Notify the opener tab that auth completed so it can poll.
-  if (window.opener) { try { window.opener.postMessage('patchwork:gmail:connected', 'http://localhost:3200'); } catch(_) {} }
+  if (window.opener) { try { window.opener.postMessage('patchwork:gmail:connected', window.location.origin); } catch(_) {} }
 </script>
 </body></html>`;
 }

--- a/src/connectors/googleDocs.ts
+++ b/src/connectors/googleDocs.ts
@@ -3,6 +3,7 @@ import { existsSync, readFileSync, unlinkSync } from "node:fs";
 import { homedir } from "node:os";
 import path from "node:path";
 import { connectorRedirectUri } from "./connectorRedirectUri.js";
+import { safeOAuthErrorCode } from "./oauthError.js";
 import { readSecret } from "./secrets.js";
 import {
   deleteSecretJsonSync,
@@ -208,8 +209,10 @@ async function exchangeCode(
     }).toString(),
   });
   if (!res.ok) {
-    const body = await res.text();
-    throw new Error(`Token exchange failed: ${res.status} ${body}`);
+    const body = await res.text().catch(() => "");
+    throw new Error(
+      `Token exchange failed: ${res.status} (${safeOAuthErrorCode(body)})`,
+    );
   }
   const json = (await res.json()) as {
     access_token: string;
@@ -250,8 +253,10 @@ async function refreshAccessToken(tokens: DocsTokens): Promise<DocsTokens> {
     }).toString(),
   });
   if (!res.ok) {
-    const body = await res.text();
-    throw new Error(`Token refresh failed: ${res.status} ${body}`);
+    const body = await res.text().catch(() => "");
+    throw new Error(
+      `Token refresh failed: ${res.status} (${safeOAuthErrorCode(body)})`,
+    );
   }
   const json = (await res.json()) as {
     access_token: string;

--- a/src/connectors/googleDrive.ts
+++ b/src/connectors/googleDrive.ts
@@ -3,6 +3,7 @@ import { existsSync, readFileSync, unlinkSync } from "node:fs";
 import { homedir } from "node:os";
 import path from "node:path";
 import { connectorRedirectUri } from "./connectorRedirectUri.js";
+import { safeOAuthErrorCode } from "./oauthError.js";
 import { readSecret } from "./secrets.js";
 import {
   deleteSecretJsonSync,
@@ -139,8 +140,10 @@ async function exchangeCode(
     }).toString(),
   });
   if (!res.ok) {
-    const body = await res.text();
-    throw new Error(`Token exchange failed: ${res.status} ${body}`);
+    const body = await res.text().catch(() => "");
+    throw new Error(
+      `Token exchange failed: ${res.status} (${safeOAuthErrorCode(body)})`,
+    );
   }
   const json = (await res.json()) as {
     access_token: string;
@@ -181,8 +184,10 @@ async function refreshAccessToken(tokens: DriveTokens): Promise<DriveTokens> {
     }).toString(),
   });
   if (!res.ok) {
-    const body = await res.text();
-    throw new Error(`Token refresh failed: ${res.status} ${body}`);
+    const body = await res.text().catch(() => "");
+    throw new Error(
+      `Token refresh failed: ${res.status} (${safeOAuthErrorCode(body)})`,
+    );
   }
   const json = (await res.json()) as {
     access_token: string;

--- a/src/connectors/mcpClient.ts
+++ b/src/connectors/mcpClient.ts
@@ -166,10 +166,12 @@ export class McpClient {
       }
 
       if (!res.ok) {
-        const snippet = (await res.text()).slice(0, 300);
-        throw new Error(
-          `MCP HTTP ${res.status} at ${this.endpoint}: ${snippet}`,
-        );
+        // Drain the body so the connection can be reused, but never embed it in
+        // the thrown Error — upstream MCP error bodies can carry internal
+        // context, stack traces, or token values that propagate into recipe
+        // tool results and LLM context (audit 2026-06-09 connector-new-5).
+        await res.text().catch(() => {});
+        throw new Error(`MCP HTTP ${res.status} at ${this.endpoint}`);
       }
       return parseMcpResponse(res);
     }

--- a/src/connectors/monday.ts
+++ b/src/connectors/monday.ts
@@ -15,6 +15,7 @@ import { existsSync, readFileSync, unlinkSync } from "node:fs";
 import { homedir } from "node:os";
 import path from "node:path";
 import { connectorRedirectUri } from "./connectorRedirectUri.js";
+import { safeOAuthErrorCode } from "./oauthError.js";
 import { createOAuthStateStore } from "./oauthStateStore.js";
 import {
   deleteSecretJsonSync,
@@ -262,8 +263,10 @@ async function exchangeCode(
     }).toString(),
   });
   if (!res.ok) {
-    const body = await res.text();
-    throw new Error(`Token exchange failed: ${res.status} ${body}`);
+    const body = await res.text().catch(() => "");
+    throw new Error(
+      `Token exchange failed: ${res.status} (${safeOAuthErrorCode(body)})`,
+    );
   }
   const json = (await res.json()) as {
     access_token: string;
@@ -304,8 +307,10 @@ async function refreshAccessToken(tokens: MondayTokens): Promise<MondayTokens> {
     }).toString(),
   });
   if (!res.ok) {
-    const body = await res.text();
-    throw new Error(`Token refresh failed: ${res.status} ${body}`);
+    const body = await res.text().catch(() => "");
+    throw new Error(
+      `Token refresh failed: ${res.status} (${safeOAuthErrorCode(body)})`,
+    );
   }
   const json = (await res.json()) as {
     access_token: string;

--- a/src/connectors/oauthError.ts
+++ b/src/connectors/oauthError.ts
@@ -1,0 +1,47 @@
+/**
+ * Shared OAuth token-exchange error redaction.
+ *
+ * Audit 2026-06-09 HIGH (connector-new-1 / connector-new-2): IdP token-exchange
+ * error bodies can embed access_token / refresh_token / error_description values
+ * that are sensitive. Several connectors embedded the *raw* response body in a
+ * thrown Error, which their callback handlers then surfaced verbatim into the
+ * HTTP response (HTML or JSON) shown to the browser. Only the HTTP status and a
+ * parsed, non-sensitive `error` code are safe to surface.
+ *
+ * `safeOAuthErrorCode` extracts the standard OAuth 2.0 `error` field (RFC 6749
+ * §5.2) from a JSON or form-encoded error body, ignoring everything else. It
+ * never returns free-form text from the body, so it cannot leak token values or
+ * `error_description` detail.
+ */
+
+/** Parse only the OAuth `error` code from a token-exchange error body. */
+export function safeOAuthErrorCode(body: string | null | undefined): string {
+  if (!body) return "unknown";
+  // JSON error body: { "error": "invalid_grant", ... }
+  try {
+    const parsed = JSON.parse(body) as { error?: unknown };
+    if (typeof parsed.error === "string" && parsed.error) {
+      return sanitizeCode(parsed.error);
+    }
+  } catch {
+    // not JSON — fall through to form-encoded
+  }
+  // Form-encoded error body: error=invalid_grant&...
+  try {
+    const code = new URLSearchParams(body).get("error");
+    if (code) return sanitizeCode(code);
+  } catch {
+    // not parseable
+  }
+  return "unknown";
+}
+
+/**
+ * OAuth error codes are short alphanumeric tokens (RFC 6749 §5.2). Clamp length
+ * and strip anything unexpected so a hostile IdP can't smuggle a long secret in
+ * via the `error` field itself.
+ */
+function sanitizeCode(code: string): string {
+  const cleaned = code.replace(/[^a-zA-Z0-9_.-]/g, "").slice(0, 64);
+  return cleaned || "unknown";
+}


### PR DESCRIPTION
## What

Closes the **#1 ranked HIGH** from the 2026-06-09 audit (`docs/audit-2026-06-09.md`, included in this PR): the token-exchange raw-IdP-body credential leak that PR #947 fixed in `mcpOAuth.ts` **only**. The identical pattern survived in six independent connectors whose callback handlers surface the thrown `Error` verbatim into the HTTP response.

## The leak

`const body = await res.text(); throw new Error(\`... ${body}\`)` — IdP error bodies can embed `access_token` / `refresh_token` / `error_description` values. Those reached:

- **HTML** callback page → discord, asana, gitlab
- **JSON** API response → monday, googleDocs, **googleDrive**

> googleDrive was **not** named in the audit — caught by sweeping the whole class, which is the audit's own headline lesson ("when a finding names a bug *class*, grep before closing").

## Fix

- New shared helper `src/connectors/oauthError.ts` → `safeOAuthErrorCode()` parses **only** the RFC 6749 §5.2 `error` code (length-clamped to 64, charset-stripped) from JSON or form-encoded bodies. It can never return token values or free-form `error_description` text.
- Wired into **both** the token-exchange and token-refresh sinks of all six connectors.
- `McpClient.post()` (connector-new-5) no longer embeds the 300-char upstream MCP error body in its thrown Error (that error propagates into recipe tool results → LLM context).

## postMessage origins (connector-new-3 / connector-new-4)

- gmail used a hardcoded `http://localhost:3200` → silently dropped on any non-local deployment.
- discord / asana / gitlab used wildcard `'*'` → any tab could observe auth completion.
- All now use `window.location.origin`, matching slack.

## Tests (test-first, Bug Fix Protocol)

- `connectorTokenLeak.redaction.test.ts` drives the real authorize→callback flow with a leaky 400 for all six connectors and asserts the secret tokens are absent while the status is still surfaced.
- `mcpClient.test.ts` adds a 500-with-secret-body case.
- 18 redaction tests green; full connector suite (1352 tests across touched areas) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)