### PR TITLE
fix: byte-accurate UTF-8 caps at 3 UTF-16-counting sites (audit 2026-06-09 #10)

### DIFF
--- a/src/claudeDriver.ts
+++ b/src/claudeDriver.ts
@@ -552,7 +552,10 @@ export class SubprocessDriver implements IClaudeDriver {
     // orchestrator can set cancelReason: "startup_timeout".
     if (startupTimedOut) {
       return {
-        text: accumulated.slice(0, OUTPUT_CAP),
+        // Byte-accurate cap like every other return site in this driver — slice
+        // counts UTF-16 code units and would over-store CJK output (audit
+        // 2026-06-09 orch-driver-6).
+        text: truncateUtf8Bytes(accumulated, OUTPUT_CAP),
         exitCode: -1,
         durationMs: Date.now() - start,
         stderrTail: stderrTailOf(stderr),

--- a/src/recipeOrchestration.ts
+++ b/src/recipeOrchestration.ts
@@ -10,6 +10,7 @@ import { basename, extname, join } from "node:path";
 import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
 import { recordRecipeRun } from "./activationMetrics.js";
 import type { ClaudeOrchestrator } from "./claudeOrchestrator.js";
+import { truncateUtf8Bytes } from "./drivers/outputCap.js";
 import { loadConfig } from "./patchworkConfig.js";
 import { getConfigDisabledNames } from "./recipes/disabledMarkers.js";
 import { summariseHalts } from "./recipes/haltCategory.js";
@@ -641,13 +642,16 @@ export class RecipeOrchestration {
       // dashboard distinguish "model produced 2 MB of garbage" from
       // "model emitted a 4 KB recipe".
       const truncationWarnings: string[] = [];
+      // Byte-accurate cap: task.output.length counts UTF-16 code units, but the
+      // cap is named/intended in bytes (audit 2026-06-09 orch-driver-5).
+      const outputBytes = Buffer.byteLength(task.output, "utf8");
       const cappedOutput =
-        task.output.length > MAX_MODEL_OUTPUT_BYTES
-          ? task.output.slice(0, MAX_MODEL_OUTPUT_BYTES)
+        outputBytes > MAX_MODEL_OUTPUT_BYTES
+          ? truncateUtf8Bytes(task.output, MAX_MODEL_OUTPUT_BYTES)
           : task.output;
-      if (task.output.length > MAX_MODEL_OUTPUT_BYTES) {
+      if (outputBytes > MAX_MODEL_OUTPUT_BYTES) {
         truncationWarnings.push(
-          `Model output exceeded ${MAX_MODEL_OUTPUT_BYTES}-byte cap (was ${task.output.length} bytes); truncated before parse. Regenerate with a shorter prompt if the recipe was cut off.`,
+          `Model output exceeded ${MAX_MODEL_OUTPUT_BYTES}-byte cap (was ${outputBytes} bytes); truncated before parse. Regenerate with a shorter prompt if the recipe was cut off.`,
         );
       }
 
@@ -810,13 +814,16 @@ export class RecipeOrchestration {
       }
 
       const truncationWarnings: string[] = [];
+      // Byte-accurate cap: task.output.length counts UTF-16 code units, but the
+      // cap is named/intended in bytes (audit 2026-06-09 orch-driver-5).
+      const outputBytes = Buffer.byteLength(task.output, "utf8");
       const cappedOutput =
-        task.output.length > MAX_MODEL_OUTPUT_BYTES
-          ? task.output.slice(0, MAX_MODEL_OUTPUT_BYTES)
+        outputBytes > MAX_MODEL_OUTPUT_BYTES
+          ? truncateUtf8Bytes(task.output, MAX_MODEL_OUTPUT_BYTES)
           : task.output;
-      if (task.output.length > MAX_MODEL_OUTPUT_BYTES) {
+      if (outputBytes > MAX_MODEL_OUTPUT_BYTES) {
         truncationWarnings.push(
-          `Model output exceeded ${MAX_MODEL_OUTPUT_BYTES}-byte cap (was ${task.output.length} bytes); truncated before parse.`,
+          `Model output exceeded ${MAX_MODEL_OUTPUT_BYTES}-byte cap (was ${outputBytes} bytes); truncated before parse.`,
         );
       }
 

--- a/src/tools/__tests__/ctxGetTaskContext.test.ts
+++ b/src/tools/__tests__/ctxGetTaskContext.test.ts
@@ -143,6 +143,36 @@ describe("ctxGetTaskContext — issue flow", () => {
     expect(res.warnings).toEqual([]);
   });
 
+  it("caps the issue body by BYTES, not UTF-16 length (audit 2026-06-09 tools-ctx-1)", async () => {
+    // 400 CJK chars = 400 UTF-16 code units but 1200 UTF-8 bytes. The old
+    // raw.length check (400 <= 500) would NOT truncate, returning ~1200 bytes —
+    // 2-3x the intended 500-byte context budget.
+    const cjkBody = "あ".repeat(400);
+    mockExec
+      .mockResolvedValueOnce(ok("gh version 2")) // gh --version
+      .mockResolvedValueOnce(ok(".git")) // git rev-parse
+      .mockResolvedValueOnce(
+        ok(
+          JSON.stringify({
+            number: 7,
+            title: "CJK body",
+            state: "OPEN",
+            url: "https://gh/issues/7",
+            body: cjkBody,
+            labels: [],
+          }),
+        ),
+      );
+
+    const res = parse(
+      await createCtxGetTaskContextTool({ workspace: WS }).handler({
+        ref: "#7",
+      }),
+    );
+    expect(res.bodyTruncated).toBe(true);
+    expect(Buffer.byteLength(res.issue.body, "utf8")).toBeLessThanOrEqual(500);
+  });
+
   it("degrades gracefully when gh is unavailable", async () => {
     mockExec
       .mockResolvedValueOnce(fail("gh: command not found", 127))

--- a/src/tools/ctxGetTaskContext.ts
+++ b/src/tools/ctxGetTaskContext.ts
@@ -1,5 +1,6 @@
 import type { CommitIssueLinkLog } from "../commitIssueLinkLog.js";
 import { fetchIssue } from "../connectors/linear.js";
+import { truncateUtf8Bytes } from "../drivers/outputCap.js";
 import { runGitStdout } from "./git-utils.js";
 import {
   GH_NOT_AUTHED,
@@ -72,12 +73,17 @@ function detectRefType(raw: string): { type: RefType; id: string } {
   return { type: "unknown", id: trimmed };
 }
 
-const BODY_CAP = 500;
+const BODY_CAP_BYTES = 500;
 
 function trimBody(raw: unknown): { value: string | null; truncated: boolean } {
   if (typeof raw !== "string") return { value: null, truncated: false };
-  if (raw.length <= BODY_CAP) return { value: raw, truncated: false };
-  return { value: raw.slice(0, BODY_CAP), truncated: true };
+  // Byte-accurate cap: raw.length counts UTF-16 code units, so a 500-char CJK
+  // or emoji body could be ~1.5-2KB of UTF-8 — 2-3x the intended context budget
+  // (audit 2026-06-09 tools-ctx-1). Cap by bytes at a codepoint boundary.
+  if (Buffer.byteLength(raw, "utf8") <= BODY_CAP_BYTES) {
+    return { value: raw, truncated: false };
+  }
+  return { value: truncateUtf8Bytes(raw, BODY_CAP_BYTES), truncated: true };
 }
 
 async function fetchGhJson(


### PR DESCRIPTION
## What

Part of the **#10 "finish the incomplete fixes"** batch. PR #948 made output caps byte-accurate, but three sites kept counting **UTF-16 code units** against **byte-named** budgets — so CJK/emoji content overshoots 2-3x.

- **tools-ctx-1** (`ctxGetTaskContext.trimBody`): `BODY_CAP` compared and sliced by `raw.length`, so a 500-char CJK/emoji issue/PR body was ~1.5 KB — 2-3x the intended context budget. Now caps by `Buffer.byteLength` + `truncateUtf8Bytes`.
- **orch-driver-5** (`recipeOrchestration`): the `MAX_MODEL_OUTPUT_BYTES` guard compared `task.output.length` (UTF-16) to a byte constant and sliced by chars. Switched to byte comparison + `truncateUtf8Bytes`; the warning now reports real byte length.
- **orch-driver-6** (`claudeDriver`, `@deprecated` legacy): the `startupTimedOut` path used `accumulated.slice(0, OUTPUT_CAP)` while every sibling return site used `truncateUtf8Bytes`. Made consistent.

## Tests (test-first)

A 400-char CJK issue body (1200 bytes) now sets `bodyTruncated` and returns ≤500 bytes (the old `raw.length` check left it untruncated). Driver + orchestration suites (51 tests) + `ctxGetTaskContext` (21 tests) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)