### PR TITLE
feat(automation): fire installed recipe triggers (file_watch/git_hook)

### DIFF
--- a/src/__tests__/automation-recipe-triggers.test.ts
+++ b/src/__tests__/automation-recipe-triggers.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Recipe-trigger registration → firing proof.
+ *
+ * Guards the wiring that makes `trigger: { type: file_watch | git_hook }`
+ * recipes actually fire: collected programs are registered into AutomationHooks
+ * and run on the same events the bridge already dispatches. Before this wiring
+ * such recipes were parsed + installed but decorative (the "0 tasks" assertion
+ * below). See docs/dogfood/recipe-dogfood-2026-05-01/C-triggers.md.
+ */
+
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import type { AutomationPolicy } from "../automation.js";
+import { AutomationHooks } from "../automation.js";
+import { ClaudeOrchestrator } from "../claudeOrchestrator.js";
+import type { IClaudeDriver } from "../drivers/types.js";
+import { compileRecipe } from "../recipes/compiler.js";
+import { parseRecipe } from "../recipes/parser.js";
+
+function makeHooks() {
+  const driver: IClaudeDriver = {
+    name: "instant",
+    async run() {
+      return { text: "ok", exitCode: 0, durationMs: 1 };
+    },
+  };
+  const orch = new ClaudeOrchestrator(driver, os.tmpdir(), () => {});
+  // Empty policy → parsePolicy returns ok([]) → interpreter backend initialises,
+  // so registered recipe programs have a live backend to run on.
+  const hooks = new AutomationHooks(
+    {} as AutomationPolicy,
+    orch,
+    () => {},
+    undefined,
+    os.tmpdir(),
+  );
+  return { hooks, orch };
+}
+
+const settle = () => new Promise((r) => setTimeout(r, 30));
+const tsFile = () => path.join(os.tmpdir(), "watched.ts");
+
+const fwProgram = compileRecipe(
+  parseRecipe({
+    name: "fw-recipe",
+    version: "1.0.0",
+    trigger: { type: "file_watch", patterns: ["**/*.ts"] },
+    steps: [{ id: "s1", tool: "getGitStatus", params: {} }],
+  }),
+);
+const ghProgram = compileRecipe(
+  parseRecipe({
+    name: "gh-recipe",
+    version: "1.0.0",
+    trigger: { type: "git_hook", event: "post-commit" },
+    steps: [{ id: "s1", tool: "getGitStatus", params: {} }],
+  }),
+);
+
+describe("recipe trigger registration", () => {
+  it("file_watch recipe is decorative until registered, then fires on save", async () => {
+    const { hooks, orch } = makeHooks();
+
+    // Unregistered: the gap this PR closes — nothing fires.
+    hooks.handleFileSaved("id", "save", tsFile());
+    await settle();
+    expect(orch.list()).toHaveLength(0);
+
+    hooks.registerRecipePrograms([fwProgram]);
+    hooks.handleFileSaved("id", "save", tsFile());
+    await settle();
+
+    const tasks = orch.list();
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0]!.prompt).toContain("fw-recipe");
+  });
+
+  it("gates by hook type: git_hook recipe fires on commit, not on file save", async () => {
+    const { hooks, orch } = makeHooks();
+    hooks.registerRecipePrograms([fwProgram, ghProgram]);
+
+    hooks.handleFileSaved("id", "save", tsFile());
+    await settle();
+    let tasks = orch.list();
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0]!.prompt).toContain("fw-recipe");
+    expect(tasks[0]!.prompt).not.toContain("gh-recipe");
+
+    await hooks.handleGitCommit({
+      hash: "abc1234",
+      branch: "main",
+      message: "feat: x",
+      count: 1,
+      files: ["src/a.ts"],
+    });
+    await settle();
+    tasks = orch.list();
+    expect(tasks).toHaveLength(2);
+    expect(tasks.some((t) => t.prompt.includes("gh-recipe"))).toBe(true);
+  });
+
+  it("is idempotent: re-registering the same set does not duplicate hooks", async () => {
+    const { hooks, orch } = makeHooks();
+    hooks.registerRecipePrograms([fwProgram]);
+    hooks.registerRecipePrograms([fwProgram]); // simulate hot-reload
+
+    hooks.handleFileSaved("id", "save", tsFile());
+    await settle();
+    expect(orch.list()).toHaveLength(1);
+  });
+});

