### PR TITLE
fix(recipe-tools): soft-error envelope on connector throw across 21 tool files (audit 2026-06-09 #4)

### DIFF
--- a/src/recipes/tools/__tests__/shopify.test.ts
+++ b/src/recipes/tools/__tests__/shopify.test.ts
@@ -261,4 +261,19 @@ describe("shopify recipe-step tools", () => {
       });
     });
   });
+
+  // Audit 2026-06-09 connector-tools-1/2/3: a connector throw must become the
+  // soft `{ ok:false, error }` envelope (via wrapConnectorExecute) so the
+  // recipe runner can continue instead of hard-halting with `tool_threw`.
+  describe("soft-error envelope on connector throw", () => {
+    it("returns { ok:false, error } instead of throwing", async () => {
+      listProducts.mockRejectedValue(new Error("Shopify token missing"));
+      const tool = getTool("shopify.list_products");
+      const out = await tool?.execute(ctx({}));
+      expect(out).toBeTypeOf("string");
+      const parsed = JSON.parse(out as string);
+      expect(parsed.ok).toBe(false);
+      expect(parsed.error).toContain("Shopify token missing");
+    });
+  });
 });

--- a/src/recipes/tools/caldiy.ts
+++ b/src/recipes/tools/caldiy.ts
@@ -12,6 +12,7 @@
  */
 
 import { CommonSchemas, registerTool } from "../toolRegistry.js";
+import { wrapConnectorExecute } from "./wrapConnectorExecute.js";
 
 // ============================================================================
 // caldiy.list_event_types
@@ -48,12 +49,12 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async () => {
+  execute: wrapConnectorExecute(async () => {
     const { getCalDiyConnector } = await import("../../connectors/caldiy.js");
     const connector = getCalDiyConnector();
     const result = await connector.getEventTypes();
     return JSON.stringify(result);
-  },
+  }),
 });
 
 // ============================================================================
@@ -120,7 +121,7 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getCalDiyConnector } = await import("../../connectors/caldiy.js");
     const connector = getCalDiyConnector();
     const result = await connector.getBookings({
@@ -134,7 +135,7 @@ registerTool({
       dateTo: typeof params.dateTo === "string" ? params.dateTo : undefined,
     });
     return JSON.stringify(result);
-  },
+  }),
 });
 
 // ============================================================================
@@ -181,12 +182,12 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getCalDiyConnector } = await import("../../connectors/caldiy.js");
     const connector = getCalDiyConnector();
     const result = await connector.getBooking(params.uid as string);
     return JSON.stringify(result);
-  },
+  }),
 });
 
 // ============================================================================
@@ -218,7 +219,7 @@ registerTool({
   riskDefault: "medium",
   isWrite: true,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getCalDiyConnector } = await import("../../connectors/caldiy.js");
     const connector = getCalDiyConnector();
     const result = await connector.cancelBooking(
@@ -226,5 +227,5 @@ registerTool({
       typeof params.reason === "string" ? params.reason : undefined,
     );
     return JSON.stringify(result);
-  },
+  }),
 });

--- a/src/recipes/tools/confluence.ts
+++ b/src/recipes/tools/confluence.ts
@@ -6,6 +6,7 @@
 
 import { assertWriteAllowed } from "../../featureFlags.js";
 import { CommonSchemas, registerTool } from "../toolRegistry.js";
+import { wrapConnectorExecute } from "./wrapConnectorExecute.js";
 
 // ============================================================================
 // confluence.getPage
@@ -44,7 +45,7 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getConfluenceConnector } = await import(
       "../../connectors/confluence.js"
     );
@@ -66,7 +67,7 @@ registerTool({
       body: page.body?.storage?.value ?? null,
       url: page._links.webui,
     });
-  },
+  }),
 });
 
 // ============================================================================
@@ -100,7 +101,7 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getConfluenceConnector } = await import(
       "../../connectors/confluence.js"
     );
@@ -110,7 +111,7 @@ registerTool({
       typeof params.limit === "number" ? params.limit : 25,
     );
     return JSON.stringify(result);
-  },
+  }),
 });
 
 // ============================================================================
@@ -150,7 +151,7 @@ registerTool({
   riskDefault: "medium",
   isWrite: true,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     assertWriteAllowed("confluence.createPage");
     const { getConfluenceConnector } = await import(
       "../../connectors/confluence.js"
@@ -168,7 +169,7 @@ registerTool({
       url: page._links.webui,
       version: page.version.number,
     });
-  },
+  }),
 });
 
 // ============================================================================
@@ -204,7 +205,7 @@ registerTool({
   riskDefault: "medium",
   isWrite: true,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     assertWriteAllowed("confluence.appendToPage");
     const { getConfluenceConnector } = await import(
       "../../connectors/confluence.js"
@@ -220,7 +221,7 @@ registerTool({
       version: page.version.number,
       url: page._links.webui,
     });
-  },
+  }),
 });
 
 // ============================================================================
@@ -265,7 +266,7 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getConfluenceConnector } = await import(
       "../../connectors/confluence.js"
     );
@@ -283,5 +284,5 @@ registerTool({
       })),
       count: spaces.length,
     });
-  },
+  }),
 });

