### PR TITLE
docs: fix Jekyll Pages build broken by audit report's {{...}} examples

### DIFF
--- a/docs/audit-2026-06-09.md
+++ b/docs/audit-2026-06-09.md
@@ -1,3 +1,4 @@
+{% raw %}
 # Patchwork OS — Incremental Full-Surface Audit (2026-06-09)
 
 > Multi-agent audit, one day after [audit-2026-06-08.md](audit-2026-06-08.md) and the #947–#953 fix wave. 17 finder agents swept every subsystem **deduped against the 06-08 doc**, with dedicated finders for the never-audited PR #953 semantic-memory code, the current branch (`feat/traces-semantic-toggle`), and a regression review of the six fix PRs themselves. Every finding adversarially verified by an independent skeptic. **143 agents, ~9.6M tokens, 27 min.**
@@ -1852,3 +1853,4 @@ scripts/audit-lsp-tools.mjs output:
 - cli/cli-doctor-sincems-timestamp-vs-duration: recipe doctor CLI passes Unix timestamp as sinceMs duration — bridge returns all-time halts
 - platform-misc/unsurfaced-1: GET /feature-flags endpoint missing — dashboard cannot read current flag values before toggling
 - docs-drift/docs-drift-8: CLAUDE.md webhook fan-out says 'any opted-in hook may add webhook' but code restricts to onCompaction hooks only
+{% endraw %}


### PR DESCRIPTION
## What

The four merged audit-fix PRs went green on their PR checks but turned **`main` red** — the **Deploy docs to GitHub Pages** workflow (`pages.yml`) runs **only on push to `main`** (paths `docs/**`), so it never ran on the PR branches.

The committed `docs/audit-2026-06-09.md` contains literal recipe-template examples — including a **deliberately-malformed `{{some_key}`** (single closing brace) quoted in the `recipe-flat-new-7` finding. `jekyll-optional-front-matter` makes every `docs/*.md` a Liquid template, so Liquid raised a fatal `Variable '{{some_key}' was not properly terminated` SyntaxError and aborted the Pages build.

## Fix

Wrap the whole report in `{% raw %}` / `{% endraw %}` so Liquid skips its mustache examples (the canonical Jekyll fix for docs that quote template syntax). Verified no other tracked `docs/**/*.md` has the unterminated-brace pattern; the other docs' `{{ ... }}` are well-formed and render harmlessly.

> Note: `pages.yml` has no `pull_request` trigger, so this can only be validated by the push-to-main build after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)