### PR TITLE
fix(ci): grant contents:write to publish-alpha/beta for the release step

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -34,7 +34,9 @@ jobs:
     # exchanges the GitHub Actions OIDC token for a short-lived registry
     # credential, so no NPM_TOKEN secret is stored or can expire.
     permissions:
-      contents: read
+      # write so the post-publish "Create GitHub pre-release" step
+      # (gh release create) can create the release; read 401'd it.
+      contents: write
       id-token: write
     steps:
       - uses: actions/checkout@v4
@@ -99,7 +101,9 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/') && contains(github.ref, '-beta')
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      # write so the post-publish "Create GitHub pre-release" step
+      # (gh release create) can create the release; read 401'd it.
+      contents: write
       id-token: write
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Fixes the recurring red on every alpha/beta release.

The `publish-alpha`/`publish-beta` jobs had `contents: read`, so the post-publish **Create GitHub pre-release** step (`gh release create`) failed `HTTP 401: Bad credentials`. `npm publish` runs first and succeeds (OIDC), so packages shipped fine but the job showed red and no GitHub release was auto-created (e.g. v0.2.0-beta.12 had to be created manually).

Bump both jobs to `contents: write` (matching the stable `publish` job); `id-token: write` retained for OIDC trusted publishing. `publish-canary` left at `read` (no release step).
