### PR TITLE
feat(recipes): flight-recorder replay for flat (manual/cron/webhook) recipes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,8 @@ Comply with all docs in `/documents/`. Consult before changes:
 - `recipe record <name>` — Record a successful run as a learned trace.
 - `recipe schema` — Print the active recipe JSON schema.
 
+**Flight recorder / mocked replay** (`POST /runs/:seq/replay`, dashboard run-detail page — no dedicated CLI verb): every successful tool step's output is captured onto `RunStepResult.output` (secret-redacted, 8 KB cap) for both chained recipes (VD-2, pre-existing) and flat manual/cron/webhook recipes (`src/recipes/yamlRunner.ts`'s `StepResult.output` + `captureForRunlog`). Replay re-runs the recipe with each captured step short-circuited to its prior output — `replayMockedRun` for chained, `replayFlatMockedRun` for flat (`src/recipes/replayRun.ts`) — so template/transform/expect wiring can be debugged against real evidence with zero external calls or write side effects. `runReplayFn` in `src/recipeOrchestration.ts` dispatches on the recipe's `trigger.type`; flat recipes previously hard-errored with `replay_only_supported_for_chained_recipes` before this capability existed. Real-mode replay (write tools actually fire) is deliberately out of scope — needs a confirmation UX + kill-switch interaction, ship separately.
+
 #### Operational commands
 
 - `start [--port N] [--workspace <path>]` — Single-bridge start (no tmux). Pair with `--watch` for supervised mode.

