### PR TITLE
fix(workers): close worker-sandbox enumeration gap for destructive tools

### DIFF
--- a/src/riskTier.ts
+++ b/src/riskTier.ts
@@ -107,6 +107,16 @@ const TIER_MAP: Record<string, RiskTier> = {
   runClaudeTask: "high",
   resumeClaudeTask: "high",
   evaluateInDebugger: "high",
+  // Diagnostic-report finding (session-review): these classify as "high" via
+  // inferTierFromName's heuristic already, but the worker-autonomy agent-step
+  // sandbox (disallowedToolsForAgentStep, workerGate.ts) only enumerates tools
+  // present in TIER_MAP ∪ DOMAIN_BY_TOOL — a tool absent from BOTH is never
+  // even considered for blocking, regardless of what the heuristic would say.
+  // Adding them here explicitly closes that enumeration gap.
+  runVSCodeTask: "high", // runs an arbitrary VS Code task (tasks.json) — equivalent to runCommand/runInTerminal
+  spawnWorkspace: "high", // spawns an arbitrary child process (a new bridge instance)
+  launchQuickTask: "high", // thin wrapper around runClaudeTask/resumeClaudeTask
+  cancelClaudeTask: "high", // sibling of runClaudeTask/resumeClaudeTask, kept consistent with them
 };
 
 /**

--- a/src/workers/__tests__/workerGate.test.ts
+++ b/src/workers/__tests__/workerGate.test.ts
@@ -270,6 +270,31 @@ describe("disallowedToolsForAgentStep (agent-bypass sandbox)", () => {
     }
   });
 
+  // Regression (diagnostic-report triage): the deny-list "universe" is built
+  // from two static maps (TIER_MAP ∪ DOMAIN_BY_TOOL) — a tool absent from
+  // BOTH is never even considered, no matter what classifyTool() would infer
+  // for it. `runVSCodeTask` runs an arbitrary VS Code task from tasks.json
+  // (equivalent to runCommand/runInTerminal, already "high") but was missing
+  // from both maps, so an L0 worker could invoke it uncontested through an
+  // agent step even though the SAME classifyTool() heuristic already treats
+  // it as high risk everywhere else in the codebase. spawnWorkspace (spawns
+  // an arbitrary child process) and launchQuickTask/cancelClaudeTask (thin
+  // wrappers around runClaudeTask/resumeClaudeTask, already "high") had the
+  // identical gap.
+  it("blocks destructive tools that classifyTool already infers as high-risk but were missing from the enumerable universe", () => {
+    const w = parseWorker({ id: "w", name: "W", owns: ["fs-write"] });
+    const blocked = disallowedToolsForAgentStep(w, new WorkerLevelStore());
+    for (const destructive of [
+      "runVSCodeTask",
+      "spawnWorkspace",
+      "launchQuickTask",
+      "cancelClaudeTask",
+    ]) {
+      expect(blocked).toContain(destructive);
+      expect(blocked).toContain(`mcp__patchwork__${destructive}`);
+    }
+  });
+
   it("does NOT block a risky tool the worker has EARNED autonomy on", () => {
     // owns vcs-push + earned L4 on gitPush → the agent may use it.
     const w = parseWorker({ id: "w", name: "W", owns: ["vcs-push"] });


### PR DESCRIPTION
## Summary
Fourth fix from the diagnostic-report triage (workflow review, confirmed CONFIRMED/HIGH). `disallowedToolsForAgentStep()` (`src/workers/workerGate.ts`) builds the worker-autonomy agent-step sandbox's deny-list "universe" as the union of two static maps — `TIER_MAP` (`src/riskTier.ts`) and `DOMAIN_BY_TOOL` (`src/workers/actionClass.ts`). A tool present in **neither** map is never even considered for blocking, regardless of what `classifyTool()`'s name-based heuristic would infer for it elsewhere.

`runVSCodeTask` runs an arbitrary VS Code task from `tasks.json` — functionally equivalent to `runCommand`/`runInTerminal` (already `"high"` in `TIER_MAP`) — but was missing from both maps, so an L0 worker's agent step could invoke it uncontested under the subprocess/MCP configuration. That's exactly the bypass the sandbox exists to close.

I audited the full registered tool-name list against `classifyTool()` vs. the enumerable universe and found 3 more tools with the identical gap, each confirmed genuinely high-risk on inspection (not just heuristic false positives):
- `spawnWorkspace` — spawns an arbitrary child process (a new bridge instance), confirmed via `node:child_process` `spawn()` in its handler
- `launchQuickTask` — thin wrapper composing `runTask`/`resumeTask`, i.e. the same capability as `runClaudeTask`/`resumeClaudeTask` (already `"high"`)
- `cancelClaudeTask` — sibling of the same task-orchestration family, kept consistent with its already-`"high"` siblings

## Fix
Added all 4 to `TIER_MAP`.

**Deliberately left out of scope** (lower-confidence / more debatable risk — didn't want to over-block on a security-motivated fix without individually reviewing each): `deletePlan`, `openDiff`/`openFile`/`openInBrowser`, `startDebugging`/`stopDebugging`. The same audit approach surfaces these as heuristic-high-but-unmapped too; noting them here so they're not silently dropped, worth a follow-up pass with individual review.

## Test plan (bug-fix protocol: test-first)
- [x] Added a regression test asserting all 4 tools appear in `disallowedToolsForAgentStep`'s blocked list (both bare and `mcp__patchwork__` forms) — confirmed it FAILED against the old `TIER_MAP` before adding the entries
- [x] All 24 tests in `workerGate.test.ts` pass after the fix; `riskTier.test.ts` (7 tests) still green
- [x] `npx tsc --noEmit` and `npx tsc -p tsconfig.tests.core.json --noEmit` clean
- [x] `npm run build` clean
- [x] `npx vitest run` — full suite green except the 3 pre-existing, unrelated `tokenEfficiency.test.ts` environment-dependent flakes
- [x] `scripts/audit-lsp-tools.mjs`, `scripts/audit-docs-drift.mjs`, `scripts/audit-test-fixtures.mjs` all pass
- [x] `npx biome check` clean

## Next
One more CONFIRMED/HIGH item from the same triage queued next: `plugin-registertool-missing` (`documents/plugin-authoring.md` describes a `ctx.registerTool()` API that doesn't exist on the real `PluginContext`, so a plugin following the documented path throws during loading and is skipped).