### PR TITLE
fix(recipes): dedup redelivered webhooks against the write-effect ledger

### DIFF
--- a/src/__tests__/recipeOrchestration.test.ts
+++ b/src/__tests__/recipeOrchestration.test.ts
@@ -71,6 +71,11 @@ vi.mock("../commands/recipe.js", () => ({
   runRecipeDryPlan: vi.fn().mockResolvedValue({}),
 }));
 
+vi.mock("../recipes/yamlRunner.js", () => ({
+  buildChainedDeps: vi.fn().mockReturnValue({}),
+  dispatchRecipe: vi.fn().mockResolvedValue({ success: true, summary: {} }),
+}));
+
 // ---------------------------------------------------------------------------
 
 describe("RecipeOrchestration", () => {
@@ -357,6 +362,98 @@ describe("RecipeOrchestration", () => {
       logLabel: '"foo"',
     });
     expect(result).toMatchObject({ ok: false, error: "boom" });
+  });
+
+  it("fireYamlRecipe() — deliveryId threads manualRunId + a fixed ledgerDir into the dispatch deps (webhook redelivery dedup)", async () => {
+    const { dispatchRecipe } = await import("../recipes/yamlRunner.js");
+    vi.mocked(dispatchRecipe).mockClear();
+
+    // Capture the dispatchFn passed to recipeOrchestrator.fire() and invoke
+    // it ourselves — fire() itself is mocked and would never call it.
+    let capturedDispatchFn:
+      | ((recipe: unknown, deps: unknown, seedContext: unknown) => unknown)
+      | undefined;
+    const fireStub = vi.fn().mockImplementation(async (opts) => {
+      capturedDispatchFn = opts.dispatchFn;
+      return { ok: true, taskId: "t1", name: "foo" };
+    });
+    const recipeOrch = makeRecipeOrchestrator({ fire: fireStub });
+    const mockOrchestrator = { runAndWait: vi.fn() };
+
+    const server = makeServer();
+    const ro = new RecipeOrchestration({
+      server,
+      getOrchestrator: () => mockOrchestrator,
+      recipeOrchestrator: recipeOrch,
+      recipeRunLog: null,
+      workdir: "/tmp/ws",
+      logger: { info: vi.fn(), warn: vi.fn() },
+    });
+
+    await ro.fireYamlRecipe({
+      filePath: "/r/foo.yaml",
+      name: "foo",
+      taskIdPrefix: "yaml-webhook-foo",
+      triggerSourceSuffix: "webhook:foo",
+      logLabel: 'webhook "foo"',
+      deliveryId: "deadbeefdeadbeefdeadbeefdeadbeef",
+    });
+
+    expect(capturedDispatchFn).toBeDefined();
+    await capturedDispatchFn?.({ name: "foo" }, {}, {});
+
+    expect(dispatchRecipe).toHaveBeenCalledTimes(1);
+    const passedDeps = vi.mocked(dispatchRecipe).mock.calls[0]![1] as {
+      manualRunId?: string;
+      ledgerDir?: string;
+    };
+    expect(passedDeps.manualRunId).toBe("deadbeefdeadbeefdeadbeefdeadbeef");
+    expect(passedDeps.ledgerDir).toMatch(
+      /[/\\]\.patchwork[/\\]webhook-effect-ledger$/,
+    );
+  });
+
+  it("fireYamlRecipe() — omits manualRunId/ledgerDir when no deliveryId is given (scheduler/dashboard-fired runs)", async () => {
+    const { dispatchRecipe } = await import("../recipes/yamlRunner.js");
+    vi.mocked(dispatchRecipe).mockClear();
+
+    let capturedDispatchFn:
+      | ((recipe: unknown, deps: unknown, seedContext: unknown) => unknown)
+      | undefined;
+    const fireStub = vi.fn().mockImplementation(async (opts) => {
+      capturedDispatchFn = opts.dispatchFn;
+      return { ok: true, taskId: "t1", name: "foo" };
+    });
+    const recipeOrch = makeRecipeOrchestrator({ fire: fireStub });
+    const mockOrchestrator = { runAndWait: vi.fn() };
+
+    const server = makeServer();
+    const ro = new RecipeOrchestration({
+      server,
+      getOrchestrator: () => mockOrchestrator,
+      recipeOrchestrator: recipeOrch,
+      recipeRunLog: null,
+      workdir: "/tmp/ws",
+      logger: { info: vi.fn(), warn: vi.fn() },
+    });
+
+    await ro.fireYamlRecipe({
+      filePath: "/r/foo.yaml",
+      name: "foo",
+      taskIdPrefix: "yaml-recipe-foo",
+      triggerSourceSuffix: "recipe:foo",
+      logLabel: '"foo"',
+      // no deliveryId — scheduler/dashboard-fired run
+    });
+
+    await capturedDispatchFn?.({ name: "foo" }, {}, {});
+
+    const passedDeps = vi.mocked(dispatchRecipe).mock.calls[0]![1] as {
+      manualRunId?: string;
+      ledgerDir?: string;
+    };
+    expect(passedDeps.manualRunId).toBeUndefined();
+    expect(passedDeps.ledgerDir).toBeUndefined();
   });
 
   it("buildScheduler() — returns a RecipeScheduler instance", () => {

--- a/src/__tests__/server-webhook-hmac.test.ts
+++ b/src/__tests__/server-webhook-hmac.test.ts
@@ -6,7 +6,7 @@
  * over the raw request body, bypassing the bearer-token gate. Bearer
  * access continues to work — HMAC is additive, not a replacement.
  */
-import { createHmac } from "node:crypto";
+import { createHash, createHmac } from "node:crypto";
 import http from "node:http";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { Logger } from "../logger.js";
@@ -19,14 +19,14 @@ const SECRET =
 
 let server: Server | null = null;
 let port = 0;
-let calls: Array<{ path: string; payload: unknown }>;
+let calls: Array<{ path: string; payload: unknown; deliveryId?: string }>;
 
 async function startServer(opts: { secret: string | null }): Promise<void> {
   calls = [];
   server = new Server(TOKEN, logger);
   server.webhookSecret = opts.secret;
-  server.webhookFn = async (path, payload) => {
-    calls.push({ path, payload });
+  server.webhookFn = async (path, payload, deliveryId) => {
+    calls.push({ path, payload, deliveryId });
     return { ok: true, name: "stub-recipe", taskId: "task-1" };
   };
   port = await server.findAndListen(null);
@@ -236,5 +236,92 @@ describe("readSingleSignatureHeader — H6 multi-valued rejection", () => {
     expect(
       readSingleSignatureHeader("sha256=invalid1, sha256=invalid2"),
     ).toBeNull();
+  });
+});
+
+// Webhook redelivery dedup — deliveryId derivation passed to webhookFn.
+// A sender's own delivery-id header (GitHub's X-GitHub-Delivery, a UUID
+// unique per delivery attempt, including retries of the SAME delivery)
+// should produce a stable, deterministic deliveryId so a recipe's
+// write-effect ledger can dedup a redelivered webhook against a run that
+// already executed its writes before a crash/restart mid-run. Senders with
+// no delivery header fall back to a hash of the raw body.
+describe("POST /hooks/* — deliveryId derivation for webhook redelivery dedup", () => {
+  it("derives deliveryId from X-GitHub-Delivery when present", async () => {
+    await startServer({ secret: null });
+    const body = JSON.stringify({ action: "opened" });
+    const deliveryHeader = "12345678-1234-1234-1234-123456789012";
+    const { status } = await postHooks(body, {
+      Authorization: `Bearer ${TOKEN}`,
+      "X-GitHub-Delivery": deliveryHeader,
+    });
+    expect(status).toBe(200);
+    expect(calls).toHaveLength(1);
+    const expected = createHash("sha256")
+      .update(deliveryHeader)
+      .digest("hex")
+      .slice(0, 32);
+    expect(calls[0]!.deliveryId).toBe(expected);
+  });
+
+  it("two deliveries with the SAME X-GitHub-Delivery produce the SAME deliveryId (redelivery dedup)", async () => {
+    await startServer({ secret: null });
+    const deliveryHeader = "same-delivery-id-retried-once";
+    await postHooks(JSON.stringify({ n: 1 }), {
+      Authorization: `Bearer ${TOKEN}`,
+      "X-GitHub-Delivery": deliveryHeader,
+    });
+    // Sender retries the identical delivery (e.g. bridge timed out the
+    // first response) — same delivery id, possibly identical or retried body.
+    await postHooks(JSON.stringify({ n: 1 }), {
+      Authorization: `Bearer ${TOKEN}`,
+      "X-GitHub-Delivery": deliveryHeader,
+    });
+    expect(calls).toHaveLength(2);
+    expect(calls[0]!.deliveryId).toBe(calls[1]!.deliveryId);
+  });
+
+  it("falls back to a hash of the raw body when no delivery header is present", async () => {
+    await startServer({ secret: null });
+    const body = JSON.stringify({ action: "opened" });
+    const { status } = await postHooks(body, {
+      Authorization: `Bearer ${TOKEN}`,
+    });
+    expect(status).toBe(200);
+    const expected = createHash("sha256")
+      .update(Buffer.from(body, "utf-8"))
+      .digest("hex")
+      .slice(0, 32);
+    expect(calls[0]!.deliveryId).toBe(expected);
+  });
+
+  it("different bodies with no delivery header produce different deliveryIds", async () => {
+    await startServer({ secret: null });
+    await postHooks(JSON.stringify({ a: 1 }), {
+      Authorization: `Bearer ${TOKEN}`,
+    });
+    await postHooks(JSON.stringify({ a: 2 }), {
+      Authorization: `Bearer ${TOKEN}`,
+    });
+    expect(calls).toHaveLength(2);
+    expect(calls[0]!.deliveryId).not.toBe(calls[1]!.deliveryId);
+  });
+
+  it("ignores a spoofed multi-valued X-GitHub-Delivery header and falls back to the body hash", async () => {
+    // Same H6 rejection pattern as X-Hub-Signature-256: a multi-valued
+    // delivery header (duplicate lines, comma-joined by Node, or an
+    // upstream proxy handing us a string[]) must not be trusted verbatim.
+    await startServer({ secret: null });
+    const body = JSON.stringify({ action: "opened" });
+    const { status } = await postHooks(body, {
+      Authorization: `Bearer ${TOKEN}`,
+      "X-GitHub-Delivery": "id-one, id-two",
+    });
+    expect(status).toBe(200);
+    const expected = createHash("sha256")
+      .update(Buffer.from(body, "utf-8"))
+      .digest("hex")
+      .slice(0, 32);
+    expect(calls[0]!.deliveryId).toBe(expected);
   });
 });

--- a/src/recipeOrchestration.ts
+++ b/src/recipeOrchestration.ts
@@ -753,7 +753,11 @@ export class RecipeOrchestration {
 
     this.wireGenerateFn();
 
-    server.webhookFn = async (hookPath: string, payload: unknown) => {
+    server.webhookFn = async (
+      hookPath: string,
+      payload: unknown,
+      deliveryId?: string,
+    ) => {
       // #605: same kill-switch gate as runRecipeFn — webhook trigger
       // is just another path into recipe execution.
       try {
@@ -823,6 +827,7 @@ export class RecipeOrchestration {
           triggerSourceSuffix: `webhook:${match.name}`,
           logLabel: `webhook "${match.name}"`,
           seedContext,
+          deliveryId,
         });
       }
       const loaded = loadRecipePrompt(
@@ -1288,6 +1293,15 @@ export class RecipeOrchestration {
     triggerSourceSuffix: string;
     logLabel: string;
     seedContext?: Record<string, string>;
+    /**
+     * Stable per-delivery identity (webhook redelivery only — see
+     * `server.webhookFn`'s doc comment). When set, disk-backs this run's
+     * write-effect ledger so a redelivered webhook can't double-execute
+     * writes a prior (possibly crashed-mid-run) delivery already made.
+     * Scheduler/dashboard-fired runs never pass this — there's no "same
+     * logical event, redelivered" case for those triggers.
+     */
+    deliveryId?: string;
   }): Promise<{ ok: boolean; taskId?: string; name?: string; error?: string }> {
     if (!this.deps.recipeOrchestrator) {
       return { ok: false, error: "recipe orchestrator unavailable" };
@@ -1387,6 +1401,16 @@ export class RecipeOrchestration {
       ...(gateAutomatedRuns && { gateAutomatedRuns: true }),
       ...(agentDisallowedTools && { agentDisallowedTools }),
       ...(workerId && { workerId }),
+      // Webhook redelivery dedup — see fireYamlRecipe's `deliveryId` doc
+      // comment. Disk-backs the write-effect ledger under a fixed shared
+      // directory (scoped internally by a hash of recipeName+deliveryId,
+      // per idempotencyKey.ts's deriveScopeKey) so a sender's retried
+      // delivery can't double-execute writes a crashed-mid-run prior
+      // delivery already made.
+      ...(opts.deliveryId && {
+        manualRunId: opts.deliveryId,
+        ledgerDir: join(homedir(), ".patchwork", "webhook-effect-ledger"),
+      }),
     };
     // Pass the bridge's long-lived RecipeRunLog so chainedRunner can flip the
     // run from `running` → terminal in-place via startRun/completeRun. The

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,4 +1,4 @@
-import { createHmac, timingSafeEqual } from "node:crypto";
+import { createHash, createHmac, timingSafeEqual } from "node:crypto";
 import { EventEmitter } from "node:events";
 import { unlinkSync } from "node:fs";
 import http from "node:http";
@@ -516,11 +516,22 @@ export class Server extends EventEmitter<ServerEvents> {
   public broadcastKillSwitchEventFn:
     | ((engaged: boolean, reason?: string) => void)
     | null = null;
-  /** Patchwork: set by bridge to match + fire webhook-triggered recipes. */
+  /**
+   * Patchwork: set by bridge to match + fire webhook-triggered recipes.
+   * `deliveryId` — a stable per-delivery identity (sender's delivery
+   * header if present, else a hash of the raw request body — see the
+   * call site) — lets the recipe's write-effect ledger disk-back and
+   * dedup a redelivered webhook (sender retries on timeout/5xx) against
+   * a run that already executed its writes before the bridge crashed or
+   * restarted mid-run. Scheduler/dashboard-fired runs have no equivalent
+   * "same logical event, redelivered" case, so they intentionally don't
+   * pass anything analogous here.
+   */
   public webhookFn:
     | ((
         path: string,
         payload: unknown,
+        deliveryId?: string,
       ) => Promise<{
         ok: boolean;
         taskId?: string;
@@ -1451,6 +1462,21 @@ export class Server extends EventEmitter<ServerEvents> {
             payload = read.body;
           }
         }
+        // Stable per-delivery identity for redelivery dedup: the sender's
+        // own delivery-id header when present (GitHub's X-GitHub-Delivery
+        // is a UUID unique per delivery attempt — including retries of the
+        // SAME delivery, which is exactly what we want to dedup against),
+        // else a hash of the raw body as a best-effort fallback for
+        // senders with no delivery header. Hashed either way rather than
+        // used verbatim so this stays a fixed-length, filesystem/audit-safe
+        // token regardless of what a sender puts in the header.
+        const deliveryHeader = readSingleSignatureHeader(
+          req.headers["x-github-delivery"],
+        );
+        const deliveryId = createHash("sha256")
+          .update(deliveryHeader ?? read.bytes)
+          .digest("hex")
+          .slice(0, 32);
         if (!this.webhookFn) {
           res.writeHead(503, { "Content-Type": "application/json" });
           res.end(
@@ -1462,7 +1488,7 @@ export class Server extends EventEmitter<ServerEvents> {
           );
           return;
         }
-        const result = await this.webhookFn(hookPath, payload);
+        const result = await this.webhookFn(hookPath, payload, deliveryId);
         const status = result.ok
           ? 200
           : result.error === "not_found"


### PR DESCRIPTION
## Summary
- `WriteEffectLedger`'s disk-backed persistence (PR5a/b) only activates when `manualRunId` + `ledgerDir` + `recipeName` are all present — which only CLI-invoked runs (`patchwork recipe run --attempt --ledger-dir`) ever supply. Scheduler/webhook/dashboard-fired runs all fell back to pure in-memory dedup.
- **Scheduler cron fires and dashboard "Run" clicks are correctly unaffected by this fix** — each firing is a genuinely new logical event (a daily digest's tomorrow run should post fresh content, not dedup against today's run), so leaving those in-memory-only is the right behavior, not a gap.
- **Webhook-triggered runs were a real gap**, though: a sender (GitHub, Stripe, etc.) retries the *same* delivery on a timeout/5xx. If the bridge crashed mid-execution on the first attempt and the sender redelivers, nothing catches the redelivery — a step that already posted to Slack could post again, with no ledger entry surviving the restart to short-circuit it.
- Fix: thread a stable per-delivery identity through the webhook path.
  - `src/server.ts`'s `POST /hooks/*` handler derives `deliveryId` as a SHA-256 hash of the sender's `X-GitHub-Delivery` header (falling back to a hash of the raw body when the header is absent, multi-valued, or comma-joined — same H6 rejection posture already used for the signature header), and passes it to `webhookFn` as a new optional third argument.
  - `src/recipeOrchestration.ts`'s `webhookFn`/`fireYamlRecipe` thread it into `runnerDeps` as `manualRunId`, with a fixed shared `ledgerDir` under `~/.patchwork/webhook-effect-ledger` — reusing `WriteEffectLedger`'s existing scope-key hashing (`recipeName` + `manualRunId`) with no changes to that module at all.

Found + scoped while mining startup/connection bugs (companion fixes: #1167-#1177).

## Test plan
- [x] `src/__tests__/server-webhook-hmac.test.ts` — 5 new tests: deliveryId derived from `X-GitHub-Delivery`, same header → same deliveryId across two deliveries (the actual dedup guarantee), fallback to body-hash when no header, different bodies → different deliveryIds, spoofed multi-valued header falls back to body-hash rather than being trusted
- [x] `src/__tests__/recipeOrchestration.test.ts` — 2 new tests: `deliveryId` threads `manualRunId`/`ledgerDir` into the dispatch deps; no `deliveryId` (scheduler/dashboard path) omits both
- [x] Confirmed the wiring test fails when the fix is reverted (`expected undefined to be 'deadbeef...'`) and passes with it
- [x] `npx vitest run` — 123/123 across recipeOrchestration/server-webhook-hmac/webhookRecipes/idempotencyKey/workerGate suites
- [x] `npx tsc --noEmit` clean
- [x] `npx biome check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)