### PR TITLE
fix(bridge): restore non-null assertion broken by biome auto-fix (CI typecheck)

### DIFF
--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -1194,26 +1194,23 @@ export class Bridge {
         this.config.automationAllowPrivateWebhooks,
         this.recipeOrchestration
           ? (opts) =>
-              this.recipeOrchestration
-                ?.fireYamlRecipe({
-                  filePath: path.join(
-                    os.homedir(),
-                    ".patchwork",
-                    "recipes",
-                    `${opts.recipeName}.yaml`,
-                  ),
-                  name: opts.recipeName,
-                  taskIdPrefix: `automation-recipe-${opts.recipeName}`,
-                  triggerSourceSuffix: `automation:${opts.triggerSource}`,
-                  logLabel: `automation "${opts.recipeName}"`,
-                  seedContext: Object.fromEntries(
-                    Object.entries(opts.eventData),
-                  ),
-                })
-                .then((r) => {
-                  if (!r.ok) throw new Error(r.error ?? "recipe fire failed");
-                  return r.taskId ?? "";
-                })
+              // biome-ignore lint/style/noNonNullAssertion: guarded by outer ternary
+              this.recipeOrchestration!.fireYamlRecipe({
+                filePath: path.join(
+                  os.homedir(),
+                  ".patchwork",
+                  "recipes",
+                  `${opts.recipeName}.yaml`,
+                ),
+                name: opts.recipeName,
+                taskIdPrefix: `automation-recipe-${opts.recipeName}`,
+                triggerSourceSuffix: `automation:${opts.triggerSource}`,
+                logLabel: `automation "${opts.recipeName}"`,
+                seedContext: Object.fromEntries(Object.entries(opts.eventData)),
+              }).then((r) => {
+                if (!r.ok) throw new Error(r.error ?? "recipe fire failed");
+                return r.taskId ?? "";
+              })
           : undefined,
       );
       this.logger.info(
@@ -1250,26 +1247,25 @@ export class Bridge {
           this.config.automationAllowPrivateWebhooks,
           this.recipeOrchestration
             ? (opts) =>
-                this.recipeOrchestration
-                  ?.fireYamlRecipe({
-                    filePath: path.join(
-                      os.homedir(),
-                      ".patchwork",
-                      "recipes",
-                      `${opts.recipeName}.yaml`,
-                    ),
-                    name: opts.recipeName,
-                    taskIdPrefix: `automation-recipe-${opts.recipeName}`,
-                    triggerSourceSuffix: `automation:${opts.triggerSource}`,
-                    logLabel: `automation "${opts.recipeName}"`,
-                    seedContext: Object.fromEntries(
-                      Object.entries(opts.eventData),
-                    ),
-                  })
-                  .then((r) => {
-                    if (!r.ok) throw new Error(r.error ?? "recipe fire failed");
-                    return r.taskId ?? "";
-                  })
+                // biome-ignore lint/style/noNonNullAssertion: guarded by outer ternary
+                this.recipeOrchestration!.fireYamlRecipe({
+                  filePath: path.join(
+                    os.homedir(),
+                    ".patchwork",
+                    "recipes",
+                    `${opts.recipeName}.yaml`,
+                  ),
+                  name: opts.recipeName,
+                  taskIdPrefix: `automation-recipe-${opts.recipeName}`,
+                  triggerSourceSuffix: `automation:${opts.triggerSource}`,
+                  logLabel: `automation "${opts.recipeName}"`,
+                  seedContext: Object.fromEntries(
+                    Object.entries(opts.eventData),
+                  ),
+                }).then((r) => {
+                  if (!r.ok) throw new Error(r.error ?? "recipe fire failed");
+                  return r.taskId ?? "";
+                })
             : undefined,
         );
         this.automationHooks.registerRecipePrograms(collected.programs);


### PR DESCRIPTION
## Summary

- `biome check --write` silently replaced `!.fireYamlRecipe` with `?.fireYamlRecipe` inside a ternary that already guards the truthy case
- `?.` changes the return type from `Promise<string>` to `Promise<string> | undefined`, which tsc rejects at the `AutomationHooks` call site
- Local `tsc` was not run after the biome auto-fix before the direct push to main — CI caught it
- Fix: restore `!.` with a `biome-ignore` comment explaining the outer ternary already guarantees non-null

## Root cause

Direct push to main skipped CI feedback loop. Moving to PR workflow from here.

## Test plan

- [ ] `npm run typecheck` — clean
- [ ] `npm run build` — clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)