### PR TITLE
feat(workers): cold-start priors — prior pseudo-count reduces novel-floor latency

### DIFF
--- a/src/workers/__tests__/trustLevel.test.ts
+++ b/src/workers/__tests__/trustLevel.test.ts
@@ -32,10 +32,29 @@ describe("trustLevel — cold start", () => {
   });
 
   it("a high-mean competence prior with no local evidence is still capped at L1", () => {
-    // ships competence (mean 0.95) but trust must be earned locally
+    // strength=8 contributes 6 pseudo-obs toward the floor (10 required).
+    // With 0 real observations, effectiveEvidence=6 < 10 → still L1.
     const prior = priorFromCompetence(0.95, 8);
     const r = levelFromPosterior(prior, prior, { reachable: ALL_REACHABLE });
     expect(evidenceCount(prior, prior)).toBe(0);
+    expect(r.level).toBeLessThanOrEqual(1);
+  });
+
+  it("strong prior (strength=8) reduces cold-start: 4 real obs graduate past L1", () => {
+    // strength=8 → priorContribution=6; 4 real obs → effectiveEvidence=10 → floor lifted.
+    const prior = priorFromCompetence(0.95, 8);
+    const p = applyN(prior, 4, true, 1);
+    const r = levelFromPosterior(p, prior, { reachable: ALL_REACHABLE });
+    expect(evidenceCount(p, prior)).toBe(4);
+    expect(r.level).toBeGreaterThan(1); // floor no longer blocks
+  });
+
+  it("default prior offers no cold-start reduction: 4 real obs still capped at L1", () => {
+    // DEFAULT_PRIOR (alpha=1, beta=1) contributes 0 extra → effectiveEvidence=4 < 10.
+    const p = applyN(DEFAULT_PRIOR, 4, true, 1);
+    const r = levelFromPosterior(p, DEFAULT_PRIOR, {
+      reachable: ALL_REACHABLE,
+    });
     expect(r.level).toBeLessThanOrEqual(1);
   });
 });

--- a/src/workers/trustLevel.ts
+++ b/src/workers/trustLevel.ts
@@ -105,8 +105,13 @@ export interface LevelResult {
 /**
  * Map a posterior to a discrete rung, applying:
  *  1. LCB → raw level via thresholds.
- *  2. Novel-class floor: below the evidence minimum, cap at L1 regardless of how
- *     good the (necessarily wide) posterior looks — no class graduates on faith.
+ *  2. Novel-class floor: below the effective evidence minimum, cap at L1.
+ *     "Effective evidence" = real observations + prior pseudo-count beyond the
+ *     uniform baseline (prior.alpha + prior.beta − 2). A strong operator prior
+ *     (strength 8 → contributes 6) reduces the real observations needed before
+ *     graduation is permitted; the default uniform prior contributes 0 so
+ *     existing behaviour is unchanged. No class can skip the floor entirely via
+ *     prior alone — the prior's LCB is still too wide without real data.
  *  3. Reachability clamp: drop to the highest reachable rung ≤ the computed one,
  *     so an irreversible class climbing through "would-be L2/L3" stays at L1
  *     until it actually clears the L4 bar.
@@ -129,8 +134,12 @@ export function levelFromPosterior(
     thresholds.find((t) => lcb >= t.min)?.level ?? (0 as TrustLevel);
 
   let level: TrustLevel = rawLevel;
-  // Novel-class floor.
-  if (evidence < minEvidence && level > 1) level = 1;
+  // Novel-class floor: prior pseudo-count beyond the uniform baseline counts
+  // toward the evidence minimum, reducing cold-start latency for operator-
+  // configured workers without letting the prior alone bypass the floor.
+  const priorContribution = Math.max(0, prior.alpha + prior.beta - 2);
+  const effectiveEvidence = evidence + priorContribution;
+  if (effectiveEvidence < minEvidence && level > 1) level = 1;
   // Reachability clamp (highest reachable rung ≤ level).
   const allowed = reachable.filter((r) => r <= level);
   level = (allowed.length ? Math.max(...allowed) : 0) as TrustLevel;


### PR DESCRIPTION
## Summary

- Workers configured with `competence: {mean: 0.95, strength: 8}` previously still ground from L0 for 10+ observations before L2 was reachable — the novel-floor ignored the prior's pseudo-count entirely
- Fix: `effectiveEvidence = real evidence + max(0, prior.alpha + prior.beta − 2)`. The −2 subtracts the uniform baseline so **default prior contributes nothing** (backwards-compatible)
- `strength=8` contributes 6 pseudo-observations, cutting required real observations from 10 to **4** before the floor lifts

## Why this is safe

The prior alone **cannot bypass** the floor: with 0 real obs and strength=8, effectiveEvidence=6 < 10 → still L1. The LCB of the prior posterior is also too wide to reach L2 without real data. Four clean outcomes then unlock graduation — still a meaningful evidence requirement.

## Practical impact

Paired with the L2/L3 gate (#1036), a trusted worker configured with high competence can reach compensable auto-allow in **days** (a few recipe runs) rather than weeks. A worker doing 3 tool calls per daily run reaches the floor in ~2 days.

## Test plan

- [x] Existing "still capped at L1 with no local evidence" test passes unchanged
- [x] New: strength=8 + 4 real obs → graduates past L1
- [x] New: default prior + 4 real obs → still capped (no regression)
- [x] Full suite: 8,652 pass, 0 new failures
- [x] `npm run build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)