### PR TITLE
feat(dashboard): terminal deck v2 Phase 2 — gate-activity feed in 4:workers

### DIFF
--- a/dashboard/src/app/__tests__/page.test.tsx
+++ b/dashboard/src/app/__tests__/page.test.tsx
@@ -62,7 +62,24 @@ const HEALTHY_ROUTES: Record<string, () => Response> = {
   "/api/bridge/runs": () => jsonResponse({ runs: [] }),
   "/api/bridge/workers/shadow": () =>
     jsonResponse({ workers: [], runsScanned: 0, decisionsScanned: 0 }),
+  "/api/bridge/gate/decisions": () => jsonResponse({ decisions: [] }),
   "/api/inbox": () => jsonResponse({ items: [] }),
+};
+
+const SAMPLE_GATE_DECISION = {
+  seq: 42,
+  decidedAt: Date.UTC(2026, 5, 3, 7, 43),
+  workerId: "test-guardian",
+  toolName: "githubCreateIssue",
+  classKey: "issue:compensable:high",
+  action: "gate",
+  owned: true,
+  earnedLevel: 1,
+  autonomyCeiling: 3,
+  effectiveLevel: 1,
+  reason: "earned trust (L1) below the compensable-action threshold (L2)",
+  recipeName: "triage-failing-tests",
+  gatePolicyVersion: "v1",
 };
 
 describe("<HomePage/> — Terminal deck", () => {
@@ -154,5 +171,80 @@ describe("<HomePage/> — Terminal deck", () => {
     await waitFor(() => {
       expect(fleetPane.className).toMatch(/td-pane-active/);
     });
+  });
+
+  it("renders gate-activity entries in the workers pane (Decision Record feed)", async () => {
+    mockFetchRoutes({
+      ...HEALTHY_ROUTES,
+      "/api/bridge/gate/decisions": () =>
+        jsonResponse({ decisions: [SAMPLE_GATE_DECISION] }),
+    });
+    render(<HomePage />);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(50);
+    });
+
+    const workersPane = screen.getByRole("region", { name: "workers" });
+    expect(workersPane.textContent).toMatch(/GATE/);
+    expect(workersPane.textContent).toMatch(/test-guardian/);
+    expect(workersPane.textContent).toMatch(/issue:compensable:high/);
+    // effectiveLevel 1 → "asks first" per the shared level-phrase vocabulary.
+    expect(workersPane.textContent).toMatch(/asks first/);
+  });
+
+  it("expands a gate-activity row to show the plain-English explain rendering", async () => {
+    mockFetchRoutes({
+      ...HEALTHY_ROUTES,
+      "/api/bridge/gate/decisions": () =>
+        jsonResponse({ decisions: [SAMPLE_GATE_DECISION] }),
+    });
+    render(<HomePage />);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(50);
+    });
+
+    const row = screen.getByRole("button", { expanded: false });
+    await act(async () => {
+      row.click();
+    });
+
+    await waitFor(() => {
+      expect(row.getAttribute("aria-expanded")).toBe("true");
+    });
+    const workersPane = screen.getByRole("region", { name: "workers" });
+    expect(workersPane.textContent).toMatch(/earned L1/);
+    expect(workersPane.textContent).toMatch(/autonomy ceiling L3/);
+    expect(workersPane.textContent).toMatch(
+      /earned trust \(L1\) below the compensable-action threshold \(L2\)/,
+    );
+  });
+
+  it("fails soft when /gate/decisions is empty or errors", async () => {
+    mockFetchRoutes({
+      ...HEALTHY_ROUTES,
+      "/api/bridge/gate/decisions": () => jsonResponse({ decisions: [] }),
+    });
+    const { unmount } = render(<HomePage />);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(50);
+    });
+    let workersPane = screen.getByRole("region", { name: "workers" });
+    expect(workersPane.textContent).toMatch(/no gate decisions yet/i);
+    unmount();
+
+    mockFetchRoutes({
+      ...HEALTHY_ROUTES,
+      "/api/bridge/gate/decisions": () => jsonResponse({ error: "boom" }, 500),
+    });
+    render(<HomePage />);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(50);
+    });
+    workersPane = screen.getByRole("region", { name: "workers" });
+    expect(workersPane.textContent).toMatch(/gate activity unavailable/i);
+    // Rest of the pane (worker trust rows) still renders — fail-soft.
+    expect(workersPane.textContent).toMatch(/no worker activity yet/i);
   });
 });

--- a/dashboard/src/app/globals.css
+++ b/dashboard/src/app/globals.css
@@ -9813,6 +9813,38 @@ details[open] .traces-detail-arrow { transform: rotate(90deg); }
 [data-theme="paper"] .td-worker-status-climbing { color: var(--warn-text); }
 [data-theme="paper"] .td-worker-status-reversible { color: var(--ink-3); }
 
