### PR TITLE
fix(policy): enforce patchwork.policy.yml even when approval gate is off

### DIFF
--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -377,29 +377,42 @@ export class Bridge {
       transport.setActivityLog(this.activityLog);
       transport.setToolRateLimit(this.config.toolRateLimit);
       if (this.config.lazyTools) transport.setLazyTools(true);
-      if (this.server.approvalGate !== "off") {
-        this.logger.info(
-          `[patchwork] approval gate active: ${this.server.approvalGate} tier(s) require dashboard approval`,
-        );
-        // The approval gate only sees traffic if Claude Code's PreToolUse
-        // hook is registered to POST into /approvals. If it isn't, every
-        // CC tool call bypasses the bridge entirely — the queue stays
-        // empty, no `approval_decision` rows accumulate, and the entire
-        // personalSignals catalog has no input data. Silent foot-gun
-        // that wasted hours of investigation; surface it loudly.
-        try {
-          const ccSettingsPath = path.join(
-            process.env.CLAUDE_CONFIG_DIR ?? path.join(os.homedir(), ".claude"),
-            "settings.json",
+      // The policy check must run even when the trust/approval gate is off —
+      // policy and trust are separate axes, and a deployment that disables
+      // the gate (or hasn't opted into it yet) should not thereby also
+      // silently disable patchwork.policy.yml enforcement. So the gate
+      // handler is installed whenever either the approval gate or policy
+      // enforcement is active; the two concerns are independently checked
+      // inside the handler.
+      if (
+        this.server.approvalGate !== "off" ||
+        isEnabled(FLAG_ENFORCE_POLICY)
+      ) {
+        if (this.server.approvalGate !== "off") {
+          this.logger.info(
+            `[patchwork] approval gate active: ${this.server.approvalGate} tier(s) require dashboard approval`,
           );
-          if (!isPreToolUseHookRegistered(ccSettingsPath)) {
-            this.logger.warn?.(
-              `[patchwork] WARNING: approval gate is on but no PreToolUse hook found in ${ccSettingsPath}. ` +
-                `Claude Code will bypass the approval queue. Run 'patchwork-init' to register the hook.`,
+          // The approval gate only sees traffic if Claude Code's PreToolUse
+          // hook is registered to POST into /approvals. If it isn't, every
+          // CC tool call bypasses the bridge entirely — the queue stays
+          // empty, no `approval_decision` rows accumulate, and the entire
+          // personalSignals catalog has no input data. Silent foot-gun
+          // that wasted hours of investigation; surface it loudly.
+          try {
+            const ccSettingsPath = path.join(
+              process.env.CLAUDE_CONFIG_DIR ??
+                path.join(os.homedir(), ".claude"),
+              "settings.json",
             );
+            if (!isPreToolUseHookRegistered(ccSettingsPath)) {
+              this.logger.warn?.(
+                `[patchwork] WARNING: approval gate is on but no PreToolUse hook found in ${ccSettingsPath}. ` +
+                  `Claude Code will bypass the approval queue. Run 'patchwork-init' to register the hook.`,
+              );
+            }
+          } catch {
+            // Best-effort warning — never block startup on a hook check failure.
           }
-        } catch {
-          // Best-effort warning — never block startup on a hook check failure.
         }
         transport.setApprovalGate(
           async ({ toolName, params, sessionId, onPending }) => {

--- a/src/streamableHttp.ts
+++ b/src/streamableHttp.ts
@@ -864,19 +864,16 @@ export class StreamableHttpHandler {
     }
     if (scope) transport.setSessionScope(scope);
     if (denyTools.size > 0) transport.setDenyTools(denyTools);
-    if (this.config.approvalGate !== "off") {
+    if (this.config.approvalGate !== "off" || isEnabled(FLAG_ENFORCE_POLICY)) {
       transport.setApprovalGate(
         async ({ toolName, params, sessionId, onPending }) => {
           // Deterministic policy check — see the matching block in
           // bridge.ts's WS approval-gate wiring for the full rationale.
-          // KNOWN LIMITATION shared with the WS path: this whole callback
-          // (and therefore the policy check) is only registered when
-          // approvalGate !== "off". A policy-forbidden action is NOT
-          // currently blocked on a bridge started with approvalGate=off,
-          // even though policy and trust are meant to be independent
-          // axes. Fixing that means restructuring gate registration to
-          // run unconditionally, which is a bigger change than this pass
-          // — tracked as a follow-up, not silently accepted as correct.
+          // Runs even when approvalGate is "off": policy and trust are
+          // independent axes, and evaluateInProcessGate below already
+          // bypasses unconditionally for gate "off" once the policy check
+          // clears, so installing this handler unconditionally costs
+          // nothing on the trust-gate side while closing the policy gap.
           if (isEnabled(FLAG_ENFORCE_POLICY)) {
             const loaded = loadPolicyFile(this.config.workspace);
             if (!loaded.ok) {


### PR DESCRIPTION
## Summary
- Closes the "policy-enforcement-only-when-gate-on" gap flagged in #1157: both `bridge.ts` (WS) and `streamableHttp.ts` (remote MCP) only installed the approval-gate handler — and therefore the `checkPolicy` call — when `approvalGate !== "off"`. A bridge started with the trust gate off silently skipped `patchwork.policy.yml` enforcement too, even with `FLAG_ENFORCE_POLICY` on.
- Fix: install the gate handler whenever the trust gate is active OR policy enforcement is active. `evaluateInProcessGate` already bypasses unconditionally for gate `"off"`, so this only adds the policy check on that path — no behavior change when `FLAG_ENFORCE_POLICY` is off.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx biome check` clean
- [x] `node scripts/audit-test-fixtures.mjs` clean
- [x] `npx vitest run` on policy.test.ts + all bridge/streamableHttp/approval-gate suites (220 passed, 1 pre-existing skip)