### PR TITLE
fix(connectors): github create_issue → issue_write (hosted MCP server tool rename)

### DIFF
--- a/src/connectors/__tests__/github.test.ts
+++ b/src/connectors/__tests__/github.test.ts
@@ -548,15 +548,15 @@ describe("createIssue (WRITE)", () => {
     callTool.mockRestore();
   });
 
-  it("calls create_issue with owner/repo/title/body/labels/assignees and returns the issue", async () => {
+  it("calls issue_write (method:create) with owner/repo/title/body/labels/assignees and returns the issue", async () => {
     mockConnected();
     const callTool = vi
       .spyOn(McpClient.prototype, "callTool")
+      // issue_write returns `{ id, url }` — NOT the old `{ number, html_url, title }`.
       .mockResolvedValue(
         mcpJsonResult({
-          number: 42,
-          html_url: "https://github.com/acme/widget/issues/42",
-          title: "Flaky test",
+          id: "4767853687",
+          url: "https://github.com/acme/widget/issues/42",
         }),
       );
     const issue = await createIssue({
@@ -566,9 +566,13 @@ describe("createIssue (WRITE)", () => {
       labels: ["bug"],
       assignees: ["octocat"],
     });
+    // Regression: GitHub's hosted MCP server renamed create_issue → issue_write
+    // (keyed by a `method` enum). Calling the old name returns -32602
+    // "unknown tool". Surfaced live by the Test Guardian worker dogfood.
     expect(callTool).toHaveBeenCalledWith(
-      "create_issue",
+      "issue_write",
       expect.objectContaining({
+        method: "create",
         owner: "acme",
         repo: "widget",
         title: "Flaky test",
@@ -578,6 +582,7 @@ describe("createIssue (WRITE)", () => {
       }),
       expect.any(Object),
     );
+    // The issue number is derived from the URL (issue_write doesn't echo it).
     expect(issue).toEqual({
       number: 42,
       url: "https://github.com/acme/widget/issues/42",
@@ -585,13 +590,63 @@ describe("createIssue (WRITE)", () => {
     });
   });
 
-  it("throws when the MCP response has no issue number (no fabricated success)", async () => {
+  it("never calls the legacy create_issue tool name (regression guard)", async () => {
+    mockConnected();
+    const callTool = vi
+      .spyOn(McpClient.prototype, "callTool")
+      .mockResolvedValue(
+        mcpJsonResult({ id: "1", url: "https://github.com/a/b/issues/9" }),
+      );
+    await createIssue({ repo: "a/b", title: "t" });
+    expect(callTool.mock.calls[0]?.[0]).toBe("issue_write");
+    expect(callTool.mock.calls[0]?.[0]).not.toBe("create_issue");
+  });
+
+  it("throws when issue_write returns no parseable issue URL (no fabricated success)", async () => {
+    mockConnected();
+    // A non-issue URL (e.g. a pulls URL) must not be mistaken for a created issue.
+    vi.spyOn(McpClient.prototype, "callTool").mockResolvedValue(
+      mcpJsonResult({
+        id: "123",
+        url: "https://github.com/acme/widget/pulls/5",
+      }),
+    );
+    await expect(
+      createIssue({ repo: "acme/widget", title: "t" }),
+    ).rejects.toThrow(/no parseable issue URL/);
+  });
+
+  it("throws when issue_write returns no url at all (no fabricated success)", async () => {
     mockConnected();
     vi.spyOn(McpClient.prototype, "callTool").mockResolvedValue(
       mcpJsonResult({ message: "ok but not an issue" }),
     );
     await expect(
       createIssue({ repo: "acme/widget", title: "t" }),
-    ).rejects.toThrow(/no issue number/);
+    ).rejects.toThrow(/no parseable issue URL/);
+  });
+
+  it("propagates an MCP -32602 unknown-tool error (the regression this fix exists for)", async () => {
+    mockConnected();
+    // Before the fix, the connector called the renamed `create_issue` and got
+    // this back; the recipe-tool wrapper must see a thrown error, not a success.
+    vi.spyOn(McpClient.prototype, "callTool").mockRejectedValue(
+      new Error('tools/call create_issue: unknown tool "create_issue"'),
+    );
+    await expect(
+      createIssue({ repo: "acme/widget", title: "t" }),
+    ).rejects.toThrow(/unknown tool/);
+  });
+
+  it("takes the last /issues/<n> segment from a multi-segment URL", async () => {
+    mockConnected();
+    vi.spyOn(McpClient.prototype, "callTool").mockResolvedValue(
+      mcpJsonResult({
+        id: "9",
+        url: "https://github.com/acme/issues/111/x/acme/widget/issues/42",
+      }),
+    );
+    const issue = await createIssue({ repo: "acme/widget", title: "t" });
+    expect(issue.number).toBe(42);
   });
 });

--- a/src/connectors/github.ts
+++ b/src/connectors/github.ts
@@ -204,7 +204,8 @@ export interface CreatedGitHubIssue {
 }
 
 /**
- * Create a GitHub issue via the connector's MCP `create_issue` tool. A WRITE —
+ * Create a GitHub issue via the hosted MCP server's `issue_write` tool
+ * (method: "create"). A WRITE —
  * never cached. Mirrors listIssues' auth/client/parse path so it works headless
  * (no `gh` CLI dependency). Throws on a missing connector / bad input / MCP
  * error so the recipe-tool wrapper can surface a `{error}` step result.
@@ -223,26 +224,51 @@ export async function createIssue(
   const parts = opts.repo.split("/");
   if (parts.length !== 2 || !parts[0]?.trim() || !parts[1]?.trim())
     throw new Error(
-      "github create_issue requires `repo` in exact 'owner/repo' format",
+      "github issue creation requires `repo` in exact 'owner/repo' format",
     );
   const [owner, repo] = parts.map((s) => s.trim());
   if (!opts.title?.trim())
-    throw new Error("github create_issue requires a non-empty title");
-  const args: Record<string, unknown> = { owner, repo, title: opts.title };
+    throw new Error("github issue creation requires a non-empty title");
+  // GitHub's hosted MCP server (api.githubcopilot.com/mcp) consolidated the old
+  // `create_issue` tool into a unified `issue_write` tool keyed by a `method`
+  // enum ("create" | "update"); the legacy `create_issue` name now returns
+  // -32602 "unknown tool". Surfaced live 2026-06-29 by the Test Guardian worker
+  // dogfood (the read tools list_issues/list_commits were unaffected).
+  const args: Record<string, unknown> = {
+    method: "create",
+    owner,
+    repo,
+    title: opts.title,
+  };
   if (opts.body) args.body = opts.body;
   if (opts.labels?.length) args.labels = opts.labels;
   if (opts.assignees?.length) args.assignees = opts.assignees;
-  const res = await client().callTool("create_issue", args, { signal });
-  const raw = McpClient.extractJson<RawIssue>(res);
-  // Defensive (brand-exposed write): a non-issue 200 payload must not fabricate
-  // a success. Review #1029 LOW.
-  if (typeof raw?.number !== "number")
-    throw new Error("github create_issue: MCP returned no issue number");
-  return {
-    number: raw.number,
-    url: raw.html_url ?? raw.url ?? "",
-    title: raw.title ?? opts.title,
-  };
+  const res = await client().callTool("issue_write", args, { signal });
+  // issue_write returns `{ id: "<node-id>", url: ".../issues/<n>" }` — NOT the
+  // old `{ number, html_url, title }` shape. Derive the issue number from the
+  // URL; the title isn't echoed back, so fall back to the requested one.
+  // (Verified live 2026-06-29 against api.githubcopilot.com/mcp.)
+  // extractJson throws on a missing / non-JSON text block; swallow that so the
+  // deliberate guard below always produces the friendly message (the read tools
+  // wrap callTool the same way) rather than leaking a raw parse error.
+  let url = "";
+  try {
+    const raw = McpClient.extractJson<{ id?: string; url?: string }>(res);
+    if (typeof raw?.url === "string") url = raw.url;
+  } catch {
+    /* fall through to the no-parseable-url guard */
+  }
+  // Take the LAST `/issues/<n>` segment (the canonical issue URL ends in it) so
+  // an unrelated earlier one in a malformed payload can't yield a wrong number.
+  const matches = [...url.matchAll(/\/issues\/(\d+)(?:[/?#]|$)/g)];
+  const number = matches.length
+    ? Number(matches[matches.length - 1]?.[1])
+    : Number.NaN;
+  // Defensive (brand-exposed write): a 200 without a parseable, positive,
+  // safe-integer issue URL must not fabricate a success. Review #1029 LOW.
+  if (!Number.isSafeInteger(number) || number <= 0)
+    throw new Error("github issue_write: MCP returned no parseable issue URL");
+  return { number, url, title: opts.title };
 }
 
 interface RawPR extends RawIssue {


### PR DESCRIPTION
## What

GitHub's **hosted** MCP server (`api.githubcopilot.com/mcp`) consolidated the `create_issue` tool into a unified **`issue_write`** tool keyed by a `method` enum (`create` | `update`), and reshaped its response from `{ number, html_url, title }` to **`{ id, url }`**. The legacy `create_issue` name now returns `-32602 "unknown tool"`, so **every `github.create_issue` recipe-tool call fails** before this fix.

## How it was found

Live, by the **Test Guardian worker dogfood** — the first real end-to-end run of the worker-autonomy ramp against a genuine external side-effect. The gate engaged, a human approved, and the filing *still* failed — first with `-32602 unknown tool`, then (after the rename fix) with `MCP returned no issue number` once the response shape mismatch surfaced. A clean, gated, human-approved filing only worked after this fix. Pure unit tests could never have caught it — it only shows up against the live hosted server.

## The fix (`src/connectors/github.ts` `createIssue`)

- Call **`issue_write`** with `method: "create"` (owner/repo were already split correctly).
- Derive the issue number from the response **URL** (last `/issues/<n>` segment); the title isn't echoed back, so fall back to the requested title.
- **Fail closed** on a malformed / non-issue / unsafe URL — no fabricated success — including the non-JSON / no-text-content `extractJson` throw paths (wrapped in try/catch so the deliberate guard message always wins, mirroring the read tools).

## Tests

Updated the `createIssue (WRITE)` block to pin the **new** contract: tool name `issue_write` + `method: "create"`, URL-derived number, last-`/issues/<n>` selection, `-32602` unknown-tool propagation, and the no-fabricated-success guards (non-issue URL, no URL). 44/44 in the connector suite.

Gates: `tsc -p tsconfig.json` · `tsc -p tsconfig.tests.core.json` · `biome` · `audit-lsp-tools.mjs` — all green. Reviewed via a 3-dimension adversarial workflow (correctness / blast-radius / test-quality, 19 agents); 14 confirmed findings, **all LOW**, the worthwhile ones folded in (parse hardening, last-segment match, `isSafeInteger`, stale-reference cleanup, the missing -32602 test).

## ⚠️ Known follow-up — the READ tools are also reshaped (out of scope here)

While verifying, I confirmed live that the same server reshape broke the read paths too — but **inconsistently per tool**, and I couldn't fully verify populated shapes against the near-empty test repo, so they need a dedicated PR with proper fixtures:

- **`listIssues`** (`list_issues`): response is now an **`{ issues, totalCount, pageInfo }`** envelope — the connector only unwraps bare-array or `{ items }`, so it **silently returns `[]`** (the exact silent-empty failure mode PR #72 was built to prevent). Items also **no longer carry `html_url`**, so `coerceIssue`'s `url` would be empty.
- **`listCommits`** (`list_commits`): bare array with a **nested `commit`** object — likely needs a shape update.
- **`listPRs`** (`list_pull_requests`): came back empty in the test repo; populated shape unverified.

These do not affect the worker dogfood (the triage recipe uses `git.log_since`, not `github.list_*`), but `listIssues` silently returning "no issues" is a real correctness risk for any recipe that reads issues. Recommend a follow-up that verifies each tool against a repo with real issues/PRs/commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)