### PR TITLE
fix(dashboard): close the marketplace browse-grid one-click install bypass (same class of bug as #1185)

### DIFF
--- a/dashboard/src/app/marketplace/_components/TrustDivergenceNotice.tsx
+++ b/dashboard/src/app/marketplace/_components/TrustDivergenceNotice.tsx
@@ -1,4 +1,11 @@
-import type { TrustMetadata } from "@/lib/registry";
+import {
+  fetchManifest,
+  fetchRecipeYaml,
+  parseInstallSource,
+  type RegistryRecipe,
+  summarizeRisk,
+  type TrustMetadata,
+} from "@/lib/registry";
 
 /**
  * Trust-vs-YAML reconciliation for the recipe DETAIL page.
@@ -85,6 +92,46 @@ export function detectTrustDivergence(
   }
 
   return contradictions;
+}
+
+/**
+ * Fetch a recipe's actual YAML and check it against the registry's
+ * self-reported risk metadata via `detectTrustDivergence` — the same
+ * reconciliation the detail page runs eagerly (via `TrustDivergenceNotice`
+ * below), but computed on demand here so callers that render many recipes
+ * at once (the marketplace browse grid) aren't forced to fetch YAML for
+ * every card up front. Intended to be called only when the metadata ALONE
+ * would already bypass an elevated-confirm gate — a recipe that's already
+ * going to show a confirm dialog on its own metadata doesn't need this.
+ *
+ * Fails open (returns false) on any fetch/parse error, matching the detail
+ * page's `yaml=null` → zero-risk-summary → no-divergence semantics: this is
+ * a hint layer on top of the default-deny metadata gate, not the sole gate.
+ */
+export async function checkTrustDivergence(
+  recipe: RegistryRecipe,
+): Promise<boolean> {
+  const src = parseInstallSource(recipe.install);
+  if (!src) return false;
+  try {
+    const manifest = await fetchManifest(src);
+    const main = manifest?.recipes?.main;
+    if (!main) return false;
+    const yaml = await fetchRecipeYaml(src, main);
+    if (!yaml) return false;
+    const riskSummary = summarizeRisk(yaml);
+    const contradictions = detectTrustDivergence(
+      {
+        risk_level: recipe.risk_level,
+        network_access: recipe.network_access,
+        file_access: recipe.file_access,
+      },
+      riskSummary,
+    );
+    return contradictions.length > 0;
+  } catch {
+    return false;
+  }
 }
 
 /**

--- a/dashboard/src/app/marketplace/_components/__tests__/TrustDivergenceNotice.test.tsx
+++ b/dashboard/src/app/marketplace/_components/__tests__/TrustDivergenceNotice.test.tsx
@@ -11,8 +11,10 @@
  */
 
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { RegistryRecipe } from "@/lib/registry";
 import {
+  checkTrustDivergence,
   detectTrustDivergence,
   TrustDivergenceNotice,
 } from "../TrustDivergenceNotice";
@@ -101,5 +103,102 @@ describe("TrustDivergenceNotice (render)", () => {
       />,
     );
     expect(container).toBeEmptyDOMElement();
+  });
+});
+
+// Regression: the marketplace BROWSE grid (dashboard/src/app/marketplace/
+// page.tsx's useRecipeInstall) gates its one-click-vs-confirm-dialog
+// decision on registry metadata alone — the same class of bug #1185 fixed
+// on the detail page's InstallPanel. checkTrustDivergence is the fetch +
+// reconcile helper the browse grid calls at install-click time (not eagerly
+// per card) to close that gap; test it directly against a mocked fetch
+// rather than mounting the 1000+-line, untested page component.
+describe("checkTrustDivergence", () => {
+  const baseRecipe: RegistryRecipe = {
+    name: "@patchworkos/example",
+    version: "1.0.0",
+    description: "example",
+    tags: [],
+    connectors: [],
+    downloads: 0,
+    install: "github:patchworkos/recipes/recipes/example",
+  };
+
+  function jsonResponse(body: unknown): Response {
+    return new Response(JSON.stringify(body), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  }
+
+  function textResponse(body: string): Response {
+    return new Response(body, {
+      status: 200,
+      headers: { "content-type": "text/plain" },
+    });
+  }
+
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns true when metadata claims low-risk but the YAML declares high-risk steps", async () => {
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(
+        jsonResponse({ name: "example", version: "1.0.0", recipes: { main: "recipe.yaml" } }),
+      )
+      .mockResolvedValueOnce(
+        textResponse("steps:\n  - risk: high\n  - risk: high\n"),
+      );
+
+    const divergent = await checkTrustDivergence({
+      ...baseRecipe,
+      risk_level: "low",
+      network_access: false,
+      file_access: false,
+    });
+    expect(divergent).toBe(true);
+  });
+
+  it("returns false when metadata and YAML agree", async () => {
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(
+        jsonResponse({ name: "example", version: "1.0.0", recipes: { main: "recipe.yaml" } }),
+      )
+      .mockResolvedValueOnce(textResponse("steps:\n  - risk: low\n"));
+
+    const divergent = await checkTrustDivergence({
+      ...baseRecipe,
+      risk_level: "low",
+      network_access: false,
+      file_access: false,
+    });
+    expect(divergent).toBe(false);
+  });
+
+  it("fails open (returns false) when the manifest fetch fails", async () => {
+    vi.mocked(fetch).mockRejectedValue(new Error("network error"));
+
+    const divergent = await checkTrustDivergence({
+      ...baseRecipe,
+      risk_level: "low",
+      network_access: false,
+      file_access: false,
+    });
+    expect(divergent).toBe(false);
+  });
+
+  it("returns false for an unparseable install source", async () => {
+    const divergent = await checkTrustDivergence({
+      ...baseRecipe,
+      install: "not-a-github-source",
+      risk_level: "low",
+    });
+    expect(divergent).toBe(false);
+    expect(fetch).not.toHaveBeenCalled();
   });
 });

