### PR TITLE
fix(security): block npx --node-options interpreter bypass (H10 sibling)

### DIFF
--- a/src/fp/__tests__/commandDescription.test.ts
+++ b/src/fp/__tests__/commandDescription.test.ts
@@ -256,4 +256,20 @@ describe("buildCommandDescription — H10: --node-options blocked for npm/yarn/p
       ),
     ).toThrow(/--node-options.*blocked/);
   });
+
+  it("blocks npx --node-options (same interpreter bypass as npm/yarn/pnpm)", () => {
+    const npxConfig: CommandConfig = {
+      ...config,
+      commandAllowlist: [...config.commandAllowlist, "npx"],
+    };
+    expect(() =>
+      build(
+        {
+          command: "npx",
+          args: ["tsx", "--node-options=--require=/tmp/evil.js", "x.ts"],
+        },
+        npxConfig,
+      ),
+    ).toThrow(/--node-options.*blocked/);
+  });
 });

--- a/src/fp/commandDescription.ts
+++ b/src/fp/commandDescription.ts
@@ -65,6 +65,9 @@ export const DANGEROUS_FLAGS_FOR_COMMAND: Record<string, Set<string>> = {
   npm: new Set(["--node-options"]),
   yarn: new Set(["--node-options"]),
   pnpm: new Set(["--node-options"]),
+  // npx runs an arbitrary package binary, so --node-options is the same
+  // interpreter-bypass vector as npm/yarn/pnpm (H10 sibling — was missed).
+  npx: new Set(["--node-options"]),
 };
 
 export const PATH_FLAG_EXEMPTIONS: Record<string, Set<string>> = {


### PR DESCRIPTION
## What
Adds `npx` to `DANGEROUS_FLAGS_FOR_COMMAND` so `npx --node-options=...` is rejected, closing a sibling gap to the H10 fix (audit 2026-06-19).

`--node-options` passes raw V8/Node.js flags (e.g. `--require`, `--eval`) to the underlying node process, bypassing the interpreter-command guard. `npm`/`yarn`/`pnpm` already block it; `npx` — which runs an arbitrary package binary — was missed.

## Test
- New regression test mirrors the existing npm/yarn/pnpm cases. Confirmed failing before the fix, passing after.
- Full `commandDescription` suite: 33 passed. Build + biome clean.

## Scope note
This was scoped from the 2026-06-22 audit's "3 remaining MEDIUMs". On verification against current source, the other two did **not** hold and are intentionally excluded:
- **`stageEdit` null-byte**: `applySearchReplace` (`previewEdit.ts`) is pure in-memory (no shell-out), so the `searchAndReplace` null-byte guard — which exists because that path shells out to `rg` — has no security rationale here. Consistency-only at best.
- **`runInTerminal` named-terminal fallthrough**: "terminal not found" is already returned as a distinct structured error by the extension handler (`vscode-extension/src/handlers/terminal.ts`); the `result === null` fallthrough is the *intentional* shell-integration-unavailable (SSH/no-PTY) subprocess fallback. Erroring there would regress legitimate SSH-remote named-terminal use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
