### PR TITLE
fix(bridge): oversized-lock cleanup no longer bypasses PID liveness

### DIFF
--- a/src/__tests__/lockfile.test.ts
+++ b/src/__tests__/lockfile.test.ts
@@ -240,4 +240,67 @@ describe("LockFileManager", () => {
       });
     }
   });
+
+  // ─── Oversized lock file (size guard must not bypass liveness check) ──────
+  // A multi-root workspace with many long folder paths in workspaceFolders
+  // can legitimately produce a lock file over 4096 bytes. The size guard
+  // must not delete it purely for being large — it must fall back to the
+  // same PID-liveness logic used everywhere else in cleanStale().
+  it("cleanStale removes an oversized lock file with a dead PID", () => {
+    const ideDir = path.join(tmpDir, "ide");
+    fs.mkdirSync(ideDir, { recursive: true, mode: 0o700 });
+
+    const bigWorkspaceFolders = Array.from(
+      { length: 200 },
+      (_, i) => `/some/long/workspace/folder/path/number-${i}`,
+    );
+    const oversizedDeadPath = path.join(ideDir, "44441.lock");
+    const content = JSON.stringify({
+      pid: 999999, // dead
+      workspaceFolders: bigWorkspaceFolders,
+    });
+    expect(Buffer.byteLength(content)).toBeGreaterThan(4096);
+    fs.writeFileSync(oversizedDeadPath, content, { mode: 0o600 });
+
+    const mgr = new LockFileManager(logger);
+    mgr.cleanStale();
+
+    expect(fs.existsSync(oversizedDeadPath)).toBe(false);
+  });
+
+  it("cleanStale keeps an oversized lock file with a live PID (legit large multi-root workspace)", () => {
+    const ideDir = path.join(tmpDir, "ide");
+    fs.mkdirSync(ideDir, { recursive: true, mode: 0o700 });
+
+    const bigWorkspaceFolders = Array.from(
+      { length: 200 },
+      (_, i) => `/some/long/workspace/folder/path/number-${i}`,
+    );
+    const oversizedLivePath = path.join(ideDir, "44442.lock");
+    const content = JSON.stringify({
+      pid: process.pid, // alive
+      workspaceFolders: bigWorkspaceFolders,
+    });
+    expect(Buffer.byteLength(content)).toBeGreaterThan(4096);
+    fs.writeFileSync(oversizedLivePath, content, { mode: 0o600 });
+
+    const mgr = new LockFileManager(logger);
+    mgr.cleanStale();
+
+    expect(fs.existsSync(oversizedLivePath)).toBe(true);
+  });
+
+  it("cleanStale removes an oversized lock file that isn't valid JSON", () => {
+    const ideDir = path.join(tmpDir, "ide");
+    fs.mkdirSync(ideDir, { recursive: true, mode: 0o700 });
+
+    const oversizedGarbagePath = path.join(ideDir, "44443.lock");
+    const garbage = "x".repeat(5000);
+    fs.writeFileSync(oversizedGarbagePath, garbage, { mode: 0o600 });
+
+    const mgr = new LockFileManager(logger);
+    mgr.cleanStale();
+
+    expect(fs.existsSync(oversizedGarbagePath)).toBe(false);
+  });
 });

--- a/src/lockfile.ts
+++ b/src/lockfile.ts
@@ -129,6 +129,39 @@ export class LockFileManager {
             continue;
           }
           if (stat.size > 4096) {
+            // A multi-root workspace with many long folder paths in
+            // workspaceFolders can legitimately exceed 4096 bytes — don't
+            // delete a live sibling's lock based on size alone (every other
+            // branch in this function checks PID liveness first). Only treat
+            // it as garbage if it doesn't parse as valid JSON with a live PID.
+            let keep = false;
+            try {
+              const raw = fs.readFileSync(filePath, "utf-8");
+              const content = JSON.parse(raw);
+              if (
+                typeof content.pid === "number" &&
+                Number.isInteger(content.pid) &&
+                content.pid > 0
+              ) {
+                try {
+                  process.kill(content.pid, 0);
+                  keep = true;
+                } catch (killErr) {
+                  // EPERM: process exists but we lack permission to signal it
+                  // (cross-user/elevated) — assume a legitimate live sibling.
+                  // ESRCH or anything else: dead, fall through to delete.
+                  keep = (killErr as NodeJS.ErrnoException).code === "EPERM";
+                }
+              }
+            } catch {
+              // unparseable — fall through to delete as oversized garbage
+            }
+            if (keep) {
+              this.logger.debug(
+                `Oversized but valid lock file, keeping: ${file} (${stat.size} bytes)`,
+              );
+              continue;
+            }
             this.logger.warn(
               `Removing oversized lock file: ${file} (${stat.size} bytes)`,
             );


### PR DESCRIPTION
## Summary
- `LockFileManager.cleanStale()` (`src/lockfile.ts`) unconditionally unlinked any lock file over 4096 bytes before ever checking whether its owning PID was alive — the only branch in the function that skipped the liveness check every other branch relies on.
- A multi-root workspace with many long folder paths in `workspaceFolders` can legitimately produce a lock file over 4096 bytes (confirmed: 200 folders at ~50 chars each exceeds it easily). This guard could delete a live sibling bridge's coordination file purely for being large, unlike the rest of the function which is careful to check `process.kill(pid, 0)` first.
- Fixed by falling back to the same liveness logic used elsewhere in `cleanStale()`: an oversized file is now only deleted if it doesn't parse as valid JSON with a live PID (EPERM still treated as alive, per the existing cross-user/elevated-process handling).

Found while mining startup/connection bugs (companion fixes: #1167, #1168, #1169).

## Test plan
- [x] `npx vitest run src/__tests__/lockfile.test.ts` — 12/12 (3 new: oversized+dead PID removed, oversized+live PID kept, oversized+unparseable removed)
- [x] `npx tsc --noEmit` clean
- [x] `npx biome check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)