### PR TITLE
fix(workers): cap test-guardian-worker's autonomyCeiling below compensable auto-allow

### DIFF
--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -25,7 +25,7 @@ Format: `- <date> <branch-or-PR> — <one-line scope> — <session/chat identity
 
 ## Active
 
-*(empty — add entries here as work starts)*
+- 2026-07-01 `fix/test-guardian-ceiling-cap` — cap test-guardian-worker's autonomyCeiling below the compensable auto-allow threshold pending real-world trust-signal validation
 
 ## Recently closed (informal log, prune periodically)
 

--- a/docs/runbooks/worker-autonomy-dogfood.md
+++ b/docs/runbooks/worker-autonomy-dogfood.md
@@ -2,8 +2,10 @@
 
 **Audience:** the operator (you) running the first *real* delegation.
 **Goal:** earn the first genuine trust evidence on the dial by letting the
-Test Guardian worker file real triage issues — gated by the ramp until it
-earns L4 on the `issue` action-class.
+Test Guardian worker file real triage issues — gated by the ramp on every
+filing (the shipped manifest caps `autonomyCeiling` at 1, below the compensable
+auto-allow rung, so filing stays gated even after the `issue` class earns L4;
+see switch 1).
 
 This is the **weeks-long "does trust accrue?" run**, not the smoke. The smoke
 (`src/recipes/__tests__/workerAutonomySmoke.test.ts`) already proves the machine
@@ -126,7 +128,9 @@ signal exists.
 > worker at the autofile recipe (switch 2) while the flag is off would file a
 > real issue on **every** failing test run with **no approval**. Enable the flag
 > first so the very first filing is gated. (Expect more approval prompts up
-> front; autonomous filing is the payoff *after* L4 is earned.)
+> front; the shipped ceiling=1 keeps filing gated even at earned L4 —
+> autonomous filing is unlocked only by manually raising the ceiling once the
+> outcome-verification signal is validated.)
 
 ### 2. Point the worker at the autofile recipe
 
@@ -223,8 +227,11 @@ each gated filing; `/runs` shows each fired run and its step verdicts.
   from real evidence, not an input you grant. The competence prior
   (`mean: 0.8, strength: 4` in the manifest) accelerates the honest path to
   ~days, not weeks, without faking evidence.
-- When `issue` reaches L4, the gate stops prompting and filings flow
-  autonomously — the first responsibility genuinely delegated.
+- When `issue` reaches L4, the *earned* level is maxed — but the shipped
+  manifest caps `autonomyCeiling` at 1, so the gate keeps prompting on every
+  filing. Autonomous filing (the first responsibility genuinely delegated)
+  requires manually raising the ceiling to ≥2 once the outcome-verification
+  signal has a real-world track record.
 
 ### Rollback
 

--- a/docs/runbooks/worker-autonomy-dogfood.md
+++ b/docs/runbooks/worker-autonomy-dogfood.md
@@ -113,8 +113,13 @@ echo '{ "worker.autonomy": true }' > ~/.patchwork/config/flags.json
 ```
 
 This is the switch that **adds the gate**. With it ON, the
-`github.create_issue` step is routed to the human-approval queue every time
-*until* the worker has earned (ceiling-capped) L4 on the `issue` class.
+`github.create_issue` step is routed to the human-approval queue every time.
+The shipped `test-guardian.worker.yaml` caps `autonomyCeiling` at `1` — below
+the compensable auto-allow threshold (L2) — so filing stays gated for human
+approval even after the worker earns L4 on the `issue` class, until the
+outcome-verification signal (confirmed/junk labelling) has a real-world
+recall/false-negative track record. Raise the ceiling manually once that
+signal exists.
 
 > ⚠️ **Why first.** The flag does NOT enable filing — switches 2+3 do. With the
 > flag OFF, an automated `on_test_run` run is **not gated**, so pointing the

