### PR TITLE
fix(dashboard): match marketplace detail pages' fetch-cache revalidate to their route-segment ISR window

### DIFF
--- a/dashboard/src/app/marketplace/[...slug]/__tests__/page.revalidate.test.ts
+++ b/dashboard/src/app/marketplace/[...slug]/__tests__/page.revalidate.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Regression: the recipe detail page's `export const revalidate = 60`
+ * governs the ROUTE SEGMENT's re-render cadence, but fetchRegistry() /
+ * fetchManifest() / fetchRecipeYaml() were called with no `opts`, so each
+ * underlying fetch() fell back to fetchGithubFile's own independent
+ * `next: { revalidate }` fetch-cache default of 300s (registry.ts).
+ *
+ * Next's per-fetch data cache and the route segment's ISR revalidate are
+ * separate caching layers — the page could re-render every 60s while
+ * still being served a manifest/YAML fetch cached for up to 5x longer.
+ * This specifically weakened the trust-divergence gate (#1185/#1186),
+ * which depends on fetching the CURRENT recipe YAML to detect when it
+ * contradicts the registry's self-reported risk metadata.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("next/navigation", () => ({
+  notFound: vi.fn(() => {
+    throw new Error("notFound() called");
+  }),
+}));
+
+import RecipeDetailPage from "../page";
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function textResponse(body: string): Response {
+  return new Response(body, {
+    status: 200,
+    headers: { "content-type": "text/plain" },
+  });
+}
+
+const REGISTRY = {
+  version: "1",
+  updated_at: "2026-01-01T00:00:00Z",
+  recipes: [
+    {
+      name: "@patchworkos/example",
+      version: "1.0.0",
+      description: "example",
+      tags: [],
+      connectors: [],
+      downloads: 0,
+      install: "github:patchworkos/recipes/recipes/example",
+    },
+  ],
+};
+
+describe("RecipeDetailPage — fetch-cache revalidate wiring", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("passes revalidate=60 (not fetchGithubFile's 300s default) to every registry/manifest/YAML fetch", async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(REGISTRY)) // fetchRegistry → index.json
+      .mockResolvedValueOnce(
+        jsonResponse({
+          name: "example",
+          version: "1.0.0",
+          recipes: { main: "recipe.yaml" },
+        }),
+      ) // fetchManifest → recipe.json
+      .mockResolvedValueOnce(textResponse("steps: []\n")); // fetchRecipeYaml → recipe.yaml
+
+    await RecipeDetailPage({
+      params: Promise.resolve({ slug: ["@patchworkos", "example"] }),
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    for (const call of fetchMock.mock.calls) {
+      const init = call[1] as { next?: { revalidate?: number } } | undefined;
+      expect(init?.next?.revalidate).toBe(60);
+    }
+  });
+});

--- a/dashboard/src/app/marketplace/[...slug]/page.tsx
+++ b/dashboard/src/app/marketplace/[...slug]/page.tsx
@@ -28,6 +28,18 @@ import InstallPanel from "./InstallPanel";
 // minutes ago but still 404" surprise.
 export const revalidate = 60;
 
