### PR TITLE
fix(bridge): don't accept sessions until plugin loading finishes

### DIFF
--- a/src/__tests__/bridge-activation-metrics.test.ts
+++ b/src/__tests__/bridge-activation-metrics.test.ts
@@ -16,8 +16,8 @@ const yamlRunnerModule = await vi.hoisted(async () => ({
 }));
 
 const pluginLoaderModule = await vi.hoisted(async () => ({
-  loadPlugins: vi.fn(async () => []),
-  loadPluginsFull: vi.fn(async () => []),
+  loadPlugins: vi.fn(async (): Promise<unknown[]> => []),
+  loadPluginsFull: vi.fn(async (): Promise<unknown[]> => []),
 }));
 
 vi.mock("../activationMetrics.js", () => activationMetricsModule);
@@ -248,7 +248,7 @@ describe("Bridge activation metrics", () => {
     let resolveLoadPlugins!: (tools: unknown[]) => void;
     pluginLoaderModule.loadPlugins.mockImplementation(
       () =>
-        new Promise((resolve) => {
+        new Promise<unknown[]>((resolve) => {
           resolveLoadPlugins = resolve;
         }),
     );

--- a/src/__tests__/bridge-activation-metrics.test.ts
+++ b/src/__tests__/bridge-activation-metrics.test.ts
@@ -15,6 +15,11 @@ const yamlRunnerModule = await vi.hoisted(async () => ({
   buildChainedDeps: vi.fn(() => ({})),
 }));
 
+const pluginLoaderModule = await vi.hoisted(async () => ({
+  loadPlugins: vi.fn(async () => []),
+  loadPluginsFull: vi.fn(async () => []),
+}));
+
 vi.mock("../activationMetrics.js", () => activationMetricsModule);
 vi.mock("../bridgeToken.js", () => ({
   loadOrCreateBridgeToken: vi.fn(() => "bridge-test-token"),
@@ -26,8 +31,8 @@ vi.mock("../probe.js", () => ({
   probeAll: vi.fn(async () => ({})),
 }));
 vi.mock("../pluginLoader.js", () => ({
-  loadPlugins: vi.fn(async () => []),
-  loadPluginsFull: vi.fn(async () => []),
+  loadPlugins: pluginLoaderModule.loadPlugins,
+  loadPluginsFull: pluginLoaderModule.loadPluginsFull,
 }));
 vi.mock("../bridgeToolsRules.js", () => ({
   repairBridgeToolsRulesIfStale: vi.fn(),
@@ -117,6 +122,10 @@ describe("Bridge activation metrics", () => {
       trigger: { type: "manual" },
       steps: [],
     });
+    pluginLoaderModule.loadPlugins.mockReset();
+    pluginLoaderModule.loadPlugins.mockImplementation(async () => []);
+    pluginLoaderModule.loadPluginsFull.mockReset();
+    pluginLoaderModule.loadPluginsFull.mockImplementation(async () => []);
   });
 
   afterEach(() => {
@@ -230,6 +239,38 @@ describe("Bridge activation metrics", () => {
 
       expect(yamlRunnerModule.dispatchRecipe).toHaveBeenCalledTimes(1);
       expect(activationMetricsModule.recordRecipeRun).not.toHaveBeenCalled();
+    } finally {
+      await bridge.stop();
+    }
+  });
+
+  it("does not report ready until plugin loading resolves (regression: sessions could connect before plugin tools were registered)", async () => {
+    let resolveLoadPlugins!: (tools: unknown[]) => void;
+    pluginLoaderModule.loadPlugins.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveLoadPlugins = resolve;
+        }),
+    );
+
+    const workspace = fs.mkdtempSync(path.join(tempDir, "workspace-ready-"));
+    const bridge = new Bridge(makeConfig(workspace));
+
+    try {
+      const startPromise = bridge.start();
+
+      // Let start() run up to (and block on) the loadPlugins() await, without
+      // letting it resolve yet. A few microtask turns is enough since nothing
+      // between probeAll() and loadPlugins() awaits anything real.
+      for (let i = 0; i < 5; i++) {
+        await Promise.resolve();
+      }
+      expect((bridge as unknown as { ready: boolean }).ready).toBe(false);
+
+      resolveLoadPlugins([]);
+      await startPromise;
+
+      expect((bridge as unknown as { ready: boolean }).ready).toBe(true);
     } finally {
       await bridge.stop();
     }

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -1044,11 +1044,17 @@ export class Bridge {
 
     // 1. Probe available CLI tools (pass workspace so local node_modules/.bin is checked)
     this.probes = await probeAll(this.config.workspace);
-    this.ready = true;
 
     this.tokenUsageTracker.start();
 
-    // 2. Load plugins (after probes, before accepting sessions)
+    // 2. Load plugins (after probes, before accepting sessions). this.ready
+    // is NOT set until after this resolves — it's the gate the WS connection
+    // handler checks before accepting a session (see the `if (!this.ready)`
+    // guard above), and the /ready HTTP endpoint reports on it too. Setting
+    // it earlier (as this code used to) let a client connect and receive a
+    // fully-initialized session whose tools/list was silently missing every
+    // plugin tool, for as long as the plugin's register()/import took to
+    // resolve — worse the slower the plugin.
     this.pluginTools = await loadPlugins(
       this.config.plugins,
       this.config,
@@ -1070,6 +1076,8 @@ export class Bridge {
         `[plugin-watch] Watching ${loadedPlugins.length} plugin director${loadedPlugins.length === 1 ? "y" : "ies"}`,
       );
     }
+
+    this.ready = true;
 
     const probes = this.probes;
     const probeList = (keys?: string[]) =>


### PR DESCRIPTION
## Summary
- `Bridge.start()` set `this.ready = true` immediately after `probeAll()`, **before** awaiting `loadPlugins()`. The WS connection handler's readiness gate (`if (!this.ready) { ws.close(1013, ...); return; }`) only checks `this.ready` — it doesn't know plugin loading is still in flight.
- Concrete failure: on a bridge configured with one or more `--plugin` entries, a client connecting in the window between `probeAll()` resolving and `loadPlugins()` resolving gets a fully-initialized session whose `tools/list` silently omits every plugin tool — worse the slower the plugin's `register()`/import is (npm-resolved plugin, disk I/O, etc.). This contradicted the ordering the adjacent comment already claimed ("loaded after CLI probes, before sessions accepted") without the code actually enforcing it.
- Fix: `this.ready = true` moved to after plugin loading (and plugin-watch setup) completes. The `/ready` HTTP endpoint, which also reads `this.ready`, now correctly reports not-ready during plugin load too.

Found while mining startup/connection bugs (companion fixes: #1167-#1172).

## Test plan
- [x] `npx vitest run src/__tests__/bridge-activation-metrics.test.ts` — 6/6 (1 new regression test using a controllable deferred `loadPlugins()` promise, asserting `bridge.ready` stays `false` until it resolves)
- [x] Confirmed the new test fails on the pre-fix code (reverted `bridge.ts` locally, test failed with `expected true to be false`) and passes with the fix
- [x] `npx vitest run` on pluginLoader/pluginWatcher/streamableHttpToolRegistration/bridge-real-session-resumption — 39/39, unaffected
- [x] `npx tsc --noEmit` clean
- [x] `npx biome check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)