### PR TITLE
docs: fix accuracy drift surfaced by documentation review

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Claude IDE Bridge — Architecture
 
-Version 0.2.0-beta.9 · Node.js ≥ 22 · TypeScript
+Version 0.2.0-beta.13 · Node.js ≥ 20 · TypeScript
 
 ---
 
@@ -132,19 +132,18 @@ A dedicated WebSocket connection (separate from the Claude Code connection) runs
 
 ## Automation Engine
 
-`AutomationHooks` (`src/automation.ts`) implements 18 hooks defined in the `AutomationPolicy` interface:
+`AutomationHooks` (`src/automation.ts`) implements the hooks defined in the `AutomationPolicy` interface. The author-facing surface uses unified, discriminated hooks (v2.43.0+); the parser expands them into internal slots:
 
 | Hook | Trigger |
 |---|---|
-| `onDiagnosticsError` | New error/warning diagnostics appear for a file |
-| `onDiagnosticsCleared` | Errors/warnings drop to zero for a file |
+| `onDiagnosticsStateChange` | New error/warning diagnostics (`state: "error"`) or errors clear (`state: "cleared"`) for a file |
 | `onFileSave` | Matching file saved (minimatch glob) |
 | `onFileChanged` | Matching file buffer changed (CC 2.1.83+) |
+| `onRecipeSave` | Any `.yaml`/`.yml` file saved |
 | `onCwdChanged` | Claude Code working directory changes (CC 2.1.83+) |
-| `onPostCompact` | Claude Code compacts context (CC 2.1.76+) |
+| `onCompaction` | Claude Code compacts context — `phase: "pre"` / `"post"` (CC 2.1.76+) |
 | `onInstructionsLoaded` | Claude Code session starts (CC 2.1.76+) |
-| `onTestRun` | `runTests` tool completes |
-| `onTestPassAfterFailure` | Test runner transitions fail → pass |
+| `onTestRun` | `runTests` tool completes — `filter: "any"｜"failure"｜"pass-after-fail"` |
 | `onGitCommit` | `gitCommit` tool succeeds |
 | `onGitPush` | `gitPush` tool succeeds |
 | `onGitPull` | `gitPull` tool succeeds |
@@ -153,7 +152,9 @@ A dedicated WebSocket connection (separate from the Claude Code connection) runs
 | `onTaskCreated` | Claude Code TaskCreated hook (CC 2.1.84+) |
 | `onTaskSuccess` | Orchestrator task completes with status `done` |
 | `onPermissionDenied` | Claude Code PermissionDenied hook (CC 2.1.89+) |
-| `onDebugSessionEnd` | VS Code debug session terminates |
+| `onDebugSession` | VS Code debug session — `phase: "start"` / `"end"` |
+
+The pre-v2.43.0 split names (`onDiagnosticsError`/`onDiagnosticsCleared`, `onPreCompact`/`onPostCompact`, `onTestPassAfterFailure`, `onDebugSessionStart`/`onDebugSessionEnd`) are still accepted but emit a deprecation warning.
 
 **Event flow**: lifecycle event fires (tool call completes or `/notify` POST received) → `handle*()` method checks policy enabled + per-file/event cooldown (min 5s) + loop guard (prevents re-entrant triggers) → `_evaluateWhen()` checks `AutomationCondition` (minDiagnosticCount, diagnosticsMinSeverity, testRunnerLastStatus) → `_enqueueAutomationTask()` → `SubprocessDriver` spawns `claude --verbose` subprocess with the resolved prompt. Rolling 60-minute rate limit window caps tasks per hour (default 20). Requires `--driver subprocess`.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,8 +46,7 @@ npm test
 | Area | Files | Good first issue? |
 |---|---|---|
 | Model adapters | `src/adapters/*.ts` | Yes — OpenAI, local/Ollama |
-| Starter recipes | `recipes/*.yaml` | Yes |
-| MCP servers (non-code) | `packages/mcp-*/` | Yes — obsidian, csv, email |
+| Starter recipes | `templates/recipes/*.yaml`, `examples/recipes/` | Yes |
 | Dashboard components | `dashboard/src/components/` | Phase-1+ |
 | Security hardening | `src/transport.ts`, risk tiers | Advanced |
 

--- a/README.bridge.md
+++ b/README.bridge.md
@@ -1,9 +1,9 @@
 # Claude IDE Bridge
 
