### PR TITLE
feat(workers): read-only shadow logger — dial + ramp-vs-gate from live logs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -211,6 +211,7 @@ const KNOWN_SUBCOMMANDS = [
   "analytics",
   "doctor",
   "shadow-scan",
+  "workers",
 ] as const;
 
 const __invokedSubcommand = (() => {
@@ -4643,6 +4644,41 @@ if (process.argv[2] === "shadow-scan") {
         json: jsonFlag,
       });
       // runShadowScanCli sets process.exitCode = 1 on reclassified > 0; no explicit exit needed.
+    } catch (err) {
+      process.stderr.write(
+        `Error: ${err instanceof Error ? err.message : String(err)}\n`,
+      );
+      process.exit(1);
+    }
+  })();
+}
+
+// Handle workers subcommand — read-only worker trust-dial (shadow). Replays the
+// recipe run log + gate decision log through the (worker × action-class) ramp
+// and prints the dial + a "ramp would vs gate did" comparison. Changes nothing.
+if (process.argv[2] === "workers") {
+  const args = process.argv.slice(3);
+  if (args[0] !== "shadow" || args.includes("--help") || args.includes("-h")) {
+    process.stdout.write(
+      "Usage: patchwork workers shadow [--workers-dir <path>]\n\n" +
+        "Read-only worker trust dial: replays ~/.patchwork/runs.jsonl and the\n" +
+        "gate decision log through the (worker × action-class) trust ramp. It\n" +
+        "computes what the ramp WOULD decide vs what the gate DID — and never\n" +
+        "changes a live decision.\n\n" +
+        "  --workers-dir <path>  Where *.worker.yaml live (default ~/.patchwork/workers)\n",
+    );
+    process.exit(0);
+  }
+  (async () => {
+    try {
+      const dirIdx = args.indexOf("--workers-dir");
+      const workersDir = dirIdx !== -1 ? args[dirIdx + 1] : undefined;
+      const { runWorkerShadowReport } = await import(
+        "./workers/runWorkerShadow.js"
+      );
+      process.stdout.write(
+        runWorkerShadowReport(workersDir ? { workersDir } : {}),
+      );
     } catch (err) {
       process.stderr.write(
         `Error: ${err instanceof Error ? err.message : String(err)}\n`,

--- a/src/workers/__tests__/shadowObserver.test.ts
+++ b/src/workers/__tests__/shadowObserver.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import type { GraduationConfig } from "../graduation.js";
+import { type RunRecord, WorkerShadowObserver } from "../shadowObserver.js";
+import { parseWorker } from "../worker.js";
+
+const CFG: GraduationConfig = {
+  dwellMs: 1000,
+  demoteCooldownMs: 5000,
+  minEvidenceForGraduation: 5,
+};
+
+const release = parseWorker({
+  id: "release-notes-worker",
+  name: "Release Worker",
+  recipe: "release-notes",
+  owns: ["fs-write", "vcs-read"],
+});
+
+function editRun(at: number, steps: number): RunRecord {
+  return {
+    recipeName: "release-notes",
+    at,
+    steps: Array.from({ length: steps }, () => ({
+      tool: "editText",
+      status: "ok" as const,
+    })),
+  };
+}
+
+function climb(obs: WorkerShadowObserver) {
+  obs.ingestRun(editRun(0, 60)); // build posterior (no climb at t=0)
+  for (const at of [1000, 2000, 3000, 4000]) obs.ingestRun(editRun(at, 1));
+}
+
+describe("WorkerShadowObserver", () => {
+  it("feeds attributed recipe-run outcomes into the worker's dial", () => {
+    const obs = new WorkerShadowObserver([release], { cfg: CFG });
+    climb(obs);
+    const r = obs.report()[0]!;
+    const fsWrite = r.board.find(
+      (b) => b.classKey === "fs-write:reversible:medium",
+    );
+    expect(fsWrite?.level).toBe(4);
+    expect(r.events.some((e) => e.type === "promote")).toBe(true);
+  });
+
+  it("ignores runs whose recipe maps to no worker", () => {
+    const obs = new WorkerShadowObserver([release], { cfg: CFG });
+    obs.ingestRun({
+      recipeName: "some-other-recipe",
+      at: 0,
+      steps: [{ tool: "editText", status: "ok" }],
+    });
+    expect(obs.report()[0]!.board).toHaveLength(0);
+  });
+
+  it("compares ramp recommendation against the live gate decision", () => {
+    const obs = new WorkerShadowObserver([release], { cfg: CFG });
+    climb(obs); // fs-write earned L4 → ramp would bypass editText
+    // gate DENIED an editText the ramp would now auto-run → divergence
+    obs.ingestDecision({ toolName: "editText", decision: "deny", at: 5000 });
+    // gate ALLOWED an editText the ramp would also auto-run → agreement
+    obs.ingestDecision({ toolName: "editText", decision: "allow", at: 6000 });
+    const r = obs.report()[0]!;
+    expect(r.compared).toBe(2);
+    expect(r.agreed).toBe(1);
+    expect(r.divergences).toHaveLength(1);
+    expect(r.divergences[0]!.ramp).toBe("bypass");
+    expect(r.divergences[0]!.gate).toBe("deny");
+  });
+
+  it("skips decisions for tools no single worker owns (ambiguous attribution)", () => {
+    const obs = new WorkerShadowObserver([release], { cfg: CFG });
+    // slackPostMessage is messaging — release doesn't own it
+    obs.ingestDecision({
+      toolName: "slackPostMessage",
+      decision: "deny",
+      at: 0,
+    });
+    expect(obs.report()[0]!.compared).toBe(0);
+  });
+});

--- a/src/workers/__tests__/shadowReport.test.ts
+++ b/src/workers/__tests__/shadowReport.test.ts
@@ -1,0 +1,96 @@
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import type { GraduationConfig } from "../graduation.js";
+import type { DecisionRecord, RunRecord } from "../shadowObserver.js";
+import { buildShadowReport, formatShadowReport } from "../shadowReport.js";
+import { parseWorker } from "../worker.js";
+import { loadWorkersFromDir } from "../workerLoader.js";
+
+const CFG: GraduationConfig = {
+  dwellMs: 1000,
+  demoteCooldownMs: 5000,
+  minEvidenceForGraduation: 5,
+};
+
+const release = parseWorker({
+  id: "release-notes-worker",
+  name: "Release Worker",
+  recipe: "release-notes",
+  owns: ["fs-write"],
+});
+
+function editRun(at: number, steps: number): RunRecord {
+  return {
+    recipeName: "release-notes",
+    at,
+    steps: Array.from({ length: steps }, () => ({
+      tool: "editText",
+      status: "ok" as const,
+    })),
+  };
+}
+
+describe("loadWorkersFromDir", () => {
+  it("loads the shipped dogfood worker manifests", () => {
+    const dir = path.join(process.cwd(), "templates", "workers");
+    const workers = loadWorkersFromDir(dir);
+    expect(workers.map((w) => w.id)).toContain("release-notes-worker");
+    expect(workers.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it("returns [] for a missing directory (fail-soft)", () => {
+    expect(loadWorkersFromDir(path.join(process.cwd(), "no-such-dir"))).toEqual(
+      [],
+    );
+  });
+});
+
+describe("buildShadowReport", () => {
+  it("interleaves runs + decisions by time and reports dial + comparison", () => {
+    const runs: RunRecord[] = [
+      editRun(0, 60),
+      editRun(1000, 1),
+      editRun(2000, 1),
+      editRun(3000, 1),
+      editRun(4000, 1),
+    ];
+    const decisions: DecisionRecord[] = [
+      { toolName: "editText", decision: "deny", at: 5000 },
+    ];
+    const [r] = buildShadowReport([release], runs, decisions, CFG);
+    expect(
+      r!.board.find((b) => b.classKey === "fs-write:reversible:medium")?.level,
+    ).toBe(4);
+    expect(r!.compared).toBe(1);
+    expect(r!.divergences).toHaveLength(1);
+    expect(r!.divergences[0]!.ramp).toBe("bypass");
+  });
+});
+
+describe("formatShadowReport", () => {
+  it("renders the dial, the ceiling, and divergences", () => {
+    const reports = buildShadowReport(
+      [release],
+      [
+        editRun(0, 60),
+        editRun(1000, 1),
+        editRun(2000, 1),
+        editRun(3000, 1),
+        editRun(4000, 1),
+      ],
+      [{ toolName: "editText", decision: "deny", at: 5000 }],
+      CFG,
+    );
+    const text = formatShadowReport(reports);
+    expect(text).toContain("SHADOW");
+    expect(text).toContain("Release Worker");
+    expect(text).toContain("fs-write:reversible:medium");
+    expect(text).toContain("ramp vs gate");
+    expect(text).toContain("⚠");
+  });
+
+  it("shows an honest empty state when a worker has no activity", () => {
+    const text = formatShadowReport(buildShadowReport([release], [], [], CFG));
+    expect(text).toContain("no attributed activity yet");
+  });
+});

--- a/src/workers/runWorkerShadow.ts
+++ b/src/workers/runWorkerShadow.ts
@@ -1,0 +1,104 @@
+import { readdirSync, readFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { RecipeRunLog } from "../runLog.js";
+import type { DecisionRecord, RunRecord } from "./shadowObserver.js";
+import { buildShadowReport, formatShadowReport } from "./shadowReport.js";
+import { loadWorkersFromDir } from "./workerLoader.js";
+
+/**
+ * I/O entry for the shadow logger: read the REAL logs the bridge already
+ * writes — `~/.patchwork/runs.jsonl` (RecipeRunLog → the dial's evidence) and
+ * `~/.claude/ide/activity-*.jsonl` (the live gate's approval decisions) — and
+ * produce the trust-dial + ramp-vs-gate report. Fully read-only; touches
+ * nothing. Empty logs are honest, not an error (new workers have no activity).
+ */
+
+export interface RunWorkerShadowOpts {
+  /** Where worker manifests live (default ~/.patchwork/workers). */
+  workersDir?: string;
+  /** ~/.patchwork (runs.jsonl) override (tests). */
+  patchworkDir?: string;
+  /** ~/.claude/ide (activity-*.jsonl) override (tests). */
+  ideDir?: string;
+}
+
+function readRuns(patchworkDir: string): RunRecord[] {
+  try {
+    const log = new RecipeRunLog({ dir: patchworkDir });
+    return log.query({}).map((r) => ({
+      recipeName: r.recipeName,
+      at: r.doneAt ?? r.startedAt ?? r.createdAt,
+      steps: (r.stepResults ?? []).map((s) => ({
+        tool: s.tool,
+        status: s.status,
+      })),
+    }));
+  } catch {
+    return [];
+  }
+}
+
+function readDecisions(ideDir: string): DecisionRecord[] {
+  let files: string[];
+  try {
+    files = readdirSync(ideDir).filter((f) => /^activity-.*\.jsonl$/.test(f));
+  } catch {
+    return [];
+  }
+  const out: DecisionRecord[] = [];
+  for (const f of files) {
+    let text: string;
+    try {
+      text = readFileSync(path.join(ideDir, f), "utf-8");
+    } catch {
+      continue;
+    }
+    for (const line of text.split("\n")) {
+      const t = line.trim();
+      // cheap pre-filter before the JSON.parse; an empty line never matches
+      if (!t.includes("approval_decision")) continue;
+      let obj: Record<string, unknown>;
+      try {
+        obj = JSON.parse(t);
+      } catch {
+        continue;
+      }
+      if (obj.event !== "approval_decision") continue;
+      const md = (obj.metadata ?? {}) as Record<string, unknown>;
+      const decision =
+        md.decision === "allow"
+          ? "allow"
+          : md.decision === "deny"
+            ? "deny"
+            : null;
+      if (typeof md.toolName !== "string" || !decision) continue;
+      out.push({
+        toolName: md.toolName,
+        decision,
+        at:
+          typeof obj.timestamp === "string"
+            ? Date.parse(obj.timestamp) || 0
+            : 0,
+      });
+    }
+  }
+  return out;
+}
+
+export function runWorkerShadowReport(opts: RunWorkerShadowOpts = {}): string {
+  const home = os.homedir();
+  const patchworkDir = opts.patchworkDir ?? path.join(home, ".patchwork");
+  const ideDir = opts.ideDir ?? path.join(home, ".claude", "ide");
+  const workersDir = opts.workersDir ?? path.join(patchworkDir, "workers");
+
+  const workers = loadWorkersFromDir(workersDir);
+  if (workers.length === 0) {
+    return `No worker manifests found in ${workersDir}.\nAdd *.worker.yaml there (e.g. copy templates/workers/) and re-run.\n`;
+  }
+
+  const runs = readRuns(patchworkDir);
+  const decisions = readDecisions(ideDir);
+  const reports = buildShadowReport(workers, runs, decisions);
+  return `${formatShadowReport(reports)}\n(scanned ${runs.length} recipe runs, ${decisions.length} gate decisions · read-only)\n`;
+}

--- a/src/workers/shadowObserver.ts
+++ b/src/workers/shadowObserver.ts
@@ -1,0 +1,164 @@
+import { classifyActionClass } from "./actionClass.js";
+import {
+  DEFAULT_GRADUATION_CONFIG,
+  type GraduationConfig,
+} from "./graduation.js";
+import { recommend } from "./shadowGate.js";
+import { ownsAction, priorFor, type WorkerManifest } from "./worker.js";
+import {
+  type AuditEvent,
+  type BoardRow,
+  WorkerLevelStore,
+} from "./workerLevelStore.js";
+
+/**
+ * Read-only shadow logger. Consumes signals the bridge ALREADY persists —
+ * RecipeRunLog outcomes (the dial's evidence) and ActivityLog approval
+ * decisions (the live gate's actual calls) — and maintains the trust dial +
+ * a "what the ramp WOULD have decided vs what the gate DID" comparison. It
+ * never touches the live gate: the gate's own decision log IS the input, so
+ * this observes the live path with zero hot-path risk. (worker-ramp-v0, shadow)
+ */
+
+/** A recipe run, reduced to what the dial needs (maps from RecipeRun). */
+export interface RunRecord {
+  recipeName: string;
+  /** epoch ms */
+  at: number;
+  steps: Array<{ tool?: string; status: "ok" | "skipped" | "error" }>;
+}
+
+/** A live gate decision (maps from an ActivityLog approval_decision row). */
+export interface DecisionRecord {
+  toolName: string;
+  /** the gate's actual verdict */
+  decision: "allow" | "deny";
+  at: number;
+  params?: Record<string, unknown>;
+}
+
+export interface Divergence {
+  classKey: string;
+  toolName: string;
+  ramp: "queue" | "bypass";
+  gate: "allow" | "deny";
+  at: number;
+  note: string;
+}
+
+export interface WorkerShadowReport {
+  workerId: string;
+  name: string;
+  autonomyCeiling: number;
+  board: BoardRow[];
+  events: AuditEvent[];
+  /** ramp-vs-gate comparison over attributable decisions */
+  compared: number;
+  agreed: number;
+  divergences: Divergence[];
+}
+
+interface CompareSlot {
+  compared: number;
+  agreed: number;
+  divergences: Divergence[];
+}
+
+export class WorkerShadowObserver {
+  private readonly store: WorkerLevelStore;
+  private readonly cfg: GraduationConfig;
+  private readonly workers: WorkerManifest[];
+  private readonly compare = new Map<string, CompareSlot>();
+
+  constructor(
+    workers: WorkerManifest[],
+    opts: { store?: WorkerLevelStore; cfg?: GraduationConfig } = {},
+  ) {
+    this.workers = workers;
+    this.store = opts.store ?? new WorkerLevelStore();
+    this.cfg = opts.cfg ?? DEFAULT_GRADUATION_CONFIG;
+  }
+
+  /** Attribute a run to the worker whose recipe is its body. */
+  private workerForRecipe(recipeName: string): WorkerManifest | undefined {
+    return this.workers.find((w) => w.recipe === recipeName);
+  }
+
+  /** Attribute a tool call to its SOLE owning worker (ambiguous → skip). */
+  private workerForAction(
+    toolName: string,
+    params?: Record<string, unknown>,
+  ): WorkerManifest | undefined {
+    const ac = classifyActionClass(toolName, params);
+    const owners = this.workers.filter((w) => ownsAction(w, ac));
+    return owners.length === 1 ? owners[0] : undefined;
+  }
+
+  /** Feed a recipe run's step outcomes into the owning worker's dial. */
+  ingestRun(run: RunRecord): void {
+    const worker = this.workerForRecipe(run.recipeName);
+    if (!worker) return;
+    const prior = priorFor(worker);
+    for (const step of run.steps) {
+      if (!step.tool || step.status === "skipped") continue; // skipped ≠ evidence
+      this.store.apply(
+        worker.id,
+        { toolName: step.tool, good: step.status === "ok", at: run.at },
+        { prior, cfg: this.cfg },
+      );
+    }
+  }
+
+  /** Compare what the ramp WOULD recommend (given the dial as of now) against
+   * the gate's actual decision. Read-only — records agreement + divergences. */
+  ingestDecision(d: DecisionRecord): void {
+    const worker = this.workerForAction(d.toolName, d.params);
+    if (!worker) return;
+    const rec = recommend(worker, d.toolName, d.params, this.store);
+    const rampBypass = rec.decision === "bypass";
+    const gateAllowed = d.decision === "allow";
+    // ramp "bypass" ↔ gate would not need to gate; ramp "queue" ↔ gate gates.
+    const agree = rampBypass === gateAllowed;
+    const slot = this.compare.get(worker.id) ?? {
+      compared: 0,
+      agreed: 0,
+      divergences: [],
+    };
+    slot.compared++;
+    if (agree) {
+      slot.agreed++;
+    } else {
+      slot.divergences.push({
+        classKey: rec.classKey,
+        toolName: d.toolName,
+        ramp: rec.decision,
+        gate: d.decision,
+        at: d.at,
+        note: rampBypass
+          ? "ramp would auto-run (earned L4); gate still gated"
+          : "ramp would gate; gate allowed",
+      });
+    }
+    this.compare.set(worker.id, slot);
+  }
+
+  report(): WorkerShadowReport[] {
+    return this.workers.map((w) => {
+      const c = this.compare.get(w.id) ?? {
+        compared: 0,
+        agreed: 0,
+        divergences: [],
+      };
+      return {
+        workerId: w.id,
+        name: w.name,
+        autonomyCeiling: w.autonomyCeiling,
+        board: this.store.board(w.id),
+        events: this.store.events(w.id),
+        compared: c.compared,
+        agreed: c.agreed,
+        divergences: c.divergences,
+      };
+    });
+  }
+}

--- a/src/workers/shadowReport.ts
+++ b/src/workers/shadowReport.ts
@@ -1,0 +1,69 @@
+import type { GraduationConfig } from "./graduation.js";
+import {
+  type DecisionRecord,
+  type RunRecord,
+  WorkerShadowObserver,
+  type WorkerShadowReport,
+} from "./shadowObserver.js";
+import type { WorkerManifest } from "./worker.js";
+
+/**
+ * Build the shadow report by feeding runs + decisions into the observer in
+ * timestamp order, so each ramp-vs-gate comparison sees the dial as it stood AT
+ * that moment (not the final state). Pure — the I/O entry (runWorkerShadow)
+ * supplies the records read from the real logs.
+ */
+export function buildShadowReport(
+  workers: WorkerManifest[],
+  runs: RunRecord[],
+  decisions: DecisionRecord[],
+  cfg?: GraduationConfig,
+): WorkerShadowReport[] {
+  const obs = new WorkerShadowObserver(workers, { cfg });
+  const merged: Array<{ at: number; run?: RunRecord; dec?: DecisionRecord }> = [
+    ...runs.map((r) => ({ at: r.at, run: r })),
+    ...decisions.map((d) => ({ at: d.at, dec: d })),
+  ].sort((a, b) => a.at - b.at);
+  for (const e of merged) {
+    if (e.run) obs.ingestRun(e.run);
+    else if (e.dec) obs.ingestDecision(e.dec);
+  }
+  return obs.report();
+}
+
+export function formatShadowReport(reports: WorkerShadowReport[]): string {
+  const lines: string[] = [
+    "Worker trust dial — SHADOW (read-only; no live gate change)",
+    "",
+  ];
+  for (const r of reports) {
+    lines.push(
+      `▸ ${r.name} [${r.workerId}]  ·  autonomy ceiling L${r.autonomyCeiling}`,
+    );
+    if (r.board.length === 0) {
+      lines.push(
+        "    (no attributed activity yet — dial fills as the worker runs)",
+      );
+    } else {
+      for (const b of r.board) {
+        const capped =
+          b.level > r.autonomyCeiling
+            ? `  → operating L${r.autonomyCeiling} (ceiling)`
+            : "";
+        lines.push(
+          `    ${b.classKey.padEnd(36)} earned L${b.level}${capped}  ·  ${b.observations} obs  ·  ${(b.mean * 100).toFixed(0)}% mean`,
+        );
+      }
+    }
+    if (r.compared > 0) {
+      lines.push(
+        `    ramp vs gate: ${r.agreed}/${r.compared} agree · ${r.divergences.length} divergence(s)`,
+      );
+      for (const d of r.divergences.slice(0, 5)) {
+        lines.push(`      ⚠ ${d.toolName} — ${d.note}`);
+      }
+    }
+    lines.push("");
+  }
+  return lines.join("\n");
+}

--- a/src/workers/workerLoader.ts
+++ b/src/workers/workerLoader.ts
@@ -1,0 +1,35 @@
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { parse as parseYaml } from "yaml";
+import { parseWorker, type WorkerManifest } from "./worker.js";
+
+/**
+ * Load worker manifests from a directory of `*.worker.yaml` files. Fail-soft:
+ * a malformed worker file is skipped (logged by the caller if a logger is
+ * passed), never fatal — one bad manifest must not blind the whole dial.
+ */
+export function loadWorkersFromDir(
+  dir: string,
+  log?: (msg: string) => void,
+): WorkerManifest[] {
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return [];
+  }
+  const workers: WorkerManifest[] = [];
+  for (const f of entries) {
+    if (!/\.worker\.ya?ml$/i.test(f)) continue;
+    try {
+      workers.push(
+        parseWorker(parseYaml(readFileSync(path.join(dir, f), "utf-8"))),
+      );
+    } catch (err) {
+      log?.(
+        `[workers] skipped ${f} — ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+  return workers.sort((a, b) => a.id.localeCompare(b.id));
+}


### PR DESCRIPTION
Supersedes #1023 (auto-closed when its stacked base branch was deleted on the #1022 merge). Rebased onto `main`; only the 7-file shadow-logger delta.

Read-only worker trust dial with **zero blast radius**: consumes what the bridge already persists — `RecipeRunLog` outcomes (dial evidence) + `ActivityLog` approval decisions (the live gate's verdicts) — and produces the `(worker × action-class)` dial plus a "ramp would X / gate did Y" comparison. The gate's own decision log *is* the input, so the live path is observed, not modified.

- `shadowObserver` — ingestRun (dial), ingestDecision (ramp-vs-gate agreement + divergences), report. Attribution: runs by recipe→worker, decisions by sole-owning worker.
- `shadowReport` — interleaves runs+decisions by timestamp; `formatShadowReport`.
- `runWorkerShadow` — read-only I/O entry.
- CLI: `patchwork workers shadow [--workers-dir <path>]`.

**Verified live** on this repo's real logs (100 runs, 754 gate decisions) — already surfaced a real divergence (a `gitPush` the ramp would gate that the gate allowed). 50 worker tests; tsc + tests:core + biome + fixture audit green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)