### PR TITLE
fix(dashboard): guard bulk "Discard expired" against a second concurrent pass

### DIFF
--- a/dashboard/src/app/transactions/__tests__/discardAllExpired.test.tsx
+++ b/dashboard/src/app/transactions/__tests__/discardAllExpired.test.tsx
@@ -1,0 +1,101 @@
+/**
+ * Regression: discardAllExpired() (the "Discard expired (N)" bulk action)
+ * reset confirmingExpired to false BEFORE the serial rollback loop
+ * finished, with no separate in-flight lock. Since expiredIds only
+ * refreshes on the next poll tick or a rollback's own refetch(), the
+ * "Discard expired (N)" button re-armed immediately while the first batch
+ * was still running — a second click (racing the network, or just an
+ * impatient double-click) fired a second full pass of rollback POSTs
+ * against the same still-listed ids, concurrently with the first.
+ *
+ * Every per-row Discard button already has this exact guard via the
+ * `busy` state; the bulk action had none.
+ */
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import TransactionsPage from "../page";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+const EXPIRED_TX = (id: string) => ({
+  id,
+  createdAt: Date.now() - 60_000,
+  expiresAt: Date.now() - 1_000, // already expired
+  edits: [{ filePath: `/tmp/${id}.txt`, sizeBefore: 10, sizeAfter: 20, lineDelta: 1 }],
+});
+
+let fetchMock: ReturnType<typeof vi.fn>;
+let rollbackCalls: string[];
+
+beforeEach(() => {
+  rollbackCalls = [];
+  fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.toString();
+    const method = init?.method ?? "GET";
+    if (method === "GET" && url.includes("/api/bridge/transactions") && !url.includes("rollback")) {
+      return jsonResponse({ transactions: [EXPIRED_TX("tx-a"), EXPIRED_TX("tx-b")] });
+    }
+    const rollbackMatch = /\/transactions\/([^/]+)\/rollback$/.exec(url);
+    if (method === "POST" && rollbackMatch) {
+      const id = rollbackMatch[1]!;
+      rollbackCalls.push(id);
+      // The bulk loop is serial (await rollback(id) per iteration) — hang
+      // the FIRST id's request forever so the loop is deterministically
+      // stuck mid-pass, instead of racing real promise timing. If a
+      // second bulk pass incorrectly starts, it would show up as a
+      // duplicate "tx-a" entry or (if the guard is fully absent) reach
+      // "tx-b" out of order.
+      if (id === "tx-a") return new Promise<Response>(() => {});
+      return jsonResponse({ ok: true });
+    }
+    return jsonResponse({}, 404);
+  });
+  global.fetch = fetchMock as unknown as typeof fetch;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("discardAllExpired — bulk-discard concurrency guard", () => {
+  it("does not fire a second pass of rollback calls while the first is still in flight", async () => {
+    render(<TransactionsPage />);
+
+    const armBtn = await screen.findByText(/Discard expired \(2\)/i);
+    fireEvent.click(armBtn);
+
+    const confirmBtn = await screen.findByText("Confirm");
+    fireEvent.click(confirmBtn);
+
+    // First pass starts with tx-a, which hangs — the serial loop is now
+    // stuck mid-pass, exactly the window the pre-fix code left unguarded.
+    await waitFor(() => {
+      expect(rollbackCalls).toEqual(["tx-a"]);
+    });
+
+    // The bulk button must now show the in-flight state, not silently
+    // re-arm as a fresh "Discard expired (2)" button a second click could
+    // hit. Its title attribute (unlike its "Discarding…" label, which a
+    // per-row Discard button can share) uniquely identifies it.
+    const discardingBtn = await waitFor(() => {
+      const btn = screen.getByTitle(/Discard 2 expired transactions/i);
+      expect(btn).toBeDisabled();
+      return btn;
+    });
+
+    // Simulate the exact race this bug allowed: click again while the
+    // first pass is still stuck on tx-a.
+    fireEvent.click(discardingBtn);
+
+    // Give any (incorrect) second pass a tick to fire before asserting.
+    await new Promise((r) => setTimeout(r, 20));
+    expect(rollbackCalls).toEqual(["tx-a"]);
+  });
+});

--- a/dashboard/src/app/transactions/page.tsx
+++ b/dashboard/src/app/transactions/page.tsx
@@ -100,6 +100,11 @@ export default function TransactionsPage() {
   );
   const [busy, setBusy] = useState<Record<string, "rolling-back" | string>>({});
   const [confirmingExpired, setConfirmingExpired] = useState(false);
