### PR TITLE
fix(extension): validate --workspace arg before shell:true bridge spawn

### DIFF
--- a/vscode-extension/src/__tests__/bridgeProcess.test.ts
+++ b/vscode-extension/src/__tests__/bridgeProcess.test.ts
@@ -43,7 +43,7 @@ vi.mock("node:child_process", async (importOriginal) => {
 });
 
 import * as vscode from "vscode";
-import { BridgeProcess } from "../bridgeProcess";
+import { BridgeProcess, validateShellArgs } from "../bridgeProcess";
 
 let tmpDir: string;
 let output: {
@@ -418,5 +418,44 @@ describe("BridgeProcess — fixed port", () => {
     const spawnCalls = vi.mocked(spawn).mock.calls;
     const args = spawnCalls[spawnCalls.length - 1]![1] as string[];
     expect(args).not.toContain("--port");
+  });
+});
+
+// ── validateShellArgs (Windows shell:true injection guard) ────────────────
+//
+// The .cmd-wrapper spawn path uses shell:true, under which Node's own docs
+// warn array-form argument escaping isn't guaranteed complete for every
+// shell metacharacter. --workspace carries a user-controlled path (could
+// contain "&", "%", etc. on Windows from an unusual folder/username) — this
+// validates it the same way validateBinaryPath already validates the binary.
+describe("validateShellArgs", () => {
+  // SHELL_METACHARACTERS is a module-level constant frozen at import time
+  // from the real process.platform — it can't be exercised for both
+  // platform variants in one test run, so these tests cover the rules that
+  // hold on every platform (the metacharacter set minus backslash, which is
+  // POSIX-only per validateBinaryPath's existing platform split).
+  it("does not throw for ordinary paths, including ones with spaces", () => {
+    expect(() =>
+      validateShellArgs(["--workspace", "/Users/John Smith/Projects/Foo"]),
+    ).not.toThrow();
+  });
+
+  it("throws when an argument contains a shell metacharacter", () => {
+    expect(() =>
+      validateShellArgs(["--workspace", "/Users/evil/Foo & Bar"]),
+    ).toThrow(/shell metacharacters/);
+  });
+
+  it("throws on each of the blocked metacharacters", () => {
+    for (const ch of [";", "&", "|", "`", "$", "(", ")", "<", ">", '"', "'"]) {
+      expect(
+        () => validateShellArgs([`some${ch}value`]),
+        `expected "${ch}" to be rejected`,
+      ).toThrow();
+    }
+  });
+
+  it("does not throw when no args are passed", () => {
+    expect(() => validateShellArgs([])).not.toThrow();
   });
 });

--- a/vscode-extension/src/bridgeProcess.ts
+++ b/vscode-extension/src/bridgeProcess.ts
@@ -37,6 +37,26 @@ function validateBinaryPath(binaryPath: string): void {
 }
 
 /**
+ * Validate spawn arguments when shell:true is used (Windows .cmd wrappers).
+ * Node's array-form argument escaping for shell:true is not guaranteed
+ * complete for every shell metacharacter (the Node docs explicitly warn
+ * against passing unsanitized input under shell:true) — an argument like
+ * the workspace path could otherwise carry a `&`/`%`/etc. straight into
+ * cmd.exe's command line. This only fires under shell:true; the plain
+ * spawn(shell:false) path is not subject to shell interpretation at all.
+ * @throws Error if any arg contains shell metacharacters
+ */
+export function validateShellArgs(args: string[]): void {
+  for (const arg of args) {
+    if (SHELL_METACHARACTERS.test(arg)) {
+      throw new Error(
+        `Argument contains shell metacharacters (potential injection under shell:true): ${arg}`,
+      );
+    }
+  }
+}
+
+/**
  * Normalize a workspace path for cross-platform comparison: resolve it,
  * convert backslashes to forward slashes, and (on Windows only) lowercase
  * it — NTFS paths are case-insensitive but VS Code / a terminal-spawned
@@ -391,6 +411,19 @@ export class BridgeProcess {
     // with ENOENT even though the path is valid.
     const needsShell =
       process.platform === "win32" && binary.toLowerCase().endsWith(".cmd");
+
+    if (needsShell) {
+      try {
+        validateShellArgs(spawnArgs);
+      } catch (err) {
+        const msg = `Bridge spawn blocked: ${err instanceof Error ? err.message : String(err)}`;
+        this.log(msg);
+        await this.releaseSentinel();
+        this.onStartupFailed?.(msg);
+        return;
+      }
+    }
+
     const child = spawn(binary, spawnArgs, {
       stdio: ["ignore", "pipe", "pipe"],
       detached: false,


### PR DESCRIPTION
## Summary
- `BridgeProcess.spawn()` (`vscode-extension/src/bridgeProcess.ts`) validates the resolved binary path for shell metacharacters (`validateBinaryPath`) before executing under `shell:true` (needed for `.cmd` wrappers on Windows npm global installs) — but the `--workspace` argument passed alongside it in the same spawn call was never validated.
- Node's own `child_process` docs warn that array-form argument escaping under `shell:true` is not guaranteed complete for every shell metacharacter (this is the class of bug behind several past Node CVEs for Windows `child_process`). A workspace path containing `&`, `%`, etc. — plausible on a fresh Windows machine with an unusual folder name or a username like "John Smith & Co" — could misbehave when it reaches cmd.exe unescaped.
- Fix: `validateShellArgs()` applies the same metacharacter check already used for the binary path, scoped to only run when `needsShell` is actually true — the plain `spawn(shell:false)` path (the common case, non-`.cmd` binaries) isn't subject to shell interpretation at all and doesn't need it.

Found while mining startup/connection bugs (companion fixes: #1167, #1168, #1169, #1170, #1171).

## Test plan
- [x] `npx vitest run src/__tests__/bridgeProcess.test.ts` — 20/20 (4 new: ordinary paths incl. spaces pass, metacharacter-bearing args rejected, each blocked metacharacter individually verified, empty-args no-op)
- [x] `npx tsc --noEmit` clean
- [x] `npx biome check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)