### PR TITLE
fix(recipes): accept 6-field cron + orchestrator dispatch timeout (audit 2026-06-09 #8)

### DIFF
--- a/src/recipes/RecipeOrchestrator.ts
+++ b/src/recipes/RecipeOrchestrator.ts
@@ -39,15 +39,28 @@ export interface FireDeps {
     deps: RunnerDeps,
     seedContext?: Record<string, string>,
   ) => Promise<RunResult | ChainedRunResult>;
+  /**
+   * Safety-net TTL (ms) for the in-flight dedup entry. If a dispatch promise
+   * never settles (a tool step hangs with no timeout_ms), the entry would
+   * otherwise be stuck forever, permanently rejecting every future fire() for
+   * that recipe with `already_in_flight` (audit 2026-06-09 orch-hang-1). When
+   * the timer fires, the slot is freed so the recipe can run again. Default
+   * 30 min. Set to 0 to disable.
+   */
+  dispatchTimeoutMs?: number;
   logger?: Logger;
 }
 
 type ResolvedFireDeps = Required<Omit<FireDeps, "logger">> &
   Pick<FireDeps, "logger">;
 
+const DEFAULT_DISPATCH_TIMEOUT_MS = 30 * 60_000;
+
 export class RecipeOrchestrator {
   private readonly inFlight = new Set<string>();
+  private readonly inFlightTimers = new Map<string, NodeJS.Timeout>();
   private readonly fireDeps: ResolvedFireDeps;
+  private readonly dispatchTimeoutMs: number;
 
   constructor(
     private readonly deps: RunnerDeps,
@@ -56,8 +69,21 @@ export class RecipeOrchestrator {
     this.fireDeps = {
       loadYamlRecipe: fireDeps.loadYamlRecipe ?? defaultLoadYamlRecipe,
       dispatchFn: fireDeps.dispatchFn ?? dispatchRecipe,
+      dispatchTimeoutMs:
+        fireDeps.dispatchTimeoutMs ?? DEFAULT_DISPATCH_TIMEOUT_MS,
       logger: fireDeps.logger,
     };
+    this.dispatchTimeoutMs = this.fireDeps.dispatchTimeoutMs;
+  }
+
+  /** Free the in-flight slot for `name` and clear any pending safety timer. */
+  private clearInFlight(name: string): void {
+    this.inFlight.delete(name);
+    const timer = this.inFlightTimers.get(name);
+    if (timer !== undefined) {
+      clearTimeout(timer);
+      this.inFlightTimers.delete(name);
+    }
   }
 
   run(
@@ -87,9 +113,25 @@ export class RecipeOrchestrator {
     const taskId = `${name}-${Date.now()}`;
     this.inFlight.add(name);
 
+    // Safety net: if the dispatch promise never settles (a hung tool step),
+    // free the slot after the TTL so future fires aren't permanently rejected.
+    if (this.dispatchTimeoutMs > 0) {
+      const timer = setTimeout(() => {
+        if (this.inFlight.has(name)) {
+          this.fireDeps.logger?.warn?.(
+            `[orchestrator] recipe "${name}" dispatch exceeded ${this.dispatchTimeoutMs}ms — clearing in-flight slot (run may still be running)`,
+          );
+          this.clearInFlight(name);
+        }
+      }, this.dispatchTimeoutMs);
+      // Don't keep the process alive just for the safety timer.
+      timer.unref?.();
+      this.inFlightTimers.set(name, timer);
+    }
+
     dispatch(recipe, this.deps, seedContext)
       .finally(() => {
-        this.inFlight.delete(name);
+        this.clearInFlight(name);
       })
       .catch((err: unknown) => {
         this.fireDeps.logger?.warn?.(

--- a/src/recipes/__tests__/RecipeOrchestrator.fire.test.ts
+++ b/src/recipes/__tests__/RecipeOrchestrator.fire.test.ts
@@ -372,4 +372,52 @@ describe("RecipeOrchestrator.fire()", () => {
 
     d2.resolve(makeRunResult());
   });
+
+  it("frees the in-flight slot after dispatchTimeoutMs when dispatch never settles (audit 2026-06-09 orch-hang-1)", async () => {
+    vi.useFakeTimers();
+    try {
+      const recipe = makeYamlRecipe("hang-recipe");
+      const loadYamlRecipe = vi.fn().mockReturnValue(recipe);
+      // Dispatch promise that NEVER settles — simulates a hung tool step.
+      const dispatchFn = vi
+        .fn()
+        .mockReturnValue(new Promise<RunResult>(() => {}));
+
+      const orchestrator = new RecipeOrchestrator(baseDeps(), {
+        loadYamlRecipe,
+        dispatchFn,
+        dispatchTimeoutMs: 1000,
+      });
+
+      const first = await orchestrator.fire({
+        filePath: "/recipes/hang-recipe.yaml",
+        name: "hang-recipe",
+        triggerSource: "test",
+      });
+      expect(first).toMatchObject({ ok: true });
+      expect(orchestrator.isInFlight("hang-recipe")).toBe(true);
+
+      // Before the TTL elapses, a second fire is still rejected.
+      const blocked = await orchestrator.fire({
+        filePath: "/recipes/hang-recipe.yaml",
+        name: "hang-recipe",
+        triggerSource: "test",
+      });
+      expect(blocked).toMatchObject({ ok: false, error: "already_in_flight" });
+
+      // After the TTL, the safety net frees the slot.
+      vi.advanceTimersByTime(1000);
+      expect(orchestrator.isInFlight("hang-recipe")).toBe(false);
+
+      const retried = await orchestrator.fire({
+        filePath: "/recipes/hang-recipe.yaml",
+        name: "hang-recipe",
+        triggerSource: "test",
+      });
+      expect(retried).toMatchObject({ ok: true });
+      expect(dispatchFn).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/src/recipes/__tests__/scheduler.test.ts
+++ b/src/recipes/__tests__/scheduler.test.ts
@@ -34,12 +34,25 @@ describe("parseSchedule", () => {
   });
 
   it.each([
+    ["0 0 8 * * 1-5"], // every weekday 08:00:00 (seconds field)
+    ["*/30 * * * * *"], // every 30 seconds
+  ])("parses 6-field cron expression %s (audit 2026-06-09 sched-cron6-1)", (input) => {
+    const result = parseSchedule(input);
+    expect(result).not.toBeNull();
+    expect(result?.kind).toBe("cron5");
+    expect((result as { kind: "cron5"; expression: string }).expression).toBe(
+      input.trim(),
+    );
+  });
+
+  it.each([
     "",
     "@every 0s",
     "@every -1m",
     "every 5m",
     "@every 5",
     "@every 5d",
+    "0 0 8 * * 1-5 7", // 7 fields — too many
   ])("rejects unsupported schedule %s", (input) => {
     expect(parseSchedule(input)).toBeNull();
   });

--- a/src/recipes/scheduler.ts
+++ b/src/recipes/scheduler.ts
@@ -447,8 +447,12 @@ export function parseSchedule(schedule: string): ParsedSchedule | null {
     return { kind: "interval", intervalMs: n * multiplier };
   }
 
-  // 5-field cron expression (e.g. "0 8 * * 1-5")
-  if (/^\S+\s+\S+\s+\S+\s+\S+\s+\S+$/.test(trimmed)) {
+  // 5- or 6-field cron expression. node-cron accepts an optional leading
+  // seconds field (e.g. "0 0 8 * * 1-5" = every weekday 08:00:00), so accept
+  // both lengths and let cron.validate() decide correctness — previously a
+  // 6-field expression passed cron.validate() but was rejected here, silently
+  // never scheduling the recipe (audit 2026-06-09 sched-cron6-1).
+  if (/^\S+(?:\s+\S+){4,5}$/.test(trimmed)) {
     if (cron.validate(trimmed)) {
       return { kind: "cron5", expression: trimmed };
     }


### PR DESCRIPTION
## What

Two recipe-scheduling reliability findings (#8 in the audit ranking).

### sched-cron6-1 — 6-field cron silently never scheduled
`parseSchedule`'s regex required **exactly 5** cron fields. node-cron supports an optional leading **seconds** field (e.g. `0 0 8 * * 1-5` = every weekday 08:00:00), so a 6-field expression passed `cron.validate()` but was rejected by the regex first → `parseSchedule` returned `null`, the scheduler logged a generic "unsupported schedule" warning, and **the recipe was never scheduled** with no hint that the field count was the problem.

**Fix:** regex now accepts 5 **or** 6 fields and lets `cron.validate()` judge correctness.

### orch-hang-1 — hung dispatch permanently blocks future fires
`RecipeOrchestrator.fire()` added the recipe to `inFlight` and only removed it in the dispatch promise's `.finally()`. If a dispatched run hangs forever (a tool step with no `timeout_ms`), the entry was never cleared, so **every future `fire()` returned `already_in_flight` permanently** — cron/webhook/CLI runs for that recipe silently rejected until bridge restart.

**Fix:** a configurable `dispatchTimeoutMs` safety net (default 30 min, `unref`'d) frees the slot if dispatch never settles. The `.finally()` clears both the entry and the timer on normal completion.

## Tests (test-first)

- 6-field cron parses; 7-field rejected.
- A never-settling dispatch is still deduped before the TTL, then the slot is freed after `dispatchTimeoutMs` and a subsequent `fire()` succeeds.
- 49 scheduler + orchestrator tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)