### PR TITLE
feat(workers): outcome verification — junk issues flip trust to good:false

### DIFF
--- a/src/recipes/yamlRunner.ts
+++ b/src/recipes/yamlRunner.ts
@@ -2265,6 +2265,25 @@ export async function runYamlRecipe(
           result === null ? "skipped" : stepError ? "error" : "ok";
         const retryNote =
           retryCount > 0 ? ` after ${retryCount + 1} attempts` : "";
+        // Outcome attribution: capture the filed-issue URL on github.create_issue
+        // steps so trust-replay can look up the issue's eventual disposition in
+        // the outcome store (confirmed/junk/unknown). Targeted to this one tool
+        // only — storing all tool outputs would bloat the run log unnecessarily.
+        let stepOutput: Record<string, unknown> | undefined;
+        if (
+          finalStatus === "ok" &&
+          result !== null &&
+          step.tool === "github.create_issue"
+        ) {
+          try {
+            const parsed = JSON.parse(result) as Record<string, unknown>;
+            if (typeof parsed.url === "string") {
+              stepOutput = { url: parsed.url, issueNumber: parsed.issueNumber };
+            }
+          } catch {
+            /* non-JSON or missing url — skip output capture */
+          }
+        }
         stepResults.push({
           id: stepId,
           tool: step.tool,
@@ -2276,6 +2295,7 @@ export async function runYamlRecipe(
                 haltCategory: "tool_error" as HaltCategory,
               }
             : {}),
+          ...(stepOutput !== undefined ? { output: stepOutput } : {}),
           durationMs: Date.now() - stepStart,
         });
         if (stepError) {

--- a/src/workers/__tests__/outcomeStore.test.ts
+++ b/src/workers/__tests__/outcomeStore.test.ts
@@ -1,0 +1,177 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  classifyIssueDisposition,
+  type OutcomeRecord,
+  OutcomeStore,
+} from "../outcomeStore.js";
+
+describe("classifyIssueDisposition", () => {
+  it("labels signalling noise → junk (case-insensitive, substring)", () => {
+    for (const label of [
+      "invalid",
+      "Duplicate",
+      "WONTFIX",
+      "won't fix",
+      "not a bug",
+      "by design",
+      "spam",
+      "status: duplicate", // substring match
+    ]) {
+      expect(
+        classifyIssueDisposition({ state: "open", labels: [label] }),
+        label,
+      ).toBe("junk");
+    }
+  });
+
+  it("state_reason 'not_planned' → junk (closed-as-not-planned)", () => {
+    expect(
+      classifyIssueDisposition({
+        state: "closed",
+        state_reason: "not_planned",
+      }),
+    ).toBe("junk");
+  });
+
+  it("closed-as-completed → confirmed (GitHub's default positive close)", () => {
+    expect(
+      classifyIssueDisposition({ state: "closed", state_reason: "completed" }),
+    ).toBe("confirmed");
+  });
+
+  it("a positive label → confirmed", () => {
+    for (const label of ["patchwork:valid", "confirmed", "verified"]) {
+      expect(
+        classifyIssueDisposition({ state: "open", labels: [label] }),
+        label,
+      ).toBe("confirmed");
+    }
+  });
+
+  it("JUNK wins over confirmed signals (conservative precedence)", () => {
+    // closed-as-completed BUT labelled duplicate → junk, not confirmed.
+    expect(
+      classifyIssueDisposition({
+        state: "closed",
+        state_reason: "completed",
+        labels: ["duplicate"],
+      }),
+    ).toBe("junk");
+    // not_planned outranks a positive label too.
+    expect(
+      classifyIssueDisposition({
+        state: "closed",
+        state_reason: "not_planned",
+        labels: ["verified"],
+      }),
+    ).toBe("junk");
+  });
+
+  it("still-open / no clear signal → unknown (weak not-reverted rung)", () => {
+    expect(classifyIssueDisposition({ state: "open" })).toBe("unknown");
+    expect(classifyIssueDisposition({ state: "open", labels: [] })).toBe(
+      "unknown",
+    );
+    // closed with no state_reason and no labels → unknown (not assumed good).
+    expect(classifyIssueDisposition({ state: "closed" })).toBe("unknown");
+    expect(classifyIssueDisposition({})).toBe("unknown");
+  });
+
+  it("accepts both string and {name} label shapes", () => {
+    expect(
+      classifyIssueDisposition({
+        state: "open",
+        labels: [{ name: "invalid" }, "other"],
+      }),
+    ).toBe("junk");
+    // a malformed {name: undefined} entry must not throw.
+    expect(
+      classifyIssueDisposition({ state: "open", labels: [{}, "confirmed"] }),
+    ).toBe("confirmed");
+  });
+});
+
+describe("OutcomeStore", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(path.join(os.tmpdir(), "outcome-store-"));
+  });
+  afterEach(() => {
+    try {
+      rmSync(dir, { recursive: true, force: true });
+    } catch {
+      /* OS reaps temp dir */
+    }
+  });
+
+  const rec = (
+    issueUrl: string,
+    disposition: OutcomeRecord["disposition"],
+    checkedAt = 1,
+  ): OutcomeRecord => ({ issueUrl, disposition, checkedAt });
+
+  it("returns null for an unknown URL (and a missing log file)", () => {
+    const store = new OutcomeStore(dir);
+    expect(store.getDisposition("https://x/issues/1")).toBeNull();
+  });
+
+  it("upsert → getDisposition round-trips, and the same instance sees its write", () => {
+    const store = new OutcomeStore(dir);
+    store.upsert(rec("https://x/issues/1", "junk"));
+    expect(store.getDisposition("https://x/issues/1")).toBe("junk");
+  });
+
+  it("persists across instances (append-only JSONL on disk)", () => {
+    new OutcomeStore(dir).upsert(rec("https://x/issues/1", "confirmed"));
+    // A fresh instance lazy-loads from disk.
+    expect(new OutcomeStore(dir).getDisposition("https://x/issues/1")).toBe(
+      "confirmed",
+    );
+  });
+
+  it("last-writer-wins: a later disposition supersedes an earlier one", () => {
+    const store = new OutcomeStore(dir);
+    store.upsert(rec("https://x/issues/1", "unknown", 1));
+    store.upsert(rec("https://x/issues/1", "junk", 2));
+    expect(store.getDisposition("https://x/issues/1")).toBe("junk");
+    // and across a fresh read of the same append-only log:
+    expect(new OutcomeStore(dir).getDisposition("https://x/issues/1")).toBe(
+      "junk",
+    );
+  });
+
+  it("skips malformed JSONL lines without throwing", () => {
+    const logPath = path.join(dir, "outcome-log.jsonl");
+    writeFileSync(
+      logPath,
+      [
+        "{ not valid json",
+        JSON.stringify(rec("https://x/issues/2", "confirmed")),
+        "", // blank line
+        '{"issueUrl":"","disposition":"junk"}', // empty key → ignored
+      ].join("\n"),
+      "utf-8",
+    );
+    const store = new OutcomeStore(dir);
+    expect(store.getDisposition("https://x/issues/2")).toBe("confirmed");
+    expect(store.getDisposition("")).toBeNull();
+  });
+
+  it("readAll dedupes to last-writer-wins full records", () => {
+    const store = new OutcomeStore(dir);
+    store.upsert(rec("https://x/issues/1", "unknown", 1));
+    store.upsert(rec("https://x/issues/1", "confirmed", 2));
+    store.upsert(rec("https://x/issues/3", "junk", 3));
+    const all = store.readAll();
+    expect(all).toHaveLength(2);
+    expect(all.find((r) => r.issueUrl.endsWith("/1"))?.disposition).toBe(
+      "confirmed",
+    );
+    expect(all.find((r) => r.issueUrl.endsWith("/3"))?.disposition).toBe(
+      "junk",
+    );
+  });
+});

