### PR TITLE
feat(dashboard): worst-blast-tier approval action + fleet run metadata

### DIFF
--- a/dashboard/src/app/__tests__/page.test.tsx
+++ b/dashboard/src/app/__tests__/page.test.tsx
@@ -130,6 +130,48 @@ describe("<HomePage/> — Terminal deck", () => {
     expect(screen.getByText(/patchwork · local:/)).toBeTruthy();
   });
 
+  it("2:fleet shows an avg-duration + last-run-relative-time metadata line under a recipe with run history", async () => {
+    mockFetchRoutes({
+      ...HEALTHY_ROUTES,
+      "/api/bridge/runs": () =>
+        jsonResponse({
+          runs: [
+            {
+              seq: 1,
+              recipe: "daily-brief",
+              recipeName: "daily-brief",
+              startedAt: Date.now() - 5 * 60_000,
+              doneAt: Date.now() - 5 * 60_000 + 30_000,
+              durationMs: 30_000,
+              status: "done",
+            },
+            {
+              seq: 2,
+              recipe: "daily-brief",
+              recipeName: "daily-brief",
+              startedAt: Date.now() - 65 * 60_000,
+              doneAt: Date.now() - 65 * 60_000 + 90_000,
+              durationMs: 90_000,
+              status: "done",
+            },
+          ],
+        }),
+    });
+    const { container } = render(<HomePage />);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(50);
+    });
+
+    const rows = Array.from(container.querySelectorAll(".td-fleet-row"));
+    const row = rows.find((r) => r.textContent?.includes("Daily Brief"));
+    expect(row).toBeTruthy();
+    const meta = row?.querySelector(".td-fleet-meta");
+    expect(meta).toBeTruthy();
+    // avg of 30s and 90s = 60s.
+    expect(meta?.textContent).toMatch(/avg 1m 0s/);
+    expect(meta?.textContent).toMatch(/5m/);
+  });
+
   it("fails soft: one endpoint 500ing still lets the rest of the deck render", async () => {
     mockFetchRoutes({
       ...HEALTHY_ROUTES,
@@ -337,6 +379,60 @@ describe("<HomePage/> — Terminal deck", () => {
     await waitFor(() => {
       expect(within(attentionPane).queryByTitle("Stop this run of daily-brief")).toBeNull();
     });
+  });
+
+  it("0:attention shows the worst-blast-tier pending approval with a blast badge, sorted first, and Approve/Deny wired to the same endpoint as /approvals", async () => {
+    const approveMock = vi.fn().mockResolvedValue(jsonResponse({ ok: true }));
+    global.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url.includes("/api/bridge/approvals/approve/")) return approveMock(init);
+      for (const [key, make] of Object.entries({
+        ...HEALTHY_ROUTES,
+        "/api/bridge/approvals": () =>
+          jsonResponse([
+            {
+              callId: "call-low",
+              toolName: "readFile",
+              tier: "low",
+              requestedAt: Date.now(),
+              summary: "read a config file",
+            },
+            {
+              callId: "call-high",
+              toolName: "runCommand",
+              tier: "high",
+              requestedAt: Date.now(),
+              summary: "rm -rf /tmp/x",
+            },
+          ]),
+      })) {
+        if (url.includes(key)) return make();
+      }
+      return jsonResponse({}, 404);
+    }) as unknown as typeof fetch;
+
+    render(<HomePage />);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(50);
+    });
+
+    const attentionPane = screen.getByRole("region", { name: "attention" });
+    // The higher-blast-tier request (runCommand, tier high → classified
+    // irreversible) is shown, not the low-tier readFile — worst first.
+    expect(attentionPane.textContent).toMatch(/runCommand/);
+    expect(attentionPane.textContent).toMatch(/rm -rf \/tmp\/x/);
+
+    const approveBtn = within(attentionPane).getByText("Approve");
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
+    await act(async () => {
+      approveBtn.click();
+    });
+
+    expect(confirmSpy).toHaveBeenCalled(); // high-tier safety gate fired
+    await waitFor(() => {
+      expect(approveMock).toHaveBeenCalledTimes(1);
+    });
+    confirmSpy.mockRestore();
   });
 
   it("1:tail shows a Stop control on the row for an in-progress run matched by recipeName", async () => {

--- a/dashboard/src/app/globals.css
+++ b/dashboard/src/app/globals.css
@@ -9910,7 +9910,11 @@ details[open] .traces-detail-arrow { transform: rotate(90deg); }
 }
 
 /* Pane 2: fleet */
-.td-fleet-row { display: flex; align-items: center; gap: 8px; font-size: var(--fs-xs); }
+.td-fleet-row { display: flex; flex-direction: column; gap: 2px; font-size: var(--fs-xs); padding: 2px 0; }
+.td-fleet-row-top { display: flex; align-items: center; gap: 8px; }
+/* Mockup's R-A ".ra-meta" row — avg duration + last-run-relative-time,
+   indented under the glyph column so it reads as this row's detail. */
+.td-fleet-meta { padding-left: calc(1em + 8px); }
 .td-fleet-glyph { width: 1em; text-align: center; }
 /* Data-backed pulse for a recipe with a run in progress right now (not
    decorative) — mirrors the mockup's .he-pulse ring convention, adapted

--- a/dashboard/src/app/page.tsx
+++ b/dashboard/src/app/page.tsx
@@ -36,6 +36,8 @@ import { collapseConsecutiveEvents } from "@/lib/collapseConsecutiveEvents";
 import { triggerLabel } from "@/lib/triggerLabel";
 import { previewText } from "@/lib/textPreview";
 import { useToast } from "@/components/Toast";
+import { classifyPendingAction, reversibilityRank } from "@/lib/actionClass";
+import { BlastBadge } from "@/components/patchwork";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -216,6 +218,17 @@ function formatAgo(ms: number): string {
   if (hours > 0) return `${hours}h ${mins % 60}m ago`;
   if (mins > 0) return `${mins}m ${sec % 60}s ago`;
   return `${sec}s ago`;
+}
+
+/** A duration (not "ago"), for fleet's "avg 48s" metadata line. */
+function formatDurationShort(ms: number): string {
+  if (ms < 0) ms = 0;
+  const sec = Math.round(ms / 1000);
+  if (sec < 60) return `${sec}s`;
+  const mins = Math.floor(sec / 60);
+  if (mins < 60) return `${mins}m ${sec % 60}s`;
+  const hours = Math.floor(mins / 60);
+  return `${hours}h ${mins % 60}m`;
 }
 
 // Phase 4: halt-age escalation — a halt sitting unaddressed for hours
@@ -480,6 +493,7 @@ export default function HomePage() {
   });
   const toast = useToast();
   const [outcomeBusy, setOutcomeBusy] = useState<string | null>(null);
