### PR TITLE
fix(extension): refresh liveness on RTT pong to stop 120s false-reconnect

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "claude-ide-bridge-extension",
   "displayName": "Claude IDE Bridge",
   "description": "MCP bridge between Claude Code and your IDE. 177 tools — diagnostics, LSP, debugger, terminal, git. Optional Patchwork OS layer adds recipes, oversight, and approval queue.",
-  "version": "1.4.22",
+  "version": "1.4.23",
   "extensionKind": [
     "workspace"
   ],

--- a/vscode-extension/src/__tests__/connection-fixes.test.ts
+++ b/vscode-extension/src/__tests__/connection-fixes.test.ts
@@ -297,6 +297,46 @@ describe("heartbeat — sleep/wake active probe", () => {
   });
 });
 
+// ── P0-3: RTT pong refreshes liveness baseline (no 120s false-positive 1006) ──
+
+describe("heartbeat — RTT pong refreshes liveness baseline (P0-3)", () => {
+  it("does not force-reconnect a healthy idle connection kept alive only by RTT pongs (bridge sends no 'ping' frames)", () => {
+    const conn = new BridgeConnection();
+    const handleDisconnectSpy = vi
+      .spyOn(conn as any, "handleDisconnect")
+      .mockImplementation(() => {});
+    const { EventEmitter } = require("node:events");
+    const fakeSock: any = new EventEmitter();
+    fakeSock.readyState = 1; // WebSocket.OPEN
+    fakeSock.ping = vi.fn();
+    fakeSock.terminate = vi.fn();
+    fakeSock.close = vi.fn();
+    fakeSock.send = vi.fn();
+    (conn as any).ws = fakeSock;
+
+    (conn as any).stopHeartbeat();
+    (conn as any).startHeartbeat();
+
+    // Simulate >120s of a healthy idle connection. The bridge never emits its
+    // own 'ping' frames (regression: the extension socket is not in the server
+    // ping set), so the only liveness signal is the extension's own 45s RTT
+    // ping, which always gets a pong back — direct proof the bridge is alive.
+    // Run 3 heartbeat ticks (~135s), delivering the RTT pong after each tick.
+    for (let i = 0; i < 3; i++) {
+      vi.advanceTimersByTime(45_001);
+      // Each normal tick sends an RTT ping and registers a once('pong') handler.
+      fakeSock.emit("pong", Buffer.from(String((conn as any).lastPingTime)));
+    }
+
+    // Fix: the RTT pong refreshes lastBridgePong, so the 120s staleness check
+    // (connection.ts) never trips. Without it, lastBridgePong stagnates at
+    // startHeartbeat time and tick 3 (~135s) force-reconnects → 1006 churn.
+    expect(handleDisconnectSpy).not.toHaveBeenCalled();
+    expect(fakeSock.terminate).not.toHaveBeenCalled();
+    conn.dispose();
+  });
+});
+
 // ── sendNotification dispose guard (1e) ───────────────────────────────────────
 
 describe("sendNotification — dispose guard", () => {

--- a/vscode-extension/src/connection.ts
+++ b/vscode-extension/src/connection.ts
@@ -539,6 +539,12 @@ export class BridgeConnection {
         }
         this.rttPongHandler = (data) => {
           this.rttPongHandler = null;
+          // A pong is direct proof the bridge is alive — refresh the liveness
+          // baseline so the 120s staleness check above cannot false-positive
+          // when the bridge isn't sending its own 'ping' frames (which the
+          // extension socket never receives when it's absent from the server
+          // ping set). Mirrors the sleep/wake probe handler. (P0-3)
+          this.lastBridgePong = Date.now();
           const sentAt = Number.parseInt(data?.toString() ?? "", 10);
           const rtt = !Number.isNaN(sentAt)
             ? Date.now() - sentAt


### PR DESCRIPTION
## What

Fixes the VS Code extension force-reconnecting a healthy idle bridge connection roughly every 120s (observed as WebSocket close code `1006`).

## Root cause

The heartbeat refreshed `lastBridgePong` only from **bridge-originated `'ping'` frames** and the sleep/wake probe. The regular 45s **RTT pong** handler set `lastRttMs` but **not** `lastBridgePong`. When the bridge sends no pings of its own — which is the case when the extension socket isn't in the server-side ping set — a healthy idle connection's `lastBridgePong` stagnates and the 120s staleness check (`connection.ts`) force-reconnects, even though the extension's own RTT ping is getting pongs back (direct proof the bridge is alive).

## Fix

Refresh `lastBridgePong = Date.now()` inside the RTT pong handler — a received pong *is* proof of liveness. This makes the extension's own 45s ping→pong a sufficient keepalive, independent of bridge-originated pings. Mirrors the existing sleep/wake probe handler.

## Tests

- New regression test in `connection-fixes.test.ts`: a healthy idle connection kept alive **only** by RTT pongs (no bridge `'ping'` frames) across 3 ticks (~135s). **Failed before** (`handleDisconnect` fired at tick 3), **passes after**.
- Full extension suite green: **595 tests**. Bridge unaffected.

## Notes

- Bumps extension `1.4.22 → 1.4.23` (Windsurf caches `.vsix` by version).
- Complementary server-side fix (add the extension socket to the bridge ping set) is a belt-and-suspenders follow-up; this extension-side change alone resolves the churn.
- From the changelog-driven audit (item **P0-3**), `docs/audit-bridge-changelog-2026-06-25.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
