### PR TITLE
fix(bridge): case-fold workspace paths in lock discovery for Windows

### DIFF
--- a/scripts/mcp-stdio-shim.cjs
+++ b/scripts/mcp-stdio-shim.cjs
@@ -51,14 +51,26 @@ function isAlive(pid) {
 // rather than on every poll tick.
 let lastSelectedLockPath = null;
 
+// Normalize a path for cross-platform comparison: resolve it, convert
+// backslashes to forward slashes, and (on Windows only) lowercase it — NTFS
+// paths are case-insensitive but a VS Code-spawned bridge and a
+// terminal-spawned shim can report the same path with different casing.
+// Mirrors normalizePathForComparison() in src/bridgeLockDiscovery.ts.
+function normalizePathForComparison(p) {
+  const resolved = path.resolve(p).replace(/\\/g, "/");
+  return process.platform === "win32" ? resolved.toLowerCase() : resolved;
+}
+
 // True when `cwd` is the workspace root or a descendant of it. Used (only when
 // no --workspace filter is set) to prefer the bridge for the project the shim is
 // actually running in, rather than whichever lock has the newest mtime. Mirrors
 // cwdInWorkspace() in src/bridgeLockDiscovery.ts (unit-tested there).
 function cwdInWorkspace(cwd, workspace) {
   if (!workspace) return false;
-  const rel = path.relative(workspace, cwd);
-  return rel === "" || (!rel.startsWith("..") && !path.isAbsolute(rel));
+  const normCwd = normalizePathForComparison(cwd);
+  const normWorkspace = normalizePathForComparison(workspace);
+  const rel = path.posix.relative(normWorkspace, normCwd);
+  return rel === "" || (!rel.startsWith("..") && !path.posix.isAbsolute(rel));
 }
 
 function findLockFile() {
@@ -93,7 +105,14 @@ function findLockFile() {
         // When a workspace filter is set, require an EXACT workspace match — a
         // lock with a missing/blank workspace field must not be picked under the
         // filter (otherwise the shim can latch onto an unrelated bridge).
-        if (workspaceFilter && (!data || data.workspace !== workspaceFilter))
+        // Normalized so a --workspace flag with different drive-letter casing
+        // than the lock file's recorded path still matches on Windows.
+        if (
+          workspaceFilter &&
+          (!data?.workspace ||
+            normalizePathForComparison(data.workspace) !==
+              normalizePathForComparison(workspaceFilter))
+        )
           continue;
         const isBridge = data ? data.isBridge === true : false;
         const isOrchestrator = data ? data.orchestrator === true : false;

--- a/src/__tests__/bridgeLockDiscovery.test.ts
+++ b/src/__tests__/bridgeLockDiscovery.test.ts
@@ -17,7 +17,11 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { findAllLiveBridges, findBridgeLock } from "../bridgeLockDiscovery.js";
+import {
+  cwdInWorkspace,
+  findAllLiveBridges,
+  findBridgeLock,
+} from "../bridgeLockDiscovery.js";
 
 let dir: string;
 
@@ -261,5 +265,37 @@ describe("findBridgeLock() — workspace-aware selection (multi-bridge)", () => 
       cwd: "/totally/unrelated",
     });
     expect(pick?.port).toBe(3101);
+  });
+});
+
+describe("cwdInWorkspace() — Windows drive-letter/case handling", () => {
+  const originalPlatform = process.platform;
+
+  afterEach(() => {
+    Object.defineProperty(process, "platform", { value: originalPlatform });
+  });
+
+  it("matches a drive-letter-case mismatch when platform is win32", () => {
+    Object.defineProperty(process, "platform", { value: "win32" });
+    // VS Code-style lowercase drive letter + forward slashes vs. a bridge's
+    // OS-native uppercase-drive, backslash-separated workspace path.
+    expect(
+      cwdInWorkspace("c:/users/dev/repo/src", "C:\\Users\\dev\\repo"),
+    ).toBe(true);
+  });
+
+  it("matches mixed segment casing when platform is win32", () => {
+    Object.defineProperty(process, "platform", { value: "win32" });
+    expect(cwdInWorkspace("C:/Repo/Src", "c:/repo")).toBe(true);
+  });
+
+  it("does NOT fold case on non-Windows platforms", () => {
+    Object.defineProperty(process, "platform", { value: "darwin" });
+    expect(cwdInWorkspace("/ws/a/src", "/Ws/A")).toBe(false);
+  });
+
+  it("still matches exact-case paths on non-Windows platforms", () => {
+    Object.defineProperty(process, "platform", { value: "darwin" });
+    expect(cwdInWorkspace("/ws/a/src", "/ws/a")).toBe(true);
   });
 });

--- a/src/bridgeLockDiscovery.ts
+++ b/src/bridgeLockDiscovery.ts
@@ -31,11 +31,29 @@ export interface LockDiscoveryDeps {
   cwd?: string;
 }
 
