### PR TITLE
fix(tests): unblock typecheck:tests:core ratchet gate

### DIFF
--- a/src/__tests__/decisionTraceRoutes.test.ts
+++ b/src/__tests__/decisionTraceRoutes.test.ts
@@ -62,7 +62,15 @@ beforeEach(() => {
   tmpDir = mkdtempSync(path.join(os.tmpdir(), "decision-trace-routes-"));
   log = new DecisionTraceLog({ dir: tmpDir });
   deps = {
-    saveDecisionTraceFn: (input) =>
+    saveDecisionTraceFn: (input: {
+      ref: string;
+      problem: string;
+      solution: string;
+      workspace?: string;
+      tags?: string[];
+      sessionId?: string;
+      source?: string;
+    }) =>
       log.record({
         ref: input.ref,
         problem: input.problem,


### PR DESCRIPTION
## Summary
- `main` is currently red on the \`typecheck:tests:core\` ratchet gate (TS7006 on \`decisionTraceRoutes.test.ts:65\`), introduced by #1094. Blocking merges of unrelated PRs (e.g. #1103).
- \`deps\` in that test is built via \`as unknown as RecipeRouteDeps\`, so the object literal gets no contextual typing — the arrow function param needs an explicit annotation.

## Test plan
- [x] \`npm run typecheck:tests:core\` passes locally