### PR TITLE
test(parity): close #850 — docs⇒wired + dispatch-guard invariants

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,8 @@ jobs:
         run: node scripts/audit-intellij-parity.mjs
       - name: Audit runner-parity xfail ratchet (#850)
         run: node scripts/audit-parity-xfails.mjs
+      - name: Audit docs⇒wired parity (#850)
+        run: node scripts/audit-docs-wired.mjs
 
   plugin-validate:
     name: Validate plugin manifest

--- a/documents/platform-docs.md
+++ b/documents/platform-docs.md
@@ -1,6 +1,6 @@
 # Claude IDE Bridge — Platform Documentation
 
-177 tools · 36 MCP prompts · 20 automation hooks · 46 connectors (OAuth/PAT integrations — Slack, GitHub, Linear, Gmail, Google Calendar, Google Drive, Sentry, Notion, Confluence, Datadog, HubSpot, Intercom, Stripe, Zendesk, Jira, PagerDuty, Discord, Asana, GitLab — plus database/data connectors like Postgres, MongoDB, Redis; see [README](../README.md) for the canonical list) — current version in [package.json](../package.json)
+177 tools · 36 MCP prompts · 24 automation hooks · 46 connectors (OAuth/PAT integrations — Slack, GitHub, Linear, Gmail, Google Calendar, Google Drive, Sentry, Notion, Confluence, Datadog, HubSpot, Intercom, Stripe, Zendesk, Jira, PagerDuty, Discord, Asana, GitLab — plus database/data connectors like Postgres, MongoDB, Redis; see [README](../README.md) for the canonical list) — current version in [package.json](../package.json)
 
 > **Deployment model:** Remote deployment (VPS + reverse proxy, systemd service, `--bind 0.0.0.0 --issuer-url <https-url>`) is a first-class, production-ready pattern and is the recommended architecture for team or cloud access. Local mode (`127.0.0.1`, no `--issuer-url`) is for individual development.
 
@@ -533,7 +533,7 @@ Multi-step workflows using `previewEdit`, transaction tools, `explainDiagnostic`
 
 ## Automation Hooks
 
-When started with `--automation --automation-policy <file>`, the bridge enqueues Claude tasks in response to IDE events. The policy is a JSON file with any of these 18 hook keys:
+When started with `--automation --automation-policy <file>`, the bridge enqueues Claude tasks in response to IDE events. The policy is a JSON file with any of these 24 accepted hook keys (the 21 internal `HookType` slots plus the 3 unified aliases — `onCompaction`, `onDiagnosticsStateChange`, `onDebugSession` — that the loader expands into them; the legacy split names remain accepted but emit a deprecation warning):
 
 | Hook | Trigger | Placeholders |
 |------|---------|--------------|

--- a/scripts/audit-docs-wired.mjs
+++ b/scripts/audit-docs-wired.mjs
@@ -1,0 +1,247 @@
+/**
+ * "Documented ⇒ wired" parity audit (issue #850, acceptance criterion #3).
+ *
+ * The docs are a contract: anything the docs present as usable must actually
+ * exist in the code's source-of-truth surfaces. This script asserts three
+ * cross-layer invariants and exits 1 on any mismatch.
+ *
+ *   1. PROMPTS — the count of top-level entries in `PROMPTS: McpPrompt[]`
+ *      (src/prompts.ts) must equal the "<N> MCP prompts" number documented in
+ *      documents/platform-docs.md (banner line) AND in CLAUDE.md. The doc number
+ *      is parsed, never hardcoded.
+ *
+ *   2. CLI subcommands — every subcommand DOCUMENTED in CLAUDE.md's
+ *      "### CLI Subcommands" section must be present in the code's wired set
+ *      (KNOWN_SUBCOMMANDS array ∪ every `process.argv[2] === "x"` dispatch in
+ *      src/index.ts). "Documented ⇒ wired." Registered-but-undocumented
+ *      subcommands are REPORTED (informational), not failed — over-documenting
+ *      is the dangerous direction, not under-documenting.
+ *
+ *   3. Automation hooks — every hook key the docs present as usable must be
+ *      accepted by the policy loader. The wired surface is:
+ *        - the HookType union (src/fp/automationProgram.ts) — the legacy/internal
+ *          slots the parser (src/fp/policyParser.ts) handles, AND
+ *        - the unified aliases that loadPolicy (src/automation.ts) expands into
+ *          those slots (onCompaction, onDiagnosticsStateChange, onDebugSession).
+ *      The "<N> automation hooks" banner number in platform-docs.md must equal
+ *      the count of distinct accepted hook keys. (This script does NOT mutate
+ *      docs; if the number is wrong it fails and prints the value to set.)
+ *
+ * Usage:
+ *   node scripts/audit-docs-wired.mjs
+ *
+ * Exit code 0 = all checks pass. Exit code 1 = issues found.
+ */
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, "..");
+
+function read(rel) {
+  return readFileSync(path.join(root, rel), "utf8");
+}
+
+const problems = [];
+const notes = [];
+
+// ── 1. PROMPTS ─────────────────────────────────────────────────────────────
+
+function auditPrompts() {
+  const src = read("src/prompts.ts");
+  // Slice the PROMPTS array literal: from `export const PROMPTS` to the matching
+  // top-level `];`. Top-level entries are `  {` at two-space indent.
+  const start = src.indexOf("export const PROMPTS");
+  if (start === -1) {
+    problems.push(
+      "prompts: could not find `export const PROMPTS` in src/prompts.ts",
+    );
+    return;
+  }
+  // Each prompt object opens with a two-space-indented `{` and carries a
+  // four-space-indented `name: "..."`. Count names — robust against nested
+  // braces in descriptions.
+  const arrEnd = src.indexOf("\n];", start);
+  const slice = src.slice(start, arrEnd === -1 ? undefined : arrEnd);
+  const names = [...slice.matchAll(/^ {4}name: "([^"]+)",/gm)].map((m) => m[1]);
+  const codeCount = new Set(names).size;
+  if (names.length !== codeCount) {
+    problems.push(
+      `prompts: duplicate prompt names in src/prompts.ts (${names.length} entries, ${codeCount} unique)`,
+    );
+  }
+
+  for (const [docRel, label] of [
+    ["documents/platform-docs.md", "platform-docs.md"],
+    ["CLAUDE.md", "CLAUDE.md"],
+  ]) {
+    const doc = read(docRel);
+    const m = doc.match(/(\d+)\s+MCP prompts/);
+    if (!m) {
+      problems.push(`prompts: could not find "<N> MCP prompts" in ${label}`);
+      continue;
+    }
+    const docCount = Number(m[1]);
+    if (docCount !== codeCount) {
+      problems.push(
+        `prompts: ${label} says "${docCount} MCP prompts" but src/prompts.ts has ${codeCount}. Set the doc number to ${codeCount}.`,
+      );
+    }
+  }
+  notes.push(`prompts: ${codeCount} entries in PROMPTS[]`);
+}
+
+// ── 2. CLI subcommands ───────────────────────────────────────────────────────
+
+function auditSubcommands() {
+  const idx = read("src/index.ts");
+
+  // Wired set A: the KNOWN_SUBCOMMANDS array literal.
+  const knownMatch = idx.match(
+    /const KNOWN_SUBCOMMANDS\s*=\s*\[([\s\S]*?)\]\s*as const/,
+  );
+  const wired = new Set();
+  if (knownMatch) {
+    for (const m of knownMatch[1].matchAll(/"([a-z][a-z-]*)"/g))
+      wired.add(m[1]);
+  } else {
+    problems.push(
+      "subcommands: could not find KNOWN_SUBCOMMANDS array in src/index.ts",
+    );
+  }
+  // Wired set B: every `process.argv[2] === "x"` dispatch. Some subcommands
+  // (e.g. `tools`) dispatch directly without being in KNOWN_SUBCOMMANDS.
+  for (const m of idx.matchAll(
+    /process\.argv\[2\]\s*===\s*"([a-z][a-z-]*)"/g,
+  )) {
+    wired.add(m[1]);
+  }
+  // Drop pseudo-commands that are flags/help, never documented as subcommands.
+  for (const pseudo of ["help", "patchwork-init"]) wired.delete(pseudo);
+
+  // Documented set: top-level `- \`<cmd>\`` bullets inside the
+  // "### CLI Subcommands" section of CLAUDE.md, up to the next "## " heading.
+  const claude = read("CLAUDE.md");
+  const secStart = claude.indexOf("### CLI Subcommands");
+  if (secStart === -1) {
+    problems.push(
+      "subcommands: could not find '### CLI Subcommands' in CLAUDE.md",
+    );
+    return;
+  }
+  const secEnd = claude.indexOf("\n## ", secStart);
+  const section = claude.slice(secStart, secEnd === -1 ? undefined : secEnd);
+  // A documented subcommand is the first token of a top-level bullet:
+  // `- \`init ...\`` → "init". Ignore flags (`--watch`) and release channels
+  // (latest/beta/canary) which are not subcommands.
+  const documented = new Set();
+  for (const line of section.split("\n")) {
+    const m = line.match(/^- `([a-z][a-z-]*)\b/);
+    if (m) documented.add(m[1]);
+  }
+  const NON_SUBCOMMAND_TOKENS = new Set(["latest", "beta", "canary"]);
+  for (const t of NON_SUBCOMMAND_TOKENS) documented.delete(t);
+
+  // Documented ⇒ wired (the failure direction).
+  const missing = [...documented].filter((c) => !wired.has(c)).sort();
+  if (missing.length > 0) {
+    problems.push(
+      `subcommands: documented in CLAUDE.md but NOT wired in src/index.ts: ${missing.join(", ")}`,
+    );
+  }
+  // Wired but undocumented — informational only.
+  const undocumented = [...wired].filter((c) => !documented.has(c)).sort();
+  if (undocumented.length > 0) {
+    notes.push(
+      `subcommands: wired but not documented (informational): ${undocumented.join(", ")}`,
+    );
+  }
+  notes.push(`subcommands: ${documented.size} documented, ${wired.size} wired`);
+}
+
+// ── 3. Automation hooks ──────────────────────────────────────────────────────
+
+function auditHooks() {
+  // Wired surface: HookType union (legacy/internal slots the parser handles).
+  const prog = read("src/fp/automationProgram.ts");
+  const unionMatch = prog.match(/export type HookType\s*=([\s\S]*?);/);
+  if (!unionMatch) {
+    problems.push(
+      "hooks: could not find HookType union in src/fp/automationProgram.ts",
+    );
+    return;
+  }
+  const internal = new Set(
+    [...unionMatch[1].matchAll(/"([a-zA-Z]+)"/g)].map((m) => m[1]),
+  );
+
+  // Unified aliases that loadPolicy expands into internal slots. Derived from
+  // the expandDiscriminatedHook(...,"<unifiedKey>",...) call sites in
+  // src/automation.ts — these are the parseable user-facing hook keys that do
+  // NOT appear in the HookType union.
+  const auto = read("src/automation.ts");
+  const unified = new Set(
+    [
+      ...auto.matchAll(/expandDiscriminatedHook\(\s*policy,\s*"([a-zA-Z]+)"/g),
+    ].map((m) => m[1]),
+  );
+
+  // Accepted hook keys = internal slots ∪ unified aliases.
+  const accepted = new Set([...internal, ...unified]);
+  const acceptedCount = accepted.size;
+
+  // The platform-docs banner "<N> automation hooks" must equal acceptedCount.
+  const docs = read("documents/platform-docs.md");
+  const banner = docs.match(/(\d+)\s+automation hooks/);
+  if (!banner) {
+    problems.push(
+      'hooks: could not find "<N> automation hooks" banner in platform-docs.md',
+    );
+  } else if (Number(banner[1]) !== acceptedCount) {
+    problems.push(
+      `hooks: platform-docs.md banner says "${banner[1]} automation hooks" but the policy loader accepts ${acceptedCount} distinct hook keys. Set the banner to ${acceptedCount}.`,
+    );
+  }
+
+  // The "<N> hook keys" sentence in the Automation Hooks section must also match.
+  const sectionN = docs.match(/JSON file with any of these (\d+) hook keys/);
+  if (sectionN && Number(sectionN[1]) !== acceptedCount) {
+    problems.push(
+      `hooks: platform-docs.md "any of these ${sectionN[1]} hook keys" but loader accepts ${acceptedCount}. Set it to ${acceptedCount}.`,
+    );
+  }
+
+  // Contract: every hook the docs/rules present as usable must be parseable.
+  // The unified names are presented as the current form in CLAUDE.md +
+  // .claude/rules/automation.md — assert the loader accepts them.
+  for (const uni of [
+    "onDiagnosticsStateChange",
+    "onCompaction",
+    "onDebugSession",
+  ]) {
+    if (!accepted.has(uni)) {
+      problems.push(
+        `hooks: docs present unified hook "${uni}" as usable but loadPolicy does not expand it (real drift — investigate src/automation.ts).`,
+      );
+    }
+  }
+  notes.push(
+    `hooks: ${acceptedCount} accepted keys (${internal.size} internal + ${unified.size} unified aliases)`,
+  );
+}
+
+// ── run ──────────────────────────────────────────────────────────────────────
+
+auditPrompts();
+auditSubcommands();
+auditHooks();
+
+for (const n of notes) console.log(`  ℹ ${n}`);
+if (problems.length > 0) {
+  console.error("\n✖ docs⇒wired audit failed:\n");
+  for (const p of problems) console.error(`  • ${p}`);
+  process.exit(1);
+}
+console.log("\n✓ docs⇒wired audit passed");

--- a/src/__tests__/dispatch-guard-parity.test.ts
+++ b/src/__tests__/dispatch-guard-parity.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Dispatch-path guard parity (issue #850, acceptance criterion #2).
+ *
+ * The bridge has more than one tool-dispatch entry point. The cross-layer
+ * invariant this guards: the two MCP-transport dispatch paths — the
+ * registered-tool path and the dynamic/proxy path in `src/transport.ts` —
+ * enforce the SAME per-session deny-list (`this.denyTools`). The dynamic path
+ * was historically a bypass (a session that denied a tool via
+ * `X-Bridge-Deny-Tools` could still invoke it as an orchestrator child/proxy
+ * tool); the fix mirrored the `denyTools.has(...)` check onto the dynamic path.
+ * This test pins that parity so the bypass cannot silently regress.
+ *
+ * ── On the recipe dispatch path (deliberately NOT asserted as sharing denyTools)
+ *
+ * `executeTool` in `src/recipes/toolRegistry.ts` is a THIRD dispatch entry
+ * point, but it is a different architectural boundary, not a gap:
+ *
+ *   - It dispatches over a SEPARATE registry (the recipe tool registry, keyed
+ *     by `namespace.action` ids like `github.createPR`) — not the MCP tool map
+ *     that `denyTools` filters. `denyTools` is populated from the per-MCP-session
+ *     `X-Bridge-Deny-Tools` header (`src/transport.ts`), a session-scoped concept
+ *     that has no meaning for a recipe run (recipes are not MCP sessions).
+ *   - Recipe tool execution is policy-gated by a DIFFERENT, intentional set of
+ *     controls: `assertWriteAllowed` (the global write kill-switch), the
+ *     write-effect idempotency ledger, and — at the runner layer — the approval
+ *     gate. Routing recipe dispatch through the MCP session deny-list would be a
+ *     category error.
+ *
+ * So this test asserts the guarantee that IS real and shared (both transport
+ * paths consult `denyTools`) and documents — but does not falsely assert — the
+ * recipe path. If a future change makes the recipe path MCP-session-aware, the
+ * contract here should be revisited deliberately.
+ *
+ * Implementation: a source-text scan of `src/transport.ts`, matching the
+ * sibling cross-layer parity tests' style (they scan source rather than import
+ * across package/tsconfig boundaries).
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, "..", "..");
+
+function read(rel: string): string {
+  return readFileSync(path.join(root, rel), "utf8");
+}
+
+describe("dispatch-guard parity (#850)", () => {
+  const transport = read("src/transport.ts");
+
+  it("both MCP transport dispatch paths consult denyTools", () => {
+    // The deny check appears once on the dynamic/proxy path (inside the
+    // `!tool && this.dynamicToolDispatch` branch) and once on the
+    // registered-tool path. Anchor on the comment that marks the dynamic-path
+    // guard, then assert a denyTools.has() check exists in BOTH regions.
+    const dynamicAnchor = transport.indexOf(
+      "Per-session deny list applies to dynamic/proxied tools too",
+    );
+    expect(
+      dynamicAnchor,
+      "dynamic-dispatch deny-list guard comment missing — the proxy path may have lost its denyTools check",
+    ).toBeGreaterThan(-1);
+
+    const denyChecks = [
+      ...transport.matchAll(/this\.denyTools\.has\(params\.name\)/g),
+    ];
+    expect(
+      denyChecks.length,
+      "expected denyTools.has(params.name) on BOTH the dynamic and registered dispatch paths",
+    ).toBeGreaterThanOrEqual(2);
+
+    // At least one deny check must sit in the dynamic region (before the
+    // `if (!tool)` not-found branch that begins the registered path) and at
+    // least one after it.
+    const notFoundBranch = transport.indexOf("\n            if (!tool) {");
+    expect(notFoundBranch).toBeGreaterThan(dynamicAnchor);
+    const dynamicDeny = denyChecks.some((m) => m.index! < notFoundBranch);
+    const registeredDeny = denyChecks.some((m) => m.index! > notFoundBranch);
+    expect(dynamicDeny, "dynamic/proxy path missing denyTools check").toBe(
+      true,
+    );
+    expect(registeredDeny, "registered-tool path missing denyTools check").toBe(
+      true,
+    );
+  });
+
+  it("denyTools is the single per-session deny-list source on the transport", () => {
+    // Guard against a second, divergent deny structure being introduced on the
+    // transport: the only deny-list field should be `denyTools`.
+    expect(transport).toMatch(/private denyTools: Set<string>/);
+  });
+
+  it("recipe executeTool is a distinct boundary, not the MCP deny-list", () => {
+    // Documents the deliberate boundary: the recipe dispatch path does NOT (and
+    // should not) reference the MCP-session denyTools. It is gated by
+    // assertWriteAllowed instead. If this ever changes, the cross-layer
+    // contract above must be reconsidered on purpose.
+    const recipeRegistry = read("src/recipes/toolRegistry.ts");
+    expect(
+      recipeRegistry.includes("denyTools"),
+      "recipe executeTool must not consult the MCP-session denyTools (different boundary; see file header)",
+    ).toBe(false);
+    expect(
+      recipeRegistry.includes("assertWriteAllowed"),
+      "recipe executeTool is expected to enforce the write kill-switch via assertWriteAllowed",
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## What
Completes the two remaining acceptance criteria of #850 ("cross-layer parity invariant tests to catch seam drift"). Criteria **1** (connector parity) and **4** (ctx-tool default availability) already shipped via `connector-dashboard-parity.test.ts` and `ctxToolsUnconditional.test.ts`; this adds the other two.

### Criterion 3 — "documented ⇒ wired" → `scripts/audit-docs-wired.mjs` (new, wired into the CI audit job)
Asserts the docs match the code's source of truth, exits 1 on drift:
- **Prompts:** `PROMPTS[]` has 36 entries; docs say 36 ✓.
- **CLI subcommands:** all 26 documented subcommands are in `index.ts`'s authoritative wired set ✓ (4 wired-but-undocumented surfaced as informational: `connect`, `dashboard`, `doctor`, `shadow-scan`).
- **Automation hooks:** found two *wrong* doc counts and fixed them — **20 → 24** (banner) and **18 → 24** (section). 24 = 21 internal `HookType` slots + 3 unified aliases (`onCompaction`/`onDiagnosticsStateChange`/`onDebugSession`) that `loadPolicy` expands; legacy split names remain accepted (deprecated). Confirmed the unified names *are* wired end-to-end — no behavioral drift, just stale counts.

### Criterion 2 — dispatch-path guard coverage → `src/__tests__/dispatch-guard-parity.test.ts` (new)
Pins that **both** MCP-transport dispatch paths (registered + dynamic/proxy) consult the same per-session `denyTools` list, so the historic proxy-path bypass can't silently regress. Also documents + positively asserts that the recipe `toolRegistry` dispatch **intentionally** does not use the session-scoped `denyTools` (it's gated by `assertWriteAllowed` + the write-effect ledger + the approval gate) — no false cross-layer invariant.

## Test
- `node scripts/audit-docs-wired.mjs` → exit 0; `dispatch-guard-parity` → 3 passed; build + biome clean; sibling audits unaffected.

## Note
Honest finding for a future call (not fixed here): `connect`/`dashboard`/`doctor`/`shadow-scan` are wired but undocumented in CLAUDE.md's CLI section — worth documenting.

Closes #850.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
