### PR TITLE
feat(moat): one-click "Enable self-correction" in the recipe editor

### DIFF
--- a/dashboard/src/app/recipes/[...name]/_edit/page.tsx
+++ b/dashboard/src/app/recipes/[...name]/_edit/page.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { parse as parseYaml } from "yaml";
+import { enableSelfCorrection } from "@/lib/selfCorrection";
 import { apiPath } from "@/lib/api";
 // BackLink and RelationStrip are rendered by the shared recipes/[name]/layout.tsx
 import { useToast } from "@/components/Toast";
@@ -703,6 +704,21 @@ export default function RecipeEditPage({ name }: { name: string }) {
     setRepairProposal(null);
   }
 
+  // One-click "enable self-correction": inject a judge→refine loop + a
+  // more-capable escalation ladder onto an agent step. Operates on the raw
+  // YAML (the structured form is a lossy subset that doesn't model
+  // judge/escalate), so it's only offered in YAML mode and writes the result
+  // straight back into the editor for review before saving.
+  function handleSelfCorrect() {
+    const result = enableSelfCorrection(content);
+    if (result.changed) {
+      setContent(result.yaml);
+      toast.success(result.message);
+    } else {
+      toast.info(result.message);
+    }
+  }
+
   return (
     <section>
       {/* The layout at recipes/[name]/layout.tsx already renders
@@ -744,6 +760,17 @@ export default function RecipeEditPage({ name }: { name: string }) {
           ))}
         </div>
         <div style={{ display: "flex", gap: "var(--s-2)", alignItems: "center", marginLeft: "auto" }}>
+          {editMode === "yaml" && (
+            <button
+              type="button"
+              className="btn ghost"
+              onClick={handleSelfCorrect}
+              disabled={loading}
+              title="Add a judge→refine self-correction loop (with a model-escalation ladder) to the last agent step. Edits the YAML for you to review."
+            >
+              ✨ Self-correct
+            </button>
+          )}
           <Link
             href={`/recipes/${encodeURIComponent(name)}/plan`}
             className="btn ghost"

--- a/dashboard/src/lib/__tests__/selfCorrection.test.ts
+++ b/dashboard/src/lib/__tests__/selfCorrection.test.ts
@@ -1,0 +1,128 @@
+import { parse } from "yaml";
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_ESCALATE_LADDER,
+  DEFAULT_MAX_REVISIONS,
+  enableSelfCorrection,
+} from "../selfCorrection";
+
+const RECIPE = `name: demo
+trigger:
+  type: manual
+steps:
+  - tool: git.log_since
+    into: commits
+  - agent:
+      prompt: Summarize the commits
+    into: summary
+`;
+
+interface Step {
+  id?: string;
+  into?: string;
+  kind?: string;
+  reviews?: string;
+  max_revisions?: number;
+  on_exhausted?: string;
+  escalate?: Array<{ model?: string; driver?: string }>;
+  agent?: { prompt?: string };
+}
+
+function steps(yaml: string): Step[] {
+  return (parse(yaml) as { steps: Step[] }).steps;
+}
+
+describe("enableSelfCorrection", () => {
+  it("adds a judge step + escalate ladder to the last agent step", () => {
+    const { yaml, changed, message } = enableSelfCorrection(RECIPE);
+    expect(changed).toBe(true);
+    expect(message).toMatch(/self-correction judge for "summary"/);
+
+    const s = steps(yaml);
+    // git step + agent step + inserted judge = 3
+    expect(s).toHaveLength(3);
+
+    const agent = s.find((x) => x.into === "summary")!;
+    expect(agent.escalate).toEqual([...DEFAULT_ESCALATE_LADDER]);
+
+    const judge = s.find((x) => x.kind === "judge")!;
+    expect(judge.reviews).toBe("summary");
+    expect(judge.max_revisions).toBe(DEFAULT_MAX_REVISIONS);
+    expect(judge.on_exhausted).toBe("proceed");
+    expect(judge.agent?.prompt).toBeTruthy();
+    // judge is inserted immediately AFTER the reviewed step
+    expect(s.indexOf(judge)).toBe(s.indexOf(agent) + 1);
+  });
+
+  it("escalate ladder is model-only (driver-agnostic, safe for any setup)", () => {
+    const s = steps(enableSelfCorrection(RECIPE).yaml);
+    const agent = s.find((x) => x.into === "summary")!;
+    for (const rung of agent.escalate!) {
+      expect(rung.model).toBeTruthy();
+      expect(rung.driver).toBeUndefined();
+    }
+  });
+
+  it("targets a specific agent step by id/into when given", () => {
+    const multi = `name: m
+trigger: { type: manual }
+steps:
+  - agent: { prompt: a }
+    into: first
+  - agent: { prompt: b }
+    into: second
+`;
+    const s = steps(enableSelfCorrection(multi, "first").yaml);
+    const judge = s.find((x) => x.kind === "judge")!;
+    expect(judge.reviews).toBe("first");
+    // inserted right after "first", before "second"
+    expect(s.map((x) => x.into ?? x.kind)).toEqual([
+      "first",
+      "judge",
+      "second",
+    ]);
+  });
+
+  it("is idempotent — no second judge for an already-corrected step", () => {
+    const once = enableSelfCorrection(RECIPE).yaml;
+    const twice = enableSelfCorrection(once);
+    expect(twice.changed).toBe(false);
+    expect(twice.message).toMatch(/already has a self-correction judge/);
+    expect(steps(twice.yaml).filter((x) => x.kind === "judge")).toHaveLength(1);
+  });
+
+  it("keeps an existing escalate ladder instead of clobbering it", () => {
+    const withLadder = `name: x
+trigger: { type: manual }
+steps:
+  - agent: { prompt: a }
+    into: out
+    escalate:
+      - model: my-custom-model
+`;
+    const { yaml, message } = enableSelfCorrection(withLadder);
+    const agent = steps(yaml).find((x) => x.into === "out")!;
+    expect(agent.escalate).toEqual([{ model: "my-custom-model" }]);
+    expect(message).toMatch(/existing escalation ladder/);
+  });
+
+  it("no-ops on a recipe with no agent step", () => {
+    const toolsOnly = `name: t
+trigger: { type: manual }
+steps:
+  - tool: git.log_since
+    into: commits
+`;
+    const r = enableSelfCorrection(toolsOnly);
+    expect(r.changed).toBe(false);
+    expect(r.message).toMatch(/No agent step/);
+    expect(r.yaml).toBe(toolsOnly);
+  });
+
+  it("no-ops (does not throw) on unparseable YAML", () => {
+    const bad = "name: x\n  steps: [oops";
+    const r = enableSelfCorrection(bad);
+    expect(r.changed).toBe(false);
+    expect(r.yaml).toBe(bad);
+  });
+});

--- a/dashboard/src/lib/selfCorrection.ts
+++ b/dashboard/src/lib/selfCorrection.ts
@@ -1,0 +1,159 @@
+/**
+ * "Enable self-correction" recipe transform (#moat / strategic-D).
+ *
+ * Patchwork's judge→refine + escalate[] loop is the one feature no competing
+ * agent runtime has — but today it's reachable only by hand-authoring
+ * `kind: judge`, `reviews:`, `max_revisions:`, and `escalate:` YAML. This
+ * pure transform powers a one-click "Enable self-correction" affordance in the
+ * recipe editor: pick an agent step and it injects a sensible judge→refine
+ * loop with a more-capable escalation ladder.
+ *
+ * It operates on the RAW YAML (parse → mutate → stringify), NOT the structured
+ * form — the form is a lossy subset view (it doesn't model model/kind/escalate)
+ * and round-tripping complex recipes through it drops fields (the documented
+ * "complex YAML → raw editor" rule). Keeping the transform on the YAML text is
+ * the only lossless path.
+ *
+ * Schema contract (src/recipes/schemaGenerator.ts):
+ *   - the reviewed agent step gets `escalate: [{model}...]` (ordered
+ *     more-capable fallbacks; the Nth request_changes revision re-runs it with
+ *     escalate[N-1]).
+ *   - a `kind: judge` step is inserted after it with `reviews: <into>`,
+ *     `max_revisions`, `on_exhausted`.
+ */
+
+import { parse, stringify } from "yaml";
+
+/**
+ * Default escalation ladder. MODEL-ONLY (no `driver` override) so it stays
+ * valid for every driver — API key OR subscription (`claude-code`) OR a local
+ * base model keep their driver and only the model gets stronger. The user can
+ * edit the rungs (e.g. prepend a local→cloud `driver` switch) afterwards.
+ */
+export const DEFAULT_ESCALATE_LADDER: ReadonlyArray<{ model: string }> = [
+  { model: "claude-sonnet-4-6" },
+  { model: "claude-opus-4-8" },
+];
+
+export const DEFAULT_MAX_REVISIONS = 2;
+
+export interface SelfCorrectionResult {
+  /** Transformed YAML — identical to the input when `changed` is false. */
+  yaml: string;
+  changed: boolean;
+  /** Human-facing note: what happened, or why nothing did. */
+  message: string;
+}
+
+interface LooseStep {
+  id?: string;
+  into?: string;
+  tool?: unknown;
+  tools?: unknown;
+  agent?: unknown;
+  kind?: string;
+  reviews?: string;
+  escalate?: unknown;
+  [k: string]: unknown;
+}
+
+/** An agent step is one with an `agent` block that is NOT already a judge. */
+function isAgentStep(s: LooseStep | null | undefined): boolean {
+  return !!s && typeof s === "object" && !!s.agent && s.kind !== "judge";
+}
+
+function stepKey(s: LooseStep, index: number): string {
+  return s.id ?? s.into ?? `step_${index + 1}`;
+}
+
+/**
+ * Inject a judge→refine self-correction loop around one agent step.
+ *
+ * @param yamlText  the recipe YAML
+ * @param targetStepId  id/into of the agent step to wrap; when omitted, the
+ *   LAST agent step is used (the typical "judge the final output" case).
+ */
+export function enableSelfCorrection(
+  yamlText: string,
+  targetStepId?: string,
+): SelfCorrectionResult {
+  const noChange = (message: string): SelfCorrectionResult => ({
+    yaml: yamlText,
+    changed: false,
+    message,
+  });
+
+  let doc: { steps?: LooseStep[] } | null;
+  try {
+    doc = parse(yamlText) as { steps?: LooseStep[] } | null;
+  } catch {
+    return noChange("Could not parse the recipe YAML — fix syntax first.");
+  }
+  if (!doc || typeof doc !== "object" || !Array.isArray(doc.steps)) {
+    return noChange("Recipe has no steps to add self-correction to.");
+  }
+  const steps = doc.steps;
+
+  let idx = -1;
+  if (targetStepId) {
+    idx = steps.findIndex(
+      (s, i) => isAgentStep(s) && stepKey(s, i) === targetStepId,
+    );
+    if (idx === -1) {
+      return noChange(`No agent step "${targetStepId}" found.`);
+    }
+  } else {
+    for (let i = steps.length - 1; i >= 0; i--) {
+      if (isAgentStep(steps[i])) {
+        idx = i;
+        break;
+      }
+    }
+    if (idx === -1) {
+      return noChange("No agent step found to add self-correction to.");
+    }
+  }
+
+  const step = steps[idx]!;
+  const into = step.into ?? stepKey(step, idx);
+
+  // Idempotent: don't add a second judge for a step that already has one.
+  if (steps.some((s) => s.kind === "judge" && s.reviews === into)) {
+    return noChange(`"${into}" already has a self-correction judge.`);
+  }
+
+  // 1. The judge needs a stable output key to review.
+  if (!step.into) step.into = into;
+
+  // 2. Escalation ladder on the reviewed step — don't clobber an existing one.
+  let addedLadder = false;
+  if (!Array.isArray(step.escalate) || step.escalate.length === 0) {
+    step.escalate = DEFAULT_ESCALATE_LADDER.map((r) => ({ ...r }));
+    addedLadder = true;
+  }
+
+  // 3. Insert the judge step immediately after the reviewed step.
+  const judge: LooseStep = {
+    id: `${into}_review`,
+    agent: {
+      prompt:
+        "Review the previous step's output for correctness, completeness, and " +
+        "adherence to the task. Reply 'approve' if it is good, or " +
+        "'request_changes' with a brief, specific reason.",
+    },
+    kind: "judge",
+    reviews: into,
+    max_revisions: DEFAULT_MAX_REVISIONS,
+    on_exhausted: "proceed",
+  };
+  steps.splice(idx + 1, 0, judge);
+
+  const ladderNote = addedLadder
+    ? ` with a ${DEFAULT_ESCALATE_LADDER.length}-rung model-escalation ladder`
+    : " (kept the step's existing escalation ladder)";
+  return {
+    yaml: stringify(doc),
+    changed: true,
+    message: `Added a self-correction judge for "${into}"${ladderNote}, up to ${DEFAULT_MAX_REVISIONS} revisions. Review the generated steps and tune the models/criteria before saving.`,
+  };
+}


### PR DESCRIPTION
## What (Moat "D" — make the unmatched feature discoverable)
Patchwork's judge→refine + `escalate[]` loop — start on a cheap/local model, judge the output, and auto-escalate to a stronger model only when it fails review — is the one capability no competing agent runtime has. But it was reachable **only by hand-authoring** `kind: judge` / `reviews` / `max_revisions` / `escalate` YAML. This adds a one-click **"✨ Self-correct"** button to the recipe editor.

- **Pure transform** (`dashboard/src/lib/selfCorrection.ts`): parses the recipe YAML, finds the target agent step (the last one, or a given `id`/`into`), adds a **model-only** `escalate` ladder (`sonnet → opus` — no `driver` override, so it's valid for an API key **or** a subscription **or** a local base model), and inserts a `kind: judge` step (`reviews: <into>`, `max_revisions: 2`, `on_exhausted: proceed`) right after it. Idempotent; preserves an existing ladder; no-ops (without throwing) on tool-only or unparseable recipes.
- **UI:** the button is offered **only in YAML mode** and writes the transformed YAML back into the editor for review before saving. This is deliberate: the structured form is a *lossy subset* (it doesn't model `judge`/`escalate`), so applying through it would silently drop fields — the established "complex YAML → raw editor" rule.

## Test
- 7 unit tests on the transform (insert / target-by-id / idempotent / keep-existing-ladder / model-only-ladder / no-agent / bad-yaml). Dashboard `tsc` clean.

## Note / follow-up
The default ladder (`sonnet → opus`, 2 revisions) is a sensible, editable starting point shown to the user — not a forced config. A natural enhancement: detect a **local** base model and prepend a `driver` switch for the literal "local → cloud" escalation headline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
