### PR TITLE
feat(policy): deterministic patchwork.policy.yml enforcement

### DIFF
--- a/src/__tests__/policy.test.ts
+++ b/src/__tests__/policy.test.ts
@@ -208,7 +208,7 @@ describe("checkPolicy", () => {
     it("does not restrict non-network tools even with a host allowlist configured", () => {
       const result = checkPolicy(policy, {
         toolName: "file.write",
-        params: { path: "/tmp/x.txt" },
+        params: { path: path.join(os.tmpdir(), "x.txt") },
       });
       expect(result.allowed).toBe(true);
     });

--- a/src/__tests__/policy.test.ts
+++ b/src/__tests__/policy.test.ts
@@ -1,0 +1,348 @@
+/**
+ * patchwork.policy.yml — deterministic policy loader + checker.
+ */
+
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { checkPolicy, loadPolicyFile, parsePolicy } from "../policy.js";
+
+describe("parsePolicy", () => {
+  it("parses a minimal valid policy", () => {
+    const policy = parsePolicy({ version: 1 });
+    expect(policy.version).toBe(1);
+    expect(policy.defaults.forbiddenPaths).toEqual([]);
+    expect(policy.workers).toEqual({});
+  });
+
+  it("parses a full policy with defaults and worker overrides", () => {
+    const policy = parsePolicy({
+      version: 1,
+      defaults: {
+        forbiddenPaths: ["**/.env"],
+        allowedNetworkHosts: ["api.github.com"],
+        allowedCommands: ["git *"],
+      },
+      workers: {
+        "test-guardian-worker": { allowedTools: ["git.log_since"] },
+      },
+    });
+    expect(policy.defaults.forbiddenPaths).toEqual(["**/.env"]);
+    expect(policy.workers["test-guardian-worker"]?.allowedTools).toEqual([
+      "git.log_since",
+    ]);
+  });
+
+  it("rejects a non-object", () => {
+    expect(() => parsePolicy("not an object")).toThrow(/mapping/);
+    expect(() => parsePolicy(null)).toThrow(/mapping/);
+  });
+
+  it("rejects an unsupported version", () => {
+    expect(() => parsePolicy({ version: 2 })).toThrow(/version/);
+    expect(() => parsePolicy({})).toThrow(/version/);
+  });
+
+  it("rejects non-string-array fields", () => {
+    expect(() =>
+      parsePolicy({ version: 1, defaults: { forbiddenPaths: [1, 2] } }),
+    ).toThrow(/forbiddenPaths/);
+    expect(() =>
+      parsePolicy({
+        version: 1,
+        workers: { w1: { allowedTools: "not-an-array" } },
+      }),
+    ).toThrow(/allowedTools/);
+  });
+
+  it("rejects a non-object worker entry", () => {
+    expect(() => parsePolicy({ version: 1, workers: { w1: "nope" } })).toThrow(
+      /workers\.w1/,
+    );
+  });
+});
+
+describe("loadPolicyFile", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(path.join(os.tmpdir(), "policy-test-"));
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("returns the default (no-restriction) policy when the file is absent", () => {
+    const result = loadPolicyFile(dir);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.policy.defaults.forbiddenPaths).toEqual([]);
+    }
+  });
+
+  it("loads and parses a valid file", () => {
+    writeFileSync(
+      path.join(dir, "patchwork.policy.yml"),
+      "version: 1\ndefaults:\n  forbiddenPaths:\n    - '**/.env'\n",
+    );
+    const result = loadPolicyFile(dir);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.policy.defaults.forbiddenPaths).toEqual(["**/.env"]);
+    }
+  });
+
+  it("fails closed (ok:false) on a malformed file, never silently permissive", () => {
+    writeFileSync(
+      path.join(dir, "patchwork.policy.yml"),
+      "version: 1\ndefaults:\n  forbiddenPaths: not-an-array\n",
+    );
+    const result = loadPolicyFile(dir);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toMatch(/malformed/);
+    }
+  });
+
+  it("fails closed on invalid YAML syntax", () => {
+    writeFileSync(
+      path.join(dir, "patchwork.policy.yml"),
+      "version: 1\n  bad indent: [",
+    );
+    const result = loadPolicyFile(dir);
+    expect(result.ok).toBe(false);
+  });
+});
+
+describe("checkPolicy", () => {
+  it("allows any call under the default (empty) policy", () => {
+    const policy = parsePolicy({ version: 1 });
+    const result = checkPolicy(policy, {
+      toolName: "file.write",
+      params: { path: "/anywhere/at/all.txt" },
+    });
+    expect(result.allowed).toBe(true);
+  });
+
+  describe("forbidden paths", () => {
+    const policy = parsePolicy({
+      version: 1,
+      defaults: { forbiddenPaths: ["**/.env", "**/.env.*", "**/id_rsa*"] },
+    });
+
+    it("blocks a direct match on a forbidden path glob", () => {
+      const result = checkPolicy(policy, {
+        toolName: "file.read",
+        params: { path: "/repo/.env" },
+      });
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toMatch(/\.env/);
+    });
+
+    it("blocks a nested match via the ** glob", () => {
+      const result = checkPolicy(policy, {
+        toolName: "file.read",
+        params: { path: "/repo/deep/nested/dir/.env.production" },
+      });
+      expect(result.allowed).toBe(false);
+    });
+
+    it("blocks when the path appears in a differently-named param key", () => {
+      const result = checkPolicy(policy, {
+        toolName: "editText",
+        params: { filePath: "/home/user/.ssh/id_rsa" },
+      });
+      expect(result.allowed).toBe(false);
+    });
+
+    it("allows a path that does not match any forbidden glob", () => {
+      const result = checkPolicy(policy, {
+        toolName: "file.read",
+        params: { path: "/repo/src/index.ts" },
+      });
+      expect(result.allowed).toBe(true);
+    });
+  });
+
+  describe("network host allowlist", () => {
+    const policy = parsePolicy({
+      version: 1,
+      defaults: {
+        allowedNetworkHosts: ["api.github.com", "*.githubusercontent.com"],
+      },
+    });
+
+    it("allows an exact allowlisted host", () => {
+      const result = checkPolicy(policy, {
+        toolName: "sendHttpRequest",
+        params: { url: "https://api.github.com/repos/foo/bar" },
+      });
+      expect(result.allowed).toBe(true);
+    });
+
+    it("allows a wildcard-matched host", () => {
+      const result = checkPolicy(policy, {
+        toolName: "sendHttpRequest",
+        params: { url: "https://raw.githubusercontent.com/foo/bar" },
+      });
+      expect(result.allowed).toBe(true);
+    });
+
+    it("blocks a non-allowlisted host", () => {
+      const result = checkPolicy(policy, {
+        toolName: "sendHttpRequest",
+        params: { url: "https://evil.example.com/exfiltrate" },
+      });
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toMatch(/evil\.example\.com/);
+    });
+
+    it("fails closed on an unparsable URL", () => {
+      const result = checkPolicy(policy, {
+        toolName: "sendHttpRequest",
+        params: { url: "not a url" },
+      });
+      expect(result.allowed).toBe(false);
+    });
+
+    it("does not restrict non-network tools even with a host allowlist configured", () => {
+      const result = checkPolicy(policy, {
+        toolName: "file.write",
+        params: { path: "/tmp/x.txt" },
+      });
+      expect(result.allowed).toBe(true);
+    });
+
+    it("has no restriction when allowedNetworkHosts is empty", () => {
+      const openPolicy = parsePolicy({ version: 1 });
+      const result = checkPolicy(openPolicy, {
+        toolName: "sendHttpRequest",
+        params: { url: "https://anywhere.example.com" },
+      });
+      expect(result.allowed).toBe(true);
+    });
+  });
+
+  describe("command allowlist", () => {
+    const policy = parsePolicy({
+      version: 1,
+      defaults: { allowedCommands: ["git *", "npm test"] },
+    });
+
+    it("allows a matching command", () => {
+      const result = checkPolicy(policy, {
+        toolName: "runCommand",
+        params: { command: "git status" },
+      });
+      expect(result.allowed).toBe(true);
+    });
+
+    it("blocks a non-matching command", () => {
+      const result = checkPolicy(policy, {
+        toolName: "runCommand",
+        params: { command: "rm -rf /" },
+      });
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toMatch(/rm -rf/);
+    });
+
+    it("applies to runInTerminal and sendTerminalCommand too", () => {
+      expect(
+        checkPolicy(policy, {
+          toolName: "runInTerminal",
+          params: { command: "curl evil.com" },
+        }).allowed,
+      ).toBe(false);
+      expect(
+        checkPolicy(policy, {
+          toolName: "sendTerminalCommand",
+          params: { command: "curl evil.com" },
+        }).allowed,
+      ).toBe(false);
+    });
+
+    it("has no restriction when allowedCommands is empty", () => {
+      const openPolicy = parsePolicy({ version: 1 });
+      const result = checkPolicy(openPolicy, {
+        toolName: "runCommand",
+        params: { command: "anything at all" },
+      });
+      expect(result.allowed).toBe(true);
+    });
+  });
+
+  describe("per-worker tool allowlist", () => {
+    const policy = parsePolicy({
+      version: 1,
+      workers: {
+        "test-guardian-worker": {
+          allowedTools: ["git.log_since", "github.create_issue"],
+        },
+      },
+    });
+
+    it("allows a tool in the worker's allowlist", () => {
+      const result = checkPolicy(policy, {
+        toolName: "git.log_since",
+        params: {},
+        workerId: "test-guardian-worker",
+      });
+      expect(result.allowed).toBe(true);
+    });
+
+    it("blocks a tool not in the worker's allowlist", () => {
+      const result = checkPolicy(policy, {
+        toolName: "gitPush",
+        params: {},
+        workerId: "test-guardian-worker",
+      });
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toMatch(/test-guardian-worker/);
+    });
+
+    it("does not restrict a worker with no policy entry", () => {
+      const result = checkPolicy(policy, {
+        toolName: "anything",
+        params: {},
+        workerId: "some-other-worker",
+      });
+      expect(result.allowed).toBe(true);
+    });
+
+    it("does not restrict when no workerId is supplied (non-worker call)", () => {
+      const result = checkPolicy(policy, {
+        toolName: "gitPush",
+        params: {},
+      });
+      expect(result.allowed).toBe(true);
+    });
+
+    it("a worker entry with no allowedTools field imposes no additional restriction", () => {
+      const p = parsePolicy({
+        version: 1,
+        workers: { "quiet-worker": {} },
+      });
+      const result = checkPolicy(p, {
+        toolName: "anything",
+        params: {},
+        workerId: "quiet-worker",
+      });
+      expect(result.allowed).toBe(true);
+    });
+  });
+
+  it("checks run independently — a forbidden path blocks even for an allowed tool", () => {
+    const policy = parsePolicy({
+      version: 1,
+      defaults: { forbiddenPaths: ["**/.env"] },
+      workers: { w1: { allowedTools: ["file.write"] } },
+    });
+    const result = checkPolicy(policy, {
+      toolName: "file.write",
+      params: { path: "/repo/.env" },
+      workerId: "w1",
+    });
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toMatch(/\.env/);
+  });
+});

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -19,7 +19,12 @@ import { DecisionTraceLog } from "./decisionTraceLog.js";
 import { createDriver } from "./drivers/index.js";
 import { getLocalEmbedFn } from "./embeddings/index.js";
 import { ExtensionClient } from "./extensionClient.js";
