### PR TITLE
fix(cli): patchwork status — workspace-aware, isBridge-filtered lock discovery

### DIFF
--- a/src/__tests__/index-cli-status-workspace-aware.test.ts
+++ b/src/__tests__/index-cli-status-workspace-aware.test.ts
@@ -1,0 +1,129 @@
+/**
+ * `patchwork status` (no --port) lock-selection regression.
+ *
+ * Bug: the no-`--port` path picked the *newest-mtime* `.lock` file in the
+ * whole `~/.claude/ide` directory with no `isBridge` filter and no
+ * `PATCHWORK_BRIDGE_PORT` check — a completely separate, unfixed copy of the
+ * same "wrong lock picked" bug that #1052/#1054 fixed for the MCP shim
+ * (`findBridgeLock` / `mcp-stdio-shim.cjs`). A non-bridge IDE lock (e.g. a
+ * different editor's `isBridge`-less lock, or another tool's lock) with a
+ * newer mtime would be reported as the bridge's status — or worse, an
+ * unrelated *older* bridge on another port would silently win over the one
+ * `PATCHWORK_BRIDGE_PORT` actually points at.
+ *
+ * Fix: reuse `findBridgeLockForTask` (already used by the task-runner CLI
+ * path) — isBridge-filtered, live-PID-filtered, PATCHWORK_BRIDGE_PORT-aware,
+ * workspace-aware when multiple live bridges exist.
+ */
+
+import { spawnSync } from "node:child_process";
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  utimesSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+const repoRoot = fileURLToPath(new URL("../..", import.meta.url));
+const indexTs = join(repoRoot, "src", "index.ts");
+
+let configDir: string;
+let lockDir: string;
+
+beforeEach(() => {
+  configDir = mkdtempSync(join(tmpdir(), "status-workspace-aware-"));
+  lockDir = join(configDir, "ide");
+  mkdirSync(lockDir, { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(configDir, { recursive: true, force: true });
+});
+
+function runStatus(env: Record<string, string> = {}) {
+  const res = spawnSync(
+    process.execPath,
+    ["--import", "tsx", indexTs, "status", "--json"],
+    {
+      cwd: repoRoot,
+      encoding: "utf-8",
+      timeout: 60_000,
+      env: { ...process.env, CLAUDE_CONFIG_DIR: configDir, ...env },
+    },
+  );
+  return {
+    code: res.status ?? -1,
+    stdout: res.stdout,
+    stderr: res.stderr,
+  };
+}
+
+describe("patchwork status — workspace-aware lock selection (no --port)", () => {
+  it("skips a newer non-bridge (isBridge: false/missing) lock and picks the real bridge", () => {
+    // Older lock: the REAL bridge. isBridge:true, live pid (this test's own
+    // process — genuinely alive for the duration of the test).
+    writeFileSync(
+      join(lockDir, "3101.lock"),
+      JSON.stringify({
+        pid: process.pid,
+        authToken: "real-bridge-token",
+        workspace: repoRoot,
+        isBridge: true,
+        ideName: "TestBridge",
+      }),
+    );
+    // Ensure a distinct, newer mtime on the second file.
+    const now = Date.now();
+    utimesSync(join(lockDir, "3101.lock"), now / 1000 - 10, now / 1000 - 10);
+
+    // Newer lock: an unrelated editor's IDE-owned lock (no isBridge flag) —
+    // must NOT be reported as the bridge.
+    writeFileSync(
+      join(lockDir, "9999.lock"),
+      JSON.stringify({
+        pid: process.pid,
+        workspaceFolders: ["/some/other/project"],
+        ideName: "SomeOtherEditor",
+      }),
+    );
+
+    const { stdout } = runStatus();
+    const parsed = JSON.parse(stdout.trim());
+    // Must report port 3101 (the real bridge), never 9999 (the IDE lock).
+    expect(parsed.port).toBe("3101");
+  });
+
+  it("respects PATCHWORK_BRIDGE_PORT over the newest-mtime lock", () => {
+    // Two live bridges. The newer one (8888) is NOT the one PATCHWORK_BRIDGE_PORT
+    // points at — status must still pick 3101.
+    writeFileSync(
+      join(lockDir, "3101.lock"),
+      JSON.stringify({
+        pid: process.pid,
+        authToken: "bridge-a-token",
+        workspace: repoRoot,
+        isBridge: true,
+        ideName: "BridgeA",
+      }),
+    );
+    writeFileSync(
+      join(lockDir, "8888.lock"),
+      JSON.stringify({
+        pid: process.pid,
+        authToken: "bridge-b-token",
+        workspace: "/some/other/workspace",
+        isBridge: true,
+        ideName: "BridgeB",
+      }),
+    );
+
+    const { stdout } = runStatus({ PATCHWORK_BRIDGE_PORT: "3101" });
+    const parsed = JSON.parse(stdout.trim());
+    expect(parsed.port).toBe("3101");
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -4393,7 +4393,9 @@ Options:
   }
 
   const portIdx = argv.indexOf("--port");
-  const portArg = portIdx !== -1 ? argv[portIdx + 1] : undefined;
+  // --port wins over PATCHWORK_BRIDGE_PORT wins over workspace-aware discovery.
+  const portArg =
+    portIdx !== -1 ? argv[portIdx + 1] : process.env.PATCHWORK_BRIDGE_PORT;
   const jsonFlag = argv.includes("--json");
 
   const lockDir = path.join(
@@ -4428,20 +4430,17 @@ Options:
       process.exit(1);
     }
   } else {
-    let bestMtime = 0;
-    try {
-      for (const f of readdirSync(lockDir)) {
-        if (!f.endsWith(".lock")) continue;
-        const full = path.join(lockDir, f);
-        const mtime = statSync(full).mtimeMs;
-        if (mtime > bestMtime) {
-          bestMtime = mtime;
-          lockFile = full;
-          lockPort = f.replace(".lock", "");
-        }
-      }
-    } catch {
-      // lock dir doesn't exist
+    // Workspace-aware, isBridge-filtered, live-PID-filtered discovery — the
+    // same helper the MCP shim and task runner use (#1052/#1054 fixed the
+    // shim's copy of this bug; this was a separate, unfixed copy that instead
+    // picked the newest-mtime `.lock` file in the directory with no isBridge
+    // check, so an unrelated editor's IDE-owned lock — or a stale bridge from
+    // a different workspace — could shadow the real bridge's status).
+    const { findBridgeLock } = await import("./bridgeLockDiscovery.js");
+    const found = findBridgeLock({ lockDir });
+    if (found) {
+      lockFile = path.join(lockDir, `${found.port}.lock`);
+      lockPort = String(found.port);
     }
   }
 


### PR DESCRIPTION
## Summary
- Root cause: `patchwork status` (no `--port`) picked the newest-mtime `.lock` file in `~/.claude/ide/` with no `isBridge` filter and no `PATCHWORK_BRIDGE_PORT` check — a separate, unfixed copy of the same wrong-lock-picked bug class that #1052/#1054 fixed for the MCP shim (`findBridgeLock` / `mcp-stdio-shim.cjs`).
- Impact: `status` is the first command an operator runs to check bridge health. It could report an unrelated editor's IDE-owned lock (no `isBridge` flag) or a stale bridge from a different workspace as "the" status, or ignore `PATCHWORK_BRIDGE_PORT` entirely — a false negative/false report on the one command whose whole job is telling you whether the bridge is healthy. Flagged directly in this session's dogfooding.
- Fix: reuse `findBridgeLock()` (`bridgeLockDiscovery.ts`) for the no-`--port` path — isBridge-filtered, live-PID-filtered, workspace-aware when multiple bridges are live. `PATCHWORK_BRIDGE_PORT` now takes precedence over discovery, matching the documented env-var precedence every other CLI subcommand already follows.
- The explicit `--port <n>` path (with its path-traversal validation, cli-commands-1) is untouched.

## Test plan
- [x] Bug Fix Protocol — wrote failing tests first (`expected '9999' to be '3101'`, `expected '8888' to be '3101'`), confirmed they fail against the current code, then fixed.
- [x] `npx biome check --write` on changed files
- [x] `npm run build`
- [x] `npm run typecheck`
- [x] `npm test` — full suite, 8759 passed (was 8757 before this branch's 2 new tests)
- [x] `node scripts/audit-test-fixtures.mjs` — clean
- [x] Existing `index-cli-status-port.test.ts` regression suite (path-traversal, port 0, out-of-range, missing-lock message) still passes unchanged — confirms the explicit `--port` path wasn't touched