### PR TITLE
fix(recipes): re-check kill switch immediately before each connector write

### DIFF
--- a/src/recipes/tools/__tests__/slack.killswitch.test.ts
+++ b/src/recipes/tools/__tests__/slack.killswitch.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Regression: connector write tools (Slack, Notion, HubSpot, Datadog,
+ * Confluence, Zendesk, Intercom) checked the kill switch once at the top of
+ * execute(), then did an async import()/token-load before their actual
+ * network write, with no re-check in between. An operator engaging the
+ * kill switch specifically because a run is misbehaving would not stop a
+ * write that had already passed its initial check — the "fail-closed
+ * emergency brake" framing didn't hold for genuinely in-flight operations.
+ *
+ * Fixed by adding a second assertWriteAllowed() call immediately before
+ * each connector's network call. This test simulates the kill switch
+ * flipping ON during the async gap (import + token load) and asserts the
+ * write never reaches the network.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { clearRegistry, executeTool } from "../../toolRegistry.js";
+import type { RunContext, StepDeps } from "../../yamlRunner.js";
+
+const KILL_SWITCH_ENV = "PATCHWORK_FLAG_KILL_SWITCH_WRITES";
+
+vi.mock("../../../connectors/slack.js", () => ({
+  loadTokens: vi.fn(() => {
+    // Simulate the kill switch being engaged during the async gap between
+    // the first assertWriteAllowed() check and the network call — e.g. an
+    // operator hits the emergency stop right as this run's import()/
+    // token-load was in flight.
+    process.env[KILL_SWITCH_ENV] = "1";
+    return {
+      access_token: "xoxb-test",
+      team_id: "T1",
+      team_name: "Acme",
+      bot_user_id: "U1",
+      connected_at: "2026-01-01T00:00:00Z",
+    };
+  }),
+  postMessage: vi.fn().mockResolvedValue({ ts: "1.0", channel: "C1" }),
+}));
+
+const dummyContext = {
+  params: { channel: "general", text: "hi" },
+  step: {},
+  ctx: { env: {}, steps: {} } as unknown as RunContext,
+  deps: {} as StepDeps,
+};
+
+describe("recipe tool slack.post_message — kill-switch re-check before network write", () => {
+  beforeEach(async () => {
+    clearRegistry();
+    delete process.env[KILL_SWITCH_ENV];
+    await import("../slack.js"); // registers "slack.post_message" as a side effect
+  });
+
+  afterEach(() => {
+    delete process.env[KILL_SWITCH_ENV];
+    clearRegistry();
+    vi.clearAllMocks();
+  });
+
+  it("blocks the write and never calls postMessage when the kill switch engages between the first check and the network call", async () => {
+    const { postMessage } = await import("../../../connectors/slack.js");
+
+    await expect(
+      executeTool("slack.post_message", dummyContext),
+    ).rejects.toThrow(/Write operation blocked by kill switch/);
+
+    expect(postMessage).not.toHaveBeenCalled();
+  });
+});