+/* Pane 4: workers — gate activity feed (Decision Record, GET /gate/decisions) */
+.td-gate-activity { margin-top: 8px; padding-top: 6px; border-top: 1px solid var(--line-1); }
+.td-gate-activity-title { font-size: var(--fs-xs); margin-bottom: 4px; text-transform: uppercase; letter-spacing: 0.04em; }
+.td-gate-row-wrap { display: flex; flex-direction: column; }
+.td-gate-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: var(--fs-xs);
+  font-family: inherit;
+  background: none;
+  border: none;
+  padding: 2px 0;
+  color: inherit;
+  cursor: pointer;
+  text-align: left;
+  width: 100%;
+}
+.td-gate-row:hover { opacity: 0.85; }
+.td-gate-verb { color: #e0b054; }
+[data-theme="paper"] .td-gate-verb { color: var(--warn-text); }
+.td-gate-arrow { opacity: 0.6; }
+.td-gate-explain {
+  font-size: var(--fs-xs);
+  color: var(--terminal-comment);
+  padding: 4px 0 6px 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+[data-theme="paper"] .td-gate-explain { color: var(--ink-3); }
+
 /* Pane 5: vitals */
 .td-kv-row { display: flex; justify-content: space-between; font-size: var(--fs-xs); padding: 3px 0; border-top: 1px solid var(--line-1); }
 .td-kv-row:first-of-type { border-top: 0; }

--- a/dashboard/src/app/page.tsx
+++ b/dashboard/src/app/page.tsx
@@ -90,6 +90,44 @@ interface InboxItem {
   provenance?: { recipe?: string };
 }
 
+// Slim mirror of `GateDecisionRecord` (src/workerGateDecisionLog.ts) — only
+// the fields this pane actually renders. The bridge's `GET /gate/decisions`
+// (backing `patchwork gate explain`) has never had a dashboard consumer
+// before this pane; this is its first.
+interface GateDecisionRecord {
+  seq: number;
+  decidedAt: number;
+  workerId: string;
+  toolName: string;
+  classKey: string;
+  action: "allow" | "gate";
+  owned: boolean;
+  earnedLevel: number;
+  autonomyCeiling: number;
+  effectiveLevel: number;
+  contextCeiling?: number;
+  contextRiskScore?: number;
+  contextRiskReasons?: string[];
+  reason: string;
+  recipeName: string;
+  gatePolicyVersion: string;
+}
+
+// Short level→phrase vocabulary, index = trust level 0-4. Mirrors
+// PLAIN_LEVEL_SHORT in app/workers/page.tsx (the source of "asks first" /
+// "acts + undo" etc.) — kept as a local copy since that array isn't
+// currently exported from a shared lib; do not invent new phrasing here.
+const GATE_LEVEL_SHORT = [
+  "suggests only",
+  "asks first",
+  "acts + undo",
+  "acts + spot-check",
+  "on its own",
+];
+function gateLevelPhrase(n: number): string {
+  return GATE_LEVEL_SHORT[n] ?? `level ${n}`;
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -294,6 +332,14 @@ export default function HomePage() {
     "/api/bridge/workers/shadow",
     { intervalMs: 15000 },
   );
+  // Gate activity feed for pane 4 — GET /gate/decisions with no filters
+  // returns the most-recent decisions across ALL workers (query() only
+  // filters fields that are actually supplied), so this is a genuine "last
+  // N gate decisions, any worker" feed, not a per-worker/per-class lookup.
+  // Same 15s cadence as the workers-shadow fetch above (no new timer).
+  const { data: gateDecisionsData, error: gateDecisionsError } = useBridgeFetch<{
+    decisions?: GateDecisionRecord[];
+  }>("/api/bridge/gate/decisions?limit=6", { intervalMs: 15000 });
   const { data: inboxData, error: inboxError } = useBridgeFetch<{ items?: InboxItem[] }>(
     "/api/inbox",
     { intervalMs: 15000 },
@@ -544,6 +590,8 @@ export default function HomePage() {
     );
     return hasNonReversibleOwned ? "climbing" : "reversible";
   }
+  const gateDecisions: GateDecisionRecord[] = gateDecisionsData?.decisions ?? [];
+  const [expandedGateSeq, setExpandedGateSeq] = useState<number | null>(null);
 
   // ---- Pane 6: inbox ---------------------------------------------------
   // Data source: workspace-level GET /api/inbox (proxies bridge GET /inbox,
@@ -891,6 +939,65 @@ export default function HomePage() {
               );
             })
           )}
