### PR TITLE
fix(transport): cap HTTP tool timeout under CC 5-min abort + typed TIMEOUT code

### DIFF
--- a/src/__tests__/transport-http-timeout-ceiling.test.ts
+++ b/src/__tests__/transport-http-timeout-ceiling.test.ts
@@ -1,0 +1,203 @@
+/**
+ * audit P0-1 / P1-10 — Streamable-HTTP tool-timeout ceiling + typed timeout code.
+ *
+ * Claude Code hard-aborts remote (Streamable-HTTP) MCP tool calls after 5
+ * minutes (CC 2.1.183/2.1.187). Tools that declare a longer timeoutMs (e.g.
+ * vscodeTasks/terminal at 610s) would run past the abort and have their result
+ * silently discarded with no isError the model can act on. The HTTP transport
+ * now clamps a tool's effective timeout to `httpTimeoutCeilingMs` (~280s) so the
+ * tool rejects cleanly BEFORE CC kills the call. The WebSocket transport (local
+ * CLI, no such ceiling) keeps the tool's declared timeout.
+ *
+ * Separately (P1-10), a tool timeout now rejects with a typed
+ * ToolErrorCodes.TIMEOUT code so CC's retry path can distinguish a transient
+ * timeout from a deterministic failure.
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+import { ToolErrorCodes } from "../errors.js";
+import { Logger } from "../logger.js";
+import { McpTransport } from "../transport.js";
+
+interface McpMessage {
+  jsonrpc: "2.0";
+  id?: string | number;
+  method?: string;
+  params?: unknown;
+  result?: unknown;
+  error?: unknown;
+}
+
+class MockWs {
+  readyState = 1; // OPEN
+  sent: string[] = [];
+  handlers: Record<string, (arg: unknown) => void> = {};
+  on(event: string, fn: (arg: unknown) => void) {
+    this.handlers[event] = fn;
+    return this;
+  }
+  off(event: string, _fn: unknown) {
+    delete this.handlers[event];
+    return this;
+  }
+  removeListener(event: string, _fn: unknown) {
+    delete this.handlers[event];
+    return this;
+  }
+  send(data: string, cb?: (err?: Error) => void) {
+    this.sent.push(data);
+    if (cb) cb();
+  }
+  close() {
+    this.readyState = 3;
+  }
+  ping() {}
+  pong() {}
+  addEventListener(event: string, fn: (arg: unknown) => void) {
+    this.on(event, fn);
+  }
+  terminate() {
+    this.close();
+  }
+}
+
+const NEVER_RESOLVES = async () => {
+  await new Promise<never>(() => {}); // handler hangs → the timeout must fire
+  return { content: [{ type: "text", text: "unreachable" }] };
+};
+
+function setup(
+  opts: { timeoutMs?: number; ceiling?: number | null; hang?: boolean } = {},
+) {
+  const transport = new McpTransport(new Logger(false));
+  if (opts.ceiling !== undefined) transport.httpTimeoutCeilingMs = opts.ceiling;
+
+  transport.registerTool(
+    {
+      name: "slowTool",
+      description: "fake long-running tool",
+      inputSchema: { type: "object", properties: {} },
+    },
+    opts.hang
+      ? NEVER_RESOLVES
+      : async () => ({ content: [{ type: "text", text: "done" }] }),
+    opts.timeoutMs,
+  );
+
+  const ws = new MockWs();
+  transport.attach(ws as unknown as import("ws").WebSocket);
+
+  const send = (msg: McpMessage) => {
+    ws.handlers.message?.(Buffer.from(JSON.stringify(msg)));
+  };
+
+  send({
+    jsonrpc: "2.0",
+    id: 0,
+    method: "initialize",
+    params: {
+      protocolVersion: "2025-11-25",
+      capabilities: {},
+      clientInfo: { name: "test", version: "0" },
+    },
+  });
+  send({ jsonrpc: "2.0", method: "notifications/initialized" });
+
+  return { transport, ws, send };
+}
+
+async function waitForReply(ws: MockWs, id: string | number) {
+  const deadline = Date.now() + 3000;
+  while (Date.now() < deadline) {
+    for (const raw of ws.sent) {
+      try {
+        const parsed = JSON.parse(raw) as McpMessage;
+        if (parsed.id === id) return parsed;
+      } catch {
+        // ignore non-JSON frames
+      }
+    }
+    await new Promise((r) => setTimeout(r, 5));
+  }
+  throw new Error(`timed out waiting for reply id=${id}`);
+}
+
+function parsePayload(reply: McpMessage) {
+  const result = reply.result as {
+    isError?: boolean;
+    content: Array<{ type: string; text: string }>;
+  };
+  const first = result.content[0];
+  if (!first) throw new Error("tool reply had no content");
+  return {
+    isError: result.isError,
+    payload: JSON.parse(first.text) as {
+      error: string;
+      code?: string;
+    },
+  };
+}
+
+const transports: McpTransport[] = [];
+afterEach(() => {
+  transports.length = 0;
+});
+
+describe("getToolTimeout — httpTimeoutCeilingMs clamp (P0-1)", () => {
+  it("returns the declared timeout when no ceiling is set (WebSocket transport)", () => {
+    const { transport } = setup({ timeoutMs: 600_000 });
+    expect(transport.getToolTimeout("slowTool")).toBe(600_000);
+  });
+
+  it("clamps a long declared timeout down to the ceiling when set (HTTP transport)", () => {
+    const { transport } = setup({ timeoutMs: 600_000, ceiling: 280_000 });
+    expect(transport.getToolTimeout("slowTool")).toBe(280_000);
+  });
+
+  it("leaves a declared timeout below the ceiling unchanged", () => {
+    const { transport } = setup({ timeoutMs: 30_000, ceiling: 280_000 });
+    expect(transport.getToolTimeout("slowTool")).toBe(30_000);
+  });
+
+  it("falls back to the default tool timeout (60s) for unknown tools", () => {
+    const { transport } = setup({});
+    expect(transport.getToolTimeout("nope")).toBe(60_000);
+  });
+});
+
+describe("tool timeout — ceiling enforced on execution + typed code (P0-1 / P1-10)", () => {
+  it("rejects a hung tool at the ceiling, not its larger declared timeout", async () => {
+    // declared 5_000ms, ceiling 80ms → must reject at the 80ms ceiling.
+    const ctx = setup({ timeoutMs: 5_000, ceiling: 80, hang: true });
+    transports.push(ctx.transport);
+    ctx.send({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "tools/call",
+      params: { name: "slowTool", arguments: {} },
+    });
+    const reply = await waitForReply(ctx.ws, 1);
+    expect(reply.error).toBeUndefined();
+    const { isError, payload } = parsePayload(reply);
+    expect(isError).toBe(true);
+    // Capped value (80), not the declared 5000 — proves the cap hit execution.
+    expect(payload.error).toContain("timed out after 80ms");
+    expect(payload.code).toBe(ToolErrorCodes.TIMEOUT);
+  });
+
+  it("tags an uncapped tool timeout with ToolErrorCodes.TIMEOUT (P1-10)", async () => {
+    const ctx = setup({ timeoutMs: 60, hang: true }); // no ceiling
+    transports.push(ctx.transport);
+    ctx.send({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "tools/call",
+      params: { name: "slowTool", arguments: {} },
+    });
+    const reply = await waitForReply(ctx.ws, 1);
+    const { isError, payload } = parsePayload(reply);
+    expect(isError).toBe(true);
+    expect(payload.error).toContain("timed out after 60ms");
+    expect(payload.code).toBe(ToolErrorCodes.TIMEOUT);
+  });
+});

--- a/src/streamableHttp.ts
+++ b/src/streamableHttp.ts
@@ -40,6 +40,13 @@ const MAX_PENDING_SENDS = 100; // per-session response queue cap
 // Buffer added over a tool's own timeout when sizing the HTTP response wait, so
 // the wait always outlives the tool (audit 2026-06-08 transport-1).
 const HTTP_SEND_TIMEOUT_BUFFER_MS = 10_000;
+// Upper bound on a tool's effective execution timeout over Streamable HTTP.
+// Claude Code hard-aborts remote MCP tool calls at 5 min (CC 2.1.183/2.1.187),
+// so we reject ~20s earlier with a clean TOOL_TIMEOUT isError the model can act
+// on, rather than letting a 610s tool run to a silently-discarded result. The
+// HTTP response wait is sized at this + HTTP_SEND_TIMEOUT_BUFFER_MS = 290s,
+// still under CC's 300s abort. (audit P0-1)
+const HTTP_TOOL_TIMEOUT_CEILING_MS = 280_000;
 const SSE_HEARTBEAT_MS = 20_000; // keep SSE streams alive through proxies/firewalls
 const SSE_BUFFER_MAX = 100; // max events retained per session for Last-Event-ID replay
 const SSE_BUFFER_TTL_MS = 30_000; // events older than 30s are not replayed
@@ -825,6 +832,7 @@ export class StreamableHttpHandler {
       }, // refresh on SSE writes
     );
     const transport = new McpTransport(this.logger);
+    transport.httpTimeoutCeilingMs = HTTP_TOOL_TIMEOUT_CEILING_MS;
     transport.workspace = this.config.workspace;
     transport.sessionId = id;
     transport.onActivity = () => {

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -1,7 +1,7 @@
 import { WebSocket } from "ws";
 import type { ActivityLog } from "./activityLog.js";
 import { createAjv2020, type ValidateFunction } from "./ajv2020.js";
-import { ErrorCodes } from "./errors.js";
+import { ErrorCodes, ToolErrorCodes } from "./errors.js";
 import type { Logger } from "./logger.js";
 import { withSpan } from "./telemetry.js";
 import { BRIDGE_PROTOCOL_VERSION, PACKAGE_VERSION } from "./version.js";
@@ -171,6 +171,15 @@ export class McpTransport {
   private wireSchemaCacheSizeBytes: number | null = null;
   /** When true, tools/list omits inputSchema. Clients must call tools/schema before tools/call. */
   private lazyTools = false;
