### PR TITLE
fix(workers): adversarial review — trust-transfer, TIER_MAP, reversible shadow, NaN (#1036+#1037)

### DIFF
--- a/src/riskTier.ts
+++ b/src/riskTier.ts
@@ -92,6 +92,8 @@ const TIER_MAP: Record<string, RiskTier> = {
   gitPull: "high",
   gitFetch: "high",
   githubCreatePR: "high",
+  githubMergePR: "high",
+  githubApprovePR: "high",
   githubCommentIssue: "high",
   githubCreateIssue: "high",
   githubPostPRReview: "high",

--- a/src/workers/__tests__/actionClass.test.ts
+++ b/src/workers/__tests__/actionClass.test.ts
@@ -15,7 +15,7 @@ describe("classifyActionClass", () => {
       brandExposed: false,
     });
     expect(classifyActionClass("gitPush").key).toBe(
-      "vcs-remote:compensable:high",
+      "vcs-push:compensable:high",
     );
     expect(classifyActionClass("slackPostMessage").key).toBe(
       "messaging:irreversible:medium",

--- a/src/workers/__tests__/shadowGate.test.ts
+++ b/src/workers/__tests__/shadowGate.test.ts
@@ -10,62 +10,153 @@ const CFG: GraduationConfig = {
   minEvidenceForGraduation: 5,
 };
 
-/** Build a store where `workerId` has earned L4 on editText (fs-write). */
-function storeWithL4(workerId: string): WorkerLevelStore {
+/** Build a store where `workerId` has earned L4 on `toolName`. */
+function storeWithL4(workerId: string, toolName: string): WorkerLevelStore {
   const store = new WorkerLevelStore();
   for (let i = 0; i < 60; i++)
-    store.apply(
-      workerId,
-      { toolName: "editText", good: true, at: 0 },
-      { cfg: CFG },
-    );
+    store.apply(workerId, { toolName, good: true, at: 0 }, { cfg: CFG });
   for (const at of [1000, 2000, 3000, 4000])
-    store.apply(
-      workerId,
-      { toolName: "editText", good: true, at },
-      { cfg: CFG },
-    );
+    store.apply(workerId, { toolName, good: true, at }, { cfg: CFG });
   return store;
 }
 
-describe("shadowGate.recommend", () => {
-  it("bypasses an owned class the worker has earned L4 on", () => {
-    const w = parseWorker({ id: "release-bot", name: "R", owns: ["fs-write"] });
-    const d = recommend(w, "editText", {}, storeWithL4("release-bot"));
-    expect(d.earnedLevel).toBe(4);
-    expect(d.effectiveLevel).toBe(4);
+/** Build a store where `workerId` has earned L2 on `toolName`. */
+function storeWithL2(workerId: string, toolName: string): WorkerLevelStore {
+  const store = new WorkerLevelStore();
+  for (let i = 0; i < 10; i++)
+    store.apply(workerId, { toolName, good: true, at: 0 }, { cfg: CFG });
+  store.apply(workerId, { toolName, good: true, at: 1000 }, { cfg: CFG });
+  store.apply(workerId, { toolName, good: true, at: 2000 }, { cfg: CFG });
+  return store;
+}
+
+describe("shadowGate.recommend — reversible short-circuit", () => {
+  it("bypasses reversible action regardless of earned level (no trust required)", () => {
+    const w = parseWorker({ id: "w", name: "W", owns: ["fs-write"] });
+    const d = recommend(w, "editText", {}, new WorkerLevelStore());
+    expect(d.decision).toBe("bypass");
+    expect(d.reason).toContain("reversible");
+  });
+
+  it("bypasses reversible even when autonomyCeiling=0", () => {
+    const w = parseWorker({
+      id: "w",
+      name: "W",
+      owns: ["fs-write"],
+      autonomyCeiling: 0,
+    });
+    const d = recommend(w, "editText", {}, new WorkerLevelStore());
     expect(d.decision).toBe("bypass");
   });
 
-  it("autonomyCeiling caps the effective level below earned → still queues", () => {
-    // a Legal-sector-style worker pinned at L2 regardless of track record
+  it("bypasses reversible even when action is outside worker's domain", () => {
+    // getGitStatus is vcs-read (reversible) — not in owns; still flows un-gated
+    const w = parseWorker({ id: "w", name: "W", owns: ["fs-write"] });
+    const d = recommend(w, "getGitStatus", {}, new WorkerLevelStore());
+    expect(d.decision).toBe("bypass");
+  });
+});
+
+describe("shadowGate.recommend — compensable at L2", () => {
+  it("bypasses compensable when worker has earned L2 (threshold met)", () => {
+    const w = parseWorker({ id: "w", name: "W", owns: ["vcs-push"] });
+    const d = recommend(w, "gitPush", {}, storeWithL2("w", "gitPush"));
+    expect(d.earnedLevel).toBeGreaterThanOrEqual(2);
+    expect(d.decision).toBe("bypass");
+    expect(d.reason).toContain("autonomous");
+  });
+
+  it("queues compensable at effective L1 (below L2 threshold)", () => {
+    const w = parseWorker({ id: "w", name: "W", owns: ["vcs-push"] });
+    const store = new WorkerLevelStore();
+    store.apply("w", { toolName: "gitPush", good: true, at: 0 }, { cfg: CFG });
+    const d = recommend(w, "gitPush", {}, store);
+    expect(d.earnedLevel).toBeLessThan(2);
+    expect(d.decision).toBe("queue");
+    expect(d.reason).toContain("below-autonomy");
+  });
+
+  it("queues compensable when ceiling=1 even at earned L4", () => {
     const w = parseWorker({
-      id: "release-bot",
-      name: "R",
-      owns: ["fs-write"],
-      autonomyCeiling: 2,
+      id: "w",
+      name: "W",
+      owns: ["vcs-push"],
+      autonomyCeiling: 1,
     });
-    const d = recommend(w, "editText", {}, storeWithL4("release-bot"));
+    const d = recommend(w, "gitPush", {}, storeWithL4("w", "gitPush"));
     expect(d.earnedLevel).toBe(4);
-    expect(d.effectiveLevel).toBe(2);
+    expect(d.effectiveLevel).toBe(1);
     expect(d.decision).toBe("queue");
     expect(d.reason).toContain("capped-by-autonomy-ceiling");
   });
 
-  it("floors to L0 and queues for an action outside the worker's domain", () => {
-    const w = parseWorker({ id: "release-bot", name: "R", owns: ["fs-write"] });
-    // worker has L4 on fs-write but slackPostMessage is messaging — not owned
-    const d = recommend(w, "slackPostMessage", {}, storeWithL4("release-bot"));
+  it("bypasses compensable when ceiling=2 and earned L4 (effectiveLevel meets threshold)", () => {
+    const w = parseWorker({
+      id: "w",
+      name: "W",
+      owns: ["vcs-remote"],
+      autonomyCeiling: 2,
+    });
+    const d = recommend(
+      w,
+      "githubCreatePR",
+      {},
+      storeWithL4("w", "githubCreatePR"),
+    );
+    expect(d.earnedLevel).toBe(4);
+    expect(d.effectiveLevel).toBe(2);
+    expect(d.decision).toBe("bypass");
+  });
+});
+
+describe("shadowGate.recommend — irreversible", () => {
+  it("queues an unearned irreversible action (outside domain)", () => {
+    const w = parseWorker({ id: "w", name: "W", owns: ["fs-write"] });
+    const d = recommend(
+      w,
+      "slackPostMessage",
+      {},
+      storeWithL4("w", "editText"),
+    );
     expect(d.owned).toBe(false);
     expect(d.effectiveLevel).toBe(0);
     expect(d.decision).toBe("queue");
     expect(d.reason).toBe("outside-worker-domain");
   });
 
-  it("queues an owned class with no track record (cold start)", () => {
-    const w = parseWorker({ id: "fresh", name: "F", owns: ["fs-write"] });
-    const d = recommend(w, "editText", {}, new WorkerLevelStore());
-    expect(d.earnedLevel).toBe(0);
+  it("bypasses irreversible only at earned L4", () => {
+    const w = parseWorker({ id: "w", name: "W", owns: ["shell"] });
+    const d = recommend(
+      w,
+      "runInTerminal",
+      {},
+      storeWithL4("w", "runInTerminal"),
+    );
+    expect(d.earnedLevel).toBe(4);
+    expect(d.decision).toBe("bypass");
+  });
+
+  it("queues irreversible below L4 (no mid-ramp unlock for irreversible)", () => {
+    // Irreversible reachable levels are [0,1,4] — even with enough evidence to
+    // reach a "would-be L2/L3" LCB, the ramp clamps to L1 until L4 is cleared.
+    const w = parseWorker({ id: "w", name: "W", owns: ["shell"] });
+    // 30 successes put LCB in the L2/L3 range for a compensable class;
+    // irreversible clamping means earnedLevel stays at L1 here.
+    const store = new WorkerLevelStore();
+    for (let i = 0; i < 30; i++)
+      store.apply(
+        "w",
+        { toolName: "runInTerminal", good: true, at: 0 },
+        { cfg: CFG },
+      );
+    for (const at of [1000, 2000, 3000, 4000])
+      store.apply(
+        "w",
+        { toolName: "runInTerminal", good: true, at },
+        { cfg: CFG },
+      );
+    const d = recommend(w, "runInTerminal", {}, store);
+    expect(d.earnedLevel).toBeLessThan(4);
     expect(d.decision).toBe("queue");
   });
 });

--- a/src/workers/__tests__/shadowObserver.test.ts
+++ b/src/workers/__tests__/shadowObserver.test.ts
@@ -143,7 +143,7 @@ describe("WorkerShadowObserver", () => {
 
   it("flags board rows for classes the worker performs but does NOT own (L3)", () => {
     const obs = new WorkerShadowObserver([release], { cfg: CFG });
-    // gitPush is vcs-remote — release owns fs-write + vcs-read, NOT vcs-remote
+    // gitPush is vcs-push — release owns fs-write + vcs-read, NOT vcs-remote
     obs.ingestRun({
       recipeName: "release-notes",
       at: 0,
@@ -151,7 +151,7 @@ describe("WorkerShadowObserver", () => {
     });
     const row = obs
       .report()[0]!
-      .board.find((b) => b.classKey.startsWith("vcs-remote"));
+      .board.find((b) => b.classKey.startsWith("vcs-push"));
     expect(row).toBeDefined();
     expect(row!.owned).toBe(false);
   });

--- a/src/workers/__tests__/shadowReport.test.ts
+++ b/src/workers/__tests__/shadowReport.test.ts
@@ -107,7 +107,7 @@ describe("formatShadowReport", () => {
   });
 
   it("annotates a NOT-OWNED class the worker performed (L3)", () => {
-    // release owns fs-write only; a gitPush (vcs-remote) it performs is shown
+    // release owns fs-write only; a gitPush (vcs-push) it performs is shown
     // but flagged because the live gate floors it to L0.
     const reports = buildShadowReport(
       [release],
@@ -122,7 +122,7 @@ describe("formatShadowReport", () => {
       CFG,
     );
     const text = formatShadowReport(reports);
-    expect(text).toContain("vcs-remote");
+    expect(text).toContain("vcs-push");
     expect(text).toContain("NOT OWNED");
   });
 });

--- a/src/workers/__tests__/workerGate.test.ts
+++ b/src/workers/__tests__/workerGate.test.ts
@@ -63,7 +63,7 @@ describe("decideWorkerAction", () => {
   });
 
   it("GATES a compensable/irreversible action the worker has not earned", () => {
-    const w = parseWorker({ id: "w", name: "W", owns: ["vcs-remote"] });
+    const w = parseWorker({ id: "w", name: "W", owns: ["vcs-push"] });
     const d = decideWorkerAction(w, "gitPush", {}, new WorkerLevelStore());
     expect(d.action).toBe("gate");
     expect(d.owned).toBe(true);
@@ -72,7 +72,7 @@ describe("decideWorkerAction", () => {
   });
 
   it("ALLOWS a risky action once the worker has earned L4 on it", () => {
-    const w = parseWorker({ id: "w", name: "W", owns: ["vcs-remote"] });
+    const w = parseWorker({ id: "w", name: "W", owns: ["vcs-push"] });
     const d = decideWorkerAction(w, "gitPush", {}, storeWithL4("w", "gitPush"));
     expect(d.earnedLevel).toBe(4);
     expect(d.effectiveLevel).toBe(4);
@@ -84,7 +84,7 @@ describe("decideWorkerAction", () => {
     const w = parseWorker({
       id: "w",
       name: "W",
-      owns: ["vcs-remote"],
+      owns: ["vcs-push"],
       autonomyCeiling: 1,
     });
     const d = decideWorkerAction(w, "gitPush", {}, storeWithL4("w", "gitPush"));
@@ -98,7 +98,7 @@ describe("decideWorkerAction", () => {
     const w = parseWorker({
       id: "w",
       name: "W",
-      owns: ["vcs-remote"],
+      owns: ["vcs-push"],
       autonomyCeiling: 2,
     });
     const d = decideWorkerAction(w, "gitPush", {}, storeWithL4("w", "gitPush"));
@@ -109,7 +109,7 @@ describe("decideWorkerAction", () => {
   });
 
   it("ALLOWS compensable once worker naturally earns L2 (no ceiling override)", () => {
-    const w = parseWorker({ id: "w", name: "W", owns: ["vcs-remote"] });
+    const w = parseWorker({ id: "w", name: "W", owns: ["vcs-push"] });
     const store = storeWithL2("w", "gitPush");
     const d = decideWorkerAction(w, "gitPush", {}, store);
     expect(d.earnedLevel).toBeGreaterThanOrEqual(2);
@@ -119,7 +119,7 @@ describe("decideWorkerAction", () => {
 
   it("GATES compensable at effective L1 (earnedLevel < 2)", () => {
     // Worker owns vcs-remote but has almost no evidence → L0/L1 → still gated.
-    const w = parseWorker({ id: "w", name: "W", owns: ["vcs-remote"] });
+    const w = parseWorker({ id: "w", name: "W", owns: ["vcs-push"] });
     const store = new WorkerLevelStore();
     store.apply("w", { toolName: "gitPush", good: true, at: 0 }, { cfg: CFG });
     const d = decideWorkerAction(w, "gitPush", {}, store);

--- a/src/workers/actionClass.ts
+++ b/src/workers/actionClass.ts
@@ -44,10 +44,13 @@ const DOMAIN_BY_TOOL: Record<string, string> = {
   gitCommit: "vcs-local",
   gitCheckout: "vcs-local",
   gitStash: "vcs-local",
-  // version control — remote / shared history
-  gitPush: "vcs-remote",
-  githubCreatePR: "vcs-remote",
-  githubMergePR: "vcs-remote",
+  // version control — remote / shared history.
+  // Each operation has its OWN domain so trust earned on one never unlocks
+  // another (trust-transfer prevention: a worker grinding PR creation must
+  // separately earn evidence on push, and separately on merge).
+  gitPush: "vcs-push", // can be force-reverted; compensable
+  githubCreatePR: "vcs-remote", // PR is a proposal; closeable
+  githubMergePR: "vcs-merge", // lands commits in main; hard to undo cleanly
   // filesystem
   editText: "fs-write",
   searchAndReplace: "fs-write",
@@ -89,8 +92,8 @@ const DOMAIN_BY_TOOL: Record<string, string> = {
   "file.append": "fs-write",
   "slack.post_message": "messaging",
   "http.post": "http",
-  "linear.list_issues": "issue",
-  "sentry.get_issue": "issue",
+  "linear.list_issues": "issue-read", // read-only; reversible
+  "sentry.get_issue": "issue-read", // read-only; reversible
   "diagnostics.get": "fs-read",
 };
 
@@ -99,13 +102,16 @@ const DOMAIN_BY_TOOL: Record<string, string> = {
 const REVERSIBILITY_BY_DOMAIN: Record<string, Reversibility> = {
   "vcs-read": "reversible",
   "vcs-local": "reversible", // reset / reflog / restore
-  "vcs-remote": "compensable", // force-push back / close PR — lossy, possible
+  "vcs-remote": "compensable", // close PR — lossy but possible
+  "vcs-push": "compensable", // force-revert / reflog — lossy but possible
+  "vcs-merge": "compensable", // git revert on main — painful but recoverable
   "fs-write": "reversible", // transactions + WriteEffectLedger
   "fs-read": "reversible",
   shell: "irreversible", // arbitrary side effects — assume unrecoverable
   messaging: "irreversible", // a sent message can't be unsent reliably
   http: "irreversible", // a POST may not be undoable
   issue: "compensable", // close / delete the created issue
+  "issue-read": "reversible", // read-only issue queries
   ci: "reversible", // re-runnable, no durable side effect
   "deps-read": "reversible",
   other: "irreversible",
@@ -115,6 +121,8 @@ const REVERSIBILITY_BY_DOMAIN: Record<string, Reversibility> = {
 const BRAND_EXPOSED_DOMAINS = new Set([
   "messaging",
   "vcs-remote",
+  "vcs-push",
+  "vcs-merge",
   "issue",
   "http",
 ]);

--- a/src/workers/shadowGate.ts
+++ b/src/workers/shadowGate.ts
@@ -42,6 +42,23 @@ export function recommend(
 ): ShadowDecision {
   const ac = classifyActionClass(toolName, params);
   const owned = ownsAction(worker, ac);
+
+  // Reversible actions always bypass — no trust threshold applies. Short-
+  // circuiting here prevents false divergence-log noise (the dial would
+  // otherwise compare against L4 and always report a "miss" for reads).
+  if (ac.reversibility === "reversible") {
+    const earnedLevel = (store.getState(worker.id, ac.key)?.level ??
+      0) as TrustLevel;
+    return {
+      decision: "bypass",
+      classKey: ac.key,
+      owned,
+      earnedLevel,
+      autonomyCeiling: worker.autonomyCeiling,
+      effectiveLevel: owned ? earnedLevel : (0 as TrustLevel),
+      reason: "reversible — flows un-gated regardless of earned level",
+    };
+  }
   const earnedLevel = (store.getState(worker.id, ac.key)?.level ??
     0) as TrustLevel;
 

--- a/src/workers/shadowObserver.ts
+++ b/src/workers/shadowObserver.ts
@@ -179,7 +179,7 @@ export class WorkerShadowObserver {
         gate: d.decision,
         at: d.at,
         note: rampBypass
-          ? "ramp would auto-run (earned L4); gate still gated"
+          ? `ramp would auto-run (${rec.reason}); gate still gated`
           : "ramp would gate; gate allowed",
       });
     }

--- a/src/workers/worker.ts
+++ b/src/workers/worker.ts
@@ -37,8 +37,10 @@ export interface WorkerManifest {
   /**
    * Policy/regulatory cap on the max ramp level this worker may EVER reach,
    * independent of earned track record — the schema encoding of the
-   * autonomy-tolerance axis (e.g. a Legal-sector worker is pinned at L2). The
-   * dial still shows *earned* level; the gate operates at min(earned, ceiling).
+   * autonomy-tolerance axis. The dial still shows *earned* level; the gate
+   * operates at min(earned, ceiling). Note: ceiling=2 is PERMISSIVE for
+   * compensable classes (they auto-allow at L2), not conservative — use
+   * ceiling=1 to keep compensable actions gated on a new or restricted worker.
    */
   autonomyCeiling: TrustLevel;
   /** Optional shipped competence → the per-class prior. */
@@ -99,10 +101,12 @@ export function parseWorker(raw: unknown): WorkerManifest {
       typeof c !== "object" ||
       c === null ||
       typeof c.mean !== "number" ||
-      typeof c.strength !== "number"
+      !Number.isFinite(c.mean) ||
+      typeof c.strength !== "number" ||
+      !Number.isFinite(c.strength)
     )
       throw new WorkerParseError(
-        "worker.competence must be { mean: number, strength: number }",
+        "worker.competence must be { mean: number, strength: number } (finite values)",
       );
     if (c.mean < 0 || c.mean > 1)
       throw new WorkerParseError("worker.competence.mean must be in [0,1]");

--- a/src/workers/workerGate.ts
+++ b/src/workers/workerGate.ts
@@ -131,7 +131,7 @@ export function decideWorkerAction(
     return {
       ...base,
       action: "allow",
-      reason: `earned autonomy (L${effectiveLevel}) on compensable class — auto-allowed at L2+`,
+      reason: `earned autonomy (L${effectiveLevel}) on compensable class — auto-allowed at L${COMPENSABLE_AUTONOMY_LEVEL}+`,
     };
   }
 


### PR DESCRIPTION
## Summary

Implements critical + high fixes surfaced by 5-lens adversarial review of PRs #1036 and #1037.

**Critical**
- `actionClass`: split `gitPush→vcs-push` and `githubMergePR→vcs-merge` into distinct domains — trust earned on PR creation can no longer unlock git push (trust-transfer attack prevention)
- `riskTier`: add `githubMergePR: "high"` and `githubApprovePR: "high"` to TIER_MAP — previously fell through `inferTierFromName` to "medium", letting workers auto-approve merges under `approvalGate: "high"` policy

**High**
- `shadowGate`: add reversible short-circuit at top of `recommend()` — reversible actions always bypass, stopping false divergence-log noise (reads were being compared against the L4 threshold, inflating "ramp-missed-gate" counts)
- `worker`: update `autonomyCeiling=2` docstring (permissive for compensable, not conservative as written); add `Number.isFinite` check on `competence.strength` (NaN passed `typeof === "number"` and propagated through all Bayesian math)
- `workerGate`: fix hardcoded `"L2+"` string → `L${COMPENSABLE_AUTONOMY_LEVEL}+`
- `shadowObserver`: fix hardcoded `"earned L4"` divergence note → `rec.reason` (would show wrong threshold after compensable-at-L2 unlock)

**Also**
- `linear.list_issues` + `sentry.get_issue` → `issue-read` domain (reversible, not compensable — read ops)
- `shadowGate` tests: full coverage of reversible bypass, compensable-at-L2 bypass, ceiling=1 blocks compensable, irreversible queues below L4

## Test plan
- [x] `npx vitest run src/workers` — 79 tests pass (11 new shadowGate tests)
- [x] `npm run build` — clean
- [x] `npx biome check --write` — clean
- [x] All domain-rename ripples updated across test files

🤖 Generated with [Claude Code](https://claude.com/claude-code)