### PR TITLE
fix(recipes): captured step output never survived disk persistence

### DIFF
--- a/src/recipes/__tests__/workerAutonomySmoke.test.ts
+++ b/src/recipes/__tests__/workerAutonomySmoke.test.ts
@@ -346,6 +346,25 @@ describe("worker-autonomy smoke (triage-failing-tests-autofile, flag ON)", () =>
       "a recent issue success is withheld (durable-outcome label)",
     ).toBeUndefined();
 
+    // An operator confirmation (`patchwork outcomes confirm <url>`) is the
+    // only thing that moves the dial for a non-reversible success — an
+    // unconfirmed ("unknown" disposition) filing is durably WITHHELD, never
+    // folded as evidence, even after the durability window elapses (#1064).
+    // Now that the flight-recorder fix makes `output.url` actually reach
+    // disk (see the yamlRunner.ts finalStepResults regression fixed
+    // alongside this test), loadWorkerTrustForRecipe's OutcomeStore lookup
+    // is reachable — simulate the real confirm step so this smoke test
+    // still exercises "durable success + confirmed disposition", the
+    // combination that's actually supposed to accrue evidence.
+    const { OutcomeStore } = await import("../../workers/outcomeStore.js");
+    new OutcomeStore(patchworkDir).upsert({
+      issueUrl: "https://github.com/patchwork/os/issues/4242",
+      disposition: "confirmed",
+      checkedAt: Date.now(),
+      recipeName: RECIPE_NAME,
+      origin: "manual",
+    });
+
     // …but once the run has survived the durability window it accrues evidence.
     // (Inject a future `now` to simulate the window elapsing.)
     const durableTrust = loadWorkerTrustForRecipe(RECIPE_NAME, {

--- a/src/recipes/__tests__/yamlRunner.test.ts
+++ b/src/recipes/__tests__/yamlRunner.test.ts
@@ -5016,6 +5016,46 @@ describe("ephemeral file rollback (end-to-end through runYamlRecipe)", () => {
 });
 
 describe("flight recorder — per-step output capture", () => {
+  it("REGRESSION: captured output survives the real runLog.completeRun disk persist + reload round trip", async () => {
+    // Bug found by dogfooding replay end-to-end (not caught by any prior
+    // unit test): completeRun's call site builds `finalStepResults` via a
+    // hand-picked whitelist map (id/tool/status/error/haltReason/...) that
+    // did NOT include `output` — so the captured output existed on the
+    // in-memory RunResult (what every other test in this describe block
+    // checks) but was silently stripped before ever reaching
+    // runs.jsonl. Every prior replay test fed a SYNTHETIC RecipeRun
+    // fixture directly into replayFlatMockedRun/buildFlatMockedOutputs,
+    // so none of them round-tripped through a real RecipeRunLog and none
+    // caught this. This test goes through the actual disk persist +
+    // reload, the only way replay ever consumes a run in production.
+    const { RecipeRunLog } = await import("../../runLog.js");
+    const tmp = mkdtempSync(path.join(os.tmpdir(), "runlog-output-capture-"));
+    try {
+      const runLog = new RecipeRunLog({ dir: tmp });
+      const recipe = makeRecipe({
+        name: "output-persist-regression",
+        steps: [
+          {
+            tool: "file.write",
+            path: path.join(TMP, "persist.md"),
+            content: "x",
+          },
+        ],
+      });
+      await runYamlRecipe(recipe, { ...noop(), runLog });
+      const persisted = runLog.query({
+        recipe: "output-persist-regression",
+      })[0];
+      expect(persisted?.stepResults?.[0]?.status).toBe("ok");
+      expect(persisted?.stepResults?.[0]?.output).toBeDefined();
+      expect(persisted?.stepResults?.[0]?.output).toHaveProperty(
+        "bytesWritten",
+      );
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
   it("captures a successful tool step's output onto StepResult.output", async () => {
     const recipe = makeRecipe({
       steps: [

--- a/src/recipes/yamlRunner.ts
+++ b/src/recipes/yamlRunner.ts
@@ -2593,6 +2593,17 @@ export async function runYamlRecipe(
           : {}),
         ...(typeof s.costUsd === "number" ? { costUsd: s.costUsd } : {}),
         durationMs: s.durationMs,
+        // Flight recorder — without this, the captured `output` (added
+        // alongside replayFlatMockedRun) never survives persistence: this
+        // whitelist map is what actually reaches disk via
+        // `runLog.completeRun`, so a replay reloading the ORIGINAL run
+        // from disk (the only way replay ever consumes it in real usage)
+        // saw every step as unmocked no matter what executeStep captured
+        // in memory. Found by dogfooding replay end-to-end — unit tests
+        // missed it because they fed synthetic RecipeRun fixtures
+        // directly into replayFlatMockedRun, never round-tripping through
+        // a real runLog persist + reload.
+        ...(s.output !== undefined ? { output: s.output } : {}),
       }));
       // P1: run-level token aggregate + budget totals (latter only when a
       // budget was configured — never persist all-zero no-budget totals).


### PR DESCRIPTION
## Summary
Found by dogfooding the session's shipped work end-to-end against a real (sandboxed) bridge instance instead of just the test suite. `completeRun`'s call site builds `finalStepResults` via a hand-picked whitelist map that never included `output` — the flight-recorder capture added this session existed in memory but was silently stripped before ever reaching `runs.jsonl`. Since replay always reloads the original run from disk, **the entire mocked-replay feature was inert for every real run** — it only worked in unit tests because those tests fed synthetic `RecipeRun` fixtures directly into `replayFlatMockedRun`, never round-tripping through a real persist + reload.

- `src/recipes/yamlRunner.ts`: add `output` to the whitelist map.
- `src/recipes/__tests__/yamlRunner.test.ts`: new regression test that round-trips through a real `RecipeRunLog` — verified red without the fix, green with it.
- `src/recipes/__tests__/workerAutonomySmoke.test.ts`: this fix incidentally makes `output.url` reach disk for `github.create_issue` steps for the first time, exposing a previously-unreachable `OutcomeStore` lookup in `loadWorkerTrustForRecipe`. That lookup correctly withholds evidence for an unconfirmed issue filing (per #1042's durable-outcome-labelling), so the test now simulates an explicit operator confirmation — not a new bug, this test was previously passing for the wrong reason (dead code path).

## Dogfood results (sandboxed scratch bridge, no live bridge touched)
- ✅ Policy enforcement — deny + allow paths confirmed
- ✅ Circuit breaker — 5 real failures → trip → short-circuit confirmed
- ✅ File rollback — mutate → rollback → restored confirmed
- ✅ Flight-recorder replay — **found and fixed the bug above**; after the fix, confirmed zero real tool calls during replay and output parity with the original run

## Test plan
- [x] `npx tsc --noEmit` + `npx tsc --noEmit -p tsconfig.tests.core.json` clean
- [x] `npx biome check` clean
- [x] `node scripts/audit-test-fixtures.mjs` clean
- [x] New regression test verified red→green
- [x] Full repo suite green (9109/9113, pre-existing skips only)