### PR TITLE
docs(recipes): pin codex as intentionally unbilled (step 5)

### DIFF
--- a/src/recipes/__tests__/runBudget.test.ts
+++ b/src/recipes/__tests__/runBudget.test.ts
@@ -213,6 +213,21 @@ describe("RunBudget — usdMax (cost-routing Phase 3)", () => {
     ).toBe(true);
   });
 
+  it("does not enforce usd for the codex driver (ChatGPT subscription, not metered API billing)", () => {
+    // Regression: `codex` spawns under the user's own ChatGPT-subscription CLI
+    // auth, same as the Claude/Gemini subprocess drivers — not a per-token API
+    // key. Even a model id that happens to collide with a priced entry must
+    // not be charged notional $.
+    const b = new RunBudget({ usdMax: 0.5 }, TABLE);
+    b.reconcile(
+      "codex",
+      { inputTokens: 9_000_000, outputTokens: 9_000_000 },
+      "m1",
+    );
+    expect(b.totals().usd).toBe(0);
+    expect(b.admit().admitted).toBe(true);
+  });
+
   it("never poisons usd accounting for a prototype-key model name", () => {
     // Regression: a model id colliding with an Object.prototype key
     // ("__proto__", "constructor", …) must resolve to unpriced (undefined),
@@ -258,6 +273,8 @@ describe("RunBudget — routing helpers (cost-routing Phase 4)", () => {
     expect(b.quoteUsd(undefined, "m1", 1_000_000, 0)).toBeCloseTo(1, 6);
     // non-billable driver (local) → undefined (free, never enforced).
     expect(b.quoteUsd("local", "m1", 1_000_000, 1_000_000)).toBeUndefined();
+    // non-billable driver (codex — ChatGPT subscription, not metered) → undefined.
+    expect(b.quoteUsd("codex", "m1", 1_000_000, 1_000_000)).toBeUndefined();
     // unpriced model → undefined.
     expect(b.quoteUsd("openai", "nope", 1_000_000, 1_000_000)).toBeUndefined();
     // openai with missing model → undefined (provider default unknown here).

--- a/src/recipes/runBudget.ts
+++ b/src/recipes/runBudget.ts
@@ -39,6 +39,10 @@ import type { BudgetPolicy } from "./schema.js";
  * (self-hosted Ollama / LM Studio) DOES report usage but costs no real money,
  * so it must not be priced at notional API rates and halted on spend that
  * never happened. Anything not in this set fails open with a one-time notice.
+ *
+ * `codex` is deliberately absent — like the Claude/Gemini subprocess drivers,
+ * it spawns a CLI under the user's own ChatGPT subscription auth, not a
+ * per-token API key, so its spend is notional rather than real money out.
  */
 const BILLABLE_DRIVERS = new Set([
   "anthropic",

--- a/src/recipes/yamlRunner.ts
+++ b/src/recipes/yamlRunner.ts
@@ -1014,6 +1014,8 @@ export async function loadRecipeServers(specs: string[]): Promise<void> {
  * Mirrors `BILLABLE_DRIVERS` in runBudget.ts (kept local — that set is private
  * and runBudget.ts is enforcement-critical / must not be modified for P1).
  * `local` reports usage but costs no real money, so it is NOT billable.
+ * `codex` is deliberately absent too — ChatGPT-subscription CLI auth, not a
+ * per-token API key (same reasoning as the Claude/Gemini subprocess drivers).
  */
 const COST_BILLABLE_DRIVERS = new Set([
   "anthropic",


### PR DESCRIPTION
## Summary
Step 5 (optional) of the Codex/ChatGPT driver work (follow-on to #1199/#1200/#1201/#1202) — the pricing decision flagged as "confirmed fail-open by design ... genuinely last/optional" in the original plan.

**No functional change.** `codex` was already correctly excluded from `BILLABLE_DRIVERS` (`runBudget.ts`) and `COST_BILLABLE_DRIVERS` (`yamlRunner.ts`) since step 3 (#1201) — I deliberately left it out of both sets when wiring the recipe surfaces, same reasoning as the Claude/Gemini subprocess drivers: ChatGPT-subscription CLI auth is notional spend, not a metered per-token API charge. `priceTable.ts` is fail-open by design — an unpriced model id just returns `undefined` from `costUsd`/`quoteUsd`, so an un-priced driver runs unbudgeted rather than crashing or getting billed at the wrong rate.

This PR makes that decision **explicit and load-bearing** instead of implicit-by-omission:
- Doc comments on both `BILLABLE_DRIVERS` (`runBudget.ts`) and `COST_BILLABLE_DRIVERS` (`yamlRunner.ts`) now name `codex` directly, so a future contributor doesn't mistake the omission for an oversight and "fix" it into a bug.
- Regression tests pin that a `codex` call never accrues USD spend (`RunBudget.reconcile`/`admit`) and that `quoteUsd("codex", ...)` returns `undefined`, mirroring the existing `local`-driver coverage exactly.

## Test plan
- [x] `npx tsc --noEmit` and `npx tsc -p tsconfig.tests.core.json --noEmit` clean
- [x] `npm run build` clean
- [x] Added 2 regression tests to `runBudget.test.ts` (never-billed + quoteUsd-undefined for codex)
- [x] `npx vitest run` — full suite green except the 3 pre-existing, unrelated `tokenEfficiency.test.ts` environment-dependent flakes
- [x] `scripts/audit-lsp-tools.mjs`, `scripts/audit-docs-drift.mjs`, `scripts/audit-test-fixtures.mjs` all pass
- [x] `npx biome check` on changed files clean

## Status
This closes out the full Codex/ChatGPT-driver plan (steps 1-5). Remaining known gap, tracked separately and explicitly out of scope here (see #1202's description): `spawnDepth` recursive-spawn-depth protection — doesn't exist for any driver today, pre-existing tech debt unrelated to codex.