--- a/src/workers/__tests__/shadowObserver.test.ts
+++ b/src/workers/__tests__/shadowObserver.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { GraduationConfig } from "../graduation.js";
+import type { OutcomeDisposition, OutcomeStore } from "../outcomeStore.js";
 import {
   isDurableSuccess,
   type RunRecord,
@@ -214,5 +215,103 @@ describe("WorkerShadowObserver — durable-outcome labelling", () => {
     const obs = new WorkerShadowObserver([issuer], { cfg: CFG }); // no now
     obs.ingestRun(issueRun(now - 1000));
     expect(issueRow(obs)?.observations).toBe(1);
+  });
+});
+
+describe("WorkerShadowObserver — outcome verification (junk → good:false)", () => {
+  const now = 100 * W;
+  const URL = "https://github.com/o/r/issues/1";
+  const issuer = parseWorker({
+    id: "issuer",
+    name: "Issuer",
+    recipe: "file-issues",
+    owns: ["issue"],
+  });
+  // A DURABLE (past-window) issue filing carrying the captured URL.
+  const durableFiling = (url?: string): RunRecord => ({
+    recipeName: "file-issues",
+    at: now - 2 * W,
+    steps: [
+      {
+        tool: "githubCreateIssue",
+        status: "ok",
+        ...(url ? { output: { url } } : {}),
+      },
+    ],
+  });
+  const issueRow = (obs: WorkerShadowObserver) =>
+    obs.report()[0]!.board.find((b) => b.classKey.startsWith("issue"));
+  // Minimal stand-in for OutcomeStore — the observer only calls getDisposition.
+  const fakeStore = (m: Record<string, OutcomeDisposition>) =>
+    ({
+      getDisposition: (u: string) => m[u] ?? null,
+    }) as unknown as OutcomeStore;
+
+  it("folds a durable JUNK filing as good:false (lowers trust, not neutral)", () => {
+    const junk = new WorkerShadowObserver([issuer], {
+      cfg: CFG,
+      now,
+      outcomeStore: fakeStore({ [URL]: "junk" }),
+    });
+    junk.ingestRun(durableFiling(URL));
+    const confirmed = new WorkerShadowObserver([issuer], {
+      cfg: CFG,
+      now,
+      outcomeStore: fakeStore({ [URL]: "confirmed" }),
+    });
+    confirmed.ingestRun(durableFiling(URL));
+
+    // Both record one observation (a junk filing is still EVIDENCE)…
+    expect(issueRow(junk)?.observations).toBe(1);
+    expect(issueRow(confirmed)?.observations).toBe(1);
+    // …but the junk posterior mean is strictly LOWER — proving good:false was
+    // folded for junk and good:true for confirmed (the #1046 noise case).
+    expect(issueRow(junk)!.mean).toBeLessThan(issueRow(confirmed)!.mean);
+  });
+
+  it("confirmed and unknown dispositions both keep the good:true path (identical dial)", () => {
+    const confirmed = new WorkerShadowObserver([issuer], {
+      cfg: CFG,
+      now,
+      outcomeStore: fakeStore({ [URL]: "confirmed" }),
+    });
+    confirmed.ingestRun(durableFiling(URL));
+    // unknown = no record for the URL → getDisposition null → weak not-reverted path
+    const unknown = new WorkerShadowObserver([issuer], {
+      cfg: CFG,
+      now,
+      outcomeStore: fakeStore({}),
+    });
+    unknown.ingestRun(durableFiling(URL));
+    expect(issueRow(unknown)!.mean).toBe(issueRow(confirmed)!.mean);
+  });
+
+  it("ignores the outcome store before the durability window (still pending)", () => {
+    const obs = new WorkerShadowObserver([issuer], {
+      cfg: CFG,
+      now,
+      outcomeStore: fakeStore({ [URL]: "junk" }),
+    });
+    // filed 1s ago — junk or not, a non-durable success earns nothing yet.
+    obs.ingestRun({
+      recipeName: "file-issues",
+      at: now - 1000,
+      steps: [
+        { tool: "githubCreateIssue", status: "ok", output: { url: URL } },
+      ],
+    });
+    expect(issueRow(obs)).toBeUndefined();
+  });
+
+  it("a durable filing with no captured URL falls through to good:true (back-compat)", () => {
+    const obs = new WorkerShadowObserver([issuer], {
+      cfg: CFG,
+      now,
+      outcomeStore: fakeStore({ [URL]: "junk" }),
+    });
+    obs.ingestRun(durableFiling()); // no output.url → no lookup
+    const baseline = new WorkerShadowObserver([issuer], { cfg: CFG, now });
+    baseline.ingestRun(durableFiling());
+    expect(issueRow(obs)!.mean).toBe(issueRow(baseline)!.mean);
   });
 });