+// Next's per-fetch data cache (the `next: { revalidate }` option each
+// fetchGithubFile() call sets) is a SEPARATE cache from the route
+// segment's ISR `revalidate` above — matching the constant here doesn't
+// happen automatically. Without this, fetchRegistry/fetchManifest/
+// fetchRecipeYaml below fell back to fetchGithubFile's own 300s default,
+// so the route segment could re-render every 60s while still being
+// served a manifest/YAML fetch cached for up to 5x longer — quietly
+// undercutting the very freshness this page's revalidate=60 change was
+// written to guarantee, and specifically weakening the trust-divergence
+// gate (#1185/#1186) that depends on fetching the CURRENT YAML.
+const FETCH_OPTS = { revalidate };
+
 interface PageProps {
   // Next 15: dynamic route params are Promise-typed.
   params: Promise<{ slug: string[] }>;
@@ -36,7 +48,7 @@ interface PageProps {
 export async function generateMetadata({ params }: PageProps) {
   const { slug } = await params;
   const fullName = decodeURIComponent(slug.join("/"));
-  const registry = await fetchRegistry();
+  const registry = await fetchRegistry(FETCH_OPTS);
   // Don't mislabel a registry-down page as 404 — separate title makes
   // tab-history and SEO crawlers distinguish the two states.
   if (!registry) {
@@ -69,7 +81,7 @@ export default async function RecipeDetailPage({ params }: PageProps) {
   const { slug } = await params;
   const fullName = decodeURIComponent(slug.join("/"));
 
-  const registry = await fetchRegistry();
+  const registry = await fetchRegistry(FETCH_OPTS);
   // Distinguish "registry unreachable" (CDN failure, transient network
   // issue) from "recipe genuinely missing" — pre-fix both collapsed into
   // notFound(), so every detail-page URL 404'd whenever the CDN was down.
@@ -87,14 +99,14 @@ export default async function RecipeDetailPage({ params }: PageProps) {
   // than throwing a 500 the user can't recover from.
   if (src) {
     try {
-      manifest = await fetchManifest(src);
+      manifest = await fetchManifest(src, FETCH_OPTS);
     } catch {
       manifest = null;
     }
     const main = manifest?.recipes?.main;
     if (main) {
       try {
-        yaml = await fetchRecipeYaml(src, main);
+        yaml = await fetchRecipeYaml(src, main, FETCH_OPTS);
       } catch {
         yaml = null;
       }

--- a/dashboard/src/app/marketplace/bundle/[...slug]/__tests__/page.revalidate.test.ts
+++ b/dashboard/src/app/marketplace/bundle/[...slug]/__tests__/page.revalidate.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Same regression as the recipe detail page's page.revalidate.test.ts:
+ * fetchRegistry() / fetchBundleManifest() were called with no `opts`,
+ * falling back to fetchGithubFile's independent 300s fetch-cache default
+ * instead of matching this route's `revalidate = 60`.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("next/navigation", () => ({
+  notFound: vi.fn(() => {
+    throw new Error("notFound() called");
+  }),
+}));
+
+import BundleDetailPage from "../page";
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+const REGISTRY = {
+  version: "1",
+  updated_at: "2026-01-01T00:00:00Z",
+  recipes: [],
+  bundles: [
+    {
+      name: "@patchworkos/example-bundle",
+      version: "1.0.0",
+      description: "example bundle",
+      install: "github:patchworkos/recipes/bundles/example",
+    },
+  ],
+};
+
+describe("BundleDetailPage — fetch-cache revalidate wiring", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("passes revalidate=60 (not fetchGithubFile's 300s default) to registry + bundle manifest fetches", async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(REGISTRY)) // fetchRegistry → index.json
+      .mockResolvedValueOnce(
+        jsonResponse({
+          name: "example-bundle",
+          version: "1.0.0",
+          recipes: ["a-recipe"],
+        }),
+      ); // fetchBundleManifest → patchwork-bundle.json
+
+    await BundleDetailPage({
+      params: Promise.resolve({ slug: ["@patchworkos", "example-bundle"] }),
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    for (const call of fetchMock.mock.calls) {
+      const init = call[1] as { next?: { revalidate?: number } } | undefined;
+      expect(init?.next?.revalidate).toBe(60);
+    }
+  });
+});

--- a/dashboard/src/app/marketplace/bundle/[...slug]/page.tsx
+++ b/dashboard/src/app/marketplace/bundle/[...slug]/page.tsx
@@ -17,6 +17,13 @@ import BundleInstallPanel from "./BundleInstallPanel";
 // bundles shouldn't 404 for 5 min after the registry PR lands.
 export const revalidate = 60;
 
+// Same fix as the recipe detail page (marketplace/[...slug]/page.tsx):
+// fetchGithubFile's own `next: { revalidate }` fetch-cache option
+// defaults to 300s independently of the route segment's revalidate
+// above — pass it explicitly so a bundle manifest edit is visible within
+// the same 60s window the page itself re-renders on, not up to 5x later.
+const FETCH_OPTS = { revalidate };
+
 interface PageProps {
   // Next 15: dynamic route params are Promise-typed.
   params: Promise<{ slug: string[] }>;
@@ -25,7 +32,7 @@ interface PageProps {
 export async function generateMetadata({ params }: PageProps) {
   const { slug } = await params;
   const fullName = decodeURIComponent(slug.join("/"));
-  const registry = await fetchRegistry();
+  const registry = await fetchRegistry(FETCH_OPTS);
   if (!registry) {
     return { title: "Registry unreachable — Marketplace · Patchwork OS" };
   }
@@ -41,7 +48,7 @@ export default async function BundleDetailPage({ params }: PageProps) {
   const { slug } = await params;
   const fullName = decodeURIComponent(slug.join("/"));
 
-  const registry = await fetchRegistry();
+  const registry = await fetchRegistry(FETCH_OPTS);
   // Same fix as the recipe detail page: don't conflate "registry
   // unreachable" with "bundle missing". Pre-fix, every bundle URL 404'd
   // whenever the CDN was down.
@@ -54,7 +61,7 @@ export default async function BundleDetailPage({ params }: PageProps) {
   let manifestErr = false;
   if (src) {
     try {
-      manifest = await fetchBundleManifest(src);
+      manifest = await fetchBundleManifest(src, FETCH_OPTS);
       // fetchBundleManifest swallows network errors and returns null —
       // treat null as a manifest-unavailable signal so the page renders
       // a notice instead of an empty bundle.


### PR DESCRIPTION
## Summary
- Both marketplace detail pages set \`export const revalidate = 60\`, documented as closing the "merged 4 minutes ago but still 404" staleness gap. But \`fetchRegistry()\`/\`fetchManifest()\`/\`fetchRecipeYaml()\`/\`fetchBundleManifest()\` were called with no \`opts\`, so each underlying \`fetch()\` fell back to \`fetchGithubFile\`'s own **independent** \`next: { revalidate }\` fetch-cache default of 300s.
- Next's per-fetch data cache and the route segment's ISR revalidate are separate caching layers — the route could re-render every 60s while still being served a manifest/YAML fetch cached for up to 5x longer.
- This specifically weakened the trust-divergence gate (#1185/#1186), which depends on fetching the CURRENT recipe YAML to detect when it contradicts the registry's self-reported risk metadata — an edited \`recipe.yaml\` could take up to 5 minutes to become visible to that gate even though the surrounding page was already re-rendering on the fresh registry index.
- Fix: pass \`{ revalidate }\` explicitly to every \`fetchGithubFile\`-backed call on both detail pages, so the fetch cache matches the route segment's window.

Found during this session's 15th mining pass, which was specifically asked to check whether the "gate computed but not consistently wired everywhere" pattern from #1185/#1186 recurred — this is a related-but-distinct data-freshness gap underneath a now-correctly-wired gate.

## Test plan
- [x] \`npx tsc --noEmit\` clean (both dashboard and root)
- [x] \`npx tsc --noEmit -p tsconfig.tests.core.json\` clean
- [x] New regression tests on both detail pages asserting \`next.revalidate === 60\` on every registry/manifest/YAML fetch, verified failing on the prior code (300 from \`fetchGithubFile\`'s default) and passing with the fix
- [x] \`next lint\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)