### PR TITLE
feat(recipes): abort in-flight chained step on run cancel

### DIFF
--- a/src/recipes/__tests__/chainedRunner.test.ts
+++ b/src/recipes/__tests__/chainedRunner.test.ts
@@ -231,6 +231,56 @@ describe("executeChainedStep", () => {
     expect(result.data).toBe("quick");
   });
 
+  // run-cancel: an in-flight step must abort promptly when the run signal
+  // fires, not block until its own (5s) work resolves.
+  it("aborts an in-flight step immediately when the signal is already aborted", async () => {
+    const reg = createOutputRegistry();
+    const ctl = new AbortController();
+    ctl.abort("run cancelled by user");
+    const slowDeps = {
+      executeTool: () =>
+        new Promise((resolve) => setTimeout(() => resolve("late"), 5000)),
+      executeAgent: vi.fn(),
+      loadNestedRecipe: vi.fn().mockResolvedValue(null),
+    };
+    const result = await executeChainedStep(
+      {
+        registry: reg,
+        step: { id: "s", tool: "slow.tool" },
+        options: { ...baseOptions, signal: ctl.signal },
+        recipe: { name: "r", steps: [] },
+        depth: 0,
+      },
+      slowDeps,
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/step_cancelled/);
+  });
+
+  it("aborts an in-flight step when the signal fires mid-execution", async () => {
+    const reg = createOutputRegistry();
+    const ctl = new AbortController();
+    const slowDeps = {
+      executeTool: () =>
+        new Promise((resolve) => setTimeout(() => resolve("late"), 5000)),
+      executeAgent: vi.fn(),
+      loadNestedRecipe: vi.fn().mockResolvedValue(null),
+    };
+    setTimeout(() => ctl.abort("run cancelled by user"), 10);
+    const result = await executeChainedStep(
+      {
+        registry: reg,
+        step: { id: "s", tool: "slow.tool" },
+        options: { ...baseOptions, signal: ctl.signal },
+        recipe: { name: "r", steps: [] },
+        depth: 0,
+      },
+      slowDeps,
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/step_cancelled/);
+  });
+
   it("fails an agent step with step_timeout when it exceeds timeout_ms", async () => {
     const reg = createOutputRegistry();
     const slowDeps = {

--- a/src/recipes/chainedRunner.ts
+++ b/src/recipes/chainedRunner.ts
@@ -362,18 +362,50 @@ function raceStepTimeout<T>(
   work: Promise<T>,
   timeoutMs: number | undefined,
   label: string,
+  signal?: AbortSignal,
 ): Promise<T> {
-  if (typeof timeoutMs !== "number" || timeoutMs <= 0) return work;
+  const hasTimeout = typeof timeoutMs === "number" && timeoutMs > 0;
+  if (!hasTimeout && !signal) return work;
+
+  // Run-cancel: reject promptly when the run is aborted so an in-flight
+  // tool/agent step doesn't block the run from draining (the underlying call
+  // keeps running but its result is ignored — same contract as the timeout).
+  if (signal?.aborted) {
+    return Promise.reject(
+      new Error(`step_cancelled: run aborted before step "${label}" completed`),
+    );
+  }
+
+  const racers: Promise<never>[] = [];
   let timer: ReturnType<typeof setTimeout> | undefined;
-  const timeout = new Promise<never>((_, reject) => {
-    timer = setTimeout(() => {
-      reject(
-        new Error(`step_timeout: exceeded ${timeoutMs}ms in step "${label}"`),
-      );
-    }, timeoutMs);
-  });
-  return Promise.race([work, timeout]).finally(() => {
+  if (hasTimeout) {
+    racers.push(
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => {
+          reject(
+            new Error(
+              `step_timeout: exceeded ${timeoutMs}ms in step "${label}"`,
+            ),
+          );
+        }, timeoutMs);
+      }),
+    );
+  }
+  let onAbort: (() => void) | undefined;
+  if (signal) {
+    racers.push(
+      new Promise<never>((_, reject) => {
+        onAbort = () =>
+          reject(
+            new Error(`step_cancelled: run aborted during step "${label}"`),
+          );
+        signal.addEventListener("abort", onAbort, { once: true });
+      }),
+    );
+  }
+  return Promise.race([work, ...racers]).finally(() => {
     if (timer) clearTimeout(timer);
+    if (signal && onAbort) signal.removeEventListener("abort", onAbort);
   });
 }
 
@@ -637,6 +669,7 @@ export async function executeChainedStep(
           deps.executeAgent(prompt, dispatchModel, dispatchDriver),
           step.timeout_ms,
           step.id,
+          options.signal,
         ),
       );
 
@@ -734,6 +767,7 @@ export async function executeChainedStep(
         deps.executeTool(step.tool, resolved),
         step.timeout_ms,
         step.id,
+        options.signal,
       );
       // Detect tool-level errors reported as JSON {ok: false, error: ...} (mirrors flat runner)
       if (typeof result === "string") {
@@ -1250,6 +1284,10 @@ export async function runChainedRecipe(
       : cancelSignals.length === 1
         ? cancelSignals[0]
         : AbortSignal.any(cancelSignals);
+  // Expose the combined signal on the options that flow into executeChainedStep
+  // so an in-flight tool/agent step (via raceStepTimeout) also aborts on cancel,
+  // not just not-yet-started steps. Safe no-op when undefined. (run-cancel)
+  options.signal = effectiveSignal;
 
   const execOptions: ExecutionOptions = {
     maxConcurrency: options.maxConcurrency,


### PR DESCRIPTION
## Abort in-flight chained step on run cancel

Completes the run-cancel feature shipped in #967. Previously a cancel only stopped the run **between** steps — a step stuck in a long agent (LLM) call blocked cancellation until that call finished or hit its own 300s timeout. This races the in-flight tool/agent dispatch against the run signal so **cancel takes effect immediately, even mid-step**.

### Change
- `raceStepTimeout` (chainedRunner) gains an optional `AbortSignal`: it already wraps both the tool and agent dispatch, so one change covers both. On abort it rejects with `step_cancelled` (already-aborted → rejects synchronously; mid-flight → on the `abort` event, listener cleaned up in `finally`).
- `runChainedRecipe` sets `options.signal = effectiveSignal` (the combined parent + run-registry signal) so `executeChainedStep` passes it to `raceStepTimeout` at both call sites.

### Behavior
The abandoned call is GC'd exactly like the existing per-step timeout (`raceStepTimeout` "abandons the wait, does not cancel the call"). The run drains promptly via the between-step skip from #967. Additive + backward-compatible: no signal → identical to before.

### Tests
Two new `executeChainedStep` tests — already-aborted signal → step returns `step_cancelled` immediately (doesn't wait out a 5s tool); signal fires mid-execution → same. Full bridge suite green (8,073), tsc + biome + fixtures gate clean.

### Note / further refinement
This stops the run from *waiting* on the in-flight call. Full HTTP-level termination (aborting the actual `fetch`/`driver.run` to stop tokens/billing the instant cancel fires) needs threading the signal through `stepDeps.claudeFn`/`providerDriverFn` → `driver.run` — a larger change to the shared agent path, deferred as a separate refinement. For the operational gap (stop a runaway recipe promptly) this is sufficient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
