### PR TITLE
feat(workers): github.create_issue recipe tool + opt-in autofile recipe

### DIFF
--- a/src/connectors/__tests__/github.test.ts
+++ b/src/connectors/__tests__/github.test.ts
@@ -19,6 +19,7 @@ vi.stubGlobal("fetch", mockFetch);
 
 import * as fs from "node:fs";
 import {
+  createIssue,
   fetchGitHubIssue,
   fetchGitHubPR,
   getStatus,
@@ -520,5 +521,77 @@ describe("listCommits", () => {
     await expect(listCommits({ repo: "acme/widget" })).rejects.toThrow(
       /list_commits failed.*401 token expired/,
     );
+  });
+});
+
+describe("createIssue (WRITE)", () => {
+  it("throws when not connected (no MCP call)", async () => {
+    const callTool = vi.spyOn(McpClient.prototype, "callTool");
+    await expect(
+      createIssue({ repo: "acme/widget", title: "t" }),
+    ).rejects.toThrow(/not connected/);
+    expect(callTool).not.toHaveBeenCalled();
+    callTool.mockRestore();
+  });
+
+  it("rejects a non 'owner/repo' repo before any MCP call (review #1029)", async () => {
+    mockConnected();
+    const callTool = vi.spyOn(McpClient.prototype, "callTool");
+    // 3-segment must NOT silently truncate to owner/repo
+    await expect(
+      createIssue({ repo: "acme/widget/extra", title: "t" }),
+    ).rejects.toThrow(/exact 'owner\/repo'/);
+    await expect(createIssue({ repo: "widget", title: "t" })).rejects.toThrow(
+      /exact 'owner\/repo'/,
+    );
+    expect(callTool).not.toHaveBeenCalled();
+    callTool.mockRestore();
+  });
+
+  it("calls create_issue with owner/repo/title/body/labels/assignees and returns the issue", async () => {
+    mockConnected();
+    const callTool = vi
+      .spyOn(McpClient.prototype, "callTool")
+      .mockResolvedValue(
+        mcpJsonResult({
+          number: 42,
+          html_url: "https://github.com/acme/widget/issues/42",
+          title: "Flaky test",
+        }),
+      );
+    const issue = await createIssue({
+      repo: "acme/widget",
+      title: "Flaky test",
+      body: "details",
+      labels: ["bug"],
+      assignees: ["octocat"],
+    });
+    expect(callTool).toHaveBeenCalledWith(
+      "create_issue",
+      expect.objectContaining({
+        owner: "acme",
+        repo: "widget",
+        title: "Flaky test",
+        body: "details",
+        labels: ["bug"],
+        assignees: ["octocat"],
+      }),
+      expect.any(Object),
+    );
+    expect(issue).toEqual({
+      number: 42,
+      url: "https://github.com/acme/widget/issues/42",
+      title: "Flaky test",
+    });
+  });
+
+  it("throws when the MCP response has no issue number (no fabricated success)", async () => {
+    mockConnected();
+    vi.spyOn(McpClient.prototype, "callTool").mockResolvedValue(
+      mcpJsonResult({ message: "ok but not an issue" }),
+    );
+    await expect(
+      createIssue({ repo: "acme/widget", title: "t" }),
+    ).rejects.toThrow(/no issue number/);
   });
 });

--- a/src/connectors/github.ts
+++ b/src/connectors/github.ts
@@ -188,6 +188,55 @@ export async function listIssues(
   }
 }
 
