### PR TITLE
fix(traces): /traces limit→400, semantic floor fallback, hoist embed provider (audit 2026-06-09 #6)

### DIFF
--- a/src/__tests__/server-traces.test.ts
+++ b/src/__tests__/server-traces.test.ts
@@ -140,6 +140,32 @@ describe("GET /traces", () => {
     expect(received[0]?.limit).toBeUndefined();
   });
 
+  it("returns 400 (not 500) for an out-of-range limit (audit 2026-06-09 sem-1)", async () => {
+    let called = false;
+    await startServer(async () => {
+      called = true;
+      return { traces: [], count: 0, sources: {} };
+    });
+    const big = await get("/traces?limit=501");
+    expect(big.status).toBe(400);
+    expect(JSON.parse(big.body).error).toMatch(/limit/i);
+    const zero = await get("/traces?limit=0");
+    expect(zero.status).toBe(400);
+    // Validation happens before the backend is invoked.
+    expect(called).toBe(false);
+  });
+
+  it("accepts a limit at the boundary (500)", async () => {
+    const received: Array<Record<string, unknown>> = [];
+    await startServer(async (q) => {
+      received.push(q);
+      return { traces: [], count: 0, sources: {} };
+    });
+    const { status } = await get("/traces?limit=500");
+    expect(status).toBe(200);
+    expect(received[0]?.limit).toBe(500);
+  });
+
   it("returns 500 when tracesFn throws", async () => {
     await startServer(async () => {
       throw new Error("backend on fire");

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -1269,15 +1269,20 @@ export class Bridge {
         nearby: nearby as unknown as Record<string, unknown>[],
       };
     };
+    // Build the traces tool + embeddings provider ONCE at startup. The
+    // dashboard polls /traces every few seconds; re-constructing the tool and
+    // re-allocating the embeddings provider on every request was pure waste
+    // (audit sem-4). The log references and embed fn are stable for the
+    // bridge's lifetime.
+    const tracesTool = createCtxQueryTracesTool({
+      activityLog: this.activityLog,
+      commitIssueLinkLog: this.commitIssueLinkLog,
+      recipeRunLog: this.recipeRunLog,
+      decisionTraceLog: this.decisionTraceLog,
+      embedFn: getLocalEmbedFn(),
+    });
     this.server.tracesFn = async (query) => {
-      const tool = createCtxQueryTracesTool({
-        activityLog: this.activityLog,
-        commitIssueLinkLog: this.commitIssueLinkLog,
-        recipeRunLog: this.recipeRunLog,
-        decisionTraceLog: this.decisionTraceLog,
-        embedFn: getLocalEmbedFn(),
-      });
-      const result = await tool.handler({
+      const result = await tracesTool.handler({
         ...(query.traceType && { traceType: query.traceType }),
         ...(query.key && { key: query.key }),
         ...(query.q && { q: query.q }),

--- a/src/server.ts
+++ b/src/server.ts
@@ -960,6 +960,32 @@ export class Server extends EventEmitter<ServerEvents> {
           const q = parsedUrl.searchParams;
           const sinceStr = q.get("since");
           const limitStr = q.get("limit");
+          // Validate numeric ranges up front so an out-of-range value returns a
+          // 400 with an actionable message instead of bubbling an exception
+          // from ctxQueryTraces' optionalInt() into a generic 500 (audit sem-1).
+          if (limitStr !== null && /^\d+$/.test(limitStr)) {
+            const limitNum = Number(limitStr);
+            if (limitNum < 1 || limitNum > 500) {
+              res.writeHead(400, { "Content-Type": "application/json" });
+              res.end(
+                JSON.stringify({
+                  error: "limit must be an integer between 1 and 500",
+                }),
+              );
+              return;
+            }
+          }
+          if (sinceStr !== null && /^\d+$/.test(sinceStr)) {
+            if (!Number.isSafeInteger(Number(sinceStr))) {
+              res.writeHead(400, { "Content-Type": "application/json" });
+              res.end(
+                JSON.stringify({
+                  error: "since must be a safe integer (epoch ms)",
+                }),
+              );
+              return;
+            }
+          }
           const data = this.tracesFn
             ? await this.tracesFn({
                 traceType: q.get("traceType") ?? undefined,

--- a/src/tools/__tests__/ctxQueryTraces.semantic.test.ts
+++ b/src/tools/__tests__/ctxQueryTraces.semantic.test.ts
@@ -128,6 +128,49 @@ describe("ctxQueryTraces semantic ranking", () => {
     );
   });
 
+  it("falls back to substring when ALL semantic scores are below the floor (audit 2026-06-09 sem-2)", async () => {
+    // Both traces are lexically about "widget" (below-floor vectors vs the
+    // query), so semanticRank returns an empty array. The handler must NOT
+    // return zero results — it should fall back to substring search, which
+    // matches "widget".
+    now = 1_000_000;
+    decisionTraceLog.record({
+      ref: "WIDGET-1",
+      problem: "widget alignment drift",
+      solution: "unrelated knob recalibration",
+      workspace: "/ws",
+      tags: ["widget"],
+    });
+    now = 2_000_000;
+    decisionTraceLog.record({
+      ref: "WIDGET-2",
+      problem: "widget jitter unrelated",
+      solution: "unrelated damping fix",
+      workspace: "/ws",
+      tags: ["widget"],
+    });
+
+    // Bespoke embedder: the query vector is orthogonal to every trace vector
+    // (cosine 0 < floor) regardless of text, so semanticRank returns []. The
+    // query string "widget" still substring-matches both traces, so the
+    // substring fallback must surface them.
+    const orthogonalEmbedFn = vi.fn((texts: string[]) =>
+      Promise.resolve(
+        texts.map((_t, i): number[] => (i === 0 ? [1, 0] : [0, 1])),
+      ),
+    );
+    const tool = createCtxQueryTracesTool({
+      decisionTraceLog,
+      embedFn: orthogonalEmbedFn,
+    });
+
+    const res = parse(await tool.handler({ q: "widget", semantic: true }));
+
+    expect(orthogonalEmbedFn).toHaveBeenCalled();
+    // Substring fallback finds both "widget" traces rather than returning empty.
+    expect(res.count).toBe(2);
+  });
+
   it("does NOT call embedFn when semantic is false / omitted", async () => {
     seedTwoDecisions();
     const embedFn = vi.fn(fakeEmbedFn);

--- a/src/tools/ctxQueryTraces.ts
+++ b/src/tools/ctxQueryTraces.ts
@@ -359,15 +359,20 @@ export function createCtxQueryTracesTool(deps: CtxQueryTracesDeps) {
           deps.embedFn,
           limit,
         );
-        if (ranked) {
+        // A non-empty ranked array is a real semantic result. An EMPTY array
+        // means every candidate scored below the floor (or there were none) —
+        // treat that like a miss and fall through to substring search rather
+        // than returning zero results with no explanation (audit sem-2). null
+        // already signals embeddings unavailable.
+        if (ranked && ranked.length > 0) {
           return successStructured({
             traces: ranked,
             count: ranked.length,
             sources,
           });
         }
-        // Fallback: embeddings unavailable. Apply the substring filter we
-        // skipped in semantic mode, then recency-sort like the default path.
+        // Fallback: embeddings unavailable or all-below-floor. Apply the
+        // substring filter we skipped in semantic mode, then recency-sort.
         const qNeedle = qFilter.toLowerCase();
         filtered = filtered.filter((t) => matchesSubstring(t, qNeedle));
       }


### PR DESCRIPTION
## What

The three "fix before merging the semantic-toggle work" items (sem-1/2/4) from the 2026-06-09 audit. The toggle itself already merged (#955); these harden it.

- **sem-1** — `GET /traces?limit=N` outside `[1,500]` (or `since` beyond `MAX_SAFE_INTEGER`) threw inside `ctxQueryTraces`' `optionalInt()` → uncaught → generic **500**. Now range-validated in the route → **400** with an actionable message, before the backend is invoked.
- **sem-2** — semantic ranking returning an **empty array** (all candidates below `SEMANTIC_FLOOR`) was treated as a real result via `if (ranked)` (`[]` is truthy) → zero results, no fallback. Now `ranked && ranked.length > 0`; an all-below-floor result falls through to substring search like a null/miss.
- **sem-4** — `tracesFn` re-constructed the `ctxQueryTraces` tool and re-allocated the embeddings provider on **every** `/traces` request (dashboard polls every few seconds). Hoisted to a single startup allocation.

## Tests (test-first)

- sem-1: 400 at the boundary (limit 501 / 0), 500-handler still intact, backend not invoked on bad input.
- sem-2: bespoke orthogonal-embedder makes every trace fall below floor while the query string still substring-matches → fallback surfaces them.
- sem-4: verified by typecheck + existing suites.
- 34 tests green across `ctxQueryTraces` + `server-traces`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)