### PR TITLE
fix(shim): workspace-aware bridge lock discovery

### DIFF
--- a/scripts/mcp-stdio-shim.cjs
+++ b/scripts/mcp-stdio-shim.cjs
@@ -51,17 +51,30 @@ function isAlive(pid) {
 // rather than on every poll tick.
 let lastSelectedLockPath = null;
 
+// True when `cwd` is the workspace root or a descendant of it. Used (only when
+// no --workspace filter is set) to prefer the bridge for the project the shim is
+// actually running in, rather than whichever lock has the newest mtime. Mirrors
+// cwdInWorkspace() in src/bridgeLockDiscovery.ts (unit-tested there).
+function cwdInWorkspace(cwd, workspace) {
+  if (!workspace) return false;
+  const rel = path.relative(workspace, cwd);
+  return rel === "" || (!rel.startsWith("..") && !path.isAbsolute(rel));
+}
+
 function findLockFile() {
   const lockDir = path.join(
     process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), ".claude"),
     "ide",
   );
-  // Three-tier preference: orchestrator > bridge > any lock (each by newest mtime).
-  // Orchestrator locks win because child bridge restarts produce newer lock files,
-  // which would hijack the shim away from the orchestrator if we only used mtime.
-  const orchestrator = { path: null, mtime: 0, data: null };
-  const bridge = { path: null, mtime: 0, data: null };
-  const fallback = { path: null, mtime: 0, data: null };
+  const cwd = process.cwd();
+  // Three-tier preference: orchestrator > bridge > any lock. Within a tier, a
+  // lock whose workspace contains the cwd wins (so a no---workspace shim attaches
+  // to the project it is running in); ties break on newest mtime. Orchestrator
+  // locks still win across tiers because child bridge restarts produce newer
+  // lock files that would otherwise hijack the shim away from the orchestrator.
+  const orchestrator = { path: null, mtime: 0, data: null, cwdMatch: false };
+  const bridge = { path: null, mtime: 0, data: null, cwdMatch: false };
+  const fallback = { path: null, mtime: 0, data: null, cwdMatch: false };
   try {
     for (const f of fs.readdirSync(lockDir)) {
       if (!f.endsWith(".lock")) continue;
@@ -89,10 +102,23 @@ function findLockFile() {
           : isBridge
             ? bridge
             : fallback;
-        if (stat.mtimeMs > tier.mtime) {
+        // When no --workspace filter is set, prefer a lock whose workspace
+        // contains the cwd over a non-matching one; otherwise fall back to
+        // newest mtime. (With a filter, every survivor already exact-matches,
+        // so cwdMatch is uniformly false and this reduces to newest-mtime.)
+        const cwdMatch =
+          !workspaceFilter &&
+          !!data &&
+          cwdInWorkspace(cwd, data.workspace || "");
+        const better =
+          tier.path === null ||
+          (cwdMatch && !tier.cwdMatch) ||
+          (cwdMatch === tier.cwdMatch && stat.mtimeMs > tier.mtime);
+        if (better) {
           tier.mtime = stat.mtimeMs;
           tier.path = fullPath;
           tier.data = data;
+          tier.cwdMatch = cwdMatch;
         }
       } catch {
         // skip unreadable files

--- a/src/__tests__/bridgeLockDiscovery.test.ts
+++ b/src/__tests__/bridgeLockDiscovery.test.ts
@@ -194,3 +194,72 @@ describe("findBridgeLock() — first-of-many (back-compat)", () => {
     expect(first).toBeNull();
   });
 });
+
+describe("findBridgeLock() — workspace-aware selection (multi-bridge)", () => {
+  it("prefers the bridge whose workspace contains the caller's cwd", () => {
+    writeLock(3101, {
+      pid: 1001,
+      authToken: "tok-a",
+      workspace: "/ws/a",
+      isBridge: true,
+    });
+    writeLock(3102, {
+      pid: 1002,
+      authToken: "tok-b",
+      workspace: "/ws/b",
+      isBridge: true,
+    });
+    const pick = findBridgeLock({
+      lockDir: dir,
+      isLive: () => true,
+      cwd: "/ws/b",
+    });
+    expect(pick?.port).toBe(3102);
+    expect(pick?.authToken).toBe("tok-b");
+  });
+
+  it("matches a cwd nested under the workspace root (not just an exact match)", () => {
+    writeLock(3101, { pid: 1001, workspace: "/ws/a", isBridge: true });
+    writeLock(3102, { pid: 1002, workspace: "/ws/b", isBridge: true });
+    const pick = findBridgeLock({
+      lockDir: dir,
+      isLive: () => true,
+      cwd: "/ws/b/packages/api/src",
+    });
+    expect(pick?.port).toBe(3102);
+  });
+
+  it("does NOT match a sibling whose path merely shares a prefix string", () => {
+    // "/ws/b-other" must not be considered a parent of "/ws/b".
+    writeLock(3101, { pid: 1001, workspace: "/ws/b-other", isBridge: true });
+    writeLock(3102, { pid: 1002, workspace: "/ws/b", isBridge: true });
+    const pick = findBridgeLock({
+      lockDir: dir,
+      isLive: () => true,
+      cwd: "/ws/b/src",
+    });
+    expect(pick?.port).toBe(3102);
+  });
+
+  it("falls back to a live bridge when no workspace contains the cwd", () => {
+    writeLock(3101, { pid: 1001, workspace: "/ws/a", isBridge: true });
+    writeLock(3102, { pid: 1002, workspace: "/ws/b", isBridge: true });
+    const pick = findBridgeLock({
+      lockDir: dir,
+      isLive: () => true,
+      cwd: "/somewhere/else",
+    });
+    // No match → first live bridge (order is FS-dependent; just assert one).
+    expect([3101, 3102]).toContain(pick?.port);
+  });
+
+  it("ignores the cwd preference when only one bridge is live (byte-identical)", () => {
+    writeLock(3101, { pid: 1001, workspace: "/ws/a", isBridge: true });
+    const pick = findBridgeLock({
+      lockDir: dir,
+      isLive: () => true,
+      cwd: "/totally/unrelated",
+    });
+    expect(pick?.port).toBe(3101);
+  });
+});

--- a/src/bridgeLockDiscovery.ts
+++ b/src/bridgeLockDiscovery.ts
@@ -21,6 +21,21 @@ export interface LockDiscoveryDeps {
   lockDir?: string;
   /** Returns true if the PID is live; production default = `process.kill(pid, 0)`. */
   isLive?: (pid: number) => boolean;
+  /**
+   * Caller's working directory, used to disambiguate when MORE THAN ONE live
+   * bridge is present: `findBridgeLock` prefers the bridge whose `workspace`
+   * contains this path. Defaults to `process.cwd()`. (A bare `claude-ide-bridge
+   * shim` with no `--workspace` would otherwise pick whichever isBridge lock
+   * `readdir` happens to return first — non-deterministic across filesystems.)
+   */
+  cwd?: string;
+}
+
+/** True when `cwd` is the workspace root or a descendant of it. */
+function cwdInWorkspace(cwd: string, workspace: string): boolean {
+  if (!workspace) return false;
+  const rel = path.relative(workspace, cwd);
+  return rel === "" || (!rel.startsWith("..") && !path.isAbsolute(rel));
 }
 
 function defaultIsLive(pid: number): boolean {
@@ -43,14 +58,24 @@ function defaultLockDir(): string {
 }
 
 /**
- * Scan ~/.claude/ide/*.lock and return the first running patchwork bridge
+ * Scan ~/.claude/ide/*.lock and return one running patchwork bridge
  * (isBridge:true + live PID). Port is parsed from the lockfile name.
+ *
+ * With a single live bridge this is byte-identical to "the only one". With
+ * MULTIPLE live bridges (a multi-workspace deployment, or a stale-but-live
+ * sibling), it prefers the bridge whose `workspace` contains the caller's cwd
+ * — so a no-`--workspace` shim deterministically attaches to the bridge for the
+ * project it is actually running in, instead of whatever `readdir` returned
+ * first. Falls back to the first when no workspace matches.
  */
 export function findBridgeLock(
   deps: LockDiscoveryDeps = {},
 ): BridgeLockInfo | null {
   const all = findAllLiveBridges(deps);
-  return all[0] ?? null;
+  if (all.length <= 1) return all[0] ?? null;
+  const cwd = deps.cwd ?? process.cwd();
+  const match = all.find((b) => cwdInWorkspace(cwd, b.workspace));
+  return match ?? all[0] ?? null;
 }
 
 /**


### PR DESCRIPTION
## Problem

`findBridgeLock()` returned `findAllLiveBridges()[0]` — the **first isBridge lock in readdir order**. With more than one live bridge (multi-workspace deployment, or a stale-but-live sibling), the choice is non-deterministic, so a bare `claude-ide-bridge shim` (no `--workspace`) can attach to the *wrong* bridge — or churn as `connecting…` in `/mcp`. This is the recurring "stale connection / can't reconnect" footgun (CLAUDE.md already warns about the global shim entry; this hardens the discovery it relies on).

## Fix

When **2+ bridges are live**, prefer the one whose `workspace` contains the caller's cwd (root or any descendant), falling back to the first when none match. `path.relative`-based containment so a prefix sibling (`/ws/b-other` vs `/ws/b`) isn't mismatched.

**Single-bridge behaviour is byte-identical** — `all.length <= 1` returns early, so the cwd preference only engages when the selection was already ambiguous. Zero risk to the common case.

```ts
export function findBridgeLock(deps = {}): BridgeLockInfo | null {
  const all = findAllLiveBridges(deps);
  if (all.length <= 1) return all[0] ?? null;          // unchanged path
  const cwd = deps.cwd ?? process.cwd();
  return all.find((b) => cwdInWorkspace(cwd, b.workspace)) ?? all[0] ?? null;
}
```

## Tests

cwd in workspace root / nested subdir → that bridge; prefix-sibling not mismatched; no-match → first live bridge; single bridge ignores cwd (back-compat). Build + strict tests-core typecheck + shim ping/reconnect suites green.

Note: complements a local SessionStart hook that strips the stray global `claude-ide-bridge` entry `init` re-adds — this PR makes that entry *correct* when present; the hook removes the redundant duplicate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)