### PR TITLE
feat(recipes): M3 safe-half — classifyTool tiering fix + flat-runner approval gate + SimulatePanel default

### DIFF
--- a/dashboard/src/app/recipes/[...name]/page.tsx
+++ b/dashboard/src/app/recipes/[...name]/page.tsx
@@ -340,8 +340,11 @@ function RecipeHubOverviewPage({ name }: { name: string }) {
   // Deep-link: `?diagnose=1` (from the recipes list / failed-run views)
   // auto-runs the Doctor panel and scrolls to it.
   const autoDiagnose = useSearchParams().get("diagnose") === "1";
-  // Deep-link: `?simulate=1` auto-runs the What-If Preview panel + scrolls to it.
-  const autoSimulate = useSearchParams().get("simulate") === "1";
+  // M3 — the What-If Preview is the DEFAULT pre-run affordance: it auto-runs on
+  // every recipe view so the operator sees what a run would do (risk tiers,
+  // writes, blast radius) before clicking Run. Opt out with `?simulate=0`.
+  // `?simulate=1` still works (and scrolls to the panel via the deep-link).
+  const autoSimulate = useSearchParams().get("simulate") !== "0";
 
   // Reusable list fetch for the recipe row (matches layout's data source).
   const { data: recipes, refetch: refetchRecipes } = useBridgeFetch<Recipe[]>(

--- a/dashboard/src/lib/haltCategory.ts
+++ b/dashboard/src/lib/haltCategory.ts
@@ -21,6 +21,7 @@ export type HaltCategory =
   | "rate_limited"
   | "network_error"
   | "missing_connector"
+  | "approval_rejected"
   | "run_level"
   | "unknown";
 
@@ -44,6 +45,7 @@ export const HALT_CATEGORY_LABEL: Record<HaltCategory, string> = {
   rate_limited: "rate limited",
   network_error: "network error",
   missing_connector: "missing connector",
+  approval_rejected: "approval rejected",
   run_level: "run-level halt",
   unknown: "uncategorised",
 };
@@ -76,6 +78,8 @@ export const HALT_CATEGORY_HINT: Record<HaltCategory, string> = {
     "Transport-level failure (DNS, refused, timeout). Check connectivity to the upstream service.",
   missing_connector:
     "Recipe references a connector that isn't configured. Install/connect from /connections.",
+  approval_rejected:
+    "A step was rejected at the approval gate. Approve it from the dashboard, or set requireApproval: false on the recipe.",
   run_level:
     "Whole-recipe failure (no step ran). Check the recipe for circular deps / parse errors.",
   unknown: "Uncategorised halt. Open the run trace for the raw error.",

--- a/src/__tests__/riskTier.test.ts
+++ b/src/__tests__/riskTier.test.ts
@@ -1,0 +1,83 @@
+/**
+ * classifyTool tiering — including the namespaced recipe-tool-id fix.
+ *
+ * Bug (M3, audit follow-up): `classifyTool` / `inferTierFromName` were written
+ * for camelCase MCP tool names (gitPush, githubCreatePR) and had no handling
+ * for the namespaced `namespace.verb` recipe tool ids (github.list_issues,
+ * slack.post_message, jira.get_issue, …). Every namespaced id fell through to
+ * the uniform "medium" default — so connector READS were over-tiered and the
+ * approval gate's tier disagreed with the simulation/registry (riskDefault).
+ *
+ * The fix: (1) an authoritative resolver hook the recipe tool registry
+ * populates with each tool's `riskDefault`, and (2) a namespaced heuristic
+ * fallback (read verbs → low, write verbs → medium) that matches the registry's
+ * `isWrite ? medium : low` convention when the registry isn't loaded.
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  classifyTool,
+  type RiskTier,
+  registerTierResolver,
+} from "../riskTier.js";
+
+afterEach(() => {
+  // Clear any resolver a test installed so cases don't leak into each other.
+  registerTierResolver(null);
+});
+
+describe("classifyTool — camelCase MCP names (unchanged)", () => {
+  it("keeps known high/medium/low MCP tools", () => {
+    expect(classifyTool("gitPush")).toBe("high");
+    expect(classifyTool("editText")).toBe("medium");
+    expect(classifyTool("getDiagnostics")).toBe("low");
+  });
+});
+
+describe("classifyTool — namespaced recipe tool ids (the bug)", () => {
+  it("classifies connector READS as low, not the uniform medium default", () => {
+    expect(classifyTool("github.list_issues")).toBe("low");
+    expect(classifyTool("jira.get_issue")).toBe("low");
+    expect(classifyTool("gmail.search")).toBe("low");
+    expect(classifyTool("datadog.list_monitors")).toBe("low");
+  });
+
+  it("classifies connector WRITES as medium (matches registry convention)", () => {
+    expect(classifyTool("slack.post_message")).toBe("medium");
+    expect(classifyTool("jira.create_issue")).toBe("medium");
+    expect(classifyTool("http.post")).toBe("medium");
+    expect(classifyTool("sendgrid.send_email")).toBe("medium");
+  });
+
+  it("defaults an unrecognized namespaced verb to medium (safe)", () => {
+    expect(classifyTool("weird.frobnicate")).toBe("medium");
+  });
+});
+
+describe("classifyTool — authoritative resolver hook", () => {
+  it("uses the registered resolver's riskDefault for namespaced ids", () => {
+    const table: Record<string, RiskTier> = {
+      "github.list_issues": "low",
+      "custom.escalate": "high", // registry could mark a tool high
+    };
+    registerTierResolver((id) => table[id]);
+    expect(classifyTool("custom.escalate")).toBe("high");
+    expect(classifyTool("github.list_issues")).toBe("low");
+  });
+
+  it("falls back to the heuristic when the resolver returns undefined", () => {
+    registerTierResolver(() => undefined);
+    expect(classifyTool("github.list_issues")).toBe("low");
+    expect(classifyTool("slack.post_message")).toBe("medium");
+  });
+
+  it("does not consult the resolver for non-namespaced names", () => {
+    let called = false;
+    registerTierResolver((_id) => {
+      called = true;
+      return "high";
+    });
+    expect(classifyTool("getDiagnostics")).toBe("low");
+    expect(called).toBe(false);
+  });
+});

--- a/src/recipeOrchestration.ts
+++ b/src/recipeOrchestration.ts
@@ -52,6 +52,39 @@ import type { Server } from "./server.js";
 // all others used 1_800_000ms (30 min).
 export const RECIPE_TASK_TIMEOUT_MS = 1_800_000;
 
+/**
+ * M3 — build the flat-runner approval fn backed by the bridge ApprovalQueue.
+ * Returns true (allow) for steps below the gate threshold; otherwise queues a
+ * human approval and resolves true only on an explicit "approved" decision
+ * (a reject / expire / cancel halts the run — fail-closed, ADR-0016 spirit).
+ */
+async function makeRecipeApprovalFn(
+  gate: "high" | "all",
+): Promise<
+  (input: {
+    toolId: string;
+    tier: import("./riskTier.js").RiskTier;
+    summary?: string;
+    params?: Record<string, unknown>;
+  }) => Promise<boolean>
+> {
+  const { getApprovalQueue } = await import("./approvalQueue.js");
+  const queue = getApprovalQueue();
+  return async (input) => {
+    // Below-threshold steps don't need sign-off.
+    if (gate === "high" && input.tier !== "high") return true;
+    const { promise } = queue.request({
+      toolName: input.toolId,
+      params: input.params ?? {},
+      tier: input.tier,
+      sessionId: "recipe",
+      ...(input.summary !== undefined && { summary: input.summary }),
+    });
+    const decision = await promise;
+    return decision === "approved";
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Public interfaces
 // ---------------------------------------------------------------------------
@@ -935,7 +968,21 @@ export class RecipeOrchestration {
       });
       return task.output ?? task.errorMessage ?? "";
     };
-    const runnerDeps = { workdir: this.deps.workdir, claudeCodeFn };
+    // M3 — flat-runner approval gate. Inject a queue-backed approval fn
+    // whenever the bridge's approvalGate is engaged. The flat runner only
+    // consults it for `manual`-triggered runs (safe-by-default: automated
+    // cron/webhook runs never block mid-flight), so this injection does not
+    // need to inspect the trigger type here.
+    const approvalGate = this.deps.server?.approvalGate ?? "off";
+    const requireApprovalFn =
+      approvalGate === "off"
+        ? undefined
+        : await makeRecipeApprovalFn(approvalGate);
+    const runnerDeps = {
+      workdir: this.deps.workdir,
+      claudeCodeFn,
+      ...(requireApprovalFn && { requireApprovalFn }),
+    };
     // Pass the bridge's long-lived RecipeRunLog so chainedRunner can flip the
     // run from `running` → terminal in-place via startRun/completeRun. The
     // dashboard reads the same instance, so /runs surfaces the live entry

--- a/src/recipes/__tests__/flatRunnerApproval.test.ts
+++ b/src/recipes/__tests__/flatRunnerApproval.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Flat-runner approval gate (M3).
+ *
+ * The gate is safe-by-default:
+ *   - only engages for `manual`-triggered runs (cron/webhook/recipe never block);
+ *   - only when the bridge injects `requireApprovalFn` (approvalGate != "off");
+ *   - per-recipe opt-out via `requireApproval: false`;
+ *   - a `false` result is an explicit human rejection → the run HALTS with
+ *     haltCategory "approval_rejected" and later steps do not execute.
+ */
+
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, describe, expect, it, vi } from "vitest";
+import {
+  type RunnerDeps,
+  runYamlRecipe,
+  type YamlRecipe,
+} from "../yamlRunner.js";
+
+const TMP = mkdtempSync(path.join(os.tmpdir(), "flat-approval-"));
+afterAll(() => rmSync(TMP, { recursive: true, force: true }));
+
+function deps(extra: Partial<RunnerDeps> = {}): RunnerDeps {
+  return {
+    now: () => new Date("2026-06-22T12:00:00Z"),
+    logDir: TMP,
+    readFile: () => {
+      throw new Error("nf");
+    },
+    writeFile: () => {},
+    appendFile: () => {},
+    mkdir: () => {},
+    gitLogSince: () => "",
+    gitStaleBranches: () => "",
+    getDiagnostics: () => "",
+    ...extra,
+  };
+}
+
+function recipe(
+  trigger: { type: string },
+  overrides: Partial<YamlRecipe> = {},
+): YamlRecipe {
+  return {
+    name: "approval-flat",
+    trigger,
+    steps: [
+      { tool: "file.write", path: `${TMP}/a`, content: "1" },
+      { tool: "file.write", path: `${TMP}/b`, content: "2" },
+    ],
+    ...overrides,
+  } as YamlRecipe;
+}
+
+describe("flat-runner approval gate", () => {
+  it("halts the run when a manual step is rejected", async () => {
+    let writes = 0;
+    // Reject the 2nd step (b), allow the first.
+    const requireApprovalFn = vi.fn(
+      async (i: { params?: Record<string, unknown> }) => {
+        return i.params?.path !== `${TMP}/b`;
+      },
+    );
+    const result = await runYamlRecipe(
+      recipe({ type: "manual" }),
+      deps({
+        requireApprovalFn,
+        writeFile: () => {
+          writes++;
+        },
+      }),
+    );
+    expect(requireApprovalFn).toHaveBeenCalledTimes(2);
+    expect(writes).toBe(1); // only the approved step wrote
+    const rejected = result.stepResults.find(
+      (s) => s.haltCategory === "approval_rejected",
+    );
+    expect(rejected).toBeDefined();
+    expect(result.errorMessage).toMatch(/approval_rejected/);
+  });
+
+  it("runs all steps when every manual step is approved", async () => {
+    let writes = 0;
+    const requireApprovalFn = vi.fn(async () => true);
+    await runYamlRecipe(
+      recipe({ type: "manual" }),
+      deps({
+        requireApprovalFn,
+        writeFile: () => {
+          writes++;
+        },
+      }),
+    );
+    expect(requireApprovalFn).toHaveBeenCalledTimes(2);
+    expect(writes).toBe(2);
+  });
+
+  it("NEVER consults the gate for cron triggers (crons don't block)", async () => {
+    let writes = 0;
+    const requireApprovalFn = vi.fn(async () => false); // would reject everything
+    await runYamlRecipe(
+      recipe({ type: "cron" }),
+      deps({
+        requireApprovalFn,
+        writeFile: () => {
+          writes++;
+        },
+      }),
+    );
+    expect(requireApprovalFn).not.toHaveBeenCalled();
+    expect(writes).toBe(2); // cron ran unblocked
+  });
+
+  it("per-recipe opt-out (requireApproval:false) skips the gate on manual runs", async () => {
+    let writes = 0;
+    const requireApprovalFn = vi.fn(async () => false);
+    await runYamlRecipe(
+      recipe({ type: "manual" }, { requireApproval: false }),
+      deps({
+        requireApprovalFn,
+        writeFile: () => {
+          writes++;
+        },
+      }),
+    );
+    expect(requireApprovalFn).not.toHaveBeenCalled();
+    expect(writes).toBe(2);
+  });
+
+  it("is a no-op when no requireApprovalFn is injected (approvalGate off)", async () => {
+    let writes = 0;
+    await runYamlRecipe(
+      recipe({ type: "manual" }),
+      deps({
+        writeFile: () => {
+          writes++;
+        },
+      }),
+    );
+    expect(writes).toBe(2);
+  });
+});

--- a/src/recipes/haltCategory.ts
+++ b/src/recipes/haltCategory.ts
@@ -52,6 +52,11 @@ export type HaltCategory =
    * Actionable: install/connect from /connections.
    */
   | "missing_connector"
+  /**
+   * A human rejected the step at the flat-runner approval gate (M3). Distinct
+   * from a tool failure — the run was deliberately stopped by an operator.
+   */
+  | "approval_rejected"
   /** Whole-recipe failure (e.g. circular dependencies) — has no step row. */
   | "run_level"
   | "unknown";
@@ -76,6 +81,7 @@ export const HALT_CATEGORY_LABELS: Record<HaltCategory, string> = {
   rate_limited: "rate limited",
   network_error: "network error",
   missing_connector: "missing connector",
+  approval_rejected: "approval rejected",
   run_level: "run-level halt",
   unknown: "uncategorised",
 };
@@ -101,6 +107,8 @@ export const HALT_CATEGORY_HINTS: Record<HaltCategory, string> = {
   rate_limited: "back off cron cadence or wait",
   network_error: "check connectivity to upstream",
   missing_connector: "install/connect from /connections",
+  approval_rejected:
+    "approve the step from the dashboard, or set requireApproval: false",
   run_level: "check recipe for circular deps / parse errors",
   unknown: "open run trace for raw error",
 };
@@ -118,6 +126,8 @@ export function categoriseHaltReason(reason: string | undefined): HaltCategory {
   if (/kill[- _]?switch/i.test(reason)) return "kill_switch";
   if (/budget[_ ]?exceeded|exceeded its token budget/i.test(reason))
     return "budget_exceeded";
+  if (/approval[_ ]?rejected|rejected by .*approval/i.test(reason))
+    return "approval_rejected";
   if (/^expect_failed/i.test(reason)) return "expect_failed";
   // Opt-in judge→refine loop exhaustion (`judge "x" did not approve after N
   // revisions`). Must precede the generic `Agent step ... threw` matcher.

--- a/src/recipes/simulation/aggregateRunRisk.ts
+++ b/src/recipes/simulation/aggregateRunRisk.ts
@@ -10,9 +10,12 @@
  *   2. `summarizeRunRisk` — a transparent 0–100 workflow score derived from
  *      step counts, returned WITH its components so it is never a black box.
  *
- * Risk tier source is `riskDefault` (already enriched onto the plan step),
- * NOT `classifyTool` — which mis-tiers namespaced recipe tool ids to a uniform
- * "medium" (see the investigation report, §3b).
+ * Risk tier source is `riskDefault` (already enriched onto the plan step) —
+ * the registry's authoritative value. `classifyTool` now agrees for namespaced
+ * recipe tool ids (it consults the same registry via a resolver hook, with a
+ * read/write verb fallback), so the approval gate and this simulation no longer
+ * disagree. We keep reading `riskDefault` directly here since it's already on
+ * the step — no need to re-look-up.
  */
 
 import type {

--- a/src/recipes/toolRegistry.ts
+++ b/src/recipes/toolRegistry.ts
@@ -10,6 +10,7 @@
  */
 
 import { assertWriteAllowed } from "../featureFlags.js";
+import { registerTierResolver } from "../riskTier.js";
 import { deriveIdempotencyKey } from "./idempotencyKey.js";
 import type { RunContext, StepDeps } from "./yamlRunner.js";
 
@@ -54,6 +55,12 @@ export interface RegisteredTool extends ToolMetadata {
 
 /** Internal registry map */
 const registry = new Map<string, RegisteredTool>();
+
+// Make the recipe tool registry the authoritative source of risk tiers for
+// namespaced tool ids in classifyTool (approval gate, simulation, dashboard).
+// Lazy: resolves at call time so it reflects whatever has registered so far.
+// (Dependency points registry → riskTier; riskTier imports nothing → no cycle.)
+registerTierResolver((id) => registry.get(id)?.riskDefault);
 
 /**
  * Register a tool. Duplicate IDs throw.

--- a/src/recipes/yamlRunner.ts
+++ b/src/recipes/yamlRunner.ts
@@ -42,6 +42,7 @@ import { sanitizeEnv } from "../drivers/claude/envSanitizer.js";
 import { isLoopbackOrPrivateEndpoint } from "../localEndpointGuard.js";
 import { loadConfig as loadPatchworkConfigSync } from "../patchworkConfig.js";
 import { findYamlRecipePath } from "../recipesHttp.js";
+import { classifyTool } from "../riskTier.js";
 import type { RecipeRunLog } from "../runLog.js";
 /**
  * Local alias for `sanitizeParsedJson` from `src/sanitizeParsedJson.ts`.
@@ -483,6 +484,15 @@ export interface YamlRecipe {
   on_error?: ErrorPolicy;
   /** PR2b — per-recipe token budget (see `BudgetPolicy` in schema.ts). */
   budget?: import("./schema.js").BudgetPolicy;
+  /**
+   * M3 — per-recipe opt-out of the flat-runner approval gate. The gate is
+   * safe-by-default: it only ever engages for `manual`-triggered runs (so
+   * automated cron/webhook runs never block mid-flight) and only when the
+   * bridge injects a `requireApprovalFn` (i.e. approvalGate != "off"). Set
+   * `requireApproval: false` to disable the gate for this recipe even on a
+   * manual run.
+   */
+  requireApproval?: boolean;
 }
 
 export type RunContext = Record<string, string>;
@@ -581,6 +591,21 @@ export interface RunnerDeps {
    * semantics). Caller-supplied; left unset for cron / webhook runs.
    */
   manualRunId?: string;
+  /**
+   * M3 — flat-runner approval gate. When the bridge injects this (only when
+   * `approvalGate != "off"`), the runner calls it before each step on a
+   * `manual`-triggered run and HALTS the run if it resolves `false` (human
+   * rejected). The fn itself applies the gate threshold (high/all) against the
+   * step's tier and returns `true` for steps that don't need sign-off, so the
+   * runner only has to act on an explicit rejection. Never consulted for
+   * automated (cron/webhook/recipe) triggers, so crons can't block mid-run.
+   */
+  requireApprovalFn?: (input: {
+    toolId: string;
+    tier: import("../riskTier.js").RiskTier;
+    summary?: string;
+    params?: Record<string, unknown>;
+  }) => Promise<boolean>;
 }
 
 export interface RunResult {
@@ -684,6 +709,9 @@ export type StepDeps = Required<
     | "ledgerDir"
     | "manualRunId"
     | "activityLog"
+    // M3 — approval gate runs in the run loop against `deps`, not per-step
+    // StepDeps; keep it off StepDeps so it isn't forced Required here.
+    | "requireApprovalFn"
   >
 > & {
   workdir: string;
@@ -1642,6 +1670,48 @@ export async function runYamlRecipe(
         persistLiveStepResults();
         emitStepDone(stepIdForEmit);
         continue;
+      }
+
+      // M3 — flat-runner approval gate. Safe-by-default: only engages for
+      // `manual`-triggered runs (cron/webhook/recipe runs never block
+      // mid-flight) and only when the bridge injected `requireApprovalFn`
+      // (i.e. approvalGate != "off"). Per-recipe opt-out via
+      // `requireApproval: false`. The injected fn applies the tier threshold
+      // itself and returns `true` for steps that don't need sign-off; a
+      // `false` result is an explicit human rejection → halt the run.
+      if (
+        deps.requireApprovalFn &&
+        recipeTriggerKind === "manual" &&
+        recipe.requireApproval !== false
+      ) {
+        const approvalToolId = step.agent ? "agent" : (step.tool ?? "unknown");
+        const approved = await deps.requireApprovalFn({
+          toolId: approvalToolId,
+          tier: classifyTool(approvalToolId),
+          summary: step.agent
+            ? `agent step${step.agent.into ? ` → ${step.agent.into}` : ""}`
+            : `tool ${approvalToolId}`,
+          params: step.agent ? undefined : (step as Record<string, unknown>),
+        });
+        if (!approved) {
+          const reason = `Step rejected by approval gate — approval_rejected.`;
+          runError = runError ?? reason;
+          haltAfterFailure = true;
+          const rejId = step.into ?? step.agent?.into ?? `step_${stepsRun}`;
+          stepResults.push({
+            id: rejId,
+            tool: step.agent ? "agent" : step.tool,
+            status: "error",
+            error: reason,
+            haltReason: reason,
+            haltCategory: "approval_rejected",
+            durationMs: 0,
+          });
+          stepsRun++;
+          persistLiveStepResults();
+          emitStepDone(stepIdForEmit);
+          continue;
+        }
       }
 
       // Handle agent steps separately

--- a/src/riskTier.ts
+++ b/src/riskTier.ts
@@ -150,7 +150,49 @@ export function inferTierFromName(toolName: string): RiskTier {
   return "medium";
 }
 
+/**
+ * Read vs write verb heuristics for namespaced recipe tool ids
+ * (`namespace.verb`, e.g. `github.list_issues`). Mirrors the recipe tool
+ * registry's default convention (`isWrite ? "medium" : "low"`) so the approval
+ * gate agrees with the simulation/registry even when the registry has not been
+ * loaded (e.g. a bare classifyTool call in a transport module).
+ */
+const NAMESPACED_READ_VERB =
+  /^(list|get|search|fetch|read|describe|resolve|lookup|view|count|find|query|export|download|preview|check|status|stats?)/;
+const NAMESPACED_WRITE_VERB =
+  /^(create|post|send|update|add|delete|remove|comment|write|set|merge|close|archive|move|upload|publish|reply|assign|transition|edit|put|patch|cancel|run|trigger|invite|react|upsert)/;
+
+function inferTierFromNamespacedId(id: string): RiskTier {
+  const verb = id.slice(id.indexOf(".") + 1).toLowerCase();
+  if (NAMESPACED_READ_VERB.test(verb)) return "low";
+  if (NAMESPACED_WRITE_VERB.test(verb)) return "medium";
+  return "medium"; // unknown verb → conservative default
+}
+
+/**
+ * Optional authoritative resolver, populated by the recipe tool registry with
+ * each tool's declared `riskDefault`. When set and it returns a tier for a
+ * namespaced id, that tier wins over the heuristic — keeping a single source of
+ * truth. The dependency points registry → riskTier (riskTier imports nothing),
+ * so there is no import cycle.
+ */
+export type TierResolver = (toolName: string) => RiskTier | undefined;
+let tierResolver: TierResolver | null = null;
+
+export function registerTierResolver(fn: TierResolver | null): void {
+  tierResolver = fn;
+}
+
 export function classifyTool(toolName: string): RiskTier {
+  // Namespaced recipe tool ids (`namespace.verb`) never appear in TIER_MAP and
+  // do not match the camelCase heuristics — they previously fell through to the
+  // uniform "medium" default. MCP tool names match /^[a-zA-Z0-9_]+$/ (no dot),
+  // so a "." reliably marks a recipe tool id.
+  if (toolName.includes(".")) {
+    const resolved = tierResolver?.(toolName);
+    if (resolved !== undefined) return resolved;
+    return inferTierFromNamespacedId(toolName);
+  }
   // Object.hasOwn guards against prototype keys ("valueOf", "toString",
   // "constructor", etc.) which would otherwise resolve to Object.prototype
   // members instead of falling through to the heuristic.


### PR DESCRIPTION
Phase 4 "Trustworthy Substrate" — M3 (safe half). Builds on M1 (#992) + M2 (#993), both merged.

## 1. classifyTool correctly tiers namespaced recipe tool ids
`classifyTool`/`inferTierFromName` were camelCase-only (gitPush); namespaced recipe ids (`github.list_issues`, `slack.post_message`) all fell through to uniform "medium" — over-tiering connector reads and desyncing the approval gate from the simulation/registry `riskDefault`. Fix: a `registerTierResolver` hook the recipe registry populates (single source of truth, no import cycle) + a namespaced read/write verb fallback. Updates the `aggregateRunRisk` workaround comment.

## 2. Flat-runner approval gate (safe-by-default)
- `RunnerDeps.requireApprovalFn`: injected only when `approvalGate != "off"`; the flat runner requests approval before each step and HALTS (`haltCategory: "approval_rejected"`) on rejection.
- Engages **only for `manual` triggers** — cron/webhook/recipe runs never block mid-flight. Per-recipe opt-out via `requireApproval: false`.
- Threshold (high/all) applied against the step's (now-correct) tier; below-threshold steps auto-allow. Reject/expire/cancel all halt (fail-closed, ADR-0016 spirit).
- Wired in `recipeOrchestration.fireYamlRecipe` via a queue-backed fn over the bridge `ApprovalQueue` + `server.approvalGate`.
- New `approval_rejected` halt category (label/hint/categoriser + dashboard mirror).

## 3. SimulatePanel = default pre-run affordance
The recipe-detail What-If Preview auto-runs on every view (opt out `?simulate=0`), surfacing risk tiers / writes / blast radius before Run.

## Tests
`riskTier.test.ts` (tiering + resolver), `flatRunnerApproval.test.ts` (halt-on-reject, all-approved, cron-never-blocks, opt-out, no-op-when-off). Bridge: 50 pass + 3 xfail across affected suites; dashboard SimulatePanel green.

Note: `judgeReviewsValidation.test.ts` is order-sensitive in narrow subsets (pre-existing on main, passes in the full `npm test` run) — unrelated to this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)