### PR TITLE
fix(dashboard): bulk approve enforces the evidence gate on irreversible actions

### DIFF
--- a/dashboard/src/app/approvals/__tests__/batchApproveEvidenceGate.test.tsx
+++ b/dashboard/src/app/approvals/__tests__/batchApproveEvidenceGate.test.tsx
@@ -1,0 +1,109 @@
+/**
+ * Regression: batchDecide() (the "Approve selected" bulk action) never
+ * checked the evidence gate that both the single-item Approve button
+ * (evidenceLocked, see the card's `disabled` prop) and the `E` keyboard
+ * shortcut already enforce — an irreversible action (e.g. a shell command)
+ * can't be approved until the reviewer has opened its evidence/diff
+ * preview at least once. Bulk approve only gated on a generic
+ * window.confirm for high-tier/count>=3 selections and then approved every
+ * selected id unconditionally, so a multi-select including an unreviewed
+ * irreversible action got approved without the reviewer ever having seen
+ * what it does — the same class of gap #1185/#1186/#1191/#1192 closed on
+ * other paths, just not this one.
+ *
+ * Fix: batchDecide excludes evidence-locked ids from an approve batch
+ * (mirroring the `E` keyboard shortcut's predicate) and surfaces which ids
+ * were skipped instead of silently approving them.
+ */
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+  usePathname: () => "/approvals",
+}));
+
+import ApprovalsPage from "../page";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+// runCommand → domain "shell" → reversibility "irreversible"
+// (see dashboard/src/lib/actionClass.ts). Not high-tier, so the bulk
+// confirm dialog's tier-based gate wouldn't catch this on its own.
+const IRREVERSIBLE_APPROVAL = {
+  callId: "bbbbbbbb-2222-2222-2222-222222222222",
+  toolName: "runCommand",
+  tier: "medium" as const,
+  requestedAt: Date.now(),
+  summary: "rm -rf /tmp/scratch",
+};
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  Element.prototype.scrollIntoView = vi.fn();
+  fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.toString();
+    const method = init?.method ?? "GET";
+    if (method === "GET" && url.includes("/api/bridge/approvals") && !url.includes("stream")) {
+      return jsonResponse([IRREVERSIBLE_APPROVAL]);
+    }
+    if (url.includes("/api/bridge/cc-permissions")) {
+      return jsonResponse(null);
+    }
+    return jsonResponse({}, 404);
+  });
+  global.fetch = fetchMock as unknown as typeof fetch;
+  // Batch confirm dialog would fire if the id weren't filtered out by the
+  // evidence gate before reaching the confirm step — default to true so a
+  // regression (gate not applied) doesn't get masked by a cancelled confirm.
+  vi.spyOn(window, "confirm").mockReturnValue(true);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+async function selectAndBulkApprove() {
+  render(<ApprovalsPage />);
+
+  const checkbox = await screen.findByLabelText(
+    /Select runCommand approval bbbbbbbb/i,
+  );
+  fireEvent.click(checkbox);
+
+  const approveBtn = await screen.findByText(/Approve selected/i);
+  fireEvent.click(approveBtn);
+}
+
+describe("batchDecide — bulk approve enforces the evidence gate on irreversible actions", () => {
+  it("does not POST an approve for an irreversible action whose evidence was never opened", async () => {
+    await selectAndBulkApprove();
+
+    // Give any (incorrect) approve fetch a tick to fire before asserting.
+    await new Promise((r) => setTimeout(r, 50));
+    const approveCall = fetchMock.mock.calls.find(
+      (c) =>
+        (c[1] as RequestInit | undefined)?.method === "POST" &&
+        (c[0] as string).includes(`/approve/${IRREVERSIBLE_APPROVAL.callId}`),
+    );
+    expect(approveCall).toBeUndefined();
+  });
+
+  it("surfaces that the item was locked instead of silently doing nothing", async () => {
+    await selectAndBulkApprove();
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText(/Approve locked for 1 item/i),
+      ).not.toBeNull();
+    });
+  });
+});

