### PR TITLE
fix(dashboard): force AI-generated recipes disabled on save, same fix as copilot chat's installGeneratedRecipe (#1189)

### DIFF
--- a/dashboard/src/app/recipes/new/__tests__/applyAiYaml.test.ts
+++ b/dashboard/src/app/recipes/new/__tests__/applyAiYaml.test.ts
@@ -53,7 +53,8 @@ steps:
     const result = await prepareAndSaveAiRecipe(yaml, fetcher);
 
     expect(result).toEqual({ ok: true, recipeName: "morning-inbox" });
-    expect(fetcher).toHaveBeenCalledTimes(1);
+    // 2 calls: the PUT save, then the force-disable PATCH (#1189-style fix).
+    expect(fetcher).toHaveBeenCalledTimes(2);
     const [url, init] = (fetcher as unknown as { mock: { calls: [string, RequestInit][] } })
       .mock.calls[0];
     expect(url).toBe("/api/bridge/recipes/morning-inbox");
@@ -207,6 +208,83 @@ describe("prepareAndSaveAiRecipe — error + demo paths", () => {
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.error).toBe("ECONNREFUSED");
+    }
+  });
+});
+
+describe("prepareAndSaveAiRecipe — force-disable after save (same fix as #1189's installGeneratedRecipe)", () => {
+  // Regression: a top-level recipe file is enabled by default
+  // (isRecipeFileEnabled in src/recipesHttp.ts), and AI-generated YAML has
+  // no guarantee of including `enabled: false`. Without checking the
+  // disable PATCH's response, a save could succeed while the recipe stays
+  // live/enabled with no error surfaced — the caller (page.tsx) would then
+  // redirect to the edit page as if everything were safe, before the user
+  // ever reviewed the generated steps.
+  it("PATCHes { enabled: false } after a successful save", async () => {
+    const yaml = `name: cron-recipe\ntrigger: { type: manual }\nsteps: []\n`;
+    const fetcher = vi.fn(async () => okResponse({ ok: true })) as unknown as typeof fetch;
+
+    const result = await prepareAndSaveAiRecipe(yaml, fetcher);
+
+    expect(result).toEqual({ ok: true, recipeName: "cron-recipe" });
+    expect(fetcher).toHaveBeenCalledTimes(2);
+    const calls = (fetcher as unknown as { mock: { calls: [string, RequestInit][] } }).mock.calls;
+    const [patchUrl, patchInit] = calls[1]!;
+    expect(patchUrl).toBe("/api/bridge/recipes/cron-recipe");
+    expect(patchInit?.method).toBe("PATCH");
+    expect(JSON.parse(patchInit?.body as string)).toEqual({ enabled: false });
+  });
+
+  it("returns ok:false and surfaces the bridge's error when the disable PATCH fails", async () => {
+    const yaml = `name: cron-recipe\ntrigger: { type: manual }\nsteps: []\n`;
+    let call = 0;
+    const fetcher = vi.fn(async () => {
+      call++;
+      if (call === 1) return okResponse({ ok: true }); // PUT save succeeds
+      return errorResponse(500, { error: "bridge busy" }); // PATCH disable fails
+    }) as unknown as typeof fetch;
+
+    const result = await prepareAndSaveAiRecipe(yaml, fetcher);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBe("bridge busy");
+    }
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+
+  it("falls back to a clear message when the disable PATCH fails with no error body", async () => {
+    const yaml = `name: cron-recipe\ntrigger: { type: manual }\nsteps: []\n`;
+    let call = 0;
+    const fetcher = vi.fn(async () => {
+      call++;
+      if (call === 1) return okResponse({ ok: true });
+      return errorResponse(500, {});
+    }) as unknown as typeof fetch;
+
+    const result = await prepareAndSaveAiRecipe(yaml, fetcher);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toMatch(/could not be forced disabled/i);
+      expect(result.error).toMatch(/cron-recipe/);
+    }
+  });
+
+  it("recovers when the disable PATCH itself throws a network error", async () => {
+    const yaml = `name: cron-recipe\ntrigger: { type: manual }\nsteps: []\n`;
+    let call = 0;
+    const fetcher = vi.fn(async () => {
+      call++;
+      if (call === 1) return okResponse({ ok: true });
+      throw new Error("ECONNRESET");
+    }) as unknown as typeof fetch;
+
+    const result = await prepareAndSaveAiRecipe(yaml, fetcher);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBe("ECONNRESET");
     }
   });
 });

