### PR TITLE
fix(workers): cap dependency-upkeep autonomyCeiling 3→1 (close PR trust-by-neglect leak)

### DIFF
--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -25,10 +25,11 @@ Format: `- <date> <branch-or-PR> — <one-line scope> — <session/chat identity
 
 ## Active
 
-- 2026-07-02 `feat/outcomes-confirm-cli` — `patchwork outcomes confirm|reject|list` verb (operator confirm-label loop) + outcome-ingester label-comment fix; touches src/index.ts, src/workers/outcomesCli.ts, templates/recipes/outcome-ingester.yaml, docs/runbooks/worker-autonomy-dogfood.md (append-only), CLAUDE.md
+- 2026-07-02 `fix/dependency-upkeep-ceiling-cap` — cap dependency-upkeep-worker's autonomyCeiling 3→1 (neutralise the PR-path trust-by-neglect leak: vcs-remote had no outcome grader) pending a PR-outcome grader
 
 ## Recently closed (informal log, prune periodically)
 
+- 2026-07-02 `feat/outcomes-confirm-cli` (#1066) — `patchwork outcomes confirm|reject|list` verb (operator confirm-label loop) + outcome-ingester label-comment fix — merged
 - 2026-07-02 `fix/test-guardian-ceiling-cap` (#1065) — cap test-guardian-worker's autonomyCeiling below the compensable auto-allow threshold pending real-world trust-signal validation — merged
 - 2026-07-02 `fix/shadow-observer-unknown-not-durable` (#1064) — trust-by-neglect fix: unknown disposition withheld (not good:true) in WorkerShadowObserver.ingestRun — merged
 

--- a/src/workers/__tests__/runWorkerShadow.test.ts
+++ b/src/workers/__tests__/runWorkerShadow.test.ts
@@ -309,4 +309,47 @@ describe("loadWorkerTrustForRecipe (live-gate entry)", () => {
     expect(d.effectiveLevel).toBe(1);
     expect(d.action).toBe("gate");
   });
+
+  it("dependency-upkeep's PR-opening stays gated at earned L4 (ceiling cap neutralises the PR trust-by-neglect leak)", () => {
+    // dependency-upkeep owns `vcs-remote` (githubCreatePR, compensable). Its
+    // ceiling is capped at 1 because there is no PR-outcome grader yet, so a bump
+    // PR nobody reviews would otherwise fold good:true and graduate the class to
+    // auto-open PRs (the trust-by-neglect leak, on the PR path). Seed enough
+    // dwell-separated clean PR opens to earn L4, then prove the gate STILL gates.
+    const log = new RecipeRunLog({ dir });
+    const SEVEN_HOURS = 7 * 3600 * 1000; // > the 6h default dwell window
+    for (let i = 0; i < 18; i++) {
+      log.appendDirect({
+        taskId: `dep${i}`,
+        recipeName: "dependency-bump",
+        trigger: "recipe",
+        status: "done",
+        createdAt: i * SEVEN_HOURS,
+        doneAt: i * SEVEN_HOURS,
+        durationMs: 1,
+        stepResults: Array.from({ length: 5 }, (_, k) => ({
+          id: `d${i}-${k}`,
+          tool: "githubCreatePR",
+          status: "ok" as const,
+          durationMs: 1,
+        })),
+      });
+    }
+    const trust = loadWorkerTrustForRecipe("dependency-bump", {
+      workersDir: WORKERS_DIR,
+      patchworkDir: dir,
+    });
+    expect(trust).not.toBeNull();
+    const d = decideWorkerAction(
+      trust!.worker,
+      "githubCreatePR",
+      {},
+      trust!.store,
+    );
+    expect(d.owned).toBe(true);
+    expect(d.earnedLevel).toBe(4);
+    // Ceiling (1) < compensable threshold (2) → capped despite earned L4.
+    expect(d.effectiveLevel).toBe(1);
+    expect(d.action).toBe("gate");
+  });
 });

--- a/templates/workers/dependency-upkeep.worker.yaml
+++ b/templates/workers/dependency-upkeep.worker.yaml
@@ -1,6 +1,6 @@
 # Dependency-upkeep worker — top-right beachhead. The classic low-blast,
 # continuous, verifiable job to land first (the wedge): watch for outdated /
-# vulnerable deps and open a bump PR. A human still merges → ceiling held at L3.
+# vulnerable deps and open a bump PR.
 id: dependency-upkeep-worker
 name: Dependency Upkeep Worker
 sector: engineering
@@ -12,7 +12,15 @@ owns:
   - deps-read # auditDependencies / getSecurityAdvisories — read-only
   - vcs-local # gitCommit / gitCheckout on a branch — reversible
   - vcs-remote # githubCreatePR — compensable + brand-exposed
-autonomyCeiling: 3 # opening PRs autonomously is fine; merging stays human (policy)
+# Opening a PR (vcs-remote) is compensable — but there is NO outcome grader for
+# PRs yet (OutcomeStore is issue-URL-keyed only), so a bump PR nobody reviews
+# would fold good:true past the 24h durability window: the same trust-by-neglect
+# the issue-class fix (#1064) closed, surviving on the PR path. Cap below the
+# compensable auto-allow rung (L2) so PR-opening stays human-approved regardless
+# of earned level — mirroring test-guardian's `issue` cap. Raise to 3 (open PRs
+# autonomously, merging still human) once a PR-outcome grader exists (merged/
+# closed-state detection feeding the OutcomeStore).
+autonomyCeiling: 1
 competence:
   mean: 0.8
   strength: 4


### PR DESCRIPTION
## Summary
The review of #1064/#1065 found the trust-by-neglect leak is only *fully* closed for `github.create_issue`. Digging into the shipped worker configs, the one **live, un-neutralised** instance is **`dependency-upkeep`**:

- It owns `vcs-remote` (`githubCreatePR`, compensable) at ceiling **3**, so once it earned L2 it would **auto-open PRs**.
- Nothing captures a PR's URL and there is no PR-outcome grader (`OutcomeStore` is issue-URL-keyed only), so PR-opens ride the **status-only** path: a bump PR nobody reviews folds `good:true` past the 24h durability window — the same leak #1064 closed for issues, surviving on the PR path.
- `test-guardian` is already capped at 1; `release-notes` is all-reversible. `dependency-upkeep` was the gap.

## Change
- `templates/workers/dependency-upkeep.worker.yaml`: `autonomyCeiling` **3 → 1** (below the compensable auto-allow rung L2), mirroring test-guardian's `issue` cap, with an honest comment explaining the missing PR-outcome grader and the raise criteria.
- Rewrote the stale "opening PRs autonomously is fine" framing — that always meant *earned* autonomy, which is currently earned dishonestly.
- Regression test in `runWorkerShadow.test.ts`: seed 18 dwell-separated `githubCreatePR` successes → the class still reaches earned **L4**, but the gate returns `effectiveLevel: 1` / `action: "gate"` (mirrors the M2 test for test-guardian).

## Not in scope (deferred)
The proper long-term fix is a **PR-outcome grader** (merged/closed-state detection feeding the OutcomeStore) so `vcs-remote` can earn on a real signal, then raise the ceiling back to 3. Holding that until the github-issue confirm loop (#1066) is validated on real dogfood data — building a second grader before the first is proven is premature.

## Test plan
- [x] New regression test + `shadowRun.test.ts` manifest-parse test — pass
- [x] `npm run typecheck` && `npm run typecheck:tests:core` — clean
- [x] `npm run build` — clean
- [x] `npm test` — 8791 passed | 4 skipped
- [x] `audit-lsp-tools` / `audit-test-fixtures` / `audit-schema-changes` — all pass, 0 breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)