### PR TITLE
feat(driver): capture claude -p result usage/cost into providerMeta (telemetry=0 fix)

### DIFF
--- a/src/drivers/claude/__tests__/subprocess.telemetry.test.ts
+++ b/src/drivers/claude/__tests__/subprocess.telemetry.test.ts
@@ -1,0 +1,132 @@
+/**
+ * audit P0-4 — capture the `claude -p` stream-json result event's usage/cost
+ * telemetry into ProviderTaskResult.providerMeta.
+ *
+ * Before: the result event's `usage`, `total_cost_usd`, `num_turns`,
+ * `duration_ms` were discarded (not even on the StreamJsonEvent type), so
+ * providerMeta was empty and RunBudget/runlog saw zero token usage for every
+ * subprocess (claude -p) step — the "tool-call telem=0" symptom.
+ *
+ * After: the result event populates providerMeta.{inputTokens,outputTokens,
+ * costUsd,numTurns,durationMs,model}, which the existing
+ * providerMetaToUsage → RunBudget.reconcile path already consumes (and which is
+ * recorded to the runlog). `subprocess` is NOT a BILLABLE_DRIVER, so usdMax
+ * stays fail-open — this only surfaces telemetry, it does not start charging
+ * subscription runs.
+ */
+
+import { EventEmitter } from "node:events";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+class MockChild extends EventEmitter {
+  stdout = new EventEmitter();
+  stderr = new EventEmitter();
+  exitCode: number | null = null;
+}
+
+let mockChild: MockChild;
+
+vi.mock("node:child_process", async (importOriginal) => {
+  const original = await importOriginal<typeof import("node:child_process")>();
+  return {
+    ...original,
+    spawn: vi.fn(() => {
+      mockChild = new MockChild();
+      mockChild.stdout = new EventEmitter();
+      mockChild.stderr = new EventEmitter();
+      (mockChild.stdout as { setEncoding?: () => void }).setEncoding = vi.fn();
+      (mockChild.stderr as { setEncoding?: () => void }).setEncoding = vi.fn();
+      return mockChild;
+    }),
+  };
+});
+
+import { providerMetaToUsage } from "../../../recipes/yamlRunner.js";
+import type { ProviderTaskResult } from "../../types.js";
+import { SubprocessDriver } from "../subprocess.js";
+
+function makeInput(overrides: Record<string, unknown> = {}) {
+  return {
+    prompt: "hello",
+    workspace: "/workspace/test",
+    timeoutMs: 5000,
+    signal: new AbortController().signal,
+    ...overrides,
+  } as Parameters<SubprocessDriver["run"]>[0];
+}
+
+function newDriver() {
+  return new SubprocessDriver("claude", "ant", vi.fn());
+}
+
+/** Run the driver, emit a single result event, close, and return the result. */
+async function runWithResult(
+  driver: SubprocessDriver,
+  resultEvent: Record<string, unknown>,
+  input = makeInput(),
+): Promise<ProviderTaskResult> {
+  const p = driver.run(input);
+  await new Promise<void>((r) => setTimeout(r, 0));
+  mockChild.stdout.emit("data", `${JSON.stringify(resultEvent)}\n`);
+  mockChild.emit("close", 0);
+  return p;
+}
+
+describe("SubprocessDriver result-event telemetry (P0-4)", () => {
+  beforeEach(() => vi.clearAllMocks());
+  afterEach(() => vi.useRealTimers());
+
+  it("captures usage + cost from the result event into providerMeta", async () => {
+    const result = await runWithResult(newDriver(), {
+      type: "result",
+      is_error: false,
+      result: "done",
+      usage: { input_tokens: 1200, output_tokens: 340 },
+      total_cost_usd: 0.0123,
+      num_turns: 3,
+      duration_ms: 5400,
+    });
+    expect(result.providerMeta).toBeDefined();
+    expect(result.providerMeta).toMatchObject({
+      inputTokens: 1200,
+      outputTokens: 340,
+      costUsd: 0.0123,
+      numTurns: 3,
+      durationMs: 5400,
+    });
+  });
+
+  it("providerMeta is consumable by the existing providerMetaToUsage path", async () => {
+    const result = await runWithResult(newDriver(), {
+      type: "result",
+      is_error: false,
+      result: "done",
+      usage: { input_tokens: 800, output_tokens: 200 },
+    });
+    expect(providerMetaToUsage(result.providerMeta)).toEqual({
+      inputTokens: 800,
+      outputTokens: 200,
+    });
+  });
+
+  it("omits token fields when the result event has no usage (old binary) — no crash", async () => {
+    const result = await runWithResult(newDriver(), {
+      type: "result",
+      is_error: false,
+      result: "done",
+    });
+    // No usage → providerMetaToUsage returns undefined (RunBudget fails open as before).
+    expect(providerMetaToUsage(result.providerMeta)).toBeUndefined();
+    expect(result.text).toBe("done");
+  });
+
+  it("ignores malformed usage (non-number tokens) without poisoning providerMeta", async () => {
+    const result = await runWithResult(newDriver(), {
+      type: "result",
+      is_error: false,
+      result: "done",
+      usage: { input_tokens: "lots", output_tokens: null },
+    });
+    expect(providerMetaToUsage(result.providerMeta)).toBeUndefined();
+  });
+});

