### PR TITLE
feat(workers): Decision Record — persist every gate decision + its inputs

### DIFF
--- a/src/__tests__/recipeOrchestration.workerGate.test.ts
+++ b/src/__tests__/recipeOrchestration.workerGate.test.ts
@@ -23,6 +23,7 @@ import {
   buildWorkerAutonomyGate,
 } from "../recipeOrchestration.js";
 import { RecipeRunLog } from "../runLog.js";
+import type { RecordGateDecisionInput } from "../workerGateDecisionLog.js";
 
 /** Seed durable, dwell-separated successes so the worker earns autonomy on
  *  `tool`'s class (ancient timestamps → durable under durable-outcome labels). */
@@ -223,6 +224,44 @@ describe("buildWorkerAutonomyGate", () => {
     expect(
       await gate!({ toolId: "githubCreatePR", tier: "high", params: {} }),
     ).toBe(true);
+  });
+
+  it("records a Decision Record on BOTH the gate and allow paths", async () => {
+    const records: RecordGateDecisionInput[] = [];
+    const gate = await buildWorkerAutonomyGate("test-recipe", undefined, opts, {
+      recordGateDecision: (r) => records.push(r),
+    });
+    // GATE path: unowned risky gitPush (worker owns vcs-remote, not vcs-push).
+    const p = gate!({ toolId: "gitPush", tier: "high", params: {} });
+    await tick();
+    getApprovalQueue().reject(firstCallId());
+    await p;
+    // ALLOW path: reversible editText flows.
+    expect(await gate!({ toolId: "editText", tier: "low", params: {} })).toBe(
+      true,
+    );
+
+    const gated = records.find((r) => r.toolName === "gitPush");
+    const allowed = records.find((r) => r.toolName === "editText");
+    expect(gated?.action).toBe("gate"); // autonomous gate is recorded
+    expect(allowed?.action).toBe("allow"); // and the allow leaves a trail too
+    // the record carries the decision INPUTS, not just a verdict
+    expect(gated?.classKey).toContain("vcs-push");
+    expect(gated?.owned).toBe(false);
+    expect(gated?.gatePolicyVersion).toBe("worker-ramp-v0");
+    expect(allowed?.reversibility).toBe("reversible");
+  });
+
+  it("a throwing recordGateDecision never blocks the gate (fail-soft)", async () => {
+    const gate = await buildWorkerAutonomyGate("test-recipe", undefined, opts, {
+      recordGateDecision: () => {
+        throw new Error("disk full");
+      },
+    });
+    // logging blew up, but the reversible action still flows.
+    expect(await gate!({ toolId: "editText", tier: "low", params: {} })).toBe(
+      true,
+    );
   });
 });
 

--- a/src/__tests__/workerGateDecisionLog.test.ts
+++ b/src/__tests__/workerGateDecisionLog.test.ts
@@ -1,0 +1,118 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  type RecordGateDecisionInput,
+  WorkerGateDecisionLog,
+} from "../workerGateDecisionLog.js";
+
+let dir: string;
+beforeEach(() => {
+  dir = mkdtempSync(path.join(os.tmpdir(), "pw-gate-decisions-"));
+});
+afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+function rec(
+  over: Partial<RecordGateDecisionInput> = {},
+): RecordGateDecisionInput {
+  return {
+    recipeName: "triage",
+    workerId: "w1",
+    toolName: "githubCreateIssue",
+    action: "gate",
+    classKey: "issue:compensable:high",
+    domain: "issue",
+    owned: true,
+    blastTier: "high",
+    reversibility: "compensable",
+    earnedLevel: 0,
+    autonomyCeiling: 4,
+    effectiveLevel: 0,
+    reason: "compensable + unearned (effective L0 < L4) — gated for approval",
+    gatePolicyVersion: "worker-ramp-v0",
+    ...over,
+  };
+}
+
+describe("WorkerGateDecisionLog", () => {
+  it("records a decision and reads it back with assigned seq + decidedAt", () => {
+    const log = new WorkerGateDecisionLog({ dir, now: () => 1234 });
+    const r = log.record(rec());
+    expect(r.seq).toBe(1);
+    expect(r.decidedAt).toBe(1234);
+    const [back] = log.query();
+    expect(back?.toolName).toBe("githubCreateIssue");
+    expect(back?.gatePolicyVersion).toBe("worker-ramp-v0");
+  });
+
+  it("persists context-risk inputs only when present", () => {
+    const log = new WorkerGateDecisionLog({ dir });
+    const withRisk = log.record(
+      rec({
+        contextCeiling: 0,
+        contextRiskScore: 0.9,
+        contextRiskReasons: ["huge diff"],
+      }),
+    );
+    expect(withRisk.contextCeiling).toBe(0);
+    expect(withRisk.contextRiskScore).toBe(0.9);
+    expect(withRisk.contextRiskReasons).toEqual(["huge diff"]);
+    const clean = log.record(rec());
+    expect(clean).not.toHaveProperty("contextCeiling");
+    expect(clean).not.toHaveProperty("contextRiskScore");
+  });
+
+  it("filters by workerId / classKey / action / since / after", () => {
+    const log = new WorkerGateDecisionLog({ dir, now: () => 100 });
+    log.record(rec({ workerId: "w1", action: "gate" }));
+    log.record(
+      rec({
+        workerId: "w2",
+        action: "allow",
+        classKey: "vcs-push:compensable:high",
+      }),
+    );
+    expect(log.query({ workerId: "w1" })).toHaveLength(1);
+    expect(log.query({ action: "allow" })).toHaveLength(1);
+    expect(log.query({ classKey: "vcs-push:compensable:high" })).toHaveLength(
+      1,
+    );
+    expect(log.query({ after: 1 })).toHaveLength(1); // seq > 1 → only the 2nd
+    expect(log.query({ since: 200 })).toHaveLength(0);
+  });
+
+  it("validates required identity fields + a legal action", () => {
+    const log = new WorkerGateDecisionLog({ dir });
+    expect(() => log.record(rec({ recipeName: "" }))).toThrow(/recipeName/);
+    expect(() => log.record(rec({ workerId: "  " }))).toThrow(/workerId/);
+    expect(() => log.record(rec({ classKey: "" }))).toThrow(/classKey/);
+    expect(() =>
+      log.record(rec({ action: "approve" as unknown as "gate" })),
+    ).toThrow(/action/);
+  });
+
+  it("clips an overlong reason + caps context reasons", () => {
+    const log = new WorkerGateDecisionLog({ dir });
+    const r = log.record(
+      rec({
+        reason: "x".repeat(5000),
+        contextRiskReasons: Array.from({ length: 50 }, (_, i) => `r${i}`),
+      }),
+    );
+    expect(r.reason.length).toBeLessThanOrEqual(1000);
+    expect((r.contextRiskReasons ?? []).length).toBeLessThanOrEqual(16);
+  });
+
+  it("survives a process restart (loadExisting from JSONL)", () => {
+    const a = new WorkerGateDecisionLog({ dir });
+    a.record(rec({ toolName: "gitPush" }));
+    a.record(rec({ toolName: "githubMergePR" }));
+    // a fresh instance reads the persisted rows
+    const b = new WorkerGateDecisionLog({ dir });
+    expect(b.size()).toBe(2);
+    expect(b.query().map((r) => r.toolName)).toContain("githubMergePR");
+    // seq continues monotonically, not reset
+    expect(b.record(rec()).seq).toBe(3);
+  });
+});

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -67,6 +67,7 @@ import { resolveFilePath } from "./tools/utils.js";
 import { McpTransport } from "./transport.js";
 import { PACKAGE_VERSION } from "./version.js";
 import { wireHaltPushDispatch } from "./wireHaltPushDispatch.js";
