### PR TITLE
feat(dashboard): speak-human pass over the /workers page (plain copy + promotion-readiness + details toggle)

### DIFF
--- a/dashboard/src/app/workers/__tests__/outcomesPanel.test.tsx
+++ b/dashboard/src/app/workers/__tests__/outcomesPanel.test.tsx
@@ -130,11 +130,11 @@ const PENDING = {
 
 describe("AwaitingConfirmationPanel (the confirm queue on /workers)", () => {
   it("renders pending filings + a count, suppressed when the queue is empty", async () => {
-    // Empty pending → panel absent.
+    // Empty pending, endpoint answered 200 → all-clear affirmation (not absent).
     fetchMock.mockImplementation(routeMock({ outcomes: [] }, { pending: [] }));
-    const { unmount } = render(<WorkersPage />);
-    await screen.findByText(/No workers yet/);
-    expect(screen.queryByText(/Awaiting confirmation/)).toBeNull();
+    const { container: emptyC, unmount } = render(<WorkersPage />);
+    expect(await screen.findByText(/all clear/)).toBeTruthy();
+    expect(emptyC.textContent).toContain("0 pending");
     unmount();
 
     // Non-empty pending → panel renders the URL + count.
@@ -145,6 +145,25 @@ describe("AwaitingConfirmationPanel (the confirm queue on /workers)", () => {
       "https://github.com/o/r/issues/42",
     );
     expect(container.textContent).toContain("1 pending");
+  });
+
+  it("suppresses the panel entirely on a bridge too old to serve /outcomes/pending (404)", async () => {
+    // 404 → useBridgeFetch treats it as terminal (status 404, data null); the
+    // panel must NOT render the all-clear affirmation (which would false-signal
+    // "drained" on a bridge that simply lacks the endpoint).
+    fetchMock.mockImplementation((url: string | URL) => {
+      const u = String(url);
+      if (u.includes("/approvals/kpi"))
+        return Promise.resolve(jsonResponse({ total: 0 }));
+      if (u.includes("/outcomes/pending"))
+        return Promise.resolve(jsonResponse({ error: "not found" }, 404));
+      if (u.includes("/outcomes"))
+        return Promise.resolve(jsonResponse({ outcomes: [] }));
+      return Promise.resolve(jsonResponse(EMPTY_SHADOW));
+    });
+    render(<WorkersPage />);
+    await screen.findByText(/No workers yet/);
+    expect(screen.queryByText(/Awaiting confirmation/)).toBeNull();
   });
 
   it("Confirm POSTs disposition + audit context (recipe + class) for a pending filing", async () => {

--- a/dashboard/src/app/workers/__tests__/outcomesPanel.test.tsx
+++ b/dashboard/src/app/workers/__tests__/outcomesPanel.test.tsx
@@ -36,7 +36,7 @@ const OUTCOMES = {
 
 // The page fetches /workers/shadow, /approvals/kpi, /outcomes, and
 // /outcomes/pending. Route each; distinguish the GET poll from the
-// Confirm/Reject POST by method. `/outcomes/pending` is matched BEFORE the bare
+// confirm/reject POST by method. `/outcomes/pending` is matched BEFORE the bare
 // `/outcomes` (the latter substring-matches the former).
 function routeMock(
   outcomes: unknown = OUTCOMES,
@@ -58,18 +58,19 @@ function routeMock(
 }
 
 describe("FiledOutcomesPanel (on /workers)", () => {
-  it("renders filed outcomes with a disposition pill + issue link + context", async () => {
+  it("renders reviewed outcomes with a plain verdict pill + issue link + task", async () => {
     fetchMock.mockImplementation(routeMock());
     const { container } = render(<WorkersPage />);
-    expect(await screen.findByText(/Filed outcomes/)).toBeTruthy();
+    expect(await screen.findByText(/Did the workers get it right/)).toBeTruthy();
     expect(container.textContent).toContain(ISSUE_URL);
-    expect(container.textContent).toContain("unknown");
-    expect(container.textContent).toContain("issue:compensable:high");
+    // Plain verdict for "unknown" + plain task for issue:compensable:high.
+    expect(container.textContent).toContain("not reviewed");
+    expect(container.textContent).toContain("filing issues");
   });
 
-  it("POSTs the confirm disposition + flips the pill after the refetch (closes the loop)", async () => {
+  it("Looks real POSTs the confirm verdict + flips the pill after refetch (closes the loop)", async () => {
     // Stateful mock: the POST records the disposition; later GETs reflect it, so
-    // a dropped refetch() would leave the pill stuck on "unknown" and fail this.
+    // a dropped refetch() would leave the pill stuck on "not reviewed" and fail.
     let current = "unknown";
     fetchMock.mockImplementation((url: string | URL, opts?: RequestInit) => {
       const u = String(url);
@@ -89,7 +90,7 @@ describe("FiledOutcomesPanel (on /workers)", () => {
       return Promise.resolve(jsonResponse(EMPTY_SHADOW));
     });
     render(<WorkersPage />);
-    const confirmBtn = await screen.findByRole("button", { name: "Confirm" });
+    const confirmBtn = await screen.findByRole("button", { name: "Looks real" });
     fireEvent.click(confirmBtn);
     // The POST carried the right disposition…
     await waitFor(() => {
@@ -101,17 +102,17 @@ describe("FiledOutcomesPanel (on /workers)", () => {
         JSON.parse((postCall as [string, RequestInit])[1].body as string),
       ).toEqual({ issueUrl: ISSUE_URL, disposition: "confirmed" });
     });
-    // …and refetch() flipped the pill to confirmed (the queue updated).
-    expect(await screen.findByText("confirmed")).toBeTruthy();
+    // …and refetch() flipped the pill to the plain "looks real" (the queue updated).
+    expect(await screen.findByText("looks real")).toBeTruthy();
   });
 
-  it("renders no panel when no outcomes are filed", async () => {
+  it("renders no panel when nothing has been filed", async () => {
     fetchMock.mockImplementation(routeMock({ outcomes: [] }));
     render(<WorkersPage />);
     // The page still renders (empty workers → its own empty state)…
-    expect(await screen.findByText(/No workers yet/)).toBeTruthy();
-    // …but the outcomes panel suppresses itself when the queue is empty.
-    expect(screen.queryByText(/Filed outcomes/)).toBeNull();
+    expect(await screen.findByText(/No workers set up yet/)).toBeTruthy();
+    // …but the outcomes panel suppresses itself when there is nothing to review.
+    expect(screen.queryByText(/Did the workers get it right/)).toBeNull();
   });
 });
 
@@ -128,29 +129,29 @@ const PENDING = {
   ],
 };
 
-describe("AwaitingConfirmationPanel (the confirm queue on /workers)", () => {
-  it("renders pending filings + a count, suppressed when the queue is empty", async () => {
-    // Empty pending, endpoint answered 200 → all-clear affirmation (not absent).
+describe("AwaitingConfirmationPanel (the review queue on /workers)", () => {
+  it("renders items needing review + a count, all-caught-up when empty", async () => {
+    // Empty queue, endpoint answered 200 → all-caught-up affirmation (not absent).
     fetchMock.mockImplementation(routeMock({ outcomes: [] }, { pending: [] }));
     const { container: emptyC, unmount } = render(<WorkersPage />);
-    expect(await screen.findByText(/all clear/)).toBeTruthy();
-    expect(emptyC.textContent).toContain("0 pending");
+    expect(await screen.findByText(/all caught up/)).toBeTruthy();
+    expect(emptyC.textContent).toContain("0 waiting");
     unmount();
 
-    // Non-empty pending → panel renders the URL + count.
+    // Non-empty → panel renders the URL + count.
     fetchMock.mockImplementation(routeMock({ outcomes: [] }, PENDING));
     const { container } = render(<WorkersPage />);
-    expect(await screen.findByText(/Awaiting confirmation/)).toBeTruthy();
+    expect(await screen.findByText(/Needs your review/)).toBeTruthy();
     expect(container.textContent).toContain(
       "https://github.com/o/r/issues/42",
     );
-    expect(container.textContent).toContain("1 pending");
+    expect(container.textContent).toContain("1 waiting");
   });
 
   it("suppresses the panel entirely on a bridge too old to serve /outcomes/pending (404)", async () => {
     // 404 → useBridgeFetch treats it as terminal (status 404, data null); the
-    // panel must NOT render the all-clear affirmation (which would false-signal
-    // "drained" on a bridge that simply lacks the endpoint).
+    // panel must NOT render the all-caught-up affirmation (which would
+    // false-signal "drained" on a bridge that simply lacks the endpoint).
     fetchMock.mockImplementation((url: string | URL) => {
       const u = String(url);
       if (u.includes("/approvals/kpi"))
@@ -162,14 +163,14 @@ describe("AwaitingConfirmationPanel (the confirm queue on /workers)", () => {
       return Promise.resolve(jsonResponse(EMPTY_SHADOW));
     });
     render(<WorkersPage />);
-    await screen.findByText(/No workers yet/);
-    expect(screen.queryByText(/Awaiting confirmation/)).toBeNull();
+    await screen.findByText(/No workers set up yet/);
+    expect(screen.queryByText(/Needs your review/)).toBeNull();
   });
 
-  it("Confirm POSTs disposition + audit context (recipe + class) for a pending filing", async () => {
+  it("Looks real POSTs the verdict + audit context (recipe + class) for a queued item", async () => {
     fetchMock.mockImplementation(routeMock({ outcomes: [] }, PENDING));
     render(<WorkersPage />);
-    const confirmBtn = await screen.findByRole("button", { name: "Confirm" });
+    const confirmBtn = await screen.findByRole("button", { name: "Looks real" });
     fireEvent.click(confirmBtn);
     await waitFor(() => {
       const postCall = fetchMock.mock.calls.find(

--- a/dashboard/src/app/workers/__tests__/page.test.tsx
+++ b/dashboard/src/app/workers/__tests__/page.test.tsx
@@ -190,4 +190,66 @@ describe("WorkersPage", () => {
     fireEvent.click(screen.getByRole("button", { name: "Show details" }));
     expect(container.textContent).toContain("reject rate 0%");
   });
+
+  it("shows the trust journey — stepper stops + a plain 'how it got here' timeline (climbs AND slips)", async () => {
+    const JOURNEY_SHADOW = {
+      runsScanned: 20,
+      decisionsScanned: 20,
+      workers: [
+        {
+          workerId: "test-guardian-worker",
+          name: "Test Guardian Worker",
+          autonomyCeiling: 1,
+          board: [
+            {
+              classKey: "issue:compensable:high",
+              level: 0,
+              observations: 5,
+              mean: 0.21,
+              owned: true,
+            },
+          ],
+          events: [
+            {
+              type: "promote",
+              classKey: "issue:compensable:high",
+              from: 0,
+              to: 1,
+              at: 1000,
+              evidence: 4,
+              reason: "sustained evidence",
+              workerId: "test-guardian-worker",
+            },
+            {
+              type: "demote",
+              classKey: "issue:compensable:high",
+              from: 1,
+              to: 0,
+              at: 2000,
+              evidence: 31,
+              reason: "a rejected filing",
+              workerId: "test-guardian-worker",
+            },
+          ],
+          compared: 0,
+          agreed: 0,
+          divergences: [],
+        },
+      ],
+    };
+    fetchMock.mockImplementation(routeMock(JOURNEY_SHADOW));
+    const { container } = render(<WorkersPage />);
+    expect(await screen.findByText("Test Guardian Worker")).toBeTruthy();
+    // The journey stepper renders the plain stops.
+    expect(container.textContent).toContain("Just watching");
+    expect(container.textContent).toContain("Fully trusted");
+    // The history: newest first — the slip (demote) then the climb (promote).
+    expect(container.textContent).toContain("How it got here");
+    expect(container.textContent).toMatch(
+      /Slipped back to .Just watching. on filing issues/,
+    );
+    expect(container.textContent).toMatch(
+      /Earned .Asks first. on filing issues/,
+    );
+  });
 });

--- a/dashboard/src/app/workers/__tests__/page.test.tsx
+++ b/dashboard/src/app/workers/__tests__/page.test.tsx
@@ -1,5 +1,5 @@
 /** @vitest-environment jsdom */
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import WorkersPage from "../page";
 
@@ -68,17 +68,21 @@ function routeMock(
 }
 
 describe("WorkersPage", () => {
-  it("renders the trust dial + a ramp-vs-gate divergence from the shadow endpoint", async () => {
+  it("renders the plain per-task record; ramp-vs-gate divergence lives under details", async () => {
     fetchMock.mockImplementation(routeMock(SHADOW));
     const { container } = render(<WorkersPage />);
     expect(await screen.findByText("Release Worker")).toBeTruthy();
-    // the divergence text is split across nodes (⚠ {tool} — {note}); assert on
-    // the rendered textContent rather than an exact single-node match
+    // Plain per-task record: fs-write:reversible:medium (not owned) → "changing files".
+    expect(container.textContent).toContain("changing files");
+    expect(container.textContent).toContain("not one of its jobs");
+    // The ramp-vs-gate divergence is engine-detail — hidden until "Show details".
+    expect(container.textContent).not.toContain("gitPush");
+    fireEvent.click(screen.getByRole("button", { name: "Show details" }));
     expect(container.textContent).toContain("gitPush");
     expect(container.textContent).toContain("ramp would gate; gate allowed");
   });
 
-  it("floors a not-owned class to L0 and flags it, instead of rendering it as earned trust", async () => {
+  it("floors a not-owned class and flags it in plain words, not raw levels", async () => {
     const NOT_OWNED_SHADOW = {
       runsScanned: 5,
       decisionsScanned: 5,
@@ -105,11 +109,44 @@ describe("WorkersPage", () => {
     fetchMock.mockImplementation(routeMock(NOT_OWNED_SHADOW));
     const { container } = render(<WorkersPage />);
     expect(await screen.findByText("Release Worker")).toBeTruthy();
-    // Not-owned classes must render as NOT OWNED / floored to L0, not as the
-    // raw earned level (L3) — a worker has no standing trust on classes it
-    // doesn't own, regardless of accrued evidence.
-    expect(container.textContent).toMatch(/NOT OWNED/i);
+    // Not-owned classes must read as "not one of its jobs" (floored), never as
+    // the raw earned level (L3) — a worker has no standing trust there.
+    expect(container.textContent).toMatch(/not one of its jobs/i);
     expect(container.textContent).not.toContain("L3 act+sample");
+  });
+
+  it("surfaces a 'ready for more independence?' headline when earned > ceiling", async () => {
+    const READY_SHADOW = {
+      runsScanned: 20,
+      decisionsScanned: 20,
+      workers: [
+        {
+          workerId: "test-guardian-worker",
+          name: "Test Guardian Worker",
+          autonomyCeiling: 1,
+          board: [
+            {
+              classKey: "issue:compensable:high",
+              level: 4,
+              observations: 18,
+              mean: 0.96,
+              owned: true,
+            },
+          ],
+          compared: 0,
+          agreed: 0,
+          divergences: [],
+        },
+      ],
+    };
+    fetchMock.mockImplementation(routeMock(READY_SHADOW));
+    const { container } = render(<WorkersPage />);
+    expect(
+      await screen.findByText(/Ready for more independence/),
+    ).toBeTruthy();
+    // Names the earned capability + the exact config change to make.
+    expect(container.textContent).toContain("filing issues");
+    expect(container.textContent).toContain("autonomyCeiling: 4");
   });
 
   it("shows the empty state when no workers are configured", async () => {
@@ -117,10 +154,10 @@ describe("WorkersPage", () => {
       routeMock({ workers: [], runsScanned: 0, decisionsScanned: 0 }),
     );
     render(<WorkersPage />);
-    expect(await screen.findByText(/No workers yet/)).toBeTruthy();
+    expect(await screen.findByText(/No workers set up yet/)).toBeTruthy();
   });
 
-  it("renders the considered-approval panel with the rubber-stamp warning", async () => {
+  it("shows the rubber-stamp warning in plain view; telemetry under details", async () => {
     fetchMock.mockImplementation(
       routeMock(SHADOW, {
         total: 8,
@@ -144,9 +181,13 @@ describe("WorkersPage", () => {
       }),
     );
     const { container } = render(<WorkersPage />);
-    expect(await screen.findByText(/Considered approvals/)).toBeTruthy();
+    expect(await screen.findByText(/rubber-stamping/)).toBeTruthy();
+    // Plain warning is shown by default; raw telemetry is not.
+    expect(container.textContent).toMatch(
+      /approved all 8 requests with no rejections/,
+    );
+    expect(container.textContent).not.toContain("reject rate 0%");
+    fireEvent.click(screen.getByRole("button", { name: "Show details" }));
     expect(container.textContent).toContain("reject rate 0%");
-    // 8 decided, 0 rejected → the rubber-stamp warning must fire
-    expect(container.textContent).toMatch(/rubber-stamps/);
   });
 });

--- a/dashboard/src/app/workers/page.tsx
+++ b/dashboard/src/app/workers/page.tsx
@@ -626,7 +626,7 @@ function JourneyStepper({
                   left: 0,
                   right: 0,
                   textAlign: "center",
-                  fontSize: 11,
+                  fontSize: "var(--fs-xs)",
                 }}
               >
                 ⚑ leash
@@ -649,7 +649,7 @@ function JourneyStepper({
               style={{
                 textAlign: "center",
                 marginTop: 6,
-                fontSize: 11,
+                fontSize: "var(--fs-xs)",
                 color: reached ? "inherit" : "var(--line-3)",
               }}
             >

--- a/dashboard/src/app/workers/page.tsx
+++ b/dashboard/src/app/workers/page.tsx
@@ -23,11 +23,23 @@ interface Divergence {
   at: number;
   note: string;
 }
+/** A promote/demote milestone in a worker's trust journey. */
+interface AuditEvent {
+  type: "promote" | "demote";
+  classKey: string;
+  from: number;
+  to: number;
+  at: number;
+  evidence: number;
+  reason: string;
+  workerId: string;
+}
 interface WorkerReport {
   workerId: string;
   name: string;
   autonomyCeiling: number;
   board: BoardRow[];
+  events: AuditEvent[];
   compared: number;
   agreed: number;
   divergences: Divergence[];
@@ -534,12 +546,179 @@ function levelColor(effective: number): string {
   return "var(--line-3)";
 }
 
+// ── The trust journey ───────────────────────────────────────────────────────
+// Every worker travels the same 5-stop path from "just watching" to "fully
+// trusted". Where it stands (and how it got there) is the story an owner wants.
+const JOURNEY_STOPS = [
+  "Just watching",
+  "Asks first",
+  "Acts, you undo",
+  "Acts, checked",
+  "Fully trusted",
+];
+
+const BLAST_RANK: Record<string, number> = { high: 3, medium: 2, low: 1 };
+
+/** The worker's "main job": the highest-stakes OWNED, non-reversible task — the
+ *  one the leash is really about. Falls back to any owned task. */
+function primaryJob(w: WorkerReport): BoardRow | undefined {
+  const owned = w.board.filter((b) => b.owned);
+  const risky = owned.filter((b) => !isReversible(b.classKey));
+  const pool = risky.length ? risky : owned;
+  if (pool.length === 0) return undefined;
+  return [...pool].sort(
+    (a, b) =>
+      (BLAST_RANK[b.classKey.split(":")[2] ?? ""] ?? 0) -
+        (BLAST_RANK[a.classKey.split(":")[2] ?? ""] ?? 0) || b.level - a.level,
+  )[0];
+}
+
+function relTime(at: number, now: number): string {
+  const ms = Math.max(0, now - at);
+  const h = Math.floor(ms / 3_600_000);
+  if (h < 1) return "just now";
+  if (h < 24) return `${h}h ago`;
+  const d = Math.floor(h / 24);
+  return `${d}d ago`;
+}
+
+/**
+ * The journey track — 5 stops, filled up to what the worker has EARNED on its
+ * main job, with a flag at the leash (the max you allow) and a ring on where it
+ * stands right now. One glance says how far along a worker is; stack them and a
+ * whole team is scannable.
+ */
+function JourneyStepper({
+  earned,
+  ceiling,
+}: {
+  earned: number;
+  ceiling: number;
+}) {
+  const effective = Math.min(earned, ceiling);
+  return (
+    <div style={{ display: "flex", marginTop: "var(--s-4)" }}>
+      {JOURNEY_STOPS.map((stop, i) => {
+        const reached = i <= earned;
+        return (
+          <div
+            key={stop}
+            style={{ flex: 1, position: "relative", paddingTop: 14 }}
+          >
+            {i > 0 && (
+              <div
+                style={{
+                  position: "absolute",
+                  top: 14 + 6,
+                  left: "-50%",
+                  width: "100%",
+                  height: 2,
+                  background: reached ? "var(--ok)" : "var(--line-3)",
+                }}
+              />
+            )}
+            {i === ceiling && (
+              <div
+                className="muted"
+                style={{
+                  position: "absolute",
+                  top: -2,
+                  left: 0,
+                  right: 0,
+                  textAlign: "center",
+                  fontSize: 11,
+                }}
+              >
+                ⚑ leash
+              </div>
+            )}
+            <div
+              style={{
+                position: "relative",
+                width: 13,
+                height: 13,
+                borderRadius: 999,
+                margin: "0 auto",
+                background: reached ? "var(--ok)" : "var(--surface-2)",
+                border: reached ? "none" : "1px solid var(--line-3)",
+                boxShadow:
+                  i === effective ? "0 0 0 3px var(--accent)" : "none",
+              }}
+            />
+            <div
+              style={{
+                textAlign: "center",
+                marginTop: 6,
+                fontSize: 11,
+                color: reached ? "inherit" : "var(--line-3)",
+              }}
+            >
+              {stop}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+/**
+ * "How it got here" — the worker's promote/demote milestones in plain words,
+ * newest first. This is the trust journey's *history*: each step it climbed (or
+ * slipped), what it was doing, and how much evidence it took.
+ */
+function JourneyTimeline({
+  events,
+  now,
+}: {
+  events: AuditEvent[];
+  now: number;
+}) {
+  if (events.length === 0) return null;
+  const recent = [...events].sort((a, b) => b.at - a.at).slice(0, 6);
+  return (
+    <div style={{ marginTop: "var(--s-3)" }}>
+      <div
+        className="editorial-sub"
+        style={{ fontFamily: "inherit", marginBottom: "var(--s-2)" }}
+      >
+        <strong>How it got here</strong>
+      </div>
+      {recent.map((e, i) => (
+        <div
+          className="suggestion-row"
+          key={`${e.classKey}-${e.to}-${e.at}-${i}`}
+        >
+          <span style={{ color: e.type === "promote" ? "var(--ok)" : "var(--warn)" }}>
+            {e.type === "promote" ? "▲" : "▼"}
+          </span>{" "}
+          {e.type === "promote" ? "Earned" : "Slipped back to"} “
+          {JOURNEY_STOPS[e.to] ?? `level ${e.to}`}” on {taskName(e.classKey)}
+          <span className="muted">
+            {" "}
+            · after {e.evidence} {e.evidence === 1 ? "try" : "tries"} ·{" "}
+            {relTime(e.at, now)}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
 /**
  * One worker — led by the DECISION an owner cares about ("can I give it more
  * independence yet?"), then a plain per-task record. The engine view (the L0–L4
  * dial bars, action-class keys, ramp-vs-gate) lives under "Show details".
  */
-function WorkerCard({ w, expert }: { w: WorkerReport; expert: boolean }) {
+function WorkerCard({
+  w,
+  expert,
+  now,
+}: {
+  w: WorkerReport;
+  expert: boolean;
+  now: number;
+}) {
   const owned = w.board.filter((b) => b.owned);
   // Ready to promote: an OWNED, non-reversible task where the worker earned a
   // higher level than the ceiling you set — it has proven more than you allow on
@@ -549,6 +728,18 @@ function WorkerCard({ w, expert }: { w: WorkerReport; expert: boolean }) {
     .filter((b) => !isReversible(b.classKey) && b.level > w.autonomyCeiling)
     .sort((a, b) => b.level - a.level);
   const top = promotable[0];
+  const primary = primaryJob(w);
+  // The journey/leash only matters for gated (non-reversible) work. A worker
+  // whose only owned tasks are reversible runs freely — no stepper, no leash.
+  const gatedPrimary =
+    primary && !isReversible(primary.classKey) ? primary : undefined;
+
+  const status =
+    w.board.length === 0
+      ? { label: "New", bg: "var(--surface-2)", fg: "inherit" }
+      : top
+        ? { label: "Ready to advance", bg: "var(--ok)", fg: "var(--bg)" }
+        : { label: "Proving itself", bg: "var(--surface-2)", fg: "inherit" };
 
   const effectiveItems = w.board.map((b) => {
     const effective = b.owned ? Math.min(b.level, w.autonomyCeiling) : 0;
@@ -571,21 +762,42 @@ function WorkerCard({ w, expert }: { w: WorkerReport; expert: boolean }) {
     <div className="card" style={{ marginTop: "var(--s-4)" }}>
       <div className="card-head">
         <strong>{w.name}</strong>
-        <span className="pill muted">
-          {expert
-            ? `ceiling L${w.autonomyCeiling}`
-            : `max: ${PLAIN_LEVEL_SHORT[w.autonomyCeiling] ?? `L${w.autonomyCeiling}`}`}
+        <span style={{ display: "flex", gap: "var(--s-2)" }}>
+          <span
+            className="pill"
+            style={{ background: status.bg, color: status.fg }}
+          >
+            {status.label}
+          </span>
+          <span className="pill muted">
+            {expert
+              ? `ceiling L${w.autonomyCeiling}`
+              : `max: ${PLAIN_LEVEL_SHORT[w.autonomyCeiling] ?? `L${w.autonomyCeiling}`}`}
+          </span>
         </span>
       </div>
 
-      {/* Readiness headline — the promote-or-not decision. */}
+      {/* Where it is on the journey — the hero. */}
+      {gatedPrimary ? (
+        <JourneyStepper
+          earned={gatedPrimary.level}
+          ceiling={w.autonomyCeiling}
+        />
+      ) : owned.length > 0 ? (
+        <div className="editorial-sub" style={{ fontFamily: "inherit" }}>
+          Low-risk helper — {w.name} only does easily-undone work, so it runs
+          freely without needing a leash.
+        </div>
+      ) : null}
+
+      {/* Ready-to-advance decision, else a plain standing line. */}
       {top ? (
         <div
           style={{
             border: "1px solid var(--ok)",
             borderRadius: "var(--radius-2, 8px)",
             padding: "var(--s-3)",
-            marginBottom: "var(--s-3)",
+            marginTop: "var(--s-3)",
           }}
         >
           <strong>✅ Ready for more independence?</strong>
@@ -601,14 +813,31 @@ function WorkerCard({ w, expert }: { w: WorkerReport; expert: boolean }) {
             worker’s <code>.worker.yaml</code> file.
           </div>
         </div>
-      ) : owned.length > 0 ? (
-        <div className="editorial-sub" style={{ fontFamily: "inherit" }}>
-          Still proving itself — {w.name} is performing within the independence
-          you’ve already allowed.
+      ) : gatedPrimary ? (
+        <div
+          className="editorial-sub"
+          style={{ fontFamily: "inherit", marginTop: "var(--s-3)" }}
+        >
+          {gatedPrimary.level === 0
+            ? `Just starting out on its main job, ${taskName(gatedPrimary.classKey)}`
+            : gatedPrimary.level < w.autonomyCeiling
+              ? `Climbing — earned "${levelPhrase(gatedPrimary.level)}" on ${taskName(gatedPrimary.classKey)}, working toward your leash`
+              : `At its leash on ${taskName(gatedPrimary.classKey)}, performing well`}{" "}
+          · {pct(gatedPrimary.mean)}% success over {gatedPrimary.observations}{" "}
+          tries.
         </div>
       ) : null}
 
+      {/* How it got here — the journey's history. */}
+      <JourneyTimeline events={w.events ?? []} now={now} />
+
       {/* Per-task record. */}
+      <div
+        className="editorial-sub"
+        style={{ fontFamily: "inherit", marginTop: "var(--s-3)" }}
+      >
+        <strong>What it does</strong>
+      </div>
       {w.board.length === 0 ? (
         <div className="editorial-sub" style={{ fontFamily: "inherit" }}>
           Hasn’t done anything yet — this fills in as the worker runs.
@@ -674,7 +903,25 @@ export default function WorkersPage() {
     { intervalMs: 30000 },
   );
   const [expert, setExpert] = useState(false);
-  const workers = data?.workers ?? [];
+  const now = data?.generatedAt ? Date.parse(data.generatedAt) : Date.now();
+
+  // Fleet view: a worker "needs attention" when it's earned past its leash
+  // (ready to advance). Sort those first so a team of many workers stays
+  // scannable — the ones awaiting a decision rise to the top.
+  function readyToAdvance(w: WorkerReport): boolean {
+    return w.board.some(
+      (b) => b.owned && !isReversible(b.classKey) && b.level > w.autonomyCeiling,
+    );
+  }
+  function rank(w: WorkerReport): number {
+    if (readyToAdvance(w)) return 0;
+    if (w.board.length === 0) return 2;
+    return 1;
+  }
+  const workers = [...(data?.workers ?? [])].sort(
+    (a, b) => rank(a) - rank(b) || a.name.localeCompare(b.name),
+  );
+  const readyCount = workers.filter(readyToAdvance).length;
 
   return (
     <section>
@@ -733,8 +980,24 @@ export default function WorkersPage() {
         />
       )}
 
+      {workers.length > 0 && (
+        <div
+          className="editorial-sub"
+          style={{ fontFamily: "inherit", marginTop: "var(--s-4)" }}
+        >
+          <strong>
+            Your team — {workers.length} worker
+            {workers.length === 1 ? "" : "s"}
+          </strong>
+          {readyCount > 0 &&
+            ` · ${readyCount} ready to advance (shown first)`}
+          . As you add workers that hand off to each other, this is where you’ll
+          watch the whole team’s trust grow together.
+        </div>
+      )}
+
       {workers.map((w) => (
-        <WorkerCard key={w.workerId} w={w} expert={expert} />
+        <WorkerCard key={w.workerId} w={w} expert={expert} now={now} />
       ))}
     </section>
   );

--- a/dashboard/src/app/workers/page.tsx
+++ b/dashboard/src/app/workers/page.tsx
@@ -64,6 +64,11 @@ interface KpiResponse {
   byTool: ToolKpi[];
 }
 
+// ── Plain-language vocabulary ───────────────────────────────────────────────
+// The whole page speaks in the gate's engine terms (levels, ceilings,
+// action-classes, Bayesian means). These maps translate them for the owner who
+// is deciding how far to trust a worker — the engine terms stay available under
+// "Show details". Index = trust level 0–4 → what the worker may do at it.
 const LEVEL_LABELS = [
   "L0 suggest",
   "L1 approve-each",
@@ -71,6 +76,58 @@ const LEVEL_LABELS = [
   "L3 act+sample",
   "L4 autonomous",
 ];
+/** What the worker may DO at each level, in plain words (verb phrase). */
+const PLAIN_LEVELS = [
+  "only suggest what to do",
+  "ask you before each action",
+  "act on its own, and you can undo it",
+  "act on its own, with spot-checks",
+  "act fully on its own",
+];
+/** Short chip form of each level. */
+const PLAIN_LEVEL_SHORT = [
+  "suggests only",
+  "asks first",
+  "acts + undo",
+  "acts + spot-check",
+  "on its own",
+];
+/** The classKey is `domain:reversibility:blastTier` — plain names per part. */
+const DOMAIN_LABELS: Record<string, string> = {
+  issue: "filing issues",
+  "fs-write": "changing files",
+  "fs-read": "reading files",
+  "vcs-read": "reading code history",
+  "vcs-remote": "pushing to GitHub",
+  "vcs-merge": "merging code",
+  "vcs-local": "local commits",
+  messaging: "sending messages",
+  ci: "running tests / CI",
+  net: "network requests",
+  other: "other actions",
+};
+const STAKES_LABELS: Record<string, string> = {
+  low: "low stakes",
+  medium: "medium stakes",
+  high: "high stakes",
+};
+function taskName(classKey: string): string {
+  const domain = classKey.split(":")[0] ?? classKey;
+  return DOMAIN_LABELS[domain] ?? domain;
+}
+function taskStakes(classKey: string): string {
+  const tier = classKey.split(":")[2] ?? "";
+  return STAKES_LABELS[tier] ?? "";
+}
+/** The reversibility segment of the classKey. Reversible actions bypass the
+ *  gate unconditionally (they're easily undone), so the autonomy ceiling never
+ *  restricts them — "capped" and "ready to promote" are meaningless there. */
+function isReversible(classKey: string): boolean {
+  return classKey.split(":")[1] === "reversible";
+}
+function levelPhrase(n: number): string {
+  return PLAIN_LEVELS[n] ?? `level ${n}`;
+}
 
 function fmtMs(ms: number): string {
   if (ms < 1000) return `${ms}ms`;
@@ -84,13 +141,15 @@ const channelStr = (c: Record<string, number> | undefined): string =>
     .sort((a, b) => b[1] - a[1])
     .map(([k, v]) => `${k} ${v}`)
     .join(" · ");
+const pct = (x: number): number => Math.round(x * 100);
 
 /**
- * Considered-approval KPI — the honesty lens beside the dial. The dial says how
- * high trust climbed; this says whether the approvals behind it were considered.
- * A 0% reject rate over a real sample is the clearest tell of a rubber-stamp.
+ * "Are you really reviewing?" — the honesty lens beside the dial. Trust only
+ * means something if the approvals behind it were considered; a 0% reject rate
+ * over a real sample is the clearest tell of rubber-stamping. Plain by default;
+ * the reject-rate / latency / per-tool telemetry lives under "Show details".
  */
-function ConsideredApprovalPanel() {
+function ConsideredApprovalPanel({ expert }: { expert: boolean }) {
   const { data } = useBridgeFetch<KpiResponse>("/api/bridge/approvals/kpi", {
     intervalMs: 30000,
   });
@@ -99,52 +158,72 @@ function ConsideredApprovalPanel() {
   // crashes on an unexpected shape.
   if (!data || !data.total) return null;
   const rubberStamp = data.decided >= 5 && data.rejectRate === 0;
+  const rejectPct = pct(data.rejectRate);
   return (
     <div className="card" style={{ marginTop: "var(--s-4)" }}>
       <div className="card-head">
         <strong>
-          Considered approvals — <span className="accent">is it earned?</span>
+          Are you really reviewing —{" "}
+          <span className="accent">or rubber-stamping?</span>
         </strong>
-        <span className="pill muted">{data.decided} decided</span>
+        <span className="pill muted">{data.decided} you decided</span>
       </div>
-      <div style={{ display: "flex", gap: "var(--s-4)", flexWrap: "wrap" }}>
-        <span
-          className="pill"
-          style={{
-            background: rubberStamp ? "var(--warn)" : "var(--surface-2)",
-            color: rubberStamp ? "var(--bg)" : "inherit",
-          }}
-        >
-          reject rate {Math.round(data.rejectRate * 100)}%
-        </span>
-        <span className="pill muted">latency {fmtLat(data.latency)}</span>
-        {data.abandoned > 0 && (
-          <span className="pill muted">{data.abandoned} abandoned</span>
-        )}
-        <span className="pill muted">{channelStr(data.channels)}</span>
-      </div>
-      {rubberStamp && (
+      {rubberStamp ? (
         <div
           className="editorial-sub"
           style={{ fontFamily: "inherit", color: "var(--warn)" }}
         >
-          ⚠ Every one of {data.decided} prompts approved with no rejections — the
-          dial may be climbing on rubber-stamps, not earned trust.
+          ⚠ You approved all {data.decided} requests with no rejections. A perfect
+          record like that usually means clicking “yes” without really checking —
+          so the trust below may be inflated, not earned.
         </div>
-      )}
-      {data.latency === null && (
+      ) : (
         <div className="editorial-sub" style={{ fontFamily: "inherit" }}>
-          Latency captures from the next decision forward (it cannot be
-          backfilled).
+          You’ve reviewed {data.decided} requests and said no {rejectPct}% of the
+          time
+          {data.abandoned > 0 ? `, and left ${data.abandoned} undecided` : ""}. A
+          healthy amount of “no” is a sign you’re really looking.
         </div>
       )}
-      {data.byTool.map((t) => (
-        <div className="suggestion-row" key={t.toolName}>
-          {t.toolName} — decided {t.decided} · reject{" "}
-          {Math.round(t.rejectRate * 100)}% · {fmtLat(t.latency)} ·{" "}
-          {channelStr(t.channels)}
-        </div>
-      ))}
+      {expert && (
+        <>
+          <div
+            style={{
+              display: "flex",
+              gap: "var(--s-4)",
+              flexWrap: "wrap",
+              marginTop: "var(--s-3)",
+            }}
+          >
+            <span
+              className="pill"
+              style={{
+                background: rubberStamp ? "var(--warn)" : "var(--surface-2)",
+                color: rubberStamp ? "var(--bg)" : "inherit",
+              }}
+            >
+              reject rate {rejectPct}%
+            </span>
+            <span className="pill muted">latency {fmtLat(data.latency)}</span>
+            {data.abandoned > 0 && (
+              <span className="pill muted">{data.abandoned} abandoned</span>
+            )}
+            <span className="pill muted">{channelStr(data.channels)}</span>
+          </div>
+          {data.latency === null && (
+            <div className="editorial-sub" style={{ fontFamily: "inherit" }}>
+              Latency captures from the next decision forward (it cannot be
+              backfilled).
+            </div>
+          )}
+          {data.byTool.map((t) => (
+            <div className="suggestion-row" key={t.toolName}>
+              {t.toolName} — decided {t.decided} · reject {pct(t.rejectRate)}% ·{" "}
+              {fmtLat(t.latency)} · {channelStr(t.channels)}
+            </div>
+          ))}
+        </>
+      )}
     </div>
   );
 }
@@ -161,6 +240,12 @@ interface OutcomesResponse {
   outcomes: OutcomeRecord[];
 }
 
+/** Plain label for a disposition (the raw value shows under "Show details"). */
+const DISPOSITION_LABEL: Record<Disposition, string> = {
+  confirmed: "looks real",
+  junk: "not real",
+  unknown: "not reviewed",
+};
 function dispositionStyle(d: Disposition): CSSProperties {
   if (d === "confirmed") return { background: "var(--ok)", color: "var(--bg)" };
   if (d === "junk") return { background: "var(--warn)", color: "var(--bg)" };
@@ -179,16 +264,35 @@ interface PendingResponse {
   pending: PendingConfirmation[];
 }
 
+/** Render a URL as a link only for http(s) — never emit a raw href for a
+ *  non-web-scheme URL (defence-in-depth against a javascript: URL, which React
+ *  does not sanitise, even though every write path validates http(s)). */
+function UrlCell({ url }: { url: string }) {
+  const style: CSSProperties = {
+    flex: 1,
+    minWidth: "12rem",
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+    whiteSpace: "nowrap",
+  };
+  return /^https?:\/\//i.test(url) ? (
+    <a href={url} target="_blank" rel="noreferrer" style={style}>
+      {url}
+    </a>
+  ) : (
+    <span style={style}>{url}</span>
+  );
+}
+
 /**
- * Awaiting confirmation — the CONFIRM QUEUE. Worker issue filings with NO
- * operator disposition yet: their trust is WITHHELD until a human acts. This
- * is the queue the confirm loop exists to drain, and the age of this queue IS
- * the evidence-latency moat metric. One-click Confirm/Reject POSTs to the same
- * Bearer-gated /outcomes route (never a recipe step — no self-confirm) and the
- * queue refreshes. Sourced from GET /outcomes/pending (a read-only join over the
- * run log + dispositions). Suppressed when the queue is empty.
+ * "Needs your review" — the CONFIRM QUEUE. Things a worker created (issue
+ * filings) that have no verdict yet: they don't count toward the worker's
+ * record until you say whether they're real. Read-only join over the run log +
+ * dispositions (GET /outcomes/pending); one-click confirm/reject POSTs to the
+ * Bearer-gated /outcomes route (never a recipe step — a worker can't grade its
+ * own homework) and the queue refreshes.
  */
-function AwaitingConfirmationPanel() {
+function AwaitingConfirmationPanel({ expert }: { expert: boolean }) {
   const { data, status, refetch } = useBridgeFetch<PendingResponse>(
     "/api/bridge/outcomes/pending",
     { intervalMs: 30000 },
@@ -207,18 +311,17 @@ function AwaitingConfirmationPanel() {
       <div className="card" style={{ marginTop: "var(--s-4)" }}>
         <div className="card-head">
           <strong>
-            Awaiting confirmation — <span className="accent">all clear.</span>
+            Needs your review — <span className="accent">all caught up.</span>
           </strong>
           <span
             className="pill"
             style={{ background: "var(--ok)", color: "var(--bg)" }}
           >
-            0 pending
+            0 waiting
           </span>
         </div>
         <div className="editorial-sub" style={{ fontFamily: "inherit" }}>
-          Every worker filing has an operator disposition — the confirm queue is
-          drained (evidence latency at zero).
+          Nothing’s waiting on you — you’ve reviewed everything the workers filed.
         </div>
       </div>
     );
@@ -254,18 +357,19 @@ function AwaitingConfirmationPanel() {
     <div className="card" style={{ marginTop: "var(--s-4)" }}>
       <div className="card-head">
         <strong>
-          Awaiting confirmation — <span className="accent">needs your call.</span>
+          Needs your review — <span className="accent">is it real?</span>
         </strong>
         <span
           className="pill"
           style={{ background: "var(--warn)", color: "var(--bg)" }}
         >
-          {pending.length} pending
+          {pending.length} waiting
         </span>
       </div>
       <div className="editorial-sub" style={{ fontFamily: "inherit" }}>
-        Filings whose trust is withheld until you confirm or reject them — the
-        age of this queue is the evidence latency the trust ramp exists to shrink.
+        Things the workers created that need your yes/no. Until you decide, they
+        don’t count toward a worker’s record — so this queue is the one thing
+        holding trust back.
       </div>
       {err && (
         <div
@@ -286,26 +390,9 @@ function AwaitingConfirmationPanel() {
             flexWrap: "wrap",
           }}
         >
-          {/^https?:\/\//i.test(p.issueUrl) ? (
-            <a
-              href={p.issueUrl}
-              target="_blank"
-              rel="noreferrer"
-              style={{
-                flex: 1,
-                minWidth: "12rem",
-                overflow: "hidden",
-                textOverflow: "ellipsis",
-                whiteSpace: "nowrap",
-              }}
-            >
-              {p.issueUrl}
-            </a>
-          ) : (
-            <span style={{ flex: 1, minWidth: "12rem" }}>{p.issueUrl}</span>
-          )}
+          <UrlCell url={p.issueUrl} />
           <span className="pill muted">
-            {p.workerName} · {p.classKey}
+            {p.workerName} · {expert ? p.classKey : taskName(p.classKey)}
           </span>
           <button
             type="button"
@@ -313,7 +400,7 @@ function AwaitingConfirmationPanel() {
             disabled={busy !== null}
             onClick={() => act(p, "confirmed")}
           >
-            Confirm
+            Looks real
           </button>
           <button
             type="button"
@@ -321,7 +408,7 @@ function AwaitingConfirmationPanel() {
             disabled={busy !== null}
             onClick={() => act(p, "junk")}
           >
-            Reject
+            Not real
           </button>
         </div>
       ))}
@@ -330,14 +417,12 @@ function AwaitingConfirmationPanel() {
 }
 
 /**
- * Filed outcomes — the operator's one-click confirm/reject queue. A worker's
- * `issue` dial only moves once a HUMAN confirms the filing was real (or rejects
- * it as junk) — a worker cannot self-confirm. This is the dashboard twin of
- * `patchwork outcomes confirm|reject`, POSTing to the Bearer-gated /outcomes
- * route through the generic bridge proxy. Converts approvals into *considered*
- * approvals and slashes evidence latency (the declared moat KPI).
+ * "Did the workers get it right?" — the record of things a worker created and
+ * your verdict on each. A worker only earns trust once YOU confirm its work was
+ * real; it can't grade its own homework. POSTs to the Bearer-gated /outcomes
+ * route through the generic bridge proxy.
  */
-function FiledOutcomesPanel() {
+function FiledOutcomesPanel({ expert }: { expert: boolean }) {
   const { data, refetch } = useBridgeFetch<OutcomesResponse>(
     "/api/bridge/outcomes",
     { intervalMs: 30000 },
@@ -377,17 +462,18 @@ function FiledOutcomesPanel() {
     <div className="card" style={{ marginTop: "var(--s-4)" }}>
       <div className="card-head">
         <strong>
-          Filed outcomes — <span className="accent">confirm or reject.</span>
+          Did the workers get it right? —{" "}
+          <span className="accent">your verdicts.</span>
         </strong>
         <span className="pill muted">
-          {outcomes.length} recorded
-          {confirmedCount > 0 && ` · ${confirmedCount} confirmed`}
-          {junkCount > 0 && ` · ${junkCount} junk`}
+          {outcomes.length} reviewed
+          {confirmedCount > 0 && ` · ${confirmedCount} real`}
+          {junkCount > 0 && ` · ${junkCount} not real`}
         </span>
       </div>
       <div className="editorial-sub" style={{ fontFamily: "inherit" }}>
-        A worker&apos;s <code>issue</code> dial only moves once a human confirms
-        the filing was real — a worker can&apos;t self-confirm its own filings.
+        A worker only earns trust once you confirm its work was real — it can’t
+        grade its own homework. Change your mind anytime; the latest verdict wins.
       </div>
       {err && (
         <div
@@ -398,7 +484,11 @@ function FiledOutcomesPanel() {
         </div>
       )}
       {outcomes.map((o) => {
-        const ctx = [o.recipeName, o.workerClass].filter(Boolean).join(" · ");
+        const ctx = expert
+          ? [o.recipeName, o.workerClass].filter(Boolean).join(" · ")
+          : o.workerClass
+            ? taskName(o.workerClass)
+            : "";
         return (
           <div
             className="suggestion-row"
@@ -411,30 +501,9 @@ function FiledOutcomesPanel() {
             }}
           >
             <span className="pill" style={dispositionStyle(o.disposition)}>
-              {o.disposition}
+              {expert ? o.disposition : DISPOSITION_LABEL[o.disposition]}
             </span>
-            {/* Render as a link only for http(s) — never emit a raw href for a
-                non-web-scheme URL (defence-in-depth against a javascript: URL,
-                which React does not sanitise, even though every write path
-                already validates http(s)). */}
-            {/^https?:\/\//i.test(o.issueUrl) ? (
-              <a
-                href={o.issueUrl}
-                target="_blank"
-                rel="noreferrer"
-                style={{
-                  flex: 1,
-                  minWidth: "12rem",
-                  overflow: "hidden",
-                  textOverflow: "ellipsis",
-                  whiteSpace: "nowrap",
-                }}
-              >
-                {o.issueUrl}
-              </a>
-            ) : (
-              <span style={{ flex: 1, minWidth: "12rem" }}>{o.issueUrl}</span>
-            )}
+            <UrlCell url={o.issueUrl} />
             {ctx && <span className="pill muted">{ctx}</span>}
             <button
               type="button"
@@ -442,7 +511,7 @@ function FiledOutcomesPanel() {
               disabled={busy !== null || o.disposition === "confirmed"}
               onClick={() => setDisposition(o.issueUrl, "confirmed")}
             >
-              Confirm
+              Looks real
             </button>
             <button
               type="button"
@@ -450,7 +519,7 @@ function FiledOutcomesPanel() {
               disabled={busy !== null || o.disposition === "junk"}
               onClick={() => setDisposition(o.issueUrl, "junk")}
             >
-              Reject
+              Not real
             </button>
           </div>
         );
@@ -465,11 +534,146 @@ function levelColor(effective: number): string {
   return "var(--line-3)";
 }
 
+/**
+ * One worker — led by the DECISION an owner cares about ("can I give it more
+ * independence yet?"), then a plain per-task record. The engine view (the L0–L4
+ * dial bars, action-class keys, ramp-vs-gate) lives under "Show details".
+ */
+function WorkerCard({ w, expert }: { w: WorkerReport; expert: boolean }) {
+  const owned = w.board.filter((b) => b.owned);
+  // Ready to promote: an OWNED, non-reversible task where the worker earned a
+  // higher level than the ceiling you set — it has proven more than you allow on
+  // work that actually needs a leash. Reversible tasks bypass the gate, so their
+  // earned level never justifies raising the ceiling (it wouldn't change a thing).
+  const promotable = owned
+    .filter((b) => !isReversible(b.classKey) && b.level > w.autonomyCeiling)
+    .sort((a, b) => b.level - a.level);
+  const top = promotable[0];
+
+  const effectiveItems = w.board.map((b) => {
+    const effective = b.owned ? Math.min(b.level, w.autonomyCeiling) : 0;
+    const capped =
+      b.owned && b.level > w.autonomyCeiling
+        ? ` (earned L${b.level}, capped)`
+        : "";
+    const notOwned = b.owned
+      ? ""
+      : `  ⚠ NOT OWNED — gate floors to L0 (earned L${b.level})`;
+    return {
+      label: b.classKey,
+      value: effective,
+      color: b.owned ? levelColor(effective) : "var(--warn)",
+      sub: `${LEVEL_LABELS[effective] ?? `L${effective}`} · ${b.observations} obs · ${pct(b.mean)}% mean${capped}${notOwned}`,
+    };
+  });
+
+  return (
+    <div className="card" style={{ marginTop: "var(--s-4)" }}>
+      <div className="card-head">
+        <strong>{w.name}</strong>
+        <span className="pill muted">
+          {expert
+            ? `ceiling L${w.autonomyCeiling}`
+            : `max: ${PLAIN_LEVEL_SHORT[w.autonomyCeiling] ?? `L${w.autonomyCeiling}`}`}
+        </span>
+      </div>
+
+      {/* Readiness headline — the promote-or-not decision. */}
+      {top ? (
+        <div
+          style={{
+            border: "1px solid var(--ok)",
+            borderRadius: "var(--radius-2, 8px)",
+            padding: "var(--s-3)",
+            marginBottom: "var(--s-3)",
+          }}
+        >
+          <strong>✅ Ready for more independence?</strong>
+          <div className="editorial-sub" style={{ fontFamily: "inherit" }}>
+            {w.name} has proven it can <strong>{levelPhrase(top.level)}</strong>{" "}
+            on <strong>{taskName(top.classKey)}</strong> ({pct(top.mean)}% success
+            over {top.observations} tries), but you’ve limited it to{" "}
+            <strong>{levelPhrase(w.autonomyCeiling)}</strong>. Raise its limit
+            when you’re comfortable.
+          </div>
+          <div className="editorial-sub" style={{ fontFamily: "inherit" }}>
+            To do it: set <code>autonomyCeiling: {top.level}</code> in this
+            worker’s <code>.worker.yaml</code> file.
+          </div>
+        </div>
+      ) : owned.length > 0 ? (
+        <div className="editorial-sub" style={{ fontFamily: "inherit" }}>
+          Still proving itself — {w.name} is performing within the independence
+          you’ve already allowed.
+        </div>
+      ) : null}
+
+      {/* Per-task record. */}
+      {w.board.length === 0 ? (
+        <div className="editorial-sub" style={{ fontFamily: "inherit" }}>
+          Hasn’t done anything yet — this fills in as the worker runs.
+        </div>
+      ) : expert ? (
+        <HBarList items={effectiveItems} max={4} />
+      ) : (
+        <div>
+          {w.board.map((b) => {
+            const reversible = isReversible(b.classKey);
+            const effective = b.owned ? Math.min(b.level, w.autonomyCeiling) : 0;
+            const capped = b.owned && !reversible && b.level > w.autonomyCeiling;
+            const status = !b.owned
+              ? "not one of its jobs, so it can’t act on its own here"
+              : reversible
+                ? "can do this on its own (it’s easily undone)"
+                : `can ${levelPhrase(effective)}`;
+            return (
+              <div className="suggestion-row" key={b.classKey}>
+                <strong>{taskName(b.classKey)}</strong>{" "}
+                <span className="muted">({taskStakes(b.classKey)})</span> —{" "}
+                {status}
+                {" · "}
+                {pct(b.mean)}% success over {b.observations} tries
+                {capped && (
+                  <div
+                    className="editorial-sub"
+                    style={{ fontFamily: "inherit" }}
+                  >
+                    It’s earned enough to {levelPhrase(b.level)} — you’ve capped
+                    it at {levelPhrase(w.autonomyCeiling)}.
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {/* Engine detail: where the trust score and the live safety-check disagree. */}
+      {expert && w.compared > 0 && (
+        <div style={{ marginTop: "var(--s-3)" }}>
+          <span className="pill muted">
+            ramp vs gate: {w.agreed}/{w.compared} agree
+          </span>
+          {w.divergences.slice(0, 5).map((d, i) => (
+            <div
+              className="suggestion-row"
+              key={`${w.workerId}-${d.toolName}-${i}`}
+            >
+              ⚠ {d.toolName} — {d.note}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
 export default function WorkersPage() {
   const { data, error, loading, refetch } = useBridgeFetch<ShadowResponse>(
     "/api/bridge/workers/shadow",
     { intervalMs: 30000 },
   );
+  const [expert, setExpert] = useState(false);
   const workers = data?.workers ?? [];
 
   return (
@@ -477,25 +681,39 @@ export default function WorkersPage() {
       <div className="page-head">
         <div>
           <h1 className="editorial-h1" style={{ margin: 0 }}>
-            Workers — <span className="accent">trust dial (shadow).</span>
+            Workers —{" "}
+            <span className="accent">how far you can trust each one.</span>
           </h1>
           <div className="editorial-sub" style={{ fontFamily: "inherit" }}>
-            Earned autonomy per worker × action-class, replayed read-only from
-            the run + gate logs. No live decision is changed.
+            How much independence each AI worker has earned from its track record.
+            Looking here never changes what a worker is allowed to do.
           </div>
         </div>
-        {data && (
-          <span className="pill muted">
-            {data.runsScanned} runs · {data.decisionsScanned} gate decisions
-          </span>
-        )}
+        <div
+          style={{ display: "flex", gap: "var(--s-3)", alignItems: "center" }}
+        >
+          {data && (
+            <span className="pill muted">
+              {expert
+                ? `${data.runsScanned} runs · ${data.decisionsScanned} gate decisions`
+                : `based on ${data.runsScanned} runs`}
+            </span>
+          )}
+          <button
+            type="button"
+            className="btn sm ghost"
+            onClick={() => setExpert((e) => !e)}
+          >
+            {expert ? "Plain view" : "Show details"}
+          </button>
+        </div>
       </div>
 
-      <ConsideredApprovalPanel />
+      <ConsideredApprovalPanel expert={expert} />
 
-      <AwaitingConfirmationPanel />
+      <AwaitingConfirmationPanel expert={expert} />
 
-      <FiledOutcomesPanel />
+      <FiledOutcomesPanel expert={expert} />
 
       {loading && workers.length === 0 && <SkeletonList rows={3} columns={2} />}
 
@@ -510,61 +728,14 @@ export default function WorkersPage() {
 
       {!loading && !error && workers.length === 0 && (
         <EmptyState
-          title="No workers yet"
-          description="Add *.worker.yaml to ~/.patchwork/workers (e.g. copy templates/workers/)."
+          title="No workers set up yet"
+          description="Add a worker to ~/.patchwork/workers (copy one from templates/workers/ to start)."
         />
       )}
 
-      {workers.map((w) => {
-        const effectiveItems = w.board.map((b) => {
-          const effective = b.owned
-            ? Math.min(b.level, w.autonomyCeiling)
-            : 0;
-          const capped =
-            b.owned && b.level > w.autonomyCeiling
-              ? ` (earned L${b.level}, capped)`
-              : "";
-          const notOwned = b.owned
-            ? ""
-            : `  ⚠ NOT OWNED — gate floors to L0 (earned L${b.level})`;
-          return {
-            label: b.classKey,
-            value: effective,
-            color: b.owned ? levelColor(effective) : "var(--warn)",
-            sub: `${LEVEL_LABELS[effective] ?? `L${effective}`} · ${b.observations} obs · ${Math.round(b.mean * 100)}% mean${capped}${notOwned}`,
-          };
-        });
-        return (
-          <div className="card" key={w.workerId} style={{ marginTop: "var(--s-4)" }}>
-            <div className="card-head">
-              <strong>{w.name}</strong>
-              <span className="pill muted">ceiling L{w.autonomyCeiling}</span>
-            </div>
-            {w.board.length === 0 ? (
-              <div className="editorial-sub" style={{ fontFamily: "inherit" }}>
-                No attributed activity yet — the dial fills as this worker runs.
-              </div>
-            ) : (
-              <HBarList items={effectiveItems} max={4} />
-            )}
-            {w.compared > 0 && (
-              <div style={{ marginTop: "var(--s-3)" }}>
-                <span className="pill muted">
-                  ramp vs gate: {w.agreed}/{w.compared} agree
-                </span>
-                {w.divergences.slice(0, 5).map((d, i) => (
-                  <div
-                    className="suggestion-row"
-                    key={`${w.workerId}-${d.toolName}-${i}`}
-                  >
-                    ⚠ {d.toolName} — {d.note}
-                  </div>
-                ))}
-              </div>
-            )}
-          </div>
-        );
-      })}
+      {workers.map((w) => (
+        <WorkerCard key={w.workerId} w={w} expert={expert} />
+      ))}
     </section>
   );
 }

--- a/dashboard/src/app/workers/page.tsx
+++ b/dashboard/src/app/workers/page.tsx
@@ -189,14 +189,40 @@ interface PendingResponse {
  * run log + dispositions). Suppressed when the queue is empty.
  */
 function AwaitingConfirmationPanel() {
-  const { data, refetch } = useBridgeFetch<PendingResponse>(
+  const { data, status, refetch } = useBridgeFetch<PendingResponse>(
     "/api/bridge/outcomes/pending",
     { intervalMs: 30000 },
   );
   const [busy, setBusy] = useState<string | null>(null);
   const [err, setErr] = useState<string | null>(null);
   const pending = data?.pending ?? [];
-  if (pending.length === 0) return null;
+
+  // Empty AND the endpoint answered (200) → the loop exists and is drained; say
+  // so, rather than vanishing (which reads as "feature missing"). On a bridge
+  // too old to serve /outcomes/pending (404 → status stays null / non-200) the
+  // panel suppresses entirely, so this never false-signals "clear".
+  if (pending.length === 0) {
+    if (status !== 200) return null;
+    return (
+      <div className="card" style={{ marginTop: "var(--s-4)" }}>
+        <div className="card-head">
+          <strong>
+            Awaiting confirmation — <span className="accent">all clear.</span>
+          </strong>
+          <span
+            className="pill"
+            style={{ background: "var(--ok)", color: "var(--bg)" }}
+          >
+            0 pending
+          </span>
+        </div>
+        <div className="editorial-sub" style={{ fontFamily: "inherit" }}>
+          Every worker filing has an operator disposition — the confirm queue is
+          drained (evidence latency at zero).
+        </div>
+      </div>
+    );
+  }
 
   async function act(p: PendingConfirmation, disposition: "confirmed" | "junk") {
     setBusy(`${p.issueUrl}:${disposition}`);
@@ -321,6 +347,10 @@ function FiledOutcomesPanel() {
   const outcomes = data?.outcomes ?? [];
   // Nothing filed yet → don't clutter the page (the confirm loop has no queue).
   if (outcomes.length === 0) return null;
+  const confirmedCount = outcomes.filter(
+    (o) => o.disposition === "confirmed",
+  ).length;
+  const junkCount = outcomes.filter((o) => o.disposition === "junk").length;
 
   async function setDisposition(issueUrl: string, disposition: Disposition) {
     setBusy(`${issueUrl}:${disposition}`);
@@ -349,7 +379,11 @@ function FiledOutcomesPanel() {
         <strong>
           Filed outcomes — <span className="accent">confirm or reject.</span>
         </strong>
-        <span className="pill muted">{outcomes.length} recorded</span>
+        <span className="pill muted">
+          {outcomes.length} recorded
+          {confirmedCount > 0 && ` · ${confirmedCount} confirmed`}
+          {junkCount > 0 && ` · ${junkCount} junk`}
+        </span>
       </div>
       <div className="editorial-sub" style={{ fontFamily: "inherit" }}>
         A worker&apos;s <code>issue</code> dial only moves once a human confirms

--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -25,9 +25,11 @@ Format: `- <date> <branch-or-PR> — <one-line scope> — <session/chat identity
 
 ## Active
 
-- 2026-07-02 `feat/pending-outcomes-visibility` — roadmap plan slice #4 (make the confirm queue visible): `computePendingConfirmations` join (runs × dispositions) in runWorkerShadow → `patchwork outcomes pending [--json]` + `GET /outcomes/pending` (new `pendingConfirmationsFn` dep) + an "Awaiting confirmation" one-click Confirm/Reject panel on dashboard `/workers`. The age of this queue IS the evidence-latency moat KPI. Delivered via the on-demand join (single source) rather than a FoldDecision-reason observer counter; the shadow-board inline "N awaiting" count is deferred (the CLI/panel cover the same info). — build session
+- 2026-07-02 `feat/workers-page-confirm-ux` — dashboard `/workers` "speak-human" pass (operator-facing, no bridge change): plain-language copy across every panel; a per-worker "Ready for more independence?" promotion-readiness headline computed from the earned-vs-ceiling gap on OWNED, non-reversible tasks (reversible bypasses the gate, so it never justifies a raise); plain per-task record (task name + stakes + success rate) replacing the L0–L4 dial in the default view; a "Show details" toggle that restores the full engine view (reject-rate/p90, action-class keys, L-levels, ramp-vs-gate). Also the confirm-loop polish (empty-state all-caught-up, disposition summary). — build session
 
 ## Recently closed (informal log, prune periodically)
+
+- 2026-07-02 `feat/pending-outcomes-visibility` (#1074) — roadmap plan slice #4 (make the confirm queue visible): `computePendingConfirmations` join (runs × dispositions) in runWorkerShadow → `patchwork outcomes pending [--json]` + `GET /outcomes/pending` (new `pendingConfirmationsFn` dep) + an "Awaiting confirmation" one-click confirm/reject panel on dashboard `/workers` — merged
 
 - 2026-07-02 `feat/outcomes-http-confirm-panel` (#1073) — roadmap plan slice #3 (outcomes over HTTP + confirm panel): bridge `GET/POST /outcomes` (Bearer-gated, `outcomeStoreFn` dep) + a one-click Confirm/Reject "Filed outcomes" card on dashboard `/workers`. NEVER a recipe step / MCP tool (self-confirm prohibition). Load-bearing fix: a single shared `resolveOutcomeLogDir()` so the outcome-log WRITE (CLI/ingester/POST) and the trust-replay READ (runWorkerShadow) agree on one file even under PATCHWORK_HOME — merged
 


### PR DESCRIPTION
## Speak-human pass over `/workers`

Rewrites the workers page for the **owner deciding how far to trust a worker**, not the engineer who built the gate. Every precise number is preserved behind a **"Show details"** toggle (default off) — nothing is lost, just translated. Dashboard-only; **no bridge change**.

### What changed
- **Plain-language copy** across every panel: "how far you can trust each one", "Are you really reviewing — or rubber-stamping?", "Needs your review — is it real?", "Did the workers get it right?", **Looks real / Not real** verdicts, plain disposition + task names (`issue:compensable:high` → "filing issues", stakes low/med/high).
- **Per-worker "Ready for more independence?" headline** — the promote-or-not decision, computed from the earned-vs-ceiling gap on **owned, non-reversible** tasks. Reversible actions bypass the gate, so their earned level never justifies raising the ceiling — surfacing them would mislead the owner (this was a real bug in the first draft). Names the earned capability, success rate, and the exact one-line `autonomyCeiling:` edit.
- **Plain per-task record** (task · stakes · "can …" · success rate) replaces the L0–L4 dial bars in the default view; reversible tasks read *"can do this on its own (it's easily undone)"*, never "capped".
- **"Show details" toggle** restores the full engine view: reject-rate/latency percentiles, per-tool KPI, action-class keys, the L0–L4 dial (HBarList), and ramp-vs-gate divergences.
- **Confirm-loop polish folded in**: all-caught-up empty state (gated on a 200 so a pre-route bridge still suppresses — never false-signals), disposition summary ("3 reviewed · 3 real").

### Before → after
| Was | Now (default) |
|---|---|
| "Workers — trust dial (shadow)" | "Workers — how far you can trust each one." |
| "L0 suggest · 5 obs · 21% mean" | "filing issues (high stakes) — can only suggest what to do · 21% success over 5 tries" |
| "ceiling L1" | "max: asks first" |
| bars at 0 hiding earned L3 | "✅ Ready for more independence?" card with the exact edit |

### Tests / gates
- `dashboard vitest` — 944 pass (updated to the new copy + a promotion-readiness case + a reversible-not-promotable check via the "still proving itself" path).
- `tsc --noEmit` clean · `next lint` clean.
- Verified live via Playwright against the reinstalled bridge (both plain + "Show details" views).

🤖 Generated with [Claude Code](https://claude.com/claude-code)