### PR TITLE
fix(recipes): triage worker — reproducibility gate before filing an issue

### DIFF
--- a/src/recipes/__tests__/workerAutonomySmoke.test.ts
+++ b/src/recipes/__tests__/workerAutonomySmoke.test.ts
@@ -249,12 +249,17 @@ describe("worker-autonomy smoke (triage-failing-tests-autofile, flag ON)", () =>
       (s) => s.tool === "github.create_issue",
     );
     expect(issueStep?.status).toBe("ok");
-    // All four steps ran and EVERY one succeeded — assert the positive `ok`
+    // All FIVE steps ran and EVERY one succeeded — assert the positive `ok`
     // status, not merely the absence of `error`, so a silently skipped/halted
     // reversible step (e.g. the file.write triage note) can't pass unnoticed
-    // (review #smoke-review F5).
-    expect(result.stepsRun).toBe(4);
+    // (review #smoke-review F5). The 5 steps: get_commits, triage_agent,
+    // verify_reproduced (reproducibility gate), write_note, file_issue. The
+    // canned agent stub returns a non-falsy note, so `when: {{reproduced}}` is
+    // truthy and file_issue runs (the reproduced-path; a real agent emits
+    // true/false).
+    expect(result.stepsRun).toBe(5);
     expect(result.stepResults.map((s) => s.status)).toEqual([
+      "ok",
       "ok",
       "ok",
       "ok",

--- a/templates/recipes/triage-failing-tests-autofile.yaml
+++ b/templates/recipes/triage-failing-tests-autofile.yaml
@@ -35,10 +35,12 @@ trigger:
       default: ""
       description: "owner/repo the issue is filed against (set this to enable)"
 steps:
-  - tool: git.log_since
+  - id: get_commits
+    tool: git.log_since
     since: 12h
     into: recent
-  - agent:
+  - id: triage_agent
+    agent:
       prompt: |
         Tests just failed. Runner: {{runner}}. Failed {{failed}} / {{total}}.
 
@@ -53,24 +55,53 @@ steps:
         command to run to confirm.
       driver: claude-code
       into: triage
-  - tool: file.write
+  # Reproducibility gate (issue-hygiene). A worker triage is a LEAD, not a
+  # verified diagnosis — the on_test_run event can fire on a flake, a transient,
+  # or an already-fixed failure (e.g. #1046: a triage that confidently blamed a
+  # commit for a test that actually passes on `main`). Before filing a real,
+  # brand-exposed issue, re-run the named test(s) in ISOLATION and only proceed
+  # if the failure still reproduces. A non-reproducing run writes the draft note
+  # (below) but files NO issue — strictly noise-reducing, never blocks a real one.
+  - id: verify_reproduced
+    agent:
+      prompt: |
+        A test run reported failures and this triage was written:
+
+        {{triage}}
+
+        Re-run ONLY the specific failing test(s) named above, in isolation, on the
+        current checkout, to confirm they still fail — e.g.
+        `npx vitest run <file> -t "<test name>"`. A test that PASSES on isolated
+        re-run is a flake / transient / already-fixed and must NOT be filed.
+
+        Output EXACTLY one word and nothing else:
+          true   — the failure REPRODUCED (a real, current failure worth filing)
+          false  — it did NOT reproduce (flake / transient / already green)
+      driver: claude-code
+      into: reproduced
+  - id: write_note
+    tool: file.write
     path: ~/.patchwork/inbox/test-triage-{{date}}-{{time}}.md
     content: |
       # Test triage — {{date}} {{time}}
 
-      Runner {{runner}} · failed {{failed}}/{{total}}
+      Runner {{runner}} · failed {{failed}}/{{total}} · reproduced: {{reproduced}}
 
       {{triage}}
-  # The risky owned action. Runs AFTER the draft is written, so a gate
-  # rejection (or a missing `repo`) never loses the triage note.
-  - tool: github.create_issue
+  # The risky owned action. Runs AFTER the draft is written (so a gate rejection,
+  # a missing `repo`, or a non-reproducing failure never loses the triage note)
+  # and ONLY when the failure reproduced — `when` skips the step (not a failure)
+  # on a falsy guard ("", "false", "0", "null", "undefined").
+  - id: file_issue
+    when: "{{reproduced}}"
+    tool: github.create_issue
     repo: "{{repo}}"
     title: "Test triage {{date}}: {{runner}} failing {{failed}}/{{total}}"
     body: |
       {{triage}}
 
       ---
-      _Filed by the Test Guardian Worker from a failing {{runner}} run._
+      _Filed by the Test Guardian Worker from a failing {{runner}} run (reproduced on isolated re-run)._
     labels:
       - test-failure
     into: filed_issue


### PR DESCRIPTION
## Why

The dogfood surfaced this concretely: the Test Guardian worker filed **#1046** — a confident triage blaming #1042/#1044 for a `graduation.test.ts` failure that **does not reproduce on `main`** (the file passes 7/7). A worker triage is a *lead*, not a verified diagnosis. The `on_test_run` trigger fires on flakes / transients / already-fixed failures, and filing a real, brand-exposed GitHub issue on each is noise — and inflates the worker's `issue`-class trust on junk.

## What

- New **`verify_reproduced`** agent step re-runs the named failing test(s) **in isolation** on the current checkout and emits a bare `true`/`false`.
- **`file_issue` gains `when: "{{reproduced}}"`** — a non-reproducing run still writes the local triage draft but files **no** issue (the `when` guard records a skip, not a failure). Strictly noise-reducing; never blocks a real failure (fail-toward-filing on ambiguity, since a missed real regression is worse than a noise issue).
- Steps gain explicit `id`s; the draft note records `reproduced: …`.

**This would have suppressed #1046.** Lints clean (0 warnings).

## Scope / follow-up
- Template only — the installed copy (`~/.patchwork/recipes/`) must be reinstalled to pick it up (deliberately not touched mid-dogfood).
- **Dedup** (don't file when an open issue already covers the same failure) is a separate follow-up: it needs a `labels`/`state` filter on `github.list_issues` (today it's assignee-scoped) + a stable failure key in the title (currently date-stamped, so it never matches). Flagged, not done here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)