### PR TITLE
fix(recipes): recognize bare {error} connector failures in the effect ledger

### DIFF
--- a/src/recipes/__tests__/idempotencyKey.test.ts
+++ b/src/recipes/__tests__/idempotencyKey.test.ts
@@ -207,6 +207,54 @@ describe("WriteEffectLedger.getOrExecute", () => {
     expect(ledger.size()).toBe(1);
   });
 
+  it("does not cache a bare {error} result with no ok field — retry re-executes", async () => {
+    // Regression (diagnostic-report triage): several connectors (Linear,
+    // Jira, Google Drive, gmail, confluence, ...) catch a failure and RETURN
+    // `JSON.stringify({error: msg})` — no `ok` field at all — rather than
+    // the `{ok:false, error}` shape the ledger was built to recognize. That
+    // bare-{error} failure was previously indistinguishable from a genuine
+    // success and got cached, so a retry after reconnecting/fixing the
+    // underlying issue replayed the cached failure forever instead of
+    // re-executing.
+    const ledger = new WriteEffectLedger();
+    let calls = 0;
+    const fn = async () => {
+      calls++;
+      if (calls === 1) {
+        return JSON.stringify({ error: "Linear not connected" });
+      }
+      return JSON.stringify({ id: "issue_1" });
+    };
+
+    const first = await ledger.getOrExecute("k", fn);
+    expect(JSON.parse(first as string).error).toBe("Linear not connected");
+    expect(ledger.has("k")).toBe(false);
+    expect(ledger.size()).toBe(0);
+
+    const second = await ledger.getOrExecute("k", fn);
+    expect(JSON.parse(second as string).id).toBe("issue_1");
+    expect(calls).toBe(2);
+    expect(ledger.has("k")).toBe(true);
+  });
+
+  it("caches a result with an explicit {ok:true} even if it also carries an `error` field", async () => {
+    // A step that explicitly asserts ok:true must be respected as a genuine
+    // success even if it incidentally carries an `error` key (e.g. a
+    // partial-success/warning payload) — bare-{error} detection must not
+    // override an explicit ok:true.
+    const ledger = new WriteEffectLedger();
+    let calls = 0;
+    const fn = async () => {
+      calls++;
+      return JSON.stringify({ ok: true, error: "non-fatal warning" });
+    };
+    await ledger.getOrExecute("k", fn);
+    const second = await ledger.getOrExecute("k", fn);
+    expect(JSON.parse(second as string).ok).toBe(true);
+    expect(calls).toBe(1);
+    expect(ledger.has("k")).toBe(true);
+  });
+
   it("caches a genuine {ok:true} success — fn runs once", async () => {
     const ledger = new WriteEffectLedger();
     let calls = 0;

--- a/src/recipes/idempotencyKey.ts
+++ b/src/recipes/idempotencyKey.ts
@@ -26,11 +26,13 @@
  *   - Records only on successful execution; failures don't pollute the
  *     ledger, so retry-after-failure still re-executes (correct: if the
  *     tool failed, we can't assume the side effect happened). A failure
- *     is EITHER a thrown/rejected error OR a resolved JSON `{ok:false}`
- *     envelope — connector write tools (e.g. asana.create_task) catch
- *     transient errors and RETURN `JSON.stringify({ok:false, error})`
- *     rather than throwing, and that return-value failure must also skip
- *     the cache (see `isReturnValueFailure` + `getOrExecute`).
+ *     is EITHER a thrown/rejected error OR a resolved JSON `{ok:false}` /
+ *     bare `{error}` envelope — connector write tools catch transient
+ *     errors and RETURN `JSON.stringify({ok:false, error})` (e.g.
+ *     asana.create_task) or just `JSON.stringify({error})` (e.g.
+ *     linear.createIssue) rather than throwing, and either return-value
+ *     failure shape must skip the cache (see `isReturnValueFailure` +
+ *     `getOrExecute`).
  *   - No cross-run persistence — that's PR5b (disk-backed effect ledger).
  *   - No retry-time idempotency on partial-failure cases (Slack posted
  *     but HTTP timed out); that needs tool-side support and is a future
@@ -236,10 +238,20 @@ function assertSafeLedgerDir(dir: string): void {
  * in the effect ledger (the side effect didn't happen, so retry should
  * re-execute).
  *
- * Robustness: only a JSON object literal with an explicit `ok === false`
- * counts as a failure. `null`, non-JSON strings (`JSON.parse` throws),
- * JSON primitives/arrays, and objects without `ok === false` (e.g.
- * `{ok:true}`) are all treated as genuine successes and cache normally.
+ * Also recognizes a BARE `{error: "..."}` result with no `ok` field at
+ * all — several connectors (Linear, Jira, Google Drive, gmail, confluence,
+ * ...) catch a failure and return just `{error: msg}` rather than the
+ * `{ok:false, error}` shape, and that failure was previously
+ * indistinguishable from a genuine success (getting cached and replayed
+ * forever on retry instead of re-executing). An explicit `ok === true`
+ * always wins over a merely-present `error` field — a step that asserts
+ * success must not be overridden just because it also carries an
+ * incidental `error`/warning key.
+ *
+ * Robustness: only a JSON object literal counts. `null`, non-JSON strings
+ * (`JSON.parse` throws), JSON primitives/arrays, and objects with neither
+ * `ok === false` nor a non-empty string `error` (e.g. `{ok:true}`, `{id:1}`)
+ * are all treated as genuine successes and cache normally.
  */
 export function isReturnValueFailure(result: string | null): boolean {
   if (result === null) return false;
@@ -250,12 +262,13 @@ export function isReturnValueFailure(result: string | null): boolean {
     // Non-JSON string output — a genuine success (e.g. "Posted to #x").
     return false;
   }
-  return (
-    typeof parsed === "object" &&
-    parsed !== null &&
-    !Array.isArray(parsed) &&
-    (parsed as Record<string, unknown>).ok === false
-  );
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    return false;
+  }
+  const obj = parsed as Record<string, unknown>;
+  if (obj.ok === true) return false; // explicit success always wins
+  if (obj.ok === false) return true;
+  return typeof obj.error === "string" && obj.error.length > 0;
 }
 
 export class WriteEffectLedger {


### PR DESCRIPTION
## Summary
Second fix from the diagnostic-report triage (workflow review, confirmed CONFIRMED/HIGH). `isReturnValueFailure` (`src/recipes/idempotencyKey.ts`) — the shared detector `WriteEffectLedger.getOrExecute` and `fan_out`'s per-item aggregation both use to decide whether a resolved (not-thrown) tool result is actually a failure — only recognized the explicit `{ok:false, error}` envelope.

Several connectors catch a failure and return a **bare** `{error: msg}` instead, with no `ok` field at all — Linear (`createIssue`), Jira, Google Drive, gmail, confluence, and others (grepped `src/recipes/tools/*.ts` for the pattern; it's not an isolated case, 4+ files). That shape was indistinguishable from a genuine success, so:
- `WriteEffectLedger.getOrExecute` cached the failed result under its idempotency key
- a retry (e.g. after reconnecting an expired token) served the **cached failure forever** instead of re-executing — the exact scenario idempotency/effect-ledger exists to prevent for successes, silently inverted for failures
- `fan_out`'s per-item success/failure counting (`src/recipes/tools/fanOut.ts:216`) uses the same detector, so a failed fan-out item could be counted as a success there too

## Fix
`isReturnValueFailure` now also treats a non-empty string `error` field as a failure when `ok` is absent. An explicit `ok === true` always wins over a merely-present `error` key — a step that asserts success isn't overridden just because it also carries an incidental `error`/warning field.

## Test plan (bug-fix protocol: test-first)
- [x] Added a regression test reproducing the bare-`{error}` caching bug — confirmed it FAILED against the old code before writing the fix
- [x] Added a test pinning that `{ok:true, error:...}` still caches as a success (the override doesn't get too aggressive)
- [x] All 39 tests in `idempotencyKey.test.ts` pass after the fix; `fanOut.test.ts` (8 tests) still green
- [x] `npx tsc --noEmit` and `npx tsc -p tsconfig.tests.core.json --noEmit` clean
- [x] `npm run build` clean
- [x] `npx vitest run` — full suite green except the 3 pre-existing, unrelated `tokenEfficiency.test.ts` environment-dependent flakes
- [x] `scripts/audit-lsp-tools.mjs`, `scripts/audit-docs-drift.mjs`, `scripts/audit-test-fixtures.mjs` all pass
- [x] `npx biome check` clean (pre-existing unrelated warning at line 503 of the test file, not touched by this change)

## Next
One more item from the same triage queued next: `reconnect-result-loss` (stale-`ws` capture in `transport.ts` drops a completed write's result on reconnect).