### PR TITLE
fix(push): wire real phone approval-gate notifications

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -75,6 +75,7 @@
     "pushServiceUrl": { "type": "string", "format": "uri" },
     "pushServiceToken": { "type": "string" },
     "pushServiceBaseUrl": { "type": "string", "format": "uri" },
+    "pushServiceAllowPrivate": { "type": "boolean" },
     "ntfyTopic": { "type": "string" },
     "ntfyServer": { "type": "string", "format": "uri" }
   },

--- a/dashboard/src/app/api/push/test/route.ts
+++ b/dashboard/src/app/api/push/test/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import webpush from "web-push";
+import { pushAgent } from "@/lib/pushAgent";
 import { getSubscriptionsFor } from "@/lib/pushStore";
 import { requireSameOrigin } from "@/lib/csrf";
 
@@ -45,7 +46,7 @@ export async function POST(req: Request) {
   });
 
   const results = await Promise.allSettled(
-    subs.map((sub) => webpush.sendNotification(sub, payload)),
+    subs.map((sub) => webpush.sendNotification(sub, payload, { agent: pushAgent })),
   );
 
   const sent = results.filter((r) => r.status === "fulfilled").length;

--- a/dashboard/src/app/api/push/test/route.ts
+++ b/dashboard/src/app/api/push/test/route.ts
@@ -46,7 +46,12 @@ export async function POST(req: Request) {
   });
 
   const results = await Promise.allSettled(
-    subs.map((sub) => webpush.sendNotification(sub, payload, { agent: pushAgent })),
+    subs.map((sub) =>
+      webpush.sendNotification(sub, payload, {
+        agent: pushAgent,
+        urgency: "high",
+      }),
+    ),
   );
 
   const sent = results.filter((r) => r.status === "fulfilled").length;

--- a/dashboard/src/app/api/relay/halt/route.ts
+++ b/dashboard/src/app/api/relay/halt/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import webpush from "web-push";
 import { verifyBearerToken } from "@/lib/constantTimeEqual";
