### PR TITLE
fix(tokenStorage): guard Linux secret-tool sinks with keychain allowlist (audit 2026-06-09 pr949-1)

### DIFF
--- a/src/connectors/__tests__/tokenStorage.linux-allowlist.test.ts
+++ b/src/connectors/__tests__/tokenStorage.linux-allowlist.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Audit 2026-06-09 pr949-1 — the isValidKeychainKey allowlist guard
+ * (code-scanning #135) was added to the macOS keychain sinks in PR #949 but the
+ * three Linux secret-tool sinks were left unguarded, leaving the taint path
+ * asymmetric across platforms. These tests assert the Linux sinks now reject an
+ * invalid key BEFORE spawning `secret-tool`, deterministically on any OS.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:child_process")>();
+  return {
+    ...actual,
+    spawnSync: vi.fn(() => ({
+      pid: 1,
+      output: [null, Buffer.from(""), Buffer.from("")],
+      stdout: Buffer.from(""),
+      stderr: Buffer.from(""),
+      status: 0,
+      signal: null,
+    })),
+  };
+});
+
+import { spawnSync } from "node:child_process";
+import {
+  deleteLinuxSecretSync,
+  getLinuxSecretSync,
+  setLinuxSecretSync,
+} from "../tokenStorage.js";
+
+afterEach(() => vi.mocked(spawnSync).mockClear());
+
+const BAD_KEYS = [
+  "patchwork-os.foo; rm -rf .",
+  "patchwork-os.$(whoami)",
+  "patchwork-os.a b",
+  "patchwork-os.a|b",
+  "patchwork-os.a\nb",
+  "",
+];
+
+describe("Linux secret-tool sinks reject invalid keys before spawning (audit pr949-1)", () => {
+  it("setLinuxSecretSync returns false and never spawns secret-tool", () => {
+    for (const bad of BAD_KEYS) {
+      expect(setLinuxSecretSync(bad, "value"), bad).toBe(false);
+    }
+    expect(vi.mocked(spawnSync)).not.toHaveBeenCalled();
+  });
+
+  it("getLinuxSecretSync returns null and never spawns secret-tool", () => {
+    for (const bad of BAD_KEYS) {
+      expect(getLinuxSecretSync(bad), bad).toBeNull();
+    }
+    expect(vi.mocked(spawnSync)).not.toHaveBeenCalled();
+  });
+
+  it("deleteLinuxSecretSync returns false and never spawns secret-tool", () => {
+    for (const bad of BAD_KEYS) {
+      expect(deleteLinuxSecretSync(bad), bad).toBe(false);
+    }
+    expect(vi.mocked(spawnSync)).not.toHaveBeenCalled();
+  });
+
+  it("a valid key IS allowed through to secret-tool", () => {
+    setLinuxSecretSync("patchwork-os.github", "value");
+    expect(vi.mocked(spawnSync)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(spawnSync).mock.calls[0]?.[0]).toBe("secret-tool");
+  });
+});

--- a/src/connectors/tokenStorage.ts
+++ b/src/connectors/tokenStorage.ts
@@ -596,7 +596,14 @@ function listKeychainItems(): string[] {
 }
 
 // Linux Secret Service
-function setLinuxSecretSync(key: string, value: string): boolean {
+//
+// Same isValidKeychainKey allowlist guard as the macOS sinks (code-scanning
+// #135). secret-tool takes the key as a positional arg, not a shell string, so
+// the risk is lower — but PR #949 only guarded the macOS branch, leaving the
+// Linux path asymmetric (audit 2026-06-09 pr949-1). Guard all three sinks for
+// defence-in-depth so the taint path is provably sanitised on every platform.
+export function setLinuxSecretSync(key: string, value: string): boolean {
+  if (!isValidKeychainKey(key)) return false;
   try {
     const result = spawnSync(
       "secret-tool",
@@ -609,7 +616,8 @@ function setLinuxSecretSync(key: string, value: string): boolean {
   }
 }
 
-function getLinuxSecretSync(key: string): string | null {
+export function getLinuxSecretSync(key: string): string | null {
+  if (!isValidKeychainKey(key)) return null;
   try {
     const result = spawnSync(
       "secret-tool",
@@ -625,7 +633,8 @@ function getLinuxSecretSync(key: string): string | null {
   }
 }
 
-function deleteLinuxSecretSync(key: string): boolean {
+export function deleteLinuxSecretSync(key: string): boolean {
+  if (!isValidKeychainKey(key)) return false;
   try {
     const result = spawnSync(
       "secret-tool",


### PR DESCRIPTION
## What

Part of the **#10 "finish the incomplete fixes"** batch (pr949-1).

PR #949 added the `isValidKeychainKey` allowlist guard (code-scanning #135, CWE-78/88) to the three **macOS** keychain spawn sinks but left the three **Linux** `secret-tool` sinks (`set`/`get`/`deleteLinuxSecretSync`) unguarded — an asymmetric, incomplete class fix. `secret-tool` takes the key as a positional arg (not a shell string) so the risk is lower, but the taint path stayed live on Linux.

## Fix

Added the same `if (!isValidKeychainKey(key)) return …` guard to all three Linux sinks. Exported them so the guard can be tested directly and deterministically on any OS.

## Tests (test-first)

A mocked `spawnSync` confirms invalid keys (shell metacharacters, newline, empty) are rejected **before** `secret-tool` is spawned, and a valid key still passes through. Verified the test fails without the guard. 7 tests green (incl. the existing macOS allowlist suite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)