### PR TITLE
chore(release): bump to 1.1.0-beta.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [1.1.0-beta.2] — 2026-07-08
+
+Small follow-up cycle from live dogfooding of the worker-autonomy gate.
+
+### Fixed
+
+- `templates/recipes/triage-failing-tests-autofile.yaml` was missing the `allowWrites: [file.write, github.create_issue]` block that the installed/dogfooded copy carried — a fresh install from the template would have hit a write-policy denial (#1144).
+- `npm test` now routes through the bridge's `runTests` tool when a bridge is live (`scripts/test-via-bridge.mjs`), so ordinary local test runs fire the worker-autonomy `on_test_run` trigger — previously only agent-invoked `runTests` calls did. Falls back to plain `vitest run` with no bridge attached (CI, unchanged). Windows fallback crash (missing `shell: true` on the `npx` spawn) fixed same-day (#1145).
+
+### Docs
+
+- Refreshed the README dashboard screenshot — the previous one predated the recent Overview-pane UI/UX passes (#1146).
+
 ## [1.1.0-beta.1] — 2026-07-06
 
 Worker-autonomy policy gate (keystone feature) · dashboard "Terminal deck" rewrite + copilot pane · Decision Record legibility layer · 123 commits since beta.13 (#1004–#1130). Minor/major version jump reflects the scale of this cycle, not a breaking API change — see below.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "patchwork-os",
-  "version": "1.1.0-beta.1",
+  "version": "1.1.0-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "patchwork-os",
-      "version": "1.1.0-beta.1",
+      "version": "1.1.0-beta.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "patchwork-os",
-  "version": "1.1.0-beta.1",
+  "version": "1.1.0-beta.2",
   "description": "Your personal AI runtime, local-first. Patchwork OS gives any AI model a consistent set of tools, YAML recipes, a delegation policy with approval queue, and a durable trace memory — all on your machine, all under your policy.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
Version bump per the release checklist (`docs/release-checklist.md`), rolling up today's dogfood fast-follow fixes:
- #1144 — `triage-failing-tests-autofile.yaml` template `allowWrites` gap
- #1145 — `npm test` routes through the bridge's `runTests` for real worker-autonomy dogfooding
- #1146 — README dashboard screenshot refresh

## Test plan
- [x] `npm --prefix . version` used to bump both `package.json` and `package-lock.json` consistently
- [x] CHANGELOG entry added for 1.1.0-beta.2
- [ ] CI green
- [ ] After merge: tag `v1.1.0-beta.2` and push to trigger `publish-npm.yml`'s `publish-beta` job (manual step — see below)