### PR TITLE
fix(dashboard): gate one-click install on YAML-vs-metadata trust divergence, not just registry metadata

### DIFF
--- a/dashboard/src/app/marketplace/[...slug]/InstallPanel.tsx
+++ b/dashboard/src/app/marketplace/[...slug]/InstallPanel.tsx
@@ -28,6 +28,18 @@ interface Props {
   connectors?: string[];
   networkAccess?: boolean;
   fileAccess?: boolean;
+  /**
+   * True when the recipe's actual YAML (fetched live from GitHub)
+   * contradicts the registry's self-reported risk metadata above — e.g.
+   * `risk_level: "low"` but the YAML contains high-risk file/network
+   * steps (see `detectTrustDivergence` in TrustDivergenceNotice.tsx).
+   * The registry is community-maintained and unsigned, so a stale or
+   * dishonest entry could otherwise get a bare one-click Install button
+   * while the contradiction warning renders further down the same page,
+   * after the button the user already clicked. Any divergence forces the
+   * confirm dialog regardless of what the metadata alone would allow.
+   */
+  hasTrustDivergence?: boolean;
 }
 
 // Three-state instead of boolean — distinguishes 401 (logged-out
@@ -47,6 +59,7 @@ export default function InstallPanel({
   connectors,
   networkAccess,
   fileAccess,
+  hasTrustDivergence,
 }: Props) {
   const [bridgeStatus, setBridgeStatus] = useState<BridgeStatus>("checking");
   const [installed, setInstalled] = useState(false);
@@ -70,11 +83,12 @@ export default function InstallPanel({
   // is exactly ONE definition of "needs confirmation". Only bypass the
   // dialog when the recipe EXPLICITLY claims low risk AND disclaims
   // network + file access; anything missing those flags fails closed.
-  const elevated = requiresElevatedConfirm({
-    risk_level: riskLevel,
-    network_access: networkAccess,
-    file_access: fileAccess,
-  });
+  const elevated =
+    requiresElevatedConfirm({
+      risk_level: riskLevel,
+      network_access: networkAccess,
+      file_access: fileAccess,
+    }) || !!hasTrustDivergence;
 
   useEffect(() => {
     let cancelled = false;

--- a/dashboard/src/app/marketplace/[...slug]/__tests__/InstallPanel.test.tsx
+++ b/dashboard/src/app/marketplace/[...slug]/__tests__/InstallPanel.test.tsx
@@ -96,6 +96,59 @@ describe("InstallPanel — install-confirm dialog", () => {
     await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
   });
 
+  // Regression: InstallPanel's elevated-confirm gate previously looked
+  // ONLY at the registry's self-reported (unsigned, community-maintained)
+  // risk_level/network_access/file_access — the reconciliation against the
+  // recipe's actual YAML (detectTrustDivergence, in TrustDivergenceNotice)
+  // rendered further down the same page but never fed back into this
+  // gate. A recipe that claimed low-risk while its real YAML disagreed
+  // still got a bare one-click Install button.
+  it("opens the confirm dialog when hasTrustDivergence is true even though metadata claims low-risk", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(200, { recipes: [] })); // status poll
+    render(
+      <InstallPanel
+        install={INSTALL}
+        name={NAME}
+        riskLevel="low"
+        networkAccess={false}
+        fileAccess={false}
+        hasTrustDivergence={true}
+      />,
+    );
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: /^Install$/i }),
+      ).toBeInTheDocument(),
+    );
+    fireEvent.click(screen.getByRole("button", { name: /^Install$/i }));
+    // Dialog opens — install POST does NOT fire yet.
+    await screen.findByRole("dialog");
+    expect(fetchMock).toHaveBeenCalledTimes(1); // status poll only
+  });
+
+  it("still installs in one tap when hasTrustDivergence is false and metadata is low-risk", async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(200, { recipes: [] })) // status poll
+      .mockResolvedValueOnce(jsonResponse(200, { ok: true })); // install
+    render(
+      <InstallPanel
+        install={INSTALL}
+        name={NAME}
+        riskLevel="low"
+        networkAccess={false}
+        fileAccess={false}
+        hasTrustDivergence={false}
+      />,
+    );
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: /^Install$/i }),
+      ).toBeInTheDocument(),
+    );
+    fireEvent.click(screen.getByRole("button", { name: /^Install$/i }));
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+  });
+
   it("opens the confirm dialog when trust metadata is missing (live-registry case)", async () => {
     // Marketplace trust Wave 0 — the live registry doesn't carry
     // risk_level / network_access / file_access on any recipe today.

--- a/dashboard/src/app/marketplace/[...slug]/page.tsx
+++ b/dashboard/src/app/marketplace/[...slug]/page.tsx
@@ -14,7 +14,10 @@ import {
   shortName,
   summarizeRisk,
 } from "@/lib/registry";
-import { TrustDivergenceNotice } from "../_components/TrustDivergenceNotice";
+import {
+  detectTrustDivergence,
+  TrustDivergenceNotice,
+} from "../_components/TrustDivergenceNotice";
 import InstallPanel from "./InstallPanel";
 
 // 60s ISR (was 300s). A 5-minute cache hides freshly merged recipes
@@ -98,6 +101,25 @@ export default async function RecipeDetailPage({ params }: PageProps) {
     }
   }
 
+  // Computed once and shared by InstallPanel's elevated-confirm gate and
+  // TrustDivergenceNotice's warning banner, so they can never disagree.
+  // Pre-fix, InstallPanel's one-click-vs-confirm decision only looked at
+  // the registry's self-reported (community-maintained, unsigned)
+  // risk_level/network_access/file_access — a recipe whose actual YAML
+  // contradicted that metadata (declared low-risk but the fetched YAML has
+  // high-risk file/network steps) still got a bare one-click Install
+  // button; the divergence warning rendered further down the page only
+  // AFTER the button the user had already clicked.
+  const divergenceMeta = {
+    risk_level: recipe.risk_level,
+    network_access: recipe.network_access,
+    file_access: recipe.file_access,
+  };
+  const riskSummary = yaml
+    ? summarizeRisk(yaml)
+    : { low: 0, medium: 0, high: 0, steps: 0 };
+  const trustDivergence = detectTrustDivergence(divergenceMeta, riskSummary);
+
   return (
     <section style={{ display: "flex", flexDirection: "column", gap: "var(--s-6)" }}>
       <Link
@@ -119,6 +141,7 @@ export default async function RecipeDetailPage({ params }: PageProps) {
         connectors={recipe.connectors}
         networkAccess={recipe.network_access}
         fileAccess={recipe.file_access}
+        hasTrustDivergence={trustDivergence.length > 0}
       />
 
       <ConnectorHealthPanel connectors={recipe.connectors} marginTop={0} />
@@ -130,12 +153,8 @@ export default async function RecipeDetailPage({ params }: PageProps) {
       <TrustMetadataCard recipe={recipe} />
 
       <TrustDivergenceNotice
-        meta={{
-          risk_level: recipe.risk_level,
-          network_access: recipe.network_access,
-          file_access: recipe.file_access,
-        }}
-        riskSummary={yaml ? summarizeRisk(yaml) : { low: 0, medium: 0, high: 0, steps: 0 }}
+        meta={divergenceMeta}
+        riskSummary={riskSummary}
       />
 
       <YamlPreview yaml={yaml} src={src} mainFile={manifest?.recipes?.main} />


### PR DESCRIPTION
## Summary
- \`InstallPanel\`'s elevated-confirm gate (\`requiresElevatedConfirm\`) only looked at the registry's self-reported \`risk_level\`/\`network_access\`/\`file_access\` — community-maintained \`index.json\` fields, not signature-verified.
- The detail page separately fetches the recipe's actual YAML and runs \`summarizeRisk\` + \`detectTrustDivergence\` (\`TrustDivergenceNotice\`) to detect when the YAML contradicts that metadata — but that divergence result was purely cosmetic, rendered further down the same page and never fed back into \`InstallPanel\`'s gate.
- Concrete failure: a recipe whose registry entry claims \`{risk_level: "low", network_access: false, file_access: false}\` while its real YAML (fetched from a separate path/cache than the registry) declares high-risk file-write/network steps got a bare one-click Install button. The contradiction warning the page already computes sits below the button the user already clicked.
- Fix: compute the divergence once at the page level and pass \`hasTrustDivergence\` to \`InstallPanel\`; its elevated gate now ORs that in, so any YAML-vs-metadata contradiction forces the confirm dialog regardless of what the metadata alone would allow.

Found during this session's 13th mining pass.

## Test plan
- [x] \`npx tsc --noEmit\` clean (both dashboard and root)
- [x] \`npx tsc --noEmit -p tsconfig.tests.core.json\` clean
- [x] New regression tests (dialog opens when \`hasTrustDivergence=true\` even with low-risk metadata; still one-tap when false), verified failing on the prior code (install fired immediately, no dialog) and passing with the fix
- [x] \`next lint\` clean (pre-existing unrelated unused-import warning in the same file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)