### PR TITLE
feat(workers): trust-dial dashboard — GET /workers/shadow + /workers page

### DIFF
--- a/dashboard/src/app/workers/__tests__/page.test.tsx
+++ b/dashboard/src/app/workers/__tests__/page.test.tsx
@@ -1,0 +1,73 @@
+/** @vitest-environment jsdom */
+import { render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import WorkersPage from "../page";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+let fetchMock: ReturnType<typeof vi.fn>;
+beforeEach(() => {
+  fetchMock = vi.fn();
+  vi.stubGlobal("fetch", fetchMock);
+});
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+const SHADOW = {
+  runsScanned: 12,
+  decisionsScanned: 30,
+  workers: [
+    {
+      workerId: "release-notes-worker",
+      name: "Release Worker",
+      autonomyCeiling: 4,
+      board: [
+        {
+          classKey: "fs-write:reversible:medium",
+          level: 3,
+          observations: 40,
+          mean: 0.95,
+        },
+      ],
+      compared: 1,
+      agreed: 0,
+      divergences: [
+        {
+          classKey: "vcs-remote:compensable:high",
+          toolName: "gitPush",
+          ramp: "queue",
+          gate: "allow",
+          at: 0,
+          note: "ramp would gate; gate allowed",
+        },
+      ],
+    },
+  ],
+};
+
+describe("WorkersPage", () => {
+  it("renders the trust dial + a ramp-vs-gate divergence from the shadow endpoint", async () => {
+    fetchMock.mockResolvedValue(jsonResponse(SHADOW));
+    const { container } = render(<WorkersPage />);
+    expect(await screen.findByText("Release Worker")).toBeTruthy();
+    // the divergence text is split across nodes (⚠ {tool} — {note}); assert on
+    // the rendered textContent rather than an exact single-node match
+    expect(container.textContent).toContain("gitPush");
+    expect(container.textContent).toContain("ramp would gate; gate allowed");
+  });
+
+  it("shows the empty state when no workers are configured", async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse({ workers: [], runsScanned: 0, decisionsScanned: 0 }),
+    );
+    render(<WorkersPage />);
+    expect(await screen.findByText(/No workers yet/)).toBeTruthy();
+  });
+});

