### PR TITLE
feat(policy): enforce per-worker allowedTools inside executeStep

### DIFF
--- a/src/recipeOrchestration.ts
+++ b/src/recipeOrchestration.ts
@@ -276,6 +276,32 @@ export async function buildWorkerAgentDisallowedTools(
   }
 }
 
+/**
+ * The id of the worker that owns `recipeName` (its `*.worker.yaml` manifest
+ * declares `recipe: <recipeName>`), if any. Deliberately independent of
+ * FLAG_WORKER_AUTONOMY — unlike the trust-ramp gate above, patchwork.policy.yml's
+ * per-worker `allowedTools` list is a separate deterministic boundary that
+ * should apply whenever a worker owns a recipe, autonomy flag on or off.
+ * Only reads worker manifests from disk (no trust-store / run-log replay),
+ * so this is cheap enough to call on every recipe fire. Fail-soft: any
+ * resolution error → undefined (never crash a run over a malformed manifest).
+ */
+export async function resolveWorkerIdForRecipe(
+  recipeName: string,
+  workersDir?: string,
+): Promise<string | undefined> {
+  try {
+    const os = await import("node:os");
+    const path = await import("node:path");
+    const { loadWorkersFromDir } = await import("./workers/workerLoader.js");
+    const dir = workersDir ?? path.join(os.homedir(), ".patchwork", "workers");
+    const workers = loadWorkersFromDir(dir);
+    return workers.find((w) => w.recipe === recipeName)?.id;
+  } catch {
+    return undefined;
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Public interfaces
 // ---------------------------------------------------------------------------
@@ -1275,6 +1301,9 @@ export class RecipeOrchestration {
     const agentDisallowedTools = await buildWorkerAgentDisallowedTools(
       opts.name,
     );
+    // Independent of FLAG_WORKER_AUTONOMY — see resolveWorkerIdForRecipe's
+    // doc comment. Feeds executeStep's per-worker allowedTools policy check.
+    const workerId = await resolveWorkerIdForRecipe(opts.name);
     const runnerDeps = {
       workdir: this.deps.workdir,
       claudeCodeFn,
@@ -1288,6 +1317,7 @@ export class RecipeOrchestration {
       ...(requireApprovalFn && { requireApprovalFn }),
       ...(gateAutomatedRuns && { gateAutomatedRuns: true }),
       ...(agentDisallowedTools && { agentDisallowedTools }),
+      ...(workerId && { workerId }),
     };
     // Pass the bridge's long-lived RecipeRunLog so chainedRunner can flip the
     // run from `running` → terminal in-place via startRun/completeRun. The

--- a/src/recipes/__tests__/yamlRunner.test.ts
+++ b/src/recipes/__tests__/yamlRunner.test.ts
@@ -4618,3 +4618,135 @@ describe("runtime allowWrites enforcement (FLAG_ENFORCE_ALLOWWRITES)", () => {
     expect(written[path.join(TMP, "unflagged.md")]).toBe("hello");
   });
 });
+
+describe("per-worker allowedTools policy enforcement (FLAG_ENFORCE_POLICY)", () => {
+  // The bridge's CLI/HTTP dispatch chokepoint (bridge.ts / streamableHttp.ts)
+  // has no workerId to check patchwork.policy.yml's per-worker allowedTools
+  // against — recipe/worker context only exists at this layer. These tests
+  // exercise executeStep's own checkPolicy call, gated on `deps.workerId`
+  // (set by the orchestrator via resolveWorkerIdForRecipe) AND the flag.
+  let policyDir: string;
+
+  afterEach(async () => {
+    const { setFlag, FLAG_ENFORCE_POLICY } = await import(
+      "../../featureFlags.js"
+    );
+    setFlag(FLAG_ENFORCE_POLICY, false);
+    rmSync(policyDir, { recursive: true, force: true });
+  });
+
+  function writePolicy(yaml: string): string {
+    policyDir = mkdtempSync(path.join(os.tmpdir(), "yamlrunner-policy-"));
+    writeFileSync(path.join(policyDir, "patchwork.policy.yml"), yaml);
+    return policyDir;
+  }
+
+  it("denies a tool call outside the worker's allowedTools when the flag is ON", async () => {
+    const { setFlag, FLAG_ENFORCE_POLICY } = await import(
+      "../../featureFlags.js"
+    );
+    setFlag(FLAG_ENFORCE_POLICY, true);
+    const workdir = writePolicy(
+      "version: 1\nworkers:\n  triage-bot:\n    allowedTools: [github.listIssues]\n",
+    );
+    const recipe = makeRecipe({
+      steps: [
+        { tool: "file.write", path: path.join(TMP, "x.md"), content: "x" },
+      ],
+    });
+    const result = await runYamlRecipe(recipe, {
+      ...noop(),
+      workdir,
+      workerId: "triage-bot",
+    });
+    expect(result.stepResults[0]?.status).toBe("error");
+    expect(result.stepResults[0]?.error).toMatch(/policy_denied/);
+    expect(result.stepResults[0]?.error).toMatch(/not allowed to call/);
+  });
+
+  it("allows a tool call inside the worker's allowedTools when the flag is ON", async () => {
+    const { setFlag, FLAG_ENFORCE_POLICY } = await import(
+      "../../featureFlags.js"
+    );
+    setFlag(FLAG_ENFORCE_POLICY, true);
+    const written: Record<string, string> = {};
+    const workdir = writePolicy(
+      "version: 1\nworkers:\n  triage-bot:\n    allowedTools: [file.write]\n",
+    );
+    const recipe = makeRecipe({
+      steps: [
+        {
+          tool: "file.write",
+          path: path.join(TMP, "allowed.md"),
+          content: "x",
+        },
+      ],
+    });
+    const result = await runYamlRecipe(recipe, {
+      ...noop(),
+      workdir,
+      workerId: "triage-bot",
+      writeFile: (p, c) => {
+        written[p] = c;
+      },
+    });
+    expect(result.stepResults[0]?.status).toBe("ok");
+    expect(written[path.join(TMP, "allowed.md")]).toBe("x");
+  });
+
+  it("does NOT restrict a recipe with no workerId, even with the flag ON", async () => {
+    const { setFlag, FLAG_ENFORCE_POLICY } = await import(
+      "../../featureFlags.js"
+    );
+    setFlag(FLAG_ENFORCE_POLICY, true);
+    const written: Record<string, string> = {};
+    const workdir = writePolicy(
+      "version: 1\nworkers:\n  triage-bot:\n    allowedTools: [github.listIssues]\n",
+    );
+    const recipe = makeRecipe({
+      steps: [
+        {
+          tool: "file.write",
+          path: path.join(TMP, "no-worker.md"),
+          content: "x",
+        },
+      ],
+    });
+    const result = await runYamlRecipe(recipe, {
+      ...noop(),
+      workdir,
+      // no workerId — recipe isn't owned by a worker.
+      writeFile: (p, c) => {
+        written[p] = c;
+      },
+    });
+    expect(result.stepResults[0]?.status).toBe("ok");
+    expect(written[path.join(TMP, "no-worker.md")]).toBe("x");
+  });
+
+  it("does NOT restrict a worker-owned recipe when the flag is OFF (default)", async () => {
+    const written: Record<string, string> = {};
+    const workdir = writePolicy(
+      "version: 1\nworkers:\n  triage-bot:\n    allowedTools: [github.listIssues]\n",
+    );
+    const recipe = makeRecipe({
+      steps: [
+        {
+          tool: "file.write",
+          path: path.join(TMP, "flag-off.md"),
+          content: "x",
+        },
+      ],
+    });
+    const result = await runYamlRecipe(recipe, {
+      ...noop(),
+      workdir,
+      workerId: "triage-bot",
+      writeFile: (p, c) => {
+        written[p] = c;
+      },
+    });
+    expect(result.stepResults[0]?.status).toBe("ok");
+    expect(written[path.join(TMP, "flag-off.md")]).toBe("x");
+  });
+});

--- a/src/recipes/yamlRunner.ts
+++ b/src/recipes/yamlRunner.ts
@@ -39,9 +39,14 @@ import { fileURLToPath } from "node:url";
 import { parse as parseYaml } from "yaml";
 import { captureFixture } from "../connectors/fixtureRecorder.js";
 import { sanitizeEnv } from "../drivers/claude/envSanitizer.js";
-import { FLAG_ENFORCE_ALLOWWRITES, isEnabled } from "../featureFlags.js";
+import {
+  FLAG_ENFORCE_ALLOWWRITES,
+  FLAG_ENFORCE_POLICY,
+  isEnabled,
+} from "../featureFlags.js";
 import { isLoopbackOrPrivateEndpoint } from "../localEndpointGuard.js";
 import { loadConfig as loadPatchworkConfigSync } from "../patchworkConfig.js";
+import { checkPolicy, loadPolicyFile } from "../policy.js";
 import { findYamlRecipePath } from "../recipesHttp.js";
 import { classifyTool } from "../riskTier.js";
 import type { RecipeRunLog } from "../runLog.js";
@@ -661,6 +666,18 @@ export interface RunnerDeps {
    * recipes → agent steps are byte-identical to pre-flip behaviour.
    */
   agentDisallowedTools?: string[];
+  /**
+   * The id of the worker that owns this recipe (matches `id:` in the
+   * worker's `*.worker.yaml` manifest), if any. Set by the orchestrator via
+   * `resolveWorkerIdForRecipe` independent of the FLAG_WORKER_AUTONOMY trust
+   * ramp — policy's per-worker `allowedTools` list (patchwork.policy.yml) is
+   * a separate deterministic boundary from earned trust, so this is
+   * populated whenever a worker owns the recipe, autonomy flag or not.
+   * Passed to `checkPolicy` in `executeStep` so a worker restricted to a
+   * specific tool list can't call anything outside it, even via a plain
+   * (non-agent) tool step. Undefined for non-worker recipes.
+   */
+  workerId?: string;
 }
 
 export interface RunResult {
@@ -774,6 +791,9 @@ export type StepDeps = Required<
     // Cancellation is checked in the run loop against `deps`, not per-step;
     // keep it off StepDeps so it isn't forced Required here.
     | "signal"
+    // Present only when a worker owns the recipe — keep optional, not
+    // forced Required by the Omit-based mapped type.
+    | "workerId"
   >
 > & {
   workdir: string;
@@ -796,6 +816,8 @@ export type StepDeps = Required<
    * `runChainedRecipe`; discarded when the run completes.
    */
   writeEffectLedger?: WriteEffectLedger;
+  /** See `RunnerDeps.workerId`. */
+  workerId?: string;
 };
 
 // Strip tool-call narration some models (e.g. Gemini) prepend before the markdown block.
@@ -2651,6 +2673,33 @@ export async function executeStep(
       params[key] = deepRender(value, ctx);
     }
 
+    // Deterministic per-worker tool-allowlist policy check. The bridge's
+    // CLI/HTTP dispatch chokepoint (bridge.ts / streamableHttp.ts) already
+    // runs `checkPolicy` for every tool call, but has no workerId to check
+    // against — recipe/worker context only exists here, inside the runner.
+    // Runs only when `deps.workerId` is set (a worker owns this recipe) and
+    // FLAG_ENFORCE_POLICY is on; a recipe with no owning worker is
+    // unaffected. Deny is fail-closed on a malformed policy file, matching
+    // the bridge-level check.
+    if (deps.workerId && isEnabled(FLAG_ENFORCE_POLICY)) {
+      const loaded = loadPolicyFile(deps.workdir);
+      if (!loaded.ok) {
+        const err = new Error(`policy_denied: ${loaded.error}`);
+        (err as Error & { code?: string }).code = "policy_denied";
+        throw err;
+      }
+      const verdict = checkPolicy(loaded.policy, {
+        toolName: toolId,
+        params,
+        workerId: deps.workerId,
+      });
+      if (!verdict.allowed) {
+        const err = new Error(`policy_denied: ${verdict.reason}`);
+        (err as Error & { code?: string }).code = "policy_denied";
+        throw err;
+      }
+    }
+
     // Check if mock connector is available for this tool
     if (deps.mockConnectors?.[toolId]) {
       return deps.mockConnectors[toolId].invoke("execute", params);
@@ -2950,6 +2999,7 @@ function resolveStepDeps(
             ),
           })
         : new WriteEffectLedger(),
+    workerId: deps.workerId,
   };
 }
 


