### PR TITLE
feat(automation): wire on_file_save + on_test_run recipe triggers

### DIFF
--- a/src/recipes/__tests__/compiler.test.ts
+++ b/src/recipes/__tests__/compiler.test.ts
@@ -20,6 +20,7 @@ function unwrapToHook(program: ReturnType<typeof compileRecipe>): {
   hookType: string;
   prompt: string;
   patterns?: string[];
+  extras?: { kind: string; onFailureOnly?: boolean };
 } {
   // Walk: WithRateLimit → WithCooldown → (WithRetry?) → Hook
   let p = program;
@@ -31,6 +32,7 @@ function unwrapToHook(program: ReturnType<typeof compileRecipe>): {
     hookType: p.hookType,
     prompt: p.promptSource.kind === "inline" ? p.promptSource.prompt : "",
     patterns: p.patterns,
+    extras: p.extras as { kind: string; onFailureOnly?: boolean } | undefined,
   };
 }
 
@@ -100,6 +102,51 @@ describe("compileRecipe", () => {
       );
       expect(inner.hookType).toBe(c.expect);
     }
+  });
+
+  it("maps on_file_save → onFileSave (glob → patterns; absent → fire-all)", () => {
+    const withGlob = unwrapToHook(
+      compileRecipe({
+        ...BASE,
+        trigger: { type: "on_file_save", glob: "**/*.md" },
+      }),
+    );
+    expect(withGlob.hookType).toBe("onFileSave");
+    expect(withGlob.patterns).toEqual(["**/*.md"]);
+
+    const noGlob = unwrapToHook(
+      compileRecipe({ ...BASE, trigger: { type: "on_file_save" } }),
+    );
+    expect(noGlob.hookType).toBe("onFileSave");
+    expect(noGlob.patterns).toBeUndefined();
+  });
+
+  it("maps on_test_run filter → onTestRun / onTestPassAfterFailure", () => {
+    const any = unwrapToHook(
+      compileRecipe({ ...BASE, trigger: { type: "on_test_run" } }),
+    );
+    expect(any.hookType).toBe("onTestRun");
+    expect(any.extras?.kind).toBe("none");
+
+    const failure = unwrapToHook(
+      compileRecipe({
+        ...BASE,
+        trigger: { type: "on_test_run", filter: "failure" },
+      }),
+    );
+    expect(failure.hookType).toBe("onTestRun");
+    expect(failure.extras).toMatchObject({
+      kind: "testRun",
+      onFailureOnly: true,
+    });
+
+    const passAfterFail = unwrapToHook(
+      compileRecipe({
+        ...BASE,
+        trigger: { type: "on_test_run", filter: "pass-after-fail" },
+      }),
+    );
+    expect(passAfterFail.hookType).toBe("onTestPassAfterFailure");
   });
 
   it("rejects webhook trigger with clear message", () => {

--- a/src/recipes/__tests__/triggerDispatchCompleteness.test.ts
+++ b/src/recipes/__tests__/triggerDispatchCompleteness.test.ts
@@ -39,18 +39,17 @@ const TRIGGER_DISPATCH: Record<TriggerType, DispatchPath> = {
   webhook: "webhook",
   manual: "cli",
   chained: "chained-runner",
-  // No compiler `mapTrigger` case yet — the bridge fires onFileSave/onTestRun,
-  // but compileRecipe() can't target them, so these recipes don't auto-fire.
-  // Flip to "automation-hook" once the compiler maps them (the runtime check
-  // then enforces collection end-to-end). Tracked follow-up to PR #1016.
-  on_file_save: "UNWIRED",
-  on_test_run: "UNWIRED",
+  // Wired: compileRecipe maps on_file_save→onFileSave and on_test_run→
+  // onTestRun / onTestPassAfterFailure (by filter). The runtime check below
+  // enforces that they are actually collected end-to-end.
+  on_file_save: "automation-hook",
+  on_test_run: "automation-hook",
 };
 
-const KNOWN_UNWIRED: ReadonlySet<TriggerType> = new Set<TriggerType>([
-  "on_file_save",
-  "on_test_run",
-]);
+// Every TriggerType now has a live dispatch path. If a new trigger lands
+// unwired, classify it "UNWIRED" here AND add it to this set in the same
+// change — the drift check below then keeps the gap explicit.
+const KNOWN_UNWIRED: ReadonlySet<TriggerType> = new Set<TriggerType>([]);
 
 const NAME: Record<TriggerType, string> = {
   webhook: "g-webhook",
@@ -127,10 +126,15 @@ describe("recipe trigger dispatch completeness", () => {
     }
   });
 
-  it("the automation-hook set is exactly file_watch + git_hook", () => {
+  it("the automation-hook set matches the compiler's event triggers", () => {
     const hookTriggers = ALL_TRIGGERS.filter(
       (t) => TRIGGER_DISPATCH[t] === "automation-hook",
     ).sort();
-    expect(hookTriggers).toEqual(["file_watch", "git_hook"]);
+    expect(hookTriggers).toEqual([
+      "file_watch",
+      "git_hook",
+      "on_file_save",
+      "on_test_run",
+    ]);
   });
 });

--- a/src/recipes/compiler.ts
+++ b/src/recipes/compiler.ts
@@ -1,5 +1,6 @@
 import type {
   AutomationProgram,
+  HookExtras,
   HookNode,
   HookType,
 } from "../fp/automationProgram.js";
@@ -117,7 +118,10 @@ function bucketForRisk(
 }
 
 export function compileRecipe(recipe: Recipe): AutomationProgram {
-  const { hookType, patterns } = mapTrigger(recipe.trigger, recipe.name);
+  const { hookType, patterns, extras } = mapTrigger(
+    recipe.trigger,
+    recipe.name,
+  );
   const prompt = buildPrompt(recipe);
 
   let program: AutomationProgram = hook({
@@ -125,7 +129,7 @@ export function compileRecipe(recipe: Recipe): AutomationProgram {
     enabled: true,
     patterns,
     promptSource: { kind: "inline", prompt },
-    extras: { kind: "none" },
+    extras: extras ?? { kind: "none" },
   } satisfies Omit<HookNode, "_tag">);
 
   // retry wrapper
@@ -155,10 +159,18 @@ export function compileRecipe(recipe: Recipe): AutomationProgram {
 function mapTrigger(
   trigger: Trigger,
   recipeName: string,
-): { hookType: HookType; patterns?: string[] } {
+): { hookType: HookType; patterns?: string[]; extras?: HookExtras } {
   switch (trigger.type) {
     case "file_watch":
       return { hookType: "onFileSave", patterns: trigger.patterns };
+    case "on_file_save":
+      // Runtime-facing alias of file_watch. `glob` is optional — when absent
+      // the interpreter's patterns check is skipped, so the hook fires on every
+      // save (parity with how the bridge dispatches onFileSave from IDE events).
+      return {
+        hookType: "onFileSave",
+        patterns: trigger.glob ? [trigger.glob] : undefined,
+      };
     case "git_hook":
       switch (trigger.event) {
         case "post-commit":
@@ -169,6 +181,23 @@ function mapTrigger(
           return { hookType: "onGitPull" };
       }
       break;
+    case "on_test_run":
+      // Mirror loadPolicy's onTestRun.filter normalization so a recipe trigger
+      // fires the SAME hook a policy-file entry would:
+      //   - "failure"         → onTestRun gated on a non-zero failure count
+      //   - "pass-after-fail" → the dedicated fail→pass transition hook
+      //   - "any" / absent    → onTestRun on every run
+      switch (trigger.filter) {
+        case "failure":
+          return {
+            hookType: "onTestRun",
+            extras: { kind: "testRun", onFailureOnly: true },
+          };
+        case "pass-after-fail":
+          return { hookType: "onTestPassAfterFailure" };
+        default:
+          return { hookType: "onTestRun" };
+      }
     case "webhook":
       throw new RecipeCompileError(
         `recipe '${recipeName}': webhook triggers fire via POST /hooks/* (server.webhookFn) and bypass the automation interpreter — installer.ts skips compileRecipeFull for them. Reaching this branch means a non-bypass caller invoked compileTrigger directly; check the call site.`,

--- a/src/recipes/eventTriggerPrograms.ts
+++ b/src/recipes/eventTriggerPrograms.ts
@@ -15,12 +15,11 @@ import { parseRecipe } from "./parser.js";
  * a native automation hook the bridge already fires.
  *
  * `compileRecipe` (compiler.ts) maps:
- *   - `file_watch` → onFileSave
- *   - `git_hook`   → onGitCommit / onGitPush / onGitPull
+ *   - `file_watch` / `on_file_save` → onFileSave
+ *   - `git_hook`                    → onGitCommit / onGitPush / onGitPull
+ *   - `on_test_run`                 → onTestRun / onTestPassAfterFailure (by filter)
  * and THROWS for cron/webhook/manual/chained (those route through the cron
- * scheduler / POST /hooks / CLI / chained runner respectively). The newer
- * `on_file_save` / `on_test_run` trigger types have no compiler case yet, so
- * they are intentionally excluded here and tracked as a follow-up.
+ * scheduler / POST /hooks / CLI / chained runner respectively).
  *
  * Before this collector existed, these compiled programs were never registered
  * into AutomationHooks — a recipe with `trigger: { type: file_watch }` parsed,
@@ -34,6 +33,8 @@ import { parseRecipe } from "./parser.js";
 const COMPILABLE_EVENT_TRIGGERS: ReadonlySet<string> = new Set([
   "file_watch",
   "git_hook",
+  "on_file_save",
+  "on_test_run",
 ]);
 
 export interface CollectedTriggerPrograms {

--- a/src/recipes/installer.ts
+++ b/src/recipes/installer.ts
@@ -68,18 +68,16 @@ export function installRecipeFromFile(
   // respectively. Synthesize an empty CompiledRecipe stub so the caller API
   // stays uniform; file_watch and git_hook still run through compile.
   //
-  // `chained`, `on_file_save`, and `on_test_run` are runtime-only triggers
-  // (ChainedRecipeRunner / yamlRunner + the bridge's automation hooks) that
-  // the recipe→AutomationProgram compiler does not model. They must bypass
-  // compile too — otherwise mapTrigger() throws "unknown trigger type" and
-  // a recipe that lints + runs cannot be installed (the original bug).
+  // `chained` is a runtime-only trigger (ChainedRecipeRunner / yamlRunner) the
+  // recipe→AutomationProgram compiler does not model, so it bypasses compile.
+  // `on_file_save` / `on_test_run` DO compile now — mapTrigger maps them to
+  // onFileSave / onTestRun / onTestPassAfterFailure — so they install with a
+  // real AutomationProgram + suggestedPermissions instead of a bypass stub.
   const bypassCompile =
     recipe.trigger.type === "manual" ||
     recipe.trigger.type === "cron" ||
     recipe.trigger.type === "webhook" ||
-    recipe.trigger.type === "chained" ||
-    recipe.trigger.type === "on_file_save" ||
-    recipe.trigger.type === "on_test_run";
+    recipe.trigger.type === "chained";
   const compiled: CompiledRecipe = bypassCompile
     ? {
         program: {


### PR DESCRIPTION
**Stacked on #1016** (base = `feat/recipe-trigger-dispatch`). Retarget to `main` once #1016 merges (this repo squash-merges).

Completes recipe trigger-dispatch coverage: the two remaining event trigger types now compile + register instead of being bypassed at install.

## Changes
- **`compiler.ts`** — `mapTrigger` now returns optional `extras`, and handles:
  - `on_file_save` → `onFileSave` (glob → patterns; absent glob → fires on every save, matching the interpreter's patterns-optional matching at `automationInterpreter.ts:361`).
  - `on_test_run` → `onTestRun` (filter `any`), `onTestRun` + `{kind: testRun, onFailureOnly: true}` (filter `failure`), or `onTestPassAfterFailure` (filter `pass-after-fail`). Mirrors `loadPolicy`'s `onTestRun.filter` normalization so a recipe trigger fires the **same** hook a policy entry would. Verified `handleTestRun` emits both `onTestRun` and `onTestPassAfterFailure`.
- **`installer.ts`** — drops `on_file_save`/`on_test_run` from the compile-bypass list (they compile now → install with a real program + `suggestedPermissions`).
- **`eventTriggerPrograms.ts`** — adds both to the collected set.
- **Wiring-completeness gate** — flips both `UNWIRED → automation-hook`; `KNOWN_UNWIRED` is now empty. Every `TriggerType` has a live dispatch path, and the runtime check asserts both are collected end-to-end.

Delivers the headline **"tests fail → investigate"** automation via `on_test_run`.

## Tests
`compiler.test.ts` asserts each new mapping (incl. all three `on_test_run` filters and glob-present/absent). Local gates green: `tsc`, `tsc -p tsconfig.tests.core.json`, fixture audit, biome; 600 tests across compiler/triggers/installer/automation/parser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)