+
+  /**
+   * Optional upper bound (ms) on a tool's effective execution timeout. Set by
+   * the Streamable-HTTP transport (~280s) so a long-declared tool rejects with
+   * a clean TOOL_TIMEOUT isError BEFORE Claude Code's 5-minute remote-MCP
+   * hard-abort (CC 2.1.183/2.1.187) silently discards the result. null = no cap
+   * (the WebSocket transport, where the local CLI has no such ceiling). (P0-1)
+   */
+  public httpTimeoutCeilingMs: number | null = null;
   /** Per-session tool-call rate limit (calls/minute). 0 = disabled. */
   private toolRateLimit = 60;
   /**
@@ -463,7 +472,18 @@ export class McpTransport {
    * timeout fires (audit 2026-06-08 transport-1). Unknown tools get the default.
    */
   getToolTimeout(name: string): number {
-    return this.tools.get(name)?.timeoutMs ?? TOOL_TIMEOUT_MS;
+    return this.capTimeout(this.tools.get(name)?.timeoutMs ?? TOOL_TIMEOUT_MS);
+  }
+
+  /**
+   * Clamp a tool timeout to `httpTimeoutCeilingMs` when set (Streamable-HTTP
+   * transport). No-op on the WebSocket transport, where the ceiling is null.
+   * (audit P0-1)
+   */
+  private capTimeout(ms: number): number {
+    return this.httpTimeoutCeilingMs !== null
+      ? Math.min(ms, this.httpTimeoutCeilingMs)
+      : ms;
   }
 
   /** Upsert a tool by name — replaces if already registered, inserts if new. */