-[![npm version](https://img.shields.io/npm/v/claude-ide-bridge)](https://www.npmjs.com/package/claude-ide-bridge)
-[![CI](https://github.com/Oolab-labs/claude-ide-bridge/actions/workflows/ci.yml/badge.svg)](https://github.com/Oolab-labs/claude-ide-bridge/actions/workflows/ci.yml)
-[![Docker](https://img.shields.io/badge/docker-ghcr.io%2FOolab--labs%2Fclaude--ide--bridge-blue)](https://github.com/Oolab-labs/claude-ide-bridge/pkgs/container/claude-ide-bridge)
-[![License: MIT](https://img.shields.io/npm/l/claude-ide-bridge)](https://opensource.org/licenses/MIT)
+[![npm version](https://img.shields.io/npm/v/patchwork-os)](https://www.npmjs.com/package/patchwork-os)
+[![CI](https://github.com/Oolab-labs/patchwork-os/actions/workflows/ci.yml/badge.svg)](https://github.com/Oolab-labs/patchwork-os/actions/workflows/ci.yml)
+[![Docker](https://img.shields.io/badge/docker-ghcr.io%2FOolab--labs%2Fpatchwork--os-blue)](https://github.com/Oolab-labs/patchwork-os/pkgs/container/patchwork-os)
+[![License: MIT](https://img.shields.io/npm/l/patchwork-os)](https://opensource.org/licenses/MIT)
 
 **MCP bridge giving Claude Code IDE superpowers — 170+ tools for LSP, debugging, git, GitHub, terminals, and more (see [platform-docs](documents/platform-docs.md) for the full list).**
 
@@ -21,7 +21,7 @@ https://github.com/user-attachments/assets/a81a8d11-2cc3-46f3-88ad-6a905a221a2c
 
 ## Quick Start
 
-**Prerequisites:** [Claude Code CLI](https://claude.ai/code), Node.js ≥ 22
+**Prerequisites:** [Claude Code CLI](https://claude.ai/code), Node.js ≥ 20
 
 ```bash
 # 1. Install the bridge
@@ -182,8 +182,8 @@ The sidebar's quick-task buttons also work from the CLI — same context-gatheri
 
 ```bash
 # 7 presets: fixErrors · refactorFile · addTests · explainCode · optimizePerf · runTests · resumeLastCancelled
-claude-ide-bridge quick-task fix-errors
-claude-ide-bridge quick-task add-tests --json
+claude-ide-bridge quick-task fixErrors
+claude-ide-bridge quick-task addTests --json
 
 # free-form description (Claude gathers its own context)
 claude-ide-bridge start-task "Refactor the auth module for clarity, keep behaviour identical"
@@ -204,7 +204,8 @@ Event-driven hooks that trigger Claude tasks automatically — no polling, no ma
 {
   "hooks": [
     {
-      "event": "onDiagnosticsError",
+      "event": "onDiagnosticsStateChange",
+      "state": "error",
       "prompt": "Fix the type error in {{file}}: {{diagnostics}}",
       "cooldownMs": 30000
     },
@@ -226,7 +227,7 @@ Start with:
 claude-ide-bridge --watch --automation --automation-policy ./policy.json --driver subprocess
 ```
 
-**18 hook events:** `onFileSave`, `onFileChanged`, `onDiagnosticsError`, `onDiagnosticsCleared`, `onGitCommit`, `onGitPush`, `onGitPull`, `onBranchCheckout`, `onPullRequest`, `onTestRun`, `onTestPassAfterFailure`, `onPostCompact`, `onInstructionsLoaded`, `onTaskCreated`, `onTaskSuccess`, `onPermissionDenied`, `onCwdChanged`, `onDebugSessionEnd`
+**Hook events:** `onFileSave`, `onFileChanged`, `onRecipeSave`, `onDiagnosticsStateChange` (`state: "error"|"cleared"`), `onGitCommit`, `onGitPush`, `onGitPull`, `onBranchCheckout`, `onPullRequest`, `onTestRun` (`filter: "any"|"failure"|"pass-after-fail"`), `onCompaction` (`phase: "pre"|"post"`), `onInstructionsLoaded`, `onTaskCreated`, `onTaskSuccess`, `onPermissionDenied`, `onCwdChanged`, `onDebugSession` (`phase: "start"|"end"`). The pre-v2.43.0 split names (`onDiagnosticsError`/`onDiagnosticsCleared`, `onPreCompact`/`onPostCompact`, `onTestPassAfterFailure`, `onDebugSessionStart`/`onDebugSessionEnd`) are still accepted but deprecated.
 
 All hooks support `cooldownMs` (min 5s), `promptName`/`promptArgs` for named prompts, and `when` conditions (`minDiagnosticCount`, `testRunnerLastStatus`). See [docs/automation.md](docs/automation.md).
 
@@ -259,12 +260,11 @@ See [documents/plugin-authoring.md](documents/plugin-authoring.md) for the full 
 Install curated companion MCP servers directly into your Claude Desktop config:
 
 ```bash
-claude-ide-bridge marketplace list
-claude-ide-bridge marketplace search memory
-claude-ide-bridge install claude-mem
+claude-ide-bridge install memory
+claude-ide-bridge install superpowers --target desktop
 ```
 
-`install` merges the companion into `mcpServers` in your Claude Desktop config atomically and idempotently — no manual JSON editing.
+Bundled companions: `memory`, `superpowers`, `devtools`, `database`, `slack`, `playwright`, `codebase-memory`. `install` merges the companion into `mcpServers` in your Claude Desktop (or Claude Code CLI) config atomically and idempotently — no manual JSON editing.
 
 ---
 
@@ -279,8 +279,7 @@ claude-ide-bridge install claude-mem
 | `claude-ide-bridge gen-claude-md --write` | Add bridge section to existing CLAUDE.md |
 | `claude-ide-bridge print-token` | Print auth token from active lock file |
 | `claude-ide-bridge gen-plugin-stub <dir>` | Scaffold a new plugin |
-| `claude-ide-bridge marketplace list` | List available companion servers |
-| `claude-ide-bridge install <companion>` | Install companion into Claude Desktop config |
+| `claude-ide-bridge install <companion>` | Install a bundled companion server into Claude Desktop / Claude Code config |
 | `claude-ide-bridge notify <Event>` | Post a hook event to a running bridge (for CC hook wiring) |
 | `claude-ide-bridge quick-task <preset>` | Launch a context-aware Claude task from a preset (headless parity with the sidebar) |
 | `claude-ide-bridge start-task "<description>"` | Enqueue a free-form Claude task with workspace context |
@@ -333,7 +332,7 @@ claude-ide-bridge install claude-mem
 
 ## Requirements
 
-- **Node.js ≥ 22** (bridge)
+- **Node.js ≥ 20** (bridge)
 - **VS Code, Cursor, or Windsurf** — optional. Headless mode covers git, terminals, GitHub, and LSP via `typescript-language-server`. Extension required for debugger, editor decorations, and live editor state.
 - **Claude Code CLI** — for local use. Remote MCP clients (claude.ai, Codex CLI) work via Streamable HTTP transport with OAuth 2.0.
 

--- a/README.md
+++ b/README.md
@@ -347,7 +347,7 @@ Start the bridge with `--issuer-url https://your-domain.com` to expose a full OA
 
 ### 🪟 Native Windows support
 
-Bridge, VS Code extension, smoke harness, and CI are all green on native Windows — no WSL required. See [Windows Quick Start](#-windows-quick-start) above.
+Bridge, VS Code extension, smoke harness, and CI are all green on native Windows — no WSL required. See [Windows](#windows) above.
 
 ### ☀️ Morning summary
 

--- a/docs/adr/0001-dual-version-numbers.md
+++ b/docs/adr/0001-dual-version-numbers.md
@@ -32,7 +32,7 @@ The MCP `initialize` response uses `BRIDGE_PROTOCOL_VERSION` for the handshake. 
 
 **Negative:**
 - Contributors must remember that bumping `package.json` does NOT bump the protocol version.
-- When a wire-format change IS needed, both `BRIDGE_PROTOCOL_VERSION` and the extension's `BRIDGE_VERSION` constant must be updated in lockstep.
+- When a wire-format change IS needed, both `BRIDGE_PROTOCOL_VERSION` and the extension's `EXTENSION_PROTOCOL_VERSION` constant must be updated in lockstep. (The extension's `BRIDGE_VERSION` is the npm package version injected at build time, not the wire-protocol constant.)
 
 **How to decide which to bump:**
 - Changed tool schema, added/removed JSON-RPC method, changed message envelope → bump `BRIDGE_PROTOCOL_VERSION`.

--- a/docs/adr/0005-http-session-eviction.md
+++ b/docs/adr/0005-http-session-eviction.md
@@ -25,8 +25,8 @@ Rules:
 2. If it has been idle for more than 60 seconds, evict it (close its transport, remove from pool) and create the new session in its place.
 3. If ALL sessions have been active within the last 60 seconds (genuinely concurrent use), return 503. This preserves the fairness guarantee — truly active sessions are never evicted.
 
-Additionally, reduce TTL and prune frequency:
-- `SESSION_TTL_MS`: 30 min → **10 min** (faster reclamation of legitimately abandoned sessions)
+Additionally, tighten TTL and prune frequency:
+- `SESSION_TTL_MS`: 24 h → **2 h** (faster reclamation of legitimately abandoned sessions; also limits the captured-session-ID reuse window)
 - Prune interval: 5 min → **2 min** (check more often)
 
 ## Consequences
@@ -34,7 +34,7 @@ Additionally, reduce TTL and prune frequency:
 **Positive:**
 - New connections succeed immediately when ghost sessions are present (the common case).
 - No user intervention needed after client crashes or network drops.
-- 10-min TTL reclaims abandoned sessions 3x faster than before.
+- 2-hour TTL reclaims abandoned sessions far faster than the previous 24-hour window.
 
 **Negative:**
 - A session that has been idle for 61 seconds can be evicted even if the client intends to resume. Mitigated by: (a) Claude Desktop and claude.ai both send periodic requests that keep `lastActivity` fresh, and (b) clients must handle 404 "session not found" gracefully and re-initialize anyway.

--- a/docs/adr/0007-multi-bridge-jsonl-concurrency.md
+++ b/docs/adr/0007-multi-bridge-jsonl-concurrency.md
@@ -1,6 +1,6 @@
 # ADR-0007: Multi-Bridge JSONL Concurrency
 
-**Status:** Proposed
+**Status:** Accepted
 **Date:** 2026-04-18
 
 ## Context
@@ -73,9 +73,9 @@ Advisory lock (`proper-lockfile` or `flock`) around every append; reload the who
 **Adopt Option A (tail-on-read).** Keep `seq` as a per-process integer — no composite-id schema change. Add an advisory lock around each append so tearing isn't a correctness concern.
 
 1. **Tail-on-read:** each log tracks `lastReadOffset: number` (file byte offset). `query()` first calls `statSync(file)`; if `size > lastReadOffset`, reads `[lastReadOffset, size)`, parses new rows, merges into the in-memory ring (respecting `memoryCap`), advances `lastReadOffset` and `this.seq`. Reuses the existing parse/validate block from `loadExisting` — factor into `parseLine()`.
-2. **`seq` stays per-process, non-unique across writers.** A codebase audit ([docs/adr-0007-research.md] — see PR thread) confirms no consumer requires uniqueness: seq is used only as a pagination cursor and sort key. Pagination cursor becomes a `(createdAt, seq)` tuple so ties are broken deterministically. React keys in the dashboard already use `taskId` / `(ts, key)` tuples, not seq. No schema change on the wire; the `after` query param gains a companion `afterTs`.
+2. **`seq` stays per-process, non-unique across writers.** A codebase audit (see the PR thread for #584) confirms no consumer requires uniqueness: seq is used only as a pagination cursor and sort key. Pagination cursor becomes a `(createdAt, seq)` tuple so ties are broken deterministically. React keys in the dashboard already use `taskId` / `(ts, key)` tuples, not seq. No schema change on the wire; the `after` query param gains a companion `afterTs`.
 3. **Sort order:** `ORDER BY createdAt DESC, seq DESC`. Both in-memory (`sort`) and in the dashboard.
-4. **Append atomicity:** POSIX does **not** guarantee non-interleaved concurrent appends to regular files. Linux ext4/xfs holds the inode mutex for sub-page writes in practice (not a contract). macOS APFS has been empirically shown to tear at ~256 bytes — well below our typical row size. Therefore: wrap each append in `proper-lockfile` (or `fs.flockSync` via a native binding) around a short critical section: `open(O_APPEND) → flock(LOCK_EX) → write → flock(LOCK_UN) → close`. Lock contention at our write volume (≤ tens/min) is negligible. Readers remain lock-free — torn rows would fail `JSON.parse` and be skipped, but locking eliminates that failure mode entirely.
+4. **Append atomicity:** POSIX does **not** guarantee non-interleaved concurrent appends to regular files. Linux ext4/xfs holds the inode mutex for sub-page writes in practice (not a contract). macOS APFS has been empirically shown to tear at ~256 bytes — well below our typical row size. Therefore: wrap each append in an advisory cross-process lock around a short critical section: `open(O_APPEND) → lock → write → unlock → close`. (As shipped this is the custom `withFileLockSync` helper in `src/fileLockSync.ts`, #584 — not the `proper-lockfile` package.) Lock contention at our write volume (≤ tens/min) is negligible. Readers remain lock-free — torn rows would fail `JSON.parse` and be skipped, but locking eliminates that failure mode entirely.
 5. **Memory ring unchanged:** still bounded by `memoryCap`. Tail reads evict oldest entries as needed.
 
 The tail-on-read cost is one `statSync` per query plus occasional small reads. For the query volume we see (dashboard polls, session-start digest), this is well under 1ms amortized.
@@ -105,4 +105,5 @@ Migrating later is strictly cheaper than migrating now: rows to convert grow lin
 
 - Unit test harness for the two-writer case (`src/__tests__/multiWriter.test.ts` — spawn two `DecisionTraceLog` instances on the same dir, interleave writes and queries).
 - Dashboard: audit any code path that compares traces by numeric `seq` (sort, pagination cursors). The composite id must round-trip through the HTTP API.
-- Delete this ADR's "Proposed" tag once the PR lands.
+
+*Shipped in #584 (`src/decisionTraceLog.ts`, `src/commitIssueLinkLog.ts` — tail-on-read + `withFileLockSync`).*

--- a/docs/multi-ide.md
+++ b/docs/multi-ide.md
@@ -75,7 +75,7 @@ No extension available. Run bridge in headless mode. LSP fallback tools work if 
 
 ## Port Management
 
-Default port: 18765. To run multiple bridge instances (e.g. one per project):
+Default port: a random free port (pin one with `--port N`). To run multiple bridge instances (e.g. one per project):
 
 ```bash
 claude-ide-bridge --port 18766 --workspace /path/to/project2

--- a/docs/plans/dogfood-findings-2026-04-29.md
+++ b/docs/plans/dogfood-findings-2026-04-29.md
@@ -1,6 +1,6 @@
 # Dogfood Findings — 2026-04-29
 
-> **Amendment (post-review):** CRIT-A and HIGH-A below are **false alarms** caused by my testing methodology. I navigated to `/inbox` etc. by typing URLs directly into the address bar; that bypasses Next.js's `basePath` rewriting (configured at `dashboard/next.config.js:2`). When the same routes are reached via the sidebar `<Link>` component, Next.js auto-prepends `/dashboard/` and they resolve correctly. Verified: clicking the Inbox sidebar link goes to `/dashboard/inbox` and renders 12 messages. **The sidebar nav works.** The fix plan at [plans/dashboard-fix-plan.md](plans/dashboard-fix-plan.md) v2 has the corrections. Other findings below stand.
+> **Amendment (post-review):** CRIT-A and HIGH-A below are **false alarms** caused by my testing methodology. I navigated to `/inbox` etc. by typing URLs directly into the address bar; that bypasses Next.js's `basePath` rewriting (configured at `dashboard/next.config.js:2`). When the same routes are reached via the sidebar `<Link>` component, Next.js auto-prepends `/dashboard/` and they resolve correctly. Verified: clicking the Inbox sidebar link goes to `/dashboard/inbox` and renders 12 messages. **The sidebar nav works.** The fix plan at [plans/dashboard-fix-plan.md](./dashboard-fix-plan.md) v2 has the corrections. Other findings below stand.
 
 **Method:** Parallel agents — Playwright walked every dashboard page; a CLI dogfood agent ran the recipe install/enable/disable/run/uninstall lifecycle against the running bridge (port 3101).
 
@@ -147,4 +147,4 @@ PRs 1–3 are 5-minute fixes that would substantially de-broken the user's first
 
 ## Notes for the visual-debugger plan
 
-The [docs/plans/visual-recipe-debugger.md](plans/visual-recipe-debugger.md) plan assumed `/dashboard/runs/<seq>` was a working baseline. **It's not** — the page 404s for every seq right now. Phase 0 of that plan should be "fix run-detail data path" before any debugger feature work begins. Likely the same `findInstallDirByRecipeName`/`iterateInstallDirs` work from PR #49 needs to apply to the run-detail lookup, or the run-log query is mis-keyed.
+The [docs/plans/visual-recipe-debugger.md](./visual-recipe-debugger.md) plan assumed `/dashboard/runs/<seq>` was a working baseline. **It's not** — the page 404s for every seq right now. Phase 0 of that plan should be "fix run-detail data path" before any debugger feature work begins. Likely the same `findInstallDirByRecipeName`/`iterateInstallDirs` work from PR #49 needs to apply to the run-detail lookup, or the run-log query is mis-keyed.

--- a/docs/plans/recipe-authoring-wave2-plan-review.md
+++ b/docs/plans/recipe-authoring-wave2-plan-review.md
@@ -1,6 +1,6 @@
 # Wave 2 + Ecosystem Plan — Multi-Agent Review
 
-Review of [`recipe-authoring-wave2-plan.md`](./recipe-authoring-wave2-plan.md) from five angles. Findings ranked by severity: **C** critical (blocks ship), **H** high (must address pre-commit), **M** medium (revisit before GA), **L** low (worth noting).
+Review of [`recipe-authoring-wave2-plan.md`](../recipe-authoring-wave2-plan.md) from five angles. Findings ranked by severity: **C** critical (blocks ship), **H** high (must address pre-commit), **M** medium (revisit before GA), **L** low (worth noting).
 
 ---
 

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -5,7 +5,7 @@ Steps to complete before tagging a new version.
 ## Code
 
 - [ ] `npm run build` passes (bridge)
-- [ ] `npm test` passes — all tests green on Node 22
+- [ ] `npm test` passes — all tests green on Node 20 and 22 (CI matrix)
 - [ ] `npm run typecheck` passes — zero type errors
 - [ ] `npx biome check .` passes — zero lint errors
 - [ ] `cd vscode-extension && npm run build && npm test` passes
@@ -29,8 +29,8 @@ grep -rn "\b[0-9]\+ tools\b\|\b[0-9]\+ hook\|\b[0-9]\+ skill\|\b[0-9]\+ test\|\b
 
 Verify each number found against actual code:
 
-- [ ] Slim tool count (`SLIM_TOOL_NAMES.size`) — currently **50**
-- [ ] Full mode tool count — currently **136+**
+- [ ] Slim tool count (`SLIM_TOOL_NAMES.size`) — currently **61**
+- [ ] Full mode tool count (`node scripts/audit-lsp-tools.mjs` Stats line) — currently **177**
 - [ ] Hook event count (keys in `claude-ide-bridge-plugin/hooks/hooks.json`) — currently **16**
 - [ ] Plugin skill count (entries in `claude-ide-bridge-plugin/skills/`) — currently **9**
 - [ ] Plugin subagent count (entries in `claude-ide-bridge-plugin/agents/`) — currently **3**

--- a/docs/self-healing-quickstart.md
+++ b/docs/self-healing-quickstart.md
@@ -21,7 +21,7 @@ npm install -g patchwork-os
 Verify:
 
 ```bash
-claude-ide-bridge --version   # → 2.42.1 or newer
+claude-ide-bridge --version   # → 0.2.0-beta.9 or newer
 ```
 
 ## 2. Install the companion extension
@@ -93,6 +93,6 @@ You saved a file. Claude noticed. Nobody typed a prompt.
 
 ## Why this works
 
-The bridge is an MCP server *and* an event source. Your IDE's language server reports errors to the extension, the extension forwards them to the bridge, the bridge's policy engine decides which events trigger Claude subprocesses, and those subprocesses get the bridge's full tool surface (141 tools including LSP, git, shell, debugger).
+The bridge is an MCP server *and* an event source. Your IDE's language server reports errors to the extension, the extension forwards them to the bridge, the bridge's policy engine decides which events trigger Claude subprocesses, and those subprocesses get the bridge's full tool surface (177 tools including LSP, git, shell, debugger).
 
 Most Claude integrations need a prompt. This one watches the editor and shows up on its own.

--- a/docs/ssh-resilience.md
+++ b/docs/ssh-resilience.md
@@ -31,7 +31,7 @@ WARNING: Not running inside tmux or screen. SSH disconnection will kill this pro
 
 ## Grace Period
 
-When Claude Code disconnects from the bridge (e.g., process restart, brief network blip), the bridge preserves the session state for a configurable grace period (default: 30 seconds). If Claude Code reconnects within that window, it reattaches seamlessly — no state is lost.
+When Claude Code disconnects from the bridge (e.g., process restart, brief network blip), the bridge preserves the session state for a configurable grace period (default: 120 seconds, via `--grace-period <ms>`). If Claude Code reconnects within that window, it reattaches seamlessly — no state is lost.
 
 For environments with longer disconnections, increase the grace period:
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,4 +1,4 @@
-# Troubleshooting — patchwork-os 0.2.0-beta.9
+# Troubleshooting — patchwork-os
 
 ---
 
@@ -27,12 +27,12 @@ Run these five checks before reading further. They catch 90% of issues.
    ```
    No lock file means the bridge hasn't started successfully or is writing to the wrong directory.
 
-5. **Is Node.js version 22 or higher?**
+5. **Is Node.js version 20 or higher?**
    ```bash
    node --version
-   # Must be v22.x or higher
+   # Must be v20.x or higher
    ```
-   Upgrade if needed: `nvm install 22 && nvm use 22`
+   Upgrade if needed: `nvm install 20 && nvm use 20`
 
 ---
 
@@ -79,7 +79,7 @@ Ask Claude to call `bridgeDoctor` for a full health check — it reports lock fi
 
 ### Fewer tools than expected
 
-**Cause:** The bridge was started with `--slim`, or `"fullMode": false` is set in the config file. Slim mode exposes only ~60 IDE-exclusive tools (LSP, debugger, editor state). Git, terminal, file ops, GitHub, and HTTP tools are hidden.
+**Cause:** The bridge was started with `--slim`, or `"fullMode": false` is set in the config file. Slim mode exposes only 61 IDE-exclusive tools (LSP, debugger, editor state). Git, terminal, file ops, GitHub, and HTTP tools are hidden.
 
 **Fix:** Drop `--slim` from your start command, or remove `"fullMode": false` from `claude-ide-bridge.config.json`:
 ```bash
@@ -343,7 +343,7 @@ If you see the delay stuck at 30s and cycling, the bridge has a persistent crash
 | Port already bound | `EADDRINUSE` in logs | Use a different port or stop the conflicting process |
 | Workspace path not found | `ENOENT: workspace` | Pass `--workspace /absolute/path` |
 | `package.json` parse error | `SyntaxError` at startup | Fix malformed `package.json` in workspace |
-| Node.js below v22 | Various failures | `nvm install 22 && nvm use 22` |
+| Node.js below v20 | Various failures | `nvm install 20 && nvm use 20` |
 
 ### Getting crash logs
 

--- a/documents/data-reference.md
+++ b/documents/data-reference.md
@@ -158,25 +158,12 @@ Resolution:
   └─ Returns JSON-RPC error -32601 if prompt name not found
 ```
 
-**Registered prompts (15):**
+**Registered prompts: 36** (9 core · 5 Dispatch · 2 agent/scheduled · 1 setup · 16 LSP-composition · 3 edit-workflow).
 
-| Name | Required Args | Optional Args | Category |
-|------|--------------|---------------|----------|
-| `review-file` | `file` | — | Core |
-| `explain-diagnostics` | `file` | — | Core |
-| `generate-tests` | `file` | — | Core |
-| `debug-context` | — | — | Core |
-| `git-review` | — | `base` (default: `main`) | Core |
-| `cowork` | — | `task` | Core |
-| `set-effort` | — | `level` (default: `medium`) | Core |
-| `gen-claude-md` | — | — | Core |
-| `project-status` | — | — | Dispatch |
-| `quick-tests` | — | `filter` | Dispatch |
-| `quick-review` | — | — | Dispatch |
-| `build-check` | — | — | Dispatch |
-| `recent-activity` | — | `count` (default: `10`) | Dispatch |
-| `team-status` | — | — | Teams |
-| `health-check` | — | — | Scheduled |
+The full per-prompt table — names, required/optional args, and categories — lives in
+**[prompts-reference.md](prompts-reference.md)**, which is the single source of truth (kept in
+sync with `src/prompts.ts`). It is not duplicated here to avoid drift. At runtime, trust the
+live `prompts/list` response over any static list.
 
 **Transport state additions:**
 - `prompts` registry (`Map<string, RegisteredPrompt>`) stored on the transport alongside `tools`

--- a/documents/headless-quickstart.md
+++ b/documents/headless-quickstart.md
@@ -17,7 +17,7 @@ At startup the bridge probes for available CLIs. Tool availability depends on wh
 | `rg` | `rg` (ripgrep) | `searchWorkspace`, `findRelatedTests` (rg path) | Alpine: `apk add ripgrep` |
 | `ctags` | `ctags --version \| grep "Universal Ctags"` | `searchWorkspaceSymbols` ctags fallback, `navigateToSymbolByName` | Alpine: `apk add ctags` |
 | `typescript-language-server` | `typescript-language-server --version` | `goToDefinition`, `findReferences`, `getTypeSignature` LSP fallback | `npm i -g typescript-language-server typescript` |
-| `gh` | `gh auth status` | `githubCreatePR`, `listPRs`, GitHub tools | Install GitHub CLI |
+| `gh` | `gh auth status` | `githubCreatePR`, `githubListPRs`, GitHub tools | Install GitHub CLI |
 | `git` | `git --version` | All git tools | Usually pre-installed |
 
 Call `getBridgeStatus` after connecting to see which probes passed and which tools are available.
@@ -65,8 +65,8 @@ Call `getBridgeStatus` after connecting to see which probes passed and which too
 | Tool | Notes |
 |------|-------|
 | `githubCreatePR` | Open pull request |
-| `listPRs` | List open PRs |
-| `getIssues` | List issues |
+| `githubListPRs` | List open PRs |
+| `githubListIssues` | List issues |
 
 ### Shell
 
@@ -253,14 +253,14 @@ Probes not found at startup emit a single `WARN probe not found: <name>` log lin
 The bridge writes a lock file at `$CLAUDE_CONFIG_DIR/ide/<port>.lock` containing the auth token:
 
 ```bash
-# Print token for the default port (18765)
+# Print token — auto-discovers the active bridge lock file (port is random by default)
 claude-ide-bridge print-token
 
-# Specify port explicitly
+# Specify port explicitly (e.g. if you pinned one with --port)
 claude-ide-bridge print-token --port 18766
 
-# Read raw JSON from lock file
-cat ~/.claude/ide/18765.lock
+# Read raw JSON from lock file (substitute the actual port)
+cat ~/.claude/ide/<port>.lock
 ```
 
 The lock file JSON structure:
@@ -344,7 +344,7 @@ bash deploy/bootstrap-new-vps.sh
 |----------|---------|---------|
 | `CLAUDE_CONFIG_DIR` | `~/.claude` | Lock file and token location |
 | `BRIDGE_BIND_ADDRESS` | `127.0.0.1` | Bind address (`0.0.0.0` for containers) |
-| `PORT` | `18765` | Listen port |
+| `CLAUDE_IDE_BRIDGE_PORT` / `PATCHWORK_BRIDGE_PORT` | _(random free port)_ | Port hint for CLI subcommands locating the bridge. To pin the bridge's own listen port, pass `--port N` (no env var; default is a random free port). |
 | `CLAUDE_IDE_BRIDGE_CORS_ORIGINS` | _(none)_ | Comma-separated CORS origins for OAuth mode |
 
 ---

--- a/documents/platform-docs.md
+++ b/documents/platform-docs.md
@@ -46,8 +46,8 @@ The bridge operates in two modes controlled at startup:
 
 | Mode | Flag | Tool count | Description |
 |------|------|-----------|-------------|
-| Full | _(default since v2.43.0)_ | ~140 | All tools including git, GitHub, terminal, file ops, HTTP, orchestration |
-| Slim | `--slim` | ~60 | IDE-exclusive tools only — LSP, debugger, editor state, bridge introspection |
+| Full | _(default since v2.43.0)_ | 177 | All tools including git, GitHub, terminal, file ops, HTTP, orchestration |
+| Slim | `--slim` | 61 | IDE-exclusive tools only — LSP, debugger, editor state, bridge introspection |
 
 **Full mode** (the default) exposes every workspace operation. Use this when Claude needs to perform git operations, run terminal commands, edit files, or interact with GitHub without falling back to shell commands.
 
@@ -719,6 +719,9 @@ Cross-session memory for agents. Every decision (approval verdict, enrichment li
 | `ctxSaveTrace(ref, problem, solution, tags?)` | Agent writes a durable trace after resolving a task. Persists to `DecisionTraceLog`. Required: `ref` (issue/PR/commit/free-text, ≤256 chars), `problem` (≤500 chars), `solution` (≤500 chars). Optional: up to 10 tags × 32 chars each. |
 | `ctxGetTaskContext(ref)` | Unified context for an issue, PR, commit, or error ref. Auto-detects ref type. Composes `gh issue view` / `gh pr view` / `git show` + `CommitIssueLinkLog` reverse lookup. Fail-soft: partial context on missing `gh` / git / log rather than throw. |
 | `ctxQueryTraces({traceType?, key?, since?, limit?})` | Unified query over all four trace stores. `traceType: "approval" \| "enrichment" \| "recipe_run" \| "decision"` (omit for all). Key substring match. Returns `{traces:[{traceType, ts, key, summary, body}], count, sources}`. |
+| `enrichCommit(sha)` | Enrich a commit with the issues it references. Parses the commit message for issue refs, resolves their state via `gh`, and persists the links to `CommitIssueLinkLog`. |
+| `getCommitsForIssue(ref)` | Reverse lookup: commits that touched a given issue, read back from `CommitIssueLinkLog`. The inverse of `enrichCommit`. |
+| `enrichStackTrace(stackTrace)` | Map each stack frame to the commit that likely introduced it (per-frame `git blame`), surfacing the top suspect commit for a failing trace. |
 
 ### Persistence
 

--- a/documents/roadmap.md
+++ b/documents/roadmap.md
@@ -108,7 +108,7 @@ All four "phantom tools" previously advertised in the MCP handshake (`ctxGetTask
 | OpenAI | Shipped (`src/drivers/openai`) | Responses API + function calling |
 | Grok (xAI) | Shipped (`src/drivers/grok`) | OpenAI-compatible endpoint |
 
-**Full design:** [`docs/plans/multi-provider-drivers.md`](../docs/plans/multi-provider-drivers.md)
+**Full design:** `docs/plans/multi-provider-drivers.md` _(planned — not yet written)_
 
 ---
 

--- a/documents/tool-schema-changelog.md
+++ b/documents/tool-schema-changelog.md
@@ -12,7 +12,7 @@ Format:
 
 ## v2.26.x baseline — 2026-04-14
 
-Initial snapshot generated from v2.26.9 (133 tools, full mode).
+Initial snapshot generated from v2.26.9 (137 tools, full mode).
 
 Notable schema history before this baseline:
 - `contextBundle`: `activeFileContent` field fixed (was never populated before v2.25.18)
@@ -22,5 +22,12 @@ Notable schema history before this baseline:
 - All tool descriptions compressed to ≤200 chars (v2.25.29–33)
 
 ---
+
+> ⚠️ **Baseline drift (known):** the committed `tool-schemas-snapshot.json` holds 137 tool
+> entries, but the live registry now exposes 177 (`node scripts/audit-lsp-tools.mjs` Stats line).
+> The snapshot has not been regenerated since the 2026-04-14 baseline, which weakens the CI
+> schema-diff gate for the ~40 tools added since. Regenerate with
+> `node scripts/audit-schema-changes.mjs --update` (requires a full `npm install && npm run build`)
+> and append the corresponding entries here.
 
 <!-- Add new entries above this line -->

--- a/examples/recipes/advanced-patterns/README.md
+++ b/examples/recipes/advanced-patterns/README.md
@@ -92,7 +92,7 @@ Two recipes in one file:
 
 ---
 
-### [`small-business-brain.yaml`](small-business-brain.yaml)
+### Small-business brain — [`business-intake-router.yaml`](business-intake-router.yaml) · [`business-decision-brief.yaml`](business-decision-brief.yaml) · [`business-quarterly-review.yaml`](business-quarterly-review.yaml)
 
 **Three interlocking recipes for solo operators.**
 
@@ -174,7 +174,7 @@ trigger:
 | `mixed-provider-pipeline` | `file-mcp`, multi-provider model support |
 | `writer-feedback-loop` | `driver`, `file-mcp`, `dashboard-mcp`, `notify-mcp` |
 | `relationship-memory` | `gmail-mcp`, `file-mcp`, `notify-mcp` |
-| `small-business-brain` | `gmail-mcp`, `file-mcp`, `notify-mcp`, `scheduler-mcp` |
+| `business-intake-router` / `business-decision-brief` / `business-quarterly-review` | `gmail-mcp`, `file-mcp`, `notify-mcp`, `scheduler-mcp` |
 
 All recipes degrade gracefully — steps that need a missing MCP skip with a
 warning rather than crashing the run.

--- a/templates/CLAUDE.bridge.md
+++ b/templates/CLAUDE.bridge.md
@@ -110,7 +110,7 @@ Workflow:
 
 **If bridge tools are missing from your tool list inside Cowork:** you're in the wrong context. Exit, run the prompt in regular chat, then return.
 
-Full details: [docs/cowork-workflow.md](docs/cowork-workflow.md)
+Full details: [docs/cowork.md](docs/cowork.md)
 
 **Cowork uses git worktrees:** Cowork sessions operate in an isolated git worktree (separate branch/working copy), not the main workspace root. Files written by Cowork land in the worktree. Always add "write all files to the workspace root, not a subdirectory" as the first instruction in your CLAUDE.md when using Cowork with a synced workspace. After Cowork finishes, review and merge the worktree branch back to main.
 


### PR DESCRIPTION
## Summary

Five parallel doc-review passes verified the documentation against the actual code and found drift concentrated in **numeric claims, stale ADRs, and broken links**. This PR fixes 21 files. The two headline claims in `CLAUDE.md` (177 tools, 36 prompts) were already correct and are unchanged; the fixes bring the rest of the docs in line with them.

## What changed

**Numeric drift → authoritative counts (61 slim / 177 full / 36 prompts)**
- `platform-docs.md` modes table (`~140` → 177), `release-checklist.md` (50 / 136+), `self-healing-quickstart.md` (141), `troubleshooting.md` (~60)
- `data-reference.md`: stale 15-row prompts table replaced with a redirect to `prompts-reference.md` (single source of truth, kept in sync with `src/prompts.ts`)
- `tool-schema-changelog.md`: baseline count corrected (133 → 137) + a recorded drift warning (see "Known follow-up" below)

**ADRs**
- **0005** — session TTL `10 min` → `2 h` (matches `SESSION_TTL_MS` in `streamableHttp.ts`)
- **0007** — status `Proposed` → `Accepted` (shipped in #584); removed dead `adr-0007-research.md` link; corrected `proper-lockfile` note to the shipped `withFileLockSync`
- **0001** — protocol-lockstep constant corrected to `EXTENSION_PROTOCOL_VERSION` (the `BRIDGE_VERSION` it named is the npm version)

**Stale guidance**
- Node version aligned to `>=20` (matches `engines.node`) across `troubleshooting.md`, `README.bridge.md`, `ARCHITECTURE.md`, `release-checklist.md`
- `README.bridge.md`: invalid `quick-task` presets (`fix-errors` → `fixErrors`), removed the deleted `marketplace` subcommand, repointed badges from `claude-ide-bridge` → `patchwork-os`, modernized the hook list to the v2.43.0 unified hooks
- `ARCHITECTURE.md`: automation-hook table modernized to unified hooks (`onDiagnosticsStateChange`, `onCompaction`, `onDebugSession`, `onTestRun{filter}`); version header refreshed
- Default-port phrasing corrected (random free port, not a fixed `18765`) in `headless-quickstart.md` and `multi-ide.md`; removed the unread `PORT` env var; fixed GitHub tool names (`listPRs` → `githubListPRs`, `getIssues` → `githubListIssues`)
- `ssh-resilience.md`: grace-period default `30s` → `120s`
- `CONTRIBUTING.md`: corrected recipe path, dropped non-existent `packages/mcp-*/` row

**Broken links (9)** fixed in `roadmap.md`, `advanced-patterns/README.md`, `recipe-authoring-wave2-plan-review.md`, `dogfood-findings-2026-04-29.md`, `templates/CLAUDE.bridge.md`, and a `README.md` anchor.

## Verification
- `node scripts/audit-lsp-tools.mjs` → `61 slim · 177 total registered` ✓
- `node scripts/audit-docs-wired.mjs` → docs⇒wired audit passed ✓
- All fixed link targets verified to resolve; snapshot JSON re-validated

## Known follow-up (not in this PR)
`documents/tool-schemas-snapshot.json` is stale (137 entries vs 177 registered), weakening the CI schema-diff gate. Regenerating it needs `npm install && npm run build` + `node scripts/audit-schema-changes.mjs --update`, but the review environment's network policy hard-blocks the `yaml` package tarball (403), so the install couldn't complete. The snapshot JSON was intentionally **not** hand-edited (risk of a wrong CI baseline); instead a drift warning documenting the regen steps was added to `tool-schema-changelog.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01E5S9kjG9Zz8V8dwZLHQr8H)_