--- a/dashboard/src/app/approvals/page.tsx
+++ b/dashboard/src/app/approvals/page.tsx
@@ -913,11 +913,43 @@ function ApprovalsContent() {
   const selectedInView = filtered.filter((p) => selected.has(p.callId));
 
   async function batchDecide(decision: "approve" | "reject") {
-    const ids = selectedInView.map((p) => p.callId);
+    const allIds = selectedInView.map((p) => p.callId);
+    // Evidence gate (irreversible only) applies to bulk approve too — same
+    // predicate the single-item Approve button (evidenceLocked) and the `E`
+    // keyboard shortcut already enforce. Previously this approved every
+    // selected id unconditionally, so a multi-select including an
+    // unreviewed irreversible action (e.g. a destructive shell command)
+    // could be approved via "Approve selected" without the reviewer ever
+    // having opened its evidence/diff — the same class of gap
+    // #1185/#1186/#1191/#1192 closed on other paths, just not this one.
+    let lockedIds: string[] = [];
+    let ids = allIds;
+    if (decision === "approve") {
+      lockedIds = selectedInView
+        .filter((p) => {
+          const cls = classifyPendingAction(p.toolName);
+          return (
+            cls?.reversibility === "irreversible" &&
+            !evidenceOpenedIds.has(p.callId)
+          );
+        })
+        .map((p) => p.callId);
+      if (lockedIds.length > 0) {
+        ids = allIds.filter((id) => !lockedIds.includes(id));
+      }
+    }
+    if (ids.length === 0) {
+      setBatchErr(
+        `Approve locked for ${lockedIds.length} item${lockedIds.length === 1 ? "" : "s"} — open the evidence/diff first.`,
+      );
+      return;
+    }
     // Confirm gate is tier-weighted: any high-risk selection demands a
     // confirm even for a batch of 1; non-high batches keep the historical
     // ≥3 threshold so the prompt doesn't become noise for tidy reviews.
-    const highCount = selectedInView.filter((p) => p.tier === "high").length;
+    const highCount = selectedInView.filter(
+      (p) => ids.includes(p.callId) && p.tier === "high",
+    ).length;
     const needsConfirm = highCount > 0 || ids.length >= 3;
     if (needsConfirm) {
       const verb = decision === "approve" ? "Approve" : "Reject";
@@ -961,8 +993,17 @@ function ApprovalsContent() {
           }),
         ),
       );
-      if (failedIds.length > 0) {
-        setBatchErr(`${decision} failed for: ${failedIds.join(", ")}`);
+      if (failedIds.length > 0 || lockedIds.length > 0) {
+        const parts: string[] = [];
+        if (failedIds.length > 0) {
+          parts.push(`${decision} failed for: ${failedIds.join(", ")}`);
+        }
+        if (lockedIds.length > 0) {
+          parts.push(
+            `${lockedIds.length} locked — open the evidence/diff first`,
+          );
+        }
+        setBatchErr(parts.join("; "));
       }
     } catch (e) {
       setBatchErr(e instanceof Error ? e.message : `${decision} request failed`);


### PR DESCRIPTION
## Summary
- `batchDecide()`'s "Approve selected" bulk action never checked the evidence gate that the single-item Approve button and the `E` keyboard shortcut already enforce — an irreversible action could be bulk-approved without the reviewer ever opening its evidence/diff preview.
- Same bug class as #1185/#1186/#1191/#1192 (safety gate present on one entry point, silently absent on a sibling), found during this session's mining pass.
- Fix: exclude evidence-locked ids from the approve batch, surface which ones were skipped via the existing `batchErr` banner.

## Test plan
- [x] 2 regression tests added, verified failing on prior code and passing with the fix
- [x] `npx tsc --noEmit` (dashboard) clean
- [x] `next lint` on touched files clean
- [x] Root `npx tsc --noEmit -p tsconfig.tests.core.json` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)