### PR TITLE
fix(dashboard): accurate run status + timing on /traces and /analytics

### DIFF
--- a/dashboard/src/app/traces/page.tsx
+++ b/dashboard/src/app/traces/page.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { relTime } from "@/components/time";
 import { apiPath } from "@/lib/api";
 import { canonicalRecipeKey } from "@/lib/entityKey";
+import { traceStatus } from "@/lib/traceStatus";
 import { useBridgeFetch } from "@/hooks/useBridgeFetch";
 import { useDebounced } from "@/hooks/useDebounced";
 import { arr, isRecord, shape, type ShapeCheck } from "@/lib/validate";
@@ -63,13 +64,6 @@ const TYPE_THEME: Record<
   recipe_run: { fg: "var(--blue)", bg: "var(--blue-soft)", pill: "info" },
   decision: { fg: "var(--purple)", bg: "var(--purple-soft)", pill: "purp" },
 };
-
-function traceStatus(t: DecisionTrace): "done" | "error" | "running" {
-  const s = String(t.body?.status ?? t.body?.outcome ?? "").toLowerCase();
-  if (s === "ok" || s === "done" || s === "success" || s === "approved") return "done";
-  if (s === "error" || s === "failed" || s === "rejected" || s === "errored") return "error";
-  return "running";
-}
 
 // ------------------------------------------------------------------ detail panel
 

--- a/dashboard/src/lib/__tests__/traceStatus.test.ts
+++ b/dashboard/src/lib/__tests__/traceStatus.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Regression test for /traces rendering terminal runs as "running".
+ *
+ * `traceStatus()` used `"running"` as a catch-all, so terminal halt
+ * statuses (interrupted / cancelled) rendered as still-active. The fix
+ * routes them through the canonical `isHaltStatus()` helper (which
+ * covers error/failed/cancelled/interrupted), keeping the page in sync
+ * with the rest of the dashboard.
+ */
+
+import { describe, expect, it } from "vitest";
+import { traceStatus } from "@/lib/traceStatus";
+
+const withStatus = (status: string) => ({ body: { status } });
+
+describe("traceStatus", () => {
+  it("treats interrupted as an error (terminal), not running", () => {
+    expect(traceStatus(withStatus("interrupted"))).toBe("error");
+  });
+
+  it("treats cancelled as an error (terminal), not running", () => {
+    expect(traceStatus(withStatus("cancelled"))).toBe("error");
+  });
+
+  it("still maps error/failed/rejected/errored to error", () => {
+    expect(traceStatus(withStatus("error"))).toBe("error");
+    expect(traceStatus(withStatus("failed"))).toBe("error");
+    expect(traceStatus(withStatus("rejected"))).toBe("error");
+    expect(traceStatus(withStatus("errored"))).toBe("error");
+  });
+
+  it("maps ok/done/success/approved to done", () => {
+    expect(traceStatus(withStatus("ok"))).toBe("done");
+    expect(traceStatus(withStatus("done"))).toBe("done");
+    expect(traceStatus(withStatus("success"))).toBe("done");
+    expect(traceStatus(withStatus("approved"))).toBe("done");
+  });
+
+  it("maps an actual running status to running", () => {
+    expect(traceStatus(withStatus("running"))).toBe("running");
+  });
+
+  it("falls back to outcome when status is absent", () => {
+    expect(traceStatus({ body: { outcome: "cancelled" } })).toBe("error");
+  });
+});

--- a/dashboard/src/lib/traceStatus.ts
+++ b/dashboard/src/lib/traceStatus.ts
@@ -1,0 +1,23 @@
+import { isHaltStatus } from "@/lib/runStatus";
+
+/**
+ * Map a decision trace's body status/outcome to a coarse display state.
+ *
+ * Lives in lib/ (not the traces page) because Next.js page modules may
+ * only export the framework's allowed names — a stray named export on
+ * page.tsx fails the generated `.next/types` constraint. Keeping it here
+ * also makes it unit-testable in isolation.
+ *
+ * `interrupted` / `cancelled` are terminal halts: they must render as
+ * "error", not the old "running" catch-all. `isHaltStatus` is the
+ * canonical halt set (error/failed/cancelled/interrupted); `rejected` /
+ * `errored` are kept explicitly since that set doesn't include them.
+ */
+export function traceStatus(t: {
+  body?: { status?: unknown; outcome?: unknown } | null;
+}): "done" | "error" | "running" {
+  const s = String(t.body?.status ?? t.body?.outcome ?? "").toLowerCase();
+  if (s === "ok" || s === "done" || s === "success" || s === "approved") return "done";
+  if (isHaltStatus(s) || s === "rejected" || s === "errored") return "error";
+  return "running";
+}

--- a/src/__tests__/runLog.test.ts
+++ b/src/__tests__/runLog.test.ts
@@ -279,6 +279,71 @@ describe("RecipeRunLog.record", () => {
     expect(log.getBySeq(99)).toBeNull(); // non-existent seq, must not throw
   });
 
