### PR TITLE
fix(supervisor): --watch no longer crashes when the child can't spawn at all

### DIFF
--- a/src/__tests__/bridge-supervisor.test.ts
+++ b/src/__tests__/bridge-supervisor.test.ts
@@ -302,6 +302,66 @@ child.on('exit', () => {
     expect(allOutput).toContain("[supervisor] bridge stopped");
     expect(allOutput).not.toContain("unexpected restart");
   }, 10_000);
+
+  // Regression: spawn() failing entirely (ENOENT — binary moved/deleted
+  // between restarts, permission denied) emits 'error', not 'exit'. Without
+  // an 'error' handler, Node re-throws it as an unhandled 'error' event and
+  // crashes the whole supervisor process — the restart/backoff logic never
+  // runs, so --watch silently stops auto-restarting. This mirrors the real
+  // fix in src/index.ts's runChild(): both 'error' and 'exit' route through
+  // the same restart() function, guarded against firing twice.
+  it("supervisor restarts (does not crash) when the child binary can't be spawned at all", async () => {
+    const scriptDir = fs.mkdtempSync(path.join(os.tmpdir(), "bridge-sup-"));
+    tmpDirs.push(scriptDir);
+
+    const supervisorPath = path.join(scriptDir, "supervisor.mjs");
+    fs.writeFileSync(
+      supervisorPath,
+      `
+import { spawn } from 'node:child_process';
+
+const BASE_DELAY_MS = 50;
+const MAX_DELAY_MS = 200;
+let delay = BASE_DELAY_MS;
+let runs = 0;
+
+function runChild() {
+  runs++;
+  if (runs > 2) { process.stderr.write('[supervisor] giving up\\n'); process.exit(0); }
+  process.stderr.write('[supervisor] starting bridge\\n');
+  const child = spawn('/definitely/does/not/exist-xyz', [], { stdio: 'inherit' });
+  let handled = false;
+  const restart = (reason) => {
+    if (handled) return;
+    handled = true;
+    process.stderr.write('[supervisor] ' + reason + ', restarting in ' + (delay / 1000) + 's\\n');
+    setTimeout(() => { delay = Math.min(delay * 2, MAX_DELAY_MS); runChild(); }, delay);
+  };
+  child.on('error', (err) => restart('bridge failed to start (' + err.message + ')'));
+  child.on('exit', (code, signal) => restart('bridge exited (code=' + (code ?? signal) + ')'));
+}
+runChild();
+`,
+      "utf-8",
+    );
+
+    const proc = spawn(process.execPath, [supervisorPath], {
+      stdio: ["ignore", "ignore", "pipe"],
+    });
+    const lines = await collectStderr(proc, 3000);
+    const exitCode = await new Promise<number | null>((resolve) => {
+      if (proc.exitCode !== null) return resolve(proc.exitCode);
+      proc.on("exit", (code) => resolve(code));
+    });
+
+    const output = lines.join("\n");
+    // The supervisor process itself must not crash with an unhandled
+    // 'error' exception — it should log and retry, then give up cleanly.
+    expect(exitCode).toBe(0);
+    expect(output).toContain("bridge failed to start");
+    expect(output).toContain("giving up");
+    expect(output).not.toContain("Unhandled 'error' event");
+  }, 5000);
 });
 
 // ── Regression: orchestrator subcommand must not fall through to parseConfig ──

--- a/src/index.ts
+++ b/src/index.ts
@@ -5198,7 +5198,17 @@ if (__subcommandWillRun) {
         });
       }
 
-      child.on("exit", (code, signal) => {
+      // A failed spawn (e.g. ENOENT — binary moved/deleted between restarts,
+      // permission denied) emits 'error', NOT 'exit'. Without this handler
+      // Node re-throws it as an unhandled 'error' event and kills the whole
+      // supervisor process — the restart/backoff logic below never runs, so
+      // --watch silently stops auto-restarting instead of retrying. Guard
+      // against a double-restart in the rare case both 'error' and 'exit'
+      // fire for the same failure.
+      let handled = false;
+      const restart = (reason: string) => {
+        if (handled) return;
+        handled = true;
         if (stopping) {
           process.stderr.write("[supervisor] bridge stopped\n");
           process.exit(0);
@@ -5208,12 +5218,19 @@ if (__subcommandWillRun) {
           delay = BASE_DELAY_MS; // reset backoff after a stable run
         }
         process.stderr.write(
-          `[supervisor] bridge exited (code=${code ?? signal}), restarting in ${delay / 1000}s\n`,
+          `[supervisor] ${reason}, restarting in ${delay / 1000}s\n`,
         );
         setTimeout(() => {
           delay = Math.min(delay * 2, MAX_DELAY_MS);
           runChild();
         }, delay);
+      };
+
+      child.on("error", (err) => {
+        restart(`bridge failed to start (${err.message})`);
+      });
+      child.on("exit", (code, signal) => {
+        restart(`bridge exited (code=${code ?? signal})`);
       });
     }
 


### PR DESCRIPTION
## Summary
- `patchwork start --watch`'s supervisor (`src/index.ts` `runChild()`) only listened for the child's `'exit'` event. A `spawn()` failure where the child process never actually launches (ENOENT — binary moved/deleted between restarts, e.g. an `nvm` version bump or global reinstall changing the resolved path; or a permission error) emits `'error'`, not `'exit'`.
- Without an `'error'` listener, Node re-throws it as an unhandled `'error'` event, which crashes the **entire supervisor process** — the exit handler's restart/backoff logic never runs at all. The documented 2s→30s auto-restart silently stops working the first time this happens, with no further retries until the user notices and manually relaunches.
- Verified empirically (`spawn('/nonexistent/binary', [])` with only an `'exit'` listener throws `Unhandled 'error' event` and kills the process).
- Fix: both `'error'` and `'exit'` now route through the same `restart()` function, guarded with a `handled` flag against double-restarting in the rare case both events fire for one failure.

Found while mining startup/connection bugs (companion fixes: #1167, #1168, #1169, #1170).

## Test plan
- [x] `npx vitest run src/__tests__/bridge-supervisor.test.ts` — 6/7 passing, 1 skipped (Windows-only, pre-existing skip) — 1 new test spawning a nonexistent binary, asserting the supervisor logs + retries instead of crashing
- [x] `npx tsc --noEmit` clean
- [x] `npx biome check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)