--- a/dashboard/src/app/workers/page.tsx
+++ b/dashboard/src/app/workers/page.tsx
@@ -1,0 +1,139 @@
+"use client";
+import { EmptyState, ErrorState, HBarList } from "@/components/patchwork";
+import { SkeletonList } from "@/components/Skeleton";
+import { useBridgeFetch } from "@/hooks/useBridgeFetch";
+
+interface BoardRow {
+  classKey: string;
+  level: number;
+  observations: number;
+  mean: number;
+}
+interface Divergence {
+  classKey: string;
+  toolName: string;
+  ramp: string;
+  gate: string;
+  at: number;
+  note: string;
+}
+interface WorkerReport {
+  workerId: string;
+  name: string;
+  autonomyCeiling: number;
+  board: BoardRow[];
+  compared: number;
+  agreed: number;
+  divergences: Divergence[];
+}
+interface ShadowResponse {
+  workers: WorkerReport[];
+  runsScanned: number;
+  decisionsScanned: number;
+  generatedAt?: string;
+}
+
+const LEVEL_LABELS = [
+  "L0 suggest",
+  "L1 approve-each",
+  "L2 act+undo",
+  "L3 act+sample",
+  "L4 autonomous",
+];
+
+function levelColor(effective: number): string {
+  if (effective >= 4) return "var(--ok)";
+  if (effective >= 2) return "var(--warn)";
+  return "var(--line-3)";
+}
+
+export default function WorkersPage() {
+  const { data, error, loading, refetch } = useBridgeFetch<ShadowResponse>(
+    "/api/bridge/workers/shadow",
+    { intervalMs: 30000 },
+  );
+  const workers = data?.workers ?? [];
+
+  return (
+    <section>
+      <div className="page-head">
+        <div>
+          <h1 className="editorial-h1" style={{ margin: 0 }}>
+            Workers — <span className="accent">trust dial (shadow).</span>
+          </h1>
+          <div className="editorial-sub" style={{ fontFamily: "inherit" }}>
+            Earned autonomy per worker × action-class, replayed read-only from
+            the run + gate logs. No live decision is changed.
+          </div>
+        </div>
+        {data && (
+          <span className="pill muted">
+            {data.runsScanned} runs · {data.decisionsScanned} gate decisions
+          </span>
+        )}
+      </div>
+
+      {loading && workers.length === 0 && <SkeletonList rows={3} columns={2} />}
+
+      {error && workers.length === 0 && (
+        <ErrorState
+          title="Couldn't load workers"
+          description="The bridge isn't responding to /workers/shadow."
+          error={error}
+          onRetry={refetch}
+        />
+      )}
+
+      {!loading && !error && workers.length === 0 && (
+        <EmptyState
+          title="No workers yet"
+          description="Add *.worker.yaml to ~/.patchwork/workers (e.g. copy templates/workers/)."
+        />
+      )}
+
+      {workers.map((w) => {
+        const effectiveItems = w.board.map((b) => {
+          const effective = Math.min(b.level, w.autonomyCeiling);
+          const capped =
+            b.level > w.autonomyCeiling ? ` (earned L${b.level}, capped)` : "";
+          return {
+            label: b.classKey,
+            value: effective,
+            color: levelColor(effective),
+            sub: `${LEVEL_LABELS[effective] ?? `L${effective}`} · ${b.observations} obs · ${Math.round(b.mean * 100)}% mean${capped}`,
+          };
+        });
+        return (
+          <div className="card" key={w.workerId} style={{ marginTop: "var(--s-4)" }}>
+            <div className="card-head">
+              <strong>{w.name}</strong>
+              <span className="pill muted">ceiling L{w.autonomyCeiling}</span>
+            </div>
+            {w.board.length === 0 ? (
+              <div className="editorial-sub" style={{ fontFamily: "inherit" }}>
+                No attributed activity yet — the dial fills as this worker runs.
+              </div>
+            ) : (
+              <HBarList items={effectiveItems} max={4} />
+            )}
+            {w.compared > 0 && (
+              <div style={{ marginTop: "var(--s-3)" }}>
+                <span className="pill muted">
+                  ramp vs gate: {w.agreed}/{w.compared} agree
+                </span>
+                {w.divergences.slice(0, 5).map((d, i) => (
+                  <div
+                    className="suggestion-row"
+                    key={`${w.workerId}-${d.toolName}-${i}`}
+                  >
+                    ⚠ {d.toolName} — {d.note}
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </section>
+  );
+}

--- a/dashboard/src/lib/navRoutes.ts
+++ b/dashboard/src/lib/navRoutes.ts
@@ -73,6 +73,7 @@ export const NAV_SECTIONS: NavSection[] = [
     routes: [
       { href: "/recipes",     label: "Recipes",     icon: "book" },
       { href: "/marketplace", label: "Marketplace", icon: "store" },
+      { href: "/workers",     label: "Workers",     paletteLabel: "Build — Workers", icon: "person" },
     ],
   },
   {

--- a/src/__tests__/recipeRoutes-route-match-and-sanitize.test.ts
+++ b/src/__tests__/recipeRoutes-route-match-and-sanitize.test.ts
@@ -72,6 +72,7 @@ function makeDeps(overrides: Partial<RecipeRouteDeps>): RecipeRouteDeps {
     judgeSummaryFn: null,
     runPlanFn: null,
     simulateFn: null,
+    workerShadowFn: null,
     runReplayFn: null,
     runRecipeFn: null,
     onRecipesChangedFn: null,

--- a/src/recipeOrchestration.ts
+++ b/src/recipeOrchestration.ts
@@ -315,6 +315,15 @@ export class RecipeOrchestration {
       })) as unknown as Record<string, unknown>;
     };
 
+    // Read-only worker trust dial (shadow): replays the run + decision logs
+    // through the (worker × action-class) ramp. Touches nothing.
+    server.workerShadowFn = async () => {
+      const { getWorkerShadowData } = await import(
+        "./workers/runWorkerShadow.js"
+      );
+      return getWorkerShadowData() as unknown as Record<string, unknown>;
+    };
+
     // VD-4 mocked replay: load the original run, re-parse its recipe
     // from disk (so a later edit replays against the new logic), and
     // re-fire through chainedRunner with `mockedOutputs` populated from

--- a/src/recipeRoutes.ts
+++ b/src/recipeRoutes.ts
@@ -639,6 +639,8 @@ export interface RecipeRouteDeps {
   runPlanFn: ((recipeName: string) => Promise<Record<string, unknown>>) | null;
   /** What-If Preview: static counterfactual simulation for a recipe by name. */
   simulateFn: ((recipeName: string) => Promise<Record<string, unknown>>) | null;
+  /** Read-only worker trust dial (shadow) — replays run + decision logs. */
+  workerShadowFn: (() => Promise<Record<string, unknown>>) | null;
   runReplayFn:
     | ((seq: number) => Promise<{
         ok: boolean;
@@ -903,6 +905,28 @@ export function tryHandleRecipeRoute(
     } catch (err) {
       respond500(res, err);
     }
+    return true;
+  }
+
+  // GET /workers/shadow — read-only worker trust dial + ramp-vs-gate report.
+  // Replays the run log + gate decision log through the (worker × action-class)
+  // ramp; changes nothing. Backs the dashboard /workers page.
+  if (parsedUrl.pathname === "/workers/shadow" && req.method === "GET") {
+    void (async () => {
+      try {
+        const data = (await deps.workerShadowFn?.()) ?? {
+          workers: [],
+          runsScanned: 0,
+          decisionsScanned: 0,
+        };
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(
+          JSON.stringify({ ...data, generatedAt: new Date().toISOString() }),
+        );
+      } catch (err) {
+        respond500(res, err);
+      }
+    })();
     return true;
   }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -331,6 +331,9 @@ export class Server extends EventEmitter<ServerEvents> {
   public simulateFn:
     | ((recipeName: string) => Promise<Record<string, unknown>>)
     | null = null;
+  /** Patchwork: read-only worker trust dial (shadow) — replays run + decision
+   *  logs through the (worker × action-class) ramp. Backs GET /workers/shadow. */
+  public workerShadowFn: (() => Promise<Record<string, unknown>>) | null = null;
   /** Patchwork (VD-4): mocked replay of an existing run. Returns the new
    *  run's seq plus any unmocked steps the caller may want to surface. */
   public runReplayFn:
@@ -1635,6 +1638,7 @@ export class Server extends EventEmitter<ServerEvents> {
           judgeSummaryFn: this.judgeSummaryFn,
           runPlanFn: this.runPlanFn,
           simulateFn: this.simulateFn,
+          workerShadowFn: this.workerShadowFn,
           runReplayFn: this.runReplayFn,
           runRecipeFn: this.runRecipeFn,
           onRecipesChangedFn: this.onRecipesChangedFn,

--- a/src/workers/__tests__/runWorkerShadow.test.ts
+++ b/src/workers/__tests__/runWorkerShadow.test.ts
@@ -1,0 +1,40 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { getWorkerShadowData } from "../runWorkerShadow.js";
+
+const WORKERS_DIR = path.join(process.cwd(), "templates", "workers");
+
+describe("getWorkerShadowData", () => {
+  let emptyDir: string;
+  beforeEach(() => {
+    emptyDir = mkdtempSync(path.join(os.tmpdir(), "pw-shadow-data-"));
+  });
+  afterEach(() => {
+    rmSync(emptyDir, { recursive: true, force: true });
+  });
+
+  it("returns a structured per-worker report (empty logs → empty dials)", () => {
+    const data = getWorkerShadowData({
+      workersDir: WORKERS_DIR,
+      patchworkDir: emptyDir, // no runs.jsonl
+      ideDir: emptyDir, // no activity-*.jsonl
+    });
+    expect(data.workers.length).toBeGreaterThanOrEqual(3);
+    expect(data.workers[0]).toHaveProperty("workerId");
+    expect(data.workers[0]).toHaveProperty("board");
+    expect(data.workers[0]).toHaveProperty("autonomyCeiling");
+    expect(data.runsScanned).toBe(0);
+    expect(data.decisionsScanned).toBe(0);
+  });
+
+  it("returns no workers when the workers dir is absent", () => {
+    const data = getWorkerShadowData({
+      workersDir: path.join(emptyDir, "nope"),
+      patchworkDir: emptyDir,
+      ideDir: emptyDir,
+    });
+    expect(data.workers).toEqual([]);
+  });
+});

--- a/src/workers/runWorkerShadow.ts
+++ b/src/workers/runWorkerShadow.ts
@@ -2,7 +2,11 @@ import { readdirSync, readFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { RecipeRunLog } from "../runLog.js";
-import type { DecisionRecord, RunRecord } from "./shadowObserver.js";
+import type {
+  DecisionRecord,
+  RunRecord,
+  WorkerShadowReport,
+} from "./shadowObserver.js";
 import { buildShadowReport, formatShadowReport } from "./shadowReport.js";
 import { loadWorkersFromDir } from "./workerLoader.js";
 
@@ -86,19 +90,42 @@ function readDecisions(ideDir: string): DecisionRecord[] {
   return out;
 }
 
-export function runWorkerShadowReport(opts: RunWorkerShadowOpts = {}): string {
+export interface WorkerShadowData {
+  workers: WorkerShadowReport[];
+  runsScanned: number;
+  decisionsScanned: number;
+  /** The directory worker manifests were loaded from (for empty-state copy). */
+  workersDir: string;
+}
+
+/**
+ * Structured shadow report — a read-only replay of the run + decision logs
+ * through the (worker × action-class) ramp. Backs both the CLI and the bridge
+ * `GET /workers/shadow` JSON endpoint. Pure aside from the log reads.
+ */
+export function getWorkerShadowData(
+  opts: RunWorkerShadowOpts = {},
+): WorkerShadowData {
   const home = os.homedir();
   const patchworkDir = opts.patchworkDir ?? path.join(home, ".patchwork");
   const ideDir = opts.ideDir ?? path.join(home, ".claude", "ide");
   const workersDir = opts.workersDir ?? path.join(patchworkDir, "workers");
 
   const workers = loadWorkersFromDir(workersDir);
-  if (workers.length === 0) {
-    return `No worker manifests found in ${workersDir}.\nAdd *.worker.yaml there (e.g. copy templates/workers/) and re-run.\n`;
-  }
+  const runs = workers.length ? readRuns(patchworkDir) : [];
+  const decisions = workers.length ? readDecisions(ideDir) : [];
+  return {
+    workers: buildShadowReport(workers, runs, decisions),
+    runsScanned: runs.length,
+    decisionsScanned: decisions.length,
+    workersDir,
+  };
+}
 
-  const runs = readRuns(patchworkDir);
-  const decisions = readDecisions(ideDir);
-  const reports = buildShadowReport(workers, runs, decisions);
-  return `${formatShadowReport(reports)}\n(scanned ${runs.length} recipe runs, ${decisions.length} gate decisions · read-only)\n`;
+export function runWorkerShadowReport(opts: RunWorkerShadowOpts = {}): string {
+  const data = getWorkerShadowData(opts);
+  if (data.workers.length === 0) {
+    return `No worker manifests found in ${data.workersDir}.\nAdd *.worker.yaml there (e.g. copy templates/workers/) and re-run.\n`;
+  }
+  return `${formatShadowReport(data.workers)}\n(scanned ${data.runsScanned} recipe runs, ${data.decisionsScanned} gate decisions · read-only)\n`;
 }


### PR DESCRIPTION
Surfaces the worker trust dial in the dashboard — the "trust dial is the UI, not the chat window" thesis, made visible. **Read-only**: the bridge endpoint replays the run + gate logs (same as the CLI), changing no live decision.

## Bridge
- `getWorkerShadowData()` (src/workers/runWorkerShadow.ts) returns the structured report `{ workers, runsScanned, decisionsScanned }`; the CLI now formats it.
- `GET /workers/shadow` (recipeRoutes.ts + `server.workerShadowFn` + recipeOrchestration wiring) → JSON `{ workers, …counts, generatedAt }`. Mirrors the halt-summary/doctor read-route precedent.

## Dashboard
- `/workers` page: per-worker dial — `HBarList` of action-class → **earned level** bars (with the `autonomyCeiling` cap shown), the ramp-vs-gate **divergences**, and the runs/decisions scanned count. Empty/loading/error states mirror `/suggestions`.
- Nav entry under **Build** (icon `person`). Routes through the existing catch-all bridge proxy — no dedicated dashboard route (no `[...name]` shadowing under `/workers/`, unlike the doctor case).

## Tests / gates
`getWorkerShadowData` structured-shape test + a dashboard page test (mock fetch → renders the dial + a divergence, plus the empty state). Green: bridge `tsc` / `tests:core` / fixture-audit / biome (52 worker tests), and dashboard `tsc` / vitest / `next lint` / inline-fontsize / vocabulary.

Once worker recipes (#1024) run, this page shows live climbing dials + a growing ramp-vs-gate agreement rate — the evidence for whether to ever flip the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)