### PR TITLE
feat(dashboard): stop control for live runs

### DIFF
--- a/dashboard/src/app/globals.css
+++ b/dashboard/src/app/globals.css
@@ -882,6 +882,34 @@ button.topbar-search {
 .global-live-runs-strip-overflow:hover {
   color: var(--ink-1);
 }
+.global-live-runs-strip-row-wrap {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  flex-shrink: 0;
+}
+.global-live-runs-strip-stop-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 22px;
+  min-height: 22px;
+  padding: 0 4px;
+  border-radius: 999px;
+  border: 1px solid var(--err, var(--red));
+  background: transparent;
+  color: var(--err, var(--red));
+  font-size: 9px;
+  line-height: 1;
+  cursor: pointer;
+}
+.global-live-runs-strip-stop-btn:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--err, var(--red)) 12%, transparent);
+}
+.global-live-runs-strip-stop-btn:disabled {
+  opacity: 0.5;
+  cursor: wait;
+}
 
 .app-content {
   position: relative;
@@ -2013,6 +2041,13 @@ a.btn { text-decoration: none; }
 
 /* Status pill in table rows — slightly larger than xs */
 .runs-status-pill { font-size: var(--fs-xs); }
+
+/* Stop button next to a running-run's status pill (list rows + mobile cards) */
+.runs-stop-btn {
+  margin-left: 6px;
+  color: var(--err, var(--red));
+  border-color: var(--err, var(--red));
+}
 
 /* Duration cell: bar + text */
 .runs-dur-cell { display: flex; align-items: center; gap: 8px; }
@@ -9387,7 +9422,6 @@ details[open] .traces-detail-arrow { transform: rotate(90deg); }
   outline-offset: 2px;
 }
 
