### PR TITLE
fix(workers): withhold unknown-disposition filings from trust replay

### DIFF
--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -25,7 +25,7 @@ Format: `- <date> <branch-or-PR> — <one-line scope> — <session/chat identity
 
 ## Active
 
-*(empty — add entries here as work starts)*
+- 2026-07-01 `fix/shadow-observer-unknown-not-durable` — trust-by-neglect fix: unknown disposition withheld (not good:true) in WorkerShadowObserver.ingestRun
 
 ## Recently closed (informal log, prune periodically)
 

--- a/src/workers/__tests__/shadowObserver.test.ts
+++ b/src/workers/__tests__/shadowObserver.test.ts
@@ -269,21 +269,27 @@ describe("WorkerShadowObserver — outcome verification (junk → good:false)", 
     expect(issueRow(junk)!.mean).toBeLessThan(issueRow(confirmed)!.mean);
   });
 
-  it("confirmed and unknown dispositions both keep the good:true path (identical dial)", () => {
-    const confirmed = new WorkerShadowObserver([issuer], {
-      cfg: CFG,
-      now,
-      outcomeStore: fakeStore({ [URL]: "confirmed" }),
-    });
-    confirmed.ingestRun(durableFiling(URL));
-    // unknown = no record for the URL → getDisposition null → weak not-reverted path
+  it("WITHHOLDS a durable filing with unknown disposition (not evidence — trust-by-neglect fix)", () => {
+    // unknown = no record for the URL → getDisposition null → nobody has acted
+    // on it within the durability window. This must NOT count as good:true —
+    // that would let an unactioned filing earn trust just by sitting unopened.
     const unknown = new WorkerShadowObserver([issuer], {
       cfg: CFG,
       now,
       outcomeStore: fakeStore({}),
     });
     unknown.ingestRun(durableFiling(URL));
-    expect(issueRow(unknown)!.mean).toBe(issueRow(confirmed)!.mean);
+    expect(issueRow(unknown)).toBeUndefined();
+  });
+
+  it("still counts a durable CONFIRMED filing as good:true", () => {
+    const confirmed = new WorkerShadowObserver([issuer], {
+      cfg: CFG,
+      now,
+      outcomeStore: fakeStore({ [URL]: "confirmed" }),
+    });
+    confirmed.ingestRun(durableFiling(URL));
+    expect(issueRow(confirmed)?.observations).toBe(1);
   });
 
   it("ignores the outcome store before the durability window (still pending)", () => {

--- a/src/workers/outcomeStore.ts
+++ b/src/workers/outcomeStore.ts
@@ -12,9 +12,10 @@ import path from "node:path";
  *               or otherwise dismissed. Strong negative: the worker filed noise.
  *               Flipped to good:false in trust-replay — junk must lower trust,
  *               not be neutral (surviving 24h unopened ≠ correctness).
- *   unknown   — issue still open past the window, or no signal yet. The
- *               current weak "not-reverted" rung (good:true, status quo). A
- *               null return from getDisposition is treated identically.
+ *   unknown   — issue still open past the window, or no signal yet. WITHHELD —
+ *               not folded as evidence at all (an unactioned filing must not
+ *               earn trust just by sitting unopened; trust-by-neglect fix,
+ *               #1064). A null return from getDisposition is treated identically.
  */
 export type OutcomeDisposition = "confirmed" | "junk" | "unknown";
 
@@ -76,7 +77,9 @@ export class OutcomeStore {
 
   /**
    * Disposition for `issueUrl`, or null when no record exists.
-   * Null is treated by trust-replay as "unknown" (current weak-durable path).
+   * Null is treated by trust-replay as "unknown" — WITHHELD (not folded as
+   * evidence). A filing with no recorded disposition can neither raise nor
+   * lower trust. (#1064)
    */
   getDisposition(issueUrl: string): OutcomeDisposition | null {
     return this.cache.get(issueUrl) ?? null;

--- a/src/workers/shadowObserver.ts
+++ b/src/workers/shadowObserver.ts
@@ -214,8 +214,10 @@ export class WorkerShadowObserver {
           continue; // pending — survives the window before it earns trust
         // Past the window: check outcome store for non-reversible steps.
         // Junk issues (closed-as-not-planned / labelled invalid/duplicate) mean
-        // the worker filed noise → flip to good:false. confirmed/unknown fall
-        // through to the good:true path below (current weak-durable behaviour).
+        // the worker filed noise → flip to good:false. confirmed is a positive
+        // human/external act → good:true. unknown (nobody has acted on it within
+        // the window) is WITHHELD — not evidence — so an unactioned filing can't
+        // earn trust just by sitting unopened (trust-by-neglect fix).
         if (ac.reversibility !== "reversible" && this.outcomeStore) {
           const url =
             step.output && typeof step.output.url === "string"
@@ -231,6 +233,7 @@ export class WorkerShadowObserver {
               );
               continue;
             }
+            if (disposition === "unknown" || disposition === null) continue; // withheld — not evidence
           }
         }
       }


### PR DESCRIPTION
## Summary
- `WorkerShadowObserver.ingestRun` folded both `confirmed` and `unknown` outcome dispositions to `good:true` for durable non-reversible filings — an issue nobody acted on within the 24h durability window earned trust identically to one a human confirmed (trust-by-neglect).
- Only `confirmed` now counts as evidence of `good:true`. `unknown` is withheld entirely (no evidence, same as a not-yet-durable pending success). `junk` is unchanged (`good:false`).

## Bug Fix Protocol
1. Added a failing test (`WITHHOLDS a durable filing with unknown disposition...`) proving the old fold counted unknown as good:true.
2. Fixed the fold in `src/workers/shadowObserver.ts` (~L219–236) to `continue` (withhold) on `unknown`/`null` disposition.
3. Replaced the test that codified the old behavior (`confirmed and unknown ... identical dial`) with two tests: one proving unknown is withheld, one proving confirmed still counts.

## Test plan
- [x] `npx vitest run src/workers/__tests__/shadowObserver.test.ts` — 18/18 pass
- [x] `npx vitest run src/workers/` — 139/139 pass
- [x] `npm run typecheck` && `npm run typecheck:tests:core` — clean
- [x] `npm run build` — clean
- [x] `npm test` — 8778 passed | 4 skipped
- [x] `node scripts/audit-lsp-tools.mjs` / `audit-test-fixtures.mjs` / `audit-schema-changes.mjs` — all pass, no breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)