### PR TITLE
fix(recipes): stage installs + atomic rename so a crash mid-copy can't install a live, incomplete recipe

### DIFF
--- a/src/commands/__tests__/recipeUninstallReinstall.test.ts
+++ b/src/commands/__tests__/recipeUninstallReinstall.test.ts
@@ -14,17 +14,29 @@ import {
   existsSync,
   mkdtempSync,
   readdirSync,
+  readFileSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   isRecipeEnabled,
   runRecipeInstall,
   runRecipeUninstall,
 } from "../recipeInstall.js";
+
+// Native ESM module namespaces aren't configurable, so cpSync/rmSync can't
+// be vi.spyOn'd directly (they can only be intercepted via vi.mock).
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return {
+    ...actual,
+    cpSync: vi.fn(actual.cpSync),
+    rmSync: vi.fn(actual.rmSync),
+  };
+});
 
 let recipesRoot: string;
 let srcRoot: string;
@@ -221,5 +233,151 @@ describe("runRecipeInstall — reinstall correctness", () => {
     expect(before).toContain(".disabled");
     expect(before).toContain("recipe.json");
     expect(before).toContain("main.yaml");
+  });
+});
+
+describe("runRecipeInstall — crash safety (staged install + atomic rename)", () => {
+  afterEach(async () => {
+    // Reset the mocked cpSync/rmSync back to real implementations so other
+    // describe blocks in this file (which share the same mocked module
+    // instance) aren't affected by a mockImplementation set here.
+    const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+    const mocked = await import("node:fs");
+    vi.mocked(mocked.cpSync).mockImplementation(actual.cpSync);
+    vi.mocked(mocked.rmSync).mockImplementation(actual.rmSync);
+  });
+
+  /**
+   * Makes cpSync throw only for the per-file copies into the recipesDir
+   * staging directory (what we're actually testing crash-safety for) —
+   * NOT for stageLocalSource's own unrelated bulk `cpSync(src, tmpDir,
+   * {recursive:true})` call that stages the source package into an OS
+   * temp dir before runRecipeInstall ever reaches the code under test.
+   */
+  async function mockCpSyncThrowsForRecipesRoot(): Promise<void> {
+    const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+    const { cpSync } = await import("node:fs");
+    vi.mocked(cpSync).mockImplementation((src, dest, opts) => {
+      if (String(dest).includes(recipesRoot)) {
+        throw new Error("simulated crash mid-copy");
+      }
+      return actual.cpSync(src as never, dest as never, opts as never);
+    });
+  }
+
+  it("fresh install: a crash mid-copy leaves no trace at the final install path", async () => {
+    const src = writeSrcRecipe(
+      { "main.yaml": "name: crash-fresh\nsteps: []\n" },
+      {
+        name: "crash-fresh",
+        version: "1.0.0",
+        description: "x",
+        recipes: { main: "main.yaml" },
+      },
+    );
+
+    await mockCpSyncThrowsForRecipesRoot();
+
+    await expect(
+      runRecipeInstall(src, { recipesDir: recipesRoot }),
+    ).rejects.toThrow("simulated crash mid-copy");
+
+    // The real install path was never touched — nothing under it, because
+    // nothing was ever copied there directly (staged in a sibling dir first).
+    expect(existsSync(path.join(recipesRoot, "crash-fresh"))).toBe(false);
+  });
+
+  it("fresh install: if cleanup itself also fails, the orphaned staging dir is still marked disabled (never scanned as live)", async () => {
+    const src = writeSrcRecipe(
+      { "main.yaml": "name: crash-fresh-2\nsteps: []\n" },
+      {
+        name: "crash-fresh-2",
+        version: "1.0.0",
+        description: "x",
+        recipes: { main: "main.yaml" },
+      },
+    );
+
+    await mockCpSyncThrowsForRecipesRoot();
+    const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+    const { rmSync: mockedRmSync } = await import("node:fs");
+    // Simulate the process dying before the catch block's best-effort
+    // rmSync(stagingDir) cleanup can run.
+    vi.mocked(mockedRmSync).mockImplementation((target, opts) => {
+      if (String(target).includes(".installing-")) {
+        throw new Error("simulated: no cleanup, process died");
+      }
+      return actual.rmSync(target as string, opts as never);
+    });
+
+    await expect(
+      runRecipeInstall(src, { recipesDir: recipesRoot }),
+    ).rejects.toThrow("simulated crash mid-copy");
+
+    const leftovers = readdirSync(recipesRoot).filter((f) =>
+      f.startsWith(".installing-"),
+    );
+    expect(leftovers.length).toBeGreaterThan(0);
+    for (const leftover of leftovers) {
+      // The safety marker was written BEFORE any file copy was attempted —
+      // an orphaned staging dir is always inert, regardless of how much (if
+      // any) of the copy loop completed before the crash.
+      expect(existsSync(path.join(recipesRoot, leftover, ".disabled"))).toBe(
+        true,
+      );
+    }
+  });
+
+  it("reinstall: a crash mid-copy leaves the PREVIOUS version installed and enabled, untouched", async () => {
+    const v1 = writeSrcRecipe(
+      { "main.yaml": "name: crash-reinstall\nsteps: []\nversion: 1\n" },
+      {
+        name: "crash-reinstall",
+        version: "1.0.0",
+        description: "x",
+        recipes: { main: "main.yaml" },
+      },
+    );
+    const inst1 = await runRecipeInstall(v1, { recipesDir: recipesRoot });
+    // Explicitly enable it, like a real user would after a fresh install.
+    writeFileSync(
+      path.join(inst1.installDir, "main.yaml"),
+      "name: crash-reinstall\nsteps: []\nversion: 1\n",
+    );
+    const disabledMarker = path.join(inst1.installDir, ".disabled");
+    rmSync(disabledMarker, { force: true });
+    expect(isRecipeEnabled(inst1.installDir)).toBe(true);
+
+    const v2 = writeSrcRecipe(
+      { "main.yaml": "name: crash-reinstall\nsteps: []\nversion: 2\n" },
+      {
+        name: "crash-reinstall",
+        version: "2.0.0",
+        description: "x",
+        recipes: { main: "main.yaml" },
+      },
+    );
+
+    await mockCpSyncThrowsForRecipesRoot();
+
+    await expect(
+      runRecipeInstall(v2, { recipesDir: recipesRoot }),
+    ).rejects.toThrow("simulated crash mid-copy");
+
+    // The old install dir must still exist, unchanged, and still enabled —
+    // the old dir is renamed aside (not deleted) until the new one has
+    // fully landed, and a crash during copy means the new one never lands.
+    expect(existsSync(inst1.installDir)).toBe(true);
+    expect(isRecipeEnabled(inst1.installDir)).toBe(true);
+    expect(
+      readFileSync(path.join(inst1.installDir, "main.yaml"), "utf-8"),
+    ).toContain("version: 1");
+
+    // No leftover `.replaced-<ts>` backup dir either — restored via rename,
+    // not left as a stray duplicate.
+    const stray = readdirSync(recipesRoot).filter((f) =>
+      f.includes(".replaced-"),
+    );
+    expect(stray).toEqual([]);
   });
 });

