### PR TITLE
fix(workers): trust evidence durability + agent-step autonomy sandbox

### DIFF
--- a/src/__tests__/recipeOrchestration.workerGate.test.ts
+++ b/src/__tests__/recipeOrchestration.workerGate.test.ts
@@ -18,7 +18,10 @@ import {
   resetApprovalQueueForTests,
 } from "../approvalQueue.js";
 import { FLAG_WORKER_AUTONOMY, setFlag } from "../featureFlags.js";
-import { buildWorkerAutonomyGate } from "../recipeOrchestration.js";
+import {
+  buildWorkerAgentDisallowedTools,
+  buildWorkerAutonomyGate,
+} from "../recipeOrchestration.js";
 
 const WORKER_YAML = `id: test-worker
 name: Test Worker
@@ -146,5 +149,48 @@ describe("buildWorkerAutonomyGate", () => {
     expect(getApprovalQueue().list()).toHaveLength(1);
     ac.abort(); // run cancelled → pending approval resolves "cancelled"
     expect(await p).toBe(false);
+  });
+});
+
+describe("buildWorkerAgentDisallowedTools (agent-step bypass)", () => {
+  let dir: string;
+  let opts: { workersDir: string; patchworkDir: string };
+
+  beforeEach(() => {
+    dir = mkdtempSync(path.join(os.tmpdir(), "pw-wagent-"));
+    const workersDir = path.join(dir, "workers");
+    mkdirSync(workersDir, { recursive: true });
+    writeFileSync(path.join(workersDir, "test.worker.yaml"), WORKER_YAML);
+    opts = { workersDir, patchworkDir: dir }; // empty patchworkDir → unearned
+    setFlag(FLAG_WORKER_AUTONOMY, true, false);
+  });
+
+  afterEach(() => {
+    setFlag(FLAG_WORKER_AUTONOMY, false, false);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("returns null when the flag is off", async () => {
+    setFlag(FLAG_WORKER_AUTONOMY, false, false);
+    expect(
+      await buildWorkerAgentDisallowedTools("test-recipe", opts),
+    ).toBeNull();
+  });
+
+  it("returns null when no worker owns the recipe", async () => {
+    expect(
+      await buildWorkerAgentDisallowedTools("unknown-recipe", opts),
+    ).toBeNull();
+  });
+
+  it("blocks risky-unearned tools (both forms) but not reversible ones", async () => {
+    const list = await buildWorkerAgentDisallowedTools("test-recipe", opts);
+    expect(list).not.toBeNull();
+    expect(list).toContain("gitPush");
+    expect(list).toContain("mcp__patchwork__gitPush");
+    expect(list).toContain("Bash");
+    // reversible tools the agent legitimately needs stay callable
+    expect(list).not.toContain("editText");
+    expect(list).not.toContain("getGitStatus");
   });
 });

--- a/src/recipeOrchestration.ts
+++ b/src/recipeOrchestration.ts
@@ -169,6 +169,45 @@ export async function buildWorkerAutonomyGate(
   }
 }
 
+/**
+ * The `--disallowed-tools` an `agent` step must inherit when a worker owns this
+ * recipe (worker.autonomy flag on). An agent step spawns a Claude subprocess
+ * whose internal tool calls bypass the per-step worker gate — so without this a
+ * worker could perform via its agent exactly the risky action the gate would
+ * have queued. We re-apply the worker's autonomy boundary as a subprocess
+ * sandbox: every tool the worker can't currently run autonomously is denied.
+ *
+ * Returns null when the flag is off, no worker owns the recipe, or the worker
+ * is fully trusted on everything (nothing to block) — callers then leave agent
+ * steps byte-identical. Fail-soft: any resolution error → null (never crash a
+ * run, never widen access).
+ */
+export async function buildWorkerAgentDisallowedTools(
+  recipeName: string,
+  trustOpts?: import("./workers/runWorkerShadow.js").RunWorkerShadowOpts,
+): Promise<string[] | null> {
+  try {
+    const { isEnabled, FLAG_WORKER_AUTONOMY } = await import(
+      "./featureFlags.js"
+    );
+    if (!isEnabled(FLAG_WORKER_AUTONOMY)) return null;
+
+    const { loadWorkerTrustForRecipe } = await import(
+      "./workers/runWorkerShadow.js"
+    );
+    const trust = loadWorkerTrustForRecipe(recipeName, trustOpts);
+    if (!trust) return null;
+
+    const { disallowedToolsForAgentStep } = await import(
+      "./workers/workerGate.js"
+    );
+    const list = disallowedToolsForAgentStep(trust.worker, trust.store);
+    return list.length ? list : null;
+  } catch {
+    return null;
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Public interfaces
 // ---------------------------------------------------------------------------
@@ -1108,6 +1147,13 @@ export class RecipeOrchestration {
     );
     const requireApprovalFn = workerApprovalFn ?? tierApprovalFn;
     const gateAutomatedRuns = workerApprovalFn != null;
+    // Agent-step bypass guard: when a worker owns this recipe, its agent steps
+    // inherit a `--disallowed-tools` list covering everything the worker can't
+    // run autonomously (the subprocess's internal tool calls don't pass through
+    // the per-step gate). Null for non-worker recipes → agent steps unchanged.
+    const agentDisallowedTools = await buildWorkerAgentDisallowedTools(
+      opts.name,
+    );
     const runnerDeps = {
       workdir: this.deps.workdir,
       claudeCodeFn,
@@ -1120,6 +1166,7 @@ export class RecipeOrchestration {
       ...(this.deps.activityLog && { activityLog: this.deps.activityLog }),
       ...(requireApprovalFn && { requireApprovalFn }),
       ...(gateAutomatedRuns && { gateAutomatedRuns: true }),
+      ...(agentDisallowedTools && { agentDisallowedTools }),
     };
     // Pass the bridge's long-lived RecipeRunLog so chainedRunner can flip the
     // run from `running` → terminal in-place via startRun/completeRun. The

--- a/src/recipes/__tests__/agentExecutor.test.ts
+++ b/src/recipes/__tests__/agentExecutor.test.ts
@@ -294,6 +294,79 @@ describe("unknown driver", () => {
   });
 });
 
+// ── 9b. enforceSandbox: worker-mandated sandbox needs the subprocess driver ──
+// A worker agent step's --disallowed-tools is enforced ONLY by the subprocess
+// driver. On any other driver the deny list is dropped, re-opening the bypass.
+// enforceSandbox makes executeAgent fail CLOSED instead of running un-sandboxed.
+
+describe("enforceSandbox (worker autonomy never-widen guard)", () => {
+  afterEach(() => {
+    delete process.env.ANTHROPIC_API_KEY;
+  });
+
+  it.each([
+    "anthropic",
+    "claude",
+    "openai",
+    "grok",
+    "gemini",
+    "local",
+  ])("refuses to run on non-subprocess driver %s; no driver fn called", async (driver) => {
+    const deps = makeDeps();
+    const result = await executeAgent(
+      { driver, prompt: "hi", enforceSandbox: true, disallowedTools: ["x"] },
+      deps,
+    );
+    expect(result.text).toMatch(/\[agent step failed:.*subprocess/);
+    expect(deps.anthropicFn).not.toHaveBeenCalled();
+    expect(deps.providerDriverFn).not.toHaveBeenCalled();
+    expect(deps.localFn).not.toHaveBeenCalled();
+    expect(deps.claudeCliFn).not.toHaveBeenCalled();
+  });
+
+  it("refuses to run on auto-detect when ANTHROPIC_API_KEY is set", async () => {
+    process.env.ANTHROPIC_API_KEY = "sk-test";
+    const deps = makeDeps({ loadPatchworkConfig: vi.fn().mockReturnValue({}) });
+    const result = await executeAgent(
+      { prompt: "hi", enforceSandbox: true },
+      deps,
+    );
+    expect(result.text).toMatch(/\[agent step failed:/);
+    expect(deps.anthropicFn).not.toHaveBeenCalled();
+  });
+
+  it("ALLOWS the subprocess driver and forwards the deny list", async () => {
+    const deps = makeDeps();
+    const result = await executeAgent(
+      {
+        driver: "claude-code",
+        prompt: "hi",
+        enforceSandbox: true,
+        disallowedTools: ["gitPush"],
+      },
+      deps,
+    );
+    expect(result.text).toBe("claude-cli-result");
+    expect(deps.claudeCliFn).toHaveBeenCalledWith("hi", {
+      disallowedTools: ["gitPush"],
+    });
+  });
+
+  it("ALLOWS auto-detect when the claude CLI is present (no API key)", async () => {
+    delete process.env.ANTHROPIC_API_KEY;
+    const deps = makeDeps({
+      loadPatchworkConfig: vi.fn().mockReturnValue({}),
+      probeClaudeCli: vi.fn().mockReturnValue(true),
+    });
+    const result = await executeAgent(
+      { prompt: "hi", enforceSandbox: true },
+      deps,
+    );
+    expect(result.servedBy?.driver).toBe("subprocess");
+    expect(deps.claudeCliFn).toHaveBeenCalled();
+  });
+});
+
 // ── 10. servedBy is idempotent — a dep that already set it is preserved ──────
 
 describe("servedBy stamping", () => {

--- a/src/recipes/agentExecutor.ts
+++ b/src/recipes/agentExecutor.ts
@@ -86,6 +86,16 @@ export interface AgentExecutorInput {
   /** Deny rules via --disallowed-tools (any mode). */
   disallowedTools?: string[];
   /**
+   * Worker-autonomy hard requirement. When true, this agent step carries a
+   * worker-mandated tool sandbox (see disallowedToolsForAgentStep) that ONLY the
+   * subprocess / claude-code driver can enforce (`--disallowed-tools`). Every
+   * other driver structurally drops the deny list, which would silently re-open
+   * the exact agent-bypass the sandbox exists to close (a NEVER-WIDEN hole). So
+   * when this is set and the resolved driver is not sandbox-enforcing, executeAgent
+   * REFUSES to run the step (fail-closed) instead of running it un-sandboxed.
+   */
+  enforceSandbox?: boolean;
+  /**
    * Opaque per-call driver options forwarded to the provider driver (e.g.
    * `{ responseFormat: { type: "json_object" } }` for constrained decoding).
    * Only the provider-driver path (openai/grok/gemini-api) consumes it; other
@@ -101,6 +111,27 @@ export interface AgentExecutorInput {
  */
 export const DEFAULT_MODEL = "claude-haiku-4-5-20251001";
 
+/**
+ * Will `executeAgent` route this call to the subprocess (`claude -p`) driver —
+ * the ONLY driver that enforces `--disallowed-tools`? Mirrors the dispatch in
+ * `executeAgent` exactly (explicit driver, then pwCfg, then auto-detect) so the
+ * worker-sandbox guard agrees with where the call actually lands. `probeClaudeCli`
+ * / `loadPatchworkConfig` are cheap + idempotent, so calling them here too is fine.
+ */
+function resolvesToSubprocessDriver(
+  driver: string | undefined,
+  deps: AgentExecutorDeps,
+): boolean {
+  if (driver === "subprocess" || driver === "claude-code") return true;
+  if (driver !== undefined) return false; // anthropic/claude/openai/grok/gemini*/local
+  const pwCfg = deps.loadPatchworkConfig();
+  if (pwCfg.model === "local") return false;
+  if (pwCfg.driver === "subprocess" || pwCfg.driver === "claude-code")
+    return true;
+  if (process.env.ANTHROPIC_API_KEY) return false; // auto-detect → anthropic API
+  return deps.probeClaudeCli(); // CLI present → subprocess; else falls back to API
+}
+
 export async function executeAgent(
   input: AgentExecutorInput,
   deps: AgentExecutorDeps,
@@ -114,7 +145,21 @@ export async function executeAgent(
     allowedTools,
     disallowedTools,
     providerOptions,
+    enforceSandbox,
   } = input;
+
+  // NEVER-WIDEN guard. A worker-mandated sandbox is enforceable only on the
+  // subprocess driver; on any other driver the deny list is silently dropped and
+  // the worker's agent step could perform exactly the risky action the gate
+  // believed it sandboxed. Fail closed: refuse to run rather than run un-gated.
+  // The "[agent step failed:" prefix is the marker the runners already treat as a
+  // step failure (halting non-optional steps), so the agent never executes.
+  if (enforceSandbox && !resolvesToSubprocessDriver(driver, deps)) {
+    return {
+      text: "[agent step failed: worker autonomy requires the subprocess driver to enforce its tool sandbox — set the agent step (or recipe) driver to `subprocess`/`claude-code`; refusing to run un-sandboxed]",
+      servedBy: { driver: driver ?? "auto" },
+    };
+  }
   const cliOpts =
     mcpAccess !== undefined ||
     sandbox !== undefined ||

--- a/src/recipes/yamlRunner.ts
+++ b/src/recipes/yamlRunner.ts
@@ -53,6 +53,7 @@ import type { RecipeRunLog } from "../runLog.js";
  */
 import { sanitizeParsedJson as sanitizeParsed } from "../sanitizeParsedJson.js";
 import { ensureCmdShim } from "../winShim.js";
+import { mergeAgentDisallowedTools } from "../workers/workerGate.js";
 import {
   executeAgent as _executeAgent,
   type AgentExecutorDeps,
@@ -638,6 +639,15 @@ export interface RunnerDeps {
    * Unset/false → manual-only gating, byte-identical to pre-flip behaviour.
    */
   gateAutomatedRuns?: boolean;
+  /**
+   * Worker agent-step sandbox (worker.autonomy flag). When a worker owns the
+   * recipe, this is the `--disallowed-tools` list its `agent` steps must inherit
+   * so the spawned Claude subprocess can't call tools the worker hasn't earned
+   * autonomy on (the subprocess's internal tool calls bypass the per-step gate).
+   * Merged with each step's own `agent.disallowedTools`. Unset for non-worker
+   * recipes → agent steps are byte-identical to pre-flip behaviour.
+   */
+  agentDisallowedTools?: string[];
 }
 
 export interface RunResult {
@@ -745,6 +755,9 @@ export type StepDeps = Required<
     // StepDeps; keep it off StepDeps so it isn't forced Required here.
     | "requireApprovalFn"
     | "gateAutomatedRuns"
+    // Agent-step sandbox is read in the agent branch against `deps`, not per-
+    // step StepDeps; keep it off StepDeps so it isn't forced Required here.
+    | "agentDisallowedTools"
     // Cancellation is checked in the run loop against `deps`, not per-step;
     // keep it off StepDeps so it isn't forced Required here.
     | "signal"
@@ -1397,9 +1410,18 @@ export async function runYamlRecipe(
         ...(sandboxOpts?.tools !== undefined && {
           allowedTools: sandboxOpts.tools,
         }),
-        ...(sandboxOpts?.disallowedTools !== undefined && {
-          disallowedTools: sandboxOpts.disallowedTools,
-        }),
+        // Worker.autonomy: a sandboxed step STAYS sandboxed across re-runs AND
+        // inherits the worker's agent-step deny list (same merge as the primary
+        // agent branch), so refine-loop re-runs can't bypass the gate either.
+        ...(() => {
+          const merged = mergeAgentDisallowedTools(
+            sandboxOpts?.disallowedTools,
+            deps.agentDisallowedTools,
+          );
+          return merged !== undefined ? { disallowedTools: merged } : {};
+        })(),
+        // Fail closed if a worker sandbox can't be enforced on the chosen driver.
+        ...(deps.agentDisallowedTools?.length && { enforceSandbox: true }),
         ...(providerOptions && { providerOptions }),
       },
       buildAgentExecutorDeps(stepDeps, deps),
@@ -1863,6 +1885,12 @@ export async function runYamlRecipe(
             renderedPrompt,
             runBudget,
           );
+          // Worker.autonomy: fold the worker's agent-step sandbox into this
+          // step's own deny list so the subprocess can't bypass the gate.
+          const agentDisallowed = mergeAgentDisallowedTools(
+            agentCfg.disallowedTools,
+            deps.agentDisallowedTools,
+          );
           const agentReturn = await _executeAgent(
             {
               prompt: renderedPrompt,
@@ -1880,8 +1908,13 @@ export async function runYamlRecipe(
               ...(agentCfg.tools !== undefined && {
                 allowedTools: agentCfg.tools,
               }),
-              ...(agentCfg.disallowedTools !== undefined && {
-                disallowedTools: agentCfg.disallowedTools,
+              ...(agentDisallowed !== undefined && {
+                disallowedTools: agentDisallowed,
+              }),
+              // Worker sandbox is enforceable only on the subprocess driver;
+              // fail closed on any other driver rather than run un-sandboxed.
+              ...(deps.agentDisallowedTools?.length && {
+                enforceSandbox: true,
               }),
               // Constrained decoding: enforce a pure-JSON verdict on judge steps
               // (OpenAI-compatible drivers honor it; others ignore it). Pairs
@@ -3427,8 +3460,19 @@ export function buildChainedDeps(
         ...(opts?.allowedTools !== undefined && {
           allowedTools: opts.allowedTools,
         }),
-        ...(opts?.disallowedTools !== undefined && {
-          disallowedTools: opts.disallowedTools,
+        // Worker.autonomy: single chokepoint for the CHAINED path — fold the
+        // worker's agent-step deny list into every chained agent call so the
+        // subprocess can't bypass the per-step gate (mirrors the flat branch).
+        ...(() => {
+          const merged = mergeAgentDisallowedTools(
+            opts?.disallowedTools,
+            runnerDeps.agentDisallowedTools,
+          );
+          return merged !== undefined ? { disallowedTools: merged } : {};
+        })(),
+        // Fail closed if a worker sandbox can't be enforced on the chosen driver.
+        ...(runnerDeps.agentDisallowedTools?.length && {
+          enforceSandbox: true,
         }),
       },
       buildAgentExecutorDeps(stepDeps, runnerDeps, claudeCodeFnOverride),

--- a/src/runLog.ts
+++ b/src/runLog.ts
@@ -188,7 +188,10 @@ const DEFAULT_MEMORY_CAP = 500;
  * the most recent N lines.
  */
 const MAX_PERSIST_BYTES = 1024 * 1024; // 1 MB
-const MAX_PERSIST_LINES = 10_000;
+/** Disk-retention line cap. Exported so a reader that must see the FULL retained
+ *  history (e.g. worker trust replay) can size its in-memory ring to match the
+ *  disk, instead of being silently bounded by DEFAULT_MEMORY_CAP. */
+export const MAX_PERSIST_LINES = 10_000;
 
 export interface RunLogOptions {
   /** Directory holding runs.jsonl. Created if missing. */

--- a/src/workers/__tests__/graduation.test.ts
+++ b/src/workers/__tests__/graduation.test.ts
@@ -135,6 +135,65 @@ describe("graduation — demote cooldown", () => {
   });
 });
 
+describe("graduation — config tightening does not retroactively demote", () => {
+  it("a class earned under a loose floor is NOT demoted when the floor is raised", () => {
+    const key = classifyActionClass(EDIT).key;
+    // Climb to L4 under the loose test config (minEvidenceForGraduation=5).
+    let { state } = runSeq(
+      initialState(key, DEFAULT_PRIOR),
+      goods(EDIT, 60, 0),
+    );
+    ({ state } = runSeq(
+      state,
+      [1000, 2000, 3000, 4000].map((at) => ({
+        toolName: EDIT,
+        good: true,
+        at,
+      })),
+    ));
+    expect(state.level).toBe(4);
+    // The threshold it graduated under is recorded on the state.
+    expect(state.minEvidenceAtLastPromotion).toBe(5);
+
+    // Operator RAISES minEvidenceForGraduation far above the accrued evidence.
+    // The novel-class floor is a COLD-START gate — raising it must not claw back
+    // an already-earned level. One more clean outcome must NOT demote.
+    const tightened: GraduationConfig = {
+      ...CFG,
+      minEvidenceForGraduation: 1000,
+    };
+    const after = graduate(
+      state,
+      { toolName: EDIT, good: true, at: 5000 },
+      tightened,
+    );
+    expect(after.event?.type).not.toBe("demote");
+    expect(after.state.level).toBe(4);
+  });
+
+  it("a cold-start class still faces the CURRENT (raised) floor", () => {
+    // A class that has NOT cleared L1 uses the live config, so raising the floor
+    // correctly slows a fresh climb (no retroactive protection for cold-start).
+    const key = classifyActionClass(EDIT).key;
+    const tightened: GraduationConfig = {
+      ...CFG,
+      minEvidenceForGraduation: 1000,
+    };
+    const { state } = runSeq(
+      initialState(key, DEFAULT_PRIOR),
+      goods(EDIT, 60, 0),
+      tightened,
+    );
+    const climb = runSeq(
+      state,
+      [1000, 2000].map((at) => ({ toolName: EDIT, good: true, at })),
+      tightened,
+    );
+    // floor (evidence ~62 < 1000) caps at L1 — no promotion past L1.
+    expect(climb.state.level).toBeLessThanOrEqual(1);
+  });
+});
+
 describe("graduation — irreversible class jumps L1→L4", () => {
   it("never visits L2/L3 for an irreversible class", () => {
     const key = classifyActionClass(SHELL).key;

--- a/src/workers/__tests__/runWorkerShadow.test.ts
+++ b/src/workers/__tests__/runWorkerShadow.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -32,6 +32,82 @@ describe("getWorkerShadowData", () => {
     expect(data.workers[0]).toHaveProperty("autonomyCeiling");
     expect(data.runsScanned).toBe(0);
     expect(data.decisionsScanned).toBe(0);
+  });
+
+  it("retains a buried worker run on the dial behind >100 unrelated runs", () => {
+    // Dial-path twin of the live-gate regression: getWorkerShadowData must
+    // filter runs by the loaded workers' recipes, not read the global last-100.
+    const log = new RecipeRunLog({ dir: emptyDir });
+    log.appendDirect({
+      taskId: "rel",
+      recipeName: "release-notes",
+      trigger: "recipe",
+      status: "done",
+      createdAt: 0,
+      doneAt: 1,
+      durationMs: 1,
+      stepResults: [
+        { id: "s1", tool: "editText", status: "ok", durationMs: 1 },
+      ],
+    });
+    for (let i = 0; i < 150; i++) {
+      log.appendDirect({
+        taskId: `noise-${i}`,
+        recipeName: "some-unrelated-recipe",
+        trigger: "recipe",
+        status: "done",
+        createdAt: 10 + i,
+        doneAt: 11 + i,
+        durationMs: 1,
+        stepResults: [
+          { id: `n${i}`, tool: "editText", status: "ok", durationMs: 1 },
+        ],
+      });
+    }
+    const data = getWorkerShadowData({
+      workersDir: WORKERS_DIR,
+      patchworkDir: emptyDir,
+      ideDir: emptyDir,
+    });
+    const rel = data.workers.find((w) => w.workerId === "release-notes-worker");
+    expect(rel?.board.length).toBeGreaterThan(0);
+  });
+
+  it("does NOT double-count evidence when two workers share a recipe (dedup)", () => {
+    // Two manifests declaring the same recipe → recipeNames has a duplicate. An
+    // un-deduped flatMap would query that recipe twice and ingest every run
+    // twice, doubling the dial's evidence (a dial-vs-gate divergence). readRuns
+    // dedups, so the owning (first-match) worker counts each run exactly once.
+    const wdir = path.join(emptyDir, "dup-workers");
+    mkdirSync(wdir, { recursive: true });
+    const mk = (id: string) =>
+      `id: ${id}\nname: ${id}\nrecipe: dup-recipe\nowns:\n  - fs-write\nautonomyCeiling: 4\n`;
+    writeFileSync(path.join(wdir, "a.worker.yaml"), mk("worker-a"));
+    writeFileSync(path.join(wdir, "b.worker.yaml"), mk("worker-b"));
+
+    const log = new RecipeRunLog({ dir: emptyDir });
+    log.appendDirect({
+      taskId: "r1",
+      recipeName: "dup-recipe",
+      trigger: "recipe",
+      status: "done",
+      createdAt: 0,
+      doneAt: 1,
+      durationMs: 1,
+      stepResults: [
+        { id: "s1", tool: "editText", status: "ok", durationMs: 1 },
+      ],
+    });
+
+    const data = getWorkerShadowData({
+      workersDir: wdir,
+      patchworkDir: emptyDir,
+      ideDir: emptyDir,
+    });
+    // exactly ONE observation on the first-match worker's fs-write class, not 2.
+    const owner = data.workers.find((w) => w.board.length > 0);
+    const fsWrite = owner?.board.find((b) => b.classKey.startsWith("fs-write"));
+    expect(fsWrite?.observations).toBe(1);
   });
 
   it("returns no workers when the workers dir is absent", () => {
@@ -98,6 +174,93 @@ describe("loadWorkerTrustForRecipe (live-gate entry)", () => {
     const board = trust?.store.board("release-notes-worker") ?? [];
     expect(board.length).toBeGreaterThan(0);
     expect(board.some((b) => b.classKey.startsWith("fs-write"))).toBe(true);
+  });
+
+  it("retains a worker's evidence behind >500 unrelated runs (ring not just window)", () => {
+    // Stronger than the 150-run case: the in-memory ring defaults to 500, so a
+    // worker run buried behind >500 unrelated runs would be evicted from the ring
+    // entirely (the per-recipe filter runs AFTER ring eviction). readRuns sizes
+    // the ring to the full disk retention, so the worker run survives.
+    const log = new RecipeRunLog({ dir });
+    log.appendDirect({
+      taskId: "worker-run",
+      recipeName: "release-notes",
+      trigger: "recipe",
+      status: "done",
+      createdAt: 0,
+      doneAt: 1,
+      durationMs: 1,
+      stepResults: [
+        { id: "s1", tool: "editText", status: "ok", durationMs: 1 },
+      ],
+    });
+    for (let i = 0; i < 600; i++) {
+      log.appendDirect({
+        taskId: `noise-${i}`,
+        recipeName: "some-unrelated-recipe",
+        trigger: "recipe",
+        status: "done",
+        createdAt: 10 + i,
+        doneAt: 11 + i,
+        durationMs: 1,
+        stepResults: [
+          { id: `n${i}`, tool: "editText", status: "ok", durationMs: 1 },
+        ],
+      });
+    }
+    const trust = loadWorkerTrustForRecipe("release-notes", {
+      workersDir: WORKERS_DIR,
+      patchworkDir: dir,
+    });
+    expect(
+      (trust?.store.board("release-notes-worker") ?? []).length,
+    ).toBeGreaterThan(0);
+  });
+
+  it("retains a worker's evidence behind >100 newer unrelated runs (window eviction)", () => {
+    // Regression: readRuns used query({}) (default limit 100). A low-frequency
+    // worker's run buried behind >100 newer UNRELATED recipe runs aged out of
+    // the window → the live gate saw zero evidence and silently floored the
+    // worker to L0. This is exactly why test-guardian showed an empty dial
+    // despite a real, correctly-executed run.
+    const log = new RecipeRunLog({ dir });
+    // One real worker run with a clean owned step (oldest by `at`).
+    log.appendDirect({
+      taskId: "worker-run",
+      recipeName: "release-notes",
+      trigger: "recipe",
+      status: "done",
+      createdAt: 0,
+      doneAt: 1,
+      durationMs: 1,
+      stepResults: [
+        { id: "s1", tool: "editText", status: "ok", durationMs: 1 },
+      ],
+    });
+    // 150 unrelated (non-worker) runs AFTER it — these flood the default
+    // 100-run query window and would evict the single worker run.
+    for (let i = 0; i < 150; i++) {
+      log.appendDirect({
+        taskId: `noise-${i}`,
+        recipeName: "some-unrelated-recipe",
+        trigger: "recipe",
+        status: "done",
+        createdAt: 10 + i,
+        doneAt: 11 + i,
+        durationMs: 1,
+        stepResults: [
+          { id: `n${i}`, tool: "editText", status: "ok", durationMs: 1 },
+        ],
+      });
+    }
+    const trust = loadWorkerTrustForRecipe("release-notes", {
+      workersDir: WORKERS_DIR,
+      patchworkDir: dir,
+    });
+    expect(trust).not.toBeNull();
+    // The worker's run must still be visible despite the newer noise.
+    const board = trust?.store.board("release-notes-worker") ?? [];
+    expect(board.length).toBeGreaterThan(0);
   });
 
   it("a risky class can graduate to earned L4 via ascending replay (M2)", () => {

--- a/src/workers/__tests__/trustLevel.test.ts
+++ b/src/workers/__tests__/trustLevel.test.ts
@@ -46,7 +46,9 @@ describe("trustLevel — cold start", () => {
     const p = applyN(prior, 4, true, 1);
     const r = levelFromPosterior(p, prior, { reachable: ALL_REACHABLE });
     expect(evidenceCount(p, prior)).toBe(4);
-    expect(r.level).toBeGreaterThan(1); // floor no longer blocks
+    // LCB ≈ 0.892 → L3 by thresholds; floor lifted (effectiveEvidence=10).
+    // Pin the exact rung so a threshold/prior-math regression is caught.
+    expect(r.level).toBe(3);
   });
 
   it("default prior offers no cold-start reduction: 4 real obs still capped at L1", () => {

--- a/src/workers/__tests__/workerGate.test.ts
+++ b/src/workers/__tests__/workerGate.test.ts
@@ -2,7 +2,12 @@ import { describe, expect, it } from "vitest";
 import { classifyActionClass } from "../actionClass.js";
 import type { GraduationConfig } from "../graduation.js";
 import { parseWorker } from "../worker.js";
-import { decideWorkerAction, flowsUngated } from "../workerGate.js";
+import {
+  decideWorkerAction,
+  disallowedToolsForAgentStep,
+  flowsUngated,
+  mergeAgentDisallowedTools,
+} from "../workerGate.js";
 import { WorkerLevelStore } from "../workerLevelStore.js";
 
 const CFG: GraduationConfig = {
@@ -112,7 +117,9 @@ describe("decideWorkerAction", () => {
     const w = parseWorker({ id: "w", name: "W", owns: ["vcs-push"] });
     const store = storeWithL2("w", "gitPush");
     const d = decideWorkerAction(w, "gitPush", {}, store);
-    expect(d.earnedLevel).toBeGreaterThanOrEqual(2);
+    // Pin the exact earned rung (the helper is built to land at L2) so a
+    // graduation-curve regression that over- or under-shoots is caught.
+    expect(d.earnedLevel).toBe(2);
     expect(d.action).toBe("allow");
     expect(d.reason).toContain("L2+");
   });
@@ -146,5 +153,91 @@ describe("decideWorkerAction", () => {
     expect(d.effectiveLevel).toBe(0);
     expect(d.action).toBe("gate");
     expect(d.reason).toContain("outside");
+  });
+});
+
+describe("disallowedToolsForAgentStep (agent-bypass sandbox)", () => {
+  it("blocks risky tools the worker can't run autonomously, not reversible ones", () => {
+    const w = parseWorker({ id: "w", name: "W", owns: ["fs-write"] });
+    const blocked = disallowedToolsForAgentStep(w, new WorkerLevelStore());
+    // risky (compensable/irreversible) tools the worker can't do → blocked,
+    // in BOTH the bare form (native CC tools) and the bridge MCP form so a
+    // claude -p `--disallowed-tools` actually denies the MCP call.
+    expect(blocked).toContain("gitPush");
+    expect(blocked).toContain("mcp__patchwork__gitPush");
+    expect(blocked).toContain("githubMergePR");
+    expect(blocked).toContain("slackPostMessage");
+    expect(blocked).toContain("runCommand");
+    // native CC shell tool is blocked too (the primary agent side-effect vector)
+    expect(blocked).toContain("Bash");
+    // reversible tools flow un-gated → NEVER blocked (the agent needs them)
+    expect(blocked).not.toContain("getGitStatus");
+    expect(blocked).not.toContain("editText");
+    expect(blocked).not.toContain("mcp__patchwork__editText");
+    // the reasoning step itself is never self-blocked
+    expect(blocked).not.toContain("agent");
+    // recipe-DSL ids (with a ".") are never emitted — the subprocess can't call
+    // them; only their camelCase MCP twin is.
+    expect(blocked.some((t) => t.includes("."))).toBe(false);
+    // Harmless read/nav tools classify as other:irreversible:low — they must NOT
+    // be over-blocked, or the agent loses the tools it needs to investigate.
+    for (const read of [
+      "getDiagnostics",
+      "searchWorkspace",
+      "goToDefinition",
+      "getHover",
+    ]) {
+      expect(blocked).not.toContain(read);
+    }
+  });
+
+  it("does NOT block a risky tool the worker has EARNED autonomy on", () => {
+    // owns vcs-push + earned L4 on gitPush → the agent may use it.
+    const w = parseWorker({ id: "w", name: "W", owns: ["vcs-push"] });
+    const blocked = disallowedToolsForAgentStep(w, storeWithL4("w", "gitPush"));
+    expect(blocked).not.toContain("gitPush");
+    // a DIFFERENT risky class it has not earned is still blocked.
+    expect(blocked).toContain("githubMergePR");
+  });
+
+  it("a lowered autonomy ceiling blocks even an earned risky tool", () => {
+    // earned L4 on gitPush but ceiling L1 → effective L1 < L2 → gated → blocked.
+    const w = parseWorker({
+      id: "w",
+      name: "W",
+      owns: ["vcs-push"],
+      autonomyCeiling: 1,
+    });
+    const blocked = disallowedToolsForAgentStep(w, storeWithL4("w", "gitPush"));
+    expect(blocked).toContain("gitPush");
+  });
+});
+
+describe("mergeAgentDisallowedTools", () => {
+  it("unions + dedups + sorts when a worker list is present", () => {
+    expect(mergeAgentDisallowedTools(["b", "a"], ["a", "c"])).toEqual([
+      "a",
+      "b",
+      "c",
+    ]);
+    expect(mergeAgentDisallowedTools(undefined, ["c", "a", "a"])).toEqual([
+      "a",
+      "c",
+    ]);
+  });
+
+  it("returns undefined when both empty", () => {
+    expect(mergeAgentDisallowedTools(undefined, undefined)).toBeUndefined();
+    expect(mergeAgentDisallowedTools([], [])).toBeUndefined();
+  });
+
+  it("preserves the step's list VERBATIM when there is no worker list (non-worker byte-identical)", () => {
+    // order + duplicates retained — argv must match pre-flip behaviour exactly.
+    expect(mergeAgentDisallowedTools(["b", "a", "b"], undefined)).toEqual([
+      "b",
+      "a",
+      "b",
+    ]);
+    expect(mergeAgentDisallowedTools(["b", "a"], [])).toEqual(["b", "a"]);
   });
 });

--- a/src/workers/actionClass.ts
+++ b/src/workers/actionClass.ts
@@ -127,6 +127,16 @@ const BRAND_EXPOSED_DOMAINS = new Set([
   "http",
 ]);
 
+/**
+ * The tool names this module can classify (MCP names + recipe-tool ids). Exposed
+ * so the worker-agent sandbox can enumerate every risky tool to consider
+ * blocking. NOT exhaustive of the whole MCP surface — any unknown tool classifies
+ * as `other:irreversible` and is gated at the per-step gate regardless.
+ */
+export function knownActionTools(): string[] {
+  return Object.keys(DOMAIN_BY_TOOL);
+}
+
 export function classifyActionClass(
   toolName: string,
   _params?: Record<string, unknown>,

--- a/src/workers/graduation.ts
+++ b/src/workers/graduation.ts
@@ -41,6 +41,15 @@ export interface ClassTrustState {
   /** epoch ms before which promotions are blocked (post-demote cooldown). */
   demoteUntil: number;
   observations: number;
+  /**
+   * The `minEvidenceForGraduation` threshold in effect when this class last
+   * promoted ABOVE L1. The novel-class floor is a cold-start gate: once a class
+   * has cleared it, RAISING the config later must not retroactively re-apply the
+   * floor and demote an already-earned level. We honour the threshold the class
+   * actually graduated under. `undefined` = never promoted above L1 (cold-start;
+   * the current config applies in full).
+   */
+  minEvidenceAtLastPromotion?: number;
 }
 
 export interface GraduationConfig {
@@ -50,10 +59,14 @@ export interface GraduationConfig {
   minEvidenceForGraduation?: number;
 }
 
+/** Default novel-class floor — MUST match levelFromPosterior's internal `?? 10`
+ *  so a config that omits the field behaves identically through both paths. */
+const DEFAULT_MIN_EVIDENCE = 10;
+
 export const DEFAULT_GRADUATION_CONFIG: GraduationConfig = {
   dwellMs: 6 * 60 * 60 * 1000, // 6h between climbs
   demoteCooldownMs: 24 * 60 * 60 * 1000, // 24h freeze after a fall
-  minEvidenceForGraduation: 10,
+  minEvidenceForGraduation: DEFAULT_MIN_EVIDENCE,
 };
 
 export interface GraduationEvent {
@@ -93,9 +106,24 @@ export function graduate(
   const posterior = applyOutcome(state.posterior, outcome.good, weight);
   const observations = state.observations + 1;
 
+  // Novel-class floor threshold. For a class already ABOVE L1, honour the
+  // (possibly looser) threshold it graduated under so a later config TIGHTENING
+  // can't retroactively floor it back to L1 and trigger a spurious demote. A
+  // class still in cold-start (≤ L1) always faces the current config in full.
+  // `Math.min` also lets a config LOOSENING apply immediately. Genuine
+  // evidence-based demotions (LCB crash from real failures) are unaffected —
+  // they don't go through the floor.
+  // Resolve to a concrete number (matches levelFromPosterior's internal `?? 10`)
+  // so the recorded threshold is always defined.
+  const cfgMinEvidence = cfg.minEvidenceForGraduation ?? DEFAULT_MIN_EVIDENCE;
+  const floorMinEvidence =
+    state.level > 1 && state.minEvidenceAtLastPromotion !== undefined
+      ? Math.min(cfgMinEvidence, state.minEvidenceAtLastPromotion)
+      : cfgMinEvidence;
+
   const result = levelFromPosterior(posterior, state.prior, {
     k: cfg.k,
-    minEvidenceForGraduation: cfg.minEvidenceForGraduation,
+    minEvidenceForGraduation: floorMinEvidence,
     reachable: reachableLevels(ac),
   });
   const candidate = result.level;
@@ -140,7 +168,17 @@ export function graduate(
       if (nextRung !== undefined) {
         const to = nextRung as TrustLevel;
         return {
-          state: { ...base, level: to, lastChangeAt: outcome.at },
+          state: {
+            ...base,
+            level: to,
+            lastChangeAt: outcome.at,
+            // Record the floor it just cleared (only meaningful above L1, where
+            // the floor actually gates). Keeps the running threshold the class
+            // has demonstrably satisfied, for the retroactive-demotion guard.
+            ...(to > 1 && {
+              minEvidenceAtLastPromotion: floorMinEvidence,
+            }),
+          },
           event: {
             type: "promote",
             classKey: state.classKey,

--- a/src/workers/runWorkerShadow.ts
+++ b/src/workers/runWorkerShadow.ts
@@ -1,7 +1,7 @@
 import { readdirSync, readFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { RecipeRunLog } from "../runLog.js";
+import { MAX_PERSIST_LINES, RecipeRunLog } from "../runLog.js";
 import {
   type DecisionRecord,
   type RunRecord,
@@ -30,10 +30,37 @@ export interface RunWorkerShadowOpts {
   ideDir?: string;
 }
 
-function readRuns(patchworkDir: string): RunRecord[] {
+function readRuns(patchworkDir: string, recipeNames?: string[]): RunRecord[] {
   try {
-    const log = new RecipeRunLog({ dir: patchworkDir });
-    return log.query({}).map((r) => ({
+    // Size the in-memory ring to the FULL disk retention (MAX_PERSIST_LINES), not
+    // the default 500. `query()` only ever scans the ring, so with the default
+    // cap a low-frequency worker's run is evicted once >500 unrelated runs land
+    // after it — even with a per-recipe filter (the filter is applied AFTER ring
+    // eviction). Matching the ring to the disk cap means worker evidence is
+    // bounded only by what the log actually retains, not by global run volume.
+    const log = new RecipeRunLog({
+      dir: patchworkDir,
+      memoryCap: MAX_PERSIST_LINES,
+    });
+    // Query FILTERED BY the worker recipes — NOT the global last-N window.
+    // `query({})` defaults to the 100 most-recent runs, so a low-frequency
+    // worker's evidence ages out behind unrelated high-frequency recipe traffic
+    // (this is exactly why the test-guardian dial read empty despite a real,
+    // correctly-executed run). Filtering means only same-recipe runs compete for
+    // the window. DEDUP the names first: two manifests can declare the same
+    // recipe, and an un-deduped flatMap would query it twice → ingest every run
+    // twice → double-count the dial's evidence (a dial-vs-gate divergence, since
+    // the live gate passes a single recipe name).
+    const names = recipeNames?.length
+      ? Array.from(new Set(recipeNames))
+      : undefined;
+    // `query` clamps limit to 500, but it now scans the full-history ring, so
+    // this is the 500 most-recent runs OF THIS RECIPE — ample per-worker, and no
+    // longer evictable by unrelated traffic.
+    const rows = names
+      ? names.flatMap((recipe) => log.query({ recipe, limit: 500 }))
+      : log.query({ limit: 500 });
+    return rows.map((r) => ({
       recipeName: r.recipeName,
       at: r.doneAt ?? r.startedAt ?? r.createdAt,
       steps: (r.stepResults ?? []).map((s) => ({
@@ -122,7 +149,12 @@ export function getWorkerShadowData(
   const workersDir = opts.workersDir ?? path.join(patchworkDir, "workers");
 
   const workers = loadWorkersFromDir(workersDir);
-  const runs = workers.length ? readRuns(patchworkDir) : [];
+  const runs = workers.length
+    ? readRuns(
+        patchworkDir,
+        workers.map((w) => w.recipe).filter((r): r is string => !!r),
+      )
+    : [];
   const decisions = workers.length ? readDecisions(ideDir) : [];
   return {
     workers: buildShadowReport(workers, runs, decisions),
@@ -166,7 +198,9 @@ export function loadWorkerTrustForRecipe(
   // risky classes never promote — the earned-L4 path would be unreachable and
   // the gate would floor every compensable/irreversible class to L0 forever.
   // This mirrors buildShadowReport (the dial), so the gate and dial agree.
-  const runs = readRuns(patchworkDir).sort((a, b) => a.at - b.at);
+  // `recipeName` === the owning worker's recipe (workerForRecipe matched on it),
+  // so filter the replay to just this recipe's runs.
+  const runs = readRuns(patchworkDir, [recipeName]).sort((a, b) => a.at - b.at);
   for (const run of runs) observer.ingestRun(run);
   return { worker, store: observer.levelStore };
 }

--- a/src/workers/workerGate.ts
+++ b/src/workers/workerGate.ts
@@ -1,4 +1,9 @@
-import { type ActionClass, classifyActionClass } from "./actionClass.js";
+import { classifyTool, getRiskTierMap } from "../riskTier.js";
+import {
+  type ActionClass,
+  classifyActionClass,
+  knownActionTools,
+} from "./actionClass.js";
 import type { TrustLevel } from "./trustLevel.js";
 import { ownsAction, type WorkerManifest } from "./worker.js";
 import type { WorkerLevelStore } from "./workerLevelStore.js";
@@ -61,6 +66,12 @@ const COMPENSABLE_AUTONOMY_LEVEL = 2 as const;
 
 /** Irreversible actions (and unowned/unearned anything) require full L4. */
 const AUTONOMOUS_LEVEL = 4 as const;
+
+/** How the Claude subprocess sees bridge MCP tools under `--disallowed-tools`:
+ *  `mcp__<server>__<tool>`. The server name is fixed to `patchwork` by the
+ *  subprocess driver's writeMcpConfigFile, so the agent-step sandbox must block
+ *  this form (not just the bare tool name) to actually deny a bridge MCP call. */
+const BRIDGE_MCP_TOOL_PREFIX = "mcp__patchwork__";
 
 /**
  * Undoable → flows un-gated even when unearned. Only reversible actions are
@@ -157,4 +168,88 @@ export function decideWorkerAction(
     reason = `${ac.reversibility} + unearned (effective L${effectiveLevel} < L${threshold}) — gated for approval`;
   }
   return { ...base, action: "gate", reason };
+}
+
+/**
+ * Tools a worker's AGENT step must be barred from calling.
+ *
+ * An `agent` step spawns a Claude subprocess whose INTERNAL tool calls bypass
+ * the per-step worker gate (only recipe *steps* pass through `decideWorkerAction`
+ * — tools the subprocess invokes itself never do). Without this, a worker could
+ * do via its agent exactly the risky action (`gitPush`, `githubMergePR`,
+ * `slackPostMessage`, `runCommand`, …) the gate would otherwise have queued for
+ * approval. We re-apply the gate as a subprocess sandbox: every tool the worker
+ * cannot currently run autonomously (`decideWorkerAction → "gate"`) is added to
+ * the subprocess's `--disallowed-tools`.
+ *
+ * Honours the live trust state AND the autonomy ceiling (both fold into
+ * `decideWorkerAction`'s `effectiveLevel = min(earned, ceiling)`): reversible
+ * tools and risky tools the worker has EARNED stay callable; everything else is
+ * blocked. The universe is the canonical tool registry (TIER_MAP keys); params
+ * are unknown at sandbox-build time, so each tool is classified conservatively
+ * with empty params.
+ */
+export function disallowedToolsForAgentStep(
+  worker: WorkerManifest,
+  store: WorkerLevelStore,
+): string[] {
+  // Universe = the canonical risk-tier map (broad MCP coverage) ∪ the worker
+  // subsystem's own tool→domain map (adds messaging/http TIER_MAP omits).
+  // Neither alone is complete; the union is the best enumerable approximation of
+  // the risky tool surface.
+  const universe = new Set([
+    ...Object.keys(getRiskTierMap()),
+    ...knownActionTools(),
+  ]);
+  const blocked = new Set<string>();
+  for (const toolName of universe) {
+    // The agent step itself is always allowed (reasoning, not a durable side-
+    // effect — decideWorkerAction special-cases it); never self-block.
+    if (toolName === "agent") continue;
+    // Recipe-DSL ids (`github.create_issue`, `file.write`) are internal to the
+    // recipe runner — the Claude subprocess never calls them by that name, so
+    // they would be dead weight in `--disallowed-tools`. The camelCase MCP twin
+    // (githubCreateIssue) is enumerated separately and IS emitted below.
+    if (toolName.includes(".")) continue;
+    if (
+      decideWorkerAction(worker, toolName, undefined, store).action !== "gate"
+    )
+      continue;
+    // Don't over-block. An UNKNOWN tool (domain "other") defaults to
+    // irreversible in the trust model — conservative for EARNING, but blanket-
+    // denying every unknown here would strip the agent of the harmless reads and
+    // navigation it needs to do its job (getDiagnostics, searchWorkspace,
+    // goToDefinition, getHover, … all classify as other:irreversible:low). Only
+    // block an "other" tool when the registry rates it high-blast (e.g. Bash);
+    // tools with a KNOWN risky domain (shell, messaging, http, vcs-push/merge,
+    // issue) are always blocked. The recipe's explicit tool STEPS still gate on
+    // their own class — this list is defense-in-depth, not the only gate.
+    const ac = classifyActionClass(toolName);
+    if (ac.domain === "other" && classifyTool(toolName) !== "high") continue;
+    // Emit BOTH naming forms the subprocess might use: the bare name (native CC
+    // tools like `Bash`, and any non-namespaced match) AND the bridge MCP form
+    // `mcp__patchwork__<tool>` (how claude -p sees bridge tools under
+    // --disallowed-tools; server name fixed by writeMcpConfigFile). A form that
+    // matches nothing is harmless; missing one would leave the bypass open.
+    blocked.add(toolName);
+    blocked.add(`${BRIDGE_MCP_TOOL_PREFIX}${toolName}`);
+  }
+  return Array.from(blocked).sort();
+}
+
+/**
+ * Union a step's own `disallowedTools` with the worker-ceiling-derived block
+ * list. Returns `undefined` when both are empty so callers preserve the "field
+ * absent" shape. When there is NO worker list (the non-worker case), the step's
+ * list is returned VERBATIM — same value, same order, same duplicates — so a
+ * non-worker agent step is byte-identical to pre-flip behaviour. Only an actual
+ * merge dedups + sorts (argv order/dupes are inert for a deny SET).
+ */
+export function mergeAgentDisallowedTools(
+  stepList?: string[],
+  workerList?: string[],
+): string[] | undefined {
+  if (!workerList?.length) return stepList?.length ? stepList : undefined;
+  if (!stepList?.length) return Array.from(new Set(workerList)).sort();
+  return Array.from(new Set([...stepList, ...workerList])).sort();
 }


### PR DESCRIPTION
## Why

The test-guardian worker was silently building **zero** trust despite a real, correctly-executed run. Root cause: `readRuns()` used `query({})` (last-100 window), so a low-frequency worker's evidence aged out behind unrelated recipe traffic — on **both** the dial and the **live gate**. This PR fixes that, hardens the trust model, and closes an agent-step autonomy bypass.

## Changes

**Trust evidence durability** (`runWorkerShadow.ts`, `runLog.ts`)
- Query the run log **filtered by worker recipe names**, and size the in-memory ring to the full disk retention (`MAX_PERSIST_LINES`) so worker evidence is bounded only by what the log retains, not by global run volume.
- **Dedup** recipe names before the per-recipe `flatMap` — two manifests sharing a recipe no longer double-count the dial.

**Trust model** (`graduation.ts`)
- `minEvidenceAtLastPromotion`: the novel-class floor is a cold-start gate, so **raising** `minEvidenceForGraduation` no longer retroactively demotes an already-earned level.
- Pin `storeWithL2` → `toBe(2)` and cold-start → `toBe(3)` (exact-rung regression tightening).

**Agent-step autonomy sandbox** (`workerGate.ts`, `agentExecutor.ts`, `yamlRunner.ts`, `recipeOrchestration.ts`, `actionClass.ts`)
- An agent step spawns a subprocess whose internal tool calls bypass the per-step worker gate. `disallowedToolsForAgentStep()` re-applies the worker's autonomy boundary as a `--disallowed-tools` sandbox (bare + `mcp__patchwork__` forms), merged into the flat + chained agent paths.
- **NEVER-WIDEN guard:** `--disallowed-tools` is enforced **only** by the subprocess driver; on any other driver the deny list is dropped. `executeAgent` now **fails closed** (`enforceSandbox`) rather than running a worker agent step un-sandboxed.
- **No over-blocking:** unknown (`other:irreversible`) tools are no longer blanket-denied — only known-risky domains + high-blast tools (e.g. `Bash`) are — so the agent keeps the harmless reads/nav (`getDiagnostics`, `searchWorkspace`) it needs.

## Process

All fixes test-first (Bug Fix Protocol). The agent-sandbox findings — including the critical never-widen hole — were surfaced by an **adversarial multi-agent review of the diff (13 confirmed findings)** before this commit, then fixed and re-tested.

## Verification
- 1640 recipe + worker tests green; full build + strict tests-core typecheck + biome + fixture-hygiene gate clean.
- Live dial verified on real data: the worker now accrues evidence (earned L1) and the deny list blocks `gitPush`/`Bash`/`githubMergePR` while freeing `getDiagnostics`/`searchWorkspace`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)