### PR TITLE
feat(workers): ramp v0 — Bayesian (worker × action-class) trust + dogfood workers

### DIFF
--- a/docs/design/worker-ramp-v0.md
+++ b/docs/design/worker-ramp-v0.md
@@ -1,0 +1,105 @@
+# Worker Ramp v0 — design
+
+**Status:** v0 implementation (shadow-mode). Net-new subsystem under `src/workers/`.
+
+## Thesis
+
+A **worker** is a persistent, responsibility-based role (Release, Dependency-upkeep,
+Test-guardian…), not a session or a prompt. Its durable asset is its **track record**,
+which model swaps don't touch. The product spine is the **trust/autonomy ramp**:
+how much a worker may do unsupervised, earned by evidence, scoped narrowly.
+
+## Non-negotiable design decisions (and why)
+
+1. **Worker = recipe + identity, NOT a new first-class actor object.** Patchwork's
+   recurring failure mode is forking the execution model (flat vs chained runner
+   drift; "incomplete-fix-one-path"). A parallel `Worker` runtime would re-introduce
+   exactly that. The recipe is the worker's *body* (triggers + steps); the worker
+   manifest adds *identity + owned action-classes + trust priors* as additive
+   metadata. The recipe schema is **untouched**.
+
+2. **Trust is per `(worker × action-class)`, never global.** A worker with 2,000
+   clean dependency bumps has earned *nothing* on "production deploy". Novel classes
+   default to the floor regardless of overall reputation. This single rule defeats the
+   scariest failure: a trusted worker doing something unprecedented.
+
+3. **The level is a Bayesian posterior, surfaced as discrete L0–L4.** Internals are a
+   Beta posterior over per-class reliability; the discrete level is a threshold
+   crossing of its *lower confidence bound*. This makes three hard problems fall out
+   of one mechanism:
+   - **Asymmetry** ("slow up, instant down") is information, not a hand-tuned rule: a
+     high-blast failure is high-information (large posterior shift), routine successes
+     are low-information.
+   - **Cold-start + marketplace portability** unify: a shipped worker arrives with a
+     *prior* (competence) and wide uncertainty; local evidence tightens it (trust). A
+     vendor can ship a prior mean but cannot ship your posterior — uncertainty only
+     collapses on *your* data.
+   - **Evidence sparsity is survivable**: priors carry the worker through the weeks
+     before it has local evidence.
+
+4. **Reversibility is the primary taxonomy axis, not risk-tier.** A ramp rung is an
+   *execution mode*, and the middle rungs (act-with-undo / act-and-sample) only exist
+   where a compensating action exists. An action-class is
+   `(domain × reversibility × blastTier)`; reversibility ∈
+   `{reversible | compensable | irreversible}`. Irreversible classes skip the safety
+   rungs, so their bar to autonomy must be far higher.
+
+## The ramp
+
+| Rung | Execution mode | v0 status |
+|---|---|---|
+| L0 suggest | propose, don't execute | deferred (phase 2) |
+| L1 approve-each | queue for human OK | **v0** (= today's gate `queue`) |
+| L2 act-with-undo | execute in a reversible window | deferred (needs compensating-action infra; reversible classes only) |
+| L3 act-and-sample | execute + async sampled review | deferred (needs async review queue) |
+| L4 autonomous | execute, escalate anomalies only | **v0** (= today's gate `bypass`) |
+
+**v0 surfaces only L1↔L4** — the two execution modes that already exist in the
+approval gate (`evaluateInProcessGate` → queue/bypass). The full L0–L4 posterior is
+computed for the dial; only the L1/L4 distinction is *actionable* in v0. L0/L2/L3 are
+phase 2 (new execution machinery).
+
+## v0 scope
+
+**Built (this PR):**
+- `actionClass.ts` — classify a tool call into an action-class + blast weight.
+- `trustLevel.ts` — Beta posterior, LCB, posterior→level mapping.
+- `graduation.ts` — fold outcomes into the posterior with asymmetry, hysteresis
+  (dwell + demote-cooldown), and novel-class floor.
+- `workerLevelStore.ts` — JSONL persistence of posteriors + a promotion/demotion
+  event log (the compliance/audit artifact).
+- `worker.ts` — parse a worker manifest; resolve which action-classes it owns.
+- `shadowGate.ts` — a **pure** recommender: what the ramp *would* decide. Logged in
+  shadow; **does not change live gate behavior** in v0.
+- `templates/workers/*.worker.yaml` — 3 dogfood workers for developing Patchwork.
+- `shadowRun.ts` — replay an outcome sequence → dial trajectory (the evidence-latency
+  test).
+
+**Deferred (phase 2+), deliberately:**
+- Flipping the live gate to obey the ramp (behind a flag, after shadow validation).
+- L0/L2/L3 execution modes (suggest / reversible-window / async-sample).
+- The trust-dial UI (the dashboard board).
+- Multi-worker coordination / delegation protocols (YAGNI until ≥2 mature workers).
+- License-tier autonomy caps; marketplace prior shipping.
+
+## How it composes from what exists
+
+| Need | Reuse | Net-new |
+|---|---|---|
+| self-waking role | recipe triggers (cron/file-watch/git/on-test-run) | worker identity layer |
+| blast tier | `classifyTool` (low/med/high) | reversibility tag |
+| content risk | `RiskSignal` kinds (`destructive_command`, `data_exfiltration`, …) | — |
+| evidence | decision/run/approval/judge trace stores | regroup by `(worker × class)` |
+| control floor | approval gate (`evaluateInProcessGate`) + kill switch | worker-aware decision (shadow) |
+| experience compounds | what compounds is the **earned autonomy state**, not model memory — delivered before a distillation loop exists | — |
+
+## Anti-gaming (honest)
+
+- **Trust-transfer grinding** (1,000 trivial actions → one catastrophe): defeated by
+  per-class scoping + **blast-radius weighting** — a routine success barely moves the
+  posterior; a high-blast failure dominates. Count alone never graduates a risky class.
+- **Trust-hoarding** (do less to keep stats clean): *not cleanly solvable* from traces
+  — there is no ground-truth denominator for "should have acted". v0 mitigation is an
+  operator-set per-class expected cadence that **flags** silence (does not auto-demote).
+  Documented as a soft signal, not a solved metric.
+- **Flapping**: dwell-time before a climb + a demote-cooldown after a fall.

--- a/src/workers/__tests__/actionClass.test.ts
+++ b/src/workers/__tests__/actionClass.test.ts
@@ -37,6 +37,13 @@ describe("classifyActionClass", () => {
     expect(c.domain).toBe("other");
     expect(c.reversibility).toBe("irreversible");
   });
+
+  it("classifies recipe-tool ids (what RecipeRunLog records) into the right domains", () => {
+    expect(classifyActionClass("git.log_since").domain).toBe("vcs-read");
+    expect(classifyActionClass("file.write").domain).toBe("fs-write");
+    expect(classifyActionClass("github.list_prs").domain).toBe("vcs-read");
+    expect(classifyActionClass("slack.post_message").brandExposed).toBe(true);
+  });
 });
 
 describe("reachableLevels", () => {

--- a/src/workers/__tests__/actionClass.test.ts
+++ b/src/workers/__tests__/actionClass.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import {
+  classifyActionClass,
+  outcomeWeight,
+  reachableLevels,
+} from "../actionClass.js";
+
+describe("classifyActionClass", () => {
+  it("keys a class as domain:reversibility:blastTier", () => {
+    expect(classifyActionClass("getGitStatus")).toEqual({
+      key: "vcs-read:reversible:low",
+      domain: "vcs-read",
+      reversibility: "reversible",
+      blastTier: "low",
+      brandExposed: false,
+    });
+    expect(classifyActionClass("gitPush").key).toBe(
+      "vcs-remote:compensable:high",
+    );
+    expect(classifyActionClass("slackPostMessage").key).toBe(
+      "messaging:irreversible:medium",
+    );
+  });
+
+  it("folds blast-tier into the key so a higher-blast action is a DISTINCT class", () => {
+    // routine read vs a high-blast local mutation in the same vcs family
+    expect(classifyActionClass("getGitStatus").key).not.toBe(
+      classifyActionClass("gitCommit").key,
+    );
+    expect(classifyActionClass("gitCommit").key).toBe(
+      "vcs-local:reversible:high",
+    );
+  });
+
+  it("treats unknown tools as irreversible (conservative default)", () => {
+    const c = classifyActionClass("someBespokePluginTool");
+    expect(c.domain).toBe("other");
+    expect(c.reversibility).toBe("irreversible");
+  });
+});
+
+describe("reachableLevels", () => {
+  it("irreversible classes skip the safety-net rungs L2/L3", () => {
+    expect(reachableLevels(classifyActionClass("runCommand"))).toEqual([
+      0, 1, 4,
+    ]);
+  });
+
+  it("reversible classes can reach every rung", () => {
+    expect(reachableLevels(classifyActionClass("editText"))).toEqual([
+      0, 1, 2, 3, 4,
+    ]);
+  });
+});
+
+describe("outcomeWeight", () => {
+  it("a routine success is low-information (weight 1)", () => {
+    expect(outcomeWeight(classifyActionClass("editText"), true)).toBe(1);
+    expect(outcomeWeight(classifyActionClass("runCommand"), true)).toBe(1);
+  });
+
+  it("a high-blast irreversible failure vastly outweighs a low-blast reversible one", () => {
+    const catastrophic = outcomeWeight(
+      classifyActionClass("runCommand"), // shell:irreversible:high → 12 * 3
+      false,
+    );
+    const trivial = outcomeWeight(
+      classifyActionClass("getGitStatus"), // vcs-read:reversible:low → 2 * 1
+      false,
+    );
+    expect(catastrophic).toBe(36);
+    expect(trivial).toBe(2);
+    // the anti-grinding guarantee: one catastrophic failure outweighs ~18
+    // trivial successes worth of climb
+    expect(catastrophic).toBeGreaterThan(trivial * 10);
+  });
+
+  it("a brand-exposed failure is weighted heavier than the same class would be internally", () => {
+    const slack = classifyActionClass("slackPostMessage"); // messaging → brand-exposed
+    expect(slack.brandExposed).toBe(true);
+    // messaging:irreversible:medium → 5 × 3 × 1.5 (brand) = 22.5
+    expect(outcomeWeight(slack, false)).toBe(22.5);
+    // internal tools are not brand-exposed (no multiplier)
+    expect(classifyActionClass("runCommand").brandExposed).toBe(false);
+    expect(classifyActionClass("editText").brandExposed).toBe(false);
+  });
+});

--- a/src/workers/__tests__/graduation.test.ts
+++ b/src/workers/__tests__/graduation.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from "vitest";
+import { classifyActionClass } from "../actionClass.js";
+import {
+  type ClassTrustState,
+  type GraduationConfig,
+  type GraduationEvent,
+  graduate,
+  initialState,
+  type Outcome,
+} from "../graduation.js";
+import { DEFAULT_PRIOR } from "../trustLevel.js";
+
+const CFG: GraduationConfig = {
+  dwellMs: 1000,
+  demoteCooldownMs: 5000,
+  minEvidenceForGraduation: 5,
+};
+
+function runSeq(
+  start: ClassTrustState,
+  outcomes: Outcome[],
+  cfg = CFG,
+): { state: ClassTrustState; events: GraduationEvent[] } {
+  let state = start;
+  const events: GraduationEvent[] = [];
+  for (const o of outcomes) {
+    const r = graduate(state, o, cfg);
+    state = r.state;
+    if (r.event) events.push(r.event);
+  }
+  return { state, events };
+}
+
+function goods(tool: string, n: number, at: number): Outcome[] {
+  return Array.from({ length: n }, () => ({ toolName: tool, good: true, at }));
+}
+
+const EDIT = "editText"; // fs-write:reversible:medium → reachable [0..4]
+const SHELL = "runCommand"; // shell:irreversible:high → reachable [0,1,4]
+
+describe("graduation — dwell gating", () => {
+  it("a burst of successes at one instant never promotes (no time elapsed)", () => {
+    const key = classifyActionClass(EDIT).key;
+    const { state, events } = runSeq(
+      initialState(key, DEFAULT_PRIOR),
+      goods(EDIT, 30, 0),
+    );
+    expect(state.level).toBe(0);
+    expect(events).toHaveLength(0);
+    expect(state.observations).toBe(30);
+  });
+});
+
+describe("graduation — gradual climb", () => {
+  it("climbs one rung per dwell period up to L4 on a reversible class", () => {
+    const key = classifyActionClass(EDIT).key;
+    // build a tight, high posterior at t=0 (no promotions yet)...
+    let { state } = runSeq(
+      initialState(key, DEFAULT_PRIOR),
+      goods(EDIT, 60, 0),
+    );
+    // ...then one success per dwell period — each unlocks one climb
+    const climbs: Outcome[] = [1000, 2000, 3000, 4000].map((at) => ({
+      toolName: EDIT,
+      good: true,
+      at,
+    }));
+    const r = runSeq(state, climbs);
+    state = r.state;
+    expect(r.events.map((e) => `${e.from}->${e.to}`)).toEqual([
+      "0->1",
+      "1->2",
+      "2->3",
+      "3->4",
+    ]);
+    expect(state.level).toBe(4);
+  });
+});
+
+describe("graduation — instant demote", () => {
+  it("demotes immediately mid-dwell (asymmetry: down ignores dwell)", () => {
+    const key = classifyActionClass(EDIT).key;
+    let { state } = runSeq(
+      initialState(key, DEFAULT_PRIOR),
+      goods(EDIT, 60, 0),
+    );
+    ({ state } = runSeq(
+      state,
+      [1000, 2000, 3000, 4000].map((at) => ({
+        toolName: EDIT,
+        good: true,
+        at,
+      })),
+    ));
+    expect(state.level).toBe(4);
+
+    // a failure at t=4100 — inside the dwell window — must demote instantly
+    const dem = graduate(state, { toolName: EDIT, good: false, at: 4100 }, CFG);
+    expect(dem.event?.type).toBe("demote");
+    expect(dem.event!.to).toBeLessThan(4);
+    expect(dem.event!.at).toBe(4100);
+    expect(dem.state.demoteUntil).toBe(4100 + CFG.demoteCooldownMs);
+  });
+});
+
+describe("graduation — demote cooldown", () => {
+  it("freezes promotions until the cooldown elapses, even when evidence supports a climb", () => {
+    const key = classifyActionClass(EDIT).key;
+    // posterior strongly supports L4, but the worker was just demoted to L1 and
+    // is inside its cooldown window — a fast re-grind must NOT buy trust back.
+    const earned = runSeq(
+      initialState(key, DEFAULT_PRIOR),
+      goods(EDIT, 60, 0),
+    ).state;
+    const inCooldown: ClassTrustState = {
+      ...earned,
+      level: 1,
+      lastChangeAt: 0,
+      demoteUntil: 9100,
+    };
+    const blocked = graduate(
+      inCooldown,
+      { toolName: EDIT, good: true, at: 5000 },
+      CFG,
+    );
+    expect(blocked.event).toBeUndefined();
+    expect(blocked.state.level).toBe(1);
+
+    const after = graduate(
+      blocked.state,
+      { toolName: EDIT, good: true, at: 10000 },
+      CFG,
+    );
+    expect(after.event?.type).toBe("promote");
+  });
+});
+
+describe("graduation — irreversible class jumps L1→L4", () => {
+  it("never visits L2/L3 for an irreversible class", () => {
+    const key = classifyActionClass(SHELL).key;
+    let { state } = runSeq(
+      initialState(key, DEFAULT_PRIOR),
+      goods(SHELL, 150, 0),
+    );
+    const r = runSeq(
+      state,
+      [1000, 2000].map((at) => ({ toolName: SHELL, good: true, at })),
+    );
+    state = r.state;
+    const hops = r.events.map((e) => `${e.from}->${e.to}`);
+    expect(hops).toEqual(["0->1", "1->4"]);
+    expect(hops.some((h) => h.includes("2") || h.includes("3"))).toBe(false);
+    expect(state.level).toBe(4);
+  });
+});

--- a/src/workers/__tests__/shadowGate.test.ts
+++ b/src/workers/__tests__/shadowGate.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import type { GraduationConfig } from "../graduation.js";
+import { recommend } from "../shadowGate.js";
+import { parseWorker } from "../worker.js";
+import { WorkerLevelStore } from "../workerLevelStore.js";
+
+const CFG: GraduationConfig = {
+  dwellMs: 1000,
+  demoteCooldownMs: 5000,
+  minEvidenceForGraduation: 5,
+};
+
+/** Build a store where `workerId` has earned L4 on editText (fs-write). */
+function storeWithL4(workerId: string): WorkerLevelStore {
+  const store = new WorkerLevelStore();
+  for (let i = 0; i < 60; i++)
+    store.apply(
+      workerId,
+      { toolName: "editText", good: true, at: 0 },
+      { cfg: CFG },
+    );
+  for (const at of [1000, 2000, 3000, 4000])
+    store.apply(
+      workerId,
+      { toolName: "editText", good: true, at },
+      { cfg: CFG },
+    );
+  return store;
+}
+
+describe("shadowGate.recommend", () => {
+  it("bypasses an owned class the worker has earned L4 on", () => {
+    const w = parseWorker({ id: "release-bot", name: "R", owns: ["fs-write"] });
+    const d = recommend(w, "editText", {}, storeWithL4("release-bot"));
+    expect(d.earnedLevel).toBe(4);
+    expect(d.effectiveLevel).toBe(4);
+    expect(d.decision).toBe("bypass");
+  });
+
+  it("autonomyCeiling caps the effective level below earned → still queues", () => {
+    // a Legal-sector-style worker pinned at L2 regardless of track record
+    const w = parseWorker({
+      id: "release-bot",
+      name: "R",
+      owns: ["fs-write"],
+      autonomyCeiling: 2,
+    });
+    const d = recommend(w, "editText", {}, storeWithL4("release-bot"));
+    expect(d.earnedLevel).toBe(4);
+    expect(d.effectiveLevel).toBe(2);
+    expect(d.decision).toBe("queue");
+    expect(d.reason).toContain("capped-by-autonomy-ceiling");
+  });
+
+  it("floors to L0 and queues for an action outside the worker's domain", () => {
+    const w = parseWorker({ id: "release-bot", name: "R", owns: ["fs-write"] });
+    // worker has L4 on fs-write but slackPostMessage is messaging — not owned
+    const d = recommend(w, "slackPostMessage", {}, storeWithL4("release-bot"));
+    expect(d.owned).toBe(false);
+    expect(d.effectiveLevel).toBe(0);
+    expect(d.decision).toBe("queue");
+    expect(d.reason).toBe("outside-worker-domain");
+  });
+
+  it("queues an owned class with no track record (cold start)", () => {
+    const w = parseWorker({ id: "fresh", name: "F", owns: ["fs-write"] });
+    const d = recommend(w, "editText", {}, new WorkerLevelStore());
+    expect(d.earnedLevel).toBe(0);
+    expect(d.decision).toBe("queue");
+  });
+});

--- a/src/workers/__tests__/shadowRun.test.ts
+++ b/src/workers/__tests__/shadowRun.test.ts
@@ -1,0 +1,86 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { parse as parseYaml } from "yaml";
+import type { Outcome } from "../graduation.js";
+import { cadence, firstReached, shadowRun } from "../shadowRun.js";
+import { parseWorker } from "../worker.js";
+
+const DAY = 24 * 60 * 60 * 1000;
+const EDIT_CLASS = "fs-write:reversible:medium";
+
+describe("dogfood worker definitions parse", () => {
+  it("the three shipped worker manifests are valid", () => {
+    const dir = path.join(process.cwd(), "templates", "workers");
+    for (const f of [
+      "release-notes.worker.yaml",
+      "dependency-upkeep.worker.yaml",
+      "test-guardian.worker.yaml",
+    ]) {
+      const w = parseWorker(
+        parseYaml(readFileSync(path.join(dir, f), "utf-8")),
+      );
+      expect(w.id).toMatch(/^[a-z0-9-]+$/);
+      expect(w.owns.length).toBeGreaterThan(0);
+      expect(w.autonomyCeiling).toBeGreaterThanOrEqual(0);
+    }
+  });
+});
+
+describe("dial trajectory — the evidence-latency reality", () => {
+  const noPrior = parseWorker({
+    id: "rel-noprior",
+    name: "R",
+    owns: ["fs-write"],
+  });
+  const withPrior = parseWorker({
+    id: "rel-prior",
+    name: "R",
+    owns: ["fs-write"],
+    competence: { mean: 0.85, strength: 4 },
+  });
+  // ~2.5 weeks of one edit every 6h, all clean
+  const work = cadence("editText", 70);
+
+  it("a cold worker takes WEEKS of clean evidence to reach L4 (slow to climb)", () => {
+    const r = shadowRun(noPrior, work);
+    const l4 = firstReached(r, EDIT_CLASS, 4);
+    expect(l4).toBeDefined();
+    // not days — the trustworthy thing is genuinely slow
+    expect(l4!.at).toBeGreaterThan(10 * DAY);
+    // and it climbs gradually, not in one jump
+    expect(
+      r.events.filter((e) => e.type === "promote").length,
+    ).toBeGreaterThanOrEqual(4);
+    expect(r.board[0]!.level).toBe(4);
+  });
+
+  it("a shipped competence prior accelerates the climb without faking trust", () => {
+    const cold = shadowRun(noPrior, work);
+    const primed = shadowRun(withPrior, work);
+    const coldL1 = firstReached(cold, EDIT_CLASS, 1)!;
+    const primedL1 = firstReached(primed, EDIT_CLASS, 1)!;
+    const coldL4 = firstReached(cold, EDIT_CLASS, 4)!;
+    const primedL4 = firstReached(primed, EDIT_CLASS, 4)!;
+    // the prior reaches the first rung no later (cold-start head start)…
+    expect(primedL1.index).toBeLessThanOrEqual(coldL1.index);
+    // …and reaches full autonomy sooner than the cold worker…
+    expect(primedL4.at).toBeLessThan(coldL4.at);
+    // …but trust is NOT faked: L4 still takes days of real local evidence.
+    expect(primedL4.at).toBeGreaterThan(3 * DAY);
+  });
+
+  it("one failure demotes a long-earned L4 in a single step (instant to fall)", () => {
+    const outcomes: Outcome[] = [
+      ...cadence("editText", 65),
+      { toolName: "editText", good: false, at: 66 * 6 * 60 * 60 * 1000 },
+    ];
+    const r = shadowRun(noPrior, outcomes);
+    const demote = r.trajectory.find((s) => s.changed === "demote");
+    expect(demote).toBeDefined();
+    expect(demote!.level).toBeLessThan(4);
+    // the step immediately before the failure was at L4
+    const beforeFail = r.trajectory[r.trajectory.length - 2]!;
+    expect(beforeFail.level).toBe(4);
+  });
+});

--- a/src/workers/__tests__/trustLevel.test.ts
+++ b/src/workers/__tests__/trustLevel.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyOutcome,
+  DEFAULT_PRIOR,
+  evidenceCount,
+  levelFromPosterior,
+  type Posterior,
+  posteriorMean,
+  priorFromCompetence,
+} from "../trustLevel.js";
+
+function applyN(
+  p: Posterior,
+  n: number,
+  good: boolean,
+  weight: number,
+): Posterior {
+  let cur = p;
+  for (let i = 0; i < n; i++) cur = applyOutcome(cur, good, weight);
+  return cur;
+}
+
+const ALL_REACHABLE = [0, 1, 2, 3, 4];
+const IRREVERSIBLE_REACHABLE = [0, 1, 4];
+
+describe("trustLevel — cold start", () => {
+  it("a fresh uniform prior floors at L0 (wide posterior → low bound)", () => {
+    const r = levelFromPosterior(DEFAULT_PRIOR, DEFAULT_PRIOR, {
+      reachable: ALL_REACHABLE,
+    });
+    expect(r.level).toBe(0);
+  });
+
+  it("a high-mean competence prior with no local evidence is still capped at L1", () => {
+    // ships competence (mean 0.95) but trust must be earned locally
+    const prior = priorFromCompetence(0.95, 8);
+    const r = levelFromPosterior(prior, prior, { reachable: ALL_REACHABLE });
+    expect(evidenceCount(prior, prior)).toBe(0);
+    expect(r.level).toBeLessThanOrEqual(1);
+  });
+});
+
+describe("trustLevel — slow climb", () => {
+  it("reaches L4 only after sustained success on a reversible class (~dozens of obs)", () => {
+    const p = applyN(DEFAULT_PRIOR, 60, true, 1);
+    const r = levelFromPosterior(p, DEFAULT_PRIOR, {
+      reachable: ALL_REACHABLE,
+    });
+    expect(r.level).toBe(4);
+  });
+
+  it("a handful of successes is NOT enough to graduate past L1", () => {
+    const p = applyN(DEFAULT_PRIOR, 5, true, 1);
+    const r = levelFromPosterior(p, DEFAULT_PRIOR, {
+      reachable: ALL_REACHABLE,
+    });
+    expect(r.level).toBeLessThanOrEqual(1);
+  });
+});
+
+describe("trustLevel — instant demote (asymmetry)", () => {
+  it("one high-blast failure craters a long-earned L4 in a single step", () => {
+    const earned = applyN(DEFAULT_PRIOR, 60, true, 1);
+    expect(
+      levelFromPosterior(earned, DEFAULT_PRIOR, { reachable: ALL_REACHABLE })
+        .level,
+    ).toBe(4);
+    // a single catastrophic failure (blast-weighted weight 36)
+    const after = applyOutcome(earned, false, 36);
+    const r = levelFromPosterior(after, DEFAULT_PRIOR, {
+      reachable: ALL_REACHABLE,
+    });
+    expect(r.level).toBeLessThanOrEqual(1);
+  });
+});
+
+describe("trustLevel — reachability clamp", () => {
+  it("an irreversible class at a would-be-L3 posterior stays at L1 (skips L2/L3)", () => {
+    const p = applyN(DEFAULT_PRIOR, 30, true, 1); // lands ~L3 by LCB
+    const rev = levelFromPosterior(p, DEFAULT_PRIOR, {
+      reachable: ALL_REACHABLE,
+    });
+    expect(rev.rawLevel).toBeGreaterThanOrEqual(2);
+    const irrev = levelFromPosterior(p, DEFAULT_PRIOR, {
+      reachable: IRREVERSIBLE_REACHABLE,
+    });
+    expect(irrev.level).toBe(1); // highest reachable rung ≤ rawLevel
+  });
+
+  it("an irreversible class jumps straight L1→L4 once it clears the top bar", () => {
+    const p = applyN(DEFAULT_PRIOR, 120, true, 1);
+    const r = levelFromPosterior(p, DEFAULT_PRIOR, {
+      reachable: IRREVERSIBLE_REACHABLE,
+    });
+    expect(r.level).toBe(4);
+  });
+});
+
+describe("priorFromCompetence", () => {
+  it("encodes the claimed mean and caps strength so it can be overcome", () => {
+    const p = priorFromCompetence(0.9, 100);
+    expect(posteriorMean(p)).toBeCloseTo(0.9, 2);
+    expect(p.alpha + p.beta).toBeLessThanOrEqual(8); // strength capped
+  });
+});

--- a/src/workers/__tests__/worker.test.ts
+++ b/src/workers/__tests__/worker.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import { classifyActionClass } from "../actionClass.js";
+import { DEFAULT_PRIOR, posteriorMean } from "../trustLevel.js";
+import {
+  ownsAction,
+  parseWorker,
+  priorFor,
+  WorkerParseError,
+} from "../worker.js";
+
+describe("parseWorker", () => {
+  it("parses a full manifest", () => {
+    const w = parseWorker({
+      id: "release-bot",
+      name: "Release Worker",
+      responsibilities: ["draft release notes"],
+      recipe: "release-notes",
+      owns: ["vcs-read", "fs-write"],
+      autonomyCeiling: 3,
+      competence: { mean: 0.9, strength: 4 },
+      sector: "engineering",
+    });
+    expect(w.id).toBe("release-bot");
+    expect(w.autonomyCeiling).toBe(3);
+    expect(w.owns).toEqual(["vcs-read", "fs-write"]);
+  });
+
+  it("defaults autonomyCeiling to 4 (uncapped) and owns to []", () => {
+    const w = parseWorker({ id: "w", name: "W" });
+    expect(w.autonomyCeiling).toBe(4);
+    expect(w.owns).toEqual([]);
+    expect(w.competence).toBeUndefined();
+  });
+
+  it("rejects a non-kebab id, an out-of-range ceiling, and a bad competence mean", () => {
+    expect(() => parseWorker({ id: "Bad Id", name: "x" })).toThrow(
+      WorkerParseError,
+    );
+    expect(() =>
+      parseWorker({ id: "w", name: "x", autonomyCeiling: 5 }),
+    ).toThrow(WorkerParseError);
+    expect(() =>
+      parseWorker({ id: "w", name: "x", competence: { mean: 2, strength: 4 } }),
+    ).toThrow(WorkerParseError);
+  });
+});
+
+describe("priorFor", () => {
+  it("returns the uniform prior with no competence claim", () => {
+    expect(priorFor(parseWorker({ id: "w", name: "W" }))).toEqual(
+      DEFAULT_PRIOR,
+    );
+  });
+
+  it("encodes a competence claim as the prior mean", () => {
+    const p = priorFor(
+      parseWorker({
+        id: "w",
+        name: "W",
+        competence: { mean: 0.9, strength: 4 },
+      }),
+    );
+    expect(posteriorMean(p)).toBeCloseTo(0.9, 2);
+  });
+});
+
+describe("ownsAction", () => {
+  const w = parseWorker({
+    id: "w",
+    name: "W",
+    owns: ["vcs-local", "fs-write:reversible:medium"],
+  });
+
+  it("matches by domain, exact key, and prefix; rejects unowned", () => {
+    expect(ownsAction(w, classifyActionClass("gitCommit"))).toBe(true); // vcs-local domain
+    expect(ownsAction(w, classifyActionClass("editText"))).toBe(true); // exact key
+    expect(ownsAction(w, classifyActionClass("slackPostMessage"))).toBe(false);
+  });
+
+  it("a worker owning nothing matches nothing", () => {
+    const empty = parseWorker({ id: "e", name: "E" });
+    expect(ownsAction(empty, classifyActionClass("editText"))).toBe(false);
+  });
+});

--- a/src/workers/__tests__/workerLevelStore.test.ts
+++ b/src/workers/__tests__/workerLevelStore.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import type { GraduationConfig } from "../graduation.js";
+import { WorkerLevelStore } from "../workerLevelStore.js";
+
+const CFG: GraduationConfig = {
+  dwellMs: 1000,
+  demoteCooldownMs: 5000,
+  minEvidenceForGraduation: 5,
+};
+const W = "release-bot";
+
+function climbToL4(store: WorkerLevelStore, worker: string) {
+  for (let i = 0; i < 60; i++) {
+    store.apply(
+      worker,
+      { toolName: "editText", good: true, at: 0 },
+      { cfg: CFG },
+    );
+  }
+  for (const at of [1000, 2000, 3000, 4000]) {
+    store.apply(worker, { toolName: "editText", good: true, at }, { cfg: CFG });
+  }
+}
+
+describe("WorkerLevelStore", () => {
+  it("accumulates per-class trust and surfaces it on the dial board", () => {
+    const store = new WorkerLevelStore();
+    climbToL4(store, W);
+    const board = store.board(W);
+    expect(board).toHaveLength(1);
+    expect(board[0]).toMatchObject({
+      classKey: "fs-write:reversible:medium",
+      level: 4,
+      observations: 64,
+    });
+  });
+
+  it("records promotion events stamped with the worker id (audit log)", () => {
+    const store = new WorkerLevelStore();
+    climbToL4(store, W);
+    const ev = store.events(W);
+    expect(ev.length).toBeGreaterThanOrEqual(4);
+    expect(ev.every((e) => e.workerId === W)).toBe(true);
+    expect(ev[0]!.type).toBe("promote");
+  });
+
+  it("isolates trust per worker", () => {
+    const store = new WorkerLevelStore();
+    climbToL4(store, W);
+    store.apply(
+      "other-bot",
+      { toolName: "runTests", good: true, at: 0 },
+      { cfg: CFG },
+    );
+    expect(store.board(W)).toHaveLength(1); // unaffected
+    expect(store.board("other-bot")).toHaveLength(1);
+    expect(store.events("other-bot")).toHaveLength(0);
+  });
+
+  it("round-trips state + audit log through JSONL", () => {
+    const store = new WorkerLevelStore();
+    climbToL4(store, W);
+    const restored = WorkerLevelStore.fromJSONL(store.toJSONL());
+    expect(restored.board(W)).toEqual(store.board(W));
+    expect(restored.events(W).length).toBe(store.events(W).length);
+    expect(restored.getState(W, "fs-write:reversible:medium")?.level).toBe(4);
+  });
+});

--- a/src/workers/actionClass.ts
+++ b/src/workers/actionClass.ts
@@ -1,0 +1,159 @@
+import { classifyTool, type RiskTier } from "../riskTier.js";
+
+/**
+ * Worker trust is scoped per (worker × action-class), never globally. An
+ * action-class is the unit that accumulates evidence. It is intentionally
+ * COARSE enough to graduate (a worker touches only a handful) yet keyed on
+ * blast-tier so that a rarer, higher-blast action in the same domain is a
+ * DISTINCT, less-trusted class — competence on routine `git status` can never
+ * transfer to `git push --force`. (worker-ramp-v0)
+ */
+
+export type Reversibility = "reversible" | "compensable" | "irreversible";
+
+export interface ActionClass {
+  /** Stable identity: `${domain}:${reversibility}:${blastTier}`. */
+  key: string;
+  domain: string;
+  reversibility: Reversibility;
+  blastTier: RiskTier;
+  /**
+   * Brand/reputational exposure — a DISTINCT gating dimension from safety blast
+   * radius (cf. Arts & Media: low safety risk, high reputational risk). An
+   * externally-visible action (outbound message, public PR/push, issue) whose
+   * failure damages reputation rather than (or as well as) systems. Folds into
+   * the failure weight so reputational mistakes demote trust harder.
+   */
+  brandExposed: boolean;
+}
+
+/**
+ * Tool → capability domain. Coarse on purpose. Unknown tools fall to "other"
+ * (treated as irreversible — conservative: an unrecognised side effect is
+ * assumed unrecoverable until proven otherwise).
+ */
+const DOMAIN_BY_TOOL: Record<string, string> = {
+  // version control — read
+  getGitStatus: "vcs-read",
+  getGitDiff: "vcs-read",
+  getGitLog: "vcs-read",
+  gitBlame: "vcs-read",
+  gitListBranches: "vcs-read",
+  // version control — local mutations (reversible: reset/reflog/restore)
+  gitAdd: "vcs-local",
+  gitCommit: "vcs-local",
+  gitCheckout: "vcs-local",
+  gitStash: "vcs-local",
+  // version control — remote / shared history
+  gitPush: "vcs-remote",
+  githubCreatePR: "vcs-remote",
+  githubMergePR: "vcs-remote",
+  // filesystem
+  editText: "fs-write",
+  searchAndReplace: "fs-write",
+  createFile: "fs-write",
+  formatDocument: "fs-write",
+  getBufferContent: "fs-read",
+  findFiles: "fs-read",
+  // shell
+  runCommand: "shell",
+  runInTerminal: "shell",
+  sendTerminalCommand: "shell",
+  // outbound messaging
+  slackPostMessage: "messaging",
+  // generic network
+  sendHttpRequest: "http",
+  WebFetch: "http",
+  // issue trackers
+  githubCreateIssue: "issue",
+  createLinearIssue: "issue",
+  addLinearComment: "issue",
+  updateLinearIssue: "issue",
+  // CI / tests
+  runTests: "ci",
+  githubActions: "ci",
+  // dependency intel (read-only)
+  auditDependencies: "deps-read",
+  getSecurityAdvisories: "deps-read",
+};
+
+/** Domain → reversibility. The middle ramp rungs (L2/L3) only exist for a class
+ * whose reversibility is not "irreversible", so this is load-bearing. */
+const REVERSIBILITY_BY_DOMAIN: Record<string, Reversibility> = {
+  "vcs-read": "reversible",
+  "vcs-local": "reversible", // reset / reflog / restore
+  "vcs-remote": "compensable", // force-push back / close PR — lossy, possible
+  "fs-write": "reversible", // transactions + WriteEffectLedger
+  "fs-read": "reversible",
+  shell: "irreversible", // arbitrary side effects — assume unrecoverable
+  messaging: "irreversible", // a sent message can't be unsent reliably
+  http: "irreversible", // a POST may not be undoable
+  issue: "compensable", // close / delete the created issue
+  ci: "reversible", // re-runnable, no durable side effect
+  "deps-read": "reversible",
+  other: "irreversible",
+};
+
+/** Domains whose actions are externally visible — failure is reputational. */
+const BRAND_EXPOSED_DOMAINS = new Set([
+  "messaging",
+  "vcs-remote",
+  "issue",
+  "http",
+]);
+
+export function classifyActionClass(
+  toolName: string,
+  _params?: Record<string, unknown>,
+): ActionClass {
+  const domain = DOMAIN_BY_TOOL[toolName] ?? "other";
+  const reversibility = REVERSIBILITY_BY_DOMAIN[domain] ?? "irreversible";
+  const blastTier = classifyTool(toolName);
+  return {
+    key: `${domain}:${reversibility}:${blastTier}`,
+    domain,
+    reversibility,
+    blastTier,
+    brandExposed: BRAND_EXPOSED_DOMAINS.has(domain),
+  };
+}
+
+const BLAST_MULTIPLIER: Record<RiskTier, number> = {
+  low: 2,
+  medium: 5,
+  high: 12,
+};
+const REVERSIBILITY_MULTIPLIER: Record<Reversibility, number> = {
+  reversible: 1,
+  compensable: 1.5,
+  irreversible: 3,
+};
+
+/**
+ * Evidence weight for one outcome. A routine success is low-information
+ * (weight 1 → the posterior climbs slowly). A failure is weighted by
+ * blast-tier × reversibility, so a high-blast irreversible failure is high
+ * information and craters the posterior (instant demote). This is the entire
+ * anti-trust-transfer-grinding defence: count alone never graduates a risky
+ * class, and one catastrophic outcome dominates a thousand trivial ones.
+ */
+const BRAND_MULTIPLIER = 1.5;
+
+export function outcomeWeight(actionClass: ActionClass, good: boolean): number {
+  if (good) return 1;
+  const brand = actionClass.brandExposed ? BRAND_MULTIPLIER : 1;
+  return (
+    BLAST_MULTIPLIER[actionClass.blastTier] *
+    REVERSIBILITY_MULTIPLIER[actionClass.reversibility] *
+    brand
+  );
+}
+
+/** Which ramp rungs are reachable for a class. Irreversible classes skip the
+ * safety-net rungs L2/L3 (no compensating action exists), so they must clear a
+ * higher bar to reach L4. */
+export function reachableLevels(actionClass: ActionClass): number[] {
+  return actionClass.reversibility === "irreversible"
+    ? [0, 1, 4]
+    : [0, 1, 2, 3, 4];
+}

--- a/src/workers/actionClass.ts
+++ b/src/workers/actionClass.ts
@@ -75,6 +75,22 @@ const DOMAIN_BY_TOOL: Record<string, string> = {
   // dependency intel (read-only)
   auditDependencies: "deps-read",
   getSecurityAdvisories: "deps-read",
+  // recipe-tool ids — RecipeRunLog records THESE (not the MCP names), so the
+  // shadow dial attributes recipe-run steps by them. git.*/github.list_* are
+  // reads; file.* writes; slack/http are outbound. (worker-ramp-v0 dogfood)
+  "git.log_since": "vcs-read",
+  "git.stale_branches": "vcs-read",
+  "github.list_commits": "vcs-read",
+  "github.list_prs": "vcs-read",
+  "github.list_issues": "vcs-read",
+  "file.read": "fs-read",
+  "file.write": "fs-write",
+  "file.append": "fs-write",
+  "slack.post_message": "messaging",
+  "http.post": "http",
+  "linear.list_issues": "issue",
+  "sentry.get_issue": "issue",
+  "diagnostics.get": "fs-read",
 };
 
 /** Domain → reversibility. The middle ramp rungs (L2/L3) only exist for a class

--- a/src/workers/graduation.ts
+++ b/src/workers/graduation.ts
@@ -1,0 +1,161 @@
+import {
+  type ActionClass,
+  classifyActionClass,
+  outcomeWeight,
+  reachableLevels,
+} from "./actionClass.js";
+import {
+  applyOutcome,
+  levelFromPosterior,
+  type Posterior,
+  type TrustLevel,
+} from "./trustLevel.js";
+
+/**
+ * Folds outcomes into a (worker × action-class) trust state and decides
+ * promotions/demotions with the asymmetry + hysteresis the ramp requires:
+ *   - DEMOTE is instant and can jump multiple rungs (one catastrophic outcome
+ *     craters the posterior; we honor it immediately, even mid-dwell);
+ *   - PROMOTE is gated by dwell-time (real elapsed time since the last level
+ *     change) AND a post-demote cooldown, and climbs only to the NEXT reachable
+ *     rung — so reaching L4 needs both sustained evidence and sustained time.
+ * Every level change emits an event — the promotion/demotion log is the
+ * compliance/audit artifact.
+ */
+
+export interface Outcome {
+  toolName: string;
+  good: boolean;
+  /** epoch ms (passed in — the runtime has no Date.now() in pure code). */
+  at: number;
+  params?: Record<string, unknown>;
+}
+
+export interface ClassTrustState {
+  classKey: string;
+  posterior: Posterior;
+  prior: Posterior;
+  level: TrustLevel;
+  /** epoch ms of the last level change (drives dwell). */
+  lastChangeAt: number;
+  /** epoch ms before which promotions are blocked (post-demote cooldown). */
+  demoteUntil: number;
+  observations: number;
+}
+
+export interface GraduationConfig {
+  dwellMs: number;
+  demoteCooldownMs: number;
+  k?: number;
+  minEvidenceForGraduation?: number;
+}
+
+export const DEFAULT_GRADUATION_CONFIG: GraduationConfig = {
+  dwellMs: 6 * 60 * 60 * 1000, // 6h between climbs
+  demoteCooldownMs: 24 * 60 * 60 * 1000, // 24h freeze after a fall
+  minEvidenceForGraduation: 10,
+};
+
+export interface GraduationEvent {
+  type: "promote" | "demote";
+  classKey: string;
+  from: TrustLevel;
+  to: TrustLevel;
+  at: number;
+  lcb: number;
+  evidence: number;
+  reason: string;
+}
+
+export function initialState(
+  classKey: string,
+  prior: Posterior,
+  at = 0,
+): ClassTrustState {
+  return {
+    classKey,
+    posterior: prior,
+    prior,
+    level: 0,
+    lastChangeAt: at,
+    demoteUntil: 0,
+    observations: 0,
+  };
+}
+
+export function graduate(
+  state: ClassTrustState,
+  outcome: Outcome,
+  cfg: GraduationConfig = DEFAULT_GRADUATION_CONFIG,
+): { state: ClassTrustState; event?: GraduationEvent } {
+  const ac: ActionClass = classifyActionClass(outcome.toolName, outcome.params);
+  const weight = outcomeWeight(ac, outcome.good);
+  const posterior = applyOutcome(state.posterior, outcome.good, weight);
+  const observations = state.observations + 1;
+
+  const result = levelFromPosterior(posterior, state.prior, {
+    k: cfg.k,
+    minEvidenceForGraduation: cfg.minEvidenceForGraduation,
+    reachable: reachableLevels(ac),
+  });
+  const candidate = result.level;
+
+  const base: ClassTrustState = {
+    ...state,
+    posterior,
+    observations,
+  };
+
+  // DEMOTE — instant, may skip rungs.
+  if (candidate < state.level) {
+    const next: ClassTrustState = {
+      ...base,
+      level: candidate,
+      lastChangeAt: outcome.at,
+      demoteUntil: outcome.at + cfg.demoteCooldownMs,
+    };
+    return {
+      state: next,
+      event: {
+        type: "demote",
+        classKey: state.classKey,
+        from: state.level,
+        to: candidate,
+        at: outcome.at,
+        lcb: result.lcb,
+        evidence: result.evidence,
+        reason: `blast-weighted failure (weight=${weight})`,
+      },
+    };
+  }
+
+  // PROMOTE — gated by dwell + cooldown, one reachable rung at a time.
+  if (candidate > state.level) {
+    const dwellOk = outcome.at >= state.lastChangeAt + cfg.dwellMs;
+    const cooldownOk = outcome.at >= state.demoteUntil;
+    if (dwellOk && cooldownOk) {
+      const nextRung = reachableLevels(ac)
+        .filter((r) => r > state.level && r <= candidate)
+        .sort((a, b) => a - b)[0];
+      if (nextRung !== undefined) {
+        const to = nextRung as TrustLevel;
+        return {
+          state: { ...base, level: to, lastChangeAt: outcome.at },
+          event: {
+            type: "promote",
+            classKey: state.classKey,
+            from: state.level,
+            to,
+            at: outcome.at,
+            lcb: result.lcb,
+            evidence: result.evidence,
+            reason: `sustained evidence (lcb=${result.lcb.toFixed(3)})`,
+          },
+        };
+      }
+    }
+  }
+
+  // No level change — posterior still updates.
+  return { state: base };
+}

--- a/src/workers/shadowGate.ts
+++ b/src/workers/shadowGate.ts
@@ -1,0 +1,69 @@
+import { classifyActionClass } from "./actionClass.js";
+import type { TrustLevel } from "./trustLevel.js";
+import { ownsAction, type WorkerManifest } from "./worker.js";
+import type { WorkerLevelStore } from "./workerLevelStore.js";
+
+/**
+ * What the ramp WOULD decide for a worker's action — a PURE recommendation.
+ *
+ * v0 is shadow-only: this is NOT wired into the live approval gate
+ * (`evaluateInProcessGate`). Flipping the gate to obey the ramp is a deliberate,
+ * flag-gated phase-2 step, taken only after shadow data shows the ramp's
+ * decisions track reality. Until then this exists to log "ramp would bypass /
+ * gate did queue" and to drive the dial.
+ *
+ * Only the two execution modes that already exist are actionable in v0:
+ *   L4 → bypass (autonomous), everything below → queue (approve-each).
+ * The full earned level (0–4) is reported for the dial. The effective level is
+ * `min(earned, autonomyCeiling)`, floored to 0 for actions outside the worker's
+ * domain — a worker has no standing trust on things it doesn't own.
+ */
+
+export interface ShadowDecision {
+  decision: "queue" | "bypass";
+  classKey: string;
+  owned: boolean;
+  /** Trust the worker has actually earned on this class (drives the dial). */
+  earnedLevel: TrustLevel;
+  autonomyCeiling: TrustLevel;
+  /** What the gate would operate at: min(earned, ceiling), 0 if not owned. */
+  effectiveLevel: TrustLevel;
+  reason: string;
+}
+
+const AUTONOMOUS_LEVEL = 4;
+
+export function recommend(
+  worker: WorkerManifest,
+  toolName: string,
+  params: Record<string, unknown> | undefined,
+  store: WorkerLevelStore,
+): ShadowDecision {
+  const ac = classifyActionClass(toolName, params);
+  const owned = ownsAction(worker, ac);
+  const earnedLevel = (store.getState(worker.id, ac.key)?.level ??
+    0) as TrustLevel;
+
+  let effectiveLevel: TrustLevel = owned ? earnedLevel : 0;
+  if (effectiveLevel > worker.autonomyCeiling)
+    effectiveLevel = worker.autonomyCeiling;
+
+  const decision = effectiveLevel >= AUTONOMOUS_LEVEL ? "bypass" : "queue";
+
+  let reason: string;
+  if (!owned) reason = "outside-worker-domain";
+  else if (worker.autonomyCeiling < earnedLevel)
+    reason = `capped-by-autonomy-ceiling (L${worker.autonomyCeiling}, earned L${earnedLevel})`;
+  else if (decision === "bypass") reason = "autonomous (earned L4)";
+  else reason = `below-autonomy (effective L${effectiveLevel})`;
+
+  return {
+    decision,
+    classKey: ac.key,
+    owned,
+    earnedLevel,
+    autonomyCeiling: worker.autonomyCeiling,
+    effectiveLevel,
+    reason,
+  };
+}

--- a/src/workers/shadowRun.ts
+++ b/src/workers/shadowRun.ts
@@ -1,0 +1,94 @@
+import {
+  DEFAULT_GRADUATION_CONFIG,
+  type GraduationConfig,
+  type Outcome,
+} from "./graduation.js";
+import { priorFor, type WorkerManifest } from "./worker.js";
+import {
+  type AuditEvent,
+  type BoardRow,
+  WorkerLevelStore,
+} from "./workerLevelStore.js";
+
+/**
+ * Replay an outcome sequence for a worker and capture the per-step dial
+ * trajectory. This is the cheapest test of the evidence-latency risk: it shows,
+ * deterministically, how many real observations (and how much wall-clock) a
+ * worker needs to climb each class — and how one catastrophic outcome demotes
+ * it in a single step. No model calls, no live gate — pure replay.
+ */
+
+export interface TrajectoryStep {
+  index: number;
+  at: number;
+  toolName: string;
+  good: boolean;
+  classKey: string;
+  level: number;
+  changed: "promote" | "demote" | null;
+}
+
+export interface ShadowRunResult {
+  workerId: string;
+  trajectory: TrajectoryStep[];
+  board: BoardRow[];
+  events: AuditEvent[];
+  store: WorkerLevelStore;
+}
+
+export function shadowRun(
+  worker: WorkerManifest,
+  outcomes: Outcome[],
+  opts: { cfg?: GraduationConfig; store?: WorkerLevelStore } = {},
+): ShadowRunResult {
+  const store = opts.store ?? new WorkerLevelStore();
+  const cfg = opts.cfg ?? DEFAULT_GRADUATION_CONFIG;
+  const prior = priorFor(worker);
+  const trajectory: TrajectoryStep[] = [];
+  outcomes.forEach((o, index) => {
+    const r = store.apply(worker.id, o, { prior, cfg });
+    trajectory.push({
+      index,
+      at: o.at,
+      toolName: o.toolName,
+      good: o.good,
+      classKey: r.classKey,
+      level: r.state.level,
+      changed: r.event?.type ?? null,
+    });
+  });
+  return {
+    workerId: worker.id,
+    trajectory,
+    board: store.board(worker.id),
+    events: store.events(worker.id),
+    store,
+  };
+}
+
+/** First trajectory step where `classKey` reached at least `level`. */
+export function firstReached(
+  result: ShadowRunResult,
+  classKey: string,
+  level: number,
+): TrajectoryStep | undefined {
+  return result.trajectory.find(
+    (s) => s.classKey === classKey && s.level >= level,
+  );
+}
+
+/** Build a steady cadence of same-tool outcomes spaced `intervalMs` apart. */
+export function cadence(
+  toolName: string,
+  count: number,
+  opts: { startAt?: number; intervalMs?: number; good?: boolean } = {},
+): Outcome[] {
+  const start = opts.startAt ?? 0;
+  const interval = opts.intervalMs ?? 6 * 60 * 60 * 1000; // 6h
+  const good = opts.good ?? true;
+  return Array.from({ length: count }, (_, i) => ({
+    toolName,
+    good,
+    at: start + i * interval,
+  }));
+}

--- a/src/workers/trustLevel.ts
+++ b/src/workers/trustLevel.ts
@@ -1,0 +1,139 @@
+/**
+ * Bayesian trust model for a single (worker × action-class) pair.
+ *
+ * Reliability `p` (the probability that an action of this class is "good") is a
+ * Beta(α, β) posterior. The discrete autonomy rung L0–L4 is a threshold
+ * crossing of the posterior's LOWER confidence bound, not its mean. Using the
+ * lower bound is what makes the ramp behave correctly:
+ *   - cold-start floors automatically: a fresh/wide posterior has a low bound
+ *     even if its mean is optimistic, so a worker (or a marketplace prior) can't
+ *     start trusted — uncertainty must collapse on local evidence first;
+ *   - climbing is slow: the bound only rises as the mean rises AND variance
+ *     shrinks, i.e. with sustained evidence;
+ *   - demotion is instant: one high-weight failure spikes β, the mean drops and
+ *     the bound craters in a single step.
+ *
+ * Asymmetry ("slow up, instant down") is therefore information, not a tuned
+ * rule — it falls out of weighting failures by blast radius (see actionClass).
+ */
+
+export interface Posterior {
+  readonly alpha: number;
+  readonly beta: number;
+}
+
+/** Uniform prior — maximally uncertain, no shipped competence. */
+export const DEFAULT_PRIOR: Posterior = { alpha: 1, beta: 1 };
+
+/**
+ * Build a prior from a competence claim: a mean reliability + a strength
+ * (pseudo-count). Low strength = wide uncertainty = the bound stays low until
+ * local evidence accumulates. This is how a marketplace worker ships
+ * competence (a mean) without shipping trust (the bound only tightens on the
+ * operator's own data). Strength is capped low on purpose.
+ */
+export function priorFromCompetence(mean: number, strength: number): Posterior {
+  const m = Math.min(0.99, Math.max(0.01, mean));
+  const s = Math.min(8, Math.max(0.5, strength));
+  return { alpha: m * s, beta: (1 - m) * s };
+}
+
+export function posteriorMean(p: Posterior): number {
+  return p.alpha / (p.alpha + p.beta);
+}
+
+export function posteriorStddev(p: Posterior): number {
+  const n = p.alpha + p.beta;
+  return Math.sqrt((p.alpha * p.beta) / (n * n * (n + 1)));
+}
+
+/** Lower confidence bound: mean − k·σ, clamped to [0, 1]. The level reads off
+ * THIS, not the mean. */
+export function lowerConfidenceBound(p: Posterior, k = 1.5): number {
+  return Math.max(0, Math.min(1, posteriorMean(p) - k * posteriorStddev(p)));
+}
+
+/** Apply one outcome. A good outcome adds to α, a bad one to β, scaled by the
+ * blast-weighted evidence weight from actionClass.outcomeWeight. */
+export function applyOutcome(
+  p: Posterior,
+  good: boolean,
+  weight: number,
+): Posterior {
+  return good
+    ? { alpha: p.alpha + weight, beta: p.beta }
+    : { alpha: p.alpha, beta: p.beta + weight };
+}
+
+/** Total evidence accumulated relative to the prior (pseudo-observations). */
+export function evidenceCount(p: Posterior, prior: Posterior): number {
+  return p.alpha + p.beta - (prior.alpha + prior.beta);
+}
+
+export type TrustLevel = 0 | 1 | 2 | 3 | 4;
+
+/** LCB → rung. Tunable; conservative by default. */
+export const DEFAULT_THRESHOLDS: ReadonlyArray<{
+  min: number;
+  level: TrustLevel;
+}> = [
+  { min: 0.95, level: 4 },
+  { min: 0.85, level: 3 },
+  { min: 0.7, level: 2 },
+  { min: 0.5, level: 1 },
+  { min: 0, level: 0 },
+];
+
+export interface LevelOpts {
+  k?: number;
+  /** Min evidence before a class may exceed L1 (novel-class floor). */
+  minEvidenceForGraduation?: number;
+  /** Rungs reachable for this class (irreversible classes omit L2/L3). */
+  reachable?: number[];
+  thresholds?: ReadonlyArray<{ min: number; level: TrustLevel }>;
+}
+
+export interface LevelResult {
+  level: TrustLevel;
+  /** Level before the novel-floor + reachability clamps (for diagnostics). */
+  rawLevel: TrustLevel;
+  lcb: number;
+  mean: number;
+  evidence: number;
+}
+
+/**
+ * Map a posterior to a discrete rung, applying:
+ *  1. LCB → raw level via thresholds.
+ *  2. Novel-class floor: below the evidence minimum, cap at L1 regardless of how
+ *     good the (necessarily wide) posterior looks — no class graduates on faith.
+ *  3. Reachability clamp: drop to the highest reachable rung ≤ the computed one,
+ *     so an irreversible class climbing through "would-be L2/L3" stays at L1
+ *     until it actually clears the L4 bar.
+ */
+export function levelFromPosterior(
+  p: Posterior,
+  prior: Posterior,
+  opts: LevelOpts = {},
+): LevelResult {
+  const k = opts.k ?? 1.5;
+  const minEvidence = opts.minEvidenceForGraduation ?? 10;
+  const reachable = opts.reachable ?? [0, 1, 2, 3, 4];
+  const thresholds = opts.thresholds ?? DEFAULT_THRESHOLDS;
+
+  const lcb = lowerConfidenceBound(p, k);
+  const mean = posteriorMean(p);
+  const evidence = evidenceCount(p, prior);
+
+  const rawLevel =
+    thresholds.find((t) => lcb >= t.min)?.level ?? (0 as TrustLevel);
+
+  let level: TrustLevel = rawLevel;
+  // Novel-class floor.
+  if (evidence < minEvidence && level > 1) level = 1;
+  // Reachability clamp (highest reachable rung ≤ level).
+  const allowed = reachable.filter((r) => r <= level);
+  level = (allowed.length ? Math.max(...allowed) : 0) as TrustLevel;
+
+  return { level, rawLevel, lcb, mean, evidence };
+}

--- a/src/workers/worker.ts
+++ b/src/workers/worker.ts
@@ -1,0 +1,137 @@
+import type { ActionClass } from "./actionClass.js";
+import {
+  DEFAULT_PRIOR,
+  type Posterior,
+  priorFromCompetence,
+  type TrustLevel,
+} from "./trustLevel.js";
+
+/**
+ * A worker manifest. Deliberately NOT a fork of the recipe schema — the recipe
+ * is the worker's *body* (triggers + steps); this manifest adds identity, the
+ * action-classes it owns, a trust prior, and the policy autonomy ceiling. It
+ * references a recipe by name rather than redefining execution. (worker-ramp-v0)
+ */
+
+const WORKER_ID_RE = /^[a-z0-9][a-z0-9-]{0,63}$/;
+
+export interface WorkerCompetence {
+  /** Claimed reliability mean (0–1) — a competence claim, not trust. */
+  mean: number;
+  /** Prior strength (pseudo-count); capped low so local evidence dominates. */
+  strength: number;
+}
+
+export interface WorkerManifest {
+  id: string;
+  name: string;
+  responsibilities: string[];
+  /** Recipe name that forms this worker's body (its triggers + steps). */
+  recipe?: string;
+  /**
+   * Action-classes this worker is responsible for. Each pattern matches a
+   * class by its domain, or by an exact/prefix class-key match
+   * (`vcs-local` matches `vcs-local:*`; `fs-write:reversible:medium` is exact).
+   */
+  owns: string[];
+  /**
+   * Policy/regulatory cap on the max ramp level this worker may EVER reach,
+   * independent of earned track record — the schema encoding of the
+   * autonomy-tolerance axis (e.g. a Legal-sector worker is pinned at L2). The
+   * dial still shows *earned* level; the gate operates at min(earned, ceiling).
+   */
+  autonomyCeiling: TrustLevel;
+  /** Optional shipped competence → the per-class prior. */
+  competence?: WorkerCompetence;
+  /** Free-form sector tag (drives default ceilings / reporting). */
+  sector?: string;
+}
+
+export class WorkerParseError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "WorkerParseError";
+  }
+}
+
+function reqString(o: Record<string, unknown>, key: string): string {
+  const v = o[key];
+  if (typeof v !== "string" || !v)
+    throw new WorkerParseError(`worker.${key} must be a non-empty string`);
+  return v;
+}
+
+export function parseWorker(raw: unknown): WorkerManifest {
+  if (typeof raw !== "object" || raw === null)
+    throw new WorkerParseError("worker must be an object");
+  const r = raw as Record<string, unknown>;
+
+  const id = reqString(r, "id");
+  if (!WORKER_ID_RE.test(id))
+    throw new WorkerParseError(
+      `worker.id must be kebab-case (got ${JSON.stringify(id)})`,
+    );
+  const name = reqString(r, "name");
+
+  const owns = Array.isArray(r.owns)
+    ? r.owns.filter((x): x is string => typeof x === "string")
+    : [];
+
+  const responsibilities = Array.isArray(r.responsibilities)
+    ? r.responsibilities.filter((x): x is string => typeof x === "string")
+    : [];
+
+  // autonomyCeiling: 0–4, default 4 (uncapped).
+  let autonomyCeiling: TrustLevel = 4;
+  if (r.autonomyCeiling !== undefined) {
+    const c = r.autonomyCeiling;
+    if (typeof c !== "number" || !Number.isInteger(c) || c < 0 || c > 4)
+      throw new WorkerParseError(
+        "worker.autonomyCeiling must be an integer 0–4",
+      );
+    autonomyCeiling = c as TrustLevel;
+  }
+
+  let competence: WorkerCompetence | undefined;
+  if (r.competence !== undefined) {
+    const c = r.competence as Record<string, unknown>;
+    if (
+      typeof c !== "object" ||
+      c === null ||
+      typeof c.mean !== "number" ||
+      typeof c.strength !== "number"
+    )
+      throw new WorkerParseError(
+        "worker.competence must be { mean: number, strength: number }",
+      );
+    if (c.mean < 0 || c.mean > 1)
+      throw new WorkerParseError("worker.competence.mean must be in [0,1]");
+    competence = { mean: c.mean, strength: c.strength };
+  }
+
+  return {
+    id,
+    name,
+    responsibilities,
+    recipe: typeof r.recipe === "string" ? r.recipe : undefined,
+    owns,
+    autonomyCeiling,
+    competence,
+    sector: typeof r.sector === "string" ? r.sector : undefined,
+  };
+}
+
+/** The per-class trust prior for a worker (its shipped competence, or uniform). */
+export function priorFor(worker: WorkerManifest): Posterior {
+  return worker.competence
+    ? priorFromCompetence(worker.competence.mean, worker.competence.strength)
+    : DEFAULT_PRIOR;
+}
+
+/** Whether a worker is responsible for a given action-class. A pattern matches
+ * the class domain, an exact key, or a key prefix. Empty `owns` ⇒ owns nothing. */
+export function ownsAction(worker: WorkerManifest, ac: ActionClass): boolean {
+  return worker.owns.some(
+    (p) => p === ac.domain || p === ac.key || ac.key.startsWith(`${p}:`),
+  );
+}

