### PR TITLE
feat(recipes): quality-aware escalation (stronger model on judge rejection)

### DIFF
--- a/src/recipes/__tests__/downshiftValidation.test.ts
+++ b/src/recipes/__tests__/downshiftValidation.test.ts
@@ -55,3 +55,31 @@ describe("agent.downshift validation", () => {
     ).toMatch(/not a known driver/);
   });
 });
+
+describe("agent.escalate validation (quality-aware, shares the route-list helper)", () => {
+  it("accepts a valid escalate list", () => {
+    expect(
+      agentErrors({
+        escalate: [{ model: "claude-opus-4-8" }, { driver: "anthropic" }],
+      }),
+    ).toBe("");
+  });
+
+  it("rejects a non-array escalate", () => {
+    expect(agentErrors({ escalate: "opus" })).toMatch(
+      /'escalate' must be an array/,
+    );
+  });
+
+  it("rejects an empty entry", () => {
+    expect(agentErrors({ escalate: [{}] })).toMatch(
+      /at least one of 'driver' or 'model'/,
+    );
+  });
+
+  it("rejects an unknown driver", () => {
+    expect(agentErrors({ escalate: [{ driver: "telepathy" }] })).toMatch(
+      /not a known driver/,
+    );
+  });
+});

--- a/src/recipes/__tests__/judgeRefineLoop.test.ts
+++ b/src/recipes/__tests__/judgeRefineLoop.test.ts
@@ -266,3 +266,85 @@ describe("judge→refine: budget off-by-one (audit 2026-06-03 LOW #2)", () => {
     expect(result.errorMessage).toBeUndefined();
   });
 });
+
+describe("judge→refine: quality-aware escalation", () => {
+  it("re-runs the revision with escalate[0]'s model, not the base model", async () => {
+    const calls: Array<{ kind: string; model?: string }> = [];
+    const recipe = {
+      name: "judge-escalate",
+      trigger: { type: "manual" },
+      steps: [
+        {
+          agent: {
+            prompt: "write the thing",
+            driver: "anthropic",
+            model: "claude-haiku-4-5-20251001",
+            into: "draft",
+            // On judge rejection, escalate the revision to a stronger model.
+            escalate: [{ model: "claude-opus-4-8" }],
+          },
+        },
+        {
+          agent: {
+            kind: "judge",
+            reviews: "draft",
+            max_revisions: 1,
+            on_exhausted: "proceed",
+            prompt: "review the draft",
+            driver: "anthropic",
+            model: "claude-haiku-4-5-20251001",
+          },
+        },
+      ],
+    } as YamlRecipe;
+
+    const deps: RunnerDeps = {
+      now: () => new Date("2026-06-03T08:00:00Z"),
+      logDir,
+      claudeFn: async (prompt: string, model: string) => {
+        if (prompt.includes("<revision-request>")) {
+          calls.push({ kind: "revise", model });
+          return "REVISED v2";
+        }
+        if (prompt.includes("<artefact>")) {
+          calls.push({ kind: "judge", model });
+          return prompt.includes("REVISED v2") ? APPROVE : REQUEST_CHANGES;
+        }
+        calls.push({ kind: "draft", model });
+        return "DRAFT v1";
+      },
+    };
+
+    const result = await runYamlRecipe(recipe, deps);
+
+    const draft = calls.find((c) => c.kind === "draft");
+    const revise = calls.find((c) => c.kind === "revise");
+    // First pass used the cheap base model…
+    expect(draft?.model).toBe("claude-haiku-4-5-20251001");
+    // …and the rejection re-ran the revision on the escalated (stronger) model.
+    expect(revise).toBeDefined();
+    expect(revise?.model).toBe("claude-opus-4-8");
+    expect(result.errorMessage).toBeUndefined();
+  });
+
+  it("reuses the base model on revision when no escalate list is set", async () => {
+    const reviseModels: string[] = [];
+    const deps: RunnerDeps = {
+      now: () => new Date("2026-06-03T08:00:00Z"),
+      logDir,
+      claudeFn: async (prompt: string, model: string) => {
+        if (prompt.includes("<revision-request>")) {
+          reviseModels.push(model);
+          return "REVISED v2";
+        }
+        if (prompt.includes("<artefact>")) {
+          return prompt.includes("REVISED v2") ? APPROVE : REQUEST_CHANGES;
+        }
+        return "DRAFT v1";
+      },
+    };
+    await runYamlRecipe(judgeRecipe(1, "proceed"), deps);
+    // No escalate → the revision uses the reviewed agent's base model.
+    expect(reviseModels).toEqual(["claude-haiku-4-5-20251001"]);
+  });
+});

--- a/src/recipes/schemaGenerator.ts
+++ b/src/recipes/schemaGenerator.ts
@@ -547,6 +547,32 @@ function generateRecipeSchema(
           },
         },
       },
