### PR TITLE
fix(workers): shadow divergence inflation — filter Claude-session approvals from ramp-vs-gate

### DIFF
--- a/src/approvalHttp.ts
+++ b/src/approvalHttp.ts
@@ -290,6 +290,7 @@ export async function routeApprovalRequest(
     const approveEntry = deps.queue.list?.().find((e) => e.callId === callId);
     const approveToolName = approveEntry?.toolName;
     const approveRequestedAt = approveEntry?.requestedAt;
+    const approveRecipeName = approveEntry?.recipeName;
     const ok = deps.queue.approve(callId);
     if (ok) {
       // Audit 2026-06-03 (MEDIUM #27): fire the audit hook on APPROVE too —
@@ -307,6 +308,12 @@ export async function routeApprovalRequest(
         ...(approveToolName !== undefined && { toolName: approveToolName }),
         ...(approveRequestedAt !== undefined && {
           requestedAt: approveRequestedAt,
+        }),
+        // Worker-shadow attribution: recipeName lets the shadow observer
+        // filter out Claude-session tool calls (which also emit
+        // approval_decision but are NOT worker-gate decisions).
+        ...(approveRecipeName !== undefined && {
+          recipeName: approveRecipeName,
         }),
       });
       return { status: 200, body: { decision: "allow", callId } };
@@ -387,6 +394,7 @@ export async function routeApprovalRequest(
     const rejectEntry = deps.queue.list?.().find((e) => e.callId === callId);
     const rejectToolName = rejectEntry?.toolName;
     const rejectRequestedAt = rejectEntry?.requestedAt;
+    const rejectRecipeName = rejectEntry?.recipeName;
     const ok = deps.queue.reject(callId);
     if (ok) {
       deps.onDecision?.("approval_decision", {
@@ -398,6 +406,9 @@ export async function routeApprovalRequest(
         ...(rejectToolName !== undefined && { toolName: rejectToolName }),
         ...(rejectRequestedAt !== undefined && {
           requestedAt: rejectRequestedAt,
+        }),
+        ...(rejectRecipeName !== undefined && {
+          recipeName: rejectRecipeName,
         }),
       });
       return { status: 200, body: { decision: "deny", callId } };

--- a/src/recipeOrchestration.ts
+++ b/src/recipeOrchestration.ts
@@ -153,6 +153,10 @@ export async function buildWorkerAutonomyGate(
           tier: input.tier,
           sessionId: `worker:${worker.id}`,
           summary: `${worker.name} (${decision.classKey}): ${decision.reason}`,
+          // recipeName propagates to the ActivityLog decision row so the shadow
+          // observer can distinguish worker-gate approvals from plain Claude-
+          // session MCP tool approvals (same event type, different source).
+          recipeName,
         },
         { signal: input.signal }, // L1: cancel the wait when the run aborts
       );

--- a/src/workers/__tests__/shadowObserver.test.ts
+++ b/src/workers/__tests__/shadowObserver.test.ts
@@ -58,9 +58,19 @@ describe("WorkerShadowObserver", () => {
     const obs = new WorkerShadowObserver([release], { cfg: CFG });
     climb(obs); // fs-write earned L4 → ramp would bypass editText
     // gate DENIED an editText the ramp would now auto-run → divergence
-    obs.ingestDecision({ toolName: "editText", decision: "deny", at: 5000 });
+    obs.ingestDecision({
+      toolName: "editText",
+      decision: "deny",
+      at: 5000,
+      recipeName: "test-recipe",
+    });
     // gate ALLOWED an editText the ramp would also auto-run → agreement
-    obs.ingestDecision({ toolName: "editText", decision: "allow", at: 6000 });
+    obs.ingestDecision({
+      toolName: "editText",
+      decision: "allow",
+      at: 6000,
+      recipeName: "test-recipe",
+    });
     const r = obs.report()[0]!;
     expect(r.compared).toBe(2);
     expect(r.agreed).toBe(1);
@@ -76,7 +86,20 @@ describe("WorkerShadowObserver", () => {
       toolName: "slackPostMessage",
       decision: "deny",
       at: 0,
+      recipeName: "test-recipe",
     });
+    expect(obs.report()[0]!.compared).toBe(0);
+  });
+
+  it("skips decisions without recipeName (plain Claude-session MCP approvals)", () => {
+    // Decisions without recipeName are Claude-session tool calls, not worker-gate
+    // decisions. Including them inflates divergences with calls the worker gate
+    // never saw (e.g. this Claude Code session approving github.create_issue
+    // directly via its own general approvalGate).
+    const obs = new WorkerShadowObserver([release], { cfg: CFG });
+    climb(obs); // fs-write earned L4
+    // No recipeName → should be skipped entirely
+    obs.ingestDecision({ toolName: "editText", decision: "deny", at: 5000 });
     expect(obs.report()[0]!.compared).toBe(0);
   });
 

--- a/src/workers/__tests__/shadowReport.test.ts
+++ b/src/workers/__tests__/shadowReport.test.ts
@@ -55,7 +55,12 @@ describe("buildShadowReport", () => {
       editRun(4000, 1),
     ];
     const decisions: DecisionRecord[] = [
-      { toolName: "editText", decision: "deny", at: 5000 },
+      {
+        toolName: "editText",
+        decision: "deny",
+        at: 5000,
+        recipeName: "test-recipe",
+      },
     ];
     const [r] = buildShadowReport([release], runs, decisions, CFG);
     expect(
@@ -78,7 +83,14 @@ describe("formatShadowReport", () => {
         editRun(3000, 1),
         editRun(4000, 1),
       ],
-      [{ toolName: "editText", decision: "deny", at: 5000 }],
+      [
+        {
+          toolName: "editText",
+          decision: "deny",
+          at: 5000,
+          recipeName: "test-recipe",
+        },
+      ],
       CFG,
     );
     const text = formatShadowReport(reports);

--- a/src/workers/runWorkerShadow.ts
+++ b/src/workers/runWorkerShadow.ts
@@ -88,6 +88,12 @@ function readDecisions(ideDir: string): DecisionRecord[] {
           typeof obj.timestamp === "string"
             ? Date.parse(obj.timestamp) || 0
             : 0,
+        // Only present on worker-gate decisions (recipe runner path). Plain
+        // Claude-session MCP approvals have no recipeName; ingestDecision
+        // skips them so they don't inflate the ramp-vs-gate divergence count.
+        ...(typeof md.recipeName === "string" && {
+          recipeName: md.recipeName,
+        }),
       });
     }
   }

--- a/src/workers/shadowObserver.ts
+++ b/src/workers/shadowObserver.ts
@@ -47,6 +47,10 @@ export interface DecisionRecord {
   decision: "allow" | "deny";
   at: number;
   params?: Record<string, unknown>;
+  /** Present only on worker-gate decisions (recipe runner path). Absent on
+   * Claude-session MCP tool approvals — the shadow only counts worker-gate
+   * decisions so mixing in session approvals won't inflate divergences. */
+  recipeName?: string;
 }
 
 export interface Divergence {
@@ -144,8 +148,14 @@ export class WorkerShadowObserver {
   }
 
   /** Compare what the ramp WOULD recommend (given the dial as of now) against
-   * the gate's actual decision. Read-only — records agreement + divergences. */
+   * the gate's actual decision. Read-only — records agreement + divergences.
+   *
+   * Only worker-gate decisions (those with a recipeName) are counted. Plain
+   * Claude-session MCP tool approvals share the same ActivityLog event type
+   * but have no recipeName — including them would inflate divergences with
+   * calls the worker gate never saw. */
   ingestDecision(d: DecisionRecord): void {
+    if (!d.recipeName) return;
     const worker = this.workerForAction(d.toolName, d.params);
     if (!worker) return;
     const rec = recommend(worker, d.toolName, d.params, this.store);


### PR DESCRIPTION
## Problem

`patchwork workers shadow` was showing misleading divergences:

```
ramp vs gate: 1/5 agree · 4 divergence(s)
  ⚠ github.create_issue — ramp would gate; gate allowed
  ⚠ github.create_issue — ramp would gate; gate allowed
  ⚠ github.create_issue — ramp would gate; gate allowed
  ⚠ github.create_issue — ramp would gate; gate allowed
```

Root cause: `readDecisions` ingests **all** `approval_decision` ActivityLog rows — including approvals from Claude Code sessions using the general `approvalGate` (e.g. this Claude session approving `github.create_issue` directly as an MCP tool call). These are not worker-gate decisions, but they appeared identical in the ActivityLog. The shadow observer couldn't distinguish them, so it counted them as "gate allowed, ramp would gate" divergences even though the **worker gate never saw those calls**.

## Fix

Tag worker-gate approvals at the source:

1. **`recipeOrchestration.ts`** — pass `recipeName` to `queue.request()` when the worker gate queues a step (it was already in the `ApprovalQueueEntry` schema, just unused)
2. **`approvalHttp.ts`** — include `recipeName` from the queue entry in the `approval_decision` ActivityLog row (both approve and reject paths)
3. **`shadowObserver.ts`** — add `recipeName?` to `DecisionRecord`; `ingestDecision` skips entries without it (Claude-session path)
4. **`runWorkerShadow.ts`** — propagate `recipeName` from ActivityLog metadata → `DecisionRecord`

After this, `workers shadow` only compares actual worker-gate decisions against the ramp — not the general approval gate.

## Test plan

- [ ] New test: "skips decisions without recipeName" in `shadowObserver.test.ts`
- [ ] Updated fixtures: all `DecisionRecord` test fixtures now carry `recipeName`
- [ ] `npm run typecheck` — clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)