+  // Guards discardAllExpired against a second bulk pass firing while the
+  // first is still running (see discardAllExpired's comment). Distinct
+  // from per-row `busy` — this locks the BULK button/confirm affordance
+  // itself, not an individual transaction row.
+  const [bulkDiscarding, setBulkDiscarding] = useState(false);
   const transactions = data?.transactions ?? [];
   const toast = useToast();
 
@@ -139,17 +144,28 @@ export default function TransactionsPage() {
   }, [expiredIds.length]);
 
   async function discardAllExpired() {
-    if (expiredIds.length === 0) return;
+    if (expiredIds.length === 0 || bulkDiscarding) return;
     if (!confirmingExpired) {
       setConfirmingExpired(true);
       return;
     }
     setConfirmingExpired(false);
-    // Serial to keep rate-limiting predictable and to make the UI state
-    // changes visible row-by-row rather than as one giant flicker.
-    for (const id of expiredIds) {
-      // eslint-disable-next-line no-await-in-loop
-      await rollback(id);
+    // Without this lock, confirmingExpired flips back to false immediately
+    // (above) while expiredIds still lists the same ids for the duration
+    // of the loop below — the "Discard expired (N)" button re-arms and a
+    // second click re-fires the same rollback POSTs concurrently with the
+    // first pass. Every per-row Discard button has this exact guard via
+    // `busy`; the bulk action had none.
+    setBulkDiscarding(true);
+    try {
+      // Serial to keep rate-limiting predictable and to make the UI state
+      // changes visible row-by-row rather than as one giant flicker.
+      for (const id of expiredIds) {
+        // eslint-disable-next-line no-await-in-loop
+        await rollback(id);
+      }
+    } finally {
+      setBulkDiscarding(false);
     }
   }
 
@@ -209,9 +225,10 @@ export default function TransactionsPage() {
               type="button"
               className="btn sm"
               onClick={() => void discardAllExpired()}
+              disabled={bulkDiscarding}
               title={`Discard ${expiredIds.length} expired transaction${expiredIds.length === 1 ? "" : "s"}`}
             >
-              Discard expired ({expiredIds.length})
+              {bulkDiscarding ? "Discarding…" : `Discard expired (${expiredIds.length})`}
             </button>
           )}
           {confirmingExpired && (
@@ -223,6 +240,7 @@ export default function TransactionsPage() {
                 type="button"
                 className="btn sm danger"
                 onClick={() => void discardAllExpired()}
+                disabled={bulkDiscarding}
               >
                 Confirm
               </button>
@@ -230,6 +248,7 @@ export default function TransactionsPage() {
                 type="button"
                 className="btn sm ghost"
                 onClick={() => setConfirmingExpired(false)}
+                disabled={bulkDiscarding}
               >
                 Cancel
               </button>


### PR DESCRIPTION
## Summary
- \`discardAllExpired()\` reset \`confirmingExpired\` to \`false\` **before** the serial rollback loop finished, with no separate in-flight lock. \`expiredIds\` only refreshes on the next 3s poll tick or a rollback's own \`refetch()\`, so it kept listing the same ids for the whole duration of the loop — the "Discard expired (N)" button re-armed immediately while the first batch was still running.
- Concrete failure: user clicks "Discard expired (3)" → "Confirm" → the loop starts serially POSTing \`/rollback\` for ids A, B, C. Before A finishes (network latency, bridge under load), the button has already reverted to its initial armable state; a second click + confirm fires a **second** full pass over the same still-listed ids, issuing duplicate rollback POSTs concurrently with the first.
- Every per-row Discard button already has this exact guard via the \`busy\` state; the bulk action had none — the same class of gap found and fixed six times already this session (#1184-#1191), on a page not yet audited.
- Fix: add a \`bulkDiscarding\` lock set for the duration of the loop, disabling both the arm/confirm buttons and showing "Discarding…" so a second click can't re-fire the same pass.

Found during this session's 20th (final planned) mining pass.

## Test plan
- [x] \`npx tsc --noEmit\` clean (both dashboard and root)
- [x] \`npx tsc --noEmit -p tsconfig.tests.core.json\` clean
- [x] New regression test (first for this page), verified failing on the prior code (button never disabled, race window fully open) and passing with the fix
- [x] \`next lint\` clean (pre-existing unrelated warning in the same file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)