### PR TITLE
fix(init): pin --workspace on the global claude-ide-bridge MCP shim entry

### DIFF
--- a/src/__tests__/init.test.ts
+++ b/src/__tests__/init.test.ts
@@ -222,10 +222,20 @@ describe("init --workspace", () => {
     expect(fs.existsSync(wrongClaudeJson)).toBe(false);
 
     const parsed = JSON.parse(fs.readFileSync(expectedClaudeJson, "utf-8")) as {
-      mcpServers?: Record<string, unknown>;
+      mcpServers?: Record<string, { args?: string[] }>;
     };
     expect(parsed.mcpServers).toBeDefined();
     expect(parsed.mcpServers?.["claude-ide-bridge"]).toBeDefined();
+    // Regression: this entry must pin --workspace so the stdio shim's
+    // workspace-aware lock discovery picks THIS project's bridge lock when
+    // multiple bridges are running, instead of falling back to cwd-based
+    // guessing (the root cause of the recurring /mcp stall — see
+    // docs/audit-bridge-changelog-2026-06-25.md).
+    expect(parsed.mcpServers?.["claude-ide-bridge"]?.args).toEqual([
+      "shim",
+      "--workspace",
+      ws,
+    ]);
   });
 
   it("persists CLAUDE_CODE_IDE_SKIP_VALID_CHECK in settings.json env so `claude --ide` needs no prefix", () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -3874,9 +3874,19 @@ Steps performed:
       // claude -p spawns the stdio command via Node's child_process, which
       // can't resolve a bare `.cmd` shim on Windows. Record the `.cmd` form
       // on win32 so the bridge binary is findable by the spawned process.
+      //
+      // This global entry stays even though the project also gets a
+      // `patchwork` MCP server (project .mcp.json / project config) covering
+      // this same workspace — VS Code/Windsurf/Cursor launches inject
+      // --mcp-config, which overrides any project .mcp.json entirely, so
+      // this ~/.claude.json entry is the ONLY way bridge tools are wired
+      // under an IDE launch. Pin --workspace so that when multiple bridges
+      // are running (this one plus others elsewhere), the workspace-aware
+      // lock discovery in mcp-stdio-shim.cjs picks THIS project's lock
+      // instead of falling back to cwd-based guessing or the wrong bridge.
       mcpServers["claude-ide-bridge"] = {
         command: ensureCmdShim("claude-ide-bridge"),
-        args: ["shim"],
+        args: ["shim", "--workspace", workspace],
         type: "stdio",
       };
       claudeJson.mcpServers = mcpServers;
@@ -3892,7 +3902,7 @@ Steps performed:
     }
   } catch {
     process.stderr.write(
-      `  [warn] Could not update ${claudeJsonAbs} — add manually:\n         { "mcpServers": { "claude-ide-bridge": { "command": "claude-ide-bridge", "args": ["shim"] } } }\n\n`,
+      `  [warn] Could not update ${claudeJsonAbs} — add manually:\n         { "mcpServers": { "claude-ide-bridge": { "command": "claude-ide-bridge", "args": ["shim", "--workspace", "${workspace}"] } } }\n\n`,
     );
   }
 


### PR DESCRIPTION
## Summary
- Root cause of the recurring `/mcp` "stale connection / can't reconnect" stall: `init` writes the global `~/.claude.json` `claude-ide-bridge` shim entry with `args: ["shim"]` — no `--workspace` filter — so `mcp-stdio-shim.cjs` falls back to cwd-based lock guessing whenever more than one bridge is running, and can pick the wrong bridge's lock.
- The entry can't just be deleted: VS Code/Windsurf/Cursor launches inject `--mcp-config`, which overrides any project `.mcp.json` entirely, so this global entry is the *only* way bridge tools get wired under an IDE launch (see the comment this PR adds at the write site).
- Fix: pin `--workspace <path>` on the shim args at write time, reusing the workspace-aware lock discovery already shipped in #1052 (`findLockFile` in `scripts/mcp-stdio-shim.cjs`). The shim now resolves directly to this project's bridge lock instead of guessing by cwd.
- The `~/.claude/hooks/strip-stray-bridge-shim.py` SessionStart hook that band-aided this is now optional (not removed by this PR — leaving cleanup of that hook to a follow-up / the user, since it's outside `src/`).

## Test plan
- [x] `npx biome check --write` on changed files
- [x] `npm run build`
- [x] `npm run typecheck`
- [x] `npm test -- src/__tests__/init.test.ts` — 17 passed, including new assertion that the written entry's `args` is `["shim", "--workspace", <ws>]`
- [x] `npm test -- src/__tests__/bridgeLockDiscovery.test.ts src/__tests__/shim-ping.test.ts src/__tests__/shim-reconnect.test.ts src/__tests__/shim-pending-overflow.test.ts src/__tests__/shim-backoff.test.ts` — 35 passed