### PR TITLE
fix(recipes): translate worker sandbox to codex's coarse lockdown

### DIFF
--- a/src/recipes/__tests__/agentExecutor.test.ts
+++ b/src/recipes/__tests__/agentExecutor.test.ts
@@ -337,9 +337,8 @@ describe("enforceSandbox (worker autonomy never-widen guard)", () => {
     "openai",
     "grok",
     "gemini",
-    "codex",
     "local",
-  ])("refuses to run on non-subprocess driver %s; no driver fn called", async (driver) => {
+  ])("refuses to run on non-subprocess/non-codex driver %s; no driver fn called", async (driver) => {
     const deps = makeDeps();
     const result = await executeAgent(
       { driver, prompt: "hi", enforceSandbox: true, disallowedTools: ["x"] },
@@ -392,6 +391,63 @@ describe("enforceSandbox (worker autonomy never-widen guard)", () => {
     );
     expect(result.servedBy?.driver).toBe("subprocess");
     expect(deps.claudeCliFn).toHaveBeenCalled();
+  });
+
+  // ── codex: coarse lockdown, not granular refusal ──────────────────────────
+  // CodexDriver has no --disallowed-tools equivalent, so it can't honour the
+  // per-tool deny list the subprocess driver does. Instead of refusing outright
+  // (which would permanently block worker-owned recipes from ever using codex),
+  // executeAgent forces CodexDriver's own coarsest lockdown — see
+  // CODEX_WORKER_SANDBOX_LOCKDOWN — and OVERRIDES any providerOptions the step
+  // itself requested, so a worker-owned step can't negotiate its own escape
+  // hatch (e.g. driver:codex with providerOptions:{sandboxMode:"danger-full-access"}).
+  it("ALLOWS the codex driver and forces the sandbox lockdown, overriding step providerOptions", async () => {
+    const deps = makeDeps();
+    const result = await executeAgent(
+      {
+        driver: "codex",
+        prompt: "hi",
+        model: "gpt-5-codex",
+        enforceSandbox: true,
+        disallowedTools: ["gitPush"], // ignored by codex — no per-tool mechanism
+        providerOptions: { sandboxMode: "danger-full-access" }, // must be overridden
+      },
+      deps,
+    );
+    expect(result.text).toBe("codex-result");
+    expect(result.servedBy).toEqual({ driver: "codex", model: "gpt-5-codex" });
+    expect(deps.providerDriverFn).toHaveBeenCalledWith(
+      "codex",
+      "hi",
+      "gpt-5-codex",
+      {
+        sandboxMode: "read-only",
+        approvalMode: "never",
+        networkAccess: false,
+        webSearch: false,
+      },
+    );
+    expect(deps.claudeCliFn).not.toHaveBeenCalled();
+  });
+
+  it("does NOT apply the codex lockdown when enforceSandbox is false", async () => {
+    const deps = makeDeps();
+    const result = await executeAgent(
+      {
+        driver: "codex",
+        prompt: "hi",
+        model: "gpt-5-codex",
+        providerOptions: { sandboxMode: "danger-full-access" },
+      },
+      deps,
+    );
+    expect(result.text).toBe("codex-result");
+    expect(deps.providerDriverFn).toHaveBeenCalledWith(
+      "codex",
+      "hi",
+      "gpt-5-codex",
+      { sandboxMode: "danger-full-access" },
+    );
   });
 });
 

