### PR TITLE
feat(recipes): constrained-decoding for judge verdicts (response_format)

### DIFF
--- a/src/recipes/__tests__/judgeRefineLoop.test.ts
+++ b/src/recipes/__tests__/judgeRefineLoop.test.ts
@@ -348,3 +348,56 @@ describe("judge→refine: quality-aware escalation", () => {
     expect(reviseModels).toEqual(["claude-haiku-4-5-20251001"]);
   });
 });
+
+describe("judge: constrained decoding (response_format)", () => {
+  it("requests JSON response_format for a judge on a provider driver, not the writer", async () => {
+    const captured: Array<Record<string, unknown> | undefined> = [];
+    const recipe = {
+      name: "judge-constrained",
+      trigger: { type: "manual" },
+      steps: [
+        {
+          agent: {
+            prompt: "write the thing",
+            driver: "openai",
+            model: "gpt-x",
+            into: "draft",
+          },
+        },
+        {
+          agent: {
+            kind: "judge",
+            reviews: "draft",
+            prompt: "review the draft",
+            driver: "openai",
+            model: "gpt-x",
+          },
+        },
+      ],
+    } as YamlRecipe;
+
+    const deps: RunnerDeps = {
+      now: () => new Date("2026-06-03T08:00:00Z"),
+      logDir,
+      providerDriverFn: async (
+        _driver: string,
+        prompt: string,
+        _model: string | undefined,
+        providerOptions?: Record<string, unknown>,
+      ) => {
+        captured.push(providerOptions);
+        // Judge sees the <artefact> block; writer does not.
+        return prompt.includes("<artefact>") ? APPROVE : "DRAFT v1";
+      },
+    };
+
+    await runYamlRecipe(recipe, deps);
+
+    // Two provider calls: writer (no options) then judge (constrained).
+    expect(captured).toHaveLength(2);
+    expect(captured[0]).toBeUndefined(); // writer step — unconstrained
+    expect(captured[1]).toEqual({
+      responseFormat: { type: "json_object" },
+    });
+  });
+});