-/** True when `cwd` is the workspace root or a descendant of it. */
-function cwdInWorkspace(cwd: string, workspace: string): boolean {
+/**
+ * Normalize a path for cross-platform comparison: resolve it, convert
+ * backslashes to forward slashes, and (on Windows only) lowercase it — NTFS
+ * paths are case-insensitive but VS Code / a terminal-spawned process can
+ * report the same path with different drive-letter/segment casing.
+ */
+function normalizePathForComparison(p: string): string {
+  const resolved = path.resolve(p).replace(/\\/g, "/");
+  return process.platform === "win32" ? resolved.toLowerCase() : resolved;
+}
+
+/**
+ * True when `cwd` is the workspace root or a descendant of it. Exported for
+ * direct unit testing of the cross-platform (case/slash) comparison rules —
+ * `findBridgeLock`'s own tests otherwise depend on non-deterministic
+ * `readdir` ordering to observe which candidate wins.
+ */
+export function cwdInWorkspace(cwd: string, workspace: string): boolean {
   if (!workspace) return false;
-  const rel = path.relative(workspace, cwd);
-  return rel === "" || (!rel.startsWith("..") && !path.isAbsolute(rel));
+  const normCwd = normalizePathForComparison(cwd);
+  const normWorkspace = normalizePathForComparison(workspace);
+  const rel = path.posix.relative(normWorkspace, normCwd);
+  return rel === "" || (!rel.startsWith("..") && !path.posix.isAbsolute(rel));
 }
 
 function defaultIsLive(pid: number): boolean {

--- a/vscode-extension/src/__tests__/lockfiles-multiworkspace.test.ts
+++ b/vscode-extension/src/__tests__/lockfiles-multiworkspace.test.ts
@@ -189,3 +189,40 @@ describe("readAllMatchingLockFiles", () => {
     expect(results).toHaveLength(0);
   });
 });
+
+// ── Windows drive-letter/case-insensitivity ──────────────────────────────────
+
+describe("cross-platform workspace-path matching", () => {
+  const originalPlatform = process.platform;
+
+  afterEach(() => {
+    Object.defineProperty(process, "platform", { value: originalPlatform });
+  });
+
+  it("readLockFileForWorkspace matches a drive-letter-case mismatch on win32", async () => {
+    Object.defineProperty(process, "platform", { value: "win32" });
+    setupLocks([{ file: "10001.lock", workspace: "C:\\Users\\dev\\repo" }]);
+    // VS Code-style lowercase drive letter + forward slashes.
+    const result = await readLockFileForWorkspace("c:/users/dev/repo");
+    expect(result).not.toBeNull();
+    expect(result!.port).toBe(10001);
+  });
+
+  it("readLockFileForWorkspace does NOT fold case on non-Windows platforms", async () => {
+    Object.defineProperty(process, "platform", { value: "darwin" });
+    setupLocks([{ file: "10001.lock", workspace: "/Project/A" }]);
+    const result = await readLockFileForWorkspace("/project/a");
+    expect(result).toBeNull();
+  });
+
+  it("readAllMatchingLockFiles matches drive-letter-case mismatches on win32", async () => {
+    Object.defineProperty(process, "platform", { value: "win32" });
+    (vscode.workspace as any).workspaceFolders = [
+      { uri: { fsPath: "c:/users/dev/repo" } },
+    ];
+    setupLocks([{ file: "10001.lock", workspace: "C:\\Users\\dev\\repo" }]);
+    const results = await readAllMatchingLockFiles();
+    expect(results).toHaveLength(1);
+    expect(results[0].port).toBe(10001);
+  });
+});

--- a/vscode-extension/src/bridgeProcess.ts
+++ b/vscode-extension/src/bridgeProcess.ts
@@ -36,6 +36,17 @@ function validateBinaryPath(binaryPath: string): void {
   }
 }
 