--- a/src/recipes/tools/datadog.ts
+++ b/src/recipes/tools/datadog.ts
@@ -6,6 +6,7 @@
 
 import { assertWriteAllowed } from "../../featureFlags.js";
 import { CommonSchemas, registerTool } from "../toolRegistry.js";
+import { wrapConnectorExecute } from "./wrapConnectorExecute.js";
 
 // ============================================================================
 // datadog.queryMetrics
@@ -45,7 +46,7 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getDatadogConnector } = await import("../../connectors/datadog.js");
     const connector = getDatadogConnector();
     const result = await connector.queryMetrics(
@@ -54,7 +55,7 @@ registerTool({
       params.to as number,
     );
     return JSON.stringify(result);
-  },
+  }),
 });
 
 // ============================================================================
@@ -92,7 +93,7 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getDatadogConnector } = await import("../../connectors/datadog.js");
     const connector = getDatadogConnector();
     const monitors = await connector.listMonitors({
@@ -100,7 +101,7 @@ registerTool({
       perPage: typeof params.perPage === "number" ? params.perPage : undefined,
     });
     return JSON.stringify({ monitors, count: monitors.length });
-  },
+  }),
 });
 
 // ============================================================================
@@ -131,12 +132,12 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getDatadogConnector } = await import("../../connectors/datadog.js");
     const connector = getDatadogConnector();
     const monitor = await connector.getMonitor(params.monitorId as number);
     return JSON.stringify(monitor);
-  },
+  }),
 });
 
 // ============================================================================
@@ -165,12 +166,12 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async ({ params: _ }) => {
+  execute: wrapConnectorExecute(async ({ params: _ }) => {
     const { getDatadogConnector } = await import("../../connectors/datadog.js");
     const connector = getDatadogConnector();
     const alerts = await connector.listActiveAlerts();
     return JSON.stringify({ alerts, count: alerts.length });
-  },
+  }),
 });
 
 // ============================================================================
@@ -206,7 +207,7 @@ registerTool({
   riskDefault: "medium",
   isWrite: true,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     assertWriteAllowed("datadog.muteMonitor");
     const { getDatadogConnector } = await import("../../connectors/datadog.js");
     const connector = getDatadogConnector();
@@ -219,7 +220,7 @@ registerTool({
       name: monitor.name,
       overall_state: monitor.overall_state,
     });
-  },
+  }),
 });
 
 // ============================================================================
@@ -252,12 +253,12 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getDatadogConnector } = await import("../../connectors/datadog.js");
     const connector = getDatadogConnector();
     const result = await connector.listIncidents({
       perPage: typeof params.perPage === "number" ? params.perPage : undefined,
     });
     return JSON.stringify({ data: result.data, count: result.data.length });
-  },
+  }),
 });

--- a/src/recipes/tools/docs.ts
+++ b/src/recipes/tools/docs.ts
@@ -17,6 +17,7 @@
  */
 
 import { CommonSchemas, registerTool } from "../toolRegistry.js";
+import { wrapConnectorExecute } from "./wrapConnectorExecute.js";
 
 // ============================================================================
 // docs.get_document
@@ -53,10 +54,10 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getDocument } = await import("../../connectors/googleDocs.js");
     return JSON.stringify(await getDocument(params.documentId as string));
-  },
+  }),
 });
 
 // ============================================================================
@@ -92,9 +93,9 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getDocumentText } = await import("../../connectors/googleDocs.js");
     const text = await getDocumentText(params.documentId as string);
     return JSON.stringify({ text });
-  },
+  }),
 });

--- a/src/recipes/tools/elasticsearch.ts
+++ b/src/recipes/tools/elasticsearch.ts
@@ -10,6 +10,7 @@
  */
 
 import { CommonSchemas, registerTool } from "../toolRegistry.js";
+import { wrapConnectorExecute } from "./wrapConnectorExecute.js";
 
 // ============================================================================
 // elasticsearch.search
@@ -58,7 +59,7 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getElasticsearchConnector } = await import(
       "../../connectors/elasticsearch.js"
     );
@@ -72,7 +73,7 @@ registerTool({
       params._source,
     );
     return JSON.stringify(result);
-  },
+  }),
 });
 
 // ============================================================================
@@ -107,7 +108,7 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getElasticsearchConnector } = await import(
       "../../connectors/elasticsearch.js"
     );
@@ -117,7 +118,7 @@ registerTool({
       params.query as Record<string, unknown> | undefined,
     );
     return JSON.stringify(result);
-  },
+  }),
 });
 
 // ============================================================================
@@ -143,14 +144,14 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async () => {
+  execute: wrapConnectorExecute(async () => {
     const { getElasticsearchConnector } = await import(
       "../../connectors/elasticsearch.js"
     );
     const connector = getElasticsearchConnector();
     const result = await connector.listIndices();
     return JSON.stringify(result);
-  },
+  }),
 });
 
 // ============================================================================
@@ -176,12 +177,12 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async () => {
+  execute: wrapConnectorExecute(async () => {
     const { getElasticsearchConnector } = await import(
       "../../connectors/elasticsearch.js"
     );
     const connector = getElasticsearchConnector();
     const result = await connector.clusterHealth();
     return JSON.stringify(result);
-  },
+  }),
 });

--- a/src/recipes/tools/figma.ts
+++ b/src/recipes/tools/figma.ts
@@ -11,6 +11,7 @@
  */
 
 import { CommonSchemas, registerTool } from "../toolRegistry.js";
