### PR TITLE
feat(reliability): actionable failure alerts — halt category + fix hint to phone

### DIFF
--- a/dashboard/public/sw.js
+++ b/dashboard/public/sw.js
@@ -127,11 +127,24 @@ self.addEventListener("push", (event) => {
   // and halt pushes (kind === "halt") render different notifications
   // and have different click targets.
   if (data.kind === "halt") {
-    const { recipeName, runSeq, status, haltReason, stepId, errorMessage } =
-      data;
+    const {
+      recipeName,
+      runSeq,
+      status,
+      haltReason,
+      haltCategory,
+      actionHint,
+      stepId,
+      errorMessage,
+    } = data;
     const isError = status === "error";
     const title = `${isError ? "⚠️ Run errored" : "Run halted"}: ${recipeName ?? "recipe"}`;
-    const body = haltReason || errorMessage || (isError ? "Run errored" : "Run halted");
+    // Show "what + how to fix": the reason followed by the actionable hint
+    // (e.g. "401 unauthorized — reconnect from /connections"), so a halt seen
+    // on a phone is recoverable without opening a laptop.
+    const reason =
+      haltReason || errorMessage || (isError ? "Run errored" : "Run halted");
+    const body = actionHint ? `${reason} — ${actionHint}` : reason;
     // Coalesce repeat fires for the same run so flapping doesn't spam.
     const tag = `halt-${runSeq ?? recipeName ?? "unknown"}`;
     event.waitUntil(
@@ -141,7 +154,7 @@ self.addEventListener("push", (event) => {
         icon: "/icons/icon-192.png",
         badge: "/icons/icon-192.png",
         requireInteraction: false,
-        data: { kind: "halt", runSeq, stepId },
+        data: { kind: "halt", runSeq, stepId, haltCategory },
       }),
     );
     return;
@@ -191,11 +204,23 @@ self.addEventListener("notificationclick", (event) => {
   // Halt notifications deep-link to the failing run/step. No inline
   // actions — the user inspects the run in the dashboard.
   if (notifData.kind === "halt") {
-    const { runSeq, stepId } = notifData;
-    if (!runSeq) return;
-    const targetUrl = stepId
-      ? `./runs/${runSeq}#step-${encodeURIComponent(stepId)}`
-      : `./runs/${runSeq}`;
+    const { runSeq, stepId, haltCategory } = notifData;
+    // Connection-class halts (auth failure / missing connector) are fixed on
+    // the /connections page, not the run page — deep-link there so the user
+    // can reconnect straight from the notification tap. Everything else opens
+    // the failing run/step.
+    const fixOnConnections =
+      haltCategory === "auth_failure" || haltCategory === "missing_connector";
+    let targetUrl;
+    if (fixOnConnections) {
+      targetUrl = "./connections";
+    } else if (runSeq) {
+      targetUrl = stepId
+        ? `./runs/${runSeq}#step-${encodeURIComponent(stepId)}`
+        : `./runs/${runSeq}`;
+    } else {
+      return;
+    }
     event.waitUntil(
       self.clients
         .matchAll({ type: "window", includeUncontrolled: true })

--- a/dashboard/src/app/api/relay/halt/__tests__/route.test.ts
+++ b/dashboard/src/app/api/relay/halt/__tests__/route.test.ts
@@ -37,6 +37,7 @@ const validBody = {
   status: "halted" as const,
   haltReason: "Agent step 'summarize' returned only narration",
   haltCategory: "agent_narration_only",
+  actionHint: "tighten prompt or add `into:` target",
   stepId: "summarize",
 };
 
@@ -148,6 +149,9 @@ describe("POST /api/relay/halt", () => {
       runSeq: 42,
       status: "halted",
       stepId: "summarize",
+      // Actionable enrichment forwarded to the service worker (#850/A).
+      haltCategory: "agent_narration_only",
+      actionHint: "tighten prompt or add `into:` target",
     });
   });
 

--- a/dashboard/src/app/api/relay/halt/route.ts
+++ b/dashboard/src/app/api/relay/halt/route.ts
@@ -40,6 +40,9 @@ interface RelayHaltBody {
   status?: "halted" | "error";
   haltReason?: string;
   haltCategory?: string;
+  /** Actionable fix hint (rendered by the bridge from HALT_CATEGORY_HINTS) —
+   *  forwarded verbatim so the service worker can show "what to do". */
+  actionHint?: string;
   stepId?: string;
   errorMessage?: string;
   occurredAt?: number;
@@ -108,6 +111,7 @@ export async function POST(req: Request) {
     status,
     haltReason: body.haltReason,
     haltCategory: body.haltCategory,
+    actionHint: body.actionHint,
     stepId: body.stepId,
     errorMessage: body.errorMessage,
     occurredAt: body.occurredAt ?? now,

--- a/src/__tests__/wireHaltPushDispatch.test.ts
+++ b/src/__tests__/wireHaltPushDispatch.test.ts
@@ -51,6 +51,51 @@ describe("wireHaltPushDispatch", () => {
         runSeq: 42,
         status: "error",
         errorMessage: "Agent silent-fail in step summarize",
+        // Actionable enrichment (#850/A): the bridge now classifies the halt
+        // and attaches the fix hint so the phone shows "what + how to fix",
+        // not a raw error string.
+        haltReason: "Agent silent-fail in step summarize",
+        haltCategory: "agent_silent_fail",
+        actionHint: "inspect prompt + check trace",
+      }),
+    );
+  });
+
+  it("classifies an auth-failure halt and attaches the reconnect hint", () => {
+    wireHaltPushDispatch({ activityLog, getPushConfig: () => CFG });
+    activityLog.recordEvent("recipe_done", {
+      runSeq: 7,
+      recipeName: "pr-triage",
+      status: "error",
+      errorMessage:
+        'Tool "github.list_prs" reported an error: 401 unauthorized',
+    });
+    expect(dispatchHaltPushNotification).toHaveBeenCalledWith(
+      CFG.url,
+      CFG.token,
+      expect.objectContaining({
+        haltCategory: "auth_failure",
+        actionHint: "reconnect from /connections",
+      }),
+    );
+  });
+
+  it("prefers an explicit haltReason from the event over errorMessage", () => {
+    wireHaltPushDispatch({ activityLog, getPushConfig: () => CFG });
+    activityLog.recordEvent("recipe_done", {
+      runSeq: 8,
+      recipeName: "spend",
+      status: "error",
+      haltReason: "budget_exceeded: run exceeded its token budget",
+      errorMessage: "step 3 failed",
+    });
+    expect(dispatchHaltPushNotification).toHaveBeenCalledWith(
+      CFG.url,
+      CFG.token,
+      expect.objectContaining({
+        haltReason: "budget_exceeded: run exceeded its token budget",
+        haltCategory: "budget_exceeded",
+        actionHint: "raise tokensMax / usdMax or shrink prompts",
       }),
     );
   });

--- a/src/haltPushDispatch.ts
+++ b/src/haltPushDispatch.ts
@@ -37,6 +37,10 @@ export interface HaltPushPayload {
   status: "error" | "halted";
   haltReason?: string;
   haltCategory?: string;
+  /** Actionable one-liner for this category (HALT_CATEGORY_HINTS) — lets the
+   *  push notification / SW show "what to do" without importing the TS hint
+   *  map. Source of truth: src/recipes/haltCategory.ts. */
+  actionHint?: string;
   stepId?: string;
   errorMessage?: string;
   occurredAt?: number;

--- a/src/wireHaltPushDispatch.ts
+++ b/src/wireHaltPushDispatch.ts
@@ -18,6 +18,10 @@
 
 import type { ActivityLog } from "./activityLog.js";
 import { dispatchHaltPushNotification } from "./haltPushDispatch.js";
+import {
+  categoriseHaltReason,
+  HALT_CATEGORY_HINTS,
+} from "./recipes/haltCategory.js";
 
 interface WireHaltPushDispatchDeps {
   activityLog: ActivityLog;
@@ -68,6 +72,15 @@ export function wireHaltPushDispatch(
     const runSeq = typeof md.runSeq === "number" ? md.runSeq : 0;
     const errorMessage =
       typeof md.errorMessage === "string" ? md.errorMessage : undefined;
+    // Classify the halt + attach the actionable fix hint so the push (and the
+    // service worker) can show "what + how to fix" instead of a raw error
+    // string — the difference between "github.list_prs: 401" and
+    // "auth failure → reconnect from /connections" on a phone at 3am.
+    // Prefer an explicit haltReason from the event; fall back to errorMessage.
+    const haltReason =
+      typeof md.haltReason === "string" ? md.haltReason : errorMessage;
+    const haltCategory = categoriseHaltReason(haltReason);
+    const actionHint = HALT_CATEGORY_HINTS[haltCategory];
 
     // Dedup: skip if this runSeq fired a push within the window.
     // runSeq 0 is the "unknown" sentinel — never dedup it, since two
@@ -86,6 +99,9 @@ export function wireHaltPushDispatch(
       recipeName,
       runSeq,
       status: "error",
+      haltReason,
+      haltCategory,
+      actionHint,
       errorMessage,
       occurredAt: at,
     }).catch((err) => {


### PR DESCRIPTION
## What (Reliability "A" — the failure-trust loop)
When a recipe halts, the push notification used to carry only the raw error string (often effectively "unknown error") — the single worst moment for trust: a cron that failed while you were asleep, with no idea what broke or how to fix it.

Now the **already-computed** diagnosis reaches the phone:
- **Bridge** (`wireHaltPushDispatch`) classifies the halt via `categoriseHaltReason` and attaches the actionable fix hint from the canonical `HALT_CATEGORY_HINTS` (`haltReason`, `haltCategory`, `actionHint`).
- **Relay** forwards the new fields verbatim.
- **Service worker** renders `reason — hint`, e.g. **"401 unauthorized — reconnect from /connections"**, and a tap on connection-class halts (`auth_failure` / `missing_connector`) **deep-links straight to `/connections`** instead of the run page.

Single source of truth (`src/recipes/haltCategory.ts`) — no hint map duplicated into `sw.js`.

## Why now
The synthesis ranked this the #1 stage-appropriate bet: the data + hints + doctor loop already exist, they just stopped at the dashboard boundary. This is wiring, not new features, and it targets the moment that decides whether anyone trusts Patchwork to run unattended.

## Test
- `wireHaltPushDispatch` payload now asserts `haltCategory` + `actionHint` for `agent_silent_fail`, `auth_failure`, and `budget_exceeded` (incl. preferring an explicit `haltReason` over `errorMessage`) — **13 passed**.
- Relay route asserts the fields are forwarded — **10 passed**.
- Bridge build + dashboard `tsc` clean.

## Follow-up (not in this PR)
Make the hint **text on the dashboard** run-detail/runs pills a clickable link too (the page already renders the hint string; this PR did the higher-value phone path + the SW tap-target).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