+/**
+ * Normalize a workspace path for cross-platform comparison: resolve it,
+ * convert backslashes to forward slashes, and (on Windows only) lowercase
+ * it — NTFS paths are case-insensitive but VS Code / a terminal-spawned
+ * process can report the same path with different casing.
+ */
+function normalizeWorkspacePathForComparison(p: string): string {
+  const resolved = path.resolve(p).replace(/\\/g, "/");
+  return process.platform === "win32" ? resolved.toLowerCase() : resolved;
+}
+
 export interface BridgeStartedEvent {
   port: number;
   authToken: string;
@@ -264,9 +275,12 @@ export class BridgeProcess {
                 // Normalise both sides to forward slashes before comparing so
                 // a lock file written with a Unix path (e.g. from WSL or a
                 // cross-platform tool) matches a Windows backslash path and
-                // vice-versa.
-                path.resolve(content.workspace).replace(/\\/g, "/") !==
-                  path.resolve(this.workspacePath).replace(/\\/g, "/")
+                // vice-versa. Also lowercase on Windows — NTFS paths are
+                // case-insensitive but VS Code's URI-normalized workspace path
+                // and a bridge's process.cwd()-derived path can differ in
+                // drive-letter/segment casing.
+                normalizeWorkspacePathForComparison(content.workspace) !==
+                  normalizeWorkspacePathForComparison(this.workspacePath)
               )
                 continue;
 

--- a/vscode-extension/src/lockfiles.ts
+++ b/vscode-extension/src/lockfiles.ts
@@ -7,6 +7,18 @@ import type { LockFileData } from "./types";
 
 // ── Internal helper ───────────────────────────────────────────────────────────
 
+/**
+ * Normalize a path for cross-platform comparison: resolve it, convert
+ * backslashes to forward slashes, and (on Windows only) lowercase it — NTFS
+ * paths are case-insensitive, but VS Code's URI-normalized workspace paths
+ * (typically lowercase drive letter) and a bridge's `process.cwd()`-derived
+ * workspace field (OS-native case) can otherwise fail to match.
+ */
+function normalizeWorkspacePath(p: string): string {
+  const resolved = path.resolve(p).replace(/\\/g, "/");
+  return process.platform === "win32" ? resolved.toLowerCase() : resolved;
+}
+
 /** Read all valid, live lock files and return their parsed data sorted newest first. */
 async function readValidLockFiles(
   lockDir?: string,
@@ -106,7 +118,10 @@ export async function readLockFilesAsync(
   }
   for (const candidate of candidates) {
     if (currentWorkspace && candidate.workspace) {
-      if (path.resolve(candidate.workspace) !== path.resolve(currentWorkspace))
+      if (
+        normalizeWorkspacePath(candidate.workspace) !==
+        normalizeWorkspacePath(currentWorkspace)
+      )
         continue;
     }
     return candidate;
@@ -120,12 +135,12 @@ export async function readLockFileForWorkspace(
   lockDir?: string,
 ): Promise<LockFileData | null> {
   const candidates = await readValidLockFiles(lockDir);
-  const resolved = path.resolve(workspace);
+  const resolved = normalizeWorkspacePath(workspace);
   for (const candidate of candidates) {
     // Skip candidates with no workspace field — they must not match a specific
     // workspace query or they could connect to the wrong bridge in multi-root setups.
     if (!candidate.workspace) continue;
-    if (path.resolve(candidate.workspace) !== resolved) continue;
+    if (normalizeWorkspacePath(candidate.workspace) !== resolved) continue;
     return candidate;
   }
   return null;
@@ -150,9 +165,9 @@ export async function readAllMatchingLockFiles(
   const seenPorts = new Set<number>();
 
   for (const folder of folders) {
-    const resolved = path.resolve(folder.uri.fsPath);
+    const resolved = normalizeWorkspacePath(folder.uri.fsPath);
     const match = candidates.find(
-      (c) => c.workspace && path.resolve(c.workspace) === resolved,
+      (c) => c.workspace && normalizeWorkspacePath(c.workspace) === resolved,
     );
     if (match && !seenPorts.has(match.port)) {
       seenPorts.add(match.port);


### PR DESCRIPTION
## Summary
- Workspace-path comparisons across the lock-discovery code compared paths as plain strings (after `path.resolve()`/slash-normalization) without folding case. NTFS paths are case-insensitive, but VS Code's URI-normalized workspace path (typically lowercase drive letter, e.g. `c:\repo`) commonly differs in case from a bridge's `process.cwd()`-derived workspace field (OS-native case, e.g. `C:\repo`) or a hand-typed `--workspace` flag.
- On Windows this silently failed to match, which could cause the extension to spawn a duplicate bridge for an already-running workspace, or misreport "multiple bridge instances found."
- Adds Windows-only case-folding (plus the existing slash-normalization) to:
  - `src/bridgeLockDiscovery.ts` — `cwdInWorkspace()` (used by the CLI and mirrored in the stdio shim); now exported for direct unit testing
  - `vscode-extension/src/lockfiles.ts` — `readLockFilesAsync`, `readLockFileForWorkspace`, `readAllMatchingLockFiles`
  - `vscode-extension/src/bridgeProcess.ts` — the spawn-confirmation lock match, which already normalized slashes but not case
  - `scripts/mcp-stdio-shim.cjs` — its hand-copy of `cwdInWorkspace`, plus the `--workspace` filter's exact-match check (previously case-sensitive with no normalization at all)
- Non-Windows behavior is unchanged — comparisons remain case-sensitive on macOS/Linux, verified by tests.

Found during a broader audit of dashboard/IDE/CLI/driver bridge-connection startup code (see PR #1167 for the companion dashboard lock-discovery fix).

## Test plan
- [x] `npx vitest run src/__tests__/bridgeLockDiscovery.test.ts` — 20/20 (4 new: win32 drive-letter/segment-case matches, darwin case-sensitivity preserved)
- [x] `npx vitest run` on `vscode-extension`'s lockfiles/bridgeProcess suites — 61/61 (3 new)
- [x] `npx tsc --noEmit` clean (root + vscode-extension)
- [x] `node --check scripts/mcp-stdio-shim.cjs`
- [x] `npx biome check` clean on all touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)