### PR TITLE
feat(workers): durable-outcome labels — risky successes must survive before they count

### DIFF
--- a/src/recipes/__tests__/workerAutonomySmoke.test.ts
+++ b/src/recipes/__tests__/workerAutonomySmoke.test.ts
@@ -282,16 +282,36 @@ describe("worker-autonomy smoke (triage-failing-tests-autofile, flag ON)", () =>
       ),
     ).toBe(true);
 
-    // --- D. trust replay ATTRIBUTES the run + records issue-class evidence -
-    const postTrust = loadWorkerTrustForRecipe(RECIPE_NAME, {
+    // --- D. trust replay + DURABLE-OUTCOME LABELLING ----------------------
+    // A just-approved issue write is a non-reversible SUCCESS — it must NOT
+    // count as earned trust until it has survived the durability window (it
+    // could be reverted / closed-as-junk minutes later). So with real `now`
+    // the issue class has NO evidence yet…
+    const HOUR = 60 * 60 * 1000;
+    const freshTrust = loadWorkerTrustForRecipe(RECIPE_NAME, {
       workersDir,
       patchworkDir,
     });
-    const board = postTrust?.store.board(WORKER_ID) ?? [];
-    const issueRow = board.find((r) => r.classKey.includes("issue"));
+    expect(
+      (freshTrust?.store.board(WORKER_ID) ?? []).find((r) =>
+        r.classKey.includes("issue"),
+      ),
+      "a recent issue success is withheld (durable-outcome label)",
+    ).toBeUndefined();
+
+    // …but once the run has survived the durability window it accrues evidence.
+    // (Inject a future `now` to simulate the window elapsing.)
+    const durableTrust = loadWorkerTrustForRecipe(RECIPE_NAME, {
+      workersDir,
+      patchworkDir,
+      now: Date.now() + 25 * HOUR,
+    });
+    const issueRow = (durableTrust?.store.board(WORKER_ID) ?? []).find((r) =>
+      r.classKey.includes("issue"),
+    );
     expect(
       issueRow,
-      "issue action-class has evidence on the dial",
+      "issue evidence accrues once the success is durable",
     ).toBeDefined();
     expect(issueRow?.observations ?? 0).toBeGreaterThanOrEqual(1);
 
@@ -299,6 +319,7 @@ describe("worker-autonomy smoke (triage-failing-tests-autofile, flag ON)", () =>
       workersDir,
       patchworkDir,
       ideDir: tmpHome,
+      now: Date.now() + 25 * HOUR,
     });
     expect(shadow.runsScanned).toBeGreaterThanOrEqual(1);
     expect(shadow.workers.some((w) => w.workerId === WORKER_ID)).toBe(true);

--- a/src/workers/__tests__/shadowObserver.test.ts
+++ b/src/workers/__tests__/shadowObserver.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 import type { GraduationConfig } from "../graduation.js";
-import { type RunRecord, WorkerShadowObserver } from "../shadowObserver.js";
+import {
+  isDurableSuccess,
+  type RunRecord,
+  WorkerShadowObserver,
+} from "../shadowObserver.js";
 import { parseWorker } from "../worker.js";
 
 const CFG: GraduationConfig = {
@@ -154,5 +158,61 @@ describe("WorkerShadowObserver", () => {
       .board.find((b) => b.classKey.startsWith("vcs-push"));
     expect(row).toBeDefined();
     expect(row!.owned).toBe(false);
+  });
+});
+
+const W = 24 * 60 * 60 * 1000;
+
+describe("isDurableSuccess (durable-outcome label)", () => {
+  it("reversible successes are always durable (even brand-new)", () => {
+    expect(isDurableSuccess("reversible", 1000, 1000, W)).toBe(true);
+  });
+  it("a non-reversible success is durable only after surviving the window", () => {
+    const now = 100 * W;
+    expect(isDurableSuccess("compensable", now - 1000, now, W)).toBe(false); // 1s ago → pending
+    expect(isDurableSuccess("compensable", now - 2 * W, now, W)).toBe(true); // survived
+    expect(isDurableSuccess("irreversible", now - 1000, now, W)).toBe(false);
+    expect(isDurableSuccess("irreversible", now - 2 * W, now, W)).toBe(true);
+  });
+});
+
+describe("WorkerShadowObserver — durable-outcome labelling", () => {
+  const now = 100 * W;
+  const issuer = parseWorker({
+    id: "issuer",
+    name: "Issuer",
+    recipe: "file-issues",
+    owns: ["issue"],
+  });
+  const issueRun = (at: number, status: "ok" | "error" = "ok"): RunRecord => ({
+    recipeName: "file-issues",
+    at,
+    steps: [{ tool: "githubCreateIssue", status }],
+  });
+  const issueRow = (obs: WorkerShadowObserver) =>
+    obs.report()[0]!.board.find((b) => b.classKey.startsWith("issue"));
+
+  it("WITHHOLDS a recent non-reversible success (the #1041 junk-issue case)", () => {
+    const obs = new WorkerShadowObserver([issuer], { cfg: CFG, now });
+    obs.ingestRun(issueRun(now - 1000)); // filed 1s ago → not yet durable
+    expect(issueRow(obs)).toBeUndefined(); // no evidence on the issue class
+  });
+
+  it("COUNTS a non-reversible success once it has survived the window", () => {
+    const obs = new WorkerShadowObserver([issuer], { cfg: CFG, now });
+    obs.ingestRun(issueRun(now - 2 * W)); // 2 days ago → durable
+    expect(issueRow(obs)?.observations).toBe(1);
+  });
+
+  it("counts a recent FAILURE immediately (failure is durable evidence)", () => {
+    const obs = new WorkerShadowObserver([issuer], { cfg: CFG, now });
+    obs.ingestRun(issueRun(now - 1000, "error"));
+    expect(issueRow(obs)?.observations).toBe(1);
+  });
+
+  it("without `now`, falls back to status-only (recent success counts) — back-compat", () => {
+    const obs = new WorkerShadowObserver([issuer], { cfg: CFG }); // no now
+    obs.ingestRun(issueRun(now - 1000));
+    expect(issueRow(obs)?.observations).toBe(1);
   });
 });