@@ -1520,16 +1540,20 @@ export class McpTransport {
                 // the time the human spent thinking about the approval.
                 startTime = Date.now();
                 try {
-                  const effectiveTimeout = tool.timeoutMs ?? TOOL_TIMEOUT_MS;
+                  const effectiveTimeout = this.capTimeout(
+                    tool.timeoutMs ?? TOOL_TIMEOUT_MS,
+                  );
                   const timeoutPromise = new Promise<never>((_, reject) => {
                     timeoutHandle = setTimeout(() => {
                       timedOut = true;
                       controller.abort();
-                      reject(
-                        new Error(
-                          `Tool "${params.name}" timed out after ${effectiveTimeout}ms`,
-                        ),
-                      );
+                      // Typed code so Claude Code's retry path can tell a
+                      // transient timeout from a deterministic failure. (P1-10)
+                      const timeoutErr = new Error(
+                        `Tool "${params.name}" timed out after ${effectiveTimeout}ms`,
+                      ) as Error & { code: string };
+                      timeoutErr.code = ToolErrorCodes.TIMEOUT;
+                      reject(timeoutErr);
                     }, effectiveTimeout);
                   });
 


### PR DESCRIPTION
## What

Caps a tool's effective execution timeout on the **Streamable-HTTP** (remote MCP) transport, and tags tool timeouts with a typed error code. From the changelog-driven audit, items **P0-1** and **P1-10** (`docs/audit-bridge-changelog-2026-06-25.md`).

## Why

Claude Code hard-aborts remote MCP tool calls after 5 minutes (CC 2.1.183/2.1.187). Several bridge tools declare a much longer `timeoutMs` — `vscodeTasks`/`terminal` at 610s, `runTests`/`runCommand` at 300s. Over HTTP they ran past CC's abort and had their result **silently discarded** with no `isError` the model could act on (the bridge's zombie-tool tracking only logs). The HTTP response wait was even sized *above* the tool timeout (`streamableHttp.ts:644`), so nothing capped it.

## Changes

**P0-1** — `McpTransport` gains `httpTimeoutCeilingMs`, applied via a `capTimeout()` helper in both `getToolTimeout()` and the execution path (`effectiveTimeout`). The Streamable-HTTP transport sets it to **280s** (`streamableHttp.ts`), so a long tool rejects cleanly ~20s before CC's 300s abort — the HTTP response wait becomes `280 + 10s` buffer = 290s < 300s. The **WebSocket** transport (local CLI, no such ceiling) is unchanged: ceiling stays `null`, declared timeouts preserved.

**P1-10** — the timeout rejection now carries `ToolErrorCodes.TIMEOUT` (`errors.ts`), so CC's retry path can distinguish a transient timeout from a deterministic failure. The catch already propagated `err.code` into the `isError` payload; only the throw site lacked it.

## Tests

New `transport-http-timeout-ceiling.test.ts`: clamp units (no-cap / clamped / below-cap / unknown tool) + behavioral (a hung tool with a 5s declared timeout rejects at the **80ms ceiling**) + typed-code assertions. **Failed before, pass after.** 6 new; **103** transport/HTTP regression tests green; `tsc` clean; biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