--- a/src/workers/__tests__/runWorkerShadow.test.ts
+++ b/src/workers/__tests__/runWorkerShadow.test.ts
@@ -264,11 +264,15 @@ describe("loadWorkerTrustForRecipe (live-gate entry)", () => {
   });
 
   it("a risky class can graduate to earned L4 via ascending replay (M2)", () => {
-    // test-guardian owns `issue` (compensable, ceiling 4); githubCreateIssue is
-    // an issue-domain step. Seed many dwell-separated clean runs. With the
-    // ascending-order fix the dwell/hysteresis logic promotes the class to L4,
-    // so the live gate ALLOWS it. (Pre-fix the replay was newest-first → dwell
-    // never held → the class would gate forever.)
+    // test-guardian owns `issue` (compensable); githubCreateIssue is an
+    // issue-domain step. Seed many dwell-separated clean runs. With the
+    // ascending-order fix the dwell/hysteresis logic promotes the EARNED level
+    // to L4 regardless of the gate's verdict. (Pre-fix the replay was
+    // newest-first → dwell never held → the class would never earn L4.)
+    // The worker's autonomyCeiling is capped at 1 (below the compensable
+    // auto-allow threshold of L2) until the outcome-verification signal has a
+    // real-world track record — so despite earning L4, the live gate still
+    // gates the action rather than auto-allowing it.
     const log = new RecipeRunLog({ dir });
     const SEVEN_HOURS = 7 * 3600 * 1000; // > the 6h default dwell window
     for (let i = 0; i < 18; i++) {
@@ -301,6 +305,8 @@ describe("loadWorkerTrustForRecipe (live-gate entry)", () => {
     );
     expect(d.owned).toBe(true);
     expect(d.earnedLevel).toBe(4);
-    expect(d.action).toBe("allow");
+    // Ceiling (1) < compensable threshold (2) → capped despite earned L4.
+    expect(d.effectiveLevel).toBe(1);
+    expect(d.action).toBe("gate");
   });
 });

--- a/templates/workers/test-guardian.worker.yaml
+++ b/templates/workers/test-guardian.worker.yaml
@@ -12,7 +12,13 @@ owns:
   - ci # runTests (re-runnable) — reversible
   - vcs-read # getGitDiff / gitBlame to find the suspect commit
   - issue # githubCreateIssue / addLinearComment — compensable + brand-exposed
-autonomyCeiling: 4
+# Capped below the compensable auto-allow threshold (L2): the ramp has only
+# been validated on synthetic data (one planted break, 16 gate decisions) and
+# the outcome-verification signal (confirmed/junk labelling, see outcomeStore.ts)
+# has no real-world recall/false-negative track record yet. Earned trust on
+# `issue` can climb, but auto-filing stays gated for human approval until that
+# signal exists. Raise once a real-world graduation is observed and confirmed.
+autonomyCeiling: 1
 competence:
   mean: 0.8
   strength: 4


### PR DESCRIPTION
## Summary
- The worker-trust ramp has only been validated on synthetic data (one planted break, 16 gate decisions) and the outcome-verification signal (confirmed/junk labelling from #1064-class work) has no real-world recall/false-negative track record yet.
- Caps `test-guardian-worker`'s `autonomyCeiling` from `4` → `1` in `templates/workers/test-guardian.worker.yaml` — below the compensable auto-allow threshold (L2, per `workerGate.ts`'s `COMPENSABLE_AUTONOMY_LEVEL`) — so `github.create_issue` filing stays gated for human approval even after the worker earns L4 on the `issue` class.
- The earned trust level is unaffected — the worker can still climb to L4 on the dial; only the live gate's effective (ceiling-clamped) level changes.

## Why this and not a code change
`autonomyCeiling` is already a per-worker scalar clamped into `effectiveLevel = min(earned, ceiling, contextCeiling)` (`src/workers/workerGate.ts:117-119`, `src/workers/shadowGate.ts:66-67`) — no new mechanism needed, just a more conservative default until the outcome-verification signal proves itself on real traffic.

## Changes
- `templates/workers/test-guardian.worker.yaml` — `autonomyCeiling: 4` → `1`, with a comment explaining why and what would justify raising it.
- `src/workers/__tests__/runWorkerShadow.test.ts` — updated the M2 ascending-replay test: earned level still reaches L4, but `action` is now `"gate"` (not `"allow"`) and asserts `effectiveLevel === 1`.
- `docs/runbooks/worker-autonomy-dogfood.md` — corrected the stale claim that earning L4 auto-allows filing; now documents the ceiling cap and what raises it.

## Test plan
- [x] `npx vitest run src/workers/` — 138/138 pass (the conflicting test now asserts the capped behavior)
- [x] `npm run typecheck` && `npm run typecheck:tests:core` — clean
- [x] `npm run build` — clean
- [x] `npm test` — 8777 passed | 4 skipped
- [x] `node scripts/audit-lsp-tools.mjs` / `audit-test-fixtures.mjs` / `audit-schema-changes.mjs` — all pass, no breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)