### PR TITLE
feat(workers): context-risk scorer + live gate wiring (producer behind #1040)

### DIFF
--- a/src/__tests__/recipeOrchestration.workerGate.test.ts
+++ b/src/__tests__/recipeOrchestration.workerGate.test.ts
@@ -22,6 +22,31 @@ import {
   buildWorkerAgentDisallowedTools,
   buildWorkerAutonomyGate,
 } from "../recipeOrchestration.js";
+import { RecipeRunLog } from "../runLog.js";
+
+/** Seed durable, dwell-separated successes so the worker earns autonomy on
+ *  `tool`'s class (ancient timestamps → durable under durable-outcome labels). */
+function seedEarned(dir: string, recipeName: string, tool: string, n = 18) {
+  const log = new RecipeRunLog({ dir });
+  const SEVEN_HOURS = 7 * 3600 * 1000;
+  for (let i = 0; i < n; i++) {
+    log.appendDirect({
+      taskId: `seed-${i}`,
+      recipeName,
+      trigger: "recipe",
+      status: "done",
+      createdAt: i * SEVEN_HOURS,
+      doneAt: i * SEVEN_HOURS,
+      durationMs: 1,
+      stepResults: Array.from({ length: 5 }, (_, k) => ({
+        id: `s${i}-${k}`,
+        tool,
+        status: "ok" as const,
+        durationMs: 1,
+      })),
+    });
+  }
+}
 
 const WORKER_YAML = `id: test-worker
 name: Test Worker
@@ -149,6 +174,55 @@ describe("buildWorkerAutonomyGate", () => {
     expect(getApprovalQueue().list()).toHaveLength(1);
     ac.abort(); // run cancelled → pending approval resolves "cancelled"
     expect(await p).toBe(false);
+  });
+
+  it("context-risk DE-RATES an EARNED action (live wiring, descending only)", async () => {
+    seedEarned(dir, "test-recipe", "githubCreatePR"); // worker earns vcs-remote
+
+    // Baseline: earned + clean context → the action flows.
+    const clean = await buildWorkerAutonomyGate(
+      "test-recipe",
+      undefined,
+      opts,
+      {
+        contextRiskProvider: async () => undefined,
+      },
+    );
+    expect(
+      await clean!({ toolId: "githubCreatePR", tier: "high", params: {} }),
+    ).toBe(true);
+
+    // Dangerous live context → the SAME earned action is throttled to a gate
+    // (queues for approval). Proves the resolved contextRisk reaches the decision.
+    const risky = await buildWorkerAutonomyGate(
+      "test-recipe",
+      undefined,
+      opts,
+      {
+        contextRiskProvider: async () => ({
+          score: 0.9,
+          reasons: ["huge uncommitted diff"],
+        }),
+      },
+    );
+    const p = risky!({ toolId: "githubCreatePR", tier: "high", params: {} });
+    await tick();
+    expect(getApprovalQueue().list()).toHaveLength(1);
+    getApprovalQueue().reject(firstCallId());
+    expect(await p).toBe(false);
+  });
+
+  it("a failing context-risk provider is fail-soft (no de-rate, no crash)", async () => {
+    seedEarned(dir, "test-recipe", "githubCreatePR");
+    const gate = await buildWorkerAutonomyGate("test-recipe", undefined, opts, {
+      contextRiskProvider: async () => {
+        throw new Error("git blew up");
+      },
+    });
+    // provider threw → contextRisk undefined → earned action still flows.
+    expect(
+      await gate!({ toolId: "githubCreatePR", tier: "high", params: {} }),
+    ).toBe(true);
   });
 });
 

--- a/src/recipeOrchestration.ts
+++ b/src/recipeOrchestration.ts
@@ -114,6 +114,14 @@ export async function buildWorkerAutonomyGate(
   recipeName: string,
   tierApprovalFn?: ApprovalFn,
   trustOpts?: import("./workers/runWorkerShadow.js").RunWorkerShadowOpts,
+  ctxOpts?: {
+    /** Workspace root — git context-risk signals are gathered from here. */
+    workdir?: string;
+    /** Test injection: bypass the git collector with a fixed risk. */
+    contextRiskProvider?: () => Promise<
+      import("./workers/contextRisk.js").ContextRisk | undefined
+    >;
+  },
 ): Promise<ApprovalFn | null> {
   try {
     const { isEnabled, FLAG_WORKER_AUTONOMY } = await import(
@@ -132,12 +140,31 @@ export async function buildWorkerAutonomyGate(
     const queue = getApprovalQueue();
     const { worker, store } = trust;
 
+    // Context-risk: a live, situational DESCENDING de-rater resolved ONCE for the
+    // run (the working tree is ~constant during a run). Fail-soft — any error →
+    // no contextRisk → no de-rate (never widens). The decision then operates at
+    // min(earned, ceiling, contextCeiling).
+    let contextRisk: import("./workers/contextRisk.js").ContextRisk | undefined;
+    try {
+      if (ctxOpts?.contextRiskProvider) {
+        contextRisk = await ctxOpts.contextRiskProvider();
+      } else if (ctxOpts?.workdir) {
+        const { resolveGitContextRisk } = await import(
+          "./workers/contextRiskScorer.js"
+        );
+        contextRisk = await resolveGitContextRisk({ cwd: ctxOpts.workdir });
+      }
+    } catch {
+      contextRisk = undefined;
+    }
+
     return async (input) => {
       const decision = decideWorkerAction(
         worker,
         input.toolId,
         input.params,
         store,
+        contextRisk ? { contextRisk } : undefined,
       );
       // allow → defer to the tier gate so we never DROP tier-policy protection
       // (floor composition). When no tier fn is injected (approvalGate off),
@@ -1144,6 +1171,10 @@ export class RecipeOrchestration {
     const workerApprovalFn = await buildWorkerAutonomyGate(
       opts.name,
       tierApprovalFn,
+      undefined,
+      // Gather live context-risk signals from the workspace so the gate can
+      // throttle a worker in a dangerous situation (huge diff, on trunk).
+      { workdir: this.deps.workdir },
     );
     const requireApprovalFn = workerApprovalFn ?? tierApprovalFn;
     const gateAutomatedRuns = workerApprovalFn != null;

--- a/src/workers/__tests__/contextRiskScorer.test.ts
+++ b/src/workers/__tests__/contextRiskScorer.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+import { contextRiskCeiling } from "../contextRisk.js";
+import {
+  collectGitContextSignals,
+  type ExecFn,
+  resolveGitContextRisk,
+  scoreContextRisk,
+} from "../contextRiskScorer.js";
+
+describe("scoreContextRisk", () => {
+  it("a clean situation scores 0 with no reasons", () => {
+    const r = scoreContextRisk({ diffLines: 10, dirtyFiles: 1 });
+    expect(r.score).toBe(0);
+    expect(r.reasons).toBeUndefined();
+  });
+
+  it("escalates with uncommitted diff size", () => {
+    expect(scoreContextRisk({ diffLines: 250 }).score).toBeCloseTo(0.3);
+    expect(scoreContextRisk({ diffLines: 800 }).score).toBeCloseTo(0.5);
+    expect(scoreContextRisk({ diffLines: 5000 }).score).toBeCloseTo(0.9);
+  });
+
+  it("a huge diff alone caps autonomy to propose-only (ceiling 0)", () => {
+    const r = scoreContextRisk({ diffLines: 5000 });
+    expect(contextRiskCeiling(r.score)).toBe(0);
+    expect(r.reasons?.[0]).toContain("huge uncommitted diff");
+  });
+
+  it("combines moderate signals by noisy-OR (they compound)", () => {
+    // sizeable diff (0.3) + on default branch (0.3) → 1-(0.7*0.7)=0.51
+    const r = scoreContextRisk({ diffLines: 250, onDefaultBranch: true });
+    expect(r.score).toBeCloseTo(0.51, 2);
+    expect(contextRiskCeiling(r.score)).toBe(1); // crosses into elevated
+    expect(r.reasons).toHaveLength(2);
+  });
+
+  it("flags many dirty files and the default branch", () => {
+    expect(scoreContextRisk({ dirtyFiles: 25 }).score).toBeCloseTo(0.5);
+    expect(scoreContextRisk({ onDefaultBranch: true }).score).toBeCloseTo(0.3);
+    expect(scoreContextRisk({ onDefaultBranch: false }).score).toBe(0);
+  });
+});
+
+function fakeExec(out: Record<string, string>): ExecFn {
+  return async (_cmd, args) => {
+    const key = args.join(" ");
+    const v = out[key];
+    if (v !== undefined) return v;
+    throw new Error(`no fake for: ${key}`);
+  };
+}
+
+describe("collectGitContextSignals", () => {
+  it("parses numstat into diff lines + file count and detects the branch", async () => {
+    const s = await collectGitContextSignals({
+      cwd: "/x",
+      exec: fakeExec({
+        "diff HEAD --numstat":
+          "10\t5\tsrc/a.ts\n3\t2\tsrc/b.ts\n-\t-\timg.png\n",
+        "rev-parse --abbrev-ref HEAD": "main\n",
+      }),
+    });
+    expect(s.diffLines).toBe(20); // 10+5+3+2 (binary "-" counts 0)
+    expect(s.dirtyFiles).toBe(3);
+    expect(s.onDefaultBranch).toBe(true);
+  });
+
+  it("a feature branch is not the default branch", async () => {
+    const s = await collectGitContextSignals({
+      cwd: "/x",
+      exec: fakeExec({
+        "diff HEAD --numstat": "",
+        "rev-parse --abbrev-ref HEAD": "feat/thing\n",
+      }),
+    });
+    expect(s.onDefaultBranch).toBe(false);
+    expect(s.diffLines).toBe(0);
+  });
+
+  it("is fail-soft: a git error leaves signals undefined, never throws", async () => {
+    const s = await collectGitContextSignals({
+      cwd: "/x",
+      exec: async () => {
+        throw new Error("not a git repo");
+      },
+    });
+    expect(s.diffLines).toBeUndefined();
+    expect(s.onDefaultBranch).toBeUndefined();
+  });
+});
+
+describe("resolveGitContextRisk", () => {
+  it("returns a ContextRisk for a risky tree, undefined for a clean one", async () => {
+    const risky = await resolveGitContextRisk({
+      cwd: "/x",
+      exec: fakeExec({
+        "diff HEAD --numstat": "3000\t0\tsrc/huge.ts\n",
+        "rev-parse --abbrev-ref HEAD": "main\n",
+      }),
+    });
+    expect(risky?.score).toBeGreaterThan(0.8);
+
+    const clean = await resolveGitContextRisk({
+      cwd: "/x",
+      exec: fakeExec({
+        "diff HEAD --numstat": "1\t0\tsrc/tiny.ts\n",
+        "rev-parse --abbrev-ref HEAD": "feat/x\n",
+      }),
+    });
+    expect(clean).toBeUndefined();
+  });
+});

--- a/src/workers/contextRiskScorer.ts
+++ b/src/workers/contextRiskScorer.ts
@@ -1,0 +1,137 @@
+import { execSafe } from "../tools/utils.js";
+import type { ContextRisk } from "./contextRisk.js";
+
+/**
+ * The live producer behind the context-risk seam (workerGate / contextRisk.ts).
+ * Gathers cheap, dependency-light situational signals from the workspace and
+ * scores them into a `ContextRisk` the gate uses as a DESCENDING de-rater.
+ *
+ * Signals are deliberately the ones reliably available server-side during a
+ * recipe run (the bridge runs in a git repo): working-tree size + which branch.
+ * Diagnostics / coverage / CI are richer but require the extension / network and
+ * are added later. Everything is fail-soft: an unavailable signal simply doesn't
+ * contribute, and a total failure yields score 0 (no de-rate, never widens).
+ * See docs/worker-autonomy-policy-gate.md §3a.
+ */
+
+/** Raw situational signals. All optional — absent ⇒ no contribution. */
+export interface ContextSignals {
+  /** Uncommitted lines changed (added + deleted) vs HEAD. */
+  diffLines?: number;
+  /** Files with uncommitted changes vs HEAD. */
+  dirtyFiles?: number;
+  /** HEAD is the default branch (main/master) — acting on trunk is riskier
+   *  than on a feature branch that can be reviewed before merge. */
+  onDefaultBranch?: boolean;
+}
+
+/**
+ * Pure scorer: signals → ContextRisk (0..1 + human reasons). Each signal
+ * contributes risk independently and they combine by NOISY-OR
+ * (`1 − ∏(1 − sᵢ)`), so several moderate signals compound toward "act with
+ * caution" without any single one needing to be severe. Higher = more dangerous
+ * to act RIGHT NOW. Pure + deterministic.
+ */
+export function scoreContextRisk(signals: ContextSignals): ContextRisk {
+  const contribs: Array<{ score: number; reason: string }> = [];
+
+  if (signals.diffLines !== undefined) {
+    if (signals.diffLines >= 2000)
+      contribs.push({
+        score: 0.9,
+        reason: `huge uncommitted diff (${signals.diffLines} lines)`,
+      });
+    else if (signals.diffLines >= 500)
+      contribs.push({
+        score: 0.5,
+        reason: `large uncommitted diff (${signals.diffLines} lines)`,
+      });
+    else if (signals.diffLines >= 200)
+      contribs.push({
+        score: 0.3,
+        reason: `sizeable uncommitted diff (${signals.diffLines} lines)`,
+      });
+  }
+  if (signals.dirtyFiles !== undefined && signals.dirtyFiles >= 20)
+    contribs.push({
+      score: 0.5,
+      reason: `${signals.dirtyFiles} files with uncommitted changes`,
+    });
+  if (signals.onDefaultBranch)
+    contribs.push({
+      score: 0.3,
+      reason: "operating directly on the default branch",
+    });
+
+  const score =
+    contribs.length === 0
+      ? 0
+      : 1 - contribs.reduce((p, c) => p * (1 - c.score), 1);
+  return {
+    score,
+    ...(contribs.length > 0 && { reasons: contribs.map((c) => c.reason) }),
+  };
+}
+
+/** Injectable command runner (returns stdout). Defaults to the bridge's
+ *  allowlisted `execSafe` over `cwd`. Exposed so tests supply fake git output. */
+export type ExecFn = (cmd: string, args: string[]) => Promise<string>;
+
+/**
+ * Gather git working-tree signals. Fully fail-soft: any git error leaves the
+ * corresponding signal undefined (→ no contribution). Never throws.
+ */
+export async function collectGitContextSignals(opts: {
+  cwd: string;
+  exec?: ExecFn;
+}): Promise<ContextSignals> {
+  const exec: ExecFn =
+    opts.exec ??
+    (async (cmd, args) =>
+      (await execSafe(cmd, args, { cwd: opts.cwd, timeout: 5000 })).stdout);
+  const signals: ContextSignals = {};
+
+  try {
+    // `diff HEAD` = staged + unstaged vs the last commit (the full uncommitted
+    // delta). `--numstat` is `<added>\t<deleted>\t<path>` per file ("-" binary).
+    const numstat = await exec("git", ["diff", "HEAD", "--numstat"]);
+    let lines = 0;
+    let files = 0;
+    for (const row of numstat.split("\n")) {
+      const m = /^(\d+|-)\t(\d+|-)\t/.exec(row);
+      if (!m) continue;
+      files++;
+      lines +=
+        (m[1] === "-" ? 0 : Number(m[1])) + (m[2] === "-" ? 0 : Number(m[2]));
+    }
+    signals.diffLines = lines;
+    signals.dirtyFiles = files;
+  } catch {
+    /* git unavailable / not a repo → leave diff signals undefined */
+  }
+
+  try {
+    const branch = (
+      await exec("git", ["rev-parse", "--abbrev-ref", "HEAD"])
+    ).trim();
+    signals.onDefaultBranch = branch === "main" || branch === "master";
+  } catch {
+    /* ignore */
+  }
+
+  return signals;
+}
+
+/** Convenience: collect + score in one fail-soft call. Returns undefined when
+ *  the situation is clean (score 0) so callers can omit the field. */
+export async function resolveGitContextRisk(opts: {
+  cwd: string;
+  exec?: ExecFn;
+}): Promise<ContextRisk | undefined> {
+  try {
+    const risk = scoreContextRisk(await collectGitContextSignals(opts));
+    return risk.score > 0 ? risk : undefined;
+  } catch {
+    return undefined;
+  }
+}


### PR DESCRIPTION
## Why

#1040 shipped the context-risk **seam** (the gate *accepts* a descending de-rater). This wires the live **producer**: a worker is now throttled toward propose-only when the **situation** is dangerous, independent of its earned trust — the fast, day-1, no-cold-start half of the autonomy decision that approve-similar structurally can't model (`docs/worker-autonomy-policy-gate.md` §3a).

## What

- **`contextRiskScorer.ts`**
  - `scoreContextRisk(signals)` — pure, **noisy-OR** over uncommitted-diff-size / dirty-file-count / on-default-branch, → `{ score, reasons }`.
  - `collectGitContextSignals({ cwd, exec? })` — injectable-exec git collector (`git diff HEAD --numstat`, branch), fully **fail-soft**.
  - `resolveGitContextRisk` — collect + score; `undefined` when clean.
- **`buildWorkerAutonomyGate`** resolves context-risk **once per run** (the working tree is ~constant during a run) from `deps.workdir`, and passes it to every `decideWorkerAction` → `effectiveLevel = min(earned, ceiling, contextCeiling)`. A `contextRiskProvider` injection point makes the wiring testable without git fixtures. Wrapped in try/catch → a failing resolver **never crashes a run**.

## Invariants
- **Descending only** — context-risk can lower autonomy, never raise it (never-widen).
- Behind `FLAG_WORKER_AUTONOMY` (default-off); resolved only when a worker owns the recipe → non-worker recipes byte-identical.
- Any git error → score 0 → no de-rate.

## Tests
- Scorer (thresholds, noisy-OR compounding, reasons), collector (numstat/branch parse + fail-soft), and **orchestration wiring**: an *earned* `githubCreatePR` is de-rated to a gate under dangerous context; a failing provider is fail-soft (action still flows).
- 1677 worker + recipe tests green; build + strict typecheck + biome + fixture gate clean.

## Follow-ups
Richer signals (diagnostics / coverage / CI status) once extension/network availability is handled; per-action (not per-run) context for actions that touch specific files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)