-import { lockKillSwitchEnv, watchFlags } from "./featureFlags.js";
+import {
+  FLAG_ENFORCE_POLICY,
+  isEnabled,
+  lockKillSwitchEnv,
+  watchFlags,
+} from "./featureFlags.js";
 import { FileLock } from "./fileLock.js";
 import { buildEnforcementReminder } from "./instructionsUtils.js";
 import { LockFileManager } from "./lockfile.js";
@@ -33,6 +38,7 @@ import {
 import type { LoadedPluginTool } from "./pluginLoader.js";
 import { loadPlugins, loadPluginsFull } from "./pluginLoader.js";
 import { PluginWatcher } from "./pluginWatcher.js";
+import { checkPolicy, loadPolicyFile } from "./policy.js";
 import { isPreToolUseHookRegistered } from "./preToolUseHook.js";
 import type { ProbeResults } from "./probe.js";
 import { probeAll } from "./probe.js";
@@ -397,6 +403,30 @@ export class Bridge {
         }
         transport.setApprovalGate(
           async ({ toolName, params, sessionId, onPending }) => {
+            // Deterministic policy check — runs BEFORE the trust/approval
+            // gate and is checked independently of it. A policy violation
+            // is refused outright, even for a call the gate would have
+            // bypassed entirely (e.g. a reversible read of a forbidden
+            // path) — trust level and policy are separate axes; no amount
+            // of earned trust unlocks a policy-forbidden action. Gated
+            // behind FLAG_ENFORCE_POLICY (default off) — see its doc
+            // comment in featureFlags.ts.
+            if (isEnabled(FLAG_ENFORCE_POLICY)) {
+              const loaded = loadPolicyFile(this.config.workspace);
+              if (!loaded.ok) {
+                // Fail-closed: a malformed patchwork.policy.yml must never
+                // be silently equivalent to "no policy configured".
+                this.logger.warn?.(`[policy] ${loaded.error}`);
+                return "policy_denied";
+              }
+              const verdict = checkPolicy(loaded.policy, { toolName, params });
+              if (!verdict.allowed) {
+                this.logger.warn?.(
+                  `[policy] denied "${toolName}": ${verdict.reason}`,
+                );
+                return "policy_denied";
+              }
+            }
             const gate = evaluateInProcessGate({
               toolName,
               params,

--- a/src/featureFlags.ts
+++ b/src/featureFlags.ts
@@ -337,6 +337,18 @@ export const FLAG_WORKER_AUTONOMY = "worker.autonomy";
  */
 export const FLAG_ENFORCE_ALLOWWRITES = "recipe.enforce-allowwrites";
 
+/**
+ * Enforce `patchwork.policy.yml` (src/policy.ts) — a deterministic,
+ * non-LLM permissions matrix checked BEFORE the trust/approval gate.
+ * Default OFF: no policy file exists on a fresh install, and even where
+ * one does, this changes the failure mode of every gated tool call from
+ * "queue for approval" to a hard, silent-to-the-caller "policy_denied"
+ * for anything the file forbids — worth opting into deliberately per
+ * operator rather than surprising an existing setup. See src/policy.ts's
+ * module doc for the fail-closed-on-malformed-file behavior.
+ */
+export const FLAG_ENFORCE_POLICY = "policy.enforce";
+
 // Register built-in flags
 registerFlag({
   id: KILL_SWITCH_WRITES,
@@ -387,6 +399,15 @@ registerFlag({
   id: FLAG_ENFORCE_ALLOWWRITES,
   description:
     "Enforce a recipe's allowWrites acknowledgment at runtime (not just at `recipe preflight` time) — an unacknowledged write step throws instead of running. Default off; see FLAG_ENFORCE_ALLOWWRITES doc comment for why.",
+  defaultValue: false,
+  category: "safety",
+  requiresOptIn: true,
+});
+
+registerFlag({
+  id: FLAG_ENFORCE_POLICY,
+  description:
+    "Enforce patchwork.policy.yml — a deterministic, non-LLM permissions matrix checked before the trust/approval gate. Default off; see FLAG_ENFORCE_POLICY doc comment for why.",
   defaultValue: false,
   category: "safety",
   requiresOptIn: true,

--- a/src/policy.ts
+++ b/src/policy.ts
@@ -1,0 +1,287 @@
+/**
+ * patchwork.policy.yml — deterministic, non-LLM security boundary.
+ *
+ * This is NOT a prompt or an LLM instruction. It's a rigid, machine-checked
+ * permissions matrix, evaluated in `evaluateInProcessGate` (riskSignals.ts)
+ * BEFORE the trust/approval gate even runs. A policy violation is refused
+ * outright — it never reaches the Approval Queue, unlike a gated action
+ * (which is held for human review). Even a fully-trusted, L4 worker cannot
+ * cross a policy boundary; policy and trust are independent axes.
+ *
+ * Fail-closed on a malformed file: if `patchwork.policy.yml` exists but
+ * fails to parse, every checked action is denied rather than silently
+ * running unrestricted — a typo in the policy file must never be
+ * indistinguishable from "no policy configured". A MISSING file is treated
+ * as "no policy configured" (opt-in feature, existing behavior unchanged).
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { minimatch } from "minimatch";
+import { parse as parseYaml } from "yaml";
+
+export interface PatchworkPolicyDefaults {
+  /** Path globs never readable/writable, any tool, any worker. */
+  forbiddenPaths: string[];
+  /** Outbound network hosts allowed for http-namespace / sendHttpRequest-style tools. Empty = no extra restriction beyond the existing SSRF guard. */
+  allowedNetworkHosts: string[];
+  /** Terminal command allowlist for runCommand/runInTerminal. Empty = no extra restriction beyond the bridge's existing command allowlist. */
+  allowedCommands: string[];
+}
+
+export interface PatchworkWorkerPolicy {
+  /** Tool ids this worker may call. Absent = no additional restriction (defaults still apply). Present = worker is restricted to exactly this list. */
+  allowedTools?: string[];
+}
+
+export interface PatchworkPolicy {
+  version: number;
+  defaults: PatchworkPolicyDefaults;
+  /** Keyed by worker id (matches `id:` in the worker's *.worker.yaml manifest). */
+  workers: Record<string, PatchworkWorkerPolicy>;
+}
+
+const DEFAULT_POLICY: PatchworkPolicy = {
+  version: 1,
+  defaults: {
+    forbiddenPaths: [],
+    allowedNetworkHosts: [],
+    allowedCommands: [],
+  },
+  workers: {},
+};
+
+function asStringArray(v: unknown, field: string): string[] {
+  if (v === undefined) return [];
+  if (!Array.isArray(v) || !v.every((x) => typeof x === "string")) {
+    throw new Error(`${field} must be an array of strings`);
+  }
+  return v;
+}
+
+/** Parse + validate a raw parsed-YAML object into a PatchworkPolicy. Throws on any structural error — callers decide fail-closed handling. */
+export function parsePolicy(raw: unknown): PatchworkPolicy {
+  if (raw === null || typeof raw !== "object") {
+    throw new Error("policy file must be a YAML mapping");
+  }
+  const obj = raw as Record<string, unknown>;
+  const version = obj.version;
+  if (version !== 1) {
+    throw new Error(
+      `policy version must be 1 (got ${JSON.stringify(version)})`,
+    );
+  }
+
+  const defaultsRaw = (obj.defaults ?? {}) as Record<string, unknown>;
+  const defaults: PatchworkPolicyDefaults = {
+    forbiddenPaths: asStringArray(
+      defaultsRaw.forbiddenPaths,
+      "defaults.forbiddenPaths",
+    ),
+    allowedNetworkHosts: asStringArray(
+      defaultsRaw.allowedNetworkHosts,
+      "defaults.allowedNetworkHosts",
+    ),
+    allowedCommands: asStringArray(
+      defaultsRaw.allowedCommands,
+      "defaults.allowedCommands",
+    ),
+  };
+
+  const workersRaw = (obj.workers ?? {}) as Record<string, unknown>;
+  const workers: Record<string, PatchworkWorkerPolicy> = {};
+  for (const [workerId, w] of Object.entries(workersRaw)) {
+    if (w === null || typeof w !== "object") {
+      throw new Error(`workers.${workerId} must be a mapping`);
+    }
+    const wObj = w as Record<string, unknown>;
+    workers[workerId] = {
+      ...(wObj.allowedTools !== undefined && {
+        allowedTools: asStringArray(
+          wObj.allowedTools,
+          `workers.${workerId}.allowedTools`,
+        ),
+      }),
+    };
+  }
+
+  return { version, defaults, workers };
+}
+
+export type PolicyLoadResult =
+  | { ok: true; policy: PatchworkPolicy }
+  | { ok: false; error: string };
+
+/**
+ * Load `patchwork.policy.yml` from a directory (typically the workspace
+ * root). Returns `{ ok: true, policy: DEFAULT_POLICY }` (i.e. no
+ * restriction) when the file is absent — this is an opt-in feature.
+ * Returns `{ ok: false }` when the file exists but fails to parse —
+ * callers MUST treat this as fail-closed (deny), never as "no policy".
+ */
+export function loadPolicyFile(workspaceDir: string): PolicyLoadResult {
+  const filePath = path.join(workspaceDir, "patchwork.policy.yml");
+  if (!existsSync(filePath)) {
+    return { ok: true, policy: DEFAULT_POLICY };
+  }
+  try {
+    const policy = parsePolicy(parseYaml(readFileSync(filePath, "utf-8")));
+    return { ok: true, policy };
+  } catch (err) {
+    return {
+      ok: false,
+      error: `patchwork.policy.yml is malformed: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+}
+
+export interface PolicyCheckResult {
+  allowed: boolean;
+  /** Populated only when allowed=false — the specific rule that blocked the call. */
+  reason?: string;
+}
+
+/**
+ * Extract candidate filesystem path values from a tool call's params.
+ * Deliberately broad (checks several common key names) rather than
+ * per-tool-aware — a false-positive scan (checking a param that isn't
+ * really a path) costs nothing; a false negative (missing a real path
+ * param) defeats the whole boundary.
+ */
+const PATH_PARAM_KEYS = [
+  "path",
+  "filePath",
+  "file",
+  "cwd",
+  "workdir",
+  "directory",
+];
+
+function extractPathCandidates(params: Record<string, unknown>): string[] {
+  const out: string[] = [];
+  for (const key of PATH_PARAM_KEYS) {
+    const v = params[key];
+    if (typeof v === "string" && v.length > 0) out.push(v);
+  }
+  return out;
+}
+
+function matchesAnyGlob(candidate: string, globs: string[]): string | null {
+  // Match both the raw (possibly relative) value and its normalized form,
+  // since a forbidden-path glob author can't predict whether a tool
+  // receives an absolute or workspace-relative path.
+  const normalized = candidate.replace(/\\/g, "/");
+  for (const g of globs) {
+    if (
+      minimatch(normalized, g, { dot: true }) ||
+      minimatch(path.basename(normalized), g, { dot: true })
+    ) {
+      return g;
+    }
+  }
+  return null;
+}
+
+function extractUrlCandidates(
+  toolName: string,
+  params: Record<string, unknown>,
+): string[] {
+  const isNetworkTool =
+    toolName === "sendHttpRequest" || toolName.startsWith("http.");
+  if (!isNetworkTool) return [];
+  const v = params.url;
+  return typeof v === "string" && v.length > 0 ? [v] : [];
+}
+
+function hostAllowed(url: string, allowedHosts: string[]): boolean {
+  if (allowedHosts.length === 0) return true; // no restriction configured
+  let hostname: string;
+  try {
+    hostname = new URL(url).hostname;
+  } catch {
+    return false; // unparsable URL — fail closed
+  }
+  return allowedHosts.some((pattern) => minimatch(hostname, pattern));
+}
+
+function extractCommandCandidate(
+  toolName: string,
+  params: Record<string, unknown>,
+): string | null {
+  const isCommandTool =
+    toolName === "runCommand" ||
+    toolName === "runInTerminal" ||
+    toolName === "sendTerminalCommand";
+  if (!isCommandTool) return null;
+  const v = params.command;
+  return typeof v === "string" && v.length > 0 ? v : null;
+}
+
+/**
+ * Deterministic policy check for a single tool call. Pure function — no
+ * I/O, no LLM, same inputs always produce the same output. Called from
+ * `evaluateInProcessGate` before the trust/approval gate runs.
+ */
+export function checkPolicy(
+  policy: PatchworkPolicy,
+  opts: {
+    toolName: string;
+    params: Record<string, unknown>;
+    workerId?: string;
+  },
+): PolicyCheckResult {
+  const { toolName, params, workerId } = opts;
+
+  // 1. Forbidden paths — applies to every tool/worker, no override.
+  for (const candidate of extractPathCandidates(params)) {
+    const hit = matchesAnyGlob(candidate, policy.defaults.forbiddenPaths);
+    if (hit) {
+      return {
+        allowed: false,
+        reason: `path "${candidate}" matches forbidden pattern "${hit}"`,
+      };
+    }
+  }
+
+  // 2. Network host allowlist.
+  for (const url of extractUrlCandidates(toolName, params)) {
+    if (!hostAllowed(url, policy.defaults.allowedNetworkHosts)) {
+      return {
+        allowed: false,
+        reason: `network request to "${url}" is not in allowedNetworkHosts`,
+      };
+    }
+  }
+
+  // 3. Command allowlist.
+  const command = extractCommandCandidate(toolName, params);
+  if (command && policy.defaults.allowedCommands.length > 0) {
+    const permitted = policy.defaults.allowedCommands.some((pattern) =>
+      minimatch(command, pattern),
+    );
+    if (!permitted) {
+      return {
+        allowed: false,
+        reason: `command "${command}" is not in allowedCommands`,
+      };
+    }
+  }
+
+  // 4. Per-worker tool allowlist — only applies when the worker has an
+  // explicit allowedTools list; absent worker entry or absent field means
+  // no additional restriction beyond the defaults already checked above.
+  if (workerId) {
+    const workerPolicy = policy.workers[workerId];
+    if (
+      workerPolicy?.allowedTools &&
+      !workerPolicy.allowedTools.includes(toolName)
+    ) {
+      return {
+        allowed: false,
+        reason: `worker "${workerId}" is not allowed to call "${toolName}" (not in its allowedTools list)`,
+      };
+    }
+  }
+
+  return { allowed: true };
+}

--- a/src/streamableHttp.ts
+++ b/src/streamableHttp.ts
@@ -21,10 +21,12 @@ import type { ActivityLog } from "./activityLog.js";
 import { getApprovalQueue } from "./approvalQueue.js";
 import type { Config } from "./config.js";
 import type { ExtensionClient } from "./extensionClient.js";
+import { FLAG_ENFORCE_POLICY, isEnabled } from "./featureFlags.js";
 import type { FileLock } from "./fileLock.js";
 import type { Logger } from "./logger.js";
 import type { LoadedPluginTool } from "./pluginLoader.js";
 import type { PluginWatcher } from "./pluginWatcher.js";
+import { checkPolicy, loadPolicyFile } from "./policy.js";
 import type { ProbeResults } from "./probe.js";
 import { evaluateInProcessGate } from "./riskSignals.js";
 import { corsOrigin } from "./server.js";
@@ -865,6 +867,30 @@ export class StreamableHttpHandler {
     if (this.config.approvalGate !== "off") {
       transport.setApprovalGate(
         async ({ toolName, params, sessionId, onPending }) => {
+          // Deterministic policy check — see the matching block in
+          // bridge.ts's WS approval-gate wiring for the full rationale.
+          // KNOWN LIMITATION shared with the WS path: this whole callback
+          // (and therefore the policy check) is only registered when
+          // approvalGate !== "off". A policy-forbidden action is NOT
+          // currently blocked on a bridge started with approvalGate=off,
+          // even though policy and trust are meant to be independent
+          // axes. Fixing that means restructuring gate registration to
+          // run unconditionally, which is a bigger change than this pass
+          // — tracked as a follow-up, not silently accepted as correct.
+          if (isEnabled(FLAG_ENFORCE_POLICY)) {
+            const loaded = loadPolicyFile(this.config.workspace);
+            if (!loaded.ok) {
+              this.logger.warn?.(`[policy] ${loaded.error}`);
+              return "policy_denied";
+            }
+            const verdict = checkPolicy(loaded.policy, { toolName, params });
+            if (!verdict.allowed) {
+              this.logger.warn?.(
+                `[policy] denied "${toolName}": ${verdict.reason}`,
+              );
+              return "policy_denied";
+            }
+          }
           const gate = evaluateInProcessGate({
             toolName,
             params,

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -143,6 +143,10 @@ export class McpTransport {
    * increment errorCount and never produce a tool-stats entry.
    */
   private approvalRejectionCount = 0;
+  /** Tool calls blocked by patchwork.policy.yml — tracked separately from
+   *  approvalRejectionCount since no human/approval-gate decision was
+   *  involved (a deterministic policy check refused the call outright). */
+  private policyDenialCount = 0;
   private generation = 0; // incremented on each attach; stale handlers check this
   private readonly sessionStartedAt = Date.now();
   private readonly resultSizeTracker = new Map<string, number>();
@@ -215,7 +219,12 @@ export class McpTransport {
          *  for human approval — lets the dispatcher signal "pending" to clients. */
         onPending?: (callId: string) => void;
       }) => Promise<
-        "approved" | "rejected" | "expired" | "cancelled" | "bypass"
+        | "approved"
+        | "rejected"
+        | "expired"
+        | "cancelled"
+        | "bypass"
+        | "policy_denied"
       >)
     | null = null;
 
@@ -225,7 +234,14 @@ export class McpTransport {
       params: Record<string, unknown>;
       sessionId: string | null;
       onPending?: (callId: string) => void;
-    }) => Promise<"approved" | "rejected" | "expired" | "cancelled" | "bypass">,
+    }) => Promise<
+      | "approved"
+      | "rejected"
+      | "expired"
+      | "cancelled"
+      | "bypass"
+      | "policy_denied"
+    >,
   ): void {
     this.approvalGate = fn;
   }
@@ -662,6 +678,7 @@ export class McpTransport {
     callCount: number;
     errorCount: number;
     approvalRejectionCount: number;
+    policyDenialCount: number;
     activeToolCalls: number;
     inFlightTools: string[];
     startedAt: number;
@@ -670,6 +687,7 @@ export class McpTransport {
       callCount: this.callCount,
       errorCount: this.errorCount,
       approvalRejectionCount: this.approvalRejectionCount,
+      policyDenialCount: this.policyDenialCount,
       activeToolCalls: this.activeToolCalls,
       inFlightTools: [...this.inFlightToolNames.values()],
       startedAt: this.sessionStartedAt,
@@ -1501,7 +1519,8 @@ export class McpTransport {
                     | "rejected"
                     | "expired"
                     | "cancelled"
-                    | "bypass";
+                    | "bypass"
+                    | "policy_denied";
                   try {
                     decision = await this.approvalGate({
                       toolName: params.name,
@@ -1546,7 +1565,8 @@ export class McpTransport {
                   if (
                     decision === "rejected" ||
                     decision === "expired" ||
-                    decision === "cancelled"
+                    decision === "cancelled" ||
+                    decision === "policy_denied"
                   ) {
                     // Clamp: detach() may have reset activeToolCalls to 0 if
                     // the WS dropped mid-approval. See line 1478 for the
@@ -1557,15 +1577,25 @@ export class McpTransport {
                     );
                     this.inFlightToolNames.delete(msg.id);
                     this.inFlightControllers.delete(msg.id);
-                    // Approval rejections/expiries are NOT tool failures — track
-                    // them on a dedicated counter and record a lifecycle event
-                    // (not a tool entry) so stats() avg/p95/p99 stay clean.
-                    this.approvalRejectionCount++;
-                    this.activityLog?.recordEvent("approval_rejected", {
-                      tool: params.name,
-                      decision,
-                      sessionId: this.sessionId ?? undefined,
-                    });
+                    // Approval rejections/expiries/policy denials are NOT tool
+                    // failures — track them on a dedicated counter and record
+                    // a lifecycle event (not a tool entry) so stats()
+                    // avg/p95/p99 stay clean.
+                    if (decision === "policy_denied") {
+                      this.policyDenialCount++;
+                    } else {
+                      this.approvalRejectionCount++;
+                    }
+                    this.activityLog?.recordEvent(
+                      decision === "policy_denied"
+                        ? "policy_denied"
+                        : "approval_rejected",
+                      {
+                        tool: params.name,
+                        decision,
+                        sessionId: this.sessionId ?? undefined,
+                      },
+                    );
                     response = {
                       jsonrpc: "2.0",
                       id: msg.id,
@@ -1578,7 +1608,9 @@ export class McpTransport {
                                 ? `Tool call "${params.name}" rejected by human reviewer via Patchwork dashboard.`
                                 : decision === "cancelled"
                                   ? `Tool call "${params.name}" cancelled before a human decision was made (originating client abandoned the request).`
-                                  : `Tool call "${params.name}" expired without human decision (no action taken).`,
+                                  : decision === "policy_denied"
+                                    ? `Tool call "${params.name}" blocked by patchwork.policy.yml — see the bridge log for the specific rule.`
+                                    : `Tool call "${params.name}" expired without human decision (no action taken).`,
                           },
                         ],
                         isError: true,


### PR DESCRIPTION
## Summary

First piece of the "trust architecture" plan (Ephemeral Rollback / Deterministic Policy / Dynamic Handoff Router / Flight Recorder) — the deterministic policy layer, built WITHOUT wiring it to a live worker yet (per explicit instruction — dogfooding against Test Guardian is a deliberate follow-up, not part of this PR).

A rigid, non-LLM permissions matrix (`patchwork.policy.yml`) checked **before** the trust/approval gate. A policy violation is refused outright (`policy_denied`) — it never reaches the Approval Queue, unlike a gated action held for human review. Policy and trust are independent axes: no amount of earned worker trust unlocks a policy-forbidden action.

- `src/policy.ts` — `parsePolicy`/`loadPolicyFile`/`checkPolicy`. **Fail-closed** on a malformed `patchwork.policy.yml` (denies rather than silently running unrestricted); a missing file means no policy configured (opt-in). Checks: forbidden path globs (any tool/worker), network host allowlist, command allowlist, per-worker tool allowlist (narrows only, never widens defaults).
- `src/transport.ts` — new `"policy_denied"` approval-gate decision with its own honest message. Reusing the existing `"rejected"` would have falsely claimed a human reviewer was involved. Tracked on a separate `policyDenialCount`, not folded into `approvalRejectionCount`.
- Wired into **both** `transport.setApprovalGate` call sites: `bridge.ts` (WS/Claude Code CLI) and `streamableHttp.ts` (remote MCP clients). The initial implementation only covered `bridge.ts` — an end-to-end smoke test against the real HTTP transport caught the gap. Also surfaced (not fixed here): `streamableHttp.ts` never got the earlier `enqueueApprovalWithDispatch` push-notification fix either — flagged as a separate follow-up.
- **Known limitation** (both paths): the policy check only runs when `approvalGate !== "off"`, since it lives inside that conditional block. Fixing this needs a bigger restructure of gate registration — noted in code comments, not silently accepted as correct.
- Gated behind `FLAG_ENFORCE_POLICY` (default off, category `"safety"`).

## Test plan
- [x] `npx tsc --noEmit` clean (both `tsconfig.json` and the stricter `tsconfig.tests.core.json`)
- [x] 31 new unit tests (`src/__tests__/policy.test.ts`)
- [x] `transport.test.ts` / `transport-ajv.test.ts` still green (81 tests)
- [x] Verified live against the real bridge over Streamable HTTP: a forbidden-path `createFile` call was blocked with the correct log message (`[policy] denied "createFile": path ... matches forbidden pattern ...`); an otherwise-identical allowed-path call succeeded normally