### PR TITLE
fix(dashboard): global staleness indicator — useBridgeFetch never told you data was frozen

### DIFF
--- a/dashboard/src/app/page.tsx
+++ b/dashboard/src/app/page.tsx
@@ -25,6 +25,7 @@ import {
 import { LiveRunsStrip, type LiveRun } from "@/components/LiveRunsStrip";
 import { LiveWire } from "@/components/LiveWire";
 import { useRunRecipe } from "@/hooks/useRunRecipe";
+import { useManualPollStaleness } from "@/lib/staleFetchRegistry";
 
 // ---------------------------------------------------------------------------
 // Keyframe injection — scoped to this page, no globals.css edits needed.
@@ -273,6 +274,24 @@ export default function HomePage() {
   const [syncSpinning, setSyncSpinning] = useState(false);
   const tickRef = useRef<() => void>(() => {});
 
+  // Primary user-visible feed for Overview: the recipes/runs/halts/activity
+  // fan-out below. This drives every telemetry tile on the page ("what's
+  // happening right now?") — if it stalls silently, the operator sees
+  // frozen counters that look identical to "nothing is happening", which
+  // is the exact failure mode this whole staleness feature exists to
+  // catch. `/api/bridge/health` (fetched separately via useBridgeFetch
+  // above) is a narrower secondary signal and not chosen here.
+  const { markSuccess: markOverviewPollSuccess } = useManualPollStaleness({
+    key: "/api/bridge/recipes+runs+halts",
+    intervalMs: 5000,
+    refetch: () => tickRef.current(),
+  });
+  // Ref indirection so the tick() effect (deps: []) doesn't need to
+  // depend on markOverviewPollSuccess's identity, which changes every
+  // render.
+  const markOverviewPollSuccessRef = useRef(markOverviewPollSuccess);
+  markOverviewPollSuccessRef.current = markOverviewPollSuccess;
+
   useEffect(() => {
     let alive = true;
     const tick = async () => {
@@ -330,6 +349,7 @@ export default function HomePage() {
         setActivityEvents(
           (activityData.events ?? []).map(withAt),
         );
+        markOverviewPollSuccessRef.current();
       } catch {
         // bridge offline
       }

--- a/dashboard/src/app/runs/page.tsx
+++ b/dashboard/src/app/runs/page.tsx
@@ -15,6 +15,7 @@ import { useDebounced } from "@/hooks/useDebounced";
 import { useBridgeStream } from "@/hooks/useBridgeStream";
 import { usePaneShortcut } from "@/hooks/usePaneShortcuts";
 import { dedupeRunsByKey } from "@/lib/dedupeRuns";
+import { useManualPollStaleness } from "@/lib/staleFetchRegistry";
 
 interface AssertionFailure {
   assertion: string;
@@ -255,6 +256,23 @@ export default function RunsPage() {
 
   const reloadRef = useRef<() => void>(() => {});
 
+  // Primary user-visible feed for /runs: the filtered run list. If this
+  // poll stalls, the page silently shows a frozen run list that looks
+  // identical to "nothing is happening" — flag it via the shared
+  // staleness registry (same one useBridgeFetch's trackStaleness writes
+  // to) so Shell's global strip surfaces it.
+  const { markSuccess: markRunsPollSuccess } = useManualPollStaleness({
+    key: "/api/bridge/runs",
+    intervalMs: 5000,
+    refetch: () => reloadRef.current(),
+  });
+  // Ref indirection so the poll effect below doesn't need
+  // markRunsPollSuccess in its dependency array — the returned function
+  // identity changes every render, which would otherwise force the poll
+  // effect (and its AbortController + interval) to re-run on every render.
+  const markRunsPollSuccessRef = useRef(markRunsPollSuccess);
+  markRunsPollSuccessRef.current = markRunsPollSuccess;
+
   useEffect(() => {
     // Audit 2026-05-17 (#600): one AbortController per effect run,
     // aborted in cleanup. Without this, rapid filter changes could
@@ -285,6 +303,7 @@ export default function RunsPage() {
         // row key and triggers React's duplicate-key error + miscounts.
         setRuns(dedupeRunsByKey(data.runs ?? []));
         setErr(undefined);
+        markRunsPollSuccessRef.current();
       } catch (e) {
         // AbortError on unmount / dep change is expected — don't surface.
         if (e instanceof DOMException && e.name === "AbortError") return;

--- a/dashboard/src/app/workers/page.tsx
+++ b/dashboard/src/app/workers/page.tsx
@@ -1149,9 +1149,13 @@ function WorkerCard({
 }
 
 export default function WorkersPage() {
+  // Primary user-visible feed for /workers: the shadow-report roster
+  // (per-worker trust dial + divergences) — the headline data on this
+  // page. Everything else fetched below (KPI, outcomes, pending) is a
+  // secondary widget; this is the one an operator is actually reading.
   const { data, error, loading, refetch } = useBridgeFetch<ShadowResponse>(
     "/api/bridge/workers/shadow",
-    { intervalMs: 30000 },
+    { intervalMs: 30000, trackStaleness: true },
   );
   // Page-level expert mode (persisted, shared with every DetailsFold). Replaces
   // the old local `expert` useState.

--- a/dashboard/src/components/Shell.tsx
+++ b/dashboard/src/components/Shell.tsx
@@ -11,6 +11,7 @@ import { getHaltsLookbackMs, subscribeHaltsSeen } from "@/lib/haltsSeen";
 import { NAV_SECTIONS } from "@/lib/navRoutes";
 import { ActivityTicker } from "./ActivityTicker";
 import { BridgeOfflineBanner } from "./BridgeOfflineBanner";
+import { StalenessStrip } from "./StalenessStrip";
 import { KillSwitchBanner } from "./KillSwitchBanner";
 import { PWAInstallPrompt } from "./PWAInstallPrompt";
 import { CommandPalette } from "./CommandPalette";
@@ -573,6 +574,7 @@ function AppShell({ children }: { children: ReactNode }) {
 
       <main id="main-content" className="app-main" tabIndex={-1}>
         <BridgeOfflineBanner status={status} />
+        <StalenessStrip />
         {status.killSwitch?.engaged && (
           <KillSwitchBanner
             engaged={status.killSwitch.engaged}

--- a/dashboard/src/components/StalenessStrip.tsx
+++ b/dashboard/src/components/StalenessStrip.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  getStaleFetchSummary,
+  subscribeStaleFetchRegistry,
+} from "@/lib/staleFetchRegistry";
+
+/**
+ * One global slim strip, rendered by Shell, that surfaces "the data
+ * you're looking at may be frozen" — the aggregate of every
+ * `useBridgeFetch({ trackStaleness: true })` instance across the app.
+ *
+ * Deliberately NOT a per-page banner: individual poll hooks fail
+ * independently and at different cadences, so a banner-per-hook would
+ * either spam the page or require every page to duplicate this wiring.
+ * A single strip driven by the shared registry keeps the signal in one
+ * place, matching the precedent set by BridgeOfflineBanner (also one
+ * strip, driven by aggregated bridge-status state) — but staleness is a
+ * "the poll for THIS data went quiet" signal, distinct from "the bridge
+ * process itself is unreachable", so it's a separate component rather
+ * than folded into BridgeOfflineBanner's condition.
+ *
+ * Timestamp choice: shows the MOST RECENT successful fetch across all
+ * registered fetchers (not the earliest-stale one) — that's the
+ * honest "freshest data we can vouch for" answer, and matches the
+ * intuitive reading of "Data as of HH:MM:SS".
+ *
+ * Retry affordance: retries every currently-stale registered fetcher
+ * (calls each hook's `refetch()`) rather than a full page reload —
+ * cheap, targeted, and reuses the same backoff-aware fetch path the
+ * hook already has.
+ */
+
+const POLL_MS = 1000;
+
+function formatClock(ms: number): string {
+  const d = new Date(ms);
+  return d.toLocaleTimeString(undefined, {
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  });
+}
+
+export function StalenessStrip() {
+  const [summary, setSummary] = useState(() => getStaleFetchSummary());
+
+  useEffect(() => {
+    const recompute = () => setSummary(getStaleFetchSummary());
+    recompute();
+    const unsubscribe = subscribeStaleFetchRegistry(recompute);
+    const id = setInterval(recompute, POLL_MS);
+    return () => {
+      unsubscribe();
+      clearInterval(id);
+    };
+  }, []);
+
+  if (!summary.anyStale) return null;
+
+  const asOf =
+    summary.mostRecentSuccessAt !== null
+      ? formatClock(summary.mostRecentSuccessAt)
+      : "unknown";
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      style={{
+        background: "color-mix(in srgb, var(--amber) 14%, var(--surface))",
+        borderBottom: "1px solid color-mix(in srgb, var(--amber) 40%, transparent)",
+        padding: "8px 20px",
+        display: "flex",
+        alignItems: "center",
+        gap: 10,
+        flexWrap: "wrap",
+        fontSize: "var(--fs-s)",
+        color: "var(--ink-1)",
+      }}
+    >
+      <span
+        aria-hidden="true"
+        style={{
+          width: 8,
+          height: 8,
+          borderRadius: "50%",
+          background: "var(--amber)",
+          flexShrink: 0,
+        }}
+      />
+      <span>
+        Data as of <strong>{asOf}</strong> — reconnecting…
+      </span>
+
+      <span style={{ flex: 1, minWidth: 12 }} aria-hidden="true" />
+
+      <button
+        type="button"
+        onClick={() => summary.retryStale()}
+        style={{
+          background: "transparent",
+          border: "1px solid color-mix(in srgb, var(--amber) 35%, transparent)",
+          color: "var(--ink-2)",
+          padding: "3px 10px",
+          borderRadius: "var(--r-2)",
+          fontSize: "var(--fs-xs)",
+          cursor: "pointer",
+        }}
+      >
+        Retry now
+      </button>
+    </div>
+  );
+}

--- a/dashboard/src/components/__tests__/StalenessStrip.test.tsx
+++ b/dashboard/src/components/__tests__/StalenessStrip.test.tsx
@@ -1,0 +1,220 @@
+/** @vitest-environment jsdom */
+/**
+ * Verifies the global staleness-strip contract:
+ *   - hidden when nothing registered is stale
+ *   - renders when a registered fetcher goes stale (via the shared
+ *     staleFetchRegistry, the same registry useBridgeFetch writes to)
+ *   - clears when the stale fetcher recovers
+ *   - "Retry now" calls refetch() on the stale entries
+ */
+
+import { act, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { StalenessStrip } from "@/components/StalenessStrip";
+import { useBridgeFetch } from "@/hooks/useBridgeFetch";
+import {
+  __resetStaleFetchRegistryForTests,
+  registerStaleFetch,
+  updateStaleFetch,
+} from "@/lib/staleFetchRegistry";
+
+beforeEach(() => {
+  __resetStaleFetchRegistryForTests();
+});
+
+afterEach(() => {
+  __resetStaleFetchRegistryForTests();
+  vi.useRealTimers();
+});
+
+describe("<StalenessStrip/>", () => {
+  it("does not render when nothing is registered", () => {
+    const { container } = render(<StalenessStrip />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("does not render when a registered fetcher is fresh", () => {
+    const now = Date.now();
+    const unregister = registerStaleFetch({
+      id: "test-fresh",
+      lastSuccessAt: now,
+      staleAfterMs: 3000,
+      refetch: vi.fn(),
+    });
+
+    const { container } = render(<StalenessStrip />);
+    expect(container.firstChild).toBeNull();
+    unregister();
+  });
+
+  it("renders when a registered fetcher goes stale", async () => {
+    vi.useFakeTimers();
+    const base = Date.now();
+    vi.setSystemTime(base);
+
+    const refetch = vi.fn();
+    const unregister = registerStaleFetch({
+      id: "test-stale",
+      lastSuccessAt: base,
+      staleAfterMs: 1000,
+      refetch,
+    });
+
+    const { container } = render(<StalenessStrip />);
+    expect(container.firstChild).toBeNull();
+
+    // Advance system clock + the strip's own poll ticker past the
+    // staleness threshold.
+    await act(async () => {
+      vi.setSystemTime(base + 2000);
+      await vi.advanceTimersByTimeAsync(1500);
+    });
+
+    expect(container.textContent).toMatch(/Data as of/i);
+    expect(container.textContent).toMatch(/reconnecting/i);
+
+    unregister();
+  });
+
+  it("clicking 'Retry now' calls refetch() on stale entries", async () => {
+    vi.useFakeTimers();
+    const base = Date.now();
+    vi.setSystemTime(base);
+
+    const refetch = vi.fn();
+    const unregister = registerStaleFetch({
+      id: "test-retry",
+      lastSuccessAt: base,
+      staleAfterMs: 1000,
+      refetch,
+    });
+
+    const { container, getByRole } = render(<StalenessStrip />);
+
+    await act(async () => {
+      vi.setSystemTime(base + 2000);
+      await vi.advanceTimersByTimeAsync(1500);
+    });
+
+    expect(container.textContent).toMatch(/Data as of/i);
+    const btn = getByRole("button", { name: /retry now/i });
+    await act(async () => {
+      btn.click();
+    });
+    expect(refetch).toHaveBeenCalledTimes(1);
+
+    unregister();
+  });
+
+  it("clears once the stale fetcher records a fresh success", async () => {
+    vi.useFakeTimers();
+    const base = Date.now();
+    vi.setSystemTime(base);
+
+    const unregister = registerStaleFetch({
+      id: "test-recover",
+      lastSuccessAt: base,
+      staleAfterMs: 1000,
+      refetch: vi.fn(),
+    });
+
+    const { container } = render(<StalenessStrip />);
+
+    await act(async () => {
+      vi.setSystemTime(base + 2000);
+      await vi.advanceTimersByTimeAsync(1500);
+    });
+    expect(container.textContent).toMatch(/Data as of/i);
+
+    // Recovery: registry entry records a fresh success.
+    await act(async () => {
+      vi.setSystemTime(base + 3600);
+      updateStaleFetch("test-recover", Date.now());
+      await vi.advanceTimersByTimeAsync(100);
+    });
+
+    expect(container.textContent ?? "").not.toMatch(/reconnecting/i);
+
+    unregister();
+  });
+});
+
+describe("<StalenessStrip/> — integration with a real useBridgeFetch({ trackStaleness: true }) consumer", () => {
+  // Smoke test for the actual end-to-end wiring used on /workers
+  // (workers/page.tsx:1152 sets trackStaleness: true on its primary
+  // shadow-report feed): a component polling via useBridgeFetch, not the
+  // registry API directly. Confirms the hook's registration + the
+  // strip's subscription actually connect, not just each half in
+  // isolation.
+
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  function jsonResponse(body: Record<string, unknown>): Response {
+    return new Response(JSON.stringify(body), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  }
+
+  function PrimaryFeedConsumer() {
+    // Mirrors the real call site's shape (path + intervalMs + trackStaleness).
+    useBridgeFetch<{ ok: boolean }>("/api/bridge/workers/shadow", {
+      intervalMs: 1000,
+      trackStaleness: true,
+    });
+    return null;
+  }
+
+  it("shows the global strip once a real trackStaleness consumer's poll goes quiet, and hides it again once it recovers", async () => {
+    // First poll succeeds; every poll after that hangs (bridge went
+    // unresponsive) — same failure mode the bug report describes.
+    fetchMock.mockResolvedValueOnce(jsonResponse({ ok: true }));
+    fetchMock.mockImplementation(() => new Promise(() => {}));
+
+    const { container } = render(
+      <>
+        <PrimaryFeedConsumer />
+        <StalenessStrip />
+      </>,
+    );
+
+    // Let the first successful tick land.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(50);
+    });
+    expect(container.textContent ?? "").not.toMatch(/reconnecting/i);
+
+    // Advance past 3x intervalMs — the strip should now show the
+    // aggregate staleness signal, driven purely by the hook's own
+    // internal registration (no direct registry calls in this test).
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3 * 1000 + 1500);
+    });
+    expect(container.textContent).toMatch(/Data as of/i);
+    expect(container.textContent).toMatch(/reconnecting/i);
+
+    // Recovery: bridge comes back, next poll succeeds via retry.
+    fetchMock.mockReset();
+    fetchMock.mockResolvedValue(jsonResponse({ ok: true }));
+    await act(async () => {
+      container.querySelector("button")?.dispatchEvent(
+        new MouseEvent("click", { bubbles: true }),
+      );
+      await vi.advanceTimersByTimeAsync(1500);
+    });
+
+    expect(container.textContent ?? "").not.toMatch(/reconnecting/i);
+  });
+});

--- a/dashboard/src/hooks/__tests__/useBridgeFetch.test.tsx
+++ b/dashboard/src/hooks/__tests__/useBridgeFetch.test.tsx
@@ -1,5 +1,5 @@
 /** @vitest-environment jsdom */
-import { renderHook, waitFor } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { useBridgeFetch } from "../useBridgeFetch";
@@ -201,6 +201,7 @@ describe("useBridgeFetch — initial state", () => {
       status: null,
       unsupported: false,
       refetch: expect.any(Function),
+      stale: false,
     });
   });
 });
@@ -213,5 +214,72 @@ describe("useBridgeFetch — cache: no-store (M6)", () => {
     expect(fetchMock).toHaveBeenCalled();
     const [, opts] = fetchMock.mock.calls[0] as [string, RequestInit];
     expect(opts?.cache).toBe("no-store");
+  });
+});
+
+describe("useBridgeFetch — staleness (dashboard-gap-remediation #1)", () => {
+  // Regression coverage for: the hook kept last-good `data` forever when
+  // polling failed, with no signal to the consumer that the data on
+  // screen might be frozen. `stale` flips true once
+  // Date.now() - lastSuccessAt exceeds 3 * intervalMs, and must
+  // re-evaluate over time even if the poll loop itself has stalled
+  // (i.e. no new fetch happening) — so it can't only be computed
+  // inside tick().
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("flips stale=true after 3x intervalMs of no successful fetch, then clears on recovery", async () => {
+    const intervalMs = 1000;
+
+    // First call succeeds; every call after that hangs forever (never
+    // resolves) — simulates the bridge going unresponsive mid-poll.
+    fetchMock.mockResolvedValueOnce(jsonResponse({ count: 1 }));
+    fetchMock.mockImplementation(() => new Promise(() => {}));
+
+    const { result } = renderHook(() =>
+      useBridgeFetch<{ count: number }>("/api/x", {
+        intervalMs,
+        trackStaleness: true,
+      }),
+    );
+
+    // Let the first successful tick land.
+    await vi.waitFor(() => expect(result.current.data).toEqual({ count: 1 }));
+    expect(result.current.stale).toBe(false);
+
+    // Advance past 3x the interval — the poll loop scheduled a next tick
+    // at `intervalMs` which is now hung, so only a staleness re-check
+    // ticker (not a new fetch) can flip `stale` here.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3 * intervalMs + 1500);
+    });
+
+    expect(result.current.stale).toBe(true);
+    // Last-good data must still be shown — staleness is a signal, not a
+    // data-clearing operation.
+    expect(result.current.data).toEqual({ count: 1 });
+
+    // Recovery: a subsequent successful fetch clears `stale` back to false.
+    fetchMock.mockReset();
+    fetchMock.mockResolvedValue(jsonResponse({ count: 2 }));
+    result.current.refetch();
+
+    await vi.waitFor(() => expect(result.current.data).toEqual({ count: 2 }));
+    expect(result.current.stale).toBe(false);
+  });
+
+  it("does not expose staleness tracking unless trackStaleness is set (opt-in)", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ count: 1 }));
+    const { result } = renderHook(() =>
+      useBridgeFetch<{ count: number }>("/api/x", { intervalMs: 1000 }),
+    );
+    await vi.waitFor(() => expect(result.current.data).toEqual({ count: 1 }));
+    expect(result.current.stale).toBe(false);
   });
 });

--- a/dashboard/src/hooks/useBridgeFetch.ts
+++ b/dashboard/src/hooks/useBridgeFetch.ts
@@ -1,6 +1,7 @@
 "use client";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useId, useRef, useState } from "react";
 import { apiPath } from "@/lib/api";
