### PR TITLE
fix(dashboard): bulk-reject reuses decide() so it gets the same audit-reason capture and 409 handling as single-item reject

### DIFF
--- a/dashboard/src/app/approvals/__tests__/batchDecide.test.tsx
+++ b/dashboard/src/app/approvals/__tests__/batchDecide.test.tsx
@@ -53,7 +53,7 @@ beforeEach(() => {
   // keyboard-focus effect that fires on mount.
   Element.prototype.scrollIntoView = vi.fn();
   // jsdom has no EventSource — the page's polling fallback fires
-  // immediately via fetch(`${API}/approvals`), no fake timers needed.
+  // immediately via a GET to the approvals endpoint, no fake timers needed.
   fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
     const url = typeof input === "string" ? input : input.toString();
     const method = init?.method ?? "GET";

--- a/dashboard/src/app/approvals/__tests__/batchDecide.test.tsx
+++ b/dashboard/src/app/approvals/__tests__/batchDecide.test.tsx
@@ -1,0 +1,158 @@
+/**
+ * Regression: batchDecide() (the "Reject selected" bulk action) built its
+ * own inline `fetch(POST)` with no body, instead of reusing decide() — the
+ * function the single-item reject path uses. Two things silently regressed
+ * on the bulk path as a result:
+ *
+ *   1. decide() collects and POSTs an audit `reason` for high-tier rejects
+ *      (see handleDecide's window.prompt). batchDecide never captured or
+ *      sent one — every high-tier bulk rejection was logged with no
+ *      justification, exactly the audit-provenance gap the single-item
+ *      path was hardened against.
+ *   2. decide() treats a 409 (another session already decided the call) as
+ *      success and fades the card out. batchDecide's raw fetch treated any
+ *      non-ok status — including 409 — as a failure, producing a
+ *      confusing false-error toast for an already-resolved item.
+ *
+ * Both are fixed by having batchDecide reuse decide() instead of a second,
+ * unhardened fetch call.
+ */
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+  usePathname: () => "/approvals",
+}));
+
+import ApprovalsPage from "../page";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+const HIGH_TIER_APPROVAL = {
+  callId: "aaaaaaaa-1111-1111-1111-111111111111",
+  toolName: "runCommand",
+  tier: "high" as const,
+  requestedAt: Date.now(),
+  summary: "rm -rf /tmp/scratch",
+};
+
+let fetchMock: ReturnType<typeof vi.fn>;
+let promptSpy: ReturnType<typeof vi.spyOn>;
+let confirmSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  // jsdom has no scrollIntoView implementation; the page calls it from a
+  // keyboard-focus effect that fires on mount.
+  Element.prototype.scrollIntoView = vi.fn();
+  // jsdom has no EventSource — the page's polling fallback fires
+  // immediately via fetch(`${API}/approvals`), no fake timers needed.
+  fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.toString();
+    const method = init?.method ?? "GET";
+    if (method === "GET" && url.includes("/api/bridge/approvals") && !url.includes("stream")) {
+      return jsonResponse([HIGH_TIER_APPROVAL]);
+    }
+    if (url.includes("/api/bridge/cc-permissions")) {
+      return jsonResponse(null);
+    }
+    return jsonResponse({}, 404);
+  });
+  global.fetch = fetchMock as unknown as typeof fetch;
+  confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
+  promptSpy = vi.spyOn(window, "prompt").mockReturnValue("looked malicious, blocking");
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+async function selectAndRejectHighTierApproval() {
+  render(<ApprovalsPage />);
+
+  const checkbox = await screen.findByLabelText(
+    /Select runCommand approval aaaaaaaa/i,
+  );
+  fireEvent.click(checkbox);
+
+  const rejectBtn = await screen.findByText(/Reject selected/i);
+  fireEvent.click(rejectBtn);
+}
+
+describe("batchDecide — bulk reject reuses decide()'s audit-reason + 409 handling", () => {
+  it("prompts once for a reason and POSTs it as the request body for a high-tier bulk reject", async () => {
+    await selectAndRejectHighTierApproval();
+
+    await waitFor(() => {
+      const rejectCall = fetchMock.mock.calls.find(
+        (c) =>
+          (c[1] as RequestInit | undefined)?.method === "POST" &&
+          (c[0] as string).includes(`/reject/${HIGH_TIER_APPROVAL.callId}`),
+      );
+      expect(rejectCall).toBeDefined();
+    });
+
+    expect(promptSpy).toHaveBeenCalledTimes(1);
+    const rejectCall = fetchMock.mock.calls.find(
+      (c) =>
+        (c[1] as RequestInit | undefined)?.method === "POST" &&
+        (c[0] as string).includes(`/reject/${HIGH_TIER_APPROVAL.callId}`),
+    )!;
+    const init = rejectCall[1] as RequestInit;
+    expect(JSON.parse(init.body as string)).toEqual({
+      reason: "looked malicious, blocking",
+    });
+  });
+
+  it("does not send a reason and does not prompt when the user cancels the reason prompt", async () => {
+    promptSpy.mockReturnValue(null);
+    await selectAndRejectHighTierApproval();
+
+    // Give any (incorrect) fetch a tick to fire before asserting it didn't.
+    await new Promise((r) => setTimeout(r, 10));
+    const rejectCall = fetchMock.mock.calls.find(
+      (c) =>
+        (c[1] as RequestInit | undefined)?.method === "POST" &&
+        (c[0] as string).includes(`/reject/${HIGH_TIER_APPROVAL.callId}`),
+    );
+    expect(rejectCall).toBeUndefined();
+  });
+
+  it("treats a 409 (already decided elsewhere) as success, not a bulk-reject failure", async () => {
+    fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      const method = init?.method ?? "GET";
+      if (method === "GET" && url.includes("/api/bridge/approvals") && !url.includes("stream")) {
+        return jsonResponse([HIGH_TIER_APPROVAL]);
+      }
+      if (url.includes("/api/bridge/cc-permissions")) return jsonResponse(null);
+      if (method === "POST" && url.includes(`/reject/${HIGH_TIER_APPROVAL.callId}`)) {
+        return jsonResponse({ error: "already decided" }, 409);
+      }
+      return jsonResponse({}, 404);
+    });
+
+    await selectAndRejectHighTierApproval();
+
+    await waitFor(() => {
+      expect(
+        fetchMock.mock.calls.some(
+          (c) =>
+            (c[1] as RequestInit | undefined)?.method === "POST" &&
+            (c[0] as string).includes(`/reject/${HIGH_TIER_APPROVAL.callId}`),
+        ),
+      ).toBe(true);
+    });
+
+    // No "reject failed for: ..." banner — the 409 must be swallowed as
+    // success by decide(), same as the single-item path.
+    expect(screen.queryByText(/reject failed for/i)).toBeNull();
+  });
+});