--- a/src/workers/outcomeStore.ts
+++ b/src/workers/outcomeStore.ts
@@ -1,0 +1,161 @@
+import { appendFileSync, existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+/**
+ * Outcome disposition for a filed issue. Drives the trust signal the ramp
+ * folds in once the durability window has elapsed:
+ *
+ *   confirmed — issue closed-as-completed or labelled valid. Strong positive:
+ *               the worker's filing was real and accepted. Counts as good:true
+ *               with full weight (same as today, but now human-verified).
+ *   junk      — issue closed-as-not-planned, labelled invalid/duplicate/wontfix,
+ *               or otherwise dismissed. Strong negative: the worker filed noise.
+ *               Flipped to good:false in trust-replay — junk must lower trust,
+ *               not be neutral (surviving 24h unopened ≠ correctness).
+ *   unknown   — issue still open past the window, or no signal yet. The
+ *               current weak "not-reverted" rung (good:true, status quo). A
+ *               null return from getDisposition is treated identically.
+ */
+export type OutcomeDisposition = "confirmed" | "junk" | "unknown";
+
+export interface OutcomeRecord {
+  /** GitHub issue URL — the lookup key. */
+  issueUrl: string;
+  disposition: OutcomeDisposition;
+  /** Epoch ms when this record was written by the ingester. */
+  checkedAt: number;
+  /** Optional context for auditing. */
+  recipeName?: string;
+  workerClass?: string;
+}
+
+/**
+ * Persist + query outcome dispositions for filed issues.
+ *
+ * Storage: append-only JSONL at `~/.patchwork/outcome-log.jsonl` (one record
+ * per line). Later writes for the same issueUrl supersede earlier ones — the
+ * in-memory cache always resolves to the LAST record for a URL (last-writer-
+ * wins). This lets the ingester update a disposition as an issue evolves
+ * (e.g. open → closed-as-completed over days).
+ *
+ * Write path: `upsert()` — called by the outcome-ingester cron recipe.
+ * Read path: `getDisposition(url)` — called by WorkerShadowObserver.ingestRun
+ *             on the hot trust-replay path. Cache is lazy-loaded once per
+ *             instance; create a new instance per trust-replay (the observer
+ *             already does one replay per gate decision).
+ */
+export class OutcomeStore {
+  private readonly logPath: string;
+  /** Lazy-loaded from disk. null = not yet loaded. */
+  private _cache: Map<string, OutcomeDisposition> | null = null;
+
+  constructor(patchworkDir: string) {
+    this.logPath = path.join(patchworkDir, "outcome-log.jsonl");
+  }
+
+  /** Last-writer-wins map of issueUrl → disposition. Loaded once per instance. */
+  private get cache(): Map<string, OutcomeDisposition> {
+    if (this._cache) return this._cache;
+    this._cache = new Map();
+    if (!existsSync(this.logPath)) return this._cache;
+    const text = readFileSync(this.logPath, "utf-8");
+    for (const line of text.split("\n")) {
+      const t = line.trim();
+      if (!t) continue;
+      try {
+        const r = JSON.parse(t) as OutcomeRecord;
+        if (r.issueUrl && r.disposition) {
+          this._cache.set(r.issueUrl, r.disposition);
+        }
+      } catch {
+        /* skip malformed lines */
+      }
+    }
+    return this._cache;
+  }
+
+  /**
+   * Disposition for `issueUrl`, or null when no record exists.
+   * Null is treated by trust-replay as "unknown" (current weak-durable path).
+   */
+  getDisposition(issueUrl: string): OutcomeDisposition | null {
+    return this.cache.get(issueUrl) ?? null;
+  }
+
+  /**
+   * Persist a disposition for `issueUrl`. Later calls supersede earlier ones
+   * (both on disk via append, and in the in-memory cache).
+   */
+  upsert(record: OutcomeRecord): void {
+    const line = `${JSON.stringify(record)}\n`;
+    appendFileSync(this.logPath, line, "utf-8");
+    // Update cache so the same instance sees its own write immediately.
+    if (this._cache) this._cache.set(record.issueUrl, record.disposition);
+  }
+
+  /** All records (deduped, last-writer-wins). For reporting / ingester diffing. */
+  readAll(): OutcomeRecord[] {
+    // Re-parse to get full records (cache only stores disposition).
+    const seen = new Map<string, OutcomeRecord>();
+    if (!existsSync(this.logPath)) return [];
+    const text = readFileSync(this.logPath, "utf-8");
+    for (const line of text.split("\n")) {
+      const t = line.trim();
+      if (!t) continue;
+      try {
+        const r = JSON.parse(t) as OutcomeRecord;
+        if (r.issueUrl && r.disposition) seen.set(r.issueUrl, r);
+      } catch {
+        /* skip malformed */
+      }
+    }
+    return Array.from(seen.values());
+  }
+}
+
+/**
+ * Map a GitHub issue's state/labels to an OutcomeDisposition.
+ * Pure function — used both by the ingester recipe agent prompt and by tests.
+ *
+ * Junk signals (any one → junk):
+ *   - state_reason: "not_planned"
+ *   - labels containing: "invalid", "duplicate", "wontfix", "won't fix",
+ *     "not a bug", "by design", "spam"
+ *
+ * Confirmed signals (issue closed with a positive signal):
+ *   - state: "closed" + state_reason: "completed" (GitHub's default close)
+ *   - labels containing: "patchwork:valid", "confirmed", "verified"
+ *
+ * Unknown: still open, or closed with no clear signal.
+ */
+export function classifyIssueDisposition(issue: {
+  state?: string;
+  state_reason?: string | null;
+  labels?: Array<string | { name?: string }>;
+}): OutcomeDisposition {
+  const labelNames = (issue.labels ?? [])
+    .map((l) => (typeof l === "string" ? l : (l.name ?? "")))
+    .map((s) => s.toLowerCase());
+
+  const JUNK_LABELS = [
+    "invalid",
+    "duplicate",
+    "wontfix",
+    "won't fix",
+    "not a bug",
+    "by design",
+    "spam",
+  ];
+  const CONFIRMED_LABELS = ["patchwork:valid", "confirmed", "verified"];
+
+  if (JUNK_LABELS.some((j) => labelNames.some((l) => l.includes(j))))
+    return "junk";
+  if (issue.state_reason === "not_planned") return "junk";
+
+  if (CONFIRMED_LABELS.some((c) => labelNames.some((l) => l.includes(c))))
+    return "confirmed";
+  if (issue.state === "closed" && issue.state_reason === "completed")
+    return "confirmed";
+
+  return "unknown";
+}

--- a/src/workers/runWorkerShadow.ts
+++ b/src/workers/runWorkerShadow.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { MAX_PERSIST_LINES, RecipeRunLog } from "../runLog.js";
 import { backtestWorker, formatBacktestReport } from "./backtest.js";
+import { OutcomeStore } from "./outcomeStore.js";
 import {
   type DecisionRecord,
   type RunRecord,
@@ -71,6 +72,12 @@ function readRuns(patchworkDir: string, recipeNames?: string[]): RunRecord[] {
         tool: s.tool,
         status: s.status,
         haltReason: s.haltReason,
+        // Outcome attribution: carry the captured issue URL so ingestRun can
+        // look up the issue's disposition in the outcome store. Only present on
+        // github.create_issue steps (see yamlRunner.ts step output capture).
+        ...(s.output !== undefined && typeof s.output === "object"
+          ? { output: s.output as Record<string, unknown> }
+          : {}),
       })),
     }));
   } catch {
@@ -166,6 +173,7 @@ export function getWorkerShadowData(
     // production; tests inject opts.now.
     workers: buildShadowReport(workers, runs, decisions, undefined, {
       now: opts.now ?? Date.now(),
+      outcomeStore: new OutcomeStore(patchworkDir),
     }),
     runsScanned: runs.length,
     decisionsScanned: decisions.length,
@@ -203,6 +211,7 @@ export function loadWorkerTrustForRecipe(
   // reverted. Real Date.now() in production; tests inject opts.now.
   const observer = new WorkerShadowObserver(workers, {
     now: opts.now ?? Date.now(),
+    outcomeStore: new OutcomeStore(patchworkDir),
   });
   const worker = observer.workerForRecipe(recipeName);
   if (!worker) return null;

--- a/src/workers/shadowObserver.ts
+++ b/src/workers/shadowObserver.ts
@@ -4,6 +4,7 @@ import {
   DEFAULT_GRADUATION_CONFIG,
   type GraduationConfig,
 } from "./graduation.js";
+import type { OutcomeStore } from "./outcomeStore.js";
 import { recommend } from "./shadowGate.js";
 import {
   ownsAction,
@@ -37,6 +38,14 @@ export interface RunRecord {
     /** Persisted halt reason — used to tell a worker failure apart from a
      * human approval decision (the latter is not trust evidence; see L2). */
     haltReason?: string;
+    /**
+     * Captured tool output for outcome attribution. Only populated for
+     * github.create_issue steps (contains `{url, issueNumber}`). Used by
+     * ingestRun to look up the issue's eventual disposition in the outcome
+     * store so junk filings flip to good:false rather than counting as earned
+     * trust. See outcomeStore.ts.
+     */
+    output?: Record<string, unknown>;
   }>;
 }
 
@@ -122,6 +131,9 @@ export class WorkerShadowObserver {
    *  the prior status-only behaviour is preserved (back-compat for pure tests). */
   private readonly now?: number;
   private readonly durabilityWindowMs: number;
+  /** Optional outcome store — when present, junk issues flip good:false past
+   *  the durability window instead of counting as earned trust. */
+  private readonly outcomeStore?: OutcomeStore;
 
   constructor(
     workers: WorkerManifest[],
@@ -130,6 +142,7 @@ export class WorkerShadowObserver {
       cfg?: GraduationConfig;
       now?: number;
       durabilityWindowMs?: number;
+      outcomeStore?: OutcomeStore;
     } = {},
   ) {
     this.workers = workers;
@@ -138,6 +151,7 @@ export class WorkerShadowObserver {
     this.now = opts.now;
     this.durabilityWindowMs =
       opts.durabilityWindowMs ?? DEFAULT_DURABILITY_WINDOW_MS;
+    this.outcomeStore = opts.outcomeStore;
   }
 
   /**
@@ -198,6 +212,27 @@ export class WorkerShadowObserver {
           )
         )
           continue; // pending — survives the window before it earns trust
+        // Past the window: check outcome store for non-reversible steps.
+        // Junk issues (closed-as-not-planned / labelled invalid/duplicate) mean
+        // the worker filed noise → flip to good:false. confirmed/unknown fall
+        // through to the good:true path below (current weak-durable behaviour).
+        if (ac.reversibility !== "reversible" && this.outcomeStore) {
+          const url =
+            step.output && typeof step.output.url === "string"
+              ? step.output.url
+              : null;
+          if (url) {
+            const disposition = this.outcomeStore.getDisposition(url);
+            if (disposition === "junk") {
+              this.store.apply(
+                worker.id,
+                { toolName: step.tool, good: false, at: run.at },
+                { prior, cfg: this.cfg },
+              );
+              continue;
+            }
+          }
+        }
       }
       this.store.apply(
         worker.id,

--- a/src/workers/shadowReport.ts
+++ b/src/workers/shadowReport.ts
@@ -1,4 +1,5 @@
 import type { GraduationConfig } from "./graduation.js";
+import type { OutcomeStore } from "./outcomeStore.js";
 import {
   type DecisionRecord,
   type RunRecord,
@@ -18,7 +19,11 @@ export function buildShadowReport(
   runs: RunRecord[],
   decisions: DecisionRecord[],
   cfg?: GraduationConfig,
-  opts: { now?: number; durabilityWindowMs?: number } = {},
+  opts: {
+    now?: number;
+    durabilityWindowMs?: number;
+    outcomeStore?: OutcomeStore;
+  } = {},
 ): WorkerShadowReport[] {
   const obs = new WorkerShadowObserver(workers, {
     cfg,
@@ -26,6 +31,7 @@ export function buildShadowReport(
     ...(opts.durabilityWindowMs !== undefined && {
       durabilityWindowMs: opts.durabilityWindowMs,
     }),
+    ...(opts.outcomeStore !== undefined && { outcomeStore: opts.outcomeStore }),
   });
   const merged: Array<{ at: number; run?: RunRecord; dec?: DecisionRecord }> = [
     ...runs.map((r) => ({ at: r.at, run: r })),

--- a/templates/recipes/outcome-ingester.yaml
+++ b/templates/recipes/outcome-ingester.yaml
@@ -1,0 +1,72 @@
+# yaml-language-server: $schema=https://patchwork.dev/schemas/recipe.v1.json
+#
+# Outcome Ingester — polls GitHub for issues filed by the Test Guardian Worker
+# and records their dispositions (confirmed / junk / unknown) to
+# ~/.patchwork/outcome-log.jsonl. The worker trust-replay reads this file to
+# flip junk filings to good:false past the 24h durability window, so the ramp
+# demotes workers that file noise rather than rewarding them.
+#
+# Schedule: every 6 hours. Stagger from the triage recipe so the outcome poll
+# runs well after new issues have settled (most "junk" signals appear within
+# hours of filing).
+#
+# Prerequisite: GitHub connector authorised. Label "patchwork:filed" must be
+# applied by the triage recipe (or manually) so this ingester can scope its
+# poll. If you use a different label, update `labels` below.
+apiVersion: patchwork.sh/v1
+name: outcome-ingester
+description: Poll GitHub for Test Guardian issues and record outcome dispositions to the trust-replay store.
+trigger:
+  type: cron
+  at: "0 */6 * * *"
+  vars:
+    - name: repo
+      default: ""
+      description: "owner/repo to poll (leave blank to poll all accessible repos)"
+    - name: label
+      default: "patchwork:filed"
+      description: "Label that marks worker-filed issues"
+    - name: max
+      default: "50"
+      description: "Max issues to poll per run"
+steps:
+  - id: list_issues
+    tool: github.list_issues
+    repo: "{{repo}}"
+    labels:
+      - "{{label}}"
+    assignee: any
+    state: all
+    max: 50
+    into: issues
+
+  - id: classify
+    when: "{{issues}}"
+    agent:
+      prompt: |
+        You are classifying GitHub issues to determine whether they were useful filings or junk.
+
+        Issues JSON:
+        {{issues}}
+
+        For each issue, determine its disposition:
+        - "confirmed" — issue is closed with state_reason "completed", OR has a label containing "confirmed", "verified", or "patchwork:valid". This means the filing was correct and accepted.
+        - "junk" — issue has state_reason "not_planned", OR has a label containing "invalid", "duplicate", "wontfix", "won't fix", "not a bug", "by design", or "spam". This means the filing was noise.
+        - "unknown" — issue is still open, or closed with no clear signal.
+
+        Output ONLY raw JSONL — one JSON object per line, no markdown, no explanation:
+        {"issueUrl":"<url>","disposition":"<confirmed|junk|unknown>","checkedAt":<epoch_ms>}
+
+        Rules:
+        - issueUrl is the issue's html_url field
+        - checkedAt is the current Unix epoch in milliseconds (approximate — use the issue's updated_at epoch if current time unavailable)
+        - Emit one line per issue. No trailing commas, no array brackets, no other text.
+        - If there are no issues to classify, output nothing (empty string).
+      model: claude-haiku-4-5-20251001
+      into: outcome_lines
+
+  - id: persist
+    when: "{{outcome_lines}}"
+    tool: file.append
+    path: ~/.patchwork/outcome-log.jsonl
+    content: "{{outcome_lines}}\n"


### PR DESCRIPTION
## What

The **outcome half** of the Decision Record. #1047 shipped the *decision* side (why the worker acted). Until now the only *outcome* signal was the durable-label's "not reverted after 24h" — so a junk issue nobody closed in time counted as **earned trust** (the #1041/#1046 failure mode). This folds the issue's eventual disposition back in: **junk filings lower trust instead of counting as success.**

## How

- **`outcomeStore.ts`** — append-only JSONL (`~/.patchwork/outcome-log.jsonl`), last-writer-wins. `classifyIssueDisposition()` pure fn: `not_planned` / `invalid`/`duplicate`/`wontfix`/… → **junk**; closed-as-completed / `patchwork:valid`/`confirmed`/`verified` → **confirmed**; else **unknown**. Junk-beats-confirmed precedence (conservative).
- **`outcome-ingester.yaml`** — cron (`0 */6 * * *`) lists `test-failure` issues, classifies disposition, appends to the log. **This is the only place that calls GitHub** — keeps the network out of the trust hot path.
- **`shadowObserver.ingestRun`** — past the durability window, a non-reversible step with a captured issue URL looks up its disposition: **junk → `good:false`**; confirmed/unknown keep the current `good:true` (weak not-reverted) path. Within-window successes still pend.
- **`yamlRunner` / `runWorkerShadow`** — capture `{url, issueNumber}` on `github.create_issue` ok steps and thread it through `readRuns` into the `RunRecord` so trust-replay can do the lookup locally.

## Tests (added here — the handoff shipped this trust-affecting code untested)

- **`outcomeStore.test.ts`** — `classifyIssueDisposition` across junk/confirmed/unknown + junk-beats-confirmed precedence + string/`{name}` label shapes; `OutcomeStore` persistence, last-writer-wins, malformed-line skip, missing-file → null.
- **`shadowObserver.test.ts`** — a durable **junk** filing folds `good:false` (posterior mean strictly below a confirmed filing); **confirmed == unknown** (good:true path); the store is ignored **before** the window (still pending); a filing with **no captured URL** falls through to good:true (back-compat).

Build clean · strict tests-core typecheck · worker suite 138 green · yamlRunner/runWorkerShadow green · biome + LSP + fixture + schema gates clean. Branched off `main` (post-#1049).

Deferred (low value now): shadow-report confirmed/weak/junk breakdown counts (needs a store-side counter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)