--- a/src/drivers/claude/streamParser.ts
+++ b/src/drivers/claude/streamParser.ts
@@ -12,6 +12,19 @@ export interface StreamJsonEvent {
   is_error?: boolean;
   /** Present on type === "system" — session identifier. */
   session_id?: string;
+  /** Present on type === "result" — token usage for the run. */
+  usage?: {
+    input_tokens?: number;
+    output_tokens?: number;
+    cache_creation_input_tokens?: number;
+    cache_read_input_tokens?: number;
+  };
+  /** Present on type === "result" — total billed cost in USD (0 under subscription auth). */
+  total_cost_usd?: number;
+  /** Present on type === "result" — number of agent turns. */
+  num_turns?: number;
+  /** Present on type === "result" — wall-clock duration in ms. */
+  duration_ms?: number;
 }
 
 export interface ParsedLine {

--- a/src/drivers/claude/subprocess.ts
+++ b/src/drivers/claude/subprocess.ts
@@ -246,6 +246,35 @@ export class SubprocessDriver implements ProviderDriver {
     let doneFromResult = false;
     let resultText = "";
     let resultIsError = false;
+    // P0-4: capture the result event's usage/cost telemetry (previously
+    // discarded). Surfaced via providerMeta so the existing
+    // providerMetaToUsage → RunBudget.reconcile path (and the runlog) sees real
+    // token usage for claude -p steps instead of zero. `subprocess` is not a
+    // BILLABLE_DRIVER, so usdMax stays fail-open — this only surfaces telemetry.
+    let resultUsage:
+      | { input_tokens?: number; output_tokens?: number }
+      | undefined;
+    let resultCostUsd: number | undefined;
+    let resultNumTurns: number | undefined;
+    let resultDurationMs: number | undefined;
+    const providerMetaOf = (): Record<string, unknown> | undefined => {
+      const meta: Record<string, unknown> = {};
+      const inT = resultUsage?.input_tokens;
+      const outT = resultUsage?.output_tokens;
+      if (typeof inT === "number" && typeof outT === "number") {
+        meta.inputTokens = inT;
+        meta.outputTokens = outT;
+      }
+      if (typeof resultCostUsd === "number") meta.costUsd = resultCostUsd;
+      if (typeof resultNumTurns === "number") meta.numTurns = resultNumTurns;
+      if (typeof resultDurationMs === "number") {
+        meta.durationMs = resultDurationMs;
+      }
+      if (typeof input.model === "string" && input.model.length > 0) {
+        meta.model = input.model;
+      }
+      return Object.keys(meta).length > 0 ? meta : undefined;
+    };
 
     child.stdout.setEncoding("utf-8");
     child.stdout.on("data", (chunk: string) => {
@@ -291,6 +320,10 @@ export class SubprocessDriver implements ProviderDriver {
           doneFromResult = true;
           resultIsError = event.is_error === true;
           resultText = text || accumulated;
+          resultUsage = event.usage;
+          resultCostUsd = event.total_cost_usd;
+          resultNumTurns = event.num_turns;
+          resultDurationMs = event.duration_ms;
         }
       }
     });
@@ -341,6 +374,7 @@ export class SubprocessDriver implements ProviderDriver {
           durationMs: Date.now() - start,
           stderrTail: stderrTailOf(stderr),
           startupMs: startupMsOf(),
+          providerMeta: providerMetaOf(),
         };
       }
       const isAbort =
@@ -399,6 +433,10 @@ export class SubprocessDriver implements ProviderDriver {
           doneFromResult = true;
           resultIsError = event.is_error === true;
           resultText = text || accumulated;
+          resultUsage = event.usage;
+          resultCostUsd = event.total_cost_usd;
+          resultNumTurns = event.num_turns;
+          resultDurationMs = event.duration_ms;
         }
       }
       lineBuf = "";
@@ -432,6 +470,7 @@ export class SubprocessDriver implements ProviderDriver {
       durationMs: Date.now() - start,
       stderrTail: stderrTailOf(stderr),
       startupMs: startupMsOf(),
+      providerMeta: providerMetaOf(),
     };
   }
 


### PR DESCRIPTION
> **Stacked on #1017** (`fix/recipe-tools-allowlist`) — both touch `src/drivers/claude/subprocess.ts`. Base is the P0-5 branch so this PR shows only the P0-4 diff. **Before merge: retarget to `main` (after #1017 merges) or merge #1017 first**, per the squash-merge caveat.

## What
Captures the `claude -p` result event's usage/cost telemetry. From the changelog audit, item **P0-4** — fixes the live "tool-call telem=0" symptom.

## Why
The stream-json `result` event carries `usage` / `total_cost_usd` / `num_turns` / `duration_ms`, but `StreamJsonEvent` didn't type them and the subprocess driver discarded them — so `providerMeta` was empty and RunBudget/runlog saw **zero token usage** for every `claude -p` step.

## Change (minimal, no downstream edits)
- Type the result-event fields on `StreamJsonEvent`.
- Populate `ProviderTaskResult.providerMeta` with `{inputTokens, outputTokens, costUsd, numTurns, durationMs, model}` at both result branches + both `doneFromResult` returns.
- The **existing** `providerMetaToUsage` → `RunBudget.reconcile` path (and the runlog) already consume `providerMeta` — so token telemetry is now visible with no RunBudget change.

## No subscription-pricing regression
`subprocess` is **not** in `BILLABLE_DRIVERS` (runBudget.ts:43), so `reconcile` records token counts but leaves `usdMax` fail-open for subscription runs — exactly as today. The CLI's authoritative `total_cost_usd` (0 under subscription) is recorded for visibility.

## Tests
`subprocess.telemetry.test.ts`: result event → `providerMeta`; consumable by `providerMetaToUsage`; no-usage (old binary) → undefined + no crash; malformed usage rejected. tsc default + **core ratchet** + audit-test-fixtures + biome + vitest (349 across driver/budget/runner suites) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
