### PR TITLE
fix(dashboard): dashboard-pages audit follow-up (5 real findings)

### DIFF
--- a/dashboard/src/app/decisions/page.tsx
+++ b/dashboard/src/app/decisions/page.tsx
@@ -195,9 +195,7 @@ function DecisionsContent() {
         </div>
         <div style={{ display: "flex", gap: 8, flexWrap: "wrap", alignItems: "center" }}>
           <label className="decisions-input-focus" style={{ display: "flex", flexDirection: "column", gap: 2 }}>
-            <span className="visually-hidden" style={{ position: "absolute", width: 1, height: 1, overflow: "hidden", clip: "rect(0,0,0,0)" }}>
-              Search decisions
-            </span>
+            <span className="sr-only">Search decisions</span>
             <input
               ref={searchInputRef}
               type="text"

--- a/dashboard/src/app/globals.css
+++ b/dashboard/src/app/globals.css
@@ -7896,6 +7896,8 @@ details[open] .traces-detail-arrow { transform: rotate(90deg); }
 .runs-tr[data-status="error"] td:first-child,
 .runs-tr[data-status="error"] { border-left: 3px solid var(--err); }
 .runs-tr[data-status="running"] { border-left: 3px solid var(--accent); }
+.runs-tr--failure td:first-child,
+.runs-tr--failure { border-left: 3px solid var(--err); }
 .runs-tr td:first-child { padding-left: 12px; }
 .run-card { transition: box-shadow 0.15s ease, transform 0.15s ease, background 0.12s ease; }
 .run-card:hover {
@@ -8523,6 +8525,23 @@ details[open] .traces-detail-arrow { transform: rotate(90deg); }
   display: flex;
   flex-direction: column;
   gap: 8px;
+}
+.rd-needs {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 12px 14px;
+  border: 1px solid var(--warn);
+  border-radius: var(--radius);
+  background: color-mix(in oklch, var(--warn) 8%, var(--card-bg));
+}
+.rd-needs-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  font-size: var(--fs-s);
+  color: var(--ink-1);
 }
 .rd-facts {
   display: flex;

--- a/dashboard/src/app/globals.css
+++ b/dashboard/src/app/globals.css
@@ -1305,6 +1305,12 @@ a.btn { text-decoration: none; }
 .pill.err  { background: var(--err-soft);  color: var(--err-text);  border-color: transparent; }
 .pill.info { background: var(--blue-soft);  color: var(--info-text);  border-color: transparent; }
 .pill.muted { color: var(--ink-3); background: var(--recess); border-color: transparent; }
+@media (prefers-reduced-motion: no-preference) {
+  .pill-critical-pulse { animation: pulse-dot 0.8s ease-in-out infinite; font-weight: 700; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .pill-critical-pulse { font-weight: 700; }
+}
 /* ── VD-3: per-step hover diff panel ─────────────────────────────── */
 /* Position is set inline (fixed coordinates from the anchor row's
  * getBoundingClientRect) — the panel renders into a React Portal at

--- a/dashboard/src/app/marketplace/page.tsx
+++ b/dashboard/src/app/marketplace/page.tsx
@@ -1270,7 +1270,7 @@ export default function MarketplacePage() {
               <div className="lft">
                 <div className="star">★ Featured this week</div>
                 <h3 className="mono">{shortName(featured.name)}</h3>
-                <div className="sub" style={{ maxWidth: "48ch", fontSize: "var(--fs-s)", color: "var(--ink-2)" }}>
+                <div style={{ maxWidth: "48ch", fontSize: "var(--fs-s)", color: "var(--ink-2)" }}>
                   {featured.description}
                 </div>
                 <div style={{ display: "flex", gap: 8, marginTop: "var(--s-4)" }}>

--- a/dashboard/src/app/transactions/page.tsx
+++ b/dashboard/src/app/transactions/page.tsx
@@ -76,16 +76,12 @@ function TtlPill({ expiresAt }: { expiresAt: number }) {
   const warning = !expired && !critical && ms < 60_000;
   const cls =
     expired || critical
-      ? "pill err"
+      ? `pill err${critical ? " pill-critical-pulse" : ""}`
       : warning
         ? "pill warn"
         : "pill muted";
   return (
-    <span
-      className={cls}
-      title={`expires ${new Date(expiresAt).toISOString()}`}
-      style={critical ? { animation: "pulse-dot 0.8s ease-in-out infinite", fontWeight: 700 } : undefined}
-    >
+    <span className={cls} title={`expires ${new Date(expiresAt).toISOString()}`}>
       TTL {ttlRemaining(expiresAt)}
     </span>
   );


### PR DESCRIPTION
## Summary
Replaces #1120, which was accidentally built on a stale/diverged branch (missing #1116-#1118, plus a stray already-merged commit) and hit a real merge conflict. This branch is cut cleanly from current `main` with just the two intended commits cherry-picked over.

Final audit pass over the recently-touched dashboard pages beyond the earlier Overview-only pass (#1118): activity, analytics, approvals, connections, decisions, inbox, insights, marketplace, recipes, runs, sessions, settings, suggestions, tasks, traces, transactions, workers.

**5 real findings, all fixed:**
1. `transactions/page.tsx`'s `TtlPill` set its critical-state pulse via an inline `style={{ animation }}` — CSS media queries can't target inline styles, so it kept looping regardless of `prefers-reduced-motion`. Moved to a new `.pill-critical-pulse` class using the same gating pattern as `.td-pill-critical`.
2. `decisions/page.tsx`: `visually-hidden` className has no matching CSS rule — the correct existing utility is `.sr-only`. Swapped in, dropped the duplicate inline styles.
3. `marketplace/page.tsx`: `sub` className on the featured-recipe description has no matching rule (dead — already fully inline-styled). Removed.
4. `recipes/[...name]/layout.tsx`: `rd-needs`/`rd-needs-row` (the "recipe needs setup before running" alert box) had zero CSS — rendered as unstyled plain text. Added a warn-toned alert box matching the page's existing `.rd-error-card` pattern.
5. `runs/page.tsx`: **live bug** — `runs-tr--failure` had zero CSS. Rows that fail via `assertionFailures.length > 0` alone (status not `"error"`) relied entirely on this modifier for their red failure border, since the sibling `[data-status="error"]` attribute selector doesn't cover that case. Those rows were silently rendering with no failure indication.

Everything else reviewed (className↔CSS consistency across the rest of the pages, `setInterval` cleanup on all polling pages, `dangerouslySetInnerHTML` usage, the copilot chat's propose-not-execute safety boundary) came back clean.

## Test plan
- `npx tsc --noEmit` on the dashboard passes with no new errors touching these files.
- All changes are CSS/className swaps or additions — no new runtime logic; verified each className now has exactly one matching selector via grep.