### PR TITLE
refactor(dashboard): extract recipe run-health computation to lib/recipeRunHealth.ts

### DIFF
--- a/dashboard/src/app/recipes/[...name]/page.tsx
+++ b/dashboard/src/app/recipes/[...name]/page.tsx
@@ -46,6 +46,7 @@ import {
 import { highlightYaml } from "@/components/patchwork/CodeBlock";
 import type { RelatedGroup } from "@/components/patchwork";
 import { detectConnectorsForRecipe } from "@/lib/recipeConnectors";
+import { computeAvgDuration, computeSuccessPct } from "@/lib/recipeRunHealth";
 import { fmtDuration } from "@/components/time";
 import { Skeleton } from "@/components/Skeleton";
 import { DetailsFold, ExpertToggle, useExpertMode } from "@/components/DetailsFold";
@@ -543,19 +544,8 @@ function RecipeHubOverviewPage({ name }: { name: string }) {
   // Derived run metrics.
   const lastRun = runs[0];
   const recentRuns = runs.slice(0, 10);
-  const successPct = useMemo(() => {
-    const settled = runs.filter(
-      (r) => r.status !== "running" && r.status !== "queued" && r.status !== "pending",
-    );
-    if (settled.length === 0) return null;
-    const ok = settled.filter((r) => r.status === "done" || r.status === "success").length;
-    return (ok / settled.length) * 100;
-  }, [runs]);
-  const avgDurationMs = useMemo(() => {
-    const ds = runs.map((r) => r.durationMs).filter((d): d is number => typeof d === "number" && d > 0);
-    if (ds.length === 0) return undefined;
-    return ds.reduce((s, d) => s + d, 0) / ds.length;
-  }, [runs]);
+  const successPct = useMemo(() => computeSuccessPct(runs), [runs]);
+  const avgDurationMs = useMemo(() => computeAvgDuration(runs), [runs]);
 
   // Latest inbox output — PR #742 attaches inboxOutputs to RecipeRun.
   const latestInboxOutput = useMemo(() => {

--- a/dashboard/src/app/recipes/page.tsx
+++ b/dashboard/src/app/recipes/page.tsx
@@ -6,6 +6,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { Dialog } from "@/components/Dialog";
 import { apiPath } from "@/lib/api";
 import { canonicalRecipeKey } from "@/lib/entityKey";
+import { computeAvgDuration, computeSuccessPct } from "@/lib/recipeRunHealth";
 import { ConnectorHealthPanel } from "@/components/ConnectorHealthPanel";
 import { SkeletonList } from "@/components/Skeleton";
 import { useToast } from "@/components/Toast";
@@ -702,24 +703,11 @@ export default function RecipesPage() {
   }, [recipes]);
 
   function successPct(name: string): number | null {
-    const runs = allRunsMap.get(name);
-    if (!runs || runs.length === 0) return null;
-    const settled = runs.filter(
-      (r) => r.status !== "running" && r.status !== "queued" && r.status !== "pending",
-    );
-    if (settled.length === 0) return null;
-    const ok = settled.filter((r) => r.status === "done" || r.status === "success").length;
-    return (ok / settled.length) * 100;
+    return computeSuccessPct(allRunsMap.get(name));
   }
 
   function avgDuration(name: string): number | undefined {
-    const runs = allRunsMap.get(name);
-    if (!runs || runs.length === 0) return undefined;
-    const ds = runs
-      .map((r) => r.durationMs)
-      .filter((d): d is number => typeof d === "number" && d > 0);
-    if (ds.length === 0) return undefined;
-    return ds.reduce((s, d) => s + d, 0) / ds.length;
+    return computeAvgDuration(allRunsMap.get(name));
   }
 
   function isLive(name: string): boolean {

--- a/dashboard/src/lib/__tests__/recipeRunHealth.test.ts
+++ b/dashboard/src/lib/__tests__/recipeRunHealth.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import {
+  computeAvgDuration,
+  computeSuccessPct,
+  type RunHealthRecord,
+} from "../recipeRunHealth";
+
+describe("computeSuccessPct", () => {
+  it("undefined/empty runs → null", () => {
+    expect(computeSuccessPct(undefined)).toBeNull();
+    expect(computeSuccessPct([])).toBeNull();
+  });
+
+  it("all runs in-flight (no settled runs) → null", () => {
+    const runs: RunHealthRecord[] = [
+      { status: "running" },
+      { status: "queued" },
+      { status: "pending" },
+    ];
+    expect(computeSuccessPct(runs)).toBeNull();
+  });
+
+  it("all success → 100", () => {
+    const runs: RunHealthRecord[] = [
+      { status: "done" },
+      { status: "success" },
+    ];
+    expect(computeSuccessPct(runs)).toBe(100);
+  });
+
+  it("mixed success/error → percentage over settled runs only", () => {
+    const runs: RunHealthRecord[] = [
+      { status: "done" },
+      { status: "error" },
+      { status: "running" }, // excluded from denominator
+      { status: "success" },
+      { status: "error" },
+    ];
+    // settled = done, error, success, error → 4; ok = done, success → 2
+    expect(computeSuccessPct(runs)).toBe(50);
+  });
+
+  it("single successful run → 100", () => {
+    expect(computeSuccessPct([{ status: "done" }])).toBe(100);
+  });
+
+  it("single failed run → 0", () => {
+    expect(computeSuccessPct([{ status: "error" }])).toBe(0);
+  });
+});
+
+describe("computeAvgDuration", () => {
+  it("undefined/empty runs → undefined", () => {
+    expect(computeAvgDuration(undefined)).toBeUndefined();
+    expect(computeAvgDuration([])).toBeUndefined();
+  });
+
+  it("no runs with valid duration → undefined", () => {
+    const runs: RunHealthRecord[] = [
+      { status: "running" },
+      { status: "done", durationMs: 0 },
+      { status: "done", durationMs: -5 },
+    ];
+    expect(computeAvgDuration(runs)).toBeUndefined();
+  });
+
+  it("averages only positive durations", () => {
+    const runs: RunHealthRecord[] = [
+      { status: "done", durationMs: 1000 },
+      { status: "done", durationMs: 3000 },
+      { status: "error" }, // no durationMs, excluded
+    ];
+    expect(computeAvgDuration(runs)).toBe(2000);
+  });
+
+  it("single run with duration → that duration", () => {
+    expect(computeAvgDuration([{ status: "done", durationMs: 500 }])).toBe(500);
+  });
+});

--- a/dashboard/src/lib/recipeRunHealth.ts
+++ b/dashboard/src/lib/recipeRunHealth.ts
@@ -1,0 +1,49 @@
+/**
+ * Pure, page-agnostic helpers for computing per-recipe run-health metrics
+ * (success rate, average duration) from a list of run records.
+ *
+ * Extracted from page-local closures in `recipes/page.tsx` (gallery grid,
+ * `allRunsMap` bucketing) and `recipes/[...name]/page.tsx` (Dossier page,
+ * single-recipe `runs` list) — both computed the identical settled/success/
+ * duration logic independently. This module is the single source of truth;
+ * behavior is byte-identical to both prior implementations.
+ *
+ * Prep for the future "fleet pane" (Terminal+Copilot redesign) which needs
+ * the same per-recipe health computation without page component state.
+ */
+
+/** Minimal shape needed to compute run-health metrics. Both dashboard
+ *  `RunRecord` types (gallery + dossier) satisfy this structurally. */
+export interface RunHealthRecord {
+  status: string;
+  durationMs?: number;
+}
+
+const IN_FLIGHT_STATUSES = new Set(["running", "queued", "pending"]);
+const SUCCESS_STATUSES = new Set(["done", "success"]);
+
+/**
+ * Success percentage (0-100) across "settled" runs (excludes running /
+ * queued / pending). Returns null when there are no runs, or no settled
+ * runs, to distinguish "no data" from "0% success".
+ */
+export function computeSuccessPct(runs: RunHealthRecord[] | undefined): number | null {
+  if (!runs || runs.length === 0) return null;
+  const settled = runs.filter((r) => !IN_FLIGHT_STATUSES.has(r.status));
+  if (settled.length === 0) return null;
+  const ok = settled.filter((r) => SUCCESS_STATUSES.has(r.status)).length;
+  return (ok / settled.length) * 100;
+}
+
+/**
+ * Average duration in ms across runs with a positive `durationMs`.
+ * Returns undefined when there are no runs, or none have a valid duration.
+ */
+export function computeAvgDuration(runs: RunHealthRecord[] | undefined): number | undefined {
+  if (!runs || runs.length === 0) return undefined;
+  const ds = runs
+    .map((r) => r.durationMs)
+    .filter((d): d is number => typeof d === "number" && d > 0);
+  if (ds.length === 0) return undefined;
+  return ds.reduce((s, d) => s + d, 0) / ds.length;
+}

--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -25,7 +25,7 @@ Format: `- <date> <branch-or-PR> — <one-line scope> — <session/chat identity
 
 ## Active
 
-- 2026-07-03 `feat/dashboard-today-page` — dashboard redesign Deliverable 2 (new "Today" page, `app/today/page.tsx`, ADDITIVE — does not replace Overview at `/`): single 840px column, hero (overnight run/halt count + 3-segment progress), §1 read-the-brief (newest unread inbox brief item), §2 clear-the-decisions (merged worst-first list reusing Deliverable 1's blast badges + pending worker verdicts + reversible-batch row), §3 glance-at-the-team (workers data). localStorage daily progress ticks. Added to sidebar `NAV_SECTIONS` "Today" section (`dashboard/src/lib/navRoutes.ts`), above Overview. Spec: docs/plans/dashboard-redesign-2026-07-03.md Deliverable 2. Follows PR #1089 (Deliverable 1, merged — reuses its blast-badge components). — build session
+- 2026-07-03 `feat/dashboard-recipe-run-health-extract` — Terminal+Copilot deck plan (docs/plans/dashboard-terminal-copilot-plan-2026-07-03.md) PR 1/10: extract `allRunsMap`/`successPct`/`avgDuration` out of `app/recipes/page.tsx` into `dashboard/src/lib/recipeRunHealth.ts` as pure functions, golden-master tested against current inline behavior, reconciled with any independent run-aggregation in `recipes/[...name]/page.tsx`. No UI change — data-layer prep for the future fleet pane. Worker-trust equivalent (PR 2) already landed as part of Deliverable 2 (#1090, `lib/workerTrust.ts`). — build session
 
 ## Recently closed (informal log, prune periodically)
 


### PR DESCRIPTION
## Summary
- Terminal+Copilot deck plan (`docs/plans/dashboard-terminal-copilot-plan-2026-07-03.md`) PR 1/10 — pure refactor, zero behavior change.
- `successPct`/`avgDuration` were implemented three times across `recipes/page.tsx` and `recipes/[...name]/page.tsx` — extracted to `computeSuccessPct`/`computeAvgDuration` in `dashboard/src/lib/recipeRunHealth.ts`, both call sites now share one implementation.
- Prep work for a future "fleet pane" — no UI change in this PR.
- Worker-trust equivalent (plan's PR 2/10) already landed in #1090 as `dashboard/src/lib/workerTrust.ts`.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `node scripts/check-inline-fontsize.mjs`
- [x] `npx vitest run` (99 files / 1021 tests, 10 new golden-master tests for the extracted functions)
- [x] `npm run lint` (zero new warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)