+import { wrapConnectorExecute } from "./wrapConnectorExecute.js";
 
 // ============================================================================
 // figma.get_file
@@ -57,7 +58,7 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getFigmaConnector } = await import("../../connectors/figma.js");
     const connector = getFigmaConnector();
     const result = await connector.getFile(params.fileKey as string, {
@@ -65,7 +66,7 @@ registerTool({
       geometry: params.geometry === "paths" ? "paths" : undefined,
     });
     return JSON.stringify(result);
-  },
+  }),
 });
 
 // ============================================================================
@@ -96,12 +97,12 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getFigmaConnector } = await import("../../connectors/figma.js");
     const connector = getFigmaConnector();
     const result = await connector.getFileComments(params.fileKey as string);
     return JSON.stringify(result);
-  },
+  }),
 });
 
 // ============================================================================
@@ -133,12 +134,12 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getFigmaConnector } = await import("../../connectors/figma.js");
     const connector = getFigmaConnector();
     const result = await connector.listProjectFiles(params.projectId as string);
     return JSON.stringify(result);
-  },
+  }),
 });
 
 // ============================================================================
@@ -186,7 +187,7 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getFigmaConnector } = await import("../../connectors/figma.js");
     const connector = getFigmaConnector();
     const result = await connector.getImageUrls(params.fileKey as string, {
@@ -201,5 +202,5 @@ registerTool({
       scale: typeof params.scale === "number" ? params.scale : undefined,
     });
     return JSON.stringify(result);
-  },
+  }),
 });

--- a/src/recipes/tools/hubspot.ts
+++ b/src/recipes/tools/hubspot.ts
@@ -6,6 +6,7 @@
 
 import { assertWriteAllowed } from "../../featureFlags.js";
 import { CommonSchemas, registerTool } from "../toolRegistry.js";
+import { wrapConnectorExecute } from "./wrapConnectorExecute.js";
 
 // ============================================================================
 // hubspot.listContacts
@@ -41,7 +42,7 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getHubSpotConnector } = await import("../../connectors/hubspot.js");
     const connector = getHubSpotConnector();
     const result = await connector.listContacts({
@@ -49,7 +50,7 @@ registerTool({
       after: typeof params.after === "string" ? params.after : undefined,
     });
     return JSON.stringify(result);
-  },
+  }),
 });
 
 // ============================================================================
@@ -77,12 +78,12 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getHubSpotConnector } = await import("../../connectors/hubspot.js");
     const connector = getHubSpotConnector();
     const contact = await connector.getContact(params.contactId as string);
     return JSON.stringify({ contact });
-  },
+  }),
 });
 
 // ============================================================================
@@ -119,7 +120,7 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getHubSpotConnector } = await import("../../connectors/hubspot.js");
     const connector = getHubSpotConnector();
     const result = await connector.listDeals({
@@ -127,7 +128,7 @@ registerTool({
       stage: typeof params.stage === "string" ? params.stage : undefined,
     });
     return JSON.stringify(result);
-  },
+  }),
 });
 
 // ============================================================================
@@ -155,12 +156,12 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getHubSpotConnector } = await import("../../connectors/hubspot.js");
     const connector = getHubSpotConnector();
     const deal = await connector.getDeal(params.dealId as string);
     return JSON.stringify({ deal });
-  },
+  }),
 });
 
 // ============================================================================
@@ -198,7 +199,7 @@ registerTool({
   riskDefault: "medium",
   isWrite: true,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     assertWriteAllowed("hubspot.createNote");
     const { getHubSpotConnector } = await import("../../connectors/hubspot.js");
     const connector = getHubSpotConnector();
@@ -208,7 +209,7 @@ registerTool({
       typeof params.dealId === "string" ? params.dealId : undefined,
     );
     return JSON.stringify({ id: note.id, createdAt: note.createdAt });
-  },
+  }),
 });
 
 // ============================================================================
@@ -240,10 +241,10 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getHubSpotConnector } = await import("../../connectors/hubspot.js");
     const connector = getHubSpotConnector();
     const results = await connector.searchContacts(params.query as string);
     return JSON.stringify({ results, count: results.length });
-  },
+  }),
 });

--- a/src/recipes/tools/intercom.ts
+++ b/src/recipes/tools/intercom.ts
@@ -6,6 +6,7 @@
 
 import { assertWriteAllowed } from "../../featureFlags.js";
 import { CommonSchemas, registerTool } from "../toolRegistry.js";
+import { wrapConnectorExecute } from "./wrapConnectorExecute.js";
 
 // ============================================================================
 // intercom.listConversations
@@ -48,7 +49,7 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getIntercomConnector } = await import(
       "../../connectors/intercom.js"
     );
@@ -65,7 +66,7 @@ registerTool({
       perPage: typeof params.perPage === "number" ? params.perPage : 20,
     });
     return JSON.stringify(result);
-  },
+  }),
 });
 
 // ============================================================================
@@ -98,7 +99,7 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getIntercomConnector } = await import(
       "../../connectors/intercom.js"
     );
@@ -107,7 +108,7 @@ registerTool({
       params.conversationId as string,
     );
     return JSON.stringify(conversation);
-  },
+  }),
 });
 
 // ============================================================================
