### PR TITLE
fix(dashboard): stop bundle-install panel from double-counting recipes on retry

### DIFF
--- a/dashboard/src/app/marketplace/bundle/[...slug]/BundleInstallPanel.tsx
+++ b/dashboard/src/app/marketplace/bundle/[...slug]/BundleInstallPanel.tsx
@@ -73,7 +73,19 @@ export default function BundleInstallPanel({
   fileAccess,
 }: Props) {
   const [bridgeStatus, setBridgeStatus] = useState<BridgeStatus>("checking");
-  const [installedCount, setInstalledCount] = useState(0);
+  // Tracks WHICH manifest recipes are confirmed installed, not just a
+  // count. The bridge's bundle installer has no skip-if-already-installed
+  // check — every /recipes/install call re-installs (or replaces) every
+  // recipe named in the manifest and returns all of them in `installed[]`,
+  // regardless of whether they succeeded on a prior call. Accumulating
+  // `prev + body.installed.length` across retries double-counted recipes
+  // that were already installed before the retry, permanently overshooting
+  // recipes.length and getting the panel stuck out of both the "all
+  // installed" and "partial" states. A Set keyed by recipe name is
+  // idempotent across repeated installs of the same recipe.
+  const [installedNames, setInstalledNames] = useState<Set<string>>(
+    new Set(),
+  );
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState<string | null>(null);
   const [result, setResult] = useState<BundleInstallResponse | null>(null);
@@ -102,7 +114,7 @@ export default function BundleInstallPanel({
           : Array.isArray(data?.recipes)
             ? data.recipes
             : [];
-        const installedNames = new Set<string>(
+        const bridgeInstalledNames = new Set<string>(
           list
             .map((x: { name?: string }) => x.name)
             .filter((n: string | undefined): n is string => Boolean(n)),
@@ -110,11 +122,11 @@ export default function BundleInstallPanel({
         // Bundle manifest entries may be scoped (`@scope/name`); the
         // bridge writes recipes under their unscoped YAML `name:`. Strip
         // the scope before comparing.
-        const count = recipes.filter((r) =>
-          installedNames.has(shortName(r)),
-        ).length;
+        const matched = recipes.filter((r) =>
+          bridgeInstalledNames.has(shortName(r)),
+        );
         setBridgeStatus("online");
-        setInstalledCount(count);
+        setInstalledNames(new Set(matched));
       })
       .catch(() => {
         if (!cancelled) setBridgeStatus("offline");
@@ -151,13 +163,25 @@ export default function BundleInstallPanel({
         if (res.status === 401) setBridgeStatus("unauth");
         else if (res.status >= 500) setBridgeStatus("offline");
         setErr(body.error ?? `Install failed (HTTP ${res.status})`);
-        // Still bump the count when partial — those recipes ARE
-        // installed even if the bundle as a whole errored.
+        // Still record the installs when partial — those recipes ARE
+        // installed even if the bundle as a whole errored. Merge into
+        // the Set rather than adding a count — the bridge re-installs
+        // every manifest recipe on every call (no skip-if-installed
+        // check), so `installed[]` may re-list recipes from a prior
+        // successful call.
         if (hasInstalled) {
-          setInstalledCount((prev) => prev + body.installed!.length);
+          setInstalledNames((prev) => {
+            const next = new Set(prev);
+            for (const item of body.installed!) next.add(item.name);
+            return next;
+          });
         }
       } else if (hasInstalled) {
-        setInstalledCount((prev) => prev + body.installed!.length);
+        setInstalledNames((prev) => {
+          const next = new Set(prev);
+          for (const item of body.installed!) next.add(item.name);
+          return next;
+        });
       }
     } catch (e) {
       setErr(e instanceof Error ? e.message : String(e));
@@ -177,6 +201,10 @@ export default function BundleInstallPanel({
     }
   }
 
+  // Intersect against `recipes` (not just installedNames.size) so a stray
+  // name in the Set that no longer matches the current manifest can never
+  // inflate the count past recipes.length.
+  const installedCount = recipes.filter((r) => installedNames.has(r)).length;
   const allInstalled = installedCount === recipes.length && recipes.length > 0;
   const partialInstalled = installedCount > 0 && installedCount < recipes.length;
 

--- a/dashboard/src/app/marketplace/bundle/[...slug]/__tests__/BundleInstallPanel.test.tsx
+++ b/dashboard/src/app/marketplace/bundle/[...slug]/__tests__/BundleInstallPanel.test.tsx
@@ -233,6 +233,74 @@ describe("BundleInstallPanel — install action", () => {
     ).toBeInTheDocument();
   });
 
+  // Regression: the bridge's bundle installer has no skip-if-already-installed
+  // check — every /recipes/install call re-installs (or replaces) every
+  // manifest recipe and returns ALL of them in installed[], not just the ones
+  // newly installed by that call. Retrying after a partial failure used to
+  // add the full retry response length on top of the earlier partial count,
+  // overshooting recipes.length and getting the panel stuck unable to reach
+  // either the "all installed" or "partial" copy.
+  it("does not double-count recipes on retry after a partial failure (regression)", async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(200, { recipes: [] })) // status poll
+      .mockResolvedValueOnce(
+        // First install attempt: 2 succeed, 1 fails.
+        jsonResponse(200, {
+          ok: true,
+          kind: "bundle",
+          installed: [
+            { name: "a-recipe", action: "created" },
+            { name: "b-recipe", action: "created" },
+          ],
+          failures: [{ name: "c-recipe", error: "Upstream returned 500" }],
+        }),
+      )
+      .mockResolvedValueOnce(
+        // Retry: bridge re-installs/replaces ALL 3 recipes (not just the
+        // one that failed before) and reports all 3 as installed.
+        jsonResponse(200, {
+          ok: true,
+          kind: "bundle",
+          installed: [
+            { name: "a-recipe", action: "replaced" },
+            { name: "b-recipe", action: "replaced" },
+            { name: "c-recipe", action: "created" },
+          ],
+          failures: [],
+        }),
+      );
+    render(<BundleInstallPanel installSource={SOURCE} recipes={RECIPES} name={NAME} />);
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: /Install bundle/i }),
+      ).toBeInTheDocument(),
+    );
+
+    // First attempt — partial.
+    fireEvent.click(screen.getByRole("button", { name: /Install bundle/i }));
+    let confirmBtns = screen.getAllByRole("button", { name: /Install bundle/i });
+    fireEvent.click(confirmBtns[confirmBtns.length - 1]);
+    await waitFor(() =>
+      expect(screen.getByText(/2 of 3 recipes already installed/i)).toBeInTheDocument(),
+    );
+
+    // Retry — all 3 now succeed.
+    fireEvent.click(screen.getByRole("button", { name: /Install bundle/i }));
+    confirmBtns = screen.getAllByRole("button", { name: /Install bundle/i });
+    fireEvent.click(confirmBtns[confirmBtns.length - 1]);
+
+    await waitFor(() =>
+      expect(screen.getByText(/All 3 recipes installed/i)).toBeInTheDocument(),
+    );
+    // The stale "N of 3" partial copy and the Install button must both be
+    // gone — pre-fix, the count overshot to 5 and neither the "all
+    // installed" nor "partial" branch matched, so the panel fell through
+    // to showing the Install button again forever.
+    expect(
+      screen.queryByRole("button", { name: /Install bundle/i }),
+    ).not.toBeInTheDocument();
+  });
+
   it("surfaces an error banner when bridge returns 502 with no installed[]", async () => {
     fetchMock
       .mockResolvedValueOnce(jsonResponse(200, { recipes: [] }))


### PR DESCRIPTION
## Summary
- \`BundleInstallPanel\` accumulated \`installedCount\` as \`prev + body.installed.length\` on every install response. The bridge's bundle installer has no skip-if-already-installed check — every \`/recipes/install\` call re-installs (or replaces) **every** recipe named in the manifest and returns all of them in \`installed[]\`, not just the ones newly installed by that call.
- Concrete failure: a 5-recipe bundle has 2 succeed / 3 fail (transient 5xx) → \`installedCount = 2\`. User retries; this time all 5 succeed and \`installed[]\` lists all 5 → \`installedCount\` becomes \`2 + 5 = 7\`, permanently overshooting \`recipes.length\` (5). Both \`allInstalled\` and \`partialInstalled\` become false, so the panel falls through to showing "install all 5 recipes" again forever even though the bundle fully installed.
- Fix: track installed recipe names in a \`Set\` instead of accumulating a count — merging \`installed[]\` entries is idempotent across retries. \`installedCount\` is now derived by intersecting the Set against the current \`recipes\` prop.

Found during this session's 12th mining pass.

## Test plan
- [x] \`npx tsc --noEmit\` clean (both dashboard and root)
- [x] \`npx tsc --noEmit -p tsconfig.tests.core.json\` clean
- [x] New regression test simulating the retry-after-partial-failure sequence, verified failing on the prior code (stuck on the raw per-response "Installed N recipes" line, Install button still present) and passing with the fix
- [x] \`next lint\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)