### PR TITLE
fix(runlog): persist tokenTotals/budgetTotals in completeRun (audit 2026-06-09 HIGH #3)

### DIFF
--- a/src/__tests__/runLog.test.ts
+++ b/src/__tests__/runLog.test.ts
@@ -361,6 +361,9 @@ describe("RecipeRunLog.record", () => {
         outputTokens: 80,
         total: 200,
         usd: 0.0042,
+        breached: false,
+        usdBreached: false,
+        haltOnBreach: false,
       },
     });
     const run = log.getBySeq(seq);

--- a/src/__tests__/runLog.test.ts
+++ b/src/__tests__/runLog.test.ts
@@ -342,6 +342,43 @@ describe("RecipeRunLog.record", () => {
     expect(parsed.status).toBe("done");
   });
 
+  it("completeRun persists tokenTotals and budgetTotals (audit 2026-06-09 data-loss-1)", () => {
+    const log = new RecipeRunLog({ dir: tmp });
+    const seq = log.startRun({
+      taskId: "chained:cost:1",
+      recipeName: "cost",
+      trigger: "recipe",
+      createdAt: 1_000,
+    });
+    log.completeRun(seq, {
+      status: "done",
+      doneAt: 2_000,
+      durationMs: 1_000,
+      stepResults: [{ id: "a", status: "ok", durationMs: 100 }],
+      tokenTotals: { inputTokens: 120, outputTokens: 80, costUsd: 0.0042 },
+      budgetTotals: {
+        inputTokens: 120,
+        outputTokens: 80,
+        total: 200,
+        usd: 0.0042,
+      },
+    });
+    const run = log.getBySeq(seq);
+    expect(run?.tokenTotals).toEqual({
+      inputTokens: 120,
+      outputTokens: 80,
+      costUsd: 0.0042,
+    });
+    expect(run?.budgetTotals?.total).toBe(200);
+    // Must survive the round-trip to disk (bridge-path runs read the last row).
+    const lines = readFileSync(path.join(tmp, "runs.jsonl"), "utf-8")
+      .trim()
+      .split("\n");
+    const parsed = JSON.parse(lines[lines.length - 1]!);
+    expect(parsed.tokenTotals.inputTokens).toBe(120);
+    expect(parsed.budgetTotals.total).toBe(200);
+  });
+
   it("completeRun sets hadStepErrors=true when a step ended in error but the run is done", () => {
     const log = new RecipeRunLog({ dir: tmp });
     const seq = log.startRun({

--- a/src/runLog.ts
+++ b/src/runLog.ts
@@ -492,6 +492,8 @@ export class RecipeRunLog {
       assertionFailures?: RecipeRun["assertionFailures"];
       inboxOutputs?: RecipeRun["inboxOutputs"];
       budgetWarnings?: RecipeRun["budgetWarnings"];
+      tokenTotals?: RecipeRun["tokenTotals"];
+      budgetTotals?: RecipeRun["budgetTotals"];
     },
   ): void {
     const idx = this.runs.findIndex((r) => r.seq === seq);
@@ -523,6 +525,10 @@ export class RecipeRunLog {
         opts.budgetWarnings.length > 0 && {
           budgetWarnings: opts.budgetWarnings,
         }),
+      ...(opts.tokenTotals !== undefined && { tokenTotals: opts.tokenTotals }),
+      ...(opts.budgetTotals !== undefined && {
+        budgetTotals: opts.budgetTotals,
+      }),
     };
     this.runs[idx] = finalized;
     mkdirSync(path.dirname(this.file), { recursive: true, mode: 0o700 });


### PR DESCRIPTION
## What

Closes the **#3 ranked HIGH** (data-loss-1) from the 2026-06-09 audit.

`completeRun()`'s `opts` type omitted `tokenTotals` and `budgetTotals`. Both recipe runners (`yamlRunner`, `chainedRunner`) spread `...(tokenTotals ? {tokenTotals} : {})` into the opts arg — the spread **bypasses TS excess-property checks**, so the fields were silently dropped and never copied into the finalized `RecipeRun`.

Result: **no bridge-path recipe run ever persisted cost/token data** — which also left the dashboard cost columns with nothing to render (unsurfaced-3 in the prior audit was doubly broken).

## Fix

Add `tokenTotals` / `budgetTotals` to the `completeRun` opts type and conditionally include them in the finalized object.

## Tests (test-first)

`completeRun` now round-trips both fields through memory and disk. Full `runLog.test.ts` suite green (34 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)