### PR TITLE
feat(dashboard): 4:workers gets a review-needed tray for pending verdicts

### DIFF
--- a/dashboard/src/app/__tests__/page.test.tsx
+++ b/dashboard/src/app/__tests__/page.test.tsx
@@ -645,6 +645,60 @@ describe("<HomePage/> — Terminal deck", () => {
     expect(workersPane.textContent).toMatch(/ready to promote/i);
   });
 
+  it("4:workers shows a review-needed tray for pending worker-verdict confirmations, sharing state with 0:attention's identical item", async () => {
+    const outcomeMock = vi.fn().mockResolvedValue(jsonResponse({ ok: true }));
+    global.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url.includes("/api/bridge/outcomes") && !url.includes("/pending")) {
+        return outcomeMock(init);
+      }
+      for (const [key, make] of Object.entries({
+        ...HEALTHY_ROUTES,
+        "/api/bridge/outcomes/pending": () =>
+          jsonResponse({
+            pending: [
+              {
+                issueUrl: "https://github.com/o/r/issues/9",
+                recipeName: "triage-failing-tests",
+                workerId: "test-guardian",
+                workerName: "Test Guardian",
+                filedAt: Date.now() - 60_000,
+                classKey: "issue:compensable:high",
+                title: "Flaky reconnect test",
+              },
+            ],
+          }),
+      })) {
+        if (url.includes(key)) return make();
+      }
+      return jsonResponse({}, 404);
+    }) as unknown as typeof fetch;
+
+    render(<HomePage />);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(50);
+    });
+
+    const workersPane = screen.getByRole("region", { name: "workers" });
+    expect(workersPane.textContent).toMatch(/review needed/i);
+    expect(workersPane.textContent).toMatch(/Flaky reconnect test/);
+    expect(workersPane.textContent).toMatch(/issue:compensable:high/);
+
+    const confirmBtn = within(workersPane).getByText("Looks real");
+    await act(async () => {
+      confirmBtn.click();
+    });
+
+    await waitFor(() => {
+      expect(outcomeMock).toHaveBeenCalledTimes(1);
+    });
+    const body = JSON.parse((outcomeMock.mock.calls[0]?.[0] as RequestInit)?.body as string);
+    expect(body).toMatchObject({
+      issueUrl: "https://github.com/o/r/issues/9",
+      disposition: "confirmed",
+    });
+  });
+
   // --------------------------------------------------------------------
   // 7:copilot — Tier 1 lever-action chat pane.
   // --------------------------------------------------------------------

--- a/dashboard/src/app/globals.css
+++ b/dashboard/src/app/globals.css
@@ -9953,6 +9953,34 @@ details[open] .traces-detail-arrow { transform: rotate(90deg); }
 [data-theme="paper"] .td-worker-status-climbing { color: var(--warn-text); }
 [data-theme="paper"] .td-worker-status-reversible { color: var(--ink-3); }
 
+/* Pane 4: workers — review-needed tray (mockup's W-B ".wb-review"), the
+   worker-verdict confirm queue surfaced inline instead of just an
+   aggregate count. */
+.td-worker-review {
+  margin-top: 8px;
+  padding: 8px 10px;
+  border: 1px solid rgba(224, 176, 84, 0.35);
+  border-radius: var(--r-2, 6px);
+  background: rgba(224, 176, 84, 0.08);
+}
+.td-worker-review-head {
+  font-size: var(--fs-2xs);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--terminal-comment);
+  margin-bottom: 6px;
+}
+[data-theme="paper"] .td-worker-review-head { color: var(--ink-3); }
+.td-worker-review-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  font-size: var(--fs-xs);
+  padding: 4px 0;
+}
+.td-worker-review-body { min-width: 0; }
+
 /* Pane 4: workers — gate activity feed (Decision Record, GET /gate/decisions) */
 .td-gate-activity { margin-top: 8px; padding-top: 6px; border-top: 1px solid var(--line-1); }
 .td-gate-activity-title { font-size: var(--fs-xs); margin-bottom: 4px; text-transform: uppercase; letter-spacing: 0.04em; }

--- a/dashboard/src/app/page.tsx
+++ b/dashboard/src/app/page.tsx
@@ -1656,6 +1656,46 @@ export default function HomePage() {
             })
           )}
 
+          {/* Review-needed tray (mockup's W-B "Ledger" .wb-review) — the
+              worker-verdict confirm queue, surfaced HERE too, not just in
+              0:attention. 4:workers previously only showed aggregate
+              counts ("N ready to promote · N slipped back"); this is the
+              actual "is it real?" queue the counts refer to, reusing the
+              exact same workerPending/actOutcome data+handler
+              0:attention's identical item already uses — additive, same
+              established pattern as the earlier approval item. */}
+          {workerPending.length > 0 && (
+            <div className="td-worker-review">
+              <div className="td-worker-review-head">review needed</div>
+              {workerPending.map((p) => (
+                <div className="td-worker-review-row" key={p.issueUrl}>
+                  <span className="pill muted">issue</span>
+                  <span className="td-worker-review-body">
+                    <strong>{p.workerName}</strong> filed &ldquo;{p.title ?? "a new issue"}&rdquo;
+                    <span className="td-muted"> · {formatAgo(nowMs - p.filedAt)} · {p.classKey}</span>
+                  </span>
+                  <span className="td-pane-sp" />
+                  <button
+                    type="button"
+                    className="btn sm primary"
+                    disabled={outcomeBusy === p.issueUrl}
+                    onClick={() => void actOutcome(p, "confirmed")}
+                  >
+                    Looks real
+                  </button>
+                  <button
+                    type="button"
+                    className="btn sm ghost"
+                    disabled={outcomeBusy === p.issueUrl}
+                    onClick={() => void actOutcome(p, "junk")}
+                  >
+                    Not real
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
+
           {/* Gate activity — first-ever dashboard surface of the Decision
               Record (GET /gate/decisions, backs `patchwork gate explain`).
               Renders the last ~6 gate decisions across all workers. */}


### PR DESCRIPTION
## Summary
Third batch from the mockup-mining pass (workers dimension). Independent of #1123/#1124/#1125 — no diff overlap, safe to land in any order.

4:workers previously only surfaced the worker-verdict confirm queue as an aggregate rollup in its header ("N ready to promote · N slipped back") — the actual "is it real?" items backing those counts had no home in this pane, only in 0:attention. Mockup's W-B "Ledger" `.wb-review` callout box (the single highest-value finding in that mining report) is the model: a pinned tray listing each pending item inline with its own actions.

New review-needed tray reuses the exact same `workerPending` state and `actOutcome` handler 0:attention's identical item already uses — no new fetch, no new endpoint, no duplicated logic. Explicitly additive (same pattern established for the approvals item in #1125): the item still shows in 0:attention too.

**Skipped from the same mining report:**
- The SVG trust dial — would abandon the deliberate monospace-glyph convention, per the mining agent's own flag.
- The dense drill-down ledger table — better suited to the full `/workers` detail page than this compact pane.
- 3:next's "would-fire" digest for paused recipes (from the fleet/next report) — conflicts with a deliberate prior fix that collapsed paused recipes to a single count specifically to stop list-crowding; expanding it back out risks reintroducing that bug.

## Test plan
- 1 new test: tray renders with real data, Confirm posts to the same endpoint/body shape as 0:attention's identical action.
- All 26 tests in `page.test.tsx` pass (25 existing + 1 new).
- `npx tsc --noEmit` clean.
- Verified live — correctly hidden on this bridge's current zero-pending state; unit test covers the populated case.