### PR TITLE
fix(automation): fix DNS-rebinding IP-pinning silently no-op'ing for uppercase hostnames

### DIFF
--- a/src/fp/__tests__/interpreterContext.test.ts
+++ b/src/fp/__tests__/interpreterContext.test.ts
@@ -164,6 +164,61 @@ describe("VsCodeBackend.postWebhook — SSRF DNS pre-resolution (LOW #25)", () =
     expect(headers["Host"] ?? headers["host"]).toBe("example.com");
   });
 
+  // Regression: URL always lowercases parsed.hostname, so pinning that did
+  // opts.url.replace(parsed.hostname, pinnedHost) silently no-op'd for any
+  // URL with uppercase letters in its host — fetch() then re-resolved the
+  // original hostname itself, reopening the exact DNS-rebinding TOCTOU
+  // window M15 exists to close, with no error/log to signal the failure.
+  it("still pins the resolved IP when the URL's hostname has uppercase letters", async () => {
+    vi.mocked(dns.lookup).mockResolvedValue({
+      address: "93.184.216.34",
+      family: 4,
+    });
+    fetchMock.mockResolvedValue({ ok: true, status: 200 });
+
+    const backend = makeBackend(false);
+    await backend.postWebhook({
+      url: "http://MyHooks.Example.COM/hook",
+      method: "POST",
+      headers: {},
+      body: { x: 1 },
+      hookKey: "test",
+    });
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [calledUrl, calledOpts] = fetchMock.mock.calls[0] as [
+      string,
+      RequestInit & { headers: Record<string, string> },
+    ];
+    expect(calledUrl).toContain("93.184.216.34");
+    expect(calledUrl.toLowerCase()).not.toContain("myhooks.example.com");
+    const headers = calledOpts.headers as Record<string, string>;
+    expect((headers["Host"] ?? headers["host"])?.toLowerCase()).toBe(
+      "myhooks.example.com",
+    );
+  });
+
+  it("pins an IPv6 resolved address in bracket form", async () => {
+    vi.mocked(dns.lookup).mockResolvedValue({
+      address: "2606:2800:220:1:248:1893:25c8:1946",
+      family: 6,
+    });
+    fetchMock.mockResolvedValue({ ok: true, status: 200 });
+
+    const backend = makeBackend(false);
+    await backend.postWebhook({
+      url: "http://example.com/hook",
+      method: "POST",
+      headers: {},
+      body: {},
+      hookKey: "test",
+    });
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [calledUrl] = fetchMock.mock.calls[0] as [string, unknown];
+    expect(calledUrl).toContain("[2606:2800:220:1:248:1893:25c8:1946]");
+  });
+
   it("allows private IPs when allowPrivateWebhooks=true", async () => {
     // With the allow-private flag, private hosts are permitted regardless.
     vi.mocked(dns.lookup).mockResolvedValue({

--- a/src/fp/interpreterContext.ts
+++ b/src/fp/interpreterContext.ts
@@ -257,9 +257,20 @@ export class VsCodeBackend implements Backend {
           );
           return { ok: false, error };
         }
-        // Pin the resolved IP: replace hostname with IP in the URL.
+        // Pin the resolved IP by mutating the URL object's hostname
+        // directly — NOT opts.url.replace(parsed.hostname, pinnedHost).
+        // parsed.hostname is always lowercased by the WHATWG URL parser,
+        // so a string .replace() against the original (possibly
+        // mixed-case) opts.url silently finds no match and returns
+        // opts.url unchanged for any URL with uppercase letters in its
+        // host — quietly defeating the whole point of pinning (the
+        // subsequent fetch() then re-resolves the hostname itself,
+        // reopening the DNS-rebinding TOCTOU window this code exists to
+        // close, with no error/log to indicate the pin failed).
         const pinnedHost = family === 6 ? `[${address}]` : address;
-        fetchUrl = opts.url.replace(parsed.hostname, pinnedHost);
+        const pinnedUrl = new URL(opts.url);
+        pinnedUrl.hostname = pinnedHost;
+        fetchUrl = pinnedUrl.href;
       } catch {
         // DNS failure is treated as non-blocking — let the subsequent fetch
         // surface the real network error. This mirrors the policy in


### PR DESCRIPTION
## Summary
- \`VsCodeBackend.postWebhook()\`'s M15 IP-pinning defense (closes the DNS-rebinding TOCTOU window between the SSRF pre-check and the actual \`fetch()\`) built the pinned URL via \`opts.url.replace(parsed.hostname, pinnedHost)\`.
- \`parsed.hostname\` comes from the WHATWG \`URL\` parser, which always lowercases the host. So for any webhook URL with uppercase letters in its hostname (e.g. \`https://MyHooks.example.com/...\` — an entirely ordinary thing for an operator to type or paste), the string \`.replace()\` finds no match and silently returns \`opts.url\` unchanged.
- \`fetchUrl\` then still points at the original hostname, the Host-header-override guard (\`if (fetchUrl !== opts.url)\`) is skipped too, and the subsequent \`fetch()\` re-resolves the hostname itself with **no log or error** indicating the pin failed — reopening exactly the DNS-rebinding window M15 exists to close, for a very common URL shape.
- Fix: build the pinned URL by mutating a cloned \`URL\` object's \`.hostname\` directly instead of string-replacing against the raw input, so casing can't defeat the substitution. Also confirmed IPv6 addresses pin correctly in bracket form (\`[::1]\`).

Found during this session's 11th mining pass.

## Test plan
- [x] \`npx tsc --noEmit\` clean
- [x] \`npx tsc --noEmit -p tsconfig.tests.core.json\` clean
- [x] New regression tests, verified failing on the prior code (fetch called with the original mixed-case hostname instead of the pinned IP) and passing with the fix
- [x] \`npx biome check\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)