### PR TITLE
chore: gitignore vps-backups/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,6 @@ intellij-plugin/.gradle/
 # Codex CLI scaffolding (different coding agent tool, not used for this repo)
 /.codex/
 /AGENTS.md
+
+# Local VPS backup snapshots pulled down for inspection — never repo content.
+/vps-backups/


### PR DESCRIPTION
chore: gitignore vps-backups/

Local-only directory used to hold VPS backup snapshots pulled down for
inspection — never repo content. Same hygiene fix as patchwork-multitenant
PR #5: paths that are "untracked by nobody running git add" but never
actually gitignored are one careless \`git stash -u\` / \`git clean\` away
from being swept into git history or lost. No functional change.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>