### PR TITLE
fix(onboarding): give first-time users an actionable path forward

### DIFF
--- a/dashboard/src/app/page.tsx
+++ b/dashboard/src/app/page.tsx
@@ -1795,7 +1795,7 @@ export default function HomePage() {
 
   return (
     <section className="td-root">
-      <FirstRunChecklist />
+      <FirstRunChecklist bridgeStatus={bridgeStatus} />
 
       {/* Statusline */}
       <div className="td-statusline" role="status" aria-label="Bridge status">

--- a/dashboard/src/components/FirstRunChecklist.tsx
+++ b/dashboard/src/components/FirstRunChecklist.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { useCallback, useEffect, useState } from "react";
+import { useBridgeStatus } from "@/hooks/useBridgeStatus";
 import { apiPath } from "@/lib/api";
 
 /**
@@ -89,6 +90,7 @@ function writeDismissed() {
 export function FirstRunChecklist() {
   const [status, setStatus] = useState<Status>(emptyStatus);
   const [dismissed, setDismissed] = useState(false);
+  const bridgeStatus = useBridgeStatus();
 
   useEffect(() => {
     setDismissed(readDismissed());
@@ -144,6 +146,19 @@ export function FirstRunChecklist() {
 
   if (dismissed) return null;
   if (!status.loaded) return null;
+  // Bridge unreachable — probeArray() treats a 503 ("no bridge running") the
+  // same as "reachable, zero items", so without this check a first-time user
+  // with no bridge running sees a misleading "0 of 4 done" checklist whose
+  // CTAs all lead to more silent dead ends. BridgeOfflineBanner (rendered in
+  // Shell) already tells them how to fix it (`patchwork start`); don't
+  // duplicate/contradict that here. Gate on lastAttemptAt so this doesn't
+  // flash-suppress the checklist before the first status poll resolves.
+  if (
+    bridgeStatus.lastAttemptAt !== undefined &&
+    !bridgeStatus.ok &&
+    !bridgeStatus.degraded
+  )
+    return null;
 
   const allDone =
     status.recipes.done &&

--- a/dashboard/src/components/FirstRunChecklist.tsx
+++ b/dashboard/src/components/FirstRunChecklist.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useCallback, useEffect, useState } from "react";
-import { useBridgeStatus } from "@/hooks/useBridgeStatus";
+import type { BridgeStatus } from "@/hooks/useBridgeStatus";
 import { apiPath } from "@/lib/api";
 
 /**
@@ -87,10 +87,20 @@ function writeDismissed() {
   }
 }
 
-export function FirstRunChecklist() {
+export function FirstRunChecklist({
+  bridgeStatus,
+}: {
+  /**
+   * Passed down from the page rather than calling useBridgeStatus() here
+   * directly — HomePage already polls /api/bridge/status via its own
+   * useBridgeStatus() instance; a second independent instance in this
+   * component would double real polling traffic on every page load where
+   * the checklist is visible (each instance opens its own fetch interval).
+   */
+  bridgeStatus: BridgeStatus;
+}) {
   const [status, setStatus] = useState<Status>(emptyStatus);
   const [dismissed, setDismissed] = useState(false);
-  const bridgeStatus = useBridgeStatus();
 
   useEffect(() => {
     setDismissed(readDismissed());

--- a/dashboard/src/components/__tests__/FirstRunChecklist.test.tsx
+++ b/dashboard/src/components/__tests__/FirstRunChecklist.test.tsx
@@ -134,6 +134,26 @@ describe("<FirstRunChecklist/>", () => {
     expect(c2.firstChild).toBeNull();
   });
 
+  it("suppresses itself when the bridge is unreachable (leaves it to BridgeOfflineBanner)", async () => {
+    // /api/bridge/status and /api/bridge/approvals both fail (no bridge
+    // running) — useBridgeStatus() should land on ok:false, degraded:false.
+    global.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url.includes("/api/bridge/status") || url.includes("/api/bridge/approvals")) {
+        return new Response("Service Unavailable", { status: 503 });
+      }
+      // Recipe/run/inbox/connection probes would all report "empty" too,
+      // since a real 503 from the proxy looks the same to probeArray().
+      return new Response("[]", {
+        headers: { "content-type": "application/json" },
+      });
+    }) as unknown as typeof fetch;
+    const { container } = render(<FirstRunChecklist />);
+    await waitFor(() => {
+      expect(container.firstChild).toBeNull();
+    });
+  });
+
   it("step CTAs link to the correct pages", async () => {
     global.fetch = makeFetch({
       "/api/bridge/recipes": { kind: "wrap", key: "recipes", arr: [] },

--- a/dashboard/src/components/__tests__/FirstRunChecklist.test.tsx
+++ b/dashboard/src/components/__tests__/FirstRunChecklist.test.tsx
@@ -4,13 +4,26 @@
  *   - first incomplete step is marked as "next" (data-state="next")
  *   - collapses when all 4 steps are complete
  *   - collapses when the user dismisses + persists across remounts
+ *
+ * bridgeStatus is passed in as a prop (not fetched internally) — see
+ * FirstRunChecklist.tsx's comment: a second independent useBridgeStatus()
+ * instance here would double real /api/bridge/status polling traffic
+ * alongside HomePage's own instance.
  */
 
 import { fireEvent, render, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { FirstRunChecklist } from "@/components/FirstRunChecklist";
+import type { BridgeStatus } from "@/hooks/useBridgeStatus";
 
 const originalFetch = global.fetch;
+
+const HEALTHY_STATUS: BridgeStatus = { ok: true };
+const UNREACHABLE_STATUS: BridgeStatus = {
+  ok: false,
+  degraded: false,
+  lastAttemptAt: Date.now(),
+};
 
 type Probe =
   | { kind: "arr"; arr: unknown[] }
@@ -48,7 +61,9 @@ describe("<FirstRunChecklist/>", () => {
       "/api/bridge/inbox": { kind: "wrap", key: "items", arr: [] },
       "/api/bridge/connections": { kind: "wrap", key: "connectors", arr: [] },
     });
-    const { findByText, container } = render(<FirstRunChecklist />);
+    const { findByText, container } = render(
+      <FirstRunChecklist bridgeStatus={HEALTHY_STATUS} />,
+    );
     expect(await findByText(/Get started/)).toBeInTheDocument();
     // Step 1 label is present
     expect(container.textContent).toMatch(/Install or create a recipe/);
@@ -65,7 +80,9 @@ describe("<FirstRunChecklist/>", () => {
       "/api/bridge/inbox": { kind: "wrap", key: "items", arr: [] },
       "/api/bridge/connections": { kind: "wrap", key: "connectors", arr: [] },
     });
-    const { findByText, container } = render(<FirstRunChecklist />);
+    const { findByText, container } = render(
+      <FirstRunChecklist bridgeStatus={HEALTHY_STATUS} />,
+    );
     await findByText(/Get started/);
     const items = container.querySelectorAll("li");
     // Step 1 done, step 2 is next
@@ -80,7 +97,9 @@ describe("<FirstRunChecklist/>", () => {
       "/api/bridge/inbox": { kind: "wrap", key: "items", arr: [] },
       "/api/bridge/connections": { kind: "wrap", key: "connectors", arr: [] },
     });
-    const { findByText, container } = render(<FirstRunChecklist />);
+    const { findByText, container } = render(
+      <FirstRunChecklist bridgeStatus={HEALTHY_STATUS} />,
+    );
     await findByText(/Get started/);
     const items = container.querySelectorAll("li");
     expect(items[2]?.getAttribute("data-state")).toBe("next");
@@ -93,7 +112,9 @@ describe("<FirstRunChecklist/>", () => {
       "/api/bridge/inbox": { kind: "wrap", key: "items", arr: [{ id: "i1" }] },
       "/api/bridge/connections": { kind: "wrap", key: "connectors", arr: [{ id: "gmail" }] },
     });
-    const { container } = render(<FirstRunChecklist />);
+    const { container } = render(
+      <FirstRunChecklist bridgeStatus={HEALTHY_STATUS} />,
+    );
     await waitFor(() => {
       expect(global.fetch).toHaveBeenCalled();
     });
@@ -109,7 +130,9 @@ describe("<FirstRunChecklist/>", () => {
       "/api/bridge/inbox": { kind: "wrap", key: "items", arr: [] },
       "/api/bridge/connections": { kind: "wrap", key: "connectors", arr: [] },
     });
-    const { container } = render(<FirstRunChecklist />);
+    const { container } = render(
+      <FirstRunChecklist bridgeStatus={HEALTHY_STATUS} />,
+    );
     expect(container.firstChild).toBeNull();
   });
 
@@ -120,14 +143,18 @@ describe("<FirstRunChecklist/>", () => {
       "/api/bridge/inbox": { kind: "wrap", key: "items", arr: [] },
       "/api/bridge/connections": { kind: "wrap", key: "connectors", arr: [] },
     });
-    const { findByRole, container, unmount } = render(<FirstRunChecklist />);
+    const { findByRole, container, unmount } = render(
+      <FirstRunChecklist bridgeStatus={HEALTHY_STATUS} />,
+    );
     const dismiss = await findByRole("button", {
       name: /dismiss first-run checklist/i,
     });
     fireEvent.click(dismiss);
     expect(container.firstChild).toBeNull();
     unmount();
-    const { container: c2 } = render(<FirstRunChecklist />);
+    const { container: c2 } = render(
+      <FirstRunChecklist bridgeStatus={HEALTHY_STATUS} />,
+    );
     await waitFor(() => {
       expect(global.fetch).toHaveBeenCalled();
     });
@@ -135,20 +162,15 @@ describe("<FirstRunChecklist/>", () => {
   });
 
   it("suppresses itself when the bridge is unreachable (leaves it to BridgeOfflineBanner)", async () => {
-    // /api/bridge/status and /api/bridge/approvals both fail (no bridge
-    // running) — useBridgeStatus() should land on ok:false, degraded:false.
-    global.fetch = vi.fn(async (input: RequestInfo | URL) => {
-      const url = typeof input === "string" ? input : input.toString();
-      if (url.includes("/api/bridge/status") || url.includes("/api/bridge/approvals")) {
-        return new Response("Service Unavailable", { status: 503 });
-      }
-      // Recipe/run/inbox/connection probes would all report "empty" too,
-      // since a real 503 from the proxy looks the same to probeArray().
-      return new Response("[]", {
-        headers: { "content-type": "application/json" },
-      });
-    }) as unknown as typeof fetch;
-    const { container } = render(<FirstRunChecklist />);
+    global.fetch = makeFetch({
+      "/api/bridge/recipes": { kind: "wrap", key: "recipes", arr: [] },
+      "/api/bridge/runs": { kind: "wrap", key: "runs", arr: [] },
+      "/api/bridge/inbox": { kind: "wrap", key: "items", arr: [] },
+      "/api/bridge/connections": { kind: "wrap", key: "connectors", arr: [] },
+    });
+    const { container } = render(
+      <FirstRunChecklist bridgeStatus={UNREACHABLE_STATUS} />,
+    );
     await waitFor(() => {
       expect(container.firstChild).toBeNull();
     });
@@ -161,7 +183,9 @@ describe("<FirstRunChecklist/>", () => {
       "/api/bridge/inbox": { kind: "wrap", key: "items", arr: [] },
       "/api/bridge/connections": { kind: "wrap", key: "connectors", arr: [] },
     });
-    const { findByText, container } = render(<FirstRunChecklist />);
+    const { findByText, container } = render(
+      <FirstRunChecklist bridgeStatus={HEALTHY_STATUS} />,
+    );
     await findByText(/Get started/);
     // All 4 steps have CTAs since nothing is done
     expect(container.querySelector('a[href="/marketplace"]')).not.toBeNull();

--- a/src/index.ts
+++ b/src/index.ts
@@ -107,6 +107,50 @@ const __dirnameTop = path.dirname(fileURLToPath(import.meta.url));
 const OPEN_VSX_PUBLISHER = "oolab-labs";
 const OPEN_VSX_NAME = "claude-ide-bridge-extension";
 
+/** True when running inside WSL (Windows Subsystem for Linux). */
+function detectWsl(): boolean {
+  return (
+    process.platform === "linux" &&
+    (process.env.WSL_DISTRO_NAME !== undefined ||
+      process.env.WSLENV !== undefined ||
+      (() => {
+        try {
+          return readFileSync("/proc/version", "utf-8")
+            .toLowerCase()
+            .includes("microsoft");
+        } catch {
+          return false;
+        }
+      })())
+  );
+}
+
+/**
+ * Actionable message for "no editor found on PATH" — the most common
+ * first-run cause is that VS Code IS installed but its `code` CLI shim was
+ * never added to PATH (macOS/Linux require running "Shell Command: Install
+ * 'code' command in PATH" from the Command Palette; this doesn't happen
+ * automatically). A bare "no editor found" error leaves a first-time user
+ * with no path forward.
+ */
+function editorNotFoundHint(): string {
+  const wslHint = detectWsl()
+    ? "WSL detected: ensure VS Code is installed on the Windows host and the\n" +
+      "Remote - WSL extension is active, then retry.\n" +
+      "Alternatively, pass the editor explicitly: claude-ide-bridge install-extension code\n\n"
+    : "";
+  return (
+    `No supported editor found on PATH (checked: code, cursor, windsurf, antigravity/ag).\n\n` +
+    `If VS Code is installed but not found, its 'code' CLI shim may not be on PATH:\n` +
+    `  1. Open VS Code\n` +
+    `  2. Cmd/Ctrl+Shift+P -> "Shell Command: Install 'code' command in PATH"\n` +
+    `  3. Re-run this command\n\n` +
+    wslHint +
+    `Or specify the editor command explicitly: claude-ide-bridge install-extension <code|cursor|windsurf>\n` +
+    `Or install manually: https://open-vsx.org/extension/${OPEN_VSX_PUBLISHER}/${OPEN_VSX_NAME}\n`
+  );
+}
+
 // CLAUDE.md versioned-block patching moved to ./claudeMdPatch.ts so tests
 // can import the helpers without triggering the top-level CLI side effects
 // at the bottom of this file. Re-exported here for back-compat.
@@ -3737,32 +3781,15 @@ Steps performed:
 
   process.stderr.write("Claude IDE Bridge — setup\n\n");
 
-  // WSL detection: warn early if running in WSL without a detected editor
-  const isWsl =
-    process.platform === "linux" &&
-    (process.env.WSL_DISTRO_NAME !== undefined ||
-      process.env.WSLENV !== undefined ||
-      (() => {
-        try {
-          return readFileSync("/proc/version", "utf-8")
-            .toLowerCase()
-            .includes("microsoft");
-        } catch {
-          return false;
-        }
-      })());
-
   // Step 1: Install extension
   const editor = findEditor();
   if (!editor) {
-    const wslHint = isWsl
-      ? "\n         WSL detected: ensure VS Code is installed on the Windows host and\n" +
-        "         the Remote - WSL extension is active. Then re-run init.\n" +
-        "         Alternatively, pass the editor explicitly: claude-ide-bridge install-extension code\n"
-      : "";
-    process.stderr.write(
-      `  [skip] Extension install — no supported editor found on PATH.\n         Install manually: https://open-vsx.org/extension/${OPEN_VSX_PUBLISHER}/${OPEN_VSX_NAME}\n${wslHint}\n`,
-    );
+    const indented = editorNotFoundHint()
+      .trimEnd()
+      .split("\n")
+      .map((line) => `         ${line}`)
+      .join("\n");
+    process.stderr.write(`  [skip] Extension install —\n${indented}\n\n`);
   } else {
     process.stderr.write(`  Installing extension into ${editor}...\n`);
     const __dirname2 = path.dirname(fileURLToPath(import.meta.url));
@@ -4381,9 +4408,7 @@ if (process.argv[2] === "orchestrator") {
   }
   const editor = process.argv[3] || findEditor();
   if (!editor) {
-    process.stderr.write(
-      "Error: No editor found. Specify the editor command: claude-ide-bridge install-extension <code|cursor|windsurf>\n",
-    );
+    process.stderr.write(`Error: ${editorNotFoundHint()}`);
     process.exit(1);
   }
 


### PR DESCRIPTION
## Summary
Found auditing the clean-machine (first-time-user) startup path — no `~/.claude` dir, no lock files, first `install-extension`/dashboard load.

- **`install-extension` / `init`'s inline install step** (`src/index.ts`): when `findEditor()` finds nothing, the error was a bare "no editor found" with no explanation of the actual common cause. On a genuinely fresh machine, VS Code is very often installed but its `code` CLI shim was never added to PATH — that requires manually running "Shell Command: Install 'code' command in PATH" from the Command Palette, which doesn't happen automatically on install. Added a shared `editorNotFoundHint()` (with the actual fix steps, WSL guidance, and the Open VSX manual-install fallback) used by both call sites, replacing two independent ad-hoc messages that had already drifted from each other.
- **Dashboard `FirstRunChecklist`**: `probeArray()` treats a `503` ("no bridge running") identically to "bridge reachable, zero items" (catches all fetch failures → returns `0`). A first-time user with no bridge running saw a misleading "Get started · 0 of 4 done" checklist whose CTAs (Browse marketplace, Open recipes, etc.) all led to more silent "unavailable" dead ends, with nothing telling them the actual problem. `BridgeOfflineBanner` (in `Shell.tsx`) already correctly surfaces "Bridge offline" + `patchwork start --port <N>` — the checklist now checks `useBridgeStatus()` and suppresses itself when the bridge is confirmed unreachable, instead of rendering a contradictory/misleading state alongside that banner.

## Test plan
- [x] `npx vitest run src/components/__tests__/FirstRunChecklist.test.tsx` — 8/8 (1 new: suppresses when bridge unreachable)
- [x] `npx vitest run src/hooks/__tests__/useBridgeStatus.test.tsx src/components/__tests__/BridgeOfflineBanner.test.tsx` — unaffected, still green
- [x] `npx vitest run src/__tests__/config.test.ts` (root) — unaffected, still green
- [x] `npx tsc --noEmit` clean (root + dashboard)
- [x] `npx biome check` clean
- [x] Manually rendered both new error-message call sites to confirm formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)