### PR TITLE
fix(workers): clear worker-ramp fast-follow review findings (L1–L5)

### DIFF
--- a/src/__tests__/approvalHttp-channel.test.ts
+++ b/src/__tests__/approvalHttp-channel.test.ts
@@ -14,12 +14,14 @@ function makeQueue(opts?: {
   approve?: (callId: string) => boolean;
   reject?: (callId: string) => boolean;
   getRecentDecision?: (callId: string) => "allow" | "deny" | undefined;
+  list?: () => Array<{ callId: string; toolName: string }>;
 }): ApprovalQueue {
   return {
     validateToken: opts?.validateToken ?? (() => true),
     approve: opts?.approve ?? (() => true),
     reject: opts?.reject ?? (() => true),
     getRecentDecision: opts?.getRecentDecision ?? (() => undefined),
+    list: opts?.list ?? (() => []),
     enqueue: () => Promise.resolve({ callId: "test", timedOut: false }),
     cancelPending: () => {},
     getPendingList: () => [],
@@ -128,6 +130,47 @@ describe("routeApprovalRequest — approval_decision channel provenance", () => 
         callId: "call-4",
         decision: "deny",
         channel: "dashboard",
+      }),
+    );
+  });
+
+  it("includes the pending entry's toolName on an approve decision (L4)", async () => {
+    const onDecision = vi.fn();
+    await routeApprovalRequest(
+      { method: "POST", path: "/approve/call-5", body: {} },
+      {
+        queue: makeQueue({
+          approve: () => true,
+          list: () => [{ callId: "call-5", toolName: "gitPush" }],
+        }),
+        workspace: "/tmp",
+        onDecision,
+      },
+    );
+    expect(onDecision).toHaveBeenCalledWith(
+      "approval_decision",
+      expect.objectContaining({ callId: "call-5", toolName: "gitPush" }),
+    );
+  });
+
+  it("includes the pending entry's toolName on a reject decision (L4)", async () => {
+    const onDecision = vi.fn();
+    await routeApprovalRequest(
+      { method: "POST", path: "/reject/call-6", body: {} },
+      {
+        queue: makeQueue({
+          reject: () => true,
+          list: () => [{ callId: "call-6", toolName: "githubCreateIssue" }],
+        }),
+        workspace: "/tmp",
+        onDecision,
+      },
+    );
+    expect(onDecision).toHaveBeenCalledWith(
+      "approval_decision",
+      expect.objectContaining({
+        callId: "call-6",
+        toolName: "githubCreateIssue",
       }),
     );
   });

--- a/src/__tests__/recipeOrchestration.workerGate.test.ts
+++ b/src/__tests__/recipeOrchestration.workerGate.test.ts
@@ -132,4 +132,19 @@ describe("buildWorkerAutonomyGate", () => {
     getApprovalQueue().approve(firstCallId());
     expect(await p).toBe(true);
   });
+
+  it("aborting the run signal resolves a gated step false, not a TTL hang (L1)", async () => {
+    const g = await buildWorkerAutonomyGate("test-recipe", undefined, opts);
+    const ac = new AbortController();
+    const p = g!({
+      toolId: "gitPush",
+      tier: "high",
+      params: {},
+      signal: ac.signal,
+    });
+    await tick();
+    expect(getApprovalQueue().list()).toHaveLength(1);
+    ac.abort(); // run cancelled → pending approval resolves "cancelled"
+    expect(await p).toBe(false);
+  });
 });

--- a/src/approvalHttp.ts
+++ b/src/approvalHttp.ts
@@ -281,6 +281,12 @@ export async function routeApprovalRequest(
         };
       }
     }