+import { WorkerGateDecisionLog } from "./workerGateDecisionLog.js";
 
 const SHUTDOWN_TIMEOUT_MS = 5000;
 
@@ -186,6 +187,7 @@ export class Bridge {
   private recipeOrchestrator: RecipeOrchestrator | null = null;
   private commitIssueLinkLog: CommitIssueLinkLog | null = null;
   private decisionTraceLog: DecisionTraceLog | null = null;
+  private workerGateDecisionLog: WorkerGateDecisionLog | null = null;
   /** Pre-computed digest of recent decisions, refreshed on each session connect. */
   private recentTracesDigest: string[] = [];
   private httpMcpHandler: StreamableHttpHandler | null = null;
@@ -504,6 +506,7 @@ export class Bridge {
         this.commitIssueLinkLog ?? undefined,
         this.recipeRunLog ?? undefined,
         this.decisionTraceLog ?? undefined,
+        this.workerGateDecisionLog ?? undefined,
       );
 
       transport.attach(ws);
@@ -1044,6 +1047,12 @@ export class Bridge {
       dir: patchworkDir,
       logger: this.logger,
     });
+    // Decision Record store — every worker-gate decision + inputs (replayable
+    // audit trail). Always available so the gate's decisions are never discarded.
+    this.workerGateDecisionLog = new WorkerGateDecisionLog({
+      dir: patchworkDir,
+      logger: this.logger,
+    });
 
     // 2. Initialize Claude driver and orchestrator (if configured)
     if (this.config.driver !== "none") {
@@ -1138,6 +1147,7 @@ export class Bridge {
           recipeOrchestrator: this.recipeOrchestrator,
           recipeRunLog: this.recipeRunLog,
           activityLog: this.activityLog,
+          workerGateDecisionLog: this.workerGateDecisionLog,
           workdir: this.config.workspace,
           logger: this.logger,
         });
@@ -1416,6 +1426,7 @@ export class Bridge {
       commitIssueLinkLog: this.commitIssueLinkLog,
       recipeRunLog: this.recipeRunLog,
       decisionTraceLog: this.decisionTraceLog,
+      workerGateDecisionLog: this.workerGateDecisionLog,
       embedFn: getLocalEmbedFn(),
     });
     this.server.tracesFn = async (query) => {
@@ -1878,6 +1889,9 @@ export class Bridge {
         ...(this.recipeRunLog && { recipeRunLog: this.recipeRunLog }),
         ...(this.decisionTraceLog && {
           decisionTraceLog: this.decisionTraceLog,
+        }),
+        ...(this.workerGateDecisionLog && {
+          workerGateDecisionLog: this.workerGateDecisionLog,
         }),
       },
     );