@@ -147,7 +148,7 @@ registerTool({
   riskDefault: "medium",
   isWrite: true,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     assertWriteAllowed("intercom.replyToConversation");
     const { getIntercomConnector } = await import(
       "../../connectors/intercom.js"
@@ -159,7 +160,7 @@ registerTool({
       (params.type as "comment" | "note" | undefined) ?? "comment",
     );
     return JSON.stringify({ id: conversation.id, state: conversation.state });
-  },
+  }),
 });
 
 // ============================================================================
@@ -191,7 +192,7 @@ registerTool({
   riskDefault: "medium",
   isWrite: true,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     assertWriteAllowed("intercom.closeConversation");
     const { getIntercomConnector } = await import(
       "../../connectors/intercom.js"
@@ -201,7 +202,7 @@ registerTool({
       params.conversationId as string,
     );
     return JSON.stringify({ id: conversation.id, state: conversation.state });
-  },
+  }),
 });
 
 // ============================================================================
@@ -248,7 +249,7 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getIntercomConnector } = await import(
       "../../connectors/intercom.js"
     );
@@ -258,5 +259,5 @@ registerTool({
       perPage: typeof params.perPage === "number" ? params.perPage : 20,
     });
     return JSON.stringify(result);
-  },
+  }),
 });

--- a/src/recipes/tools/notion.ts
+++ b/src/recipes/tools/notion.ts
@@ -6,6 +6,7 @@
 
 import { assertWriteAllowed } from "../../featureFlags.js";
 import { CommonSchemas, registerTool } from "../toolRegistry.js";
+import { wrapConnectorExecute } from "./wrapConnectorExecute.js";
 
 // ============================================================================
 // notion.queryDatabase
@@ -61,7 +62,7 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getNotionConnector } = await import("../../connectors/notion.js");
     const connector = getNotionConnector();
     const result = await connector.queryDatabase(
@@ -73,7 +74,7 @@ registerTool({
       typeof params.pageSize === "number" ? params.pageSize : 20,
     );
     return JSON.stringify({ ...result, count: result.results.length });
-  },
+  }),
 });
 
 // ============================================================================
@@ -109,12 +110,12 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getNotionConnector } = await import("../../connectors/notion.js");
     const connector = getNotionConnector();
     const page = await connector.getPage(params.pageId as string);
     return JSON.stringify(page);
-  },
+  }),
 });
 
 // ============================================================================
@@ -159,7 +160,7 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getNotionConnector } = await import("../../connectors/notion.js");
     const connector = getNotionConnector();
     const result = await connector.search(
@@ -168,7 +169,7 @@ registerTool({
       typeof params.pageSize === "number" ? params.pageSize : 10,
     );
     return JSON.stringify({ ...result, count: result.results.length });
-  },
+  }),
 });
 
 // ============================================================================
@@ -222,7 +223,7 @@ registerTool({
   riskDefault: "medium",
   isWrite: true,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     assertWriteAllowed("notion.createPage");
     const { getNotionConnector } = await import("../../connectors/notion.js");
     const connector = getNotionConnector();
@@ -239,7 +240,7 @@ registerTool({
       created_time: page.created_time,
       ok: true,
     });
-  },
+  }),
 });
 
 // ============================================================================
@@ -291,7 +292,7 @@ registerTool({
   riskDefault: "medium",
   isWrite: true,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     assertWriteAllowed("notion.appendBlock");
     const { getNotionConnector } = await import("../../connectors/notion.js");
     const connector = getNotionConnector();
@@ -303,5 +304,5 @@ registerTool({
       >[0]["blockType"],
     });
     return JSON.stringify({ ok: true, blockCount: result.results.length });
-  },
+  }),
 });

--- a/src/recipes/tools/obsidian.ts
+++ b/src/recipes/tools/obsidian.ts
@@ -14,6 +14,7 @@
  */
 
 import { CommonSchemas, registerTool } from "../toolRegistry.js";
+import { wrapConnectorExecute } from "./wrapConnectorExecute.js";
 
 // ============================================================================
 // obsidian.list_vault
@@ -49,7 +50,7 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getObsidianConnector } = await import(
       "../../connectors/obsidian.js"
     );
@@ -58,7 +59,7 @@ registerTool({
       typeof params.vaultPath === "string" ? params.vaultPath : undefined,
     );
     return JSON.stringify(result);
-  },
+  }),
 });
 
 // ============================================================================
@@ -87,14 +88,14 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getObsidianConnector } = await import(
       "../../connectors/obsidian.js"
     );
     const connector = getObsidianConnector();
     const result = await connector.readNote(params.notePath as string);
     return JSON.stringify(result);
-  },
+  }),
 });
 
 // ============================================================================
@@ -137,7 +138,7 @@ registerTool({
   riskDefault: "medium",
   isWrite: true,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getObsidianConnector } = await import(
       "../../connectors/obsidian.js"
     );
@@ -146,7 +147,7 @@ registerTool({
     const append = params.append === true;
     await connector.writeNote(notePath, params.content as string, append);
     return JSON.stringify({ ok: true, path: notePath, append });
-  },
+  }),
 });
 
 // ============================================================================
