### PR TITLE
feat(recipes): opt-in tool sandbox for agent steps (sandbox + disallowedTools)

### DIFF
--- a/src/claudeOrchestrator.ts
+++ b/src/claudeOrchestrator.ts
@@ -67,6 +67,12 @@ export interface ClaudeTask {
    * bridge that spawned them.
    */
   mcpAccess?: boolean;
+  /** P0-5 opt-in tool sandbox — repackaged into providerOptions at the driver.run hop. */
+  sandbox?: boolean;
+  /** Tool allowlist enforced via --allowed-tools when sandbox is true. */
+  allowedTools?: string[];
+  /** Deny rules via --disallowed-tools (any mode). */
+  disallowedTools?: string[];
   /** Set when status === "cancelled": what triggered the cancel. */
   cancelReason?: CancelReason;
   /** Last ~2KB of subprocess stderr — populated on timeout and other aborts. */
@@ -113,6 +119,15 @@ export type EnqueueOpts = {
    * call bridge tools. Opt-in per task — see ClaudeTask.mcpAccess for details.
    */
   mcpAccess?: boolean;
+  /**
+   * P0-5 opt-in tool sandbox. When `sandbox` is true and `allowedTools` is
+   * non-empty, the spawned `claude -p` runs with --permission-mode dontAsk +
+   * --allowed-tools and DROPS --dangerously-skip-permissions. `disallowedTools`
+   * applies in any mode. Repackaged into providerOptions at the driver.run hop.
+   */
+  sandbox?: boolean;
+  allowedTools?: string[];
+  disallowedTools?: string[];
 };
 
 /** Shape of a task entry in the v1 tasks file. */
@@ -146,6 +161,11 @@ interface PersistedTask {
   // automation infinite-chain guard (isAutomationTask).
   useAnt?: boolean;
   mcpAccess?: boolean;
+  // P0-5: a sandboxed task must STAY sandboxed after a bridge restart →
+  // persist + reload these alongside mcpAccess (audit HIGH #11 durability).
+  sandbox?: boolean;
+  allowedTools?: string[];
+  disallowedTools?: string[];
   isAutomationTask?: boolean;
 }
 
@@ -237,6 +257,13 @@ export class ClaudeOrchestrator {
       }),
       ...(opts.useAnt !== undefined && { useAnt: opts.useAnt }),
       ...(opts.mcpAccess !== undefined && { mcpAccess: opts.mcpAccess }),
+      ...(opts.sandbox !== undefined && { sandbox: opts.sandbox }),
+      ...(opts.allowedTools !== undefined && {
+        allowedTools: opts.allowedTools,
+      }),
+      ...(opts.disallowedTools !== undefined && {
+        disallowedTools: opts.disallowedTools,
+      }),
     };
 
     this.tasks.set(id, task);
