### PR TITLE
chore: gitignore three personal working docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,8 @@ intellij-plugin/.gradle/
 *-snapshot.md
 *.jpeg
 *.jpg
+
+# Personal/local working docs, not for version control
+/docs/audit-bridge-changelog-2026-06-25.md
+/docs/positioning-pricing-onepager.md
+/docs/roadmap-plan-2026-07-02.md


### PR DESCRIPTION
## Summary
- Adds explicit ignore entries for three untracked local notes files that were sitting at the repo root — not meant for version control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)