### PR TITLE
feat(dashboard): 4:workers gate-activity becomes a per-worker collapsible accordion

### DIFF
--- a/dashboard/src/app/__tests__/page.test.tsx
+++ b/dashboard/src/app/__tests__/page.test.tsx
@@ -380,6 +380,60 @@ describe("<HomePage/> — Terminal deck", () => {
     );
   });
 
+  it("groups gate activity into a collapsible per-worker accordion once more than one worker appears, collapsed by default", async () => {
+    const secondWorkerDecision = {
+      ...SAMPLE_GATE_DECISION,
+      seq: 43,
+      workerId: "dependency-bump-worker",
+      classKey: "vcs-remote:compensable:medium",
+    };
+    mockFetchRoutes({
+      ...HEALTHY_ROUTES,
+      "/api/bridge/gate/decisions": () =>
+        jsonResponse({ decisions: [secondWorkerDecision, SAMPLE_GATE_DECISION] }),
+    });
+    render(<HomePage />);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(50);
+    });
+
+    const workersPane = screen.getByRole("region", { name: "workers" });
+    // Collapsed by default — worker names visible, decision detail is not.
+    expect(workersPane.textContent).toMatch(/dependency-bump-worker/);
+    expect(workersPane.textContent).toMatch(/test-guardian/);
+    expect(workersPane.textContent).not.toMatch(/issue:compensable:high/);
+
+    const toggle = within(workersPane).getByText("test-guardian").closest("button");
+    expect(toggle).toBeTruthy();
+    await act(async () => {
+      toggle?.click();
+    });
+
+    await waitFor(() => {
+      expect(workersPane.textContent).toMatch(/issue:compensable:high/);
+    });
+    // The other worker's group is untouched — still collapsed.
+    expect(workersPane.textContent).not.toMatch(/vcs-remote:compensable:medium/);
+  });
+
+  it("a single worker's gate activity stays a flat list, no accordion grouping", async () => {
+    mockFetchRoutes({
+      ...HEALTHY_ROUTES,
+      "/api/bridge/gate/decisions": () =>
+        jsonResponse({ decisions: [SAMPLE_GATE_DECISION] }),
+    });
+    const { container } = render(<HomePage />);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(50);
+    });
+
+    expect(container.querySelector(".td-gate-worker-group")).toBeNull();
+    // The flat row already shows the class key inline, unlike the
+    // grouped accordion which hides it behind a collapsed toggle.
+    const workersPane = screen.getByRole("region", { name: "workers" });
+    expect(workersPane.textContent).toMatch(/issue:compensable:high/);
+  });
+
   it("statusline clock flips to 'data as of … reconnecting' when the deck's own poll goes stale, and clears on recovery", async () => {
     // Bug Fix Protocol: this test must fail before the statusline is wired
     // to the staleness registry — the deck's primary poll (tracked via

--- a/dashboard/src/app/globals.css
+++ b/dashboard/src/app/globals.css
@@ -9850,6 +9850,11 @@ details[open] .traces-detail-arrow { transform: rotate(90deg); }
 .td-pane-title { text-transform: uppercase; letter-spacing: 0.08em; font-size: var(--fs-xs); color: var(--terminal-comment); }
 [data-theme="paper"] .td-pane-title { color: var(--ink-3); }
 .td-pane-sp { flex: 1; }
+/* Alias: several call sites (the "Unified morning" section's action
+   rows) use .td-sp as a flex spacer expecting it globally, but the only
+   existing rule was scoped to .td-statusline .td-sp — those spacers were
+   silent no-ops outside the statusline. Same behavior as .td-pane-sp. */
+.td-sp { flex: 1; }
 .td-pane-link { color: inherit; text-decoration: none; opacity: 0.7; }
 .td-pane-link:hover { opacity: 1; }
 
@@ -10080,6 +10085,27 @@ details[open] .traces-detail-arrow { transform: rotate(90deg); }
 .td-gate-activity { margin-top: 8px; padding-top: 6px; border-top: 1px solid var(--line-1); }
 .td-gate-activity-title { font-size: var(--fs-xs); margin-bottom: 4px; text-transform: uppercase; letter-spacing: 0.04em; }
 .td-gate-row-wrap { display: flex; flex-direction: column; }
+.td-gate-row-wrap.td-gate-row-indent { padding-left: 14px; }
+/* Per-worker collapsible group (mockup's W-B "Ledger" worker-row/
+   task-subrow split) — shown instead of one flat mixed feed once more
+   than one worker appears in the gate-activity data. */
+.td-gate-worker-group { margin-bottom: 2px; }
+.td-gate-worker-toggle {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: var(--fs-xs);
+  font-family: inherit;
+  background: none;
+  border: none;
+  padding: 3px 0;
+  color: inherit;
+  cursor: pointer;
+  text-align: left;
+  width: 100%;
+  font-weight: 600;
+}
+.td-gate-worker-toggle:hover { opacity: 0.85; }
 .td-gate-row {
   display: flex;
   align-items: center;

--- a/dashboard/src/app/page.tsx
+++ b/dashboard/src/app/page.tsx
@@ -185,6 +185,56 @@ function gateLevelPhrase(n: number): string {
   return GATE_LEVEL_SHORT[n] ?? `level ${n}`;
 }
 
+/** One gate-decision row + its click-to-expand explain panel. Extracted
+ *  so it can render both in the flat single-worker list and inside each
+ *  worker's collapsible group without duplicating the JSX. */
+function GateRow({
+  d,
+  isOpen,
+  onToggle,
+  indent,
+}: {
+  d: GateDecisionRecord;
+  isOpen: boolean;
+  onToggle: () => void;
+  indent?: boolean;
+}) {
+  const hhmm = new Date(d.decidedAt).toLocaleTimeString([], {
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  });
+  return (
+    <div className={`td-gate-row-wrap${indent ? " td-gate-row-indent" : ""}`}>
+      <button type="button" className="td-gate-row" aria-expanded={isOpen} onClick={onToggle}>
+        <span className="mono td-muted">{hhmm}</span>
+        <span className="td-gate-verb">GATE</span>
+        {!indent && <span className="mono">{d.workerId}</span>}
+        <span className="td-muted mono">{d.classKey}</span>
+        <span className="td-gate-arrow">→</span>
+        <span>{gateLevelPhrase(d.effectiveLevel)}</span>
+      </button>
+      {isOpen && (
+        <div className="td-gate-explain">
+          <div>
+            effective L{d.effectiveLevel} ({gateLevelPhrase(d.effectiveLevel)})
+            {" vs required "}
+            {d.action === "allow" ? "— none (allowed)" : "higher"}
+          </div>
+          <div>
+            earned L{d.earnedLevel} · autonomy ceiling L{d.autonomyCeiling}
+            {d.contextCeiling !== undefined ? ` · context ceiling L${d.contextCeiling}` : ""}
+          </div>
+          {d.contextRiskReasons && d.contextRiskReasons.length > 0 && (
+            <div>context signals: {d.contextRiskReasons.join(", ")}</div>
+          )}
+          <div className="td-muted">{d.reason}</div>
+        </div>
+      )}
+    </div>
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -1155,6 +1205,15 @@ export default function HomePage() {
   }
   const gateDecisions: GateDecisionRecord[] = gateDecisionsData?.decisions ?? [];
   const [expandedGateSeq, setExpandedGateSeq] = useState<number | null>(null);
+  // Mockup's W-B "Ledger" worker-row/task-subrow split (mined idea #9,
+  // previously deferred to a future /workers detail page) — brought into
+  // this compact pane per user request: when multiple workers are
+  // engaged, one flat feed mixing all their decisions together gets
+  // unreadable fast. Grouped by worker, collapsed by default, one open
+  // at a time (accordion). A single worker keeps today's flat list —
+  // there's nothing to disambiguate with only one source.
+  const [expandedGateWorker, setExpandedGateWorker] = useState<string | null>(null);
+  const gateWorkerIds = Array.from(new Set(gateDecisions.map((d) => d.workerId)));
   // Team rollup — formerly /today §3's "N ready to promote" framing.
   // Per-row ⚑/▼ markers below already carry the detail; this is just the
   // one-line "should I even look" summary the deck's header convention
@@ -2136,57 +2195,57 @@ export default function HomePage() {
 
           {/* Gate activity — first-ever dashboard surface of the Decision
               Record (GET /gate/decisions, backs `patchwork gate explain`).
-              Renders the last ~6 gate decisions across all workers. */}
+              Renders the last ~6 gate decisions. Grouped into a
+              collapsible-per-worker accordion (mockup's W-B "Ledger"
+              worker-row/task-subrow split) once more than one worker
+              shows up in the feed — a single flat list mixing multiple
+              workers' decisions together stops being readable fast. */}
           <div className="td-gate-activity">
             <div className="td-gate-activity-title td-muted">gate activity</div>
             {gateDecisionsError ? (
               <div className="td-error-row">gate activity unavailable</div>
             ) : gateDecisions.length === 0 ? (
               <div className="td-empty-line">no gate decisions yet</div>
+            ) : gateWorkerIds.length <= 1 ? (
+              gateDecisions.slice(0, 6).map((d) => (
+                <GateRow
+                  key={d.seq}
+                  d={d}
+                  isOpen={expandedGateSeq === d.seq}
+                  onToggle={() => setExpandedGateSeq(expandedGateSeq === d.seq ? null : d.seq)}
+                />
+              ))
             ) : (
-              gateDecisions.slice(0, 6).map((d) => {
-                const isOpen = expandedGateSeq === d.seq;
-                const hhmm = new Date(d.decidedAt).toLocaleTimeString([], {
-                  hour: "2-digit",
-                  minute: "2-digit",
-                  hour12: false,
-                });
+              gateWorkerIds.map((workerId) => {
+                const workerDecisions = gateDecisions.filter((d) => d.workerId === workerId);
+                const latest = workerDecisions[0];
+                const isWorkerOpen = expandedGateWorker === workerId;
                 return (
-                  <div className="td-gate-row-wrap" key={d.seq}>
+                  <div className="td-gate-worker-group" key={workerId}>
                     <button
                       type="button"
-                      className="td-gate-row"
-                      aria-expanded={isOpen}
-                      onClick={() =>
-                        setExpandedGateSeq(isOpen ? null : d.seq)
-                      }
+                      className="td-gate-worker-toggle"
+                      aria-expanded={isWorkerOpen}
+                      onClick={() => setExpandedGateWorker(isWorkerOpen ? null : workerId)}
                     >
-                      <span className="mono td-muted">{hhmm}</span>
-                      <span className="td-gate-verb">GATE</span>
-                      <span className="mono">{d.workerId}</span>
-                      <span className="td-muted mono">{d.classKey}</span>
-                      <span className="td-gate-arrow">→</span>
-                      <span>{gateLevelPhrase(d.effectiveLevel)}</span>
+                      <span aria-hidden="true">{isWorkerOpen ? "▾" : "▸"}</span>
+                      <span className="mono">{workerId}</span>
+                      <span className="td-muted">
+                        {workerDecisions.length} decision{workerDecisions.length === 1 ? "" : "s"}
+                      </span>
+                      <span className="td-sp" />
+                      <span className="td-muted">{gateLevelPhrase(latest.effectiveLevel)}</span>
                     </button>
-                    {isOpen && (
-                      <div className="td-gate-explain">
-                        <div>
-                          effective L{d.effectiveLevel} ({gateLevelPhrase(d.effectiveLevel)})
-                          {" vs required "}
-                          {d.action === "allow" ? "— none (allowed)" : "higher"}
-                        </div>
-                        <div>
-                          earned L{d.earnedLevel} · autonomy ceiling L{d.autonomyCeiling}
-                          {d.contextCeiling !== undefined
-                            ? ` · context ceiling L${d.contextCeiling}`
-                            : ""}
-                        </div>
-                        {d.contextRiskReasons && d.contextRiskReasons.length > 0 && (
-                          <div>context signals: {d.contextRiskReasons.join(", ")}</div>
-                        )}
-                        <div className="td-muted">{d.reason}</div>
-                      </div>
-                    )}
+                    {isWorkerOpen &&
+                      workerDecisions.slice(0, 6).map((d) => (
+                        <GateRow
+                          key={d.seq}
+                          d={d}
+                          isOpen={expandedGateSeq === d.seq}
+                          onToggle={() => setExpandedGateSeq(expandedGateSeq === d.seq ? null : d.seq)}
+                          indent
+                        />
+                      ))}
                   </div>
                 );
               })


### PR DESCRIPTION
## Summary
User request: gate activity was one flat feed mixing every worker's decisions together — readable at 1 worker, unreadable fast at 2+.

Grouped by `workerId` once more than one worker appears in the feed (mockup's W-B "Ledger" worker-row/task-subrow split, mined earlier this session but deferred to a future `/workers` detail page — brought into this compact pane instead per explicit request). Each worker's group is a collapsed toggle by default (name + decision count + latest verdict); click to expand and see that worker's own recent decisions. Accordion, not independent toggles — matches the mockup's single-open-drill-down idiom. A single worker keeps today's flat list unchanged.

Extracted the per-row markup into a shared `GateRow` component so the flat and grouped paths don't duplicate JSX.

**Also fixed a latent bug** found while working in this area: `.td-sp` was used as a flex spacer in 5 places (the "Unified morning" section, merged in #1123) but the only existing CSS rule was scoped to `.td-statusline .td-sp` — those spacers were silent no-ops everywhere else. Added the missing global `.td-sp { flex: 1 }` rule.

## Test plan
- 2 new tests: multi-worker groups collapsed by default, one expands independently without affecting the other; single-worker stays a flat list with no accordion markup.
- All 38 tests in `page.test.tsx` pass (36 existing + 2 new).
- `npx tsc --noEmit` clean.
- Verified live against the running bridge (currently has exactly one worker) — confirmed the flat-list path is unchanged, no console errors.