+import { pushAgent } from "@/lib/pushAgent";
 import { getSubscriptionsFor, removeSubscription } from "@/lib/pushStore";
 import {
   DASHBOARD_API_BODY_CAPS,
@@ -120,7 +121,7 @@ export async function POST(req: Request) {
   webpush.setVapidDetails(vapid.subject, vapid.publicKey, vapid.privateKey);
 
   const results = await Promise.allSettled(
-    subs.map((sub) => webpush.sendNotification(sub, payload)),
+    subs.map((sub) => webpush.sendNotification(sub, payload, { agent: pushAgent })),
   );
   const sent = results.filter((r) => r.status === "fulfilled").length;
 

--- a/dashboard/src/app/api/relay/halt/route.ts
+++ b/dashboard/src/app/api/relay/halt/route.ts
@@ -121,7 +121,12 @@ export async function POST(req: Request) {
   webpush.setVapidDetails(vapid.subject, vapid.publicKey, vapid.privateKey);
 
   const results = await Promise.allSettled(
-    subs.map((sub) => webpush.sendNotification(sub, payload, { agent: pushAgent })),
+    subs.map((sub) =>
+      webpush.sendNotification(sub, payload, {
+        agent: pushAgent,
+        urgency: "high",
+      }),
+    ),
   );
   const sent = results.filter((r) => r.status === "fulfilled").length;
 

--- a/dashboard/src/app/api/relay/push/route.ts
+++ b/dashboard/src/app/api/relay/push/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import webpush from "web-push";
 import { verifyBearerToken } from "@/lib/constantTimeEqual";
+import { pushAgent } from "@/lib/pushAgent";
 import { getSubscriptionsFor, removeSubscription } from "@/lib/pushStore";
 import {
   DASHBOARD_API_BODY_CAPS,
@@ -158,7 +159,7 @@ export async function POST(req: Request) {
   webpush.setVapidDetails(vapid.subject, vapid.publicKey, vapid.privateKey);
 
   const results = await Promise.allSettled(
-    subs.map((sub) => webpush.sendNotification(sub, payload)),
+    subs.map((sub) => webpush.sendNotification(sub, payload, { agent: pushAgent })),
   );
   const sent = results.filter((r) => r.status === "fulfilled").length;
 

--- a/dashboard/src/app/api/relay/push/route.ts
+++ b/dashboard/src/app/api/relay/push/route.ts
@@ -159,7 +159,12 @@ export async function POST(req: Request) {
   webpush.setVapidDetails(vapid.subject, vapid.publicKey, vapid.privateKey);
 
   const results = await Promise.allSettled(
-    subs.map((sub) => webpush.sendNotification(sub, payload, { agent: pushAgent })),
+    subs.map((sub) =>
+      webpush.sendNotification(sub, payload, {
+        agent: pushAgent,
+        urgency: "high",
+      }),
+    ),
   );
   const sent = results.filter((r) => r.status === "fulfilled").length;
 

--- a/dashboard/src/lib/pushAgent.ts
+++ b/dashboard/src/lib/pushAgent.ts
@@ -1,0 +1,12 @@
+import https from "node:https";
+
+/**
+ * Shared https.Agent forcing IPv4-only connections for outbound Web Push
+ * sends. Some local network configs (observed: Tailscale active without a
+ * working native IPv6 uplink) inject unroutable AAAA records that make
+ * Node's Happy Eyeballs dual-stack connect hang until ETIMEDOUT, even
+ * though IPv4 to the same push endpoint (e.g. web.push.apple.com) works
+ * fine. web-push has no global family override, so every sendNotification
+ * call must pass this agent explicitly via the options argument.
+ */
+export const pushAgent = new https.Agent({ family: 4 });

--- a/docs/dogfood/release-notes-trigger-test.md
+++ b/docs/dogfood/release-notes-trigger-test.md
@@ -1,0 +1,6 @@
+# Release-notes trigger dogfood test
+
+2026-07-10: verifying the `release-notes` recipe's `git_hook`/post-commit trigger
+fires `release-notes-worker` for the first time, via a commit routed through the
+bridge's `gitCommit` MCP tool (required — a bare terminal `git commit` does not
+fire `onGitCommit`).

--- a/src/__tests__/helpers/fixtures.ts
+++ b/src/__tests__/helpers/fixtures.ts
@@ -48,6 +48,7 @@ export function makeConfig(overrides: Partial<Config> = {}): Config {
     pushServiceUrl: null,
     pushServiceToken: null,
     pushServiceBaseUrl: null,
+    pushServiceAllowPrivate: false,
     ntfyTopic: null,
     ntfyServer: null,
     watch: false,

--- a/src/__tests__/wireHaltPushDispatch.test.ts
+++ b/src/__tests__/wireHaltPushDispatch.test.ts
@@ -58,6 +58,7 @@ describe("wireHaltPushDispatch", () => {
         haltCategory: "agent_silent_fail",
         actionHint: "inspect prompt + check trace",
       }),
+      false, // allowPrivate
     );
   });
 
@@ -77,6 +78,7 @@ describe("wireHaltPushDispatch", () => {
         haltCategory: "auth_failure",
         actionHint: "reconnect from /connections",
       }),
+      false, // allowPrivate
     );
   });
 
@@ -97,6 +99,7 @@ describe("wireHaltPushDispatch", () => {
         haltCategory: "budget_exceeded",
         actionHint: "raise tokensMax / usdMax or shrink prompts",
       }),
+      false, // allowPrivate
     );
   });
 
@@ -181,6 +184,7 @@ describe("wireHaltPushDispatch", () => {
         runSeq: 0,
         status: "error",
       }),
+      false, // allowPrivate
     );
   });
 });

