### PR TITLE
fix(analytics): record recipe tool calls so dashboard telemetry isn't zero

### DIFF
--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -1331,13 +1331,20 @@ export class Bridge {
       const wh =
         typeof windowHours === "number" && windowHours >= 1 ? windowHours : 24;
       const cutoff = Date.now() - wh * 3_600 * 1_000;
-      const statsMap = this.activityLog.stats();
+      // Respect the requested window for tool counts (was all-time `stats()`).
+      const statsMap = this.activityLog.windowedStats(wh * 3_600 * 1_000);
+      // Per-tool latency percentiles. `percentiles()` is computed over the
+      // bounded duration-sample buffer (not windowed) and omits any tool with
+      // <2 samples — default those to 0 so the dashboard ToolStat shape is
+      // always satisfied.
+      const pctMap = this.activityLog.percentiles();
       const topTools = Object.entries(statsMap)
         .map(([tool, s]) => ({
           tool,
           calls: s.count,
           errors: s.errors,
-          avgMs: s.avgDurationMs,
+          p50Ms: pctMap[tool]?.p50 ?? 0,
+          p95Ms: pctMap[tool]?.p95 ?? 0,
         }))
         .sort((a, b) => b.calls - a.calls)
         .slice(0, 10);

--- a/src/recipeOrchestration.ts
+++ b/src/recipeOrchestration.ts
@@ -981,6 +981,13 @@ export class RecipeOrchestration {
     const runnerDeps = {
       workdir: this.deps.workdir,
       claudeCodeFn,
+      // Bug 2026-06-24: forward the bridge ActivityLog into runnerDeps so
+      // buildChainedDeps → resolveStepDeps carries it onto StepDeps and the
+      // executeTool chokepoint records chained recipe tool calls. Previously
+      // activityLog reached only `chainedOptions` (live-tail SSE), not the
+      // StepDeps used for tool dispatch — so chained tool calls were never
+      // counted in dashboard telemetry.
+      ...(this.deps.activityLog && { activityLog: this.deps.activityLog }),
       ...(requireApprovalFn && { requireApprovalFn }),
     };
     // Pass the bridge's long-lived RecipeRunLog so chainedRunner can flip the

--- a/src/recipes/__tests__/runnerActivityLog.test.ts
+++ b/src/recipes/__tests__/runnerActivityLog.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Bug fix test (2026-06-24): recipe / agent tool calls were never recorded to
+ * the bridge ActivityLog — only MCP-session tool calls went through
+ * `activityLog.record()` (src/transport.ts). The dashboard tool-call
+ * telemetry ("TOOLS CALLED TODAY", /analytics) therefore read ZERO for all
+ * recipe-driven work.
+ *
+ * Fix: instrument the shared tool chokepoint `toolRegistry.executeTool`, which
+ * both the flat (yaml) runner and the chained runner funnel through. Both
+ * runners must produce an ActivityLog entry per actual tool execution.
+ *
+ * Per Bug Fix Protocol: these tests MUST fail before the fix, pass after.
+ */
+
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { ActivityLog } from "../../activityLog.js";
+import type { ChainedRecipe } from "../chainedRunner.js";
+import {
+  buildChainedDeps,
+  dispatchRecipe,
+  type RunnerDeps,
+  runYamlRecipe,
+  type YamlRecipe,
+} from "../yamlRunner.js";
+
+const tmpDir = mkdtempSync(path.join(os.tmpdir(), "runner-activitylog-"));
+
+afterEach(() => {
+  // best-effort cleanup of any files written
+});
+
+function baseDeps(activityLog: ActivityLog): RunnerDeps {
+  return {
+    now: () => new Date("2026-06-24T08:00:00Z"),
+    writeFile: () => {},
+    appendFile: () => {},
+    mkdir: () => {},
+    readFile: () => "",
+    activityLog,
+  };
+}
+
+describe("flat (yaml) runner — records tool calls to ActivityLog", () => {
+  it("records a file.write tool execution", async () => {
+    const activityLog = new ActivityLog();
+    const recipe: YamlRecipe = {
+      name: "flat-activitylog",
+      trigger: { type: "manual" },
+      steps: [
+        {
+          tool: "file.write",
+          path: path.join(tmpDir, "flat.md"),
+          content: "hello",
+        },
+      ],
+    };
+
+    const result = await runYamlRecipe(recipe, baseDeps(activityLog));
+    expect(result.stepsRun).toBe(1);
+
+    const stats = activityLog.stats();
+    expect(stats["file.write"]).toBeDefined();
+    expect(stats["file.write"]?.count).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe("chained runner — records tool calls to ActivityLog", () => {
+  it("records a file.write tool execution through buildChainedDeps", async () => {
+    const activityLog = new ActivityLog();
+    const recipe = {
+      name: "chained-activitylog",
+      trigger: { type: "chained" },
+      steps: [
+        {
+          id: "s1",
+          tool: "file.write",
+          path: path.join(tmpDir, "chained.md"),
+          content: "hi",
+        },
+      ],
+    } as unknown as ChainedRecipe & { trigger: { type: string } };
+
+    // Mirror the production wiring (recipeOrchestration.ts): runnerDeps carries
+    // activityLog, and chainedDeps is built from those same runnerDeps so the
+    // resolved StepDeps reach the executeTool chokepoint with activityLog.
+    const runnerDeps = baseDeps(activityLog);
+    await dispatchRecipe(recipe as unknown as YamlRecipe, {
+      ...runnerDeps,
+      chainedDeps: buildChainedDeps(runnerDeps),
+      chainedOptions: { activityLog },
+    });
+
+    const stats = activityLog.stats();
+    expect(stats["file.write"]).toBeDefined();
+    expect(stats["file.write"]?.count).toBeGreaterThanOrEqual(1);
+  });
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});

--- a/src/recipes/toolRegistry.ts
+++ b/src/recipes/toolRegistry.ts
@@ -125,23 +125,53 @@ export async function executeTool(
   if (!tool) {
     throw new Error(`Unknown tool: "${id}"`);
   }
-  if (tool.isWrite) {
-    assertWriteAllowed(id);
 
-    // PR5a — idempotency dedup. Within a single recipe run, the same
-    // write tool with the same params must execute exactly once. If a
-    // parallel branch (chained recipe) or a re-dispatch reaches this
-    // function with a key already in the ledger, return the cached
-    // output so downstream `{{steps.x.data}}` references stay coherent.
-    // Errors are NOT recorded — retry-after-failure still re-executes
-    // (correct: a failed call may not have completed its side effect).
-    const ledger = context.deps.writeEffectLedger;
-    if (ledger) {
-      const key = deriveIdempotencyKey(id, context.params);
-      return ledger.getOrExecute(key, () => tool.execute(context));
+  // Telemetry chokepoint (bug 2026-06-24): record every recipe/agent tool
+  // execution to the bridge ActivityLog so dashboard tool-call telemetry
+  // counts recipe-driven work — not just MCP-session calls. Fail-soft: CLI /
+  // test runs without a bridge omit `activityLog`, so `?.record` no-ops.
+  // Both the flat (yaml) runner and the chained runner funnel tool dispatch
+  // through this function (chained: buildChainedDeps → executeStep →
+  // executeTool), so instrumenting here covers both.
+  const activityLog = context.deps.activityLog;
+  const start = Date.now();
+  const recordOutcome = (ok: boolean, errMsg?: string): void => {
+    activityLog?.record(
+      id,
+      Date.now() - start,
+      ok ? "success" : "error",
+      errMsg,
+    );
+  };
+
+  const run = async (): Promise<string | null> => {
+    if (tool.isWrite) {
+      assertWriteAllowed(id);
+
+      // PR5a — idempotency dedup. Within a single recipe run, the same
+      // write tool with the same params must execute exactly once. If a
+      // parallel branch (chained recipe) or a re-dispatch reaches this
+      // function with a key already in the ledger, return the cached
+      // output so downstream `{{steps.x.data}}` references stay coherent.
+      // Errors are NOT recorded — retry-after-failure still re-executes
+      // (correct: a failed call may not have completed its side effect).
+      const ledger = context.deps.writeEffectLedger;
+      if (ledger) {
+        const key = deriveIdempotencyKey(id, context.params);
+        return ledger.getOrExecute(key, () => tool.execute(context));
+      }
     }
+    return tool.execute(context);
+  };
+
+  try {
+    const result = await run();
+    recordOutcome(true);
+    return result;
+  } catch (err) {
+    recordOutcome(false, err instanceof Error ? err.message : String(err));
+    throw err;
   }
-  return tool.execute(context);
 }
 
 /**

--- a/src/recipes/yamlRunner.ts
+++ b/src/recipes/yamlRunner.ts
@@ -718,6 +718,13 @@ export type StepDeps = Required<
   logDir?: string;
   recordFixturesDir?: string;
   runLog?: RecipeRunLog;
+  /**
+   * Bridge ActivityLog (optional). When wired, `toolRegistry.executeTool`
+   * records each recipe/agent tool execution so the dashboard tool-call
+   * telemetry counts recipe-driven work — not just MCP-session tool calls.
+   * Omitted in CLI / test runs without a bridge (recording is fail-soft).
+   */
+  activityLog?: import("../activityLog.js").ActivityLog;
   testMode: boolean;
   /**
    * PR5a — per-run idempotency ledger. When present, `executeTool`
@@ -2687,6 +2694,7 @@ function resolveStepDeps(
         return getValidAccessToken();
       }),
     logDir: deps.logDir,
+    activityLog: deps.activityLog,
     testMode: deps.testMode ?? false,
     // PR5a/b: per-attempt idempotency ledger. Disk-backed when
     // `ledgerDir` + `manualRunId` + recipe name are all available so a


### PR DESCRIPTION
## What
The dashboard tool-call telemetry read **zero** everywhere — Overview "TOOLS CALLED TODAY: 0", /analytics "Total Tool Calls 0 / Unique Tools 0 / Top tools: No data yet" — despite active recipe runs. Cause: `activityLog.record()` was only called from the MCP transport, so **recipe/agent** tool executions were never counted.

### Fix
- **Record at the chokepoint.** `toolRegistry.executeTool()` is the single funnel both runners use (flat via `executeStep`; chained via `buildChainedDeps → executeStep`). It now times the call and `activityLog?.record(id, ms, ok ? "success" : "error", err)`. Fail-soft — CLI/test runs without a bridge no-op.
- **Wire `activityLog` to the tool layer.** Added optional `activityLog?` to `StepDeps` and passed it through `resolveStepDeps`. Critically, `recipeOrchestration` only forwarded `activityLog` onto `chainedOptions` (live-tail SSE), **not** the `runnerDeps`/`StepDeps` used for tool dispatch — so chained recipes never recorded. Now forwarded there too.
- **Secondary (analyticsFn):** use `windowedStats(windowHours)` instead of all-time `stats()` so the window is respected; emit `p50Ms`/`p95Ms` (from `percentiles()`) to match the dashboard `ToolStat` interface instead of `avgMs` (which rendered "—").

## Test
- New `runnerActivityLog.test.ts`: a **flat** recipe and a **chained** recipe (built via real `buildChainedDeps`) each with a tool step + a real `ActivityLog` → assert the tool is recorded. **Both failed before, pass after.**
- `src/recipes/__tests__/` full run: 1087 passed (only the 2 pre-existing locally-excluded `judgeReviewsValidation` reds remain). Build + biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