@@ -183,12 +184,12 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getObsidianConnector } = await import(
       "../../connectors/obsidian.js"
     );
     const connector = getObsidianConnector();
     const result = await connector.searchVault(params.query as string);
     return JSON.stringify(result);
-  },
+  }),
 });

--- a/src/recipes/tools/paystack.ts
+++ b/src/recipes/tools/paystack.ts
@@ -10,6 +10,7 @@
  */
 
 import { CommonSchemas, registerTool } from "../toolRegistry.js";
+import { wrapConnectorExecute } from "./wrapConnectorExecute.js";
 
 // ============================================================================
 // paystack.list_transactions
@@ -65,7 +66,7 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getPaystackConnector } = await import(
       "../../connectors/paystack.js"
     );
@@ -78,7 +79,7 @@ registerTool({
       status: typeof params.status === "string" ? params.status : undefined,
     });
     return JSON.stringify(result);
-  },
+  }),
 });
 
 // ============================================================================
@@ -117,7 +118,7 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getPaystackConnector } = await import(
       "../../connectors/paystack.js"
     );
@@ -126,7 +127,7 @@ registerTool({
       params.reference as string,
     );
     return JSON.stringify(result);
-  },
+  }),
 });
 
 // ============================================================================
@@ -165,14 +166,14 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getPaystackConnector } = await import(
       "../../connectors/paystack.js"
     );
     const connector = getPaystackConnector();
     const result = await connector.getTransaction(params.id as number);
     return JSON.stringify(result);
-  },
+  }),
 });
 
 // ============================================================================
@@ -216,7 +217,7 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getPaystackConnector } = await import(
       "../../connectors/paystack.js"
     );
@@ -226,5 +227,5 @@ registerTool({
       page: typeof params.page === "number" ? params.page : undefined,
     });
     return JSON.stringify(result);
-  },
+  }),
 });

--- a/src/recipes/tools/pipedrive.ts
+++ b/src/recipes/tools/pipedrive.ts
@@ -15,6 +15,7 @@
  */
 
 import { CommonSchemas, registerTool } from "../toolRegistry.js";
+import { wrapConnectorExecute } from "./wrapConnectorExecute.js";
 
 // ============================================================================
 // pipedrive.list_deals
@@ -65,7 +66,7 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getPipedriveConnector } = await import(
       "../../connectors/pipedrive.js"
     );
@@ -84,7 +85,7 @@ registerTool({
       limit: typeof params.limit === "number" ? params.limit : undefined,
     });
     return JSON.stringify(result);
-  },
+  }),
 });
 
 // ============================================================================
@@ -138,7 +139,7 @@ registerTool({
   riskDefault: "medium",
   isWrite: true,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getPipedriveConnector } = await import(
       "../../connectors/pipedrive.js"
     );
@@ -162,7 +163,7 @@ registerTool({
           : undefined,
     });
     return JSON.stringify(result);
-  },
+  }),
 });
 
 // ============================================================================
@@ -205,7 +206,7 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getPipedriveConnector } = await import(
       "../../connectors/pipedrive.js"
     );
@@ -215,7 +216,7 @@ registerTool({
       limit: typeof params.limit === "number" ? params.limit : undefined,
     });
     return JSON.stringify(result);
-  },
+  }),
 });
 
 // ============================================================================
@@ -250,12 +251,12 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async () => {
+  execute: wrapConnectorExecute(async () => {
     const { getPipedriveConnector } = await import(
       "../../connectors/pipedrive.js"
     );
     const connector = getPipedriveConnector();
     const result = await connector.getPipelines();
     return JSON.stringify(result);
-  },
+  }),
 });

--- a/src/recipes/tools/postgres.ts
+++ b/src/recipes/tools/postgres.ts
@@ -14,6 +14,7 @@
  */
 
 import { CommonSchemas, registerTool } from "../toolRegistry.js";
+import { wrapConnectorExecute } from "./wrapConnectorExecute.js";
 
 // ============================================================================
 // postgres.list_tables
@@ -48,7 +49,7 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getPostgresConnector } = await import(
       "../../connectors/postgres.js"
     );
@@ -57,7 +58,7 @@ registerTool({
       typeof params.schema === "string" ? params.schema : undefined,
     );
     return JSON.stringify(result);
-  },
+  }),
 });
 
 // ============================================================================
@@ -99,7 +100,7 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getPostgresConnector } = await import(
       "../../connectors/postgres.js"
     );
@@ -109,7 +110,7 @@ registerTool({
       typeof params.schema === "string" ? params.schema : undefined,
     );
     return JSON.stringify(result);
-  },
+  }),
 });
 
 // ============================================================================
@@ -164,7 +165,7 @@ registerTool({
   riskDefault: "medium",
   isWrite: true,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getPostgresConnector } = await import(
       "../../connectors/postgres.js"
     );
@@ -175,7 +176,7 @@ registerTool({
       typeof params.rowLimit === "number" ? params.rowLimit : undefined,
     );
     return JSON.stringify(result);
-  },
+  }),
 });
 
 // ============================================================================
@@ -204,12 +205,12 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getPostgresConnector } = await import(
       "../../connectors/postgres.js"
     );
     const connector = getPostgresConnector();
     const result = await connector.explain(params.sql as string);
     return JSON.stringify(result);
-  },
+  }),
 });

