### PR TITLE
fix(dashboard): match CLI bridge-lock discovery (EPERM-alive, CLAUDE_CONFIG_DIR)

### DIFF
--- a/dashboard/src/lib/__tests__/bridge.test.ts
+++ b/dashboard/src/lib/__tests__/bridge.test.ts
@@ -15,6 +15,7 @@ const ENV_KEYS = [
   "PATCHWORK_BRIDGE_URL",
   "PATCHWORK_BRIDGE_TOKEN",
   "PATCHWORK_BRIDGE_PORT",
+  "CLAUDE_CONFIG_DIR",
 ] as const;
 
 function clearBridgeEnv() {
@@ -234,5 +235,41 @@ describe("findBridge — lock-file scan", () => {
     const future = Date.now() / 1000 + 60;
     fs.utimesSync(path.join(ideDir, "4242.lock"), future, future);
     expect(findBridge()?.authToken).toBe("good");
+  });
+
+  it("honours CLAUDE_CONFIG_DIR to relocate the lock scan directory", () => {
+    const altConfigDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "bridge-altconfig-"),
+    );
+    const altIdeDir = path.join(altConfigDir, "ide");
+    fs.mkdirSync(altIdeDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(altIdeDir, "7777.lock"),
+      JSON.stringify({ pid: process.pid, authToken: "alt", isBridge: true }),
+    );
+    process.env.CLAUDE_CONFIG_DIR = altConfigDir;
+    try {
+      expect(findBridge()?.authToken).toBe("alt");
+    } finally {
+      fs.rmSync(altConfigDir, { recursive: true, force: true });
+    }
+  });
+
+  it("treats a PID that throws EPERM as alive (cross-user/elevated process)", () => {
+    writeLock(8888, { pid: 4321, authToken: "eperm-ok", isBridge: true });
+    const eperm = Object.assign(new Error("EPERM"), { code: "EPERM" });
+    vi.spyOn(process, "kill").mockImplementation((pid) => {
+      if (pid === 4321) throw eperm;
+      throw Object.assign(new Error("ESRCH"), { code: "ESRCH" });
+    });
+    expect(findBridge()?.authToken).toBe("eperm-ok");
+  });
+
+  it("treats a PID that throws ESRCH as dead", () => {
+    writeLock(8889, { pid: 4322, authToken: "esrch-bad", isBridge: true });
+    vi.spyOn(process, "kill").mockImplementation(() => {
+      throw Object.assign(new Error("ESRCH"), { code: "ESRCH" });
+    });
+    expect(findBridge()).toBeNull();
   });
 });

--- a/dashboard/src/lib/bridge.ts
+++ b/dashboard/src/lib/bridge.ts
@@ -54,8 +54,13 @@ export function findBridge(): BridgeLock | null {
   return lock;
 }
 
+function _lockDir(): string {
+  const configDir = process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), ".claude");
+  return path.join(configDir, "ide");
+}
+
 function _scanLockFiles(): BridgeLock | null {
-  const dir = path.join(os.homedir(), ".claude", "ide");
+  const dir = _lockDir();
   if (!fs.existsSync(dir)) return null;
   const pinned = process.env.PATCHWORK_BRIDGE_PORT;
   const files = fs
@@ -109,7 +114,11 @@ function isPidAlive(pid: number): boolean {
   try {
     process.kill(pid, 0);
     return true;
-  } catch {
+  } catch (err) {
+    // EPERM: we lack permission to signal the process, but it IS running
+    // (cross-user or elevated on Windows). Mirror src/bridgeLockDiscovery.ts.
+    if ((err as NodeJS.ErrnoException).code === "EPERM") return true;
+    // ESRCH (or anything else): no such process → dead.
     return false;
   }
 }


### PR DESCRIPTION
## Summary
- `dashboard/src/lib/bridge.ts` independently reimplements the `~/.claude/ide/*.lock` scan that `src/bridgeLockDiscovery.ts` (used by the CLI) already has, because the dashboard is a standalone npm package and can't import across the workspace boundary. The two had drifted:
  - `isPidAlive()` treated *any* `process.kill()` throw as "dead" — misreading `EPERM` (process exists but signaling is denied: cross-user or elevated, common on Windows) as a dead bridge and silently skipping a live lock.
  - The scan directory was hardcoded to `~/.claude/ide`, ignoring `CLAUDE_CONFIG_DIR`.
- Both now mirror `bridgeLockDiscovery.ts`'s behavior (EPERM ⇒ alive, ESRCH/other ⇒ dead; honors `CLAUDE_CONFIG_DIR`).
- No change to multi-bridge disambiguation (cwd-matching) — the dashboard is a long-running server with no per-request cwd, so `PATCHWORK_BRIDGE_PORT` remains the documented way to pin it in multi-workspace setups.

## Test plan
- [x] `npx vitest run src/lib/__tests__/bridge.test.ts` — 24/24 passing (4 new: `CLAUDE_CONFIG_DIR` override, EPERM-as-alive, ESRCH-as-dead)
- [x] `npx tsc --noEmit` clean on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)