### PR TITLE
feat(workers): live worker-autonomy gate flip (flag-gated, default off)

### DIFF
--- a/docs/design/worker-ramp-v0.md
+++ b/docs/design/worker-ramp-v0.md
@@ -84,17 +84,24 @@ phase 2 (new execution machinery).
   This is the answer to "what should an unearned AUTOMATED worker action do":
   fail-closed *only for the dangerous, non-undoable actions* — pure "gate
   everything unearned" would halt a new worker on everything for weeks (the
-  evidence-latency reality), which is unusable.
+  evidence-latency reality), which is unusable. **Agent (reasoning) steps are
+  never gated by the ramp** (they classify as `other:irreversible`, owned by no
+  one — gating them would stall every worker; the downstream tool steps still
+  gate on their own class).
 - `runWorkerShadow.loadWorkerTrustForRecipe(name)` — resolves the owning worker +
-  its earned-level store (replayed from the same run log as the dial).
-- `recipeOrchestration.buildWorkerAutonomyGate(name)` — when the
-  **`worker.autonomy`** flag is on AND a worker owns the recipe, supersedes the
-  tier approval fn with the worker-aware one and sets `gateAutomatedRuns` so the
-  flat runner's gate engages on AUTOMATED triggers too (that's how workers run).
-  Flag off OR no owning worker → byte-identical to pre-flip behaviour.
+  its earned-level store, **replayed in ascending timestamp order** (same as the
+  dial; the graduation dwell logic is order-sensitive — newest-first would mean
+  no risky class ever graduates and earned-L4 would be unreachable).
+- `recipeOrchestration.buildWorkerAutonomyGate(name, tierFn)` — when the
+  **`worker.autonomy`** flag is on AND a worker owns the recipe, composes the
+  worker-aware fn as a **FLOOR over the tier fn** (a worker `allow` decision
+  DEFERS to the tier fn, so it can only ADD gating — never drop the operator's
+  `approvalGate` protection, even on manual runs) and sets `gateAutomatedRuns` so
+  the flat runner's gate engages on AUTOMATED triggers too (that's how workers
+  run). Flag off OR no owning worker → byte-identical to pre-flip behaviour.
 - Fail-soft: any error resolving worker trust falls back to the tier gate; the
   decision never *widens* access — a "gate" result only routes to the existing
-  human-approval queue (fail-closed on reject/expire).
+  human-approval queue (fail-closed on reject/expire/cancel).
 
 **Still deferred (phase 3+), deliberately:**
 - L0/L2/L3 execution modes (suggest / reversible-window via `beginTransaction`/

--- a/docs/design/worker-ramp-v0.md
+++ b/docs/design/worker-ramp-v0.md
@@ -75,12 +75,35 @@ phase 2 (new execution machinery).
 - `shadowRun.ts` — replay an outcome sequence → dial trajectory (the evidence-latency
   test).
 
-**Deferred (phase 2+), deliberately:**
-- Flipping the live gate to obey the ramp (behind a flag, after shadow validation).
-- L0/L2/L3 execution modes (suggest / reversible-window / async-sample).
-- The trust-dial UI (the dashboard board).
+**Phase 2 — live gate flip (built, flag-gated, default OFF):**
+- `workerGate.ts` — the **live** decision `decideWorkerAction(worker, tool, params, store)`.
+  Reversibility-scoped: REVERSIBLE actions flow un-gated regardless of earned
+  level (undoable — the routine work a new worker should just do; blast still
+  drives the failure weight); COMPENSABLE / IRREVERSIBLE actions are gated for
+  approval until the worker has EARNED (ceiling-capped) L4 on that exact class.
+  This is the answer to "what should an unearned AUTOMATED worker action do":
+  fail-closed *only for the dangerous, non-undoable actions* — pure "gate
+  everything unearned" would halt a new worker on everything for weeks (the
+  evidence-latency reality), which is unusable.
+- `runWorkerShadow.loadWorkerTrustForRecipe(name)` — resolves the owning worker +
+  its earned-level store (replayed from the same run log as the dial).
+- `recipeOrchestration.buildWorkerAutonomyGate(name)` — when the
+  **`worker.autonomy`** flag is on AND a worker owns the recipe, supersedes the
+  tier approval fn with the worker-aware one and sets `gateAutomatedRuns` so the
+  flat runner's gate engages on AUTOMATED triggers too (that's how workers run).
+  Flag off OR no owning worker → byte-identical to pre-flip behaviour.
+- Fail-soft: any error resolving worker trust falls back to the tier gate; the
+  decision never *widens* access — a "gate" result only routes to the existing
+  human-approval queue (fail-closed on reject/expire).
+
+**Still deferred (phase 3+), deliberately:**
+- L0/L2/L3 execution modes (suggest / reversible-window via `beginTransaction`/
+  `rollback` / async-sample) — phase 2 only distinguishes gate vs flow.
+- Per-step caching of the replayed trust store (replays the run log per run).
 - Multi-worker coordination / delegation protocols (YAGNI until ≥2 mature workers).
 - License-tier autonomy caps; marketplace prior shipping.
+
+**Done in earlier phases:** shadow logger + the trust-dial UI (dashboard board).
 
 ## How it composes from what exists
 
@@ -90,7 +113,7 @@ phase 2 (new execution machinery).
 | blast tier | `classifyTool` (low/med/high) | reversibility tag |
 | content risk | `RiskSignal` kinds (`destructive_command`, `data_exfiltration`, …) | — |
 | evidence | decision/run/approval/judge trace stores | regroup by `(worker × class)` |
-| control floor | approval gate (`evaluateInProcessGate`) + kill switch | worker-aware decision (shadow) |
+| control floor | approval gate (`requireApprovalFn` / `evaluateInProcessGate`) + kill switch | worker-aware decision (live, `worker.autonomy` flag) |
 | experience compounds | what compounds is the **earned autonomy state**, not model memory — delivered before a distillation loop exists | — |
 
 ## Anti-gaming (honest)