--- a/src/recipes/tools/redis.ts
+++ b/src/recipes/tools/redis.ts
@@ -8,6 +8,7 @@
  */
 
 import { CommonSchemas, registerTool } from "../toolRegistry.js";
+import { wrapConnectorExecute } from "./wrapConnectorExecute.js";
 
 // ============================================================================
 // redis.get
@@ -33,12 +34,12 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getRedisConnector } = await import("../../connectors/redis.js");
     const connector = getRedisConnector();
     const result = await connector.get(params.key as string);
     return JSON.stringify(result);
-  },
+  }),
 });
 
 // ============================================================================
@@ -74,7 +75,7 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getRedisConnector } = await import("../../connectors/redis.js");
     const connector = getRedisConnector();
     const result = await connector.keys(
@@ -82,7 +83,7 @@ registerTool({
       typeof params.limit === "number" ? params.limit : undefined,
     );
     return JSON.stringify(result);
-  },
+  }),
 });
 
 // ============================================================================
@@ -110,12 +111,12 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getRedisConnector } = await import("../../connectors/redis.js");
     const connector = getRedisConnector();
     const result = await connector.hgetall(params.key as string);
     return JSON.stringify(result);
-  },
+  }),
 });
 
 // ============================================================================
@@ -147,12 +148,12 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getRedisConnector } = await import("../../connectors/redis.js");
     const connector = getRedisConnector();
     const result = await connector.info(
       typeof params.section === "string" ? params.section : undefined,
     );
     return JSON.stringify(result);
-  },
+  }),
 });

--- a/src/recipes/tools/shopify.ts
+++ b/src/recipes/tools/shopify.ts
@@ -15,6 +15,7 @@
  */
 
 import { CommonSchemas, registerTool } from "../toolRegistry.js";
+import { wrapConnectorExecute } from "./wrapConnectorExecute.js";
 
 // ============================================================================
 // shopify.list_products
@@ -75,7 +76,7 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getShopifyConnector } = await import("../../connectors/shopify.js");
     const connector = getShopifyConnector();
     const result = await connector.listProducts({
@@ -86,7 +87,7 @@ registerTool({
         typeof params.productType === "string" ? params.productType : undefined,
     });
     return JSON.stringify(result);
-  },
+  }),
 });
 
 // ============================================================================
@@ -153,7 +154,7 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getShopifyConnector } = await import("../../connectors/shopify.js");
     const connector = getShopifyConnector();
     const result = await connector.listOrders({
@@ -169,7 +170,7 @@ registerTool({
           : undefined,
     });
     return JSON.stringify(result);
-  },
+  }),
 });
 
 // ============================================================================
@@ -211,12 +212,12 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getShopifyConnector } = await import("../../connectors/shopify.js");
     const connector = getShopifyConnector();
     const result = await connector.getOrder(params.orderId as string | number);
     return JSON.stringify(result);
-  },
+  }),
 });
 
 // ============================================================================
@@ -271,7 +272,7 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getShopifyConnector } = await import("../../connectors/shopify.js");
     const connector = getShopifyConnector();
     const result = await connector.listCustomers({
@@ -279,5 +280,5 @@ registerTool({
       query: typeof params.query === "string" ? params.query : undefined,
     });
     return JSON.stringify(result);
-  },
+  }),
 });

--- a/src/recipes/tools/supabase.ts
+++ b/src/recipes/tools/supabase.ts
@@ -8,6 +8,7 @@
  */
 
 import { CommonSchemas, registerTool } from "../toolRegistry.js";
+import { wrapConnectorExecute } from "./wrapConnectorExecute.js";
 
 // ============================================================================
 // supabase.list_files
@@ -56,7 +57,7 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getSupabaseConnector } = await import(
       "../../connectors/supabase.js"
     );
@@ -67,7 +68,7 @@ registerTool({
       typeof params.limit === "number" ? params.limit : undefined,
     );
     return JSON.stringify(result);
-  },
+  }),
 });
 
 // ============================================================================
@@ -92,14 +93,14 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async () => {
+  execute: wrapConnectorExecute(async () => {
     const { getSupabaseConnector } = await import(
       "../../connectors/supabase.js"
     );
     const connector = getSupabaseConnector();
     const result = await connector.getSchema();
     return JSON.stringify(result);
-  },
+  }),
 });
 
 // ============================================================================
@@ -141,7 +142,7 @@ registerTool({
   riskDefault: "medium",
   isWrite: true,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getSupabaseConnector } = await import(
       "../../connectors/supabase.js"
     );
@@ -153,5 +154,5 @@ registerTool({
       typeof params.contentType === "string" ? params.contentType : undefined,
     );
     return JSON.stringify(result);
-  },
+  }),
 });

--- a/src/recipes/tools/todoist.ts
+++ b/src/recipes/tools/todoist.ts
@@ -14,6 +14,7 @@
  */
 
 import { CommonSchemas, registerTool } from "../toolRegistry.js";
+import { wrapConnectorExecute } from "./wrapConnectorExecute.js";
 
 // ============================================================================
 // todoist.list_tasks
@@ -72,7 +73,7 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getTodoistConnector } = await import("../../connectors/todoist.js");
     const connector = getTodoistConnector();
     const result = await connector.getTasks(
@@ -81,7 +82,7 @@ registerTool({
       typeof params.limit === "number" ? params.limit : undefined,
     );
     return JSON.stringify(result);
-  },
+  }),
 });
 
 // ============================================================================
