### PR TITLE
fix(dashboard): replay preflight now flags auto-generated positional step ids as unmocked

### DIFF
--- a/dashboard/src/app/runs/[seq]/page.tsx
+++ b/dashboard/src/app/runs/[seq]/page.tsx
@@ -895,7 +895,9 @@ function ReplayPreflight({ stepResults }: { stepResults: StepResult[] }) {
             {" — "}
             {u.reason === "truncated"
               ? "output >8 KB, will fire real tool"
-              : "no capture"}
+              : u.reason === "positional-id"
+                ? "no stable id (add into:), will fire real tool"
+                : "no capture"}
           </li>
         ))}
         {preflight.unmocked.length > 8 && (

--- a/dashboard/src/lib/__tests__/registryDiff.test.ts
+++ b/dashboard/src/lib/__tests__/registryDiff.test.ts
@@ -76,6 +76,46 @@ describe("previewMockedReplay — truncated path", () => {
   });
 });
 
+describe("previewMockedReplay — positional step ids (auto-generated `step_N`)", () => {
+  // Regression: the bridge's FLAT-recipe replay (buildFlatMockedOutputs in
+  // src/recipes/replayRun.ts) always forces a step with no explicit `into:`
+  // name to real execution — its id ("step_3") isn't stable across a
+  // recipe edit, so replaying a captured output under it risks matching a
+  // DIFFERENT step post-edit. previewMockedReplay had no knowledge of this
+  // rule: a positional-id step with a normal (non-truncated) captured
+  // output was marked "mocked", so the dashboard told the user "no
+  // external API calls" right before the bridge fired that step for real.
+  it("flags a step with an auto-generated positional id as unmocked even though it has a usable capture", () => {
+    const out = previewMockedReplay([
+      {
+        id: "step_3",
+        status: "ok",
+        tool: "slack.postMessage",
+        output: "posted",
+      },
+    ]);
+    expect(out.mocked).toEqual([]);
+    expect(out.unmocked).toEqual([
+      { id: "step_3", tool: "slack.postMessage", reason: "positional-id" },
+    ]);
+  });
+
+  it("still mocks a step with an explicit `into:`-derived id", () => {
+    const out = previewMockedReplay([
+      { id: "fetchIssue", status: "ok", output: "issue body" },
+    ]);
+    expect(out.mocked).toEqual(["fetchIssue"]);
+    expect(out.unmocked).toEqual([]);
+  });
+
+  it("does not misclassify an id that merely contains 'step_' as a substring", () => {
+    const out = previewMockedReplay([
+      { id: "step_3_retry", status: "ok", output: "ok" },
+    ]);
+    expect(out.mocked).toEqual(["step_3_retry"]);
+  });
+});
+
 describe("diffSnapshots", () => {
   it("treats every key in current as added when prev is undefined", () => {
     expect(diffSnapshots(undefined, { a: 1, b: 2 })).toEqual({

--- a/dashboard/src/lib/registryDiff.ts
+++ b/dashboard/src/lib/registryDiff.ts
@@ -24,16 +24,39 @@ export interface StepForReplayPreflight {
 }
 
 /**
+ * Auto-generated positional step id (yamlRunner.ts: `step.into ?? "step_${n}"`).
+ * Mirrors `POSITIONAL_STEP_ID` in `src/recipes/replayRun.ts` — kept in
+ * sync manually since the two live in separate packages (dashboard vs
+ * bridge) with no shared module. A step with no explicit `into:`/`id:`
+ * name isn't stable across a recipe edit, so the bridge's FLAT-recipe
+ * replay path (`buildFlatMockedOutputs`) always forces it to real
+ * execution regardless of whether a capture exists. Applied
+ * unconditionally here (not just for flat recipes) because the
+ * dashboard has no cheap way to know a run's chained-vs-flat shape
+ * before replay, and it's a safe over-approximation either way: a
+ * chained recipe's step ids are mandatory/explicit, so a real collision
+ * with this pattern is rare, and misclassifying a chained step as
+ * "will run for real" only over-warns — it never falsely promises "no
+ * side effects" for a step that actually fires for real, which is the
+ * dangerous direction for a safety preflight.
+ */
+const POSITIONAL_STEP_ID = /^step_\d+$/;
+
+/**
  * Pre-flight a mocked replay: classify each step into "mocked" (will
  * return its captured output) vs "unmocked" (will fall through to REAL
  * execution because we have no usable capture). Mirrors `buildMockedOutputs`
- * in `src/recipes/replayRun.ts` so the dashboard can show the user
- * up-front what side effects to expect, instead of warning after the
- * fact (BUG-3 from the post-merge dogfood).
+ * / `buildFlatMockedOutputs` in `src/recipes/replayRun.ts` so the dashboard
+ * can show the user up-front what side effects to expect, instead of
+ * warning after the fact (BUG-3 from the post-merge dogfood).
  */
 export interface ReplayPreflight {
   mocked: string[];
-  unmocked: Array<{ id: string; tool?: string; reason: "no-capture" | "truncated" }>;
+  unmocked: Array<{
+    id: string;
+    tool?: string;
+    reason: "no-capture" | "truncated" | "positional-id";
+  }>;
 }
 
 export function previewMockedReplay(
@@ -43,6 +66,14 @@ export function previewMockedReplay(
   const unmocked: ReplayPreflight["unmocked"] = [];
   for (const s of steps) {
     if (s.status === "skipped") continue; // skipped steps aren't replayed
+    if (POSITIONAL_STEP_ID.test(s.id)) {
+      unmocked.push({
+        id: s.id,
+        ...(s.tool !== undefined && { tool: s.tool }),
+        reason: "positional-id",
+      });
+      continue;
+    }
     if (s.output === undefined) {
       unmocked.push({
         id: s.id,


### PR DESCRIPTION
## Summary
- \`previewMockedReplay\` (the dashboard's "will this step be mocked or run for real" check, shown before a user confirms a run replay) only checked for a missing capture or the >8KB truncation envelope — it had no knowledge of \`POSITIONAL_STEP_ID\` in \`src/recipes/replayRun.ts\`, which the bridge's flat-recipe replay path (\`buildFlatMockedOutputs\`) uses to always force a step with no explicit \`into:\` name to REAL execution (its auto-generated id like \`step_3\` isn't stable across a recipe edit).
- Concrete failure: a flat (manual/cron/webhook) recipe has a step with no \`into:\` key and a normal captured output from a prior run. The dashboard told the user "All N steps will be mocked from captures. No external API calls." The user confirms, trusting that — but the bridge's actual replay logic fires that step for real, contradicting the assurance the user just acted on.
- Fix: mirror \`POSITIONAL_STEP_ID\` in \`registryDiff.ts\` and flag matching ids as unmocked (new \`"positional-id"\` reason), applied unconditionally rather than only for flat recipes — the dashboard has no cheap way to know a run's chained-vs-flat shape before replay, and applying it to chained recipes too only over-warns (their ids are mandatory/explicit) rather than under-warns, which is the safe direction for a preflight.

Found during this session's 16th mining pass.

## Test plan
- [x] \`npx tsc --noEmit\` clean (both dashboard and root)
- [x] \`npx tsc --noEmit -p tsconfig.tests.core.json\` clean
- [x] New regression tests, verified failing on the prior code (a positional-id step with a usable capture was classified "mocked" instead of "unmocked") and passing with the fix
- [x] \`next lint\` clean (pre-existing unrelated warning in the same file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)