### PR TITLE
fix(recipes): unblock worker filing — trigger var defaults + agent-decision when-gate

### DIFF
--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -25,7 +25,7 @@ Format: `- <date> <branch-or-PR> — <one-line scope> — <session/chat identity
 
 ## Active
 
-*(empty — add entries here as work starts)*
+- 2026-07-02 `fix/dogfood-filing-var-defaults-and-decision-gate` — unblock worker filing: (1) RecipeOrchestrator.fire merges trigger.vars/inputs defaults on every fire path (on_test_run runs no longer drop `repo`); (2) `when` guard evaluates the last token so an agent decision's prose ending in true/false gates correctly (yamlRunner + chainedRunner parity). Extracts applyTriggerInputDefaults → src/recipes/triggerVars.ts.
 
 ## Recently closed (informal log, prune periodically)
 

--- a/src/recipeOrchestration.ts
+++ b/src/recipeOrchestration.ts
@@ -22,6 +22,7 @@ import type {
 } from "./recipes/scheduler.js";
 import { RecipeScheduler } from "./recipes/scheduler.js";
 import { hasTool } from "./recipes/toolRegistry.js";
+import { applyTriggerInputDefaults } from "./recipes/triggerVars.js";
 import {
   archiveRecipe,
   deleteRecipeContent,
@@ -1730,55 +1731,11 @@ export function collectUnknownToolIds(yaml: string): string[] {
   return out;
 }
 
-/**
- * Read a YAML recipe's trigger.inputs[] declarations and merge any declared
- * defaults underneath caller-provided vars. Caller vars always win. Tolerates
- * missing files / malformed YAML / non-array inputs by returning the original
- * vars untouched.
- */
-export function applyTriggerInputDefaults(
-  ymlPath: string,
-  vars?: Record<string, string>,
-): Record<string, string> | undefined {
-  let parsed: unknown;
-  try {
-    parsed = parseYaml(readFileSync(ymlPath, "utf-8"));
-  } catch {
-    return vars;
-  }
-  const trigger = (parsed as { trigger?: unknown } | null)?.trigger as
-    | Record<string, unknown>
-    | null
-    | undefined;
-
-  // Collect defaults from both trigger.inputs and trigger.vars (array forms).
-  // trigger.vars holds recipe-declared defaults; trigger.inputs holds
-  // user-overrideable parameters. Both use {name, default} entries.
-  const defaults: Record<string, string> = {};
-  for (const key of ["inputs", "vars"] as const) {
-    const arr = trigger?.[key];
-    if (arr !== undefined && !Array.isArray(arr) && typeof arr === "object") {
-      // Map format (vars: {NAME: value}) is not supported — values silently
-      // never reach the recipe context. Warn so authors catch the mistake early.
-      console.warn(
-        `[recipe] trigger.${key} must be an array of {name, default} objects, ` +
-          `got a plain object in ${ymlPath}. Vars will not be substituted.`,
-      );
-    }
-    if (!Array.isArray(arr)) continue;
-    for (const item of arr) {
-      if (!item || typeof item !== "object") continue;
-      const name = (item as { name?: unknown }).name;
-      const dflt = (item as { default?: unknown }).default;
-      if (typeof name !== "string" || name.length === 0) continue;
-      if (dflt === undefined || dflt === null) continue;
-      if (!(name in defaults)) defaults[name] = String(dflt);
-    }
-  }
-
-  if (Object.keys(defaults).length === 0) return vars;
-  return { ...defaults, ...(vars ?? {}) };
-}
+// `applyTriggerInputDefaults` moved to ./recipes/triggerVars.ts (leaf module) so
+// RecipeOrchestrator.fire can apply declared defaults on EVERY fire path without a
+// circular import. Imported at the top for internal use here; re-exported below for
+// back-compat with existing import sites (e.g. commands/recipe.ts).
+export { applyTriggerInputDefaults };
 
 function checkRequiredVars(
   ymlPath: string,

--- a/src/recipes/RecipeOrchestrator.ts
+++ b/src/recipes/RecipeOrchestrator.ts
@@ -6,6 +6,7 @@
 
 import type { Logger } from "../logger.js";
 import type { ChainedRunResult } from "./chainedRunner.js";
+import { applyTriggerInputDefaults } from "./triggerVars.js";
 import {
   loadYamlRecipe as defaultLoadYamlRecipe,
   dispatchRecipe,
@@ -113,6 +114,16 @@ export class RecipeOrchestrator {
       };
     }
 
+    // Merge the recipe's declared `trigger.vars` / `trigger.inputs` defaults
+    // underneath the caller-supplied seedContext (caller/event values always
+    // win). This is the ONE chokepoint every fire path shares (HTTP webhook,
+    // CLI, scheduler, automation hooks), so a declared default like
+    // `repo: owner/repo` now reaches an on_test_run-triggered run instead of
+    // being dropped — the seedContext previously carried only event placeholders
+    // ({{runner}}, {{failed}}, …), so github.create_issue hard-errored on empty
+    // repo. Fail-soft: a missing/malformed file returns seedContext unchanged.
+    const mergedContext = applyTriggerInputDefaults(filePath, seedContext);
+
     const taskId = `${name}-${Date.now()}`;
     this.inFlight.add(name);
 
@@ -132,7 +143,7 @@ export class RecipeOrchestrator {
       this.inFlightTimers.set(name, timer);
     }
 
-    dispatch(recipe, this.deps, seedContext)
+    dispatch(recipe, this.deps, mergedContext)
       .finally(() => {
         this.clearInFlight(name);
       })

--- a/src/recipes/__tests__/RecipeOrchestrator.fire.test.ts
+++ b/src/recipes/__tests__/RecipeOrchestrator.fire.test.ts
@@ -3,7 +3,10 @@
  * All tests expected to fail (TypeError or similar) until fire() is implemented.
  */
 
-import { describe, expect, it, vi } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { RecipeOrchestrator } from "../RecipeOrchestrator.js";
 import type { RunResult, YamlRecipe } from "../yamlRunner.js";
 
@@ -371,6 +374,105 @@ describe("RecipeOrchestrator.fire()", () => {
     expect(orchestrator.listInFlight()).toEqual(["beta"]);
 
     d2.resolve(makeRunResult());
+  });
+
+  describe("merges declared trigger.vars/inputs defaults into seedContext (Bug 1)", () => {
+    let dir: string;
+    beforeEach(() => {
+      dir = mkdtempSync(path.join(os.tmpdir(), "fire-vardefaults-"));
+    });
+    afterEach(() => {
+      rmSync(dir, { recursive: true, force: true });
+    });
+
+    it("fills a declared repo default the caller didn't supply, event vars still win", async () => {
+      // Mirrors the on_test_run path: the trigger seeds only event placeholders
+      // ({{runner}}, {{failed}}), never the recipe's declared `repo` default.
+      // Pre-fix, dispatch got that raw seedContext and github.create_issue
+      // hard-errored on empty repo.
+      const ymlPath = path.join(dir, "triage.yaml");
+      writeFileSync(
+        ymlPath,
+        [
+          "name: triage",
+          "trigger:",
+          "  type: on_test_run",
+          "  vars:",
+          "    - name: repo",
+          '      default: "owner/repo"',
+          "steps:",
+          "  - tool: file.write",
+          "    path: /tmp/x",
+          "    content: hi",
+        ].join("\n"),
+      );
+      const recipe = makeYamlRecipe("triage");
+      const loadYamlRecipe = vi.fn().mockReturnValue(recipe);
+      const { promise, resolve } = deferred<RunResult>();
+      const dispatchFn = vi.fn().mockReturnValue(promise);
+
+      const orchestrator = new RecipeOrchestrator(baseDeps(), {
+        loadYamlRecipe,
+        dispatchFn,
+      });
+      await orchestrator.fire({
+        filePath: ymlPath,
+        name: "triage",
+        triggerSource: "automation:on_test_run",
+        seedContext: { runner: "vitest", failed: "1" },
+      });
+      resolve(makeRunResult());
+
+      const passedContext = dispatchFn.mock.calls[0]?.[2] as Record<
+        string,
+        string
+      >;
+      // declared default filled…
+      expect(passedContext.repo).toBe("owner/repo");
+      // …and event vars preserved (caller wins on overlap).
+      expect(passedContext.runner).toBe("vitest");
+      expect(passedContext.failed).toBe("1");
+    });
+
+    it("caller value overrides a declared default (no clobber)", async () => {
+      const ymlPath = path.join(dir, "triage.yaml");
+      writeFileSync(
+        ymlPath,
+        [
+          "name: triage",
+          "trigger:",
+          "  type: on_test_run",
+          "  vars:",
+          "    - name: repo",
+          '      default: "owner/default-repo"',
+          "steps:",
+          "  - tool: file.write",
+          "    path: /tmp/x",
+          "    content: hi",
+        ].join("\n"),
+      );
+      const loadYamlRecipe = vi.fn().mockReturnValue(makeYamlRecipe("triage"));
+      const { promise, resolve } = deferred<RunResult>();
+      const dispatchFn = vi.fn().mockReturnValue(promise);
+
+      const orchestrator = new RecipeOrchestrator(baseDeps(), {
+        loadYamlRecipe,
+        dispatchFn,
+      });
+      await orchestrator.fire({
+        filePath: ymlPath,
+        name: "triage",
+        triggerSource: "test",
+        seedContext: { repo: "owner/explicit" },
+      });
+      resolve(makeRunResult());
+
+      const passedContext = dispatchFn.mock.calls[0]?.[2] as Record<
+        string,
+        string
+      >;
+      expect(passedContext.repo).toBe("owner/explicit");
+    });
   });
 
   it("frees the in-flight slot after dispatchTimeoutMs when dispatch never settles (audit 2026-06-09 orch-hang-1)", async () => {

--- a/src/recipes/__tests__/yamlRunner.test.ts
+++ b/src/recipes/__tests__/yamlRunner.test.ts
@@ -931,6 +931,103 @@ describe("runYamlRecipe — step.when guard", () => {
     expect(result.stepResults[1]!.status).toBe("ok");
   });
 
+  // Bug 2: a `when` fed an agent's free-text decision (e.g. decide_file emitting
+  // paragraphs of reasoning that END in "false") must gate on the DECISION, not
+  // on "non-empty string ⇒ truthy". The guard now evaluates the last token.
+  const VERBOSE_FALSE =
+    "1. REPRODUCE: the failing test does not exist on the current checkout.\n" +
+    "2. DEDUP: moot — non-reproduction settles it.\n\nfalse";
+  const VERBOSE_TRUE =
+    "Reproduced on an isolated re-run and no open duplicate tracks it.\n\ntrue";
+
+  it("skips the guarded step when a decision's prose ends in `false`", async () => {
+    const written: Record<string, string> = {};
+    const recipe = makeRecipe({
+      steps: [
+        {
+          tool: "file.write",
+          path: path.join(TMP, "note.md"),
+          content: "always",
+        },
+        {
+          tool: "file.write",
+          path: path.join(TMP, "filed.md"),
+          content: "filed",
+          when: "{{should_file}}",
+        },
+      ],
+    });
+    const result = await runYamlRecipe(
+      recipe,
+      {
+        ...noop(),
+        writeFile: (p, c) => {
+          written[p] = c;
+        },
+      },
+      { should_file: VERBOSE_FALSE },
+    );
+    expect(written[path.join(TMP, "filed.md")]).toBeUndefined();
+    expect(result.stepResults[1]!.status).toBe("skipped");
+  });
+
+  it("runs the guarded step when a decision's prose ends in `true`", async () => {
+    const written: Record<string, string> = {};
+    const recipe = makeRecipe({
+      steps: [
+        {
+          tool: "file.write",
+          path: path.join(TMP, "note.md"),
+          content: "always",
+        },
+        {
+          tool: "file.write",
+          path: path.join(TMP, "filed.md"),
+          content: "filed",
+          when: "{{should_file}}",
+        },
+      ],
+    });
+    const result = await runYamlRecipe(
+      recipe,
+      {
+        ...noop(),
+        writeFile: (p, c) => {
+          written[p] = c;
+        },
+      },
+      { should_file: VERBOSE_TRUE },
+    );
+    expect(written[path.join(TMP, "filed.md")]).toBe("filed");
+    expect(result.stepResults[1]!.status).toBe("ok");
+  });
+
+  it("tolerates punctuation/backticks around a trailing `false` token", async () => {
+    const written: Record<string, string> = {};
+    const recipe = makeRecipe({
+      steps: [
+        {
+          tool: "file.write",
+          path: path.join(TMP, "filed.md"),
+          content: "filed",
+          when: "{{should_file}}",
+        },
+      ],
+    });
+    const result = await runYamlRecipe(
+      recipe,
+      {
+        ...noop(),
+        writeFile: (p, c) => {
+          written[p] = c;
+        },
+      },
+      { should_file: "decision: `false`." },
+    );
+    expect(written[path.join(TMP, "filed.md")]).toBeUndefined();
+    expect(result.stepResults[0]!.status).toBe("skipped");
+  });
+
   it("skips an agent step when `when` is empty (no agent invocation)", async () => {
     let agentCalls = 0;
     const recipe = makeRecipe({

--- a/src/recipes/chainedRunner.ts
+++ b/src/recipes/chainedRunner.ts
@@ -398,14 +398,18 @@ export function resolveStepTemplates(
         errors.push(result.error);
         conditionResult = false;
       } else {
-        // Simple truthiness check (empty string, "0", "false" are falsy)
+        // Falsy if the WHOLE value is a falsy token OR its LAST token is — so a
+        // `when` fed an agent's free-text decision (prose ending in "true"/"false")
+        // gates on the verdict, not on "non-empty ⇒ truthy". Single-token guards
+        // are unchanged (last token === whole value). Kept in lockstep with
+        // yamlRunner.ts's guard (runner behavioral parity).
         const val = result.value.trim().toLowerCase();
-        conditionResult =
-          !!val &&
-          val !== "0" &&
-          val !== "false" &&
-          val !== "null" &&
-          val !== "undefined";
+        const FALSY = new Set(["", "0", "false", "null", "undefined"]);
+        const lastToken = (val.split(/\s+/).pop() ?? "").replace(
+          /[^a-z0-9]/g,
+          "",
+        );
+        conditionResult = !!val && !FALSY.has(val) && !FALSY.has(lastToken);
       }
     }
   }

--- a/src/recipes/triggerVars.ts
+++ b/src/recipes/triggerVars.ts
@@ -1,0 +1,60 @@
+import { readFileSync } from "node:fs";
+import { parse as parseYaml } from "yaml";
+
+/**
+ * Read a YAML recipe's `trigger.inputs[]` / `trigger.vars[]` declarations and
+ * merge any declared defaults underneath caller-provided vars. Caller vars
+ * always win. Tolerates missing files / malformed YAML / non-array inputs by
+ * returning the original vars untouched.
+ *
+ * Leaf module (no recipe-runner deps) so BOTH the high-level orchestration
+ * wiring (`recipeOrchestration.ts`) and the low-level `RecipeOrchestrator.fire`
+ * chokepoint can apply defaults without a circular import. `RecipeOrchestrator.fire`
+ * calls this so EVERY fire path (HTTP webhook, CLI, scheduler, automation hooks)
+ * gets declared defaults merged — previously only the manual/HTTP path did, so an
+ * `on_test_run`-triggered recipe fired with only the event placeholders and its
+ * declared `repo` default was dropped (the filing then hard-errored on empty repo).
+ */
+export function applyTriggerInputDefaults(
+  ymlPath: string,
+  vars?: Record<string, string>,
+): Record<string, string> | undefined {
+  let parsed: unknown;
+  try {
+    parsed = parseYaml(readFileSync(ymlPath, "utf-8"));
+  } catch {
+    return vars;
+  }
+  const trigger = (parsed as { trigger?: unknown } | null)?.trigger as
+    | Record<string, unknown>
+    | null
+    | undefined;
+
+  // Collect defaults from both trigger.inputs and trigger.vars (array forms).
+  // trigger.vars holds recipe-declared defaults; trigger.inputs holds
+  // user-overrideable parameters. Both use {name, default} entries.
+  const defaults: Record<string, string> = {};
+  for (const key of ["inputs", "vars"] as const) {
+    const arr = trigger?.[key];
+    if (arr !== undefined && !Array.isArray(arr) && typeof arr === "object") {
+      // Map format (vars: {NAME: value}) is not supported — values silently
+      // never reach the recipe context. Warn so authors catch the mistake early.
+      console.warn(
+        `[recipe] trigger.${key} must be an array of {name, default} objects, ` +
+          `got a plain object in ${ymlPath}. Vars will not be substituted.`,
+      );
+    }
+    if (!Array.isArray(arr)) continue;
+    for (const item of arr) {
+      if (!item || typeof item !== "object") continue;
+      const name = (item as { name?: unknown }).name;
+      const dflt = (item as { default?: unknown }).default;
+      if (typeof name !== "string" || name.length === 0) continue;
+      if (dflt === undefined || dflt === null) continue;
+      if (!(name in defaults)) defaults[name] = String(dflt);
+    }
+  }
+
+  if (Object.keys(defaults).length === 0) return vars;
+  return { ...defaults, ...(vars ?? {}) };
+}

--- a/src/recipes/yamlRunner.ts
+++ b/src/recipes/yamlRunner.ts
@@ -1727,12 +1727,22 @@ export async function runYamlRecipe(
           step.when === false
             ? "false"
             : render(step.when, ctx).trim().toLowerCase();
+        // Falsy if the WHOLE value is a falsy token OR its LAST token is. The
+        // last-token check is what makes a `when` fed an agent's free-text
+        // decision gate correctly: a step like `decide_file` emits paragraphs of
+        // reasoning that END in "true"/"false" (into: should_file), and a bare
+        // "non-empty ⇒ truthy" check treated that prose as truthy and ran the
+        // guarded step even on a "false" verdict. Single-token guards (the common
+        // case — {{phone}}, {{repo}}, "0") are unchanged: last token === whole
+        // value. Trailing punctuation/backticks/quotes are stripped so `` `false`. ``
+        // still reads false.
+        const FALSY = new Set(["", "0", "false", "null", "undefined"]);
+        const lastToken = (rendered.split(/\s+/).pop() ?? "").replace(
+          /[^a-z0-9]/g,
+          "",
+        );
         const truthy =
-          !!rendered &&
-          rendered !== "0" &&
-          rendered !== "false" &&
-          rendered !== "null" &&
-          rendered !== "undefined";
+          !!rendered && !FALSY.has(rendered) && !FALSY.has(lastToken);
         if (!truthy) {
           const skipId = step.into ?? step.agent?.into ?? `step_${stepsRun}`;
           stepResults.push({


### PR DESCRIPTION
Two bugs the **live dogfood surfaced** (a real `on_test_run` run wrote a triage note, then errored instead of filing — no issue created).

## Bug 1 — declared trigger var defaults dropped on non-manual fire paths
`RecipeOrchestrator.fire` passed the caller's `seedContext` straight to dispatch. An `on_test_run`-triggered run therefore carried **only** the event placeholders (`{{runner}}`, `{{failed}}`, …) and the recipe's declared `repo` default never applied → `github.create_issue` hard-errored:
> `github create_issue requires 'repo' in exact 'owner/repo' format`

**Fix:** `fire` now merges `trigger.vars`/`trigger.inputs` defaults underneath the seedContext (caller/event values always win) — at the one chokepoint every fire path shares (HTTP, CLI, scheduler, automation hooks). Extracted `applyTriggerInputDefaults` into a leaf module `src/recipes/triggerVars.ts` so the low-level orchestrator can use it without a circular import; `recipeOrchestration.ts` re-exports it for back-compat.

## Bug 2 — a `when` guard fed an agent's free-text decision was always truthy
`decide_file` emits paragraphs of reasoning ending in `true`/`false` (`into: should_file`), but the guard was falsy only if the **whole** rendered value equalled a falsy token. So the prose read truthy and the gated `file_issue` step ran even on a **"false"** verdict — defeating the reproducibility/dedup gate (a latent false-positive-filing bug, masked here only by Bug 1).

**Fix:** the guard now also checks the **last token** (trailing punctuation/backticks/quotes stripped). Single-token guards (`{{repo}}`, `{{phone}}`, `"0"`, `when: false`) are byte-identical. Applied to **both** `yamlRunner` and `chainedRunner` (runner behavioral parity).

## Test-first (Bug Fix Protocol)
- `RecipeOrchestrator.fire.test.ts`: declared `repo` default filled when caller omits it (event vars preserved); caller value overrides default (no clobber).
- `yamlRunner.test.ts`: decision prose ending in `false` → step **skipped**; ending in `true` → **runs**; `` `false`. `` (punctuation/backticks) tolerated. Existing single-token `when` tests unchanged.

## Verification
- [x] targeted suites (yamlRunner, chainedRunner, RecipeOrchestrator.fire, runner behavioral-parity) — 282 pass
- [x] `npm run typecheck` && `typecheck:tests:core` — clean
- [x] `npm run build` — clean
- [x] `npm test` — 8799 passed | 4 skipped
- [x] audit-lsp-tools / audit-test-fixtures / audit-schema-changes — all pass, 0 breaking changes

## Note
The live bridge runs the **global install**, so after merge it needs `npm run install:global` + a LaunchAgent restart to pick up these fixes (the recurring "merged ≠ live" step). The `decide_file` prompt already instructs "output exactly one word"; this makes the gate robust when the agent appends reasoning anyway. Recipe-prompt tightening (constrained output) is a possible defense-in-depth follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)