### PR TITLE
feat(drivers): add core CodexDriver (unwired, not yet selectable)

### DIFF
--- a/src/drivers/codex/__tests__/streamParser.test.ts
+++ b/src/drivers/codex/__tests__/streamParser.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from "vitest";
+import { parseStreamLine, splitLines } from "../streamParser.js";
+
+describe("codex streamParser: parseStreamLine", () => {
+  it("parses thread.started and extracts no text", () => {
+    const line = JSON.stringify({ type: "thread.started", thread_id: "t1" });
+    const parsed = parseStreamLine(line);
+    expect(parsed.kind).toBe("event");
+    if (parsed.kind === "event") {
+      expect(parsed.event.type).toBe("thread.started");
+      expect(parsed.event.thread_id).toBe("t1");
+      expect(parsed.text).toBe("");
+    }
+  });
+
+  it("parses turn.started with no text", () => {
+    const parsed = parseStreamLine(JSON.stringify({ type: "turn.started" }));
+    expect(parsed.kind).toBe("event");
+    if (parsed.kind === "event") expect(parsed.text).toBe("");
+  });
+
+  it("parses turn.completed and preserves the usage object", () => {
+    const line = JSON.stringify({
+      type: "turn.completed",
+      usage: {
+        input_tokens: 100,
+        cached_input_tokens: 20,
+        output_tokens: 50,
+        reasoning_output_tokens: 10,
+      },
+    });
+    const parsed = parseStreamLine(line);
+    expect(parsed.kind).toBe("event");
+    if (parsed.kind === "event") {
+      expect(parsed.event.usage).toEqual({
+        input_tokens: 100,
+        cached_input_tokens: 20,
+        output_tokens: 50,
+        reasoning_output_tokens: 10,
+      });
+      expect(parsed.text).toBe("");
+    }
+  });
+
+  it("extracts text from item.completed when item.type is agent_message", () => {
+    const line = JSON.stringify({
+      type: "item.completed",
+      item: { id: "i1", type: "agent_message", text: "Hello from Codex" },
+    });
+    const parsed = parseStreamLine(line);
+    expect(parsed.kind).toBe("event");
+    if (parsed.kind === "event") {
+      expect(parsed.text).toBe("Hello from Codex");
+    }
+  });
+
+  it("does NOT extract text from item.completed for a non-agent_message item (e.g. command execution)", () => {
+    const line = JSON.stringify({
+      type: "item.completed",
+      item: {
+        id: "i2",
+        type: "command_execution",
+        command: "ls",
+        status: "ok",
+      },
+    });
+    const parsed = parseStreamLine(line);
+    expect(parsed.kind).toBe("event");
+    if (parsed.kind === "event") expect(parsed.text).toBe("");
+  });
+
+  it("item.started never carries text, regardless of item.type", () => {
+    const line = JSON.stringify({
+      type: "item.started",
+      item: { id: "i3", type: "agent_message" },
+    });
+    const parsed = parseStreamLine(line);
+    expect(parsed.kind).toBe("event");
+    if (parsed.kind === "event") expect(parsed.text).toBe("");
+  });
+
+  it("extracts error text from a message field", () => {
+    const line = JSON.stringify({ type: "error", message: "sandbox denied" });
+    const parsed = parseStreamLine(line);
+    expect(parsed.kind).toBe("event");
+    if (parsed.kind === "event") expect(parsed.text).toBe("sandbox denied");
+  });
+
+  it("falls back to an error field when message is absent", () => {
+    const line = JSON.stringify({ type: "error", error: "spawn failed" });
+    const parsed = parseStreamLine(line);
+    expect(parsed.kind).toBe("event");
+    if (parsed.kind === "event") expect(parsed.text).toBe("spawn failed");
+  });
+
+  it("falls back to stringifying the whole event when an error carries neither known field — never silently drops an error", () => {
+    const line = JSON.stringify({ type: "error", code: "E_UNKNOWN" });
+    const parsed = parseStreamLine(line);
+    expect(parsed.kind).toBe("event");
+    if (parsed.kind === "event") {
+      expect(parsed.text.length).toBeGreaterThan(0);
+      expect(parsed.text).toContain("E_UNKNOWN");
+    }
+  });
+
+  it("extracts error text from a turn.failed event the same way as an error event", () => {
+    const line = JSON.stringify({
+      type: "turn.failed",
+      message: "model overloaded",
+    });
+    const parsed = parseStreamLine(line);
+    expect(parsed.kind).toBe("event");
+    if (parsed.kind === "event") expect(parsed.text).toBe("model overloaded");
+  });
+
+  it("returns a raw line for non-JSON input instead of throwing", () => {
+    const parsed = parseStreamLine("not json at all");
+    expect(parsed.kind).toBe("raw");
+    if (parsed.kind === "raw") expect(parsed.text).toBe("not json at all\n");
+  });
+
+  it("returns a raw line for empty-object-adjacent malformed JSON", () => {
+    const parsed = parseStreamLine("{type: 'missing quotes'}");
+    expect(parsed.kind).toBe("raw");
+  });
+});
+
+describe("codex streamParser: splitLines", () => {
+  it("splits a chunk with multiple complete lines", () => {
+    const { lines, remainder } = splitLines("", "line1\nline2\nline3\n");
+    expect(lines).toEqual(["line1", "line2", "line3"]);
+    expect(remainder).toBe("");
+  });
+
+  it("carries a partial final line into the remainder", () => {
+    const { lines, remainder } = splitLines("", "line1\npartial");
+    expect(lines).toEqual(["line1"]);
+    expect(remainder).toBe("partial");
+  });
+
+  it("joins a carried-over remainder with the next chunk", () => {
+    const first = splitLines("", "partial-sta");
+    expect(first.lines).toEqual([]);
+    expect(first.remainder).toBe("partial-sta");
+    const second = splitLines(first.remainder, "rt\ncomplete\n");
+    expect(second.lines).toEqual(["partial-start", "complete"]);
+    expect(second.remainder).toBe("");
+  });
+
+  it("handles a chunk containing no newline at all", () => {
+    const { lines, remainder } = splitLines("", "no newline here");
+    expect(lines).toEqual([]);
+    expect(remainder).toBe("no newline here");
+  });
+});

