### PR TITLE
chore(release): v0.2.0-beta.12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "patchwork-os",
-  "version": "0.2.0-beta.11",
+  "version": "0.2.0-beta.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "patchwork-os",
-      "version": "0.2.0-beta.11",
+      "version": "0.2.0-beta.12",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "patchwork-os",
-  "version": "0.2.0-beta.11",
+  "version": "0.2.0-beta.12",
   "description": "Your personal AI runtime, local-first. Patchwork OS gives any AI model a consistent set of tools, YAML recipes, a delegation policy with approval queue, and a durable trace memory — all on your machine, all under your policy.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## chore(release): v0.2.0-beta.12

Bumps `patchwork-os` 0.2.0-beta.11 → **0.2.0-beta.12**. On merge, push the `v0.2.0-beta.12` tag to trigger `publish-npm.yml` → `npm publish --tag beta` (OIDC trusted-publisher).

### What's in this beta (since beta.11, 44 commits)
**Recipe run-cancellation (new):**
- Run registry + `POST /runs/:seq/cancel` + dashboard Cancel button (#967)
- Mid-step abort — cancel takes effect even during an in-flight LLM call (#968)

**AI-native quality routing (the moat):**
- Quality-aware **escalation** — escalate to a stronger model on judge rejection (#969)
- Judge verdict reliability — tolerant parse + pure-JSON prompt (#970)
- **Constrained decoding** — enforce JSON verdicts via `response_format` (#971)

**Recipe engine + connectors:**
- MongoDB recipe steps → **46/46 connector-step parity** (#966)
- `parallel:{each}` fail-loud guard (no more silent no-op) (#966)
- NET-001 EADDRINUSE test determinism + safe `close()` (#966)

**Correctness/security:** the 84-finding full-codebase audit fixes (#965) and the 2026-06-09 HIGH-severity wave (#956–#958, already in beta.11's line) are all on main.

### Release checklist
- [x] version bumped (package.json + lock, version-only diff)
- [ ] CI green on this PR
- [ ] merge → push tag `v0.2.0-beta.12` → beta publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)