--- a/src/workers/runWorkerShadow.ts
+++ b/src/workers/runWorkerShadow.ts
@@ -28,6 +28,9 @@ export interface RunWorkerShadowOpts {
   patchworkDir?: string;
   /** ~/.claude/ide (activity-*.jsonl) override (tests). */
   ideDir?: string;
+  /** Wall-clock override (tests) for durable-outcome labelling. Defaults to
+   *  Date.now() — supplied here (the I/O entry) so the observer stays pure. */
+  now?: number;
 }
 
 function readRuns(patchworkDir: string, recipeNames?: string[]): RunRecord[] {
@@ -157,7 +160,12 @@ export function getWorkerShadowData(
     : [];
   const decisions = workers.length ? readDecisions(ideDir) : [];
   return {
-    workers: buildShadowReport(workers, runs, decisions),
+    // `now` drives durable-outcome labelling (recent non-reversible successes
+    // are withheld until they survive the durability window). Real Date.now() in
+    // production; tests inject opts.now.
+    workers: buildShadowReport(workers, runs, decisions, undefined, {
+      now: opts.now ?? Date.now(),
+    }),
     runsScanned: runs.length,
     decisionsScanned: decisions.length,
     workersDir,
@@ -189,7 +197,12 @@ export function loadWorkerTrustForRecipe(
 
   const workers = loadWorkersFromDir(workersDir);
   if (!workers.length) return null;
-  const observer = new WorkerShadowObserver(workers);
+  // Same durable-outcome labelling as the dial (one source of truth): the live
+  // gate must not count a recent non-reversible success that could still be
+  // reverted. Real Date.now() in production; tests inject opts.now.
+  const observer = new WorkerShadowObserver(workers, {
+    now: opts.now ?? Date.now(),
+  });
   const worker = observer.workerForRecipe(recipeName);
   if (!worker) return null;
   // Replay in ASCENDING timestamp order (review #1027 M2). The graduation

--- a/src/workers/shadowObserver.ts
+++ b/src/workers/shadowObserver.ts
@@ -1,5 +1,5 @@
 import { categoriseHaltReason } from "../recipes/haltCategory.js";
-import { classifyActionClass } from "./actionClass.js";
+import { classifyActionClass, type Reversibility } from "./actionClass.js";
 import {
   DEFAULT_GRADUATION_CONFIG,
   type GraduationConfig,
@@ -82,19 +82,62 @@ interface CompareSlot {
   divergences: Divergence[];
 }
 
+/** Default durability window — a non-reversible success must survive this long
+ *  before it counts as earned trust. 24h is long enough to catch a revert /
+ *  close-as-junk / rollback, short enough that a genuinely-good action graduates
+ *  within a day. */
+export const DEFAULT_DURABILITY_WINDOW_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Durable-outcome label. `good = step.status:ok` is an OPTIMISTIC proxy: a PR
+ * that merged, an issue that filed — but a junk issue closed seconds later, or a
+ * commit reverted within the hour, "succeeded" at the moment yet is not earned
+ * trust. So a SUCCESS on a non-reversible (compensable/irreversible) action is
+ * "durable" — i.e. counts as evidence — only once it has survived the durability
+ * window. Reversible successes (undoable / re-runnable: reads, ledgered writes,
+ * local commits, CI) are always durable. Failures are unaffected (a failure is
+ * durable evidence of failure regardless of age).
+ *
+ * This only ever WITHHOLDS recent risky successes (reduces evidence → lower
+ * trust → more gating), so it never widens autonomy. See
+ * docs/worker-autonomy-policy-gate.md §3d.
+ */
+export function isDurableSuccess(
+  reversibility: Reversibility,
+  runAt: number,
+  now: number,
+  windowMs: number,
+): boolean {
+  if (reversibility === "reversible") return true;
+  return runAt <= now - windowMs;
+}
+
 export class WorkerShadowObserver {
   private readonly store: WorkerLevelStore;
   private readonly cfg: GraduationConfig;
   private readonly workers: WorkerManifest[];
   private readonly compare = new Map<string, CompareSlot>();
+  /** Wall-clock supplied by the I/O entry (the observer stays pure — no
+   *  Date.now). When set, durable-outcome labelling is active; when undefined,
+   *  the prior status-only behaviour is preserved (back-compat for pure tests). */
+  private readonly now?: number;
+  private readonly durabilityWindowMs: number;
 
   constructor(
     workers: WorkerManifest[],
-    opts: { store?: WorkerLevelStore; cfg?: GraduationConfig } = {},
+    opts: {
+      store?: WorkerLevelStore;
+      cfg?: GraduationConfig;
+      now?: number;
+      durabilityWindowMs?: number;
+    } = {},
   ) {
     this.workers = workers;
     this.store = opts.store ?? new WorkerLevelStore();
     this.cfg = opts.cfg ?? DEFAULT_GRADUATION_CONFIG;
+    this.now = opts.now;
+    this.durabilityWindowMs =
+      opts.durabilityWindowMs ?? DEFAULT_DURABILITY_WINDOW_MS;
   }
 
   /**
@@ -139,6 +182,23 @@ export class WorkerShadowObserver {
         categoriseHaltReason(step.haltReason) === "approval_rejected"
       )
         continue;
+      // Durable-outcome label: a recent SUCCESS on a non-reversible action is
+      // provisional (a filed issue / pushed commit / merged PR can be reverted
+      // or closed-as-junk minutes later), so it is NOT yet counted as evidence.
+      // Only active when `now` was supplied by the I/O entry; otherwise the prior
+      // status-only fold is used. Withholds evidence only → never widens.
+      if (this.now !== undefined && step.status === "ok") {
+        const ac = classifyActionClass(step.tool);
+        if (
+          !isDurableSuccess(
+            ac.reversibility,
+            run.at,
+            this.now,
+            this.durabilityWindowMs,
+          )
+        )
+          continue; // pending — survives the window before it earns trust
+      }
       this.store.apply(
         worker.id,
         { toolName: step.tool, good: step.status === "ok", at: run.at },

--- a/src/workers/shadowReport.ts
+++ b/src/workers/shadowReport.ts
@@ -18,8 +18,15 @@ export function buildShadowReport(
   runs: RunRecord[],
   decisions: DecisionRecord[],
   cfg?: GraduationConfig,
+  opts: { now?: number; durabilityWindowMs?: number } = {},
 ): WorkerShadowReport[] {
-  const obs = new WorkerShadowObserver(workers, { cfg });
+  const obs = new WorkerShadowObserver(workers, {
+    cfg,
+    ...(opts.now !== undefined && { now: opts.now }),
+    ...(opts.durabilityWindowMs !== undefined && {
+      durabilityWindowMs: opts.durabilityWindowMs,
+    }),
+  });
   const merged: Array<{ at: number; run?: RunRecord; dec?: DecisionRecord }> = [
     ...runs.map((r) => ({ at: r.at, run: r })),
     ...decisions.map((d) => ({ at: d.at, dec: d })),


### PR DESCRIPTION
## Why

`good = step.status:ok` is an **optimistic proxy**. A PR that merged or an issue that filed "succeeded" at that instant — but a junk issue closed seconds later, or a commit reverted within the hour, is *not* earned trust. We proved this live this session: an accidental local run filed **and immediately closed** a junk issue (#1041), yet it still counted as good evidence on the worker's `issue` class.

This is the honest foundation under the policy-gate plan (`docs/worker-autonomy-policy-gate.md` §3d) — the increment after #1040.

## What

A **SUCCESS on a non-reversible action** (compensable/irreversible) only counts as evidence once it has **survived a durability window** (default 24h):
- **Reversible** successes (reads, ledgered writes, local commits, CI) count immediately — they're undoable.
- **Failures** count immediately — a failure is durable evidence of failure regardless of age.
- **Recent risky successes** are *withheld* (pending) until they survive the window.

- `isDurableSuccess(reversibility, runAt, now, windowMs)` — pure predicate.
- The observer takes an injected `now` (stays pure — no `Date.now`); the two I/O entries (`getWorkerShadowData`, `loadWorkerTrustForRecipe`) supply `Date.now()` in production, tests inject it. Threaded via `buildShadowReport`.
- **WITHHOLDS evidence only** → lower trust → more gating → **never widens autonomy**. When `now` is absent, the prior status-only fold is preserved (back-compat for pure tests).

## Verified on live data
With durable-labels active, the spurious **#1041 junk-issue** observation is **withheld** from the dial; reversible (`vcs-read`/`fs-write`) evidence is unaffected. A contrast run with a future `now` shows the `issue` evidence correctly reappearing once durable.

## Tests
- `isDurableSuccess` unit + observer behavior (withheld-when-recent / counts-once-durable / failure-counts-immediately / no-`now`-back-compat).
- Updated the autonomy smoke test to assert durable-labels (recent issue success withheld; accrues once the window elapses).
- 99 worker + 1547 recipe tests green; build + strict typecheck + biome + fixture gate clean.

## Follow-ups
The window is a *time-based* durability proxy. A future increment can add **revert/close detection** (a success that's reverted/closed-as-junk *within* the window → `bad`, not just `pending`) using `enrichCommit`/`getCommitsForIssue`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)