### PR TITLE
feat(dashboard): terminal deck v2 Phase 3 — staleness in statusline, cancel in the deck

### DIFF
--- a/dashboard/src/app/__tests__/page.test.tsx
+++ b/dashboard/src/app/__tests__/page.test.tsx
@@ -11,7 +11,7 @@
  *   - pane focus responds to number-key shortcuts (0-6)
  */
 
-import { act, render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor, within } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import HomePage from "@/app/page";
 
@@ -219,6 +219,168 @@ describe("<HomePage/> — Terminal deck", () => {
     expect(workersPane.textContent).toMatch(
       /earned trust \(L1\) below the compensable-action threshold \(L2\)/,
     );
+  });
+
+  it("statusline clock flips to 'data as of … reconnecting' when the deck's own poll goes stale, and clears on recovery", async () => {
+    // Bug Fix Protocol: this test must fail before the statusline is wired
+    // to the staleness registry — the deck's primary poll (tracked via
+    // useManualPollStaleness) already existed, but nothing in the
+    // statusline read `getStaleFetchSummary()`, so a stalled bridge never
+    // changed what the clock segment showed.
+    let hang = false;
+    mockFetchRoutes({
+      ...HEALTHY_ROUTES,
+      "/api/bridge/recipes": () => {
+        if (hang) return new Promise(() => {}) as unknown as Response;
+        return jsonResponse({ recipes: [] });
+      },
+    });
+    render(<HomePage />);
+
+    // First tick succeeds — registers a lastSuccessAt.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(50);
+    });
+
+    const statusline = screen.getByRole("status", { name: "Bridge status" });
+    expect(statusline.textContent).not.toMatch(/reconnecting/);
+
+    // Now every subsequent poll hangs forever — 3x the 5000ms interval
+    // (plus the 1s staleness re-check cadence) must flip the flag.
+    hang = true;
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(16_000);
+    });
+
+    await waitFor(() => {
+      expect(statusline.textContent).toMatch(/data as of .* reconnecting/i);
+    });
+
+    // Recovery: next successful poll clears it back to the live clock.
+    hang = false;
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(6_000);
+    });
+
+    await waitFor(() => {
+      expect(statusline.textContent).not.toMatch(/reconnecting/i);
+    });
+  });
+
+  it("0:attention shows a Stop control for a live run and cancels it via the shared dialog", async () => {
+    const cancelMock = vi.fn().mockResolvedValue(
+      jsonResponse({ cancelled: true, seq: 501 }),
+    );
+    global.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url.includes("/api/bridge/runs/501/cancel")) return cancelMock();
+      for (const [key, make] of Object.entries({
+        ...HEALTHY_ROUTES,
+        "/api/bridge/runs": () =>
+          jsonResponse({
+            runs: [
+              {
+                seq: 501,
+                recipe: "daily-brief",
+                recipeName: "daily-brief",
+                startedAt: Date.now() - 5000,
+                status: "running",
+              },
+            ],
+          }),
+      })) {
+        if (url.includes(key)) return make();
+      }
+      return jsonResponse({}, 404);
+    }) as unknown as typeof fetch;
+
+    render(<HomePage />);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(50);
+    });
+
+    const attentionPane = screen.getByRole("region", { name: "attention" });
+    expect(attentionPane.textContent).toMatch(/running/i);
+    expect(attentionPane.textContent).toMatch(/daily brief/i);
+
+    const stopBtn = within(attentionPane).getByTitle("Stop this run of daily-brief");
+    await act(async () => {
+      stopBtn.click();
+    });
+
+    // Confirm dialog gates the actual cancel call.
+    const confirmBtn = await screen.findByText("Stop run");
+    await act(async () => {
+      confirmBtn.click();
+    });
+
+    await waitFor(() => {
+      expect(cancelMock).toHaveBeenCalledTimes(1);
+    });
+
+    // Optimistic update: the live-run row disappears once cancelled.
+    await waitFor(() => {
+      expect(within(attentionPane).queryByTitle("Stop this run of daily-brief")).toBeNull();
+    });
+  });
+
+  it("1:tail shows a Stop control on the row for an in-progress run matched by recipeName", async () => {
+    const cancelMock = vi.fn().mockResolvedValue(
+      jsonResponse({ cancelled: true, seq: 777 }),
+    );
+    global.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url.includes("/api/bridge/runs/777/cancel")) return cancelMock();
+      for (const [key, make] of Object.entries({
+        ...HEALTHY_ROUTES,
+        "/api/bridge/runs": () =>
+          jsonResponse({
+            runs: [
+              {
+                seq: 777,
+                recipe: "morning-brief",
+                recipeName: "morning-brief",
+                startedAt: Date.now() - 2000,
+                status: "running",
+              },
+            ],
+          }),
+        "/api/bridge/activity": () =>
+          jsonResponse({
+            events: [
+              {
+                kind: "lifecycle",
+                event: "recipe_step_started",
+                at: Date.now() - 1000,
+                metadata: { recipeName: "morning-brief" },
+              },
+            ],
+          }),
+      })) {
+        if (url.includes(key)) return make();
+      }
+      return jsonResponse({}, 404);
+    }) as unknown as typeof fetch;
+
+    render(<HomePage />);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(50);
+    });
+
+    const tailPane = screen.getByRole("region", { name: "tail" });
+    const stopBtn = within(tailPane).getByTitle("Stop this run of morning-brief");
+    await act(async () => {
+      stopBtn.click();
+    });
+
+    const confirmBtn = await screen.findByText("Stop run");
+    await act(async () => {
+      confirmBtn.click();
+    });
+
+    await waitFor(() => {
+      expect(cancelMock).toHaveBeenCalledTimes(1);
+    });
   });
 
   it("fails soft when /gate/decisions is empty or errors", async () => {

--- a/dashboard/src/app/globals.css
+++ b/dashboard/src/app/globals.css
@@ -9770,10 +9770,13 @@ details[open] .traces-detail-arrow { transform: rotate(90deg); }
 .td-attention-actions { display: flex; gap: 6px; flex-wrap: wrap; margin-top: 4px; }
 .td-attention-foot { margin-top: 8px; font-size: var(--fs-xs); }
 .td-attention-foot a { color: inherit; }
+.td-attention-live { padding-bottom: 8px; margin-bottom: 8px; border-bottom: 1px solid rgba(255,255,255,0.08); }
+[data-theme="paper"] .td-attention-live { border-bottom-color: var(--border-subtle, rgba(0,0,0,0.08)); }
 
 /* Pane 1: tail */
 .td-tail { display: flex; flex-direction: column; gap: 2px; }
 .td-tail-row { display: flex; gap: 8px; font-size: var(--fs-xs); align-items: baseline; }
+.td-tail-stop { margin-left: auto; flex-shrink: 0; }
 .td-tail-ts { color: var(--terminal-comment); font-variant-numeric: tabular-nums; }
 [data-theme="paper"] .td-tail-ts { color: var(--ink-3); }
 .td-tail-level { font-weight: 700; width: 3.5em; flex-shrink: 0; }

--- a/dashboard/src/app/page.tsx
+++ b/dashboard/src/app/page.tsx
@@ -10,7 +10,13 @@ import { isHaltStatus } from "@/lib/runStatus";
 import { canonicalRecipeKey } from "@/lib/entityKey";
 import type { LiveRun } from "@/components/LiveRunsStrip";
 import { useRunRecipe } from "@/hooks/useRunRecipe";
-import { useManualPollStaleness } from "@/lib/staleFetchRegistry";
+import {
+  useManualPollStaleness,
+  getStaleFetchSummary,
+  subscribeStaleFetchRegistry,
+} from "@/lib/staleFetchRegistry";
+import { useCancelRun } from "@/hooks/useCancelRun";
+import { CancelRunDialog } from "@/components/CancelRunDialog";
 import { computeSuccessPct } from "@/lib/recipeRunHealth";
 import {
   isReversible,
@@ -237,6 +243,28 @@ function useClock(): string {
   return label;
 }
 
+/** Subscribes to the shared staleFetchRegistry (the same registry
+ *  `useBridgeFetch({ trackStaleness: true })` and `useManualPollStaleness`
+ *  write to) so the deck's own statusline clock segment can flip to an
+ *  amber "data as of HH:MM:SS — reconnecting…" state whenever ANY of the
+ *  deck's own tracked fetchers has gone stale — a separate, page-local
+ *  presentation of the same underlying signal the global `StalenessStrip`
+ *  banner shows, not a duplicate state machine. */
+function useDeckStaleness() {
+  const [summary, setSummary] = useState(() => getStaleFetchSummary());
+  useEffect(() => {
+    const recompute = () => setSummary(getStaleFetchSummary());
+    recompute();
+    const unsubscribe = subscribeStaleFetchRegistry(recompute);
+    const id = setInterval(recompute, 1000);
+    return () => {
+      unsubscribe();
+      clearInterval(id);
+    };
+  }, []);
+  return summary;
+}
+
 /** Forces a re-render every `everyMs` so relative-time / countdown strings
  *  stay live without each consumer running its own interval. */
 function useTick(everyMs: number): number {
@@ -330,7 +358,7 @@ export default function HomePage() {
   // fetch effect below — new proxy wiring per the plan's Pane 4/6 sections.
   const { data: shadowData, error: shadowError } = useBridgeFetch<ShadowResponse>(
     "/api/bridge/workers/shadow",
-    { intervalMs: 15000 },
+    { intervalMs: 15000, trackStaleness: true },
   );
   // Gate activity feed for pane 4 — GET /gate/decisions with no filters
   // returns the most-recent decisions across ALL workers (query() only
@@ -339,15 +367,24 @@ export default function HomePage() {
   // Same 15s cadence as the workers-shadow fetch above (no new timer).
   const { data: gateDecisionsData, error: gateDecisionsError } = useBridgeFetch<{
     decisions?: GateDecisionRecord[];
-  }>("/api/bridge/gate/decisions?limit=6", { intervalMs: 15000 });
+  }>("/api/bridge/gate/decisions?limit=6", { intervalMs: 15000, trackStaleness: true });
   const { data: inboxData, error: inboxError } = useBridgeFetch<{ items?: InboxItem[] }>(
     "/api/inbox",
-    { intervalMs: 15000 },
+    { intervalMs: 15000, trackStaleness: true },
   );
 
   const [pendingApprovals, setPendingApprovals] = useState<Pending[]>([]);
   const [recipes, setRecipes] = useState<Recipe[]>([]);
   const [runs, setRuns] = useState<LiveRun[]>([]);
+  // Stop control shared by the 0:attention live-run row and the 1:tail
+  // in-progress row — same hook/dialog the other 4 cancel call sites
+  // (GlobalLiveRunsStrip, LiveRunsStrip, /runs, /runs/[seq]) already use.
+  // Optimistic local override by seq, same pattern as LiveRunsStrip.tsx,
+  // so a just-cancelled run stops showing "running" before the next poll.
+  const [cancelledSeqs, setCancelledSeqs] = useState<Set<number>>(new Set());
+  const cancelRun = useCancelRun((seq) => {
+    setCancelledSeqs((prev) => new Set(prev).add(seq));
+  });
   const [haltCount24hState, setHaltCount24h] = useState<number | null>(null);
   const [activityEvents, setActivityEvents] = useState<ActivityEvent[]>([]);
   const [fetchErrors, setFetchErrors] = useState<{
@@ -442,6 +479,13 @@ export default function HomePage() {
 
   // Live clock (statusline). SSR-safe placeholder, ticks client-side.
   const clockLabel = useClock();
+  // Aggregate staleness across the deck's own tracked fetchers (the
+  // primary recipes/runs/halts/activity poll via useManualPollStaleness
+  // above, plus workers/shadow, gate/decisions, and inbox via
+  // useBridgeFetch's trackStaleness). When any is stale, the clock
+  // segment itself flips to an amber "data as of … reconnecting…"
+  // instead of the live tick.
+  const deckStaleness = useDeckStaleness();
   // Drive re-renders for the attention "halted Xh Ym ago" ticker + the
   // cron countdowns in pane 3 — both need a 1s heartbeat but shouldn't
   // each run their own interval.
@@ -477,6 +521,14 @@ export default function HomePage() {
   const topAttentionRun = attentionRuns[0];
   const attentionCount = pendingCount + haltCount24h + errCount24h;
 
+  // A run "live" locally overrides its status if we've already optimistically
+  // cancelled it (same override LiveRunsStrip.tsx uses) so the Stop control
+  // disappears immediately instead of waiting on the next poll tick.
+  const liveRuns = runs
+    .filter((r) => r.status === "running" && !(r.seq != null && cancelledSeqs.has(r.seq)))
+    .sort((a, b) => b.startedAt - a.startedAt);
+  const topLiveRun = liveRuns[0];
+
   // ---- Pane 1: tail (activity) --------------------------------------------
   // Default-hide bridge-lifecycle plumbing (grace/extension/heartbeat
   // churn) — previously this pane showed near-100% plumbing NOTE events
@@ -505,6 +557,28 @@ export default function HomePage() {
     tailEvents.length > 0
       ? `Latest: ${eventLine(tailEvents[tailEvents.length - 1].event)}`
       : "No recent activity.";
+
+  // Map recipe name -> the single live run for it (undefined when 0 or 2+
+  // live runs share a name — ambiguous, so no Stop control renders rather
+  // than risk stopping the wrong run). Backs the tail row Stop control:
+  // a tail event whose metadata.recipeName matches a currently-running
+  // run's recipe name is treated as representing that in-progress run.
+  const liveRunByRecipeName = useMemo(() => {
+    const m = new Map<string, LiveRun | null>();
+    for (const r of liveRuns) {
+      const name = (r.recipeName ?? r.recipe ?? "").replace(/:agent$/, "");
+      if (!name) continue;
+      m.set(name, m.has(name) ? null : r);
+    }
+    return m;
+  }, [liveRuns]);
+
+  function tailEventLiveRun(e: ActivityEvent): LiveRun | undefined {
+    const metaName = e.metadata?.recipeName;
+    if (typeof metaName !== "string" || !metaName) return undefined;
+    const match = liveRunByRecipeName.get(metaName.replace(/:agent$/, ""));
+    return match ?? undefined;
+  }
 
   // ---- Pane 2: fleet -------------------------------------------------------
   const allRunsMap = useMemo(() => {
@@ -668,9 +742,19 @@ export default function HomePage() {
         <span className="td-sep">|</span>
         <span className="td-seg">kill-switch {killSwitchLabel}</span>
         <span className="td-sp" />
-        <span className="td-seg td-clock" suppressHydrationWarning>
-          {clockLabel}
-        </span>
+        {deckStaleness.anyStale ? (
+          <span className="td-seg td-clock td-warn" suppressHydrationWarning>
+            data as of{" "}
+            {deckStaleness.mostRecentSuccessAt != null
+              ? tsLabel(deckStaleness.mostRecentSuccessAt)
+              : "—"}{" "}
+            — reconnecting…
+          </span>
+        ) : (
+          <span className="td-seg td-clock" suppressHydrationWarning>
+            {clockLabel}
+          </span>
+        )}
       </div>
 
       <div className="td-grid">
@@ -685,24 +769,59 @@ export default function HomePage() {
         >
           {!bridgeStatus.ok ? (
             <div className="td-error-row">bridge offline — can&apos;t reach attention data</div>
-          ) : isMuted ? (
-            <div className="td-muted-row">
-              Muted until {new Date(muteUntil).toLocaleTimeString()}.{" "}
-              <button
-                type="button"
-                className="td-link-btn"
-                onClick={() => {
-                  writeMuteUntil(0);
-                  setMuteUntilState(0);
-                }}
-              >
-                unmute
-              </button>
-            </div>
-          ) : attentionCount === 0 ? (
-            <div className="td-empty-line">nothing needs you</div>
           ) : (
             <>
+              {topLiveRun && (() => {
+                const name = (topLiveRun.recipeName ?? topLiveRun.recipe ?? "").replace(/:agent$/, "");
+                const isStopping =
+                  topLiveRun.seq != null &&
+                  cancelRun.cancelSeq === topLiveRun.seq &&
+                  cancelRun.phase === "cancelling";
+                const agoMs = nowMs - topLiveRun.startedAt;
+                return (
+                  <div className="td-attention-item td-attention-live">
+                    <div className="td-attention-head">
+                      <span className="td-pill td-pill-warn">running</span>
+                      <strong className="mono">{recipeDisplayName(name)}</strong>
+                      <span className="td-muted">started {formatAgo(agoMs)}</span>
+                    </div>
+                    <div className="td-attention-actions">
+                      <button
+                        type="button"
+                        className="btn sm ghost"
+                        disabled={isStopping || topLiveRun.seq == null}
+                        title={`Stop this run of ${name}`}
+                        onClick={() => {
+                          if (topLiveRun.seq != null) cancelRun.requestConfirm(topLiveRun.seq);
+                        }}
+                      >
+                        {isStopping ? "stopping…" : "■ Stop"}
+                      </button>
+                      <Link href={`/runs/${topLiveRun.seq ?? ""}`} className="btn sm ghost">
+                        View run
+                      </Link>
+                    </div>
+                  </div>
+                );
+              })()}
+              {isMuted ? (
+                <div className="td-muted-row">
+                  Muted until {new Date(muteUntil).toLocaleTimeString()}.{" "}
+                  <button
+                    type="button"
+                    className="td-link-btn"
+                    onClick={() => {
+                      writeMuteUntil(0);
+                      setMuteUntilState(0);
+                    }}
+                  >
+                    unmute
+                  </button>
+                </div>
+              ) : attentionCount === 0 ? (
+                !topLiveRun && <div className="td-empty-line">nothing needs you</div>
+              ) : (
+              <>
               {topAttentionRun && (() => {
                 const name = (topAttentionRun.recipeName ?? topAttentionRun.recipe ?? "").replace(/:agent$/, "");
                 const key = canonicalRecipeKey(name);
@@ -758,6 +877,8 @@ export default function HomePage() {
                   <Link href="/approvals">{pendingCount} approval{pendingCount === 1 ? "" : "s"} pending →</Link>
                 </div>
               )}
+              </>
+              )}
             </>
           )}
         </Pane>
@@ -810,14 +931,40 @@ export default function HomePage() {
                 ) : (
                   tailEvents.map(({ event: e, count }, i) => {
                     const level = activityEventLevel(e);
+                    const rowLiveRun = tailEventLiveRun(e);
+                    const isStopping =
+                      rowLiveRun?.seq != null &&
+                      cancelRun.cancelSeq === rowLiveRun.seq &&
+                      cancelRun.phase === "cancelling";
                     return (
-                      <div className={`td-tail-row td-lvl-${level} td-tail-enter`} key={e.id ?? `${e.at}-${i}`}>
+                      <div
+                        className={`td-tail-row td-lvl-${level} td-tail-enter`}
+                        key={e.id ?? `${e.at}-${i}`}
+                        // The parent .td-tail is aria-hidden (a fast-updating
+                        // feed would spam screen readers) — a row carrying a
+                        // Stop control must stay reachable, so un-hide it.
+                        aria-hidden={rowLiveRun ? "false" : undefined}
+                      >
                         <span className="td-tail-ts">{tsLabel(e.at ?? Date.now())}</span>
                         <span className="td-tail-level">{level.toUpperCase()}</span>
                         <span className="td-tail-msg">
                           {eventLine(e)}
                           {count > 1 ? ` ×${count}` : ""}
                         </span>
+                        {rowLiveRun && rowLiveRun.seq != null && (
+                          <button
+                            type="button"
+                            className="btn sm ghost td-tail-stop"
+                            disabled={isStopping}
+                            title={`Stop this run of ${(rowLiveRun.recipeName ?? rowLiveRun.recipe ?? "").replace(/:agent$/, "")}`}
+                            onClick={(ev) => {
+                              ev.stopPropagation();
+                              cancelRun.requestConfirm(rowLiveRun.seq as number);
+                            }}
+                          >
+                            {isStopping ? "stopping…" : "■ Stop"}
+                          </button>
+                        )}
                       </div>
                     );
                   })
@@ -1061,6 +1208,16 @@ export default function HomePage() {
           )}
         </Pane>
       </div>
+
+      <CancelRunDialog
+        open={cancelRun.phase === "confirming"}
+        onClose={cancelRun.dismiss}
+        onConfirm={() => void cancelRun.confirm()}
+        recipeName={
+          runs.find((r) => r.seq === cancelRun.cancelSeq)?.recipeName
+        }
+        seq={cancelRun.cancelSeq}
+      />
     </section>
   );
 }

--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -25,14 +25,12 @@ Format: `- <date> <branch-or-PR> — <one-line scope> — <session/chat identity
 
 ## Active
 
-- 2026-07-04 `fix/deck-pane-row-height-consistency` — Terminal deck v2, grid-geometry reconciliation pass (against the mockup's actual "H-D · Terminal" CSS): `.td-pane-body` gets a max-height + scroll cap (260px) so a content-heavy pane (tail's rows, workers' trust-lines + gate-activity feed) never stretches its grid row taller than a light neighbor (vitals' 4 KV rows) — mirrors the mockup's `.hd-tailbox{height:148px;overflow:hidden}` intent, generalized to every pane since more than just tail grew. CSS-only, no logic change. Phase 2 (gate-activity feed) merged as #1101. — build session
-
 ## Recently closed (informal log, prune periodically)
 
+- 2026-07-04 `fix/deck-pane-row-height-consistency` (#1102) — Terminal deck v2, grid-geometry reconciliation pass: `.td-pane-body` gets a max-height + scroll cap (260px) so a content-heavy pane never stretches its grid row taller than a light neighbor. CSS-only, no logic change. — merged
+- 2026-07-04 `feat/deck-staleness-and-cancel` (#1103) — Terminal deck v2 Phase 3: surface the already-existing staleness/cancel infra IN the deck itself. Statusline clock flips to "data as of HH:MM:SS — reconnecting…" (amber) when any deck fetcher is stale (reusing `staleFetchRegistry`/`useBridgeFetch`'s `stale` field from #1097). Live runs on `0:attention` and the tail row get a Stop control (reusing `useCancelRun`/`CancelRunDialog` from #1099). Phase 4 (halt-age escalation, footer hint, polish) and a separate visual-parity pass against the mockup follow. — merged
+- 2026-07-04 `feat/deck-workers-gate-activity` (#1101) — Terminal deck v2 Phase 2: `4:workers` pane gets a "gate activity" feed below the trust lines — last ~6 `GET /gate/decisions` entries, terminal-style rows, expandable to a plain-English `gate explain`-style rendering. First-ever dashboard surface for the Decision Record. — merged
 - 2026-07-03 `feat/dashboard-terminal-deck-phase1` (#1095) — Terminal+Copilot deck plan PR 6/10: full rewrite of `app/page.tsx` replacing the PR #1085 Command Deck bento with the "Home D · Terminal (dark)" statusline + 7-pane mono grid. — merged
-
-## Recently closed (informal log, prune periodically)
-
 - 2026-07-04 `feat/run-cancel-ui` (#1099) — dashboard gap remediation item 4: `POST /runs/:seq/cancel` had zero dashboard consumers. Stop control + confirm dialog wired into GlobalLiveRunsStrip, LiveRunsStrip, /runs list rows, /runs/[seq] header. — merged
 - 2026-07-03 `feat/connector-token-expiry` (#1098) — dashboard gap remediation item 2: connector `getStatus()`/`/connections` gets optional `tokenExpiresAt`/`lastSuccessAt`; connections card renders expiry pill + last-call line. Bridge-side — needs snapshotting to `../patchwork-multitenant/src/`. — merged
 - 2026-07-03 `fix/dashboard-staleness-indicator` (#1097) — dashboard gap remediation item 1 (bug-shaped, Bug Fix Protocol: failing test first): `useBridgeFetch` kept last-good data forever with no freshness marker. Added `lastSuccessAt` tracking + `stale: boolean` + one global Shell strip aggregating across all opted-in fetchers via a small registry, not per-page banners. No poll-interval changes, no new endpoints. — merged


### PR DESCRIPTION
## Summary
- Both pieces of infra already existed from earlier work (#1097 staleness, #1099 cancel) — this wires them into the deck, not building from scratch.
- **Statusline**: clock segment flips to "data as of HH:MM:SS — reconnecting…" (amber) when any of the deck's own tracked fetchers go stale, reusing the same `staleFetchRegistry` functions `StalenessStrip.tsx` already reads — a second independent read of the same registry, not a duplicate state machine.
- **Bug Fix Protocol followed**: failing test written first (hang the primary poll after one success, assert "reconnecting" never appears), confirmed failing, then wired, confirmed passing, confirmed recovery clears it.
- **Run cancel**: `0:attention` previously showed zero live-run state — added a live-run row with a Stop control, independent of the halt empty-state gate. `1:tail` rows matching a running run by `recipeName` also get Stop (ambiguous matches render no control rather than guess). Both reuse `useCancelRun`/`CancelRunDialog` exactly as `runs/page.tsx`/`LiveRunsStrip.tsx` already do.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `node scripts/check-inline-fontsize.mjs`
- [x] `npx vitest run` (110 files / 1105 tests — 3 new tests for staleness flip/recovery and both cancel flows)
- [x] `npm run lint` (zero new warnings)
- [x] Independently re-verified: `useCancelRun`/`CancelRunDialog` imports confirmed (not reimplemented), `getStaleFetchSummary`/`subscribeStaleFetchRegistry` confirmed shared with `StalenessStrip.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)