### PR TITLE
fix(transport): route reconnected tool-call responses to the live socket

### DIFF
--- a/src/__tests__/transport-reconnect-response-routing.test.ts
+++ b/src/__tests__/transport-reconnect-response-routing.test.ts
@@ -1,0 +1,242 @@
+/**
+ * Bug: a tool call that completes AFTER a grace-period reconnect sends its
+ * response on the stale, closed WebSocket instead of the reconnected
+ * client's current socket.
+ *
+ * `detachSoft()` intentionally preserves in-flight tool calls across a
+ * grace-period reconnect (see transport-detachSoft-leak.test.ts) — the
+ * reconnected client is meant to receive the eventual result of a write it
+ * kicked off before disconnecting. But the message listener that dispatches
+ * `tools/call` closes over the `ws` parameter passed to `attach()` at the
+ * time the request arrived. If the tool handler's promise resolves after a
+ * `detachSoft()` + `attach(newWs)` cycle, the final `safeSend` in that
+ * listener still targets the ORIGINAL (now-closed) socket — the reconnected
+ * client never sees the response and may retry an already-completed write
+ * (the side effect already happened; only the acknowledgement was lost).
+ *
+ * The dynamic-tool-dispatch branch already reroutes through `this.activeWs`
+ * for exactly this reason (with a generation guard) — the tools/call path
+ * didn't, and unlike the dynamic branch, a *generation* guard alone is
+ * wrong here: `detachSoft()` deliberately preserves the call across the
+ * generation bump, so the fix must redirect for that specific case
+ * (`detachSoftInflight` / `wasSoftPreserved`), not skip sending outright.
+ *
+ * Fix: `respondViaActiveWs` is set when the completing call's id was
+ * snapshotted by `detachSoft()`, and the final response send targets
+ * `this.activeWs` instead of the closed-over `ws` in that case only — a
+ * hard reconnect (unrelated new client, `detachSoftInflight` does NOT
+ * contain the id) must never redirect, since that would leak a response to
+ * a different client's session.
+ */
+
+import { describe, expect, it } from "vitest";
+import { Logger } from "../logger.js";
+import { McpTransport } from "../transport.js";
+
+interface McpMessage {
+  jsonrpc: "2.0";
+  id?: string | number;
+  method?: string;
+  params?: unknown;
+  result?: unknown;
+  error?: unknown;
+}
+
+class MockWs {
+  readyState = 1; // OPEN
+  sent: string[] = [];
+  handlers: Record<string, (arg: unknown) => void> = {};
+  on(event: string, fn: (arg: unknown) => void) {
+    this.handlers[event] = fn;
+    return this;
+  }
+  off(event: string, _fn: unknown) {
+    delete this.handlers[event];
+    return this;
+  }
+  removeListener(event: string, _fn: unknown) {
+    delete this.handlers[event];
+    return this;
+  }
+  send(data: string, cb?: (err?: Error) => void) {
+    this.sent.push(data);
+    if (cb) cb();
+  }
+  close() {
+    this.readyState = 3;
+  }
+  ping() {}
+  pong() {}
+  addEventListener(event: string, fn: (arg: unknown) => void) {
+    this.on(event, fn);
+  }
+  terminate() {
+    this.close();
+  }
+}
+
+function attachAndHandshake(transport: McpTransport): MockWs {
+  const ws = new MockWs();
+  transport.attach(ws as unknown as import("ws").WebSocket);
+  const send = (msg: McpMessage) => {
+    ws.handlers.message?.(Buffer.from(JSON.stringify(msg)));
+  };
+  send({
+    jsonrpc: "2.0",
+    id: 0,
+    method: "initialize",
+    params: {
+      protocolVersion: "2025-11-25",
+      capabilities: {},
+      clientInfo: { name: "test", version: "0" },
+    },
+  });
+  send({ jsonrpc: "2.0", method: "notifications/initialized" });
+  return ws;
+}
+
+describe("transport reconnect response routing", () => {
+  it("delivers a tool call's response on the RECONNECTED socket, not the stale one, after a grace-period reconnect", async () => {
+    const transport = new McpTransport(new Logger(false));
+
+    let resolveTool: ((value: unknown) => void) | null = null;
+    transport.registerTool(
+      {
+        name: "writeTool",
+        description: "long-running write tool for reconnect test",
+        inputSchema: { type: "object", properties: {} },
+      },
+      () =>
+        new Promise<{ content: { type: string; text: string }[] }>(
+          (resolve) => {
+            resolveTool = (v: unknown) =>
+              resolve(v as { content: { type: string; text: string }[] });
+          },
+        ),
+    );
+
+    const ws1 = attachAndHandshake(transport);
+
+    ws1.handlers.message?.(
+      Buffer.from(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: 99,
+          method: "tools/call",
+          params: { name: "writeTool", arguments: {} },
+        }),
+      ),
+    );
+
+    const internals = transport as unknown as {
+      inFlightControllers: Map<string | number, AbortController>;
+    };
+    const startDeadline = Date.now() + 1000;
+    while (
+      !internals.inFlightControllers.has(99) &&
+      Date.now() < startDeadline
+    ) {
+      await new Promise((r) => setTimeout(r, 5));
+    }
+    expect(internals.inFlightControllers.has(99)).toBe(true);
+
+    // Grace-period reconnect: detachSoft + attach(new ws).
+    transport.detachSoft();
+    const ws2 = attachAndHandshake(transport);
+
+    // The call the ORIGINAL client made now settles. Read via a getter
+    // (rather than the bare `resolveTool` reference) so TS's control-flow
+    // analysis doesn't narrow the closure-reassigned variable to `never`
+    // after the guard below.
+    const getResolver = () => resolveTool;
+    const resolve = getResolver();
+    if (!resolve) throw new Error("tool never started");
+    resolve({ content: [{ type: "text", text: "write completed" }] });
+
+    await new Promise((r) => setTimeout(r, 30));
+
+    // The reconnected client (ws2) must see the response...
+    const ws2Response = ws2.sent
+      .map((s) => JSON.parse(s) as McpMessage)
+      .find((m) => m.id === 99);
+    expect(ws2Response).toBeDefined();
+    expect(ws2Response?.result).toMatchObject({
+      content: [{ type: "text", text: "write completed" }],
+    });
+
+    // ...and the stale, disconnected socket (ws1) must NOT have received it
+    // (it was sent exactly one message before the reconnect — the initial
+    // handshake response already captured by attachAndHandshake — so no
+    // NEW message should have arrived for id 99).
+    const ws1Response = ws1.sent
+      .map((s) => JSON.parse(s) as McpMessage)
+      .find((m) => m.id === 99);
+    expect(ws1Response).toBeUndefined();
+  });
+
+  it("does NOT redirect to a new socket after a HARD reconnect (unrelated client) — response is simply dropped, never cross-delivered", async () => {
+    const transport = new McpTransport(new Logger(false));
+
+    let resolveTool: ((value: unknown) => void) | null = null;
+    transport.registerTool(
+      {
+        name: "writeTool",
+        description: "long-running write tool for hard-reconnect test",
+        inputSchema: { type: "object", properties: {} },
+      },
+      () =>
+        new Promise<{ content: { type: string; text: string }[] }>(
+          (resolve) => {
+            resolveTool = (v: unknown) =>
+              resolve(v as { content: { type: string; text: string }[] });
+          },
+        ),
+    );
+
+    const ws1 = attachAndHandshake(transport);
+
+    ws1.handlers.message?.(
+      Buffer.from(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: 7,
+          method: "tools/call",
+          params: { name: "writeTool", arguments: {} },
+        }),
+      ),
+    );
+
+    const internals = transport as unknown as {
+      inFlightControllers: Map<string | number, AbortController>;
+    };
+    const startDeadline = Date.now() + 1000;
+    while (
+      !internals.inFlightControllers.has(7) &&
+      Date.now() < startDeadline
+    ) {
+      await new Promise((r) => setTimeout(r, 5));
+    }
+    expect(internals.inFlightControllers.has(7)).toBe(true);
+
+    // HARD detach (a genuinely different client connecting, not a
+    // grace-period resumption) — detach() aborts in-flight calls and does
+    // NOT snapshot them into detachSoftInflight.
+    transport.detach();
+    const ws2 = attachAndHandshake(transport);
+
+    const getResolver2 = () => resolveTool;
+    const resolve2 = getResolver2();
+    if (!resolve2) throw new Error("tool never started");
+    resolve2({ content: [{ type: "text", text: "write completed" }] });
+
+    await new Promise((r) => setTimeout(r, 30));
+
+    // Neither socket should have received a response keyed to the old
+    // call's id — it must never be cross-delivered to the new, unrelated
+    // client's session.
+    const ws2Response = ws2.sent
+      .map((s) => JSON.parse(s) as McpMessage)
+      .find((m) => m.id === 7);
+    expect(ws2Response).toBeUndefined();
+  });
+});

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -982,6 +982,19 @@ export class McpTransport {
         // `countRequestInRateLimit = false` to skip the write.
         let countRequestInRateLimit = true;
 
+        // Set true only when this request's completion was carried across a
+        // grace-period reconnect (detachSoft() preserved its in-flight id —
+        // see `wasSoftPreserved` in the tools/call case below). In that case
+        // the closed-over `ws` from THIS listener invocation is the now-dead
+        // socket; the reconnected client is listening on `this.activeWs`. A
+        // hard reconnect (unrelated new client, detach() cleared the
+        // preserved-id set) must NOT redirect here — that would leak this
+        // call's response to a different client's session — so this stays
+        // false in every case except the grace-period resumption it exists
+        // for. Mirrors the same-purpose `this.activeWs` redirect the dynamic
+        // tool-dispatch branch already does (see setImmediate above).
+        let respondViaActiveWs = false;
+
         let response: JsonRpcResponse = {
           jsonrpc: "2.0",
           // biome-ignore lint/style/noNonNullAssertion: only reachable for requests (not notifications), which always have an id
@@ -1552,6 +1565,7 @@ export class McpTransport {
                     const wasSoftPreserved = this.detachSoftInflight.delete(
                       msg.id,
                     );
+                    if (wasSoftPreserved) respondViaActiveWs = true;
                     if (gen === this.generation || wasSoftPreserved) {
                       this.inFlightControllers.delete(msg.id);
                       this.inFlightToolNames.delete(msg.id);
@@ -1580,6 +1594,7 @@ export class McpTransport {
                     const wasSoftPreserved = this.detachSoftInflight.delete(
                       msg.id,
                     );
+                    if (wasSoftPreserved) respondViaActiveWs = true;
                     if (gen === this.generation || wasSoftPreserved) {
                       this.activeToolCalls = Math.max(
                         0,
@@ -1772,6 +1787,10 @@ export class McpTransport {
                   const wasSoftPreserved = this.detachSoftInflight.delete(
                     msg.id,
                   );
+                  // This call's completion must reach the reconnected
+                  // client's CURRENT socket, not the stale `ws` this listener
+                  // closed over — see `respondViaActiveWs`'s declaration.
+                  if (wasSoftPreserved) respondViaActiveWs = true;
                   if (gen === this.generation || wasSoftPreserved) {
                     this.inFlightControllers.delete(msg.id);
                     this.inFlightToolNames.delete(msg.id);
@@ -2007,7 +2026,18 @@ export class McpTransport {
         }
 
         this.logger.debug(`--> response for ${safeMethod(msg.method)}`);
-        const sent = await safeSend(ws, JSON.stringify(response), this.logger);
+        // A grace-period reconnect during this call means `ws` (closed over
+        // when this listener was attached) is now the dead socket — the
+        // reconnected client is listening on `this.activeWs`. Redirect ONLY
+        // for that specific case (see `respondViaActiveWs`'s declaration);
+        // otherwise send on `ws` exactly as before.
+        const responseTarget =
+          respondViaActiveWs && this.activeWs ? this.activeWs : ws;
+        const sent = await safeSend(
+          responseTarget,
+          JSON.stringify(response),
+          this.logger,
+        );
         if (!sent) {
           this.logger.warn(
             `Response for ${safeMethod(msg.method)} (id=${msg.id}) dropped — socket closed`,


### PR DESCRIPTION
## Summary
Third fix from the diagnostic-report triage (workflow review, confirmed CONFIRMED/HIGH). A tool call's message listener (`McpTransport.attach`, `src/transport.ts`) closes over the `ws` parameter passed to `attach()` at the moment the request arrived. If a grace-period reconnect (`detachSoft()` + `attach(newWs)`) happens while the call's handler is still in flight — which is the whole point of `detachSoft()`: it deliberately preserves in-flight write calls across the reconnect instead of aborting them, so a reconnecting client can pick up the result of a write it kicked off before disconnecting — the eventual response was still sent on the ORIGINAL, now-closed socket. The reconnected client never saw the result and could retry an already-completed write; only the acknowledgement was lost, not the side effect.

The dynamic-tool-dispatch branch (the orchestrator proxy path for unknown tool names) already reroutes through `this.activeWs` for exactly this reason, generation-guarded. A plain generation guard is wrong for the `tools/call` path though: `detachSoft()` intentionally carries the call across the generation bump, so bailing on generation mismatch would silently DROP the response instead of delivering it to the right place.

## Fix
Added `respondViaActiveWs`, set only when the completing call's id was snapshotted by `detachSoft()` (`wasSoftPreserved` — already computed at all three sites that need it: the approval-gate error path, the approval rejection/expiry/policy-denial path, and the tool-execution `finally`). The final response send now targets `this.activeWs` only in that specific case; a HARD reconnect (a genuinely different, unrelated client — `detach()` does not snapshot ids into `detachSoftInflight`) never redirects, so a stale call's response can never leak into a different client's session.

## Test plan (bug-fix protocol: test-first)
- [x] Added `src/__tests__/transport-reconnect-response-routing.test.ts` — two tests:
  - Grace-period reconnect: the reconnected socket receives the response; the stale socket does not. **Confirmed this test FAILED against the old code** (stashed the `transport.ts` fix, ran red, restored, reran green) before committing the fix.
  - Hard reconnect: pins the safety property (no cross-session leak) holds in both directions — the new, unrelated client never receives a response keyed to the old call's id.
- [x] Existing `transport-detachSoft-leak.test.ts` and `transport-approval-generation-leak.test.ts` still pass (no regression in the adjacent leak fixes this change touches the same code paths as)
- [x] `npx tsc --noEmit` and `npx tsc -p tsconfig.tests.core.json --noEmit` clean (hit and worked around an unrelated pre-existing TS narrowing quirk with closure-reassigned `let` variables under `strict` — same latent issue exists in the sibling `transport-detachSoft-leak.test.ts` file, just never caught because that file is in `tsconfig.tests.core.json`'s exclude list; worked around locally in the new test via a getter-function read instead of adding new exclusions, since the ratchet plan is to shrink that list, not grow it)
- [x] `npm run build` clean
- [x] `npx vitest run` — full suite green except the 3 pre-existing, unrelated `tokenEfficiency.test.ts` environment-dependent flakes
- [x] `scripts/audit-lsp-tools.mjs`, `scripts/audit-docs-drift.mjs`, `scripts/audit-test-fixtures.mjs` all pass
- [x] `npx biome check` clean

## Status
This closes out the 3 highest-priority fixes from the diagnostic-report triage (workflow review). Remaining CONFIRMED/HIGH items not yet addressed: `worker-sandbox-missing-tool` (`runVSCodeTask` absent from the risk-tier maps) and `plugin-registertool-missing` (docs describe a `ctx.registerTool()` API that doesn't exist).