### PR TITLE
feat(onboarding): plain `claude --ide` after init + first-recipe nudge + fresh-HOME fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,11 +89,22 @@ claude-ide-bridge install-extension
 claude-ide-bridge --workspace .
 
 # 4. Connect Claude Code (in another terminal)
-#    The env var skips Claude Code's built-in IDE-detection check — the bridge
-#    manages this connection itself. Add `export CLAUDE_CODE_IDE_SKIP_VALID_CHECK=true`
-#    to your shell profile so `claude --ide` is all you need going forward.
-CLAUDE_CODE_IDE_SKIP_VALID_CHECK=true claude --ide
+claude --ide
 ```
+
+> **First time `claude --ide` says it can't find an IDE?** Claude Code's `--ide`
+> flag runs an in-terminal IDE-detection check; a standalone bridge launched from
+> a plain terminal trips it, so you need to set `CLAUDE_CODE_IDE_SKIP_VALID_CHECK=true`.
+> `patchwork init` writes this into your `~/.claude/settings.json` for you (so a
+> plain `claude --ide` just works). If you're only running the bridge (no `init`),
+> add it once yourself — Claude Code applies its `env` block to every session:
+>
+> ```json
+> // ~/.claude/settings.json
+> { "env": { "CLAUDE_CODE_IDE_SKIP_VALID_CHECK": "true" } }
+> ```
+>
+> Or prefix it for a single run: `CLAUDE_CODE_IDE_SKIP_VALID_CHECK=true claude --ide`.
 
 Type `/ide` in Claude Code to confirm the connection. That's it — Claude now sees your diagnostics, open files, and editor state, and can call 177 tools to act on them.
 

--- a/src/__tests__/init.test.ts
+++ b/src/__tests__/init.test.ts
@@ -227,6 +227,33 @@ describe("init --workspace", () => {
     expect(parsed.mcpServers).toBeDefined();
     expect(parsed.mcpServers?.["claude-ide-bridge"]).toBeDefined();
   });
+
+  it("persists CLAUDE_CODE_IDE_SKIP_VALID_CHECK in settings.json env so `claude --ide` needs no prefix", () => {
+    const ws = makeTmpDir();
+    const fakeHome = makeTmpDir();
+    const configDir = path.join(fakeHome, ".claude");
+    const settingsPath = path.join(configDir, "settings.json");
+
+    // NOTE: do NOT pass CLAUDE_CODE_IDE_SKIP_VALID_CHECK in the spawn env here —
+    // this test asserts that `init` itself writes it into settings.json.
+    const result = spawnSync("node", [distIndex, "init", "--workspace", ws], {
+      input: "n\n",
+      encoding: "utf-8",
+      env: {
+        ...process.env,
+        CLAUDE_CONFIG_DIR: configDir,
+        HOME: fakeHome,
+      },
+      timeout: 30_000,
+    });
+
+    expect(result.status).toBe(0);
+    expect(fs.existsSync(settingsPath)).toBe(true);
+    const settings = JSON.parse(fs.readFileSync(settingsPath, "utf-8")) as {
+      env?: Record<string, unknown>;
+    };
+    expect(settings.env?.CLAUDE_CODE_IDE_SKIP_VALID_CHECK).toBe("true");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/__tests__/settingsEnv.test.ts
+++ b/src/__tests__/settingsEnv.test.ts
@@ -1,0 +1,107 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  registerSkipIdeValidCheckEnv,
+  SKIP_IDE_VALID_CHECK_KEY,
+} from "../settingsEnv.js";
+
+let dir: string;
+let settingsPath: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(path.join(tmpdir(), "patchwork-env-"));
+  settingsPath = path.join(dir, "settings.json");
+});
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+function readSettings() {
+  return JSON.parse(readFileSync(settingsPath, "utf-8")) as {
+    env?: Record<string, unknown>;
+    hooks?: unknown;
+    permissions?: unknown;
+  };
+}
+
+describe("registerSkipIdeValidCheckEnv", () => {
+  it("creates a fresh settings.json with the env block and the skip flag", () => {
+    const r = registerSkipIdeValidCheckEnv(settingsPath);
+    expect(r.action).toBe("added");
+    const s = readSettings();
+    expect(s.env).toBeDefined();
+    expect(s.env?.[SKIP_IDE_VALID_CHECK_KEY]).toBe("true");
+  });
+
+  it("adds the flag to an existing env block without dropping other vars", () => {
+    writeFileSync(
+      settingsPath,
+      JSON.stringify({ env: { FOO: "bar" } }, null, 2),
+    );
+    const r = registerSkipIdeValidCheckEnv(settingsPath);
+    expect(r.action).toBe("added");
+    const s = readSettings();
+    expect(s.env?.FOO).toBe("bar");
+    expect(s.env?.[SKIP_IDE_VALID_CHECK_KEY]).toBe("true");
+  });
+
+  it("is idempotent — second call reports already-present and does not churn", () => {
+    registerSkipIdeValidCheckEnv(settingsPath);
+    const before = readFileSync(settingsPath, "utf-8");
+    const r2 = registerSkipIdeValidCheckEnv(settingsPath);
+    expect(r2.action).toBe("already-present");
+    // Byte-for-byte unchanged on the no-op path.
+    expect(readFileSync(settingsPath, "utf-8")).toBe(before);
+  });
+
+  it("preserves a user-pinned non-true value instead of clobbering it", () => {
+    writeFileSync(
+      settingsPath,
+      JSON.stringify({ env: { [SKIP_IDE_VALID_CHECK_KEY]: "false" } }, null, 2),
+    );
+    const r = registerSkipIdeValidCheckEnv(settingsPath);
+    expect(r.action).toBe("preserved-user-value");
+    expect(r.existingValue).toBe("false");
+    // The user's value must survive untouched.
+    const s = readSettings();
+    expect(s.env?.[SKIP_IDE_VALID_CHECK_KEY]).toBe("false");
+  });
+
+  it("preserves unrelated top-level settings (hooks, permissions)", () => {
+    writeFileSync(
+      settingsPath,
+      JSON.stringify(
+        {
+          permissions: { allow: ["Read"] },
+          hooks: { PreToolUse: [{ matcher: "*", hooks: [] }] },
+        },
+        null,
+        2,
+      ),
+    );
+    const r = registerSkipIdeValidCheckEnv(settingsPath);
+    expect(r.action).toBe("added");
+    const s = readSettings();
+    expect(s.permissions).toEqual({ allow: ["Read"] });
+    expect(s.hooks).toEqual({ PreToolUse: [{ matcher: "*", hooks: [] }] });
+    expect(s.env?.[SKIP_IDE_VALID_CHECK_KEY]).toBe("true");
+  });
+
+  it("reports an error (without clobbering) when env is not an object", () => {
+    writeFileSync(settingsPath, JSON.stringify({ env: "oops" }, null, 2));
+    const r = registerSkipIdeValidCheckEnv(settingsPath);
+    expect(r.action).toBe("error");
+    expect(r.error).toMatch(/not an object/);
+    // Original file is left intact — no destructive write on the error path.
+    expect(JSON.parse(readFileSync(settingsPath, "utf-8")).env).toBe("oops");
+  });
+
+  it("reports an error on malformed JSON rather than throwing", () => {
+    writeFileSync(settingsPath, "{ not json");
+    const r = registerSkipIdeValidCheckEnv(settingsPath);
+    expect(r.action).toBe("error");
+    expect(typeof r.error).toBe("string");
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -3895,10 +3895,18 @@ Steps performed:
   }
 
   // Step 3b: Wire CC hooks in ~/.claude/settings.json
-  const ccSettingsPath = path.join(
-    process.env.CLAUDE_CONFIG_DIR ?? path.join(os.homedir(), ".claude"),
-    "settings.json",
-  );
+  const ccConfigDir =
+    process.env.CLAUDE_CONFIG_DIR ?? path.join(os.homedir(), ".claude");
+  const ccSettingsPath = path.join(ccConfigDir, "settings.json");
+  // On a truly fresh machine ~/.claude/ may not exist yet. Every settings.json
+  // writer below (CC hooks, the IDE-skip env step, the PreToolUse hook) does an
+  // atomic write that needs the parent dir to exist — without this, all three
+  // silently fail with ENOENT and the user's onboarding state is never persisted.
+  try {
+    mkdirSync(ccConfigDir, { recursive: true });
+  } catch {
+    // best-effort — the individual writers below surface their own warnings
+  }
   const CC_HOOK_NOTIFY_CMDS: Record<string, string> = {
     PreCompact: "claude-ide-bridge notify PreCompact",
     PostCompact: "claude-ide-bridge notify PostCompact",
@@ -3982,6 +3990,40 @@ Steps performed:
     );
   }
 
+  // Step 3c: Persist CLAUDE_CODE_IDE_SKIP_VALID_CHECK into the settings.json
+  // `env` block so `claude --ide` connects without the user prefixing the var
+  // on every launch. The bridge writes its own ~/.claude/ide/<port>.lock, but
+  // Claude Code's `--ide` "valid check" is an in-IDE-terminal detection that a
+  // standalone bridge can't satisfy by lock-file shape alone — so we set the
+  // skip flag where Patchwork already manages CC config (NOT the shell rc).
+  try {
+    const { registerSkipIdeValidCheckEnv } = await import("./settingsEnv.js");
+    const envResult = registerSkipIdeValidCheckEnv(ccSettingsPath);
+    if (envResult.action === "added") {
+      process.stderr.write(
+        `  ✓ IDE connect — set CLAUDE_CODE_IDE_SKIP_VALID_CHECK=true in ${ccSettingsPath}\n     You can now run a plain \`claude --ide\` — no env-var prefix needed.\n\n`,
+      );
+    } else if (envResult.action === "already-present") {
+      process.stderr.write(
+        `  ✓ IDE connect — CLAUDE_CODE_IDE_SKIP_VALID_CHECK already set in ${ccSettingsPath}\n\n`,
+      );
+    } else if (envResult.action === "preserved-user-value") {
+      process.stderr.write(
+        `  [info] IDE connect — left your CLAUDE_CODE_IDE_SKIP_VALID_CHECK="${envResult.existingValue}" untouched.\n` +
+          `         If \`claude --ide\` won't connect, set it to "true" in ${ccSettingsPath}.\n\n`,
+      );
+    } else {
+      process.stderr.write(
+        `  [warn] IDE connect — could not set CLAUDE_CODE_IDE_SKIP_VALID_CHECK (${envResult.error}).\n` +
+          `         Add { "env": { "CLAUDE_CODE_IDE_SKIP_VALID_CHECK": "true" } } to ${ccSettingsPath} manually.\n\n`,
+      );
+    }
+  } catch (err) {
+    process.stderr.write(
+      `  [warn] IDE connect — ${err instanceof Error ? err.message : String(err)}\n\n`,
+    );
+  }
+
   // Patchwork: register PreToolUse approval hook so the dashboard can
   // approve/reject CC tool calls in real time.
   try {
@@ -4049,8 +4091,14 @@ Steps performed:
       "Next steps:\n" +
       `  1. Start the bridge:    claude-ide-bridge --watch   (runs in this workspace)\n` +
       "  2. Restart your IDE once so it picks up the new extension + MCP config.\n" +
-      "  3. Open Claude Code and type /mcp — the claude-ide-bridge server should show as connected.\n" +
-      "  4. Type /ide to see live workspace state (open editors, diagnostics, git status).\n\n",
+      "  3. Connect Claude Code: claude --ide   (the IDE-detection skip flag is\n" +
+      "       already set in ~/.claude/settings.json — no env-var prefix needed).\n" +
+      "  4. Type /mcp — the claude-ide-bridge server should show as connected,\n" +
+      "       then /ide to see live workspace state (open editors, diagnostics, git).\n" +
+      "  5. Run your first recipe (no connectors needed — local git + a brief):\n" +
+      "       patchwork recipe run daily-status --local\n" +
+      "       Writes a morning brief to ~/.patchwork/inbox/. Try --dry-run first to\n" +
+      "       see the plan without spending tokens.\n\n",
   );
 
   if (inWorktree) {

--- a/src/settingsEnv.ts
+++ b/src/settingsEnv.ts
@@ -1,0 +1,111 @@
+import { existsSync, readFileSync } from "node:fs";
+import { writeFileAtomicSync } from "./writeFileAtomic.js";
+
+/**
+ * Persist `CLAUDE_CODE_IDE_SKIP_VALID_CHECK=true` into Claude Code's
+ * `~/.claude/settings.json` `env` block during `patchwork init`.
+ *
+ * Why this exists
+ * ---------------
+ * Running `claude --ide` makes Claude Code try to auto-connect to an IDE.
+ * Part of that flow is a "valid check" that detects whether the current
+ * terminal is running *inside* a recognized IDE's integrated terminal
+ * (parent-process / terminal detection). The Patchwork bridge is a
+ * standalone process that writes its own `~/.claude/ide/<port>.lock`, so a
+ * `claude --ide` launched from a plain terminal trips that check even though
+ * the bridge connection is perfectly valid. `CLAUDE_CODE_IDE_SKIP_VALID_CHECK=true`
+ * skips it.
+ *
+ * The lock-file SHAPE is not the problem — there's no field a third-party
+ * bridge can set to satisfy the check, because it's an in-IDE-terminal
+ * detection, not a lock-file-content check. So the cleanest way to make the
+ * raw README env-var workaround unnecessary is to persist the variable where
+ * Patchwork already manages Claude Code config: the `env` block of
+ * `~/.claude/settings.json`. Claude Code applies that block to every session,
+ * so a subsequent plain `claude --ide` sees the variable set.
+ *
+ * This deliberately does NOT touch the user's shell dotfiles (~/.zshrc etc.).
+ * Idempotent: re-running `patchwork init` does not duplicate or churn the
+ * entry, and it never overwrites a value the user set themselves.
+ */
+
+export const SKIP_IDE_VALID_CHECK_KEY = "CLAUDE_CODE_IDE_SKIP_VALID_CHECK";
+
+export interface SetEnvResult {
+  action: "added" | "already-present" | "preserved-user-value" | "error";
+  path: string;
+  /** The value currently in settings.json after the operation (for "preserved-user-value"). */
+  existingValue?: string;
+  error?: string;
+}
+
+/**
+ * Ensure `CLAUDE_CODE_IDE_SKIP_VALID_CHECK=true` is present in the `env` block
+ * of the given Claude Code settings.json.
+ *
+ * - Missing file or missing `env` block → create them and add the key ("added").
+ * - Key already === "true" → no write ("already-present").
+ * - Key present with a DIFFERENT value → leave it untouched and report
+ *   ("preserved-user-value"). We never clobber an explicit user choice.
+ * - Read/parse/write failure → ("error") with the message; the caller treats
+ *   this as a non-fatal warning, matching every other init settings.json step.
+ */
+export function registerSkipIdeValidCheckEnv(
+  ccSettingsPath: string,
+): SetEnvResult {
+  try {
+    let ccSettings: Record<string, unknown> = {};
+    if (existsSync(ccSettingsPath)) {
+      ccSettings = JSON.parse(readFileSync(ccSettingsPath, "utf-8")) as Record<
+        string,
+        unknown
+      >;
+    }
+
+    // `env` must be a plain object. If the user (or a corrupt write) left a
+    // non-object there, don't blow it away — bail out as an error so init
+    // surfaces a warning instead of silently dropping their config.
+    const rawEnv = ccSettings.env;
+    if (
+      rawEnv !== undefined &&
+      (typeof rawEnv !== "object" || rawEnv === null || Array.isArray(rawEnv))
+    ) {
+      return {
+        action: "error",
+        path: ccSettingsPath,
+        error: `settings.json "env" is not an object`,
+      };
+    }
+
+    const env = (rawEnv ?? {}) as Record<string, unknown>;
+    const current = env[SKIP_IDE_VALID_CHECK_KEY];
+
+    if (typeof current === "string" && current !== "true") {
+      // User pinned a different value (e.g. "false") — respect it.
+      return {
+        action: "preserved-user-value",
+        path: ccSettingsPath,
+        existingValue: current,
+      };
+    }
+    if (current === "true") {
+      return { action: "already-present", path: ccSettingsPath };
+    }
+
+    env[SKIP_IDE_VALID_CHECK_KEY] = "true";
+    ccSettings.env = env;
+    // Atomic — settings.json holds the user's full Claude Code config;
+    // a crash mid-write must not corrupt it.
+    writeFileAtomicSync(
+      ccSettingsPath,
+      `${JSON.stringify(ccSettings, null, 2)}\n`,
+    );
+    return { action: "added", path: ccSettingsPath };
+  } catch (err) {
+    return {
+      action: "error",
+      path: ccSettingsPath,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}


### PR DESCRIPTION
## What (Adoption "B" — time-to-first-value)
Removes the first rough edge a new developer hits and gets them to a working recipe immediately.

- **Launch friction (B1):** the README's step-4 workaround `CLAUDE_CODE_IDE_SKIP_VALID_CHECK=true claude --ide` is gone. Root cause: that flag skips Claude Code's *in-IDE-terminal* detection — there's no lock-file field that satisfies it, so the right fix is to persist the flag. `patchwork init` now writes it into the `~/.claude/settings.json` `env` block (new `settingsEnv.ts`: idempotent, atomic, preserves other vars, never clobbers a user value, fail-soft). After `init`, a plain **`claude --ide`** works. README documents a one-time `settings.json` snippet for the bridge-only path that never runs `init`.
- **First-recipe nudge (B2):** `init`'s next-steps now ends with a real **zero-connector** recipe — `patchwork recipe run daily-status --local` (`--dry-run` first) — so the user reaches an "aha" without configuring anything.
- **Bonus fix:** a fresh-HOME integration test surfaced that `init` never created `~/.claude/` before its atomic writes — so on a brand-new machine the CC hooks, the approval hook, *and* the new env step all silently `ENOENT`'d. Added a recursive `mkdir`.

## Test
- New `settingsEnv` unit tests (add / idempotent / preserve-user-value / preserve-other-settings / error paths) + a fresh-`HOME` `init` integration test — **35 pass** (init / settingsEnv / preToolUseHook). Build + biome clean.

## Not in this PR (needs a human)
The 45-second demo GIF — a screen recording I can't produce. Recommended next: record `init → bridge → recipe run → inbox file` and drop it near the top of the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