--- a/src/recipeOrchestration.ts
+++ b/src/recipeOrchestration.ts
@@ -603,18 +603,9 @@ export class RecipeOrchestration {
         const { readFileSync } = await import("node:fs");
         const { parse: parseYaml } = await import("yaml");
         const recipeYaml = parseYaml(readFileSync(recipePath, "utf-8"));
-        // Only chained recipes have per-step capture today; flag others.
         const triggerType = (
           recipeYaml as { trigger?: { type?: string } } | undefined
         )?.trigger?.type;
-        if (triggerType !== "chained") {
-          return {
-            ok: false,
-            error: "replay_only_supported_for_chained_recipes",
-          };
-        }
-        const { replayMockedRun } = await import("./recipes/replayRun.js");
-        const { buildChainedDeps } = await import("./recipes/yamlRunner.js");
         // Reuse the orchestrator's claudeCodeFn for any step that falls
         // through to real execution (unmocked steps — caller is told).
         const orch = this.deps.getOrchestrator();
@@ -648,6 +639,39 @@ export class RecipeOrchestration {
           return task.output ?? task.errorMessage ?? "";
         };
         const runnerDeps = { workdir: this.deps.workdir, claudeCodeFn };
+
+        // Flat (manual/cron/webhook) recipes: runYamlRecipe + per-step
+        // output capture (added alongside replayFlatMockedRun) make these
+        // just as replayable as chained recipes — previously hard-flagged
+        // "replay_only_supported_for_chained_recipes" here.
+        if (triggerType !== "chained") {
+          const { replayFlatMockedRun } = await import(
+            "./recipes/replayRun.js"
+          );
+          const result = await replayFlatMockedRun({
+            originalRun: original as unknown as import("./runLog.js").RecipeRun,
+            recipe:
+              recipeYaml as unknown as import("./recipes/yamlRunner.js").YamlRecipe,
+            deps: {
+              runLog: this.deps.recipeRunLog,
+              ...(this.deps.activityLog !== undefined && {
+                activityLog: this.deps.activityLog,
+              }),
+              runnerDeps,
+            },
+          });
+          return {
+            ok: result.ok,
+            ...(result.newSeq !== undefined && { newSeq: result.newSeq }),
+            ...(result.unmockedSteps !== undefined && {
+              unmockedSteps: result.unmockedSteps,
+            }),
+            ...(result.error !== undefined && { error: result.error }),
+          };
+        }
+
+        const { replayMockedRun } = await import("./recipes/replayRun.js");
+        const { buildChainedDeps } = await import("./recipes/yamlRunner.js");
         // buildChainedDeps just primes default tool/agent/recipe loaders.
         void buildChainedDeps;
         const result = await replayMockedRun({

--- a/src/recipes/__tests__/replayRun.test.ts
+++ b/src/recipes/__tests__/replayRun.test.ts
@@ -9,8 +9,13 @@ import type {
   RunOptions,
 } from "../chainedRunner.js";
 import { runChainedRecipe } from "../chainedRunner.js";
-import { buildMockedOutputs, replayMockedRun } from "../replayRun.js";
-import type { RunnerDeps } from "../yamlRunner.js";
+import {
+  buildFlatMockedOutputs,
+  buildMockedOutputs,
+  replayFlatMockedRun,
+  replayMockedRun,
+} from "../replayRun.js";
+import type { RunnerDeps, YamlRecipe } from "../yamlRunner.js";
 
 let tmpDir: string;
 
@@ -392,5 +397,176 @@ describe("replayMockedRun", () => {
       if (origSecret === undefined) delete process.env.SUPER_SECRET_TOKEN;
       else process.env.SUPER_SECRET_TOKEN = origSecret;
     }
+  });
+});
+
+// ── buildFlatMockedOutputs — flat-recipe counterpart to buildMockedOutputs ─
+
+describe("buildFlatMockedOutputs", () => {
+  it("collects captured outputs into the map keyed by stepId, stringified", () => {
+    const run: RecipeRun = {
+      seq: 7,
+      taskId: "t",
+      recipeName: "r",
+      trigger: "recipe",
+      status: "done",
+      createdAt: 100,
+      doneAt: 200,
+      durationMs: 100,
+      stepResults: [
+        { id: "s1", status: "ok", durationMs: 5, output: "already-a-string" },
+        { id: "s2", status: "ok", durationMs: 5, output: { a: 1 } },
+      ],
+    };
+    const { outputs, unmocked } = buildFlatMockedOutputs(run);
+    expect(outputs.get("s1")).toBe("already-a-string");
+    expect(outputs.get("s2")).toBe(JSON.stringify({ a: 1 }));
+    expect(unmocked).toEqual([]);
+  });
+
+  it("flags steps without captured output as unmocked", () => {
+    const run: RecipeRun = {
+      seq: 1,
+      taskId: "t",
+      recipeName: "r",
+      trigger: "recipe",
+      status: "done",
+      createdAt: 1,
+      doneAt: 2,
+      durationMs: 1,
+      stepResults: [
+        { id: "captured", status: "ok", durationMs: 5, output: "ok" },
+        { id: "no-capture", status: "ok", durationMs: 5 },
+      ],
+    };
+    const { outputs, unmocked } = buildFlatMockedOutputs(run);
+    expect([...outputs.keys()]).toEqual(["captured"]);
+    expect(unmocked).toEqual(["no-capture"]);
+  });
+
+  it("excludes truncation-envelope outputs (>8KB)", () => {
+    const run: RecipeRun = {
+      seq: 1,
+      taskId: "t",
+      recipeName: "r",
+      trigger: "recipe",
+      status: "done",
+      createdAt: 1,
+      doneAt: 2,
+      durationMs: 1,
+      stepResults: [
+        {
+          id: "huge",
+          status: "ok",
+          durationMs: 5,
+          output: { "[truncated]": true, bytes: 20000, preview: "x" },
+        },
+        { id: "small", status: "ok", durationMs: 5, output: "fine" },
+      ],
+    };
+    const { outputs, unmocked } = buildFlatMockedOutputs(run);
+    expect([...outputs.keys()]).toEqual(["small"]);
+    expect(unmocked).toEqual(["huge"]);
+  });
+
+  it("skips steps with status 'skipped'", () => {
+    const run: RecipeRun = {
+      seq: 1,
+      taskId: "t",
+      recipeName: "r",
+      trigger: "recipe",
+      status: "done",
+      createdAt: 1,
+      doneAt: 2,
+      durationMs: 1,
+      stepResults: [
+        { id: "conditional", status: "skipped", durationMs: 0 },
+        { id: "actual", status: "ok", durationMs: 5, output: "data" },
+      ],
+    };
+    const { outputs } = buildFlatMockedOutputs(run);
+    expect([...outputs.keys()]).toEqual(["actual"]);
+  });
+});
+
+// ── replayFlatMockedRun — the flat entrypoint, previously nonexistent
+// ("replay_only_supported_for_chained_recipes" was hard-coded) ────────────
+
+describe("replayFlatMockedRun", () => {
+  function flatRecipe(): YamlRecipe {
+    return {
+      name: "daily-flat",
+      trigger: { type: "manual" },
+      steps: [
+        { tool: "file.write", into: "s1", path: "note.md", content: "x" },
+      ],
+    } as unknown as YamlRecipe;
+  }
+
+  function originalRun(overrides: Partial<RecipeRun> = {}): RecipeRun {
+    return {
+      seq: 1,
+      taskId: "t1",
+      recipeName: "daily-flat",
+      trigger: "recipe",
+      status: "done",
+      createdAt: 1000,
+      doneAt: 2000,
+      durationMs: 1000,
+      stepResults: [
+        { id: "s1", status: "ok", durationMs: 5, output: "captured-value" },
+      ],
+      ...overrides,
+    } as RecipeRun;
+  }
+
+  async function deps() {
+    const { RecipeRunLog } = await import("../../runLog.js");
+    const runLog = new RecipeRunLog({ dir: tmpDir });
+    const runnerDeps: RunnerDeps = {
+      logDir: tmpDir,
+      workdir: tmpDir,
+      testMode: false,
+      writeFile: () => {
+        throw new Error("real tool must not run — step should be mocked");
+      },
+    };
+    return { runLog, activityLog: undefined, runnerDeps };
+  }
+
+  it("replays using captured step outputs and reports the new run's seq", async () => {
+    const replayDeps = await deps();
+    const result = await replayFlatMockedRun({
+      originalRun: originalRun(),
+      recipe: flatRecipe(),
+      deps: replayDeps,
+    });
+    expect(result.ok).toBe(true);
+    expect(result.newSeq).toBeDefined();
+    expect(result.result?.context.s1).toBe("captured-value");
+    expect(result.unmockedSteps).toBeUndefined();
+  });
+
+  it("tags the new run with manualRunId replay-<originalSeq> (BUG-4 parity)", async () => {
+    const replayDeps = await deps();
+    await replayFlatMockedRun({
+      originalRun: originalRun({ seq: 42 }),
+      recipe: flatRecipe(),
+      deps: replayDeps,
+    });
+    const run = replayDeps.runLog.query()[0];
+    expect(run?.manualRunId).toBe("replay-42");
+  });
+
+  it("reports unmockedSteps when a step in the original run has no captured output", async () => {
+    const replayDeps = await deps();
+    const result = await replayFlatMockedRun({
+      originalRun: originalRun({
+        stepResults: [{ id: "s1", status: "ok", durationMs: 5 }],
+      }),
+      recipe: flatRecipe(),
+      deps: replayDeps,
+    });
+    expect(result.unmockedSteps).toEqual(["s1"]);
   });
 });

