### PR TITLE
fix(bridge): resolve pending approvals with 'cancelled' on shutdown

### DIFF
--- a/src/__tests__/bridge-activation-metrics.test.ts
+++ b/src/__tests__/bridge-activation-metrics.test.ts
@@ -2,6 +2,10 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  getApprovalQueue,
+  resetApprovalQueueForTests,
+} from "../approvalQueue.js";
 import type { Config } from "../config.js";
 import { makeConfig as buildConfig } from "./helpers/fixtures.js";
 
@@ -274,5 +278,29 @@ describe("Bridge activation metrics", () => {
     } finally {
       await bridge.stop();
     }
+  });
+
+  it("resolves pending human approvals with 'cancelled' on shutdown instead of losing them silently", async () => {
+    // Regression: ApprovalQueue is purely in-memory — a pending approval
+    // request survived nowhere else. bridge.stop() cancelled orchestrator
+    // tasks but never touched the approval queue, so a parked approval
+    // just vanished on restart with no decision ever reaching the
+    // originating tool call (an ungraceful teardown instead of the
+    // "cancelled" semantics this queue already has a dedicated
+    // discriminant for — see cancelAll()'s doc comment).
+    resetApprovalQueueForTests();
+    const workspace = fs.mkdtempSync(path.join(tempDir, "workspace-approval-"));
+    const bridge = new Bridge(makeConfig(workspace));
+    await bridge.start();
+
+    const { promise } = getApprovalQueue().request({
+      toolName: "test.write",
+      params: {},
+      tier: "high",
+    });
+
+    await bridge.stop();
+
+    await expect(promise).resolves.toBe("cancelled");
   });
 });

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -2378,6 +2378,14 @@ export class Bridge {
         this.orchestrator.cancel(task.id, "shutdown");
       }
     }
+    // Same reasoning as the orchestrator cancel above: the ApprovalQueue is
+    // purely in-memory (no disk persistence), so a pending human-approval
+    // request silently vanishes on restart with no "cancelled" decision ever
+    // reaching the originating tool call — it just hangs until its own
+    // connection drops, an ungraceful teardown instead of the graceful
+    // `cancelled` semantics this queue already has a dedicated discriminant
+    // for. Resolve them here, while the transport is still reachable.
+    getApprovalQueue().cancelAll();
     try {
       await this.server.close();
     } catch {


### PR DESCRIPTION
## Summary
- `ApprovalQueue` is purely in-memory (`src/approvalQueue.ts`) — no disk persistence, unlike the write-effect ledger and file-rollback log (both already vetted as clean this session).
- `bridge.stop()` already cancels every pending/running orchestrator task on shutdown, but never touched the approval queue at all.
- Concrete failure: a tool call is parked awaiting human approval in the dashboard. The bridge restarts (crash, `--restart`, or graceful SIGTERM/SIGINT) before the human decides. On restart, `ApprovalQueue` is a fresh empty `Map` — the pending entry and its `approvalToken` are gone with no trace. The originating caller doesn't get the graceful `"cancelled"` decision this queue already has a dedicated discriminant for (see `cancelAll()`'s existing doc comment — used elsewhere for the same "abandoned" case) — it just hangs until its own connection drops, an ungraceful teardown.
- Fix: call `getApprovalQueue().cancelAll()` in the shutdown sequence, symmetric with the existing orchestrator-cancel call, placed before `this.server.close()` so the resolution can still reach connected clients while the transport is reachable.

Found while mining startup/connection bugs (companion fixes: #1167-#1176).

## Test plan
- [x] New regression test in `bridge-activation-metrics.test.ts`: starts a real `Bridge`, parks an approval via `getApprovalQueue().request(...)`, calls `bridge.stop()`, asserts the promise resolves to `"cancelled"`
- [x] Confirmed the new test times out (15s) on the pre-fix code — the promise never resolves — and passes immediately with the fix
- [x] `npx vitest run` on bridge-activation-metrics / approvalQueue / approvalGate.e2e / approvalHttp / approvalMount — 114/114, unaffected
- [x] `npx tsc --noEmit` clean
- [x] `npx biome check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)