### PR TITLE
feat(dashboard): restore the "N of 3 done" morning-habit strip on Overview

### DIFF
--- a/dashboard/src/app/__tests__/page.test.tsx
+++ b/dashboard/src/app/__tests__/page.test.tsx
@@ -607,6 +607,57 @@ describe("<HomePage/> — Terminal deck", () => {
     });
   });
 
+  it("shows the 'N of 3 done' morning-habit strip between the statusline and the pane grid, and 'You're clear' once all 3 are done", async () => {
+    mockFetchRoutes(HEALTHY_ROUTES);
+    const { container } = render(<HomePage />);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(50);
+    });
+
+    const strip = container.querySelector(".td-today-strip");
+    expect(strip).toBeTruthy();
+    // Placed between the statusline and the grid, not inside either.
+    expect(strip?.previousElementSibling).toHaveClass("td-statusline");
+    expect(strip?.nextElementSibling).toHaveClass("td-grid");
+    // HEALTHY_ROUTES has no pending outcomes, no workers, no inbox items —
+    // all 3 sections ("decisions", "team", "brief") read as done.
+    expect(strip?.textContent).toMatch(/You're clear/);
+  });
+
+  it("today strip shows 'N of 3 done' when a worker-verdict confirmation is still pending", async () => {
+    global.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input.toString();
+      for (const [key, make] of Object.entries({
+        ...HEALTHY_ROUTES,
+        "/api/bridge/outcomes/pending": () =>
+          jsonResponse({
+            pending: [
+              {
+                issueUrl: "https://github.com/o/r/issues/1",
+                recipeName: "triage-failing-tests",
+                workerId: "test-guardian",
+                workerName: "Test Guardian",
+                filedAt: Date.now() - 60_000,
+                classKey: "issue:compensable:high",
+                title: "Login test failing on main",
+              },
+            ],
+          }),
+      })) {
+        if (url.includes(key)) return make();
+      }
+      return jsonResponse({}, 404);
+    }) as unknown as typeof fetch;
+
+    const { container } = render(<HomePage />);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(50);
+    });
+
+    const strip = container.querySelector(".td-today-strip");
+    expect(strip?.textContent).toMatch(/2 of 3 done/);
+  });
+
   it("4:workers header shows a promote/demote rollup (folded from /today's 'glance at the team')", async () => {
     mockFetchRoutes({
       ...HEALTHY_ROUTES,

--- a/dashboard/src/app/globals.css
+++ b/dashboard/src/app/globals.css
@@ -9713,6 +9713,17 @@ details[open] .traces-detail-arrow { transform: rotate(90deg); }
 [data-theme="paper"] .td-statusline .td-err { color: var(--err-text, var(--err)); }
 [data-theme="paper"] .td-statusline .td-warn { color: var(--warn-text, var(--warn)); }
 
+/* "N of 3 done" morning-habit strip, between the statusline and the pane
+   grid — see TodayProgressStrip in page.tsx. */
+.td-today-strip {
+  margin-bottom: 14px;
+  font-size: var(--fs-s);
+  color: var(--terminal-comment);
+}
+.td-today-clear { color: #7fd1a8; }
+[data-theme="paper"] .td-today-strip { color: var(--ink-3); }
+[data-theme="paper"] .td-today-clear { color: var(--ok-text, var(--ok)); }
+
 .td-grid {
   display: grid;
   grid-template-columns: repeat(6, 1fr);

--- a/dashboard/src/app/page.tsx
+++ b/dashboard/src/app/page.tsx
@@ -230,6 +230,41 @@ function haltAgeTier(ageMs: number): HaltAgeTier {
   return "fresh";
 }
 
+// "N of 3 done" strip — the former standalone /today page's morning-habit
+// framing (clear decisions / glance at team / read the brief), removed as
+// a page in #1112 when its 3 sections were folded into 0:attention/
+// 4:workers/6:inbox. Re-added here (2026-07-04) as a thin status line the
+// user still wanted between the statusline and the pane grid: it derives
+// "done" from data these panes already compute, it isn't a second source
+// of truth. `nextBriefLabel` mirrors #1112's "next brief" framing when
+// all 3 are clear — passed in rather than fetched again here.
+function TodayProgressStrip({
+  decisionsDone,
+  teamDone,
+  briefDone,
+  nextBriefLabel,
+}: {
+  decisionsDone: boolean;
+  teamDone: boolean;
+  briefDone: boolean;
+  nextBriefLabel: string | null;
+}) {
+  const doneCount = [decisionsDone, teamDone, briefDone].filter(Boolean).length;
+  const allDone = doneCount === 3;
+  return (
+    <div className="td-today-strip" role="status" aria-live="polite" aria-atomic="true">
+      {allDone ? (
+        <span className="td-today-clear">
+          <span aria-hidden="true">✓</span> You&apos;re clear
+          {nextBriefLabel ? ` — next brief ${nextBriefLabel}` : " — check back tomorrow."}
+        </span>
+      ) : (
+        <span className="td-today-count">{doneCount} of 3 done</span>
+      )}
+    </div>
+  );
+}
+
 function eventLine(e: ActivityEvent): string {
   if (e.kind === "tool") return e.tool ?? "tool";
   if (e.kind === "lifecycle" && e.event) return e.event.replace(/_/g, " ");
@@ -1157,6 +1192,13 @@ export default function HomePage() {
           </span>
         )}
       </div>
+
+      <TodayProgressStrip
+        decisionsDone={workerPending.length === 0}
+        teamDone={promotableCount === 0 && demotedRecentCount === 0}
+        briefDone={inboxUnreadCount === 0}
+        nextBriefLabel={null}
+      />
 
       <div className="td-grid">
         {/* 0: attention */}


### PR DESCRIPTION
## Summary
User feedback on the Overview redesign: the old standalone `/today` page had an "N of 3 done" progress strip (clear decisions / glance at team / read the brief) at the top. When it was folded into Overview (#1112), that strip was dropped — each of the 3 checklist items was folded into an existing pane's content (0:attention's confirm queue, 4:workers' rollup, 6:inbox's NEW/read distinction) instead of kept as a standalone visual element. The user still wanted that one-line status visible, specifically between the statusline and the pane grid — confirmed via a clarifying question before implementing.

- New `TodayProgressStrip` component, rendered between `.td-statusline` and `.td-grid`.
- Derives "done" for each of the 3 sections from data the panes already compute — no new fetches:
  - **decisions**: `workerPending.length === 0` (same data 0:attention's confirm queue uses)
  - **team**: `promotableCount === 0 && demotedRecentCount === 0` (same data 4:workers' rollup uses)
  - **brief**: `inboxUnreadCount === 0` (same data 6:inbox's unread count uses)
- Shows "N of 3 done" while any are pending, "You're clear" once all 3 are done (mirrors the original page's copy).

## Test plan
- 2 new tests: strip renders between statusline/grid and shows "You're clear" on a healthy bridge with nothing pending; shows "2 of 3 done" when a worker-verdict confirmation is pending.
- All 27 tests in `page.test.tsx` pass (25 existing + 2 new).
- `npx tsc --noEmit` passes with no new errors.
- Verified live against the running dev server (screenshot attached in conversation) — renders correctly in the exact position requested, no console errors.