### PR TITLE
feat(automation): auto-enable recipe triggers when a driver is active

### DIFF
--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -36,7 +36,10 @@ import { isPreToolUseHookRegistered } from "./preToolUseHook.js";
 import type { ProbeResults } from "./probe.js";
 import { probeAll } from "./probe.js";
 import { RecipeOrchestration } from "./recipeOrchestration.js";
-import { collectEventTriggerPrograms } from "./recipes/eventTriggerPrograms.js";
+import {
+  collectEventTriggerPrograms,
+  shouldAutoEnableAutomation,
+} from "./recipes/eventTriggerPrograms.js";
 import {
   haltSummaryToPrometheus,
   summariseHalts,
@@ -1197,6 +1200,38 @@ export class Bridge {
       // interpreter — they compile to hooks the bridge already fires, but were
       // never registered until now (decorative). See C-triggers.md.
       this.registerRecipeTriggerPrograms();
+    } else if (this.orchestrator) {
+      // Auto-enable (no --automation policy): when installed recipes declare
+      // event triggers AND a subprocess driver is active, stand up a policy-less
+      // AutomationHooks so those triggers actually fire. The `this.orchestrator`
+      // guard is the safety floor — we never spawn tasks unless the operator
+      // already enabled a driver. Pass --automation --automation-policy to add
+      // policy-file hooks on top of the recipe triggers.
+      const recipesDir = path.join(os.homedir(), ".patchwork", "recipes");
+      const collected = collectEventTriggerPrograms(recipesDir, {
+        logger: this.logger,
+      });
+      if (
+        shouldAutoEnableAutomation({
+          automationEnabled: this.config.automationEnabled,
+          hasDriver: true,
+          eventProgramCount: collected.programs.length,
+        })
+      ) {
+        this.automationHooks = new AutomationHooks(
+          {},
+          this.orchestrator,
+          (msg) => this.logger.info(msg),
+          this.extensionClient,
+          this.config.workspace,
+          this.config.automationAllowPrivateWebhooks,
+        );
+        this.automationHooks.registerRecipePrograms(collected.programs);
+        const n = collected.programs.length;
+        this.logger.info(
+          `[bridge] Automation auto-enabled for ${n} event-driven recipe${n === 1 ? "" : "s"} (${collected.recipeNames.join(", ")}) — no --automation policy; pass --automation --automation-policy to add policy hooks`,
+        );
+      }
     }
 
     // 3. Wire up /health endpoint data and /metrics

--- a/src/recipes/__tests__/eventTriggerPrograms.test.ts
+++ b/src/recipes/__tests__/eventTriggerPrograms.test.ts
@@ -2,7 +2,10 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { collectEventTriggerPrograms } from "../eventTriggerPrograms.js";
+import {
+  collectEventTriggerPrograms,
+  shouldAutoEnableAutomation,
+} from "../eventTriggerPrograms.js";
 
 // Minimal valid recipe YAML by trigger type. parseRecipe requires a kebab
 // `name`, a `trigger`, and a non-empty `steps` array.
@@ -127,5 +130,47 @@ describe("collectEventTriggerPrograms", () => {
     );
     expect(result.programs).toHaveLength(0);
     expect(result.recipeNames).toHaveLength(0);
+  });
+});
+
+describe("shouldAutoEnableAutomation", () => {
+  it("auto-enables when a driver is active and event recipes exist", () => {
+    expect(
+      shouldAutoEnableAutomation({
+        automationEnabled: false,
+        hasDriver: true,
+        eventProgramCount: 2,
+      }),
+    ).toBe(true);
+  });
+
+  it("never auto-enables when automation is already explicitly enabled", () => {
+    expect(
+      shouldAutoEnableAutomation({
+        automationEnabled: true,
+        hasDriver: true,
+        eventProgramCount: 2,
+      }),
+    ).toBe(false);
+  });
+
+  it("safety floor: never auto-enables without a driver", () => {
+    expect(
+      shouldAutoEnableAutomation({
+        automationEnabled: false,
+        hasDriver: false,
+        eventProgramCount: 2,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not auto-enable when no event-trigger recipe is installed", () => {
+    expect(
+      shouldAutoEnableAutomation({
+        automationEnabled: false,
+        hasDriver: true,
+        eventProgramCount: 0,
+      }),
+    ).toBe(false);
   });
 });

--- a/src/recipes/eventTriggerPrograms.ts
+++ b/src/recipes/eventTriggerPrograms.ts
@@ -190,3 +190,23 @@ function compileFromFile(
 function errMsg(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
 }
+
+/**
+ * Decide whether the bridge should auto-enable a policy-less AutomationHooks so
+ * installed event-trigger recipes fire WITHOUT an explicit `--automation`
+ * policy.
+ *
+ * Safety floor: `hasDriver` must be true — auto-enable only when the operator
+ * already enabled a subprocess driver (i.e. already opted into Claude task
+ * spawning). Never auto-enable when automation was explicitly configured (that
+ * path owns construction) or when no event-trigger recipe is installed.
+ */
+export function shouldAutoEnableAutomation(opts: {
+  automationEnabled: boolean;
+  hasDriver: boolean;
+  eventProgramCount: number;
+}): boolean {
+  return (
+    !opts.automationEnabled && opts.hasDriver && opts.eventProgramCount > 0
+  );
+}


### PR DESCRIPTION
**Stacked on #1018** (base = `feat/recipe-on-test-run-triggers`). Merge chain: **#1016 → #1018 → this**; retarget each to `main` as its parent merges (repo squash-merges).

Makes the recipe-trigger work reachable for typical users. Until now event triggers only fired under explicit `--automation --automation-policy` — the only path that constructs `AutomationHooks`.

## What
At startup, stand up a **policy-less** `AutomationHooks` when **both**:
- a subprocess driver is active (`--driver != none`, i.e. `this.orchestrator` exists), **and**
- ≥1 installed recipe declares an event trigger.

## Safety posture
The driver requirement is the deliberate floor — auto-enable never spawns Claude tasks unless the operator already opted into a driver. Explicit `--automation` still owns construction and layers policy-file hooks on top. A loud startup log line announces it. The decision lives in a pure, tested predicate `shouldAutoEnableAutomation` (true only when `!automationEnabled && hasDriver && eventProgramCount > 0`).

## Tests
`shouldAutoEnableAutomation` unit tests cover the true case + each false case (already-enabled, no-driver floor, zero recipes). Empty-policy `AutomationHooks` firing is already proven in `automation-recipe-triggers.test.ts`. Gates green: `tsc`, `tsc -p tsconfig.tests.core.json`, fixture audit, biome; 465 tests across eventTriggerPrograms/automation/bridge-activation.

## Known limitation
Startup-only: installing the *first* event-trigger recipe mid-session without `--automation` won't retroactively construct `AutomationHooks` until restart. Tracked follow-up (the hot-reload path already re-syncs once hooks exist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)