--- a/src/automation.ts
+++ b/src/automation.ts
@@ -1390,6 +1390,15 @@ export function checkCcHookWiring(): Record<string, boolean> {
 export class AutomationHooks {
   /** Compiled AST for the functional interpreter. Null if parse failed. */
   private _programAST: AutomationProgram[] | null = null;
+  /**
+   * Policy-file-derived programs (from `parsePolicy`). Kept separate from the
+   * effective `_programAST` so `registerRecipePrograms()` can rebuild the AST as
+   * (policy ⊕ recipe) idempotently on every recipe hot-reload without
+   * duplicating the policy hooks.
+   */
+  private _policyPrograms: AutomationProgram[] | null = null;
+  /** Programs compiled from installed recipe triggers (file_watch / git_hook). */
+  private _recipePrograms: AutomationProgram[] = [];
   /** Backend instance for the functional interpreter. */
   private _interpreterBackend: VsCodeBackend | null = null;
   /**
@@ -1434,6 +1443,7 @@ export class AutomationHooks {
       const parseResult = parsePolicy(policy);
       if (parseResult.ok) {
         this._programAST = parseResult.value;
+        this._policyPrograms = parseResult.value;
         this._interpreterBackend = new VsCodeBackend(
           orchestrator,
           { info: this.log.bind(this) },
@@ -1445,6 +1455,33 @@ export class AutomationHooks {
         );
       }
     }
+  }
+
+  /**
+   * Register AutomationPrograms compiled from installed recipe triggers
+   * (file_watch / git_hook). They run alongside the policy-file programs on the
+   * SAME hook events the bridge already fires (handleFileSaved / handleGitCommit
+   * / handleGitPush / handleGitPull), so a recipe with `trigger: { type:
+   * file_watch }` actually fires instead of being parsed-but-decorative.
+   *
+   * Idempotent: each call REPLACES the prior recipe set, so the bridge can call
+   * it again on every recipe install / save / delete (hot-reload) without
+   * duplicating hooks. No-op when the interpreter backend never initialised
+   * (policy parse failed) or after destroy().
+   */
+  registerRecipePrograms(programs: AutomationProgram[]): void {
+    if (this._isDestroyed) return;
+    if (!this._interpreterBackend) {
+      this.log(
+        "[automation] recipe triggers not registered — interpreter backend unavailable (policy parse failed)",
+      );
+      return;
+    }
+    this._recipePrograms = programs;
+    this._programAST = [
+      ...(this._policyPrograms ?? []),
+      ...this._recipePrograms,
+    ];
   }
 
   /**

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -36,6 +36,7 @@ import { isPreToolUseHookRegistered } from "./preToolUseHook.js";
 import type { ProbeResults } from "./probe.js";
 import { probeAll } from "./probe.js";
 import { RecipeOrchestration } from "./recipeOrchestration.js";
+import { collectEventTriggerPrograms } from "./recipes/eventTriggerPrograms.js";
 import {
   haltSummaryToPrometheus,
   summariseHalts,
@@ -931,6 +932,33 @@ export class Bridge {
     return this.authToken;
   }
 
+  /**
+   * Compile installed recipe triggers (file_watch / git_hook) and register them
+   * into the live AutomationHooks so they actually fire on the corresponding
+   * events. Without this, such recipes are parsed + installed but decorative
+   * (see docs/dogfood/recipe-dogfood-2026-05-01/C-triggers.md). Idempotent and
+   * fail-soft: safe to call at startup and on every recipe hot-reload; a no-op
+   * when automation is disabled.
+   */
+  private registerRecipeTriggerPrograms(): void {
+    if (!this.automationHooks) return;
+    try {
+      const recipesDir = path.join(os.homedir(), ".patchwork", "recipes");
+      const collected = collectEventTriggerPrograms(recipesDir, {
+        logger: this.logger,
+      });
+      this.automationHooks.registerRecipePrograms(collected.programs);
+      const n = collected.programs.length;
+      this.logger.info(
+        `[bridge] Recipe triggers registered · ${n} event-driven recipe${n === 1 ? "" : "s"}${collected.recipeNames.length ? ` (${collected.recipeNames.join(", ")})` : ""}`,
+      );
+    } catch (err) {
+      this.logger.warn?.(
+        `[bridge] recipe trigger registration failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
   async start(): Promise<void> {
     // 0. Initialize OpenTelemetry (no-op when OTEL_EXPORTER_OTLP_ENDPOINT is unset)
     initTelemetry();
@@ -1138,6 +1166,10 @@ export class Bridge {
               `[patchwork] scheduler restart failed: ${err instanceof Error ? err.message : String(err)}`,
             );
           }
+          // Re-sync recipe-derived event triggers (file_watch / git_hook) on
+          // every install / save / delete. registerRecipePrograms() replaces the
+          // prior recipe set, so this is idempotent.
+          this.registerRecipeTriggerPrograms();
         };
       }
     }
@@ -1161,6 +1193,10 @@ export class Bridge {
       this.logger.info(
         `[bridge] Automation enabled (policy: ${this.config.automationPolicyPath})`,
       );
+      // Wire installed recipe triggers (file_watch / git_hook) into the live
+      // interpreter — they compile to hooks the bridge already fires, but were
+      // never registered until now (decorative). See C-triggers.md.
+      this.registerRecipeTriggerPrograms();
     }
 
     // 3. Wire up /health endpoint data and /metrics

--- a/src/recipes/__tests__/eventTriggerPrograms.test.ts
+++ b/src/recipes/__tests__/eventTriggerPrograms.test.ts
@@ -1,0 +1,131 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { collectEventTriggerPrograms } from "../eventTriggerPrograms.js";
+
+// Minimal valid recipe YAML by trigger type. parseRecipe requires a kebab
+// `name`, a `trigger`, and a non-empty `steps` array.
+function recipeYaml(name: string, triggerBlock: string): string {
+  return `name: ${name}
+version: "1.0.0"
+${triggerBlock}
+steps:
+  - id: s1
+    tool: getGitStatus
+    params: {}
+`;
+}
+
+const FILE_WATCH = `trigger:
+  type: file_watch
+  patterns:
+    - "**/*.ts"`;
+const GIT_HOOK = `trigger:
+  type: git_hook
+  event: post-commit`;
+const CRON = `trigger:
+  type: cron
+  schedule: "0 9 * * *"`;
+const MANUAL = `trigger:
+  type: manual`;
+
+describe("collectEventTriggerPrograms", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(path.join(os.tmpdir(), "pw-evt-triggers-"));
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  function write(file: string, content: string) {
+    writeFileSync(path.join(dir, file), content, "utf-8");
+  }
+
+  it("collects only the compilable event triggers (file_watch + git_hook)", () => {
+    write("fw-recipe.yaml", recipeYaml("fw-recipe", FILE_WATCH));
+    write("gh-recipe.yaml", recipeYaml("gh-recipe", GIT_HOOK));
+    write("cron-recipe.yaml", recipeYaml("cron-recipe", CRON));
+    write("manual-recipe.yaml", recipeYaml("manual-recipe", MANUAL));
+
+    const { programs, recipeNames } = collectEventTriggerPrograms(dir, {
+      disabledRecipes: [],
+    });
+
+    expect(recipeNames.sort()).toEqual(["fw-recipe", "gh-recipe"]);
+    expect(programs).toHaveLength(2);
+  });
+
+  it("resolves install-dir recipes via recipe.json main", () => {
+    const inst = path.join(dir, "installed");
+    mkdirSync(inst);
+    writeFileSync(
+      path.join(inst, "recipe.json"),
+      JSON.stringify({ recipes: { main: "main.yaml" } }),
+      "utf-8",
+    );
+    writeFileSync(
+      path.join(inst, "main.yaml"),
+      recipeYaml("installed-fw", FILE_WATCH),
+      "utf-8",
+    );
+
+    const { recipeNames } = collectEventTriggerPrograms(dir, {
+      disabledRecipes: [],
+    });
+    expect(recipeNames).toContain("installed-fw");
+  });
+
+  it("skips install dirs carrying a .disabled marker", () => {
+    const inst = path.join(dir, "off");
+    mkdirSync(inst);
+    writeFileSync(path.join(inst, ".disabled"), "", "utf-8");
+    writeFileSync(
+      path.join(inst, "r.yaml"),
+      recipeYaml("should-not-load", FILE_WATCH),
+      "utf-8",
+    );
+
+    const { recipeNames } = collectEventTriggerPrograms(dir, {
+      disabledRecipes: [],
+    });
+    expect(recipeNames).not.toContain("should-not-load");
+  });
+
+  it("excludes recipes named in the disabled set", () => {
+    write("fw-recipe.yaml", recipeYaml("fw-recipe", FILE_WATCH));
+    write("gh-recipe.yaml", recipeYaml("gh-recipe", GIT_HOOK));
+
+    const { recipeNames } = collectEventTriggerPrograms(dir, {
+      disabledRecipes: ["fw-recipe"],
+    });
+    expect(recipeNames).toEqual(["gh-recipe"]);
+  });
+
+  it("is fail-soft: a malformed recipe is skipped, others still collected", () => {
+    write("fw-recipe.yaml", recipeYaml("fw-recipe", FILE_WATCH));
+    // Empty steps → parseRecipe throws → must be skipped, not fatal.
+    write(
+      "broken.yaml",
+      `name: broken-recipe\nversion: "1.0.0"\n${FILE_WATCH}\nsteps: []\n`,
+    );
+    write("not-a-recipe.yaml", "this: is: not: valid: yaml: : :");
+
+    const { programs, recipeNames } = collectEventTriggerPrograms(dir, {
+      disabledRecipes: [],
+    });
+    expect(recipeNames).toEqual(["fw-recipe"]);
+    expect(programs).toHaveLength(1);
+  });
+
+  it("returns empty for a non-existent recipes dir (no throw)", () => {
+    const result = collectEventTriggerPrograms(
+      path.join(dir, "does-not-exist"),
+      { disabledRecipes: [] },
+    );
+    expect(result.programs).toHaveLength(0);
+    expect(result.recipeNames).toHaveLength(0);
+  });
+});

--- a/src/recipes/__tests__/triggerDispatchCompleteness.test.ts
+++ b/src/recipes/__tests__/triggerDispatchCompleteness.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Wiring-completeness gate for recipe trigger dispatch.
+ *
+ * Guards the bug class that made file_watch/git_hook recipes decorative: a
+ * recipe TriggerType that the runtime never dispatches. Every TriggerType MUST
+ * be classified into a known dispatch path or explicitly recorded as an unwired
+ * gap. The `Record<TriggerType, DispatchPath>` below is exhaustive by
+ * construction — tsc fails to compile if a new TriggerType is added without a
+ * key, so a new trigger can never silently ship "parsed but never fired". The
+ * runtime checks then verify the classification is accurate: every
+ * "automation-hook" trigger is actually collected, and nothing else is.
+ */
+
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { collectEventTriggerPrograms } from "../eventTriggerPrograms.js";
+import type { TriggerType } from "../schema.js";
+
+type DispatchPath =
+  | "automation-hook" // compiled + registered into AutomationHooks (PR #1016)
+  | "scheduler" // RecipeScheduler (cron)
+  | "webhook" // POST /hooks/* → server.webhookFn
+  | "cli" // `patchwork run <name>`
+  | "chained-runner" // dispatchRecipe → chainedRunner
+  | "UNWIRED"; // no runtime dispatch yet — tracked follow-up
+
+/**
+ * THE GATE. Adding a TriggerType to schema.ts without a key here is a compile
+ * error. Flipping an entry to "automation-hook" without wiring the compiler
+ * fails the runtime check below. Removing an entry from UNWIRED must coincide
+ * with KNOWN_UNWIRED.
+ */
+const TRIGGER_DISPATCH: Record<TriggerType, DispatchPath> = {
+  file_watch: "automation-hook",
+  git_hook: "automation-hook",
+  cron: "scheduler",
+  webhook: "webhook",
+  manual: "cli",
+  chained: "chained-runner",
+  // No compiler `mapTrigger` case yet — the bridge fires onFileSave/onTestRun,
+  // but compileRecipe() can't target them, so these recipes don't auto-fire.
+  // Flip to "automation-hook" once the compiler maps them (the runtime check
+  // then enforces collection end-to-end). Tracked follow-up to PR #1016.
+  on_file_save: "UNWIRED",
+  on_test_run: "UNWIRED",
+};
+
+const KNOWN_UNWIRED: ReadonlySet<TriggerType> = new Set<TriggerType>([
+  "on_file_save",
+  "on_test_run",
+]);
+
+const NAME: Record<TriggerType, string> = {
+  webhook: "g-webhook",
+  cron: "g-cron",
+  file_watch: "g-file-watch",
+  git_hook: "g-git-hook",
+  manual: "g-manual",
+  chained: "g-chained",
+  on_file_save: "g-on-file-save",
+  on_test_run: "g-on-test-run",
+};
+
+const TRIGGER_BLOCK: Record<TriggerType, string> = {
+  webhook: 'trigger:\n  type: webhook\n  path: "/g-webhook"',
+  cron: 'trigger:\n  type: cron\n  schedule: "0 9 * * *"',
+  file_watch: 'trigger:\n  type: file_watch\n  patterns:\n    - "**/*.ts"',
+  git_hook: "trigger:\n  type: git_hook\n  event: post-commit",
+  manual: "trigger:\n  type: manual",
+  chained: "trigger:\n  type: chained",
+  on_file_save: "trigger:\n  type: on_file_save",
+  on_test_run: "trigger:\n  type: on_test_run",
+};
+
+function recipeYaml(name: string, block: string): string {
+  return `name: ${name}\nversion: "1.0.0"\n${block}\nsteps:\n  - id: s1\n    tool: getGitStatus\n    params: {}\n`;
+}
+
+const ALL_TRIGGERS = Object.keys(NAME) as TriggerType[];
+
+describe("recipe trigger dispatch completeness", () => {
+  let dir: string;
+  let collectedNames: Set<string>;
+
+  beforeAll(() => {
+    dir = mkdtempSync(path.join(os.tmpdir(), "pw-trigger-gate-"));
+    for (const t of ALL_TRIGGERS) {
+      writeFileSync(
+        path.join(dir, `${NAME[t]}.yaml`),
+        recipeYaml(NAME[t], TRIGGER_BLOCK[t]),
+        "utf-8",
+      );
+    }
+    collectedNames = new Set(
+      collectEventTriggerPrograms(dir, { disabledRecipes: [] }).recipeNames,
+    );
+  });
+
+  afterAll(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("classifies every TriggerType (exhaustive Record = compile-time gate)", () => {
+    // If this fails, a TriggerType lost its NAME/TRIGGER_BLOCK fixture — but the
+    // Record<TriggerType, …> maps would have failed tsc first.
+    for (const t of ALL_TRIGGERS) {
+      expect(TRIGGER_DISPATCH[t]).toBeDefined();
+    }
+  });
+
+  it("UNWIRED set has not drifted (wiring one forces a deliberate update)", () => {
+    const unwired = ALL_TRIGGERS.filter(
+      (t) => TRIGGER_DISPATCH[t] === "UNWIRED",
+    ).sort();
+    expect(unwired).toEqual([...KNOWN_UNWIRED].sort());
+  });
+
+  it("every 'automation-hook' trigger is actually collected; nothing else is", () => {
+    for (const t of ALL_TRIGGERS) {
+      const shouldCollect = TRIGGER_DISPATCH[t] === "automation-hook";
+      expect(
+        collectedNames.has(NAME[t]),
+        `${t} (${TRIGGER_DISPATCH[t]}) collected=${collectedNames.has(NAME[t])}, expected=${shouldCollect}`,
+      ).toBe(shouldCollect);
+    }
+  });
+
+  it("the automation-hook set is exactly file_watch + git_hook", () => {
+    const hookTriggers = ALL_TRIGGERS.filter(
+      (t) => TRIGGER_DISPATCH[t] === "automation-hook",
+    ).sort();
+    expect(hookTriggers).toEqual(["file_watch", "git_hook"]);
+  });
+});

--- a/src/recipes/eventTriggerPrograms.ts
+++ b/src/recipes/eventTriggerPrograms.ts
@@ -1,0 +1,192 @@
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+import { parse as parseYaml } from "yaml";
+import type { AutomationProgram } from "../fp/automationProgram.js";
+import { loadConfig } from "../patchworkConfig.js";
+import { compileRecipe } from "./compiler.js";
+import {
+  getConfigDisabledNames,
+  isInstallDirDisabled,
+} from "./disabledMarkers.js";
+import { parseRecipe } from "./parser.js";
+
+/**
+ * Collect AutomationPrograms from installed recipes whose trigger type maps to
+ * a native automation hook the bridge already fires.
+ *
+ * `compileRecipe` (compiler.ts) maps:
+ *   - `file_watch` → onFileSave
+ *   - `git_hook`   → onGitCommit / onGitPush / onGitPull
+ * and THROWS for cron/webhook/manual/chained (those route through the cron
+ * scheduler / POST /hooks / CLI / chained runner respectively). The newer
+ * `on_file_save` / `on_test_run` trigger types have no compiler case yet, so
+ * they are intentionally excluded here and tracked as a follow-up.
+ *
+ * Before this collector existed, these compiled programs were never registered
+ * into AutomationHooks — a recipe with `trigger: { type: file_watch }` parsed,
+ * linted, and installed, but never fired (decorative). See
+ * docs/dogfood/recipe-dogfood-2026-05-01/C-triggers.md.
+ *
+ * NOTE: the directory walk here mirrors RecipeScheduler.start()'s candidate
+ * enumeration deliberately rather than sharing it — the live cron scheduler is
+ * load-bearing and must not regress. Unifying the two walks is a follow-up.
+ */
+const COMPILABLE_EVENT_TRIGGERS: ReadonlySet<string> = new Set([
+  "file_watch",
+  "git_hook",
+]);
+
+export interface CollectedTriggerPrograms {
+  programs: AutomationProgram[];
+  /** Names of the recipes whose programs were collected (for logging). */
+  recipeNames: string[];
+}
+
+interface CollectLogger {
+  info?: (msg: string) => void;
+  warn?: (msg: string) => void;
+}
+
+export interface CollectOptions {
+  /**
+   * Override the disabled-recipe set. Tests inject this to avoid reading the
+   * operator's real ~/.patchwork/config.json (whose disabled list would
+   * otherwise silently drop a recipe whose name collides with the dev set).
+   */
+  disabledRecipes?: ReadonlyArray<string>;
+  logger?: CollectLogger;
+}
+
+export function collectEventTriggerPrograms(
+  recipesDir: string,
+  opts: CollectOptions = {},
+): CollectedTriggerPrograms {
+  const programs: AutomationProgram[] = [];
+  const recipeNames: string[] = [];
+
+  let entries: string[];
+  try {
+    entries = readdirSync(recipesDir);
+  } catch {
+    return { programs, recipeNames };
+  }
+
+  const disabled =
+    opts.disabledRecipes !== undefined
+      ? new Set(opts.disabledRecipes)
+      : safeDisabledNames();
+
+  for (const entry of entries) {
+    const fullPath = path.join(recipesDir, entry);
+    let isDir = false;
+    try {
+      isDir = statSync(fullPath).isDirectory();
+    } catch {
+      continue;
+    }
+
+    let filePath: string | null = null;
+    if (isDir) {
+      // Honor the per-install `.disabled` marker (parity with the scheduler).
+      if (isInstallDirDisabled(fullPath)) continue;
+      filePath = resolveInstallEntrypoint(fullPath);
+    } else if (isRecipeFile(entry)) {
+      filePath = fullPath;
+    }
+    if (!filePath) continue;
+
+    const program = compileFromFile(
+      filePath,
+      disabled,
+      recipeNames,
+      opts.logger,
+    );
+    if (program) programs.push(program);
+  }
+
+  return { programs, recipeNames };
+}
+
+function safeDisabledNames(): Set<string> {
+  try {
+    return getConfigDisabledNames(loadConfig());
+  } catch {
+    return new Set();
+  }
+}
+
+function isRecipeFile(name: string): boolean {
+  if (name.endsWith(".permissions.json")) return false;
+  return (
+    name.endsWith(".yaml") || name.endsWith(".yml") || name.endsWith(".json")
+  );
+}
+
+/** Resolve an install dir's recipe entrypoint: recipe.json `recipes.main`, else
+ *  the first YAML file. Mirrors RecipeScheduler's resolution. */
+function resolveInstallEntrypoint(installDir: string): string | null {
+  const manifestPath = path.join(installDir, "recipe.json");
+  if (existsSync(manifestPath)) {
+    try {
+      const m = JSON.parse(readFileSync(manifestPath, "utf-8")) as {
+        recipes?: { main?: string };
+      };
+      if (m.recipes?.main) {
+        const candidate = path.join(installDir, m.recipes.main);
+        if (existsSync(candidate)) return candidate;
+      }
+    } catch {
+      // Malformed manifest — fall through to first-yaml lookup.
+    }
+  }
+  try {
+    const yaml = readdirSync(installDir).find((x) => /\.ya?ml$/i.test(x));
+    if (yaml) return path.join(installDir, yaml);
+  } catch {
+    // Unreadable install dir — skip.
+  }
+  return null;
+}
+
+function compileFromFile(
+  filePath: string,
+  disabled: Set<string>,
+  recipeNames: string[],
+  logger?: CollectLogger,
+): AutomationProgram | null {
+  let recipe: ReturnType<typeof parseRecipe>;
+  try {
+    const raw = readFileSync(filePath, "utf-8");
+    const obj = /\.ya?ml$/i.test(filePath) ? parseYaml(raw) : JSON.parse(raw);
+    recipe = parseRecipe(obj);
+  } catch (err) {
+    // Fail-soft: one malformed recipe must never break startup registration.
+    logger?.warn?.(
+      `[recipe-triggers] skipped ${path.basename(filePath)} — ${errMsg(err)}`,
+    );
+    return null;
+  }
+
+  if (!COMPILABLE_EVENT_TRIGGERS.has(recipe.trigger.type)) return null;
+  if (disabled.has(recipe.name)) {
+    logger?.info?.(
+      `[recipe-triggers] skipping disabled recipe "${recipe.name}"`,
+    );
+    return null;
+  }
+
+  try {
+    const program = compileRecipe(recipe);
+    recipeNames.push(recipe.name);
+    return program;
+  } catch (err) {
+    logger?.warn?.(
+      `[recipe-triggers] could not compile "${recipe.name}" — ${errMsg(err)}`,
+    );
+    return null;
+  }
+}
+
+function errMsg(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}


### PR DESCRIPTION
## What & why

Recipes with `trigger: { type: file_watch | git_hook }` were parsed, linted, and installed — but never fired. `compileRecipe()` produced an `AutomationProgram` that no runtime listener ever registered: the bridge built `AutomationHooks` from `automation-policy.json` only. These triggers compile to `onFileSave` / `onGitCommit` / `onGitPush` / `onGitPull` — hooks the bridge **already dispatches** — so this is pure wiring, not new runtime.

Confirmed HIGH-severity in `docs/dogfood/recipe-dogfood-2026-05-01/C-triggers.md`.

## Changes
- **`src/recipes/eventTriggerPrograms.ts`** (new) — `collectEventTriggerPrograms()` walks `~/.patchwork/recipes` (top-level + install dirs, honoring `.disabled` markers + config-disabled names), parses + compiles the `file_watch`/`git_hook` recipes. Fail-soft per recipe. Deliberately mirrors the scheduler walk rather than sharing it — the live cron path is load-bearing and must not regress.
- **`src/automation.ts`** — `AutomationHooks.registerRecipePrograms()` merges recipe programs with the policy programs idempotently (replaces the recipe set each call → safe on hot-reload).
- **`src/bridge.ts`** — registers at startup (after `AutomationHooks` construction) and re-syncs on every recipe install/save/delete (`onRecipesChangedFn`).

## Scope / follow-ups
- Fires only under `--automation --automation-policy --driver subprocess` (the only path that constructs `AutomationHooks`). Auto-enabling for event-trigger recipes without a policy file is a follow-up.
- `on_test_run` / `on_file_save` trigger types have no compiler case yet → deferred follow-up.

## Tests (test-first)
- **Proof** (`automation-recipe-triggers.test.ts`): a `file_watch` recipe enqueues **0 tasks before** registration, **1 after**; hookType gating (a `git_hook` recipe fires on commit, not on save); idempotent re-registration.
- **Collector** (`eventTriggerPrograms.test.ts`): trigger filtering, install-dir resolution, `.disabled` skip, disabled-by-name, fail-soft on malformed YAML, missing-dir.

Local gates green: `tsc --noEmit`, `tsc -p tsconfig.tests.core.json`, `audit-test-fixtures.mjs`, biome; 589 tests across automation/compiler/scheduler/parser + 9 new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)