### PR TITLE
feat(approvals): considered-approval KPI — is delegated trust earned or rubber-stamped?

### DIFF
--- a/dashboard/src/app/workers/__tests__/page.test.tsx
+++ b/dashboard/src/app/workers/__tests__/page.test.tsx
@@ -52,9 +52,24 @@ const SHADOW = {
   ],
 };
 
+// The page fetches BOTH /workers/shadow and /approvals/kpi (KPI panel). A fresh
+// Response per call is required — a single mockResolvedValue Response can only
+// have its body read once, so the second fetch would get an empty/consumed body.
+function routeMock(
+  shadow: unknown,
+  kpi: unknown = { total: 0 },
+): (url: string | URL) => Promise<Response> {
+  return (url) =>
+    Promise.resolve(
+      String(url).includes("/approvals/kpi")
+        ? jsonResponse(kpi)
+        : jsonResponse(shadow),
+    );
+}
+
 describe("WorkersPage", () => {
   it("renders the trust dial + a ramp-vs-gate divergence from the shadow endpoint", async () => {
-    fetchMock.mockResolvedValue(jsonResponse(SHADOW));
+    fetchMock.mockImplementation(routeMock(SHADOW));
     const { container } = render(<WorkersPage />);
     expect(await screen.findByText("Release Worker")).toBeTruthy();
     // the divergence text is split across nodes (⚠ {tool} — {note}); assert on
@@ -64,10 +79,40 @@ describe("WorkersPage", () => {
   });
 
   it("shows the empty state when no workers are configured", async () => {
-    fetchMock.mockResolvedValue(
-      jsonResponse({ workers: [], runsScanned: 0, decisionsScanned: 0 }),
+    fetchMock.mockImplementation(
+      routeMock({ workers: [], runsScanned: 0, decisionsScanned: 0 }),
     );
     render(<WorkersPage />);
     expect(await screen.findByText(/No workers yet/)).toBeTruthy();
+  });
+
+  it("renders the considered-approval panel with the rubber-stamp warning", async () => {
+    fetchMock.mockImplementation(
+      routeMock(SHADOW, {
+        total: 8,
+        decided: 8,
+        approved: 8,
+        rejected: 0,
+        abandoned: 0,
+        rejectRate: 0,
+        latency: { count: 8, medianMs: 200, p90Ms: 400 },
+        channels: { dashboard: 5, phone: 3 },
+        byTool: [
+          {
+            toolName: "github.create_issue",
+            decided: 8,
+            rejected: 0,
+            rejectRate: 0,
+            latency: { count: 8, medianMs: 200, p90Ms: 400 },
+            channels: { dashboard: 5, phone: 3 },
+          },
+        ],
+      }),
+    );
+    const { container } = render(<WorkersPage />);
+    expect(await screen.findByText(/Considered approvals/)).toBeTruthy();
+    expect(container.textContent).toContain("reject rate 0%");
+    // 8 decided, 0 rejected → the rubber-stamp warning must fire
+    expect(container.textContent).toMatch(/rubber-stamps/);
   });
 });

--- a/dashboard/src/app/workers/page.tsx
+++ b/dashboard/src/app/workers/page.tsx
@@ -33,6 +33,31 @@ interface ShadowResponse {
   generatedAt?: string;
 }
 
+interface LatencyStats {
+  count: number;
+  medianMs: number;
+  p90Ms: number;
+}
+interface ToolKpi {
+  toolName: string;
+  decided: number;
+  rejected: number;
+  rejectRate: number;
+  latency: LatencyStats | null;
+  channels: Record<string, number>;
+}
+interface KpiResponse {
+  total: number;
+  decided: number;
+  approved: number;
+  rejected: number;
+  abandoned: number;
+  rejectRate: number;
+  latency: LatencyStats | null;
+  channels: Record<string, number>;
+  byTool: ToolKpi[];
+}
+
 const LEVEL_LABELS = [
   "L0 suggest",
   "L1 approve-each",
@@ -40,6 +65,79 @@ const LEVEL_LABELS = [
   "L3 act+sample",
   "L4 autonomous",
 ];
+
+function fmtMs(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  if (ms < 60000) return `${(ms / 1000).toFixed(1)}s`;
+  return `${(ms / 60000).toFixed(1)}m`;
+}
+const fmtLat = (l: LatencyStats | null): string =>
+  l ? `${fmtMs(l.medianMs)} med · ${fmtMs(l.p90Ms)} p90` : "—";
+const channelStr = (c: Record<string, number>): string =>
+  Object.entries(c)
+    .sort((a, b) => b[1] - a[1])
+    .map(([k, v]) => `${k} ${v}`)
+    .join(" · ");
+
+/**
+ * Considered-approval KPI — the honesty lens beside the dial. The dial says how
+ * high trust climbed; this says whether the approvals behind it were considered.
+ * A 0% reject rate over a real sample is the clearest tell of a rubber-stamp.
+ */
+function ConsideredApprovalPanel() {
+  const { data } = useBridgeFetch<KpiResponse>("/api/bridge/approvals/kpi", {
+    intervalMs: 30000,
+  });
+  if (!data || data.total === 0) return null;
+  const rubberStamp = data.decided >= 5 && data.rejectRate === 0;
+  return (
+    <div className="card" style={{ marginTop: "var(--s-4)" }}>
+      <div className="card-head">
+        <strong>
+          Considered approvals — <span className="accent">is it earned?</span>
+        </strong>
+        <span className="pill muted">{data.decided} decided</span>
+      </div>
+      <div style={{ display: "flex", gap: "var(--s-4)", flexWrap: "wrap" }}>
+        <span
+          className="pill"
+          style={{
+            background: rubberStamp ? "var(--warn)" : "var(--surface-2)",
+            color: rubberStamp ? "var(--bg)" : "inherit",
+          }}
+        >
+          reject rate {Math.round(data.rejectRate * 100)}%
+        </span>
+        <span className="pill muted">latency {fmtLat(data.latency)}</span>
+        {data.abandoned > 0 && (
+          <span className="pill muted">{data.abandoned} abandoned</span>
+        )}
+        <span className="pill muted">{channelStr(data.channels)}</span>
+      </div>
+      {rubberStamp && (
+        <div
+          className="editorial-sub"
+          style={{ fontFamily: "inherit", color: "var(--warn)" }}
+        >
+          ⚠ Every one of {data.decided} prompts approved with no rejections — the
+          dial may be climbing on rubber-stamps, not earned trust.
+        </div>
+      )}
+      {data.latency === null && (
+        <div className="editorial-sub" style={{ fontFamily: "inherit" }}>
+          Latency captures from the next decision forward (it can't be backfilled).
+        </div>
+      )}
+      {data.byTool.map((t) => (
+        <div className="suggestion-row" key={t.toolName}>
+          {t.toolName} — decided {t.decided} · reject{" "}
+          {Math.round(t.rejectRate * 100)}% · {fmtLat(t.latency)} ·{" "}
+          {channelStr(t.channels)}
+        </div>
+      ))}
+    </div>
+  );
+}
 
 function levelColor(effective: number): string {
   if (effective >= 4) return "var(--ok)";
@@ -72,6 +170,8 @@ export default function WorkersPage() {
           </span>
         )}
       </div>
+
+      <ConsideredApprovalPanel />
 
       {loading && workers.length === 0 && <SkeletonList rows={3} columns={2} />}
 

--- a/dashboard/src/app/workers/page.tsx
+++ b/dashboard/src/app/workers/page.tsx
@@ -128,7 +128,8 @@ function ConsideredApprovalPanel() {
       )}
       {data.latency === null && (
         <div className="editorial-sub" style={{ fontFamily: "inherit" }}>
-          Latency captures from the next decision forward (it can't be backfilled).
+          Latency captures from the next decision forward (it cannot be
+          backfilled).
         </div>
       )}
       {data.byTool.map((t) => (

--- a/dashboard/src/app/workers/page.tsx
+++ b/dashboard/src/app/workers/page.tsx
@@ -73,8 +73,8 @@ function fmtMs(ms: number): string {
 }
 const fmtLat = (l: LatencyStats | null): string =>
   l ? `${fmtMs(l.medianMs)} med · ${fmtMs(l.p90Ms)} p90` : "—";
-const channelStr = (c: Record<string, number>): string =>
-  Object.entries(c)
+const channelStr = (c: Record<string, number> | undefined): string =>
+  Object.entries(c ?? {})
     .sort((a, b) => b[1] - a[1])
     .map(([k, v]) => `${k} ${v}`)
     .join(" · ");
@@ -88,7 +88,10 @@ function ConsideredApprovalPanel() {
   const { data } = useBridgeFetch<KpiResponse>("/api/bridge/approvals/kpi", {
     intervalMs: 30000,
   });
-  if (!data || data.total === 0) return null;
+  // Render only with real KPI data: `!data.total` catches both the empty case
+  // (total 0) and a non-KPI/error payload (total undefined), so the panel never
+  // crashes on an unexpected shape.
+  if (!data || !data.total) return null;
   const rubberStamp = data.decided >= 5 && data.rejectRate === 0;
   return (
     <div className="card" style={{ marginTop: "var(--s-4)" }}>

--- a/src/__tests__/approvalHttp.test.ts
+++ b/src/__tests__/approvalHttp.test.ts
@@ -151,6 +151,9 @@ describe("routeApprovalRequest", () => {
       event: "approval_decision",
       meta: { callId, decision: "allow" },
     });
+    // The considered-approval KPI derives latency from this; it must ride the
+    // emit (read from the queue entry before approve() removes it).
+    expect(typeof events[0]?.meta.requestedAt).toBe("number");
   });
 
   it("POST /approve on truly-unknown callId → 404 (not 409)", async () => {

--- a/src/__tests__/approvalKpi.test.ts
+++ b/src/__tests__/approvalKpi.test.ts
@@ -1,0 +1,276 @@
+/**
+ * Considered-approval KPI aggregator — the lens that separates judgement from
+ * rubber-stamping. Tests the read (human decisions only, outcome classification,
+ * latency field) and the aggregation (reject rate over DECIDED, abandoned kept
+ * separate from rejections, latency/channel/per-day rollups).
+ */
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  computeConsideredApprovalKpi,
+  readConsideredDecisions,
+} from "../approvalKpi.js";
+
+let ideDir: string;
+
+/** Build one ActivityLog `approval_decision` line. */
+function decisionLine(o: {
+  ts: string;
+  toolName: string;
+  decision: "allow" | "deny";
+  reason: string;
+  requestedAt?: number;
+  channel?: string;
+  tier?: string;
+}): string {
+  return JSON.stringify({
+    event: "approval_decision",
+    timestamp: o.ts,
+    metadata: {
+      toolName: o.toolName,
+      decision: o.decision,
+      reason: o.reason,
+      ...(o.requestedAt !== undefined && { requestedAt: o.requestedAt }),
+      ...(o.channel !== undefined && { channel: o.channel }),
+      ...(o.tier !== undefined && { tier: o.tier }),
+    },
+  });
+}
+
+beforeEach(() => {
+  ideDir = mkdtempSync(path.join(os.tmpdir(), "kpi-ide-"));
+  mkdirSync(ideDir, { recursive: true });
+});
+afterEach(() => rmSync(ideDir, { recursive: true, force: true }));
+
+describe("readConsideredDecisions", () => {
+  it("keeps human-deliberated decisions and drops instant-policy emits", () => {
+    const t0 = Date.parse("2026-06-29T10:00:00.000Z");
+    writeFileSync(
+      path.join(ideDir, "activity-1.jsonl"),
+      [
+        // human approve via dashboard, 12s deliberation
+        decisionLine({
+          ts: "2026-06-29T10:00:12.000Z",
+          toolName: "github.create_issue",
+          decision: "allow",
+          reason: "approved",
+          requestedAt: t0,
+          channel: "dashboard",
+        }),
+        // human reject via phone, 40s
+        decisionLine({
+          ts: "2026-06-29T10:00:40.000Z",
+          toolName: "github.create_issue",
+          decision: "deny",
+          reason: "rejected",
+          requestedAt: t0,
+          channel: "phone",
+        }),
+        // expired prompt → abandoned, NOT a rejection. Abandonment happens
+        // server-side on the CC-hook path (no channel — you can't *click* an
+        // expired prompt), so this row carries no channel.
+        decisionLine({
+          ts: "2026-06-29T10:05:00.000Z",
+          toolName: "github.create_issue",
+          decision: "deny",
+          reason: "expired",
+          requestedAt: t0,
+        }),
+        // instant policy — must be excluded (no human)
+        decisionLine({
+          ts: "2026-06-29T10:06:00.000Z",
+          toolName: "getGitStatus",
+          decision: "allow",
+          reason: "gate_below_threshold",
+        }),
+        decisionLine({
+          ts: "2026-06-29T10:07:00.000Z",
+          toolName: "readFile",
+          decision: "allow",
+          reason: "gate_off",
+        }),
+        // legacy human row (no requestedAt) — kept, but no latency
+        decisionLine({
+          ts: "2026-06-28T09:00:00.000Z",
+          toolName: "gitPush",
+          decision: "allow",
+          reason: "approved",
+          channel: "dashboard",
+        }),
+        "",
+        "not-json",
+      ].join("\n"),
+    );
+    const decisions = readConsideredDecisions({ ideDir });
+    // 3 issue decisions + 1 legacy gitPush; the 2 instant-policy excluded
+    expect(decisions).toHaveLength(4);
+    expect(decisions.every((d) => d.toolName !== "getGitStatus")).toBe(true);
+    expect(decisions.every((d) => d.toolName !== "readFile")).toBe(true);
+    // chronological
+    expect(decisions[0]?.toolName).toBe("gitPush"); // 06-28 first
+    // outcome classification: expired → abandoned, not rejected
+    const expired = decisions.find((d) => d.outcome === "abandoned");
+    expect(expired).toBeDefined();
+    expect(expired?.toolName).toBe("github.create_issue");
+  });
+
+  it("respects the sinceMs window", () => {
+    writeFileSync(
+      path.join(ideDir, "activity-1.jsonl"),
+      [
+        decisionLine({
+          ts: "2026-06-20T10:00:00.000Z",
+          toolName: "gitPush",
+          decision: "allow",
+          reason: "approved",
+        }),
+        decisionLine({
+          ts: "2026-06-29T10:00:00.000Z",
+          toolName: "gitPush",
+          decision: "allow",
+          reason: "approved",
+        }),
+      ].join("\n"),
+    );
+    const recent = readConsideredDecisions({
+      ideDir,
+      sinceMs: Date.parse("2026-06-25T00:00:00.000Z"),
+    });
+    expect(recent).toHaveLength(1);
+    expect(recent[0]?.decidedAt).toBe(Date.parse("2026-06-29T10:00:00.000Z"));
+  });
+
+  it("captures worker-gate approvals (dashboard/phone channel, no reason)", () => {
+    // The path that actually matters: worker-gate approvals land on
+    // POST /approve|reject, which sets `channel` but no outcome `reason`. The
+    // earlier filter (reason/requestedAt only) silently dropped these.
+    const t0 = Date.parse("2026-06-29T11:00:00.000Z");
+    writeFileSync(
+      path.join(ideDir, "activity-2.jsonl"),
+      [
+        // dashboard approve — channel set, no reason, no requestedAt (legacy)
+        decisionLine({
+          ts: "2026-06-29T11:00:08.000Z",
+          toolName: "github.create_issue",
+          decision: "allow",
+          reason: "",
+          channel: "dashboard",
+        }),
+        // phone approve WITH requestedAt (post-instrumentation) → 20s latency
+        decisionLine({
+          ts: "2026-06-29T11:01:20.000Z",
+          toolName: "github.create_issue",
+          decision: "allow",
+          reason: "",
+          requestedAt: t0 + 60_000,
+          channel: "phone",
+        }),
+        // dashboard REJECT with free-form reason text — must NOT be read as
+        // "abandoned" just because reason text exists.
+        decisionLine({
+          ts: "2026-06-29T11:02:00.000Z",
+          toolName: "github.create_issue",
+          decision: "deny",
+          reason: "flaky test, not a real bug",
+          channel: "dashboard",
+        }),
+      ].join("\n"),
+    );
+    const ds = readConsideredDecisions({ ideDir });
+    expect(ds).toHaveLength(3);
+    expect(ds.filter((d) => d.outcome === "approved")).toHaveLength(2);
+    const rej = ds.find((d) => d.outcome === "rejected");
+    expect(rej?.channel).toBe("dashboard");
+    expect(ds.some((d) => d.outcome === "abandoned")).toBe(false);
+    const kpi = computeConsideredApprovalKpi(ds);
+    expect(kpi.rejectRate).toBeCloseTo(1 / 3);
+    expect(kpi.latency?.count).toBe(1); // only the requestedAt row
+    expect(kpi.channels).toEqual({ dashboard: 2, phone: 1 });
+  });
+
+  it("returns [] for a missing ide dir (fail-soft)", () => {
+    expect(readConsideredDecisions({ ideDir: "/no/such/dir" })).toEqual([]);
+  });
+});
+
+describe("computeConsideredApprovalKpi", () => {
+  it("computes reject rate over DECIDED (abandoned excluded from the denominator)", () => {
+    const base = Date.parse("2026-06-29T10:00:00.000Z");
+    const decisions = [
+      { outcome: "approved", channel: "dashboard", decidedAt: base + 1000 },
+      { outcome: "approved", channel: "phone", decidedAt: base + 2000 },
+      { outcome: "rejected", channel: "dashboard", decidedAt: base + 3000 },
+      { outcome: "abandoned", channel: "unknown", decidedAt: base + 4000 },
+    ].map((d) => ({ toolName: "github.create_issue", ...d })) as never;
+    const kpi = computeConsideredApprovalKpi(decisions);
+    expect(kpi.total).toBe(4);
+    expect(kpi.decided).toBe(3); // abandoned excluded
+    expect(kpi.approved).toBe(2);
+    expect(kpi.rejected).toBe(1);
+    expect(kpi.abandoned).toBe(1);
+    expect(kpi.rejectRate).toBeCloseTo(1 / 3); // 1 reject / 3 decided, not /4
+  });
+
+  it("derives latency stats only from rows carrying requestedAt", () => {
+    const base = Date.parse("2026-06-29T10:00:00.000Z");
+    const decisions = [
+      // 10s and 30s deliberations
+      {
+        toolName: "github.create_issue",
+        outcome: "approved",
+        channel: "phone",
+        decidedAt: base + 10_000,
+        requestedAt: base,
+      },
+      {
+        toolName: "github.create_issue",
+        outcome: "rejected",
+        channel: "dashboard",
+        decidedAt: base + 30_000,
+        requestedAt: base,
+      },
+      // legacy row — no requestedAt → excluded from latency
+      {
+        toolName: "github.create_issue",
+        outcome: "approved",
+        channel: "dashboard",
+        decidedAt: base + 99_000,
+      },
+    ] as never;
+    const kpi = computeConsideredApprovalKpi(decisions);
+    expect(kpi.latency?.count).toBe(2); // legacy row excluded
+    expect(kpi.latency?.medianMs).toBe(30_000);
+    expect(kpi.channels).toEqual({ phone: 1, dashboard: 2 });
+    expect(kpi.byTool[0]?.toolName).toBe("github.create_issue");
+  });
+
+  it("rubber-stamp signature: 100% approve, near-zero latency", () => {
+    const base = Date.parse("2026-06-29T10:00:00.000Z");
+    const decisions = Array.from({ length: 8 }, (_, i) => ({
+      toolName: "github.create_issue",
+      outcome: "approved" as const,
+      channel: "phone",
+      decidedAt: base + i * 1000 + 200,
+      requestedAt: base + i * 1000, // 200ms taps
+    })) as never;
+    const kpi = computeConsideredApprovalKpi(decisions);
+    expect(kpi.rejectRate).toBe(0); // never said no
+    expect(kpi.latency?.medianMs).toBeLessThan(1000); // reflexive
+  });
+
+  it("empty input → zeroed report", () => {
+    const kpi = computeConsideredApprovalKpi([]);
+    expect(kpi).toMatchObject({
+      total: 0,
+      decided: 0,
+      rejectRate: 0,
+      latency: null,
+      byTool: [],
+      perDay: [],
+    });
+  });
+});

--- a/src/__tests__/approvalKpi.test.ts
+++ b/src/__tests__/approvalKpi.test.ts
@@ -25,6 +25,7 @@ function decisionLine(o: {
   requestedAt?: number;
   channel?: string;
   tier?: string;
+  callId?: string;
 }): string {
   return JSON.stringify({
     event: "approval_decision",
@@ -36,6 +37,7 @@ function decisionLine(o: {
       ...(o.requestedAt !== undefined && { requestedAt: o.requestedAt }),
       ...(o.channel !== undefined && { channel: o.channel }),
       ...(o.tier !== undefined && { tier: o.tier }),
+      ...(o.callId !== undefined && { callId: o.callId }),
     },
   });
 }
@@ -192,6 +194,42 @@ describe("readConsideredDecisions", () => {
     expect(kpi.channels).toEqual({ dashboard: 2, phone: 1 });
   });
 
+  it("dedups the two rows a single human decision emits (callId), keeping the channel'd one", () => {
+    // Production reality (the HIGH the review caught): a CC-hook approval
+    // resolved via the dashboard emits BOTH a POST row (channel'd, no reason)
+    // and the awaiting CC-hook row (no channel, reason'd) — same callId, same
+    // outcome. Counting both ~2x-inflates and injects a phantom "unknown".
+    const t0 = Date.parse("2026-06-29T12:00:00.000Z");
+    writeFileSync(
+      path.join(ideDir, "activity-3.jsonl"),
+      [
+        decisionLine({
+          ts: "2026-06-29T12:00:09.000Z",
+          toolName: "Bash",
+          decision: "allow",
+          reason: "",
+          requestedAt: t0,
+          channel: "dashboard",
+          callId: "abc-123",
+        }),
+        decisionLine({
+          ts: "2026-06-29T12:00:09.000Z",
+          toolName: "Bash",
+          decision: "allow",
+          reason: "approved",
+          requestedAt: t0,
+          callId: "abc-123", // same decision, CC-hook dup (no channel)
+        }),
+      ].join("\n"),
+    );
+    const ds = readConsideredDecisions({ ideDir });
+    expect(ds).toHaveLength(1); // collapsed, not 2
+    expect(ds[0]?.channel).toBe("dashboard"); // kept the channel'd row
+    const kpi = computeConsideredApprovalKpi(ds);
+    expect(kpi.decided).toBe(1);
+    expect(kpi.channels).toEqual({ dashboard: 1 }); // no phantom "unknown"
+  });
+
   it("returns [] for a missing ide dir (fail-soft)", () => {
     expect(readConsideredDecisions({ ideDir: "/no/such/dir" })).toEqual([]);
   });
@@ -243,7 +281,7 @@ describe("computeConsideredApprovalKpi", () => {
     ] as never;
     const kpi = computeConsideredApprovalKpi(decisions);
     expect(kpi.latency?.count).toBe(2); // legacy row excluded
-    expect(kpi.latency?.medianMs).toBe(30_000);
+    expect(kpi.latency?.medianMs).toBe(20_000); // interpolated median of [10s,30s]
     expect(kpi.channels).toEqual({ phone: 1, dashboard: 2 });
     expect(kpi.byTool[0]?.toolName).toBe("github.create_issue");
   });

--- a/src/approvalHttp.ts
+++ b/src/approvalHttp.ts
@@ -281,12 +281,15 @@ export async function routeApprovalRequest(
         };
       }
     }
-    // Capture the tool name BEFORE resolving (approve() removes the entry).
-    // L4: the worker shadow logger keys ramp-vs-gate attribution off `toolName`
-    // in the decision metadata — without it the comparison silently drops the row.
-    const approveToolName = deps.queue
-      .list?.()
-      .find((e) => e.callId === callId)?.toolName;
+    // Capture the entry BEFORE resolving (approve() removes it). `toolName`
+    // keys the worker shadow logger's ramp-vs-gate attribution; `requestedAt`
+    // is the prompt time the considered-approval KPI needs to derive
+    // latency-to-decision (this dashboard/phone path is where worker-gate
+    // approvals actually land — handleApprovalRequest is the separate CC-hook
+    // path).
+    const approveEntry = deps.queue.list?.().find((e) => e.callId === callId);
+    const approveToolName = approveEntry?.toolName;
+    const approveRequestedAt = approveEntry?.requestedAt;
     const ok = deps.queue.approve(callId);
     if (ok) {
       // Audit 2026-06-03 (MEDIUM #27): fire the audit hook on APPROVE too —
@@ -302,6 +305,9 @@ export async function routeApprovalRequest(
         // where", not just "who/what/when".
         channel: req.approvalToken !== undefined ? "phone" : "dashboard",
         ...(approveToolName !== undefined && { toolName: approveToolName }),
+        ...(approveRequestedAt !== undefined && {
+          requestedAt: approveRequestedAt,
+        }),
       });
       return { status: 200, body: { decision: "allow", callId } };
     }
@@ -376,10 +382,11 @@ export async function routeApprovalRequest(
       if (trimmed.length > 0) reason = trimmed;
     }
     // L4: capture toolName before reject() removes the entry (worker shadow
-    // attribution keys off it).
-    const rejectToolName = deps.queue
-      .list?.()
-      .find((e) => e.callId === callId)?.toolName;
+    // attribution keys off it); requestedAt feeds the considered-approval KPI's
+    // latency-to-decision.
+    const rejectEntry = deps.queue.list?.().find((e) => e.callId === callId);
+    const rejectToolName = rejectEntry?.toolName;
+    const rejectRequestedAt = rejectEntry?.requestedAt;
     const ok = deps.queue.reject(callId);
     if (ok) {
       deps.onDecision?.("approval_decision", {
@@ -389,6 +396,9 @@ export async function routeApprovalRequest(
         // Provenance: phone (single-use token) vs dashboard/Bearer caller.
         channel: req.approvalToken !== undefined ? "phone" : "dashboard",
         ...(rejectToolName !== undefined && { toolName: rejectToolName }),
+        ...(rejectRequestedAt !== undefined && {
+          requestedAt: rejectRequestedAt,
+        }),
       });
       return { status: 200, body: { decision: "deny", callId } };
     }
@@ -802,6 +812,13 @@ async function handleApprovalRequest(
     reason: string,
     extras?: {
       callId?: string;
+      // Epoch-ms the approval was PROMPTED (queued). Present only on the
+      // human-decision path (after a queue wait); absent on instant-policy
+      // emits (gate_off / cc_allow_rule / …) which have no deliberation
+      // latency. The considered-approval KPI derives latency-to-decision as
+      // `event.timestamp − requestedAt`; without it, latency is unrecoverable
+      // retroactively (the queue entry is gone by decision time).
+      requestedAt?: number;
     },
   ) =>
     deps.onDecision?.("approval_decision", {
@@ -821,6 +838,9 @@ async function handleApprovalRequest(
       ...(riskSignals.length > 0 && { riskSignals }),
       ...(summary !== undefined && { summary }),
       ...(extras?.callId && { callId: extras.callId }),
+      ...(extras?.requestedAt !== undefined && {
+        requestedAt: extras.requestedAt,
+      }),
     });
 
   // CC settings.json precedence
@@ -989,7 +1009,10 @@ async function handleApprovalRequest(
   if (outcome !== "expired") {
     recordApprovalCompleted();
   }
-  emit(outcome === "approved" ? "allow" : "deny", outcome, { callId });
+  emit(outcome === "approved" ? "allow" : "deny", outcome, {
+    callId,
+    requestedAt: now,
+  });
 
   // Publish a confirmation back to the same ntfy topic so the lock-screen
   // tap has visible feedback. The iOS ntfy app gives no UI signal when an

--- a/src/approvalKpi.ts
+++ b/src/approvalKpi.ts
@@ -259,3 +259,75 @@ export function computeConsideredApprovalKpi(
     perDay,
   };
 }
+
+// ── Terminal report ──────────────────────────────────────────────────────────
+
+function fmtMs(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`;
+  return `${(ms / 60_000).toFixed(1)}m`;
+}
+
+function fmtLatency(l: LatencyStats | null): string {
+  return l
+    ? `median ${fmtMs(l.medianMs)} · p90 ${fmtMs(l.p90Ms)} (n=${l.count})`
+    : "—";
+}
+
+/**
+ * Human-readable considered-approval report (CLI `patchwork approvals`). The
+ * rubber-stamp warning is the point: a 0% reject rate over a non-trivial sample
+ * is the single clearest tell that the trust climbing the dial isn't real.
+ */
+export function formatConsideredApprovalKpi(
+  kpi: ConsideredApprovalKpi,
+  opts: { windowLabel?: string } = {},
+): string {
+  const out: string[] = [];
+  out.push(
+    `Considered-approval KPI${opts.windowLabel ? ` — ${opts.windowLabel}` : ""}`,
+  );
+  out.push("");
+  if (kpi.total === 0) {
+    out.push(
+      "  (no human approval decisions in window — fills as the gate queues risky actions you approve/reject)",
+    );
+    return out.join("\n");
+  }
+  out.push(
+    `  decided ${kpi.decided} · approved ${kpi.approved} · rejected ${kpi.rejected} · abandoned ${kpi.abandoned}`,
+  );
+  const stamp =
+    kpi.decided >= 5 && kpi.rejectRate === 0
+      ? "   ⚠ 0% over ≥5 decisions — every prompt approved; possible rubber-stamp"
+      : "";
+  out.push(`  reject rate ${(kpi.rejectRate * 100).toFixed(0)}%${stamp}`);
+  out.push(`  latency ${fmtLatency(kpi.latency)}`);
+  out.push(
+    `  channels: ${Object.entries(kpi.channels)
+      .sort((a, b) => b[1] - a[1])
+      .map(([k, v]) => `${k} ${v}`)
+      .join(" · ")}`,
+  );
+  if (kpi.byTool.length > 0) {
+    out.push("");
+    out.push("  by action:");
+    for (const t of kpi.byTool) {
+      const ch = Object.entries(t.channels)
+        .map(([k, v]) => `${k} ${v}`)
+        .join(", ");
+      out.push(
+        `    ${t.toolName.padEnd(22)} decided ${t.decided} · reject ${(
+          t.rejectRate * 100
+        ).toFixed(0)}% · latency ${fmtLatency(t.latency)}  [${ch}]`,
+      );
+    }
+  }
+  if (kpi.perDay.length > 0) {
+    out.push("");
+    out.push("  per day:");
+    for (const d of kpi.perDay)
+      out.push(`    ${d.day}  decided ${d.decided} (${d.rejected} rejected)`);
+  }
+  return out.join("\n");
+}

--- a/src/approvalKpi.ts
+++ b/src/approvalKpi.ts
@@ -1,0 +1,261 @@
+/**
+ * Considered-approval KPI — the lens that tells you whether delegated trust is
+ * being earned HONESTLY or rubber-stamped.
+ *
+ * The worker trust dial answers "how high has the level climbed". It does NOT
+ * answer the question the thesis actually rests on: are the approvals behind
+ * that climb *considered*? A dial that rose on reflexive taps is theater. This
+ * module reads the same `approval_decision` events the gate already writes to
+ * the ActivityLog (~/.claude/ide/activity-*.jsonl) and derives the signals that
+ * separate judgement from rubber-stamping:
+ *
+ *   - reject rate   — a human who never says no isn't deciding (0% = a stamp).
+ *   - latency       — how long you deliberated (decision ts − requestedAt). Sub-
+ *                     second medians across the board are the tell of a stamp.
+ *   - abandoned     — expired / cancelled prompts (approval fatigue / unreachable).
+ *   - channel split — dashboard vs phone (where the oversight actually happens).
+ *
+ * Read-only and fail-soft: a missing/garbled log is an empty report, never a
+ * throw. Latency needs the `requestedAt` field added to the decision event
+ * (approvalHttp.ts) — older rows lack it and are counted but excluded from
+ * latency, which is unrecoverable retroactively (the queue entry is long gone).
+ */
+
+import { readdirSync, readFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+/** Outcomes that reflect a HUMAN decision (a queue wait resolved), vs the
+ * instant-policy emits (gate_off / cc_allow_rule / gate_below_threshold / …)
+ * that never reached a person. Only these count toward the KPI. */
+const APPROVED = "approved";
+const REJECTED = "rejected";
+const ABANDONED_REASONS = new Set(["expired", "cancelled"]);
+const HUMAN_REASONS = new Set([APPROVED, REJECTED, "expired", "cancelled"]);
+
+export interface ConsideredDecision {
+  toolName: string;
+  /** Classified outcome — distinguishes a real rejection from a timeout, which
+   * the raw `decision: "deny"` field conflates (both are "deny"). */
+  outcome: "approved" | "rejected" | "abandoned";
+  /** Epoch-ms the decision was logged. */
+  decidedAt: number;
+  /** Epoch-ms the approval was prompted (queued); undefined on legacy rows. */
+  requestedAt?: number;
+  /** Where the human decided: "dashboard" | "phone" | "unknown". */
+  channel: string;
+  tier?: string;
+  sessionId?: string;
+}
+
+export interface ReadDecisionsOpts {
+  /** Override ~/.claude/ide (tests / remote). */
+  ideDir?: string;
+  /** Only decisions at/after this epoch-ms. */
+  sinceMs?: number;
+}
+
+/**
+ * Read human-deliberated approval decisions from the ActivityLog. Instant-policy
+ * decisions (auto-allowed sub-threshold calls, CC allow/deny rules) are skipped
+ * — they involved no human, so they aren't "considered approvals".
+ */
+export function readConsideredDecisions(
+  opts: ReadDecisionsOpts = {},
+): ConsideredDecision[] {
+  const ideDir = opts.ideDir ?? path.join(os.homedir(), ".claude", "ide");
+  let files: string[];
+  try {
+    files = readdirSync(ideDir).filter((f) => /^activity-.*\.jsonl$/.test(f));
+  } catch {
+    return [];
+  }
+  const out: ConsideredDecision[] = [];
+  for (const f of files) {
+    let text: string;
+    try {
+      text = readFileSync(path.join(ideDir, f), "utf-8");
+    } catch {
+      continue;
+    }
+    for (const line of text.split("\n")) {
+      const t = line.trim();
+      // cheap pre-filter before the JSON.parse
+      if (!t.includes("approval_decision")) continue;
+      let obj: Record<string, unknown>;
+      try {
+        obj = JSON.parse(t);
+      } catch {
+        continue;
+      }
+      if (obj.event !== "approval_decision") continue;
+      const md = (obj.metadata ?? {}) as Record<string, unknown>;
+      if (typeof md.toolName !== "string") continue;
+      const reason = typeof md.reason === "string" ? md.reason : "";
+      const requestedAt =
+        typeof md.requestedAt === "number" ? md.requestedAt : undefined;
+      const channel = typeof md.channel === "string" ? md.channel : "";
+      // Human-deliberated iff it carries a `channel` (the dashboard/phone
+      // approve|reject path — where WORKER-gate approvals actually land), a
+      // `requestedAt`, or a human-outcome `reason` (legacy CC-hook rows).
+      // Everything else is instant policy (gate_off / cc_allow_rule / …),
+      // excluded — those never reached a person.
+      const isHuman =
+        channel !== "" ||
+        requestedAt !== undefined ||
+        HUMAN_REASONS.has(reason);
+      if (!isHuman) continue;
+      const decidedAt =
+        typeof obj.timestamp === "string" ? Date.parse(obj.timestamp) || 0 : 0;
+      if (opts.sinceMs !== undefined && decidedAt < opts.sinceMs) continue;
+      // A channel'd event is a human click → outcome from `decision` (its
+      // `reason`, if any, is free-form rejection text, not an outcome marker).
+      // A channel-less CC-hook event uses `reason` to flag expired/cancelled.
+      const outcome: ConsideredDecision["outcome"] =
+        channel === "" && ABANDONED_REASONS.has(reason)
+          ? "abandoned"
+          : md.decision === "allow"
+            ? "approved"
+            : "rejected";
+      out.push({
+        toolName: md.toolName,
+        outcome,
+        decidedAt,
+        ...(requestedAt !== undefined && { requestedAt }),
+        channel: channel || "unknown",
+        ...(typeof md.tier === "string" && { tier: md.tier }),
+        ...(typeof md.sessionId === "string" && { sessionId: md.sessionId }),
+      });
+    }
+  }
+  out.sort((a, b) => a.decidedAt - b.decidedAt);
+  return out;
+}
+
+export interface LatencyStats {
+  count: number;
+  medianMs: number;
+  p90Ms: number;
+}
+
+export interface ToolKpi {
+  toolName: string;
+  /** approved + rejected (decided by a human). Abandoned excluded. */
+  decided: number;
+  approved: number;
+  rejected: number;
+  abandoned: number;
+  /** rejected / decided — 0 means a possible rubber-stamp. */
+  rejectRate: number;
+  latency: LatencyStats | null;
+  /** channel → count (dashboard / phone / unknown). */
+  channels: Record<string, number>;
+}
+
+export interface ConsideredApprovalKpi {
+  /** Total human-deliberated decisions in window (incl. abandoned). */
+  total: number;
+  decided: number;
+  approved: number;
+  rejected: number;
+  abandoned: number;
+  rejectRate: number;
+  latency: LatencyStats | null;
+  channels: Record<string, number>;
+  byTool: ToolKpi[];
+  /** Decisions per ISO day (chronological) — the approvals-per-week trend. */
+  perDay: Array<{ day: string; decided: number; rejected: number }>;
+}
+
+function percentile(sortedAsc: number[], p: number): number {
+  if (sortedAsc.length === 0) return 0;
+  const idx = Math.min(
+    sortedAsc.length - 1,
+    Math.floor((p / 100) * sortedAsc.length),
+  );
+  return sortedAsc[idx] as number;
+}
+
+function latencyOf(decisions: ConsideredDecision[]): LatencyStats | null {
+  const lat = decisions
+    .filter((d) => d.requestedAt !== undefined)
+    .map((d) => d.decidedAt - (d.requestedAt as number))
+    .filter((x) => x >= 0)
+    .sort((a, b) => a - b);
+  if (lat.length === 0) return null;
+  return {
+    count: lat.length,
+    medianMs: percentile(lat, 50),
+    p90Ms: percentile(lat, 90),
+  };
+}
+
+function channelsOf(decisions: ConsideredDecision[]): Record<string, number> {
+  const c: Record<string, number> = {};
+  for (const d of decisions) c[d.channel] = (c[d.channel] ?? 0) + 1;
+  return c;
+}
+
+/**
+ * Aggregate decisions into the considered-approval KPI. Reject rate and latency
+ * are computed over DECIDED (approved + rejected); abandoned (expired/cancelled)
+ * is tracked separately so a timeout never masquerades as a rejection.
+ */
+export function computeConsideredApprovalKpi(
+  decisions: ConsideredDecision[],
+): ConsideredApprovalKpi {
+  const decidedDs = decisions.filter((d) => d.outcome !== "abandoned");
+  const approved = decidedDs.filter((d) => d.outcome === "approved").length;
+  const rejected = decidedDs.filter((d) => d.outcome === "rejected").length;
+  const abandoned = decisions.length - decidedDs.length;
+  const decided = decidedDs.length;
+
+  const byToolMap = new Map<string, ConsideredDecision[]>();
+  for (const d of decisions) {
+    const arr = byToolMap.get(d.toolName) ?? [];
+    arr.push(d);
+    byToolMap.set(d.toolName, arr);
+  }
+  const byTool: ToolKpi[] = [...byToolMap.entries()]
+    .map(([toolName, ds]) => {
+      const dec = ds.filter((d) => d.outcome !== "abandoned");
+      const ap = dec.filter((d) => d.outcome === "approved").length;
+      const rej = dec.filter((d) => d.outcome === "rejected").length;
+      return {
+        toolName,
+        decided: dec.length,
+        approved: ap,
+        rejected: rej,
+        abandoned: ds.length - dec.length,
+        rejectRate: dec.length ? rej / dec.length : 0,
+        latency: latencyOf(dec),
+        channels: channelsOf(ds),
+      };
+    })
+    .sort((a, b) => b.decided - a.decided);
+
+  const perDayMap = new Map<string, { decided: number; rejected: number }>();
+  for (const d of decidedDs) {
+    const day = new Date(d.decidedAt).toISOString().slice(0, 10);
+    const e = perDayMap.get(day) ?? { decided: 0, rejected: 0 };
+    e.decided++;
+    if (d.outcome === "rejected") e.rejected++;
+    perDayMap.set(day, e);
+  }
+  const perDay = [...perDayMap.entries()]
+    .map(([day, e]) => ({ day, ...e }))
+    .sort((a, b) => a.day.localeCompare(b.day));
+
+  return {
+    total: decisions.length,
+    decided,
+    approved,
+    rejected,
+    abandoned,
+    rejectRate: decided ? rejected / decided : 0,
+    latency: latencyOf(decidedDs),
+    channels: channelsOf(decisions),
+    byTool,
+    perDay,
+  };
+}

--- a/src/approvalKpi.ts
+++ b/src/approvalKpi.ts
@@ -44,6 +44,10 @@ export interface ConsideredDecision {
   requestedAt?: number;
   /** Where the human decided: "dashboard" | "phone" | "unknown". */
   channel: string;
+  /** Queue callId — the dedup key. A single human decision double-emits: once
+   * on the dashboard/phone POST handler (channel'd) and once on the CC-hook path
+   * that was awaiting the same queue entry (no channel). Same callId. */
+  callId?: string;
   tier?: string;
   sessionId?: string;
 }
@@ -123,13 +127,33 @@ export function readConsideredDecisions(
         decidedAt,
         ...(requestedAt !== undefined && { requestedAt }),
         channel: channel || "unknown",
+        ...(typeof md.callId === "string" && { callId: md.callId }),
         ...(typeof md.tier === "string" && { tier: md.tier }),
         ...(typeof md.sessionId === "string" && { sessionId: md.sessionId }),
       });
     }
   }
-  out.sort((a, b) => a.decidedAt - b.decidedAt);
-  return out;
+  // Dedup: a single human decision lands TWICE in the log — the dashboard/phone
+  // POST handler row (channel'd) and the CC-hook row that was awaiting the same
+  // queue entry (no channel, reason'd). Same callId, same outcome. Collapse to
+  // one, preferring the richer row (real channel, then a prompt time) so counts
+  // aren't ~2x inflated and the channel split isn't polluted with a phantom
+  // "unknown" per decision. Rows without a callId (legacy) are never deduped.
+  const rank = (d: ConsideredDecision): number =>
+    (d.channel !== "unknown" ? 2 : 0) + (d.requestedAt !== undefined ? 1 : 0);
+  const byCallId = new Map<string, ConsideredDecision>();
+  const deduped: ConsideredDecision[] = [];
+  for (const d of out) {
+    if (!d.callId) {
+      deduped.push(d);
+      continue;
+    }
+    const prev = byCallId.get(d.callId);
+    if (!prev || rank(d) > rank(prev)) byCallId.set(d.callId, d);
+  }
+  deduped.push(...byCallId.values());
+  deduped.sort((a, b) => a.decidedAt - b.decidedAt);
+  return deduped;
 }
 
 export interface LatencyStats {
@@ -169,11 +193,18 @@ export interface ConsideredApprovalKpi {
 
 function percentile(sortedAsc: number[], p: number): number {
   if (sortedAsc.length === 0) return 0;
-  const idx = Math.min(
-    sortedAsc.length - 1,
-    Math.floor((p / 100) * sortedAsc.length),
-  );
-  return sortedAsc[idx] as number;
+  if (sortedAsc.length === 1) return sortedAsc[0] as number;
+  // Linear interpolation between closest ranks. The floor/nearest-rank variant
+  // rounds toward the SLOWER middle sample (median of [10s,30s] → 30s), which
+  // makes reflexive approvals look more deliberated than they were — a false
+  // negative on the one signal this module exists to catch.
+  const rank = (p / 100) * (sortedAsc.length - 1);
+  const lo = Math.floor(rank);
+  const hi = Math.ceil(rank);
+  const a = sortedAsc[lo] as number;
+  if (lo === hi) return a;
+  const b = sortedAsc[hi] as number;
+  return a + (b - a) * (rank - lo);
 }
 
 function latencyOf(decisions: ConsideredDecision[]): LatencyStats | null {

--- a/src/index.ts
+++ b/src/index.ts
@@ -212,6 +212,7 @@ const KNOWN_SUBCOMMANDS = [
   "doctor",
   "shadow-scan",
   "workers",
+  "approvals",
 ] as const;
 
 const __invokedSubcommand = (() => {
@@ -4679,6 +4680,72 @@ if (process.argv[2] === "workers") {
       process.stdout.write(
         runWorkerShadowReport(workersDir ? { workersDir } : {}),
       );
+    } catch (err) {
+      process.stderr.write(
+        `Error: ${err instanceof Error ? err.message : String(err)}\n`,
+      );
+      process.exit(1);
+    }
+  })();
+}
+
+// Handle approvals subcommand — considered-approval KPI. Reads the local
+// approval-decision log directly (like `workers shadow`); no bridge round-trip.
+// The lens that tells you whether the trust climbing the worker dial was EARNED
+// or rubber-stamped: reject rate, latency-to-decision, abandoned, channel split.
+if (process.argv[2] === "approvals") {
+  const args = process.argv.slice(3);
+  if (args.includes("--help") || args.includes("-h")) {
+    process.stdout.write(
+      "Usage: patchwork approvals [--window 1h|24h|overnight|7d|any] [--json]\n\n" +
+        "Considered-approval KPI from the local approval-decision log:\n" +
+        "  reject rate · latency-to-decision · abandoned · dashboard-vs-phone.\n\n" +
+        "  --window <name>  lookback (default: any). overnight = since 6pm yesterday.\n" +
+        "  --json           emit raw JSON (for scripting)\n",
+    );
+    process.exit(0);
+  }
+  (async () => {
+    try {
+      const wIdx = args.findIndex((a) => a === "--window" || a === "-w");
+      const win =
+        wIdx >= 0 && wIdx + 1 < args.length
+          ? (args[wIdx + 1] as string)
+          : "any";
+      const fixed: Record<string, number | null> = {
+        "1h": 3_600_000,
+        "24h": 86_400_000,
+        "7d": 604_800_000,
+        any: null,
+      };
+      let sinceMs: number | undefined;
+      if (win === "overnight") {
+        const d = new Date();
+        d.setHours(18, 0, 0, 0);
+        if (d.getTime() > Date.now()) d.setDate(d.getDate() - 1);
+        sinceMs = d.getTime();
+      } else if (win in fixed) {
+        const dur = fixed[win];
+        sinceMs = dur == null ? undefined : Date.now() - dur;
+      } else {
+        process.stderr.write(`Unknown --window value: "${win}"\n`);
+        process.exit(1);
+      }
+      const {
+        readConsideredDecisions,
+        computeConsideredApprovalKpi,
+        formatConsideredApprovalKpi,
+      } = await import("./approvalKpi.js");
+      const decisions = readConsideredDecisions(
+        sinceMs !== undefined ? { sinceMs } : {},
+      );
+      const kpi = computeConsideredApprovalKpi(decisions);
+      process.stdout.write(
+        args.includes("--json")
+          ? `${JSON.stringify(kpi, null, 2)}\n`
+          : `${formatConsideredApprovalKpi(kpi, { windowLabel: win })}\n`,
+      );
+      process.exit(0);
     } catch (err) {
       process.stderr.write(
         `Error: ${err instanceof Error ? err.message : String(err)}\n`,

--- a/src/index.ts
+++ b/src/index.ts
@@ -4724,7 +4724,7 @@ if (process.argv[2] === "approvals") {
         d.setHours(18, 0, 0, 0);
         if (d.getTime() > Date.now()) d.setDate(d.getDate() - 1);
         sinceMs = d.getTime();
-      } else if (win in fixed) {
+      } else if (Object.hasOwn(fixed, win)) {
         const dur = fixed[win];
         sinceMs = dur == null ? undefined : Date.now() - dur;
       } else {

--- a/src/recipeRoutes.ts
+++ b/src/recipeRoutes.ts
@@ -930,6 +930,33 @@ export function tryHandleRecipeRoute(
     return true;
   }
 
+  // GET /approvals/kpi — considered-approval KPI (reject rate, latency-to-
+  // decision, abandoned, dashboard-vs-phone). Read-only over the persisted
+  // approval-decision log; the sibling of /workers/shadow that answers "was the
+  // trust climbing the dial EARNED or rubber-stamped". Backs the dashboard
+  // approval panel. Optional ?sinceMs=<epoch-ms> windows it. Fail-soft.
+  if (parsedUrl.pathname === "/approvals/kpi" && req.method === "GET") {
+    void (async () => {
+      try {
+        const sinceRaw = parsedUrl.searchParams.get("sinceMs");
+        const sinceMs = sinceRaw ? Number.parseInt(sinceRaw, 10) : Number.NaN;
+        const { readConsideredDecisions, computeConsideredApprovalKpi } =
+          await import("./approvalKpi.js");
+        const decisions = readConsideredDecisions(
+          Number.isFinite(sinceMs) ? { sinceMs } : {},
+        );
+        const kpi = computeConsideredApprovalKpi(decisions);
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(
+          JSON.stringify({ ...kpi, generatedAt: new Date().toISOString() }),
+        );
+      } catch (err) {
+        respond500(res, err);
+      }
+    })();
+    return true;
+  }
+
   // GET /recipes/doctor?recipe=<name> — one-call recipe health diagnosis.
   // Server-side home for the `recipe doctor` CLI: composes the static
   // preflight check (lint + write-policy + plan) with the recipe-scoped


### PR DESCRIPTION
## What

The worker trust dial shows how high a worker's level climbed. It **cannot** tell you the thing the whole thesis rests on: were the approvals behind that climb **considered**, or rubber-stamped? A dial that rose on reflexive taps is theater. This adds the lens that answers it, read from the `approval_decision` events the gate already writes.

## Why now

We just brought the Test Guardian worker fully live (real repo, phone approvals). Before weeks of evidence accrue, we need to be able to tell honest accrual from theater — otherwise the dial climbs and we can't interpret it. Latency especially **can't be backfilled** (the queue entry is gone by decision time), so the instrumentation has to land before the run, not after.

## The signals (per worker × action-class, windowed)

- **reject rate** — a human who never says no isn't deciding. 0% over a real sample is the clearest tell of a stamp.
- **latency-to-decision** — `decision ts − requestedAt`. Sub-second medians across the board = reflexive.
- **abandoned** — expired/cancelled prompts (approval fatigue / unreachable).
- **channel split** — dashboard vs phone (where oversight actually happens).

## Surfaces

- **Instrumentation** — `requestedAt` logged on the decision event, on **both** emit paths (CC-hook + dashboard/phone).
- **`patchwork approvals`** (CLI) — reads the local log directly, like `workers shadow`. Fires a rubber-stamp warning on 0% reject over ≥5 decisions.
- **`GET /approvals/kpi`** (bridge) — read-only, fail-soft, sibling of `/workers/shadow`.
- **Dashboard** — a "Considered approvals — is it earned?" panel atop `/workers`, surfacing the warning in `--warn` beside the dial it qualifies.

## Validated on live data + adversarial review

Built test-first, then run against the real activity log — which immediately caught a **HIGH the unit tests structurally couldn't**: a single human decision **double-emits** (the dashboard POST row + the awaiting CC-hook row, same callId), ~2x-inflating counts and injecting a phantom `unknown` channel. Fixed by callId dedup (decided 14→12 on real data; `github.create_issue` unchanged at 4 — worker approvals were single-emit). The review (3 dims × verify, 17 agents) also tightened percentile math (interpolation, so latency can't round rubber-stamps to look deliberated), the CLI window check (`Object.hasOwn`), and added emit/dedup regression tests.

## Honest caveat on the data so far

Current reject rate is **0%** — because every decision to date was a *test*, approved without deliberation. That's the KPI being honest, not broken: it only becomes meaningful once real junk gets rejected on the live run. That discipline is what makes the eventual L4 real.

## Gates

`tsc` (bridge ×2 + dashboard) · `biome` · `audit-lsp-tools` · vocabulary/fontsize ratchets · **69 tests**. Deployed + verified live: CLI, route, and dashboard panel all read the same instrumented data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)