### PR TITLE
fix(plugins): don't advance the plugin registry when a hot-reload fails on a live transport

### DIFF
--- a/src/__tests__/pluginWatcher.test.ts
+++ b/src/__tests__/pluginWatcher.test.ts
@@ -374,6 +374,52 @@ describe("PluginWatcher", () => {
     watcher.stop();
   });
 
+  // Regression: applying a broken reload to every live transport used to
+  // roll each transport back to `old.tools` but still commit `fresh` to
+  // `loadedPlugins` (the source `getTools()` reads from). Any NEW session
+  // connecting after the failed reload would then be seeded with the
+  // broken `fresh` tools via `getTools()`, even though every EXISTING
+  // session correctly kept running the old ones.
+  it("reloadPlugin() — replaceTool throws on every transport — does NOT advance loadedPlugins/getTools(), does NOT call sendListChanged", async () => {
+    const config = makeConfig();
+    const logger = makeLogger();
+    const sendListChanged = vi.fn();
+    const watcher = new PluginWatcher(config, logger, sendListChanged);
+
+    const spec = "./my-plugin";
+    const plugin = makeLoadedPlugin(spec, tmpDir, "testPluginOld");
+    watcher.start([plugin]);
+
+    const freshPlugin = makeLoadedPlugin(spec, tmpDir, "testPluginBroken");
+    vi.mocked(loadOnePluginFull).mockResolvedValueOnce(freshPlugin);
+
+    const transport = makeTransport();
+    vi.mocked(transport.replaceTool).mockImplementation((schema) => {
+      // Fail applying the fresh tool, succeed on the old-tools rollback pass.
+      if (schema.name === "testPluginBroken") {
+        throw new Error("ajv.compile: invalid outputSchema");
+      }
+    });
+    watcher.addTransport(transport);
+
+    await watcher.reloadPlugin(spec);
+
+    // Rollback ran: transport ends up re-registered with the old tool.
+    expect(vi.mocked(transport.replaceTool)).toHaveBeenCalledWith(
+      plugin.tools[0]!.schema,
+      plugin.tools[0]!.handler,
+      undefined,
+    );
+    // But the canonical registry must NOT advance to the broken version —
+    // a session connecting right now must still see the old tools.
+    expect(sendListChanged).not.toHaveBeenCalled();
+    const tools = watcher.getTools();
+    expect(tools).toHaveLength(1);
+    expect(tools[0]!.schema.name).toBe("testPluginOld");
+
+    watcher.stop();
+  });
+
   it("getTools() returns flat list of all plugin tools", () => {
     const config = makeConfig();
     const logger = makeLogger();

--- a/src/pluginWatcher.ts
+++ b/src/pluginWatcher.ts
@@ -137,6 +137,7 @@ export class PluginWatcher {
     }
 
     // Apply to all active transports
+    let anyTransportFailed = false;
     for (const transport of this.transports) {
       try {
         transport.deregisterToolsByPrefix(old.manifest.toolNamePrefix);
@@ -144,6 +145,7 @@ export class PluginWatcher {
           transport.replaceTool(t.schema, t.handler, t.timeoutMs);
         }
       } catch (err) {
+        anyTransportFailed = true;
         this.logger.warn(
           `[plugin-watch] Failed to patch transport for "${fresh.manifest.name}": ${err instanceof Error ? err.message : String(err)}; attempting rollback`,
         );
@@ -162,6 +164,20 @@ export class PluginWatcher {
           );
         }
       }
+    }
+
+    // Only advance the canonical registry when every live transport actually
+    // took `fresh`. Committing it unconditionally used to leak a broken
+    // reload into `getTools()`/`pluginTools` — every EXISTING session had
+    // correctly rolled back to `old.tools` above, but any NEW session
+    // connecting afterwards (new IDE window, new HTTP session, WS
+    // reconnect) was seeded from `loadedPlugins`, which still pointed at
+    // the version that just failed to apply everywhere.
+    if (anyTransportFailed) {
+      this.logger.warn(
+        `[plugin-watch] Not advancing registry for "${old.manifest.name}" — reload failed on at least one transport; new sessions will keep using the previous tools`,
+      );
+      return;
     }
 
     this.loadedPlugins.set(spec, fresh);


### PR DESCRIPTION
## Summary
- \`PluginWatcher._reloadPluginInner()\` correctly rolls a transport back to \`old.tools\` when applying a reload fails (e.g. \`ajv.compile()\` rejecting a malformed \`outputSchema\`, or a disallowed tool name introduced by an edit) — but it then unconditionally committed the broken "fresh" plugin to \`this.loadedPlugins\` and fired \`sendListChanged()\` regardless of whether *any* transport actually ended up running it.
- \`getTools()\` reads from \`loadedPlugins\`, and it seeds tool registration for brand-new sessions (both the WS path in \`bridge.ts\` and the HTTP session path in \`streamableHttp.ts\`), not just existing ones. So a plugin edit that fails to apply — where every existing session correctly stays on the old tools — would still get committed as canonical, and any new session connecting afterwards got handed the broken schema instead of the one every live session was actually running.
- Fix: track whether any transport's apply failed and only commit \`loadedPlugins.set(spec, fresh)\` / call \`sendListChanged()\` when every transport succeeded.

Found during this session's 9th mining pass — fresh territory (plugin hot-reload consistency), not covered by the 15 prior findings (#1167–#1180).

## Test plan
- [x] \`npx tsc --noEmit\` clean
- [x] \`npx tsc --noEmit -p tsconfig.tests.core.json\` clean
- [x] New regression test in \`pluginWatcher.test.ts\`, verified failing on the prior code (asserted \`sendListChanged\` not called / \`getTools()\` still returning the old tool name — failed because the old code called it and returned the broken tool) and passing with the fix
- [x] \`npx biome check\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)