### PR TITLE
fix(tools): strip credential headers on cross-origin redirect in sendHttpRequest (audit 2026-06-09 HIGH #2)

### DIFF
--- a/src/tools/__tests__/httpClient.test.ts
+++ b/src/tools/__tests__/httpClient.test.ts
@@ -247,6 +247,66 @@ describe("sendHttpRequest — userinfo (credentials) stripped from URL", () => {
   });
 });
 
+describe("sendHttpRequest — credential headers stripped on cross-origin redirect", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  function redirectThenOk(location: string) {
+    return vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(null, {
+          status: 302,
+          headers: { location },
+        }),
+      )
+      .mockResolvedValueOnce(new Response("ok", { status: 200 }));
+  }
+
+  it("HIGH: Authorization/Cookie/X-Api-Key are NOT forwarded to a cross-origin redirect (audit 2026-06-09 tools-http-1)", async () => {
+    const fetchSpy = redirectThenOk("https://evil.example.net/harvest");
+    vi.spyOn(dns, "lookup").mockResolvedValue({
+      address: "93.184.216.34",
+      family: 4,
+    } as never);
+
+    await tool.handler({
+      method: "GET",
+      url: "https://api.example.com/resource",
+      headers: {
+        Authorization: "Bearer SECRET_TOKEN",
+        Cookie: "session=abc",
+        "X-Api-Key": "APIKEY123",
+      },
+    });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    const secondHeaders = (fetchSpy.mock.calls[1]?.[1] as RequestInit)
+      .headers as Record<string, string>;
+    expect(secondHeaders.authorization).toBeUndefined();
+    expect(secondHeaders.cookie).toBeUndefined();
+    expect(secondHeaders["x-api-key"]).toBeUndefined();
+  });
+
+  it("keeps credential headers on a same-origin redirect", async () => {
+    const fetchSpy = redirectThenOk("https://api.example.com/resource/v2");
+    vi.spyOn(dns, "lookup").mockResolvedValue({
+      address: "93.184.216.34",
+      family: 4,
+    } as never);
+
+    await tool.handler({
+      method: "GET",
+      url: "https://api.example.com/resource",
+      headers: { Authorization: "Bearer SECRET_TOKEN" },
+    });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    const secondHeaders = (fetchSpy.mock.calls[1]?.[1] as RequestInit)
+      .headers as Record<string, string>;
+    expect(secondHeaders.authorization).toBe("Bearer SECRET_TOKEN");
+  });
+});
+
 describe("sendHttpRequest — Content-Length exceeded drains body", () => {
   afterEach(() => vi.restoreAllMocks());
 

--- a/src/tools/httpClient.ts
+++ b/src/tools/httpClient.ts
@@ -232,6 +232,11 @@ export function createSendHttpRequestTool(options?: {
         // against the real hostname (not the pinned IP), and so Host header
         // derivation uses the real name rather than the resolved IP address.
         let currentDisplayUrl = cleanUrlStr;
+        // Origin of the original request. Credential headers (Authorization,
+        // Cookie, etc.) must NOT be forwarded to a redirect destination on a
+        // different origin — any redirecting intermediary could otherwise
+        // harvest them (audit 2026-06-09 tools-http-1, mirrors browser fetch).
+        const originalOrigin = new URL(cleanUrlStr).origin;
         let redirectCount = 0;
         let resp: Response;
 
@@ -281,6 +286,20 @@ export function createSendHttpRequestTool(options?: {
           // Always set Host from the un-pinned display URL so a DNS failure
           // doesn't leave the previous hop's Host header on the new request.
           headers.host = nextDisplayUrl.hostname;
+
+          // Cross-origin hop → strip caller-supplied credential headers so a
+          // redirecting intermediary can't harvest them (audit tools-http-1).
+          // Header keys were lowercased when collected above.
+          if (nextDisplayUrl.origin !== originalOrigin) {
+            for (const h of [
+              "authorization",
+              "cookie",
+              "x-api-key",
+              "proxy-authorization",
+            ]) {
+              delete headers[h];
+            }
+          }
 
           // Strip any userinfo (user:password@) from the URL sent to fetch —
           // credentials must not be forwarded across redirect hops to new origins.


### PR DESCRIPTION
## What

Closes the **#2 ranked HIGH** (tools-http-1) from the 2026-06-09 audit.

`sendHttpRequest`'s manual redirect loop updated only `headers.host` on each hop. Caller-supplied **credential headers** (`Authorization`, `Cookie`, `X-Api-Key`, `Proxy-Authorization`) were forwarded unchanged to **every** redirect destination, including cross-origin ones. Any redirecting intermediary could 302 to its own origin and harvest them. URL userinfo was already stripped; header credentials were not.

## Fix

Capture the original request origin once; on any redirect hop whose origin differs, delete the credential headers before the next `fetch` — mirroring browser fetch behavior. Same-origin redirects retain them.

## Tests (test-first)

- Cross-origin 302 → asserts `authorization` / `cookie` / `x-api-key` are absent on the second fetch.
- Same-origin 302 → asserts they're retained.
- Full `httpClient.test.ts` suite green (27 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)