@@ -149,7 +150,7 @@ registerTool({
   riskDefault: "medium",
   isWrite: true,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getTodoistConnector } = await import("../../connectors/todoist.js");
     const connector = getTodoistConnector();
     const result = await connector.createTask(
@@ -161,7 +162,7 @@ registerTool({
       Array.isArray(params.labels) ? (params.labels as string[]) : undefined,
     );
     return JSON.stringify(result);
-  },
+  }),
 });
 
 // ============================================================================
@@ -194,7 +195,7 @@ registerTool({
   riskDefault: "medium",
   isWrite: true,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getTodoistConnector } = await import("../../connectors/todoist.js");
     const connector = getTodoistConnector();
     const id = params.id as string;
@@ -203,7 +204,7 @@ registerTool({
     // satisfies the `string | null` execute contract and downstream
     // `{{steps.x.ok}}` references stay coherent.
     return JSON.stringify({ ok: true, id });
-  },
+  }),
 });
 
 // ============================================================================
@@ -242,10 +243,10 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async () => {
+  execute: wrapConnectorExecute(async () => {
     const { getTodoistConnector } = await import("../../connectors/todoist.js");
     const connector = getTodoistConnector();
     const result = await connector.getProjects();
     return JSON.stringify(result);
-  },
+  }),
 });

--- a/src/recipes/tools/vercel.ts
+++ b/src/recipes/tools/vercel.ts
@@ -8,6 +8,7 @@
  */
 
 import { CommonSchemas, registerTool } from "../toolRegistry.js";
+import { wrapConnectorExecute } from "./wrapConnectorExecute.js";
 
 // ============================================================================
 // vercel.list_deployments
@@ -56,7 +57,7 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getVercelConnector } = await import("../../connectors/vercel.js");
     const connector = getVercelConnector();
     const result = await connector.listDeployments({
@@ -66,7 +67,7 @@ registerTool({
       state: typeof params.state === "string" ? params.state : undefined,
     });
     return JSON.stringify(result);
-  },
+  }),
 });
 
 // ============================================================================
@@ -100,12 +101,12 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getVercelConnector } = await import("../../connectors/vercel.js");
     const connector = getVercelConnector();
     const result = await connector.getDeployment(params.id as string);
     return JSON.stringify(result);
-  },
+  }),
 });
 
 // ============================================================================
@@ -143,12 +144,12 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getVercelConnector } = await import("../../connectors/vercel.js");
     const connector = getVercelConnector();
     const result = await connector.listProjects({
       limit: typeof params.limit === "number" ? params.limit : undefined,
     });
     return JSON.stringify(result);
-  },
+  }),
 });

--- a/src/recipes/tools/webflow.ts
+++ b/src/recipes/tools/webflow.ts
@@ -10,6 +10,7 @@
  */
 
 import { CommonSchemas, registerTool } from "../toolRegistry.js";
+import { wrapConnectorExecute } from "./wrapConnectorExecute.js";
 
 // ============================================================================
 // webflow.list_sites
@@ -56,12 +57,12 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async () => {
+  execute: wrapConnectorExecute(async () => {
     const { getWebflowConnector } = await import("../../connectors/webflow.js");
     const connector = getWebflowConnector();
     const result = await connector.listSites();
     return JSON.stringify(result);
-  },
+  }),
 });
 
 // ============================================================================
@@ -110,12 +111,12 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getWebflowConnector } = await import("../../connectors/webflow.js");
     const connector = getWebflowConnector();
     const result = await connector.listCollections(params.siteId as string);
     return JSON.stringify(result);
-  },
+  }),
 });
 
 // ============================================================================
@@ -175,7 +176,7 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getWebflowConnector } = await import("../../connectors/webflow.js");
     const connector = getWebflowConnector();
     const result = await connector.listCollectionItems(
@@ -186,7 +187,7 @@ registerTool({
       },
     );
     return JSON.stringify(result);
-  },
+  }),
 });
 
 // ============================================================================
@@ -245,7 +246,7 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getWebflowConnector } = await import("../../connectors/webflow.js");
     const connector = getWebflowConnector();
     const result = await connector.listFormSubmissions(
@@ -256,5 +257,5 @@ registerTool({
       },
     );
     return JSON.stringify(result);
-  },
+  }),
 });

--- a/src/recipes/tools/woocommerce.ts
+++ b/src/recipes/tools/woocommerce.ts
@@ -17,6 +17,7 @@
  */
 
 import { CommonSchemas, registerTool } from "../toolRegistry.js";
+import { wrapConnectorExecute } from "./wrapConnectorExecute.js";
 
 // ============================================================================
 // woocommerce.list_orders
@@ -80,7 +81,7 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getWooCommerceConnector } = await import(
       "../../connectors/woocommerce.js"
     );
@@ -93,7 +94,7 @@ registerTool({
       before: typeof params.before === "string" ? params.before : undefined,
     });
     return JSON.stringify(result);
-  },
+  }),
 });
 
 // ============================================================================
@@ -136,14 +137,14 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getWooCommerceConnector } = await import(
       "../../connectors/woocommerce.js"
     );
     const connector = getWooCommerceConnector();
     const result = await connector.getOrder(params.id as number);
     return JSON.stringify(result);