--- a/src/workers/workerLevelStore.ts
+++ b/src/workers/workerLevelStore.ts
@@ -1,0 +1,123 @@
+import { classifyActionClass } from "./actionClass.js";
+import {
+  type ClassTrustState,
+  DEFAULT_GRADUATION_CONFIG,
+  type GraduationConfig,
+  type GraduationEvent,
+  graduate,
+  initialState,
+  type Outcome,
+} from "./graduation.js";
+import { DEFAULT_PRIOR, type Posterior, posteriorMean } from "./trustLevel.js";
+
+/**
+ * Holds the per-(worker × action-class) trust state and the promotion/demotion
+ * event log. The state map is the dial; the event log is the compliance/audit
+ * artifact ("prove this worker never acted beyond its authority"). In-memory
+ * with a JSONL round-trip; wiring it to a live append-only JSONL file with the
+ * tail-on-read concurrency pattern (ADR-0007, as the existing trace stores do)
+ * is the productionization step — kept out of v0 to stay pure + testable.
+ */
+
+function compositeKey(workerId: string, classKey: string): string {
+  return `${workerId}::${classKey}`;
+}
+
+export type AuditEvent = GraduationEvent & { workerId: string };
+
+export interface AppliedOutcome {
+  classKey: string;
+  state: ClassTrustState;
+  event?: AuditEvent;
+}
+
+export interface BoardRow {
+  classKey: string;
+  level: number;
+  observations: number;
+  mean: number;
+}
+
+export class WorkerLevelStore {
+  private states = new Map<string, ClassTrustState>();
+  private log: AuditEvent[] = [];
+
+  /** Fold one outcome for a worker; derives the action-class from the tool. */
+  apply(
+    workerId: string,
+    outcome: Outcome,
+    opts: { prior?: Posterior; cfg?: GraduationConfig } = {},
+  ): AppliedOutcome {
+    const ac = classifyActionClass(outcome.toolName, outcome.params);
+    const k = compositeKey(workerId, ac.key);
+    const prior = opts.prior ?? DEFAULT_PRIOR;
+    const current =
+      this.states.get(k) ?? initialState(ac.key, prior, outcome.at);
+    const { state, event } = graduate(
+      current,
+      outcome,
+      opts.cfg ?? DEFAULT_GRADUATION_CONFIG,
+    );
+    this.states.set(k, state);
+    const audit = event ? { ...event, workerId } : undefined;
+    if (audit) this.log.push(audit);
+    return { classKey: ac.key, state, event: audit };
+  }
+
+  getState(workerId: string, classKey: string): ClassTrustState | undefined {
+    return this.states.get(compositeKey(workerId, classKey));
+  }
+
+  /** Dial snapshot for one worker: every action-class it has touched, sorted. */
+  board(workerId: string): BoardRow[] {
+    const prefix = `${workerId}::`;
+    const rows: BoardRow[] = [];
+    for (const [k, s] of this.states) {
+      if (!k.startsWith(prefix)) continue;
+      rows.push({
+        classKey: s.classKey,
+        level: s.level,
+        observations: s.observations,
+        mean: posteriorMean(s.posterior),
+      });
+    }
+    return rows.sort((a, b) => a.classKey.localeCompare(b.classKey));
+  }
+
+  /** The audit log (optionally filtered to one worker). */
+  events(workerId?: string): AuditEvent[] {
+    return workerId
+      ? this.log.filter((e) => e.workerId === workerId)
+      : this.log;
+  }
+
+  /** Serialize states + events to JSONL (one record per line). */
+  toJSONL(): string {
+    const lines: string[] = [];
+    for (const [k, s] of this.states) {
+      const workerId = k.slice(0, k.indexOf("::"));
+      lines.push(JSON.stringify({ rec: "state", workerId, state: s }));
+    }
+    for (const e of this.log)
+      lines.push(JSON.stringify({ rec: "event", ...e }));
+    return lines.join("\n");
+  }
+
+  static fromJSONL(text: string): WorkerLevelStore {
+    const store = new WorkerLevelStore();
+    for (const line of text.split("\n")) {
+      const t = line.trim();
+      if (!t) continue;
+      const obj = JSON.parse(t) as Record<string, unknown>;
+      if (obj.rec === "state") {
+        const workerId = obj.workerId as string;
+        const state = obj.state as ClassTrustState;
+        store.states.set(compositeKey(workerId, state.classKey), state);
+      } else if (obj.rec === "event") {
+        const { rec: _rec, ...event } = obj;
+        store.log.push(event as unknown as AuditEvent);
+      }
+    }
+    return store;
+  }
+}

