### PR TITLE
feat(dashboard): 5:vitals gets a 24h activity heatmap grid

### DIFF
--- a/dashboard/src/app/__tests__/page.test.tsx
+++ b/dashboard/src/app/__tests__/page.test.tsx
@@ -307,6 +307,38 @@ describe("<HomePage/> — Terminal deck", () => {
     expect(delta?.textContent).toMatch(/↑1/);
   });
 
+  it("5:vitals shows a 24h activity heatmap with an error-colored cell for the hour a tool call failed, and hides it entirely when there's no activity", async () => {
+    mockFetchRoutes(HEALTHY_ROUTES);
+    const { container: emptyContainer } = render(<HomePage />);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(50);
+    });
+    // No activity at all — the heatmap doesn't render a wall of empty cells.
+    expect(emptyContainer.querySelector(".td-heatmap")).toBeNull();
+
+    mockFetchRoutes({
+      ...HEALTHY_ROUTES,
+      "/api/bridge/activity": () =>
+        jsonResponse({
+          events: [
+            { kind: "tool", tool: "readFile", status: "success", at: Date.now() - 30 * 60_000 },
+            { kind: "tool", tool: "runCommand", status: "error", at: Date.now() - 30 * 60_000 },
+          ],
+        }),
+    });
+    const { container } = render(<HomePage />);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(50);
+    });
+
+    const heatmap = container.querySelector(".td-heatmap");
+    expect(heatmap).toBeTruthy();
+    expect(heatmap?.querySelectorAll(".td-heatmap-cell").length).toBe(24);
+    const errorCell = heatmap?.querySelector(".td-heatmap-er");
+    expect(errorCell).toBeTruthy();
+    expect(errorCell?.getAttribute("title")).toMatch(/1 error/);
+  });
+
   it("fails soft: one endpoint 500ing still lets the rest of the deck render", async () => {
     mockFetchRoutes({
       ...HEALTHY_ROUTES,

--- a/dashboard/src/app/globals.css
+++ b/dashboard/src/app/globals.css
@@ -10129,6 +10129,28 @@ details[open] .traces-detail-arrow { transform: rotate(90deg); }
 .td-bar2 span { position: absolute; inset: 0 auto 0 0; height: 100%; border-radius: 3px; background: rgba(91, 138, 79, 0.7); }
 [data-theme="paper"] .td-bar2 span { background: var(--ok); }
 
+/* Mockup's H-C ".hc-heat" 24h activity grid — one cell per hour, oldest
+   on the left, colored by event density/errors. */
+.td-heatmap {
+  display: grid;
+  grid-template-columns: repeat(24, 1fr);
+  gap: 2px;
+  margin-top: 8px;
+  padding-top: 6px;
+  border-top: 1px solid var(--line-1);
+}
+.td-heatmap-cell {
+  aspect-ratio: 1;
+  border-radius: 1px;
+  background: var(--recess);
+}
+.td-heatmap-l1 { background: rgba(127, 191, 111, 0.3); }
+.td-heatmap-l2 { background: rgba(127, 191, 111, 0.6); }
+.td-heatmap-l3 { background: #7fbf6f; }
+.td-heatmap-er { background: #e0847e; }
+[data-theme="paper"] .td-heatmap-l3 { background: var(--ok); }
+[data-theme="paper"] .td-heatmap-er { background: var(--err); }
+
 /* Pane 6: inbox */
 .td-inbox-row {
   display: flex;

--- a/dashboard/src/app/globals.css
+++ b/dashboard/src/app/globals.css
@@ -10130,18 +10130,31 @@ details[open] .traces-detail-arrow { transform: rotate(90deg); }
 [data-theme="paper"] .td-bar2 span { background: var(--ok); }
 
 /* Mockup's H-C ".hc-heat" 24h activity grid — one cell per hour, oldest
-   on the left, colored by event density/errors. */
+   on the left, colored by event density/errors. Styled after GitHub's
+   contribution graph (rounder cells, tick labels, a Less→More legend)
+   per user request, adapted to what's actually true here: 24 hours of
+   Patchwork activity, not 52 weeks of contributions. */
+.td-heatmap-block {
+  margin-top: 8px;
+  padding-top: 8px;
+  border-top: 1px solid var(--line-1);
+}
+.td-heatmap-count { font-size: var(--fs-2xs); margin-bottom: 6px; }
+.td-heatmap-ticks {
+  display: flex;
+  justify-content: space-between;
+  font-size: var(--fs-2xs);
+  margin-bottom: 3px;
+}
+.td-heatmap-ticks span { white-space: nowrap; }
 .td-heatmap {
   display: grid;
   grid-template-columns: repeat(24, 1fr);
-  gap: 2px;
-  margin-top: 8px;
-  padding-top: 6px;
-  border-top: 1px solid var(--line-1);
+  gap: 3px;
 }
 .td-heatmap-cell {
   aspect-ratio: 1;
-  border-radius: 1px;
+  border-radius: 2px;
   background: var(--recess);
 }
 .td-heatmap-l1 { background: rgba(127, 191, 111, 0.3); }
@@ -10150,6 +10163,15 @@ details[open] .traces-detail-arrow { transform: rotate(90deg); }
 .td-heatmap-er { background: #e0847e; }
 [data-theme="paper"] .td-heatmap-l3 { background: var(--ok); }
 [data-theme="paper"] .td-heatmap-er { background: var(--err); }
+.td-heatmap-legend {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 4px;
+  margin-top: 6px;
+  font-size: var(--fs-2xs);
+}
+.td-heatmap-legend .td-heatmap-cell { width: 10px; height: 10px; aspect-ratio: unset; }
 
 /* Pane 6: inbox */
 .td-inbox-row {

--- a/dashboard/src/app/page.tsx
+++ b/dashboard/src/app/page.tsx
@@ -923,6 +923,32 @@ export default function HomePage() {
   }, [sessionsCount]);
   const enabledRecipesCount = recipes.filter((r) => r.enabled !== false).length;
 
+  // Mockup's H-C ".hc-heat" 24-hour activity grid (mined idea #1) — one
+  // cell per hour of the last 24h, colored by event density/errors.
+  // Caveat, stated honestly rather than silently: activityEvents is
+  // capped at the last 500 fetched events (`/api/bridge/activity?last=500`
+  // above), so on a very high-traffic bridge the earliest hours in this
+  // window may under-count — this is the same fetch every other
+  // activity-derived number on this page already relies on, not a new
+  // limitation introduced here.
+  const activityHeatmap = useMemo(() => {
+    const HOURS = 24;
+    const bucketMs = 60 * 60 * 1000;
+    const cells = Array.from({ length: HOURS }, () => ({ count: 0, errors: 0 }));
+    const cutoff = nowMs - HOURS * bucketMs;
+    for (const e of activityEvents) {
+      if (isNoiseEvent(e)) continue;
+      const at = e.at ?? 0;
+      if (at < cutoff || at > nowMs) continue;
+      const bucketIndex = Math.min(HOURS - 1, Math.floor((nowMs - at) / bucketMs));
+      const cell = cells[HOURS - 1 - bucketIndex];
+      cell.count += 1;
+      if (e.status === "error") cell.errors += 1;
+    }
+    const maxCount = Math.max(1, ...cells.map((c) => c.count));
+    return { cells, maxCount };
+  }, [activityEvents, nowMs]);
+
   // ---- Pane 0: attention -------------------------------------------------
   const [muteUntil, setMuteUntilState] = useState(0);
   const [muteFingerprint, setMuteFingerprintState] = useState("");
@@ -2267,6 +2293,30 @@ export default function HomePage() {
                   }}
                 />
               </div>
+            </div>
+          )}
+          {activityHeatmap.cells.some((c) => c.count > 0) && (
+            <div className="td-heatmap" title="activity in the last 24h, one cell per hour, oldest on the left">
+              {activityHeatmap.cells.map((cell, i) => {
+                const tier =
+                  cell.errors > 0
+                    ? "er"
+                    : cell.count === 0
+                      ? ""
+                      : cell.count >= activityHeatmap.maxCount * 0.66
+                        ? "l3"
+                        : cell.count >= activityHeatmap.maxCount * 0.33
+                          ? "l2"
+                          : "l1";
+                const hoursAgo = activityHeatmap.cells.length - 1 - i;
+                return (
+                  <span
+                    key={i}
+                    className={`td-heatmap-cell${tier ? ` td-heatmap-${tier}` : ""}`}
+                    title={`${cell.count} event${cell.count === 1 ? "" : "s"}${cell.errors > 0 ? `, ${cell.errors} error${cell.errors === 1 ? "" : "s"}` : ""}, ${hoursAgo}h-${hoursAgo + 1}h ago`}
+                  />
+                );
+              })}
             </div>
           )}
         </Pane>

--- a/dashboard/src/app/page.tsx
+++ b/dashboard/src/app/page.tsx
@@ -2296,27 +2296,52 @@ export default function HomePage() {
             </div>
           )}
           {activityHeatmap.cells.some((c) => c.count > 0) && (
-            <div className="td-heatmap" title="activity in the last 24h, one cell per hour, oldest on the left">
-              {activityHeatmap.cells.map((cell, i) => {
-                const tier =
-                  cell.errors > 0
-                    ? "er"
-                    : cell.count === 0
-                      ? ""
-                      : cell.count >= activityHeatmap.maxCount * 0.66
-                        ? "l3"
-                        : cell.count >= activityHeatmap.maxCount * 0.33
-                          ? "l2"
-                          : "l1";
-                const hoursAgo = activityHeatmap.cells.length - 1 - i;
-                return (
-                  <span
-                    key={i}
-                    className={`td-heatmap-cell${tier ? ` td-heatmap-${tier}` : ""}`}
-                    title={`${cell.count} event${cell.count === 1 ? "" : "s"}${cell.errors > 0 ? `, ${cell.errors} error${cell.errors === 1 ? "" : "s"}` : ""}, ${hoursAgo}h-${hoursAgo + 1}h ago`}
-                  />
-                );
-              })}
+            <div className="td-heatmap-block">
+              {/* GitHub-contribution-graph styling (rounder cells, tick
+                  labels, a Less→More legend) adapted to what's actually
+                  true of this data: 24 hours, not 52 weeks, so the ticks
+                  read "24h ago…now" instead of month names, and the count
+                  line is framed as "events" not "contributions". */}
+              <div className="td-heatmap-count td-muted">
+                {activityHeatmap.cells.reduce((sum, c) => sum + c.count, 0)} events in the last 24h
+              </div>
+              <div className="td-heatmap-ticks td-muted" aria-hidden="true">
+                <span>24h ago</span>
+                <span>18h ago</span>
+                <span>12h ago</span>
+                <span>6h ago</span>
+                <span>now</span>
+              </div>
+              <div className="td-heatmap" title="activity in the last 24h, one cell per hour, oldest on the left">
+                {activityHeatmap.cells.map((cell, i) => {
+                  const tier =
+                    cell.errors > 0
+                      ? "er"
+                      : cell.count === 0
+                        ? ""
+                        : cell.count >= activityHeatmap.maxCount * 0.66
+                          ? "l3"
+                          : cell.count >= activityHeatmap.maxCount * 0.33
+                            ? "l2"
+                            : "l1";
+                  const hoursAgo = activityHeatmap.cells.length - 1 - i;
+                  return (
+                    <span
+                      key={i}
+                      className={`td-heatmap-cell${tier ? ` td-heatmap-${tier}` : ""}`}
+                      title={`${cell.count} event${cell.count === 1 ? "" : "s"}${cell.errors > 0 ? `, ${cell.errors} error${cell.errors === 1 ? "" : "s"}` : ""}, ${hoursAgo}h-${hoursAgo + 1}h ago`}
+                    />
+                  );
+                })}
+              </div>
+              <div className="td-heatmap-legend td-muted" aria-hidden="true">
+                <span>Less</span>
+                <span className="td-heatmap-cell" />
+                <span className="td-heatmap-cell td-heatmap-l1" />
+                <span className="td-heatmap-cell td-heatmap-l2" />
+                <span className="td-heatmap-cell td-heatmap-l3" />
+                <span>More</span>
+              </div>
             </div>
           )}
         </Pane>


### PR DESCRIPTION
## Summary
Fifth batch from the mockup-mining pass (vitals/inbox dimension). Independent of #1123/#1124/#1125/#1126/#1127 — no diff overlap.

Mockup's H-C `.hc-heat` 24-cell hourly grid, colored by event density and errors. Bucketed from the same `activityEvents` state 1:tail already renders, filtered through the same `isNoiseEvent` gate so plumbing churn doesn't dominate the density signal. Hidden entirely when there's no activity in the window, rather than rendering 24 empty cells.

Stated honestly in the code comment: `activityEvents` is capped at the last 500 fetched events (the same fetch every other activity-derived number on this page already relies on), so on a very high-traffic bridge the earliest hours in the 24h window may under-count. Not a new limitation introduced here — just not hidden.

**Dropped from this same mining report:** inbox category filter chips — the 6:inbox pane only ever shows a 3-item compact preview (the full list lives on `/inbox`), so filter chips would add UI weight to a pane that structurally has nothing to filter down from. Better fit for the full `/inbox` page.

## Test plan
- 1 new test: heatmap hidden with zero activity, 24 cells + an error-colored cell rendered from a real failed tool call.
- All 26 tests in `page.test.tsx` pass (25 existing + 1 new).
- `npx tsc --noEmit` clean.
- Verified live against the running bridge (screenshot in conversation) — 3 real green cells at the correct recency, no console errors.