+  it("dedups duplicate/stale rows per seq on load, keeping the latest state", () => {
+    // The on-disk runs.jsonl is append-only: one run (one seq) gets
+    // multiple rows over its lifecycle (running → terminal), and the
+    // restart sweep historically appended a fresh "interrupted" row each
+    // boot. Without dedup, loadExisting pushes EVERY row into this.runs,
+    // so query()/getBySeq return stale/duplicate rows after restarts.
+    const file = path.join(tmp, "runs.jsonl");
+    const base = {
+      seq: 5,
+      taskId: "dup",
+      recipeName: "r",
+      trigger: "recipe",
+      createdAt: 1,
+      doneAt: 0,
+      durationMs: 0,
+    };
+    const distinct = {
+      seq: 6,
+      taskId: "other",
+      recipeName: "r",
+      trigger: "recipe",
+      status: "done",
+      createdAt: 10,
+      doneAt: 20,
+      durationMs: 10,
+    };
+    require("node:fs").writeFileSync(
+      file,
+      [
+        // seq=5 appears 3×: running, then interrupted, then interrupted again.
+        JSON.stringify({ ...base, status: "running", doneAt: 0 }),
+        JSON.stringify({
+          ...base,
+          status: "interrupted",
+          doneAt: 100,
+          durationMs: 99,
+        }),
+        JSON.stringify({
+          ...base,
+          status: "interrupted",
+          doneAt: 200,
+          durationMs: 199,
+        }),
+        JSON.stringify(distinct),
+        "",
+      ].join("\n"),
+    );
+
+    const log = new RecipeRunLog({ dir: tmp });
+
+    // query() must return exactly ONE row for seq=5, terminal status.
+    const seq5 = log.query().filter((r) => r.seq === 5);
+    expect(seq5).toHaveLength(1);
+    expect(seq5[0]!.status).toBe("interrupted");
+
+    // getBySeq must return the latest (terminal) row, not the stale running one.
+    expect(log.getBySeq(5)?.status).toBe("interrupted");
+
+    // The distinct run is untouched.
+    expect(log.getBySeq(6)?.status).toBe("done");
+
+    // Total in-memory rows: one per seq (5 and 6).
+    expect(log.size()).toBe(2);
+  });
+
   // ── VD-0: running-state run entries ──────────────────────────────────────
   // Recipe runs are now visible while in flight. `startRun` allocates a seq
   // and adds a `status:"running"` entry to the in-memory ring (no disk write,

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -1365,6 +1365,8 @@ export class Bridge {
                 t.doneAt !== undefined && {
                   durationMs: t.doneAt - t.startedAt,
                 }),
+              ...(t.startedAt !== undefined && { startedAt: t.startedAt }),
+              ...(t.doneAt !== undefined && { completedAt: t.doneAt }),
               createdAt: new Date(t.createdAt).toISOString(),
               ...(t.output !== undefined && {
                 output: t.output.slice(0, 2000),

--- a/src/runLog.ts
+++ b/src/runLog.ts
@@ -714,6 +714,15 @@ export class RecipeRunLog {
         // skip malformed line — never let one bad row break startup
       }
     }
+    // Dedup by seq, keeping the latest-appended row per run. The append-only log
+    // writes multiple rows per seq (running → terminal), and the sweep below
+    // historically appended a fresh "interrupted" row each restart; without this,
+    // query()/getBySeq return stale/duplicate rows after a restart.
+    const bySeq = new Map<number, RecipeRun>();
+    for (const r of this.runs) bySeq.set(r.seq, r);
+    const deduped = Array.from(bySeq.values()).sort((a, b) => a.seq - b.seq);
+    this.runs.length = 0;
+    this.runs.push(...deduped);
     if (this.runs.length > this.memoryCap) {
       this.runs.splice(0, this.runs.length - this.memoryCap);
     }


### PR DESCRIPTION
## What
Three data-accuracy bugs (found by clicking through the live dashboard) that made it misrepresent run state. All fixed test-first.

### `/traces` showed terminal runs as "running"
`traceStatus()` returned `"running"` as a catch-all, so `interrupted`/`cancelled` runs (the bulk of history) rendered as still-active. It predated the shared `isHaltStatus()` helper and drifted. Now routes through `isHaltStatus()` (+ keeps `rejected`/`errored`). Extracted to `dashboard/src/lib/traceStatus.ts` because Next.js rejects stray named exports from `page.tsx` — which also makes it unit-testable.

### One run appeared dozens of times on `/traces`
`runLog.loadExisting()` pushed **every** row of the append-only `runs.jsonl` into the in-memory ring. Since a run writes multiple rows over its lifecycle (`running` → terminal) — and the restart sweep historically appended a fresh `interrupted` row every boot — `query()`/`getBySeq()` returned duplicate/stale rows per `seq` (e.g. 64 copies of one run; `getBySeq` returned the stale `running` row). Now dedups by `seq` keeping the latest. Bonus: with the latest row terminal, the restart sweep no longer re-appends, so the on-disk log stops accumulating duplicates.

### `/analytics` "Recent recipe tasks" Time/Duration showed "—"
The analytics task map emitted `durationMs` but omitted `startedAt`/`completedAt`, which the dashboard `AutomationTask` interface needs. Added both.

## Test
- New `runLog` dedup test (running+interrupted×2 for one seq → one latest row; `getBySeq` returns the terminal row): **37 passed**.
- New `traceStatus` unit test (interrupted/cancelled → "error", not "running"): **6 passed**; full dashboard suite **914 passed**.
- Bridge `npm run build` + dashboard `tsc --noEmit` clean; biome clean.

## Note
`interrupted`/`cancelled` now bucket as "error" within the page's 3-value status model (matching how the Overview already treats halts). A distinct "interrupted" visual could be a follow-up. Sibling of the second live-data bug (tool-call telemetry reading 0) — that fix is separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