--- a/templates/workers/dependency-upkeep.worker.yaml
+++ b/templates/workers/dependency-upkeep.worker.yaml
@@ -1,0 +1,18 @@
+# Dependency-upkeep worker — top-right beachhead. The classic low-blast,
+# continuous, verifiable job to land first (the wedge): watch for outdated /
+# vulnerable deps and open a bump PR. A human still merges → ceiling held at L3.
+id: dependency-upkeep-worker
+name: Dependency Upkeep Worker
+sector: engineering
+recipe: dependency-bump
+responsibilities:
+  - Audit dependencies for outdated / vulnerable packages
+  - Open a bump PR with the changelog and advisory links
+owns:
+  - deps-read # auditDependencies / getSecurityAdvisories — read-only
+  - vcs-local # gitCommit / gitCheckout on a branch — reversible
+  - vcs-remote # githubCreatePR — compensable + brand-exposed
+autonomyCeiling: 3 # opening PRs autonomously is fine; merging stays human (policy)
+competence:
+  mean: 0.8
+  strength: 4

--- a/templates/workers/release-notes.worker.yaml
+++ b/templates/workers/release-notes.worker.yaml
@@ -1,0 +1,17 @@
+# Release worker — top-right beachhead (high task-impact × high autonomy-tolerance).
+# Body: a chained recipe triggered on merge-to-main that drafts release notes.
+# Reversible, verifiable, internal → fast ramp evidence.
+id: release-notes-worker
+name: Release Worker
+sector: engineering
+recipe: release-notes # the recipe that forms this worker's body
+responsibilities:
+  - Watch merges to main and draft release notes / changelog entries
+  - Summarize the diff and link the PRs in the range
+owns:
+  - vcs-read # getGitStatus / getGitDiff / getGitLog — reversible, low blast
+  - fs-write # editText / createFile (the changelog) — reversible
+autonomyCeiling: 4 # internal + reversible: may earn full autonomy
+competence: # shipped competence (a prior), NOT trust — trust earns locally
+  mean: 0.85
+  strength: 4