--- a/src/recipes/agentExecutor.ts
+++ b/src/recipes/agentExecutor.ts
@@ -48,6 +48,9 @@ export interface AgentExecutorDeps {
     driver: "openai" | "grok" | "gemini" | "gemini-api",
     prompt: string,
     model: string | undefined,
+    /** Opaque per-call driver options (e.g. responseFormat for constrained
+     * decoding). Forwarded to driver.run; drivers ignore keys they don't use. */
+    providerOptions?: Record<string, unknown>,
   ) => Promise<AgentResult>;
   claudeCliFn: (
     prompt: string,
@@ -71,6 +74,13 @@ export interface AgentExecutorInput {
    * Ignored by API drivers — they reach the bridge through other means.
    */
   mcpAccess?: boolean;
+  /**
+   * Opaque per-call driver options forwarded to the provider driver (e.g.
+   * `{ responseFormat: { type: "json_object" } }` for constrained decoding).
+   * Only the provider-driver path (openai/grok/gemini-api) consumes it; other
+   * drivers ignore it. Used by the judge to enforce parseable JSON verdicts.
+   */
+  providerOptions?: Record<string, unknown>;
 }
 
 /**
@@ -84,7 +94,7 @@ export async function executeAgent(
   input: AgentExecutorInput,
   deps: AgentExecutorDeps,
 ): Promise<AgentResult> {
-  const { prompt, driver, model, mcpAccess } = input;
+  const { prompt, driver, model, mcpAccess, providerOptions } = input;
   const cliOpts = mcpAccess !== undefined ? { mcpAccess } : undefined;
 
   // Stamp the driver that ACTUALLY ran onto the result. This is the single
@@ -121,7 +131,15 @@ export async function executeAgent(
     driver === "gemini" ||
     driver === "gemini-api"
   ) {
-    return stamp(driver, model, deps.providerDriverFn(driver, prompt, model));
+    return stamp(
+      driver,
+      model,
+      // Only pass the 4th arg when set so the common (unconstrained) call keeps
+      // its 3-arg shape — backward-compatible with callers/mocks.
+      providerOptions
+        ? deps.providerDriverFn(driver, prompt, model, providerOptions)
+        : deps.providerDriverFn(driver, prompt, model),
+    );
   }
   if (driver === "subprocess" || driver === "claude-code") {
     return stamp("subprocess", model, deps.claudeCliFn(prompt, cliOpts));

--- a/src/recipes/yamlRunner.ts
+++ b/src/recipes/yamlRunner.ts
@@ -558,6 +558,7 @@ export interface RunnerDeps {
     driverName: "openai" | "grok" | "gemini" | "gemini-api",
     prompt: string,
     model: string | undefined,
+    providerOptions?: Record<string, unknown>,
   ) => Promise<string | AgentResult>;
   /** Mock connector replays used by `patchwork recipe test`. */
   mockConnectors?: Partial<Record<string, MockToolConnector>>;
@@ -1281,6 +1282,7 @@ export async function runYamlRecipe(
     model: string | undefined,
     mcpAccess: boolean | undefined,
     downshift?: RouteCandidate[],
+    providerOptions?: Record<string, unknown>,
   ): Promise<{ value: unknown; ok: boolean }> => {
     // Phase 4: route revisions too, so a downshift on the reviewed step also
     // applies to its refine-loop re-runs (no-op when downshift is absent).
@@ -1296,6 +1298,7 @@ export async function runYamlRecipe(
         driver: routed.driver === "api" ? "anthropic" : routed.driver,
         model: routed.model,
         ...(mcpAccess !== undefined && { mcpAccess }),
+        ...(providerOptions && { providerOptions }),
       },
       buildAgentExecutorDeps(stepDeps, deps),
     );
@@ -1454,6 +1457,9 @@ export async function runYamlRecipe(
         agentCfg.driver,
         agentCfg.model,
         agentCfg.mcpAccess,
+        undefined,
+        // Re-judge is a judge call → enforce JSON on supporting drivers.
+        { responseFormat: { type: "json_object" } },
       );
       if (!judged.ok) {
         // Audit 2026-06-03 (MEDIUM #17): a failed / silent-fail / empty
@@ -1677,6 +1683,12 @@ export async function runYamlRecipe(
               model: routed.model,
               ...(agentCfg.mcpAccess !== undefined && {
                 mcpAccess: agentCfg.mcpAccess,
+              }),
+              // Constrained decoding: enforce a pure-JSON verdict on judge steps
+              // (OpenAI-compatible drivers honor it; others ignore it). Pairs
+              // with the pure-JSON JUDGE_PROMPT_SUFFIX + tolerant parser.
+              ...(isJudge && {
+                providerOptions: { responseFormat: { type: "json_object" } },
               }),
             },
             buildAgentExecutorDeps(stepDeps, deps),
@@ -2623,8 +2635,19 @@ function buildAgentExecutorDeps(
   return {
     anthropicFn: async (prompt, model) =>
       toAgentResult(await stepDeps.claudeFn(prompt, model)),
-    providerDriverFn: async (driver, prompt, model) =>
-      toAgentResult(await stepDeps.providerDriverFn(driver, prompt, model)),
+    providerDriverFn: async (driver, prompt, model, providerOptions) =>
+      toAgentResult(
+        // Keep the 3-arg call shape when unconstrained (backward-compatible
+        // with deps.providerDriverFn mocks that assert exact arity).
+        providerOptions
+          ? await stepDeps.providerDriverFn(
+              driver,
+              prompt,
+              model,
+              providerOptions,
+            )
+          : await stepDeps.providerDriverFn(driver, prompt, model),
+      ),
     claudeCliFn: async (prompt, opts) =>
       toAgentResult(await claudeCliFn(prompt, opts)),
     localFn: async (prompt, model) =>
@@ -2834,12 +2857,14 @@ export function makeProviderDriverFn(): (
   driverName: "openai" | "grok" | "gemini" | "gemini-api",
   prompt: string,
   model: string | undefined,
+  providerOptions?: Record<string, unknown>,
 ) => Promise<string | AgentResult> {
   const cache = new Map<string, import("../drivers/types.js").ProviderDriver>();
   return async function defaultProviderDriverFn(
     driverName: "openai" | "grok" | "gemini" | "gemini-api",
     prompt: string,
     model: string | undefined,
+    providerOptions?: Record<string, unknown>,
   ): Promise<string | AgentResult> {
     try {
       let driver = cache.get(driverName);
@@ -2868,6 +2893,7 @@ export function makeProviderDriverFn(): (
           startupTimeoutMs,
           signal: controller.signal,
           model,
+          ...(providerOptions && { providerOptions }),
         });
         if (result.exitCode !== undefined && result.exitCode !== 0) {
           const detail = result.stderrTail ?? result.text ?? "";


### PR DESCRIPTION
## Constrained-decoding for judge verdicts (response_format)

The keystone's final piece: **enforce** the judge's JSON output, not just parse it tolerantly (#970). Judge→refine (#859) and quality-aware escalation (#969) are only as reliable as the verdict parsing — the audit traced real halts to unparseable verdicts from smaller/local models.

### What it does
- Adds an optional **`providerOptions`** channel threaded through the agent path: `AgentExecutorInput` → `executeAgent` → `providerDriverFn` → `driver.run` (the OpenAI driver seam that consumes `responseFormat` already shipped, commit `783a8e95`).
- **Judge steps** (first verdict + re-judge) now request `{ responseFormat: { type: "json_object" } }`. On OpenAI-compatible drivers this forces a pure-JSON response; other drivers ignore the unknown key. Pairs with #970's pure-JSON prompt + tolerant parser.

### Safety / design
- **Additive + backward-compatible**: `providerOptions` is optional everywhere; the unconstrained (non-judge) call keeps its **3-arg shape** so existing behavior and mocks are untouched (verified — the provider-driver arity tests still pass).
- The `providerOptions` channel is **reusable** — any future structured-output step (or the deferred mid-agent-abort signal) can ride it.
- Writer/non-judge steps are never constrained.

### Tests
+1: a judge on a provider driver receives `response_format` while the writer step does not. Full bridge suite green (8,095), tsc + biome + fixtures/lsp gates clean. OpenAI `response_format` seam tests unchanged.

### The moat, now complete
try cheap/local → **enforce + tolerantly-parse** the judge verdict → **escalate** to a stronger model only on rejection. #859 + #969 + #970 + this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
