### PR TITLE
fix(dashboard): check the response of the copilot-install disable PATCH before claiming success

### DIFF
--- a/dashboard/src/app/__tests__/page.test.tsx
+++ b/dashboard/src/app/__tests__/page.test.tsx
@@ -1495,6 +1495,82 @@ describe("<HomePage/> — Terminal deck", () => {
     expect(screen.queryByText("Undo")).toBeNull();
   });
 
+  // Regression: installGeneratedRecipe's disabling PATCH (the only thing
+  // enforcing "a copilot-installed recipe always lands disabled") was
+  // fire-and-forget — its response was never checked. If it failed, the
+  // code still recorded a decision trace claiming success and navigated
+  // away, even though the recipe compiler defaults enabled:true and the
+  // recipe could be left live.
+  it("surfaces an error instead of claiming success when the post-install disable PATCH fails", async () => {
+    const traceMock = vi.fn().mockResolvedValue(jsonResponse({ ok: true }));
+    global.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      const method = init?.method ?? "GET";
+      if (url.includes("/api/bridge/copilot/message")) {
+        return jsonResponse({
+          reply: "Here's a draft.",
+          action: { kind: "create_recipe", goal: "summarize slack threads" },
+        });
+      }
+      if (method === "POST" && url.includes("/api/bridge/recipes/generate")) {
+        return jsonResponse({
+          ok: true,
+          yaml: "name: slack-summary\ntrigger:\n  type: manual\nsteps: []\n",
+        });
+      }
+      if (method === "PUT" && url.includes("/api/bridge/recipes/slack-summary")) {
+        return jsonResponse({ ok: true });
+      }
+      if (method === "PATCH" && url.includes("/api/bridge/recipes/slack-summary")) {
+        return jsonResponse({ error: "bridge busy" }, 500);
+      }
+      if (method === "POST" && url.includes("/api/bridge/traces/decision")) {
+        return traceMock(init);
+      }
+      for (const [key, make] of Object.entries(HEALTHY_ROUTES)) {
+        if (url.includes(key)) return make();
+      }
+      return jsonResponse({}, 404);
+    }) as unknown as typeof fetch;
+
+    render(<HomePage />);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(50);
+    });
+
+    const input = screen.getByLabelText("Copilot chat input");
+    await act(async () => {
+      typeIntoInput(input as HTMLInputElement, "create a recipe that summarizes slack threads");
+    });
+    const form = input.closest("form") as HTMLFormElement;
+    await act(async () => {
+      form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+      await vi.advanceTimersByTimeAsync(50);
+    });
+
+    const confirmBtn = await screen.findByText("Confirm");
+    await act(async () => {
+      confirmBtn.click();
+      await vi.advanceTimersByTimeAsync(50);
+    });
+
+    const installBtn = await screen.findByText("Install (disabled)");
+    await act(async () => {
+      installBtn.click();
+      await vi.advanceTimersByTimeAsync(50);
+    });
+
+    // The bridge's own PATCH error message ("bridge busy") is surfaced,
+    // not swallowed — this is the failure the pre-fix code let through
+    // silently (no error, decision trace recorded as if it succeeded).
+    await waitFor(() => {
+      expect(screen.getByText("bridge busy")).toBeTruthy();
+    });
+    // The decision trace claims success — it must NOT fire when the
+    // disable PATCH failed, since the recipe may actually be live/enabled.
+    expect(traceMock).not.toHaveBeenCalled();
+  });
+
   it("audit regression: a stale background poll landing right after Confirm does not clobber the optimistic state, so Undo still flips the right direction", async () => {
     // Simulates the exact race an audit found: the page's 5s poll always
     // returns the recipe as `enabled: true` here (as if fetched before the

--- a/dashboard/src/app/page.tsx
+++ b/dashboard/src/app/page.tsx
@@ -1693,11 +1693,39 @@ export default function HomePage() {
         return;
       }
       // Force disabled regardless of whatever the fresh save defaulted to.
-      await fetch(apiPath(`/api/bridge/recipes/${encodeURIComponent(name)}`), {
+      // The response MUST be checked — the recipe compiler defaults
+      // `enabled: true` unless the YAML explicitly opts out, and LLM-
+      // generated YAML has no guarantee of including `enabled: false`.
+      // This PATCH is the only thing enforcing "install always lands
+      // disabled" for copilot-authored content; silently proceeding to
+      // claim success on a failed PATCH would leave a live, enabled
+      // recipe able to fire autonomously with no human review.
+      const disableRes = await fetch(apiPath(`/api/bridge/recipes/${encodeURIComponent(name)}`), {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ enabled: false }),
       });
+      if (!disableRes.ok) {
+        const disableResult = (await disableRes.json().catch(() => ({}))) as {
+          error?: string;
+        };
+        setCopilotMessages((prev) =>
+          prev.map((m) =>
+            m.id === msg.id && m.action
+              ? {
+                  ...m,
+                  action: {
+                    ...m.action,
+                    generatedError:
+                      disableResult.error ??
+                      `"${name}" was saved but could not be forced disabled (HTTP ${disableRes.status}) — it may be live and enabled. Check /recipes/${name} before trusting it.`,
+                  },
+                }
+              : m,
+          ),
+        );
+        return;
+      }
       recordCopilotDecisionTrace(action, `Installed "${name}" (disabled) via copilot.`);
       router.push(`/recipes/${encodeURIComponent(name)}`);
     } catch (e) {


### PR DESCRIPTION
## Summary
- \`installGeneratedRecipe\` fires a \`PATCH { enabled: false }\` after saving a copilot-drafted recipe to force it disabled, but never checked that PATCH's response — the fetch result was discarded entirely, no \`.ok\` check.
- This PATCH is the **only** thing enforcing "a copilot-installed recipe always lands disabled": the recipe compiler defaults \`enabled: true\` unless the YAML explicitly opts out, and LLM-generated YAML has no guarantee of including \`enabled: false\`.
- Concrete failure: the disabling PATCH fails (transient bridge busy, 5xx, momentary network blip) with a non-throwing error response. The old code still recorded a decision trace claiming "Installed (disabled)" and navigated to the recipe page with no error shown — the recipe is actually live and enabled, able to fire autonomously against real connectors with no human review, exactly what this flow exists to prevent for LLM-authored content.
- Fix: check \`disableRes.ok\`; on failure, surface the bridge's own error message (or a clear fallback) in the chat UI and do NOT record the decision trace or navigate away.

Found during this session's 17th mining pass, specifically tasked with hunting the recurring "mirror/dependent logic drifts out of sync or is unchecked" pattern found in prior passes (#1185-#1188).

## Test plan
- [x] \`npx tsc --noEmit\` clean (both dashboard and root)
- [x] \`npx tsc --noEmit -p tsconfig.tests.core.json\` clean
- [x] New regression test simulating the disable-PATCH failure, verified failing on the prior code (error silently swallowed, no error text rendered) and passing with the fix
- [x] \`next lint\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)