--- a/templates/workers/test-guardian.worker.yaml
+++ b/templates/workers/test-guardian.worker.yaml
@@ -1,0 +1,18 @@
+# Test-guardian worker — top-right beachhead. Fires on a test-run failure
+# (on_test_run trigger), investigates the failure, and files an issue. Reversible
+# investigation + compensable issue creation → may earn full autonomy on triage.
+id: test-guardian-worker
+name: Test Guardian Worker
+sector: engineering
+recipe: triage-failing-tests
+responsibilities:
+  - On a failing test run, investigate the stack trace and identify the cause
+  - File / update an issue with the failure summary and the suspect commit
+owns:
+  - ci # runTests (re-runnable) — reversible
+  - vcs-read # getGitDiff / gitBlame to find the suspect commit
+  - issue # githubCreateIssue / addLinearComment — compensable + brand-exposed
+autonomyCeiling: 4
+competence:
+  mean: 0.8
+  strength: 4


### PR DESCRIPTION
First implementation of the **worker trust/autonomy ramp** — the spine of the worker system. **Shadow-mode: does not touch the live approval gate.** Net-new `src/workers/`, fully additive. Design: `docs/design/worker-ramp-v0.md`.

## Core decisions (grounded in the repo)
- **Worker = recipe + identity, not a forked actor object.** The recipe stays the worker's *body* (triggers + steps); this adds identity, owned action-classes, a trust prior, and a policy ceiling as metadata + a level store. Avoids re-introducing the flat-vs-chained "fork" failure mode.
- **Trust is per `(worker × action-class)`, never global.** Blast-tier is folded into the class key, so competence on `git status` can't transfer to `git push --force`; novel classes default to the floor.
- **The level is a Bayesian posterior surfaced as discrete L0–L4.** Cold-start floor, slow climb, and instant catastrophic demote all fall out of one model (LCB threshold crossing + blast-weighted evidence). Competence priors ship competence without shipping trust — uncertainty only collapses on local data.
- **Reversibility is the primary taxonomy axis.** Ramp rungs are execution modes; the middle rungs (L2/L3) exist only for reversible/compensable classes. Irreversible classes jump L1→L4 and must clear a higher bar.
- **`autonomyCeiling`** encodes the autonomy-tolerance axis: a policy/regulatory cap (e.g. Legal worker pinned L2) applied at the gate as `min(earned, ceiling)` — the dial still shows *earned*.
- **brand-risk** is a distinct gating dimension (reputational failure weighted heavier than the same internal action).

## Modules (40 unit tests)
`actionClass` · `trustLevel` (Beta + LCB) · `graduation` (asymmetry + dwell/cooldown hysteresis + novel floor) · `workerLevelStore` (state + audit log + JSONL) · `worker` (manifest parse) · `shadowGate` (pure queue/bypass recommender, v0 surfaces L1↔L4 only) · `shadowRun` (replay → dial trajectory).

## The evidence-latency proof (the honest part)
The dial-trajectory test demonstrates the real commercial risk and its fix: a **cold worker needs ~weeks of clean evidence to reach L4** (trustworthy = slow); a **competence prior accelerates that to ~7.5 days without faking trust**; and **one failure demotes a long-earned L4 in a single step**.

## Dogfood workers (`templates/workers/`)
Release-notes, dependency-upkeep, test-guardian — the top-right beachhead (internal engineering: reversible, verifiable, fast-ramp).

## Deferred (intentionally, per the design doc)
Flipping the live gate to obey the ramp (flag-gated phase 2, after shadow validation) · L0/L2/L3 execution modes · the trust-dial UI · multi-worker coordination.

Local gates green: `tsc`, `tsc -p tsconfig.tests.core.json`, biome, fixture audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)