--- a/src/recipes/__tests__/yamlRunner.test.ts
+++ b/src/recipes/__tests__/yamlRunner.test.ts
@@ -4986,3 +4986,160 @@ describe("ephemeral file rollback (end-to-end through runYamlRecipe)", () => {
     expect(fs.readFileSync(target, "utf-8")).toBe("mutated by the run"); // unchanged — nothing to roll back
   });
 });
+
+describe("flight recorder — per-step output capture", () => {
+  it("captures a successful tool step's output onto StepResult.output", async () => {
+    const recipe = makeRecipe({
+      steps: [
+        { tool: "file.write", path: path.join(TMP, "cap.md"), content: "x" },
+      ],
+    });
+    const result = await runYamlRecipe(recipe, noop());
+    expect(result.stepResults[0]?.status).toBe("ok");
+    expect(result.stepResults[0]?.output).toBeDefined();
+    // file.write returns JSON.stringify({path, bytesWritten}) — the raw
+    // string result, captured via captureForRunlog (redaction + cap, no
+    // reshaping for a plain string under the size cap).
+    expect(result.stepResults[0]?.output).toContain("bytesWritten");
+  });
+
+  it("does not capture output for a skipped step", async () => {
+    const recipe = makeRecipe({
+      steps: [
+        {
+          tool: "file.append",
+          path: path.join(TMP, "skip.md"),
+          content: "x",
+          when: "missing > 0", // resolves false — step is skipped
+        },
+      ],
+    });
+    const result = await runYamlRecipe(recipe, noop());
+    expect(result.stepResults[0]?.status).toBe("skipped");
+    expect(result.stepResults[0]?.output).toBeUndefined();
+  });
+
+  it("does not capture output for an errored step", async () => {
+    const recipe = makeRecipe({
+      steps: [
+        { tool: "file.write", path: path.join(TMP, "err.md"), content: "x" },
+      ],
+    });
+    const result = await runYamlRecipe(recipe, {
+      ...noop(),
+      writeFile: () => {
+        throw new Error("disk full");
+      },
+    });
+    expect(result.stepResults[0]?.status).toBe("error");
+    expect(result.stepResults[0]?.output).toBeUndefined();
+  });
+
+  it("preserves the narrow {url, issueNumber} shape for github.create_issue (outcome attribution)", async () => {
+    const recipe = makeRecipe({
+      steps: [
+        {
+          tool: "github.create_issue",
+          owner: "acme",
+          repo: "widgets",
+          title: "bug",
+        },
+      ],
+    });
+    const result = await runYamlRecipe(recipe, {
+      ...noop(),
+      mockConnectors: {
+        "github.create_issue": {
+          invoke: async () =>
+            JSON.stringify({
+              url: "https://github.com/acme/widgets/issues/1",
+              issueNumber: 1,
+              title: "bug",
+              body: "irrelevant, must not leak into the captured output",
+            }),
+        },
+      },
+    });
+    expect(result.stepResults[0]?.status).toBe("ok");
+    expect(result.stepResults[0]?.output).toEqual({
+      url: "https://github.com/acme/widgets/issues/1",
+      issueNumber: 1,
+    });
+  });
+});
+
+describe("flight recorder — mockedOutputs replay short-circuit", () => {
+  it("uses the mocked value instead of calling the real tool", async () => {
+    let realCalls = 0;
+    const recipe = makeRecipe({
+      steps: [
+        {
+          tool: "file.write",
+          path: path.join(TMP, "real.md"),
+          content: "x",
+          into: "s1",
+        },
+      ],
+    });
+    const result = await runYamlRecipe(recipe, {
+      ...noop(),
+      writeFile: () => {
+        realCalls++;
+      },
+      mockedOutputs: new Map([["s1", "MOCKED_OUTPUT"]]),
+    });
+    expect(realCalls).toBe(0);
+    expect(result.stepResults[0]?.status).toBe("ok");
+    expect(result.context.s1).toBe("MOCKED_OUTPUT");
+  });
+
+  it("falls through to real execution for a step NOT in mockedOutputs", async () => {
+    let realCalls = 0;
+    const recipe = makeRecipe({
+      steps: [
+        {
+          tool: "file.write",
+          path: path.join(TMP, "real2.md"),
+          content: "x",
+          into: "s1",
+        },
+        {
+          tool: "file.write",
+          path: path.join(TMP, "real3.md"),
+          content: "x",
+          into: "s2",
+        },
+      ],
+    });
+    const result = await runYamlRecipe(recipe, {
+      ...noop(),
+      writeFile: () => {
+        realCalls++;
+      },
+      mockedOutputs: new Map([["s1", "MOCKED_OUTPUT"]]),
+    });
+    expect(realCalls).toBe(1); // only s2 ran for real
+    expect(result.context.s1).toBe("MOCKED_OUTPUT");
+    expect(result.stepResults[1]?.status).toBe("ok");
+  });
+
+  it("re-applies the step's transform on top of the mocked value", async () => {
+    const recipe = makeRecipe({
+      steps: [
+        {
+          tool: "file.write",
+          path: path.join(TMP, "transform.md"),
+          content: "x",
+          into: "s1",
+          transform: "hello, {{ $result }}",
+        },
+      ],
+    });
+    const result = await runYamlRecipe(recipe, {
+      ...noop(),
+      writeFile: () => {},
+      mockedOutputs: new Map([["s1", "world"]]),
+    });
+    expect(result.context.s1).toBe("hello, world");
+  });
+});