--- a/src/drivers/codex/__tests__/subprocess.test.ts
+++ b/src/drivers/codex/__tests__/subprocess.test.ts
@@ -1,0 +1,304 @@
+import { EventEmitter } from "node:events";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+class MockChild extends EventEmitter {
+  stdout = new EventEmitter();
+  stderr = new EventEmitter();
+  exitCode: number | null = null;
+  pid = 4242;
+  signalCode: NodeJS.Signals | null = null;
+}
+
+let mockChild: MockChild;
+let lastSpawnEnv: NodeJS.ProcessEnv | undefined;
+
+vi.mock("node:child_process", async (importOriginal) => {
+  const original = await importOriginal<typeof import("node:child_process")>();
+  return {
+    ...original,
+    spawn: vi.fn(
+      (_cmd: string, _args: string[], opts?: { env?: NodeJS.ProcessEnv }) => {
+        lastSpawnEnv = opts?.env;
+        mockChild = new MockChild();
+        mockChild.stdout = new EventEmitter();
+        mockChild.stderr = new EventEmitter();
+        (mockChild.stdout as { setEncoding?: () => void }).setEncoding =
+          vi.fn();
+        (mockChild.stderr as { setEncoding?: () => void }).setEncoding =
+          vi.fn();
+        return mockChild;
+      },
+    ),
+  };
+});
+
+const { treeKillMock } = vi.hoisted(() => ({ treeKillMock: vi.fn() }));
+vi.mock("../../../processTree.js", () => ({ treeKill: treeKillMock }));
+
+import { spawn } from "node:child_process";
+import type { ProviderTaskInput } from "../../types.js";
+import { CodexDriver } from "../subprocess.js";
+
+const spawnMock = vi.mocked(spawn);
+
+function makeInput(
+  overrides: Partial<ProviderTaskInput> = {},
+): ProviderTaskInput {
+  return {
+    prompt: "hello",
+    workspace: "/workspace/codex-test",
+    timeoutMs: 5000,
+    signal: new AbortController().signal,
+    ...overrides,
+  };
+}
+
+async function finishRun(
+  p: Promise<unknown>,
+  events: string[] = [
+    JSON.stringify({
+      type: "item.completed",
+      item: { id: "i1", type: "agent_message", text: "ok" },
+    }),
+  ],
+): Promise<void> {
+  await new Promise<void>((r) => setTimeout(r, 0));
+  for (const e of events) mockChild.stdout.emit("data", `${e}\n`);
+  mockChild.emit("close", 0);
+  await p;
+}
+
+function valuesAfter(args: string[], flag: string): string[] {
+  const out: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === flag) {
+      const v = args[i + 1];
+      if (v !== undefined) out.push(v);
+    }
+  }
+  return out;
+}
+
+function newDriver() {
+  return new CodexDriver("codex", vi.fn());
+}
+
+describe("CodexDriver: fail-closed defaults (no providerOptions)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("passes the full restrictive flag set with no opt-in", async () => {
+    const driver = newDriver();
+    await finishRun(driver.run(makeInput()));
+    const args = spawnMock.mock.calls[0]![1] as string[];
+
+    expect(args).toContain("exec");
+    expect(args).toContain("--json");
+    expect(args).toContain("--sandbox");
+    expect(args[args.indexOf("--sandbox") + 1]).toBe("read-only");
+    expect(args).toContain("--ask-for-approval");
+    expect(args[args.indexOf("--ask-for-approval") + 1]).toBe("never");
+    expect(args).toContain("--ignore-user-config");
+    expect(args).toContain("--ignore-rules");
+    expect(args).toContain("--skip-git-repo-check");
+    expect(args).toContain("--ephemeral");
+    expect(valuesAfter(args, "-c")).toContain("sandbox.network_access=false");
+  });
+
+  it("does not pass --search by default (web search stays at Codex's own default)", async () => {
+    const driver = newDriver();
+    await finishRun(driver.run(makeInput()));
+    const args = spawnMock.mock.calls[0]![1] as string[];
+    expect(args).not.toContain("--search");
+  });
+
+  it("uses detached:true + process.signal wiring so treeKill can reach the whole process group", async () => {
+    const driver = newDriver();
+    await finishRun(driver.run(makeInput()));
+    const spawnOpts = spawnMock.mock.calls[0]![2] as { detached?: boolean };
+    expect(spawnOpts.detached).toBe(true);
+  });
+});
+
+describe("CodexDriver: explicit escalation via providerOptions", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("escalates sandboxMode when explicitly requested", async () => {
+    const driver = newDriver();
+    await finishRun(
+      driver.run(
+        makeInput({ providerOptions: { sandboxMode: "workspace-write" } }),
+      ),
+    );
+    const args = spawnMock.mock.calls[0]![1] as string[];
+    expect(args[args.indexOf("--sandbox") + 1]).toBe("workspace-write");
+  });
+
+  it("rejects an unrecognized sandboxMode value and falls back to the safe default", async () => {
+    const driver = newDriver();
+    await finishRun(
+      driver.run(
+        makeInput({ providerOptions: { sandboxMode: "not-a-real-mode" } }),
+      ),
+    );
+    const args = spawnMock.mock.calls[0]![1] as string[];
+    expect(args[args.indexOf("--sandbox") + 1]).toBe("read-only");
+  });
+
+  it("escalates approvalMode when explicitly requested", async () => {
+    const driver = newDriver();
+    await finishRun(
+      driver.run(
+        makeInput({ providerOptions: { approvalMode: "on-request" } }),
+      ),
+    );
+    const args = spawnMock.mock.calls[0]![1] as string[];
+    expect(args[args.indexOf("--ask-for-approval") + 1]).toBe("on-request");
+  });
+
+  it("enables network access only when explicitly requested", async () => {
+    const driver = newDriver();
+    await finishRun(
+      driver.run(makeInput({ providerOptions: { networkAccess: true } })),
+    );
+    const args = spawnMock.mock.calls[0]![1] as string[];
+    expect(valuesAfter(args, "-c")).toContain("sandbox.network_access=true");
+  });
+
+  it("passes --search only when webSearch is explicitly requested", async () => {
+    const driver = newDriver();
+    await finishRun(
+      driver.run(makeInput({ providerOptions: { webSearch: true } })),
+    );
+    const args = spawnMock.mock.calls[0]![1] as string[];
+    expect(args).toContain("--search");
+  });
+});
+
+describe("CodexDriver: argv injection guard", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("rejects a prompt starting with '-' before spawning", async () => {
+    const driver = newDriver();
+    await expect(driver.run(makeInput({ prompt: "-rf /" }))).rejects.toThrow(
+      /argv injection guard/,
+    );
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("CodexDriver: NDJSON stream handling", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("accumulates agent_message text across multiple item.completed events", async () => {
+    const driver = newDriver();
+    const result = await (async () => {
+      const p = driver.run(makeInput());
+      await finishRun(p, [
+        JSON.stringify({ type: "thread.started", thread_id: "t1" }),
+        JSON.stringify({ type: "turn.started" }),
+        JSON.stringify({
+          type: "item.completed",
+          item: { id: "i1", type: "agent_message", text: "Hello, " },
+        }),
+        JSON.stringify({
+          type: "item.completed",
+          item: { id: "i2", type: "agent_message", text: "world." },
+        }),
+        JSON.stringify({
+          type: "turn.completed",
+          usage: { input_tokens: 10, output_tokens: 5 },
+        }),
+      ]);
+      return p;
+    })();
+    expect(result.text).toBe("Hello, world.");
+    expect(result.exitCode).toBe(0);
+    expect(result.providerMeta?.inputTokens).toBe(10);
+    expect(result.providerMeta?.outputTokens).toBe(5);
+  });
+
+  it("ignores item.completed text from non-agent_message items (e.g. command execution)", async () => {
+    const driver = newDriver();
+    const p = driver.run(makeInput());
+    await finishRun(p, [
+      JSON.stringify({
+        type: "item.completed",
+        item: {
+          id: "i1",
+          type: "command_execution",
+          command: "ls",
+          status: "ok",
+        },
+      }),
+      JSON.stringify({
+        type: "item.completed",
+        item: { id: "i2", type: "agent_message", text: "done" },
+      }),
+    ]);
+    const result = await p;
+    expect(result.text).toBe("done");
+  });
+
+  it("surfaces an error event as errorMessage and exitCode 1, even when the process itself exits 0", async () => {
+    const driver = newDriver();
+    const p = driver.run(makeInput());
+    await finishRun(p, [
+      JSON.stringify({ type: "error", message: "sandbox denied write" }),
+    ]);
+    const result = await p;
+    expect(result.exitCode).toBe(1);
+    expect(result.errorMessage).toBe("sandbox denied write");
+  });
+
+  it("treats turn.failed the same as an error event", async () => {
+    const driver = newDriver();
+    const p = driver.run(makeInput());
+    await finishRun(p, [
+      JSON.stringify({ type: "turn.failed", message: "model overloaded" }),
+    ]);
+    const result = await p;
+    expect(result.exitCode).toBe(1);
+    expect(result.errorMessage).toBe("model overloaded");
+  });
+
+  it("does not crash on a non-JSON stray line, treating it as raw passthrough text", async () => {
+    const driver = newDriver();
+    const p = driver.run(makeInput());
+    await finishRun(p, [
+      "not valid json",
+      JSON.stringify({
+        type: "item.completed",
+        item: { id: "i1", type: "agent_message", text: "still works" },
+      }),
+    ]);
+    const result = await p;
+    expect(result.text).toContain("still works");
+  });
+});
+
+describe("CodexDriver: cancellation", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("calls treeKill (process-group kill, not direct-child-only) on abort", async () => {
+    const driver = newDriver();
+    const controller = new AbortController();
+    const p = driver.run(makeInput({ signal: controller.signal }));
+    await new Promise<void>((r) => setTimeout(r, 0));
+    controller.abort();
+    expect(treeKillMock).toHaveBeenCalledWith(mockChild);
+    mockChild.emit("close", -1);
+    await p;
+  });
+});
+
+describe("CodexDriver: env sanitization", () => {
+  beforeEach(() => vi.clearAllMocks());
+  afterEach(() => vi.unstubAllEnvs());
+
+  it("does not need OPENAI_API_KEY preserved for the default subscription-auth path — it is stripped like any other cross-provider secret", async () => {
+    vi.stubEnv("OPENAI_API_KEY", "sk-test-should-be-stripped");
+    const driver = newDriver();
+    await finishRun(driver.run(makeInput()));
+    expect(lastSpawnEnv?.OPENAI_API_KEY).toBeUndefined();
+  });
+});

--- a/src/drivers/codex/streamParser.ts
+++ b/src/drivers/codex/streamParser.ts
@@ -1,0 +1,104 @@
+/**
+ * Shape of a parsed NDJSON event from `codex exec --json`.
+ *
+ * Event types confirmed via OpenAI's developer docs (developers.openai.com/
+ * codex/noninteractive, redirects to learn.chatgpt.com/docs/non-interactive-mode):
+ * thread.started, turn.started, turn.completed, turn.failed, item.started,
+ * item.completed, error. The final agent response text lives in an
+ * item.completed event whose item.type === "agent_message" — NOT at the
+ * top level of the event, unlike Claude's stream-json "result" event.
+ *
+ * The exact field shape of the `error` and `turn.failed` event types is not
+ * documented on the pages fetched — parseStreamLine defensively checks a few
+ * plausible field names (`message`, `error`) for both and falls back to
+ * stringifying the event so an error is never silently dropped even if the
+ * real field name differs.
+ */
+export interface CodexEvent {
+  type:
+    | "thread.started"
+    | "turn.started"
+    | "turn.completed"
+    | "turn.failed"
+    | "item.started"
+    | "item.completed"
+    | "error"
+    | string;
+  /** Present on type === "thread.started". */
+  thread_id?: string;
+  /** Present on type === "turn.completed". */
+  usage?: {
+    input_tokens?: number;
+    cached_input_tokens?: number;
+    output_tokens?: number;
+    reasoning_output_tokens?: number;
+  };
+  /** Present on type === "item.started" / "item.completed". */
+  item?: {
+    id?: string;
+    type?: string;
+    command?: string;
+    status?: string;
+    /** Present when item.type === "agent_message" on a completed item. */
+    text?: string;
+  };
+  /** Field name unconfirmed for type === "error" — checked defensively. */
+  message?: string;
+  error?: string;
+}
+
+export interface ParsedLine {
+  kind: "event";
+  event: CodexEvent;
+  /** Extracted response/error text for this event, "" if the event carries none. */
+  text: string;
+}
+
+export interface RawLine {
+  kind: "raw";
+  text: string;
+}
+
+export type ParsedStreamLine = ParsedLine | RawLine;
+
+/**
+ * Parse a single NDJSON line from `codex exec --json`. Returns a raw line
+ * entry for non-JSON lines (defensive — mirrors the Claude parser's
+ * backward-compat handling for unexpected output).
+ */
+export function parseStreamLine(line: string): ParsedStreamLine {
+  try {
+    const event = JSON.parse(line) as CodexEvent;
+    let text = "";
+    if (
+      event.type === "item.completed" &&
+      event.item?.type === "agent_message"
+    ) {
+      text = typeof event.item.text === "string" ? event.item.text : "";
+    } else if (event.type === "error" || event.type === "turn.failed") {
+      text =
+        typeof event.message === "string"
+          ? event.message
+          : typeof event.error === "string"
+            ? event.error
+            : JSON.stringify(event);
+    }
+    return { kind: "event", event, text };
+  } catch {
+    return { kind: "raw", text: `${line}\n` };
+  }
+}
+
+/** Split a chunk into complete lines + a leftover partial. Identical logic to
+ * the Claude driver's splitLines (pure, format-agnostic) — kept as a local
+ * copy rather than a cross-driver import so codex/ has no dependency on
+ * claude/ internals. */
+export function splitLines(
+  buf: string,
+  chunk: string,
+): { lines: string[]; remainder: string } {
+  const combined = buf + chunk;
+  const parts = combined.split("\n");
+  const remainder = parts.pop() ?? "";
+  return { lines: parts, remainder };
+}

--- a/src/drivers/codex/subprocess.ts
+++ b/src/drivers/codex/subprocess.ts
@@ -1,0 +1,304 @@
+import { spawn } from "node:child_process";
+import { treeKill } from "../../processTree.js";
+import { ensureCmdShim } from "../../winShim.js";
+import { sanitizeEnv } from "../claude/envSanitizer.js";
+import { truncateToBytes, truncateUtf8Bytes } from "../outputCap.js";
+import type {
+  ProviderDriver,
+  ProviderTaskInput,
+  ProviderTaskResult,
+} from "../types.js";
+import { toProviderTaskOutcome } from "../types.js";
+import { parseStreamLine, splitLines } from "./streamParser.js";
+
+const OUTPUT_CAP = 50 * 1024; // 50KB — matches the Claude subprocess driver's cap
+
+type SandboxMode = "read-only" | "workspace-write" | "danger-full-access";
+type ApprovalMode = "untrusted" | "on-request" | "never";
+
+/**
+ * Scrub secrets from a string before storing or surfacing it. Same patterns
+ * as the Claude driver's scrubSecrets, plus an OpenAI-shaped API key pattern
+ * (sk-proj-.../sk-...) in case a user has OPENAI_API_KEY-based auth rather
+ * than the default ChatGPT-subscription login.
+ */
+export function scrubSecrets(text: string): string {
+  return text
+    .replace(/sk-(proj-)?[A-Za-z0-9_-]{20,}/g, "[REDACTED_API_KEY]")
+    .replace(/Bearer\s+[A-Za-z0-9._-]{16,}/gi, "Bearer [REDACTED]")
+    .replace(/\btoken[=:]\s*[A-Za-z0-9._-]{16,}/gi, "token=[REDACTED]");
+}
+
+/**
+ * Codex subprocess driver — spawns `codex exec` with ChatGPT-subscription
+ * auth (whatever `codex login` already established; no API key handling
+ * here, mirroring how the Claude subprocess driver relies on `claude`'s own
+ * stored subscription auth rather than passing a credential itself).
+ *
+ * FAIL-CLOSED BY DEFAULT — this is a deliberate divergence from the Claude
+ * subprocess driver, whose default (no sandbox opt-in) is
+ * `--dangerously-skip-permissions` (fail-OPEN: full native tool access).
+ * Codex CLI's own non-interactive docs explicitly warn that `codex exec`
+ * does NOT default to something safe for unattended callers — every
+ * restrictive flag below is passed unconditionally unless a caller
+ * explicitly escalates via providerOptions:
+ *
+ *   sandboxMode:    "read-only" (default) | "workspace-write" | "danger-full-access"
+ *   approvalMode:   "never" (default) | "on-request" | "untrusted"
+ *   networkAccess:  false (default) — passed as `-c sandbox.network_access=false`
+ *   webSearch:      false (default) — omitting --search leaves Codex's own
+ *                   default ("cached"); NOT the same as fully disabled, but
+ *                   there is no documented flag to disable it outright as of
+ *                   this writing. Flagged here rather than silently assumed.
+ *
+ * Codex CLI's own cancellation has confirmed upstream bugs (orphaned MCP
+ * stdio subprocesses, shell-wrapper children surviving interrupt — see
+ * openai/codex issues #4337, #7985, #12491, #15379, #20869) — treeKill
+ * (process-group kill, not a direct-child-only kill()) is used from the
+ * start, not added later.
+ */
+export class CodexDriver implements ProviderDriver {
+  readonly name = "codex";
+
+  constructor(
+    private readonly binary: string,
+    private readonly log: (msg: string) => void,
+  ) {}
+
+  async run(input: ProviderTaskInput): Promise<ProviderTaskResult> {
+    const opts = input.providerOptions ?? {};
+
+    // Defense-in-depth: reject argv-confusable user-controlled strings.
+    // Spawn is called with an array (no shell), so this is argv defense for
+    // the child's flag parser, not shell-injection defense. Mirrors the
+    // Claude driver's identical guard.
+    if (input.prompt.startsWith("-")) {
+      throw new Error(
+        "[CodexDriver] prompt cannot start with '-' (argv injection guard)",
+      );
+    }
+
+    const effectiveBinary = ensureCmdShim(this.binary);
+
+    const sandboxMode: SandboxMode =
+      opts.sandboxMode === "workspace-write" ||
+      opts.sandboxMode === "danger-full-access"
+        ? opts.sandboxMode
+        : "read-only";
+    const approvalMode: ApprovalMode =
+      opts.approvalMode === "on-request" || opts.approvalMode === "untrusted"
+        ? opts.approvalMode
+        : "never";
+    const networkAccess = opts.networkAccess === true;
+    const webSearch = opts.webSearch === true;
+
+    const args = [
+      "exec",
+      input.prompt,
+      "--json",
+      "--sandbox",
+      sandboxMode,
+      "--ask-for-approval",
+      approvalMode,
+      "--ignore-user-config",
+      "--ignore-rules",
+      "--skip-git-repo-check",
+      "--ephemeral",
+      "-c",
+      `sandbox.network_access=${networkAccess ? "true" : "false"}`,
+    ];
+    if (webSearch) args.push("--search");
+
+    // env sanitization: reuse the Claude driver's sanitizeEnv as-is (a
+    // generic cross-provider-secret strip with no Claude-specific coupling —
+    // see envSanitizer.ts's own doc comment). Codex's subscription auth
+    // lives in codex's own config/auth file, not an env var, so no
+    // `preserve` entry is needed for the default (subscription) auth path.
+    const env = sanitizeEnv(process.env);
+
+    this.log(
+      `[CodexDriver] spawning: ${effectiveBinary} exec <prompt> (workspace: ${input.workspace}, sandbox: ${sandboxMode})`,
+    );
+
+    const child = spawn(effectiveBinary, args, {
+      cwd: input.workspace,
+      env,
+      signal: input.signal,
+      stdio: ["ignore", "pipe", "pipe"],
+      // setsid() — prevents subprocess from opening /dev/tty for interactive
+      // prompts, and makes it its own process-group leader for treeKill.
+      detached: true,
+    });
+    // Node's `signal` option calls `child.kill()` on abort, which only
+    // signals the immediate child — insufficient given Codex's confirmed
+    // upstream orphaned-child-process bugs (see class doc comment).
+    const onAbort = () => treeKill(child);
+    input.signal.addEventListener("abort", onAbort, { once: true });
+    child.once("close", () => {
+      input.signal.removeEventListener("abort", onAbort);
+    });
+
+    let lineBuf = "";
+    let accumulated = "";
+    let outputBytesSent = 0;
+    let firstAgentMessageAt: number | undefined;
+    let sawError = false;
+    let errorText = "";
+    let resultUsage:
+      | { input_tokens?: number; output_tokens?: number }
+      | undefined;
+
+    const emitText = (text: string) => {
+      if (text.length === 0) return;
+      accumulated += text;
+      if (outputBytesSent < OUTPUT_CAP) {
+        const { send, bytes } = truncateToBytes(
+          text,
+          OUTPUT_CAP - outputBytesSent,
+        );
+        if (bytes > 0) {
+          input.onChunk?.(send);
+          outputBytesSent += bytes;
+        }
+      }
+    };
+
+    const handleLine = (line: string) => {
+      if (line.trim() === "") return;
+      const parsed = parseStreamLine(line);
+      if (parsed.kind === "raw") {
+        emitText(parsed.text);
+        return;
+      }
+      const { event, text } = parsed;
+      if (
+        event.type === "item.completed" &&
+        event.item?.type === "agent_message"
+      ) {
+        if (firstAgentMessageAt === undefined) firstAgentMessageAt = Date.now();
+        emitText(text);
+      } else if (event.type === "turn.completed") {
+        resultUsage = event.usage;
+      } else if (event.type === "error" || event.type === "turn.failed") {
+        sawError = true;
+        errorText = text || errorText;
+      }
+    };
+
+    child.stdout.setEncoding("utf-8");
+    child.stdout.on("data", (chunk: string) => {
+      const { lines, remainder } = splitLines(lineBuf, chunk);
+      lineBuf = remainder;
+      for (const line of lines) handleLine(line);
+    });
+
+    let stderr = "";
+    child.stderr.setEncoding("utf-8");
+    child.stderr.on("data", (chunk: string) => {
+      if (Buffer.byteLength(stderr, "utf8") < OUTPUT_CAP) {
+        stderr += chunk;
+        if (Buffer.byteLength(stderr, "utf8") > OUTPUT_CAP) {
+          stderr = truncateUtf8Bytes(stderr, OUTPUT_CAP);
+        }
+      }
+    });
+
+    const start = Date.now();
+    const stderrTailOf = (s: string): string | undefined =>
+      s.length > 0 ? scrubSecrets(s.slice(-2048)) : undefined;
+    const startupMsOf = (): number | undefined =>
+      firstAgentMessageAt !== undefined
+        ? firstAgentMessageAt - start
+        : undefined;
+
+    let startupTimedOut = false;
+    const startupHandle = input.startupTimeoutMs
+      ? setTimeout(() => {
+          if (firstAgentMessageAt === undefined) {
+            startupTimedOut = true;
+            treeKill(child);
+          }
+        }, input.startupTimeoutMs)
+      : null;
+
+    let exitCode: number;
+    try {
+      exitCode = await new Promise<number>((resolve, reject) => {
+        child.on("close", (code) => resolve(code ?? 0));
+        child.on("error", reject);
+      });
+    } catch (err) {
+      if (startupHandle) clearTimeout(startupHandle);
+      const isAbort =
+        (err instanceof Error && err.name === "AbortError") ||
+        input.signal.aborted;
+      if (isAbort) {
+        return {
+          text: truncateUtf8Bytes(accumulated, OUTPUT_CAP),
+          exitCode: -1,
+          durationMs: Date.now() - start,
+          stderrTail: stderrTailOf(stderr),
+          wasAborted: true,
+          startupMs: startupMsOf(),
+        };
+      }
+      throw err;
+    }
+    if (startupHandle) clearTimeout(startupHandle);
+
+    // Flush any partial line remaining in lineBuf after stdout closes —
+    // mirrors the Claude driver's identical flush-on-close handling.
+    if (lineBuf.trim().length > 0) {
+      handleLine(lineBuf);
+      lineBuf = "";
+    }
+
+    if (startupTimedOut) {
+      return {
+        text: truncateUtf8Bytes(accumulated, OUTPUT_CAP),
+        exitCode: -1,
+        durationMs: Date.now() - start,
+        stderrTail: stderrTailOf(stderr),
+        wasAborted: true,
+        startupTimedOut: true,
+      };
+    }
+
+    const effectiveExitCode = sawError ? 1 : exitCode;
+    if (effectiveExitCode !== 0 && stderr) {
+      this.log(`[CodexDriver] stderr: ${stderr.slice(0, 500)}`);
+    }
+
+    const providerMeta: Record<string, unknown> = {};
+    if (
+      typeof resultUsage?.input_tokens === "number" &&
+      typeof resultUsage?.output_tokens === "number"
+    ) {
+      providerMeta.inputTokens = resultUsage.input_tokens;
+      providerMeta.outputTokens = resultUsage.output_tokens;
+    }
+    if (input.model && !input.model.startsWith("-")) {
+      providerMeta.model = input.model;
+    }
+
+    return {
+      text: truncateUtf8Bytes(
+        sawError && accumulated.length === 0 ? errorText : accumulated,
+        OUTPUT_CAP,
+      ),
+      exitCode: effectiveExitCode,
+      errorMessage: sawError
+        ? errorText || "codex exec reported an error"
+        : undefined,
+      durationMs: Date.now() - start,
+      stderrTail: stderrTailOf(stderr),
+      startupMs: startupMsOf(),
+      providerMeta:
+        Object.keys(providerMeta).length > 0 ? providerMeta : undefined,
+    };
+  }
+
+  async runOutcome(input: ProviderTaskInput) {
+    return toProviderTaskOutcome(await this.run(input));
+  }
+}


### PR DESCRIPTION
## Summary

Step 1 of the Codex/ChatGPT-subscription driver work (per the reviewed implementation plan): the core `ProviderDriver` implementation and its NDJSON stream parser, mirroring `src/drivers/claude/subprocess.ts`'s proven shape.

**Not wired in yet** — `codex` is not selectable via `--driver`, the settings API, recipe dispatch, or the dashboard after this PR. That's steps 2-5, separate follow-ups.

- Event schema and CLI flag syntax verified against OpenAI's own docs (not assumed) — corrected one earlier-assumed config key path (`sandbox.network_access`, not `sandbox_workspace_write.network_access`) and confirmed `--search` is a boolean that enables *live* web search, with no documented flag to disable Codex's own "cached" default outright.
- **Fail-closed by default** — a deliberate divergence from the Claude driver's fail-open default (`--dangerously-skip-permissions` unless a caller opts into sandboxing). Codex's own docs explicitly warn non-interactive callers not to rely on an implicit safe default, so every restrictive flag is passed unconditionally here.
- `treeKill` (process-group kill) from the start — Codex CLI has multiple confirmed open upstream bugs where cancel doesn't reliably kill its full process tree.
- Reuse audit per a multi-agent review of the plan before any code was written: `sanitizeEnv`/`treeKill`/`outputCap`/`ensureCmdShim` are driver-agnostic, reused as-is — no new `envSanitizer.ts` file (the originally-planned "thin wrapper" turned out unnecessary).

## Test plan
- [x] 32 tests across 2 files — caught and fixed 2 real bugs while writing (a missing mock-clear, and `turn.failed` events not having their error text extracted)
- [x] `npm run build`, `tsc --noEmit` (both configs) clean
- [x] `audit-test-fixtures.mjs` / `audit-lsp-tools.mjs` / `audit-docs-drift.mjs` clean
- [x] Full `src/drivers/` suite (176 tests, 17 files) still green — this addition doesn't touch or break any existing driver

🤖 Generated with [Claude Code](https://claude.com/claude-code)