+
+          {/* Gate activity — first-ever dashboard surface of the Decision
+              Record (GET /gate/decisions, backs `patchwork gate explain`).
+              Renders the last ~6 gate decisions across all workers. */}
+          <div className="td-gate-activity">
+            <div className="td-gate-activity-title td-muted">gate activity</div>
+            {gateDecisionsError ? (
+              <div className="td-error-row">gate activity unavailable</div>
+            ) : gateDecisions.length === 0 ? (
+              <div className="td-empty-line">no gate decisions yet</div>
+            ) : (
+              gateDecisions.slice(0, 6).map((d) => {
+                const isOpen = expandedGateSeq === d.seq;
+                const hhmm = new Date(d.decidedAt).toLocaleTimeString([], {
+                  hour: "2-digit",
+                  minute: "2-digit",
+                  hour12: false,
+                });
+                return (
+                  <div className="td-gate-row-wrap" key={d.seq}>
+                    <button
+                      type="button"
+                      className="td-gate-row"
+                      aria-expanded={isOpen}
+                      onClick={() =>
+                        setExpandedGateSeq(isOpen ? null : d.seq)
+                      }
+                    >
+                      <span className="mono td-muted">{hhmm}</span>
+                      <span className="td-gate-verb">GATE</span>
+                      <span className="mono">{d.workerId}</span>
+                      <span className="td-muted mono">{d.classKey}</span>
+                      <span className="td-gate-arrow">→</span>
+                      <span>{gateLevelPhrase(d.effectiveLevel)}</span>
+                    </button>
+                    {isOpen && (
+                      <div className="td-gate-explain">
+                        <div>
+                          effective L{d.effectiveLevel} ({gateLevelPhrase(d.effectiveLevel)})
+                          {" vs required "}
+                          {d.action === "allow" ? "— none (allowed)" : "higher"}
+                        </div>
+                        <div>
+                          earned L{d.earnedLevel} · autonomy ceiling L{d.autonomyCeiling}
+                          {d.contextCeiling !== undefined
+                            ? ` · context ceiling L${d.contextCeiling}`
+                            : ""}
+                        </div>
+                        {d.contextRiskReasons && d.contextRiskReasons.length > 0 && (
+                          <div>context signals: {d.contextRiskReasons.join(", ")}</div>
+                        )}
+                        <div className="td-muted">{d.reason}</div>
+                      </div>
+                    )}
+                  </div>
+                );
+              })
+            )}
+          </div>
         </Pane>
 
         {/* 5: vitals */}

--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -25,7 +25,7 @@ Format: `- <date> <branch-or-PR> — <one-line scope> — <session/chat identity
 
 ## Active
 
-- 2026-07-04 `fix/deck-pane-signal-quality` — Terminal deck v2 Phase 1 (pane signal quality): user reviewed the merged deck (#1095) live and found real-data signal-quality problems the mockup couldn't expose. 1:tail defaults to hiding bridge-lifecycle plumbing (grace/heartbeat/connected) behind a toggle + collapses consecutive duplicates with ×N (reusing activity page's compression logic) + fixes level coloring. 3:next shows only enabled schedules sorted by next-fire with countdowns, paused collapse to one footer line. 2:fleet sorts real/active recipes first, maps trigger labels to short display names, caps ~6 rows + "+N more". 6:inbox strips markdown + truncates at word boundary. Phases 2-4 (Decision Record gate-activity in 4:workers, staleness-in-statusline + run-cancel-on-deck, halt-age escalation + polish) follow as separate PRs. — build session
+- 2026-07-04 `feat/deck-workers-gate-activity` — Terminal deck v2 Phase 2: `4:workers` pane gets a "gate activity" feed below the trust lines — last ~6 `GET /gate/decisions` entries (worker × classKey decisions), terminal-style rows, expandable to a plain-English `gate explain`-style rendering. First-ever dashboard surface for the Decision Record. Reuses the pane's existing poll cadence, no new loop. Phase 1 (pane signal quality) merged as #1100. Phases 3-4 (staleness/cancel-in-deck, polish) follow as separate PRs. — build session
 
 ## Recently closed (informal log, prune periodically)
 


### PR DESCRIPTION
## Summary
- **The Decision Record's first-ever dashboard consumer.** `GET /gate/decisions` (backing `patchwork gate explain`) has had zero UI surface anywhere in the product until now.
- Below the existing worker-trust lines, `4:workers` renders the last ~6 decisions across ALL workers (no workerId/classKey filter needed — `WorkerGateDecisionLog.query()` already supports this, sorting by seq descending before slicing) as terminal rows: `HH:MM GATE <workerId> <classKey> → <phrase>` (e.g. `07:43 GATE test-guardian issue:compensable:high → asks first`).
- Click to expand shows effective vs required level, earned/autonomy/context ceilings (only the ones actually present on the record), context signals, and the raw reason — mirrors `formatGateDecision()`/gate-explain's field set, omitting anything not on the record rather than fabricating.
- No dedicated proxy needed: `/gate/decisions` is a static top-level segment (unlike `/recipes/doctor`, which needed one because `recipes/[...name]` would swallow its query) — the generic `/api/bridge/[...path]` catch-all already forwards query strings unconditionally.
- Reuses a second `useBridgeFetch` call at the same 15s cadence as the existing `workers/shadow` fetch — no new timer.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `node scripts/check-inline-fontsize.mjs`
- [x] `npx vitest run` (110 files / 1102 tests — feed rendering, expand/explain, empty-state, fail-soft on 500)
- [x] `npm run lint` (zero new warnings)
- [x] Independently re-verified `WorkerGateDecisionLog.query()`'s no-filter descending-sort behavior directly against source

🤖 Generated with [Claude Code](https://claude.com/claude-code)