### PR TITLE
fix(approvals): dismiss phone push when a pending approval is cancelled server-side

### DIFF
--- a/dashboard/public/sw.js
+++ b/dashboard/public/sw.js
@@ -123,6 +123,24 @@ self.addEventListener("push", (event) => {
     return;
   }
 
+  // Cancel pushes tell us to dismiss a previously-shown approval card —
+  // fired when the operator downgrades the approval gate to "off" or the
+  // bridge shuts down while a request is still pending, so the phone
+  // isn't left with a stale "tap to approve" button whose token the
+  // bridge has already invalidated server-side. Close by tag; no-op if
+  // the notification was already dismissed or never arrived on this
+  // device.
+  if (data.kind === "cancel") {
+    event.waitUntil(
+      self.registration
+        .getNotifications({ tag: `approval-${data.callId}` })
+        .then((notifications) => {
+          for (const n of notifications) n.close();
+        }),
+    );
+    return;
+  }
+
   // Branch on payload kind. Approval pushes (no kind, legacy shape)
   // and halt pushes (kind === "halt") render different notifications
   // and have different click targets.

--- a/dashboard/src/app/api/relay/push/__tests__/route.test.ts
+++ b/dashboard/src/app/api/relay/push/__tests__/route.test.ts
@@ -363,3 +363,39 @@ describe("POST /api/relay/push — respects approvals opt-out", () => {
     expect(webpush.sendNotification).not.toHaveBeenCalled();
   });
 });
+
+describe("POST /api/relay/push — cancel (dismiss a stale approval card)", () => {
+  it("fans out a { kind: 'cancel', callId } payload without requiring approve/reject fields", async () => {
+    const r = await POST(
+      req({ authorization: `Bearer ${TOKEN}` }, { kind: "cancel", callId: "call-123" }),
+    );
+    expect(r.status).toBe(200);
+    expect(webpush.sendNotification).toHaveBeenCalledTimes(1);
+    const [, payloadStr] = vi.mocked(webpush.sendNotification).mock.calls[0]!;
+    expect(JSON.parse(payloadStr as string)).toEqual({
+      kind: "cancel",
+      callId: "call-123",
+    });
+  });
+
+  it("400s a cancel payload missing callId", async () => {
+    const r = await POST(req({ authorization: `Bearer ${TOKEN}` }, { kind: "cancel" }));
+    expect(r.status).toBe(400);
+    expect(webpush.sendNotification).not.toHaveBeenCalled();
+  });
+
+  it("404s a cancel payload when no subscriber is opted in to approvals", async () => {
+    vi.mocked(getSubscriptionsFor).mockReturnValue([]);
+    const r = await POST(
+      req({ authorization: `Bearer ${TOKEN}` }, { kind: "cancel", callId: "call-123" }),
+    );
+    expect(r.status).toBe(404);
+    expect(webpush.sendNotification).not.toHaveBeenCalled();
+  });
+
+  it("still enforces Bearer auth for cancel payloads", async () => {
+    const r = await POST(req({}, { kind: "cancel", callId: "call-123" }));
+    expect(r.status).toBe(401);
+    expect(webpush.sendNotification).not.toHaveBeenCalled();
+  });
+});

--- a/dashboard/src/app/api/relay/push/route.ts
+++ b/dashboard/src/app/api/relay/push/route.ts
@@ -45,6 +45,7 @@ function readVapidConfig(): {
 }
 
 interface RelayPushBody {
+  kind?: "cancel";
   callId?: string;
   toolName?: string;
   tier?: string;
@@ -87,6 +88,37 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
   }
   const body = parsed.value;
