### PR TITLE
docs: fix connector count (19→46) + refresh roadmap status to beta.13

### DIFF
--- a/documents/platform-docs.md
+++ b/documents/platform-docs.md
@@ -1,6 +1,6 @@
 # Claude IDE Bridge — Platform Documentation
 
-177 tools · 36 MCP prompts · 20 automation hooks · 19 connectors (Slack, GitHub, Linear, Gmail, Google Calendar, Google Drive, Sentry, Notion, Confluence, Datadog, HubSpot, Intercom, Stripe, Zendesk, Jira, PagerDuty, Discord, Asana, GitLab — see [README](../README.md) for canonical list) — current version in [package.json](../package.json)
+177 tools · 36 MCP prompts · 20 automation hooks · 46 connectors (OAuth/PAT integrations — Slack, GitHub, Linear, Gmail, Google Calendar, Google Drive, Sentry, Notion, Confluence, Datadog, HubSpot, Intercom, Stripe, Zendesk, Jira, PagerDuty, Discord, Asana, GitLab — plus database/data connectors like Postgres, MongoDB, Redis; see [README](../README.md) for the canonical list) — current version in [package.json](../package.json)
 
 > **Deployment model:** Remote deployment (VPS + reverse proxy, systemd service, `--bind 0.0.0.0 --issuer-url <https-url>`) is a first-class, production-ready pattern and is the recommended architecture for team or cloud access. Local mode (`127.0.0.1`, no `--issuer-url`) is for individual development.
 

--- a/documents/roadmap.md
+++ b/documents/roadmap.md
@@ -4,9 +4,9 @@ Development direction and exploration guidance. Living document — update as pr
 
 ---
 
-## Status (2026-05-16)
+## Status (2026-06-25)
 
-Current: `0.2.0-beta.9` (bridge), `1.4.20` (extension). 177 tools registered. Recent waves:
+Current: `0.2.0-beta.13` (bridge), `1.4.22` (extension). 177 tools registered. Newer work (beta.10–beta.13: security-audit waves, npm-package leak fix, recipe runner-parity, dashboard data-accuracy) is in [CHANGELOG.md](../CHANGELOG.md); the waves below are historical (beta.9 era):
 
 - **Native Windows support** — smoke harness + extension suites green on `windows-latest` CI; advisory→blocking flip in PR #537. Helpers: `winShim`, `processTree`, `fsWatchWithFallback`. ADRs 0010-0012.
 - **Write-tier kill-switch** — `patchwork kill-switch engage|release|status` + `panic` alias, multi-bridge HTTP fan-out, dashboard toggle, fs.watch convergence. Issue #422 design; ADR 0013.


### PR DESCRIPTION
## What
Two factual doc-drift fixes flagged in the project assessment (docs-only, no code):

- **`documents/platform-docs.md`** — header claimed **19 connectors**; the registry has **46**. The 19 named were the OAuth/PAT integrations — relabeled as such, with a note about the database/data connectors and a pointer to the README for the canonical list.
- **`documents/roadmap.md`** — the Status block was pinned at **2026-05-16 / beta.9 / ext 1.4.20**. Bumped to **2026-06-25 / beta.13 / ext 1.4.22**, with a CHANGELOG pointer for the beta.10–beta.13 work (the wave bullets below remain beta.9-era historical, as the section already disclaims).

Left the "20 automation hooks" count untouched — it's genuinely ambiguous (unified hooks with sub-states) and not worth a guess.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
