### PR TITLE
fix(dashboard): cap terminal deck pane body height for row consistency

### DIFF
--- a/dashboard/src/app/globals.css
+++ b/dashboard/src/app/globals.css
@@ -9705,7 +9705,21 @@ details[open] .traces-detail-arrow { transform: rotate(90deg); }
 .td-pane-link { color: inherit; text-decoration: none; opacity: 0.7; }
 .td-pane-link:hover { opacity: 1; }
 
-.td-pane-body { display: flex; flex-direction: column; gap: 6px; flex: 1; min-width: 0; }
+.td-pane-body {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  flex: 1;
+  min-width: 0;
+  /* Mockup's tailbox caps at a fixed height (overflow-hidden, bottom-anchored)
+     so a busy pane never grows taller than its half-width row partner —
+     panes render at wildly different content lengths (tail's 7 rows vs
+     vitals' 4 KV rows vs workers' trust lines + 6 gate-activity rows), and
+     without a cap the grid row stretches to the tallest one, leaving
+     ragged-looking neighbors. Capping + scrolling keeps every row even. */
+  max-height: 260px;
+  overflow-y: auto;
+}
 
 .td-muted { color: var(--terminal-comment); }
 [data-theme="paper"] .td-muted { color: var(--ink-3); }

--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -25,7 +25,7 @@ Format: `- <date> <branch-or-PR> — <one-line scope> — <session/chat identity
 
 ## Active
 
-- 2026-07-04 `feat/deck-workers-gate-activity` — Terminal deck v2 Phase 2: `4:workers` pane gets a "gate activity" feed below the trust lines — last ~6 `GET /gate/decisions` entries (worker × classKey decisions), terminal-style rows, expandable to a plain-English `gate explain`-style rendering. First-ever dashboard surface for the Decision Record. Reuses the pane's existing poll cadence, no new loop. Phase 1 (pane signal quality) merged as #1100. Phases 3-4 (staleness/cancel-in-deck, polish) follow as separate PRs. — build session
+- 2026-07-04 `fix/deck-pane-row-height-consistency` — Terminal deck v2, grid-geometry reconciliation pass (against the mockup's actual "H-D · Terminal" CSS): `.td-pane-body` gets a max-height + scroll cap (260px) so a content-heavy pane (tail's rows, workers' trust-lines + gate-activity feed) never stretches its grid row taller than a light neighbor (vitals' 4 KV rows) — mirrors the mockup's `.hd-tailbox{height:148px;overflow:hidden}` intent, generalized to every pane since more than just tail grew. CSS-only, no logic change. Phase 2 (gate-activity feed) merged as #1101. — build session
 
 ## Recently closed (informal log, prune periodically)
 


### PR DESCRIPTION
## Summary
- Reconciled the shipped deck against the mockup's actual "H-D · Terminal" CSS (fetched and compared directly): its tail box is a fixed-height (148px), overflow-hidden, bottom-anchored container specifically so a busy pane never grows taller than its half-width row partner.
- `.td-pane-body` had no such cap — with the workers pane now carrying trust lines + a 6-row gate-activity feed (#1101), grid rows could render visibly ragged as pane content length varies.
- Applied the cap generally (260px, `overflow-y: auto`) to `.td-pane-body` rather than tail-only, since more than one pane now has variable-length content.
- Grid column geometry itself (uniform half-width panes + full-width `0:attention`) was compared against the mockup's mixed span-3/span-2 example and kept as-is — a legitimate, cleaner design choice for 7 panes, not a bug.
- CSS-only, no logic touched.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `node scripts/check-inline-fontsize.mjs`
- [x] `npx vitest run` (110 files / 1102 tests — unchanged, confirms no logic regression from a CSS-only edit)
- [ ] Eyeball both themes at ~375px (asking the user)

🤖 Generated with [Claude Code](https://claude.com/claude-code)