--- a/src/recipeOrchestration.ts
+++ b/src/recipeOrchestration.ts
@@ -121,6 +121,12 @@ export async function buildWorkerAutonomyGate(
     contextRiskProvider?: () => Promise<
       import("./workers/contextRisk.js").ContextRisk | undefined
     >;
+    /** Persist each gate decision + its inputs (the Decision Record). Called on
+     *  BOTH allow and gate paths. Wired to WorkerGateDecisionLog.record by the
+     *  caller (fail-soft there); a throwing impl never blocks the gate. */
+    recordGateDecision?: (
+      input: import("./workerGateDecisionLog.js").RecordGateDecisionInput,
+    ) => void;
   },
 ): Promise<ApprovalFn | null> {
   try {
@@ -135,7 +141,9 @@ export async function buildWorkerAutonomyGate(
     const trust = loadWorkerTrustForRecipe(recipeName, trustOpts);
     if (!trust) return null;
 
-    const { decideWorkerAction } = await import("./workers/workerGate.js");
+    const { decideWorkerAction, GATE_POLICY_VERSION } = await import(
+      "./workers/workerGate.js"
+    );
     const { getApprovalQueue } = await import("./approvalQueue.js");
     const queue = getApprovalQueue();
     const { worker, store } = trust;
@@ -166,6 +174,36 @@ export async function buildWorkerAutonomyGate(
         store,
         contextRisk ? { contextRisk } : undefined,
       );
+      // Decision Record: persist the decision + its inputs on EVERY path (incl.
+      // autonomous allows, which otherwise leave no trail). Fail-soft — a logging
+      // error must never block or change the gate.
+      try {
+        ctxOpts?.recordGateDecision?.({
+          recipeName,
+          workerId: worker.id,
+          toolName: input.toolId,
+          action: decision.action,
+          classKey: decision.classKey,
+          domain: decision.domain,
+          owned: decision.owned,
+          blastTier: decision.blastTier,
+          reversibility: decision.reversibility,
+          earnedLevel: decision.earnedLevel,
+          autonomyCeiling: decision.autonomyCeiling,
+          effectiveLevel: decision.effectiveLevel,
+          ...(decision.contextCeiling !== undefined && {
+            contextCeiling: decision.contextCeiling,
+          }),
+          ...(contextRisk && { contextRiskScore: contextRisk.score }),
+          ...(contextRisk?.reasons && {
+            contextRiskReasons: contextRisk.reasons,
+          }),
+          reason: decision.reason,
+          gatePolicyVersion: GATE_POLICY_VERSION,
+        });
+      } catch {
+        /* never block the gate on a logging failure */
+      }
       // allow → defer to the tier gate so we never DROP tier-policy protection
       // (floor composition). When no tier fn is injected (approvalGate off),
       // a worker `allow` means flow.
@@ -252,6 +290,12 @@ export interface RecipeOrchestrationDeps {
    * without live-tail.
    */
   activityLog?: import("./activityLog.js").ActivityLog;
+  /** The Decision Record store — every worker-gate decision + its inputs is
+   *  appended here (the replayable/explainable audit artifact). Optional: when
+   *  absent, gating still works, just without the persisted decision trail. */
+  workerGateDecisionLog?:
+    | import("./workerGateDecisionLog.js").WorkerGateDecisionLog
+    | null;
   workdir: string;
   logger: { info?: (s: string) => void; warn?: (s: string) => void };
 }
@@ -1168,13 +1212,26 @@ export class RecipeOrchestration {
     // composition — it can only ADD gating, never drop tier-policy protection)
     // and the gate engages on automated runs too. Otherwise everything below is
     // byte-identical to pre-flip behaviour.
+    const gateDecisionLog = this.deps.workerGateDecisionLog;
     const workerApprovalFn = await buildWorkerAutonomyGate(
       opts.name,
       tierApprovalFn,
       undefined,
       // Gather live context-risk signals from the workspace so the gate can
-      // throttle a worker in a dangerous situation (huge diff, on trunk).
-      { workdir: this.deps.workdir },
+      // throttle a worker in a dangerous situation (huge diff, on trunk), and
+      // persist every decision to the Decision Record (fail-soft).
+      {
+        workdir: this.deps.workdir,
+        ...(gateDecisionLog && {
+          recordGateDecision: (rec) => {
+            try {
+              gateDecisionLog.record(rec);
+            } catch {
+              /* never block the gate on a logging failure */
+            }
+          },
+        }),
+      },
     );
     const requireApprovalFn = workerApprovalFn ?? tierApprovalFn;
     const gateAutomatedRuns = workerApprovalFn != null;

--- a/src/tools/__tests__/ctxQueryTraces.test.ts
+++ b/src/tools/__tests__/ctxQueryTraces.test.ts
@@ -6,6 +6,7 @@ import { ActivityLog } from "../../activityLog.js";
 import { CommitIssueLinkLog } from "../../commitIssueLinkLog.js";
 import { DecisionTraceLog } from "../../decisionTraceLog.js";
 import { RecipeRunLog } from "../../runLog.js";
+import { WorkerGateDecisionLog } from "../../workerGateDecisionLog.js";
 import { createCtxQueryTracesTool } from "../ctxQueryTraces.js";
 
 let dir: string;
@@ -83,6 +84,41 @@ describe("ctxQueryTraces", () => {
     expect(res.traces[0].body.summary).toBe("push to main");
   });
 
+  it("surfaces worker-gate decisions as traceType gate_decision", async () => {
+    const gateLog = new WorkerGateDecisionLog({ dir });
+    gateLog.record({
+      recipeName: "triage",
+      workerId: "test-guardian-worker",
+      toolName: "githubCreateIssue",
+      action: "gate",
+      classKey: "issue:compensable:high",
+      domain: "issue",
+      owned: true,
+      blastTier: "high",
+      reversibility: "compensable",
+      earnedLevel: 0,
+      autonomyCeiling: 4,
+      effectiveLevel: 0,
+      contextRiskScore: 0.9,
+      contextRiskReasons: ["huge uncommitted diff"],
+      reason: "compensable + unearned (effective L0 < L4) — gated for approval",
+      gatePolicyVersion: "worker-ramp-v0",
+    });
+    const tool = createCtxQueryTracesTool({ workerGateDecisionLog: gateLog });
+    const res = parse(await tool.handler({ traceType: "gate_decision" }));
+    expect(res.count).toBe(1);
+    expect(res.sources.gate_decision).toBe(true);
+    const t = res.traces[0];
+    expect(t.traceType).toBe("gate_decision");
+    expect(t.key).toBe("test-guardian-worker:issue:compensable:high");
+    expect(t.summary).toContain("gate githubCreateIssue");
+    expect(t.summary).toContain("effL0");
+    // the inputs that produced the decision are preserved in the body
+    expect(t.body.gatePolicyVersion).toBe("worker-ramp-v0");
+    expect(t.body.contextRiskScore).toBe(0.9);
+    expect(t.body.earnedLevel).toBe(0);
+  });
+
   it("filters by key substring", async () => {
     linkLog.record({
       sha: "aaa",
@@ -147,6 +183,7 @@ describe("ctxQueryTraces", () => {
       enrichment: true,
       recipe_run: false,
       decision: false,
+      gate_decision: false,
     });
   });
 

--- a/src/tools/ctxQueryTraces.ts
+++ b/src/tools/ctxQueryTraces.ts
@@ -3,6 +3,7 @@ import type { CommitIssueLinkLog } from "../commitIssueLinkLog.js";
 import type { DecisionTraceLog } from "../decisionTraceLog.js";
 import { cosineSimilarity } from "../embeddings/index.js";
 import type { RecipeRunLog } from "../runLog.js";
+import type { WorkerGateDecisionLog } from "../workerGateDecisionLog.js";
 import { optionalInt, optionalString, successStructured } from "./utils.js";
 
 /**
@@ -37,7 +38,12 @@ const MAX_SEMANTIC_BATCH = 200;
  * need richer per-type shapes can key on `traceType` and unwrap `body`.
  */
 
-export type TraceType = "approval" | "enrichment" | "recipe_run" | "decision";
+export type TraceType =
+  | "approval"
+  | "enrichment"
+  | "recipe_run"
+  | "decision"
+  | "gate_decision";
 
 export interface DecisionTrace {
   traceType: TraceType;
@@ -61,6 +67,7 @@ export interface CtxQueryTracesDeps {
   commitIssueLinkLog?: CommitIssueLinkLog | null;
   activityLog?: ActivityLog | null;
   decisionTraceLog?: DecisionTraceLog | null;
+  workerGateDecisionLog?: WorkerGateDecisionLog | null;
   /**
    * Optional on-device embeddings function — wired from
    * `createEmbeddingsProvider()?.embed` at the registration site. Returns one
@@ -115,6 +122,12 @@ function semanticTextFor(t: DecisionTrace): string {
       return cap(
         `${str(b.toolName)} ${str(b.decision)} ${str(b.reason)} ${str(
           b.summary,
+        )}`.trim(),
+      );
+    case "gate_decision":
+      return cap(
+        `${str(b.toolName)} ${str(b.action)} ${str(b.classKey)} ${str(
+          b.reason,
         )}`.trim(),
       );
     default:
@@ -223,6 +236,17 @@ function decisionTraces(log: DecisionTraceLog): DecisionTrace[] {
   }));
 }
 
+function gateDecisionTraces(log: WorkerGateDecisionLog): DecisionTrace[] {
+  return log.query({ limit: 500 }).map((d) => ({
+    traceType: "gate_decision",
+    ts: d.decidedAt,
+    // worker × action-class — the natural join key for the trust dial.
+    key: `${d.workerId}:${d.classKey}`,
+    summary: `${d.action} ${d.toolName} (effL${d.effectiveLevel}): ${d.reason}`,
+    body: d as unknown as Record<string, unknown>,
+  }));
+}
+
 export function createCtxQueryTracesTool(deps: CtxQueryTracesDeps) {
   return {
     schema: {
@@ -235,9 +259,15 @@ export function createCtxQueryTracesTool(deps: CtxQueryTracesDeps) {
         properties: {
           traceType: {
             type: "string",
-            enum: ["approval", "enrichment", "recipe_run", "decision"],
+            enum: [
+              "approval",
+              "enrichment",
+              "recipe_run",
+              "decision",
+              "gate_decision",
+            ],
             description:
-              "Optional filter — restrict to one source. Omit to get all.",
+              "Optional filter — restrict to one source. Omit to get all. `gate_decision` = worker-autonomy gate decisions + their inputs.",
           },
           key: {
             type: "string",
@@ -282,7 +312,13 @@ export function createCtxQueryTracesTool(deps: CtxQueryTracesDeps) {
               properties: {
                 traceType: {
                   type: "string",
-                  enum: ["approval", "enrichment", "recipe_run", "decision"],
+                  enum: [
+                    "approval",
+                    "enrichment",
+                    "recipe_run",
+                    "decision",
+                    "gate_decision",
+                  ],
                 },
                 ts: { type: "integer" },
                 key: { type: "string" },
@@ -300,6 +336,7 @@ export function createCtxQueryTracesTool(deps: CtxQueryTracesDeps) {
               enrichment: { type: "boolean" },
               recipe_run: { type: "boolean" },
               decision: { type: "boolean" },
+              gate_decision: { type: "boolean" },
             },
           },
         },
@@ -324,6 +361,7 @@ export function createCtxQueryTracesTool(deps: CtxQueryTracesDeps) {
         enrichment: Boolean(deps.commitIssueLinkLog),
         recipe_run: Boolean(deps.recipeRunLog),
         decision: Boolean(deps.decisionTraceLog),
+        gate_decision: Boolean(deps.workerGateDecisionLog),
       };
 
       const pools: DecisionTrace[] = [];
@@ -341,6 +379,12 @@ export function createCtxQueryTracesTool(deps: CtxQueryTracesDeps) {
       }
       if ((!traceType || traceType === "decision") && deps.decisionTraceLog) {
         pools.push(...decisionTraces(deps.decisionTraceLog));
+      }
+      if (
+        (!traceType || traceType === "gate_decision") &&
+        deps.workerGateDecisionLog
+      ) {
+        pools.push(...gateDecisionTraces(deps.workerGateDecisionLog));
       }
 
       // In semantic mode `q` is the similarity query, NOT a substring

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -336,6 +336,7 @@ export interface ToolContext {
   commitIssueLinkLog?: import("../commitIssueLinkLog.js").CommitIssueLinkLog;
   recipeRunLog?: import("../runLog.js").RecipeRunLog;
   decisionTraceLog?: import("../decisionTraceLog.js").DecisionTraceLog;
+  workerGateDecisionLog?: import("../workerGateDecisionLog.js").WorkerGateDecisionLog;
 }
 
 export function registerAllTools(ctx: ToolContext): void;
@@ -359,6 +360,7 @@ export function registerAllTools(
   commitIssueLinkLog?: import("../commitIssueLinkLog.js").CommitIssueLinkLog,
   recipeRunLog?: import("../runLog.js").RecipeRunLog,
   decisionTraceLog?: import("../decisionTraceLog.js").DecisionTraceLog,
+  workerGateDecisionLog?: import("../workerGateDecisionLog.js").WorkerGateDecisionLog,
 ): void;
 export function registerAllTools(
   transportOrCtx: McpTransport | ToolContext,
@@ -380,6 +382,7 @@ export function registerAllTools(
   commitIssueLinkLogArg?: import("../commitIssueLinkLog.js").CommitIssueLinkLog,
   recipeRunLogArg?: import("../runLog.js").RecipeRunLog,
   decisionTraceLogArg?: import("../decisionTraceLog.js").DecisionTraceLog,
+  workerGateDecisionLogArg?: import("../workerGateDecisionLog.js").WorkerGateDecisionLog,
 ): void {
   // Options-object form: unpack and re-dispatch through the positional path.
   if (
@@ -409,6 +412,7 @@ export function registerAllTools(
       ctx.commitIssueLinkLog,
       ctx.recipeRunLog,
       ctx.decisionTraceLog,
+      ctx.workerGateDecisionLog,
     );
     return;
   }
@@ -784,6 +788,7 @@ export function registerAllTools(
       commitIssueLinkLog: commitIssueLinkLog ?? null,
       recipeRunLog: recipeRunLog ?? null,
       decisionTraceLog: decisionTraceLog ?? null,
+      workerGateDecisionLog: workerGateDecisionLogArg ?? null,
       embedFn: getLocalEmbedFn(),
     }),
     createCtxGetTaskContextTool({

--- a/src/workerGateDecisionLog.ts
+++ b/src/workerGateDecisionLog.ts
@@ -1,0 +1,372 @@
+import {
+  appendFileSync,
+  closeSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  readSync,
+  renameSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import path from "node:path";
+import { withFileLockSync } from "./fileLockSync.js";
+import type { Logger } from "./logger.js";
+import type { Reversibility } from "./workers/actionClass.js";
+
+/**
+ * WorkerGateDecisionLog — the immutable record of every worker-autonomy gate
+ * decision, with the INPUTS that produced it.
+ *
+ * The first concrete slice of the "Decision Record" north star
+ * (docs/worker-autonomy-policy-gate.md): `decideWorkerAction` computes a rich
+ * `WorkerGateDecision` (earned level, ceiling, context-risk de-rate, reason)
+ * and — before this log — discarded it, persisting only a human-readable
+ * `summary` string into the approval queue. So an autonomous `allow` left NO
+ * trail at all, and a `gate` kept only its summary; a decision could not be
+ * replayed or explained from the log.
+ *
+ * This captures the decision + its inputs on BOTH paths (allow AND gate) so an
+ * operator can answer "why did the worker (auto-)act / gate here, on what
+ * evidence, under which policy version?" — explainable from stored evidence
+ * (replay ≠ bit-exact re-execution; the world drifts). Retention is bounded by
+ * the rotation caps below (most-recent 10k rows / 1 MB), like the sibling logs;
+ * a longer/archival horizon for compliance is a deliberate follow-up, not a
+ * promise this file makes today.
+ *
+ * Same battle-tested JSONL machinery as DecisionTraceLog / RecipeRunLog:
+ * append-only + cross-process flock (ADR-0007 torn-row guard) + bounded
+ * in-memory ring + size/line rotation + tail-on-read so a sibling bridge's
+ * appends become visible. Schema is additive.
+ */
+
+export type GateAction = "allow" | "gate";
+
+export interface GateDecisionRecord {
+  /** Monotonic sequence id within the process — stable for pagination. */
+  seq: number;
+  /** ms epoch when the decision was made. */
+  decidedAt: number;
+  recipeName: string;
+  workerId: string;
+  toolName: string;
+  action: GateAction;
+  /** `${domain}:${reversibility}:${blastTier}` — the trust unit. */
+  classKey: string;
+  domain: string;
+  owned: boolean;
+  /** "low" | "medium" | "high" (RiskTier, kept as string to decouple). */
+  blastTier: string;
+  reversibility: Reversibility;
+  /** Trust earned on this class as of the decision. */
+  earnedLevel: number;
+  autonomyCeiling: number;
+  /** min(earned, ceiling, contextCeiling), 0 if unowned — what the gate acted on. */
+  effectiveLevel: number;
+  /** Descending ceiling from live context-risk (present only when supplied). */
+  contextCeiling?: number;
+  /** Context-risk score 0..1 (present only when a context-risk was resolved). */
+  contextRiskScore?: number;
+  /** Human reasons the situation was risky (e.g. "huge uncommitted diff"). */
+  contextRiskReasons?: string[];
+  /** Human-readable rationale for the action. */
+  reason: string;
+  /** The gate-policy version (thresholds/constants) that produced this row.
+   *  Replay is not reproducible without knowing which policy decided. */
+  gatePolicyVersion: string;
+}
+
+export type RecordGateDecisionInput = Omit<
+  GateDecisionRecord,
+  "seq" | "decidedAt"
+>;
+
+const DEFAULT_MEMORY_CAP = 2_000;
+const MAX_PERSIST_BYTES = 1024 * 1024; // 1 MB
+const MAX_PERSIST_LINES = 10_000;
+const MAX_REASON_LEN = 1_000;
+const MAX_CONTEXT_REASONS = 16;
+
+export interface WorkerGateDecisionLogOptions {
+  dir: string;
+  logger?: Logger;
+  memoryCap?: number;
+  now?: () => number;
+}
+
+export interface GateDecisionQuery {
+  workerId?: string;
+  classKey?: string;
+  recipeName?: string;
+  action?: GateAction;
+  /** Only return rows with seq > after. */
+  after?: number;
+  /** Only return rows with decidedAt >= since. */
+  since?: number;
+  limit?: number;
+}
+
+export class WorkerGateDecisionLog {
+  private records: GateDecisionRecord[] = [];
+  private seq = 0;
+  private readonly file: string;
+  private readonly memoryCap: number;
+  private readonly now: () => number;
+  /** Byte offset up to which `file` has been loaded (ADR-0007 tail-on-read). */
+  private lastReadOffset = 0;
+
+  constructor(private readonly opts: WorkerGateDecisionLogOptions) {
+    this.file = path.join(opts.dir, "worker_gate_decisions.jsonl");
+    this.memoryCap = opts.memoryCap ?? DEFAULT_MEMORY_CAP;
+    this.now = opts.now ?? Date.now;
+    try {
+      mkdirSync(opts.dir, { recursive: true, mode: 0o700 });
+    } catch (err) {
+      opts.logger?.warn?.(
+        `[gate-decision-log] could not create ${opts.dir}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+    this.loadExisting();
+  }
+
+  /**
+   * Record one gate decision. Validates the required identity fields and clips
+   * free-form text so a runaway reason can't bloat the audit log. Returns the
+   * stored record. The caller appends this fail-soft (a logging failure must
+   * never block the gate) — so this throws only on programmer error (missing
+   * required fields), which the caller catches.
+   */
+  record(input: RecordGateDecisionInput): GateDecisionRecord {
+    const recipeName = input.recipeName.trim();
+    const workerId = input.workerId.trim();
+    const toolName = input.toolName.trim();
+    const classKey = input.classKey.trim();
+    if (!recipeName) throw new Error("recipeName is required");
+    if (!workerId) throw new Error("workerId is required");
+    if (!toolName) throw new Error("toolName is required");
+    if (!classKey) throw new Error("classKey is required");
+    if (input.action !== "allow" && input.action !== "gate") {
+      throw new Error(`invalid action: ${String(input.action)}`);
+    }
+
+    const reasons = (input.contextRiskReasons ?? [])
+      .map((r) => String(r).trim())
+      .filter((r) => r.length > 0)
+      .slice(0, MAX_CONTEXT_REASONS);
+
+    this.seq += 1;
+    const rec: GateDecisionRecord = {
+      seq: this.seq,
+      decidedAt: this.now(),
+      recipeName,
+      workerId,
+      toolName,
+      action: input.action,
+      classKey,
+      domain: input.domain,
+      owned: input.owned,
+      blastTier: input.blastTier,
+      reversibility: input.reversibility,
+      earnedLevel: input.earnedLevel,
+      autonomyCeiling: input.autonomyCeiling,
+      effectiveLevel: input.effectiveLevel,
+      ...(input.contextCeiling !== undefined && {
+        contextCeiling: input.contextCeiling,
+      }),
+      ...(input.contextRiskScore !== undefined && {
+        contextRiskScore: input.contextRiskScore,
+      }),
+      ...(reasons.length > 0 && { contextRiskReasons: reasons }),
+      reason: input.reason.slice(0, MAX_REASON_LEN),
+      gatePolicyVersion: input.gatePolicyVersion,
+    };
+    this.records.push(rec);
+    if (this.records.length > this.memoryCap) {
+      this.records.splice(0, this.records.length - this.memoryCap);
+    }
+    this.append(rec);
+    return rec;
+  }
+
+  query(q: GateDecisionQuery = {}): GateDecisionRecord[] {
+    this.tailDisk();
+    const out: GateDecisionRecord[] = [];
+    for (const r of this.records) {
+      if (q.workerId && r.workerId !== q.workerId) continue;
+      if (q.classKey && r.classKey !== q.classKey) continue;
+      if (q.recipeName && r.recipeName !== q.recipeName) continue;
+      if (q.action && r.action !== q.action) continue;
+      if (q.after !== undefined && r.seq <= q.after) continue;
+      if (q.since !== undefined && r.decidedAt < q.since) continue;
+      out.push(r);
+    }
+    out.sort((a, b) => b.seq - a.seq);
+    const limit = Math.min(Math.max(q.limit ?? 100, 1), 1_000);
+    return out.slice(0, limit);
+  }
+
+  size(): number {
+    return this.records.length;
+  }
+
+  private append(rec: GateDecisionRecord): void {
+    try {
+      try {
+        const st = statSync(this.file);
+        if (st.size > MAX_PERSIST_BYTES) this.rotateDisk();
+      } catch (err) {
+        const code = (err as NodeJS.ErrnoException).code;
+        if (code !== "ENOENT") throw err;
+      }
+      // Cross-process flock around the append (ADR-0007): two bridges sharing
+      // $HOME can interleave bytes within one JSONL row; the torn line then
+      // fails JSON.parse and is silently skipped on every reader.
+      withFileLockSync(this.file, () => {
+        appendFileSync(this.file, `${JSON.stringify(rec)}\n`, { mode: 0o600 });
+        // Advance the tail offset past our own write so the next query() doesn't
+        // re-read this row (we already pushed it in `record`).
+        try {
+          this.lastReadOffset = statSync(this.file).size;
+        } catch {
+          /* the next tailDisk() reloads cleanly if this ever fails */
+        }
+      });
+    } catch (err) {
+      this.opts.logger?.warn?.(
+        `[gate-decision-log] append failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  /** Trim to the most recent MAX_PERSIST_LINES / MAX_PERSIST_BYTES. Best-effort. */
+  private rotateDisk(): void {
+    try {
+      const raw = readFileSync(this.file, "utf-8");
+      let lines = raw.split("\n").filter((l) => l.trim());
+      if (lines.length > MAX_PERSIST_LINES)
+        lines = lines.slice(-MAX_PERSIST_LINES);
+      let joined = lines.join("\n");
+      while (joined.length + 1 > MAX_PERSIST_BYTES && lines.length > 1) {
+        lines = lines.slice(-Math.max(1, Math.floor(lines.length / 2)));
+        joined = lines.join("\n");
+      }
+      if (lines.length === 1 && joined.length + 1 > MAX_PERSIST_BYTES) {
+        this.opts.logger?.warn?.(
+          `[gate-decision-log] rotate dropped 1 oversized row (${joined.length} bytes)`,
+        );
+        lines = [];
+        joined = "";
+      }
+      const tmp = `${this.file}.tmp`;
+      writeFileSync(tmp, joined.length > 0 ? `${joined}\n` : "", {
+        mode: 0o600,
+      });
+      try {
+        renameSync(tmp, this.file);
+      } catch (renameErr) {
+        if (
+          process.platform === "win32" &&
+          (renameErr as NodeJS.ErrnoException).code === "EEXIST"
+        ) {
+          try {
+            unlinkSync(this.file);
+          } catch {
+            /* best-effort */
+          }
+          renameSync(tmp, this.file);
+        } else {
+          throw renameErr;
+        }
+      }
+    } catch (err) {
+      this.opts.logger?.warn?.(
+        `[gate-decision-log] rotate failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  private loadExisting(): void {
+    let size: number;
+    try {
+      size = statSync(this.file).size;
+    } catch {
+      this.lastReadOffset = 0;
+      return;
+    }
+    let raw: string;
+    try {
+      raw = readFileSync(this.file, "utf-8");
+    } catch (err) {
+      this.opts.logger?.warn?.(
+        `[gate-decision-log] read failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      return;
+    }
+    this.consumeRawJsonl(raw);
+    this.lastReadOffset = size;
+    if (this.records.length > this.memoryCap) {
+      this.records.splice(0, this.records.length - this.memoryCap);
+    }
+  }
+
+  /** Read rows appended since `lastReadOffset` and merge them (ADR-0007). */
+  private tailDisk(): void {
+    let size: number;
+    try {
+      size = statSync(this.file).size;
+    } catch {
+      return;
+    }
+    if (size === this.lastReadOffset) return;
+    if (size < this.lastReadOffset) {
+      // Rotated/truncated by a sibling — full reload.
+      this.records.length = 0;
+      this.lastReadOffset = 0;
+      this.loadExisting();
+      return;
+    }
+    let buf: Buffer;
+    try {
+      const fd = openSync(this.file, "r");
+      try {
+        const len = size - this.lastReadOffset;
+        buf = Buffer.alloc(len);
+        readSync(fd, buf, 0, len, this.lastReadOffset);
+      } finally {
+        closeSync(fd);
+      }
+    } catch (err) {
+      this.opts.logger?.warn?.(
+        `[gate-decision-log] tail read failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      return;
+    }
+    this.consumeRawJsonl(buf.toString("utf-8"));
+    this.lastReadOffset = size;
+    if (this.records.length > this.memoryCap) {
+      this.records.splice(0, this.records.length - this.memoryCap);
+    }
+  }
+
+  private consumeRawJsonl(raw: string): void {
+    for (const line of raw.split("\n")) {
+      if (!line) continue;
+      try {
+        const parsed = JSON.parse(line) as GateDecisionRecord;
+        if (
+          typeof parsed.seq !== "number" ||
+          typeof parsed.workerId !== "string" ||
+          typeof parsed.toolName !== "string" ||
+          (parsed.action !== "allow" && parsed.action !== "gate")
+        ) {
+          continue;
+        }
+        this.records.push(parsed);
+        if (parsed.seq > this.seq) this.seq = parsed.seq;
+      } catch {
+        // skip malformed row
+      }
+    }
+  }
+}

--- a/src/workers/workerGate.ts
+++ b/src/workers/workerGate.ts
@@ -81,6 +81,12 @@ const COMPENSABLE_AUTONOMY_LEVEL = 2 as const;
 /** Irreversible actions (and unowned/unearned anything) require full L4. */
 const AUTONOMOUS_LEVEL = 4 as const;
 
+/** The gate-policy version stamped on every persisted decision (the threshold
+ *  constants + composition rule below). A decision can't be replayed/explained
+ *  without knowing which policy produced it — bump when the thresholds or the
+ *  reversibility→level mapping change. */
+export const GATE_POLICY_VERSION = "worker-ramp-v0";
+
 /** How the Claude subprocess sees bridge MCP tools under `--disallowed-tools`:
  *  `mcp__<server>__<tool>`. The server name is fixed to `patchwork` by the
  *  subprocess driver's writeMcpConfigFile, so the agent-step sandbox must block


### PR DESCRIPTION
## Why

The dogfood proved the worker is *months* from earned autonomy — so the auditable **receipt**, not the autonomy, is the value. But `decideWorkerAction` computed a rich `WorkerGateDecision` (earned level, ceiling, context-risk de-rate, reason) and then **discarded it**: an autonomous `allow` left no trail, a `gate` kept only a summary string. The north-star artifact (`docs/worker-autonomy-policy-gate.md`) literally didn't exist. This is its first concrete slice.

## What

- **`workerGateDecisionLog.ts`** (new) — append-only JSONL of `GateDecisionRecord`, a faithful clone of `decisionTraceLog`'s proven machinery (cross-process flock / rotation / tail-on-read / seq monotonicity / malformed-row skip). Stores the decision **+ its inputs** (classKey, owned, blastTier, reversibility, earned/ceiling/effective levels, contextCeiling, contextRisk score+reasons, reason) + **`gatePolicyVersion`** so replay knows which policy decided.
- Recorded at the one gate call site on **both** the allow and gate paths, **fail-soft** (double try/catch; strictly after the decision is computed — a logging error can never block or change a decision).
- Exposed through the **existing** read layer: `ctxQueryTraces({traceType: "gate_decision"})` — no new tool, no dashboard. Threaded into both the MCP tool registration and the dashboard `tracesFn`.

## Invariants
- **No secrets/PII** — carries only classification labels + levels + reason (never tool params; `reason`/context reasons are built from action-class metadata + numeric counts). Built field-by-field (no `...input` spread). `reason` clipped to 1000 chars, context reasons capped at 16.
- **Additive + never-widen** — flag-off / non-worker recipes never reach the gate → byte-identical. Existing `ctxQueryTraces` callers gain one optional source.
- Session-start digest deliberately does **not** receive gate decisions (would flood it). Retention bounded by rotation (10k/1 MB); archival compliance horizon is a follow-up.

## Process
Surfaced by an adversarial multi-agent diff review (6 confirmed; the one actionable finding — the **MCP** `ctxQueryTraces` tool wasn't getting the log, only the dashboard path was — is fixed here; the rest were positive invariant confirmations).

## Verification
6326 tests green + new log/query/both-paths/fail-soft tests; build + strict typecheck + biome + LSP/schema/fixture gates clean.

## Next (per the roadmap)
Dogfood harder for durable evidence · surface pending-durability in `workers shadow` · outcome-based durable label (needs the decision→outcome pointer this record now anchors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)