--- a/src/approvalHttp.ts
+++ b/src/approvalHttp.ts
@@ -66,6 +66,15 @@ export interface ApprovalHttpDeps {
   /** Public base URL of this bridge (e.g. https://mybridge.example.com). Embedded in push payload as callback base. */
   pushServiceBaseUrl?: string;
   /**
+   * Skip the SSRF private/CGNAT-range block for `pushServiceUrl` specifically.
+   * Off by default — the guard treats a private-range push relay the same as
+   * any other SSRF target. Set when the operator has deliberately pointed
+   * `pushServiceUrl` at a private/CGNAT host they control (e.g. a Tailscale
+   * `*.ts.net` address, 100.64.0.0/10), mirroring
+   * `--automation-allow-private-webhooks` for the automation webhook fan-out.
+   */
+  pushServiceAllowPrivate?: boolean;
+  /**
    * ntfy.sh topic for direct phone-path approvals via action buttons. When set
    * AND `pushServiceBaseUrl` is set (so the action URLs can reach the bridge),
    * each queued approval is published to the topic with Approve / Reject HTTP
@@ -565,6 +574,7 @@ async function dispatchPushNotification(
     approvalToken: string;
     bridgeCallbackBase: string;
   },
+  allowPrivate: boolean = false,
 ): Promise<void> {
   if (!pushServiceUrl.startsWith("https://")) {
     console.warn(`[push] Rejected non-HTTPS push service URL`);
@@ -581,7 +591,8 @@ async function dispatchPushNotification(
     console.warn(`[push] Blocked loopback push service hostname`);
     return;
   }
-  if (await hostResolvesToBlockedIp(hostname, "push")) return;
+  if (!allowPrivate && (await hostResolvesToBlockedIp(hostname, "push")))
+    return;
 
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), 5_000);
@@ -987,17 +998,22 @@ async function handleApprovalRequest(
 
   // Fire push notification in the background — phone path
   if (deps.pushServiceUrl && deps.pushServiceToken && approvalToken) {
-    dispatchPushNotification(deps.pushServiceUrl, deps.pushServiceToken, {
-      toolName,
-      tier,
-      callId,
-      requestedAt: now,
-      expiresAt: now + 5 * 60_000,
-      summary,
-      riskSignals,
-      approvalToken,
-      bridgeCallbackBase: deps.pushServiceBaseUrl ?? "",
-    }).catch(() => {});
+    dispatchPushNotification(
+      deps.pushServiceUrl,
+      deps.pushServiceToken,
+      {
+        toolName,
+        tier,
+        callId,
+        requestedAt: now,
+        expiresAt: now + 5 * 60_000,
+        summary,
+        riskSignals,
+        approvalToken,
+        bridgeCallbackBase: deps.pushServiceBaseUrl ?? "",
+      },
+      deps.pushServiceAllowPrivate ?? false,
+    ).catch(() => {});
   }
 
   // ntfy.sh phone path — independent of the FCM/APNS relay above. Action

--- a/src/approvalHttp.ts
+++ b/src/approvalHttp.ts
@@ -3,7 +3,11 @@ import {
   recordApprovalCompleted,
   recordApprovalPrompted,
 } from "./activationMetrics.js";
-import type { ApprovalQueue, RiskSignal } from "./approvalQueue.js";
+import type {
+  ApprovalDecision,
+  ApprovalQueue,
+  RiskSignal,
+} from "./approvalQueue.js";
 import { computePersonalSignals } from "./approvalSignals.js";
 import {
   evaluateRules,
@@ -12,6 +16,7 @@ import {
 } from "./ccPermissions.js";
 import { captureForRunlog } from "./recipes/stepObservation.js";
 import { computeRiskSignals } from "./riskSignals.js";
+import type { RiskTier } from "./riskTier.js";
 import { classifyTool } from "./riskTier.js";
 import { isPrivateHost } from "./ssrfGuard.js";
 
@@ -790,6 +795,111 @@ async function dispatchNtfyConfirmation(
   }
 }
 
+/** Notification-relevant subset of ApprovalDeps — the fields every approval
+ *  entry point (HTTP /approvals route, CLI PreToolUse gate) needs to fan out
+ *  webhook/push/ntfy dispatch identically. */
+export interface ApprovalNotifyDeps {
+  queue: ApprovalQueue;
+  webhookUrl?: string;
+  pushServiceUrl?: string;
+  pushServiceToken?: string;
+  pushServiceBaseUrl?: string;
+  pushServiceAllowPrivate?: boolean;
+  ntfyTopic?: string;
+  ntfyServer?: string;
+  ntfyHmacSecret?: string;
+}
+
+/**
+ * Queue an approval and fan out every configured notification channel
+ * (webhook, Web Push, ntfy) identically. Extracted so both the HTTP
+ * `/approvals` route (`handleApprovalRequest`) and the CLI PreToolUse gate
+ * (`transport.setApprovalGate` in bridge.ts) get the same phone-path
+ * notifications — before this extraction, CLI-originated approvals (the
+ * common case: `gitCommit`, `runInTerminal`, etc. from `claude` itself)
+ * silently enqueued with NO notification of any kind, since the CLI gate
+ * called `queue.request()` directly and never touched the dispatch* helpers
+ * below.
+ */
+export function enqueueApprovalWithDispatch(
+  deps: ApprovalNotifyDeps,
+  request: {
+    toolName: string;
+    params: Record<string, unknown>;
+    tier: RiskTier;
+    riskSignals: RiskSignal[];
+    summary?: string;
+    sessionId?: string;
+    personalSignals?: ReturnType<typeof computePersonalSignals>;
+  },
+): {
+  callId: string;
+  promise: Promise<ApprovalDecision>;
+} {
+  const { toolName, params, tier, riskSignals, summary, sessionId } = request;
+  const now = Date.now();
+  const { callId, approvalToken, promise } = deps.queue.request(
+    {
+      toolName,
+      params,
+      tier,
+      summary,
+      sessionId,
+      riskSignals,
+      ...(request.personalSignals !== undefined && {
+        personalSignals: request.personalSignals,
+      }),
+    },
+    { withToken: !!deps.pushServiceUrl || !!deps.ntfyTopic },
+  );
+  recordApprovalPrompted();
+
+  if (deps.webhookUrl) {
+    dispatchApprovalWebhook(deps.webhookUrl, {
+      toolName,
+      tier,
+      callId,
+      requestedAt: now,
+      expiresAt: now + 5 * 60_000,
+      summary,
+    }).catch(() => {});
+  }
+
+  if (deps.pushServiceUrl && deps.pushServiceToken && approvalToken) {
+    dispatchPushNotification(
+      deps.pushServiceUrl,
+      deps.pushServiceToken,
+      {
+        toolName,
+        tier,
+        callId,
+        requestedAt: now,
+        expiresAt: now + 5 * 60_000,
+        summary,
+        riskSignals,
+        approvalToken,
+        bridgeCallbackBase: deps.pushServiceBaseUrl ?? "",
+      },
+      deps.pushServiceAllowPrivate ?? false,
+    ).catch(() => {});
+  }
+
+  if (deps.ntfyTopic && approvalToken && deps.pushServiceBaseUrl) {
+    dispatchNtfyApproval(deps.ntfyServer ?? "https://ntfy.sh", {
+      topic: deps.ntfyTopic,
+      toolName,
+      tier,
+      callId,
+      summary,
+      approvalToken,
+      bridgeCallbackBase: deps.pushServiceBaseUrl,
+      hmacSecret: deps.ntfyHmacSecret,
+    }).catch(() => {});
+  }
+
+  return { callId, promise };
+}
+
 async function handleApprovalRequest(
   req: HttpRequest,
   deps: ApprovalHttpDeps,
@@ -962,75 +1072,15 @@ async function handleApprovalRequest(
     : undefined;
 
   const now = Date.now();
-  const { callId, approvalToken, promise } = deps.queue.request(
-    {
-      toolName,
-      params,
-      tier,
-      summary,
-      sessionId,
-      riskSignals,
-      // Always include personalSignals when activityLog is wired, even
-      // if the array is empty. The presence of the key is the signal
-      // that the wire is live; conditionally omitting it made it
-      // impossible to distinguish "wire broken" from "no signals fired"
-      // during dogfooding (verified end-to-end on 2026-05-03 — first
-      // three test runs looked broken when they were just empty).
-      // When activityLog isn't wired (no signals computed at all), the
-      // field stays absent — that case still means "not configured."
-      ...(personalSignals !== undefined && { personalSignals }),
-    },
-    { withToken: !!deps.pushServiceUrl || !!deps.ntfyTopic },
-  );
-  recordApprovalPrompted();
-
-  // Fire webhook notification in the background — never block approval flow
-  if (deps.webhookUrl) {
-    dispatchApprovalWebhook(deps.webhookUrl, {
-      toolName,
-      tier,
-      callId,
-      requestedAt: now,
-      expiresAt: now + 5 * 60_000,
-      summary,
-    }).catch(() => {});
-  }
-
-  // Fire push notification in the background — phone path
-  if (deps.pushServiceUrl && deps.pushServiceToken && approvalToken) {
-    dispatchPushNotification(
-      deps.pushServiceUrl,
-      deps.pushServiceToken,
-      {
-        toolName,
-        tier,
-        callId,
-        requestedAt: now,
-        expiresAt: now + 5 * 60_000,
-        summary,
-        riskSignals,
-        approvalToken,
-        bridgeCallbackBase: deps.pushServiceBaseUrl ?? "",
-      },
-      deps.pushServiceAllowPrivate ?? false,
-    ).catch(() => {});
-  }
-
-  // ntfy.sh phone path — independent of the FCM/APNS relay above. Action
-  // buttons in the notification POST back to /approve|/reject with the
-  // single-use token. Requires a public bridgeCallbackBase (HTTPS).
-  if (deps.ntfyTopic && approvalToken && deps.pushServiceBaseUrl) {
-    dispatchNtfyApproval(deps.ntfyServer ?? "https://ntfy.sh", {
-      topic: deps.ntfyTopic,
-      toolName,
-      tier,
-      callId,
-      summary,
-      approvalToken,
-      bridgeCallbackBase: deps.pushServiceBaseUrl,
-      hmacSecret: deps.ntfyHmacSecret,
-    }).catch(() => {});
-  }
+  const { callId, promise } = enqueueApprovalWithDispatch(deps, {
+    toolName,
+    params,
+    tier,
+    riskSignals,
+    summary,
+    sessionId,
+    personalSignals,
+  });
 
   const outcome = await promise;
   if (outcome !== "expired") {

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -7,6 +7,7 @@ import { ActivityLog } from "./activityLog.js";
 import { buildSummary } from "./analyticsAggregator.js";
 import { getAnalyticsPref, getAnalyticsSalt } from "./analyticsPrefs.js";
 import { sendAnalytics } from "./analyticsSend.js";
+import { enqueueApprovalWithDispatch } from "./approvalHttp.js";
 import { getApprovalQueue } from "./approvalQueue.js";
 import { AutomationHooks, loadPolicy } from "./automation.js";
 import { loadOrCreateBridgeToken } from "./bridgeToken.js";
@@ -403,14 +404,25 @@ export class Bridge {
               workspace: this.config.workspace,
             });
             if (gate.decision === "bypass") return "bypass";
-            const queue = getApprovalQueue();
-            const { promise, callId } = queue.request({
-              toolName,
-              params,
-              tier: gate.tier,
-              sessionId: sessionId ?? undefined,
-              riskSignals: gate.riskSignals,
-            });
+            const { promise, callId } = enqueueApprovalWithDispatch(
+              {
+                queue: getApprovalQueue(),
+                webhookUrl: this.server.approvalWebhookUrl,
+                pushServiceUrl: this.server.pushServiceUrl,
+                pushServiceToken: this.server.pushServiceToken,
+                pushServiceBaseUrl: this.server.pushServiceBaseUrl,
+                pushServiceAllowPrivate: this.server.pushServiceAllowPrivate,
+                ntfyTopic: this.server.ntfyTopic,
+                ntfyServer: this.server.ntfyServer,
+              },
+              {
+                toolName,
+                params,
+                tier: gate.tier,
+                sessionId: sessionId ?? undefined,
+                riskSignals: gate.riskSignals,
+              },
+            );
             onPending?.(callId);
             return promise;
           },
@@ -1678,6 +1690,8 @@ export class Bridge {
     this.server.pushServiceToken = this.config.pushServiceToken ?? undefined;
     this.server.pushServiceBaseUrl =
       this.config.pushServiceBaseUrl ?? undefined;
+    this.server.pushServiceAllowPrivate =
+      this.config.pushServiceAllowPrivate ?? false;
     this.server.ntfyTopic = this.config.ntfyTopic ?? undefined;
     this.server.ntfyServer = this.config.ntfyServer ?? undefined;
 
@@ -1691,7 +1705,11 @@ export class Bridge {
         const url = this.server.pushServiceUrl;
         const token = this.server.pushServiceToken;
         if (!url || !token) return null;
-        return { url, token };
+        return {
+          url,
+          token,
+          allowPrivate: this.server.pushServiceAllowPrivate,
+        };
       },
       logger: this.logger,
     });
@@ -1794,6 +1812,7 @@ export class Bridge {
             pushServiceUrl: this.server.pushServiceUrl ?? null,
             pushServiceToken: this.server.pushServiceToken ? "***" : null,
             pushServiceBaseUrl: this.server.pushServiceBaseUrl ?? null,
+            pushServiceAllowPrivate: this.server.pushServiceAllowPrivate,
             ntfyTopic: this.server.ntfyTopic ?? null,
             ntfyServer: this.server.ntfyServer ?? null,
           };

--- a/src/config.ts
+++ b/src/config.ts
@@ -68,6 +68,8 @@ export interface Config {
   pushServiceUrl: string | null;
   pushServiceToken: string | null;
   pushServiceBaseUrl: string | null;
+  /** Allow pushServiceUrl to target a private/CGNAT host (e.g. Tailscale *.ts.net, 100.64.0.0/10). Default false. */
+  pushServiceAllowPrivate: boolean;
   ntfyTopic: string | null;
   ntfyServer: string | null;
   watch: boolean;
@@ -571,6 +573,7 @@ export function parseConfig(argv: string[]): Config {
   let pushServiceUrl: string | null = null;
   let pushServiceToken: string | null = null;
   let pushServiceBaseUrl: string | null = null;
+  let pushServiceAllowPrivate = false;
   let ntfyTopic: string | null = null;
   let ntfyServer: string | null = null;
   const approvalWebhookUrl: string | null = (() => {
@@ -585,6 +588,7 @@ export function parseConfig(argv: string[]): Config {
       pushServiceUrl = pw.pushServiceUrl ?? null;
       pushServiceToken = pw.pushServiceToken ?? null;
       pushServiceBaseUrl = pw.pushServiceBaseUrl ?? null;
+      pushServiceAllowPrivate = pw.pushServiceAllowPrivate ?? false;
       ntfyTopic = pw.ntfyTopic ?? null;
       ntfyServer = pw.ntfyServer ?? null;
       // Seed driver from patchwork config if not already set by fileConfig or CLI
@@ -804,6 +808,9 @@ export function parseConfig(argv: string[]): Config {
       case "--automation-allow-private-webhooks":
         automationAllowPrivateWebhooks = true;
         break;
+      case "--push-service-allow-private":
+        pushServiceAllowPrivate = true;
+        break;
       case "--plugin": {
         const pluginPath = requireArg(args, ++i, "--plugin");
         if (pluginPath.length > 4096)
@@ -993,6 +1000,10 @@ Automation:
   --automation-allow-private-webhooks
                             Allow automation webhooks to target private/non-loopback hosts
                             (RFC1918, link-local, etc.). Default: loopback + public hosts only.
+  --push-service-allow-private
+                            Allow pushServiceUrl to target a private/CGNAT host (e.g. a
+                            Tailscale *.ts.net address, 100.64.0.0/10). Default: SSRF guard
+                            blocks private ranges.
 
 Plugins:
   --plugin <path-or-package>  Load a plugin (repeatable). Accepts a local path (./my-plugin) or
@@ -1186,6 +1197,7 @@ Environment Variables:
     pushServiceUrl,
     pushServiceToken,
     pushServiceBaseUrl,
+    pushServiceAllowPrivate,
     ntfyTopic,
     ntfyServer,
     toolRateLimit,

--- a/src/haltPushDispatch.ts
+++ b/src/haltPushDispatch.ts
@@ -54,6 +54,7 @@ export async function dispatchHaltPushNotification(
   pushServiceUrl: string,
   pushServiceToken: string,
   payload: HaltPushPayload,
+  allowPrivate: boolean = false,
 ): Promise<void> {
   if (!pushServiceUrl.startsWith("https://")) {
     console.warn(`[halt-push] Rejected non-HTTPS push service URL`);
@@ -70,19 +71,21 @@ export async function dispatchHaltPushNotification(
     console.warn(`[halt-push] Blocked loopback push service hostname`);
     return;
   }
-  try {
-    const resolved = await dns.lookup(hostname);
-    if (isBlockedIp(resolved.address)) {
+  if (!allowPrivate) {
+    try {
+      const resolved = await dns.lookup(hostname);
+      if (isBlockedIp(resolved.address)) {
+        console.warn(
+          `[halt-push] Blocked private/loopback IP for push service: ${resolved.address}`,
+        );
+        return;
+      }
+    } catch (err) {
       console.warn(
-        `[halt-push] Blocked private/loopback IP for push service: ${resolved.address}`,
+        `[halt-push] DNS resolution failed for ${hostname}: ${err instanceof Error ? err.message : String(err)}`,
       );
       return;
     }
-  } catch (err) {
-    console.warn(
-      `[halt-push] DNS resolution failed for ${hostname}: ${err instanceof Error ? err.message : String(err)}`,
-    );
-    return;
   }
 
   const controller = new AbortController();

--- a/src/patchworkConfig.ts
+++ b/src/patchworkConfig.ts
@@ -98,6 +98,13 @@ export interface PatchworkConfig {
    */
   pushServiceBaseUrl?: string;
   /**
+   * Allow `pushServiceUrl` to target a private/CGNAT host (e.g. a Tailscale
+   * `*.ts.net` address, 100.64.0.0/10). Default false — the SSRF guard
+   * treats a private-range push relay the same as any other SSRF target.
+   * Set with `--push-service-allow-private`.
+   */
+  pushServiceAllowPrivate?: boolean;
+  /**
    * Public-ntfy.sh push channel. Topic acts as a bearer; server defaults
    * to https://ntfy.sh and can be overridden for self-hosted instances.
    */

--- a/src/server.ts
+++ b/src/server.ts
@@ -418,6 +418,8 @@ export class Server extends EventEmitter<ServerEvents> {
   public pushServiceToken: string | undefined = undefined;
   /** Patchwork: public base URL of this bridge, embedded in push payloads as callback base. */
   public pushServiceBaseUrl: string | undefined = undefined;
+  /** Patchwork: allow pushServiceUrl to target a private/CGNAT host (e.g. Tailscale). Default false — SSRF guard blocks private ranges. */
+  public pushServiceAllowPrivate: boolean = false;
   /** Patchwork: ntfy.sh topic for direct phone-path approvals via action buttons. */
   public ntfyTopic: string | undefined = undefined;
   /** Patchwork: ntfy server (default https://ntfy.sh; override for self-hosted). */
@@ -1785,6 +1787,7 @@ export class Server extends EventEmitter<ServerEvents> {
           pushServiceUrl?: string;
           pushServiceToken?: string;
           pushServiceBaseUrl?: string;
+          pushServiceAllowPrivate?: boolean;
           ntfyTopic?: string;
           ntfyServer?: string;
         }>(req, SETTINGS_BODY_CAP);
@@ -1813,6 +1816,7 @@ export class Server extends EventEmitter<ServerEvents> {
                 "pushServiceUrl",
                 "pushServiceToken",
                 "pushServiceBaseUrl",
+                "pushServiceAllowPrivate",
                 "ntfyTopic",
                 "ntfyServer",
               ])
@@ -1961,6 +1965,15 @@ export class Server extends EventEmitter<ServerEvents> {
               return;
             }
 
+            // pushServiceAllowPrivate
+            if (
+              body.pushServiceAllowPrivate !== undefined &&
+              typeof body.pushServiceAllowPrivate !== "boolean"
+            ) {
+              respond400("pushServiceAllowPrivate must be a boolean");
+              return;
+            }
+
             // ntfyTopic — bearer-token on public ntfy.sh; charset-restricted.
             const ntfyTopicTrimmed =
               body.ntfyTopic !== undefined ? body.ntfyTopic.trim() : undefined;
@@ -2077,6 +2090,9 @@ export class Server extends EventEmitter<ServerEvents> {
             if (pushBaseTrimmed !== undefined) {
               cfg.pushServiceBaseUrl = pushBaseTrimmed || undefined;
             }
+            if (body.pushServiceAllowPrivate !== undefined) {
+              cfg.pushServiceAllowPrivate = body.pushServiceAllowPrivate;
+            }
             if (ntfyTopicTrimmed !== undefined) {
               cfg.ntfyTopic = ntfyTopicTrimmed || undefined;
             }
@@ -2188,6 +2204,9 @@ export class Server extends EventEmitter<ServerEvents> {
             if (pushBaseTrimmed !== undefined) {
               this.pushServiceBaseUrl = pushBaseTrimmed || undefined;
             }
+            if (body.pushServiceAllowPrivate !== undefined) {
+              this.pushServiceAllowPrivate = body.pushServiceAllowPrivate;
+            }
             if (ntfyTopicTrimmed !== undefined) {
               this.ntfyTopic = ntfyTopicTrimmed || undefined;
             }
@@ -2233,6 +2252,8 @@ export class Server extends EventEmitter<ServerEvents> {
                 changes.pushServiceToken = pushTokenTrimmed ? "***" : "";
               if (pushBaseTrimmed !== undefined)
                 changes.pushServiceBaseUrl = pushBaseTrimmed || "";
+              if (body.pushServiceAllowPrivate !== undefined)
+                changes.pushServiceAllowPrivate = body.pushServiceAllowPrivate;
               if (ntfyTopicTrimmed !== undefined)
                 changes.ntfyTopic = ntfyTopicTrimmed ? "***" : "";
               if (ntfyServerTrimmed !== undefined)
@@ -2897,6 +2918,7 @@ export class Server extends EventEmitter<ServerEvents> {
               pushServiceUrl: this.pushServiceUrl,
               pushServiceToken: this.pushServiceToken,
               pushServiceBaseUrl: this.pushServiceBaseUrl,
+              pushServiceAllowPrivate: this.pushServiceAllowPrivate,
               ntfyTopic: this.ntfyTopic,
               ntfyServer: this.ntfyServer,
               activityLog: this.activityLog,

--- a/src/wireHaltPushDispatch.ts
+++ b/src/wireHaltPushDispatch.ts
@@ -28,7 +28,11 @@ interface WireHaltPushDispatchDeps {
   /** Called per event — returns the current push relay config or null
    *  if push isn't configured. Reading from a getter rather than a
    *  captured value picks up runtime config changes. */
-  getPushConfig: () => { url: string; token: string } | null;
+  getPushConfig: () => {
+    url: string;
+    token: string;
+    allowPrivate?: boolean;
+  } | null;
   logger?: { warn?: (msg: string) => void };
   /** Override the dedup window. Default 60_000 ms. Tests pass a small
    *  value; production never sets it. */
@@ -95,16 +99,21 @@ export function wireHaltPushDispatch(
 
     // Best-effort: dispatchHaltPushNotification swallows errors, but
     // a synchronously-thrown URL parse error would still surface here.
-    dispatchHaltPushNotification(cfg.url, cfg.token, {
-      recipeName,
-      runSeq,
-      status: "error",
-      haltReason,
-      haltCategory,
-      actionHint,
-      errorMessage,
-      occurredAt: at,
-    }).catch((err) => {
+    dispatchHaltPushNotification(
+      cfg.url,
+      cfg.token,
+      {
+        recipeName,
+        runSeq,
+        status: "error",
+        haltReason,
+        haltCategory,
+        actionHint,
+        errorMessage,
+        occurredAt: at,
+      },
+      cfg.allowPrivate ?? false,
+    ).catch((err) => {
       deps.logger?.warn?.(
         `[halt-push] unexpected dispatcher error: ${err instanceof Error ? err.message : String(err)}`,
       );


### PR DESCRIPTION
## Summary
- CLI-originated tool approvals (the `transport.setApprovalGate` PreToolUse path — `gitCommit`, `runInTerminal`, etc. from `claude` itself) never dispatched any notification at all. The webhook/push/ntfy dispatch logic only lived in the separate HTTP `/approvals` route handler, used by a different caller. Extracted `enqueueApprovalWithDispatch()` so both paths share identical dispatch behavior.
- Web Push sends had no `urgency` header, letting APNs defer delivery under battery-saving heuristics — manifested as notifications arriving late or not at all despite a successful server-side send. Added `urgency: "high"`.
- `web-push`'s default dual-stack connect could hang/ETIMEDOUT on a network with unroutable IPv6 (observed with Tailscale active but no native IPv6 uplink), silently dropping every push. Forced IPv4 via a shared `https.Agent`.
- The SSRF guard on `pushServiceUrl` blocked the entire `100.64.0.0/10` CGNAT range — which includes Tailscale's own address space, the standard way to get HTTPS in front of a private dashboard. Added `--push-service-allow-private` / `pushServiceAllowPrivate` (default off), mirroring the existing `--automation-allow-private-webhooks` precedent.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] Full test suite green (approvalHttp, bridge session-resumption/real-resumption, haltPushDispatch, wireHaltPushDispatch)
- [x] Verified end-to-end on a real device: subscribed a real iOS PWA via Web Push, fired real approval-gate events (`gitCommit` through the bridge), confirmed push delivery + phone approval closes the loop