### PR TITLE
feat(workers): triage dedup — skip filing when an open issue already tracks the failure

### DIFF
--- a/src/connectors/__tests__/github.test.ts
+++ b/src/connectors/__tests__/github.test.ts
@@ -114,6 +114,39 @@ describe("listIssues", () => {
     callTool.mockRestore();
   });
 
+  it("forwards labels + non-default state, and omits both when unset", async () => {
+    mockConnected();
+    const callTool = vi
+      .spyOn(McpClient.prototype, "callTool")
+      .mockResolvedValue(mcpJsonResult([]));
+    await listIssues({
+      repo: "acme/widget",
+      labels: ["test-failure", "bug"],
+      state: "all",
+    });
+    expect(callTool).toHaveBeenCalledWith(
+      "list_issues",
+      expect.objectContaining({
+        state: "all",
+        labels: ["test-failure", "bug"],
+        owner: "acme",
+        repo: "widget",
+      }),
+      expect.any(Object),
+    );
+    // No assignee filter requested → arg absent (lists across all assignees).
+    expect(callTool.mock.calls[0]?.[1]).not.toHaveProperty("assignee");
+    callTool.mockClear();
+
+    // Unset labels/state → byte-identical to the historical args (state defaults
+    // to "open", no `labels` key) so existing callers are unaffected.
+    await listIssues({ repo: "acme/widget" });
+    const args = callTool.mock.calls[0]?.[1] as Record<string, unknown>;
+    expect(args.state).toBe("open");
+    expect(args).not.toHaveProperty("labels");
+    callTool.mockRestore();
+  });
+
   it("coerces array-shape MCP response", async () => {
     mockConnected();
     vi.spyOn(McpClient.prototype, "callTool").mockResolvedValue(

--- a/src/connectors/github.ts
+++ b/src/connectors/github.ts
@@ -54,6 +54,10 @@ export interface ListIssuesOpts {
   mention?: string;
   limit?: number;
   repo?: string;
+  /** Filter to issues carrying ALL of these labels (GitHub AND semantics). */
+  labels?: string[];
+  /** Issue state filter. Defaults to "open" (unchanged historical behaviour). */
+  state?: "open" | "closed" | "all";
 }
 
 export interface ListPRsOpts {
@@ -156,7 +160,8 @@ export async function listIssues(
     );
   const { owner, repo } = parseRepo(opts);
   const args: Record<string, unknown> = {
-    state: "open",
+    // Default "open" preserved; an explicit opts.state ("closed"/"all") wins.
+    state: opts.state ?? "open",
     perPage: Math.min(opts.limit ?? 20, 50),
   };
   if (owner) args.owner = owner;
@@ -164,6 +169,9 @@ export async function listIssues(
   if (opts.assignee)
     args.assignee = opts.assignee === "@me" ? "@me" : opts.assignee;
   if (opts.mention) args.mentioned = opts.mention;
+  // Label filter (GitHub AND-matches a label array). Only send when non-empty
+  // so the existing no-label callers keep their byte-identical MCP args.
+  if (opts.labels?.length) args.labels = opts.labels;
   try {
     const res = await client().callTool("list_issues", args, {
       cacheKey: `gh:issues:${JSON.stringify(args)}`,

--- a/src/recipes/__tests__/workerAutonomySmoke.test.ts
+++ b/src/recipes/__tests__/workerAutonomySmoke.test.ts
@@ -49,9 +49,17 @@ const createIssueMock = vi.fn(
     title: opts.title,
   }),
 );
+// `github.list_issues` (the dedup read) does the same dynamic import and calls
+// `listIssues`. A RECORDING mock (default → no existing issues) so the test can
+// assert the YAML→runner→recipe-tool→connector arg plumbing end-to-end (the
+// composed `assignee:"any"`→undefined seam no single unit test crosses), and so
+// the dedup-skip test can inject an open duplicate.
+const listIssuesMock = vi.fn(async (_opts?: unknown) => [] as unknown[]);
 vi.mock("../../connectors/github.js", () => ({
   createIssue: (...args: unknown[]) =>
     (createIssueMock as (...a: unknown[]) => unknown)(...args),
+  listIssues: (...args: unknown[]) =>
+    (listIssuesMock as (...a: unknown[]) => unknown)(...args),
 }));
 
 import {
@@ -123,6 +131,8 @@ beforeEach(() => {
   setFlag(FLAG_WORKER_AUTONOMY, true, false);
   resetApprovalQueueForTests();
   createIssueMock.mockClear();
+  listIssuesMock.mockReset();
+  listIssuesMock.mockResolvedValue([]);
 });
 
 afterEach(() => {
@@ -144,6 +154,7 @@ afterEach(() => {
 function makeDeps(
   runLog: RecipeRunLog,
   requireApprovalFn: RunnerDeps["requireApprovalFn"],
+  claudeCodeFn?: RunnerDeps["claudeCodeFn"],
 ): RunnerDeps {
   return {
     now: () => new Date("2026-06-29T09:00:00Z"),
@@ -152,8 +163,11 @@ function makeDeps(
     runLog,
     requireApprovalFn,
     gateAutomatedRuns: true,
-    claudeCodeFn: async () =>
-      "Triage: foo.test.ts failed; suspect commit abc123.",
+    // Default: a constant non-falsy note (every agent step → file-it path). The
+    // dedup-skip test injects a prompt-aware fn that returns a bare `false`.
+    claudeCodeFn:
+      claudeCodeFn ??
+      (async () => "Triage: foo.test.ts failed; suspect commit abc123."),
     readFile: () => {
       throw new Error("nf");
     },
@@ -249,22 +263,45 @@ describe("worker-autonomy smoke (triage-failing-tests-autofile, flag ON)", () =>
       (s) => s.tool === "github.create_issue",
     );
     expect(issueStep?.status).toBe("ok");
-    // All FIVE steps ran and EVERY one succeeded — assert the positive `ok`
+    // All SIX steps ran and EVERY one succeeded — assert the positive `ok`
     // status, not merely the absence of `error`, so a silently skipped/halted
     // reversible step (e.g. the file.write triage note) can't pass unnoticed
-    // (review #smoke-review F5). The 5 steps: get_commits, triage_agent,
-    // verify_reproduced (reproducibility gate), write_note, file_issue. The
-    // canned agent stub returns a non-falsy note, so `when: {{reproduced}}` is
-    // truthy and file_issue runs (the reproduced-path; a real agent emits
-    // true/false).
-    expect(result.stepsRun).toBe(5);
+    // (review #smoke-review F5). The 6 steps: get_commits, triage_agent,
+    // list_existing (dedup read, stubbed → []), decide_file (reproduce + dedup
+    // gate), write_note, file_issue. The canned agent stub returns a non-falsy
+    // note, so `when: {{should_file}}` is truthy and file_issue runs (the
+    // file-it path; a real agent emits a bare true/false).
+    expect(result.stepsRun).toBe(6);
     expect(result.stepResults.map((s) => s.status)).toEqual([
       "ok",
       "ok",
       "ok",
       "ok",
       "ok",
+      "ok",
     ]);
+
+    // --- A2. the dedup READ exercised the full YAML→runner→recipe-tool→connector
+    // arg plumbing. This is the only place that crosses the composed
+    // `assignee:"any"` → undefined seam end-to-end (the unit tests prove each
+    // half against a hand-built mock; here the REAL recipe tool runs). A broken
+    // list_existing (dropped labels, missing repo, or a literal "any" reaching
+    // the connector) fails HERE, not silently.
+    expect(listIssuesMock).toHaveBeenCalledTimes(1);
+    expect(listIssuesMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        repo: "patchwork/os",
+        labels: ["test-failure"],
+        state: "open",
+        limit: 30,
+      }),
+    );
+    // assignee:"any" must be dropped (NOT sent as the literal "any") — worker-
+    // filed issues are unassigned, so any non-undefined value would hide them.
+    expect(
+      (listIssuesMock.mock.calls[0]?.[0] as { assignee?: unknown } | undefined)
+        ?.assignee,
+    ).toBeUndefined();
 
     // The reversible file.write actually landed the triage note UNDER the temp
     // home — proves step C's side-effect ran AND that `~/` expanded to tmpHome
@@ -328,5 +365,74 @@ describe("worker-autonomy smoke (triage-failing-tests-autofile, flag ON)", () =>
     });
     expect(shadow.runsScanned).toBeGreaterThanOrEqual(1);
     expect(shadow.workers.some((w) => w.workerId === WORKER_ID)).toBe(true);
+  });
+
+  it("skips the issue write when an open duplicate already tracks the failure (dedup gate)", async () => {
+    // list_existing returns an OPEN test-failure issue that already covers this
+    // exact failure — the dedup half of the decision gate.
+    listIssuesMock.mockResolvedValue([
+      {
+        number: 4242,
+        title: "Test triage 2026-06-29: vitest failing 1/42",
+        repo: "patchwork/os",
+        url: "https://github.com/patchwork/os/issues/4242",
+        labels: ["test-failure"],
+        updatedAt: "2026-06-29T08:00:00Z",
+      },
+    ]);
+    // Prompt-aware agent stub: the decision step (the only prompt containing the
+    // "Output EXACTLY one word" directive) returns a bare `false` (duplicate);
+    // the triage step returns its note as before.
+    const claudeCodeFn = async (prompt: string) =>
+      prompt.includes("Output EXACTLY one word")
+        ? "false"
+        : "Triage: foo.test.ts failed; suspect commit abc123.";
+
+    const gate = await buildWorkerAutonomyGate(RECIPE_NAME, undefined, {
+      workersDir,
+      patchworkDir,
+    });
+    // Auto-approve anything that reaches the queue. Nothing SHOULD (file_issue is
+    // skipped on the falsy verdict) — but if dedup regresses and the write fires,
+    // this approves it so the `not.toHaveBeenCalled` assertion below fails loudly
+    // instead of the run hanging on a never-answered approval.
+    const queue = getApprovalQueue();
+    const unsub = queue.subscribe(() => {
+      for (const pending of queue.list()) queue.approve(pending.callId);
+    });
+
+    const runLog = new RecipeRunLog({ dir: patchworkDir });
+    const recipe = parseYaml(RECIPE_YAML) as unknown as YamlRecipe;
+    const result = await runYamlRecipe(
+      recipe,
+      makeDeps(runLog, gate ?? undefined, claudeCodeFn),
+      {
+        repo: "patchwork/os",
+        runner: "vitest",
+        failed: "1",
+        total: "42",
+        failures: "foo.test.ts > does the thing",
+        time: "0900",
+      },
+    );
+    unsub();
+
+    // The decision was `false` (duplicate) → file_issue is SKIPPED, not run.
+    expect(createIssueMock).not.toHaveBeenCalled();
+    const issueStep = result.stepResults.find(
+      (s) => s.tool === "github.create_issue",
+    );
+    expect(issueStep?.status).toBe("skipped");
+
+    // …but the triage note is STILL written (note durability holds on the
+    // dedup-skip path too — the worker leaves a record even when it files nothing).
+    const inboxDir = path.join(patchworkDir, "inbox");
+    const notes = readdirSync(inboxDir).filter((f) =>
+      f.startsWith("test-triage-"),
+    );
+    expect(
+      notes.length,
+      "triage note written even when filing is skipped",
+    ).toBe(1);
   });
 });

--- a/src/recipes/tools/__tests__/github-list-issues.test.ts
+++ b/src/recipes/tools/__tests__/github-list-issues.test.ts
@@ -1,0 +1,113 @@
+/**
+ * github.list_issues — read tool used for issue triage AND dedup. Verifies the
+ * label/state/assignee plumbing into the connector `listIssues`, in particular
+ * the `assignee: "any"` opt-out the worker dedup query relies on (worker-filed
+ * issues are unassigned, so the default `@me` filter would never see them).
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const listIssues = vi.fn();
+
+vi.mock("../../../connectors/github.js", () => ({
+  listIssues,
+  // other exports the github tool module may import dynamically (unused here)
+  createIssue: vi.fn(),
+  listPRs: vi.fn(),
+  listCommits: vi.fn(),
+}));
+
+import "../github.js";
+import { getTool } from "../../toolRegistry.js";
+import type { RunContext, StepDeps } from "../../yamlRunner.js";
+
+function ctx(params: Record<string, unknown>) {
+  return {
+    params,
+    step: {} as Record<string, unknown>,
+    ctx: {} as RunContext,
+    deps: {} as StepDeps,
+  };
+}
+
+afterEach(() => vi.clearAllMocks());
+
+describe("github.list_issues", () => {
+  it("defaults assignee to @me and state to open", async () => {
+    listIssues.mockResolvedValue([]);
+    const tool = getTool("github.list_issues");
+    await tool?.execute(ctx({ repo: "o/r" }));
+    expect(listIssues).toHaveBeenCalledWith(
+      expect.objectContaining({ repo: "o/r", assignee: "@me", state: "open" }),
+    );
+    // No labels requested → passed through as undefined (connector then omits
+    // the MCP arg entirely; covered in the connector test).
+    expect(
+      (listIssues.mock.calls[0]?.[0] as Record<string, unknown>).labels,
+    ).toBeUndefined();
+  });
+
+  it("forwards labels + state and drops the assignee filter on assignee:'any'", async () => {
+    listIssues.mockResolvedValue([]);
+    const tool = getTool("github.list_issues");
+    await tool?.execute(
+      ctx({
+        repo: "o/r",
+        labels: ["test-failure"],
+        state: "open",
+        assignee: "any",
+        max: 30,
+      }),
+    );
+    const opts = listIssues.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(opts.repo).toBe("o/r");
+    expect(opts.labels).toEqual(["test-failure"]);
+    expect(opts.state).toBe("open");
+    expect(opts.limit).toBe(30);
+    // The dedup-critical bit: "any" → undefined → connector adds no assignee arg.
+    expect(opts.assignee).toBeUndefined();
+  });
+
+  it("coerces a lone scalar label into a single-element array", async () => {
+    listIssues.mockResolvedValue([]);
+    const tool = getTool("github.list_issues");
+    await tool?.execute(ctx({ labels: "test-failure" }));
+    expect(
+      (listIssues.mock.calls[0]?.[0] as Record<string, unknown>).labels,
+    ).toEqual(["test-failure"]);
+  });
+
+  it("treats '*' and '' as the any-assignee opt-out too", async () => {
+    listIssues.mockResolvedValue([]);
+    const tool = getTool("github.list_issues");
+    await tool?.execute(ctx({ assignee: "*" }));
+    expect(
+      (listIssues.mock.calls[0]?.[0] as Record<string, unknown>).assignee,
+    ).toBeUndefined();
+  });
+
+  it("falls back to 'open' on an unrecognised state value", async () => {
+    listIssues.mockResolvedValue([]);
+    const tool = getTool("github.list_issues");
+    await tool?.execute(ctx({ state: "bogus" }));
+    expect(
+      (listIssues.mock.calls[0]?.[0] as Record<string, unknown>).state,
+    ).toBe("open");
+  });
+
+  it("normalises a connector failure to {count:0, issues:[], error}", async () => {
+    listIssues.mockRejectedValue(new Error("403 rate limit exceeded"));
+    const tool = getTool("github.list_issues");
+    const out = await tool?.execute(ctx({ repo: "o/r" }));
+    const parsed = JSON.parse(out ?? "{}");
+    expect(parsed.count).toBe(0);
+    expect(parsed.issues).toEqual([]);
+    expect(parsed.error).toMatch(/rate limit/);
+  });
+
+  it("is a read tool (not write, low risk)", () => {
+    const tool = getTool("github.list_issues");
+    expect(tool?.isWrite).toBe(false);
+    expect(tool?.riskDefault).toBe("low");
+  });
+});

--- a/src/recipes/tools/github.ts
+++ b/src/recipes/tools/github.ts
@@ -13,7 +13,8 @@ import { CommonSchemas, registerTool } from "../toolRegistry.js";
 registerTool({
   id: "github.list_issues",
   namespace: "github",
-  description: "List GitHub issues assigned to a user or matching filters.",
+  description:
+    "List GitHub issues by assignee, label, and/or state. Defaults to issues assigned to the current user; pass assignee:'any' to drop the assignee filter (e.g. label-scoped dedup queries).",
   paramsSchema: {
     type: "object",
     properties: {
@@ -24,8 +25,21 @@ registerTool({
       },
       assignee: {
         type: "string",
-        description: "User to filter by (use '@me' for current user)",
+        description:
+          "User to filter by (use '@me' for current user, or 'any'/'*' to drop the assignee filter entirely)",
         default: "@me",
+      },
+      labels: {
+        type: "array",
+        items: { type: "string" },
+        description:
+          "Only issues carrying ALL of these labels (GitHub AND semantics). Omit for no label filter.",
+      },
+      state: {
+        type: "string",
+        enum: ["open", "closed", "all"],
+        description: "Issue state filter (default 'open').",
+        default: "open",
       },
       max: CommonSchemas.max,
       into: CommonSchemas.into,
@@ -45,13 +59,33 @@ registerTool({
   execute: async ({ params }) => {
     const { listIssues } = await import("../../connectors/github.js");
     const repo = params.repo ? String(params.repo) : undefined;
-    const assignee = params.assignee ? String(params.assignee) : "@me";
+    // `assignee` defaults to @me, but "any"/"*"/"" drops the filter so a
+    // label-scoped query (e.g. dedup against worker-filed, unassigned issues)
+    // sees ALL matching issues, not just the caller's.
+    const rawAssignee = params.assignee ? String(params.assignee) : "@me";
+    const assignee =
+      rawAssignee === "any" || rawAssignee === "*" || rawAssignee === ""
+        ? undefined
+        : rawAssignee;
+    // Accept both the YAML list form (`labels: [a, b]`) and a lone scalar
+    // (`labels: test-failure`) — the latter is a common hand-authoring shape
+    // that would otherwise be silently dropped (no filter → lists every issue).
+    const labels = Array.isArray(params.labels)
+      ? params.labels.map(String).filter(Boolean)
+      : typeof params.labels === "string" && params.labels
+        ? [params.labels]
+        : undefined;
+    const stateRaw = params.state ? String(params.state) : "open";
+    const state =
+      stateRaw === "open" || stateRaw === "closed" || stateRaw === "all"
+        ? (stateRaw as "open" | "closed" | "all")
+        : "open";
     const limit = typeof params.max === "number" ? params.max : 20;
     try {
-      const issues = await listIssues({ repo, assignee, limit });
+      const issues = await listIssues({ repo, assignee, labels, state, limit });
       return JSON.stringify({ count: issues.length, issues });
     } catch (err) {
-      // Translate connector throw into the {count:0, items:[], error}
+      // Translate connector throw into the {count:0, issues:[], error}
       // shape that the runner's silent-fail detector (PR #72) catches
       // as a step error. Pre-fix this just propagated as a thrown
       // error which the runner caught fine — but the connector

--- a/templates/recipes/triage-failing-tests-autofile.yaml
+++ b/templates/recipes/triage-failing-tests-autofile.yaml
@@ -55,45 +55,90 @@ steps:
         command to run to confirm.
       driver: claude-code
       into: triage
-  # Reproducibility gate (issue-hygiene). A worker triage is a LEAD, not a
+  # Dedup read (issue-hygiene, part 1). Pull the currently-OPEN `test-failure`
+  # issues so the decision step below can avoid filing a duplicate of a failure
+  # that is already tracked. `assignee: any` is REQUIRED — worker-filed issues
+  # are unassigned, so the default `@me` filter would never see them.
+  # `optional: true` makes this FAIL-OPEN: if the list call fails (token expiry,
+  # rate limit, MCP outage) the run continues and `{{existing}}` is empty — a
+  # missed dedup (one possible duplicate) is strictly better than a blocked real
+  # filing. Dedup must never gate a genuine failure behind GitHub availability.
+  # `when: "{{repo}}"` skips this read when `repo` is unset: with an empty repo
+  # the connector would drop the owner/repo filter and dedup against EVERY
+  # accessible repo's `test-failure` issues (cross-repo poisoning). Skipping
+  # leaves `{{existing}}` empty → "not a duplicate"; the misconfig still surfaces
+  # loudly at file_issue (which hard-errors on an empty repo).
+  - id: list_existing
+    when: "{{repo}}"
+    optional: true
+    tool: github.list_issues
+    repo: "{{repo}}"
+    labels:
+      - test-failure
+    state: open
+    assignee: any
+    max: 30
+    into: existing
+  # Decision gate (issue-hygiene, part 2). A worker triage is a LEAD, not a
   # verified diagnosis — the on_test_run event can fire on a flake, a transient,
   # or an already-fixed failure (e.g. #1046: a triage that confidently blamed a
-  # commit for a test that actually passes on `main`). Before filing a real,
-  # brand-exposed issue, re-run the named test(s) in ISOLATION and only proceed
-  # if the failure still reproduces. A non-reproducing run writes the draft note
-  # (below) but files NO issue — strictly noise-reducing, never blocks a real one.
-  - id: verify_reproduced
+  # commit for a test that actually passes on `main`). This single step answers
+  # the worker's real question — "is this worth filing a NEW issue?" — which is
+  # true ONLY when the failure (1) REPRODUCES on an isolated re-run AND (2) is
+  # NOT already covered by an open issue from `list_existing`. A `false` run
+  # still writes the draft note (below) but files NO issue: strictly noise-
+  # reducing, never blocks a real, novel failure.
+  # `optional: true` is a deliberate FAIL-CLOSED-ON-FILING guard: if THIS agent
+  # step itself fails (the re-run crashes, the model returns silent-fail /
+  # narration-only output), the run does NOT halt — `{{should_file}}` is left
+  # unset, so the file_issue gate below renders falsy and SKIPS. A decision we
+  # couldn't make must never auto-file a brand-exposed issue, and the triage note
+  # (written next) is preserved either way.
+  - id: decide_file
+    optional: true
     agent:
       prompt: |
         A test run reported failures and this triage was written:
 
         {{triage}}
 
-        Re-run ONLY the specific failing test(s) named above, in isolation, on the
-        current checkout, to confirm they still fail — e.g.
-        `npx vitest run <file> -t "<test name>"`. A test that PASSES on isolated
-        re-run is a flake / transient / already-fixed and must NOT be filed.
+        Open issues already labelled `test-failure` (JSON; may be empty or an
+        error object if the lookup failed — treat anything other than a clear
+        matching issue as "not a duplicate"):
+        {{existing}}
+
+        Do BOTH checks, then decide whether to file a NEW issue:
+        1. REPRODUCE: re-run ONLY the specific failing test(s) named above, in
+           isolation, on the current checkout — e.g.
+           `npx vitest run <file> -t "<test name>"`. A test that PASSES on
+           isolated re-run is a flake / transient / already-fixed.
+        2. DEDUP: check whether an OPEN issue above already tracks THIS failure
+           (same test/file and root cause). If so, it is a duplicate.
 
         Output EXACTLY one word and nothing else:
-          true   — the failure REPRODUCED (a real, current failure worth filing)
-          false  — it did NOT reproduce (flake / transient / already green)
+          true   — the failure REPRODUCED *and* is NOT already tracked (file it)
+          false  — it did NOT reproduce, OR an open issue already covers it
       driver: claude-code
-      into: reproduced
+      into: should_file
   - id: write_note
     tool: file.write
     path: ~/.patchwork/inbox/test-triage-{{date}}-{{time}}.md
     content: |
       # Test triage — {{date}} {{time}}
 
-      Runner {{runner}} · failed {{failed}}/{{total}} · reproduced: {{reproduced}}
+      Runner {{runner}} · failed {{failed}}/{{total}} · file new issue: {{should_file}}
 
       {{triage}}
-  # The risky owned action. Runs AFTER the draft is written (so a gate rejection,
-  # a missing `repo`, or a non-reproducing failure never loses the triage note)
-  # and ONLY when the failure reproduced — `when` skips the step (not a failure)
-  # on a falsy guard ("", "false", "0", "null", "undefined").
+  # The risky owned action. Runs AFTER the draft is written — and the two steps
+  # between the note and here (list_existing, decide_file) are BOTH `optional`,
+  # so a gate rejection, a missing `repo`, a non-reproducing failure, a duplicate,
+  # OR a crashed decision agent never halts before write_note: the triage note is
+  # always preserved. Files ONLY when the decision step emitted a truthy verdict —
+  # `when` skips the step (not a failure) on a falsy guard ("", "false", "0",
+  # "null", "undefined"), which also covers the unset-var case when decide_file
+  # failed fail-open.
   - id: file_issue
-    when: "{{reproduced}}"
+    when: "{{should_file}}"
     tool: github.create_issue
     repo: "{{repo}}"
     title: "Test triage {{date}}: {{runner}} failing {{failed}}/{{total}}"
@@ -101,7 +146,7 @@ steps:
       {{triage}}
 
       ---
-      _Filed by the Test Guardian Worker from a failing {{runner}} run (reproduced on isolated re-run)._
+      _Filed by the Test Guardian Worker from a failing {{runner}} run (reproduced on isolated re-run; no open duplicate)._
     labels:
       - test-failure
     into: filed_issue


### PR DESCRIPTION
## What

Completes the **issue-hygiene** pair for the Test Guardian worker. #1048 added the *reproducibility* gate (don't file flakes/transients/already-fixed). This adds **dedup**: don't file a NEW issue when an OPEN one already tracks the same failure.

## Changes

**`github.list_issues` (connector + recipe tool)**
- New `labels` (AND-match) + `state` (`open`/`closed`/`all`, default `open`) filters.
- New `assignee: "any"|"*"|""` opt-out → drops the assignee filter. Worker-filed issues are **unassigned**, so the historical `@me` default could never find them; a label-scoped dedup query needs to see all of them.
- Unset `labels`/`state` produce **byte-identical** MCP args to before (back-compat; covered by a connector test).

**`triage-failing-tests-autofile` recipe**
- A fail-open `list_existing` read pulls the open `test-failure` issues.
- The single decision agent now answers *"file a NEW issue?"* = **reproduced AND not-already-tracked** (bare `true`/`false` → `file_issue`'s `when` gate).

## Robustness (driven by an adversarial multi-agent review of the diff)

- **Dedup fails OPEN.** `list_existing` is `optional: true` — a GitHub outage (token expiry / rate limit / MCP down) never blocks a real filing. A missed dup ≪ a missed real issue. (Three independent layers verified: step-optional, the tool's error-envelope, and the prompt's "treat empty/error as not-a-duplicate".)
- **No cross-repo poisoning.** `list_existing` is guarded `when: "{{repo}}"` — with an unset repo the connector would otherwise dedup against *every* accessible repo's `test-failure` issues. The misconfig still surfaces loudly at `file_issue` (hard-errors on empty repo).
- **Note durability + fail-closed filing.** `decide_file` is `optional: true`: a crashed/silent decision agent no longer halts before `write_note` (the triage note is always preserved) and leaves `should_file` unset → `file_issue`'s `when` skips. A decision we couldn't make never auto-files a brand-exposed issue.
- Scalar `labels: test-failure` is coerced to `["test-failure"]` (was silently dropped for hand-authored callers).

## Tests

- **Connector** (`github.test.ts`): forwards `labels` + non-default `state`; omits both when unset (byte-identical legacy args).
- **Recipe tool** (`github-list-issues.test.ts`, new): `any`/`*`/`""` → assignee dropped; scalar label coerced; unknown state → `open`; failure → `{count:0,issues:[],error}`.
- **Smoke** (`workerAutonomySmoke.test.ts`): now asserts the dedup read's full **YAML→runner→recipe-tool→connector** arg plumbing end-to-end (the composed assignee opt-out seam no unit test crossed), plus a new **dedup-SKIP** case proving a `false` verdict skips `file_issue` while the triage note still lands.

Build, strict tests-core typecheck, recipe lint (0 warnings), LSP + schema audit gates all green. Branched off `main` (post-#1048 squash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)