@@ -446,6 +473,11 @@ export class ClaudeOrchestrator {
           maxBudgetUsd: task.maxBudgetUsd,
           useAnt: task.useAnt,
           mcpAccess: task.mcpAccess,
+          // P0-5 — the single hop where typed top-level sandbox fields are
+          // repackaged into the untyped providerOptions bag the driver reads.
+          sandbox: task.sandbox,
+          allowedTools: task.allowedTools,
+          disallowedTools: task.disallowedTools,
         },
         onChunk: (chunk: string) => {
           // Per-task streaming callback (e.g. for MCP notifications/progress)
@@ -577,6 +609,11 @@ export class ClaudeOrchestrator {
         ...(t.systemPrompt !== undefined && { systemPrompt: t.systemPrompt }),
         ...(t.useAnt !== undefined && { useAnt: t.useAnt }),
         ...(t.mcpAccess !== undefined && { mcpAccess: t.mcpAccess }),
+        ...(t.sandbox !== undefined && { sandbox: t.sandbox }),
+        ...(t.allowedTools !== undefined && { allowedTools: t.allowedTools }),
+        ...(t.disallowedTools !== undefined && {
+          disallowedTools: t.disallowedTools,
+        }),
         ...(t.isAutomationTask !== undefined && {
           isAutomationTask: t.isAutomationTask,
         }),
@@ -741,6 +778,13 @@ export class ClaudeOrchestrator {
               }),
               ...(t.useAnt !== undefined && { useAnt: t.useAnt }),
               ...(t.mcpAccess !== undefined && { mcpAccess: t.mcpAccess }),
+              ...(t.sandbox !== undefined && { sandbox: t.sandbox }),
+              ...(t.allowedTools !== undefined && {
+                allowedTools: t.allowedTools,
+              }),
+              ...(t.disallowedTools !== undefined && {
+                disallowedTools: t.disallowedTools,
+              }),
               ...(t.isAutomationTask !== undefined && {
                 isAutomationTask: t.isAutomationTask,
               }),
@@ -823,6 +867,11 @@ export class ClaudeOrchestrator {
       ...(t.systemPrompt !== undefined && { systemPrompt: t.systemPrompt }),
       ...(t.useAnt !== undefined && { useAnt: t.useAnt }),
       ...(t.mcpAccess !== undefined && { mcpAccess: t.mcpAccess }),
+      ...(t.sandbox !== undefined && { sandbox: t.sandbox }),
+      ...(t.allowedTools !== undefined && { allowedTools: t.allowedTools }),
+      ...(t.disallowedTools !== undefined && {
+        disallowedTools: t.disallowedTools,
+      }),
       ...(t.isAutomationTask !== undefined && {
         isAutomationTask: t.isAutomationTask,
       }),

--- a/src/drivers/claude/__tests__/subprocess.sandbox.test.ts
+++ b/src/drivers/claude/__tests__/subprocess.sandbox.test.ts
@@ -1,0 +1,204 @@
+import { EventEmitter } from "node:events";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+class MockChild extends EventEmitter {
+  stdout = new EventEmitter();
+  stderr = new EventEmitter();
+  exitCode: number | null = null;
+}
+
+let mockChild: MockChild;
+
+vi.mock("node:child_process", async (importOriginal) => {
+  const original = await importOriginal<typeof import("node:child_process")>();
+  return {
+    ...original,
+    spawn: vi.fn(() => {
+      mockChild = new MockChild();
+      mockChild.stdout = new EventEmitter();
+      mockChild.stderr = new EventEmitter();
+      (mockChild.stdout as { setEncoding?: () => void }).setEncoding = vi.fn();
+      (mockChild.stderr as { setEncoding?: () => void }).setEncoding = vi.fn();
+      return mockChild;
+    }),
+  };
+});
+
+import { spawn } from "node:child_process";
+import type { ProviderTaskInput } from "../../types.js";
+import { SubprocessDriver } from "../subprocess.js";
+
+const spawnMock = vi.mocked(spawn);
+
+function makeInput(
+  overrides: Partial<ProviderTaskInput> = {},
+): ProviderTaskInput {
+  return {
+    prompt: "hello",
+    workspace: "/workspace/sandbox",
+    timeoutMs: 5000,
+    signal: new AbortController().signal,
+    ...overrides,
+  };
+}
+
+async function finishRun(p: Promise<unknown>): Promise<void> {
+  await new Promise<void>((r) => setTimeout(r, 0));
+  mockChild.stdout.emit(
+    "data",
+    `${JSON.stringify({ type: "result", is_error: false, result: "ok" })}\n`,
+  );
+  mockChild.emit("close", 0);
+  await p;
+}
+
+/** Collect the values that follow each occurrence of `flag` in argv. */
+function valuesAfter(args: string[], flag: string): string[] {
+  const out: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === flag) {
+      const v = args[i + 1];
+      if (v !== undefined) out.push(v);
+    }
+  }
+  return out;
+}
+
+describe("SubprocessDriver opt-in tool sandbox (P0-5)", () => {
+  beforeEach(() => vi.clearAllMocks());
+  afterEach(() => vi.useRealTimers());
+
+  function newDriver() {
+    return new SubprocessDriver("claude", "ant", vi.fn());
+  }
+
+  it("sandbox + allowlist ⇒ enforces --permission-mode dontAsk + --allowed-tools and DROPS skip-permissions", async () => {
+    const driver = newDriver();
+    await finishRun(
+      driver.run(
+        makeInput({
+          providerOptions: {
+            sandbox: true,
+            allowedTools: ["getDiagnostics", "getGitStatus"],
+          },
+        }),
+      ),
+    );
+    const args = spawnMock.mock.calls[0]![1] as string[];
+
+    expect(args).toContain("--permission-mode");
+    expect(args[args.indexOf("--permission-mode") + 1]).toBe("dontAsk");
+    expect(args).toContain("--allowed-tools");
+    // Variadic: one flag, both values follow it.
+    expect(valuesAfter(args, "--allowed-tools")).toEqual(["getDiagnostics"]);
+    const flagIdx = args.indexOf("--allowed-tools");
+    expect(args.slice(flagIdx + 1, flagIdx + 3)).toEqual([
+      "getDiagnostics",
+      "getGitStatus",
+    ]);
+    expect(args).not.toContain("--dangerously-skip-permissions");
+  });
+
+  it("sandbox off (no providerOptions) ⇒ byte-identical default: skip-permissions, no sandbox flags", async () => {
+    const driver = newDriver();
+    await finishRun(driver.run(makeInput()));
+    const args = spawnMock.mock.calls[0]![1] as string[];
+
+    expect(args).toContain("--dangerously-skip-permissions");
+    expect(args).not.toContain("--allowed-tools");
+    expect(args).not.toContain("--permission-mode");
+    expect(args).not.toContain("--disallowed-tools");
+  });
+
+  it("sandbox: true but EMPTY allowlist ⇒ falls back to skip-permissions (sandboxActive guard requires non-empty)", async () => {
+    const driver = newDriver();
+    await finishRun(
+      driver.run(
+        makeInput({ providerOptions: { sandbox: true, allowedTools: [] } }),
+      ),
+    );
+    const args = spawnMock.mock.calls[0]![1] as string[];
+
+    expect(args).toContain("--dangerously-skip-permissions");
+    expect(args).not.toContain("--allowed-tools");
+    expect(args).not.toContain("--permission-mode");
+  });
+
+  it("disallowedTools applies in DEFAULT mode (alongside skip-permissions)", async () => {
+    const driver = newDriver();
+    await finishRun(
+      driver.run(
+        makeInput({ providerOptions: { disallowedTools: ["runCommand"] } }),
+      ),
+    );
+    const args = spawnMock.mock.calls[0]![1] as string[];
+
+    expect(args).toContain("--dangerously-skip-permissions");
+    expect(args).toContain("--disallowed-tools");
+    expect(valuesAfter(args, "--disallowed-tools")).toEqual(["runCommand"]);
+  });
+
+  it("disallowedTools applies UNDER sandbox (with allowed-tools, no skip-permissions)", async () => {
+    const driver = newDriver();
+    await finishRun(
+      driver.run(
+        makeInput({
+          providerOptions: {
+            sandbox: true,
+            allowedTools: ["getGitStatus"],
+            disallowedTools: ["runCommand"],
+          },
+        }),
+      ),
+    );
+    const args = spawnMock.mock.calls[0]![1] as string[];
+
+    expect(args).toContain("--permission-mode");
+    expect(args[args.indexOf("--permission-mode") + 1]).toBe("dontAsk");
+    expect(valuesAfter(args, "--allowed-tools")).toEqual(["getGitStatus"]);
+    expect(valuesAfter(args, "--disallowed-tools")).toEqual(["runCommand"]);
+    expect(args).not.toContain("--dangerously-skip-permissions");
+  });
+
+  it("drops leading-dash tool values (argv-injection guard) in allowlist and denylist", async () => {
+    const driver = newDriver();
+    await finishRun(
+      driver.run(
+        makeInput({
+          providerOptions: {
+            sandbox: true,
+            allowedTools: ["--evil", "getDiagnostics"],
+            disallowedTools: ["-x", "runCommand"],
+          },
+        }),
+      ),
+    );
+    const args = spawnMock.mock.calls[0]![1] as string[];
+
+    expect(args).not.toContain("--evil");
+    expect(args).not.toContain("-x");
+    expect(valuesAfter(args, "--allowed-tools")).toEqual(["getDiagnostics"]);
+    expect(valuesAfter(args, "--disallowed-tools")).toEqual(["runCommand"]);
+  });
+
+  it("sandbox where every allowed tool is leading-dash ⇒ FILTERED list empty ⇒ falls back to skip-permissions", async () => {
+    const driver = newDriver();
+    await finishRun(
+      driver.run(
+        makeInput({
+          providerOptions: { sandbox: true, allowedTools: ["--a", "--b"] },
+        }),
+      ),
+    );
+    const args = spawnMock.mock.calls[0]![1] as string[];
+
+    // The branch keys off the FILTERED allowlist being non-empty (argv-injection
+    // facts): all values are leading-dash → filtered list empty → not sandbox-
+    // active → default skip-permissions path, no allowlist flag/values leak.
+    expect(args).not.toContain("--a");
+    expect(args).not.toContain("--b");
+    expect(args).not.toContain("--allowed-tools");
+    expect(args).not.toContain("--permission-mode");
+    expect(args).toContain("--dangerously-skip-permissions");
+  });
+});

