### PR TITLE
feat(dashboard): restore the "Unified morning" section on Overview

### DIFF
--- a/dashboard/src/app/__tests__/page.test.tsx
+++ b/dashboard/src/app/__tests__/page.test.tsx
@@ -646,6 +646,145 @@ describe("<HomePage/> — Terminal deck", () => {
   });
 
   // --------------------------------------------------------------------
+  // "Unified morning" section — restored /today content, between the
+  // statusline and the pane grid.
+  // --------------------------------------------------------------------
+
+  it("shows the collapsed 'You're clear' banner when nothing is waiting", async () => {
+    mockFetchRoutes(HEALTHY_ROUTES);
+    const { container } = render(<HomePage />);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(50);
+    });
+
+    // HEALTHY_ROUTES has no approvals, no pending outcomes, no workers, no
+    // inbox items — all 3 sections read as done.
+    const done = container.querySelector(".td-today-done");
+    expect(done).toBeTruthy();
+    expect(done?.textContent).toMatch(/You're clear/);
+    expect(container.querySelector(".td-today")).toBeNull();
+    // Placed between the statusline and the grid, not inside either.
+    expect(done?.previousElementSibling).toHaveClass("td-statusline");
+    expect(done?.nextElementSibling).toHaveClass("td-grid");
+  });
+
+  it("section 2 lists a pending approval with a blast badge and Approve/Deny wired to the same endpoint as /approvals", async () => {
+    const approveMock = vi.fn().mockResolvedValue(jsonResponse({ ok: true }));
+    global.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url.includes("/api/bridge/approvals/approve/")) return approveMock(init);
+      for (const [key, make] of Object.entries({
+        ...HEALTHY_ROUTES,
+        "/api/bridge/approvals": () =>
+          jsonResponse([
+            {
+              callId: "call-1",
+              toolName: "gitPush",
+              tier: "medium",
+              requestedAt: Date.now(),
+              summary: "push to main",
+            },
+          ]),
+      })) {
+        if (url.includes(key)) return make();
+      }
+      return jsonResponse({}, 404);
+    }) as unknown as typeof fetch;
+
+    const { container } = render(<HomePage />);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(50);
+    });
+
+    const section = container.querySelector(".td-today");
+    expect(section).toBeTruthy();
+    expect(section?.textContent).toMatch(/gitPush/);
+    expect(section?.textContent).toMatch(/push to main/);
+
+    const approveBtn = within(section as HTMLElement).getByText("Approve");
+    await act(async () => {
+      approveBtn.click();
+    });
+
+    await waitFor(() => {
+      expect(approveMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("section 2's high-tier approve asks for confirmation, same safety gate as /approvals", async () => {
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(false);
+    mockFetchRoutes({
+      ...HEALTHY_ROUTES,
+      "/api/bridge/approvals": () =>
+        jsonResponse([
+          {
+            callId: "call-2",
+            toolName: "runCommand",
+            tier: "high",
+            requestedAt: Date.now(),
+            summary: "rm -rf /tmp/x",
+          },
+        ]),
+    });
+
+    const { container } = render(<HomePage />);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(50);
+    });
+
+    const section = container.querySelector(".td-today") as HTMLElement;
+    const approveBtn = within(section).getByText("Approve");
+    await act(async () => {
+      approveBtn.click();
+    });
+
+    expect(confirmSpy).toHaveBeenCalled();
+    // User declined the confirm — the row must still be there, not silently approved.
+    expect(section.textContent).toMatch(/runCommand/);
+    confirmSpy.mockRestore();
+  });
+
+  it("section 3 lists the promotable/demoted workers by name with trust percentages", async () => {
+    mockFetchRoutes({
+      ...HEALTHY_ROUTES,
+      "/api/bridge/workers/shadow": () =>
+        jsonResponse({
+          workers: [
+            {
+              workerId: "w1",
+              name: "Dependency Bump",
+              autonomyCeiling: 1,
+              board: [
+                {
+                  classKey: "vcs-remote:compensable:medium",
+                  level: 3,
+                  observations: 20,
+                  mean: 0.95,
+                  owned: true,
+                },
+              ],
+              events: [],
+              compared: 10,
+              agreed: 9,
+              divergences: [],
+            },
+          ],
+          runsScanned: 0,
+          decisionsScanned: 0,
+        }),
+    });
+    const { container } = render(<HomePage />);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(50);
+    });
+
+    const section = container.querySelector(".td-today") as HTMLElement;
+    expect(section.textContent).toMatch(/Dependency Bump/);
+    expect(section.textContent).toMatch(/ready for a promotion/);
+    expect(section.textContent).toMatch(/90% over 10 tries/);
+  });
+
+  // --------------------------------------------------------------------
   // 7:copilot — Tier 1 lever-action chat pane.
   // --------------------------------------------------------------------
 

