### PR TITLE
fix(oauth): enforce Mcp-Session-Token in OAuth mode instead of treating a missing header as automatically allowed

### DIFF
--- a/src/__tests__/streamableHttp.test.ts
+++ b/src/__tests__/streamableHttp.test.ts
@@ -326,6 +326,75 @@ describe("Streamable HTTP: per-session ownership token", () => {
     );
     expect(res.status).toBe(200);
   });
+});
+
+// Regression: checkOwnership() previously allowed ANY request that simply
+// omitted Mcp-Session-Token, even in OAuth mode — the exact deployment the
+// token exists to protect, where multiple distinct clients share visibility
+// of the bridge and could plausibly learn each other's Mcp-Session-Id. An
+// attacker who knew a victim's session ID could hijack it by never sending
+// the header at all. Sessions created while OAuth mode is active
+// (resolveScopeFn configured) now require the header.
+describe("Streamable HTTP: per-session ownership token — OAuth mode enforcement", () => {
+  let oauthHandler: StreamableHttpHandler | null = null;
+  let oauthPort: number;
+
+  beforeEach(async () => {
+    const deps = makeDeps();
+    const oauthServer = new Server(TOKEN, logger);
+    oauthHandler = new StreamableHttpHandler(
+      deps.config as any,
+      {} as any,
+      deps.extensionClient as any,
+      deps.activityLog as any,
+      deps.fileLock as any,
+      new Map(),
+      null,
+      logger,
+      () => [],
+      () => null,
+      () => null, // resolveScopeFn configured — simulates OAuth mode active
+    );
+    oauthServer.httpMcpHandler = (req, res) => oauthHandler!.handle(req, res);
+    oauthPort = await oauthServer.findAndListen(null);
+    (oauthHandler as unknown as { __server: Server }).__server = oauthServer;
+  });
+
+  afterEach(async () => {
+    const s = (oauthHandler as unknown as { __server: Server })?.__server;
+    oauthHandler?.close();
+    oauthHandler = null;
+    await s?.close();
+  });
+
+  it("DELETE without Mcp-Session-Token is REJECTED (403) in OAuth mode", async () => {
+    const { sid } = await initSession(oauthPort);
+    const res = await httpReq(oauthPort, "DELETE", sid); // no token
+    expect(res.status).toBe(403);
+  });
+
+  it("DELETE with the correct Mcp-Session-Token still succeeds in OAuth mode", async () => {
+    const { sid, token } = await initSession(oauthPort);
+    const res = await httpReq(oauthPort, "DELETE", sid, token);
+    expect(res.status).toBe(204);
+  });
+
+  it("DELETE with a wrong Mcp-Session-Token is rejected (403) in OAuth mode", async () => {
+    const { sid } = await initSession(oauthPort);
+    const wrongToken = "0".repeat(64);
+    const res = await httpReq(oauthPort, "DELETE", sid, wrongToken);
+    expect(res.status).toBe(403);
+  });
+
+  it("POST without Mcp-Session-Token is REJECTED (403) in OAuth mode", async () => {
+    const { sid } = await initSession(oauthPort);
+    const res = await post(
+      oauthPort,
+      { jsonrpc: "2.0", id: 2, method: "tools/list", params: {} },
+      sid, // no token
+    );
+    expect(res.status).toBe(403);
+  });
 
   it("session A's token cannot DELETE session B (cross-session takeover)", async () => {
     const a = await initSession(port);

--- a/src/streamableHttp.ts
+++ b/src/streamableHttp.ts
@@ -324,6 +324,18 @@ interface HttpSession {
    * insufficient.
    */
   ownershipToken: string;
+  /**
+   * Whether `checkOwnership` must reject requests that omit
+   * `Mcp-Session-Token` entirely, not just ones that present a wrong
+   * value. True only for sessions created while OAuth mode is active
+   * (`resolveScopeFn` configured) — the multi-client-shared-bridge
+   * scenario the token was introduced to protect. False for the
+   * single-user local/VPS bearer-token deployment, where standard MCP
+   * clients (Gemini CLI, Codex) that never send the header must keep
+   * working and no other client realistically has visibility into this
+   * bridge's session IDs.
+   */
+  requireOwnershipToken: boolean;
 }
 
 /** Constant-time hex-string comparison; both inputs must be same length. */
@@ -340,18 +352,22 @@ function hexEquals(a: string, b: string): boolean {
 /**
  * Verifies the `Mcp-Session-Token` header matches the session's ownership
  * token. Returns `true` if authorized.
- * The header is optional — standard MCP clients (Gemini CLI, Codex, etc.)
- * don't send it and the Bearer token already authenticated them. The check
- * only applies when the header is present, preventing session-ID hijacking
- * in shared-bridge-token / OAuth deployments where multiple clients share a
- * single Bearer token and could theoretically know each other's session IDs.
+ *
+ * For most sessions the header is optional — standard MCP clients (Gemini
+ * CLI, Codex, etc.) don't send it and the Bearer token already
+ * authenticated them, so a missing header is allowed. But when
+ * `session.requireOwnershipToken` is set (OAuth mode — multiple distinct
+ * clients share visibility of the same bridge and could plausibly learn
+ * each other's session IDs), a missing header is REJECTED, not allowed:
+ * an attacker who simply omits the header would otherwise defeat the
+ * entire point of the token by not presenting one at all.
  */
 function checkOwnership(
   req: http.IncomingMessage,
-  session: { ownershipToken: string },
+  session: { ownershipToken: string; requireOwnershipToken: boolean },
 ): boolean {
   const presented = req.headers["mcp-session-token"];
-  if (typeof presented !== "string") return true; // header absent → allowed
+  if (typeof presented !== "string") return !session.requireOwnershipToken;
   return hexEquals(presented, session.ownershipToken);
 }
 
@@ -831,6 +847,12 @@ export class StreamableHttpHandler {
       inFlight: 0,
       claudeCodeSessionId: null,
       ownershipToken,
+      // Gated on OAuth mode being active for this bridge instance (not on
+      // whether this particular token happens to carry a scope) — even a
+      // full-access OAuth token still shares the bridge with other OAuth
+      // clients, which is the multi-client-visibility risk the token
+      // exists to close.
+      requireOwnershipToken: this.resolveScopeFn !== null,
     } as HttpSession;
     const adapter = new HttpAdapter(
       (msg) => this.logger.warn(msg),


### PR DESCRIPTION
## Summary
- \`checkOwnership()\` (src/streamableHttp.ts) only checked \`Mcp-Session-Token\` when the caller sent it — a missing header was unconditionally allowed.
- The token exists specifically to stop a caller who knows/captured another client's \`Mcp-Session-Id\` (plausible in shared-bearer-token/OAuth deployments) from hijacking that session's SSE stream, DELETE-ing it, or impersonating its POST traffic — but that exact attacker defeats the check trivially by just never sending the header, since absence was treated as authorized. The mitigation only stopped a strictly *weaker* attacker (wrong token), not the one it was written for.
- Standard MCP clients (Gemini CLI, Codex) never send this header and rely on the Bearer token alone, so unconditionally requiring it would break local/VPS single-bearer-token deployments.
- Fix: gate enforcement on whether OAuth mode is active for the bridge instance (\`resolveScopeFn\` configured — the actual multi-client-shared-bridge scenario this token protects) via a new \`requireOwnershipToken\` field set at session creation. Non-OAuth sessions keep the existing optional-header behavior; OAuth sessions now reject a missing header the same way they already rejected a wrong one.

Found during this session's 10th mining pass; the fix approach (scope enforcement to OAuth-bound sessions rather than enforcing globally or leaving it undocumented) was confirmed with the repo owner before implementing, given the security/compatibility tradeoff.

## Test plan
- [x] \`npx tsc --noEmit\` clean
- [x] \`npx tsc --noEmit -p tsconfig.tests.core.json\` clean
- [x] New regression tests constructing a handler with OAuth mode active, verified failing on the prior code (missing header allowed through with 204/200 instead of 403) and passing with the fix
- [x] \`npx biome check\` clean (pre-existing unused-var warnings in the same test file, unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)