+export interface CreateIssueOpts {
+  /** "owner/repo" — required. */
+  repo: string;
+  title: string;
+  body?: string;
+  labels?: string[];
+  assignees?: string[];
+}
+
+export interface CreatedGitHubIssue {
+  number: number;
+  url: string;
+  title: string;
+}
+
+/**
+ * Create a GitHub issue via the connector's MCP `create_issue` tool. A WRITE —
+ * never cached. Mirrors listIssues' auth/client/parse path so it works headless
+ * (no `gh` CLI dependency). Throws on a missing connector / bad input / MCP
+ * error so the recipe-tool wrapper can surface a `{error}` step result.
+ */
+export async function createIssue(
+  opts: CreateIssueOpts,
+  signal?: AbortSignal,
+): Promise<CreatedGitHubIssue> {
+  if (!isConnected("github"))
+    throw new Error(
+      "github connector not connected — visit /connections to authenticate",
+    );
+  const { owner, repo } = parseRepo(opts);
+  if (!owner || !repo)
+    throw new Error(
+      "github create_issue requires `repo` in 'owner/repo' format",
+    );
+  if (!opts.title?.trim())
+    throw new Error("github create_issue requires a non-empty title");
+  const args: Record<string, unknown> = { owner, repo, title: opts.title };
+  if (opts.body) args.body = opts.body;
+  if (opts.labels?.length) args.labels = opts.labels;
+  if (opts.assignees?.length) args.assignees = opts.assignees;
+  const res = await client().callTool("create_issue", args, { signal });
+  const raw = McpClient.extractJson<RawIssue>(res);
+  return {
+    number: raw.number,
+    url: raw.html_url ?? raw.url ?? "",
+    title: raw.title ?? opts.title,
+  };
+}
+
 interface RawPR extends RawIssue {
   draft?: boolean;
   isDraft?: boolean;

--- a/src/connectors/github.ts
+++ b/src/connectors/github.ts
@@ -217,11 +217,15 @@ export async function createIssue(
     throw new Error(
       "github connector not connected — visit /connections to authenticate",
     );
-  const { owner, repo } = parseRepo(opts);
-  if (!owner || !repo)
+  // A WRITE must not misdirect: require EXACTLY "owner/repo" (parseRepo is
+  // lenient by design for the read tools — a 3-segment "a/b/c" would silently
+  // truncate to a/b). Review #1029 LOW.
+  const parts = opts.repo.split("/");
+  if (parts.length !== 2 || !parts[0]?.trim() || !parts[1]?.trim())
     throw new Error(
-      "github create_issue requires `repo` in 'owner/repo' format",
+      "github create_issue requires `repo` in exact 'owner/repo' format",
     );
+  const [owner, repo] = parts.map((s) => s.trim());
   if (!opts.title?.trim())
     throw new Error("github create_issue requires a non-empty title");
   const args: Record<string, unknown> = { owner, repo, title: opts.title };
@@ -230,6 +234,10 @@ export async function createIssue(
   if (opts.assignees?.length) args.assignees = opts.assignees;
   const res = await client().callTool("create_issue", args, { signal });
   const raw = McpClient.extractJson<RawIssue>(res);
+  // Defensive (brand-exposed write): a non-issue 200 payload must not fabricate
+  // a success. Review #1029 LOW.
+  if (typeof raw?.number !== "number")
+    throw new Error("github create_issue: MCP returned no issue number");
   return {
     number: raw.number,
     url: raw.html_url ?? raw.url ?? "",

--- a/src/recipes/tools/__tests__/github-create-issue.test.ts
+++ b/src/recipes/tools/__tests__/github-create-issue.test.ts
@@ -1,0 +1,92 @@
+/**
+ * github.create_issue — the first GitHub-write recipe tool. Wraps the connector
+ * createIssue and normalises success/failure into the recipe-tool JSON shape.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const createIssue = vi.fn();
+
+vi.mock("../../../connectors/github.js", () => ({
+  createIssue,
+  // other exports the github tool module may import dynamically (unused here)
+  listIssues: vi.fn(),
+  listPRs: vi.fn(),
+  listCommits: vi.fn(),
+}));
+
+import "../github.js";
+import { getTool } from "../../toolRegistry.js";
+import type { RunContext, StepDeps } from "../../yamlRunner.js";
+
+function ctx(params: Record<string, unknown>) {
+  return {
+    params,
+    step: {} as Record<string, unknown>,
+    ctx: {} as RunContext,
+    deps: {} as StepDeps,
+  };
+}
+
+afterEach(() => vi.clearAllMocks());
+
+describe("github.create_issue", () => {
+  it("creates an issue and returns number/url/title", async () => {
+    createIssue.mockResolvedValue({
+      number: 42,
+      url: "https://github.com/o/r/issues/42",
+      title: "Flaky test in auth",
+    });
+    const tool = getTool("github.create_issue");
+    const out = await tool?.execute(
+      ctx({ repo: "o/r", title: "Flaky test in auth", body: "details" }),
+    );
+    const parsed = JSON.parse(out ?? "{}");
+    expect(parsed).toEqual({
+      number: 42,
+      url: "https://github.com/o/r/issues/42",
+      title: "Flaky test in auth",
+    });
+    expect(createIssue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        repo: "o/r",
+        title: "Flaky test in auth",
+        body: "details",
+      }),
+    );
+  });
+
+  it("forwards labels and assignees arrays", async () => {
+    createIssue.mockResolvedValue({ number: 1, url: "u", title: "t" });
+    const tool = getTool("github.create_issue");
+    await tool?.execute(
+      ctx({
+        repo: "o/r",
+        title: "t",
+        labels: ["bug", "ci"],
+        assignees: ["alice"],
+      }),
+    );
+    expect(createIssue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        labels: ["bug", "ci"],
+        assignees: ["alice"],
+      }),
+    );
+  });
+
+  it("normalises a connector failure into {error} (no throw)", async () => {
+    createIssue.mockRejectedValue(new Error("github connector not connected"));
+    const tool = getTool("github.create_issue");
+    const out = await tool?.execute(ctx({ repo: "o/r", title: "t" }));
+    const parsed = JSON.parse(out ?? "{}");
+    expect(parsed.error).toMatch(/not connected/);
+    expect(parsed.number).toBeUndefined();
+  });
+
+  it("is registered as a write tool (kill-switch / approval gated)", () => {
+    const tool = getTool("github.create_issue");
+    expect(tool?.isWrite).toBe(true);
+    expect(tool?.riskDefault).toBe("high");
+  });
+});

--- a/src/recipes/tools/__tests__/github-create-issue.test.ts
+++ b/src/recipes/tools/__tests__/github-create-issue.test.ts
@@ -43,6 +43,7 @@ describe("github.create_issue", () => {
     );
     const parsed = JSON.parse(out ?? "{}");
     expect(parsed).toEqual({
+      ok: true,
       number: 42,
       url: "https://github.com/o/r/issues/42",
       title: "Flaky test in auth",
@@ -75,11 +76,12 @@ describe("github.create_issue", () => {
     );
   });
 
-  it("normalises a connector failure into {error} (no throw)", async () => {
+  it("reports a connector failure as {ok:false, error} so the runner halts (no throw, not silent success)", async () => {
     createIssue.mockRejectedValue(new Error("github connector not connected"));
     const tool = getTool("github.create_issue");
     const out = await tool?.execute(ctx({ repo: "o/r", title: "t" }));
     const parsed = JSON.parse(out ?? "{}");
+    expect(parsed.ok).toBe(false); // hard ok:false → runner flags a step error
     expect(parsed.error).toMatch(/not connected/);
     expect(parsed.number).toBeUndefined();
   });

--- a/src/recipes/tools/github.ts
+++ b/src/recipes/tools/github.ts
@@ -198,3 +198,78 @@ registerTool({
     }
   },
 });
+
+// ============================================================================
+// github.create_issue  (WRITE — the first GitHub-write recipe tool)
+// ============================================================================
+
+registerTool({
+  id: "github.create_issue",
+  namespace: "github",
+  description:
+    "Create a GitHub issue in a repository (title + optional body, labels, assignees).",
+  paramsSchema: {
+    type: "object",
+    properties: {
+      repo: {
+        type: "string",
+        description: "Repository in 'owner/repo' format (required)",
+      },
+      title: { type: "string", description: "Issue title (required)" },
+      body: { type: "string", description: "Issue body (Markdown)" },
+      labels: {
+        type: "array",
+        items: { type: "string" },
+        description: "Labels to apply",
+      },
+      assignees: {
+        type: "array",
+        items: { type: "string" },
+        description: "GitHub usernames to assign",
+      },
+      into: CommonSchemas.into,
+    },
+    required: ["repo", "title"],
+  },
+  outputSchema: {
+    type: "object",
+    properties: {
+      number: { type: "number" },
+      url: { type: "string" },
+      title: { type: "string" },
+      error: { type: "string" },
+    },
+  },
+  riskDefault: "high",
+  isWrite: true,
+  isConnector: true,
+  execute: async ({ params }) => {
+    const { createIssue } = await import("../../connectors/github.js");
+    const repo = params.repo ? String(params.repo) : "";
+    const title = params.title ? String(params.title) : "";
+    try {
+      const issue = await createIssue({
+        repo,
+        title,
+        ...(params.body !== undefined && { body: String(params.body) }),
+        ...(Array.isArray(params.labels) && {
+          labels: params.labels.map(String),
+        }),
+        ...(Array.isArray(params.assignees) && {
+          assignees: params.assignees.map(String),
+        }),
+      });
+      return JSON.stringify({
+        number: issue.number,
+        url: issue.url,
+        title: issue.title,
+      });
+    } catch (err) {
+      // Translate connector throw into a {error} shape the runner's silent-fail
+      // detector flags as a step error (matches the list_* tools above).
+      return JSON.stringify({
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  },
+});

--- a/src/recipes/tools/github.ts
+++ b/src/recipes/tools/github.ts
@@ -234,6 +234,7 @@ registerTool({
   outputSchema: {
     type: "object",
     properties: {
+      ok: { type: "boolean" },
       number: { type: "number" },
       url: { type: "string" },
       title: { type: "string" },
@@ -260,14 +261,19 @@ registerTool({
         }),
       });
       return JSON.stringify({
+        ok: true,
         number: issue.number,
         url: issue.url,
         title: issue.title,
       });
     } catch (err) {
-      // Translate connector throw into a {error} shape the runner's silent-fail
-      // detector flags as a step error (matches the list_* tools above).
+      // A WRITE that failed MUST surface as a step error — return the
+      // `{ok:false,error}` envelope so the runner's hard ok:false check
+      // (yamlRunner) halts the run and the worker ramp records a FAILURE.
+      // (The list_* read tools use a `{count:0,...,error}` shape instead;
+      // a bare `{error}` would read as success here — review #1029 HIGH.)
       return JSON.stringify({
+        ok: false,
         error: err instanceof Error ? err.message : String(err),
       });
     }

--- a/src/riskTier.ts
+++ b/src/riskTier.ts
@@ -162,7 +162,22 @@ const NAMESPACED_READ_VERB =
 const NAMESPACED_WRITE_VERB =
   /^(create|post|send|update|add|delete|remove|comment|write|set|merge|close|archive|move|upload|publish|reply|assign|transition|edit|put|patch|cancel|run|trigger|invite|react|upsert)/;
 
+/**
+ * Static tier for namespaced ids whose declared `riskDefault` is HIGHER than the
+ * verb heuristic would infer — so the tier is deterministic even when the recipe
+ * tool registry resolver is not loaded (e.g. the `workers shadow` process, which
+ * never imports recipes/tools). Without this, github.create_issue resolved to
+ * `high` in the live gate (registry loaded) but `medium` in the shadow dial,
+ * splitting a worker's trust ledger by process. Extend whenever a write tool's
+ * riskDefault exceeds its verb tier (`create*` → medium heuristic). Review #1029.
+ */
+const NAMESPACED_TIER_OVERRIDES: Record<string, RiskTier> = {
+  "github.create_issue": "high", // brand-exposed external write
+};
+
 function inferTierFromNamespacedId(id: string): RiskTier {
+  const override = NAMESPACED_TIER_OVERRIDES[id];
+  if (override !== undefined) return override;
   const verb = id.slice(id.indexOf(".") + 1).toLowerCase();
   if (NAMESPACED_READ_VERB.test(verb)) return "low";
   if (NAMESPACED_WRITE_VERB.test(verb)) return "medium";

--- a/src/workers/__tests__/actionClass.test.ts
+++ b/src/workers/__tests__/actionClass.test.ts
@@ -53,6 +53,16 @@ describe("classifyActionClass", () => {
     // compensable ⇒ the full ramp is reachable (can earn L4), unlike irreversible
     expect(reachableLevels(c)).toEqual([0, 1, 2, 3, 4]);
   });
+
+  it("resolves github.create_issue blastTier to 'high' WITHOUT the recipe-tool registry (review #1029 MEDIUM)", () => {
+    // This test process never imports recipes/tools, so the tier resolver is
+    // absent — exactly the `workers shadow` process. The static override must
+    // still yield `high`, matching the live gate, so a worker's trust ledger is
+    // keyed identically in both processes (no medium/high split).
+    const c = classifyActionClass("github.create_issue");
+    expect(c.blastTier).toBe("high");
+    expect(c.key).toBe("issue:compensable:high");
+  });
 });
 
 describe("reachableLevels", () => {

--- a/src/workers/__tests__/actionClass.test.ts
+++ b/src/workers/__tests__/actionClass.test.ts
@@ -44,6 +44,15 @@ describe("classifyActionClass", () => {
     expect(classifyActionClass("github.list_prs").domain).toBe("vcs-read");
     expect(classifyActionClass("slack.post_message").brandExposed).toBe(true);
   });
+
+  it("classifies github.create_issue as issue / compensable / brand-exposed (a graduating risky class)", () => {
+    const c = classifyActionClass("github.create_issue");
+    expect(c.domain).toBe("issue");
+    expect(c.reversibility).toBe("compensable"); // an issue is closeable
+    expect(c.brandExposed).toBe(true); // externally visible
+    // compensable ⇒ the full ramp is reachable (can earn L4), unlike irreversible
+    expect(reachableLevels(c)).toEqual([0, 1, 2, 3, 4]);
+  });
 });
 
 describe("reachableLevels", () => {

--- a/src/workers/actionClass.ts
+++ b/src/workers/actionClass.ts
@@ -83,6 +83,7 @@ const DOMAIN_BY_TOOL: Record<string, string> = {
   "github.list_commits": "vcs-read",
   "github.list_prs": "vcs-read",
   "github.list_issues": "vcs-read",
+  "github.create_issue": "issue", // write — compensable (closeable) + brand-exposed
   "file.read": "fs-read",
   "file.write": "fs-write",
   "file.append": "fs-write",

--- a/templates/recipes/triage-failing-tests-autofile.yaml
+++ b/templates/recipes/triage-failing-tests-autofile.yaml
@@ -9,14 +9,20 @@
 # trust dial actually move.
 #
 # DEFAULT-OFF: the Test Guardian Worker ships pointing at the base
-# `triage-failing-tests` (draft-to-file only). To delegate issue-filing:
-#   1. point `recipe:` in templates/workers/test-guardian.worker.yaml at
+# `triage-failing-tests` (draft-to-file only), so nothing here runs until you
+# switch the worker to this recipe. To enable, IN THIS ORDER:
+#   1. enable the `worker.autonomy` feature flag FIRST — this is what GATES the
+#      github.create_issue step for human approval until the worker EARNS L4
+#      trust on the `issue` class (then it flows autonomously);
+#   2. point `recipe:` in templates/workers/test-guardian.worker.yaml at
 #      `triage-failing-tests-autofile`;
-#   2. set `trigger.vars.repo` below to your "owner/repo";
-#   3. enable the `worker.autonomy` feature flag.
-# With the flag on, the github.create_issue step is GATED for human approval on
-# every run until the worker EARNS L4 trust on the `issue` class — then it flows
-# autonomously. (Expect more approvals up front; the payoff comes after L4.)
+#   3. set `trigger.vars.repo` below to your "owner/repo".
+#
+# ⚠ ORDER MATTERS. With `worker.autonomy` OFF, steps 2+3 ALONE file a real issue
+# on EVERY failing test run with NO approval — an automated (on_test_run) flat
+# run is not gated unless the flag is on. The flag ADDS the gate; it is not what
+# enables filing. Enable the flag first so the very first filing is gated.
+# (Expect more approvals up front; the payoff — autonomous filing — comes after L4.)
 apiVersion: patchwork.sh/v1
 name: triage-failing-tests-autofile
 description: On a failing test run, write a triage note and FILE a GitHub issue (opt-in; gated by the worker trust ramp).

--- a/templates/recipes/triage-failing-tests-autofile.yaml
+++ b/templates/recipes/triage-failing-tests-autofile.yaml
@@ -1,0 +1,70 @@
+# yaml-language-server: $schema=https://patchwork.dev/schemas/recipe.v1.json
+#
+# OPT-IN variant of `triage-failing-tests` for the Test Guardian Worker.
+#
+# This is the "make it real" recipe: it does everything the base recipe does
+# (correlate the failure, write a triage note) AND files a GitHub issue — an
+# explicit, RISKY, owned action (`github.create_issue` → the `issue` action
+# class: compensable + brand-exposed). It is the action that lets the worker's
+# trust dial actually move.
+#
+# DEFAULT-OFF: the Test Guardian Worker ships pointing at the base
+# `triage-failing-tests` (draft-to-file only). To delegate issue-filing:
+#   1. point `recipe:` in templates/workers/test-guardian.worker.yaml at
+#      `triage-failing-tests-autofile`;
+#   2. set `trigger.vars.repo` below to your "owner/repo";
+#   3. enable the `worker.autonomy` feature flag.
+# With the flag on, the github.create_issue step is GATED for human approval on
+# every run until the worker EARNS L4 trust on the `issue` class — then it flows
+# autonomously. (Expect more approvals up front; the payoff comes after L4.)
+apiVersion: patchwork.sh/v1
+name: triage-failing-tests-autofile
+description: On a failing test run, write a triage note and FILE a GitHub issue (opt-in; gated by the worker trust ramp).
+trigger:
+  type: on_test_run
+  filter: failure
+  vars:
+    # REQUIRED to enable — the repository the issue is filed against.
+    - name: repo
+      default: ""
+      description: "owner/repo the issue is filed against (set this to enable)"
+steps:
+  - tool: git.log_since
+    since: 12h
+    into: recent
+  - agent:
+      prompt: |
+        Tests just failed. Runner: {{runner}}. Failed {{failed}} / {{total}}.
+
+        Failures:
+        {{failures}}
+
+        Recent commits (last 12h) that may be responsible:
+        {{recent}}
+
+        Write a triage note (≤5 sentences): (1) which test(s) failed, (2) the
+        single most likely cause, (3) the suspect commit if any, (4) the first
+        command to run to confirm.
+      driver: claude-code
+      into: triage
+  - tool: file.write
+    path: ~/.patchwork/inbox/test-triage-{{date}}-{{time}}.md
+    content: |
+      # Test triage — {{date}} {{time}}
+
+      Runner {{runner}} · failed {{failed}}/{{total}}
+
+      {{triage}}
+  # The risky owned action. Runs AFTER the draft is written, so a gate
+  # rejection (or a missing `repo`) never loses the triage note.
+  - tool: github.create_issue
+    repo: "{{repo}}"
+    title: "Test triage {{date}}: {{runner}} failing {{failed}}/{{total}}"
+    body: |
+      {{triage}}
+
+      ---
+      _Filed by the Test Guardian Worker from a failing {{runner}} run._
+    labels:
+      - test-failure
+    into: filed_issue


### PR DESCRIPTION
## Why

The worker trust ramp (#1022–#1028) is built but **inert**: the three dogfood workers do only reversible work, and the one risky action a worker *owns* (test-guardian owns the `issue` action-class) had **no recipe tool** — GitHub's recipe tools are read-only and the github connector had no `createIssue`. So no worker could take a risky owned action to earn trust on. This is the GitHub-native enabler for the "make it real" step.

## What

- **`connectors/github.ts` — `createIssue(opts)`**: a WRITE, never cached, via the same MCP `create_issue` tool path as `listIssues` (works headless; no `gh` CLI dependency).
- **`recipes/tools/github.ts` — `github.create_issue`**: recipe tool (required `repo`+`title`; optional `body`/`labels`/`assignees`), `outputSchema {number,url,title,error}`, `isWrite:true`, `riskDefault:high` → kill-switch + approval + write-policy gated.
- **`workers/actionClass.ts`**: map `github.create_issue` → `issue` (compensable + brand-exposed), so test-guardian owns it and **can graduate to L4** (compensable ⇒ reachable `[0,1,2,3,4]`).
- **`templates/recipes/triage-failing-tests-autofile.yaml`**: opt-in variant of `triage-failing-tests` that adds the issue-filing step *after* the draft (so a gate rejection never loses the triage note).

## Default-off, and why a variant

The worker still ships pointing at the **base** (draft-only) recipe. Enabling the delegation is a deliberate three-switch act: point the worker at this recipe → set `trigger.vars.repo` → turn on the `worker.autonomy` flag. Then the `github.create_issue` step gates for approval on every run until the worker **earns L4** on `issue`, then flows autonomously.

A separate recipe (rather than a `when:`-guarded step on the base) is the *only* true default-off path here: `when:` is chained-runner-only, and a triggered recipe (`trigger.type: on_test_run`) always runs on the flat runner — a guard on it would be silently ignored and the step would fire every run.

> Note: this front-loads oversight (every failure → a gated issue) until the worker earns L4; the ROI (autonomous filing, fewer approvals) arrives after graduation. That's the ramp working as designed.

## Tests / gates

`github-create-issue` tool (success / labels / failure→`{error}` / write-tier), actionClass mapping (issue / compensable / brand-exposed / reachable L4). Variant recipe validates clean (0 errors/warnings). `tsc` + `tsc -p tsconfig.tests.core.json` + biome + `audit-lsp-tools` + `audit-test-fixtures` green; 1337 tests pass across connectors/tools/workers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)