--- a/dashboard/src/app/marketplace/page.tsx
+++ b/dashboard/src/app/marketplace/page.tsx
@@ -6,6 +6,7 @@ import { Skeleton, SkeletonText } from "@/components/Skeleton";
 import { EmptyState, HintCard } from "@/components/patchwork";
 import { canonicalRecipeKey } from "@/lib/entityKey";
 import { InstallConfirmDialog } from "./_components/InstallConfirmDialog";
+import { checkTrustDivergence } from "./_components/TrustDivergenceNotice";
 import { apiPath } from "@/lib/api";
 import {
   assertValidInstallSource,
@@ -285,8 +286,23 @@ function useRecipeInstall(
     }
   }
 
-  function handleInstall() {
+  async function handleInstall() {
     if (elevated) {
+      setConfirmOpen(true);
+      return;
+    }
+    // Metadata alone says one-click is safe, but the registry is
+    // community-maintained and unsigned — verify the actual YAML
+    // doesn't contradict it before bypassing the confirm dialog
+    // (mirrors the detail page's hasTrustDivergence gate, #1185).
+    setLoading(true);
+    let divergent = false;
+    try {
+      divergent = await checkTrustDivergence(recipe);
+    } finally {
+      setLoading(false);
+    }
+    if (divergent) {
       setConfirmOpen(true);
       return;
     }


### PR DESCRIPTION
## Summary
- \`useRecipeInstall\` (shared by \`RecipeCard\`/\`RecipeTile\` on the marketplace **browse grid** — the primary, most-trafficked install surface) gated one-click-vs-confirm-dialog purely on \`requiresElevatedConfirm(recipe)\`: the registry's self-reported, community-maintained, unsigned \`risk_level\`/\`network_access\`/\`file_access\` fields. It never checked whether the recipe's actual YAML contradicts that metadata — the same gap #1185 just fixed on the detail-page \`InstallPanel\`.
- A recipe whose registry entry claims \`{risk_level: "low", network_access: false, file_access: false}\` while its real YAML declares high-risk file-write/network steps still got a bare one-click Install button on the browse grid, reintroducing the exact bypass #1185 closed elsewhere — just reachable from a more prominent entry point.
- Fix: extracted the fetch-YAML-and-reconcile logic (\`checkTrustDivergence\`) into \`TrustDivergenceNotice.tsx\` (already home to \`detectTrustDivergence\`), called from \`handleInstall\` only when the metadata alone would already bypass the dialog — not eagerly for every card in the grid (would mean N unauthenticated GitHub fetches per page load). Fails open on any fetch/parse error, matching the detail page's existing \`yaml=null\` semantics.

Found during this session's 14th mining pass.

## Test plan
- [x] \`npx tsc --noEmit\` clean (both dashboard and root)
- [x] \`npx tsc --noEmit -p tsconfig.tests.core.json\` clean
- [x] New tests against \`checkTrustDivergence\` directly (mocked \`fetch\`) — \`RecipeCard\`/\`RecipeTile\` aren't exported and \`marketplace/page.tsx\` has no existing test harness (1400+ lines, no prior \`__tests__\` dir), so coverage targets the extracted, brand-new logic this fix depends on rather than mounting the untested page component
- [x] \`next lint\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)