### PR TITLE
feat(recipes): external cancellation for the flat runner (#850 parity, last xfail)

### DIFF
--- a/scripts/audit-parity-xfails.mjs
+++ b/scripts/audit-parity-xfails.mjs
@@ -35,8 +35,8 @@ const target = path.join(
 
 // Baseline = the documented divergences that exist today. Lower this (never
 // raise it) as gaps are closed. Current xfails:
-//   1. flat runner has no AbortSignal / cancellation seam
-const BASELINE = 1;
+//   (none — flat/chained behavioral parity is fully enforced)
+const BASELINE = 0;
 
 const raw = readFileSync(target, "utf8");
 

--- a/src/recipes/__tests__/runner.behavioral-parity.test.ts
+++ b/src/recipes/__tests__/runner.behavioral-parity.test.ts
@@ -693,12 +693,11 @@ describe("parity: when:false skips the step on both runners", () => {
   });
 });
 
-describe("DIVERGENCE (xfail): AbortSignal is not threaded through dispatchRecipe", () => {
-  // dispatchRecipe builds chained RunOptions WITHOUT forwarding
-  // chainedOptions.signal (yamlRunner.ts dispatchRecipe), and the flat runner
-  // has no signal plumbing at all. A pre-aborted run therefore still executes
-  // every step on BOTH paths. Backlog: thread signal through dispatch + wire
-  // cancellation into the flat runner (M3/Phase 5).
+describe("parity: AbortSignal cancellation stops both runners", () => {
+  // Both paths now honour an abort: dispatchRecipe forwards chainedOptions.signal
+  // to the chained runner (#998), and the flat runner checks deps.signal at the
+  // top of its step loop (#850 — this change). A pre-aborted run makes no
+  // dispatch; an abort mid-run stops before the next step is started.
   it("chained run is cancelled when chainedOptions.signal is pre-aborted", async () => {
     const ctl = new AbortController();
     ctl.abort("cancelled");
@@ -723,23 +722,24 @@ describe("DIVERGENCE (xfail): AbortSignal is not threaded through dispatchRecipe
     expect(executeAgent).not.toHaveBeenCalled();
   });
 
-  it.fails("flat run is cancelled when caller requests abort (NOT YET — flat has no signal)", async () => {
-    // The flat runner exposes no signal seam, so there is no way to stop a
-    // run mid-flight. This marker documents that gap for M3.
+  it("flat run is cancelled when the caller's signal is aborted mid-run", async () => {
     let calls = 0;
+    const ctl = new AbortController();
     const recipe = flatAgentRecipe([
       { agent: { prompt: "a", model: HAIKU, into: "o0" } },
       { agent: { prompt: "b", model: HAIKU, into: "o1" } },
     ]);
     const result = (await dispatchRecipe(recipe, {
       ...baseDeps(),
+      signal: ctl.signal,
       claudeFn: async () => {
         calls++;
+        ctl.abort(); // cancel after step 1's agent runs
         return { text: "x", usage: { inputTokens: 1, outputTokens: 1 } };
       },
     })) as RunResult;
-    // Parity target: a cancellation seam would let us stop after step 1.
-    // Today there is none, so both steps run.
+    // The signal is checked at the top of the loop, so once the run is aborted
+    // after step 1, step 2 is never dispatched.
     expect(calls).toBe(1);
     expect(result.stepResults).toHaveLength(1);
   });

--- a/src/recipes/yamlRunner.ts
+++ b/src/recipes/yamlRunner.ts
@@ -547,6 +547,15 @@ export interface RunnerDeps {
    */
   activityLog?: import("../activityLog.js").ActivityLog;
   /**
+   * Optional caller-provided cancellation signal. When it (or the internal
+   * registry/kill-switch controller) is aborted, the run stops before the next
+   * step is dispatched — the flat-runner counterpart to the chained runner's
+   * `RunOptions.signal` (#850 parity; makes `POST /runs/:seq/cancel` effective
+   * on flat YAML recipes too). Between-steps granularity: an already-dispatched
+   * step completes; the next one is not started.
+   */
+  signal?: AbortSignal;
+  /**
    * Optional Anthropic API caller for agent steps. Defaults to fetch-based
    * impl. May return either a raw string (legacy / tests) or `AgentResult`
    * carrying usage tokens (bridge wrappers, real adapters). The runner
@@ -712,6 +721,9 @@ export type StepDeps = Required<
     // M3 — approval gate runs in the run loop against `deps`, not per-step
     // StepDeps; keep it off StepDeps so it isn't forced Required here.
     | "requireApprovalFn"
+    // Cancellation is checked in the run loop against `deps`, not per-step;
+    // keep it off StepDeps so it isn't forced Required here.
+    | "signal"
   >
 > & {
   workdir: string;
@@ -1585,8 +1597,11 @@ export async function runYamlRecipe(
       // log_only|deliver_original) never set `haltAfterFailure`, so they
       // still let the run continue exactly as before.
       if (haltAfterFailure) break;
-      // Run-level cancel: abort when the registry controller fires (H11).
-      if (runController?.signal.aborted) {
+      // Run-level cancel: abort when the registry controller fires (H11) OR
+      // when a caller-provided signal is aborted (#850 parity — external
+      // cancellation, e.g. POST /runs/:seq/cancel). An in-flight step is
+      // allowed to finish; the next step is not dispatched.
+      if (runController?.signal.aborted || deps.signal?.aborted) {
         runError = runError ?? "recipe run cancelled";
         break;
       }


### PR DESCRIPTION
## What
Gives the **flat** YAML runner an external cancellation seam, closing the **last** flat-vs-chained behavioral-parity divergence (#850).

The flat runner already broke its step loop on the internal registry/kill-switch controller (H11), but a **caller-provided** `AbortSignal` had no path in — so `POST /runs/:seq/cancel` was effectively a no-op on flat recipes (only chained runs honored it, since #998). This adds `signal?: AbortSignal` to `RunnerDeps` and ORs it into the existing top-of-loop abort check.

- **Granularity:** between-steps — an already-dispatched step finishes; the next is not started. This matches the chained runner's external-cancel behavior at the parity-test level. (Mid-step interruption of an in-flight agent call is a deeper, separate item, not currently encoded as a divergence.)
- `signal` is excluded from `StepDeps` (cancellation is a run-loop concern checked against `deps`, not per-step) — same pattern as `activityLog`/`requireApprovalFn`.

## Test
- The last behavioral-parity `it.fails` is rewritten to provide + abort a real signal and flipped to a passing `it()`; the describe is renamed from "DIVERGENCE (xfail)" to a parity assertion.
- **Ratchet `BASELINE` 1 → 0** (`scripts/audit-parity-xfails.mjs`) — flat/chained runtime parity is now fully machine-enforced; no documented divergences remain.
- Verified: parity + chained + dispatch-parity + yamlRunner + activityLog suites — **191 passed**; `npm run build` + biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
