### PR TITLE
fix(tools): reject empty-string workspace + null bytes in editText

### DIFF
--- a/src/tools/__tests__/documentLinks.test.ts
+++ b/src/tools/__tests__/documentLinks.test.ts
@@ -82,4 +82,18 @@ describe("getDocumentLinks", () => {
     await tool.handler({ filePath });
     expect(client.getDocumentLinks).toHaveBeenCalledWith(filePath, undefined);
   });
+
+  it("rejects an empty-string workspace instead of silently bypassing scoping", async () => {
+    const client = makeClient();
+    // Empty-string workspace previously defeated resolveFilePath's containment
+    // check: path.resolve("", "foo.ts") === path.resolve(process.cwd(), "foo.ts"),
+    // and path.resolve("") === process.cwd(), so the containment check trivially
+    // passed and getDocumentLinks was called on a cwd-relative path completely
+    // outside the intended workspace — an explicit reject is required instead.
+    const tool = createGetDocumentLinksTool("", client as never);
+    const result = (await tool.handler({ filePath: "foo.ts" })) as any;
+    expect(result.isError).toBe(true);
+    expect(result.structuredContent.code).toBe("workspace_escape");
+    expect(client.getDocumentLinks).not.toHaveBeenCalled();
+  });
 });

--- a/src/tools/__tests__/editText.test.ts
+++ b/src/tools/__tests__/editText.test.ts
@@ -266,6 +266,37 @@ describe("createEditTextTool — input validation", () => {
     expect(result.error).toMatch(/text.*required/i);
   });
 
+  it("returns error when insert text contains a null byte", async () => {
+    const tool = createEditTextTool(tmpDir, disconnected);
+    const result = parse(
+      await tool.handler({
+        filePath: "test.ts",
+        edits: [{ type: "insert", line: 1, column: 1, text: "foo\x00bar" }],
+      }),
+    );
+    expect(result.error).toMatch(/null byte/i);
+  });
+
+  it("returns error when replace text contains a null byte", async () => {
+    const tool = createEditTextTool(tmpDir, disconnected);
+    const result = parse(
+      await tool.handler({
+        filePath: "test.ts",
+        edits: [
+          {
+            type: "replace",
+            line: 1,
+            column: 1,
+            endLine: 1,
+            endColumn: 2,
+            text: "foo\x00bar",
+          },
+        ],
+      }),
+    );
+    expect(result.error).toMatch(/null byte/i);
+  });
+
   it("returns error when delete missing endLine/endColumn", async () => {
     const tool = createEditTextTool(tmpDir, disconnected);
     const result = parse(

--- a/src/tools/documentLinks.ts
+++ b/src/tools/documentLinks.ts
@@ -1,6 +1,8 @@
+import { ToolErrorCodes } from "../errors.js";
 import type { ExtensionClient } from "../extensionClient.js";
 import { lspColdStartError, lspWithRetry } from "./lsp.js";
 import {
+  error,
   extensionRequired,
   requireString,
   resolveFilePath,
@@ -52,6 +54,17 @@ export function createGetDocumentLinksTool(
     async handler(args: Record<string, unknown>, signal?: AbortSignal) {
       if (!extensionClient.isConnected()) {
         return extensionRequired("getDocumentLinks");
+      }
+      // An explicitly empty-string workspace defeats resolveFilePath's
+      // containment check (path.resolve("") === process.cwd()), letting a
+      // relative filePath resolve outside the intended workspace and be
+      // returned unscoped. Reject explicitly rather than treating "" as "no
+      // scoping requested" — that's what `undefined` is for.
+      if (workspace === "") {
+        return error(
+          "getDocumentLinks: workspace must not be an empty string — this would bypass workspace scoping.",
+          ToolErrorCodes.WORKSPACE_ESCAPE,
+        );
       }
       const filePath = resolveFilePath(
         requireString(args, "filePath"),

--- a/src/tools/editText.ts
+++ b/src/tools/editText.ts
@@ -298,6 +298,14 @@ export function createEditTextTool(
         if (type === "replace" && typeof edit.text !== "string") {
           return error(`edits[${i}].text is required for replace operations`);
         }
+        // Null bytes in edit text permanently corrupt the file (same rationale as
+        // searchAndReplace's guard): git treats it as binary, tsc/editors refuse to open it.
+        if (
+          typeof edit.text === "string" &&
+          (edit.text as string).includes("\x00")
+        ) {
+          return error(`edits[${i}].text must not contain a null byte`);
+        }
       }
 
       const filePath = resolveFilePath(rawPath, workspace, { write: true });


### PR DESCRIPTION
## Summary
Recovered from two abandoned git worktrees found during a branch-cleanup pass — both fixes were written and tested but never landed:

- **getDocumentLinks**: an explicitly empty-string `workspace` defeated `resolveFilePath`'s containment check (`path.resolve("") === process.cwd()`, so a relative `filePath` resolved outside the intended workspace and was returned unscoped). Now rejects `""` explicitly with `WORKSPACE_ESCAPE`.
- **editText**: null bytes in insert/replace text permanently corrupt the file (git treats it as binary, tsc/editors refuse to open it) — same rationale as `searchAndReplace`'s existing null-byte guard. Now rejected up front.

Two independent agent sessions had separately attempted the `documentLinks` fix (found in two different abandoned worktrees, near-identical) — picked the more complete version (fix + test).

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `documentLinks.test.ts` + `editText.test.ts` — 41 tests, all green