### PR TITLE
fix(dashboard): copilot pane UI polish + real class-name bugs

### DIFF
--- a/dashboard/src/app/globals.css
+++ b/dashboard/src/app/globals.css
@@ -10003,7 +10003,6 @@ details[open] .traces-detail-arrow { transform: rotate(90deg); }
   border-bottom: 1px solid var(--line-2);
   font-size: var(--fs-xs);
 }
-.td-copilot-head b { color: var(--terminal-fg); }
 .td-copilot-msgs {
   max-height: 340px;
   overflow-y: auto;
@@ -10011,17 +10010,42 @@ details[open] .traces-detail-arrow { transform: rotate(90deg); }
   display: flex;
   flex-direction: column;
   gap: 10px;
+  scroll-behavior: smooth;
 }
-.td-copilot-msg { font-size: var(--fs-s); line-height: 1.55; max-width: 72ch; }
+/* Matches the mockup's own empty-state hint line — was previously
+   unstyled (no CSS rule existed for this class at all), inheriting
+   plain body text instead of the muted/centered terminal-empty look
+   every other pane's empty state already uses. */
+.td-copilot-empty {
+  color: var(--terminal-comment);
+  font-size: var(--fs-xs);
+  text-align: center;
+  padding: 18px 0;
+}
+[data-theme="paper"] .td-copilot-empty { color: var(--ink-3); }
+.td-copilot-msg {
+  font-size: var(--fs-s);
+  line-height: 1.55;
+  max-width: 72ch;
+  overflow-wrap: anywhere;
+}
 .td-copilot-msg-user {
   align-self: flex-end;
   background: var(--pressed, rgba(255,255,255,0.05));
   border: 1px solid var(--line-2);
-  border-radius: 8px;
+  border-radius: 8px 8px 2px 8px;
   padding: 6px 10px;
 }
 .td-copilot-msg-bot { color: var(--terminal-fg); }
 .td-copilot-who { color: var(--accent); font-weight: 700; margin-right: 6px; }
+/* "◆ copilot is thinking…" placeholder row shown while a reply is in
+   flight — the mockup has an .hd-typing equivalent; previously the pane
+   just sat silent between send and reply with no feedback at all. */
+.td-copilot-thinking { color: var(--terminal-comment); font-size: var(--fs-s); }
+[data-theme="paper"] .td-copilot-thinking { color: var(--ink-3); }
+@media (prefers-reduced-motion: no-preference) {
+  .td-copilot-thinking { animation: td-pill-pulse 1.4s ease-in-out infinite; }
+}
 .td-copilot-act {
   border: 1px solid var(--line-2);
   border-left: 3px solid var(--accent);
@@ -10029,29 +10053,27 @@ details[open] .traces-detail-arrow { transform: rotate(90deg); }
   background: var(--surface);
   padding: 8px 10px;
   margin-top: 8px;
+  transition: border-left-color 0.2s ease;
 }
 .td-copilot-act-head { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; margin-bottom: 6px; }
