### PR TITLE
fix(approval): content-aware in-process gate — real risk signals + severity escalation

### DIFF
--- a/src/__tests__/approvalGate.content.e2e.test.ts
+++ b/src/__tests__/approvalGate.content.e2e.test.ts
@@ -1,0 +1,221 @@
+/**
+ * audit P0-2 — end-to-end wiring of the content-aware in-process gate.
+ *
+ * Mirrors approvalGate.e2e.test.ts but drives the REAL gate logic
+ * (evaluateInProcessGate, the same fn bridge.ts/streamableHttp.ts call) through
+ * McpTransport → ApprovalQueue, proving:
+ *   - a destructive command queues WITH its risk signals (was riskSignals: [])
+ *   - a sub-high tool carrying a high-severity signal is escalated to the queue
+ *   - a benign sub-high call still bypasses (handler runs)
+ */
+
+import * as path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  type ApprovalQueue,
+  getApprovalQueue,
+  resetApprovalQueueForTests,
+} from "../approvalQueue.js";
+import { Logger } from "../logger.js";
+import { evaluateInProcessGate } from "../riskSignals.js";
+import { McpTransport } from "../transport.js";
+
+const WS = path.resolve("content-gate-test-ws");
+const OUTSIDE = path.resolve(path.dirname(WS), "escapes.txt");
+const INSIDE = path.join(WS, "ok.txt");
+
+interface McpMessage {
+  jsonrpc: "2.0";
+  id?: string | number;
+  method?: string;
+  params?: unknown;
+  result?: unknown;
+  error?: unknown;
+}
+
+class MockWs {
+  readyState = 1;
+  sent: string[] = [];
+  handlers: Record<string, (arg: unknown) => void> = {};
+  on(event: string, fn: (arg: unknown) => void) {
+    this.handlers[event] = fn;
+    return this;
+  }
+  off(event: string, _fn: unknown) {
+    delete this.handlers[event];
+    return this;
+  }
+  removeListener(event: string, _fn: unknown) {
+    delete this.handlers[event];
+    return this;
+  }
+  send(data: string, cb?: (err?: Error) => void) {
+    this.sent.push(data);
+    if (cb) cb();
+  }
+  close() {
+    this.readyState = 3;
+    this.handlers.close?.({});
+  }
+  ping() {}
+  pong() {}
+  addEventListener(event: string, fn: (arg: unknown) => void) {
+    this.on(event, fn);
+  }
+  terminate() {
+    this.close();
+  }
+}
+
+function setup(): {
+  queue: ApprovalQueue;
+  ran: Record<string, boolean>;
+  send(msg: McpMessage): void;
+  nextMatching(predicate: (m: McpMessage) => boolean): Promise<McpMessage>;
+} {
+  resetApprovalQueueForTests();
+  const queue = getApprovalQueue();
+  const transport = new McpTransport(new Logger(false));
+  const ran: Record<string, boolean> = { runCommand: false, Read: false };
+
+  for (const name of ["runCommand", "Read"] as const) {
+    transport.registerTool(
+      {
+        name,
+        description: `fake ${name}`,
+        inputSchema: { type: "object", properties: {} },
+      },
+      async () => {
+        ran[name] = true;
+        return { content: [{ type: "text", text: `${name} ran` }] };
+      },
+    );
+  }
+
+  // The SAME logic bridge.ts/streamableHttp.ts run at gate "high".
+  transport.setApprovalGate(
+    async ({ toolName, params, sessionId, onPending }) => {
+      const gate = evaluateInProcessGate({
+        toolName,
+        params,
+        gate: "high",
+        workspace: WS,
+      });
+      if (gate.decision === "bypass") return "bypass";
+      const { promise, callId } = queue.request({
+        toolName,
+        params,
+        tier: gate.tier,
+        sessionId: sessionId ?? undefined,
+        riskSignals: gate.riskSignals,
+      });
+      onPending?.(callId);
+      return promise;
+    },
+  );
+
+  const ws = new MockWs();
+  transport.attach(ws as unknown as import("ws").WebSocket);
+
+  const send = (msg: McpMessage) => {
+    ws.handlers.message?.(Buffer.from(JSON.stringify(msg)));
+  };
+  const nextMatching = (predicate: (m: McpMessage) => boolean) =>
+    new Promise<McpMessage>((resolve, reject) => {
+      const deadline = Date.now() + 5000;
+      const tick = () => {
+        for (const raw of ws.sent) {
+          try {
+            const parsed = JSON.parse(raw) as McpMessage;
+            if (predicate(parsed)) return resolve(parsed);
+          } catch {
+            // skip non-JSON frame
+          }
+        }
+        if (Date.now() > deadline)
+          return reject(new Error("Timed out waiting for message"));
+        setTimeout(tick, 10);
+      };
+      tick();
+    });
+
+  send({
+    jsonrpc: "2.0",
+    id: 0,
+    method: "initialize",
+    params: {
+      protocolVersion: "2025-11-25",
+      capabilities: {},
+      clientInfo: { name: "test", version: "0" },
+    },
+  });
+  send({ jsonrpc: "2.0", method: "notifications/initialized" });
+
+  return { queue, ran, send, nextMatching };
+}
+
+async function waitForQueue(queue: ApprovalQueue) {
+  const deadline = Date.now() + 2000;
+  while (queue.size() === 0 && Date.now() < deadline) {
+    await new Promise((r) => setTimeout(r, 10));
+  }
+}
+
+afterEach(() => {
+  resetApprovalQueueForTests();
+});
+
+describe("content-aware in-process gate E2E (P0-2)", () => {
+  it("queues a destructive command WITH its high-severity risk signal", async () => {
+    const { queue, ran, send } = setup();
+    send({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "tools/call",
+      params: { name: "runCommand", arguments: { command: "rm -rf ./build" } },
+    });
+    await waitForQueue(queue);
+    const pending = queue.list();
+    expect(pending).toHaveLength(1);
+    expect(pending[0]!.riskSignals).toBeDefined();
+    expect(
+      pending[0]!.riskSignals?.some(
+        (s) => s.severity === "high" && s.label === "rm with -rf flags",
+      ),
+    ).toBe(true);
+    expect(ran.runCommand).toBe(false);
+  });
+
+  it("escalates a sub-high tool with a high-severity signal to the queue", async () => {
+    const { queue, ran, send, nextMatching } = setup();
+    // Read is 'medium' tier; a workspace-escaping path is a high signal →
+    // pre-fix this bypassed and ran immediately. Now it must queue.
+    send({
+      jsonrpc: "2.0",
+      id: 2,
+      method: "tools/call",
+      params: { name: "Read", arguments: { file_path: OUTSIDE } },
+    });
+    await waitForQueue(queue);
+    const pending = queue.list();
+    expect(pending).toHaveLength(1);
+    expect(pending[0]!.toolName).toBe("Read");
+    expect(ran.Read).toBe(false);
+    queue.approve(pending[0]!.callId);
+    await nextMatching((m) => m.id === 2);
+    expect(ran.Read).toBe(true);
+  });
+
+  it("bypasses a benign sub-high call (no high signal) — handler runs", async () => {
+    const { queue, ran, send, nextMatching } = setup();
+    send({
+      jsonrpc: "2.0",
+      id: 3,
+      method: "tools/call",
+      params: { name: "Read", arguments: { file_path: INSIDE } },
+    });
+    await nextMatching((m) => m.id === 3);
+    expect(ran.Read).toBe(true);
+    expect(queue.size()).toBe(0);
+  });
+});