-  },
+  }),
 });
 
 // ============================================================================
@@ -205,7 +206,7 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getWooCommerceConnector } = await import(
       "../../connectors/woocommerce.js"
     );
@@ -218,7 +219,7 @@ registerTool({
         typeof params.category === "string" ? params.category : undefined,
     });
     return JSON.stringify(result);
-  },
+  }),
 });
 
 // ============================================================================
@@ -269,7 +270,7 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getWooCommerceConnector } = await import(
       "../../connectors/woocommerce.js"
     );
@@ -280,5 +281,5 @@ registerTool({
       page: typeof params.page === "number" ? params.page : undefined,
     });
     return JSON.stringify(result);
-  },
+  }),
 });

--- a/src/recipes/tools/zendesk.ts
+++ b/src/recipes/tools/zendesk.ts
@@ -6,6 +6,7 @@
 
 import { assertWriteAllowed } from "../../featureFlags.js";
 import { CommonSchemas, registerTool } from "../toolRegistry.js";
+import { wrapConnectorExecute } from "./wrapConnectorExecute.js";
 
 // ============================================================================
 // zendesk.listTickets
@@ -52,7 +53,7 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getZendeskConnector } = await import("../../connectors/zendesk.js");
     const connector = getZendeskConnector();
     const result = await connector.listTickets({
@@ -70,7 +71,7 @@ registerTool({
       perPage: typeof params.perPage === "number" ? params.perPage : 25,
     });
     return JSON.stringify(result);
-  },
+  }),
 });
 
 // ============================================================================
@@ -104,7 +105,7 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getZendeskConnector } = await import("../../connectors/zendesk.js");
     const connector = getZendeskConnector();
     const ticketId = params.ticketId as number;
@@ -115,7 +116,7 @@ registerTool({
         : Promise.resolve([]),
     ]);
     return JSON.stringify({ ticket, comments });
-  },
+  }),
 });
 
 // ============================================================================
@@ -152,7 +153,7 @@ registerTool({
   riskDefault: "medium",
   isWrite: true,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     assertWriteAllowed("zendesk.addComment");
     const { getZendeskConnector } = await import("../../connectors/zendesk.js");
     const connector = getZendeskConnector();
@@ -166,7 +167,7 @@ registerTool({
       status: ticket.status,
       updated_at: ticket.updated_at,
     });
-  },
+  }),
 });
 
 // ============================================================================
@@ -201,7 +202,7 @@ registerTool({
   riskDefault: "medium",
   isWrite: true,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     assertWriteAllowed("zendesk.updateStatus");
     const { getZendeskConnector } = await import("../../connectors/zendesk.js");
     const connector = getZendeskConnector();
@@ -220,7 +221,7 @@ registerTool({
       status: ticket.status,
       updated_at: ticket.updated_at,
     });
-  },
+  }),
 });
 
 // ============================================================================
@@ -270,7 +271,7 @@ registerTool({
   riskDefault: "low",
   isWrite: false,
   isConnector: true,
-  execute: async ({ params }) => {
+  execute: wrapConnectorExecute(async ({ params }) => {
     const { getZendeskConnector } = await import("../../connectors/zendesk.js");
     const connector = getZendeskConnector();
     const users = await connector.listUsers(
@@ -278,5 +279,5 @@ registerTool({
       typeof params.perPage === "number" ? params.perPage : 50,
     );
     return JSON.stringify({ users, count: users.length });
-  },
+  }),
 });


### PR DESCRIPTION
## What

Closes the **#4 ranked MED** cluster (connector-tools-1/2/3) from the 2026-06-09 audit — the one with **live production evidence**: the bridge's own last-12h halt summary showed `tool_error` as the **top halt category**.

~21 connector recipe-tool files had **no try/catch** and did **not** use `wrapConnectorExecute`. Any connector throw — missing token, network failure, 429 rate-limit, auth failure — propagated uncaught, so the recipe runner hard-halted the **entire run** with `tool_threw` instead of returning the soft `{ ok:false, error }` envelope its non-fatal path (optional step / `on_error.fallback`) expects.

## Fix

Swept the **whole class**, not just the 3 cited files. Wrapped all **89 `execute` sites** across these 21 files with the existing `wrapConnectorExecute` helper — the exact pattern twilio / stripe / circleci / snowflake / airtable / salesforce already use:

`caldiy, confluence, datadog, docs, elasticsearch, figma, hubspot, intercom, notion, obsidian, paystack, pipedrive, postgres, redis, shopify, supabase, todoist, vercel, webflow, woocommerce, zendesk`

Success paths are byte-identical; only thrown errors become the envelope.

### Why per-site and not a central wrap in `executeTool`?

A central wrap would convert a write tool's throw into a *returned* value, which the write-idempotency ledger (`executeTool` → `writeEffectLedger.getOrExecute`) would then **record** — breaking its "errors are NOT recorded → retry-after-failure re-executes" invariant. The per-site helper is the established, audit-endorsed pattern and keeps that boundary intact.

## Tests

- `shopify.list_products` now asserts a connector throw → `{ ok:false, error }` rather than propagating.
- Full recipe-tools suite (282 tests) green; `tests:core` tsc + fixture/lsp audits green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)