### PR TITLE
fix(recipes): stop unit tests polluting the operator run log (plan #1)

### DIFF
--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -25,10 +25,11 @@ Format: `- <date> <branch-or-PR> — <one-line scope> — <session/chat identity
 
 ## Active
 
-- 2026-07-02 `fix/dogfood-filing-var-defaults-and-decision-gate` — unblock worker filing: (1) RecipeOrchestrator.fire merges trigger.vars/inputs defaults on every fire path (on_test_run runs no longer drop `repo`); (2) `when` guard evaluates the last token so an agent decision's prose ending in true/false gates correctly (yamlRunner + chainedRunner parity). Extracts applyTriggerInputDefaults → src/recipes/triggerVars.ts.
+- 2026-07-02 `fix/runlog-vitest-testmode-guard` — roadmap plan slice #1 (run-log hygiene): VITEST-aware `testMode` default in `runYamlRecipe` so a bare test run never appends synthetic rows to the operator's live `~/.patchwork/runs.jsonl` (which is also the de-facto trust store, rotates at 1MB). Guard test `runLogIsolation.test.ts` (temp HOME) + explicit `testMode:false` on the 4 persistence-asserting test files. Flat runner only — chained runner already gates its appendDirect on an explicit `runLogDir`. — build session
 
 ## Recently closed (informal log, prune periodically)
 
+- 2026-07-02 `fix/dogfood-filing-var-defaults-and-decision-gate` (#1070) — unblock worker filing: (1) RecipeOrchestrator.fire merges trigger.vars/inputs defaults on every fire path (on_test_run runs no longer drop `repo`); (2) `when` guard evaluates the last token so an agent decision's prose ending in true/false gates correctly (yamlRunner + chainedRunner parity); extracts applyTriggerInputDefaults → src/recipes/triggerVars.ts — merged
 - 2026-07-02 `feat/backtest-outcome-parity` (#1068) — thread OutcomeStore into backtestWorker via a shared foldOutcome helper so `patchwork workers backtest` labels outcomes exactly like `workers shadow` (junk→bad, unknown→withheld); refactors ingestRun onto the same helper — merged
 - 2026-07-02 `fix/dependency-upkeep-ceiling-cap` (#1067) — cap dependency-upkeep-worker's autonomyCeiling 3→1 (neutralise the PR-path trust-by-neglect leak: vcs-remote had no outcome grader) pending a PR-outcome grader — merged
 - 2026-07-02 `feat/outcomes-confirm-cli` (#1066) — `patchwork outcomes confirm|reject|list` verb (operator confirm-label loop) + outcome-ingester label-comment fix — merged

--- a/src/recipes/__tests__/flatRunnerApproval.test.ts
+++ b/src/recipes/__tests__/flatRunnerApproval.test.ts
@@ -27,6 +27,11 @@ function deps(extra: Partial<RunnerDeps> = {}): RunnerDeps {
   return {
     now: () => new Date("2026-06-22T12:00:00Z"),
     logDir: TMP,
+    // Persist to the temp logDir (never homedir) — the run-registry / cancel
+    // tests need the runController registered, which is gated on `!testMode`.
+    // Under the VITEST-aware default, testMode would otherwise default ON. See
+    // runLogIsolation.test.ts.
+    testMode: false,
     readFile: () => {
       throw new Error("nf");
     },

--- a/src/recipes/__tests__/runCostPersistence.test.ts
+++ b/src/recipes/__tests__/runCostPersistence.test.ts
@@ -70,6 +70,9 @@ describe("yamlRunner — per-step token capture + persistence", () => {
     // claudeFn may return a full AgentResult; usage + servedBy flow through.
     const deps: RunnerDeps = {
       logDir: tmpDir,
+      // Persistence test: force the run-log write to the temp dir (never
+      // homedir) under the VITEST-aware testMode default. See runLogIsolation.test.ts.
+      testMode: false,
       claudeFn: async (): Promise<AgentResult> => ({
         text: "the answer",
         usage: { inputTokens: 1000, outputTokens: 200 },
@@ -144,6 +147,9 @@ describe("yamlRunner — per-step token capture + persistence", () => {
     // → per-step sum for the judge step = 300 in / 30 out.
     const deps: RunnerDeps = {
       logDir: tmpDir,
+      // Persistence test: force the run-log write to the temp dir (never
+      // homedir) under the VITEST-aware testMode default. See runLogIsolation.test.ts.
+      testMode: false,
       claudeFn: async (prompt: string): Promise<AgentResult> => {
         let text: string;
         if (prompt.includes("<revision-request>")) text = "REVISED v2";
@@ -189,6 +195,9 @@ describe("yamlRunner — per-step token capture + persistence", () => {
 
     const deps: RunnerDeps = {
       logDir: tmpDir,
+      // Persistence test: force the run-log write to the temp dir (never
+      // homedir) under the VITEST-aware testMode default. See runLogIsolation.test.ts.
+      testMode: false,
       // plain string → toAgentResult → { text } with no usage.
       claudeFn: async () => "just text, no usage",
     };
@@ -227,6 +236,9 @@ describe("yamlRunner — per-step token capture + persistence", () => {
 
     const deps: RunnerDeps = {
       logDir: tmpDir,
+      // Persistence test: force the run-log write to the temp dir (never
+      // homedir) under the VITEST-aware testMode default. See runLogIsolation.test.ts.
+      testMode: false,
       claudeFn: async (): Promise<AgentResult> => ({
         text: "text",
         usage: { inputTokens: 500, outputTokens: 50 },

--- a/src/recipes/__tests__/runLogIsolation.test.ts
+++ b/src/recipes/__tests__/runLogIsolation.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Guard: unit tests must NEVER write the operator's real
+ * `~/.patchwork/runs.jsonl`.
+ *
+ * `runYamlRecipe` persists a completed run to `deps.logDir ?? ~/.patchwork`
+ * whenever `testMode` is off. Before the VITEST-aware default, a bare
+ * `runYamlRecipe(recipe, deps)` in a test (no `testMode`, no `logDir`, no
+ * `runLog`) defaulted `testMode` to `false` and appended a synthetic row to the
+ * operator's live run log — which is also the de-facto worker-trust store and
+ * rotates at 1 MB / 10k lines, so test rows evict real trust evidence and every
+ * operator surface (halts, doctor, dashboard, push) reads noise.
+ *
+ * Per Bug Fix Protocol: the first test below FAILS on the pre-fix code (the
+ * homedir file gets created) and passes once `testMode` defaults on under
+ * vitest. The second test guards the explicit-persistence path — an explicit
+ * `deps.testMode=false` + `logDir` override must still persist, and only to the
+ * override dir, never homedir.
+ */
+
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  type RunnerDeps,
+  runYamlRecipe,
+  type YamlRecipe,
+} from "../yamlRunner.js";
+
+// A recipe that runs one agent step to completion via a mocked driver — no
+// network, no filesystem — so the only write attempted is the run-log append.
+function probeRecipe(): YamlRecipe {
+  return {
+    name: "runlog-isolation-probe",
+    trigger: { type: "manual" },
+    steps: [{ agent: { prompt: "noop", into: "out", driver: "anthropic" } }],
+  };
+}
+
+function agentDeps(overrides: Partial<RunnerDeps> = {}): RunnerDeps {
+  return {
+    claudeFn: vi.fn().mockResolvedValue("ok"),
+    claudeCodeFn: vi.fn().mockResolvedValue("ok"),
+    ...overrides,
+  };
+}
+
+describe("run-log isolation — no unit test writes ~/.patchwork/runs.jsonl", () => {
+  let fakeHome: string;
+  let prevHome: string | undefined;
+  let prevUserProfile: string | undefined;
+
+  beforeEach(() => {
+    fakeHome = mkdtempSync(path.join(os.tmpdir(), "runlog-iso-home-"));
+    prevHome = process.env.HOME;
+    prevUserProfile = process.env.USERPROFILE;
+    // os.homedir() reads $HOME on POSIX and %USERPROFILE% on Windows, so
+    // override BOTH to redirect the runner's default log dir (`~/.patchwork`)
+    // into a throwaway directory on every platform. Without the USERPROFILE
+    // override this guard is inert on the blocking windows-latest CI leg —
+    // it would pass vacuously and, on pre-fix code, still pollute the real
+    // %USERPROFILE%\.patchwork\runs.jsonl. (Same convention as
+    // workerAutonomySmoke.test.ts.)
+    process.env.HOME = fakeHome;
+    process.env.USERPROFILE = fakeHome;
+  });
+
+  afterEach(() => {
+    if (prevHome === undefined) delete process.env.HOME;
+    else process.env.HOME = prevHome;
+    if (prevUserProfile === undefined) delete process.env.USERPROFILE;
+    else process.env.USERPROFILE = prevUserProfile;
+    rmSync(fakeHome, { recursive: true, force: true });
+  });
+
+  it("a bare runYamlRecipe under vitest writes nothing to $HOME/.patchwork/runs.jsonl", async () => {
+    const runsPath = path.join(fakeHome, ".patchwork", "runs.jsonl");
+    expect(existsSync(runsPath)).toBe(false);
+
+    await runYamlRecipe(probeRecipe(), agentDeps());
+
+    // The VITEST-aware `testMode` default must suppress the homedir persistence.
+    expect(existsSync(runsPath)).toBe(false);
+  });
+
+  it("explicit deps.testMode=false + logDir override persists to the override dir, never homedir", async () => {
+    const logDir = mkdtempSync(path.join(os.tmpdir(), "runlog-iso-log-"));
+    try {
+      await runYamlRecipe(
+        probeRecipe(),
+        agentDeps({ testMode: false, logDir }),
+      );
+      const homeRuns = path.join(fakeHome, ".patchwork", "runs.jsonl");
+      const overrideRuns = path.join(logDir, "runs.jsonl");
+      expect(existsSync(homeRuns)).toBe(false);
+      expect(existsSync(overrideRuns)).toBe(true);
+    } finally {
+      rmSync(logDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/recipes/__tests__/workerAutonomySmoke.test.ts
+++ b/src/recipes/__tests__/workerAutonomySmoke.test.ts
@@ -161,6 +161,11 @@ function makeDeps(
     workdir: tmpHome,
     logDir: patchworkDir,
     runLog,
+    // Persist to the injected runLog (temp patchworkDir, never homedir) — the
+    // smoke asserts `runLog.query(...)`, which needs `!testMode`. Under the
+    // VITEST-aware default, testMode would otherwise default ON. See
+    // runLogIsolation.test.ts.
+    testMode: false,
     requireApprovalFn,
     gateAutomatedRuns: true,
     // Default: a constant non-falsy note (every agent step → file-it path). The

--- a/src/recipes/__tests__/yamlRunner.test.ts
+++ b/src/recipes/__tests__/yamlRunner.test.ts
@@ -82,6 +82,12 @@ function noop(): RunnerDeps {
   return {
     now: () => new Date("2026-04-18T08:00:00Z"),
     logDir: tmpLogDir,
+    // Persist to the temp logDir / injected runLog (never homedir) — several
+    // tests below assert on the run log. Explicit `testMode: true` on individual
+    // calls still wins (it spreads after `...noop()`). Under the VITEST-aware
+    // default in yamlRunner.ts, testMode would otherwise default ON. See
+    // runLogIsolation.test.ts.
+    testMode: false,
     readFile: () => {
       throw new Error("not found");
     },

--- a/src/recipes/yamlRunner.ts
+++ b/src/recipes/yamlRunner.ts
@@ -2788,6 +2788,19 @@ export function defaultGitStaleBranches(
   }
 }
 
+/**
+ * True when running under the vitest harness (same VITEST / NODE_ENV signal
+ * `src/recipes/migrations/index.ts` guards on). Used only to DEFAULT `testMode` on so a
+ * bare `runYamlRecipe(...)` in a unit test never appends a synthetic row to the
+ * operator's real `~/.patchwork/runs.jsonl` — which is also the de-facto
+ * worker-trust store and rotates at 1 MB / 10k lines, so test rows would evict
+ * real trust evidence and pollute every operator halt surface. An explicit
+ * `deps.testMode` (true or false) always wins over this default.
+ */
+function isVitestEnv(): boolean {
+  return process.env.VITEST != null || process.env.NODE_ENV === "test";
+}
+
 /** Resolve all RunnerDeps to concrete StepDeps with production defaults filled in. */
 function resolveStepDeps(
   deps: RunnerDeps,
@@ -2863,7 +2876,7 @@ function resolveStepDeps(
       }),
     logDir: deps.logDir,
     activityLog: deps.activityLog,
-    testMode: deps.testMode ?? false,
+    testMode: deps.testMode ?? isVitestEnv(),
     // PR5a/b: per-attempt idempotency ledger. Disk-backed when
     // `ledgerDir` + `manualRunId` + recipe name are all available so a
     // retry of the same logical attempt re-uses prior records (resume


### PR DESCRIPTION
## Roadmap plan slice #1 — run-log hygiene

**Problem.** `runYamlRecipe` defaulted `testMode` to `false` ([`yamlRunner.ts`](src/recipes/yamlRunner.ts) `resolveStepDeps`). With `testMode` off and no `deps.logDir`/`deps.runLog`, a completed run is appended to `os.homedir()/.patchwork/runs.jsonl`. So a bare `runYamlRecipe(recipe, deps)` in a unit test wrote to the **operator's real run log** — which is also the de-facto worker-trust store (`loadWorkerTrustForRecipe` replays it) and rotates at 1 MB / 10k lines, so synthetic test rows evict real trust evidence and pollute every operator surface (`patchwork halts`, `recipe doctor`, dashboard, Prometheus, push). On the live bridge ~95% of recent halts were the test recipe `r` from `runner.contract.test.ts`.

**Fix.** Default `testMode` to `isVitestEnv()` (`process.env.VITEST` / `NODE_ENV=test` — the same signal `src/recipes/migrations/index.ts` already guards on). An explicit `deps.testMode` (true **or** false) still wins via `??`, so:
- `patchwork recipe run --local` outside vitest persists **exactly as before**.
- Persistence tests keep their coverage with an explicit `testMode: false` + tmp `logDir`.

Flat runner only — the chained runner already gates its `appendDirect` on an explicit `runLogDir`/`runLog`, so it never defaulted to a homedir write.

**Bug Fix Protocol.** New `src/recipes/__tests__/runLogIsolation.test.ts`:
- **fails on pre-fix code** (bare run creates `$HOME/.patchwork/runs.jsonl`), passes after — verified by reverting the one-line default.
- guards the explicit-persistence path (`testMode:false` + `logDir` → override dir, never homedir).
- overrides **both `HOME` and `USERPROFILE`** (and restores them) so the guard is effective on the blocking `windows-latest` CI leg where `os.homedir()` reads `%USERPROFILE%` — same convention as `workerAutonomySmoke.test.ts`.

**Test fallout.** The full suite flagged exactly the 4 files whose tests assert on the persistence / `runLog` / run-controller path (all gated on `!testMode`): `yamlRunner.test.ts`, `runCostPersistence.test.ts`, `flatRunnerApproval.test.ts`, `workerAutonomySmoke.test.ts`. Each got an explicit `testMode: false` on its shared factory / inline deps — all already route writes to a tmp dir or injected `runLog`, so none touch homedir.

## Gates
- `npm test` — 8801 passed / 4 skipped, 0 failed
- `tsc --noEmit` + `tsc -p tsconfig.tests.core.json` — clean
- `npm run build` — clean
- `biome check` — clean (pre-existing warning in unrelated `yamlRunner.test.ts:4255` untouched)
- `audit-lsp-tools` / `audit-test-fixtures` / `audit-schema-changes` — pass

Adversarially reviewed (3-lens workflow + verify); the one confirmed finding (Windows `USERPROFILE`) is fixed above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)