--- a/src/recipes/agentExecutor.ts
+++ b/src/recipes/agentExecutor.ts
@@ -112,25 +112,58 @@ export interface AgentExecutorInput {
 export const DEFAULT_MODEL = "claude-haiku-4-5-20251001";
 
 /**
- * Will `executeAgent` route this call to the subprocess (`claude -p`) driver —
- * the ONLY driver that enforces `--disallowed-tools`? Mirrors the dispatch in
- * `executeAgent` exactly (explicit driver, then pwCfg, then auto-detect) so the
- * worker-sandbox guard agrees with where the call actually lands. `probeClaudeCli`
- * / `loadPatchworkConfig` are cheap + idempotent, so calling them here too is fine.
+ * How (if at all) `executeAgent` can enforce a worker-mandated tool sandbox on
+ * this call. Mirrors the dispatch in `executeAgent` exactly (explicit driver,
+ * then pwCfg, then auto-detect) so the worker-sandbox guard agrees with where
+ * the call actually lands. `probeClaudeCli` / `loadPatchworkConfig` are cheap
+ * + idempotent, so calling them here too is fine.
+ *
+ *   "granular"       — the subprocess (`claude -p`) driver, which honours a
+ *                       per-tool `--disallowed-tools` deny list exactly.
+ *   "codex-lockdown"  — the codex driver, which has NO per-tool granularity at
+ *                       all (no `--disallowed-tools` equivalent). The only
+ *                       defensible translation is Codex's own coarsest
+ *                       lockdown (read-only sandbox, no network, no approval
+ *                       escalation) — see CODEX_WORKER_SANDBOX_LOCKDOWN.
+ *   "none"            — no enforcement mechanism; enforceSandbox must refuse.
  */
-function resolvesToSubprocessDriver(
+type SandboxEnforcement = "granular" | "codex-lockdown" | "none";
+
+function resolveSandboxEnforcement(
   driver: string | undefined,
   deps: AgentExecutorDeps,
-): boolean {
-  if (driver === "subprocess" || driver === "claude-code") return true;
-  if (driver !== undefined) return false; // anthropic/claude/openai/grok/gemini*/local
+): SandboxEnforcement {
+  if (driver === "subprocess" || driver === "claude-code") return "granular";
+  if (driver === "codex") return "codex-lockdown";
+  if (driver !== undefined) return "none"; // anthropic/claude/openai/grok/gemini*/local
   const pwCfg = deps.loadPatchworkConfig();
-  if (pwCfg.model === "local") return false;
+  if (pwCfg.model === "local") return "none";
   if (pwCfg.driver === "subprocess" || pwCfg.driver === "claude-code")
-    return true;
-  if (process.env.ANTHROPIC_API_KEY) return false; // auto-detect → anthropic API
-  return deps.probeClaudeCli(); // CLI present → subprocess; else falls back to API
+    return "granular";
+  if (process.env.ANTHROPIC_API_KEY) return "none"; // auto-detect → anthropic API
+  return deps.probeClaudeCli() ? "granular" : "none"; // CLI present → subprocess; else falls back to API
 }
+
+/**
+ * CodexDriver's coarsest lockdown — read-only filesystem, no network, no
+ * interactive approval escalation (see src/drivers/codex/subprocess.ts's
+ * SandboxMode/ApprovalMode). This is the ONLY translation available for a
+ * worker-mandated tool sandbox on the codex driver: Codex has no per-tool
+ * `--disallowed-tools` equivalent, so we cannot allow-list individual tools
+ * the way the subprocess driver does. Strictly safer than the granular
+ * sandbox (blocks everything it would ALSO block, plus more) at the cost of
+ * blocking some tools the granular sandbox would still permit (harmless
+ * reads). Deliberately OVERRIDES — never merges with — whatever
+ * providerOptions the step itself requested: a worker-owned step must never
+ * be able to negotiate its own escape hatch (e.g. `danger-full-access`) out
+ * from under the gate.
+ */
+const CODEX_WORKER_SANDBOX_LOCKDOWN: Record<string, unknown> = {
+  sandboxMode: "read-only",
+  approvalMode: "never",
+  networkAccess: false,
+  webSearch: false,
+};
 
 export async function executeAgent(
   input: AgentExecutorInput,
@@ -148,15 +181,17 @@ export async function executeAgent(
     enforceSandbox,
   } = input;
 
-  // NEVER-WIDEN guard. A worker-mandated sandbox is enforceable only on the
-  // subprocess driver; on any other driver the deny list is silently dropped and
-  // the worker's agent step could perform exactly the risky action the gate
-  // believed it sandboxed. Fail closed: refuse to run rather than run un-gated.
-  // The "[agent step failed:" prefix is the marker the runners already treat as a
-  // step failure (halting non-optional steps), so the agent never executes.
-  if (enforceSandbox && !resolvesToSubprocessDriver(driver, deps)) {
+  // NEVER-WIDEN guard. A worker-mandated sandbox is enforceable only on drivers
+  // resolveSandboxEnforcement recognizes; on any other driver the deny list is
+  // silently dropped and the worker's agent step could perform exactly the risky
+  // action the gate believed it sandboxed. Fail closed: refuse to run rather than
+  // run un-gated. The "[agent step failed:" prefix is the marker the runners
+  // already treat as a step failure (halting non-optional steps), so the agent
+  // never executes.
+  const sandboxEnforcement = resolveSandboxEnforcement(driver, deps);
+  if (enforceSandbox && sandboxEnforcement === "none") {
     return {
-      text: "[agent step failed: worker autonomy requires the subprocess driver to enforce its tool sandbox — set the agent step (or recipe) driver to `subprocess`/`claude-code`; refusing to run un-sandboxed]",
+      text: "[agent step failed: worker autonomy requires the subprocess or codex driver to enforce its tool sandbox — set the agent step (or recipe) driver to `subprocess`/`claude-code`/`codex`; refusing to run un-sandboxed]",
       servedBy: { driver: driver ?? "auto" },
     };
   }
@@ -208,13 +243,19 @@ export async function executeAgent(
     driver === "gemini-api" ||
     driver === "codex"
   ) {
+    // A worker-mandated sandbox on the codex driver overrides — never merges
+    // with — the step's own providerOptions. See CODEX_WORKER_SANDBOX_LOCKDOWN.
+    const effectiveProviderOptions =
+      driver === "codex" && enforceSandbox
+        ? CODEX_WORKER_SANDBOX_LOCKDOWN
+        : providerOptions;
     return stamp(
       driver,
       model,
       // Only pass the 4th arg when set so the common (unconstrained) call keeps
       // its 3-arg shape — backward-compatible with callers/mocks.
-      providerOptions
-        ? deps.providerDriverFn(driver, prompt, model, providerOptions)
+      effectiveProviderOptions
+        ? deps.providerDriverFn(driver, prompt, model, effectiveProviderOptions)
         : deps.providerDriverFn(driver, prompt, model),
     );
   }


### PR DESCRIPTION
## Summary
Step 4 (safety half) of the Codex/ChatGPT driver work (follow-on to #1199/#1200/#1201).

**The bug this closes**: after #1201, a worker-owned recipe's agent step with `driver: codex` was **permanently refused** whenever `enforceSandbox` applied. `CodexDriver` isn't `"subprocess"`/`"claude-code"`, so `resolvesToSubprocessDriver()` returned false and the NEVER-WIDEN guard fail-closed on it forever — there was no trust-translation path that could ever unblock it, unlike every other driver.

**The fix**: `CodexDriver` has no `--disallowed-tools` equivalent — no per-tool granularity at all, only coarse `sandboxMode`/`approvalMode`/`networkAccess` controls (see `src/drivers/codex/subprocess.ts`). There is no way to allow-list individual tools the way the subprocess driver does, so the only defensible translation is Codex's own coarsest lockdown: `read-only` sandbox, `never` approval, no network, no web search. This is strictly safer than the granular subprocess sandbox (blocks everything it would ALSO block, plus more) at the cost of blocking some tools the granular sandbox would still permit.

- `src/recipes/agentExecutor.ts`: `resolvesToSubprocessDriver` (boolean) → `resolveSandboxEnforcement` returning `"granular" | "codex-lockdown" | "none"`, so the guard and the dispatch branch agree on which mechanism applies for a given driver.
- When `enforceSandbox && driver === "codex"`, the dispatch forces `CODEX_WORKER_SANDBOX_LOCKDOWN` as `providerOptions` — **overriding**, never merging with, whatever the step itself requested. A worker-owned step must never be able to negotiate its own escape hatch (e.g. `driver: codex` + `providerOptions: {sandboxMode: "danger-full-access"}`).

**Deliberately NOT included**: `spawnDepth` / recursive-spawn-depth threading through `EnqueueOpts` and task orchestration. Grepped the codebase — it doesn't exist for **any** driver today, so it's pre-existing tech debt this change doesn't introduce or worsen, not something codex-specific. Left as separate future work rather than bolting a new cross-cutting orchestration feature onto a driver-wiring change.

## Test plan
- [x] `npx tsc --noEmit` and `npx tsc -p tsconfig.tests.core.json --noEmit` clean
- [x] `npm run build` clean
- [x] Updated the `enforceSandbox` NEVER-WIDEN parametrized refusal test (removed `codex` — it's no longer refused)
- [x] Added: codex driver ALLOWS + forces the lockdown, overriding step-provided `providerOptions` (proves the escape-hatch can't be negotiated)
- [x] Added: codex driver does NOT apply the lockdown when `enforceSandbox` is false (proves non-worker codex steps are unaffected)
- [x] `npx vitest run` — full suite green except the 3 pre-existing, unrelated `tokenEfficiency.test.ts` environment-dependent flakes
- [x] `scripts/audit-lsp-tools.mjs`, `scripts/audit-docs-drift.mjs`, `scripts/audit-test-fixtures.mjs` all pass
- [x] `npx biome check` on changed files clean

## Next
- `spawnDepth` recursive-spawn protection (general, not codex-specific — separate work item).
- Step 5 (optional/fail-open by design): `src/recipes/pricing/priceTable.ts` codex pricing — unpriced drivers run unbudgeted, not broken, so not blocking.