### PR TITLE
feat(dashboard): 5:vitals shows a session-count trend delta

### DIFF
--- a/dashboard/src/app/__tests__/page.test.tsx
+++ b/dashboard/src/app/__tests__/page.test.tsx
@@ -274,6 +274,39 @@ describe("<HomePage/> — Terminal deck", () => {
     expect(workersPane.textContent).toMatch(/71% over 14 tries/);
   });
 
+  it("5:vitals shows a session-count delta when the active-session count changes between polls, not on the very first load", async () => {
+    let statusCalls = 0;
+    global.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url.includes("/api/bridge/status")) {
+        statusCalls += 1;
+        // First poll: 2 sessions. Second poll (5s later): 3 sessions.
+        return jsonResponse({ ok: true, port: 3101, uptimeMs: 60_000, activeSessions: statusCalls === 1 ? 2 : 3 });
+      }
+      for (const [key, make] of Object.entries(HEALTHY_ROUTES)) {
+        if (url.includes(key)) return make();
+      }
+      return jsonResponse({}, 404);
+    }) as unknown as typeof fetch;
+
+    render(<HomePage />);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(50);
+    });
+
+    const vitalsPane = screen.getByRole("region", { name: "vitals" });
+    // No prior poll to compare against yet — no delta on first load.
+    expect(vitalsPane.querySelector(".td-kv-delta")).toBeNull();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5000);
+    });
+
+    const delta = vitalsPane.querySelector(".td-kv-delta");
+    expect(delta).toBeTruthy();
+    expect(delta?.textContent).toMatch(/↑1/);
+  });
+
   it("fails soft: one endpoint 500ing still lets the rest of the deck render", async () => {
     mockFetchRoutes({
       ...HEALTHY_ROUTES,

--- a/dashboard/src/app/globals.css
+++ b/dashboard/src/app/globals.css
@@ -10111,6 +10111,10 @@ details[open] .traces-detail-arrow { transform: rotate(90deg); }
 /* Pane 5: vitals */
 .td-kv-row { display: flex; justify-content: space-between; font-size: var(--fs-xs); padding: 3px 0; border-top: 1px solid var(--line-1); }
 .td-kv-row:first-of-type { border-top: 0; }
+/* Mockup's H-C ".hc-kv" trend annotation — a small delta next to a KV
+   value that genuinely goes up/down between polls (sessions), not a
+   monotonic counter. */
+.td-kv-delta { font-size: var(--fs-2xs); font-weight: 400; margin-left: 2px; }
 .td-rate-budget { flex-wrap: wrap; }
 /* Mockup's .hd-bar2: a thin fill bar (rate-budget remaining/limit). */
 .td-bar2 {

--- a/dashboard/src/app/page.tsx
+++ b/dashboard/src/app/page.tsx
@@ -903,6 +903,24 @@ export default function HomePage() {
   const okCount24h = succeeded24h.length - withErrCount24h;
 
   const sessionsCount = bridgeStatus.activeSessions ?? health?.activeSessions;
+  // Mockup's H-C ".hc-kv" trend annotations (mined idea #3) — scoped to
+  // sessions only, not every KV row: sessions is a small gauge that
+  // genuinely goes up/down between polls, so a delta is informative. A
+  // monotonic 24h counter (tool calls) or a rarely-changing one (recipes
+  // enabled) would just show noise or near-always-zero, so those are left
+  // alone rather than fabricating a "trend" that isn't one.
+  const prevSessionsRef = useRef<number | undefined>(undefined);
+  const [sessionsDelta, setSessionsDelta] = useState<number | null>(null);
+  useEffect(() => {
+    if (typeof sessionsCount !== "number") return;
+    if (
+      typeof prevSessionsRef.current === "number" &&
+      prevSessionsRef.current !== sessionsCount
+    ) {
+      setSessionsDelta(sessionsCount - prevSessionsRef.current);
+    }
+    prevSessionsRef.current = sessionsCount;
+  }, [sessionsCount]);
   const enabledRecipesCount = recipes.filter((r) => r.enabled !== false).length;
 
   // ---- Pane 0: attention -------------------------------------------------
@@ -2198,7 +2216,19 @@ export default function HomePage() {
         <Pane index={5} id="vitals" title="vitals" activePane={activePane} setActivePane={setActivePane}>
           <div className="td-kv-row">
             <span className="td-muted">sessions</span>
-            <strong>{typeof sessionsCount === "number" ? sessionsCount : "—"}</strong>
+            <strong>
+              {typeof sessionsCount === "number" ? sessionsCount : "—"}
+              {sessionsDelta ? (
+                <span
+                  className={`td-kv-delta ${sessionsDelta > 0 ? "td-ok" : "td-err"}`}
+                  title="change since the last poll"
+                >
+                  {" "}
+                  {sessionsDelta > 0 ? "↑" : "↓"}
+                  {Math.abs(sessionsDelta)}
+                </span>
+              ) : null}
+            </strong>
           </div>
           <div className="td-kv-row">
             <span className="td-muted">tool calls · 24h</span>


### PR DESCRIPTION
## Summary
Fourth batch from the mockup-mining pass (vitals/inbox dimension). Independent of #1123/#1124/#1125/#1126 — no diff overlap.

Mockup's H-C `.hc-kv` rows show inline trend deltas ("341 ↑12%") on every KV row. Scoped this to **sessions only**, not every row: sessions is a small gauge that genuinely goes up/down between polls, so a delta is informative. "tool calls · 24h" is a monotonic day-counter (only ever grows until midnight) — a poll-over-poll delta on that would just restate "still counting up," not a real trend. "recipes enabled" rarely changes — a delta would almost always read "+0", noise not signal. Left both alone rather than fabricating a "trend" that isn't one (same reasoning applied throughout this mining series: `workerTrustPct` returning `null` on zero comparisons in #1124, dropping the 7-dot activity sparkline idea, etc.).

Implementation is a plain `useRef`-tracked previous value + `useEffect`, comparing on every `sessionsCount` change — no new fetch, reuses the already-polled `useBridgeStatus()` value. No delta shown until a second poll has actually happened.

## Test plan
- 1 new test: no delta on first load, `↑1` delta after a real second poll changes `activeSessions` from 2 to 3.
- All 26 tests in `page.test.tsx` pass (25 existing + 1 new).
- `npx tsc --noEmit` clean.
- Verified live against the running bridge, no console errors.