### PR TITLE
fix(recipes): chained usdMax + cancellation parity (#850) + Runs dup-key

### DIFF
--- a/dashboard/src/components/GlobalLiveRunsStrip.tsx
+++ b/dashboard/src/components/GlobalLiveRunsStrip.tsx
@@ -93,8 +93,13 @@ export function GlobalLiveRunsStrip() {
       >
         {announce}
       </p>
-      {visible.map((r) => {
+      {visible.map((r, i) => {
         const p = pct(r);
+        // A recipe can be in flight more than once, so keying by
+        // recipeName collides (React drops/duplicates rows). Prefer the
+        // unique per-run seq with an index fallback — mirrors LiveRunsStrip.
+        const rowKey =
+          r.runSeq && r.runSeq > 0 ? `run-${r.runSeq}` : `${r.recipeName}-${i}`;
         const label =
           r.status === "running"
             ? r.totalSteps > 0
@@ -119,7 +124,7 @@ export function GlobalLiveRunsStrip() {
         );
         return href ? (
           <Link
-            key={r.recipeName}
+            key={rowKey}
             href={href}
             className="global-live-runs-strip-row"
             title={`Open run #${r.runSeq}`}
@@ -127,7 +132,7 @@ export function GlobalLiveRunsStrip() {
             {inner}
           </Link>
         ) : (
-          <span key={r.recipeName} className="global-live-runs-strip-row">
+          <span key={rowKey} className="global-live-runs-strip-row">
             {inner}
           </span>
         );

--- a/dashboard/src/components/__tests__/GlobalLiveRunsStrip.test.tsx
+++ b/dashboard/src/components/__tests__/GlobalLiveRunsStrip.test.tsx
@@ -1,0 +1,89 @@
+/**
+ * Regression test for the duplicate React key bug in the global live-runs
+ * strip.
+ *
+ * The strip renders one row per live/recent run. It used to key each row
+ * by `r.recipeName`, but the same recipe can be in flight more than once
+ * (e.g. recipe "r" with many runs). When two visible rows shared a
+ * recipeName, React logged "Encountered two children with the same key"
+ * and dropped/duplicated rows. The sibling <LiveRunsStrip/> already used a
+ * safe composite key — this is the "fix one path, miss the sibling" case.
+ *
+ * The component reads its data via the `useActiveRuns()` hook (a module
+ * singleton store keyed by recipeName), NOT via props — so we mock the
+ * hook to inject two runs that share a recipeName but have distinct
+ * runSeq, then assert React never warns about duplicate keys.
+ */
+
+import { render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ActiveRunState } from "@/hooks/useRecipeRunStream";
+
+// Mock the live-runs store so we control exactly which runs the strip
+// sees. `useActiveRuns` is the only export the component consumes.
+const mockRuns = vi.fn<() => Map<string, ActiveRunState>>();
+vi.mock("@/hooks/LiveRunsContext", () => ({
+  useActiveRuns: () => mockRuns(),
+}));
+
+import { GlobalLiveRunsStrip } from "@/components/GlobalLiveRunsStrip";
+
+function run(partial: Partial<ActiveRunState>): ActiveRunState {
+  return {
+    runSeq: 0,
+    recipeName: "r",
+    totalSteps: 3,
+    doneSteps: 1,
+    startedAt: Date.now(),
+    status: "running",
+    ...partial,
+  };
+}
+
+describe("<GlobalLiveRunsStrip/>", () => {
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    errorSpy.mockRestore();
+    mockRuns.mockReset();
+  });
+
+  it("does not warn about duplicate keys when one recipe has multiple runs", () => {
+    // Two runs of the same recipe ("r") with distinct runSeq. A Map can
+    // hold these under different keys even though they share recipeName —
+    // exactly what the bridge stream yields when a recipe runs repeatedly.
+    const m = new Map<string, ActiveRunState>();
+    m.set("r#1", run({ recipeName: "r", runSeq: 101, status: "running" }));
+    m.set("r#2", run({ recipeName: "r", runSeq: 102, status: "running" }));
+    m.set("r#3", run({ recipeName: "r", runSeq: 103, status: "ok" }));
+    mockRuns.mockReturnValue(m);
+
+    const { container } = render(<GlobalLiveRunsStrip />);
+
+    // The strip rendered rows (it is not the auto-hide empty state).
+    expect(container.querySelectorAll(".global-live-runs-strip-row").length).toBeGreaterThan(1);
+
+    // React must not have logged a duplicate-key warning.
+    const sawDupKey = errorSpy.mock.calls.some((args: unknown[]) =>
+      args.some((a) => typeof a === "string" && /same key/i.test(a)),
+    );
+    expect(sawDupKey).toBe(false);
+  });
+
+  it("renders distinct rows for runs that share a recipeName", () => {
+    const m = new Map<string, ActiveRunState>();
+    m.set("r#1", run({ recipeName: "r", runSeq: 201, status: "running" }));
+    m.set("r#2", run({ recipeName: "r", runSeq: 202, status: "running" }));
+    mockRuns.mockReturnValue(m);
+
+    const { container } = render(<GlobalLiveRunsStrip />);
+
+    // Both runs have runSeq > 0 → both render as <Link> to /runs/<seq>.
+    expect(container.querySelector('a[href="/runs/201"]')).not.toBeNull();
+    expect(container.querySelector('a[href="/runs/202"]')).not.toBeNull();
+  });
+});

--- a/scripts/audit-parity-xfails.mjs
+++ b/scripts/audit-parity-xfails.mjs
@@ -35,10 +35,8 @@ const target = path.join(
 
 // Baseline = the documented divergences that exist today. Lower this (never
 // raise it) as gaps are closed. Current xfails:
-//   1. chained usdMax not enforced through dispatchRecipe (no price table threaded)
-//   2. AbortSignal not threaded through dispatchRecipe to chainedRunner
-//   3. flat runner has no AbortSignal / cancellation seam
-const BASELINE = 3;
+//   1. flat runner has no AbortSignal / cancellation seam
+const BASELINE = 1;
 
 const raw = readFileSync(target, "utf8");
 

--- a/src/recipes/__tests__/runner.behavioral-parity.test.ts
+++ b/src/recipes/__tests__/runner.behavioral-parity.test.ts
@@ -250,7 +250,7 @@ describe("parity: budget halt on usdMax (price table)", () => {
   // and the USD cap is silently ignored. tokensMax works (no pricing needed);
   // usdMax does not. The flat runner (above) enforces it. Backlog: thread a
   // loaded priceTable into the chained dispatch options (M3/Phase 5).
-  it.fails("chained runner refuses the 2nd dispatch after usdMax breach (NOT YET — dispatch threads no price table)", async () => {
+  it("chained runner refuses the 2nd dispatch after usdMax breach", async () => {
     await withPriceTable(async () => {
       const { deps, calls } = chainedAgentDeps(HEAVY);
       const recipe = chainedAgentRecipe(
@@ -699,7 +699,7 @@ describe("DIVERGENCE (xfail): AbortSignal is not threaded through dispatchRecipe
   // has no signal plumbing at all. A pre-aborted run therefore still executes
   // every step on BOTH paths. Backlog: thread signal through dispatch + wire
   // cancellation into the flat runner (M3/Phase 5).
-  it.fails("chained run is cancelled when chainedOptions.signal is pre-aborted (NOT YET — dispatch drops signal)", async () => {
+  it("chained run is cancelled when chainedOptions.signal is pre-aborted", async () => {
     const ctl = new AbortController();
     ctl.abort("cancelled");
     const executeAgent = vi.fn(async () => ({

--- a/src/recipes/chainedRunner.ts
+++ b/src/recipes/chainedRunner.ts
@@ -778,14 +778,30 @@ export async function executeChainedStep(
       // instead of discarding it). Subscription drivers report no usage →
       // RunBudget fails open with a one-time warning.
       if (budget) {
-        // Normalize the "api" alias to "anthropic" on the no-downshift
-        // fallback path too (the downshift branch already does this at line
-        // 596). Without this, a bare-string AgentExecutor return with
-        // `agent.driver: "api"` reconciles against a non-billable driver and
-        // the USD cap is silently unenforced even though the call was billed.
+        // Resolve the driver this call should be BILLED against, mirroring the
+        // flat runner exactly (#850 parity):
+        //   1. Prefer the driver `_executeAgent` actually resolved+stamped
+        //      (`servedBy.driver`) — the single source of auto-detect truth.
+        //   2. Normalize the "api" alias to "anthropic" (the downshift branch
+        //      already does this) so a metered call with `agent.driver: "api"`
+        //      and no `servedBy` is charged, not silently dropped.
+        //   3. When the step declares NO driver and the call left no
+        //      `servedBy`, default to "anthropic" — the same API path
+        //      `_executeAgent`'s auto-detect lands on for an unspecified
+        //      driver. The flat runner reaches this default via `servedBy`
+        //      (it always routes through `_executeAgent`); the chained runner
+        //      may be handed an injected `executeAgent` that returns measured
+        //      usage without a `servedBy`, so it must apply the same default
+        //      here or usdMax would be enforced on one runner and not the
+        //      other for identical recipes. A subscription/CLI call that
+        //      genuinely incurs no metered cost stamps `servedBy.driver:
+        //      "subprocess"` via `_executeAgent`, so it never reaches this
+        //      default and stays correctly fail-open.
         const reconcileDriver =
           agentReturn.servedBy?.driver ??
-          (dispatchDriver === "api" ? "anthropic" : (dispatchDriver ?? "auto"));
+          (dispatchDriver === "api" || dispatchDriver === undefined
+            ? "anthropic"
+            : dispatchDriver);
         budget.reconcile(
           reconcileDriver,
           agentReturn.usage,

--- a/src/recipes/yamlRunner.ts
+++ b/src/recipes/yamlRunner.ts
@@ -3442,6 +3442,20 @@ export async function dispatchRecipe(
       activityLog: deps.chainedOptions?.activityLog,
       mockedOutputs: deps.chainedOptions?.mockedOutputs,
       taskIdPrefix: deps.chainedOptions?.taskIdPrefix,
+      // Parity (#850): forward the run-level budget, price table, and
+      // cancellation signal that the chained runner honours. Without these the
+      // chained path silently diverged from the flat path —
+      //   - `budget`     lets a caller inject a shared RunBudget (and is the
+      //                  hook the chained runner uses to enforce usdMax).
+      //   - `priceTable` reuses an already-loaded table instead of forcing the
+      //                  chained RunBudget to re-load it from disk.
+      //   - `signal`     wires AbortSignal-based cancellation into the run; a
+      //                  pre-aborted signal now prevents dispatch on the
+      //                  chained path too (parity target — flat cancellation
+      //                  is still a separate gap).
+      budget: deps.chainedOptions?.budget,
+      priceTable: deps.chainedOptions?.priceTable,
+      signal: deps.chainedOptions?.signal,
     };
     if (!deps.chainedDeps) {
       throw new Error(

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "claude-ide-bridge-extension",
   "displayName": "Claude IDE Bridge",
   "description": "MCP bridge between Claude Code and your IDE. 177 tools — diagnostics, LSP, debugger, terminal, git. Optional Patchwork OS layer adds recipes, oversight, and approval queue.",
-  "version": "1.4.21",
+  "version": "1.4.22",
   "extensionKind": [
     "workspace"
   ],


### PR DESCRIPTION
## What

Closes two flat-vs-chained runner-parity divergences (#850) plus a live dashboard render bug — all test-first.

### Runner parity (the recurring "incomplete-fix-one-path" theme)
- **Chained `usdMax` now enforced.** The chained reconcile path defaulted an unspecified-driver call with no `servedBy` to the non-billable `"auto"`, so USD was never charged and `budget.usdMax` went silently unenforced. It now defaults to `"anthropic"` (the API path `_executeAgent` auto-detects), matching the flat runner. `dispatchRecipe` also threads `budget`/`priceTable`.
- **Chained runs are now cancellable.** `dispatchRecipe` forwards `chainedOptions.signal`; a pre-aborted run no longer dispatches steps (`POST /runs/:seq/cancel` was previously a no-op on chained runs).
- Flips the two `it.fails` xfails to passing and lowers the parity ratchet `BASELINE` 3 → 1. The remaining xfail is the flat-runner cancellation seam (separate, larger).

### Dashboard
- **`/runs` duplicate-key fix.** `GlobalLiveRunsStrip` keyed rows by `recipeName`, which collided when a recipe had more than one in-flight run (182 "same key" console errors → dropped/duplicated rows). Now uses the per-run seq with an index fallback, mirroring `LiveRunsStrip`. Adds a regression test.

## Test
- `runner.behavioral-parity` + `runBudget` + `runCostPersistence` + `chainedRunner`: **131 passed, 1 expected-fail** (flat cancellation).
- parity ratchet: **baseline 1** (exit 0).
- dashboard component suite: **53 passed**.
- `npm run build` clean; biome + fixture-hygiene + lsp-tools gates green.

## Note
A prior assessment flagged chained `detectSilentFail` as "never called" — that was a false finding (it is called at `chainedRunner.ts:824/889`), so it is intentionally not part of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