--- a/src/drivers/claude/subprocess.ts
+++ b/src/drivers/claude/subprocess.ts
@@ -133,6 +133,24 @@ export class SubprocessDriver implements ProviderDriver {
     const mcpAccess = opts.mcpAccess === true;
     const mcp = mcpAccess ? this.bridgeMcp?.() : undefined;
 
+    // P0-5 opt-in tool sandbox. Filter argv-injection-confusable values up front
+    // (leading `-` could be misread as a flag by the child's parser), then key
+    // the sandbox branch off the FILTERED allowlist being non-empty.
+    const sandbox = opts.sandbox === true;
+    const allowedTools = (
+      Array.isArray(opts.allowedTools) ? (opts.allowedTools as string[]) : []
+    ).filter(
+      (t) => typeof t === "string" && t.length > 0 && !t.startsWith("-"),
+    );
+    const disallowedTools = (
+      Array.isArray(opts.disallowedTools)
+        ? (opts.disallowedTools as string[])
+        : []
+    ).filter(
+      (t) => typeof t === "string" && t.length > 0 && !t.startsWith("-"),
+    );
+    const sandboxActive = sandbox && allowedTools.length > 0;
+
     const args = [
       "-p",
       input.prompt,
@@ -173,8 +191,23 @@ export class SubprocessDriver implements ProviderDriver {
     }
     if (maxBudgetUsd !== undefined)
       args.push("--max-budget-usd", String(maxBudgetUsd));
-    // Always skip permissions: headless subprocesses can't respond to prompts.
-    args.push("--dangerously-skip-permissions");
+    if (sandboxActive) {
+      // Sandbox: enforce the allowlist. --dangerously-skip-permissions VOIDS
+      // --allowed-tools (per CC docs), so they are mutually exclusive — drop
+      // skip-permissions and run in dontAsk mode (no interactive prompt, but
+      // permission rules are honored). --allowed-tools is variadic: push the
+      // flag once followed by all (already argv-filtered) tool values.
+      args.push("--permission-mode", "dontAsk");
+      args.push("--allowed-tools", ...allowedTools);
+    } else {
+      // Default (no sandbox): headless subprocesses can't respond to prompts.
+      args.push("--dangerously-skip-permissions");
+    }
+    // Deny rules apply in ANY mode — even under --dangerously-skip-permissions.
+    // --disallowed-tools is variadic: one flag, all (filtered) values.
+    if (disallowedTools.length > 0) {
+      args.push("--disallowed-tools", ...disallowedTools);
+    }
     for (const f of input.contextFiles ?? []) {
       if (typeof f === "string" && f.length > 0 && !f.startsWith("-")) {
         args.push("--add-dir", f);

--- a/src/recipeOrchestration.ts
+++ b/src/recipeOrchestration.ts
@@ -358,7 +358,12 @@ export class RecipeOrchestration {
         const orch = this.deps.getOrchestrator();
         const claudeCodeFn = async (
           prompt: string,
-          callOpts?: { mcpAccess?: boolean },
+          callOpts?: {
+            mcpAccess?: boolean;
+            sandbox?: boolean;
+            allowedTools?: string[];
+            disallowedTools?: string[];
+          },
         ): Promise<string> => {
           if (!orch) return "";
           const task = await orch.runAndWait({
@@ -367,6 +372,15 @@ export class RecipeOrchestration {
             timeoutMs: 1_800_000,
             ...(callOpts?.mcpAccess !== undefined && {
               mcpAccess: callOpts.mcpAccess,
+            }),
+            ...(callOpts?.sandbox !== undefined && {
+              sandbox: callOpts.sandbox,
+            }),
+            ...(callOpts?.allowedTools !== undefined && {
+              allowedTools: callOpts.allowedTools,
+            }),
+            ...(callOpts?.disallowedTools !== undefined && {
+              disallowedTools: callOpts.disallowedTools,
             }),
           });
           return task.output ?? task.errorMessage ?? "";
@@ -956,7 +970,12 @@ export class RecipeOrchestration {
     );
     const claudeCodeFn = async (
       prompt: string,
-      callOpts?: { mcpAccess?: boolean },
+      callOpts?: {
+        mcpAccess?: boolean;
+        sandbox?: boolean;
+        allowedTools?: string[];
+        disallowedTools?: string[];
+      },
     ): Promise<string> => {
       const task = await orch.runAndWait({
         prompt,
@@ -964,6 +983,13 @@ export class RecipeOrchestration {
         timeoutMs: 1_800_000,
         ...(callOpts?.mcpAccess !== undefined && {
           mcpAccess: callOpts.mcpAccess,
+        }),
+        ...(callOpts?.sandbox !== undefined && { sandbox: callOpts.sandbox }),
+        ...(callOpts?.allowedTools !== undefined && {
+          allowedTools: callOpts.allowedTools,
+        }),
+        ...(callOpts?.disallowedTools !== undefined && {
+          disallowedTools: callOpts.disallowedTools,
         }),
       });
       return task.output ?? task.errorMessage ?? "";

--- a/src/recipes/__tests__/schemaGenerator.sandbox.test.ts
+++ b/src/recipes/__tests__/schemaGenerator.sandbox.test.ts
@@ -1,0 +1,113 @@
+import { Ajv } from "ajv";
+import { beforeEach, describe, expect, it } from "vitest";
+import { generateSchemaSet } from "../schemaGenerator.js";
+import { clearRegistry, registerTool } from "../toolRegistry.js";
+
+/** Register a trivial tool so the namespace machinery has something to chew on. */
+function registerEcho(): void {
+  registerTool({
+    id: "test.echo",
+    namespace: "test",
+    description: "Echo test",
+    paramsSchema: { type: "object", properties: {} },
+    outputSchema: { type: "string" },
+    riskDefault: "low",
+    isWrite: false,
+    execute: async () => "ok",
+  });
+}
+
+function recipeWithAgent(agent: Record<string, unknown>) {
+  return {
+    name: "sandbox-recipe",
+    trigger: { type: "manual" },
+    steps: [{ agent }],
+  };
+}
+
+describe("schemaGenerator — agent step sandbox fields (P0-5)", () => {
+  beforeEach(() => {
+    clearRegistry();
+  });
+
+  it("exposes sandbox / tools / disallowedTools on the agent step config schema", () => {
+    registerEcho();
+    const schemas = generateSchemaSet();
+    const recipeSchema = schemas.recipe as {
+      properties?: {
+        steps?: { items?: { oneOf?: Array<Record<string, unknown>> } };
+      };
+    };
+    const agentStep = recipeSchema.properties?.steps?.items?.oneOf?.find(
+      (entry) =>
+        "properties" in entry &&
+        "agent" in ((entry.properties as Record<string, unknown>) ?? {}),
+    ) as
+      | { properties?: { agent?: { properties?: Record<string, unknown> } } }
+      | undefined;
+    const agentProps = agentStep?.properties?.agent?.properties;
+    expect(agentProps).toBeDefined();
+    expect(agentProps?.sandbox).toMatchObject({ type: "boolean" });
+    expect(agentProps?.tools).toMatchObject({
+      type: "array",
+      items: { type: "string" },
+    });
+    expect(agentProps?.disallowedTools).toMatchObject({
+      type: "array",
+      items: { type: "string" },
+    });
+  });
+
+  it("validates a recipe that opts into the sandbox", () => {
+    registerEcho();
+    const schemas = generateSchemaSet();
+    const ajv = new Ajv({ allErrors: true, strict: false });
+    // The recipe schema $refs per-namespace tool schemas (./tools/<ns>.json).
+    // Register them so AJV can resolve those refs at compile time.
+    for (const nsSchema of Object.values(schemas.namespaces)) {
+      ajv.addSchema(nsSchema as object);
+    }
+    const validate = ajv.compile(schemas.recipe as object);
+    const ok = validate(
+      recipeWithAgent({
+        prompt: "do the thing",
+        sandbox: true,
+        tools: ["getDiagnostics", "getGitStatus"],
+        disallowedTools: ["runCommand"],
+      }),
+    );
+    expect(ok).toBe(true);
+  });
+
+  it("rejects a non-boolean sandbox value", () => {
+    registerEcho();
+    const schemas = generateSchemaSet();
+    const ajv = new Ajv({ allErrors: true, strict: false });
+    // The recipe schema $refs per-namespace tool schemas (./tools/<ns>.json).
+    // Register them so AJV can resolve those refs at compile time.
+    for (const nsSchema of Object.values(schemas.namespaces)) {
+      ajv.addSchema(nsSchema as object);
+    }
+    const validate = ajv.compile(schemas.recipe as object);
+    const ok = validate(
+      recipeWithAgent({ prompt: "do the thing", sandbox: "yes" }),
+    );
+    expect(ok).toBe(false);
+  });
+
+  it("rejects a non-array tools value", () => {
+    registerEcho();
+    const schemas = generateSchemaSet();
+    const ajv = new Ajv({ allErrors: true, strict: false });
+    // The recipe schema $refs per-namespace tool schemas (./tools/<ns>.json).
+    // Register them so AJV can resolve those refs at compile time.
+    for (const nsSchema of Object.values(schemas.namespaces)) {
+      ajv.addSchema(nsSchema as object);
+    }
+    const validate = ajv.compile(schemas.recipe as object);
+    const ok = validate(
+      recipeWithAgent({ prompt: "do the thing", tools: "getDiagnostics" }),
+    );
+    expect(ok).toBe(false);
+  });
+});

--- a/src/recipes/__tests__/yamlRunner.test.ts
+++ b/src/recipes/__tests__/yamlRunner.test.ts
@@ -1603,6 +1603,63 @@ describe("runYamlRecipe — agent step with driver: claude-code", () => {
     expect(result.context.summary).toBe("cli response");
   });
 
+  // P0-5 — runner seam: the opt-in tool sandbox fields must thread from the
+  // YAML agent step through the flat runner into the claudeCodeFn opts (HOPs
+  // 0b/1/2). Proven without spawning a subprocess by capturing the opts arg.
+  it("threads sandbox/tools/disallowedTools through the FLAT runner into claudeCodeFn opts", async () => {
+    const seen: Array<{ prompt: string; opts: unknown }> = [];
+    const claudeCodeFn = vi.fn(async (prompt: string, opts?: unknown) => {
+      seen.push({ prompt, opts });
+      return "ok";
+    });
+    const recipe = makeRecipe({
+      steps: [
+        {
+          agent: {
+            prompt: "Do the thing",
+            driver: "claude-code",
+            sandbox: true,
+            tools: ["getDiagnostics"],
+            disallowedTools: ["runCommand"],
+            into: "result",
+          },
+        },
+      ],
+    });
+    await runYamlRecipe(recipe, { ...noop(), claudeCodeFn }, {});
+    expect(claudeCodeFn).toHaveBeenCalledTimes(1);
+    expect(seen[0]!.opts).toEqual({
+      sandbox: true,
+      allowedTools: ["getDiagnostics"],
+      disallowedTools: ["runCommand"],
+    });
+  });
+
+  // P0-5 + parity fix (Edit 8): the chained runner closure previously dropped
+  // its 4th arg (mcpAccess) because AgentExecutor was 3-arg. Now it forwards an
+  // opts object — proving both the sandbox fields AND mcpAccess thread through.
+  it("threads sandbox/tools/disallowedTools (and mcpAccess) through the CHAINED executeAgent into claudeCodeFn opts", async () => {
+    const seen: Array<{ prompt: string; opts: unknown }> = [];
+    const claudeCodeFn = vi.fn(async (prompt: string, opts?: unknown) => {
+      seen.push({ prompt, opts });
+      return "cc result";
+    });
+    const deps = buildChainedDeps({ ...noop(), testMode: true }, claudeCodeFn);
+    await deps.executeAgent("review this", undefined, "claude-code", {
+      mcpAccess: true,
+      sandbox: true,
+      allowedTools: ["getGitStatus"],
+      disallowedTools: ["gitPush"],
+    });
+    expect(claudeCodeFn).toHaveBeenCalledTimes(1);
+    expect(seen[0]!.opts).toEqual({
+      mcpAccess: true,
+      sandbox: true,
+      allowedTools: ["getGitStatus"],
+      disallowedTools: ["gitPush"],
+    });
+  });
+
   it("stores claudeCodeFn output in context key", async () => {
     const recipe = makeRecipe({
       steps: [

--- a/src/recipes/agentExecutor.ts
+++ b/src/recipes/agentExecutor.ts
@@ -54,7 +54,12 @@ export interface AgentExecutorDeps {
   ) => Promise<AgentResult>;
   claudeCliFn: (
     prompt: string,
-    opts?: { mcpAccess?: boolean },
+    opts?: {
+      mcpAccess?: boolean;
+      sandbox?: boolean;
+      allowedTools?: string[];
+      disallowedTools?: string[];
+    },
   ) => Promise<AgentResult>;
   localFn: (prompt: string, model: string) => Promise<AgentResult>;
   /** Returns true when the `claude` CLI is available on PATH. */
@@ -74,6 +79,12 @@ export interface AgentExecutorInput {
    * Ignored by API drivers — they reach the bridge through other means.
    */
   mcpAccess?: boolean;
+  /** Opt-in tool sandbox — enforced argv on the subprocess path only. */
+  sandbox?: boolean;
+  /** Tool allowlist enforced via --allowed-tools when sandbox is true. */
+  allowedTools?: string[];
+  /** Deny rules via --disallowed-tools (any mode). */
+  disallowedTools?: string[];
   /**
    * Opaque per-call driver options forwarded to the provider driver (e.g.
    * `{ responseFormat: { type: "json_object" } }` for constrained decoding).
@@ -94,8 +105,28 @@ export async function executeAgent(
   input: AgentExecutorInput,
   deps: AgentExecutorDeps,
 ): Promise<AgentResult> {
-  const { prompt, driver, model, mcpAccess, providerOptions } = input;
-  const cliOpts = mcpAccess !== undefined ? { mcpAccess } : undefined;
+  const {
+    prompt,
+    driver,
+    model,
+    mcpAccess,
+    sandbox,
+    allowedTools,
+    disallowedTools,
+    providerOptions,
+  } = input;
+  const cliOpts =
+    mcpAccess !== undefined ||
+    sandbox !== undefined ||
+    allowedTools !== undefined ||
+    disallowedTools !== undefined
+      ? {
+          ...(mcpAccess !== undefined && { mcpAccess }),
+          ...(sandbox !== undefined && { sandbox }),
+          ...(allowedTools !== undefined && { allowedTools }),
+          ...(disallowedTools !== undefined && { disallowedTools }),
+        }
+      : undefined;
 
   // Stamp the driver that ACTUALLY ran onto the result. This is the single
   // place driver auto-detection is resolved, so it is the only place that

--- a/src/recipes/chainedRunner.ts
+++ b/src/recipes/chainedRunner.ts
@@ -60,6 +60,12 @@ export interface ChainedStep {
     /** Cost-aware routing fallbacks (Phase 4) — mirrors the flat path. */
     downshift?: RouteCandidate[];
     mcpAccess?: boolean;
+    /** Tool allowlist enforced via --allowed-tools when `sandbox` is true. */
+    tools?: string[];
+    /** Opt-in tool sandbox — drop --dangerously-skip-permissions, enforce allowlist. */
+    sandbox?: boolean;
+    /** Deny rules via --disallowed-tools in any mode. */
+    disallowedTools?: string[];
   };
   recipe?: NestedRecipeConfig["recipe"];
   chain?: NestedRecipeConfig["recipe"];
@@ -211,6 +217,12 @@ export type AgentExecutor = (
   prompt: string,
   model?: string,
   driver?: string,
+  opts?: {
+    mcpAccess?: boolean;
+    sandbox?: boolean;
+    allowedTools?: string[];
+    disallowedTools?: string[];
+  },
 ) => Promise<string | AgentResult>;
 
 /** Normalise the union AgentExecutor return into an AgentResult. */
@@ -767,7 +779,20 @@ export async function executeChainedStep(
 
       const agentReturn = toChainedAgentResult(
         await raceStepTimeout(
-          deps.executeAgent(prompt, dispatchModel, dispatchDriver),
+          deps.executeAgent(prompt, dispatchModel, dispatchDriver, {
+            ...(step.agent.mcpAccess !== undefined && {
+              mcpAccess: step.agent.mcpAccess,
+            }),
+            ...(step.agent.sandbox !== undefined && {
+              sandbox: step.agent.sandbox,
+            }),
+            ...(step.agent.tools !== undefined && {
+              allowedTools: step.agent.tools,
+            }),
+            ...(step.agent.disallowedTools !== undefined && {
+              disallowedTools: step.agent.disallowedTools,
+            }),
+          }),
           step.timeout_ms,
           step.id,
           options.signal,

--- a/src/recipes/schema.ts
+++ b/src/recipes/schema.ts
@@ -93,7 +93,12 @@ export interface AgentStep {
   id: string;
   agent: true;
   prompt: string;
+  /** Allowlist enforced by --allowed-tools when `sandbox` is true. */
   tools?: string[];
+  /** Opt-in tool sandbox: enforce `tools` allowlist via claude -p permission mode. */
+  sandbox?: boolean;
+  /** Deny rules applied via --disallowed-tools in any permission mode. */
+  disallowedTools?: string[];
   risk?: RiskTier;
   output?: string;
 }

--- a/src/recipes/schemaGenerator.ts
+++ b/src/recipes/schemaGenerator.ts
@@ -498,6 +498,23 @@ function generateRecipeSchema(
         description:
           "When true, grants the agent step access to MCP tools registered on the bridge. Defaults to false for subprocess driver steps.",
       },
+      tools: {
+        type: "array",
+        items: { type: "string" },
+        description:
+          "Tool allowlist. When `sandbox` is true, enforced via --allowed-tools on the spawned claude -p.",
+      },
+      sandbox: {
+        type: "boolean",
+        description:
+          "Opt-in tool sandbox: enforce the `tools` allowlist by running claude -p with --permission-mode dontAsk + --allowed-tools (drops --dangerously-skip-permissions). Default off. Pure pass-through with mcpAccess: when both are set, MCP tool names must be listed in `tools` or they will be blocked (no auto-injection).",
+      },
+      disallowedTools: {
+        type: "array",
+        items: { type: "string" },
+        description:
+          "Deny rules applied via --disallowed-tools regardless of sandbox mode.",
+      },
       kind: {
         type: "string",
         enum: ["judge"],

--- a/src/recipes/yamlRunner.ts
+++ b/src/recipes/yamlRunner.ts
@@ -129,6 +129,12 @@ export interface YamlStep {
      * trace queries, etc.).
      */
     mcpAccess?: boolean;
+    /** Tool allowlist enforced via --allowed-tools when `sandbox` is true. */
+    tools?: string[];
+    /** Opt-in tool sandbox — drop --dangerously-skip-permissions, enforce allowlist. */
+    sandbox?: boolean;
+    /** Deny rules via --disallowed-tools in any mode. */
+    disallowedTools?: string[];
     /**
      * PR3a — judge step (cold-eyes review). When `kind: "judge"` the
      * runner appends a structured-verdict instruction to the prompt and
@@ -565,7 +571,12 @@ export interface RunnerDeps {
   /** Optional Claude Code CLI caller for agent steps with driver: claude-code. */
   claudeCodeFn?: (
     prompt: string,
-    opts?: { mcpAccess?: boolean },
+    opts?: {
+      mcpAccess?: boolean;
+      sandbox?: boolean;
+      allowedTools?: string[];
+      disallowedTools?: string[];
+    },
   ) => Promise<string | AgentResult>;
   /** Optional local LLM caller (Ollama / LM Studio) for agent steps with driver: local or model: local. */
   localFn?: (prompt: string, model: string) => Promise<string | AgentResult>;
@@ -1334,6 +1345,13 @@ export async function runYamlRecipe(
     mcpAccess: boolean | undefined,
     downshift?: RouteCandidate[],
     providerOptions?: Record<string, unknown>,
+    // P0-5: carry the reviewed/judge step's opt-in tool sandbox into refine-loop
+    // re-runs so a sandboxed step STAYS sandboxed across revisions/re-judges.
+    sandboxOpts?: {
+      sandbox?: boolean;
+      tools?: string[];
+      disallowedTools?: string[];
+    },
   ): Promise<{ value: unknown; ok: boolean }> => {
     // Phase 4: route revisions too, so a downshift on the reviewed step also
     // applies to its refine-loop re-runs (no-op when downshift is absent).
@@ -1349,6 +1367,15 @@ export async function runYamlRecipe(
         driver: routed.driver === "api" ? "anthropic" : routed.driver,
         model: routed.model,
         ...(mcpAccess !== undefined && { mcpAccess }),
+        ...(sandboxOpts?.sandbox !== undefined && {
+          sandbox: sandboxOpts.sandbox,
+        }),
+        ...(sandboxOpts?.tools !== undefined && {
+          allowedTools: sandboxOpts.tools,
+        }),
+        ...(sandboxOpts?.disallowedTools !== undefined && {
+          disallowedTools: sandboxOpts.disallowedTools,
+        }),
         ...(providerOptions && { providerOptions }),
       },
       buildAgentExecutorDeps(stepDeps, deps),
@@ -1466,6 +1493,19 @@ export async function runYamlRecipe(
         escalateTo?.model ?? reviewedAgent.model,
         reviewedAgent.mcpAccess,
         escalateTo ? undefined : reviewedAgent.downshift,
+        undefined,
+        // P0-5: the revision re-runs the REVIEWED step → keep its sandbox.
+        {
+          ...(reviewedAgent.sandbox !== undefined && {
+            sandbox: reviewedAgent.sandbox,
+          }),
+          ...(reviewedAgent.tools !== undefined && {
+            tools: reviewedAgent.tools,
+          }),
+          ...(reviewedAgent.disallowedTools !== undefined && {
+            disallowedTools: reviewedAgent.disallowedTools,
+          }),
+        },
       );
       if (!revised.ok) {
         // A failed / empty revision can't be re-judged — stop and treat the
@@ -1513,6 +1553,14 @@ export async function runYamlRecipe(
         agentCfg.downshift,
         // Re-judge is a judge call → enforce JSON on supporting drivers.
         { responseFormat: { type: "json_object" } },
+        // P0-5: the re-judge re-runs the JUDGE step → keep its sandbox.
+        {
+          ...(agentCfg.sandbox !== undefined && { sandbox: agentCfg.sandbox }),
+          ...(agentCfg.tools !== undefined && { tools: agentCfg.tools }),
+          ...(agentCfg.disallowedTools !== undefined && {
+            disallowedTools: agentCfg.disallowedTools,
+          }),
+        },
       );
       if (!judged.ok) {
         // Audit 2026-06-03 (MEDIUM #17): a failed / silent-fail / empty
@@ -1792,6 +1840,18 @@ export async function runYamlRecipe(
               model: routed.model,
               ...(agentCfg.mcpAccess !== undefined && {
                 mcpAccess: agentCfg.mcpAccess,
+              }),
+              // P0-5 opt-in tool sandbox: thread sandbox + allow/deny lists onto
+              // the executor input so the subprocess driver can enforce them via
+              // --allowed-tools / --disallowed-tools / --permission-mode dontAsk.
+              ...(agentCfg.sandbox !== undefined && {
+                sandbox: agentCfg.sandbox,
+              }),
+              ...(agentCfg.tools !== undefined && {
+                allowedTools: agentCfg.tools,
+              }),
+              ...(agentCfg.disallowedTools !== undefined && {
+                disallowedTools: agentCfg.disallowedTools,
               }),
               // Constrained decoding: enforce a pure-JSON verdict on judge steps
               // (OpenAI-compatible drivers honor it; others ignore it). Pairs
@@ -2746,7 +2806,12 @@ function buildAgentExecutorDeps(
   runnerDeps: RunnerDeps,
   claudeCodeFnOverride?: (
     prompt: string,
-    opts?: { mcpAccess?: boolean },
+    opts?: {
+      mcpAccess?: boolean;
+      sandbox?: boolean;
+      allowedTools?: string[];
+      disallowedTools?: string[];
+    },
   ) => Promise<string | AgentResult>,
 ): AgentExecutorDeps {
   const claudeCliFn = claudeCodeFnOverride ?? stepDeps.claudeCodeFn;
@@ -2822,7 +2887,12 @@ export function resolveClaudeBinary(): string {
 
 export function defaultClaudeCodeFn(
   prompt: string,
-  opts?: { mcpAccess?: boolean },
+  opts?: {
+    mcpAccess?: boolean;
+    sandbox?: boolean;
+    allowedTools?: string[];
+    disallowedTools?: string[];
+  },
 ): Promise<string> {
   const binary = resolveClaudeBinary();
   // Resolve a workspace cwd so the spawned `claude -p` doesn't inherit the
@@ -2846,33 +2916,49 @@ export function defaultClaudeCodeFn(
       "[agent step failed: recipe_mcp_unsupported — defaultClaudeCodeFn does not support mcpAccess:true; route via SubprocessDriver or unset the mcpAccess flag on this step]",
     );
   }
+  // P0-5 opt-in tool sandbox on the `recipe run --local` / non-bridge path.
+  // Without this the sandbox would be silently ignored here (a one-path gap);
+  // mirror the SubprocessDriver argv rule (§3): filter argv-injection values,
+  // run in --permission-mode dontAsk + --allowed-tools when sandbox is active,
+  // and always apply --disallowed-tools regardless of mode.
+  const sandboxAllowed = (
+    Array.isArray(opts?.allowedTools) ? opts.allowedTools : []
+  ).filter((t) => typeof t === "string" && t.length > 0 && !t.startsWith("-"));
+  const sandboxDenied = (
+    Array.isArray(opts?.disallowedTools) ? opts.disallowedTools : []
+  ).filter((t) => typeof t === "string" && t.length > 0 && !t.startsWith("-"));
+  const localArgs = [
+    "-p",
+    prompt,
+    // --strict-mcp-config: never load ~/.claude.json or .mcp.json. Recipes
+    // are sandboxed by default (mcpAccess defaults to false above). This
+    // also prevents accidental session attachment when the parent process
+    // had a bridge MCP entry in ~/.claude.json.
+    "--strict-mcp-config",
+    "--system-prompt",
+    "You are a helpful assistant processing a recipe task. Use ONLY the data explicitly provided in the user message — treat it as ground truth. Do not call tools to look up git history, emails, or any other information; all necessary data is already included.",
+    "--no-session-persistence",
+  ];
+  if (opts?.sandbox === true && sandboxAllowed.length > 0) {
+    localArgs.push("--permission-mode", "dontAsk");
+    localArgs.push("--allowed-tools", ...sandboxAllowed);
+  }
+  // Deny rules apply in ANY mode.
+  if (sandboxDenied.length > 0) {
+    localArgs.push("--disallowed-tools", ...sandboxDenied);
+  }
   try {
-    const result = spawnSync(
-      binary,
-      [
-        "-p",
-        prompt,
-        // --strict-mcp-config: never load ~/.claude.json or .mcp.json. Recipes
-        // are sandboxed by default (mcpAccess defaults to false above). This
-        // also prevents accidental session attachment when the parent process
-        // had a bridge MCP entry in ~/.claude.json.
-        "--strict-mcp-config",
-        "--system-prompt",
-        "You are a helpful assistant processing a recipe task. Use ONLY the data explicitly provided in the user message — treat it as ground truth. Do not call tools to look up git history, emails, or any other information; all necessary data is already included.",
-        "--no-session-persistence",
-      ],
-      {
-        cwd: workspace.path,
-        // sanitizeEnv strips CLAUDECODE / CLAUDE_CODE_* / MCP_* from the
-        // child so the spawn doesn't re-authenticate as, or nest under,
-        // the parent Claude Code session. Mirrors SubprocessDriver.run
-        // hygiene. Preserves CLAUDE_CODE_OAUTH_TOKEN (subscription auth).
-        env: sanitizeEnv(process.env),
-        encoding: "utf-8",
-        timeout: 600_000,
-        maxBuffer: 10 * 1024 * 1024,
-      },
-    );
+    const result = spawnSync(binary, localArgs, {
+      cwd: workspace.path,
+      // sanitizeEnv strips CLAUDECODE / CLAUDE_CODE_* / MCP_* from the
+      // child so the spawn doesn't re-authenticate as, or nest under,
+      // the parent Claude Code session. Mirrors SubprocessDriver.run
+      // hygiene. Preserves CLAUDE_CODE_OAUTH_TOKEN (subscription auth).
+      env: sanitizeEnv(process.env),
+      encoding: "utf-8",
+      timeout: 600_000,
+      maxBuffer: 10 * 1024 * 1024,
+    });
     if (result.error) {
       // Surface the configured binary path in the error so users diagnosing
       // ENOENT can see whether resolveClaudeBinary picked up their override.
@@ -3216,7 +3302,12 @@ export function buildChainedDeps(
   runnerDeps: RunnerDeps,
   claudeCodeFnOverride?: (
     prompt: string,
-    opts?: { mcpAccess?: boolean },
+    opts?: {
+      mcpAccess?: boolean;
+      sandbox?: boolean;
+      allowedTools?: string[];
+      disallowedTools?: string[];
+    },
   ) => Promise<string | AgentResult>,
 ): import("./chainedRunner.js").ExecutionDeps {
   const stepDeps = resolveStepDeps(runnerDeps);
@@ -3279,19 +3370,36 @@ export function buildChainedDeps(
     prompt: string,
     model?: string,
     driver?: string,
-    mcpAccess?: boolean,
+    opts?: {
+      mcpAccess?: boolean;
+      sandbox?: boolean;
+      allowedTools?: string[];
+      disallowedTools?: string[];
+    },
   ): Promise<AgentResult> => {
     // Surface the FULL AgentResult (text + usage + servedBy) so the chained
     // runner can reconcile real spend against the run budget — alignment with
     // the flat path, which already reads `.usage`. (Previously this closure
     // discarded everything but `.text`, leaving the chained path's budget
     // unenforced — the S1 SECURITY finding.)
+    //
+    // P0-5 + parity fix: the prior 4th param was `mcpAccess?: boolean`, but the
+    // AgentExecutor type was 3-arg and the chained call site passed only 3 args
+    // → chained recipes silently dropped mcpAccess (and would have dropped the
+    // new sandbox fields too). Threading an opts object closes both gaps.
     return _executeAgent(
       {
         prompt,
         model,
         driver: driver === "api" ? "anthropic" : driver,
-        ...(mcpAccess !== undefined && { mcpAccess }),
+        ...(opts?.mcpAccess !== undefined && { mcpAccess: opts.mcpAccess }),
+        ...(opts?.sandbox !== undefined && { sandbox: opts.sandbox }),
+        ...(opts?.allowedTools !== undefined && {
+          allowedTools: opts.allowedTools,
+        }),
+        ...(opts?.disallowedTools !== undefined && {
+          disallowedTools: opts.disallowedTools,
+        }),
       },
       buildAgentExecutorDeps(stepDeps, runnerDeps, claudeCodeFnOverride),
     );


### PR DESCRIPTION
## What
Makes recipe agent-step `tools:` real (opt-in). From the changelog audit, item **P0-5** (`docs/audit-bridge-changelog-2026-06-25.md`).

## Why
`tools:` was advisory-only: the subprocess driver always passed `--dangerously-skip-permissions`, which (per CC docs) **voids `--allowed-tools`**. So a recipe declaring `tools:[Read]` got zero enforcement.

## Changes (opt-in, backward-compatible)
- `AgentStep` gains **`sandbox?: boolean`** and **`disallowedTools?: string[]`** (allowlist = existing `tools`).
- When `sandbox: true` + non-empty `tools`, the spawned `claude -p` runs with `--permission-mode dontAsk --allowed-tools <list>` and **drops** `--dangerously-skip-permissions` (real enforcement). `disallowedTools` → `--disallowed-tools`, which applies in **any** mode (deny rules survive bypass).
- **Default (no sandbox) path is byte-identical** — existing recipes (starter-pack, `oolabs-daily-tweets`, `weekly-commit-report`, …) are unaffected.
- Threaded end-to-end via the `mcpAccess` template: schema + flat/chained runtime step types + JSON schema + `agentExecutor` + both runner dispatch paths + `ClaudeOrchestrator` EnqueueOpts/ClaudeTask/**PersistedTask (+ persist/reload spreads, so a sandbox survives a bridge restart)** → `providerOptions` → subprocess argv. The chained arity fix also closes a **pre-existing `mcpAccess` silent no-op** on the chained path. Applied to the `--local` (`defaultClaudeCodeFn`) path too. Deprecated `claudeDriver.ts` left untouched.

## Flag correctness
Verified against the installed `claude` 2.1.185: `--permission-mode` accepts `dontAsk`; `--allowed-tools`/`--disallowed-tools` are variadic (`<tools...>`) → one flag, filtered values. Each tool value is argv-injection-guarded (`!startsWith("-")`).

## Tests
`subprocess.sandbox.test.ts` (dontAsk+allowed-tools+no-skip when on; byte-identical when off; empty-allowlist fallback; disallowedTools in both modes; leading-dash injection guard) + `schemaGenerator.sandbox.test.ts` (validation) + `yamlRunner.test.ts` seam (opts thread through **flat AND chained**). tsc default + core ratchet + audit-test-fixtures + biome + vitest (323 in the affected suites) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