--- a/src/commands/recipeInstall.ts
+++ b/src/commands/recipeInstall.ts
@@ -16,6 +16,7 @@ import {
   mkdtempSync,
   readdirSync,
   readFileSync,
+  renameSync,
   rmSync,
   statSync,
   unlinkSync,
@@ -546,37 +547,90 @@ export async function runRecipeInstall(
     const isReinstall = existsSync(installDir);
     const wasEnabled = isReinstall ? !isInstallDirDisabled(installDir) : false;
 
-    if (isReinstall) {
-      // Clear stale files from the previous version so files dropped from
-      // the new manifest don't linger. We rebuild the install dir wholesale
-      // rather than overlay the new files on top of the old.
-      try {
-        rmSync(installDir, { recursive: true, force: true });
-      } catch {
-        // best-effort; mkdirSync below will throw with a clearer error
-      }
-    }
-    mkdirSync(installDir, { recursive: true });
+    // Stage the new install content in a sibling directory inside
+    // `recipesDir` (same filesystem as `installDir`, required for an
+    // atomic rename below) instead of copying directly into `installDir`.
+    //
+    // Previously, files were `cpSync`'d one at a time straight into
+    // `installDir`, with the `.disabled` safety marker written only AFTER
+    // every file finished copying. A crash/kill between the first and
+    // last copy left a partially-copied recipe with no marker — the next
+    // startup's directory scan (eventTriggerPrograms.ts / scheduler.ts,
+    // neither of which checks "does this look complete") would treat it
+    // as a live, enabled recipe and either throw cryptically on the
+    // missing file or silently run a mutated/incomplete version.
+    //
+    // Now the `.disabled` marker is written into the staging dir BEFORE
+    // any file is copied, so a crash anywhere before the final rename
+    // leaves (at worst) an orphaned `.installing-*` directory that scans
+    // as disabled and is inert. The marker is only removed from the real
+    // `installDir` — restoring "was enabled" for a reinstall — after the
+    // rename has fully succeeded.
+    mkdirSync(recipesDir, { recursive: true });
+    const stagingDir = mkdtempSync(
+      path.join(recipesDir, `.installing-${installName}-`),
+    );
+    try {
+      writeFileSync(disabledMarkerPath(stagingDir), "");
 
-    // Copy files
-    for (const file of filesToCopy) {
-      const src = path.join(tmpDir, file);
-      const dest = path.join(installDir, file);
-      // Ensure subdirs exist (recipe.json could declare children in subdirs)
-      const destParent = path.dirname(dest);
-      if (!existsSync(destParent)) {
-        mkdirSync(destParent, { recursive: true });
+      for (const file of filesToCopy) {
+        const src = path.join(tmpDir, file);
+        const dest = path.join(stagingDir, file);
+        // Ensure subdirs exist (recipe.json could declare children in subdirs)
+        const destParent = path.dirname(dest);
+        if (!existsSync(destParent)) {
+          mkdirSync(destParent, { recursive: true });
+        }
+        cpSync(src, dest);
       }
-      cpSync(src, dest);
+
+      if (isReinstall) {
+        // Move the old install dir aside rather than deleting it first —
+        // if the process dies between removing the old dir and renaming
+        // the new one into place, the recipe would vanish entirely
+        // instead of just being stale. Renaming keeps a recoverable copy
+        // on disk until the very last (best-effort) cleanup step.
+        const backupDir = `${installDir}.replaced-${Date.now()}`;
+        renameSync(installDir, backupDir);
+        try {
+          renameSync(stagingDir, installDir);
+        } catch (err) {
+          // Restore the old install dir so the recipe isn't left missing.
+          renameSync(backupDir, installDir);
+          throw err;
+        }
+        try {
+          rmSync(backupDir, { recursive: true, force: true });
+        } catch {
+          // best-effort — a leftover `${name}.replaced-<ts>` dir is
+          // harmless (not a valid recipe name; won't collide on rescan)
+        }
+      } else {
+        renameSync(stagingDir, installDir);
+      }
+    } catch (err) {
+      try {
+        rmSync(stagingDir, { recursive: true, force: true });
+      } catch {
+        /* best-effort cleanup */
+      }
+      throw err;
     }
 
     // Write the disabled-marker policy:
-    //   - Fresh install: start disabled (per the wave2 plan's safety story).
+    //   - Fresh install: start disabled (per the wave2 plan's safety story;
+    //     the marker written into the staging dir above already achieves
+    //     this — nothing further to do).
     //   - Reinstall (upgrade in place): preserve whatever the user had set.
-    //     If the recipe was enabled before, leave it enabled; if disabled,
-    //     leave it disabled. Don't silently revoke an explicit user opt-in.
-    if (!isReinstall || !wasEnabled) {
-      writeFileSync(disabledMarkerPath(installDir), "");
+    //     If the recipe was enabled before, remove the marker we staged
+    //     with so it goes back to enabled; if disabled, leave it.
+    if (isReinstall && wasEnabled) {
+      try {
+        unlinkSync(disabledMarkerPath(installDir));
+      } catch {
+        /* best-effort — worst case the recipe stays disabled and the user
+           re-enables it, rather than silently losing the "enabled" state */
+      }
     }
 
     return {


### PR DESCRIPTION
## Summary
- `runRecipeInstall` copied a recipe's declared files one at a time straight into `recipesDir/<name>/`, writing the `.disabled` safety marker only **after** every file finished copying.
- Concrete failure: a crash/kill (OOM, `--watch` supervisor restart, host reboot) between the first and last `cpSync` call left a partially-copied recipe with no marker. The next startup's directory scan (`eventTriggerPrograms.ts` / `scheduler.ts` — neither checks "does this look complete") treats it as a live, enabled recipe: either a cryptic failure on the missing file, or a silently mutated/incomplete recipe running with real safety-gated actions, having skipped the "install starts disabled" guarantee entirely.
- Fix: stage the new install content in a sibling `.installing-<name>-*` directory (same filesystem as the real install dir — required for an atomic rename) and write the `.disabled` marker into it **before** any file is copied, not after.
  - A crash anywhere before the final rename now leaves, at worst, an orphaned staging directory that scans as disabled and is completely inert, regardless of how much of the copy completed.
  - Reinstalls rename the old install dir aside (not delete) until the new one has fully landed, so a crash during a reinstall never leaves the recipe missing — only its previous version, unchanged and still enabled if it was enabled before.

Found + scoped while mining startup/connection bugs (companion fixes: #1167-#1178).

## Test plan
- [x] 3 new regression tests in `recipeUninstallReinstall.test.ts`:
  - fresh install: crash mid-copy leaves no trace at the final install path
  - fresh install: even if cleanup itself also fails (simulating the process dying before the catch block's best-effort `rmSync` runs), the orphaned staging dir is still marked `.disabled`
  - reinstall: crash mid-copy leaves the previous version installed and enabled, untouched, with no stray backup dir left behind
- [x] `npx vitest run` — 63/63 across recipeInstall/recipeInstall-httpsget-bytecap/recipeInstall-shorthand/recipeUninstallReinstall/recipeEnable
- [x] `npx tsc --noEmit` clean
- [x] `npx biome check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)