--- a/src/__tests__/riskSignals.test.ts
+++ b/src/__tests__/riskSignals.test.ts
@@ -1,0 +1,159 @@
+/**
+ * audit P0-2 — content-aware in-process approval gate.
+ *
+ * The bridge's OWN MCP tools (runCommand/runInTerminal/sendTerminalCommand/…)
+ * were gated on risk TIER alone: riskSignals were hardcoded to [] and a
+ * high-severity content signal never escalated a sub-high tool. These tests
+ * pin the extracted, shared logic in src/riskSignals.ts:
+ *   - computeRiskSignals: the catalog (incl. new terraform/pulumi entries and
+ *     the sendTerminalCommand `text` param key), and benign input → no signals.
+ *   - evaluateInProcessGate: off→bypass, all→queue, high-tier→queue-with-signals,
+ *     and the escalation (sub-high tier + high-severity signal → queue).
+ */
+
+import * as path from "node:path";
+import { describe, expect, it } from "vitest";
+import { computeRiskSignals, evaluateInProcessGate } from "../riskSignals.js";
+
+const WS = path.resolve("riskSignals-test-ws");
+const OUTSIDE = path.resolve(path.dirname(WS), "outside-the-workspace.txt");
+const INSIDE = path.join(WS, "inside.txt");
+
+describe("computeRiskSignals — command catalog", () => {
+  it("flags rm -rf as high severity (runCommand uses params.command)", () => {
+    const s = computeRiskSignals(
+      "runCommand",
+      { command: "rm -rf ./build" },
+      WS,
+    );
+    expect(s).toContainEqual({
+      kind: "destructive_flag",
+      label: "rm with -rf flags",
+      severity: "high",
+    });
+  });
+
+  it("returns no signals for a benign command", () => {
+    expect(computeRiskSignals("runCommand", { command: "ls -la" }, WS)).toEqual(
+      [],
+    );
+  });
+
+  it("flags terraform destroy as high severity", () => {
+    const s = computeRiskSignals(
+      "runInTerminal",
+      { command: "terraform destroy -auto-approve" },
+      WS,
+    );
+    expect(s).toContainEqual({
+      kind: "destructive_flag",
+      label: "terraform destroy",
+      severity: "high",
+    });
+  });
+
+  it("flags pulumi destroy as high severity", () => {
+    const s = computeRiskSignals(
+      "runCommand",
+      { command: "pulumi destroy -y" },
+      WS,
+    );
+    expect(s).toContainEqual({
+      kind: "destructive_flag",
+      label: "pulumi destroy",
+      severity: "high",
+    });
+  });
+
+  it("reads sendTerminalCommand from params.text (not params.command)", () => {
+    const s = computeRiskSignals(
+      "sendTerminalCommand",
+      { text: "sudo rm -rf /" },
+      WS,
+    );
+    expect(s.some((x) => x.severity === "high")).toBe(true);
+    expect(s.map((x) => x.label)).toContain("rm with -rf flags");
+    expect(s.map((x) => x.label)).toContain("runs as sudo");
+  });
+
+  it("flags non-HTTPS and direct-IP URLs for sendHttpRequest", () => {
+    const s = computeRiskSignals(
+      "sendHttpRequest",
+      { url: "http://1.2.3.4/exfil" },
+      WS,
+    );
+    expect(s.map((x) => x.label)).toContain("non-HTTPS URL");
+    expect(s.map((x) => x.label)).toContain("direct IP address");
+  });
+
+  it("flags a file path that escapes the workspace as high severity", () => {
+    const s = computeRiskSignals("Read", { file_path: OUTSIDE }, WS);
+    expect(s).toContainEqual({
+      kind: "path_escape",
+      label: "file path outside workspace",
+      severity: "high",
+    });
+  });
+
+  it("does not flag a file path inside the workspace", () => {
+    expect(computeRiskSignals("Read", { file_path: INSIDE }, WS)).toEqual([]);
+  });
+});
+
+describe("evaluateInProcessGate — decision + escalation", () => {
+  it("gate 'off' always bypasses (even a destructive command)", () => {
+    const d = evaluateInProcessGate({
+      toolName: "runCommand",
+      params: { command: "rm -rf /" },
+      gate: "off",
+      workspace: WS,
+    });
+    expect(d.decision).toBe("bypass");
+  });
+
+  it("gate 'high' queues a high-tier tool and carries its risk signals", () => {
+    const d = evaluateInProcessGate({
+      toolName: "runCommand",
+      params: { command: "rm -rf ./build" },
+      gate: "high",
+      workspace: WS,
+    });
+    expect(d.decision).toBe("queue");
+    if (d.decision === "queue") {
+      expect(d.tier).toBe("high");
+      expect(d.riskSignals.some((s) => s.severity === "high")).toBe(true);
+    }
+  });
+
+  it("ESCALATION: a sub-high tool carrying a high-severity signal is forced to queue", () => {
+    // classifyTool('Read') === 'medium'; a workspace-escaping path is a high
+    // signal. Pre-fix this bypassed (tier !== 'high'); now it must queue.
+    const d = evaluateInProcessGate({
+      toolName: "Read",
+      params: { file_path: OUTSIDE },
+      gate: "high",
+      workspace: WS,
+    });
+    expect(d.decision).toBe("queue");
+  });
+
+  it("gate 'high' bypasses a sub-high tool with no high-severity signal", () => {
+    const d = evaluateInProcessGate({
+      toolName: "Read",
+      params: { file_path: INSIDE },
+      gate: "high",
+      workspace: WS,
+    });
+    expect(d.decision).toBe("bypass");
+  });
+
+  it("gate 'all' queues everything, including a benign sub-high tool", () => {
+    const d = evaluateInProcessGate({
+      toolName: "getDiagnostics",
+      params: {},
+      gate: "all",
+      workspace: WS,
+    });
+    expect(d.decision).toBe("queue");
+  });
+});

