### PR TITLE
fix(bridge): reset extensionProtocolMismatch on connection replace

### DIFF
--- a/src/__tests__/extensionClient.test.ts
+++ b/src/__tests__/extensionClient.test.ts
@@ -425,6 +425,50 @@ describe("ExtensionClient", () => {
     ws.close();
   });
 
+  it("replacing a mismatched connection resets extensionProtocolMismatch (clean slate for the new connection)", async () => {
+    // Regression: the replace-connection branch in handleExtensionConnection()
+    // never fires handleDisconnect() for the old socket (its listeners are
+    // removed before terminate(), so 'close' never fires) — handleDisconnect
+    // is the only other place extensionProtocolMismatch was reset, alongside
+    // a fresh (non-mismatched) "hello". Without resetting it on replace too,
+    // a version-compatible reconnect stayed marked unavailable until its own
+    // hello was processed.
+    const firstConn = new Promise<WebSocket>((resolve) => {
+      wss.once("connection", resolve);
+    });
+    const ws1 = new WebSocket(`ws://127.0.0.1:${port}`);
+    await waitForOpen(ws1);
+    const serverWs1 = await firstConn;
+    client.handleExtensionConnection(serverWs1);
+
+    ws1.send(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        method: "extension/hello",
+        params: { extensionVersion: "99.0.0", vscodeVersion: "1.85.0" },
+      }),
+    );
+    await new Promise((r) => setTimeout(r, 50));
+    expect(client.isConnected()).toBe(false); // marked unavailable by mismatch
+
+    // A second extension connects and replaces the first — before it has a
+    // chance to send its own "hello".
+    const secondConn = new Promise<WebSocket>((resolve) => {
+      wss.once("connection", resolve);
+    });
+    const ws2 = new WebSocket(`ws://127.0.0.1:${port}`);
+    await waitForOpen(ws2);
+    const serverWs2 = await secondConn;
+    client.handleExtensionConnection(serverWs2);
+
+    // Fresh connection, no hello processed yet — must not still be marked
+    // unavailable by the PREVIOUS connection's mismatch.
+    expect(client.isConnected()).toBe(true);
+
+    ws1.close();
+    ws2.close();
+  });
+
   it("disconnect() does not fire onExtensionDisconnected (spurious-callback fix)", async () => {
     const serverConn = new Promise<WebSocket>((resolve) => {
       wss.on("connection", resolve);

--- a/src/extensionClient.ts
+++ b/src/extensionClient.ts
@@ -222,6 +222,14 @@ export class ExtensionClient {
     this.extensionFailureTimes = [];
     this.extensionHalfOpen = false;
     this.lastRttMs = null;
+    // Also reset the protocol-mismatch gate: on the replace-connection path
+    // above, the old socket's close event never fires (listeners removed),
+    // so handleDisconnect() — the only other place this resets — never runs
+    // for it. Without this, a previously-mismatched connection's stale
+    // extensionProtocolMismatch=true would make isAvailable() report false
+    // for a freshly reconnected (possibly now version-compatible) extension
+    // until its next "hello" is processed.
+    this.extensionProtocolMismatch = false;
 
     this.logger.info("Extension client connected");
 


### PR DESCRIPTION
## Summary
- `handleExtensionConnection()`'s replace-connection branch (when a new extension WS connects while one is already active) resets the circuit breaker (`extensionSuspendedUntil`, `extensionFailureTimes`, `extensionHalfOpen`, `lastRttMs`) for the fresh connection — but not `extensionProtocolMismatch`.
- The old socket's `close` event never fires on that path (its listeners are removed before `terminate()` — see the existing comment on that code), so `handleDisconnect()` never runs for it. `handleDisconnect()` is the only other place `extensionProtocolMismatch` gets reset, alongside a fresh non-mismatched `extension/hello`.
- Concrete effect: once a connection has been marked mismatched (`extensionProtocolMismatch = true`), a subsequent reconnect that *replaces* that connection (rather than going through a clean disconnect first — e.g. extension restart, VS Code reload, a flaky/tunneled connection opening a new socket before the OS tears down the old half-open one) inherits the stale `true` value. `isConnected()` (which gates `extensionRequired` tools) keeps reporting `false` for the new — possibly now version-compatible — connection until its own `hello` is processed, contradicting the "fresh connection deserves a clean slate" comment two lines above the existing resets.
- Fix: reset `extensionProtocolMismatch = false` alongside the other per-connection resets in the replace-connection path.

Found while mining startup/connection bugs (companion fixes: #1167-#1173).

## Test plan
- [x] `npx vitest run src/__tests__/extensionClient.test.ts` — 22/22 (1 new regression test: mismatch a connection, replace it, assert the new connection isn't still gated)
- [x] Confirmed the new test fails on the pre-fix code (`expected false to be true`) and passes with the fix
- [x] `npx vitest run src/__tests__/transport.test.ts` — 45/45, unaffected
- [x] `npx tsc --noEmit` clean
- [x] `npx biome check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)