### PR TITLE
Dashboard UX follow-ups (post-#1010): legibility + remaining audit themes

### DIFF
--- a/dashboard/src/app/activity/page.tsx
+++ b/dashboard/src/app/activity/page.tsx
@@ -538,9 +538,9 @@ export default function ActivityPage() {
           <div
             style={{
               fontFamily: "var(--font-mono)",
-              fontSize: "var(--fs-2xs)",
-              fontWeight: 500,
-              color: "var(--ink-3)",
+              fontSize: "var(--fs-xs)",
+              fontWeight: 600,
+              color: "var(--ink-2)",
               marginBottom: 10,
             }}
           >

--- a/dashboard/src/app/analytics/page.tsx
+++ b/dashboard/src/app/analytics/page.tsx
@@ -271,7 +271,7 @@ export default function AnalyticsPage() {
             style={{ padding: "14px 20px 10px", marginTop: "var(--s-4)", marginBottom: "var(--s-4)" }}
           >
             <div style={{ display: "flex", alignItems: "center", gap: "var(--s-3)", marginBottom: 8 }}>
-              <span style={{ fontFamily: "var(--font-mono)", fontSize: "var(--fs-2xs)", fontWeight: 500, color: "var(--ink-3)" }}>
+              <span style={{ fontFamily: "var(--font-mono)", fontSize: "var(--fs-xs)", fontWeight: 600, color: "var(--ink-2)" }}>
                 Calls — last 24 hours
               </span>
               <span style={{ flex: 1 }} />


### PR DESCRIPTION
Follow-up to **#1010** (the dashboard overhaul + UI/UX audit, now merged to `main`). This PR continues the audit roadmap (`docs/dashboard-ux-audit-2026-06-25.md`) against the merged base.

## In this PR so far
- **Theme 5 (legibility) — chart titles**: the chart card titles "Calls — last 24 hours" (Analytics) and "Events / minute" + the events-by-kind title (Activity) were rendered at `--fs-2xs` (10px) in `--ink-3` (the faintest ink). Bumped to `--fs-xs` (11px) / weight 600 / `--ink-2` so the headings are legible. Scoped to genuine informational titles — intentional micro-pills/badges and chart axis ticks left as-is.

## Queued (remaining audit themes, to add here or as separate PRs)
- **Theme 5 remainder** — a full sub-11px legibility floor is a design-system/token decision (≈111 `--fs-2xs` usages); deferred pending a call on whether to change the token vs continue per-element.
- **Theme 6** — ARIA-pattern sweep (lists/tabs/segmented controls/expandable cards).
- **Theme 1** — strip serif page-`h1` taglines app-wide (brand-voice decision — needs explicit sign-off).

All green: 933 dashboard tests, `tsc`, tokens/inline-fontsize/vocabulary ratchets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)