### PR TITLE
feat(workers): autonomy policy-gate keystone + context-risk descending dial

### DIFF
--- a/docs/worker-autonomy-policy-gate.md
+++ b/docs/worker-autonomy-policy-gate.md
@@ -1,0 +1,227 @@
+# Worker Autonomy — the Policy Gate (keystone)
+
+**Status:** design / sequencing doc · 2026-06-30
+**Scope:** `src/workers/` — generalize the autonomy decision from a threshold on
+one slow signal into a policy over several signals, most of them fast.
+
+> One-line thesis: **don't make the slow earned-trust posterior carry the whole
+> autonomy decision.** Wrap it in fast, computable signals. The posterior is the
+> input that compounds into a moat; the other inputs make the product demoable on
+> day 1, safe on sparse high-value actions, and robust to drift — and they are the
+> things "approve-similar" structurally cannot copy.
+
+This is deliberately framed against the four standing weaknesses of an
+earned-trust model (cold-start latency, sparse high-blast samples,
+non-stationarity, wrong unit of trust). Each weakness is answered by a *different
+input to the same gate*, not a separate subsystem.
+
+---
+
+## 1. Where we are today
+
+The live decision is `decideWorkerAction` (`src/workers/workerGate.ts`):
+
+```ts
+decideWorkerAction(
+  worker: WorkerManifest,
+  toolName: string,
+  params: Record<string, unknown> | undefined,
+  store: WorkerLevelStore,
+): WorkerGateDecision   // { action: "allow" | "gate", effectiveLevel, ... }
+```
+
+The decision is essentially:
+
+```
+effectiveLevel = min(earnedLevel(worker, class), autonomyCeiling)   // store-derived, SLOW
+action         = reversible        ? allow
+               : compensable && eff >= L2 ? allow
+               : eff >= L4         ? allow
+               : gate
+```
+
+`earnedLevel` comes from the Beta-posterior LCB ramp (`trustLevel.ts` →
+`graduation.ts`). It is the **only** signal. Everything good about the system —
+asymmetry, blast-weighting, never-widen — already lives here. The problem is not
+the math; it's that one slow input gates everything.
+
+---
+
+## 2. The keystone change
+
+Make the decision a **policy function over signals**:
+
+```
+autonomy = f(earned_trust, context_risk, blast_radius, regime_freshness)
+```
+
+Concretely, generalize the gate to take a **decision context** instead of just
+the store:
+
+```ts
+interface AutonomyContext {
+  store: WorkerLevelStore;          // earned_trust (slow, the moat)
+  contextRisk?: ContextRisk;        // live situational risk (fast, day-1)
+  regime?: RegimeState;             // freshness vs. known discontinuities (medium)
+  // blast_radius is already on the ActionClass (actionClass.ts) — no new input.
+}
+
+decideWorkerAction(
+  worker: WorkerManifest,
+  toolName: string,
+  params: Record<string, unknown> | undefined,
+  ctx: AutonomyContext,             // was: store
+): WorkerGateDecision
+```
+
+**Backward-compatible seam first.** Land the signature change with `ctx = {store}`
+and *no behavioural change* — every new field optional, every absent field a
+no-op. All four mitigations then become *additions to `ctx`*, each shippable on
+its own, each independently testable. This is the single prerequisite; do it
+before any signal work.
+
+### Invariant the gate must keep: **never-widen, and now never-widen-UP**
+
+Every new signal may only **lower** autonomy, never raise it. `earned_trust` is
+the sole input that can *grant* autonomy; `context_risk` and `regime_freshness`
+can only *de-rate* it. Formally:
+
+```
+effectiveLevel = min(
+  earnedLevel,
+  autonomyCeiling,
+  contextCeiling(contextRisk),       // descending only
+  regimeCeiling(regime),             // descending only
+)
+```
+
+This is what preserves the entire existing safety story (and the agent-step
+sandbox shipped in #1039) while making the decision richer.
+
+---
+
+## 3. The four inputs, mapped to the four weaknesses
+
+| Weakness | Input | Speed | Already shipped? |
+|---|---|---|---|
+| Cold-start latency | **backtest-as-divergence** (prime the posterior from history) | compute, not wall-clock | partial — shadow machinery exists |
+| Sparse high-blast samples | **compositional trust** (policy over earned sub-claims) | — | no |
+| Non-stationarity | **regime_freshness** (time-decay + discontinuity markers) | medium | partial — `minEvidenceAtLastPromotion` (#1039) is a special case |
+| Wrong unit of trust | **context_risk** (live situational de-rater) | fast, day-1 | no |
+
+### 3a. `context_risk` — the fast second dial (highest leverage, build first)
+
+A live, situational risk score computed per-action from signals the bridge
+**already exposes**, gating *down* only:
+
+- `getDiagnostics` — error/warning count in the touched files
+- `getCodeCoverage` — coverage of the touched code
+- `getGitHotspots` — is this a churn-heavy/fragile file
+- diff size / `getGitStatus` — how big is the pending change
+- CI status — is the build currently red
+
+```
+contextRisk ∈ [0,1]  →  contextCeiling: high risk caps autonomy down
+  clean repo, green CI, small diff   → no de-rate (full earned autonomy)
+  red CI / huge diff / hotspot file  → cap to "propose-only" even at earned L4
+```
+
+Why this is the keystone's best first move:
+- **Zero cold-start.** Computable on day 1 — it carries the pilot demo while the
+  posterior accrues. ("L1-earned but the repo is clean → one-click propose" vs
+  "L4-earned but CI is red and the diff is huge → stop.")
+- **Decouples** "is this worker generally reliable" (slow, earned) from "is this
+  situation safe right now" (fast, computed) — directly answers Weakness 4
+  (failures come from *context*, not the recipe).
+- **Uncopyable.** Approve-similar has no situational model; this is the thing it
+  structurally cannot do.
+
+### 3b. `regime_freshness` — drift-aware caution
+
+Evidence must **decay**, not just accumulate (today `applyOutcome` only ever adds
+to α/β). Two parts:
+
+1. **Time-decay**: recent outcomes weigh more (exponential forgetting toward the
+   prior). Handles gradual drift.
+2. **Discontinuity markers**: a model-version bump / framework migration / policy
+   change emits a regime marker that **widens the confidence interval** (autonomy
+   auto-throttles down) until fresh evidence re-confirms it. Versions the actor:
+   a model bump = a new actor with a strong *inherited* prior (CI widened),
+   **not** a reset, and the receipts stay honest (prior labeled inherited).
+
+This is a *selling point*, not a tax: "our workers automatically get more cautious
+after a major change, then re-earn autonomy" is exactly the safety behaviour an
+enterprise wants — and approve-similar can't do it. `minEvidenceAtLastPromotion`
+(#1039) is already a degenerate case (one kind of regime change: config tightening).
+
+### 3c. `backtest-as-divergence` — cold-start without faking earned trust
+
+Point the existing shadow machinery (`shadowGate.recommend` vs gate decisions) at
+the prospect's **historical** run/PR/ticket logs instead of live. By end of week 1
+you have hundreds of real samples — compute-latency, not wall-clock.
+
+**The honest framing — read this twice.** Replaying past *merged* PRs scores
+*mimicry of decisions humans already made*, a censored sample: you never observe
+the counterfactual where the worker diverged and it would have gone wrong. So the
+metric is **divergence-from-human, not success-rate**:
+
+> "the worker agreed with your team on 94% of 300 real actions; here are the 6%
+> where it diverged and who was right."
+
+That is more compelling than a fake success posterior (the divergences are where
+the value and risk live) *and* it avoids quietly becoming the config-trust product
+we claim to beat. Backtest primes the prior + demos calibration; it does not, by
+itself, grant autonomy.
+
+### 3d. Compositional trust — the only honest answer to sparse high-blast actions
+
+You will never earn high autonomy on a twice-a-quarter prod deploy from frequency
+alone. **Don't try — decompose.** A rare composite (`deploy`) is a policy over
+*frequent, observable* sub-claims: tests passed · diff in-scope · migration
+reversible · canary held. Each sub-claim is a high-volume action-class you *can*
+earn trust on. Autonomy on the composite = a guard over component trust + live
+checks, **not** a posterior on the composite.
+
+Caveat we must state plainly: the human writes the decomposition, so the
+*structure* of trust is config; only the *leaf* reliabilities are earned. That's
+fine and honest — and it makes the enterprise-legible product a **library of
+action decompositions** (NIST/SOC2-style controls for AI actions), which sells far
+better than "Bayesian autonomy." The chained runner's `step` + `step.expect`
+primitives are the substrate. (Caveat to NOT pretend: for genuinely
+rare+irreversible+high-blast actions the correct product answer is "10 approvals →
+1 *considered* approval," never zero — which is already the repo's KPI.)
+
+A precondition for all of the above: **durable-outcome labels.** Today
+`good = step.status === "ok"` (absence-of-error) — an optimistic proxy. A PR that
+merged isn't a PR that was *good*. Trust must update on **durable** outcomes (not
+reverted, survived N days, issue not reopened, deploy not rolled back), which the
+bridge can already detect (`enrichCommit`, `getCommitsForIssue`, revert/reopen).
+Until the label is durable, every posterior is confidently measuring the wrong
+event — this is the honest foundation under all four inputs.
+
+---
+
+## 4. Sequence (leverage ÷ build cost)
+
+1. **Durable-outcome labels** — cheapest, and nothing else is honest without it.
+2. **Keystone seam** — `decideWorkerAction(…, ctx)` backward-compatible, no
+   behaviour change. Prerequisite for 3–5.
+3. **`context_risk` descending dial** — day-1 demoable, repo already exposes the
+   signals, preserves never-widen, answers Weakness 4, carries the pilot.
+4. **`backtest-as-divergence`** — small build on existing shadow code; answers
+   Weakness 1 honestly.
+5. **`regime_freshness`** (time-decay + markers) — medium build, outsized
+   narrative value. Makes the #1039 window-eviction fix load-bearing (decay needs
+   the full history to recompute).
+6. **Compositional trust** — the real moat and the honest answer to Weakness 2;
+   sequence last, once the seam + 1–5 prove out.
+
+## 5. Positioning (so we build the right thing)
+
+Lead the product with **governance + reach + receipts** — the policy/decomposition
+engine, blast-radius ceilings, the immutable audit trail, and cross-tool span —
+all demoable on day 1 with no cold-start. Demote earned-trust from headline to
+engine, and reframe its claim from "earned autonomy" to **institutional reliability
+memory**: a track record that survives across actions and adapts to drift — which a
+stateless context-risk score cannot tell, and which is the one thing the posterior
+uniquely earns. Ship the Bayes quietly; sell the governance.

--- a/src/workers/__tests__/workerGate.test.ts
+++ b/src/workers/__tests__/workerGate.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { classifyActionClass } from "../actionClass.js";
+import { contextRiskCeiling } from "../contextRisk.js";
 import type { GraduationConfig } from "../graduation.js";
 import { parseWorker } from "../worker.js";
 import {
@@ -153,6 +154,84 @@ describe("decideWorkerAction", () => {
     expect(d.effectiveLevel).toBe(0);
     expect(d.action).toBe("gate");
     expect(d.reason).toContain("outside");
+  });
+});
+
+describe("contextRiskCeiling", () => {
+  it("descends with risk; clean/unknown → no de-rate (L4)", () => {
+    expect(contextRiskCeiling(0)).toBe(4);
+    expect(contextRiskCeiling(0.1)).toBe(4);
+    expect(contextRiskCeiling(0.3)).toBe(2);
+    expect(contextRiskCeiling(0.5)).toBe(1);
+    expect(contextRiskCeiling(0.8)).toBe(0);
+    expect(contextRiskCeiling(1)).toBe(0);
+    expect(contextRiskCeiling(Number.NaN)).toBe(4); // unmeasured → no de-rate
+    expect(contextRiskCeiling(-1)).toBe(4);
+  });
+});
+
+describe("decideWorkerAction — context-risk descending clamp (keystone seam)", () => {
+  it("is a no-op when no contextRisk is supplied (backward-compatible)", () => {
+    const w = parseWorker({ id: "w", name: "W", owns: ["vcs-push"] });
+    const d = decideWorkerAction(w, "gitPush", {}, storeWithL4("w", "gitPush"));
+    expect(d.action).toBe("allow");
+    expect(d.contextCeiling).toBeUndefined();
+  });
+
+  it("throttles an EARNED risky action down to gate under dangerous context", () => {
+    // earned L4 on gitPush, but the live situation is dangerous (score 0.9 →
+    // ceiling L0). The compensable action that would auto-allow at L2 is gated.
+    const w = parseWorker({ id: "w", name: "W", owns: ["vcs-push"] });
+    const d = decideWorkerAction(
+      w,
+      "gitPush",
+      {},
+      storeWithL4("w", "gitPush"),
+      {
+        contextRisk: { score: 0.9, reasons: ["CI red", "diff 1.2k lines"] },
+      },
+    );
+    expect(d.earnedLevel).toBe(4);
+    expect(d.contextCeiling).toBe(0);
+    expect(d.effectiveLevel).toBe(0);
+    expect(d.action).toBe("gate");
+    expect(d.reason).toContain("context-risk");
+    expect(d.reason).toContain("CI red");
+  });
+
+  it("does NOT throttle when the context is clean (earned autonomy preserved)", () => {
+    const w = parseWorker({ id: "w", name: "W", owns: ["vcs-push"] });
+    const d = decideWorkerAction(
+      w,
+      "gitPush",
+      {},
+      storeWithL4("w", "gitPush"),
+      {
+        contextRisk: { score: 0.0 },
+      },
+    );
+    expect(d.contextCeiling).toBe(4);
+    expect(d.effectiveLevel).toBe(4);
+    expect(d.action).toBe("allow");
+  });
+
+  it("never WIDENS: context-risk can't lift an unearned action to allow", () => {
+    // unearned compensable + clean context → still gated (clamp only lowers).
+    const w = parseWorker({ id: "w", name: "W", owns: ["vcs-push"] });
+    const d = decideWorkerAction(w, "gitPush", {}, new WorkerLevelStore(), {
+      contextRisk: { score: 0 },
+    });
+    expect(d.action).toBe("gate");
+  });
+
+  it("reversible actions still flow un-gated regardless of context-risk", () => {
+    // reversible = undoable; context-risk lowers the level but the reversible
+    // path is exempt from the level requirement by design.
+    const w = parseWorker({ id: "w", name: "W", owns: ["fs-write"] });
+    const d = decideWorkerAction(w, "editText", {}, new WorkerLevelStore(), {
+      contextRisk: { score: 0.95 },
+    });
+    expect(d.action).toBe("allow");
   });
 });
 

--- a/src/workers/contextRisk.ts
+++ b/src/workers/contextRisk.ts
@@ -1,0 +1,43 @@
+import type { TrustLevel } from "./trustLevel.js";
+
+/**
+ * Context-risk — the FAST, situational half of the autonomy decision.
+ *
+ * Earned trust answers "is this worker generally reliable on this action-class?"
+ * (slow, accrued over many runs). Context-risk answers a DIFFERENT, orthogonal
+ * question: "is THIS situation safe to act in RIGHT NOW?" — computed per-action
+ * from signals the bridge already exposes (open diagnostics in the touched
+ * files, test coverage, git hotspot-ness, diff size, CI status). It has no
+ * cold-start: it is fully computable on day one, so it can de-rate autonomy from
+ * the very first action while the trust posterior is still accruing.
+ *
+ * It is a DE-RATER only: it can lower the effective autonomy level, never raise
+ * it (never-widen). Combined with earned trust + the autonomy ceiling, the gate
+ * becomes `min(earned, ceiling, contextCeiling)` — a worker stays at its earned
+ * level when the situation is clean and is throttled toward propose-only as live
+ * risk climbs. This is the dimension "approve-once / approve-similar" structurally
+ * cannot model. See docs/worker-autonomy-policy-gate.md §3a.
+ */
+export interface ContextRisk {
+  /** 0 (clean) … 1 (dangerous). Out-of-range / NaN is treated as "unknown". */
+  score: number;
+  /** Human-readable contributors (e.g. "CI red", "diff 1.2k lines", "hotspot
+   *  file"), surfaced in the gate reason + audit trail. */
+  reasons?: string[];
+}
+
+/**
+ * Map a context-risk score to the MAX autonomy rung permitted in this situation.
+ * DESCENDING only — higher risk ⇒ lower ceiling. Returns L4 (no de-rate) for a
+ * clean OR unknown/unmeasurable score: context-risk adds caution when danger is
+ * MEASURED; when it can't be measured the base gate (earned trust + ceiling)
+ * still applies its own floor, so an unknown situation must not silently throttle
+ * everything to zero.
+ */
+export function contextRiskCeiling(score: number): TrustLevel {
+  if (!Number.isFinite(score) || score <= 0) return 4; // clean / unknown → no de-rate
+  if (score >= 0.8) return 0; // dangerous → propose-only: every risky action gated
+  if (score >= 0.5) return 1; // elevated → reversible only flows freely
+  if (score >= 0.3) return 2; // moderate → compensable ok, irreversible still gated
+  return 4; // mild → no de-rate
+}

--- a/src/workers/workerGate.ts
+++ b/src/workers/workerGate.ts
@@ -4,6 +4,7 @@ import {
   classifyActionClass,
   knownActionTools,
 } from "./actionClass.js";
+import { type ContextRisk, contextRiskCeiling } from "./contextRisk.js";
 import type { TrustLevel } from "./trustLevel.js";
 import { ownsAction, type WorkerManifest } from "./worker.js";
 import type { WorkerLevelStore } from "./workerLevelStore.js";
@@ -49,9 +50,22 @@ export interface WorkerGateDecision {
   /** Trust actually earned on this class (for logging / the dial). */
   earnedLevel: TrustLevel;
   autonomyCeiling: TrustLevel;
-  /** What the gate operates at: min(earned, ceiling), 0 if not owned. */
+  /** What the gate operates at: min(earned, ceiling, contextCeiling), 0 if not
+   *  owned. */
   effectiveLevel: TrustLevel;
+  /** The descending ceiling imposed by live context-risk (4 = no de-rate).
+   *  Present only when a contextRisk was supplied. Diagnostic / audit. */
+  contextCeiling?: TrustLevel;
   reason: string;
+}
+
+/** Optional, descending-only signals that fold into the autonomy decision
+ *  alongside earned trust (the keystone seam — see
+ *  docs/worker-autonomy-policy-gate.md). All absent ⇒ byte-identical to the
+ *  earned-trust-only gate. New signals may only LOWER autonomy, never raise it. */
+export interface AutonomyDecisionOpts {
+  /** Live situational risk for THIS action (fast, day-1, no cold-start). */
+  contextRisk?: ContextRisk;
 }
 
 /**
@@ -87,6 +101,7 @@ export function decideWorkerAction(
   toolName: string,
   params: Record<string, unknown> | undefined,
   store: WorkerLevelStore,
+  opts?: AutonomyDecisionOpts,
 ): WorkerGateDecision {
   const ac = classifyActionClass(toolName, params);
   const owned = ownsAction(worker, ac);
@@ -97,6 +112,17 @@ export function decideWorkerAction(
   if (effectiveLevel > worker.autonomyCeiling)
     effectiveLevel = worker.autonomyCeiling;
 
+  // Descending context-risk clamp (keystone seam). A live, situational de-rater:
+  // it can only LOWER the effective level (never-widen). Absent ⇒ no-op, so the
+  // earned-trust-only path is byte-identical. A worker with a clean situation
+  // keeps its earned autonomy; a dangerous live context (red CI, huge diff,
+  // hotspot file) throttles it toward propose-only regardless of earned level.
+  const contextCeiling: TrustLevel | undefined = opts?.contextRisk
+    ? contextRiskCeiling(opts.contextRisk.score)
+    : undefined;
+  if (contextCeiling !== undefined && effectiveLevel > contextCeiling)
+    effectiveLevel = contextCeiling;
+
   const base = {
     classKey: ac.key,
     domain: ac.domain,
@@ -106,6 +132,7 @@ export function decideWorkerAction(
     earnedLevel,
     autonomyCeiling: worker.autonomyCeiling,
     effectiveLevel,
+    ...(contextCeiling !== undefined && { contextCeiling }),
   } as const;
 
   // Agent (reasoning) steps are not a durable side-effecting action-class: the
@@ -160,7 +187,23 @@ export function decideWorkerAction(
       ? COMPENSABLE_AUTONOMY_LEVEL
       : AUTONOMOUS_LEVEL;
   let reason: string;
-  if (!owned) {
+  // Context-risk is the BINDING constraint when it dropped the effective level
+  // below what earned trust + ceiling alone would have allowed. Attribute it so
+  // the audit trail shows the situation throttled the action, not stale trust.
+  const earnedCapped = Math.min(
+    owned ? earnedLevel : 0,
+    worker.autonomyCeiling,
+  );
+  if (
+    contextCeiling !== undefined &&
+    contextCeiling < threshold &&
+    contextCeiling < earnedCapped
+  ) {
+    const why = opts?.contextRisk?.reasons?.length
+      ? ` (${opts.contextRisk.reasons.join(", ")})`
+      : "";
+    reason = `${ac.reversibility} throttled by live context-risk (ceiling L${contextCeiling} < L${threshold})${why} — gated`;
+  } else if (!owned) {
     reason = `${ac.reversibility} action outside the worker's owned domain — gated`;
   } else if (worker.autonomyCeiling < threshold) {
     reason = `${ac.reversibility} class capped by autonomy ceiling (L${worker.autonomyCeiling} < L${threshold}) — always gated`;


### PR DESCRIPTION
## Why

The earned-trust ramp makes one **slow** signal carry the entire autonomy decision — which is exactly what makes it fragile (cold-start latency, sparse high-blast samples, drift, wrong unit of trust). The fix (see `docs/worker-autonomy-policy-gate.md`, included) is to make the decision a **policy over several signals**, most of them fast, with earned-trust as the one input that compounds into a moat.

This PR lands the **keystone seam** + the first new signal (**context-risk**).

## What

- `decideWorkerAction` gains an optional `opts: AutonomyDecisionOpts`. **Absent ⇒ byte-identical** to the earned-trust-only gate — the two production callers and all existing tests are untouched (backward-compatible seam).
- `contextRisk.ts`: `ContextRisk` + `contextRiskCeiling()` — a **fast, day-1, no-cold-start** situational de-rater. `effectiveLevel` becomes `min(earned, ceiling, contextCeiling)`:
  - clean situation → worker keeps its earned autonomy
  - dangerous live context (red CI, huge diff, hotspot file) → throttled toward propose-only **regardless of earned level**
  - **descending-only** — context-risk can never *raise* autonomy (never-widen preserved); reversible actions stay exempt (undoable)
- Gate reason attributes context-risk when it's the binding constraint (with contributing reasons) for the audit trail.

## Why this signal first

Context-risk answers "is **this situation** safe right now" — decoupled from the slow "is this worker generally reliable" (directly addresses the *failures-come-from-context-not-the-recipe* weakness). It's computable on day 1, so it carries a pilot while the posterior accrues, and it's the dimension approve-once/approve-similar structurally cannot model.

## Scope

Seam + pure clamp + tests only. The live **scorer** (diagnostics / coverage / hotspots / CI → score) and its orchestration wiring are the next increment. All behind `FLAG_WORKER_AUTONOMY` (default-off).

## Verification
- 99 worker tests green (incl. new `contextRiskCeiling` + descending-clamp + never-widen + backward-compat cases); build + biome clean.
- Stacks conceptually on #1039 (merged); branched off updated main so the diff is just these 4 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)