+    // Capture the tool name BEFORE resolving (approve() removes the entry).
+    // L4: the worker shadow logger keys ramp-vs-gate attribution off `toolName`
+    // in the decision metadata — without it the comparison silently drops the row.
+    const approveToolName = deps.queue
+      .list?.()
+      .find((e) => e.callId === callId)?.toolName;
     const ok = deps.queue.approve(callId);
     if (ok) {
       // Audit 2026-06-03 (MEDIUM #27): fire the audit hook on APPROVE too —
@@ -295,6 +301,7 @@ export async function routeApprovalRequest(
         // approval UI in practice. Lets the audit log answer "approved from
         // where", not just "who/what/when".
         channel: req.approvalToken !== undefined ? "phone" : "dashboard",
+        ...(approveToolName !== undefined && { toolName: approveToolName }),
       });
       return { status: 200, body: { decision: "allow", callId } };
     }
@@ -368,6 +375,11 @@ export async function routeApprovalRequest(
       const trimmed = raw.trim().slice(0, 500);
       if (trimmed.length > 0) reason = trimmed;
     }
+    // L4: capture toolName before reject() removes the entry (worker shadow
+    // attribution keys off it).
+    const rejectToolName = deps.queue
+      .list?.()
+      .find((e) => e.callId === callId)?.toolName;
     const ok = deps.queue.reject(callId);
     if (ok) {
       deps.onDecision?.("approval_decision", {
@@ -376,6 +388,7 @@ export async function routeApprovalRequest(
         ...(reason !== undefined && { reason }),
         // Provenance: phone (single-use token) vs dashboard/Bearer caller.
         channel: req.approvalToken !== undefined ? "phone" : "dashboard",
+        ...(rejectToolName !== undefined && { toolName: rejectToolName }),
       });
       return { status: 200, body: { decision: "deny", callId } };
     }

--- a/src/recipeOrchestration.ts
+++ b/src/recipeOrchestration.ts
@@ -58,28 +58,24 @@ export const RECIPE_TASK_TIMEOUT_MS = 1_800_000;
  * human approval and resolves true only on an explicit "approved" decision
  * (a reject / expire / cancel halts the run — fail-closed, ADR-0016 spirit).
  */
-async function makeRecipeApprovalFn(
-  gate: "high" | "all",
-): Promise<
-  (input: {
-    toolId: string;
-    tier: import("./riskTier.js").RiskTier;
-    summary?: string;
-    params?: Record<string, unknown>;
-  }) => Promise<boolean>
-> {
+async function makeRecipeApprovalFn(gate: "high" | "all"): Promise<ApprovalFn> {
   const { getApprovalQueue } = await import("./approvalQueue.js");
   const queue = getApprovalQueue();
   return async (input) => {
     // Below-threshold steps don't need sign-off.
     if (gate === "high" && input.tier !== "high") return true;
-    const { promise } = queue.request({
-      toolName: input.toolId,
-      params: input.params ?? {},
-      tier: input.tier,
-      sessionId: "recipe",
-      ...(input.summary !== undefined && { summary: input.summary }),
-    });
+    const { promise } = queue.request(
+      {
+        toolName: input.toolId,
+        params: input.params ?? {},
+        tier: input.tier,
+        sessionId: "recipe",
+        ...(input.summary !== undefined && { summary: input.summary }),
+      },
+      // L1: abort the wait if the run is cancelled (→ "cancelled" → halt)
+      // instead of blocking for the full approval TTL.
+      { signal: input.signal },
+    );
     const decision = await promise;
     return decision === "approved";
   };
@@ -90,6 +86,10 @@ type ApprovalFn = (input: {
   tier: import("./riskTier.js").RiskTier;
   summary?: string;
   params?: Record<string, unknown>;
+  /** The run's AbortSignal — when it fires, the pending approval resolves
+   * "cancelled" so a cancelled run halts promptly instead of waiting the full
+   * approval TTL (L1). */
+  signal?: AbortSignal;
 }) => Promise<boolean>;
 
 /**
@@ -146,13 +146,16 @@ export async function buildWorkerAutonomyGate(
         return tierApprovalFn ? tierApprovalFn(input) : true;
       }
       // gate → queue for human approval; fail-closed on reject / expire / cancel
-      const { promise } = queue.request({
-        toolName: input.toolId,
-        params: input.params ?? {},
-        tier: input.tier,
-        sessionId: `worker:${worker.id}`,
-        summary: `${worker.name} (${decision.classKey}): ${decision.reason}`,
-      });
+      const { promise } = queue.request(
+        {
+          toolName: input.toolId,
+          params: input.params ?? {},
+          tier: input.tier,
+          sessionId: `worker:${worker.id}`,
+          summary: `${worker.name} (${decision.classKey}): ${decision.reason}`,
+        },
+        { signal: input.signal }, // L1: cancel the wait when the run aborts
+      );
       return (await promise) === "approved";
     };
   } catch {

--- a/src/recipes/__tests__/chainedRunner-tier1-guards.test.ts
+++ b/src/recipes/__tests__/chainedRunner-tier1-guards.test.ts
@@ -105,6 +105,23 @@ describe("executeChainedStep — approval gate (Tier-1 #4)", () => {
     expect(result.success).toBe(true);
   });
 
+  it("forwards the run's AbortSignal into requireApprovalFn (L1/L5 chained path)", async () => {
+    // A worker recipe can be chained; the approval wait must be cancellable so a
+    // cancelled run doesn't block for the full TTL.
+    const ac = new AbortController();
+    const requireApprovalFn = vi.fn().mockResolvedValue(true);
+    const deps = makeDeps({ requireApprovalFn });
+    await executeChainedStep(
+      ctxFor({ id: "s", tool: "some.tool" }, recipeNoTrigger, {
+        options: { ...baseOptions, signal: ac.signal },
+      }),
+      deps,
+    );
+    expect(requireApprovalFn).toHaveBeenCalledWith(
+      expect.objectContaining({ signal: ac.signal }),
+    );
+  });
+
   it("does not gate NESTED chained recipes (depth > 0) — only the top-level run", async () => {
     // A chained recipe always has trigger.type:"chained" (cron/webhook route to
     // the flat runner), so depth is the safe-by-default signal: a nested chained

--- a/src/recipes/__tests__/flatRunnerApproval.test.ts
+++ b/src/recipes/__tests__/flatRunnerApproval.test.ts
@@ -13,6 +13,7 @@ import { mkdtempSync, rmSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterAll, describe, expect, it, vi } from "vitest";
+import { cancelRun } from "../runRegistry.js";
 import {
   type RunnerDeps,
   runYamlRecipe,
@@ -219,5 +220,48 @@ describe("flat-runner approval gate — gateAutomatedRuns (worker.autonomy)", ()
     );
     expect(requireApprovalFn).not.toHaveBeenCalled();
     expect(writes).toBe(2);
+  });
+});
+
+/**
+ * L1 (review #1028) — the flat runner must forward the LIVE run signal
+ * (runController.signal, aborted by POST /runs/:seq/cancel) into the approval
+ * wait, not just deps.signal (undefined in production). Cancelling a registered
+ * run must abort a pending approval instead of hanging the full TTL.
+ */
+describe("flat-runner approval gate — cancel aborts a pending approval (L1)", () => {
+  it("forwards the run-registry signal so cancelRun(seq) resolves the wait", async () => {
+    const SEQ = 919191;
+    // minimal runLog stub so the runner registers a runController for SEQ
+    const runLog = {
+      startRun: () => SEQ,
+      updateRunSteps: () => {},
+      completeRun: () => {},
+    } as unknown as RunnerDeps["runLog"];
+
+    let captured: AbortSignal | undefined;
+    // mimic the real ApprovalQueue: resolve false ("cancelled") on abort, else hang
+    const requireApprovalFn = vi.fn(async (i: { signal?: AbortSignal }) => {
+      captured = i.signal;
+      if (i.signal?.aborted) return false;
+      return new Promise<boolean>((resolve) => {
+        i.signal?.addEventListener("abort", () => resolve(false));
+      });
+    });
+
+    const p = runYamlRecipe(
+      recipe({ type: "manual" }),
+      deps({ runLog, requireApprovalFn }),
+    );
+    await new Promise((r) => setImmediate(r));
+    // the approval wait received the LIVE run signal (not undefined)
+    expect(captured).toBeDefined();
+    expect(captured?.aborted).toBe(false);
+
+    cancelRun(SEQ); // POST /runs/:seq/cancel equivalent
+    expect(captured?.aborted).toBe(true); // pending approval is aborted, not hung
+
+    const result = await p;
+    expect(result.errorMessage).toMatch(/approval_rejected/);
   });
 });

--- a/src/recipes/chainedRunner.ts
+++ b/src/recipes/chainedRunner.ts
@@ -257,6 +257,8 @@ export interface ExecutionDeps {
     tier: RiskTier;
     summary?: string;
     params?: Record<string, unknown>;
+    /** Run AbortSignal — cancels the approval wait promptly on run abort (L1). */
+    signal?: AbortSignal;
   }) => Promise<boolean>;
 }
 
@@ -657,6 +659,7 @@ export async function executeChainedStep(
         tier: classifyTool(approvalToolId),
         summary: step.agent ? "agent step" : `tool ${approvalToolId}`,
         params: step.agent ? undefined : (resolved as Record<string, unknown>),
+        ...(options.signal && { signal: options.signal }), // L1
       });
       if (!approved) {
         return {

--- a/src/recipes/yamlRunner.ts
+++ b/src/recipes/yamlRunner.ts
@@ -1242,6 +1242,17 @@ export async function runYamlRecipe(
   // Mirrors chainedRunner.ts:1277 — only the top-level run registers.
   const runController = runSeq !== undefined ? registerRun(runSeq) : undefined;
 
+  // L1 (review #1028): the LIVE cancel handle is runController.signal (aborted
+  // by POST /runs/:seq/cancel); deps.signal is the external caller signal
+  // (absent on the production flat path). Combine both so a cancelled run aborts
+  // a pending approval wait instead of hanging the full TTL — forwarding only
+  // deps.signal left the flat path's L1 goal unmet. Mirrors the dual-signal
+  // next-step check below.
+  const effectiveRunSignal =
+    runController?.signal && deps.signal
+      ? AbortSignal.any([runController.signal, deps.signal])
+      : (runController?.signal ?? deps.signal);
+
   const outputs: string[] = [];
   const stepResults: StepResult[] = [];
   // P1 cost/token corpus. The price table is loaded once per run (fail-open).
@@ -1780,7 +1791,7 @@ export async function runYamlRecipe(
             ? `agent step${step.agent.into ? ` → ${step.agent.into}` : ""}`
             : `tool ${approvalToolId}`,
           params: step.agent ? undefined : (step as Record<string, unknown>),
-          ...(deps.signal && { signal: deps.signal }), // L1
+          ...(effectiveRunSignal && { signal: effectiveRunSignal }), // L1
         });
         if (!approved) {
           const reason = `Step rejected by approval gate — approval_rejected.`;

--- a/src/recipes/yamlRunner.ts
+++ b/src/recipes/yamlRunner.ts
@@ -625,6 +625,9 @@ export interface RunnerDeps {
     tier: import("../riskTier.js").RiskTier;
     summary?: string;
     params?: Record<string, unknown>;
+    /** The run's AbortSignal — lets the approval wait be cancelled promptly
+     * when the run is aborted, instead of blocking for the full TTL (L1). */
+    signal?: AbortSignal;
   }) => Promise<boolean>;
   /**
    * Worker-autonomy gate (worker.autonomy flag). When set, the approval gate
@@ -1777,6 +1780,7 @@ export async function runYamlRecipe(
             ? `agent step${step.agent.into ? ` → ${step.agent.into}` : ""}`
             : `tool ${approvalToolId}`,
           params: step.agent ? undefined : (step as Record<string, unknown>),
+          ...(deps.signal && { signal: deps.signal }), // L1
         });
         if (!approved) {
           const reason = `Step rejected by approval gate — approval_rejected.`;

--- a/src/workers/__tests__/shadowObserver.test.ts
+++ b/src/workers/__tests__/shadowObserver.test.ts
@@ -79,4 +79,57 @@ describe("WorkerShadowObserver", () => {
     });
     expect(obs.report()[0]!.compared).toBe(0);
   });
+
+  it("counts a genuine tool error as evidence but NOT a human rejection (L2)", () => {
+    // a real failure is evidence (shows up on the dial)
+    const real = new WorkerShadowObserver([release], { cfg: CFG });
+    real.ingestRun({
+      recipeName: "release-notes",
+      at: 0,
+      steps: [
+        {
+          tool: "editText",
+          status: "error",
+          haltReason: 'Tool "editText" threw: boom',
+        },
+      ],
+    });
+    expect(
+      real.report()[0]!.board.some((b) => b.classKey.startsWith("fs-write")),
+    ).toBe(true);
+
+    // a human reject/expire/cancel is a control decision, not a worker failure
+    const rejected = new WorkerShadowObserver([release], { cfg: CFG });
+    rejected.ingestRun({
+      recipeName: "release-notes",
+      at: 0,
+      steps: [
+        {
+          tool: "editText",
+          status: "error",
+          haltReason: "Step rejected by approval gate — approval_rejected.",
+        },
+      ],
+    });
+    expect(
+      rejected
+        .report()[0]!
+        .board.some((b) => b.classKey.startsWith("fs-write")),
+    ).toBe(false); // skipped → no evidence → no demotion
+  });
+
+  it("flags board rows for classes the worker performs but does NOT own (L3)", () => {
+    const obs = new WorkerShadowObserver([release], { cfg: CFG });
+    // gitPush is vcs-remote — release owns fs-write + vcs-read, NOT vcs-remote
+    obs.ingestRun({
+      recipeName: "release-notes",
+      at: 0,
+      steps: [{ tool: "gitPush", status: "ok" }],
+    });
+    const row = obs
+      .report()[0]!
+      .board.find((b) => b.classKey.startsWith("vcs-remote"));
+    expect(row).toBeDefined();
+    expect(row!.owned).toBe(false);
+  });
 });

--- a/src/workers/__tests__/shadowReport.test.ts
+++ b/src/workers/__tests__/shadowReport.test.ts
@@ -93,4 +93,24 @@ describe("formatShadowReport", () => {
     const text = formatShadowReport(buildShadowReport([release], [], [], CFG));
     expect(text).toContain("no attributed activity yet");
   });
+
+  it("annotates a NOT-OWNED class the worker performed (L3)", () => {
+    // release owns fs-write only; a gitPush (vcs-remote) it performs is shown
+    // but flagged because the live gate floors it to L0.
+    const reports = buildShadowReport(
+      [release],
+      [
+        {
+          recipeName: "release-notes",
+          at: 0,
+          steps: [{ tool: "gitPush", status: "ok" }],
+        },
+      ],
+      [],
+      CFG,
+    );
+    const text = formatShadowReport(reports);
+    expect(text).toContain("vcs-remote");
+    expect(text).toContain("NOT OWNED");
+  });
 });

--- a/src/workers/runWorkerShadow.ts
+++ b/src/workers/runWorkerShadow.ts
@@ -39,6 +39,7 @@ function readRuns(patchworkDir: string): RunRecord[] {
       steps: (r.stepResults ?? []).map((s) => ({
         tool: s.tool,
         status: s.status,
+        haltReason: s.haltReason,
       })),
     }));
   } catch {

--- a/src/workers/shadowObserver.ts
+++ b/src/workers/shadowObserver.ts
@@ -1,10 +1,16 @@
+import { categoriseHaltReason } from "../recipes/haltCategory.js";
 import { classifyActionClass } from "./actionClass.js";
 import {
   DEFAULT_GRADUATION_CONFIG,
   type GraduationConfig,
 } from "./graduation.js";
 import { recommend } from "./shadowGate.js";
-import { ownsAction, priorFor, type WorkerManifest } from "./worker.js";
+import {
+  ownsAction,
+  ownsClassKey,
+  priorFor,
+  type WorkerManifest,
+} from "./worker.js";
 import {
   type AuditEvent,
   type BoardRow,
@@ -25,7 +31,13 @@ export interface RunRecord {
   recipeName: string;
   /** epoch ms */
   at: number;
-  steps: Array<{ tool?: string; status: "ok" | "skipped" | "error" }>;
+  steps: Array<{
+    tool?: string;
+    status: "ok" | "skipped" | "error";
+    /** Persisted halt reason — used to tell a worker failure apart from a
+     * human approval decision (the latter is not trust evidence; see L2). */
+    haltReason?: string;
+  }>;
 }
 
 /** A live gate decision (maps from an ActivityLog approval_decision row). */
@@ -50,7 +62,9 @@ export interface WorkerShadowReport {
   workerId: string;
   name: string;
   autonomyCeiling: number;
-  board: BoardRow[];
+  /** Dial rows. `owned: false` = the worker performed this class but does not
+   * own it, so the live gate floors it to L0 regardless of accrued evidence. */
+  board: Array<BoardRow & { owned: boolean }>;
   events: AuditEvent[];
   /** ramp-vs-gate comparison over attributable decisions */
   compared: number;
@@ -111,6 +125,16 @@ export class WorkerShadowObserver {
     const prior = priorFor(worker);
     for (const step of run.steps) {
       if (!step.tool || step.status === "skipped") continue; // skipped ≠ evidence
+      // L2: a step halted because a HUMAN rejected / let expire / cancelled the
+      // approval is a control decision, not a worker failure — counting it as
+      // `good: false` would demote the worker for every correct "not yet", so
+      // the gate could never self-clear. Skip it (non-evidence). Genuine tool
+      // errors still count.
+      if (
+        step.status === "error" &&
+        categoriseHaltReason(step.haltReason) === "approval_rejected"
+      )
+        continue;
       this.store.apply(
         worker.id,
         { toolName: step.tool, good: step.status === "ok", at: run.at },
@@ -163,7 +187,13 @@ export class WorkerShadowObserver {
         workerId: w.id,
         name: w.name,
         autonomyCeiling: w.autonomyCeiling,
-        board: this.store.board(w.id),
+        // L3: flag rows for classes the worker performs but does NOT own — the
+        // dial shows accrued evidence there, but the live gate floors them to 0
+        // (a worker has no standing trust outside its `owns`). Without the flag
+        // the dial looks like earned autonomy that the gate silently ignores.
+        board: this.store
+          .board(w.id)
+          .map((r) => ({ ...r, owned: ownsClassKey(w, r.classKey) })),
         events: this.store.events(w.id),
         compared: c.compared,
         agreed: c.agreed,

--- a/src/workers/shadowReport.ts
+++ b/src/workers/shadowReport.ts
@@ -50,8 +50,12 @@ export function formatShadowReport(reports: WorkerShadowReport[]): string {
           b.level > r.autonomyCeiling
             ? `  → operating L${r.autonomyCeiling} (ceiling)`
             : "";
+        // L3: a class the worker performs but doesn't own is floored to L0 by
+        // the gate regardless of the evidence shown here — flag it so the dial
+        // isn't read as earned autonomy the gate will honour.
+        const notOwned = b.owned ? "" : "  ⚠ NOT OWNED — gate floors to L0";
         lines.push(
-          `    ${b.classKey.padEnd(36)} earned L${b.level}${capped}  ·  ${b.observations} obs  ·  ${(b.mean * 100).toFixed(0)}% mean`,
+          `    ${b.classKey.padEnd(36)} earned L${b.level}${capped}  ·  ${b.observations} obs  ·  ${(b.mean * 100).toFixed(0)}% mean${notOwned}`,
         );
       }
     }

--- a/src/workers/worker.ts
+++ b/src/workers/worker.ts
@@ -135,3 +135,18 @@ export function ownsAction(worker: WorkerManifest, ac: ActionClass): boolean {
     (p) => p === ac.domain || p === ac.key || ac.key.startsWith(`${p}:`),
   );
 }
+
+/**
+ * Ownership check against a raw class key (`domain:reversibility:blastTier`),
+ * for callers that have a board row's `classKey` but not a full ActionClass
+ * (e.g. the dial). Mirrors `ownsAction`: the domain is the key's first segment.
+ */
+export function ownsClassKey(
+  worker: WorkerManifest,
+  classKey: string,
+): boolean {
+  const domain = classKey.split(":")[0];
+  return worker.owns.some(
+    (p) => p === domain || p === classKey || classKey.startsWith(`${p}:`),
+  );
+}


### PR DESCRIPTION
Fast-follow from the adversarial review of #1027. Clears the 5 LOW findings (+ nit), all test-first. No product-design changes; correctness/robustness/observability for when the `worker.autonomy` flag is enabled.

## Fixes

**L2 — trust poisoning (the important one).** A step halted because a *human* rejected / let expire / cancelled the approval was persisted as `status:"error"` and replayed as a worker *failure* (`good:false`, weight up to 27). So every correct "not yet" demoted the worker and the gate could never self-clear. `shadowObserver.ingestRun` now skips steps whose `haltReason` categorises as `approval_rejected` (non-evidence); genuine tool errors still count. `RunRecord.steps` carries `haltReason`.

**L1 — cancel responsiveness.** The approval wait took no `AbortSignal`, so a cancelled run blocked for the full 5-min TTL. The run signal is now threaded through `requireApprovalFn` → `queue.request({...},{signal})` on **both** the flat and chained paths (`makeRecipeApprovalFn` + `buildWorkerAutonomyGate` forward it). A cancelled run resolves the pending approval `"cancelled"` → halts promptly. Undefined signal is a no-op (byte-identical when absent).

**L4 — shadow attribution.** The interactive `/approve` and `/reject` handlers omitted `toolName` from the `approval_decision` metadata, which the worker shadow logger requires to attribute a gate decision to a worker — so the ramp-vs-gate comparison silently dropped those rows. Both handlers now capture the pending entry's `toolName` (via `queue.list()`, guarded) before resolving. The auto path already had it.

**L3 — dial honesty.** A class a worker *performs* but does not `own` accrued visible evidence while the gate floors it to L0 — the dial read like earned autonomy the gate ignores. `WorkerShadowReport` board rows now carry `owned`; `formatShadowReport` flags not-owned rows `⚠ NOT OWNED — gate floors to L0`. New `ownsClassKey()` helper.

**L5 — coverage.** Added the chained-runner worker-path test (requireApprovalFn consulted + run signal forwarded at depth 0); earned-L4-via-gate is covered by the `runWorkerShadow` ascending-replay test.

## Tests
+L2/L3 (shadowObserver), +L3 format (shadowReport), +L4 ×2 (approvalHttp-channel), +L1 (recipeOrchestration.workerGate), +L1/L5 chained. Full `tsc` + `tsc -p tsconfig.tests.core.json` + biome clean; affected suites green (104 across the changed files; 1691/1692 in the broad run — the one failure is the pre-existing `runner.contract` agent-sentinel timing flake, verified failing identically on clean `main`, unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)