--- a/dashboard/src/app/globals.css
+++ b/dashboard/src/app/globals.css
@@ -9713,6 +9713,79 @@ details[open] .traces-detail-arrow { transform: rotate(90deg); }
 [data-theme="paper"] .td-statusline .td-err { color: var(--err-text, var(--err)); }
 [data-theme="paper"] .td-statusline .td-warn { color: var(--warn-text, var(--warn)); }
 
+/* "Unified morning" section — restored /today content, between the
+   statusline and the pane grid (mockup's TY · Unified morning variant).
+   See TodayMorningSection in page.tsx. */
+.td-today {
+  border: 1px solid var(--line-2);
+  border-radius: var(--r-2, 6px);
+  background: var(--surface);
+  color: var(--terminal-fg);
+  padding: 14px 18px 16px;
+  margin-bottom: 14px;
+}
+[data-theme="paper"] .td-today { color: var(--ink-0); }
+.td-today-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 14px;
+  flex-wrap: wrap;
+  margin-bottom: 14px;
+}
+.td-today-title { font-size: var(--fs-base); }
+.td-today-title em { font-style: normal; color: var(--orange); }
+.td-today-progress { display: flex; gap: 5px; align-items: center; flex: none; }
+.td-today-progress i { width: 20px; height: 6px; border-radius: 3px; background: var(--recess); display: block; }
+.td-today-progress i.d { background: var(--ok); }
+.td-today-sec { margin-bottom: 14px; }
+.td-today-sec:last-child { margin-bottom: 0; }
+.td-today-sh { display: flex; gap: 8px; align-items: baseline; margin-bottom: 8px; flex-wrap: wrap; }
+.td-today-sh h3 { font-size: var(--fs-s); margin: 0; }
+.td-today-n {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: var(--terminal-fg);
+  color: var(--terminal-bg);
+  font-size: var(--fs-2xs);
+  font-weight: 700;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: none;
+}
+.td-today-card {
+  background: var(--recess);
+  border-radius: var(--r-2, 6px);
+  padding: 10px 14px;
+  font-size: var(--fs-s);
+}
+.td-today-brief-text { margin: 0; max-width: 68ch; line-height: 1.5; }
+.td-today-actions {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  margin-top: 10px;
+  padding-top: 10px;
+  border-top: 1px solid var(--line-1);
+}
+.td-today-rows { display: flex; flex-direction: column; gap: 8px; padding: 4px 0; }
+.td-today-row { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; font-size: var(--fs-s); }
+.td-today-row-body { min-width: 0; }
+.td-today-done {
+  border: 1px solid rgba(127, 209, 168, 0.4);
+  background: var(--ok-soft);
+  border-radius: var(--r-2, 6px);
+  padding: 12px 16px;
+  margin-bottom: 14px;
+  font-size: var(--fs-base);
+  color: var(--ok-text, #3f6b36);
+  display: flex;
+  gap: 10px;
+  align-items: center;
+}
+
 .td-grid {
   display: grid;
   grid-template-columns: repeat(6, 1fr);

--- a/dashboard/src/app/page.tsx
+++ b/dashboard/src/app/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 import Link from "next/link";
 import { useEffect, useMemo, useRef, useState } from "react";
+import type { ReactNode } from "react";
 import { apiPath } from "@/lib/api";
 import { recipeDisplayName } from "@/lib/recipeDisplay";
 import { FirstRunChecklist } from "@/components/FirstRunChecklist";
@@ -29,6 +30,8 @@ import {
   type WorkerReport,
 } from "@/lib/workerTrust";
 import { describeNextRun, humanizeSchedule } from "@/lib/humanSchedule";
+import { classifyPendingAction, reversibilityRank } from "@/lib/actionClass";
+import { BlastBadge } from "@/components/patchwork";
 import { usePaneShortcut } from "@/hooks/usePaneShortcuts";
 import { isNoiseEvent } from "@/lib/activityNoise";
 import { eventLevel as activityEventLevel } from "@/lib/activityLevel";
@@ -228,6 +231,254 @@ function haltAgeTier(ageMs: number): HaltAgeTier {
   if (ageMs >= 6 * 60 * 60 * 1000) return "critical";
   if (ageMs >= 60 * 60 * 1000) return "stale";
   return "fresh";
+}
+
+/** agreed/compared as a 0-100 trust percentage, or null if there's no
+ *  comparison history yet (never fabricate a rate from zero data). */
+function workerTrustPct(w: WorkerReport): number | null {
+  if (w.compared <= 0) return null;
+  return Math.round((w.agreed / w.compared) * 100);
+}
+
+// The former standalone /today page's "unified morning" layout (numbered
+// 1/2/3 sections + progress dots + collapse-to-clear banner), removed as
+// a page in #1112, restored here as a section on Overview between the
+// statusline and the pane grid per user request (2026-07-04) — the
+// minimal "N of 3 done" text-only version from the first attempt at this
+// wasn't what was wanted; this is a faithful port of the richer mockup
+// (docs artifact 21d32382, "TY · Unified morning" section) using data the
+// panes below already compute, not a second source of truth. Approvals
+// and worker-verdict actions here are ADDITIVE to 0:attention's existing
+// versions of the same queues (user's explicit choice — some duplication,
+// more surface area, rather than relocating that pane's content).
+function TodayMorningSection({
+  newestUnreadBrief,
+  newestBrief,
+  onMarkBriefRead,
+  approvals,
+  approvalBusy,
+  onApprovalDecide,
+  workerPending,
+  outcomeBusy,
+  onOutcomeDecide,
+  promotableWorkers,
+  demotedRecentWorkers,
+  otherWorkerCount,
+}: {
+  newestUnreadBrief: InboxItem | undefined;
+  newestBrief: InboxItem | undefined;
+  onMarkBriefRead: (name: string) => void;
+  approvals: Pending[];
+  approvalBusy: string | null;
+  onApprovalDecide: (p: Pending, decision: "approve" | "reject") => void;
+  workerPending: PendingConfirmation[];
+  outcomeBusy: string | null;
+  onOutcomeDecide: (p: PendingConfirmation, disposition: "confirmed" | "junk") => void;
+  promotableWorkers: WorkerReport[];
+  demotedRecentWorkers: WorkerReport[];
+  otherWorkerCount: number;
+}) {
+  const decisionsDone = approvals.length === 0 && workerPending.length === 0;
+  const teamDone = promotableWorkers.length === 0 && demotedRecentWorkers.length === 0;
+  const briefDone = !newestUnreadBrief;
+  const doneCount = [decisionsDone, teamDone, briefDone].filter(Boolean).length;
+  const allDone = doneCount === 3;
+
+  const sortedApprovals = [...approvals].sort(
+    (a, b) =>
+      reversibilityRank(classifyPendingAction(a.toolName)?.reversibility) -
+      reversibilityRank(classifyPendingAction(b.toolName)?.reversibility),
+  );
+
+  if (allDone) {
+    return (
+      <div className="td-today-done" role="status">
+        <span aria-hidden="true">✓</span> You&apos;re clear — check back tomorrow.
+      </div>
+    );
+  }
+
+  const decisionCount = approvals.length + workerPending.length;
+  const titleParts: ReactNode[] = [];
+  if (!decisionsDone) {
+    titleParts.push(
+      <em key="decisions">
+        {decisionCount} decision{decisionCount === 1 ? "" : "s"}
+      </em>,
+    );
+  }
+  if (!briefDone) titleParts.push("one brief");
+
+  return (
+    <div className="td-today">
+      <div className="td-today-head">
+        <span className="td-today-title">
+          Morning.{" "}
+          {titleParts.length === 0 ? (
+            "Nothing waiting"
+          ) : (
+            titleParts.reduce<ReactNode[]>(
+              (acc, part, i) => (i === 0 ? [part] : [...acc, ", ", part]),
+              [],
+            )
+          )}
+          , and you&apos;re clear.
+        </span>
+        <span className="td-today-progress" aria-label={`${doneCount} of 3 done`}>
+          <i className={decisionsDone ? "d" : ""} />
+          <i className={teamDone ? "d" : ""} />
+          <i className={briefDone ? "d" : ""} />
+        </span>
+      </div>
+
+      <div className="td-today-sec">
+        <div className="td-today-sh">
+          <span className="td-today-n">1</span>
+          <h3>Read the brief</h3>
+          {newestUnreadBrief && <span className="td-muted">from {newestUnreadBrief.provenance?.recipe ?? "morning-brief"}</span>}
+        </div>
+        {newestUnreadBrief ? (
+          <div className="td-today-card">
+            <p className="td-today-brief-text">{newestUnreadBrief.preview}</p>
+            <div className="td-today-actions">
+              <Link href="/inbox" className="btn sm ghost">
+                Open full note
+              </Link>
+              <span className="td-sp" />
+              <button
+                type="button"
+                className="btn sm ghost"
+                onClick={() => onMarkBriefRead(newestUnreadBrief.name)}
+              >
+                Mark read ✓
+              </button>
+            </div>
+          </div>
+        ) : (
+          <div className="td-today-card td-muted">
+            {newestBrief ? "No new brief since last read." : "No briefs yet."}
+          </div>
+        )}
+      </div>
+
+      <div className="td-today-sec">
+        <div className="td-today-sh">
+          <span className="td-today-n">2</span>
+          <h3>Clear the decisions</h3>
+          {!decisionsDone && (
+            <span className="td-muted">{decisionCount} waiting · worst first</span>
+          )}
+        </div>
+        {decisionsDone ? (
+          <div className="td-today-card td-muted">Nothing waiting.</div>
+        ) : (
+          <div className="td-today-card td-today-rows">
+            {sortedApprovals.map((p) => (
+              <div className="td-today-row" key={p.callId}>
+                <BlastBadge cls={classifyPendingAction(p.toolName)} />
+                <span className="td-today-row-body">
+                  <strong className="mono">{p.toolName}</strong>
+                  {p.summary ? ` — ${p.summary}` : ""}
+                </span>
+                <span className="td-sp" />
+                <button
+                  type="button"
+                  className="btn sm primary"
+                  disabled={approvalBusy === p.callId}
+                  onClick={() => onApprovalDecide(p, "approve")}
+                >
+                  Approve
+                </button>
+                <button
+                  type="button"
+                  className="btn sm ghost"
+                  disabled={approvalBusy === p.callId}
+                  onClick={() => onApprovalDecide(p, "reject")}
+                >
+                  Deny
+                </button>
+              </div>
+            ))}
+            {workerPending.map((p) => (
+              <div className="td-today-row" key={p.issueUrl}>
+                <span className="pill muted">verdict</span>
+                <span className="td-today-row-body">
+                  <strong>{p.workerName}</strong> filed &ldquo;{p.title ?? "a new issue"}&rdquo; — real?
+                </span>
+                <span className="td-sp" />
+                <button
+                  type="button"
+                  className="btn sm primary"
+                  disabled={outcomeBusy === p.issueUrl}
+                  onClick={() => onOutcomeDecide(p, "confirmed")}
+                >
+                  Looks real
+                </button>
+                <button
+                  type="button"
+                  className="btn sm ghost"
+                  disabled={outcomeBusy === p.issueUrl}
+                  onClick={() => onOutcomeDecide(p, "junk")}
+                >
+                  Not real
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <div className="td-today-sec">
+        <div className="td-today-sh">
+          <span className="td-today-n">3</span>
+          <h3>Glance at the team</h3>
+        </div>
+        {teamDone ? (
+          <div className="td-today-card td-muted">Team is quiet and healthy.</div>
+        ) : (
+          <div className="td-today-card td-today-rows">
+            {promotableWorkers.map((w) => {
+              const pct = workerTrustPct(w);
+              return (
+                <div className="td-today-row" key={`promo-${w.workerId}`}>
+                  <span className="dot ok" />
+                  <span className="td-today-row-body">
+                    <strong>{w.name}</strong> is ready for a promotion
+                    {pct != null ? ` — ${pct}% over ${w.compared} tries.` : "."}
+                  </span>
+                  <span className="td-sp" />
+                  <Link href="/workers" className="btn sm ghost">
+                    Raise limit →
+                  </Link>
+                </div>
+              );
+            })}
+            {demotedRecentWorkers.map((w) => {
+              const pct = workerTrustPct(w);
+              return (
+                <div className="td-today-row" key={`demote-${w.workerId}`}>
+                  <span className="dot warn" />
+                  <span className="td-today-row-body">
+                    <strong>{w.name}</strong> rebuilding trust after a recent demotion
+                    {pct != null ? ` (${pct}%).` : "."}
+                  </span>
+                </div>
+              );
+            })}
+            {otherWorkerCount > 0 && (
+              <div className="td-today-row">
+                <span className="dot mut" />
+                <span className="td-today-row-body">
+                  {otherWorkerCount} other{otherWorkerCount === 1 ? "" : "s"} quiet and healthy ·{" "}
+                  <Link href="/workers">full roster →</Link>
+                </span>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
 }
 
 function eventLine(e: ActivityEvent): string {
@@ -480,6 +731,7 @@ export default function HomePage() {
   });
   const toast = useToast();
   const [outcomeBusy, setOutcomeBusy] = useState<string | null>(null);
+  const [approvalBusy, setApprovalBusy] = useState<string | null>(null);
 
   const [pendingApprovals, setPendingApprovals] = useState<Pending[]>([]);
   const [recipes, setRecipes] = useState<Recipe[]>([]);
@@ -688,6 +940,43 @@ export default function HomePage() {
     }
   }
 
+  // Mirrors approvals/page.tsx's `decide()` — same endpoint, same high-tier
+  // confirm/reason-prompt gate (a stray click on a high-tier `rm -rf`
+  // approving instantly was a real, already-fixed bug there; this surface
+  // must not reopen it). A 409 means another session already decided —
+  // treated as success so the row just clears rather than erroring.
+  async function actApproval(p: Pending, decision: "approve" | "reject") {
+    if (decision === "approve" && p.tier === "high") {
+      const proceed = window.confirm(`Approve high-risk ${p.toolName}? This cannot be undone.`);
+      if (!proceed) return;
+    }
+    let reason: string | undefined;
+    if (decision === "reject" && p.tier === "high") {
+      const entered = window.prompt(
+        `Why are you rejecting ${p.toolName}? (logged for audit; max 500 chars)`,
+        "",
+      );
+      if (entered === null) return;
+      reason = entered.trim() || undefined;
+    }
+    setApprovalBusy(p.callId);
+    try {
+      const init: RequestInit = { method: "POST" };
+      if (reason) {
+        init.headers = { "Content-Type": "application/json" };
+        init.body = JSON.stringify({ reason: reason.slice(0, 500) });
+      }
+      const res = await fetch(apiPath(`/api/bridge/approvals/${decision}/${p.callId}`), init);
+      if (!res.ok && res.status !== 409) throw new Error(`${decision} failed (${res.status})`);
+      toast.success(decision === "approve" ? "Approved" : "Denied");
+      setPendingApprovals((prev) => prev.filter((x) => x.callId !== p.callId));
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : String(e));
+    } finally {
+      setApprovalBusy(null);
+    }
+  }
+
   // A run "live" locally overrides its status if we've already optimistically
   // cancelled it (same override LiveRunsStrip.tsx uses) so the Stop control
   // disappears immediately instead of waiting on the next poll tick.
@@ -841,11 +1130,13 @@ export default function HomePage() {
   // Per-row ⚑/▼ markers below already carry the detail; this is just the
   // one-line "should I even look" summary the deck's header convention
   // wants (mirrors 0:attention's "· N items" / 2:fleet's "N/M on").
-  const promotableCount = workers.filter(readyToAdvance).length;
-  const demotedRecentCount = workers.filter((w) => {
+  const promotableWorkers = workers.filter(readyToAdvance);
+  const demotedRecentWorkers = workers.filter((w) => {
     const d = lastDemotion(w);
     return Boolean(d) && Date.now() - (d?.at ?? 0) < 7 * 86_400_000;
-  }).length;
+  });
+  const promotableCount = promotableWorkers.length;
+  const demotedRecentCount = demotedRecentWorkers.length;
 
   // ---- Pane 6: inbox ---------------------------------------------------
   // Data source: workspace-level GET /api/inbox (proxies bridge GET /inbox,
@@ -863,9 +1154,30 @@ export default function HomePage() {
       /* ignore */
     }
   }, []);
+  // Shared by the 6:inbox row click and the morning-strip's "Mark read" —
+  // one seen-set, so reading the brief from either place clears both.
+  function markInboxSeen(name: string) {
+    setInboxSeen((prev) => {
+      const next = new Set(prev);
+      next.add(name);
+      try {
+        window.localStorage.setItem(INBOX_SEEN_KEY, JSON.stringify([...next]));
+      } catch {
+        /* ignore */
+      }
+      return next;
+    });
+  }
   const inboxAllItems = inboxData?.items ?? [];
   const inboxItems = inboxAllItems.slice(0, 3);
   const inboxUnreadCount = inboxAllItems.filter((item) => !inboxSeen.has(item.name)).length;
+  const isBriefItem = (name: string) => name.toLowerCase().includes("morning-brief");
+  const briefItems = inboxAllItems
+    .filter((item) => isBriefItem(item.name))
+    .slice()
+    .sort((a, b) => Date.parse(b.modifiedAt) - Date.parse(a.modifiedAt));
+  const newestBrief = briefItems[0];
+  const newestUnreadBrief = briefItems.find((item) => !inboxSeen.has(item.name));
 
   // Pane focus / keyboard nav (usePaneShortcuts, PR #1092).
   const [activePane, setActivePane] = useState(0);
@@ -1157,6 +1469,25 @@ export default function HomePage() {
           </span>
         )}
       </div>
+
+      <TodayMorningSection
+        newestUnreadBrief={newestUnreadBrief}
+        newestBrief={newestBrief}
+        onMarkBriefRead={markInboxSeen}
+        approvals={pendingApprovals}
+        approvalBusy={approvalBusy}
+        onApprovalDecide={actApproval}
+        workerPending={workerPending}
+        outcomeBusy={outcomeBusy}
+        onOutcomeDecide={actOutcome}
+        promotableWorkers={promotableWorkers}
+        demotedRecentWorkers={demotedRecentWorkers}
+        otherWorkerCount={Math.max(
+          0,
+          workers.length -
+            new Set([...promotableWorkers, ...demotedRecentWorkers].map((w) => w.workerId)).size,
+        )}
+      />
 
       <div className="td-grid">
         {/* 0: attention */}
@@ -1789,18 +2120,7 @@ export default function HomePage() {
                   href="/inbox"
                   className="td-inbox-row"
                   key={item.name}
-                  onClick={() => {
-                    setInboxSeen((prev) => {
-                      const next = new Set(prev);
-                      next.add(item.name);
-                      try {
-                        window.localStorage.setItem(INBOX_SEEN_KEY, JSON.stringify([...next]));
-                      } catch {
-                        /* ignore */
-                      }
-                      return next;
-                    });
-                  }}
+                  onClick={() => markInboxSeen(item.name)}
                 >
                   {isNew ? (
                     <span className="td-pill td-pill-warn">NEW</span>


### PR DESCRIPTION
## Summary
Replaces the closed #1122 (a minimal "N of 3 done" text strip that wasn't what was wanted). This is a faithful port of the mockup's richer "TY · Unified morning" variant, added between the statusline and the pane grid on Overview.

Three numbered sections, each backed by real data the panes below already compute (no new endpoints):
1. **Read the brief** — newest unread morning-brief-style inbox item, Open full note / Mark read. Shares the exact same `inboxSeen` localStorage set as 6:inbox (extracted `markInboxSeen`) so marking read from either place clears both.
2. **Clear the decisions** — real pending approvals (`BlastBadge` + Approve/Deny, sorted worst-blast-tier-first) plus the worker-verdict confirm queue (Looks real/Not real). The new `actApproval` handler mirrors `/approvals`'s `decide()` exactly, including its high-tier confirm()/reason-prompt() gate — that gate exists because a stray click on a high-tier `rm -rf` used to approve instantly before it was added; this surface must not reopen that. Per explicit user direction, this is **additive** to 0:attention's existing worker-verdict queue, not a replacement (some duplication, more surface area, deliberate choice).
3. **Glance at the team** — real promotable/demoted workers with trust percentages, same data 4:workers' rollup uses.

Collapses to a single "You're clear" banner when all 3 are done.

## Test plan
- 4 new tests: collapsed "You're clear" state placement, approval row renders + Approve wired to the same endpoint as `/approvals`, high-tier approve's confirm() gate blocks on cancel, team section lists real worker names/percentages.
- All 29 tests in `page.test.tsx` pass (25 existing + 4 new).
- `npx tsc --noEmit` clean.
- Verified live against the running bridge (dev server, screenshots in conversation) — renders correctly, Mark read advances through multiple unread briefs, no console errors.