+  const [approvalBusy, setApprovalBusy] = useState<string | null>(null);
 
   const [pendingApprovals, setPendingApprovals] = useState<Pending[]>([]);
   const [recipes, setRecipes] = useState<Recipe[]>([]);
@@ -655,6 +669,15 @@ export default function HomePage() {
   const workerPending = pendingOutcomesData?.pending ?? [];
   const attentionCount = pendingCount + haltCount24h + errCount24h + workerPending.length;
   const topWorkerPending = [...workerPending].sort((a, b) => a.filedAt - b.filedAt)[0];
+  // Worst-blast-tier pending approval first (mockup's A-A "Considered" —
+  // "sorted by blast radius, the one that can't be undone is on top").
+  // Maps directly onto the worker-autonomy gate's existing
+  // domain:reversibility:blastTier vocabulary via classifyPendingAction.
+  const topApproval = [...pendingApprovals].sort(
+    (a, b) =>
+      reversibilityRank(classifyPendingAction(a.toolName)?.reversibility) -
+      reversibilityRank(classifyPendingAction(b.toolName)?.reversibility),
+  )[0];
   // Identity of whatever halt is currently the top attention item — a
   // "Mute 24h" click only ever fires from inside that halt's own action
   // row, so this is what a stored mute fingerprint gets compared against.
@@ -685,6 +708,43 @@ export default function HomePage() {
       toast.error(e instanceof Error ? e.message : String(e));
     } finally {
       setOutcomeBusy(null);
+    }
+  }
+
+  // Mirrors approvals/page.tsx's `decide()` — same endpoint, same high-tier
+  // confirm/reason-prompt gate (a stray click on a high-tier `rm -rf`
+  // approving instantly was a real, already-fixed bug there; this surface
+  // must not reopen it). A 409 means another session already decided —
+  // treated as success so the row just clears rather than erroring.
+  async function actApproval(p: Pending, decision: "approve" | "reject") {
+    if (decision === "approve" && p.tier === "high") {
+      const proceed = window.confirm(`Approve high-risk ${p.toolName}? This cannot be undone.`);
+      if (!proceed) return;
+    }
+    let reason: string | undefined;
+    if (decision === "reject" && p.tier === "high") {
+      const entered = window.prompt(
+        `Why are you rejecting ${p.toolName}? (logged for audit; max 500 chars)`,
+        "",
+      );
+      if (entered === null) return;
+      reason = entered.trim() || undefined;
+    }
+    setApprovalBusy(p.callId);
+    try {
+      const init: RequestInit = { method: "POST" };
+      if (reason) {
+        init.headers = { "Content-Type": "application/json" };
+        init.body = JSON.stringify({ reason: reason.slice(0, 500) });
+      }
+      const res = await fetch(apiPath(`/api/bridge/approvals/${decision}/${p.callId}`), init);
+      if (!res.ok && res.status !== 409) throw new Error(`${decision} failed (${res.status})`);
+      toast.success(decision === "approve" ? "Approved" : "Denied");
+      setPendingApprovals((prev) => prev.filter((x) => x.callId !== p.callId));
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : String(e));
+    } finally {
+      setApprovalBusy(null);
     }
   }
 