-<<<<<<< HEAD
 /* ── Workers "Roster" (redesign W-A) ─────────────────────────────────────── */
 .wa-head {
   display: flex;

--- a/dashboard/src/app/runs/[seq]/page.tsx
+++ b/dashboard/src/app/runs/[seq]/page.tsx
@@ -9,7 +9,9 @@ import { RecipeChip, RunChip, ToolChip, InboxChip } from "@/components/patchwork
 import { StepDiffHover } from "@/components/StepDiffHover";
 import { Skeleton, SkeletonList } from "@/components/Skeleton";
 import { Dialog } from "@/components/Dialog";
+import { CancelRunDialog } from "@/components/CancelRunDialog";
 import { useBridgeStream } from "@/hooks/useBridgeStream";
+import { useCancelRun } from "@/hooks/useCancelRun";
 import {
   HALT_CATEGORY_HINT,
   type HaltCategory,
@@ -931,6 +933,15 @@ export default function RunDetailPage() {
   const [replayMessage, setReplayMessage] = useState<string>();
   const replayTimeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
 
+  // Stop control for a live run. On success, optimistically flip local
+  // status to "cancelled" — the SSE/poll cycle will confirm shortly after,
+  // but this avoids a beat of stale "running" after the user just stopped it.
+  const cancelRun = useCancelRun((cancelledSeq) => {
+    setRun((prev) =>
+      prev && prev.seq === cancelledSeq ? { ...prev, status: "cancelled" } : prev,
+    );
+  });
+
   // Phase 1A item 8 — surface prior fix decisions for this recipe.
   // `ctxQueryTraces({traceType:"decision", key:recipeName})` is what powers
   // the /decisions and /traces pages; we read the same /api/bridge/traces
@@ -1357,6 +1368,26 @@ export default function RunDetailPage() {
             <span style={{ fontSize: "var(--fs-xs)", color: "var(--ink-3)", marginLeft: 4 }}>
               {fmtTs(run.createdAt)}
             </span>
+            {/* Stop control — only meaningful while the run is live. */}
+            {run.status === "running" && (
+              <button
+                type="button"
+                onClick={() => cancelRun.requestConfirm(run.seq)}
+                disabled={cancelRun.phase === "cancelling"}
+                title="Abort this run's in-progress step immediately."
+                style={{
+                  fontSize: "var(--fs-xs)",
+                  padding: "4px 10px",
+                  borderRadius: "var(--r-1, 4px)",
+                  border: "1px solid var(--err, var(--red))",
+                  background: "transparent",
+                  color: "var(--err, var(--red))",
+                  cursor: cancelRun.phase === "cancelling" ? "wait" : "pointer",
+                }}
+              >
+                {cancelRun.phase === "cancelling" ? "Stopping…" : "Stop"}
+              </button>
+            )}
             {/* VD-4: replay button (mocked-only). Real replay TBD. */}
             {run.status !== "running" && (
               <button
@@ -1442,6 +1473,14 @@ export default function RunDetailPage() {
           </button>
         </div>
       </Dialog>
+
+      <CancelRunDialog
+        open={cancelRun.phase === "confirming"}
+        onClose={cancelRun.dismiss}
+        onConfirm={() => void cancelRun.confirm()}
+        recipeName={run?.recipeName}
+        seq={cancelRun.cancelSeq}
+      />
 
       {runErr && <div className="alert-err" role="alert">Failed to load run: {runErr}</div>}
       {!seqIsValid ? (

--- a/dashboard/src/app/runs/page.tsx
+++ b/dashboard/src/app/runs/page.tsx
@@ -14,6 +14,8 @@ import { ActivityTabs } from "@/components/ActivityTabs";
 import { useDebounced } from "@/hooks/useDebounced";
 import { useBridgeStream } from "@/hooks/useBridgeStream";
 import { usePaneShortcut } from "@/hooks/usePaneShortcuts";
+import { useCancelRun } from "@/hooks/useCancelRun";
+import { CancelRunDialog } from "@/components/CancelRunDialog";
 import { dedupeRunsByKey } from "@/lib/dedupeRuns";
 import { useManualPollStaleness } from "@/lib/staleFetchRegistry";
 
@@ -272,6 +274,18 @@ export default function RunsPage() {
   // effect (and its AbortController + interval) to re-run on every render.
   const markRunsPollSuccessRef = useRef(markRunsPollSuccess);
   markRunsPollSuccessRef.current = markRunsPollSuccess;
+
+  // Stop control for a live run. On success, optimistically patch the
+  // matching row(s) to "cancelled" in local state — a run can appear more
+  // than once if seq collides across a poll/SSE race, so patch by seq
+  // rather than assuming uniqueness.
+  const cancelRun = useCancelRun((seq) => {
+    setRuns((prev) =>
+      prev
+        ? prev.map((r) => (r.seq === seq ? { ...r, status: "cancelled" } : r))
+        : prev,
+    );
+  });
 
   useEffect(() => {
     // Audit 2026-05-17 (#600): one AbortController per effect run,
@@ -923,6 +937,26 @@ export default function RunsPage() {
                           {sClass !== "running" && <span className="pill-dot" />}
                           {sLabel}
                         </span>
+                        {r.status === "running" && (
+                          <button
+                            type="button"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              cancelRun.requestConfirm(r.seq);
+                            }}
+                            disabled={
+                              cancelRun.cancelSeq === r.seq &&
+                              cancelRun.phase === "cancelling"
+                            }
+                            className="btn sm ghost runs-stop-btn"
+                            title={`Stop this run of ${r.recipeName}`}
+                          >
+                            {cancelRun.cancelSeq === r.seq &&
+                            cancelRun.phase === "cancelling"
+                              ? "Stopping…"
+                              : "Stop"}
+                          </button>
+                        )}
                       </td>
                       <td
                         aria-label={`Duration ${
@@ -1104,6 +1138,26 @@ export default function RunsPage() {
                     {sClass !== "running" && <span className="pill-dot" />}
                     {sLabel}
                   </span>
+                  {r.status === "running" && (
+                    <button
+                      type="button"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        cancelRun.requestConfirm(r.seq);
+                      }}
+                      disabled={
+                        cancelRun.cancelSeq === r.seq &&
+                        cancelRun.phase === "cancelling"
+                      }
+                      className="btn sm ghost runs-stop-btn"
+                      title={`Stop this run of ${r.recipeName}`}
+                    >
+                      {cancelRun.cancelSeq === r.seq &&
+                      cancelRun.phase === "cancelling"
+                        ? "Stopping…"
+                        : "Stop"}
+                    </button>
+                  )}
                 </div>
                 <div className="run-card-meta">
                   <span className={`pill ${triggerPillClass(r.trigger)} xs`}>
@@ -1164,6 +1218,13 @@ export default function RunsPage() {
         </div>
         </>
       )}
+      <CancelRunDialog
+        open={cancelRun.phase === "confirming"}
+        onClose={cancelRun.dismiss}
+        onConfirm={() => void cancelRun.confirm()}
+        recipeName={runs?.find((r) => r.seq === cancelRun.cancelSeq)?.recipeName}
+        seq={cancelRun.cancelSeq}
+      />
     </section>
   );
 }

--- a/dashboard/src/components/CancelRunDialog.tsx
+++ b/dashboard/src/components/CancelRunDialog.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { Dialog } from "@/components/Dialog";
+
+/**
+ * Shared confirm-dialog for stopping a running run, used by:
+ *   - LiveRunsStrip (Overview page live-run cards)
+ *   - GlobalLiveRunsStrip (Shell-global strip)
+ *   - /runs list rows
+ *   - /runs/[seq] detail header
+ *
+ * `POST /runs/:seq/cancel` aborts the run's registered AbortController —
+ * a mid-flight interrupt of in-progress (possibly write-tier) work — so a
+ * single accidental click had no confirmation anywhere in the dashboard.
+ * Mirrors `KillSwitchConfirmDialog`'s shape: Cancel is first in DOM order
+ * and not autofocused so Tab/Enter defaults land on the safe action.
+ */
+export interface CancelRunDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+  /** Recipe name / run label shown in the confirm copy. */
+  recipeName?: string;
+  seq?: number | null;
+}
+
+export function CancelRunDialog({
+  open,
+  onClose,
+  onConfirm,
+  recipeName,
+  seq,
+}: CancelRunDialogProps) {
+  const label = recipeName
+    ? `${recipeName}${seq != null ? ` (#${seq})` : ""}`
+    : seq != null
+      ? `run #${seq}`
+      : "this run";
+
+  return (
+    <Dialog open={open} onClose={onClose} ariaLabel="Stop this run?">
+      <h2
+        style={{
+          margin: 0,
+          marginBottom: "var(--s-3)",
+          fontSize: "var(--fs-l)",
+          color: "var(--ink-0)",
+        }}
+      >
+        Stop this run?
+      </h2>
+      <p
+        style={{
+          margin: 0,
+          marginBottom: "var(--s-5)",
+          fontSize: "var(--fs-s)",
+          color: "var(--ink-2)",
+          lineHeight: 1.5,
+        }}
+      >
+        This interrupts <strong>{label}</strong> mid-flight — any step in
+        progress is aborted immediately. Steps already completed are not
+        undone.
+      </p>
+      <div
+        style={{
+          display: "flex",
+          gap: "var(--s-2)",
+          justifyContent: "flex-end",
+        }}
+      >
+        <button type="button" className="btn sm ghost" onClick={onClose}>
+          Keep running
+        </button>
+        <button
+          type="button"
+          className="btn sm primary"
+          onClick={() => {
+            onClose();
+            onConfirm();
+          }}
+        >
+          Stop run
+        </button>
+      </div>
+    </Dialog>
+  );
+}

--- a/dashboard/src/components/GlobalLiveRunsStrip.tsx
+++ b/dashboard/src/components/GlobalLiveRunsStrip.tsx
@@ -3,6 +3,8 @@ import Link from "next/link";
 import { useEffect, useRef, useState } from "react";
 import { useActiveRuns } from "@/hooks/LiveRunsContext";
 import { StatusPill } from "@/components/patchwork";
+import { useCancelRun } from "@/hooks/useCancelRun";
+import { CancelRunDialog } from "@/components/CancelRunDialog";
 
 /**
  * Always-on global "what's running now" strip. Mounted in Shell so it
@@ -48,6 +50,14 @@ function transitionKey(
 
 export function GlobalLiveRunsStrip() {
   const runs = useActiveRuns();
+  // Optimistic local override — this store is entirely SSE-driven with no
+  // client-side setter, so a just-cancelled run would otherwise still show
+  // "running" until the bridge's recipe_done event arrives. Tracked by
+  // runSeq since that's the stable identity `POST /runs/:seq/cancel` uses.
+  const [cancelledSeqs, setCancelledSeqs] = useState<Set<number>>(new Set());
+  const cancelRun = useCancelRun((seq) => {
+    setCancelledSeqs((prev) => new Set(prev).add(seq));
+  });
   // Order: running first, then most recent terminal first.
   const all = Array.from(runs.values()).sort((a, b) => {
     if (a.status === "running" && b.status !== "running") return -1;
@@ -100,8 +110,14 @@ export function GlobalLiveRunsStrip() {
         // unique per-run seq with an index fallback — mirrors LiveRunsStrip.
         const rowKey =
           r.runSeq && r.runSeq > 0 ? `run-${r.runSeq}` : `${r.recipeName}-${i}`;
-        const label =
-          r.status === "running"
+        const isCancelled = r.runSeq > 0 && cancelledSeqs.has(r.runSeq);
+        const status = isCancelled ? "error" : r.status;
+        const isLive = !isCancelled && r.status === "running";
+        const isStopping =
+          r.runSeq > 0 && cancelRun.cancelSeq === r.runSeq && cancelRun.phase === "cancelling";
+        const label = isCancelled
+          ? "Cancelled"
+          : r.status === "running"
             ? r.totalSteps > 0
               ? `Step ${r.doneSteps}/${r.totalSteps}`
               : "Running"
@@ -114,26 +130,42 @@ export function GlobalLiveRunsStrip() {
         const inner = (
           <>
             <span className="global-live-runs-strip-name">{r.recipeName}</span>
-            <StatusPill tone={tone(r.status)}>{label}</StatusPill>
-            {r.status === "running" && r.totalSteps > 0 && (
+            <StatusPill tone={tone(status)}>{label}</StatusPill>
+            {isLive && r.totalSteps > 0 && (
               <span className="global-live-runs-strip-bar" aria-label={`Progress ${p}%`}>
                 <span style={{ width: `${p}%` }} />
               </span>
             )}
           </>
         );
-        return href ? (
-          <Link
-            key={rowKey}
-            href={href}
-            className="global-live-runs-strip-row"
-            title={`Open run #${r.runSeq}`}
-          >
-            {inner}
-          </Link>
-        ) : (
-          <span key={rowKey} className="global-live-runs-strip-row">
-            {inner}
+        return (
+          <span key={rowKey} className="global-live-runs-strip-row-wrap">
+            {href ? (
+              <Link
+                href={href}
+                className="global-live-runs-strip-row"
+                title={`Open run #${r.runSeq}`}
+              >
+                {inner}
+              </Link>
+            ) : (
+              <span className="global-live-runs-strip-row">{inner}</span>
+            )}
+            {isLive && r.runSeq > 0 && (
+              <button
+                type="button"
+                onClick={(ev) => {
+                  ev.preventDefault();
+                  ev.stopPropagation();
+                  cancelRun.requestConfirm(r.runSeq);
+                }}
+                disabled={isStopping}
+                className="global-live-runs-strip-stop-btn"
+                title={`Stop ${r.recipeName}`}
+              >
+                {isStopping ? "stopping…" : "■"}
+              </button>
+            )}
           </span>
         );
       })}
@@ -142,6 +174,13 @@ export function GlobalLiveRunsStrip() {
           +{overflow} more
         </Link>
       )}
+      <CancelRunDialog
+        open={cancelRun.phase === "confirming"}
+        onClose={cancelRun.dismiss}
+        onConfirm={() => void cancelRun.confirm()}
+        recipeName={all.find((r) => r.runSeq === cancelRun.cancelSeq)?.recipeName}
+        seq={cancelRun.cancelSeq}
+      />
     </div>
   );
 }

--- a/dashboard/src/components/LiveRunsStrip.tsx
+++ b/dashboard/src/components/LiveRunsStrip.tsx
@@ -1,9 +1,12 @@
 "use client";
 
 import Link from "next/link";
+import { useState } from "react";
 import { LivePill, StatusPill } from "@/components/patchwork";
 import { relTime } from "@/components/time";
 import { useRunRecipe } from "@/hooks/useRunRecipe";
+import { useCancelRun } from "@/hooks/useCancelRun";
+import { CancelRunDialog } from "@/components/CancelRunDialog";
 
 /**
  * Horizontal "what's running now" strip for the Overview page. Renders
@@ -63,6 +66,14 @@ export function LiveRunsStrip({
   limit = 5,
 }: LiveRunsStripProps) {
   const { run, pending } = useRunRecipe();
+  // Optimistic local override — the `runs` prop is fetched by the parent
+  // (Overview page) on its own poll cadence, so a just-cancelled run would
+  // otherwise still render "running" until that poll catches up. Tracked
+  // by seq since that's the stable identity `POST /runs/:seq/cancel` uses.
+  const [cancelledSeqs, setCancelledSeqs] = useState<Set<number>>(new Set());
+  const cancelRun = useCancelRun((seq) => {
+    setCancelledSeqs((prev) => new Set(prev).add(seq));
+  });
   const now = Date.now();
   const visible = runs
     .filter((r) => {
@@ -83,8 +94,13 @@ export function LiveRunsStrip({
     <section aria-label="Live and recent recipe runs" className="live-runs-strip">
       {visible.map((r, i) => {
         const name = recipeNameOf(r);
-        const tone = statusTone(r.status);
-        const isLive = r.status === "running";
+        // Local optimistic override wins over the prop's (possibly stale)
+        // status until the next parent poll confirms the cancellation.
+        const isCancelled = r.seq != null && cancelledSeqs.has(r.seq);
+        const status = isCancelled ? "cancelled" : r.status;
+        const tone = statusTone(status);
+        const isLive = !isCancelled && r.status === "running";
+        const isStopping = r.seq != null && cancelRun.cancelSeq === r.seq && cancelRun.phase === "cancelling";
         const elapsed = isLive
           ? fmtElapsed(now - r.startedAt)
           : r.durationMs
@@ -104,7 +120,7 @@ export function LiveRunsStrip({
             title={
               r.haltReason
                 ? `Halt: ${r.haltReason}`
-                : `${name} · ${r.status} · ${isLive ? "started" : "finished"} ${relTime(isLive ? r.startedAt : r.doneAt ?? r.startedAt)}`
+                : `${name} · ${status} · ${isLive ? "started" : "finished"} ${relTime(isLive ? r.startedAt : r.doneAt ?? r.startedAt)}`
             }
           >
             <Link href={href} className="lrc-link">
@@ -112,7 +128,7 @@ export function LiveRunsStrip({
                 {isLive ? (
                   <LivePill label={elapsed} tone="accent" />
                 ) : (
-                  <StatusPill tone={tone}>{r.status}</StatusPill>
+                  <StatusPill tone={tone}>{status}</StatusPill>
                 )}
                 <span className="lrc-name">{name}</span>
               </div>
@@ -127,6 +143,22 @@ export function LiveRunsStrip({
                 )}
               </div>
             </Link>
+            {isLive && r.seq != null && (
+              <button
+                type="button"
+                onClick={(ev) => {
+                  ev.preventDefault();
+                  ev.stopPropagation();
+                  cancelRun.requestConfirm(r.seq as number);
+                }}
+                disabled={isStopping}
+                className="live-run-rerun-btn"
+                data-tone="err"
+                title={`Stop ${name}`}
+              >
+                {isStopping ? "stopping…" : "■ Stop"}
+              </button>
+            )}
             {showRerun && (
               <button
                 type="button"
@@ -146,6 +178,16 @@ export function LiveRunsStrip({
           </div>
         );
       })}
+      <CancelRunDialog
+        open={cancelRun.phase === "confirming"}
+        onClose={cancelRun.dismiss}
+        onConfirm={() => void cancelRun.confirm()}
+        recipeName={
+          runs.find((r) => r.seq === cancelRun.cancelSeq)?.recipeName ??
+          runs.find((r) => r.seq === cancelRun.cancelSeq)?.recipe
+        }
+        seq={cancelRun.cancelSeq}
+      />
     </section>
   );
 }

--- a/dashboard/src/components/__tests__/GlobalLiveRunsStrip.test.tsx
+++ b/dashboard/src/components/__tests__/GlobalLiveRunsStrip.test.tsx
@@ -15,7 +15,8 @@
  * runSeq, then assert React never warns about duplicate keys.
  */
 
-import { render } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ActiveRunState } from "@/hooks/useRecipeRunStream";
 
@@ -50,6 +51,7 @@ describe("<GlobalLiveRunsStrip/>", () => {
   afterEach(() => {
     errorSpy.mockRestore();
     mockRuns.mockReset();
+    vi.unstubAllGlobals();
   });
 
   it("does not warn about duplicate keys when one recipe has multiple runs", () => {
@@ -85,5 +87,81 @@ describe("<GlobalLiveRunsStrip/>", () => {
     // Both runs have runSeq > 0 → both render as <Link> to /runs/<seq>.
     expect(container.querySelector('a[href="/runs/201"]')).not.toBeNull();
     expect(container.querySelector('a[href="/runs/202"]')).not.toBeNull();
+  });
+
+  describe("Stop control", () => {
+    function seedOneRunningRow() {
+      const m = new Map<string, ActiveRunState>();
+      m.set("r#1", run({ recipeName: "r", runSeq: 301, status: "running" }));
+      mockRuns.mockReturnValue(m);
+    }
+
+    it("shows a Stop button only for the running row and opens a confirm dialog", async () => {
+      seedOneRunningRow();
+      const fetchMock = vi.fn();
+      vi.stubGlobal("fetch", fetchMock);
+      const user = userEvent.setup();
+      render(<GlobalLiveRunsStrip />);
+
+      const stopBtn = screen.getByTitle("Stop r");
+      expect(stopBtn).toBeInTheDocument();
+      expect(fetchMock).not.toHaveBeenCalled();
+
+      await user.click(stopBtn);
+
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+      expect(screen.getByText("Stop this run?")).toBeInTheDocument();
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it("confirming calls POST /api/bridge/runs/:seq/cancel and shows Cancelled on success", async () => {
+      seedOneRunningRow();
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ cancelled: true, seq: 301 }),
+      });
+      vi.stubGlobal("fetch", fetchMock);
+      const user = userEvent.setup();
+      render(<GlobalLiveRunsStrip />);
+
+      await user.click(screen.getByTitle("Stop r"));
+      await user.click(screen.getByRole("button", { name: "Stop run" }));
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+      expect(url).toContain("/api/bridge/runs/301/cancel");
+      expect(init.method).toBe("POST");
+
+      await waitFor(() => {
+        expect(screen.getByText("Cancelled")).toBeInTheDocument();
+      });
+      // Optimistic override also hides the Stop button for that row.
+      expect(screen.queryByTitle("Stop r")).not.toBeInTheDocument();
+    });
+
+    it("reverts to running on failure", async () => {
+      seedOneRunningRow();
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+        json: async () => ({ cancelled: false, seq: 301 }),
+      });
+      vi.stubGlobal("fetch", fetchMock);
+      const user = userEvent.setup();
+      render(<GlobalLiveRunsStrip />);
+
+      await user.click(screen.getByTitle("Stop r"));
+      await user.click(screen.getByRole("button", { name: "Stop run" }));
+
+      await waitFor(() => {
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+      });
+      // Row still shows the live status, Stop button still present/enabled.
+      await waitFor(() => {
+        const stopBtn = screen.getByTitle("Stop r");
+        expect(stopBtn).not.toBeDisabled();
+      });
+      expect(screen.queryByText("Cancelled")).not.toBeInTheDocument();
+    });
   });
 });

--- a/dashboard/src/components/__tests__/LiveRunsStrip.test.tsx
+++ b/dashboard/src/components/__tests__/LiveRunsStrip.test.tsx
@@ -1,0 +1,98 @@
+/**
+ * Coverage for the Stop control on <LiveRunsStrip/> — the Overview page's
+ * "what's running now" strip (embedded directly in app/page.tsx, not via
+ * GlobalLiveRunsStrip). Confirms the running -> cancelling -> cancelled
+ * happy path and the failure-reverts-to-running path, gated behind the
+ * shared CancelRunDialog confirm step.
+ */
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { LiveRunsStrip, type LiveRun } from "@/components/LiveRunsStrip";
+
+function baseRun(partial: Partial<LiveRun>): LiveRun {
+  return {
+    seq: 501,
+    recipe: "nightly-review",
+    recipeName: "nightly-review",
+    startedAt: Date.now() - 5000,
+    status: "running",
+    ...partial,
+  };
+}
+
+describe("<LiveRunsStrip/> Stop control", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("shows a Stop button for a live run and opens a confirm dialog first", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const user = userEvent.setup();
+    render(<LiveRunsStrip runs={[baseRun({})]} />);
+
+    const stopBtn = screen.getByTitle("Stop nightly-review");
+    expect(stopBtn).toBeInTheDocument();
+
+    await user.click(stopBtn);
+
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByText("Stop this run?")).toBeInTheDocument();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("does not render a Stop button for a finished run", () => {
+    render(
+      <LiveRunsStrip
+        runs={[baseRun({ status: "done", doneAt: Date.now(), durationMs: 1200 })]}
+      />,
+    );
+    expect(screen.queryByTitle("Stop nightly-review")).not.toBeInTheDocument();
+  });
+
+  it("confirming calls POST /api/bridge/runs/:seq/cancel and flips the row to cancelled", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ cancelled: true, seq: 501 }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const user = userEvent.setup();
+    render(<LiveRunsStrip runs={[baseRun({})]} />);
+
+    await user.click(screen.getByTitle("Stop nightly-review"));
+    await user.click(screen.getByRole("button", { name: "Stop run" }));
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain("/api/bridge/runs/501/cancel");
+    expect(init.method).toBe("POST");
+
+    await waitFor(() => {
+      expect(screen.getByText("cancelled")).toBeInTheDocument();
+    });
+    expect(screen.queryByTitle("Stop nightly-review")).not.toBeInTheDocument();
+  });
+
+  it("reverts to running and keeps the Stop button on failure", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: async () => ({}),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const user = userEvent.setup();
+    render(<LiveRunsStrip runs={[baseRun({})]} />);
+
+    await user.click(screen.getByTitle("Stop nightly-review"));
+    await user.click(screen.getByRole("button", { name: "Stop run" }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+    await waitFor(() => {
+      expect(screen.getByTitle("Stop nightly-review")).not.toBeDisabled();
+    });
+    expect(screen.queryByText("cancelled")).not.toBeInTheDocument();
+  });
+});

--- a/dashboard/src/hooks/__tests__/useCancelRun.test.tsx
+++ b/dashboard/src/hooks/__tests__/useCancelRun.test.tsx
@@ -1,0 +1,131 @@
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useCancelRun } from "@/hooks/useCancelRun";
+
+/**
+ * Unit coverage for the shared cancel-run flow used by GlobalLiveRunsStrip,
+ * LiveRunsStrip, /runs, and /runs/[seq]. Exercises the phase state machine
+ * (idle → confirming → cancelling → idle) and the two outcomes of
+ * `POST /api/bridge/runs/:seq/cancel`.
+ */
+describe("useCancelRun", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("starts idle and moves to confirming on requestConfirm", () => {
+    const { result } = renderHook(() => useCancelRun());
+    expect(result.current.phase).toBe("idle");
+    expect(result.current.cancelSeq).toBeNull();
+
+    act(() => {
+      result.current.requestConfirm(42);
+    });
+
+    expect(result.current.phase).toBe("confirming");
+    expect(result.current.cancelSeq).toBe(42);
+  });
+
+  it("dismiss returns to idle without calling the API", () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const { result } = renderHook(() => useCancelRun());
+
+    act(() => {
+      result.current.requestConfirm(7);
+    });
+    act(() => {
+      result.current.dismiss();
+    });
+
+    expect(result.current.phase).toBe("idle");
+    expect(result.current.cancelSeq).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("confirm: running -> cancelling -> idle, calls onCancelled on success", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ cancelled: true, seq: 9 }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const onCancelled = vi.fn();
+    const { result } = renderHook(() => useCancelRun(onCancelled));
+
+    act(() => {
+      result.current.requestConfirm(9);
+    });
+
+    let confirmPromise: Promise<void>;
+    act(() => {
+      confirmPromise = result.current.confirm();
+    });
+    // Phase flips to "cancelling" synchronously before the await resolves.
+    expect(result.current.phase).toBe("cancelling");
+
+    await act(async () => {
+      await confirmPromise;
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain("/api/bridge/runs/9/cancel");
+    expect(init.method).toBe("POST");
+
+    expect(result.current.phase).toBe("idle");
+    expect(result.current.cancelSeq).toBeNull();
+    expect(onCancelled).toHaveBeenCalledWith(9);
+  });
+
+  it("confirm: reverts to idle (running-equivalent) on 404 and does not call onCancelled", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 404,
+      json: async () => ({ cancelled: false, seq: 9 }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const onCancelled = vi.fn();
+    const { result } = renderHook(() => useCancelRun(onCancelled));
+
+    act(() => {
+      result.current.requestConfirm(9);
+    });
+    await act(async () => {
+      await result.current.confirm();
+    });
+
+    await waitFor(() => {
+      expect(result.current.phase).toBe("idle");
+    });
+    expect(onCancelled).not.toHaveBeenCalled();
+  });
+
+  it("confirm: reverts to idle on network error and does not call onCancelled", async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new Error("network down"));
+    vi.stubGlobal("fetch", fetchMock);
+    const onCancelled = vi.fn();
+    const { result } = renderHook(() => useCancelRun(onCancelled));
+
+    act(() => {
+      result.current.requestConfirm(9);
+    });
+    await act(async () => {
+      await result.current.confirm();
+    });
+
+    expect(result.current.phase).toBe("idle");
+    expect(onCancelled).not.toHaveBeenCalled();
+  });
+
+  it("confirm is a no-op when no seq is pending", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const { result } = renderHook(() => useCancelRun());
+
+    await act(async () => {
+      await result.current.confirm();
+    });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/dashboard/src/hooks/useCancelRun.ts
+++ b/dashboard/src/hooks/useCancelRun.ts
@@ -1,0 +1,96 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { apiPath } from "@/lib/api";
+import { useToast } from "@/components/Toast";
+
+export type CancelRunPhase = "idle" | "confirming" | "cancelling";
+
+interface CancelRunResponse {
+  cancelled: boolean;
+  seq: number;
+}
+
+/**
+ * Shared "Stop a running run" flow — wraps `POST /api/bridge/runs/:seq/cancel`
+ * (proxies the bridge's `POST /runs/:seq/cancel`, which aborts the run's
+ * registered AbortController; 200 `{cancelled:true}` when a live run was
+ * found, 404 `{cancelled:false}` otherwise).
+ *
+ * Mid-flight interrupt is destructive-ish (stops in-progress work), so the
+ * call site is expected to gate the actual `cancel()` invocation behind a
+ * confirm dialog — this hook exposes `phase` (idle → confirming →
+ * cancelling → idle) so a single call site can drive both the confirm
+ * dialog's `open` state and the button's disabled/label state from one
+ * source of truth, mirroring the inline confirm state machines already
+ * used for kill-switch and replay on this page.
+ *
+ * Keyed per-run (not global) via the `seq` passed to each call, so
+ * multiple live-run rows can each carry independent phase without
+ * colliding — callers track "which seq is this hook instance for"
+ * themselves (one hook instance per row, or store seq alongside phase).
+ *
+ * On success, calls the optional `onCancelled(seq)` callback so the call
+ * site can optimistically flip its local run/row state to "cancelled"
+ * without waiting on the next poll / SSE tick. On failure, phase reverts
+ * to "idle" (the caller's row should fall back to rendering "running")
+ * and a toast reports the error.
+ */
+export function useCancelRun(onCancelled?: (seq: number) => void) {
+  const toast = useToast();
+  const [phase, setPhase] = useState<CancelRunPhase>("idle");
+  const [seq, setSeq] = useState<number | null>(null);
+
+  const requestConfirm = useCallback((targetSeq: number) => {
+    setSeq(targetSeq);
+    setPhase("confirming");
+  }, []);
+
+  const dismiss = useCallback(() => {
+    setPhase("idle");
+    setSeq(null);
+  }, []);
+
+  const confirm = useCallback(async () => {
+    if (seq == null) return;
+    const targetSeq = seq;
+    setPhase("cancelling");
+    try {
+      const res = await fetch(apiPath(`/api/bridge/runs/${targetSeq}/cancel`), {
+        method: "POST",
+      });
+      const data = (await res.json().catch(() => ({}))) as Partial<CancelRunResponse>;
+      if (res.ok && data.cancelled) {
+        setPhase("idle");
+        setSeq(null);
+        onCancelled?.(targetSeq);
+        return;
+      }
+      toast.error(
+        res.status === 404
+          ? `Run #${targetSeq} is no longer running — nothing to stop.`
+          : `Couldn't stop run #${targetSeq}: HTTP ${res.status}`,
+      );
+      setPhase("idle");
+      setSeq(null);
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      toast.error(`Couldn't stop run #${targetSeq}: ${msg}`);
+      setPhase("idle");
+      setSeq(null);
+    }
+  }, [seq, onCancelled, toast]);
+
+  return {
+    /** Current lifecycle phase of the (at most one) in-flight cancel flow. */
+    phase,
+    /** The seq currently being confirmed/cancelled, if any. */
+    cancelSeq: seq,
+    /** Open the confirm dialog for the given run. */
+    requestConfirm,
+    /** Close the confirm dialog without cancelling. */
+    dismiss,
+    /** Confirm the pending cancel — fires the request. */
+    confirm,
+  };
+}

--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -26,11 +26,11 @@ Format: `- <date> <branch-or-PR> — <one-line scope> — <session/chat identity
 ## Active
 
 - 2026-07-03 `feat/dashboard-terminal-deck-phase1` (PR #1095, awaiting user visual review before merge) — Terminal+Copilot deck plan PR 6/10: full rewrite of `app/page.tsx` replacing the PR #1085 Command Deck bento with the "Home D · Terminal (dark)" statusline + 7-pane mono grid. Prep sequence PRs 1-5 all merged.
-- 2026-07-03 `feat/connector-token-expiry` (PR #1098) — dashboard gap remediation item 2: connector `getStatus()`/`/connections` HTTP response gets optional `tokenExpiresAt`/`lastSuccessAt` (PAT connectors without expiry return neither, never guess); connections card renders "expires in Nd" (amber <7d, red+reauthorize once expired) + "last call ✓ Nh ago". Bridge-side change — needs snapshotting to `../patchwork-multitenant/src/` per repo policy (flagged in PR, not done by the agent).
 - 2026-07-04 `feat/run-cancel-ui` (PR #1099) — dashboard gap remediation item 4: `POST /runs/:seq/cancel` had zero dashboard consumers. Stop control + confirm dialog wired into GlobalLiveRunsStrip, LiveRunsStrip, /runs list rows, /runs/[seq] header.
 
 ## Recently closed (informal log, prune periodically)
 
+- 2026-07-03 `feat/connector-token-expiry` (#1098) — dashboard gap remediation item 2: connector `getStatus()`/`/connections` gets optional `tokenExpiresAt`/`lastSuccessAt`; connections card renders expiry pill + last-call line. Bridge-side — needs snapshotting to `../patchwork-multitenant/src/`. — merged
 - 2026-07-03 `fix/dashboard-staleness-indicator` (#1097) — dashboard gap remediation item 1 (bug-shaped, Bug Fix Protocol: failing test first): `useBridgeFetch` kept last-good data forever with no freshness marker. Added `lastSuccessAt` tracking + `stale: boolean` + one global Shell strip aggregating across all opted-in fetchers via a small registry, not per-page banners. No poll-interval changes, no new endpoints. — merged
 - 2026-07-03 `docs/gap-assessment-verify-orphans` (#1096) — dashboard gap remediation item 0 (verify-first): confirmed all 4 "possible orphan" endpoints flagged in docs/dashboard-gap-assessment-2026-07-03.md are real, missed by the original scan (proxy-route/shared-hook consumers). No UI work. — merged
 - 2026-07-03 `feat/dashboard-killswitch-confirm` (#1093) — Terminal+Copilot deck plan PR 4/10 (last of the prep sequence): shared confirm dialog for engaging/releasing the kill-switch, wired into `KillSwitchBanner.tsx` and `settings/page.tsx`'s `ToggleRow` — neither had a client-side confirm before. — merged


### PR DESCRIPTION
## Summary
- Dashboard gap remediation item 4. `POST /runs/:seq/cancel` existed bridge-side with zero dashboard consumers — the dashboard could retry a finished run but never stop one mid-flight.
- New shared `useCancelRun` hook (confirming → cancelling → idle state machine, error-toast + revert on failure) + `CancelRunDialog` (mirrors `KillSwitchConfirmDialog`'s safe-action-first shape) wired into every site a running run renders: `GlobalLiveRunsStrip` (Shell-global, SSE-fed), `LiveRunsStrip` (Overview page — did NOT need to touch `app/page.tsx` itself, it just embeds this component, confirmed via investigation), `/runs` list rows (desktop + mobile), and `/runs/[seq]`'s sticky header.
- Optimistic local overrides where the parent store has no client setter (`GlobalLiveRunsStrip`'s SSE-only store), functional `setState` patches elsewhere.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `node scripts/check-inline-fontsize.mjs` (baseline unchanged)
- [x] `npx vitest run` (104 files / 1059 tests — 13 new tests across hook + both strip components)
- [x] `npm run lint` (zero new warnings, verified via git-stash diff that the one remaining warning pre-dates this change)
- [ ] Eyeball both themes at ~375px (asking the user)

🤖 Generated with [Claude Code](https://claude.com/claude-code)