-.td-copilot-act-head b { color: var(--terminal-fg); }
-.td-copilot-act-kv {
-  display: flex;
-  gap: 14px;
-  flex-wrap: wrap;
-  color: var(--terminal-comment);
-  font-size: var(--fs-2xs);
-  margin-bottom: 8px;
-}
-.td-copilot-act-kv b { color: var(--terminal-fg); font-weight: 600; }
-.td-copilot-act-done { border-left-color: #7fbf6f; }
-[data-theme="paper"] .td-copilot-act-done { border-left-color: var(--ok-text); }
-.td-copilot-act-buttons { display: flex; gap: 8px; align-items: center; }
-.td-copilot-input {
+.td-copilot-act-head strong { color: var(--terminal-fg); }
+/* Run actions execute immediately on Confirm (no undo step like
+   pause/enable) — a distinct accent-tinted pill flags that at a glance
+   instead of looking identical to the lever pill. */
+.td-pill-accent { background: var(--accent-soft, rgba(224,101,60,0.16)); color: var(--accent); }
+.td-copilot-act.done { border-left-color: #7fbf6f; }
+[data-theme="paper"] .td-copilot-act.done { border-left-color: var(--ok-text); }
+.td-copilot-act-actions { display: flex; gap: 8px; align-items: center; }
+.td-copilot-in {
   display: flex;
   gap: 10px;
   align-items: center;
   border-top: 1px solid var(--line-1);
   padding: 9px 12px;
+  transition: background 0.15s ease;
 }
-.td-copilot-input input {
+.td-copilot-in:focus-within { background: var(--recess, rgba(255,255,255,0.03)); }
+.td-copilot-in input {
   flex: 1;
   background: transparent;
   border: 0;
@@ -10059,7 +10081,8 @@ details[open] .traces-detail-arrow { transform: rotate(90deg); }
   color: var(--terminal-fg);
   font: inherit;
 }
-.td-copilot-input input::placeholder { color: var(--terminal-comment); }
+.td-copilot-in input::placeholder { color: var(--terminal-comment); }
+.td-copilot-in input:disabled { opacity: 0.6; }
 .td-copilot-prompt { color: var(--accent); }
 .td-copilot-send {
   background: var(--accent);
@@ -10069,7 +10092,9 @@ details[open] .traces-detail-arrow { transform: rotate(90deg); }
   padding: 5px 12px;
   cursor: pointer;
   font: inherit;
+  transition: background 0.15s ease;
 }
+.td-copilot-send:hover:not(:disabled) { background: #ab4622; }
 .td-copilot-send:disabled { opacity: 0.5; cursor: not-allowed; }
 
 /* ------------------------------------------------------------------ */

--- a/dashboard/src/app/page.tsx
+++ b/dashboard/src/app/page.tsx
@@ -878,6 +878,14 @@ export default function HomePage() {
   const [copilotInput, setCopilotInput] = useState("");
   const [copilotSending, setCopilotSending] = useState(false);
   const copilotMsgSeq = useRef(0);
+  const copilotMsgsRef = useRef<HTMLDivElement>(null);
+  // Auto-scroll to the newest message/thinking-indicator — without this,
+  // a reply landing past the 340px scroll cap is invisible until the
+  // user manually scrolls down.
+  useEffect(() => {
+    const el = copilotMsgsRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, [copilotMessages, copilotSending]);
 
   async function sendCopilotMessage() {
     const text = copilotInput.trim();
@@ -1666,7 +1674,7 @@ export default function HomePage() {
             · chat proposes, buttons dispose — every action hits the same gate as cron
           </span>
         </div>
-        <div className="td-copilot-msgs">
+        <div className="td-copilot-msgs" ref={copilotMsgsRef}>
           {copilotMessages.length === 0 && (
             <div className="td-copilot-empty">
               ask or act: pause · run · why did X halt…
@@ -1675,16 +1683,16 @@ export default function HomePage() {
           {copilotMessages.map((m) => (
             <div
               key={m.id}
-              className={`td-copilot-msg ${m.role === "user" ? "td-copilot-msg-user" : "td-copilot-msg-bot"}`}
+              className={`td-copilot-msg td-tail-enter ${m.role === "user" ? "td-copilot-msg-user" : "td-copilot-msg-bot"}`}
             >
               {m.role === "bot" && <span className="td-copilot-who">◆ copilot</span>}
               {m.text}
               {m.action && (
                 <div
-                  className={`td-copilot-act${m.action.status === "done" ? " done" : ""}`}
+                  className={`td-copilot-act td-tail-enter${m.action.status === "done" ? " done" : ""}`}
                 >
                   <div className="td-copilot-act-head">
-                    <span className="td-pill">
+                    <span className={`td-pill${m.action.kind === "run_recipe" ? " td-pill-accent" : ""}`}>
                       {m.action.kind === "run_recipe" ? "run" : "lever"}
                     </span>
                     <strong>{recipeDisplayName(m.action.recipeName)}</strong>
@@ -1722,6 +1730,11 @@ export default function HomePage() {
               )}
             </div>
           ))}
+          {copilotSending && (
+            <div className="td-copilot-msg td-copilot-thinking" aria-live="polite">
+              <span className="td-copilot-who">◆ copilot</span>thinking…
+            </div>
+          )}
         </div>
         <form
           className="td-copilot-in"

--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -25,7 +25,7 @@ Format: `- <date> <branch-or-PR> — <one-line scope> — <session/chat identity
 
 ## Active
 
-(none)
+- 2026-07-04 `fix/copilot-pane-ui-polish` (#1116) — UI polish pass on the Tier-1 copilot pane (#1114); found 5 real CSS/JSX class-name mismatches that left the input row, action-buttons row, "done" state, recipe-name emphasis, and empty-state hint completely unstyled. Fixed + added entrance animation, thinking indicator, auto-scroll, accent "run" pill. — awaiting CI
 
 ## Recently closed (informal log, prune periodically)
 


### PR DESCRIPTION
## Summary
- Found and fixed 5 real CSS/JSX class-name mismatches in the merged Tier-1 copilot pane (#1114) that left key states completely unstyled: the input row, action-buttons row, "done" state, recipe-name emphasis, and the empty-state hint.
- Added real polish: message/action-card entrance animation (reusing the existing `.td-tail-enter` convention), a "thinking…" placeholder while a reply is in flight, auto-scroll-to-bottom, an accent-tinted pill for `run` actions (executes immediately, unlike pause/enable which are one-click-reversible), send-button hover state, input-row focus-within highlight, and long-message overflow-wrap.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npx vitest run` (109 files / 1109 tests)
- [x] `node scripts/check-inline-fontsize.mjs`
- [x] Manual verification via Playwright against the live dashboard dev server + real bridge: sent messages, confirmed action-card styling (accent "run" pill, bold recipe name), confirmed Dismiss removes only the card, confirmed input focus highlight