--- a/src/recipes/__tests__/yamlRunner.test.ts
+++ b/src/recipes/__tests__/yamlRunner.test.ts
@@ -5050,13 +5050,13 @@ describe("flight recorder — per-step output capture", () => {
       ...noop(),
       mockConnectors: {
         "github.create_issue": {
-          invoke: async () =>
+          invoke: async <TOutput = unknown>() =>
             JSON.stringify({
               url: "https://github.com/acme/widgets/issues/1",
               issueNumber: 1,
               title: "bug",
               body: "irrelevant, must not leak into the captured output",
-            }),
+            }) as TOutput,
         },
       },
     });

--- a/src/recipes/replayRun.ts
+++ b/src/recipes/replayRun.ts
@@ -25,8 +25,12 @@ import type {
   RunOptions,
 } from "./chainedRunner.js";
 import { runChainedRecipe } from "./chainedRunner.js";
-import type { RunnerDeps } from "./yamlRunner.js";
-import { buildChainedDeps, declaredRecipeEnv } from "./yamlRunner.js";
+import type { RunnerDeps, RunResult, YamlRecipe } from "./yamlRunner.js";
+import {
+  buildChainedDeps,
+  declaredRecipeEnv,
+  runYamlRecipe,
+} from "./yamlRunner.js";
 
 export interface ReplayDeps {
   /** Long-lived run log so the new run shows up live in the dashboard. */
@@ -132,6 +136,101 @@ export async function replayMockedRun(opts: {
     const newRun = recent.find((r) => r.createdAt > originalRun.doneAt);
     return {
       ok: result.success,
+      ...(newRun?.seq !== undefined && { newSeq: newRun.seq }),
+      result,
+      ...(result.errorMessage !== undefined && { error: result.errorMessage }),
+      ...(unmocked.length > 0 && { unmockedSteps: unmocked }),
+    };
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+      ...(unmocked.length > 0 && { unmockedSteps: unmocked }),
+    };
+  }
+}
+
+/**
+ * Build the `mockedOutputs` map for a FLAT (non-chained) recipe's replay.
+ * Flat `RunContext` values are strings (see `RunContext = Record<string,
+ * string>` in yamlRunner.ts), so a captured non-string output is
+ * JSON-stringified — matching what the original tool call's raw string
+ * result would have looked like before any downstream `{{template}}`
+ * substitution treated it as text.
+ */
+export function buildFlatMockedOutputs(originalRun: RecipeRun): {
+  outputs: Map<string, string>;
+  unmocked: string[];
+} {
+  const outputs = new Map<string, string>();
+  const unmocked: string[] = [];
+  for (const step of originalRun.stepResults ?? []) {
+    if (step.status === "skipped") continue;
+    const out = step.output;
+    if (out === undefined) {
+      unmocked.push(step.id);
+      continue;
+    }
+    if (
+      out !== null &&
+      typeof out === "object" &&
+      (out as Record<string, unknown>)["[truncated]"] === true
+    ) {
+      unmocked.push(step.id);
+      continue;
+    }
+    outputs.set(step.id, typeof out === "string" ? out : JSON.stringify(out));
+  }
+  return { outputs, unmocked };
+}
+
+export interface FlatReplayResult {
+  ok: boolean;
+  /** New run's seq if the replay started successfully. */
+  newSeq?: number;
+  /** Underlying flat-runner result for callers that want full detail. */
+  result?: RunResult;
+  error?: string;
+  /** Steps that lacked captured outputs — fell through to REAL execution. */
+  unmockedSteps?: string[];
+}
+
+/**
+ * Fire a mocked replay of a FLAT (manual/cron/webhook-triggered) recipe's
+ * run — the counterpart to `replayMockedRun` for recipes that use
+ * `runYamlRecipe` rather than `runChainedRecipe`. Previously flat recipes
+ * had NO replay capability at all (`runReplayFn` in recipeOrchestration.ts
+ * hard-coded `replay_only_supported_for_chained_recipes`) even though
+ * `runYamlRecipe`'s per-step captures (added alongside this function) make
+ * it just as replayable.
+ *
+ * Tagged via `manualRunId: "replay-<originalSeq>"` (reusing the existing
+ * PR5b field) rather than a taskId prefix — yamlRunner's taskId format
+ * (`yaml:<recipe>:<startedAt>`) has no override seam, and manualRunId is
+ * already surfaced in the dashboard / `runs.jsonl`, so this is enough to
+ * distinguish a replay run from a real one without new plumbing.
+ */
+export async function replayFlatMockedRun(opts: {
+  originalRun: RecipeRun;
+  recipe: YamlRecipe;
+  deps: ReplayDeps;
+}): Promise<FlatReplayResult> {
+  const { originalRun, recipe, deps } = opts;
+  const { outputs, unmocked } = buildFlatMockedOutputs(originalRun);
+
+  try {
+    const result = await runYamlRecipe(recipe, {
+      ...deps.runnerDeps,
+      runLog: deps.runLog,
+      ...(deps.activityLog !== undefined && { activityLog: deps.activityLog }),
+      mockedOutputs: outputs,
+      manualRunId: `replay-${originalRun.seq}`,
+      testMode: false,
+    });
+    const recent = deps.runLog.query({ recipe: recipe.name, limit: 5 });
+    const newRun = recent.find((r) => r.createdAt >= originalRun.doneAt);
+    return {
+      ok: !result.errorMessage,
       ...(newRun?.seq !== undefined && { newSeq: newRun.seq }),
       result,
       ...(result.errorMessage !== undefined && { error: result.errorMessage }),

--- a/src/recipes/yamlRunner.ts
+++ b/src/recipes/yamlRunner.ts
@@ -95,7 +95,11 @@ import { resolveRecipePath } from "./resolveRecipePath.js";
 import { RunBudget } from "./runBudget.js";
 import { registerRun, unregisterRun } from "./runRegistry.js";
 import type { ErrorPolicy } from "./schema.js";
-import { detectSilentFail, redactSecretsForPrompt } from "./stepObservation.js";
+import {
+  captureForRunlog,
+  detectSilentFail,
+  redactSecretsForPrompt,
+} from "./stepObservation.js";
 // Import tool registry and trigger tool self-registration
 import {
   applyToolOutputContext,
@@ -682,6 +686,20 @@ export interface RunnerDeps {
    * (non-agent) tool step. Undefined for non-worker recipes.
    */
   workerId?: string;
+  /**
+   * Flight-recorder mocked replay for flat (non-chained) recipes — the flat
+   * counterpart to `chainedRunner.ts`'s `RunOptions.mockedOutputs`. Keyed by
+   * step id (the same `step.into ?? "step_${n}"` value RunStepResult.id
+   * uses). When a step's id is present, its real tool execution is
+   * SKIPPED — the mocked value is used as the step's result and flows
+   * through `transform` / `expect` / ctx-commit exactly as a real result
+   * would, so a replay shows how the recipe's wiring (not just the
+   * upstream tool) behaves against captured evidence. Built by
+   * `replayFlatMockedRun` (replayRun.ts) from a prior run's captured
+   * `output` fields (see `captureForRunlog` in the step-result push
+   * sites below). Unset for a normal (non-replay) run.
+   */
+  mockedOutputs?: Map<string, string>;
 }
 
 export interface RunResult {
@@ -773,6 +791,14 @@ export type StepResult = {
    */
   costUsd?: number;
   durationMs: number;
+  /**
+   * Flight recorder — the step's captured output (via `captureForRunlog`:
+   * secret-key redaction + 8 KB cap, `[truncated]` envelope beyond that).
+   * Present for successful tool steps; ABSENT for agent steps, skipped
+   * steps, and errored steps. Mirrors `RunStepResult.output` in runLog.ts
+   * (VD-2) — feeds `replayFlatMockedRun`'s mocked replay for flat recipes.
+   */
+  output?: unknown;
 };
 
 export type StepDeps = Required<
@@ -798,6 +824,10 @@ export type StepDeps = Required<
     // Present only when a worker owns the recipe — keep optional, not
     // forced Required by the Omit-based mapped type.
     | "workerId"
+    // Flight-recorder mocked replay is checked in the run loop against
+    // `deps`, not per-step StepDeps; keep it off StepDeps so it isn't
+    // forced Required here.
+    | "mockedOutputs"
   >
 > & {
   workdir: string;
@@ -2218,98 +2248,107 @@ export async function runYamlRecipe(
       let stepErrorIsSilentFail = false;
       let thrownError: string | undefined;
       let thrownErrorCode: string | undefined;
-      for (let attempt = 0; attempt <= retryCount; attempt++) {
-        if (attempt > 0) {
-          await new Promise((r) => setTimeout(r, retryDelayMs));
-        }
-        stepError = undefined;
-        stepErrorIsSilentFail = false;
-        thrownError = undefined;
-        thrownErrorCode = undefined;
-        try {
-          // Slice (sandbox-alternative): per-step wall-clock timeout via
-          // Promise.race. The underlying tool keeps running in the
-          // background — this is a halt signal for the runner, not a
-          // process kill. The thrown error carries a `step_timeout`
-          // prefix so categoriseHaltReason maps it correctly.
-          const timeoutMs =
-            typeof step.timeout_ms === "number" && step.timeout_ms > 0
-              ? step.timeout_ms
-              : 0;
-          if (timeoutMs > 0) {
-            let timer: NodeJS.Timeout | undefined;
-            const timeoutPromise = new Promise<string | null>((_, reject) => {
-              timer = setTimeout(() => {
-                reject(
-                  new Error(
-                    `step_timeout: exceeded ${timeoutMs}ms in step "${step.into ?? step.tool ?? "?"}"`,
-                  ),
-                );
-              }, timeoutMs);
-            });
-            try {
-              result = await Promise.race([
-                executeStep(step, ctx, stepDeps),
-                timeoutPromise,
-              ]);
-            } finally {
-              if (timer) clearTimeout(timer);
-            }
-          } else {
-            result = await executeStep(step, ctx, stepDeps);
+      // Flight-recorder mocked replay: short-circuit BEFORE executing the
+      // tool. The step still flows through transform/expect/ctx-commit
+      // below (driven by `result`), so a replay shows how the recipe's
+      // wiring behaves against captured evidence — only the tool call
+      // itself is skipped. See RunnerDeps.mockedOutputs's doc comment.
+      if (deps.mockedOutputs?.has(stepId)) {
+        result = deps.mockedOutputs.get(stepId) ?? null;
+      } else {
+        for (let attempt = 0; attempt <= retryCount; attempt++) {
+          if (attempt > 0) {
+            await new Promise((r) => setTimeout(r, retryDelayMs));
           }
-          // Detect tool-level errors reported as JSON {ok: false, error: ...}
-          if (result !== null) {
-            try {
-              const parsed = JSON.parse(result) as Record<string, unknown>;
-              if (parsed.ok === false && typeof parsed.error === "string") {
-                stepError = parsed.error;
+          stepError = undefined;
+          stepErrorIsSilentFail = false;
+          thrownError = undefined;
+          thrownErrorCode = undefined;
+          try {
+            // Slice (sandbox-alternative): per-step wall-clock timeout via
+            // Promise.race. The underlying tool keeps running in the
+            // background — this is a halt signal for the runner, not a
+            // process kill. The thrown error carries a `step_timeout`
+            // prefix so categoriseHaltReason maps it correctly.
+            const timeoutMs =
+              typeof step.timeout_ms === "number" && step.timeout_ms > 0
+                ? step.timeout_ms
+                : 0;
+            if (timeoutMs > 0) {
+              let timer: NodeJS.Timeout | undefined;
+              const timeoutPromise = new Promise<string | null>((_, reject) => {
+                timer = setTimeout(() => {
+                  reject(
+                    new Error(
+                      `step_timeout: exceeded ${timeoutMs}ms in step "${step.into ?? step.tool ?? "?"}"`,
+                    ),
+                  );
+                }, timeoutMs);
+              });
+              try {
+                result = await Promise.race([
+                  executeStep(step, ctx, stepDeps),
+                  timeoutPromise,
+                ]);
+              } finally {
+                if (timer) clearTimeout(timer);
               }
-            } catch {
-              /* non-JSON result is fine */
+            } else {
+              result = await executeStep(step, ctx, stepDeps);
             }
-          }
-          // Silent-fail detection: tools that return string placeholders
-          // (`(git branches unavailable)`, `[agent step skipped: ...]`)
-          // or empty list-tool error shapes (`{count:0,error:"..."}`)
-          // succeed with bad data — flag them as `error` so the runner
-          // doesn't quietly hand garbage to a downstream agent. Per-step
-          // opt-out via `silentFailDetection: false`.
-          if (
-            !stepError &&
-            result !== null &&
-            step.silentFailDetection !== false
-          ) {
-            const detected = detectSilentFail(result);
-            if (detected) {
-              stepError = `silent-fail detected (${detected.reason}): ${detected.matched}`;
-              stepErrorIsSilentFail = true;
+            // Detect tool-level errors reported as JSON {ok: false, error: ...}
+            if (result !== null) {
+              try {
+                const parsed = JSON.parse(result) as Record<string, unknown>;
+                if (parsed.ok === false && typeof parsed.error === "string") {
+                  stepError = parsed.error;
+                }
+              } catch {
+                /* non-JSON result is fine */
+              }
             }
+            // Silent-fail detection: tools that return string placeholders
+            // (`(git branches unavailable)`, `[agent step skipped: ...]`)
+            // or empty list-tool error shapes (`{count:0,error:"..."}`)
+            // succeed with bad data — flag them as `error` so the runner
+            // doesn't quietly hand garbage to a downstream agent. Per-step
+            // opt-out via `silentFailDetection: false`.
+            if (
+              !stepError &&
+              result !== null &&
+              step.silentFailDetection !== false
+            ) {
+              const detected = detectSilentFail(result);
+              if (detected) {
+                stepError = `silent-fail detected (${detected.reason}): ${detected.matched}`;
+                stepErrorIsSilentFail = true;
+              }
+            }
+          } catch (err) {
+            thrownError = err instanceof Error ? err.message : String(err);
+            // Preserve structured error codes (e.g. recipe_path_jail_escape)
+            // so callers and tests can branch on `err.code` per R2 M-4
+            // without scraping the message string.
+            const code = (err as { code?: unknown })?.code;
+            if (typeof code === "string") thrownErrorCode = code;
+            result = null;
           }
-        } catch (err) {
-          thrownError = err instanceof Error ? err.message : String(err);
-          // Preserve structured error codes (e.g. recipe_path_jail_escape)
-          // so callers and tests can branch on `err.code` per R2 M-4
-          // without scraping the message string.
-          const code = (err as { code?: unknown })?.code;
-          if (typeof code === "string") thrownErrorCode = code;
-          result = null;
+          if (!stepError && !thrownError) break;
+          // Audit 2026-06-10 recipe-runners-2: do NOT retry on a step_timeout.
+          // The timed-out attempt's underlying tool call keeps running in the
+          // background (Promise.race only abandons the wait, it does not cancel
+          // the call). Re-issuing the step here is, at best, pointless — for a
+          // write tool the in-flight idempotency ledger short-circuits the retry
+          // to the SAME promise (no second side effect, but also no progress) —
+          // and, at worst, a second side effect for any tool the ledger cannot
+          // dedup (non-write tools, or a write tool whose first attempt already
+          // committed its effect then threw). A true cancel needs an AbortSignal
+          // threaded through every tool/connector call, which is out of scope
+          // here; until then, refusing to retry on timeout is the safe contract.
+          // (Genuine transient failures — non-timeout throws / {ok:false} — still
+          // retry below.)
+          if (thrownError?.startsWith("step_timeout:")) break;
         }
-        if (!stepError && !thrownError) break;
-        // Audit 2026-06-10 recipe-runners-2: do NOT retry on a step_timeout.
-        // The timed-out attempt's underlying tool call keeps running in the
-        // background (Promise.race only abandons the wait, it does not cancel
-        // the call). Re-issuing the step here is, at best, pointless — for a
-        // write tool the in-flight idempotency ledger short-circuits the retry
-        // to the SAME promise (no second side effect, but also no progress) —
-        // and, at worst, a second side effect for any tool the ledger cannot
-        // dedup (non-write tools, or a write tool whose first attempt already
-        // committed its effect then threw). A true cancel needs an AbortSignal
-        // threaded through every tool/connector call, which is out of scope
-        // here; until then, refusing to retry on timeout is the safe contract.
-        // (Genuine transient failures — non-timeout throws / {ok:false} — still
-        // retry below.)
-        if (thrownError?.startsWith("step_timeout:")) break;
       }
 
       // Recipe-level fallback: log_only / deliver_original treat step failure
@@ -2350,9 +2389,10 @@ export async function runYamlRecipe(
           retryCount > 0 ? ` after ${retryCount + 1} attempts` : "";
         // Outcome attribution: capture the filed-issue URL on github.create_issue
         // steps so trust-replay can look up the issue's eventual disposition in
-        // the outcome store (confirmed/junk/unknown). Targeted to this one tool
-        // only — storing all tool outputs would bloat the run log unnecessarily.
-        let stepOutput: Record<string, unknown> | undefined;
+        // the outcome store (confirmed/junk/unknown). Takes priority over the
+        // general capture below — a smaller, stable shape trust-replay depends
+        // on, rather than the tool's full (and potentially larger) response.
+        let stepOutput: unknown | undefined;
         if (
           finalStatus === "ok" &&
           result !== null &&
@@ -2364,8 +2404,22 @@ export async function runYamlRecipe(
               stepOutput = { url: parsed.url, issueNumber: parsed.issueNumber };
             }
           } catch {
-            /* non-JSON or missing url — skip output capture */
+            /* non-JSON or missing url — falls through to general capture */
           }
+        }
+        // Flight recorder — general per-step output capture (parity with
+        // chainedRunner's VD-2 `captureForRunlog(result.data)`). Redacts
+        // known secret keys and caps at 8 KB (truncation envelope beyond
+        // that). Feeds `replayFlatMockedRun`'s mocked replay for flat
+        // recipes; previously ONLY github.create_issue steps captured
+        // anything, so flat recipes had no flight-recorder / replay
+        // capability at all (chained recipes only — see replayRun.ts).
+        if (
+          stepOutput === undefined &&
+          finalStatus === "ok" &&
+          result !== null
+        ) {
+          stepOutput = captureForRunlog(result);
         }
         stepResults.push({
           id: stepId,


### PR DESCRIPTION
## Summary
Next roadmap item after the policy layer, idempotency, circuit breakers, and file rollback (#1157-#1161). Investigation found the "flight recorder" capability was already half-built: `chainedRunner.ts`'s VD-2 per-step output capture + VD-4 mocked replay (`replayRun.ts`) let an operator replay a **chained** recipe against captured evidence with zero external calls. But **flat** recipes (`runYamlRecipe` — manual/cron/webhook triggers, the common case) had no capture at all, and `runReplayFn` hard-coded `replay_only_supported_for_chained_recipes` for anything else.

- `src/recipes/yamlRunner.ts`: `StepResult` gains `output?: unknown`, captured via `captureForRunlog` for every successful tool step — generalizes the previous `github.create_issue`-only capture (preserved as a priority branch since `shadowObserver.ts`'s outcome attribution depends on its narrow `{url, issueNumber}` shape). `RunnerDeps` gains `mockedOutputs?: Map<string, string>`: when a step's id has a mocked value, real tool execution is skipped and the mocked value flows through transform/expect/ctx-commit exactly as a real result would.
- `src/recipes/replayRun.ts`: new `buildFlatMockedOutputs` + `replayFlatMockedRun`, the flat counterpart to the existing chained functions. Tags the new run via `manualRunId: "replay-<originalSeq>"`.
- `src/recipeOrchestration.ts`: `runReplayFn` now dispatches flat recipes through `replayFlatMockedRun` instead of erroring.
- `CLAUDE.md`: documents the mechanism.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx biome check` clean
- [x] `node scripts/audit-test-fixtures.mjs` / `audit-lsp-tools.mjs` clean
- [x] 7 new tests in `yamlRunner.test.ts`: output capture on success/skip/error, `github.create_issue` shape preserved, mockedOutputs short-circuit + fallthrough + transform re-application
- [x] 10 new tests in `replayRun.test.ts`: `buildFlatMockedOutputs` parity with `buildMockedOutputs`, `replayFlatMockedRun` seq/manualRunId/unmockedSteps
- [x] Full `src/recipes/` + `src/workers/` + orchestration suites green (1879/1879)
- [x] Coverage margin checked directly (learned from #1161's Windows flake): global branches 65.78% vs 62% floor, `yamlRunner.ts`/`replayRun.ts` both ~78-79% branch coverage