--- a/src/approvalHttp.ts
+++ b/src/approvalHttp.ts
@@ -1,5 +1,4 @@
 import * as dns from "node:dns/promises";
-import * as path from "node:path";
 import {
   recordApprovalCompleted,
   recordApprovalPrompted,
@@ -12,6 +11,7 @@ import {
   loadCcPermissionsAttributed,
 } from "./ccPermissions.js";
 import { captureForRunlog } from "./recipes/stepObservation.js";
+import { computeRiskSignals } from "./riskSignals.js";
 import { classifyTool } from "./riskTier.js";
 import { isPrivateHost } from "./ssrfGuard.js";
 
@@ -745,104 +745,6 @@ async function dispatchNtfyConfirmation(
   }
 }
 
-function computeRiskSignals(
-  toolName: string,
-  params: Record<string, unknown>,
-  workspace: string,
-): RiskSignal[] {
-  const signals: RiskSignal[] = [];
-
-  // Destructive flags — Bash / runCommand
-  if (toolName === "Bash" || toolName === "runCommand") {
-    const cmd = typeof params.command === "string" ? params.command : "";
-    if (/\brm\b.*-[a-z]*r[a-z]*f|\brm\b.*-[a-z]*f[a-z]*r/i.test(cmd)) {
-      signals.push({
-        kind: "destructive_flag",
-        label: "rm with -rf flags",
-        severity: "high",
-      });
-    }
-    if (/--force\b/i.test(cmd)) {
-      signals.push({
-        kind: "destructive_flag",
-        label: "contains --force flag",
-        severity: "medium",
-      });
-    }
-    if (/\bsudo\b/i.test(cmd)) {
-      signals.push({
-        kind: "destructive_flag",
-        label: "runs as sudo",
-        severity: "high",
-      });
-    }
-    if (/\bDROP\s+(TABLE|DATABASE|SCHEMA)\b/i.test(cmd)) {
-      signals.push({
-        kind: "destructive_flag",
-        label: "SQL DROP statement",
-        severity: "high",
-      });
-    }
-    if (/\bTRUNCATE\b/i.test(cmd)) {
-      signals.push({
-        kind: "destructive_flag",
-        label: "SQL TRUNCATE statement",
-        severity: "medium",
-      });
-    }
-    if (/[`$()]\s*|&&|\|\|/.test(cmd)) {
-      signals.push({
-        kind: "chaining",
-        label: "command chaining or substitution",
-        severity: "low",
-      });
-    }
-  }
-
-  // Domain reputation — WebFetch / sendHttpRequest
-  if (toolName === "WebFetch" || toolName === "sendHttpRequest") {
-    const url = typeof params.url === "string" ? params.url : "";
-    if (url && !url.startsWith("https://")) {
-      signals.push({
-        kind: "domain_reputation",
-        label: "non-HTTPS URL",
-        severity: "medium",
-      });
-    }
-    try {
-      const hostname = new URL(url).hostname;
-      if (/^\d+\.\d+\.\d+\.\d+$/.test(hostname)) {
-        signals.push({
-          kind: "domain_reputation",
-          label: "direct IP address",
-          severity: "medium",
-        });
-      }
-    } catch {
-      // unparseable URL — skip hostname check
-    }
-  }
-
-  // Path escape — Write / Edit / Read
-  if (toolName === "Write" || toolName === "Edit" || toolName === "Read") {
-    const filePath =
-      typeof params.file_path === "string" ? params.file_path : "";
-    if (filePath) {
-      const resolved = path.resolve(filePath);
-      const wsRoot = path.resolve(workspace) + path.sep;
-      if (!resolved.startsWith(wsRoot)) {
-        signals.push({
-          kind: "path_escape",
-          label: "file path outside workspace",
-          severity: "high",
-        });
-      }
-    }
-  }
-
-  return signals;
-}
-
 async function handleApprovalRequest(
   req: HttpRequest,
   deps: ApprovalHttpDeps,
@@ -965,7 +867,13 @@ async function handleApprovalRequest(
     emit("allow", "gate_off");
     return { status: 200, body: { decision: "allow", reason: "gate_off" } };
   }
-  if (gate === "high" && tier !== "high") {
+  // A high-severity content signal (rm -rf, sudo, terraform destroy, path
+  // escape, …) forces the queue even for a sub-high tier, mirroring the
+  // in-process gate so CC-native calls aren't gated content-blind. Additive:
+  // only ever removes a bypass, never adds one, and runs AFTER the CC
+  // deny/ask/dontAsk/plan precedence so a signal can't downgrade a deny. (P0-2)
+  const hasHighSeverity = riskSignals.some((s) => s.severity === "high");
+  if (gate === "high" && tier !== "high" && !hasHighSeverity) {
     emit("allow", "gate_below_threshold");
     return {
       status: 200,

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -46,7 +46,7 @@ import {
 } from "./recipes/judgeSummary.js";
 import { warnAboutLegacyPermissionsSidecars } from "./recipes/migrationWarnings.js";
 import { RecipeOrchestrator } from "./recipes/RecipeOrchestrator.js";
-import { classifyTool } from "./riskTier.js";
+import { evaluateInProcessGate } from "./riskSignals.js";
 import { RecipeRunLog } from "./runLog.js";
 import { Server } from "./server.js";
 import { type CheckpointData, SessionCheckpoint } from "./sessionCheckpoint.js";
@@ -377,17 +377,20 @@ export class Bridge {
         }
         transport.setApprovalGate(
           async ({ toolName, params, sessionId, onPending }) => {
-            const tier = classifyTool(toolName);
-            if (this.server.approvalGate === "off") return "bypass";
-            if (this.server.approvalGate !== "all" && tier !== "high")
-              return "bypass";
+            const gate = evaluateInProcessGate({
+              toolName,
+              params,
+              gate: this.server.approvalGate,
+              workspace: this.config.workspace,
+            });
+            if (gate.decision === "bypass") return "bypass";
             const queue = getApprovalQueue();
             const { promise, callId } = queue.request({
               toolName,
               params,
-              tier,
+              tier: gate.tier,
               sessionId: sessionId ?? undefined,
-              riskSignals: [],
+              riskSignals: gate.riskSignals,
             });
             onPending?.(callId);
             return promise;

--- a/src/riskSignals.ts
+++ b/src/riskSignals.ts
@@ -1,0 +1,180 @@
+import * as path from "node:path";
+import type { RiskSignal } from "./approvalQueue.js";
+import { classifyTool, type RiskTier } from "./riskTier.js";
+
+/**
+ * Command-bearing tools whose params carry a shell command string. Bash /
+ * runCommand / runInTerminal expose it as `command`; sendTerminalCommand uses
+ * `text`. computeRiskSignals reads whichever is present.
+ */
+const COMMAND_TOOLS = new Set([
+  "Bash",
+  "runCommand",
+  "runInTerminal",
+  "sendTerminalCommand",
+]);
+
+/**
+ * Content-derived risk signals for an approval request. Pure + synchronous
+ * (regex tests + one `path.resolve` + a try/caught `URL` parse), so it is safe
+ * to call inside the in-process approval gate's async closure.
+ *
+ * Single source of truth for BOTH the in-process gate (bridge.ts /
+ * streamableHttp.ts) and the CC-native /approvals path (approvalHttp.ts) — so
+ * the catalog can never fork (the repo's recurring "incomplete-fix-one-path"
+ * failure mode). (audit P0-2)
+ */
+export function computeRiskSignals(
+  toolName: string,
+  params: Record<string, unknown>,
+  workspace: string,
+): RiskSignal[] {
+  const signals: RiskSignal[] = [];
+
+  // Destructive flags — shell commands
+  if (COMMAND_TOOLS.has(toolName)) {
+    const cmd =
+      (typeof params.command === "string" && params.command) ||
+      (typeof params.text === "string" && params.text) ||
+      "";
+    if (/\brm\b.*-[a-z]*r[a-z]*f|\brm\b.*-[a-z]*f[a-z]*r/i.test(cmd)) {
+      signals.push({
+        kind: "destructive_flag",
+        label: "rm with -rf flags",
+        severity: "high",
+      });
+    }
+    if (/--force\b/i.test(cmd)) {
+      signals.push({
+        kind: "destructive_flag",
+        label: "contains --force flag",
+        severity: "medium",
+      });
+    }
+    if (/\bsudo\b/i.test(cmd)) {
+      signals.push({
+        kind: "destructive_flag",
+        label: "runs as sudo",
+        severity: "high",
+      });
+    }
+    if (/\bDROP\s+(TABLE|DATABASE|SCHEMA)\b/i.test(cmd)) {
+      signals.push({
+        kind: "destructive_flag",
+        label: "SQL DROP statement",
+        severity: "high",
+      });
+    }
+    if (/\bTRUNCATE\b/i.test(cmd)) {
+      signals.push({
+        kind: "destructive_flag",
+        label: "SQL TRUNCATE statement",
+        severity: "medium",
+      });
+    }
+    if (/\bterraform\b[\s\S]*\bdestroy\b/i.test(cmd)) {
+      signals.push({
+        kind: "destructive_flag",
+        label: "terraform destroy",
+        severity: "high",
+      });
+    }
+    if (/\bpulumi\b[\s\S]*\bdestroy\b/i.test(cmd)) {
+      signals.push({
+        kind: "destructive_flag",
+        label: "pulumi destroy",
+        severity: "high",
+      });
+    }
+    if (/[`$()]\s*|&&|\|\|/.test(cmd)) {
+      signals.push({
+        kind: "chaining",
+        label: "command chaining or substitution",
+        severity: "low",
+      });
+    }
+  }
+
+  // Domain reputation — WebFetch / sendHttpRequest
+  if (toolName === "WebFetch" || toolName === "sendHttpRequest") {
+    const url = typeof params.url === "string" ? params.url : "";
+    if (url && !url.startsWith("https://")) {
+      signals.push({
+        kind: "domain_reputation",
+        label: "non-HTTPS URL",
+        severity: "medium",
+      });
+    }
+    try {
+      const hostname = new URL(url).hostname;
+      if (/^\d+\.\d+\.\d+\.\d+$/.test(hostname)) {
+        signals.push({
+          kind: "domain_reputation",
+          label: "direct IP address",
+          severity: "medium",
+        });
+      }
+    } catch {
+      // unparseable URL — skip hostname check
+    }
+  }
+
+  // Path escape — Write / Edit / Read
+  if (toolName === "Write" || toolName === "Edit" || toolName === "Read") {
+    const filePath =
+      typeof params.file_path === "string" ? params.file_path : "";
+    if (filePath) {
+      const resolved = path.resolve(filePath);
+      const wsRoot = path.resolve(workspace) + path.sep;
+      if (!resolved.startsWith(wsRoot)) {
+        signals.push({
+          kind: "path_escape",
+          label: "file path outside workspace",
+          severity: "high",
+        });
+      }
+    }
+  }
+
+  return signals;
+}
+
+export type InProcessGateDecision =
+  | { decision: "bypass" }
+  | { decision: "queue"; tier: RiskTier; riskSignals: RiskSignal[] };
+
+/**
+ * Decide whether an in-process MCP tool call (the bridge's OWN tools) bypasses
+ * the approval gate or must queue for human approval, and compute the content
+ * risk signals that travel with it. Single source of truth shared by the
+ * WebSocket transport (bridge.ts) and the Streamable-HTTP transport
+ * (streamableHttp.ts) so the two can't drift — a content-blind copy on one
+ * transport would let `rm -rf` gate like `ls` over that transport. (audit P0-2)
+ *
+ * Semantics are strictly ADDITIVE vs the prior tier-only gate — escalation can
+ * only ever turn a bypass into a queue, never the reverse:
+ *  - gate "off"  → always bypass (a deliberate, documented full bypass).
+ *  - a HIGH-severity content signal forces the queue even for a sub-high base
+ *    tier (escalation). High-tier tools queue as before, now WITH their signals.
+ *  - gate "high" + sub-high tier + no high signal → bypass (unchanged).
+ *  - gate "all" → everything queues (unchanged).
+ */
+export function evaluateInProcessGate(opts: {
+  toolName: string;
+  params: Record<string, unknown>;
+  gate: "off" | "high" | "all";
+  workspace: string;
+}): InProcessGateDecision {
+  if (opts.gate === "off") return { decision: "bypass" };
+  const tier = classifyTool(opts.toolName);
+  const riskSignals = computeRiskSignals(
+    opts.toolName,
+    opts.params,
+    opts.workspace,
+  );
+  const hasHighSeverity = riskSignals.some((s) => s.severity === "high");
+  if (opts.gate !== "all" && tier !== "high" && !hasHighSeverity) {
+    return { decision: "bypass" };
+  }
+  return { decision: "queue", tier, riskSignals };
+}

