### PR TITLE
fix(workers): backtest OutcomeStore parity via shared foldOutcome helper

### DIFF
--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -25,10 +25,11 @@ Format: `- <date> <branch-or-PR> — <one-line scope> — <session/chat identity
 
 ## Active
 
-- 2026-07-02 `feat/outcomes-confirm-cli` — `patchwork outcomes confirm|reject|list` verb (operator confirm-label loop) + outcome-ingester label-comment fix; touches src/index.ts, src/workers/outcomesCli.ts, templates/recipes/outcome-ingester.yaml, docs/runbooks/worker-autonomy-dogfood.md (append-only), CLAUDE.md
+- 2026-07-02 `feat/backtest-outcome-parity` — thread OutcomeStore into backtestWorker via a shared foldOutcome helper so `patchwork workers backtest` labels outcomes exactly like `workers shadow` (junk→bad, unknown→withheld); refactors ingestRun onto the same helper
 
 ## Recently closed (informal log, prune periodically)
 
+- 2026-07-02 `feat/outcomes-confirm-cli` (#1066) — `patchwork outcomes confirm|reject|list` verb (operator confirm-label loop) + outcome-ingester label-comment fix — merged
 - 2026-07-02 `fix/test-guardian-ceiling-cap` (#1065) — cap test-guardian-worker's autonomyCeiling below the compensable auto-allow threshold pending real-world trust-signal validation — merged
 - 2026-07-02 `fix/shadow-observer-unknown-not-durable` (#1064) — trust-by-neglect fix: unknown disposition withheld (not good:true) in WorkerShadowObserver.ingestRun — merged
 

--- a/src/workers/__tests__/backtest.test.ts
+++ b/src/workers/__tests__/backtest.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { backtestWorker, formatBacktestReport } from "../backtest.js";
+import type { OutcomeDisposition, OutcomeStore } from "../outcomeStore.js";
 import type { RunRecord } from "../shadowObserver.js";
 import { parseWorker } from "../worker.js";
 
@@ -22,6 +23,18 @@ function issueRun(at: number, status: "ok" | "error", nSteps = 5): RunRecord {
     })),
   };
 }
+
+// A single filing carrying a captured issue URL (as github.create_issue does).
+function issueRunUrl(at: number, url: string): RunRecord {
+  return {
+    recipeName: "file-issues",
+    at,
+    steps: [{ tool: "githubCreateIssue", status: "ok", output: { url } }],
+  };
+}
+// Minimal OutcomeStore stand-in — backtest only calls getDisposition.
+const fakeStore = (m: Record<string, OutcomeDisposition>) =>
+  ({ getDisposition: (u: string) => m[u] ?? null }) as unknown as OutcomeStore;
 
 describe("backtestWorker", () => {
   it("counts early successes the ramp would have GATED as false-gate", () => {
@@ -107,5 +120,52 @@ describe("backtestWorker", () => {
     expect(r.considered).toBe(0);
     expect(r.agreementRate).toBe(0);
     expect(formatBacktestReport(r)).toContain("nothing to calibrate");
+  });
+
+  describe("outcome-store parity (matches the live dial labelling)", () => {
+    const URL = "https://github.com/o/r/issues/99";
+    // 18 dwell-separated url-less clean filings → the worker earns L4 on `issue`,
+    // so by the 19th filing the ramp would BYPASS.
+    const earned = Array.from({ length: 18 }, (_, i) =>
+      issueRun(i * SEVEN_HOURS, "ok"),
+    );
+
+    it("a durable JUNK filing scores as a BAD outcome (false-allow), not a spurious good", () => {
+      const history = [...earned, issueRunUrl(18 * SEVEN_HOURS, URL)];
+      const withStore = backtestWorker(issuer, history, {
+        outcomeStore: fakeStore({ [URL]: "junk" }),
+      });
+      const statusOnly = backtestWorker(issuer, history); // no store → old behaviour
+      // The junk filing is the differentiator: with the store it is a BAD outcome
+      // the earned ramp would auto-run → an extra false-allow the status-only
+      // backtest misses entirely.
+      expect(withStore.falseAllow).toBe(statusOnly.falseAllow + 1);
+      expect(
+        withStore.divergences.some(
+          (d) => d.kind === "false-allow" && d.outcome === "bad",
+        ),
+      ).toBe(true);
+    });
+
+    it("a durable UNKNOWN filing is WITHHELD — excluded from the divergence sample", () => {
+      const history = [...earned, issueRunUrl(18 * SEVEN_HOURS, URL)];
+      const withUnknown = backtestWorker(issuer, history, {
+        outcomeStore: fakeStore({ [URL]: "unknown" }),
+      });
+      const statusOnly = backtestWorker(issuer, history); // scores the filing as good
+      // The unknown filing has no ground truth → not scored (one fewer considered)
+      // rather than counted as a spurious "good".
+      expect(withUnknown.considered).toBe(statusOnly.considered - 1);
+    });
+
+    it("a durable CONFIRMED filing scores as good — same as the status-only path", () => {
+      const history = [...earned, issueRunUrl(18 * SEVEN_HOURS, URL)];
+      const withConfirmed = backtestWorker(issuer, history, {
+        outcomeStore: fakeStore({ [URL]: "confirmed" }),
+      });
+      const statusOnly = backtestWorker(issuer, history);
+      expect(withConfirmed.considered).toBe(statusOnly.considered);
+      expect(withConfirmed.falseAllow).toBe(statusOnly.falseAllow);
+    });
   });
 });

--- a/src/workers/backtest.ts
+++ b/src/workers/backtest.ts
@@ -4,10 +4,11 @@ import {
   DEFAULT_GRADUATION_CONFIG,
   type GraduationConfig,
 } from "./graduation.js";
+import type { OutcomeStore } from "./outcomeStore.js";
 import { recommend } from "./shadowGate.js";
 import {
   DEFAULT_DURABILITY_WINDOW_MS,
-  isDurableSuccess,
+  foldOutcome,
   type RunRecord,
 } from "./shadowObserver.js";
 import { ownsAction, priorFor, type WorkerManifest } from "./worker.js";
@@ -67,6 +68,12 @@ export interface BacktestOpts {
    *  whole history is treated as durable (a backtest looks at settled outcomes). */
   now?: number;
   durabilityWindowMs?: number;
+  /** When present, non-reversible durable successes are outcome-verified exactly
+   *  as the live dial does (junk → bad, unknown/null → withheld) via the shared
+   *  foldOutcome. Without it the backtest falls back to status-only labelling —
+   *  which diverges from `workers shadow` whenever dispositions exist, so the
+   *  live entry (runWorkerBacktest) always passes one. */
+  outcomeStore?: OutcomeStore;
 }
 
 /**
@@ -107,10 +114,25 @@ export function backtestWorker(
         continue;
 
       const ac = classifyActionClass(step.tool);
-      // Score only risky OWNED actions — the calibration-relevant ones.
-      if (ac.reversibility !== "reversible" && ownsAction(worker, ac)) {
+      // Durable-outcome fold — the SAME labelling the live dial/gate uses (shared
+      // foldOutcome): junk → bad, unknown/null → withheld, pending → withheld.
+      const decision = foldOutcome(step, run.at, {
+        now,
+        windowMs,
+        outcomeStore: opts.outcomeStore,
+      });
+
+      // Score only risky OWNED actions with a KNOWN durable outcome. A withheld
+      // step (pending, or unknown disposition) has no ground truth to calibrate
+      // against, so it is excluded from the divergence sample rather than counted
+      // as a spurious "good" (which is exactly the status-only bug this fixes).
+      if (
+        ac.reversibility !== "reversible" &&
+        ownsAction(worker, ac) &&
+        decision.fold
+      ) {
         const rec = recommend(worker, step.tool, undefined, store); // as-of decision
-        const outcomeGood = step.status === "ok";
+        const outcomeGood = decision.good;
         const rampBypass = rec.decision === "bypass";
         considered++;
         if (rampBypass === outcomeGood) {
@@ -133,18 +155,14 @@ export function backtestWorker(
         }
       }
 
-      // Fold the outcome (durable-outcome aware) so the ramp evolves over the
-      // replay — same labelling as the live dial/gate.
-      if (
-        step.status === "ok" &&
-        !isDurableSuccess(ac.reversibility, run.at, now, windowMs)
-      )
-        continue; // recent non-reversible success — not yet durable
-      store.apply(
-        worker.id,
-        { toolName: step.tool, good: step.status === "ok", at: run.at },
-        { prior, cfg },
-      );
+      // Fold so the ramp evolves over the replay (skips withheld steps).
+      if (decision.fold) {
+        store.apply(
+          worker.id,
+          { toolName: step.tool, good: decision.good, at: run.at },
+          { prior, cfg },
+        );
+      }
     }
   }
 

--- a/src/workers/runWorkerShadow.ts
+++ b/src/workers/runWorkerShadow.ts
@@ -256,10 +256,11 @@ export function runWorkerBacktest(opts: RunWorkerShadowOpts = {}): string {
     "  false-gate  = ramp would gate a GOOD action (over-caution, the cost)",
     "",
   ];
+  const outcomeStore = new OutcomeStore(patchworkDir);
   for (const w of workers) {
     if (!w.recipe) continue;
     const runs = readRuns(patchworkDir, [w.recipe]);
-    lines.push(formatBacktestReport(backtestWorker(w, runs)));
+    lines.push(formatBacktestReport(backtestWorker(w, runs, { outcomeStore })));
   }
   return lines.join("\n");
 }

--- a/src/workers/shadowObserver.ts
+++ b/src/workers/shadowObserver.ts
@@ -121,6 +121,54 @@ export function isDurableSuccess(
   return runAt <= now - windowMs;
 }
 
+/** A single step reduced to what the outcome fold needs. */
+type FoldStep = Pick<RunRecord["steps"][number], "tool" | "status" | "output">;
+
+/**
+ * The durable-outcome fold decision for one step — the SINGLE source of truth
+ * shared by the live/shadow dial (`WorkerShadowObserver.ingestRun`) and the
+ * cold-start backtest (`backtestWorker`), so the two can never drift on how an
+ * outcome is labelled. Returns either "withhold" (not evidence — a pending or
+ * unknown-disposition risky success) or "count as good/bad".
+ *
+ * Assumes the caller has already skipped no-tool / skipped / approval-rejected
+ * steps (those are non-evidence for reasons the caller owns). Semantics:
+ *   - failure (status ≠ ok)                → count, good:false (durable evidence of failure)
+ *   - success, no `now`                    → count, good:true (back-compat status-only)
+ *   - success, non-reversible, pre-window  → WITHHOLD (provisional; not yet durable)
+ *   - success, non-reversible, junk         → count, good:false (filed noise)
+ *   - success, non-reversible, unknown/null → WITHHOLD (unactioned ≠ correct; trust-by-neglect fix)
+ *   - success, otherwise (reversible / confirmed / no url / no store) → count, good:true
+ */
+export type FoldDecision = { fold: false } | { fold: true; good: boolean };
+
+export function foldOutcome(
+  step: FoldStep,
+  runAt: number,
+  opts: { now?: number; windowMs: number; outcomeStore?: OutcomeStore },
+): FoldDecision {
+  if (!step.tool) return { fold: false };
+  if (step.status !== "ok") return { fold: true, good: false };
+  // Success. Without a wall-clock, keep the prior status-only fold (back-compat).
+  if (opts.now === undefined) return { fold: true, good: true };
+  const ac = classifyActionClass(step.tool);
+  if (!isDurableSuccess(ac.reversibility, runAt, opts.now, opts.windowMs))
+    return { fold: false }; // pending — survives the window before it earns trust
+  if (ac.reversibility !== "reversible" && opts.outcomeStore) {
+    const url =
+      step.output && typeof step.output.url === "string"
+        ? step.output.url
+        : null;
+    if (url) {
+      const disposition = opts.outcomeStore.getDisposition(url);
+      if (disposition === "junk") return { fold: true, good: false };
+      if (disposition === "unknown" || disposition === null)
+        return { fold: false }; // withheld — not evidence
+    }
+  }
+  return { fold: true, good: true };
+}
+
 export class WorkerShadowObserver {
   private readonly store: WorkerLevelStore;
   private readonly cfg: GraduationConfig;
@@ -196,50 +244,20 @@ export class WorkerShadowObserver {
         categoriseHaltReason(step.haltReason) === "approval_rejected"
       )
         continue;
-      // Durable-outcome label: a recent SUCCESS on a non-reversible action is
-      // provisional (a filed issue / pushed commit / merged PR can be reverted
-      // or closed-as-junk minutes later), so it is NOT yet counted as evidence.
-      // Only active when `now` was supplied by the I/O entry; otherwise the prior
-      // status-only fold is used. Withholds evidence only → never widens.
-      if (this.now !== undefined && step.status === "ok") {
-        const ac = classifyActionClass(step.tool);
-        if (
-          !isDurableSuccess(
-            ac.reversibility,
-            run.at,
-            this.now,
-            this.durabilityWindowMs,
-          )
-        )
-          continue; // pending — survives the window before it earns trust
-        // Past the window: check outcome store for non-reversible steps.
-        // Junk issues (closed-as-not-planned / labelled invalid/duplicate) mean
-        // the worker filed noise → flip to good:false. confirmed is a positive
-        // human/external act → good:true. unknown (nobody has acted on it within
-        // the window) is WITHHELD — not evidence — so an unactioned filing can't
-        // earn trust just by sitting unopened (trust-by-neglect fix).
-        if (ac.reversibility !== "reversible" && this.outcomeStore) {
-          const url =
-            step.output && typeof step.output.url === "string"
-              ? step.output.url
-              : null;
-          if (url) {
-            const disposition = this.outcomeStore.getDisposition(url);
-            if (disposition === "junk") {
-              this.store.apply(
-                worker.id,
-                { toolName: step.tool, good: false, at: run.at },
-                { prior, cfg: this.cfg },
-              );
-              continue;
-            }
-            if (disposition === "unknown" || disposition === null) continue; // withheld — not evidence
-          }
-        }
-      }
+      // Durable-outcome fold (shared with the backtest via foldOutcome): a recent
+      // SUCCESS on a non-reversible action is provisional, and past the window a
+      // junk filing flips good:false while an unknown/unactioned one is WITHHELD
+      // (trust-by-neglect fix). Only active when `now` was supplied; otherwise the
+      // prior status-only fold is used. Withholds evidence only → never widens.
+      const decision = foldOutcome(step, run.at, {
+        now: this.now,
+        windowMs: this.durabilityWindowMs,
+        outcomeStore: this.outcomeStore,
+      });
+      if (!decision.fold) continue;
       this.store.apply(
         worker.id,
-        { toolName: step.tool, good: step.status === "ok", at: run.at },
+        { toolName: step.tool, good: decision.good, at: run.at },
         { prior, cfg: this.cfg },
       );
     }


### PR DESCRIPTION
## Summary
Confirmed review finding #2: `backtestWorker` scored and folded outcomes **status-only** — it never consulted the `OutcomeStore`. So `patchwork workers backtest` diverged from `patchwork workers shadow` whenever dispositions existed: a durable **junk** or **unknown** filing counted as a spurious `good`, inflating `agreementRate` and hiding false-allows. Its inline "same labelling as the live dial/gate" comment was false after #1064.

## Fix
- Extract the durable-outcome fold into a single **exported `foldOutcome()`** in `shadowObserver.ts` (junk → bad, unknown/null → withheld, pending → withheld, else good).
- Route **both** `WorkerShadowObserver.ingestRun` (live/shadow dial) and `backtestWorker` (cold-start calibration) through it — one source of truth, so they can't drift again.
- Thread an optional `OutcomeStore` through `BacktestOpts`; the live entry `runWorkerBacktest` always passes `new OutcomeStore(patchworkDir)`.
- A **withheld** step (pending / unknown disposition) has no ground truth, so it's now **excluded from the divergence sample** rather than scored as a false "good".

## Safety
`ingestRun`'s behaviour is byte-identical — it's a pure refactor onto the shared helper, and the existing `shadowObserver.test.ts` suite (unchanged) validates every branch (failure, back-compat no-`now`, pending, junk, unknown-withheld, confirmed). No live-gate behaviour change; this only corrects a diagnostic tool's fidelity.

## Test plan
- [x] `shadowObserver.test.ts` (18) unchanged and green — proves the ingestRun refactor is behaviour-preserving
- [x] New backtest parity tests: durable junk → +1 false-allow vs status-only; unknown → one fewer `considered` (withheld); confirmed → identical to status-only
- [x] `src/workers/` — 154 tests pass
- [x] `npm run typecheck` && `npm run typecheck:tests:core` — clean
- [x] `npm run build` — clean
- [x] `npm test` — 8793 passed | 4 skipped
- [x] `audit-lsp-tools` / `audit-test-fixtures` / `audit-schema-changes` — all pass, 0 breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)