### PR TITLE
feat(recipes): worker recipe bodies (release-notes, dependency-bump, triage)

### DIFF
--- a/templates/recipes/dependency-bump.yaml
+++ b/templates/recipes/dependency-bump.yaml
@@ -1,0 +1,33 @@
+# yaml-language-server: $schema=https://patchwork.dev/schemas/recipe.v1.json
+# Body for the Dependency Upkeep Worker
+# (templates/workers/dependency-upkeep.worker.yaml). Weekly cron — reviews the
+# open dependency-update PRs rather than opening them (autonomyCeiling L3: a
+# human still merges).
+apiVersion: patchwork.sh/v1
+name: dependency-bump
+description: Weekly — list open dependency-update PRs and summarize which look safe to merge.
+trigger:
+  type: cron
+  at: "0 9 * * MON"
+steps:
+  - tool: github.list_prs
+    max: 30
+    into: prs
+  - agent:
+      prompt: |
+        Open pull requests:
+        {{prs}}
+
+        Identify the dependency-update PRs (dependabot / renovate / "bump …"
+        titles). For each, note the package, the version jump (patch / minor /
+        major), and a recommendation: SAFE to merge (patch/minor with green CI)
+        or NEEDS REVIEW (major, or a security-sensitive dependency). Output a
+        short markdown table; if there are none, say "No dependency PRs open."
+      driver: claude-code
+      into: review
+  - tool: file.write
+    path: ~/.patchwork/inbox/dependency-review-{{date}}.md
+    content: |
+      # Dependency PR review — {{date}}
+
+      {{review}}

--- a/templates/recipes/release-notes.yaml
+++ b/templates/recipes/release-notes.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://patchwork.dev/schemas/recipe.v1.json
+# Body for the Release Worker (templates/workers/release-notes.worker.yaml).
+# Self-waking on every commit (git_hook → onGitCommit, wired in #1016/#1018).
+apiVersion: patchwork.sh/v1
+name: release-notes
+description: After a commit lands, draft a changelog entry from the new commits into the inbox.
+trigger:
+  type: git_hook
+  event: post-commit
+steps:
+  - tool: git.log_since
+    since: 24h
+    into: commits
+  - agent:
+      prompt: |
+        New commits landed in the last 24h:
+        {{commits}}
+
+        Write a concise changelog entry as a markdown bullet list — one line per
+        user-facing change, grouped under feat / fix / chore. Omit pure noise
+        (merge commits, formatting-only). If nothing is user-facing, say so.
+      # subprocess `claude -p` under your existing subscription (no API key)
+      driver: claude-code
+      into: notes
+  - tool: file.write
+    path: ~/.patchwork/inbox/release-notes-{{date}}.md
+    content: |
+      # Release notes draft — {{date}}
+
+      {{notes}}

--- a/templates/recipes/triage-failing-tests.yaml
+++ b/templates/recipes/triage-failing-tests.yaml
@@ -1,0 +1,38 @@
+# yaml-language-server: $schema=https://patchwork.dev/schemas/recipe.v1.json
+# Body for the Test Guardian Worker
+# (templates/workers/test-guardian.worker.yaml). Self-waking on a FAILING test
+# run (on_test_run.filter: failure). Correlates the failure with recent commits
+# and writes a triage note — richer than the plain watch-failing-tests recipe.
+apiVersion: patchwork.sh/v1
+name: triage-failing-tests
+description: On a failing test run, correlate the failure with recent commits and write a triage note.
+trigger:
+  type: on_test_run
+  filter: failure
+steps:
+  - tool: git.log_since
+    since: 12h
+    into: recent
+  - agent:
+      prompt: |
+        Tests just failed. Runner: {{runner}}. Failed {{failed}} / {{total}}.
+
+        Failures:
+        {{failures}}
+
+        Recent commits (last 12h) that may be responsible:
+        {{recent}}
+
+        Write a triage note (≤5 sentences): (1) which test(s) failed, (2) the
+        single most likely cause, (3) the suspect commit if any, (4) the first
+        command to run to confirm.
+      driver: claude-code
+      into: triage
+  - tool: file.write
+    path: ~/.patchwork/inbox/test-triage-{{date}}-{{time}}.md
+    content: |
+      # Test triage — {{date}} {{time}}
+
+      Runner {{runner}} · failed {{failed}}/{{total}}
+
+      {{triage}}


### PR DESCRIPTION
The runnable bodies for the dogfood workers in #1022 — makes "test 2–3 workers on this project" literally possible. Independent of the worker code (plain recipes), so it targets `main` directly.

Each self-wakes via the trigger types wired in #1016–#1019:
| Recipe | Trigger | Body |
|---|---|---|
| `release-notes` | `git_hook` post-commit | `git.log_since` → agent drafts a changelog entry → `file.write` to inbox |
| `dependency-bump` | weekly `cron` | `github.list_prs` → agent flags which dep-PRs are safe to merge → `file.write` (review, not auto-merge — matches the worker's L3 ceiling) |
| `triage-failing-tests` | `on_test_run` filter:`failure` | `git.log_since` → agent correlates the failure with recent commits → `file.write` triage note |

All three pass `recipe lint` (0 warnings); only existing recipe tools + the `claude-code` subprocess driver.

**Pairs with**: the worker manifests in #1022 reference these by name; once both land + a worker runs, `patchwork workers shadow` (#1023) attributes the runs and the dial fills.

**Follow-up (noted, on the worker branch)**: the dial attributes by RecipeRunLog step tool-ids (`git.log_since`, `file.write`, …), but `actionClass.DOMAIN_BY_TOOL` keys on MCP tool names — so recipe-run steps classify as `other` until those ids are added to the taxonomy. Addressing on #1022.

🤖 Generated with [Claude Code](https://claude.com/claude-code)