@@ -1293,6 +1353,38 @@ export default function HomePage() {
                   </div>
                 );
               })()}
+              {topApproval && (
+                <div className="td-attention-item">
+                  <div className="td-attention-head">
+                    <BlastBadge cls={classifyPendingAction(topApproval.toolName)} />
+                    <strong className="mono">{topApproval.toolName}</strong>
+                    <span className="td-muted">
+                      filed {formatAgo(nowMs - topApproval.requestedAt)}
+                    </span>
+                  </div>
+                  {topApproval.summary && (
+                    <div className="td-attention-reason">└ {topApproval.summary}</div>
+                  )}
+                  <div className="td-attention-actions">
+                    <button
+                      type="button"
+                      className="btn sm primary"
+                      disabled={approvalBusy === topApproval.callId}
+                      onClick={() => void actApproval(topApproval, "approve")}
+                    >
+                      Approve
+                    </button>
+                    <button
+                      type="button"
+                      className="btn sm ghost"
+                      disabled={approvalBusy === topApproval.callId}
+                      onClick={() => void actApproval(topApproval, "reject")}
+                    >
+                      Deny
+                    </button>
+                  </div>
+                </div>
+              )}
               {topWorkerPending && (
                 <div className="td-attention-item">
                   <div className="td-attention-head">
@@ -1469,40 +1561,59 @@ export default function HomePage() {
                 // sized to the success percentage.
                 const BAR_WIDTH = 8;
                 const filled = pct == null ? 0 : Math.round((pct / 100) * BAR_WIDTH);
+                // Mockup's R-A ".ra-meta" row (mined idea #7) — avg
+                // duration + last-run-relative-time, using the same
+                // runList this row's health bar already computes from.
+                const finishedRuns = runList.filter((r) => r.durationMs != null);
+                const avgDurationMs =
+                  finishedRuns.length > 0
+                    ? finishedRuns.reduce((sum, r) => sum + (r.durationMs ?? 0), 0) /
+                      finishedRuns.length
+                    : null;
+                const lastRun = runList[0];
                 return (
                   <div className="td-fleet-row" key={recipe.name}>
-                    <span
-                      className={`td-fleet-glyph${isLive ? " td-fleet-glyph-live" : ""}`}
-                      title={isLive ? "running now" : enabled ? "enabled" : "paused"}
-                    >
-                      {enabled ? "▶" : "⏸"}
-                    </span>
-                    <strong className="mono td-fleet-name">{recipeDisplayName(recipe.name)}</strong>
-                    <span className="td-muted td-fleet-trigger">{triggerLabel(trigger)}</span>
-                    {!enabled ? (
-                      <span className="td-fleet-bar td-muted" aria-hidden="true">
-                        {"─".repeat(BAR_WIDTH)}
+                    <div className="td-fleet-row-top">
+                      <span
+                        className={`td-fleet-glyph${isLive ? " td-fleet-glyph-live" : ""}`}
+                        title={isLive ? "running now" : enabled ? "enabled" : "paused"}
+                      >
+                        {enabled ? "▶" : "⏸"}
                       </span>
-                    ) : (
-                      // Keyed by `filled` so the whole bar remounts (and
-                      // replays its fade-in) when the success rate changes
-                      // between polls — reuses the tail pane's existing
-                      // .td-tail-enter convention rather than a new one.
-                      <span className="td-fleet-bar td-tail-enter" key={filled} aria-hidden="true">
-                        {Array.from({ length: BAR_WIDTH }, (_, i) =>
-                          i < filled ? (
-                            <span key={i} className="td-blk-ok">
-                              █
-                            </span>
-                          ) : (
-                            <span key={i} className="td-blk-empty">
-                              {hasHistory ? "─" : "·"}
-                            </span>
-                          ),
-                        )}
-                      </span>
+                      <strong className="mono td-fleet-name">{recipeDisplayName(recipe.name)}</strong>
+                      <span className="td-muted td-fleet-trigger">{triggerLabel(trigger)}</span>
+                      {!enabled ? (
+                        <span className="td-fleet-bar td-muted" aria-hidden="true">
+                          {"─".repeat(BAR_WIDTH)}
+                        </span>
+                      ) : (
+                        // Keyed by `filled` so the whole bar remounts (and
+                        // replays its fade-in) when the success rate changes
+                        // between polls — reuses the tail pane's existing
+                        // .td-tail-enter convention rather than a new one.
+                        <span className="td-fleet-bar td-tail-enter" key={filled} aria-hidden="true">
+                          {Array.from({ length: BAR_WIDTH }, (_, i) =>
+                            i < filled ? (
+                              <span key={i} className="td-blk-ok">
+                                █
+                              </span>
+                            ) : (
+                              <span key={i} className="td-blk-empty">
+                                {hasHistory ? "─" : "·"}
+                              </span>
+                            ),
+                          )}
+                        </span>
+                      )}
+                      <span className="td-muted">{!enabled ? "off" : pct == null ? "—" : `${Math.round(pct)}%`}</span>
+                    </div>
+                    {enabled && hasHistory && (avgDurationMs != null || lastRun) && (
+                      <div className="td-fleet-meta td-muted">
+                        {avgDurationMs != null && <>avg {formatDurationShort(avgDurationMs)}</>}
+                        {avgDurationMs != null && lastRun ? " · " : ""}
+                        {lastRun && <>{formatAgo(nowMs - lastRun.startedAt)}</>}
+                      </div>
                     )}
-                    <span className="td-muted">{!enabled ? "off" : pct == null ? "—" : `${Math.round(pct)}%`}</span>
                   </div>
                 );
               })}


### PR DESCRIPTION
## Summary
Second batch from the mockup-mining pass (attention/approvals, fleet/next dimensions). Independent of #1123 (Unified morning, under review) and #1124 (prior quick-wins batch) — no file-level overlap in the actual diffs beyond both touching page.tsx/globals.css in different places, safe to land in any order.

- **0:attention** — shows the single worst-blast-tier pending approval inline (mockup's A-A "Considered": approvals sorted so the one that can't be undone is always on top, via `classifyPendingAction` + `reversibilityRank` — the same vocabulary the worker-autonomy gate already uses), with a `BlastBadge` and Approve/Deny. New `actApproval` handler mirrors `/approvals`'s `decide()` exactly, including the high-tier confirm()/reason-prompt() safety gate (a stray click on a high-tier `rm -rf` used to approve instantly before that gate existed — this surface must not reopen it). Additive to the existing worker-verdict item, same pattern already established for that queue.
- **2:fleet** — an avg-duration + last-run-relative-time metadata line under each row with run history (mockup's R-A `.ra-meta`), computed from the same `runList` data the row's health bar already uses. Left the existing packed fill-bar alone — replacing it with a per-run sparkline would relitigate a deliberate design decision from #1109 without new evidence it's wrong.

## Test plan
- 2 new tests: worst-blast-tier-first sort + high-tier approve confirm() gate fires; fleet metadata line with a real avg-duration computation (30s + 90s → "avg 1m 0s").
- All 27 tests in `page.test.tsx` pass (25 existing + 2 new).
- `npx tsc --noEmit` clean.
- Verified live against the running bridge, no console errors.