+import { registerStaleFetch, updateStaleFetch } from "@/lib/staleFetchRegistry";
 
 export interface UseBridgeFetchResult<T> {
   data: T | null;
@@ -9,9 +10,25 @@ export interface UseBridgeFetchResult<T> {
   status: number | null;
   unsupported: boolean;
   refetch: () => void;
+  /**
+   * True when it's been more than 3x intervalMs since the last successful
+   * fetch. `data` is never cleared on failure (see tick()'s error
+   * branches), so without this flag a stalled poll loop is
+   * indistinguishable from "nothing is happening" — the dashboard would
+   * silently show frozen numbers. Only meaningful when
+   * `options.trackStaleness` is set; otherwise always false.
+   */
+  stale: boolean;
 }
 
 const MAX_BACKOFF_MS = 30_000;
+/** How far past a successful fetch before we call the data "stale". */
+const STALE_AFTER_INTERVALS = 3;
+/** Cadence of the staleness re-check ticker — cheap re-render trigger,
+ *  NOT a new fetch. Independent of intervalMs so this stays correct even
+ *  if the poll loop itself has stalled entirely (e.g. every scheduled
+ *  tick is awaiting a hung fetch). */
+const STALE_CHECK_MS = 1000;
 
 function nextDelay(failures: number, baseMs: number): number {
   const exp = Math.min(baseMs * 2 ** failures, MAX_BACKOFF_MS);
@@ -26,10 +43,22 @@ export function useBridgeFetch<T>(
     transform?: (data: unknown) => T;
     unsupportedValue?: T | null;
     enabled?: boolean;
+    /**
+     * Opt-in: registers this hook's staleness with the global
+     * staleFetchRegistry (drives Shell's single aggregate strip) and
+     * computes `stale` on the returned result. Off by default — most
+     * `useBridgeFetch` call sites are secondary/background polls (KPI
+     * widgets, outcomes tables, etc.) where flagging global staleness
+     * for a poll nobody's watching would be a false positive. Set this
+     * on the handful of call sites that represent a page's primary,
+     * user-visible data feed.
+     */
+    trackStaleness?: boolean;
   },
 ): UseBridgeFetchResult<T> {
   const intervalMs = options?.intervalMs ?? 5000;
   const enabled = options?.enabled ?? true;
+  const trackStaleness = options?.trackStaleness ?? false;
   const transformRef = useRef(options?.transform);
   transformRef.current = options?.transform;
   // Hold unsupportedValue in a ref so the effect doesn't restart when callers
@@ -47,6 +76,17 @@ export function useBridgeFetch<T>(
   // Caller-triggered re-fetch token; bumping it triggers an immediate tick.
   const [refetchToken, setRefetchToken] = useState(0);
   const refetch = useCallback(() => setRefetchToken((n) => n + 1), []);
+
+  // Epoch ms of the last successful fetch (res.ok + JSON parsed). Read
+  // from a ref so the staleness ticker below can recompute `stale` on its
+  // own cadence without depending on tick()'s closures.
+  const lastSuccessAtRef = useRef<number | null>(null);
+  const [stale, setStale] = useState(false);
+  const staleAfterMs = STALE_AFTER_INTERVALS * intervalMs;
+
+  // Stable per-hook-instance id for the registry.
+  const reactId = useId();
+  const registryId = `${path}#${reactId}`;
 
   useEffect(() => {
     if (!enabled) return;
@@ -117,6 +157,9 @@ export function useBridgeFetch<T>(
         setError(undefined);
         setLoading(false);
         failures = 0;
+        lastSuccessAtRef.current = Date.now();
+        setStale(false);
+        if (trackStaleness) updateStaleFetch(registryId, lastSuccessAtRef.current);
         schedule(intervalMs);
       } catch (e) {
         if (!alive) return;
@@ -137,7 +180,38 @@ export function useBridgeFetch<T>(
       alive = false;
       if (timerId !== null) clearTimeout(timerId);
     };
-  }, [path, intervalMs, enabled, refetchToken]);
+  }, [path, intervalMs, enabled, refetchToken, trackStaleness, registryId]);
 
-  return { data, error, loading, status, unsupported, refetch };
+  // Staleness re-check ticker: recomputes `stale` on a cheap fixed
+  // cadence (no fetch, just a Date.now() comparison) so staleness still
+  // flips even if the poll loop itself has stalled entirely — e.g. every
+  // scheduled tick is awaiting a hung fetch and never reaches a
+  // success/failure branch to reschedule.
+  useEffect(() => {
+    if (!enabled) return;
+    const recompute = () => {
+      const last = lastSuccessAtRef.current;
+      const isStale = last !== null && Date.now() - last > staleAfterMs;
+      setStale(isStale);
+    };
+    recompute();
+    const id = setInterval(recompute, STALE_CHECK_MS);
+    return () => clearInterval(id);
+  }, [enabled, staleAfterMs]);
+
+  // Registry registration: opt-in only. Registers once per mount and
+  // exposes a refetch() so the global staleness strip can retry this
+  // fetcher specifically.
+  useEffect(() => {
+    if (!trackStaleness || !enabled) return;
+    const unregister = registerStaleFetch({
+      id: registryId,
+      lastSuccessAt: lastSuccessAtRef.current,
+      staleAfterMs,
+      refetch,
+    });
+    return unregister;
+  }, [trackStaleness, enabled, registryId, staleAfterMs, refetch]);
+
+  return { data, error, loading, status, unsupported, refetch, stale: trackStaleness ? stale : false };
 }

--- a/dashboard/src/lib/staleFetchRegistry.ts
+++ b/dashboard/src/lib/staleFetchRegistry.ts
@@ -1,0 +1,156 @@
+"use client";
+
+/**
+ * Tiny module-level registry that `useBridgeFetch` instances opt into
+ * (via `options.trackStaleness`) so `Shell` can render ONE aggregate
+ * "data may be stale" strip instead of a banner per page/poll.
+ *
+ * Deliberately not React context: `useBridgeFetch` is called from deep
+ * leaf components on many different pages, and a context provider would
+ * need to wrap the whole app just to carry a handful of numbers that
+ * change on independent timers. A plain subscribable module singleton
+ * is simpler and avoids re-rendering the entire tree on every tick.
+ */
+
+export interface StaleEntry {
+  /** Stable per-hook-instance id, e.g. `${path}#${mountIndex}`. */
+  id: string;
+  /** Epoch ms of the last successful fetch, or null if none yet. */
+  lastSuccessAt: number | null;
+  /** ms since lastSuccessAt after which this entry counts as stale. */
+  staleAfterMs: number;
+  /** Re-runs the underlying hook's fetch immediately. */
+  refetch: () => void;
+}
+
+type Listener = () => void;
+
+const entries = new Map<string, StaleEntry>();
+const listeners = new Set<Listener>();
+
+function notify() {
+  for (const l of listeners) l();
+}
+
+export function registerStaleFetch(entry: StaleEntry): () => void {
+  entries.set(entry.id, entry);
+  notify();
+  return () => {
+    entries.delete(entry.id);
+    notify();
+  };
+}
+
+export function updateStaleFetch(id: string, lastSuccessAt: number | null): void {
+  const existing = entries.get(id);
+  if (!existing) return;
+  existing.lastSuccessAt = lastSuccessAt;
+  notify();
+}
+
+export function subscribeStaleFetchRegistry(listener: Listener): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+export interface StaleFetchSummary {
+  /** True when at least one registered fetcher is currently stale. */
+  anyStale: boolean;
+  /**
+   * Most recent successful fetch across ALL registered fetchers (not
+   * just the stale ones) — this is the freshest timestamp we can
+   * honestly show the user as "data as of".
+   */
+  mostRecentSuccessAt: number | null;
+  /** Retry every currently-stale fetcher. */
+  retryStale: () => void;
+}
+
+export function getStaleFetchSummary(): StaleFetchSummary {
+  const now = Date.now();
+  let anyStale = false;
+  let mostRecentSuccessAt: number | null = null;
+  const staleIds: string[] = [];
+
+  for (const entry of entries.values()) {
+    if (entry.lastSuccessAt !== null) {
+      if (mostRecentSuccessAt === null || entry.lastSuccessAt > mostRecentSuccessAt) {
+        mostRecentSuccessAt = entry.lastSuccessAt;
+      }
+    }
+    const isStale =
+      entry.lastSuccessAt !== null && now - entry.lastSuccessAt > entry.staleAfterMs;
+    if (isStale) {
+      anyStale = true;
+      staleIds.push(entry.id);
+    }
+  }
+
+  return {
+    anyStale,
+    mostRecentSuccessAt,
+    retryStale: () => {
+      for (const id of staleIds) {
+        entries.get(id)?.refetch();
+      }
+    },
+  };
+}
+
+/** Test-only escape hatch to reset module state between test files. */
+export function __resetStaleFetchRegistryForTests(): void {
+  entries.clear();
+  listeners.clear();
+}
+
+// ---------------------------------------------------------------------------
+// useManualPollStaleness
+// ---------------------------------------------------------------------------
+//
+// Some pages' primary data feed predates `useBridgeFetch` and runs its own
+// hand-rolled `useEffect` + `setInterval` poll loop (e.g. runs/page.tsx's
+// filter-driven /api/bridge/runs fetch, page.tsx's Promise.all tick()).
+// Rewriting those loops onto `useBridgeFetch` is out of scope for wiring up
+// staleness — they carry request-cancellation, multi-endpoint fan-out, and
+// filter-dependency behavior `useBridgeFetch` doesn't support. This hook
+// lets them opt into the SAME registry `useBridgeFetch({ trackStaleness })`
+// writes to, by calling `markSuccess()` from inside their existing tick()
+// on every successful poll — no fetch/timer logic duplicated here.
+
+import { useEffect, useId, useRef } from "react";
+
+export function useManualPollStaleness(options: {
+  /** Human-readable key, e.g. "/api/bridge/runs". Combined with a stable
+   *  React id so multiple pages using the same endpoint don't collide. */
+  key: string;
+  /** Same semantics as useBridgeFetch's intervalMs — the poll's normal
+   *  cadence; staleness threshold is 3x this. */
+  intervalMs: number;
+  /** Call to force an immediate reload (wired to the strip's retry). */
+  refetch: () => void;
+  enabled?: boolean;
+}): { markSuccess: () => void } {
+  const { key, intervalMs, refetch, enabled = true } = options;
+  const reactId = useId();
+  const idRef = useRef(`${key}#${reactId}`);
+  const refetchRef = useRef(refetch);
+  refetchRef.current = refetch;
+
+  useEffect(() => {
+    if (!enabled) return;
+    const unregister = registerStaleFetch({
+      id: idRef.current,
+      lastSuccessAt: null,
+      staleAfterMs: 3 * intervalMs,
+      refetch: () => refetchRef.current(),
+    });
+    return unregister;
+  }, [enabled, intervalMs]);
+
+  return {
+    markSuccess: () => {
+      if (!enabled) return;
+      updateStaleFetch(idRef.current, Date.now());
+    },
+  };
+}

--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -26,9 +26,13 @@ Format: `- <date> <branch-or-PR> — <one-line scope> — <session/chat identity
 ## Active
 
 - 2026-07-03 `feat/dashboard-terminal-deck-phase1` (PR #1095, awaiting user visual review before merge) — Terminal+Copilot deck plan PR 6/10: full rewrite of `app/page.tsx` replacing the PR #1085 Command Deck bento with the "Home D · Terminal (dark)" statusline + 7-pane mono grid. Prep sequence PRs 1-5 all merged.
-- 2026-07-03 `docs/gap-assessment-verify-orphans` — dashboard gap remediation task item 0 (verify-first): confirmed all 4 "possible orphan" endpoints flagged in docs/dashboard-gap-assessment-2026-07-03.md (`GET /approval-insights` base, `GET /analytics`, `GET /inbox`+`/inbox/{file}`, `GET /stream`) are real consumers, missed by the original scan because they're hit via `/api/bridge/*`/`/api/inbox` proxy routes and shared hooks (`streamLiveness.ts`, `useBridgeStream`) rather than page-level literal-path fetches. Doc corrected with exact consumer citations. No UI work (per task instruction). — build session
 
 ## Recently closed (informal log, prune periodically)
+
+- 2026-07-03 `fix/dashboard-staleness-indicator` (#1097) — dashboard gap remediation item 1 (bug-shaped, Bug Fix Protocol: failing test first): `useBridgeFetch` kept last-good data forever with no freshness marker. Added `lastSuccessAt` tracking + `stale: boolean` + one global Shell strip aggregating across all opted-in fetchers via a small registry, not per-page banners. No poll-interval changes, no new endpoints. — merged
+- 2026-07-03 `docs/gap-assessment-verify-orphans` (#1096) — dashboard gap remediation item 0 (verify-first): confirmed all 4 "possible orphan" endpoints flagged in docs/dashboard-gap-assessment-2026-07-03.md are real, missed by the original scan (proxy-route/shared-hook consumers). No UI work.
+
+- 2026-07-03 `feat/dashboard-killswitch-confirm` (#1093) — Terminal+Copilot deck plan PR 4/10 (last of the prep sequence): shared confirm dialog for engaging/releasing the kill-switch, wired into `KillSwitchBanner.tsx` and `settings/page.tsx`'s `ToggleRow` — neither had a client-side confirm before. — merged
 
 - 2026-07-03 `feat/decision-record-http-source` (#1094) — Terminal+Copilot deck plan PR 5/10: Decision Record HTTP route (`POST /traces/decision`, Bearer-gated) + optional `source` field on `DecisionTrace`/`RecordDecisionInput`, backward-compatible with existing `decision_traces.jsonl`. Ships standalone value; no dashboard wiring yet. — merged
 - 2026-07-03 `feat/dashboard-shared-hotkey-hook` (#1092) — Terminal+Copilot deck plan PR 3/10: consolidate the 6x-duplicated tag/isContentEditable keyboard-shortcut guard pattern into a shared `usePaneShortcuts`/`useGlobalHotkey` hook in `dashboard/src/hooks/`. Pure refactor, no behavior change. — merged


### PR DESCRIPTION
## Summary
- Dashboard gap remediation, ranked fix #1 from `docs/dashboard-gap-assessment-2026-07-03.md`. Bug-shaped — Bug Fix Protocol followed (failing test first, confirmed failing, then fixed).
- `useBridgeFetch` kept last-good data forever with no indication a poll had stopped succeeding — every polling page could render frozen numbers indistinguishable from "nothing is happening."
- Adds `lastSuccessAt` tracking + `stale: boolean` (true once `now - lastSuccessAt > 3× intervalMs`, re-evaluated on a lightweight independent ticker so it flips even if the poll loop itself has fully stalled). Opt-in via `trackStaleness` — not blanket, since most `useBridgeFetch` calls are secondary widgets, not a page's primary feed.
- One global Shell strip (`StalenessStrip.tsx`, styled to match `BridgeOfflineBanner`), not per-page banners, via a small registry (`staleFetchRegistry.ts`).
- **Wired onto the three pages the gap-assessment doc cites**: `workers/page.tsx`'s shadow-roster feed (real `useBridgeFetch` call), plus `page.tsx` and `runs/page.tsx`'s primary feeds — both of which turned out to be hand-rolled poll loops that predate `useBridgeFetch`, not `useBridgeFetch` calls themselves, so a `useManualPollStaleness` escape hatch was added to let any manual poll register with the same shared registry via one `markSuccess()` call, no fetch/timer logic duplicated.
- No poll intervals changed, no new endpoints added.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `node scripts/check-inline-fontsize.mjs` (baseline unchanged)
- [x] `npx vitest run` (103 files / 1054 tests — includes a hook-to-registry-to-strip integration test, not just isolated unit tests)
- [x] `npm run lint` (zero new warnings)
- [ ] Eyeball both themes at ~375px (asking the user)

🤖 Generated with [Claude Code](https://claude.com/claude-code)