--- a/dashboard/src/app/approvals/page.tsx
+++ b/dashboard/src/app/approvals/page.tsx
@@ -930,19 +930,34 @@ function ApprovalsContent() {
       );
       if (!proceed) return;
     }
+    // Collect one shared rejection reason for the whole batch when it
+    // includes any high-tier item — mirrors the audit-provenance
+    // requirement handleDecide enforces for a single high-tier reject
+    // (one prompt per batch, not one per item, so this doesn't become
+    // N confirm dialogs for a large selection).
+    let reason: string | undefined;
+    if (decision === "reject" && highCount > 0) {
+      const entered = window.prompt(
+        `Why are you rejecting ${highCount} high-risk approval${highCount === 1 ? "" : "s"}? (logged for audit; max 500 chars)`,
+        "",
+      );
+      if (entered === null) return; // user hit cancel
+      reason = entered.trim() || undefined;
+    }
     if (decision === "approve") setBatchApproving(true);
     else setBatchRejecting(true);
     setBatchErr(null);
     try {
       const failedIds: string[] = [];
+      // Reuse decide() (not a raw fetch) so the batch path gets the same
+      // audit-reason body and 409-already-decided handling as the
+      // single-item path — previously this inline fetch silently dropped
+      // the rejection reason on every high-tier bulk reject and treated
+      // an already-decided-elsewhere 409 as a failure.
       await Promise.all(
         ids.map((id) =>
-          fetch(`${API}/${decision}/${id}`, { method: "POST" }).then((res) => {
-            if (res.ok) {
-              removeWithFade(id);
-            } else {
-              failedIds.push(id.slice(0, 8));
-            }
+          decide(id, decision, reason).catch(() => {
+            failedIds.push(id.slice(0, 8));
           }),
         ),
       );


### PR DESCRIPTION
## Summary
- \`batchDecide()\` (the "Reject selected" bulk action) built its own inline \`fetch(POST)\` with no body, instead of reusing \`decide()\` — the function the single-item reject path uses. Two things silently regressed on the bulk path:
  1. \`decide()\` collects and POSTs an audit \`reason\` for high-tier rejects. \`batchDecide\` never captured or sent one — every high-tier bulk rejection was recorded with no justification, exactly the audit-provenance gap the single-item path was hardened against.
  2. \`decide()\` treats a \`409\` (another session already decided the call) as success and fades the card out. \`batchDecide\`'s raw fetch treated any non-ok status — including \`409\` — as a failure, producing a confusing false-error toast for an already-resolved item.
- Fix: \`batchDecide\` now calls \`decide()\` per id instead of a second, unhardened fetch. Adds one shared reason prompt for the whole batch when it includes any high-tier item (not one prompt per item).

Found during this session's 19th mining pass, hunting for more instances of this session's recurring "same operation, two code paths, one hardened and one not" bug class (#1185/#1186/#1187/#1188/#1189/#1190).

## Test plan
- [x] \`npx tsc --noEmit\` clean (both dashboard and root)
- [x] \`npx tsc --noEmit -p tsconfig.tests.core.json\` clean
- [x] New regression tests (first test suite for this page), verified failing on the prior code (no reason sent/prompted; 409 surfaced as a failure banner) and passing with the fix
- [x] \`next lint\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)