### PR TITLE
feat(dashboard): humane-redesign S1 — shared primitives

### DIFF
--- a/dashboard/src/components/DetailsFold.tsx
+++ b/dashboard/src/components/DetailsFold.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { useCallback, useEffect, useState } from "react";
+
+/**
+ * Page-level "Show details" affordance, shared across the redesigned pages.
+ *
+ * One boolean — expert mode — persisted in localStorage so the operator's
+ * choice sticks across navigations and reloads, and synced across every
+ * `useExpertMode()` consumer on the page (many `DetailsFold` regions + one
+ * `ExpertToggle`) via a custom same-tab event plus the native cross-tab
+ * `storage` event. Replaces the workers page's local `expert` useState.
+ *
+ * Expert content is never deleted — `DetailsFold` folds it away and marks
+ * the region `data-details` so the Playwright "glance test" can assert the
+ * default view is jargon-free while allowing raw terms inside the fold.
+ */
+
+const STORAGE_KEY = "pw:expert";
+const SYNC_EVENT = "pw:expert-change";
+
+function readStored(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.localStorage.getItem(STORAGE_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+export interface ExpertMode {
+  expert: boolean;
+  setExpert: (v: boolean) => void;
+  toggle: () => void;
+}
+
+export function useExpertMode(): ExpertMode {
+  // SSR-safe: start false (server + first client render agree), hydrate from
+  // storage in an effect to avoid a hydration mismatch.
+  const [expert, setExpertState] = useState(false);
+
+  useEffect(() => {
+    const sync = () => setExpertState(readStored());
+    sync();
+    window.addEventListener(SYNC_EVENT, sync);
+    window.addEventListener("storage", sync);
+    return () => {
+      window.removeEventListener(SYNC_EVENT, sync);
+      window.removeEventListener("storage", sync);
+    };
+  }, []);
+
+  const setExpert = useCallback((v: boolean) => {
+    setExpertState(v);
+    try {
+      window.localStorage.setItem(STORAGE_KEY, v ? "1" : "0");
+    } catch {
+      // Private mode / storage disabled — state still works in-memory for
+      // this session; just not persisted.
+    }
+    // Notify sibling consumers in THIS tab (storage event only fires in others).
+    window.dispatchEvent(new Event(SYNC_EVENT));
+  }, []);
+
+  const toggle = useCallback(() => setExpert(!readStored()), [setExpert]);
+
+  return { expert, setExpert, toggle };
+}
+
+/**
+ * The page-level toggle button. Renders "Show details ▸" / "Hide details ▾".
+ * Any number can be on a page; they all reflect and drive the same state.
+ */
+export function ExpertToggle({ style, className }: { style?: React.CSSProperties; className?: string }) {
+  const { expert, toggle } = useExpertMode();
+  return (
+    <button
+      type="button"
+      onClick={toggle}
+      aria-expanded={expert}
+      className={className}
+      style={{
+        background: "none",
+        border: "none",
+        padding: 0,
+        cursor: "pointer",
+        fontSize: "var(--fs-s)",
+        fontWeight: 500,
+        color: "var(--ink-2)",
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 4,
+        ...style,
+      }}
+    >
+      {expert ? "Hide details" : "Show details"}
+      <span aria-hidden="true">{expert ? "▾" : "▸"}</span>
+    </button>
+  );
+}
+
+/**
+ * A region that only renders (and is only in the DOM) when expert mode is on.
+ * Marked `data-details` so the glance test can scope banned-jargon checks.
+ */
+export function DetailsFold({
+  children,
+  style,
+  className,
+}: {
+  children: ReactNode;
+  style?: React.CSSProperties;
+  className?: string;
+}) {
+  const { expert } = useExpertMode();
+  if (!expert) return null;
+  return (
+    <div data-details="" className={className} style={style}>
+      {children}
+    </div>
+  );
+}

--- a/dashboard/src/components/DotStrip.tsx
+++ b/dashboard/src/components/DotStrip.tsx
@@ -1,0 +1,70 @@
+import type { CSSProperties } from "react";
+
+/**
+ * "Worked 9 of last 10 times" as dots — the redesign's replacement for the
+ * bare "success rate 90%" stat. Meaning first (the sentence), number as a
+ * dot strip, never a naked percentage.
+ *
+ * Renders the most recent `max` outcomes as filled (good, green) or hollow
+ * (not-good, muted) dots. `good` is clamped to `[0, shown]`. When there's
+ * no history yet it renders nothing (callers show a "new" state instead).
+ */
+
+interface DotStripProps {
+  /** Number of good outcomes among the shown window. */
+  good: number;
+  /** Total outcomes observed. */
+  total: number;
+  /** Max dots to render (the "last N"). Default 10. */
+  max?: number;
+  /** Prefix the dots with the plain "Worked N of last M times" sentence. */
+  withSentence?: boolean;
+  style?: CSSProperties;
+}
+
+/** The plain sentence form, exported so headers can use it without dots. */
+export function workedSentence(good: number, total: number, max = 10): string {
+  const shown = Math.min(total, max);
+  const g = Math.max(0, Math.min(good, shown));
+  if (shown === 0) return "No runs yet";
+  if (shown === 1) return g === 1 ? "Worked the one time it ran" : "Didn't work the one time it ran";
+  return `Worked ${g} of last ${shown} times`;
+}
+
+export function DotStrip({ good, total, max = 10, withSentence = false, style }: DotStripProps) {
+  const shown = Math.min(total, max);
+  if (shown === 0) return null;
+  const g = Math.max(0, Math.min(good, shown));
+  const dots = Array.from({ length: shown }, (_, i) => i < g);
+  const label = workedSentence(good, total, max);
+
+  return (
+    <span
+      style={{ display: "inline-flex", alignItems: "center", gap: 8, ...style }}
+      role="img"
+      aria-label={label}
+    >
+      {withSentence && (
+        <span style={{ fontSize: "var(--fs-s)", color: "var(--ink-2)" }}>{label}</span>
+      )}
+      <span aria-hidden="true" style={{ display: "inline-flex", gap: 3 }}>
+        {dots.map((isGood, i) => (
+          <span
+            // Fixed-length ordered strip; index is a stable key here.
+            // biome-ignore lint/suspicious/noArrayIndexKey: positional dots
+            key={i}
+            style={{
+              width: 7,
+              height: 7,
+              borderRadius: "50%",
+              background: isGood ? "var(--ok)" : "transparent",
+              border: isGood
+                ? "1px solid var(--ok)"
+                : "1px solid color-mix(in srgb, var(--ink-3) 60%, transparent)",
+            }}
+          />
+        ))}
+      </span>
+    </span>
+  );
+}

--- a/dashboard/src/components/StatusMedallion.tsx
+++ b/dashboard/src/components/StatusMedallion.tsx
@@ -1,0 +1,160 @@
+import type { CSSProperties, ReactNode } from "react";
+
+/**
+ * The one dominant status object at the top of a redesigned page (recipe
+ * detail, workers). A big colored medallion + a "Working fine" headline +
+ * a verb-first sentence. Carries page state by color and size first, words
+ * second — the non-technical operator should read it in one glance.
+ *
+ * Tone → traffic-light discipline: ok=green, warn=amber (waiting on you),
+ * err=red (stopped), muted=grey/white (new / calm). `pulse` animates the
+ * disc for a live "running now" state.
+ */
+
+export type MedallionTone = "ok" | "warn" | "err" | "muted";
+
+interface StatusMedallionProps {
+  tone: MedallionTone;
+  /** Short headline, e.g. "Working fine", "Waiting on you", "Stopped". */
+  title: string;
+  /** The plain sentence under the headline. */
+  children?: ReactNode;
+  /** Animate the disc (a live "running now" state). */
+  pulse?: boolean;
+  size?: number;
+  style?: CSSProperties;
+}
+
+const COLOR: Record<MedallionTone, string> = {
+  ok: "var(--ok)",
+  warn: "var(--warn)",
+  err: "var(--err)",
+  muted: "var(--ink-3)",
+};
+
+// A soft tint behind the disc so the color reads on both light and dark
+// themes (flat fills wash out on the "paper" theme).
+const TINT: Record<MedallionTone, string> = {
+  ok: "color-mix(in srgb, var(--ok) 16%, transparent)",
+  warn: "color-mix(in srgb, var(--warn) 18%, transparent)",
+  err: "color-mix(in srgb, var(--err) 16%, transparent)",
+  muted: "color-mix(in srgb, var(--ink-3) 14%, transparent)",
+};
+
+function Glyph({ tone }: { tone: MedallionTone }) {
+  switch (tone) {
+    case "ok":
+      return (
+        <path
+          d="M6 11l3 3 5-6"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          fill="none"
+        />
+      );
+    case "warn":
+      return (
+        <>
+          <rect x="9" y="5.5" width="2" height="6" rx="1" fill="currentColor" />
+          <circle cx="10" cy="14.5" r="1.15" fill="currentColor" />
+        </>
+      );
+    case "err":
+      return (
+        <path
+          d="M6.5 6.5l7 7M13.5 6.5l-7 7"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          fill="none"
+        />
+      );
+    case "muted":
+      return <circle cx="10" cy="10" r="2.5" fill="currentColor" />;
+  }
+}
+
+const TITLE_TONE_CLASS: Record<MedallionTone, string> = {
+  ok: "ink-1",
+  warn: "ink-1",
+  err: "ink-1",
+  muted: "ink-2",
+};
+
+export function StatusMedallion({
+  tone,
+  title,
+  children,
+  pulse = false,
+  size = 44,
+  style,
+}: StatusMedallionProps) {
+  const color = COLOR[tone];
+  return (
+    <div
+      role="status"
+      data-tone={tone}
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 14,
+        ...style,
+      }}
+    >
+      <span
+        aria-hidden="true"
+        style={{
+          flexShrink: 0,
+          width: size,
+          height: size,
+          borderRadius: "50%",
+          background: TINT[tone],
+          display: "inline-flex",
+          alignItems: "center",
+          justifyContent: "center",
+          color,
+        }}
+      >
+        <svg
+          width={size * 0.55}
+          height={size * 0.55}
+          viewBox="0 0 20 20"
+          fill="none"
+          style={
+            pulse
+              ? { animation: "pulse-dot 1.4s ease-in-out infinite" }
+              : undefined
+          }
+        >
+          <Glyph tone={tone} />
+        </svg>
+      </span>
+      <div style={{ minWidth: 0 }}>
+        <div
+          style={{
+            fontSize: "var(--fs-xl)",
+            fontWeight: 650,
+            lineHeight: 1.15,
+            color: `var(--${TITLE_TONE_CLASS[tone]})`,
+          }}
+        >
+          {title}
+        </div>
+        {children != null && (
+          <div
+            style={{
+              fontSize: "var(--fs-m)",
+              color: "var(--ink-2)",
+              lineHeight: 1.4,
+              marginTop: 3,
+            }}
+          >
+            {children}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/dashboard/src/components/__tests__/DetailsFold.test.tsx
+++ b/dashboard/src/components/__tests__/DetailsFold.test.tsx
@@ -1,0 +1,72 @@
+/** @vitest-environment jsdom */
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { DetailsFold, ExpertToggle, useExpertMode } from "../DetailsFold";
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+afterEach(() => {
+  window.localStorage.clear();
+});
+
+// A tiny harness: a toggle + a fold + a second fold, all sharing state.
+function Harness() {
+  return (
+    <div>
+      <ExpertToggle />
+      <DetailsFold>
+        <span>engine detail A</span>
+      </DetailsFold>
+      <DetailsFold>
+        <span>engine detail B</span>
+      </DetailsFold>
+    </div>
+  );
+}
+
+describe("DetailsFold + useExpertMode", () => {
+  it("folds expert content by default; toggle reveals it in a data-details region", () => {
+    const { container } = render(<Harness />);
+    expect(container.textContent).not.toContain("engine detail A");
+    expect(container.querySelector("[data-details]")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Show details" }));
+
+    expect(container.textContent).toContain("engine detail A");
+    // Both folds react to the single shared state.
+    expect(container.textContent).toContain("engine detail B");
+    expect(container.querySelectorAll("[data-details]").length).toBe(2);
+  });
+
+  it("persists the choice to localStorage", () => {
+    render(<Harness />);
+    fireEvent.click(screen.getByRole("button", { name: "Show details" }));
+    expect(window.localStorage.getItem("pw:expert")).toBe("1");
+    fireEvent.click(screen.getByRole("button", { name: "Hide details" }));
+    expect(window.localStorage.getItem("pw:expert")).toBe("0");
+  });
+
+  it("hydrates from a pre-existing stored value", () => {
+    window.localStorage.setItem("pw:expert", "1");
+    const { container } = render(<Harness />);
+    expect(container.textContent).toContain("engine detail A");
+    expect(screen.getByRole("button", { name: "Hide details" })).toBeTruthy();
+  });
+
+  it("exposes setExpert/toggle via the hook", () => {
+    function Probe() {
+      const { expert, setExpert } = useExpertMode();
+      return (
+        <button type="button" onClick={() => setExpert(true)}>
+          {expert ? "on" : "off"}
+        </button>
+      );
+    }
+    render(<Probe />);
+    const btn = screen.getByRole("button");
+    expect(btn.textContent).toBe("off");
+    fireEvent.click(btn);
+    expect(btn.textContent).toBe("on");
+  });
+});

--- a/dashboard/src/components/__tests__/DotStrip.test.tsx
+++ b/dashboard/src/components/__tests__/DotStrip.test.tsx
@@ -1,0 +1,40 @@
+/** @vitest-environment jsdom */
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { DotStrip, workedSentence } from "../DotStrip";
+
+describe("workedSentence", () => {
+  it("caps the window at max and phrases plainly", () => {
+    expect(workedSentence(9, 10)).toBe("Worked 9 of last 10 times");
+    expect(workedSentence(45, 50, 10)).toBe("Worked 10 of last 10 times"); // good clamps to shown
+    expect(workedSentence(0, 0)).toBe("No runs yet");
+    expect(workedSentence(1, 1)).toMatch(/the one time/);
+    expect(workedSentence(0, 1)).toMatch(/Didn't work the one time/);
+  });
+});
+
+describe("DotStrip", () => {
+  it("renders one dot per outcome in the window, good ones filled", () => {
+    const { container } = render(<DotStrip good={9} total={10} />);
+    const strip = container.querySelector('[role="img"]');
+    expect(strip?.getAttribute("aria-label")).toBe("Worked 9 of last 10 times");
+    const dots = container.querySelectorAll('[aria-hidden="true"] > span');
+    expect(dots.length).toBe(10);
+  });
+
+  it("clamps the window to max", () => {
+    const { container } = render(<DotStrip good={30} total={40} max={10} />);
+    const dots = container.querySelectorAll('[aria-hidden="true"] > span');
+    expect(dots.length).toBe(10);
+  });
+
+  it("renders the sentence inline when asked", () => {
+    const { container } = render(<DotStrip good={8} total={10} withSentence />);
+    expect(container.textContent).toContain("Worked 8 of last 10 times");
+  });
+
+  it("renders nothing with no history", () => {
+    const { container } = render(<DotStrip good={0} total={0} />);
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/dashboard/src/components/__tests__/StatusMedallion.test.tsx
+++ b/dashboard/src/components/__tests__/StatusMedallion.test.tsx
@@ -1,0 +1,33 @@
+/** @vitest-environment jsdom */
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { StatusMedallion } from "../StatusMedallion";
+
+describe("StatusMedallion", () => {
+  it("renders title + sentence and exposes the tone", () => {
+    const { container } = render(
+      <StatusMedallion tone="ok" title="Working fine">
+        Ran this morning in 42s.
+      </StatusMedallion>,
+    );
+    expect(screen.getByText("Working fine")).toBeTruthy();
+    expect(screen.getByText(/Ran this morning/)).toBeTruthy();
+    expect(container.querySelector('[data-tone="ok"]')).toBeTruthy();
+    expect(screen.getByRole("status")).toBeTruthy();
+  });
+
+  it("carries each tone as a data attribute (state by color, not words)", () => {
+    for (const tone of ["ok", "warn", "err", "muted"] as const) {
+      const { container, unmount } = render(
+        <StatusMedallion tone={tone} title="x" />,
+      );
+      expect(container.querySelector(`[data-tone="${tone}"]`)).toBeTruthy();
+      unmount();
+    }
+  });
+
+  it("renders without a sentence", () => {
+    render(<StatusMedallion tone="muted" title="New" />);
+    expect(screen.getByText("New")).toBeTruthy();
+  });
+});

--- a/dashboard/src/lib/__tests__/haltPhrasing.test.ts
+++ b/dashboard/src/lib/__tests__/haltPhrasing.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import type { HaltCategory } from "../haltCategory";
+import { ownerHaltPhrase } from "../haltPhrasing";
+
+describe("ownerHaltPhrase", () => {
+  it("auth_failure names the service + a reconnect fix", () => {
+    const p = ownerHaltPhrase("auth_failure", "GitHub");
+    expect(p.sentence).toBe("It can't sign in to GitHub anymore.");
+    expect(p.fix).toBe("reconnect");
+    expect(p.fixLabel).toBe("Reconnect");
+  });
+
+  it("missing_connector → connect", () => {
+    const p = ownerHaltPhrase("missing_connector", "Slack");
+    expect(p.sentence).toContain("Slack");
+    expect(p.fix).toBe("connect");
+  });
+
+  it("rate_limited → wait, no fix button", () => {
+    expect(ownerHaltPhrase("rate_limited", "GitHub").fix).toBe("wait");
+    // Falls back gracefully with no service.
+    expect(ownerHaltPhrase("rate_limited").sentence).toMatch(/slow down/);
+  });
+
+  it("budget_exceeded → raise-budget", () => {
+    expect(ownerHaltPhrase("budget_exceeded").fix).toBe("raise-budget");
+  });
+
+  it("kill_switch → release-kill-switch, plain safety-switch wording", () => {
+    const p = ownerHaltPhrase("kill_switch");
+    expect(p.fix).toBe("release-kill-switch");
+    expect(p.sentence).toMatch(/safety switch/i);
+  });
+
+  it("approval_rejected → none", () => {
+    expect(ownerHaltPhrase("approval_rejected").fix).toBe("none");
+  });
+
+  it("engine categories collapse to see-what-happened", () => {
+    for (const c of ["tool_error", "agent_silent_fail", "expect_failed", "run_level", "unknown"] as HaltCategory[]) {
+      expect(ownerHaltPhrase(c).fix).toBe("open-trace");
+    }
+  });
+
+  it("uses a generic service when none is given for auth_failure", () => {
+    expect(ownerHaltPhrase("auth_failure").sentence).toMatch(/the service it needs/);
+  });
+
+  it("no sentence contains engineer jargon", () => {
+    const banned = /expect:|tokensMax|connector|cron|LCB|disposition|actionClass/i;
+    const cats: HaltCategory[] = [
+      "auth_failure",
+      "missing_connector",
+      "rate_limited",
+      "network_error",
+      "budget_exceeded",
+      "kill_switch",
+      "approval_rejected",
+      "step_timeout",
+      "expect_failed",
+      "agent_silent_fail",
+      "agent_narration_only",
+      "agent_threw",
+      "tool_threw",
+      "tool_error",
+      "run_level",
+      "unknown",
+    ];
+    for (const c of cats) {
+      expect(ownerHaltPhrase(c, "GitHub").sentence).not.toMatch(banned);
+    }
+  });
+});

--- a/dashboard/src/lib/__tests__/humanSchedule.test.ts
+++ b/dashboard/src/lib/__tests__/humanSchedule.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import { describeNextRun, humanizeSchedule } from "../humanSchedule";
+
+// A fixed clock: Wed 2026-07-01 06:00:00 local.
+const NOW = new Date(2026, 6, 1, 6, 0, 0, 0);
+
+describe("humanizeSchedule", () => {
+  it("empty → runs-only-when-started", () => {
+    expect(humanizeSchedule("", NOW).text).toMatch(/only when you start it/i);
+    expect(humanizeSchedule(undefined, NOW).humanized).toBe(true);
+  });
+
+  it("daily cron at a time", () => {
+    const r = humanizeSchedule("0 7 * * *", NOW);
+    expect(r.text).toBe("Every day at 7:00");
+    expect(r.humanized).toBe(true);
+    // 07:00 today is 1h out from 06:00.
+    expect(r.nextRunAt).toBe(new Date(2026, 6, 1, 7, 0, 0, 0).getTime());
+  });
+
+  it("daily cron whose time already passed today rolls to tomorrow", () => {
+    const r = humanizeSchedule("30 5 * * *", NOW);
+    expect(r.text).toBe("Every day at 5:30");
+    expect(r.nextRunAt).toBe(new Date(2026, 6, 2, 5, 30, 0, 0).getTime());
+  });
+
+  it("every N minutes", () => {
+    const r = humanizeSchedule("*/15 * * * *", NOW);
+    expect(r.text).toBe("Every 15 minutes");
+    expect(r.nextRunAt).toBe(NOW.getTime() + 15 * 60_000);
+  });
+
+  it("hourly at a minute", () => {
+    expect(humanizeSchedule("0 * * * *", NOW).text).toBe("Every hour, on the hour");
+    expect(humanizeSchedule("20 * * * *", NOW).text).toBe("Every hour at :20");
+  });
+
+  it("weekly on a weekday", () => {
+    // dow 1 = Monday. From Wed, next Monday.
+    const r = humanizeSchedule("0 9 * * 1", NOW);
+    expect(r.text).toBe("Every Monday at 9:00");
+    expect(new Date(r.nextRunAt as number).getDay()).toBe(1);
+  });
+
+  it("monthly on a day-of-month", () => {
+    expect(humanizeSchedule("0 8 15 * *", NOW).text).toBe(
+      "On the 15th of every month at 8:00",
+    );
+  });
+
+  it("@every macros", () => {
+    expect(humanizeSchedule("@every 30s", NOW).text).toBe("Every 30 seconds");
+    expect(humanizeSchedule("@every 1h", NOW).text).toBe("Every 1 hour");
+    const r = humanizeSchedule("@every 30s", NOW);
+    expect(r.nextRunAt).toBe(NOW.getTime() + 30_000);
+  });
+
+  it("@daily / @hourly macros", () => {
+    expect(humanizeSchedule("@daily", NOW).text).toBe("Every day at midnight");
+    expect(humanizeSchedule("@hourly", NOW).text).toBe("Every hour");
+  });
+
+  it("unrecognized cron falls back to raw, humanized=false", () => {
+    const r = humanizeSchedule("5 4 * 3 2", NOW);
+    expect(r.humanized).toBe(false);
+    expect(r.text).toBe("5 4 * 3 2");
+    expect(r.raw).toBe("5 4 * 3 2");
+  });
+});
+
+describe("describeNextRun", () => {
+  it("minutes / hours / days buckets", () => {
+    expect(describeNextRun(NOW.getTime() + 5 * 60_000, NOW)).toBe("next in 5 minutes");
+    expect(describeNextRun(NOW.getTime() + 14 * 3_600_000, NOW)).toBe("next in 14 hours");
+    expect(describeNextRun(NOW.getTime() + 3 * 86_400_000, NOW)).toBe("next in 3 days");
+  });
+  it("past / missing", () => {
+    expect(describeNextRun(NOW.getTime() - 1000, NOW)).toBe("any moment now");
+    expect(describeNextRun(undefined, NOW)).toBeNull();
+  });
+});

--- a/dashboard/src/lib/haltPhrasing.ts
+++ b/dashboard/src/lib/haltPhrasing.ts
@@ -1,0 +1,129 @@
+/**
+ * Owner-level phrasing for halt categories — the plain sentence a
+ * non-technical operator reads in the recipe "Needs you" band, plus a
+ * semantic hint for the one fix button.
+ *
+ * Sits BESIDE `HALT_CATEGORY_HINT` (haltCategory.ts), which is the
+ * engineer-level text kept for the expert/details view. Same category
+ * union, different audience: HINT tells a developer how to debug;
+ * this tells the owner what happened and what to press.
+ *
+ * The `fix` action is a semantic enum, not a URL — the page decides how to
+ * wire each one (a link to /connections, opening the budget details, etc.)
+ * so this module stays free of routing concerns and easy to unit-test.
+ */
+
+import type { HaltCategory } from "./haltCategory";
+
+export type HaltFixAction =
+  | "reconnect"
+  | "connect"
+  | "raise-budget"
+  | "release-kill-switch"
+  | "approve"
+  | "open-trace"
+  | "wait"
+  | "none";
+
+export interface OwnerHaltPhrase {
+  /** One plain sentence, no jargon. `{service}` already substituted. */
+  sentence: string;
+  /** What the single fix button should do, or "none"/"wait" when there's nothing to press. */
+  fix: HaltFixAction;
+  /** Suggested button label for the fix, when there is one. */
+  fixLabel?: string;
+}
+
+const SERVICE_FALLBACK = "the service it needs";
+
+/**
+ * Plain owner-facing phrasing for a halt.
+ * @param category  the categorised halt
+ * @param service   the connector/service name when known (e.g. "GitHub")
+ */
+export function ownerHaltPhrase(
+  category: HaltCategory,
+  service?: string,
+): OwnerHaltPhrase {
+  const svc = service && service.trim() ? service.trim() : SERVICE_FALLBACK;
+  switch (category) {
+    case "auth_failure":
+      return {
+        sentence: `It can't sign in to ${svc} anymore.`,
+        fix: "reconnect",
+        fixLabel: "Reconnect",
+      };
+    case "missing_connector":
+      return {
+        sentence: `It needs ${svc} connected before it can run.`,
+        fix: "connect",
+        fixLabel: "Connect",
+      };
+    case "rate_limited":
+      return {
+        sentence: `${service && service.trim() ? svc : "The service"} asked it to slow down — it'll try again on its own soon.`,
+        fix: "wait",
+      };
+    case "network_error":
+      return {
+        sentence: `It couldn't reach ${svc}. This is usually temporary.`,
+        fix: "wait",
+      };
+    case "budget_exceeded":
+      return {
+        sentence: "It hit its spending limit for this run.",
+        fix: "raise-budget",
+        fixLabel: "Raise limit",
+      };
+    case "kill_switch":
+      return {
+        sentence: "It's paused by the safety switch — nothing can make changes right now.",
+        fix: "release-kill-switch",
+        fixLabel: "Turn safety switch off",
+      };
+    case "approval_rejected":
+      return {
+        sentence: "You turned down its last request, so it stopped.",
+        fix: "none",
+      };
+    case "step_timeout":
+      return {
+        sentence: "One step took too long and was stopped.",
+        fix: "open-trace",
+        fixLabel: "See what happened",
+      };
+    case "expect_failed":
+      return {
+        sentence: "It checked its own work and something didn't look right, so it stopped.",
+        fix: "open-trace",
+        fixLabel: "See what happened",
+      };
+    case "agent_silent_fail":
+    case "agent_narration_only":
+    case "agent_threw":
+      return {
+        sentence: "Claude didn't finish this step cleanly, so it stopped.",
+        fix: "open-trace",
+        fixLabel: "See what happened",
+      };
+    case "tool_threw":
+    case "tool_error":
+      return {
+        sentence: "One of its tools ran into an error and it stopped.",
+        fix: "open-trace",
+        fixLabel: "See what happened",
+      };
+    case "run_level":
+      return {
+        sentence: "It couldn't start — something in its setup needs fixing.",
+        fix: "open-trace",
+        fixLabel: "See what happened",
+      };
+    case "unknown":
+      return {
+        sentence: "It stopped for a reason we couldn't label.",
+        fix: "open-trace",
+        fixLabel: "See what happened",
+      };
+  }
+}

--- a/dashboard/src/lib/humanSchedule.ts
+++ b/dashboard/src/lib/humanSchedule.ts
@@ -1,0 +1,233 @@
+/**
+ * Turn a recipe schedule string into plain English for the non-technical
+ * operator — "Every day at 7:00", "Every 15 minutes" — and, where the
+ * cadence is derivable, the next fire time so the header can say
+ * "next in 14h".
+ *
+ * Handles the common shapes only: Go-style `@every 30s` / `@daily` macros
+ * and 5-field cron for the cases a normal recipe actually uses (daily at a
+ * time, hourly, every-N-minutes, a weekday, day-of-month). Anything more
+ * exotic falls back to the raw string (surfaced under expert details, never
+ * in the plain view) with `humanized: false` so callers can tell.
+ *
+ * No cron library exists in the repo; this is intentionally small and
+ * total — it never throws, worst case returns the raw string.
+ */
+
+export interface HumanSchedule {
+  /** Plain-English cadence, or the raw string if we couldn't humanize. */
+  text: string;
+  /** True when `text` is a real translation (not the raw fallback). */
+  humanized: boolean;
+  /** Next fire time in epoch ms, when derivable from the cadence. */
+  nextRunAt?: number;
+  /** The input, verbatim — for the expert/details view. */
+  raw: string;
+}
+
+const DOW = [
+  "Sunday",
+  "Monday",
+  "Tuesday",
+  "Wednesday",
+  "Thursday",
+  "Friday",
+  "Saturday",
+];
+
+const UNIT_MS: Record<string, number> = {
+  s: 1000,
+  m: 60_000,
+  h: 3_600_000,
+  d: 86_400_000,
+};
+
+const UNIT_WORD: Record<string, string> = {
+  s: "second",
+  m: "minute",
+  h: "hour",
+  d: "day",
+};
+
+function plural(n: number, word: string): string {
+  return n === 1 ? `1 ${word}` : `${n} ${word}s`;
+}
+
+function hhmm(h: number, m: number): string {
+  return `${h}:${m.toString().padStart(2, "0")}`;
+}
+
+function ordinal(n: number): string {
+  const rem10 = n % 10;
+  const rem100 = n % 100;
+  if (rem100 >= 11 && rem100 <= 13) return `${n}th`;
+  if (rem10 === 1) return `${n}st`;
+  if (rem10 === 2) return `${n}nd`;
+  if (rem10 === 3) return `${n}rd`;
+  return `${n}th`;
+}
+
+/** Next occurrence of local time h:m at or after `from`. */
+function nextDailyAt(h: number, m: number, from: Date): number {
+  const d = new Date(from);
+  d.setHours(h, m, 0, 0);
+  if (d.getTime() <= from.getTime()) d.setDate(d.getDate() + 1);
+  return d.getTime();
+}
+
+/** Next occurrence of weekday `dow` at h:m at or after `from`. */
+function nextWeekdayAt(dow: number, h: number, m: number, from: Date): number {
+  const d = new Date(from);
+  d.setHours(h, m, 0, 0);
+  let add = (dow - d.getDay() + 7) % 7;
+  if (add === 0 && d.getTime() <= from.getTime()) add = 7;
+  d.setDate(d.getDate() + add);
+  return d.getTime();
+}
+
+function macro(raw: string, s: string, now: Date): HumanSchedule | null {
+  // @every <dur>  — Go/robfig style, e.g. "@every 30s", "@every 1h30m".
+  const every = /^@every\s+(.+)$/i.exec(s);
+  if (every) {
+    const dur = every[1].trim();
+    const parts = [...dur.matchAll(/(\d+)\s*([smhd])/gi)];
+    if (parts.length) {
+      let ms = 0;
+      for (const p of parts) ms += Number(p[1]) * (UNIT_MS[p[2].toLowerCase()] ?? 0);
+      // Single-unit cadences read cleanest ("Every 30 seconds").
+      const text =
+        parts.length === 1
+          ? `Every ${plural(Number(parts[0][1]), UNIT_WORD[parts[0][2].toLowerCase()])}`
+          : `Every ${dur}`;
+      return {
+        text,
+        humanized: true,
+        raw,
+        nextRunAt: ms > 0 ? now.getTime() + ms : undefined,
+      };
+    }
+  }
+  const map: Record<string, { text: string; h: number; m: number; weekly?: boolean; monthly?: boolean; yearly?: boolean }> = {
+    "@hourly": { text: "Every hour", h: -1, m: 0 },
+    "@daily": { text: "Every day at midnight", h: 0, m: 0 },
+    "@midnight": { text: "Every day at midnight", h: 0, m: 0 },
+    "@weekly": { text: "Every Sunday at midnight", h: 0, m: 0, weekly: true },
+    "@monthly": { text: "On the 1st of every month at midnight", h: 0, m: 0, monthly: true },
+    "@yearly": { text: "Once a year at midnight on Jan 1", h: 0, m: 0, yearly: true },
+    "@annually": { text: "Once a year at midnight on Jan 1", h: 0, m: 0, yearly: true },
+  };
+  const hit = map[s.toLowerCase()];
+  if (hit) {
+    let nextRunAt: number | undefined;
+    if (hit.h === -1) {
+      const d = new Date(now);
+      d.setMinutes(0, 0, 0);
+      d.setHours(d.getHours() + 1);
+      nextRunAt = d.getTime();
+    } else if (hit.weekly) {
+      nextRunAt = nextWeekdayAt(0, hit.h, hit.m, now);
+    } else if (!hit.monthly && !hit.yearly) {
+      nextRunAt = nextDailyAt(hit.h, hit.m, now);
+    }
+    return { text: hit.text, humanized: true, raw, nextRunAt };
+  }
+  return null;
+}
+
+/**
+ * Humanize a schedule string. `now` is injectable for testing; defaults to
+ * the current time.
+ */
+export function humanizeSchedule(schedule: string | undefined | null, now: Date = new Date()): HumanSchedule {
+  const raw = (schedule ?? "").trim();
+  if (!raw) return { text: "No schedule — runs only when you start it", humanized: true, raw };
+
+  if (raw.startsWith("@")) {
+    const m = macro(raw, raw, now);
+    if (m) return m;
+    return { text: raw, humanized: false, raw };
+  }
+
+  const fields = raw.split(/\s+/);
+  if (fields.length !== 5) return { text: raw, humanized: false, raw };
+  const [min, hr, dom, mon, dow] = fields;
+
+  // Every N minutes: "*/n * * * *"
+  const stepMin = /^\*\/(\d+)$/.exec(min);
+  if (stepMin && hr === "*" && dom === "*" && mon === "*" && dow === "*") {
+    const n = Number(stepMin[1]);
+    return {
+      text: n === 1 ? "Every minute" : `Every ${n} minutes`,
+      humanized: true,
+      raw,
+      nextRunAt: now.getTime() + n * 60_000,
+    };
+  }
+
+  const isNum = (v: string) => /^\d+$/.test(v);
+
+  // Hourly at minute M: "M * * * *"
+  if (isNum(min) && hr === "*" && dom === "*" && mon === "*" && dow === "*") {
+    const m = Number(min);
+    const d = new Date(now);
+    d.setMinutes(m, 0, 0);
+    if (d.getTime() <= now.getTime()) d.setHours(d.getHours() + 1);
+    const text = m === 0 ? "Every hour, on the hour" : `Every hour at :${m.toString().padStart(2, "0")}`;
+    return { text, humanized: true, raw, nextRunAt: d.getTime() };
+  }
+
+  // Daily at H:M: "M H * * *"
+  if (isNum(min) && isNum(hr) && dom === "*" && mon === "*" && dow === "*") {
+    const h = Number(hr);
+    const m = Number(min);
+    return {
+      text: `Every day at ${hhmm(h, m)}`,
+      humanized: true,
+      raw,
+      nextRunAt: nextDailyAt(h, m, now),
+    };
+  }
+
+  // Weekly on a weekday at H:M: "M H * * D"
+  if (isNum(min) && isNum(hr) && dom === "*" && mon === "*" && isNum(dow)) {
+    const h = Number(hr);
+    const m = Number(min);
+    const d = Number(dow) % 7;
+    return {
+      text: `Every ${DOW[d]} at ${hhmm(h, m)}`,
+      humanized: true,
+      raw,
+      nextRunAt: nextWeekdayAt(d, h, m, now),
+    };
+  }
+
+  // Monthly on day-of-month at H:M: "M H DOM * *"
+  if (isNum(min) && isNum(hr) && isNum(dom) && mon === "*" && dow === "*") {
+    const h = Number(hr);
+    const m = Number(min);
+    return {
+      text: `On the ${ordinal(Number(dom))} of every month at ${hhmm(h, m)}`,
+      humanized: true,
+      raw,
+    };
+  }
+
+  return { text: raw, humanized: false, raw };
+}
+
+/**
+ * "next in 14h" style relative phrasing for a next-run time. Returns null
+ * when there is no derivable next run. Coarse on purpose — the operator
+ * wants a feel, not a countdown.
+ */
+export function describeNextRun(nextRunAt: number | undefined, now: Date = new Date()): string | null {
+  if (nextRunAt == null || !Number.isFinite(nextRunAt)) return null;
+  const ms = nextRunAt - now.getTime();
+  if (ms <= 0) return "any moment now";
+  const mins = Math.round(ms / 60_000);
+  if (mins < 60) return `next in ${plural(mins, "minute")}`;
+  const hrs = Math.round(ms / 3_600_000);
+  if (hrs < 48) return `next in ${plural(hrs, "hour")}`;
+  const days = Math.round(ms / 86_400_000);
+  return `next in ${plural(days, "day")}`;
+}

--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -25,9 +25,11 @@ Format: `- <date> <branch-or-PR> — <one-line scope> — <session/chat identity
 
 ## Active
 
-- 2026-07-02 `feat/workers-page-confirm-ux` — dashboard `/workers` "speak-human" pass (operator-facing, no bridge change): plain-language copy across every panel; a per-worker "Ready for more independence?" promotion-readiness headline computed from the earned-vs-ceiling gap on OWNED, non-reversible tasks (reversible bypasses the gate, so it never justifies a raise); plain per-task record (task name + stakes + success rate) replacing the L0–L4 dial in the default view; a "Show details" toggle that restores the full engine view (reject-rate/p90, action-class keys, L-levels, ramp-vs-gate). Also the confirm-loop polish (empty-state all-caught-up, disposition summary). — build session
+- 2026-07-02 `feat/dashboard-humane-s1-primitives` — dashboard humane-redesign slice S1 (shared primitives, additive, no page rewrites yet): `StatusMedallion` (dominant traffic-light status object), `DotStrip` + `workedSentence` ("Worked 9 of last 10" not "90%"), `DetailsFold`/`ExpertToggle`/`useExpertMode` (page-level expert mode persisted in localStorage, same-tab-synced — replaces the workers-page local `expert` useState in a later slice), `lib/humanSchedule.ts` (cron/`@every` → "Every day at 7:00" + next-run), `lib/haltPhrasing.ts` (owner-level halt sentences beside the engineer-level `HALT_CATEGORY_HINT`). Spec: docs/plans/dashboard-humane-redesign-2026-07-02.md §7. Next: R1 (recipe Band 1+2) ‖ W1 (workers Bands 1+2). — build session
 
 ## Recently closed (informal log, prune periodically)
+
+- 2026-07-02 `feat/workers-page-confirm-ux` (#1075) — dashboard `/workers` "speak-human" pass + trust-journey (stepper + "How it got here" history timeline + attention-first fleet sort); plain per-task record replacing the L0–L4 dial; page-level "Show details" toggle; confirm-loop polish — merged
 
 - 2026-07-02 `feat/pending-outcomes-visibility` (#1074) — roadmap plan slice #4 (make the confirm queue visible): `computePendingConfirmations` join (runs × dispositions) in runWorkerShadow → `patchwork outcomes pending [--json]` + `GET /outcomes/pending` (new `pendingConfirmationsFn` dep) + an "Awaiting confirmation" one-click confirm/reject panel on dashboard `/workers` — merged
 


### PR DESCRIPTION
First slice of the dashboard humane redesign (spec: `docs/plans/dashboard-humane-redesign-2026-07-02.md` §7). **Additive only** — no page is rewritten yet. These are the shared building blocks the recipe (R1) and workers (W1) slices compose.

## What's here
- **`StatusMedallion`** — the one dominant traffic-light status object for a redesigned page header. Tone (`ok`/`warn`/`err`/`muted`) carries state by color and size first, words second. Soft `color-mix` tint so it survives the light "paper" theme.
- **`DotStrip` + `workedSentence`** — "Worked 9 of last 10 times" + a dot strip, replacing the bare "success rate 90%" stat (meaning → evidence → number).
- **`DetailsFold` / `ExpertToggle` / `useExpertMode`** — one page-level "Show details" affordance, persisted in `localStorage` and synced across every consumer in the tab (custom event + cross-tab `storage`). Expert content folds into `[data-details]` regions, never deleted. This is the hook that replaces the workers-page local `expert` `useState` in W2.
- **`lib/humanSchedule.ts`** — cron / `@every` / `@macro` → plain English ("Every day at 7:00") + a derivable next-run time and "next in 14h" phrasing. Total (never throws), falls back to the raw string when it can't humanize.
- **`lib/haltPhrasing.ts`** — owner-level one-sentence halt phrasing + a semantic fix action, sitting **beside** the engineer-level `HALT_CATEGORY_HINT` (kept for the expert view).

## Verification
- 33 new unit tests across 5 files (`vitest run` green).
- `tsc --noEmit` clean; inline-fontSize ratchet unchanged (9, baseline 9).
- `next lint` — no new warnings in these files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)