### PR TITLE
docs: sync project docs with worker autonomy subsystem (#1011–#1042)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,7 @@ Comply with all docs in `/documents/`. Consult before changes:
 - **[documents/data-reference.md](documents/data-reference.md)** — Data flows, state mgmt, protocol details. Consult before modifying connection/auth/state logic.
 - **[documents/plugin-authoring.md](documents/plugin-authoring.md)** — Plugin manifest schema, entrypoint API, distribution.
 - **[docs/adr/](docs/adr/)** — Architecture Decision Records. Read before touching version numbers, lock files, error codes, session mgmt, or reconnect logic.
+- **[docs/runbooks/](docs/runbooks/)** — Operator runbooks for live campaigns (worker-autonomy-dogfood.md, etc.).
 
 > **Cowork (computer-use) sessions:** MCP bridge tools NOT available inside Cowork. Run `/mcp__bridge__cowork` in regular Desktop chat first to capture IDE context, then switch to Cowork. Cowork runs in isolated git worktree — output won't appear in `git status` on main until merged. (see [docs/cowork.md](docs/cowork.md))
 
@@ -41,7 +42,7 @@ Comply with all docs in `/documents/`. Consult before changes:
 - `recipe list` — Print installed recipes from the active bridge.
 - `recipe install <source>` — Install from `github:owner/repo[/path][@ref]`. Same shape the dashboard install panel posts.
 - `recipe uninstall <name>` — Remove a locally installed recipe.
-- `recipe enable <name>` / `recipe disable <name>` — Flip the per-recipe disabled marker so cron / file-watch triggers stop firing without uninstalling. Used by the dashboard's pause toggle.
+- `recipe enable <name>` / `recipe disable <name>` — Flip the per-recipe disabled marker so cron / file-watch / git-hook triggers stop firing without uninstalling. Used by the dashboard's pause toggle.
 - `recipe run <name> [--local --dry-run --step <id> --attempt <n> --ledger-dir <path> --var k=v]` — Manual run with overrides; `--local` skips the bridge API.
 - `recipe lint <file.yaml>` — Lint a recipe YAML against the schema + best-practice rules.
 - `recipe preflight <file.yaml>` — Connector preflight: list authorisations the recipe needs.
@@ -62,6 +63,8 @@ Comply with all docs in `/documents/`. Consult before changes:
 - `analytics show|configure|clear|test` — Manage the opt-in telemetry collector config (endpoint + shared secret) at `~/.claude/ide/analytics-config.json` (mode 0600). Replaces the brittle pattern of putting the secret in a launchd plist. `configure --endpoint URL --key KEY` writes both atomically; `test` sends a tiny synthetic payload and reports the HTTP status; `show` prints active values and resolution source (env / config / default). Env vars still win for headless/CI.
 - `panic` — Shortcut for `kill-switch engage --reason "manual panic"`.
 - `judgments [--window 1h|24h|overnight|7d|any] [--recipe <name>] [--json]` — Recent judge-step verdicts (from recipe steps with `agent.kind: judge`) across runs. Discovers the running bridge via lock file, queries `/runs/judge-summary`, prints per-verdict counts + 5 most-recent. Sibling of `halts`; same window/filter shape.
+- `workers shadow [--workers-dir <path>]` — Replay run + gate logs to show per-worker × action-class trust dial and ramp-vs-gate divergences. Primary monitoring tool during the worker autonomy dogfood campaign. See [docs/runbooks/worker-autonomy-dogfood.md](docs/runbooks/worker-autonomy-dogfood.md).
+- `workers backtest [--workers-dir <path>]` — Cold-start calibration: replay historical runs as if the gate were live; measures how many shadow divergences the gate would have produced.
 - `suggest [--since-days N]` — Recipe co-occurrence + unused-tool suggestions from recent activity.
 - `traces export [--passphrase <p>] [--mode keyed|public] > file.jsonl` — Export decision traces; `--mode keyed` encrypts with the passphrase.
 - `traces import [--passphrase <p>] [--dry-run] < file.jsonl` — Restore traces from an export.
@@ -98,6 +101,7 @@ Most users don't need to touch these — CLI flags cover the common cases. Liste
 | `PATCHWORK_TOKEN_DIR` / `PATCHWORK_TOKEN_STORAGE_BACKEND` | Connector-token storage location + backend (`file` vs `keychain`). |
 | `PATCHWORK_FLAG_KILL_SWITCH_WRITES` | Feature flag — gate write tools on kill-switch state. |
 | `PATCHWORK_FLAG_UI_SCHEMA_LINT` | Feature flag — strict UI-schema linting in the recipe editor. |
+| `PATCHWORK_FLAG_WORKER_AUTONOMY` | Feature flag — enable trust-ramp-aware autonomy gate for worker recipes. Gates compensable/irreversible automated recipe actions until the owning worker earns L4 trust on that action-class; reversible actions always flow freely. Default off. Requires `--driver subprocess`. |
 | `LOCAL_MODEL` / `LOCAL_ENDPOINT` / `LOCAL_API_KEY` / `LOCAL_ENDPOINT_ALLOW_REMOTE` | Local-model driver config (Ollama / vLLM / OpenAI-compatible endpoint). |
 | `OTEL_SERVICE_NAME` | Override the OTel service name (default `claude-ide-bridge`). |
 | `PATCHWORK_ANALYTICS_ENDPOINT` | Override the opt-in telemetry collector URL (default `https://analytics.claude-ide-bridge.dev/v1/usage`). Must be `http(s)://`; invalid values fall back to default. Per-call resolution; precedence: env > config file > default. For CI/headless. Prefer `patchwork analytics configure` for persistent setups — keeps the secret out of launchd plists. |
@@ -230,6 +234,19 @@ All LSP tools available in both slim and full mode (full is the default since v2
 | Links / file refs in doc? | `getDocumentLinks` |
 | Code lens counts? | `getCodeLens` |
 
+## Workers / Autonomy Gate
+
+The `src/workers/` subsystem implements a trust-ramp-aware autonomy gate for recipe-bound workers.
+
+- **Worker identity**: a worker = a named recipe identity. Trust is per `(workerName × actionClassKey)` — never global. Competence demonstrated on reversible low-blast actions (reads, CI) cannot transfer to compensable or irreversible high-blast actions (git push, PR merge, file delete).
+- **Trust levels**: L0–L4, Bayesian Beta posterior + LCB threshold. `outcomeWeight` is blast-weighted so one high-blast failure outweighs many trivial successes.
+- **Gate formula**: `effectiveLevel = min(earned, autonomyCeiling, contextCeiling)`. The `contextCeiling` is a descending-only seam — signals can only lower autonomy, never raise it (NaN / out-of-range → no de-rate).
+- **Autonomy thresholds**: reversible actions bypass the gate unconditionally. Compensable actions unlock at effective L2. Irreversible actions require L4.
+- **Feature flag**: `PATCHWORK_FLAG_WORKER_AUTONOMY` (default off). With the flag off, the gate is a no-op — byte-identical to pre-ramp behavior. Requires `--driver subprocess`.
+- **Dogfood templates**: `templates/workers/` — three reference workers (release-notes, dependency-bump, triage-failing-tests).
+- **Monitoring**: `patchwork workers shadow` replays logs and shows per-worker × action-class trust dial + ramp-vs-gate divergences. `patchwork workers backtest` calibrates cold-start without touching live gate behavior.
+- **Full reference**: [docs/worker-autonomy-policy-gate.md](docs/worker-autonomy-policy-gate.md), [docs/runbooks/worker-autonomy-dogfood.md](docs/runbooks/worker-autonomy-dogfood.md).
+
 ## Architecture Rules
 
 - **Tools**: factory pattern `createXxxTool(deps)` returning `{ schema, handler }`. Register in `src/tools/index.ts`.
@@ -304,7 +321,9 @@ Full reference: [documents/platform-docs.md](documents/platform-docs.md) (Claude
 
 Event-driven hooks that trigger Claude tasks automatically.
 
-- **Activation**: `--automation --automation-policy <path.json> --driver subprocess`
+- **Activation**: Two paths:
+  1. `--automation --automation-policy <path.json> --driver subprocess` — explicit policy file; hooks fire immediately and stay active for the bridge lifetime.
+  2. Auto-enable (no `--automation` flag needed) — when `--driver` is non-none and at least one installed recipe declares a `file_watch`, `git_hook`, `on_file_save`, or `on_test_run` trigger, the bridge stands up a policy-less `AutomationHooks` at startup. **Startup-only**: installing a trigger recipe mid-session requires a bridge restart to take effect unless `--automation` is also active. `file_watch` and `git_hook` triggers hot-reload on recipe install/save/delete via `onRecipesChangedFn`; `on_file_save` and `on_test_run` are startup-only under the auto-enable path.
 - **Hooks**:
   - `onDiagnosticsStateChange` (v2.43.0+) — unified diagnostics hook. `state: "error"` fires on new error/warning diagnostics (`{{file}}`, `{{diagnostics}}`, severity filter). `state: "cleared"` fires when errors/warnings drop to zero (`{{file}}`). Replaces deprecated `onDiagnosticsError` + `onDiagnosticsCleared`.
   - `onFileSave` — matching files saved. Minimatch glob patterns. Placeholder: `{{file}}`.
@@ -317,7 +336,7 @@ Event-driven hooks that trigger Claude tasks automatically.
   - `onGitPush` — fires after successful `gitPush`. Placeholders: `{{remote}}`, `{{branch}}`, `{{hash}}`.
   - `onBranchCheckout` — fires after successful `gitCheckout`. Placeholders: `{{branch}}`, `{{previousBranch}}`, `{{created}}`.
   - `onPullRequest` — fires after successful `githubCreatePR`. Placeholders: `{{url}}`, `{{number}}`, `{{title}}`, `{{branch}}`.
-  - `onTestRun` — fires after `runTests` completes. Placeholders: `{{runner}}`, `{{failed}}`, `{{passed}}`, `{{total}}`, `{{failures}}` (JSON array). Supports `filter: "any"|"failure"|"pass-after-fail"` (v2.43.0+). `"pass-after-fail"` replaces the deprecated separate `onTestPassAfterFailure` hook. Legacy `onFailureOnly` boolean still works but emits a deprecation warning.
+  - `onTestRun` — fires after `runTests` completes. **Caveat**: only fires when tests are invoked via the bridge `runTests` tool — bare `npm test` / `npx vitest` invocations do NOT trigger this hook. Placeholders: `{{runner}}`, `{{failed}}`, `{{passed}}`, `{{total}}`, `{{failures}}` (JSON array). Supports `filter: "any"|"failure"|"pass-after-fail"` (v2.43.0+). `"pass-after-fail"` replaces the deprecated separate `onTestPassAfterFailure` hook. Legacy `onFailureOnly` boolean still works but emits a deprecation warning.
   - `onTaskCreated` — fires on Claude Code TaskCreated hook (CC 2.1.84+). Placeholders: `{{taskId}}`, `{{prompt}}`.
   - `onTaskSuccess` — fires when orchestrator task completes successfully. Placeholders: `{{taskId}}`, `{{output}}`.
   - `onPermissionDenied` — fires on Claude Code PermissionDenied hook (CC 2.1.89+). Placeholders: `{{tool}}`, `{{reason}}`.

--- a/docs/adr/0006-approval-gate-design.md
+++ b/docs/adr/0006-approval-gate-design.md
@@ -80,13 +80,15 @@ Changeable at runtime — no reconnect, no hook reinstall — because the gate i
 
 ### Risk signals
 
-High-tier tools are tagged with `riskSignals` ([src/approvalHttp.ts](../../src/approvalHttp.ts) `computeRiskSignals`) that the dashboard surfaces as badges:
+Risk signals are computed by `computeRiskSignals` in [`src/riskSignals.ts`](../../src/riskSignals.ts) (shared module, replaces former inline logic in `src/approvalHttp.ts`) and surfaced as dashboard badges:
 
 - Destructive flags: `rm -rf`, `--force`, `sudo`, `DROP TABLE`, `TRUNCATE`, shell chaining.
 - Domain reputation: non-HTTPS, raw IP hostname.
 - Path escape: `file_path` outside workspace.
+- **Destructive command (HIGH)**: `git reset --hard`, `git clean -f/-d/--force`, `git push --force` without `--force-with-lease`, `eval`, `chmod 777`, `kill -9`, `pkill`. Also applied to structured `runCommand{command, args}` calls (args joined before pattern matching).
+- **Data exfiltration (HIGH)**: network-egress upload flag co-occurring with a credential-path token (`~/.ssh`, `~/.aws`, `.env`, `id_rsa`, `.npmrc`, `.netrc`, etc.).
 
-Signals are advisory — they don't change the decision, they help the human decide.
+**Amendment (PR #1015):** Signals are now **escalatory**, not advisory. A sub-high-tier tool that carries any HIGH-severity signal (`hasHighSeverity = true`) is promoted from bypass → queue. Both WebSocket and Streamable-HTTP transports are content-aware via `evaluateInProcessGate()` (previously both hardcoded `riskSignals:[]`).
 
 ## Consequences
 

--- a/docs/worker-autonomy-policy-gate.md
+++ b/docs/worker-autonomy-policy-gate.md
@@ -1,6 +1,7 @@
 # Worker Autonomy — the Policy Gate (keystone)
 
-**Status:** design / sequencing doc · 2026-06-30
+**Status:** implementation complete · last updated 2026-06-30
+**Shipped:** compensable-at-L2 gate (#1036), contextRisk seam + AutonomyDecisionOpts keystone (#1040), cold-start priors (#1037), shadow machinery (#1025), trust-dial dashboard (#1026), live gate (FLAG_WORKER_AUTONOMY, #1027), durable-outcome labels (#1042), agent-step sandbox (#1039).
 **Scope:** `src/workers/` — generalize the autonomy decision from a threshold on
 one slow signal into a policy over several signals, most of them fast.
 
@@ -104,10 +105,22 @@ sandbox shipped in #1039) while making the decision richer.
 
 | Weakness | Input | Speed | Already shipped? |
 |---|---|---|---|
-| Cold-start latency | **backtest-as-divergence** (prime the posterior from history) | compute, not wall-clock | partial — shadow machinery exists |
+| Cold-start latency | **prior pseudo-count** (reduces novel-floor latency) | instant | **SHIPPED — #1037**; **backtest-as-divergence** (calibrate from history) is the follow-on |
 | Sparse high-blast samples | **compositional trust** (policy over earned sub-claims) | — | no |
 | Non-stationarity | **regime_freshness** (time-decay + discontinuity markers) | medium | partial — `minEvidenceAtLastPromotion` (#1039) is a special case |
-| Wrong unit of trust | **context_risk** (live situational de-rater) | fast, day-1 | no |
+| Wrong unit of trust | **context_risk** (live situational de-rater) | fast, day-1 | **SHIPPED — #1040** |
+
+> **Shadow machinery**: **SHIPPED — #1025**. `shadowObserver` + `shadowReport` + `runWorkerShadow` all live. `patchwork workers shadow` is the primary observability tool.
+
+> **Action-class domain taxonomy**: the `vcs-remote` domain **no longer exists** (split into `vcs-push` for `gitPush` and `vcs-merge` for `githubMergePR` in #1038). Trust earned on PR creation cannot unlock push/merge — domains must not span operations with materially different blast radius or reversibility. `linear.list_issues` and `sentry.get_issue` moved from compensable to `issue-read` (reversible) in #1038. Read operations belong in reversible domains regardless of which tool they use.
+
+> **autonomyCeiling=1 safety callout**: ceiling=1 blocks compensable actions even at earned L4 (ceiling caps `effectiveLevel` before the L2 check). One worker in ceiling-1 mode will never autonomously push, merge, or file issues regardless of earned trust.
+
+> **Shadow observer correctness**: (1) `ingestDecision` silently drops `DecisionRecord` without `recipeName` — general `approvalGate` MCP approvals from Claude Code sessions are excluded from ramp comparison (#1034); (2) `ingestRun` skips steps whose `haltReason` categorizes as `approval_rejected` — human-rejected/expired/cancelled approvals do not poison the Beta posterior (#1028); (3) `owned` field on `WorkerShadowReport` board rows — not-owned rows flagged `⚠ NOT OWNED — gate floors to L0` (#1028).
+
+> **Worker evidence filtering**: `readRuns()` queries filtered by worker recipe names (not global last-100 window) so sparse-worker evidence is not aged out by unrelated recipe traffic (#1039). Recipe names are deduped before evidence aggregation to prevent double-counting.
+
+> **Known limitation**: recipe-run step tool IDs (e.g. `git.log_since`, `file.write`) do not yet map to `DOMAIN_BY_TOOL`, which keys on MCP tool names. Steps using recipe-native tool IDs are classified as `domain:other`; autonomy dial attribution is approximate until the taxonomy is extended.
 
 ### 3a. `context_risk` — the fast second dial (highest leverage, build first)
 
@@ -191,13 +204,13 @@ primitives are the substrate. (Caveat to NOT pretend: for genuinely
 rare+irreversible+high-blast actions the correct product answer is "10 approvals →
 1 *considered* approval," never zero — which is already the repo's KPI.)
 
-A precondition for all of the above: **durable-outcome labels.** Today
-`good = step.status === "ok"` (absence-of-error) — an optimistic proxy. A PR that
-merged isn't a PR that was *good*. Trust must update on **durable** outcomes (not
-reverted, survived N days, issue not reopened, deploy not rolled back), which the
-bridge can already detect (`enrichCommit`, `getCommitsForIssue`, revert/reopen).
-Until the label is durable, every posterior is confidently measuring the wrong
-event — this is the honest foundation under all four inputs.
+**Durable-outcome labels** — **SHIPPED #1042.** `isDurableSuccess(reversibility, runAt, now, windowMs)` pure predicate; `DEFAULT_DURABILITY_WINDOW_MS = 24h`. Reversible successes and all failures count immediately. Compensable/irreversible successes are withheld until they survive the durability window. `now` is injected via opts on `buildShadowReport` / `getWorkerShadowData` / `loadWorkerTrustForRecipe` (production defaults to `Date.now()`). Revert/close detection within the window remains future work.
+
+---
+
+## 2b. Agent-step autonomy sandbox (shipped #1039)
+
+`disallowedToolsForAgentStep()` emits both bare and `mcp__patchwork__`-prefixed forms for known-risky domains. These are merged into the flat + chained agent paths via `mergeAgentDisallowedTools`. Enforcement requires `--driver subprocess` — `agentExecutor` **fails closed** (`enforceSandbox` flag) on any other driver rather than silently skipping the deny list. Unknown tools are NOT blanket-denied (preserves harmless reads).
 
 ---
 
@@ -225,3 +238,13 @@ engine, and reframe its claim from "earned autonomy" to **institutional reliabil
 memory**: a track record that survives across actions and adapts to drift — which a
 stateless context-risk score cannot tell, and which is the one thing the posterior
 uniquely earns. Ship the Bayes quietly; sell the governance.
+
+> **Considered-approval KPI** — **LIVE as of #1032**: `GET /approvals/kpi` tracks reject rate, latency percentiles, channel split, and rubber-stamp warnings per worker × action-class. Dashboard: Workers page `ConsideredApprovalPanel`.
+
+---
+
+## See also
+
+- [docs/runbooks/worker-autonomy-dogfood.md](runbooks/worker-autonomy-dogfood.md) — operator runbook for the live dogfood campaign
+- `src/workers/` — implementation
+- `templates/workers/` — three reference worker manifests


### PR DESCRIPTION
## Summary

62-agent workflow reviewed all 30 PRs merged in the last 2 weeks and identified documentation gaps. This PR applies the critical updates.

**Files changed:**
- `CLAUDE.md` — 6 additions/corrections
- `docs/adr/0006-approval-gate-design.md` — corrects factually wrong "signals are advisory" claim
- `docs/worker-autonomy-policy-gate.md` — upgrades from design doc to accurate implementation reference

## What changed and why

### CLAUDE.md
- **`PATCHWORK_FLAG_WORKER_AUTONOMY`** added to env var table (was missing entirely — PRs #1027/#1030 both flagged this independently)
- **Workers / Autonomy Gate** architecture section added — `src/workers/` had zero orientation for new developers
- **`workers shadow` / `workers backtest`** CLI commands added — referenced in runbook but absent from CLI reference
- **Automation Policy activation** corrected — #1019 added auto-enable path (recipe triggers fire without `--automation` when `--driver` is active); old text was flat wrong
- **`recipe enable/disable`** updated to include git-hook triggers (wired in #1016)
- **`on_test_run` caveat** added — fires only via bridge `runTests`, not bare `npm test`
- **`docs/runbooks/`** added to Documentation section

### docs/adr/0006-approval-gate-design.md
- Corrects: "Signals are advisory — they don't change the decision" — **factually wrong** since #1015. HIGH-severity signals now promote sub-high-tier tools from bypass → queue.
- Updates source ref: `approvalHttp.ts` → shared `riskSignals.ts`
- Adds two new HIGH signal kinds: `destructive_command`, `data_exfiltration`

### docs/worker-autonomy-policy-gate.md
- Status updated from "design doc" → "implementation complete"
- Weakness table updated: cold-start priors SHIPPED (#1037), context_risk SHIPPED (#1040), shadow SHIPPED (#1025)
- `vcs-remote` domain removal noted (split into `vcs-push`/`vcs-merge` in #1038 — trust-transfer attack fix)
- Shadow observer correctness callouts (#1028, #1034)
- Agent-step sandbox section added (#1039)
- Durable-outcome labels marked shipped (#1042)
- `autonomyCeiling=1` safety callout added
- Considered-approval KPI noted as live (#1032)
- See Also section added

## Not in this PR (minor/ADR candidates)
- `documents/platform-docs.md` updates (GET /approvals/kpi, git_hook trigger row, sandbox fields, risk signal section) — follow-on
- `documents/triggers.md` on_file_save row — follow-on
- `documents/roadmap.md` version bump + worker ramp milestone — follow-on
- 5 ADR candidates (ADR-0017 through ADR-0021) — separate PRs

## Test plan
- [ ] Read CLAUDE.md Workers section — confirms `src/workers/` orientation
- [ ] Read ADR-0006 Risk signals section — confirms escalatory (not advisory) language
- [ ] Read worker-autonomy-policy-gate.md — confirms shipped status, no stale "design doc" language

🤖 Generated with [Claude Code](https://claude.com/claude-code)