--- a/src/__tests__/recipeOrchestration.workerGate.test.ts
+++ b/src/__tests__/recipeOrchestration.workerGate.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Worker-autonomy gate at the orchestration layer (review #1027 M1 + M3 + M4).
+ *
+ * buildWorkerAutonomyGate is the seam that carries the headline invariants:
+ *   - FLOOR composition (never-widen): a worker `allow` decision DEFERS to the
+ *     tier fn, so it can only ADD gating, never drop tier-policy protection.
+ *   - agent steps are not gated forever (M3).
+ *   - fail-closed: a gated risky step resolves false on reject / cancel / expire
+ *     and true only on an explicit approve (M4).
+ */
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  getApprovalQueue,
+  resetApprovalQueueForTests,
+} from "../approvalQueue.js";
+import { FLAG_WORKER_AUTONOMY, setFlag } from "../featureFlags.js";
+import { buildWorkerAutonomyGate } from "../recipeOrchestration.js";
+
+const WORKER_YAML = `id: test-worker
+name: Test Worker
+recipe: test-recipe
+owns:
+  - fs-write
+  - vcs-remote
+autonomyCeiling: 4
+`;
+
+const tick = () => new Promise((r) => setImmediate(r));
+
+function firstCallId(): string {
+  const [pend] = getApprovalQueue().list();
+  if (!pend) throw new Error("expected one pending approval");
+  return pend.callId;
+}
+
+describe("buildWorkerAutonomyGate", () => {
+  let dir: string;
+  let opts: { workersDir: string; patchworkDir: string };
+
+  beforeEach(() => {
+    dir = mkdtempSync(path.join(os.tmpdir(), "pw-wgate-"));
+    const workersDir = path.join(dir, "workers");
+    mkdirSync(workersDir, { recursive: true });
+    writeFileSync(path.join(workersDir, "test.worker.yaml"), WORKER_YAML);
+    opts = { workersDir, patchworkDir: dir }; // empty patchworkDir → unearned
+    setFlag(FLAG_WORKER_AUTONOMY, true, false);
+    resetApprovalQueueForTests();
+  });
+
+  afterEach(() => {
+    setFlag(FLAG_WORKER_AUTONOMY, false, false);
+    resetApprovalQueueForTests();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("returns null when the flag is off", async () => {
+    setFlag(FLAG_WORKER_AUTONOMY, false, false);
+    const g = await buildWorkerAutonomyGate("test-recipe", undefined, opts);
+    expect(g).toBeNull();
+  });
+
+  it("returns null when no worker owns the recipe", async () => {
+    const g = await buildWorkerAutonomyGate("unknown-recipe", undefined, opts);
+    expect(g).toBeNull();
+  });
+
+  it("FLOOR: a reversible step defers to the tier fn — never widens (M1)", async () => {
+    // tier fn would have queued/rejected this step; the worker gate must NOT
+    // auto-allow it just because it is reversible.
+    const tierFn = vi.fn(async () => false);
+    const g = await buildWorkerAutonomyGate("test-recipe", tierFn, opts);
+    const r = await g!({ toolId: "editText", tier: "high", params: {} });
+    expect(tierFn).toHaveBeenCalledTimes(1);
+    expect(r).toBe(false); // tier protection retained
+  });
+
+  it("FLOOR: a reversible step is allowed when the tier fn allows", async () => {
+    const tierFn = vi.fn(async () => true);
+    const g = await buildWorkerAutonomyGate("test-recipe", tierFn, opts);
+    const r = await g!({ toolId: "editText", tier: "low", params: {} });
+    expect(tierFn).toHaveBeenCalledTimes(1);
+    expect(r).toBe(true);
+  });
+
+  it("agent steps defer to the tier fn, never gate forever (M3)", async () => {
+    const tierFn = vi.fn(async () => true);
+    const g = await buildWorkerAutonomyGate("test-recipe", tierFn, opts);
+    const r = await g!({ toolId: "agent", tier: "medium", params: {} });
+    expect(tierFn).toHaveBeenCalledTimes(1);
+    expect(r).toBe(true);
+  });
+
+  it("a reversible step flows when there is no tier fn (approvalGate off)", async () => {
+    const g = await buildWorkerAutonomyGate("test-recipe", undefined, opts);
+    const r = await g!({ toolId: "editText", tier: "low", params: {} });
+    expect(r).toBe(true);
+  });
+
+  it("fail-closed: a risky unearned step queues and REJECT → false (M4)", async () => {
+    const g = await buildWorkerAutonomyGate("test-recipe", undefined, opts);
+    const p = g!({ toolId: "gitPush", tier: "high", params: {} });
+    await tick();
+    expect(getApprovalQueue().list()).toHaveLength(1);
+    getApprovalQueue().reject(firstCallId());
+    expect(await p).toBe(false);
+  });
+
+  it("fail-closed: a risky unearned step CANCEL → false (M4)", async () => {
+    const g = await buildWorkerAutonomyGate("test-recipe", undefined, opts);
+    const p = g!({ toolId: "gitPush", tier: "high", params: {} });
+    await tick();
+    getApprovalQueue().cancel(firstCallId());
+    expect(await p).toBe(false);
+  });
+
+  it("fail-closed: a risky unearned step EXPIRE → false (M4)", async () => {
+    const g = await buildWorkerAutonomyGate("test-recipe", undefined, opts);
+    const p = g!({ toolId: "gitPush", tier: "high", params: {} });
+    await tick();
+    getApprovalQueue().clear(); // resolves pending as "expired"
+    expect(await p).toBe(false);
+  });
+
+  it("a risky unearned step APPROVE → true (M4)", async () => {
+    const g = await buildWorkerAutonomyGate("test-recipe", undefined, opts);
+    const p = g!({ toolId: "gitPush", tier: "high", params: {} });
+    await tick();
+    getApprovalQueue().approve(firstCallId());
+    expect(await p).toBe(true);
+  });
+});

--- a/src/featureFlags.ts
+++ b/src/featureFlags.ts
@@ -314,6 +314,16 @@ export const FLAG_REPAIR_AI = "recipe.repair-ai";
  */
 export const FLAG_BLOCK_RECIPE_ALLOW_PRIVATE = "block-recipe-allow-private";
 
+/**
+ * Worker autonomy ramp (worker-ramp-v0). When ON, an automated worker recipe's
+ * RISKY steps (high-blast or irreversible action-classes) are gated for human
+ * approval UNTIL the owning worker has earned L4 trust on that class; low-blast
+ * reversible steps flow freely. Default OFF — behavior is byte-identical to
+ * today (automated runs never gate) until an operator opts in after the shadow
+ * dial shows real earned levels.
+ */
+export const FLAG_WORKER_AUTONOMY = "worker.autonomy";
+
 // Register built-in flags
 registerFlag({
   id: KILL_SWITCH_WRITES,
@@ -346,6 +356,15 @@ registerFlag({
   id: FLAG_BLOCK_RECIPE_ALLOW_PRIVATE,
   description:
     "Globally disable the per-step allowPrivate:true SSRF bypass in the recipe http.post tool. When on, private/loopback hosts are blocked even if a recipe sets allowPrivate:true.",
+  defaultValue: false,
+  category: "safety",
+  requiresOptIn: true,
+});
+
+registerFlag({
+  id: FLAG_WORKER_AUTONOMY,
+  description:
+    "Worker autonomy ramp: gate a worker recipe's risky (high-blast / irreversible) automated steps for approval until the owning worker earns L4 trust on that action-class; low-blast reversible steps flow freely. Default off.",
   defaultValue: false,
   category: "safety",
   requiresOptIn: true,

--- a/src/recipeOrchestration.ts
+++ b/src/recipeOrchestration.ts
@@ -85,6 +85,70 @@ async function makeRecipeApprovalFn(
   };
 }
 
+/**
+ * Worker-autonomy gate (worker-ramp-v0 phase 2, `worker.autonomy` flag, default
+ * off). When the flag is on AND a worker owns `recipeName` (recipe === body),
+ * returns a per-step approval fn that lets the worker's REVERSIBLE actions flow
+ * but QUEUES its risky (compensable/irreversible) actions for human approval
+ * until it has EARNED L4 trust on that action-class (fail-closed on reject /
+ * expire). Returns null when the flag is off or no worker owns the recipe — the
+ * caller falls back to the tier-based fn, so non-worker recipes are byte-
+ * identical. Unlike the tier gate this engages on AUTOMATED runs too (workers
+ * run automatically); the caller sets `gateAutomatedRuns` whenever this is set.
+ */
+async function buildWorkerAutonomyGate(
+  recipeName: string,
+): Promise<
+  | ((input: {
+      toolId: string;
+      tier: import("./riskTier.js").RiskTier;
+      summary?: string;
+      params?: Record<string, unknown>;
+    }) => Promise<boolean>)
+  | null
+> {
+  try {
+    const { isEnabled, FLAG_WORKER_AUTONOMY } = await import(
+      "./featureFlags.js"
+    );
+    if (!isEnabled(FLAG_WORKER_AUTONOMY)) return null;
+
+    const { loadWorkerTrustForRecipe } = await import(
+      "./workers/runWorkerShadow.js"
+    );
+    const trust = loadWorkerTrustForRecipe(recipeName);
+    if (!trust) return null;
+
+    const { decideWorkerAction } = await import("./workers/workerGate.js");
+    const { getApprovalQueue } = await import("./approvalQueue.js");
+    const queue = getApprovalQueue();
+    const { worker, store } = trust;
+
+    return async (input) => {
+      const decision = decideWorkerAction(
+        worker,
+        input.toolId,
+        input.params,
+        store,
+      );
+      if (decision.action === "allow") return true;
+      // gate → queue for human approval; fail-closed on reject / expire / cancel
+      const { promise } = queue.request({
+        toolName: input.toolId,
+        params: input.params ?? {},
+        tier: input.tier,
+        sessionId: `worker:${worker.id}`,
+        summary: `${worker.name} (${decision.classKey}): ${decision.reason}`,
+      });
+      return (await promise) === "approved";
+    };
+  } catch {
+    // Any failure resolving worker trust → fall back to tier gate (never widen
+    // access on an error; never crash the run).
+    return null;
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Public interfaces
 // ---------------------------------------------------------------------------
@@ -1009,10 +1073,17 @@ export class RecipeOrchestration {
     // cron/webhook runs never block mid-flight), so this injection does not
     // need to inspect the trigger type here.
     const approvalGate = this.deps.server?.approvalGate ?? "off";
-    const requireApprovalFn =
+    const tierApprovalFn =
       approvalGate === "off"
         ? undefined
         : await makeRecipeApprovalFn(approvalGate);
+    // worker.autonomy flip (flag-gated, default off). When a worker owns this
+    // recipe and the flag is on, the worker-aware fn supersedes the tier fn and
+    // the gate engages on automated runs too. Otherwise everything below is
+    // byte-identical to pre-flip behaviour.
+    const workerApprovalFn = await buildWorkerAutonomyGate(opts.name);
+    const requireApprovalFn = workerApprovalFn ?? tierApprovalFn;
+    const gateAutomatedRuns = workerApprovalFn != null;
     const runnerDeps = {
       workdir: this.deps.workdir,
       claudeCodeFn,
@@ -1024,6 +1095,7 @@ export class RecipeOrchestration {
       // counted in dashboard telemetry.
       ...(this.deps.activityLog && { activityLog: this.deps.activityLog }),
       ...(requireApprovalFn && { requireApprovalFn }),
+      ...(gateAutomatedRuns && { gateAutomatedRuns: true }),
     };
     // Pass the bridge's long-lived RecipeRunLog so chainedRunner can flip the
     // run from `running` → terminal in-place via startRun/completeRun. The

--- a/src/recipeOrchestration.ts
+++ b/src/recipeOrchestration.ts
@@ -85,6 +85,13 @@ async function makeRecipeApprovalFn(
   };
 }
 
+type ApprovalFn = (input: {
+  toolId: string;
+  tier: import("./riskTier.js").RiskTier;
+  summary?: string;
+  params?: Record<string, unknown>;
+}) => Promise<boolean>;
+
 /**
  * Worker-autonomy gate (worker-ramp-v0 phase 2, `worker.autonomy` flag, default
  * off). When the flag is on AND a worker owns `recipeName` (recipe === body),
@@ -95,18 +102,19 @@ async function makeRecipeApprovalFn(
  * caller falls back to the tier-based fn, so non-worker recipes are byte-
  * identical. Unlike the tier gate this engages on AUTOMATED runs too (workers
  * run automatically); the caller sets `gateAutomatedRuns` whenever this is set.
+ *
+ * NEVER-WIDEN (review #1027 M1): the worker fn is composed as a FLOOR over the
+ * tier fn, never a replacement. A worker `gate` decision queues; a worker
+ * `allow` decision DEFERS to `tierApprovalFn` (when present) so a step the tier
+ * policy would have queued is still queued. The worker gate can therefore only
+ * ADD gating, never remove gating the operator's `approvalGate` required — even
+ * on manual runs of a worker-owned recipe. Exported for orchestration tests.
  */
-async function buildWorkerAutonomyGate(
+export async function buildWorkerAutonomyGate(
   recipeName: string,
-): Promise<
-  | ((input: {
-      toolId: string;
-      tier: import("./riskTier.js").RiskTier;
-      summary?: string;
-      params?: Record<string, unknown>;
-    }) => Promise<boolean>)
-  | null
-> {
+  tierApprovalFn?: ApprovalFn,
+  trustOpts?: import("./workers/runWorkerShadow.js").RunWorkerShadowOpts,
+): Promise<ApprovalFn | null> {
   try {
     const { isEnabled, FLAG_WORKER_AUTONOMY } = await import(
       "./featureFlags.js"
@@ -116,7 +124,7 @@ async function buildWorkerAutonomyGate(
     const { loadWorkerTrustForRecipe } = await import(
       "./workers/runWorkerShadow.js"
     );
-    const trust = loadWorkerTrustForRecipe(recipeName);
+    const trust = loadWorkerTrustForRecipe(recipeName, trustOpts);
     if (!trust) return null;
 
     const { decideWorkerAction } = await import("./workers/workerGate.js");
@@ -131,7 +139,12 @@ async function buildWorkerAutonomyGate(
         input.params,
         store,
       );
-      if (decision.action === "allow") return true;
+      // allow → defer to the tier gate so we never DROP tier-policy protection
+      // (floor composition). When no tier fn is injected (approvalGate off),
+      // a worker `allow` means flow.
+      if (decision.action === "allow") {
+        return tierApprovalFn ? tierApprovalFn(input) : true;
+      }
       // gate → queue for human approval; fail-closed on reject / expire / cancel
       const { promise } = queue.request({
         toolName: input.toolId,
@@ -1078,10 +1091,14 @@ export class RecipeOrchestration {
         ? undefined
         : await makeRecipeApprovalFn(approvalGate);
     // worker.autonomy flip (flag-gated, default off). When a worker owns this
-    // recipe and the flag is on, the worker-aware fn supersedes the tier fn and
-    // the gate engages on automated runs too. Otherwise everything below is
+    // recipe and the flag is on, the worker-aware fn wraps the tier fn (FLOOR
+    // composition — it can only ADD gating, never drop tier-policy protection)
+    // and the gate engages on automated runs too. Otherwise everything below is
     // byte-identical to pre-flip behaviour.
-    const workerApprovalFn = await buildWorkerAutonomyGate(opts.name);
+    const workerApprovalFn = await buildWorkerAutonomyGate(
+      opts.name,
+      tierApprovalFn,
+    );
     const requireApprovalFn = workerApprovalFn ?? tierApprovalFn;
     const gateAutomatedRuns = workerApprovalFn != null;
     const runnerDeps = {

--- a/src/recipes/__tests__/flatRunnerApproval.test.ts
+++ b/src/recipes/__tests__/flatRunnerApproval.test.ts
@@ -142,3 +142,82 @@ describe("flat-runner approval gate", () => {
     expect(writes).toBe(2);
   });
 });
+
+/**
+ * worker.autonomy flip — `gateAutomatedRuns` makes the SAME gate engage on
+ * automated triggers too (that's how workers run). Off → byte-identical to the
+ * manual-only behaviour above.
+ */
+describe("flat-runner approval gate — gateAutomatedRuns (worker.autonomy)", () => {
+  it("engages on a CRON trigger when gateAutomatedRuns is set", async () => {
+    let writes = 0;
+    const requireApprovalFn = vi.fn(
+      async (i: { params?: Record<string, unknown> }) =>
+        i.params?.path !== `${TMP}/b`, // reject the 2nd step
+    );
+    const result = await runYamlRecipe(
+      recipe({ type: "cron" }),
+      deps({
+        requireApprovalFn,
+        gateAutomatedRuns: true,
+        writeFile: () => {
+          writes++;
+        },
+      }),
+    );
+    expect(requireApprovalFn).toHaveBeenCalledTimes(2); // consulted on cron
+    expect(writes).toBe(1); // rejected step did not write
+    expect(result.errorMessage).toMatch(/approval_rejected/);
+  });
+
+  it("runs an automated worker recipe unblocked when every step is approved", async () => {
+    let writes = 0;
+    const requireApprovalFn = vi.fn(async () => true);
+    await runYamlRecipe(
+      recipe({ type: "cron" }),
+      deps({
+        requireApprovalFn,
+        gateAutomatedRuns: true,
+        writeFile: () => {
+          writes++;
+        },
+      }),
+    );
+    expect(requireApprovalFn).toHaveBeenCalledTimes(2);
+    expect(writes).toBe(2);
+  });
+
+  it("withOUT gateAutomatedRuns a cron NEVER consults the gate (flag-off parity)", async () => {
+    let writes = 0;
+    const requireApprovalFn = vi.fn(async () => false); // would reject everything
+    await runYamlRecipe(
+      recipe({ type: "cron" }),
+      deps({
+        requireApprovalFn,
+        // gateAutomatedRuns omitted → manual-only, identical to pre-flip
+        writeFile: () => {
+          writes++;
+        },
+      }),
+    );
+    expect(requireApprovalFn).not.toHaveBeenCalled();
+    expect(writes).toBe(2);
+  });
+
+  it("respects requireApproval:false opt-out even with gateAutomatedRuns", async () => {
+    let writes = 0;
+    const requireApprovalFn = vi.fn(async () => false);
+    await runYamlRecipe(
+      recipe({ type: "cron" }, { requireApproval: false }),
+      deps({
+        requireApprovalFn,
+        gateAutomatedRuns: true,
+        writeFile: () => {
+          writes++;
+        },
+      }),
+    );
+    expect(requireApprovalFn).not.toHaveBeenCalled();
+    expect(writes).toBe(2);
+  });
+});

--- a/src/recipes/yamlRunner.ts
+++ b/src/recipes/yamlRunner.ts
@@ -626,6 +626,15 @@ export interface RunnerDeps {
     summary?: string;
     params?: Record<string, unknown>;
   }) => Promise<boolean>;
+  /**
+   * Worker-autonomy gate (worker.autonomy flag). When set, the approval gate
+   * ALSO engages on automated (cron/webhook/recipe) triggers — not just manual
+   * — because workers run automatically. Set by the orchestrator only when the
+   * flag is on AND a worker owns the recipe; then `requireApprovalFn` is the
+   * worker-aware fn (reversible actions pass, risky-unearned actions queue).
+   * Unset/false → manual-only gating, byte-identical to pre-flip behaviour.
+   */
+  gateAutomatedRuns?: boolean;
 }
 
 export interface RunResult {
@@ -732,6 +741,7 @@ export type StepDeps = Required<
     // M3 — approval gate runs in the run loop against `deps`, not per-step
     // StepDeps; keep it off StepDeps so it isn't forced Required here.
     | "requireApprovalFn"
+    | "gateAutomatedRuns"
     // Cancellation is checked in the run loop against `deps`, not per-step;
     // keep it off StepDeps so it isn't forced Required here.
     | "signal"
@@ -1742,16 +1752,21 @@ export async function runYamlRecipe(
         continue;
       }
 
-      // M3 — flat-runner approval gate. Safe-by-default: only engages for
+      // M3 — flat-runner approval gate. Safe-by-default: engages for
       // `manual`-triggered runs (cron/webhook/recipe runs never block
       // mid-flight) and only when the bridge injected `requireApprovalFn`
       // (i.e. approvalGate != "off"). Per-recipe opt-out via
       // `requireApproval: false`. The injected fn applies the tier threshold
       // itself and returns `true` for steps that don't need sign-off; a
       // `false` result is an explicit human rejection → halt the run.
+      //
+      // worker.autonomy: when `gateAutomatedRuns` is set the gate ALSO engages
+      // on automated triggers (that's how workers run), and `requireApprovalFn`
+      // is the worker-aware fn — reversible actions pass, risky-unearned ones
+      // queue. Off → manual-only, byte-identical to pre-flip behaviour.
       if (
         deps.requireApprovalFn &&
-        recipeTriggerKind === "manual" &&
+        (recipeTriggerKind === "manual" || deps.gateAutomatedRuns) &&
         recipe.requireApproval !== false
       ) {
         const approvalToolId = step.agent ? "agent" : (step.tool ?? "unknown");

--- a/src/workers/__tests__/runWorkerShadow.test.ts
+++ b/src/workers/__tests__/runWorkerShadow.test.ts
@@ -99,4 +99,45 @@ describe("loadWorkerTrustForRecipe (live-gate entry)", () => {
     expect(board.length).toBeGreaterThan(0);
     expect(board.some((b) => b.classKey.startsWith("fs-write"))).toBe(true);
   });
+
+  it("a risky class can graduate to earned L4 via ascending replay (M2)", () => {
+    // test-guardian owns `issue` (compensable, ceiling 4); githubCreateIssue is
+    // an issue-domain step. Seed many dwell-separated clean runs. With the
+    // ascending-order fix the dwell/hysteresis logic promotes the class to L4,
+    // so the live gate ALLOWS it. (Pre-fix the replay was newest-first → dwell
+    // never held → the class would gate forever.)
+    const log = new RecipeRunLog({ dir });
+    const SEVEN_HOURS = 7 * 3600 * 1000; // > the 6h default dwell window
+    for (let i = 0; i < 18; i++) {
+      log.appendDirect({
+        taskId: `t${i}`,
+        recipeName: "triage-failing-tests",
+        trigger: "recipe",
+        status: "done",
+        createdAt: i * SEVEN_HOURS,
+        doneAt: i * SEVEN_HOURS,
+        durationMs: 1,
+        stepResults: Array.from({ length: 5 }, (_, k) => ({
+          id: `s${i}-${k}`,
+          tool: "githubCreateIssue",
+          status: "ok" as const,
+          durationMs: 1,
+        })),
+      });
+    }
+    const trust = loadWorkerTrustForRecipe("triage-failing-tests", {
+      workersDir: WORKERS_DIR,
+      patchworkDir: dir,
+    });
+    expect(trust).not.toBeNull();
+    const d = decideWorkerAction(
+      trust!.worker,
+      "githubCreateIssue",
+      {},
+      trust!.store,
+    );
+    expect(d.owned).toBe(true);
+    expect(d.earnedLevel).toBe(4);
+    expect(d.action).toBe("allow");
+  });
 });

--- a/src/workers/__tests__/runWorkerShadow.test.ts
+++ b/src/workers/__tests__/runWorkerShadow.test.ts
@@ -2,7 +2,12 @@ import { mkdtempSync, rmSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { getWorkerShadowData } from "../runWorkerShadow.js";
+import { RecipeRunLog } from "../../runLog.js";
+import {
+  getWorkerShadowData,
+  loadWorkerTrustForRecipe,
+} from "../runWorkerShadow.js";
+import { decideWorkerAction } from "../workerGate.js";
 
 const WORKERS_DIR = path.join(process.cwd(), "templates", "workers");
 
@@ -36,5 +41,62 @@ describe("getWorkerShadowData", () => {
       ideDir: emptyDir,
     });
     expect(data.workers).toEqual([]);
+  });
+});
+
+describe("loadWorkerTrustForRecipe (live-gate entry)", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(path.join(os.tmpdir(), "pw-worker-trust-"));
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("returns null when no worker owns the recipe", () => {
+    const trust = loadWorkerTrustForRecipe("some-random-recipe", {
+      workersDir: WORKERS_DIR,
+      patchworkDir: dir,
+    });
+    expect(trust).toBeNull();
+  });
+
+  it("resolves the owning worker with an empty store when there are no runs", () => {
+    const trust = loadWorkerTrustForRecipe("release-notes", {
+      workersDir: WORKERS_DIR,
+      patchworkDir: dir, // no runs.jsonl
+    });
+    expect(trust).not.toBeNull();
+    expect(trust?.worker.id).toBe("release-notes-worker");
+    expect(trust?.store.board("release-notes-worker")).toEqual([]);
+    // a reversible action still flows even on an empty store
+    const d = decideWorkerAction(trust!.worker, "editText", {}, trust!.store);
+    expect(d.action).toBe("allow");
+  });
+
+  it("replays the run log into the store (same source as the dial)", () => {
+    const log = new RecipeRunLog({ dir });
+    log.appendDirect({
+      taskId: "t1",
+      recipeName: "release-notes",
+      trigger: "recipe",
+      status: "done",
+      createdAt: 0,
+      doneAt: 1,
+      durationMs: 1,
+      stepResults: [
+        { id: "s1", tool: "editText", status: "ok", durationMs: 1 },
+        { id: "s2", tool: "getGitStatus", status: "ok", durationMs: 1 },
+      ],
+    });
+    const trust = loadWorkerTrustForRecipe("release-notes", {
+      workersDir: WORKERS_DIR,
+      patchworkDir: dir,
+    });
+    expect(trust).not.toBeNull();
+    // the seeded successes are now evidence on the worker's dial
+    const board = trust?.store.board("release-notes-worker") ?? [];
+    expect(board.length).toBeGreaterThan(0);
+    expect(board.some((b) => b.classKey.startsWith("fs-write"))).toBe(true);
   });
 });

--- a/src/workers/__tests__/workerGate.test.ts
+++ b/src/workers/__tests__/workerGate.test.ts
@@ -80,6 +80,16 @@ describe("decideWorkerAction", () => {
     expect(d.reason).toContain("autonomy ceiling");
   });
 
+  it("ALLOWS an agent (reasoning) step — never gates it forever (M3)", () => {
+    // "agent" classifies as other:irreversible, owned by no worker → without
+    // the special-case it would gate on every run and stall the worker. The
+    // downstream tool steps still gate on their own class.
+    const w = parseWorker({ id: "w", name: "W", owns: ["fs-write"] });
+    const d = decideWorkerAction(w, "agent", undefined, new WorkerLevelStore());
+    expect(d.action).toBe("allow");
+    expect(d.reason).toContain("agent");
+  });
+
   it("GATES a risky action outside the worker's owned domain", () => {
     const w = parseWorker({ id: "w", name: "W", owns: ["fs-write"] });
     // worker has L4 on gitPush in the store, but does not OWN vcs-remote

--- a/src/workers/__tests__/workerGate.test.ts
+++ b/src/workers/__tests__/workerGate.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import { classifyActionClass } from "../actionClass.js";
+import type { GraduationConfig } from "../graduation.js";
+import { parseWorker } from "../worker.js";
+import { decideWorkerAction, flowsUngated } from "../workerGate.js";
+import { WorkerLevelStore } from "../workerLevelStore.js";
+
+const CFG: GraduationConfig = {
+  dwellMs: 1000,
+  demoteCooldownMs: 5000,
+  minEvidenceForGraduation: 5,
+};
+
+/** Build a store where `workerId` has earned L4 on `toolName`. */
+function storeWithL4(workerId: string, toolName: string): WorkerLevelStore {
+  const store = new WorkerLevelStore();
+  for (let i = 0; i < 80; i++)
+    store.apply(workerId, { toolName, good: true, at: 0 }, { cfg: CFG });
+  // dwell-separated outcomes so graduation can climb rung by rung to L4
+  for (const at of [1000, 2000, 3000, 4000, 5000, 6000, 7000, 8000])
+    store.apply(workerId, { toolName, good: true, at }, { cfg: CFG });
+  return store;
+}
+
+describe("flowsUngated", () => {
+  it("is true for reversible classes (any blast) and false otherwise", () => {
+    expect(flowsUngated(classifyActionClass("getGitStatus"))).toBe(true); // low
+    expect(flowsUngated(classifyActionClass("editText"))).toBe(true); // medium
+    expect(flowsUngated(classifyActionClass("gitPush"))).toBe(false); // compensable
+    expect(flowsUngated(classifyActionClass("slackPostMessage"))).toBe(false); // irreversible
+  });
+});
+
+describe("decideWorkerAction", () => {
+  it("lets a REVERSIBLE action flow un-gated even unearned and unowned", () => {
+    const w = parseWorker({ id: "w", name: "W", owns: ["fs-write"] });
+    const d = decideWorkerAction(w, "getGitStatus", {}, new WorkerLevelStore());
+    expect(d.action).toBe("allow");
+    expect(d.reason).toContain("reversible");
+  });
+
+  it("lets the worker's own REVERSIBLE core action flow before earning L4", () => {
+    // the release-notes case: writing the CHANGELOG (fs-write, reversible,
+    // medium blast) must NOT halt for weeks while trust accrues.
+    const w = parseWorker({ id: "w", name: "W", owns: ["fs-write"] });
+    const d = decideWorkerAction(w, "editText", {}, new WorkerLevelStore());
+    expect(d.action).toBe("allow");
+    expect(d.effectiveLevel).toBe(0);
+  });
+
+  it("GATES a compensable/irreversible action the worker has not earned", () => {
+    const w = parseWorker({ id: "w", name: "W", owns: ["vcs-remote"] });
+    const d = decideWorkerAction(w, "gitPush", {}, new WorkerLevelStore());
+    expect(d.action).toBe("gate");
+    expect(d.owned).toBe(true);
+    expect(d.effectiveLevel).toBe(0);
+    expect(d.reason).toContain("unearned");
+  });
+
+  it("ALLOWS a risky action once the worker has earned L4 on it", () => {
+    const w = parseWorker({ id: "w", name: "W", owns: ["vcs-remote"] });
+    const d = decideWorkerAction(w, "gitPush", {}, storeWithL4("w", "gitPush"));
+    expect(d.earnedLevel).toBe(4);
+    expect(d.effectiveLevel).toBe(4);
+    expect(d.action).toBe("allow");
+    expect(d.reason).toContain("earned autonomy");
+  });
+
+  it("autonomyCeiling caps a risky class below L4 → still gated despite earning L4", () => {
+    const w = parseWorker({
+      id: "w",
+      name: "W",
+      owns: ["vcs-remote"],
+      autonomyCeiling: 2,
+    });
+    const d = decideWorkerAction(w, "gitPush", {}, storeWithL4("w", "gitPush"));
+    expect(d.earnedLevel).toBe(4);
+    expect(d.effectiveLevel).toBe(2);
+    expect(d.action).toBe("gate");
+    expect(d.reason).toContain("autonomy ceiling");
+  });
+
+  it("GATES a risky action outside the worker's owned domain", () => {
+    const w = parseWorker({ id: "w", name: "W", owns: ["fs-write"] });
+    // worker has L4 on gitPush in the store, but does not OWN vcs-remote
+    const d = decideWorkerAction(w, "gitPush", {}, storeWithL4("w", "gitPush"));
+    expect(d.owned).toBe(false);
+    expect(d.effectiveLevel).toBe(0);
+    expect(d.action).toBe("gate");
+    expect(d.reason).toContain("outside");
+  });
+});

--- a/src/workers/runWorkerShadow.ts
+++ b/src/workers/runWorkerShadow.ts
@@ -153,7 +153,14 @@ export function loadWorkerTrustForRecipe(
   const observer = new WorkerShadowObserver(workers);
   const worker = observer.workerForRecipe(recipeName);
   if (!worker) return null;
-  for (const run of readRuns(patchworkDir)) observer.ingestRun(run);
+  // Replay in ASCENDING timestamp order (review #1027 M2). The graduation
+  // dwell/hysteresis logic is order-sensitive: ingesting newest-first leaves
+  // `lastChangeAt` pinned to the most recent run so `dwellOk` never holds and
+  // risky classes never promote — the earned-L4 path would be unreachable and
+  // the gate would floor every compensable/irreversible class to L0 forever.
+  // This mirrors buildShadowReport (the dial), so the gate and dial agree.
+  const runs = readRuns(patchworkDir).sort((a, b) => a.at - b.at);
+  for (const run of runs) observer.ingestRun(run);
   return { worker, store: observer.levelStore };
 }
 

--- a/src/workers/runWorkerShadow.ts
+++ b/src/workers/runWorkerShadow.ts
@@ -2,12 +2,15 @@ import { readdirSync, readFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { RecipeRunLog } from "../runLog.js";
-import type {
-  DecisionRecord,
-  RunRecord,
-  WorkerShadowReport,
+import {
+  type DecisionRecord,
+  type RunRecord,
+  WorkerShadowObserver,
+  type WorkerShadowReport,
 } from "./shadowObserver.js";
 import { buildShadowReport, formatShadowReport } from "./shadowReport.js";
+import type { WorkerManifest } from "./worker.js";
+import type { WorkerLevelStore } from "./workerLevelStore.js";
 import { loadWorkersFromDir } from "./workerLoader.js";
 
 /**
@@ -120,6 +123,38 @@ export function getWorkerShadowData(
     decisionsScanned: decisions.length,
     workersDir,
   };
+}
+
+export interface RecipeWorkerTrust {
+  worker: WorkerManifest;
+  /** Earned-level store, replayed from the run log — same source as the dial. */
+  store: WorkerLevelStore;
+}
+
+/**
+ * Load the worker that owns `recipeName` (recipe === body) plus its earned-level
+ * store, replayed from the same run log the dial uses. Returns null when no
+ * worker owns the recipe (the common case — non-worker recipes are unaffected).
+ *
+ * This is the LIVE-gate entry: `workerGate.decideWorkerAction(worker, tool,
+ * params, store)` reads the returned store. It replays the run log on each call
+ * (recipe executions are infrequent); a future optimisation could cache it.
+ */
+export function loadWorkerTrustForRecipe(
+  recipeName: string,
+  opts: RunWorkerShadowOpts = {},
+): RecipeWorkerTrust | null {
+  const home = os.homedir();
+  const patchworkDir = opts.patchworkDir ?? path.join(home, ".patchwork");
+  const workersDir = opts.workersDir ?? path.join(patchworkDir, "workers");
+
+  const workers = loadWorkersFromDir(workersDir);
+  if (!workers.length) return null;
+  const observer = new WorkerShadowObserver(workers);
+  const worker = observer.workerForRecipe(recipeName);
+  if (!worker) return null;
+  for (const run of readRuns(patchworkDir)) observer.ingestRun(run);
+  return { worker, store: observer.levelStore };
 }
 
 export function runWorkerShadowReport(opts: RunWorkerShadowOpts = {}): string {

--- a/src/workers/shadowObserver.ts
+++ b/src/workers/shadowObserver.ts
@@ -79,8 +79,18 @@ export class WorkerShadowObserver {
     this.cfg = opts.cfg ?? DEFAULT_GRADUATION_CONFIG;
   }
 
-  /** Attribute a run to the worker whose recipe is its body. */
-  private workerForRecipe(recipeName: string): WorkerManifest | undefined {
+  /**
+   * The populated level store. Exposed so the LIVE worker-autonomy gate
+   * (`workerGate.decideWorkerAction`) can read the same earned levels this
+   * observer derives from the run log — one source of truth for the dial and
+   * the gate. Read-only intent; callers must not mutate.
+   */
+  get levelStore(): WorkerLevelStore {
+    return this.store;
+  }
+
+  /** The worker whose recipe body is `recipeName`, if any. */
+  workerForRecipe(recipeName: string): WorkerManifest | undefined {
     return this.workers.find((w) => w.recipe === recipeName);
   }
 

--- a/src/workers/workerGate.ts
+++ b/src/workers/workerGate.ts
@@ -86,6 +86,21 @@ export function decideWorkerAction(
     effectiveLevel,
   } as const;
 
+  // Agent (reasoning) steps are not a durable side-effecting action-class: the
+  // claude subprocess produces an output var, and any tool calls it makes are
+  // gated on their OWN class. The step id classifies as `other:irreversible`
+  // (owned by no worker), so without this it would gate forever and stall every
+  // worker on its agent step while the real file.write flowed. Let it through;
+  // the downstream tool steps still gate. The tier gate (composed as a floor by
+  // the caller) still applies its own policy to the agent step.
+  if (toolName === "agent") {
+    return {
+      ...base,
+      action: "allow",
+      reason: "agent reasoning step — not a gated action-class",
+    };
+  }
+
   // Reversible: flows freely. The routine work a new worker should just do.
   if (flowsUngated(ac)) {
     return {

--- a/src/workers/workerGate.ts
+++ b/src/workers/workerGate.ts
@@ -1,0 +1,116 @@
+import { type ActionClass, classifyActionClass } from "./actionClass.js";
+import type { TrustLevel } from "./trustLevel.js";
+import { ownsAction, type WorkerManifest } from "./worker.js";
+import type { WorkerLevelStore } from "./workerLevelStore.js";
+
+/**
+ * The LIVE worker-autonomy decision (worker-ramp-v0, phase 2). Unlike
+ * `shadowGate.recommend` — which reports queue/bypass purely for the dial — this
+ * is what the approval gate ACTS on when the `worker.autonomy` flag is enabled.
+ *
+ * The rule is reversibility-scoped, deliberately. Pure "gate everything the
+ * worker hasn't earned L4 on" is correct-but-unusable: a brand-new worker would
+ * halt on EVERY action for the weeks it takes to accumulate evidence (the
+ * evidence-latency reality). Reversibility is the ramp's primary axis, so it is
+ * the gate's too:
+ *
+ *   - REVERSIBLE actions flow un-gated regardless of earned level. They are
+ *     undoable (transactions + WriteEffectLedger, git reset/reflog, re-runnable
+ *     CI) so the cost of being wrong is bounded — undo it. Blast tier still
+ *     drives the FAILURE WEIGHT, so a big reversible mistake demotes the worker
+ *     hard; it just isn't pre-gated. This is the routine work (read, local
+ *     commit, ledgered file write) a new worker should simply do.
+ *   - COMPENSABLE / IRREVERSIBLE actions (lossy or no undo — remote push, PR,
+ *     merge, outbound message, http POST, shell, delete) are gated for human
+ *     approval until the worker has EARNED (ceiling-capped) L4 trust on that
+ *     exact action-class. This is the "stop and ask before the dangerous thing"
+ *     behaviour of a trustworthy new employee.
+ *
+ * The decision NEVER widens access on its own: when the flag is off the gate
+ * path this feeds is not engaged at all, and even on, a "gate" result only ever
+ * routes an action to the EXISTING human-approval queue (fail-closed) — it never
+ * auto-approves anything that would otherwise have been queued by tier policy.
+ */
+
+export type WorkerGateAction = "allow" | "gate";
+
+export interface WorkerGateDecision {
+  action: WorkerGateAction;
+  classKey: string;
+  domain: string;
+  owned: boolean;
+  blastTier: ActionClass["blastTier"];
+  reversibility: ActionClass["reversibility"];
+  /** Trust actually earned on this class (for logging / the dial). */
+  earnedLevel: TrustLevel;
+  autonomyCeiling: TrustLevel;
+  /** What the gate operates at: min(earned, ceiling), 0 if not owned. */
+  effectiveLevel: TrustLevel;
+  reason: string;
+}
+
+const AUTONOMOUS_LEVEL = 4 as const;
+
+/**
+ * Undoable → flows un-gated even when unearned. Only reversible actions are
+ * exempt from the trust requirement; compensable / irreversible ones (lossy or
+ * no undo) wait for earned L4. Reversibility is the ramp's primary axis.
+ */
+export function flowsUngated(ac: ActionClass): boolean {
+  return ac.reversibility === "reversible";
+}
+
+export function decideWorkerAction(
+  worker: WorkerManifest,
+  toolName: string,
+  params: Record<string, unknown> | undefined,
+  store: WorkerLevelStore,
+): WorkerGateDecision {
+  const ac = classifyActionClass(toolName, params);
+  const owned = ownsAction(worker, ac);
+  const earnedLevel = (store.getState(worker.id, ac.key)?.level ??
+    0) as TrustLevel;
+
+  let effectiveLevel: TrustLevel = owned ? earnedLevel : 0;
+  if (effectiveLevel > worker.autonomyCeiling)
+    effectiveLevel = worker.autonomyCeiling;
+
+  const base = {
+    classKey: ac.key,
+    domain: ac.domain,
+    owned,
+    blastTier: ac.blastTier,
+    reversibility: ac.reversibility,
+    earnedLevel,
+    autonomyCeiling: worker.autonomyCeiling,
+    effectiveLevel,
+  } as const;
+
+  // Reversible: flows freely. The routine work a new worker should just do.
+  if (flowsUngated(ac)) {
+    return {
+      ...base,
+      action: "allow",
+      reason: `reversible (${ac.blastTier} blast) — undoable, flows un-gated`,
+    };
+  }
+
+  // Compensable / irreversible: autonomous only once EARNED (ceiling-capped) L4.
+  if (effectiveLevel >= AUTONOMOUS_LEVEL) {
+    return {
+      ...base,
+      action: "allow",
+      reason: `earned autonomy (L4) on a ${ac.reversibility} class`,
+    };
+  }
+
+  let reason: string;
+  if (!owned) {
+    reason = `${ac.reversibility} action outside the worker's owned domain — gated`;
+  } else if (worker.autonomyCeiling < AUTONOMOUS_LEVEL) {
+    reason = `${ac.reversibility} class capped by autonomy ceiling (L${worker.autonomyCeiling}) — always gated`;
+  } else {
+    reason = `${ac.reversibility} + unearned (effective L${effectiveLevel} < L4) — gated for approval`;
+  }
+  return { ...base, action: "gate", reason };
+}


### PR DESCRIPTION
## What

Phase 2 of `worker-ramp-v0`: let the recipe approval gate **obey the trust ramp**, behind a new **`worker.autonomy`** feature flag (default **OFF**, opt-in). Flag off → behaviour is byte-identical to today.

This answers the open design fork — *what should an AUTOMATED worker action the worker hasn't earned L4 trust for do?* — with **fail-closed, but only for the dangerous, non-undoable actions.**

## The rule (reversibility-scoped)

The ramp's primary axis (reversibility) applied to the gate:

- **REVERSIBLE** actions (read, local commit, ledgered file write, re-runnable CI) **flow un-gated regardless of earned level**. Undoable → the cost of being wrong is bounded. Blast tier still drives the *failure weight* that demotes hard on a bad outcome; it just isn't pre-gated. This is the routine work a new worker should simply do.
- **COMPENSABLE / IRREVERSIBLE** actions (remote push, PR, merge, outbound message, http POST, shell, delete) are **gated for human approval until the worker has EARNED (ceiling-capped) L4** on that exact action-class.

Why not "gate everything unearned"? It's correct-but-unusable: a brand-new worker would halt on *every* action for the weeks it takes to accumulate evidence (the evidence-latency reality). Reversibility is the line that's both protective and usable — "stop and ask before the dangerous thing."

## Wiring

- `featureFlags`: register `worker.autonomy` (category safety, `requiresOptIn`).
- `workers/workerGate.ts` (new): pure `decideWorkerAction(worker, tool, params, store)` → `allow | gate` + full decision detail.
- `runWorkerShadow.loadWorkerTrustForRecipe(name)`: resolve the owning worker + its earned-level store, **replayed from the same run log the dial uses** (one source of truth). `shadowObserver` exposes `levelStore` + public `workerForRecipe`.
- `recipeOrchestration.buildWorkerAutonomyGate(name)`: when the flag is on **and** a worker owns the recipe, supersede the tier approval fn with the worker-aware one and set `gateAutomatedRuns`.
- `yamlRunner`: the flat-runner gate engages on **automated** triggers too when `gateAutomatedRuns` is set (that's how workers run). Flag off or no owning worker → the condition is identical to the prior manual-only behaviour.

**Fail-soft / never-widen:** any error resolving worker trust falls back to the tier gate; a `gate` result only ever routes to the *existing* human-approval queue (fail-closed on reject/expire). The flip never auto-approves anything tier policy would have queued.

## Tests

- `workerGate.test.ts` — reversible flows un-gated (even unowned/unearned); risky-unearned gates; earned-L4 allows; `autonomyCeiling` caps a risky class below L4 → still gated; risky-outside-domain gates.
- `runWorkerShadow.test.ts` — `loadWorkerTrustForRecipe`: null when unowned, worker resolution, run-log replay into the store.
- `flatRunnerApproval.test.ts` — `gateAutomatedRuns`: cron engages the gate when set; **without** it a cron never consults the gate (flag-off parity); respects `requireApproval:false`.

Full project `tsc` + `tsc -p tsconfig.tests.core.json` clean; biome clean.

> Note: `runner.contract.test.ts` agent-sentinel test is a pre-existing local timing flake (verified failing identically on clean `origin/main`), unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)