--- a/src/streamableHttp.ts
+++ b/src/streamableHttp.ts
@@ -26,7 +26,7 @@ import type { Logger } from "./logger.js";
 import type { LoadedPluginTool } from "./pluginLoader.js";
 import type { PluginWatcher } from "./pluginWatcher.js";
 import type { ProbeResults } from "./probe.js";
-import { classifyTool } from "./riskTier.js";
+import { evaluateInProcessGate } from "./riskSignals.js";
 import { corsOrigin } from "./server.js";
 import { registerAllTools } from "./tools/index.js";
 import { McpTransport } from "./transport.js";
@@ -850,18 +850,22 @@ export class StreamableHttpHandler {
     if (scope) transport.setSessionScope(scope);
     if (denyTools.size > 0) transport.setDenyTools(denyTools);
     if (this.config.approvalGate !== "off") {
-      const gateAll = this.config.approvalGate === "all";
       transport.setApprovalGate(
         async ({ toolName, params, sessionId, onPending }) => {
-          const tier = classifyTool(toolName);
-          if (!gateAll && tier !== "high") return "bypass";
+          const gate = evaluateInProcessGate({
+            toolName,
+            params,
+            gate: this.config.approvalGate,
+            workspace: this.config.workspace,
+          });
+          if (gate.decision === "bypass") return "bypass";
           const queue = getApprovalQueue();
           const { promise, callId } = queue.request({
             toolName,
             params,
-            tier,
+            tier: gate.tier,
             sessionId: sessionId ?? undefined,
-            riskSignals: [],
+            riskSignals: gate.riskSignals,
           });
           onPending?.(callId);
           return promise;


### PR DESCRIPTION
## What

Makes the bridge's **in-process approval gate** (for its own MCP tools) content-aware. From the changelog-driven audit, item **P0-2** (`docs/audit-bridge-changelog-2026-06-25.md`) — the headline "permission-enforcement asymmetry" finding.

## Why

The in-process gate (WebSocket `bridge.ts`, Streamable-HTTP `streamableHttp.ts`) keyed on risk **tier alone**: it hardcoded `riskSignals: []` and never escalated a sub-high tool on a high-severity content signal. So `runCommand{command:'rm -rf /'}` and `runCommand{command:'ls'}` were gated **identically** — the approver saw no risk context — and the same blind spot was copy-pasted across both transports. (This is the `git reset --hard origin/main`-class risk from the project's incident history.)

## Changes

- **`src/riskSignals.ts` (new)** — extract `computeRiskSignals` out of `approvalHttp.ts` (it was module-private) and add `evaluateInProcessGate()`, a single shared decision function both transports call. One source of truth ⇒ a content-blind copy can't drift onto one transport (the repo's recurring "fix-one-path" failure mode).
- **`bridge.ts` / `streamableHttp.ts`** — both gates now compute real risk signals and a **high-severity signal forces the queue** even for a sub-high base tier. Strictly **additive**: the escalation is an `&& !hasHighSeverity` AND-clause folded into the existing bypass condition, so it can only ever turn a bypass into a queue, never the reverse. `approvalGate:"off"` stays the first short-circuit.
- **Catalog extended** — `terraform destroy` / `pulumi destroy` (high); `sendTerminalCommand` reads `params.text` (it doesn't use `params.command`, so it previously yielded zero signals).
- **`approvalHttp.ts`** — imports the shared `computeRiskSignals` (no fork) and gets the **same escalation** on the CC-native `/approvals` path, inserted **after** the CC deny/ask/dontAsk/plan precedence so a signal can never downgrade a `deny`.

## Out of scope (deferred)

Wiring `evaluateRules` (`Tool(param:value)` / `Bash(git push*)` deny rules) to the in-process path — open question whether users target `Bash(...)` or the bridge-native `runCommand(...)` rule names. The severity escalation is the load-bearing safety net meanwhile; this is noted for a follow-up.

## Tests

- `riskSignals.test.ts` (13) — catalog incl. terraform/pulumi + the `text` key; gate decisions incl. the escalation (a medium-tier `Read` escaping the workspace is forced to queue — it bypassed pre-fix).
- `approvalGate.content.e2e.test.ts` (3) — end-to-end through `McpTransport → ApprovalQueue`: a destructive command queues **with** its high signal; the escalation queues a sub-high tool; a benign sub-high call still bypasses.
- **454 tests green** across the approval/transport/bridge/http suites; `tsc` (default + **core ratchet**) clean; biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
