### PR TITLE
docs+ci: add advisory docs-drift guard, fix stale coverage-threshold claim

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
         # mid-run. Not a hang; confirmed via a full local `vitest run`
         # completing clean (8759 passed).
         timeout-minutes: 10
-      - name: Coverage (enforce 75% lines / 70% branches / 75% functions)
+      - name: Coverage (enforce 71% lines / 62% branches / 70% functions)
         run: npm run test:coverage -- --reporter=dot --reporter=github-actions
         timeout-minutes: 8
 
@@ -105,6 +105,8 @@ jobs:
         run: node scripts/audit-parity-xfails.mjs
       - name: Audit docs⇒wired parity (#850)
         run: node scripts/audit-docs-wired.mjs
+      - name: Audit docs drift (advisory, tool-count/coverage claims)
+        run: node scripts/audit-docs-drift.mjs
 
   plugin-validate:
     name: Validate plugin manifest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -269,7 +269,7 @@ The `src/workers/` subsystem implements a trust-ramp-aware autonomy gate for rec
 - New tools: unit tests in `src/tools/__tests__/`
 - New extension handlers: tests in `vscode-extension/src/__tests__/handlers/`
 - Use vitest for both bridge and extension tests
-- Coverage gates: 75% lines, 70% branches, 75% functions
+- Coverage gates: 71% lines, 62% branches, 70% functions (see `vitest.config.ts`'s inline comment — re-baselined down from 75/70/75 for vitest 4's stricter AST-aware coverage counting; actual test coverage did not regress, only the measurement got stricter. Ratchet plan: nudge back up as margin allows — Windows/ubuntu CI currently clear ~72/63/71, so there's roughly 1pt of headroom already banked)
 - Test circuit breaker and reconnect behavior for connection-related changes
 - **outputSchema is mandatory** for all tools. `scripts/audit-lsp-tools.mjs` enforces per-schema-block (not per-file) — multi-tool files can't mask gaps. Exceptions go in `scripts/audit-output-schema-allowlist.json` with a reason; ratchet gate rejects new entries and stale ones.
 

--- a/scripts/audit-docs-drift.mjs
+++ b/scripts/audit-docs-drift.mjs
@@ -1,0 +1,168 @@
+/**
+ * Docs-drift guard (Track B3, resultmaxxing pass 2026-07).
+ *
+ * Sibling to audit-docs-wired.mjs (#850/#1012), which checks that documented
+ * features actually exist in code ("documented ⇒ wired"). This script checks
+ * the opposite failure mode: numeric claims in the docs going STALE relative
+ * to a moving ground truth — a tool count creeping up without the doc being
+ * updated, or a coverage threshold changing (e.g. a vitest major-version
+ * re-baseline) without CLAUDE.md's copy being touched.
+ *
+ * ADVISORY ONLY — this script never fails CI (always exits 0). Drift here is
+ * a documentation-hygiene issue, not a correctness break; a hard gate would
+ * fight routine threshold-tuning PRs. It exists purely to surface drift in
+ * a scannable place instead of silently rotting.
+ *
+ * Checks:
+ *   1. Tool count — CLAUDE.md's "N tools registered" claim (documents/
+ *      platform-docs.md reference line) vs. the actual registered-tool count,
+ *      computed the same way audit-lsp-tools.mjs computes its Stats line
+ *      (every distinct tool `name` seen in the built tool-schema exports).
+ *   2. Coverage thresholds — CLAUDE.md's "Coverage gates: X% lines, Y%
+ *      branches, Z% functions" claim vs. the actual `thresholds` block in
+ *      vitest.config.ts.
+ *
+ * Usage: node scripts/audit-docs-drift.mjs
+ * Exit code: always 0. Non-zero only on a script bug (file not found, etc).
+ */
+
+import { execSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, "..");
+
+function read(rel) {
+  return readFileSync(path.join(root, rel), "utf8");
+}
+
+const drift = [];
+const notes = [];
+
+// ── 1. Tool count ────────────────────────────────────────────────────────────
+
+function auditToolCount() {
+  let statsLine;
+  try {
+    // audit-lsp-tools.mjs already computes and prints the authoritative
+    // "Stats: N slim tools · ... · M total registered · ..." line — reuse it
+    // rather than re-deriving the registered-tool set a second way.
+    statsLine = execSync("node scripts/audit-lsp-tools.mjs", {
+      cwd: root,
+      encoding: "utf8",
+    });
+  } catch (err) {
+    // audit-lsp-tools.mjs failing is that script's job to report; don't mask
+    // it, but don't crash this advisory pass either.
+    drift.push(
+      `tool-count: could not run audit-lsp-tools.mjs to get ground truth (${err instanceof Error ? err.message : String(err)})`,
+    );
+    return;
+  }
+  const m = statsLine.match(/(\d+)\s+total registered/);
+  if (!m) {
+    drift.push(
+      "tool-count: could not parse 'N total registered' from audit-lsp-tools.mjs Stats line — its output format may have changed.",
+    );
+    return;
+  }
+  const actual = Number(m[1]);
+
+  const claude = read("CLAUDE.md");
+  const claudeMatch = claude.match(/\((\d+)\s+tools registered\)/);
+  if (claudeMatch && Number(claudeMatch[1]) !== actual) {
+    drift.push(
+      `tool-count: CLAUDE.md claims ${claudeMatch[1]} tools registered; actual is ${actual} (per audit-lsp-tools.mjs Stats line). Update CLAUDE.md's platform-docs.md reference line.`,
+    );
+  } else if (claudeMatch) {
+    notes.push(
+      `tool-count: CLAUDE.md's ${claudeMatch[1]} matches actual ${actual}`,
+    );
+  } else {
+    notes.push(
+      "tool-count: could not find a 'N tools registered' claim in CLAUDE.md to check (informational — not necessarily a problem).",
+    );
+  }
+
+  const platformDocs = read("documents/platform-docs.md");
+  const platformMatch = platformDocs.match(/(\d+)\s+tools\s+·/);
+  if (platformMatch && Number(platformMatch[1]) !== actual) {
+    drift.push(
+      `tool-count: documents/platform-docs.md's banner claims ${platformMatch[1]} tools; actual is ${actual}. Update the banner line.`,
+    );
+  } else if (platformMatch) {
+    notes.push(
+      `tool-count: platform-docs.md banner (${platformMatch[1]}) matches actual ${actual}`,
+    );
+  }
+}
+
+// ── 2. Coverage thresholds ───────────────────────────────────────────────────
+
+function auditCoverageThresholds() {
+  const vitestConfig = read("vitest.config.ts");
+  const linesMatch = vitestConfig.match(/lines:\s*(\d+)/);
+  const branchesMatch = vitestConfig.match(/branches:\s*(\d+)/);
+  const functionsMatch = vitestConfig.match(/functions:\s*(\d+)/);
+  if (!linesMatch || !branchesMatch || !functionsMatch) {
+    drift.push(
+      "coverage: could not parse lines/branches/functions thresholds out of vitest.config.ts — its shape may have changed.",
+    );
+    return;
+  }
+  const actual = {
+    lines: Number(linesMatch[1]),
+    branches: Number(branchesMatch[1]),
+    functions: Number(functionsMatch[1]),
+  };
+
+  const claude = read("CLAUDE.md");
+  const claudeMatch = claude.match(
+    /Coverage gates:\s*(\d+)%\s*lines,\s*(\d+)%\s*branches,\s*(\d+)%\s*functions/,
+  );
+  if (!claudeMatch) {
+    notes.push(
+      "coverage: could not find a 'Coverage gates: X% lines, Y% branches, Z% functions' claim in CLAUDE.md to check.",
+    );
+    return;
+  }
+  const documented = {
+    lines: Number(claudeMatch[1]),
+    branches: Number(claudeMatch[2]),
+    functions: Number(claudeMatch[3]),
+  };
+  const mismatched =
+    documented.lines !== actual.lines ||
+    documented.branches !== actual.branches ||
+    documented.functions !== actual.functions;
+  if (mismatched) {
+    drift.push(
+      `coverage: CLAUDE.md claims ${documented.lines}/${documented.branches}/${documented.functions} ` +
+        `(lines/branches/functions); vitest.config.ts's actual thresholds are ` +
+        `${actual.lines}/${actual.branches}/${actual.functions}. Update CLAUDE.md's "Coverage gates" line ` +
+        `(check vitest.config.ts's inline comment first — a mismatch here is often an intentional ` +
+        `re-baseline, e.g. a vitest major-version coverage-counting change, not a real coverage drop).`,
+    );
+  } else {
+    notes.push(
+      `coverage: CLAUDE.md's ${documented.lines}/${documented.branches}/${documented.functions} matches vitest.config.ts`,
+    );
+  }
+}
+
+// ── run ──────────────────────────────────────────────────────────────────────
+
+auditToolCount();
+auditCoverageThresholds();
+
+for (const n of notes) console.log(`  ℹ ${n}`);
+if (drift.length > 0) {
+  console.log("\n⚠ docs-drift found (advisory only, does not fail CI):\n");
+  for (const d of drift) console.log(`  • ${d}`);
+} else {
+  console.log("\n✓ no docs drift found");
+}
+// Always exit 0 — see file header for why this is advisory-only.
+process.exit(0);


### PR DESCRIPTION
## Summary
- Track B3 of the resultmaxxing pass: extends the existing "documented ⇒ wired" pattern (`scripts/audit-docs-wired.mjs`, #850/#1012) with a sibling `scripts/audit-docs-drift.mjs` that checks the opposite failure mode — numeric doc claims (tool count, coverage thresholds) going stale relative to a moving ground truth.
- **Advisory only** (always exits 0) — drift here is a hygiene issue, not a correctness break; a hard gate would fight routine threshold-tuning PRs.
- Checks tool count (CLAUDE.md / platform-docs.md vs. `audit-lsp-tools.mjs`'s own Stats line) — currently clean, both already say 177.
- Checks coverage thresholds (CLAUDE.md vs. `vitest.config.ts`) — **this was drifted**: CLAUDE.md said 75/70/75, but `vitest.config.ts` has run 71/62/70 since an intentional re-baseline for vitest 4's stricter AST-aware coverage counting (the file's own inline comment already explains this isn't a real coverage regression, just a stricter measurement method). Fixed CLAUDE.md to state the actual numbers with that context, plus a ratchet-plan note (CI platforms currently clear ~72/63/71, so ~1pt of headroom is already banked for climbing back up).
- Also fixed a matching stale "75%/70%/75%" string in the CI step's *display name* in `ci.yml` — the enforcement itself was never wrong, only the label.
- Wired into the `lsp-audit` CI job alongside `audit-docs-wired.mjs`.

## Test plan
- [x] `node scripts/audit-docs-drift.mjs` — reports clean after the CLAUDE.md fix
- [x] `npm run typecheck`
- [x] `npx tsc -p tsconfig.tests.core.json`
- [x] `npx biome check --write` on changed files
- [x] Verified YAML indentation of the new CI step matches its siblings exactly

🤖 Generated with [Claude Code](https://claude.com/claude-code)