### PR TITLE
chore: audit follow-ups — NET-001 flake, MongoDB 46/46, parallel:{each} fail-loud

### DIFF
--- a/src/__tests__/connector-step-parity-allowlist.json
+++ b/src/__tests__/connector-step-parity-allowlist.json
@@ -1,4 +1,4 @@
 {
   "_README": "Backlog of connectors that authenticate but expose NO recipe-step tool yet, so they cannot be wired into a recipe. Enforced by connector-step-parity.test.ts. RULES: (1) entries may only be REMOVED \u2014 never added casually \u2014 as recipe steps are backfilled for each connector (a src/recipes/tools/<namespace>.ts module registering `<namespace>.<action>` tools); (2) a NEW connector added to the registry with no recipe step must be CONSCIOUSLY appended here (the test fails until it is); (3) once a connector gains a step it MUST be deleted from this list (the test fails if a listed connector now has steps). The list can only shrink. See also connectorRoutes-registry-parity.test.ts (#850 cross-layer parity).",
-  "connectorsWithoutSteps": ["mongodb"]
+  "connectorsWithoutSteps": []
 }

--- a/src/__tests__/server-edge-cases.test.ts
+++ b/src/__tests__/server-edge-cases.test.ts
@@ -563,12 +563,16 @@ describe("Server.findAndListen — EADDRINUSE retry (NET-001)", () => {
     // AFTER FIX:  retries with backoff, succeeds on second attempt.
     server = new Server("test-token", logger);
 
-    // Spy on the internal listen method to throw EADDRINUSE on first call then succeed
+    // Stub listen() entirely: throw EADDRINUSE on the first attempt, then
+    // resolve with the port. No real socket binding, so the test is
+    // deterministic under fake timers and parallel workers — the previous
+    // version called the real listen() on retry and hung when port 59991 was
+    // genuinely busy on a CI worker (real EADDRINUSE → a 2000ms backoff the
+    // test never advanced → 15s timeout).
     let listenCallCount = 0;
-    const realListen = (server as any).listen.bind(server);
     vi.spyOn(server as any, "listen").mockImplementation(
       async (...args: unknown[]) => {
-        const [port, addr] = args as [number, string];
+        const [port] = args as [number, string];
         listenCallCount++;
         if (listenCallCount === 1 && port !== 0) {
           const err = new Error(
@@ -577,18 +581,18 @@ describe("Server.findAndListen — EADDRINUSE retry (NET-001)", () => {
           err.code = "EADDRINUSE";
           throw err;
         }
-        return realListen(port, addr);
+        return port === 0 ? 50000 : port;
       },
     );
 
     vi.useFakeTimers();
     const listenPromise = server.findAndListen(59991);
-    // Advance past the first backoff delay (1000ms) to trigger retry
+    // Advance past the first backoff delay (1000ms) to trigger the retry
     await vi.advanceTimersByTimeAsync(1100);
     const port = await listenPromise;
 
-    // After fix: gets a valid port (either preferred or OS-assigned fallback)
-    expect(port).toBeGreaterThan(0);
-    expect(listenCallCount).toBeGreaterThan(1);
+    // Retried the preferred port and succeeded on the second attempt.
+    expect(port).toBe(59991);
+    expect(listenCallCount).toBe(2);
   });
 });

--- a/src/recipes/__tests__/chainedRunner.test.ts
+++ b/src/recipes/__tests__/chainedRunner.test.ts
@@ -966,6 +966,25 @@ describe("expandParallelSteps", () => {
     expect(p2?.awaits).toContain("pre");
   });
 
+  it("throws a clear error on the parallel:{ each } object form (no silent no-op)", () => {
+    // The runtime map-reduce form iterates an array a prior step produces, which
+    // the static plan-time expander can't handle. It used to fall through and
+    // execute zero iterations (silent data loss); it must fail loud instead.
+    // (audit recipe-chained-1)
+    const steps = [
+      {
+        id: "loop",
+        parallel: {
+          each: "{{plan.items}}",
+          as: "item",
+          steps: [{ id: "s1", tool: "t", with: { x: "{{item}}" } }],
+        },
+      },
+    ] as unknown as Parameters<typeof expandParallelSteps>[0];
+    expect(() => expandParallelSteps(steps)).toThrow(/parallel:\{ each \}/);
+    expect(() => expandParallelSteps(steps)).toThrow(/fan_out/);
+  });
+
   it("steps after the group await all children not the group id", () => {
     const steps = [
       {

--- a/src/recipes/chainedRunner.ts
+++ b/src/recipes/chainedRunner.ts
@@ -922,6 +922,25 @@ export function expandParallelSteps(steps: ChainedStep[]): ChainedStep[] {
       }
 
       groupChildren.set(groupId, childIds);
+    } else if (
+      typeof step.parallel === "object" &&
+      step.parallel !== null &&
+      !Array.isArray(step.parallel) &&
+      "each" in (step.parallel as Record<string, unknown>)
+    ) {
+      // parallel: { each, as, steps } — runtime map-reduce over an array that a
+      // PRIOR step produces. Real support needs dynamic agent fan-out (per-iter
+      // budget/judge/silent-fail) the chained engine doesn't have yet, and the
+      // array isn't known at plan-expansion time. This object form used to fall
+      // through to the flat-step branch below and execute ZERO iterations —
+      // silent data loss with no signal. Fail loud instead. (audit
+      // recipe-chained-1)
+      throw new Error(
+        `Step "${step.id ?? `parallel_${i}`}" uses parallel:{ each } ` +
+          `(runtime map-reduce), which is not yet implemented in chained ` +
+          "recipes. Use the `fan_out` tool step for tool-only loops; agent " +
+          "fan-out over a runtime-produced array is not yet supported.",
+      );
     } else {
       if (step.id && seenIds.has(step.id)) {
         throw new Error(

--- a/src/recipes/connectorPreflight.ts
+++ b/src/recipes/connectorPreflight.ts
@@ -72,6 +72,7 @@ export const TOOL_NAMESPACE_TO_CONNECTOR: Record<string, string> = {
   obsidian: "obsidian",
   paystack: "paystack",
   pipedrive: "pipedrive",
+  mongodb: "mongodb",
   postgres: "postgres",
   posthog: "posthog",
   redis: "redis",

--- a/src/recipes/tools/__tests__/mongodb.test.ts
+++ b/src/recipes/tools/__tests__/mongodb.test.ts
@@ -1,0 +1,123 @@
+/**
+ * mongodb recipe-step tools — completes connector-step parity (46/46).
+ *
+ * The connector exposes a read-only query surface (listDatabases /
+ * listCollections / describeCollection / find / aggregate) as module-level
+ * functions; these tools wrap them. Mocked via vi.hoisted so the mock factory
+ * can reference the stubs directly (the connector has no getXConnector
+ * accessor to defer behind).
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { listDatabases, listCollections, describeCollection, find, aggregate } =
+  vi.hoisted(() => ({
+    listDatabases: vi.fn(),
+    listCollections: vi.fn(),
+    describeCollection: vi.fn(),
+    find: vi.fn(),
+    aggregate: vi.fn(),
+  }));
+
+vi.mock("../../../connectors/mongodb.js", () => ({
+  listDatabases,
+  listCollections,
+  describeCollection,
+  find,
+  aggregate,
+}));
+
+import "../mongodb.js";
+import { getTool } from "../../toolRegistry.js";
+import type { RunContext, StepDeps } from "../../yamlRunner.js";
+
+function ctx(params: Record<string, unknown>) {
+  return {
+    params,
+    step: {} as Record<string, unknown>,
+    ctx: {} as RunContext,
+    deps: {} as StepDeps,
+  };
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("mongodb recipe-step tools", () => {
+  it("registers all five tools as read-only connector steps", () => {
+    for (const id of [
+      "mongodb.list_databases",
+      "mongodb.list_collections",
+      "mongodb.describe_collection",
+      "mongodb.find",
+      "mongodb.aggregate",
+    ]) {
+      const tool = getTool(id);
+      expect(tool, id).toBeTruthy();
+      expect(tool?.isWrite).toBe(false);
+      expect(tool?.isConnector).toBe(true);
+    }
+  });
+
+  it("list_databases returns the connector result as JSON", async () => {
+    listDatabases.mockResolvedValue(["admin", "app"]);
+    const out = await getTool("mongodb.list_databases")?.execute(ctx({}));
+    expect(listDatabases).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(out ?? "null")).toEqual(["admin", "app"]);
+  });
+
+  it("find forwards database/collection/filter/projection/limit", async () => {
+    find.mockResolvedValue([{ _id: 1 }]);
+    const out = await getTool("mongodb.find")?.execute(
+      ctx({
+        database: "app",
+        collection: "users",
+        filter: { active: true },
+        projection: { name: 1 },
+        limit: 25,
+      }),
+    );
+    expect(find).toHaveBeenCalledWith(
+      "app",
+      "users",
+      { active: true },
+      { projection: { name: 1 }, limit: 25 },
+    );
+    expect(JSON.parse(out ?? "null")).toEqual([{ _id: 1 }]);
+  });
+
+  it("find defaults filter to {} and leaves projection/limit unset", async () => {
+    find.mockResolvedValue([]);
+    await getTool("mongodb.find")?.execute(
+      ctx({ database: "app", collection: "users" }),
+    );
+    expect(find).toHaveBeenCalledWith(
+      "app",
+      "users",
+      {},
+      { projection: undefined, limit: undefined },
+    );
+  });
+
+  it("aggregate forwards the pipeline and limit", async () => {
+    aggregate.mockResolvedValue([{ n: 3 }]);
+    const pipeline = [{ $match: { active: true } }];
+    await getTool("mongodb.aggregate")?.execute(
+      ctx({ database: "app", collection: "users", pipeline, limit: 50 }),
+    );
+    expect(aggregate).toHaveBeenCalledWith("app", "users", pipeline, 50);
+  });
+
+  it("describe_collection returns sample + indexes", async () => {
+    describeCollection.mockResolvedValue({ sample: { a: 1 }, indexes: [] });
+    const out = await getTool("mongodb.describe_collection")?.execute(
+      ctx({ database: "app", collection: "users" }),
+    );
+    expect(describeCollection).toHaveBeenCalledWith("app", "users");
+    expect(JSON.parse(out ?? "null")).toEqual({
+      sample: { a: 1 },
+      indexes: [],
+    });
+  });
+});

--- a/src/recipes/tools/index.ts
+++ b/src/recipes/tools/index.ts
@@ -38,6 +38,7 @@ import "./elasticsearch.js";
 import "./postgres.js";
 import "./redis.js";
 import "./snowflake.js";
+import "./mongodb.js";
 import "./caldiy.js";
 import "./cloudflare.js";
 import "./figma.js";

--- a/src/recipes/tools/mongodb.ts
+++ b/src/recipes/tools/mongodb.ts
@@ -1,0 +1,222 @@
+/**
+ * MongoDB recipe-step tools — read-only query surface.
+ *
+ * Self-registering tool module for the recipe tool registry. Like the other
+ * module-function connectors (salesforce/monday/google-docs), src/connectors/
+ * mongodb.ts exports standalone async functions rather than a getXConnector()
+ * accessor, so each tool dynamically imports the function it wraps and
+ * JSON-stringifies the raw return value.
+ *
+ * Every tool is read-only (`isWrite: false`): the connector enforces a
+ * read-only-operation guard (`isReadOnlyMongoOp`) on filters/pipelines and
+ * rejects mutating aggregation stages ($out/$merge/$function/$where), and the
+ * result sets are limit-capped (default 100, hard cap 1000). There is no
+ * insert/update/delete surface by design.
+ *
+ * Completes connector-step parity: mongodb was the last entry in
+ * connector-step-parity-allowlist.json.
+ */
+
+import { CommonSchemas, registerTool } from "../toolRegistry.js";
+import { wrapConnectorExecute } from "./wrapConnectorExecute.js";
+
+// ============================================================================
+// mongodb.list_databases
+// ============================================================================
+
+registerTool({
+  id: "mongodb.list_databases",
+  namespace: "mongodb",
+  description: "List the database names available on the connected MongoDB.",
+  paramsSchema: {
+    type: "object",
+    properties: {
+      into: CommonSchemas.into,
+    },
+    required: [],
+  },
+  outputSchema: {
+    type: "array",
+    items: { type: "string" },
+  },
+  riskDefault: "low",
+  isWrite: false,
+  isConnector: true,
+  execute: wrapConnectorExecute(async () => {
+    const { listDatabases } = await import("../../connectors/mongodb.js");
+    return JSON.stringify(await listDatabases());
+  }),
+});
+
+// ============================================================================
+// mongodb.list_collections
+// ============================================================================
+
+registerTool({
+  id: "mongodb.list_collections",
+  namespace: "mongodb",
+  description: "List the collection names in a MongoDB database.",
+  paramsSchema: {
+    type: "object",
+    properties: {
+      database: {
+        type: "string",
+        description: "Database name to list collections from",
+      },
+      into: CommonSchemas.into,
+    },
+    required: ["database"],
+  },
+  outputSchema: {
+    type: "array",
+    items: { type: "string" },
+  },
+  riskDefault: "low",
+  isWrite: false,
+  isConnector: true,
+  execute: wrapConnectorExecute(async ({ params }) => {
+    const { listCollections } = await import("../../connectors/mongodb.js");
+    return JSON.stringify(await listCollections(params.database as string));
+  }),
+});
+
+// ============================================================================
+// mongodb.describe_collection
+// ============================================================================
+
+registerTool({
+  id: "mongodb.describe_collection",
+  namespace: "mongodb",
+  description:
+    "Describe a MongoDB collection: a sample document plus its index list.",
+  paramsSchema: {
+    type: "object",
+    properties: {
+      database: { type: "string", description: "Database name" },
+      collection: { type: "string", description: "Collection name" },
+      into: CommonSchemas.into,
+    },
+    required: ["database", "collection"],
+  },
+  outputSchema: {
+    type: "object",
+    properties: {
+      sample: {},
+      indexes: { type: "array" },
+    },
+  },
+  riskDefault: "low",
+  isWrite: false,
+  isConnector: true,
+  execute: wrapConnectorExecute(async ({ params }) => {
+    const { describeCollection } = await import("../../connectors/mongodb.js");
+    return JSON.stringify(
+      await describeCollection(
+        params.database as string,
+        params.collection as string,
+      ),
+    );
+  }),
+});
+
+// ============================================================================
+// mongodb.find
+// ============================================================================
+
+registerTool({
+  id: "mongodb.find",
+  namespace: "mongodb",
+  description:
+    "Run a read-only find() against a MongoDB collection. The filter and " +
+    "projection are guarded against query operators that execute server-side " +
+    "code; results are limit-capped (default 100, hard cap 1000).",
+  paramsSchema: {
+    type: "object",
+    properties: {
+      database: { type: "string", description: "Database name" },
+      collection: { type: "string", description: "Collection name" },
+      filter: {
+        type: "object",
+        description: "MongoDB query filter (read-only operators only)",
+      },
+      projection: {
+        type: "object",
+        description: "Optional field projection",
+      },
+      limit: {
+        type: "number",
+        description: "Max documents (default 100, hard cap 1000)",
+      },
+      into: CommonSchemas.into,
+    },
+    required: ["database", "collection"],
+  },
+  outputSchema: {
+    type: "array",
+    items: { type: "object" },
+  },
+  riskDefault: "low",
+  isWrite: false,
+  isConnector: true,
+  execute: wrapConnectorExecute(async ({ params }) => {
+    const { find } = await import("../../connectors/mongodb.js");
+    const result = await find(
+      params.database as string,
+      params.collection as string,
+      (params.filter as Record<string, unknown>) ?? {},
+      {
+        projection: params.projection as Record<string, unknown> | undefined,
+        limit: typeof params.limit === "number" ? params.limit : undefined,
+      },
+    );
+    return JSON.stringify(result);
+  }),
+});
+
+// ============================================================================
+// mongodb.aggregate
+// ============================================================================
+
+registerTool({
+  id: "mongodb.aggregate",
+  namespace: "mongodb",
+  description:
+    "Run a read-only aggregation pipeline against a MongoDB collection. " +
+    "Mutating stages ($out/$merge/$function/$where/$accumulator) are rejected " +
+    "and a $limit stage is appended (default 100, hard cap 1000).",
+  paramsSchema: {
+    type: "object",
+    properties: {
+      database: { type: "string", description: "Database name" },
+      collection: { type: "string", description: "Collection name" },
+      pipeline: {
+        type: "array",
+        items: { type: "object" },
+        description: "Aggregation pipeline stages (read-only)",
+      },
+      limit: {
+        type: "number",
+        description: "Max documents (default 100, hard cap 1000)",
+      },
+      into: CommonSchemas.into,
+    },
+    required: ["database", "collection", "pipeline"],
+  },
+  outputSchema: {
+    type: "array",
+    items: { type: "object" },
+  },
+  riskDefault: "low",
+  isWrite: false,
+  isConnector: true,
+  execute: wrapConnectorExecute(async ({ params }) => {
+    const { aggregate } = await import("../../connectors/mongodb.js");
+    const result = await aggregate(
+      params.database as string,
+      params.collection as string,
+      params.pipeline as Array<Record<string, unknown>>,
+      typeof params.limit === "number" ? params.limit : undefined,
+    );
+    return JSON.stringify(result);
+  }),
+});

--- a/src/server.ts
+++ b/src/server.ts
@@ -3207,6 +3207,10 @@ export class Server extends EventEmitter<ServerEvents> {
 
   async close(): Promise<void> {
     if (this.pingInterval) clearInterval(this.pingInterval);
+    // close() may run before listen() (failed startup, or tests that stub
+    // listen()); wss/httpServer are only created in listen(), so a pre-listen
+    // close is a safe no-op rather than a crash on undefined this.wss.
+    if (!this.wss) return;
     for (const client of this.wss.clients) {
       client.close(1001, "Server shutting down");
     }


### PR DESCRIPTION
## Audit follow-ups (post-#965)

Two small, independent follow-ups from the full-codebase audit.

### 1. NET-001 EADDRINUSE test — deterministic + safe `close()`
The `findAndListen` EADDRINUSE-retry test (`server-edge-cases.test.ts`) called the **real** `listen()` on retry and hung (15s timeout) when port 59991 was genuinely busy on a parallel CI worker (real EADDRINUSE → a 2000ms backoff the test never advanced). Now `listen()` is stubbed to resolve with the port — no real I/O, deterministic under fake timers (verified 3× + full file).

Also hardened `Server.close()` to no-op when `this.wss` was never created (close-before-listen safety), so a fully-stubbed `listen()` doesn't crash `afterEach`.

### 2. MongoDB recipe-step tools — connector-step parity 46/46
Adds read-only `mongodb.{list_databases,list_collections,describe_collection,find,aggregate}` step tools wrapping the connector's existing read-only query surface, and clears the **last** entry in `connector-step-parity-allowlist.json` → **46/46 connectors usable in recipes**. The connector already enforces read-only-operator + forbidden-stage ($out/$merge/$function/$where) guards and limit caps; all five tools are `isWrite: false`.

### Verification
Bridge tsc (main + strict tests) clean · biome 0 errors · all 3 CI gates pass (lsp-tools / test-fixtures / schema) · new + affected tests green.

### Deliberately deferred
The `recipe-runners-2` ideal **AbortSignal-cancel** is *not* here: it's high blast-radius (threading a signal through `ToolContext` → `executeTool` → the HTTP layer of ~26 connectors) for marginal value, since the shipped no-retry-on-timeout already fixes the duplicate-write bug. Better as its own deliberate PR if/when retry-on-timeout is ever wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### 3. `parallel:{ each }` fail-loud (audit recipe-chained-1)
The chained-runner object map-reduce form (`parallel: { each, as, steps }`) iterates a runtime-produced array and can't be statically expanded at plan time — it silently fell through and ran **zero iterations** (data loss). Now throws a clear, actionable error pointing at the `fan_out` tool. True runtime *agent* fan-out (the deferred v2) is still not implemented; this just removes the silent-no-op landmine. No test executes the affected example recipes, and validation/lint behavior is unchanged.

Reconciliation note: verified the 2026-06-09 incremental audit's 4 HIGHs are all fixed in main (#956 5-connector token-leak redaction, #957 sendHttpRequest cross-origin cred-strip, #958 completeRun token/budget totals), and the 06-08 `mcpClient` init-race + `GET /connections` TTL are both closed by #965.