### PR DESCRIPTION
## Summary
- Closes the third roadmap gap from #1157: patchwork.policy.yml's per-worker `allowedTools` list was defined in the schema but never checked anywhere, because `checkPolicy`'s `workerId` param had no caller — worker/recipe context doesn't exist at the bridge's CLI/HTTP dispatch chokepoint, only inside the recipe runner.
- `src/recipeOrchestration.ts`: new `resolveWorkerIdForRecipe()` scans `*.worker.yaml` manifests for the worker owning a recipe. Deliberately independent of `FLAG_WORKER_AUTONOMY` — policy is a separate deterministic boundary from earned trust. Wired into `fire()`'s `runnerDeps`.
- `src/recipes/yamlRunner.ts`: `executeStep` now calls `checkPolicy` with the resolved `workerId` (when `FLAG_ENFORCE_POLICY` is on), right after step params are rendered. Fail-closed on a malformed policy file, same pattern as the existing unacknowledged-write check.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx biome check` clean
- [x] `node scripts/audit-test-fixtures.mjs` / `audit-lsp-tools.mjs` clean
- [x] 4 new tests in `yamlRunner.test.ts`: deny outside allowedTools, allow inside allowedTools, no-workerId unaffected, flag-off unaffected — all passing (185/185 in the file)
- [x] Full `recipeOrchestration`/worker-gate/runner suites still green (35/35)