--- a/src/recipes/tools/confluence.ts
+++ b/src/recipes/tools/confluence.ts
@@ -157,6 +157,9 @@ registerTool({
       "../../connectors/confluence.js"
     );
     const connector = getConfluenceConnector();
+    // Re-check immediately before the network write: the kill switch may
+    // have been engaged during the import() above.
+    assertWriteAllowed("confluence.createPage");
     const page = await connector.createPage({
       spaceId: params.spaceId as string,
       title: params.title as string,
@@ -211,6 +214,9 @@ registerTool({
       "../../connectors/confluence.js"
     );
     const connector = getConfluenceConnector();
+    // Re-check immediately before the network write: the kill switch may
+    // have been engaged during the import() above.
+    assertWriteAllowed("confluence.appendToPage");
     const page = await connector.appendToPage(
       params.pageId as string,
       params.content as string,

--- a/src/recipes/tools/datadog.ts
+++ b/src/recipes/tools/datadog.ts
@@ -211,6 +211,9 @@ registerTool({
     assertWriteAllowed("datadog.muteMonitor");
     const { getDatadogConnector } = await import("../../connectors/datadog.js");
     const connector = getDatadogConnector();
+    // Re-check immediately before the network write: the kill switch may
+    // have been engaged during the import() above.
+    assertWriteAllowed("datadog.muteMonitor");
     const monitor = await connector.muteMonitor(
       params.monitorId as number,
       typeof params.end === "number" ? params.end : undefined,

--- a/src/recipes/tools/http.ts
+++ b/src/recipes/tools/http.ts
@@ -150,6 +150,9 @@ registerTool({
       60_000,
     );
 
+    // Re-check immediately before the network write: the kill switch may
+    // have been engaged during the SSRF/URL validation above.
+    assertWriteAllowed("http.post");
     const ctrl = new AbortController();
     const timer = setTimeout(() => ctrl.abort(), timeoutMs);
     // Use undici.fetch directly (not global fetch) so we can pass the custom

--- a/src/recipes/tools/hubspot.ts
+++ b/src/recipes/tools/hubspot.ts
@@ -203,6 +203,9 @@ registerTool({
     assertWriteAllowed("hubspot.createNote");
     const { getHubSpotConnector } = await import("../../connectors/hubspot.js");
     const connector = getHubSpotConnector();
+    // Re-check immediately before the network write: the kill switch may
+    // have been engaged during the import() above.
+    assertWriteAllowed("hubspot.createNote");
     const note = await connector.createNote(
       params.body as string,
       typeof params.contactId === "string" ? params.contactId : undefined,

--- a/src/recipes/tools/intercom.ts
+++ b/src/recipes/tools/intercom.ts
@@ -154,6 +154,9 @@ registerTool({
       "../../connectors/intercom.js"
     );
     const connector = getIntercomConnector();
+    // Re-check immediately before the network write: the kill switch may
+    // have been engaged during the import() above.
+    assertWriteAllowed("intercom.replyToConversation");
     const conversation = await connector.replyToConversation(
       params.conversationId as string,
       params.body as string,
@@ -198,6 +201,9 @@ registerTool({
       "../../connectors/intercom.js"
     );
     const connector = getIntercomConnector();
+    // Re-check immediately before the network write: the kill switch may
+    // have been engaged during the import() above.
+    assertWriteAllowed("intercom.closeConversation");
     const conversation = await connector.closeConversation(
       params.conversationId as string,
     );

--- a/src/recipes/tools/notion.ts
+++ b/src/recipes/tools/notion.ts
@@ -227,6 +227,9 @@ registerTool({
     assertWriteAllowed("notion.createPage");
     const { getNotionConnector } = await import("../../connectors/notion.js");
     const connector = getNotionConnector();
+    // Re-check immediately before the network write: the kill switch may
+    // have been engaged during the import() above.
+    assertWriteAllowed("notion.createPage");
     const page = await connector.createPage({
       parentId: params.parentId as string,
       parentType: (params.parentType as "database" | "page") ?? "database",
@@ -296,6 +299,9 @@ registerTool({
     assertWriteAllowed("notion.appendBlock");
     const { getNotionConnector } = await import("../../connectors/notion.js");
     const connector = getNotionConnector();
+    // Re-check immediately before the network write: the kill switch may
+    // have been engaged during the import() above.
+    assertWriteAllowed("notion.appendBlock");
     const result = await connector.appendBlock({
       pageId: params.pageId as string,
       content: params.content as string,

--- a/src/recipes/tools/slack.ts
+++ b/src/recipes/tools/slack.ts
@@ -73,6 +73,11 @@ const slackPostMessage: RegisteredTool = {
     const blocks = Array.isArray(params.blocks) ? params.blocks : undefined;
     const threadTs = params.thread_ts ? String(params.thread_ts) : undefined;
 
+    // Re-check immediately before the network write: the kill switch may
+    // have been engaged during the import()/token-load above (the whole
+    // point of an emergency-stop is to catch writes that haven't dispatched
+    // yet, however small the window).
+    assertWriteAllowed("slack.post_message");
     try {
       const result = await postMessage(
         channel,

--- a/src/recipes/tools/zendesk.ts
+++ b/src/recipes/tools/zendesk.ts
@@ -157,6 +157,9 @@ registerTool({
     assertWriteAllowed("zendesk.addComment");
     const { getZendeskConnector } = await import("../../connectors/zendesk.js");
     const connector = getZendeskConnector();
+    // Re-check immediately before the network write: the kill switch may
+    // have been engaged during the import() above.
+    assertWriteAllowed("zendesk.addComment");
     const ticket = await connector.addComment(
       params.ticketId as number,
       params.body as string,
@@ -206,6 +209,9 @@ registerTool({
     assertWriteAllowed("zendesk.updateStatus");
     const { getZendeskConnector } = await import("../../connectors/zendesk.js");
     const connector = getZendeskConnector();
+    // Re-check immediately before the network write: the kill switch may
+    // have been engaged during the import() above.
+    assertWriteAllowed("zendesk.updateStatus");
     const ticket = await connector.updateStatus(
       params.ticketId as number,
       params.status as


### PR DESCRIPTION
## Summary
- `assertWriteAllowed()` (the kill-switch gate) was checked once at the top of each connector write tool's `execute()`, before an async `import()`/token-load gap, with **no re-check right before the actual outbound network call**. Affects 7 connector tools (Slack, Notion, HubSpot, Datadog, Confluence, Zendesk, Intercom — 11 write call sites) plus `http.post`'s SSRF-validation gap.
- `isWriteKillSwitchActive()` is just a cheap in-memory flag read (backed by a debounced `flags.json` watcher) — a second check costs essentially nothing.
- Concrete failure: an operator engages the kill switch specifically because a run is misbehaving. Any write that already passed its initial check moments earlier (while its module was importing / token was loading) proceeds anyway — the documented "fail-closed emergency brake" framing doesn't hold for genuinely in-flight operations at exactly the moment that guarantee matters most.
- Fix: add a second `assertWriteAllowed()` call immediately before each connector's network dispatch.
- Scoped deliberately to the tools where a real async gap exists: `file.write`/`file.append` and `outcomes.classify_issues` only do synchronous local work between their check and their effect, so there's no meaningful window to close there — left untouched.

This is Phase 1 of a two-phase plan (discussed and scoped with the user first). **Phase 2** — true cancellation of an already-dispatched request via a kill-switch-triggered `AbortSignal` — is a separate, larger follow-up; `http.post` already builds its own `AbortController` for timeout purposes, which would be the cheapest starting point.

Found while mining startup/connection bugs (companion fixes: #1167-#1175).

## Test plan
- [x] New regression test `src/recipes/tools/__tests__/slack.killswitch.test.ts`: mocks the Slack connector's `loadTokens()` to flip the kill switch mid-flight (simulating an operator hitting the emergency stop during the import/token-load gap), asserts `executeTool` rejects and `postMessage` is never called
- [x] Confirmed the new test fails on the pre-fix `slack.ts` (write proceeds, `postMessage` called) and passes with the fix
- [x] `npx vitest run src/recipes` — 1646/1646, unaffected
- [x] `npx tsc --noEmit` clean
- [x] `npx biome check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)