### PR TITLE
docs: add in-flight work ledger for parallel-session coordination

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -445,6 +445,8 @@ Path globs on rule files mean Claude only loads them when working on matching fi
 
 Bridge tool substitution rules in `.claude/rules/bridge-tools.md` (loaded above). Quick reference table below is summary.
 
+Before starting non-trivial work (a new branch, anything touching shared subsystems), check [docs/in-flight.md](docs/in-flight.md) for work another session may already have in progress, and add an entry before you start.
+
 ### Quick reference
 
 > Tools marked **[full]** are NOT available when the bridge was started with `--slim`. Full mode is the default (since v2.43.0); slim mode opts out to expose only IDE-exclusive tools (LSP, debugger, editor state). Call `getToolCapabilities` to confirm available tools.

--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -1,0 +1,36 @@
+# In-flight work ledger
+
+Lightweight coordination doc for when more than one Claude Code session is
+working in this repo at the same time (parallel chats, Cowork worktrees,
+scheduled routines). Not enforced by tooling — a convention, not a gate.
+
+## Why this exists
+
+On 2026-06-30/07-01, two sessions independently built the exact same fix
+(`github.search_issues` registration + `state`/`stateReason` plumbing for
+the outcome-ingester) without knowing about each other. One session's
+commit landed on the *other* session's active branch
+(`fix/shim-workspace-aware-lock-discovery`), which had to be rescued by
+branching the commit off and leaving that branch untouched rather than
+force-moving it back — avoidable with five minutes of a shared ledger.
+
+## Convention
+
+Before starting non-trivial work (a new branch, a fix touching shared
+subsystems like the worker-trust gate, the recipe runner, or the bridge
+init/shim path), add a line here. Remove the line once the PR merges (or
+mark it merged and delete on the next sweep).
+
+Format: `- <date> <branch-or-PR> — <one-line scope> — <session/chat identity if known>`
+
+## Active
+
+*(empty — add entries here as work starts)*
+
+## Recently closed (informal log, prune periodically)
+
+- 2026-07-01 `fix/outcome-ingester-search-issues` (#1053) — github.search_issues + state plumbing — merged
+- 2026-07-01 `fix/bridge-mcp-init-stray-shim` (#1054) — pin --workspace on global MCP shim init — merged
+- 2026-07-01 `fix/outcome-ingester-deterministic-classify` (#1055) — remove LLM judge from outcome classification — merged
+- 2026-07-01 `fix/status-cli-workspace-aware-lock` (#1056) — patchwork status workspace-aware lock discovery — in review
+- 2026-06-30/07-01 `dogfood/outcome-ingester-search-issues` — duplicate of #1053, discovered and deleted after confirming byte-identical content — the incident that prompted this doc


### PR DESCRIPTION
## Summary
- Mitigation for a real coordination gap this session: two sessions independently built the identical outcome-ingester fix, and one session's commit landed on the other's active branch (`fix/shim-workspace-aware-lock-discovery`), requiring a rescue (branch off the commit, leave the shared branch untouched) rather than a force-move.
- Adds `docs/in-flight.md` — a lightweight, unenforced convention (not tooling) for flagging non-trivial in-progress work so parallel sessions can check before duplicating or colliding.

## Test plan
- Docs-only change, no code paths touched.