+
+  // Cancel pushes only need a callId — they tell the SW to close a
+  // previously-shown "tap to approve" notification by tag, not to show a
+  // new one, so none of the approve/reject wiring below applies.
+  if (body.kind === "cancel") {
+    if (!body.callId) {
+      return NextResponse.json(
+        { error: "missing required field: callId" },
+        { status: 400 },
+      );
+    }
+    const subs = getSubscriptionsFor("approvals");
+    if (subs.length === 0) {
+      return NextResponse.json(
+        { ok: false, sent: 0, total: 0, error: "no approval subscribers" },
+        { status: 404 },
+      );
+    }
+    const cancelPayload = JSON.stringify({
+      kind: "cancel",
+      callId: body.callId,
+    });
+    webpush.setVapidDetails(vapid.subject, vapid.publicKey, vapid.privateKey);
+    const results = await Promise.allSettled(
+      subs.map((sub) =>
+        webpush.sendNotification(sub, cancelPayload, { agent: pushAgent }),
+      ),
+    );
+    const sent = results.filter((r) => r.status === "fulfilled").length;
+    return NextResponse.json({ ok: true, sent, total: subs.length });
+  }
 
   const { callId, toolName, tier, approvalToken, bridgeCallbackBase } = body;
   if (!callId || !toolName || !tier || !approvalToken) {

--- a/src/__tests__/approvalQueue.test.ts
+++ b/src/__tests__/approvalQueue.test.ts
@@ -215,23 +215,23 @@ describe("ApprovalQueue — cancellation", () => {
     expect(q.cancel("not-a-real-id")).toBe(false);
   });
 
-  it("cancelAll resolves every pending promise with 'cancelled' and returns the count", async () => {
+  it("cancelAll resolves every pending promise with 'cancelled' and returns the cancelled callIds", async () => {
     const q = new ApprovalQueue();
     const a = q.request({ toolName: "x", params: { i: 1 }, tier: "high" });
     const b = q.request({ toolName: "y", params: { i: 2 }, tier: "high" });
     const c = q.request({ toolName: "z", params: { i: 3 }, tier: "high" });
     expect(q.size()).toBe(3);
-    const n = q.cancelAll();
-    expect(n).toBe(3);
+    const cancelled = q.cancelAll();
+    expect(cancelled.sort()).toEqual([a.callId, b.callId, c.callId].sort());
     expect(q.size()).toBe(0);
     await expect(a.promise).resolves.toBe("cancelled");
     await expect(b.promise).resolves.toBe("cancelled");
     await expect(c.promise).resolves.toBe("cancelled");
   });
 
-  it("cancelAll on an empty queue is a no-op returning 0", () => {
+  it("cancelAll on an empty queue is a no-op returning []", () => {
     const q = new ApprovalQueue();
-    expect(q.cancelAll()).toBe(0);
+    expect(q.cancelAll()).toEqual([]);
   });
 
   it("AbortSignal on request() resolves the promise with 'cancelled'", async () => {

--- a/src/__tests__/server-settings.test.ts
+++ b/src/__tests__/server-settings.test.ts
@@ -24,6 +24,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Logger } from "../logger.js";
 import { Server } from "../server.js";
 
+vi.mock("../approvalHttp.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../approvalHttp.js")>();
+  return { ...actual, dispatchCancelPush: vi.fn(async () => {}) };
+});
+
 // Stub loadPatchworkConfig / savePatchworkConfig so the handler doesn't need a
 // real ~/.patchwork directory.
 vi.mock("../patchworkConfig.js", async (importOriginal) => {
@@ -757,6 +762,79 @@ describe("POST /settings — kill-switch gate", () => {
     } finally {
       setFlag(KILL_SWITCH_WRITES, false);
     }
+  });
+});
+
+describe("POST /settings — approvalGate downgrade dismisses stale phone pushes", () => {
+  // Regression: cancelAll() resolving a pending entry with "cancelled" only
+  // updates in-memory state — nothing tells the phone to close the "tap to
+  // approve" notification it already received. Before the fix, that card
+  // sat on the lock screen forever pointing at a now-invalidated token.
+  afterEach(async () => {
+    const { resetApprovalQueueForTests } = await import("../approvalQueue.js");
+    resetApprovalQueueForTests();
+  });
+
+  it("calls dispatchCancelPush once per cancelled callId when gate drops to off", async () => {
+    const { dispatchCancelPush } = await import("../approvalHttp.js");
+    const { getApprovalQueue } = await import("../approvalQueue.js");
+    vi.mocked(dispatchCancelPush).mockClear();
+
+    server!.approvalGate = "high";
+    server!.pushServiceUrl = "https://relay.example.com";
+    server!.pushServiceToken = "tok_abc";
+
+    const queue = getApprovalQueue();
+    const { callId } = queue.request({
+      toolName: "Bash",
+      params: {},
+      tier: "high",
+    });
+
+    const { status } = await makeRequest(
+      {
+        method: "POST",
+        path: "/settings",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${TOKEN}`,
+        },
+      },
+      JSON.stringify({ approvalGate: "off" }),
+    );
+    expect(status).toBe(200);
+    expect(dispatchCancelPush).toHaveBeenCalledTimes(1);
+    expect(dispatchCancelPush).toHaveBeenCalledWith(
+      "https://relay.example.com",
+      "tok_abc",
+      callId,
+      false,
+    );
+  });
+
+  it("does not call dispatchCancelPush when no push service is configured", async () => {
+    const { dispatchCancelPush } = await import("../approvalHttp.js");
+    const { getApprovalQueue } = await import("../approvalQueue.js");
+    vi.mocked(dispatchCancelPush).mockClear();
+
+    server!.approvalGate = "high";
+    server!.pushServiceUrl = undefined;
+    server!.pushServiceToken = undefined;
+
+    getApprovalQueue().request({ toolName: "Bash", params: {}, tier: "high" });
+
+    await makeRequest(
+      {
+        method: "POST",
+        path: "/settings",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${TOKEN}`,
+        },
+      },
+      JSON.stringify({ approvalGate: "off" }),
+    );
+    expect(dispatchCancelPush).not.toHaveBeenCalled();
   });
 });
 

--- a/src/approvalHttp.ts
+++ b/src/approvalHttp.ts
@@ -626,6 +626,66 @@ async function dispatchPushNotification(
 }
 
 /**
+ * Tell the push relay to dismiss a previously-sent approval notification.
+ * Fired when a pending entry resolves via a path other than the phone tap
+ * itself — gate downgraded to "off" (`ApprovalQueue.cancelAll()`) or bridge
+ * shutdown — so a stale "tap to approve" card doesn't sit on the lock
+ * screen forever for a decision that's already moot. Same SSRF guard and
+ * fire-and-forget contract as `dispatchPushNotification`; a failed dismiss
+ * just means the notification lingers until the user dismisses it by hand,
+ * it never blocks the cancellation itself.
+ */
+export async function dispatchCancelPush(
+  pushServiceUrl: string,
+  pushServiceToken: string,
+  callId: string,
+  allowPrivate: boolean = false,
+): Promise<void> {
+  if (!pushServiceUrl.startsWith("https://")) {
+    console.warn(`[push] Rejected non-HTTPS push service URL`);
+    return;
+  }
+  let hostname: string;
+  try {
+    hostname = new URL(pushServiceUrl).hostname;
+  } catch {
+    console.warn(`[push] Malformed push service URL — skipping`);
+    return;
+  }
+  if (hostname === "localhost") {
+    console.warn(`[push] Blocked loopback push service hostname`);
+    return;
+  }
+  if (!allowPrivate && (await hostResolvesToBlockedIp(hostname, "push")))
+    return;
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 5_000);
+  try {
+    const res = await fetch(`${pushServiceUrl}/push`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${pushServiceToken}`,
+      },
+      body: JSON.stringify({ kind: "cancel", callId }),
+      signal: controller.signal,
+    });
+    if (!res.ok) {
+      console.warn(
+        `[push] Non-2xx from push relay (cancel): ${res.status} ${res.statusText}`,
+      );
+    }
+  } catch (err) {
+    console.warn(
+      `[push] Cancel dispatch failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
  * Publish an approval prompt to ntfy.sh with Approve / Reject HTTP action
  * buttons that POST back to the bridge using the single-use approval token.
  * Reuses the same SSRF guard as the push relay path. Fire-and-forget.

--- a/src/approvalQueue.ts
+++ b/src/approvalQueue.ts
@@ -394,15 +394,17 @@ export class ApprovalQueue {
    * Used when the operator downgrades the approval gate to "off" so
    * phone approvers don't see "Approve" buttons whose token is now
    * meaningless (the originating tool dispatch already short-circuited
-   * to bypass on the new gate). Returns the number of entries that
-   * were cancelled.
+   * to bypass on the new gate). Returns the callIds that were cancelled —
+   * callers use this to dismiss any outstanding phone push per entry
+   * (`dispatchCancelPush`), since resolving the promise here only updates
+   * in-memory state and does not reach the device.
    */
-  cancelAll(): number {
-    let n = 0;
+  cancelAll(): string[] {
+    const cancelled: string[] = [];
     for (const id of this.entries.keys()) {
-      if (this.resolveEntry(id, "cancelled")) n++;
+      if (this.resolveEntry(id, "cancelled")) cancelled.push(id);
     }
-    return n;
+    return cancelled;
   }
 
   list(): PendingApproval[] {

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -7,7 +7,10 @@ import { ActivityLog } from "./activityLog.js";
 import { buildSummary } from "./analyticsAggregator.js";
 import { getAnalyticsPref, getAnalyticsSalt } from "./analyticsPrefs.js";
 import { sendAnalytics } from "./analyticsSend.js";
-import { enqueueApprovalWithDispatch } from "./approvalHttp.js";
+import {
+  dispatchCancelPush,
+  enqueueApprovalWithDispatch,
+} from "./approvalHttp.js";
 import { getApprovalQueue } from "./approvalQueue.js";
 import { AutomationHooks, loadPolicy } from "./automation.js";
 import { loadOrCreateBridgeToken } from "./bridgeToken.js";
@@ -2385,7 +2388,19 @@ export class Bridge {
     // connection drops, an ungraceful teardown instead of the graceful
     // `cancelled` semantics this queue already has a dedicated discriminant
     // for. Resolve them here, while the transport is still reachable.
-    getApprovalQueue().cancelAll();
+    const cancelledOnShutdown = getApprovalQueue().cancelAll();
+    const shutdownPushUrl = this.server.pushServiceUrl;
+    const shutdownPushToken = this.server.pushServiceToken;
+    if (shutdownPushUrl && shutdownPushToken) {
+      for (const callId of cancelledOnShutdown) {
+        dispatchCancelPush(
+          shutdownPushUrl,
+          shutdownPushToken,
+          callId,
+          this.server.pushServiceAllowPrivate ?? false,
+        ).catch(() => {});
+      }
+    }
     try {
       await this.server.close();
     } catch {

--- a/src/server.ts
+++ b/src/server.ts
@@ -12,7 +12,11 @@ import {
   getTelemetryPrefs,
   setTelemetryPrefs,
 } from "./analyticsPrefs.js";
-import { handleApprovalsStream, routeApprovalRequest } from "./approvalHttp.js";
+import {
+  dispatchCancelPush,
+  handleApprovalsStream,
+  routeApprovalRequest,
+} from "./approvalHttp.js";
 import { getApprovalQueue } from "./approvalQueue.js";
 import type { AttributedPermissionRules } from "./ccPermissions.js";
 import {
@@ -2243,10 +2247,20 @@ export class Server extends EventEmitter<ServerEvents> {
               // and any pending phone notification reflects reality.
               if (gateRaw === "off" && prevGate !== "off") {
                 const cancelled = getApprovalQueue().cancelAll();
-                if (cancelled > 0) {
+                if (cancelled.length > 0) {
                   this.logger.info(
-                    `[/settings] approvalGate → off; cancelled ${cancelled} pending entr${cancelled === 1 ? "y" : "ies"}`,
+                    `[/settings] approvalGate → off; cancelled ${cancelled.length} pending entr${cancelled.length === 1 ? "y" : "ies"}`,
                   );
+                  if (this.pushServiceUrl && this.pushServiceToken) {
+                    for (const callId of cancelled) {
+                      dispatchCancelPush(
+                        this.pushServiceUrl,
+                        this.pushServiceToken,
+                        callId,
+                        this.pushServiceAllowPrivate,
+                      ).catch(() => {});
+                    }
+                  }
                 }
               }
             }


### PR DESCRIPTION
## Summary
- `ApprovalQueue.cancelAll()` (fired on approval-gate downgrade to \"off\" and on bridge shutdown) resolves pending entries in-memory but never told the phone to close the push notification it already showed — a stale \"tap to approve\" card could sit on the lock screen forever pointing at an already-invalidated token.
- Adds `dispatchCancelPush()` (mirrors the existing `dispatchPushNotification`'s SSRF guard/fire-and-forget contract), wired into both `cancelAll()` call sites.
- Dashboard relay route fans a `{ kind: "cancel", callId }` payload out via Web Push; the service worker closes any notification tagged `approval-${callId}` on receipt.
- `cancelAll()` now returns the cancelled callIds instead of a count, so callers can act per-entry.
- ntfy-based approvals are out of scope — ntfy.sh has no programmatic dismiss API.

Found during this session's mining pass (8th) as a High-severity gap alongside the already-merged #1177 (approval queue drained on shutdown).

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx tsc --noEmit -p tsconfig.tests.core.json` clean
- [x] New regression tests in `server-settings.test.ts` / `approvalQueue.test.ts` / dashboard relay route test, verified failing on pre-fix code and passing with the fix
- [x] `npx biome check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)