### PR TITLE
fix(templates): add missing allowWrites to triage-failing-tests-autofile

### DIFF
--- a/templates/recipes/triage-failing-tests-autofile.yaml
+++ b/templates/recipes/triage-failing-tests-autofile.yaml
@@ -26,6 +26,9 @@
 apiVersion: patchwork.sh/v1
 name: triage-failing-tests-autofile
 description: On a failing test run, write a triage note and FILE a GitHub issue (opt-in; gated by the worker trust ramp).
+allowWrites:
+  - file.write
+  - github.create_issue
 trigger:
   type: on_test_run
   filter: failure


### PR DESCRIPTION
## Summary
- The installed `~/.patchwork/recipes/triage-failing-tests-autofile.yaml` (patched during the worker-autonomy dogfood campaign) already declares `allowWrites: [file.write, github.create_issue]`, but the repo template it was scaffolded from was missing it.
- Anyone installing this recipe fresh from `templates/recipes/` would hit a write-policy denial on the `write_note` / `file_issue` steps.
- Checked `outcome-ingester.yaml`'s template for the same gap — it's a read-only poll (`github.search_issues`) plus a local `outcomes.classify_issues` tool with no recipe-declared writes, so no change needed there.

## Test plan
- [x] Diffed the fixed template against the installed copy — content now matches
- [ ] `patchwork recipe lint templates/recipes/triage-failing-tests-autofile.yaml` (schema/best-practice check)