+      escalate: {
+        type: "array",
+        description:
+          "OPT-IN quality-aware escalation (dual of downshift). Ordered MORE-capable fallbacks. In a judge→refine loop (reviews + max_revisions>0), the Nth request_changes revision re-runs the reviewed step with escalate[N-1] instead of the base model — start local/cheap, escalate to a stronger model only when output fails judgment. Each entry overrides driver and/or model.",
+        items: {
+          type: "object",
+          additionalProperties: false,
+          minProperties: 1,
+          properties: {
+            driver: {
+              type: "string",
+              enum: [
+                "claude",
+                "claude-code",
+                "api",
+                "openai",
+                "grok",
+                "gemini",
+                "anthropic",
+                "local",
+              ],
+            },
+            model: { type: "string" },
+          },
+        },
+      },
     },
   };
   const toolRefs = Object.keys(namespaceSchemas).map((ns) => ({

--- a/src/recipes/validation.ts
+++ b/src/recipes/validation.ts
@@ -50,6 +50,62 @@ export interface LintIssue {
   path?: string;
 }
 
+/**
+ * Validate an ordered route-candidate list (`downshift` / `escalate`): an array
+ * of `{driver?, model?}` where each entry sets at least one field and any
+ * `driver` is dispatch-known. Shared by both routing fields so they stay in
+ * lockstep. Codes are field-prefixed (`downshift-type`, `escalate-type`, …).
+ * (quality-aware-escalation)
+ */
+function validateRouteCandidateList(
+  field: "downshift" | "escalate",
+  value: unknown,
+  stepIndex: number,
+  issues: LintIssue[],
+): void {
+  if (value === undefined) return;
+  const base = `steps.${stepIndex}.agent.${field}`;
+  if (!Array.isArray(value)) {
+    issues.push({
+      level: "error",
+      message: `Step ${stepIndex + 1}: '${field}' must be an array of {driver?, model?} candidates`,
+      code: `${field}-type`,
+      path: base,
+    });
+    return;
+  }
+  value.forEach((entry: unknown, di: number) => {
+    if (typeof entry !== "object" || entry === null || Array.isArray(entry)) {
+      issues.push({
+        level: "error",
+        message: `Step ${stepIndex + 1}: ${field}[${di}] must be an object with 'driver' and/or 'model'`,
+        code: `${field}-entry-type`,
+        path: `${base}.${di}`,
+      });
+      return;
+    }
+    const e = entry as Record<string, unknown>;
+    const hasDriver = typeof e.driver === "string";
+    const hasModel = typeof e.model === "string";
+    if (!hasDriver && !hasModel) {
+      issues.push({
+        level: "error",
+        message: `Step ${stepIndex + 1}: ${field}[${di}] must set at least one of 'driver' or 'model'`,
+        code: `${field}-entry-empty`,
+        path: `${base}.${di}`,
+      });
+    }
+    if (hasDriver && !DOWNSHIFT_KNOWN_DRIVERS.has(e.driver as string)) {
+      issues.push({
+        level: "error",
+        message: `Step ${stepIndex + 1}: ${field}[${di}].driver '${String(e.driver)}' is not a known driver`,
+        code: `${field}-driver-enum`,
+        path: `${base}.${di}.driver`,
+      });
+    }
+  });
+}
+
 export interface LintResult {
   valid: boolean;
   issues: LintIssue[];
@@ -274,57 +330,11 @@ export function validateRecipeDefinition(recipe: unknown): LintResult {
             });
           }
 
-          // OPT-IN cost-aware routing (Phase 4). `downshift` is an ordered list
-          // of {driver?, model?} cheaper fallbacks; each entry must set at
-          // least one field and any driver must be dispatch-known.
-          if (agent.downshift !== undefined) {
-            if (!Array.isArray(agent.downshift)) {
-              issues.push({
-                level: "error",
-                message: `Step ${i + 1}: 'downshift' must be an array of {driver?, model?} candidates`,
-                code: "downshift-type",
-                path: `steps.${i}.agent.downshift`,
-              });
-            } else {
-              agent.downshift.forEach((entry: unknown, di: number) => {
-                if (
-                  typeof entry !== "object" ||
-                  entry === null ||
-                  Array.isArray(entry)
-                ) {
-                  issues.push({
-                    level: "error",
-                    message: `Step ${i + 1}: downshift[${di}] must be an object with 'driver' and/or 'model'`,
-                    code: "downshift-entry-type",
-                    path: `steps.${i}.agent.downshift.${di}`,
-                  });
-                  return;
-                }
-                const e = entry as Record<string, unknown>;
-                const hasDriver = typeof e.driver === "string";
-                const hasModel = typeof e.model === "string";
-                if (!hasDriver && !hasModel) {
-                  issues.push({
-                    level: "error",
-                    message: `Step ${i + 1}: downshift[${di}] must set at least one of 'driver' or 'model'`,
-                    code: "downshift-entry-empty",
-                    path: `steps.${i}.agent.downshift.${di}`,
-                  });
-                }
-                if (
-                  hasDriver &&
-                  !DOWNSHIFT_KNOWN_DRIVERS.has(e.driver as string)
-                ) {
-                  issues.push({
-                    level: "error",
-                    message: `Step ${i + 1}: downshift[${di}].driver '${String(e.driver)}' is not a known driver`,
-                    code: "downshift-driver-enum",
-                    path: `steps.${i}.agent.downshift.${di}.driver`,
-                  });
-                }
-              });
-            }
-          }
+          // OPT-IN routing fallbacks, both ordered {driver?, model?} lists:
+          // `downshift` (cost-aware, Phase 4 — go cheaper as budget depletes)
+          // and `escalate` (quality-aware — go more capable on judge rejection).
+          validateRouteCandidateList("downshift", agent.downshift, i, issues);
+          validateRouteCandidateList("escalate", agent.escalate, i, issues);
         }
 
         // Unconditional risk-enum check. `risk` was previously never

--- a/src/recipes/yamlRunner.ts
+++ b/src/recipes/yamlRunner.ts
@@ -177,6 +177,16 @@ export interface YamlStep {
      * model is always used (byte-identical to no routing).
      */
     downshift?: import("./pricing/costRouter.js").RouteCandidate[];
+    /**
+     * OPT-IN quality-aware escalation (dual of `downshift`). Ordered MORE-capable
+     * fallbacks, each overriding `driver` and/or `model`. Consumed by the
+     * judge→refine loop: on a `request_changes` verdict the Nth revision re-runs
+     * the reviewed step with `escalate[N-1]` instead of the base model — i.e.
+     * start cheap/local, escalate to a stronger (cloud) model only when the
+     * output fails judgment. Requires `reviews` + `max_revisions > 0`. Absent ⇒
+     * every revision reuses the base model (byte-identical to prior behavior).
+     */
+    escalate?: import("./pricing/costRouter.js").RouteCandidate[];
   };
   into?: string;
   optional?: boolean;
@@ -1389,12 +1399,19 @@ export async function runYamlRecipe(
       const revisionPrompt =
         render(reviewedAgent.prompt, redactSecretsForPrompt(ctx, secretKeys)) +
         revisionBlock;
+      // Quality-aware escalation: on the Nth revision, re-run the reviewed step
+      // with the Nth more-capable candidate (`escalate[revisions]`) instead of
+      // the base model — local/cheap first, escalate to cloud only when the
+      // judge keeps rejecting. `revisions` is 0-based here (incremented after
+      // the re-judge below). When escalating we drop `downshift` for this call:
+      // escalation means "go stronger", so it must not be re-downshifted.
+      const escalateTo = reviewedAgent.escalate?.[revisions];
       const revised = await runAgentText(
         revisionPrompt,
-        reviewedAgent.driver,
-        reviewedAgent.model,
+        escalateTo?.driver ?? reviewedAgent.driver,
+        escalateTo?.model ?? reviewedAgent.model,
         reviewedAgent.mcpAccess,
-        reviewedAgent.downshift,
+        escalateTo ? undefined : reviewedAgent.downshift,
       );
       if (!revised.ok) {
         // A failed / empty revision can't be re-judged — stop and treat the


### PR DESCRIPTION
## Quality-aware escalation — stronger model on judge rejection

The first slice of the "actual moat": route on **output quality**, not just cost. Adds `agent.escalate` — the **dual of `downshift`** — an ordered list of *more-capable* `{driver?, model?}` fallbacks.

### How it composes (no new runtime, rides existing pieces)
The judge→refine loop (#859) already re-runs a reviewed step on a `request_changes` verdict. This makes that re-run use a **stronger** model: on the Nth rejection, the revision dispatches with `escalate[N-1]` instead of the base model.

```yaml
steps:
  - agent:
      prompt: "draft the release notes"
      driver: local            # start cheap / on-device (MLX/Ollama)
      model: llama3.1
      into: draft
      escalate:                # …escalate only when the judge rejects
        - { driver: anthropic, model: claude-sonnet-4-6 }
        - { driver: anthropic, model: claude-opus-4-8 }
  - agent:
      kind: judge
      reviews: draft
      max_revisions: 2
      prompt: "is this publishable? request_changes with a fixList if not"
```
First pass runs locally (free). If the judge rejects → revision 1 re-runs on Sonnet; still rejects → revision 2 on Opus. Approve at any point ends the loop. You pay for cloud **only when local fails judgment**.

### Design
- `escalate` overrides driver/model on the revise dispatch; when escalating, `downshift` is dropped for that call (escalation means "go stronger", it must not be re-downshifted). Absent ⇒ every revision reuses the base model — **byte-identical** to prior behavior.
- Validation shares a new `validateRouteCandidateList` helper with `downshift` (same error codes preserved → existing downshift tests still pass); schema (`schemaGenerator`) + lint both cover `escalate`.
- Flat-runner judge→refine only (consistent with judge→refine being flat-only today).

### Tests
Escalation behavior — revision re-runs on `escalate[0]`'s model, and reuses the base model when `escalate` is absent (2). Escalate validation — array/entry/driver-enum (4). Full bridge suite green (8,079), tsc + biome + all 3 audit gates clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