--- a/dashboard/src/app/recipes/new/applyAiYaml.ts
+++ b/dashboard/src/app/recipes/new/applyAiYaml.ts
@@ -103,6 +103,45 @@ export async function prepareAndSaveAiRecipe(
         "Demo mode — recipe was not persisted. Disable demo mode to save real recipes.",
     };
   }
+
+  // Force disabled regardless of whatever the fresh save defaulted to —
+  // same reasoning and same check-the-response fix as the copilot chat
+  // install flow (installGeneratedRecipe in app/page.tsx, #1189). A
+  // top-level recipe file is enabled by default (isRecipeFileEnabled in
+  // src/recipesHttp.ts), and AI-generated YAML has no guarantee of
+  // including `enabled: false` — without this PATCH (and without
+  // checking it), a recipe with e.g. a cron trigger drafted from a
+  // prompt like "every weekday at 9am, summarize Gmail and post to
+  // Slack" would autonomously fire before the user ever reviewed it on
+  // the edit page this flow redirects to.
+  let disableRes: Response;
+  try {
+    disableRes = await fetcher(
+      apiPath(`/api/bridge/recipes/${encodeURIComponent(recipeName)}`),
+      {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ enabled: false }),
+      },
+    );
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+  if (!disableRes.ok) {
+    const disableData = (await disableRes.json().catch(() => ({}))) as {
+      error?: string;
+    };
+    return {
+      ok: false,
+      error:
+        disableData.error ??
+        `"${recipeName}" was saved but could not be forced disabled (HTTP ${disableRes.status}) — it may be live and enabled. Check /recipes/${recipeName} before trusting it.`,
+    };
+  }
+
   return {
     ok: true,
     recipeName,


### PR DESCRIPTION
## Summary
- The \`/recipes/new\` "Generate with AI" → "Save and edit" flow (\`prepareAndSaveAiRecipe\`) PUT-saved the LLM-drafted YAML verbatim and redirected straight to the edit page — with no step forcing the recipe disabled.
- A top-level recipe file is enabled by default (\`isRecipeFileEnabled\` in \`src/recipesHttp.ts\` has no install dir to check a \`.disabled\` marker against), and AI-generated YAML has no guarantee of including \`enabled: false\`.
- Concrete failure: user types "every weekday at 9am, summarize my unread Gmail and post the digest to Slack." Claude drafts a cron-triggered recipe. User clicks "Save and edit" expecting to review it first — but the recipe is now live and will autonomously fire at the next matching cron tick, before the user has read a single line of the generated steps.
- This is the identical safety invariant PR #1189 established for the sibling copilot-chat install flow (\`installGeneratedRecipe\` in \`app/page.tsx\`), just silently absent on this other entry point into the same \`PUT /api/bridge/recipes/:name\` write path.
- Fix: PATCH \`{ enabled: false }\` after a successful save, checking the response the same way #1189 does — on failure, surface the bridge's error (or a clear fallback) instead of redirecting as if the recipe is safely disabled.

Found during this session's 18th mining pass, which was specifically tasked with checking whether the other action handlers in the copilot flow — and sibling entry points into the same write path — had the same "unchecked follow-up fetch" pattern just fixed in #1189. This is the fourth variant of that bug class found this session (#1185, #1186, #1188, #1189, #1190).

## Test plan
- [x] \`npx tsc --noEmit\` clean (both dashboard and root)
- [x] \`npx tsc --noEmit -p tsconfig.tests.core.json\` clean
- [x] New regression tests, verified failing on the prior code (no disable PATCH fired at all) and passing with the fix
- [x] \`next lint\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)